### PR TITLE
market, book: rework duplicate order detection for cancels

### DIFF
--- a/server/book/book.go
+++ b/server/book/book.go
@@ -122,9 +122,20 @@ func (b *Book) Remove(oid order.OrderID) (*order.LimitOrder, bool) {
 
 // HaveOrder checks if an order is in either the buy or sell side of the book.
 func (b *Book) HaveOrder(oid order.OrderID) bool {
-	b.mtx.Lock()
-	defer b.mtx.Unlock()
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
 	return b.buys.HaveOrder(oid) || b.sells.HaveOrder(oid)
+}
+
+// Order attempts to retrieve an order from either the buy or sell side of the
+// book. If the order data is not required, consider using HaveOrder.
+func (b *Book) Order(oid order.OrderID) *order.LimitOrder {
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+	if lo := b.buys.Order(oid); lo != nil {
+		return lo
+	}
+	return b.sells.Order(oid)
 }
 
 // SellOrders copies out all sell orders in the book, sorted.

--- a/server/book/orderpq.go
+++ b/server/book/orderpq.go
@@ -441,6 +441,16 @@ func (pq *OrderPQ) HaveOrder(oid order.OrderID) bool {
 	return pq.orders[oid] != nil
 }
 
+// Order retrieves any existing order in the queue with the given ID.
+func (pq *OrderPQ) Order(oid order.OrderID) *order.LimitOrder {
+	pq.mtx.Lock()
+	defer pq.mtx.Unlock()
+	if oe := pq.orders[oid]; oe != nil {
+		return oe.order
+	}
+	return nil
+}
+
 // removeOrder removes the specified orderEntry from the queue. This function is
 // NOT thread-safe.
 func (pq *OrderPQ) removeOrder(o *orderEntry) (*order.LimitOrder, bool) {


### PR DESCRIPTION
Duplicate order IDs in `processOrder` cannot really exist unless the
server time stamp is equal along with all the other serializable data.
This can still be checked as it is possible for this to happen, but it is
not the only check needed.
A proper duplicate order check may be done via the commitment;
this will be in another set of changes.

In the present changes, we now enforce that multiple cancel orders
targeting the same order cannot be added to the epoch queue. If not,
`ErrDuplicateCancelOrder`.
Add `EpochQueue.CancelTargets` to facilitate this check.

Further, verify that the target order is on the books or in the epoch
queue, and that the account of the `CancelOrder` is the same as the
account of the target order.  If not, `ErrInvalidCancelOrder`.
Add `(*Market).CancelableBy` to perform the account check.

`book`: `Add (*OrderPQ).Order` and `(*Book).Order` to facilitate the above
`market` changes.

Note: In addition to the stricter cancel order checks, this also resolves a spurious test failure that snuck in when order times were made with millisecond resolution:

```
 --- FAIL: TestMarket_runEpochs (1.84s)
##[error]    market_test.go:212: dcr_btc
##[error]    market_test.go:332: A duplicate order was processed, but it should not have been.
##[error]    market_test.go:347: order failed validation
```