### PR TITLE
core: fix cancel order and match status updating

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -932,7 +932,7 @@ func (c *Core) Register(form *RegisterForm) error {
 	// Set up the coin waiter.
 	trigger := confTrigger(wallet, coin.ID(), dc.cfg.RegFeeConfirms)
 	c.wait(assetID, trigger, func(err error) {
-		log.Debugf("Registration fee txn %x now has %d confirmations.", coin.ID(), dc.cfg.RegFeeConfirms)
+		log.Debugf("Registration fee txn %s now has %d confirmations.", coinIDString(assetID, coin.ID()), dc.cfg.RegFeeConfirms)
 		defer func() {
 			if err != nil {
 				details := fmt.Sprintf("Error encountered while paying fees to %s: %v", dc.acct.url, err)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -283,6 +283,10 @@ func (tdb *TDB) SetChangeCoin(order.OrderID, order.CoinID) error {
 	return nil
 }
 
+func (tdb *TDB) UpdateOrderStatus(oid order.OrderID, status order.OrderStatus) error {
+	return nil
+}
+
 func (tdb *TDB) UpdateMatch(m *db.MetaMatch) error {
 	return nil
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -385,3 +385,15 @@ func token(id []byte) string {
 	}
 	return hex.EncodeToString(id[:4])
 }
+
+// coinIDString converts a coin ID to a human-readable string. If an error is
+// encountered, the error is logged at Warning level, and the value
+// "<invalid coin>" is returned.
+func coinIDString(assetID uint32, coinID []byte) string {
+	coinStr, err := asset.DecodeCoinID(assetID, coinID)
+	if err != nil {
+		log.Warnf("invalid coin ID %x for asset %d -> %s: %v", coinID, assetID, unbip(assetID), err)
+		return "<invalid coin>"
+	}
+	return coinStr
+}

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -456,11 +456,22 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 // chained for matches, so only the last change coin needs to be saved.
 func (db *boltDB) SetChangeCoin(oid order.OrderID, changeCoin order.CoinID) error {
 	return db.ordersUpdate(func(master *bbolt.Bucket) error {
-		oBkt, err := master.CreateBucketIfNotExists(oid[:])
-		if err != nil {
-			return err
+		oBkt := master.Bucket(oid[:])
+		if oBkt == nil {
+			return fmt.Errorf("SetChangeCoin - order %s not found", oid)
 		}
 		return oBkt.Put(changeKey, changeCoin)
+	})
+}
+
+// UpdateOrderStatus sets the order status for an order.
+func (db *boltDB) UpdateOrderStatus(oid order.OrderID, status order.OrderStatus) error {
+	return db.ordersUpdate(func(master *bbolt.Bucket) error {
+		oBkt := master.Bucket(oid[:])
+		if oBkt == nil {
+			return fmt.Errorf("UpdateOrderStatus - order %s not found", oid)
+		}
+		return oBkt.Put(statusKey, uint16Bytes(uint16(status)))
 	})
 }
 

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -501,6 +501,37 @@ func TestOrders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error after order fixed: %v", err)
 	}
+
+	// Set the change coin for an order.
+	activeOrder := activeOrders[0].Order
+	err = boltdb.UpdateOrderStatus(activeOrder.ID(), order.OrderStatusExecuted)
+	if err != nil {
+		t.Fatalf("error setting order status: %v", err)
+	}
+	mord, _ = boltdb.Order(activeOrder.ID())
+	if mord.MetaData.Status != order.OrderStatusExecuted {
+		t.Fatalf("failed to update order status")
+	}
+	// random id should be an error
+	err = boltdb.UpdateOrderStatus(ordertest.RandomOrderID(), order.OrderStatusExecuted)
+	if err == nil {
+		t.Fatalf("no error encountered for updating unknown order's status")
+	}
+
+	// Set the change coin.
+	err = boltdb.SetChangeCoin(activeOrder.ID(), []byte("abc"))
+	if err != nil {
+		t.Fatalf("error setting change coin: %v", err)
+	}
+	mord, _ = boltdb.Order(activeOrder.ID())
+	if string(mord.MetaData.ChangeCoin) != "abc" {
+		t.Fatalf("failed to set change coin")
+	}
+	// random id should be an error
+	err = boltdb.SetChangeCoin(ordertest.RandomOrderID(), []byte("abc"))
+	if err == nil {
+		t.Fatalf("no error encountered for updating unknown order change coin")
+	}
 }
 
 func TestMatches(t *testing.T) {

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -59,7 +59,7 @@ type DB interface {
 	MarketOrders(dex string, base, quote uint32, n int, since uint64) ([]*MetaOrder, error)
 	// SetChangeCoin stores the change coin for the order.
 	SetChangeCoin(order.OrderID, order.CoinID) error
-	// SetChangeCoin sets the order status for an order.
+	// UpdateOrderStatus sets the order status for an order.
 	UpdateOrderStatus(oid order.OrderID, status order.OrderStatus) error
 	// UpdateMatch updates the match information in the database. Any existing
 	// entry for the match will be overwritten without indication.

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -59,6 +59,8 @@ type DB interface {
 	MarketOrders(dex string, base, quote uint32, n int, since uint64) ([]*MetaOrder, error)
 	// SetChangeCoin stores the change coin for the order.
 	SetChangeCoin(order.OrderID, order.CoinID) error
+	// SetChangeCoin sets the order status for an order.
+	UpdateOrderStatus(oid order.OrderID, status order.OrderStatus) error
 	// UpdateMatch updates the match information in the database. Any existing
 	// entry for the match will be overwritten without indication.
 	UpdateMatch(m *MetaMatch) error


### PR DESCRIPTION
Adds a `DB` method `UpdateOrderStatus`. Updates the order status for both orders in `(*Core).negotiate`. 