### PR TITLE
spec: millisecond order time stamps and epoch duration

### DIFF
--- a/spec/accounts.mediawiki
+++ b/spec/accounts.mediawiki
@@ -25,7 +25,7 @@ pre-published for further validation.
 |-
 | pubkey    || string || hex-encoded public account key
 |-
-| timestamp || int    || UNIX timestamp
+| timestamp || int    || UNIX timestamp (milliseconds)
 |-
 | sig       || string || hex-encoded signature of serialized registration. serialization described below
 |}
@@ -37,7 +37,7 @@ pre-published for further validation.
 |-
 | pubkey    || 33 || the user's public account key
 |-
-| timestamp || 8  || the client's UNIX timestamp
+| timestamp || 8  || the client's UNIX timestamp (milliseconds)
 |}
 
 '''DEX response'''
@@ -52,7 +52,7 @@ pre-published for further validation.
 |-
 | fee       || int    || fee (atoms)
 |-
-| timestamp || int    || UNIX timestamp
+| timestamp || int    || UNIX timestamp (milliseconds)
 |-
 | sig       || string || hex-encoded signature of the serialized response. serialization described below
 |}
@@ -66,7 +66,7 @@ pre-published for further validation.
 |-
 | client pubkey || 33 || the client's public account  key
 |-
-| timestamp  || 8  || the server's UNIX timestamp
+| timestamp  || 8  || the server's UNIX timestamp (milliseconds)
 |-
 | fee        || 8  || registration fee (atoms)
 |-
@@ -92,7 +92,7 @@ the registration process.
 |-
 | coinid    || string || hex-encoded coin ID
 |-
-| timestamp || int    || UNIX timestamp
+| timestamp || int    || UNIX timestamp (milliseconds)
 |-
 | sig       || string || hex-encoded signature of serialized fee notification. serialization described below
 |}

--- a/spec/admin.mediawiki
+++ b/spec/admin.mediawiki
@@ -14,7 +14,7 @@ possible.
 {|
 ! variable !! relevant section !! units || default
 |-
-| epoch&nbsp;duration || [[fundamentals.mediawiki/#Epochbased_Order_Matching|Epoch-based Order Matching]] || seconds || 60
+| epoch&nbsp;duration || [[fundamentals.mediawiki/#Epochbased_Order_Matching|Epoch-based Order Matching]] || milliseconds || 60000
 |-
 | market&nbsp;buy&nbsp;buffer || [[orders.mediawiki/#Market_Buy_Orders|Market Buy Orders]] || unitless ratio || 1.25
 |-

--- a/spec/comm.mediawiki
+++ b/spec/comm.mediawiki
@@ -19,6 +19,13 @@ virtually all popular programming languages.
 Websocket messages are secured by encryption on Transport Layer
 Security (TLS) [https://tools.ietf.org/html/rfc8446 &#91;5&#93;] connections.
 
+===Timestamps===
+
+In all client-server messages that include a timestamp or duration field, the
+units of time are milliseconds unless otherwise specified. Location-independent
+timestamps are encoded as milliseconds since the UNIX epoch (Jan 01 00:00:00
+1970 UTC).
+
 ===Message Protocol===
 
 DEX messaging is JSON-formatted [https://tools.ietf.org/html/rfc8259 &#91;6&#93;].
@@ -113,7 +120,7 @@ connection is established, the client will supply their account ID and signature
 |-
 | apiver    || int    || requested API version
 |-
-| timestamp || int    || UNIX timestamp
+| timestamp || int    || UNIX timestamp (milliseconds)
 |-
 | sig       || string || hex-encoded signature of serialized connection data. serialization described below
 |}
@@ -127,7 +134,7 @@ connection is established, the client will supply their account ID and signature
 |-
 | API version || 2 || requested API version
 |-
-| timestamp || 8  || the client's UNIX timestamp
+| timestamp || 8  || the client's UNIX timestamp (milliseconds)
 |}
 
 '''Connect response'''

--- a/spec/fundamentals.mediawiki
+++ b/spec/fundamentals.mediawiki
@@ -67,7 +67,7 @@ respond with its current configuration.
 {|
 ! field     !! type !! description
 |-
-| epochlen  || int   || the [[#Epochbased_Order_Matching|epoch duration]] (seconds)
+| epochlen  || int   || the [[#Epochbased_Order_Matching|epoch duration]] (milliseconds)
 |-
 | buybuffer || float || the [[orders.mediawiki/#Market_Buy_Orders|market buy buffer]]
 |-
@@ -156,17 +156,19 @@ spoofing, and other manipulative trading practices.
 
 ====Epoch Time====
 
-For a given epoch duration '''''d > 0''''' , and current UNIX epoch timestamp
-'''''t''''' (in seconds since Jan 01 00:00:00 1970 UTC), the current order
-matching epoch index, '''''i''''', and epoch range are computed as
+For a given epoch duration '''''d > 0''''' in milliseconds, and current UNIX
+epoch timestamp '''''t''''' (in milliseconds since Jan 01 00:00:00 1970 UTC),
+the current order matching epoch index, '''''i''''', and epoch range are
+computed as
 
 <!--i = t / d, i d \leq t_i < d (i + 1)-->
 [[File:images/epoch-index.png]]
 
 where '''''/''''' is integer division. For example, at the time of writing,
-'''''t = 1562008475''''' , which for '''''d = 60''''' corresponds to epoch
-number '''''i = 26033474''''' spanning '''''&#91;1562008440, 1562008500)'''''.
-This convention allows epoch times to be known without querying the server.
+'''''t = 1562008475123''''' , which for '''''d = 8000''''' (8 seconds)
+corresponds to epoch number '''''i = 195251059''''' spanning
+'''''&#91;1562008472000, 1562008480000)'''''. This convention allows epoch start
+and end times for any epoch duration to be known without querying the server.
 
 A clock synchronization protocol such as NTP will be used to ensure server and
 client clocks are synchronized within acceptable tolerances.

--- a/spec/orders.mediawiki
+++ b/spec/orders.mediawiki
@@ -332,9 +332,9 @@ All order serializations have common '''prefix''' fields.
 |-
 | ordertype  || 1  || int || the type of order. limit = 1, market=2, cancel=3
 |-
-| tclient    || 8  || int || the client's UNIX timestamp
+| tclient    || 8  || int || the client's UNIX timestamp (milliseconds)
 |-
-| tserver    || 8  || int || the server's UNIX timestamp. zero for client signature
+| tserver    || 8  || int || the server's UNIX timestamp (milliseconds). zero for client signature
 |-
 | epochidx   || 8  || int || the epoch index assigned by the server. zero for client signature
 |-
@@ -364,7 +364,7 @@ the timestamp.
 |-
 | orderid   || string || the order ID
 |-
-| tserver || int  || the server's UNIX timestamp
+| tserver || int  || the server's UNIX timestamp (milliseconds)
 |}
 
 The client should use the server's timestamp to create a serialized order and
@@ -434,7 +434,7 @@ crosses the spread (i.e. a taker rather than a maker). The
 |-
 | sig       || string || server hex-encoded signature of the serialized order, after adding the DEX timestamp
 |-
-| server time || int  || the server's UNIX timestamp
+| server time || int  || the server's UNIX timestamp (milliseconds)
 |}
 
 ===Market Order===
@@ -490,7 +490,7 @@ the epoch match cycle) is left unfilled.
 |-
 | sig       || string || server hex-encoded signature of the order by server, after adding the DEX timestamp
 |-
-| server time || int  || the server's UNIX timestamp
+| server time || int  || the server's UNIX timestamp (milliseconds)
 |}
 
 ====Market Buy Orders====
@@ -569,7 +569,7 @@ This is by design and discourages certain types of spoofing.
 |-
 | sig       || string || server hex-encoded signature of the serialize order data, after adding the DEX timestamp
 |-
-| server time || int  || the server's UNIX timestamp
+| server time || int  || the server's UNIX timestamp (milliseconds)
 |}
 
 ===Preimage Reveal===
@@ -645,7 +645,7 @@ transaction and inform the server with an <code>init</code> notification
 |-
 | rate      || int    || the matched price rate. [[#Rate_Encoding|message-rate encoding]]
 |-
-| timestamp || int    || server's UNIX timestamp
+| timestamp || int    || server's UNIX timestamp (milliseconds)
 |-
 | address   || string || the counterparty's receiving address
 |-
@@ -665,7 +665,7 @@ transaction and inform the server with an <code>init</code> notification
 |-
 | rate       || 8  || the matched price rate. [[#Rate_Encoding|message-rate encoding]]
 |-
-| timestamp  || 8  || server's UNIX timestamp
+| timestamp  || 8  || server's UNIX timestamp (milliseconds)
 |-
 | address    || varies || UTF-8 encoded receiving address for the match
 |}
@@ -688,7 +688,7 @@ relay to the matching party.
 |-
 | coinid    || string || hex-encoded coin ID
 |-
-| timestamp  || int    || client's UNIX timestamp
+| timestamp  || int    || client's UNIX timestamp (milliseconds)
 |-
 | contract   || string || hex-encoded swap redeem script
 |-
@@ -706,7 +706,7 @@ relay to the matching party.
 |-
 | coin ID    || asset-dependent  || the coin ID
 |-
-| timestamp  || 8  || the client's UNIX timestamp
+| timestamp  || 8  || the client's UNIX timestamp (milliseconds)
 |-
 | contract   || asset-dependent || swap redeem script
 |}
@@ -730,7 +730,7 @@ contract and issue their redemption.
 |-
 | matchid   || string || the match ID
 |-
-| timestamp || int  || server's UNIX timestamp
+| timestamp || int  || server's UNIX timestamp (milliseconds)
 |-
 | contract  || string || hex-encoded swap redeem script
 |-
@@ -746,7 +746,7 @@ contract and issue their redemption.
 |-
 | matchid    || 32  || the match ID
 |-
-| timestamp  || 8  || server's UNIX timestamp
+| timestamp  || 8  || server's UNIX timestamp (milliseconds)
 |-
 | contract   || asset-dependent || swap redeem script
 |}
@@ -767,7 +767,7 @@ When a client has redeemed their contract, they will notify the server.
 |-
 | coinid    || string || hex-encoded coin ID
 |-
-| timestamp  || int    || client's UNIX timestamp
+| timestamp  || int    || client's UNIX timestamp (milliseconds)
 |-
 | sig        || string || client signature of the serialized notification. serialization described below
 |}
@@ -782,7 +782,7 @@ When a client has redeemed their contract, they will notify the server.
 |-
 | coin ID    || asset-dependent  || the coin ID
 |-
-| timestamp  || 8  || the client's UNIX timestamp
+| timestamp  || 8  || the client's UNIX timestamp (milliseconds)
 |}
 
 The DEX responds with an acknowledgement.
@@ -801,7 +801,7 @@ The DEX informs the taker when the maker has redeemed.
 |-
 | coinid     || string || hex-encoded coin ID
 |-
-| timestamp  || int    || server's UNIX timestamp
+| timestamp  || int    || server's UNIX timestamp (milliseconds)
 |-
 | sig        || string || DEX's signature of the serialized notification. serialization described below
 |}
@@ -817,7 +817,7 @@ The DEX informs the taker when the maker has redeemed.
 |-
 | coin ID    || asset-dependent  || the coin ID
 |-
-| timestamp  || 8  || server's UNIX timestamp
+| timestamp  || 8  || server's UNIX timestamp (milliseconds)
 |}
 
 The client will respond with an acknowledgement.


### PR DESCRIPTION
This is the corresponding spec update for PR https://github.com/decred/dcrdex/pull/96