### PR TITLE
server/asset/dcr: verify network of connected node

### DIFF
--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -108,6 +108,26 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (*Bac
 	if err != nil {
 		return nil, err
 	}
+
+	// Ensure the network of the connected node is correct for the expected
+	// dex.Network.
+	net, err := dcr.client.GetCurrentNet()
+	if err != nil {
+		return nil, fmt.Errorf("getcurrentnet failure: %v", err)
+	}
+	var wantCurrencyNet wire.CurrencyNet
+	switch network {
+	case dex.Testnet:
+		wantCurrencyNet = wire.TestNet3
+	case dex.Mainnet:
+		wantCurrencyNet = wire.MainNet
+	case dex.Regtest: // dex.Simnet
+		wantCurrencyNet = wire.SimNet
+	}
+	if net != wantCurrencyNet {
+		return nil, fmt.Errorf("wrong net %v", net.String())
+	}
+
 	err = dcr.client.NotifyBlocks()
 	if err != nil {
 		return nil, fmt.Errorf("error registering for block notifications")


### PR DESCRIPTION
It was previously possible to connect to a node on a network that did not match with the one specified to NewBackend.

Cherry-picked from https://github.com/decred/dcrdex/pull/193