### PR TITLE
dex/ws: Add WriteControl and SetReadDeadline to Connection interface

### DIFF
--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -80,8 +80,8 @@ func TestWsConn(t *testing.T) {
 	var id uint64
 	// server's "/ws" handler
 	handler := func(w http.ResponseWriter, r *http.Request) {
+		id := atomic.AddUint64(&id, 1) // shadow id
 		hCtx, hCancel := context.WithCancel(ctx)
-		atomic.AddUint64(&id, 1)
 
 		c, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
@@ -89,7 +89,6 @@ func TestWsConn(t *testing.T) {
 		}
 
 		c.SetPongHandler(func(string) error {
-			id := atomic.LoadUint64(&id)
 			t.Logf("handler #%d: pong received", id)
 			return nil
 		})
@@ -107,7 +106,6 @@ func TestWsConn(t *testing.T) {
 						return
 					}
 
-					id := atomic.LoadUint64(&id)
 					t.Logf("handler #%d: ping sent", id)
 
 				case msg := <-readPumpCh:

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -129,6 +129,14 @@ func (c *TConn) SetWriteDeadline(_ time.Time) error {
 	return nil
 }
 
+func (c *TConn) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	return nil
+}
+
+func (c *TConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
 func (c *TConn) Close() error {
 	// If the test has a non-nil close channel, signal close.
 	select {

--- a/client/rpcserver/websocket.go
+++ b/client/rpcserver/websocket.go
@@ -56,7 +56,7 @@ func (s *RPCServer) handleWS(w http.ResponseWriter, r *http.Request) {
 	if err == nil && host != "" {
 		ip = host
 	}
-	wsConn, err := ws.NewConnection(w, r, pingPeriod+pongWait)
+	wsConn, err := ws.NewConnection(w, r, pongWait)
 	if err != nil {
 		log.Errorf("ws connection error: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -179,6 +179,14 @@ func (c *TConn) SetWriteDeadline(t time.Time) error {
 	return nil
 }
 
+func (c *TConn) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	return nil
+}
+
+func (c *TConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
 func (c *TConn) WriteMessage(_ int, msg []byte) error {
 	c.msg = msg
 	select {

--- a/client/webserver/websocket.go
+++ b/client/webserver/websocket.go
@@ -56,7 +56,7 @@ func (s *WebServer) handleWS(w http.ResponseWriter, r *http.Request) {
 	if err == nil && host != "" {
 		ip = host
 	}
-	wsConn, err := ws.NewConnection(w, r, pingPeriod+pongWait)
+	wsConn, err := ws.NewConnection(w, r, pongWait)
 	if err != nil {
 		log.Errorf("ws connection error: %v", err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// outBufferSize is the size of the client's buffered channel for outgoing
+// outBufferSize is the size of the WSLink's buffered channel for outgoing
 // messages.
 const outBufferSize = 128
 
@@ -32,24 +32,27 @@ func (e Error) Error() string {
 	return string(e)
 }
 
-// ErrClientDisconnected will be returned if Send or Request is called on a
+// ErrPeerDisconnected will be returned if Send or Request is called on a
 // disconnected link.
-const ErrClientDisconnected = Error("client disconnected")
+const ErrPeerDisconnected = Error("peer disconnected")
 
-// Connection represents a websocket connection to the client. In practice,
+// Connection represents a websocket connection to a remote peer. In practice,
 // it is satisfied by *websocket.Conn. For testing, a stub can be used.
 type Connection interface {
-	WriteControl(messageType int, data []byte, deadline time.Time) error
-	ReadMessage() (int, []byte, error)
-	WriteMessage(int, []byte) error
-	SetWriteDeadline(t time.Time) error
-	SetReadDeadline(t time.Time) error
 	Close() error
+
+	SetReadDeadline(t time.Time) error
+	ReadMessage() (int, []byte, error)
+
+	SetWriteDeadline(t time.Time) error
+	WriteMessage(int, []byte) error
+	WriteControl(messageType int, data []byte, deadline time.Time) error
 }
 
-// wsLink is the local, per-connection representation of a DEX client.
+// WSLink is the local, per-connection representation of a DEX peer (client or
+// server) connection.
 type WSLink struct {
-	// ip is the client's IP address.
+	// ip is the peer's IP address.
 	ip string
 	// conn is the gorilla websocket.Conn, or a stub for testing.
 	conn Connection
@@ -58,23 +61,23 @@ type WSLink struct {
 	// on is used internally to prevent multiple Close calls on the underlying
 	// connections.
 	on bool
-	// Once the client is disconnected, the quit channel will be closed.
+	// After disconnect, the quit channel will be closed.
 	quit chan struct{}
-	// wg is the client's WaitGroup. The client has at least 3 goroutines, one for
-	// read, one for write, and one server goroutine to monitor the client
-	// disconnect. The WaitGroup is used to synchronize cleanup on disconnection.
+	// The WSLink has at least 3 goroutines, one for read, one for write, and
+	// one server goroutine to monitor for peer disconnection. The WaitGroup is
+	// used to synchronize cleanup on disconnection.
 	wg sync.WaitGroup
-	// Messages to the client are routed through the outChan. This ensures
+	// Messages to the peer are routed through the outChan. This ensures
 	// messages are sent in the correct order, and satisfies the thread-safety
 	// requirements of the (*websocket.Conn).WriteMessage.
 	outChan chan []byte
 	// A master message handler.
 	handler func(*msgjson.Message) *msgjson.Error
-	// pingPeriod is how often to ping the client.
+	// pingPeriod is how often to ping the peer.
 	pingPeriod time.Duration
 }
 
-// newWSLink is a constructor for a new WSLink.
+// NewWSLink is a constructor for a new WSLink.
 func NewWSLink(addr string, conn Connection, pingPeriod time.Duration, handler func(*msgjson.Message) *msgjson.Error) *WSLink {
 	return &WSLink{
 		on:         true,
@@ -87,26 +90,29 @@ func NewWSLink(addr string, conn Connection, pingPeriod time.Duration, handler f
 	}
 }
 
-// Send sends the passed Message to the websocket client. If the client's
-// channel is blocking (outBufferSize pending messages), the client is
-// disconnected.
+// Send sends the passed Message to the websocket peer.
 func (c *WSLink) Send(msg *msgjson.Message) error {
 	if c.Off() {
-		return ErrClientDisconnected
+		return ErrPeerDisconnected
 	}
 	b, err := json.Marshal(msg)
 	if err != nil {
 		return err
 	}
+
+	// If outChan is blocking (outBufferSize pending messages), many messages
+	// are being sent and not quickly enough. If the connection is actually
+	// down, c.quit will be closed. TODO: Add a default case with error return
+	// or just block until outHandler receives?
 	select {
 	case c.outChan <- b:
 	case <-c.quit:
-		return ErrClientDisconnected
+		return ErrPeerDisconnected
 	}
 	return nil
 }
 
-// SendError sends the msgjson.Error to the client.
+// SendError sends the msgjson.Error to the peer.
 func (c *WSLink) SendError(id uint64, rpcErr *msgjson.Error) {
 	msg, err := msgjson.NewResponse(id, nil, rpcErr)
 	if err != nil {
@@ -114,21 +120,23 @@ func (c *WSLink) SendError(id uint64, rpcErr *msgjson.Error) {
 	}
 	err = c.Send(msg)
 	if err != nil {
-		log.Debug("SendError: failed to send message to %s: %v", c.ip, err)
+		log.Debug("SendError: failed to send message to peer %s: %v", c.ip, err)
 	}
 }
 
 // Start begins processing input and output messages.
 func (c *WSLink) Start() {
 	// Set the initial read deadline now that the ping ticker is about to be
-	// started. The pong handler will set subsequent read deadlines.
+	// started. The pong handler will set subsequent read deadlines. 2x ping
+	// period is a very generous initial pong wait; the readWait provided to
+	// NewConnection could be stored and used here (once) instead.
 	err := c.conn.SetReadDeadline(time.Now().Add(c.pingPeriod * 2))
 	if err != nil {
 		log.Errorf("Failed to set initial read deadline for %v: %v", c.ip, err)
 		return
 	}
 
-	log.Tracef("Starting websocket client %s", c.ip)
+	log.Tracef("Starting websocket messaging with peer %s", c.ip)
 	// Start processing input and output.
 	c.wg.Add(2)
 	go c.inHandler()
@@ -144,14 +152,14 @@ func (c *WSLink) Disconnect() {
 		log.Debugf("Disconnect attempted on stopped WSLink.")
 		return
 	}
-	log.Tracef("Closing connection with client %v", c.ip)
+	log.Tracef("Closing connection with peer %v", c.ip)
 	c.on = false
 	c.conn.Close()
 	close(c.quit)
 }
 
-// WaitForShutdown blocks until the websocket client goroutines are stopped
-// and the connection is closed.
+// WaitForShutdown blocks until the WSLink goroutines are stopped and the
+// connection is closed.
 func (c *WSLink) WaitForShutdown() {
 	c.wg.Wait()
 }
@@ -174,7 +182,7 @@ out:
 			// Log the error if it's not due to disconnecting.
 			if !websocket.IsCloseError(err, websocket.CloseGoingAway,
 				websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
-				log.Errorf("Websocket receive error from %s: %v", c.ip, err)
+				log.Errorf("Websocket receive error from peer %s: %v", c.ip, err)
 			}
 			break out
 		}
@@ -244,17 +252,17 @@ cleanup:
 		}
 	}
 	c.wg.Done()
-	log.Tracef("Websocket client output handler done for %s", c.ip)
+	log.Tracef("Websocket output handler done for peer %s", c.ip)
 }
 
-// Off will return true if the client has disconnected.
+// Off will return true if the link has disconnected.
 func (c *WSLink) Off() bool {
 	c.quitMtx.RLock()
 	defer c.quitMtx.RUnlock()
 	return !c.on
 }
 
-// IP is the address passed to the constructor.
+// IP is the peer address passed to the constructor.
 func (c *WSLink) IP() string {
 	return c.ip
 }

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -320,7 +320,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 	if acctInfo == nil {
 		return &msgjson.Error{
 			Code:    msgjson.AuthenticationError,
-			Message: "not account info found for account ID" + connect.AccountID.String(),
+			Message: "no account info found for account ID" + connect.AccountID.String(),
 		}
 	}
 	if !paid {
@@ -354,6 +354,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 	// Send the connect response, which includes a list of active matches.
 	matches, err := auth.storage.ActiveMatches(user)
 	if err != nil {
+		log.Errorf("ActiveMatches(%x): %v", user, err)
 		return &msgjson.Error{
 			Code:    msgjson.RPCInternalError,
 			Message: "DB error",

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -111,6 +111,14 @@ func (conn *wsConnStub) SetWriteDeadline(t time.Time) error {
 	return nil // TODO implement and test write timeouts
 }
 
+func (conn *wsConnStub) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (conn *wsConnStub) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	return nil
+}
+
 func (conn *wsConnStub) Close() error {
 	select {
 	case <-conn.quit:

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -395,9 +395,9 @@ func TestClientRequests(t *testing.T) {
 	if !server.isQuarantined(stubAddr) {
 		t.Fatalf("server has not marked client as quarantined")
 	}
-	// A call to Send should return ErrClientDisconnected
+	// A call to Send should return ErrPeerDisconnected
 	lockedExe(func() {
-		if !errors.Is(client.Send(nil), ws.ErrClientDisconnected) {
+		if !errors.Is(client.Send(nil), ws.ErrPeerDisconnected) {
 			t.Fatalf("incorrect error for disconnected client")
 		}
 	})

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -213,7 +213,7 @@ func (s *Server) Run(ctx context.Context) {
 			http.Error(w, "server at maximum capacity", http.StatusServiceUnavailable)
 			return
 		}
-		wsConn, err := ws.NewConnection(w, r, pingPeriod+pongWait)
+		wsConn, err := ws.NewConnection(w, r, pongWait)
 		if err != nil {
 			log.Errorf("ws connection error: %v", err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -799,7 +799,7 @@ func (m *Market) collectPreimages(orders []order.Order) (cSum []byte, ordersReve
 			m.handlePreimageResp(msg, reqData)
 		}, piTimeout, miss)
 		if err != nil {
-			if errors.Is(err, ws.ErrClientDisconnected) {
+			if errors.Is(err, ws.ErrPeerDisconnected) {
 				misses = append(misses, ord)
 				log.Debug("Preimage request failed: client gone.")
 			} else {


### PR DESCRIPTION
This adds `WriteControl` and `SetReadDeadline` to the `ws.Connection` interface.

Use `WriteControl` in `(*WSLink).outHandler` to send a ping.

Fix some some typos, and add extra logging.

Set initial read deadline in `(*WSLink).Start`, let pong handler set subsequent deadlines.

dex/ws: Use "peer" terminology instead of "client".  Rename `ErrClientDisconnected` -> `ErrPeerDisconnected`.  Alternatively, we could clarify that `WSLink` is only intended for use by a server, and `client/comms.wsConn` is for client connections to the server.