### PR TITLE
spec: upgrades headers. add subsection links to readme

### DIFF
--- a/spec/README.mediawiki
+++ b/spec/README.mediawiki
@@ -91,9 +91,16 @@ critical sections.
 messaging protocols and communication layer technologies that are to be used
 for the DEX API.
 
+* [[comm.mediawiki/#Encoding|Data Encodings]]
+* [[comm.mediawiki/#Message_Protocol|Message Protocol]]
+
 '''&#91;2&#93; [[fundamentals.mediawiki|Distributed Exchange Design Fundamentals]]'''
 describes the notable design aspects that facilitate an exchange service with
 the features described above.
+
+* [[fundamentals.mediawiki/#Exchange_Variables|Exchange Variables]]
+* [[fundamentals.mediawiki/#Epochbased_Order_Matching|Epoch-based Order Matching]]
+* [[fundamentals.mediawiki/#Identities_based_on_Public_Key_Infrastructure_PKI_Key_Pairs|Identification]]
 
 '''&#91;3&#93; [[admin.mediawiki|Distributed Exchange Administration]]''' describes
 the tasks required to administer the exchange.
@@ -103,6 +110,12 @@ the tasks required to administer the exchange.
 '''&#91;5&#93; [[orders.mediawiki|Client Order Management]]''' details the different
 order types and the client/server workflows required to synchronize the order
 book and place orders.
+
+* [[orders.mediawiki/#Connection_Persistence|Connection Persistence]]
+* [[orders.mediawiki/#Order_Book_Subscriptions|Order Book Subscriptions]]
+* [[orders.mediawiki/#Order_Type|Order Types]]
+* [[orders.mediawiki/#Preimage_Reveal|Preimage Handling]]
+* [[orders.mediawiki/#Match_negotiation|Match Negotiation]]
 
 '''&#91;6&#93; [[api.mediawiki| Data API]]''' defines http and websocket APIs to browse
 trade history.

--- a/spec/accounts.mediawiki
+++ b/spec/accounts.mediawiki
@@ -1,4 +1,6 @@
-==Account Creation==
+=Account Creation=
+
+__TOC__
 
 An account is uniquely identified by the client's public account key (pubkey),
 which the client provides during registration.
@@ -9,7 +11,7 @@ double Blake-256 hash of the client's pubkey,
 '''''<code>blake256(blake256(pubkey))</code>''''', provided as a hex-encoded
 string in API messages.
 
-===Step 1: Registration===
+==Step 1: Registration==
 
 The user creates a websocket connection and sends their
 [[fundamentals.mediawiki/#Identities_based_on_Public_Key_Infrastructure_PKI_Key_Pairs|public account key]].
@@ -73,7 +75,7 @@ pre-published for further validation.
 | address    || varies || UTF-8 encoded fee address
 |}
 
-===Step 2: Fee Notification===
+==Step 2: Fee Notification==
 
 The client pays the fee on-chain and notifies the DEX of the transaction detail.
 The fee is paid with a standard P2PKH output to the address received in step 1.

--- a/spec/admin.mediawiki
+++ b/spec/admin.mediawiki
@@ -1,4 +1,6 @@
-==Exchange Administration==
+=Exchange Administration=
+
+__TOC__
 
 Operation of the DEX will require a non-trivial amount of administrative labor.
 Clients will expect near-perfect uptime and long-term operation.

--- a/spec/api.mediawiki
+++ b/spec/api.mediawiki
@@ -1,3 +1,5 @@
-==Data API==
+=Data API=
+
+__TOC__
 
 Trade history will be made available to both websocket and HTTP clients.

--- a/spec/atomic.mediawiki
+++ b/spec/atomic.mediawiki
@@ -1,4 +1,6 @@
-==Atomic Settlement==
+=Atomic Settlement=
+
+__TOC__
 
 In order to facilitate trustless, non-custodial exchange, the DEX leverages an
 atomic swap process that enables all parties to maintain full control over their
@@ -27,7 +29,7 @@ The market is a DCR/BTC market, where DCR is the &#x201C;base asset&#x201D; and 
 Order quantities are in units of DCR, and the rate offered in a limit order is
 denominated in BTC.
 
-===Case A: Perfect match===
+==Case A: Perfect match==
 
 In the most basic case, Alice and a trader named Bob are the only participants
 and their orders match perfectly.
@@ -118,7 +120,7 @@ the atomic swap.'''
 
 <img src="images/bob-redeem.png">
 
-===Case B: Multi-taker with partial fill===
+==Case B: Multi-taker with partial fill==
 
 In case B, Alice is similarly trying to sell 3 DCR for 0.3 BTC, but the match
 found by the DEX is not perfect this time.

--- a/spec/comm.mediawiki
+++ b/spec/comm.mediawiki
@@ -1,6 +1,8 @@
-==Communication Protocols==
+=Communication Protocols=
 
-===WebSockets===
+__TOC__
+
+==WebSockets==
 
 Trustless negotiation of trades requires considerable messaging.
 Transaction details must be reported and relayed at appropriate times, sometimes
@@ -19,14 +21,14 @@ virtually all popular programming languages.
 Websocket messages are secured by encryption on Transport Layer
 Security (TLS) [https://tools.ietf.org/html/rfc8446 &#91;5&#93;] connections.
 
-===Timestamps===
+==Timestamps==
 
 In all client-server messages that include a timestamp or duration field, the
 units of time are milliseconds unless otherwise specified. Location-independent
 timestamps are encoded as milliseconds since the UNIX epoch (Jan 01 00:00:00
 1970 UTC).
 
-===Message Protocol===
+==Message Protocol==
 
 DEX messaging is JSON-formatted [https://tools.ietf.org/html/rfc8259 &#91;6&#93;].
 All messages, regardless of originating party, use a common top-level
@@ -105,7 +107,7 @@ The payload for a response has a structure that enables quick error checking.
 }
 </pre>
 
-===Session Authentication===
+==Session Authentication==
 
 Many DEX messages must be sent on an authenticated connection. Once a websocket
 connection is established, the client will supply their account ID and signature.
@@ -155,7 +157,7 @@ the client's absence. A list of any pending matches is included in the response.
 | matches    || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
 |}
 
-===HTTP===
+==HTTP==
 
 An API using HTTP for message transport may be provided for basic account
 management and server status queries, however websocket connections are to be

--- a/spec/comm.mediawiki
+++ b/spec/comm.mediawiki
@@ -21,12 +21,48 @@ virtually all popular programming languages.
 Websocket messages are secured by encryption on Transport Layer
 Security (TLS) [https://tools.ietf.org/html/rfc8446 &#91;5&#93;] connections.
 
-==Timestamps==
+==Encoding==
+
+===Timestamps===
 
 In all client-server messages that include a timestamp or duration field, the
 units of time are milliseconds unless otherwise specified. Location-independent
 timestamps are encoded as milliseconds since the UNIX epoch (Jan 01 00:00:00
 1970 UTC).
+
+===Rate Encoding===
+
+Because the rate assigned to a limit order is a quotient, the value is naturally
+expressed as a floating point number.
+To avoid floating-point error, rates in API messages are encoded using a
+custom unit, '''atoms quote asset per unit base asset'''.
+This is called the '''message-rate format'''.
+This can alternatively be viewed as conventional rate multiplied by
+10<sup>8</sup> and floored to the nearest integer.
+
+As an example of message-rate encoding, if someone wanted to purchase asset Z
+using asset Y on the Z/Y market, and the user wanted to pay 0.001 Y for each 1
+Z, the message-rate encoding would be
+
+'''''r<sub>msg</sub> = 1 x 10<sup>8</sup> x 0.001 = 100000'''''
+
+with unit ''atoms Y / unit Z''.
+
+===Coin ID===
+
+In order to demonstrate control of unspent value on the blockchain, a user must
+provide its location. For Bitcoin-based blockchains, value is located by
+pointing to an unspent transaction output (UTXO), identified by its transaction
+ID and output index (vout).
+
+In an effort to stay blockchain-protocol agnostic, the DEX accepts
+and recognizes the locating information as a single byte-array called the
+'''''coin ID''''', with the term '''''coin''''' being defined here as a some
+amount of spendable value that is verifiable on the blockchain.
+It is up to backend and wallet developers to decide on how to properly encode the
+identifier as a coin ID. As an example, Bitcoin implements
+encoding as 36 bytes with the transaction hash being the first 32-bytes, and the
+big-endian encoded output index as the last 4 bytes.
 
 ==Message Protocol==
 

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -1,17 +1,19 @@
-==Community Conduct==
+=Community Conduct=
+
+__TOC__
 
 By registering, clients agree to abide by the rules described here. These rules
 are designed to ensure that clients are acting in good faith and maintaining
 behaviors that contribute to a smooth DEX experience for other users.
 
-===Rules of Community Conduct===
+==Rules of Community Conduct==
 
-====Rule 1: Clients must respond to all preimage requests====
+===Rule 1: Clients must respond to all preimage requests===
 
 At the expiration of the epoch, every client with an order will receive a
 <code>preimage</code> request. The client has 5 seconds to respond.
 
-====Rule 2: Every match must be fully settled====
+===Rule 2: Every match must be fully settled===
 
 Swap transactions must be created at the correct times (see
 [[fundamentals.mediawiki/#Exchange_Variables|broadcast timeout]]).
@@ -25,7 +27,7 @@ replace the order.
 In the event that the taker fails to respond to the maker's initialization
 transaction, the maker will incur no violation.
 
-====Rule 3: An account's cancellation ratio must remain below the threshold====
+===Rule 3: An account's cancellation ratio must remain below the threshold===
 
 The cancellation ratio is the ratio of the count of canceled orders to the
 count of completed orders.
@@ -37,7 +39,7 @@ dropped and the client fails to reconnect for more than 1 epoch duration.
 Cancellation of a partially filled order is counted as a full cancellation.
 The cancellation ratio is evaluated on a 25-order rolling window.
 
-====Rule 4: Transaction outputs must be properly sized====
+===Rule 4: Transaction outputs must be properly sized===
 
 The swap output value must be sized to exactly the matched amount. The fee rate
 must be at least the minimum value set by the DEX. It is the client's
@@ -45,7 +47,7 @@ responsibility to ensure that fees on a partial fill are not overpaid to a
 level that results in a violation of rules 1 or 3 when the remaining portion is
 matched.
 
-===Penalties===
+==Penalties==
 
 The primary penalty for breaches of conduct is a '''ban''', which includes loss
 of trading privileges, forfeiture of registration fee, and immediate revocation

--- a/spec/fundamentals.mediawiki
+++ b/spec/fundamentals.mediawiki
@@ -1,4 +1,6 @@
-==Distributed Exchange Design Fundamentals==
+=Distributed Exchange Design Fundamentals=
+
+__TOC__
 
 There are several notable aspects of the DEX design that were chosen to permit
 peer-to-peer trades with the mechanics of order execution existing entirely on
@@ -11,7 +13,7 @@ These are:
 
 This section describes each of these design aspects.
 
-===Exchange Variables===
+==Exchange Variables==
 
 There are a number of asset-specific variables that must be known by the client.
 
@@ -100,7 +102,7 @@ respond with its current configuration.
 | fundconf || int || minimum confirmations for funding coins
 |}
 
-===Fees===
+==Fees==
 
 The DEX collects no trading fees.
 Collecting fees from trades executed via atomic swaps (where the server
@@ -113,7 +115,7 @@ Registration fees discourage certain spam attacks, enable punitive actions when
 DEX operating expenses.
 Registration fees will be configurable by the exchange operator.
 
-====Transaction Fees====
+===Transaction Fees===
 
 The clients will cover on-chain transaction fees at a minimum fee rate set by
 the DEX operator.
@@ -143,7 +145,7 @@ mined.
 
 See also: [[orders.mediawiki/#Calculating_Transaction_Fees|Calculating Transaction Fees]]
 
-===Epoch-based Order Matching===
+==Epoch-based Order Matching==
 
 In order to devalue predatory behavior exhibited by certain high-frequency
 trading algorithms, received orders are not processed continuously, but rather
@@ -154,7 +156,7 @@ a deterministic latency advantage over other clients when executing trades.
 Limiting this possibility mitigates advantages gained from front-running,
 spoofing, and other manipulative trading practices.
 
-====Epoch Time====
+===Epoch Time===
 
 For a given epoch duration '''''d > 0''''' in milliseconds, and current UNIX
 epoch timestamp '''''t''''' (in milliseconds since Jan 01 00:00:00 1970 UTC),
@@ -173,7 +175,7 @@ and end times for any epoch duration to be known without querying the server.
 A clock synchronization protocol such as NTP will be used to ensure server and
 client clocks are synchronized within acceptable tolerances.
 
-====Pseudorandom Order Matching====
+===Pseudorandom Order Matching===
 
 When the epoch ends, a match cycle begins.
 
@@ -218,7 +220,7 @@ price rate).
 The process continues with the next order in the list and iterates until all
 orders have been processed.
 
-===Identities based on Public Key Infrastructure (PKI) Key Pairs===
+==Identities based on Public Key Infrastructure (PKI) Key Pairs==
 
 The server and the clients are identified and authenticated using public keys,
 with matching private keys used to sign and authorize orders and other messages.
@@ -238,7 +240,7 @@ exchange data via Politeia. For example, given common identities between the DEX
 and Politeia, anchoring data related to DEX client and server conduct on the
 Decred blockchain may be useful for establishing a reputation system.
 
-===Blockchain Interaction===
+==Blockchain Interaction==
 
 '''Clients''' need wallets that support atomic swaps and the ability to
 broadcast transactions to each of the blockchain networks involved in

--- a/spec/orders.mediawiki
+++ b/spec/orders.mediawiki
@@ -87,7 +87,7 @@ re-subscribe to the market to synchronize the order book from scratch.
 |-
 | qty     || int      || order size (atoms) || epoch_order, book_order
 |-
-| rate    || int    || price rate. [[#Rate_Encoding|message-rate encoding]]. only set on limit orders
+| rate    || int    || price rate. [[comm.mediawiki/#Rate_Encoding|message-rate encoding]]. only set on limit orders
 |-
 | tif     || string || time in force. one of "i" for ''immediate'' or "s" for ''standing''. only set on limit orders
 |-
@@ -167,7 +167,7 @@ websocket connection.
 
 As part of the order, the client must demonstrate control of funds.
 This is accomplished by supplying information and a signature for each
-[[#Coin_ID|coin]] that will be spent.
+[[comm.mediawiki/#Coin_ID|coin]] that will be spent.
 The client covers the ''backing fees'' associated with the inputs spending their
 own coins.
 
@@ -209,43 +209,9 @@ backing coins, '''''f<sub>coin</sub>'''''.
 The client must know how to calculate the script sizes to assess fees.
 The DEX will verify the coin sum before accepting the order.
 
-===Rate Encoding===
-
-Because the rate assigned to a limit order is a quotient, the value is naturally
-expressed as a floating point number.
-To avoid floating-point error, rates in JSON API messages are encoded using a
-custom unit, '''atoms quote asset per unit base asset'''.
-This is called the '''message-rate format'''.
-This can alternatively be viewed as conventional rate multiplied by
-10<sup>8</sup> and floored to the nearest integer.
-
-As an example of message-rate encoding, if someone wanted to purchase asset Z
-using asset Y on the Z/Y market, and the user wanted to pay 0.001 Y for each 1
-Z, the message-rate encoding would be
-
-'''''r<sub>msg</sub> = 1 x 10<sup>8</sup> x 0.001 = 100000'''''
-
-with unit ''atoms Y / unit Z''.
-
-===Coin ID===
-
-In order to demonstrate control of unspent value on the blockchain, a user must
-provide its location. For Bitcoin-based blockchains, value is located by
-pointing to an unspent transaction output (UTXO), identified by its transaction
-ID and output index (vout).
-
-In an effort to stay blockchain-protocol agnostic, the DEX accepts
-and recognizes the locating information as a single byte-array called the
-'''''coin ID''''', with the term '''''coin''''' being defined here as a some
-amount of spendable value that is verifiable on the blockchain.
-It is up to backend and wallet developers to decide on how to properly encode the
-identifier as a coin ID. As an example, Bitcoin implements
-encoding as 36 bytes with the transaction hash being the first 32-bytes, and the
-big-endian encoded output index as the last 4 bytes.
-
 ===Coin Preparation===
 
-All backing [[#Coin_ID|coins]] must have a minimum number of confirmations. The exact number,
+All backing [[comm.mediawiki/#Coin_ID|coins]] must have a minimum number of confirmations. The exact number,
 <code>swapconf</code>, is an [[fundamentals.mediawiki/#Exchange_Variables|asset variable]] set by the
 DEX operator.
 
@@ -373,7 +339,9 @@ The client should use the server's timestamp to create a serialized order and
 independently verify the order ID. The serialized order is also the message for
 the server's signature.
 
-==Limit Order==
+==Order Types==
+
+===Limit Order===
 
 Limit orders are for the trade of assets at a rate no higher (buy) or lower
 (sell) than a specified price.
@@ -397,7 +365,7 @@ crosses the spread (i.e. a taker rather than a maker). The
 |-
 | ordersize   || int || order size (atoms)
 |-
-| rate        || int || price rate. [[#Rate_Encoding|message-rate encoding]]
+| rate        || int || price rate. [[comm.mediawiki/#Rate_Encoding|message-rate encoding]]
 |-
 | timeinforce || int || standing = 1, immediate = 2
 |-
@@ -423,7 +391,7 @@ crosses the spread (i.e. a taker rather than a maker). The
 |-
 | quantity   || 8 || quantity to buy or sell (atoms)
 |-
-| rate       || 8 || price rate. [[#Rate_Encoding|message-rate encoding]]
+| rate       || 8 || price rate. [[comm.mediawiki/#Rate_Encoding|message-rate encoding]]
 |-
 | time in force || 1 || 1 for ''standing'', 2 for ''immediate''
 |-
@@ -439,7 +407,7 @@ crosses the spread (i.e. a taker rather than a maker). The
 | server time || int  || the server's UNIX timestamp (milliseconds)
 |}
 
-==Market Order==
+===Market Order===
 
 A market order is an order to buy or sell an asset at the best available
 market price. The request payload fields are similar to a limit order, but
@@ -495,7 +463,7 @@ the epoch match cycle) is left unfilled.
 | server time || int  || the server's UNIX timestamp (milliseconds)
 |}
 
-===Market Buy Orders===
+====Market Buy Orders====
 
 Market buy orders have a slightly different ruleset than market sell orders or
 limit orders.
@@ -532,7 +500,7 @@ accepted but is now too small to match is considered executed but unfilled and
 there is no change to the account's
 [[community.mediawiki/#Rules_of_Community_Conduct|cancellation statistics]].
 
-==Cancel Order==
+===Cancel Order===
 
 Cancel orders remove standing limit orders from the order book.
 A client cannot cancel a market order or a limit order with time in force
@@ -645,7 +613,7 @@ transaction and inform the server with an <code>init</code> notification
 |-
 | quantity  || int    || the matched amount, in atoms of the base asset
 |-
-| rate      || int    || the matched price rate. [[#Rate_Encoding|message-rate encoding]]
+| rate      || int    || the matched price rate. [[comm.mediawiki/#Rate_Encoding|message-rate encoding]]
 |-
 | timestamp || int    || server's UNIX timestamp (milliseconds)
 |-
@@ -665,7 +633,7 @@ transaction and inform the server with an <code>init</code> notification
 |-
 | quantity   || 8  || the matched amount, in atoms of the base asset
 |-
-| rate       || 8  || the matched price rate. [[#Rate_Encoding|message-rate encoding]]
+| rate       || 8  || the matched price rate. [[comm.mediawiki/#Rate_Encoding|message-rate encoding]]
 |-
 | timestamp  || 8  || server's UNIX timestamp (milliseconds)
 |-

--- a/spec/orders.mediawiki
+++ b/spec/orders.mediawiki
@@ -1,4 +1,6 @@
-==Client Order Management==
+=Client Order Management=
+
+__TOC__
 
 This section describes the steps required of the client to place an order, and
 the interactions between the client and server to execute an order once a match
@@ -16,7 +18,7 @@ The order book holds only limit orders with time in force ''standing'' that have
 not completely filled or been canceled. All other orders are only valid for one
 [[fundamentals.mediawiki/#Epochbased_Order_Matching|epoch match cycle]].
 
-===Connection Persistence===
+==Connection Persistence==
 
 Regardless of connection status, if a client does not respond to their
 <code>preimage</code> request, they are in violation of
@@ -29,7 +31,7 @@ Once a match is made, a client is always subject to violation of
 [[community.mediawiki/#Rule_2_Every_match_must_be_fully_settled|rule 2]] via the
 [[fundamentals.mediawiki/#Exchange_Variables|broadcast timeout]].
 
-===Order Book Subscriptions===
+==Order Book Subscriptions==
 
 An order book can be viewed and tracked by subscribing to a market.
 
@@ -161,7 +163,7 @@ websocket connection.
 
 <code>result</code>: boolean <code>true</code> on success.
 
-===Order Preparation===
+==Order Preparation==
 
 As part of the order, the client must demonstrate control of funds.
 This is accomplished by supplying information and a signature for each
@@ -176,7 +178,7 @@ single-lot matches for the entire order.
 In practice, large orders will rarely pay the total of the base fees because
 many of the matches will be more than a single-lot.
 
-====Calculating Transaction Fees====
+===Calculating Transaction Fees===
 
 The '''base fees''' cover transaction fees associated with making
 initialization transactions for every match in the order.
@@ -207,7 +209,7 @@ backing coins, '''''f<sub>coin</sub>'''''.
 The client must know how to calculate the script sizes to assess fees.
 The DEX will verify the coin sum before accepting the order.
 
-====Rate Encoding====
+===Rate Encoding===
 
 Because the rate assigned to a limit order is a quotient, the value is naturally
 expressed as a floating point number.
@@ -225,7 +227,7 @@ Z, the message-rate encoding would be
 
 with unit ''atoms Y / unit Z''.
 
-====Coin ID====
+===Coin ID===
 
 In order to demonstrate control of unspent value on the blockchain, a user must
 provide its location. For Bitcoin-based blockchains, value is located by
@@ -241,7 +243,7 @@ identifier as a coin ID. As an example, Bitcoin implements
 encoding as 36 bytes with the transaction hash being the first 32-bytes, and the
 big-endian encoded output index as the last 4 bytes.
 
-====Coin Preparation====
+===Coin Preparation===
 
 All backing [[#Coin_ID|coins]] must have a minimum number of confirmations. The exact number,
 <code>swapconf</code>, is an [[fundamentals.mediawiki/#Exchange_Variables|asset variable]] set by the
@@ -283,7 +285,7 @@ The data is signed with the private key(s) corresponding to the
 The <code>pubkeys</code> themselves must correspond with addresses payable by
 the coin's pubkey script (or corresponding redeem script).
 
-====Order Commitment====
+===Order Commitment===
 
 As part of every submitted order, the client should submit a cryptographic
 '''commitment'''.
@@ -306,7 +308,7 @@ The preimages are used as the inputs to
 matching order. Before matching commences, the preimages are broadcast
 in the <code>match_proof</code> message.
 
-====Order Signing====
+===Order Signing===
 
 All orders must be signed by the client and the server.
 The basic signing procedure will involve serializing order data into a byte array
@@ -341,7 +343,7 @@ All order serializations have common '''prefix''' fields.
 | epochdur   || 2  || int || the current DEX epoch duration, in seconds
 |}
 
-====Order ID====
+===Order ID===
 
 The order serialization is used to create a unique order ID.
 The ID is defined as the Blake-256 hash of the serialized order, including the
@@ -371,7 +373,7 @@ The client should use the server's timestamp to create a serialized order and
 independently verify the order ID. The serialized order is also the message for
 the server's signature.
 
-===Limit Order===
+==Limit Order==
 
 Limit orders are for the trade of assets at a rate no higher (buy) or lower
 (sell) than a specified price.
@@ -437,7 +439,7 @@ crosses the spread (i.e. a taker rather than a maker). The
 | server time || int  || the server's UNIX timestamp (milliseconds)
 |}
 
-===Market Order===
+==Market Order==
 
 A market order is an order to buy or sell an asset at the best available
 market price. The request payload fields are similar to a limit order, but
@@ -493,7 +495,7 @@ the epoch match cycle) is left unfilled.
 | server time || int  || the server's UNIX timestamp (milliseconds)
 |}
 
-====Market Buy Orders====
+===Market Buy Orders===
 
 Market buy orders have a slightly different ruleset than market sell orders or
 limit orders.
@@ -530,7 +532,7 @@ accepted but is now too small to match is considered executed but unfilled and
 there is no change to the account's
 [[community.mediawiki/#Rules_of_Community_Conduct|cancellation statistics]].
 
-===Cancel Order===
+==Cancel Order==
 
 Cancel orders remove standing limit orders from the order book.
 A client cannot cancel a market order or a limit order with time in force
@@ -572,7 +574,7 @@ This is by design and discourages certain types of spoofing.
 | server time || int  || the server's UNIX timestamp (milliseconds)
 |}
 
-===Preimage Reveal===
+==Preimage Reveal==
 
 At the expiration of the epoch, the DEX sends out a <code>preimage</code>
 request for each order in the epoch queue. The match cycle begins 5 seconds
@@ -606,7 +608,7 @@ the checksum generated from their local copy of the epoch queue.
 | pimg    || string || hex-encoded preimage for the order's commitment
 |}
 
-===Match negotiation===
+==Match negotiation==
 
 Swap negotiation details will be relayed through the DEX with a series of
 notifications or progress reports.
@@ -825,7 +827,7 @@ The client will respond with an acknowledgement.
 The taker will get the key from the maker's redemption and broadcast their own
 redemption transaction.
 
-===Match revocation===
+==Match revocation==
 
 A match can be revoked by the server if a client fails to act within the
 [[fundamentals.mediawiki/#Exchange_Variables|broadcast timeout]]. A match revocation will result in


### PR DESCRIPTION
Added select subsection links beneath their section link on the landing page. Also repositions the table of contents for each section below the section header. Since we paginated, we are able to upgrade the section headers 1 level. This enables one move level of table of contents navigation, though it's not used yet.

Moves the message-rate, timestamp, and coin ID subsections to a new encoding subsection on the comms page. 

[Quick Link](https://github.com/buck54321/dcrdex/blob/specheaders/spec/README.mediawiki) 