### PR TITLE
client/core: put the core together

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -43,7 +43,7 @@ type WsCfg struct {
 	PingWait time.Duration
 	// The rpc certificate file path.
 	RpcCert string
-	// ReconnectSync runs the needed reconnection synchronisation after
+	// ReconnectSync runs the needed reconnection synchronization after
 	// a disconnect.
 	ReconnectSync func()
 	// The dex client context.
@@ -327,7 +327,7 @@ func (conn *WsConn) Send(msg *msgjson.Message) error {
 }
 
 // Request sends the message with Send, but keeps a record of the callback
-// function to run when a response is recieved.
+// function to run when a response is received.
 func (conn *WsConn) Request(msg *msgjson.Message, f func(*msgjson.Message)) error {
 	// Log the message sent if it is a request.
 	if msg.Type == msgjson.Request {

--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -229,7 +229,7 @@ func TestWsConn(t *testing.T) {
 		t.Fatal("expected a non-nil read source")
 	}
 
-	// Ensure th read source can be fetched once.
+	// Ensure the read source can be fetched once.
 	rSource := wsc.MessageSource()
 	if rSource != nil {
 		t.Fatal("expected a nil read source")
@@ -310,18 +310,18 @@ func TestWsConn(t *testing.T) {
 	}
 
 	// Ensure the request got logged.
-	h := wsc.respHandler(mId)
-	if h == nil {
+	hndlr := wsc.respHandler(mId)
+	if hndlr == nil {
 		t.Fatalf("no handler found")
 	}
-	h.f(nil)
+	hndlr.f(nil)
 	if !handlerRun {
 		t.Fatalf("wrong handler retrieved")
 	}
 
 	// Lookup an unlogged request id.
-	h = wsc.respHandler(next)
-	if h != nil {
+	hndlr = wsc.respHandler(next)
+	if hndlr != nil {
 		t.Fatal("expected an error for unlogged id")
 	}
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1,0 +1,251 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/client/comms"
+	"decred.org/dcrdex/client/db"
+	"decred.org/dcrdex/client/db/bolt"
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+)
+
+var log dex.Logger
+
+// websocket is satisfied by a comms.WsConn, or a stub for testing.
+type websocket interface {
+	NextID() uint64
+	WaitForShutdown()
+	Send(msg *msgjson.Message) error
+	Request(msg *msgjson.Message, f func(*msgjson.Message)) error
+	MessageSource() <-chan *msgjson.Message
+}
+
+// dexConnection is the websocket connection and the DEX configuration.
+type dexConnection struct {
+	conn   websocket
+	assets map[uint32]*msgjson.Asset
+	cfg    *msgjson.ConfigResult
+}
+
+// Config is the configuration for the Core.
+type Config struct {
+	// DBPath is a filepath to use for the client database. If the database does
+	// not already exist, it will be created.
+	DBPath string
+	// Logger is a logger for the core to use. Having the logger as an argument
+	// enables creating custom loggers for use in a GUI interface.
+	Logger dex.Logger
+	// Certs is a mapping of URL to filepaths of TLS Certificates for the server.
+	// This is intended for accomodating self-signed certificates, mostly for
+	// testing.
+	Certs map[string]string
+}
+
+// Core is the core client application.
+type Core struct {
+	ctx     context.Context
+	wg      sync.WaitGroup
+	cfg     *Config
+	connMtx sync.RWMutex
+	conns   map[string]*dexConnection
+	db      db.DB
+	certs   map[string]string
+}
+
+// New is the constructor for a new Core.
+func New(cfg *Config) *Core {
+	log = cfg.Logger
+	core := &Core{
+		cfg:   cfg,
+		conns: make(map[string]*dexConnection),
+	}
+	return core
+}
+
+// Run runs the core. Satisfies the runner.Runner interface.
+func (c *Core) Run(ctx context.Context) {
+	log.Infof("started DEX client core")
+	db, err := bolt.NewDB(ctx, c.cfg.DBPath)
+	if err != nil {
+		log.Errorf("database initialization error: %v", err)
+		return
+	}
+	c.ctx = ctx
+	c.db = db
+	go c.initialize()
+	c.wg.Wait()
+	log.Infof("DEX client core off")
+}
+
+// ListMarkets returns a list of known markets.
+func (c *Core) ListMarkets() []*MarketInfo {
+	c.connMtx.RLock()
+	defer c.connMtx.RUnlock()
+	var infos []*MarketInfo
+	for uri, dc := range c.conns {
+		mi := &MarketInfo{DEX: uri}
+		for _, bq := range dc.cfg.Markets {
+			base, quote := dc.assets[bq[0]], dc.assets[bq[1]]
+			mi.Markets = append(mi.Markets, Market{
+				BaseID:      base.ID,
+				BaseSymbol:  base.Symbol,
+				QuoteID:     quote.ID,
+				QuoteSymbol: quote.Symbol,
+			})
+		}
+		infos = append(infos, mi)
+	}
+	return infos
+}
+
+// initialize pulls the known DEX URLs from the database and attempts to
+// connect and retreive the DEX configuration.
+func (c *Core) initialize() {
+	dexs, err := c.db.ListAccounts()
+	if err != nil {
+		log.Errorf("Error retreiving accounts from database: %v", err)
+	}
+	var wg sync.WaitGroup
+	for _, uri := range dexs {
+		wg.Add(1)
+		u := uri
+		go func() {
+			c.addDex(u)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if len(dexs) > 0 {
+		c.connMtx.RLock()
+		log.Infof("Successfully connected to %d out of %d DEX servers", len(c.conns), len(dexs))
+		c.connMtx.RUnlock()
+	}
+}
+
+// addDex adds a dexConnection to the conns map if a connection can be made
+// and the DEX configuration is successfully retrieved. The connection is
+// unauthenticated until the `connect` request is sent and accepted by the
+// server.
+func (c *Core) addDex(uri string) {
+	// Get the host from the DEX URL.
+	parsedURL, err := url.Parse(uri)
+	if err != nil {
+		log.Errorf("error parsing account URL %s: %v", uri, err)
+		return
+	}
+	// Create a websocket connection to the server.
+	conn, err := comms.NewWsConn(&comms.WsCfg{
+		URL:      "wss://" + parsedURL.Host + "/ws",
+		PingWait: 60 * time.Second,
+		RpcCert:  c.certs[uri],
+		ReconnectSync: func() {
+			go c.handleReconnect(uri)
+		},
+		Ctx: c.ctx,
+	})
+	if err != nil {
+		log.Errorf("Error creating websocket connection for %s: %v", uri, err)
+		return
+	}
+	// Request the market configuration. The DEX is only added when the DEX
+	// configuration is successfully retrieved.
+	reqMsg, err := msgjson.NewRequest(conn.NextID(), msgjson.ConfigRoute, nil)
+	if err != nil {
+		log.Errorf("error creating 'config' request: %v", err)
+	}
+	conn.Request(reqMsg, func(msg *msgjson.Message) {
+		resp, err := msg.Response()
+		if err != nil {
+			log.Errorf("failed to parse 'config' response message: %v", err)
+			return
+		}
+		var dexCfg *msgjson.ConfigResult
+		err = json.Unmarshal(resp.Result, dexCfg)
+		if err != nil {
+			log.Errorf("failed to parse config response")
+			return
+		}
+		assets := make(map[uint32]*msgjson.Asset)
+		for _, asset := range dexCfg.Assets {
+			assets[asset.ID] = &asset
+		}
+		// Validate the markets so we don't have to check every time later.
+		for _, bq := range dexCfg.Markets {
+			_, ok := assets[bq[0]]
+			if !ok {
+				log.Errorf("%s reported a market with base asset %d, but did not provide the asset info.", uri, bq[0])
+			}
+			_, ok = assets[bq[1]]
+			if !ok {
+				log.Errorf("%s reported a market with quote asset %d, but did not provide the asset info.", uri, bq[1])
+			}
+		}
+		// Create the dexConnection and add it to the map.
+		dc := &dexConnection{
+			conn:   conn,
+			assets: assets,
+			cfg:    dexCfg,
+		}
+		c.connMtx.Lock()
+		c.conns[uri] = dc
+		c.connMtx.Unlock()
+		c.wg.Add(1)
+		// Listen for incoming messages.
+		go c.listen(dc)
+	})
+}
+
+// handleReconnect is called when a WsConn indicates that a lost connection has
+// been re-established.
+func (c *Core) handleReconnect(uri string) {
+	log.Infof("DEX at %s has reconnected", uri)
+}
+
+// listen monitors the DEX webscocket connection for server requests and
+// notifications.
+func (c *Core) listen(dc *dexConnection) {
+	msgs := dc.conn.MessageSource()
+	defer c.wg.Done()
+out:
+	for {
+		select {
+		case msg := <-msgs:
+			switch msg.Route {
+			// Requests
+			case msgjson.MatchDataRoute:
+				log.Info("match_data message received")
+			case msgjson.MatchProofRoute:
+				log.Info("match_proof message received")
+			case msgjson.PreimageRoute:
+				log.Info("preimage message received")
+			case msgjson.MatchRoute:
+				log.Info("match message received")
+			case msgjson.AuditRoute:
+				log.Info("audit message received")
+			case msgjson.RedemptionRoute:
+				log.Info("redemption message received")
+			case msgjson.RevokeMatchRoute:
+				log.Info("revoke_match message received")
+			case msgjson.SuspensionRoute:
+				log.Info("suspension message received")
+			// Notifications
+			case msgjson.BookOrderRoute:
+				log.Info("book_order message received")
+			case msgjson.EpochOrderRoute:
+				log.Info("epoch_order message received")
+			case msgjson.UnbookOrderRoute:
+				log.Info("unbook_order message received")
+			}
+		case <-c.ctx.Done():
+			break out
+		}
+	}
+}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1,0 +1,116 @@
+package core
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+
+	"decred.org/dcrdex/dex/msgjson"
+)
+
+var tCtx context.Context
+
+// type TWebsocket struct {
+// 	id      uint64
+// 	sendErr error
+// 	reqErr  error
+// 	msgs    <-chan *msgjson.Message
+// }
+//
+// func newTWebsocket() *TWebsocket {
+// 	return &TWebsocket{msgs: make(<-chan *msgjson.Message)}
+// }
+//
+// func (conn *TWebsocket) NextID() uint64 {
+// 	conn.id++
+// 	return conn.id
+// }
+//
+// func (conn *TWebsocket) WaitForShutdown()                {}
+// func (conn *TWebsocket) Send(msg *msgjson.Message) error { return conn.sendErr }
+// func (conn *TWebsocket) Request(msg *msgjson.Message, f func(*msgjson.Message)) error {
+// 	return conn.reqErr
+// }
+// func (conn *TWebsocket) MessageSource() <-chan *msgjson.Message { return conn.msgs }
+
+var tAssetID uint32
+
+func randomAsset() *msgjson.Asset {
+	tAssetID++
+	return &msgjson.Asset{
+		Symbol: "BT" + strconv.Itoa(int(tAssetID)),
+		ID:     tAssetID,
+	}
+}
+
+func randomMsgMarket() (baseAsset, quoteAsset *msgjson.Asset) {
+	return randomAsset(), randomAsset()
+}
+
+func testCore() *Core {
+	return &Core{
+		ctx:   tCtx,
+		conns: make(map[string]*dexConnection),
+	}
+}
+
+func tMarketID(bq [2]uint32) string {
+	return strconv.Itoa(int(bq[0])) + "-" + strconv.Itoa(int(bq[1]))
+}
+
+func TestMain(m *testing.M) {
+	var shutdown context.CancelFunc
+	tCtx, shutdown = context.WithCancel(context.Background())
+	doIt := func() int {
+		// Not counted as coverage, must test Archiver constructor explicitly.
+		defer shutdown()
+		return m.Run()
+	}
+	os.Exit(doIt())
+}
+
+func TestListMarkets(t *testing.T) {
+	tCore := testCore()
+	// Simulate 10 markets.
+	marketIDs := make(map[string]struct{})
+	var markets [][2]uint32
+	assets := make(map[uint32]*msgjson.Asset)
+	for i := 0; i < 10; i++ {
+		base, quote := randomMsgMarket()
+		mkt := [2]uint32{base.ID, quote.ID}
+		marketIDs[tMarketID(mkt)] = struct{}{}
+		markets = append(markets, mkt)
+		assets[base.ID] = base
+		assets[quote.ID] = quote
+	}
+	tCore.conns["testdex"] = &dexConnection{
+		assets: assets,
+		cfg: &msgjson.ConfigResult{
+			Markets: markets,
+		},
+	}
+
+	// Just check that the information is coming through correctly.
+	dexes := tCore.ListMarkets()
+	if len(dexes) != 1 {
+		t.Fatalf("expected 1 MarketConfig, got %d", len(dexes))
+	}
+	mktCfg := dexes[0]
+	if len(mktCfg.Markets) != 10 {
+		t.Fatalf("expected 10 Markets, got %d", len(mktCfg.Markets))
+	}
+	for _, market := range mktCfg.Markets {
+		mkt := tMarketID([2]uint32{market.BaseID, market.QuoteID})
+		_, found := marketIDs[mkt]
+		if !found {
+			t.Fatalf("market %s not found", mkt)
+		}
+		if assets[market.BaseID].Symbol != market.BaseSymbol {
+			t.Fatalf("base symbol mismatch. %s != %s", assets[market.BaseID].Symbol, market.BaseSymbol)
+		}
+		if assets[market.QuoteID].Symbol != market.QuoteSymbol {
+			t.Fatalf("quote symbol mismatch. %s != %s", assets[market.QuoteID].Symbol, market.QuoteSymbol)
+		}
+	}
+}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -1,0 +1,41 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package core
+
+// Registration is used to register a new DEX account.
+type Registration struct {
+	DEX        string `json:"dex"`
+	Wallet     string `json:"wallet"`
+	WalletPass string `json:"walletpass"`
+	RPCAddr    string `json:"rpcaddr"`
+	RPCUser    string `json:"rpcuser"`
+	RPCPass    string `json:"rpcpass"`
+}
+
+// MarketInfo contains information about a particular market.
+type MarketInfo struct {
+	DEX     string   `json:"dex"`
+	Markets []Market `json:"markets"`
+}
+
+// Market is market info.
+type Market struct {
+	BaseID      uint32 `json:"baseid"`
+	BaseSymbol  string `json:"basesymbol"`
+	QuoteID     uint32 `json:"quoteid"`
+	QuoteSymbol string `json:"quotesymbol"`
+}
+
+// MiniOrder is minimal information about an order in a market's order book.
+type MiniOrder struct {
+	Qty   float64 `json:"qty"`
+	Rate  float64 `json:"rate"`
+	Epoch bool    `json:"epoch"`
+}
+
+// OrderBook represents an order book, which is just two sorted lists of orders.
+type OrderBook struct {
+	Sells []*MiniOrder `json:"sells"`
+	Buys  []*MiniOrder `json:"buys"`
+}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -13,7 +13,7 @@ type Registration struct {
 	RPCPass    string `json:"rpcpass"`
 }
 
-// MarketInfo contains information about a particular market.
+// MarketInfo contains information about the markets for a DEX server.
 type MarketInfo struct {
 	DEX     string   `json:"dex"`
 	Markets []Market `json:"markets"`

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -1,4 +1,4 @@
-package boltdb
+package bolt
 
 import (
 	"context"

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -713,8 +713,8 @@ type ConfigResult struct {
 	Markets          [][2]uint32 `json:"markets"`
 }
 
-// Asset is included with the DEX configuration, and describes an asset
-// available for trading.
+// Asset describes and asset and its variables, and is returned as part of a
+// ConfigResult.
 type Asset struct {
 	Symbol          string  `json:"symbol"`
 	ID              uint32  `json:"id"`

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -105,6 +105,21 @@ const (
 	// DEX that the fee has been paid and has the requisite number of
 	// confirmations.
 	NotifyFeeRoute = "notifyfee"
+	// ConfigRoute is the client-originating request-type message requesting the
+	// DEX configuration information.
+	ConfigRoute = "config"
+	// MatchDataRoute is the DEX-originating request-type message delivering
+	// match cycle info to the client.
+	MatchDataRoute = "match_data"
+	// MatchProofRoute is the DEX-originating request-type message delivering
+	// match cycle results to the client.
+	MatchProofRoute = "match_proof"
+	// PreimageRoute is the DEX-originating request-type message requesting the
+	// preimages for the client's epoch orders.
+	PreimageRoute = "preimage"
+	// SuspensionRoute is the DEX-originating request-type message informing the
+	// client of an upcoming trade suspension.
+	SuspensionRoute = "suspension"
 )
 
 type Bytes = dex.Bytes
@@ -687,6 +702,29 @@ func (n *NotifyFee) Serialize() ([]byte, error) {
 // serialization.
 type NotifyFeeResult struct {
 	signable
+}
+
+// ConfigResult is the successful result from the 'config' route.
+type ConfigResult struct {
+	EpochDuration    uint64      `json:"epochlen"`
+	CancelMax        float32     `json:"cancelmax"`
+	BroadcastTimeout uint64      `json:"btimeout"`
+	Assets           []Asset     `json:"assets"`
+	Markets          [][2]uint32 `json:"markets"`
+}
+
+// Asset is included with the DEX configuration, and describes an asset
+// available for trading.
+type Asset struct {
+	Symbol          string  `json:"symbol"`
+	ID              uint32  `json:"id"`
+	LotSize         uint64  `json:"lotsize"`
+	RateStep        uint64  `json:"ratestep"`
+	FeeRate         uint64  `json:"feerate"`
+	SwapSize        uint64  `json:"swapsize"`
+	SwapConf        uint16  `json:"swapconf"`
+	FundConf        uint16  `json:"fundconf"`
+	MarketBuyBuffer float32 `json:"buybuffer"`
 }
 
 // Convert uint64 to 8 bytes.


### PR DESCRIPTION
This incorporates the db and comms package functionality into client core application. This PR should hopefully add some clarity to the client structure and enable concurrent work. @dnldd can add in order book handling. @JoeGruffins can implement an RPC server that uses the core. I'll start into authentication via web interface.

All the core does right now is list the available markets, but I think future work can be done independently in the following rough categories.

1. Order book subscription management
2. Registration and authentication
3. Order management
4. Data access

Eventually reconnect handling and match auditing too.