### PR TITLE
client/rpcserver: Fix port race

### DIFF
--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -130,7 +130,6 @@ func (c *TConn) Close() error {
 var tPort = 5142
 
 func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, *TCore, func()) {
-	tPort++
 	c := &TCore{}
 	var shutdown func()
 	ctx, killCtx := context.WithCancel(tCtx)


### PR DESCRIPTION
Use ports different from other tests. Retrieve ports with sync/atomic.
Try three times for an open port.

Tests are passing 10/10 for me now.  I think I was using the same ports as another test. Changing the ports. To be extra safe be cautious of concurrency issues when retrieving ports, in case tests are run in parallel, and try three times for an open port, incrementing by 3.