### PR TITLE
multi: implement generic parsing for ini configs

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -47,10 +47,11 @@ const (
 	minProtocolVersion   = 70015
 )
 
-// How often to check the tip hash.
 var (
+	// blockTicker is the delay between calls to check for new blocks.
 	blockTicker = time.Second
-	walletInfo  = &asset.WalletInfo{
+	// walletInfo defines some general information about a Bitcoin wallet.
+	walletInfo = &asset.WalletInfo{
 		Name:              "Bitcoin",
 		Units:             "Satoshis",
 		DefaultConfigPath: dexbtc.SystemConfigPath("bitcoin"),

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -51,10 +51,10 @@ const (
 var (
 	blockTicker = time.Second
 	walletInfo  = &asset.WalletInfo{
-		ConfigPath: dexbtc.SystemConfigPath("bitcoin"),
-		Name:       "Bitcoin",
-		FeeRate:    defaultWithdrawalFee,
-		Units:      "Satoshis",
+		Name:              "Bitcoin",
+		Units:             "Satoshis",
+		DefaultConfigPath: dexbtc.SystemConfigPath("bitcoin"),
+		DefaultFeeRate:    defaultWithdrawalFee,
 	}
 )
 
@@ -255,10 +255,6 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		return nil, fmt.Errorf("unknown network ID %v", network)
 	}
 
-	if cfg.INIPath == "" {
-		cfg.INIPath = dexbtc.SystemConfigPath("bitcoin")
-	}
-
 	return BTCCloneWallet(cfg, "btc", logger, network, params, dexbtc.RPCPorts)
 }
 
@@ -270,7 +266,7 @@ func BTCCloneWallet(cfg *asset.WalletConfig, symbol string, logger dex.Logger,
 	network dex.Network, chainParams *chaincfg.Params, ports dexbtc.NetPorts) (*ExchangeWallet, error) {
 
 	// Read the configuration parameters
-	btcCfg, err := dexbtc.LoadConfig(cfg.INIPath, assetName, network, ports)
+	btcCfg, err := dexbtc.LoadConfigFromSettings(cfg.Settings, assetName, network, ports)
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1257,7 +1257,7 @@ func testSender(t *testing.T, senderType tSenderType) {
 	}
 	if senderType == tWithdrawSender {
 		sender = func(addr string, val uint64) (asset.Coin, error) {
-			return wallet.Withdraw(addr, val, walletInfo.FeeRate)
+			return wallet.Withdraw(addr, val, walletInfo.DefaultFeeRate)
 		}
 	}
 	defer shutdown()

--- a/client/asset/btc/regnet_test.go
+++ b/client/asset/btc/regnet_test.go
@@ -29,6 +29,7 @@ import (
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
 	dexbtc "decred.org/dcrdex/dex/btc"
+	"decred.org/dcrdex/dex/config"
 	"github.com/decred/slog"
 )
 
@@ -65,9 +66,14 @@ func tBackend(t *testing.T, conf, name string, blkFunc func(string, error)) (*Ex
 	if err != nil {
 		t.Fatalf("error getting current user: %v", err)
 	}
+	cfgPath := filepath.Join(user.HomeDir, "dextest", "btc", "harness-ctl", conf+".conf")
+	connSettings, err := config.Options(cfgPath)
+	if err != nil {
+		t.Fatalf("error reading config options: %v", err)
+	}
 	walletCfg := &asset.WalletConfig{
-		INIPath: filepath.Join(user.HomeDir, "dextest", "btc", "harness-ctl", conf+".conf"),
-		Account: name,
+		Settings: connSettings,
+		Account:  name,
 		TipChange: func(err error) {
 			blkFunc(conf, err)
 		},

--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -48,16 +48,13 @@ type DCRConfig struct {
 	Context context.Context
 }
 
-// loadConfig loads the DCRConfig from file. If no values are found for
-// RPCListen or RPCCert in the specified file, default values will be used.
-// If configPath is an empty string, loadConfig will attempt to read settings
-// directly from the default dcrwallet.conf filepath. If there is no error, the
-// module-level chainParams variable will be set appropriately for the network.
+// loadConfig loads the DCRConfig from a settings map. If no values are found
+// for RPCListen or RPCCert in the specified file, default values will be used.
+// If there is no error, the module-level chainParams variable will be set
+// appropriately for the network.
 func loadConfig(settings map[string]string, network dex.Network) (*DCRConfig, error) {
 	cfg := new(DCRConfig)
-	cfgData := config.OptionsMapToINIData(settings)
-	err := config.Parse(cfgData, cfg)
-	if err != nil {
+	if err := config.Unmapify(settings, cfg); err != nil {
 		return nil, fmt.Errorf("error parsing config: %v", err)
 	}
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -44,10 +44,10 @@ const (
 var (
 	blockTicker = time.Second
 	walletInfo  = &asset.WalletInfo{
-		ConfigPath: defaultConfigPath,
-		Name:       "Decred",
-		FeeRate:    defaultWithdrawalFee,
-		Units:      "atoms",
+		Name:              "Decred",
+		Units:             "atoms",
+		DefaultConfigPath: defaultConfigPath,
+		DefaultFeeRate:    defaultWithdrawalFee,
 	}
 )
 
@@ -256,7 +256,7 @@ var _ asset.Wallet = (*ExchangeWallet)(nil)
 func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (*ExchangeWallet, error) {
 	// loadConfig will set fields if defaults are used and set the chainParams
 	// package variable.
-	walletCfg, err := loadConfig(cfg.INIPath, network)
+	walletCfg, err := loadConfig(cfg.Settings, network)
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -40,10 +40,11 @@ const (
 	defaultWithdrawalFee = 10
 )
 
-// How often to check the tip hash.
 var (
+	// blockTicker is the delay between calls to check for new blocks.
 	blockTicker = time.Second
-	walletInfo  = &asset.WalletInfo{
+	// walletInfo defines some general information about a Decred wallet.
+	walletInfo = &asset.WalletInfo{
 		Name:              "Decred",
 		Units:             "atoms",
 		DefaultConfigPath: defaultConfigPath,

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1177,7 +1177,7 @@ func testSender(t *testing.T, senderType tSenderType) {
 		// For withdraw, test with unspent total = withdraw value
 		unspentVal = sendVal
 		sender = func(addr string, val uint64) (asset.Coin, error) {
-			return wallet.Withdraw(addr, val, walletInfo.FeeRate)
+			return wallet.Withdraw(addr, val, walletInfo.DefaultFeeRate)
 		}
 	}
 	defer shutdown()

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -26,6 +26,7 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/config"
 	dexdcr "decred.org/dcrdex/dex/dcr"
 	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/slog"
@@ -61,9 +62,14 @@ func tBackend(t *testing.T, name string, blkFunc func(string, error)) (*Exchange
 	if err != nil {
 		t.Fatalf("error getting current user: %v", err)
 	}
+	cfgPath := filepath.Join(user.HomeDir, "dextest", "dcr", name, "w-"+name+".conf")
+	connSettings, err := config.Options(cfgPath)
+	if err != nil {
+		t.Fatalf("error reading config options: %v", err)
+	}
 	walletCfg := &asset.WalletConfig{
-		INIPath: filepath.Join(user.HomeDir, "dextest", "dcr", name, "w-"+name+".conf"),
-		Account: "default",
+		Settings: connSettings,
+		Account:  "default",
 		TipChange: func(err error) {
 			blkFunc(name, err)
 		},

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -80,9 +80,9 @@ func Assets() map[uint32]RegisteredAsset {
 
 // DefaultConfigPath returns the default config path for a registered asset.
 func DefaultConfigPath(assetID uint32) (string, error) {
-	driversMtx.Lock()
+	driversMtx.RLock()
 	drv, ok := drivers[assetID]
-	driversMtx.Unlock()
+	driversMtx.RUnlock()
 	if !ok {
 		return "", fmt.Errorf("asset: unknown asset driver %d", assetID)
 	}

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -77,3 +77,14 @@ func Assets() map[uint32]RegisteredAsset {
 	}
 	return assets
 }
+
+// DefaultConfigPath returns the default config path for a registered asset.
+func DefaultConfigPath(assetID uint32) (string, error) {
+	driversMtx.Lock()
+	drv, ok := drivers[assetID]
+	driversMtx.Unlock()
+	if !ok {
+		return "", fmt.Errorf("asset: unknown asset driver %d", assetID)
+	}
+	return drv.Info().DefaultConfigPath, nil
+}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -21,7 +21,7 @@ type WalletInfo struct {
 	// Units is the unit used for the smallest (integer) denomination of the
 	// currency, in plural form e.g. atoms, Satoshis.
 	Units string `json:"units"`
-	// DefaultConfigPath is the default DefaultConfigPath that the wallet will search for its
+	// DefaultConfigPath is the default file path that the Wallet uses for its
 	// configuration file.
 	DefaultConfigPath string `json:"configpath"`
 	// DefaultFeeRate is the default fee rate used for withdraws.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -16,16 +16,16 @@ const CoinNotFoundError = dex.Error("coin not found")
 
 // WalletInfo is auxiliary information about an ExchangeWallet.
 type WalletInfo struct {
-	// ConfigPath is the default ConfigPath that the wallet will search for its
-	// configuration file.
-	ConfigPath string `json:"configpath"`
 	// Name is the display name for the currency, e.g. "Decred"
 	Name string `json:"name"`
-	// FeeRate is the default fee rate used for withdraws.
-	FeeRate uint64 `json:"feerate"`
 	// Units is the unit used for the smallest (integer) denomination of the
 	// currency, in plural form e.g. atoms, Satoshis.
 	Units string `json:"units"`
+	// DefaultConfigPath is the default DefaultConfigPath that the wallet will search for its
+	// configuration file.
+	DefaultConfigPath string `json:"configpath"`
+	// DefaultFeeRate is the default fee rate used for withdraws.
+	DefaultFeeRate uint64 `json:"feerate"`
 }
 
 // WalletConfig is the configuration settings for the wallet. WalletConfig
@@ -34,8 +34,8 @@ type WalletConfig struct {
 	// Account is the name of the wallet account. The account and wallet must
 	// already exist.
 	Account string
-	// INIPath is the path of a configuration file.
-	INIPath string
+	// Settings is the key-value store of wallet connection parameters.
+	Settings map[string]string
 	// TipChange is a function that will be called when the blockchain monitoring
 	// loop detects a new block. If the error supplied is nil, the client should
 	// check the confirmations on any negotiating swaps to see if action is

--- a/client/cmd/dexc/go.sum
+++ b/client/cmd/dexc/go.sum
@@ -192,6 +192,9 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/go-ini/ini.v1 v1.55.0 h1:IIqJ/Ve0n3e3VPMY8PM2uQLOrBtKeh1vx12NtVIAlJ4=
+gopkg.in/go-ini/ini.v1 v1.55.0/go.mod h1:M74/hG4RTwbkZyTEZ9iQwM4v6dFD4u6QBjoqT/pM8Kg=
+gopkg.in/ini.v1 v1.55.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/client/cmd/dexcctl/go.sum
+++ b/client/cmd/dexcctl/go.sum
@@ -167,6 +167,9 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/go-ini/ini.v1 v1.55.0 h1:IIqJ/Ve0n3e3VPMY8PM2uQLOrBtKeh1vx12NtVIAlJ4=
+gopkg.in/go-ini/ini.v1 v1.55.0/go.mod h1:M74/hG4RTwbkZyTEZ9iQwM4v6dFD4u6QBjoqT/pM8Kg=
+gopkg.in/ini.v1 v1.55.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -538,6 +538,13 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 		return fmt.Errorf("wallet password encryption error: %v", err)
 	}
 
+	if form.INIPath == "" {
+		form.INIPath, err = asset.DefaultConfigPath(assetID)
+		if err != nil {
+			return fmt.Errorf("cannot use default wallet config path: %v", err)
+		}
+	}
+
 	dbWallet := &db.Wallet{
 		AssetID:     assetID,
 		Account:     form.Account,
@@ -601,14 +608,9 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 // wallet. The returned wallet is running but not connected.
 func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 	// todo: wallet config file should be parsed when wallet is being created
-	// and the parsed options save to db. Remember to use the default ini path
-	// if an emtpy path is passed to CreateWallet()
+	// and the parsed options save to db.
 	if dbWallet.INIPath == "" {
-		defaultINIPath, err := asset.DefaultConfigPath(dbWallet.AssetID)
-		if err != nil {
-			return nil, fmt.Errorf("error creating wallet: %v", err)
-		}
-		dbWallet.INIPath = defaultINIPath
+		return nil, fmt.Errorf("wallet config path not set")
 	}
 	walletConnSettings, err := config.Options(dbWallet.INIPath)
 	if err != nil {

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -66,7 +66,7 @@ func (w *xcWallet) state() *WalletState {
 		Running: w.connector.On(),
 		Balance: w.balance,
 		Address: w.address,
-		FeeRate: winfo.FeeRate, // Withdraw fee, not swap.
+		FeeRate: winfo.DefaultFeeRate, // Withdraw fee, not swap.
 		Units:   winfo.Units,
 	}
 }

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -89,7 +89,7 @@ func mkSupportedAsset(symbol string, state *tWalletState, bal uint64) *core.Supp
 			Running: state.running,
 			Address: ordertest.RandomAddress(),
 			Balance: bal,
-			FeeRate: winfos[assetID].FeeRate,
+			FeeRate: winfos[assetID].DefaultFeeRate,
 			Units:   winfos[assetID].Units,
 		}
 	}
@@ -100,8 +100,8 @@ func mkSupportedAsset(symbol string, state *tWalletState, bal uint64) *core.Supp
 		Symbol: symbol,
 		Wallet: wallet,
 		Info: &asset.WalletInfo{
-			Name:       name,
-			ConfigPath: "/home/you/." + lower + "/" + lower + ".conf",
+			Name:              name,
+			DefaultConfigPath: "/home/you/." + lower + "/" + lower + ".conf",
 		},
 	}
 }
@@ -391,34 +391,34 @@ func (c *TCore) AckNotes(ids []dex.Bytes) {}
 
 var winfos = map[uint32]*asset.WalletInfo{
 	0: {
-		FeeRate: 2,
-		Units:   "Satoshis",
-		Name:    "Bitcoin",
+		DefaultFeeRate: 2,
+		Units:          "Satoshis",
+		Name:           "Bitcoin",
 	},
 	2: {
-		FeeRate: 100,
-		Units:   "litoshi", // Plural seemingly has no 's'.
-		Name:    "Litecoin",
+		DefaultFeeRate: 100,
+		Units:          "litoshi", // Plural seemingly has no 's'.
+		Name:           "Litecoin",
 	},
 	42: {
-		FeeRate: 10,
-		Units:   "atoms",
-		Name:    "Decred",
+		DefaultFeeRate: 10,
+		Units:          "atoms",
+		Name:           "Decred",
 	},
 	22: {
-		FeeRate: 50,
-		Units:   "atoms",
-		Name:    "Monacoin",
+		DefaultFeeRate: 50,
+		Units:          "atoms",
+		Name:           "Monacoin",
 	},
 	3: {
-		FeeRate: 1000,
-		Units:   "atoms",
-		Name:    "Dogecoin",
+		DefaultFeeRate: 1000,
+		Units:          "atoms",
+		Name:           "Dogecoin",
 	},
 	28: {
-		FeeRate: 20,
-		Units:   "Satoshis",
-		Name:    "Vertcoin",
+		DefaultFeeRate: 20,
+		Units:          "Satoshis",
+		Name:           "Vertcoin",
 	},
 }
 
@@ -437,7 +437,7 @@ func (c *TCore) WalletState(assetID uint32) *core.WalletState {
 		Running: w.running,
 		Address: ordertest.RandomAddress(),
 		Balance: c.balances[assetID],
-		FeeRate: winfos[assetID].FeeRate,
+		FeeRate: winfos[assetID].DefaultFeeRate,
 		Units:   winfos[assetID].Units,
 	}
 }
@@ -499,7 +499,7 @@ func (c *TCore) Wallets() []*core.WalletState {
 			Running: wallet.running,
 			Address: ordertest.RandomAddress(),
 			Balance: c.balances[assetID],
-			FeeRate: winfos[assetID].FeeRate,
+			FeeRate: winfos[assetID].DefaultFeeRate,
 			Units:   winfos[assetID].Units,
 		})
 	}

--- a/dex/config/config.go
+++ b/dex/config/config.go
@@ -31,17 +31,17 @@ func options(cfgFile *ini.File) map[string]string {
 }
 
 // Unmapify parses config options from the provided settings map into the
-// specified struct object.
+// specified interface.
 func Unmapify(settings map[string]string, obj interface{}) error {
 	cfgData := optionsMapToINIData(settings)
 	return Parse(cfgData, obj)
 }
 
 // Parse parses config options from the provided config file path or []byte
-// data into the specified struct object.
+// data into the specified interface.
 // If the config has section headers, the config options are first read into
-// a map, then converted to []byte before being parsed. Otherwise the struct
-// object would not be modified with any data from the config file.
+// a map, then converted to []byte before being parsed. Otherwise `obj` would
+// not be modified with any data from the config.
 func Parse(cfgPathOrData, obj interface{}) error {
 	cfgFile, err := ini.Load(cfgPathOrData)
 	if err != nil {

--- a/dex/config/config.go
+++ b/dex/config/config.go
@@ -10,15 +10,6 @@ import (
 	"gopkg.in/go-ini/ini.v1"
 )
 
-// OptionsMapToINIData generates a config []byte data from settings.
-func OptionsMapToINIData(options map[string]string) []byte {
-	var buffer bytes.Buffer
-	for key, value := range options {
-		buffer.WriteString(fmt.Sprintf("%s=%s\n", key, value))
-	}
-	return buffer.Bytes()
-}
-
 // Options returns a collection of all key-value options in provided config
 // file path or []byte data.
 func Options(cfgPathOrData interface{}) (map[string]string, error) {
@@ -39,6 +30,13 @@ func options(cfgFile *ini.File) map[string]string {
 	return options
 }
 
+// Unmapify parses config options from the provided settings map into the
+// specified struct object.
+func Unmapify(settings map[string]string, obj interface{}) error {
+	cfgData := optionsMapToINIData(settings)
+	return Parse(cfgData, obj)
+}
+
 // Parse parses config options from the provided config file path or []byte
 // data into the specified struct object.
 // If the config has section headers, the config options are first read into
@@ -55,10 +53,19 @@ func Parse(cfgPathOrData, obj interface{}) error {
 		// config file or data has non-default section headers, remove sections
 		// by extracting all config options and regenerating the config data.
 		cfgOptions := options(cfgFile)
-		cfgPathOrData = OptionsMapToINIData(cfgOptions)
+		cfgPathOrData = optionsMapToINIData(cfgOptions)
 		return Parse(cfgPathOrData, obj)
 	}
 
 	err = cfgFile.MapTo(obj)
 	return err
+}
+
+// optionsMapToINIData generates a config []byte data from settings.
+func optionsMapToINIData(settings map[string]string) []byte {
+	var buffer bytes.Buffer
+	for key, value := range settings {
+		buffer.WriteString(fmt.Sprintf("%s=%s\n", key, value))
+	}
+	return buffer.Bytes()
 }

--- a/dex/config/config.go
+++ b/dex/config/config.go
@@ -1,0 +1,64 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package config
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/go-ini/ini.v1"
+)
+
+// OptionsMapToINIData generates a config []byte data from settings.
+func OptionsMapToINIData(options map[string]string) []byte {
+	var buffer bytes.Buffer
+	for key, value := range options {
+		buffer.WriteString(fmt.Sprintf("%s=%s\n", key, value))
+	}
+	return buffer.Bytes()
+}
+
+// Options returns a collection of all key-value options in provided config
+// file path or []byte data.
+func Options(cfgPathOrData interface{}) (map[string]string, error) {
+	cfgFile, err := ini.Load(cfgPathOrData)
+	if err != nil {
+		return nil, err
+	}
+	return options(cfgFile), nil
+}
+
+func options(cfgFile *ini.File) map[string]string {
+	options := make(map[string]string)
+	for _, section := range cfgFile.Sections() {
+		for _, key := range section.Keys() {
+			options[key.Name()] = key.String()
+		}
+	}
+	return options
+}
+
+// Parse parses config options from the provided config file path or []byte
+// data into the specified struct object.
+// If the config has section headers, the config options are first read into
+// a map, then converted to []byte before being parsed. Otherwise the struct
+// object would not be modified with any data from the config file.
+func Parse(cfgPathOrData, obj interface{}) error {
+	cfgFile, err := ini.Load(cfgPathOrData)
+	if err != nil {
+		return err
+	}
+
+	cfgSections := cfgFile.Sections()
+	if len(cfgSections) > 1 || cfgSections[0].Name() != ini.DefaultSection {
+		// config file or data has non-default section headers, remove sections
+		// by extracting all config options and regenerating the config data.
+		cfgOptions := options(cfgFile)
+		cfgPathOrData = OptionsMapToINIData(cfgOptions)
+		return Parse(cfgPathOrData, obj)
+	}
+
+	err = cfgFile.MapTo(obj)
+	return err
+}

--- a/dex/config/config_test.go
+++ b/dex/config/config_test.go
@@ -229,7 +229,7 @@ func TestMapToINIDataConversion(t *testing.T) {
 		"KEY4": "4.4",
 		"key5": "parsed as option, but not populated into struct",
 	}
-	cfgData := OptionsMapToINIData(m)
+	cfgData := optionsMapToINIData(m)
 
 	opts, err := Options(cfgData)
 	if err != nil {

--- a/dex/config/config_test.go
+++ b/dex/config/config_test.go
@@ -1,0 +1,260 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/ini.v1"
+)
+
+type config struct {
+	Key1 string  `ini:"key1"`
+	Key2 bool    `ini:"key2"`
+	Key3 int     `ini:"key3"`
+	KEY4 float64 // defaults to field name i.e. `ini:"KEY4"`
+	Key5 string  `ini:"-"` // ignored because of '-' ini tag
+}
+
+// defaultConfig returns config with default values.
+func defaultConfig() config {
+	return config{
+		Key1: "default value",
+		Key2: true,
+		Key3: 0,
+		KEY4: 3.142,
+		Key5: "ignored",
+	}
+}
+
+// makeConfig returns a pointer to a config with default values.
+func makeConfigPtr() *config {
+	c := defaultConfig()
+	return &c
+}
+
+// TestConfigParsing tests the Options() and Parse() functions.
+func TestConfigParsing(t *testing.T) {
+	var testConfig = defaultConfig()
+
+	tempDir, err := ioutil.TempDir("", "configtest")
+	if err != nil {
+		t.Fatalf("error creating temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+	cfgFilePath := filepath.Join(tempDir, "test.conf")
+	cfgFile := ini.Empty()
+	err = cfgFile.ReflectFrom(&testConfig)
+	if err != nil {
+		t.Fatalf("error creating temporary config file: %v", err)
+	}
+	err = cfgFile.SaveTo(cfgFilePath)
+	if err != nil {
+		t.Fatalf("error creating temporary config file: %v", err)
+	}
+
+	type expectations struct {
+		optionsError bool
+		optionsCount int
+		parseError   bool
+		parsedCfg    config
+	}
+
+	type test struct {
+		name      string
+		cfgData   interface{}
+		parsedCfg interface{}
+		expect    expectations
+	}
+
+	testCount := 0
+	makeOkTest := func(name, sectionHeader, secondSectionHeader string) test {
+		testCount++
+		value1 := fmt.Sprintf("value %d", testCount)
+		value4 := 1.1 * float64(testCount)
+		cfgDataString := fmt.Sprintf(`
+		%v
+		key1=%v
+		key2=false
+		%v
+		key3=%v
+		KEY4=%v
+		key5=parsed as option, but not populated into struct
+		`, sectionHeader, value1, secondSectionHeader, testCount, value4)
+
+		return test{
+			name:      name,
+			cfgData:   []byte(cfgDataString),
+			parsedCfg: makeConfigPtr(),
+			expect: expectations{
+				optionsError: false,
+				optionsCount: 5,
+				parseError:   false,
+				parsedCfg: config{
+					Key1: value1,
+					Key2: false,
+					Key3: testCount,
+					KEY4: value4,
+					Key5: testConfig.Key5, // should be unchanged
+				},
+			},
+		}
+	}
+
+	// Test Options() function.
+	tests := []test{
+		makeOkTest("ok, with default application options header", "[Application Options]", ""),
+		makeOkTest("ok, with random section header", "[Random Header]", ""),
+		makeOkTest("ok, with random section header", "[Application Options]", "[Random Options]"),
+		makeOkTest("ok, with no section header", "", ""),
+		{
+			name:      "ok, with file path",
+			cfgData:   cfgFilePath,
+			parsedCfg: makeConfigPtr(),
+			expect: expectations{
+				optionsError: false,
+				optionsCount: 4, // file was created from struct with only 4 valid ini fields
+				parseError:   false,
+				parsedCfg:    defaultConfig(),
+			},
+		},
+		{
+			name:      "parse error, file path, parsedCfg obj not pointer",
+			cfgData:   cfgFilePath,
+			parsedCfg: defaultConfig(), // not a pointer
+			expect: expectations{
+				optionsError: false,
+				optionsCount: 4, // file was created from cfg struct with only 4 valid ini fields
+				parseError:   true,
+			},
+		},
+		{
+			name: "parse error, []byte data, parsedCfg obj not pointer",
+			cfgData: []byte(`
+			key1=value 1
+			key2=false
+			key3=10
+			`),
+			parsedCfg: defaultConfig(), // not a pointer
+			expect: expectations{
+				optionsError: false,
+				optionsCount: 3,
+				parseError:   true,
+			},
+		},
+		{
+			name: "error, malformed section header",
+			cfgData: []byte(`
+			[Random Options
+			key1=value 1
+			key2=false
+			key3=10
+			`),
+			parsedCfg: makeConfigPtr(),
+			expect: expectations{
+				optionsError: true,
+				parseError:   true,
+			},
+		},
+		{
+			name: "error, malformed option",
+			cfgData: []byte(`
+			=value 1
+			key2=false
+			key3=10
+			`),
+			parsedCfg: makeConfigPtr(),
+			expect: expectations{
+				optionsError: true,
+				parseError:   true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		parsedOptions, err := Options(tt.cfgData)
+		if tt.expect.optionsError && err == nil {
+			t.Fatalf("%s: expected Options() error but got no error", tt.name)
+		} else if !tt.expect.optionsError && err != nil {
+			t.Fatalf("%s: got unexpected Options() error: %v", tt.name, err)
+		}
+		if len(parsedOptions) != tt.expect.optionsCount {
+			t.Fatalf("%s: expected %d options, got %d", tt.name, tt.expect.optionsCount, len(parsedOptions))
+		}
+
+		err = Parse(tt.cfgData, tt.parsedCfg)
+		if tt.expect.parseError && err != nil {
+			return
+		}
+		if tt.expect.parseError && err == nil {
+			t.Fatalf("%s: expected Parse() error but got no error", tt.name)
+		} else if !tt.expect.parseError && err != nil {
+			t.Fatalf("%s: got unexpected Parse() error: %v", tt.name, err)
+		}
+
+		parsedCfg, ok := tt.parsedCfg.(*config)
+		if !ok {
+			t.Fatalf("%s: unexpected type for parsed config", tt.name)
+		}
+		if parsedCfg.Key1 != tt.expect.parsedCfg.Key1 {
+			t.Fatalf("%s: expected parsed cfg key1 to have '%v', got '%v'", tt.name, tt.expect.parsedCfg.Key1,
+				parsedCfg.Key1)
+		}
+		if parsedCfg.Key2 != tt.expect.parsedCfg.Key2 {
+			t.Fatalf("%s: expected parsed cfg key2 to have '%v', got '%v'", tt.name, tt.expect.parsedCfg.Key2,
+				parsedCfg.Key2)
+		}
+		if parsedCfg.Key3 != tt.expect.parsedCfg.Key3 {
+			t.Fatalf("%s: expected parsed cfg key3 to have '%v', got '%v'", tt.name, tt.expect.parsedCfg.Key3,
+				parsedCfg.Key3)
+		}
+		if parsedCfg.KEY4 != tt.expect.parsedCfg.KEY4 {
+			t.Fatalf("%s: expected parsed cfg key4 to have '%v', got '%v'", tt.name, tt.expect.parsedCfg.KEY4,
+				parsedCfg.KEY4)
+		}
+		if parsedCfg.Key5 != tt.expect.parsedCfg.Key5 {
+			t.Fatalf("%s: expected parsed cfg key5 to have '%v', got '%v'", tt.name, tt.expect.parsedCfg.Key5,
+				parsedCfg.Key3)
+		}
+	}
+}
+
+// Test OptionsMapToINIData()
+func TestMapToINIDataConversion(t *testing.T) {
+	m := map[string]string{
+		"key1": "value1",
+		"key2": "false",
+		"key3": "3",
+		"KEY4": "4.4",
+		"key5": "parsed as option, but not populated into struct",
+	}
+	cfgData := OptionsMapToINIData(m)
+
+	opts, err := Options(cfgData)
+	if err != nil {
+		t.Fatalf("unexpected error when extracting options from cfg data generated from map: %v", err)
+	}
+	if len(opts) != len(m) {
+		t.Fatalf("map-cfg-map: expected %d options, got %d", len(m), len(opts))
+	}
+	for k, vOriginal := range m {
+		if vExtracted, ok := opts[k]; !ok {
+			t.Fatalf("map-cfg-map: key '%s' not found in extracted options", k)
+		} else if vExtracted != vOriginal {
+			t.Fatalf("map-cfg-map: unexpected value for key '%s', expected '%s', got '%s'", k, vOriginal, vExtracted)
+		}
+	}
+
+	var cfg = makeConfigPtr()
+	err = Parse(cfgData, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error when parsing cfg data generated from map into obj: %v", err)
+	}
+	if cfg.Key1 != m["key1"] {
+		t.Fatalf("map-cfg-obh: unexpected value for key 'key1', expected '%s', got '%s'", m["key1"], cfg.Key1)
+	}
+	if cfg.Key5 != defaultConfig().Key5 {
+		t.Fatalf("map-cfg-obh: expected value for key 'key5' not to change, changed to '%s'", cfg.Key5)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	github.com/ltcsuite/ltcd v0.0.0-20190519120615-e27ee083f08f
 	go.etcd.io/bbolt v1.3.4
 	golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c
+	gopkg.in/go-ini/ini.v1 v1.55.0
+	gopkg.in/ini.v1 v1.55.0
 )
 
 replace github.com/ltcsuite/ltcutil => github.com/ltcsuite/ltcutil v0.0.0-20190507133322-23cdfa9fcc3d

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,10 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/go-ini/ini.v1 v1.55.0 h1:IIqJ/Ve0n3e3VPMY8PM2uQLOrBtKeh1vx12NtVIAlJ4=
+gopkg.in/go-ini/ini.v1 v1.55.0/go.mod h1:M74/hG4RTwbkZyTEZ9iQwM4v6dFD4u6QBjoqT/pM8Kg=
+gopkg.in/ini.v1 v1.55.0 h1:E8yzL5unfpW3M6fz/eB7Cb5MQAYSZ7GKo4Qth+N2sgQ=
+gopkg.in/ini.v1 v1.55.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -131,7 +131,7 @@ func NewBTCClone(name, configPath string, logger dex.Logger, network dex.Network
 	params *chaincfg.Params, ports dexbtc.NetPorts) (*Backend, error) {
 
 	// Read the configuration parameters
-	cfg, err := dexbtc.LoadConfig(configPath, name, network, ports)
+	cfg, err := dexbtc.LoadConfigFromPath(configPath, name, network, ports)
 	if err != nil {
 		return nil, err
 	}

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/decred/slog"
-	flags "github.com/jessevdk/go-flags"
+	"gopkg.in/ini.v1"
 )
 
 var (
@@ -61,16 +61,19 @@ func TestConfig(t *testing.T) {
 	}
 	defer os.RemoveAll(tempDir)
 	filePath := filepath.Join(tempDir, "test.conf")
-	rootParser := flags.NewParser(cfg, flags.None)
-	iniParser := flags.NewIniParser(rootParser)
 
 	runCfg := func(config *dexbtc.Config) error {
 		*cfg = *config
-		err := iniParser.WriteFile(filePath, flags.IniNone)
+		cfgFile := ini.Empty()
+		err := cfgFile.ReflectFrom(cfg)
 		if err != nil {
 			return err
 		}
-		parsedCfg, err = dexbtc.LoadConfig(filePath, assetName, dex.Mainnet, dexbtc.RPCPorts)
+		err = cfgFile.SaveTo(filePath)
+		if err != nil {
+			return err
+		}
+		parsedCfg, err = dexbtc.LoadConfigFromPath(filePath, assetName, dex.Mainnet, dexbtc.RPCPorts)
 		return err
 	}
 

--- a/server/cmd/dcrdex/go.sum
+++ b/server/cmd/dcrdex/go.sum
@@ -175,6 +175,9 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/go-ini/ini.v1 v1.55.0 h1:IIqJ/Ve0n3e3VPMY8PM2uQLOrBtKeh1vx12NtVIAlJ4=
+gopkg.in/go-ini/ini.v1 v1.55.0/go.mod h1:M74/hG4RTwbkZyTEZ9iQwM4v6dFD4u6QBjoqT/pM8Kg=
+gopkg.in/ini.v1 v1.55.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Resolves step 1 of https://github.com/decred/dcrdex/issues/292#issuecomment-619540709.

add config.Options() function to read key-value options from a config file or []byte data.
add config.Parse() function to populate a struct pointer with options parsed from a config file or []byte data.

config.Options() is called from `client/core.loadWallet` to read wallet connection settings from a config file path. Usage should ultimately move to `core.CreateWallet` so that the settings would be saved to db along with other wallet info.

config.Parse() is used by `client/asset/dcr` to read wallet connection settings into a DCRConfig object; and by `dex/btc` to read wallet connection (client) or backend connection (server) settings into a btc.Config object.