### PR TITLE
core/webserver: client notification system

### DIFF
--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -1,0 +1,111 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package core
+
+import (
+	"decred.org/dcrdex/client/db"
+	"decred.org/dcrdex/dex"
+)
+
+// notify sends a notification to all subscribers. If the notification is of
+// sufficient severity, it is stored in the database.
+func (c *Core) notify(n Notification) {
+	if n.Severity() >= db.Success {
+		c.db.SaveNotification(n.DBNote())
+	}
+	c.noteMtx.RLock()
+	for _, ch := range c.noteChans {
+		select {
+		case ch <- n:
+		default:
+		}
+	}
+	c.noteMtx.RUnlock()
+}
+
+// NotificationFeed returns a new receiving channel for notifications. The
+// channel has capacity 16, and should be monitored for the lifetime of the
+// Core. Blocking channels are silently ignored.
+func (c *Core) NotificationFeed() <-chan Notification {
+	ch := make(chan Notification, 16)
+	c.noteMtx.Lock()
+	c.noteChans = append(c.noteChans, ch)
+	c.noteMtx.Unlock()
+	return ch
+}
+
+// AckNotes sets the acknowledgement field for the notifications.
+func (c *Core) AckNotes(ids []dex.Bytes) {
+	for _, id := range ids {
+		err := c.db.AckNotification(id)
+		if err != nil {
+			log.Errorf("error saving notification acknowledgement for %s: %v", id, err)
+		}
+	}
+}
+
+// Notification is an interface for a user notification. Notification is
+// satisfied by db.Notification, so concrete types can embed the db type.
+type Notification interface {
+	// Type is a string ID unique to the concrete type.
+	Type() string
+	// Subject is a short description of the notification contents. When displayed
+	// to the user, the Subject will typically be given visual prominence. For
+	// notifications with Severity < Poke (not meant for display), the Subject
+	// field may be repurposed as a second-level category ID.
+	Subject() string
+	// Details should contain more detailed information.
+	Details() string
+	// Severity is the notification severity.
+	Severity() db.Severity
+	// Time is the notification timestamp. The timestamp is set in
+	// db.NewNotification.
+	Time() uint64
+	// Acked is true if the user has seen the notification. Acknowledgement is
+	// recorded with (*Core).AckNotes.
+	Acked() bool
+	// ID should be unique, except in the case of identical copies of
+	// db.Notification where the IDs should be the same.
+	ID() dex.Bytes
+	// Stamp sets the notification timestamp. If db.NewNotification is used to
+	// construct the db.Notification, the timestamp will already be set.
+	Stamp()
+	// DBNote returns the underlying *db.Notification.
+	DBNote() *db.Notification
+}
+
+// FeePaymentNote is a notification regarding registration fee payment.
+type FeePaymentNote struct {
+	db.Notification
+}
+
+func newFeePaymentNote(subject, details string, severity db.Severity) *FeePaymentNote {
+	return &FeePaymentNote{
+		Notification: db.NewNotification("fee payment", subject, details, severity),
+	}
+}
+
+// WithdrawNote is a notification regarding a requested withdraw.
+type WithdrawNote struct {
+	db.Notification
+}
+
+func newWithdrawNote(subject, details string, severity db.Severity) *WithdrawNote {
+	return &WithdrawNote{
+		Notification: db.NewNotification("withdraw", subject, details, severity),
+	}
+}
+
+// OrderNote is a notification about an order or a match.
+type OrderNote struct {
+	db.Notification
+	Order *Order `json:"order"`
+}
+
+func newOrderNote(subject, details string, severity db.Severity, corder *Order) *OrderNote {
+	return &OrderNote{
+		Notification: db.NewNotification("order", subject, details, severity),
+		Order:        corder,
+	}
+}

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -19,6 +19,7 @@ func (c *Core) notify(n Notification) {
 		select {
 		case ch <- n:
 		default:
+			log.Errorf("blocking notification channel")
 		}
 	}
 	c.noteMtx.RUnlock()
@@ -60,7 +61,7 @@ type Notification interface {
 	// Severity is the notification severity.
 	Severity() db.Severity
 	// Time is the notification timestamp. The timestamp is set in
-	// db.NewNotification.
+	// db.NewNotification. Time is a UNIX timestamp, in milliseconds.
 	Time() uint64
 	// Acked is true if the user has seen the notification. Acknowledgement is
 	// recorded with (*Core).AckNotes.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -8,6 +8,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -80,17 +81,18 @@ type trackedTrade struct {
 	latencyQ *wait.TickerQueue
 	wallets  *walletSet
 	preImg   order.Preimage
-	sid      string
+	mktID    string
 	coins    map[string]asset.Coin
 	change   asset.Coin
 	cancel   *trackedCancel
 	matchMtx sync.RWMutex
 	matches  map[order.MatchID]*matchTracker
+	notify   func(Notification)
 }
 
 // newTrackedTrade is a constructor for a trackedTrade.
 func newTrackedTrade(dbOrder *db.MetaOrder, preImg order.Preimage, dc *dexConnection,
-	db db.DB, latencyQ *wait.TickerQueue, wallets *walletSet, coins asset.Coins) *trackedTrade {
+	db db.DB, latencyQ *wait.TickerQueue, wallets *walletSet, coins asset.Coins, notify func(Notification)) *trackedTrade {
 
 	ord := dbOrder.Order
 	return &trackedTrade{
@@ -101,9 +103,10 @@ func newTrackedTrade(dbOrder *db.MetaOrder, preImg order.Preimage, dc *dexConnec
 		latencyQ: latencyQ,
 		wallets:  wallets,
 		preImg:   preImg,
-		sid:      sid(ord.Base(), ord.Quote()),
+		mktID:    mktID(ord.Base(), ord.Quote()),
 		coins:    mapifyCoins(coins),
 		matches:  make(map[order.MatchID]*matchTracker),
+		notify:   notify,
 	}
 }
 
@@ -121,23 +124,37 @@ func (t *trackedTrade) rate() uint64 {
 func (t *trackedTrade) coreOrder() (*Order, *Order) {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
+	t.matchMtx.RLock()
+	defer t.matchMtx.RUnlock()
+	return t.coreOrderInternal()
+}
+
+// coreOrderInternal constructs a *core.Order for the tracked order.Order. If
+// the trade has a cancel order associated with it, the cancel order will be
+// returned, otherwise the second returned *Order will be nil. coreOrderInternal
+// should be called with both the mtx and the matchMtx locked.
+func (t *trackedTrade) coreOrderInternal() (*Order, *Order) {
 	prefix, trade := t.Prefix(), t.Trade()
 	var tif order.TimeInForce
 	if lo, ok := t.Order.(*order.LimitOrder); ok {
 		tif = lo.Force
 	}
+	cancelling := t.cancel != nil
 	coreOrder := &Order{
-		Type:        prefix.OrderType,
-		ID:          t.ID().String(),
-		Stamp:       encode.UnixMilliU(prefix.ServerTime),
-		Rate:        t.rate(),
-		Qty:         trade.Quantity,
-		Sell:        trade.Sell,
-		Filled:      trade.Filled(),
-		Cancelling:  t.cancel != nil,
+		DEX:        t.dc.acct.url,
+		MarketID:   t.mktID,
+		Type:       prefix.OrderType,
+		ID:         t.ID().String(),
+		Stamp:      encode.UnixMilliU(prefix.ServerTime),
+		Rate:       t.rate(),
+		Qty:        trade.Quantity,
+		Sell:       trade.Sell,
+		Filled:     trade.Filled(),
+		Cancelling: cancelling,
+		Canceled:   cancelling && t.cancel.matches.maker != nil,
+
 		TimeInForce: tif,
 	}
-	t.matchMtx.RLock()
 	for _, match := range t.matches {
 		dbMatch := match.Match
 		coreOrder.Matches = append(coreOrder.Matches, &Match{
@@ -147,16 +164,23 @@ func (t *trackedTrade) coreOrder() (*Order, *Order) {
 			Qty:     dbMatch.Quantity,
 		})
 	}
-	t.matchMtx.RUnlock()
 	var cancelOrder *Order
 	if t.cancel != nil {
 		cancelOrder = &Order{
+			DEX:      t.dc.acct.url,
+			MarketID: t.mktID,
 			Type:     order.CancelOrderType,
 			Stamp:    encode.UnixMilliU(t.cancel.ServerTime),
 			TargetID: t.cancel.TargetOrderID.String(),
 		}
 	}
 	return coreOrder, cancelOrder
+}
+
+// token is a shortened representation of the order ID.
+func (t *trackedTrade) token() string {
+	id := t.ID()
+	return hex.EncodeToString(id[:4])
 }
 
 // cancelTrade sets the cancellation data with the order and its preimage.
@@ -178,6 +202,8 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 	defer t.mtx.Unlock()
 
 	// Add the matches to the match map and update the database.
+	trade := t.Trade()
+	var includesCancellation, includesTrades bool
 	for _, msgMatch := range msgMatches {
 		if len(msgMatch.MatchID) != order.MatchIDSize {
 			return fmt.Errorf("match id of incorrect length. expected %d, got %d",
@@ -227,9 +253,11 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		// field being an empty string.
 		isCancel := t.cancel != nil && msgMatch.Address == ""
 		if isCancel {
+			includesCancellation = true
 			log.Infof("maker notification for cancel order received for order %s. match id = %s", oid, msgMatch.MatchID)
 			t.cancel.matches.maker = msgMatch
 		} else {
+			includesTrades = true
 			t.matchMtx.Lock()
 			t.matches[match.id] = match
 			t.matchMtx.Unlock()
@@ -237,7 +265,7 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 	}
 
 	// Calculate the new filled value for the order.
-	isMarketBuy := t.Type() == order.MarketOrderType && !t.Trade().Sell
+	isMarketBuy := t.Type() == order.MarketOrderType && !trade.Sell
 	var filled uint64
 	// If the order has been canceled, add that to the filled.
 	if t.cancel != nil && t.cancel.matches.maker != nil {
@@ -251,10 +279,25 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 			filled += n.Match.Quantity
 		}
 	}
-	t.matchMtx.RUnlock()
 	// The filled amount includes all of the trackedTrade's matches, so the
 	// filled amount must be set, not just increased.
-	t.Trade().SetFill(filled)
+	trade.SetFill(filled)
+	corder, cancelOrder := t.coreOrderInternal()
+	t.matchMtx.RUnlock()
+	// Send notifications. Call coreOrderInternal with the matchMtx locked.
+	if includesCancellation {
+		details := fmt.Sprintf("%s order on %s-%s at %s has been canceled (%s)",
+			strings.Title(sellString(trade.Sell)), unbip(t.Base()), unbip(t.Quote()), t.dc.acct.url, t.token())
+		t.notify(newOrderNote("Order canceled", details, db.Success, corder))
+		// Also send out a data notification with the cancel order information.
+		t.notify(newOrderNote("cancel", "", db.Data, cancelOrder))
+	}
+	if includesTrades {
+		fillRatio := float64(trade.Filled()) / float64(trade.Quantity)
+		details := fmt.Sprintf("%s order on %s-%s %.1f%% filled (%s)",
+			strings.Title(sellString(trade.Sell)), unbip(t.Base()), unbip(t.Quote()), fillRatio*100, t.token())
+		t.notify(newOrderNote("Matches made", details, db.Poke, corder))
+	}
 
 	return t.tick()
 }
@@ -347,31 +390,68 @@ func (t *trackedTrade) tick() error {
 
 	t.matchMtx.Lock()
 	defer t.matchMtx.Unlock()
+	var sent, quoteSent, received, quoteReceived uint64
 	for _, match := range t.matches {
 		if t.isSwappable(match) {
 			swaps = append(swaps, match)
+			sent += match.Match.Quantity
+			quoteSent += calc.BaseToQuote(match.Match.Rate, match.Match.Quantity)
 		} else if t.isRedeemable(match) {
 			redeems = append(redeems, match)
+			received += match.Match.Quantity
+			quoteReceived += calc.BaseToQuote(match.Match.Rate, match.Match.Quantity)
 		}
 	}
 	if len(swaps) > 0 {
-		err := t.swapMatches(swaps)
-		if err != nil {
-			return err
+		fromID := t.wallets.fromAsset.ID
+		qty := sent
+		if !t.Trade().Sell {
+			qty = quoteSent
 		}
+		err := t.swapMatches(swaps)
+		// swapMatches might modify the matches, so don't get the *Order for
+		// notifications before swapMatches.
+		corder, _ := t.coreOrderInternal()
+		if err != nil {
+			details := fmt.Sprintf("Error encountered sending a swap output(s) worth %.8f %s on order %s",
+				float64(qty)/1e8, unbip(fromID), t.token())
+			log.Error(details + " " + err.Error())
+			t.notify(newOrderNote("Swap error", details, db.ErrorLevel, corder))
+			return err
+		} else {
+
+			details := fmt.Sprintf("Sent swaps worth %.8f %s on order %s",
+				float64(qty)/1e8, unbip(fromID), t.token())
+			log.Error(details)
+			t.notify(newOrderNote("Swaps initiated", details, db.Poke, corder))
+		}
+
 	}
 	if len(redeems) > 0 {
+		toAsset := t.wallets.toAsset.ID
+		qty := received
+		if t.Trade().Sell {
+			qty = quoteReceived
+		}
 		err := t.redeemMatches(redeems)
+		corder, _ := t.coreOrderInternal()
 		if err != nil {
+			details := fmt.Sprintf("Error encountered sending redemptions worth %.8f %s on order %s", float64(qty)/1e8, unbip(toAsset), t.token())
+			log.Error(details)
+			t.notify(newOrderNote("Redemption error", details, db.ErrorLevel, corder))
 			return err
+		} else {
+			details := fmt.Sprintf("Redeemed %.8f %s on order %s", float64(qty)/1e8, unbip(toAsset), t.token())
+			log.Error(details)
+			t.notify(newOrderNote("Match complete", details, db.Poke, corder))
 		}
 	}
 	return nil
 }
 
-// swapMatches will send a transaction with swap inputs for the specified
+// swapMatches will send a transaction with swap outputs for the specified
 // matches.
-func (t *trackedTrade) swapMatches(matches []*matchTracker) *errorSet {
+func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 	errs := newErrorSet("swapMatches order %s - ", t.ID())
 	// Prepare the asset.Contracts.
 	swaps := new(asset.Swaps)
@@ -470,12 +550,13 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) *errorSet {
 			match.setStatus(order.MakerSwapCast)
 			proof.MakerSwap = coinID
 		}
+
 	}
 	return errs.ifany()
 }
 
 // redeemMatches will send a transaction redeeming the specified matches.
-func (t *trackedTrade) redeemMatches(matches []*matchTracker) *errorSet {
+func (t *trackedTrade) redeemMatches(matches []*matchTracker) error {
 	errs := newErrorSet("redeemMatches - order %s - ", t.ID())
 	// Collect a asset.Redemption for each match into a slice of redemptions that
 	// will be grouped into a single transaction.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -43,7 +43,7 @@ func (set *errorSet) addErr(err error) *errorSet {
 }
 
 // If any returns the error set if there are any errors, else nil.
-func (set *errorSet) ifany() *errorSet {
+func (set *errorSet) ifany() error {
 	if len(set.errs) > 0 {
 		return set
 	}
@@ -114,6 +114,8 @@ type Match struct {
 // Order is core's general type for an order. An order may be a market, limit,
 // or cancel order. Some fields are only relevant to particular order types.
 type Order struct {
+	DEX         string            `json:"dex"`
+	MarketID    string            `json:"market"`
 	Type        order.OrderType   `json:"type"`
 	ID          string            `json:"id"`
 	Stamp       uint64            `json:"stamp"`
@@ -122,6 +124,7 @@ type Order struct {
 	Filled      uint64            `json:"filled"`
 	Matches     []*Match          `json:"matches"`
 	Cancelling  bool              `json:"cancelling"`
+	Canceled    bool              `json:"canceled"`
 	Rate        uint64            `json:"rate"`               // limit only
 	TimeInForce order.TimeInForce `json:"tif"`                // limit only
 	TargetID    string            `json:"targetID,omitempty"` // cancel only
@@ -145,9 +148,9 @@ func (m *Market) Display() string {
 	return newDisplayIDFromSymbols(m.BaseSymbol, m.QuoteSymbol)
 }
 
-// sid is a simpler string ID constructed from the asset IDs.
-func (m *Market) sid() string {
-	return sid(m.BaseID, m.QuoteID)
+// mktID is a string ID constructed from the asset IDs.
+func (m *Market) mktID() string {
+	return mktID(m.BaseID, m.QuoteID)
 }
 
 // Exchange represents a single DEX with any number of markets.
@@ -346,7 +349,7 @@ type TradeForm struct {
 	TifNow  bool   `json:"tifnow"`
 }
 
-// sid is a string ID constructed from the asset IDs.
-func sid(b, q uint32) string {
+// mktID is a string ID constructed from the asset IDs.
+func mktID(b, q uint32) string {
 	return strconv.Itoa(int(b)) + "-" + strconv.Itoa(int(q))
 }

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -846,7 +846,7 @@ func newTimeIndexNewest(n int) *timeIndexNewest {
 // oldest pair's time.
 func (idx *timeIndexNewest) add(t uint64, k []byte) {
 	count := len(idx.pairs)
-	if idx.cap == 0 || count < idx.cap { // count = 0 always evals true here.
+	if idx.cap == 0 || count < idx.cap {
 		idx.pairs = append(idx.pairs, &keyTimePair{
 			// Need to make a copy, and []byte(k) upsets the linter.
 			k: append([]byte(nil), k...),
@@ -870,8 +870,7 @@ func (idx *timeIndexNewest) add(t uint64, k []byte) {
 
 // timeNow is the current unix timestamp in milliseconds.
 func timeNow() uint64 {
-	t := time.Now()
-	return uint64(t.Unix()*1e3) + uint64(t.Nanosecond())/1e6
+	return encode.UnixMilliU(time.Now())
 }
 
 // A couple of common bbolt functions.

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -69,4 +69,10 @@ type DB interface {
 	Wallets() ([]*Wallet, error)
 	// Backup makes a copy of the database.
 	Backup() error
+	// SaveNotification saves the notification.
+	SaveNotification(*Notification) error
+	// NotificationsN reads out the N most recent notifications.
+	NotificationsN(int) ([]*Notification, error)
+	// AckNotification sets the acknowledgement for a notification.
+	AckNotification(id []byte) error
 }

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -19,6 +19,14 @@ func randomPubKey() *secp256k1.PublicKey {
 	return pub
 }
 
+func randString(maxLen int) string {
+	s := string(randBytes(int(randBytes(1)[0])))
+	if len(s) > maxLen {
+		s = s[:maxLen]
+	}
+	return s
+}
+
 // RandomAccountInfo creates an AccountInfo with random values.
 func RandomAccountInfo() *db.AccountInfo {
 	return &db.AccountInfo{
@@ -105,6 +113,16 @@ func RandomMatchProof(sparsity float64) *db.MatchProof {
 		proof.Auth.RedemptionStamp = rand.Uint64()
 	}
 	return proof
+}
+
+func RandomNotification(maxTime uint64) *db.Notification {
+	return &db.Notification{
+		NoteType:    randString(25),
+		SubjectText: randString(255),
+		DetailText:  randString(255),
+		Severeness:  db.Severity(randBytes(1)[0]),
+		TimeStamp:   uint64(rand.Int63n(int64(maxTime))),
+	}
 }
 
 type testKiller interface {
@@ -225,5 +243,26 @@ func MustCompareWallets(t testKiller, w1, w2 *db.Wallet) {
 	}
 	if !bytes.Equal(w1.EncryptedPW, w2.EncryptedPW) {
 		t.Fatalf("EncryptedPW mismatch. %x != %x", w1.EncryptedPW, w2.EncryptedPW)
+	}
+}
+
+func MustCompareNotifications(t testKiller, n1, n2 *db.Notification) {
+	if n1.NoteType != n2.NoteType {
+		t.Fatalf("NoteType mismatch. %s != %s", n1.NoteType, n2.NoteType)
+	}
+	if n1.SubjectText != n2.SubjectText {
+		t.Fatalf("SubjectText mismatch. %s != %s", n1.SubjectText, n2.SubjectText)
+	}
+	if n1.DetailText != n2.DetailText {
+		t.Fatalf("DetailText mismatch. %s != %s", n1.DetailText, n2.DetailText)
+	}
+	if n1.Severeness != n2.Severeness {
+		t.Fatalf("Severeness mismatch. %d != %d", n1.Severeness, n2.Severeness)
+	}
+	if n1.TimeStamp != n2.TimeStamp {
+		t.Fatalf("TimeStamp mismatch. %d != %d", n1.TimeStamp, n2.TimeStamp)
+	}
+	if n1.ID().String() != n2.ID().String() {
+		t.Fatalf("ID mismatch. %s != %s", n1.ID(), n2.ID())
 	}
 }

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/client/core"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
@@ -211,14 +212,12 @@ func (c *TCore) InitializeClient(pw string) error {
 }
 func (c *TCore) PreRegister(dex string) (uint64, error) { return 1e8, nil }
 
-func (c *TCore) Register(r *core.Registration) (error, <-chan error) {
+func (c *TCore) Register(r *core.Registration) error {
 	randomDelay()
 	c.reg = r
-	errChan := make(chan error, 1)
-	errChan <- nil
-	return nil, errChan
+	return nil
 }
-func (c *TCore) Login(string) error { return nil }
+func (c *TCore) Login(string) ([]*db.Notification, error) { return nil, nil }
 
 func (c *TCore) Sync(dex string, base, quote uint32) (chan *core.BookUpdate, error) {
 	return make(chan *core.BookUpdate), nil
@@ -266,6 +265,8 @@ func (c *TCore) Unsync(dex string, base, quote uint32) {}
 func (c *TCore) Balance(uint32) (uint64, error) {
 	return uint64(rand.Float64() * math.Pow10(rand.Intn(6)+6)), nil
 }
+
+func (c *TCore) AckNotes(ids []dex.Bytes) {}
 
 var winfos = map[uint32]*asset.WalletInfo{
 	0: {
@@ -438,6 +439,8 @@ func (c *TCore) Cancel(pw string, sid string) error {
 	}
 	return nil
 }
+
+func (c *TCore) NotificationFeed() <-chan core.Notification { return make(chan core.Notification, 1) }
 
 func TestServer(t *testing.T) {
 	ctx, shutdown := context.WithCancel(context.Background())

--- a/client/webserver/site/src/css/application.scss
+++ b/client/webserver/site/src/css/application.scss
@@ -1,6 +1,7 @@
 // Variables
 $grid-columns: 24;
 $font-color-dark: #dfe2e1;
+$font-color-light: #333;
 $buycolor_dark: #05a35a;
 $sellcolor_dark: #ae3333;
 $buycolor_light: #207a46;
@@ -10,6 +11,7 @@ $light_bg_2: #d5d5d5;
 $dark_bg_1: #111;
 $dark_bg_2: #1e1e1e;
 $dark_bg_3: #292929;
+$sans: 'source-sans', sans-serif;
 $demi-sans: 'demi-sans', sans-serif;
 $mono: 'mono', monospace;
 

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -9,7 +9,7 @@ html {
 
 html,
 button {
-  color: #333;
+  color: $font-color-light;
 }
 
 body {
@@ -22,7 +22,7 @@ body {
   flex-direction: column;
   justify-content: flex-start;
   background-color: #e0e0e0;
-  font-family: 'source-sans', sans-serif;
+  font-family: $sans;
 }
 
 button {
@@ -116,14 +116,12 @@ body.dark button {
 }
 
 div.mainlinks > span {
-  font-family: $demi-sans;
-  font-weight: bolder;
   padding-right: 1.7em;
   color: #4a4949;
   cursor: pointer;
 }
 
-div.mainlinks > span:hover {
+div.mainlinks .hoverbright:hover {
   color: $dark_bg_3;
 }
 
@@ -168,13 +166,42 @@ div.note-indicator {
 }
 
 div.note-indicator.good {
-  display: block;
   background-color: green;
 }
 
 div.note-indicator.bad {
-  display: block;
   background-color: red;
+}
+
+div.note-indicator.warn {
+  background-color: orange;
+}
+
+div.poke-note {
+  position: fixed;
+  right: 20px;
+  top: 100%;
+  height: 30px;
+  transition: top 1s;
+  background-color: black;
+  color: $font-color-dark;
+  border-radius: 5px 5px 0 0;
+  z-index: 1000;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #444;
+  max-width: 90%;
+
+  & > span {
+    display: inline-block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+div.poke-note.active {
+  top: calc(100% - 30px);
 }
 
 #noteBox {
@@ -182,23 +209,26 @@ div.note-indicator.bad {
   display: none;
   top: -10px;
   right: 10px;
-  width: 375px;
-  padding: 10px;
+  width: 450px;
   background-color: white;
   border: 1px solid black;
   z-index: 1;
   cursor: default;
+  font-family: $sans;
 }
 
-div.note {
-  overflow-wrap: break-word;
-  padding: 5px 0;
+div.note-header {
+  margin: 0 5px;
+  padding: 10px 5px;
+  border-bottom-style: solid;
+  border-width: 2px;
+  border-color: #aaa;
 }
 
 div.note:not(:last-child) {
   border-bottom-style: solid;
   border-width: 1px;
-  border-color: #777;
+  border-color: #aaa;
 }
 
 @keyframes spin {

--- a/client/webserver/site/src/css/main_dark.scss
+++ b/client/webserver/site/src/css/main_dark.scss
@@ -20,12 +20,20 @@ body.dark {
     color: #a8a8a8;
   }
 
-  div.mainlinks > span:hover {
+  div.mainlinks .hoverbright:hover {
     color: #c5c5c5;
   }
 
   div.logo {
     background-image: url('/img/logo_wide_dark_v0.png');
+  }
+
+  div.note-header {
+    border-color: #333;
+  }
+
+  div.note:not(:last-child) {
+    border-color: #333;
   }
 
   .bg0 {
@@ -70,6 +78,12 @@ body.dark {
   #noteBox {
     background-color: $dark_bg_1;
     border-color: white;
+  }
+
+  div.poke-note {
+    background-color: white;
+    color: $font-color-light;
+    border-color: #aaa;
   }
 
   .buycolor {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -3,22 +3,30 @@
   {{$authed := .UserInfo.Authed}}
   <div data-pagelink="" class="logo"></div>
   <div class="mainlinks fs18 offwhite">
-  <span data-pagelink="markets">Markets</span>
-  <span data-pagelink="wallets"{{if not $authed}} class="d-hide"{{end}} id="walletsMenuEntry">Wallets</span>
-  <span class="d-inline-block position-relative{{if not $authed}} d-hide{{end}}" id="noteMenuEntry">
-    <div class="note-indicator" id="noteIndicator"></div>
-    <div id="noteBox">
-      <div id="noteList">
-        <div id="noteTemplate" class="note fs14">
-          <div class="note-indicator d-inline-block mr-2"></div>
-          <span class="note-msg"></span>
+    <span data-pagelink="markets" class="demi hoverbright">Markets</span>
+    <span data-pagelink="wallets" class="demi hoverbright{{if not $authed}} d-hide{{end}}" id="walletsMenuEntry">Wallets</span>
+    <span class="d-inline-block position-relative{{if not $authed}} d-hide{{end}}" id="noteMenuEntry">
+      <div class="note-indicator" id="noteIndicator"></div>
+      <div id="noteBox">
+        <div class="note-header fs20 demi">
+          <span class="ico-bell fs15 mr-2" id="noteBell"></span>
+          Notifications
+        </div>
+        <div id="noteList">
+          <div id="noteTemplate" class="note fs14 p-2">
+            <div class="d-flex justify-content-center align-items-center px-1">
+              <div class="note-indicator d-inline-block mr-2"></div>
+              <div class="note-subject flex-grow-1 d-inline-block fs16 demi mb-1"></div>
+              <div class="note-time fs14 pr-2"></div> ago
+            </div>
+            <div class="note-details px-2"></div>
+          </div>
         </div>
       </div>
-    </div>
-    <span class="ico-bell fs20" id="noteBell"></span>
-  </span>
-  <span class="ico-settings fs24{{if not $authed}} d-hide{{end}}" data-pagelink="settings" id="settingsIcon"></span>
-  <span data-pagelink="login"{{if $authed}} class="d-hide"{{end}} id="loginLink">Sign In</span>
+      <span class="ico-bell fs20 hoverbright" id="noteBell"></span>
+    </span>
+    <span class="ico-settings hoverbright fs24{{if not $authed}} d-hide{{end}}" data-pagelink="settings" id="settingsIcon"></span>
+    <span data-pagelink="login" class="hoverbright{{if $authed}} d-hide{{end}}" id="loginLink">Sign In</span>
   </div>
   <div id="loader" class="fill-abs flex-center d-hide">
     <div class="ico-spinner spinner"></div>
@@ -39,6 +47,7 @@
   <link href="/css/style.css?v=0" rel="stylesheet">
 </head>
 <body data-handler="home"{{if .UserInfo.DarkMode}} class="dark"{{end}}>
+<div class="poke-note px-2 fs14 d-flex align-items-center" id="pokeNote"><span>Here is a poke note.</span></div>
 {{template "header" .}}
 {{end}}
 

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -8,22 +8,27 @@ const bind = Doc.bind
 const unbind = Doc.unbind
 var app
 
-const SUCCESS = 'success'
-const ERROR = 'error'
+const IGNORE = 0
+// const DATA = 1
+const POKE = 2
+const SUCCESS = 3
+const WARNING = 4
+const ERROR = 5
+
 const DCR_ID = 42
 const LIMIT = 1
 // const MARKET = 2
 // const CANCEL = 3
 
 const updateWalletRoute = 'update_wallet'
-const errorMsgRoute = 'error_message'
-const successMsgRoute = 'success_message'
+const notificationRoute = 'notify'
 
 // window.logit = function (lvl, msg) { app.notify(lvl, msg) }
 
 // Application is the main javascript web application for the Decred DEX client.
 export default class Application {
   constructor () {
+    this.notifiers = {}
     this.notes = []
     this.user = {
       accounts: {},
@@ -42,9 +47,11 @@ export default class Application {
     this.main = idel(document, 'main')
     const handler = this.main.dataset.handler
     window.history.replaceState({ page: handler }, '', `/${handler}`)
-    this.attachHeader(idel(document, 'header'))
+    this.attachHeader()
     this.attachCommon(this.header)
     this.attach()
+    const notes = State.fetch('notifications')
+    this.setNotes(notes || [])
     ws.connect(getSocketURI(), this.reconnected)
     ws.registerRoute(updateWalletRoute, wallet => {
       this.assets[wallet.assetID].wallet = wallet
@@ -52,11 +59,8 @@ export default class Application {
       const balances = this.main.querySelectorAll(`[data-balance-target="${wallet.assetID}"]`)
       balances.forEach(el => { el.textContent = (wallet.balance / 1e8).toFixed(8) })
     })
-    ws.registerRoute(errorMsgRoute, msg => {
-      this.notify(ERROR, msg)
-    })
-    ws.registerRoute(successMsgRoute, msg => {
-      this.notify(SUCCESS, msg)
+    ws.registerRoute(notificationRoute, note => {
+      this.notify(note)
     })
   }
 
@@ -108,17 +112,18 @@ export default class Application {
     if (!handler) {
       console.error(`no handler for ${handlerID}`)
     }
-    handler(this.main, data)
+    this.notifiers = handler(this.main, data) || {}
   }
 
-  attachHeader (header) {
-    this.header = header
-    const pg = this.page = parsePage(header, [
+  attachHeader () {
+    this.header = idel(document.body, 'header')
+    this.pokeNote = idel(document.body, 'pokeNote')
+    const pg = this.page = parsePage(this.header, [
       'noteIndicator', 'noteBox', 'noteList', 'noteTemplate',
       'walletsMenuEntry', 'noteMenuEntry', 'settingsIcon', 'loginLink', 'loader'
     ])
     pg.noteIndicator.style.display = 'none'
-    pg.noteTemplate.id = undefined
+    delete pg.noteTemplate.id
     pg.noteTemplate.remove()
     pg.loader.remove()
     pg.loader.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
@@ -130,14 +135,37 @@ export default class Application {
         unbind(document, hide)
       }
     }
-    bind(pg.noteMenuEntry, 'click', e => {
+    bind(pg.noteMenuEntry, 'click', async e => {
       bind(document, 'click', hide)
       pg.noteBox.style.display = 'block'
       pg.noteIndicator.style.display = 'none'
+      const acks = []
+      for (const note of this.notes) {
+        if (!note.acked) {
+          note.acked = true
+          if (note.id && note.severity > POKE) acks.push(note.id)
+        }
+        note.el.querySelector('div.note-time').textContent = timeSince(note.stamp)
+      }
+      this.storeNotes()
+      if (acks.length) ws.request('acknotes', acks)
     })
     if (this.notes.length === 0) {
       pg.noteList.textContent = 'no notifications'
     }
+  }
+
+  storeNotes () {
+    State.store('notifications', this.notes.map(n => {
+      return {
+        subject: n.subject,
+        details: n.details,
+        severity: n.severity,
+        stamp: n.stamp,
+        id: n.id,
+        acked: n.acked
+      }
+    }))
   }
 
   // Use setLogged when user has signed in or out. For logging out, it may be
@@ -163,58 +191,77 @@ export default class Application {
     })
   }
 
-  notify (level, msg) {
-    var found = false
-    for (let i = 0; i < this.notes.length; i++) {
-      if (this.notes[i].msg === msg) {
-        this.notes[i].count++
-        found = true
-        break
+  setNotes (notes) {
+    this.notes = notes
+    this.setNoteElements()
+  }
+
+  notify (note) {
+    const order = note.order
+    const mkt = this.user.exchanges[order.dex].markets[order.market]
+    // Handle type-specific updates.
+    switch (note.type) {
+      case 'order':
+        if (mkt.orders) {
+          for (const i in mkt.orders) {
+            if (mkt.orders[i].id === order.id) {
+              mkt.orders[i] = order
+              break
+            }
+          }
+        }
+    }
+    // Inform the page.
+    if (this.notifiers[note.type]) this.notifiers[note.type](note)
+    // Discard data notifications.
+    if (note.severity < POKE) return
+    // Poke notifications have their own display.
+    if (note.severity === POKE) {
+      this.pokeNote.firstChild.textContent = `${note.subject}: ${note.details}`
+      this.pokeNote.classList.add('active')
+      if (this.pokeNote.timer) {
+        clearTimeout(this.pokeNote.timer)
       }
+      this.pokeNote.timer = setTimeout(() => {
+        this.pokeNote.classList.remove('active')
+        delete this.pokeNote.timer
+      }, 5000)
+      return
     }
-    if (!found) {
-      this.notes.push({
-        level: level,
-        msg: msg,
-        count: 1
-      })
-    }
-    const notes = this.page.noteList
-    Doc.empty(notes)
+    // Success and higher severity go to the bell dropdown.
+    this.notes.push(note)
+    this.setNoteElements()
+  }
+
+  setNoteElements () {
+    const noteList = this.page.noteList
+    while (this.notes.length > 10) this.notes.shift()
+    Doc.empty(noteList)
     for (let i = this.notes.length - 1; i >= 0; i--) {
-      if (i < this.notes.length - 10) return
       const note = this.notes[i]
-      const noteEl = this.makeNote(note.level, note.msg)
-      notes.appendChild(noteEl)
+      const noteEl = this.makeNote(note)
+      note.el = noteEl
+      noteList.appendChild(noteEl)
     }
-    this.notifyUI()
+    this.storeNotes()
+    // Set the indicator color.
+    if (this.notes.length === 0) return
+    const severity = this.notes.reduce((s, v) => {
+      if (!v.acked && v.severity > s) return v.severity
+      return s
+    }, IGNORE)
+    setSeverityClass(this.page.noteIndicator, severity)
   }
 
-  notifyUI () {
-    const ni = this.page.noteIndicator
-    ni.style.display = 'block'
-    ni.classList.remove('bad')
-    ni.classList.remove('good')
-    const noteLevel = this.notes.reduce((a, v) => {
-      if (v.level === ERROR) return ERROR
-      if (v.level === SUCCESS && a !== ERROR) return SUCCESS
-      return a
-    }, 0)
-    switch (noteLevel) {
-      case ERROR:
-        ni.classList.add('bad')
-        break
-      case SUCCESS:
-        ni.classList.add('good')
-        break
+  makeNote (note) {
+    const el = this.page.noteTemplate.cloneNode(true)
+    if (note.severity > POKE) {
+      const cls = note.severity === SUCCESS ? 'good' : note.severity === WARNING ? 'warn' : 'bad'
+      el.querySelector('div.note-indicator').classList.add(cls)
     }
-  }
-
-  makeNote (level, msg) {
-    const note = this.page.noteTemplate.cloneNode(true)
-    note.querySelector('div').classList.add(level === ERROR ? 'bad' : 'good')
-    note.querySelector('span').textContent = msg
-    return note
+    el.querySelector('div.note-subject').textContent = note.subject
+    el.querySelector('div.note-details').textContent = note.details
+    return el
   }
 
   loading (el) {
@@ -302,6 +349,8 @@ function handleLogin (main) {
     app.loaded()
     var res = await postJSON('/api/login', { pass: pw })
     if (!checkResponse(res)) return
+    res.notes.reverse()
+    app.setNotes(res.notes)
     await app.fetchUser()
     app.setLogged(true)
     app.loadPage('markets')
@@ -368,6 +417,9 @@ function handleRegister (main) {
       Doc.show(page.appErrMsg)
       return
     }
+    // User account created. Clearing the notification cache here, because old
+    // notifications are annoying during dev.
+    State.store('notifications', null)
     app.setLogged(true)
     const dcrWallet = app.walletMap[DCR_ID]
     if (!dcrWallet) {
@@ -433,7 +485,6 @@ function handleRegister (main) {
   // SUBMIT DEX REGISTRATION
   bindForm(page.pwForm, page.submitPW, async () => {
     Doc.hide(page.regErr)
-    const dex = page.addrInput.value
     const registration = {
       dex: page.addrInput.value,
       pass: page.clientPass.value,
@@ -451,13 +502,12 @@ function handleRegister (main) {
     // Need to get a fresh market list. May consider handling this with a
     // websocket update instead.
     await app.fetchUser()
-    app.notify(SUCCESS, `Account registered for ${dex}. Waiting for confirmations.`)
     app.loadPage('markets')
   })
 }
 
 // handleMarkets is the 'markets' page main element handler.
-async function handleMarkets (main, data) {
+function handleMarkets (main, data) {
   var market
   const page = parsePage(main, [
     // Templates, loaders, chart div...
@@ -690,11 +740,14 @@ async function handleMarkets (main, data) {
     }
   }
 
+  const orderRows = {}
   const refreshActiveOrders = () => {
+    for (const oid in orderRows) delete orderRows[oid]
     const orders = app.orders(selected.dex.url, selected.base.id, selected.quote.id)
     Doc.empty(page.liveList)
     for (const order of orders) {
       const row = page.liveTemplate.cloneNode(true)
+      orderRows[order.id] = row
       const set = (col, s) => { row.querySelector(`[data-col=${col}]`).textContent = s }
       set('side', order.sell ? 'sell' : 'buy')
       set('age', timeSince(order.stamp))
@@ -703,8 +756,8 @@ async function handleMarkets (main, data) {
       set('filled', `${(order.filled / order.qty * 100).toFixed(1)}%`)
       if (order.type === LIMIT) {
         if (order.cancelling) {
-          set('cancel', 'cancelling')
-        } else {
+          set('cancel', order.canceled ? 'canceled' : 'cancelling')
+        } else if (order.filled !== order.qty) {
           const icon = row.querySelector('[data-col=cancel] > span')
           Doc.show(icon)
           Doc.bind(icon, 'click', e => {
@@ -996,6 +1049,24 @@ async function handleMarkets (main, data) {
     ws.deregisterRoute('bookupdate')
     chart.unattach()
   })
+
+  return {
+    order: note => {
+      const order = note.order
+      if (order.targetID && note.subject === 'cancel') {
+        orderRows[order.targetID].querySelector('[data-col=cancel]').textContent = 'canceled'
+      } else {
+        const row = orderRows[order.id]
+        if (!row) return
+        const td = row.querySelector('[data-col=filled]')
+        td.textContent = `${(order.filled / order.qty * 100).toFixed(1)}%`
+        if (order.filled === order.qty) {
+          // Remove the cancellation button.
+          row.querySelector('[data-col=cancel]').textContent = ''
+        }
+      }
+    }
+  }
 }
 
 function makeMarket (dex, base, quote) {
@@ -1186,7 +1257,7 @@ function handleWallets (main) {
     const asset = app.assets[assetID]
     const wallet = app.walletMap[assetID]
     if (!wallet) {
-      app.notify(ERROR, `No wallet found for ${asset.info.name}. Cannot retrieve deposit address.`)
+      app.notify(makeNotification(`No wallet found for ${asset.info.name}`, 'Cannot retrieve deposit address.', ERROR))
       return
     }
     await hideBox()
@@ -1201,7 +1272,7 @@ function handleWallets (main) {
     const asset = app.assets[assetID]
     const wallet = app.walletMap[assetID]
     if (!wallet) {
-      app.notify(ERROR, `No wallet found for ${asset.info.name}. Cannot withdraw.`)
+      app.notify(makeNotification(`No wallet found for ${asset.info.name}`, 'Cannot withdraw.', ERROR))
     }
     await hideBox()
     page.withdrawAddr.value = ''
@@ -1267,7 +1338,6 @@ function handleWallets (main) {
       Doc.show(page.withdrawErr)
       return
     }
-    app.notify(SUCCESS, `Withdraw initiated. Coin ID ${res.coin}.`)
     showMarkets(assetID)
   })
 
@@ -1361,7 +1431,7 @@ function parsePage (main, ids) {
 
 function checkResponse (resp) {
   if (!resp.requestSuccessful || !resp.ok) {
-    if (app.user.inited) app.notify(ERROR, resp.msg)
+    if (app.user.inited) app.notify(makeNotification('Error', resp.msg, ERROR))
     return false
   }
   return true
@@ -1543,4 +1613,26 @@ function timeSince (t) {
   [s, seconds] = timeMod(seconds, 1000)
   add(s, 's')
   return result || '0 s'
+}
+
+function makeNotification (subject, details, severity) {
+  return {
+    subject: subject,
+    details: details,
+    severity: severity,
+    stamp: new Date().getTime()
+  }
+}
+
+const severityClassMap = {
+  [SUCCESS]: 'good',
+  [ERROR]: 'bad',
+  [WARNING]: 'warn'
+}
+
+function setSeverityClass (el, severity) {
+  el.classList.remove('bad', 'warn', 'good')
+  const cls = severityClassMap[severity]
+  if (cls) el.classList.add(cls)
+  el.style.display = cls ? 'block' : 'none'
 }

--- a/client/webserver/site/src/js/charts.js
+++ b/client/webserver/site/src/js/charts.js
@@ -133,6 +133,7 @@ export class DepthChart {
 
   // click_ is the canvas 'click' event handler.
   click_ (e) {
+    if (!this.dataExtents) return
     const x = e.clientX - this.rect.left
     const y = e.clientY - this.rect.y
     if (this.zoomInBttn.contains(x, y)) { this.zoom(true); return }


### PR DESCRIPTION
Adds a client notification system. **core** defines the interface, but the methods are implemented by the `db.Notification` type. **core** then defines concrete types that may or may not carry auxiliary information beyond the persistent db data.

Notifications above a certain "severity" are stored in the database. `(*Core).Login` now returns a list of the 10 most recent notifications for the browser to cache.

The browser uses `Window.localStorage` to store the most recent notifications and prevent extraneous requests when multiple tabs are used. As a demonstration of the usage of notifications in the browser, the current order table on the markets page is now updated live.

Closes #218