### PR TITLE
order: add Trade struct

### DIFF
--- a/dex/order/match_test.go
+++ b/dex/order/match_test.go
@@ -17,7 +17,7 @@ func TestMatchID(t *testing.T) {
 	qty := uint64(132413241324)
 
 	mo := &MarketOrder{
-		Prefix: Prefix{
+		P: Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -25,7 +25,7 @@ func TestMatchID(t *testing.T) {
 			ClientTime: time.Unix(1566497653, 0),
 			ServerTime: time.Unix(1566497656, 0),
 		},
-		Trade: Trade{
+		T: Trade{
 			Coins: []CoinID{
 				utxoCoinID("a985d8df97571b130ce30a049a76ffedaa79b6e69b173ff81b1bf9fc07f063c7", 1),
 			},
@@ -41,7 +41,7 @@ func TestMatchID(t *testing.T) {
 	copy(limitID[:], limitID0)
 
 	lo := &LimitOrder{
-		Prefix: Prefix{
+		P: Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -49,7 +49,7 @@ func TestMatchID(t *testing.T) {
 			ClientTime: time.Unix(1566497653, 0),
 			ServerTime: time.Unix(1566497656, 0),
 		},
-		Trade: Trade{
+		T: Trade{
 			Coins: []CoinID{
 				utxoCoinID("01516d9c7ffbe260b811dc04462cedd3f8969ce3a3ffe6231ae870775a92e9b0", 1),
 			},

--- a/dex/order/match_test.go
+++ b/dex/order/match_test.go
@@ -25,12 +25,14 @@ func TestMatchID(t *testing.T) {
 			ClientTime: time.Unix(1566497653, 0),
 			ServerTime: time.Unix(1566497656, 0),
 		},
-		Coins: []CoinID{
-			utxoCoinID("a985d8df97571b130ce30a049a76ffedaa79b6e69b173ff81b1bf9fc07f063c7", 1),
+		Trade: Trade{
+			Coins: []CoinID{
+				utxoCoinID("a985d8df97571b130ce30a049a76ffedaa79b6e69b173ff81b1bf9fc07f063c7", 1),
+			},
+			Sell:     true,
+			Quantity: qty,
+			Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
 		},
-		Sell:     true,
-		Quantity: qty,
-		Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
 	}
 
 	// maker
@@ -39,15 +41,15 @@ func TestMatchID(t *testing.T) {
 	copy(limitID[:], limitID0)
 
 	lo := &LimitOrder{
-		MarketOrder: MarketOrder{
-			Prefix: Prefix{
-				AccountID:  acct0,
-				BaseAsset:  AssetDCR,
-				QuoteAsset: AssetBTC,
-				OrderType:  LimitOrderType,
-				ClientTime: time.Unix(1566497653, 0),
-				ServerTime: time.Unix(1566497656, 0),
-			},
+		Prefix: Prefix{
+			AccountID:  acct0,
+			BaseAsset:  AssetDCR,
+			QuoteAsset: AssetBTC,
+			OrderType:  LimitOrderType,
+			ClientTime: time.Unix(1566497653, 0),
+			ServerTime: time.Unix(1566497656, 0),
+		},
+		Trade: Trade{
 			Coins: []CoinID{
 				utxoCoinID("01516d9c7ffbe260b811dc04462cedd3f8969ce3a3ffe6231ae870775a92e9b0", 1),
 			},

--- a/dex/order/order_test.go
+++ b/dex/order/order_test.go
@@ -197,11 +197,13 @@ func TestMarketOrder_Serialize_SerializeSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &MarketOrder{
-				Prefix:   tt.fields.Prefix,
-				Coins:    tt.fields.Coins,
-				Sell:     tt.fields.Sell,
-				Quantity: tt.fields.Quantity,
-				Address:  tt.fields.Address,
+				Prefix: tt.fields.Prefix,
+				Trade: Trade{
+					Coins:    tt.fields.Coins,
+					Sell:     tt.fields.Sell,
+					Quantity: tt.fields.Quantity,
+					Address:  tt.fields.Address,
+				},
 			}
 			got := o.Serialize()
 			if !reflect.DeepEqual(got, tt.want) {
@@ -239,13 +241,15 @@ func TestLimitOrder_Serialize_SerializeSize(t *testing.T) {
 						ClientTime: time.Unix(1566497653, 0),
 						ServerTime: time.Unix(1566497656, 0),
 					},
-					Coins: []CoinID{
-						utxoCoinID("d186e4b6625c9c94797cc494f535fc150177e0619e2303887e0a677f29ef1bab", 0),
-						utxoCoinID("11d9580e19ad65a875a5bc558d600e96b2916062db9e8b65cbc2bb905207c1ad", 16),
+					Trade: Trade{
+						Coins: []CoinID{
+							utxoCoinID("d186e4b6625c9c94797cc494f535fc150177e0619e2303887e0a677f29ef1bab", 0),
+							utxoCoinID("11d9580e19ad65a875a5bc558d600e96b2916062db9e8b65cbc2bb905207c1ad", 16),
+						},
+						Sell:     false,
+						Quantity: 132413241324,
+						Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
 					},
-					Sell:     false,
-					Quantity: 132413241324,
-					Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
 				},
 				Rate:  13241324,
 				Force: StandingTiF,
@@ -298,9 +302,10 @@ func TestLimitOrder_Serialize_SerializeSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &LimitOrder{
-				MarketOrder: tt.fields.MarketOrder,
-				Rate:        tt.fields.Rate,
-				Force:       tt.fields.Force,
+				Prefix: tt.fields.MarketOrder.Prefix,
+				Trade:  tt.fields.MarketOrder.Trade,
+				Rate:   tt.fields.Rate,
+				Force:  tt.fields.Force,
 			}
 			got := o.Serialize()
 			if !reflect.DeepEqual(got, tt.want) {
@@ -422,11 +427,13 @@ func TestMarketOrder_ID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &MarketOrder{
-				Prefix:   tt.fields.Prefix,
-				Coins:    tt.fields.Coins,
-				Sell:     tt.fields.Sell,
-				Quantity: tt.fields.Quantity,
-				Address:  tt.fields.Address,
+				Prefix: tt.fields.Prefix,
+				Trade: Trade{
+					Coins:    tt.fields.Coins,
+					Sell:     tt.fields.Sell,
+					Quantity: tt.fields.Quantity,
+					Address:  tt.fields.Address,
+				},
 			}
 			remaining := o.Remaining()
 			if remaining != o.Quantity-o.Filled {
@@ -467,12 +474,14 @@ func TestLimitOrder_ID(t *testing.T) {
 						ClientTime: time.Unix(1566497653, 0),
 						ServerTime: time.Unix(1566497656, 0),
 					},
-					Coins: []CoinID{
-						utxoCoinID("01516d9c7ffbe260b811dc04462cedd3f8969ce3a3ffe6231ae870775a92e9b0", 1),
+					Trade: Trade{
+						Coins: []CoinID{
+							utxoCoinID("01516d9c7ffbe260b811dc04462cedd3f8969ce3a3ffe6231ae870775a92e9b0", 1),
+						},
+						Sell:     false,
+						Quantity: 132413241324,
+						Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
 					},
-					Sell:     false,
-					Quantity: 132413241324,
-					Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
 				},
 				Rate:  13241324,
 				Force: StandingTiF,
@@ -483,9 +492,10 @@ func TestLimitOrder_ID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &LimitOrder{
-				MarketOrder: tt.fields.MarketOrder,
-				Rate:        tt.fields.Rate,
-				Force:       tt.fields.Force,
+				Trade:  tt.fields.MarketOrder.Trade,
+				Prefix: tt.fields.MarketOrder.Prefix,
+				Rate:   tt.fields.Rate,
+				Force:  tt.fields.Force,
 			}
 			remaining := o.Remaining()
 			if remaining != o.Quantity-o.Filled {

--- a/dex/order/order_test.go
+++ b/dex/order/order_test.go
@@ -114,16 +114,16 @@ func TestPrefix_Serialize(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Prefix.Serialize() = %#v, want %#v", got, tt.want)
 			}
-			sz := p.SerializeSize()
+			sz := p.serializeSize()
 			wantSz := len(got)
 			if sz != wantSz {
-				t.Errorf("Prefix.SerializeSize() = %d,\n want %d", sz, wantSz)
+				t.Errorf("Prefix.serializeSize() = %d,\n want %d", sz, wantSz)
 			}
 		})
 	}
 }
 
-func TestMarketOrder_Serialize_SerializeSize(t *testing.T) {
+func TestMarketOrder_Serialize_serializeSize(t *testing.T) {
 	type fields struct {
 		Prefix   Prefix
 		Coins    []CoinID
@@ -197,8 +197,8 @@ func TestMarketOrder_Serialize_SerializeSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &MarketOrder{
-				Prefix: tt.fields.Prefix,
-				Trade: Trade{
+				P: tt.fields.Prefix,
+				T: Trade{
 					Coins:    tt.fields.Coins,
 					Sell:     tt.fields.Sell,
 					Quantity: tt.fields.Quantity,
@@ -209,16 +209,16 @@ func TestMarketOrder_Serialize_SerializeSize(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MarketOrder.Serialize() = %#v,\n want %#v", got, tt.want)
 			}
-			sz := o.SerializeSize()
+			sz := o.serializeSize()
 			wantSz := len(got)
 			if sz != wantSz {
-				t.Errorf("MarketOrder.SerializeSize() = %d,\n want %d", sz, wantSz)
+				t.Errorf("MarketOrder.serializeSize() = %d,\n want %d", sz, wantSz)
 			}
 		})
 	}
 }
 
-func TestLimitOrder_Serialize_SerializeSize(t *testing.T) {
+func TestLimitOrder_Serialize_serializeSize(t *testing.T) {
 	type fields struct {
 		MarketOrder MarketOrder
 		Rate        uint64
@@ -233,7 +233,7 @@ func TestLimitOrder_Serialize_SerializeSize(t *testing.T) {
 			"ok acct0",
 			fields{
 				MarketOrder: MarketOrder{
-					Prefix: Prefix{
+					P: Prefix{
 						AccountID:  acct0,
 						BaseAsset:  AssetDCR,
 						QuoteAsset: AssetBTC,
@@ -241,7 +241,7 @@ func TestLimitOrder_Serialize_SerializeSize(t *testing.T) {
 						ClientTime: time.Unix(1566497653, 0),
 						ServerTime: time.Unix(1566497656, 0),
 					},
-					Trade: Trade{
+					T: Trade{
 						Coins: []CoinID{
 							utxoCoinID("d186e4b6625c9c94797cc494f535fc150177e0619e2303887e0a677f29ef1bab", 0),
 							utxoCoinID("11d9580e19ad65a875a5bc558d600e96b2916062db9e8b65cbc2bb905207c1ad", 16),
@@ -302,19 +302,19 @@ func TestLimitOrder_Serialize_SerializeSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &LimitOrder{
-				Prefix: tt.fields.MarketOrder.Prefix,
-				Trade:  tt.fields.MarketOrder.Trade,
-				Rate:   tt.fields.Rate,
-				Force:  tt.fields.Force,
+				P:     tt.fields.MarketOrder.P,
+				T:     tt.fields.MarketOrder.T,
+				Rate:  tt.fields.Rate,
+				Force: tt.fields.Force,
 			}
 			got := o.Serialize()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LimitOrder.Serialize() = %#v, want %#v", got, tt.want)
 			}
-			sz := o.SerializeSize()
+			sz := o.serializeSize()
 			wantSz := len(got)
 			if sz != wantSz {
-				t.Errorf("LimitOrder.SerializeSize() = %d,\n want %d", sz, wantSz)
+				t.Errorf("LimitOrder.serializeSize() = %d,\n want %d", sz, wantSz)
 			}
 		})
 	}
@@ -370,17 +370,17 @@ func TestCancelOrder_Serialize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &CancelOrder{
-				Prefix:        tt.fields.Prefix,
+				P:             tt.fields.Prefix,
 				TargetOrderID: tt.fields.TargetOrderID,
 			}
 			got := o.Serialize()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("CancelOrder.Serialize() = %#v, want %v", got, tt.want)
 			}
-			sz := o.SerializeSize()
+			sz := o.serializeSize()
 			wantSz := len(got)
 			if sz != wantSz {
-				t.Errorf("CancelOrder.SerializeSize() = %d,\n want %d", sz, wantSz)
+				t.Errorf("CancelOrder.serializeSize() = %d,\n want %d", sz, wantSz)
 			}
 		})
 	}
@@ -427,8 +427,8 @@ func TestMarketOrder_ID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &MarketOrder{
-				Prefix: tt.fields.Prefix,
-				Trade: Trade{
+				P: tt.fields.Prefix,
+				T: Trade{
 					Coins:    tt.fields.Coins,
 					Sell:     tt.fields.Sell,
 					Quantity: tt.fields.Quantity,
@@ -466,7 +466,7 @@ func TestLimitOrder_ID(t *testing.T) {
 			"ok",
 			fields{
 				MarketOrder: MarketOrder{
-					Prefix: Prefix{
+					P: Prefix{
 						AccountID:  acct0,
 						BaseAsset:  AssetDCR,
 						QuoteAsset: AssetBTC,
@@ -474,7 +474,7 @@ func TestLimitOrder_ID(t *testing.T) {
 						ClientTime: time.Unix(1566497653, 0),
 						ServerTime: time.Unix(1566497656, 0),
 					},
-					Trade: Trade{
+					T: Trade{
 						Coins: []CoinID{
 							utxoCoinID("01516d9c7ffbe260b811dc04462cedd3f8969ce3a3ffe6231ae870775a92e9b0", 1),
 						},
@@ -492,10 +492,10 @@ func TestLimitOrder_ID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &LimitOrder{
-				Trade:  tt.fields.MarketOrder.Trade,
-				Prefix: tt.fields.MarketOrder.Prefix,
-				Rate:   tt.fields.Rate,
-				Force:  tt.fields.Force,
+				T:     tt.fields.MarketOrder.T,
+				P:     tt.fields.MarketOrder.P,
+				Rate:  tt.fields.Rate,
+				Force: tt.fields.Force,
 			}
 			remaining := o.Remaining()
 			if remaining != o.Quantity-o.Filled {
@@ -546,12 +546,8 @@ func TestCancelOrder_ID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &CancelOrder{
-				Prefix:        tt.fields.Prefix,
+				P:             tt.fields.Prefix,
 				TargetOrderID: tt.fields.TargetOrderID,
-			}
-			remaining := o.Remaining()
-			if remaining != 0 {
-				t.Errorf("CancelOrder.Remaining should be 0, got %d", remaining)
 			}
 			if got := o.ID(); got != tt.want {
 				t.Errorf("CancelOrder.ID() = %v, want %v", got, tt.want)

--- a/dex/order/test/helpers.go
+++ b/dex/order/test/helpers.go
@@ -52,7 +52,7 @@ type Market struct {
 // values.
 func WriteLimitOrder(writer *Writer, rate, lots uint64, force order.TimeInForce, timeOffset int64) *order.LimitOrder {
 	return &order.LimitOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  writer.Acct,
 			BaseAsset:  writer.Market.Base,
 			QuoteAsset: writer.Market.Quote,
@@ -60,7 +60,7 @@ func WriteLimitOrder(writer *Writer, rate, lots uint64, force order.TimeInForce,
 			ClientTime: time.Unix(baseClientTime+timeOffset, 0),
 			ServerTime: time.Unix(baseServerTime+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     writer.Sell,
 			Quantity: lots * writer.Market.LotSize,
@@ -78,7 +78,7 @@ func WriteMarketOrder(writer *Writer, lots uint64, timeOffset int64) *order.Mark
 		lots *= writer.Market.LotSize
 	}
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  writer.Acct,
 			BaseAsset:  writer.Market.Base,
 			QuoteAsset: writer.Market.Quote,
@@ -86,7 +86,7 @@ func WriteMarketOrder(writer *Writer, lots uint64, timeOffset int64) *order.Mark
 			ClientTime: time.Unix(baseClientTime+timeOffset, 0).UTC(),
 			ServerTime: time.Unix(baseServerTime+timeOffset, 0).UTC(),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     writer.Sell,
 			Quantity: lots,
@@ -98,7 +98,7 @@ func WriteMarketOrder(writer *Writer, lots uint64, timeOffset int64) *order.Mark
 // WriteCancelOrder creates a cancel order with the specified order ID.
 func WriteCancelOrder(writer *Writer, targetOrderID order.OrderID, timeOffset int64) *order.CancelOrder {
 	return &order.CancelOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  writer.Acct,
 			BaseAsset:  writer.Market.Base,
 			QuoteAsset: writer.Market.Quote,

--- a/dex/order/test/helpers.go
+++ b/dex/order/test/helpers.go
@@ -52,15 +52,15 @@ type Market struct {
 // values.
 func WriteLimitOrder(writer *Writer, rate, lots uint64, force order.TimeInForce, timeOffset int64) *order.LimitOrder {
 	return &order.LimitOrder{
-		MarketOrder: order.MarketOrder{
-			Prefix: order.Prefix{
-				AccountID:  writer.Acct,
-				BaseAsset:  writer.Market.Base,
-				QuoteAsset: writer.Market.Quote,
-				OrderType:  order.LimitOrderType,
-				ClientTime: time.Unix(baseClientTime+timeOffset, 0),
-				ServerTime: time.Unix(baseServerTime+timeOffset, 0),
-			},
+		Prefix: order.Prefix{
+			AccountID:  writer.Acct,
+			BaseAsset:  writer.Market.Base,
+			QuoteAsset: writer.Market.Quote,
+			OrderType:  order.LimitOrderType,
+			ClientTime: time.Unix(baseClientTime+timeOffset, 0),
+			ServerTime: time.Unix(baseServerTime+timeOffset, 0),
+		},
+		Trade: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     writer.Sell,
 			Quantity: lots * writer.Market.LotSize,
@@ -86,10 +86,12 @@ func WriteMarketOrder(writer *Writer, lots uint64, timeOffset int64) *order.Mark
 			ClientTime: time.Unix(baseClientTime+timeOffset, 0).UTC(),
 			ServerTime: time.Unix(baseServerTime+timeOffset, 0).UTC(),
 		},
-		Coins:    []order.CoinID{},
-		Sell:     writer.Sell,
-		Quantity: lots,
-		Address:  writer.Addr,
+		Trade: order.Trade{
+			Coins:    []order.CoinID{},
+			Sell:     writer.Sell,
+			Quantity: lots,
+			Address:  writer.Addr,
+		},
 	}
 }
 

--- a/server/book/book_test.go
+++ b/server/book/book_test.go
@@ -39,7 +39,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -47,7 +47,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     sell,
 			Quantity: quantityLots * LotSize,

--- a/server/book/book_test.go
+++ b/server/book/book_test.go
@@ -39,15 +39,15 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		MarketOrder: order.MarketOrder{
-			Prefix: order.Prefix{
-				AccountID:  acct0,
-				BaseAsset:  AssetDCR,
-				QuoteAsset: AssetBTC,
-				OrderType:  order.LimitOrderType,
-				ClientTime: time.Unix(1566497653+timeOffset, 0),
-				ServerTime: time.Unix(1566497656+timeOffset, 0),
-			},
+		Prefix: order.Prefix{
+			AccountID:  acct0,
+			BaseAsset:  AssetDCR,
+			QuoteAsset: AssetBTC,
+			OrderType:  order.LimitOrderType,
+			ClientTime: time.Unix(1566497653+timeOffset, 0),
+			ServerTime: time.Unix(1566497656+timeOffset, 0),
+		},
+		Trade: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     sell,
 			Quantity: quantityLots * LotSize,

--- a/server/coinlock/coinlocker.go
+++ b/server/coinlock/coinlocker.go
@@ -187,7 +187,7 @@ func (ac *AssetCoinLocker) LockCoins(orderCoins map[order.OrderID][]CoinID) {
 func (ac *AssetCoinLocker) LockOrdersCoins(orders []order.Order) {
 	ac.coinMtx.Lock()
 	for _, ord := range orders {
-		coinIDs := ord.CoinIDs()
+		coinIDs := ord.Trade().Coins
 		if len(coinIDs) == 0 {
 			continue // e.g. CancelOrder
 		}

--- a/server/db/driver/pg/matches.go
+++ b/server/db/driver/pg/matches.go
@@ -90,8 +90,8 @@ func upsertMatch(dbe sqlExecutor, tableName string, match *order.Match) (int64, 
 	stmt := fmt.Sprintf(internal.UpsertMatch, tableName)
 	epochID := fmt.Sprintf("%d:%d", match.Epoch.Idx, match.Epoch.Dur)
 	return sqlExec(dbe, stmt, match.ID(),
-		match.Taker.ID(), match.Taker.User(), match.Taker.SwapAddress(),
-		match.Maker.ID(), match.Maker.User(), match.Maker.SwapAddress(),
+		match.Taker.ID(), match.Taker.User(), match.Taker.Trade().SwapAddress(),
+		match.Maker.ID(), match.Maker.User(), match.Maker.Trade().SwapAddress(),
 		epochID, int64(match.Quantity), int64(match.Rate), int8(match.Status),
 		match.Sigs.TakerMatch, match.Sigs.MakerMatch,
 		match.Sigs.TakerAudit, match.Sigs.MakerAudit,

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -89,7 +89,7 @@ func (a *Archiver) Order(oid order.OrderID, base, quote uint32) (order.Order, or
 	// - try to load from orders table, which includes market and limit orders
 	// - if found, coerce into the correct order type and return
 	// - if not found, try loading a cancel order with this oid
-	lo, status, err := loadLimitOrder(a.db, a.dbName, marketSchema, oid)
+	ord, status, err := loadTrade(a.db, a.dbName, marketSchema, oid)
 	if errA, ok := err.(db.ArchiveError); ok {
 		if errA.Code != db.ErrUnknownOrder {
 			return nil, order.OrderStatusUnknown, err
@@ -107,21 +107,9 @@ func (a *Archiver) Order(oid order.OrderID, base, quote uint32) (order.Order, or
 	if err != nil {
 		return nil, order.OrderStatusUnknown, err
 	}
-
-	lo.BaseAsset, lo.QuoteAsset = base, quote
-
-	// Since loadLimitOrder returns both market and limit orders in a
-	// *LimitOrder, identify the real type via the OrderType field. Extract the
-	// MarketOrder if necessary.
-	switch lo.OrderType {
-	case order.MarketOrderType:
-		return &lo.MarketOrder, pgToMarketStatus(status), nil
-	case order.LimitOrderType:
-		return lo, pgToMarketStatus(status), nil
-	}
-
-	return nil, order.OrderStatusUnknown,
-		fmt.Errorf("retrieved unsupported order type %d (%s)", lo.OrderType, lo.OrderType)
+	prefix, _ := ord.Parts()
+	prefix.BaseAsset, prefix.QuoteAsset = base, quote
+	return ord, pgToMarketStatus(status), nil
 }
 
 type pgOrderStatus uint16
@@ -641,50 +629,67 @@ func findOrder(dbe *sql.DB, oid order.OrderID, fullTable string) (bool, pgOrderS
 	}
 }
 
-func loadLimitOrder(dbe *sql.DB, dbName, marketSchema string, oid order.OrderID) (*order.LimitOrder, pgOrderStatus, error) {
+func loadTrade(dbe *sql.DB, dbName, marketSchema string, oid order.OrderID) (order.Order, pgOrderStatus, error) {
 	// Search active orders first.
 	fullTable := fullOrderTableName(dbName, marketSchema, false)
-	lo, status, err := loadLimitOrderFromTable(dbe, fullTable, oid)
+	ord, status, err := loadTradeFromTable(dbe, fullTable, oid)
 	switch err {
 	case sql.ErrNoRows:
 		// try archived orders next
 	case nil:
 		// found
-		return lo, status, nil
+		return ord, status, nil
 	default:
 		// query error
-		return lo, orderStatusUnknown, err
+		return ord, orderStatusUnknown, err
 	}
 
 	// Search archived orders.
 	fullTable = fullOrderTableName(dbName, marketSchema, true)
-	lo, status, err = loadLimitOrderFromTable(dbe, fullTable, oid)
+	ord, status, err = loadTradeFromTable(dbe, fullTable, oid)
 	switch err {
 	case sql.ErrNoRows:
 		return nil, orderStatusUnknown, db.ArchiveError{Code: db.ErrUnknownOrder}
 	case nil:
 		// found
-		return lo, status, nil
+		return ord, status, nil
 	default:
 		// query error
 		return nil, orderStatusUnknown, err
 	}
 }
 
-func loadLimitOrderFromTable(dbe *sql.DB, fullTable string, oid order.OrderID) (*order.LimitOrder, pgOrderStatus, error) {
+func loadTradeFromTable(dbe *sql.DB, fullTable string, oid order.OrderID) (order.Order, pgOrderStatus, error) {
 	stmt := fmt.Sprintf(internal.SelectOrder, fullTable)
 
-	var lo order.LimitOrder
+	var prefix order.Prefix
+	var trade order.Trade
 	var id order.OrderID
+	var tif order.TimeInForce
+	var rate uint64
 	var status pgOrderStatus
-	err := dbe.QueryRow(stmt, oid).Scan(&id, &lo.OrderType, &lo.Sell,
-		&lo.AccountID, &lo.Address, &lo.ClientTime, &lo.ServerTime, (*dbCoins)(&lo.Coins),
-		&lo.Quantity, &lo.Rate, &lo.Force, &status, &lo.Filled)
+	err := dbe.QueryRow(stmt, oid).Scan(&id, &prefix.OrderType, &trade.Sell,
+		&prefix.AccountID, &trade.Address, &prefix.ClientTime, &prefix.ServerTime, (*dbCoins)(&trade.Coins),
+		&trade.Quantity, &rate, &tif, &status, &trade.Filled)
 	if err != nil {
 		return nil, orderStatusUnknown, err
 	}
+	switch prefix.OrderType {
+	case order.LimitOrderType:
+		return &order.LimitOrder{
+			Trade:  trade,
+			Prefix: prefix,
+			Rate:   rate,
+			Force:  tif,
+		}, status, nil
+	case order.MarketOrderType:
+		return &order.MarketOrder{
+			Trade:  trade,
+			Prefix: prefix,
+		}, status, nil
 
-	return &lo, status, nil
+	}
+	return nil, 0, fmt.Errorf("unknown order type %d retreived", prefix.OrderType)
 }
 
 func userOrders(ctx context.Context, dbe *sql.DB, dbName, marketSchema string, aid account.AccountID) ([]order.Order, []pgOrderStatus, error) {

--- a/server/db/driver/pg/orders_online_test.go
+++ b/server/db/driver/pg/orders_online_test.go
@@ -527,10 +527,10 @@ func TestActiveOrderCoins(t *testing.T) {
 		case 0: // no active
 		case 1: // active base coins (sell order)
 			coins = baseCoins[os.ord.ID()]
-			wantCoins = os.ord.CoinIDs()
+			wantCoins = os.ord.Trade().Coins
 		case -1: // active quote coins (buy order)
 			coins = quoteCoins[os.ord.ID()]
-			wantCoins = os.ord.CoinIDs()
+			wantCoins = os.ord.Trade().Coins
 		}
 
 		if len(coins) != len(wantCoins) {
@@ -588,6 +588,7 @@ func TestOrderStatus(t *testing.T) {
 
 	for i := range orderStatuses {
 		ordIn := orderStatuses[i].ord
+		trade := ordIn.Trade()
 		statusIn := orderStatuses[i].status
 		err := archie.StoreOrder(ordIn, statusIn)
 		if err != nil {
@@ -609,9 +610,9 @@ func TestOrderStatus(t *testing.T) {
 				typeOut, ordIn.Type())
 		}
 
-		if filledOut != int64(ordIn.FilledAmt()) {
+		if filledOut != int64(trade.Filled) {
 			t.Errorf("Incorrect FilledAmt for retrieved order. Got %v, expected %v.",
-				filledOut, ordIn.FilledAmt())
+				filledOut, trade.Filled)
 		}
 	}
 }

--- a/server/db/driver/pg/testhelpers_test.go
+++ b/server/db/driver/pg/testhelpers_test.go
@@ -71,7 +71,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  randomAccountID(),
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -79,7 +79,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 			ClientTime: time.Unix(1566497653+timeOffset, 0).UTC(),
 			ServerTime: time.Unix(1566497656+timeOffset, 0).UTC(),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins: []order.CoinID{
 				randomBytes(36),
 				randomBytes(36),
@@ -95,7 +95,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 
 func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrder {
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  randomAccountID(),
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -103,7 +103,7 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 			ClientTime: time.Unix(1566497653+timeOffset, 0).UTC(),
 			ServerTime: time.Unix(1566497656+timeOffset, 0).UTC(),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{randomBytes(36)},
 			Sell:     true,
 			Quantity: quantityLots * LotSize,
@@ -114,7 +114,7 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 
 func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.MarketOrder {
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  randomAccountID(),
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -122,7 +122,7 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 			ClientTime: time.Unix(1566497653+timeOffset, 0).UTC(),
 			ServerTime: time.Unix(1566497656+timeOffset, 0).UTC(),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{randomBytes(36)},
 			Sell:     false,
 			Quantity: quantityQuoteAsset,
@@ -133,7 +133,7 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 
 func newCancelOrder(targetOrderID order.OrderID, base, quote uint32, timeOffset int64) *order.CancelOrder {
 	return &order.CancelOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  randomAccountID(),
 			BaseAsset:  base,
 			QuoteAsset: quote,

--- a/server/db/driver/pg/testhelpers_test.go
+++ b/server/db/driver/pg/testhelpers_test.go
@@ -71,15 +71,15 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		MarketOrder: order.MarketOrder{
-			Prefix: order.Prefix{
-				AccountID:  randomAccountID(),
-				BaseAsset:  AssetDCR,
-				QuoteAsset: AssetBTC,
-				OrderType:  order.LimitOrderType,
-				ClientTime: time.Unix(1566497653+timeOffset, 0).UTC(),
-				ServerTime: time.Unix(1566497656+timeOffset, 0).UTC(),
-			},
+		Prefix: order.Prefix{
+			AccountID:  randomAccountID(),
+			BaseAsset:  AssetDCR,
+			QuoteAsset: AssetBTC,
+			OrderType:  order.LimitOrderType,
+			ClientTime: time.Unix(1566497653+timeOffset, 0).UTC(),
+			ServerTime: time.Unix(1566497656+timeOffset, 0).UTC(),
+		},
+		Trade: order.Trade{
 			Coins: []order.CoinID{
 				randomBytes(36),
 				randomBytes(36),
@@ -103,10 +103,12 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 			ClientTime: time.Unix(1566497653+timeOffset, 0).UTC(),
 			ServerTime: time.Unix(1566497656+timeOffset, 0).UTC(),
 		},
-		Coins:    []order.CoinID{randomBytes(36)},
-		Sell:     true,
-		Quantity: quantityLots * LotSize,
-		Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+		Trade: order.Trade{
+			Coins:    []order.CoinID{randomBytes(36)},
+			Sell:     true,
+			Quantity: quantityLots * LotSize,
+			Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+		},
 	}
 }
 
@@ -120,10 +122,12 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 			ClientTime: time.Unix(1566497653+timeOffset, 0).UTC(),
 			ServerTime: time.Unix(1566497656+timeOffset, 0).UTC(),
 		},
-		Coins:    []order.CoinID{randomBytes(36)},
-		Sell:     false,
-		Quantity: quantityQuoteAsset,
-		Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+		Trade: order.Trade{
+			Coins:    []order.CoinID{randomBytes(36)},
+			Sell:     false,
+			Quantity: quantityQuoteAsset,
+			Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+		},
 	}
 }
 

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -195,7 +195,7 @@ func ValidateOrder(ord order.Order, status order.OrderStatus, mkt *dex.MarketInf
 		}
 
 		// Market sell orders must respect lot size.
-		if ot.Sell && (ot.Quantity%mkt.LotSize != 0 || ord.Remaining()%mkt.LotSize != 0) {
+		if ot.Sell && (ot.Quantity%mkt.LotSize != 0 || ot.Remaining()%mkt.LotSize != 0) {
 			return false
 		}
 
@@ -210,11 +210,6 @@ func ValidateOrder(ord order.Order, status order.OrderStatus, mkt *dex.MarketInf
 
 		if ot.OrderType != order.CancelOrderType {
 			return false
-		}
-
-		// All cancel orders must have zero and filled remaining amounts.
-		if ord.Remaining() != 0 || ord.FilledAmt() != 0 {
-			panic("a CancelOrder should always return 0 Remaining and FilledAmt")
 		}
 
 	case *order.LimitOrder:
@@ -237,7 +232,7 @@ func ValidateOrder(ord order.Order, status order.OrderStatus, mkt *dex.MarketInf
 		}
 
 		// All limit orders must respect lot size.
-		if ot.Quantity%mkt.LotSize != 0 || ord.Remaining()%mkt.LotSize != 0 {
+		if ot.Quantity%mkt.LotSize != 0 || ot.Remaining()%mkt.LotSize != 0 {
 			return false
 		}
 	default:

--- a/server/db/testhelpers_test.go
+++ b/server/db/testhelpers_test.go
@@ -39,15 +39,15 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		MarketOrder: order.MarketOrder{
-			Prefix: order.Prefix{
-				AccountID:  acct0,
-				BaseAsset:  AssetDCR,
-				QuoteAsset: AssetBTC,
-				OrderType:  order.LimitOrderType,
-				ClientTime: time.Unix(1566497653+timeOffset, 0),
-				ServerTime: time.Unix(1566497656+timeOffset, 0),
-			},
+		Prefix: order.Prefix{
+			AccountID:  acct0,
+			BaseAsset:  AssetDCR,
+			QuoteAsset: AssetBTC,
+			OrderType:  order.LimitOrderType,
+			ClientTime: time.Unix(1566497653+timeOffset, 0),
+			ServerTime: time.Unix(1566497656+timeOffset, 0),
+		},
+		Trade: order.Trade{
 			Coins: []order.CoinID{
 				{
 					0x45, 0xb8, 0x21, 0x38, 0xca, 0x90, 0xe6, 0x65, 0xa1, 0xc8, 0x79, 0x3a,
@@ -74,10 +74,12 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Coins:    []order.CoinID{},
-		Sell:     true,
-		Quantity: quantityLots * LotSize,
-		Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+		Trade: order.Trade{
+			Coins:    []order.CoinID{},
+			Sell:     true,
+			Quantity: quantityLots * LotSize,
+			Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+		},
 	}
 }
 
@@ -91,10 +93,12 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Coins:    []order.CoinID{},
-		Sell:     false,
-		Quantity: quantityQuoteAsset,
-		Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+		Trade: order.Trade{
+			Coins:    []order.CoinID{},
+			Sell:     false,
+			Quantity: quantityQuoteAsset,
+			Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+		},
 	}
 }
 

--- a/server/db/testhelpers_test.go
+++ b/server/db/testhelpers_test.go
@@ -39,7 +39,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -47,7 +47,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins: []order.CoinID{
 				{
 					0x45, 0xb8, 0x21, 0x38, 0xca, 0x90, 0xe6, 0x65, 0xa1, 0xc8, 0x79, 0x3a,
@@ -66,7 +66,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 
 func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrder {
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -74,7 +74,7 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     true,
 			Quantity: quantityLots * LotSize,
@@ -85,7 +85,7 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 
 func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.MarketOrder {
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -93,7 +93,7 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     false,
 			Quantity: quantityQuoteAsset,
@@ -104,7 +104,7 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 
 func newCancelOrder(targetOrderID order.OrderID, base, quote uint32, timeOffset int64) *order.CancelOrder {
 	return &order.CancelOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  base,
 			QuoteAsset: quote,

--- a/server/market/integ/booker_matcher_test.go
+++ b/server/market/integ/booker_matcher_test.go
@@ -49,15 +49,15 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		MarketOrder: order.MarketOrder{
-			Prefix: order.Prefix{
-				AccountID:  acct0,
-				BaseAsset:  AssetDCR,
-				QuoteAsset: AssetBTC,
-				OrderType:  order.LimitOrderType,
-				ClientTime: time.Unix(1566497653+timeOffset, 0),
-				ServerTime: time.Unix(1566497656+timeOffset, 0),
-			},
+		Prefix: order.Prefix{
+			AccountID:  acct0,
+			BaseAsset:  AssetDCR,
+			QuoteAsset: AssetBTC,
+			OrderType:  order.LimitOrderType,
+			ClientTime: time.Unix(1566497653+timeOffset, 0),
+			ServerTime: time.Unix(1566497656+timeOffset, 0),
+		},
+		Trade: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     sell,
 			Quantity: quantityLots * LotSize,
@@ -78,10 +78,12 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Coins:    []order.CoinID{},
-		Sell:     true,
-		Quantity: quantityLots * LotSize,
-		Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+		Trade: order.Trade{
+			Coins:    []order.CoinID{},
+			Sell:     true,
+			Quantity: quantityLots * LotSize,
+			Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+		},
 	}
 }
 
@@ -95,10 +97,12 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Coins:    []order.CoinID{},
-		Sell:     false,
-		Quantity: quantityQuoteAsset,
-		Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+		Trade: order.Trade{
+			Coins:    []order.CoinID{},
+			Sell:     false,
+			Quantity: quantityQuoteAsset,
+			Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+		},
 	}
 }
 

--- a/server/market/integ/booker_matcher_test.go
+++ b/server/market/integ/booker_matcher_test.go
@@ -49,7 +49,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -57,7 +57,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     sell,
 			Quantity: quantityLots * LotSize,
@@ -70,7 +70,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 
 func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrder {
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -78,7 +78,7 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     true,
 			Quantity: quantityLots * LotSize,
@@ -89,7 +89,7 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 
 func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.MarketOrder {
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -97,7 +97,7 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     false,
 			Quantity: quantityQuoteAsset,
@@ -611,7 +611,7 @@ func TestMatchWithBook_limitsOnly_multipleQueued(t *testing.T) {
 
 func newCancelOrder(targetOrderID order.OrderID, serverTime time.Time) *order.CancelOrder {
 	return &order.CancelOrder{
-		Prefix:        order.Prefix{ServerTime: serverTime},
+		P:             order.Prefix{ServerTime: serverTime},
 		TargetOrderID: targetOrderID,
 	}
 }
@@ -1075,9 +1075,9 @@ func TestMatch_marketBuysOnly(t *testing.T) {
 				if !reflect.DeepEqual(matches[i], tt.wantMatches[i]) {
 					t.Errorf("matches[%d] = %v, want %v", i, matches[i], tt.wantMatches[i])
 				}
-				if matches[i].Taker.Remaining() != tt.remaining[i] {
+				if matches[i].Taker.Trade().Remaining() != tt.remaining[i] {
 					t.Errorf("Incorrect taker order amount remaining. Expected %d, got %d",
-						tt.remaining[i], matches[i].Taker.Remaining())
+						tt.remaining[i], matches[i].Taker.Trade().Remaining())
 				}
 			}
 			if len(passed) != tt.wantNumPassed {

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -395,7 +395,7 @@ func (m *Market) coinsLocked(o order.Order) []order.CoinID {
 	}
 
 	locker := m.coinLockerQuote
-	if o.IsSell() {
+	if o.Trade().Trade().Sell {
 		locker = m.coinLockerBase
 	}
 
@@ -406,7 +406,7 @@ func (m *Market) coinsLocked(o order.Order) []order.CoinID {
 	}
 
 	// Check the individual coins.
-	for _, coin := range o.CoinIDs() {
+	for _, coin := range o.Trade().Coins {
 		if locker.CoinLocked(coin) {
 			lockedCoins = append(lockedCoins, coin)
 		}
@@ -419,7 +419,7 @@ func (m *Market) lockOrderCoins(o order.Order) {
 		return
 	}
 
-	if o.IsSell() {
+	if o.Trade().Sell {
 		m.coinLockerBase.LockOrdersCoins([]order.Order{o})
 	} else {
 		m.coinLockerQuote.LockOrdersCoins([]order.Order{o})
@@ -431,7 +431,7 @@ func (m *Market) unlockOrderCoins(o order.Order) {
 		return
 	}
 
-	if o.IsSell() {
+	if o.Trade().Sell {
 		m.coinLockerBase.UnlockOrderCoins(o.ID())
 	} else {
 		m.coinLockerQuote.UnlockOrderCoins(o.ID())

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -211,14 +211,14 @@ func TestMarket_runEpochs(t *testing.T) {
 
 	newLimit := func() *order.LimitOrder {
 		return &order.LimitOrder{
-			Prefix: order.Prefix{
+			P: order.Prefix{
 				AccountID:  aid,
 				BaseAsset:  limit.Base,
 				QuoteAsset: limit.Quote,
 				OrderType:  order.LimitOrderType,
 				ClientTime: now,
 			},
-			Trade: order.Trade{
+			T: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     true,
 				Quantity: limit.Quantity,
@@ -459,14 +459,14 @@ func TestMarket_Cancelable(t *testing.T) {
 
 	newLimit := func() *order.LimitOrder {
 		return &order.LimitOrder{
-			Prefix: order.Prefix{
+			P: order.Prefix{
 				AccountID:  aid,
 				BaseAsset:  limitMsg.Base,
 				QuoteAsset: limitMsg.Quote,
 				OrderType:  order.LimitOrderType,
 				ClientTime: now,
 			},
-			Trade: order.Trade{
+			T: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     true,
 				Quantity: limitMsg.Quantity,

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -211,14 +211,14 @@ func TestMarket_runEpochs(t *testing.T) {
 
 	newLimit := func() *order.LimitOrder {
 		return &order.LimitOrder{
-			MarketOrder: order.MarketOrder{
-				Prefix: order.Prefix{
-					AccountID:  aid,
-					BaseAsset:  limit.Base,
-					QuoteAsset: limit.Quote,
-					OrderType:  order.LimitOrderType,
-					ClientTime: now,
-				},
+			Prefix: order.Prefix{
+				AccountID:  aid,
+				BaseAsset:  limit.Base,
+				QuoteAsset: limit.Quote,
+				OrderType:  order.LimitOrderType,
+				ClientTime: now,
+			},
+			Trade: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     true,
 				Quantity: limit.Quantity,
@@ -459,14 +459,14 @@ func TestMarket_Cancelable(t *testing.T) {
 
 	newLimit := func() *order.LimitOrder {
 		return &order.LimitOrder{
-			MarketOrder: order.MarketOrder{
-				Prefix: order.Prefix{
-					AccountID:  aid,
-					BaseAsset:  limitMsg.Base,
-					QuoteAsset: limitMsg.Quote,
-					OrderType:  order.LimitOrderType,
-					ClientTime: now,
-				},
+			Prefix: order.Prefix{
+				AccountID:  aid,
+				BaseAsset:  limitMsg.Base,
+				QuoteAsset: limitMsg.Quote,
+				OrderType:  order.LimitOrderType,
+				ClientTime: now,
+			},
+			Trade: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     true,
 				Quantity: limitMsg.Quantity,

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -197,7 +197,7 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 
 	// Create the limit order
 	lo := &order.LimitOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  user,
 			BaseAsset:  limit.Base,
 			QuoteAsset: limit.Quote,
@@ -205,7 +205,7 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 			ClientTime: order.UnixTimeMilli(int64(limit.ClientTime)),
 			//ServerTime set in epoch queue processing pipeline.
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    utxos,
 			Sell:     sell,
 			Quantity: limit.Quantity,
@@ -287,7 +287,7 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 	clientTime := order.UnixTimeMilli(int64(market.ClientTime))
 	serverTime := time.Now().Truncate(time.Millisecond).UTC()
 	mo := &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  user,
 			BaseAsset:  market.Base,
 			QuoteAsset: market.Quote,
@@ -295,7 +295,7 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 			ClientTime: clientTime,
 			ServerTime: serverTime,
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    coins,
 			Sell:     sell,
 			Quantity: market.Quantity,
@@ -360,7 +360,7 @@ func (r *OrderRouter) handleCancel(user account.AccountID, msg *msgjson.Message)
 	clientTime := order.UnixTimeMilli(int64(cancel.ClientTime))
 	serverTime := time.Now().Truncate(time.Millisecond).UTC()
 	co := &order.CancelOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  user,
 			BaseAsset:  cancel.Base,
 			QuoteAsset: cancel.Quote,

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -197,15 +197,15 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 
 	// Create the limit order
 	lo := &order.LimitOrder{
-		MarketOrder: order.MarketOrder{
-			Prefix: order.Prefix{
-				AccountID:  user,
-				BaseAsset:  limit.Base,
-				QuoteAsset: limit.Quote,
-				OrderType:  order.LimitOrderType,
-				ClientTime: order.UnixTimeMilli(int64(limit.ClientTime)),
-				//ServerTime set in epoch queue processing pipeline.
-			},
+		Prefix: order.Prefix{
+			AccountID:  user,
+			BaseAsset:  limit.Base,
+			QuoteAsset: limit.Quote,
+			OrderType:  order.LimitOrderType,
+			ClientTime: order.UnixTimeMilli(int64(limit.ClientTime)),
+			//ServerTime set in epoch queue processing pipeline.
+		},
+		Trade: order.Trade{
 			Coins:    utxos,
 			Sell:     sell,
 			Quantity: limit.Quantity,
@@ -295,10 +295,12 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 			ClientTime: clientTime,
 			ServerTime: serverTime,
 		},
-		Coins:    coins,
-		Sell:     sell,
-		Quantity: market.Quantity,
-		Address:  market.Address,
+		Trade: order.Trade{
+			Coins:    coins,
+			Sell:     sell,
+			Quantity: market.Quantity,
+			Address:  market.Address,
+		},
 	}
 
 	// Send the order to the epoch queue.

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -504,14 +504,14 @@ func TestLimit(t *testing.T) {
 	// Create the order manually, so that we can compare the IDs as another check
 	// of equivalence.
 	lo := &order.LimitOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  user.acct,
 			BaseAsset:  limit.Base,
 			QuoteAsset: limit.Quote,
 			OrderType:  order.LimitOrderType,
 			ClientTime: clientTime,
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Sell:     false,
 			Quantity: qty,
 			Address:  dcrAddr,
@@ -636,14 +636,14 @@ func TestMarketStartProcessStop(t *testing.T) {
 	// Create the order manually, so that we can compare the IDs as another check
 	// of equivalence.
 	mo := &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  user.acct,
 			BaseAsset:  mkt.Base,
 			QuoteAsset: mkt.Quote,
 			OrderType:  order.MarketOrderType,
 			ClientTime: clientTime,
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Sell:     false,
 			Quantity: qty,
 			Address:  dcrAddr,
@@ -750,7 +750,7 @@ func TestCancel(t *testing.T) {
 	// Create the order manually, so that we can compare the IDs as another check
 	// of equivalence.
 	co := &order.CancelOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  user.acct,
 			BaseAsset:  cancel.Base,
 			QuoteAsset: cancel.Quote,
@@ -1130,7 +1130,7 @@ func TestRouter(t *testing.T) {
 	}
 
 	compareTrade := func(msgOrder *msgjson.BookOrderNote, ord order.Order, tag string) {
-		prefix, trade := ord.Parts()
+		prefix, trade := ord.Prefix(), ord.Trade()
 		if trade.Sell != (msgOrder.Side == msgjson.SellOrderNum) {
 			t.Fatalf("%s: message order has wrong side marked. sell = %t, side = '%d'", tag, trade.Sell, msgOrder.Side)
 		}

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -504,16 +504,14 @@ func TestLimit(t *testing.T) {
 	// Create the order manually, so that we can compare the IDs as another check
 	// of equivalence.
 	lo := &order.LimitOrder{
-		MarketOrder: order.MarketOrder{
-			Prefix: order.Prefix{
-				AccountID:  user.acct,
-				BaseAsset:  limit.Base,
-				QuoteAsset: limit.Quote,
-				OrderType:  order.LimitOrderType,
-				ClientTime: clientTime,
-				// ServerTime: sTime,
-			},
-			// UTXOs:    []order.Outpoint{},
+		Prefix: order.Prefix{
+			AccountID:  user.acct,
+			BaseAsset:  limit.Base,
+			QuoteAsset: limit.Quote,
+			OrderType:  order.LimitOrderType,
+			ClientTime: clientTime,
+		},
+		Trade: order.Trade{
 			Sell:     false,
 			Quantity: qty,
 			Address:  dcrAddr,
@@ -644,12 +642,12 @@ func TestMarketStartProcessStop(t *testing.T) {
 			QuoteAsset: mkt.Quote,
 			OrderType:  order.MarketOrderType,
 			ClientTime: clientTime,
-			// ServerTime: sTime,
 		},
-		// UTXOs:    []order.Outpoint{},
-		Sell:     false,
-		Quantity: qty,
-		Address:  dcrAddr,
+		Trade: order.Trade{
+			Sell:     false,
+			Quantity: qty,
+			Address:  dcrAddr,
+		},
 	}
 	// Get the last order submitted to the epoch
 	oRecord := oRig.market.pop()
@@ -1131,15 +1129,16 @@ func TestRouter(t *testing.T) {
 		return findOrder(id, src.buys, src.sells)
 	}
 
-	compareMO := func(msgOrder *msgjson.BookOrderNote, mo *order.MarketOrder, tag string) {
-		if mo.Sell != (msgOrder.Side == msgjson.SellOrderNum) {
-			t.Fatalf("%s: message order has wrong side marked. sell = %t, side = '%d'", tag, mo.Sell, msgOrder.Side)
+	compareTrade := func(msgOrder *msgjson.BookOrderNote, ord order.Order, tag string) {
+		prefix, trade := ord.Parts()
+		if trade.Sell != (msgOrder.Side == msgjson.SellOrderNum) {
+			t.Fatalf("%s: message order has wrong side marked. sell = %t, side = '%d'", tag, trade.Sell, msgOrder.Side)
 		}
-		if msgOrder.Quantity != mo.Remaining() {
-			t.Fatalf("%s: message order quantity incorrect. expected %d, got %d", tag, mo.Quantity, msgOrder.Quantity)
+		if msgOrder.Quantity != trade.Remaining() {
+			t.Fatalf("%s: message order quantity incorrect. expected %d, got %d", tag, trade.Quantity, msgOrder.Quantity)
 		}
-		if msgOrder.Time != uint64(mo.Time()) {
-			t.Fatalf("%s: wrong time. expected %d, got %d", tag, mo.Time(), msgOrder.Time)
+		if msgOrder.Time != uint64(prefix.Time()) {
+			t.Fatalf("%s: wrong time. expected %d, got %d", tag, prefix.Time(), msgOrder.Time)
 		}
 	}
 
@@ -1150,7 +1149,7 @@ func TestRouter(t *testing.T) {
 		if msgOrder.TiF != tifFlag {
 			t.Fatalf("%s: message order has wrong time-in-force flag. wanted %d, got %d", tag, tifFlag, msgOrder.TiF)
 		}
-		compareMO(msgOrder, &lo.MarketOrder, tag)
+		compareTrade(msgOrder, lo, tag)
 	}
 
 	// A helper function to scan through the received msgjson.OrderBook.Orders and
@@ -1226,10 +1225,10 @@ func TestRouter(t *testing.T) {
 	tick(5)
 
 	epochNote = getEpochNoteFromLink(t, link1)
-	compareMO(&epochNote.BookOrderNote, mo, "link 1 market 2 epoch update (market order)")
+	compareTrade(&epochNote.BookOrderNote, mo, "link 1 market 2 epoch update (market order)")
 
 	epochNote = getEpochNoteFromLink(t, link2)
-	compareMO(&epochNote.BookOrderNote, mo, "link 2 market 2 epoch update (market order)")
+	compareTrade(&epochNote.BookOrderNote, mo, "link 2 market 2 epoch update (market order)")
 
 	// Grab a random order from the market 2 sell book. Fill 1 lot and send a
 	// bookAction update.

--- a/server/matcher/match.go
+++ b/server/matcher/match.go
@@ -285,9 +285,10 @@ func matchMarketSellOrder(book Booker, ord *order.MarketOrder) (matchSet *order.
 	// A market sell order is a special case of a limit order with time-in-force
 	// immediate and no minimum rate (a rate of 0).
 	limOrd := &order.LimitOrder{
-		MarketOrder: *ord,
-		Force:       order.ImmediateTiF,
-		Rate:        0,
+		Prefix: ord.Prefix,
+		Trade:  ord.Trade,
+		Force:  order.ImmediateTiF,
+		Rate:   0,
 	}
 	matchSet = matchLimitOrder(book, limOrd)
 	if matchSet == nil {

--- a/server/matcher/match_test.go
+++ b/server/matcher/match_test.go
@@ -43,10 +43,12 @@ var (
 				ClientTime: time.Unix(1566497653, 0),
 				ServerTime: time.Unix(1566497656, 0),
 			},
-			Coins:    []order.CoinID{},
-			Sell:     false,
-			Quantity: 4 * LotSize,
-			Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+			Trade: order.Trade{
+				Coins:    []order.CoinID{},
+				Sell:     false,
+				Quantity: 4 * LotSize,
+				Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+			},
 		},
 		{ // market SELL of 2 lots
 			Prefix: order.Prefix{
@@ -57,24 +59,26 @@ var (
 				ClientTime: time.Unix(1566497654, 0),
 				ServerTime: time.Unix(1566497656, 0),
 			},
-			Coins:    []order.CoinID{},
-			Sell:     true,
-			Quantity: 2 * LotSize,
-			Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+			Trade: order.Trade{
+				Coins:    []order.CoinID{},
+				Sell:     true,
+				Quantity: 2 * LotSize,
+				Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+			},
 		},
 	}
 
 	limitOrders = []*order.LimitOrder{
 		{ // limit BUY of 2 lots at 0.043
-			MarketOrder: order.MarketOrder{
-				Prefix: order.Prefix{
-					AccountID:  acct0,
-					BaseAsset:  AssetDCR,
-					QuoteAsset: AssetBTC,
-					OrderType:  order.LimitOrderType,
-					ClientTime: time.Unix(1566497653, 0),
-					ServerTime: time.Unix(1566497656, 0),
-				},
+			Prefix: order.Prefix{
+				AccountID:  acct0,
+				BaseAsset:  AssetDCR,
+				QuoteAsset: AssetBTC,
+				OrderType:  order.LimitOrderType,
+				ClientTime: time.Unix(1566497653, 0),
+				ServerTime: time.Unix(1566497656, 0),
+			},
+			Trade: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     false,
 				Quantity: 2 * LotSize,
@@ -84,15 +88,15 @@ var (
 			Force: order.StandingTiF,
 		},
 		{ // limit SELL of 3 lots at 0.045
-			MarketOrder: order.MarketOrder{
-				Prefix: order.Prefix{
-					AccountID:  acct0,
-					BaseAsset:  AssetDCR,
-					QuoteAsset: AssetBTC,
-					OrderType:  order.LimitOrderType,
-					ClientTime: time.Unix(1566497651, 0),
-					ServerTime: time.Unix(1566497652, 0),
-				},
+			Prefix: order.Prefix{
+				AccountID:  acct0,
+				BaseAsset:  AssetDCR,
+				QuoteAsset: AssetBTC,
+				OrderType:  order.LimitOrderType,
+				ClientTime: time.Unix(1566497651, 0),
+				ServerTime: time.Unix(1566497652, 0),
+			},
+			Trade: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     true,
 				Quantity: 3 * LotSize,
@@ -102,15 +106,15 @@ var (
 			Force: order.StandingTiF,
 		},
 		{ // limit BUY of 1 lot at 0.046
-			MarketOrder: order.MarketOrder{
-				Prefix: order.Prefix{
-					AccountID:  acct0,
-					BaseAsset:  AssetDCR,
-					QuoteAsset: AssetBTC,
-					OrderType:  order.LimitOrderType,
-					ClientTime: time.Unix(1566497655, 0),
-					ServerTime: time.Unix(1566497656, 0),
-				},
+			Prefix: order.Prefix{
+				AccountID:  acct0,
+				BaseAsset:  AssetDCR,
+				QuoteAsset: AssetBTC,
+				OrderType:  order.LimitOrderType,
+				ClientTime: time.Unix(1566497655, 0),
+				ServerTime: time.Unix(1566497656, 0),
+			},
+			Trade: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     false,
 				Quantity: 1 * LotSize,
@@ -120,15 +124,15 @@ var (
 			Force: order.StandingTiF,
 		},
 		{ // limit BUY of 1 lot at 0.045
-			MarketOrder: order.MarketOrder{
-				Prefix: order.Prefix{
-					AccountID:  acct0,
-					BaseAsset:  AssetDCR,
-					QuoteAsset: AssetBTC,
-					OrderType:  order.LimitOrderType,
-					ClientTime: time.Unix(1566497649, 0),
-					ServerTime: time.Unix(1566497651, 0),
-				},
+			Prefix: order.Prefix{
+				AccountID:  acct0,
+				BaseAsset:  AssetDCR,
+				QuoteAsset: AssetBTC,
+				OrderType:  order.LimitOrderType,
+				ClientTime: time.Unix(1566497649, 0),
+				ServerTime: time.Unix(1566497651, 0),
+			},
+			Trade: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     false,
 				Quantity: 1 * LotSize,
@@ -210,15 +214,15 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		MarketOrder: order.MarketOrder{
-			Prefix: order.Prefix{
-				AccountID:  acct0,
-				BaseAsset:  AssetDCR,
-				QuoteAsset: AssetBTC,
-				OrderType:  order.LimitOrderType,
-				ClientTime: time.Unix(1566497653+timeOffset, 0),
-				ServerTime: time.Unix(1566497656+timeOffset, 0),
-			},
+		Prefix: order.Prefix{
+			AccountID:  acct0,
+			BaseAsset:  AssetDCR,
+			QuoteAsset: AssetBTC,
+			OrderType:  order.LimitOrderType,
+			ClientTime: time.Unix(1566497653+timeOffset, 0),
+			ServerTime: time.Unix(1566497656+timeOffset, 0),
+		},
+		Trade: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     sell,
 			Quantity: quantityLots * LotSize,
@@ -239,10 +243,12 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Coins:    []order.CoinID{},
-		Sell:     true,
-		Quantity: quantityLots * LotSize,
-		Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+		Trade: order.Trade{
+			Coins:    []order.CoinID{},
+			Sell:     true,
+			Quantity: quantityLots * LotSize,
+			Address:  "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm",
+		},
 	}
 }
 
@@ -256,10 +262,12 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Coins:    []order.CoinID{},
-		Sell:     false,
-		Quantity: quantityQuoteAsset,
-		Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+		Trade: order.Trade{
+			Coins:    []order.CoinID{},
+			Sell:     false,
+			Quantity: quantityQuoteAsset,
+			Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
+		},
 	}
 }
 

--- a/server/matcher/match_test.go
+++ b/server/matcher/match_test.go
@@ -35,7 +35,7 @@ func startLogger() {
 var (
 	marketOrders = []*order.MarketOrder{
 		{ // market BUY of 4 lots
-			Prefix: order.Prefix{
+			P: order.Prefix{
 				AccountID:  acct0,
 				BaseAsset:  AssetDCR,
 				QuoteAsset: AssetBTC,
@@ -43,7 +43,7 @@ var (
 				ClientTime: time.Unix(1566497653, 0),
 				ServerTime: time.Unix(1566497656, 0),
 			},
-			Trade: order.Trade{
+			T: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     false,
 				Quantity: 4 * LotSize,
@@ -51,7 +51,7 @@ var (
 			},
 		},
 		{ // market SELL of 2 lots
-			Prefix: order.Prefix{
+			P: order.Prefix{
 				AccountID:  acct0,
 				BaseAsset:  AssetDCR,
 				QuoteAsset: AssetBTC,
@@ -59,7 +59,7 @@ var (
 				ClientTime: time.Unix(1566497654, 0),
 				ServerTime: time.Unix(1566497656, 0),
 			},
-			Trade: order.Trade{
+			T: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     true,
 				Quantity: 2 * LotSize,
@@ -70,7 +70,7 @@ var (
 
 	limitOrders = []*order.LimitOrder{
 		{ // limit BUY of 2 lots at 0.043
-			Prefix: order.Prefix{
+			P: order.Prefix{
 				AccountID:  acct0,
 				BaseAsset:  AssetDCR,
 				QuoteAsset: AssetBTC,
@@ -78,7 +78,7 @@ var (
 				ClientTime: time.Unix(1566497653, 0),
 				ServerTime: time.Unix(1566497656, 0),
 			},
-			Trade: order.Trade{
+			T: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     false,
 				Quantity: 2 * LotSize,
@@ -88,7 +88,7 @@ var (
 			Force: order.StandingTiF,
 		},
 		{ // limit SELL of 3 lots at 0.045
-			Prefix: order.Prefix{
+			P: order.Prefix{
 				AccountID:  acct0,
 				BaseAsset:  AssetDCR,
 				QuoteAsset: AssetBTC,
@@ -96,7 +96,7 @@ var (
 				ClientTime: time.Unix(1566497651, 0),
 				ServerTime: time.Unix(1566497652, 0),
 			},
-			Trade: order.Trade{
+			T: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     true,
 				Quantity: 3 * LotSize,
@@ -106,7 +106,7 @@ var (
 			Force: order.StandingTiF,
 		},
 		{ // limit BUY of 1 lot at 0.046
-			Prefix: order.Prefix{
+			P: order.Prefix{
 				AccountID:  acct0,
 				BaseAsset:  AssetDCR,
 				QuoteAsset: AssetBTC,
@@ -114,7 +114,7 @@ var (
 				ClientTime: time.Unix(1566497655, 0),
 				ServerTime: time.Unix(1566497656, 0),
 			},
-			Trade: order.Trade{
+			T: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     false,
 				Quantity: 1 * LotSize,
@@ -124,7 +124,7 @@ var (
 			Force: order.StandingTiF,
 		},
 		{ // limit BUY of 1 lot at 0.045
-			Prefix: order.Prefix{
+			P: order.Prefix{
 				AccountID:  acct0,
 				BaseAsset:  AssetDCR,
 				QuoteAsset: AssetBTC,
@@ -132,7 +132,7 @@ var (
 				ClientTime: time.Unix(1566497649, 0),
 				ServerTime: time.Unix(1566497651, 0),
 			},
-			Trade: order.Trade{
+			T: order.Trade{
 				Coins:    []order.CoinID{},
 				Sell:     false,
 				Quantity: 1 * LotSize,
@@ -214,7 +214,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
 	}
 	return &order.LimitOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -222,7 +222,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     sell,
 			Quantity: quantityLots * LotSize,
@@ -235,7 +235,7 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 
 func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrder {
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -243,7 +243,7 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     true,
 			Quantity: quantityLots * LotSize,
@@ -254,7 +254,7 @@ func newMarketSellOrder(quantityLots uint64, timeOffset int64) *order.MarketOrde
 
 func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.MarketOrder {
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  acct0,
 			BaseAsset:  AssetDCR,
 			QuoteAsset: AssetBTC,
@@ -262,7 +262,7 @@ func newMarketBuyOrder(quantityQuoteAsset uint64, timeOffset int64) *order.Marke
 			ClientTime: time.Unix(1566497653+timeOffset, 0),
 			ServerTime: time.Unix(1566497656+timeOffset, 0),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Coins:    []order.CoinID{},
 			Sell:     false,
 			Quantity: quantityQuoteAsset,
@@ -451,7 +451,7 @@ func Test_matchLimitOrder(t *testing.T) {
 
 func newCancelOrder(targetOrderID order.OrderID, serverTime time.Time) *order.CancelOrder {
 	return &order.CancelOrder{
-		Prefix:        order.Prefix{ServerTime: serverTime},
+		P:             order.Prefix{ServerTime: serverTime},
 		TargetOrderID: targetOrderID,
 	}
 }
@@ -1112,9 +1112,9 @@ func TestMatch_marketBuysOnly(t *testing.T) {
 				if !reflect.DeepEqual(matches[i], tt.wantMatches[i]) {
 					t.Errorf("matches[%d] = %v, want %v", i, matches[i], tt.wantMatches[i])
 				}
-				if matches[i].Taker.Remaining() != tt.remaining[i] {
+				if matches[i].Taker.Trade().Remaining() != tt.remaining[i] {
 					t.Errorf("Incorrect taker order amount remaining. Expected %d, got %d",
-						tt.remaining[i], matches[i].Taker.Remaining())
+						tt.remaining[i], matches[i].Taker.Trade().Remaining())
 				}
 			}
 			if len(passed) != tt.wantNumPassed {

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -738,7 +738,7 @@ func (rig *testRig) checkRedeem(msg *msgjson.Message, oid string, coinID []byte,
 
 func makeCancelOrder(limitOrder *order.LimitOrder, user *tUser) *order.CancelOrder {
 	return &order.CancelOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  user.acct,
 			BaseAsset:  limitOrder.BaseAsset,
 			QuoteAsset: limitOrder.QuoteAsset,
@@ -752,7 +752,7 @@ func makeCancelOrder(limitOrder *order.LimitOrder, user *tUser) *order.CancelOrd
 
 func makeLimitOrder(qty, rate uint64, user *tUser, makerSell bool) *order.LimitOrder {
 	return &order.LimitOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  user.acct,
 			BaseAsset:  ABCID,
 			QuoteAsset: XYZID,
@@ -760,7 +760,7 @@ func makeLimitOrder(qty, rate uint64, user *tUser, makerSell bool) *order.LimitO
 			ClientTime: order.UnixTimeMilli(1566497654000),
 			ServerTime: order.UnixTimeMilli(1566497655000),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Sell:     makerSell,
 			Quantity: qty,
 			Address:  user.addr,
@@ -771,7 +771,7 @@ func makeLimitOrder(qty, rate uint64, user *tUser, makerSell bool) *order.LimitO
 
 func makeMarketOrder(qty uint64, user *tUser, makerSell bool) *order.MarketOrder {
 	return &order.MarketOrder{
-		Prefix: order.Prefix{
+		P: order.Prefix{
 			AccountID:  user.acct,
 			BaseAsset:  ABCID,
 			QuoteAsset: XYZID,
@@ -779,7 +779,7 @@ func makeMarketOrder(qty uint64, user *tUser, makerSell bool) *order.MarketOrder
 			ClientTime: order.UnixTimeMilli(1566497654000),
 			ServerTime: order.UnixTimeMilli(1566497655000),
 		},
-		Trade: order.Trade{
+		T: order.Trade{
 			Sell:     makerSell,
 			Quantity: qty,
 			Address:  user.addr,

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -752,15 +752,15 @@ func makeCancelOrder(limitOrder *order.LimitOrder, user *tUser) *order.CancelOrd
 
 func makeLimitOrder(qty, rate uint64, user *tUser, makerSell bool) *order.LimitOrder {
 	return &order.LimitOrder{
-		MarketOrder: order.MarketOrder{
-			Prefix: order.Prefix{
-				AccountID:  user.acct,
-				BaseAsset:  ABCID,
-				QuoteAsset: XYZID,
-				OrderType:  order.LimitOrderType,
-				ClientTime: order.UnixTimeMilli(1566497654000),
-				ServerTime: order.UnixTimeMilli(1566497655000),
-			},
+		Prefix: order.Prefix{
+			AccountID:  user.acct,
+			BaseAsset:  ABCID,
+			QuoteAsset: XYZID,
+			OrderType:  order.LimitOrderType,
+			ClientTime: order.UnixTimeMilli(1566497654000),
+			ServerTime: order.UnixTimeMilli(1566497655000),
+		},
+		Trade: order.Trade{
 			Sell:     makerSell,
 			Quantity: qty,
 			Address:  user.addr,
@@ -779,9 +779,11 @@ func makeMarketOrder(qty uint64, user *tUser, makerSell bool) *order.MarketOrder
 			ClientTime: order.UnixTimeMilli(1566497654000),
 			ServerTime: order.UnixTimeMilli(1566497655000),
 		},
-		Sell:     makerSell,
-		Quantity: qty,
-		Address:  user.addr,
+		Trade: order.Trade{
+			Sell:     makerSell,
+			Quantity: qty,
+			Address:  user.addr,
+		},
 	}
 }
 


### PR DESCRIPTION
 A change to the order structs to embed a type called `Trade` with common field for limit and market orders. This cleans up `Order` interface so there is now only one method that accesses non-prefix data. 