### PR TITLE
market,dex: trade suspension

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1945,8 +1945,7 @@ func (c *Core) connectDEX(acctInfo *db.AccountInfo) (*dexConnection, error) {
 	}
 
 	assets := make(map[uint32]*dex.Asset, len(dexCfg.Assets))
-	for i := range dexCfg.Assets {
-		asset := &dexCfg.Assets[i]
+	for _, asset := range dexCfg.Assets {
 		assets[asset.ID] = convertAssetInfo(asset)
 	}
 	// Validate the markets so we don't have to check every time later.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -163,11 +163,11 @@ func testDexConnection() (*dexConnection, *TWebsocket, *dexAccount) {
 		cfg: &msgjson.ConfigResult{
 			CancelMax:        0.8,
 			BroadcastTimeout: 5 * 60 * 1000,
-			Assets: []msgjson.Asset{
-				*uncovertAssetInfo(tDCR),
-				*uncovertAssetInfo(tBTC),
+			Assets: []*msgjson.Asset{
+				uncovertAssetInfo(tDCR),
+				uncovertAssetInfo(tBTC),
 			},
-			Markets: []msgjson.Market{
+			Markets: []*msgjson.Market{
 				{
 					Name:            tDcrBtcMktName,
 					Base:            tDCR.ID,
@@ -633,7 +633,7 @@ func TestMarkets(t *testing.T) {
 		base, quote := randomMsgMarket()
 		marketIDs[marketName(base.ID, quote.ID)] = struct{}{}
 		cfg := rig.dc.cfg
-		cfg.Markets = append(cfg.Markets, msgjson.Market{
+		cfg.Markets = append(cfg.Markets, &msgjson.Market{
 			Name:            base.Symbol + quote.Symbol,
 			Base:            base.ID,
 			Quote:           quote.ID,

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -5,7 +5,14 @@ package admin
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"decred.org/dcrdex/dex/encode"
+	"github.com/go-chi/chi"
 )
 
 // writeJSON marshals the provided interface and writes the bytes to the
@@ -34,4 +41,108 @@ func (_ *Server) apiPing(w http.ResponseWriter, _ *http.Request) {
 // apiConfig is the handler for the '/config' API request.
 func (s *Server) apiConfig(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, s.core.ConfigMsg())
+}
+
+func (s *Server) apiMarkets(w http.ResponseWriter, r *http.Request) {
+	statuses := s.core.MarketStatuses()
+	mktStatuses := make(map[string]*MarketStatus)
+	for name, status := range statuses {
+		mktStatus := &MarketStatus{
+			// Name is empty since the key is the name.
+			Running:       status.Running,
+			EpochDuration: status.EpochDuration,
+			ActiveEpoch:   status.ActiveEpoch,
+			StartEpoch:    status.StartEpoch,
+			SuspendEpoch:  status.SuspendEpoch,
+		}
+		if status.SuspendEpoch != 0 {
+			persist := status.PersistBook
+			mktStatus.PersistBook = &persist
+		}
+		mktStatuses[name] = mktStatus
+	}
+
+	writeJSON(w, mktStatuses)
+}
+
+// apiMarketInfo is the handler for the '/market/{marketName}' API request.
+func (s *Server) apiMarketInfo(w http.ResponseWriter, r *http.Request) {
+	mkt := strings.ToLower(chi.URLParam(r, marketNameKey))
+	status := s.core.MarketStatus(mkt)
+	if status == nil {
+		http.Error(w, fmt.Sprintf("unknown market %q", mkt), http.StatusBadRequest)
+		return
+	}
+
+	mktStatus := &MarketStatus{
+		Name:          mkt,
+		Running:       status.Running,
+		EpochDuration: status.EpochDuration,
+		ActiveEpoch:   status.ActiveEpoch,
+		StartEpoch:    status.ActiveEpoch,
+		SuspendEpoch:  status.SuspendEpoch,
+	}
+	if status.SuspendEpoch != 0 {
+		persist := status.PersistBook
+		mktStatus.PersistBook = &persist
+	}
+	writeJSON(w, mktStatus)
+}
+
+// hander for route '/market/{marketName}/suspend?t=EPOCH-MS&persist=BOOL'
+func (s *Server) apiSuspend(w http.ResponseWriter, r *http.Request) {
+	// Ensure the market exists and is running.
+	mkt := strings.ToLower(chi.URLParam(r, marketNameKey))
+	found, running := s.core.MarketRunning(mkt)
+	if !found {
+		http.Error(w, fmt.Sprintf("unknown market %q", mkt), http.StatusBadRequest)
+		return
+	}
+	if !running {
+		http.Error(w, fmt.Sprintf("market %q not running", mkt), http.StatusBadRequest)
+		return
+	}
+
+	// Validate the suspend time provided in the "t" query. If not specified,
+	// the zero time.Time is used to indicate ASAP.
+	var suspTime time.Time
+	if tSuspendStr := r.URL.Query().Get("t"); tSuspendStr != "" {
+		suspTimeMs, err := strconv.ParseInt(tSuspendStr, 10, 64)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid suspend time %q: %v", tSuspendStr, err), http.StatusBadRequest)
+			return
+		}
+
+		suspTime = encode.UnixTimeMilli(suspTimeMs)
+		if time.Until(suspTime) < 0 {
+			http.Error(w, fmt.Sprintf("specified market suspend time is in the past: %v", suspTime),
+				http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Validate the persist book flag provided in the "persist" query. If not
+	// specified, persist the books, do not purge.
+	persistBook := true
+	if persistBookStr := r.URL.Query().Get("persist"); persistBookStr != "" {
+		var err error
+		persistBook, err = strconv.ParseBool(persistBookStr)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid persist book boolean %q: %v", persistBookStr, err), http.StatusBadRequest)
+			return
+		}
+	}
+
+	suspEpoch := s.core.SuspendMarket(mkt, suspTime, persistBook)
+	if suspEpoch == nil {
+		// Should not happen.
+		http.Error(w, "failed to suspend market "+mkt, http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, &SuspendResult{
+		Market:      mkt,
+		FinalEpoch:  suspEpoch.Idx,
+		SuspendTime: APITime{suspEpoch.End},
+	})
 }

--- a/server/admin/types.go
+++ b/server/admin/types.go
@@ -1,0 +1,51 @@
+package admin
+
+import (
+	"time"
+)
+
+// MarketStatus summarizes the operational status of a market.
+type MarketStatus struct {
+	Name          string `json:"market,omitempty"`
+	Running       bool   `json:"running"`
+	EpochDuration uint64 `json:"epochlen"`
+	ActiveEpoch   int64  `json:"activeepoch"`
+	StartEpoch    int64  `json:"startepoch"`
+	SuspendEpoch  int64  `json:"finalepoch,omitempty"`
+	PersistBook   *bool  `json:"persistbook,omitempty"`
+}
+
+// APITime marshals and unmarshals a time value in time.RFC3339Nano format.
+type APITime struct {
+	time.Time
+}
+
+// SuspendResult describes the result of a market suspend request. FinalEpoch is
+// the last epoch before shutdown, and it the market will run for it's entire
+// duration. As such, SuspendTime is the time at which the market is closed,
+// immediately after close of FinalEpoch.
+type SuspendResult struct {
+	Market      string  `json:"market"`
+	FinalEpoch  int64   `json:"finalepoch"`
+	SuspendTime APITime `json:"supendtime"`
+}
+
+// RFC3339Milli is the RFC3339 time formatting with millisecond precision.
+const RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
+
+// MarshalJSON marshals APITime to a JSON string in RFC3339 format except with
+// millisecond precision.
+func (at *APITime) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + at.Time.Format(RFC3339Milli) + `"`), nil
+}
+
+// UnmarshalJSON unmarshals JSON string containing a time in RFC3339 format with
+// millisecond precision into an APITime.
+func (at *APITime) UnmarshalJSON(b []byte) error {
+	t, err := time.Parse(RFC3339Milli, string(b))
+	if err != nil {
+		return nil
+	}
+	at.Time = t
+	return nil
+}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -500,7 +500,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 	}
 
 	auth.addClient(client)
-	log.Tracef("user %x connected", acctInfo.ID[:])
+	log.Debugf("User %s connected from %s.", acctInfo.ID, conn.IP())
 	return nil
 }
 

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -92,6 +92,7 @@ type tReq struct {
 // tRPCClient satisfies the comms.Link interface.
 type TRPCClient struct {
 	id         uint64
+	ip         string
 	sendErr    error
 	requestErr error
 	banished   bool
@@ -100,6 +101,7 @@ type TRPCClient struct {
 }
 
 func (c *TRPCClient) ID() uint64 { return c.id }
+func (c *TRPCClient) IP() string { return c.ip }
 func (c *TRPCClient) Send(msg *msgjson.Message) error {
 	c.sends = append(c.sends, msg)
 	return c.sendErr
@@ -133,7 +135,10 @@ var tClientID uint64
 
 func tNewRPCClient() *TRPCClient {
 	tClientID++
-	return &TRPCClient{id: tClientID}
+	return &TRPCClient{
+		id: tClientID,
+		ip: "123.123.123.123",
+	}
 }
 
 var tAcctID uint64

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -106,6 +106,8 @@ func (c *TRPCClient) Send(msg *msgjson.Message) error {
 	c.sends = append(c.sends, msg)
 	return c.sendErr
 }
+func (c *TRPCClient) SendError(id uint64, msg *msgjson.Error) {
+}
 func (c *TRPCClient) Request(msg *msgjson.Message, f func(comms.Link, *msgjson.Message), _ time.Duration, _ func()) error {
 	c.reqs = append(c.reqs, &tReq{
 		msg:      msg,

--- a/server/book/book.go
+++ b/server/book/book.go
@@ -25,6 +25,7 @@ const (
 type Book struct {
 	mtx     sync.RWMutex
 	lotSize uint64
+	halfCap uint32
 	buys    *OrderPQ
 	sells   *OrderPQ
 }
@@ -39,9 +40,18 @@ func New(lotSize uint64, halfCapacity ...uint32) *Book {
 	}
 	return &Book{
 		lotSize: lotSize,
+		halfCap: halfCap,
 		buys:    NewMaxOrderPQ(halfCap),
 		sells:   NewMinOrderPQ(halfCap),
 	}
+}
+
+// Clear reset the order book with configured capacity.
+func (b *Book) Clear() {
+	b.mtx.Lock()
+	b.buys = NewMaxOrderPQ(b.halfCap)
+	b.sells = NewMaxOrderPQ(b.halfCap)
+	b.mtx.Unlock()
 }
 
 // Realloc changes the capacity of the order book given the specified capacity

--- a/server/book/book_test.go
+++ b/server/book/book_test.go
@@ -248,4 +248,20 @@ func TestBook(t *testing.T) {
 		t.Errorf("Failed to remove best sell order. Got %v, wanted %v",
 			removed.ID(), bestSellOrder.ID())
 	}
+
+	if b.SellCount() == 0 {
+		t.Errorf("sell side was empty")
+	}
+	if b.BuyCount() == 0 {
+		t.Errorf("buy side was empty")
+	}
+
+	b.Clear()
+
+	if b.SellCount() != 0 {
+		t.Errorf("sell side was not empty after Clear")
+	}
+	if b.BuyCount() != 0 {
+		t.Errorf("buy side was not empty after Clear")
+	}
 }

--- a/server/coinlock/coinlocker_test.go
+++ b/server/coinlock/coinlocker_test.go
@@ -159,7 +159,7 @@ func Test_bookLocker_LockCoins(t *testing.T) {
 
 	bookLock.LockCoins(coinMap)
 
-	verifyLocked := func(cl CoinLockChecker, coins []CoinID, wantLocked bool) bool {
+	verifyLocked := func(cl CoinLockChecker, coins []CoinID, wantLocked bool) (ok bool) {
 		for _, coin := range coins {
 			locked := cl.CoinLocked(coin)
 			if locked != wantLocked {
@@ -201,5 +201,19 @@ func Test_bookLocker_LockCoins(t *testing.T) {
 	}
 	if !verifyLocked(swapLock, orderCoins, false) {
 		t.Errorf("swapLock indicated coins were locked that should have been unlocked")
+	}
+
+	// Relock the coins.
+	bookLock.LockCoins(coinMap)
+
+	// Make sure the BOOK locker say they are locked.
+	if !verifyLocked(bookLock, allCoins, true) {
+		t.Errorf("bookLock indicated coins were unlocked that should have been locked")
+	}
+
+	bookLock.UnlockAll()
+
+	if !verifyLocked(bookLock, orderCoins, false) {
+		t.Errorf("bookLock indicated coins were locked that should have been unlocked")
 	}
 }

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -11,10 +11,6 @@ import (
 	"decred.org/dcrdex/dex/ws"
 )
 
-// outBufferSize is the size of the client's buffered channel for outgoing
-// messages.
-const outBufferSize = 128
-
 // Link is an interface for a communication channel with an API client. The
 // reference implementation of a Link-satisfying type is the wsLink, which
 // passes messages over a websocket connection.
@@ -23,8 +19,11 @@ type Link interface {
 	ID() uint64
 	// IP returns the IP address of the peer.
 	IP() string
-	// Send sends the msgjson.Message to the client.
+	// Send sends the msgjson.Message to the peer.
 	Send(msg *msgjson.Message) error
+	// SendError sends the msgjson.Error to the peer, with reference to a
+	// request message ID.
+	SendError(id uint64, rpcErr *msgjson.Error)
 	// Request sends the Request-type msgjson.Message to the client and registers
 	// a handler for the response.
 	Request(msg *msgjson.Message, f func(Link, *msgjson.Message), expireTime time.Duration, expire func()) error

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -19,8 +19,10 @@ const outBufferSize = 128
 // reference implementation of a Link-satisfying type is the wsLink, which
 // passes messages over a websocket connection.
 type Link interface {
-	// ID will return a unique ID by which this connection can be identified.
+	// ID returns a unique ID by which this connection can be identified.
 	ID() uint64
+	// IP returns the IP address of the peer.
+	IP() string
 	// Send sends the msgjson.Message to the client.
 	Send(msg *msgjson.Message) error
 	// Request sends the Request-type msgjson.Message to the client and registers
@@ -69,8 +71,14 @@ func (c *wsLink) Banish() {
 	c.Disconnect()
 }
 
+// ID returns a unique ID by which this connection can be identified.
 func (c *wsLink) ID() uint64 {
 	return c.id
+}
+
+// IP returns the IP address of the peer.
+func (c *wsLink) IP() string {
+	return c.WSLink.IP()
 }
 
 func handleMessage(c *wsLink, msg *msgjson.Message) *msgjson.Error {

--- a/server/db/driver/pg/internal/orders.go
+++ b/server/db/driver/pg/internal/orders.go
@@ -121,8 +121,8 @@ const (
 	//			quantity,
 	//			rate,
 	//			force,
-	//			2,                                      -- new status ($d)
-	//			123456789,                              -- new filled ($d)
+	//			2,                                      -- new status (%d)
+	//			123456789,                              -- new filled (%d)
 	//          epoch_idx, epoch_dur, preimage, complete_time
 	//		)
 	//		INSERT INTO dcrdex.dcr_btc.orders_archived  -- destination table (%s)
@@ -138,6 +138,18 @@ const (
 	INSERT INTO %s
 	SELECT * FROM moved;`
 	// TODO: consider a MoveOrderSameFilled query
+
+	PurgeBook = `WITH moved AS (
+		DELETE FROM %s       -- active orders table for market X
+		WHERE status = $1    -- booked status code
+		RETURNING oid, type, sell, account_id, address,
+			client_time, server_time, commit, coins, quantity,
+			rate, force, %d, filled, -- revoked status code
+			epoch_idx, epoch_dur, preimage, complete_time
+	)
+	INSERT INTO %s -- archived orders table for market X
+	SELECT * FROM moved
+	RETURNING oid, sell, account_id;`
 
 	// CreateCancelOrdersTable creates a table specified via the %s printf
 	// specifier for cancel orders.

--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -67,7 +67,7 @@ func openDB() (func() error, error) {
 		User:         PGTestsUser,
 		Pass:         PGTestsPass,
 		DBName:       PGTestsDBName,
-		ShowPGConfig: true,
+		ShowPGConfig: false,
 		QueryTimeout: 0, // zero to use the default
 		MarketCfg:    []*dex.MarketInfo{mktInfo, mktInfo2},
 		//CheckedStores: true,

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -82,6 +82,9 @@ type OrderArchiver interface {
 	// BookOrders returns all book orders for a market.
 	BookOrders(base, quote uint32) ([]*order.LimitOrder, error)
 
+	// FlushBook revokes all booked orders for a market.
+	FlushBook(base, quote uint32) (sellsRemoved, buysRemoved []order.OrderID, err error)
+
 	// ActiveOrderCoins retrieves a CoinID slice for each active order.
 	ActiveOrderCoins(base, quote uint32) (baseCoins, quoteCoins map[order.OrderID][]order.CoinID, err error)
 

--- a/server/market/epump.go
+++ b/server/market/epump.go
@@ -1,0 +1,139 @@
+package market
+
+import (
+	"context"
+	"sync"
+
+	"decred.org/dcrdex/dex/order"
+	"decred.org/dcrdex/server/matcher"
+)
+
+type readyEpoch struct {
+	*EpochQueue
+	ready          chan struct{} // close this when the struct is ready
+	cSum           []byte
+	ordersRevealed []*matcher.OrderRevealed
+	misses         []order.Order
+}
+
+type epochPump struct {
+	ready chan *readyEpoch // consumer receives from this
+
+	mtx    sync.RWMutex
+	q      []*readyEpoch
+	halt   bool
+	halted bool
+	head   chan *readyEpoch // internal, closed when ready to halt
+}
+
+func newEpochPump() *epochPump {
+	return &epochPump{
+		ready: make(chan *readyEpoch, 1),
+		head:  make(chan *readyEpoch, 1),
+	}
+}
+
+func (ep *epochPump) Run(ctx context.Context) {
+	// Context cancellation must cause a graceful shutdown.
+	go func() {
+		<-ctx.Done()
+
+		ep.mtx.Lock()
+		defer ep.mtx.Unlock()
+
+		// gracefully shut down the epoch pump, allowing the queue to be fully
+		// drained and all epochs passed on to the consumer.
+		if len(ep.q) == 0 {
+			// Ready to shutdown.
+			close(ep.head) // cause next() to return a closed channel and Run to return.
+			ep.halted = true
+		} else {
+			// next will close it after it drains the queue.
+			ep.halt = true
+		}
+	}()
+
+	defer close(ep.ready)
+	for {
+		rq, ok := <-ep.next()
+		if !ok {
+			return
+		}
+		ep.ready <- rq // consumer should receive this
+	}
+}
+
+// Insert enqueues an EpochQueue and starts preimage collection immediately.
+// Access epoch queues in order and when they have completed preimage collection
+// by receiving from the epochPump.ready channel.
+func (ep *epochPump) Insert(epoch *EpochQueue) *readyEpoch {
+	rq := &readyEpoch{
+		EpochQueue: epoch,
+		ready:      make(chan struct{}),
+	}
+
+	ep.mtx.Lock()
+	defer ep.mtx.Unlock()
+
+	if ep.halted || ep.halt {
+		// head is closed or about to be.
+		return nil
+	}
+
+	select {
+	case ep.head <- rq: // buffered, so non-blocking when empty and no receiver
+	default:
+		// push: append a new readyEpoch to the closed epoch queue.
+		ep.q = append(ep.q, rq)
+	}
+
+	return rq
+}
+
+// popFront removes the next readyEpoch from the closed epoch queue, q. It is
+// not thread-safe. pop is only used in next to advance the head of the pump.
+func (ep *epochPump) popFront() *readyEpoch {
+	if len(ep.q) == 0 {
+		return nil
+	}
+	x := ep.q[0]
+	ep.q = ep.q[1:]
+	return x
+}
+
+// next provides a channel for receiving the next readyEpoch when it completes
+// preimage collection. next blocks until there is an epoch to send.
+func (ep *epochPump) next() <-chan *readyEpoch {
+	ready := make(chan *readyEpoch) // next sent on this channel when ready
+	next := <-ep.head
+
+	// A closed head channel signals a halted and drained pump.
+	if next == nil {
+		close(ready)
+		return ready
+	}
+
+	ep.mtx.Lock()
+	defer ep.mtx.Unlock()
+
+	// If the queue is not empty, set new head.
+	x := ep.popFront()
+	if x != nil {
+		ep.head <- x // non-blocking, received in select above
+	} else if ep.halt {
+		// Only halt the pump once the queue is emptied. The final head is still
+		// forwarded to the consumer.
+		close(ep.head)
+		ep.halted = true
+		// continue to serve next, but a closed channel will be returned on
+		// subsequent calls.
+	}
+
+	// Send next on the returned channel when it becomes ready. If the process
+	// dies before goroutine completion, the Market is down anyway.
+	go func() {
+		<-next.ready // block until preimage collection is complete (close this channel)
+		ready <- next
+	}()
+	return ready
+}

--- a/server/market/epump_test.go
+++ b/server/market/epump_test.go
@@ -1,0 +1,159 @@
+package market
+
+import (
+	"context"
+	"math/rand"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestMarket_epochPumpHalt(t *testing.T) {
+	// This tests stopping the epochPump.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ePump := newEpochPump()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ePump.Run(ctx)
+	}()
+
+	eq0 := NewEpoch(123413513, 1000)
+	rq0 := ePump.Insert(eq0)
+
+	eq1 := NewEpoch(123413514, 1000)
+	rq1 := ePump.Insert(eq1) // testing ep.q append
+
+	close(rq1.ready)
+
+	var rq0Out *readyEpoch
+	select {
+	case rq0Out = <-ePump.ready:
+		t.Fatalf("readyQueue provided out of order, got epoch %d", rq0Out.Epoch)
+	default:
+		// good, nothing was supposed to come out yet
+	}
+
+	close(rq0.ready)
+
+	rq0Out = <-ePump.ready
+	if rq0Out.EpochQueue.Epoch != eq0.Epoch {
+		t.Errorf("expected epoch %d, got %d", eq0.Epoch, rq0Out.EpochQueue.Epoch)
+	}
+
+	cancel() // testing len(ep.q) == 0 (Ready to shutdown), with rq1 in head
+	wg.Wait()
+
+	// pump should be done, but the final readyEpoch should have been sent on
+	// the buffered ready chan.
+	rq1Out := <-ePump.ready
+	if rq1Out.EpochQueue.Epoch != eq1.Epoch {
+		t.Errorf("expected epoch %d, got %d", eq1.Epoch, rq1Out.EpochQueue.Epoch)
+	}
+
+	// Test shutdown with multiple queued epochs.
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	ePump = newEpochPump()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ePump.Run(ctx)
+	}()
+
+	eq0 = NewEpoch(123413513, 1000)
+	rq0 = ePump.Insert(eq0)
+	eq1 = NewEpoch(123413514, 1000)
+	rq1 = ePump.Insert(eq1)
+	eq2 := NewEpoch(123413515, 1000)
+	rq2 := ePump.Insert(eq2)
+
+	cancel()          // testing len(ep.q) != 0 (stop after it drains the queue).
+	runtime.Gosched() // let Run start shutting things down
+	time.Sleep(50 * time.Millisecond)
+
+	// Make sure epochs come out in order.
+	close(rq0.ready)
+	rq0Out = <-ePump.ready
+	if rq0Out.EpochQueue.Epoch != eq0.Epoch {
+		t.Errorf("expected epoch %d, got %d", eq0.Epoch, rq0Out.EpochQueue.Epoch)
+	}
+
+	close(rq1.ready)
+	rq1Out = <-ePump.ready
+	if rq1Out.EpochQueue.Epoch != eq1.Epoch {
+		t.Errorf("expected epoch %d, got %d", eq1.Epoch, rq1Out.EpochQueue.Epoch)
+	}
+
+	close(rq2.ready)
+	rq2Out := <-ePump.ready
+	if rq2Out.EpochQueue.Epoch != eq2.Epoch {
+		t.Errorf("expected epoch %d, got %d", eq2.Epoch, rq2Out.EpochQueue.Epoch)
+	}
+
+	select {
+	case _, ok := <-ePump.ready:
+		if ok {
+			t.Errorf("ready channel should be closed now (Run returned), but something came through")
+		}
+	case <-time.After(time.Second):
+		t.Errorf("ready channel should be closed by now (Run returned)")
+	}
+
+	rqX := ePump.Insert(eq2)
+	if rqX != nil {
+		t.Errorf("halted epoch pump allowed insertion of new epoch queue")
+	}
+
+	wg.Wait()
+}
+
+func Test_epochPump_next(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ep := newEpochPump()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		ep.Run(ctx)
+		wg.Done()
+	}()
+
+	waitTime := int64(5 * time.Second)
+	if testing.Short() {
+		waitTime = int64(1 * time.Second)
+	}
+
+	var epochStart, epochDur, numEpochs int64 = 123413513, 1_000, 100
+	epochs := make([]*readyEpoch, numEpochs)
+	for i := int64(0); i < numEpochs; i++ {
+		rq := ep.Insert(NewEpoch(i+epochStart, epochDur))
+		epochs[i] = rq
+
+		// Simulate preimage collection, randomly making the queues ready.
+		go func() {
+			wait := time.Duration(rand.Int63n(waitTime))
+			time.Sleep(wait)
+			close(rq.ready)
+		}()
+	}
+
+	// Receive all the ready epochs, verifying they come in order.
+	for i := epochStart; i < numEpochs+epochStart; i++ {
+		rq := <-ep.ready
+		if rq.Epoch != i {
+			t.Errorf("Received epoch %d, expected %d", rq.Epoch, i)
+		}
+	}
+	// All fake preimage collection goroutines are done now.
+
+	cancel()
+	wg.Wait()
+}

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -1101,6 +1101,7 @@ func (s *TBookSource) OrderFeed() <-chan *bookUpdateSignal {
 type TLink struct {
 	mtx      sync.Mutex
 	id       uint64
+	ip       string
 	sends    []*msgjson.Message
 	sendErr  error
 	banished bool
@@ -1112,11 +1113,13 @@ func tNewLink() *TLink {
 	linkCounter++
 	return &TLink{
 		id:    linkCounter,
+		ip:    "[1:800:dex:rules::]",
 		sends: make([]*msgjson.Message, 0),
 	}
 }
 
 func (conn *TLink) ID() uint64 { return conn.id }
+func (conn *TLink) IP() string { return conn.ip }
 func (conn *TLink) Send(msg *msgjson.Message) error {
 	conn.mtx.Lock()
 	defer conn.mtx.Unlock()


### PR DESCRIPTION
This deals with trade suspension on a per-market basis, and makes Market shutdown more courteous.  This does not deal with `Market` resume, or clean `Swapper` shutdown or resume, which is going to be a significant task in itself.

Notable areas of work:

- market: Graceful suspend (the `epochPump` and `(*Market).Run` work), with optional book purge and coin unlock (the book and coinlock work).
- db: Book purge from persistent storage (mass booked -> revoked status, plus pseudo-cancels recording the actions)
- msgjson, market: Add the `TradeSuspension` message, and send it to clients from `server/dex.DEX` to subscribed clients via `comms/Server` on `Market` suspend command.
- admin: market info and suspend routes
- market: refactor book router's update signals from market

Technically, a suspend involves:
- Setting a future epoch index to be the last, after which orders are rejected.
- Suspend of a market means return of the `Market`'s `Run` goroutine after the final scheduled epoch.  `Markets` can start `Run` again, and this is done in tests with the same `Market` instance, but a resume command to do so is note implemented in this work.
- When `(*Market).Run` begins shutting down, it always allows the closed epoch processing pipeline (preimage collection and hand off of orders `Swapper`) to complete/drain so no submitted orders are lost.
- The DEX manager commands a suspend for a market via the order `OrderRouter`, which submits the requests to the target `Market` and gets the suspend request result (final epoch and suspend time).  It also has access to a new `(*Market).Running` method to short circuit the new order processing rather than have the order rejected downstream by the `Market`. Proxying all suspend requests through the `OrderRouter` puts it in a position to track running and suspended markets, and markets with pending suspension.

Note that this also improves the regular dcrdex shutdown in response to a CTRL+C (and cancellation of all Contexts), in that a `Market`'s `Run` goroutine will always allow the closed epoch processing pipeline to completely drain and no received orders are just dropped.  dcrdex process interrupt is unlike a suspend in that it does not wait for the current epoch to close, but the closed epochs always complete processing.  Better coordination of subsystem shutdown by the `DEX` manager is still needed however.

Major next steps:
- Resume. A suspend also stops book routers presently, but this needs to be reconsidered for resume handling (do we maintain book subscriptions, or require new subs?). Also, the order router may want to track running and suspended markets to facilitate resume and be smarter about when orders may be submitted, another task for resume.
- The `Swapper` needs a clean shutdown/resume solution too, which I believe will be difficult or complex to do with the pg DB, so I'm considering options to dump tracked trades, swap statuses, etc. and everything `Swapper` needs to resume into a gob file or similar.