### PR TITLE
github,lint: use v2 of checkout and setup-go actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.26.0"
 
       - name: Test
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,12 @@ jobs:
         go: [1.13, 1.14]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
 
       - name: Check out source
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Install Linters
         run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0"
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -36,9 +36,11 @@ cd $dir
 
 # check linters
 golangci-lint run --disable-all --deadline=10m \
+  --out-format=github-actions \
   --enable=goimports \
   --enable=govet \
   --enable=gosimple \
   --enable=unconvert \
   --enable=structcheck \
-  --enable=ineffassign
+  --enable=ineffassign \
+  --enable=asciicheck


### PR DESCRIPTION
This updates actions/checkout to v2 to avoid [the checkout/v1 bug](https://github.com/actions/checkout/issues/23) when master changes.

This also updates golangci-lint to 1.26, which [adds a `github-actions` output format](https://github.com/golangci/golangci-lint/pull/1017).  This option is enabled in run_tests.sh along with the new [asciicheck](https://github.com/tdakkota/asciicheck) linter.