### PR TITLE
client.Core needs to wait for DB to close

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -142,7 +142,7 @@ func (c *Core) Run(ctx context.Context) {
 	// when new accounts are registered.
 	c.ctx = ctx
 	c.initialize()
-	<-ctx.Done()
+	c.db.Run(ctx)
 	c.wg.Wait()
 	log.Infof("DEX client core off")
 }


### PR DESCRIPTION
In a short lived client test app I noticed that DB writes would be missing on the next run.  This seems to be if the the `Core` shutdown does not also wait for bbolt DB shutdown while their are pending/in-progress writes.  The db's `Run` method waits for context cancellation and then closes the bbolt DB. Using this instead of `ctx.Done` in `Core.Run`.