### PR TITLE
client/core: Add more registration notifications 

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -947,7 +947,7 @@ func (c *Core) verifyRegistrationFee(wallet *xcWallet, dc *dexConnection, coinID
 		details := fmt.Sprintf("Fee payment confirmations %v/%v", confs, uint32(reqConfs))
 
 		if confs < uint32(reqConfs) {
-			c.notify(newFeePaymentNote("Waiting for confirmations", details, db.Data))
+			c.notify(newFeePaymentNoteWithConfirmations("Waiting for confirmations", details, db.Data, uint32(reqConfs), confs))
 		}
 
 		return confs >= uint32(reqConfs), nil

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -933,7 +933,7 @@ func (c *Core) Register(form *RegisterForm) error {
 
 // verifyRegistrationFee waits the required amount of confirmations for the
 // registration fee payment. Once the requirment is met the server is notified.
-// If the server acknowedlment is successfull, the account is set as 'paid' in
+// If the server acknowledgment is successfull, the account is set as 'paid' in
 // the database. Notifications about confirmations increase, errors and success
 // events are broadcasted to all subscribers.
 func (c *Core) verifyRegistrationFee(wallet *xcWallet, dc *dexConnection, coinID []byte, assetID uint32) {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -101,7 +101,7 @@ type Notification interface {
 type FeePaymentNote struct {
 	db.Notification
 	ConfirmationsRequired uint32 `json:"confirmationsrequired,omitempty"`
-	ConfirmationsReceived uint32 `json:"confirmationsreceived,omitempty"`
+	Confirmations         uint32 `json:"confirmations,omitempty"`
 }
 
 func newFeePaymentNote(subject, details string, severity db.Severity) *FeePaymentNote {
@@ -113,7 +113,7 @@ func newFeePaymentNote(subject, details string, severity db.Severity) *FeePaymen
 func newFeePaymentNoteWithConfirmations(subject, details string, severity db.Severity, reqConfs uint32, currConfs uint32) *FeePaymentNote {
 	feePmtNt := newFeePaymentNote(subject, details, severity)
 	feePmtNt.ConfirmationsRequired = reqConfs
-	feePmtNt.ConfirmationsReceived = currConfs
+	feePmtNt.Confirmations = currConfs
 	return feePmtNt
 }
 

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -100,12 +100,21 @@ type Notification interface {
 // FeePaymentNote is a notification regarding registration fee payment.
 type FeePaymentNote struct {
 	db.Notification
+	ConfirmationsRequired uint32 `json:"confirmationsrequired,omitempty"`
+	ConfirmationsReceived uint32 `json:"confirmationsreceived,omitempty"`
 }
 
 func newFeePaymentNote(subject, details string, severity db.Severity) *FeePaymentNote {
 	return &FeePaymentNote{
 		Notification: db.NewNotification("fee payment", subject, details, severity),
 	}
+}
+
+func newFeePaymentNoteWithConfirmations(subject, details string, severity db.Severity, reqConfs uint32, currConfs uint32) *FeePaymentNote {
+	feePmtNt := newFeePaymentNote(subject, details, severity)
+	feePmtNt.ConfirmationsRequired = reqConfs
+	feePmtNt.ConfirmationsReceived = currConfs
+	return feePmtNt
 }
 
 // WithdrawNote is a notification regarding a requested withdraw.


### PR DESCRIPTION
This PR primarily adds a new notification when the number of confirmation increases for the registration fee payment. 

Full list of changes:
- Reuses the same code for registration fee payment verification both during `Register` and `reFee` (re-check of the fee in case the verification wasn't completed correctly).
- By reusing the same code, the notification on success is now sent in both cases. Which wasn't happening for `reFee`.
- Adds notification when the confirmation amount increases but has not met the min requirement yet.
- Moves `confTrigger` as an internal function of `c.verifyRegistrationFee` since it is no longer being used anywhere else.

**Edit:**
Added 2 new fields to the `FeePaymentNote` notification: `ConfirmationsRequired` and `ConfirmationsReceived` so the client/frontend can use it for further user feedback.

closes #336 