### PR TITLE
db,swap: store the swap secret in the matches table

### DIFF
--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -48,6 +48,7 @@ const (
 
 		-- initiator/A (maker) REDEEM data
 		aRedeemCoinID BYTEA,      -- the input spending the taker's contract output includes the secret
+		aRedeemSecret BYTEA,
 		aRedeemTime INT8,         -- server time stamp
 		bSigAckOfARedeem BYTEA,   -- counterparty's (participant) sig with ack of initiator REDEEM data
 
@@ -60,7 +61,7 @@ const (
 	RetrieveSwapData = `SELECT status, sigMatchAckMaker, sigMatchAckTaker,
 		aContractCoinID, aContract, aContractTime, bSigAckOfAContract,
 		bContractCoinID, bContract, bContractTime, aSigAckOfBContract,
-		aRedeemCoinID, aRedeemTime, bSigAckOfARedeem,
+		aRedeemCoinID, aRedeemSecret, aRedeemTime, bSigAckOfARedeem,
 		bRedeemCoinID, bRedeemTime, aSigAckOfBRedeem
 	FROM %s WHERE matchid = $1;`
 
@@ -113,7 +114,7 @@ const (
 	SetInitiatorContractAuditSig   = `UPDATE %s SET aSigAckOfBContract = $2 WHERE matchid = $1;`
 
 	SetInitiatorRedeemData = `UPDATE %s SET status = $2,
-		aRedeemCoinID = $3, aRedeemTime = $4
+		aRedeemCoinID = $3, aRedeemSecret = $4, aRedeemTime = $5
 	WHERE matchid = $1;`
 	SetParticipantRedeemData = `UPDATE %s SET status = $2,
 		bRedeemCoinID = $3, bRedeemTime = $4

--- a/server/db/driver/pg/matches_online_test.go
+++ b/server/db/driver/pg/matches_online_test.go
@@ -260,8 +260,9 @@ func TestSetSwapData(t *testing.T) {
 
 	// Redeem A
 	redeemCoinIDA := randomBytes(36)
+	secret := randomBytes(72)
 	redeemATime := int64(1234)
-	err = archie.SaveRedeemA(mid, redeemCoinIDA, redeemATime)
+	err = archie.SaveRedeemA(mid, redeemCoinIDA, secret, redeemATime)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -275,6 +276,10 @@ func TestSetSwapData(t *testing.T) {
 	if !bytes.Equal(swapData.RedeemACoinID, redeemCoinIDA) {
 		t.Fatalf("RedeemACoinID incorrect. got %v, expected %v",
 			swapData.RedeemACoinID, redeemCoinIDA)
+	}
+	if !bytes.Equal(swapData.RedeemASecret, secret) {
+		t.Fatalf("RedeemASecret incorrect. got %v, expected %v",
+			swapData.RedeemASecret, secret)
 	}
 	if swapData.RedeemATime != redeemATime {
 		t.Fatalf("RedeemATime incorrect. got %d, expected %d",

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -196,7 +196,7 @@ type MatchData struct {
 type SwapData struct {
 	SigMatchAckMaker []byte
 	SigMatchAckTaker []byte
-	ContractA        []byte
+	ContractA        []byte // contains the secret hash used by both parties
 	ContractACoinID  []byte
 	ContractATime    int64
 	ContractAAckSig  []byte // B's signature of contract A data
@@ -205,6 +205,7 @@ type SwapData struct {
 	ContractBTime    int64
 	ContractBAckSig  []byte // A's signature of contract B data
 	RedeemACoinID    []byte
+	RedeemASecret    []byte // the secret revealed in A's redeem, also used in B's redeem
 	RedeemATime      int64
 	RedeemAAckSig    []byte // B's signature of redeem A data
 	RedeemAAckTime   int64  // time that B's signature of redeem A data was received
@@ -296,7 +297,7 @@ type SwapArchiver interface {
 	// SaveRedeemA records party A's redemption coinID (e.g. transaction
 	// output), which spends party B's swap contract on chain Y. Note that this
 	// transaction will contain the secret, which party B extracts.
-	SaveRedeemA(mid MarketMatchID, coinID []byte, timestamp int64) error
+	SaveRedeemA(mid MarketMatchID, coinID, secret []byte, timestamp int64) error
 
 	// SaveRedeemAckSigB records party B's signature acknowledging party A's
 	// redemption, which spent their swap contract on chain Y and revealed the

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -160,7 +160,7 @@ func (ta *TArchivist) SaveContractB(mid db.MarketMatchID, contract []byte, coinI
 func (ta *TArchivist) SaveAuditAckSigA(mid db.MarketMatchID, sig []byte) error { return nil }
 
 // Redeem data.
-func (ta *TArchivist) SaveRedeemA(mid db.MarketMatchID, coinID []byte, timestamp int64) error {
+func (ta *TArchivist) SaveRedeemA(mid db.MarketMatchID, coinID, secret []byte, timestamp int64) error {
 	return nil
 }
 func (ta *TArchivist) SaveRedeemAckSigB(mid db.MarketMatchID, sig []byte) error {

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -240,7 +240,7 @@ func (s *TStorage) SaveContractB(mid db.MarketMatchID, contract []byte, coinID [
 func (s *TStorage) SaveAuditAckSigA(mid db.MarketMatchID, sig []byte) error { return nil }
 
 // Redeem data.
-func (s *TStorage) SaveRedeemA(mid db.MarketMatchID, coinID []byte, timestamp int64) error {
+func (s *TStorage) SaveRedeemA(mid db.MarketMatchID, coinID, secret []byte, timestamp int64) error {
 	return nil
 }
 func (s *TStorage) SaveRedeemAckSigB(mid db.MarketMatchID, sig []byte) error {


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/216, implements the secret-related spec changes described in https://github.com/decred/dcrdex/pull/209

db: `SaveRedeemA` also stores the swap secret

The secret is also stored in the matches table.

Although the secret is used by both redeem txns, and both are validated,
`SaveRedeemA` stores the secret.  Thus, `SwapData` now includes a
`RedeemASecret` field for the secret since A revealed the secret even if
the server heard about the secret from B's `'redeem'` request first.

pg: refactor swap data storage functions to use the new
`(*Archiver).updateMatchStmt` method which is generalized for any SQL
statement with any number of arguments, expecting to update a single
row of the matches table for a market.

swap: update for SaveRedeemA with the secret input