### PR TITLE
Add the UnknownOrderType OrderType as 0x0.

### DIFF
--- a/server/book/go.mod
+++ b/server/book/go.mod
@@ -8,8 +8,7 @@ replace (
 )
 
 require (
-	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrdex/server/account v0.0.0-20190907171020-c48f5b8f4bbc
-	github.com/decred/dcrdex/server/order v0.0.0-00010101000000-000000000000
+	github.com/decred/dcrdex/server/order v0.0.0-20191015161642-e29ca1b594a7
 	github.com/decred/slog v1.0.0
 )

--- a/server/book/go.sum
+++ b/server/book/go.sum
@@ -1,5 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=

--- a/server/market/go.mod
+++ b/server/market/go.mod
@@ -10,10 +10,9 @@ replace (
 )
 
 require (
-	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrdex/server/account v0.0.0-20190907171020-c48f5b8f4bbc
 	github.com/decred/dcrdex/server/book v0.0.0-00010101000000-000000000000
 	github.com/decred/dcrdex/server/matcher v0.0.0-00010101000000-000000000000
-	github.com/decred/dcrdex/server/order v0.0.0-00010101000000-000000000000
+	github.com/decred/dcrdex/server/order v0.0.0-20191015161642-e29ca1b594a7
 	github.com/decred/slog v1.0.0
 )

--- a/server/market/go.sum
+++ b/server/market/go.sum
@@ -1,12 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
-github.com/decred/dcrd v1.3.0 h1:EEXm7BdiROfazDtuFsOu9mfotnyy00bgCuVwUqaszFo=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.2 h1:awk7sYJ4pGWmtkiGHFfctztJjHMKGLV8jctGQhAbKe0=
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.2/go.mod h1:CHTUIVfmDDd0KFVFpNX1pFVCBUegxW387nN0IGwNKR0=
-github.com/decred/dcrdex v0.0.0-20190820222222-0c633a45b26a h1:IkTp1kie2MKG5zf4nlcVsP9UXPghXUBLa8JB+T538UQ=
-github.com/decred/dcrdex v0.0.0-20190907171020-c48f5b8f4bbc h1:ayS9BgTwUetJ/mphtm5Yt3X4iPV+pD7jBomGU3yEPQs=
+github.com/decred/dcrdex/server/account v0.0.0-20190907171020-c48f5b8f4bbc/go.mod h1:JLrghdqZ/Ho48JV1Np0qsPcC1nErNekEZd0jJ1QuISI=
+github.com/decred/dcrdex/server/order v0.0.0-20191015161642-e29ca1b594a7/go.mod h1:+bOjO6AlusnQuIFdR+zmO+YHmXt+Ea1/BnL6rbl52pc=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=

--- a/server/matcher/go.mod
+++ b/server/matcher/go.mod
@@ -10,6 +10,6 @@ replace (
 require (
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
 	github.com/decred/dcrdex/server/account v0.0.0-20190907171020-c48f5b8f4bbc
-	github.com/decred/dcrdex/server/order v0.0.0-00010101000000-000000000000
+	github.com/decred/dcrdex/server/order v0.0.0-20191015161642-e29ca1b594a7
 	github.com/decred/slog v1.0.0
 )

--- a/server/matcher/go.sum
+++ b/server/matcher/go.sum
@@ -1,5 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=

--- a/server/matcher/match_test.go
+++ b/server/matcher/match_test.go
@@ -572,7 +572,7 @@ func TestMatch_limitsOnly(t *testing.T) {
 		newLimitOrder(false, 4550000, 2, order.StandingTiF, 0),  // buy, 2 lot, standing, equal rate, partial taker insert to book
 		newLimitOrder(false, 4550000, 2, order.ImmediateTiF, 0), // buy, 2 lot, immediate, equal rate, partial taker unfilled
 		newLimitOrder(false, 4100000, 1, order.ImmediateTiF, 0), // buy, 1 lot, immediate, unfilled fail
-		newLimitOrder(true, 4540000, 1, order.ImmediateTiF, 0),  // sell, 1 lot, immediate
+		newLimitOrder(true, 4540000, 1, order.ImmediateTiF, 5),  // sell, 1 lot, immediate
 	}
 
 	resetTakers := func() {
@@ -1078,8 +1078,8 @@ func Test_shuffleQueue(t *testing.T) {
 
 	// q3Shuffled is the expected result of sorting q3_1 and q3_2
 	q3Shuffled := []order.Order{
-		marketOrders[0],
 		marketOrders[1],
+		marketOrders[0],
 		limitOrders[0],
 	}
 
@@ -1113,8 +1113,8 @@ func Test_shuffleQueue(t *testing.T) {
 	}
 
 	q2Shuffled := []order.Order{
-		limitOrders[0],
 		marketOrders[0],
+		limitOrders[0],
 	}
 
 	tests := []struct {
@@ -1155,7 +1155,7 @@ func Test_shuffleQueue(t *testing.T) {
 		{
 			"q1",
 			q1,
-			[]order.Order{q2Shuffled[1]},
+			[]order.Order{q1[0]},
 		},
 		{
 			"q2_a",
@@ -1170,7 +1170,7 @@ func Test_shuffleQueue(t *testing.T) {
 		{
 			"qDup",
 			qDup,
-			[]order.Order{q2Shuffled[1], q2Shuffled[1]},
+			[]order.Order{q1[0], q1[0]},
 		},
 	}
 	for _, tt := range tests {
@@ -1203,8 +1203,8 @@ func Test_sortQueue(t *testing.T) {
 
 	// q3Sorted is the expected result of sorting q3_1 and q3_2
 	q3Sorted := []order.Order{
-		marketOrders[1],
 		marketOrders[0],
+		marketOrders[1],
 		limitOrders[0],
 	}
 

--- a/server/order/order.go
+++ b/server/order/order.go
@@ -31,7 +31,8 @@ type OrderType uint8
 
 // The different OrderType values.
 const (
-	LimitOrderType OrderType = iota
+	UnknownOrderType OrderType = iota
+	LimitOrderType
 	MarketOrderType
 	CancelOrderType
 )

--- a/server/order/order_test.go
+++ b/server/order/order_test.go
@@ -90,7 +90,7 @@ func TestPrefix_Serialize(t *testing.T) {
 				// QuoteAsset 4 bytes
 				0x0, 0x0, 0x0, 0x1,
 				// OrderType 1 byte
-				0x0,
+				0x1,
 				// ClientTime 8 bytes
 				0x0, 0x0, 0x0, 0x0, 0x5d, 0x5e, 0xdb, 0x75,
 				// ServerTime 8 bytes
@@ -163,7 +163,7 @@ func TestMarketOrder_Serialize_SerializeSize(t *testing.T) {
 				// Prefix - QuoteAsset 4 bytes
 				0x0, 0x0, 0x0, 0x1,
 				// Prefix - OrderType 1 byte
-				0x1,
+				0x2,
 				// Prefix - ClientTime 8 bytes
 				0x0, 0x0, 0x0, 0x0, 0x5d, 0x5e, 0xdb, 0x75,
 				// Prefix - ServerTime 8 bytes
@@ -258,7 +258,7 @@ func TestLimitOrder_Serialize_SerializeSize(t *testing.T) {
 				// Prefix - QuoteAsset 4 bytes
 				0x0, 0x0, 0x0, 0x1,
 				// Prefix - OrderType 1 byte
-				0x0,
+				0x1,
 				// Prefix - ClientTime 8 bytes
 				0x0, 0x0, 0x0, 0x0, 0x5d, 0x5e, 0xdb, 0x75,
 				// Prefix - ServerTime 8 bytes
@@ -348,7 +348,7 @@ func TestCancelOrder_Serialize(t *testing.T) {
 				// Prefix - QuoteAsset 4 bytes
 				0x0, 0x0, 0x0, 0x1,
 				// Prefix - OrderType 1 byte
-				0x2,
+				0x3,
 				// Prefix - ClientTime 8 bytes
 				0x0, 0x0, 0x0, 0x0, 0x5d, 0x5e, 0xdb, 0x9d,
 				// Prefix - ServerTime 8 bytes
@@ -380,7 +380,7 @@ func TestCancelOrder_Serialize(t *testing.T) {
 }
 
 func TestMarketOrder_ID(t *testing.T) {
-	orderID0, _ := hex.DecodeString("5327657626d7b4d4ad2aad4e73d73569a3caed20a0eff860dc2cc10846627dec")
+	orderID0, _ := hex.DecodeString("a347a8b9b9204e7626ed9f03e6a3a49f16a527451fb42c4d6c9494b136e85d50")
 	var orderID OrderID
 	copy(orderID[:], orderID0)
 
@@ -439,7 +439,7 @@ func TestMarketOrder_ID(t *testing.T) {
 }
 
 func TestLimitOrder_ID(t *testing.T) {
-	orderID0, _ := hex.DecodeString("1b0f1c102281f5683ab04877191c52bd662b3dc1d60dd2e7c29cde7713e3556b")
+	orderID0, _ := hex.DecodeString("1bd2250771efa587e2b076bc59b93ee56bcbfd8b8d534a362127d23ce4766f51")
 	var orderID OrderID
 	copy(orderID[:], orderID0)
 
@@ -502,7 +502,7 @@ func TestCancelOrder_ID(t *testing.T) {
 	var limitOrderID OrderID
 	copy(limitOrderID[:], limitOrderID0)
 
-	orderID0, _ := hex.DecodeString("6b7a0e160de0350142936c03a624202e056b3ce24a9e3c37f5d8c1b79f5800bd")
+	orderID0, _ := hex.DecodeString("c051a262af8bd781e1464e72b3c24c2774989eca44d08ef088d82122ce669750")
 	var cancelOrderID OrderID
 	copy(cancelOrderID[:], orderID0)
 


### PR DESCRIPTION
Regarding https://github.com/decred/dcrdex/pull/47#discussion_r334299792

An explicitly-defined `UnknownOrderType` `OrderType` is desirable, especially as the zero-value `OrderType`.