### PR TITLE
market: update epochOrders map before responding to order router

### DIFF
--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -162,7 +162,8 @@ type MatchArchiver interface {
 // ValidateOrder ensures that the order with the given status for the specified
 // market is sensible. This function is in the database package because the
 // concept of a valid order-status-market state is dependent on the semantics of
-// order archival.
+// order archival. The ServerTime may not be set yet, so the OrderID cannot be
+// computed.
 func ValidateOrder(ord order.Order, status order.OrderStatus, mkt *dex.MarketInfo) bool {
 	// Orders with status OrderStatusUnknown should never reach the database.
 	if status == order.OrderStatusUnknown {

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -521,7 +521,7 @@ func TestMarket_Cancelable(t *testing.T) {
 	}
 
 	// Let the epoch cycle.
-	time.Sleep(time.Duration(epochDurationMSec)*time.Millisecond + time.Duration(epochDurationMSec/20))
+	time.Sleep(time.Duration(epochDurationMSec+epochDurationMSec/20) * time.Millisecond)
 	if !mkt.Cancelable(lo.ID()) {
 		t.Errorf("Cancelable failed to report order %v as cancelable, "+
 			"but it should have been booked.", lo)


### PR DESCRIPTION
`(*Market).processOrder` must respond to the submitter of new orders
only after updating `epochOrders` so that `Cancelable` will reflect that
the order is now in the epoch queue.

`SubmitOrderAsync` may not use order ID for logging when orders fail
validation because the `ServerTime` is not yet set.
Also, when testing order submission, set the time in the current epoch.