### PR TITLE
core: handle revoke match messages.

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1671,7 +1671,7 @@ func TestHandleRevokeMatchMsg(t *testing.T) {
 	preImg := newPreimage()
 	payload := &msgjson.RevokeMatch{
 		OrderID: oid[:],
-		MatchID: encode.RandomBytes(order.OrderIDSize),
+		MatchID: encode.RandomBytes(order.MatchIDSize),
 	}
 	req, _ := msgjson.NewRequest(rig.dc.NextID(), msgjson.RevokeMatchRoute, payload)
 


### PR DESCRIPTION
This adds the revoke_match message handler to the client core.