### PR TITLE
client/comms: add servername to tls config

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -89,6 +90,11 @@ func NewWsConn(cfg *WsCfg) (WsConn, error) {
 	var tlsConfig *tls.Config
 	if len(cfg.Cert) > 0 {
 
+		uri, err := url.Parse(cfg.URL)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing URL: %v", err)
+		}
+
 		rootCAs, _ := x509.SystemCertPool()
 		if rootCAs == nil {
 			rootCAs = x509.NewCertPool()
@@ -101,6 +107,7 @@ func NewWsConn(cfg *WsCfg) (WsConn, error) {
 		tlsConfig = &tls.Config{
 			RootCAs:    rootCAs,
 			MinVersion: tls.VersionTLS12,
+			ServerName: uri.Hostname(),
 		}
 	}
 

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,12 +168,18 @@ func sendReplace(t *testing.T, conn *wsConnStub, thing interface{}, old, new str
 }
 
 func newTestDEXClient(addr string, rootCAs *x509.CertPool) (*websocket.Conn, error) {
+	uri, err := url.Parse(addr)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing url: %v", err)
+	}
+
 	dialer := &websocket.Dialer{
 		Proxy:            http.ProxyFromEnvironment, // Same as DefaultDialer.
 		HandshakeTimeout: 10 * time.Second,          // DefaultDialer is 45 seconds.
 		TLSClientConfig: &tls.Config{
 			RootCAs:            rootCAs,
 			InsecureSkipVerify: true,
+			ServerName:         uri.Hostname(),
 		},
 	}
 


### PR DESCRIPTION
The `ServerName` field should be set in the tls configuration for websocket clients.