### PR TITLE
core: fix wallet creation sequence

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -538,7 +538,7 @@ func (c *Core) CreateWallet(appPW, walletPW string, form *WalletForm) error {
 	}
 
 	initErr := func(s string, a ...interface{}) error {
-		wallet.connector.Disconnect()
+		wallet.Disconnect()
 		return fmt.Errorf(s, a...)
 	}
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -4,13 +4,11 @@
 package core
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/db"
@@ -96,100 +94,6 @@ type SupportedAsset struct {
 	Symbol string            `json:"symbol"`
 	Wallet *WalletState      `json:"wallet"`
 	Info   *asset.WalletInfo `json:"info"`
-}
-
-// xcWallet is a wallet.
-type xcWallet struct {
-	asset.Wallet
-	connector *dex.ConnectionMaster
-	AssetID   uint32
-	mtx       sync.RWMutex
-	lockTime  time.Time
-	hookedUp  bool
-	balance   uint64
-	balUpdate time.Time
-	encPW     []byte
-	address   string
-}
-
-// Unlock unlocks the wallet.
-func (w *xcWallet) Unlock(pw string, dur time.Duration) error {
-	err := w.Wallet.Unlock(pw, dur)
-	if err != nil {
-		return err
-	}
-	w.mtx.Lock()
-	w.lockTime = time.Now().Add(dur)
-	w.mtx.Unlock()
-	return nil
-}
-
-// lock the wallet, setting the lockTime to the time when the wallet will be
-// locked.
-func (w *xcWallet) lock() error {
-	w.mtx.Lock()
-	w.lockTime = time.Time{}
-	w.mtx.Unlock()
-	return w.Lock()
-}
-
-// unlocked will return true if the lockTime has not passed.
-func (w *xcWallet) unlocked() bool {
-	w.mtx.RLock()
-	defer w.mtx.RUnlock()
-	return w.lockTime.After(time.Now())
-}
-
-// state returns the current WalletState.
-func (w *xcWallet) state() *WalletState {
-	w.mtx.RLock()
-	defer w.mtx.RUnlock()
-	winfo := w.Info()
-	return &WalletState{
-		Symbol:  unbip(w.AssetID),
-		AssetID: w.AssetID,
-		Open:    w.lockTime.After(time.Now()),
-		Running: w.connector.On(),
-		Balance: w.balance,
-		Address: w.address,
-		FeeRate: winfo.FeeRate, // Withdraw fee, not swap.
-		Units:   winfo.Units,
-	}
-}
-
-// setBalance sets the wallet balance.
-func (w *xcWallet) setBalance(bal uint64) {
-	w.mtx.Lock()
-	w.balance = bal
-	w.balUpdate = time.Now()
-	w.mtx.Unlock()
-}
-
-// setAddress sets the wallet's deposit address.
-func (w *xcWallet) setAddress(addr string) {
-	w.mtx.Lock()
-	w.address = addr
-	w.mtx.Unlock()
-}
-
-// connected is true if the wallet has already been connected.
-func (w *xcWallet) connected() bool {
-	w.mtx.RLock()
-	defer w.mtx.RUnlock()
-	return w.hookedUp
-}
-
-// Connect calls the dex.Connector's Connect method and sets the
-// xcWallet.hookedUp flag.
-func (w *xcWallet) Connect(ctx context.Context) error {
-	err := w.connector.Connect(ctx)
-	if err != nil {
-		return err
-	}
-	w.mtx.Lock()
-	w.hookedUp = true
-	w.mtx.Unlock()
-	return nil
 }
 
 // Registration is information necessary to register an account on a DEX.

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -1,0 +1,107 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package core
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/dex"
+)
+
+// xcWallet is a wallet.
+type xcWallet struct {
+	asset.Wallet
+	connector *dex.ConnectionMaster
+	AssetID   uint32
+	mtx       sync.RWMutex
+	lockTime  time.Time
+	hookedUp  bool
+	balance   uint64
+	balUpdate time.Time
+	encPW     []byte
+	address   string
+}
+
+// Unlock unlocks the wallet.
+func (w *xcWallet) Unlock(pw string, dur time.Duration) error {
+	err := w.Wallet.Unlock(pw, dur)
+	if err != nil {
+		return err
+	}
+	w.mtx.Lock()
+	w.lockTime = time.Now().Add(dur)
+	w.mtx.Unlock()
+	return nil
+}
+
+// lock the wallet, setting the lockTime to the time when the wallet will be
+// locked.
+func (w *xcWallet) Lock() error {
+	w.mtx.Lock()
+	w.lockTime = time.Time{}
+	w.mtx.Unlock()
+	return w.Wallet.Lock()
+}
+
+// unlocked will return true if the lockTime has not passed.
+func (w *xcWallet) unlocked() bool {
+	w.mtx.RLock()
+	defer w.mtx.RUnlock()
+	return w.lockTime.After(time.Now())
+}
+
+// state returns the current WalletState.
+func (w *xcWallet) state() *WalletState {
+	w.mtx.RLock()
+	defer w.mtx.RUnlock()
+	winfo := w.Info()
+	return &WalletState{
+		Symbol:  unbip(w.AssetID),
+		AssetID: w.AssetID,
+		Open:    w.lockTime.After(time.Now()),
+		Running: w.connector.On(),
+		Balance: w.balance,
+		Address: w.address,
+		FeeRate: winfo.FeeRate, // Withdraw fee, not swap.
+		Units:   winfo.Units,
+	}
+}
+
+// setBalance sets the wallet balance.
+func (w *xcWallet) setBalance(bal uint64) {
+	w.mtx.Lock()
+	w.balance = bal
+	w.balUpdate = time.Now()
+	w.mtx.Unlock()
+}
+
+// setAddress sets the wallet's deposit address.
+func (w *xcWallet) setAddress(addr string) {
+	w.mtx.Lock()
+	w.address = addr
+	w.mtx.Unlock()
+}
+
+// connected is true if the wallet has already been connected.
+func (w *xcWallet) connected() bool {
+	w.mtx.RLock()
+	defer w.mtx.RUnlock()
+	return w.hookedUp
+}
+
+// Connect calls the dex.Connector's Connect method and sets the
+// xcWallet.hookedUp flag.
+func (w *xcWallet) Connect(ctx context.Context) error {
+	err := w.connector.Connect(ctx)
+	if err != nil {
+		return err
+	}
+	w.mtx.Lock()
+	w.hookedUp = true
+	w.mtx.Unlock()
+	return nil
+}

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -38,8 +38,7 @@ func (w *xcWallet) Unlock(pw string, dur time.Duration) error {
 	return nil
 }
 
-// lock the wallet, setting the lockTime to the time when the wallet will be
-// locked.
+// Lock the wallet. The lockTime is zeroed so that unlocked will return false.
 func (w *xcWallet) Lock() error {
 	w.mtx.Lock()
 	w.lockTime = time.Time{}
@@ -94,7 +93,7 @@ func (w *xcWallet) connected() bool {
 }
 
 // Connect calls the dex.Connector's Connect method and sets the
-// xcWallet.hookedUp flag.
+// xcWallet.hookedUp flag to true.
 func (w *xcWallet) Connect(ctx context.Context) error {
 	err := w.connector.Connect(ctx)
 	if err != nil {
@@ -104,4 +103,13 @@ func (w *xcWallet) Connect(ctx context.Context) error {
 	w.hookedUp = true
 	w.mtx.Unlock()
 	return nil
+}
+
+// Disconnect calls the dex.Connector's Disconnect method and sets the
+// xcWallet.hookedUp flag to false.
+func (w *xcWallet) Disconnect() {
+	w.connector.Disconnect()
+	w.mtx.Lock()
+	w.hookedUp = false
+	w.mtx.Unlock()
 }

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -137,23 +137,6 @@ func (s *WebServer) apiNewWallet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.notifyWalletUpdate(form.AssetID)
-	type response struct {
-		OK     bool   `json:"ok"`
-		Locked bool   `json:"locked"`
-		Msg    string `json:"msg"`
-	}
-	err = s.core.OpenWallet(form.AssetID, form.AppPW)
-	if err != nil {
-		errMsg := fmt.Sprintf("wallet connected, but failed to open with provided password: %v", err)
-		log.Errorf(errMsg)
-		resp := &response{
-			Locked: true,
-			Msg:    errMsg,
-		}
-		writeJSON(w, resp, s.indent)
-		return
-	}
-	s.notifyWalletUpdate(form.AssetID)
 	writeJSON(w, simpleAck(), s.indent)
 }
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -574,10 +574,6 @@ func TestAPINewWallet(t *testing.T) {
 	ensure(`{"ok":false,"msg":"error creating btc wallet: test error"}`)
 	tCore.createWalletErr = nil
 
-	tCore.openWalletErr = tErr
-	ensure(`{"ok":false,"locked":true,"msg":"wallet connected, but failed to open with provided password: test error"}`)
-	tCore.openWalletErr = nil
-
 	tCore.notHas = false
 }
 


### PR DESCRIPTION
Resolves #235

Moves `xcWallet` from *types.go* to *wallet.go*.