### PR TITLE
dcrdex: enable networked PostgreSQL db names and use by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Place the pubkey string into a new DEX configuration file.
 regfeexpub=tpubVWHTkHRefqHptAnBdNcDJ...
 
 # PostgreSQL Credentials
-pgdbname=dcrdex_testnet
 pgpass=dexpass
 ```
 

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -32,7 +32,7 @@ const (
 	defaultMaxLogZips          = 16
 	defaultPGHost              = "127.0.0.1:5432"
 	defaultPGUser              = "dcrdex"
-	defaultPGDBName            = "dcrdex"
+	defaultPGDBName            = "dcrdex_{netname}"
 	defaultDEXPrivKeyFilename  = "sigkey"
 	defaultRPCHost             = "127.0.0.1"
 	defaultRPCPort             = "7232"
@@ -509,6 +509,9 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		}
 		adminSrvAddr = cfg.AdminSrvAddr
 	}
+
+	// If using {netname} then replace it with the network name.
+	cfg.PGDBName = strings.Replace(cfg.PGDBName, "{netname}", network.String(), -1)
 
 	dexCfg := &dexConf{
 		Network:          network,


### PR DESCRIPTION
Resolves #152. Don't forget to `CREATE DATABASE dcrdex_simnet OWNER dcrdex;` and `CREATE DATABASE dcrdex_testnet OWNER dcrdex;`