### PR TITLE
pg: cancel order matches are inactive

### DIFF
--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -221,7 +221,8 @@ func (t *trackedTrade) readConnectMatches(msgMatches []*msgjson.Match) {
 
 	url := t.dc.acct.url
 	if len(missing) > 0 {
-		details := fmt.Sprintf("%d matches for order %s were not reported by %s and are in a failed state", missing, t.ID(), t.dc.acct.url)
+		details := fmt.Sprintf("%d matches for order %s were not reported by %q and are in a failed state",
+			len(missing), t.ID(), t.dc.acct.url)
 		corder, _ := t.coreOrder()
 		t.notify(newOrderNote("Missing matches", details, db.ErrorLevel, corder))
 		for _, mid := range missing {

--- a/server/db/driver/pg/matches.go
+++ b/server/db/driver/pg/matches.go
@@ -151,8 +151,8 @@ func upsertMatch(dbe sqlExecutor, tableName string, match *order.Match) (int64, 
 		takerAddr = tt.SwapAddress()
 	}
 
-	// Cancel orders do not store taker address, and stored with complete status
-	// with no active swap negotiation.
+	// Cancel orders do not store taker or maker addresses, and are stored with
+	// complete status with no active swap negotiation.
 	if takerAddr == "" {
 		stmt := fmt.Sprintf(internal.UpsertCancelMatch, tableName)
 		return sqlExec(dbe, stmt, match.ID(),

--- a/server/db/driver/pg/matches.go
+++ b/server/db/driver/pg/matches.go
@@ -47,14 +47,17 @@ func userMatches(ctx context.Context, dbe *sql.DB, tableName string, aid account
 	for rows.Next() {
 		var m db.MatchData
 		var status uint8
+		var takerAddr, makerAddr sql.NullString
 		err := rows.Scan(&m.ID, &m.Active,
-			&m.Taker, &m.TakerAcct, &m.TakerAddr,
-			&m.Maker, &m.MakerAcct, &m.MakerAddr,
+			&m.Taker, &m.TakerAcct, &takerAddr,
+			&m.Maker, &m.MakerAcct, &makerAddr,
 			&m.Epoch.Idx, &m.Epoch.Dur, &m.Quantity, &m.Rate, &status)
 		if err != nil {
 			return nil, err
 		}
 		m.Status = order.MatchStatus(status)
+		m.TakerAddr = takerAddr.String
+		m.MakerAddr = makerAddr.String
 		ms = append(ms, &m)
 	}
 
@@ -94,40 +97,41 @@ func activeUserMatches(ctx context.Context, dbe *sql.DB, tableName string, aid a
 
 	var ms []*order.UserMatch
 	for rows.Next() {
-		var m db.MatchData
+		var md db.MatchData
 		var status uint8
-		err := rows.Scan(&m.ID, &m.Taker, &m.TakerAcct, &m.TakerAddr,
-			&m.Maker, &m.MakerAcct, &m.MakerAddr,
-			&m.Epoch.Idx, &m.Epoch.Dur, &m.Quantity, &m.Rate, &status)
+		var takerAddr, makerAddr sql.NullString
+		err := rows.Scan(&md.ID, &md.Taker, &md.TakerAcct, &takerAddr,
+			&md.Maker, &md.MakerAcct, &makerAddr,
+			&md.Epoch.Idx, &md.Epoch.Dur, &md.Quantity, &md.Rate, &status)
 		if err != nil {
 			return nil, err
 		}
-		m.Status = order.MatchStatus(status)
+		md.Status = order.MatchStatus(status)
 
 		var addr string
 		var oid order.OrderID
 		var side order.MatchSide
 		switch aid {
-		case m.TakerAcct:
-			addr = m.TakerAddr
-			oid = m.Taker
+		case md.TakerAcct:
+			addr = takerAddr.String
+			oid = md.Taker
 			side = order.Taker
-		case m.MakerAcct:
-			addr = m.MakerAddr
-			oid = m.Maker
+		case md.MakerAcct:
+			addr = makerAddr.String
+			oid = md.Maker
 			side = order.Maker
 		default:
-			return nil, fmt.Errorf("loaded match %v not belonging to user %v", m.ID, aid)
+			return nil, fmt.Errorf("loaded match %v not belonging to user %v", md.ID, aid)
 		}
 
 		um := &order.UserMatch{
 			OrderID:  oid,
-			MatchID:  m.ID,
-			Quantity: m.Quantity,
-			Rate:     m.Rate,
+			MatchID:  md.ID,
+			Quantity: md.Quantity,
+			Rate:     md.Rate,
 			Address:  addr,
 			Side:     side,
-			Status:   m.Status,
+			Status:   md.Status,
 		}
 
 		ms = append(ms, um)
@@ -146,6 +150,19 @@ func upsertMatch(dbe sqlExecutor, tableName string, match *order.Match) (int64, 
 	if tt != nil {
 		takerAddr = tt.SwapAddress()
 	}
+
+	// Cancel orders do not store taker address, and stored with complete status
+	// with no active swap negotiation.
+	if takerAddr == "" {
+		stmt := fmt.Sprintf(internal.UpsertCancelMatch, tableName)
+		return sqlExec(dbe, stmt, match.ID(),
+			match.Taker.ID(), match.Taker.User(), // taker address remains unset/default
+			match.Maker.ID(), match.Maker.User(), // as does maker's since it is not used
+			match.Epoch.Idx, match.Epoch.Dur,
+			int64(match.Quantity), int64(match.Rate), // quantity and rate may be useful for cancel statistics however
+			int8(order.MatchComplete)) // status is complete
+	}
+
 	stmt := fmt.Sprintf(internal.UpsertMatch, tableName)
 	return sqlExec(dbe, stmt, match.ID(),
 		match.Taker.ID(), match.Taker.User(), takerAddr,
@@ -189,15 +206,18 @@ func (a *Archiver) MatchByID(mid order.MatchID, base, quote uint32) (*db.MatchDa
 func matchByID(dbe *sql.DB, tableName string, mid order.MatchID) (*db.MatchData, error) {
 	var m db.MatchData
 	var status uint8
+	var takerAddr, makerAddr sql.NullString
 	stmt := fmt.Sprintf(internal.RetrieveMatchByID, tableName)
 	err := dbe.QueryRow(stmt, mid).
 		Scan(&m.ID, &m.Active,
-			&m.Taker, &m.TakerAcct, &m.TakerAddr,
-			&m.Maker, &m.MakerAcct, &m.MakerAddr,
+			&m.Taker, &m.TakerAcct, &takerAddr,
+			&m.Maker, &m.MakerAcct, &makerAddr,
 			&m.Epoch.Idx, &m.Epoch.Dur, &m.Quantity, &m.Rate, &status)
 	if err != nil {
 		return nil, err
 	}
+	m.TakerAddr = takerAddr.String
+	m.MakerAddr = makerAddr.String
 	m.Status = order.MatchStatus(status)
 	return &m, nil
 }

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1765,6 +1765,10 @@ func (s *Swapper) Negotiate(matchSets []*order.MatchSet, offBook map[order.Order
 	// let the others proceed, but that could seem selective trickery to the
 	// clients.
 	for _, match := range matches {
+		// Note that matches where the taker order is a cancel will be stored
+		// with status MatchComplete, and without the maker swap address. The
+		// match will also be flagged as inactive since there is no associated
+		// swap negotiation.
 		if err := s.storage.InsertMatch(match.Match); err != nil {
 			log.Errorf("InsertMatch (match id=%v) failed: %v", match.ID(), err)
 			// TODO: notify clients (notification or response to what?)


### PR DESCRIPTION
When storing a match where the taker is a cancel order, store with
status `MatchComplete`, and without the maker swap address. The match
will also be flagged as inactive since there is no associated swap
negotiation.  `ActiveMatches` can now never return such a match with
a taker cancel order.

`InsertMatch` now identifies cancel orders for this handling by the taker's
order.  If the `order.Match.Taker` has a `nil` `*Trade`, the match is inserted
with the handling described above.

Internally, this allows both maker and taker addresses to remain `NULL` in
the matches table.  Scan code is modified to use `sql.NullString`.

This pertains to issue https://github.com/decred/dcrdex/issues/317#issuecomment-621967218, and resolves the "Missing matches" notification for cancel orders matches erroneously returned by the server in the `'connect'` response, although only for cancel orders made while using this PR.  To fix matches for cancel orders:

```sql
UPDATE dcr_btc.matches SET active=FALSE, makeraddress=NULL, takeraddress=NULL, status=4;
```