### PR TITLE
testing: Add ltc harness.

### DIFF
--- a/dex/testing/ltc/README.md
+++ b/dex/testing/ltc/README.md
@@ -1,0 +1,52 @@
+# LTC Simnet Test Harness
+
+You must have `litecoind` and `litecoin-cli` in `PATH` to use the harness.
+
+The harness script will create three connected regnet nodes and wallets, and
+then mine some blocks and send some LTC around. The result is a set of wallets
+named **alpha**, **beta**, and **gamma**, each with slightly different
+properties.
+
+**Beta** is purely a mining node/wallet and has never sent a transaction. Beta
+does have some mature coinbase transaction outputs to spend.
+
+**Alpha** is also a mining node/wallet. Unlike beta, alpha has sent some LTC
+so has some change outputs that are not coinbase and have varying number of
+confirmations.
+
+**Gamma** is another wallet on the alpha node. Gamma is encrypted, so requires
+unlocking for sensitive operations. Gamma has no coinbase-spending outputs,
+but has a number of UTXOs of varying size and confirmation count.
+**The gamma wallet password is "abc"**.
+
+## Harness control scripts
+
+The `./harness.sh` script will drop you into a tmux window in a directory
+called `harness-ctl`. Inside of this directory are a number of scripts to
+allow you to perform RPC calls against each wallet.
+
+`./alpha`, `./beta`, and `./gamma` are just `litecoin-cli` configured for their
+respective wallets.
+Try `./gamma getbalance`, for example.
+
+`./reorg` will step through a script that causes the alpha node to undergo a
+1-deep reorganization.
+
+`./quit` shuts down the nodes and closes the tmux session.
+
+## Dev Stuff
+
+If things aren't looking right, you may need to look at the node windows to
+see errors. In tmux, you can navigate between windows by typing `Ctrl+b` and
+then the window number. The window numbers are listed at the bottom
+of the tmux window. `Ctrl+b` followed by the number `0`, for example, will
+change to the alpha node window. Examining the node output to look for errors
+is usually a good first debugging step.
+
+An unfortunate issue that will pop up if you're fiddling with the script is
+zombie litecoind processes preventing the harness nodes from binding to the
+specified ports. You'll have to manually hunt down the zombie PIDs and `kill`
+them if this happens.
+
+Don't forget that there may be tests that rely on the existing script's
+specifics to function correctly. Changes must be tested throughout dcrdex.

--- a/dex/testing/ltc/harness.sh
+++ b/dex/testing/ltc/harness.sh
@@ -1,0 +1,226 @@
+#!/bin/sh
+# Tmux script that sets up a simnet harness.
+set -e
+#set -x # for verbose output
+SESSION="ltc-harness"
+NODES_ROOT=~/dextest/ltc
+RPC_USER="user"
+RPC_PASS="pass"
+ALPHA_LISTEN_PORT="20585"
+BETA_LISTEN_PORT="20586"
+ALPHA_RPC_PORT="20566"
+BETA_RPC_PORT="20567"
+ALPHA_WALLET_SEED="cMndqchcXSCUQDDZQSKU2cUHbPb5UfFL9afspxsBELeE6qx6ac9n"
+BETA_WALLET_SEED="cRHosJjgZ2UWsEAeHYYUFa8Z6viHYXm94GguGtpzMo6qwKBC1DSq"
+# Gamma is a named wallet in the alpha wallet directory.
+GAMMA_WALLET_SEED="cR6gasj1RtB9Qv9j2kVej2XzQmXPmZBcn8KzUmxSSCQoz3TqTNMg"
+GAMMA_WALLET_PASSWORD="abc"
+GAMMA_ADDRESS="2N9Lwbw6DKoNSyTB9xL4e9LXftuPP7XU214"
+ALPHA_MINING_ADDR="2MzNGEV9CBZBptm25CZ4rm2TrKF8gfVU8XA"
+BETA_MINING_ADDR="2NC2bYfZ9GX3gnDZB8CL7pYLytNKMfVxYDX"
+
+if [ -d "${NODES_ROOT}" ]; then
+  rm -R "${NODES_ROOT}"
+fi
+
+ALPHA_DIR="${NODES_ROOT}/alpha"
+BETA_DIR="${NODES_ROOT}/beta"
+HARNESS_DIR="${NODES_ROOT}/harness-ctl"
+
+echo "Writing node config files"
+mkdir -p "${ALPHA_DIR}"
+mkdir -p "${BETA_DIR}"
+mkdir -p "${HARNESS_DIR}"
+
+# Get the absolute path.
+NODES_ROOT=$(cd ~/dextest/ltc; pwd)
+
+ALPHA_CLI_CFG="-rpcwallet= -rpcport=${ALPHA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass"
+
+BETA_CLI_CFG="-rpcwallet= -rpcport=${BETA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass"
+
+GAMMA_CLI_CFG="-rpcwallet=gamma -rpcport=${ALPHA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass"
+
+# WAIT can be used in a send-keys call along with a `wait-for doneltc` command to
+# wait for process termination.
+WAIT="; tmux wait-for -S doneltc"
+
+cd ${NODES_ROOT} && tmux new-session -d -s $SESSION
+
+################################################################################
+# Write config files.
+################################################################################
+
+# These config files aren't actually used here, but can be used by other
+# programs. I would use them here, but litecoind seems to have some issues
+# reading from the file when using regtest.
+
+cat > "${HARNESS_DIR}/alpha.conf" <<EOF
+rpcuser=user
+rpcpassword=pass
+datadir=${ALPHA_DIR}
+txindex=1
+port=${ALPHA_LISTEN_PORT}
+regtest=1
+rpcport=${ALPHA_RPC_PORT}
+EOF
+
+cat > "${HARNESS_DIR}/beta.conf" <<EOF
+rpcuser=user
+rpcpassword=pass
+datadir=${BETA_DIR}
+txindex=1
+regtest=1
+rpcport=${BETA_RPC_PORT}
+EOF
+
+################################################################################
+# Start the alpha node.
+################################################################################
+
+tmux rename-window -t $SESSION:0 'alpha'
+tmux send-keys -t $SESSION:0 "cd ${ALPHA_DIR}" C-m
+echo "Starting simnet alpha node"
+tmux send-keys -t $SESSION:0 "litecoind -rpcuser=user -rpcpassword=pass \
+  -rpcport=${ALPHA_RPC_PORT} -datadir=${ALPHA_DIR} \
+  -txindex=1 -regtest=1 -port=${ALPHA_LISTEN_PORT}; tmux wait-for -S alphaltc" C-m
+sleep 3
+
+################################################################################
+# Setup the beta node.
+################################################################################
+
+tmux new-window -t $SESSION:1 -n 'beta'
+tmux send-keys -t $SESSION:1 "cd ${BETA_DIR}" C-m
+
+echo "Starting simnet beta node"
+tmux send-keys -t $SESSION:1 "litecoind -rpcuser=user -rpcpassword=pass \
+  -rpcport=${BETA_RPC_PORT} -datadir=${BETA_DIR} -txindex=1 -regtest=1 \
+  -port=${BETA_LISTEN_PORT}; tmux wait-for -S betaltc" C-m
+sleep 3
+
+################################################################################
+# Setup the harness-ctl directory
+################################################################################
+
+tmux new-window -t $SESSION:2 -n 'harness-ctl'
+tmux send-keys -t $SESSION:2 "cd ${HARNESS_DIR}" C-m
+sleep 1
+
+cd ${HARNESS_DIR}
+
+cat > "./alpha" <<EOF
+#!/bin/sh
+litecoin-cli ${ALPHA_CLI_CFG} "\$@"
+EOF
+chmod +x "./alpha"
+
+cat > "./mine-alpha" <<EOF
+#!/bin/sh
+litecoin-cli ${ALPHA_CLI_CFG} generatetoaddress \$1 ${ALPHA_MINING_ADDR}
+EOF
+chmod +x "./mine-alpha"
+
+cat > "./gamma" <<EOF
+#!/bin/sh
+litecoin-cli ${GAMMA_CLI_CFG} "\$@"
+EOF
+chmod +x "./gamma"
+
+cat > "./beta" <<EOF
+#!/bin/sh
+litecoin-cli ${BETA_CLI_CFG} "\$@"
+EOF
+chmod +x "./beta"
+
+cat > "./mine-beta" <<EOF
+#!/bin/sh
+litecoin-cli ${BETA_CLI_CFG} generatetoaddress \$1 ${BETA_MINING_ADDR}
+EOF
+chmod +x "./mine-beta"
+
+cat > "./reorg" <<EOF
+#!/bin/sh
+set -x
+echo "Disconnecting beta from alpha"
+sleep 1
+./beta disconnectnode 127.0.0.1:${ALPHA_LISTEN_PORT}
+echo "Mining a block on alpha"
+sleep 1
+./mine-alpha 1
+echo "Mining 3 blocks on beta"
+./mine-beta 3
+sleep 2
+echo "Reconnecting beta to alpha"
+./beta addnode 127.0.0.1:${ALPHA_LISTEN_PORT} onetry
+sleep 2
+EOF
+chmod +x "./reorg"
+
+cat > "${HARNESS_DIR}/quit" <<EOF
+#!/bin/sh
+tmux send-keys -t $SESSION:0 C-c
+tmux send-keys -t $SESSION:1 C-c
+tmux wait-for alphaltc
+tmux wait-for betaltc
+# seppuku
+tmux kill-session
+EOF
+chmod +x "${HARNESS_DIR}/quit"
+
+tmux send-keys -t $SESSION:2 "./beta addnode 127.0.0.1:${ALPHA_LISTEN_PORT} add${WAIT}" C-m\; wait-for doneltc
+# This timeout is apparently critical. Give the nodes time to sync.
+sleep 1
+
+echo "Generating the genesis block"
+tmux send-keys -t $SESSION:2 "./alpha generatetoaddress 1 ${ALPHA_MINING_ADDR}${WAIT}" C-m\; wait-for doneltc
+sleep 1
+
+#################################################################################
+# Setup the alpha wallet
+################################################################################
+
+echo "Setting private key for alpha"
+tmux send-keys -t $SESSION:2 "./alpha sethdseed true ${ALPHA_WALLET_SEED}${WAIT}" C-m\; wait-for doneltc
+tmux send-keys -t $SESSION:2 "./alpha getnewaddress${WAIT}" C-m\; wait-for doneltc
+tmux send-keys -t $SESSION:2 "./alpha getnewaddress \"\" \"legacy\"${WAIT}" C-m\; wait-for doneltc
+echo "Generating 30 blocks for alpha"
+tmux send-keys -t $SESSION:2 "./alpha generatetoaddress 30 ${ALPHA_MINING_ADDR}${WAIT}" C-m\; wait-for doneltc
+
+#################################################################################
+# Setup the beta wallet
+################################################################################
+
+echo "Setting private key for beta"
+tmux send-keys -t $SESSION:2 "./beta sethdseed true ${BETA_WALLET_SEED}${WAIT}" C-m\; wait-for doneltc
+tmux send-keys -t $SESSION:2 "./beta getnewaddress${WAIT}" C-m\; wait-for doneltc
+tmux send-keys -t $SESSION:2 "./beta getnewaddress \"\" \"legacy\"${WAIT}" C-m\; wait-for doneltc
+echo "Generating 110 blocks for beta"
+tmux send-keys -t $SESSION:2 "./beta generatetoaddress 110 ${BETA_MINING_ADDR}${WAIT}" C-m\; wait-for doneltc
+
+################################################################################
+# Setup the gamma wallet
+################################################################################
+
+# Create  wallet, encrypt it, and send it some litecoin, mining some blocks too.
+echo "Creating the gamma wallet"
+tmux send-keys -t $SESSION:2 "./alpha createwallet gamma${WAIT}" C-m\; wait-for doneltc
+tmux send-keys -t $SESSION:2 "./gamma sethdseed true ${GAMMA_WALLET_SEED}${WAIT}" C-m\; wait-for doneltc
+tmux send-keys -t $SESSION:2 "./gamma getnewaddress${WAIT}" C-m\; wait-for doneltc
+tmux send-keys -t $SESSION:2 "./gamma getnewaddress \"\" \"legacy\"${WAIT}" C-m\; wait-for doneltc
+echo "Encrypting the gamma wallet (may take a minute)"
+tmux send-keys -t $SESSION:2 "./gamma encryptwallet ${GAMMA_WALLET_PASSWORD}${WAIT}" C-m\; wait-for doneltc
+echo "Restarting alpha/gamma wallets."
+tmux send-keys -t $SESSION:0 "litecoind -rpcuser=user -rpcpassword=pass \
+  -rpcport=${ALPHA_RPC_PORT} -datadir=${ALPHA_DIR} \
+  -txindex=1 -regtest=1 -port=${ALPHA_LISTEN_PORT}; tmux wait-for -S alphaltc" C-m
+sleep 3
+tmux send-keys -t $SESSION:2 "./alpha loadwallet gamma${WAIT}" C-m\; wait-for doneltc
+echo "Sending 84 BTC to gamma in 8 blocks"
+for i in 10 18 5 7 1 15 3 25
+do
+  tmux send-keys -t $SESSION:2 "./alpha sendtoaddress ${GAMMA_ADDRESS} ${i}${WAIT}" C-m\; wait-for doneltc
+  tmux send-keys -t $SESSION:2 "./mine-alpha 1${WAIT}" C-m\; wait-for doneltc
+done
+
+tmux attach-session -t $SESSION


### PR DESCRIPTION
Almost an exact copy of the btc harness. The only difference is that the
ltc node shuts down after encrypting a wallet and must be restarted.

Using litecoin v0.17.1