### PR TITLE
dcrdex: use encrypt.Crypter for the signing key storage

### DIFF
--- a/dex/encrypt/encrypt.go
+++ b/dex/encrypt/encrypt.go
@@ -46,8 +46,8 @@ var intCoder = encode.IntCoder
 // Key is 32 bytes.
 type Key [KeySize]byte
 
-// Salt is randomness used as part of key deriviation. This is different from
-// the salt generated during xchacha20poly1305 encryption, which is shorter.
+// Salt is randomness used as part of key derivation. This is different from the
+// salt generated during xchacha20poly1305 encryption, which is shorter.
 type Salt [SaltSize]byte
 
 // newSalt is the constructor for a salt based on randomness from crypto/rand.

--- a/server/admin/prompt.go
+++ b/server/admin/prompt.go
@@ -14,30 +14,29 @@ import (
 
 // PasswordPrompt prompts the user to enter a password. Password must not be an
 // empty string.
-func PasswordPrompt(prompt string) (string, error) {
+func PasswordPrompt(prompt string) ([]byte, error) {
 	fmt.Print(prompt)
 	pass, err := terminal.ReadPassword(syscall.Stdin)
 	fmt.Println()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if pass == nil {
-		return "", errors.New("password must not be empty")
+		return nil, errors.New("password must not be empty")
 	}
-	return string(pass), nil
+	return pass, nil
 }
 
 // PasswordHashPrompt prompts the user to enter a password and returns its
 // SHA256 hash. Password must not be an empty string.
-func PasswordHashPrompt(prompt string) ([32]byte, error) {
-	var authSHA [32]byte
-	password, err := PasswordPrompt(prompt)
+func PasswordHashPrompt(prompt string) ([sha256.Size]byte, error) {
+	var authSHA [sha256.Size]byte
+	passBytes, err := PasswordPrompt(prompt)
 	if err != nil {
 		return authSHA, err
 	}
-	passBytes := []byte(password)
 	authSHA = sha256.Sum256(passBytes)
-	// Zero password bytes. What about the password string?
+	// Zero password bytes.
 	ClearBytes(passBytes)
 	return authSHA, nil
 }

--- a/server/admin/prompt.go
+++ b/server/admin/prompt.go
@@ -12,22 +12,38 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// PasswordPrompt prompts the user to enter a password and returns its sha256
-// hash. Password must not be an empty string.
-func PasswordPrompt(prompt string) ([32]byte, error) {
+// PasswordPrompt prompts the user to enter a password. Password must not be an
+// empty string.
+func PasswordPrompt(prompt string) (string, error) {
+	fmt.Print(prompt)
+	pass, err := terminal.ReadPassword(syscall.Stdin)
+	fmt.Println()
+	if err != nil {
+		return "", err
+	}
+	if pass == nil {
+		return "", errors.New("password must not be empty")
+	}
+	return string(pass), nil
+}
+
+// PasswordHashPrompt prompts the user to enter a password and returns its
+// SHA256 hash. Password must not be an empty string.
+func PasswordHashPrompt(prompt string) ([32]byte, error) {
 	var authSHA [32]byte
-	fmt.Println(prompt)
-	password, err := terminal.ReadPassword(syscall.Stdin)
+	password, err := PasswordPrompt(prompt)
 	if err != nil {
 		return authSHA, err
 	}
-	if password == nil {
-		return authSHA, errors.New("password must not be empty")
-	}
-	authSHA = sha256.Sum256(password)
-	// Zero password bytes.
-	for i := range password {
-		password[i] = 0x00
-	}
+	passBytes := []byte(password)
+	authSHA = sha256.Sum256(passBytes)
+	// Zero password bytes. What about the password string?
+	ClearBytes(passBytes)
 	return authSHA, nil
+}
+
+func ClearBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
 }

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -17,7 +16,6 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex"
-	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 	"github.com/decred/dcrd/dcrutil/v2"
 	flags "github.com/jessevdk/go-flags"
 )
@@ -35,7 +33,7 @@ const (
 	defaultPGHost              = "127.0.0.1:5432"
 	defaultPGUser              = "dcrdex"
 	defaultPGDBName            = "dcrdex"
-	defaultDEXPrivKeyFilename  = "dexprivkey"
+	defaultDEXPrivKeyFilename  = "sigkey"
 	defaultRPCHost             = "127.0.0.1"
 	defaultRPCPort             = "7232"
 	defaultAdminSrvAddr        = "127.0.0.1:6542"
@@ -68,7 +66,7 @@ type dexConf struct {
 	RegFeeConfirms   int64
 	RegFeeAmount     uint64
 	CancelThreshold  float64
-	DEXPrivKey       *secp256k1.PrivateKey
+	DEXPrivKeyPath   string
 	RPCCert          string
 	RPCKey           string
 	RPCListen        []string
@@ -507,14 +505,6 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		adminSrvAddr = cfg.AdminSrvAddr
 	}
 
-	// Load the DEX signing key. TODO: Implement a secure key storage scheme.
-	pkFileBuffer, err := ioutil.ReadFile(cfg.DEXPrivKeyPath)
-	if err != nil {
-		return loadConfigError(fmt.Errorf("unable to read DEX private key file %s: %v",
-			cfg.DEXPrivKeyPath, err))
-	}
-	privKey, _ := secp256k1.PrivKeyFromBytes(pkFileBuffer)
-
 	dexCfg := &dexConf{
 		Network:          network,
 		DBName:           cfg.PGDBName,
@@ -527,7 +517,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		RegFeeConfirms:   cfg.RegFeeConfirms,
 		RegFeeXPub:       cfg.RegFeeXPub,
 		CancelThreshold:  cfg.CancelThreshold,
-		DEXPrivKey:       privKey,
+		DEXPrivKeyPath:   cfg.DEXPrivKeyPath,
 		RPCCert:          cfg.RPCCert,
 		RPCKey:           cfg.RPCKey,
 		RPCListen:        RPCListen,

--- a/server/cmd/dcrdex/key.go
+++ b/server/cmd/dcrdex/key.go
@@ -1,0 +1,103 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/dex/encrypt"
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
+)
+
+func dexKey(path, pass string) (*secp256k1.PrivateKey, error) {
+	var privKey *secp256k1.PrivateKey
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		log.Infof("Creating new DEX signing key file at %s...", path)
+		privKey, err = createAndStoreKey(path, pass)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load DEX private key from file %s: %v",
+				path, err)
+		}
+	} else {
+		log.Infof("Loading DEX signing key from %s...", path)
+		privKey, err = loadKeyFile(path, pass)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load DEX private key from file %s: %v",
+				path, err)
+		}
+	}
+	return privKey, nil
+}
+
+func loadKeyFile(path, pass string) (*secp256k1.PrivateKey, error) {
+	// Load and decrypt it.
+	pkFileBuffer, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("ReadFile: %v", err)
+	}
+
+	ver, pushes, err := encode.DecodeBlob(pkFileBuffer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal DEX signing key data: %v", err)
+	}
+	if ver != 0 {
+		return nil, fmt.Errorf("unrecognized key file version %d: %v", ver, err)
+	}
+	keyParams := pushes[0]
+	encKey := pushes[1]
+
+	crypter, err := encrypt.Deserialize(pass, keyParams)
+	if err != nil {
+		return nil, err
+	}
+
+	keyB, err := crypter.Decrypt(encKey)
+	if err != nil {
+		return nil, err
+	}
+	privKey, _ := secp256k1.PrivKeyFromBytes(keyB)
+	return privKey, nil
+}
+
+func createAndStoreKey(path, pass string) (*secp256k1.PrivateKey, error) {
+	// Disallow an empty password.
+	if pass == "" {
+		return nil, fmt.Errorf("empty password")
+	}
+	// Do not overwrite existing key files.
+	if _, err := os.Stat(path); err == nil {
+		return nil, fmt.Errorf("key file exists")
+	}
+
+	// Create and store a new key.
+	privKey, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate DEX signing key: %v", err)
+	}
+
+	// Encrypt the private key.
+	crypter := encrypt.NewCrypter(pass)
+	keyParams := crypter.Serialize()
+	encKey, err := crypter.Encrypt(privKey.Serialize())
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt DEX signing key: %v", err)
+	}
+	// Check a round trip with this key data.
+	_, err = crypter.Decrypt(encKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt DEX signing key: %v", err)
+	}
+
+	// Store it.
+	data := encode.BuildyBytes{0}.AddData(keyParams).AddData(encKey)
+	err = ioutil.WriteFile(path, data, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write DEX signing key: %v", err)
+	}
+
+	return privKey, nil
+}

--- a/server/cmd/dcrdex/key_test.go
+++ b/server/cmd/dcrdex/key_test.go
@@ -1,0 +1,174 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package main
+
+import (
+	"bytes"
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_createAndStoreKey(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(dir)
+
+	file := "newkey"
+
+	tests := []struct {
+		name    string
+		path    string
+		pass    string
+		wantErr bool
+	}{
+		{
+			"bad path",
+			"/totally/not/a/path",
+			"pass1234",
+			true,
+		},
+		{
+			"ok new",
+			filepath.Join(dir, file),
+			"pass1234",
+			false,
+		},
+		{
+			"already exists",
+			filepath.Join(dir, file),
+			"pass1234",
+			true,
+		},
+		{
+			"empty pass",
+			filepath.Join(dir, "newkey2"),
+			"",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := createAndStoreKey(tt.path, tt.pass)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createAndStoreKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func Test_loadKeyFile(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(dir)
+
+	fullFile := filepath.Join(dir, "newkey")
+	pass := "pass1234"
+
+	privKey, err := createAndStoreKey(fullFile, pass)
+	if err != nil {
+		t.Fatalf("createAndStoreKey: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		pass    string
+		want    *secp256k1.PrivateKey
+		wantErr bool
+	}{
+		{
+			"ok",
+			fullFile,
+			"pass1234",
+			privKey,
+			false,
+		},
+		{
+			"bad path",
+			filepath.Join(dir, "wrongName"),
+			"pass1234",
+			nil,
+			true,
+		},
+		{
+			"wrong pass",
+			fullFile,
+			"adsf",
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pk, err := loadKeyFile(tt.path, tt.pass)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("loadKeyFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.want == nil {
+				return
+			}
+			if !bytes.Equal(tt.want.Serialize(), pk.Serialize()) {
+				t.Errorf("private key mismatch")
+			}
+		})
+	}
+}
+
+func Test_dexKey(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(dir)
+
+	file := "newkey"
+	fullFile := filepath.Join(dir, file)
+
+	tests := []struct {
+		name    string
+		path    string
+		pass    string
+		wantErr bool
+	}{
+		{
+			"bad path",
+			"/totally/not/a/path",
+			"pass1234",
+			true,
+		},
+		{
+			"ok new",
+			fullFile,
+			"pass1234",
+			false,
+		},
+		{
+			"ok exists",
+			fullFile,
+			"pass1234",
+			false,
+		},
+		{
+			"wrong pass",
+			fullFile,
+			"adsf",
+			true,
+		},
+		{
+			"empty pass for new",
+			filepath.Join(dir, "newkey2"),
+			"",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := dexKey(tt.path, tt.pass)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("dexKey() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/server/cmd/dcrdex/key_test.go
+++ b/server/cmd/dcrdex/key_test.go
@@ -21,31 +21,31 @@ func Test_createAndStoreKey(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
-		pass    string
+		pass    []byte
 		wantErr bool
 	}{
 		{
 			"bad path",
 			"/totally/not/a/path",
-			"pass1234",
+			[]byte("pass1234"),
 			true,
 		},
 		{
 			"ok new",
 			filepath.Join(dir, file),
-			"pass1234",
+			[]byte("pass1234"),
 			false,
 		},
 		{
 			"already exists",
 			filepath.Join(dir, file),
-			"pass1234",
+			[]byte("pass1234"),
 			true,
 		},
 		{
 			"empty pass",
 			filepath.Join(dir, "newkey2"),
-			"",
+			[]byte{},
 			true,
 		},
 	}
@@ -65,7 +65,7 @@ func Test_loadKeyFile(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	fullFile := filepath.Join(dir, "newkey")
-	pass := "pass1234"
+	pass := []byte("pass1234")
 
 	privKey, err := createAndStoreKey(fullFile, pass)
 	if err != nil {
@@ -75,28 +75,28 @@ func Test_loadKeyFile(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
-		pass    string
+		pass    []byte
 		want    *secp256k1.PrivateKey
 		wantErr bool
 	}{
 		{
 			"ok",
 			fullFile,
-			"pass1234",
+			[]byte("pass1234"),
 			privKey,
 			false,
 		},
 		{
 			"bad path",
 			filepath.Join(dir, "wrongName"),
-			"pass1234",
+			[]byte("pass1234"),
 			nil,
 			true,
 		},
 		{
 			"wrong pass",
 			fullFile,
-			"adsf",
+			[]byte("adsd"),
 			nil,
 			true,
 		},
@@ -128,37 +128,37 @@ func Test_dexKey(t *testing.T) {
 	tests := []struct {
 		name    string
 		path    string
-		pass    string
+		pass    []byte
 		wantErr bool
 	}{
 		{
 			"bad path",
 			"/totally/not/a/path",
-			"pass1234",
+			[]byte("pass1234"),
 			true,
 		},
 		{
 			"ok new",
 			fullFile,
-			"pass1234",
+			[]byte("pass1234"),
 			false,
 		},
 		{
 			"ok exists",
 			fullFile,
-			"pass1234",
+			[]byte("pass1234"),
 			false,
 		},
 		{
 			"wrong pass",
 			fullFile,
-			"adsf",
+			[]byte("adsf"),
 			true,
 		},
 		{
 			"empty pass for new",
 			filepath.Join(dir, "newkey2"),
-			"",
+			[]byte{},
 			true,
 		},
 	}

--- a/server/cmd/dcrdex/log.go
+++ b/server/cmd/dcrdex/log.go
@@ -29,6 +29,9 @@ type logWriter struct{}
 
 // Write writes the data in p to standard out and the log rotator.
 func (logWriter) Write(p []byte) (n int, err error) {
+	if logRotator == nil {
+		return os.Stdout.Write(p)
+	}
 	os.Stdout.Write(p)
 	return logRotator.Write(p)
 }

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -90,6 +90,7 @@ func mainCore(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		admin.ClearBytes(keyPW)
 	}
 
 	// Create the DEX manager.

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -19,6 +19,7 @@ import (
 	_ "decred.org/dcrdex/server/asset/dcr" // register dcr asset
 	_ "decred.org/dcrdex/server/asset/ltc" // register ltc asset
 	dexsrv "decred.org/dcrdex/server/dex"
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 )
 
 func mainCore(ctx context.Context) error {
@@ -34,10 +35,10 @@ func mainCore(ctx context.Context) error {
 		}
 	}()
 
-	// Aquire admin server password if turned on.
+	// Acquire admin server password if enabled.
 	var adminSrvAuthSHA [32]byte
 	if cfg.AdminSrvOn {
-		adminSrvAuthSHA, err = admin.PasswordPrompt("Enter admin server password:")
+		adminSrvAuthSHA, err = admin.PasswordHashPrompt("Admin interface password: ")
 		if err != nil {
 			return fmt.Errorf("cannot use password: %v", err)
 		}
@@ -78,6 +79,19 @@ func mainCore(ctx context.Context) error {
 	log.Infof("Found %d assets, loaded %d markets, for network %s",
 		len(assets), len(markets), strings.ToUpper(cfg.Network.String()))
 
+	// Load, or create and save, the DEX signing key.
+	var privKey *secp256k1.PrivateKey
+	{
+		keyPW, err := admin.PasswordPrompt("Signing key password: ")
+		if err != nil {
+			return fmt.Errorf("cannot use password: %v", err)
+		}
+		privKey, err = dexKey(cfg.DEXPrivKeyPath, keyPW)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Create the DEX manager.
 	dexConf := &dexsrv.DexConf{
 		LogBackend: cfg.LogMaker,
@@ -96,7 +110,7 @@ func mainCore(ctx context.Context) error {
 		RegFeeConfirms:   cfg.RegFeeConfirms,
 		BroadcastTimeout: cfg.BroadcastTimeout,
 		CancelThreshold:  cfg.CancelThreshold,
-		DEXPrivKey:       cfg.DEXPrivKey,
+		DEXPrivKey:       privKey,
 		CommsCfg: &dexsrv.RPCConfig{
 			RPCCert:     cfg.RPCCert,
 			RPCKey:      cfg.RPCKey,


### PR DESCRIPTION
Replace the unencrypted "dexprivkey" file with an encrypted "sigkey"
file. The sigkey file is a binary encoding of the signing key and the
encryption parameters, created using encode.BuildyBytes and
encode.Crypter:

    encode.BuildyBytes{0}.AddData(keyParams).AddData(encKey)

server/admin: Add PasswordHashPrompt, and modify PasswordPrompt
to retrieve the raw password string, not the hash of it.

Starting dcrdex with no existing "sigkey" file creates a new private key,
encrypts it, and stores the encrypted key along with the encryption
parameters:

```
Signing key password: {no echo}
2020-04-13 17:14:43.764 [INF] MAIN: Creating new DEX signing key file at /home/jon/.dcrdex/sigkey...
```

Subsequent startups load and decrypt the key file:

```
Signing key password: {no echo}
2020-04-13 17:14:26.060 [INF] MAIN: Loading DEX signing key from /home/jon/.dcrdex/sigkey...
```

