### PR TITLE
book: export and copy functions

### DIFF
--- a/server/book/book.go
+++ b/server/book/book.go
@@ -5,8 +5,6 @@
 package book
 
 import (
-	"fmt"
-
 	"github.com/decred/dcrdex/server/order"
 )
 
@@ -68,23 +66,13 @@ func (b *Book) SellCount() int {
 // BestSell returns a pointer to the best sell order in the order book. The
 // order is NOT removed from the book.
 func (b *Book) BestSell() *order.LimitOrder {
-	best, ok := b.sells.PeekBest().(*order.LimitOrder)
-	if !ok {
-		panic(fmt.Sprintf("Best sell order is not a *order.LimitOrder: %T",
-			b.sells.PeekBest()))
-	}
-	return best
+	return b.sells.PeekBest()
 }
 
 // BestBuy returns a pointer to the best buy order in the order book. The
 // order is NOT removed from the book.
 func (b *Book) BestBuy() *order.LimitOrder {
-	best, ok := b.buys.PeekBest().(*order.LimitOrder)
-	if !ok {
-		panic(fmt.Sprintf("Best sell order is not a *order.LimitOrder: %T",
-			b.sells.PeekBest()))
-	}
-	return best
+	return b.buys.PeekBest()
 }
 
 // Insert attempts to insert the provided order into the order book, returning a
@@ -106,10 +94,10 @@ func (b *Book) Insert(o *order.LimitOrder) bool {
 func (b *Book) Remove(oid order.OrderID) (*order.LimitOrder, bool) {
 	uid := oid.String()
 	if removed, ok := b.sells.RemoveOrderUID(uid); ok {
-		return removed.(*order.LimitOrder), true
+		return removed, true
 	}
 	if removed, ok := b.buys.RemoveOrderUID(uid); ok {
-		return removed.(*order.LimitOrder), true
+		return removed, true
 	}
 	return nil, false
 }
@@ -124,11 +112,7 @@ func (b *Book) SellOrdersN(N int) []*order.LimitOrder {
 	orders := b.sells.OrdersN(N) // N = len(orders)
 	limits := make([]*order.LimitOrder, 0, len(orders))
 	for _, o := range orders {
-		lo, ok := o.(*order.LimitOrder)
-		if !ok {
-			panic(fmt.Sprintf("A sell order is not a *order.LimitOrder: %T", o))
-		}
-		limits = append(limits, lo)
+		limits = append(limits, o)
 	}
 	return limits
 }
@@ -143,11 +127,7 @@ func (b *Book) BuyOrdersN(N int) []*order.LimitOrder {
 	orders := b.buys.OrdersN(N) // N = len(orders)
 	limits := make([]*order.LimitOrder, 0, len(orders))
 	for _, o := range orders {
-		lo, ok := o.(*order.LimitOrder)
-		if !ok {
-			panic(fmt.Sprintf("A buy order is not a *order.LimitOrder: %T", o))
-		}
-		limits = append(limits, lo)
+		limits = append(limits, o)
 	}
 	return limits
 }

--- a/server/book/book.go
+++ b/server/book/book.go
@@ -99,3 +99,41 @@ func (b *Book) Remove(oid order.OrderID) (*order.LimitOrder, bool) {
 	}
 	return nil, false
 }
+
+// SellOrders copies out all sell orders in the book, sorted.
+func (b *Book) SellOrders() []*order.LimitOrder {
+	return b.SellOrdersN(b.SellCount())
+}
+
+// SellOrdersN copies out the N best sell orders in the book, sorted.
+func (b *Book) SellOrdersN(N int) []*order.LimitOrder {
+	orders := b.sells.OrdersN(N) // N = len(orders)
+	limits := make([]*order.LimitOrder, 0, len(orders))
+	for _, o := range orders {
+		lo, ok := o.(*order.LimitOrder)
+		if !ok {
+			panic(fmt.Sprintf("A sell order is not a *order.LimitOrder: %T", o))
+		}
+		limits = append(limits, lo)
+	}
+	return limits
+}
+
+// BuyOrders copies out all buy orders in the book, sorted.
+func (b *Book) BuyOrders() []*order.LimitOrder {
+	return b.BuyOrdersN(b.BuyCount())
+}
+
+// BuyOrdersN copies out the N best buy orders in the book, sorted.
+func (b *Book) BuyOrdersN(N int) []*order.LimitOrder {
+	orders := b.buys.OrdersN(N) // N = len(orders)
+	limits := make([]*order.LimitOrder, 0, len(orders))
+	for _, o := range orders {
+		lo, ok := o.(*order.LimitOrder)
+		if !ok {
+			panic(fmt.Sprintf("A buy order is not a *order.LimitOrder: %T", o))
+		}
+		limits = append(limits, lo)
+	}
+	return limits
+}

--- a/server/book/book_test.go
+++ b/server/book/book_test.go
@@ -146,6 +146,18 @@ func TestBook(t *testing.T) {
 			b.BestSell().ID(), bestSellOrder.ID())
 	}
 
+	sells := b.SellOrders()
+	if len(sells) != b.SellCount() {
+		t.Errorf("Incorrect number of sell orders. Got %d, expected %d",
+			len(sells), b.SellCount())
+	}
+
+	buys := b.BuyOrders()
+	if len(buys) != b.BuyCount() {
+		t.Errorf("Incorrect number of buy orders. Got %d, expected %d",
+			len(buys), b.BuyCount())
+	}
+
 	badOrder := newLimitOrder(false, 2500000, 1, order.StandingTiF, 0)
 	badOrder.Quantity /= 3
 	if b.Insert(badOrder) {

--- a/server/book/book_test.go
+++ b/server/book/book_test.go
@@ -93,7 +93,7 @@ var (
 func newBook(t *testing.T) *Book {
 	resetMakers()
 
-	b := New(LotSize)
+	b := New(LotSize, DefaultBookHalfCapacity)
 
 	for _, o := range bookBuyOrders {
 		if ok := b.Insert(o); !ok {
@@ -156,6 +156,32 @@ func TestBook(t *testing.T) {
 	if len(buys) != b.BuyCount() {
 		t.Errorf("Incorrect number of buy orders. Got %d, expected %d",
 			len(buys), b.BuyCount())
+	}
+
+	b.Realloc(DefaultBookHalfCapacity * 2)
+
+	buys2 := b.BuyOrders()
+	if len(buys) != len(buys2) {
+		t.Errorf("Incorrect number of buy orders after realloc. Got %d, expected %d",
+			len(buys), len(buys2))
+	}
+	for i := range buys2 {
+		if buys2[i] != buys[i] {
+			t.Errorf("Buy order %d mismatch after realloc. Got %s, expected %s",
+				i, buys2[i].UID(), buys[i].UID())
+		}
+	}
+
+	sells2 := b.SellOrders()
+	if len(sells) != len(sells2) {
+		t.Errorf("Incorrect number of sell orders after realloc. Got %d, expected %d",
+			len(sells), len(sells2))
+	}
+	for i := range sells2 {
+		if sells2[i] != sells[i] {
+			t.Errorf("Sell order %d mismatch after realloc. Got %s, expected %s",
+				i, sells2[i].UID(), sells[i].UID())
+		}
 	}
 
 	badOrder := newLimitOrder(false, 2500000, 1, order.StandingTiF, 0)

--- a/server/book/orderpq.go
+++ b/server/book/orderpq.go
@@ -7,34 +7,29 @@ import (
 	"container/heap"
 	"fmt"
 	"sync"
+
+	"github.com/decred/dcrdex/server/order"
 )
 
-// OrderPrice is the type stored in the priority queue.
-type OrderPricer interface {
-	UID() string
-	Price() uint64
-	Time() int64
-}
-
 type orderEntry struct {
-	OrderPricer
+	order   *order.LimitOrder
 	heapIdx int
 }
 
 type orderHeap []*orderEntry
 
-// OrderPQ is a priority queue for orders, provided as OrderPricers, based on
+// OrderPQ is a priority queue for orders, provided as orders, based on
 // price rate. A max-oriented queue with highest rates on top is constructed via
 // NewMaxOrderPQ, while a min-oriented queue is constructed via NewMinOrderPQ.
 type OrderPQ struct {
 	mtx      sync.Mutex
 	oh       orderHeap
 	capacity uint32
-	lessFn   func(bi, bj OrderPricer) bool
+	lessFn   func(bi, bj *order.LimitOrder) bool
 	orders   map[string]*orderEntry
 }
 
-// Copy makes a deep copy of the OrderPQ. The OrderPricers are the same; each
+// Copy makes a deep copy of the OrderPQ. The orders are the same; each
 // orderEntry is new. The capacity and lessFn are the same.
 func (pq *OrderPQ) Copy() *OrderPQ {
 	pq.mtx.Lock()
@@ -43,7 +38,7 @@ func (pq *OrderPQ) Copy() *OrderPQ {
 }
 
 // Copy makes a deep copy of the OrderPQ with the given capacity. The
-// OrderPricers are the same; each orderEntry is new. The lessFn is the same.
+// orders are the same; each orderEntry is new. The lessFn is the same.
 func (pq *OrderPQ) Realloc(newCap uint32) {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
@@ -53,14 +48,14 @@ func (pq *OrderPQ) Realloc(newCap uint32) {
 	pq.oh = newPQ.oh
 }
 
-// copy makes a deep copy of the OrderPQ. The OrderPricers are the same; each
+// copy makes a deep copy of the OrderPQ. The orders are the same; each
 // orderEntry is new. The lessFn is the same. This function is not thread-safe.
 func (pq *OrderPQ) copy(newCap uint32) *OrderPQ {
 	// Deep copy the order heap.
 	orderHeap := make(orderHeap, 0, newCap)
 	for _, oe := range pq.oh {
 		orderHeap = append(orderHeap, &orderEntry{
-			oe.OrderPricer,
+			oe.order,
 			oe.heapIdx,
 		})
 	}
@@ -68,7 +63,7 @@ func (pq *OrderPQ) copy(newCap uint32) *OrderPQ {
 	// Deep copy the orders map.
 	orders := make(map[string]*orderEntry, newCap)
 	for _, oe := range orderHeap {
-		orders[oe.UID()] = oe
+		orders[oe.order.UID()] = oe
 	}
 
 	newPQ := &OrderPQ{
@@ -88,14 +83,14 @@ func (pq *OrderPQ) copy(newCap uint32) *OrderPQ {
 // Orders copies all orders, sorted with the lessFn. The is heap sort. To avoid
 // modifying the OrderPQ or any of the data fields, a deep copy of the OrderPQ
 // is made and ExtractBest is called until all entries are extracted.
-func (pq *OrderPQ) Orders() []OrderPricer {
+func (pq *OrderPQ) Orders() []*order.LimitOrder {
 	return pq.OrdersN(len(pq.oh))
 }
 
 // OrdersN copies the N best orders, sorted with the lessFn. The is heap sort.
 // To avoid modifying the OrderPQ or any of the data fields, a deep copy of the
 // OrderPQ is made and ExtractBest is called until the entries are extracted.
-func (pq *OrderPQ) OrdersN(count int) []OrderPricer {
+func (pq *OrderPQ) OrdersN(count int) []*order.LimitOrder {
 	// Make a deep copy since extracting all the orders in sorted order (i.e.
 	// heap sort) modifies the heap, and the heapIdx of each orderEntry.
 	tmp := pq.Copy()
@@ -106,7 +101,7 @@ func (pq *OrderPQ) OrdersN(count int) []OrderPricer {
 // sort. ExtractBest is called until all entries are extracted. Thus, the
 // OrderPQ is reduced in length by count, or the length of the heap, whichever
 // is shorter. To avoid modifying the queue, use Orders or OrdersN.
-func (pq *OrderPQ) ExtractN(count int) []OrderPricer {
+func (pq *OrderPQ) ExtractN(count int) []*order.LimitOrder {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
 	sz := len(pq.oh)
@@ -116,7 +111,7 @@ func (pq *OrderPQ) ExtractN(count int) []OrderPricer {
 	if count < 1 {
 		return nil
 	}
-	orders := make([]OrderPricer, 0, count)
+	orders := make([]*order.LimitOrder, 0, count)
 	for len(orders) < count {
 		orders = append(orders, pq.ExtractBest())
 	}
@@ -137,7 +132,7 @@ func NewMaxOrderPQ(capacity uint32) *OrderPQ {
 	return newOrderPQ(capacity, GreaterByPriceThenTime)
 }
 
-func newOrderPQ(cap uint32, lessFn func(bi, bj OrderPricer) bool) *OrderPQ {
+func newOrderPQ(cap uint32, lessFn func(bi, bj *order.LimitOrder) bool) *OrderPQ {
 	return &OrderPQ{
 		oh:       make(orderHeap, 0, cap),
 		capacity: cap,
@@ -166,7 +161,7 @@ func (pq *OrderPQ) Len() int {
 // OrderPQ.SetLessFn to define the desired behavior for the orderEntry heap[i]
 // and heap[j]. Less is required for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Less(i, j int) bool {
-	return pq.lessFn(pq.oh[i], pq.oh[j])
+	return pq.lessFn(pq.oh[i].order, pq.oh[j].order)
 }
 
 // Swap swaps the orderEntry at i and j. This is used by container/heap. Swap is
@@ -180,18 +175,18 @@ func (pq *OrderPQ) Swap(i, j int) {
 // Push an order, which must be an OrderPricer. Use heap.Push, not this directly.
 // Push is required for heap.Interface. It is not thread-safe.
 func (pq *OrderPQ) Push(ord interface{}) {
-	pricer, ok := ord.(OrderPricer)
-	if !ok || pricer == nil {
+	lo, ok := ord.(*order.LimitOrder)
+	if !ok || lo == nil {
 		fmt.Printf("Failed to push an order: %v", ord)
 		return
 	}
 
 	entry := &orderEntry{
-		OrderPricer: pricer,
-		heapIdx:     len(pq.oh),
+		order:   lo,
+		heapIdx: len(pq.oh),
 	}
 
-	uid := entry.UID()
+	uid := entry.order.UID()
 	if pq.orders[uid] != nil {
 		fmt.Printf("Attempted to push existing order: %v", ord)
 		return
@@ -208,11 +203,11 @@ func (pq *OrderPQ) Push(ord interface{}) {
 func (pq *OrderPQ) Pop() interface{} {
 	n := pq.Len()
 	old := pq.oh
-	order := old[n-1] // heap.Pop put the best value at the end and reheaped without it
-	order.heapIdx = -1
+	ord := old[n-1] // heap.Pop put the best value at the end and reheaped without it
+	ord.heapIdx = -1
 	pq.oh = old[0 : n-1]
-	delete(pq.orders, order.UID())
-	return order.OrderPricer
+	delete(pq.orders, ord.order.UID())
+	return ord.order
 }
 
 // End heap.Inferface.
@@ -220,25 +215,25 @@ func (pq *OrderPQ) Pop() interface{} {
 // SetLessFn sets the function called by Less. The input lessFn must accept two
 // *orderEntry and return a bool, unlike Less, which accepts heap indexes i, j.
 // This allows to define a comparator without requiring a heap.
-func (pq *OrderPQ) SetLessFn(lessFn func(bi, bj OrderPricer) bool) {
+func (pq *OrderPQ) SetLessFn(lessFn func(bi, bj *order.LimitOrder) bool) {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
 	pq.lessFn = lessFn
 }
 
 // LessByPrice defines a higher priority as having a lower price rate.
-func LessByPrice(bi, bj OrderPricer) bool {
+func LessByPrice(bi, bj *order.LimitOrder) bool {
 	return bi.Price() < bj.Price()
 }
 
 // GreaterByPrice defines a higher priority as having a higher price rate.
-func GreaterByPrice(bi, bj OrderPricer) bool {
+func GreaterByPrice(bi, bj *order.LimitOrder) bool {
 	return bi.Price() > bj.Price()
 }
 
 // LessByPriceThenTime defines a higher priority as having a lower price rate,
 // with older orders breaking any tie.
-func LessByPriceThenTime(bi, bj OrderPricer) bool {
+func LessByPriceThenTime(bi, bj *order.LimitOrder) bool {
 	if bi.Price() == bj.Price() {
 		return bi.Time() < bj.Time()
 	}
@@ -247,7 +242,7 @@ func LessByPriceThenTime(bi, bj OrderPricer) bool {
 
 // GreaterByPriceThenTime defines a higher priority as having a higher price
 // rate, with older orders breaking any tie.
-func GreaterByPriceThenTime(bi, bj OrderPricer) bool {
+func GreaterByPriceThenTime(bi, bj *order.LimitOrder) bool {
 	if bi.Price() == bj.Price() {
 		return bi.Time() < bj.Time()
 	}
@@ -256,33 +251,33 @@ func GreaterByPriceThenTime(bi, bj OrderPricer) bool {
 
 // ExtractBest a.k.a. pop removes the highest priority order from the queue, and
 // returns it.
-func (pq *OrderPQ) ExtractBest() OrderPricer {
+func (pq *OrderPQ) ExtractBest() *order.LimitOrder {
 	return pq.extractBest()
 }
 
 // extractBest is the not thread-safe version of ExtractBest
-func (pq *OrderPQ) extractBest() OrderPricer {
+func (pq *OrderPQ) extractBest() *order.LimitOrder {
 	if pq.Len() == 0 {
 		return nil
 	}
-	return heap.Pop(pq).(OrderPricer)
+	return heap.Pop(pq).(*order.LimitOrder)
 }
 
 // PeekBest returns the highest priority order without removing it from the
 // queue.
-func (pq *OrderPQ) PeekBest() OrderPricer {
+func (pq *OrderPQ) PeekBest() *order.LimitOrder {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
 	if pq.Len() == 0 {
 		return nil
 	}
-	return pq.oh[0].OrderPricer
+	return pq.oh[0].order
 }
 
 // Reset creates a fresh queue given the input []OrderPricer. For every element
 // in the queue, Reset resets the heap index. The heap is then heapified. The
 // input slice is not modifed.
-func (pq *OrderPQ) Reset(orders []OrderPricer) {
+func (pq *OrderPQ) Reset(orders []*order.LimitOrder) {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
 
@@ -290,8 +285,8 @@ func (pq *OrderPQ) Reset(orders []OrderPricer) {
 	pq.orders = make(map[string]*orderEntry, len(pq.oh))
 	for i, o := range orders {
 		entry := &orderEntry{
-			OrderPricer: o,
-			heapIdx:     i,
+			order:   o,
+			heapIdx: i,
 		}
 		pq.oh = append(pq.oh, entry)
 		pq.orders[o.UID()] = entry
@@ -317,7 +312,7 @@ func (pq *OrderPQ) resetHeap(oh []*orderEntry) {
 
 	pq.orders = make(map[string]*orderEntry, len(oh))
 	for _, oe := range oh {
-		pq.orders[oe.UID()] = oe
+		pq.orders[oe.order.UID()] = oe
 	}
 
 	// Do not call Reheap unless you want a deadlock.
@@ -335,7 +330,7 @@ func (pq *OrderPQ) Reheap() {
 // if at capacity, fail
 // else (not at capacity)
 // 		- heap.Push, which is pq.Push (append at bottom) then heapup
-func (pq *OrderPQ) Insert(pricer OrderPricer) bool {
+func (pq *OrderPQ) Insert(ord *order.LimitOrder) bool {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
 
@@ -343,11 +338,13 @@ func (pq *OrderPQ) Insert(pricer OrderPricer) bool {
 		return false
 	}
 
-	if pricer == nil || pricer.UID() == "" {
+	if ord == nil || ord.UID() == "" {
 		return false
 	}
 
-	if pq.orders[pricer.UID()] != nil {
+	uid := ord.UID()
+	if oe, ok := pq.orders[uid]; ok {
+		fmt.Println(oe.order, uid)
 		return false
 	}
 
@@ -358,13 +355,13 @@ func (pq *OrderPQ) Insert(pricer OrderPricer) bool {
 
 	// With room to grow, append at bottom and bubble up. Note that
 	// (*OrderPQ).Push will update the OrderPQ.orders map.
-	heap.Push(pq, pricer)
+	heap.Push(pq, ord)
 	return true
 }
 
 // ReplaceOrder will update the specified OrderPricer, which must be in the
 // queue, and then restores heapiness.
-func (pq *OrderPQ) ReplaceOrder(old OrderPricer, new OrderPricer) bool {
+func (pq *OrderPQ) ReplaceOrder(old *order.LimitOrder, new *order.LimitOrder) bool {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
 
@@ -385,7 +382,7 @@ func (pq *OrderPQ) ReplaceOrder(old OrderPricer, new OrderPricer) bool {
 	// Above is commented to update regardless of UID.
 
 	delete(pq.orders, oldUID)
-	entry.OrderPricer = new
+	entry.order = new
 	pq.orders[newUID] = entry
 
 	heap.Fix(pq, entry.heapIdx)
@@ -394,7 +391,7 @@ func (pq *OrderPQ) ReplaceOrder(old OrderPricer, new OrderPricer) bool {
 
 // RemoveOrder attempts to remove the provided order from the priority queue
 // based on it's UID.
-func (pq *OrderPQ) RemoveOrder(r OrderPricer) (OrderPricer, bool) {
+func (pq *OrderPQ) RemoveOrder(r *order.LimitOrder) (*order.LimitOrder, bool) {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
 	return pq.removeOrder(pq.orders[r.UID()])
@@ -402,7 +399,7 @@ func (pq *OrderPQ) RemoveOrder(r OrderPricer) (OrderPricer, bool) {
 
 // RemoveOrderUID attempts to remove the order with the given UID from the
 // priority queue.
-func (pq *OrderPQ) RemoveOrderUID(uid string) (OrderPricer, bool) {
+func (pq *OrderPQ) RemoveOrderUID(uid string) (*order.LimitOrder, bool) {
 	pq.mtx.Lock()
 	defer pq.mtx.Unlock()
 	return pq.removeOrder(pq.orders[uid])
@@ -410,18 +407,18 @@ func (pq *OrderPQ) RemoveOrderUID(uid string) (OrderPricer, bool) {
 
 // removeOrder removes the specified orderEntry from the queue. This function is
 // NOT thread-safe.
-func (pq *OrderPQ) removeOrder(o *orderEntry) (OrderPricer, bool) {
+func (pq *OrderPQ) removeOrder(o *orderEntry) (*order.LimitOrder, bool) {
 	if o != nil && o.heapIdx >= 0 && o.heapIdx < pq.Len() {
 		// Only remove the order if it is really in the queue.
-		uid := o.UID()
-		removed := pq.oh[o.heapIdx].OrderPricer
+		uid := o.order.UID()
+		removed := pq.oh[o.heapIdx].order
 		if removed.UID() == uid {
 			delete(pq.orders, uid)
 			pq.removeIndex(o.heapIdx)
 			return removed, true
 		}
 		log.Warnf("Tried to remove an order that was NOT in the PQ. ID: %s",
-			o.UID())
+			o.order.UID())
 	}
 	return nil, false
 }
@@ -446,20 +443,20 @@ func (pq *OrderPQ) leafNodes() []*orderEntry {
 // order's position (first element) is known, while the only guarantee regarding
 // the worst element is that it will not be another node's parent (i.e. it is a
 // leaf node).
-func (pq *OrderPQ) Worst() OrderPricer {
+func (pq *OrderPQ) Worst() *order.LimitOrder {
 	// Check the leaf nodes for the worst order according to lessFn.
 	leaves := pq.leafNodes()
 	switch len(leaves) {
 	case 0:
 		return nil
 	case 1:
-		return leaves[0].OrderPricer
+		return leaves[0].order
 	}
-	worst := leaves[0]
+	worst := leaves[0].order
 	for i := 0; i < len(leaves)-1; i++ {
-		if pq.lessFn(worst, leaves[i+1]) {
-			worst = leaves[i+1]
+		if pq.lessFn(worst, leaves[i+1].order) {
+			worst = leaves[i+1].order
 		}
 	}
-	return worst.OrderPricer
+	return worst
 }

--- a/server/book/orderpq_test.go
+++ b/server/book/orderpq_test.go
@@ -286,6 +286,24 @@ func TestLargeOrderMaxPriorityQueue_Orders(t *testing.T) {
 		// }
 	}
 
+	// Copy out just the six best orders.
+	sixOrders := pq.OrdersN(6)
+	for i := range sixOrders {
+		if sixOrders[i].UID() != ordersSorted[i].UID() {
+			t.Errorf("Order %d incorrect. Got %s, expected %s",
+				i, sixOrders[i].UID(), ordersSorted[i].UID())
+		}
+	}
+
+	// Do it again to ensure the queue is not changed by copying.
+	sixOrders2 := pq.OrdersN(6)
+	for i := range sixOrders2 {
+		if sixOrders[i].UID() != sixOrders2[i].UID() {
+			t.Errorf("Order %d incorrect. Got %s, expected %s",
+				i, sixOrders2[i].UID(), sixOrders[i].UID())
+		}
+	}
+
 	pq.Reset(ordersSorted)
 	if pq.Len() != len(bigList) {
 		t.Errorf("pq length incorrect. expected %d, got %d", len(bigList), pq.Len())

--- a/server/order/order.go
+++ b/server/order/order.go
@@ -112,6 +112,11 @@ type Prefix struct {
 	OrderType  OrderType
 	ClientTime time.Time
 	ServerTime time.Time
+
+	//nolint:structcheck
+	id *OrderID // cache of the order's OrderID
+	//nolint:structcheck
+	uid string // cache of the order's UID
 }
 
 // PrefixLen is the length in bytes of the serialized order Prefix.
@@ -176,12 +181,22 @@ type MarketOrder struct {
 
 // ID computes the order ID.
 func (o *MarketOrder) ID() OrderID {
-	return calcOrderID(o)
+	if o.id != nil {
+		return *o.id
+	}
+	id := calcOrderID(o)
+	o.id = &id
+	return id
 }
 
 // UID computes the order ID, returning the string representation.
 func (o *MarketOrder) UID() string {
-	return o.ID().String()
+	if o.uid != "" {
+		return o.uid
+	}
+	uid := o.ID().String()
+	o.uid = uid
+	return uid
 }
 
 // SerializeSize returns the length of the serialized MarketOrder.
@@ -256,12 +271,22 @@ type LimitOrder struct {
 
 // ID computes the order ID.
 func (o *LimitOrder) ID() OrderID {
-	return calcOrderID(o)
+	if o.id != nil {
+		return *o.id
+	}
+	id := calcOrderID(o)
+	o.id = &id
+	return id
 }
 
 // UID computes the order ID, returning the string representation.
 func (o *LimitOrder) UID() string {
-	return o.ID().String()
+	if o.uid != "" {
+		return o.uid
+	}
+	uid := o.ID().String()
+	o.uid = uid
+	return uid
 }
 
 // SerializeSize returns the length of the serialized LimitOrder.
@@ -312,12 +337,22 @@ type CancelOrder struct {
 
 // ID computes the order ID.
 func (o *CancelOrder) ID() OrderID {
-	return calcOrderID(o)
+	if o.id != nil {
+		return *o.id
+	}
+	id := calcOrderID(o)
+	o.id = &id
+	return id
 }
 
 // UID computes the order ID, returning the string representation.
 func (o *CancelOrder) UID() string {
-	return o.ID().String()
+	if o.uid != "" {
+		return o.uid
+	}
+	uid := o.ID().String()
+	o.uid = uid
+	return uid
 }
 
 // SerializeSize returns the length of the serialized CancelOrder.


### PR DESCRIPTION
This modifies the `Book` and `OrderPQ` types to support copying out a slice of orders in sorted order.  While just book updates will normally be served to the client, it will also be necessary to provide the full order books when clients start up or reconnect.  Further, the HTTP API will need to provide full snapshots of the order book, which it may obtain (and refresh at some interval) via these new `Book` methods: `SellOrders`, `SellOrdersN`, `BuyOrders`, and `BuyOrdersN`.

This also makes the order book capacity configurable via the constructor, and dynamically settable via the new `Realloc` method.