### PR TITLE
auth,multi: cancellation ratio

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -281,7 +281,7 @@ func (conn *wsConn) keepAlive(ctx context.Context) {
 	for {
 		select {
 		case <-conn.reconnectCh:
-			// Prioritize context cancelation even if there are reconnect
+			// Prioritize context cancellation even if there are reconnect
 			// requests.
 			if ctx.Err() != nil {
 				return

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1105,12 +1105,7 @@ func (c *Core) Trade(pw string, form *TradeForm) (*Order, error) {
 		ClientTime: time.Now(),
 		Commit:     preImg.Commit(),
 	}
-	trade := &order.Trade{
-		Coins:    coinIDs,
-		Sell:     form.Sell,
-		Quantity: form.Qty,
-		Address:  addr,
-	}
+
 	var ord order.Order
 	if form.IsLimit {
 		prefix.OrderType = order.LimitOrderType
@@ -1119,15 +1114,25 @@ func (c *Core) Trade(pw string, form *TradeForm) (*Order, error) {
 			tif = order.ImmediateTiF
 		}
 		ord = &order.LimitOrder{
-			P:     *prefix,
-			T:     *trade,
+			P: *prefix,
+			T: order.Trade{
+				Coins:    coinIDs,
+				Sell:     form.Sell,
+				Quantity: form.Qty,
+				Address:  addr,
+			},
 			Rate:  form.Rate,
 			Force: tif,
 		}
 	} else {
 		ord = &order.MarketOrder{
 			P: *prefix,
-			T: *trade,
+			T: order.Trade{
+				Coins:    coinIDs,
+				Sell:     form.Sell,
+				Quantity: form.Qty,
+				Address:  addr,
+			},
 		}
 	}
 	err = order.ValidateOrder(ord, order.OrderStatusEpoch, wallets.baseAsset.LotSize)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1915,7 +1915,7 @@ func TestTradeTracking(t *testing.T) {
 	if tracker.cancel.matches.maker == nil {
 		t.Fatalf("cancelMatches.maker not set")
 	}
-	if tracker.Trade().Filled != qty {
+	if tracker.Trade().Filled() != qty {
 		t.Fatalf("fill not set")
 	}
 	if tracker.cancel.matches.taker == nil {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -238,7 +238,9 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		}
 	}
 	t.matchMtx.RUnlock()
-	t.Trade().AddFill(filled)
+	// The filled amount includes all of the trackedTrade's matches, so the
+	// filled amount must be set, not just increased.
+	t.Trade().SetFill(filled)
 
 	return t.tick()
 }

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -119,7 +119,7 @@ func (t *trackedTrade) coreOrder() (*Order, *Order) {
 		Rate:        t.rate(),
 		Qty:         trade.Quantity,
 		Sell:        trade.Sell,
-		Filled:      trade.Filled,
+		Filled:      trade.Filled(),
 		Cancelling:  t.cancel != nil,
 		TimeInForce: tif,
 	}
@@ -238,7 +238,7 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		}
 	}
 	t.matchMtx.RUnlock()
-	t.Trade().Filled = filled
+	t.Trade().AddFill(filled)
 
 	return t.tick()
 }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -46,6 +46,7 @@ const (
 	InvalidPreimage                   // 30
 	PreimageCommitmentMismatch        // 31
 	UnknownMessageType                // 32
+	AccountClosedError                // 33
 )
 
 // Routes are destinations for a "payload" of data. The type of data being
@@ -782,7 +783,7 @@ type NotifyFeeResult struct {
 
 // ConfigResult is the successful result from the 'config' route.
 type ConfigResult struct {
-	CancelMax        float32  `json:"cancelmax"`
+	CancelMax        float64  `json:"cancelmax"`
 	BroadcastTimeout uint64   `json:"btimeout"`
 	RegFeeConfirms   uint16   `json:"regfeeconfirms"`
 	Assets           []Asset  `json:"assets"`

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -426,6 +426,13 @@ func (t *Trade) AddFill(amt uint64) {
 	t.fillAmtMtx.Unlock()
 }
 
+// SetFill sets the filled amount.
+func (t *Trade) SetFill(amt uint64) {
+	t.fillAmtMtx.Lock()
+	t.FillAmt = amt
+	t.fillAmtMtx.Unlock()
+}
+
 // SwapAddress returns the order's payment address.
 func (t *Trade) SwapAddress() string {
 	return t.Address

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"sync"
 	"time"
 
 	"decred.org/dcrdex/dex/encode"
@@ -242,6 +243,30 @@ func (pi *Preimage) Commit() Commitment {
 	return blake256.Sum256(pi[:])
 }
 
+// Value implements the sql/driver.Valuer interface.
+func (pi Preimage) Value() (driver.Value, error) {
+	return pi[:], nil // []byte
+}
+
+// Scan implements the sql.Scanner interface.
+func (pi *Preimage) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		copy(pi[:], src)
+		return nil
+	case nil: // NULL in the table
+		*pi = Preimage{}
+		return nil
+	}
+
+	return fmt.Errorf("cannot convert %T to Preimage", src)
+}
+
+// IsZero checks if the Preimage is the zero Preimage.
+func (pi *Preimage) IsZero() bool {
+	return *pi == Preimage{}
+}
+
 // Prefix is the order prefix containing data fields common to all orders.
 type Prefix struct {
 	AccountID  account.AccountID
@@ -353,8 +378,9 @@ type Trade struct {
 	Quantity uint64
 	Address  string
 
-	// Filled is not part of the order's serialization.
-	Filled uint64
+	// FillAmt is not part of the order's serialization.
+	fillAmtMtx sync.RWMutex
+	FillAmt    uint64 // use Filled and AddFill methods for thread-safe access
 }
 
 // T is an alias for Trade. Embedding with the alias allows us to define a
@@ -368,7 +394,23 @@ func (t *Trade) Trade() *Trade {
 
 // Remaining returns the remaining order amount.
 func (t *Trade) Remaining() uint64 {
-	return t.Quantity - t.Filled
+	t.fillAmtMtx.RLock()
+	defer t.fillAmtMtx.RUnlock()
+	return t.Quantity - t.FillAmt
+}
+
+// Filled returns the filled amount.
+func (t *Trade) Filled() uint64 {
+	t.fillAmtMtx.RLock()
+	defer t.fillAmtMtx.RUnlock()
+	return t.FillAmt
+}
+
+// AddFill increases the filled amount.
+func (t *Trade) AddFill(amt uint64) {
+	t.fillAmtMtx.Lock()
+	t.FillAmt += amt
+	t.fillAmtMtx.Unlock()
 }
 
 // SwapAddress returns the order's payment address.
@@ -615,7 +657,7 @@ func ValidateOrder(ord Order, status OrderStatus, lotSize uint64) error {
 		// Market orders OK statuses: epoch and executed (NOT booked or
 		// canceled).
 		switch status {
-		case OrderStatusEpoch, OrderStatusExecuted:
+		case OrderStatusEpoch, OrderStatusExecuted, OrderStatusRevoked:
 		default:
 			return fmt.Errorf("invalid market order status %d -> %s", status, status)
 		}
@@ -632,10 +674,11 @@ func ValidateOrder(ord Order, status OrderStatus, lotSize uint64) error {
 		}
 
 	case *CancelOrder:
-		// Cancel order OK statuses: epoch, and executed (NOT booked or
-		// canceled).
+		// Cancel order OK statuses: epoch, executed (NOT booked or canceled),
+		// and revoked. Revoked status indicates the cancel order is
+		// server-generated and corresponds to a revoked trade order.
 		switch status {
-		case OrderStatusEpoch, OrderStatusExecuted: // orderStatusFailed if we decide to export that
+		case OrderStatusEpoch, OrderStatusExecuted, OrderStatusRevoked: // orderStatusFailed if we decide to export that
 		default:
 			return fmt.Errorf("invalid cancel order status %d -> %s", status, status)
 		}

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -383,6 +383,19 @@ type Trade struct {
 	FillAmt    uint64 // use Filled and AddFill methods for thread-safe access
 }
 
+// Copy makes a shallow copy of a Trade. This is useful when attempting to
+// assign a newly-created trade to an order's field without a linter warning
+// about copying a mutex (e.g. MarketOrder{T: *aNewTrade.Copy()}).
+func (t *Trade) Copy() *Trade {
+	return &Trade{
+		Coins:    t.Coins, // shallow
+		Sell:     t.Sell,
+		Quantity: t.Quantity,
+		Address:  t.Address,
+		FillAmt:  t.FillAmt,
+	}
+}
+
 // T is an alias for Trade. Embedding with the alias allows us to define a
 // method on the interface called Trade that returns the *Trade.
 type T = Trade

--- a/dex/order/order_test.go
+++ b/dex/order/order_test.go
@@ -476,9 +476,9 @@ func TestMarketOrder_ID(t *testing.T) {
 				},
 			}
 			remaining := o.Remaining()
-			if remaining != o.Quantity-o.Filled {
+			if remaining != o.Quantity-o.FillAmt {
 				t.Errorf("MarketOrder.Remaining incorrect, got %d, expected %d",
-					remaining, o.Quantity-o.Filled)
+					remaining, o.Quantity-o.FillAmt)
 			}
 			if got := o.ID(); got != tt.want {
 				t.Errorf("MarketOrder.ID() = %v, want %v", got, tt.want)
@@ -538,9 +538,9 @@ func TestLimitOrder_ID(t *testing.T) {
 				Force: tt.fields.Force,
 			}
 			remaining := o.Remaining()
-			if remaining != o.Quantity-o.Filled {
+			if remaining != o.Quantity-o.FillAmt {
 				t.Errorf("LimitOrder.Remaining incorrect, got %d, expected %d",
-					remaining, o.Quantity-o.Filled)
+					remaining, o.Quantity-o.FillAmt)
 			}
 			if got := o.ID(); got != tt.want {
 				t.Errorf("LimitOrder.ID() = %v, want %v", got, tt.want)

--- a/dex/order/order_test.go
+++ b/dex/order/order_test.go
@@ -239,38 +239,31 @@ func TestMarketOrder_Serialize_serializeSize(t *testing.T) {
 }
 
 func TestLimitOrder_Serialize_serializeSize(t *testing.T) {
-	type fields struct {
-		MarketOrder MarketOrder
-		Rate        uint64
-		Force       TimeInForce
-	}
 	tests := []struct {
-		name   string
-		fields fields
-		want   []byte
+		name       string
+		LimitOrder *LimitOrder
+		want       []byte
 	}{
 		{
 			"ok acct0",
-			fields{
-				MarketOrder: MarketOrder{
-					P: Prefix{
-						AccountID:  acct0,
-						BaseAsset:  AssetDCR,
-						QuoteAsset: AssetBTC,
-						OrderType:  LimitOrderType,
-						ClientTime: time.Unix(1566497653, 0),
-						ServerTime: time.Unix(1566497656, 0),
-						Commit:     commit0,
+			&LimitOrder{
+				P: Prefix{
+					AccountID:  acct0,
+					BaseAsset:  AssetDCR,
+					QuoteAsset: AssetBTC,
+					OrderType:  LimitOrderType,
+					ClientTime: time.Unix(1566497653, 0),
+					ServerTime: time.Unix(1566497656, 0),
+					Commit:     commit0,
+				},
+				T: Trade{
+					Coins: []CoinID{
+						utxoCoinID("d186e4b6625c9c94797cc494f535fc150177e0619e2303887e0a677f29ef1bab", 0),
+						utxoCoinID("11d9580e19ad65a875a5bc558d600e96b2916062db9e8b65cbc2bb905207c1ad", 16),
 					},
-					T: Trade{
-						Coins: []CoinID{
-							utxoCoinID("d186e4b6625c9c94797cc494f535fc150177e0619e2303887e0a677f29ef1bab", 0),
-							utxoCoinID("11d9580e19ad65a875a5bc558d600e96b2916062db9e8b65cbc2bb905207c1ad", 16),
-						},
-						Sell:     false,
-						Quantity: 132413241324,
-						Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
-					},
+					Sell:     false,
+					Quantity: 132413241324,
+					Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
 				},
 				Rate:  13241324,
 				Force: StandingTiF,
@@ -330,12 +323,7 @@ func TestLimitOrder_Serialize_serializeSize(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			o := &LimitOrder{
-				P:     tt.fields.MarketOrder.P,
-				T:     tt.fields.MarketOrder.T,
-				Rate:  tt.fields.Rate,
-				Force: tt.fields.Force,
-			}
+			o := tt.LimitOrder
 			got := o.Serialize()
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LimitOrder.Serialize() = %#v, want %#v", got, tt.want)
@@ -492,36 +480,29 @@ func TestLimitOrder_ID(t *testing.T) {
 	var orderID OrderID
 	copy(orderID[:], orderID0)
 
-	type fields struct {
-		MarketOrder MarketOrder
-		Rate        uint64
-		Force       TimeInForce
-	}
 	tests := []struct {
-		name   string
-		fields fields
-		want   OrderID
+		name       string
+		LimitOrder *LimitOrder
+		want       OrderID
 	}{
 		{
 			"ok",
-			fields{
-				MarketOrder: MarketOrder{
-					P: Prefix{
-						AccountID:  acct0,
-						BaseAsset:  AssetDCR,
-						QuoteAsset: AssetBTC,
-						OrderType:  LimitOrderType,
-						ClientTime: time.Unix(1566497653, 0),
-						ServerTime: time.Unix(1566497656, 0),
+			&LimitOrder{
+				P: Prefix{
+					AccountID:  acct0,
+					BaseAsset:  AssetDCR,
+					QuoteAsset: AssetBTC,
+					OrderType:  LimitOrderType,
+					ClientTime: time.Unix(1566497653, 0),
+					ServerTime: time.Unix(1566497656, 0),
+				},
+				T: Trade{
+					Coins: []CoinID{
+						utxoCoinID("01516d9c7ffbe260b811dc04462cedd3f8969ce3a3ffe6231ae870775a92e9b0", 1),
 					},
-					T: Trade{
-						Coins: []CoinID{
-							utxoCoinID("01516d9c7ffbe260b811dc04462cedd3f8969ce3a3ffe6231ae870775a92e9b0", 1),
-						},
-						Sell:     false,
-						Quantity: 132413241324,
-						Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
-					},
+					Sell:     false,
+					Quantity: 132413241324,
+					Address:  "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui",
 				},
 				Rate:  13241324,
 				Force: StandingTiF,
@@ -531,12 +512,7 @@ func TestLimitOrder_ID(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			o := &LimitOrder{
-				T:     tt.fields.MarketOrder.T,
-				P:     tt.fields.MarketOrder.P,
-				Rate:  tt.fields.Rate,
-				Force: tt.fields.Force,
-			}
+			o := tt.LimitOrder
 			remaining := o.Remaining()
 			if remaining != o.Quantity-o.FillAmt {
 				t.Errorf("LimitOrder.Remaining incorrect, got %d, expected %d",

--- a/dex/order/serialize.go
+++ b/dex/order/serialize.go
@@ -286,7 +286,7 @@ func decodeOrder_v0(pushes [][]byte) (Order, error) {
 		}
 		return &LimitOrder{
 			P:     *prefix,
-			T:     *trade,
+			T:     *trade.Copy(),
 			Rate:  intCoder.Uint64(rateB),
 			Force: tif,
 		}, nil
@@ -306,7 +306,7 @@ func decodeOrder_v0(pushes [][]byte) (Order, error) {
 		}
 		return &MarketOrder{
 			P: *prefix,
-			T: *trade,
+			T: *trade.Copy(),
 		}, nil
 
 	case bEqual(oType, orderTypeCancel):

--- a/dex/order/serialize.go
+++ b/dex/order/serialize.go
@@ -92,7 +92,7 @@ func EncodeTrade(ord *Trade) []byte {
 		AddData(sell).
 		AddData(uint64B(ord.Quantity)).
 		AddData([]byte(ord.Address)).
-		AddData(uint64B(ord.Filled))
+		AddData(uint64B(ord.Filled()))
 }
 
 // DecodeTrade decodes the versioned-blob market order, but does not populate
@@ -133,7 +133,7 @@ func decodeTrade_v0(pushes [][]byte) (mrkt *Trade, err error) {
 		Sell:     sell,
 		Quantity: intCoder.Uint64(qtyB),
 		Address:  string(addrB),
-		Filled:   intCoder.Uint64(filledB),
+		FillAmt:  intCoder.Uint64(filledB),
 	}, nil
 }
 

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -248,9 +248,12 @@ func (btc *Backend) FundingCoin(coinID []byte, redeemScript []byte) (asset.Fundi
 }
 
 // ValidateCoinID attempts to decode the coinID.
-func (btc *Backend) ValidateCoinID(coinID []byte) error {
-	_, _, err := decodeCoinID(coinID)
-	return err
+func (btc *Backend) ValidateCoinID(coinID []byte) (string, error) {
+	txid, vout, err := decodeCoinID(coinID)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%v:%d", txid, vout), err
 }
 
 // ValidateContract ensures that the swap contract is constructed properly, and

--- a/server/asset/btc/utxo.go
+++ b/server/asset/btc/utxo.go
@@ -111,6 +111,12 @@ type Input struct {
 
 var _ asset.Coin = (*Input)(nil)
 
+// String creates a human-readable representation of a Bitcoin transaction input
+// in the format "{txid = [transaction hash], vin = [input index]}".
+func (input *Input) String() string {
+	return fmt.Sprintf("{txid = %s, vin = %d}", input.TxID(), input.vin)
+}
+
 // Confirmations returns the number of confirmations on this input's
 // transaction.
 func (input *Input) Confirmations() (int64, error) {
@@ -165,6 +171,17 @@ type UTXO struct {
 	value uint64
 	// address is populated for swap contract outputs
 	address string
+}
+
+// Check that UTXO satisfies the asset.Contract interface
+var _ asset.Coin = (*UTXO)(nil)
+var _ asset.FundingCoin = (*UTXO)(nil)
+var _ asset.Contract = (*UTXO)(nil)
+
+// String creates a human-readable representation of a Bitcoin transaction output
+// in the format "{txid = [transaction hash], vout = [output index]}".
+func (utxo *UTXO) String() string {
+	return fmt.Sprintf("{txid = %s, vout = %d}", utxo.TxID(), utxo.vout)
 }
 
 // Confirmations returns the number of confirmations for a UTXO's transaction.

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -32,8 +32,9 @@ type Backend interface {
 	InitTxSize() uint32
 	// CheckAddress checks that the given address is parseable.
 	CheckAddress(string) bool
-	// ValidateCoinID checks the coinID to ensure it can be decoded.
-	ValidateCoinID(coinID []byte) error
+	// ValidateCoinID checks the coinID to ensure it can be decoded, returning a
+	// human-readable string if it is valid.
+	ValidateCoinID(coinID []byte) (string, error)
 	// ValidateContract ensures that the swap contract is constructed properly
 	// for the asset.
 	ValidateContract(contract []byte) error

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -53,6 +53,8 @@ type Coin interface {
 	ID() []byte
 	// TxID is a transaction identifier for the coin.
 	TxID() string
+	// String is a human readable representation of the Coin.
+	String() string
 }
 
 // FundingCoin is some unspent value on the blockchain.

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -210,9 +210,12 @@ func (dcr *Backend) FundingCoin(coinID []byte, redeemScript []byte) (asset.Fundi
 }
 
 // ValidateCoinID attempts to decode the coinID.
-func (dcr *Backend) ValidateCoinID(coinID []byte) error {
-	_, _, err := decodeCoinID(coinID)
-	return err
+func (dcr *Backend) ValidateCoinID(coinID []byte) (string, error) {
+	txid, vout, err := decodeCoinID(coinID)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%v:%d", txid, vout), err
 }
 
 // ValidateContract ensures that the swap contract is constructed properly, and

--- a/server/asset/dcr/utxo.go
+++ b/server/asset/dcr/utxo.go
@@ -121,6 +121,12 @@ type Input struct {
 
 var _ asset.Coin = (*Input)(nil)
 
+// String creates a human-readable representation of a Decred transaction input
+// in the format "{txid = [transaction hash], vin = [input index]}".
+func (input *Input) String() string {
+	return fmt.Sprintf("{txid = %s, vin = %d}", input.TxID(), input.vin)
+}
+
 // Confirmations returns the number of confirmations on this input's
 // transaction.
 func (input *Input) Confirmations() (int64, error) {
@@ -180,6 +186,13 @@ type UTXO struct {
 // Check that UTXO satisfies the asset.Contract interface
 var _ asset.Coin = (*UTXO)(nil)
 var _ asset.FundingCoin = (*UTXO)(nil)
+var _ asset.Contract = (*UTXO)(nil)
+
+// String creates a human-readable representation of a Decred transaction output
+// in the format "{txid = [transaction hash], vout = [output index]}".
+func (utxo *UTXO) String() string {
+	return fmt.Sprintf("{txid = %s, vout = %d}", utxo.TxID(), utxo.vout)
+}
 
 // Confirmations is an asset.Backend method that returns the number of
 // confirmations for a UTXO. Because it is possible for a UTXO that was once

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -1106,7 +1106,6 @@ func TestAuthManager_RecordCancel_RecordCompletedOrder(t *testing.T) {
 		t.Errorf("got %d cancels, expected %d", cancels, 0)
 	}
 
-	fmt.Println(len(client.recentOrders.orders))
 	client.mtx.Lock()
 	ord = client.recentOrders.orders[1]
 	client.mtx.Unlock()

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -55,6 +55,12 @@ func (s *TStorage) ActiveMatches(account.AccountID) ([]*order.UserMatch, error) 
 func (s *TStorage) CreateAccount(*account.Account) (string, error)   { return s.acctAddr, s.acctErr }
 func (s *TStorage) AccountRegAddr(account.AccountID) (string, error) { return s.regAddr, s.regErr }
 func (s *TStorage) PayAccount(account.AccountID, []byte) error       { return s.payErr }
+func (s *TStorage) CompletedUserOrders(aid account.AccountID, N int) (oids []order.OrderID, compTimes []int64, err error) {
+	return nil, nil, nil
+}
+func (s *TStorage) ExecutedCancelsForUser(aid account.AccountID, N int) (oids, targets []order.OrderID, execTimes []int64, err error) {
+	return nil, nil, nil, nil
+}
 
 // TSigner satisfies the Signer interface
 type TSigner struct {
@@ -277,6 +283,7 @@ func TestMain(m *testing.M) {
 			RegistrationFee: tRegFee,
 			FeeConfs:        tCheckFeeConfs,
 			FeeChecker:      tCheckFee,
+			CancelThreshold: 0.2,
 		})
 		go authMgr.Run(ctx)
 		rig = &testRig{
@@ -1063,7 +1070,7 @@ func TestAuthManager_RecordCancel_RecordCompletedOrder(t *testing.T) {
 		t.Errorf("got %d cancels, expected %d", cancels, 0)
 	}
 
-	checkOrd := func(ord *ord, oid order.OrderID, cancel bool, timestamp int64) {
+	checkOrd := func(ord *oidStamped, oid order.OrderID, cancel bool, timestamp int64) {
 		if ord.OrderID != oid {
 			t.Errorf("completed order id mismatch. got %v, expected %v",
 				ord.OrderID, oid)

--- a/server/auth/cancel.go
+++ b/server/auth/cancel.go
@@ -103,20 +103,12 @@ func (lo *latestOrders) add(o *oidStamped) {
 		lo.orders = append(lo.orders[:i], append([]*oidStamped{o}, lo.orders[i:]...)...)
 	}
 
-	// if !sort.IsSorted(ordsByTimeThenID(lo.orders)) {
-	// 	panic("it's not sorted")
-	// }
-
 	// Pop one order if the slice was at capacity prior to pushing the new one.
 	if len(lo.orders) > int(lo.cap) {
 		// pop front, the oldest order
 		lo.orders[0] = nil // avoid memory leak
 		lo.orders = lo.orders[1:]
 	}
-
-	// if len(lo.orders) > int(lo.cap) {
-	// 	panic("still too long")
-	// }
 }
 
 func (lo *latestOrders) counts() (total, cancels int) {

--- a/server/auth/cancel.go
+++ b/server/auth/cancel.go
@@ -1,0 +1,129 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package auth
+
+import (
+	"bytes"
+	"sort"
+	"sync"
+
+	"decred.org/dcrdex/dex/order"
+)
+
+// ord is a time-stamped order ID with a flag indicating if it is a cancel.
+type ord struct {
+	order.OrderID
+	time   int64
+	target *order.OrderID
+}
+
+// ordsByTimeThenID is used to sort an ord slice in ascending order by time and
+// then order ID. This puts the oldest order at the front and latest at the back
+// of the slice.
+type ordsByTimeThenID []*ord
+
+func (o ordsByTimeThenID) Len() int {
+	return len(o)
+}
+
+func (o ordsByTimeThenID) Swap(i, j int) {
+	o[j], o[i] = o[i], o[j]
+}
+
+func (o ordsByTimeThenID) Less(i, j int) bool {
+	return less(o[i], o[j])
+}
+
+func less(oi, oj *ord) bool {
+	if oi.time == oj.time {
+		cmp := bytes.Compare(oi.OrderID[:], oj.OrderID[:])
+		if cmp == 0 {
+			panic("slice contains the more than one instance of a given order")
+		}
+		return cmp < 0 // ascending (smaller order ID first)
+	}
+	return oi.time < oj.time // ascending (newest last in slice)
+}
+
+// latestOrders manages a list of the latest orders for a user. Its purpose is
+// to track cancelation frequency.
+type latestOrders struct {
+	mtx    sync.Mutex
+	cap    int16
+	orders []*ord
+}
+
+func newLatestOrders(cap int16) *latestOrders {
+	return &latestOrders{
+		cap:    cap,
+		orders: make([]*ord, 0, cap+1), // cap+1 since an old order is always popped after a new one is pushed
+	}
+}
+
+/*func (lo *latestOrders) addSimple(o *ord) {
+	lo.mtx.Lock()
+	defer lo.mtx.Unlock()
+
+	// push back, where the latest order goes
+	lo.orders = append(lo.orders, o)
+
+	// Should be few if any swaps. This is only to deal with the possibility of
+	// adding an order that is not the latest, and equal time stamps.
+	sort.Sort(ordsByTimeThenID(lo.orders))
+
+	// Pop one order if the slice was at capacity prior to pushing the new one.
+	for len(lo.orders) > int(lo.cap) {
+		// pop front, the oldest order
+		lo.orders[0] = nil // avoid memory leak
+		lo.orders = lo.orders[1:]
+	}
+}*/
+
+func (lo *latestOrders) add(o *ord) {
+	lo.mtx.Lock()
+	defer lo.mtx.Unlock()
+
+	// Use sort.Search and insert it as the right spot.
+	n := len(lo.orders)
+	i := sort.Search(n, func(i int) bool {
+		return less(lo.orders[n-1-i], o)
+	})
+	if i == int(lo.cap) /* i == n && n == int(lo.cap) */ {
+		// The new one is the oldest/smallest, but already at capacity.
+		return
+	} else {
+		// Insert at proper location.
+		i = n - i // i-1 is first location that stays
+		lo.orders = append(lo.orders[:i], append([]*ord{o}, lo.orders[i:]...)...)
+	}
+
+	// if !sort.IsSorted(ordsByTimeThenID(lo.orders)) {
+	// 	panic("it's not sorted")
+	// }
+
+	// Pop one order if the slice was at capacity prior to pushing the new one.
+	if len(lo.orders) > int(lo.cap) {
+		// pop front, the oldest order
+		lo.orders[0] = nil // avoid memory leak
+		lo.orders = lo.orders[1:]
+	}
+
+	// if len(lo.orders) > int(lo.cap) {
+	// 	panic("still too long")
+	// }
+}
+
+func (lo *latestOrders) counts() (total, cancels int) {
+	lo.mtx.Lock()
+	defer lo.mtx.Unlock()
+
+	total = len(lo.orders)
+	for _, o := range lo.orders {
+		if o.target != nil {
+			cancels++
+		}
+	}
+
+	return
+}

--- a/server/auth/cancel_test.go
+++ b/server/auth/cancel_test.go
@@ -1,0 +1,243 @@
+package auth
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+
+	"decred.org/dcrdex/dex/order"
+)
+
+func randomOrderID() (oid order.OrderID) {
+	rand.Read(oid[:])
+	return
+}
+
+func Test_latestOrders(t *testing.T) {
+	cap := int16(25)
+	ordList := newLatestOrders(cap)
+
+	maybeCancel := func() *order.OrderID {
+		if rand.Intn(6) > 4 {
+			oid := randomOrderID()
+			return &oid
+		}
+		return nil
+	}
+
+	checkSort := func() {
+		if !sort.IsSorted(ordsByTimeThenID(ordList.orders)) {
+			t.Fatal("list wasn't sorted")
+		}
+		if len(ordList.orders) > int(ordList.cap) {
+			t.Fatalf("list is above capacity somehow")
+		}
+	}
+
+	// empty list
+	total, cancels := ordList.counts()
+	if total != 0 {
+		t.Errorf("expected 0 orders, got %d", total)
+	}
+	if cancels != 0 {
+		t.Errorf("expected 0 cancels, got %d", total)
+	}
+
+	// add one cancel
+	ts := int64(1234)
+	coid := randomOrderID()
+	ordList.add(&ord{order.OrderID{0x1}, ts, &coid})
+	checkSort()
+	total, cancels = ordList.counts()
+	if total != 1 {
+		t.Errorf("expected 1 orders, got %d", total)
+	}
+	if cancels != 1 {
+		t.Errorf("expected 1 cancels, got %d", total)
+	}
+
+	// add one non-cancel
+	ts++
+	ordList.add(&ord{order.OrderID{0x2}, ts, nil})
+	checkSort()
+	total, cancels = ordList.counts()
+	if total != 2 {
+		t.Errorf("expected 2 orders, got %d", total)
+	}
+	if cancels != 1 {
+		t.Errorf("expected 1 cancels, got %d", total)
+	}
+
+	// add one that is the smallest
+	ordList.add(&ord{order.OrderID{0x3}, ts - 10, nil})
+	checkSort()
+	total, cancels = ordList.counts()
+	if total != 3 {
+		t.Errorf("expected 3 orders, got %d", total)
+	}
+	if cancels != 1 {
+		t.Errorf("expected 1 cancels, got %d", total)
+	}
+
+	rand.Seed(1324)
+
+	for i := total; i < int(cap); i++ {
+		ts++
+		ordList.add(&ord{
+			OrderID: randomOrderID(),
+			time:    ts,
+			target:  maybeCancel(),
+		})
+		checkSort()
+	}
+
+	total, _ = ordList.counts()
+	if total != int(cap) {
+		t.Errorf("expected %d orders, got %d", int(cap), total)
+	}
+	//t.Logf("got %d cancels", cancels)
+
+	// Now that the list is at capacity, add another to test pop of the oldest order.
+	expectedOldest := ordList.orders[1] // the second oldest order
+	ts += 2                             // still in order, leave space for an out of order add
+	ordList.add(&ord{
+		OrderID: order.OrderID{0x4},
+		time:    ts,
+		target:  maybeCancel(),
+	})
+	checkSort()
+
+	// should still be at capacity
+	total, _ = ordList.counts()
+	if total != int(cap) {
+		t.Errorf("expected %d orders, got %d", int(cap), total)
+	}
+
+	// verify the oldest order is the previously second oldest
+	if expectedOldest != ordList.orders[0] {
+		t.Errorf("expected oldest order to be %x, got %x", expectedOldest, ordList.orders[0])
+	}
+
+	// Now add one with the same time as the last, but larger order ID, thus not
+	// requiring a swap.
+	oid4 := order.OrderID{0x5}
+	ordList.add(&ord{
+		OrderID: oid4,
+		time:    ts,
+		target:  maybeCancel(),
+	})
+	checkSort()
+
+	// verify the latest order is the one just stored
+	latestOid := ordList.orders[len(ordList.orders)-1].OrderID
+	if oid4 != latestOid {
+		t.Errorf("expected latest order ID to be %x, got %x", oid4, latestOid)
+	}
+
+	// Add another with the same time as last, but this time with a smaller ID,
+	// thus requiring a swap.
+	oid0 := order.OrderID{0x0}
+	ordList.add(&ord{
+		OrderID: oid0,
+		time:    ts,
+		target:  maybeCancel(),
+	})
+	checkSort()
+
+	// verify the latest order has not changed
+	latestOid = ordList.orders[len(ordList.orders)-1].OrderID
+	if oid4 != latestOid {
+		t.Errorf("expected latest order ID to be %x, got %x", oid4, latestOid)
+	}
+
+	// Add one with an older time, thus necessitating a few swaps.
+	ts--
+	ordList.add(&ord{
+		OrderID: randomOrderID(),
+		time:    ts,
+		target:  maybeCancel(),
+	})
+	checkSort()
+
+	// verify the latest order has not changed
+	latestOid = ordList.orders[len(ordList.orders)-1].OrderID
+	if oid4 != latestOid {
+		t.Errorf("expected latest order ID to be %x, got %x", oid4, latestOid)
+	}
+
+	// Now exercise it and ensure it is always sorted.
+	for i := 0; i < 100000; i++ {
+		ordList.add(&ord{
+			OrderID: randomOrderID(),
+			time:    rand.Int63n(44444),
+			target:  maybeCancel(),
+		})
+		checkSort()
+	}
+}
+
+func Test_ordsByTimeThenID_Sort(t *testing.T) {
+	tests := []struct {
+		name     string
+		ords     []*ord
+		wantOrds []*ord
+	}{
+		{
+			name: "unique, no swap",
+			ords: []*ord{
+				{order.OrderID{0x1}, 1234, nil},
+				{order.OrderID{0x2}, 1235, nil},
+			},
+			wantOrds: []*ord{
+				{order.OrderID{0x1}, 1234, nil},
+				{order.OrderID{0x2}, 1235, nil},
+			},
+		},
+		{
+			name: "unique, one swap",
+			ords: []*ord{
+				{order.OrderID{0x2}, 1235, nil},
+				{order.OrderID{0x1}, 1234, nil},
+			},
+			wantOrds: []*ord{
+				{order.OrderID{0x1}, 1234, nil},
+				{order.OrderID{0x2}, 1235, nil},
+			},
+		},
+		{
+			name: "time tie, swap by order ID",
+			ords: []*ord{
+				{order.OrderID{0x2}, 1234, nil},
+				{order.OrderID{0x1}, 1234, nil},
+			},
+			wantOrds: []*ord{
+				{order.OrderID{0x1}, 1234, nil},
+				{order.OrderID{0x2}, 1234, nil},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sort.Sort(ordsByTimeThenID(tt.ords))
+			for i, o := range tt.ords {
+				if o.OrderID != tt.wantOrds[i].OrderID {
+					t.Errorf("element %d has order ID %x, wanted %x", i,
+						o.OrderID, tt.wantOrds[i].OrderID)
+				}
+			}
+		})
+	}
+
+	t.Run("dup order should panic", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("sort should have paniced with identical orders.")
+			}
+		}()
+		dups := []*ord{
+			{order.OrderID{0x1}, 1234, nil},
+			{order.OrderID{0x1}, 1234, nil},
+		}
+		sort.Sort(ordsByTimeThenID(dups))
+	})
+}

--- a/server/book/book_test.go
+++ b/server/book/book_test.go
@@ -110,10 +110,10 @@ func newBook(t *testing.T) *Book {
 
 func resetMakers() {
 	for _, o := range bookBuyOrders {
-		o.Filled = 0
+		o.FillAmt = 0
 	}
 	for _, o := range bookSellOrders {
-		o.Filled = 0
+		o.FillAmt = 0
 	}
 }
 

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -39,6 +39,7 @@ const (
 	defaultRPCHost             = "127.0.0.1"
 	defaultRPCPort             = "7232"
 
+	defaultCancelThresh     = 0.6
 	defaultRegFeeConfirms   = 4
 	defaultRegFeeAmount     = 1e8
 	defaultBroadcastTimeout = time.Minute
@@ -65,6 +66,7 @@ type dexConf struct {
 	RegFeeXPub       string
 	RegFeeConfirms   int64
 	RegFeeAmount     uint64
+	CancelThreshold  float64
 	DEXPrivKey       *secp256k1.PrivateKey
 	RPCCert          string
 	RPCKey           string
@@ -97,6 +99,7 @@ type flagsData struct {
 	RegFeeXPub       string        `long:"regfeexpub" description:"The extended public key for deriving Decred addresses to which DEX registration fees should be paid."`
 	RegFeeConfirms   int64         `long:"regfeeconfirms" description:"The number of confirmations required to consider a registration fee paid."`
 	RegFeeAmount     uint64        `long:"regfeeamount" description:"The registration fee amount in atoms."`
+	CancelThreshold  float64       `long:"cancelthresh" description:"Cancellation ratio threshold (cancels/completed)."`
 	DEXPrivKeyPath   string        `long:"dexprivkeypath" description:"The path to a file containing the DEX private key for message signing."`
 
 	HTTPProfile bool   `long:"httpprof" short:"p" description:"Start HTTP profiler."`
@@ -251,6 +254,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		RegFeeConfirms:   defaultRegFeeConfirms,
 		RegFeeAmount:     defaultRegFeeAmount,
 		BroadcastTimeout: defaultBroadcastTimeout,
+		CancelThreshold:  defaultCancelThresh,
 	}
 
 	// Pre-parse the command line options to see if an alternative config file
@@ -504,6 +508,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		RegFeeAmount:     cfg.RegFeeAmount,
 		RegFeeConfirms:   cfg.RegFeeConfirms,
 		RegFeeXPub:       cfg.RegFeeXPub,
+		CancelThreshold:  cfg.CancelThreshold,
 		DEXPrivKey:       privKey,
 		RPCCert:          cfg.RPCCert,
 		RPCKey:           cfg.RPCKey,

--- a/server/cmd/dcrdex/go.sum
+++ b/server/cmd/dcrdex/go.sum
@@ -173,6 +173,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -84,6 +84,7 @@ func mainCore(ctx context.Context) error {
 		RegFeeAmount:     cfg.RegFeeAmount,
 		RegFeeConfirms:   cfg.RegFeeConfirms,
 		BroadcastTimeout: cfg.BroadcastTimeout,
+		CancelThreshold:  cfg.CancelThreshold,
 		DEXPrivKey:       cfg.DEXPrivKey,
 		CommsCfg: &dexsrv.RPCConfig{
 			RPCCert:     cfg.RPCCert,

--- a/server/db/driver/pg/accounts.go
+++ b/server/db/driver/pg/accounts.go
@@ -132,7 +132,7 @@ func createAccountTables(db *sql.DB) error {
 			return err
 		}
 		if created {
-			log.Infof("Table %s created", c.name)
+			log.Tracef("Table %s created", c.name)
 		}
 	}
 	return nil

--- a/server/db/driver/pg/epochs.go
+++ b/server/db/driver/pg/epochs.go
@@ -1,0 +1,66 @@
+package pg
+
+import (
+	"database/sql/driver"
+	"fmt"
+
+	"decred.org/dcrdex/dex/order"
+	"decred.org/dcrdex/server/db"
+	"decred.org/dcrdex/server/db/driver/pg/internal"
+	"github.com/lib/pq"
+)
+
+// In a table, a []order.OrderID is stored as a BYTEA[]. The orderIDs type
+// defines the Value and Scan methods for such an OrderID slice using
+// pq.ByteaArray and copying of OrderId data to/from []byte.
+type orderIDs []order.OrderID
+
+// Value implements the sql/driver.Valuer interface.
+func (oids orderIDs) Value() (driver.Value, error) {
+	if oids == nil {
+		return nil, nil
+	}
+	if len(oids) == 0 {
+		return "{}", nil
+	}
+
+	ba := make(pq.ByteaArray, 0, len(oids))
+	for i := range oids {
+		ba = append(ba, oids[i][:])
+	}
+	return ba.Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (oids *orderIDs) Scan(src interface{}) error {
+	var ba pq.ByteaArray
+	err := ba.Scan(src)
+	if err != nil {
+		return err
+	}
+
+	n := len(ba)
+	*oids = make([]order.OrderID, n)
+	for i := range ba {
+		copy((*oids)[i][:], ba[i])
+	}
+	return nil
+}
+
+// InsertEpoch stores the results of a newly-processed epoch. TODO: test.
+func (a *Archiver) InsertEpoch(ed *db.EpochResults) error {
+	marketSchema, err := a.marketSchema(ed.MktBase, ed.MktQuote)
+	if err != nil {
+		return err
+	}
+
+	epochsTableName := fullEpochsTableName(a.dbName, marketSchema)
+	stmt := fmt.Sprintf(internal.InsertEpoch, epochsTableName)
+
+	_, err = a.db.Exec(stmt, ed.Idx, ed.Dur, ed.MatchTime, ed.CSum, ed.Seed,
+		orderIDs(ed.OrdersRevealed), orderIDs(ed.OrdersMissed))
+	if err != nil {
+		a.fatalBackendErr(err)
+	}
+	return err
+}

--- a/server/db/driver/pg/internal/epochs.go
+++ b/server/db/driver/pg/internal/epochs.go
@@ -1,0 +1,19 @@
+package internal
+
+const (
+	// CreateEpochsTable creates a table specified via the %s printf specifier
+	// for epoch data.
+	CreateEpochsTable = `CREATE TABLE IF NOT EXISTS %s (
+		epoch_idx INT8,
+		epoch_dur INT4,       -- epoch duration in milliseconds
+		match_time INT8,      -- time at which matching and book/unbooks began
+		csum BYTEA,           -- commitment checksum
+		seed BYTEA,           -- preimage-derived shuffle seed
+		revealed BYTEA[],     -- order IDs with revealed preimages
+		missed BYTEA[],       -- IDs of orders with no preimage
+		PRIMARY KEY(epoch_idx, epoch_dur)  -- epoch idx:dur is unique and the primary key
+	);`
+
+	InsertEpoch = `INSERT INTO %s (epoch_idx, epoch_dur, match_time, csum, seed, revealed, missed)
+		VALUES ($1, $2, $3, $4, $5, $6, $7);`
+)

--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -54,7 +54,7 @@ const (
 		-- participant/B (taker) REDEEM data
 		bRedeemCoinID BYTEA,
 		bRedeemTime INT8,         -- server time stamp
-		aSigAckOfBRedeem BYTEA    -- counterparty's (initiator) sig with ack of participant REDEEM data
+		aSigAckOfBRedeem BYTEA   -- counterparty's (initiator) sig with ack of participant REDEEM data
 	)`
 
 	RetrieveSwapData = `SELECT status, sigMatchAckMaker, sigMatchAckTaker,

--- a/server/db/driver/pg/internal/orders.go
+++ b/server/db/driver/pg/internal/orders.go
@@ -20,29 +20,52 @@ const (
 		rate INT8,
 		force INT2,
 		status INT2,
-		filled INT8
+		filled INT8,
+		epoch_idx INT8, epoch_dur INT4,
+		preimage BYTEA UNIQUE,
+		complete_time INT8      -- when the order has successfully completed all swaps
 	);`
 
 	// InsertOrder inserts a market or limit order into the specified table.
 	InsertOrder = `INSERT INTO %s (oid, type, sell, account_id, address,
 			client_time, server_time, commit, coins, quantity,
-			rate, force, status, filled)
+			rate, force, status, filled,
+			epoch_idx, epoch_dur)
 		VALUES ($1, $2, $3, $4, $5,
 			$6, $7, $8, $9, $10,
-			$11, $12, $13, $14);`
+			$11, $12, $13, $14,
+			$15, $16);`
 
 	// SelectOrder retrieves all columns with the given order ID. This may be
 	// used for any table with an "oid" column (orders_active, cancels_archived,
 	// etc.).
-	SelectOrder = `SELECT * FROM %s WHERE oid = $1;`
+	SelectOrder = `SELECT oid, type, sell, account_id, address, client_time, server_time,
+		commit, coins, quantity, rate, force, status, filled
+	FROM %s WHERE oid = $1;`
 
 	// SelectUserOrders retrieves all columns of all orders for the given
 	// account ID.
-	SelectUserOrders = `SELECT * FROM %s WHERE account_id = $1;`
+	SelectUserOrders = `SELECT oid, type, sell, account_id, address, client_time, server_time,
+		commit, coins, quantity, rate, force, status, filled
+	FROM %s WHERE account_id = $1;`
+
+	// SelectCanceledUserOrders gets the ID of orders that were either canceled
+	// by the user or revoked/canceled by the server, but these statuses can be
+	// set by the caller. Note that revoked orders can be market or immediate
+	// limit orders that failed to swap.
+	SelectCanceledUserOrders = `SELECT oid, match_time
+		FROM %[1]s -- a archived orders table
+		JOIN %[2]s ON %[2]s.epoch_idx = %[1]s.epoch_idx AND %[2]s.epoch_dur = %[1]s.epoch_dur -- join on epochs table PK
+		WHERE account_id = $1 AND status = ANY($2) -- {orderStatusCanceled, orderStatusRevoked}
+		ORDER BY match_time DESC
+		LIMIT $3;`  // The matchTime is when the order was booked, not canceled!!!
 
 	// SelectOrderByCommit retrieves the order ID for any order with the given
 	// commitment value. This applies to the cancel order tables as well.
 	SelectOrderByCommit = `SELECT oid FROM %s WHERE commit = $1;`
+
+	// SelectOrderPreimage retrieves the preimage for the order ID;
+	SelectOrderPreimage = `SELECT preimage FROM %s WHERE oid = $1;`
 
 	// SelectOrderCoinIDs retrieves the order id, sell flag, and coins for all
 	// orders in a table with one of the given statuses. Note that this includes
@@ -50,6 +73,16 @@ const (
 	SelectOrderCoinIDs = `SELECT oid, sell, coins
 		FROM %s
 		WHERE type = ANY($1);`
+
+	SetOrderPreimage     = `UPDATE %s SET preimage = $1 WHERE oid = $2;`
+	SetOrderCompleteTime = `UPDATE %s SET complete_time = $1
+		WHERE oid = $2;`
+
+	RetrieveCompletedOrdersForAccount = `SELECT oid, account_id, complete_time
+		FROM %s
+		WHERE account_id = $1
+		ORDER BY complete_time DESC
+		LIMIT $2;`
 
 	// UpdateOrderStatus sets the status of an order with the given order ID.
 	UpdateOrderStatus = `UPDATE %s SET status = $1 WHERE oid = $2;`
@@ -87,7 +120,8 @@ const (
 	//			rate,
 	//			force,
 	//			2,                                      -- new status ($d)
-	//			123456789                               -- new filled ($d)
+	//			123456789,                              -- new filled ($d)
+	//          epoch_idx, epoch_dur, preimage, complete_time
 	//		)
 	//		INSERT INTO dcrdex.dcr_btc.orders_archived  -- destination table (%s)
 	//		SELECT * FROM moved;
@@ -96,7 +130,8 @@ const (
 		WHERE oid = $1
 		RETURNING oid, type, sell, account_id, address,
 			client_time, server_time, commit, coins, quantity,
-			rate, force, %d, %d
+			rate, force, %d, %d,
+			epoch_idx, epoch_dur, preimage, complete_time
 	)
 	INSERT INTO %s
 	SELECT * FROM moved;`
@@ -111,12 +146,46 @@ const (
 		server_time TIMESTAMPTZ,
 		commit BYTEA UNIQUE,
 		target_order BYTEA,    -- cancel orders ref another order
-		status INT2
+		status INT2,
+		epoch_idx INT8, epoch_dur INT4,
+		preimage BYTEA UNIQUE
 	);`
 
+	SelectCancelOrder = `SELECT oid, account_id, client_time, server_time,
+		commit, target_order, status
+	FROM %s WHERE oid = $1;`
+
+	// SelectRevokeCancels retrieves server-initiated cancels (revokes).
+	SelectRevokeCancels = `SELECT oid, target_order, server_time
+		FROM %s
+		WHERE account_id = $1 AND status = $2 -- use orderStatusRevoked
+		ORDER BY server_time DESC
+		LIMIT $3;`
+
+	// RetrieveCancelsForUserByStatus gets matched cancel orders by user and
+	// status, where status should be orderStatusExecuted. This query may be
+	// followed by a SELECT of match_time from the epochs table for the epoch
+	// IDs (idx:dur) returned by this query. In general, this query will be used
+	// on a market's archived cancels table, which includes matched cancels.
+	RetrieveCancelsForUserByStatus = `SELECT oid, target_order, epoch_idx, epoch_dur
+		FROM %s
+		WHERE account_id = $1 AND status = $2
+		ORDER BY epoch_idx * epoch_dur DESC;`
+	// RetrieveCancelTimesForUserByStatus is similar to
+	// RetrieveCancelsForUserByStatus, but it joins on an epochs table to get
+	// the match_time directly instead of the epoch_idx and epoch_dur. The
+	// cancels table, with full market schema, is %[1]s, while the epochs table
+	// is %[2]s.
+	RetrieveCancelTimesForUserByStatus = `SELECT oid, target_order, match_time
+		FROM %[1]s -- a cancels table
+		JOIN %[2]s ON %[2]s.epoch_idx = %[1]s.epoch_idx AND %[2]s.epoch_dur = %[1]s.epoch_dur -- join on epochs table PK
+		WHERE account_id = $1 AND status = $2
+		ORDER BY match_time DESC
+		LIMIT $3;`  // NOTE: find revoked orders via SelectRevokeCancels
+
 	// InsertCancelOrder inserts a cancel order row into the specified table.
-	InsertCancelOrder = `INSERT INTO %s (oid, account_id, client_time, server_time, commit, target_order, status)
-		VALUES ($1, $2, $3, $4, $5, $6, $7);`
+	InsertCancelOrder = `INSERT INTO %s (oid, account_id, client_time, server_time, commit, target_order, status, epoch_idx, epoch_dur)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);`
 
 	// CancelOrderStatus retrieves an order's status
 	CancelOrderStatus = `SELECT status FROM %s WHERE oid = $1;`
@@ -126,7 +195,7 @@ const (
 	MoveCancelOrder = `WITH moved AS (
 		DELETE FROM %s
 		WHERE oid = $1
-		RETURNING oid, account_id, client_time, server_time, commit, target_order, %d
+		RETURNING oid, account_id, client_time, server_time, commit, target_order, %d, epoch_idx, epoch_dur, preimage
 	)
 	INSERT INTO %s
 	SELECT * FROM moved;`

--- a/server/db/driver/pg/internal/orders.go
+++ b/server/db/driver/pg/internal/orders.go
@@ -80,7 +80,7 @@ const (
 
 	RetrieveCompletedOrdersForAccount = `SELECT oid, account_id, complete_time
 		FROM %s
-		WHERE account_id = $1
+		WHERE account_id = $1 AND complete_time IS NOT NULL
 		ORDER BY complete_time DESC
 		LIMIT $2;`
 

--- a/server/db/driver/pg/markets.go
+++ b/server/db/driver/pg/markets.go
@@ -65,7 +65,7 @@ func createMarketTables(db *sql.DB, marketUID string) error {
 		return err
 	}
 	if !created {
-		log.Debugf(`Market schema "%s" already exists.`, marketUID)
+		log.Tracef(`Market schema "%s" already exists.`, marketUID)
 	}
 
 	for _, c := range createMarketTableStatements {

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -1035,14 +1035,14 @@ func loadTradeFromTable(dbe *sql.DB, fullTable string, oid order.OrderID) (order
 	switch prefix.OrderType {
 	case order.LimitOrderType:
 		return &order.LimitOrder{
-			T:     trade,
+			T:     *trade.Copy(), // govet would complain because Trade has a Mutex
 			P:     prefix,
 			Rate:  rate,
 			Force: tif,
 		}, status, nil
 	case order.MarketOrderType:
 		return &order.MarketOrder{
-			T: trade,
+			T: *trade.Copy(),
 			P: prefix,
 		}, status, nil
 
@@ -1108,14 +1108,14 @@ func userOrdersFromTable(ctx context.Context, dbe *sql.DB, fullTable string, bas
 		case order.LimitOrderType:
 			ord = &order.LimitOrder{
 				P:     prefix,
-				T:     trade,
+				T:     *trade.Copy(),
 				Rate:  rate,
 				Force: tif,
 			}
 		case order.MarketOrderType:
 			ord = &order.MarketOrder{
 				P: prefix,
-				T: trade,
+				T: *trade.Copy(),
 			}
 		default:
 			log.Errorf("userOrdersFromTable: encountered unexpected order type %v",

--- a/server/db/driver/pg/orders_online_test.go
+++ b/server/db/driver/pg/orders_online_test.go
@@ -1204,6 +1204,15 @@ func TestCompletedUserOrders(t *testing.T) {
 		t.Fatalf("SetOrderCompleteTime failed: %v", err)
 	}
 
+	// Order without completion time set.
+	taker2Incomplete := newLimitOrder(true, 4390000, 1, order.StandingTiF, 20)
+	taker2Incomplete.AccountID = taker.AccountID
+	err = archie.StoreOrder(taker2Incomplete, epochIdx, epochDur, order.OrderStatusCanceled) // archived, but not complete
+	if err != nil {
+		t.Fatalf("StoreOrder failed: %v", err)
+	}
+	// NO SetOrderCompleteTime, BUT in an orders_archived table.
+
 	// Try and fail to set completion time for an order not in executed status.
 	taker3 := newLimitOrder(true, 4390000, 1, order.StandingTiF, 20)
 	err = archie.StoreOrder(taker3, epochIdx, epochDur, order.OrderStatusBooked)

--- a/server/db/driver/pg/orders_test.go
+++ b/server/db/driver/pg/orders_test.go
@@ -140,7 +140,7 @@ func Test_storeLimitOrder(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			N, err := storeLimitOrder(stub, "dcrdex", tt.args.lo, marketToPgStatus(tt.args.status))
+			N, err := storeLimitOrder(stub, "dcrdex", tt.args.lo, marketToPgStatus(tt.args.status), 123456, 6000)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("storeLimitOrder() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/server/db/driver/pg/system.go
+++ b/server/db/driver/pg/system.go
@@ -150,7 +150,7 @@ func createTable(db *sql.DB, fmtStmt, schema, tableName string) (bool, error) {
 	var created bool
 	if !exists {
 		stmt := fmt.Sprintf(fmtStmt, nameSpacedTable)
-		log.Infof(`Creating the "%s" table.`, nameSpacedTable)
+		log.Tracef(`Creating the "%s" table.`, nameSpacedTable)
 		_, err = db.Exec(stmt)
 		if err != nil {
 			return false, err
@@ -457,7 +457,7 @@ func createSchema(db *sql.DB, schema string) (bool, error) {
 
 	var created bool
 	if !exists {
-		log.Infof(`Creating schema "%s".`, schema)
+		log.Tracef(`Creating schema "%s".`, schema)
 		stmt := fmt.Sprintf(internal.CreateSchema, schema)
 		_, err = db.Exec(stmt)
 		if err != nil {

--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -144,7 +144,7 @@ func nukeAll(db *sql.DB) error {
 
 	// Drop market schemas.
 	for i := range markets {
-		log.Infof(`Dropping market %s schema...`, markets[i])
+		log.Tracef(`Dropping market %s schema...`, markets[i])
 		_, err = db.Exec(fmt.Sprintf("DROP SCHEMA %s CASCADE;", markets[i]))
 		if err != nil {
 			return err
@@ -155,7 +155,7 @@ func nukeAll(db *sql.DB) error {
 	dropPublic := func(stmts []tableStmt) error {
 		for i := range stmts {
 			tableName := "public." + stmts[i].name
-			log.Infof(`Dropping DEX table %s...`, tableName)
+			log.Tracef(`Dropping DEX table %s...`, tableName)
 			if err = dropTable(db, tableName); err != nil {
 				return err
 			}

--- a/server/db/driver/pg/tables.go
+++ b/server/db/driver/pg/tables.go
@@ -37,6 +37,7 @@ var createMarketTableStatements = []tableStmt{
 	{"cancels_archived", internal.CreateCancelOrdersTable},
 	{"cancels_active", internal.CreateCancelOrdersTable},
 	{"matches", internal.CreateMatchesTable}, // just one matches table per market for now
+	{"epochs", internal.CreateEpochsTable},
 }
 
 var tableMap = func() map[string]string {
@@ -80,6 +81,10 @@ func fullMatchesTableName(dbName, marketSchema string) string {
 	return dbName + "." + marketSchema + ".matches"
 }
 
+func fullEpochsTableName(dbName, marketSchema string) string {
+	return dbName + "." + marketSchema + ".epochs"
+}
+
 // CreateTable creates one of the known tables by name. The table will be
 // created in the specified schema (schema.tableName). If schema is empty,
 // "public" is used.
@@ -104,7 +109,7 @@ func PrepareTables(db *sql.DB, mktConfig []*dex.MarketInfo) error {
 		return fmt.Errorf("failed to create markets table: %v", err)
 	}
 	if created {
-		log.Warn("Creating new markets table.")
+		log.Trace("Creating new markets table.")
 	}
 
 	// Verify config of existing markets, creating a new markets table if none
@@ -145,7 +150,7 @@ func prepareMarkets(db *sql.DB, mktConfig []*dex.MarketInfo) (map[string]*dex.Ma
 	for _, mkt := range mktConfig {
 		existingMkt := marketMap[mkt.Name]
 		if existingMkt == nil {
-			log.Infof("New market specified in config: %s", mkt.Name)
+			log.Tracef("New market specified in config: %s", mkt.Name)
 			err = newMarket(db, marketsTableName, mkt)
 			if err != nil {
 				return nil, fmt.Errorf("newMarket failed: %v", err)

--- a/server/db/driver/pg/testhelpers_test.go
+++ b/server/db/driver/pg/testhelpers_test.go
@@ -44,6 +44,11 @@ func randomAccountID() account.AccountID {
 	return account.NewID(pk)
 }
 
+func randomPreimage() (pi order.Preimage) {
+	rand.Read(pi[:])
+	return
+}
+
 func randomCommitment() (com order.Commitment) {
 	rand.Read(com[:])
 	return
@@ -76,6 +81,13 @@ func newMatch(maker *order.LimitOrder, taker order.Order, quantity uint64, epoch
 		Sigs:     order.Signatures{},
 		Epoch:    epochID,
 	}
+}
+
+func newLimitOrderRevealed(sell bool, rate, quantityLots uint64, force order.TimeInForce, timeOffset int64) (*order.LimitOrder, order.Preimage) {
+	lo := newLimitOrder(sell, rate, quantityLots, force, timeOffset)
+	pi := randomPreimage()
+	lo.Commit = pi.Commit()
+	return lo, pi
 }
 
 func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce, timeOffset int64) *order.LimitOrder {

--- a/server/db/errors.go
+++ b/server/db/errors.go
@@ -49,6 +49,8 @@ const (
 	ErrUnsupportedMarket
 	ErrInvalidOrder
 	ErrReusedCommit
+	ErrOrderNotExecuted
+	ErrUpdateCount
 )
 
 func (ae ArchiveError) Error() string {
@@ -66,6 +68,10 @@ func (ae ArchiveError) Error() string {
 		desc = "invalid order"
 	case ErrReusedCommit:
 		desc = "order commit reused"
+	case ErrOrderNotExecuted:
+		desc = "order not in executed status"
+	case ErrUpdateCount:
+		desc = "unexpected number of rows updated"
 	}
 
 	if ae.Detail == "" {
@@ -83,6 +89,13 @@ func SameErrorTypes(errA, errB error) bool {
 	}
 
 	return errors.Is(errA, errB)
+}
+
+// IsErrGeneralFailure returns true if the error is of type ArchiveError and has
+// code ErrGeneralFailure.
+func IsErrGeneralFailure(err error) bool {
+	var errA ArchiveError
+	return errors.As(err, &errA) && errA.Code == ErrGeneralFailure
 }
 
 // IsErrOrderUnknown returns true if the error is of type ArchiveError and has
@@ -118,4 +131,18 @@ func IsErrInvalidOrder(err error) bool {
 func IsErrReusedCommit(err error) bool {
 	var errA ArchiveError
 	return errors.As(err, &errA) && errA.Code == ErrReusedCommit
+}
+
+// IsErrOrderNotExecuted returns true if the error is of type ArchiveError and
+// has code ErrOrderNotExecuted.
+func IsErrOrderNotExecuted(err error) bool {
+	var errA ArchiveError
+	return errors.As(err, &errA) && errA.Code == ErrOrderNotExecuted
+}
+
+// IsErrUpdateCount returns true if the error is of type ArchiveError and has
+// code ErrUpdateCount.
+func IsErrUpdateCount(err error) bool {
+	var errA ArchiveError
+	return errors.As(err, &errA) && errA.Code == ErrUpdateCount
 }

--- a/server/db/interface_test.go
+++ b/server/db/interface_test.go
@@ -37,7 +37,7 @@ func TestValidateOrder(t *testing.T) {
 	marketOrderBadAmt.Quantity /= 2
 
 	marketOrderBadRemaining := newMarketSellOrder(1, 0)
-	marketOrderBadRemaining.Filled = marketOrderBadAmt.Quantity / 2
+	marketOrderBadRemaining.FillAmt = marketOrderBadAmt.Quantity / 2
 
 	// order ID for a cancel order
 	orderID0, _ := hex.DecodeString("dd64e2ae2845d281ba55a6d46eceb9297b2bdec5c5bada78f9ae9e373164df0d")

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -94,7 +94,7 @@ type DexConf struct {
 	RegFeeConfirms   int64
 	RegFeeAmount     uint64
 	BroadcastTimeout time.Duration
-	CancelThreshold  float32
+	CancelThreshold  float64
 	DEXPrivKey       *secp256k1.PrivateKey
 	CommsCfg         *RPCConfig
 }
@@ -328,10 +328,11 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		RegistrationFee: cfg.RegFeeAmount,
 		FeeConfs:        cfg.RegFeeConfirms,
 		FeeChecker:      dcrBackend.UnspentCoinDetails,
+		CancelThreshold: cfg.CancelThreshold,
 	}
 
 	authMgr := auth.NewAuthManager(&authCfg)
-	go authMgr.Run(ctx)
+	startSubSys("Auth manager", authMgr)
 
 	// Create the swapper.
 	swapperCfg := &swap.Config{

--- a/server/market/integ/booker_matcher_test.go
+++ b/server/market/integ/booker_matcher_test.go
@@ -204,10 +204,10 @@ func newBook(t *testing.T) *book.Book {
 
 func resetMakers() {
 	for _, o := range bookBuyOrders {
-		o.Filled = 0
+		o.FillAmt = 0
 	}
 	for _, o := range bookSellOrders {
-		o.Filled = 0
+		o.FillAmt = 0
 	}
 }
 
@@ -263,9 +263,9 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 		for _, o := range takers {
 			switch ot := o.Order.(type) {
 			case *order.MarketOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			case *order.LimitOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			}
 		}
 	}
@@ -422,7 +422,7 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 			resetMakers()
 
 			// Ignore the seed since it is tested in the matcher unit tests.
-			_, matches, passed, failed, doneOK, partial, booked, unbooked := me.Match(tt.args.book, tt.args.queue)
+			_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -562,9 +562,9 @@ func TestMatchWithBook_limitsOnly_multipleQueued(t *testing.T) {
 		for _, o := range epochQueue {
 			switch ot := o.Order.(type) {
 			case *order.MarketOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			case *order.LimitOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			}
 		}
 	}
@@ -577,7 +577,7 @@ func TestMatchWithBook_limitsOnly_multipleQueued(t *testing.T) {
 	resetMakers()
 
 	// Ignore the seed since it is tested in the matcher unit tests.
-	_, matches, passed, failed, doneOK, partial, booked, unbooked := me.Match(b, epochQueue)
+	_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(b, epochQueue)
 	//t.Log(matches, passed, failed, doneOK, partial, booked, unbooked)
 
 	// PASSED orders
@@ -773,7 +773,7 @@ func TestMatch_cancelOnly(t *testing.T) {
 			numBuys0 := tt.args.book.BuyCount()
 
 			// Ignore the seed since it is tested in the matcher unit tests.
-			_, matches, passed, failed, doneOK, partial, booked, unbooked := me.Match(tt.args.book, tt.args.queue)
+			_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -837,9 +837,9 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 		for _, o := range takers {
 			switch ot := o.Order.(type) {
 			case *order.MarketOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			case *order.LimitOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			}
 		}
 	}
@@ -939,7 +939,7 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 			//fmt.Printf("%v\n", takers)
 
 			// Ignore the seed since it is tested in the matcher unit tests.
-			_, matches, passed, failed, doneOK, partial, booked, unbooked := me.Match(tt.args.book, tt.args.queue)
+			_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -1030,9 +1030,9 @@ func TestMatch_marketBuysOnly(t *testing.T) {
 		for _, o := range takers {
 			switch ot := o.Order.(type) {
 			case *order.MarketOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			case *order.LimitOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			}
 		}
 	}
@@ -1142,7 +1142,7 @@ func TestMatch_marketBuysOnly(t *testing.T) {
 			resetMakers()
 
 			// Ignore the seed since it is tested in the matcher unit tests.
-			_, matches, passed, failed, doneOK, partial, booked, unbooked := me.Match(tt.args.book, tt.args.queue)
+			_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -1259,9 +1259,9 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 		for _, o := range epochQueue {
 			switch ot := o.Order.(type) {
 			case *order.MarketOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			case *order.LimitOrder:
-				ot.Filled = 0
+				ot.FillAmt = 0
 			}
 		}
 	}
@@ -1271,7 +1271,7 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 	resetMakers()
 
 	// Ignore the seed since it is tested in the matcher unit tests.
-	_, matches, passed, failed, doneOK, partial, booked, unbooked := me.Match(b, epochQueue)
+	_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(b, epochQueue)
 	//t.Log("Matches:", matches)
 	// s := "Passed: "
 	// for _, o := range passed {

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -47,7 +47,9 @@ const (
 
 // Swapper coordinates atomic swaps for one or more matchsets.
 type Swapper interface {
+	BeginMatchAndNegotiate()
 	Negotiate(matchSets []*order.MatchSet)
+	EndMatchAndNegotiate()
 	LockCoins(asset uint32, coins map[order.OrderID][]order.CoinID)
 	LockOrdersCoins(orders []order.Order)
 	TxMonitored(user account.AccountID, asset uint32, txid string) bool
@@ -118,8 +120,18 @@ func NewMarket(mktInfo *dex.MarketInfo, storage db.DEXArchivist, swapper Swapper
 		return nil, err
 	}
 	// TODO: first check that the coins aren't already locked by e.g. another market.
+	log.Tracef("Locking %d base asset coins", len(baseCoins))
+	for oid, coins := range baseCoins {
+		log.Tracef(" - order %v: %v", oid, coins)
+	}
 	coinLockerBase.LockCoins(baseCoins)
+	log.Debugf("Locking %d quote asset coins", len(quoteCoins))
+	for oid, coins := range quoteCoins {
+		log.Tracef(" - order %v: %v", oid, coins)
+	}
 	coinLockerQuote.LockCoins(quoteCoins)
+	// TODO: fail and archive orders that are in orderStatusEpoch, and unlock
+	// their coins.
 
 	return &Market{
 		running:          make(chan struct{}),
@@ -488,7 +500,7 @@ func (m *Market) Run(ctx context.Context) {
 			err := m.processOrder(ctxRun, s.rec, orderEpoch, s.errChan)
 			if err != nil {
 				if ctxRun.Err() == nil {
-					// This was not context cancelation.
+					// This was not context cancellation.
 					log.Errorf("Failed to process order %v: %v", s.rec.order, err)
 					// Signal to the other Run goroutines to return.
 					cancel()
@@ -641,9 +653,9 @@ func (m *Market) processOrder(ctx context.Context, rec *orderRecord, epoch *Epoc
 	// 	return nil
 	// }
 
-	// Archive the new epoch order BEFORE inserting it into the epoch queue,
+	// Store the new epoch order BEFORE inserting it into the epoch queue,
 	// initiating the swap, and notifying book subscribers.
-	if err := m.storage.NewEpochOrder(ord); err != nil {
+	if err := m.storage.NewEpochOrder(ord, epoch.Epoch, epoch.Duration); err != nil {
 		errChan <- ErrInternalServer
 		return fmt.Errorf("processOrder: Failed to store new epoch order %v: %v",
 			ord, err)
@@ -695,9 +707,7 @@ func (m *Market) respondError(id uint64, user account.AccountID, code int, errMs
 
 // preimage request-response handling data
 type piData struct {
-	user     account.AccountID
-	id       order.OrderID
-	commit   order.Commitment
+	ord      order.Order
 	preimage chan *order.Preimage
 }
 
@@ -712,14 +722,14 @@ func (m *Market) handlePreimageResp(msg *msgjson.Message, reqData *piData) {
 	resp, err := msg.Response()
 	if err != nil {
 		sendPI(nil)
-		m.respondError(msg.ID, reqData.user, msgjson.RPCParseError,
+		m.respondError(msg.ID, reqData.ord.User(), msgjson.RPCParseError,
 			fmt.Sprintf("error parsing preimage notification response: %v", err))
 		return
 	}
 	err = json.Unmarshal(resp.Result, &piResp)
 	if err != nil {
 		sendPI(nil)
-		m.respondError(msg.ID, reqData.user, msgjson.RPCParseError,
+		m.respondError(msg.ID, reqData.ord.User(), msgjson.RPCParseError,
 			fmt.Sprintf("error parsing preimage notification response payload result: %v", err))
 		return
 	}
@@ -727,7 +737,7 @@ func (m *Market) handlePreimageResp(msg *msgjson.Message, reqData *piData) {
 	// Validate preimage length.
 	if len(piResp.Preimage) != order.PreimageSize {
 		sendPI(nil)
-		m.respondError(msg.ID, reqData.user, msgjson.InvalidPreimage,
+		m.respondError(msg.ID, reqData.ord.User(), msgjson.InvalidPreimage,
 			fmt.Sprintf("invalid preimage length (%d byes)", len(piResp.Preimage)))
 		return
 	}
@@ -736,16 +746,24 @@ func (m *Market) handlePreimageResp(msg *msgjson.Message, reqData *piData) {
 	var pi order.Preimage
 	copy(pi[:], piResp.Preimage)
 	piCommit := pi.Commit()
-	if reqData.commit != piCommit {
+	if reqData.ord.Commitment() != piCommit {
 		sendPI(nil)
-		m.respondError(msg.ID, reqData.user, msgjson.PreimageCommitmentMismatch,
+		m.respondError(msg.ID, reqData.ord.User(), msgjson.PreimageCommitmentMismatch,
 			fmt.Sprintf("preimage hash %x does not match order commitment %x",
-				piCommit, reqData.commit))
+				piCommit, reqData.ord.Commitment()))
 		return
 	}
 
 	// The preimage is good.
-	log.Tracef("Good preimage received for order %v: %x", reqData.id, pi)
+	log.Tracef("Good preimage received for order %v: %x", reqData.ord.UID(), pi)
+	err = m.storage.StorePreimage(reqData.ord, pi)
+	if err != nil {
+		log.Errorf("StorePreimage: %v", err)
+		// Fatal backend error. New swaps will not begin, but pass the preimage
+		// along so it does not appear as a miss to collectPreimages.
+		m.respondError(msg.ID, reqData.ord.User(), msgjson.UnknownMarketError, "internal server error")
+	}
+
 	sendPI(&pi)
 }
 
@@ -783,9 +801,7 @@ func (m *Market) collectPreimages(orders []order.Order) (cSum []byte, ordersReve
 		piChan := make(chan *order.Preimage)
 
 		reqData := &piData{
-			user:     ord.User(),
-			id:       ord.ID(), // maybe remove
-			commit:   ord.Commitment(),
+			ord:      ord,
 			preimage: piChan,
 		}
 
@@ -956,8 +972,6 @@ func (m *Market) enqueueEpoch(eq *epochPump, epoch *EpochQueue) {
 
 // epochStart collects order preimages, and penalizes users who fail to respond.
 func (m *Market) epochStart(orders []order.Order) (cSum []byte, ordersRevealed []*matcher.OrderRevealed, misses []order.Order) {
-	// TODO: consider storing the epoch order IDs in an epochs table.
-
 	// Solicit the preimages for each order.
 	cSum, ordersRevealed, misses = m.collectPreimages(orders)
 	log.Debugf("Collected %d valid order preimages, missed %d. Commit checksum: %x",
@@ -990,6 +1004,13 @@ func (m *Market) processReadyEpoch(ctx context.Context, epoch *readyEpoch) {
 		return // maybe panic
 	}
 
+	// Abort epoch processing if there was a fatal DB backend error during
+	// preimage collection.
+	if err := m.storage.LastErr(); err != nil {
+		log.Criticalf("aborting epoch processing on account of failing DB: %v", err)
+		return
+	}
+
 	// Data from preimage collection
 	ordersRevealed := epoch.ordersRevealed
 	cSum := epoch.cSum
@@ -997,16 +1018,124 @@ func (m *Market) processReadyEpoch(ctx context.Context, epoch *readyEpoch) {
 
 	// Perform order matching using the preimages to shuffle the queue.
 	m.bookMtx.Lock()
-	seed, matches, _, failed, doneOK, partial, booked, unbooked := m.matcher.Match(m.book, ordersRevealed)
+	m.swapper.BeginMatchAndNegotiate() // Suspend Swapper's order completion checking.
+	matchTime := time.Now()            // considered as the time at which matched cancel orders are executed
+	seed, matches, _, failed, doneOK, partial, booked, unbooked, updates := m.matcher.Match(m.book, ordersRevealed)
 	m.epochIdx = epoch.Epoch + 1
 	m.bookMtx.Unlock()
-	log.Debugf("Matching complete for epoch %d:"+
+	log.Debugf("Matching complete for market %v epoch %d:"+
 		" %d matches (%d partial fills), %d completed OK (not booked),"+
 		" %d booked, %d unbooked, %d failed",
-		epoch.Epoch,
+		m.marketInfo.Name, epoch.Epoch,
 		len(matches), len(partial), len(doneOK),
 		len(booked), len(unbooked), len(failed),
 	)
+	// Resume Swapper's order completion checking. If there are no new matches
+	// release the Swapper's active swap tracking for other internal updates
+	// (e.g. terminated swaps) now, otherwise after Swapper.Negotiate.
+	if len(matches) > 0 {
+		defer m.swapper.EndMatchAndNegotiate()
+	} else {
+		m.swapper.EndMatchAndNegotiate()
+	}
+
+	// Store data in epochs table, including matchTime so that cancel execution
+	// times can be obtained from the DB for cancellation ratio computation.
+	oidsRevealed := make([]order.OrderID, 0, len(ordersRevealed))
+	for _, or := range ordersRevealed {
+		oidsRevealed = append(oidsRevealed, or.Order.ID())
+	}
+	oidsMissed := make([]order.OrderID, 0, len(misses))
+	for _, om := range misses {
+		oidsMissed = append(oidsMissed, om.ID())
+	}
+
+	err := m.storage.InsertEpoch(&db.EpochResults{
+		MktBase:        m.marketInfo.Base,
+		MktQuote:       m.marketInfo.Quote,
+		Idx:            epoch.Epoch,
+		Dur:            epoch.Duration,
+		MatchTime:      encode.UnixMilli(matchTime),
+		CSum:           cSum,
+		Seed:           seed,
+		OrdersRevealed: oidsRevealed,
+		OrdersMissed:   oidsMissed,
+	})
+	if err != nil {
+		// fatal backend error, do not begin new swaps.
+		return // TODO: notify clients
+	}
+
+	// Note: validated preimages are stored in the orders/cancels tables on
+	// receipt from the user by handlePreimageResp.
+
+	// Update orders in persistent storage. Trade orders may appear in multiple
+	// trade order slices, so update in the sequence: booked, partial, completed
+	// or canceled. However, an order in the failed slice will not be in another
+	// slice since failed indicates unmatched&unbooked or bad lot size.
+	//
+	// TODO: Only execute the net effect. Each status update also updates the
+	// filled amount of the trade order.
+	//
+	// Cancel order status updates are from epoch to executed or failed status.
+
+	// Newly-booked orders.
+	for _, lo := range updates.TradesBooked {
+		if err = m.storage.BookOrder(lo); err != nil {
+			return
+		}
+	}
+
+	// Book orders that were partially filled and remain on the books.
+	for _, lo := range updates.TradesPartial {
+		if err = m.storage.UpdateOrderFilled(lo); err != nil {
+			return
+		}
+	}
+
+	// Completed orders (includes epoch and formerly booked orders).
+	for _, ord := range updates.TradesCompleted {
+		if err = m.storage.ExecuteOrder(ord); err != nil {
+			return
+		}
+	}
+	// Canceled orders.
+	for _, lo := range updates.TradesCanceled {
+		if err = m.storage.CancelOrder(lo); err != nil {
+			return
+		}
+	}
+	// Failed orders refer to epoch queue orders that are unmatched&unbooked, or
+	// had a bad lot size.
+	for _, ord := range updates.TradesFailed {
+		if err = m.storage.ExecuteOrder(ord); err != nil {
+			return
+		}
+	}
+
+	// Change cancel orders from epoch status to executed or failed status.
+	for _, co := range updates.CancelsFailed {
+		if err = m.storage.FailCancelOrder(co); err != nil {
+			return
+		}
+	}
+	for _, co := range updates.CancelsExecuted {
+		if err = m.storage.ExecuteOrder(co); err != nil {
+			return
+		}
+	}
+
+	// Set the EpochID for each MatchSet, and record executed cancels.
+	for _, match := range matches {
+		// Set the epoch ID.
+		match.Epoch.Idx = uint64(epoch.Epoch)
+		match.Epoch.Dur = uint64(epoch.Duration)
+
+		// Record the cancel in the auth manager.
+		if co, ok := match.Taker.(*order.CancelOrder); ok {
+			m.auth.RecordCancel(co.User(), co.ID(), co.TargetOrderID, matchTime) // cancel execution time, not order's server time
+		}
+	}
 
 	// Signal the match_proof to the orderbook subscribers.
 	preimages := make([]order.Preimage, len(ordersRevealed))
@@ -1028,18 +1157,6 @@ func (m *Market) processReadyEpoch(ctx context.Context, epoch *readyEpoch) {
 		epochIdx: epoch.Epoch,
 	}
 	m.notify(ctx, sig)
-
-	// Set the EpochID for each MatchSet, and record executed cancels.
-	for _, match := range matches {
-		// Set the epoch ID.
-		match.Epoch.Idx = uint64(epoch.Epoch)
-		match.Epoch.Dur = uint64(epoch.Duration)
-
-		// TODO: record the cancel in the auth manager.
-		// if match.Taker.Type() == order.CancelOrderType {
-		// 	m.auth.RecordCancel(match.Taker.User())
-		// }
-	}
 
 	// Unlock passed but not booked order (e.g. matched market and immediate
 	// orders) coins were locked upon order receipt in processOrder and must be

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -49,8 +49,8 @@ func (a *TAsset) BlockChannel(size int) chan uint32 { return nil }
 func (a *TAsset) InitTxSize() uint32                { return 100 }
 func (a *TAsset) CheckAddress(string) bool          { return true }
 func (a *TAsset) Run(context.Context)               {}
-func (a *TAsset) ValidateCoinID(coinID []byte) error {
-	return nil
+func (a *TAsset) ValidateCoinID(coinID []byte) (string, error) {
+	return "", nil
 }
 func (a *TAsset) ValidateContract(contract []byte) error {
 	return nil

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -49,9 +49,6 @@ func (a *TAsset) BlockChannel(size int) chan uint32 { return nil }
 func (a *TAsset) InitTxSize() uint32                { return 100 }
 func (a *TAsset) CheckAddress(string) bool          { return true }
 func (a *TAsset) Run(context.Context)               {}
-func (a *TAsset) CoinIDString(coinID []byte) (string, error) {
-	return "coin", nil
-}
 func (a *TAsset) ValidateCoinID(coinID []byte) error {
 	return nil
 }

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -49,6 +49,9 @@ func (a *TAsset) BlockChannel(size int) chan uint32 { return nil }
 func (a *TAsset) InitTxSize() uint32                { return 100 }
 func (a *TAsset) CheckAddress(string) bool          { return true }
 func (a *TAsset) Run(context.Context)               {}
+func (a *TAsset) CoinIDString(coinID []byte) (string, error) {
+	return "coin", nil
+}
 func (a *TAsset) ValidateCoinID(coinID []byte) error {
 	return nil
 }
@@ -99,10 +102,16 @@ func (ta *TArchivist) failOnCommitWithOrder(ord order.Order) {
 	ta.orderWithKnownCommit = ord.ID()
 	ta.mtx.Unlock()
 }
+func (ta *TArchivist) CompletedUserOrders(aid account.AccountID, N int) (oids []order.OrderID, compTimes []int64, err error) {
+	return nil, nil, nil
+}
+func (ta *TArchivist) ExecutedCancelsForUser(aid account.AccountID, N int) (oids, targets []order.OrderID, execTimes []int64, err error) {
+	return nil, nil, nil, nil
+}
 func (ta *TArchivist) OrderStatus(order.Order) (order.OrderStatus, order.OrderType, int64, error) {
 	return order.OrderStatusUnknown, order.UnknownOrderType, -1, errors.New("boom")
 }
-func (ta *TArchivist) NewEpochOrder(ord order.Order) error {
+func (ta *TArchivist) NewEpochOrder(ord order.Order, epochIdx, epochDur int64) error {
 	ta.mtx.Lock()
 	defer ta.mtx.Unlock()
 	if ta.poisonEpochOrder != nil && ord.ID() == ta.poisonEpochOrder.ID() {
@@ -110,19 +119,24 @@ func (ta *TArchivist) NewEpochOrder(ord order.Order) error {
 	}
 	return nil
 }
+func (ta *TArchivist) StorePreimage(ord order.Order, pi order.Preimage) error { return nil }
 func (ta *TArchivist) failOnEpochOrder(ord order.Order) {
 	ta.mtx.Lock()
 	ta.poisonEpochOrder = ord
 	ta.mtx.Unlock()
 }
-func (ta *TArchivist) BookOrder(*order.LimitOrder) error                      { return nil }
-func (ta *TArchivist) ExecuteOrder(ord order.Order) error                     { return nil }
-func (ta *TArchivist) CancelOrder(*order.LimitOrder) error                    { return nil }
-func (ta *TArchivist) RevokeOrder(*order.LimitOrder) error                    { return nil }
-func (ta *TArchivist) FailCancelOrder(*order.CancelOrder) error               { return nil }
-func (ta *TArchivist) UpdateOrderFilled(order.Order) error                    { return nil }
-func (ta *TArchivist) UpdateOrderStatus(order.Order, order.OrderStatus) error { return nil }
-func (ta *TArchivist) InsertMatch(match *order.Match) error                   { return nil }
+func (ta *TArchivist) InsertEpoch(ed *db.EpochResults) error { return nil }
+func (ta *TArchivist) BookOrder(*order.LimitOrder) error     { return nil }
+func (ta *TArchivist) ExecuteOrder(ord order.Order) error    { return nil }
+func (ta *TArchivist) CancelOrder(*order.LimitOrder) error   { return nil }
+func (ta *TArchivist) RevokeOrder(order.Order) (order.OrderID, time.Time, error) {
+	return order.OrderID{}, time.Now(), nil
+}
+func (ta *TArchivist) SetOrderCompleteTime(ord order.Order, compTime int64) error { return nil }
+func (ta *TArchivist) FailCancelOrder(*order.CancelOrder) error                   { return nil }
+func (ta *TArchivist) UpdateOrderFilled(*order.LimitOrder) error                  { return nil }
+func (ta *TArchivist) UpdateOrderStatus(order.Order, order.OrderStatus) error     { return nil }
+func (ta *TArchivist) InsertMatch(match *order.Match) error                       { return nil }
 func (ta *TArchivist) MatchByID(mid order.MatchID, base, quote uint32) (*db.MatchData, error) {
 	return nil, nil
 }
@@ -152,13 +166,16 @@ func (ta *TArchivist) SaveAuditAckSigA(mid db.MarketMatchID, sig []byte) error {
 func (ta *TArchivist) SaveRedeemA(mid db.MarketMatchID, coinID []byte, timestamp int64) error {
 	return nil
 }
-func (ta *TArchivist) SaveRedeemAckSigB(mid db.MarketMatchID, sig []byte) error { return nil }
+func (ta *TArchivist) SaveRedeemAckSigB(mid db.MarketMatchID, sig []byte) error {
+	return nil
+}
 func (ta *TArchivist) SaveRedeemB(mid db.MarketMatchID, coinID []byte, timestamp int64) error {
 	return nil
 }
-func (ta *TArchivist) SaveRedeemAckSigA(mid db.MarketMatchID, sig []byte) error { return nil }
-func (ta *TArchivist) SetMatchInactive(mid db.MarketMatchID) error              { return nil }
-
+func (ta *TArchivist) SaveRedeemAckSigA(mid db.MarketMatchID, sig []byte) error {
+	return nil
+}
+func (ta *TArchivist) SetMatchInactive(mid db.MarketMatchID) error  { return nil }
 func (ta *TArchivist) CloseAccount(account.AccountID, account.Rule) {}
 func (ta *TArchivist) Account(account.AccountID) (acct *account.Account, paid, open bool) {
 	return nil, false, false
@@ -941,20 +958,21 @@ func TestMarket_Cancelable(t *testing.T) {
 }
 
 func TestMarket_handlePreimageResp(t *testing.T) {
-
-	randomPreimage := func() (pi order.Preimage) {
-		rand.Read(pi[:])
-		return
-	}
-
 	randomCommit := func() (com order.Commitment) {
 		rand.Read(com[:])
 		return
 	}
 
+	newOrder := func() (*order.LimitOrder, order.Preimage) {
+		qty := uint64(dcrLotSize * 10)
+		rate := uint64(1000) * dcrRateStep
+		return makeLORevealed(seller3, rate, qty, order.StandingTiF)
+	}
+
 	authMgr := &TAuth{}
 	mkt := &Market{
-		auth: authMgr,
+		auth:    authMgr,
+		storage: &TArchivist{},
 	}
 
 	piMsg := &msgjson.PreimageResponse{
@@ -976,7 +994,8 @@ func TestMarket_handlePreimageResp(t *testing.T) {
 
 	// 1. bad Message.Type: RPCParseError
 	msg.Type = msgjson.Request // should be Response
-	dat := &piData{preimage: make(chan *order.Preimage)}
+	lo, pi := newOrder()
+	dat := &piData{lo, make(chan *order.Preimage)}
 	piRes := runAndReceive(msg, dat)
 	if piRes != nil {
 		t.Errorf("Expected <nil> preimage, got %v", piRes)
@@ -1002,7 +1021,8 @@ func TestMarket_handlePreimageResp(t *testing.T) {
 
 	// 2. empty preimage from client: InvalidPreimage
 	msg, _ = msgjson.NewResponse(5, piMsg, nil)
-	dat = &piData{preimage: make(chan *order.Preimage)}
+	//lo, pi := newOrder()
+	dat = &piData{lo, make(chan *order.Preimage)}
 	piRes = runAndReceive(msg, dat)
 	if piRes != nil {
 		t.Errorf("Expected <nil> preimage, got %v", piRes)
@@ -1025,9 +1045,10 @@ func TestMarket_handlePreimageResp(t *testing.T) {
 	}
 
 	// 3. correct preimage length, commitment mismatch
-	pi := randomPreimage()
+	//lo, pi := newOrder()
+	lo.Commit = randomCommit() // break the commitment
 	dat = &piData{
-		commit:   randomCommit(), // instead of pi.Commit()
+		ord:      lo,
 		preimage: make(chan *order.Preimage),
 	}
 	piMsg = &msgjson.PreimageResponse{
@@ -1058,8 +1079,9 @@ func TestMarket_handlePreimageResp(t *testing.T) {
 	}
 
 	// 4. correct preimage and commit
+	lo.Commit = pi.Commit() // fix the commitment
 	dat = &piData{
-		commit:   pi.Commit(),
+		ord:      lo,
 		preimage: make(chan *order.Preimage),
 	}
 	piMsg = &msgjson.PreimageResponse{
@@ -1082,7 +1104,7 @@ func TestMarket_handlePreimageResp(t *testing.T) {
 	// 5. payload is not msgjson.PreimageResponse, unmarshal still succeeds, but PI is nil
 	notaPiMsg := new(msgjson.OrderBookSubscription)
 	msg, _ = msgjson.NewResponse(5, notaPiMsg, nil)
-	dat = &piData{preimage: make(chan *order.Preimage)}
+	dat = &piData{lo, make(chan *order.Preimage)}
 	piRes = runAndReceive(msg, dat)
 	if piRes != nil {
 		t.Errorf("Expected <nil> preimage, got %v", piRes)
@@ -1107,7 +1129,7 @@ func TestMarket_handlePreimageResp(t *testing.T) {
 	// 6. payload unmarshal error
 	msg, _ = msgjson.NewResponse(5, piMsg, nil)
 	msg.Payload = json.RawMessage(`{"result":1}`) // ResponsePayload with invalid Result
-	dat = &piData{preimage: make(chan *order.Preimage)}
+	dat = &piData{lo, make(chan *order.Preimage)}
 	piRes = runAndReceive(msg, dat)
 	if piRes != nil {
 		t.Errorf("Expected <nil> preimage, got %v", piRes)

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -306,8 +306,8 @@ func (b *TBackend) addUTXO(coin *msgjson.Coin, val uint64) {
 	b.utxos[hex.EncodeToString(coin.ID)] = val
 }
 func (b *TBackend) Run(context.Context) {}
-func (b *TBackend) ValidateCoinID(coinID []byte) error {
-	return nil
+func (b *TBackend) ValidateCoinID(coinID []byte) (string, error) {
+	return "", nil
 }
 func (b *TBackend) ValidateContract(contract []byte) error {
 	return nil

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -206,6 +206,9 @@ func (a *TAuth) Penalize(user account.AccountID, rule account.Rule) {
 	log.Infof("Penalize for user %v", user)
 }
 
+func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time)        {}
+func (a *TAuth) RecordCancel(account.AccountID, order.OrderID, order.OrderID, time.Time) {}
+
 type TMarketTunnel struct {
 	adds       []*orderRecord
 	auth       *TAuth
@@ -303,6 +306,9 @@ func (b *TBackend) addUTXO(coin *msgjson.Coin, val uint64) {
 	b.utxos[hex.EncodeToString(coin.ID)] = val
 }
 func (b *TBackend) Run(context.Context) {}
+func (b *TBackend) CoinIDString(coinID []byte) (string, error) {
+	return "coin", nil
+}
 func (b *TBackend) ValidateCoinID(coinID []byte) error {
 	return nil
 }
@@ -328,6 +334,7 @@ func (u *tUTXO) Address() string                 { return "" }
 func (u *tUTXO) SpendSize() uint32               { return dummySize }
 func (u *tUTXO) ID() []byte                      { return nil }
 func (u *tUTXO) TxID() string                    { return "" }
+func (u *tUTXO) String() string                  { return "" }
 func (u *tUTXO) SpendsCoin([]byte) (bool, error) { return true, nil }
 func (u *tUTXO) Value() uint64                   { return u.val }
 func (u *tUTXO) FeeRate() uint64                 { return 0 }
@@ -1361,7 +1368,7 @@ func TestRouter(t *testing.T) {
 		break
 	}
 
-	lo.Filled = mkt2.LotSize
+	lo.FillAmt = mkt2.LotSize
 	sig = &bookUpdateSignal{
 		action: bookAction,
 		order:  lo,

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -306,9 +306,6 @@ func (b *TBackend) addUTXO(coin *msgjson.Coin, val uint64) {
 	b.utxos[hex.EncodeToString(coin.ID)] = val
 }
 func (b *TBackend) Run(context.Context) {}
-func (b *TBackend) CoinIDString(coinID []byte) (string, error) {
-	return "coin", nil
-}
 func (b *TBackend) ValidateCoinID(coinID []byte) error {
 	return nil
 }

--- a/server/matcher/match.go
+++ b/server/matcher/match.go
@@ -351,7 +351,7 @@ func matchMarketSellOrder(book Booker, ord *order.MarketOrder) (matchSet *order.
 	// immediate and no minimum rate (a rate of 0).
 	limOrd := &order.LimitOrder{
 		P:     ord.P,
-		T:     ord.T,
+		T:     *ord.T.Copy(),
 		Force: order.ImmediateTiF,
 		Rate:  0,
 	}

--- a/server/matcher/match.go
+++ b/server/matcher/match.go
@@ -88,19 +88,71 @@ type OrderRevealed struct {
 	Preimage order.Preimage
 }
 
+// OrdersUpdated represents the orders updated by (*Matcher).Match, and may
+// include orders from both the epoch queue and the book. Trade orders that are
+// not in TradesFailed may appear in multiple other trade order slices, so
+// update them in sequence: booked, partial, and finally completed or canceled.
+// Orders in TradesFailed will not be in another slice since failed indicates
+// unmatched&unbooked or bad lot size. Cancel orders may only be in one of
+// CancelsExecuted or CancelsFailed.
+type OrdersUpdated struct {
+	// CancelsExecuted are cancel orders that were matched to and removed
+	// another order from the book.
+	CancelsExecuted []*order.CancelOrder
+	// CancelsFailed are cancel orders that failed to match and cancel an order.
+	CancelsFailed []*order.CancelOrder
+
+	// TradesFailed are unmatched and unbooked (i.e. unmatched market or limit
+	// with immediate time-in-force), or orders with bad lot size. These orders
+	// will be in no other slice.
+	TradesFailed []order.Order
+
+	// TradesBooked are limit orders from the epoch queue that were put on the
+	// book. Because of downstream epoch processing, these may also be in
+	// TradesPartial, and TradesCompleted or TradesCanceled.
+	TradesBooked []*order.LimitOrder
+	// TradesPartial are limit orders that were partially filled as maker orders
+	// (while on the book). Epoch orders that were partially filled prior to
+	// being booked (while takers) are not necessarily in TradesPartial unless
+	// they are filled again by a taker. This is because all status updates also
+	// update the filled amount.
+	TradesPartial []*order.LimitOrder
+	// TradesCanceled are limit orders that were removed from the the book by a
+	// cancel order. These may also be in TradesBooked and TradesPartial, but
+	// not TradesCompleted.
+	TradesCanceled []*order.LimitOrder
+	// TradesCompleted are market or limit orders that filled to completion. For
+	// a market order, this means it had a match that partially or completely
+	// filled it. For a limit order, this means the time-in-force is immediate
+	// with at least one match for any amount, or the time-in-force is standing
+	// and it is completely filled.
+	TradesCompleted []order.Order
+}
+
+func (ou *OrdersUpdated) String() string {
+	return fmt.Sprintf("cExec=%d, cFail=%d, tPartial=%d, tBooked=%d, tCanceled=%d, tComp=%d, tFail=%d",
+		len(ou.CancelsExecuted), len(ou.CancelsFailed), len(ou.TradesPartial), len(ou.TradesBooked),
+		len(ou.TradesCanceled), len(ou.TradesCompleted), len(ou.TradesFailed))
+}
+
 // Match matches orders given a standing order book and an epoch queue. Matched
 // orders from the book are removed from the book. The EpochID of the MatchSet
 // is not set. passed = booked + doneOK. queue = passed + failed. unbooked may
 // include orders that are not in the queue. Each of partial are in passed.
-func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, matches []*order.MatchSet, passed, failed, doneOK, partial, booked []*OrderRevealed, unbooked []*order.LimitOrder) {
+//
+// TODO: Eliminate order slice return args in favor of just the *OrdersUpdated.
+func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, matches []*order.MatchSet, passed, failed, doneOK, partial, booked []*OrderRevealed, unbooked []*order.LimitOrder, updates *OrdersUpdated) {
 	// Apply the deterministic pseudorandom shuffling.
 	seed = shuffleQueue(queue)
+
+	updates = new(OrdersUpdated)
 
 	// For each order in the queue, find the best match in the book.
 	for _, q := range queue {
 		if !orderLotSizeOK(q.Order, book.LotSize()) {
 			log.Warnf("Order with bad lot size in the queue: %v!", q.Order.ID())
 			failed = append(failed, q)
+			updates.TradesFailed = append(updates.TradesFailed, q.Order)
 			continue
 		}
 
@@ -112,11 +164,14 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 				log.Debugf("Failed to remove order %v set by a cancel order %v",
 					o.ID(), o.TargetOrderID)
 				failed = append(failed, q)
+				updates.CancelsFailed = append(updates.CancelsFailed, o)
 				continue
 			}
 
 			passed = append(passed, q)
 			doneOK = append(doneOK, q)
+			updates.CancelsExecuted = append(updates.CancelsExecuted, o)
+
 			// CancelOrder Match has zero values for Amounts, Rates, and Total.
 			matches = append(matches, &order.MatchSet{
 				Taker:   q.Order,
@@ -125,6 +180,7 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 				Rates:   []uint64{removed.Rate},
 			})
 			unbooked = append(unbooked, removed)
+			updates.TradesCanceled = append(updates.TradesCanceled, removed)
 
 		case *order.LimitOrder:
 			// limit-limit order matching
@@ -136,6 +192,7 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 			} else if o.Force == order.ImmediateTiF {
 				// There was no match and TiF is Immediate. Fail.
 				failed = append(failed, q)
+				updates.TradesFailed = append(updates.TradesFailed, o)
 				break
 			}
 
@@ -146,24 +203,32 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 			for _, maker := range makers {
 				if maker.Remaining() == 0 {
 					unbooked = append(unbooked, maker)
+					updates.TradesCompleted = append(updates.TradesCompleted, maker)
+				} else {
+					updates.TradesPartial = append(updates.TradesPartial, maker)
 				}
 			}
 
 			var wasBooked bool
 			if o.Remaining() > 0 {
-				if matchSet != nil {
+				if o.Filled() > 0 {
 					partial = append(partial, q)
 				}
 				if o.Force == order.StandingTiF {
 					// Standing TiF orders go on the book.
 					book.Insert(o)
 					booked = append(booked, q)
+					updates.TradesBooked = append(updates.TradesBooked, o)
 					wasBooked = true
 				}
 			}
 
-			if !wasBooked {
+			// booked => TradesBooked
+			// !booked => TradesCompleted
+
+			if !wasBooked { // either nothing remaining or immediate force
 				doneOK = append(doneOK, q)
+				updates.TradesCompleted = append(updates.TradesCompleted, o)
 			}
 
 		case *order.MarketOrder:
@@ -180,15 +245,20 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 				matches = append(matches, matchSet)
 				passed = append(passed, q)
 				doneOK = append(doneOK, q)
+				updates.TradesCompleted = append(updates.TradesCompleted, o)
 			} else {
 				// There was no match and this is a market order. Fail.
 				failed = append(failed, q)
+				updates.TradesFailed = append(updates.TradesFailed, o)
 				break
 			}
 
 			for _, maker := range matchSet.Makers {
 				if maker.Remaining() == 0 {
 					unbooked = append(unbooked, maker)
+					updates.TradesCompleted = append(updates.TradesCompleted, maker)
+				} else {
+					updates.TradesPartial = append(updates.TradesPartial, maker)
 				}
 			}
 
@@ -202,7 +272,7 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 
 // limit-limit order matching
 func matchLimitOrder(book Booker, ord *order.LimitOrder) (matchSet *order.MatchSet) {
-	amtRemaining := ord.Remaining() // i.e. ord.Quantity - ord.Filled
+	amtRemaining := ord.Remaining() // i.e. ord.Quantity - ord.FillAmt
 	if amtRemaining == 0 {
 		return
 	}
@@ -245,11 +315,11 @@ func matchLimitOrder(book Booker, ord *order.LimitOrder) (matchSet *order.MatchS
 				log.Errorf("Failed to remove standing order %v.", best)
 			}
 		}
-		best.Filled += amt
+		best.AddFill(amt)
 
 		// Reduce the remaining quantity of the taker order.
 		amtRemaining -= amt
-		ord.Filled += amt
+		ord.AddFill(amt)
 
 		// Add the matched maker order to the output.
 		if matchSet == nil {
@@ -303,7 +373,7 @@ func matchMarketBuyOrder(book Booker, ord *order.MarketOrder) (matchSet *order.M
 	lotSize := book.LotSize()
 
 	// Amount remaining for market buy is in *quoute* asset, not base asset.
-	amtRemaining := ord.Remaining() // i.e. ord.Quantity - ord.Filled
+	amtRemaining := ord.Remaining() // i.e. ord.Quantity - ord.FillAmt
 	if amtRemaining == 0 {
 		return
 	}
@@ -339,14 +409,14 @@ func matchMarketBuyOrder(book Booker, ord *order.MarketOrder) (matchSet *order.M
 				log.Errorf("Failed to remove standing order %v.", best)
 			}
 		}
-		best.Filled += amt
+		best.AddFill(amt)
 
 		// Reduce the remaining quantity of the taker order.
 		// amtRemainingBase -= amt // FYI
 		amtQuote := BaseToQuote(best.Rate, amt)
 		//amtQuote := uint64(float64(amt) * best.Rate)
 		amtRemaining -= amtQuote // quote asset remaining
-		ord.Filled += amtQuote   // quote asset filled
+		ord.AddFill(amtQuote)    // quote asset filled
 
 		// Add the matched maker order to the output.
 		if matchSet == nil {

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1319,7 +1319,7 @@ func (s *Swapper) handleInit(user account.AccountID, msg *msgjson.Message) *msgj
 	}
 
 	// Validate the coinID and contract script before starting a coinWaiter.
-	err = stepInfo.asset.Backend.ValidateCoinID(params.CoinID)
+	coinStr, err := stepInfo.asset.Backend.ValidateCoinID(params.CoinID)
 	if err != nil {
 		// TODO: ensure Backends provide sanitized errors or type information to
 		// provide more details to the client.
@@ -1330,6 +1330,7 @@ func (s *Swapper) handleInit(user account.AccountID, msg *msgjson.Message) *msgj
 	}
 	err = stepInfo.asset.Backend.ValidateContract(params.Contract)
 	if err != nil {
+		log.Debugf("ValidateContract (asset %v, coin %v) failure: %v", stepInfo.asset.Symbol, coinStr, err)
 		// TODO: ensure Backends provide sanitized errors or type information to
 		// provide more details to the client.
 		return &msgjson.Error{
@@ -1380,7 +1381,7 @@ func (s *Swapper) handleRedeem(user account.AccountID, msg *msgjson.Message) *ms
 	// Validate the redeem coin ID before starting a coinWaiter. This does not
 	// check the blockchain, but does ensure the CoinID can be decoded for the
 	// asset before starting up a coin Waiter.
-	err = stepInfo.asset.Backend.ValidateCoinID(params.CoinID)
+	_, err = stepInfo.asset.Backend.ValidateCoinID(params.CoinID)
 	if err != nil {
 		// TODO: ensure Backends provide sanitized errors or type information to
 		// provide more details to the client.

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -1155,23 +1155,23 @@ func TestSwaps(t *testing.T) {
 		}
 		t.Run("perfect limit-limit match"+sellStr, func(t *testing.T) {
 			rig.matches = tPerfectLimitLimit(uint64(1e8), uint64(1e8), makerSell)
-			rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet})
+			rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet}, nil)
 			testSwap(t, rig)
 		})
 		t.Run("perfect limit-market match"+sellStr, func(t *testing.T) {
 			rig.matches = tPerfectLimitMarket(uint64(1e8), uint64(1e8), makerSell)
-			rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet})
+			rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet}, nil)
 			testSwap(t, rig)
 		})
 		t.Run("imperfect limit-market match"+sellStr, func(t *testing.T) {
 			// only requirement is that maker val > taker val.
 			rig.matches = tMarketPair(uint64(10e8), uint64(2e8), uint64(5e8), makerSell)
-			rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet})
+			rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet}, nil)
 			testSwap(t, rig)
 		})
 		t.Run("imperfect limit-limit match"+sellStr, func(t *testing.T) {
 			rig.matches = tLimitPair(uint64(10e8), uint64(2e8), uint64(2e8), uint64(5e8), uint64(5e8), makerSell)
-			rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet})
+			rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet}, nil)
 			testSwap(t, rig)
 		})
 		for _, isMarket := range []bool{true, false} {
@@ -1183,7 +1183,7 @@ func TestSwaps(t *testing.T) {
 				matchQtys := []uint64{uint64(1e8), uint64(9e8), uint64(3e8)}
 				rates := []uint64{uint64(10e8), uint64(11e8), uint64(12e8)}
 				rig.matches = tMultiMatchSet(matchQtys, rates, makerSell, isMarket)
-				rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet})
+				rig.swapper.Negotiate([]*order.MatchSet{rig.matches.matchSet}, nil)
 				testSwap(t, rig)
 			})
 		}
@@ -1195,7 +1195,7 @@ func TestNoAck(t *testing.T) {
 	matchInfo := set.matchInfos[0]
 	rig, cleanup := tNewTestRig(matchInfo)
 	defer cleanup()
-	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet})
+	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet}, nil)
 	ensureNilErr := makeEnsureNilErr(t)
 	mustBeError := makeMustBeError(t)
 	maker, taker := matchInfo.maker, matchInfo.taker
@@ -1253,7 +1253,7 @@ func TestTxWaiters(t *testing.T) {
 	matchInfo := set.matchInfos[0]
 	rig, cleanup := tNewTestRig(matchInfo)
 	defer cleanup()
-	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet})
+	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet}, nil)
 	ensureNilErr := makeEnsureNilErr(t)
 	dummyError := fmt.Errorf("test error")
 
@@ -1423,7 +1423,7 @@ func TestBroadcastTimeouts(t *testing.T) {
 		set := tPerfectLimitLimit(uint64(1e8), uint64(1e8), true)
 		matchInfo := set.matchInfos[0]
 		rig.matchInfo = matchInfo
-		rig.swapper.Negotiate([]*order.MatchSet{set.matchSet})
+		rig.swapper.Negotiate([]*order.MatchSet{set.matchSet}, nil)
 		// Step through the negotiation process. No errors should be generated.
 		ensureNilErr(rig.ackMatch_maker(true))
 		ensureNilErr(rig.ackMatch_taker(true))
@@ -1478,7 +1478,7 @@ func TestSigErrors(t *testing.T) {
 	matchInfo := set.matchInfos[0]
 	rig, cleanup := tNewTestRig(matchInfo)
 	defer cleanup()
-	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet})
+	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet}, nil)
 	ensureNilErr := makeEnsureNilErr(t)
 	// checkResp makes sure that the specified user has a signature error response
 	// from the swapper.
@@ -1533,7 +1533,7 @@ func TestMalformedSwap(t *testing.T) {
 	matchInfo := set.matchInfos[0]
 	rig, cleanup := tNewTestRig(matchInfo)
 	defer cleanup()
-	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet})
+	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet}, nil)
 	ensureNilErr := makeEnsureNilErr(t)
 	checkContractErr := rpcErrorChecker(t, rig, msgjson.ContractError)
 
@@ -1558,7 +1558,7 @@ func TestBadParams(t *testing.T) {
 	matchInfo := set.matchInfos[0]
 	rig, cleanup := tNewTestRig(matchInfo)
 	defer cleanup()
-	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet})
+	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet}, nil)
 	swapper := rig.swapper
 	match := rig.getTracker()
 	user := matchInfo.maker
@@ -1599,7 +1599,7 @@ func TestCancel(t *testing.T) {
 	matchInfo := set.matchInfos[0]
 	rig, cleanup := tNewTestRig(matchInfo)
 	defer cleanup()
-	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet})
+	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet}, nil)
 	// There should be no matchTracker
 	if rig.getTracker() != nil {
 		t.Fatalf("found matchTracker for a cancellation")
@@ -1638,7 +1638,7 @@ func TestTxMonitored(t *testing.T) {
 	matchInfo := set.matchInfos[0]
 	rig, cleanup := tNewTestRig(matchInfo)
 	defer cleanup()
-	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet})
+	rig.swapper.Negotiate([]*order.MatchSet{set.matchSet}, nil)
 	ensureNilErr := makeEnsureNilErr(t)
 	maker, taker := matchInfo.maker, matchInfo.taker
 

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -289,8 +289,8 @@ func (a *TAsset) Redemption(redemptionID, contractID []byte) (asset.Coin, error)
 	defer a.mtx.RUnlock()
 	return a.redemption, a.redemptionErr
 }
-func (a *TAsset) ValidateCoinID(coinID []byte) error {
-	return nil
+func (a *TAsset) ValidateCoinID(coinID []byte) (string, error) {
+	return "", nil
 }
 func (a *TAsset) ValidateContract(contract []byte) error {
 	return nil

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -289,9 +289,6 @@ func (a *TAsset) Redemption(redemptionID, contractID []byte) (asset.Coin, error)
 	defer a.mtx.RUnlock()
 	return a.redemption, a.redemptionErr
 }
-func (a *TAsset) CoinIDString(coinID []byte) (string, error) {
-	return "coin", nil
-}
 func (a *TAsset) ValidateCoinID(coinID []byte) error {
 	return nil
 }


### PR DESCRIPTION
This implements cancellation ratio computation:
- When a user connects and successfully authenticates, the DB is queried for latest completed orders, cancels, and revokes (a server-initiated cancel).
- Once connected, completed orders and cancels are recorded when they happen.

Ratio *enforcement* is not implemented in this work since there are a number of complex issues to address, including if penalization should involve a short delay in case latest order updates are recorded out of sequence, and how new users will be treated in this scheme.

auth: `clientInfo` is updated with field `recentOrders *latestOrders`, which
tracks a user's latest completed and cancelled orders via the new
`RecordCompletedOrder` and `RecordCancel` methods.
`latestOrders` manages a list of the latest orders for a user. Its purpose
is to track cancellation frequency.  Orders are added with `add`, and total
and cancel counts are obtained with `count`.

Add `ordsByTimeThenID`, which implements `sort.Interface`, for sorting
an `ord` slice in ascending order by time and then order ID. This puts the
oldest order at the front and latest at the back of the slice. `ordsByTimeThenID`
is used for verifying sorts in the tests, but also drives the (commented)
`addSimple` method that is kept for reference.

swap: use `RecordCompletedOrder` when **redeem acks** are received, and
`RevokeOrder` then `RecordCancel` on inaction for one of the users in a match.

market: use `RecordCancel` immediately after matching.

dcrdex: cancelthresh is a config param

server/db:
- The orders tables now store a **completion time, which presently corresponds
  to the time at which the final swap involving the order is completed in terms
  of the match/swap negotiation steps required of the owning user**.
- Create an epochs table with csum, seed, etc. and **match_time, which is used
  as the execution time of user-created cancels that were matched and removed
  an order from the book**. The epochs table also stores slices of order IDs with
  revealed preimages and order IDs with no preimage revealed (misses).
- The orders tables now also store the preimage, which is updated on receipt, and
  the epoch idx and epoch dur, which are included in the initial  call to
  `StoreOrder`/`NewEpochOrder` when the order is entered into the table.
- `RevokeOrder` creates a server-generated cancel order in status
  `pg.orderStatusRevoked` with a random unused commitment and no preimage.