### PR TITLE
app/charts: show epoch limit orders on depth chart

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -34,7 +34,7 @@ type BookFeed struct {
 // feed when it's no longer being used.
 func NewBookFeed(close func(feed *BookFeed)) *BookFeed {
 	return &BookFeed{
-		C:     make(chan *BookUpdate, 1),
+		C:     make(chan *BookUpdate, 256),
 		off:   make(chan struct{}),
 		id:    atomic.AddUint32(&feederID, 1),
 		close: close,

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -584,11 +584,12 @@ out:
 				Epoch:        getEpoch(),
 			}
 			c.orderMtx.Lock()
+			// Send limit orders as newly booked.
 			for _, o := range c.epochOrders {
-				o.Order.Epoch = 0
-				o.Action = msgjson.BookOrderRoute
-				c.trySend(o)
 				if (o.Order.Rate > 0) {
+					o.Order.Epoch = 0
+					o.Action = msgjson.BookOrderRoute
+					c.trySend(o)
 					if (o.Order.Sell) {
 						c.sells[o.Order.Token] = o.Order
 					} else {

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -645,7 +645,10 @@ export default class MarketsPage extends BasePage {
    * handleEpochNote handles notifications signalling the start of a new epoch.
    */
   handleEpochNote (note) {
-    if (this.book) this.book.setEpoch(note.epoch)
+    if (this.book) {
+      this.book.setEpoch(note.epoch)
+      this.chart.draw()
+    }
     this.clearOrderTableEpochs(note.epoch)
   }
 


### PR DESCRIPTION
Shows epoch limit orders as a phantom layer on top of the order book. Differentiating is important here, because the epoch orders may or may not have processed by the time a placed order matches, so the epoch layer is not as likely to be matchable.

Updates to the [test app server](https://github.com/decred/dcrdex/wiki/Test-App-Server) to more realistically handle epochs.

![image](https://user-images.githubusercontent.com/6109680/81349289-59ceda00-9085-11ea-8985-90d5b0ca01a3.png)
