### PR TITLE
multi: Now().Round -> Now().Truncate

### DIFF
--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -17,7 +17,7 @@ import (
 )
 
 func unixMsNow() time.Time {
-	return time.Now().Round(time.Millisecond).UTC()
+	return time.Now().Truncate(time.Millisecond).UTC()
 }
 
 // reqExpiration is how long a response handler will be saved before it is

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -327,7 +327,7 @@ func (m *Market) runEpochs(nextEpochIdx int64) {
 			}
 
 			// The order's server time stamp.
-			sTime := time.Now().Round(time.Millisecond).UTC()
+			sTime := time.Now().Truncate(time.Millisecond).UTC()
 
 			// Push the order into the next epoch if receiving and stamping it
 			// took just a little too long.

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -190,7 +190,7 @@ func TestMarket_runEpochs(t *testing.T) {
 	qty := uint64(dcrLotSize * lots)
 	rate := uint64(1000) * dcrRateStep
 	aid := test.NextAccount()
-	now := time.Now().Round(time.Millisecond).UTC()
+	now := time.Now().Truncate(time.Millisecond).UTC()
 	limit := &msgjson.Limit{
 		Prefix: msgjson.Prefix{
 			AccountID:  aid[:],

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -285,7 +285,7 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 	}
 	// Create the market order
 	clientTime := order.UnixTimeMilli(int64(market.ClientTime))
-	serverTime := time.Now().Round(time.Millisecond).UTC()
+	serverTime := time.Now().Truncate(time.Millisecond).UTC()
 	mo := &order.MarketOrder{
 		Prefix: order.Prefix{
 			AccountID:  user,
@@ -356,7 +356,7 @@ func (r *OrderRouter) handleCancel(user account.AccountID, msg *msgjson.Message)
 
 	// Create the cancel order
 	clientTime := order.UnixTimeMilli(int64(cancel.ClientTime))
-	serverTime := time.Now().Round(time.Millisecond).UTC()
+	serverTime := time.Now().Truncate(time.Millisecond).UTC()
 	co := &order.CancelOrder{
 		Prefix: order.Prefix{
 			AccountID:  user,

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -103,7 +103,7 @@ var (
 )
 
 func nowMs() time.Time {
-	return time.Now().Round(time.Millisecond).UTC()
+	return time.Now().Truncate(time.Millisecond).UTC()
 }
 
 // The AuthManager handles client-related actions, including authorization and


### PR DESCRIPTION
This addresses the same mistake that was fixed in swap in https://github.com/decred/dcrdex/pull/106.