### PR TITLE
server/asset: fix asset backend stutters

### DIFF
--- a/dex/asset.go
+++ b/dex/asset.go
@@ -29,7 +29,7 @@ const Simnet = Regtest
 // through the provided logger.
 type Logger = slog.Logger
 
-// Type Asset combines the DEXAsset backend with the configurable asset
+// Type Asset combines the Backend with the configurable asset
 // variables. The asset variables do not affect the backend operation, but are
 // grouped with the backend for convenience.
 type Asset struct {

--- a/dex/asset.go
+++ b/dex/asset.go
@@ -29,9 +29,7 @@ const Simnet = Regtest
 // through the provided logger.
 type Logger = slog.Logger
 
-// Type Asset combines the Backend with the configurable asset
-// variables. The asset variables do not affect the backend operation, but are
-// grouped with the backend for convenience.
+// Asset is the configurable asset variables.
 type Asset struct {
 	ID       uint32
 	Symbol   string

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -49,7 +49,7 @@ type btcNode interface {
 
 // Backend is an dex backend for Bitcoin. It has methods for fetching UTXO
 // information and subscribing to block updates. It maintains a cache of block
-// data for quick lookups. Backend implements asset.DEXAsset, so provides
+// data for quick lookups. Backend implements asset.Backend, so provides
 // exported methods for DEX-related blockchain info.
 type Backend struct {
 	// An application context provided as part of the constructor. The Backend
@@ -74,14 +74,14 @@ type Backend struct {
 	log dex.Logger
 }
 
-// Check that Backend satisfies the DEXAsset interface.
-var _ asset.DEXAsset = (*Backend)(nil)
+// Check that Backend satisfies the Backend interface.
+var _ asset.Backend = (*Backend)(nil)
 
 // NewBackend is the exported constructor by which the DEX will import the
 // backend. The provided context.Context should be cancelled when the DEX
 // application exits. The configPath can be an empty string, in which case the
 // standard system location of the bitcoind config file is assumed.
-func NewBackend(ctx context.Context, configPath string, logger dex.Logger, network dex.Network) (asset.DEXAsset, error) {
+func NewBackend(ctx context.Context, configPath string, logger dex.Logger, network dex.Network) (asset.Backend, error) {
 	var params *chaincfg.Params
 	switch network {
 	case dex.Mainnet:
@@ -177,7 +177,7 @@ func ReadCloneParams(cloneParams interface{}) (*chaincfg.Params, error) {
 	return p, nil
 }
 
-// Coin is part of the asset.DEXAsset interface. See the unexported Backend.utxo
+// Coin is part of the asset.Backend interface. See the unexported Backend.utxo
 // method for the full implementation.
 func (btc *Backend) Coin(coinID []byte, redeemScript []byte) (asset.Coin, error) {
 	txHash, vout, err := decodeCoinID(coinID)
@@ -189,7 +189,7 @@ func (btc *Backend) Coin(coinID []byte, redeemScript []byte) (asset.Coin, error)
 
 // BlockChannel creates and returns a new channel on which to receive block
 // updates. If the returned channel is ever blocking, there will be no error
-// logged from the btc package. Part of the asset.DEXAsset interface.
+// logged from the btc package. Part of the asset.Backend interface.
 func (btc *Backend) BlockChannel(size int) chan uint32 {
 	c := make(chan uint32, size)
 	btc.signalMtx.Lock()
@@ -198,7 +198,7 @@ func (btc *Backend) BlockChannel(size int) chan uint32 {
 	return c
 }
 
-// InitTxSize is an asset.DEXAsset method that must produce the max size of a
+// InitTxSize is an asset.Backend method that must produce the max size of a
 // standardized atomic swap initialization transaction.
 func (btc *Backend) InitTxSize() uint32 {
 	return dexbtc.InitTxSize

--- a/server/asset/btc/live_test.go
+++ b/server/asset/btc/live_test.go
@@ -63,7 +63,7 @@ func TestMain(m *testing.M) {
 	var ok bool
 	btc, ok = dexAsset.(*Backend)
 	if !ok {
-		fmt.Printf("Could not cast DEXAsset to *Backend")
+		fmt.Printf("Could not cast asset.Backend to *Backend")
 		return
 	}
 	os.Exit(m.Run())
@@ -127,7 +127,7 @@ func TestLiveFees(t *testing.T) {
 }
 
 // This test does not pass yet.
-// type backendConstructor func(context.Context, string, asset.Logger, asset.Network) (asset.DEXAsset, error)
+// type backendConstructor func(context.Context, string, asset.Logger, asset.Network) (asset.Backend, error)
 //
 // // TestPlugin checks for a plugin file with the default name in the current
 // // directory.
@@ -158,11 +158,11 @@ func TestLiveFees(t *testing.T) {
 // 	defer shutdown()
 // 	dexAsset, err := constructor(ctx, SystemConfigPath("bitcoin"), logger, dex.Mainnet)
 // 	if err != nil {
-// 		t.Fatalf("error creating DEXAsset from imported constructor: %v", err)
+// 		t.Fatalf("error creating Backend from imported constructor: %v", err)
 // 	}
 // 	btc, ok := dexAsset.(*Backend)
 // 	if !ok {
-// 		t.Fatalf("failed to cast plugin DEXAsset to *Backend")
+// 		t.Fatalf("failed to cast plugin Backend to *Backend")
 // 	}
 // 	_, err = btc.node.GetBestBlockHash()
 // 	if err != nil {

--- a/server/asset/btc/utxo.go
+++ b/server/asset/btc/utxo.go
@@ -110,7 +110,7 @@ func (utxo *UTXO) Confirmations() (int64, error) {
 }
 
 // Auth verifies that the utxo pays to the supplied public key(s). This is an
-// asset.DEXAsset method.
+// asset.Backend method.
 func (utxo *UTXO) Auth(pubkeys, sigs [][]byte, msg []byte) error {
 	// If there are not enough pubkeys, no reason to check anything.
 	if len(pubkeys) < utxo.numSigs {
@@ -251,7 +251,7 @@ func (utxo *UTXO) ID() []byte {
 
 // TxID is a string identifier for the transaction, typically a hexadecimal
 // representation of the byte-reversed transaction hash. Should always return
-// the same value as the txid argument passed to (DEXAsset).UTXO.
+// the same value as the txid argument passed to (Backend).UTXO.
 func (utxo *UTXO) TxID() string {
 	return utxo.txHash.String()
 }

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -5,8 +5,8 @@ package asset
 
 import "decred.org/dcrdex/dex"
 
-// The DEXAsset interface is an interface for a blockchain backend.
-type DEXAsset interface {
+// The Backend interface is an interface for a blockchain backend.
+type Backend interface {
 	// Coin should return a Coin only for outputs that would be spendable on the
 	// blockchain immediately. Pay-to-script-hash Coins require the redeem script
 	// in order to calculate sigScript length and verify pubkeys.
@@ -56,8 +56,8 @@ type Coin interface {
 	Value() uint64
 }
 
-// BackedAsset is a dex.Asset with a DEXAsset backend.
+// BackedAsset is a dex.Asset with a Backend backend.
 type BackedAsset struct {
 	dex.Asset
-	Backend DEXAsset
+	Backend Backend
 }

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -56,7 +56,7 @@ type Coin interface {
 	Value() uint64
 }
 
-// BackedAsset is a dex.Asset with a Backend backend.
+// BackedAsset is a dex.Asset with a Backend.
 type BackedAsset struct {
 	dex.Asset
 	Backend Backend

--- a/server/asset/dcr/cache.go
+++ b/server/asset/dcr/cache.go
@@ -50,7 +50,7 @@ func (cache *blockCache) block(h *chainhash.Hash) (*dcrBlock, bool) {
 
 // Getter for a mainchain block by its height. This method does not attempt
 // to load the block from the blockchain if it is not found. If that is required
-// use (*DCRBackend).getMainchainDcrBlock.
+// use (*Backend).getMainchainDcrBlock.
 func (cache *blockCache) atHeight(height uint32) (*dcrBlock, bool) {
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -122,13 +122,13 @@ func TestLoadConfig(t *testing.T) {
 
 // The remaining tests use the testBlockchain which is a stub for
 // rpcclient.Client. UTXOs, transactions and blocks are added to the blockchain
-// as jsonrpc types to be requested by the DCRBackend.
+// as jsonrpc types to be requested by the Backend.
 //
 // General formula for testing
-// 1. Create a DCRBackend with the node field set to a testNode
+// 1. Create a Backend with the node field set to a testNode
 // 2. Create a fake UTXO and all of the associated jsonrpc-type blocks and
 //    transactions and add the to the test blockchain.
-// 3. Verify the DCRBackend and UTXO methods are returning whatever is expected.
+// 3. Verify the Backend and UTXO methods are returning whatever is expected.
 // 4. Optionally add more blocks and/or transactions to the blockchain and check
 //    return values again, as things near the top of the chain can change.
 
@@ -155,7 +155,7 @@ type testBlockChain struct {
 	hashes map[int64]*chainhash.Hash
 }
 
-// The testChain is a "blockchain" to store RPC responses for the DCRBackend
+// The testChain is a "blockchain" to store RPC responses for the Backend
 // node stub to request.
 var testChain testBlockChain
 
@@ -426,7 +426,7 @@ func newStakeP2PKHScript(opcode byte) ([]byte, *testAuth) {
 
 // A MsgTx for a regular transaction with a single output. No inputs, so it's
 // not really a valid transaction, but that's okay on testBlockchain and
-// irrelevant to DCRBackend.
+// irrelevant to Backend.
 func testMsgTxRegular(sigType dcrec.SignatureType) *testMsgTx {
 	pkScript, auth := newP2PKHScript(sigType)
 	msgTx := wire.NewMsgTx()
@@ -639,7 +639,7 @@ func testMsgTxRevocation() *testMsgTx {
 }
 
 // Make a backend that logs to stdout.
-func testBackend() (*DCRBackend, func()) {
+func testBackend() (*Backend, func()) {
 	ctx, shutdown := context.WithCancel(context.Background())
 	dcr := unconnectedDCR(ctx, testLogger)
 	dcr.node = testNode{}
@@ -667,7 +667,7 @@ func TestUTXOs(t *testing.T) {
 	// 11. A UTXO with a pay-to-script-hash for a P2PKH redeem script.
 	// 12. A revocation.
 
-	// Create a DCRBackend with the test node.
+	// Create a Backend with the test node.
 	dcr, shutdown := testBackend()
 	defer shutdown()
 
@@ -1039,7 +1039,7 @@ func TestUTXOs(t *testing.T) {
 // TestReorg sends a reorganization-causing block through the anyQ channel, and
 // checks that the cache is responding as expected.
 func TestReorg(t *testing.T) {
-	// Create a DCRBackend with the test node.
+	// Create a Backend with the test node.
 	dcr, shutdown := testBackend()
 	defer shutdown()
 
@@ -1129,7 +1129,7 @@ func TestReorg(t *testing.T) {
 // TestAuxiliary checks the UTXO convenience functions like TxHash, Vout, and
 // TxID.
 func TestAuxiliary(t *testing.T) {
-	// Create a DCRBackend with the test node.
+	// Create a Backend with the test node.
 	dcr, shutdown := testBackend()
 	defer shutdown()
 
@@ -1181,7 +1181,7 @@ func TestAuxiliary(t *testing.T) {
 // TestCheckAddress checks that addresses are parsing or not parsing as
 // expected.
 func TestCheckAddress(t *testing.T) {
-	dcr := &DCRBackend{}
+	dcr := &Backend{}
 	type test struct {
 		addr    string
 		wantErr bool

--- a/server/asset/dcr/live_test.go
+++ b/server/asset/dcr/live_test.go
@@ -8,7 +8,7 @@
 // -----------------------------------
 // This command will check the UTXO paths by iterating backwards through
 // the transactions in the mainchain, starting with mempool, and requesting
-// all found outputs through the DCRBackend.utxo method. All utxos must be
+// all found outputs through the Backend.utxo method. All utxos must be
 // found or found to be spent.
 //
 // go test -v -tags dcrlive -run CacheAdvantage
@@ -42,7 +42,7 @@ import (
 
 var (
 	dcrdConfigPath = filepath.Join(dcrdHomeDir, "dcrd.conf")
-	dcr            *DCRBackend
+	dcr            *Backend
 	testLogger     dex.Logger
 )
 
@@ -176,7 +176,7 @@ func TestLiveUTXO(t *testing.T) {
 				}
 				// Check if its an acceptable script type.
 				scriptTypeOK := scriptType != dexdcr.ScriptUnsupported
-				// Now try to get the UXO with the DCRBackend
+				// Now try to get the UTXO with the Backend
 				utxo, err := dcr.utxo(txHash, uint32(vout), nil)
 				// Can't do stakebase or cainbase.
 				// ToDo: Use a custom error and check it.

--- a/server/asset/dcr/tx.go
+++ b/server/asset/dcr/tx.go
@@ -41,7 +41,7 @@ type txOut struct {
 }
 
 // A getter for a new Tx.
-func newTransaction(dcr *DCRBackend, txHash, blockHash, lastLookup *chainhash.Hash, blockHeight int64,
+func newTransaction(dcr *Backend, txHash, blockHash, lastLookup *chainhash.Hash, blockHeight int64,
 	isStake bool, ins []txIn, outs []txOut, feeRate uint64) *Tx {
 	// Set a nil blockHash to the zero hash.
 	hash := blockHash

--- a/server/asset/dcr/utxo.go
+++ b/server/asset/dcr/utxo.go
@@ -18,8 +18,8 @@ import (
 // satisfy the asset.UTXO interface to be DEX-compatible.
 type UTXO struct {
 	// Because a UTXO's validity and block info can change after creation, keep a
-	// DCRBackend around to query the state of the tx and update the block info.
-	dcr *DCRBackend
+	// Backend around to query the state of the tx and update the block info.
+	dcr *Backend
 	tx  *Tx
 	// The height and hash of the transaction's best known block.
 	height    uint32
@@ -54,7 +54,7 @@ type UTXO struct {
 // Check that UTXO satisfies the asset.UTXO interface
 var _ asset.Coin = (*UTXO)(nil)
 
-// Confirmations is an asset.DEXAsset method that returns the number of
+// Confirmations is an asset.Backend method that returns the number of
 // confirmations for a UTXO. Because it is possible for a UTXO that was once
 // considered valid to later be considered invalid, this method can return
 // an error to indicate the UTXO is no longer valid. The definition of UTXO
@@ -134,7 +134,7 @@ func (utxo *UTXO) Confirmations() (int64, error) {
 }
 
 // Auth verifies that the utxo pays to the supplied public key(s). This is an
-// asset.DEXAsset method.
+// asset.Backend method.
 func (utxo *UTXO) Auth(pubkeys, sigs [][]byte, msg []byte) error {
 	if len(pubkeys) < utxo.numSigs {
 		return fmt.Errorf("not enough signatures for utxo %s:%d. expected %d, got %d", utxo.tx.hash, utxo.vout, utxo.numSigs, len(pubkeys))
@@ -274,7 +274,7 @@ func (utxo *UTXO) ID() []byte {
 
 // TxID is a string identifier for the transaction, typically a hexadecimal
 // representation of the byte-reversed transaction hash. Should always return
-// the same value as the txid argument passed to (DEXAsset).UTXO.
+// the same value as the txid argument passed to (Backend).UTXO.
 func (utxo *UTXO) TxID() string {
 	return utxo.tx.hash.String()
 }

--- a/server/asset/ltc/live_test.go
+++ b/server/asset/ltc/live_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 	var ok bool
 	ltc, ok = dexAsset.(*btc.Backend)
 	if !ok {
-		fmt.Printf("Could not cast DEXAsset to *Backend")
+		fmt.Printf("Could not cast asset.Backend to *Backend")
 		return
 	}
 	os.Exit(m.Run())

--- a/server/asset/ltc/ltc.go
+++ b/server/asset/ltc/ltc.go
@@ -16,7 +16,7 @@ import (
 
 // NewBackend generates the network parameters and creates a ltc backend as a
 // btc clone using an asset/btc helper function.
-func NewBackend(ctx context.Context, configPath string, logger dex.Logger, network dex.Network) (asset.DEXAsset, error) {
+func NewBackend(ctx context.Context, configPath string, logger dex.Logger, network dex.Network) (asset.Backend, error) {
 	var params *chaincfg.Params
 	switch network {
 	case dex.Mainnet:

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -45,7 +45,7 @@ type Signer interface {
 }
 
 // FeeChecker is a function for retreiving the details for a fee payment. It
-// is satisfied by (dcr.DCRBackend).P2PKHDetails.
+// is satisfied by (dcr.Backend).P2PKHDetails.
 type FeeChecker func(coinID []byte) (addr string, val uint64, confs int64, err error)
 
 // A respHandler is the handler for the response to a DEX-originating request. A

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -29,7 +29,7 @@ const (
 	AssetBTC = 0
 )
 
-// This stub satisfies asset.DEXAsset.
+// This stub satisfies asset.Backend.
 type TAsset struct{}
 
 func (a *TAsset) Coin(coinID []byte, redeemScript []byte) (asset.Coin, error) {

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -82,7 +82,7 @@ type matchTracker struct {
 	takerStatus *swapStatus
 }
 
-// A blockNotification is used internally when an asset.DEXAsset reports a new
+// A blockNotification is used internally when an asset.Backend reports a new
 // block.
 type blockNotification struct {
 	time    time.Time

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -212,7 +212,7 @@ type TStorage struct{}
 func (s *TStorage) UpdateMatch(match *order.Match) error { return nil }
 func (s *TStorage) CancelOrder(*order.LimitOrder) error  { return nil }
 
-// This stub satisfies asset.DEXAsset.
+// This stub satisfies asset.Backend.
 type TAsset struct {
 	mtx     sync.RWMutex
 	coin    asset.Coin
@@ -243,7 +243,7 @@ func (a *TAsset) setCoinErr(err error) {
 	a.coinErr = err
 }
 
-// This stub satisfies asset.Transaction, used by asset.DEXAsset.
+// This stub satisfies asset.Transaction, used by asset.Backend.
 type TCoin struct {
 	mtx       sync.RWMutex
 	id        []byte
@@ -301,7 +301,7 @@ func (coin *TCoin) FeeRate() uint64 {
 	return 1
 }
 
-func TNewAsset(backend asset.DEXAsset) *asset.BackedAsset {
+func TNewAsset(backend asset.Backend) *asset.BackedAsset {
 	return &asset.BackedAsset{
 		Backend: backend,
 		Asset:   dex.Asset{SwapConf: 2},


### PR DESCRIPTION
Change `asset.DEXAsset` to `asset.Backend`. Also renames `dcr.DCRBackend` to `dcr.Backend`.