### PR TITLE
client/webserver,dexcctl: replace new wallet config file path with cfg text

### DIFF
--- a/client/cmd/dexcctl/dexcctl_test.go
+++ b/client/cmd/dexcctl/dexcctl_test.go
@@ -91,7 +91,7 @@ func TestConfigure(t *testing.T) {
 	}
 }
 
-func TestReadCert(t *testing.T) {
+func TestReadTextFile(t *testing.T) {
 	saveTextToFile := func(text, filePath string) {
 		path := cleanAndExpandPath(filePath)
 		file, err := os.Create(path)

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -58,11 +58,21 @@ var promptPasswords = map[string][]string{
 	"register":   {"App password:"},
 }
 
-// readCerts is a map of routes to TLS certificate indexes.
-var readCerts = map[string]int{
+// optionalTextFiles is a map of routes to arg index for routes that should read
+// the text content of a file, where the file path may be found in the route's
+// cmd args at the specified index.
+var optionalTextFiles = map[string]int{
 	"preregister": 1,
 	"register":    2,
+	"newwallet":   2,
 }
+
+// requiredTextFiles is a map of routes to arg index for routes that should read
+// the text content of a file, where the file path is required be present in the
+// route's cmd args at the specified index.
+// todo: "preregister" and "register" routes should be listed here instead of in
+// `optionalTextFiles` because those cmds will fail if the cert arg is not passed.
+var requiredTextFiles = map[string]int{}
 
 // promptPWs prompts for passwords on stdin and returns an error if prompting
 // fails or a password is empty. Returns passwords as a slice of []byte.
@@ -83,24 +93,30 @@ func promptPWs(ctx context.Context, cmd string) ([]encode.PassBytes, error) {
 	return pws, nil
 }
 
-// readCert reads TLS certificate content located in a file specified at args'
-// index as expected for cmd and replaces it with the file as a string. The
-// passed args are modified.
-func readCert(cmd string, args []string) error {
-	idx, exists := readCerts[cmd]
-	// Certs are optional, so it is not an error if they are not included.
-	if !exists || len(args) < idx+1 || args[idx] == "" {
-		return nil
+// readTextFile reads the text content of the file whose path is specified at
+// args' index as expected for cmd and sets the args value at the expected index
+// to the file's text content. The passed args are modified.
+func readTextFile(cmd string, args []string) error {
+	fileArgIndx, readFile := requiredTextFiles[cmd]
+	if readFile && (len(args) < fileArgIndx+1 || args[fileArgIndx] == "") {
+		return fmt.Errorf("command requires argument %d to be a file path", fileArgIndx+1)
 	}
-	path := cleanAndExpandPath(args[idx])
+	if !readFile {
+		fileArgIndx, readFile = optionalTextFiles[cmd]
+		// Not an error if file path arg is not provided for optional file args.
+		if !readFile || len(args) < fileArgIndx+1 || args[fileArgIndx] == "" {
+			return nil
+		}
+	}
+	path := cleanAndExpandPath(args[fileArgIndx])
 	if !fileExists(path) {
-		return fmt.Errorf("no cert file found at %s", path)
+		return fmt.Errorf("no file found at %s", path)
 	}
-	certB, err := ioutil.ReadFile(path)
+	fileContents, err := ioutil.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("error reading %s: %v", path, err)
 	}
-	args[idx] = string(certB)
+	args[fileArgIndx] = string(fileContents)
 	return nil
 }
 
@@ -148,7 +164,7 @@ func run(ctx context.Context) error {
 	}
 
 	// Attempt to read TLS certificates.
-	err = readCert(args[0], params)
+	err = readTextFile(args[0], params)
 	if err != nil {
 		return err
 	}

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -59,20 +59,13 @@ var promptPasswords = map[string][]string{
 }
 
 // optionalTextFiles is a map of routes to arg index for routes that should read
-// the text content of a file, where the file path may be found in the route's
+// the text content of a file, where the file path _may_ be found in the route's
 // cmd args at the specified index.
 var optionalTextFiles = map[string]int{
 	"preregister": 1,
 	"register":    2,
 	"newwallet":   2,
 }
-
-// requiredTextFiles is a map of routes to arg index for routes that should read
-// the text content of a file, where the file path is required be present in the
-// route's cmd args at the specified index.
-// todo: "preregister" and "register" routes should be listed here instead of in
-// `optionalTextFiles` because those cmds will fail if the cert arg is not passed.
-var requiredTextFiles = map[string]int{}
 
 // promptPWs prompts for passwords on stdin and returns an error if prompting
 // fails or a password is empty. Returns passwords as a slice of []byte.
@@ -97,16 +90,10 @@ func promptPWs(ctx context.Context, cmd string) ([]encode.PassBytes, error) {
 // args' index as expected for cmd and sets the args value at the expected index
 // to the file's text content. The passed args are modified.
 func readTextFile(cmd string, args []string) error {
-	fileArgIndx, readFile := requiredTextFiles[cmd]
-	if readFile && (len(args) < fileArgIndx+1 || args[fileArgIndx] == "") {
-		return fmt.Errorf("command requires argument %d to be a file path", fileArgIndx+1)
-	}
-	if !readFile {
-		fileArgIndx, readFile = optionalTextFiles[cmd]
-		// Not an error if file path arg is not provided for optional file args.
-		if !readFile || len(args) < fileArgIndx+1 || args[fileArgIndx] == "" {
-			return nil
-		}
+	fileArgIndx, readFile := optionalTextFiles[cmd]
+	// Not an error if file path arg is not provided for optional file args.
+	if !readFile || len(args) < fileArgIndx+1 || args[fileArgIndx] == "" {
+		return nil
 	}
 	path := cleanAndExpandPath(args[fileArgIndx])
 	if !fileExists(path) {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -551,7 +551,7 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 		settings, err = config.Parse([]byte(form.ConfigText))
 	}
 	if err != nil {
-		return fmt.Errorf("error parsing config file: %v", err)
+		return fmt.Errorf("error parsing config: %v", err)
 	}
 
 	dbWallet := &db.Wallet{

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -539,18 +539,16 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 		return fmt.Errorf("wallet password encryption error: %v", err)
 	}
 
-	if form.ConfigText == "" && form.INIPath == "" {
-		form.INIPath, err = asset.DefaultConfigPath(assetID)
+	var settings map[string]string
+	if form.ConfigText == "" {
+		var defaultWalletCfgPath string
+		defaultWalletCfgPath, err = asset.DefaultConfigPath(assetID)
 		if err != nil {
 			return fmt.Errorf("cannot use default wallet config path: %v", err)
 		}
-	}
-
-	var settings map[string]string
-	if form.ConfigText != "" {
-		settings, err = config.Parse([]byte(form.ConfigText))
+		settings, err = config.Parse(defaultWalletCfgPath)
 	} else {
-		settings, err = config.Parse(form.INIPath)
+		settings, err = config.Parse([]byte(form.ConfigText))
 	}
 	if err != nil {
 		return fmt.Errorf("error parsing config file: %v", err)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -539,14 +539,19 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 		return fmt.Errorf("wallet password encryption error: %v", err)
 	}
 
-	if form.INIPath == "" {
+	if form.ConfigText == "" && form.INIPath == "" {
 		form.INIPath, err = asset.DefaultConfigPath(assetID)
 		if err != nil {
 			return fmt.Errorf("cannot use default wallet config path: %v", err)
 		}
 	}
 
-	settings, err := config.Parse(form.INIPath)
+	var settings map[string]string
+	if form.ConfigText != "" {
+		settings, err = config.Parse([]byte(form.ConfigText))
+	} else {
+		settings, err = config.Parse(form.INIPath)
+	}
 	if err != nil {
 		return fmt.Errorf("error parsing config file: %v", err)
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -7,9 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 	"sync"
 	"testing"
@@ -33,7 +31,6 @@ import (
 	"github.com/decred/dcrd/crypto/blake256"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 	"github.com/decred/slog"
-	"gopkg.in/ini.v1"
 )
 
 var (
@@ -869,22 +866,11 @@ func TestCreateWallet(t *testing.T) {
 		return asset.DecodeCoinID(tDCR.ID, coinID) // using DCR decoder
 	}
 
-	tempDir, err := ioutil.TempDir("", "coretest")
-	if err != nil {
-		t.Fatalf("error creating temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-	cfgFilePath := filepath.Join(tempDir, "test.conf")
-	err = ini.Empty().SaveTo(cfgFilePath)
-	if err != nil {
-		t.Fatalf("error creating temporary config file: %v", err)
-	}
-
 	// Create registration form.
 	form := &WalletForm{
-		AssetID: tILT.ID,
-		Account: "default",
-		INIPath: cfgFilePath,
+		AssetID:    tILT.ID,
+		Account:    "default",
+		ConfigText: "rpclisten=localhost",
 	}
 
 	ensureErr := func(tag string) {
@@ -949,7 +935,7 @@ func TestCreateWallet(t *testing.T) {
 
 	// Success
 	delete(tCore.wallets, tILT.ID)
-	err = tCore.CreateWallet(tPW, []byte(wPW), form)
+	err := tCore.CreateWallet(tPW, []byte(wPW), form)
 	if err != nil {
 		t.Fatalf("error when should be no error: %v", err)
 	}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -62,10 +62,14 @@ func (set *errorSet) Error() string {
 }
 
 // WalletForm is information necessary to create a new exchange wallet.
+// Requires either config file path or config text to connect to wallet.
+// If both are provided, the config text is used. If none is provided,
+// default config file path is used.
 type WalletForm struct {
-	AssetID uint32
-	Account string
-	INIPath string
+	AssetID    uint32
+	Account    string
+	ConfigText string
+	INIPath    string
 }
 
 // WalletState is the current status of an exchange wallet.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -62,7 +62,9 @@ func (set *errorSet) Error() string {
 }
 
 // WalletForm is information necessary to create a new exchange wallet.
-// If ConfigText is provided, the asset's default config file path is used.
+// The ConfigText, if provided, will be parsed for wallet connection settings.
+// If ConfigText is not provided, and a file exists at the `asset.DefaultConfigPath`,
+// that file will be parsed for wallet connection settings.
 type WalletForm struct {
 	AssetID    uint32
 	Account    string

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -62,14 +62,11 @@ func (set *errorSet) Error() string {
 }
 
 // WalletForm is information necessary to create a new exchange wallet.
-// Requires either config file path or config text to connect to wallet.
-// If both are provided, the config text is used. If none is provided,
-// default config file path is used.
+// If ConfigText is provided, the asset's default config file path is used.
 type WalletForm struct {
 	AssetID    uint32
 	Account    string
 	ConfigText string
-	INIPath    string
 }
 
 // WalletState is the current status of an exchange wallet.

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -144,9 +144,9 @@ func handleNewWallet(s *RPCServer, params *RawParams) *msgjson.ResponsePayload {
 	}
 	// Wallet does not exist yet. Try to create it.
 	err = s.core.CreateWallet(form.AppPass, form.WalletPass, &core.WalletForm{
-		AssetID: form.AssetID,
-		Account: form.Account,
-		INIPath: form.INIPath,
+		AssetID:    form.AssetID,
+		Account:    form.Account,
+		ConfigText: form.ConfigText,
 	})
 	if err != nil {
 		errMsg := fmt.Sprintf("error creating %s wallet: %v",
@@ -390,7 +390,7 @@ var helpMsgs = map[string]helpMsg{
 	},
 	newWalletRoute: {
 		pwArgsShort: `"appPass" "walletPass"`,
-		argsShort:   `assetID "account" "inipath"`,
+		argsShort:   `assetID "account" ("config")`,
 		cmdSummary:  `Connect to a new wallet.`,
 		pwArgsLong: `Password Args:
     appPass (string): The dex client password.
@@ -399,7 +399,7 @@ var helpMsgs = map[string]helpMsg{
     assetID (int): The asset's BIP-44 registered coin index. e.g. 42 for DCR.
       See https://github.com/satoshilabs/slips/blob/master/slip-0044.md
     account (string): The account or wallet name, depending on wallet software.
-    inipath (string): The location of the wallet's config file.`,
+    config (string): Optional. The path to the wallet's config file.`,
 		returns: `Returns:
     string: The message "` + fmt.Sprintf(walletCreatedStr, "[coin symbol]") + `"`,
 	},

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -50,7 +50,7 @@ type openWalletForm struct {
 type newWalletForm struct {
 	AssetID    uint32           `json:"assetID"`
 	Account    string           `json:"account"`
-	INIPath    string           `json:"inipath"`
+	ConfigText string           `json:"config"`
 	WalletPass encode.PassBytes `json:"walletPass"`
 	AppPass    encode.PassBytes `json:"appPass"`
 }
@@ -131,7 +131,7 @@ func parseInitArgs(params *RawParams) (encode.PassBytes, error) {
 }
 
 func parseNewWalletArgs(params *RawParams) (*newWalletForm, error) {
-	if err := checkNArgs(params, []int{2}, []int{3}); err != nil {
+	if err := checkNArgs(params, []int{2}, []int{2, 3}); err != nil {
 		return nil, err
 	}
 	assetID, err := checkUIntArg(params.Args[0], "assetID", 32)
@@ -143,7 +143,9 @@ func parseNewWalletArgs(params *RawParams) (*newWalletForm, error) {
 		WalletPass: params.PWArgs[1],
 		AssetID:    uint32(assetID),
 		Account:    params.Args[1],
-		INIPath:    params.Args[2],
+	}
+	if len(params.Args) > 2 {
+		req.ConfigText = params.Args[2]
 	}
 	return req, nil
 }

--- a/client/rpcserver/types_test.go
+++ b/client/rpcserver/types_test.go
@@ -119,7 +119,7 @@ func TestParseNewWalletArgs(t *testing.T) {
 			t.Fatalf("account doesn't match")
 		}
 		if nwf.ConfigText != test.params.Args[2] {
-			t.Fatalf("inipath doesn't match")
+			t.Fatalf("config doesn't match")
 		}
 	}
 }

--- a/client/rpcserver/types_test.go
+++ b/client/rpcserver/types_test.go
@@ -81,7 +81,7 @@ func TestParseNewWalletArgs(t *testing.T) {
 		args := []string{
 			id,
 			"default",
-			"/home/wallet.conf",
+			"rpclisten=127.0.0.0",
 		}
 		return &RawParams{PWArgs: pwArgs, Args: args}
 	}
@@ -118,7 +118,7 @@ func TestParseNewWalletArgs(t *testing.T) {
 		if nwf.Account != test.params.Args[1] {
 			t.Fatalf("account doesn't match")
 		}
-		if nwf.INIPath != test.params.Args[2] {
+		if nwf.ConfigText != test.params.Args[2] {
 			t.Fatalf("inipath doesn't match")
 		}
 	}

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -87,9 +87,9 @@ func (s *WebServer) apiNewWallet(w http.ResponseWriter, r *http.Request) {
 	}
 	// Wallet does not exist yet. Try to create it.
 	err := s.core.CreateWallet(form.AppPW, form.Pass, &core.WalletForm{
-		AssetID: form.AssetID,
-		Account: form.Account,
-		INIPath: form.INIPath,
+		AssetID:    form.AssetID,
+		Account:    form.Account,
+		ConfigText: form.Config,
 	})
 	if err != nil {
 		s.writeAPIError(w, "error creating %s wallet: %v", unbip(form.AssetID), err)

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -19,8 +19,13 @@
     <input type="password" autocomplete="off" class="form-control select" id="newWalletPass">
   </div>
   <div>
-    <label for="iniPath" class="pt-3 pl-1 mb-1">Configuration Filepath</label>
-    <input type="text" class="form-control select" placeholder="leave empty to use default path" id="iniPath">
+    <div class="pt-3 pl-1 mb-1 pointer">Configuration File</div>
+    <input type="file" class="form-control select d-none" id="cfgFile">
+    <div class="pl-1 mt-2 fs15">
+      <span id="selectedCfgFile">none selected</span>
+      <span class="underline ml-3 pointer d-hide" id="removeCfgFile">remove</span>
+      <span class="underline ml-3 pointer" id="addCfgFile">select a file</span>
+    </div>
   </div>
   <div>
     <label for="wClientPass" class="pt-3 pl-1 mb-0">Client Password</label>

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -45,8 +45,13 @@
           <input type="password" class="form-control select" id="newWalletPass" autocomplete="off">
         </div>
         <div>
-          <label for="iniPath" class="pt-3 pl-1 mb-1">Configuration Filepath</label>
-          <input type="text" class="form-control select" placeholder="leave empty to use default path" id="iniPath">
+          <div class="pt-3 pl-1 mb-1 pointer">Configuration File</div>
+          <input type="file" class="form-control select d-none" id="cfgFile">
+          <div class="pl-1 mt-2 fs15">
+            <span id="selectedCfgFile">none selected</span>
+            <span class="underline ml-3 pointer d-hide" id="removeCfgFile">remove</span>
+            <span class="underline ml-3 pointer" id="addCfgFile">select a file</span>
+          </div>
         </div>
         <div>
           <label for="wClientPass" class="pt-3 pl-1 mb-0">Client Password</label>

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -22,8 +22,7 @@ export default class WalletsPage extends BasePage {
       'markets', 'dexTitle', 'marketsBox', 'oneMarket', 'marketsFor',
       'marketsCard',
       // New wallet form
-      'walletForm', 'acctName', 'newWalletPass', 'iniPath', 'walletErr',
-      'newWalletLogo', 'newWalletName',
+      'walletForm', 'acctName',
       // Unlock wallet form
       'openForm',
       // Deposit
@@ -186,14 +185,6 @@ export default class WalletsPage extends BasePage {
     const box = page.walletForm
     const asset = app.assets[assetID]
     await this.hideBox()
-    if (assetID !== this.walletAsset) {
-      page.acctName.value = ''
-      page.newWalletPass.value = ''
-      page.iniPath.value = ''
-      page.iniPath.placeholder = asset.info.configpath
-      Doc.hide(page.walletErr)
-      page.newWalletName.textContent = asset.info.name
-    }
     this.walletAsset = assetID
     page.walletForm.setAsset(asset)
     this.animation = this.showBox(box, page.acctName)

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -39,7 +39,7 @@ type newWalletForm struct {
 	// These are only used if the Decred wallet does not already exist. In that
 	// case, these parameters will be used to create the wallet.
 	Account string           `json:"account"`
-	INIPath string           `json:"inipath"`
+	Config  string           `json:"config"`
 	Pass    encode.PassBytes `json:"pass"`
 	AppPW   encode.PassBytes `json:"appPass"`
 }

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -549,7 +549,6 @@ func TestAPINewWallet(t *testing.T) {
 
 	body = &newWalletForm{
 		Account: "account",
-		INIPath: "/path/to/somewhere",
 		Pass:    encode.PassBytes("123"),
 	}
 	tCore.notHas = true


### PR DESCRIPTION
Part 3 of #292 

<img width="360" alt="Screenshot 2020-05-06 at 4 40 28 AM" src="https://user-images.githubusercontent.com/18400051/81136575-e0839a00-8f53-11ea-88df-c9d9dff9d6c2.png">

Both webserver and dexcctl now read the config text from the config file path (if provided) and sends the config text to the server rather than the config file path, in line with the reasoning that either user-facing apps could be run on a machine different from the dexc backend such that file paths valid on the local machine may be invalid on the server machine.

Also, modifies dexcctl `newwallet` args parsing to allow no arguments for config text, as is done on the web frontend, which causes the client core to use the default config path.