### PR TITLE
client/asset/dcr: RPC cert is rpccert, not cafile

### DIFF
--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -43,7 +43,7 @@ type DCRConfig struct {
 	RPCListen string `long:"rpclisten" description:"dcrd interface/port for RPC connections (default port: 9109, testnet: 19109)"`
 	// RPCCert is the filepath to the dcrwallet TLS certificate. If it is not
 	// provided, the default dcrwallet location will be assumed.
-	RPCCert string `long:"cafile" description:"File containing the TLS certificate"`
+	RPCCert string `long:"rpccert" description:"File containing the TLS certificate"`
 	// Context should be canceled when the application exits. This will cause
 	// some cleanup to be performed during shutdown.
 	Context context.Context

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -289,7 +289,7 @@ func (d *ExchangeWallet) Info() *asset.WalletInfo {
 // Connect connects the wallet to the RPC server. Satisfies the dex.Connector
 // interface.
 func (dcr *ExchangeWallet) Connect(ctx context.Context) (error, *sync.WaitGroup) {
-	err := dcr.client.Connect(ctx, true)
+	err := dcr.client.Connect(ctx, false)
 	if err != nil {
 		return fmt.Errorf("Decred Wallet connect error: %v", err), nil
 	}


### PR DESCRIPTION
This changes the `DCRConfig.RPCCert` field config tag to `"rpccert"` since that is the dcrwallet setting for it's RPC certificate, whereas `"cafile"` refers to dcrd's cert.

This also changes the call to `rpcclient.Client.Connect` in `(*ExchangeWallet).Connect` so it does not retry on failure.  This is necessary to see many config errors.  Auto-reconnect is unrelated.