### PR TITLE
market: fix (*OrderRouter).handleLimit ignoring force

### DIFF
--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -197,7 +197,13 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 	}
 
 	// Check time-in-force
-	if !(limit.TiF == msgjson.StandingOrderNum || limit.TiF == msgjson.ImmediateOrderNum) {
+	var force order.TimeInForce
+	switch limit.TiF {
+	case msgjson.StandingOrderNum:
+		force = order.StandingTiF
+	case msgjson.ImmediateOrderNum:
+		force = order.ImmediateTiF
+	default:
 		return msgjson.NewError(msgjson.OrderParameterError, "unknown time-in-force")
 	}
 
@@ -209,10 +215,6 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 	copy(commit[:], limit.Commit)
 
 	// Create the limit order.
-	force := order.StandingTiF
-	if limit.TiF == msgjson.ImmediateOrderNum {
-		force = order.ImmediateTiF
-	}
 	lo := &order.LimitOrder{
 		P: order.Prefix{
 			AccountID:  user,

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -208,7 +208,11 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 	var commit order.Commitment
 	copy(commit[:], limit.Commit)
 
-	// Create the limit order
+	// Create the limit order.
+	force := order.StandingTiF
+	if limit.TiF == msgjson.ImmediateOrderNum {
+		force = order.ImmediateTiF
+	}
 	lo := &order.LimitOrder{
 		P: order.Prefix{
 			AccountID:  user,
@@ -226,7 +230,7 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 			Address:  limit.Address,
 		},
 		Rate:  limit.Rate,
-		Force: order.StandingTiF,
+		Force: force,
 	}
 
 	// NOTE: ServerTime is not yet set, so the order's ID, which is computed


### PR DESCRIPTION
Incoming limit orders would not have their time-in-force set appropriately.  All of them were treated as standing.  When immediate limit orders were send from the client, this would result in an order ID mismatch on the client:

```
[ERR] CORE: Abandoning order. preimage: 70d70f6cee502f84e65c92770a47ba8ada88cd8dc28012543df0d94a75f61e3c, server time: 1588100600868: failed ID match. order abandoned
[ERR] WEB: error placing order: failed ID match. order abandoned
```

followed shortly after by a preimage request that the client could not answer (and a penalty)

```
[ERR] CORE: no active order found for preimage request for 3f233df511afb4230f0337e940cf86deb6c1a65d7f69e963392ec784db0b3d23
```
