### PR TITLE
multi: book feed: update remaining quantity of partially filled book order

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -291,8 +291,8 @@ func handleBookOrderMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) error 
 		return err
 	}
 	book.send(&BookUpdate{
-		Action: msg.Route,
-		Order:  minifyOrder(note.OrderID, &note.TradeNote, 0),
+		Action:  msg.Route,
+		Payload: minifyOrder(note.OrderID, &note.TradeNote, 0),
 	})
 	return nil
 }
@@ -319,8 +319,8 @@ func handleUnbookOrderMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) erro
 		return err
 	}
 	book.send(&BookUpdate{
-		Action: msg.Route,
-		Order:  &MiniOrder{Token: token(note.OrderID)},
+		Action:  msg.Route,
+		Payload: &MiniOrder{Token: token(note.OrderID)},
 	})
 
 	return nil
@@ -349,7 +349,7 @@ func handleUpdateRemainingMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) 
 	}
 	book.send(&BookUpdate{
 		Action: msg.Route,
-		Order: &MiniOrder{
+		Payload: &RemainingUpdate{
 			Token: token(note.OrderID),
 			Qty:   float64(note.Remaining) / conversionFactor,
 		},
@@ -383,8 +383,8 @@ func handleEpochOrderMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error
 	}
 	// Send a mini-order for book updates.
 	book.send(&BookUpdate{
-		Action: msg.Route,
-		Order:  minifyOrder(note.OrderID, &note.TradeNote, note.Epoch),
+		Action:  msg.Route,
+		Payload: minifyOrder(note.OrderID, &note.TradeNote, note.Epoch),
 	})
 
 	return nil

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2081,10 +2081,11 @@ var reqHandlers = map[string]routeHandler{
 }
 
 var noteHandlers = map[string]routeHandler{
-	msgjson.MatchProofRoute:  handleMatchProofMsg,
-	msgjson.BookOrderRoute:   handleBookOrderMsg,
-	msgjson.EpochOrderRoute:  handleEpochOrderMsg,
-	msgjson.UnbookOrderRoute: handleUnbookOrderMsg,
+	msgjson.MatchProofRoute:      handleMatchProofMsg,
+	msgjson.BookOrderRoute:       handleBookOrderMsg,
+	msgjson.EpochOrderRoute:      handleEpochOrderMsg,
+	msgjson.UnbookOrderRoute:     handleUnbookOrderMsg,
+	msgjson.UpdateRemainingRoute: handleUpdateRemainingMsg,
 }
 
 // listen monitors the DEX websocket connection for server requests and

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -588,7 +588,7 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 		return errs.add("error sending swap transaction: %v", err)
 	}
 	t.change = change
-	t.coins[change.String()] = change
+	t.coins[hex.EncodeToString(change.ID())] = change
 	t.metaData.ChangeCoin = []byte(change.ID())
 	t.db.SetChangeCoin(t.ID(), t.metaData.ChangeCoin)
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -206,6 +206,12 @@ type MiniOrder struct {
 	Token string  `json:"token"`
 }
 
+// RemainingUpdate is an update to the quantity for an order on the order book.
+type RemainingUpdate struct {
+	Token string  `json:"token"`
+	Qty   float64 `json:"qty"`
+}
+
 // OrderBook represents an order book, which are sorted buys and sells, and
 // unsorted epoch orders.
 type OrderBook struct {
@@ -222,8 +228,8 @@ const (
 
 // BookUpdate is an order book update.
 type BookUpdate struct {
-	Action string     `json:"action"`
-	Order  *MiniOrder `json:"order"`
+	Action  string      `json:"action"`
+	Payload interface{} `json:"payload"`
 }
 
 // dexAccount is the core type to represent the client's account information for

--- a/client/order/bookside.go
+++ b/client/order/bookside.go
@@ -108,9 +108,9 @@ func (d *bookSide) Remove(order *Order) error {
 	return fmt.Errorf("order %s not found", order.OrderID)
 }
 
-// Update updates the remaining quantity for an order. If the order is found
-// it will be returned, else nil.
-func (d *bookSide) Update(oid order.OrderID, remaining uint64) *Order {
+// UpdateRemaining updates the remaining quantity for an order. If the order is
+// found it will be returned, else nil.
+func (d *bookSide) UpdateRemaining(oid order.OrderID, remaining uint64) *Order {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 

--- a/client/order/bookside.go
+++ b/client/order/bookside.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+
+	"decred.org/dcrdex/dex/order"
 )
 
 // OrderPreference reprsents ordering preference for a sort.
@@ -104,6 +106,23 @@ func (d *bookSide) Remove(order *Order) error {
 	}
 
 	return fmt.Errorf("order %s not found", order.OrderID)
+}
+
+// Update updates the remaining quantity for an order. If the order is found
+// it will be returned, else nil.
+func (d *bookSide) Update(oid order.OrderID, remaining uint64) *Order {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+
+	for _, bin := range d.bins {
+		for _, ord := range bin {
+			if ord.OrderID == oid {
+				ord.Quantity = remaining
+				return ord
+			}
+		}
+	}
+	return nil
 }
 
 // orders is all orders for the side, sorted.

--- a/client/order/orderbook.go
+++ b/client/order/orderbook.go
@@ -308,12 +308,12 @@ func (ob *OrderBook) updateRemaining(note *msgjson.UpdateRemainingNote, cached b
 	var oid order.OrderID
 	copy(oid[:], note.OrderID)
 
-	ord := ob.sells.Update(oid, note.Remaining)
+	ord := ob.sells.UpdateRemaining(oid, note.Remaining)
 	if ord != nil {
 		return nil
 	}
 
-	ord = ob.buys.Update(oid, note.Remaining)
+	ord = ob.buys.UpdateRemaining(oid, note.Remaining)
 	if ord != nil {
 		return nil
 	}

--- a/client/order/orderbook.go
+++ b/client/order/orderbook.go
@@ -284,6 +284,8 @@ func (ob *OrderBook) Book(note *msgjson.BookOrderNote) error {
 	return ob.book(note, false)
 }
 
+// updateRemaining is the workhorse of the exported UpdateRemaining function. It
+// allows updating cached and uncached orders.
 func (ob *OrderBook) updateRemaining(note *msgjson.UpdateRemainingNote, cached bool) error {
 	if ob.marketID != note.MarketID {
 		return fmt.Errorf("invalid update_remaining note market id %s", note.MarketID)
@@ -319,6 +321,7 @@ func (ob *OrderBook) updateRemaining(note *msgjson.UpdateRemainingNote, cached b
 	return fmt.Errorf("update_remaining order %s not found", oid)
 }
 
+// UpdateRemaining updates the remaining quantity of a booked order.
 func (ob *OrderBook) UpdateRemaining(note *msgjson.UpdateRemainingNote) error {
 	return ob.updateRemaining(note, false)
 }

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -309,7 +309,7 @@ func (c *TCore) Sync(dex string, base, quote uint32) (*core.OrderBook, *core.Boo
 					side[ord.Token] = ord
 					epochOrder := &core.BookUpdate{
 						Action: msgjson.EpochOrderRoute,
-						Order:  ord,
+						Payload:  ord,
 					}
 					c.trySend(epochOrder)
 					c.epochOrders = append(c.epochOrders, epochOrder)
@@ -586,14 +586,15 @@ out:
 			c.orderMtx.Lock()
 			// Send limit orders as newly booked.
 			for _, o := range c.epochOrders {
-				if (o.Order.Rate > 0) {
-					o.Order.Epoch = 0
+				miniOrder := o.Payload.(*core.MiniOrder)
+				if (miniOrder.Rate > 0) {
+					miniOrder.Epoch = 0
 					o.Action = msgjson.BookOrderRoute
 					c.trySend(o)
-					if (o.Order.Sell) {
-						c.sells[o.Order.Token] = o.Order
+					if (miniOrder.Sell) {
+						c.sells[miniOrder.Token] = miniOrder
 					} else {
-						c.buys[o.Order.Token] = o.Order
+						c.buys[miniOrder.Token] = miniOrder
 					}
 				}
 			}

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -335,7 +335,7 @@ func (c *TCore) Sync(dex string, base, quote uint32) (*core.OrderBook, *core.Boo
 
 					c.trySend(&core.BookUpdate{
 						Action: msgjson.UnbookOrderRoute,
-						Order:  &core.MiniOrder{Token: tkn},
+						Payload:  &core.MiniOrder{Token: tkn},
 					})
 				}
 			case <-ctx.Done():

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -476,7 +476,7 @@ export default class MarketsPage extends BasePage {
 
   /* handleBookOrderRoute is the handler for 'book_order' notifications. */
   handleBookOrderRoute (data) {
-    const order = data.order
+    const order = data.payload
     if (order.rate > 0) this.book.add(order)
     this.addTableOrder(order)
     this.chart.draw()
@@ -484,7 +484,7 @@ export default class MarketsPage extends BasePage {
 
   /* handleUnbookOrderRoute is the handler for 'unbook_order' notifications. */
   handleUnbookOrderRoute (data) {
-    const order = data.order
+    const order = data.payload
     this.book.remove(order.token)
     this.removeTableOrder(order)
     this.chart.draw()
@@ -495,15 +495,15 @@ export default class MarketsPage extends BasePage {
    * notifications.
    */
   handleUpdateRemainingRoute (data) {
-    const order = data.order
-    this.book.updateRemaining(order.token, order.qty)
-    this.updateTableOrder(order)
+    const update = data.payload
+    this.book.updateRemaining(update.token, update.qty)
+    this.updateTableOrder(update)
     this.chart.draw()
   }
 
   /* handleEpochOrderRoute is the handler for 'epoch_order' notifications. */
   handleEpochOrderRoute (data) {
-    const order = data.order
+    const order = data.payload
     if (order.rate > 0) this.book.add(order)
     this.addTableOrder(order)
     this.chart.draw()
@@ -848,13 +848,13 @@ export default class MarketsPage extends BasePage {
   }
 
   /* updateTableOrder looks for the order in the table and updates the qty */
-  updateTableOrder (order) {
-    const token = order.token
+  updateTableOrder (update) {
+    const token = update.token
     for (const tbody of [this.page.sellRows, this.page.buyRows]) {
       for (const tr of Array.from(tbody.children)) {
         if (tr.order.token === token) {
           const td = tr.querySelector('[data-type=qty]')
-          td.innerText = order.qty.toFixed(8)
+          td.innerText = update.qty.toFixed(8)
           return
         }
       }

--- a/client/webserver/site/src/js/orderbook.js
+++ b/client/webserver/site/src/js/orderbook.js
@@ -23,7 +23,7 @@ export default class OrderBook {
     this.removeFromSide(this.buys, token)
   }
 
-  /* removeFromSide remvoes an order from the list of orders. */
+  /* removeFromSide removes an order from the list of orders. */
   removeFromSide (side, token) {
     const [ord, i] = this.findOrder(side, token)
     if (ord) {

--- a/client/webserver/site/src/js/orderbook.js
+++ b/client/webserver/site/src/js/orderbook.js
@@ -25,11 +25,39 @@ export default class OrderBook {
 
   /* removeFromSide remvoes an order from the list of orders. */
   removeFromSide (side, token) {
+    const [ord, i] = this.findOrder(side, token)
+    if (ord) {
+      side.splice(i, 1)
+      return true
+    }
+    return false
+  }
+
+  /* findOrder finds an order in a specified side */
+  findOrder (side, token) {
     for (const i in side) {
       if (side[i].token === token) {
-        side.splice(i, 1)
-        return true
+        return [side[i], i]
       }
+    }
+    return [null, -1]
+  }
+
+  /* updates the remaining quantity of an order. */
+  updateRemaining (token, qty) {
+    if (this.updateRemainingSide(this.sells, token, qty)) return
+    this.updateRemainingSide(this.buys, token, qty)
+  }
+
+  /*
+   * updateRemainingSide looks for the order in the side and updates the
+   * quantity, returning true on success, false if order not found.
+   */
+  updateRemainingSide (side, token, qty) {
+    const ord = this.findOrder(side, token)[0]
+    if (ord) {
+      ord.qty = qty
+      return true
     }
     return false
   }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -108,6 +108,9 @@ const (
 	// EpochOrderRoute is the DEX-originating notification-type message informing
 	// the client about an order added to the epoch queue.
 	EpochOrderRoute = "epoch_order"
+	// UpdateRemainingRoute is the DEX-originating notification-type message that
+	// updates the remaining amount of unfilled quantity on a standing limit order.
+	UpdateRemainingRoute = "update_remaining"
 	// ConnectRoute is a client-originating request-type message seeking
 	// authentication so that the connection can be used for trading.
 	ConnectRoute = "connect"
@@ -683,6 +686,13 @@ type EpochOrderNote struct {
 	OrderType uint8  `json:"otype"`
 	Epoch     uint64 `json:"epoch"`
 	TargetID  Bytes  `json:"target,omitempty"` // omit for cancel orders
+}
+
+// UpdateRemainingNote is the DEX-originating notification-type message
+// informing the client about an update to a booked order's remaining quantity.
+type UpdateRemainingNote struct {
+	OrderNote
+	Remaining uint64 `json:"remaining"`
 }
 
 // OrderBook is the response to a successful OrderBookSubscription.

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -248,7 +248,7 @@ func TestMarkets(t *testing.T) {
 		t.Fatalf("apiMarkets returned code %d, expected %d", w.Code, http.StatusOK)
 	}
 	respBody := w.Body.String()
-	if respBody != fmt.Sprintf("{}\n") {
+	if respBody != "{}\n" {
 		t.Errorf("incorrect response body: %q", respBody)
 	}
 

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -323,7 +323,7 @@ out:
 				route = msgjson.UpdateRemainingRoute
 				lo, ok := sigData.order.(*order.LimitOrder)
 				if !ok {
-					panic("non-limit order received with unbookAction")
+					panic("non-limit order received with updateRemainingAction")
 				}
 				bookNote := book.update(lo)
 				n := &msgjson.UpdateRemainingNote{

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -34,7 +34,7 @@ const (
 	// result in a msgjson.UnbookOrderNote being sent to subscribers.
 	unbookAction
 	// updateRemainingAction means a standling limit order has partially filled
-	// and will result in a msgjson.
+	// and will result in a msgjson.UpdateRemainingNote being sent to subscribers.
 	updateRemainingAction
 	// newEpochAction is an internal signal to the routers main loop that
 	// indicates when a new epoch has opened.

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1371,6 +1371,17 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 		notifyChan <- sig
 	}
 
+	// Send "update_remaining" notifications to order book subscribers.
+	for _, lo := range updates.TradesPartial {
+		notifyChan <- &updateSignal{
+			action: updateRemainingAction,
+			data: sigDataUnbookedOrder{
+				order:    lo,
+				epochIdx: epoch.Epoch,
+			},
+		}
+	}
+
 	// Initiate the swaps.
 	if len(matches) > 0 {
 		log.Debugf("Negotiating %d matches for epoch %d:%d", len(matches),

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1375,7 +1375,7 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 	for _, lo := range updates.TradesPartial {
 		notifyChan <- &updateSignal{
 			action: updateRemainingAction,
-			data: sigDataUnbookedOrder{
+			data: sigDataUpdateRemaining{
 				order:    lo,
 				epochIdx: epoch.Epoch,
 			},

--- a/server/matcher/match.go
+++ b/server/matcher/match.go
@@ -147,9 +147,9 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 
 	updates = new(OrdersUpdated)
 
-	// Store partially filled limit orders in a map to start to avoid duplicate
+	// Store partially filled limit orders in a map to avoid duplicate
 	// entries.
-	partials := make(map[order.OrderID]*order.LimitOrder)
+	partialMap := make(map[order.OrderID]*order.LimitOrder)
 
 	// For each order in the queue, find the best match in the book.
 	for _, q := range queue {
@@ -209,7 +209,7 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 					unbooked = append(unbooked, maker)
 					updates.TradesCompleted = append(updates.TradesCompleted, maker)
 				} else {
-					partials[maker.ID()] = maker
+					partialMap[maker.ID()] = maker
 				}
 			}
 
@@ -262,7 +262,7 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 					unbooked = append(unbooked, maker)
 					updates.TradesCompleted = append(updates.TradesCompleted, maker)
 				} else {
-					partials[maker.ID()] = maker
+					partialMap[maker.ID()] = maker
 				}
 			}
 
@@ -271,11 +271,11 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 
 	}
 
-	for _, partial := range partials {
+	for _, lo := range partialMap {
 		// Ignore orders with zero remainder. An order can be added to the partials
 		// map, but fill on a later order.
-		if partial.Remaining() > 0 {
-			updates.TradesPartial = append(updates.TradesPartial, partial)
+		if lo.Remaining() > 0 {
+			updates.TradesPartial = append(updates.TradesPartial, lo)
 		}
 	}
 

--- a/server/matcher/match.go
+++ b/server/matcher/match.go
@@ -147,6 +147,10 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 
 	updates = new(OrdersUpdated)
 
+	// Store partially filled limit orders in a map to start to avoid duplicate
+	// entries.
+	partials := make(map[order.OrderID]*order.LimitOrder)
+
 	// For each order in the queue, find the best match in the book.
 	for _, q := range queue {
 		if !orderLotSizeOK(q.Order, book.LotSize()) {
@@ -205,7 +209,7 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 					unbooked = append(unbooked, maker)
 					updates.TradesCompleted = append(updates.TradesCompleted, maker)
 				} else {
-					updates.TradesPartial = append(updates.TradesPartial, maker)
+					partials[maker.ID()] = maker
 				}
 			}
 
@@ -258,13 +262,21 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 					unbooked = append(unbooked, maker)
 					updates.TradesCompleted = append(updates.TradesCompleted, maker)
 				} else {
-					updates.TradesPartial = append(updates.TradesPartial, maker)
+					partials[maker.ID()] = maker
 				}
 			}
 
 			// Regardless of remaining amount, market orders never go on the book.
 		}
 
+	}
+
+	for _, partial := range partials {
+		// Ignore orders with zero remainder. An order can be added to the partials
+		// map, but fill on a later order.
+		if partial.Remaining() > 0 {
+			updates.TradesPartial = append(updates.TradesPartial, partial)
+		}
 	}
 
 	return


### PR DESCRIPTION
Introduces a new order book update type, `update_remaining`, which updates the quantity of a booked order. Modifies the `(*Matcher).Match` method to prevent duplicates. Client updates the `OrderBook` and sends a `BookUpdate` notification to websocket subscribers. 

Spec update to follow.