### PR TITLE
multi: refactor balance reporting

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -356,7 +356,7 @@ func (btc *ExchangeWallet) Connect(ctx context.Context) (error, *sync.WaitGroup)
 
 // Balance should return the total available funds in the wallet. Balance takes
 // a list of minimum confirmations for which to calculate maturity, and returns
-// a list of corresponding *assetBalance. Because of the DEX confirmation
+// a list of corresponding *asset.Balance. Because of the DEX confirmation
 // requirements, a simple getbalance with a minconf argument is not sufficient
 // to see all balance available for the exchanges. Instead, all wallet UTXOs are
 // scanned for those that match confirmation requirements. Part of the

--- a/client/asset/btc/regnet_test.go
+++ b/client/asset/btc/regnet_test.go
@@ -171,11 +171,13 @@ func TestWallet(t *testing.T) {
 
 	// Check available amount.
 	for name, wallet := range rig.backends {
-		available, unconf, err := wallet.Balance(tBTC.FundConf)
-		tLogger.Debugf("%s %f available, %f unconfirmed", name, float64(available)/1e8, float64(unconf)/1e8)
+		bals, err := wallet.Balance([]uint32{tBTC.FundConf})
 		if err != nil {
 			t.Fatalf("error getting available: %v", err)
 		}
+		bal := bals[0]
+		tLogger.Debugf("%s %f available, %f unconfirmed, %f locked",
+			name, float64(bal.Available)/1e8, float64(bal.Immature)/1e8, float64(bal.Locked)/1e8)
 	}
 	// Gamma should only have 10 BTC utxos, so calling fund for less should only
 	// return 1 utxo.

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -21,6 +21,7 @@ import (
 const (
 	methodListUnspent       = "listunspent"
 	methodLockUnspent       = "lockunspent"
+	methodListLockUnspent   = "listlockunspent"
 	methodChangeAddress     = "getrawchangeaddress"
 	methodNewAddress        = "getnewaddress"
 	methodSignTx            = "signrawtransactionwithwallet"
@@ -75,6 +76,14 @@ func (wc *walletClient) LockUnspent(unlock bool, ops []*output) error {
 		return fmt.Errorf("lockunspent unsuccessful")
 	}
 	return err
+}
+
+// ListLockUnspent returns a slice of outpoints for all unspent outputs marked
+// as locked by a wallet.
+func (wc *walletClient) ListLockUnspent() ([]*RPCOutpoint, error) {
+	var unspents []*RPCOutpoint
+	err := wc.call(methodListLockUnspent, nil, &unspents)
+	return unspents, err
 }
 
 // ChangeAddress gets a new internal address from the wallet. The address will

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -166,11 +166,13 @@ func TestWallet(t *testing.T) {
 
 	// Check available amount.
 	for name, wallet := range rig.backends {
-		available, unconf, err := wallet.Balance(tDCR.FundConf)
-		tLogger.Debugf("%s %f available, %f unconfirmed", name, float64(available)/1e8, float64(unconf)/1e8)
+		bals, err := wallet.Balance([]uint32{tDCR.FundConf})
 		if err != nil {
 			t.Fatalf("error getting available: %v", err)
 		}
+		bal := bals[0]
+		tLogger.Debugf("%s %f available, %f unconfirmed, %f locked",
+			name, float64(bal.Available)/1e8, float64(bal.Immature)/1e8, float64(bal.Locked)/1e8)
 	}
 	// Grab some coins.
 	utxos, err := rig.beta().Fund(contractValue*3, tDCR)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -128,14 +128,14 @@ type Wallet interface {
 
 // Balance is categorized information about a wallet's balance.
 type Balance struct {
-	Available uint64
-	Locked    uint64
-	Immature  uint64
-}
-
-// Total is the total sum wallet balance, including locked and immature.
-func (b *Balance) Total() uint64 {
-	return b.Available + b.Locked + b.Immature
+	// Available is the balance that is available for trading immediately.
+	Available uint64 `json:"available"`
+	// Immature is the balance that is not ready, but will be after some
+	// confirmations.
+	Immature uint64 `json:"immature"`
+	// Locked is the balance that that is currently locked for swap, but
+	// not actually swapped yet.
+	Locked uint64 `json:"locked"`
 }
 
 // Coin is some amount of spendable asset. Coin provides the information needed

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -718,6 +718,12 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 	}
 	wallet.setAddress(dbWallet.Address)
 
+	balances, err = c.walletBalances(wallet)
+	if err != nil {
+		return initErr("error getting wallet balance for %s: %v", symbol, err)
+	}
+	dbWallet.Balance = balances.ZeroConf
+
 	// Store the wallet in the database.
 	err = c.db.UpdateWallet(dbWallet)
 	if err != nil {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1717,7 +1717,7 @@ func (c *Core) AssetBalances(assetID uint32) (*BalanceSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%d -> %s wallet error: %v", assetID, unbip(assetID), err)
 	}
-	return wallet.balances, nil
+	return c.walletBalances(wallet)
 }
 
 // initialize pulls the known DEX URLs from the database and attempts to

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -535,7 +535,7 @@ func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 		// unlocked.
 		_, err = c.walletBalances(wallet)
 		if err != nil {
-			return nil, fmt.Errorf("error getting balances for %s: %v", unbip(assetID), err)
+			log.Tracef("could not retrieve balances for locked %s wallet: %v", unbip(assetID), err)
 		}
 	}
 	return wallet, nil

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -61,6 +61,15 @@ func (set *errorSet) Error() string {
 	return set.prefix + strings.Join(errStrings, ", ")
 }
 
+// BalanceSet represents a wallet's balance in various contexts, which includes
+// the zero-conf case, and balances for all asset-supporting exchanges. The
+// separate balances are required because how much is available depends on an
+// exchange's FundConf setting.
+type BalanceSet struct {
+	ZeroConf *asset.Balance            `json:"zeroConf"`
+	XC       map[string]*asset.Balance `json:"xc"`
+}
+
 // WalletForm is information necessary to create a new exchange wallet.
 // The ConfigText, if provided, will be parsed for wallet connection settings.
 // If ConfigText is not provided, and a file exists at the `asset.DefaultConfigPath`,
@@ -73,15 +82,15 @@ type WalletForm struct {
 
 // WalletState is the current status of an exchange wallet.
 type WalletState struct {
-	Symbol  string `json:"symbol"`
-	AssetID uint32 `json:"assetID"`
-	Open    bool   `json:"open"`
-	Running bool   `json:"running"`
-	Updated uint64 `json:"updated"`
-	Balance uint64 `json:"balance"`
-	Address string `json:"address"`
-	FeeRate uint64 `json:"feerate"`
-	Units   string `json:"units"`
+	Symbol   string      `json:"symbol"`
+	AssetID  uint32      `json:"assetID"`
+	Open     bool        `json:"open"`
+	Running  bool        `json:"running"`
+	Updated  uint64      `json:"updated"`
+	Balances *BalanceSet `json:"balances"`
+	Address  string      `json:"address"`
+	FeeRate  uint64      `json:"feerate"`
+	Units    string      `json:"units"`
 }
 
 // User is information about the user's wallets and DEX accounts.

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -21,7 +21,7 @@ type xcWallet struct {
 	mtx       sync.RWMutex
 	lockTime  time.Time
 	hookedUp  bool
-	balance   uint64
+	balance   *asset.Balance
 	balUpdate time.Time
 	encPW     []byte
 	address   string
@@ -72,7 +72,7 @@ func (w *xcWallet) state() *WalletState {
 }
 
 // setBalance sets the wallet balance.
-func (w *xcWallet) setBalance(bal uint64) {
+func (w *xcWallet) setBalance(*asset.Balance) {
 	w.mtx.Lock()
 	w.balance = bal
 	w.balUpdate = time.Now()

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -21,7 +21,7 @@ type xcWallet struct {
 	mtx       sync.RWMutex
 	lockTime  time.Time
 	hookedUp  bool
-	balance   *asset.Balance
+	balances  *BalanceSet
 	balUpdate time.Time
 	encPW     []byte
 	address   string
@@ -60,21 +60,21 @@ func (w *xcWallet) state() *WalletState {
 	defer w.mtx.RUnlock()
 	winfo := w.Info()
 	return &WalletState{
-		Symbol:  unbip(w.AssetID),
-		AssetID: w.AssetID,
-		Open:    w.lockTime.After(time.Now()),
-		Running: w.connector.On(),
-		Balance: w.balance,
-		Address: w.address,
-		FeeRate: winfo.DefaultFeeRate, // Withdraw fee, not swap.
-		Units:   winfo.Units,
+		Symbol:   unbip(w.AssetID),
+		AssetID:  w.AssetID,
+		Open:     w.lockTime.After(time.Now()),
+		Running:  w.connector.On(),
+		Balances: w.balances,
+		Address:  w.address,
+		FeeRate:  winfo.DefaultFeeRate, // Withdraw fee, not swap.
+		Units:    winfo.Units,
 	}
 }
 
 // setBalance sets the wallet balance.
-func (w *xcWallet) setBalance(*asset.Balance) {
+func (w *xcWallet) setBalance(bals *BalanceSet) {
 	w.mtx.Lock()
-	w.balance = bal
+	w.balances = bals
 	w.balUpdate = time.Now()
 	w.mtx.Unlock()
 }

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -643,6 +643,9 @@ func decodeTimedBalance(b []byte) (*timedBalance, error) {
 
 // UpdateWallet adds a wallet to the database.
 func (db *boltDB) UpdateWallet(wallet *dexdb.Wallet) error {
+	if wallet.Balance == nil {
+		return fmt.Errorf("cannot UpdateWallet with nil Balance field")
+	}
 	return db.walletsUpdate(func(master *bbolt.Bucket) error {
 		wBkt, err := master.CreateBucketIfNotExists(wallet.ID())
 		if err != nil {

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"time"
 
+	"decred.org/dcrdex/client/asset"
 	dexdb "decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/order"
@@ -606,14 +607,16 @@ func (db *boltDB) matchesUpdate(f bucketFunc) error {
 // timedBalance is used to store the balance in a wallet bucket.
 type timedBalance struct {
 	time    time.Time
-	balance uint64
+	balance *asset.Balance
 }
 
 // serialize serializes the timedBalance to a versioned blob.
 func (tb *timedBalance) serialize() []byte {
 	return encode.BuildyBytes{0}.
 		AddData(uint64Bytes(encode.UnixMilliU(tb.time))).
-		AddData(uint64Bytes(tb.balance))
+		AddData(uint64Bytes(tb.balance.Available)).
+		AddData(uint64Bytes(tb.balance.Immature)).
+		AddData(uint64Bytes(tb.balance.Locked))
 }
 
 // decodeTimedBalance decodes the balance from the versioned blob.
@@ -625,12 +628,16 @@ func decodeTimedBalance(b []byte) (*timedBalance, error) {
 	if ver != 0 {
 		return nil, fmt.Errorf("unrecognized timedBalance version %d", ver)
 	}
-	if len(pushes) != 2 {
-		return nil, fmt.Errorf("decodeTimedBalance: expected 2 pushes, got %d", len(pushes))
+	if len(pushes) != 4 {
+		return nil, fmt.Errorf("decodeTimedBalance: expected 4 pushes, got %d", len(pushes))
 	}
 	return &timedBalance{
-		time:    encode.DecodeUTime(pushes[0]),
-		balance: intCoder.Uint64(pushes[1]),
+		time: encode.DecodeUTime(pushes[0]),
+		balance: &asset.Balance{
+			Available: intCoder.Uint64(pushes[1]),
+			Immature:  intCoder.Uint64(pushes[2]),
+			Locked:    intCoder.Uint64(pushes[3]),
+		},
 	}, nil
 }
 
@@ -654,7 +661,7 @@ func (db *boltDB) UpdateWallet(wallet *dexdb.Wallet) error {
 }
 
 // UpdateBalance updates balance in the wallet bucket.
-func (db *boltDB) UpdateBalance(wid []byte, balance uint64) error {
+func (db *boltDB) UpdateBalance(wid []byte, balance *asset.Balance) error {
 	return db.walletsUpdate(func(master *bbolt.Bucket) error {
 		wBkt := master.Bucket(wid)
 		if wBkt == nil {

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -266,16 +266,17 @@ func TestWallets(t *testing.T) {
 	}
 	// Test changing the balance
 	w := reWallets[0]
-	newBal := w.Balance + 1e8
+	newBal := *w.Balance
+	newBal.Available += 1e8
+	newBal.Locked += 2e8
+	newBal.Immature += 3e8
 	updated := w.BalUpdate
-	boltdb.UpdateBalance(w.ID(), newBal)
+	boltdb.UpdateBalance(w.ID(), &newBal)
 	reW, err := boltdb.Wallet(w.ID())
 	if err != nil {
 		t.Fatalf("failed to retreive wallet for balance check")
 	}
-	if reW.Balance != newBal {
-		t.Fatalf("balance not updated")
-	}
+	dbtest.MustCompareBalances(t, reW.Balance, &newBal)
 	if updated.After(reW.BalUpdate) {
 		t.Fatalf("update time can't be right: %s < %s", reW.BalUpdate, updated)
 	}

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/db"
 	ordertest "decred.org/dcrdex/dex/order/test"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
@@ -50,7 +51,11 @@ func RandomWallet() *db.Wallet {
 			ordertest.RandomAddress(): ordertest.RandomAddress(),
 			ordertest.RandomAddress(): ordertest.RandomAddress(),
 		},
-		Balance:   rand.Uint64(),
+		Balance: &asset.Balance{
+			Available: rand.Uint64(),
+			Immature:  rand.Uint64(),
+			Locked:    rand.Uint64(),
+		},
 		BalUpdate: time.Now().Truncate(time.Millisecond).UTC(),
 		Address:   ordertest.RandomAddress(),
 	}
@@ -251,9 +256,7 @@ func MustCompareWallets(t testKiller, w1, w2 *db.Wallet) {
 			t.Fatalf("Settings mismatch: different values for key '%s'", k)
 		}
 	}
-	if w1.Balance != w2.Balance {
-		t.Fatalf("Balance mismatch. %d != %d", w1.Balance, w2.Balance)
-	}
+	MustCompareBalances(t, w1.Balance, w2.Balance)
 	if !w1.BalUpdate.Equal(w2.BalUpdate) {
 		t.Fatalf("BalUpdate mismatch. %s != %s", w1.BalUpdate, w2.BalUpdate)
 	}
@@ -262,6 +265,18 @@ func MustCompareWallets(t testKiller, w1, w2 *db.Wallet) {
 	}
 	if !bytes.Equal(w1.EncryptedPW, w2.EncryptedPW) {
 		t.Fatalf("EncryptedPW mismatch. %x != %x", w1.EncryptedPW, w2.EncryptedPW)
+	}
+}
+
+func MustCompareBalances(t testKiller, b1, b2 *asset.Balance) {
+	if b1.Available != b2.Available {
+		t.Fatalf("available balance mismatch. %d != %d", b1.Available, b2.Available)
+	}
+	if b1.Immature != b2.Immature {
+		t.Fatalf("immature balance mismatch. %d != %d", b1.Immature, b2.Immature)
+	}
+	if b1.Locked != b2.Locked {
+		t.Fatalf("locked balance mismatch. %d != %d", b1.Locked, b2.Locked)
 	}
 }
 

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/config"
 	"decred.org/dcrdex/dex/encode"
@@ -336,7 +337,7 @@ type Wallet struct {
 	AssetID     uint32
 	Account     string
 	Settings    map[string]string
-	Balance     uint64
+	Balance     *asset.Balance
 	BalUpdate   time.Time
 	EncryptedPW []byte
 	Address     string

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -528,7 +528,15 @@ var helpMsgs = map[string]helpMsg{
         "open" (bool): Whether the wallet is unlocked.
         "running" (bool): Whether the wallet is running.
         "updated" (int): Unix time of last balance update. Seconds since 00:00:00 Jan 1 1970.
-        "balance" (int): The wallet balance.
+        "balance" (obj): {
+          "zeroConf" (obj): {
+            "available" (int): The balance available for the use in the zero-minconf case.
+            "immature" (int): 
+            "locked" (int): The total locked balance.
+	      },
+          "xc" (map string -> obj): Mapping of dex address to balance objects with the same structure as zeroConf.
+                                    The balance categorization is based on DEX asset variables.
+        }
         "address" (string): A wallet address.
         "feerate" (int): The fee rate.
         "units" (string): Unit of measure for amounts.

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -531,7 +531,7 @@ var helpMsgs = map[string]helpMsg{
         "balance" (obj): {
           "zeroConf" (obj): {
             "available" (int): The balance available for the use in the zero-minconf case.
-            "immature" (int): 
+            "immature" (int): Balance that requires confirmations before use. Can be non-zero for balances in the xc map.
             "locked" (int): The total locked balance.
 	      },
           "xc" (map string -> obj): Mapping of dex address to balance objects with the same structure as zeroConf.

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -51,7 +51,7 @@ var (
 
 // ClientCore is satisfied by core.Core.
 type ClientCore interface {
-	Balance(assetID uint32) (baseUnits uint64, err error)
+	AssetBalances(assetID uint32) (*core.BalanceSet, error)
 	Book(dex string, base, quote uint32) (orderBook *core.OrderBook, err error)
 	CloseWallet(assetID uint32) error
 	CreateWallet(appPass, walletPass []byte, form *core.WalletForm) error

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -57,8 +57,8 @@ type TCore struct {
 func (c *TCore) Book(dex string, base, quote uint32) (*core.OrderBook, error) {
 	return nil, nil
 }
-func (c *TCore) Balance(uint32) (uint64, error) {
-	return 0, c.balanceErr
+func (c *TCore) AssetBalances(uint32) (*core.BalanceSet, error) {
+	return nil, c.balanceErr
 }
 func (c *TCore) CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error {
 	return c.createWalletErr

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -62,7 +62,7 @@
           </td>
           <td data-col="balance" data-balance-target="{{.ID}}">
             {{if .Wallet}}
-              {{printf "%.8f" (fromAtoms .Wallet.Balance)}}
+              {{printf "%.8f" (fromAtoms .Wallet.Balances.ZeroConf.Available)}}
             {{else}}
               0.00000000
             {{end}}

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -73,7 +73,7 @@ export default class Application {
       this.assets[wallet.assetID].wallet = wallet
       this.walletMap[wallet.assetID] = wallet
       const balances = this.main.querySelectorAll(`[data-balance-target="${wallet.assetID}"]`)
-      balances.forEach(el => { el.textContent = (wallet.balance / 1e8).toFixed(8) })
+      balances.forEach(el => { el.textContent = (wallet.balances.zeroConf.available / 1e8).toFixed(8) })
     })
     ws.registerRoute(notificationRoute, note => {
       this.notify(note)

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -396,7 +396,7 @@ export default class MarketsPage extends BasePage {
     if (a.wallet) {
       Doc.hide(button)
       Doc.show(row)
-      bal.textContent = Doc.formatCoinValue(a.wallet.balance / 1e8)
+      bal.textContent = Doc.formatCoinValue(a.wallet.balances.zeroConf.available / 1e8)
       return
     }
     Doc.show(button)

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -227,7 +227,7 @@ export default class WalletsPage extends BasePage {
     await this.hideBox()
     page.withdrawAddr.value = ''
     page.withdrawAmt.value = ''
-    page.withdrawAvail.textContent = (wallet.balance / 1e8).toFixed(8)
+    page.withdrawAvail.textContent = (wallet.balances.zeroConf.available / 1e8).toFixed(8)
     page.withdrawLogo.src = Doc.logoPath(asset.symbol)
     page.withdrawName.textContent = asset.info.name
     page.withdrawFee.textContent = wallet.feerate

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -65,7 +65,7 @@ type clientCore interface {
 	Login(pw []byte) (*core.LoginResult, error)
 	InitializeClient(pw []byte) error
 	Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error)
-	Balance(uint32) (uint64, error)
+	AssetBalances(assetID uint32) (*core.BalanceSet, error)
 	WalletState(assetID uint32) *core.WalletState
 	CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error
 	OpenWallet(assetID uint32, pw []byte) error
@@ -82,6 +82,8 @@ type clientCore interface {
 	AckNotes([]dex.Bytes)
 	Logout() error
 }
+
+var _ clientCore = (*core.Core)(nil)
 
 // marketSyncer is used to synchronize market subscriptions. The marketSyncer
 // manages a map of clients who are subscribed to the market, and distributes

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -85,7 +85,7 @@ func (c *TCore) Sync(dex string, base, quote uint32) (*core.OrderBook, *core.Boo
 func (c *TCore) Book(dex string, base, quote uint32) (*core.OrderBook, error) {
 	return &core.OrderBook{}, nil
 }
-func (c *TCore) Balance(uint32) (uint64, error) { return 0, c.balanceErr }
+func (c *TCore) AssetBalances(assetID uint32) (*core.BalanceSet, error) { return nil, c.balanceErr }
 func (c *TCore) WalletState(assetID uint32) *core.WalletState {
 	if c.notHas {
 		return nil


### PR DESCRIPTION
This is a precursor to resolving #345. By allowing the simultaneous calculation of multiple categorized balances with different numbers of minimum confirmations, we can efficiently retrieve and display information more accurate to the specific DEX.

No UI updates, unless you count the RPC server help message.
 
Includes an update to **db**, so **nuke your dexc.db**.