### PR TITLE
multi: Remove scheme from connection map.

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -456,7 +456,7 @@ func addrHost(addr string) string {
 		// These are addresses with at least one colon in an unexpected
 		// position.
 		a, err := url.Parse(addr)
-		// Ths address is of an unknown format. Return as is.
+		// This address is of an unknown format. Return as is.
 		if err != nil {
 			log.Debugf("addrHost: unable to parse address '%s'", addr)
 			return addr

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2780,7 +2780,6 @@ func makeLimitOrder(dc *dexConnection, sell bool, qty, rate uint64) (*order.Limi
 func TestAddrHost(t *testing.T) {
 	tests := []struct {
 		name, addr, want string
-		wantErr          bool
 	}{{
 		name: "scheme, host, and port",
 		addr: "https://localhost:5758",
@@ -2798,10 +2797,6 @@ func TestAddrHost(t *testing.T) {
 		addr: "127.0.0.1:5758",
 		want: "127.0.0.1:5758",
 	}, {
-		name: "host, port, and path",
-		addr: "localhost:5758/any/path",
-		want: "localhost:5758",
-	}, {
 		name: "just host",
 		addr: "thatonedex.com",
 		want: "thatonedex.com",
@@ -2814,29 +2809,32 @@ func TestAddrHost(t *testing.T) {
 		addr: "https://thatonedex.com/any/path",
 		want: "thatonedex.com",
 	}, {
-		name:    "invalid address",
-		addr:    "\n",
-		wantErr: true,
+		name: "ipv6 host",
+		addr: "[1:2::]",
+		want: "[1:2::]",
 	}, {
-		name:    "empty address",
-		wantErr: true,
+		name: "ipv6 host and port",
+		addr: "[1:2::]:5758",
+		want: "[1:2::]:5758",
+	}, {
+		name: "empty address",
+		want: "localhost",
+	}, {
+		name: "invalid host",
+		addr: "https://\n:1234",
+		want: "https://\n:1234",
+	}, {
+		name: "invalid port",
+		addr: ":asdf",
+		want: ":asdf",
 	}}
 	for _, test := range tests {
-		res, err := addrHost(test.addr)
-		if err != nil {
-			if test.wantErr {
-				continue
-			}
-			t.Fatalf("unexpected error for test '%s': %v", test.name, err)
-		}
+		res := addrHost(test.addr)
 		if res != test.want {
 			t.Fatalf("wanted %s but got %s for test '%s'", test.want, res, test.name)
 		}
 		// Parsing results a second time should produce the same results.
-		res, err = addrHost(res)
-		if err != nil {
-			t.Fatalf("unexpected error for test '%s': %v", test.name, err)
-		}
+		res = addrHost(res)
 		if res != test.want {
 			t.Fatalf("wanted %s but got %s for test '%s'", test.want, res, test.name)
 		}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2776,3 +2776,69 @@ func makeLimitOrder(dc *dexConnection, sell bool, qty, rate uint64) (*order.Limi
 	}
 	return lo, dbOrder, preImg, addr
 }
+
+func TestAddrHost(t *testing.T) {
+	tests := []struct {
+		name, addr, want string
+		wantErr          bool
+	}{{
+		name: "scheme, host, and port",
+		addr: "https://localhost:5758",
+		want: "localhost:5758",
+	}, {
+		name: "host and port",
+		addr: "localhost:5758",
+		want: "localhost:5758",
+	}, {
+		name: "just port",
+		addr: ":5758",
+		want: "localhost:5758",
+	}, {
+		name: "ip host and port",
+		addr: "127.0.0.1:5758",
+		want: "127.0.0.1:5758",
+	}, {
+		name: "host, port, and path",
+		addr: "localhost:5758/any/path",
+		want: "localhost:5758",
+	}, {
+		name: "just host",
+		addr: "thatonedex.com",
+		want: "thatonedex.com",
+	}, {
+		name: "shceme and host",
+		addr: "https://thatonedex.com",
+		want: "thatonedex.com",
+	}, {
+		name: "scheme, host, and path",
+		addr: "https://thatonedex.com/any/path",
+		want: "thatonedex.com",
+	}, {
+		name:    "invalid address",
+		addr:    "\n",
+		wantErr: true,
+	}, {
+		name:    "empty address",
+		wantErr: true,
+	}}
+	for _, test := range tests {
+		res, err := addrHost(test.addr)
+		if err != nil {
+			if test.wantErr {
+				continue
+			}
+			t.Fatalf("unexpected error for test '%s': %v", test.name, err)
+		}
+		if res != test.want {
+			t.Fatalf("wanted %s but got %s for test '%s'", test.want, res, test.name)
+		}
+		// Parsing results a second time should produce the same results.
+		res, err = addrHost(res)
+		if err != nil {
+			t.Fatalf("unexpected error for test '%s': %v", test.name, err)
+		}
+		if res != test.want {
+			t.Fatalf("wanted %s but got %s for test '%s'", test.want, res, test.name)
+		}
+	}
+}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -163,7 +163,7 @@ func (m *Market) marketName() string {
 
 // Exchange represents a single DEX with any number of markets.
 type Exchange struct {
-	URL        string                `json:"url"`
+	Host       string                `json:"host"`
 	Markets    map[string]*Market    `json:"markets"`
 	Assets     map[uint32]*dex.Asset `json:"assets"`
 	FeePending bool                  `json:"feePending"`

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -300,7 +300,7 @@ func handleExchanges(s *RPCServer, _ *RawParams) *msgjson.ResponsePayload {
 	for k, exchange := range exchanges {
 		exchangeDetails := convM(exchange)
 		// Remove a redundant address field.
-		delete(exchangeDetails, "url")
+		delete(exchangeDetails, "host")
 		markets := convM(exchangeDetails["markets"])
 		// Market keys are market name.
 		for k, market := range markets {
@@ -558,7 +558,7 @@ Registration is complete after the fee transaction has been confirmed.`,
 		returns: `Returns:
     map: The exchanges result.
     {
-      "[DEX url]": {
+      "[DEX host]": {
         "markets": {
           "[assetID-assetID]": {
             "baseid" (int): The base asset ID

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -448,7 +448,7 @@ func TestHandleExchanges(t *testing.T) {
 	   handleExchanges removes some redundant fields from the response.
 	   $ diff in out
 	   3d2
-	   <     "url": "https://127.0.0.1:7232",
+	   <     "host": "https://127.0.0.1:7232",
 	   6d4
 	   <         "name": "dcr_btc",
 	   16,17d13
@@ -461,7 +461,7 @@ func TestHandleExchanges(t *testing.T) {
 	*/
 	in := `{
   "https://127.0.0.1:7232": {
-    "url": "https://127.0.0.1:7232",
+    "host": "https://127.0.0.1:7232",
     "markets": {
       "dcr_btc": {
         "name": "dcr_btc",

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -182,8 +182,8 @@ func randomOrder(sell bool, maxQty, midGap, marketWidth float64, epoch bool) *co
 }
 
 var tExchanges = map[string]*core.Exchange{
-	"https://somedex.com": {
-		URL: "https://somedex.com",
+	"somedex.com": {
+		Host: "somedex.com",
 		Assets: map[uint32]*dex.Asset{
 			0:  mkDexAsset("btc"),
 			2:  mkDexAsset("ltc"),
@@ -197,8 +197,8 @@ var tExchanges = map[string]*core.Exchange{
 			mkid(3, 22): mkMrkt("doge", "mona"),
 		},
 	},
-	"https://thisdexwithalongname.com": {
-		URL: "https://thisdexwithalongname.com",
+	"thisdexwithalongname.com": {
+		Host: "thisdexwithalongname.com",
 		Assets: map[uint32]*dex.Asset{
 			0:  mkDexAsset("btc"),
 			2:  mkDexAsset("ltc"),

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -11,10 +11,10 @@
 
   {{- /* MARKET LIST */ -}}
   <div id="marketList" class="marketlist">
-    {{range $url, $xc := .Exchanges}}
-      <div class="fs16 py-1 pl-2 bg1">{{urlBase $url}}</div>
+    {{range $host, $xc := .Exchanges}}
+      <div class="fs16 py-1 pl-2 bg1">{{$host}}</div>
       {{range $xc.SortedMarkets}}
-        <div class="marketrow" data-dex="{{$url}}" data-base="{{.BaseID}}" data-quote="{{.QuoteID}}">
+        <div class="marketrow" data-dex="{{$host}}" data-base="{{.BaseID}}" data-quote="{{.QuoteID}}">
           <img src="{{logoPath .BaseSymbol}}" class="micro-icon mr-1">
           <img src="{{logoPath .QuoteSymbol}}" class="micro-icon mr-1">
           {{.Display}}

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -306,7 +306,7 @@ export default class MarketsPage extends BasePage {
       qtyField = page.mktBuyField
     }
     return {
-      dex: market.dex.url,
+      dex: market.dex.host,
       isLimit: limit,
       sell: sell,
       base: market.base.id,


### PR DESCRIPTION
This allows core methods to be called with a variety of different
patterns. Because net/url.Parse and net.SplitHostPort are not built for
our specific needs, a new function addrHost is added. This function will
parse dex addresses in a predictable manner that always produces a
host:port pair or just a host. Using the method on an already parsed
host will produce the same host.

closes #374 