### PR TITLE
client/comms: refactoring

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -72,7 +72,6 @@ type wsConn struct {
 	reqMtx       sync.RWMutex
 	connected    bool
 	connectedMtx sync.RWMutex
-	once         sync.Once
 	respHandlers map[uint64]*responseHandler
 }
 

--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -59,6 +59,8 @@ type WsCfg struct {
 
 // wsConn represents a client websocket connection.
 type wsConn struct {
+	cancel       context.CancelFunc
+	wg           sync.WaitGroup
 	reconnects   uint64
 	rID          uint64
 	cfg          *WsCfg
@@ -66,7 +68,6 @@ type wsConn struct {
 	wsMtx        sync.Mutex
 	tlsCfg       *tls.Config
 	readCh       chan *msgjson.Message
-	sendCh       chan *msgjson.Message
 	reconnectCh  chan struct{}
 	reqMtx       sync.RWMutex
 	connected    bool
@@ -118,8 +119,7 @@ func NewWsConn(cfg *WsCfg) (WsConn, error) {
 		cfg:          cfg,
 		tlsCfg:       tlsConfig,
 		readCh:       make(chan *msgjson.Message, readBuffSize),
-		sendCh:       make(chan *msgjson.Message),
-		reconnectCh:  make(chan struct{}),
+		reconnectCh:  make(chan struct{}, 1),
 		respHandlers: make(map[uint64]*responseHandler),
 	}, nil
 }
@@ -139,7 +139,7 @@ func (conn *wsConn) setConnected(connected bool) {
 }
 
 // connect attempts to establish a websocket connection.
-func (conn *wsConn) connect() error {
+func (conn *wsConn) connect(ctx context.Context) error {
 	dialer := &websocket.Dialer{
 		Proxy:            http.ProxyFromEnvironment,
 		HandshakeTimeout: 10 * time.Second,
@@ -148,18 +148,16 @@ func (conn *wsConn) connect() error {
 
 	ws, _, err := dialer.Dial(conn.cfg.URL, nil)
 	if err != nil {
-		conn.queueReconnect()
 		return err
 	}
 
 	ws.SetPingHandler(func(string) error {
-		conn.wsMtx.Lock()
-		defer conn.wsMtx.Unlock()
-
 		now := time.Now()
+
+		// Set the deadline for the next ping.
 		err := ws.SetReadDeadline(now.Add(conn.cfg.PingWait))
 		if err != nil {
-			log.Errorf("read deadline error: %v", err)
+			log.Errorf("set read deadline failed: %v", err)
 			return err
 		}
 
@@ -169,31 +167,49 @@ func (conn *wsConn) connect() error {
 			log.Errorf("pong error: %v", err)
 			return err
 		}
+		log.Tracef("got pinged, and ponged the server")
 
 		return nil
 	})
 
 	conn.wsMtx.Lock()
+	if conn.ws != nil {
+		// msg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye")
+		// conn.ws.WriteControl(websocket.CloseMessage, msg,
+		// 	time.Now().Add(writeWait))
+		//conn.ws.Close()
+	}
 	conn.ws = ws
 	conn.wsMtx.Unlock()
 
-	go conn.read()
 	conn.setConnected(true)
+	conn.wg.Add(1)
+	go func() {
+		defer conn.wg.Done()
+		conn.read(ctx)
+	}()
 
 	return nil
 }
 
 // read fetches and parses incoming messages for processing. This should be
-// run as a goroutine.
-func (conn *wsConn) read() {
+// run as a goroutine. Increment the wg before calling read.
+func (conn *wsConn) read(ctx context.Context) {
 	for {
 		msg := new(msgjson.Message)
 
+		// Lock since conn.ws may be set by connect.
 		conn.wsMtx.Lock()
 		ws := conn.ws
 		conn.wsMtx.Unlock()
 
+		// The read itself does not require locking since only this goroutine
+		// uses read functions that are not safe for concurrent use.
 		err := ws.ReadJSON(msg)
+		// Drop the read error on context cancellation.
+		if ctx.Err() != nil {
+			return
+		}
 		if err != nil {
 			var mErr *json.UnmarshalTypeError
 			if errors.As(err, &mErr) {
@@ -202,25 +218,34 @@ func (conn *wsConn) read() {
 				continue
 			}
 
+			// TODO: Now that wsConn goroutines have contexts that are canceled
+			// on shutdown, we do not have to infer the source and severity of
+			// the error; just reconnect in ALL other cases, and remove the
+			// following legacy checks.
+
+			// Expected close errors (1000 and 1001) ... but if the server
+			// closes we still want to reconnect. (???)
 			if websocket.IsCloseError(err, websocket.CloseGoingAway,
 				websocket.CloseNormalClosure) ||
 				strings.Contains(err.Error(), "websocket: close sent") {
+				conn.reconnect()
 				return
 			}
 
 			var opErr *net.OpError
-			if errors.As(err, &opErr) {
-				if opErr.Op == "read" {
-					if strings.Contains(opErr.Err.Error(),
-						"use of closed network connection") {
-						return
-					}
+			if errors.As(err, &opErr) && opErr.Op == "read" {
+				if strings.Contains(opErr.Err.Error(),
+					"use of closed network connection") {
+					log.Errorf("read quiting: %v", err)
+					conn.reconnect()
+					return
 				}
 			}
 
 			// Log all other errors and trigger a reconnection.
-			log.Errorf("read error: %v", err)
-			conn.reconnectCh <- struct{}{}
+			log.Errorf("read error (%v), attempting reconnection", err)
+			conn.reconnect()
+			// Successful reconnect via connect() will start read() again.
 			return
 		}
 
@@ -232,8 +257,14 @@ func (conn *wsConn) read() {
 				log.Errorf("no handler found for response", string(b))
 				continue
 			}
-			// Run handlers in a goroutine so that other messages can be recieved.
-			go handler.f(msg)
+			// Run handlers in a goroutine so that other messages can be
+			// received. Include the handler goroutines in the WaitGroup to
+			// allow them to complete if the connection master desires.
+			conn.wg.Add(1)
+			go func() {
+				defer conn.wg.Done()
+				handler.f(msg)
+			}()
 			continue
 		}
 		conn.readCh <- msg
@@ -243,22 +274,37 @@ func (conn *wsConn) read() {
 // keepAlive maintains an active websocket connection by reconnecting when
 // the established connection is broken. This should be run as a goroutine.
 func (conn *wsConn) keepAlive(ctx context.Context) {
+	maxReconnects := uint64(20000000) // TODO: reason to limit this?
 	for {
 		select {
 		case <-conn.reconnectCh:
-			conn.setConnected(false)
-
-			reconnects := atomic.AddUint64(&conn.reconnects, 1)
-			if reconnects > 1 {
-				conn.close()
+			// Prioritize context cancelation even if there are reconnect
+			// requests.
+			if ctx.Err() != nil {
+				return
 			}
 
-			err := conn.connect()
+			if conn.reconnects >= maxReconnects {
+				log.Errorf("Max reconnection attempts reached. Stopping connection.")
+				conn.cancel()
+				// The WaitGroup provided to the consumer by Connect will start
+				// to be decremented as goroutines shutdown.
+				return
+			}
+
+			log.Infof("Attempting to reconnect to %s...", conn.cfg.URL)
+			err := conn.connect(ctx)
 			if err != nil {
-				log.Errorf("connection error: %v", err)
-				conn.queueReconnect()
+				log.Errorf("Reconnect failed: %v", err)
+				conn.reconnects++
+				if conn.reconnects+1 < maxReconnects {
+					conn.queueReconnect()
+				}
 				continue
 			}
+
+			log.Info("Successfully reconnected.")
+			conn.reconnects = 0
 
 			// Synchronize after a reconnection.
 			if conn.cfg.ReconnectSync != nil {
@@ -266,13 +312,15 @@ func (conn *wsConn) keepAlive(ctx context.Context) {
 			}
 
 		case <-ctx.Done():
-			// Terminate the keepAlive process and read process when
-			/// the dex client signals a shutdown.
-			conn.setConnected(false)
-			conn.close()
 			return
 		}
 	}
+}
+
+// reconnect begins reconnection immediately.
+func (conn *wsConn) reconnect() {
+	conn.setConnected(false)
+	conn.reconnectCh <- struct{}{}
 }
 
 // queueReconnect queues a reconnection attempt.
@@ -289,35 +337,43 @@ func (conn *wsConn) NextID() uint64 {
 // Connect connects the client and starts an auto-reconnect loop. Any error
 // encountered during the initial connection will be returned. The reconnect
 // loop will continue to try connecting, even if an error is returned. To
-// shutdown auto-reconnect, use close().
+// shutdown auto-reconnect, use Stop() or cancel the context.
 func (conn *wsConn) Connect(ctx context.Context) (error, *sync.WaitGroup) {
-	var wg sync.WaitGroup
-	wg.Add(1)
+	var ctxInternal context.Context
+	ctxInternal, conn.cancel = context.WithCancel(ctx)
 
-	go conn.keepAlive(ctx)
-
+	conn.wg.Add(1)
 	go func() {
-		<-ctx.Done()
-		conn.close()
-		wg.Done()
+		defer conn.wg.Done()
+		conn.keepAlive(ctxInternal)
 	}()
 
-	return conn.connect(), &wg
+	conn.wg.Add(1)
+	go func() {
+		defer conn.wg.Done()
+		<-ctxInternal.Done()
+		conn.setConnected(false)
+		if conn.ws != nil {
+			log.Info("Sending close 1000 (normal) message.")
+			msg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye")
+			conn.ws.WriteControl(websocket.CloseMessage, msg,
+				time.Now().Add(writeWait))
+			conn.ws.Close()
+		}
+		close(conn.readCh) // signal to receivers that the wsConn is dead
+	}()
+
+	err := conn.connect(ctxInternal)
+	if err != nil {
+		conn.queueReconnect()
+	}
+	return err, &conn.wg
 }
 
-// Close terminates all websocket processes and closes the connection.
-func (conn *wsConn) close() {
-	conn.wsMtx.Lock()
-	defer conn.wsMtx.Unlock()
-
-	if conn.ws == nil {
-		return
-	}
-
-	msg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
-	conn.ws.WriteControl(websocket.CloseMessage, msg,
-		time.Now().Add(writeWait))
-	conn.ws.Close()
+// Stop can be used to close the connection and all of the goroutines stared by
+// Connect. Alternatively, the context passed to Connect may be canceled.
+func (conn *wsConn) Stop() {
+	conn.cancel()
 }
 
 // Send pushes outgoing messages over the websocket connection.
@@ -341,6 +397,10 @@ func (conn *wsConn) Send(msg *msgjson.Message) error {
 // Request sends the message with Send, but keeps a record of the callback
 // function to run when a response is received.
 func (conn *wsConn) Request(msg *msgjson.Message, f func(*msgjson.Message)) error {
+	if !conn.isConnected() {
+		return fmt.Errorf("cannot send on a broken connection")
+	}
+
 	// Log the message sent if it is a request.
 	if msg.Type == msgjson.Request {
 		conn.logReq(msg.ID, f)
@@ -376,15 +436,11 @@ func (conn *wsConn) respHandler(id uint64) *responseHandler {
 	return cb
 }
 
-// MessageSource returns the connection's read source only once. The returned
-// chan will receive requests and notifications from the server, but not
-// responses, which have handlers associated with their request.
+// MessageSource returns the connection's read source. The returned chan will
+// receive requests and notifications from the server, but not responses, which
+// have handlers associated with their request. The same channel is returned on
+// each call, so there must only be one receiver. When the connection is
+// shutdown, the channel will be closed.
 func (conn *wsConn) MessageSource() <-chan *msgjson.Message {
-	var ch <-chan *msgjson.Message
-
-	conn.once.Do(func() {
-		ch = conn.readCh
-	})
-
-	return ch
+	return conn.readCh
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1244,8 +1244,12 @@ out:
 		select {
 		case msg, ok := <-msgs:
 			if !ok {
-				log.Warnf("Connection closed for %s.", dc.acct.url)
-				// TODO: remove from c.conns, and then?
+				log.Debugf("Connection closed for %s.", dc.acct.url)
+				// TODO: This just means that wsConn, which created the
+				// MessageSource channel, was shut down before this loop
+				// returned via ctx.Done. It may be necessary to investigate the
+				// most appropriate normal shutdown sequence (i.e. close all
+				// connections before stopping Core).
 				return
 			}
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1237,12 +1237,18 @@ func (c *Core) handleUnbookOrderMsg(dc *dexConnection, msg *msgjson.Message) err
 // listen monitors the DEX websocket connection for server requests and
 // notifications.
 func (c *Core) listen(dc *dexConnection) {
-	msgs := dc.MessageSource()
 	defer c.wg.Done()
+	msgs := dc.MessageSource()
 out:
 	for {
 		select {
-		case msg := <-msgs:
+		case msg, ok := <-msgs:
+			if !ok {
+				log.Warnf("Connection closed for %s.", dc.acct.url)
+				// TODO: remove from c.conns, and then?
+				return
+			}
+
 			switch msg.Type {
 			case msgjson.Request:
 				switch msg.Route {


### PR DESCRIPTION
`wsConn` reconnect tweaks and logging.

supervise all goroutines, using an internal context and cancellation function.

Remove unused `wsConn.sendCh` field.

Allow `(*wsConn).MessageSource` to return the channel repeatedly, and
document this.  Also close this channel when `wsConn` shuts down to signal
to the consumer that the conn is dead (if they didn't kill it).

Only queue reconnection in keepAlive, not `connect` or `Connect`. Previously the number of reconnects queued would grow exponentially because `connect()` was queueing reconnect on `Dial` failure.