### PR TITLE
market: Errorf->Fatalf, and eliminate not-a-race

### DIFF
--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -648,7 +648,7 @@ func TestMarket_Run(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	startEpochIdx := 1 + encode.UnixMilli(time.Now())/epochDurationMSec
+	startEpochIdx := 2 + encode.UnixMilli(time.Now())/epochDurationMSec
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
This resolves a test timeout seen in https://github.com/decred/dcrdex/runs/715296974 for PR https://github.com/decred/dcrdex/pull/372, although it's still unclear why the market wasn't running.

The unguarded set of a channel was also technically a race but it couldn't ever be hit.  It wasn't necessary to nil it out, so don't.