### PR TITLE
client/core: hide order form and display registration status message

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -129,7 +129,8 @@ func (dc *dexConnection) getRegConfirms() *uint32 {
 	if dc.regConfirms == regConfirmationsPaid {
 		return nil
 	}
-	return &dc.regConfirms
+	confs := dc.regConfirms
+	return &confs
 }
 
 // setRegConfirms sets the number of confirmations received

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"strconv"
@@ -36,9 +37,10 @@ const (
 	keyParamsKey      = "keyParams"
 	conversionFactor  = 1e8
 	regFeeAssetSymbol = "dcr" // Hard-coded to Decred for registration fees, for now.
-	// high number to be assigned to 'regConfirms' in 'dexConnection'
+
+	// highest uint32 number to be assigned to 'regConfirms' in 'dexConnection'
 	// when the registration is completed
-	regConfirmationsPaid uint32 = 9999
+	regConfirmationsPaid uint32 = math.MaxUint32
 )
 
 var (

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -100,20 +100,20 @@ type Notification interface {
 // FeePaymentNote is a notification regarding registration fee payment.
 type FeePaymentNote struct {
 	db.Notification
-	ConfirmationsRequired uint32 `json:"confirmationsrequired,omitempty"`
-	Confirmations         uint32 `json:"confirmations,omitempty"`
+	Confirmations *uint32 `json:"confirmations,omitempty"`
+	Dex           string  `json:"dex,omitempty"`
 }
 
-func newFeePaymentNote(subject, details string, severity db.Severity) *FeePaymentNote {
+func newFeePaymentNote(subject, details string, severity db.Severity, dexAddr string) *FeePaymentNote {
 	return &FeePaymentNote{
-		Notification: db.NewNotification("fee payment", subject, details, severity),
+		Notification: db.NewNotification("feepayment", subject, details, severity),
+		Dex:          addrHost(dexAddr),
 	}
 }
 
-func newFeePaymentNoteWithConfirmations(subject, details string, severity db.Severity, reqConfs uint32, currConfs uint32) *FeePaymentNote {
-	feePmtNt := newFeePaymentNote(subject, details, severity)
-	feePmtNt.ConfirmationsRequired = reqConfs
-	feePmtNt.Confirmations = currConfs
+func newFeePaymentNoteWithConfirmations(subject, details string, severity db.Severity, currConfs uint32, dexAddr string) *FeePaymentNote {
+	feePmtNt := newFeePaymentNote(subject, details, severity, dexAddr)
+	feePmtNt.Confirmations = &currConfs
 	return feePmtNt
 }
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -172,11 +172,13 @@ func (m *Market) marketName() string {
 
 // Exchange represents a single DEX with any number of markets.
 type Exchange struct {
-	Host       string                `json:"host"`
-	Markets    map[string]*Market    `json:"markets"`
-	Assets     map[uint32]*dex.Asset `json:"assets"`
-	FeePending bool                  `json:"feePending"`
-	Connected  bool                  `json:"connected"`
+	Host          string                `json:"host"`
+	Markets       map[string]*Market    `json:"markets"`
+	Assets        map[uint32]*dex.Asset `json:"assets"`
+	FeePending    bool                  `json:"feePending"`
+	Connected     bool                  `json:"connected"`
+	ConfsRequired uint32                `json:"confsrequired"`
+	RegConfirms   *uint32               `json:"confs,omitempty"`
 }
 
 // newDisplayID creates a display-friendly market ID for a base/quote ID pair.

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -639,8 +639,11 @@ Registration is complete after the fee transaction has been confirmed.`,
             "fundConf" (int): The number of confirmations needed before coins
 	      can be traded.
           },...
-        },
-        "feePending" (bool): Whether the dex fee is pending.
+		},
+        "confsrequired": (int) The number of confirmations needed for the 
+        registration fee payment
+        "confs" (int): The current number of confirmations for the registration
+        fee payment. This is only present during the registration process.
       },...
     }`,
 	},

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -521,7 +521,8 @@ func TestHandleExchanges(t *testing.T) {
         "fundConf": 1
       }
     },
-    "feePending": false
+	"confsrequired": 1,
+	"confs": null
   }
 }`
 	out := `{
@@ -580,7 +581,8 @@ func TestHandleExchanges(t *testing.T) {
         "fundConf": 1
       }
     },
-    "feePending": false
+    "confsrequired": 1,
+    "confs": null
   }
 }`
 	var exchangesIn map[string]*core.Exchange

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -156,7 +156,15 @@ table.ordertable {
   }
 }
 
+#loaderMsg {
+  padding: 1rem;
+  color: red;
+}
+
 #registrationStatus {
+  padding: 0.5rem;
+  border: 1px solid #6a6a6a;
+
   .title {
     font-weight: bold;
     margin-bottom: 5px;

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -156,6 +156,35 @@ table.ordertable {
   }
 }
 
+#registrationStatus {
+  .title {
+    font-weight: bold;
+    margin-bottom: 5px;
+  }
+
+  &.waiting {
+    .title {
+      color: #9b8c09;
+    }
+  }
+
+  &.completed {
+    .title {
+      color: #5cba8b;
+    }
+
+    #regStatusMessage {
+      display: none;
+    }
+  }
+
+  &.error {
+    .title {
+      color: red;
+    }
+  }
+}
+
 #orderForm {
   min-height: 375px;
 

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -128,6 +128,20 @@
             </div>
 
             <div class="fs15 pt-3 text-center d-hide" id="loaderMsg"></div>
+            
+            {{- /* REGISTRATION STATUS */ -}}
+            <div class="d-hide" id="registrationStatus">
+              <div class="p-0 w-100">
+                <div class="d-flex flex-column justify-content-center align-items-center">
+                  <span id="regStatusTitle" class="title"></span>
+                  <p id="regStatusMessage">In order to trade at <span id="regStatusDex"></span>, the registration fee payment
+                    needs <span id="confReq"></span> confirmations.
+                  </p>
+                  <span id="regStatusConfsDisplay"></span>
+                </div>
+              </div>
+            </div>
+
             {{- /* ORDER FORM */ -}}
             <form id="orderForm" class="bg1">
               <div class="p-0 w-100">

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -258,7 +258,7 @@ export default class Application {
   }
 
   /*
-   * handleFeePaymentNote is the handler for the 'feepayment'-type notificaetion, which
+   * handleFeePaymentNote is the handler for the 'feepayment'-type notification, which
    * is used to update the dex registration status.
    */
   handleFeePaymentNote (note) {

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -96,6 +96,7 @@ export default class Application {
     if (!this.checkResponse(user)) return
     this.user = user
     this.assets = user.assets
+    this.exchanges = user.exchanges
     this.walletMap = {}
     for (const [assetID, asset] of Object.entries(user.assets)) {
       if (asset.wallet) {
@@ -240,6 +241,40 @@ export default class Application {
   }
 
   /*
+   * updateExchangeRegistration updates the information for the exchange
+   * registration payment
+   */
+  updateExchangeRegistration (dexAddr, isPaid, confs) {
+    const dex = this.exchanges[dexAddr]
+
+    if (isPaid) {
+      // setting the null value in the 'confs' field indicates that the fee
+      // payment was completed
+      dex.confs = null
+      return
+    }
+
+    dex.confs = confs
+  }
+
+  /*
+   * handleFeePaymentNote is the handler for the 'feepayment'-type notificaetion, which
+   * is used to update the dex registration status.
+   */
+  handleFeePaymentNote (note) {
+    switch (note.subject) {
+      case 'regupdate':
+        this.updateExchangeRegistration(note.dex, false, note.confirmations)
+        break
+      case 'Account registered':
+        this.updateExchangeRegistration(note.dex, true)
+        break
+      default:
+        break
+    }
+  }
+
+  /*
    * setNotes sets the current notification cache and populates the notification
    * display.
    */
@@ -273,6 +308,9 @@ export default class Application {
         if (wallet) wallet.balances = note.balances
         break
       }
+        break
+      case 'feepayment':
+        this.handleFeePaymentNote(note)
     }
 
     // Inform the page.
@@ -328,6 +366,7 @@ export default class Application {
       const cls = note.severity === ntfn.SUCCESS ? 'good' : note.severity === ntfn.WARNING ? 'warn' : 'bad'
       el.querySelector('div.note-indicator').classList.add(cls)
     }
+
     el.querySelector('div.note-subject').textContent = note.subject
     el.querySelector('div.note-details').textContent = note.details
     return el

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -308,7 +308,6 @@ export default class Application {
         if (wallet) wallet.balances = note.balances
         break
       }
-        break
       case 'feepayment':
         this.handleFeePaymentNote(note)
     }

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -74,6 +74,11 @@ export default class Doc {
     for (const el of els) el.classList.remove('d-hide')
   }
 
+  /* isHidden returns true if the specified element is hidden */
+  static isHidden (el) {
+    return el.classList.contains('d-hide')
+  }
+
   /*
    * animate runs the supplied function, which should be a "progress" function
    * accepting one argument. The progress function will be called repeatedly


### PR DESCRIPTION
This PR modifies the code so the order form is hidden while the registration payment has not been confirmed. Instead, a message is shown to communicate the status of the confirmation. See the previews for more info.

The full list of changes:

**Core changes:**
- Adds the dex URL to all `feepayment` notifications. This is particularly useful in this case to determine to either show or not the confirmation message in the current market.
- The registration update notification uses now the `regupdated` subject.
- Successful registration note uses now the `regcompleted` subject. So it server to multiple purposes in the frontend side. See 'Site changes' for more info. 
- Refresh the user after completed registration.

**Site changes:**
- ~Added an override handler in the app.js which enables the overriding of notifications subject. This is useful to have a notification serving multiple purposes, such as the 'regcompleted' in this case where it is both displayed in the notifications dropdown and it is used to display the order form once the registration payment has been successful.~
- The ~market~ app page now handles `feepayment` notifications and update the exchanges confirmations as well the `feePending` value.
- Hide 'order form' and display the 'registration status' while the fee payment has not been confirmed. Once it is confirmed, a success message is shown for 5 seconds and the order form is set as visible again.


**UI Preview:**

![Screenshot 2020-05-08 at 12 34 18](https://user-images.githubusercontent.com/14864439/81497868-a56dc780-92c1-11ea-95cb-7952d3607b34.png)
![Screenshot 2020-05-08 at 12 33 36](https://user-images.githubusercontent.com/14864439/81497870-a69ef480-92c1-11ea-809d-a5adb06083f8.png)
![Screenshot 2020-05-08 at 12 33 09](https://user-images.githubusercontent.com/14864439/81497874-a999e500-92c1-11ea-976e-2c33890c5b5f.png)


closes #337 