### PR TITLE
multi: update balances when they change

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -10,7 +10,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -787,12 +786,6 @@ func (btc *ExchangeWallet) AuditContract(coinID dex.Bytes, contract dex.Bytes) (
 	// Get the contracts P2SH address from the tx output's pubkey script.
 	txOut, err := btc.node.GetTxOut(txHash, vout, true)
 	if err != nil {
-		var rpcErr *btcjson.RPCError
-		if errors.As(err, &rpcErr) {
-			if rpcErr.Code == btcjson.ErrRPCInvalidAddressOrKey {
-				return nil, asset.CoinNotFoundError
-			}
-		}
 		return nil, fmt.Errorf("error finding unspent contract: %s:%d : %v", txHash, vout, err)
 	}
 	if txOut == nil {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -370,7 +370,7 @@ func (dcr *ExchangeWallet) Balance(confs []uint32) ([]*asset.Balance, error) {
 	if err != nil {
 		return nil, err
 	}
-	locked, err := dcr.lockedSats()
+	locked, err := dcr.lockedAtoms()
 	if err != nil {
 		return nil, err
 	}
@@ -816,9 +816,6 @@ func (dcr *ExchangeWallet) AuditContract(coinID, contract dex.Bytes) (asset.Audi
 	// Get the contracts P2SH address from the tx output's pubkey script.
 	txOut, err := dcr.node.GetTxOut(txHash, vout, true)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "-5:") {
-			return nil, asset.CoinNotFoundError
-		}
 		return nil, fmt.Errorf("error finding unspent contract: %v", err)
 	}
 	if txOut == nil {
@@ -1253,8 +1250,8 @@ func (dcr *ExchangeWallet) balances(confs []uint32) ([]*asset.Balance, error) {
 	return balances, nil
 }
 
-// lockedSats is the total value of locked outputs, as locked with LockUnspent.
-func (dcr *ExchangeWallet) lockedSats() (uint64, error) {
+// lockedAtoms is the total value of locked outputs, as locked with LockUnspent.
+func (dcr *ExchangeWallet) lockedAtoms() (uint64, error) {
 	lockedOutpoints, err := dcr.node.ListLockUnspent()
 	if err != nil {
 		return 0, err

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -605,8 +605,8 @@ func (c *Core) updateBalances(counts assetCounter) {
 	c.refreshUser()
 }
 
-// updateAssetBalance upates the balance for the specified asset. A notification
-// is sent and refreshUser is called.
+// updateAssetBalance updates the balance for the specified asset. A
+// notification is sent and refreshUser is called.
 func (c *Core) updateAssetBalance(assetID uint32) {
 	c.updateBalances(make(assetCounter).add(assetID, 1))
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -596,6 +596,10 @@ func (c *Core) updateBalances(counts assetCounter) {
 			log.Error("error updateing balance after tick: %v", err)
 			continue
 		}
+		err = c.db.UpdateBalance(w.dbID, bals.ZeroConf)
+		if err != nil {
+			log.Errorf("error updating %s balance in database: %v", unbip(assetID), err)
+		}
 		c.notify(newBalanceNote(assetID, bals))
 	}
 	c.refreshUser()
@@ -783,6 +787,7 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 		balUpdate: dbWallet.BalUpdate,
 		encPW:     dbWallet.EncryptedPW,
 		address:   dbWallet.Address,
+		dbID:      dbWallet.ID(),
 	}
 	walletCfg := &asset.WalletConfig{
 		Account:  dbWallet.Account,

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2898,3 +2898,29 @@ func TestAssetBalances(t *testing.T) {
 	dbtest.MustCompareBalances(t, bals[0], balances.ZeroConf)
 	dbtest.MustCompareBalances(t, bals[1], balances.XC[tDexHost])
 }
+
+func TestAssetCounter(t *testing.T) {
+	counts := make(assetCounter)
+	counts.add(1, 1)
+	if len(counts) != 1 {
+		t.Fatalf("count not added")
+	}
+	counts.add(1, 3)
+	if counts[1] != 4 {
+		t.Fatalf("counts not incremented properly")
+	}
+	newCounts := assetCounter{
+		1: 100,
+		2: 2,
+	}
+	counts.absorb(newCounts)
+	if len(counts) != 2 {
+		t.Fatalf("counts not absorbed properly")
+	}
+	if counts[2] != 2 {
+		t.Fatalf("absorbed counts not set correctly")
+	}
+	if counts[1] != 104 {
+		t.Fatalf("absorbed counts not combined correctly")
+	}
+}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -308,6 +308,10 @@ func (tdb *TDB) UpdateWallet(wallet *db.Wallet) error {
 	return tdb.updateWalletErr
 }
 
+func (tdb *TDB) UpdateBalance(wid []byte, balance *asset.Balance) error {
+	return nil
+}
+
 func (tdb *TDB) Wallets() ([]*db.Wallet, error) {
 	return nil, nil
 }
@@ -434,6 +438,7 @@ func newTWallet(assetID uint32) (*xcWallet, *TXCWallet) {
 		AssetID:   assetID,
 		lockTime:  time.Now().Add(time.Hour),
 		hookedUp:  true,
+		dbID:      encode.Uint32Bytes(assetID),
 	}, w
 }
 

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -187,3 +187,18 @@ func newConnEventNote(subject, host string, connected bool, details string, seve
 		Connected:    connected,
 	}
 }
+
+// BalanceNote is an update to a wallet's balance.
+type BalanceNote struct {
+	db.Notification
+	AssetID  uint32      `json:"assetID"`
+	Balances *BalanceSet `json:"balances"`
+}
+
+func newBalanceNote(assetID uint32, bals *BalanceSet) *BalanceNote {
+	return &BalanceNote{
+		Notification: db.NewNotification("balance", "balance updated", "", db.Data),
+		AssetID:      assetID,
+		Balances:     bals,
+	}
+}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -455,3 +455,22 @@ type LoginResult struct {
 	Notifications []*db.Notification `json:"notifications"`
 	DEXes         []*DEXBrief        `json:"dexes"`
 }
+
+// assetCounter tracks a count for an series of assets and provides methods for
+// adding to the count and combining assetCounters. Methods return the receiver
+// for convenience.
+type assetCounter map[uint32]int
+
+// add increments the count for a specific asset.
+func (c assetCounter) add(assetID uint32, increment int) assetCounter {
+	c[assetID] = c[assetID] + increment
+	return c
+}
+
+// absorb adds the counts from another assetCounter to the current counts.
+func (c assetCounter) absorb(otherCounter assetCounter) assetCounter {
+	for assetID, count := range otherCounter {
+		c.add(assetID, count)
+	}
+	return c
+}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -456,7 +456,7 @@ type LoginResult struct {
 	DEXes         []*DEXBrief        `json:"dexes"`
 }
 
-// assetCounter tracks a count for an series of assets and provides methods for
+// assetCounter tracks a count for a series of assets and provides methods for
 // adding to the count and combining assetCounters. Methods return the receiver
 // for convenience.
 type assetCounter map[uint32]int

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -25,6 +25,7 @@ type xcWallet struct {
 	balUpdate time.Time
 	encPW     []byte
 	address   string
+	dbID      []byte
 }
 
 // Unlock unlocks the wallet.

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -4,6 +4,7 @@
 package db
 
 import (
+	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/order"
 )
@@ -76,6 +77,8 @@ type DB interface {
 	// credentials if the wallet already exists. A wallet is specified by the
 	// pair (asset ID, account name).
 	UpdateWallet(wallet *Wallet) error
+	// UpdateBalance updates a wallet's balance.
+	UpdateBalance(wid []byte, balance *asset.Balance) error
 	// Wallets lists all saved wallets.
 	Wallets() ([]*Wallet, error)
 	// Backup makes a copy of the database.

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -266,8 +266,15 @@ export default class Application {
             }
           }
         }
+        break
+      }
+      case 'balance': {
+        const wallet = this.user.assets[note.assetID].wallet
+        if (wallet) wallet.balances = note.balances
+        break
       }
     }
+
     // Inform the page.
     this.loadedPage.notify(note)
     // Discard data notifications.

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -188,7 +188,8 @@ export default class MarketsPage extends BasePage {
     this.notifiers = {
       order: note => { this.handleOrderNote(note) },
       epoch: note => { this.handleEpochNote(note) },
-      conn: note => { this.marketList.setConnectionStatus(note) }
+      conn: note => { this.marketList.setConnectionStatus(note) },
+      balance: note => { this.handleBalanceNote(note) }
     }
 
     // Fetch the first market in the list, or the users last selected market, if
@@ -699,6 +700,11 @@ export default class MarketsPage extends BasePage {
           break
       }
     }
+  }
+
+  // handleBalanceNote handles notifications updating a wallet's balance.
+  handleBalanceNote (note) {
+    this.updateWallet(note.assetID)
   }
 
   /*

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -113,6 +113,10 @@ export default class WalletsPage extends BasePage {
 
     if (!firstRow) return
     this.showMarkets(firstRow.assetID)
+
+    this.notifiers = {
+      balance: note => { this.handleBalanceNote(note) }
+    }
   }
 
   /*
@@ -303,6 +307,12 @@ export default class WalletsPage extends BasePage {
     Doc.hide(a.lock, a.withdraw, a.deposit)
     Doc.show(a.unlock)
     rowInfo.stateIcons.locked()
+  }
+
+  /* handleBalance handles notifications updating a wallet's balance. */
+  handleBalanceNote (note) {
+    const td = this.page.walletTable.querySelector(`[data-balance-target="${note.assetID}"]`)
+    td.textContent = (note.balances.zeroConf.available / 1e8).toFixed(8)
   }
 }
 

--- a/dex/testing/btc/harness.sh
+++ b/dex/testing/btc/harness.sh
@@ -14,7 +14,7 @@ ALPHA_WALLET_SEED="cMndqchcXSCUQDDZQSKU2cUHbPb5UfFL9afspxsBELeE6qx6ac9n"
 BETA_WALLET_SEED="cRHosJjgZ2UWsEAeHYYUFa8Z6viHYXm94GguGtpzMo6qwKBC1DSq"
 # Gamma is a named wallet in the alpha wallet directory.
 GAMMA_WALLET_SEED="cR6gasj1RtB9Qv9j2kVej2XzQmXPmZBcn8KzUmxSSCQoz3TqTNMg"
-GAMMA_WALLET_PASSWORD="abc"
+WALLET_PASSWORD="abc"
 GAMMA_ADDRESS="2N9Lwbw6DKoNSyTB9xL4e9LXftuPP7XU214"
 ALPHA_MINING_ADDR="2MzNGEV9CBZBptm25CZ4rm2TrKF8gfVU8XA"
 BETA_MINING_ADDR="2NC2bYfZ9GX3gnDZB8CL7pYLytNKMfVxYDX"
@@ -208,8 +208,10 @@ tmux send-keys -t $SESSION:2 "./alpha createwallet gamma${WAIT}" C-m\; wait-for 
 tmux send-keys -t $SESSION:2 "./gamma sethdseed true ${GAMMA_WALLET_SEED}${WAIT}" C-m\; wait-for donebtc
 tmux send-keys -t $SESSION:2 "./gamma getnewaddress${WAIT}" C-m\; wait-for donebtc
 tmux send-keys -t $SESSION:2 "./gamma getnewaddress \"\" \"legacy\"${WAIT}" C-m\; wait-for donebtc
-echo "Encrypting the gamma wallet (may take a minute)"
-tmux send-keys -t $SESSION:2 "./gamma encryptwallet ${GAMMA_WALLET_PASSWORD}${WAIT}" C-m\; wait-for donebtc
+echo "Encrypting wallets (may take a minute)"
+tmux send-keys -t $SESSION:2 "./gamma encryptwallet ${WALLET_PASSWORD}${WAIT}" C-m\; wait-for donebtc
+tmux send-keys -t $SESSION:2 "./beta encryptwallet ${WALLET_PASSWORD}${WAIT}" C-m\; wait-for donebtc
+
 echo "Sending 84 BTC to gamma in 8 blocks"
 for i in 10 18 5 7 1 15 3 25
 do


### PR DESCRIPTION
Update balances at the following times.

1. When registering
2. After withdrawal
3. After a trade is initiated and coins are locked
4. After any action on a match

A `Data`-severity notification is sent whenever an update occurs. Balances on the markets and wallets view are updated live. There is more to be done on the UI side, but I'd like to do it as part of a larger effort in a separate PR.

Changes to the simnet harness enable a second client to be run on the same machine, if done carefully. Will follow up with updates to the simnet testing wiki page.

Fixes some apparent bugs in the exchange wallets for the way unspent outputs are handled, to accommodate latency correctly, and to avoid a panic. I'm not sure how I went wrong there. Did the errors change? Might need more looking into, but I may have just botched it originally. 