### PR TITLE
core: save entire TLS certificate

### DIFF
--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -174,6 +174,11 @@ func TestWsConn(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	certB, err := ioutil.ReadFile(certFile.Name())
+	if err != nil {
+		t.Fatalf("file reading error: %v", err)
+	}
+
 	host := "127.0.0.1:6060"
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", handler)
@@ -199,7 +204,7 @@ func TestWsConn(t *testing.T) {
 	cfg := &WsCfg{
 		URL:      "wss://" + host + "/ws",
 		PingWait: pingWait,
-		RpcCert:  certFile.Name(),
+		Cert:     certB,
 	}
 	conn, err := NewWsConn(cfg)
 	if err != nil {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -922,7 +922,7 @@ func TestRegister(t *testing.T) {
 	}
 
 	form := &Registration{
-		DEX:      tDexUrl,
+		URL:      tDexUrl,
 		Password: tPW,
 		Fee:      tFee,
 	}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -98,9 +98,16 @@ type SupportedAsset struct {
 
 // Registration is information necessary to register an account on a DEX.
 type Registration struct {
-	DEX      string
+	URL      string
 	Password string
 	Fee      uint64
+	Cert     string
+}
+
+// PreRegisterForm is the information necessary to pre-register a DEX.
+type PreRegisterForm struct {
+	URL  string `json:"url"`
+	Cert string `json:"cert"`
 }
 
 // Match represents a match on an order. An order may have many matches.
@@ -220,6 +227,7 @@ type dexAccount struct {
 	id        account.AccountID
 	dexPubKey *secp256k1.PublicKey
 	feeCoin   []byte
+	cert      []byte
 	isPaid    bool
 	authMtx   sync.RWMutex
 	isAuthed  bool
@@ -233,6 +241,7 @@ func newDEXAccount(acctInfo *db.AccountInfo) *dexAccount {
 		dexPubKey: acctInfo.DEXPubKey,
 		isPaid:    acctInfo.Paid,
 		feeCoin:   acctInfo.FeeCoin,
+		cert:      acctInfo.Cert,
 	}
 }
 

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -34,6 +34,7 @@ func RandomAccountInfo() *db.AccountInfo {
 		EncKey:    randBytes(32),
 		DEXPubKey: randomPubKey(),
 		FeeCoin:   randBytes(32),
+		Cert:      randBytes(100),
 	}
 }
 

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -98,7 +98,7 @@ func decodeAccountInfo_v0(pushes [][]byte) (*AccountInfo, error) {
 		return nil, fmt.Errorf("decodeAccountInfo: expected 5 data pushes, got %d", len(pushes))
 	}
 	urlB, keyB, dexB := pushes[0], pushes[1], pushes[2]
-	coinB, cert := pushes[3], pushes[4]
+	coinB, certB := pushes[3], pushes[4]
 	pk, err := secp256k1.ParsePubKey(dexB)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func decodeAccountInfo_v0(pushes [][]byte) (*AccountInfo, error) {
 		EncKey:    keyB,
 		DEXPubKey: pk,
 		FeeCoin:   coinB,
-		Cert:      cert,
+		Cert:      certB,
 	}, nil
 }
 

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -64,6 +64,7 @@ type AccountInfo struct {
 	EncKey    []byte
 	DEXPubKey *secp256k1.PublicKey
 	FeeCoin   []byte
+	Cert      []byte
 	// Paid will be set on retrieval based on whether there is an AccountProof
 	// set.
 	Paid bool
@@ -75,7 +76,8 @@ func (ai *AccountInfo) Encode() []byte {
 		AddData([]byte(ai.URL)).
 		AddData(ai.EncKey).
 		AddData(ai.DEXPubKey.Serialize()).
-		AddData(ai.FeeCoin)
+		AddData(ai.FeeCoin).
+		AddData(ai.Cert)
 }
 
 // DecodeAccountInfo decodes the versioned blob into an *AccountInfo.
@@ -92,10 +94,11 @@ func DecodeAccountInfo(b []byte) (*AccountInfo, error) {
 }
 
 func decodeAccountInfo_v0(pushes [][]byte) (*AccountInfo, error) {
-	if len(pushes) != 4 {
-		return nil, fmt.Errorf("decodeAccountInfo: expected 4 data pushes, got %d", len(pushes))
+	if len(pushes) != 5 {
+		return nil, fmt.Errorf("decodeAccountInfo: expected 5 data pushes, got %d", len(pushes))
 	}
-	urlB, keyB, dexB, coinB := pushes[0], pushes[1], pushes[2], pushes[3]
+	urlB, keyB, dexB := pushes[0], pushes[1], pushes[2]
+	coinB, cert := pushes[3], pushes[4]
 	pk, err := secp256k1.ParsePubKey(dexB)
 	if err != nil {
 		return nil, err
@@ -105,6 +108,7 @@ func decodeAccountInfo_v0(pushes [][]byte) (*AccountInfo, error) {
 		EncKey:    keyB,
 		DEXPubKey: pk,
 		FeeCoin:   coinB,
+		Cert:      cert,
 	}, nil
 }
 

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -212,14 +212,14 @@ func handleWallets(s *RPCServer, req *msgjson.Message) *msgjson.ResponsePayload 
 // *msgjson.ResponsePayload.Error is empty if successful. Requires the address
 // of a dex and returns the dex fee.
 func handlePreRegister(s *RPCServer, req *msgjson.Message) *msgjson.ResponsePayload {
-	dexURL := ""
-	err := req.Unmarshal(&dexURL)
+	form := new(core.PreRegisterForm)
+	err := json.Unmarshal(req.Payload, &form)
 	if err != nil {
 		resErr := msgjson.NewError(msgjson.RPCParseError,
 			"unable to unmarshal request")
 		return createResponse(req.Route, nil, resErr)
 	}
-	fee, err := s.core.PreRegister(dexURL)
+	fee, err := s.core.PreRegister(form)
 	if err != nil {
 		resErr := msgjson.NewError(msgjson.RPCPreRegisterError,
 			err.Error())

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -333,7 +333,8 @@ Returns:
 		`Preregister for dex.
 
 Args:
-    string: The dex address to preregister for.
+    url (string): The dex to preregister for.
+    cert-path (string): Optional. The filepath to the TLS certificate for the dex.
 
 Returns:
     obj: The preregister result.

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -240,14 +240,14 @@ func handleRegister(s *RPCServer, req *msgjson.Message) *msgjson.ResponsePayload
 		resErr := msgjson.NewError(msgjson.RPCParseError, "unable to unmarshal request")
 		return createResponse(req.Route, nil, resErr)
 	}
-	fee, err := s.core.PreRegister(form.DEX)
+	fee, err := s.core.PreRegister(&core.PreRegisterForm{URL: form.URL})
 	if err != nil {
 		resErr := msgjson.NewError(msgjson.RPCPreRegisterError,
 			err.Error())
 		return createResponse(req.Route, nil, resErr)
 	}
 	if fee != form.Fee {
-		errMsg := fmt.Sprintf("DEX at %s expects a fee of %d but %d was offered", form.DEX, fee, form.Fee)
+		errMsg := fmt.Sprintf("DEX at %s expects a fee of %d but %d was offered", form.URL, fee, form.Fee)
 		resErr := msgjson.NewError(msgjson.RPCRegisterError, errMsg)
 		return createResponse(req.Route, nil, resErr)
 	}
@@ -397,7 +397,7 @@ Returns:
       },...
     ]`,
 	},
-	registerRoute: {`"appPass" "dex" fee`,
+	registerRoute: {`"appPass" "dex" fee ("cert-path")`,
 		`Register for dex. An ok response does not mean that registration is complete.
 Registration is complete after the fee transaction has been confirmed.
 
@@ -405,6 +405,7 @@ Args:
     appPass (string): The DEX client password.
     dex (string): The DEX addr to register for.
     fee (int): The DEX fee.
+    cert-path (string): Optional. The filepath to the TLS certificate for the dex.
 
 Returns:
     string: The message "` + fmt.Sprintf(feePaidStr, "[fee]") + `"`,

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -165,7 +165,7 @@ func TestHandlePreRegister(t *testing.T) {
 		wantErrCode    int
 	}{{
 		name:           "ok",
-		arg:            "dex",
+		arg:            &core.PreRegisterForm{URL: "dex"},
 		preRegisterFee: 5,
 		wantErrCode:    -1,
 	}, {
@@ -174,7 +174,7 @@ func TestHandlePreRegister(t *testing.T) {
 		wantErrCode: msgjson.RPCParseError,
 	}, {
 		name:           "core.PreRegister error",
-		arg:            "dex",
+		arg:            &core.PreRegisterForm{URL: "dex"},
 		preRegisterFee: 5,
 		preRegisterErr: errors.New("error"),
 		wantErrCode:    msgjson.RPCPreRegisterError,

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -390,7 +390,7 @@ func TestHandleWallets(t *testing.T) {
 }
 
 func TestHandleRegister(t *testing.T) {
-	form := &core.Registration{DEX: "dex:1234", Password: "password123", Fee: 1000}
+	form := &core.Registration{URL: "dex:1234", Password: "password123", Fee: 1000}
 	tests := []struct {
 		name                        string
 		arg                         interface{}

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -49,7 +49,7 @@ var (
 type ClientCore interface {
 	Balance(assetID uint32) (baseUnits uint64, err error)
 	Book(dex string, base, quote uint32) (orderBook *core.OrderBook)
-	PreRegister(dexURL string) (fee uint64, err error)
+	PreRegister(*core.PreRegisterForm) (fee uint64, err error)
 	Sync(dex string, base, quote uint32) (updateChan chan *core.BookUpdate, err error)
 	CloseWallet(assetID uint32) error
 	CreateWallet(appPass, walletPass string, form *core.WalletForm) error

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -59,7 +59,7 @@ func (c *TCore) Unsync(dex string, base, quote uint32) {}
 func (c *TCore) Balance(uint32) (uint64, error) {
 	return 0, c.balanceErr
 }
-func (c *TCore) PreRegister(string) (uint64, error) {
+func (c *TCore) PreRegister(*core.PreRegisterForm) (uint64, error) {
 	return c.preRegisterFee, c.preRegisterErr
 }
 func (c *TCore) CreateWallet(appPW, walletPW string, form *core.WalletForm) error {

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -74,7 +74,7 @@ var nArgs = map[string][]int{
 	openWalletRoute:  {2},
 	closeWalletRoute: {1},
 	walletsRoute:     {0},
-	registerRoute:    {3},
+	registerRoute:    {3, 4},
 }
 
 // parsers is a map of commands to parsing functions.
@@ -149,7 +149,20 @@ func parseRegisterArgs(args []string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	req := &core.Registration{Password: args[0], DEX: args[1], Fee: uint64(fee)}
+	cert := ""
+	if len(args) == 4 {
+		certB, err := ioutil.ReadFile(args[3])
+		if err != nil {
+			return nil, fmt.Errorf("error reading %s: %v", args[1], err)
+		}
+		cert = string(certB)
+	}
+	req := &core.Registration{
+		Password: args[0],
+		URL:      args[1],
+		Fee:      uint64(fee),
+		Cert:     cert,
+	}
 	return req, nil
 }
 

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -6,6 +6,7 @@ package rpcserver
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"strconv"
 
 	"decred.org/dcrdex/client/core"
@@ -68,7 +69,7 @@ var nArgs = map[string][]int{
 	helpRoute:        {0, 1},
 	initRoute:        {1},
 	versionRoute:     {0},
-	preRegisterRoute: {1},
+	preRegisterRoute: {1, 2},
 	newWalletRoute:   {5},
 	openWalletRoute:  {2},
 	closeWalletRoute: {1},
@@ -81,7 +82,7 @@ var parsers = map[string](func([]string) (interface{}, error)){
 	helpRoute:        parseHelpArgs,
 	initRoute:        func(args []string) (interface{}, error) { return args[0], nil },
 	versionRoute:     func([]string) (interface{}, error) { return nil, nil },
-	preRegisterRoute: func(args []string) (interface{}, error) { return args[0], nil },
+	preRegisterRoute: parsePreRegisterArgs,
 	newWalletRoute:   parseNewWalletArgs,
 	openWalletRoute:  parseOpenWalletArgs,
 	closeWalletRoute: func(args []string) (interface{}, error) {
@@ -150,4 +151,19 @@ func parseRegisterArgs(args []string) (interface{}, error) {
 	}
 	req := &core.Registration{Password: args[0], DEX: args[1], Fee: uint64(fee)}
 	return req, nil
+}
+
+func parsePreRegisterArgs(args []string) (interface{}, error) {
+	cert := ""
+	if len(args) > 1 {
+		certB, err := ioutil.ReadFile(args[1])
+		if err != nil {
+			return nil, fmt.Errorf("error reading %s: %v", args[1], err)
+		}
+		cert = string(certB)
+	}
+	return &core.PreRegisterForm{
+		URL:  args[0],
+		Cert: cert,
+	}, nil
 }

--- a/client/rpcserver/types_test.go
+++ b/client/rpcserver/types_test.go
@@ -281,7 +281,7 @@ func TestParseRegisterArgs(t *testing.T) {
 		if reg.Password != test.args[0] {
 			t.Fatalf("appPass doesn't match")
 		}
-		if reg.DEX != test.args[1] {
+		if reg.URL != test.args[1] {
 			t.Fatalf("dex doesn't match")
 		}
 		if fmt.Sprint(reg.Fee) != test.args[2] {

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -25,18 +25,13 @@ func simpleAck() *standardResponse {
 	}
 }
 
-// preRegisterForm is the information necessary to pre-register a DEX.
-type preRegisterForm struct {
-	DEX string `json:"dex"`
-}
-
 // apiPreRegister is the handler for the '/preregister' API request.
 func (s *WebServer) apiPreRegister(w http.ResponseWriter, r *http.Request) {
-	form := new(preRegisterForm)
+	form := new(core.PreRegisterForm)
 	if !readPost(w, r, form) {
 		return
 	}
-	fee, err := s.core.PreRegister(form.DEX)
+	fee, err := s.core.PreRegister(form)
 	if err != nil {
 		s.writeAPIError(w, "preregister error: %v", err)
 		return
@@ -53,7 +48,7 @@ func (s *WebServer) apiPreRegister(w http.ResponseWriter, r *http.Request) {
 
 // registration is used to register a new DEX account.
 type registration struct {
-	DEX      string `json:"dex"`
+	URL      string `json:"url"`
 	Password string `json:"pass"`
 	Fee      uint64 `json:"fee"`
 }
@@ -80,7 +75,7 @@ func (s *WebServer) apiRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err := s.core.Register(&core.Registration{
-		DEX:      reg.DEX,
+		URL:      reg.URL,
 		Password: reg.Password,
 		Fee:      reg.Fee,
 	})

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -210,7 +210,9 @@ func (c *TCore) InitializeClient(pw string) error {
 	c.inited = true
 	return nil
 }
-func (c *TCore) PreRegister(dex string) (uint64, error) { return 1e8, nil }
+func (c *TCore) PreRegister(form *core.PreRegisterForm) (uint64, error) {
+	return 1e8, nil
+}
 
 func (c *TCore) Register(r *core.Registration) error {
 	randomDelay()

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -277,3 +277,7 @@ hr.dashed {
 .pointer {
   cursor: pointer;
 }
+
+.underline {
+  text-decoration: underline;
+}

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -73,6 +73,15 @@
           <label for="addrInput" class="pl-1 mb-1">DEX Address</label>
           <input type="text" class="form-control select" id="addrInput">
         </div>
+        <div>
+          <div class="pl-1 mb-1 mt-4 pointer">TLS Certificate</div>
+          <input type="file" class="form-control select d-none" id="certInput">
+          <div class="pl-1 mt-2 fs15">
+            <span id="selectedCert">none selected</span>
+            <span class="underline ml-3 pointer d-hide" id="removeTLS">remove</span>
+            <span class="underline ml-3 pointer" id="addTLS">add a file</span>
+          </div>
+        </div>
         <div class="d-flex justify-content-end mt-4">
           <button id="submitAddr" type="button" class="col-8 justify-content-center fs15 bg2 selected">Submit</button>
         </div>

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -69,7 +69,7 @@ type clientCore interface {
 	ConnectWallet(assetID uint32) error
 	Wallets() []*core.WalletState
 	User() *core.User
-	PreRegister(dex string) (uint64, error)
+	PreRegister(*core.PreRegisterForm) (uint64, error)
 	SupportedAssets() map[uint32]*core.SupportedAsset
 	Withdraw(pw string, assetID uint32, value uint64) (asset.Coin, error)
 	Trade(pw string, form *core.TradeForm) (*core.Order, error)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -71,11 +71,11 @@ type TCore struct {
 	notOpen         bool
 }
 
-func (c *TCore) Exchanges() map[string]*core.Exchange        { return nil }
-func (c *TCore) PreRegister(dex string) (uint64, error)      { return 1e8, c.preRegErr }
-func (c *TCore) Register(r *core.Registration) error         { return c.regErr }
-func (c *TCore) InitializeClient(pw string) error            { return c.initErr }
-func (c *TCore) Login(pw string) ([]*db.Notification, error) { return nil, c.loginErr }
+func (c *TCore) Exchanges() map[string]*core.Exchange              { return nil }
+func (c *TCore) PreRegister(*core.PreRegisterForm) (uint64, error) { return 1e8, c.preRegErr }
+func (c *TCore) Register(r *core.Registration) error               { return c.regErr }
+func (c *TCore) InitializeClient(pw string) error                  { return c.initErr }
+func (c *TCore) Login(pw string) ([]*db.Notification, error)       { return nil, c.loginErr }
 func (c *TCore) Sync(dex string, base, quote uint32) (chan *core.BookUpdate, error) {
 	return nil, c.syncErr
 }
@@ -411,7 +411,7 @@ func TestAPIRegister(t *testing.T) {
 	}
 
 	goodBody := &core.Registration{
-		DEX:      "test",
+		URL:      "test",
 		Password: "pass",
 	}
 	body = goodBody
@@ -543,7 +543,7 @@ func TestAPIPreRegister(t *testing.T) {
 		ensureResponse(t, s, s.apiPreRegister, want, reader, writer, body)
 	}
 
-	body = &preRegisterForm{"somedexaddress.org"}
+	body = &core.PreRegisterForm{URL: "somedexaddress.org"}
 	ensure(`{"ok":true,"fee":100000000}`)
 
 	// Preregister error


### PR DESCRIPTION
Alternative to #252. Drops the *certs.json* file altogether in favor of a file upload. Saves the entire file to db. 

Standardizes to name `URL` or `url` in some places where it was previously `DEX` or `dex`.

Built on #251, so the diff you want is 

https://github.com/buck54321/dcrdex/compare/js...buck54321:certupload

UI: 

Registration form now allows opening of a file dialog to select a file. The contents of the file are sent in the preregister API call.

![image](https://user-images.githubusercontent.com/6109680/79056445-57ab6400-7c1c-11ea-9a1f-36bd0ebae2c6.png)
