### PR TITLE
server: add an order book subscription router

### DIFF
--- a/server/comms/msgjson/msg_test.go
+++ b/server/comms/msgjson/msg_test.go
@@ -851,6 +851,20 @@ func TestRespReq(t *testing.T) {
 	if err == nil {
 		t.Fatalf("no error when retreiving response payload from request-type message")
 	}
+
+	// Test Notifications
+	_, err = NewNotification("testroute", make(chan int))
+	if err == nil {
+		t.Fatalf("no error for invalid json type notification payload")
+	}
+	_, err = NewNotification("", 10)
+	if err == nil {
+		t.Fatalf("no error for empty string route request")
+	}
+	msg, err = NewNotification("testroute", 10)
+	if err != nil {
+		t.Fatalf("error for valid request payload: %v", err)
+	}
 }
 
 func comparePrefix(t *testing.T, p1, p2 *Prefix) {

--- a/server/comms/msgjson/types.go
+++ b/server/comms/msgjson/types.go
@@ -37,6 +37,7 @@ const (
 	FundingError
 	UTXOAuthError
 	UnknownMarket
+	NotSubscribedError
 )
 
 // Routes are destinations for a "payload" of data. The type of data being
@@ -573,15 +574,15 @@ type TradeNote struct {
 	Time     uint64 `json:"time,omitempty"`
 }
 
-// BookNote is part of a notification about any type of order.
+// OrderNote is part of a notification about any type of order.
 type OrderNote struct {
-	Seq      uint64 `json:"seq,omitempty"` // May be empty when part of an orderbook.
-	MarketID string `json:"marketid"`
+	Seq      uint64 `json:"seq,omitempty"`      // May be empty when part of an OrderBook.
+	MarketID string `json:"marketid,omitempty"` // May be empty when part of an OrderBook.
 	OrderID  Bytes  `json:"oid"`
 }
 
-// BookOrderRoute is the DEX-originating notification-type message informing
-// the client to add the order to the order book.
+// BookOrderNote is the payload for a DEX-originating notification-type message
+// informing the client to add the order to the order book.
 type BookOrderNote struct {
 	OrderNote
 	TradeNote

--- a/server/comms/msgjson/types.go
+++ b/server/comms/msgjson/types.go
@@ -36,6 +36,7 @@ const (
 	ClockRangeError
 	FundingError
 	UTXOAuthError
+	UnknownMarket
 )
 
 // Routes are destinations for a "payload" of data. The type of data being
@@ -73,6 +74,21 @@ const (
 	// CancelRoute is the client-originating request-type message placing a cancel
 	// order.
 	CancelRoute = "cancel"
+	// OrderBookRoute is the client-originating request-type message subscribing
+	// to an order book update notification feed.
+	OrderBookRoute = "orderbook"
+	// UnsubOrderBookRoute is client-originating request-type message cancelling
+	// an order book subscription.
+	UnsubOrderBookRoute = "unsub_orderbook"
+	// BookOrderRoute is the DEX-originating notification-type message informing
+	// the client to add the order to the order book.
+	BookOrderRoute = "book_order"
+	// UnbookOrderRoute is the DEX-originating notification-type message informing
+	// the client to remove an order from the order book.
+	UnbookOrderRoute = "unbook_order"
+	// EpochOrderRoute is the DEX-originating notification-type message informing
+	// the client about an order added to the epoch queue.
+	EpochOrderRoute = "epoch_order"
 )
 
 // Bytes is a byte slice that marshals to and unmarshals from a hexadecimal
@@ -260,6 +276,22 @@ func (msg *Message) Response() (*ResponsePayload, error) {
 		return nil, err
 	}
 	return resp, nil
+}
+
+// NewNotification encodes the payload and creates a Notification-type *Message.
+func NewNotification(route string, payload interface{}) (*Message, error) {
+	if route == "" {
+		return nil, fmt.Errorf("empty string not allowed for route of request-type message")
+	}
+	encPayload, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return &Message{
+		Type:    Notification,
+		Route:   route,
+		Payload: json.RawMessage(encPayload),
+	}, nil
 }
 
 // Match is the params for a DEX-originating MatchRoute request.
@@ -516,6 +548,66 @@ type OrderResult struct {
 func (c *Cancel) Serialize() ([]byte, error) {
 	// serialization: prefix (57) + target id (32) = 89
 	return append(c.Prefix.Serialize(), c.TargetID...), nil
+}
+
+// OrderBookSubscription is the payload for a client-originating request to the
+// OrderBookRoute, intializing an order book feed.
+type OrderBookSubscription struct {
+	Base  uint32 `json:"base"`
+	Quote uint32 `json:"quote"`
+}
+
+// UnsubOrderBook is the payload for a client-originating request to the
+// UnsubOrderBookRoute, terminating an order book subscription.
+type UnsubOrderBook struct {
+	MarketID string `json:"marketid"`
+}
+
+// TradeNote is part of a notification that includes information about a
+// limit or market order.
+type TradeNote struct {
+	Side     uint8  `json:"side,omitempty"`
+	Quantity uint64 `json:"osize,omitempty"`
+	Rate     uint64 `json:"rate,omitempty"`
+	TiF      uint8  `json:"tif,omitempty"`
+	Time     uint64 `json:"time,omitempty"`
+}
+
+// BookNote is part of a notification about any type of order.
+type OrderNote struct {
+	Seq      uint64 `json:"seq,omitempty"` // May be empty when part of an orderbook.
+	MarketID string `json:"marketid"`
+	OrderID  Bytes  `json:"oid"`
+}
+
+// BookOrderRoute is the DEX-originating notification-type message informing
+// the client to add the order to the order book.
+type BookOrderNote struct {
+	OrderNote
+	TradeNote
+}
+
+// OrderBook is the response to a successful OrderBookSubscription.
+type OrderBook struct {
+	Seq      uint64 `json:"seq,omitempty"`
+	MarketID string `json:"marketid"`
+	// DRAFT NOTE: We might want to use a different structure for bulk updates.
+	// Sending a struct of arrays rather than an array of structs could
+	// potentially cut the encoding effort and encoded size substantially.
+	Orders []*BookOrderNote `json:"orders"`
+}
+
+// UnbookOrderRoute is the DEX-originating notification-type message informing
+// the client to remove an order from the order book.
+type UnbookOrderNote OrderNote
+
+// EpochOrderRoute is the DEX-originating notification-type message informing
+// the client about an order added to the epoch queue.
+type EpochOrderNote struct {
+	BookOrderNote
+	OrderType uint8  `json:"otype"`
+	TargetID  Bytes  `json:"target,omitempty"`
+	Epoch     uint64 `json:"epoch"`
 }
 
 // Convert uint64 to 8 bytes.

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -1,0 +1,389 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package market
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/decred/dcrdex/server/comms"
+	"github.com/decred/dcrdex/server/comms/msgjson"
+	"github.com/decred/dcrdex/server/market/types"
+	"github.com/decred/dcrdex/server/order"
+)
+
+// An update action classifies updates into how they affect the book or epoch
+// queue.
+type updateAction uint8
+
+const (
+	// epochAction means an order is being added to the epoch queue and will
+	// result in a msgjson.EpochOrderNote being sent to subscribers.
+	epochAction updateAction = iota
+	// bookAction means an order is being added to the order book, and will result
+	// in a msgjson.BookOrderNote being sent to subscribers.
+	bookAction
+	// unbookAction means an order is being removed from the order book and will
+	// result in a msgjson.UnbookOrderNote being sent to subscribers.
+	unbookAction
+)
+
+// updateSignal combines an updateAction with the order on which the action
+// applies.
+type updateSignal struct {
+	action updateAction
+	order  order.Order
+}
+
+// BookSource is a source of a market's order book, as well as a feed of updates
+// to the order book and epoch queue.
+type BookSource interface {
+	Book() (buys []*order.LimitOrder, sells []*order.LimitOrder)
+	OrderFeed() chan *updateSignal
+}
+
+// subscribers is a manager for a map of subscribers and maintains the sequence
+// counter.
+type subscribers struct {
+	mtx   sync.RWMutex
+	conns map[uint64]comms.Link
+	seq   uint64
+}
+
+// add adds a new subscriber.
+func (s *subscribers) add(conn comms.Link) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.conns[conn.ID()] = conn
+}
+
+// nextSeq gets the next sequence number by incrementing the counter.
+func (s *subscribers) nextSeq() uint64 {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.seq++
+	return s.seq
+}
+
+// lastSeq gets the last retreived sequence number.
+func (s *subscribers) lastSeq() uint64 {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return s.seq
+}
+
+// msgBook is a local copy of the order book information. The orders are saved
+// as msgjson.BookOrderNote structures.
+type msgBook struct {
+	mtx    sync.RWMutex
+	name   string
+	orders map[order.OrderID]*msgjson.BookOrderNote
+	subs   *subscribers
+	source BookSource
+}
+
+// Update updates the order book with the new order information. If an order
+// with the same ID already exists in the book, it is overwritten without
+// warning.  Such a case would be typical when an order's filled amount changes.
+func (book *msgBook) update(lo *order.LimitOrder) *msgjson.BookOrderNote {
+	book.mtx.Lock()
+	defer book.mtx.Unlock()
+	msgOrder := limitOrderToMsgOrder(lo, book.name)
+	book.orders[lo.ID()] = msgOrder
+	return msgOrder
+}
+
+// Remove the order from the order book.
+func (book *msgBook) remove(lo *order.LimitOrder) {
+	book.mtx.Lock()
+	defer book.mtx.Unlock()
+	delete(book.orders, lo.ID())
+}
+
+// addBulkOrders adds the lists of orders to the order book. If an order with
+// the same ID as one provided already exists in the book, it is overwritten
+// without warning. Such a case would be typical when an order's filled amount
+// changes.
+func (book *msgBook) addBulkOrders(orderSets ...[]*order.LimitOrder) {
+	book.mtx.Lock()
+	defer book.mtx.Unlock()
+	for _, set := range orderSets {
+		for _, lo := range set {
+			book.orders[lo.ID()] = limitOrderToMsgOrder(lo, book.name)
+		}
+	}
+}
+
+// OrderBookRouter handles order book subscriptions, linking the market manager
+// with a group of subscribers, and maintaining an intermediate copy of the
+// orderbook in message payload format for quick syncing.
+type OrderBookRouter struct {
+	ctx      context.Context
+	books    map[string]*msgBook
+	epochLen uint64
+}
+
+// BookRouterConfig is the configuration settings for an OrderBookRouter and the
+// only argument to its constructor.
+type BookRouterConfig struct {
+	// Ctx is the application context. The monitoring goroutines will be shut down
+	// on context cancellation.
+	Ctx context.Context
+	// Sources is a mapping of market names to sources for order and epoch queue
+	// information.
+	Sources map[string]BookSource
+	// EpochDuration is the DEX's configured epoch duration.
+	EpochDuration uint64
+}
+
+// NewOrderBookRouter is a constructor for an OrderBookRouter. Routes are
+// registered with comms and a monitoring goroutine is started for each
+// BookSource speicified.
+func NewOrderBookRouter(cfg *BookRouterConfig) *OrderBookRouter {
+	router := &OrderBookRouter{
+		ctx:      cfg.Ctx,
+		books:    make(map[string]*msgBook),
+		epochLen: cfg.EpochDuration,
+	}
+	for mkt, src := range cfg.Sources {
+		subs := &subscribers{
+			conns: make(map[uint64]comms.Link),
+		}
+		book := &msgBook{
+			name:   mkt,
+			orders: make(map[order.OrderID]*msgjson.BookOrderNote),
+			subs:   subs,
+			source: src,
+		}
+		router.books[mkt] = book
+		go router.run(book)
+	}
+	comms.Route(msgjson.OrderBookRoute, router.handleOrderBook)
+	comms.Route(msgjson.UnsubOrderBookRoute, router.handleUnsubOrderBook)
+	return router
+}
+
+// run is a montoring loop for the specified msgBook and source.
+func (r *OrderBookRouter) run(book *msgBook) {
+	// Get the initial book.
+	feed := book.source.OrderFeed()
+	book.addBulkOrders(book.source.Book())
+	subs := book.subs
+
+out:
+	for {
+		select {
+		case u := <-feed:
+			seq := subs.nextSeq()
+			var note interface{}
+			route := msgjson.BookOrderRoute
+			switch u.action {
+			case bookAction:
+				lo, ok := u.order.(*order.LimitOrder)
+				if !ok {
+					panic("non-limit order received with bookAction")
+				}
+				n := book.update(lo)
+				n.Seq = seq
+				note = n
+			case unbookAction:
+				route = msgjson.UnbookOrderRoute
+				lo, ok := u.order.(*order.LimitOrder)
+				if !ok {
+					panic("non-limit order received with unbookAction")
+				}
+				book.remove(lo)
+				oid := u.order.ID()
+				note = &msgjson.UnbookOrderNote{
+					OrderID:  oid[:],
+					MarketID: book.name,
+					Seq:      seq,
+				}
+			case epochAction:
+				route = msgjson.EpochOrderRoute
+				epochNote := new(msgjson.EpochOrderNote)
+				switch o := u.order.(type) {
+				case *order.LimitOrder:
+					epochNote.BookOrderNote = *limitOrderToMsgOrder(o, book.name)
+					epochNote.OrderType = msgjson.LimitOrderNum
+				case *order.MarketOrder:
+					epochNote.BookOrderNote = *marketOrderToMsgOrder(o, book.name)
+					epochNote.OrderType = msgjson.MarketOrderNum
+				case *order.CancelOrder:
+					epochNote.OrderType = msgjson.CancelOrderNum
+					epochNote.TargetID = o.TargetOrderID[:]
+				}
+				epochNote.Seq = seq
+				epochNote.MarketID = book.name
+				t := uint64(u.order.Time())
+				epochNote.Epoch = t - t%r.epochLen
+				note = epochNote
+			default:
+				panic("unknown orderbook update action")
+			}
+			r.sendNote(route, subs, note)
+		case <-r.ctx.Done():
+			break out
+		}
+	}
+}
+
+// sendBook encodes and sends the the entire order book to the specified client.
+func (r *OrderBookRouter) sendBook(conn comms.Link, book *msgBook, msgID uint64) {
+	msgBook := make([]*msgjson.BookOrderNote, 0, len(book.orders))
+	seq := book.subs.lastSeq()
+	book.mtx.RLock()
+	for _, o := range book.orders {
+		msgBook = append(msgBook, o)
+	}
+	book.mtx.RUnlock()
+	msg, err := msgjson.NewResponse(msgID, &msgjson.OrderBook{
+		Seq:      seq,
+		MarketID: book.name,
+		Orders:   msgBook,
+	}, nil)
+	if err != nil {
+		log.Errorf("error encoding 'orderbook' response: %v", err)
+		return
+	}
+	err = conn.Send(msg)
+	if err != nil {
+		log.Debugf("error sending 'orderbook' response: %v", err)
+	}
+}
+
+// handlerOrderBook is the handler for the non-autenticated 'orderbook' route.
+// A client sends a request to this route to start an order book subscription,
+// downloading the existing order book and receiving updates as a feed of
+// notificaitons.
+func (r *OrderBookRouter) handleOrderBook(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
+	sub := new(msgjson.OrderBookSubscription)
+	err := json.Unmarshal(msg.Payload, sub)
+	if err != nil {
+		return &msgjson.Error{
+			Code:    msgjson.RPCParseError,
+			Message: "parse error: " + err.Error(),
+		}
+	}
+	mkt, err := types.MarketName(sub.Base, sub.Quote)
+	if err != nil {
+		return &msgjson.Error{
+			Code:    msgjson.UnknownMarket,
+			Message: "market name error: " + err.Error(),
+		}
+	}
+	book, found := r.books[mkt]
+	if !found {
+		return &msgjson.Error{
+			Code:    msgjson.UnknownMarket,
+			Message: "unknown market",
+		}
+	}
+	book.subs.add(conn)
+	go r.sendBook(conn, book, msg.ID)
+	return nil
+}
+
+// handleUnsubOrderBook is the handler for the non-authenticated
+// 'unsub_orderbook' route. Clients use this route to unsubscribe from an
+// order book.
+func (r *OrderBookRouter) handleUnsubOrderBook(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
+	unsub := new(msgjson.UnsubOrderBook)
+	err := json.Unmarshal(msg.Payload, unsub)
+	if err != nil {
+		return &msgjson.Error{
+			Code:    msgjson.RPCParseError,
+			Message: "parse error: " + err.Error(),
+		}
+	}
+	book := r.books[unsub.MarketID]
+	if book == nil {
+		return &msgjson.Error{
+			Code:    msgjson.UnknownMarket,
+			Message: "unknown market: " + unsub.MarketID,
+		}
+	}
+
+	book.subs.mtx.Lock()
+	delete(book.subs.conns, conn.ID())
+	book.subs.mtx.Unlock()
+
+	return nil
+}
+
+// sendNote sends a notification to the specified subscribers.
+func (r *OrderBookRouter) sendNote(route string, subs *subscribers, note interface{}) {
+	msg, err := msgjson.NewNotification(route, note)
+	if err != nil {
+		log.Errorf("error creating notification-type Message: %v", err)
+		// Do I need to do some kind of resync here?
+		return
+	}
+
+	deletes := make([]uint64, 0)
+	subs.mtx.RLock()
+	for _, conn := range subs.conns {
+		err := conn.Send(msg)
+		if err != nil {
+			deletes = append(deletes, conn.ID())
+		}
+	}
+	subs.mtx.RUnlock()
+	if len(deletes) > 0 {
+		subs.mtx.Lock()
+		for _, id := range deletes {
+			delete(subs.conns, id)
+		}
+		subs.mtx.Unlock()
+	}
+}
+
+// limitOrderToMsgOrder converts an *order.LimitOrder to a
+// *msgjson.BookOrderNote.
+func limitOrderToMsgOrder(o *order.LimitOrder, mkt string) *msgjson.BookOrderNote {
+	oid := o.ID()
+	oSide := uint8(msgjson.BuyOrderNum)
+	if o.Sell {
+		oSide = msgjson.SellOrderNum
+	}
+	tif := uint8(msgjson.StandingOrderNum)
+	if o.Force == order.ImmediateTiF {
+		tif = msgjson.ImmediateOrderNum
+	}
+	return &msgjson.BookOrderNote{
+		TradeNote: msgjson.TradeNote{
+			Side:     oSide,
+			Quantity: o.Remaining(),
+			Rate:     o.Rate,
+			TiF:      tif,
+			Time:     uint64(o.ServerTime.Unix()),
+		},
+		OrderNote: msgjson.OrderNote{
+			MarketID: mkt,
+			OrderID:  oid[:],
+		},
+	}
+}
+
+// marketOrderToMsgOrder an *order.MarketOrder to a
+// *msgjson.BookOrderNote.
+func marketOrderToMsgOrder(o *order.MarketOrder, mkt string) *msgjson.BookOrderNote {
+	oid := o.ID()
+	oSide := uint8(msgjson.BuyOrderNum)
+	if o.Sell {
+		oSide = uint8(msgjson.SellOrderNum)
+	}
+	return &msgjson.BookOrderNote{
+		OrderNote: msgjson.OrderNote{
+			MarketID: mkt,
+			OrderID:  oid[:],
+		},
+		TradeNote: msgjson.TradeNote{
+			Side:     oSide,
+			Quantity: o.Remaining(),
+			Time:     uint64(o.ServerTime.Unix()),
+		},
+	}
+}

--- a/server/market/go.mod
+++ b/server/market/go.mod
@@ -6,7 +6,6 @@ replace (
 	github.com/decred/dcrdex/server/account => ../account
 	github.com/decred/dcrdex/server/asset => ../asset
 	github.com/decred/dcrdex/server/book => ../book
-	github.com/decred/dcrdex/server/comms => ../comms
 	github.com/decred/dcrdex/server/comms/msgjson => ../comms/msgjson
 	github.com/decred/dcrdex/server/market/types => ../market/types
 	github.com/decred/dcrdex/server/matcher => ../matcher
@@ -20,7 +19,7 @@ require (
 	github.com/decred/dcrdex/server/account v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/dcrdex/server/asset v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/dcrdex/server/book v0.0.0-20191021140456-dfb4ce4aeb06
-	github.com/decred/dcrdex/server/comms v0.0.0-00010101000000-000000000000
+	github.com/decred/dcrdex/server/comms v0.0.0-20191030182607-90a2131e2ab3
 	github.com/decred/dcrdex/server/comms/msgjson v0.0.0-00010101000000-000000000000
 	github.com/decred/dcrdex/server/matcher v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/dcrdex/server/order v0.0.0-20191021140456-dfb4ce4aeb06

--- a/server/market/go.mod
+++ b/server/market/go.mod
@@ -8,8 +8,10 @@ replace (
 	github.com/decred/dcrdex/server/book => ../book
 	github.com/decred/dcrdex/server/comms => ../comms
 	github.com/decred/dcrdex/server/comms/msgjson => ../comms/msgjson
+	github.com/decred/dcrdex/server/market/types => ../market/types
 	github.com/decred/dcrdex/server/matcher => ../matcher
 	github.com/decred/dcrdex/server/order => ../order
+	github.com/decred/dcrdex/server/order/test => ../order/test
 )
 
 require (
@@ -18,6 +20,7 @@ require (
 	github.com/decred/dcrdex/server/account v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/dcrdex/server/asset v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/dcrdex/server/book v0.0.0-20191021140456-dfb4ce4aeb06
+	github.com/decred/dcrdex/server/comms v0.0.0-00010101000000-000000000000
 	github.com/decred/dcrdex/server/comms/msgjson v0.0.0-00010101000000-000000000000
 	github.com/decred/dcrdex/server/matcher v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/dcrdex/server/order v0.0.0-20191021140456-dfb4ce4aeb06

--- a/server/market/go.sum
+++ b/server/market/go.sum
@@ -27,6 +27,9 @@ github.com/decred/dcrd/dcrec/secp256k1 v1.0.3/go.mod h1:eCL8H4MYYjRvsw2TuANvEOcV
 github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0 h1:3GIJYXQDAKpLEFriGFN8SbSffak10UXHGdIcFaMPykY=
 github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0/go.mod h1:3s92l0paYkZoIHuj4X93Teg/HB7eGM9x/zokGw+u4mY=
 github.com/decred/dcrdex v0.0.0-20191022190834-83c0cb22104f h1:pGoZcZlTHT7AjQZLXYYBOdEP0951juTkgfbFboi7+yY=
+github.com/decred/dcrdex v0.0.0-20191030182607-90a2131e2ab3 h1:GIdRyY31bxCrSsHL93sucDL0KMEFk4V2AtWsqDsvJTo=
+github.com/decred/dcrdex/server/comms v0.0.0-20191030182607-90a2131e2ab3 h1:zoyRlAO/4SfZ4Twpz9UXD286Xl+Cf/wTrH3B3bPBOFY=
+github.com/decred/dcrdex/server/comms v0.0.0-20191030182607-90a2131e2ab3/go.mod h1:iFoio46I4ZbJXHNDjVs0SWsrowiOp4UPU/QCDpi4c/o=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
The router handles client subscriptions to order book data, relaying information from the order book data source (likely a market manager) to subscribed clients.

Resolves #61