### PR TITLE
server/admin: cancel password prompt on interrupt request

### DIFF
--- a/server/admin/prompt.go
+++ b/server/admin/prompt.go
@@ -4,6 +4,7 @@
 package admin
 
 import (
+	"context"
 	"crypto/sha256"
 	"errors"
 	"fmt"
@@ -12,26 +13,53 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+type passwordReadResult struct {
+	password []byte
+	err      error
+}
+
 // PasswordPrompt prompts the user to enter a password. Password must not be an
 // empty string.
-func PasswordPrompt(prompt string) ([]byte, error) {
-	fmt.Print(prompt)
-	pass, err := terminal.ReadPassword(syscall.Stdin)
-	fmt.Println()
+func PasswordPrompt(ctx context.Context, prompt string) ([]byte, error) {
+	// Get the initial state of the terminal.
+	initialTermState, err := terminal.GetState(syscall.Stdin)
 	if err != nil {
 		return nil, err
 	}
-	if pass == nil {
-		return nil, errors.New("password must not be empty")
+
+	done := make(chan passwordReadResult, 1)
+
+	fmt.Print(prompt)
+	go func() {
+		pass, err := terminal.ReadPassword(syscall.Stdin)
+		done <- passwordReadResult{
+			password: pass,
+			err:      err,
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = terminal.Restore(syscall.Stdin, initialTermState)
+		return nil, ctx.Err()
+
+	case passwordReadResult := <-done:
+		fmt.Println()
+		if passwordReadResult.err != nil {
+			return nil, passwordReadResult.err
+		}
+		if passwordReadResult.password == nil {
+			return nil, errors.New("password must not be empty")
+		}
+		return passwordReadResult.password, nil
 	}
-	return pass, nil
 }
 
 // PasswordHashPrompt prompts the user to enter a password and returns its
 // SHA256 hash. Password must not be an empty string.
-func PasswordHashPrompt(prompt string) ([sha256.Size]byte, error) {
+func PasswordHashPrompt(ctx context.Context, prompt string) ([sha256.Size]byte, error) {
 	var authSHA [sha256.Size]byte
-	passBytes, err := PasswordPrompt(prompt)
+	passBytes, err := PasswordPrompt(ctx, prompt)
 	if err != nil {
 		return authSHA, err
 	}

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -75,6 +75,7 @@ type dexConf struct {
 	BroadcastTimeout time.Duration
 	AltDNSNames      []string
 	LogMaker         *dex.LoggerMaker
+	SigningKeyPW     []byte
 	AdminSrvOn       bool
 	AdminSrvAddr     string
 }
@@ -109,13 +110,14 @@ type flagsData struct {
 	HTTPProfile bool   `long:"httpprof" short:"p" description:"Start HTTP profiler."`
 	CPUProfile  string `long:"cpuprofile" description:"File for CPU profiling."`
 
-	PGDBName     string `long:"pgdbname" description:"PostgreSQL DB name."`
-	PGUser       string `long:"pguser" description:"PostgreSQL DB user."`
-	PGPass       string `long:"pgpass" description:"PostgreSQL DB password."`
-	PGHost       string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)."`
-	ShowPGConfig bool   `long:"showpgconfig" description:"Logs the PostgreSQL db configuration on system start up."`
-	AdminSrvOn   bool   `long:"adminsrvon" description:"turn on the admin server"`
-	AdminSrvAddr string `long:"adminsrvaddr" description:"administration HTTPS server address (default: 127.0.0.1:6542)"`
+	PGDBName           string `long:"pgdbname" description:"PostgreSQL DB name."`
+	PGUser             string `long:"pguser" description:"PostgreSQL DB user."`
+	PGPass             string `long:"pgpass" description:"PostgreSQL DB password."`
+	PGHost             string `long:"pghost" description:"PostgreSQL server host:port or UNIX socket (e.g. /run/postgresql)."`
+	ShowPGConfig       bool   `long:"showpgconfig" description:"Logs the PostgreSQL db configuration on system start up."`
+	SigningKeyPassword string `long:"signingkeypass" description:"Password for encrypting/decrypting the dex privkey. INSECURE. Do not set unless absolutely necessary."`
+	AdminSrvOn         bool   `long:"adminsrvon" description:"turn on the admin server"`
+	AdminSrvAddr       string `long:"adminsrvaddr" description:"administration HTTPS server address (default: 127.0.0.1:6542)"`
 }
 
 // cleanAndExpandPath expands environment variables and leading ~ in the passed
@@ -529,6 +531,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		BroadcastTimeout: cfg.BroadcastTimeout,
 		AltDNSNames:      cfg.AltDNSNames,
 		LogMaker:         logMaker,
+		SigningKeyPW:     []byte(cfg.SigningKeyPassword),
 		AdminSrvAddr:     adminSrvAddr,
 		AdminSrvOn:       cfg.AdminSrvOn,
 	}

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -82,15 +82,17 @@ func mainCore(ctx context.Context) error {
 	// Load, or create and save, the DEX signing key.
 	var privKey *secp256k1.PrivateKey
 	{
-		keyPW, err := admin.PasswordPrompt(ctx, "Signing key password: ")
-		if err != nil {
-			return fmt.Errorf("cannot use password: %v", err)
+		if len(cfg.SigningKeyPW) == 0 {
+			cfg.SigningKeyPW, err = admin.PasswordPrompt(ctx, "Signing key password: ")
+			if err != nil {
+				return fmt.Errorf("cannot use password: %v", err)
+			}
 		}
-		privKey, err = dexKey(cfg.DEXPrivKeyPath, keyPW)
+		privKey, err = dexKey(cfg.DEXPrivKeyPath, cfg.SigningKeyPW)
+		admin.ClearBytes(cfg.SigningKeyPW)
 		if err != nil {
 			return err
 		}
-		admin.ClearBytes(keyPW)
 	}
 
 	// Create the DEX manager.

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -81,18 +81,16 @@ func mainCore(ctx context.Context) error {
 
 	// Load, or create and save, the DEX signing key.
 	var privKey *secp256k1.PrivateKey
-	{
-		if len(cfg.SigningKeyPW) == 0 {
-			cfg.SigningKeyPW, err = admin.PasswordPrompt(ctx, "Signing key password: ")
-			if err != nil {
-				return fmt.Errorf("cannot use password: %v", err)
-			}
-		}
-		privKey, err = dexKey(cfg.DEXPrivKeyPath, cfg.SigningKeyPW)
-		admin.ClearBytes(cfg.SigningKeyPW)
+	if len(cfg.SigningKeyPW) == 0 {
+		cfg.SigningKeyPW, err = admin.PasswordPrompt(ctx, "Signing key password: ")
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot use password: %v", err)
 		}
+	}
+	privKey, err = dexKey(cfg.DEXPrivKeyPath, cfg.SigningKeyPW)
+	admin.ClearBytes(cfg.SigningKeyPW)
+	if err != nil {
+		return err
 	}
 
 	// Create the DEX manager.

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -38,7 +38,7 @@ func mainCore(ctx context.Context) error {
 	// Acquire admin server password if enabled.
 	var adminSrvAuthSHA [32]byte
 	if cfg.AdminSrvOn {
-		adminSrvAuthSHA, err = admin.PasswordHashPrompt("Admin interface password: ")
+		adminSrvAuthSHA, err = admin.PasswordHashPrompt(ctx, "Admin interface password: ")
 		if err != nil {
 			return fmt.Errorf("cannot use password: %v", err)
 		}
@@ -82,7 +82,7 @@ func mainCore(ctx context.Context) error {
 	// Load, or create and save, the DEX signing key.
 	var privKey *secp256k1.PrivateKey
 	{
-		keyPW, err := admin.PasswordPrompt("Signing key password: ")
+		keyPW, err := admin.PasswordPrompt(ctx, "Signing key password: ")
 		if err != nil {
 			return fmt.Errorf("cannot use password: %v", err)
 		}


### PR DESCRIPTION
When the prompt for admin signing password is password, hitting `ctrl+c` does not cause the dcrdex app to exit, unless user presses enter, in effect entering an empty password. This behaviour may not be quickly obvious to users who may struggle with exiting the app from the password prompt step.

Also, propose `signingkeypass` config option to aid running dcrdex without the interactive prompt asking for signing key password. Similar to dcrwallet's `pass` option for setting wallet private passphrase in config:
https://github.com/decred/dcrwallet/blob/f5b98d7c5d089fe5e0ba47bb44bc55aaad3500e8/sample-dcrwallet.conf#L13-L19

A bit of a security concern, I wouldn't mind taking it out if it is considered too unsafe.