### PR TITLE
assets: add fee rate method to DEXTx

### DIFF
--- a/server/asset/btc/live_test.go
+++ b/server/asset/btc/live_test.go
@@ -20,6 +20,11 @@
 // Monitor the blockchain for a while and make sure that the block cache is
 // updating appropriately.
 //
+// go test -v -tags btclive -run LiveFees
+// ------------------------------------------
+// Test that fees rates are parsed without error and that a few historical fee
+// rates are correct.
+//
 // This last test does not pass. Leave as a code example for now.
 // go test -v -tags btclive -run Plugin
 // ------------------------------------------
@@ -76,6 +81,14 @@ func TestUTXOStats(t *testing.T) {
 // LiveP2SHStats in testing.go for an explanation of the test.
 func TestP2SHStats(t *testing.T) {
 	LiveP2SHStats(btc, t)
+}
+
+func TestLiveFees(t *testing.T) {
+	LiveFeeRates(btc, t, map[string]uint64{
+		"a32697f1796b7b87d953637ac827e11b84c6b0f9237cff793f329f877af50aea": 5848,
+		"f3e3e209672fc057bd896c0f703f092a251fa4dca09d062a0223f760661b8187": 340,
+		"a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d": 4191,
+	})
 }
 
 // TestBlockMonitor is a live test that connects to bitcoind and listens for

--- a/server/asset/btc/tx.go
+++ b/server/asset/btc/tx.go
@@ -30,6 +30,8 @@ type Tx struct {
 	// Used to conditionally skip block lookups on mempool transactions during
 	// calls to Confirmations.
 	lastLookup *chainhash.Hash
+	// The calculated transaction fee rate, in satoshis/byte
+	feeRate uint64
 }
 
 // Check that Tx satisfies the asset.DEXTx interface
@@ -50,7 +52,7 @@ type txOut struct {
 
 // A getter for a new Tx.
 func newTransaction(btc *Backend, txHash, blockHash, lastLookup *chainhash.Hash,
-	blockHeight int64, ins []txIn, outs []txOut) *Tx {
+	blockHeight int64, ins []txIn, outs []txOut, feeRate uint64) *Tx {
 	// Set a nil blockHash to the zero hash.
 	hash := blockHash
 	if hash == nil {
@@ -64,6 +66,7 @@ func newTransaction(btc *Backend, txHash, blockHash, lastLookup *chainhash.Hash,
 		ins:        ins,
 		outs:       outs,
 		lastLookup: lastLookup,
+		feeRate:    feeRate,
 	}
 }
 
@@ -171,4 +174,9 @@ func (tx *Tx) AuditContract(vout uint32, contract []byte) (string, uint64, error
 		return "", 0, fmt.Errorf("error extracting address from swap contract for %s:%d: %v", tx.hash, vout, err)
 	}
 	return receiver, output.value, nil
+}
+
+// FeeRate returns the transaction fee rate, in satoshis/byte.
+func (tx *Tx) FeeRate() uint64 {
+	return tx.feeRate
 }

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -94,4 +94,6 @@ type DEXTx interface {
 	// hash specified in the output at the indicated vout. The receiving address
 	// and output value (in atoms) are returned if no error is encountered.
 	AuditContract(vout uint32, contract []byte) (string, uint64, error)
+	// FeeRate returns the transaction fee rate, in atoms/byte equivalent.
+	FeeRate() uint64
 }

--- a/server/asset/dcr/tx.go
+++ b/server/asset/dcr/tx.go
@@ -31,6 +31,8 @@ type Tx struct {
 	// Used to conditionally skip block lookups on mempool transactions during
 	// calls to Confirmations.
 	lastLookup *chainhash.Hash
+	// The calculated transaction fee rate, in satoshis/byte
+	feeRate uint64
 }
 
 // Check that Tx satisfies the asset.DEXTx interface
@@ -51,7 +53,7 @@ type txOut struct {
 
 // A getter for a new Tx.
 func newTransaction(dcr *dcrBackend, txHash, blockHash, lastLookup *chainhash.Hash, blockHeight int64,
-	isStake bool, ins []txIn, outs []txOut) *Tx {
+	isStake bool, ins []txIn, outs []txOut, feeRate uint64) *Tx {
 	// Set a nil blockHash to the zero hash.
 	hash := blockHash
 	if hash == nil {
@@ -66,6 +68,7 @@ func newTransaction(dcr *dcrBackend, txHash, blockHash, lastLookup *chainhash.Ha
 		outs:       outs,
 		isStake:    isStake,
 		lastLookup: lastLookup,
+		feeRate:    feeRate,
 	}
 }
 
@@ -165,4 +168,9 @@ func (tx *Tx) AuditContract(vout uint32, contract []byte) (string, uint64, error
 		return "", 0, fmt.Errorf("error extracting address from swap contract for %s:%d", tx.hash, vout)
 	}
 	return receiver, output.value, nil
+}
+
+// FeeRate returns the transaction fee rate, in atoms/byte.
+func (tx *Tx) FeeRate() uint64 {
+	return tx.feeRate
 }

--- a/server/asset/ltc/live_test.go
+++ b/server/asset/ltc/live_test.go
@@ -10,6 +10,11 @@
 // For each output in the last block, check it's previous outpoint to see if
 // it's a P2SH or P2WSH. If so, takes statistics on the script types, including
 // for the redeem script.
+//
+// go test -v -tags ltclive -run LiveFees
+// ------------------------------------------
+// Test that fees rates are parsed without error and that a few historical fee
+// rates are correct
 
 package ltc
 
@@ -53,4 +58,12 @@ func TestUTXOStats(t *testing.T) {
 
 func TestP2SHStats(t *testing.T) {
 	btc.LiveP2SHStats(ltc, t)
+}
+
+func TestLiveFees(t *testing.T) {
+	btc.LiveFeeRates(ltc, t, map[string]uint64{
+		"d9ec52f3d2c8497638b7de47f77b1e00e91ca98f88bf844b1ae3a2a8ca44bf0b": 1000,
+		"da68b225de1650d69fb57216d8403f91ea0a4b04f7be89150061748863480980": 703,
+		"6e7bfce6aee69312629b1f60afe6dcef02f367207642f2dc380a554c21181eb2": 888,
+	})
 }


### PR DESCRIPTION
The DEXTx interface did not have a fee rate method, but fees must be verified by the swap coordinator.

For the Bitcoin backend, this adds quite a bit of time to transaction fetching, since the `btcjson.TxRawResult` does not have an `AmountIn` field like Decred does, so the transaction for each vin's previous outpoint must be fetched as well. 