### PR TITLE
market: implement MarketTunnel.Cancelable

### DIFF
--- a/server/book/book.go
+++ b/server/book/book.go
@@ -109,16 +109,22 @@ func (b *Book) Insert(o *order.LimitOrder) bool {
 
 // Remove attempts to remove the order with the given OrderID from the book.
 func (b *Book) Remove(oid order.OrderID) (*order.LimitOrder, bool) {
-	uid := oid.String()
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
-	if removed, ok := b.sells.RemoveOrderUID(uid); ok {
+	if removed, ok := b.sells.RemoveOrderID(oid); ok {
 		return removed, true
 	}
-	if removed, ok := b.buys.RemoveOrderUID(uid); ok {
+	if removed, ok := b.buys.RemoveOrderID(oid); ok {
 		return removed, true
 	}
 	return nil, false
+}
+
+// HaveOrder checks if an order is in either the buy or sell side of the book.
+func (b *Book) HaveOrder(oid order.OrderID) bool {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	return b.buys.HaveOrder(oid) || b.sells.HaveOrder(oid)
 }
 
 // SellOrders copies out all sell orders in the book, sorted.

--- a/server/book/orderpq_test.go
+++ b/server/book/orderpq_test.go
@@ -588,12 +588,12 @@ func TestOrderPriorityQueue_Remove(t *testing.T) {
 	if pq.Len() != 1 {
 		t.Errorf("Queue length expected %d, got %d", 1, pq.Len())
 	}
-	remainingUID := pq.PeekBest().UID()
-	if remainingUID != orders[0].UID() {
-		t.Errorf("Remaining element expected %s, got %s", orders[0].UID(),
-			remainingUID)
+	remainingID := pq.PeekBest().ID()
+	if remainingID != orders[0].ID() {
+		t.Errorf("Remaining element expected %s, got %s", orders[0].ID(),
+			remainingID)
 	}
-	pq.RemoveOrderUID(remainingUID)
+	pq.RemoveOrderID(remainingID)
 	if pq.Len() != 0 {
 		t.Errorf("Expected empty queue, got %d", pq.Len())
 	}


### PR DESCRIPTION
This adds `(*Market).Cancelable(order.OrderID)`.

Add `epochOrders` field to `Market`.  This is somewhat inefficient since
the `currentEpoch` in `runEpochs` has the same map. However, with the
current design, there is also `nextEpoch` to consider, so `epochOrders` is
updated in `processOrder` and `processEpoch`. In the future, the `Epoch` type
can provide a `HaveOrder` method, while `Market` will have to keep the
epochs as fields with a mutex guarding them, but it's not worth it now.

book: change pq book map to key to `OrderID` (why was it ever a `string`?).

Add `(*OrderPQ).HaveOrder`.
Add `(*Book).HaveOrder`.