### PR TITLE
client/webserver: resolve shutdown deadlock

### DIFF
--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -260,10 +260,10 @@ func (s *WebServer) Run(ctx context.Context) {
 	// Disconnect the websocket clients since Shutdown does not deal with
 	// hijacked websocket connections.
 	s.mtx.Lock()
-	defer s.mtx.Unlock()
 	for _, cl := range s.clients {
 		cl.Disconnect()
 	}
+	s.mtx.Unlock()
 
 	wg.Wait()
 }


### PR DESCRIPTION
This fixes (*WebServer).Run being unable to return if there is a websocket handler goroutine waiting on the webserver mutex.