### PR TITLE
client/comms: return descriptive error for ws conn cert issues

### DIFF
--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -223,8 +223,8 @@ func TestWsConn(t *testing.T) {
 	noCertConnMaster := dex.NewConnectionMaster(noCertConn)
 	err = noCertConnMaster.Connect(ctx)
 	noCertConnMaster.Disconnect()
-	if err == nil || !errors.Is(err, ErrInvalidCert) {
-		t.Fatalf("failed to get ErrInvalidCert for no cert connection")
+	if err == nil || !errors.Is(err, ErrCertRequired) {
+		t.Fatalf("failed to get ErrCertRequired for no cert connection")
 	}
 
 	// test invalid cert error

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2090,7 +2090,7 @@ func (c *Core) connectDEX(acctInfo *db.AccountInfo) (*dexConnection, error) {
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Error creating websocket connection for %s: %v", host, err)
+		return nil, err
 	}
 
 	connMaster := dex.NewConnectionMaster(conn)
@@ -2099,7 +2099,7 @@ func (c *Core) connectDEX(acctInfo *db.AccountInfo) (*dexConnection, error) {
 	// auto-reconnect cycle.
 	if err != nil {
 		connMaster.Disconnect()
-		return nil, fmt.Errorf("Error initializing websocket connection: %v", err)
+		return nil, err
 	}
 
 	// Request the market configuration. Disconnect from the DEX server if the

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -21,7 +21,7 @@ func (s *WebServer) apiGetFee(w http.ResponseWriter, r *http.Request) {
 	}
 	fee, err := s.core.GetFee(form.URL, form.Cert)
 	if err != nil {
-		s.writeAPIError(w, "getfee error: %v", err)
+		s.writeAPIError(w, err.Error())
 		return
 	}
 	resp := struct {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -527,7 +527,7 @@ func TestAPIGetFee(t *testing.T) {
 
 	// getFee error
 	tCore.getFeeErr = tErr
-	ensure(`{"ok":false,"msg":"getfee error: test error"}`)
+	ensure(`{"ok":false,"msg":"test error"}`)
 	tCore.getFeeErr = nil
 }
 


### PR DESCRIPTION
Return **`certificate required`** or **`invalid certificate`** error message for cert-related connection issues.
Resolve #225.

_With no cert provided_
<img width="350" alt="Screenshot 2020-05-19 at 10 51 59 PM" src="https://user-images.githubusercontent.com/18400051/82385153-55ad9f80-9a29-11ea-9528-4ca701b9708a.png">

_With invalid cert provided_
<img width="350" alt="Screenshot 2020-05-18 at 9 59 59 PM" src="https://user-images.githubusercontent.com/18400051/82259181-101ea300-9953-11ea-8ad3-253db88e73c7.png">
