### PR TITLE
auth,comms: don't try to drain AfterFunc channels

### DIFF
--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -117,10 +117,7 @@ func (client *clientInfo) respHandler(id uint64) *respHandler {
 		// called, but we found the response handler in the map,
 		// clientInfo.expire is waiting for the reqMtx lock and will return
 		// false, thus preventing the registered expire func from executing.
-		if !handler.expire.Stop() {
-			// Drain the Timer channel if Timer had fired as described above.
-			<-handler.expire.C
-		}
+		handler.expire.Stop()
 	}
 	return handler
 }

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -159,10 +159,7 @@ func (c *wsLink) respHandler(id uint64) *responseHandler {
 		// called, but we found the response handler in the map, wsLink.expire
 		// is waiting for the reqMtx lock and will return false, thus preventing
 		// the registered expire func from executing.
-		if !cb.expire.Stop() {
-			// Drain the Timer channel if Timer had fired as described above.
-			<-cb.expire.C
-		}
+		cb.expire.Stop()
 	}
 	return cb
 }

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -189,7 +189,7 @@ func (a *TAuth) RequestWithTimeout(user account.AccountID, msg *msgjson.Message,
 		if !found {
 			// If we have no preimage for this order, then we've decided to
 			// expire the response after the expire duration.
-			go func() { <-time.AfterFunc(expDur, exp).C }()
+			time.AfterFunc(expDur, exp)
 		}
 		log.Infof("found preimage: %x", pi)
 		piMsg := &msgjson.PreimageResponse{


### PR DESCRIPTION
For some reason I was following the pattern of draining a `Timer.C` channel if it had already fired when calling `Stop`, but this is not to be done for `Timer`s created with `AfterFunc` as per the [Go docs](https://golang.org/pkg/time/#Timer):

> When the `Timer` expires, the current time will be sent on `C`, unless the `Timer` was created by `AfterFunc`

Indeed, `time/sleep.go` makes it clear that the `C` channel is nil for timers created with `AfterFunc` and will block forever if you try to receive on it.