### PR TITLE
dex/order: eliminate uid string cache in Prefix

### DIFF
--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -277,8 +277,7 @@ type Prefix struct {
 	ServerTime time.Time
 	Commit     Commitment
 
-	id  *OrderID // cache of the order's OrderID
-	uid string   // cache of the order's UID
+	id *OrderID // cache of the order's OrderID
 }
 
 // P is an alias for Prefix. Embedding with the alias allows us to define a
@@ -308,7 +307,7 @@ func (p *Prefix) SetTime(t time.Time) {
 	p.ServerTime = t.UTC()
 	// SetTime should only ever be called once in practice, but in case it is
 	// necessary to restamp the ServerTime, clear any computed OrderID.
-	p.id, p.uid = nil, ""
+	p.id = nil
 }
 
 // User gives the user's account ID.
@@ -507,12 +506,7 @@ func (o *MarketOrder) ID() OrderID {
 
 // UID computes the order ID, returning the string representation.
 func (o *MarketOrder) UID() string {
-	if o.uid != "" {
-		return o.uid
-	}
-	uid := o.ID().String()
-	o.uid = uid
-	return uid
+	return o.ID().String()
 }
 
 // String is the same as UID. It is defined to satisfy Stringer.
@@ -568,12 +562,7 @@ func (o *LimitOrder) ID() OrderID {
 
 // UID computes the order ID, returning the string representation.
 func (o *LimitOrder) UID() string {
-	if o.uid != "" {
-		return o.uid
-	}
-	uid := o.ID().String()
-	o.uid = uid
-	return uid
+	return o.ID().String()
 }
 
 // String is the same as UID. It is defined to satisfy Stringer.
@@ -632,12 +621,7 @@ func (o *CancelOrder) ID() OrderID {
 
 // UID computes the order ID, returning the string representation.
 func (o *CancelOrder) UID() string {
-	if o.uid != "" {
-		return o.uid
-	}
-	uid := o.ID().String()
-	o.uid = uid
-	return uid
+	return o.ID().String()
 }
 
 // Trade returns a pointer to the orders embedded Trade.


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/356.

Both `id` and `uid` caching are not thread safe, and the UID is easily
forgotten.  This removes the uid cache field, and modifies the `UID`
methods to always call `OrderID`'s `String` method.

The order ID field still gets computed and cached on first call to `ID()`.

market: stamp the order a little earlier, fixing a possible `Warnf` panic

Regardless of `order.Order` implementation, the server time stamp is
required for order ID computation by definition of the order ID.
However, it is unfortunate that the implementations' ID caching is not
thread safe, requiring the first consumer to request the ID so it gets
written to the `Order`'s (`Prefix` actually) cache before passing the order
to other goroutines that may cause a concurrent write.  We could
consider a mutex, but that is a can of worms as we saw with `order.Trade`.
For now, just avoid concurrent calls to `ID`/`UID`/`String` before the id
is cached in the `Prefix` on the first call.

The first action on receiving the order in `Market.Run` is to time stamp
it with the server time and process it with `Market.processOrder` where
it's ID is computed.