### PR TITLE
server/auth: AuthManager's coinWaiter had a bad AuthManager

### DIFF
--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -145,17 +145,18 @@ type Config struct {
 
 // NewAuthManager is the constructor for an AuthManager.
 func NewAuthManager(cfg *Config) *AuthManager {
-	var auth *AuthManager
-	auth = &AuthManager{
-		users:      make(map[account.AccountID]*clientInfo),
-		conns:      make(map[uint64]*clientInfo),
-		storage:    cfg.Storage,
-		signer:     cfg.Signer,
-		regFee:     cfg.RegistrationFee,
-		checkFee:   cfg.FeeChecker,
-		feeConfs:   cfg.FeeConfs,
-		coinWaiter: coinwaiter.New(recheckInterval, auth.Send),
+	auth := &AuthManager{
+		users:    make(map[account.AccountID]*clientInfo),
+		conns:    make(map[uint64]*clientInfo),
+		storage:  cfg.Storage,
+		signer:   cfg.Signer,
+		regFee:   cfg.RegistrationFee,
+		checkFee: cfg.FeeChecker,
+		feeConfs: cfg.FeeConfs,
 	}
+	// Referring to auth.Send in the construction above would create a function
+	// with a nil receiver, so do it after auth is set.
+	auth.coinWaiter = coinwaiter.New(recheckInterval, auth.Send)
 
 	comms.Route(msgjson.ConnectRoute, auth.handleConnect)
 	comms.Route(msgjson.RegisterRoute, auth.handleRegister)


### PR DESCRIPTION
interestingly, auth.Send is a valid value even when `auth` is `nil`, presumably because it's still a function just with a nil receiver.  The problem was that the receiver was still nil.

This caused the following panic (line numbers apply to commit [ce0a64179425a18ed844d27f1576432ac7551314](https://github.com/decred/dcrdex/tree/ce0a64179425a18ed844d27f1576432ac7551314/server)):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x85254b]

goroutine 68 [running]:
sync.(*RWMutex).RLock(...)
        /home/jon/go113/src/sync/rwmutex.go:48
decred.org/dcrdex/server/auth.(*AuthManager).user(0x0, 0xc1ed571e829157f5, 0x56adcacbb60063c0, 0x6e332c39b14d8edc, 0x1d8c77b52a58074c, 0x0)
        /home/jon/github/decred/dcrdex/server/auth/auth.go:271 +0x3b
decred.org/dcrdex/server/auth.(*AuthManager).Send(0x0, 0xc1ed571e829157f5, 0x56adcacbb60063c0, 0x6e332c39b14d8edc, 0x1d8c77b52a58074c, 0xc0004cd1c0)
        /home/jon/github/decred/dcrdex/server/auth/auth.go:217 +0x88
decred.org/dcrdex/server/coinwaiter.(*Waiter).Run.func1()
        /home/jon/github/decred/dcrdex/server/coinwaiter/coinwaiter.go:117 +0x3e3
decred.org/dcrdex/server/coinwaiter.(*Waiter).Run(0xc000073080, 0xdc5fe0, 0xc000066340)
        /home/jon/github/decred/dcrdex/server/coinwaiter/coinwaiter.go:129 +0xaf
created by decred.org/dcrdex/server/auth.(*AuthManager).Run
        /home/jon/github/decred/dcrdex/server/auth/auth.go:169 +0x57
```