### PR TITLE
server/asset: switch to polling for dcr backend block notifications

### DIFF
--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -41,7 +41,7 @@ var (
 	zeroHash chainhash.Hash
 	// The blockPollInterval is the delay between calls to GetBestBlockHash to
 	// check for new blocks.
-	blockPollInterval = time.Second * 5
+	blockPollInterval = time.Second
 )
 
 const (
@@ -80,7 +80,7 @@ type Backend struct {
 	// The backend provides block notification channels through it BlockChannel
 	// method. signalMtx locks the blockChans array.
 	signalMtx   sync.RWMutex
-	blockChans  []chan uint32
+	blockChans  []chan *asset.BlockUpdate
 	chainParams *chaincfg.Params
 	// A logger will be provided by the dex for this backend. All logging should
 	// use the provided logger.
@@ -266,8 +266,8 @@ func (btc *Backend) ValidateContract(contract []byte) error {
 // BlockChannel creates and returns a new channel on which to receive block
 // updates. If the returned channel is ever blocking, there will be no error
 // logged from the btc package. Part of the asset.Backend interface.
-func (btc *Backend) BlockChannel(size int) chan uint32 {
-	c := make(chan uint32, size)
+func (btc *Backend) BlockChannel(size int) <-chan *asset.BlockUpdate {
+	c := make(chan *asset.BlockUpdate, size)
 	btc.signalMtx.Lock()
 	defer btc.signalMtx.Unlock()
 	btc.blockChans = append(btc.blockChans, c)
@@ -291,7 +291,7 @@ func newBTC(name string, chainParams *chaincfg.Params, logger dex.Logger, node b
 	btc := &Backend{
 		name:        name,
 		blockCache:  newBlockCache(),
-		blockChans:  make([]chan uint32, 0),
+		blockChans:  make([]chan *asset.BlockUpdate, 0),
 		chainParams: chainParams,
 		log:         logger,
 		node:        node,
@@ -602,7 +602,7 @@ func (btc *Backend) Run(ctx context.Context) {
 
 	blockPoll := time.NewTicker(blockPollInterval)
 	defer blockPoll.Stop()
-	addBlock := func(block *btcjson.GetBlockVerboseResult) {
+	addBlock := func(block *btcjson.GetBlockVerboseResult, reorg bool) {
 		_, err := btc.blockCache.add(block)
 		if err != nil {
 			btc.log.Errorf("error adding new best block to cache: %v", err)
@@ -612,12 +612,32 @@ func (btc *Backend) Run(ctx context.Context) {
 			len(btc.blockChans), btc.name, block.Height)
 		for _, c := range btc.blockChans {
 			select {
-			case c <- uint32(block.Height):
+			case c <- &asset.BlockUpdate{
+				Err:   nil,
+				Reorg: reorg,
+			}:
 			default:
-				btc.log.Errorf("tried sending block update on blocking channel")
+				btc.log.Errorf("failed to send block update on blocking channel")
 			}
 		}
 		btc.signalMtx.RUnlock()
+	}
+
+	sendErr := func(err error) {
+		btc.log.Error(err)
+		for _, c := range btc.blockChans {
+			select {
+			case c <- &asset.BlockUpdate{
+				Err: err,
+			}:
+			default:
+				btc.log.Errorf("failed to send sending block update on blocking channel")
+			}
+		}
+	}
+
+	sendErrFmt := func(s string, a ...interface{}) {
+		sendErr(fmt.Errorf(s, a...))
 	}
 
 out:
@@ -627,7 +647,7 @@ out:
 			tip := btc.blockCache.tip()
 			bestHash, err := btc.node.GetBestBlockHash()
 			if err != nil {
-				btc.log.Errorf("error retrieving best block: %v", err)
+				sendErr(asset.NewConnectionError("error retrieving best block: %v", err))
 				continue
 			}
 			if *bestHash == tip.hash {
@@ -636,19 +656,19 @@ out:
 			best := bestHash.String()
 			block, err := btc.node.GetBlockVerbose(bestHash)
 			if err != nil {
-				btc.log.Errorf("error retrieving block %s: %v", best, err)
+				sendErrFmt("error retrieving block %s: %v", best, err)
 				continue
 			}
 			// If this doesn't build on the best known block, look for a reorg.
 			prevHash, err := chainhash.NewHashFromStr(block.PreviousHash)
 			if err != nil {
-				btc.log.Errorf("error parsing previous hash %s: %v", block.PreviousHash, err)
+				sendErrFmt("error parsing previous hash %s: %v", block.PreviousHash, err)
 				continue
 			}
 			// If it builds on the best block or the cache is empty, it's good to add.
 			if *prevHash == tip.hash || tip.height == 0 {
 				btc.log.Debugf("Run: Processing new block %s", bestHash)
-				addBlock(block)
+				addBlock(block, false)
 				continue
 			}
 			// It is either a reorg, or the previous block is not the cached
@@ -662,7 +682,7 @@ out:
 				}
 				iBlock, err := btc.node.GetBlockVerbose(iHash)
 				if err != nil {
-					btc.log.Errorf("error retrieving block %s: %v", iHash, err)
+					sendErrFmt("error retrieving block %s: %v", iHash, err)
 					break
 				}
 				if iBlock.Confirmations > -1 {
@@ -675,7 +695,7 @@ out:
 				reorgHeight = iBlock.Height
 				iHash, err = chainhash.NewHashFromStr(iBlock.PreviousHash)
 				if err != nil {
-					btc.log.Errorf("error decoding previous hash %s for block %s: %v",
+					sendErrFmt("error decoding previous hash %s for block %s: %v",
 						iBlock.PreviousHash, iHash.String(), err)
 					// Some blocks on the side chain may not be flagged as
 					// orphaned, but still proceed, flagging the ones we have
@@ -684,13 +704,15 @@ out:
 					break
 				}
 			}
+			var reorg bool
 			if reorgHeight > 0 {
+				reorg = true
 				btc.log.Infof("Reorg from %s (%d) to %s (%d) detected.",
 					tip.hash, tip.height, bestHash, block.Height)
 				btc.blockCache.reorg(reorgHeight)
 			}
 			// Now add the new block.
-			addBlock(block)
+			addBlock(block, reorg)
 		case <-ctx.Done():
 			break out
 		}

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -3,7 +3,11 @@
 
 package asset
 
-import "decred.org/dcrdex/dex"
+import (
+	"fmt"
+
+	"decred.org/dcrdex/dex"
+)
 
 // CoinNotFoundError is to be returned from Contract, Redemption, and
 // FundingCoin when the specified transaction cannot be found. Used by the
@@ -25,7 +29,7 @@ type Backend interface {
 	FundingCoin(coinID []byte, redeemScript []byte) (FundingCoin, error)
 	// BlockChannel creates and returns a new channel on which to receive updates
 	// when new blocks are connected.
-	BlockChannel(size int) chan uint32
+	BlockChannel(size int) <-chan *BlockUpdate
 	// InitTxSize is the size of a serialized atomic swap initialization
 	// transaction with 1 input spending a P2PKH utxo, 1 swap contract output and
 	// 1 change output.
@@ -84,6 +88,21 @@ type Contract interface {
 	FeeRate() uint64
 	// Script is the contract redeem script.
 	Script() []byte
+}
+
+// BlockUpdate is sent over the update channel when a tip change is detected.
+type BlockUpdate struct {
+	Err   error
+	Reorg bool
+}
+
+// ConnectionError error should be sent over the block update channel if a
+// connection error is detected by the Backend.
+type ConnectionError error
+
+// NewConnectionError is a constructor for a ConnectionError.
+func NewConnectionError(s string, a ...interface{}) ConnectionError {
+	return ConnectionError(fmt.Errorf(s, a...))
 }
 
 // BackedAsset is a dex.Asset with a Backend.

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"strings"
 	"sync"
+	"time"
 
 	"decred.org/dcrdex/dex"
 	dexdcr "decred.org/dcrdex/dex/dcr"
@@ -38,7 +39,12 @@ func init() {
 	asset.Register(assetName, &Driver{})
 }
 
-var zeroHash chainhash.Hash
+var (
+	zeroHash chainhash.Hash
+	// The blockPollInterval is the delay between calls to GetBestBlockHash to
+	// check for new blocks.
+	blockPollInterval = time.Second
+)
 
 type Error = dex.Error
 
@@ -55,6 +61,7 @@ type dcrNode interface {
 	GetRawTransactionVerbose(txHash *chainhash.Hash) (*chainjson.TxRawResult, error)
 	GetBlockVerbose(blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error)
 	GetBlockHash(blockHeight int64) (*chainhash.Hash, error)
+	GetBestBlockHash() (*chainhash.Hash, error)
 }
 
 // Backend is an asset backend for Decred. It has methods for fetching UTXO
@@ -71,13 +78,10 @@ type Backend struct {
 	// The backend provides block notification channels through it BlockChannel
 	// method. signalMtx locks the blockChans array.
 	signalMtx  sync.RWMutex
-	blockChans []chan uint32
+	blockChans []chan *asset.BlockUpdate
 	// The block cache stores just enough info about the blocks to prevent future
 	// calls to GetBlockVerbose.
 	blockCache *blockCache
-	// dcrd block and reorganization are synchronized through a general purpose
-	// queue.
-	anyQ chan interface{}
 	// A logger will be provided by the DEX. All logging should use the provided
 	// logger.
 	log dex.Logger
@@ -99,13 +103,10 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (*Bac
 		return nil, err
 	}
 	dcr := unconnectedDCR(logger)
-	notifications := &rpcclient.NotificationHandlers{
-		OnBlockConnected: dcr.onBlockConnected,
-	}
 	// When the exported constructor is used, the node will be an
 	// rpcclient.Client.
 	dcr.client, err = connectNodeRPC(cfg.RPCListen, cfg.RPCUser, cfg.RPCPass,
-		cfg.RPCCert, notifications)
+		cfg.RPCCert)
 	if err != nil {
 		return nil, err
 	}
@@ -129,10 +130,6 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (*Bac
 		return nil, fmt.Errorf("wrong net %v", net.String())
 	}
 
-	err = dcr.client.NotifyBlocks()
-	if err != nil {
-		return nil, fmt.Errorf("error registering for block notifications")
-	}
 	dcr.node = dcr.client
 	// Prime the cache with the best block.
 	bestHash, _, err := dcr.client.GetBestBlock()
@@ -157,8 +154,8 @@ func (btc *Backend) InitTxSize() uint32 {
 // BlockChannel creates and returns a new channel on which to receive block
 // updates. If the returned channel is ever blocking, there will be no error
 // logged from the dcr package. Part of the asset.Backend interface.
-func (dcr *Backend) BlockChannel(size int) chan uint32 {
-	c := make(chan uint32, size)
+func (dcr *Backend) BlockChannel(size int) <-chan *asset.BlockUpdate {
+	c := make(chan *asset.BlockUpdate, size)
 	dcr.signalMtx.Lock()
 	defer dcr.signalMtx.Unlock()
 	dcr.blockChans = append(dcr.blockChans, c)
@@ -372,9 +369,8 @@ func (dcr *Backend) shutdown() {
 // before use.
 func unconnectedDCR(logger dex.Logger) *Backend {
 	return &Backend{
-		blockChans: make([]chan uint32, 0),
+		blockChans: make([]chan *asset.BlockUpdate, 0),
 		blockCache: newBlockCache(logger),
-		anyQ:       make(chan interface{}, 128), // way bigger than needed.
 		log:        logger,
 	}
 }
@@ -384,64 +380,126 @@ func unconnectedDCR(logger dex.Logger) *Backend {
 // then deposit the payload into the anyQ channel.
 func (dcr *Backend) Run(ctx context.Context) {
 	defer dcr.shutdown()
+	blockPoll := time.NewTicker(blockPollInterval)
+	defer blockPoll.Stop()
+	addBlock := func(block *chainjson.GetBlockVerboseResult, reorg bool) {
+		_, err := dcr.blockCache.add(block)
+		if err != nil {
+			dcr.log.Errorf("error adding new best block to cache: %v", err)
+		}
+		dcr.signalMtx.RLock()
+		dcr.log.Debugf("Notifying %d dcr asset consumers of new block at height %d",
+			len(dcr.blockChans), block.Height)
+		for _, c := range dcr.blockChans {
+			select {
+			case c <- &asset.BlockUpdate{
+				Err:   nil,
+				Reorg: reorg,
+			}:
+			default:
+				dcr.log.Errorf("failed to send block update on blocking channel")
+			}
+		}
+		dcr.signalMtx.RUnlock()
+	}
+
+	sendErr := func(err error) {
+		dcr.log.Error(err)
+		for _, c := range dcr.blockChans {
+			select {
+			case c <- &asset.BlockUpdate{
+				Err: err,
+			}:
+			default:
+				dcr.log.Errorf("failed to send sending block update on blocking channel")
+			}
+		}
+	}
+
+	sendErrFmt := func(s string, a ...interface{}) {
+		sendErr(fmt.Errorf(s, a...))
+	}
+
 out:
 	for {
 		select {
-		case rawMsg := <-dcr.anyQ:
-			switch msg := rawMsg.(type) {
-			case *chainhash.Hash:
-				// This is a new block notification.
-				blockHash := msg
-				dcr.log.Debugf("Run: Processing new block %s", blockHash)
-				blockVerbose, err := dcr.node.GetBlockVerbose(blockHash, false)
-				if err != nil {
-					dcr.log.Errorf("onBlockConnected error retrieving block %s: %v", blockHash, err)
-					return
-				}
-				// Check if this forces a reorg.
-				currentTip := int64(dcr.blockCache.tipHeight())
-				if blockVerbose.Height <= currentTip {
-					dcr.blockCache.reorg(blockVerbose)
-				}
-				block, err := dcr.blockCache.add(blockVerbose)
-				if err != nil {
-					dcr.log.Errorf("error adding block to cache")
-				}
-				dcr.signalMtx.RLock()
-				for _, c := range dcr.blockChans {
-					select {
-					case c <- block.height:
-					default:
-						dcr.log.Errorf("tried sending block update on blocking channel")
-					}
-				}
-				dcr.signalMtx.RUnlock()
-			default:
-				dcr.log.Warn("unknown message type in Run: %T", rawMsg)
+
+		case <-blockPoll.C:
+			tip := dcr.blockCache.tip()
+			bestHash, err := dcr.node.GetBestBlockHash()
+			if err != nil {
+				sendErr(asset.NewConnectionError("error retrieving best block: %v", err))
+				continue
 			}
+			if *bestHash == tip.hash {
+				continue
+			}
+
+			best := bestHash.String()
+			block, err := dcr.node.GetBlockVerbose(bestHash, false)
+			if err != nil {
+				sendErrFmt("error retrieving block %s: %v", best, err)
+				continue
+			}
+			// If this doesn't build on the best known block, look for a reorg.
+			prevHash, err := chainhash.NewHashFromStr(block.PreviousHash)
+			if err != nil {
+				sendErrFmt("error parsing previous hash %s: %v", block.PreviousHash, err)
+				continue
+			}
+			// If it builds on the best block or the cache is empty, it's good to add.
+			if *prevHash == tip.hash || tip.height == 0 {
+				dcr.log.Debugf("Run: Processing new block %s", bestHash)
+				addBlock(block, false)
+				continue
+			}
+			// It is either a reorg, or the previous block is not the cached
+			// best block. Crawl blocks backwards until finding a mainchain
+			// block, flagging blocks from the cache as orphans along the way.
+			iHash := &tip.hash
+			reorgHeight := int64(0)
+			for {
+				if *iHash == zeroHash {
+					break
+				}
+				iBlock, err := dcr.node.GetBlockVerbose(iHash, false)
+				if err != nil {
+					sendErrFmt("error retrieving block %s: %v", iHash, err)
+					break
+				}
+				if iBlock.Confirmations > -1 {
+					// This is a mainchain block, nothing to do.
+					break
+				}
+				if iBlock.Height == 0 {
+					break
+				}
+				reorgHeight = iBlock.Height
+				iHash, err = chainhash.NewHashFromStr(iBlock.PreviousHash)
+				if err != nil {
+					sendErrFmt("error decoding previous hash %s for block %s: %v",
+						iBlock.PreviousHash, iHash.String(), err)
+					// Some blocks on the side chain may not be flagged as
+					// orphaned, but still proceed, flagging the ones we have
+					// identified and adding the new best block to the cache and
+					// setting it to the best block in the cache.
+					break
+				}
+			}
+			var reorg bool
+			if reorgHeight > 0 {
+				reorg = true
+				dcr.log.Infof("Reorg from %s (%d) to %s (%d) detected.",
+					tip.hash, tip.height, bestHash, block.Height)
+				dcr.blockCache.reorg(reorgHeight)
+			}
+			// Now add the new block.
+			addBlock(block, reorg)
+
 		case <-ctx.Done():
 			break out
 		}
 	}
-}
-
-// A callback to be registered with dcrd. It is critical that no RPC calls are
-// made from this method. Doing so will likely result in a deadlock, as per
-// https://github.com/decred/dcrd/blob/952bd7bba34c8aeab86f63f9c9f69fc74ff1a7e1/rpcclient/notify.go#L78
-func (dcr *Backend) onBlockConnected(serializedHeader []byte, _ [][]byte) {
-	blockHeader := new(wire.BlockHeader)
-	err := blockHeader.FromBytes(serializedHeader)
-	if err != nil {
-		dcr.log.Errorf("error decoding serialized header: %v", err)
-		return
-	}
-	h := blockHeader.BlockHash()
-	// TODO: Instead of a buffered channel, anyQ, make a queue with a slice so
-	// the buffer size has no role in correctness i.e. the ability of this
-	// function to work when previous blocks require RPC calls to complete their
-	// processing. That is, if the channel buffer is full there is likely to be
-	// deadlock waiting for other RPCs.
-	dcr.anyQ <- &h
 }
 
 // validateTxOut validates an outpoint (txHash:out) by retrieving associated
@@ -677,8 +735,7 @@ func (dcr *Backend) getMainchainDcrBlock(height uint32) (*dcrBlock, error) {
 
 // connectNodeRPC attempts to create a new websocket connection to a dcrd node
 // with the given credentials and notification handlers.
-func connectNodeRPC(host, user, pass, cert string,
-	notifications *rpcclient.NotificationHandlers) (*rpcclient.Client, error) {
+func connectNodeRPC(host, user, pass, cert string) (*rpcclient.Client, error) {
 
 	dcrdCerts, err := ioutil.ReadFile(cert)
 	if err != nil {
@@ -693,7 +750,7 @@ func connectNodeRPC(host, user, pass, cert string,
 		Certificates: dcrdCerts,
 	}
 
-	dcrdClient, err := rpcclient.New(config, notifications)
+	dcrdClient, err := rpcclient.New(config, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to start dcrd RPC client: %v", err)
 	}

--- a/server/asset/dcr/live_test.go
+++ b/server/asset/dcr/live_test.go
@@ -402,20 +402,20 @@ func TestBlockMonitor(t *testing.T) {
 out:
 	for {
 		select {
-		case height := <-blockChan:
-			if height > lastHeight {
-				t.Logf("block received for height %d", height)
-			} else {
-				reorgDepth := lastHeight - height + 1
-				t.Logf("block received for block %d causes a %d block reorg", height, reorgDepth)
+		case update := <-blockChan:
+			if update.Err != nil {
+				t.Fatalf("error encountered while monitoring blocks: %v", update.Err)
 			}
 			tipHeight := dcr.blockCache.tipHeight()
-			if tipHeight != height {
-				t.Fatalf("unexpected height after block notification. expected %d, received %d", height, tipHeight)
+			if update.Reorg {
+				fmt.Printf("block received at height %d causes a %d block reorg\n", tipHeight, lastHeight-tipHeight+1)
+			} else {
+				fmt.Printf("block received for height %d\n", tipHeight)
 			}
-			_, err := dcr.getMainchainDcrBlock(height)
+			lastHeight = tipHeight
+			_, err := dcr.getMainchainDcrBlock(tipHeight)
 			if err != nil {
-				t.Fatalf("error getting newly connected block at height %d", height)
+				t.Fatalf("error getting newly connected block at height %d", tipHeight)
 			}
 		case <-ctx.Done():
 			break out

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -45,10 +45,10 @@ func (a *TAsset) FundingCoin(coinID []byte, redeemScript []byte) (asset.FundingC
 func (a *TAsset) Redemption(redemptionID, contractID []byte) (asset.Coin, error) {
 	return nil, nil
 }
-func (a *TAsset) BlockChannel(size int) chan uint32 { return nil }
-func (a *TAsset) InitTxSize() uint32                { return 100 }
-func (a *TAsset) CheckAddress(string) bool          { return true }
-func (a *TAsset) Run(context.Context)               {}
+func (a *TAsset) BlockChannel(size int) <-chan *asset.BlockUpdate { return nil }
+func (a *TAsset) InitTxSize() uint32                              { return 100 }
+func (a *TAsset) CheckAddress(string) bool                        { return true }
+func (a *TAsset) Run(context.Context)                             {}
 func (a *TAsset) ValidateCoinID(coinID []byte) (string, error) {
 	return "", nil
 }

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -299,9 +299,9 @@ func (b *TBackend) FundingCoin(coinID, redeemScript []byte) (asset.FundingCoin, 
 func (b *TBackend) Redemption(redemptionID, contractID []byte) (asset.Coin, error) {
 	return b.utxo(redemptionID)
 }
-func (b *TBackend) BlockChannel(size int) chan uint32 { return nil }
-func (b *TBackend) InitTxSize() uint32                { return dummySize }
-func (b *TBackend) CheckAddress(string) bool          { return b.addrChecks }
+func (b *TBackend) BlockChannel(size int) <-chan *asset.BlockUpdate { return nil }
+func (b *TBackend) InitTxSize() uint32                              { return dummySize }
+func (b *TBackend) CheckAddress(string) bool                        { return b.addrChecks }
 func (b *TBackend) addUTXO(coin *msgjson.Coin, val uint64) {
 	b.utxos[hex.EncodeToString(coin.ID)] = val
 }


### PR DESCRIPTION
At least resolves (only partially) #115, because connection errors are now communicated.

Adds **server/asset** `BlockUpdate` type that conveys errors and reorgs.