### PR TITLE
client/asset: log new wallet config while setting up

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -272,10 +272,13 @@ func BTCCloneWallet(cfg *asset.WalletConfig, symbol string, logger dex.Logger,
 		return nil, err
 	}
 
+	endpoint := btcCfg.RPCBind + "/wallet/" + cfg.Account
+	logger.Infof("Setting up new %s wallet at %s.", symbol, endpoint)
+
 	client, err := rpcclient.New(&rpcclient.ConnConfig{
 		HTTPPostMode: true,
 		DisableTLS:   true,
-		Host:         btcCfg.RPCBind + "/wallet/" + cfg.Account,
+		Host:         endpoint,
 		User:         btcCfg.RPCUser,
 		Pass:         btcCfg.RPCPass,
 	}, nil)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -266,6 +266,8 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 	}
 	dcr := unconnectedWallet(cfg, logger)
 
+	logger.Infof("Setting up new DCR wallet at %s with TLS certificate %q.",
+		walletCfg.RPCListen, walletCfg.RPCCert)
 	dcr.client, err = newClient(walletCfg.RPCListen, walletCfg.RPCUser,
 		walletCfg.RPCPass, walletCfg.RPCCert)
 	if err != nil {


### PR DESCRIPTION
This is a common enough setup hiccup that I think some logging here is warranted to show what wallet RPC server settings (host:port for dcr and btc, and cert for dcr) were parsed from the config file (although that is not always going to be the case - see step 4 on issue https://github.com/decred/dcrdex/issues/292#issuecomment-619540709).

On CreateWallet, you get the new "Setting up new..." log lines:

```
[INF] CORE[dcr]: Setting up new DCR wallet at 127.0.0.1:19567 with TLS certificate "/home/jon/dextest/dcr/alpha/rpc.cert".
[INF] CORE: Created dcr wallet. Account "default" balance available = 4647815451734 / locked = 0, Deposit address = SsfWraUBDUtU2dKAhBAYcb8HVTEupAnj9ta
...
[INF] CORE[btc]: Setting up new btc wallet at localhost:20556/wallet/gamma.
[INF] CORE: Created btc wallet. Account "gamma" balance available = 8400000000 / locked = 0, Deposit address = mngEjYYWeoskrA9aPTBKRCxEWwWU551FJW
```

Note that this is *prior* to a connection attempt. It's just the asset backend's wallet constructor