### PR TITLE
dexc: make notui and web defaults

### DIFF
--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -69,7 +69,7 @@ func main() {
 	go clientCore.Run(appCtx)
 	// At least one of --rpc or --web must be specified.
 	if cfg.NoWeb && !cfg.RPCOn {
-		fmt.Fprintf(os.Stderr, "Cannot run without web user interface unless --rpc or --tui is specified\n")
+		fmt.Fprintf(os.Stderr, "Cannot run without web server unless --rpc or --tui is specified\n")
 		return
 	}
 	var wg sync.WaitGroup

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -72,7 +72,8 @@ func main() {
 		clientCore.Run(appCtx)
 		wg.Done()
 	}()
-	// At least one of --rpc or --web must be specified.
+	// If explicitly running without web server then you must run the rpc
+	// server or the terminal ui.
 	if cfg.NoWeb && !cfg.RPCOn {
 		fmt.Fprintf(os.Stderr, "Cannot run without web server unless --rpc or --tui is specified\n")
 		os.Exit(1)

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -101,5 +101,4 @@ func main() {
 	}
 	wg.Wait()
 	ui.Close()
-
 }

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -68,8 +68,8 @@ func main() {
 	}
 	go clientCore.Run(appCtx)
 	// At least one of --rpc or --web must be specified.
-	if !cfg.RPCOn && !cfg.WebOn {
-		fmt.Fprintf(os.Stderr, "Cannot run without TUI unless --rpc and/or --web is specified\n")
+	if cfg.NoWeb && !cfg.RPCOn {
+		fmt.Fprintf(os.Stderr, "Cannot run without web user interface unless --rpc or --tui is specified\n")
 		return
 	}
 	var wg sync.WaitGroup
@@ -87,7 +87,7 @@ func main() {
 			rpcSrv.Run(appCtx)
 		}()
 	}
-	if cfg.WebOn {
+	if !cfg.NoWeb {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -66,13 +66,17 @@ func main() {
 		fmt.Fprint(os.Stderr, "error creating client core: ", err)
 		return
 	}
-	go clientCore.Run(appCtx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		clientCore.Run(appCtx)
+		wg.Done()
+	}()
 	// At least one of --rpc or --web must be specified.
 	if cfg.NoWeb && !cfg.RPCOn {
 		fmt.Fprintf(os.Stderr, "Cannot run without web server unless --rpc or --tui is specified\n")
 		return
 	}
-	var wg sync.WaitGroup
 	if cfg.RPCOn {
 		wg.Add(1)
 		go func() {

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -44,60 +44,62 @@ func main() {
 		return
 	}
 
-	// If --notui is specified, don't create the tview application. Initialize
-	// logging with the standard stdout logger.
-	if cfg.NoTUI {
-		logStdout := func(msg []byte) {
-			os.Stdout.Write(msg)
-		}
-		logMaker := ui.InitLogging(logStdout, cfg.DebugLevel)
-		clientCore, err := core.New(&core.Config{
-			DBPath:      cfg.DBPath, // global set in config.go
-			LoggerMaker: logMaker,
-			Certs:       cfg.Certs,
-			Net:         cfg.Net,
-		})
-		if err != nil {
-			fmt.Fprint(os.Stderr, "error creating client core: ", err)
-			return
-		}
-		go clientCore.Run(appCtx)
-		// At least one of --rpc or --web must be specified.
-		if !cfg.RPCOn && !cfg.WebOn {
-			fmt.Fprintf(os.Stderr, "Cannot run without TUI unless --rpc and/or --web is specified\n")
-			return
-		}
-		var wg sync.WaitGroup
-		if cfg.RPCOn {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				rpcserver.SetLogger(logMaker.Logger("RPC"))
-				rpcCfg := &rpcserver.Config{clientCore, cfg.RPCAddr, cfg.RPCUser, cfg.RPCPass, cfg.RPCCert, cfg.RPCKey}
-				rpcSrv, err := rpcserver.New(rpcCfg)
-				if err != nil {
-					log.Errorf("Error starting rpc server: %v", err)
-					return
-				}
-				rpcSrv.Run(appCtx)
-			}()
-		}
-		if cfg.WebOn {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				webSrv, err := webserver.New(clientCore, cfg.WebAddr, logMaker.Logger("WEB"), cfg.ReloadHTML)
-				if err != nil {
-					log.Errorf("Error starting web server: %v", err)
-					return
-				}
-				webSrv.Run(appCtx)
-			}()
-		}
-		wg.Wait()
-		ui.Close()
+	if cfg.TUI {
+		// Run in TUI mode.
+		ui.Run(appCtx)
 		return
 	}
-	// Run in TUI mode.
-	ui.Run(appCtx)
+
+	// If --tui is not specified, don't create the tview application. Initialize
+	// logging with the standard stdout logger.
+	logStdout := func(msg []byte) {
+		os.Stdout.Write(msg)
+	}
+	logMaker := ui.InitLogging(logStdout, cfg.DebugLevel)
+	clientCore, err := core.New(&core.Config{
+		DBPath:      cfg.DBPath, // global set in config.go
+		LoggerMaker: logMaker,
+		Certs:       cfg.Certs,
+		Net:         cfg.Net,
+	})
+	if err != nil {
+		fmt.Fprint(os.Stderr, "error creating client core: ", err)
+		return
+	}
+	go clientCore.Run(appCtx)
+	// At least one of --rpc or --web must be specified.
+	if !cfg.RPCOn && !cfg.WebOn {
+		fmt.Fprintf(os.Stderr, "Cannot run without TUI unless --rpc and/or --web is specified\n")
+		return
+	}
+	var wg sync.WaitGroup
+	if cfg.RPCOn {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rpcserver.SetLogger(logMaker.Logger("RPC"))
+			rpcCfg := &rpcserver.Config{clientCore, cfg.RPCAddr, cfg.RPCUser, cfg.RPCPass, cfg.RPCCert, cfg.RPCKey}
+			rpcSrv, err := rpcserver.New(rpcCfg)
+			if err != nil {
+				log.Errorf("Error starting rpc server: %v", err)
+				return
+			}
+			rpcSrv.Run(appCtx)
+		}()
+	}
+	if cfg.WebOn {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			webSrv, err := webserver.New(clientCore, cfg.WebAddr, logMaker.Logger("WEB"), cfg.ReloadHTML)
+			if err != nil {
+				log.Errorf("Error starting web server: %v", err)
+				return
+			}
+			webSrv.Run(appCtx)
+		}()
+	}
+	wg.Wait()
+	ui.Close()
+
 }

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -41,13 +41,13 @@ func main() {
 	cfg, err := ui.Configure()
 	if err != nil {
 		fmt.Fprint(os.Stderr, "configration error: ", err)
-		return
+		os.Exit(1)
 	}
 
 	if cfg.TUI {
 		// Run in TUI mode.
 		ui.Run(appCtx)
-		return
+		os.Exit(0)
 	}
 
 	// If --tui is not specified, don't create the tview application. Initialize
@@ -64,7 +64,7 @@ func main() {
 	})
 	if err != nil {
 		fmt.Fprint(os.Stderr, "error creating client core: ", err)
-		return
+		os.Exit(1)
 	}
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -75,7 +75,7 @@ func main() {
 	// At least one of --rpc or --web must be specified.
 	if cfg.NoWeb && !cfg.RPCOn {
 		fmt.Fprintf(os.Stderr, "Cannot run without web server unless --rpc or --tui is specified\n")
-		return
+		os.Exit(1)
 	}
 	if cfg.RPCOn {
 		wg.Add(1)
@@ -86,7 +86,7 @@ func main() {
 			rpcSrv, err := rpcserver.New(rpcCfg)
 			if err != nil {
 				log.Errorf("Error starting rpc server: %v", err)
-				return
+				os.Exit(1)
 			}
 			rpcSrv.Run(appCtx)
 		}()
@@ -98,7 +98,7 @@ func main() {
 			webSrv, err := webserver.New(clientCore, cfg.WebAddr, logMaker.Logger("WEB"), cfg.ReloadHTML)
 			if err != nil {
 				log.Errorf("Error starting web server: %v", err)
-				return
+				os.Exit(1)
 			}
 			webSrv.Run(appCtx)
 		}()

--- a/client/cmd/dexc/ui/config.go
+++ b/client/cmd/dexc/ui/config.go
@@ -24,6 +24,7 @@ const (
 	defaultRPCCertFile = "rpc.cert"
 	defaultRPCKeyFile  = "rpc.key"
 	defaultWebAddr     = "localhost:5758"
+	defaultNoTUI       = true
 	configFilename     = "dexc.conf"
 	certsFilename      = "certs.json"
 	defaultLogLevel    = "info"
@@ -87,6 +88,7 @@ var defaultConfig = Config{
 	DebugLevel: defaultLogLevel,
 	RPCAddr:    defaultRPCAddr,
 	WebAddr:    defaultWebAddr,
+	NoTUI:      defaultNoTUI,
 }
 
 // Configure processes the application configuration.

--- a/client/cmd/dexc/ui/config.go
+++ b/client/cmd/dexc/ui/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	RPCCert    string `long:"rpccert" description:"RPC server certificate file location"`
 	RPCKey     string `long:"rpckey" description:"RPC server key file location"`
 	WebAddr    string `long:"webaddr" description:"HTTP server address"`
-	NoWeb      bool   `long:"noweb" description:"disable the web user interface."`
+	NoWeb      bool   `long:"noweb" description:"disable the web server."`
 	TUI        bool   `long:"tui" description:"enable the terminal-based user interface."`
 	Testnet    bool   `long:"testnet" description:"use testnet"`
 	Simnet     bool   `long:"simnet" description:"use simnet"`

--- a/client/cmd/dexc/ui/config.go
+++ b/client/cmd/dexc/ui/config.go
@@ -24,7 +24,6 @@ const (
 	defaultRPCCertFile = "rpc.cert"
 	defaultRPCKeyFile  = "rpc.key"
 	defaultWebAddr     = "localhost:5758"
-	defaultNoTUI       = true
 	configFilename     = "dexc.conf"
 	certsFilename      = "certs.json"
 	defaultLogLevel    = "info"
@@ -69,9 +68,9 @@ type Config struct {
 	RPCPass    string `long:"rpcpass" description:"RPC server password"`
 	RPCCert    string `long:"rpccert" description:"RPC server certificate file location"`
 	RPCKey     string `long:"rpckey" description:"RPC server key file location"`
-	WebOn      bool   `long:"web" description:"turn on the web server"`
 	WebAddr    string `long:"webaddr" description:"HTTP server address"`
-	NoTUI      bool   `long:"notui" description:"disable the terminal-based user interface. must be used with --rpc or --web"`
+	NoWeb      bool   `long:"noweb" description:"disable the web user interface."`
+	TUI        bool   `long:"tui" description:"enable the terminal-based user interface."`
 	Testnet    bool   `long:"testnet" description:"use testnet"`
 	Simnet     bool   `long:"simnet" description:"use simnet"`
 	ReloadHTML bool   `long:"reload-html" description:"Reload the webserver's page template with every request. For development purposes."`
@@ -88,7 +87,6 @@ var defaultConfig = Config{
 	DebugLevel: defaultLogLevel,
 	RPCAddr:    defaultRPCAddr,
 	WebAddr:    defaultWebAddr,
-	NoTUI:      defaultNoTUI,
 }
 
 // Configure processes the application configuration.

--- a/client/cmd/dexc/ui/config_test.go
+++ b/client/cmd/dexc/ui/config_test.go
@@ -45,7 +45,7 @@ func TestConfigure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mainnet Configure error: %v", err)
 	}
-	check("mainnet notui", cfg.NoTUI == false)
+	check("mainnet notui", cfg.NoTUI == true)
 	check("mainnet testnet", cfg.Testnet == false)
 	check("mainnet simnet", cfg.Simnet == false)
 	check("mainnet rpc", cfg.RPCOn == false)
@@ -71,7 +71,7 @@ func TestConfigure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("simnet Configure error: %v", err)
 	}
-	check("simnet notui", cfg.NoTUI == false)
+	check("simnet notui", cfg.NoTUI == true)
 	check("simnet testnet", cfg.Testnet == false)
 	check("simnet simnet", cfg.Simnet == true)
 	check("simnet rpc", cfg.RPCOn == false)

--- a/client/cmd/dexc/ui/config_test.go
+++ b/client/cmd/dexc/ui/config_test.go
@@ -48,7 +48,6 @@ func TestConfigure(t *testing.T) {
 	check("mainnet testnet", cfg.Testnet == false)
 	check("mainnet simnet", cfg.Simnet == false)
 	check("mainnet rpc", cfg.RPCOn == false)
-	//check("mainnet web", cfg.WebOn == false)
 	check("mainnet webaddr", cfg.WebAddr == ":9876")
 
 	// Check the testnet configuration.
@@ -60,7 +59,6 @@ func TestConfigure(t *testing.T) {
 	check("testnet testnet", cfg.Testnet == true)
 	check("testnet simnet", cfg.Simnet == false)
 	check("testnet rpc", cfg.RPCOn == true)
-	//check("testnet web", cfg.WebOn == false)
 	check("testnet tui", cfg.TUI == true)
 	check("testnet webaddr", cfg.WebAddr == defaultWebAddr)
 

--- a/client/cmd/dexc/ui/config_test.go
+++ b/client/cmd/dexc/ui/config_test.go
@@ -34,10 +34,10 @@ func TestConfigure(t *testing.T) {
 	createFile(mainFP, "webaddr=:9876")
 
 	testFP := filepath.Join(dir, "dexc_testnet.conf")
-	createFile(testFP, "notui=1\ntestnet=1\nrpc=1")
+	createFile(testFP, "tui=1\ntestnet=1\nrpc=1")
 
 	simFP := filepath.Join(dir, "dexc_simnet.conf")
-	createFile(simFP, "webaddr=:1234\nsimnet=1\nweb=1")
+	createFile(simFP, "webaddr=:1234\nsimnet=1\nnoweb=1")
 
 	// Check the mainnet configuration.
 	os.Args = []string{cmd, "--appdata", dir, "--config", mainFP}
@@ -45,11 +45,10 @@ func TestConfigure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mainnet Configure error: %v", err)
 	}
-	check("mainnet notui", cfg.NoTUI == true)
 	check("mainnet testnet", cfg.Testnet == false)
 	check("mainnet simnet", cfg.Simnet == false)
 	check("mainnet rpc", cfg.RPCOn == false)
-	check("mainnet web", cfg.WebOn == false)
+	//check("mainnet web", cfg.WebOn == false)
 	check("mainnet webaddr", cfg.WebAddr == ":9876")
 
 	// Check the testnet configuration.
@@ -58,11 +57,11 @@ func TestConfigure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("simnet Configure error: %v", err)
 	}
-	check("testnet notui", cfg.NoTUI == true)
 	check("testnet testnet", cfg.Testnet == true)
 	check("testnet simnet", cfg.Simnet == false)
 	check("testnet rpc", cfg.RPCOn == true)
-	check("testnet web", cfg.WebOn == false)
+	//check("testnet web", cfg.WebOn == false)
+	check("testnet tui", cfg.TUI == true)
 	check("testnet webaddr", cfg.WebAddr == defaultWebAddr)
 
 	// Check the simnet configuration.
@@ -71,10 +70,9 @@ func TestConfigure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("simnet Configure error: %v", err)
 	}
-	check("simnet notui", cfg.NoTUI == true)
 	check("simnet testnet", cfg.Testnet == false)
 	check("simnet simnet", cfg.Simnet == true)
 	check("simnet rpc", cfg.RPCOn == false)
-	check("simnet web", cfg.WebOn == true)
+	check("simnet noweb", cfg.NoWeb == true)
 	check("simnet webaddr", cfg.WebAddr == ":1234")
 }

--- a/client/cmd/dexc/ui/widgets.go
+++ b/client/cmd/dexc/ui/widgets.go
@@ -143,8 +143,8 @@ func createApp() {
 	if cfg.RPCOn {
 		rpcView.toggle()
 	}
-	// --web flag was set.
-	if cfg.WebOn {
+	// --noweb flag was not set, i.e. default to toggling on web view
+	if !cfg.NoWeb {
 		webView.toggle()
 	}
 }


### PR DESCRIPTION
Replaced notui and web flags with tui and noweb flags. The default action for starting the dex is to no longer start the terminal ui while now starting the web server. You can still start the terminal ui with the --tui flag. You can prevent starting the web server with the --noweb flag.