### PR TITLE
client: authentication

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1254,3 +1254,43 @@ func TestPayFee(t *testing.T) {
 		t.Fatalf("PayFee error afterwards: %v", err)
 	}
 }
+
+func TestCoin(t *testing.T) {
+	wallet, node, shutdown := tNewWallet()
+	defer shutdown()
+
+	coinID := make([]byte, 36)
+	copy(coinID[:32], tTxHash[:])
+
+	// Bad coin idea
+	_, err := wallet.Coin(randBytes(35))
+	if err == nil {
+		t.Fatalf("no error for bad coin ID")
+	}
+
+	// listunspent error
+	node.rawErr[methodListUnspent] = tErr
+	_, err = wallet.Coin(randBytes(35))
+	if err == nil {
+		t.Fatalf("no error for listunspent error")
+	}
+	node.rawErr[methodListUnspent] = nil
+
+	// Try to get non-existent coin.
+	unspents := make([]*ListUnspentResult, 0)
+	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+	_, err = wallet.Coin(randBytes(36))
+	if err == nil {
+		t.Fatalf("no error for missing coin")
+	}
+
+	littleUnspent := &ListUnspentResult{
+		TxID: tTxID,
+	}
+	unspents = append(unspents, littleUnspent)
+	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+	_, err = wallet.Coin(coinID)
+	if err != nil {
+		t.Fatalf("coin error: %v", err)
+	}
+}

--- a/client/asset/btc/regnet_test.go
+++ b/client/asset/btc/regnet_test.go
@@ -167,9 +167,15 @@ func TestWallet(t *testing.T) {
 	if inUTXOs(utxo, utxos) {
 		t.Fatalf("received locked output")
 	}
-	// Now unlock, and see if we get the first one back.
+	// Unlock
 	rig.gamma().ReturnCoins([]asset.Coin{utxo})
 	rig.gamma().ReturnCoins(utxos)
+	// Check that we can get the coin with Coin.
+	_, err = rig.gamma().Coin(utxo.ID())
+	if err != nil {
+		t.Fatalf("Coin error: %v", err)
+	}
+	// Make sure we get the first utxo back with Fund.
 	utxos, _ = rig.gamma().Fund(contractValue*3, tBTC)
 	if !inUTXOs(utxo, utxos) {
 		t.Fatalf("unlocked output not returned")
@@ -316,6 +322,8 @@ func TestWallet(t *testing.T) {
 		Contract: contract,
 	}
 	swaps = []*asset.Swap{swap}
+
+	time.Sleep(time.Second)
 
 	receipts, err = rig.gamma().Swap(swaps, tBTC)
 	if err != nil {

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -55,7 +55,7 @@ type anylist []interface{}
 // ListUnspent retrieves a list of the wallet's UTXOs.
 func (wc *walletClient) ListUnspent() ([]*ListUnspentResult, error) {
 	unspents := make([]*ListUnspentResult, 0)
-	return unspents, wc.call(methodListUnspent, nil, &unspents)
+	return unspents, wc.call(methodListUnspent, anylist{uint8(0)}, &unspents)
 }
 
 // LockUnspent locks and unlocks outputs for spending. An output that is part of

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -161,9 +161,15 @@ func TestWallet(t *testing.T) {
 	if inUTXOs(utxo, utxos) {
 		t.Fatalf("received locked output")
 	}
-	// Now unlock, and see if we get the first one back.
+	// Unlock
 	rig.beta().ReturnCoins([]asset.Coin{utxo})
 	rig.beta().ReturnCoins(utxos)
+	// Check that we can get the coin with Coin.
+	_, err = rig.beta().Coin(utxo.ID())
+	if err != nil {
+		t.Fatalf("Coin error: %v", err)
+	}
+	// Make sure we get the first utxo back with Fund.
 	utxos, _ = rig.beta().Fund(contractValue*3, tDCR)
 	if !inUTXOs(utxo, utxos) {
 		t.Fatalf("unlocked output not returned")

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -81,6 +81,10 @@ type Wallet interface {
 	Lock() error
 	// PayFee pays a registration fee to the DEX.
 	PayFee(address string, fee uint64, nfo *dex.Asset) (Coin, error)
+	// Coin gets a wallet Coin for a coin ID. Note that a Coin, by definition, is
+	// unspent. Attempting to retrieve a spent coin should result in an error. The
+	// coin will not be locked.
+	Coin(id dex.Bytes) (Coin, error)
 }
 
 // Coin is some amount of spendable asset. Coin provides the information needed

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -64,7 +64,7 @@ func main() {
 		go clientCore.Run(appCtx)
 		// At least one of --rpc or --web must be specified.
 		if !cfg.RPCOn && !cfg.WebOn {
-			fmt.Fprintf(os.Stderr, "Cannot run without TUI unless --rpc and/or --web is specified")
+			fmt.Fprintf(os.Stderr, "Cannot run without TUI unless --rpc and/or --web is specified\n")
 			return
 		}
 		var wg sync.WaitGroup

--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -289,7 +289,7 @@ func (conn *wsConn) NextID() uint64 {
 // Connect connects the client and starts an auto-reconnect loop. Any error
 // encountered during the initial connection will be returned. The reconnect
 // loop will continue to try connecting, even if an error is returned. To
-// shutdown auto-reconnect, use Close().
+// shutdown auto-reconnect, use close().
 func (conn *wsConn) Connect(ctx context.Context) (error, *sync.WaitGroup) {
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -60,7 +60,7 @@ func TestWsConn(t *testing.T) {
 
 	pingWait := time.Millisecond * 200
 
-	var wsc *WsConn
+	var wsc *wsConn
 
 	id := uint64(0)
 	handler := func(w http.ResponseWriter, r *http.Request) {
@@ -183,12 +183,13 @@ func TestWsConn(t *testing.T) {
 		URL:      "wss://" + host + "/ws",
 		PingWait: pingWait,
 		RpcCert:  certFile.Name(),
-		Ctx:      ctx,
 	}
-	wsc, err = NewWsConn(cfg)
+	conn, err := NewWsConn(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
+	wsc = conn.(*wsConn)
+	wsc.Connect(ctx)
 
 	go func() {
 		wsc.WaitForShutdown()
@@ -384,10 +385,14 @@ func TestFailingConnection(t *testing.T) {
 		URL:      "wss://" + host + "/ws",
 		PingWait: pingWait,
 		RpcCert:  certFile.Name(),
-		Ctx:      ctx,
 	}
 	// Initial connection will fail immediately
-	wsc, err := NewWsConn(cfg)
+	conn, err := NewWsConn(cfg)
+	if err != nil {
+		t.Fatalf("constructor error: %v", err)
+	}
+	wsc := conn.(*wsConn)
+	err = wsc.Connect(ctx)
 	if err == nil {
 		t.Fatal("no error for non-existent server")
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,52 +17,35 @@ import (
 	"decred.org/dcrdex/client/comms"
 	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/client/db/bolt"
-	"decred.org/dcrdex/client/order"
+	book "decred.org/dcrdex/client/order"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/dex/encrypt"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/dex/order"
 	srvacct "decred.org/dcrdex/server/account"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 )
 
-// Encrypter is a placeholder until a proper symmetric encryption algorithm is
-// chosen. This iinitial
-type Encrypter struct{}
-
-// KeyFromPassword derives an encryption key from a password string.
-func KeyFromPassword(pw string) (*Encrypter, error) { return &Encrypter{}, nil }
-
-// Encrypt encrypts the message.
-func (e *Encrypter) Encrypt(b []byte) ([]byte, error) { return b, nil }
-
-// Decrypt decrypts the ciphertext created by Encrypt.
-func (e *Encrypter) Decrypt(b []byte) ([]byte, error) { return b, nil }
-
 var (
 	// log is a logger generated with the LogMaker provided with Config.
-	log   dex.Logger
-	unbip = dex.BipIDSymbol
-	aYear = time.Hour * 24 * 365
+	log            dex.Logger
+	unbip          = dex.BipIDSymbol
+	aYear          = time.Hour * 24 * 365
+	requestTimeout = 10 * time.Second
 )
-
-// websocket is satisfied by a comms.WsConn, or a stub for testing.
-type websocket interface {
-	NextID() uint64
-	WaitForShutdown()
-	Send(msg *msgjson.Message) error
-	Request(msg *msgjson.Message, f func(*msgjson.Message)) error
-	MessageSource() <-chan *msgjson.Message
-}
 
 // dexConnection is the websocket connection and the DEX configuration.
 type dexConnection struct {
-	websocket
-	assets   map[uint32]*dex.Asset
-	cfg      *msgjson.ConfigResult
-	acct     *dexAccount
-	booksMtx sync.RWMutex
-	books    map[string]*order.OrderBook
-	markets  []*Market
+	comms.WsConn
+	assets      map[uint32]*dex.Asset
+	cfg         *msgjson.ConfigResult
+	acct        *dexAccount
+	booksMtx    sync.RWMutex
+	books       map[string]*book.OrderBook
+	markets     []*Market
+	matchMtx    sync.RWMutex
+	negotiators map[order.MatchID]*matchNegotiator
 }
 
 // coinWaiter is a message waiting to be stamped, signed, and sent once a
@@ -97,19 +81,24 @@ type Config struct {
 // Core is the core client application. Core manages DEX connections, wallets,
 // database access, match negotiation and more.
 type Core struct {
-	ctx         context.Context
-	wg          sync.WaitGroup
-	cfg         *Config
-	connMtx     sync.RWMutex
-	conns       map[string]*dexConnection
-	db          db.DB
-	certs       map[string]string
-	wallets     map[uint32]*xcWallet
-	walletMtx   sync.RWMutex
-	loggerMaker *dex.LoggerMaker
-	net         dex.Network
-	waiterMtx   sync.Mutex
-	waiters     map[string]coinWaiter
+	ctx           context.Context
+	wg            sync.WaitGroup
+	cfg           *Config
+	connMtx       sync.RWMutex
+	conns         map[string]*dexConnection
+	pendingTimer  *time.Timer
+	pendingReg    *dexConnection
+	db            db.DB
+	certs         map[string]string
+	wallets       map[uint32]*xcWallet
+	walletMtx     sync.RWMutex
+	loggerMaker   *dex.LoggerMaker
+	net           dex.Network
+	waiterMtx     sync.Mutex
+	waiters       map[string]coinWaiter
+	wsConstructor func(*comms.WsCfg) (comms.WsConn, error)
+	userMtx       sync.RWMutex
+	user          *User
 }
 
 // New is the constructor for a new Core.
@@ -120,14 +109,15 @@ func New(cfg *Config) (*Core, error) {
 		return nil, fmt.Errorf("database initialization error: %v", err)
 	}
 	core := &Core{
-		cfg:         cfg,
-		db:          db,
-		certs:       cfg.Certs,
-		conns:       make(map[string]*dexConnection),
-		wallets:     make(map[uint32]*xcWallet),
-		net:         cfg.Net,
-		loggerMaker: cfg.LoggerMaker,
-		waiters:     make(map[string]coinWaiter),
+		cfg:           cfg,
+		db:            db,
+		certs:         cfg.Certs,
+		conns:         make(map[string]*dexConnection),
+		wallets:       make(map[uint32]*xcWallet),
+		net:           cfg.Net,
+		loggerMaker:   cfg.LoggerMaker,
+		waiters:       make(map[string]coinWaiter),
+		wsConstructor: comms.NewWsConn,
 	}
 	log.Tracef("new client core created")
 	return core, nil
@@ -136,11 +126,9 @@ func New(cfg *Config) (*Core, error) {
 // Run runs the core. Satisfies the runner.Runner interface.
 func (c *Core) Run(ctx context.Context) {
 	log.Infof("started DEX client core")
-	// Store the context as a field for now, since we will need to spawn new
-	// DEX threads when new accounts are registered.
+	// Store the context as a field, since we will need to spawn new DEX threads
+	// when new accounts are registered.
 	c.ctx = ctx
-	// Have one thread just wait on context cancellation, since if there are no
-	// DEX accounts yet, there would be nothing else on the WaitGroup.
 	c.initialize()
 	<-ctx.Done()
 	c.wg.Wait()
@@ -164,6 +152,18 @@ func (c *Core) wallet(assetID uint32) (*xcWallet, bool) {
 	defer c.walletMtx.RUnlock()
 	w, found := c.wallets[assetID]
 	return w, found
+}
+
+func (c *Core) encryptionKey(pw string) (encrypt.Crypter, error) {
+	keyParams, err := c.db.EncryptedKey()
+	if err != nil {
+		return nil, fmt.Errorf("key retrieval error: %v", err)
+	}
+	crypter, err := encrypt.Deserialize(pw, keyParams)
+	if err != nil {
+		return nil, fmt.Errorf("encryption key deserialization error: %v", err)
+	}
+	return crypter, nil
 }
 
 // connectedWallet fetches a wallet and will connect the wallet if it is not
@@ -200,13 +200,25 @@ func (c *Core) Wallets() []*WalletStatus {
 	return stats
 }
 
-// User returns information about the client, including its known markets and
-// DEX accounts.
+// user is a thread-safe getter for the User.
 func (c *Core) User() *User {
-	return &User{
-		Wallets:  c.Wallets(),
-		Accounts: c.Markets(),
+	c.userMtx.RLock()
+	defer c.userMtx.RUnlock()
+	return c.user
+}
+
+// refreshUser is a thread-safe way to update the current User. This method
+// should be called after adding wallets and DEXes.
+func (c *Core) refreshUser() {
+	k, _ := c.db.EncryptedKey()
+	u := &User{
+		Wallets:     c.Wallets(),
+		Markets:     c.Markets(),
+		Initialized: len(k) > 0,
 	}
+	c.userMtx.Lock()
+	c.user = u
+	c.userMtx.Unlock()
 }
 
 // CreateWallet creates a new exchange wallet.
@@ -237,6 +249,8 @@ func (c *Core) CreateWallet(form *WalletForm) error {
 		wallet.waiter.Stop()
 		return fmt.Errorf("error storing wallet credentials: %v", err)
 	}
+
+	c.refreshUser()
 
 	return nil
 }
@@ -287,7 +301,45 @@ func (c *Core) OpenWallet(assetID uint32, pw string) error {
 	if err != nil {
 		return fmt.Errorf("wallet error for %d -> %s: %v", assetID, unbip(assetID), err)
 	}
-	return wallet.Unlock(pw, aYear)
+	err = wallet.Unlock(pw, aYear)
+	if err != nil {
+		return fmt.Errorf("OpenWallet: %v", err)
+	}
+	return nil
+}
+
+// PreRegister creates a connection to the specified DEX and fetches the
+// registration fee. The connection is left open and stored temporarily while
+// registration is completed.
+func (c *Core) PreRegister(dex string) (uint64, error) {
+	c.connMtx.RLock()
+	dc, found := c.conns[dex]
+	c.connMtx.RUnlock()
+	if found {
+		return 0, fmt.Errorf("already registered at %s", dex)
+	}
+	dc, err := c.connectDEX(&db.AccountInfo{URL: dex})
+	if err != nil {
+		return 0, err
+	}
+	c.connMtx.Lock()
+	c.pendingReg = dc
+	c.connMtx.Unlock()
+	if c.pendingTimer == nil {
+		c.pendingTimer = time.AfterFunc(time.Minute*5, func() {
+			c.connMtx.Lock()
+			defer c.connMtx.Unlock()
+			pendingDEX := c.pendingReg
+			if pendingDEX != nil && pendingDEX.acct.url == dc.acct.url {
+				pendingDEX.Close()
+				c.pendingReg = nil
+			}
+		})
+	} else {
+		c.pendingTimer.Stop()
+		c.pendingTimer.Reset(time.Minute * 5)
+	}
+	return dc.cfg.Fee, nil
 }
 
 // Register registers an account with a new DEX. If an error occurs while
@@ -296,6 +348,11 @@ func (c *Core) OpenWallet(assetID uint32, pw string) error {
 // for the requisite confirmations and send the fee notification to the server.
 // Any error returned from that thread will be sent over the returned channel.
 func (c *Core) Register(form *Registration) (error, <-chan error) {
+	// Check the app password.
+	crypter, err := c.encryptionKey(form.Password)
+	if err != nil {
+		return err, nil
+	}
 	// For now, asset ID is hard-coded to Decred for registration fees.
 	assetID, _ := dex.BipSymbolID("dcr")
 	if form.DEX == "" {
@@ -316,15 +373,24 @@ func (c *Core) Register(form *Registration) (error, <-chan error) {
 	ai = &db.AccountInfo{
 		URL: form.DEX,
 	}
-	c.connMtx.RLock()
-	dc := c.conns[form.DEX]
-	c.connMtx.RUnlock()
-	if dc == nil {
-		dc, err = c.addDex(ai)
+	c.connMtx.Lock()
+	dc, found := c.conns[form.DEX]
+	// If it's not already in the map, see if there is a pre-registration pending.
+	if !found && c.pendingReg != nil && c.pendingReg.acct.url == form.DEX {
+		dc = c.pendingReg
+		c.conns[ai.URL] = dc
+		found = true
+	}
+	// If it was neither in the map or pre-registered, get a new connection.
+	if !found {
+		dc, err = c.connectDEX(ai)
 		if err != nil {
 			return err, nil
 		}
+		c.conns[ai.URL] = dc
 	}
+	c.connMtx.Unlock()
+	c.refreshUser()
 
 	regAsset, found := dc.assets[assetID]
 	if !found {
@@ -337,14 +403,8 @@ func (c *Core) Register(form *Registration) (error, <-chan error) {
 		return fmt.Errorf("error creating wallet key: %v", err), nil
 	}
 
-	// Create an encryption key.
-	secretKey, err := KeyFromPassword(form.Password)
-	if err != nil {
-		return fmt.Errorf("error creating encryption key: %v", err), nil
-	}
-
 	// Encrypt the private key.
-	encPW, err := secretKey.Encrypt(privKey.Serialize())
+	encKey, err := crypter.Encrypt(privKey.Serialize())
 	if err != nil {
 		return fmt.Errorf("error encrypting private key: %v", err), nil
 	}
@@ -369,33 +429,16 @@ func (c *Core) Register(form *Registration) (error, <-chan error) {
 		return fmt.Errorf("error encoding message: %v", err), nil
 	}
 	regRes := new(msgjson.RegisterResult)
-	var wg sync.WaitGroup
-	wg.Add(1)
-	var regErr error
+	errChan := make(chan error, 1)
 	err = dc.Request(regMsg, func(msg *msgjson.Message) {
-		defer wg.Done()
-		var resp *msgjson.ResponsePayload
-		resp, regErr = msg.Response()
-		if regErr != nil {
-			return
-		}
-		if resp.Error != nil {
-			regErr = fmt.Errorf("'register' request error: %d: %s", resp.Error.Code, resp.Error.Message)
-			return
-		}
-		regErr = json.Unmarshal(resp.Result, regRes)
-		if regErr != nil {
-			regErr = fmt.Errorf("Error unmarshaling 'register' response: %v", regErr)
-			return
-		}
+		errChan <- msg.UnmarshalResult(regRes)
 	})
 	if err != nil {
 		return fmt.Errorf("'register' requst error: %v", err), nil
 	}
-
-	wg.Wait()
-	if regErr != nil {
-		return regErr, nil
+	err = extractError(errChan, requestTimeout)
+	if err != nil {
+		return fmt.Errorf("'register' result decode error: %v", err), nil
 	}
 
 	// Check the server's signature.
@@ -422,12 +465,12 @@ func (c *Core) Register(form *Registration) (error, <-chan error) {
 
 	// Set the dexConnection account fields.
 	dc.acct.dexPubKey = dexPubKey
-	dc.acct.encKey = encPW
+	dc.acct.encKey = encKey
 	dc.acct.feeCoin = coin.ID()
-	dc.acct.privKey = privKey
+	dc.acct.unlock(crypter)
 
 	// Set the db.AccountInfo fields and save the account info.
-	ai.EncKey = encPW
+	ai.EncKey = encKey
 	ai.DEXPubKey = dexPubKey
 	ai.FeeCoin = coin.ID()
 	err = c.db.CreateAccount(ai)
@@ -449,8 +492,7 @@ func (c *Core) Register(form *Registration) (error, <-chan error) {
 	}
 
 	// Set up the coin waiter.
-	errChan := make(chan error, 1)
-
+	errChan = make(chan error, 1)
 	c.waiterMtx.Lock()
 	c.waiters[form.DEX] = coinWaiter{
 		conn:  dc,
@@ -464,24 +506,14 @@ func (c *Core) Register(form *Registration) (error, <-chan error) {
 		req:     req,
 		f: func(msg *msgjson.Message, waiterErr error) {
 			var err error
-			defer func() { errChan <- err }()
 			if waiterErr != nil {
-				err = waiterErr
-				return
-			}
-			resp, err := msg.Response()
-			if err != nil {
-				err = fmt.Errorf("error decoding response: %v", err)
-				return
-			}
-			if resp.Error != nil {
-				err = fmt.Errorf("notifyfee error: %d:%s", resp.Error.Code, resp.Error.Message)
+				errChan <- waiterErr
 				return
 			}
 			ack := new(msgjson.Acknowledgement)
-			err = json.Unmarshal(resp.Result, ack)
+			err = msg.UnmarshalResult(ack)
 			if err != nil {
-				err = fmt.Errorf("notify fee result json decode error: %v", err)
+				errChan <- fmt.Errorf("notify fee result json decode error: %v", err)
 				return
 			}
 			// If there was a serialization error, validation is skipped. A warning
@@ -503,20 +535,144 @@ func (c *Core) Register(form *Registration) (error, <-chan error) {
 			} else {
 				log.Warnf("Marking account as paid, even though the server's signature could not be validated.")
 			}
-			c.db.AccountPaid(&db.AccountProof{
+			err = c.db.AccountPaid(&db.AccountProof{
 				URL:   form.DEX,
 				Stamp: req.Time,
 				Sig:   sig,
 			})
-
+			if err != nil {
+				errChan <- err
+				return
+			}
+			// New account won't have any active negotiations, so OK to discard first
+			// first return value.
+			_, err = c.authDEX(crypter, dc)
+			errChan <- err
 		},
 	}
 	c.waiterMtx.Unlock()
 	return nil, errChan
 }
 
-func (c *Core) Login(dex, pw string) error {
+// InitializeClient sets the initial app-wide password for the client.
+func (c *Core) InitializeClient(pw string) error {
+	if pw == "" {
+		return fmt.Errorf("empty password not allowed")
+	}
+	privKey, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		return fmt.Errorf("error generating new private key: %v", err)
+	}
+	encKey, err := encrypt.NewCrypter(pw).Encrypt(privKey.Serialize())
+	if err != nil {
+		return fmt.Errorf("key encryption error: %v", err)
+	}
+	err = c.db.StoreEncryptedKey(encKey)
+	if err != nil {
+		return fmt.Errorf("error storing encrypted key: %v", err)
+	}
+	c.refreshUser()
 	return nil
+}
+
+// Login logs the user in, decrypting the account keys for all known DEXes.
+func (c *Core) Login(pw string) (negotiations []Negotiation, err error) {
+	crypter, err := c.encryptionKey(pw)
+	if err != nil {
+		return nil, err
+	}
+	var wg sync.WaitGroup
+	var errs []string
+	c.connMtx.RLock()
+	defer c.connMtx.RUnlock()
+	for _, dexConn := range c.conns {
+		dc := dexConn
+		if dc.acct.authed() {
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			n, err := c.authDEX(crypter, dc)
+			if err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", dc.acct.url, err))
+				return
+			}
+			dc.matchMtx.Lock()
+			negotiations = append(negotiations, n...)
+			dc.matchMtx.Unlock()
+		}()
+	}
+	wg.Wait()
+	if errs != nil {
+		err = fmt.Errorf("authorization errors: %s", strings.Join(errs, ", "))
+	}
+	return negotiations, err
+}
+
+// authDEX authenticates the connection for a DEX.
+func (c *Core) authDEX(crypter encrypt.Crypter, dc *dexConnection) ([]Negotiation, error) {
+	// Decrypt the account private key.
+	err := dc.acct.unlock(crypter)
+	if err != nil {
+		return nil, fmt.Errorf("error unlocking account for %s: %v", dc.acct.url, err)
+	}
+	// Prepare and sign the message for the 'connect' route.
+	acctID := dc.acct.ID()
+	payload := &msgjson.Connect{
+		AccountID:  acctID[:],
+		APIVersion: 0,
+		Time:       encode.UnixMilliU(time.Now()),
+	}
+	b, err := payload.Serialize()
+	if err != nil {
+		return nil, fmt.Errorf("error serializing 'connect' message: %v", err)
+	}
+	sig, err := dc.acct.sign(b)
+	if err != nil {
+		return nil, fmt.Errorf("signing error: %v", err)
+	}
+	payload.SetSig(sig)
+	// Send the 'connect' request.
+	req, err := msgjson.NewRequest(dc.NextID(), msgjson.ConnectRoute, payload)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding 'connect' request: %v", err)
+	}
+	errChan := make(chan error, 1)
+	var result = new(msgjson.ConnectResult)
+	err = dc.Request(req, func(msg *msgjson.Message) {
+		errChan <- msg.UnmarshalResult(result)
+	})
+	// Check the request error.
+	if err != nil {
+		return nil, err
+	}
+	// Check the response error.
+	err = extractError(errChan, requestTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("'connect' error: %v", err)
+	}
+	log.Debugf("authenticated connection to %s", dc.acct.url)
+	// Set the account as authenticated.
+	dc.acct.auth()
+	// Prepare the trade Negotiations.
+	negotiations := make([]Negotiation, 0, len(result.Matches))
+	var errs []string
+	dc.matchMtx.Lock()
+	defer dc.matchMtx.Unlock()
+	for _, msgMatch := range result.Matches {
+		negotiator, err := negotiate(c.ctx, msgMatch)
+		if err != nil {
+			errs = append(errs, msgMatch.MatchID.String()+": "+err.Error())
+			continue
+		}
+		negotiations = append(negotiations, negotiator)
+		dc.negotiators[negotiator.matchID] = negotiator
+	}
+	if len(errs) > 0 {
+		err = fmt.Errorf("errors beginning match negotiations: %s", strings.Join(errs, ", "))
+	}
+	return negotiations, err
 }
 
 func (c *Core) Sync(dex string, base, quote uint32) (chan *BookUpdate, error) {
@@ -545,11 +701,15 @@ func (c *Core) initialize() {
 		a := acct
 		wg.Add(1)
 		go func() {
-			_, err := c.addDex(a)
+			defer wg.Done()
+			dc, err := c.connectDEX(a)
 			if err != nil {
 				log.Errorf("error adding DEX %s: %v", a, err)
+				return
 			}
-			wg.Done()
+			c.connMtx.Lock()
+			c.conns[a.URL] = dc
+			c.connMtx.Unlock()
 		}()
 	}
 	// If there were accounts, wait until they are loaded and log a messsage.
@@ -579,32 +739,36 @@ func (c *Core) initialize() {
 		c.walletMtx.RUnlock()
 		log.Infof("successfully loaded %d of %d wallets", numWallets, len(dbWallets))
 	}
-
+	c.refreshUser()
 }
 
-// addDex adds a dexConnection to the conns map if a connection can be made
-// and the DEX configuration is successfully retrieved. The connection is
-// unauthenticated until the `connect` request is sent and accepted by the
-// server.
-func (c *Core) addDex(acct *db.AccountInfo) (*dexConnection, error) {
+// connectDEX creates and connects a *dexConnection, but does not authenticate the
+// connection through the 'connect' route.
+func (c *Core) connectDEX(acctInfo *db.AccountInfo) (*dexConnection, error) {
 	// Get the host from the DEX URL.
-	uri := acct.URL
+	uri := acctInfo.URL
 	parsedURL, err := url.Parse(uri)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing account URL %s: %v", uri, err)
 	}
 	// Create a websocket connection to the server.
-	conn, err := comms.NewWsConn(&comms.WsCfg{
+	conn, err := c.wsConstructor(&comms.WsCfg{
 		URL:      "wss://" + parsedURL.Host + "/ws",
 		PingWait: 60 * time.Second,
 		RpcCert:  c.certs[uri],
 		ReconnectSync: func() {
 			go c.handleReconnect(uri)
 		},
-		Ctx: c.ctx,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("Error creating websocket connection for %s: %v", uri, err)
+	}
+	err = conn.Connect(c.ctx)
+	// If the initial connection returned an error, shut it down to kill the
+	// auto-reconnect cycle.
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("Error initalizing websocket connection: %v", err)
 	}
 	// Request the market configuration. The DEX is only added when the DEX
 	// configuration is successfully retrieved.
@@ -615,21 +779,10 @@ func (c *Core) addDex(acct *db.AccountInfo) (*dexConnection, error) {
 	connChan := make(chan *dexConnection, 1)
 	var reqErr error
 	err = conn.Request(reqMsg, func(msg *msgjson.Message) {
-		resp, err := msg.Response()
-		if err != nil {
-			reqErr = fmt.Errorf("failed to parse 'config' response message: %v", err)
-			connChan <- nil
-			return
-		}
-		if resp.Error != nil {
-			reqErr = fmt.Errorf("config request error: %d: %s", resp.Error.Code, resp.Error.Message)
-			connChan <- nil
-			return
-		}
 		dexCfg := new(msgjson.ConfigResult)
-		err = json.Unmarshal(resp.Result, dexCfg)
+		err = msg.UnmarshalResult(dexCfg)
 		if err != nil {
-			reqErr = fmt.Errorf("failed to parse config response '%s': %v", string(resp.Result), err)
+			reqErr = fmt.Errorf("'config' result decode error: %v", err)
 			connChan <- nil
 			return
 		}
@@ -669,21 +822,13 @@ func (c *Core) addDex(acct *db.AccountInfo) (*dexConnection, error) {
 
 		// Create the dexConnection and add it to the map.
 		dc := &dexConnection{
-			websocket: conn,
-			assets:    assets,
-			cfg:       dexCfg,
-			books:     make(map[string]*order.OrderBook),
-			acct: &dexAccount{
-				url:       acct.URL,
-				encKey:    acct.EncKey,
-				dexPubKey: acct.DEXPubKey,
-				feeCoin:   acct.FeeCoin,
-			},
+			WsConn:  conn,
+			assets:  assets,
+			cfg:     dexCfg,
+			books:   make(map[string]*book.OrderBook),
+			acct:    newDEXAccount(acctInfo.URL, acctInfo.EncKey, acctInfo.DEXPubKey),
 			markets: markets,
 		}
-		c.connMtx.Lock()
-		c.conns[uri] = dc
-		c.connMtx.Unlock()
 		connChan <- dc
 		c.wg.Add(1)
 		// Listen for incoming messages.
@@ -704,23 +849,18 @@ func (c *Core) handleReconnect(uri string) {
 
 // handleOrderBookMsg is called when an orderbook response is received.
 func (c *Core) handleOrderBookMsg(dc *dexConnection, msg *msgjson.Message) error {
-	resp, err := msg.Response()
+	snapshot := new(msgjson.OrderBook)
+	err := msg.UnmarshalResult(snapshot)
 	if err != nil {
 		return err
-	}
-
-	var snapshot msgjson.OrderBook
-	err = json.Unmarshal(resp.Result, &snapshot)
-	if err != nil {
-		return fmt.Errorf("order book unmarshal error: %v", err)
 	}
 
 	if snapshot.MarketID == "" {
 		return fmt.Errorf("snapshot market id cannot be an empty string")
 	}
 
-	ob := order.NewOrderBook()
-	err = ob.Sync(&snapshot)
+	ob := book.NewOrderBook()
+	err = ob.Sync(snapshot)
 	if err != nil {
 		return err
 	}
@@ -950,4 +1090,14 @@ func sign(privKey *secp256k1.PrivateKey, payload msgjson.Signable) error {
 func stamp(privKey *secp256k1.PrivateKey, payload msgjson.Stampable) error {
 	payload.Stamp(encode.UnixMilliU(time.Now()), 0, 0)
 	return sign(privKey, payload)
+}
+
+// extractError extracts the error from the channel with a timeout.
+func extractError(errChan <-chan error, delay time.Duration) error {
+	select {
+	case err := <-errChan:
+		return err
+	case <-time.NewTimer(delay).C:
+		return fmt.Errorf("timed out waiting for 'connect' response.")
+	}
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -110,14 +110,15 @@ func New(cfg *Config) (*Core, error) {
 		return nil, fmt.Errorf("database initialization error: %v", err)
 	}
 	core := &Core{
-		cfg:           cfg,
-		db:            db,
-		certs:         cfg.Certs,
-		conns:         make(map[string]*dexConnection),
-		wallets:       make(map[uint32]*xcWallet),
-		net:           cfg.Net,
-		loggerMaker:   cfg.LoggerMaker,
-		waiters:       make(map[string]coinWaiter),
+		cfg:         cfg,
+		db:          db,
+		certs:       cfg.Certs,
+		conns:       make(map[string]*dexConnection),
+		wallets:     make(map[uint32]*xcWallet),
+		net:         cfg.Net,
+		loggerMaker: cfg.LoggerMaker,
+		waiters:     make(map[string]coinWaiter),
+		// Allowing to change the constructor makes testing a lot easier.
 		wsConstructor: comms.NewWsConn,
 	}
 	log.Tracef("new client core created")

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -245,11 +245,11 @@ func (db *TDB) AccountPaid(proof *db.AccountProof) error {
 	return nil
 }
 
-func (db *TDB) StoreEncryptedKey([]byte) error {
+func (db *TDB) Store(k string, b []byte) error {
 	return db.storeKeyErr
 }
 
-func (db *TDB) EncryptedKey() ([]byte, error) {
+func (db *TDB) Get(k string) ([]byte, error) {
 	return nil, db.encKeyErr
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -163,8 +163,6 @@ func (conn *TWebsocket) NextID() uint64 {
 	conn.id++
 	return conn.id
 }
-
-func (conn *TWebsocket) WaitForShutdown()                {}
 func (conn *TWebsocket) Send(msg *msgjson.Message) error { return conn.sendErr }
 func (conn *TWebsocket) Request(msg *msgjson.Message, f msgFunc) error {
 	handlers := conn.getHandlers(msg.Route)
@@ -176,8 +174,9 @@ func (conn *TWebsocket) Request(msg *msgjson.Message, f msgFunc) error {
 	return conn.reqErr
 }
 func (conn *TWebsocket) MessageSource() <-chan *msgjson.Message { return conn.msgs }
-func (conn *TWebsocket) Connect(context.Context) error          { return conn.connectErr }
-func (conn *TWebsocket) Close()                                 {}
+func (conn *TWebsocket) Connect(context.Context) (error, *sync.WaitGroup) {
+	return conn.connectErr, &sync.WaitGroup{}
+}
 
 type TDB struct {
 	updateWalletErr error

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -51,9 +51,10 @@ var (
 	}
 	tDexPriv *secp256k1.PrivateKey
 	tDexKey  *secp256k1.PublicKey
-	tPW      = "dexpw"
-	tDexUrl  = "somedex.tld"
-	tErr     = fmt.Errorf("test error")
+	tPW             = "dexpw"
+	tDexUrl         = "somedex.tld"
+	tErr            = fmt.Errorf("test error")
+	tFee     uint64 = 1e8
 )
 
 type tMsg = *msgjson.Message
@@ -127,6 +128,7 @@ func testDexConnection() (*dexConnection, *TWebsocket, *dexAccount) {
 					MarketBuyBuffer: 1.1,
 				},
 			},
+			Fee: tFee,
 		},
 		markets: []*Market{
 			&Market{
@@ -650,7 +652,7 @@ func TestRegister(t *testing.T) {
 	regRes := &msgjson.RegisterResult{
 		DEXPubKey: acct.dexPubKey.Serialize(),
 		Address:   "someaddr",
-		Fee:       1e8,
+		Fee:       tFee,
 		Time:      encode.UnixMilliU(time.Now()),
 	}
 	sign(tDexPriv, regRes)
@@ -718,6 +720,7 @@ func TestRegister(t *testing.T) {
 	form := &Registration{
 		DEX:      tDexUrl,
 		Password: tPW,
+		Fee:      tFee,
 	}
 
 	tWallet.payFeeCoin = &tCoin{id: []byte("abcdef")}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -51,8 +51,8 @@ type xcWallet struct {
 	hookedUp bool
 }
 
-// unlock unlocks the wallet.
-func (w *xcWallet) unlock(pw string, dur time.Duration) error {
+// Unlock unlocks the wallet.
+func (w *xcWallet) Unlock(pw string, dur time.Duration) error {
 	err := w.Wallet.Unlock(pw, dur)
 	if err != nil {
 		return err
@@ -99,6 +99,7 @@ func (w *xcWallet) Connect() error {
 type Registration struct {
 	DEX      string
 	Password string
+	Fee      uint64
 }
 
 // Market is market info.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -51,8 +51,8 @@ type xcWallet struct {
 	hookedUp bool
 }
 
-// Unlock unlocks the wallet.
-func (w *xcWallet) Unlock(pw string, dur time.Duration) error {
+// unlock unlocks the wallet.
+func (w *xcWallet) unlock(pw string, dur time.Duration) error {
 	err := w.Wallet.Unlock(pw, dur)
 	if err != nil {
 		return err

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encrypt"
 	"decred.org/dcrdex/dex/msgjson"
@@ -157,16 +158,18 @@ type dexAccount struct {
 	id        account.AccountID
 	dexPubKey *secp256k1.PublicKey
 	feeCoin   []byte
+	paid      bool
 	authMtx   sync.RWMutex
 	isAuthed  bool
 }
 
 // newDEXAccount is a constructor for a new *dexAccount.
-func newDEXAccount(url string, encKey []byte, dexPubKey *secp256k1.PublicKey) *dexAccount {
+func newDEXAccount(acctInfo *db.AccountInfo) *dexAccount {
 	return &dexAccount{
-		url:       url,
-		encKey:    encKey,
-		dexPubKey: dexPubKey,
+		url:       acctInfo.URL,
+		encKey:    acctInfo.EncKey,
+		dexPubKey: acctInfo.DEXPubKey,
+		paid:      acctInfo.Paid,
 	}
 }
 

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -82,8 +82,7 @@ func (db *boltDB) Run(ctx context.Context) {
 	db.Close()
 }
 
-// StoreKeyParams stores the serialized key derivation parameters for an
-// encryption key.
+// Store stores a value at the specified key in a general-use bucket.
 func (db *boltDB) Store(k string, v []byte) error {
 	if len(k) == 0 {
 		return fmt.Errorf("cannot store with empty key")
@@ -98,7 +97,7 @@ func (db *boltDB) Store(k string, v []byte) error {
 	})
 }
 
-// KeyParams retrieves the currently stored key derivation parameters.
+// Get retrieves value previously stored with Store.
 func (db *boltDB) Get(k string) ([]byte, error) {
 	var v []byte
 	keyB := []byte(k)

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -54,24 +54,25 @@ func TestMain(m *testing.M) {
 	os.Exit(doIt())
 }
 
-func TestEncryptedKey(t *testing.T) {
+func TestStore(t *testing.T) {
+	k := "some random key"
 	boltdb := newTestDB(t)
 	// Check no key
-	_, err := boltdb.EncryptedKey()
+	_, err := boltdb.Get(k)
 	if err == nil {
 		t.Fatalf("no error for missing key")
 	}
-	key := randBytes(50)
-	err = boltdb.StoreEncryptedKey(key)
+	v := randBytes(50)
+	err = boltdb.Store(k, v)
 	if err != nil {
-		t.Fatalf("error storing key: %v", err)
+		t.Fatalf("error storing value: %v", err)
 	}
-	reKey, err := boltdb.EncryptedKey()
+	reV, err := boltdb.Get(k)
 	if err != nil {
-		t.Fatalf("error storing key: %v", err)
+		t.Fatalf("error storing value: %v", err)
 	}
-	if !bEqual(key, reKey) {
-		t.Fatalf("key mismatch %x != %x", key, reKey)
+	if !bEqual(v, reV) {
+		t.Fatalf("value mismatch %x != %x", v, reV)
 	}
 }
 

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -54,6 +54,27 @@ func TestMain(m *testing.M) {
 	os.Exit(doIt())
 }
 
+func TestEncryptedKey(t *testing.T) {
+	boltdb := newTestDB(t)
+	// Check no key
+	_, err := boltdb.EncryptedKey()
+	if err == nil {
+		t.Fatalf("no error for missing key")
+	}
+	key := randBytes(50)
+	err = boltdb.StoreEncryptedKey(key)
+	if err != nil {
+		t.Fatalf("error storing key: %v", err)
+	}
+	reKey, err := boltdb.EncryptedKey()
+	if err != nil {
+		t.Fatalf("error storing key: %v", err)
+	}
+	if !bEqual(key, reKey) {
+		t.Fatalf("key mismatch %x != %x", key, reKey)
+	}
+}
+
 func TestAccounts(t *testing.T) {
 	boltdb := newTestDB(t)
 	dexURLs, err := boltdb.ListAccounts()

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -12,10 +12,10 @@ import (
 // manager.
 type DB interface {
 	dex.Runner
-	// StoreEncryptedKey stores the encrypted key.
-	StoreEncryptedKey([]byte) error
-	// EncryptedKey retrieves the currently stored encrypted key.
-	EncryptedKey() ([]byte, error)
+	// Store allows the storage of arbitrary data.
+	Store(string, []byte) error
+	// Get retreives values stored with Store.
+	Get(string) ([]byte, error)
 	// ListAccounts returns a list of DEX URLs. The DB is designed to have a
 	// single account per DEX, so the account is uniquely identified by the DEX
 	// URL.

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -12,6 +12,10 @@ import (
 // manager.
 type DB interface {
 	dex.Runner
+	// StoreEncryptedKey stores the encrypted key.
+	StoreEncryptedKey([]byte) error
+	// EncryptedKey retrieves the currently stored encrypted key.
+	EncryptedKey() ([]byte, error)
 	// ListAccounts returns a list of DEX URLs. The DB is designed to have a
 	// single account per DEX, so the account is uniquely identified by the DEX
 	// URL.

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -21,7 +21,8 @@ type AccountInfo struct {
 	EncKey    []byte
 	DEXPubKey *secp256k1.PublicKey
 	FeeCoin   []byte
-	// Paid will be set on retrieval based on whether there is a fee proof set.
+	// Paid will be set on retrieval based on whether there is an AccountProof
+	// set.
 	Paid bool
 }
 

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -44,7 +44,7 @@ var log slog.Logger
 
 // ClientCore is satisfied by core.Core.
 type ClientCore interface {
-	ListMarkets() []*core.MarketInfo
+	ListMarkets() []*core.Market
 	Register(*core.Registration) error
 	Login(dex, pw string) error
 	Sync(dex string, base, quote uint32) (chan *core.BookUpdate, error)

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -37,7 +37,7 @@ type TCore struct {
 	loginErr   error
 }
 
-func (c *TCore) ListMarkets() []*core.MarketInfo     { return nil }
+func (c *TCore) ListMarkets() []*core.Market         { return nil }
 func (c *TCore) Register(r *core.Registration) error { return c.regErr }
 func (c *TCore) Login(dex, pw string) error          { return c.loginErr }
 func (c *TCore) Sync(dex string, base, quote uint32) (chan *core.BookUpdate, error) {

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -54,6 +54,7 @@ func (s *WebServer) apiPreRegister(w http.ResponseWriter, r *http.Request) {
 type registration struct {
 	DEX      string `json:"dex"`
 	Password string `json:"pass"`
+	Fee      uint64 `json:"fee"`
 }
 
 // apiRegister is the handler for the '/register' API request.
@@ -80,6 +81,7 @@ func (s *WebServer) apiRegister(w http.ResponseWriter, r *http.Request) {
 	err, payFeeErr := s.core.Register(&core.Registration{
 		DEX:      reg.DEX,
 		Password: reg.Password,
+		Fee:      reg.Fee,
 	})
 	if err != nil {
 		s.writeAPIError(w, "registration error: %v", err)

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -24,6 +24,7 @@ func simpleAck() *standardResponse {
 	}
 }
 
+// preRegisterForm is the information necessary to pre-register a DEX.
 type preRegisterForm struct {
 	DEX string `json:"dex"`
 }
@@ -101,6 +102,7 @@ func (s *WebServer) apiRegister(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, simpleAck(), s.indent)
 }
 
+// newWalletForm is information necessary to create a new wallet.
 type newWalletForm struct {
 	AssetID uint32 `json:"assetID"`
 	// These are only used if the Decred wallet does not already exist. In that
@@ -152,6 +154,7 @@ func (s *WebServer) apiNewWallet(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, simpleAck(), s.indent)
 }
 
+// openWalletForm is information necessary to open a wallet.
 type openWalletForm struct {
 	AssetID uint32 `json:"assetID"`
 	Pass    string `json:"pass"`

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -58,11 +58,6 @@ func commonArgs(r *http.Request, title string) *CommonArguments {
 	}
 }
 
-type initTmplData struct {
-	CommonArguments
-	User *core.User
-}
-
 // handleLogin is the handler for the '/login' page request.
 func (s *WebServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 	user := extractUserInfo(r)

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -27,18 +27,20 @@ func (s *WebServer) sendTemplate(w http.ResponseWriter, r *http.Request, tmplID 
 // handleHome is the handler for the '/' page request. The response depends on
 // whether the user is authenticated or not.
 func (s *WebServer) handleHome(w http.ResponseWriter, r *http.Request) {
-	userInfo := extractUserInfo(r)
-	var tmplID string
-	var data interface{}
+	user := extractUserInfo(r)
 	switch {
-	case !userInfo.authed:
-		tmplID = "login"
-		data = commonArgs(r, "Login | Decred DEX")
+	// The registration page also walks the user through setting up their app
+	// password and connecting the Decred wallet, if not already done.
+	case !user.Initialized || (user.Authed && len(user.Markets) == 0):
+		s.handleRegister(w, r)
+		return
+	case !user.Authed:
+		s.handleLogin(w, r)
+		return
 	default:
-		tmplID = "markets"
-		data = s.marketResult(r)
+		s.handleMarkets(w, r)
+		return
 	}
-	s.sendTemplate(w, r, tmplID, data)
 }
 
 // CommonArguments are common page arguments that must be supplied to every
@@ -56,26 +58,42 @@ func commonArgs(r *http.Request, title string) *CommonArguments {
 	}
 }
 
+type initTmplData struct {
+	CommonArguments
+	User *core.User
+}
+
 // handleLogin is the handler for the '/login' page request.
 func (s *WebServer) handleLogin(w http.ResponseWriter, r *http.Request) {
+	user := extractUserInfo(r)
+	if !user.Initialized {
+		s.handleRegister(w, r)
+		return
+	}
 	s.sendTemplate(w, r, "login", commonArgs(r, "Login | Decred DEX"))
 }
 
 // registerTmplData is template data for the /register page.
 type registerTmplData struct {
 	CommonArguments
-	WalletExists bool
-	WalletOpen   bool
+	InitStep   bool
+	WalletStep bool
+	OpenStep   bool
+	DEXStep    bool
 }
 
 // handleRegister is the handler for the '/register' page request.
 func (s *WebServer) handleRegister(w http.ResponseWriter, r *http.Request) {
+	user := extractUserInfo(r)
 	dcrID, _ := dex.BipSymbolID("dcr")
 	exists, _, open := s.core.WalletStatus(dcrID)
+	needsInit := !user.Initialized
 	data := &registerTmplData{
 		CommonArguments: *commonArgs(r, "Register | Decred DEX"),
-		WalletOpen:      open,
-		WalletExists:    exists,
+		InitStep:        needsInit,
+		WalletStep:      !needsInit && !exists,
+		OpenStep:        exists && !open,
+		DEXStep:         exists && open,
 	}
 	s.sendTemplate(w, r, "register", data)
 }

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -69,7 +69,7 @@ func (c *TCore) Register(r *core.Registration) (error, <-chan error) {
 	errChan <- nil
 	return nil, errChan
 }
-func (c *TCore) Login(pw string) error { return nil }
+func (c *TCore) Login(string) ([]core.Negotiation, error) { return nil, nil }
 
 func (c *TCore) Sync(dex string, base, quote uint32) (chan *core.BookUpdate, error) {
 	return make(chan *core.BookUpdate), nil

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -82,6 +82,7 @@ form.auth {
   width: 400px;
   border: 1px solid #222;
   border-radius: 3px;
+  position: relative;
 
   button {
     padding: 6px 0;
@@ -224,4 +225,18 @@ div.note:not(:last-child) {
 
 .sellcolor {
   color: $sellcolor_light;
+}
+
+.errcolor {
+  color: #e61c00;
+}
+
+hr.dashed {
+  border-top: 1px dashed #777;
+}
+
+.vscroll {
+  max-width: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -23,21 +23,19 @@ div.marketrow.selected {
   background-color: #f0f7f7;
 }
 
-#marketchart {
+#marketChart {
   position: relative;
   background-color: white;
-  flex: 0 0 45%;
-  min-height: 250px;
-  max-height: 100%;
+  height: 250px;
   border-bottom: 1px solid #626262;
 }
 
-#marketloader {
+#marketLoader {
   z-index: 50;
   background-color: rgba(0, 0, 0, 0.5);
 }
 
-#marketloader > div {
+#marketLoader > div {
   width: 40px;
   height: 40px;
   font-size: 40px;
@@ -123,7 +121,7 @@ table.ordertable {
   background-color: $light_bg_1;
 }
 
-#orderform {
+#orderForm {
   min-height: 375px;
 
   input[type=number] {

--- a/client/webserver/site/src/css/market_dark.scss
+++ b/client/webserver/site/src/css/market_dark.scss
@@ -1,10 +1,10 @@
 body.dark {
-  #marketchart {
+  #marketChart {
     background-color: #131313;
     border-bottom-color: black;
   }
 
-  #orderform {
+  #orderForm {
     color: #a1a1a1;
 
     button.selected {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -1,10 +1,11 @@
 {{define "header"}}
 <header id=header class="maintop">
+  {{$authed := .UserInfo.Authed}}
   <div data-pagelink="" class="logo"></div>
   <div class="mainlinks fs18 offwhite">
   <span data-pagelink="markets">Markets</span>
   <span data-pagelink="wallets">Wallets</span>
-  <span class="d-inline-block position-relative" id="noteMenuEntry">
+  <span class="d-inline-block position-relative{{if not $authed}} d-hide{{end}}" id="noteMenuEntry">
     <div class="note-indicator" id="noteIndicator"></div>
     <div id="noteBox">
       <div id="noteList">
@@ -16,7 +17,11 @@
     </div>
     <span class="ico-bell fs20" id="noteBell"></span>
   </span>
-  <span class="ico-settings fs24" data-pagelink="settings"></span>
+  <span class="ico-settings fs24{{if not $authed}} d-hide{{end}}" data-pagelink="settings" id="settingsIcon"></span>
+  <span data-pagelink="login"{{if $authed}} class="d-hide"{{end}} id="loginLink">Sign In</span>
+  </div>
+  <div id="loader" class="fill-abs flex-center d-hide">
+    <div class="ico-spinner spinner"></div>
   </div>
 </header>
 {{end}}

--- a/client/webserver/site/src/html/login.tmpl
+++ b/client/webserver/site/src/html/login.tmpl
@@ -2,23 +2,18 @@
 {{template "top" .}}
 <div id="main" data-handler="login" class="main align-items-center justify-content-center flex-column">
   <div class="d-flex flex-column overflow-auto w-100">
-    <form class="auth mx-auto my-5 p-5 bg1">
-      <div class="d-flex">
-        <button type="button" class="col-12 justify-content-center fs15 bg2 selected">Log In</button>
-        <button type="button" data-pagelink="register" class="col-12 justify-content-center fs15 bg2">Register</button>
-      </div>
+    <form class="auth mx-auto my-5 bg1" id="loginForm">
+      <div class="bg2 px-2 py-1 text-center fs18">Log In</div>
+      <div class="p-4">
+        <div class="pb-2">
+          <label for="pw" class="pl-1 mb-1">Password</label>
+          <input type="password" class="form-control select" id="pw" autocomplete="current-password">
+        </div>
+        <div class="d-flex justify-content-end mt-4">
+          <button id="submit" type="button" class="col-8 justify-content-center fs15 bg2 selected">Submit</button>
+        </div>
+        <div class="fs15 pt-3 text-center d-hide errcolor" id="errMsg"></div>
       <div>
-        <label for="dex" class="pt-4 pl-1 mb-1">DEX</label>
-        <select class="form-control select" id="dex">
-        </select>
-      </div>
-      <div class="pb-3">
-        <label for="pw" class="pt-4 pl-1 mb-1">Password</label>
-        <input type="password" class="form-control select" id="pw" autocomplete="current-password">
-      </div>
-      <div class="d-flex justify-content-end mt-4">
-        <button id="submit" type="button" class="col-12 justify-content-center fs15 bg2 selected">Submit</button>
-      </div>
     </form>
   </div>
 </div>

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -15,14 +15,18 @@
       {{end}}
     {{end}}
   </div>
+
+  {{- /* RIGHT COLUMN */ -}}
   <div class="d-flex flex-column flex-grow-1">
 
     {{- /* CHART */ -}}
-    <div id="marketchart" class="w-100">
-      <div id="marketloader" class="fill-abs flex-center">
+    <div id="marketChart" class="w-100">
+      <div id="marketLoader" class="fill-abs flex-center">
         <div class="ico-spinner spinner"></div>
       </div>
     </div>
+
+    {{- /* ORDERS */ -}}
     <div id="orders" class="overflow-auto w-100 d-flex flex-grow-1 bg1">
       <div class="col-14 d-flex justify-content-around align-items-stretch p-0">
 
@@ -41,7 +45,7 @@
             {{end}}
             <tbody id="buyRows">
               {{- /* This row is used by the app as a template. */ -}}
-              <tr id="orderRow">
+              <tr id="rowTemplate">
                 <td class="text-left pl-2" data-type="qty">-</td>
                 <td class="text-right pr-2" data-type="rate">-</td>
                 <td class="text-right pr-3" data-type="epoch"></td>
@@ -56,7 +60,7 @@
             <button id="limitBttn" type="button" class="flex-center px-2 py-0 markettab brdrleft selected">Limit Order</button>
             <button id="marketBttn" type="button" class="flex-center px-2 py-0 markettab brdrleft brdrright">Market Order</button>
           </div>
-          <form id="orderform" class="px-5 bg1">
+          <form id="orderForm" class="px-5 bg1">
             <div class="market-bal px-3 py-2 my-4 position-relative">
               <span class="mktbalancelbl">Balances</span>
               <div class="d-flex mt-1 fs15 justify-content-between">

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -1,40 +1,106 @@
 {{define "register"}}
 {{template "top" .}}
 <div id="main" data-handler="register" class="main align-items-center justify-content-center flex-column">
-  <div class="d-flex flex-column overflow-auto w-100">
-    <form class="auth mx-auto my-5 p-5 bg1">
-      <div class="d-flex">
-        <button type="button" data-pagelink="login" class="col-12 justify-content-center fs15 bg2">Log In</button>
-        <button type="button" class="col-12 justify-content-center fs15 bg2 selected">Register</button>
-      </div>
-      <div>
-        <label for="dex" class="pt-3 pl-1 mb-0">DEX Address</label>
-        <input type="text" class="form-control select" id="dex">
-      </div>
-      <div>
-        <label for="dexPass" class="pt-3 pl-1 mb-0">Create DEX Password</label>
-        <input type="password" class="form-control select" id="dexPass">
-      </div>
-      <div{{if .WalletExists}} class="d-hide"{{end}}>
-        <div>
-          <label for="iniPath" class="pt-3 pl-1 mb-0">Decred Wallet Configuration Filepath</label>
-          <input type="text" class="form-control select" id="iniPath">
+  <div class="d-flex flex-column vscroll w-100">
+
+    {{- /* Set up the initial application password. Only shown on first visit. */ -}}
+    <form class="auth mx-auto my-5 bg1{{if not .InitStep}} d-hide{{end}}" id="appPWForm">
+      <div class="bg2 px-2 py-1 text-center fs18">Set Password</div>
+      <div class="p-4">
+        <div class="fs16">Set your client password. This password will protect your DEX account keys, but not your wallets.</div>
+        <hr class="dashed my-4">
+        <div class="pb-3">
+          <label for="pw" class="pl-1 mb-1">Password</label>
+          <input type="password" class="form-control select" id="appPW" autocomplete="new-password">
         </div>
-        <div>
-          <label for="acct" class="pt-3 pl-1 mb-0">Decred Wallet Account Name</label>
-          <input type="text" class="form-control select" id="acct">
+        <div class="pb-3">
+          <label for="pwAgain" class="pl-1 mb-1">Password Again</label>
+          <input type="password" class="form-control select" id="appPWAgain" autocomplete="off">
         </div>
-      </div>
-      <div{{if .WalletOpen}} class="d-hide"{{end}}>
-        <div>
-          <label for="walletPass" class="pt-3 pl-1 mb-0">Decred Wallet Password</label>
-          <input type="password" class="form-control select" id="walletPass">
+        <div class="d-flex justify-content-end mt-4">
+          <button id="appPWSubmit" type="button" class="col-8 justify-content-center fs15 bg2 selected">Submit</button>
         </div>
-      </div>
-      <div class="d-flex justify-content-end mt-3">
-        <button id="submit" type="button" class="col-12 justify-content-center fs15 bg2 selected">Create Account</button>
+        <div class="fs15 pt-3 text-center d-hide errcolor" id="appErrMsg"></div>
       </div>
     </form>
+
+    {{- /* Set up the Decred wallet. Only shown on first visit. */ -}}
+    <form class="auth mx-auto my-5 bg1{{if not .WalletStep}} d-hide{{end}}" id="walletForm">
+      <div class="bg2 px-2 py-1 text-center fs18">Decred Wallet</div>
+      <div class="p-4">
+        <div class="fs16">You haven't connected a Decred wallet yet. Connect to your wallet now.</div>
+        <hr class="dashed my-4">
+        <div>
+          <label for="acctName" class="pl-1 mb-1">Account Name</label>
+          <input type="text" class="form-control select" id="acctName">
+        </div>
+        <div>
+          <label for="newWalletPass" class="pt-3 pl-1 mb-1">Password</label>
+          <input type="password" class="form-control select" id="newWalletPass">
+        </div>
+        <div>
+          <label for="iniPath" class="pt-3 pl-1 mb-1">Configuration Filepath</label>
+          <input type="text" class="form-control select" placeholder="leave empty to use default path" id="iniPath">
+        </div>
+        <div class="d-flex justify-content-end mt-4">
+          <button id="submitCreate" type="button" class="col-8 justify-content-center fs15 bg2 selected">Create</button>
+        </div>
+        <div class="fs15 pt-3 text-center d-hide errcolor" id="walletErr"></div>
+      </div>
+    </form>
+
+    {{- /* Open Decred wallet. Only shown if now already open. */ -}}
+    <form class="auth mx-auto my-5 bg1{{if not .OpenStep}} d-hide{{end}}" id="openForm">
+      <div class="bg2 px-2 py-1 text-center fs18">Decred Wallet</div>
+      <div class="p-4">
+        <div class="fs16">Unlock your Decred wallet to pay registration fees.</div>
+        <hr class="dashed my-4">
+        <div>
+          <label for="walletPass" class="pl-1 mb-1">Decred Wallet Password</label>
+          <input type="password" class="form-control select" id="walletPass">
+        </div>
+        <div class="d-flex justify-content-end mt-4">
+          <button id="submitOpen" type="button" class="col-8 justify-content-center fs15 bg2 selected">Open</button>
+        </div>
+        <div class="fs15 pt-3 text-center d-hide errcolor" id="openErr"></div>
+      </div>
+    </form>
+
+    {{- /* DEX URL */ -}}
+    <form class="auth mx-auto my-5 bg1{{if not .DEXStep}} d-hide{{end}}" id="urlForm">
+      <div class="bg2 px-2 py-1 text-center fs18">Add a DEX</div>
+      <div class="p-4">
+        <div>
+          <label for="addrInput" class="pl-1 mb-1">DEX Address</label>
+          <input type="text" class="form-control select" id="addrInput">
+        </div>
+        <div class="d-flex justify-content-end mt-4">
+          <button id="submitAddr" type="button" class="col-8 justify-content-center fs15 bg2 selected">Submit</button>
+        </div>
+        <div class="fs15 pt-3 text-center d-hide errcolor" id="addrErr"></div>
+      </div>
+    </form>
+
+    {{- /* Confirm registration with app password. */ -}}
+    <form class="auth mx-auto my-5 bg1 d-hide" id="pwForm">
+      <div class="bg2 px-2 py-1 text-center fs18">Confirm Password</div>
+      <div class="p-4">
+        <div class="fs16">
+          Enter your main client password to confirm DEX registration.
+          When you submit this form, <span id="feeDisplay"></span> DCR will be spent from your Decred wallet to pay registration fees.
+        </div>
+        <hr class="dashed my-4">
+        <div>
+          <label for="clientPass" class="pl-1 mb-1">Password</label>
+          <input type="password" class="form-control select" id="clientPass">
+        </div>
+        <div class="d-flex justify-content-end mt-4">
+          <button id="submitPW" type="button" class="col-8 justify-content-center fs15 bg2 selected">Register</button>
+        </div>
+        <div class="fs15 pt-3 text-center d-hide errcolor" id="regErr"></div>
+      </div>
+    </form>
+
   </div>
 </div>
 {{template "bottom"}}

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -409,6 +409,7 @@ function handleRegister (main) {
   })
 
   // ENTER NEW DEX URL
+  var fee
   bindForm(page.urlForm, page.submitAddr, async () => {
     Doc.hide(page.addrErr)
     const dex = page.addrInput.value
@@ -426,6 +427,7 @@ function handleRegister (main) {
       return
     }
     page.feeDisplay.textContent = formatCoinValue(res.fee / 1e8)
+    fee = res.fee
     await app.userPromise
     const dcrWallet = app.walletMap[DCR_ID]
     if (!dcrWallet) {
@@ -448,7 +450,8 @@ function handleRegister (main) {
     const dex = page.addrInput.value
     const registration = {
       dex: page.addrInput.value,
-      pass: page.clientPass.value
+      pass: page.clientPass.value,
+      fee: fee
     }
     app.loading(page.pwForm)
     var res = await postJSON('/api/register', registration)

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -1,4 +1,6 @@
-var parser = new window.DOMParser()
+const parser = new window.DOMParser()
+
+const FPS = 60
 
 // Helpers for working with the DOM.
 export default class Doc {
@@ -27,4 +29,40 @@ export default class Doc {
   static empty (el) {
     while (el.firstChild) el.removeChild(el.firstChild)
   }
+
+  static hide (el) {
+    el.classList.add('d-hide')
+  }
+
+  static show (el) {
+    el.classList.remove('d-hide')
+  }
+
+  static async animate (duration, f, easingAlgo) {
+    const easer = easingAlgo ? Easing[easingAlgo] : Easing.linear
+    // key is a string referencing any property of Meter.data.
+    const start = new Date().getTime()
+    const end = start + duration
+    const range = end - start
+    const frameDuration = 1000 / FPS
+    var now = start
+    while (now < end) {
+      f(easer((now - start) / range))
+      await sleep(frameDuration)
+      now = new Date().getTime()
+    }
+    f(1)
+  }
+}
+
+var Easing = {
+  linear: t => t,
+  easeIn: t => t * t,
+  easeOut: t => t * (2 - t),
+  easeInHard: t => t * t * t,
+  easeOutHard: t => (--t) * t * t + 1
+}
+
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/client/webserver/websocket.go
+++ b/client/webserver/websocket.go
@@ -110,6 +110,16 @@ func (s *WebServer) notify(route string, payload interface{}) {
 	}
 }
 
+func (s *WebServer) notifyWalletUpdate(assetID uint32, on, open bool) {
+	walletUpdate := &core.WalletStatus{
+		Symbol:  unbip(assetID),
+		AssetID: assetID,
+		Running: on,
+		Open:    open,
+	}
+	s.notify(updateWalletRoute, walletUpdate)
+}
+
 // handleMessage handles the websocket message, calling the right handler for
 // the route.
 func (s *WebServer) handleMessage(conn *wsClient, msg *msgjson.Message) *msgjson.Error {

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -297,6 +297,33 @@ func NewNotification(route string, payload interface{}) (*Message, error) {
 	}, nil
 }
 
+// Unmarshal unmarshals the Payload field into the provided interface.
+func (msg *Message) Unmarshal(payload interface{}) error {
+	return json.Unmarshal(msg.Payload, payload)
+}
+
+// UnmarshalResult is a convenience method for decoding the Result field of a
+// ResponsePayload.
+func (msg *Message) UnmarshalResult(result interface{}) error {
+	resp, err := msg.Response()
+	if err != nil {
+		return err
+	}
+	if resp.Error != nil {
+		return fmt.Errorf("rpc error: %d: %s", resp.Error.Code, resp.Error.Message)
+	}
+	return json.Unmarshal(resp.Result, result)
+}
+
+// String prints the message as a JSON-encoded string.
+func (msg *Message) String() string {
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return "[Message decode error]"
+	}
+	return string(b)
+}
+
 // Match is the params for a DEX-originating MatchRoute request.
 type Match struct {
 	signable
@@ -635,8 +662,8 @@ func (c *Connect) Serialize() ([]byte, error) {
 	return s, nil
 }
 
-// Connect is the response result for the ConnectRoute request.
-type ConnectResponse struct {
+// ConnectResult is the result result for the ConnectRoute request.
+type ConnectResult struct {
 	Matches []*Match `json:"matches"`
 }
 
@@ -716,6 +743,7 @@ type ConfigResult struct {
 	RegFeeConfirms   uint16   `json:"regfeeconfirms"`
 	Assets           []Asset  `json:"assets"`
 	Markets          []Market `json:"markets"`
+	Fee              uint64   `json:"fee"`
 }
 
 // Market describes a market and its variables, and is returned as part of a

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -47,7 +47,7 @@ func (ssw *StartStopWaiter) Stop() {
 
 // On will be true until the Runner Context is canceled.
 func (ssw *StartStopWaiter) On() bool {
-	return ssw.ctx.Err() == nil
+	return ssw.ctx != nil && ssw.ctx.Err() == nil
 }
 
 // WaitForShutdown blocks until the Runner has returned in response to Stop.

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -93,7 +93,7 @@ func NewConnectionMaster(c Connector) *ConnectionMaster {
 	}
 }
 
-// Start connects the Connector, and returns any initial connection error. Use
+// Connect connects the Connector, and returns any initial connection error. Use
 // Disconnect to shut down the Connector.
 func (c *ConnectionMaster) Connect(ctx context.Context) (err error) {
 	c.init(ctx)

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -20,13 +20,6 @@ func (cm *contextManager) init(ctx context.Context) {
 	cm.ctx, cm.cancel = context.WithCancel(ctx)
 }
 
-// Stop cancels the context.
-func (cm *contextManager) Stop() {
-	cm.mtx.RLock()
-	cm.cancel()
-	cm.mtx.RUnlock()
-}
-
 // On will be true until the context is canceled.
 func (cm *contextManager) On() bool {
 	cm.mtx.RLock()
@@ -72,6 +65,13 @@ func (ssw *StartStopWaiter) WaitForShutdown() {
 	ssw.wg.Wait()
 }
 
+// Stop cancels the context.
+func (ssw *StartStopWaiter) Stop() {
+	ssw.mtx.RLock()
+	ssw.cancel()
+	ssw.mtx.RUnlock()
+}
+
 // Connector is any type that implements the Connect method, which will return
 // a connection error, and a channel that can be used to wait on shutdown after
 // context cancellation.
@@ -105,8 +105,8 @@ func (c *ConnectionMaster) Connect(ctx context.Context) (err error) {
 
 // Disconnect closes the connection and waits for shutdown.
 func (c *ConnectionMaster) Disconnect() {
-	c.Stop()
 	c.mtx.RLock()
+	c.cancel()
 	defer c.mtx.RUnlock()
 	c.wg.Wait()
 }

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,7 @@ github.com/decred/dcrd/txscript/v2 v2.1.0/go.mod h1:XaJAVrZU4NWRx4UEzTiDAs86op1m
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/decred/dcrd/wire v1.3.0 h1:X76I2/a8esUmxXmFpJpAvXEi014IA4twgwcOBeIS8lE=
 github.com/decred/dcrd/wire v1.3.0/go.mod h1:fnKGlUY2IBuqnpxx5dYRU5Oiq392OBqAuVjRVSkIoXM=
+github.com/decred/dcrwallet v1.5.0 h1:9upGfaogh6Xl4cdbICgN0xH81rmOIGMZvM8U//5Tgug=
 github.com/decred/dcrwallet/deployments/v2 v2.0.0/go.mod h1:fY1HV1vIeeY5bHjrMknUhB/ZOVIfthBiUlSgRqFFKrg=
 github.com/decred/dcrwallet/errors/v2 v2.0.0 h1:b3QHoQNjKkrcO0GSpueeHvFKp5eqtRv9aw649MDyejA=
 github.com/decred/dcrwallet/errors/v2 v2.0.0/go.mod h1:2HYvtRuCE9XqDNCWhKmBuzLG364xUgcUIsJu02r0F5Q=

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -356,7 +356,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 			Side:     uint8(match.Side),
 		})
 	}
-	resp := &msgjson.ConnectResponse{
+	resp := &msgjson.ConnectResult{
 		Matches: msgMatches,
 	}
 	respMsg, err := msgjson.NewResponse(msg.ID, resp, nil)
@@ -385,6 +385,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 	}
 
 	auth.addClient(client)
+	log.Tracef("user %x connected", acctInfo.ID[:])
 	return nil
 }
 

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -177,12 +177,12 @@ func tNewConnect(user *tUser) *msgjson.Connect {
 	}
 }
 
-func extractConnectResponse(t *testing.T, msg *msgjson.Message) *msgjson.ConnectResponse {
+func extractConnectResult(t *testing.T, msg *msgjson.Message) *msgjson.ConnectResult {
 	if msg == nil {
 		t.Fatalf("no response from 'connect' request")
 	}
 	resp, _ := msg.Response()
-	result := new(msgjson.ConnectResponse)
+	result := new(msgjson.ConnectResult)
 	err := json.Unmarshal(resp.Result, result)
 	if err != nil {
 		t.Fatalf("unmarshal error: %v", err)
@@ -303,7 +303,7 @@ func TestConnect(t *testing.T) {
 	// Connect the user.
 	user := tNewUser(t)
 	respMsg := connectUser(t, user)
-	cResp := extractConnectResponse(t, respMsg)
+	cResp := extractConnectResult(t, respMsg)
 	if len(cResp.Matches) != 1 {
 		t.Fatalf("no active matches")
 	}
@@ -404,7 +404,7 @@ func TestAccountErrors(t *testing.T) {
 
 	// Check the response.
 	respMsg := user.conn.getSend()
-	result := extractConnectResponse(t, respMsg)
+	result := extractConnectResult(t, respMsg)
 	if len(result.Matches) != 1 {
 		t.Fatalf("expected 1 match, received %d", len(result.Matches))
 	}

--- a/server/auth/registrar.go
+++ b/server/auth/registrar.go
@@ -215,6 +215,8 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 			return coinwaiter.DontTryAgain
 		}
 
+		log.Info("new user registered")
+
 		// Create, sign, and send the the response.
 		err = auth.Sign(notifyFee)
 		if err != nil {

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -134,6 +134,7 @@ func newConfigResponse(cfg *DexConf, cfgAssets []msgjson.Asset, cfgMarkets []msg
 		RegFeeConfirms:   uint16(cfg.RegFeeConfirms),
 		Assets:           cfgAssets,
 		Markets:          cfgMarkets,
+		Fee:              cfg.RegFeeAmount,
 	}
 
 	encResult, err := json.Marshal(configMsg)

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -656,14 +656,8 @@ type messageAcker struct {
 // processAck processes a single msgjson.AcknowledgementResult, validating the
 // signature and updating the (order.Match).Sigs record.
 func (s *Swapper) processAck(msg *msgjson.Message, acker *messageAcker) {
-	var ack msgjson.Acknowledgement
-	resp, err := msg.Response()
-	if err != nil {
-		s.respondError(msg.ID, acker.user, msgjson.RPCParseError,
-			fmt.Sprintf("error parsing audit notification result: %v", err))
-		return
-	}
-	err = json.Unmarshal(resp.Result, &ack)
+	ack := new(msgjson.Acknowledgement)
+	err := msg.UnmarshalResult(ack)
 	if err != nil {
 		s.respondError(msg.ID, acker.user, msgjson.RPCParseError,
 			fmt.Sprintf("error parsing audit notification acknowledgment: %v", err))
@@ -1070,13 +1064,7 @@ func newMatchAckers(match *matchTracker) (*messageAcker, *messageAcker) {
 // an array of signatures, one for each match sent.
 func (s *Swapper) processMatchAcks(user account.AccountID, msg *msgjson.Message, matches []*messageAcker) {
 	var acks []msgjson.Acknowledgement
-	resp, err := msg.Response()
-	if err != nil {
-		s.respondError(msg.ID, user, msgjson.RPCParseError,
-			fmt.Sprintf("error parsing match acknowledgment response: %v", err))
-		return
-	}
-	err = json.Unmarshal(resp.Result, &acks)
+	err := msg.UnmarshalResult(&acks)
 	if err != nil {
 		s.respondError(msg.ID, user, msgjson.RPCParseError,
 			fmt.Sprintf("error parsing match notification acknowledgment: %v", err))

--- a/spec/README.mediawiki
+++ b/spec/README.mediawiki
@@ -93,6 +93,7 @@ for the DEX API.
 
 * [[comm.mediawiki/#Encoding|Data Encodings]]
 * [[comm.mediawiki/#Message_Protocol|Message Protocol]]
+* [[comm.mediawiki/#Session_Authentication|Session Authentication]]
 
 '''&#91;2&#93; [[fundamentals.mediawiki|Distributed Exchange Design Fundamentals]]'''
 describes the notable design aspects that facilitate an exchange service with


### PR DESCRIPTION
Adds handling of 'connect' route, which is now tied to the user signing in to the client with an app-wide password. The app-wide password is used to decode an encryption key, which itself is used to encode and decode DEX account private keys. Wallets still have their own individual passwords. This PR does not implement encryption, but does suggest an interface for the upcoming work.

UI: The /register page's single form is broken into a series of forms, the display of which is based on the current user state. The page walks the user through setting an app-wide password, connecting to a Decred wallet, and then creating a DEX account.

Testing instructions are the same as in #140. 