### PR TITLE
market: make handleOrderBook send book synchronously

### DIFF
--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -463,7 +463,7 @@ func (r *BookRouter) handleOrderBook(conn comms.Link, msg *msgjson.Message) *msg
 		}
 	}
 	book.subs.add(conn)
-	go r.sendBook(conn, book, msg.ID)
+	r.sendBook(conn, book, msg.ID)
 	return nil
 }
 

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -43,7 +43,7 @@ const (
 	mkt2BaseRate  = 8e9
 	mktName3      = "dcr_btc"
 	mkt3BaseRate  = 3e9
-	responseDelay = 10 // milliseconds
+	responseDelay = 20 // milliseconds
 
 	clientPreimageDelay = 75 * time.Millisecond
 )

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -1375,7 +1375,7 @@ func TestRouter(t *testing.T) {
 		},
 	}
 	src1.feed <- sig
-	tick(responseDelay)
+	tick(responseDelay) // let (*BookRouter).runBook receive the signal and send on the subscriber links
 
 	epochNote := getEpochNoteFromLink(t, link1)
 	compareLO(&epochNote.BookOrderNote, lo, msgjson.ImmediateOrderNum, "epoch notification, link1")


### PR DESCRIPTION
`(*BookRouter).handleOrderBook` can run `sendBook` synchronously, not in a
new goroutine since the caller is in a goroutine for just that link, a
`(*Server).websocketHandler`, meaning `comms.Link.Send` called
by `handleOrderBook` doesn't block anything except for subsequent incoming
messages just for that client until this one is handled.

This makes it less likely for the ticks in `TestRouter` to be insufficient.  e.g. https://github.com/decred/dcrdex/runs/694271908#step:5:267