### PR TITLE
client/asset: fix zero-utxo bug

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -379,6 +379,11 @@ func (btc *ExchangeWallet) Fund(value uint64, nfo *dex.Asset) (asset.Coins, erro
 
 out:
 	for {
+		// If there are none left, we don't have enough.
+		if len(utxos) == 0 {
+			return nil, fmt.Errorf("not enough to cover requested funds + fees = %d",
+				btc.reqFunds(value, size, nfo))
+		}
 		// On each loop, find the smallest UTXO that is enough for the value. If
 		// no UTXO is large enough, add the largest and continue.
 		var txout *compositeUTXO
@@ -398,11 +403,6 @@ out:
 		}
 		// Pop the utxo from the unspents
 		utxos = utxos[:len(utxos)-1]
-		// If there are none left, we don't have enough.
-		if len(utxos) == 0 {
-			return nil, fmt.Errorf("not enough to cover requested funds + fees = %d",
-				btc.reqFunds(value, size, nfo))
-		}
 	}
 
 	err = btc.wallet.LockUnspent(false, spents)

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -318,6 +318,14 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("no funding error for zero value")
 	}
 
+	// Nothing to spend
+	node.rawRes[methodListUnspent] = mustMarshal(t, []struct{}{})
+	_, err = wallet.Fund(littleBit-300, tBTC)
+	if err == nil {
+		t.Fatalf("no error for zero utxos")
+	}
+	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
 	// RPC error
 	node.rawErr[methodListUnspent] = tErr
 	_, err = wallet.Fund(littleBit-300, tBTC)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -406,6 +406,10 @@ func (dcr *ExchangeWallet) fund(confs uint32,
 
 out:
 	for {
+		// If there are none left, we don't have enough.
+		if len(utxos) == 0 {
+			return nil, 0, 0, fmt.Errorf("not enough to cover requested funds")
+		}
 		// On each loop, find the smallest UTXO that is enough. If no UTXO is large
 		// enough, add the largest and continue.
 		var txout *compositeUTXO
@@ -425,10 +429,6 @@ out:
 		}
 		// Pop the utxo from the unspents
 		utxos = utxos[:len(utxos)-1]
-		// If there are none left, we don't have enough.
-		if len(utxos) == 0 {
-			return nil, 0, 0, fmt.Errorf("not enough to cover requested funds")
-		}
 	}
 
 	err = dcr.lockFundingCoins(spents)

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -337,6 +337,14 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("no funding error for zero value")
 	}
 
+	// Nothing to spend
+	node.unspent = nil
+	_, err = wallet.Fund(littleBit-5000, tDCR)
+	if err == nil {
+		t.Fatalf("no error for zero utxos")
+	}
+	node.unspent = unspents
+
 	// RPC error
 	node.unspentErr = tErr
 	_, err = wallet.Fund(littleBit-5000, tDCR)


### PR DESCRIPTION
The utxo length check in the `Fund` loop was in the wrong spot.