### PR TITLE
market,swap,asset: verify funding of unfilled orders in NewMarket

### DIFF
--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -264,12 +264,6 @@ func (dcr *Backend) VerifyUnspentCoin(coinID []byte) (label string, err error) {
 		err = asset.CoinNotFoundError
 		return
 	}
-	// coin = &basicUTXO{
-	// 	backend: dcr,
-	// 	value:   uint64(txOut.Value * btcToSatoshi),
-	// 	txHash:  *txHash,
-	// 	vout:    vout,
-	// }
 	return fmt.Sprintf("%s:%d", txHash.String(), vout), nil
 }
 

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -257,7 +257,7 @@ func (dcr *Backend) VerifyUnspentCoin(coinID []byte) (label string, err error) {
 	}
 	txOut, err := dcr.node.GetTxOut(txHash, vout, true)
 	if err != nil {
-		err = asset.RPCError(fmt.Errorf("GetTxOut (%s:%d): %v", txHash.String(), vout, err))
+		err = fmt.Errorf("GetTxOut (%s:%d): %v", txHash.String(), vout, err)
 		return
 	}
 	if txOut == nil {

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -249,22 +249,19 @@ func (btc *Backend) ValidateContract(contract []byte) error {
 // VerifyUnspentCoin attempts to verify a coin ID by decoding the coin ID and
 // retrieving the corresponding UTXO. If the coin is not found or no longer
 // unspent, an asset.CoinNotFoundError is returned.
-func (dcr *Backend) VerifyUnspentCoin(coinID []byte) (label string, err error) {
-	txHash, vout, errCoin := decodeCoinID(coinID)
-	if errCoin != nil {
-		err = fmt.Errorf("error decoding coin ID %x: %v", coinID, errCoin)
-		return
+func (dcr *Backend) VerifyUnspentCoin(coinID []byte) error {
+	txHash, vout, err := decodeCoinID(coinID)
+	if err != nil {
+		return fmt.Errorf("error decoding coin ID %x: %v", coinID, err)
 	}
 	txOut, err := dcr.node.GetTxOut(txHash, vout, true)
 	if err != nil {
-		err = fmt.Errorf("GetTxOut (%s:%d): %v", txHash.String(), vout, err)
-		return
+		return fmt.Errorf("GetTxOut (%s:%d): %v", txHash.String(), vout, err)
 	}
 	if txOut == nil {
-		err = asset.CoinNotFoundError
-		return
+		return asset.CoinNotFoundError
 	}
-	return fmt.Sprintf("%s:%d", txHash.String(), vout), nil
+	return nil
 }
 
 // BlockChannel creates and returns a new channel on which to receive block

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -44,9 +44,14 @@ type Backend interface {
 	// ValidateContract ensures that the swap contract is constructed properly
 	// for the asset.
 	ValidateContract(contract []byte) error
+	// VerifyUnspentCoin attempts to verify a coin ID by decoding the coin ID
+	// and retrieving the corresponding Coin. If the coin is not found or no
+	// longer unspent, an asset.CoinNotFoundError is returned. Use FundingCoin
+	// for more UTXO data.
+	VerifyUnspentCoin(coinID []byte) (label string, err error)
 }
 
-// Coin represents a transaction input or ouptut.
+// Coin represents a transaction input or output.
 type Coin interface {
 	// Confirmations returns the number of confirmations for a Coin's transaction.
 	// Because a Coin can become invalid after once being considered valid, this
@@ -97,6 +102,9 @@ type BlockUpdate struct {
 	Err   error
 	Reorg bool
 }
+
+// RPCError is an error type used for unexpected backend RPC failures.
+type RPCError error
 
 // ConnectionError error should be sent over the block update channel if a
 // connection error is detected by the Backend.

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -48,7 +48,7 @@ type Backend interface {
 	// and retrieving the corresponding Coin. If the coin is not found or no
 	// longer unspent, an asset.CoinNotFoundError is returned. Use FundingCoin
 	// for more UTXO data.
-	VerifyUnspentCoin(coinID []byte) (label string, err error)
+	VerifyUnspentCoin(coinID []byte) error
 }
 
 // Coin represents a transaction input or output.

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -103,9 +103,6 @@ type BlockUpdate struct {
 	Reorg bool
 }
 
-// RPCError is an error type used for unexpected backend RPC failures.
-type RPCError error
-
 // ConnectionError error should be sent over the block update channel if a
 // connection error is detected by the Backend.
 type ConnectionError error

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -267,22 +267,19 @@ func (dcr *Backend) CheckAddress(addr string) bool {
 // VerifyUnspentCoin attempts to verify a coin ID by decoding the coin ID and
 // retrieving the corresponding UTXO. If the coin is not found or no longer
 // unspent, an asset.CoinNotFoundError is returned.
-func (dcr *Backend) VerifyUnspentCoin(coinID []byte) (label string, err error) {
-	txHash, vout, errCoin := decodeCoinID(coinID)
-	if errCoin != nil {
-		err = fmt.Errorf("error decoding coin ID %x: %v", coinID, errCoin)
-		return
+func (dcr *Backend) VerifyUnspentCoin(coinID []byte) error {
+	txHash, vout, err := decodeCoinID(coinID)
+	if err != nil {
+		return fmt.Errorf("error decoding coin ID %x: %v", coinID, err)
 	}
 	txOut, err := dcr.node.GetTxOut(txHash, vout, true)
 	if err != nil {
-		err = fmt.Errorf("GetTxOut (%s:%d): %v", txHash.String(), vout, err)
-		return
+		return fmt.Errorf("GetTxOut (%s:%d): %v", txHash.String(), vout, err)
 	}
 	if txOut == nil {
-		err = asset.CoinNotFoundError
-		return
+		return asset.CoinNotFoundError
 	}
-	return fmt.Sprintf("%s:%d", txHash.String(), vout), nil
+	return nil
 }
 
 // UnspentCoinDetails gets the recipient address, value, and confirmations of

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -282,12 +282,6 @@ func (dcr *Backend) VerifyUnspentCoin(coinID []byte) (label string, err error) {
 		err = asset.CoinNotFoundError
 		return
 	}
-	// coin = &basicUTXO{
-	// 	backend: dcr,
-	// 	value:   toAtoms(txOut.Value),
-	// 	txHash:  *txHash,
-	// 	vout:    vout,
-	// }
 	return fmt.Sprintf("%s:%d", txHash.String(), vout), nil
 }
 

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -275,7 +275,7 @@ func (dcr *Backend) VerifyUnspentCoin(coinID []byte) (label string, err error) {
 	}
 	txOut, err := dcr.node.GetTxOut(txHash, vout, true)
 	if err != nil {
-		err = asset.RPCError(fmt.Errorf("GetTxOut (%s:%d): %v", txHash.String(), vout, err))
+		err = fmt.Errorf("GetTxOut (%s:%d): %v", txHash.String(), vout, err)
 		return
 	}
 	if txOut == nil {

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -264,6 +264,33 @@ func (dcr *Backend) CheckAddress(addr string) bool {
 	return err == nil
 }
 
+// VerifyUnspentCoin attempts to verify a coin ID by decoding the coin ID and
+// retrieving the corresponding UTXO. If the coin is not found or no longer
+// unspent, an asset.CoinNotFoundError is returned.
+func (dcr *Backend) VerifyUnspentCoin(coinID []byte) (label string, err error) {
+	txHash, vout, errCoin := decodeCoinID(coinID)
+	if errCoin != nil {
+		err = fmt.Errorf("error decoding coin ID %x: %v", coinID, errCoin)
+		return
+	}
+	txOut, err := dcr.node.GetTxOut(txHash, vout, true)
+	if err != nil {
+		err = asset.RPCError(fmt.Errorf("GetTxOut (%s:%d): %v", txHash.String(), vout, err))
+		return
+	}
+	if txOut == nil {
+		err = asset.CoinNotFoundError
+		return
+	}
+	// coin = &basicUTXO{
+	// 	backend: dcr,
+	// 	value:   toAtoms(txOut.Value),
+	// 	txHash:  *txHash,
+	// 	vout:    vout,
+	// }
+	return fmt.Sprintf("%s:%d", txHash.String(), vout), nil
+}
+
 // UnspentCoinDetails gets the recipient address, value, and confirmations of
 // unspent coins. For DCR, this corresponds to a UTXO. If the utxo does not
 // exist or has a pubkey script of the wrong type, an error will be returned.

--- a/server/coinlock/coinlocker_test.go
+++ b/server/coinlock/coinlocker_test.go
@@ -209,7 +209,7 @@ func Test_bookLocker_LockCoins(t *testing.T) {
 		t.Errorf("swapLock indicated coins were locked that should have been unlocked")
 	}
 
-	// Attempt relock of the all of the already-locked coins.
+	// Attempt relock of the already-locked coins.
 	delete(coinMap, oid)
 	failed := bookLock.LockCoins(coinMap)
 	if len(failed) != len(coinMap) {

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -172,8 +172,10 @@ ordersLoop:
 					"Revoking the order.", coin, lo)
 			} else {
 				// other failure (coinID decode, RPC, etc.)
-				log.Errorf("Unexpected error checking coinID %v for order %v: %v. "+
-					"Revoking the order.", lo.Coins[i], lo, err)
+				return nil, fmt.Errorf("unexpected error checking coinID %v for order %v: %v",
+					lo.Coins[i], lo, err)
+				// NOTE: This does not revoke orders from storage since this is
+				// likely to be a configuration or node issue.
 			}
 
 			delete(bookOrdersByID, id)

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -52,7 +52,7 @@ type Swapper interface {
 	LockCoins(asset uint32, coins map[order.OrderID][]order.CoinID)
 	LockOrdersCoins(orders []order.Order)
 	TxMonitored(user account.AccountID, asset uint32, txid string) bool
-	CheckUnspent(asset uint32, coinID []byte) (string, error)
+	CheckUnspent(asset uint32, coinID []byte) error
 }
 
 // Market is the market manager. It should not be overly involved with details
@@ -160,13 +160,14 @@ ordersLoop:
 			assetID = base
 		}
 		for i := range lo.Coins {
-			coin, err := swapper.CheckUnspent(assetID, lo.Coins[i])
+			err := swapper.CheckUnspent(assetID, lo.Coins[i])
 			if err == nil {
 				continue
 			}
 
 			if errors.Is(err, asset.CoinNotFoundError) {
 				// spent, exclude this order
+				coin, _ := asset.DecodeCoinID(dex.BipIDSymbol(assetID), lo.Coins[i]) // coin decoding succeeded in CheckUnspent
 				log.Warnf("Coin %s not unspent for unfilled order %v. "+
 					"Revoking the order.", coin, lo)
 			} else {

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -103,8 +103,6 @@ type Market struct {
 	swapper Swapper
 	auth    AuthManager
 
-	// checkUnspentBase  func(coinID []byte) (val uint64, confs int64, err error)
-	// checkUnspentQuote func(coinID []byte) (val uint64, confs int64, err error)
 	coinLockerBase  coinlock.CoinLocker
 	coinLockerQuote coinlock.CoinLocker
 
@@ -144,27 +142,15 @@ ordersLoop:
 		if lo.FillAmt > 0 {
 			// Order already matched with another trade, so it is expected that
 			// the funding coins are spent in a swap.
-
+			//
 			// In general, our position is that the server is not ultimately
 			// responsible for verifying that all orders have locked coins since
 			// the client will be penalized if they cannot complete the swap.
 			// The least the server can do is ensure funding coins for NEW
-			// orders are unspent and owned by the user, but there are other
-			// possibilities:
+			// orders are unspent and owned by the user.
 
-			// TODO 1: We may consider following the chain of dex contracts and
-			// redeems to ensure that lo.Remaining() in value is unspent, or at
-			// least check that the initial coins were spent in a dex monitored
-			// tx with TxMonitored(..., spendingTx).
-
-			// TODO 2: The swapper could notify market when a redeem output is
-			// created so it can lock those coins if the order is still on the
-			// book (e.g. signal{orderID, redeemOutCoins} -> market). Otherwise
-			// the user could place new orders with these coins even though they
-			// are implicitly funding the still booked order with a remaining
-			// amount.
-
-			// On to next order. Do not bother locking coins that are spent.
+			// On to the next order. Do not lock coins that are spent or should
+			// be spent in a swap contract.
 			continue
 		}
 

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -297,11 +297,12 @@ func tNewBackend() *TBackend {
 }
 
 func (b *TBackend) utxo(coinID []byte) (*tUTXO, error) {
-	v := b.utxos[hex.EncodeToString(coinID)]
+	str := hex.EncodeToString(coinID)
+	v := b.utxos[str]
 	if v == 0 {
 		return nil, fmt.Errorf("no utxo")
 	}
-	return &tUTXO{val: v}, b.utxoErr
+	return &tUTXO{val: v, decoded: str}, b.utxoErr
 }
 
 func (b *TBackend) Contract(coinID, redeemScript []byte) (asset.Contract, error) {
@@ -328,9 +329,17 @@ func (b *TBackend) ValidateContract(contract []byte) error {
 }
 
 func (b *TBackend) ValidateSecret(secret, contract []byte) bool { return true }
+func (b *TBackend) VerifyUnspentCoin(coinID []byte) (label string, err error) {
+	utxo, err := b.utxo(coinID)
+	if err != nil {
+		return "", err
+	}
+	return utxo.String(), nil
+}
 
 type tUTXO struct {
-	val uint64
+	val     uint64
+	decoded string
 }
 
 var utxoAuthErr error
@@ -345,7 +354,7 @@ func (u *tUTXO) Address() string                 { return "" }
 func (u *tUTXO) SpendSize() uint32               { return dummySize }
 func (u *tUTXO) ID() []byte                      { return nil }
 func (u *tUTXO) TxID() string                    { return "" }
-func (u *tUTXO) String() string                  { return "" }
+func (u *tUTXO) String() string                  { return u.decoded }
 func (u *tUTXO) SpendsCoin([]byte) (bool, error) { return true, nil }
 func (u *tUTXO) Value() uint64                   { return u.val }
 func (u *tUTXO) FeeRate() uint64                 { return 0 }

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -329,12 +329,9 @@ func (b *TBackend) ValidateContract(contract []byte) error {
 }
 
 func (b *TBackend) ValidateSecret(secret, contract []byte) bool { return true }
-func (b *TBackend) VerifyUnspentCoin(coinID []byte) (label string, err error) {
-	utxo, err := b.utxo(coinID)
-	if err != nil {
-		return "", err
-	}
-	return utxo.String(), nil
+func (b *TBackend) VerifyUnspentCoin(coinID []byte) error {
+	_, err := b.utxo(coinID)
+	return err
 }
 
 type tUTXO struct {

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1657,12 +1657,11 @@ func (s *Swapper) processMatchAcks(user account.AccountID, msg *msgjson.Message,
 
 // CheckUnspent attempts to verify a coin ID for a given asset by retrieving the
 // corresponding asset.Coin. If the coin is not found or spent, an
-// asset.CoinNotFoundError is returned. On success, a human-readable
-// representation of the coin ID is returned.
-func (s *Swapper) CheckUnspent(asset uint32, coinID []byte) (string, error) {
+// asset.CoinNotFoundError is returned.
+func (s *Swapper) CheckUnspent(asset uint32, coinID []byte) error {
 	backend := s.coins[asset]
 	if backend == nil {
-		return "", fmt.Errorf("unknown asset %d", asset)
+		return fmt.Errorf("unknown asset %d", asset)
 	}
 
 	return backend.Backend.VerifyUnspentCoin(coinID)

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1655,6 +1655,18 @@ func (s *Swapper) processMatchAcks(user account.AccountID, msg *msgjson.Message,
 	}
 }
 
+// CheckUnspent attempts to verify a coin ID for a given asset by decoding the
+// coin ID and retrieving the corresponding asset.Coin. If the coin is not found
+// or spent, an asset.CoinNotFoundError is returned
+func (s *Swapper) CheckUnspent(asset uint32, coinID []byte) (string, error) {
+	backend := s.coins[asset]
+	if backend == nil {
+		return "", fmt.Errorf("unknown asset %d", asset)
+	}
+
+	return backend.Backend.VerifyUnspentCoin(coinID)
+}
+
 // LockOrdersCoins locks the backing coins for the provided orders.
 func (s *Swapper) LockOrdersCoins(orders []order.Order) {
 	// Separate orders according to the asset of their locked coins.

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1655,9 +1655,10 @@ func (s *Swapper) processMatchAcks(user account.AccountID, msg *msgjson.Message,
 	}
 }
 
-// CheckUnspent attempts to verify a coin ID for a given asset by decoding the
-// coin ID and retrieving the corresponding asset.Coin. If the coin is not found
-// or spent, an asset.CoinNotFoundError is returned
+// CheckUnspent attempts to verify a coin ID for a given asset by retrieving the
+// corresponding asset.Coin. If the coin is not found or spent, an
+// asset.CoinNotFoundError is returned. On success, a human-readable
+// representation of the coin ID is returned.
 func (s *Swapper) CheckUnspent(asset uint32, coinID []byte) (string, error) {
 	backend := s.coins[asset]
 	if backend == nil {

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -295,12 +295,12 @@ func (a *TAsset) ValidateCoinID(coinID []byte) (string, error) {
 func (a *TAsset) ValidateContract(contract []byte) error {
 	return nil
 }
-func (a *TAsset) BlockChannel(size int) <-chan *asset.BlockUpdate           { return a.bChan }
-func (a *TAsset) InitTxSize() uint32                                        { return 100 }
-func (a *TAsset) CheckAddress(string) bool                                  { return true }
-func (a *TAsset) Run(context.Context)                                       {}
-func (a *TAsset) ValidateSecret(secret, contract []byte) bool               { return true }
-func (a *TAsset) VerifyUnspentCoin(coinID []byte) (label string, err error) { return "", nil }
+func (a *TAsset) BlockChannel(size int) <-chan *asset.BlockUpdate { return a.bChan }
+func (a *TAsset) InitTxSize() uint32                              { return 100 }
+func (a *TAsset) CheckAddress(string) bool                        { return true }
+func (a *TAsset) Run(context.Context)                             {}
+func (a *TAsset) ValidateSecret(secret, contract []byte) bool     { return true }
+func (a *TAsset) VerifyUnspentCoin(coinID []byte) error           { return nil }
 
 func (a *TAsset) setContractErr(err error) {
 	a.mtx.Lock()

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -295,11 +295,12 @@ func (a *TAsset) ValidateCoinID(coinID []byte) (string, error) {
 func (a *TAsset) ValidateContract(contract []byte) error {
 	return nil
 }
-func (a *TAsset) BlockChannel(size int) <-chan *asset.BlockUpdate { return a.bChan }
-func (a *TAsset) InitTxSize() uint32                              { return 100 }
-func (a *TAsset) CheckAddress(string) bool                        { return true }
-func (a *TAsset) Run(context.Context)                             {}
-func (a *TAsset) ValidateSecret(secret, contract []byte) bool     { return true }
+func (a *TAsset) BlockChannel(size int) <-chan *asset.BlockUpdate           { return a.bChan }
+func (a *TAsset) InitTxSize() uint32                                        { return 100 }
+func (a *TAsset) CheckAddress(string) bool                                  { return true }
+func (a *TAsset) Run(context.Context)                                       {}
+func (a *TAsset) ValidateSecret(secret, contract []byte) bool               { return true }
+func (a *TAsset) VerifyUnspentCoin(coinID []byte) (label string, err error) { return "", nil }
 
 func (a *TAsset) setContractErr(err error) {
 	a.mtx.Lock()


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/363

The Market constructor loads all book orders from the DB and rebuilds the book. This PR checks each order's funding coins to be sure they are either unspent or involved in a dex monitored trade. As an optimization, if the filled amount is zero and the coins are spent, the monitored trade check is skipped and the order is not included in the rebuilt book.

This also will prevent any orders found in epoch status on startup from having their coins locked, as these orders are effectively dead.  Note that such dead epoch status orders were being created by a bug fixed in https://github.com/decred/dcrdex/pull/472, commit d4bcf4f810ca5c37df091ded2ab5907ee63d9a48.
