### PR TITLE
multi: add client epoch queue.

### DIFF
--- a/client/order/epochqueue.go
+++ b/client/order/epochqueue.go
@@ -1,0 +1,190 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package order
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"sync"
+
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/dex/order"
+	"github.com/decred/dcrd/crypto/blake256"
+)
+
+// EpochQueue represents a client epoch queue.
+type EpochQueue struct {
+	orders             map[order.OrderID]*msgjson.EpochOrderNote
+	ordersMtx          sync.Mutex
+	seedIndex          []order.OrderID
+	seedIndexMtx       sync.Mutex
+	commitmentIndex    []order.OrderID
+	commitmentIndexMtx sync.Mutex
+}
+
+// NewEpochQueue creates a client epoch queue.
+func NewEpochQueue() *EpochQueue {
+	return &EpochQueue{
+		orders:          make(map[order.OrderID]*msgjson.EpochOrderNote),
+		seedIndex:       make([]order.OrderID, 0),
+		commitmentIndex: make([]order.OrderID, 0),
+	}
+}
+
+// Reset clears the epoch queue. This should be called when a new epoch begins.
+func (eq *EpochQueue) Reset() {
+	eq.ordersMtx.Lock()
+	eq.orders = make(map[order.OrderID]*msgjson.EpochOrderNote)
+	eq.ordersMtx.Unlock()
+
+	eq.seedIndexMtx.Lock()
+	eq.seedIndex = make([]order.OrderID, 0)
+	eq.seedIndexMtx.Unlock()
+
+	eq.commitmentIndexMtx.Lock()
+	eq.commitmentIndex = make([]order.OrderID, 0)
+	eq.commitmentIndexMtx.Unlock()
+}
+
+// Queue appends the provided note to the epoch queue.
+func (eq *EpochQueue) Queue(note *msgjson.EpochOrderNote) {
+	var oid order.OrderID
+	copy(oid[:], note.OrderID[:])
+
+	eq.ordersMtx.Lock()
+	defer eq.ordersMtx.Unlock()
+
+	eq.orders[oid] = note
+
+	// Update the seed sort order per order ids.
+	eq.seedIndexMtx.Lock()
+	si := sort.Search(len(eq.seedIndex), func(i int) bool {
+		order := eq.orders[eq.seedIndex[i]]
+		return bytes.Compare(order.OrderID[:], oid[:]) > 0
+	})
+	eq.seedIndex = append(eq.seedIndex, order.OrderID{})
+	copy(eq.seedIndex[si+1:], eq.seedIndex[si:])
+	eq.seedIndex[si] = oid
+	eq.seedIndexMtx.Unlock()
+
+	// Update the commitment sort order per order commitments.
+	eq.commitmentIndexMtx.Lock()
+	ci := sort.Search(len(eq.commitmentIndex), func(i int) bool {
+		order := eq.orders[eq.commitmentIndex[i]]
+		return bytes.Compare(order.Commitment[:], note.Commitment[:]) > 0
+	})
+	eq.commitmentIndex = append(eq.commitmentIndex, order.OrderID{})
+	copy(eq.commitmentIndex[ci+1:], eq.commitmentIndex[ci:])
+	eq.commitmentIndex[ci] = oid
+	eq.commitmentIndexMtx.Unlock()
+}
+
+// Exists checks if the provided order id is in the queue.
+func (eq *EpochQueue) Size() int {
+	eq.ordersMtx.Lock()
+	size := len(eq.orders)
+	eq.ordersMtx.Unlock()
+	return size
+}
+
+// Exists checks if the provided order id is in the queue.
+func (eq *EpochQueue) Exists(oid order.OrderID) bool {
+	eq.ordersMtx.Lock()
+	_, ok := eq.orders[oid]
+	eq.ordersMtx.Unlock()
+	return ok
+}
+
+// GenerateMatchProof calculates the sorting seed used in order matching as well as the
+// commitment checksum from the provided epoch queue preimages and misses.
+func (eq *EpochQueue) GenerateMatchProof(preimages []order.Preimage, misses []string) (int64, msgjson.Bytes, error) {
+	eq.ordersMtx.Lock()
+	defer eq.ordersMtx.Unlock()
+
+	// Remove all misses.
+	for _, entry := range misses {
+		b, err := hex.DecodeString(entry[:])
+		if err != nil {
+			return 0, nil, fmt.Errorf("decoding error: %v", err)
+		}
+		var oid order.OrderID
+		copy(oid[:], b[:])
+
+		delete(eq.orders, oid)
+
+		// Remove the seed index associated with the miss, preserving
+		// the sort order in the process.
+		eq.seedIndexMtx.Lock()
+		si := sort.Search(len(eq.seedIndex), func(i int) bool { return bytes.Compare(eq.seedIndex[i][:], oid[:]) >= 0 })
+		if si == len(eq.seedIndex) {
+			return 0, nil, fmt.Errorf("expected to find id %s in seed sort index", oid)
+		}
+		if si < len(eq.seedIndex)-1 {
+			copy(eq.seedIndex[si:], eq.seedIndex[si+1:])
+		}
+		eq.seedIndex[len(eq.seedIndex)-1] = order.OrderID{}
+		eq.seedIndex = eq.seedIndex[:len(eq.seedIndex)-1]
+		eq.seedIndexMtx.Unlock()
+
+		// Remove the commitment index associated with the miss, preserving
+		// the sort order in the process.
+		eq.commitmentIndexMtx.Lock()
+		ci := sort.Search(len(eq.commitmentIndex), func(i int) bool { return bytes.Compare(eq.commitmentIndex[i][:], oid[:]) >= 0 })
+		if ci == len(eq.commitmentIndex) {
+			return 0, nil, fmt.Errorf("expected to find id %s in commitment sort index", oid)
+		}
+		if ci < len(eq.commitmentIndex)-1 {
+			copy(eq.commitmentIndex[ci:], eq.commitmentIndex[ci+1:])
+		}
+		eq.commitmentIndex[len(eq.commitmentIndex)-1] = order.OrderID{}
+		eq.commitmentIndex = eq.commitmentIndex[:len(eq.commitmentIndex)-1]
+		eq.commitmentIndexMtx.Unlock()
+	}
+
+	// Map the preimages received with their associated epoch order ids.
+	matches := make(map[order.OrderID]msgjson.Bytes)
+	for i := 0; i < len(preimages); i++ {
+		for oid, note := range eq.orders {
+			commitment := blake256.Sum256(preimages[i][:])
+			if bytes.Equal(note.Commitment, commitment[:]) {
+				matches[oid] = preimages[i][:]
+				break
+			}
+		}
+	}
+
+	// Ensure all remaining epoch orders matched to a preimage.
+	if len(matches) != len(eq.orders) {
+		return 0, nil, fmt.Errorf("expected all remaining epoch orders (%v) "+
+			"matched to a preimage (%v)", len(matches), len(eq.orders))
+	}
+
+	// Concatenate all preimages per the seed sort index and generate the
+	// seed.
+	eq.seedIndexMtx.Lock()
+	sbuff := make([]byte, 0, len(eq.seedIndex)*order.PreimageSize)
+	for _, oid := range eq.seedIndex {
+		pimg := matches[oid]
+		sbuff = append(sbuff, pimg...)
+	}
+	eq.seedIndexMtx.Unlock()
+
+	seed := int64(binary.LittleEndian.Uint64(sbuff[:64]))
+
+	// Concatenate all order commitments per the commitment sort index and
+	// generate the commitment checksum.
+	eq.commitmentIndexMtx.Lock()
+	cbuff := make([]byte, 0, len(eq.orders)*order.CommitmentSize)
+	for _, oid := range eq.commitmentIndex {
+		cbuff = append(cbuff, eq.orders[oid].Commitment...)
+	}
+	eq.commitmentIndexMtx.Unlock()
+
+	csum := blake256.Sum256(cbuff)
+
+	return seed, msgjson.Bytes(csum[:]), nil
+}

--- a/client/order/epochqueue.go
+++ b/client/order/epochqueue.go
@@ -6,7 +6,6 @@ package order
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"sort"
 	"sync"
@@ -18,142 +17,107 @@ import (
 
 // EpochQueue represents a client epoch queue.
 type EpochQueue struct {
-	orders             map[order.OrderID]*msgjson.EpochOrderNote
-	ordersMtx          sync.Mutex
-	seedIndex          []order.OrderID
-	seedIndexMtx       sync.Mutex
-	commitmentIndex    []order.OrderID
-	commitmentIndexMtx sync.Mutex
+	orders map[order.OrderID]order.Commitment
+	mtx    sync.Mutex
 }
 
 // NewEpochQueue creates a client epoch queue.
 func NewEpochQueue() *EpochQueue {
 	return &EpochQueue{
-		orders:          make(map[order.OrderID]*msgjson.EpochOrderNote),
-		seedIndex:       make([]order.OrderID, 0),
-		commitmentIndex: make([]order.OrderID, 0),
+		orders: make(map[order.OrderID]order.Commitment),
 	}
 }
 
 // Reset clears the epoch queue. This should be called when a new epoch begins.
 func (eq *EpochQueue) Reset() {
-	eq.ordersMtx.Lock()
-	eq.orders = make(map[order.OrderID]*msgjson.EpochOrderNote)
-	eq.ordersMtx.Unlock()
-
-	eq.seedIndexMtx.Lock()
-	eq.seedIndex = make([]order.OrderID, 0)
-	eq.seedIndexMtx.Unlock()
-
-	eq.commitmentIndexMtx.Lock()
-	eq.commitmentIndex = make([]order.OrderID, 0)
-	eq.commitmentIndexMtx.Unlock()
+	eq.mtx.Lock()
+	eq.orders = make(map[order.OrderID]order.Commitment)
+	eq.mtx.Unlock()
 }
 
-// Queue appends the provided note to the epoch queue.
-func (eq *EpochQueue) Queue(note *msgjson.EpochOrderNote) {
+// Enqueue appends the provided order note to the epoch queue.
+func (eq *EpochQueue) Enqueue(note *msgjson.EpochOrderNote) error {
+	if len(note.OrderID) != order.OrderIDSize {
+		return fmt.Errorf("expected order id length of %d, got %d",
+			order.OrderIDSize, len(note.OrderID))
+	}
+
 	var oid order.OrderID
-	copy(oid[:], note.OrderID[:])
+	copy(oid[:], note.OrderID)
 
-	eq.ordersMtx.Lock()
-	defer eq.ordersMtx.Unlock()
+	// Ensure the provided epoch order is not already queued.
+	_, ok := eq.orders[oid]
+	if ok {
+		return fmt.Errorf("%s is already queued", oid)
+	}
 
-	eq.orders[oid] = note
+	var commitment order.Commitment
+	copy(commitment[:], note.Commitment)
 
-	// Update the seed sort order per order ids.
-	eq.seedIndexMtx.Lock()
-	si := sort.Search(len(eq.seedIndex), func(i int) bool {
-		order := eq.orders[eq.seedIndex[i]]
-		return bytes.Compare(order.OrderID[:], oid[:]) > 0
-	})
-	eq.seedIndex = append(eq.seedIndex, order.OrderID{})
-	copy(eq.seedIndex[si+1:], eq.seedIndex[si:])
-	eq.seedIndex[si] = oid
-	eq.seedIndexMtx.Unlock()
+	eq.mtx.Lock()
+	eq.orders[oid] = commitment
+	eq.mtx.Unlock()
 
-	// Update the commitment sort order per order commitments.
-	eq.commitmentIndexMtx.Lock()
-	ci := sort.Search(len(eq.commitmentIndex), func(i int) bool {
-		order := eq.orders[eq.commitmentIndex[i]]
-		return bytes.Compare(order.Commitment[:], note.Commitment[:]) > 0
-	})
-	eq.commitmentIndex = append(eq.commitmentIndex, order.OrderID{})
-	copy(eq.commitmentIndex[ci+1:], eq.commitmentIndex[ci:])
-	eq.commitmentIndex[ci] = oid
-	eq.commitmentIndexMtx.Unlock()
+	return nil
 }
 
-// Exists checks if the provided order id is in the queue.
+// Size returns the number of entries in the epoch queue.
 func (eq *EpochQueue) Size() int {
-	eq.ordersMtx.Lock()
+	eq.mtx.Lock()
 	size := len(eq.orders)
-	eq.ordersMtx.Unlock()
+	eq.mtx.Unlock()
 	return size
 }
 
 // Exists checks if the provided order id is in the queue.
 func (eq *EpochQueue) Exists(oid order.OrderID) bool {
-	eq.ordersMtx.Lock()
+	eq.mtx.Lock()
 	_, ok := eq.orders[oid]
-	eq.ordersMtx.Unlock()
+	eq.mtx.Unlock()
 	return ok
 }
 
-// GenerateMatchProof calculates the sorting seed used in order matching as well as the
-// commitment checksum from the provided epoch queue preimages and misses.
-func (eq *EpochQueue) GenerateMatchProof(preimages []order.Preimage, misses []string) (int64, msgjson.Bytes, error) {
-	eq.ordersMtx.Lock()
-	defer eq.ordersMtx.Unlock()
+// GenerateMatchProof calculates the sorting seed used in order matching
+// as well as the commitment checksum from the provided epoch queue
+// preimages and misses.
+//
+// The epoch queue needs to be reset if there are preimage mismatches or
+// non-existent orders for preimage errors.
+func (eq *EpochQueue) GenerateMatchProof(preimages []order.Preimage, misses []order.OrderID) (int64, msgjson.Bytes, error) {
+	eq.mtx.Lock()
+	defer eq.mtx.Unlock()
+
+	if len(eq.orders) == 0 {
+		return 0, nil,
+			fmt.Errorf("cannot generate match proof with an empty epoch queue")
+	}
 
 	// Remove all misses.
-	for _, entry := range misses {
-		b, err := hex.DecodeString(entry[:])
-		if err != nil {
-			return 0, nil, fmt.Errorf("decoding error: %v", err)
-		}
-		var oid order.OrderID
-		copy(oid[:], b[:])
-
+	for _, oid := range misses {
 		delete(eq.orders, oid)
+	}
 
-		// Remove the seed index associated with the miss, preserving
-		// the sort order in the process.
-		eq.seedIndexMtx.Lock()
-		si := sort.Search(len(eq.seedIndex), func(i int) bool { return bytes.Compare(eq.seedIndex[i][:], oid[:]) >= 0 })
-		if si == len(eq.seedIndex) {
-			return 0, nil, fmt.Errorf("expected to find id %s in seed sort index", oid)
-		}
-		if si < len(eq.seedIndex)-1 {
-			copy(eq.seedIndex[si:], eq.seedIndex[si+1:])
-		}
-		eq.seedIndex[len(eq.seedIndex)-1] = order.OrderID{}
-		eq.seedIndex = eq.seedIndex[:len(eq.seedIndex)-1]
-		eq.seedIndexMtx.Unlock()
-
-		// Remove the commitment index associated with the miss, preserving
-		// the sort order in the process.
-		eq.commitmentIndexMtx.Lock()
-		ci := sort.Search(len(eq.commitmentIndex), func(i int) bool { return bytes.Compare(eq.commitmentIndex[i][:], oid[:]) >= 0 })
-		if ci == len(eq.commitmentIndex) {
-			return 0, nil, fmt.Errorf("expected to find id %s in commitment sort index", oid)
-		}
-		if ci < len(eq.commitmentIndex)-1 {
-			copy(eq.commitmentIndex[ci:], eq.commitmentIndex[ci+1:])
-		}
-		eq.commitmentIndex[len(eq.commitmentIndex)-1] = order.OrderID{}
-		eq.commitmentIndex = eq.commitmentIndex[:len(eq.commitmentIndex)-1]
-		eq.commitmentIndexMtx.Unlock()
+	if len(eq.orders) != len(preimages) {
+		return 0, nil, fmt.Errorf("expected same length for epoch queue (%v) "+
+			"preimages (%v)", len(eq.orders), len(preimages))
 	}
 
 	// Map the preimages received with their associated epoch order ids.
-	matches := make(map[order.OrderID]msgjson.Bytes)
-	for i := 0; i < len(preimages); i++ {
-		for oid, note := range eq.orders {
+	matches := make(map[order.OrderID]order.Preimage, len(eq.orders))
+	for i := range preimages {
+		var match bool
+		for oid, commit := range eq.orders {
 			commitment := blake256.Sum256(preimages[i][:])
-			if bytes.Equal(note.Commitment, commitment[:]) {
-				matches[oid] = preimages[i][:]
+			if bytes.Equal(commit[:], commitment[:]) {
+				matches[oid] = preimages[i]
+				match = true
 				break
 			}
+		}
+
+		if !match {
+			return 0, nil,
+				fmt.Errorf("no order match found for preimage %x", preimages[i])
 		}
 	}
 
@@ -163,27 +127,38 @@ func (eq *EpochQueue) GenerateMatchProof(preimages []order.Preimage, misses []st
 			"matched to a preimage (%v)", len(matches), len(eq.orders))
 	}
 
-	// Concatenate all preimages per the seed sort index and generate the
+	oids := make([]order.OrderID, 0, len(eq.orders))
+	commitments := make([]order.Commitment, 0, len(eq.orders))
+	for oid, commit := range eq.orders {
+		oids = append(oids, oid)
+		commitments = append(commitments, commit)
+	}
+
+	sort.Slice(oids, func(i, j int) bool {
+		return bytes.Compare(oids[i][:], oids[j][:]) < 0
+	})
+
+	sort.Slice(commitments, func(i, j int) bool {
+		return bytes.Compare(commitments[i][:], commitments[j][:]) < 0
+	})
+
+	// Concatenate the sorted preimages per and generate the
 	// seed.
-	eq.seedIndexMtx.Lock()
-	sbuff := make([]byte, 0, len(eq.seedIndex)*order.PreimageSize)
-	for _, oid := range eq.seedIndex {
+	sbuff := make([]byte, 0, len(eq.orders)*order.PreimageSize)
+	for _, oid := range oids {
 		pimg := matches[oid]
-		sbuff = append(sbuff, pimg...)
+		sbuff = append(sbuff, pimg[:]...)
 	}
-	eq.seedIndexMtx.Unlock()
 
-	seed := int64(binary.LittleEndian.Uint64(sbuff[:64]))
+	sum := blake256.Sum256(sbuff)
+	seed := int64(binary.LittleEndian.Uint64(sum[:8]))
 
-	// Concatenate all order commitments per the commitment sort index and
-	// generate the commitment checksum.
-	eq.commitmentIndexMtx.Lock()
+	// Concatenate the sorted order commitments and generate the
+	// commitment checksum.
 	cbuff := make([]byte, 0, len(eq.orders)*order.CommitmentSize)
-	for _, oid := range eq.commitmentIndex {
-		cbuff = append(cbuff, eq.orders[oid].Commitment...)
+	for _, commit := range commitments {
+		cbuff = append(cbuff, commit[:]...)
 	}
-	eq.commitmentIndexMtx.Unlock()
-
 	csum := blake256.Sum256(cbuff)
 
 	return seed, msgjson.Bytes(csum[:]), nil

--- a/client/order/epochqueue_test.go
+++ b/client/order/epochqueue_test.go
@@ -1,0 +1,210 @@
+package order
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/dex/order"
+	"github.com/decred/dcrd/crypto/blake256"
+)
+
+func makeEpochOrderNote(mid string, side uint8, oid order.OrderID, rate uint64,
+	qty uint64, commitment order.Commitment) *msgjson.EpochOrderNote {
+	return &msgjson.EpochOrderNote{
+		BookOrderNote: msgjson.BookOrderNote{
+			TradeNote: msgjson.TradeNote{
+				Side:     side,
+				Rate:     rate,
+				Quantity: qty,
+			},
+			OrderNote: msgjson.OrderNote{
+				MarketID:   mid,
+				OrderID:    oid[:],
+				Commitment: commitment[:],
+			},
+		},
+	}
+}
+
+func makeCommitment(pimg order.Preimage) order.Commitment {
+	return order.Commitment(blake256.Sum256(pimg[:]))
+}
+
+// makeMatchProof generates the sorting seed and commmitment checksum from the
+// provided ordered set of preimages and commitments.
+func makeMatchProof(preimages []order.Preimage, commitments []order.Commitment) (int64, msgjson.Bytes, error) {
+	if len(preimages) != len(commitments) {
+		return 0, nil, fmt.Errorf("expected equal number of preimages and commitments")
+	}
+
+	sbuff := make([]byte, 0, len(preimages)*order.PreimageSize)
+	cbuff := make([]byte, 0, len(commitments)*order.CommitmentSize)
+	for i := 0; i < len(preimages); i++ {
+		sbuff = append(sbuff, preimages[i][:]...)
+		cbuff = append(cbuff, commitments[i][:]...)
+	}
+	seed := int64(binary.LittleEndian.Uint64(sbuff[:64]))
+	csum := blake256.Sum256(cbuff)
+	return seed, msgjson.Bytes(csum[:]), nil
+}
+
+func makeSortOrder(ids ...order.OrderID) []order.OrderID {
+	so := make([]order.OrderID, 0, len(ids))
+	for _, entry := range ids {
+		var oid order.OrderID
+		copy(oid[:], entry[:])
+		so = append(so, oid)
+	}
+	return so
+}
+
+func TestEpochQueue(t *testing.T) {
+	mid := "mkt"
+	eq := NewEpochQueue()
+	n1Pimg := [32]byte{'1'}
+	n1Commitment := makeCommitment(n1Pimg)
+	n1OrderID := [32]byte{'a'}
+	n1 := makeEpochOrderNote(mid, msgjson.BuyOrderNum, n1OrderID, 1, 3, n1Commitment)
+	eq.Queue(n1)
+
+	// Ensure the epoch queue size is 1.
+	if eq.Size() != 1 {
+		t.Fatalf("[Size] expected queue size of %d, got %d", 1, eq.Size())
+	}
+
+	// Reset the epoch queue.
+	eq.Reset()
+
+	// Ensure the epoch queue size is 0.
+	if eq.Size() != 0 {
+		t.Fatalf("[Size] expected queue size of %d, got %d", 0, eq.Size())
+	}
+
+	eq.Queue(n1)
+
+	n2Pimg := [32]byte{'2'}
+	n2Commitment := makeCommitment(n2Pimg)
+	n2OrderID := [32]byte{'b'}
+	n2 := makeEpochOrderNote(mid, msgjson.BuyOrderNum, n2OrderID, 2, 4, n2Commitment)
+	eq.Queue(n2)
+
+	n3Pimg := [32]byte{'3'}
+	n3Commitment := makeCommitment(n3Pimg)
+	n3OrderID := [32]byte{'c'}
+	n3 := makeEpochOrderNote(mid, msgjson.BuyOrderNum, n3OrderID, 3, 6, n3Commitment)
+	eq.Queue(n3)
+
+	// Ensure the queue has n2 epoch order.
+	if !eq.Exists(n2OrderID) {
+		t.Fatalf("[Exists] expected order with id %x in the epoch queue", n2OrderID)
+	}
+
+	// Ensure the epoch queue size is 3.
+	if eq.Size() != 3 {
+		t.Fatalf("[Size] expected queue size of %d, got %d", 3, eq.Size())
+	}
+
+	// Ensure the seed index has the expected order.
+	expectedSeedSO := makeSortOrder(n1OrderID, n2OrderID, n3OrderID)
+
+	eq.seedIndexMtx.Lock()
+	for i := 0; i < len(eq.seedIndex); i++ {
+		if !bytes.Equal(expectedSeedSO[i][:], eq.seedIndex[i][:]) {
+			t.Fatalf("expected id %s at seed sort order index %d, got %s",
+				expectedSeedSO[i].String(), i, eq.seedIndex[i].String())
+		}
+	}
+	eq.seedIndexMtx.Unlock()
+
+	// Ensure the commitment index has the expected order.
+	expectedCommitmentSO := makeSortOrder(n3OrderID, n1OrderID, n2OrderID)
+
+	eq.commitmentIndexMtx.Lock()
+	for i := 0; i < len(eq.commitmentIndex); i++ {
+		if !bytes.Equal(expectedCommitmentSO[i][:], eq.commitmentIndex[i][:]) {
+			t.Fatalf("expected id %s at commitment sort order index %d, got %s",
+				expectedCommitmentSO[i].String(), i, eq.seedIndex[i].String())
+		}
+	}
+	eq.commitmentIndexMtx.Unlock()
+
+	// Ensure match proof generation works as expected.
+	preimages := []order.Preimage{n1Pimg, n2Pimg, n3Pimg}
+	commitments := []order.Commitment{n3Commitment, n1Commitment, n2Commitment}
+	expectedSeed, expectedCmtChecksum, err := makeMatchProof(preimages, commitments)
+	if err != nil {
+		t.Fatalf("[makeMatchProof] unexpected error: %v", err)
+	}
+
+	seed, cmtChecksum, err := eq.GenerateMatchProof(preimages, nil)
+	if err != nil {
+		t.Fatalf("[GenerateMatchProof] unexpected error: %v", err)
+	}
+
+	if expectedSeed != seed {
+		t.Fatalf("expected seed %d, got %d", expectedSeed, seed)
+	}
+
+	if !bytes.Equal(expectedCmtChecksum, cmtChecksum) {
+		t.Fatalf("expected commitment checksum %x, got %x",
+			expectedCmtChecksum, cmtChecksum)
+	}
+
+	eq.Reset()
+
+	// Queue epoch orders.
+	eq.Queue(n3)
+	eq.Queue(n1)
+	eq.Queue(n2)
+
+	// Ensure the queue has n1 epoch order.
+	if !eq.Exists(n1OrderID) {
+		t.Fatalf("[Exists] expected order with id %x in the epoch queue", n1OrderID)
+	}
+
+	// Ensure the seed index has the expected order.
+	eq.seedIndexMtx.Lock()
+	for i := 0; i < len(eq.seedIndex); i++ {
+		if !bytes.Equal(expectedSeedSO[i][:], eq.seedIndex[i][:]) {
+			t.Fatalf("expected id %s at seed sort order index %d, got %s",
+				expectedSeedSO[i].String(), i, eq.seedIndex[i].String())
+		}
+	}
+	eq.seedIndexMtx.Unlock()
+
+	// Ensure the commitment index has the expected order.
+	eq.commitmentIndexMtx.Lock()
+	for i := 0; i < len(eq.commitmentIndex); i++ {
+		if !bytes.Equal(expectedCommitmentSO[i][:], eq.commitmentIndex[i][:]) {
+			t.Fatalf("expected id %s at commitment sort order index %d, got %s",
+				expectedCommitmentSO[i].String(), i, eq.seedIndex[i].String())
+		}
+	}
+	eq.commitmentIndexMtx.Unlock()
+
+	// Ensure match proof generation works as expected, when there are misses.
+	preimages = []order.Preimage{n1Pimg, n3Pimg}
+	commitments = []order.Commitment{n3Commitment, n1Commitment}
+	expectedSeed, expectedCmtChecksum, err = makeMatchProof(preimages, commitments)
+	if err != nil {
+		t.Fatalf("[makeMatchProof] unexpected error: %v", err)
+	}
+
+	misses := []string{n2.OrderID.String()}
+	seed, cmtChecksum, err = eq.GenerateMatchProof(preimages, misses)
+	if err != nil {
+		t.Fatalf("[GenerateMatchProof] unexpected error: %v", err)
+	}
+
+	if expectedSeed != seed {
+		t.Fatalf("expected seed %d, got %d", expectedSeed, seed)
+	}
+
+	if !bytes.Equal(expectedCmtChecksum, cmtChecksum) {
+		t.Fatalf("expected commitment checksum %x, got %x",
+			expectedCmtChecksum, cmtChecksum)
+	}
+}

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -443,6 +443,7 @@ type Coin struct {
 type Prefix struct {
 	signable
 	AccountID     Bytes  `json:"accountid"`
+	Commitment    Bytes  `json:"com"`
 	Base          uint32 `json:"base"`
 	Quote         uint32 `json:"quote"`
 	OrderType     uint8  `json:"ordertype"`
@@ -459,6 +460,8 @@ func (p *Prefix) Stamp(t, epochIdx, epochDur uint64) {
 	p.EpochIdx = epochIdx
 	p.EpochDuration = epochDur
 }
+
+// TODO: Update prefix serialization with commitment.
 
 // Serialize serializes the Prefix data.
 func (p *Prefix) Serialize() []byte {
@@ -578,9 +581,10 @@ type TradeNote struct {
 
 // OrderNote is part of a notification about any type of order.
 type OrderNote struct {
-	Seq      uint64 `json:"seq,omitempty"`      // May be empty when part of an OrderBook.
-	MarketID string `json:"marketid,omitempty"` // May be empty when part of an OrderBook.
-	OrderID  Bytes  `json:"oid"`
+	Seq        uint64 `json:"seq,omitempty"`      // May be empty when part of an OrderBook.
+	MarketID   string `json:"marketid,omitempty"` // May be empty when part of an OrderBook.
+	OrderID    Bytes  `json:"oid"`
+	Commitment Bytes  `json:"com"`
 }
 
 // BookOrderNote is the payload for a DEX-originating notification-type message

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -443,7 +443,6 @@ type Coin struct {
 type Prefix struct {
 	signable
 	AccountID     Bytes  `json:"accountid"`
-	Commitment    Bytes  `json:"com"`
 	Base          uint32 `json:"base"`
 	Quote         uint32 `json:"quote"`
 	OrderType     uint8  `json:"ordertype"`
@@ -612,9 +611,10 @@ type UnbookOrderNote OrderNote
 // the client about an order added to the epoch queue.
 type EpochOrderNote struct {
 	BookOrderNote
-	OrderType uint8  `json:"otype"`
-	TargetID  Bytes  `json:"target,omitempty"`
-	Epoch     uint64 `json:"epoch"`
+	Commitment Bytes  `json:"com"`
+	OrderType  uint8  `json:"otype"`
+	TargetID   Bytes  `json:"target,omitempty"`
+	Epoch      uint64 `json:"epoch"`
 }
 
 // Connect is the payload for a client-originating ConnectRoute request.

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -183,7 +183,6 @@ type Commitment [CommitmentSize]byte
 // Prefix is the order prefix containing data fields common to all orders.
 type Prefix struct {
 	AccountID  account.AccountID
-	Commitment Commitment
 	BaseAsset  uint32
 	QuoteAsset uint32
 	OrderType  OrderType

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -168,9 +168,22 @@ func (c CoinID) String() string {
 	return hex.EncodeToString(c)
 }
 
+// PreimageSize defines the length in bytes of a Preimage.
+const PreimageSize = 32
+
+// Preimage is a 32-byte ramdom number used in generating an order commitment.
+type Preimage [PreimageSize]byte
+
+// CommitmntSize defines the length in bytes of a Commitment.
+const CommitmentSize = blake256.Size // 32
+
+// Commitment is the hash of a preimage.
+type Commitment [CommitmentSize]byte
+
 // Prefix is the order prefix containing data fields common to all orders.
 type Prefix struct {
 	AccountID  account.AccountID
+	Commitment Commitment
 	BaseAsset  uint32
 	QuoteAsset uint32
 	OrderType  OrderType
@@ -182,6 +195,8 @@ type Prefix struct {
 	//nolint:structcheck
 	uid string // cache of the order's UID
 }
+
+// TODO: Update Prefix serialization with commitment.
 
 // P is an alias for Prefix. Embedding with the alias allows us to define a
 // method on the interface called Prefix that returns the *Prefix.


### PR DESCRIPTION
This adds an epoch queue to the client with match proof validation. This comprises of generating the seed from the first 64-bits of sorted and concatenated epoch order preimages and generating the commitment checksum from the sorted and concatenated epoch order commitments.

This will be rebased and updated to use the types defined in #145 when that's ready.