### PR TITLE
client/rpcserver: Add wallet routes

### DIFF
--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -311,8 +311,9 @@ Returns:
 		`Connect to a new wallet.
 
 Args:
-    assetID (int): The assets's BIP ID, 42 for dcr or 0 for btc.
-    account (string): The account name.
+    assetID (int): The asset's BIP-44 registered coin index. e.g. 42 for DCR.
+      See https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+    account (string): The account or wallet name, depending on wallet software.
     inipath (string): The location of the wallet's config file.
     walletPass (string): The wallet's password.
     appPass (string): The dex client password.
@@ -324,7 +325,8 @@ Returns:
 		`Open an existing wallet.
 
 Args:
-    assetID (int): The asset's SLIP-0044 ID, 42 for dcr or 0 for btc.
+    assetID (int): The asset's BIP-44 registered coin index. e.g. 42 for DCR.
+      See https://github.com/satoshilabs/slips/blob/master/slip-0044.md
     appPass (string): The DEX client password.
 
 Returns:
@@ -334,7 +336,8 @@ Returns:
 		`Close an open wallet.
 
 Args:
-    assetID (int): The asset's SLIP-0044 ID. 42 for dcr or 0 for btc.
+    assetID (int): The asset's BIP-44 registered coin index. e.g. 42 for DCR.
+      See https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 
 Returns:
     string: The message "` + fmt.Sprintf(walletLockedStr, "[coin symbol]") + `"`,
@@ -347,11 +350,11 @@ Returns:
     [
       {
         "symbol" (string): The coin symbol.
-        "assetID" (int): The coin SLIP-0044 number.
+        "assetID" (int): The asset's BIP-44 registered coin index. e.g. 42 for DCR.
+          See https://github.com/satoshilabs/slips/blob/master/slip-0044.md
         "open" (bool): Whether the wallet is unlocked.
         "running" (bool): Whether the wallet is running.
-	"updated" (int): Unix time of last balance update. Seconds since
-	    00:00:00 Jan 1 1970.
+        "updated" (int): Unix time of last balance update. Seconds since 00:00:00 Jan 1 1970.
         "balance" (int): The wallet balance.
         "address" (string): A wallet address.
         "feerate" (int): The fee rate.

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"decred.org/dcrdex/client/core"
 	"decred.org/dcrdex/dex/msgjson"
 )
 
@@ -194,5 +195,188 @@ func TestHandlePreRegister(t *testing.T) {
 		if test.wantErrCode == -1 && res.Fee != test.preRegisterFee {
 			t.Fatalf("wanted registration fee %d but got %d for test %s", test.preRegisterFee, res.Fee, test.name)
 		}
+	}
+}
+
+func TestHandleInit(t *testing.T) {
+	tests := []struct {
+		name                string
+		arg                 interface{}
+		initializeClientErr error
+		wantErrCode         int
+	}{{
+		name:        "ok",
+		arg:         "password123",
+		wantErrCode: -1,
+	}, {
+		name:        "argument wrong type",
+		arg:         2,
+		wantErrCode: msgjson.RPCParseError,
+	}, {
+		name:                "core.InitializeClient error",
+		arg:                 "password123",
+		initializeClientErr: errors.New("error"),
+		wantErrCode:         msgjson.RPCErrorUnspecified,
+	}}
+	for _, test := range tests {
+		msg := new(msgjson.Message)
+		reqPayload, err := json.Marshal(test.arg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg.Payload = reqPayload
+		tc := &TCore{initializeClientErr: test.initializeClientErr}
+		r := &RPCServer{core: tc}
+		payload := handleInit(r, msg)
+		res := ""
+		if err := verifyResponse(payload, &res, test.wantErrCode); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestHandleNewWallet(t *testing.T) {
+	tests := []struct {
+		name            string
+		arg             interface{}
+		walletState     *core.WalletState
+		createWalletErr error
+		openWalletErr   error
+		wantErrCode     int
+		wantIsLocked    bool
+		wantIsNew       bool
+	}{{
+		name:        "ok new wallet",
+		arg:         &newWalletForm{AssetID: uint32(42), Account: "default", INIPath: "/home/wallet.conf", WalletPass: "password123", AppPass: "password123"},
+		wantErrCode: -1,
+		wantIsNew:   true,
+	}, {
+		name:         "ok existing wallet",
+		arg:          &newWalletForm{AssetID: uint32(42), Account: "default", INIPath: "/home/wallet.conf", WalletPass: "password123", AppPass: "password123"},
+		walletState:  &core.WalletState{Open: false},
+		wantErrCode:  -1,
+		wantIsLocked: true,
+	}, {
+		name:        "argument wrong type",
+		arg:         42,
+		wantErrCode: msgjson.RPCParseError,
+	}, {
+		name:            "core.CreateWallet error",
+		arg:             &newWalletForm{AssetID: uint32(42), Account: "default", INIPath: "/home/wallet.conf", WalletPass: "password123", AppPass: "password123"},
+		createWalletErr: errors.New("error"),
+		wantErrCode:     msgjson.RPCErrorUnspecified,
+	}, {
+		name:          "core.OpenWallet error",
+		arg:           &newWalletForm{AssetID: uint32(42), Account: "default", INIPath: "/home/wallet.conf", WalletPass: "password123", AppPass: "password123"},
+		openWalletErr: errors.New("error"),
+		wantErrCode:   msgjson.RPCErrorUnspecified,
+	}}
+	for _, test := range tests {
+		msg := new(msgjson.Message)
+		reqPayload, err := json.Marshal(test.arg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg.Payload = reqPayload
+		tc := &TCore{walletState: test.walletState, createWalletErr: test.createWalletErr, openWalletErr: test.openWalletErr}
+		r := &RPCServer{core: tc}
+		payload := handleNewWallet(r, msg)
+		res := new(newWalletResponse)
+		if err := verifyResponse(payload, res, test.wantErrCode); err != nil {
+			t.Fatal(err)
+		}
+		if test.wantErrCode == -1 {
+			if res.IsLocked != test.wantIsLocked {
+				t.Fatalf("wanted isLocked %v but got %v for test %s", test.wantIsLocked, res.IsLocked, test.name)
+			}
+			if res.IsNew != test.wantIsNew {
+				t.Fatalf("wanted isNew %v but got %v for test %s", test.wantIsNew, res.IsNew, test.name)
+			}
+		}
+	}
+}
+
+func TestHandleOpenWallet(t *testing.T) {
+	tests := []struct {
+		name          string
+		arg           interface{}
+		openWalletErr error
+		wantErrCode   int
+	}{{
+		name:        "ok",
+		arg:         &openWalletForm{AssetID: uint32(42), AppPass: "password123"},
+		wantErrCode: -1,
+	}, {
+		name:        "argument wrong type",
+		arg:         42,
+		wantErrCode: msgjson.RPCParseError,
+	}, {
+		name:          "core.OpenWallet error",
+		arg:           &openWalletForm{AssetID: uint32(42), AppPass: "password123"},
+		openWalletErr: errors.New("error"),
+		wantErrCode:   msgjson.RPCErrorUnspecified,
+	}}
+	for _, test := range tests {
+		msg := new(msgjson.Message)
+		reqPayload, err := json.Marshal(test.arg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg.Payload = reqPayload
+		tc := &TCore{openWalletErr: test.openWalletErr}
+		r := &RPCServer{core: tc}
+		payload := handleOpenWallet(r, msg)
+		res := ""
+		if err := verifyResponse(payload, &res, test.wantErrCode); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestHandleCloseWallet(t *testing.T) {
+	tests := []struct {
+		name           string
+		arg            interface{}
+		closeWalletErr error
+		wantErrCode    int
+	}{{
+		name:        "ok",
+		arg:         42,
+		wantErrCode: -1,
+	}, {
+		name:        "argument wrong type",
+		arg:         "42",
+		wantErrCode: msgjson.RPCParseError,
+	}, {
+		name:           "core.closeWallet error",
+		arg:            42,
+		closeWalletErr: errors.New("error"),
+		wantErrCode:    msgjson.RPCErrorUnspecified,
+	}}
+	for _, test := range tests {
+		msg := new(msgjson.Message)
+		reqPayload, err := json.Marshal(test.arg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg.Payload = reqPayload
+		tc := &TCore{closeWalletErr: test.closeWalletErr}
+		r := &RPCServer{core: tc}
+		payload := handleCloseWallet(r, msg)
+		res := ""
+		if err := verifyResponse(payload, &res, test.wantErrCode); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestHandleWallets(t *testing.T) {
+	msg := new(msgjson.Message)
+	tc := new(TCore)
+	r := &RPCServer{core: tc}
+	payload := handleWallets(r, msg)
+	res := ""
+	if err := verifyResponse(payload, &res, -1); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -45,9 +45,10 @@ func TestCreateResponse(t *testing.T) {
 		resErr:      nil,
 		wantErrCode: -1,
 	}, {
-		name:        "parse error",
-		res:         "",
-		resErr:      msgjson.NewError(msgjson.RPCParseError, "failed to encode response"),
+		name: "parse error",
+		res:  "",
+		resErr: msgjson.NewError(msgjson.RPCParseError,
+			"failed to encode response"),
 		wantErrCode: msgjson.RPCParseError,
 	}}
 
@@ -185,7 +186,10 @@ func TestHandlePreRegister(t *testing.T) {
 			t.Fatal(err)
 		}
 		msg.Payload = reqPayload
-		tc := &TCore{preRegisterFee: test.preRegisterFee, preRegisterErr: test.preRegisterErr}
+		tc := &TCore{
+			preRegisterFee: test.preRegisterFee,
+			preRegisterErr: test.preRegisterErr,
+		}
 		r := &RPCServer{core: tc}
 		payload := handlePreRegister(r, msg)
 		res := new(preRegisterResponse)
@@ -193,7 +197,8 @@ func TestHandlePreRegister(t *testing.T) {
 			t.Fatal(err)
 		}
 		if test.wantErrCode == -1 && res.Fee != test.preRegisterFee {
-			t.Fatalf("wanted registration fee %d but got %d for test %s", test.preRegisterFee, res.Fee, test.name)
+			t.Fatalf("wanted registration fee %d but got %d for test %s",
+				test.preRegisterFee, res.Fee, test.name)
 		}
 	}
 }
@@ -236,6 +241,13 @@ func TestHandleInit(t *testing.T) {
 }
 
 func TestHandleNewWallet(t *testing.T) {
+	nwf := &newWalletForm{
+		AssetID:    uint32(42),
+		Account:    "default",
+		INIPath:    "/home/wallet.conf",
+		WalletPass: "password123",
+		AppPass:    "password123",
+	}
 	tests := []struct {
 		name            string
 		arg             interface{}
@@ -247,12 +259,12 @@ func TestHandleNewWallet(t *testing.T) {
 		wantIsNew       bool
 	}{{
 		name:        "ok new wallet",
-		arg:         &newWalletForm{AssetID: uint32(42), Account: "default", INIPath: "/home/wallet.conf", WalletPass: "password123", AppPass: "password123"},
+		arg:         nwf,
 		wantErrCode: -1,
 		wantIsNew:   true,
 	}, {
 		name:         "ok existing wallet",
-		arg:          &newWalletForm{AssetID: uint32(42), Account: "default", INIPath: "/home/wallet.conf", WalletPass: "password123", AppPass: "password123"},
+		arg:          nwf,
 		walletState:  &core.WalletState{Open: false},
 		wantErrCode:  -1,
 		wantIsLocked: true,
@@ -262,12 +274,12 @@ func TestHandleNewWallet(t *testing.T) {
 		wantErrCode: msgjson.RPCParseError,
 	}, {
 		name:            "core.CreateWallet error",
-		arg:             &newWalletForm{AssetID: uint32(42), Account: "default", INIPath: "/home/wallet.conf", WalletPass: "password123", AppPass: "password123"},
+		arg:             nwf,
 		createWalletErr: errors.New("error"),
 		wantErrCode:     msgjson.RPCErrorUnspecified,
 	}, {
 		name:          "core.OpenWallet error",
-		arg:           &newWalletForm{AssetID: uint32(42), Account: "default", INIPath: "/home/wallet.conf", WalletPass: "password123", AppPass: "password123"},
+		arg:           nwf,
 		openWalletErr: errors.New("error"),
 		wantErrCode:   msgjson.RPCErrorUnspecified,
 	}}
@@ -278,7 +290,11 @@ func TestHandleNewWallet(t *testing.T) {
 			t.Fatal(err)
 		}
 		msg.Payload = reqPayload
-		tc := &TCore{walletState: test.walletState, createWalletErr: test.createWalletErr, openWalletErr: test.openWalletErr}
+		tc := &TCore{
+			walletState:     test.walletState,
+			createWalletErr: test.createWalletErr,
+			openWalletErr:   test.openWalletErr,
+		}
 		r := &RPCServer{core: tc}
 		payload := handleNewWallet(r, msg)
 		res := new(newWalletResponse)
@@ -287,16 +303,22 @@ func TestHandleNewWallet(t *testing.T) {
 		}
 		if test.wantErrCode == -1 {
 			if res.IsLocked != test.wantIsLocked {
-				t.Fatalf("wanted isLocked %v but got %v for test %s", test.wantIsLocked, res.IsLocked, test.name)
+				t.Fatalf("wanted isLocked %v but got %v for test %s",
+					test.wantIsLocked, res.IsLocked, test.name)
 			}
 			if res.IsNew != test.wantIsNew {
-				t.Fatalf("wanted isNew %v but got %v for test %s", test.wantIsNew, res.IsNew, test.name)
+				t.Fatalf("wanted isNew %v but got %v for test %s",
+					test.wantIsNew, res.IsNew, test.name)
 			}
 		}
 	}
 }
 
 func TestHandleOpenWallet(t *testing.T) {
+	owf := &openWalletForm{
+		AssetID: uint32(42),
+		AppPass: "password123",
+	}
 	tests := []struct {
 		name          string
 		arg           interface{}
@@ -304,7 +326,7 @@ func TestHandleOpenWallet(t *testing.T) {
 		wantErrCode   int
 	}{{
 		name:        "ok",
-		arg:         &openWalletForm{AssetID: uint32(42), AppPass: "password123"},
+		arg:         owf,
 		wantErrCode: -1,
 	}, {
 		name:        "argument wrong type",
@@ -312,7 +334,7 @@ func TestHandleOpenWallet(t *testing.T) {
 		wantErrCode: msgjson.RPCParseError,
 	}, {
 		name:          "core.OpenWallet error",
-		arg:           &openWalletForm{AssetID: uint32(42), AppPass: "password123"},
+		arg:           owf,
 		openWalletErr: errors.New("error"),
 		wantErrCode:   msgjson.RPCErrorUnspecified,
 	}}

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -177,7 +177,7 @@ func TestHandlePreRegister(t *testing.T) {
 		arg:            "dex",
 		preRegisterFee: 5,
 		preRegisterErr: errors.New("error"),
-		wantErrCode:    msgjson.RPCErrorUnspecified,
+		wantErrCode:    msgjson.RPCPreRegisterError,
 	}}
 	for _, test := range tests {
 		msg := new(msgjson.Message)
@@ -221,7 +221,7 @@ func TestHandleInit(t *testing.T) {
 		name:                "core.InitializeClient error",
 		arg:                 "password123",
 		initializeClientErr: errors.New("error"),
-		wantErrCode:         msgjson.RPCErrorUnspecified,
+		wantErrCode:         msgjson.RPCInitError,
 	}}
 	for _, test := range tests {
 		msg := new(msgjson.Message)
@@ -255,19 +255,15 @@ func TestHandleNewWallet(t *testing.T) {
 		createWalletErr error
 		openWalletErr   error
 		wantErrCode     int
-		wantIsLocked    bool
-		wantIsNew       bool
 	}{{
 		name:        "ok new wallet",
 		arg:         nwf,
 		wantErrCode: -1,
-		wantIsNew:   true,
 	}, {
-		name:         "ok existing wallet",
-		arg:          nwf,
-		walletState:  &core.WalletState{Open: false},
-		wantErrCode:  -1,
-		wantIsLocked: true,
+		name:        "ok existing wallet",
+		arg:         nwf,
+		walletState: &core.WalletState{Open: false},
+		wantErrCode: msgjson.RPCWalletExistsError,
 	}, {
 		name:        "argument wrong type",
 		arg:         42,
@@ -276,12 +272,12 @@ func TestHandleNewWallet(t *testing.T) {
 		name:            "core.CreateWallet error",
 		arg:             nwf,
 		createWalletErr: errors.New("error"),
-		wantErrCode:     msgjson.RPCErrorUnspecified,
+		wantErrCode:     msgjson.RPCCreateWalletError,
 	}, {
 		name:          "core.OpenWallet error",
 		arg:           nwf,
 		openWalletErr: errors.New("error"),
-		wantErrCode:   msgjson.RPCErrorUnspecified,
+		wantErrCode:   msgjson.RPCOpenWalletError,
 	}}
 	for _, test := range tests {
 		msg := new(msgjson.Message)
@@ -297,19 +293,9 @@ func TestHandleNewWallet(t *testing.T) {
 		}
 		r := &RPCServer{core: tc}
 		payload := handleNewWallet(r, msg)
-		res := new(newWalletResponse)
-		if err := verifyResponse(payload, res, test.wantErrCode); err != nil {
+		res := ""
+		if err := verifyResponse(payload, &res, test.wantErrCode); err != nil {
 			t.Fatal(err)
-		}
-		if test.wantErrCode == -1 {
-			if res.IsLocked != test.wantIsLocked {
-				t.Fatalf("wanted isLocked %v but got %v for test %s",
-					test.wantIsLocked, res.IsLocked, test.name)
-			}
-			if res.IsNew != test.wantIsNew {
-				t.Fatalf("wanted isNew %v but got %v for test %s",
-					test.wantIsNew, res.IsNew, test.name)
-			}
 		}
 	}
 }
@@ -336,7 +322,7 @@ func TestHandleOpenWallet(t *testing.T) {
 		name:          "core.OpenWallet error",
 		arg:           owf,
 		openWalletErr: errors.New("error"),
-		wantErrCode:   msgjson.RPCErrorUnspecified,
+		wantErrCode:   msgjson.RPCOpenWalletError,
 	}}
 	for _, test := range tests {
 		msg := new(msgjson.Message)
@@ -373,7 +359,7 @@ func TestHandleCloseWallet(t *testing.T) {
 		name:           "core.closeWallet error",
 		arg:            42,
 		closeWalletErr: errors.New("error"),
-		wantErrCode:    msgjson.RPCErrorUnspecified,
+		wantErrCode:    msgjson.RPCCloseWalletError,
 	}}
 	for _, test := range tests {
 		msg := new(msgjson.Message)

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -51,7 +51,13 @@ type ClientCore interface {
 	Book(dex string, base, quote uint32) (orderBook *core.OrderBook)
 	PreRegister(dexURL string) (fee uint64, err error)
 	Sync(dex string, base, quote uint32) (updateChan chan *core.BookUpdate, err error)
+	CloseWallet(assetID uint32) error
+	CreateWallet(appPass, walletPass string, form *core.WalletForm) error
+	InitializeClient(appPass string) error
+	OpenWallet(assetID uint32, pw string) error
 	Unsync(dex string, base, quote uint32)
+	WalletState(assetID uint32) (walletState *core.WalletState)
+	Wallets() (walletsStates []*core.WalletState)
 }
 
 // marketSyncer is used to synchronize market subscriptions. The marketSyncer

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -36,10 +36,16 @@ var (
 )
 
 type TCore struct {
-	preRegisterFee uint64
-	preRegisterErr error
-	balanceErr     error
-	syncErr        error
+	preRegisterFee      uint64
+	preRegisterErr      error
+	balanceErr          error
+	syncErr             error
+	createWalletErr     error
+	openWalletErr       error
+	walletState         *core.WalletState
+	closeWalletErr      error
+	wallets             []*core.WalletState
+	initializeClientErr error
 }
 
 func (c *TCore) Sync(dex string, base, quote uint32) (chan *core.BookUpdate, error) {
@@ -49,6 +55,14 @@ func (c *TCore) Book(dex string, base, quote uint32) *core.OrderBook { return ni
 func (c *TCore) Unsync(dex string, base, quote uint32)               {}
 func (c *TCore) Balance(uint32) (uint64, error)                      { return 0, c.balanceErr }
 func (c *TCore) PreRegister(string) (uint64, error)                  { return c.preRegisterFee, c.preRegisterErr }
+func (c *TCore) CreateWallet(appPW, walletPW string, form *core.WalletForm) error {
+	return c.createWalletErr
+}
+func (c *TCore) OpenWallet(assetID uint32, pw string) error   { return c.openWalletErr }
+func (c *TCore) WalletState(assetID uint32) *core.WalletState { return c.walletState }
+func (c *TCore) CloseWallet(assetID uint32) error             { return c.closeWalletErr }
+func (c *TCore) Wallets() []*core.WalletState                 { return c.wallets }
+func (c *TCore) InitializeClient(pw string) error             { return c.initializeClientErr }
 
 type TWriter struct {
 	b []byte

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -51,18 +51,34 @@ type TCore struct {
 func (c *TCore) Sync(dex string, base, quote uint32) (chan *core.BookUpdate, error) {
 	return nil, c.syncErr
 }
-func (c *TCore) Book(dex string, base, quote uint32) *core.OrderBook { return nil }
-func (c *TCore) Unsync(dex string, base, quote uint32)               {}
-func (c *TCore) Balance(uint32) (uint64, error)                      { return 0, c.balanceErr }
-func (c *TCore) PreRegister(string) (uint64, error)                  { return c.preRegisterFee, c.preRegisterErr }
+func (c *TCore) Book(dex string, base, quote uint32) *core.OrderBook {
+	return nil
+}
+func (c *TCore) Unsync(dex string, base, quote uint32) {}
+func (c *TCore) Balance(uint32) (uint64, error) {
+	return 0, c.balanceErr
+}
+func (c *TCore) PreRegister(string) (uint64, error) {
+	return c.preRegisterFee, c.preRegisterErr
+}
 func (c *TCore) CreateWallet(appPW, walletPW string, form *core.WalletForm) error {
 	return c.createWalletErr
 }
-func (c *TCore) OpenWallet(assetID uint32, pw string) error   { return c.openWalletErr }
-func (c *TCore) WalletState(assetID uint32) *core.WalletState { return c.walletState }
-func (c *TCore) CloseWallet(assetID uint32) error             { return c.closeWalletErr }
-func (c *TCore) Wallets() []*core.WalletState                 { return c.wallets }
-func (c *TCore) InitializeClient(pw string) error             { return c.initializeClientErr }
+func (c *TCore) OpenWallet(assetID uint32, pw string) error {
+	return c.openWalletErr
+}
+func (c *TCore) WalletState(assetID uint32) *core.WalletState {
+	return c.walletState
+}
+func (c *TCore) CloseWallet(assetID uint32) error {
+	return c.closeWalletErr
+}
+func (c *TCore) Wallets() []*core.WalletState {
+	return c.wallets
+}
+func (c *TCore) InitializeClient(pw string) error {
+	return c.initializeClientErr
+}
 
 type TWriter struct {
 	b []byte
@@ -110,7 +126,8 @@ type TConn struct {
 	close     chan struct{} // Close tells ReadMessage to return with error
 }
 
-var readTimeout = 10 * time.Second // ReadMessage must not return constantly with nothing
+// ReadMessage must not return constantly with nothing
+var readTimeout = 10 * time.Second
 
 func (c *TConn) ReadMessage() (int, []byte, error) {
 	if len(c.reads) > 0 {
@@ -170,7 +187,8 @@ type tLink struct {
 
 func newLink() *tLink {
 	conn := new(TConn)
-	cl := newWSClient("", conn, func(*msgjson.Message) *msgjson.Error { return nil })
+	cl := newWSClient("", conn,
+		func(*msgjson.Message) *msgjson.Error { return nil })
 	return &tLink{
 		cl:   cl,
 		conn: conn,
@@ -179,7 +197,8 @@ func newLink() *tLink {
 
 var tPort = 5555
 
-func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, *TCore, func()) {
+func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer,
+	*TCore, func()) {
 	c := &TCore{}
 	var shutdown func()
 	ctx, killCtx := context.WithCancel(tCtx)
@@ -190,7 +209,8 @@ func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, *TCore
 	cert, key := tmp+"/cert.cert", tmp+"/key.key"
 	defer os.Remove(cert)
 	defer os.Remove(key)
-	cfg := &Config{c, fmt.Sprintf("localhost:%d", tPort), user, pass, cert, key}
+	cfg := &Config{c, fmt.Sprintf("localhost:%d", tPort), user, pass, cert,
+		key}
 	s, err := New(cfg)
 	if err != nil {
 		t.Fatalf("error creating server: %v", err)
@@ -209,7 +229,9 @@ func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, *TCore
 	return s, c, shutdown
 }
 
-func ensureResponse(t *testing.T, s *RPCServer, f func(w http.ResponseWriter, r *http.Request), want string, reader *TReader, writer *TWriter, body interface{}) {
+func ensureResponse(t *testing.T, s *RPCServer, f func(w http.ResponseWriter,
+	r *http.Request), want string, reader *TReader, writer *TWriter,
+	body interface{}) {
 	reader.msg, _ = json.Marshal(body)
 	req, err := http.NewRequest("POST", "/", reader)
 	if err != nil {
@@ -253,8 +275,8 @@ func TestLoadMarket(t *testing.T) {
 	}
 
 	ensureWatching := func(base, quote uint32) {
-		// Add a tiny delay here because because it's convenient and this function
-		// is typically called right after ...
+		// Add a tiny delay here because because it's convenient and
+		// this function is typically called right after ...
 
 		time.Sleep(time.Millisecond)
 		mktID := marketID(base, quote)
@@ -291,7 +313,8 @@ func TestLoadMarket(t *testing.T) {
 			t.Fatalf("%s: no error", name)
 		}
 		if wantCode != got.Code {
-			t.Fatalf("%s, wanted %d, got %d", name, wantCode, got.Code)
+			t.Fatalf("%s, wanted %d, got %d",
+				name, wantCode, got.Code)
 		}
 	}
 
@@ -328,7 +351,8 @@ func TestLoadMarket(t *testing.T) {
 	for _, syncer := range s.syncers {
 		syncer.mtx.Lock()
 		if len(syncer.clients) != 0 {
-			t.Fatalf("Syncer for market %d-%d still has %d clients after unMarket", syncer.base, syncer.quote, len(syncer.clients))
+			t.Fatalf("Syncer for market %d-%d still has %d clients after unMarket",
+				syncer.base, syncer.quote, len(syncer.clients))
 		}
 		syncer.mtx.Unlock()
 	}
@@ -352,7 +376,8 @@ func TestHandleMessage(t *testing.T) {
 			t.Fatalf("%s: no error", name)
 		}
 		if wantCode != got.Code {
-			t.Fatalf("%s, wanted %d, got %d", name, wantCode, got.Code)
+			t.Fatalf("%s, wanted %d, got %d",
+				name, wantCode, got.Code)
 		}
 	}
 
@@ -371,7 +396,8 @@ func TestHandleMessage(t *testing.T) {
 
 	rpcErr := s.handleMessage(link.cl, msg)
 	if rpcErr != nil {
-		t.Fatalf("error for good message: %d: %s", rpcErr.Code, rpcErr.Message)
+		t.Fatalf("error for good message: %d: %s",
+			rpcErr.Code, rpcErr.Message)
 	}
 }
 
@@ -400,7 +426,8 @@ func TestParseHTTPRequest(t *testing.T) {
 		w := &tResponseWriter{}
 		s.handleJSON(w, r)
 		if w.code != wantCode {
-			t.Fatalf("Expected HTTP error %d, got %d", wantCode, w.code)
+			t.Fatalf("Expected HTTP error %d, got %d",
+				wantCode, w.code)
 		}
 	}
 
@@ -422,7 +449,8 @@ func TestParseHTTPRequest(t *testing.T) {
 			t.Fatalf("%s: no error", name)
 		}
 		if wantCode != payload.Error.Code {
-			t.Fatalf("%s, wanted %d, got %d", name, wantCode, payload.Error.Code)
+			t.Fatalf("%s, wanted %d, got %d",
+				name, wantCode, payload.Error.Code)
 		}
 	}
 	ensureNoErr := func(name string) {
@@ -480,7 +508,8 @@ func TestNew(t *testing.T) {
 	authTests := [][]string{
 		{"user", "pass", "AK+rg3mIGeouojwZwNRMjBjZouASr4mu4FWMTXQQcD0="},
 		{"", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},
-		{`&!"#$%&'()~=`, `+<>*?,:.;/][{}`, "Te4g4+Ke9Q07MYo3iT1OCqq5qXX2ZcB47FBiVaT41hQ="},
+		{`&!"#$%&'()~=`, `+<>*?,:.;/][{}`,
+			"Te4g4+Ke9Q07MYo3iT1OCqq5qXX2ZcB47FBiVaT41hQ="},
 	}
 	for _, test := range authTests {
 		s, _, shutdown := newTServer(t, false, test[0], test[1])
@@ -495,25 +524,29 @@ func TestNew(t *testing.T) {
 func TestAuthMiddleware(t *testing.T) {
 	s, _, shutdown := newTServer(t, false, "", "")
 	defer shutdown()
-	am := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+	am := s.authMiddleware(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
 	r, _ := http.NewRequest("GET", "", nil)
 
 	wantAuthError := func(name string, want bool) {
 		w := &tResponseWriter{}
 		am.ServeHTTP(w, r)
 		if w.code != http.StatusUnauthorized && w.code != http.StatusOK {
-			t.Fatalf("unexpected HTTP error %d for test \"%s\"", w.code, name)
+			t.Fatalf("unexpected HTTP error %d for test \"%s\"",
+				w.code, name)
 		}
 		switch want {
 		case true:
 			if w.code != http.StatusUnauthorized {
-				t.Fatalf("Expected unauthorized HTTP error for test \"%s\"", name)
+				t.Fatalf("Expected unauthorized HTTP error for test \"%s\"",
+					name)
 			}
 		case false:
 			if w.code != http.StatusOK {
-				t.Fatalf("Expected OK HTTP status for test \"%s\"", name)
+				t.Fatalf("Expected OK HTTP status for test \"%s\"",
+					name)
 			}
 		}
 	}
@@ -556,8 +589,8 @@ func TestClientMap(t *testing.T) {
 
 	go s.websocketHandler(conn, "someip")
 
-	// When a response to our dummy message is received, the client should be in
-	// RPCServer's client map.
+	// When a response to our dummy message is received, the client should
+	// be in RPCServer's client map.
 	<-resp
 
 	// While we're here, check that the client is properly mapped.

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -33,12 +33,6 @@ type preRegisterResponse struct {
 	Fee uint64 `json:"fee"`
 }
 
-// newWalletResponse is a response to newWalletRequest.
-type newWalletResponse struct {
-	IsNew    bool `json:"isnew"`
-	IsLocked bool `json:"islocked"`
-}
-
 // openWalletForm is information necessary to open a wallet.
 type openWalletForm struct {
 	AssetID uint32 `json:"assetID"`

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -6,6 +6,7 @@ package rpcserver
 import (
 	"errors"
 	"fmt"
+	"strconv"
 )
 
 var (
@@ -32,6 +33,27 @@ type preRegisterResponse struct {
 	Fee uint64 `json:"fee"`
 }
 
+// newWalletResponse is a response to newWalletRequest.
+type newWalletResponse struct {
+	IsNew    bool `json:"isnew"`
+	IsLocked bool `json:"islocked"`
+}
+
+// openWalletForm is information necessary to open a wallet.
+type openWalletForm struct {
+	AssetID uint32 `json:"assetID"`
+	AppPass string `json:"appPass"`
+}
+
+// newWalletForm is information necessary to create a new wallet.
+type newWalletForm struct {
+	AssetID    uint32 `json:"assetID"`
+	Account    string `json:"account"`
+	INIPath    string `json:"inipath"`
+	WalletPass string `json:"walletPass"`
+	AppPass    string `json:"appPass"`
+}
+
 // ParseCmdArgs parses arguments to commands for rpcserver requests.
 func ParseCmdArgs(cmd string, args []string) (interface{}, error) {
 	nArg, exists := nArgs[cmd]
@@ -47,16 +69,28 @@ func ParseCmdArgs(cmd string, args []string) (interface{}, error) {
 // nArgs is a map of routes to the number of arguments accepted. One integer
 // indicates an exact match, two are the min and max.
 var nArgs = map[string][]int{
-	helpRoute:        []int{0, 1},
-	versionRoute:     []int{0},
-	preRegisterRoute: []int{1},
+	helpRoute:        {0, 1},
+	initRoute:        {1},
+	versionRoute:     {0},
+	preRegisterRoute: {1},
+	newWalletRoute:   {5},
+	openWalletRoute:  {2},
+	closeWalletRoute: {1},
+	walletsRoute:     {0},
 }
 
 // parsers is a map of commands to parsing functions.
 var parsers = map[string](func([]string) (interface{}, error)){
 	helpRoute:        parseHelpArgs,
+	initRoute:        func(args []string) (interface{}, error) { return args[0], nil },
 	versionRoute:     func([]string) (interface{}, error) { return nil, nil },
 	preRegisterRoute: func(args []string) (interface{}, error) { return args[0], nil },
+	newWalletRoute:   parseNewWalletArgs,
+	openWalletRoute:  parseOpenWalletArgs,
+	closeWalletRoute: func(args []string) (interface{}, error) {
+		return checkIntArg(args[0], "assetID")
+	},
+	walletsRoute: func([]string) (interface{}, error) { return nil, nil },
 }
 
 func checkNArgs(have int, want []int) error {
@@ -72,9 +106,35 @@ func checkNArgs(have int, want []int) error {
 	return nil
 }
 
+func checkIntArg(arg, name string) (int, error) {
+	i, err := strconv.Atoi(arg)
+	if err != nil {
+		return i, fmt.Errorf("%w, %s must be an integer: %v", ErrArgs, name, err)
+	}
+	return i, nil
+}
+
 func parseHelpArgs(args []string) (interface{}, error) {
 	if len(args) == 0 {
 		return nil, nil
 	}
 	return args[0], nil
+}
+
+func parseNewWalletArgs(args []string) (interface{}, error) {
+	assetID, err := checkIntArg(args[0], "assetID")
+	if err != nil {
+		return nil, err
+	}
+	req := &newWalletForm{AssetID: uint32(assetID), Account: args[1], INIPath: args[2], WalletPass: args[3], AppPass: args[4]}
+	return req, nil
+}
+
+func parseOpenWalletArgs(args []string) (interface{}, error) {
+	assetID, err := checkIntArg(args[0], "assetID")
+	if err != nil {
+		return nil, err
+	}
+	req := &openWalletForm{AssetID: uint32(assetID), AppPass: args[1]}
+	return req, nil
 }

--- a/client/rpcserver/types_test.go
+++ b/client/rpcserver/types_test.go
@@ -4,6 +4,8 @@
 package rpcserver
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -76,6 +78,16 @@ func TestCheckNArgs(t *testing.T) {
 		wantNArgs: []int{2, 4},
 		wantErr:   false,
 	}, {
+		name:      "ok lower",
+		have:      2,
+		wantNArgs: []int{2, 4},
+		wantErr:   false,
+	}, {
+		name:      "ok upper",
+		have:      4,
+		wantNArgs: []int{2, 4},
+		wantErr:   false,
+	}, {
 		name:      "not exact",
 		have:      3,
 		wantNArgs: []int{2},
@@ -113,6 +125,110 @@ func TestParsers(t *testing.T) {
 	for k := range routes {
 		if _, exists := parsers[k]; !exists {
 			t.Fatalf("%v exists in routes but not in parsers", k)
+		}
+	}
+}
+
+func TestParseNewWalletArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr error
+	}{{
+		name: "ok",
+		args: []string{"42", "default", "/home/wallet.conf", "password123", "password123"},
+	}, {
+		name:    "assetID is not int",
+		args:    []string{"42.1", "default", "/home/wallet.conf", "password123", "password123"},
+		wantErr: ErrArgs,
+	}}
+	for _, test := range tests {
+		res, err := parseNewWalletArgs(test.args)
+		if test.wantErr != nil {
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("unexpected error %v for test %s", err, test.name)
+			}
+			continue
+		}
+		nwf, ok := res.(*newWalletForm)
+		if !ok {
+			t.Fatal("result doesn't wrap *newWalletForm")
+		}
+		if fmt.Sprint(nwf.AssetID) != test.args[0] {
+			t.Fatalf("assetID doesn't match")
+		}
+		if nwf.Account != test.args[1] {
+			t.Fatalf("account doesn't match")
+		}
+		if nwf.INIPath != test.args[2] {
+			t.Fatalf("inipath doesn't match")
+		}
+		if nwf.WalletPass != test.args[3] {
+			t.Fatalf("walletPass doesn't match")
+		}
+		if nwf.AppPass != test.args[4] {
+			t.Fatalf("appPass doesn't match")
+		}
+	}
+}
+
+func TestParseOpenWalletArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr error
+	}{{
+		name: "ok",
+		args: []string{"42", "password123"},
+	}, {
+		name:    "assetID is not int",
+		args:    []string{"42.1", "password123"},
+		wantErr: ErrArgs,
+	}}
+	for _, test := range tests {
+		res, err := parseOpenWalletArgs(test.args)
+		if test.wantErr != nil {
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("unexpected error %v for test %s", err, test.name)
+			}
+			continue
+		}
+		owf, ok := res.(*openWalletForm)
+		if !ok {
+			t.Fatal("result doesn't wrap *openWalletForm")
+		}
+		if fmt.Sprint(owf.AssetID) != test.args[0] {
+			t.Fatalf("assetID doesn't match")
+		}
+		if owf.AppPass != test.args[1] {
+			t.Fatalf("appPass doesn't match")
+		}
+	}
+}
+
+func TestCheckIntArg(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		wantErr error
+	}{{
+		name: "ok",
+		arg:  "42",
+	}, {
+		name:    "assetID is not int",
+		arg:     "42.1",
+		wantErr: ErrArgs,
+	}}
+	for _, test := range tests {
+		res, err := checkIntArg(test.arg, "name")
+		if test.wantErr != nil {
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("unexpected error %v for test %s", err, test.name)
+			}
+			continue
+		}
+		if fmt.Sprint(res) != test.arg {
+			t.Fatalf("strings don't match")
 		}
 	}
 }

--- a/client/rpcserver/types_test.go
+++ b/client/rpcserver/types_test.go
@@ -36,15 +36,18 @@ func TestParseCmdArgs(t *testing.T) {
 		res, err := ParseCmdArgs(test.cmd, test.args)
 		if test.wantErr {
 			if err == nil {
-				t.Fatalf("expected error for test %s", test.name)
+				t.Fatalf("expected error for test %s",
+					test.name)
 			}
 			continue
 		}
 		if err != nil {
-			t.Fatalf("unexpected error for test %s: %v", test.name, err)
+			t.Fatalf("unexpected error for test %s: %v",
+				test.name, err)
 		}
 		if res != test.want {
-			t.Fatalf("got %v but want %v for test %s", res, test.want, test.name)
+			t.Fatalf("got %v but want %v for test %s",
+				res, test.want, test.name)
 		}
 	}
 }
@@ -107,12 +110,14 @@ func TestCheckNArgs(t *testing.T) {
 		err := checkNArgs(test.have, test.wantNArgs)
 		if test.wantErr {
 			if err == nil {
-				t.Fatalf("expected error for test %s", test.name)
+				t.Fatalf("expected error for test %s",
+					test.name)
 			}
 			continue
 		}
 		if err != nil {
-			t.Fatalf("unexpected error for test %s: %v", test.name, err)
+			t.Fatalf("unexpected error for test %s: %v",
+				test.name, err)
 		}
 	}
 }
@@ -130,23 +135,33 @@ func TestParsers(t *testing.T) {
 }
 
 func TestParseNewWalletArgs(t *testing.T) {
+	argsWithAssetID := func(id string) []string {
+		return []string{
+			id,
+			"default",
+			"/home/wallet.conf",
+			"password123",
+			"password123",
+		}
+	}
 	tests := []struct {
 		name    string
 		args    []string
 		wantErr error
 	}{{
 		name: "ok",
-		args: []string{"42", "default", "/home/wallet.conf", "password123", "password123"},
+		args: argsWithAssetID("42"),
 	}, {
 		name:    "assetID is not int",
-		args:    []string{"42.1", "default", "/home/wallet.conf", "password123", "password123"},
+		args:    argsWithAssetID("42.1"),
 		wantErr: ErrArgs,
 	}}
 	for _, test := range tests {
 		res, err := parseNewWalletArgs(test.args)
 		if test.wantErr != nil {
 			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s", err, test.name)
+				t.Fatalf("unexpected error %v for test %s",
+					err, test.name)
 			}
 			continue
 		}
@@ -189,7 +204,8 @@ func TestParseOpenWalletArgs(t *testing.T) {
 		res, err := parseOpenWalletArgs(test.args)
 		if test.wantErr != nil {
 			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s", err, test.name)
+				t.Fatalf("unexpected error %v for test %s",
+					err, test.name)
 			}
 			continue
 		}
@@ -223,7 +239,8 @@ func TestCheckIntArg(t *testing.T) {
 		res, err := checkIntArg(test.arg, "name")
 		if test.wantErr != nil {
 			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s", err, test.name)
+				t.Fatalf("unexpected error %v for test %s",
+					err, test.name)
 			}
 			continue
 		}

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -47,6 +47,12 @@ const (
 	PreimageCommitmentMismatch        // 31
 	UnknownMessageType                // 32
 	AccountClosedError                // 33
+	RPCInitError                      // 34
+	RPCCreateWalletError              // 35
+	RPCOpenWalletError                // 36
+	RPCWalletExistsError              // 37
+	RPCCloseWalletError               // 38
+	RPCPreRegisterError               // 39
 )
 
 // Routes are destinations for a "payload" of data. The type of data being


### PR DESCRIPTION
Add init, newwallet, openwallet, and wallets routes.

~Change command arguments to a slice of strings.~ <- Implemented in another pr.