### PR TITLE
rpcserver: fix TestClientMap sync

### DIFF
--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -125,10 +125,11 @@ func (c *TConn) Close() error {
 
 var tPort = 5142
 
-func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, *TCore, context.CancelFunc) {
+func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, *TCore, func()) {
 	tPort++
 	c := &TCore{}
-	ctx, shutdown := context.WithCancel(tCtx)
+	var shutdown func()
+	ctx, killCtx := context.WithCancel(tCtx)
 	tmp, err := os.Getwd()
 	if err != nil {
 		t.Error(err)
@@ -143,8 +144,14 @@ func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, *TCore
 	}
 	SetLogger(tLogger)
 	if start {
-		go s.Run(ctx)
+		waiter := dex.NewStartStopWaiter(s)
+		waiter.Start(ctx)
+		shutdown = func() {
+			killCtx()
+			waiter.WaitForShutdown()
+		}
 	} else {
+		shutdown = killCtx
 		s.ctx = ctx
 	}
 	return s, c, shutdown
@@ -505,7 +512,6 @@ func TestClientMap(t *testing.T) {
 
 	// Close the server and make sure the connection is closed.
 	shutdown()
-	time.Sleep(time.Millisecond)
 	if !cl.Off() {
 		t.Fatalf("connection not closed on server shutdown")
 	}


### PR DESCRIPTION
Updates **rpcserver**'s `TestClientMap` and `newTServer` as per #160. 