### PR TITLE
msgjson+: modify ConfigResult with Market config

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -91,13 +91,16 @@ func (c *Core) ListMarkets() []*MarketInfo {
 	infos := make([]*MarketInfo, 0, len(c.conns))
 	for uri, dc := range c.conns {
 		mi := &MarketInfo{DEX: uri}
-		for _, bq := range dc.cfg.Markets {
-			base, quote := dc.assets[bq[0]], dc.assets[bq[1]]
+		for _, mkt := range dc.cfg.Markets {
+			base, quote := dc.assets[mkt.Base], dc.assets[mkt.Quote]
 			mi.Markets = append(mi.Markets, Market{
-				BaseID:      base.ID,
-				BaseSymbol:  base.Symbol,
-				QuoteID:     quote.ID,
-				QuoteSymbol: quote.Symbol,
+				BaseID:          base.ID,
+				BaseSymbol:      base.Symbol,
+				QuoteID:         quote.ID,
+				QuoteSymbol:     quote.Symbol,
+				EpochLen:        mkt.EpochLen,
+				StartEpoch:      mkt.StartEpoch,
+				MarketBuyBuffer: mkt.MarketBuyBuffer,
 			})
 		}
 		infos = append(infos, mi)
@@ -177,14 +180,14 @@ func (c *Core) addDex(uri string) {
 			assets[asset.ID] = &asset
 		}
 		// Validate the markets so we don't have to check every time later.
-		for _, bq := range dexCfg.Markets {
-			_, ok := assets[bq[0]]
+		for _, mkt := range dexCfg.Markets {
+			_, ok := assets[mkt.Base]
 			if !ok {
-				log.Errorf("%s reported a market with base asset %d, but did not provide the asset info.", uri, bq[0])
+				log.Errorf("%s reported a market with base asset %d, but did not provide the asset info.", uri, mkt.Base)
 			}
-			_, ok = assets[bq[1]]
+			_, ok = assets[mkt.Quote]
 			if !ok {
-				log.Errorf("%s reported a market with quote asset %d, but did not provide the asset info.", uri, bq[1])
+				log.Errorf("%s reported a market with quote asset %d, but did not provide the asset info.", uri, mkt.Quote)
 			}
 		}
 		// Create the dexConnection and add it to the map.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -74,13 +74,20 @@ func TestListMarkets(t *testing.T) {
 	tCore := testCore()
 	// Simulate 10 markets.
 	marketIDs := make(map[string]struct{})
-	var markets [][2]uint32
+	var markets []msgjson.Market
 	assets := make(map[uint32]*msgjson.Asset)
 	for i := 0; i < 10; i++ {
 		base, quote := randomMsgMarket()
 		mkt := [2]uint32{base.ID, quote.ID}
 		marketIDs[tMarketID(mkt)] = struct{}{}
-		markets = append(markets, mkt)
+		markets = append(markets, msgjson.Market{
+			Name:            base.Symbol + "_" + quote.Symbol,
+			Base:            base.ID,
+			Quote:           quote.ID,
+			EpochLen:        5000,
+			StartEpoch:      1234,
+			MarketBuyBuffer: 1.4,
+		})
 		assets[base.ID] = base
 		assets[quote.ID] = quote
 	}
@@ -94,7 +101,7 @@ func TestListMarkets(t *testing.T) {
 	// Just check that the information is coming through correctly.
 	dexes := tCore.ListMarkets()
 	if len(dexes) != 1 {
-		t.Fatalf("expected 1 MarketConfig, got %d", len(dexes))
+		t.Fatalf("expected 1 MarketInfo, got %d", len(dexes))
 	}
 	mktCfg := dexes[0]
 	if len(mktCfg.Markets) != 10 {

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -23,10 +23,13 @@ type MarketInfo struct {
 
 // Market is market info.
 type Market struct {
-	BaseID      uint32 `json:"baseid"`
-	BaseSymbol  string `json:"basesymbol"`
-	QuoteID     uint32 `json:"quoteid"`
-	QuoteSymbol string `json:"quotesymbol"`
+	BaseID          uint32  `json:"baseid"`
+	BaseSymbol      string  `json:"basesymbol"`
+	QuoteID         uint32  `json:"quoteid"`
+	QuoteSymbol     string  `json:"quotesymbol"`
+	EpochLen        uint64  `json:"epochlen"`
+	StartEpoch      uint64  `json:"startepoch"`
+	MarketBuyBuffer float32 `json:"buybuffer"`
 }
 
 // Display returns a ID string suitable for displaying in a UI.

--- a/dex/msgjson/msg_test.go
+++ b/dex/msgjson/msg_test.go
@@ -454,7 +454,7 @@ func TestLimit(t *testing.T) {
 		Coins:    []*Coin{coin1, coin2},
 		Address:  addr,
 	}
-	limit := &Limit{
+	limit := &LimitOrder{
 		Prefix: *prefix,
 		Trade:  *trade,
 		Rate:   350_000_000,
@@ -501,7 +501,7 @@ func TestLimit(t *testing.T) {
 		t.Fatalf("marshal error: %v", err)
 	}
 
-	var limitBack Limit
+	var limitBack LimitOrder
 	err = json.Unmarshal(limitB, &limitBack)
 	if err != nil {
 		t.Fatalf("unmarshal error: %v", err)
@@ -537,7 +537,7 @@ func TestMarket(t *testing.T) {
 		Coins:    []*Coin{coin1, coin2},
 		Address:  addr,
 	}
-	market := &Market{
+	market := &MarketOrder{
 		Prefix: *prefix,
 		Trade:  *trade,
 	}
@@ -578,7 +578,7 @@ func TestMarket(t *testing.T) {
 		t.Fatalf("marshal error: %v", err)
 	}
 
-	var marketBack Market
+	var marketBack MarketOrder
 	err = json.Unmarshal(marketB, &marketBack)
 	if err != nil {
 		t.Fatalf("unmarshal error: %v", err)
@@ -600,7 +600,7 @@ func TestCancel(t *testing.T) {
 		ServerTime: 1571874405,
 	}
 	targetID, _ := hex.DecodeString("a1f1b66916353b58dbb65562eb19731953b2f1215987a9d9137f0df3458637b7")
-	cancel := &Cancel{
+	cancel := &CancelOrder{
 		Prefix:   *prefix,
 		TargetID: targetID,
 	}
@@ -632,7 +632,7 @@ func TestCancel(t *testing.T) {
 		t.Fatalf("marshal error: %v", err)
 	}
 
-	var cancelBack Cancel
+	var cancelBack CancelOrder
 	err = json.Unmarshal(cancelB, &cancelBack)
 	if err != nil {
 		t.Fatalf("unmarshal error: %v", err)

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -498,8 +498,8 @@ func (t *Trade) Serialize() []byte {
 	return append(b, uint64Bytes(t.Quantity)...)
 }
 
-// Limit is the payload for the LimitRoute, which places a limit order.
-type Limit struct {
+// LimitOrder is the payload for the LimitRoute, which places a limit order.
+type LimitOrder struct {
 	Prefix
 	Trade
 	Rate uint64 `json:"rate"`
@@ -507,7 +507,7 @@ type Limit struct {
 }
 
 // Serialize serializes the Limit data.
-func (l *Limit) Serialize() ([]byte, error) {
+func (l *LimitOrder) Serialize() ([]byte, error) {
 	// serialization: prefix (65) + trade (variable) + rate (8)
 	// + time-in-force (1) + address (~35) = 110 + len(trade)
 	trade := l.Trade.Serialize()
@@ -519,27 +519,27 @@ func (l *Limit) Serialize() ([]byte, error) {
 	return append(b, []byte(l.Address)...), nil
 }
 
-// Market is the payload for the MarketRoute, which places a market order.
-type Market struct {
+// MarketOrder is the payload for the MarketRoute, which places a market order.
+type MarketOrder struct {
 	Prefix
 	Trade
 }
 
-// Serialize serializes the Market data.
-func (m *Market) Serialize() ([]byte, error) {
+// Serialize serializes the MarketOrder data.
+func (m *MarketOrder) Serialize() ([]byte, error) {
 	// serialization: prefix (65) + trade (varies) + address (35 ish)
 	b := append(m.Prefix.Serialize(), m.Trade.Serialize()...)
 	return append(b, []byte(m.Address)...), nil
 }
 
-// Cancel is the payload for the CancelRoute, which places a cancel order.
-type Cancel struct {
+// CancelOrder is the payload for the CancelRoute, which places a cancel order.
+type CancelOrder struct {
 	Prefix
 	TargetID Bytes `json:"targetid"`
 }
 
-// Serialize serializes the Cancel data.
-func (c *Cancel) Serialize() ([]byte, error) {
+// Serialize serializes the CancelOrder data.
+func (c *CancelOrder) Serialize() ([]byte, error) {
 	// serialization: prefix (57) + target id (32) = 89
 	return append(c.Prefix.Serialize(), c.TargetID...), nil
 }
@@ -704,25 +704,34 @@ type NotifyFeeResult struct {
 
 // ConfigResult is the successful result from the 'config' route.
 type ConfigResult struct {
-	EpochDuration    uint64      `json:"epochlen"`
-	CancelMax        float32     `json:"cancelmax"`
-	BroadcastTimeout uint64      `json:"btimeout"`
-	Assets           []Asset     `json:"assets"`
-	Markets          [][2]uint32 `json:"markets"`
+	CancelMax        float32  `json:"cancelmax"`
+	BroadcastTimeout uint64   `json:"btimeout"`
+	Assets           []Asset  `json:"assets"`
+	Markets          []Market `json:"markets"`
 }
 
-// Asset describes and asset and its variables, and is returned as part of a
+// Market describes a market and its variables, and is returned as part of a
+// ConfigResult.
+type Market struct {
+	Name            string  `json:"name"`
+	Base            uint32  `json:"base"`
+	Quote           uint32  `json:"quote"`
+	EpochLen        uint64  `json:"epochlen"`
+	StartEpoch      uint64  `json:"startepoch"`
+	MarketBuyBuffer float32 `json:"buybuffer"`
+}
+
+// Asset describes an asset and its variables, and is returned as part of a
 // ConfigResult.
 type Asset struct {
-	Symbol          string  `json:"symbol"`
-	ID              uint32  `json:"id"`
-	LotSize         uint64  `json:"lotsize"`
-	RateStep        uint64  `json:"ratestep"`
-	FeeRate         uint64  `json:"feerate"`
-	SwapSize        uint64  `json:"swapsize"`
-	SwapConf        uint16  `json:"swapconf"`
-	FundConf        uint16  `json:"fundconf"`
-	MarketBuyBuffer float32 `json:"buybuffer"`
+	Symbol   string `json:"symbol"`
+	ID       uint32 `json:"id"`
+	LotSize  uint64 `json:"lotsize"`
+	RateStep uint64 `json:"ratestep"`
+	FeeRate  uint64 `json:"feerate"`
+	SwapSize uint64 `json:"swapsize"`
+	SwapConf uint16 `json:"swapconf"`
+	FundConf uint16 `json:"fundconf"`
 }
 
 // Convert uint64 to 8 bytes.

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -58,16 +58,16 @@ func NextID() uint64 {
 	return atomic.AddUint64(&idCounter, 1)
 }
 
-// rpcRoute describes a handler for a specific message route.
-type rpcRoute func(Link, *msgjson.Message) *msgjson.Error
+// MsgHandler describes a handler for a specific message route.
+type MsgHandler func(Link, *msgjson.Message) *msgjson.Error
 
 // rpcRoutes maps message routes to the handlers.
-var rpcRoutes = make(map[string]rpcRoute)
+var rpcRoutes = make(map[string]MsgHandler)
 
 // Route registers a handler for a specified route. The handler map is global
 // and has no mutex protection. All calls to Route should be done before the
 // Server is started.
-func Route(route string, handler rpcRoute) {
+func Route(route string, handler MsgHandler) {
 	if route == "" {
 		panic("Route: route is empty string")
 	}
@@ -80,7 +80,7 @@ func Route(route string, handler rpcRoute) {
 
 // RouteHandler gets the handler registered to the specified route, if it
 // exists.
-func RouteHandler(route string) rpcRoute {
+func RouteHandler(route string) MsgHandler {
 	return rpcRoutes[route]
 }
 

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -227,7 +227,7 @@ func TestMarket_runEpochs(t *testing.T) {
 	qty := uint64(dcrLotSize * lots)
 	rate := uint64(1000) * dcrRateStep
 	aid := test.NextAccount()
-	limit := &msgjson.Limit{
+	limit := &msgjson.LimitOrder{
 		Prefix: msgjson.Prefix{
 			AccountID:  aid[:],
 			Base:       dcrID,
@@ -510,7 +510,7 @@ func TestMarket_Cancelable(t *testing.T) {
 	qty := uint64(dcrLotSize * lots)
 	rate := uint64(1000) * dcrRateStep
 	aid := test.NextAccount()
-	limitMsg := &msgjson.Limit{
+	limitMsg := &msgjson.LimitOrder{
 		Prefix: msgjson.Prefix{
 			AccountID:  aid[:],
 			Base:       dcrID,

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -146,7 +146,7 @@ func NewOrderRouter(cfg *OrderRouterConfig) *OrderRouter {
 // msgjson.Limit payload, validates the information, constructs an
 // order.LimitOrder and submits it to the epoch queue.
 func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
-	limit := new(msgjson.Limit)
+	limit := new(msgjson.LimitOrder)
 	err := json.Unmarshal(msg.Payload, limit)
 	if err != nil {
 		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'limit' payload")
@@ -234,10 +234,10 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 }
 
 // handleMarket is the handler for the 'market' route. This route accepts a
-// msgjson.Market payload, validates the information, constructs an
+// msgjson.MarketOrder payload, validates the information, constructs an
 // order.MarketOrder and submits it to the epoch queue.
 func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
-	market := new(msgjson.Market)
+	market := new(msgjson.MarketOrder)
 	err := json.Unmarshal(msg.Payload, market)
 	if err != nil {
 		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'market' payload")
@@ -323,7 +323,7 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 // msgjson.Cancel payload, validates the information, constructs an
 // order.CancelOrder and submits it to the epoch queue.
 func (r *OrderRouter) handleCancel(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
-	cancel := new(msgjson.Cancel)
+	cancel := new(msgjson.CancelOrder)
 	err := json.Unmarshal(msg.Payload, cancel)
 	if err != nil {
 		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'cancel' payload")

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -433,7 +433,7 @@ func TestLimit(t *testing.T) {
 	rate := uint64(1000) * dcrRateStep
 	user := oRig.user
 	clientTime := nowMs()
-	limit := msgjson.Limit{
+	limit := msgjson.LimitOrder{
 		Prefix: msgjson.Prefix{
 			AccountID:  user.acct[:],
 			Base:       dcrID,
@@ -574,7 +574,7 @@ func TestMarketStartProcessStop(t *testing.T) {
 	qty := uint64(dcrLotSize) * 10
 	user := oRig.user
 	clientTime := nowMs()
-	mkt := msgjson.Market{
+	mkt := msgjson.MarketOrder{
 		Prefix: msgjson.Prefix{
 			AccountID:  user.acct[:],
 			Base:       dcrID,
@@ -704,7 +704,7 @@ func TestCancel(t *testing.T) {
 	user := oRig.user
 	targetID := order.OrderID{244}
 	clientTime := nowMs()
-	cancel := msgjson.Cancel{
+	cancel := msgjson.CancelOrder{
 		Prefix: msgjson.Prefix{
 			AccountID:  user.acct[:],
 			Base:       dcrID,


### PR DESCRIPTION
This changes the `msgjson.ConfigResult` to include market variables, as proposed in https://github.com/decred/dcrdex/issues/126

Also:
- Rename `msgjson.{Limit,Market,Cancel}` to `msgjson.{Limit,Market,Cancel}Order`.
- Update `market` package tests.
-  `client/core`: Include new market variables from `msgjson.ConfigResults` in `core.Market`.  Unmarshal and unpack into `core.Market`.
-  `comms`: rename `rpcRoute` type and export to `MsgHandler`.  The `comms.Route` function is exported so it make senses that the type of each input argument should be exported too, if for no other reason than published documentation.

I intend to implement the `config` route (of the new `comms.MsgHandler` type) in the `dex` package in a follow-up PR if these changes work.