### PR TITLE
webserver: fix test synchronization

### DIFF
--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -239,11 +239,6 @@ func (s *WebServer) Run(ctx context.Context) {
 		if err != nil {
 			log.Errorf("Problem shutting down rpc: %v", err)
 		}
-		s.mtx.Lock()
-		defer s.mtx.Unlock()
-		for _, cl := range s.clients {
-			cl.Disconnect()
-		}
 	}()
 	log.Infof("Web server listening on %s", s.listener.Addr())
 	err := s.srv.Serve(s.listener)
@@ -251,6 +246,12 @@ func (s *WebServer) Run(ctx context.Context) {
 		log.Warnf("unexpected (http.Server).Serve error: %v", err)
 	}
 	log.Infof("Web server off")
+	<-ctx.Done()
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	for _, cl := range s.clients {
+		cl.Disconnect()
+	}
 }
 
 // auth creates, stores, and returns a new auth token.

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -129,7 +129,7 @@ func newTServer(t *testing.T, start bool) (*WebServer, *TCore, func()) {
 	tPort++
 	c := &TCore{}
 	var shutdown func()
-	ctx, shutdown := context.WithCancel(tCtx)
+	ctx, killCtx := context.WithCancel(tCtx)
 	s, err := New(c, fmt.Sprintf("localhost:%d", tPort), tLogger, false)
 	if err != nil {
 		t.Fatalf("error creating server: %v", err)
@@ -138,12 +138,12 @@ func newTServer(t *testing.T, start bool) (*WebServer, *TCore, func()) {
 	if start {
 		waiter := dex.NewStartStopWaiter(s)
 		waiter.Start(ctx)
-		killCtx := shutdown
 		shutdown = func() {
 			killCtx()
 			waiter.WaitForShutdown()
 		}
 	} else {
+		shutdown = killCtx
 		s.ctx = ctx
 	}
 	return s, c, shutdown

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -390,7 +390,7 @@ func TestClientMap(t *testing.T) {
 
 	// Close the server and make sure the connection is closed.
 	shutdown()
-	time.Sleep(time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 	if !cl.Off() {
 		t.Fatalf("connection not closed on server shutdown")
 	}


### PR DESCRIPTION
I'm unable to reproduce #149, but I'm figuring that the delay is longer than 1 ms at https://github.com/buck54321/dcrdex/blob/9318bad2f6338b0ff4984c4b1e8eea2e6ad4fdd8/client/webserver/webserver.go#L238 occasionally. 