### PR TITLE
dex/dcr: detect non-standard scripts, like swap contracts

### DIFF
--- a/dex/btc/script.go
+++ b/dex/btc/script.go
@@ -336,7 +336,8 @@ type BtcScriptAddrs struct {
 }
 
 // ExtractScriptAddrs extracts the addresses from the pubkey script, or the
-// redeem script if the pubkey script is P2SH.
+// redeem script if the pubkey script is P2SH. The returned bool indicates if
+// the script is non-standard.
 func ExtractScriptAddrs(script []byte, chainParams *chaincfg.Params) (*BtcScriptAddrs, bool, error) {
 	pubkeys := make([]btcutil.Address, 0)
 	pkHashes := make([]btcutil.Address, 0)
@@ -459,6 +460,7 @@ func RefundP2SHContract(contract, sig, pubkey []byte) ([]byte, error) {
 		Script()
 }
 
+// SpendInfo is information about an input and it's previous outpoint.
 type SpendInfo struct {
 	SigScriptSize     uint32
 	WitnessSize       uint32

--- a/dex/dcr/script.go
+++ b/dex/dcr/script.go
@@ -555,7 +555,8 @@ type DCRScriptAddrs struct {
 // separated into pubkey and pubkey hash, where the pkh addresses are actually a
 // catch all for non-P2PK addresses. As such, this function is not intended for
 // use on P2SH pkScripts. Rather, the corresponding redeem script should be
-// processed with ExtractScriptAddrs.
+// processed with ExtractScriptAddrs. The returned bool indicates if the script
+// is non-standard.
 func ExtractScriptAddrs(script []byte, chainParams *chaincfg.Params) (*DCRScriptAddrs, bool, error) {
 	pubkeys := make([]dcrutil.Address, 0)
 	pkHashes := make([]dcrutil.Address, 0)

--- a/dex/dcr/script.go
+++ b/dex/dcr/script.go
@@ -556,13 +556,17 @@ type DCRScriptAddrs struct {
 // catch all for non-P2PK addresses. As such, this function is not intended for
 // use on P2SH pkScripts. Rather, the corresponding redeem script should be
 // processed with ExtractScriptAddrs.
-func ExtractScriptAddrs(script []byte, chainParams *chaincfg.Params) (*DCRScriptAddrs, error) {
+func ExtractScriptAddrs(script []byte, chainParams *chaincfg.Params) (*DCRScriptAddrs, bool, error) {
 	pubkeys := make([]dcrutil.Address, 0)
 	pkHashes := make([]dcrutil.Address, 0)
 	// For P2SH and non-P2SH multi-sig, pull the addresses from the pubkey script.
-	_, addrs, numRequired, err := txscript.ExtractPkScriptAddrs(0, script, chainParams)
+	class, addrs, numRequired, err := txscript.ExtractPkScriptAddrs(0, script, chainParams)
+	nonStandard := class == txscript.NonStandardTy
 	if err != nil {
-		return nil, fmt.Errorf("ExtractScriptAddrs: %v", err)
+		return nil, nonStandard, fmt.Errorf("ExtractScriptAddrs: %v", err)
+	}
+	if nonStandard {
+		return &DCRScriptAddrs{}, nonStandard, nil
 	}
 	for _, addr := range addrs {
 		// If the address is an unhashed public key, is won't need a pubkey as part
@@ -580,14 +584,15 @@ func ExtractScriptAddrs(script []byte, chainParams *chaincfg.Params) (*DCRScript
 		PkHashes:  pkHashes,
 		NumPKH:    len(pkHashes),
 		NRequired: numRequired,
-	}, nil
+	}, false, nil
 }
 
 // SpendInfo is information about an input and it's previous outpoint.
 type SpendInfo struct {
-	SigScriptSize uint32
-	ScriptAddrs   *DCRScriptAddrs
-	ScriptType    DCRScriptType
+	SigScriptSize     uint32
+	ScriptAddrs       *DCRScriptAddrs
+	ScriptType        DCRScriptType
+	NonStandardScript bool
 }
 
 // Size is the serialized size of the input.
@@ -612,9 +617,17 @@ func InputInfo(pkScript, redeemScript []byte, chainParams *chaincfg.Params) (*Sp
 		}
 		evalScript = redeemScript
 	}
-	scriptAddrs, err := ExtractScriptAddrs(evalScript, chainParams)
+	scriptAddrs, nonStandard, err := ExtractScriptAddrs(evalScript, chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing utxo script addresses")
+	}
+	if nonStandard {
+		return &SpendInfo{
+			// SigScriptSize cannot be determined, leave zero.
+			ScriptAddrs:       scriptAddrs,
+			ScriptType:        scriptType,
+			NonStandardScript: true,
+		}, nil
 	}
 
 	// Get the size of the signature script.
@@ -646,7 +659,7 @@ func ExtractContractHash(scriptHex string, chainParams *chaincfg.Params) ([]byte
 		return nil, fmt.Errorf("error decoding scriptPubKey '%s': %v",
 			scriptHex, err)
 	}
-	scriptAddrs, err := ExtractScriptAddrs(pkScript, chainParams)
+	scriptAddrs, _, err := ExtractScriptAddrs(pkScript, chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting contract address: %v", err)
 	}

--- a/dex/dcr/script_test.go
+++ b/dex/dcr/script_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrd/chaincfg/v2/chainec"
 	"github.com/decred/dcrd/dcrec"
@@ -243,10 +244,64 @@ func TestIsDust(t *testing.T) {
 	}
 }
 
+// Test both InputInfo and ExtractScriptHashByType with a non-standard script.
+func Test_nonstandardScript(t *testing.T) {
+	// The tx hash of a DCR testnet swap contract.
+	contractTx, err := chainhash.NewHashFromStr("4a14a2d79c1374d286ebd68d2c104343bcf8be44ed54045b5963fbf73667cecc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	vout := 0 // the contract output index, 1 is change
+
+	// The contract output's P2SH pkScript and the corresponding redeem script
+	// (the actual contract).
+	pkScript, _ := hex.DecodeString("a9146d4bc656b3287a0e6b0d38802db6400f7053111787") // verboseTx.Vout[vout].ScriptPubKey.Hex from getrawtransaction(verbose)
+	contractScript, _ := hex.DecodeString("6382012088c020c6de3217594af525fb" +
+		"57eaf1f2aae04c305ddc67d465edd325151685fc5a5e428876a914479eddda81" +
+		"b6ed289515f2dbcc95f05ce80dff466704fe03865eb17576a91498a67ed502ad" +
+		"b04173d88fb1ef92d0317711c3816888ac")
+
+	scriptType := ParseScriptType(CurrentScriptVersion, pkScript, contractScript)
+	if !scriptType.IsP2SH() {
+		t.Fatalf("script was not P2SH, got %v (see script.go)", scriptType)
+	}
+
+	// Double check that the pkScript's script hash matches the hash of the
+	// redeem (contract) script.
+	scriptHash, err := ExtractScriptHashByType(scriptType, pkScript)
+	if err != nil {
+		t.Fatalf(fmt.Sprintf("ExtractScriptHashByType error: %v", err))
+	}
+	if !bytes.Equal(dcrutil.Hash160(contractScript), scriptHash) {
+		t.Fatalf(fmt.Sprintf("script hash check failed for output %s,%d", contractTx, vout))
+	}
+
+	// ExtractScriptAddrs should error for non-standard scripts.
+	chainParams := chaincfg.TestNet3Params()
+	_, nonStd, err := ExtractScriptAddrs(contractScript, chainParams)
+	if err != nil {
+		t.Fatalf("ExtractScriptAddrs failed: %v", err)
+	}
+	if !nonStd {
+		t.Errorf("expected non-standard script")
+	}
+
+	// InputInfo currently calls ExtractScriptAddrs at the time of writing, but
+	// InputInfo should error regardless.
+	spendInfo, err := InputInfo(pkScript, contractScript, chainParams)
+	if err != nil {
+		t.Fatalf("InputInfo failed: %v", err)
+	}
+	if !spendInfo.NonStandardScript {
+		t.Errorf("contract script should be non-standard")
+	}
+}
+
 func TestExtractScriptAddrs(t *testing.T) {
 	addrs := testAddresses()
 	type test struct {
 		addr   dcrutil.Address
+		nonStd bool
 		script []byte
 		pk     int
 		pkh    int
@@ -254,9 +309,10 @@ func TestExtractScriptAddrs(t *testing.T) {
 	}
 
 	tests := []test{
-		{addrs.pkh, nil, 0, 1, 1},
-		{addrs.sh, nil, 0, 1, 1},
-		{nil, addrs.multiSig, 2, 0, 1},
+		{addrs.pkh, false, nil, 0, 1, 1},
+		{addrs.sh, false, nil, 0, 1, 1},
+		{nil, false, addrs.multiSig, 2, 0, 1},
+		{nil, true, []byte{1}, 0, 0, 0},
 	}
 
 	for _, tt := range tests {
@@ -264,9 +320,12 @@ func TestExtractScriptAddrs(t *testing.T) {
 		if s == nil {
 			s, _ = txscript.PayToAddrScript(tt.addr)
 		}
-		scriptAddrs, err := ExtractScriptAddrs(s, tParams)
+		scriptAddrs, nonStd, err := ExtractScriptAddrs(s, tParams)
 		if err != nil {
 			t.Fatalf("error extracting script addresses: %v", err)
+		}
+		if nonStd != tt.nonStd {
+			t.Fatalf("expected nonStd=%v, got %v", tt.nonStd, nonStd)
 		}
 		if scriptAddrs.NumPK != tt.pk {
 			t.Fatalf("wrong number of hash addresses. wanted %d, got %d", tt.pk, scriptAddrs.NumPK)

--- a/dex/dcr/script_test.go
+++ b/dex/dcr/script_test.go
@@ -276,7 +276,8 @@ func Test_nonstandardScript(t *testing.T) {
 		t.Fatalf(fmt.Sprintf("script hash check failed for output %s,%d", contractTx, vout))
 	}
 
-	// ExtractScriptAddrs should error for non-standard scripts.
+	// ExtractScriptAddrs should not error for non-standard scripts, but should
+	// detect them as such.
 	chainParams := chaincfg.TestNet3Params()
 	_, nonStd, err := ExtractScriptAddrs(contractScript, chainParams)
 	if err != nil {

--- a/server/asset/btc/testing.go
+++ b/server/asset/btc/testing.go
@@ -35,6 +35,7 @@ func LiveP2SHStats(btc *Backend, t *testing.T) {
 		swaps        int
 		emptyRedeems int
 		addrErr      int
+		nonStd       int
 		noSigs       int
 	}
 	var stats scriptStats
@@ -146,10 +147,13 @@ out:
 					if scriptType.IsP2SH() {
 						evalScript = redeemScript
 					}
-					scriptAddrs, err := dexbtc.ExtractScriptAddrs(evalScript, btc.chainParams)
+					scriptAddrs, nonStandard, err := dexbtc.ExtractScriptAddrs(evalScript, btc.chainParams)
 					if err != nil {
 						stats.addrErr++
 						continue
+					}
+					if nonStandard {
+						stats.nonStd++
 					}
 					if scriptAddrs.NRequired == 0 {
 						stats.noSigs++

--- a/server/asset/btc/utxo.go
+++ b/server/asset/btc/utxo.go
@@ -155,7 +155,8 @@ type UTXO struct {
 	TXIO
 	vout uint32
 	// A bitmask for script type information.
-	scriptType dexbtc.BTCScriptType
+	scriptType        dexbtc.BTCScriptType
+	nonStandardScript bool
 	// The output's scriptPubkey.
 	pkScript []byte
 	// If the pubkey script is P2SH or P2WSH, the UTXO will only be generated if
@@ -217,9 +218,20 @@ func (utxo *UTXO) Auth(pubkeys, sigs [][]byte, msg []byte) error {
 	if utxo.scriptType.IsP2SH() || utxo.scriptType.IsP2WSH() {
 		evalScript = utxo.redeemScript
 	}
-	scriptAddrs, err := dexbtc.ExtractScriptAddrs(evalScript, utxo.btc.chainParams)
+	scriptAddrs, nonStandard, err := dexbtc.ExtractScriptAddrs(evalScript, utxo.btc.chainParams)
 	if err != nil {
 		return err
+	}
+	if nonStandard {
+		return fmt.Errorf("non-standard script")
+	}
+	// Ensure that at least 1 signature is required to spend this output.
+	// Non-standard scripts are already be caught, but check again here in case
+	// this can happen another way. Note that Auth may be called via an
+	// interface, where this requirement may not fit into a generic spendability
+	// check.
+	if scriptAddrs.NRequired == 0 {
+		return fmt.Errorf("script requires no signatures to spend")
 	}
 	// Sanity check that the required signature count matches the count parsed
 	// during UTXO initialization.

--- a/server/asset/btc/utxo.go
+++ b/server/asset/btc/utxo.go
@@ -155,7 +155,9 @@ type UTXO struct {
 	TXIO
 	vout uint32
 	// A bitmask for script type information.
-	scriptType        dexbtc.BTCScriptType
+	scriptType dexbtc.BTCScriptType
+	// If the pkScript, or redeemScript in the case of a P2SH/P2WSH pkScript, is
+	// non-standard according to txscript.
 	nonStandardScript bool
 	// The output's scriptPubkey.
 	pkScript []byte

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -21,7 +21,9 @@ type Backend interface {
 	ValidateSecret(secret, contract []byte) bool
 	// Redemption returns the redemption at the specified location.
 	Redemption(redemptionID, contractID []byte) (Coin, error)
-	// FundingCoin returns the unspent coin at the specified location.
+	// FundingCoin returns the unspent coin at the specified location. Coins
+	// with non-standard pkScripts or scripts that require zero signatures to
+	// redeem must return an error.
 	FundingCoin(coinID []byte, redeemScript []byte) (FundingCoin, error)
 	// BlockChannel creates and returns a new channel on which to receive updates
 	// when new blocks are connected.

--- a/server/asset/dcr/config.go
+++ b/server/asset/dcr/config.go
@@ -51,9 +51,9 @@ type DCRConfig struct {
 }
 
 // loadConfig loads the DCRConfig from file. If no values are found for
-// RPCListen or RPCCert in the specified file, default values will be used.
-// If configPath is an empty string, loadConfig will attempt to read settings
-// directly from the default dcrd.conf filpath. If there is no error, the
+// RPCListen or RPCCert in the specified file, default values will be used. If
+// configPath is an empty string, loadConfig will attempt to read settings
+// directly from the default dcrd.conf file path. If there is no error, the
 // module-level chainParams variable will be set appropriately for the network.
 func loadConfig(configPath string, network dex.Network) (*DCRConfig, error) {
 	// Check for missing credentials. The user and password must be set.

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -235,7 +235,14 @@ func (dcr *Backend) FundingCoin(coinID []byte, redeemScript []byte) (asset.Fundi
 	if err != nil {
 		return nil, fmt.Errorf("error decoding coin ID %x: %v", coinID, err)
 	}
-	return dcr.utxo(txHash, vout, redeemScript)
+	utxo, err := dcr.utxo(txHash, vout, redeemScript)
+	if err != nil {
+		return nil, err
+	}
+	if utxo.nonStandardScript {
+		return nil, fmt.Errorf("non-standard script")
+	}
+	return utxo, nil
 }
 
 // ValidateCoinID attempts to decode the coinID.
@@ -292,9 +299,14 @@ func (dcr *Backend) UTXODetails(txid string, vout uint32) (string, uint64, int64
 		return "", 0, -1, dex.UnsupportedScriptError
 	}
 
-	scriptAddrs, err := dexdcr.ExtractScriptAddrs(pkScript, chainParams)
+	scriptAddrs, nonStandard, err := dexdcr.ExtractScriptAddrs(pkScript, chainParams)
 	if err != nil {
 		return "", 0, -1, fmt.Errorf("error parsing utxo script addresses")
+	}
+	if nonStandard {
+		// This should be covered by the NumPKH check, but this is a more
+		// informative error message.
+		return "", 0, -1, fmt.Errorf("non-standard script")
 	}
 	if scriptAddrs.NumPK != 0 {
 		return "", 0, -1, fmt.Errorf("pubkey addresses not supported for P2PKHDetails")
@@ -568,11 +580,12 @@ func (dcr *Backend) utxo(txHash *chainhash.Hash, vout uint32, redeemScript []byt
 			maturity:   int32(maturity),
 			lastLookup: lastLookup,
 		},
-		vout:         vout,
-		scriptType:   scriptType,
-		pkScript:     pkScript,
-		redeemScript: redeemScript,
-		numSigs:      inputNfo.ScriptAddrs.NRequired,
+		vout:              vout,
+		scriptType:        scriptType,
+		nonStandardScript: inputNfo.NonStandardScript,
+		pkScript:          pkScript,
+		redeemScript:      redeemScript,
+		numSigs:           inputNfo.ScriptAddrs.NRequired,
 		// The total size associated with the wire.TxIn.
 		spendSize: inputNfo.SigScriptSize + dexdcr.TxInOverhead,
 		value:     toAtoms(txOut.Value),

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -1234,7 +1234,13 @@ func TestAuxiliary(t *testing.T) {
 	confs := int64(3)
 	txout := testAddTxOut(msg.tx, 0, txHash, blockHash, int64(txHeight), confs)
 	txout.Value = 8
-	scriptAddrs, _ := dexdcr.ExtractScriptAddrs(msg.tx.TxOut[0].PkScript, chainParams)
+	scriptAddrs, nonStandard, err := dexdcr.ExtractScriptAddrs(msg.tx.TxOut[0].PkScript, chainParams)
+	if err != nil {
+		t.Fatalf("ExtractScriptAddrs error: %v", err)
+	}
+	if nonStandard {
+		t.Errorf("vote output 0 was non-standard")
+	}
 	addr := scriptAddrs.PkHashes[0].String()
 	txAddr, v, confs, err := dcr.UnspentCoinDetails(toCoinID(txHash, 0))
 	if err != nil {

--- a/server/asset/dcr/utxo.go
+++ b/server/asset/dcr/utxo.go
@@ -165,7 +165,8 @@ type UTXO struct {
 	TXIO
 	vout uint32
 	// A bitmask for script type information.
-	scriptType dexdcr.DCRScriptType
+	scriptType        dexdcr.DCRScriptType
+	nonStandardScript bool
 	// The output's scriptPubkey.
 	pkScript []byte
 	// If the pubkey script is P2SH, the UTXO will only be generated if
@@ -225,9 +226,20 @@ func (utxo *UTXO) Auth(pubkeys, sigs [][]byte, msg []byte) error {
 	if utxo.scriptType.IsP2SH() {
 		evalScript = utxo.redeemScript
 	}
-	scriptAddrs, err := dexdcr.ExtractScriptAddrs(evalScript, chainParams)
+	scriptAddrs, nonStandard, err := dexdcr.ExtractScriptAddrs(evalScript, chainParams)
 	if err != nil {
 		return err
+	}
+	if nonStandard {
+		return fmt.Errorf("non-standard script")
+	}
+	// Ensure that at least 1 signature is required to spend this output.
+	// Non-standard scripts are already be caught, but check again here in case
+	// this can happen another way. Note that Auth may be called via an
+	// interface, where this requirement may not fit into a generic spendability
+	// check.
+	if scriptAddrs.NRequired == 0 {
+		return fmt.Errorf("script requires no signatures to spend")
 	}
 	if scriptAddrs.NRequired != utxo.numSigs {
 		return fmt.Errorf("signature requirement mismatch for utxo %s:%d. %d != %d", utxo.tx.hash, utxo.vout, scriptAddrs.NRequired, utxo.numSigs)

--- a/server/asset/dcr/utxo.go
+++ b/server/asset/dcr/utxo.go
@@ -165,7 +165,9 @@ type UTXO struct {
 	TXIO
 	vout uint32
 	// A bitmask for script type information.
-	scriptType        dexdcr.DCRScriptType
+	scriptType dexdcr.DCRScriptType
+	// If the pkScript, or redeemScript in the case of a P2SH pkScript, is
+	// non-standard according to txscript.
 	nonStandardScript bool
 	// The output's scriptPubkey.
 	pkScript []byte

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -543,6 +543,9 @@ func (r *OrderRouter) checkPrefixTrade(user account.AccountID, tunnel MarketTunn
 			return errSet(msgjson.FundingError,
 				fmt.Sprintf("error retrieving coin ID %v", coin.ID))
 		}
+		// FundingCoin must ensure that the coin requires at least one signature
+		// to spend, and that the redeem script is not non-standard.
+
 		// Check that the outpoint isn't locked.
 		locked := tunnel.CoinLocked(coinAssetID, order.CoinID(coin.ID))
 		if locked {


### PR DESCRIPTION
This addresses an issue where coins (UTXOs) with non-standard pkScripts
or redeem scripts for P2SH could be accepted as valid funding coins.

**dex/{btc,dcr}**: `ExtractScriptAddrs` indicates non-std scripts

`SpendInfo` includes a `NonStandardScript bool` field.  This allows the
`InputInfo` function to convey this state to the caller.

**server/asse**t: `FundingCoin` errors for non-std script coins

`{dcr,btc}.(*Backend).FundingCoin` now returns a "non-standard script"
error if the coin's pkScript or redeem script are non-standard.

The `{dcr,btc}.UTXO` type now has a `nonStandardScript bool` field.
`{dcr,btc}.(*Backend).utxo` sets `UTXO.nonStandardScript`.

`{dcr,btc}.(*UTXO).Auth` returns an error if the script is non-standard or
the number of required keys is zero.

`dcr.(*Backend).UnspentCoinDetails` and `UTXODetails` now error for
coins with non-standard scripts, preventing registration fees being paid
by potentially unspendable outputs.

