### PR TITLE
webserver: reorganize and refactor javascript

### DIFF
--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -327,6 +327,7 @@ func (c *TCore) CreateWallet(appPW, walletPW string, form *core.WalletForm) erro
 	defer c.mtx.Unlock()
 	c.wallets[form.AssetID] = &tWalletState{
 		running: true,
+		open: true,
 	}
 	return nil
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -46,7 +46,7 @@
   <title>{{.Title}}</title>
   <link href="/css/style.css?v=0" rel="stylesheet">
 </head>
-<body data-handler="home"{{if .UserInfo.DarkMode}} class="dark"{{end}}>
+<body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
 <div class="poke-note px-2 fs14 d-flex align-items-center" id="pokeNote"><span>Here is a poke note.</span></div>
 {{template "header" .}}
 {{end}}

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -51,7 +51,7 @@ export default class Application {
       if (!page && page !== '') return
       this.loadPage(page)
     })
-    // The main element is the interchangable part of the page that doesn't
+    // The main element is the interchangeable part of the page that doesn't
     // include the header. Main should define a data-handler attribute
     // associated with  one of the available constructors.
     this.main = idel(document, 'main')
@@ -95,8 +95,6 @@ export default class Application {
     const user = await getJSON('/api/user')
     if (!app.checkResponse(user)) return
     this.user = user
-    // Clear the notification cache for unitialized users.
-    if (!user.inited) State.store('notifications', null)
     this.assets = user.assets
     this.walletMap = {}
     for (const [assetID, asset] of Object.entries(user.assets)) {
@@ -995,7 +993,7 @@ const aDay = 86400000
 const anHour = 3600000
 const aMinute = 60000
 
-/* return returns the quotient and remainder of t / dur. */
+/* timeMod returns the quotient and remainder of t / dur. */
 function timeMod (t, dur) {
   const n = Math.floor(t / dur)
   return [n, t - n * dur]

--- a/client/webserver/site/src/js/basepage.js
+++ b/client/webserver/site/src/js/basepage.js
@@ -1,0 +1,10 @@
+export default class BasePage {
+  /* notify is called when a notification is received by the app. */
+  notify (note) {
+    if (!this.notifiers || !this.notifiers[note.type]) return
+    this.notifiers[note.type](note)
+  }
+
+  /* unload is called when the user navigates away from the page. */
+  unload () {}
+}

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -13,7 +13,7 @@ const coinValueSpecs = {
 export default class Doc {
   /*
    * idel is the element with the specified id that is the descendent of the
-   * specificed node.
+   * specified node.
    */
   static idel (el, id) {
     return el.querySelector(`#${id}`)
@@ -70,11 +70,11 @@ export default class Doc {
    * accepting one argument. The progress function will be called repeatedly
    * with the argument varying from 0.0 to 1.0. The exact path that animate
    * takes from 0.0 to 1.0 will vary depending on the choice of easing
-   * algorithm. See the Easing object for the available easing algo choices.
+   * algorithm. See the Easing object for the available easing algo choices. The
+   * default easing algorithm is linear.
    */
   static async animate (duration, f, easingAlgo) {
     const easer = easingAlgo ? Easing[easingAlgo] : Easing.linear
-    // key is a string referencing any property of Meter.data.
     const start = new Date().getTime()
     const end = start + duration
     const range = end - start

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -2,6 +2,13 @@ const parser = new window.DOMParser()
 
 const FPS = 30
 
+// Parameters for printing asset values.
+const coinValueSpecs = {
+  minimumSignificantDigits: 4,
+  maximumSignificantDigits: 6,
+  maximumFractionDigits: 8
+}
+
 // Helpers for working with the DOM.
 export default class Doc {
   static idel (el, id) {
@@ -53,14 +60,87 @@ export default class Doc {
     }
     f(1)
   }
+
+  static parsePage (main, ids) {
+    const get = s => Doc.idel(main, s)
+    const page = {}
+    ids.forEach(id => { page[id] = get(id) })
+    return page
+  }
+
+  // formatCoinValue formats the asset value to a string.
+  static formatCoinValue (x) {
+    return x.toLocaleString('en-us', coinValueSpecs)
+  }
+
+  static logoPath (symbol) {
+    return `/img/coins/${symbol}.png`
+  }
 }
 
+// Easing algorithms for animations.
 var Easing = {
   linear: t => t,
   easeIn: t => t * t,
   easeOut: t => t * (2 - t),
   easeInHard: t => t * t * t,
   easeOutHard: t => (--t) * t * t + 1
+}
+
+// StateIcons are used for controlling wallets in various places.
+export class StateIcons {
+  constructor (box) {
+    const stateIcon = (row, name) => row.querySelector(`[data-state=${name}]`)
+    this.icons = {}
+    this.icons.sleeping = stateIcon(box, 'sleeping')
+    this.icons.locked = stateIcon(box, 'locked')
+    this.icons.unlocked = stateIcon(box, 'unlocked')
+    this.icons.nowallet = stateIcon(box, 'nowallet')
+  }
+
+  sleeping () {
+    const i = this.icons
+    Doc.hide(i.locked, i.unlocked, i.nowallet)
+    Doc.show(i.sleeping)
+  }
+
+  locked () {
+    const i = this.icons
+    Doc.hide(i.unlocked, i.nowallet, i.sleeping)
+    Doc.show(i.locked)
+  }
+
+  unlocked () {
+    const i = this.icons
+    Doc.hide(i.locked, i.nowallet, i.sleeping)
+    Doc.show(i.unlocked)
+  }
+
+  nowallet () {
+    const i = this.icons
+    Doc.hide(i.locked, i.unlocked, i.sleeping)
+    Doc.show(i.nowallet)
+  }
+
+  // reads the core.Wallet state and sets the icon visibility.
+  readWallet (wallet) {
+    switch (true) {
+      case (!wallet):
+        this.nowallet()
+        break
+      case (!wallet.running):
+        this.sleeping()
+        break
+      case (!wallet.open):
+        this.locked()
+        break
+      case (wallet.open):
+        this.unlocked()
+        break
+      default:
+        console.error('wallet in unknown state', wallet)
+    }
+  }
 }
 
 function sleep (ms) {

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -11,40 +11,67 @@ const coinValueSpecs = {
 
 // Helpers for working with the DOM.
 export default class Doc {
+  /*
+   * idel is the element with the specified id that is the descendent of the
+   * specificed node.
+   */
   static idel (el, id) {
     return el.querySelector(`#${id}`)
   }
 
+  /* bind binds the function to the event for the element. */
   static bind (el, ev, f) {
     el.addEventListener(ev, f)
   }
 
+  /* unbind removes the handler for the event from the element. */
   static unbind (el, ev, f) {
     el.removeEventListener(ev, f)
   }
 
+  /* noderize creates a Document object from a string of HTML. */
   static noderize (html) {
     return parser.parseFromString(html, 'text/html')
   }
 
+  /*
+   * mouseInElement returns true if the position of mouse event, e, is within
+   * the bounds of the specified element.
+   */
   static mouseInElement (e, el) {
     const rect = el.getBoundingClientRect()
     return e.pageX >= rect.left && e.pageX <= rect.right &&
       e.pageY >= rect.top && e.pageY <= rect.bottom
   }
 
+  /* empty removes all child nodes from the specified element. */
   static empty (el) {
     while (el.firstChild) el.removeChild(el.firstChild)
   }
 
+  /*
+   * hide hides the specified elements. This is accomplished by adding the
+   * bootstrap d-hide class to the element. Use Doc.show to undo.
+   */
   static hide (...els) {
     for (const el of els) el.classList.add('d-hide')
   }
 
+  /*
+   * show shows the specified elements. This is accomplished by removing the
+   * bootstrap d-hide class as added with Doc.hide.
+   */
   static show (...els) {
     for (const el of els) el.classList.remove('d-hide')
   }
 
+  /*
+   * animate runs the supplied function, which should be a "progress" function
+   * accepting one argument. The progress function will be called repeatedly
+   * with the argument varying from 0.0 to 1.0. The exact path that animate
+   * takes from 0.0 to 1.0 will vary depending on the choice of easing
+   * algorithm. See the Easing object for the available easing algo choices.
+   */
   static async animate (duration, f, easingAlgo) {
     const easer = easingAlgo ? Easing[easingAlgo] : Easing.linear
     // key is a string referencing any property of Meter.data.
@@ -61,6 +88,12 @@ export default class Doc {
     f(1)
   }
 
+  /*
+   * parsePage constructs a page object from the supplied list of id strings.
+   * The properties of the returned object have names matching the supplied
+   * id strings, with the corresponding value being the Element object. It is
+   * not an error if an element does not exist for an id in the list.
+   */
   static parsePage (main, ids) {
     const get = s => Doc.idel(main, s)
     const page = {}
@@ -73,12 +106,13 @@ export default class Doc {
     return x.toLocaleString('en-us', coinValueSpecs)
   }
 
+  /* logoPath creates a path to a png logo for the specified ticker symbol. */
   static logoPath (symbol) {
     return `/img/coins/${symbol}.png`
   }
 }
 
-// Easing algorithms for animations.
+/* Easing algorithms for animations. */
 var Easing = {
   linear: t => t,
   easeIn: t => t * t,
@@ -87,7 +121,7 @@ var Easing = {
   easeOutHard: t => (--t) * t * t + 1
 }
 
-// StateIcons are used for controlling wallets in various places.
+/* StateIcons are used for controlling wallets in various places. */
 export class StateIcons {
   constructor (box) {
     const stateIcon = (row, name) => row.querySelector(`[data-state=${name}]`)
@@ -98,31 +132,40 @@ export class StateIcons {
     this.icons.nowallet = stateIcon(box, 'nowallet')
   }
 
+  /* sleeping sets the icons to indicate that the wallet is not connected. */
   sleeping () {
     const i = this.icons
     Doc.hide(i.locked, i.unlocked, i.nowallet)
     Doc.show(i.sleeping)
   }
 
+  /*
+   * locked sets the icons to indicate that the wallet is connected, but locked.
+   */
   locked () {
     const i = this.icons
     Doc.hide(i.unlocked, i.nowallet, i.sleeping)
     Doc.show(i.locked)
   }
 
+  /*
+   * unlocked sets the icons to indicate that the wallet is connected and
+   * unlocked.
+   */
   unlocked () {
     const i = this.icons
     Doc.hide(i.locked, i.nowallet, i.sleeping)
     Doc.show(i.unlocked)
   }
 
+  /* sleeping sets the icons to indicate that no wallet exists. */
   nowallet () {
     const i = this.icons
     Doc.hide(i.locked, i.unlocked, i.sleeping)
     Doc.show(i.nowallet)
   }
 
-  // reads the core.Wallet state and sets the icon visibility.
+  /* reads the core.Wallet state and sets the icon visibility. */
   readWallet (wallet) {
     switch (true) {
       case (!wallet):
@@ -143,6 +186,7 @@ export class StateIcons {
   }
 }
 
+/* sleep can be used by async functions to pause for a specified period. */
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -76,7 +76,7 @@ export function bindOpenWallet (app, form, success) {
 }
 
 /*
- * bindForm binds the click and submit events and prevents page reloading on
+ * bind binds the click and submit events and prevents page reloading on
  * submission.
  */
 export function bind (form, submitBttn, handler) {

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -1,0 +1,89 @@
+import Doc from './doc'
+import { postJSON } from './http'
+
+/*
+ * bindNewWalletForm is used with the "newWalletForm" template. The enclosing
+ * <form> element should be the second argument.
+ */
+export function bindNewWallet (app, form, success) {
+  // CREATE DCR WALLET
+  // This form is only shown the first time the user visits the /register page.
+  const fields = Doc.parsePage(form, [
+    'iniPath', 'acctName', 'newWalletPass', 'submitCreate', 'walletErr',
+    'newWalletLogo', 'newWalletName', 'wClientPass'
+  ])
+  var currentAsset
+  form.setAsset = asset => {
+    currentAsset = asset
+    fields.newWalletLogo.src = Doc.logoPath(asset.symbol)
+    fields.newWalletName.textContent = asset.info.name
+  }
+  bind(form, fields.submitCreate, async () => {
+    Doc.hide(fields.walletErr)
+    const create = {
+      assetID: parseInt(currentAsset.id),
+      pass: fields.newWalletPass.value,
+      account: fields.acctName.value,
+      inipath: fields.iniPath.value,
+      appPass: fields.wClientPass.value
+    }
+    fields.wClientPass.value = ''
+    app.loading(form)
+    var res = await postJSON('/api/newwallet', create)
+    app.loaded()
+    if (!app.checkResponse(res)) {
+      fields.walletErr.textContent = res.msg
+      Doc.show(fields.walletErr)
+      return
+    }
+    fields.newWalletPass.value = ''
+    success()
+  })
+}
+
+/*
+ * bindOpenWallet should be used with the "unlockWalletForm" template. The
+ * enclosing <form> element should be second argument.
+ */
+export function bindOpenWallet (app, form, success) {
+  const fields = Doc.parsePage(form, [
+    'submitOpen', 'openErr', 'walletPass', 'unlockLogo', 'unlockName'
+  ])
+  var currentAsset
+  form.setAsset = asset => {
+    currentAsset = asset
+    fields.unlockLogo.src = Doc.logoPath(asset.symbol)
+    fields.unlockName.textContent = asset.name
+    fields.walletPass.value = ''
+  }
+  bind(form, fields.submitOpen, async () => {
+    Doc.hide(fields.openErr)
+    const open = {
+      assetID: parseInt(currentAsset.id),
+      pass: fields.walletPass.value
+    }
+    fields.walletPass.value = ''
+    app.loading(form)
+    var res = await postJSON('/api/openwallet', open)
+    app.loaded()
+    if (!app.checkResponse(res)) {
+      fields.openErr.textContent = res.msg
+      Doc.show(fields.openErr)
+      return
+    }
+    success()
+  })
+}
+
+/*
+ * bindForm binds the click and submit events and prevents page reloading on
+ * submission.
+ */
+export function bind (form, submitBttn, handler) {
+  const wrapper = e => {
+    if (e.preventDefault) e.preventDefault()
+    handler(e)
+  }
+  Doc.bind(submitBttn, 'click', wrapper)
+  Doc.bind(form, 'submit', wrapper)
+}

--- a/client/webserver/site/src/js/http.js
+++ b/client/webserver/site/src/js/http.js
@@ -1,4 +1,6 @@
-// requestJSON encodes the object and sends the JSON to the specified address.
+/*
+ * requestJSON encodes the object and sends the JSON to the specified address.
+ */
 export async function requestJSON (method, addr, reqBody) {
   try {
     const response = await window.fetch(addr, {
@@ -17,10 +19,17 @@ export async function requestJSON (method, addr, reqBody) {
   }
 }
 
+/*
+ * postJSON sends a POST request with JSON-formatted data and returns the
+ * response.
+ */
 export async function postJSON (addr, data) {
   return requestJSON('POST', addr, JSON.stringify(data))
 }
 
+/*
+ * getJSON sends a GET request and returns the response.
+ */
 export async function getJSON (addr) {
   return requestJSON('GET', addr)
 }

--- a/client/webserver/site/src/js/http.js
+++ b/client/webserver/site/src/js/http.js
@@ -1,0 +1,26 @@
+// requestJSON encodes the object and sends the JSON to the specified address.
+export async function requestJSON (method, addr, reqBody) {
+  try {
+    const response = await window.fetch(addr, {
+      method: method,
+      headers: new window.Headers({ 'content-type': 'application/json' }),
+      body: reqBody
+    })
+    if (response.status !== 200) { throw response }
+    const obj = await response.json()
+    obj.requestSuccessful = true
+    return obj
+  } catch (response) {
+    response.requestSuccessful = false
+    response.msg = await response.text()
+    return response
+  }
+}
+
+export async function postJSON (addr, data) {
+  return requestJSON('POST', addr, JSON.stringify(data))
+}
+
+export async function getJSON (addr) {
+  return requestJSON('GET', addr)
+}

--- a/client/webserver/site/src/js/login.js
+++ b/client/webserver/site/src/js/login.js
@@ -1,0 +1,39 @@
+import Doc from './doc'
+import BasePage from './basepage'
+import { postJSON } from './http'
+import * as forms from './forms'
+
+var app
+
+export default class LoginPage extends BasePage {
+  constructor (application, body) {
+    super()
+    app = application
+    const page = this.page = Doc.parsePage(body, [
+      'submit', 'errMsg', 'loginForm', 'pw'
+    ])
+    forms.bind(page.loginForm, page.submit, () => { this.login() })
+    page.pw.focus()
+  }
+
+  async login (e) {
+    const page = this.page
+    app.loading(page.loginForm)
+    Doc.hide(page.errMsg)
+    const pw = page.pw.value
+    page.pw.value = ''
+    if (pw === '') {
+      page.errMsg.textContent = 'password cannot be empty'
+      Doc.show(page.errMsg)
+      return
+    }
+    app.loaded()
+    var res = await postJSON('/api/login', { pass: pw })
+    if (!Doc.checkResponse(res)) return
+    res.notes.reverse()
+    app.setNotes(res.notes)
+    await app.fetchUser()
+    app.setLogged(true)
+    app.loadPage('markets')
+  }
+}

--- a/client/webserver/site/src/js/login.js
+++ b/client/webserver/site/src/js/login.js
@@ -16,6 +16,7 @@ export default class LoginPage extends BasePage {
     page.pw.focus()
   }
 
+  /* login submits the sign-in form and parses the result. */
   async login (e) {
     const page = this.page
     app.loading(page.loginForm)

--- a/client/webserver/site/src/js/login.js
+++ b/client/webserver/site/src/js/login.js
@@ -30,7 +30,7 @@ export default class LoginPage extends BasePage {
     }
     app.loaded()
     var res = await postJSON('/api/login', { pass: pw })
-    if (!Doc.checkResponse(res)) return
+    if (!app.checkResponse(res)) return
     res.notes.reverse()
     app.setNotes(res.notes)
     await app.fetchUser()

--- a/client/webserver/site/src/js/notifications.js
+++ b/client/webserver/site/src/js/notifications.js
@@ -1,0 +1,15 @@
+export const IGNORE = 0
+export const DATA = 1
+export const POKE = 2
+export const SUCCESS = 3
+export const WARNING = 4
+export const ERROR = 5
+
+export function make (subject, details, severity) {
+  return {
+    subject: subject,
+    details: details,
+    severity: severity,
+    stamp: new Date().getTime()
+  }
+}

--- a/client/webserver/site/src/js/notifications.js
+++ b/client/webserver/site/src/js/notifications.js
@@ -5,6 +5,14 @@ export const SUCCESS = 3
 export const WARNING = 4
 export const ERROR = 5
 
+/*
+ * make constructs a new notification. The notification structure is a mirror of
+ * the structure of notifications sent from the web server.
+ * NOTE: I'm hoping to make this function obsolete, since errors generated in
+ * javascript should usually be displayed/cached somewhere better. For example,
+ * if the error is generated during submission of a form, the error should be
+ * displayed on or near the form itself, not in the notifications.
+ */
 export function make (subject, details, severity) {
   return {
     subject: subject,

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -31,14 +31,14 @@ export default class RegistrationPage extends BasePage {
     forms.bind(page.appPWForm, page.appPWSubmit, () => { this.setAppPass() })
 
     // NEW DCR WALLET
-    // This form is only show if there is no DCR wallet yet.
+    // This form is only shown if there is no DCR wallet yet.
     forms.bindNewWallet(app, page.walletForm, () => {
       this.changeForm(page.walletForm, page.urlForm)
     })
     page.walletForm.setAsset(app.assets[DCR_ID])
 
     // OPEN DCR WALLET
-    // This form is only show if there is a wallet, but its not open..
+    // This form is only shown if there is a wallet, but it's not open.
     forms.bindOpenWallet(app, page.openForm, () => {
       this.changeForm(page.openForm, page.urlForm)
     })

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -1,0 +1,172 @@
+import Doc from './doc'
+import BasePage from './basepage'
+import { postJSON } from './http'
+import * as forms from './forms'
+
+const DCR_ID = 42
+const animationLength = 300
+
+var app
+
+export default class RegistrationPage extends BasePage {
+  constructor (application, body) {
+    super()
+    app = application
+    this.body = body
+    this.notifiers = {}
+    const page = this.page = Doc.parsePage(body, [
+      // Form 1: Set the application password
+      'appPWForm', 'appPWSubmit', 'appErrMsg', 'appPW', 'appPWAgain',
+      // Form 2: Create Decred wallet
+      'walletForm',
+      // Form 3: Open Decred wallet
+      'openForm',
+      // Form 4: DEX address
+      'urlForm', 'addrInput', 'submitAddr', 'feeDisplay', 'addrErr',
+      // Form 5: Final form to initiate registration. Client app password.
+      'pwForm', 'clientPass', 'submitPW', 'regErr'
+    ])
+
+    // SET APP PASSWORD
+    forms.bind(page.appPWForm, page.appPWSubmit, () => { this.setAppPass() })
+
+    // NEW DCR WALLET
+    // This form is only show if there is no DCR wallet yet.
+    forms.bindNewWallet(app, page.walletForm, () => {
+      this.changeForm(page.walletForm, page.urlForm)
+    })
+    page.walletForm.setAsset(app.assets[DCR_ID])
+
+    // OPEN DCR WALLET
+    // This form is only show if there is a wallet, but its not open..
+    forms.bindOpenWallet(app, page.openForm, () => {
+      this.changeForm(page.openForm, page.urlForm)
+    })
+    page.openForm.setAsset(app.assets[DCR_ID])
+
+    // ENTER NEW DEX URL
+    this.fee = null
+    forms.bind(page.urlForm, page.submitAddr, () => { this.checkDEX() })
+
+    // SUBMIT DEX REGISTRATION
+    forms.bind(page.pwForm, page.submitPW, () => { this.registerDEX() })
+  }
+
+  /* Swap this currently displayed form1 for form2 with an animation. */
+  async changeForm (form1, form2) {
+    const shift = this.body.offsetWidth / 2
+    await Doc.animate(animationLength, progress => {
+      form1.style.right = `${progress * shift}px`
+    }, 'easeInHard')
+    Doc.hide(form1)
+    form1.style.right = '0px'
+    form2.style.right = -shift
+    Doc.show(form2)
+    form2.querySelector('input').focus()
+    await Doc.animate(animationLength, progress => {
+      form2.style.right = `${-shift + progress * shift}px`
+    }, 'easeOutHard')
+    form2.style.right = '0px'
+  }
+
+  /* Set the application password. Attached to form submission. */
+  async setAppPass () {
+    const page = this.page
+    Doc.hide(page.appErrMsg)
+    const pw = page.appPW.value
+    const pwAgain = page.appPWAgain.value
+    if (pw === '') {
+      page.appErrMsg.textContent = 'password cannot be empty'
+      Doc.show(page.appErrMsg)
+      return
+    }
+    if (pw !== pwAgain) {
+      page.appErrMsg.textContent = 'passwords do not match'
+      Doc.show(page.appErrMsg)
+      return
+    }
+    page.appPW.value = ''
+    page.appPWAgain.value = ''
+    app.loading(page.appPWForm)
+    var res = await postJSON('/api/init', { pass: pw })
+    app.loaded()
+    if (!app.checkResponse(res)) {
+      page.appErrMsg.textContent = res.msg
+      Doc.show(page.appErrMsg)
+      return
+    }
+    app.setLogged(true)
+    const dcrWallet = app.walletMap[DCR_ID]
+    if (!dcrWallet) {
+      this.changeForm(page.appPWForm, page.walletForm)
+      return
+    }
+    // Not really sure if these other cases are possible if the user hasn't
+    // even set their password yet.
+    if (!dcrWallet.open) {
+      this.changeForm(page.appPWForm, page.openForm)
+      return
+    }
+    this.changeForm(page.appPWForm, page.urlForm)
+  }
+
+  /* Pre-register the DEX and get the reg fees. */
+  async checkDEX () {
+    const page = this.page
+    Doc.hide(page.addrErr)
+    const dex = page.addrInput.value
+    if (dex === '') {
+      page.addrErr.textContent = 'URL cannot be empty'
+      Doc.show(page.addrErr)
+      return
+    }
+    app.loading(page.urlForm)
+    var res = await postJSON('/api/preregister', { dex: dex })
+    app.loaded()
+    if (!app.checkResponse(res)) {
+      page.addrErr.textContent = res.msg
+      Doc.show(page.addrErr)
+      return
+    }
+    page.feeDisplay.textContent = Doc.formatCoinValue(res.fee / 1e8)
+    this.fee = res.fee
+
+    const dcrWallet = app.walletMap[DCR_ID]
+    if (!dcrWallet) {
+      // There is no known Decred wallet, show the wallet form
+      await this.changeForm(page.urlForm, page.walletForm)
+      return
+    }
+    // The Decred wallet is known, check if it is open.
+    if (!dcrWallet.open) {
+      await this.changeForm(page.urlForm, page.openForm)
+      return
+    }
+    // The Decred wallet is known and open, collect the main client password.
+    await this.changeForm(page.urlForm, page.pwForm)
+  }
+
+  /* Authorize DEX registration. */
+  async registerDEX () {
+    const page = this.page
+    Doc.hide(page.regErr)
+    const registration = {
+      dex: page.addrInput.value,
+      pass: page.clientPass.value,
+      fee: this.fee
+    }
+    page.clientPass.value = ''
+    app.loading(page.pwForm)
+    var res = await postJSON('/api/register', registration)
+    app.loaded()
+    if (!app.checkResponse(res)) {
+      page.regErr.textContent = res.msg
+      Doc.show(page.regErr)
+      return
+    }
+    // Need to get a fresh market list. May consider handling this with a
+    // websocket update instead.
+    await app.fetchUser()
+    app.loadPage('markets')
+  }
+}

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -85,6 +85,11 @@ export default class RegistrationPage extends BasePage {
       Doc.show(page.appErrMsg)
       return
     }
+    // Clear the notification cache. Useful for development purposes, since
+    // the Application will only clear them on login, which would leave old
+    // browser-cached notifications in place after registering even if the
+    // client db is wiped.
+    app.setNotes([])
     page.appPW.value = ''
     page.appPWAgain.value = ''
     app.loading(page.appPWForm)

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -1,0 +1,18 @@
+import Doc from './doc'
+import BasePage from './basepage'
+import State from './state'
+
+export default class SettingsPage extends BasePage {
+  constructor (application, body) {
+    super()
+    const darkMode = Doc.idel(body, 'darkMode')
+    Doc.bind(darkMode, 'click', () => {
+      State.dark(darkMode.checked)
+      if (darkMode.checked) {
+        document.body.classList.add('dark')
+      } else {
+        document.body.classList.remove('dark')
+      }
+    })
+  }
+}

--- a/client/webserver/site/src/js/state.js
+++ b/client/webserver/site/src/js/state.js
@@ -12,6 +12,9 @@ export default class State {
     document.cookie = cname + '=' + cvalue + ';' + expires + ';path=/'
   }
 
+  /*
+   * getCookie returns the value at the specified cookie name, otherwise null.
+   */
   static getCookie (cname) {
     for (const cstr of document.cookie.split(';')) {
       const [k, v] = cstr.split('=')
@@ -20,6 +23,7 @@ export default class State {
     return null
   }
 
+  /* dark sets the dark-mode cookie. */
   static dark (dark) {
     this.setCookie(darkModeCK, dark ? '1' : '0')
     if (dark) {
@@ -29,14 +33,22 @@ export default class State {
     }
   }
 
+  /*
+   * isDark returns true if the dark-mode cookie is currently set to '1' = true.
+   */
   static isDark () {
     return document.cookie.split(';').filter((item) => item.includes(`${darkModeCK}=1`)).length
   }
 
+  /* store puts the key-value pair into Window.localStorage. */
   static store (k, v) {
     window.localStorage.setItem(k, JSON.stringify(v))
   }
 
+  /*
+  * fetch fetches the value associated with the key in Window.localStorage, or
+  * null if the no value exists for the key.
+  */
   static fetch (k) {
     const v = window.localStorage.getItem(k)
     if (v !== null) {

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -1,0 +1,317 @@
+import Doc, { StateIcons } from './doc'
+import BasePage from './basepage'
+import { postJSON } from './http'
+import * as forms from './forms'
+import * as ntfn from './notifications'
+
+const bind = Doc.bind
+const animationLength = 300
+var app
+
+export default class WalletsPage extends BasePage {
+  constructor (application, body) {
+    super()
+    app = application
+    this.body = body
+    this.notifiers = {}
+    const page = this.page = Doc.parsePage(body, [
+      'rightBox',
+      // Table Rows
+      'assetArrow', 'balanceArrow', 'statusArrow', 'walletTable', 'txtStatus',
+      // Available markets
+      'markets', 'dexTitle', 'marketsBox', 'oneMarket', 'marketsFor',
+      'marketsCard',
+      // New wallet form
+      'walletForm', 'acctName', 'newWalletPass', 'iniPath', 'walletErr',
+      'newWalletLogo', 'newWalletName',
+      // Unlock wallet form
+      'openForm',
+      // Deposit
+      'deposit', 'depositName', 'depositAddress',
+      // Withdraw
+      'withdrawForm', 'withdrawLogo', 'withdrawName', 'withdrawAddr',
+      'withdrawAmt', 'withdrawAvail', 'submitWithdraw', 'withdrawFee',
+      'withdrawUnit', 'withdrawPW', 'withdrawErr'
+    ])
+
+    // Read the document, storing some info about each asset's row.
+    const getAction = (row, name) => row.querySelector(`[data-action=${name}]`)
+    const rowInfos = this.rowInfos = {}
+    const rows = page.walletTable.querySelectorAll('tr')
+    var firstRow
+    for (const tr of rows) {
+      const assetID = parseInt(tr.dataset.assetID)
+      const rowInfo = rowInfos[assetID] = {}
+      if (!firstRow) firstRow = rowInfo
+      rowInfo.assetID = assetID
+      rowInfo.tr = tr
+      rowInfo.symbol = tr.dataset.symbol
+      rowInfo.name = tr.dataset.name
+      rowInfo.stateIcons = new StateIcons(tr)
+      rowInfo.actions = {
+        connect: getAction(tr, 'connect'),
+        unlock: getAction(tr, 'unlock'),
+        withdraw: getAction(tr, 'withdraw'),
+        deposit: getAction(tr, 'deposit'),
+        create: getAction(tr, 'create'),
+        lock: getAction(tr, 'lock')
+      }
+    }
+
+    // Prepare templates
+    page.dexTitle.removeAttribute('id')
+    page.dexTitle.remove()
+    page.oneMarket.removeAttribute('id')
+    page.oneMarket.remove()
+    page.markets.removeAttribute('id')
+    page.markets.remove()
+
+    // Methods to switch the item displayed on the right side, with a little
+    // fade-in animation.
+    this.displayed = null // The currently displayed right-side element.
+    this.animation = null // Store Promise of currently running animation.
+
+    this.openAsset = null
+    this.walletAsset = null
+
+    // Bind the new wallet form.
+    forms.bindNewWallet(app, page.walletForm, () => { this.createWallet() })
+
+    // Bind the wallet unlock form.
+    forms.bindOpenWallet(app, page.openForm, () => { this.openWallet() })
+
+    // Bind the withdraw form.
+    forms.bind(page.withdrawForm, page.submitWithdraw, () => { this.withdraw() })
+
+    // Bind the row clicks, which shows the available markets for the asset.
+    for (const rowInfo of Object.values(rowInfos)) {
+      bind(rowInfo.tr, 'click', () => {
+        this.showMarkets(rowInfo.assetID)
+      })
+    }
+
+    // Bind buttons
+    for (const [k, asset] of Object.entries(rowInfos)) {
+      const assetID = parseInt(k) // keys are string asset ID.
+      const a = asset.actions
+      const run = (e, f) => {
+        e.stopPropagation()
+        f(assetID, asset)
+      }
+      bind(a.connect, 'click', e => { run(e, this.doConnect.bind(this)) })
+      bind(a.withdraw, 'click', e => { run(e, this.showWithdraw.bind(this)) })
+      bind(a.deposit, 'click', e => { run(e, this.showDeposit.bind(this)) })
+      bind(a.create, 'click', e => { run(e, this.showNewWallet.bind(this)) })
+      bind(a.unlock, 'click', e => { run(e, this.showOpen.bind(this)) })
+      bind(a.lock, 'click', async e => { run(e, this.lock.bind(this)) })
+    }
+
+    // Clicking on the available amount on the withdraw form populates the
+    // amount field.
+    bind(page.withdrawAvail, 'click', () => {
+      page.withdrawAmt.value = page.withdrawAvail.textContent
+    })
+
+    if (!firstRow) return
+    this.showMarkets(firstRow.assetID)
+  }
+
+  /*  */
+  async hideBox () {
+    if (this.animation) await this.animation
+    if (!this.displayed) return
+    Doc.hide(this.displayed)
+  }
+
+  async showBox (box, focuser) {
+    box.style.opacity = '0'
+    Doc.show(box)
+    if (focuser) focuser.focus()
+    await Doc.animate(animationLength, progress => {
+      box.style.opacity = `${progress}`
+    }, 'easeOut')
+    box.style.opacity = '1'
+    this.displayed = box
+  }
+
+  /*
+   * Show the markets box, which lists the markets available for a selected
+   * asset.
+   */
+  async showMarkets (assetID) {
+    const page = this.page
+    const box = page.marketsBox
+    const card = page.marketsCard
+    const rowInfo = this.rowInfos[assetID]
+    await this.hideBox()
+    Doc.empty(card)
+    page.marketsFor.textContent = rowInfo.name
+    for (const [url, xc] of Object.entries(app.user.exchanges)) {
+      let count = 0
+      for (const market of Object.values(xc.markets)) {
+        if (market.baseid === assetID || market.quoteid === assetID) count++
+      }
+      if (count === 0) continue
+      const header = page.dexTitle.cloneNode(true)
+      header.textContent = new URL(url).host
+      card.appendChild(header)
+      const marketsBox = page.markets.cloneNode(true)
+      card.appendChild(marketsBox)
+      for (const market of Object.values(xc.markets)) {
+        // Only show markets where this is the base or quote asset.
+        if (market.baseid !== assetID && market.quoteid !== assetID) continue
+        const mBox = page.oneMarket.cloneNode(true)
+        mBox.querySelector('span').textContent = prettyMarketName(market)
+        let counterSymbol = market.basesymbol
+        if (market.baseid === assetID) counterSymbol = market.quotesymbol
+        mBox.querySelector('img').src = Doc.logoPath(counterSymbol)
+        // Bind the click to a load of the markets page.
+        const pageData = { market: makeMarket(url, market.baseid, market.quoteid) }
+        bind(mBox, 'click', () => { app.loadPage('markets', pageData) })
+        marketsBox.appendChild(mBox)
+      }
+    }
+    this.animation = this.showBox(box)
+  }
+
+  /* Show the new wallet form. */
+  async showNewWallet (assetID) {
+    const page = this.page
+    const box = page.walletForm
+    const asset = app.assets[assetID]
+    await this.hideBox()
+    if (assetID !== this.walletAsset) {
+      page.acctName.value = ''
+      page.newWalletPass.value = ''
+      page.iniPath.value = ''
+      page.iniPath.placeholder = asset.info.configpath
+      Doc.hide(page.walletErr)
+      page.newWalletName.textContent = asset.info.name
+    }
+    this.walletAsset = assetID
+    page.walletForm.setAsset(asset)
+    this.animation = this.showBox(box, page.acctName)
+  }
+
+  /* Show the form used to unlock a wallet. */
+  async showOpen (assetID) {
+    const page = this.page
+    this.openAsset = assetID
+    await this.hideBox()
+    page.openForm.setAsset(app.assets[assetID])
+    this.animation = this.showBox(page.openForm, page.walletPass)
+  }
+
+  /* Display a deposit address. */
+  async showDeposit (assetID) {
+    const page = this.page
+    const box = page.deposit
+    const asset = app.assets[assetID]
+    const wallet = app.walletMap[assetID]
+    if (!wallet) {
+      app.notify(ntfn.make(`No wallet found for ${asset.info.name}`, 'Cannot retrieve deposit address.', ntfn.ERROR))
+      return
+    }
+    await this.hideBox()
+    page.depositName.textContent = asset.info.name
+    page.depositAddress.textContent = wallet.address
+    this.animation = this.showBox(box, page.walletPass)
+  }
+
+  // Show the form to withdraw funds.
+  async showWithdraw (assetID) {
+    const page = this.page
+    const box = page.withdrawForm
+    const asset = app.assets[assetID]
+    const wallet = app.walletMap[assetID]
+    if (!wallet) {
+      app.notify(ntfn.make(`No wallet found for ${asset.info.name}`, 'Cannot withdraw.', ntfn.ERROR))
+    }
+    await this.hideBox()
+    page.withdrawAddr.value = ''
+    page.withdrawAmt.value = ''
+    page.withdrawAvail.textContent = (wallet.balance / 1e8).toFixed(8)
+    page.withdrawLogo.src = Doc.logoPath(asset.symbol)
+    page.withdrawName.textContent = asset.info.name
+    page.withdrawFee.textContent = wallet.feerate
+    page.withdrawUnit.textContent = wallet.units
+    box.dataset.assetID = assetID
+    this.animation = this.showBox(box, page.walletPass)
+  }
+
+  async doConnect (assetID) {
+    app.loading(this.body)
+    var res = await postJSON('/api/connectwallet', {
+      assetID: assetID
+    })
+    app.loaded()
+    if (!app.checkResponse(res)) return
+    const rowInfo = this.rowInfos[assetID]
+    Doc.hide(rowInfo.actions.connect)
+    rowInfo.stateIcons.locked()
+  }
+
+  createWallet () {
+    const rowInfo = this.rowInfos[this.walletAsset]
+    this.showMarkets(rowInfo.assetID)
+    const a = rowInfo.actions
+    Doc.hide(a.create)
+    Doc.show(a.withdraw, a.deposit, a.lock)
+    rowInfo.stateIcons.unlocked()
+  }
+
+  async openWallet () {
+    const rowInfo = this.rowInfos[this.openAsset]
+    const a = rowInfo.actions
+    Doc.show(a.lock, a.withdraw, a.deposit)
+    Doc.hide(a.unlock, a.connect)
+    rowInfo.stateIcons.unlocked()
+    this.showMarkets(this.openAsset)
+  }
+
+  async withdraw () {
+    const page = this.page
+    Doc.hide(page.withdrawErr)
+    const assetID = parseInt(page.withdrawForm.dataset.assetID)
+    const open = {
+      assetID: assetID,
+      address: page.withdrawAddr.value,
+      value: parseInt(page.withdrawAmt.value * 1e8),
+      pw: page.withdrawPW.value
+    }
+    app.loading(page.withdrawForm)
+    var res = await postJSON('/api/withdraw', open)
+    app.loaded()
+    if (!app.checkResponse(res)) {
+      page.withdrawErr.textContent = res.msg
+      Doc.show(page.withdrawErr)
+      return
+    }
+    this.showMarkets(assetID)
+  }
+
+  async lock (assetID, asset) {
+    const rowInfo = this.rowInfos[assetID]
+    const page = this.page
+    app.loading(page.walletForm)
+    var res = await postJSON('/api/closewallet', { assetID: assetID })
+    app.loaded()
+    if (!app.checkResponse(res)) return
+    const a = asset.actions
+    Doc.hide(a.lock, a.withdraw, a.deposit)
+    Doc.show(a.unlock)
+    rowInfo.stateIcons.locked()
+  }
+}
+
+function prettyMarketName (market) {
+  return `${market.basesymbol.toUpperCase()}-${market.quotesymbol.toUpperCase()}`
+}
+
+function makeMarket (dex, base, quote) {
+  return {
+    dex: dex,
+    base: base,
+    quote: quote
+  }
+}

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -75,10 +75,10 @@ export default class WalletsPage extends BasePage {
     this.walletAsset = null
 
     // Bind the new wallet form.
-    forms.bindNewWallet(app, page.walletForm, () => { this.createWallet() })
+    forms.bindNewWallet(app, page.walletForm, () => { this.createWalletSuccess() })
 
     // Bind the wallet unlock form.
-    forms.bindOpenWallet(app, page.openForm, () => { this.openWallet() })
+    forms.bindOpenWallet(app, page.openForm, () => { this.openWalletSuccess() })
 
     // Bind the withdraw form.
     forms.bind(page.withdrawForm, page.submitWithdraw, () => { this.withdraw() })
@@ -116,13 +116,19 @@ export default class WalletsPage extends BasePage {
     this.showMarkets(firstRow.assetID)
   }
 
-  /*  */
+  /*
+   * hideBox hides the displayed box after waiting for the currently running
+   * animation to complete.
+   */
   async hideBox () {
     if (this.animation) await this.animation
     if (!this.displayed) return
     Doc.hide(this.displayed)
   }
 
+  /*
+   * showBox shows the box with a fade-in animation.
+   */
   async showBox (box, focuser) {
     box.style.opacity = '0'
     Doc.show(box)
@@ -218,7 +224,7 @@ export default class WalletsPage extends BasePage {
     this.animation = this.showBox(box, page.walletPass)
   }
 
-  // Show the form to withdraw funds.
+  /* Show the form to withdraw funds. */
   async showWithdraw (assetID) {
     const page = this.page
     const box = page.withdrawForm
@@ -239,6 +245,7 @@ export default class WalletsPage extends BasePage {
     this.animation = this.showBox(box, page.walletPass)
   }
 
+  /* doConnect connects to a wallet via the connectwallet API route. */
   async doConnect (assetID) {
     app.loading(this.body)
     var res = await postJSON('/api/connectwallet', {
@@ -251,7 +258,8 @@ export default class WalletsPage extends BasePage {
     rowInfo.stateIcons.locked()
   }
 
-  createWallet () {
+  /* createWalletSuccess is the success callback for wallet creation. */
+  createWalletSuccess () {
     const rowInfo = this.rowInfos[this.walletAsset]
     this.showMarkets(rowInfo.assetID)
     const a = rowInfo.actions
@@ -260,7 +268,8 @@ export default class WalletsPage extends BasePage {
     rowInfo.stateIcons.unlocked()
   }
 
-  async openWallet () {
+  /* openWalletSuccess is the success callback for wallet unlocking. */
+  async openWalletSuccess () {
     const rowInfo = this.rowInfos[this.openAsset]
     const a = rowInfo.actions
     Doc.show(a.lock, a.withdraw, a.deposit)
@@ -269,6 +278,7 @@ export default class WalletsPage extends BasePage {
     this.showMarkets(this.openAsset)
   }
 
+  /* withdraw submits the withdrawal form to the API. */
   async withdraw () {
     const page = this.page
     Doc.hide(page.withdrawErr)
@@ -290,6 +300,7 @@ export default class WalletsPage extends BasePage {
     this.showMarkets(assetID)
   }
 
+  /* lock instructs the API to lock the wallet. */
   async lock (assetID, asset) {
     const rowInfo = this.rowInfos[assetID]
     const page = this.page
@@ -304,10 +315,18 @@ export default class WalletsPage extends BasePage {
   }
 }
 
+/*
+ * Given a market object as created with makeMarket, prettyMarketName will
+ * create a string ABC-XYZ, where ABC and XYZ are the upper-case ticker symbols
+ * for the base and quote assets respectively.
+ */
 function prettyMarketName (market) {
   return `${market.basesymbol.toUpperCase()}-${market.quotesymbol.toUpperCase()}`
 }
 
+/*
+ * makeMarket creates a market object.
+ */
 function makeMarket (dex, base, quote) {
   return {
     dex: dex,


### PR DESCRIPTION
Creates a series of page classes that inherit from a `BasePage` class. Each page is moved to its own module. Common functions and constants are also organized into new or existing modules. 

This PR does not move or fully refactor the handling for the markets page. I'd like to follow up with that in a separate PR that focuses on /markets.

No substantive changes, but a couple of bug fixes and a bit more documentation.