### PR TITLE
core: reload active orders and matches

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1219,6 +1219,7 @@ func TestLockUnlock(t *testing.T) {
 
 	// just checking that the errors come through.
 	node.rawRes[methodUnlock] = mustMarshal(t, true)
+	node.rawRes[methodLockUnspent] = []byte(`true`)
 	err := wallet.Unlock("pass", time.Hour*24*365)
 	if err != nil {
 		t.Fatalf("unlock error: %v", err)

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -62,7 +62,7 @@ func (wc *walletClient) ListUnspent() ([]*ListUnspentResult, error) {
 // an order, but not yet spent, should be locked until spent or until the order
 // is  canceled or fails.
 func (wc *walletClient) LockUnspent(unlock bool, ops []*output) error {
-	rpcops := make([]*RPCOutpoint, 0, len(ops))
+	var rpcops []*RPCOutpoint // To clear all, this must be nil, not empty slice.
 	for _, op := range ops {
 		rpcops = append(rpcops, &RPCOutpoint{
 			TxID: op.txHash.String(),

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1711,7 +1711,7 @@ func (c *Core) reFee(dcrWallet *xcWallet, dc *dexConnection) {
 	})
 }
 
-// dbTrackers prepares trackeTrades based on active orders and matches in the
+// dbTrackers prepares trackedTrades based on active orders and matches in the
 // database. Since dbTrackers runs before sign in when wallets are not connected
 // or unlocked, wallets and coins are not added to the returned trackers. Use
 // resumeTrades with the app Crypter to prepare wallets and coins.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -51,6 +51,7 @@ type dexConnection struct {
 	assets     map[uint32]*dex.Asset
 	cfg        *msgjson.ConfigResult
 	acct       *dexAccount
+	notify     func(Notification)
 
 	booksMtx sync.RWMutex
 	books    map[string]*book.OrderBook
@@ -184,18 +185,18 @@ func (dc *dexConnection) ack(msgID uint64, matchID order.MatchID, signable msgjs
 	return nil
 }
 
-// trackerMatches are an intermediate structure used by the dexConnection to
+// serverMatches are an intermediate structure used by the dexConnection to
 // sort incoming match notifications.
-type trackerMatches struct {
+type serverMatches struct {
 	tracker    *trackedTrade
 	msgMatches []*msgjson.Match
 	cancel     *msgjson.Match
 }
 
 // parseMatches sorts the list of matches and associates them with a trade.
-func (dc *dexConnection) parseMatches(msgMatches []*msgjson.Match) (map[order.OrderID]*trackerMatches, []msgjson.Acknowledgement, error) {
+func (dc *dexConnection) parseMatches(msgMatches []*msgjson.Match, checkSigs bool) (map[order.OrderID]*serverMatches, []msgjson.Acknowledgement, error) {
 	var acks []msgjson.Acknowledgement
-	matches := make(map[order.OrderID]*trackerMatches)
+	matches := make(map[order.OrderID]*serverMatches)
 	var errs []string
 	for _, msgMatch := range msgMatches {
 		var oid order.OrderID
@@ -210,9 +211,11 @@ func (dc *dexConnection) parseMatches(msgMatches []*msgjson.Match) (map[order.Or
 			errs = append(errs, err.Error())
 			continue
 		}
-		err = dc.acct.checkSig(sigMsg, msgMatch.Sig)
-		if err != nil {
-			return nil, nil, fmt.Errorf("parseMatches: %v", err)
+		if checkSigs {
+			err = dc.acct.checkSig(sigMsg, msgMatch.Sig)
+			if err != nil {
+				return nil, nil, fmt.Errorf("parseMatches: %v", err)
+			}
 		}
 		sig, err := dc.acct.sign(sigMsg)
 		if err != nil {
@@ -227,7 +230,7 @@ func (dc *dexConnection) parseMatches(msgMatches []*msgjson.Match) (map[order.Or
 		trackerID := tracker.ID()
 		match := matches[trackerID]
 		if match == nil {
-			match = &trackerMatches{
+			match = &serverMatches{
 				tracker: tracker,
 			}
 			matches[trackerID] = match
@@ -246,16 +249,17 @@ func (dc *dexConnection) parseMatches(msgMatches []*msgjson.Match) (map[order.Or
 }
 
 // runMatches runs the sorted matches returned from parseMatches.
-func (dc *dexConnection) runMatches(matches map[order.OrderID]*trackerMatches) error {
+func (dc *dexConnection) runMatches(matches map[order.OrderID]*serverMatches) error {
 	for _, match := range matches {
+		tracker := match.tracker
 		if len(match.msgMatches) > 0 {
-			err := match.tracker.negotiate(match.msgMatches)
+			err := tracker.negotiate(match.msgMatches)
 			if err != nil {
 				return err
 			}
 		}
 		if match.cancel != nil {
-			err := match.tracker.processCancelMatch(match.cancel)
+			err := tracker.processCancelMatch(match.cancel)
 			if err != nil {
 				return err
 			}
@@ -263,6 +267,28 @@ func (dc *dexConnection) runMatches(matches map[order.OrderID]*trackerMatches) e
 	}
 	dc.refreshMarkets()
 	return nil
+}
+
+// compareServerMatches resolves the matches reported by the server in the
+// 'connect' response against those marked incomplete in the matchTracker map
+// for each serverMatch.
+//
+// DRAFT NOTE: Right now, the matches are just checked and notifications sent,
+// but it may be a good  place to trigger a FindRedemption if the conditions
+// warrant.
+func (dc *dexConnection) compareServerMatches(matches map[order.OrderID]*serverMatches) {
+	for _, match := range matches {
+		new, extras := match.tracker.readConnectMatches(match.msgMatches)
+		if len(extras) > 0 {
+			details := fmt.Sprintf("%d matches reported by %s were not found for %s.", len(extras), dc.acct.url, match.tracker.token())
+			corder, _ := match.tracker.coreOrder()
+			dc.notify(newOrderNote("Match resolution error", details, db.ErrorLevel, corder))
+			for _, extra := range extras {
+				log.Errorf("%s reported, but now a known active match for order %s", extra.MatchID, extra.OrderID)
+			}
+		}
+		match.msgMatches = new
+	}
 }
 
 // tickAsset checks open matches related to a specific asset for needed action.
@@ -926,13 +952,32 @@ func (c *Core) InitializeClient(pw string) error {
 
 // Login logs the user in, decrypting the account keys for all known DEXes.
 func (c *Core) Login(pw string) ([]*db.Notification, error) {
-	errs := newErrorSet("Login: ")
 	crypter, err := c.encryptionKey(pw)
 	if err != nil {
-		return nil, errs.addErr(err)
+		return nil, err
 	}
+
+	loaded := c.resolveActiveTrades(crypter)
+	if loaded > 0 {
+		log.Infof("loaded %d incomplete orders", loaded)
+	}
+
+	c.initializeDEXConnections(crypter)
+	notes, err := c.db.NotificationsN(10)
+	if err != nil {
+		log.Errorf("Login -> NotificationsN error: %v", err)
+	}
+	c.refreshUser()
+	return notes, nil
+}
+
+// initializeDEXConnections connects to the DEX servers in the conns map and
+// authenticates the connection. If registration is incomplete, reFee is run and
+// the connection will be authenticated once the `notifyfee` request is sent.
+func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) {
+	// Connections will be attempted in parallel, so we'll need to protect the
+	// errorSet.
 	var wg sync.WaitGroup
-	var mtx sync.Mutex
 	c.connMtx.RLock()
 	defer c.connMtx.RUnlock()
 	for _, dc := range c.conns {
@@ -942,37 +987,79 @@ func (c *Core) Login(pw string) ([]*db.Notification, error) {
 		}
 		err := dc.acct.unlock(crypter)
 		if err != nil {
-			errs.add("error unlocking account for %s: %v", dc.acct.url, err)
+			details := fmt.Sprintf("error unlocking account for %s: %v", dc.acct.url, err)
+			c.notify(newFeePaymentNote("Account unlock error", details, db.ErrorLevel))
 			continue
 		}
+		dcrID, _ := dex.BipSymbolID("dcr")
 		if !dc.acct.paid() {
-			// Unlock the account, but don't authenticate. Registration will be
-			// completed when the user unlocks the Decred password.
-			log.Errorf("skipping authorization for unpaid account %s", dc.acct.url)
+			// Try to unlock the Decred wallet, which should run the reFee cycle, and
+			// in turn will run authDEX.
+			if len(dc.acct.feeCoin) == 0 {
+				details := fmt.Sprintf("Empty fee coin for %s.", dc.acct.url)
+				c.notify(newFeePaymentNote("Fee coin error", details, db.ErrorLevel))
+				continue
+			}
+			dcrWallet, err := c.connectedWallet(dcrID)
+			if err != nil {
+				log.Debugf("Failed to connect for reFee at %s with error: %v", dc.acct.url, err)
+				details := fmt.Sprintf("Incomplete registration detected for %s, but failed to connect to the Decred wallet", dc.acct.url)
+				c.notify(newFeePaymentNote("Wallet connection warning", details, db.WarningLevel))
+				continue
+			}
+			if !dcrWallet.unlocked() {
+				err = unlockWallet(dcrWallet, crypter)
+				if err != nil {
+					details := fmt.Sprintf("Connected to Decred wallet to complete registration at %s, but failed to unlock: %v", dc.acct.url, err)
+					c.notify(newFeePaymentNote("Wallet unlock error", details, db.ErrorLevel))
+					continue
+				}
+			}
+			c.reFee(dcrWallet, dc)
 			continue
 		}
+
 		wg.Add(1)
 		go func(dc *dexConnection) {
 			defer wg.Done()
 			err := c.authDEX(dc)
 			if err != nil {
-				mtx.Lock()
-				errs.add("authDEX error for %s: %v", dc.acct.url, err)
-				mtx.Unlock()
+				details := fmt.Sprintf("%s: %v", dc.acct.url, err)
+				c.notify(newFeePaymentNote("DEX auth error", details, db.ErrorLevel))
 				return
 			}
 		}(dc)
 	}
-
 	wg.Wait()
+}
 
-	notes, err := c.db.NotificationsN(10)
-	if err != nil {
-		errs.addErr(err)
+// resolveActiveTrades loads order and match data from the database. Only active
+// orders and orders with active matches are loaded. Also, only active matches
+// are loaded, even if there are inactive matches for the same order, but it may
+// be desirable to load all matches, so this behavior may change.
+func (c *Core) resolveActiveTrades(crypter encrypt.Crypter) int {
+	failed := make(map[uint32]struct{})
+	c.connMtx.RLock()
+	defer c.connMtx.RUnlock()
+	var loaded int
+	for _, dc := range c.conns {
+		// loadDBTrades can add to the failed map.
+		ready, err := c.loadDBTrades(dc, crypter, failed)
+		if err != nil {
+			details := fmt.Sprintf("Some orders failed to load from the database: %v", err)
+			c.notify(newOrderNote("Order load failure", details, db.ErrorLevel, nil))
+		}
+		if len(ready) > 0 {
+			err = c.resumeTrades(dc, ready)
+			if err != nil {
+				details := fmt.Sprintf("Some active orders failed to resume: %v", err)
+				c.notify(newOrderNote("Order resumption error", details, db.ErrorLevel, nil))
+			}
+		}
+		loaded += len(ready)
+		dc.refreshMarkets()
 	}
-
-	c.refreshUser()
-	return notes, errs.ifany()
+	return loaded
 }
 
 var waiterID uint64
@@ -1430,11 +1517,17 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	// Set the account as authenticated.
 	dc.acct.auth()
 
-	matches, _, err := dc.parseMatches(result.Matches)
+	matches, _, err := dc.parseMatches(result.Matches, false)
 	if err != nil {
 		log.Error(err)
 	}
-	return dc.runMatches(matches)
+
+	// Reported matches with missing trackers are already checked by parseMatches,
+	// but we also must check for incomplete matches that the server is not
+	// reporting.
+	dc.compareServerMatches(matches)
+
+	return nil
 }
 
 func (c *Core) Sync(dex string, base, quote uint32) (chan *BookUpdate, error) {
@@ -1626,48 +1719,56 @@ func (c *Core) reFee(dcrWallet *xcWallet, dc *dexConnection) {
 	})
 }
 
-// Prepare trackers based on orders stored as active in the database.
+// dbTrackers prepares trackeTrades based on active orders and matches in the
+// database. Since dbTrackers runs before sign in when wallets are not conected
+// or unlocked, wallets and coins are not added to the returned trackers. Use
+// resumeTrades with the app Crypter to prepare wallets and coins.
 func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, error) {
 	// Prepare active orders, according to the DB.
 	dbOrders, err := c.db.ActiveDEXOrders(dc.acct.url)
 	if err != nil {
 		return nil, fmt.Errorf("database error when fetching orders for %s: %x", dc.acct.url, err)
 	}
+	// It's possible for an order to not be active, but still have active matches.
+	// Grab the orders for those too.
+	haveOrder := func(oid order.OrderID) bool {
+		for _, dbo := range dbOrders {
+			if dbo.Order.ID() == oid {
+				return true
+			}
+		}
+		return false
+	}
+
+	activeDBMatches, err := c.db.ActiveDEXMatches(dc.acct.url)
+	if err != nil {
+		return nil, fmt.Errorf("database error fetching active matches for %s: %v", dc.acct.url, err)
+	}
+	for _, dbMatch := range activeDBMatches {
+		oid := dbMatch.Match.OrderID
+		if !haveOrder(oid) {
+			dbOrder, err := c.db.Order(oid)
+			if err != nil {
+				return nil, fmt.Errorf("database error fetching order %s for active match %s at %s: %v", oid, dbMatch.Match.MatchID, dc.acct.url, err)
+			}
+			dbOrders = append(dbOrders, dbOrder)
+		}
+	}
+
 	cancels := make(map[order.OrderID]*order.CancelOrder)
 	cancelPreimages := make(map[order.OrderID]order.Preimage)
 	trackers := make(map[order.OrderID]*trackedTrade, len(dbOrders))
 	for _, dbOrder := range dbOrders {
 		ord, md := dbOrder.Order, dbOrder.MetaData
-		oid := ord.ID()
 		var preImg order.Preimage
 		copy(preImg[:], md.Proof.Preimage)
 		if co, ok := ord.(*order.CancelOrder); ok {
 			cancels[co.TargetOrderID] = co
 			cancelPreimages[co.TargetOrderID] = preImg
 		} else {
-			// Make sure we have the necessary wallets.
-			wallets, err := c.walletSet(dc, ord.Base(), ord.Quote(), ord.Trade().Sell)
-			if err != nil {
-				log.Errorf("wallet retrieval error for active order %s: %v", oid, err)
-				continue
-			}
-			coinIDs := ord.Trade().Coins
-			if len(md.ChangeCoin) != 0 {
-				coinIDs = []order.CoinID{md.ChangeCoin}
-			}
-			coins := make(asset.Coins, 0, len(coinIDs))
-			if len(coinIDs) > 0 {
-				byteIDs := make([]dex.Bytes, 0, len(coinIDs))
-				for _, cid := range coinIDs {
-					byteIDs = append(byteIDs, []byte(cid))
-				}
-				_, err = wallets.fromWallet.FundingCoins(byteIDs)
-				log.Errorf("source coins retrieval error for %s: %v", oid, err)
-				continue
-			}
 			var preImg order.Preimage
 			copy(preImg[:], dbOrder.MetaData.Proof.Preimage)
-			trackers[dbOrder.Order.ID()] = newTrackedTrade(dbOrder, preImg, dc, c.db, c.latencyQ, wallets, coins, c.notify)
+			trackers[dbOrder.Order.ID()] = newTrackedTrade(dbOrder, preImg, dc, c.db, c.latencyQ, nil, nil, c.notify)
 		}
 	}
 	for oid := range cancels {
@@ -1678,11 +1779,174 @@ func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, e
 		}
 		tracker.cancelTrade(cancels[oid], cancelPreimages[oid])
 	}
+
+	for _, dbMatch := range activeDBMatches {
+		// Impossible for the tracker to not be here, since it would have errored
+		// in the previous activeDBMatches loop.
+		tracker := trackers[dbMatch.Match.OrderID]
+		tracker.matches[dbMatch.Match.MatchID] = &matchTracker{
+			id:        dbMatch.Match.MatchID,
+			prefix:    tracker.Prefix(),
+			trade:     tracker.Trade(),
+			MetaMatch: *dbMatch,
+		}
+	}
+
 	return trackers, nil
 }
 
-// connectDEX creates and connects a *dexConnection, but does not authenticate the
-// connection through the 'connect' route.
+// loadDBTrades loads orders and matches from the database for the specified
+// dexConnection. If there are active trades, the necessary wallets will be
+// unlocked. To prevent spamming wallet connections, the 'failed' map will be
+// populated with asset IDs for which the attempt to connect or unlock has
+// failed. The failed map should be passed on subsequent calls for other dexes.
+func (c *Core) loadDBTrades(dc *dexConnection, crypter encrypt.Crypter, failed map[uint32]struct{}) ([]*trackedTrade, error) {
+	// Parse the active trades and see if any wallets need unlocking.
+	trades, err := c.dbTrackers(dc)
+	if err != nil {
+		return nil, fmt.Errorf("error retreiving active matches: %v", err)
+	}
+
+	errs := newErrorSet(dc.acct.url + ": ")
+	ready := make([]*trackedTrade, 0, len(dc.trades))
+	for _, trade := range trades {
+		base, quote := trade.Base(), trade.Quote()
+		_, baseFailed := failed[base]
+		_, quoteFailed := failed[quote]
+		if !baseFailed {
+			baseWallet, err := c.connectedWallet(base)
+			if err != nil {
+				baseFailed = true
+				failed[base] = struct{}{}
+			} else if !baseWallet.unlocked() {
+				err = unlockWallet(baseWallet, crypter)
+				if err != nil {
+					baseFailed = true
+					failed[base] = struct{}{}
+				}
+			}
+		}
+		if !baseFailed && !quoteFailed {
+			quoteWallet, err := c.connectedWallet(quote)
+			if err != nil {
+				quoteFailed = true
+				failed[quote] = struct{}{}
+			} else if !quoteWallet.unlocked() {
+				err = unlockWallet(quoteWallet, crypter)
+				if err != nil {
+					quoteFailed = true
+					failed[quote] = struct{}{}
+				}
+			}
+		}
+		if baseFailed {
+			errs.add("could not complete order %s because the wallet for %s cannot be used", trade.token(), unbip(base))
+			continue
+		}
+		if quoteFailed {
+			errs.add("could not complete order %s because the wallet for %s cannot be used", trade.token(), unbip(quote))
+			continue
+		}
+		ready = append(ready, trade)
+	}
+	return ready, errs.ifany()
+}
+
+// resumeTrades recovers the states of active trades and matches, including
+// loading audit info needed to finish swaps and funding coins needed to create
+// new matches on an order.
+func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) error {
+	var tracker *trackedTrade
+	notifyErr := func(subject, s string, a ...interface{}) {
+		detail := fmt.Sprintf(s, a...)
+		corder, _ := tracker.coreOrder()
+		c.notify(newOrderNote(subject, detail, db.ErrorLevel, corder))
+	}
+	for _, tracker = range trackers {
+		// See if the order is 100% filled.
+		trade := tracker.Trade()
+		// Make sure we have the necessary wallets.
+		wallets, err := c.walletSet(dc, tracker.Base(), tracker.Quote(), trade.Sell)
+		if err != nil {
+			notifyErr("Wallet missing", "Wallet retrieval error for active order %s: %v", tracker.token(), err)
+			continue
+		}
+		tracker.wallets = wallets
+		// If matches haven't redeemed, but the counter-swap has been received,
+		// reload the audit info.
+		isActive := tracker.metaData.Status == order.OrderStatusBooked || tracker.metaData.Status == order.OrderStatusEpoch
+		var stillNeedsCoins bool
+		for _, match := range tracker.matches {
+			dbMatch, metaData := match.Match, match.MetaData
+			var counterSwap []byte
+			takerNeedsSwap := dbMatch.Side == order.Taker && dbMatch.Status >= order.MakerSwapCast && dbMatch.Status < order.MatchComplete
+			if takerNeedsSwap {
+				stillNeedsCoins = true
+				counterSwap = metaData.Proof.MakerSwap
+			}
+			makerNeedsSwap := dbMatch.Side == order.Maker && dbMatch.Status >= order.TakerSwapCast && dbMatch.Status < order.MakerRedeemed
+			if makerNeedsSwap {
+				counterSwap = metaData.Proof.TakerSwap
+			}
+			if takerNeedsSwap || makerNeedsSwap {
+				if len(counterSwap) == 0 {
+					match.failErr = fmt.Errorf("missing counter-swap, order %s, match %s", tracker.ID(), match.id)
+					notifyErr("Match status error", "Match %s for order %s is in state %s, but has no maker swap coin.", dbMatch.Side, tracker.token(), dbMatch.Status)
+					continue
+				}
+				counterContract := metaData.Proof.CounterScript
+				if len(counterContract) == 0 {
+					match.failErr = fmt.Errorf("missing counter-contract, order %s, match %s", tracker.ID(), match.id)
+					notifyErr("Match status error", "Match %s for order %s is in state %s, but has no maker swap contract.", dbMatch.Side, tracker.token(), dbMatch.Status)
+					continue
+				}
+				auditInfo, err := wallets.toWallet.AuditContract(counterSwap, counterContract)
+				if err != nil {
+					match.failErr = fmt.Errorf("audit error, order %s, match %s: %v", tracker.ID(), match.id, err)
+					notifyErr("Match recovery error", "Error auditing counter-parties swap contract during swap recovery on order %s: %v", tracker.token(), err)
+					continue
+				}
+				match.counterSwap = auditInfo
+				continue
+			}
+		}
+
+		// Active orders and orders with matches with unsent swaps need the funding
+		// coin(s).
+		if isActive || stillNeedsCoins {
+			coinIDs := trade.Coins
+			if len(tracker.metaData.ChangeCoin) != 0 {
+				coinIDs = []order.CoinID{tracker.metaData.ChangeCoin}
+			}
+			if len(coinIDs) == 0 {
+				notifyErr("No funding coins", "Order %s has no %s funding coins", tracker.token(), unbip(wallets.fromAsset.ID))
+				continue
+			}
+			byteIDs := make([]dex.Bytes, 0, len(coinIDs))
+			for _, cid := range coinIDs {
+				byteIDs = append(byteIDs, []byte(cid))
+			}
+			if len(byteIDs) == 0 {
+				notifyErr("Order coin error", "No coins for loaded order %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
+				continue
+			}
+			coins, err := wallets.fromWallet.FundingCoins(byteIDs)
+			if err != nil {
+				notifyErr("Order coin error", "Source coins retrieval error for %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
+				continue
+			}
+			tracker.coins = mapifyCoins(coins)
+		}
+
+		dc.tradeMtx.Lock()
+		dc.trades[tracker.ID()] = tracker
+		dc.tradeMtx.Unlock()
+	}
+	return nil
+}
+
+// connectDEX creates and connects a dexConnection, but does not authenticate
+// the connection through the 'connect' route.
 func (c *Core) connectDEX(acctInfo *db.AccountInfo) (*dexConnection, error) {
 	// Get the host from the DEX URL.
 	uri := acctInfo.URL
@@ -1773,20 +2037,18 @@ func (c *Core) connectDEX(acctInfo *db.AccountInfo) (*dexConnection, error) {
 			books:      make(map[string]*book.OrderBook),
 			acct:       newDEXAccount(acctInfo),
 			marketMap:  marketMap,
+			trades:     make(map[order.OrderID]*trackedTrade),
+			notify:     c.notify,
 		}
-		dc.trades, reqErr = c.dbTrackers(dc)
-		if reqErr != nil {
-			connChan <- nil
-			return
-		}
+
 		dc.refreshMarkets()
 		connChan <- dc
 		c.wg.Add(1)
 		// Listen for incoming messages.
 		log.Infof("Connected to DEX %s and listening for messages.", uri)
 		go c.listen(dc)
+	}) // End 'config' request
 
-	})
 	if err != nil {
 		log.Errorf("error sending 'config' request: %v", err)
 		reqErr = err
@@ -2048,7 +2310,7 @@ func handleMatchRoute(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	if err != nil {
 		return fmt.Errorf("match request parsing error: %v", err)
 	}
-	matches, acks, err := dc.parseMatches(msgMatches)
+	matches, acks, err := dc.parseMatches(msgMatches, true)
 	if err != nil {
 		return err
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -175,6 +175,7 @@ func testDexConnection() (*dexConnection, *TWebsocket, *dexAccount) {
 			},
 			Fee: tFee,
 		},
+		notify:    func(Notification) {},
 		marketMap: map[string]*Market{tDcrBtcMktName: mkt},
 		trades:    make(map[order.OrderID]*trackedTrade),
 	}, conn, acct
@@ -218,97 +219,114 @@ func (conn *TWebsocket) Connect(context.Context) (error, *sync.WaitGroup) {
 }
 
 type TDB struct {
-	updateWalletErr error
-	acct            *db.AccountInfo
-	acctErr         error
-	getErr          error
-	storeErr        error
-	encKeyErr       error
-	accts           []*db.AccountInfo
-	updateOrderErr  error
+	updateWalletErr        error
+	acct                   *db.AccountInfo
+	acctErr                error
+	getErr                 error
+	storeErr               error
+	encKeyErr              error
+	accts                  []*db.AccountInfo
+	updateOrderErr         error
+	activeDEXOrders        []*db.MetaOrder
+	matchesForOID          []*db.MetaMatch
+	matchesForOIDErr       error
+	activeMatchesForDEX    []*db.MetaMatch
+	activeMatchesForDEXErr error
 }
 
-func (db *TDB) Run(context.Context) {}
+func (tdb *TDB) Run(context.Context) {}
 
-func (db *TDB) ListAccounts() ([]string, error) {
+func (tdb *TDB) ListAccounts() ([]string, error) {
 	return nil, nil
 }
 
-func (db *TDB) Accounts() ([]*db.AccountInfo, error) {
-	return db.accts, nil
+func (tdb *TDB) Accounts() ([]*db.AccountInfo, error) {
+	return tdb.accts, nil
 }
 
-func (db *TDB) Account(url string) (*db.AccountInfo, error) {
-	return db.acct, db.acctErr
+func (tdb *TDB) Account(url string) (*db.AccountInfo, error) {
+	return tdb.acct, tdb.acctErr
 }
 
-func (db *TDB) CreateAccount(ai *db.AccountInfo) error {
+func (tdb *TDB) CreateAccount(ai *db.AccountInfo) error {
 	return nil
 }
 
-func (db *TDB) UpdateOrder(m *db.MetaOrder) error {
-	return db.updateOrderErr
+func (tdb *TDB) UpdateOrder(m *db.MetaOrder) error {
+	return tdb.updateOrderErr
 }
 
-func (db *TDB) ActiveDEXOrders(dex string) ([]*db.MetaOrder, error) {
+func (tdb *TDB) ActiveDEXOrders(dex string) ([]*db.MetaOrder, error) {
+	return tdb.activeDEXOrders, nil
+}
+
+func (tdb *TDB) ActiveOrders() ([]*db.MetaOrder, error) {
 	return nil, nil
 }
 
-func (db *TDB) ActiveOrders() ([]*db.MetaOrder, error) {
+func (tdb *TDB) AccountOrders(dex string, n int, since uint64) ([]*db.MetaOrder, error) {
 	return nil, nil
 }
 
-func (db *TDB) AccountOrders(dex string, n int, since uint64) ([]*db.MetaOrder, error) {
+func (tdb *TDB) Order(order.OrderID) (*db.MetaOrder, error) {
 	return nil, nil
 }
 
-func (db *TDB) Order(order.OrderID) (*db.MetaOrder, error) {
+func (tdb *TDB) MarketOrders(dex string, base, quote uint32, n int, since uint64) ([]*db.MetaOrder, error) {
 	return nil, nil
 }
 
-func (db *TDB) MarketOrders(dex string, base, quote uint32, n int, since uint64) ([]*db.MetaOrder, error) {
-	return nil, nil
-}
-
-func (db *TDB) UpdateMatch(m *db.MetaMatch) error {
+func (tdb *TDB) SetChangeCoin(order.OrderID, order.CoinID) error {
 	return nil
 }
 
-func (db *TDB) ActiveMatches() ([]*db.MetaMatch, error) {
-	return nil, nil
-}
-
-func (db *TDB) UpdateWallet(wallet *db.Wallet) error {
-	return db.updateWalletErr
-}
-
-func (db *TDB) Wallets() ([]*db.Wallet, error) {
-	return nil, nil
-}
-
-func (db *TDB) AccountPaid(proof *db.AccountProof) error {
+func (tdb *TDB) UpdateMatch(m *db.MetaMatch) error {
 	return nil
 }
 
-func (db *TDB) SaveNotification(*db.Notification) error        { return nil }
-func (db *TDB) NotificationsN(int) ([]*db.Notification, error) { return nil, nil }
-
-func (db *TDB) Store(k string, b []byte) error {
-	return db.storeErr
+func (tdb *TDB) ActiveMatches() ([]*db.MetaMatch, error) {
+	return nil, nil
 }
 
-func (db *TDB) Get(k string) ([]byte, error) {
+func (tdb *TDB) MatchesForOrder(oid order.OrderID) ([]*db.MetaMatch, error) {
+	return tdb.matchesForOID, tdb.matchesForOIDErr
+}
+
+func (tdb *TDB) ActiveDEXMatches(dex string) ([]*db.MetaMatch, error) {
+	return tdb.activeMatchesForDEX, tdb.activeMatchesForDEXErr
+}
+
+func (tdb *TDB) UpdateWallet(wallet *db.Wallet) error {
+	return tdb.updateWalletErr
+}
+
+func (tdb *TDB) Wallets() ([]*db.Wallet, error) {
+	return nil, nil
+}
+
+func (tdb *TDB) AccountPaid(proof *db.AccountProof) error {
+	return nil
+}
+
+func (tdb *TDB) SaveNotification(*db.Notification) error        { return nil }
+func (tdb *TDB) NotificationsN(int) ([]*db.Notification, error) { return nil, nil }
+
+func (tdb *TDB) Store(k string, b []byte) error {
+	return tdb.storeErr
+}
+
+func (tdb *TDB) Get(k string) ([]byte, error) {
 	if k == keyParamsKey {
-		return nil, db.encKeyErr
+		return nil, tdb.encKeyErr
 	}
-	return nil, db.getErr
+	return nil, tdb.getErr
 }
 
-func (db *TDB) Backup() error {
+func (tdb *TDB) Backup() error {
 	return nil
 }
 
-func (db *TDB) AckNotification(id []byte) error { return nil }
+func (tdb *TDB) AckNotification(id []byte) error { return nil }
 
 type tCoin struct {
 	id       []byte
@@ -374,22 +392,24 @@ func (ai *tAuditInfo) SecretHash() dex.Bytes {
 }
 
 type TXCWallet struct {
-	mtx          sync.RWMutex
-	payFeeCoin   *tCoin
-	payFeeErr    error
-	fundCoins    asset.Coins
-	fundErr      error
-	addrErr      error
-	signCoinErr  error
-	swapReceipts []asset.Receipt
-	auditInfo    asset.AuditInfo
-	auditErr     error
-	redeemCoins  []dex.Bytes
-	badSecret    bool
-	fundedVal    uint64
-	connectErr   error
-	unlockErr    error
-	balErr       error
+	mtx            sync.RWMutex
+	payFeeCoin     *tCoin
+	payFeeErr      error
+	fundCoins      asset.Coins
+	fundErr        error
+	addrErr        error
+	signCoinErr    error
+	swapReceipts   []asset.Receipt
+	auditInfo      asset.AuditInfo
+	auditErr       error
+	redeemCoins    []dex.Bytes
+	badSecret      bool
+	fundedVal      uint64
+	connectErr     error
+	unlockErr      error
+	balErr         error
+	fundingCoins   asset.Coins
+	fundingCoinErr error
 }
 
 func newTWallet(assetID uint32) (*xcWallet, *TXCWallet) {
@@ -427,7 +447,7 @@ func (w *TXCWallet) ReturnCoins(asset.Coins) error {
 }
 
 func (w *TXCWallet) FundingCoins([]dex.Bytes) (asset.Coins, error) {
-	return nil, nil
+	return w.fundingCoins, w.fundingCoinErr
 }
 
 func (w *TXCWallet) Swap(swap *asset.Swaps, _ *dex.Asset) ([]asset.Receipt, asset.Coin, error) {
@@ -642,7 +662,8 @@ func TestDexConnectionOrderBook(t *testing.T) {
 	tCore := newTestRig().core
 	mid := "ob"
 	dc := &dexConnection{
-		books: make(map[string]*book.OrderBook),
+		books:  make(map[string]*book.OrderBook),
+		notify: func(Notification) {},
 	}
 
 	// Ensure handleOrderBookMsg creates an order book as expected.
@@ -1089,7 +1110,6 @@ func TestRegister(t *testing.T) {
 }
 
 func TestLogin(t *testing.T) {
-
 	rig := newTestRig()
 	tCore := rig.core
 	rig.acct.pay()
@@ -1105,7 +1125,7 @@ func TestLogin(t *testing.T) {
 
 	queueSuccess()
 	_, err := tCore.Login(tPW)
-	if err != nil {
+	if err != nil || !rig.acct.authed() {
 		t.Fatalf("initial Login error: %v", err)
 	}
 
@@ -1113,7 +1133,7 @@ func TestLogin(t *testing.T) {
 	rig.acct.unauth()
 	rig.db.encKeyErr = tErr
 	_, err = tCore.Login(tPW)
-	if err == nil {
+	if err == nil || rig.acct.authed() {
 		t.Fatalf("no error for missing app key")
 	}
 	rig.db.encKeyErr = nil
@@ -1121,7 +1141,7 @@ func TestLogin(t *testing.T) {
 	// Account not Paid. No error, and account should be unlocked.
 	rig.acct.isPaid = false
 	_, err = tCore.Login(tPW)
-	if err != nil {
+	if err != nil || rig.acct.authed() {
 		t.Fatalf("error for unpaid account: %v", err)
 	}
 	if rig.acct.locked() {
@@ -1137,15 +1157,16 @@ func TestLogin(t *testing.T) {
 		return nil
 	})
 	_, err = tCore.Login(tPW)
-	if err == nil {
-		t.Fatalf("no error for 'connect' route error")
+	// Should be no error, but also not authed. Error is sent and logged
+	// as a notification.
+	if err != nil || rig.acct.authed() {
+		t.Fatalf("account authed after 'connect' error")
 	}
 
 	// Success again.
-	rig.acct.unauth()
 	queueSuccess()
 	_, err = tCore.Login(tPW)
-	if err != nil {
+	if err != nil || !rig.acct.authed() {
 		t.Fatalf("final Login error: %v", err)
 	}
 }
@@ -1689,7 +1710,7 @@ func TestTradeTracking(t *testing.T) {
 			AccountID:  dc.acct.ID(),
 			BaseAsset:  tDCR.ID,
 			QuoteAsset: tBTC.ID,
-			OrderType:  order.MarketOrderType,
+			OrderType:  order.LimitOrderType,
 			ClientTime: time.Now(),
 			ServerTime: time.Now().Add(time.Millisecond),
 			Commit:     preImgL.Commit(),
@@ -2032,6 +2053,168 @@ func TestNotifications(t *testing.T) {
 	default:
 		t.Fatalf("no notification received over the notification channel")
 	}
+}
+
+func TestResolveActiveTrades(t *testing.T) {
+	rig := newTestRig()
+	tCore := rig.core
+
+	btcWallet, tBtcWallet := newTWallet(tBTC.ID)
+	tCore.wallets[tBTC.ID] = btcWallet
+
+	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
+	tCore.wallets[tDCR.ID] = dcrWallet
+
+	rig.acct.auth() // Short path through initializeDEXConnections
+
+	// Create an order
+	qty := tDCR.LotSize * 5
+	rate := tDCR.RateStep * 5
+	lo := &order.LimitOrder{
+		P: order.Prefix{
+			OrderType:  order.LimitOrderType,
+			BaseAsset:  tDCR.ID,
+			QuoteAsset: tBTC.ID,
+			ClientTime: time.Now(),
+			ServerTime: time.Now(),
+			Commit:     ordertest.RandomCommitment(),
+		},
+		T: order.Trade{
+			Quantity: qty,
+			Sell:     true,
+		},
+		Rate: rate,
+	}
+
+	oid := lo.ID()
+	changeCoinID := encode.RandomBytes(32)
+	changeCoin := &tCoin{id: changeCoinID}
+
+	// Need to return an order from db.ActiveDEXOrders
+	rig.db.activeDEXOrders = []*db.MetaOrder{
+		{
+			MetaData: &db.OrderMetaData{
+				Status:     order.OrderStatusBooked,
+				DEX:        tDexUrl,
+				Proof:      db.OrderProof{},
+				ChangeCoin: changeCoinID,
+			},
+			Order: lo,
+		},
+	}
+
+	mid := ordertest.RandomMatchID()
+	addr := ordertest.RandomAddress()
+	match := &db.MetaMatch{
+		MetaData: &db.MatchMetaData{
+			Status: order.MakerSwapCast,
+			Proof: db.MatchProof{
+				CounterScript: encode.RandomBytes(50),
+				SecretHash:    encode.RandomBytes(32),
+				MakerSwap:     encode.RandomBytes(32),
+				Auth: db.MatchAuth{
+					MatchSig: encode.RandomBytes(32),
+				},
+			},
+			DEX:   tDexUrl,
+			Base:  tDCR.ID,
+			Quote: tBTC.ID,
+		},
+		Match: &order.UserMatch{
+			OrderID:  oid,
+			MatchID:  mid,
+			Quantity: qty,
+			Rate:     rate,
+			Address:  addr,
+			Status:   order.MakerSwapCast,
+			Side:     order.Taker,
+		},
+	}
+	rig.db.activeMatchesForDEX = []*db.MetaMatch{match}
+	tDcrWallet.fundingCoins = asset.Coins{changeCoin}
+	_, auditInfo := tMsgAudit(oid, mid, addr, qty, nil)
+	tBtcWallet.auditInfo = auditInfo
+
+	// reset
+	reset := func() {
+		rig.acct.lock()
+		dcrWallet.Lock()
+		btcWallet.Lock()
+		rig.dc.trades = make(map[order.OrderID]*trackedTrade)
+	}
+
+	// Ensure the order is good, and reset the state.
+	ensureGood := func(tag string) {
+		_, err := tCore.Login(tPW)
+		if err != nil {
+			t.Fatalf("%s: login error: %v", tag, err)
+		}
+
+		if !btcWallet.unlocked() {
+			t.Fatalf("%s: btc wallet not unlocked", tag)
+		}
+
+		if !dcrWallet.unlocked() {
+			t.Fatalf("%s: dcr wallet not unlocked", tag)
+		}
+
+		trade, found := rig.dc.trades[oid]
+		if !found {
+			t.Fatalf("%s: trade with expected order id not found. len(trades) = %d", tag, len(rig.dc.trades))
+		}
+
+		_, found = trade.matches[mid]
+		if !found {
+			t.Fatalf("%s: trade with expected order id not found. len(matches) = %d", tag, len(trade.matches))
+		}
+		reset()
+	}
+
+	ensureGood("initial")
+
+	// Ensure a failuare AND reset. err != nil just helps to make sure that we're
+	// hitting errors in resolveActiveTrades, which sends errors as notifications,
+	// vs somewhere else.
+	ensureFail := func(tag string) {
+		_, err := tCore.Login(tPW)
+		if err != nil || len(rig.dc.trades) != 0 {
+			t.Fatalf("%s: no error. err = %v, len(trades) = %d", tag, err, len(rig.dc.trades))
+		}
+		reset()
+	}
+
+	// No base wallet
+	delete(tCore.wallets, tDCR.ID)
+	ensureFail("missing base")
+	tCore.wallets[tDCR.ID] = dcrWallet
+
+	// Base wallet unlock errors
+	tDcrWallet.unlockErr = tErr
+	ensureFail("base unlock")
+	tDcrWallet.unlockErr = nil
+
+	// No quote wallet
+	delete(tCore.wallets, tBTC.ID)
+	ensureFail("missing quote")
+	tCore.wallets[tBTC.ID] = btcWallet
+
+	// Quote wallet unlock errors
+	tBtcWallet.unlockErr = tErr
+	ensureFail("quote unlock")
+	tBtcWallet.unlockErr = nil
+
+	// Funding coin error.
+	tDcrWallet.fundingCoinErr = tErr
+	ensureFail("funding coin")
+	tDcrWallet.fundingCoinErr = nil
+
+	// No matches
+	rig.db.activeMatchesForDEXErr = tErr
+	ensureFail("matches error")
+	rig.db.activeMatchesForDEXErr = nil
+
+	// Success again
+	ensureGood("final")
 }
 
 func convertMsgLimitOrder(msgOrder *msgjson.LimitOrder) *order.LimitOrder {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2217,6 +2217,81 @@ func TestResolveActiveTrades(t *testing.T) {
 	ensureGood("final")
 }
 
+func TestReadConnectMatches(t *testing.T) {
+	rig := newTestRig()
+	preImg := newPreimage()
+	dc := rig.dc
+
+	notes := make(map[string][]Notification)
+	notify := func(note Notification) {
+		notes[note.Type()] = append(notes[note.Type()], note)
+	}
+
+	lo := &order.LimitOrder{
+		P: order.Prefix{
+			// 	OrderType:  order.LimitOrderType,
+			// 	BaseAsset:  tDCR.ID,
+			// 	QuoteAsset: tBTC.ID,
+			// 	ClientTime: time.Now(),
+			ServerTime: time.Now(),
+			// 	Commit:     preImg.Commit(),
+		},
+	}
+	oid := lo.ID()
+	dbOrder := &db.MetaOrder{
+		// MetaData: &db.OrderMetaData{},
+		Order: lo,
+	}
+	tracker := newTrackedTrade(dbOrder, preImg, dc, rig.db, rig.queue, nil, nil, notify)
+	metaMatch := db.MetaMatch{
+		MetaData: &db.MatchMetaData{},
+		Match:    &order.UserMatch{},
+	}
+
+	// Store a match
+	knownID := ordertest.RandomMatchID()
+	knownMatch := &matchTracker{
+		id:        knownID,
+		MetaMatch: metaMatch,
+	}
+	tracker.matches[knownID] = knownMatch
+	knownMsgMatch := &msgjson.Match{OrderID: oid[:], MatchID: knownID[:]}
+
+	missingID := ordertest.RandomMatchID()
+	missingMatch := &matchTracker{
+		id:        missingID,
+		MetaMatch: metaMatch,
+	}
+	tracker.matches[missingID] = missingMatch
+
+	extraID := ordertest.RandomMatchID()
+	extraMsgMatch := &msgjson.Match{OrderID: oid[:], MatchID: extraID[:]}
+
+	matches := []*msgjson.Match{knownMsgMatch, extraMsgMatch}
+	tracker.readConnectMatches(matches)
+
+	if knownMatch.failErr != nil {
+		t.Fatalf("error set for known and reported match")
+	}
+
+	if missingMatch.failErr == nil {
+		t.Fatalf("error not set for missing match")
+	}
+
+	if len(notes["order"]) != 2 {
+		t.Fatalf("expected 2 core 'order'-type notifications, got %d", len(notes["order"]))
+	}
+
+	if notes["order"][0].Subject() != "Missing matches" {
+		t.Fatalf("no core notification sent for missing matches")
+	}
+
+	if notes["order"][1].Subject() != "Match resolution error" {
+		t.Fatalf("no core notification sent for unknown matches")
+	}
+
+}
+
 func convertMsgLimitOrder(msgOrder *msgjson.LimitOrder) *order.LimitOrder {
 	tif := order.ImmediateTiF
 	if msgOrder.TiF == msgjson.StandingOrderNum {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -193,6 +193,38 @@ func (t *trackedTrade) cancelTrade(co *order.CancelOrder, preImg order.Preimage)
 	t.mtx.Unlock()
 }
 
+// readConnectMatches resolves the matches reported by the server in the
+// 'connect' response against those marked incomplete in the matchTracker map.
+func (t *trackedTrade) readConnectMatches(msgMatches []*msgjson.Match) (new, extras []*msgjson.Match) {
+	ids := make(map[order.MatchID]bool)
+	var missing int
+	t.matchMtx.RLock()
+	defer t.matchMtx.RUnlock()
+	for _, msgMatch := range msgMatches {
+		var matchID order.MatchID
+		copy(matchID[:], msgMatch.MatchID)
+		ids[matchID] = true
+		_, found := t.matches[matchID]
+		if !found {
+			extras = append(extras, msgMatch)
+			continue
+		}
+		new = append(new, msgMatch)
+	}
+	for _, match := range t.matches {
+		if !ids[match.id] {
+			missing++
+			match.failErr = fmt.Errorf("order not reported by the server on connect")
+		}
+	}
+	if missing > 0 {
+		details := fmt.Sprintf("%d matches for order %s were not reported by %s and are in a failed state", missing, t.ID(), t.dc.acct.url)
+		corder, _ := t.coreOrder()
+		t.notify(newOrderNote("Missing matches", details, db.ErrorLevel, corder))
+	}
+	return
+}
+
 // negotiate creates and stores matchTrackers for the []*msgjson.Match, and
 // updates (UserMatch).Filled. Match negotiation can then be progressed by
 // calling (*trackedTrade).tick when a relevant event occurs, such as a request
@@ -299,7 +331,33 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		t.notify(newOrderNote("Matches made", details, db.Poke, corder))
 	}
 
+	// Set the order as executed depending on type and fill.
+	if t.metaData.Status != order.OrderStatusCanceled {
+		switch t.Prefix().Type() {
+		case order.LimitOrderType:
+			if trade.Filled() == trade.Quantity {
+				t.metaData.Status = order.OrderStatusExecuted
+			}
+		case order.CancelOrderType:
+			t.metaData.Status = order.OrderStatusCanceled
+		case order.MarketOrderType:
+			t.metaData.Status = order.OrderStatusExecuted
+		}
+	}
+
+	err := t.db.UpdateOrder(t.metaOrder())
+	if err != nil {
+		return fmt.Errorf("Failed to update order in db")
+	}
+
 	return t.tick()
+}
+
+func (t *trackedTrade) metaOrder() *db.MetaOrder {
+	return &db.MetaOrder{
+		MetaData: t.metaData,
+		Order:    t.Order,
+	}
 }
 
 // processCancelMatch should be called with the message for the match on a
@@ -323,6 +381,7 @@ func (t *trackedTrade) isSwappable(match *matchTracker) bool {
 	if match.failErr != nil {
 		return false
 	}
+
 	dbMatch, metaData, _, _ := match.parts()
 	walletLocked := !t.wallets.fromWallet.unlocked()
 	if dbMatch.Side == order.Taker && metaData.Status == order.MakerSwapCast {
@@ -393,6 +452,7 @@ func (t *trackedTrade) tick() error {
 	var sent, quoteSent, received, quoteReceived uint64
 	for _, match := range t.matches {
 		if t.isSwappable(match) {
+
 			swaps = append(swaps, match)
 			sent += match.Match.Quantity
 			quoteSent += calc.BaseToQuote(match.Match.Rate, match.Match.Quantity)
@@ -422,7 +482,6 @@ func (t *trackedTrade) tick() error {
 
 			details := fmt.Sprintf("Sent swaps worth %.8f %s on order %s",
 				float64(qty)/conversionFactor, unbip(fromID), t.token())
-			log.Error(details)
 			t.notify(newOrderNote("Swaps initiated", details, db.Poke, corder))
 		}
 
@@ -442,7 +501,7 @@ func (t *trackedTrade) tick() error {
 			return err
 		} else {
 			details := fmt.Sprintf("Redeemed %.8f %s on order %s", float64(qty)/conversionFactor, unbip(toAsset), t.token())
-			log.Error(details)
+			log.Info(details)
 			t.notify(newOrderNote("Match complete", details, db.Poke, corder))
 		}
 	}
@@ -508,6 +567,7 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 	t.change = change
 	t.coins[change.String()] = change
 	t.metaData.ChangeCoin = []byte(change.ID())
+	t.db.SetChangeCoin(t.ID(), t.metaData.ChangeCoin)
 
 	// Prepare the msgjson.Init and send to the DEX.
 	oid := t.ID()
@@ -549,6 +609,10 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 		} else {
 			match.setStatus(order.MakerSwapCast)
 			proof.MakerSwap = coinID
+		}
+		err = t.db.UpdateMatch(&match.MetaMatch)
+		if err != nil {
+			return errs.add("error storing match info in database: %v", err)
 		}
 
 	}
@@ -728,14 +792,16 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 func (t *trackedTrade) processRedemption(msgID uint64, redemption *msgjson.Redemption) error {
 	var mid order.MatchID
 	copy(mid[:], redemption.MatchID)
-	errs := newErrorSet("processRedemption order %s, match %s -", t.ID(), mid)
+	errs := newErrorSet("processRedemption order %s, match %s - ", t.ID(), mid)
 	t.matchMtx.Lock()
 	defer t.matchMtx.Unlock()
 	match, found := t.matches[mid]
 	if !found {
 		return errs.add("match not known")
 	}
-	if match.counterSwap == nil {
+	// If the order was loaded from the DB, we're the maker, and we've already
+	// redeemed, the counterSwap (AuditInfo) will not have been retrieved.
+	if match.Match.Side == order.Taker && match.counterSwap == nil {
 		return errs.add("redemption received before audit request")
 	}
 	sigMsg, _ := redemption.Serialize()

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -55,12 +55,19 @@ type DB interface {
 	// returned. since = 0 is equivalent to disabling the time filter, since
 	// no orders were created before before 1970.
 	MarketOrders(dex string, base, quote uint32, n int, since uint64) ([]*MetaOrder, error)
+	// SetChangeCoin stores the change coin for the order.
+	SetChangeCoin(order.OrderID, order.CoinID) error
 	// UpdateMatch updates the match information in the database. Any existing
 	// entry for the match will be overwritten without indication.
 	UpdateMatch(m *MetaMatch) error
 	// ActiveMatches retrieves the matches that are in an active state, which is
 	// any state except order.MatchComplete.
 	ActiveMatches() ([]*MetaMatch, error)
+	// ActiveDEXMatches retrieves the matches that are in an active state for a
+	// specified DEX, which is any state except order.MatchComplete.
+	ActiveDEXMatches(dex string) ([]*MetaMatch, error)
+	// MatchesForOrder gets the matches for the order ID.
+	MatchesForOrder(oid order.OrderID) ([]*MetaMatch, error)
 	// Update wallets adds a wallet to the database, or updates the wallet
 	// credentials if the wallet already exists. A wallet is specified by the
 	// pair (asset ID, account name).

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -181,6 +181,7 @@ type MetaMatch struct {
 	Match *order.UserMatch
 }
 
+// ID is a unique ID for the match-order pair.
 func (m *MetaMatch) ID() []byte {
 	return hashKey(append(m.Match.MatchID[:], m.Match.OrderID[:]...))
 }

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -181,6 +181,10 @@ type MetaMatch struct {
 	Match *order.UserMatch
 }
 
+func (m *MetaMatch) ID() []byte {
+	return hashKey(append(m.Match.MatchID[:], m.Match.OrderID[:]...))
+}
+
 // MatchMetaData is important auxiliary information about the match.
 type MatchMetaData struct {
 	// Status is the last known match status.
@@ -504,7 +508,7 @@ func NewNotification(noteType, subject, details string, severity Severity) Notif
 
 // ID is a unique ID based on a hash of the notification data.
 func (n *Notification) ID() dex.Bytes {
-	return hashKey(n.Encode())
+	return noteKey(n.Encode())
 }
 
 // Type is the notification type.
@@ -592,11 +596,17 @@ func (n *Notification) Encode() []byte {
 		AddData(uint64Bytes(n.TimeStamp))
 }
 
-// hashKeySize must be <= 32.
-const hashKeySize = 8
+// noteKeySize must be <= 32.
+const noteKeySize = 8
+
+// noteKey creates a unique key from the hash of the supplied bytes.
+func noteKey(b []byte) []byte {
+	h := blake2s.Sum256(b)
+	return h[:noteKeySize]
+}
 
 // hashKey creates a unique key from the hash of the supplied bytes.
 func hashKey(b []byte) []byte {
 	h := blake2s.Sum256(b)
-	return h[:hashKeySize]
+	return h[:]
 }


### PR DESCRIPTION
Reload and prepare active orders and orders with active matches, and the matches, from the database when the user signs in. Resolve the matches reported in the server's 'connect' response with the local state. Only issue errors when discrepancies are found for now, but more sophisticated handling will be needed.

Unlock wallets needed for active orders when the user signs in.