### PR TITLE
client/core: move cfg parsing to CreateWallet and save parsed cfg to db

### DIFF
--- a/client/asset/btc/regnet_test.go
+++ b/client/asset/btc/regnet_test.go
@@ -67,12 +67,12 @@ func tBackend(t *testing.T, conf, name string, blkFunc func(string, error)) (*Ex
 		t.Fatalf("error getting current user: %v", err)
 	}
 	cfgPath := filepath.Join(user.HomeDir, "dextest", "btc", "harness-ctl", conf+".conf")
-	connSettings, err := config.Options(cfgPath)
+	settings, err := config.Parse(cfgPath)
 	if err != nil {
 		t.Fatalf("error reading config options: %v", err)
 	}
 	walletCfg := &asset.WalletConfig{
-		Settings: connSettings,
+		Settings: settings,
 		Account:  name,
 		TipChange: func(err error) {
 			blkFunc(conf, err)

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -63,12 +63,12 @@ func tBackend(t *testing.T, name string, blkFunc func(string, error)) (*Exchange
 		t.Fatalf("error getting current user: %v", err)
 	}
 	cfgPath := filepath.Join(user.HomeDir, "dextest", "dcr", name, "w-"+name+".conf")
-	connSettings, err := config.Options(cfgPath)
+	settings, err := config.Parse(cfgPath)
 	if err != nil {
 		t.Fatalf("error reading config options: %v", err)
 	}
 	walletCfg := &asset.WalletConfig{
-		Settings: connSettings,
+		Settings: settings,
 		Account:  "default",
 		TipChange: func(err error) {
 			blkFunc(name, err)

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -41,9 +41,14 @@ func RandomAccountInfo() *db.AccountInfo {
 // RandomWallet creates a random wallet.
 func RandomWallet() *db.Wallet {
 	return &db.Wallet{
-		AssetID:   rand.Uint32(),
-		Account:   ordertest.RandomAddress(),
-		INIPath:   ordertest.RandomAddress(),
+		AssetID: rand.Uint32(),
+		Account: ordertest.RandomAddress(),
+		Settings: map[string]string{
+			ordertest.RandomAddress(): ordertest.RandomAddress(),
+			ordertest.RandomAddress(): ordertest.RandomAddress(),
+			ordertest.RandomAddress(): ordertest.RandomAddress(),
+			ordertest.RandomAddress(): ordertest.RandomAddress(),
+		},
 		Balance:   rand.Uint64(),
 		BalUpdate: time.Now().Truncate(time.Millisecond).UTC(),
 		Address:   ordertest.RandomAddress(),
@@ -231,8 +236,15 @@ func MustCompareWallets(t testKiller, w1, w2 *db.Wallet) {
 	if w1.Account != w2.Account {
 		t.Fatalf("Account mismatch. %s != %s", w1.Account, w2.Account)
 	}
-	if w1.INIPath != w2.INIPath {
-		t.Fatalf("INIPath mismatch. %s != %s", w1.INIPath, w2.INIPath)
+	if len(w1.Settings) != len(w2.Settings) {
+		t.Fatalf("Settings mismatch. %d != %s", len(w1.Settings), len(w2.Settings))
+	}
+	for k, v1 := range w1.Settings {
+		if v2, ok := w2.Settings[k]; !ok {
+			t.Fatalf("Settings mismatch: key '%s' not found in one wallet", k)
+		} else if v1 != v2 {
+			t.Fatalf("Settings mismatch: different values for key '%s'", k)
+		}
 	}
 	if w1.Balance != w2.Balance {
 		t.Fatalf("Balance mismatch. %d != %d", w1.Balance, w2.Balance)

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -373,8 +373,6 @@ func decodeWallet_v0(pushes [][]byte) (*Wallet, error) {
 	keyB, addressB := pushes[3], pushes[4]
 	settings, err := config.Parse(settingsB)
 	if err != nil {
-		// this should generally not happen as `settings` is always properly
-		// encoded before saving.
 		return nil, fmt.Errorf("unable to decode wallet settings")
 	}
 	return &Wallet{

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/config"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/order"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
@@ -334,7 +335,7 @@ func decodeOrderProof_v0(pushes [][]byte) (*OrderProof, error) {
 type Wallet struct {
 	AssetID     uint32
 	Account     string
-	INIPath     string
+	Settings    map[string]string
 	Balance     uint64
 	BalUpdate   time.Time
 	EncryptedPW []byte
@@ -346,7 +347,7 @@ func (w *Wallet) Encode() []byte {
 	return dbBytes{0}.
 		AddData(uint32Bytes(w.AssetID)).
 		AddData([]byte(w.Account)).
-		AddData([]byte(w.INIPath)).
+		AddData(config.Data(w.Settings)).
 		AddData(w.EncryptedPW).
 		AddData([]byte(w.Address))
 }
@@ -368,12 +369,18 @@ func decodeWallet_v0(pushes [][]byte) (*Wallet, error) {
 	if len(pushes) != 5 {
 		return nil, fmt.Errorf("decodeWallet_v0: expected 5 pushes, got %d", len(pushes))
 	}
-	idB, acctB, iniB := pushes[0], pushes[1], pushes[2]
+	idB, acctB, settingsB := pushes[0], pushes[1], pushes[2]
 	keyB, addressB := pushes[3], pushes[4]
+	settings, err := config.Parse(settingsB)
+	if err != nil {
+		// this should generally not happen as `settings` is always properly
+		// encoded before saving.
+		return nil, fmt.Errorf("unable to decode wallet settings")
+	}
 	return &Wallet{
 		AssetID:     intCoder.Uint32(idB),
 		Account:     string(acctB),
-		INIPath:     string(iniB),
+		Settings:    settings,
 		EncryptedPW: keyB,
 		Address:     string(addressB),
 	}, nil

--- a/dex/btc/config.go
+++ b/dex/btc/config.go
@@ -44,7 +44,7 @@ type Config struct {
 // LoadConfigFromPath loads the configuration settings from the specified filepath.
 func LoadConfigFromPath(cfgPath string, name string, network dex.Network, ports NetPorts) (*Config, error) {
 	cfg := &Config{}
-	if err := config.Parse(cfgPath, cfg); err != nil {
+	if err := config.ParseInto(cfgPath, cfg); err != nil {
 		return nil, fmt.Errorf("error parsing config file: %v", err)
 	}
 	return checkConfig(cfg, name, network, ports)

--- a/dex/config/config.go
+++ b/dex/config/config.go
@@ -10,16 +10,6 @@ import (
 	"gopkg.in/go-ini/ini.v1"
 )
 
-// Options returns a collection of all key-value options in provided config
-// file path or []byte data.
-func Options(cfgPathOrData interface{}) (map[string]string, error) {
-	cfgFile, err := ini.Load(cfgPathOrData)
-	if err != nil {
-		return nil, err
-	}
-	return options(cfgFile), nil
-}
-
 func options(cfgFile *ini.File) map[string]string {
 	options := make(map[string]string)
 	for _, section := range cfgFile.Sections() {
@@ -30,19 +20,22 @@ func options(cfgFile *ini.File) map[string]string {
 	return options
 }
 
-// Unmapify parses config options from the provided settings map into the
-// specified interface.
-func Unmapify(settings map[string]string, obj interface{}) error {
-	cfgData := optionsMapToINIData(settings)
-	return Parse(cfgData, obj)
+// Parse returns a collection of all key-value options in the provided config
+// file path or []byte data.
+func Parse(cfgPathOrData interface{}) (map[string]string, error) {
+	cfgFile, err := ini.Load(cfgPathOrData)
+	if err != nil {
+		return nil, err
+	}
+	return options(cfgFile), nil
 }
 
-// Parse parses config options from the provided config file path or []byte
+// ParseInto parses config options from the provided config file path or []byte
 // data into the specified interface.
-// If the config has section headers, the config options are first read into
-// a map, then converted to []byte before being parsed. Otherwise `obj` would
-// not be modified with any data from the config.
-func Parse(cfgPathOrData, obj interface{}) error {
+// If the config has section headers, the config options are first read into a
+// map, then converted to []byte before being parsed. Otherwise `obj` would not
+// be modified with any data from the config.
+func ParseInto(cfgPathOrData, obj interface{}) error {
 	cfgFile, err := ini.Load(cfgPathOrData)
 	if err != nil {
 		return err
@@ -53,19 +46,26 @@ func Parse(cfgPathOrData, obj interface{}) error {
 		// config file or data has non-default section headers, remove sections
 		// by extracting all config options and regenerating the config data.
 		cfgOptions := options(cfgFile)
-		cfgPathOrData = optionsMapToINIData(cfgOptions)
-		return Parse(cfgPathOrData, obj)
+		cfgPathOrData = Data(cfgOptions)
+		return ParseInto(cfgPathOrData, obj)
 	}
 
 	err = cfgFile.MapTo(obj)
 	return err
 }
 
-// optionsMapToINIData generates a config []byte data from settings.
-func optionsMapToINIData(settings map[string]string) []byte {
+// Data generates a config []byte data from a settings map.
+func Data(settings map[string]string) []byte {
 	var buffer bytes.Buffer
 	for key, value := range settings {
 		buffer.WriteString(fmt.Sprintf("%s=%s\n", key, value))
 	}
 	return buffer.Bytes()
+}
+
+// Unmapify parses config options from the provided settings map into the
+// specified interface.
+func Unmapify(settings map[string]string, obj interface{}) error {
+	cfgData := Data(settings)
+	return ParseInto(cfgData, obj)
 }

--- a/dex/config/config.go
+++ b/dex/config/config.go
@@ -10,16 +10,6 @@ import (
 	"gopkg.in/go-ini/ini.v1"
 )
 
-func options(cfgFile *ini.File) map[string]string {
-	options := make(map[string]string)
-	for _, section := range cfgFile.Sections() {
-		for _, key := range section.Keys() {
-			options[key.Name()] = key.String()
-		}
-	}
-	return options
-}
-
 // Parse returns a collection of all key-value options in the provided config
 // file path or []byte data.
 func Parse(cfgPathOrData interface{}) (map[string]string, error) {
@@ -27,31 +17,29 @@ func Parse(cfgPathOrData interface{}) (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return options(cfgFile), nil
+	options := make(map[string]string)
+	for _, section := range cfgFile.Sections() {
+		for _, key := range section.Keys() {
+			options[key.Name()] = key.String()
+		}
+	}
+	return options, nil
 }
 
 // ParseInto parses config options from the provided config file path or []byte
 // data into the specified interface.
-// If the config has section headers, the config options are first read into a
-// map, then converted to []byte before being parsed. Otherwise `obj` would not
-// be modified with any data from the config.
 func ParseInto(cfgPathOrData, obj interface{}) error {
 	cfgFile, err := ini.Load(cfgPathOrData)
 	if err != nil {
 		return err
 	}
-
-	cfgSections := cfgFile.Sections()
-	if len(cfgSections) > 1 || cfgSections[0].Name() != ini.DefaultSection {
-		// config file or data has non-default section headers, remove sections
-		// by extracting all config options and regenerating the config data.
-		cfgOptions := options(cfgFile)
-		cfgPathOrData = Data(cfgOptions)
-		return ParseInto(cfgPathOrData, obj)
+	for _, section := range cfgFile.Sections() {
+		err := section.MapTo(obj)
+		if err != nil {
+			return err
+		}
 	}
-
-	err = cfgFile.MapTo(obj)
-	return err
+	return nil
 }
 
 // Data generates a config []byte data from a settings map.

--- a/dex/config/config_test.go
+++ b/dex/config/config_test.go
@@ -107,7 +107,7 @@ func TestConfigParsing(t *testing.T) {
 	tests := []test{
 		makeOkTest("ok, with default application options header", "[Application Options]", ""),
 		makeOkTest("ok, with random section header", "[Random Header]", ""),
-		makeOkTest("ok, with random section header", "[Application Options]", "[Random Options]"),
+		makeOkTest("ok, with multiple section headers", "[Application Options]", "[Random Options]"),
 		makeOkTest("ok, with no section header", "", ""),
 		{
 			name:      "ok, with file path",


### PR DESCRIPTION
Resolves part 2 of #292.

I did not implement encryption of wallet settings before saving because it would make it impossible to load the wallet on dexc start; unless we chose to defer wallets loading AND unlocking to `core.Login`.