### PR TITLE
server: add order router

### DIFF
--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -211,6 +211,12 @@ func (btc *Backend) InitTxSize() uint32 {
 	return initTxSize
 }
 
+// CheckAddress checks that the given address is parseable.
+func (btc *Backend) CheckAddress(addr string) bool {
+	_, err := btcutil.DecodeAddress(addr, btc.chainParams)
+	return err == nil
+}
+
 // Create a *Backend and start the block monitor loop.
 func newBTC(ctx context.Context, chainParams *chaincfg.Params, logger asset.Logger, node btcNode) *Backend {
 	btc := &Backend{
@@ -317,6 +323,7 @@ func (btc *Backend) utxo(txHash *chainhash.Hash, vout uint32, redeemScript []byt
 		redeemScript: redeemScript,
 		numSigs:      scriptAddrs.nRequired,
 		spendSize:    uint32(sigScriptSize) + txInOverhead,
+		value:        uint64(txOut.Value * btcToSatoshi),
 		lastLookup:   lastLookup,
 	}, nil
 }

--- a/server/asset/btc/testing.go
+++ b/server/asset/btc/testing.go
@@ -223,6 +223,7 @@ func LiveUTXOStats(btc *Backend, t *testing.T) {
 		found   int
 		checked int
 		utxoErr int
+		utxoVal uint64
 	}
 	var stats testStats
 	var unknowns [][]byte
@@ -274,12 +275,13 @@ out:
 					continue
 				}
 				stats.checked++
-				_, err = btc.utxo(txHash, uint32(vout), nil)
+				utxo, err := btc.utxo(txHash, uint32(vout), nil)
 				if err != nil {
 					stats.utxoErr++
 					continue
 				}
 				stats.found++
+				stats.utxoVal += utxo.Value()
 			}
 		}
 		prevHash, err := chainhash.NewHashFromStr(block.PreviousHash)
@@ -297,6 +299,7 @@ out:
 	t.Logf("%d P2WSH scripts", stats.p2wsh)
 	t.Logf("%d zero-valued outputs", stats.zeros)
 	t.Logf("%d P2(W)PKH UTXOs found of %d checked, %.1f%%", stats.found, stats.checked, float64(stats.found)/float64(stats.checked)*100)
+	t.Logf("total unspent value counted: %.2f", float64(stats.utxoVal)/1e8)
 	t.Logf("%d P2PKH UTXO retrieval errors (likely already spent, OK)", stats.utxoErr)
 	numUnknown := len(unknowns)
 	if numUnknown > 0 {

--- a/server/asset/btc/utxo.go
+++ b/server/asset/btc/utxo.go
@@ -39,6 +39,8 @@ type UTXO struct {
 	// spendSize stores the best estimate of the size (bytes) of the serialized
 	// transaction input that spends this UTXO.
 	spendSize uint32
+	// The output value.
+	value uint64
 	// While the utxo's tx is still in mempool, the tip hash will be stored.
 	// This enables an optimization in the Confirmations method to return zero
 	// without extraneous block lookups.
@@ -196,4 +198,9 @@ func (utxo *UTXO) TxID() string {
 // Vout is the output index of the UTXO.
 func (utxo *UTXO) Vout() uint32 {
 	return utxo.vout
+}
+
+// Value is the output value, in atoms.
+func (utxo *UTXO) Value() uint64 {
+	return utxo.value
 }

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -47,6 +47,8 @@ type DEXAsset interface {
 	// transaction with 1 input spending a P2PKH utxo, 1 swap contract output and
 	// 1 change output.
 	InitTxSize() uint32
+	// CheckAddress checks that the given address is parseable.
+	CheckAddress(string) bool
 }
 
 // UTXO provides data about an unspent transaction output.
@@ -73,6 +75,8 @@ type UTXO interface {
 	TxID() string
 	// Vout is the output index of the UTXO.
 	Vout() uint32
+	// Value is the output value.
+	Value() uint64
 }
 
 // DEXTx provides methods for verifying transaction data.
@@ -103,6 +107,7 @@ type DEXTx interface {
 // grouped with the backend for convenience.
 type Asset struct {
 	Backend  DEXAsset
+	ID       uint32
 	Symbol   string
 	LotSize  uint64
 	RateStep uint64

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -157,6 +157,12 @@ func (dcr *dcrBackend) Transaction(txid string) (asset.DEXTx, error) {
 	return dcr.transaction(txHash)
 }
 
+// CheckAddress checks that the given address is parseable.
+func (dcr *dcrBackend) CheckAddress(addr string) bool {
+	_, err := dcrutil.DecodeAddress(addr, chainParams)
+	return err == nil
+}
+
 // Get the Tx. Transaction info is not cached, so every call will result in a
 // GetRawTransactionVerbose RPC call.
 func (dcr *dcrBackend) transaction(txHash *chainhash.Hash) (*Tx, error) {
@@ -401,6 +407,7 @@ func (dcr *dcrBackend) utxo(txHash *chainhash.Hash, vout uint32, redeemScript []
 		numSigs:      scriptAddrs.nRequired,
 		// The total size associated with the wire.TxIn.
 		spendSize:  uint32(sigScriptSize) + txInOverhead,
+		value:      uint64(txOut.Value * dcrToAtoms),
 		lastLookup: lastLookup,
 	}, nil
 }

--- a/server/asset/dcr/live_test.go
+++ b/server/asset/dcr/live_test.go
@@ -89,6 +89,7 @@ func TestLiveUTXO(t *testing.T) {
 		sp2sh          int
 		immatureBefore int
 		immatureAfter  int
+		utxoVal        uint64
 	}
 	stats := new(testStats)
 	var currentHeight, tipHeight int64
@@ -209,6 +210,7 @@ func TestLiveUTXO(t *testing.T) {
 					if confs != int64(expectedConfs) {
 						return fmt.Errorf("expected %d confirmations, found %d for %s:%d", expectedConfs, confs, txHash, vout)
 					}
+					stats.utxoVal += utxo.Value()
 					break
 				case scriptTypeOK && err != nil:
 					// This is only okay if output is being spent by another transaction.
@@ -297,6 +299,7 @@ func TestLiveUTXO(t *testing.T) {
 	t.Logf("%d stake P2SH scripts", stats.sp2sh)
 	t.Logf("%d immature transactions in the last %d blocks", stats.immatureBefore, maturity)
 	t.Logf("%d immature transactions before %d blocks ago", stats.immatureAfter, maturity)
+	t.Logf("total unspent value counted: %.2f DCR", float64(stats.utxoVal)/1e8)
 }
 
 // TestCacheAdvantage compares the speed of requesting blocks from the RPC vs.

--- a/server/asset/dcr/utxo.go
+++ b/server/asset/dcr/utxo.go
@@ -42,6 +42,8 @@ type UTXO struct {
 	// spendSize stores the best estimate of the size (bytes) of the serialized
 	// transaction input that spends this UTXO.
 	spendSize uint32
+	// The output value.
+	value uint64
 	// While the utxo's tx is still in mempool, the tip hash will be stored.
 	// This enables an optimization in the Confirmations method to return zero
 	// without extraneous RPC calls.
@@ -239,4 +241,9 @@ func (utxo *UTXO) Vout() uint32 {
 // the same value as the txid argument passed to (DEXAsset).UTXO.
 func (utxo *UTXO) TxID() string {
 	return utxo.txHash.String()
+}
+
+// Value is the output value, in atoms.
+func (utxo *UTXO) Value() uint64 {
+	return utxo.value
 }

--- a/server/market/go.mod
+++ b/server/market/go.mod
@@ -6,15 +6,20 @@ replace (
 	github.com/decred/dcrdex/server/account => ../account
 	github.com/decred/dcrdex/server/asset => ../asset
 	github.com/decred/dcrdex/server/book => ../book
+	github.com/decred/dcrdex/server/comms => ../comms
+	github.com/decred/dcrdex/server/comms/msgjson => ../comms/msgjson
 	github.com/decred/dcrdex/server/matcher => ../matcher
 	github.com/decred/dcrdex/server/order => ../order
 )
 
 require (
 	github.com/decred/dcrd/dcrec/secp256k1 v1.0.3 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0
 	github.com/decred/dcrdex/server/account v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/dcrdex/server/asset v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/dcrdex/server/book v0.0.0-20191021140456-dfb4ce4aeb06
+	github.com/decred/dcrdex/server/comms v0.0.0-00010101000000-000000000000
+	github.com/decred/dcrdex/server/comms/msgjson v0.0.0-00010101000000-000000000000
 	github.com/decred/dcrdex/server/matcher v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/dcrdex/server/order v0.0.0-20191021140456-dfb4ce4aeb06
 	github.com/decred/slog v1.0.0

--- a/server/market/go.sum
+++ b/server/market/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/decred/dcrd/certgen v1.1.0 h1:lAPE2OLYdYeXDCaji/+KC53j7/s7wF7RVGeQbXK//XA=
+github.com/decred/dcrd/certgen v1.1.0/go.mod h1:ivkPLChfjdAgFh7ZQOtl6kJRqVkfrCq67dlq3AbZBQE=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2 h1:rt5Vlq/jM3ZawwiacWjPa+smINyLRN07EO0cNBV6DGU=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.2/go.mod h1:BpbrGgrPTr3YJYRN3Bm+D9NuaFd+zGyNeIKgrhCXK60=
@@ -24,10 +26,15 @@ github.com/decred/dcrd/dcrec/secp256k1 v1.0.3 h1:u4XpHqlscRolxPxt2YHrFBDVZYY1AK+
 github.com/decred/dcrd/dcrec/secp256k1 v1.0.3/go.mod h1:eCL8H4MYYjRvsw2TuANvEOcVMFbmi9rt/6hJUWU5wlU=
 github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0 h1:3GIJYXQDAKpLEFriGFN8SbSffak10UXHGdIcFaMPykY=
 github.com/decred/dcrd/dcrec/secp256k1/v2 v2.0.0/go.mod h1:3s92l0paYkZoIHuj4X93Teg/HB7eGM9x/zokGw+u4mY=
+github.com/decred/dcrdex v0.0.0-20191022190834-83c0cb22104f h1:pGoZcZlTHT7AjQZLXYYBOdEP0951juTkgfbFboi7+yY=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
+github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=

--- a/server/market/log.go
+++ b/server/market/log.go
@@ -1,0 +1,24 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package market
+
+import (
+	"github.com/decred/slog"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log = slog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	log = slog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -1,0 +1,556 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package market
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/decred/dcrdex/server/account"
+	"github.com/decred/dcrdex/server/asset"
+	"github.com/decred/dcrdex/server/comms/msgjson"
+	dex "github.com/decred/dcrdex/server/market/types"
+	"github.com/decred/dcrdex/server/matcher"
+	"github.com/decred/dcrdex/server/order"
+)
+
+const maxClockOffset = 10 // seconds
+
+// The AuthManager handles client-related actions, including authorization and
+// communications.
+type AuthManager interface {
+	Route(route string, handler func(account.AccountID, *msgjson.Message) *msgjson.Error)
+	Auth(user account.AccountID, msg, sig []byte) error
+	Sign(...msgjson.Signable)
+	Send(account.AccountID, *msgjson.Message)
+}
+
+// MarketTunnel is a connection to a market and information about existing
+// swaps.
+type MarketTunnel interface {
+	AddEpoch(order.Order) error
+	MidGap() uint64
+	OutpointLocked(txid string, vout uint32) bool
+	Cancelable(order.OrderID) bool
+	// DRAFT NOTE: TxMonitored is probably best handled by the swap monitor.
+	// Currently, the swap monitor does not track matches by user, but by match
+	// ID, so some changes would need to be made to make sure that the information
+	// could be quickly retrieved.
+	TxMonitored(user account.AccountID, txid string) bool
+}
+
+// assetSet is pointers to two differnt assets, but with 4 ways of addressing
+// them.
+type assetSet struct {
+	funding   *asset.Asset
+	receiving *asset.Asset
+	base      *asset.Asset
+	quote     *asset.Asset
+}
+
+// outpoint satisfies order.Outpoint.
+type outpoint struct {
+	hash []byte
+	vout uint32
+}
+
+// newOutpoint is a constructor for an outpoint.
+func newOutpoint(h []byte, v uint32) *outpoint {
+	return &outpoint{
+		hash: h,
+		vout: v,
+	}
+}
+
+// Txhash is a getter for the outpoint's hash.
+func (o *outpoint) TxHash() []byte { return o.hash }
+
+// Vout is a getter for the outpoint's vout.
+func (o *outpoint) Vout() uint32 { return o.vout }
+
+// OrderRouter handles the 'limit', 'market', and 'cancel' DEX routes. These
+// are authenticated routes used for placing and canceling orders.
+type OrderRouter struct {
+	auth     AuthManager
+	assets   map[uint32]*asset.Asset
+	tunnels  map[string]MarketTunnel
+	mbBuffer float64
+}
+
+// OrderRouterConfig is the configuration settings for an OrderRouter.
+type OrderRouterConfig struct {
+	AuthManager     AuthManager
+	Assets          map[uint32]*asset.Asset
+	Markets         map[string]MarketTunnel
+	MarketBuyBuffer float64
+}
+
+// NewOrderRouter is a constructor for an OrderRouter.
+func NewOrderRouter(cfg *OrderRouterConfig) *OrderRouter {
+	router := &OrderRouter{
+		auth:     cfg.AuthManager,
+		assets:   cfg.Assets,
+		tunnels:  cfg.Markets,
+		mbBuffer: cfg.MarketBuyBuffer,
+	}
+	cfg.AuthManager.Route(msgjson.LimitRoute, router.handleLimit)
+	cfg.AuthManager.Route(msgjson.MarketRoute, router.handleMarket)
+	cfg.AuthManager.Route(msgjson.CancelRoute, router.handleCancel)
+	return router
+}
+
+// handleLimit is the handler for the 'limit' route. This route accepts a
+// msgjson.Limit payload, validates the information, constructs an
+// order.LimitOrder and submits it to the epoch queue.
+func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
+	limit := new(msgjson.Limit)
+	err := json.Unmarshal(msg.Payload, limit)
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'limit' payload")
+	}
+
+	rpcErr := r.verifyAccount(user, limit.AccountID, limit)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	tunnel, coins, sell, rpcErr := r.extractMarketDetails(&limit.Prefix, &limit.Trade)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	// Check that OrderType is set correctly
+	if limit.OrderType != msgjson.LimitOrderNum {
+		return msgjson.NewError(msgjson.OrderParameterError, "wrong order type set for limit order")
+	}
+
+	valSum, spendSize, utxos, rpcErr := r.checkPrefixTrade(user, tunnel, coins, &limit.Prefix, &limit.Trade, true)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	// Check that the rate is non-zero and obeys the rate step interval.
+	if limit.Rate == 0 {
+		return msgjson.NewError(msgjson.OrderParameterError, "rate = 0 not allowed")
+	}
+	if limit.Rate%coins.quote.RateStep != 0 {
+		return msgjson.NewError(msgjson.OrderParameterError, "rate not a multiple of ratestep")
+	}
+
+	// Calculate the fees and check that the utxo sum is enough.
+	swapVal := limit.Quantity
+	if !sell {
+		swapVal = matcher.BaseToQuote(limit.Rate, limit.Quantity)
+	}
+	reqVal := requiredFunds(swapVal, spendSize, coins.funding)
+	if valSum < reqVal {
+		return msgjson.NewError(msgjson.FundingError,
+			fmt.Sprintf("not enough funds. need at least %d, got %d", reqVal, valSum))
+	}
+
+	// Check time-in-force
+	if !(limit.TiF == msgjson.StandingOrderNum || limit.TiF == msgjson.ImmediateOrderNum) {
+		return msgjson.NewError(msgjson.OrderParameterError, "unknown time-in-force")
+	}
+
+	// Create the limit order
+	serverTime := time.Now()
+	lo := &order.LimitOrder{
+		MarketOrder: order.MarketOrder{
+			Prefix: order.Prefix{
+				AccountID:  user,
+				BaseAsset:  limit.Base,
+				QuoteAsset: limit.Quote,
+				OrderType:  order.LimitOrderType,
+				ClientTime: time.Unix(int64(limit.ClientTime), 0),
+				ServerTime: serverTime,
+			},
+			UTXOs:    utxos,
+			Sell:     sell,
+			Quantity: limit.Quantity,
+			Address:  limit.Address,
+		},
+		Rate:  limit.Rate,
+		Force: order.StandingTiF,
+	}
+
+	// Send the order to the epoch queue.
+	tunnel.AddEpoch(lo)
+
+	// Add the server timestamp and get a signature of the serialized
+	// msgjson.Limit to send to the client.
+	stamp := uint64(serverTime.Unix())
+	limit.ServerTime = stamp
+	r.auth.Sign(limit)
+	oid := lo.ID()
+	res := &msgjson.OrderResult{
+		Sig:        limit.Sig,
+		ServerTime: stamp,
+		OrderID:    oid[:],
+	}
+	respMsg, err := msgjson.NewResponse(msg.ID, res, nil)
+	if err != nil {
+		log.Errorf("failed to create msgjson.Message for 'limit' response: %v", err)
+		return msgjson.NewError(msgjson.RPCInternalError, "error forming response")
+	}
+	r.auth.Send(user, respMsg)
+	return nil
+}
+
+// handleMarket is the handler for the 'market' route. This route accepts a
+// msgjson.Market payload, validates the information, constructs an
+// order.MarketOrder and submits it to the epoch queue.
+func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
+	market := new(msgjson.Market)
+	err := json.Unmarshal(msg.Payload, market)
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'market' payload")
+	}
+
+	rpcErr := r.verifyAccount(user, market.AccountID, market)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	tunnel, coins, sell, rpcErr := r.extractMarketDetails(&market.Prefix, &market.Trade)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	// Check that OrderType is set correctly
+	if market.OrderType != msgjson.MarketOrderNum {
+		return msgjson.NewError(msgjson.OrderParameterError, "wrong order type set for market order")
+	}
+
+	// Passing sell as the checkLot parameter causes the lot size check to be
+	// ignored for market buy orders.
+	valSum, spendSize, utxos, rpcErr := r.checkPrefixTrade(user, tunnel, coins, &market.Prefix, &market.Trade, sell)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	// Calculate the fees and check that the utxo sum is enough.
+	var reqVal uint64
+	if sell {
+		reqVal = requiredFunds(market.Quantity, spendSize, coins.funding)
+	} else {
+		// This is a market buy order, so the quantity gets special handling.
+		// 1. The quantity is in units of the quote asset.
+		// 2. The quantity has to satisfy the market buy buffer.
+		reqVal = matcher.QuoteToBase(tunnel.MidGap(), market.Quantity)
+		lotWithBuffer := uint64(float64(coins.base.LotSize) * r.mbBuffer)
+		minReq := matcher.QuoteToBase(tunnel.MidGap(), lotWithBuffer)
+		if reqVal < minReq {
+			return msgjson.NewError(msgjson.FundingError, "order quantity does not satisfy market buy buffer")
+		}
+	}
+	if valSum < reqVal {
+		return msgjson.NewError(msgjson.FundingError,
+			fmt.Sprintf("not enough funds. need at least %d, got %d", reqVal, valSum))
+	}
+	// Create the market order
+	serverTime := time.Now()
+	mo := &order.MarketOrder{
+		Prefix: order.Prefix{
+			AccountID:  user,
+			BaseAsset:  market.Base,
+			QuoteAsset: market.Quote,
+			OrderType:  order.MarketOrderType,
+			ClientTime: time.Unix(int64(market.ClientTime), 0),
+			ServerTime: serverTime,
+		},
+		UTXOs:    utxos,
+		Sell:     sell,
+		Quantity: market.Quantity,
+		Address:  market.Address,
+	}
+
+	// Send the order to the epoch queue.
+	tunnel.AddEpoch(mo)
+
+	// Add the server timestamp and get a signature of the serialized
+	// msgjson.Market to send to the client.
+	stamp := uint64(serverTime.Unix())
+	market.ServerTime = stamp
+	r.auth.Sign(market)
+	oid := mo.ID()
+	res := &msgjson.OrderResult{
+		Sig:        market.Sig,
+		ServerTime: stamp,
+		OrderID:    oid[:],
+	}
+	respMsg, err := msgjson.NewResponse(msg.ID, res, nil)
+	if err != nil {
+		log.Errorf("failed to create msgjson.Message for 'market' response: %v", err)
+		return msgjson.NewError(msgjson.RPCInternalError, "error forming response")
+	}
+	r.auth.Send(user, respMsg)
+	return nil
+}
+
+// handleCancel is the handler for the 'cancel' route. This route accepts a
+// msgjson.Cancel payload, validates the information, constructs an
+// order.CancelOrder and submits it to the epoch queue.
+func (r *OrderRouter) handleCancel(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
+	cancel := new(msgjson.Cancel)
+	err := json.Unmarshal(msg.Payload, cancel)
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'cancel' payload")
+	}
+
+	rpcErr := r.verifyAccount(user, cancel.AccountID, cancel)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	tunnel, rpcErr := r.extractMarket(&cancel.Prefix)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	if len(cancel.TargetID) != order.OrderIDSize {
+		return msgjson.NewError(msgjson.OrderParameterError, "invalid target ID format")
+	}
+	var targetID order.OrderID
+	copy(targetID[:], cancel.TargetID)
+
+	if !tunnel.Cancelable(targetID) {
+		return msgjson.NewError(msgjson.OrderParameterError, "target order not known")
+	}
+
+	// Check that OrderType is set correctly
+	if cancel.OrderType != msgjson.CancelOrderNum {
+		return msgjson.NewError(msgjson.OrderParameterError, "wrong order type set for cancel order")
+	}
+
+	rpcErr = checkTimes(&cancel.Prefix)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	// Create the cancel order
+	serverTime := time.Now()
+	co := &order.CancelOrder{
+		Prefix: order.Prefix{
+			AccountID:  user,
+			BaseAsset:  cancel.Base,
+			QuoteAsset: cancel.Quote,
+			OrderType:  order.MarketOrderType,
+			ClientTime: time.Unix(int64(cancel.ClientTime), 0),
+			ServerTime: serverTime,
+		},
+		TargetOrderID: targetID,
+	}
+
+	// Send the order to the epoch queue.
+	tunnel.AddEpoch(co)
+
+	// Add the server timestamp and get a signature of the serialized
+	// msgjson.Cancel to send to the client.
+	stamp := uint64(serverTime.Unix())
+	cancel.ServerTime = stamp
+	r.auth.Sign(cancel)
+	oid := co.ID()
+	res := &msgjson.OrderResult{
+		Sig:        cancel.Sig,
+		ServerTime: stamp,
+		OrderID:    oid[:],
+	}
+	respMsg, err := msgjson.NewResponse(msg.ID, res, nil)
+	if err != nil {
+		log.Errorf("failed to create msgjson.Message for 'cancel' response: %v", err)
+		return msgjson.NewError(msgjson.RPCInternalError, "error forming response")
+	}
+	r.auth.Send(user, respMsg)
+	return nil
+}
+
+// verifyAccount checks that the submitted order squares with the submitting user.
+func (r *OrderRouter) verifyAccount(user account.AccountID, msgAcct msgjson.Bytes, signable msgjson.Signable) *msgjson.Error {
+	// Verify account ID matches.
+	if !bytes.Equal(user[:], msgAcct) {
+		return msgjson.NewError(msgjson.OrderParameterError, "account ID mismatch")
+	}
+	// Check the clients signature of the order.
+	// DRAFT NOTE: These Serialize methods actually never return errors. We should
+	// just drop the error return value.
+	sigMsg, _ := signable.Serialize()
+	err := r.auth.Auth(user, sigMsg, signable.SigBytes())
+	if err != nil {
+		return msgjson.NewError(msgjson.SignatureError, "signature error: "+err.Error())
+	}
+	return nil
+}
+
+// extractMarket finds the MarketTunnel for the provided prefix.
+func (r *OrderRouter) extractMarket(prefix *msgjson.Prefix) (MarketTunnel, *msgjson.Error) {
+	mktName, err := dex.MarketName(prefix.Base, prefix.Quote)
+	if err != nil {
+		return nil, msgjson.NewError(msgjson.UnknownMarketError, "asset lookup error: "+err.Error())
+	}
+	tunnel, found := r.tunnels[mktName]
+	if !found {
+		return nil, msgjson.NewError(msgjson.UnknownMarketError, "unknown market "+mktName)
+	}
+	return tunnel, nil
+}
+
+// extractMarketDetails finds the MarketTunnel, side, and an assetSet for the
+// provided prefix.
+func (r *OrderRouter) extractMarketDetails(prefix *msgjson.Prefix, trade *msgjson.Trade) (MarketTunnel, *assetSet, bool, *msgjson.Error) {
+	// Check that assets are for a valid market.
+	tunnel, rpcErr := r.extractMarket(prefix)
+	if rpcErr != nil {
+		return nil, nil, false, rpcErr
+	}
+	// Side must be one of buy or sell
+	var sell bool
+	switch trade.Side {
+	case msgjson.BuyOrderNum:
+	case msgjson.SellOrderNum:
+		sell = true
+	default:
+		return nil, nil, false, msgjson.NewError(msgjson.OrderParameterError,
+			fmt.Sprintf("invalid side value %d", trade.Side))
+	}
+	quote, found := r.assets[prefix.Quote]
+	if !found {
+		panic("missing quote asset for known market should be impossible")
+	}
+	base, found := r.assets[prefix.Base]
+	if !found {
+		panic("missing base asset for known market should be impossible")
+	}
+	coins := &assetSet{
+		quote:     quote,
+		base:      base,
+		funding:   quote,
+		receiving: base,
+	}
+	if sell {
+		coins.funding, coins.receiving = base, quote
+	}
+	return tunnel, coins, sell, nil
+}
+
+// checkTimes validates the timestamps in an order prefix.
+func checkTimes(prefix *msgjson.Prefix) *msgjson.Error {
+	offset := time.Now().Unix() - int64(prefix.ClientTime)
+	if offset < 0 {
+		offset *= -1
+	}
+	if offset >= maxClockOffset {
+		return msgjson.NewError(msgjson.ClockRangeError, fmt.Sprintf(
+			"clock offset of %d seconds is larger than maximum allowed, %d seconds",
+			offset, maxClockOffset,
+		))
+	}
+	// Server time should be unset.
+	if prefix.ServerTime != 0 {
+		return msgjson.NewError(msgjson.OrderParameterError, "non-zero server time not allowed")
+	}
+	return nil
+}
+
+// checkPrefixTrade validates the information in the prefix and trade portions
+// of an order.
+func (r *OrderRouter) checkPrefixTrade(user account.AccountID, tunnel MarketTunnel, coins *assetSet, prefix *msgjson.Prefix,
+	trade *msgjson.Trade, checkLot bool) (uint64, uint32, []order.Outpoint, *msgjson.Error) {
+	// Check that the client's timestamp is still valid.
+	rpcErr := checkTimes(prefix)
+	if rpcErr != nil {
+		return 0, 0, nil, rpcErr
+	}
+
+	errSet := func(code int, message string) (uint64, uint32, []order.Outpoint, *msgjson.Error) {
+		return 0, 0, nil, msgjson.NewError(code, message)
+	}
+	// Quantity cannot be zero, and must be an integral multiple of the lot size.
+	if trade.Quantity == 0 {
+		return errSet(msgjson.OrderParameterError, "zero quantity not allowed")
+	}
+	if checkLot && trade.Quantity%coins.base.LotSize != 0 {
+		return errSet(msgjson.OrderParameterError, "order quantity not a multiple of lot size")
+	}
+	// Validate UTXOs
+	// Check that all required arrays are of equal length.
+	if len(trade.UTXOs) == 0 {
+		return errSet(msgjson.FundingError, "order must specify utxos")
+	}
+	var valSum uint64
+	var spendSize uint32
+	var utxos []order.Outpoint
+	for i, utxo := range trade.UTXOs {
+		sigCount := len(utxo.Sigs)
+		if sigCount == 0 {
+			return errSet(msgjson.SignatureError, fmt.Sprintf("no signature for utxo %d", i))
+		}
+		if len(utxo.PubKeys) != sigCount {
+			return errSet(msgjson.OrderParameterError, fmt.Sprintf(
+				"pubkey count %d not equal to signature count %d for utxo %d",
+				len(utxo.PubKeys), sigCount, i,
+			))
+		}
+		txid := utxo.TxID.String()
+		// Check that the outpoint isn't locked.
+		locked := tunnel.OutpointLocked(txid, utxo.Vout)
+		if locked {
+			return errSet(msgjson.FundingError,
+				fmt.Sprintf("utxo %s:%d is locked", utxo.TxID.String(), utxo.Vout))
+		}
+		// Get the utxo from the backend and validate it.
+		dexUTXO, err := coins.funding.Backend.UTXO(txid, utxo.Vout, utxo.Redeem)
+		if err != nil {
+			return errSet(msgjson.FundingError,
+				fmt.Sprintf("error retreiving utxo %s:%d", utxo.TxID.String(), utxo.Vout))
+		}
+		// Make sure the UTXO has the requisite number of confirmations.
+		confs, err := dexUTXO.Confirmations()
+		if err != nil {
+			return errSet(msgjson.FundingError,
+				fmt.Sprintf("utxo confirmations error for %s:%d: %v", utxo.TxID.String(), utxo.Vout, err))
+		}
+		if confs < int64(coins.funding.FundConf) && !tunnel.TxMonitored(user, txid) {
+			return errSet(msgjson.FundingError,
+				fmt.Sprintf("not enough confirmations for %s:%d. require %d, have %d",
+					utxo.TxID.String(), utxo.Vout, coins.funding.FundConf, confs))
+		}
+		sigMsg := utxo.Serialize()
+		err = dexUTXO.Auth(msgBytesToBytes(utxo.PubKeys), msgBytesToBytes(utxo.Sigs), sigMsg)
+		if err != nil {
+			return errSet(msgjson.UTXOAuthError,
+				fmt.Sprintf("failed to authorize utxo %s:%d", utxo.TxID.String(), utxo.Vout))
+		}
+		// Check that the address is valid.
+		if !coins.receiving.Backend.CheckAddress(trade.Address) {
+			return errSet(msgjson.OrderParameterError, "address doesn't check")
+		}
+		utxos = append(utxos, newOutpoint(utxo.TxID, utxo.Vout))
+		valSum += dexUTXO.Value()
+		spendSize += dexUTXO.SpendSize()
+	}
+	return valSum, spendSize, utxos, nil
+}
+
+// requiredFunds calculates the minimum amount needed to fulfill the swap amount
+// and pay transaction fees. The spendSize is the sum of the serialized inputs
+// associated with a set of UTXOs to be spent. The swapVal is the total quantity
+// needed to fulfill an order.
+func requiredFunds(swapVal uint64, spendSize uint32, coin *asset.Asset) uint64 {
+	R := float64(coin.SwapSize) * float64(coin.FeeRate) / float64(coin.LotSize)
+	fBase := uint64(float64(swapVal) * R)
+	fUtxo := uint64(spendSize) * coin.FeeRate
+	return swapVal + fBase + fUtxo
+}
+
+// msgBytesToBytes converts a []msgjson.Byte to a [][]byte.
+func msgBytesToBytes(msgBs []msgjson.Bytes) [][]byte {
+	b := make([][]byte, 0, len(msgBs))
+	for _, msgB := range msgBs {
+		b = append(b, msgB)
+	}
+	return b
+}

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -1,0 +1,754 @@
+package market
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
+	"github.com/decred/dcrdex/server/account"
+	"github.com/decred/dcrdex/server/asset"
+	"github.com/decred/dcrdex/server/comms/msgjson"
+	// dex "github.com/decred/dcrdex/server/market/types"
+	"github.com/decred/dcrdex/server/matcher"
+	"github.com/decred/dcrdex/server/order"
+	ordertest "github.com/decred/dcrdex/server/order/test"
+)
+
+const (
+	dummySize   = 50
+	btcLotSize  = 100_000
+	btcRateStep = 1_000
+	dcrLotSize  = 10_000_000
+	dcrRateStep = 100_000
+	btcID       = 0
+	dcrID       = 42
+	btcAddr     = "18Zpft83eov56iESWuPpV8XFLJ1b8gMZy7"
+	dcrAddr     = "DsYXjAK3UiTVN9js8v9G21iRbr2wPty7f12"
+)
+
+var (
+	oRig       *tOrderRig
+	dummyError = fmt.Errorf("test error")
+	clientTime = time.Now()
+)
+
+// The AuthManager handles client-related actions, including authorization and
+// communications.
+type TAuth struct {
+	authErr error
+	sends   []*msgjson.Message
+}
+
+func (a *TAuth) Route(route string, handler func(account.AccountID, *msgjson.Message) *msgjson.Error) {
+}
+func (a *TAuth) Auth(user account.AccountID, msg, sig []byte) error {
+	return a.authErr
+}
+func (a *TAuth) Sign(...msgjson.Signable) {}
+func (a *TAuth) Send(_ account.AccountID, msg *msgjson.Message) {
+	a.sends = append(a.sends, msg)
+}
+func (a *TAuth) getSend() *msgjson.Message {
+	if len(a.sends) == 0 {
+		return nil
+	}
+	msg := a.sends[0]
+	a.sends = a.sends[1:]
+	return msg
+}
+
+type TMarketTunnel struct {
+	addErr     error
+	adds       []order.Order
+	midGap     uint64
+	locked     bool
+	watched    bool
+	cancelable bool
+}
+
+func (m *TMarketTunnel) AddEpoch(o order.Order) error {
+	m.adds = append(m.adds, o)
+	return m.addErr
+}
+
+func (m *TMarketTunnel) MidGap() uint64 {
+	return m.midGap
+}
+
+func (m *TMarketTunnel) OutpointLocked(txid string, vout uint32) bool {
+	return m.locked
+}
+
+func (m *TMarketTunnel) TxMonitored(user account.AccountID, txid string) bool {
+	return m.watched
+}
+
+func (m *TMarketTunnel) pop() order.Order {
+	if len(m.adds) == 0 {
+		return nil
+	}
+	o := m.adds[0]
+	m.adds = m.adds[1:]
+	return o
+}
+
+func (m *TMarketTunnel) Cancelable(order.OrderID) bool {
+	return m.cancelable
+}
+
+type TBackend struct {
+	utxoErr    error
+	utxos      map[string]uint64
+	addrChecks bool
+}
+
+func tNewBackend() *TBackend {
+	return &TBackend{
+		utxos:      make(map[string]uint64),
+		addrChecks: true,
+	}
+}
+
+func (b *TBackend) UTXO(txid string, vout uint32, redeemScript []byte) (asset.UTXO, error) {
+	op := fmt.Sprintf("%s:%d", txid, vout)
+	v := b.utxos[op]
+	if v == 0 {
+		return nil, fmt.Errorf("no utxo")
+	}
+	return &tUTXO{val: v}, b.utxoErr
+}
+func (b *TBackend) BlockChannel(size int) chan uint32            { return nil }
+func (b *TBackend) Transaction(txid string) (asset.DEXTx, error) { return nil, nil }
+func (b *TBackend) InitTxSize() uint32                           { return dummySize }
+func (b *TBackend) CheckAddress(string) bool                     { return b.addrChecks }
+func (b *TBackend) addUTXO(utxo *msgjson.UTXO, val uint64) {
+	op := fmt.Sprintf("%s:%d", utxo.TxID, utxo.Vout)
+	b.utxos[op] = val
+}
+
+type tUTXO struct {
+	val uint64
+}
+
+var utxoAuthErr error
+var utxoConfsErr error
+var utxoConfs int64 = 2
+
+func (u *tUTXO) Confirmations() (int64, error) { return utxoConfs, utxoConfsErr }
+func (u *tUTXO) Auth(pubkeys,
+	sigs [][]byte, msg []byte) error {
+	return utxoAuthErr
+}
+func (u *tUTXO) SpendSize() uint32 { return dummySize }
+func (u *tUTXO) TxHash() []byte    { return nil }
+func (u *tUTXO) TxID() string      { return "" }
+func (u *tUTXO) Vout() uint32      { return 0 }
+func (u *tUTXO) Value() uint64     { return u.val }
+
+type tUser struct {
+	acct    account.AccountID
+	privKey *secp256k1.PrivateKey
+}
+
+type tOrderRig struct {
+	btc    *TBackend
+	dcr    *TBackend
+	user   *tUser
+	auth   *TAuth
+	market *TMarketTunnel
+	router *OrderRouter
+}
+
+func (rig *tOrderRig) signedUTXO(id int, val uint64, numSigs int) *msgjson.UTXO {
+	u := rig.user
+	utxo := &msgjson.UTXO{
+		TxID: randomBytes(32),
+		Vout: rand.Uint32(),
+	}
+	pk := u.privKey.PubKey().SerializeCompressed()
+	for i := 0; i < numSigs; i++ {
+		sig, _ := u.privKey.Sign(utxo.Serialize())
+		utxo.Sigs = append(utxo.Sigs, sig.Serialize())
+		utxo.PubKeys = append(utxo.PubKeys, pk)
+	}
+	switch id {
+	case btcID:
+		rig.btc.addUTXO(utxo, val)
+	case dcrID:
+		rig.dcr.addUTXO(utxo, val)
+	}
+	return utxo
+}
+
+var assetBTC = &asset.Asset{
+	ID:       0,
+	Symbol:   "btc",
+	LotSize:  btcLotSize,
+	RateStep: btcRateStep,
+	FeeRate:  4,
+	SwapSize: dummySize,
+	SwapConf: 2,
+	FundConf: 2,
+}
+
+var assetDCR = &asset.Asset{
+	ID:       42,
+	Symbol:   "dcr",
+	LotSize:  dcrLotSize,
+	RateStep: dcrRateStep,
+	FeeRate:  10,
+	SwapSize: dummySize,
+	SwapConf: 2,
+	FundConf: 2,
+}
+
+var assetUnknown = &asset.Asset{
+	ID:       54321,
+	Symbol:   "buk",
+	LotSize:  1000,
+	RateStep: 100,
+	FeeRate:  10,
+	SwapSize: 1,
+	SwapConf: 0,
+	FundConf: 0,
+}
+
+func randomBytes(len int) []byte {
+	bytes := make([]byte, len)
+	rand.Read(bytes)
+	return bytes
+}
+
+func makeEnsureErr(t *testing.T) func(tag string, rpcErr *msgjson.Error, code int) {
+	return func(tag string, rpcErr *msgjson.Error, code int) {
+		if rpcErr == nil {
+			if code == -1 {
+				return
+			}
+			t.Fatalf("%s: no rpc error", tag)
+		}
+		if rpcErr.Code != code {
+			t.Fatalf("%s: wrong error code. expected %d, got %d", tag, code, rpcErr.Code)
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	privKey, _ := secp256k1.GeneratePrivateKey()
+	oRig = &tOrderRig{
+		btc: tNewBackend(),
+		dcr: tNewBackend(),
+		user: &tUser{
+			acct:    ordertest.NextAccount(),
+			privKey: privKey,
+		},
+		auth: &TAuth{sends: make([]*msgjson.Message, 0)},
+		market: &TMarketTunnel{
+			adds:       make([]order.Order, 0),
+			midGap:     dcrRateStep * 1000,
+			cancelable: true,
+		},
+	}
+	assetDCR.Backend = oRig.dcr
+	assetBTC.Backend = oRig.btc
+	oRig.router = NewOrderRouter(&OrderRouterConfig{
+		AuthManager: oRig.auth,
+		Assets: map[uint32]*asset.Asset{
+			0:  assetBTC,
+			42: assetDCR,
+		},
+		Markets:         map[string]MarketTunnel{"dcr_btc": oRig.market},
+		MarketBuyBuffer: 1.5,
+	})
+	os.Exit(m.Run())
+}
+
+func TestLimit(t *testing.T) {
+	qty := uint64(dcrLotSize) * 10
+	rate := uint64(1000) * dcrRateStep
+	user := oRig.user
+	limit := msgjson.Limit{
+		Prefix: msgjson.Prefix{
+			AccountID:  user.acct[:],
+			Base:       dcrID,
+			Quote:      btcID,
+			OrderType:  msgjson.LimitOrderNum,
+			ClientTime: uint64(clientTime.Unix()),
+		},
+		Trade: msgjson.Trade{
+			Side:     msgjson.SellOrderNum,
+			Quantity: qty,
+			UTXOs: []*msgjson.UTXO{
+				oRig.signedUTXO(dcrID, qty-dcrLotSize, 1),
+				oRig.signedUTXO(dcrID, 2*dcrLotSize, 2),
+			},
+			Address: btcAddr,
+		},
+		Rate: rate,
+		TiF:  msgjson.StandingOrderNum,
+	}
+	reqID := uint64(5)
+
+	ensureErr := makeEnsureErr(t)
+
+	sendLimit := func() *msgjson.Error {
+		msg, _ := msgjson.NewRequest(reqID, msgjson.LimitRoute, limit)
+		return oRig.router.handleLimit(user.acct, msg)
+	}
+
+	// First just send it through and ensure there are no errors.
+	ensureErr("valid order", sendLimit(), -1)
+	// Make sure the order was submitted to the market
+	o := oRig.market.pop()
+	if o == nil {
+		t.Fatalf("no order submitted to epoch")
+	}
+
+	// Test an invalid payload.
+	msg := new(msgjson.Message)
+	msg.Payload = []byte(`?`)
+	rpcErr := oRig.router.handleLimit(user.acct, msg)
+	ensureErr("bad payload", rpcErr, msgjson.RPCParseError)
+
+	// Wrong order type marked for limit order
+	limit.OrderType = msgjson.MarketOrderNum
+	ensureErr("wrong order type", sendLimit(), msgjson.OrderParameterError)
+	limit.OrderType = msgjson.LimitOrderNum
+
+	testPrefixTrade(&limit.Prefix, &limit.Trade, oRig.dcr, oRig.btc,
+		func(tag string, code int) { ensureErr(tag, sendLimit(), code) },
+	)
+
+	// Rate = 0
+	limit.Rate = 0
+	ensureErr("zero rate", sendLimit(), msgjson.OrderParameterError)
+	limit.Rate = rate
+
+	// non-step-multiple rate
+	limit.Rate = rate + (btcRateStep / 2)
+	ensureErr("non-step-multiple", sendLimit(), msgjson.OrderParameterError)
+	limit.Rate = rate
+
+	// Time-in-force incorrectly marked
+	limit.TiF = 0
+	ensureErr("bad tif", sendLimit(), msgjson.OrderParameterError)
+	limit.TiF = msgjson.StandingOrderNum
+
+	// Now switch it to a buy order, and ensure it passes
+	// Clear the sends cache first.
+	oRig.auth.sends = nil
+	limit.Side = msgjson.BuyOrderNum
+	buyUTXO := oRig.signedUTXO(btcID, matcher.BaseToQuote(rate, qty*2), 1)
+	limit.UTXOs = []*msgjson.UTXO{
+		buyUTXO,
+	}
+	limit.Address = dcrAddr
+	rpcErr = sendLimit()
+	if rpcErr != nil {
+		t.Fatalf("error for buy order: %s", rpcErr.Message)
+	}
+
+	// Create the order manually, so that we can compare the IDs as another check
+	// of equivalence.
+	lo := &order.LimitOrder{
+		MarketOrder: order.MarketOrder{
+			Prefix: order.Prefix{
+				AccountID:  user.acct,
+				BaseAsset:  limit.Base,
+				QuoteAsset: limit.Quote,
+				OrderType:  order.LimitOrderType,
+				ClientTime: clientTime,
+				// ServerTime: sTime,
+			},
+			// UTXOs:    []order.Outpoint{},
+			Sell:     false,
+			Quantity: qty,
+			Address:  dcrAddr,
+		},
+		Rate:  rate,
+		Force: order.StandingTiF,
+	}
+	// Get the last order submitted to the epoch
+	o = oRig.market.pop()
+	if o == nil {
+		t.Fatalf("no buy order submitted to epoch")
+	}
+
+	// Check the utxo
+	epochOrder := o.(*order.LimitOrder)
+	if len(epochOrder.UTXOs) != 1 {
+		t.Fatalf("expected 1 order UTXO, got %d", len(epochOrder.UTXOs))
+	}
+	epochUTXO := epochOrder.UTXOs[0]
+	if !bytes.Equal(epochUTXO.TxHash(), buyUTXO.TxID) {
+		t.Fatalf("utxo reporting wrong txid")
+	}
+	if epochUTXO.Vout() != buyUTXO.Vout {
+		t.Fatalf("utxo reporting wrong vout")
+	}
+
+	// Now steal the UTXO
+	lo.UTXOs = epochOrder.UTXOs
+
+	// Get the server time from the response.
+	respMsg := oRig.auth.getSend()
+	if respMsg == nil {
+		t.Fatalf("no response from limit order")
+	}
+	resp, _ := respMsg.Response()
+	result := new(msgjson.OrderResult)
+	json.Unmarshal(resp.Result, result)
+	lo.ServerTime = time.Unix(int64(result.ServerTime), 0)
+
+	// Check equivalence of IDs.
+	if epochOrder.ID() != lo.ID() {
+		t.Fatalf("failed to duplicate ID")
+	}
+}
+
+func TestMarket(t *testing.T) {
+	qty := uint64(dcrLotSize) * 10
+	user := oRig.user
+	mkt := msgjson.Market{
+		Prefix: msgjson.Prefix{
+			AccountID:  user.acct[:],
+			Base:       dcrID,
+			Quote:      btcID,
+			OrderType:  msgjson.MarketOrderNum,
+			ClientTime: uint64(clientTime.Unix()),
+		},
+		Trade: msgjson.Trade{
+			Side:     msgjson.SellOrderNum,
+			Quantity: qty,
+			UTXOs: []*msgjson.UTXO{
+				oRig.signedUTXO(dcrID, qty-dcrLotSize, 1),
+				oRig.signedUTXO(dcrID, 2*dcrLotSize, 2),
+			},
+			Address: btcAddr,
+		},
+	}
+	reqID := uint64(5)
+
+	ensureErr := makeEnsureErr(t)
+
+	sendMarket := func() *msgjson.Error {
+		msg, _ := msgjson.NewRequest(reqID, msgjson.MarketRoute, mkt)
+		return oRig.router.handleMarket(user.acct, msg)
+	}
+
+	// First just send it through and ensure there are no errors.
+	ensureErr("valid order", sendMarket(), -1)
+
+	// Make sure the order was submitted to the market
+	o := oRig.market.pop()
+	if o == nil {
+		t.Fatalf("no order submitted to epoch")
+	}
+
+	// Test an invalid payload.
+	msg := new(msgjson.Message)
+	msg.Payload = []byte(`?`)
+	rpcErr := oRig.router.handleMarket(user.acct, msg)
+	ensureErr("bad payload", rpcErr, msgjson.RPCParseError)
+
+	// Wrong order type marked for market order
+	mkt.OrderType = msgjson.LimitOrderNum
+	ensureErr("wrong order type", sendMarket(), msgjson.OrderParameterError)
+	mkt.OrderType = msgjson.MarketOrderNum
+
+	testPrefixTrade(&mkt.Prefix, &mkt.Trade, oRig.dcr, oRig.btc,
+		func(tag string, code int) { ensureErr(tag, sendMarket(), code) },
+	)
+
+	// Now switch it to a buy order, and ensure it passes
+	// Clear the sends cache first.
+	oRig.auth.sends = nil
+	mkt.Side = msgjson.BuyOrderNum
+
+	midGap := oRig.market.MidGap()
+	buyUTXO := oRig.signedUTXO(btcID, matcher.BaseToQuote(midGap, qty), 1)
+	mkt.UTXOs = []*msgjson.UTXO{
+		buyUTXO,
+	}
+	mkt.Address = dcrAddr
+	mkt.Quantity = matcher.BaseToQuote(midGap, uint64(dcrLotSize*1.2))
+	// First check an order that doesn't satisfy the market buy buffer. For
+	// testing, the market buy buffer is set to 1.5.
+	ensureErr("market buy buffer unsatisfied", sendMarket(), msgjson.FundingError)
+	mkt.Quantity = qty
+	rpcErr = sendMarket()
+	if rpcErr != nil {
+		t.Fatalf("error for buy order: %s", rpcErr.Message)
+	}
+
+	// Create the order manually, so that we can compare the IDs as another check
+	// of equivalence.
+	mo := &order.MarketOrder{
+		Prefix: order.Prefix{
+			AccountID:  user.acct,
+			BaseAsset:  mkt.Base,
+			QuoteAsset: mkt.Quote,
+			OrderType:  order.MarketOrderType,
+			ClientTime: clientTime,
+			// ServerTime: sTime,
+		},
+		// UTXOs:    []order.Outpoint{},
+		Sell:     false,
+		Quantity: qty,
+		Address:  dcrAddr,
+	}
+	// Get the last order submitted to the epoch
+	o = oRig.market.pop()
+	if o == nil {
+		t.Fatalf("no buy order submitted to epoch")
+	}
+
+	// Check the utxo
+	epochOrder := o.(*order.MarketOrder)
+	if len(epochOrder.UTXOs) != 1 {
+		t.Fatalf("expected 1 order UTXO, got %d", len(epochOrder.UTXOs))
+	}
+	epochUTXO := epochOrder.UTXOs[0]
+	if !bytes.Equal(epochUTXO.TxHash(), buyUTXO.TxID) {
+		t.Fatalf("utxo reporting wrong txid")
+	}
+	if epochUTXO.Vout() != buyUTXO.Vout {
+		t.Fatalf("utxo reporting wrong vout")
+	}
+
+	// Now steal the UTXO
+	mo.UTXOs = epochOrder.UTXOs
+
+	// Get the server time from the response.
+	respMsg := oRig.auth.getSend()
+	if respMsg == nil {
+		t.Fatalf("no response from market order")
+	}
+	resp, _ := respMsg.Response()
+	result := new(msgjson.OrderResult)
+	json.Unmarshal(resp.Result, result)
+	mo.ServerTime = time.Unix(int64(result.ServerTime), 0)
+
+	// Check equivalence of IDs.
+	if epochOrder.ID() != mo.ID() {
+		t.Fatalf("failed to duplicate ID")
+	}
+}
+
+func TestCancel(t *testing.T) {
+	user := oRig.user
+	var targetID order.OrderID
+	targetID[0] = 244
+	cancel := msgjson.Cancel{
+		Prefix: msgjson.Prefix{
+			AccountID:  user.acct[:],
+			Base:       dcrID,
+			Quote:      btcID,
+			OrderType:  msgjson.CancelOrderNum,
+			ClientTime: uint64(clientTime.Unix()),
+		},
+		TargetID: targetID[:],
+	}
+	reqID := uint64(5)
+
+	ensureErr := makeEnsureErr(t)
+
+	sendCancel := func() *msgjson.Error {
+		msg, _ := msgjson.NewRequest(reqID, msgjson.CancelRoute, cancel)
+		return oRig.router.handleCancel(user.acct, msg)
+	}
+
+	// First just send it through and ensure there are no errors.
+	ensureErr("valid order", sendCancel(), -1)
+	// Make sure the order was submitted to the market
+	o := oRig.market.pop()
+	if o == nil {
+		t.Fatalf("no order submitted to epoch")
+	}
+
+	// Test an invalid payload.
+	msg := new(msgjson.Message)
+	msg.Payload = []byte(`?`)
+	rpcErr := oRig.router.handleCancel(user.acct, msg)
+	ensureErr("bad payload", rpcErr, msgjson.RPCParseError)
+
+	// Unknown order.
+	oRig.market.cancelable = false
+	ensureErr("non cancelable", sendCancel(), msgjson.OrderParameterError)
+	oRig.market.cancelable = true
+
+	// Wrong order type marked for cancel order
+	cancel.OrderType = msgjson.LimitOrderNum
+	ensureErr("wrong order type", sendCancel(), msgjson.OrderParameterError)
+	cancel.OrderType = msgjson.CancelOrderNum
+
+	testPrefix(&cancel.Prefix, func(tag string, code int) {
+		ensureErr(tag, sendCancel(), code)
+	})
+
+	// Test a short order ID.
+	badID := []byte{0x01, 0x02}
+	cancel.TargetID = badID
+	ensureErr("bad target ID", sendCancel(), msgjson.OrderParameterError)
+	cancel.TargetID = targetID[:]
+
+	// Clear the sends cache.
+	oRig.auth.sends = nil
+
+	// Create the order manually, so that we can compare the IDs as another check
+	// of equivalence.
+	co := &order.CancelOrder{
+		Prefix: order.Prefix{
+			AccountID:  user.acct,
+			BaseAsset:  cancel.Base,
+			QuoteAsset: cancel.Quote,
+			OrderType:  order.MarketOrderType,
+			ClientTime: clientTime,
+		},
+		TargetOrderID: targetID,
+	}
+	// Send the order through again, so we can grab it from the epoch.
+	rpcErr = sendCancel()
+	if rpcErr != nil {
+		t.Fatalf("error for valid order (after prefix testing): %s", rpcErr.Message)
+	}
+	o = oRig.market.pop()
+	if o == nil {
+		t.Fatalf("no cancel order submitted to epoch")
+	}
+
+	// Check the utxo
+	epochOrder := o.(*order.CancelOrder)
+
+	// Get the server time from the response.
+	respMsg := oRig.auth.getSend()
+	if respMsg == nil {
+		t.Fatalf("no response from market order")
+	}
+	resp, _ := respMsg.Response()
+	result := new(msgjson.OrderResult)
+	json.Unmarshal(resp.Result, result)
+	co.ServerTime = time.Unix(int64(result.ServerTime), 0)
+
+	// Check equivalence of IDs.
+	if epochOrder.ID() != co.ID() {
+		t.Fatalf("failed to duplicate ID")
+	}
+}
+
+func testPrefix(prefix *msgjson.Prefix, checkCode func(string, int)) {
+	ogAcct := prefix.AccountID
+	oid := ordertest.NextAccount()
+	prefix.AccountID = oid[:]
+	checkCode("bad account", msgjson.OrderParameterError)
+	prefix.AccountID = ogAcct
+
+	// Signature error
+	oRig.auth.authErr = dummyError
+	checkCode("bad order sig", msgjson.SignatureError)
+	oRig.auth.authErr = nil
+
+	// Unknown asset
+	prefix.Base = assetUnknown.ID
+	checkCode("unknown asset", msgjson.UnknownMarketError)
+
+	// Unknown market. 1 is BIP0044 testnet designator, which a "known" asset,
+	// but with no markets.
+	prefix.Base = 1
+	checkCode("unknown market", msgjson.UnknownMarketError)
+	prefix.Base = assetDCR.ID
+
+	// Too old
+	prefix.ClientTime = uint64(clientTime.Add(-time.Second * maxClockOffset).Unix())
+	checkCode("too old", msgjson.ClockRangeError)
+	prefix.ClientTime = uint64(clientTime.Unix())
+
+	// Set server time = bad
+	prefix.ServerTime = 1
+	checkCode("server time set", msgjson.OrderParameterError)
+	prefix.ServerTime = 0
+}
+
+func testPrefixTrade(prefix *msgjson.Prefix, trade *msgjson.Trade, fundingAsset, receivingAsset *TBackend, checkCode func(string, int)) {
+	// Wrong account ID
+	testPrefix(prefix, checkCode)
+
+	// Invalid side number
+	trade.Side = 100
+	checkCode("bad side num", msgjson.OrderParameterError)
+	trade.Side = msgjson.SellOrderNum
+
+	// Zero quantity
+	qty := trade.Quantity
+	trade.Quantity = 0
+	checkCode("zero quantity", msgjson.OrderParameterError)
+
+	// non-lot-multiple
+	trade.Quantity = qty + (dcrLotSize / 2)
+	checkCode("non-lot-multiple", msgjson.OrderParameterError)
+	trade.Quantity = qty
+
+	// No utxos
+	ogUTXOs := trade.UTXOs
+	trade.UTXOs = nil
+	checkCode("no utxos", msgjson.FundingError)
+	trade.UTXOs = ogUTXOs
+
+	// No signatures
+	utxo1 := trade.UTXOs[1]
+	ogSigs := utxo1.Sigs
+	utxo1.Sigs = nil
+	checkCode("no utxo sigs", msgjson.SignatureError)
+
+	// Different number of signatures than pubkeys
+	utxo1.Sigs = ogSigs[:1]
+	checkCode("not enough sigs", msgjson.OrderParameterError)
+	utxo1.Sigs = ogSigs
+
+	// output is locked
+	oRig.market.locked = true
+	checkCode("output locked", msgjson.FundingError)
+	oRig.market.locked = false
+
+	// utxo err
+	fundingAsset.utxoErr = dummyError
+	checkCode("utxo err", msgjson.FundingError)
+	fundingAsset.utxoErr = nil
+
+	// UTXO Auth error
+	utxoAuthErr = dummyError
+	checkCode("utxo auth error", msgjson.UTXOAuthError)
+	utxoAuthErr = nil
+
+	// UTXO Confirmations error
+	utxoConfsErr = dummyError
+	checkCode("utxo confs error", msgjson.FundingError)
+	utxoConfsErr = nil
+
+	// Not enough confirmations
+	utxoConfs = 0
+	checkCode("utxo no confs", msgjson.FundingError)
+
+	// Check 0 confs, but DEX-monitored transaction.
+	oRig.market.watched = true
+	checkCode("dex-monitored unconfirmed", -1)
+	utxoConfs = 2
+	oRig.market.watched = false
+	// Clear the order from the epoch.
+	oRig.market.pop()
+
+	// Not enough funding
+	trade.UTXOs = ogUTXOs[:1]
+	checkCode("unfunded", msgjson.FundingError)
+	trade.UTXOs = ogUTXOs
+
+	// Invalid address
+	receivingAsset.addrChecks = false
+	checkCode("bad address", msgjson.OrderParameterError)
+	receivingAsset.addrChecks = true
+}

--- a/server/order/test/helpers.go
+++ b/server/order/test/helpers.go
@@ -1,0 +1,109 @@
+package test
+
+import (
+	"encoding/binary"
+	"time"
+
+	"github.com/decred/dcrdex/server/account"
+	"github.com/decred/dcrdex/server/order"
+)
+
+const (
+	baseClientTime = 1566497653
+	baseServerTime = 1566497656
+)
+
+var (
+	acctTemplate = account.AccountID{
+		0x22, 0x4c, 0xba, 0xaa, 0xfa, 0x80, 0xbf, 0x3b, 0xd1, 0xff, 0x73, 0x15,
+		0x90, 0xbc, 0xbd, 0xda, 0x5a, 0x76, 0xf9, 0x1e, 0x60, 0xa1, 0x56, 0x99,
+		0x46, 0x34, 0xe9, 0x1c, 0xaa, 0xaa, 0xaa, 0xaa,
+	}
+	acctCounter uint32
+)
+
+// NextAccount gets a unique account ID.
+func NextAccount() account.AccountID {
+	acctCounter++
+	intBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(intBytes, acctCounter)
+	acctID := account.AccountID{}
+	copy(acctID[:], acctTemplate[:])
+	copy(acctID[account.HashSize-4:], intBytes)
+	return acctID
+}
+
+// Writer represents a client that places orders on one side of a market.
+type Writer struct {
+	Addr   string
+	Acct   account.AccountID
+	Sell   bool
+	Market *Market
+}
+
+// Market is a exchange market.
+type Market struct {
+	Base    uint32
+	Quote   uint32
+	LotSize uint64
+}
+
+// WriteLimitOrder creates a limit order with the specified writer and order
+// values.
+func WriteLimitOrder(writer *Writer, rate, lots uint64, force order.TimeInForce, timeOffset int64) *order.LimitOrder {
+	return &order.LimitOrder{
+		MarketOrder: order.MarketOrder{
+			Prefix: order.Prefix{
+				AccountID:  writer.Acct,
+				BaseAsset:  writer.Market.Base,
+				QuoteAsset: writer.Market.Quote,
+				OrderType:  order.LimitOrderType,
+				ClientTime: time.Unix(baseClientTime+timeOffset, 0),
+				ServerTime: time.Unix(baseServerTime+timeOffset, 0),
+			},
+			UTXOs:    []order.Outpoint{},
+			Sell:     writer.Sell,
+			Quantity: lots * writer.Market.LotSize,
+			Address:  writer.Addr,
+		},
+		Rate:  rate,
+		Force: force,
+	}
+}
+
+// WriteMarketOrder creates a market order with the specified writer and
+// quantity.
+func WriteMarketOrder(writer *Writer, lots uint64, timeOffset int64) *order.MarketOrder {
+	if writer.Sell {
+		lots *= writer.Market.LotSize
+	}
+	return &order.MarketOrder{
+		Prefix: order.Prefix{
+			AccountID:  writer.Acct,
+			BaseAsset:  writer.Market.Base,
+			QuoteAsset: writer.Market.Quote,
+			OrderType:  order.MarketOrderType,
+			ClientTime: time.Unix(baseClientTime+timeOffset, 0).UTC(),
+			ServerTime: time.Unix(baseServerTime+timeOffset, 0).UTC(),
+		},
+		UTXOs:    []order.Outpoint{},
+		Sell:     writer.Sell,
+		Quantity: lots,
+		Address:  writer.Addr,
+	}
+}
+
+// WriteCancelOrder creates a cancel order with the specified order ID.
+func WriteCancelOrder(writer *Writer, targetOrderID order.OrderID, timeOffset int64) *order.CancelOrder {
+	return &order.CancelOrder{
+		Prefix: order.Prefix{
+			AccountID:  writer.Acct,
+			BaseAsset:  writer.Market.Base,
+			QuoteAsset: writer.Market.Quote,
+			OrderType:  order.CancelOrderType,
+			ClientTime: time.Unix(baseClientTime+timeOffset, 0).UTC(),
+			ServerTime: time.Unix(baseServerTime+timeOffset, 0).UTC(),
+		},
+		TargetOrderID: targetOrderID,
+	}
+}


### PR DESCRIPTION
The order router routes market, limit, and cancel orders to waiting markets, performing validation and type translation along the way.

To accommodate the needs of the order router, two new methods were added to common types from the asset package. asset.UTXO got a value getter, and asset.DEXAsset got a method to validate addresses.

Resolves #52