### PR TITLE
dcrdex: enable logging for dex/ws package

### DIFF
--- a/server/cmd/dcrdex/log.go
+++ b/server/cmd/dcrdex/log.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"decred.org/dcrdex/dex/ws"
 	"decred.org/dcrdex/server/auth"
 	"decred.org/dcrdex/server/book"
 	"decred.org/dcrdex/server/coinwaiter"
@@ -64,6 +65,7 @@ var (
 func init() {
 	auth.UseLogger(authLogger)
 	comms.UseLogger(commsLogger)
+	ws.UseLogger(commsLogger)
 	db.UseLogger(dbLogger)
 	dexsrv.UseLogger(dexmanLogger)
 	market.UseLogger(marketLogger)


### PR DESCRIPTION
This configures the package-wide logger for `decred.org/dcrdex/dex/ws` in the `dcrdex` app.  It has been neglected.

Cherry-picked from https://github.com/decred/dcrdex/pull/193