### PR TITLE
book: add OrderPQ, a min or max priority queue for orders

### DIFF
--- a/server/book/go.mod
+++ b/server/book/go.mod
@@ -1,0 +1,5 @@
+module github.com/decred/dcrdex/server/book
+
+go 1.12
+
+require github.com/decred/dcrd/crypto/blake256 v1.0.0

--- a/server/book/go.sum
+++ b/server/book/go.sum
@@ -1,0 +1,2 @@
+github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=

--- a/server/book/orderpq.go
+++ b/server/book/orderpq.go
@@ -1,5 +1,5 @@
-// Copyright (c) 2019, The Decred developers
-// See LICENSE for details.
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
 
 package book
 

--- a/server/book/orderpq.go
+++ b/server/book/orderpq.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2019, The Decred developers
+// See LICENSE for details.
+
+package book
+
+import (
+	"container/heap"
+	"fmt"
+	"sync"
+)
+
+// OrderRater is the type stored in the priority queue.
+type OrderRater interface {
+	UID() string
+	Rate() float64
+}
+
+type orderEntry struct {
+	OrderRater
+	heapIdx int
+}
+
+type orderHeap []*orderEntry
+
+// OrderPQ is a priority queue for orders, provided as an OrderRater, based on
+// rate. A max-oriented queue with highest rates on top is constructed via
+// NewMaxOrderPQ, while a min-oriented queue is constructed via NewMinOrderPQ.
+type OrderPQ struct {
+	mtx      sync.RWMutex
+	oh       orderHeap
+	capacity uint32
+	lessFn   func(bi, bj OrderRater) bool
+	orders   map[string]*orderEntry
+}
+
+// NewMinOrderPQ is the constructor for OrderPQ that initializes an empty heap
+// with the given capacity, and sets the default LessFn for a min heap. Use
+// OrderPQ.SetLessFn to redefine the comparator.
+func NewMinOrderPQ(capacity uint32) *OrderPQ {
+	return newOrderPQ(capacity, LessByRate)
+}
+
+// NewMaxOrderPQ is the constructor for OrderPQ that initializes an empty heap
+// with the given capacity, and sets the default LessFn for a max heap. Use
+// OrderPQ.SetLessFn to redefine the comparator.
+func NewMaxOrderPQ(capacity uint32) *OrderPQ {
+	return newOrderPQ(capacity, GreaterByRate)
+}
+
+func newOrderPQ(cap uint32, lessFn func(bi, bj OrderRater) bool) *OrderPQ {
+	return &OrderPQ{
+		oh:       orderHeap{},
+		capacity: cap,
+		lessFn:   lessFn,
+		orders:   make(map[string]*orderEntry),
+	}
+}
+
+// Satisfy heap.Inferface
+
+// Len is require for heap.Interface
+func (pq *OrderPQ) Len() int {
+	return len(pq.oh)
+}
+
+// Less performs the comparison priority(i) vs. priority(j). Use
+// OrderPQ.SetLessFn to define the desired behavior for the orderEntry heap[i]
+// and heap[j].
+func (pq *OrderPQ) Less(i, j int) bool {
+	return pq.lessFn(pq.oh[i], pq.oh[j])
+}
+
+// Swap swaps the orderEntry at i and j. This is used by container/heap.
+func (pq *OrderPQ) Swap(i, j int) {
+	pq.oh[i], pq.oh[j] = pq.oh[j], pq.oh[i]
+	pq.oh[i].heapIdx = i
+	pq.oh[j].heapIdx = j
+}
+
+// SetLessFn sets the function called by Less. The input lessFn must accept two
+// *orderEntry and return a bool, unlike Less, which accepts heap indexes i, j.
+// This allows to define a comparator without requiring a heap.
+func (pq *OrderPQ) SetLessFn(lessFn func(bi, bj OrderRater) bool) {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+	pq.lessFn = lessFn
+}
+
+// LessByHeight defines a higher priority as having a higher rate.
+func LessByRate(bi, bj OrderRater) bool {
+	return bi.Rate() < bj.Rate()
+}
+
+// GreaterByRate defines a higher priority as having a lower rate.
+func GreaterByRate(bi, bj OrderRater) bool {
+	return bi.Rate() > bj.Rate()
+}
+
+// Push an order (a OrderRater). Use heap.Push, not this directly.
+func (pq *OrderPQ) Push(ord interface{}) {
+	rater, ok := ord.(OrderRater)
+	if !ok || rater == nil {
+		fmt.Printf("Failed to push an order: %v", ord)
+		return
+	}
+
+	entry := &orderEntry{
+		OrderRater: rater,
+		heapIdx:    len(pq.oh),
+	}
+
+	uid := entry.UID()
+	if pq.orders[uid] != nil {
+		fmt.Printf("Attempted to push existing order: %v", ord)
+		return
+	}
+
+	pq.orders[uid] = entry
+
+	pq.oh = append(pq.oh, entry)
+}
+
+// Pop will return an interface{} that may be cast to OrderRater (or the
+// underlying concrete type). Use heap.Pop or OrderPQ.PopBest, not this.
+func (pq *OrderPQ) Pop() interface{} {
+	n := pq.Len()
+	old := pq.oh
+	order := old[n-1] // heap.Pop put the best value at the end and reheaped without it
+	order.heapIdx = -1
+	pq.oh = old[0 : n-1]
+	delete(pq.orders, order.UID())
+	return order.OrderRater
+}
+
+// ExtractBest a.k.a. pop removes the highest priority order from the queue, and
+// returns it.
+func (pq *OrderPQ) ExtractBest() OrderRater {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+	if pq.Len() == 0 {
+		return nil
+	}
+	return heap.Pop(pq).(OrderRater)
+}
+
+// PeekBest returns the highest priority order without removing it from the
+// queue.
+func (pq *OrderPQ) PeekBest() OrderRater {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+	if pq.Len() == 0 {
+		return nil
+	}
+	return pq.oh[0].OrderRater
+}
+
+// ResetHeap creates a fresh queue given the input []*orderEntry. For every
+// element in the queue, ResetHeap resets the heap index. The heap is then
+// heapified. NOTE: the input slice is modifed, but not reordered. A fresh slice
+// is created for PQ internal use.
+func (pq *OrderPQ) ResetHeap(oh []*orderEntry) {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+
+	for i := range oh {
+		oh[i].heapIdx = i
+	}
+
+	pq.oh = make([]*orderEntry, len(oh))
+	copy(pq.oh, oh)
+
+	pq.orders = make(map[string]*orderEntry)
+
+	// Do not call Reheap unless you want a deadlock.
+	heap.Init(pq)
+}
+
+// Reheap is a thread-safe shortcut for heap.Init(pq).
+func (pq *OrderPQ) Reheap() {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+	heap.Init(pq)
+}
+
+// Insert will add an element, while respecting the queue's capacity.
+// if at capacity, fail
+// else (not at capacity)
+// 		- heap.Push, which is pq.Push (append at bottom) then heapup
+func (pq *OrderPQ) Insert(rater OrderRater) bool {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+
+	if pq.capacity == 0 {
+		return false
+	}
+
+	if rater == nil || rater.UID() == "" {
+		return false
+	}
+
+	if pq.orders[rater.UID()] != nil {
+		return false
+	}
+
+	// At capacity
+	if int(pq.capacity) <= pq.Len() {
+		return false
+	}
+
+	// With room to grow, append at bottom and bubble up. Note that
+	// (*OrderPQ).Push will update the OrderPQ.orders map.
+	heap.Push(pq, rater)
+	return true
+}
+
+// ReplaceOrder will update the specified OrderRater, which must be in the
+// queue. This function is NOT thread-safe.
+func (pq *OrderPQ) ReplaceOrder(old OrderRater, new OrderRater) {
+	if old == nil || new == nil {
+		return
+	}
+
+	oldUID := old.UID()
+	entry := pq.orders[oldUID]
+
+	newUID := new.UID()
+
+	if oldUID == newUID {
+		return
+	}
+
+	delete(pq.orders, oldUID)
+	entry.OrderRater = new
+	pq.orders[newUID] = entry
+
+	heap.Fix(pq, entry.heapIdx)
+}
+
+// RemoveOrder attempts to remove the provided order from the priority queue
+// based on it's UID.
+func (pq *OrderPQ) RemoveOrder(r OrderRater) {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+	pq.removeOrder(pq.orders[r.UID()])
+}
+
+// RemoveOrderUID attempts to remove the order with the given UID from the
+// priority queue.
+func (pq *OrderPQ) RemoveOrderUID(uid string) {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+	pq.removeOrder(pq.orders[uid])
+}
+
+// removeOrder removes the specified orderEntry from the queue.
+func (pq *OrderPQ) removeOrder(o *orderEntry) {
+	if o != nil && o.heapIdx >= 0 && o.heapIdx < pq.Len() {
+		// Only remove the order if it is really in the queue.
+		uid := o.UID()
+		if pq.oh[o.heapIdx].UID() == uid {
+			delete(pq.orders, uid)
+			pq.removeIndex(o.heapIdx)
+			return
+		}
+		fmt.Printf("Tried to remove an order that was NOT in the PQ. ID: %s",
+			o.UID())
+	}
+}
+
+// removeIndex removes the orderEntry at the specified position in the heap.
+// This function is NOT thread-safe.
+func (pq *OrderPQ) removeIndex(idx int) {
+	heap.Remove(pq, idx)
+}

--- a/server/book/orderpq.go
+++ b/server/book/orderpq.go
@@ -57,26 +57,69 @@ func newOrderPQ(cap uint32, lessFn func(bi, bj OrderRater) bool) *OrderPQ {
 	}
 }
 
-// Satisfy heap.Inferface
+// Satisfy heap.Inferface (Len, Less, Swap, Push, Pop). These functions are only
+// to be used by the container/heap functions via other thread-safe OrderPQ
+// methods. These are not thread safe.
 
-// Len is require for heap.Interface
+// Len is require for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Len() int {
 	return len(pq.oh)
 }
 
 // Less performs the comparison priority(i) vs. priority(j). Use
 // OrderPQ.SetLessFn to define the desired behavior for the orderEntry heap[i]
-// and heap[j].
+// and heap[j]. Less is require for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Less(i, j int) bool {
 	return pq.lessFn(pq.oh[i], pq.oh[j])
 }
 
-// Swap swaps the orderEntry at i and j. This is used by container/heap.
+// Swap swaps the orderEntry at i and j. This is used by container/heap. Swap is
+// require for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Swap(i, j int) {
 	pq.oh[i], pq.oh[j] = pq.oh[j], pq.oh[i]
 	pq.oh[i].heapIdx = i
 	pq.oh[j].heapIdx = j
 }
+
+// Push an order (a OrderRater). Use heap.Push, not this directly. Push is
+// require for heap.Interface. It is not thread-safe.
+func (pq *OrderPQ) Push(ord interface{}) {
+	rater, ok := ord.(OrderRater)
+	if !ok || rater == nil {
+		fmt.Printf("Failed to push an order: %v", ord)
+		return
+	}
+
+	entry := &orderEntry{
+		OrderRater: rater,
+		heapIdx:    len(pq.oh),
+	}
+
+	uid := entry.UID()
+	if pq.orders[uid] != nil {
+		fmt.Printf("Attempted to push existing order: %v", ord)
+		return
+	}
+
+	pq.orders[uid] = entry
+
+	pq.oh = append(pq.oh, entry)
+}
+
+// Pop will return an interface{} that may be cast to OrderRater (or the
+// underlying concrete type). Use heap.Pop or OrderPQ.PopBest, not this. Pop is
+// require for heap.Interface. It is not thread-safe.
+func (pq *OrderPQ) Pop() interface{} {
+	n := pq.Len()
+	old := pq.oh
+	order := old[n-1] // heap.Pop put the best value at the end and reheaped without it
+	order.heapIdx = -1
+	pq.oh = old[0 : n-1]
+	delete(pq.orders, order.UID())
+	return order.OrderRater
+}
+
+// End heap.Inferface.
 
 // SetLessFn sets the function called by Less. The input lessFn must accept two
 // *orderEntry and return a bool, unlike Less, which accepts heap indexes i, j.
@@ -115,42 +158,6 @@ func GreaterByRateThenTime(bi, bj OrderRater) bool {
 	return GreaterByRate(bi, bj)
 }
 
-// Push an order (a OrderRater). Use heap.Push, not this directly.
-func (pq *OrderPQ) Push(ord interface{}) {
-	rater, ok := ord.(OrderRater)
-	if !ok || rater == nil {
-		fmt.Printf("Failed to push an order: %v", ord)
-		return
-	}
-
-	entry := &orderEntry{
-		OrderRater: rater,
-		heapIdx:    len(pq.oh),
-	}
-
-	uid := entry.UID()
-	if pq.orders[uid] != nil {
-		fmt.Printf("Attempted to push existing order: %v", ord)
-		return
-	}
-
-	pq.orders[uid] = entry
-
-	pq.oh = append(pq.oh, entry)
-}
-
-// Pop will return an interface{} that may be cast to OrderRater (or the
-// underlying concrete type). Use heap.Pop or OrderPQ.PopBest, not this.
-func (pq *OrderPQ) Pop() interface{} {
-	n := pq.Len()
-	old := pq.oh
-	order := old[n-1] // heap.Pop put the best value at the end and reheaped without it
-	order.heapIdx = -1
-	pq.oh = old[0 : n-1]
-	delete(pq.orders, order.UID())
-	return order.OrderRater
-}
-
 // ExtractBest a.k.a. pop removes the highest priority order from the queue, and
 // returns it.
 func (pq *OrderPQ) ExtractBest() OrderRater {
@@ -173,10 +180,13 @@ func (pq *OrderPQ) PeekBest() OrderRater {
 	return pq.oh[0].OrderRater
 }
 
-// Reset creates a fresh queue given the input []OrderRater. For every
-// element in the queue, Reset resets the heap index. The heap is then
-// heapified. The input slice is note modifed.
+// Reset creates a fresh queue given the input []OrderRater. For every element
+// in the queue, Reset resets the heap index. The heap is then heapified. The
+// input slice is note modifed.
 func (pq *OrderPQ) Reset(orders []OrderRater) {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+
 	pq.oh = make([]*orderEntry, 0, len(orders))
 	for i, o := range orders {
 		pq.oh = append(pq.oh, &orderEntry{
@@ -187,7 +197,6 @@ func (pq *OrderPQ) Reset(orders []OrderRater) {
 
 	pq.orders = make(map[string]*orderEntry, len(pq.oh))
 
-	// Do not call Reheap unless you want a deadlock.
 	heap.Init(pq)
 }
 
@@ -251,26 +260,33 @@ func (pq *OrderPQ) Insert(rater OrderRater) bool {
 }
 
 // ReplaceOrder will update the specified OrderRater, which must be in the
-// queue. This function is NOT thread-safe.
-func (pq *OrderPQ) ReplaceOrder(old OrderRater, new OrderRater) {
+// queue, and then restores heapiness.
+func (pq *OrderPQ) ReplaceOrder(old OrderRater, new OrderRater) bool {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+
 	if old == nil || new == nil {
-		return
+		return false
 	}
 
 	oldUID := old.UID()
 	entry := pq.orders[oldUID]
+	if entry == nil {
+		return false
+	}
 
 	newUID := new.UID()
-
-	if oldUID == newUID {
-		return
-	}
+	// if oldUID == newUID {
+	// 	return false
+	// }
+	// Above is commented to update regardless of UID.
 
 	delete(pq.orders, oldUID)
 	entry.OrderRater = new
 	pq.orders[newUID] = entry
 
 	heap.Fix(pq, entry.heapIdx)
+	return true
 }
 
 // RemoveOrder attempts to remove the provided order from the priority queue
@@ -289,7 +305,8 @@ func (pq *OrderPQ) RemoveOrderUID(uid string) {
 	pq.removeOrder(pq.orders[uid])
 }
 
-// removeOrder removes the specified orderEntry from the queue.
+// removeOrder removes the specified orderEntry from the queue. This function is
+// NOT thread-safe.
 func (pq *OrderPQ) removeOrder(o *orderEntry) {
 	if o != nil && o.heapIdx >= 0 && o.heapIdx < pq.Len() {
 		// Only remove the order if it is really in the queue.

--- a/server/book/orderpq.go
+++ b/server/book/orderpq.go
@@ -61,28 +61,28 @@ func newOrderPQ(cap uint32, lessFn func(bi, bj OrderRater) bool) *OrderPQ {
 // to be used by the container/heap functions via other thread-safe OrderPQ
 // methods. These are not thread safe.
 
-// Len is require for heap.Interface. It is not thread-safe.
+// Len is required for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Len() int {
 	return len(pq.oh)
 }
 
 // Less performs the comparison priority(i) vs. priority(j). Use
 // OrderPQ.SetLessFn to define the desired behavior for the orderEntry heap[i]
-// and heap[j]. Less is require for heap.Interface. It is not thread-safe.
+// and heap[j]. Less is required for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Less(i, j int) bool {
 	return pq.lessFn(pq.oh[i], pq.oh[j])
 }
 
 // Swap swaps the orderEntry at i and j. This is used by container/heap. Swap is
-// require for heap.Interface. It is not thread-safe.
+// required for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Swap(i, j int) {
 	pq.oh[i], pq.oh[j] = pq.oh[j], pq.oh[i]
 	pq.oh[i].heapIdx = i
 	pq.oh[j].heapIdx = j
 }
 
-// Push an order (a OrderRater). Use heap.Push, not this directly. Push is
-// require for heap.Interface. It is not thread-safe.
+// Push an order, which must be an OrderRater. Use heap.Push, not this directly.
+// Push is required for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Push(ord interface{}) {
 	rater, ok := ord.(OrderRater)
 	if !ok || rater == nil {
@@ -107,8 +107,8 @@ func (pq *OrderPQ) Push(ord interface{}) {
 }
 
 // Pop will return an interface{} that may be cast to OrderRater (or the
-// underlying concrete type). Use heap.Pop or OrderPQ.PopBest, not this. Pop is
-// require for heap.Interface. It is not thread-safe.
+// underlying concrete type). Use heap.Pop or OrderPQ.ExtractBest, not this. Pop
+// is required for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Pop() interface{} {
 	n := pq.Len()
 	old := pq.oh

--- a/server/book/orderpq_test.go
+++ b/server/book/orderpq_test.go
@@ -1,12 +1,18 @@
 package book
 
 import (
+	"encoding/hex"
+	"math/rand"
+	"sort"
 	"testing"
+
+	"github.com/decred/dcrd/crypto/blake256"
 )
 
 type Order struct {
 	uid  string
 	rate float64
+	time int64
 }
 
 var _ OrderRater = (*Order)(nil)
@@ -19,26 +25,240 @@ func (o *Order) Rate() float64 {
 	return o.rate
 }
 
+func (o *Order) Time() int64 {
+	return o.time
+}
+
 func (o *Order) String() string {
 	return o.UID()
 }
 
 var (
-	orders = []*Order{
+	bigList []*Order
+	orders  = []*Order{
 		{
 			uid:  "fakefakefake1324",
 			rate: 42,
+			time: 56789,
 		},
 		{
 			uid:  "1324fakefakefake",
 			rate: 0.0001,
+			time: 56789,
 		},
 		{
 			uid:  "topDog",
 			rate: 123,
+			time: 56789,
+		},
+		{
+			uid:  "fakefakefake1324OLDER",
+			rate: 42,
+			time: 45678,
 		},
 	}
 )
+
+func randomBytes(len int) []byte {
+	bytes := make([]byte, len)
+	rand.Read(bytes)
+	return bytes
+}
+
+func randomHash() [32]byte {
+	return blake256.Sum256(randomBytes(32))
+}
+
+func genBigList() {
+	if bigList != nil {
+		return
+	}
+	// var b [8]byte
+	// crand.Read(b[:])
+	// seed := int64(binary.LittleEndian.Uint64(b[:]))
+	seed := int64(-3405439173988651889)
+	rand.Seed(seed)
+
+	refTime := int64(1567100226)
+
+	listSize := 1000000
+	bigList = make([]*Order, 0, listSize)
+	for i := 0; i < listSize; i++ {
+		uid := randomHash()
+		order := &Order{
+			uid:  hex.EncodeToString(uid[:]),
+			rate: rand.Float64() * 4,
+			time: rand.Int63n(240) + refTime,
+		}
+		if (i+1)%(listSize/400) == 0 {
+			order.rate = bigList[i/2].rate
+		}
+		bigList = append(bigList, order)
+	}
+}
+
+func TestLargeOrderMaxPriorityQueue(t *testing.T) {
+	genBigList()
+
+	// f, err := os.Create("insert.pprof")
+	// if err != nil {
+	// 	t.Fatal("poo")
+	// }
+	// pprof.StartCPUProfile(f)
+	// defer pprof.StopCPUProfile()
+
+	// Max oriented queue
+	pq := NewMaxOrderPQ(uint32(len(bigList) * 3 / 2))
+	for _, o := range bigList {
+		ok := pq.Insert(o)
+		if !ok {
+			t.Fatalf("Failed to insert order %v", o)
+		}
+	}
+
+	if pq.Len() != len(bigList) {
+		t.Errorf("pq length incorrect. expected %d, got %d", len(bigList), pq.Len())
+	}
+
+	initLen := pq.Len()
+	best := pq.ExtractBest()
+	allOrders := make([]OrderRater, 0, initLen)
+	allOrders = append(allOrders, best)
+
+	lastTime := best.Time()
+	lastRate := best.Rate()
+	rates := make([]float64, initLen)
+	rates[0] = lastRate
+
+	lastLen := pq.Len()
+	i := int(1) // already popped 0
+	for pq.Len() > 0 {
+		best = pq.ExtractBest()
+		allOrders = append(allOrders, best)
+		rate := best.Rate()
+		if rate > lastRate {
+			t.Fatalf("Current rate %g > last rate %g. Should be less.",
+				rate, lastRate)
+		}
+		thisTime := best.Time()
+		if rate == lastRate && thisTime < lastTime {
+			t.Fatalf("Orders with the same rate; current time %d < last time %d. Should be greater.",
+				thisTime, lastTime)
+		}
+		lastRate = rate
+		lastTime = thisTime
+
+		rates[i] = rate
+		i++
+
+		if pq.Len() != lastLen-1 {
+			t.Fatalf("Queue length failed to shrink by 1.")
+		}
+		lastLen = pq.Len()
+	}
+
+	// Ensure sorted in a different way.
+	sorted := sort.SliceIsSorted(rates, func(i, j int) bool {
+		return rates[j] < rates[i]
+	})
+	if !sorted {
+		t.Errorf("Rates should have been sorted.")
+	}
+
+	pq.Reset(allOrders)
+	if pq.Len() != len(bigList) {
+		t.Errorf("pq length incorrect. expected %d, got %d", len(bigList), pq.Len())
+	}
+	if pq.PeekBest().Rate() != rates[0] {
+		t.Errorf("Heap Reset failed.")
+	}
+
+	pq.Reheap()
+	if pq.Len() != len(bigList) {
+		t.Errorf("pq length incorrect. expected %d, got %d", len(bigList), pq.Len())
+	}
+	if pq.PeekBest().Rate() != rates[0] {
+		t.Errorf("Heap Reset failed.")
+	}
+}
+
+func TestLargeOrderMinPriorityQueue(t *testing.T) {
+	genBigList()
+
+	// Min oriented queue
+	pq := NewMinOrderPQ(uint32(len(bigList) * 3 / 2))
+	for _, o := range bigList {
+		ok := pq.Insert(o)
+		if !ok {
+			t.Fatalf("Failed to insert order %v", o)
+		}
+	}
+
+	if pq.Len() != len(bigList) {
+		t.Errorf("pq length incorrect. expected %d, got %d", len(bigList), pq.Len())
+	}
+
+	initLen := pq.Len()
+	best := pq.ExtractBest()
+	allOrders := make([]OrderRater, 0, initLen)
+	allOrders = append(allOrders, best)
+
+	lastTime := best.Time()
+	lastRate := best.Rate()
+	rates := make([]float64, initLen)
+	rates[0] = lastRate
+
+	lastLen := pq.Len()
+	i := int(1) // already popped 0
+	for pq.Len() > 0 {
+		best = pq.ExtractBest()
+		allOrders = append(allOrders, best)
+		rate := best.Rate()
+		if rate < lastRate {
+			t.Fatalf("Current (%d) rate %g < last rate %g. Should be greater.",
+				i, rate, lastRate)
+		}
+		thisTime := best.Time()
+		if rate == lastRate && thisTime < lastTime {
+			t.Fatalf("Orders with the same rate; current time %d < last time %d. Should be greater.",
+				thisTime, lastTime)
+		}
+		lastRate = rate
+		lastTime = thisTime
+
+		rates[i] = rate
+		i++
+
+		if pq.Len() != lastLen-1 {
+			t.Fatalf("Queue length failed to shrink by 1.")
+		}
+		lastLen = pq.Len()
+	}
+
+	// Ensure sorted in a different way.
+	sorted := sort.SliceIsSorted(rates, func(i, j int) bool {
+		return rates[i] < rates[j]
+	})
+	if !sorted {
+		t.Errorf("Rates should have been sorted.")
+	}
+
+	pq.Reset(allOrders)
+	if pq.Len() != len(bigList) {
+		t.Errorf("pq length incorrect. expected %d, got %d", len(bigList), pq.Len())
+	}
+	if pq.PeekBest().Rate() != rates[0] {
+		t.Errorf("Heap Reset failed.")
+	}
+
+	pq.Reheap()
+	if pq.Len() != len(bigList) {
+		t.Errorf("pq length incorrect. expected %d, got %d", len(bigList), pq.Len())
+	}
+	if pq.PeekBest().Rate() != rates[0] {
+		t.Errorf("Heap Reset failed.")
+	}
+}
 
 func TestMinOrderPriorityQueue(t *testing.T) {
 	pq := NewMinOrderPQ(2)
@@ -162,7 +382,7 @@ func TestResetHeap(t *testing.T) {
 		},
 	}
 
-	pq.ResetHeap(orderEntries)
+	pq.resetHeap(orderEntries)
 
 	best := pq.ExtractBest()
 	if best.UID() != orders[0].uid {

--- a/server/book/orderpq_test.go
+++ b/server/book/orderpq_test.go
@@ -1,0 +1,211 @@
+package book
+
+import (
+	"testing"
+)
+
+type Order struct {
+	uid  string
+	rate float64
+}
+
+var _ OrderRater = (*Order)(nil)
+
+func (o *Order) UID() string {
+	return o.uid
+}
+
+func (o *Order) Rate() float64 {
+	return o.rate
+}
+
+func (o *Order) String() string {
+	return o.UID()
+}
+
+var (
+	orders = []*Order{
+		{
+			uid:  "fakefakefake1324",
+			rate: 42,
+		},
+		{
+			uid:  "1324fakefakefake",
+			rate: 0.0001,
+		},
+		{
+			uid:  "topDog",
+			rate: 123,
+		},
+	}
+)
+
+func TestMinOrderPriorityQueue(t *testing.T) {
+	pq := NewMinOrderPQ(2)
+
+	ok := pq.Insert(orders[0])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[0])
+	}
+
+	ok = pq.Insert(orders[1])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[1])
+	}
+
+	best := pq.ExtractBest().(*Order)
+	if best.UID() != orders[1].uid {
+		t.Errorf("Incorrect lowest rate order returned: rate = %g, UID = %s",
+			best.Rate(), best.UID())
+	}
+}
+
+func TestMaxOrderPriorityQueue(t *testing.T) {
+	pq := NewMaxOrderPQ(3)
+
+	ok := pq.Insert(orders[0])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[0])
+	}
+
+	ok = pq.Insert(orders[1])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[1])
+	}
+
+	ok = pq.Insert(orders[2])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[2])
+	}
+
+	best := pq.ExtractBest().(*Order)
+	if best.UID() != orders[2].uid {
+		t.Errorf("Incorrect highest rate order returned: rate = %g, UID = %s",
+			best.Rate(), best.UID())
+	}
+}
+
+func TestOrderPriorityQueueCapacity(t *testing.T) {
+	pq := NewMaxOrderPQ(2)
+
+	ok := pq.Insert(orders[0])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[0])
+	}
+
+	ok = pq.Insert(orders[1])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[1])
+	}
+
+	ok = pq.Insert(orders[2])
+	if ok {
+		t.Errorf("Should have failed to insert order %v, but succeeded", orders[2])
+	}
+
+	best := pq.PeekBest().(*Order)
+	if best.UID() != orders[0].uid {
+		t.Errorf("Incorrect highest rate order returned: rate = %g, UID = %s",
+			best.Rate(), best.UID())
+	}
+}
+
+func TestOrderPriorityQueueNegative_Insert(t *testing.T) {
+	pq := NewMinOrderPQ(2)
+
+	ok := pq.Insert(orders[0])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[0])
+	}
+
+	ok = pq.Insert(orders[0])
+	if ok {
+		t.Errorf("Inserted duplicate order %v", orders[1])
+	}
+
+	ok = pq.Insert(nil)
+	if ok {
+		t.Errorf("Inserted nil order %v", orders[1])
+	}
+}
+
+func TestOrderPriorityQueue_Replace(t *testing.T) {
+	pq := NewMinOrderPQ(2)
+
+	ok := pq.Insert(orders[0])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[0])
+	}
+
+	pq.ReplaceOrder(orders[0], orders[1])
+	if pq.Len() != 1 {
+		t.Fatalf("expected queue length 1, got %d", pq.Len())
+	}
+	best := pq.ExtractBest()
+	if best.UID() != orders[1].uid {
+		t.Errorf("Incorrect highest rate order returned: rate = %g, UID = %s",
+			best.Rate(), best.UID())
+	}
+}
+
+func TestResetHeap(t *testing.T) {
+	pq := NewMaxOrderPQ(2)
+
+	orderEntries := []*orderEntry{
+		{
+			OrderRater: orders[0],
+			heapIdx:    -1,
+		},
+		{
+			OrderRater: orders[1],
+			heapIdx:    -1,
+		},
+	}
+
+	pq.ResetHeap(orderEntries)
+
+	best := pq.ExtractBest()
+	if best.UID() != orders[0].uid {
+		t.Errorf("Incorrect highest rate order returned: rate = %g, UID = %s",
+			best.Rate(), best.UID())
+	}
+
+	best = pq.ExtractBest()
+	if best.UID() != orders[1].uid {
+		t.Errorf("Incorrect highest rate order returned: rate = %g, UID = %s",
+			best.Rate(), best.UID())
+	}
+
+	best = pq.ExtractBest()
+	if best != nil {
+		t.Errorf("Order returned, but queue should be empty.")
+	}
+}
+
+func TestOrderPriorityQueue_Remove(t *testing.T) {
+	pq := NewMaxOrderPQ(2)
+
+	ok := pq.Insert(orders[0])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[0])
+	}
+
+	ok = pq.Insert(orders[1])
+	if !ok {
+		t.Errorf("Failed to insert order %v", orders[1])
+	}
+
+	pq.RemoveOrder(orders[1])
+	if pq.Len() != 1 {
+		t.Errorf("Queue length expected %d, got %d", 1, pq.Len())
+	}
+	remainingUID := pq.PeekBest().UID()
+	if remainingUID != orders[0].UID() {
+		t.Errorf("Remaining element expected %s, got %s", orders[0].UID(),
+			remainingUID)
+	}
+	pq.RemoveOrderUID(remainingUID)
+	if pq.Len() != 0 {
+		t.Errorf("Expected empty queue, got %d", pq.Len())
+	}
+}

--- a/server/book/orderpq_test.go
+++ b/server/book/orderpq_test.go
@@ -357,7 +357,10 @@ func TestOrderPriorityQueue_Replace(t *testing.T) {
 		t.Errorf("Failed to insert order %v", orders[0])
 	}
 
-	pq.ReplaceOrder(orders[0], orders[1])
+	ok = pq.ReplaceOrder(orders[0], orders[1])
+	if !ok {
+		t.Fatalf("failed to ReplaceOrder for %v <- %v", orders[0], orders[1])
+	}
 	if pq.Len() != 1 {
 		t.Fatalf("expected queue length 1, got %d", pq.Len())
 	}


### PR DESCRIPTION
This implements a binary heap-based priority queue of orders for efficient retrieval of the "best" orders from the order book, where best means closest to market price.

For the buy side (think left side of the depth chart), where the best order is the order with the highest price rate, a priority queue with a min-oriented heap will be used.
For the sell side, where the best order is the order with the lowest price rate, a pq with a min-oriented heap will be used.

This allows accessing the best element in constant time, and other operations (delete, insert, update) in log time, although insert and update is constant time on average.  Finding the worst (i.e. min in a max heap) is a linear time search of the leaf nodes, but that operation is not needed.

The implementation is relatively simple, supported by the `container/heap` standard library package.

Toward issue #10.