### PR TITLE
client/db: add account backup and restore. 

### DIFF
--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -566,7 +566,7 @@ type timedBalance struct {
 // serialize serializes the timedBalance to a versioned blob.
 func (tb *timedBalance) serialize() []byte {
 	return encode.BuildyBytes{0}.
-		AddData(uint64Bytes(uint64(tb.time.Unix()))).
+		AddData(uint64Bytes(encode.UnixMilliU(tb.time))).
 		AddData(uint64Bytes(tb.balance))
 }
 
@@ -583,7 +583,7 @@ func decodeTimedBalance(b []byte) (*timedBalance, error) {
 		return nil, fmt.Errorf("decodeTimedBalance: expected 2 pushes, got %d", len(pushes))
 	}
 	return &timedBalance{
-		time:    time.Unix(int64(intCoder.Uint64(pushes[0])), 0),
+		time:    encode.DecodeUTime(pushes[0]),
 		balance: intCoder.Uint64(pushes[1]),
 	}, nil
 }

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/db"
-	"decred.org/dcrdex/dex/encode"
 	ordertest "decred.org/dcrdex/dex/order/test"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 )
@@ -37,7 +36,7 @@ func RandomWallet() *db.Wallet {
 		Account:   ordertest.RandomAddress(),
 		INIPath:   ordertest.RandomAddress(),
 		Balance:   rand.Uint64(),
-		BalUpdate: encode.UnixTimeMilli(encode.UnixMilli(time.Now())),
+		BalUpdate: time.Now().Truncate(time.Millisecond).UTC(),
 		Address:   ordertest.RandomAddress(),
 	}
 }

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/db"
+	"decred.org/dcrdex/dex/encode"
 	ordertest "decred.org/dcrdex/dex/order/test"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 )
@@ -36,7 +37,7 @@ func RandomWallet() *db.Wallet {
 		Account:   ordertest.RandomAddress(),
 		INIPath:   ordertest.RandomAddress(),
 		Balance:   rand.Uint64(),
-		BalUpdate: time.Unix(int64(rand.Uint64()), 0),
+		BalUpdate: encode.UnixTimeMilli(encode.UnixMilli(time.Now())),
 		Address:   ordertest.RandomAddress(),
 	}
 }


### PR DESCRIPTION
This adds `AccountBackup` type for backup and restore functionality for user accounts.

`RandomWallet` has also been updated to use the current time for balance update times to fix an issue with `TestWallets`.

Resolves #179.