### PR TITLE
app: auto-refund swaps when trade fails

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -980,7 +980,7 @@ func (btc *ExchangeWallet) FindRedemption(ctx context.Context, coinID dex.Bytes)
 // expired.
 // NOTE: The contract cannot be retreived from the unspent coin info as the
 // wallet does not store it, even though it was known when the init transaction
-// was created. The DEX should store this information for persistence across
+// was created. The client should store this information for persistence across
 // sessions.
 func (btc *ExchangeWallet) Refund(coinID, contract dex.Bytes, nfo *dex.Asset) (dex.Bytes, error) {
 	txHash, vout, err := decodeCoinID(coinID)

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1154,7 +1154,7 @@ func TestRefund(t *testing.T) {
 	node.rawRes[methodPrivKeyForAddress] = mustMarshal(t, wif.String())
 
 	contractOutput := newOutput(node, tTxHash, 0, 1e8, contract)
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
 	if err != nil {
 		t.Fatalf("refund error: %v", err)
 	}
@@ -1163,14 +1163,14 @@ func TestRefund(t *testing.T) {
 	badReceipt := &tReceipt{
 		coin: &tCoin{id: make([]byte, 15)},
 	}
-	err = wallet.Refund(badReceipt.coin.id, badReceipt.coin.Redeem(), tBTC)
+	_, err = wallet.Refund(badReceipt.coin.id, badReceipt.coin.Redeem(), tBTC)
 	if err == nil {
 		t.Fatalf("no error for bad receipt")
 	}
 
 	// gettxout error
 	node.txOutErr = tErr
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
 	if err == nil {
 		t.Fatalf("no error for missing utxo")
 	}
@@ -1178,14 +1178,14 @@ func TestRefund(t *testing.T) {
 
 	// bad contract
 	badContractOutput := newOutput(node, tTxHash, 0, 1e8, randBytes(50))
-	err = wallet.Refund(badContractOutput.ID(), badContractOutput.Redeem(), tBTC)
+	_, err = wallet.Refund(badContractOutput.ID(), badContractOutput.Redeem(), tBTC)
 	if err == nil {
 		t.Fatalf("no error for bad contract")
 	}
 
 	// Too small.
 	node.txOutRes = newTxOutResult(nil, 100, 2)
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
 	if err == nil {
 		t.Fatalf("no error for value < fees")
 	}
@@ -1193,7 +1193,7 @@ func TestRefund(t *testing.T) {
 
 	// getrawchangeaddress error
 	node.rawErr[methodChangeAddress] = tErr
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
 	if err == nil {
 		t.Fatalf("no error for getrawchangeaddress rpc error")
 	}
@@ -1201,7 +1201,7 @@ func TestRefund(t *testing.T) {
 
 	// signature error
 	node.rawErr[methodPrivKeyForAddress] = tErr
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
 	if err == nil {
 		t.Fatalf("no error for dumpprivkey rpc error")
 	}
@@ -1209,7 +1209,7 @@ func TestRefund(t *testing.T) {
 
 	// send error
 	node.sendErr = tErr
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
 	if err == nil {
 		t.Fatalf("no error for sendrawtransaction rpc error")
 	}
@@ -1219,14 +1219,14 @@ func TestRefund(t *testing.T) {
 	var badHash chainhash.Hash
 	badHash[0] = 0x05
 	node.sendHash = &badHash
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
 	if err == nil {
 		t.Fatalf("no error for tx hash")
 	}
 	node.sendHash = nil
 
 	// Sanity check that we can succeed again.
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tBTC)
 	if err != nil {
 		t.Fatalf("re-refund error: %v", err)
 	}

--- a/client/asset/btc/regnet_test.go
+++ b/client/asset/btc/regnet_test.go
@@ -305,9 +305,9 @@ func TestWallet(t *testing.T) {
 	}
 
 	// Find the redemption
-	receipt := receipts[0]
+	swapCoin := receipts[0].Coin()
 	ctx, _ := context.WithDeadline(tCtx, time.Now().Add(time.Second*5))
-	checkKey, err := rig.gamma().FindRedemption(ctx, receipt.Coin().ID())
+	checkKey, err := rig.gamma().FindRedemption(ctx, swapCoin.ID())
 	if err != nil {
 		t.Fatalf("error finding unconfirmed redemption: %v", err)
 	}
@@ -323,13 +323,13 @@ func TestWallet(t *testing.T) {
 	}
 	// Check that there is 1 confirmation on the swap
 	checkConfs(1)
-	_, err = rig.gamma().FindRedemption(ctx, receipt.Coin().ID())
+	_, err = rig.gamma().FindRedemption(ctx, swapCoin.ID())
 	if err != nil {
 		t.Fatalf("error finding confirmed redemption: %v", err)
 	}
 
 	// Confirmations should now be an error, since the swap output has been spent.
-	_, err = receipt.Coin().Confirmations()
+	_, err = swapCoin.Confirmations()
 	if err == nil {
 		t.Fatalf("error getting confirmations. has swap output been spent?")
 	}
@@ -362,9 +362,9 @@ func TestWallet(t *testing.T) {
 	if len(receipts) != 1 {
 		t.Fatalf("expected 1 receipt, got %d", len(receipts))
 	}
-	receipt = receipts[0]
+	swapCoin = receipts[0].Coin()
 
-	err = rig.gamma().Refund(receipt, tBTC)
+	err = rig.gamma().Refund(swapCoin.ID(), swapCoin.Redeem(), tBTC)
 	if err != nil {
 		t.Fatalf("refund error: %v", err)
 	}

--- a/client/asset/btc/regnet_test.go
+++ b/client/asset/btc/regnet_test.go
@@ -364,7 +364,7 @@ func TestWallet(t *testing.T) {
 	}
 	swapCoin = receipts[0].Coin()
 
-	err = rig.gamma().Refund(swapCoin.ID(), swapCoin.Redeem(), tBTC)
+	_, err = rig.gamma().Refund(swapCoin.ID(), swapCoin.Redeem(), tBTC)
 	if err != nil {
 		t.Fatalf("refund error: %v", err)
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1004,7 +1004,7 @@ func (dcr *ExchangeWallet) FindRedemption(ctx context.Context, coinID dex.Bytes)
 // expired.
 // NOTE: The contract cannot be retreived from the unspent coin info as the
 // wallet does not store it, even though it was known when the init transaction
-// was created. The DEX should store this information for persistence across
+// was created. The client should store this information for persistence across
 // sessions.
 func (dcr *ExchangeWallet) Refund(coinID, contract dex.Bytes, nfo *dex.Asset) (dex.Bytes, error) {
 	txHash, vout, err := decodeCoinID(coinID)

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -184,6 +184,10 @@ func (c *tRPCClient) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
 	return h, nil
 }
 
+func (c *tRPCClient) GetBlockHeaderVerbose(hash *chainhash.Hash) (*chainjson.GetBlockHeaderVerboseResult, error) {
+	return nil, fmt.Errorf("not test data yet")
+}
+
 func (c *tRPCClient) GetBlockVerbose(blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error) {
 	blk, found := c.verboseBlocks[blockHash.String()]
 	if !found {
@@ -1103,11 +1107,7 @@ func TestRefund(t *testing.T) {
 	node.privWIF = dcrutil.NewWIF(privKey, chainParams.PrivateKeyID, dcrec.STEcdsaSecp256k1)
 
 	contractOutput := newOutput(node, tTxHash, 0, 1e8, wire.TxTreeRegular, contract)
-	receipt := &swapReceipt{
-		output:     contractOutput,
-		expiration: time.Now().Add(time.Hour * 24).UTC(),
-	}
-	err = wallet.Refund(receipt, tDCR)
+	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err != nil {
 		t.Fatalf("refund error: %v", err)
 	}
@@ -1116,30 +1116,29 @@ func TestRefund(t *testing.T) {
 	badReceipt := &tReceipt{
 		coin: &tCoin{id: make([]byte, 15)},
 	}
-	err = wallet.Refund(badReceipt, tDCR)
+	err = wallet.Refund(badReceipt.coin.id, badReceipt.coin.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for bad receipt")
 	}
 
 	// gettxout error
 	node.txOutErr = tErr
-	err = wallet.Refund(receipt, tDCR)
+	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for missing utxo")
 	}
 	node.txOutErr = nil
 
 	// bad contract
-	receipt.output = newOutput(node, tTxHash, 0, 1e8, wire.TxTreeRegular, randBytes(50))
-	err = wallet.Refund(receipt, tDCR)
+	badContractOutput := newOutput(node, tTxHash, 0, 1e8, wire.TxTreeRegular, randBytes(50))
+	err = wallet.Refund(badContractOutput.ID(), badContractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for bad contract")
 	}
-	receipt.output = contractOutput
 
 	// Too small.
 	node.txOutRes[bigOutID] = newTxOutResult(nil, 100, 2)
-	err = wallet.Refund(receipt, tDCR)
+	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for value < fees")
 	}
@@ -1147,7 +1146,7 @@ func TestRefund(t *testing.T) {
 
 	// signature error
 	node.privWIFErr = tErr
-	err = wallet.Refund(receipt, tDCR)
+	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for dumpprivkey rpc error")
 	}
@@ -1155,7 +1154,7 @@ func TestRefund(t *testing.T) {
 
 	// send error
 	node.sendRawErr = tErr
-	err = wallet.Refund(receipt, tDCR)
+	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for sendrawtransaction rpc error")
 	}
@@ -1165,14 +1164,14 @@ func TestRefund(t *testing.T) {
 	var badHash chainhash.Hash
 	badHash[0] = 0x05
 	node.sendRawHash = &badHash
-	err = wallet.Refund(receipt, tDCR)
+	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for tx hash")
 	}
 	node.sendRawHash = nil
 
 	// Sanity check that we can succeed again.
-	err = wallet.Refund(receipt, tDCR)
+	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err != nil {
 		t.Fatalf("re-refund error: %v", err)
 	}

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1103,7 +1103,7 @@ func TestRefund(t *testing.T) {
 	node.privWIF = dcrutil.NewWIF(privKey, chainParams.PrivateKeyID, dcrec.STEcdsaSecp256k1)
 
 	contractOutput := newOutput(node, tTxHash, 0, 1e8, wire.TxTreeRegular, contract)
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err != nil {
 		t.Fatalf("refund error: %v", err)
 	}
@@ -1112,14 +1112,14 @@ func TestRefund(t *testing.T) {
 	badReceipt := &tReceipt{
 		coin: &tCoin{id: make([]byte, 15)},
 	}
-	err = wallet.Refund(badReceipt.coin.id, badReceipt.coin.Redeem(), tDCR)
+	_, err = wallet.Refund(badReceipt.coin.id, badReceipt.coin.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for bad receipt")
 	}
 
 	// gettxout error
 	node.txOutErr = tErr
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for missing utxo")
 	}
@@ -1127,14 +1127,14 @@ func TestRefund(t *testing.T) {
 
 	// bad contract
 	badContractOutput := newOutput(node, tTxHash, 0, 1e8, wire.TxTreeRegular, randBytes(50))
-	err = wallet.Refund(badContractOutput.ID(), badContractOutput.Redeem(), tDCR)
+	_, err = wallet.Refund(badContractOutput.ID(), badContractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for bad contract")
 	}
 
 	// Too small.
 	node.txOutRes[bigOutID] = newTxOutResult(nil, 100, 2)
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for value < fees")
 	}
@@ -1142,7 +1142,7 @@ func TestRefund(t *testing.T) {
 
 	// signature error
 	node.privWIFErr = tErr
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for dumpprivkey rpc error")
 	}
@@ -1150,7 +1150,7 @@ func TestRefund(t *testing.T) {
 
 	// send error
 	node.sendRawErr = tErr
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for sendrawtransaction rpc error")
 	}
@@ -1160,14 +1160,14 @@ func TestRefund(t *testing.T) {
 	var badHash chainhash.Hash
 	badHash[0] = 0x05
 	node.sendRawHash = &badHash
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err == nil {
 		t.Fatalf("no error for tx hash")
 	}
 	node.sendRawHash = nil
 
 	// Sanity check that we can succeed again.
-	err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
+	_, err = wallet.Refund(contractOutput.ID(), contractOutput.Redeem(), tDCR)
 	if err != nil {
 		t.Fatalf("re-refund error: %v", err)
 	}

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -184,10 +184,6 @@ func (c *tRPCClient) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
 	return h, nil
 }
 
-func (c *tRPCClient) GetBlockHeaderVerbose(hash *chainhash.Hash) (*chainjson.GetBlockHeaderVerboseResult, error) {
-	return nil, fmt.Errorf("not test data yet")
-}
-
 func (c *tRPCClient) GetBlockVerbose(blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error) {
 	blk, found := c.verboseBlocks[blockHash.String()]
 	if !found {

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -300,10 +300,10 @@ func TestWallet(t *testing.T) {
 	}
 
 	// Find the redemption
-	receipt := receipts[0]
+	swapCoin := receipts[0].Coin()
 	ctx, _ := context.WithDeadline(tCtx, time.Now().Add(time.Second*5))
 	waitNetwork()
-	checkKey, err := rig.beta().FindRedemption(ctx, receipt.Coin().ID())
+	checkKey, err := rig.beta().FindRedemption(ctx, swapCoin.ID())
 	if err != nil {
 		t.Fatalf("error finding unconfirmed redemption: %v", err)
 	}
@@ -319,13 +319,13 @@ func TestWallet(t *testing.T) {
 	if !blockReported {
 		t.Fatalf("no block reported")
 	}
-	_, err = rig.beta().FindRedemption(ctx, receipt.Coin().ID())
+	_, err = rig.beta().FindRedemption(ctx, swapCoin.ID())
 	if err != nil {
 		t.Fatalf("error finding confirmed redemption: %v", err)
 	}
 
 	// Confirmations should now be an error, since the swap output has been spent.
-	_, err = receipt.Coin().Confirmations()
+	_, err = swapCoin.Confirmations()
 	if err == nil {
 		t.Fatalf("no error getting confirmations for redeemed swap. has swap output been spent?")
 	}
@@ -356,10 +356,10 @@ func TestWallet(t *testing.T) {
 	if len(receipts) != 1 {
 		t.Fatalf("expected 1 receipt, got %d", len(receipts))
 	}
-	receipt = receipts[0]
+	swapCoin = receipts[0].Coin()
 
 	waitNetwork()
-	err = rig.beta().Refund(receipt, tDCR)
+	err = rig.beta().Refund(swapCoin.ID(), swapCoin.Redeem(), tDCR)
 	if err != nil {
 		t.Fatalf("refund error: %v", err)
 	}

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -359,7 +359,7 @@ func TestWallet(t *testing.T) {
 	swapCoin = receipts[0].Coin()
 
 	waitNetwork()
-	err = rig.beta().Refund(swapCoin.ID(), swapCoin.Redeem(), tDCR)
+	_, err = rig.beta().Refund(swapCoin.ID(), swapCoin.Redeem(), tDCR)
 	if err != nil {
 		t.Fatalf("refund error: %v", err)
 	}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -117,7 +117,7 @@ type Wallet interface {
 	// wallet does not store it, even though it was known when the init transaction
 	// was created. The DEX should store this information for persistence across
 	// sessions.
-	Refund(coinID, contract dex.Bytes, nfo *dex.Asset) error
+	Refund(coinID, contract dex.Bytes, nfo *dex.Asset) (dex.Bytes, error)
 	// Address returns an address for the exchange wallet.
 	Address() (string, error)
 	// Unlock unlocks the exchange wallet.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -115,7 +115,7 @@ type Wallet interface {
 	// expired AND if the contract has not been redeemed/refunded.
 	// NOTE: The contract cannot be retreived from the unspent coin info as the
 	// wallet does not store it, even though it was known when the init transaction
-	// was created. The DEX should store this information for persistence across
+	// was created. The client should store this information for persistence across
 	// sessions.
 	Refund(coinID, contract dex.Bytes, nfo *dex.Asset) (dex.Bytes, error)
 	// Address returns an address for the exchange wallet.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -15,6 +15,11 @@ import (
 // swap transaction coin cannot be found.
 const CoinNotFoundError = dex.Error("coin not found")
 
+// CoinSpentError is returned when an attempt is made to treat a spent coin as
+// unspent. This error may be returned from AuditContract, Refund and Redeem
+// as those methods expect the provided coin to be unspent.
+const CoinSpentError = dex.Error("coin has been spent")
+
 // WalletInfo is auxiliary information about an ExchangeWallet.
 type WalletInfo struct {
 	// Name is the display name for the currency, e.g. "Decred"
@@ -89,6 +94,9 @@ type Wallet interface {
 	// ExchangeWallet should return CoinNotFoundError. This enables the client
 	// to properly handle network latency.
 	AuditContract(coinID, contract dex.Bytes) (AuditInfo, error)
+	// LocktimeExpired returns true if the specified contract's locktime has
+	// expired, making it possible to issue a Refund.
+	LocktimeExpired(contract dex.Bytes) (bool, error)
 	// FindRedemption should attempt to find the input that spends the specified
 	// coin, and return the secret key if it does.
 	//
@@ -104,8 +112,13 @@ type Wallet interface {
 	// regardless of whether the server sends the 'redemption' message or not.
 	FindRedemption(ctx context.Context, coinID dex.Bytes) (dex.Bytes, error)
 	// Refund refunds a contract. This can only be used after the time lock has
-	// expired.
-	Refund(Receipt, *dex.Asset) error
+	// expired AND if the contract has not been redeemed/refunded.
+	// CoinNotFoundError
+	// NOTE: The contract cannot be retreived from the unspent coin info as the
+	// wallet does not store it, even though it was known when the init transaction
+	// was created. The DEX should store this information for persistence across
+	// sessions.
+	Refund(coinID, contract dex.Bytes, nfo *dex.Asset) error
 	// Address returns an address for the exchange wallet.
 	Address() (string, error)
 	// Unlock unlocks the exchange wallet.
@@ -119,6 +132,10 @@ type Wallet interface {
 	// The ID need not represent an unspent coin, but coin IDs unknown to this
 	// wallet may return an error.
 	Confirmations(id dex.Bytes) (uint32, error)
+	// ConfirmTime is the utc time the specified coin ID got the specified number
+	// of confirmations. Returns a zero datetime if the coin has not gotten the
+	// specified number of confirmations.
+	ConfirmTime(id dex.Bytes, nConfs uint32) (time.Time, error)
 	// Withdraw withdraws funds to the specified address. Fees are subtracted from
 	// the value.
 	Withdraw(address string, value, feeRate uint64) (Coin, error)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -113,7 +113,6 @@ type Wallet interface {
 	FindRedemption(ctx context.Context, coinID dex.Bytes) (dex.Bytes, error)
 	// Refund refunds a contract. This can only be used after the time lock has
 	// expired AND if the contract has not been redeemed/refunded.
-	// CoinNotFoundError
 	// NOTE: The contract cannot be retreived from the unspent coin info as the
 	// wallet does not store it, even though it was known when the init transaction
 	// was created. The DEX should store this information for persistence across

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -132,10 +132,6 @@ type Wallet interface {
 	// The ID need not represent an unspent coin, but coin IDs unknown to this
 	// wallet may return an error.
 	Confirmations(id dex.Bytes) (uint32, error)
-	// ConfirmTime is the utc time the specified coin ID got the specified number
-	// of confirmations. Returns a zero datetime if the coin has not gotten the
-	// specified number of confirmations.
-	ConfirmTime(id dex.Bytes, nConfs uint32) (time.Time, error)
 	// Withdraw withdraws funds to the specified address. Fees are subtracted from
 	// the value.
 	Withdraw(address string, value, feeRate uint64) (Coin, error)

--- a/client/asset/ltc/regnet_test.go
+++ b/client/asset/ltc/regnet_test.go
@@ -375,7 +375,7 @@ func TestWallet(t *testing.T) {
 	}
 	receipt = receipts[0]
 
-	err = rig.gamma().Refund(receipt, tLTC)
+	_, err = rig.gamma().Refund(receipt, tLTC)
 	if err != nil {
 		t.Fatalf("refund error: %v", err)
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2337,6 +2337,12 @@ func handleRevokeMatchMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) erro
 		return fmt.Errorf("no order found with id %s", oid.String())
 	}
 
+	// todo: consider checking if any refunds/forced redemption are necessary
+	// before setting this match's status to Revoked.
+	// Alternatively, set status to Revoked but "remember" to attempt Refund/
+	// FindRedemption if necessary. Currently, `trackedTrade.isRefundable` will
+	// return false for this match because of the status change.
+
 	md := tracker.metaData
 	md.Status = order.OrderStatusRevoked
 	metaOrder := &db.MetaOrder{

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2337,20 +2337,24 @@ func handleRevokeMatchMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) erro
 		return fmt.Errorf("no order found with id %s", oid.String())
 	}
 
-	// todo: consider checking if any refunds/forced redemption are necessary
-	// before setting this match's status to Revoked.
-	// Alternatively, set status to Revoked but "remember" to attempt Refund/
-	// FindRedemption if necessary. Currently, `trackedTrade.isRefundable` will
-	// return false for this match because of the status change.
+	var matchID order.MatchID
+	copy(matchID[:], revocation.MatchID)
 
-	md := tracker.metaData
-	md.Status = order.OrderStatusRevoked
-	metaOrder := &db.MetaOrder{
-		MetaData: md,
-		Order:    tracker.Order,
+	var revokedMatch *matchTracker
+	tracker.matchMtx.RLock()
+	for _, match := range tracker.matches {
+		if match.id == matchID {
+			revokedMatch = match
+			break
+		}
+	}
+	tracker.matchMtx.RUnlock()
+	if revokedMatch == nil {
+		return fmt.Errorf("no match found with id %s for order %s", matchID, oid.String())
 	}
 
-	return tracker.db.UpdateOrder(metaOrder)
+	revokedMatch.MetaMatch.MetaData.Proof.IsRevoked = true
+	return tracker.db.UpdateMatch(&revokedMatch.MetaMatch)
 }
 
 // routeHandler is a handler for a message from the DEX.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -495,11 +495,15 @@ func (w *TXCWallet) AuditContract(coinID, contract dex.Bytes) (asset.AuditInfo, 
 	return w.auditInfo, w.auditErr
 }
 
+func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, error) {
+	return true, nil
+}
+
 func (w *TXCWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (dex.Bytes, error) {
 	return nil, nil
 }
 
-func (w *TXCWallet) Refund(asset.Receipt, *dex.Asset) error {
+func (w *TXCWallet) Refund(dex.Bytes, dex.Bytes, *dex.Asset) error {
 	return nil
 }
 
@@ -523,6 +527,10 @@ func (w *TXCWallet) Send(address string, fee uint64, _ *dex.Asset) (asset.Coin, 
 
 func (w *TXCWallet) Confirmations(id dex.Bytes) (uint32, error) {
 	return 0, nil
+}
+
+func (w *TXCWallet) ConfirmTime(id dex.Bytes, nConfs uint32) (time.Time, error) {
+	return time.Time{}, nil
 }
 
 func (w *TXCWallet) PayFee(address string, fee uint64, nfo *dex.Asset) (asset.Coin, error) {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -418,6 +418,8 @@ type TXCWallet struct {
 	swapReceipts   []asset.Receipt
 	auditInfo      asset.AuditInfo
 	auditErr       error
+	refundCoin     dex.Bytes
+	refundErr      error
 	redeemCoins    []dex.Bytes
 	badSecret      bool
 	fundedVal      uint64
@@ -504,7 +506,7 @@ func (w *TXCWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (dex.B
 }
 
 func (w *TXCWallet) Refund(dex.Bytes, dex.Bytes, *dex.Asset) (dex.Bytes, error) {
-	return nil, nil
+	return w.refundCoin, w.refundErr
 }
 
 func (w *TXCWallet) Address() (string, error) {
@@ -1834,8 +1836,7 @@ func TestHandleRevokeMatchMsg(t *testing.T) {
 	rig := newTestRig()
 	ord := &order.LimitOrder{P: order.Prefix{ServerTime: time.Now()}}
 	oid := ord.ID()
-	var mid order.MatchID
-	copy(mid[:], encode.RandomBytes(order.MatchIDSize))
+	mid := ordertest.RandomMatchID()
 	preImg := newPreimage()
 	payload := &msgjson.RevokeMatch{
 		OrderID: oid[:],
@@ -2212,6 +2213,170 @@ func TestTradeTracking(t *testing.T) {
 	if tracker.cancel.matches.taker == nil {
 		t.Fatalf("cancelMatches.taker not set")
 	}
+}
+
+func TestRefunds(t *testing.T) {
+	checkStatus := func(tag string, match *matchTracker, wantStatus order.MatchStatus) {
+		if match.Match.Status != wantStatus {
+			t.Fatalf("%s: wrong status wanted %d, got %d", tag, match.Match.Status, wantStatus)
+		}
+	}
+	checkRefund := func(tracker *trackedTrade, match *matchTracker, expectAmt uint64) {
+		// Confirm that the status is SwapCast.
+		if match.Match.Side == order.Maker {
+			checkStatus("maker swapped", match, order.MakerSwapCast)
+		} else {
+			checkStatus("taker swapped", match, order.TakerSwapCast)
+		}
+		// Confirm isRefundable = true.
+		if !tracker.isRefundable(match) {
+			t.Fatalf("%s's swap not refundable", match.Match.Side)
+		}
+		// Check refund.
+		amtRefunded, err := tracker.refundMatches([]*matchTracker{match})
+		if err != nil {
+			t.Fatalf("unexpected refund error %v", err)
+		}
+		// Check refunded amount.
+		if amtRefunded != expectAmt {
+			t.Fatalf("expected %d refund amount, got %d", expectAmt, amtRefunded)
+		}
+		// Confirm isRefundable = false.
+		if tracker.isRefundable(match) {
+			t.Fatalf("%s's swap refundable after being refunded", match.Match.Side)
+		}
+		// Expect refund re-attempt to not refund any coin.
+		amtRefunded, err = tracker.refundMatches([]*matchTracker{match})
+		if err != nil {
+			t.Fatalf("unexpected refund error %v", err)
+		}
+		if amtRefunded != 0 {
+			t.Fatalf("expected 0 refund amount, got %d", amtRefunded)
+		}
+		// Confirm that the status is unchanged.
+		if match.Match.Side == order.Maker {
+			checkStatus("maker swapped", match, order.MakerSwapCast)
+		} else {
+			checkStatus("taker swapped", match, order.TakerSwapCast)
+		}
+	}
+
+	rig := newTestRig()
+	dc := rig.dc
+	tCore := rig.core
+	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
+	tCore.wallets[tDCR.ID] = dcrWallet
+	dcrWallet.address = "DsVmA7aqqWeKWy461hXjytbZbgCqbB8g2dq"
+	dcrWallet.Unlock(wPW, time.Hour)
+
+	btcWallet, tBtcWallet := newTWallet(tBTC.ID)
+	tCore.wallets[tBTC.ID] = btcWallet
+	btcWallet.address = "12DXGkvxFjuq5btXYkwWfBZaz1rVwFgini"
+	btcWallet.Unlock(wPW, time.Hour)
+
+	matchSize := 4 * tDCR.LotSize
+	qty := 3 * matchSize
+	rate := tBTC.RateStep * 10
+	lo, dbOrder, preImgL, addr := makeLimitOrder(dc, true, qty, tBTC.RateStep)
+	loid := lo.ID()
+	mid := ordertest.RandomMatchID()
+	walletSet, err := tCore.walletSet(dc, tDCR.ID, tBTC.ID, true)
+	if err != nil {
+		t.Fatalf("walletSet error: %v", err)
+	}
+	mkt := dc.market(tDcrBtcMktName)
+	tracker := newTrackedTrade(dbOrder, preImgL, dc, mkt.EpochLen, rig.db, rig.queue, walletSet, nil, rig.core.notify)
+	rig.dc.trades[tracker.ID()] = tracker
+
+	// MAKER REFUND, INVALID TAKER COUNTERSWAP
+	//
+	msgMatch := &msgjson.Match{
+		OrderID:  loid[:],
+		MatchID:  mid[:],
+		Quantity: matchSize,
+		Rate:     rate,
+		Address:  "counterparty-address",
+		Side:     uint8(order.Maker),
+	}
+	counterSwapID := encode.RandomBytes(36)
+	tDcrWallet.swapReceipts = []asset.Receipt{&tReceipt{coin: &tCoin{id: counterSwapID}}}
+	sign(tDexPriv, msgMatch)
+	msg, _ := msgjson.NewRequest(1, msgjson.MatchRoute, []*msgjson.Match{msgMatch})
+	rig.ws.queueResponse(msgjson.InitRoute, initAcker)
+	err = handleMatchRoute(tCore, rig.dc, msg)
+	if err != nil {
+		t.Fatalf("match messages error: %v", err)
+	}
+	match, found := tracker.matches[mid]
+	if !found {
+		t.Fatalf("match not found")
+	}
+
+	// We're the maker, so the init transaction should be broadcast.
+	checkStatus("maker swapped", match, order.MakerSwapCast)
+	proof := &match.MetaData.Proof
+
+	// Send the counter-party's init info.
+	auditQty := calc.BaseToQuote(rate, matchSize)
+	audit, auditInfo := tMsgAudit(loid, mid, addr, auditQty, proof.SecretHash)
+	tBtcWallet.auditInfo = auditInfo
+	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
+
+	// Check audit errors.
+	tBtcWallet.auditErr = tErr
+	err = handleAuditRoute(tCore, rig.dc, msg)
+	if err == nil {
+		t.Fatalf("no maker error for AuditContract error")
+	}
+
+	// Attempt refund.
+	tDcrWallet.refundCoin = encode.RandomBytes(36)
+	tDcrWallet.refundErr = nil
+	tBtcWallet.refundCoin = nil
+	tBtcWallet.refundErr = fmt.Errorf("unexpected call to btcWallet.Refund")
+	checkRefund(tracker, match, matchSize)
+
+	// TAKER REFUND, NO MAKER REDEEM
+	//
+	mid = ordertest.RandomMatchID()
+	msgMatch = &msgjson.Match{
+		OrderID:  loid[:],
+		MatchID:  mid[:],
+		Quantity: matchSize,
+		Rate:     rate,
+		Address:  "counterparty-address",
+		Side:     uint8(order.Taker),
+	}
+	sign(tDexPriv, msgMatch)
+	msg, _ = msgjson.NewRequest(1, msgjson.MatchRoute, []*msgjson.Match{msgMatch})
+	err = handleMatchRoute(tCore, rig.dc, msg)
+	if err != nil {
+		t.Fatalf("match messages error: %v", err)
+	}
+	match, found = tracker.matches[mid]
+	if !found {
+		t.Fatalf("match not found")
+	}
+	checkStatus("taker matched", match, order.NewlyMatched)
+	// Send through the audit request for the maker's init.
+	audit, auditInfo = tMsgAudit(loid, mid, addr, matchSize, nil)
+	tBtcWallet.auditInfo = auditInfo
+	tBtcWallet.auditErr = nil
+	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
+	err = handleAuditRoute(tCore, rig.dc, msg)
+	if err != nil {
+		t.Fatalf("taker's match message error: %v", err)
+	}
+	checkStatus("taker counter-party swapped", match, order.MakerSwapCast)
+	auditInfo.coin.confs = tBTC.SwapConf
+	swapID := encode.RandomBytes(36)
+	tDcrWallet.swapReceipts = []asset.Receipt{&tReceipt{coin: &tCoin{id: swapID}}}
+	rig.ws.queueResponse(msgjson.InitRoute, initAcker)
+	dc.tickAsset(tBTC.ID)
+	checkStatus("taker swapped", match, order.TakerSwapCast)
+
+	// Attempt refund.
+	checkRefund(tracker, match, matchSize)
 }
 
 func TestNotifications(t *testing.T) {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -498,7 +498,7 @@ func (t *trackedTrade) isRefundable(match *matchTracker) bool {
 	//   status is TakerSwapCast but Taker's swap has not been redeemed. The
 	//   second case does not prevent Maker from (re-)attempting to redeem
 	//   Taker's swap; it just ensures that Maker's swap is refunded if Taker's
-	//   swap still can't be refunded **after** Maker's locktime expires.
+	//   swap can't be redeemed **after** Maker's locktime expires.
 	var hasRedeemableSwap bool
 	if side == order.Taker {
 		hasRedeemableSwap = status == order.TakerSwapCast
@@ -833,6 +833,9 @@ func (t *trackedTrade) refundMatches(matches []*matchTracker) (uint64, error) {
 		case dbMatch.Side == order.Maker && dbMatch.Status == order.MakerSwapCast:
 			swapCoinID = proof.MakerSwap
 			matchFailureReason = "no valid counterswap received from Taker"
+		case dbMatch.Side == order.Maker && dbMatch.Status == order.TakerSwapCast && proof.MakerRedeem == nil:
+			swapCoinID = proof.MakerSwap
+			matchFailureReason = "unable to redeem Taker's swap"
 		case dbMatch.Side == order.Taker && dbMatch.Status == order.TakerSwapCast:
 			swapCoinID = proof.TakerSwap
 			matchFailureReason = "no valid redemption received from Maker"

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -207,8 +207,8 @@ type MatchMetaData struct {
 	Quote uint32
 }
 
-// MatchSignatures holds the DEX signatures and timestamps associated with
-// the messages in the negotiation process.
+// MatchAuth holds the DEX signatures and timestamps associated with the
+// messages in the negotiation process.
 type MatchAuth struct {
 	MatchSig        []byte
 	MatchStamp      uint64
@@ -225,6 +225,7 @@ type MatchAuth struct {
 // MatchProof is information related to the progression of the swap negotiation
 // process.
 type MatchProof struct {
+	Script        []byte
 	CounterScript []byte
 	SecretHash    []byte
 	Secret        []byte
@@ -239,6 +240,7 @@ type MatchProof struct {
 func (p *MatchProof) Encode() []byte {
 	auth := p.Auth
 	return dbBytes{0}.
+		AddData(p.Script).
 		AddData(p.CounterScript).
 		AddData(p.SecretHash).
 		AddData(p.Secret).
@@ -272,28 +274,29 @@ func DecodeMatchProof(b []byte) (*MatchProof, error) {
 }
 
 func decodeMatchProof_v0(pushes [][]byte) (*MatchProof, error) {
-	if len(pushes) != 17 {
-		return nil, fmt.Errorf("DecodeMatchProof: expected 17 pushes, got %d", len(pushes))
+	if len(pushes) != 18 {
+		return nil, fmt.Errorf("DecodeMatchProof: expected 18 pushes, got %d", len(pushes))
 	}
 	return &MatchProof{
-		CounterScript: pushes[0],
-		SecretHash:    pushes[1],
-		Secret:        pushes[2],
-		MakerSwap:     pushes[3],
-		MakerRedeem:   pushes[4],
-		TakerSwap:     pushes[5],
-		TakerRedeem:   pushes[6],
+		Script:        pushes[0],
+		CounterScript: pushes[1],
+		SecretHash:    pushes[2],
+		Secret:        pushes[3],
+		MakerSwap:     pushes[4],
+		MakerRedeem:   pushes[5],
+		TakerSwap:     pushes[6],
+		TakerRedeem:   pushes[7],
 		Auth: MatchAuth{
-			MatchSig:        pushes[7],
-			MatchStamp:      intCoder.Uint64(pushes[8]),
-			InitSig:         pushes[9],
-			InitStamp:       intCoder.Uint64(pushes[10]),
-			AuditSig:        pushes[11],
-			AuditStamp:      intCoder.Uint64(pushes[12]),
-			RedeemSig:       pushes[13],
-			RedeemStamp:     intCoder.Uint64(pushes[14]),
-			RedemptionSig:   pushes[15],
-			RedemptionStamp: intCoder.Uint64(pushes[16]),
+			MatchSig:        pushes[8],
+			MatchStamp:      intCoder.Uint64(pushes[9]),
+			InitSig:         pushes[10],
+			InitStamp:       intCoder.Uint64(pushes[11]),
+			AuditSig:        pushes[12],
+			AuditStamp:      intCoder.Uint64(pushes[13]),
+			RedeemSig:       pushes[14],
+			RedeemStamp:     intCoder.Uint64(pushes[15]),
+			RedemptionSig:   pushes[16],
+			RedemptionStamp: intCoder.Uint64(pushes[17]),
 		},
 	}, nil
 }


### PR DESCRIPTION
Resolves #302.

In addition to checking for matches that require a swap or redemption broadcast, also check for failed matches where the client has a pending/unspent swap output and perform auto-refund where possible.

The following match disruption scenarios, necessitating a refund, are considered:
- The client is the (Maker) and has broadcast their init swap but up till the locktime expiry on the client's/Maker's swap, the other party (the Taker) has not sent "notification" of their counterswap (or sent a counterswap that failed audit checks).
- The client is the Taker and has broadcast their counterswap but up till the locktime expiry on the client's/Taker's counterswap, the other party (the Maker) has not sent "notification" of their redeeming the counterswap (or sends an invalid notification).
