### PR TITLE
pg,market: load book orders from DB on Market construction

### DIFF
--- a/server/db/driver/pg/internal/orders.go
+++ b/server/db/driver/pg/internal/orders.go
@@ -43,6 +43,10 @@ const (
 		commit, coins, quantity, rate, force, status, filled
 	FROM %s WHERE oid = $1;`
 
+	SelectOrdersByStatus = `SELECT oid, type, sell, account_id, address, client_time, server_time,
+		commit, coins, quantity, rate, force, filled
+	FROM %s WHERE status = $1;`
+
 	// SelectUserOrders retrieves all columns of all orders for the given
 	// account ID.
 	SelectUserOrders = `SELECT oid, type, sell, account_id, address, client_time, server_time,
@@ -68,11 +72,9 @@ const (
 	SelectOrderPreimage = `SELECT preimage FROM %s WHERE oid = $1;`
 
 	// SelectOrderCoinIDs retrieves the order id, sell flag, and coins for all
-	// orders in a table with one of the given statuses. Note that this includes
-	// all order statuses.
+	// orders in a certain table.
 	SelectOrderCoinIDs = `SELECT oid, sell, coins
-		FROM %s
-		WHERE type = ANY($1);`
+		FROM %s;`
 
 	SetOrderPreimage     = `UPDATE %s SET preimage = $1 WHERE oid = $2;`
 	SetOrderCompleteTime = `UPDATE %s SET complete_time = $1

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -19,7 +19,6 @@ import (
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/db/driver/pg/internal"
-	"github.com/lib/pq"
 )
 
 // Wrap the CoinID slice to implement custom Scanner and Valuer.
@@ -189,6 +188,39 @@ func (a *Archiver) NewEpochOrder(ord order.Order, epochIdx, epochDur int64) erro
 	return a.storeOrder(ord, epochIdx, epochDur, orderStatusEpoch)
 }
 
+// BookOrders retrieves all booked orders (with order status booked) for the
+// specified market. This will be used to repopulate a market's book on
+// construction of the market.
+func (a *Archiver) BookOrders(base, quote uint32) ([]*order.LimitOrder, error) {
+	marketSchema, err := a.marketSchema(base, quote)
+	if err != nil {
+		return nil, err
+	}
+
+	// All booked orders are active.
+	tableName := fullOrderTableName(a.dbName, marketSchema, true) // active (true)
+
+	// no query timeout here, only explicit cancellation
+	ords, err := ordersByStatusFromTable(a.ctx, a.db, tableName, base, quote, orderStatusBooked)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify loaded orders are limits, and cast to *LimitOrder.
+	limits := make([]*order.LimitOrder, len(ords))
+	for _, ord := range ords {
+		lo, ok := ord.(*order.LimitOrder)
+		if !ok {
+			log.Errorf("loaded book order %v that was not a limit order", ord.ID())
+			continue
+		}
+
+		limits = append(limits, lo)
+	}
+
+	return limits, nil
+}
+
 // ActiveOrderCoins retrieves a CoinID slice for each active order.
 func (a *Archiver) ActiveOrderCoins(base, quote uint32) (baseCoins, quoteCoins map[order.OrderID][]order.CoinID, err error) {
 	var marketSchema string
@@ -200,13 +232,8 @@ func (a *Archiver) ActiveOrderCoins(base, quote uint32) (baseCoins, quoteCoins m
 	tableName := fullOrderTableName(a.dbName, marketSchema, true) // active (true)
 	stmt := fmt.Sprintf(internal.SelectOrderCoinIDs, tableName)
 
-	orderTypes := []int64{
-		int64(order.MarketOrderType),
-		int64(order.LimitOrderType),
-	} // i.e. NOT cancel
-
 	var rows *sql.Rows
-	rows, err = a.db.Query(stmt, pq.Int64Array(orderTypes))
+	rows, err = a.db.Query(stmt)
 	switch err {
 	case sql.ErrNoRows:
 		err = nil
@@ -1074,6 +1101,63 @@ func (a *Archiver) userOrders(ctx context.Context, base, quote uint32, aid accou
 	statuses = append(statuses, statusesArchived...)
 
 	return orders, statuses, nil
+}
+
+// base and quote are used to set the prefix, not specify which table to search.
+// NOTE: There is considerable overlap with userOrdersFromTable, but a
+// generalized function is likely to hurt readability and simplicity.
+func ordersByStatusFromTable(ctx context.Context, dbe *sql.DB, fullTable string, base, quote uint32, status pgOrderStatus) ([]order.Order, error) {
+	stmt := fmt.Sprintf(internal.SelectOrdersByStatus, fullTable)
+	rows, err := dbe.QueryContext(ctx, stmt, status)
+	if err != nil {
+		return nil, err
+	}
+
+	var orders []order.Order
+
+	for rows.Next() {
+		var prefix order.Prefix
+		var trade order.Trade
+		var id order.OrderID
+		var tif order.TimeInForce
+		var rate uint64
+		err = rows.Scan(&id, &prefix.OrderType, &trade.Sell,
+			&prefix.AccountID, &trade.Address, &prefix.ClientTime, &prefix.ServerTime,
+			&prefix.Commit, (*dbCoins)(&trade.Coins),
+			&trade.Quantity, &rate, &tif, &trade.FillAmt)
+		if err != nil {
+			return nil, err
+		}
+		prefix.BaseAsset, prefix.QuoteAsset = base, quote
+
+		var ord order.Order
+		switch prefix.OrderType {
+		case order.LimitOrderType:
+			ord = &order.LimitOrder{
+				P:     prefix,
+				T:     *trade.Copy(),
+				Rate:  rate,
+				Force: tif,
+			}
+		case order.MarketOrderType:
+			ord = &order.MarketOrder{
+				P: prefix,
+				T: *trade.Copy(),
+			}
+		default:
+			log.Errorf("ordersByStatusFromTable: encountered unexpected order type %v",
+				prefix.OrderType)
+			continue
+		}
+
+		orders = append(orders, ord)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return orders, nil
 }
 
 // base and quote are used to set the prefix, not specify which table to search.

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -207,7 +207,7 @@ func (a *Archiver) BookOrders(base, quote uint32) ([]*order.LimitOrder, error) {
 	}
 
 	// Verify loaded orders are limits, and cast to *LimitOrder.
-	limits := make([]*order.LimitOrder, len(ords))
+	limits := make([]*order.LimitOrder, 0, len(ords))
 	for _, ord := range ords {
 		lo, ok := ord.(*order.LimitOrder)
 		if !ok {

--- a/server/db/driver/pg/orders_online_test.go
+++ b/server/db/driver/pg/orders_online_test.go
@@ -568,6 +568,7 @@ func TestOrderStatusUnknown(t *testing.T) {
 	}
 }
 
+// Test both ActiveOrderCoins and BookOrders.
 func TestActiveOrderCoins(t *testing.T) {
 	if err := cleanTables(archie.db); err != nil {
 		t.Fatalf("cleanTables: %v", err)
@@ -657,6 +658,24 @@ func TestActiveOrderCoins(t *testing.T) {
 			}
 		}
 	}
+
+	bookOrders, err := archie.BookOrders(mktInfo.Base, mktInfo.Quote)
+	if err != nil {
+		t.Fatalf("BookOrders failed: %v", err)
+	}
+
+	if len(bookOrders) != 1 {
+		t.Fatalf("got %d book orders, expected 1", len(bookOrders))
+	}
+
+	// Verify the order ID of the loaded order is correct. This ensures the
+	// order is being loaded with all the fields to provide and identical
+	// serialization.
+	if multiCoinLO.ID() != bookOrders[0].ID() {
+		t.Errorf("loaded book order has an incorrect order ID. Got %v, expected %v",
+			bookOrders[0].ID(), multiCoinLO.ID())
+	}
+
 }
 
 func TestOrderStatus(t *testing.T) {

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -79,6 +79,9 @@ type OrderArchiver interface {
 	// specified by the given base and quote assets.
 	Order(oid order.OrderID, base, quote uint32) (order.Order, order.OrderStatus, error)
 
+	// BookOrders returns all book orders for a market.
+	BookOrders(base, quote uint32) ([]*order.LimitOrder, error)
+
 	// ActiveOrderCoins retrieves a CoinID slice for each active order.
 	ActiveOrderCoins(base, quote uint32) (baseCoins, quoteCoins map[order.OrderID][]order.CoinID, err error)
 

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -137,6 +137,8 @@ func NewMarket(mktInfo *dex.MarketInfo, storage db.DEXArchivist, swapper Swapper
 		return nil, err
 	}
 
+	log.Infof("Loaded %d stored book orders.", len(bookOrders))
+
 	Book := book.New(mktInfo.LotSize)
 	for _, lo := range bookOrders {
 		if ok := Book.Insert(lo); !ok {


### PR DESCRIPTION
pg: load book orders from DB

Add `BookOrders` to `db.OrderArchiver`.

Simplify `(*Archiver).ActiveOrderCoins` by removing the order type query
constraint since cancel orders already live in a separate table.

pg/internal: Add `SelectOrdersByStatus` query. Remove type constraint from
`SelectOrderCoinIDs` query since cancel orders are in separate table.

market: In `NewMarket` use `OrderArchiver.BookOrders` to get the book orders, followed by `book.Insert` to populate the book.