### PR TITLE
multi: connect order book

### DIFF
--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -63,12 +63,11 @@ func main() {
 		os.Stdout.Write(msg)
 	}
 	logMaker := ui.InitLogging(logStdout, cfg.DebugLevel)
-	log = logMaker.Logger("DEXC")
+	core.UseLoggerMaker(logMaker)
 
 	clientCore, err := core.New(&core.Config{
-		DBPath:      cfg.DBPath, // global set in config.go
-		LoggerMaker: logMaker,
-		Net:         cfg.Net,
+		DBPath: cfg.DBPath, // global set in config.go
+		Net:    cfg.Net,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating client core: %v\n", err)

--- a/client/cmd/dexc/ui/widgets.go
+++ b/client/cmd/dexc/ui/widgets.go
@@ -104,11 +104,11 @@ func createApp() {
 	if err != nil {
 		log.Errorf("error creating core logger")
 	}
+	core.UseLoggerMaker(lm)
 
 	clientCore, err = core.New(&core.Config{
-		DBPath:      cfg.DBPath, // global set in config.go
-		LoggerMaker: lm,
-		Net:         cfg.Net,
+		DBPath: cfg.DBPath, // global set in config.go
+		Net:    cfg.Net,
 	})
 	if err != nil {
 		log.Errorf("error creating client core: %v", err)

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -1,0 +1,372 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package core
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	orderbook "decred.org/dcrdex/client/order"
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+)
+
+var (
+	feederID        uint32
+	bookFeedTimeout = time.Minute
+)
+
+// BookFeed manages a channel for receiving order book updates. The only
+// exported field, C, is a channel on which to receive the updates as a series
+// of *BookUpdate. It is imperative that the feeder (*BookFeed).Close() when no
+// longer using the feed.
+type BookFeed struct {
+	C     chan *BookUpdate
+	off   chan struct{}
+	id    uint32
+	close func(*BookFeed)
+}
+
+// NewBookFeed is a constructor for a *BookFeed. The caller must Close() the
+// feed when it's no longer being used.
+func NewBookFeed(close func(feed *BookFeed)) *BookFeed {
+	return &BookFeed{
+		C:     make(chan *BookUpdate, 1),
+		off:   make(chan struct{}),
+		id:    atomic.AddUint32(&feederID, 1),
+		close: close,
+	}
+}
+
+// Close the BookFeed.
+func (f *BookFeed) Close() {
+	f.close(f)
+	close(f.off)
+}
+
+// on is used internally to see whether the caller has Close()d the feed.
+func (f *BookFeed) on() bool {
+	select {
+	case <-f.off:
+		return false
+	default:
+	}
+	return true
+}
+
+// bookie is a BookFeed manager. bookie will maintain any number of order book
+// subscribers. When the number of subscribers goes to zero, book feed does
+// not immediately close(). Instead, a timer is set and if no more feeders
+// subscribe before the timer expires, then the bookie will invoke it's caller
+// supplied close() callback.
+type bookie struct {
+	orderbook.OrderBook
+	mtx        sync.Mutex
+	feeds      map[uint32]*BookFeed
+	close      func()
+	closeTimer *time.Timer
+}
+
+// newBookie is a constructor for a bookie. The caller should provide a callback
+// function to be called when there are no subscribers and the close timer has
+// expired.
+func newBookie(close func()) *bookie {
+	return &bookie{
+		OrderBook: *orderbook.NewOrderBook(),
+		feeds:     make(map[uint32]*BookFeed, 1),
+		close:     close,
+	}
+}
+
+// feed gets a new *BookFeed and cancels the close timer.
+func (b *bookie) feed() *BookFeed {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	if b.closeTimer != nil {
+		b.closeTimer.Stop()
+		b.closeTimer = nil
+	}
+	feed := NewBookFeed(b.closeFeed)
+	b.feeds[feed.id] = feed
+	return feed
+}
+
+// closeFeed is ultimately called when the BookFeed subscriber closes the feed.
+// If this was the last feed for this bookie aka market, set a timer to
+// unsubscribe unless another feed is requested.
+func (b *bookie) closeFeed(feed *BookFeed) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	beforeLen := len(b.feeds)
+	delete(b.feeds, feed.id)
+	if beforeLen == 1 && len(b.feeds) == 0 {
+		if b.closeTimer != nil {
+			b.closeTimer.Stop()
+		}
+		b.closeTimer = time.AfterFunc(bookFeedTimeout, func() {
+			b.mtx.Lock()
+			defer b.mtx.Unlock()
+			if len(b.feeds) == 0 {
+				b.close()
+			}
+		})
+	}
+}
+
+// send sends a *BookUpdate to all subscribers.
+func (b *bookie) send(u *BookUpdate) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	for fid, feed := range b.feeds {
+		if !feed.on() {
+			delete(b.feeds, fid)
+			continue
+		}
+		select {
+		case feed.C <- u:
+		default:
+			log.Errorf("closing blocking book update channel")
+			delete(b.feeds, fid)
+		}
+	}
+}
+
+// book returns the bookie's current order book.
+func (b *bookie) book() *OrderBook {
+	buys, sells, epoch := b.Orders()
+	return &OrderBook{
+		Buys:  translateBookSide(buys),
+		Sells: translateBookSide(sells),
+		Epoch: translateBookSide(epoch),
+	}
+}
+
+// Sync subscribes to the order book and returns the book and a BookFeed to
+// receive order book updates. The BookFeed must be Close()d when it is no
+// longer in use.
+func (c *Core) Sync(url string, base, quote uint32) (*OrderBook, *BookFeed, error) {
+	// Need to send the 'orderbook' message and parse the results.
+	c.connMtx.RLock()
+	dc, found := c.conns[url]
+	c.connMtx.RUnlock()
+	if !found {
+		return nil, nil, fmt.Errorf("unkown DEX '%s'", url)
+	}
+
+	mkt := marketName(base, quote)
+	dc.booksMtx.Lock()
+	defer dc.booksMtx.Unlock()
+	booky, found := dc.books[mkt]
+	if found {
+		return booky.book(), booky.feed(), nil
+	}
+
+	// Make sure the market exists.
+	dc.marketMtx.RLock()
+	_, found = dc.marketMap[mkt]
+	dc.marketMtx.RUnlock()
+	if !found {
+		return nil, nil, fmt.Errorf("unknown market %s", mkt)
+	}
+
+	// Subscribe
+	req, err := msgjson.NewRequest(dc.NextID(), msgjson.OrderBookRoute, &msgjson.OrderBookSubscription{
+		Base:  base,
+		Quote: quote,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error encoding 'orderbook' request: %v", err)
+	}
+	errChan := make(chan error, 1)
+	result := new(msgjson.OrderBook)
+	err = dc.Request(req, func(msg *msgjson.Message) {
+		errChan <- msg.UnmarshalResult(result)
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error subscribing to %s orderbook: %v", mkt, err)
+	}
+	err = extractError(errChan, requestTimeout, msgjson.OrderBookRoute)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	booky = newBookie(func() { c.unsub(dc, mkt) })
+	err = booky.Sync(result)
+	if err != nil {
+		return nil, nil, err
+	}
+	dc.books[mkt] = booky
+
+	return booky.book(), booky.feed(), nil
+}
+
+// unsub is the close callback passed to the bookie, and will be called when
+// there are no more subscribers and the close delay period has expired.
+func (c *Core) unsub(dc *dexConnection, mkt string) {
+	log.Debugf("unsubscribing from %s", mkt)
+
+	dc.booksMtx.Lock()
+	delete(dc.books, mkt)
+	dc.booksMtx.Unlock()
+
+	req, err := msgjson.NewRequest(dc.NextID(), msgjson.UnsubOrderBookRoute, &msgjson.UnsubOrderBook{
+		MarketID: mkt,
+	})
+	if err != nil {
+		log.Errorf("unsub_orderbook message encoding error: %v", err)
+		return
+	}
+	err = dc.Request(req, func(msg *msgjson.Message) {
+		var res bool
+		msg.UnmarshalResult(&res)
+		if !res {
+			log.Errorf("error unsubscribing from %s", mkt)
+		}
+	})
+	if err != nil {
+		log.Errorf("request error unsubscribing from %s orderbook: %v", mkt, err)
+	}
+}
+
+// Book fetches the order book. Book must be called after Sync.
+func (c *Core) Book(dex string, base, quote uint32) (*OrderBook, error) {
+	c.connMtx.RLock()
+	dc, found := c.conns[dex]
+	c.connMtx.RUnlock()
+	if !found {
+		return nil, fmt.Errorf("no DEX %s", dex)
+	}
+
+	mkt := marketName(base, quote)
+	dc.booksMtx.RLock()
+	book, found := dc.books[mkt]
+	dc.booksMtx.RUnlock()
+	if !found {
+		return nil, fmt.Errorf("no market %s", mkt)
+	}
+
+	buys, sells, epoch := book.Orders()
+
+	return &OrderBook{
+		Buys:  translateBookSide(buys),
+		Sells: translateBookSide(sells),
+		Epoch: translateBookSide(epoch),
+	}, nil
+}
+
+// translateBookSide translates from []*orderbook.Order to []*MiniOrder.
+func translateBookSide(ins []*orderbook.Order) (outs []*MiniOrder) {
+	for _, o := range ins {
+		outs = append(outs, &MiniOrder{
+			Qty:   float64(o.Quantity) / 1e8,
+			Rate:  float64(o.Rate) / 1e8,
+			Sell:  o.Side == msgjson.SellOrderNum,
+			Token: token(o.OrderID[:]),
+		})
+	}
+	return
+}
+
+// handleBookOrderMsg is called when a book_order notification is received.
+func handleBookOrderMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) error {
+	note := new(msgjson.BookOrderNote)
+	err := msg.Unmarshal(note)
+	if err != nil {
+		return fmt.Errorf("book order note unmarshal error: %v", err)
+	}
+
+	dc.booksMtx.RLock()
+	defer dc.booksMtx.RUnlock()
+
+	book, ok := dc.books[note.MarketID]
+	if !ok {
+		return fmt.Errorf("no order book found with market id '%v'",
+			note.MarketID)
+	}
+	err = book.Book(note)
+	if err != nil {
+		return err
+	}
+	book.send(&BookUpdate{
+		Action: msg.Route,
+		Order:  minifyOrder(note.OrderID, &note.TradeNote, 0),
+	})
+	return nil
+}
+
+// handleUnbookOrderMsg is called when an unbook_order notification is
+// received.
+func handleUnbookOrderMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) error {
+	note := new(msgjson.UnbookOrderNote)
+	err := msg.Unmarshal(note)
+	if err != nil {
+		return fmt.Errorf("unbook order note unmarshal error: %v", err)
+	}
+
+	dc.booksMtx.RLock()
+	defer dc.booksMtx.RUnlock()
+
+	book, ok := dc.books[note.MarketID]
+	if !ok {
+		return fmt.Errorf("no order book found with market id %q",
+			note.MarketID)
+	}
+	err = book.Unbook(note)
+	if err != nil {
+		return err
+	}
+	book.send(&BookUpdate{
+		Action: msg.Route,
+		Order:  &MiniOrder{Token: token(note.OrderID)},
+	})
+
+	return nil
+}
+
+// handleEpochOrderMsg is called when an epoch_order notification is
+// received.
+func handleEpochOrderMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
+	note := new(msgjson.EpochOrderNote)
+	err := msg.Unmarshal(note)
+	if err != nil {
+		return fmt.Errorf("epoch order note unmarshal error: %v", err)
+	}
+
+	c.setEpoch(note.Epoch)
+
+	dc.booksMtx.RLock()
+	defer dc.booksMtx.RUnlock()
+
+	book, ok := dc.books[note.MarketID]
+	if !ok {
+		return fmt.Errorf("no order book found with market id %q",
+			note.MarketID)
+	}
+
+	err = book.Enqueue(note)
+	if err != nil {
+		return err
+	}
+	// Send a mini-order for book updates.
+	book.send(&BookUpdate{
+		Action: msg.Route,
+		Order:  minifyOrder(note.OrderID, &note.TradeNote, note.Epoch),
+	})
+
+	return nil
+}
+
+// minifyOrder creates a MiniOrder from a TradeNote. The epoch and order ID must
+// be supplied.
+func minifyOrder(oid dex.Bytes, trade *msgjson.TradeNote, epoch uint64) *MiniOrder {
+	return &MiniOrder{
+		Qty:   float64(trade.Quantity) / 1e8,
+		Rate:  float64(trade.Rate) / 1e8,
+		Sell:  trade.Side == msgjson.SellOrderNum,
+		Token: token(oid),
+		Epoch: epoch,
+	}
+}

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -153,7 +153,7 @@ func (c *Core) Sync(url string, base, quote uint32) (*OrderBook, *BookFeed, erro
 	dc, found := c.conns[url]
 	c.connMtx.RUnlock()
 	if !found {
-		return nil, nil, fmt.Errorf("unkown DEX '%s'", url)
+		return nil, nil, fmt.Errorf("unknown DEX '%s'", url)
 	}
 
 	mkt := marketName(base, quote)
@@ -261,8 +261,8 @@ func (c *Core) Book(dex string, base, quote uint32) (*OrderBook, error) {
 func translateBookSide(ins []*orderbook.Order) (outs []*MiniOrder) {
 	for _, o := range ins {
 		outs = append(outs, &MiniOrder{
-			Qty:   float64(o.Quantity) / 1e8,
-			Rate:  float64(o.Rate) / 1e8,
+			Qty:   float64(o.Quantity) / conversionFactor,
+			Rate:  float64(o.Rate) / conversionFactor,
 			Sell:  o.Side == msgjson.SellOrderNum,
 			Token: token(o.OrderID[:]),
 		})
@@ -363,8 +363,8 @@ func handleEpochOrderMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error
 // be supplied.
 func minifyOrder(oid dex.Bytes, trade *msgjson.TradeNote, epoch uint64) *MiniOrder {
 	return &MiniOrder{
-		Qty:   float64(trade.Quantity) / 1e8,
-		Rate:  float64(trade.Rate) / 1e8,
+		Qty:   float64(trade.Quantity) / conversionFactor,
+		Rate:  float64(trade.Rate) / conversionFactor,
 		Sell:  trade.Side == msgjson.SellOrderNum,
 		Token: token(oid),
 		Epoch: epoch,

--- a/client/core/log.go
+++ b/client/core/log.go
@@ -1,0 +1,28 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package core
+
+import (
+	orderbook "decred.org/dcrdex/client/order"
+	"decred.org/dcrdex/dex"
+	"github.com/decred/slog"
+)
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests it.
+var log = slog.Disabled
+var loggerMaker *dex.LoggerMaker
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	log = slog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLoggerMaker(maker *dex.LoggerMaker) {
+	loggerMaker = maker
+	log = maker.Logger("CORE")
+	orderbook.UseLogger(maker.Logger("ORDBOOK"))
+}

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -110,3 +110,16 @@ func newOrderNote(subject, details string, severity db.Severity, corder *Order) 
 		Order:        corder,
 	}
 }
+
+// EpochNotification is a data notifcation that a new epoch has begun.
+type EpochNotification struct {
+	db.Notification
+	Epoch uint64 `json:"epoch"`
+}
+
+func newEpochNotification(epochIdx uint64) *EpochNotification {
+	return &EpochNotification{
+		Notification: db.NewNotification("epoch", "", "", db.Data),
+		Epoch:        epochIdx,
+	}
+}

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -103,7 +103,7 @@ func newTrackedTrade(dbOrder *db.MetaOrder, preImg order.Preimage, dc *dexConnec
 		latencyQ: latencyQ,
 		wallets:  wallets,
 		preImg:   preImg,
-		mktID:    mktID(ord.Base(), ord.Quote()),
+		mktID:    marketName(ord.Base(), ord.Quote()),
 		coins:    mapifyCoins(coins),
 		matches:  make(map[order.MatchID]*matchTracker),
 		notify:   notify,

--- a/client/order/bookside.go
+++ b/client/order/bookside.go
@@ -106,8 +106,16 @@ func (d *bookSide) Remove(order *Order) error {
 	return fmt.Errorf("order %s not found", order.OrderID)
 }
 
+// orders is all orders for the side, sorted.
+func (d *bookSide) orders() []*Order {
+	orders, _ := d.BestNOrders(int(^uint(0) >> 1)) // Max int value
+	return orders
+}
+
 // BestNOrders returns the best N orders of the book side.
 func (d *bookSide) BestNOrders(n int) ([]*Order, bool) {
+	d.mtx.RLock()
+	defer d.mtx.RUnlock()
 	count := n
 	best := make([]*Order, 0)
 

--- a/client/order/log.go
+++ b/client/order/log.go
@@ -1,0 +1,23 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package order
+
+import (
+	"github.com/decred/slog"
+)
+
+// log is a logger that is initialized with no output filters. This means the
+// package will not perform any logging by default until the caller requests it.
+var log = slog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	log = slog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/client/order/orderbook_test.go
+++ b/client/order/orderbook_test.go
@@ -293,31 +293,31 @@ func TestOrderBookBook(t *testing.T) {
 			),
 			wantErr: false,
 		},
-		{
-			label: "Book buy order with outdated sequence value",
-			orderBook: makeOrderBook(
-				2,
-				"ob",
-				[]*Order{
-					makeOrder([32]byte{'b'}, msgjson.BuyOrderNum, 10, 1, 2),
-					makeOrder([32]byte{'c'}, msgjson.BuyOrderNum, 10, 2, 5),
-				},
-				make([]*cachedOrderNote, 0),
-				true,
-			),
-			note: makeBookOrderNote(0, "ob", [32]byte{'a'}, msgjson.BuyOrderNum, 2, 3, 1),
-			expected: makeOrderBook(
-				2,
-				"ob",
-				[]*Order{
-					makeOrder([32]byte{'b'}, msgjson.BuyOrderNum, 10, 1, 2),
-					makeOrder([32]byte{'c'}, msgjson.BuyOrderNum, 10, 2, 5),
-				},
-				make([]*cachedOrderNote, 0),
-				true,
-			),
-			wantErr: false,
-		},
+		// {
+		// 	label: "Book buy order with outdated sequence value",
+		// 	orderBook: makeOrderBook(
+		// 		2,
+		// 		"ob",
+		// 		[]*Order{
+		// 			makeOrder([32]byte{'b'}, msgjson.BuyOrderNum, 10, 1, 2),
+		// 			makeOrder([32]byte{'c'}, msgjson.BuyOrderNum, 10, 2, 5),
+		// 		},
+		// 		make([]*cachedOrderNote, 0),
+		// 		true,
+		// 	),
+		// 	note: makeBookOrderNote(0, "ob", [32]byte{'a'}, msgjson.BuyOrderNum, 2, 3, 1),
+		// 	expected: makeOrderBook(
+		// 		2,
+		// 		"ob",
+		// 		[]*Order{
+		// 			makeOrder([32]byte{'b'}, msgjson.BuyOrderNum, 10, 1, 2),
+		// 			makeOrder([32]byte{'c'}, msgjson.BuyOrderNum, 10, 2, 5),
+		// 		},
+		// 		make([]*cachedOrderNote, 0),
+		// 		true,
+		// 	),
+		// 	wantErr: false,
+		// },
 		{
 			label: "Book buy order to unsynced order book",
 			orderBook: makeOrderBook(
@@ -362,29 +362,29 @@ func TestOrderBookBook(t *testing.T) {
 			expected: nil,
 			wantErr:  true,
 		},
-		{
-			label: "Book sell order to synced order book with future sequence value",
-			orderBook: makeOrderBook(
-				2,
-				"ob",
-				[]*Order{
-					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
-					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
-				},
-				make([]*cachedOrderNote, 0),
-				true,
-			),
-			note:     makeBookOrderNote(5, "ob", [32]byte{'d'}, msgjson.SellOrderNum, 5, 3, 10),
-			expected: nil,
-			wantErr:  true,
-		},
+		// {
+		// 	label: "Book sell order to synced order book with future sequence value",
+		// 	orderBook: makeOrderBook(
+		// 		2,
+		// 		"ob",
+		// 		[]*Order{
+		// 			makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+		// 			makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+		// 		},
+		// 		make([]*cachedOrderNote, 0),
+		// 		true,
+		// 	),
+		// 	note:     makeBookOrderNote(5, "ob", [32]byte{'d'}, msgjson.SellOrderNum, 5, 3, 10),
+		// 	expected: nil,
+		// 	wantErr:  true,
+		// },
 	}
 
 	for idx, tc := range tests {
 		err := tc.orderBook.Book(tc.note)
 		if (err != nil) != tc.wantErr {
-			t.Fatalf("[OrderBook.Book] #%d: error: %v, wantErr: %v",
-				idx+1, err, tc.wantErr)
+			t.Fatalf("[OrderBook.Book:%s]: error: %v, wantErr: %v",
+				tc.label, err, tc.wantErr)
 		}
 
 		if !tc.wantErr {
@@ -456,31 +456,31 @@ func TestOrderBookUnbook(t *testing.T) {
 			),
 			wantErr: false,
 		},
-		{
-			label: "Unbook sell order with outdated sequence value",
-			orderBook: makeOrderBook(
-				2,
-				"ob",
-				[]*Order{
-					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
-					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
-				},
-				make([]*cachedOrderNote, 0),
-				true,
-			),
-			note: makeUnbookOrderNote(0, "ob", [32]byte{'a'}),
-			expected: makeOrderBook(
-				2,
-				"ob",
-				[]*Order{
-					makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
-					makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
-				},
-				make([]*cachedOrderNote, 0),
-				true,
-			),
-			wantErr: false,
-		},
+		// {
+		// 	label: "Unbook sell order with outdated sequence value",
+		// 	orderBook: makeOrderBook(
+		// 		2,
+		// 		"ob",
+		// 		[]*Order{
+		// 			makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+		// 			makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+		// 		},
+		// 		make([]*cachedOrderNote, 0),
+		// 		true,
+		// 	),
+		// 	note: makeUnbookOrderNote(0, "ob", [32]byte{'a'}),
+		// 	expected: makeOrderBook(
+		// 		2,
+		// 		"ob",
+		// 		[]*Order{
+		// 			makeOrder([32]byte{'b'}, msgjson.SellOrderNum, 10, 1, 2),
+		// 			makeOrder([32]byte{'c'}, msgjson.SellOrderNum, 10, 2, 5),
+		// 		},
+		// 		make([]*cachedOrderNote, 0),
+		// 		true,
+		// 	),
+		// 	wantErr: false,
+		// },
 		{
 			label: "Unbook sell order with unsynced order book",
 			orderBook: makeOrderBook(
@@ -546,8 +546,8 @@ func TestOrderBookUnbook(t *testing.T) {
 	for idx, tc := range tests {
 		err := tc.orderBook.Unbook(tc.note)
 		if (err != nil) != tc.wantErr {
-			t.Fatalf("[OrderBook.Book] #%d: error: %v, wantErr: %v",
-				idx+1, err, tc.wantErr)
+			t.Fatalf("[OrderBook.Book:%s]: error: %v, wantErr: %v",
+				tc.label, err, tc.wantErr)
 		}
 
 		if !tc.wantErr {

--- a/client/order/orderbook_test.go
+++ b/client/order/orderbook_test.go
@@ -293,6 +293,8 @@ func TestOrderBookBook(t *testing.T) {
 			),
 			wantErr: false,
 		},
+		// May want to re-implement strict sequence checking. Might use these tests
+		// again.
 		// {
 		// 	label: "Book buy order with outdated sequence value",
 		// 	orderBook: makeOrderBook(
@@ -362,6 +364,8 @@ func TestOrderBookBook(t *testing.T) {
 			expected: nil,
 			wantErr:  true,
 		},
+		// May want to re-implement strict sequence checking. Might use these tests
+		// again.
 		// {
 		// 	label: "Book sell order to synced order book with future sequence value",
 		// 	orderBook: makeOrderBook(
@@ -456,6 +460,8 @@ func TestOrderBookUnbook(t *testing.T) {
 			),
 			wantErr: false,
 		},
+		// May want to re-implement strict sequence checking. Might use these tests
+		// again.
 		// {
 		// 	label: "Unbook sell order with outdated sequence value",
 		// 	orderBook: makeOrderBook(

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -39,6 +39,8 @@ type TCore struct {
 	preRegisterFee      uint64
 	preRegisterErr      error
 	balanceErr          error
+	syncBook            *core.OrderBook
+	syncFeed            *core.BookFeed
 	syncErr             error
 	createWalletErr     error
 	openWalletErr       error
@@ -49,13 +51,12 @@ type TCore struct {
 	registerErr         error
 }
 
-func (c *TCore) Sync(dex string, base, quote uint32) (chan *core.BookUpdate, error) {
-	return nil, c.syncErr
+func (c *TCore) Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
+	return nil, core.NewBookFeed(func(*core.BookFeed) {}), c.syncErr
 }
-func (c *TCore) Book(dex string, base, quote uint32) *core.OrderBook {
-	return nil
+func (c *TCore) Book(dex string, base, quote uint32) (*core.OrderBook, error) {
+	return nil, nil
 }
-func (c *TCore) Unsync(dex string, base, quote uint32) {}
 func (c *TCore) Balance(uint32) (uint64, error) {
 	return 0, c.balanceErr
 }
@@ -190,7 +191,9 @@ type tLink struct {
 }
 
 func newLink() *tLink {
-	conn := new(TConn)
+	conn := &TConn{
+		respReady: make(chan []byte, 1),
+	}
 	cl := newWSClient("", conn,
 		func(*msgjson.Message) *msgjson.Error { return nil })
 	return &tLink{
@@ -269,103 +272,70 @@ func TestLoadMarket(t *testing.T) {
 	link := newLink()
 	s, tCore, shutdown := newTServer(t, false, "", "")
 	defer shutdown()
-	tBase := uint32(1)
-	tQuote := uint32(2)
-	tDEX := "abc"
+	link.cl.Start()
+	defer link.cl.Disconnect()
 	params := &marketLoad{
-		DEX:   tDEX,
-		Base:  tBase,
-		Quote: tQuote,
+		DEX:   "abc",
+		Base:  uint32(1),
+		Quote: uint32(2),
 	}
 
-	ensureWatching := func(base, quote uint32) {
-		// Add a tiny delay here because because it's convenient and
-		// this function is typically called right after ...
+	subscription, _ := msgjson.NewRequest(1, "loadmarket", params)
+	tCore.syncBook = &core.OrderBook{}
 
-		time.Sleep(time.Millisecond)
-		mktID := marketID(base, quote)
-		clientCount := 0
-		s.mtx.Lock()
-		// Make sure there is only one client total
-		for _, syncer := range s.syncers {
-			clientCount += len(syncer.clients)
+	extractMessage := func() *msgjson.Message {
+		select {
+		case msgB := <-link.conn.respReady:
+			msg := new(msgjson.Message)
+			json.Unmarshal(msgB, &msg)
+			return msg
+		case <-time.NewTimer(time.Millisecond * 100).C:
+			t.Fatalf("extractMessage got nothing")
 		}
-		syncer, found := s.syncers[mktID]
-		s.mtx.Unlock()
-
-		if clientCount != 1 {
-			t.Fatalf("expected 1 client, found %d", clientCount)
-		}
-
-		if !found {
-			t.Fatalf("no syncer found for market %s", mktID)
-		}
-
-		syncer.mtx.Lock()
-		_, found = syncer.clients[link.cl.cid]
-		syncer.mtx.Unlock()
-
-		if !found {
-			t.Fatalf("client not found in syncer list")
-		}
+		return nil
 	}
 
-	msg, _ := msgjson.NewRequest(1, "a", params)
-	ensureErr := func(name string, wantCode int) {
-		got := wsLoadMarket(s, link.cl, msg)
-		if got == nil {
-			t.Fatalf("%s: no error", name)
+	ensureGood := func() {
+		// Create a new feed for every request because a Close()d feed cannot be
+		// reused.
+		tCore.syncFeed = core.NewBookFeed(func(feed *core.BookFeed) {})
+		msgErr := s.handleMessage(link.cl, subscription)
+		if msgErr != nil {
+			t.Fatalf("'loadmarket' error: %d: %s", msgErr.Code, msgErr.Message)
 		}
-		if wantCode != got.Code {
-			t.Fatalf("%s, wanted %d, got %d",
-				name, wantCode, got.Code)
+		msg := extractMessage()
+		if msg.Route != "book" {
+			t.Fatalf("wrong message received. Expected 'book', got %s", msg.Route)
+		}
+		if link.cl.feedLoop == nil {
+			t.Fatalf("nil book feed waiter after 'loadmarket'")
 		}
 	}
 
-	// Sync error from core is an error.
-	tCore.syncErr = errT
-	ensureErr("sync", msgjson.RPCInternal)
+	// Initial success.
+	ensureGood()
+
+	// Unsubscribe.
+	unsub, _ := msgjson.NewRequest(2, "unmarket", nil)
+	msgErr := s.handleMessage(link.cl, unsub)
+	if msgErr != nil {
+		t.Fatalf("'unmarket' error: %d: %s", msgErr.Code, msgErr.Message)
+	}
+
+	if link.cl.feedLoop != nil {
+		t.Fatalf("non-nil book feed waiter after 'unmarket'")
+	}
+
+	// Make sure a sync error propagates.
+	tCore.syncErr = fmt.Errorf("test error")
+	msgErr = s.handleMessage(link.cl, subscription)
+	if msgErr == nil {
+		t.Fatalf("no handleMessage error from Sync error")
+	}
 	tCore.syncErr = nil
 
-	rpcErr := wsLoadMarket(s, link.cl, msg)
-	if rpcErr != nil {
-		t.Fatalf("error loading market: %v", rpcErr)
-	}
-
-	// Ensure the client is watching.
-	ensureWatching(tBase, tQuote)
-
-	// Load a new market, and make sure the old market was unloaded.
-	newBase := uint32(3)
-	newQuote := uint32(4)
-	params.Base = newBase
-	params.Quote = newQuote
-	msg, _ = msgjson.NewRequest(2, "a", params)
-	rpcErr = wsLoadMarket(s, link.cl, msg)
-	if rpcErr != nil {
-		t.Fatalf("error loading market: %v", rpcErr)
-	}
-	ensureWatching(newBase, newQuote)
-
-	// Unsubscribe
-	wsUnmarket(nil, link.cl, nil)
-
-	// Ensure there are no clients watching any markets.
-	s.mtx.Lock()
-	for _, syncer := range s.syncers {
-		syncer.mtx.Lock()
-		if len(syncer.clients) != 0 {
-			t.Fatalf("Syncer for market %d-%d still has %d clients after unMarket",
-				syncer.base, syncer.quote, len(syncer.clients))
-		}
-		syncer.mtx.Unlock()
-	}
-	s.mtx.Unlock()
-
-	// Balance error.
-	tCore.balanceErr = errT
-	ensureErr("balance", msgjson.RPCInternal)
-	tCore.balanceErr = nil
+	// Success again.
+	ensureGood()
 }
 
 func TestHandleMessage(t *testing.T) {

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -1,29 +1,30 @@
-import Doc, { StateIcons } from './doc'
-import BasePage from './basepage'
+import Doc from './doc'
 import State from './state'
 import RegistrationPage from './register'
 import LoginPage from './login'
 import WalletsPage from './wallets'
 import SettingsPage from './settings'
-import { DepthChart } from './charts'
-import { postJSON, getJSON } from './http'
-import * as forms from './forms'
+import MarketsPage, { marketID } from './markets'
+import { getJSON } from './http'
+
 import * as ntfn from './notifications'
 import ws from './ws'
 
 const idel = Doc.idel // = element by id
 const bind = Doc.bind
 const unbind = Doc.unbind
-var app
-
-const LIMIT = 1
-// const MARKET = 2
-// const CANCEL = 3
 
 const updateWalletRoute = 'update_wallet'
 const notificationRoute = 'notify'
 
-// window.logit = function (lvl, msg) { app.notify(lvl, msg) }
+/* constructors is a map to page constructors. */
+const constructors = {
+  login: LoginPage,
+  register: RegistrationPage,
+  markets: MarketsPage,
+  wallets: WalletsPage,
+  settings: SettingsPage
+}
 
 // Application is the main javascript web application for the Decred DEX client.
 export default class Application {
@@ -40,7 +41,6 @@ export default class Application {
    * point. Read the id = main element and attach handlers.
    */
   async start () {
-    app = this
     // The "user" is a large data structure that contains nearly all state
     // information, including exchanges, markets, wallets, and orders. It must
     // be loaded immediately.
@@ -93,7 +93,7 @@ export default class Application {
    */
   async fetchUser () {
     const user = await getJSON('/api/user')
-    if (!app.checkResponse(user)) return
+    if (!this.checkResponse(user)) return
     this.user = user
     this.assets = user.assets
     this.walletMap = {}
@@ -128,8 +128,6 @@ export default class Application {
       console.error('cannot attach to content with no specified handler')
       return
     }
-    unattachers.forEach(f => f())
-    unattachers = []
     this.attachCommon(this.main)
     var constructor = constructors[handlerID]
     if (!constructor) {
@@ -172,7 +170,7 @@ export default class Application {
           note.acked = true
           if (note.id && note.severity > ntfn.POKE) acks.push(note.id)
         }
-        note.el.querySelector('div.note-time').textContent = timeSince(note.stamp)
+        note.el.querySelector('div.note-time').textContent = Doc.timeSince(note.stamp)
       }
       this.storeNotes()
       if (acks.length) ws.request('acknotes', acks)
@@ -327,10 +325,10 @@ export default class Application {
 
   /* orders retreives a list of orders for the specified dex and market. */
   orders (dex, bid, qid) {
-    var o = this.user.exchanges[dex].markets[sid(bid, qid)].orders
+    var o = this.user.exchanges[dex].markets[marketID(bid, qid)].orders
     if (!o) {
       o = []
-      this.user.exchanges[dex].markets[sid(bid, qid)].orders = o
+      this.user.exchanges[dex].markets[marketID(bid, qid)].orders = o
     }
     return o
   }
@@ -354,678 +352,6 @@ export default class Application {
 function getSocketURI () {
   var protocol = (window.location.protocol === 'https:') ? 'wss' : 'ws'
   return `${protocol}://${window.location.host}/ws`
-}
-
-/* unattachers are handlers to be run when a page is unloaded. */
-var unattachers = []
-
-/* unattach adds an unattacher to the array. */
-function unattach (f) {
-  unattachers.push(f)
-}
-
-class MarketsPage extends BasePage {
-  constructor (application, main, data) {
-    super()
-    this.notifiers = handleMarkets(main, data)
-  }
-}
-
-// handleMarkets is the 'markets' page main element handler.
-function handleMarkets (main, data) {
-  var market
-  const page = Doc.parsePage(main, [
-    // Templates, loaders, chart div...
-    'marketLoader', 'marketChart', 'marketList', 'rowTemplate', 'buyRows',
-    'sellRows',
-    // Order form.
-    'orderForm', 'priceBox', 'buyBttn', 'sellBttn', 'baseBalance',
-    'quoteBalance', 'limitBttn', 'marketBttn', 'tifBox', 'submitBttn',
-    'qtyField', 'rateField', 'orderErr', 'baseBox', 'quoteBox', 'baseImg',
-    'quoteImg', 'baseNewButton', 'quoteNewButton', 'baseBalSpan',
-    'quoteBalSpan', 'lotSize', 'rateStep', 'lotField', 'tifNow', 'mktBuyBox',
-    'mktBuyLots', 'mktBuyField', 'minMktBuy', 'qtyBox',
-    // Wallet unlock form
-    'forms', 'openForm', 'walletPass',
-    // Order submission is verified with the user's password.
-    'verifyForm', 'vSide', 'vQty', 'vBase', 'vRate',
-    'vTotal', 'vQuote', 'vPass', 'vSubmit', 'verifyLimit', 'verifyMarket',
-    'vmTotal', 'vmAsset', 'vmLots', 'mktBuyScore',
-    // Create wallet form
-    'walletForm', 'acctName',
-    // Active orders
-    'liveTemplate', 'liveList',
-    // Cancel order form
-    'cancelForm', 'cancelRemain', 'cancelUnit', 'cancelPass', 'cancelSubmit'
-  ])
-
-  page.rowTemplate.remove()
-  page.rowTemplate.removeAttribute('id')
-  page.liveTemplate.removeAttribute('id')
-  page.liveTemplate.remove()
-  const quoteUnits = main.querySelectorAll('[data-unit=quote]')
-  const baseUnits = main.querySelectorAll('[data-unit=base]')
-  const isSell = () => page.sellBttn.classList.contains('selected')
-  const isLimit = () => page.limitBttn.classList.contains('selected')
-  const asAtoms = s => Math.round(parseFloat(s) * 1e8)
-  const swapBttns = (before, now) => {
-    before.classList.remove('selected')
-    now.classList.add('selected')
-  }
-
-  const setOrderVisibility = (limit, sell) => {
-    if (limit) {
-      Doc.show(page.priceBox, page.tifBox, page.qtyBox)
-      Doc.hide(page.mktBuyBox)
-    } else {
-      Doc.hide(page.priceBox)
-      if (sell) {
-        Doc.hide(page.mktBuyBox)
-        Doc.show(page.qtyBox)
-      } else {
-        Doc.show(page.mktBuyBox)
-        Doc.hide(page.qtyBox)
-      }
-    }
-  }
-
-  bind(page.buyBttn, 'click', () => {
-    setOrderVisibility(isLimit(), false)
-    swapBttns(page.sellBttn, page.buyBttn)
-  })
-  bind(page.sellBttn, 'click', () => {
-    setOrderVisibility(isLimit(), true)
-    swapBttns(page.buyBttn, page.sellBttn)
-  })
-  // const tifCheck = tifDiv.querySelector('input[type=checkbox]')
-  bind(page.limitBttn, 'click', () => {
-    setOrderVisibility(true, isSell())
-    swapBttns(page.marketBttn, page.limitBttn)
-  })
-  bind(page.marketBttn, 'click', () => {
-    setOrderVisibility(false, isSell())
-    swapBttns(page.limitBttn, page.marketBttn)
-  })
-
-  const walletIcons = {
-    base: new StateIcons(page.baseBox),
-    quote: new StateIcons(page.quoteBox)
-  }
-
-  var selected
-  const reqMarket = async (url, base, quote) => {
-    const dex = app.user.exchanges[url]
-    selected = {
-      dex: dex,
-      sid: sid(base, quote), // A string market identifier used by the DEX.
-      base: app.assets[base],
-      baseCfg: dex.assets[base],
-      quote: app.assets[quote],
-      quoteCfg: dex.assets[quote]
-    }
-    ws.request('loadmarket', makeMarket(url, base, quote))
-  }
-
-  const reportPrice = p => { page.rateField.value = p.toFixed(8) }
-  const reporters = {
-    price: reportPrice
-  }
-  const chart = new DepthChart(page.marketChart, reporters)
-  const marketRows = page.marketList.querySelectorAll('.marketrow')
-  const markets = []
-
-  const parseOrder = () => {
-    let qtyField = page.qtyField
-    const limit = isLimit()
-    const sell = isSell()
-    if (!limit && !sell) {
-      qtyField = page.mktBuyField
-    }
-    return {
-      dex: selected.dex.url,
-      isLimit: limit,
-      sell: sell,
-      base: selected.base.id,
-      quote: selected.quote.id,
-      qty: asAtoms(qtyField.value),
-      rate: asAtoms(page.rateField.value), // message-rate
-      tifnow: page.tifNow.checked
-    }
-  }
-
-  const validateOrder = order => {
-    if (order.isLimit && !order.rate) {
-      Doc.show(page.orderErr)
-      page.orderErr.textContent = 'zero rate not allowed'
-      return false
-    }
-    if (!order.qty) {
-      Doc.show(page.orderErr)
-      page.orderErr.textContent = 'zero quantity not allowed'
-      return false
-    }
-    return true
-  }
-
-  // If no data was passed in, check if there is a market saved for the user.
-  var lastMarket = (data && data.market) ? data.market : State.fetch('selectedMarket')
-  var mktFound = false
-  marketRows.forEach(div => {
-    const base = parseInt(div.dataset.base)
-    const quote = parseInt(div.dataset.quote)
-    const dex = div.dataset.dex
-    mktFound = mktFound || (lastMarket && lastMarket.dex === dex &&
-      lastMarket.base === base && lastMarket.quote === quote)
-    bind(div, 'click', () => {
-      page.marketLoader.classList.remove('d-none')
-      reqMarket(dex, base, quote)
-    })
-    markets.push({
-      base: base,
-      quote: quote,
-      dex: dex
-    })
-  })
-
-  // Template elements used to clone rows in the order tables.
-  const tableBuilder = {
-    row: page.rowTemplate,
-    buys: page.buyRows,
-    sells: page.sellRows,
-    reporters: reporters
-  }
-
-  // handleBook is the handler for the 'book' notification from the server.
-  // Updates the charts, order tables, etc.
-  var book
-  const handleBook = (data) => {
-    book = data.book
-    const b = tableBuilder
-    if (!book) {
-      chart.clear()
-      Doc.empty(b.buys)
-      Doc.empty(b.sells)
-      return
-    }
-    chart.set({
-      book: book,
-      quoteSymbol: selected.quote.symbol,
-      baseSymbol: selected.base.symbol
-    })
-    loadTable(book.buys, b.buys, b, 'buycolor')
-    loadTable(book.sells, b.sells, b, 'sellcolor')
-  }
-
-  const midGap = () => {
-    if (!book) return
-    if (book.buys && book.buys.length) {
-      if (book.sells && book.sells.length) {
-        return (book.buys[0].rate + book.sells[0].rate) / 2
-      }
-      return book.buys[0].rate
-    }
-    if (book.sells && book.sells.length) {
-      return book.sells[0].rate
-    }
-    return null
-  }
-
-  const setMktBuyEstimate = () => {
-    const lotSize = selected.baseCfg.lotSize
-    const xc = app.user.exchanges[selected.dex.url]
-    const buffer = xc.markets[selected.sid].buybuffer
-    const gap = midGap()
-    if (gap) {
-      page.minMktBuy.textContent = Doc.formatCoinValue(lotSize * buffer * gap / 1e8)
-    }
-  }
-
-  const setBalance = (a, row, img, button, bal) => {
-    img.src = `/img/coins/${a.symbol.toLowerCase()}.png`
-    if (a.wallet) {
-      Doc.hide(button)
-      Doc.show(row)
-      bal.textContent = Doc.formatCoinValue(a.wallet.balance / 1e8)
-      return
-    }
-    Doc.show(button)
-    Doc.hide(row)
-  }
-
-  const updateWallet = assetID => {
-    const asset = app.assets[assetID]
-    switch (assetID) {
-      case (selected.base.id):
-        setBalance(asset, page.baseBalSpan, page.baseImg, page.baseNewButton, page.baseBalance)
-        walletIcons.base.readWallet(asset.wallet)
-        break
-      case (selected.quote.id):
-        setBalance(asset, page.quoteBalSpan, page.quoteImg, page.quoteNewButton, page.quoteBalance)
-        walletIcons.quote.readWallet(asset.wallet)
-    }
-  }
-
-  const orderRows = {}
-  const refreshActiveOrders = () => {
-    for (const oid in orderRows) delete orderRows[oid]
-    const orders = app.orders(selected.dex.url, selected.base.id, selected.quote.id)
-    Doc.empty(page.liveList)
-    for (const order of orders) {
-      const row = page.liveTemplate.cloneNode(true)
-      orderRows[order.id] = row
-      const set = (col, s) => { row.querySelector(`[data-col=${col}]`).textContent = s }
-      set('side', order.sell ? 'sell' : 'buy')
-      set('age', timeSince(order.stamp))
-      set('rate', Doc.formatCoinValue(order.rate / 1e8))
-      set('qty', Doc.formatCoinValue(order.qty / 1e8))
-      set('filled', `${(order.filled / order.qty * 100).toFixed(1)}%`)
-      if (order.type === LIMIT) {
-        if (order.cancelling) {
-          set('cancel', order.canceled ? 'canceled' : 'cancelling')
-        } else if (order.filled !== order.qty) {
-          const icon = row.querySelector('[data-col=cancel] > span')
-          Doc.show(icon)
-          Doc.bind(icon, 'click', e => {
-            e.stopPropagation()
-            showCancel(icon, order)
-          })
-        }
-      }
-      page.liveList.appendChild(row)
-    }
-  }
-
-  ws.registerRoute('book', data => {
-    const [b, q] = [selected.base, selected.quote]
-    if (data.base !== b.id || data.quote !== q.id) return
-    handleBook(data)
-    market = data.market
-    page.marketLoader.classList.add('d-none')
-    const url = selected.dex.url
-    marketRows.forEach(row => {
-      const d = row.dataset
-      if (d.dex === url && parseInt(d.base) === data.base && parseInt(d.quote) === data.quote) {
-        row.classList.add('selected')
-      } else {
-        row.classList.remove('selected')
-      }
-    })
-    State.store('selectedMarket', {
-      dex: data.dex,
-      base: data.base,
-      quote: data.quote
-    })
-    page.lotSize.textContent = Doc.formatCoinValue(selected.baseCfg.lotSize / 1e8)
-    page.rateStep.textContent = Doc.formatCoinValue(selected.quoteCfg.rateStep / 1e8)
-    baseUnits.forEach(el => { el.textContent = b.symbol.toUpperCase() })
-    quoteUnits.forEach(el => { el.textContent = q.symbol.toUpperCase() })
-    updateWallet(b.id)
-    updateWallet(q.id)
-    setMktBuyEstimate()
-    refreshActiveOrders()
-  })
-
-  ws.registerRoute('bookupdate', e => {
-    if (market && (e.market.dex !== market.dex || e.market.base !== market.base || e.market.quote !== market.quote)) return
-    handleBookUpdate(main, e)
-  })
-
-  const animationLength = 500
-  var currentForm
-  const showForm = async form => {
-    currentForm = form
-    Doc.hide(page.openForm, page.verifyForm, page.walletForm, page.cancelForm)
-    form.style.right = '10000px'
-    Doc.show(page.forms, form)
-    const shift = (page.forms.offsetWidth + form.offsetWidth) / 2
-    await Doc.animate(animationLength, progress => {
-      form.style.right = `${(1 - progress) * shift}px`
-    }, 'easeOutHard')
-    form.style.right = '0px'
-  }
-
-  // Show a form to connect/unlock a wallet.
-  var openAsset
-  var openFunc
-  const showOpen = async (asset, f) => {
-    openAsset = asset
-    openFunc = f
-    page.openForm.setAsset(app.assets[asset.id])
-    showForm(page.openForm)
-    page.walletPass.focus()
-  }
-
-  const showVerify = () => {
-    const order = parseOrder()
-    const baseAsset = app.assets[order.base]
-    const quoteAsset = app.assets[order.quote]
-    const fromAsset = order.sell ? baseAsset : quoteAsset
-    const toAsset = order.sell ? quoteAsset : baseAsset
-    if (order.isLimit) {
-      Doc.show(page.verifyLimit)
-      Doc.hide(page.verifyMarket)
-      page.vRate.textContent = Doc.formatCoinValue(order.rate / 1e8)
-      page.vQty.textContent = Doc.formatCoinValue(order.qty / 1e8)
-      page.vBase.textContent = baseAsset.symbol.toUpperCase()
-      page.vQuote.textContent = quoteAsset.symbol.toUpperCase()
-      page.vSide.textContent = order.sell ? 'sell' : 'buy'
-      page.vTotal.textContent = Doc.formatCoinValue(order.rate / 1e8 * order.qty / 1e8)
-    } else {
-      Doc.hide(page.verifyLimit)
-      Doc.show(page.verifyMarket)
-      page.vSide.textContent = 'trade'
-      page.vQty.textContent = Doc.formatCoinValue(order.qty / 1e8)
-      page.vBase.textContent = fromAsset.symbol.toUpperCase()
-      const gap = midGap()
-      if (gap) {
-        const received = order.sell ? order.qty * gap : order.qty / gap
-        const lotSize = selected.baseCfg.lotSize
-        const lots = order.sell ? order.qty / lotSize : received / lotSize
-        // TODO: Some kind of adjustment to align with lot sizes for market buy?
-        page.vmTotal.textContent = Doc.formatCoinValue(received / 1e8)
-        page.vmAsset.textContent = toAsset.symbol.toUpperCase()
-        page.vmLots.textContent = lots.toFixed(1)
-      } else {
-        Doc.hide(page.verifyMarket)
-      }
-    }
-    showForm(page.verifyForm)
-  }
-
-  const showCancel = (bttn, order) => {
-    const remaining = order.qty - order.filled
-    page.cancelRemain.textContent = Doc.formatCoinValue(remaining / 1e8)
-    const isMarketBuy = !order.isLimit && !order.sell
-    const symbol = isMarketBuy ? selected.quote.symbol : selected.base.symbol
-    page.cancelUnit.textContent = symbol.toUpperCase()
-    showForm(page.cancelForm)
-    Doc.bind(page.cancelSubmit, 'click', async () => {
-      const pw = page.cancelPass.value
-      page.cancelPass.value = ''
-      const req = {
-        orderID: order.id,
-        pw: pw
-      }
-      var res = await postJSON('/api/cancel', req)
-      app.loaded()
-      Doc.hide(page.forms)
-      if (!app.checkResponse(res)) return
-      bttn.parentNode.textContent = 'cancelling'
-      order.cancelling = true
-    })
-  }
-
-  var currentCreate
-  const showCreate = asset => {
-    currentCreate = asset
-    page.walletForm.setAsset(asset)
-    showForm(page.walletForm)
-    page.acctName.focus()
-  }
-
-  const stepSubmit = () => {
-    Doc.hide(page.orderErr)
-    if (!validateOrder(parseOrder())) return
-    const baseWallet = app.walletMap[selected.base.id]
-    const quoteWallet = app.walletMap[selected.quote.id]
-    if (!baseWallet) {
-      page.orderErr.textContent = `No ${selected.base.symbol} wallet`
-      Doc.show(page.orderErr)
-      return
-    }
-    if (!quoteWallet) {
-      page.orderErr.textContent = `No ${selected.quote.symbol} wallet`
-      Doc.show(page.orderErr)
-      return
-    }
-    showVerify()
-  }
-
-  // Bind the wallet unlock form.
-  forms.bindOpenWallet(app, page.openForm, async () => {
-    openFunc()
-  })
-
-  // Create a wallet
-  forms.bindNewWallet(app, page.walletForm, async () => {
-    const user = await app.fetchUser()
-    const asset = user.assets[currentCreate.id]
-    Doc.hide(page.forms)
-    updateWallet(asset.id)
-  })
-
-  // Main order form
-  forms.bind(page.orderForm, page.submitBttn, async () => {
-    stepSubmit()
-  })
-
-  // Order verification form
-  forms.bind(page.verifyForm, page.vSubmit, async () => {
-    Doc.hide(page.forms)
-    const order = parseOrder()
-    const pw = page.vPass.value
-    page.vPass.textContent = ''
-    const req = {
-      order: order,
-      pw: pw
-    }
-    if (!validateOrder(order)) return
-    var res = await postJSON('/api/trade', req)
-    app.loaded()
-    if (!app.checkResponse(res)) return
-    // If the wallets are not open locally, they must have been opened during
-    // ordering. Grab updated info.
-    const baseWallet = app.walletMap[selected.base.id]
-    const quoteWallet = app.walletMap[selected.quote.id]
-    if (!baseWallet.open || !quoteWallet.open) {
-      await app.fetchUser()
-      updateWallet(selected.base.id)
-      updateWallet(selected.quote.id)
-    }
-    app.orders(order.dex, order.base, order.quote).push(res.order)
-    refreshActiveOrders()
-  })
-
-  // If the user clicks outside of a form, it should close the page overlay.
-  bind(page.forms, 'click', e => {
-    if (!Doc.mouseInElement(e, currentForm)) Doc.hide(page.forms)
-  })
-
-  // Add wallet buttons
-  bind(page.baseNewButton, 'click', () => { showCreate(selected.base) })
-  bind(page.quoteNewButton, 'click', () => { showCreate(selected.quote) })
-  const unlocked = async () => {
-    Doc.hide(page.forms)
-    await app.fetchUser()
-    updateWallet(openAsset.id)
-  }
-  bind(walletIcons.base.icons.locked, 'click', () => { showOpen(selected.base, unlocked) })
-  bind(walletIcons.quote.icons.locked, 'click', () => { showOpen(selected.quote, unlocked) })
-  bind(walletIcons.base.icons.sleeping, 'click', () => { showOpen(selected.base, unlocked) })
-  bind(walletIcons.quote.icons.sleeping, 'click', () => { showOpen(selected.quote, unlocked) })
-
-  // Fetch the first market in the list, or the users last selected market, if
-  // it was found.
-  const firstEntry = mktFound ? lastMarket : markets[0]
-  reqMarket(firstEntry.dex, firstEntry.base, firstEntry.quote)
-
-  const lotChange = () => {
-    const lots = parseInt(page.lotField.value)
-    if (lots <= 0) {
-      page.lotField.value = 0
-      page.qtyField.value = ''
-      return
-    }
-    const lotSize = selected.baseCfg.lotSize
-    page.lotField.value = lots
-    page.qtyField.value = (lots * lotSize / 1e8)
-  }
-  bind(page.lotField, 'change', lotChange)
-  bind(page.lotField, 'keyup', lotChange)
-
-  const qtyChange = (finalize) => {
-    const order = parseOrder()
-    if (order.qty <= 0) {
-      page.lotField.value = 0
-      page.qtyField.value = ''
-      return
-    }
-    const lotSize = selected.baseCfg.lotSize
-    const lots = Math.floor(order.qty / lotSize)
-    const adjusted = lots * lotSize
-    page.lotField.value = lots
-    if (!order.isLimit && !order.sell) return
-    if (finalize) page.qtyField.value = (adjusted / 1e8)
-  }
-  bind(page.qtyField, 'change', () => qtyChange(true))
-  bind(page.qtyField, 'keyup', () => qtyChange(false))
-
-  const mktBuyChange = () => {
-    const qty = asAtoms(page.mktBuyField.value)
-    const gap = midGap()
-    if (!gap || !qty) {
-      page.mktBuyLots.textContent = '0'
-      page.mktBuyScore.textContent = '0'
-      return
-    }
-    const lotSize = selected.baseCfg.lotSize
-    const received = qty / gap
-    page.mktBuyLots.textContent = (received / lotSize).toFixed(1)
-    page.mktBuyScore.textContent = Doc.formatCoinValue(received / 1e8)
-  }
-  bind(page.mktBuyField, 'change', mktBuyChange)
-  bind(page.mktBuyField, 'keyup', mktBuyChange)
-
-  bind(page.rateField, 'change', () => {
-    const order = parseOrder()
-    if (order.rate <= 0) {
-      page.rateField.value = 0
-      return
-    }
-    // Truncate to rate step. If it is a market buy order, do not adjust.
-    const rateStep = selected.quoteCfg.rateStep
-    const adjusted = order.rate - (order.rate % rateStep)
-    page.rateField.value = (adjusted / 1e8)
-  })
-
-  unattach(() => {
-    ws.request('unmarket', {})
-    ws.deregisterRoute('book')
-    ws.deregisterRoute('bookupdate')
-    chart.unattach()
-  })
-
-  return {
-    order: note => {
-      const order = note.order
-      if (order.targetID && note.subject === 'cancel') {
-        orderRows[order.targetID].querySelector('[data-col=cancel]').textContent = 'canceled'
-      } else {
-        const row = orderRows[order.id]
-        if (!row) return
-        const td = row.querySelector('[data-col=filled]')
-        td.textContent = `${(order.filled / order.qty * 100).toFixed(1)}%`
-        if (order.filled === order.qty) {
-          // Remove the cancellation button.
-          row.querySelector('[data-col=cancel]').textContent = ''
-        }
-      }
-    }
-  }
-}
-
-/* constructors is a map to page constructors. */
-var constructors = {
-  login: LoginPage,
-  register: RegistrationPage,
-  markets: MarketsPage,
-  wallets: WalletsPage,
-  settings: SettingsPage
-}
-
-function makeMarket (dex, base, quote) {
-  return {
-    dex: dex,
-    base: base,
-    quote: quote
-  }
-}
-
-// loadTables loads the order book side into the specified table.
-function loadTable (bookSide, table, builder, cssClass) {
-  Doc.empty(table)
-  const check = document.createElement('span')
-  check.classList.add('ico-check')
-  bookSide.forEach(order => {
-    const tr = builder.row.cloneNode(true)
-    const rate = order.rate
-    bind(tr, 'click', () => {
-      builder.reporters.price(rate)
-    })
-    tr.querySelectorAll('td').forEach(td => {
-      switch (td.dataset.type) {
-        case 'qty':
-          td.innerText = order.qty.toFixed(8)
-          break
-        case 'rate':
-          td.innerText = order.rate.toFixed(8)
-          td.classList.add(cssClass)
-          break
-        case 'epoch':
-          if (order.epoch) td.appendChild(check.cloneNode())
-          break
-      }
-    })
-    table.appendChild(tr)
-  })
-}
-
-// handleBookUpdate handles a websocket order book update from the server.
-function handleBookUpdate (main, update) {
-  console.log('updating order book')
-}
-
-function sid (b, q) { return `${b}-${q}` }
-
-const aYear = 31536000000
-const aMonth = 2592000000
-const aDay = 86400000
-const anHour = 3600000
-const aMinute = 60000
-
-/* timeMod returns the quotient and remainder of t / dur. */
-function timeMod (t, dur) {
-  const n = Math.floor(t / dur)
-  return [n, t - n * dur]
-}
-
-/*
- * timeSince returns a string representation of the duration since the specified
- * unix timestamp.
- */
-function timeSince (t) {
-  var seconds = Math.floor(((new Date().getTime()) - t))
-  var result = ''
-  var count = 0
-  const add = (n, s) => {
-    if (n > 0 || count > 0) count++
-    if (n > 0) result += `${n} ${s} `
-    return count >= 2
-  }
-  var y, mo, d, h, m, s
-  [y, seconds] = timeMod(seconds, aYear)
-  if (add(y, 'y')) { return result }
-  [mo, seconds] = timeMod(seconds, aMonth)
-  if (add(mo, 'mo')) { return result }
-  [d, seconds] = timeMod(seconds, aDay)
-  if (add(d, 'd')) { return result }
-  [h, seconds] = timeMod(seconds, anHour)
-  if (add(h, 'h')) { return result }
-  [m, seconds] = timeMod(seconds, aMinute)
-  if (add(m, 'm')) { return result }
-  [s, seconds] = timeMod(seconds, 1000)
-  add(s, 's')
-  return result || '0 s'
 }
 
 /*

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -2,6 +2,14 @@ const parser = new window.DOMParser()
 
 const FPS = 30
 
+export const BipIDs = {
+  0: 'btc',
+  42: 'dcr',
+  2: 'ltc',
+  22: 'mona',
+  28: 'vtc'
+}
+
 // Parameters for printing asset values.
 const coinValueSpecs = {
   minimumSignificantDigits: 4,
@@ -110,6 +118,35 @@ export default class Doc {
   static logoPath (symbol) {
     return `/img/coins/${symbol}.png`
   }
+
+  /*
+   * timeSince returns a string representation of the duration since the specified
+   * unix timestamp.
+   */
+  static timeSince (t) {
+    var seconds = Math.floor(((new Date().getTime()) - t))
+    var result = ''
+    var count = 0
+    const add = (n, s) => {
+      if (n > 0 || count > 0) count++
+      if (n > 0) result += `${n} ${s} `
+      return count >= 2
+    }
+    var y, mo, d, h, m, s
+    [y, seconds] = timeMod(seconds, aYear)
+    if (add(y, 'y')) { return result }
+    [mo, seconds] = timeMod(seconds, aMonth)
+    if (add(mo, 'mo')) { return result }
+    [d, seconds] = timeMod(seconds, aDay)
+    if (add(d, 'd')) { return result }
+    [h, seconds] = timeMod(seconds, anHour)
+    if (add(h, 'h')) { return result }
+    [m, seconds] = timeMod(seconds, aMinute)
+    if (add(m, 'm')) { return result }
+    [s, seconds] = timeMod(seconds, 1000)
+    add(s, 's')
+    return result || '0 s'
+  }
 }
 
 /* Easing algorithms for animations. */
@@ -121,8 +158,8 @@ var Easing = {
   easeOutHard: t => (--t) * t * t + 1
 }
 
-/* StateIcons are used for controlling wallets in various places. */
-export class StateIcons {
+/* WalletIcons are used for controlling wallets in various places. */
+export class WalletIcons {
   constructor (box) {
     const stateIcon = (row, name) => row.querySelector(`[data-state=${name}]`)
     this.icons = {}
@@ -189,4 +226,16 @@ export class StateIcons {
 /* sleep can be used by async functions to pause for a specified period. */
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+const aYear = 31536000000
+const aMonth = 2592000000
+const aDay = 86400000
+const anHour = 3600000
+const aMinute = 60000
+
+/* timeMod returns the quotient and remainder of t / dur. */
+function timeMod (t, dur) {
+  const n = Math.floor(t / dur)
+  return [n, t - n * dur]
 }

--- a/client/webserver/site/src/js/login.js
+++ b/client/webserver/site/src/js/login.js
@@ -19,7 +19,6 @@ export default class LoginPage extends BasePage {
   /* login submits the sign-in form and parses the result. */
   async login (e) {
     const page = this.page
-    app.loading(page.loginForm)
     Doc.hide(page.errMsg)
     const pw = page.pw.value
     page.pw.value = ''
@@ -28,11 +27,17 @@ export default class LoginPage extends BasePage {
       Doc.show(page.errMsg)
       return
     }
-    app.loaded()
+    app.loading(page.loginForm)
     var res = await postJSON('/api/login', { pass: pw })
-    if (!app.checkResponse(res)) return
-    res.notes.reverse()
-    app.setNotes(res.notes)
+    app.loaded()
+    if (!app.checkResponse(res)) {
+      console.log(res)
+      return
+    }
+    if (res.notes) {
+      res.notes.reverse()
+    }
+    app.setNotes(res.notes || [])
     await app.fetchUser()
     app.setLogged(true)
     app.loadPage('markets')

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -1,0 +1,881 @@
+import Doc, { WalletIcons, BipIDs } from './doc'
+import State from './state'
+import BasePage from './basepage'
+import OrderBook from './orderbook'
+import { DepthChart } from './charts'
+import { postJSON } from './http'
+import * as forms from './forms'
+import ws from './ws'
+
+var app
+const bind = Doc.bind
+
+const LIMIT = 1
+// const MARKET = 2
+// const CANCEL = 3
+
+const bookRoute = 'book'
+const bookOrderRoute = 'book_order'
+const unbookOrderRoute = 'unbook_order'
+const epochOrderRoute = 'epoch_order'
+const bookUpdateRoute = 'bookupdate'
+const unmarketRoute = 'unmarket'
+
+const animationLength = 500
+
+const check = document.createElement('span')
+check.classList.add('ico-check')
+
+export default class MarketsPage extends BasePage {
+  constructor (application, main, data) {
+    super()
+    app = application
+    const page = this.page = Doc.parsePage(main, [
+      // Templates, loaders, chart div...
+      'marketLoader', 'marketChart', 'marketList', 'rowTemplate', 'buyRows',
+      'sellRows',
+      // Order form.
+      'orderForm', 'priceBox', 'buyBttn', 'sellBttn', 'baseBalance',
+      'quoteBalance', 'limitBttn', 'marketBttn', 'tifBox', 'submitBttn',
+      'qtyField', 'rateField', 'orderErr', 'baseBox', 'quoteBox', 'baseImg',
+      'quoteImg', 'baseNewButton', 'quoteNewButton', 'baseBalSpan',
+      'quoteBalSpan', 'lotSize', 'rateStep', 'lotField', 'tifNow', 'mktBuyBox',
+      'mktBuyLots', 'mktBuyField', 'minMktBuy', 'qtyBox',
+      // Wallet unlock form
+      'forms', 'openForm', 'walletPass',
+      // Order submission is verified with the user's password.
+      'verifyForm', 'vSide', 'vQty', 'vBase', 'vRate',
+      'vTotal', 'vQuote', 'vPass', 'vSubmit', 'verifyLimit', 'verifyMarket',
+      'vmTotal', 'vmAsset', 'vmLots', 'mktBuyScore',
+      // Create wallet form
+      'walletForm', 'acctName',
+      // Active orders
+      'liveTemplate', 'liveList',
+      // Cancel order form
+      'cancelForm', 'cancelRemain', 'cancelUnit', 'cancelPass', 'cancelSubmit'
+    ])
+    this.market = null
+    this.currentForm = null
+    this.openAsset = null
+    this.openFunc = null
+    this.currentCreate = null
+    this.book = null
+    this.orderRows = {}
+    this.marketRows = page.marketList.querySelectorAll('.marketrow')
+    this.markets = []
+    const reporters = {
+      price: p => { this.reportPrice(p) }
+    }
+    this.chart = new DepthChart(page.marketChart, reporters)
+
+    // Prepare templates for the buy and sell tables and the user's order table.
+    page.rowTemplate.remove()
+    page.rowTemplate.removeAttribute('id')
+    page.liveTemplate.removeAttribute('id')
+    page.liveTemplate.remove()
+
+    // Store the elements that need their ticker changed when the market
+    // changes.
+    this.quoteUnits = main.querySelectorAll('[data-unit=quote]')
+    this.baseUnits = main.querySelectorAll('[data-unit=base]')
+
+    // The wallet-control icons.
+    this.walletIcons = {
+      base: new WalletIcons(page.baseBox),
+      quote: new WalletIcons(page.quoteBox)
+    }
+
+    // Buttons to set order type and side.
+    bind(page.buyBttn, 'click', () => {
+      swapBttns(page.sellBttn, page.buyBttn)
+      this.setOrderVisibility()
+    })
+    bind(page.sellBttn, 'click', () => {
+      swapBttns(page.buyBttn, page.sellBttn)
+      this.setOrderVisibility()
+    })
+    // const tifCheck = tifDiv.querySelector('input[type=checkbox]')
+    bind(page.limitBttn, 'click', () => {
+      swapBttns(page.marketBttn, page.limitBttn)
+      this.setOrderVisibility()
+    })
+    bind(page.marketBttn, 'click', () => {
+      swapBttns(page.limitBttn, page.marketBttn)
+      this.setOrderVisibility()
+    })
+
+    // Scan the rows in the market table and pull some basic info.
+    var lastMarket = (data && data.market) ? data.market : State.fetch('selectedMarket')
+    var mktFound = false
+    this.marketRows.forEach(div => {
+      const base = parseInt(div.dataset.base)
+      const quote = parseInt(div.dataset.quote)
+      const dex = div.dataset.dex
+      mktFound = mktFound || (lastMarket && lastMarket.dex === dex &&
+        lastMarket.base === base && lastMarket.quote === quote)
+      // Clicking on the row will load a new market.
+      bind(div, 'click', () => {
+        page.marketLoader.classList.remove('d-none')
+        this.setMarket(dex, base, quote)
+      })
+      this.markets.push({
+        base: base,
+        quote: quote,
+        dex: dex
+      })
+    })
+
+    // Handle the full orderbook sent on the 'book' route.
+    ws.registerRoute(bookRoute, data => { this.handleBookRoute(data) })
+    // Handle the new order for the order book on the 'book_order' route.
+    ws.registerRoute(bookOrderRoute, data => { this.handleBookOrderRoute(data) })
+    // Remove the order sent on the 'unbook_order' route from the orderbook.
+    ws.registerRoute(unbookOrderRoute, data => { this.handleUnbookOrderRoute(data) })
+    // Handle the new order for the order book on the 'epoch_order' route.
+    ws.registerRoute(epochOrderRoute, data => { this.handleEpochOrderRoute(data) })
+    // Bind the wallet unlock form.
+    forms.bindOpenWallet(app, page.openForm, async () => { this.openFunc() })
+    // Create a wallet
+    forms.bindNewWallet(app, page.walletForm, async () => { this.createWallet() })
+    // Main order form
+    forms.bind(page.orderForm, page.submitBttn, async () => { this.stepSubmit() })
+    // Order verification form
+    forms.bind(page.verifyForm, page.vSubmit, async () => { this.submitOrder() })
+
+    // If the user clicks outside of a form, it should close the page overlay.
+    bind(page.forms, 'mousedown', e => {
+      if (!Doc.mouseInElement(e, this.currentForm)) Doc.hide(page.forms)
+    })
+
+    // Wallet button callbacks.
+    bind(page.baseNewButton, 'click', () => { this.showCreate(this.market.base) })
+    bind(page.quoteNewButton, 'click', () => { this.showCreate(this.market.quote) })
+    const i = this.walletIcons
+    bind(i.base.icons.locked, 'click', () => { this.showOpen(this.market.base, this.walletUnlocked) })
+    bind(i.quote.icons.locked, 'click', () => { this.showOpen(this.market.quote, this.walletUnlocked) })
+    bind(i.base.icons.sleeping, 'click', () => { this.showOpen(this.market.base, this.walletUnlocked) })
+    bind(i.quote.icons.sleeping, 'click', () => { this.showOpen(this.market.quote, this.walletUnlocked) })
+
+    // Event listeners for interactions with the various input fields.
+    bind(page.lotField, 'change', () => { this.lotChanged() })
+    bind(page.lotField, 'keyup', () => { this.lotChanged() })
+    bind(page.qtyField, 'change', () => { this.quantityChanged(true) })
+    bind(page.qtyField, 'keyup', () => { this.quantityChanged(false) })
+    bind(page.mktBuyField, 'change', () => { this.marketBuyChanged() })
+    bind(page.mktBuyField, 'keyup', () => { this.marketBuyChanged() })
+    bind(page.rateField, 'change', () => { this.rateFieldChanged() })
+
+    // Notification filters.
+    this.notifiers = {
+      order: note => { this.handleOrderNote(note) },
+      epoch: note => { this.handleEpochNote(note) }
+    }
+
+    // Fetch the first market in the list, or the users last selected market, if
+    // it was found.
+    const firstEntry = mktFound ? lastMarket : this.markets[0]
+    this.setMarket(firstEntry.dex, firstEntry.base, firstEntry.quote)
+  }
+
+  /* isSell is true if the user has selected sell in the order options. */
+  isSell () {
+    return this.page.sellBttn.classList.contains('selected')
+  }
+
+  /* isLimit is true if the user has selected the "limit order" tab. */
+  isLimit () {
+    return this.page.limitBttn.classList.contains('selected')
+  }
+
+  /*
+   * setOrderVisibility sets which form is visible based on the specified
+   * options.
+   */
+  setOrderVisibility () {
+    const page = this.page
+    if (this.isLimit()) {
+      Doc.show(page.priceBox, page.tifBox, page.qtyBox)
+      Doc.hide(page.mktBuyBox)
+    } else {
+      Doc.hide(page.priceBox)
+      if (this.isSell()) {
+        Doc.hide(page.mktBuyBox)
+        Doc.show(page.qtyBox)
+      } else {
+        Doc.show(page.mktBuyBox)
+        Doc.hide(page.qtyBox)
+      }
+    }
+  }
+
+  /* setMarket sets the currently displayed market. */
+  async setMarket (url, base, quote) {
+    const dex = app.user.exchanges[url]
+    this.market = {
+      dex: dex,
+      sid: marketID(base, quote), // A string market identifier used by the DEX.
+      base: app.assets[base],
+      baseCfg: dex.assets[base],
+      quote: app.assets[quote],
+      quoteCfg: dex.assets[quote]
+    }
+    ws.request('loadmarket', makeMarket(url, base, quote))
+  }
+
+  /*
+   * reportPrice is a callback used by the DepthChart when the user clicks
+   * on the chart area. The rate field is set to the x-value of the click.
+   */
+  reportPrice (p) {
+    this.page.rateField.value = p.toFixed(8)
+    this.rateFieldChanged()
+  }
+
+  /*
+   * parseOrder pulls the order information from the form fields. Data is not
+   * validated in any way.
+   */
+  parseOrder () {
+    const page = this.page
+    let qtyField = page.qtyField
+    const limit = this.isLimit()
+    const sell = this.isSell()
+    const market = this.market
+    if (!limit && !sell) {
+      qtyField = page.mktBuyField
+    }
+    return {
+      dex: market.dex.url,
+      isLimit: limit,
+      sell: sell,
+      base: market.base.id,
+      quote: market.quote.id,
+      qty: asAtoms(qtyField.value),
+      rate: asAtoms(page.rateField.value), // message-rate
+      tifnow: page.tifNow.checked
+    }
+  }
+
+  /*
+   * validateOrder performs some basic order sanity checks, returning boolean
+   * true if the order appears valid.
+   */
+  validateOrder (order) {
+    const page = this.page
+    if (order.isLimit && !order.rate) {
+      Doc.show(page.orderErr)
+      page.orderErr.textContent = 'zero rate not allowed'
+      return false
+    }
+    if (!order.qty) {
+      Doc.show(page.orderErr)
+      page.orderErr.textContent = 'zero quantity not allowed'
+      return false
+    }
+    return true
+  }
+
+  /* handleBook accepts the data sent in the 'book' notification. */
+  handleBook (data) {
+    this.book = new OrderBook(data)
+    this.loadTable()
+    for (const order of (data.book.epoch || [])) {
+      if (order.rate > 0) this.book.add(order)
+      this.addTableOrder(order)
+    }
+    if (!this.book) {
+      this.chart.clear()
+      Doc.empty(this.page.buyRows)
+      Doc.empty(this.page.sellRows)
+      return
+    }
+    this.chart.set(this.book)
+  }
+
+  /*
+   * midGap returns the value in the middle of the best buy and best sell. If
+   * either one of the buy or sell sides are empty, midGap returns the best
+   * rate from the other side. If both sides are empty, midGap returns the
+   * value null.
+   */
+  midGap () {
+    const book = this.book
+    if (!book) return
+    if (book.buys && book.buys.length) {
+      if (book.sells && book.sells.length) {
+        return (book.buys[0].rate + book.sells[0].rate) / 2
+      }
+      return book.buys[0].rate
+    }
+    if (book.sells && book.sells.length) {
+      return book.sells[0].rate
+    }
+    return null
+  }
+
+  /*
+   * setMarketBuyOrderEstimate sets the "min. buy" display for the current
+   * market.
+   */
+  setMarketBuyOrderEstimate () {
+    const market = this.market
+    const lotSize = market.baseCfg.lotSize
+    const xc = app.user.exchanges[market.dex.url]
+    const buffer = xc.markets[market.sid].buybuffer
+    const gap = this.midGap()
+    if (gap) {
+      this.page.minMktBuy.textContent = Doc.formatCoinValue(lotSize * buffer * gap / 1e8)
+    }
+  }
+
+  /* setBalance sets the balance display. */
+  setBalance (a, row, img, button, bal) {
+    img.src = `/img/coins/${a.symbol.toLowerCase()}.png`
+    if (a.wallet) {
+      Doc.hide(button)
+      Doc.show(row)
+      bal.textContent = Doc.formatCoinValue(a.wallet.balance / 1e8)
+      return
+    }
+    Doc.show(button)
+    Doc.hide(row)
+  }
+
+  /*
+   * updateWallet updates the displayed wallet information based on the
+   * core.Wallet state.
+   */
+  updateWallet (assetID) {
+    const page = this.page
+    const market = this.market
+    const asset = app.assets[assetID]
+    switch (assetID) {
+      case (market.base.id):
+        this.setBalance(asset, page.baseBalSpan, page.baseImg, page.baseNewButton, page.baseBalance)
+        this.walletIcons.base.readWallet(asset.wallet)
+        break
+      case (market.quote.id):
+        this.setBalance(asset, page.quoteBalSpan, page.quoteImg, page.quoteNewButton, page.quoteBalance)
+        this.walletIcons.quote.readWallet(asset.wallet)
+    }
+  }
+
+  /* refreshActiveOrders refreshes the user's active order list. */
+  refreshActiveOrders () {
+    const page = this.page
+    const orderRows = this.orderRows
+    const market = this.market
+    for (const oid in orderRows) delete orderRows[oid]
+    const orders = app.orders(market.dex.url, market.base.id, market.quote.id)
+    Doc.empty(page.liveList)
+    for (const order of orders) {
+      const row = page.liveTemplate.cloneNode(true)
+      orderRows[order.id] = row
+      const set = (col, s) => { row.querySelector(`[data-col=${col}]`).textContent = s }
+      set('side', order.sell ? 'sell' : 'buy')
+      set('age', Doc.timeSince(order.stamp))
+      set('rate', Doc.formatCoinValue(order.rate / 1e8))
+      set('qty', Doc.formatCoinValue(order.qty / 1e8))
+      set('filled', `${(order.filled / order.qty * 100).toFixed(1)}%`)
+      if (order.type === LIMIT) {
+        if (order.cancelling) {
+          set('cancel', order.canceled ? 'canceled' : 'cancelling')
+        } else if (order.filled !== order.qty) {
+          const icon = row.querySelector('[data-col=cancel] > span')
+          Doc.show(icon)
+          bind(icon, 'click', e => {
+            e.stopPropagation()
+            this.showCancel(icon, order)
+          })
+        }
+      }
+      page.liveList.appendChild(row)
+    }
+  }
+
+  /* handleBookRoute is the handler for the 'book' notification, which is sent
+   * in response to a new market subscription. The data received will contain
+   * the entire order book.
+   */
+  handleBookRoute (data) {
+    const market = this.market
+    const page = this.page
+    const [b, q] = [market.base, market.quote]
+    if (data.base !== b.id || data.quote !== q.id) return
+    this.handleBook(data)
+    page.marketLoader.classList.add('d-none')
+    const url = market.dex.url
+    this.marketRows.forEach(row => {
+      const d = row.dataset
+      if (d.dex === url && parseInt(d.base) === data.base && parseInt(d.quote) === data.quote) {
+        row.classList.add('selected')
+      } else {
+        row.classList.remove('selected')
+      }
+    })
+    State.store('selectedMarket', {
+      dex: data.dex,
+      base: data.base,
+      quote: data.quote
+    })
+    page.lotSize.textContent = Doc.formatCoinValue(market.baseCfg.lotSize / 1e8)
+    page.rateStep.textContent = Doc.formatCoinValue(market.quoteCfg.rateStep / 1e8)
+    this.baseUnits.forEach(el => { el.textContent = b.symbol.toUpperCase() })
+    this.quoteUnits.forEach(el => { el.textContent = q.symbol.toUpperCase() })
+    this.updateWallet(b.id)
+    this.updateWallet(q.id)
+    this.setMarketBuyOrderEstimate()
+    this.refreshActiveOrders()
+  }
+
+  /* handleBookOrderRoute is the handles for 'book_order' notifications. */
+  handleBookOrderRoute (data) {
+    const order = data.order
+    if (order.rate > 0) this.book.add(order)
+    this.addTableOrder(order)
+    this.chart.draw()
+  }
+
+  /* handleBookOrderRoute is the handles for 'unbook_order' notifications. */
+  handleUnbookOrderRoute (data) {
+    const order = data.order
+    this.book.remove(order.token)
+    this.removeTableOrder(order)
+    this.chart.draw()
+  }
+
+  /* handleBookOrderRoute is the handles for 'epoch_order' notifications. */
+  handleEpochOrderRoute (data) {
+    const order = data.order
+    if (order.rate > 0) this.book.add(order)
+    this.addTableOrder(order)
+    this.chart.draw()
+  }
+
+  /* showForm shows a modal form with a little animation. */
+  async showForm (form) {
+    this.currentForm = form
+    const page = this.page
+    Doc.hide(page.openForm, page.verifyForm, page.walletForm, page.cancelForm)
+    form.style.right = '10000px'
+    Doc.show(page.forms, form)
+    const shift = (page.forms.offsetWidth + form.offsetWidth) / 2
+    await Doc.animate(animationLength, progress => {
+      form.style.right = `${(1 - progress) * shift}px`
+    }, 'easeOutHard')
+    form.style.right = '0px'
+  }
+
+  /* showOpen shows the form to unlock a wallet. */
+  async showOpen (asset, f) {
+    const page = this.page
+    this.openAsset = asset
+    this.openFunc = f
+    page.openForm.setAsset(app.assets[asset.id])
+    this.showForm(page.openForm)
+    page.walletPass.focus()
+  }
+
+  /* showVerify shows the form to accept the currently parsed order information
+   * and confirm submission of the order to the dex.
+   */
+  showVerify () {
+    const page = this.page
+    const order = this.parseOrder()
+    const baseAsset = app.assets[order.base]
+    const quoteAsset = app.assets[order.quote]
+    const fromAsset = order.sell ? baseAsset : quoteAsset
+    const toAsset = order.sell ? quoteAsset : baseAsset
+    if (order.isLimit) {
+      Doc.show(page.verifyLimit)
+      Doc.hide(page.verifyMarket)
+      page.vRate.textContent = Doc.formatCoinValue(order.rate / 1e8)
+      page.vQty.textContent = Doc.formatCoinValue(order.qty / 1e8)
+      page.vBase.textContent = baseAsset.symbol.toUpperCase()
+      page.vQuote.textContent = quoteAsset.symbol.toUpperCase()
+      page.vSide.textContent = order.sell ? 'sell' : 'buy'
+      page.vTotal.textContent = Doc.formatCoinValue(order.rate / 1e8 * order.qty / 1e8)
+    } else {
+      Doc.hide(page.verifyLimit)
+      Doc.show(page.verifyMarket)
+      page.vSide.textContent = 'trade'
+      page.vQty.textContent = Doc.formatCoinValue(order.qty / 1e8)
+      page.vBase.textContent = fromAsset.symbol.toUpperCase()
+      const gap = this.midGap()
+      if (gap) {
+        const received = order.sell ? order.qty * gap : order.qty / gap
+        const lotSize = this.market.baseCfg.lotSize
+        const lots = order.sell ? order.qty / lotSize : received / lotSize
+        // TODO: Some kind of adjustment to align with lot sizes for market buy?
+        page.vmTotal.textContent = Doc.formatCoinValue(received / 1e8)
+        page.vmAsset.textContent = toAsset.symbol.toUpperCase()
+        page.vmLots.textContent = lots.toFixed(1)
+      } else {
+        Doc.hide(page.verifyMarket)
+      }
+    }
+    this.showForm(page.verifyForm)
+  }
+
+  /* showCancel shows a form to confirm submission of a cancel order. */
+  showCancel (bttn, order) {
+    const page = this.page
+    const remaining = order.qty - order.filled
+    page.cancelRemain.textContent = Doc.formatCoinValue(remaining / 1e8)
+    const isMarketBuy = !order.isLimit && !order.sell
+    const symbol = isMarketBuy ? this.market.quote.symbol : this.market.base.symbol
+    page.cancelUnit.textContent = symbol.toUpperCase()
+    this.showForm(page.cancelForm)
+    bind(page.cancelSubmit, 'click', async () => {
+      const pw = page.cancelPass.value
+      page.cancelPass.value = ''
+      const req = {
+        orderID: order.id,
+        pw: pw
+      }
+      var res = await postJSON('/api/cancel', req)
+      app.loaded()
+      Doc.hide(page.forms)
+      if (!app.checkResponse(res)) return
+      bttn.parentNode.textContent = 'cancelling'
+      order.cancelling = true
+    })
+  }
+
+  /* showCreate shows the new wallet creation form. */
+  showCreate (asset) {
+    const page = this.page
+    this.currentCreate = asset
+    page.walletForm.setAsset(asset)
+    this.showForm(page.walletForm)
+    page.acctName.focus()
+  }
+
+  /*
+   * stepSubmit will examine the current state of wallets and step the user
+   * through the process of order submission.
+   * NOTE: I expect this process will be streamlined soon such that the wallets
+   * will attempt to be unlocked in the order submission process, negating the
+   * need to unlock ahead of time.
+   */
+  stepSubmit () {
+    const page = this.page
+    const market = this.market
+    Doc.hide(page.orderErr)
+    if (!this.validateOrder(this.parseOrder())) return
+    const baseWallet = app.walletMap[market.base.id]
+    const quoteWallet = app.walletMap[market.quote.id]
+    if (!baseWallet) {
+      page.orderErr.textContent = `No ${market.base.symbol} wallet`
+      Doc.show(page.orderErr)
+      return
+    }
+    if (!quoteWallet) {
+      page.orderErr.textContent = `No ${market.quote.symbol} wallet`
+      Doc.show(page.orderErr)
+      return
+    }
+    this.showVerify()
+  }
+
+  /*
+   * handleOrderNote is the handler for the 'order'-type notification, which are
+   * used to update an order's status.
+   */
+  handleOrderNote (note) {
+    const order = note.order
+    if (order.targetID && note.subject === 'cancel') {
+      this.orderRows[order.targetID].querySelector('[data-col=cancel]').textContent = 'canceled'
+    } else {
+      const row = this.orderRows[order.id]
+      if (!row) return
+      const td = row.querySelector('[data-col=filled]')
+      td.textContent = `${(order.filled / order.qty * 100).toFixed(1)}%`
+      if (order.filled === order.qty) {
+        // Remove the cancellation button.
+        row.querySelector('[data-col=cancel]').textContent = ''
+      }
+    }
+  }
+
+  /*
+   * handleEpochNote handles notifications signalling the start of a new epoch.
+   */
+  handleEpochNote (note) {
+    if (this.book) this.book.setEpoch(note.epoch)
+    this.clearOrderTableEpochs(note.epoch)
+  }
+
+  /*
+   * submitOrder is attached to the affirmative button on the order validation
+   * form. Clicking the button is the last step in the order submission process.
+   */
+  async submitOrder () {
+    const page = this.page
+    const market = this.market
+    Doc.hide(page.forms)
+    const order = this.parseOrder()
+    const pw = page.vPass.value
+    page.vPass.textContent = ''
+    const req = {
+      order: order,
+      pw: pw
+    }
+    if (!this.validateOrder(order)) return
+    var res = await postJSON('/api/trade', req)
+    app.loaded()
+    if (!app.checkResponse(res)) return
+    // If the wallets are not open locally, they must have been opened during
+    // ordering. Grab updated info.
+    const baseWallet = app.walletMap[market.base.id]
+    const quoteWallet = app.walletMap[market.quote.id]
+    if (!baseWallet.open || !quoteWallet.open) {
+      await app.fetchUser()
+      this.updateWallet(market.base.id)
+      this.updateWallet(market.quote.id)
+    }
+    app.orders(order.dex, order.base, order.quote).push(res.order)
+    this.refreshActiveOrders()
+  }
+
+  /*
+   * createWallet is attached to successful submission of the wallet creation
+   * form. createWallet is only called once the form is submitted and a success
+   * response is received from the client.
+   */
+  async createWallet () {
+    const user = await app.fetchUser()
+    const asset = user.assets[this.currentCreate.id]
+    Doc.hide(this.page.forms)
+    this.updateWallet(asset.id)
+  }
+
+  /*
+   * walletUnlocked is attached to successful submission of the wallet unlock
+   * form. walletUnlocked is only called once the form is submitted and a
+   * success response is received from the client.
+   */
+  async walletUnlocked () {
+    Doc.hide(this.page.forms)
+    await app.fetchUser()
+    this.updateWallet(this.openAsset.id)
+  }
+
+  /* lotChanged is attached to the keyup and change events of the lots input. */
+  lotChanged () {
+    const page = this.page
+    const lots = parseInt(page.lotField.value)
+    if (lots <= 0) {
+      page.lotField.value = 0
+      page.qtyField.value = ''
+      return
+    }
+    const lotSize = this.market.baseCfg.lotSize
+    page.lotField.value = lots
+    page.qtyField.value = (lots * lotSize / 1e8)
+  }
+
+  /*
+   * quantityChanged is attached to the keyup and change events of the quantity
+   * input.
+   */
+  quantityChanged (finalize) {
+    const page = this.page
+    const order = this.parseOrder()
+    if (order.qty <= 0) {
+      page.lotField.value = 0
+      page.qtyField.value = ''
+      return
+    }
+    const lotSize = this.market.baseCfg.lotSize
+    const lots = Math.floor(order.qty / lotSize)
+    const adjusted = lots * lotSize
+    page.lotField.value = lots
+    if (!order.isLimit && !order.sell) return
+    if (finalize) page.qtyField.value = (adjusted / 1e8)
+  }
+
+  /*
+   * marketBuyChanged is attached to the keyup and change events of the quantity
+   * input for the market-buy form.
+   */
+  marketBuyChanged () {
+    const page = this.page
+    const qty = asAtoms(page.mktBuyField.value)
+    const gap = this.midGap()
+    if (!gap || !qty) {
+      page.mktBuyLots.textContent = '0'
+      page.mktBuyScore.textContent = '0'
+      return
+    }
+    const lotSize = this.market.baseCfg.lotSize
+    const received = qty / gap
+    page.mktBuyLots.textContent = (received / lotSize).toFixed(1)
+    page.mktBuyScore.textContent = Doc.formatCoinValue(received / 1e8)
+  }
+
+  /*
+   * rateFieldChanged is attached to the keyup and change events of the rate
+   * input.
+   */
+  rateFieldChanged () {
+    const order = this.parseOrder()
+    if (order.rate <= 0) {
+      this.page.rateField.value = 0
+      return
+    }
+    // Truncate to rate step. If it is a market buy order, do not adjust.
+    const rateStep = this.market.quoteCfg.rateStep
+    const adjusted = order.rate - (order.rate % rateStep)
+    this.page.rateField.value = (adjusted / 1e8)
+  }
+
+  /* loadTable reloads the table from the current order book information. */
+  loadTable () {
+    this.loadTableSide(true)
+    this.loadTableSide(false)
+  }
+
+  /* loadTables loads the order book side into its table. */
+  loadTableSide (sell) {
+    const bookSide = sell ? this.book.sells : this.book.buys
+    const tbody = sell ? this.page.sellRows : this.page.buyRows
+    const cssClass = sell ? 'sellcolor' : 'buycolor'
+    Doc.empty(tbody)
+    if (!bookSide || !bookSide.length) return
+    bookSide.forEach(order => { tbody.appendChild(this.orderTableRow(order, cssClass)) })
+  }
+
+  /* addTableOrder adds a single order to the appropriate table. */
+  addTableOrder (order) {
+    const tbody = order.sell ? this.page.sellRows : this.page.buyRows
+    const cssClass = order.sell ? 'sellcolor' : 'buycolor'
+    var row = tbody.firstChild
+    // Handle market order differently.
+    if (order.rate === 0) {
+      // This is a market order.
+      if (!row || row.order.rate !== 0) {
+        row = this.orderTableRow(order, cssClass)
+        tbody.insertBefore(row, tbody.firstChild)
+      }
+      row.addQty(order.qty)
+      return
+    }
+    // Must be a limit order. Sort by rate. Skip the market order row.
+    if (row && row.order.rate === 0) row = row.nextSibling
+    const tr = this.orderTableRow(order, cssClass)
+    while (row) {
+      if ((order.rate < row.order.rate) === order.sell) {
+        tbody.insertBefore(tr, row)
+        return
+      }
+      row = row.nextSibling
+    }
+    tbody.appendChild(tr)
+  }
+
+  /* removeTableOrder removes a single order from its table. */
+  removeTableOrder (order) {
+    const tbody = order.sell ? this.page.sellRows : this.page.buyRows
+    const token = order.token
+    for (const tr of Array.from(tbody.children)) {
+      if (tr.order.token === token) {
+        tr.remove()
+        return
+      }
+    }
+  }
+
+  /*
+   * clearOrderTableEpochs removes immediate-tif orders whose epoch has expired.
+   */
+  clearOrderTableEpochs (newEpoch) {
+    this.clearOrderTableEpochSide(this.page.sellRows)
+    this.clearOrderTableEpochSide(this.page.buyRows)
+  }
+
+  /*
+   * clearOrderTableEpochs removes immediate-tif orders whose epoch has expired
+   * for a single side.
+   */
+  clearOrderTableEpochSide (tbody, newEpoch) {
+    for (const tr of Array.from(tbody.children)) {
+      if (tr.order.epoch && tr.order.epoch !== newEpoch) tr.remove()
+    }
+  }
+
+  /*
+   * orderTableRow creates a new <tr> element to insert into an order table.
+   */
+  orderTableRow (order, cssClass) {
+    const tr = this.page.rowTemplate.cloneNode(true)
+    tr.qty = order.qty
+    tr.order = order
+    const rate = order.rate
+    bind(tr, 'click', () => {
+      this.reportPrice(rate)
+    })
+    var qtyTD
+    tr.querySelectorAll('td').forEach(td => {
+      switch (td.dataset.type) {
+        case 'qty':
+          qtyTD = td
+          td.innerText = order.qty.toFixed(8)
+          break
+        case 'rate':
+          if (order.rate === 0) {
+            td.innerText = 'market'
+          } else {
+            td.innerText = order.rate.toFixed(8)
+            td.classList.add(cssClass)
+          }
+          break
+        case 'epoch':
+          if (order.epoch) td.appendChild(check.cloneNode())
+          break
+      }
+    })
+    tr.addQty = (qty) => {
+      tr.qty += qty
+      qtyTD.innerText = tr.qty.toFixed(8)
+    }
+    return tr
+  }
+
+  /*
+   * unload is called by the Application when the user navigates away from
+   * the /markets page.
+   */
+  unload () {
+    ws.request(unmarketRoute, {})
+    ws.deregisterRoute(bookRoute)
+    ws.deregisterRoute(bookUpdateRoute)
+    ws.deregisterRoute(epochOrderRoute)
+    ws.deregisterRoute(bookOrderRoute)
+    ws.deregisterRoute(unbookOrderRoute)
+    this.chart.unattach()
+  }
+}
+
+/* makeMarket creates a market object that specifies basic market details. */
+function makeMarket (dex, base, quote) {
+  return {
+    dex: dex,
+    base: base,
+    quote: quote
+  }
+}
+
+/* marketID creates a DEX-compatible market name from the BIP IDs. */
+export function marketID (b, q) { return `${BipIDs[b]}_${BipIDs[q]}` }
+
+/* asAtoms converts the float string to atoms. */
+function asAtoms (s) {
+  return Math.round(parseFloat(s) * 1e8)
+}
+
+/* swapBttns changes the 'selected' class of the buttons. */
+function swapBttns (before, now) {
+  before.classList.remove('selected')
+  now.classList.add('selected')
+}

--- a/client/webserver/site/src/js/orderbook.js
+++ b/client/webserver/site/src/js/orderbook.js
@@ -1,0 +1,65 @@
+import { BipIDs } from './doc'
+
+export default class OrderBook {
+  constructor (market) {
+    this.base = market.base
+    this.baseSymbol = BipIDs[market.base]
+    this.quote = market.quote
+    this.quoteSymbol = BipIDs[market.quote]
+    // Books are sorted mid-gap first.
+    this.buys = market.book.buys || []
+    this.sells = market.book.sells || []
+  }
+
+  /* add adds an order to the order book. */
+  add (ord) {
+    const side = ord.sell ? this.sells : this.buys
+    side.splice(findIdx(side, ord.rate, !ord.sell), 0, ord)
+  }
+
+  /* remove removes an order from the order book. */
+  remove (token) {
+    if (this.removeFromSide(this.sells, token)) return
+    this.removeFromSide(this.buys, token)
+  }
+
+  /* removeFromSide remvoes an order from the list of orders. */
+  removeFromSide (side, token) {
+    for (const i in side) {
+      if (side[i].token === token) {
+        side.splice(i, 1)
+        return true
+      }
+    }
+    return false
+  }
+
+  /*
+   * setEpoch sets the current epoch and clear any orders from previous epochs.
+   */
+  setEpoch (epochIdx) {
+    const approve = ord => ord.epoch === 0 || ord.epoch === epochIdx
+    this.sells = this.sells.filter(approve)
+    this.buys = this.buys.filter(approve)
+  }
+
+  /* empty will return true if both the buys and sells lists are empty. */
+  empty () {
+    return !this.sells.length && !this.buys.length
+  }
+
+  /* count is the total count of both buy and sell orders. */
+  count () {
+    return this.sells.length + this.buys.length
+  }
+}
+
+/*
+ * findIdx find the index at which to insert the order into the list of orders.
+ */
+function findIdx (side, rate, less) {
+  for (const i in side) {
+    if ((side[i].rate < rate) === less) return i
+  }
+  return side.length
+}

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -1,4 +1,4 @@
-import Doc, { StateIcons } from './doc'
+import Doc, { WalletIcons } from './doc'
 import BasePage from './basepage'
 import { postJSON } from './http'
 import * as forms from './forms'
@@ -47,7 +47,7 @@ export default class WalletsPage extends BasePage {
       rowInfo.tr = tr
       rowInfo.symbol = tr.dataset.symbol
       rowInfo.name = tr.dataset.name
-      rowInfo.stateIcons = new StateIcons(tr)
+      rowInfo.stateIcons = new WalletIcons(tr)
       rowInfo.actions = {
         connect: getAction(tr, 'connect'),
         unlock: getAction(tr, 'unlock'),

--- a/client/webserver/site/src/js/ws.js
+++ b/client/webserver/site/src/js/ws.js
@@ -28,7 +28,10 @@ function forward (route, payload, handlers) {
     console.error(`websocket error (code ${err.code}): ${err.message}`)
     return
   }
-  if (typeof handlers[route] === 'undefined') return
+  if (typeof handlers[route] === 'undefined') {
+    // console.log(`unhandled message for ${route}: ${payload}`)
+    return
+  }
   // call each handler
   for (var i = 0; i < handlers[route].length; i++) {
     handlers[route][i](payload)

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -229,7 +229,6 @@ out:
 			}
 
 			// Prepare the book/unbook/epoch note.
-			seq := subs.nextSeq()
 			var note interface{}
 			var route string
 			switch u.action {
@@ -248,7 +247,7 @@ out:
 					panic("non-limit order received with bookAction")
 				}
 				n := book.update(lo)
-				n.Seq = seq
+				n.Seq = subs.nextSeq()
 				note = n
 
 			case unbookAction:
@@ -260,7 +259,7 @@ out:
 				book.remove(lo)
 				oid := u.order.ID()
 				note = &msgjson.UnbookOrderNote{
-					Seq:      seq,
+					Seq:      subs.nextSeq(),
 					MarketID: book.name,
 					OrderID:  oid[:],
 				}
@@ -280,9 +279,12 @@ out:
 					epochNote.TargetID = o.TargetOrderID[:]
 				}
 
-				epochNote.Seq = seq
+				epochNote.Seq = subs.nextSeq()
 				epochNote.MarketID = book.name
 				epochNote.Epoch = uint64(u.epochIdx)
+				c := u.order.Commitment()
+				epochNote.Commit = c[:]
+
 				note = epochNote
 
 			case matchProofAction:

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -580,10 +580,10 @@ func (s *Swapper) TxMonitored(user account.AccountID, asset uint32, txid string)
 		switch asset {
 		case match.makerStatus.swapAsset:
 			// Maker's swap transaction is the asset of interest.
-			if user == match.Maker.User() && match.makerStatus.swap.TxID() == txid {
+			if user == match.Maker.User() {
 				// The swap contract tx is considered monitored until the swap
 				// is complete, regardless of confirms.
-				return true
+				return match.makerStatus.swap != nil && match.makerStatus.swap.TxID() == txid
 			}
 
 			// Taker's redemption transaction is the asset of interest.
@@ -594,10 +594,10 @@ func (s *Swapper) TxMonitored(user account.AccountID, asset uint32, txid string)
 			}
 		case match.takerStatus.swapAsset:
 			// Taker's swap transaction is the asset of interest.
-			if user == match.Taker.User() && match.takerStatus.swap.TxID() == txid {
+			if user == match.Taker.User() {
 				// The swap contract tx is considered monitored until the swap
 				// is complete, regardless of confirms.
-				return true
+				return match.takerStatus.swap != nil && match.takerStatus.swap.TxID() == txid
 			}
 
 			// Maker's redemption transaction is the asset of interest.


### PR DESCRIPTION
#### app

Completes the `MarketsPage` js class, and hooks up the /markets page. Better handling of zoom in the depth chart. Epoch orders are also added to depth, but I plan to follow up with a customization to
differentiate the display of order book and epoch depth.

#### core

Subscribe to the order book when the user navigates to the /market page. Unsubscribe from the order 1 minute after last tab navigates away from the market's page. Send notifications for book, unbook and epoch orders. Send a notification when a new epoch is known to have started, which could be triggered by either a order book notification or a match_proof notification.

#### client/orders

Modifies client/orders to be more permissive of sequencing issues, which might be temporary, and also to allow orders from multiple epochs to be in the queue at the same time. The latter is necessary because order book notifications might come before the match_proof notification for the prior epoch.