### PR TITLE
client/core: prevent init of already initialized app

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -315,6 +315,10 @@ func (tdb *TDB) Store(k string, b []byte) error {
 	return tdb.storeErr
 }
 
+func (tdb *TDB) ValueExists(k string) (bool, error) {
+	return false, nil
+}
+
 func (tdb *TDB) Get(k string) ([]byte, error) {
 	if k == keyParamsKey {
 		return nil, tdb.encKeyErr

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -118,13 +118,12 @@ func (db *boltDB) Store(k string, v []byte) error {
 // bucket at the specified key.
 func (db *boltDB) ValueExists(k string) (bool, error) {
 	var exists bool
-	keyB := []byte(k)
 	return exists, db.View(func(tx *bbolt.Tx) error {
 		bucket := tx.Bucket(appBucket)
 		if bucket == nil {
 			return fmt.Errorf("app bucket not found")
 		}
-		exists = bucket.Get(keyB) != nil
+		exists = bucket.Get([]byte(k)) != nil
 		return nil
 	})
 }

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -99,7 +99,7 @@ func (db *boltDB) Run(ctx context.Context) {
 	db.Close()
 }
 
-// Store stores a value at the specified key in a general-use bucket.
+// Store stores a value at the specified key in the general-use bucket.
 func (db *boltDB) Store(k string, v []byte) error {
 	if len(k) == 0 {
 		return fmt.Errorf("cannot store with empty key")
@@ -111,6 +111,21 @@ func (db *boltDB) Store(k string, v []byte) error {
 			return fmt.Errorf("failed to create key bucket")
 		}
 		return bucket.Put(keyB, v)
+	})
+}
+
+// ValueExists checks if a value was previously stored in the general-use
+// bucket at the specified key.
+func (db *boltDB) ValueExists(k string) (bool, error) {
+	var exists bool
+	keyB := []byte(k)
+	return exists, db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket(appBucket)
+		if bucket == nil {
+			return fmt.Errorf("app bucket not found")
+		}
+		exists = bucket.Get(keyB) != nil
+		return nil
 	})
 }
 

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -87,9 +87,12 @@ func TestStore(t *testing.T) {
 	k := "some random key"
 	boltdb := newTestDB(t)
 	// Check no key
-	_, err := boltdb.Get(k)
-	if err == nil {
-		t.Fatalf("no error for missing key")
+	exists, err := boltdb.ValueExists(k)
+	if err != nil {
+		t.Fatalf("error checking if value exists for key: %v", err)
+	}
+	if exists {
+		t.Fatalf("value exists for missing key")
 	}
 	v := randBytes(50)
 	err = boltdb.Store(k, v)

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -99,6 +99,15 @@ func TestStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error storing value: %v", err)
 	}
+	// Confirm value exists for key
+	exists, err = boltdb.ValueExists(k)
+	if err != nil {
+		t.Fatalf("error checking if value exists for key: %v", err)
+	}
+	if !exists {
+		t.Fatalf("no value found for stored key")
+	}
+	// Confirm db value for key matches what was stored.
 	reV, err := boltdb.Get(k)
 	if err != nil {
 		t.Fatalf("error storing value: %v", err)

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -16,6 +16,8 @@ type DB interface {
 	Store(string, []byte) error
 	// Get retrieves values stored with Store.
 	Get(string) ([]byte, error)
+	// ValueExists checks if a value was previously stored.
+	ValueExists(k string) (bool, error)
 	// ListAccounts returns a list of DEX URLs. The DB is designed to have a
 	// single account per DEX, so the account is uniquely identified by the DEX
 	// URL.


### PR DESCRIPTION
Resolves #318 by checking if the app-wide encryption key is already set whenever `core.Initialize` is called.
The app-wide encryption key is derived and stored if it doesn't already exist, otherwise an error is returned.