### PR TITLE
client/webserver: Create listeners in Run

### DIFF
--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -141,7 +141,6 @@ func (c *TConn) Close() error {
 var tPort int = 5142
 
 func newTServer(t *testing.T, start bool) (*WebServer, *TCore, func()) {
-	tPort++
 	c := &TCore{}
 	var shutdown func()
 	ctx, killCtx := context.WithCancel(tCtx)


### PR DESCRIPTION
Creating listeners in New causes those resources to be locked up until
Run is called. Prevent this by creating listeners in Run.