### PR TITLE
server/comms: fix synchronization issues and drop sleeps in tests

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -47,7 +47,7 @@ type WsConn interface {
 	NextID() uint64
 	Send(msg *msgjson.Message) error
 	Request(msg *msgjson.Message, f func(*msgjson.Message)) error
-	Connect(ctx context.Context) (error, *sync.WaitGroup)
+	Connect(ctx context.Context) (*sync.WaitGroup, error)
 	MessageSource() <-chan *msgjson.Message
 }
 
@@ -375,7 +375,7 @@ func (conn *wsConn) NextID() uint64 {
 // connection will be returned. If the connection is successful, an
 // auto-reconnect goroutine will be started. To shutdown auto-reconnect, use
 // Stop() or cancel the context.
-func (conn *wsConn) Connect(ctx context.Context) (error, *sync.WaitGroup) {
+func (conn *wsConn) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	var ctxInternal context.Context
 	ctxInternal, conn.cancel = context.WithCancel(ctx)
 
@@ -400,7 +400,7 @@ func (conn *wsConn) Connect(ctx context.Context) (error, *sync.WaitGroup) {
 		close(conn.readCh) // signal to receivers that the wsConn is dead
 	}()
 
-	return conn.connect(ctxInternal), &conn.wg
+	return &conn.wg, conn.connect(ctxInternal)
 }
 
 // Stop can be used to close the connection and all of the goroutines started by

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -218,8 +218,8 @@ func (conn *TWebsocket) Request(msg *msgjson.Message, f msgFunc) error {
 	return conn.reqErr
 }
 func (conn *TWebsocket) MessageSource() <-chan *msgjson.Message { return conn.msgs }
-func (conn *TWebsocket) Connect(context.Context) (error, *sync.WaitGroup) {
-	return conn.connectErr, &sync.WaitGroup{}
+func (conn *TWebsocket) Connect(context.Context) (*sync.WaitGroup, error) {
+	return &sync.WaitGroup{}, conn.connectErr
 }
 
 type TDB struct {
@@ -441,8 +441,8 @@ func (w *TXCWallet) Info() *asset.WalletInfo {
 	return &asset.WalletInfo{}
 }
 
-func (w *TXCWallet) Connect(ctx context.Context) (error, *sync.WaitGroup) {
-	return w.connectErr, &sync.WaitGroup{}
+func (w *TXCWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
+	return &sync.WaitGroup{}, w.connectErr
 }
 
 func (w *TXCWallet) Run(ctx context.Context) { <-ctx.Done() }

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -270,14 +270,14 @@ func New(cfg *Config) (*RPCServer, error) {
 }
 
 // Connect starts the RPC server. Satisfies the dex.Connector interface.
-func (s *RPCServer) Connect(ctx context.Context) (error, *sync.WaitGroup) {
+func (s *RPCServer) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	// ctx passed to newMarketSyncer when making new market syncers.
 	s.ctx = ctx
 
 	// Create listener.
 	listener, err := tls.Listen("tcp", s.addr, s.tlsConfig)
 	if err != nil {
-		return fmt.Errorf("can't listen on %s. rpc server quitting: %v", s.addr, err), nil
+		return nil, fmt.Errorf("can't listen on %s. rpc server quitting: %v", s.addr, err)
 	}
 
 	// Close the listener on context cancellation.
@@ -306,7 +306,7 @@ func (s *RPCServer) Connect(ctx context.Context) (error, *sync.WaitGroup) {
 		log.Infof("RPC server off")
 	}()
 	log.Infof("RPC server listening on %s", s.addr)
-	return nil, &s.wg
+	return &s.wg, nil
 }
 
 // handleRequest sends the request to the correct handler function if able.

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -269,16 +269,15 @@ func New(cfg *Config) (*RPCServer, error) {
 	return s, nil
 }
 
-// Run starts the web server. Satisfies the dex.Runner interface.
-func (s *RPCServer) Run(ctx context.Context) {
+// Connect starts the RPC server. Satisfies the dex.Connector interface.
+func (s *RPCServer) Connect(ctx context.Context) (error, *sync.WaitGroup) {
 	// ctx passed to newMarketSyncer when making new market syncers.
 	s.ctx = ctx
 
 	// Create listener.
 	listener, err := tls.Listen("tcp", s.addr, s.tlsConfig)
 	if err != nil {
-		log.Errorf("can't listen on %s. rpc server quitting: %v", s.addr, err)
-		return
+		return fmt.Errorf("can't listen on %s. rpc server quitting: %v", s.addr, err), nil
 	}
 
 	// Close the listener on context cancellation.
@@ -292,19 +291,22 @@ func (s *RPCServer) Run(ctx context.Context) {
 			log.Errorf("HTTP server Shutdown: %v", err)
 		}
 	}()
-	log.Infof("RPC server listening on %s", s.addr)
-	if err := s.srv.Serve(listener); err != http.ErrServerClosed {
-		log.Warnf("unexpected (http.Server).Serve error: %v", err)
-	}
-	s.mtx.Lock()
-	for _, cl := range s.clients {
-		cl.Disconnect()
-	}
-	s.mtx.Unlock()
 
-	// Wait for market syncers to finish and Shutdown.
-	s.wg.Wait()
-	log.Infof("RPC server off")
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		if err := s.srv.Serve(listener); err != http.ErrServerClosed {
+			log.Warnf("unexpected (http.Server).Serve error: %v", err)
+		}
+		s.mtx.Lock()
+		for _, cl := range s.clients {
+			cl.Disconnect()
+		}
+		s.mtx.Unlock()
+		log.Infof("RPC server off")
+	}()
+	log.Infof("RPC server listening on %s", s.addr)
+	return nil, &s.wg
 }
 
 // handleRequest sends the request to the correct handler function if able.

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -287,7 +287,7 @@ func TestLoadMarket(t *testing.T) {
 	link := newLink()
 	s, tCore, shutdown := newTServer(t, false, "", "")
 	defer shutdown()
-	err, _ := link.cl.Connect(tCtx)
+	_, err := link.cl.Connect(tCtx)
 	if err != nil {
 		t.Fatalf("WSLink Start: %v", err)
 	}

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -235,11 +235,14 @@ func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer,
 		t.Fatalf("error creating server: %v", err)
 	}
 	if start {
-		waiter := dex.NewStartStopWaiter(s)
-		waiter.Start(ctx)
+		cm := dex.NewConnectionMaster(s)
+		err := cm.Connect(ctx)
+		if err != nil {
+			t.Fatalf("Error starting WebServer: %v", err)
+		}
 		shutdown = func() {
 			killCtx()
-			waiter.WaitForShutdown()
+			cm.Disconnect()
 		}
 	} else {
 		shutdown = killCtx
@@ -284,7 +287,10 @@ func TestLoadMarket(t *testing.T) {
 	link := newLink()
 	s, tCore, shutdown := newTServer(t, false, "", "")
 	defer shutdown()
-	link.cl.Start()
+	err, _ := link.cl.Connect(tCtx)
+	if err != nil {
+		t.Fatalf("WSLink Start: %v", err)
+	}
 	defer link.cl.Disconnect()
 	params := &marketLoad{
 		Host:  "abc",

--- a/client/rpcserver/websocket.go
+++ b/client/rpcserver/websocket.go
@@ -92,8 +92,13 @@ func (s *RPCServer) websocketHandler(conn ws.Connection, ip string) {
 		delete(s.clients, cl.cid)
 		s.mtx.Unlock()
 	}()
-	cl.Start()
-	cl.WaitForShutdown()
+	cm := dex.NewConnectionMaster(cl)
+	err := cm.Connect(s.ctx)
+	if err != nil {
+		log.Errorf("websocketHandler client Connect: %v")
+		return
+	}
+	cm.Wait()
 	log.Tracef("Disconnected websocket client %s", ip)
 }
 

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -707,7 +707,6 @@ func TestServer(t *testing.T) {
 	time.AfterFunc(time.Minute*59, func() { shutdown() })
 	logger := slog.NewBackend(os.Stdout).Logger("TEST")
 	logger.SetLevel(slog.LevelTrace)
-	time.AfterFunc(time.Minute*60, func() { shutdown() })
 	tCore := newTCore()
 
 	if register {
@@ -719,7 +718,11 @@ func TestServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating server: %v", err)
 	}
-	go s.Run(tCtx)
+	cm := dex.NewConnectionMaster(s)
+	err = cm.Connect(tCtx)
+	if err != nil {
+		t.Fatalf("Connect error: %v", err)
+	}
 	go tCore.runEpochs()
-	<-tCtx.Done()
+	cm.Wait()
 }

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -259,15 +259,14 @@ func New(core clientCore, addr string, logger slog.Logger, reloadHTML bool) (*We
 	return s, nil
 }
 
-// Run starts the web server. Satisfies the dex.Runner interface.
-func (s *WebServer) Run(ctx context.Context) {
+// Connect starts the web server. Satisfies the dex.Connector interface.
+func (s *WebServer) Connect(ctx context.Context) (error, *sync.WaitGroup) {
 	// We'll use the context for market syncers.
 	s.ctx = ctx
 	// Start serving.
 	listener, err := net.Listen("tcp", s.addr)
 	if err != nil {
-		log.Errorf("Can't listen on %s. web server quitting: %v", s.addr, err)
-		return
+		return fmt.Errorf("Can't listen on %s. web server quitting: %v", s.addr, err), nil
 	}
 
 	// Shutdown the server on context cancellation.
@@ -285,25 +284,28 @@ func (s *WebServer) Run(ctx context.Context) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		err = s.srv.Serve(listener)
+		if !errors.Is(err, http.ErrServerClosed) {
+			log.Warnf("unexpected (http.Server).Serve error: %v", err)
+		}
+		log.Infof("Web server off")
+		// Disconnect the websocket clients since Shutdown does not deal with
+		// hijacked websocket connections.
+		s.mtx.Lock()
+		for _, cl := range s.clients {
+			cl.Disconnect()
+		}
+		s.mtx.Unlock()
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		s.readNotifications(ctx)
 	}()
 
 	log.Infof("Web server listening on http://%s", s.addr)
-	err = s.srv.Serve(listener)
-	if !errors.Is(err, http.ErrServerClosed) {
-		log.Warnf("unexpected (http.Server).Serve error: %v", err)
-	}
-	log.Infof("Web server off")
-
-	// Disconnect the websocket clients since Shutdown does not deal with
-	// hijacked websocket connections.
-	s.mtx.Lock()
-	for _, cl := range s.clients {
-		cl.Disconnect()
-	}
-	s.mtx.Unlock()
-
-	wg.Wait()
+	return nil, &wg
 }
 
 // authorize creates, stores, and returns a new auth token to identify the

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -260,13 +260,13 @@ func New(core clientCore, addr string, logger slog.Logger, reloadHTML bool) (*We
 }
 
 // Connect starts the web server. Satisfies the dex.Connector interface.
-func (s *WebServer) Connect(ctx context.Context) (error, *sync.WaitGroup) {
+func (s *WebServer) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	// We'll use the context for market syncers.
 	s.ctx = ctx
 	// Start serving.
 	listener, err := net.Listen("tcp", s.addr)
 	if err != nil {
-		return fmt.Errorf("Can't listen on %s. web server quitting: %v", s.addr, err), nil
+		return nil, fmt.Errorf("Can't listen on %s. web server quitting: %v", s.addr, err)
 	}
 
 	// Shutdown the server on context cancellation.
@@ -305,7 +305,7 @@ func (s *WebServer) Connect(ctx context.Context) (error, *sync.WaitGroup) {
 	}()
 
 	log.Infof("Web server listening on http://%s", s.addr)
-	return nil, &wg
+	return &wg, nil
 }
 
 // authorize creates, stores, and returns a new auth token to identify the

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -316,7 +316,7 @@ func TestLoadMarket(t *testing.T) {
 	link := newLink()
 	s, tCore, shutdown := newTServer(t, false)
 	defer shutdown()
-	err, _ := link.cl.Connect(tCtx)
+	_, err := link.cl.Connect(tCtx)
 	if err != nil {
 		t.Fatalf("WSLink Start: %v", err)
 	}

--- a/client/webserver/websocket.go
+++ b/client/webserver/websocket.go
@@ -91,8 +91,13 @@ func (s *WebServer) websocketHandler(conn ws.Connection, ip string) {
 		delete(s.clients, cl.cid)
 		s.mtx.Unlock()
 	}()
-	cl.Start()
-	cl.WaitForShutdown()
+	cm := dex.NewConnectionMaster(cl)
+	err := cm.Connect(s.ctx)
+	if err != nil {
+		log.Errorf("websocketHandler client Connect: %v")
+		return
+	}
+	cm.Wait()
 	log.Tracef("Disconnected websocket client %s", ip)
 }
 

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -75,7 +75,7 @@ func (ssw *StartStopWaiter) Stop() {
 // Connector is any type that implements the Connect method, which will return
 // a connection error, and a WaitGroup that can be waited on at Disconnection.
 type Connector interface {
-	Connect(ctx context.Context) (error, *sync.WaitGroup)
+	Connect(ctx context.Context) (*sync.WaitGroup, error)
 }
 
 // ConnectionMaster manages a Connector.
@@ -97,7 +97,7 @@ func NewConnectionMaster(c Connector) *ConnectionMaster {
 func (c *ConnectionMaster) Connect(ctx context.Context) (err error) {
 	c.init(ctx)
 	c.mtx.Lock()
-	err, c.wg = c.connector.Connect(c.ctx)
+	c.wg, err = c.connector.Connect(c.ctx)
 	c.mtx.Unlock()
 	return err
 }

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -109,3 +109,8 @@ func (c *ConnectionMaster) Disconnect() {
 	defer c.mtx.RUnlock()
 	c.wg.Wait()
 }
+
+// Wait waits for the the WaitGroup returned by Connect.
+func (c *ConnectionMaster) Wait() {
+	c.wg.Wait()
+}

--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -170,8 +170,8 @@ func (c *WSLink) Disconnect() {
 // be run as a goroutine.
 func (c *WSLink) inHandler(ctx context.Context) {
 	// Ensure the connection is closed.
-	defer c.Disconnect()
 	defer c.wg.Done()
+	defer c.Disconnect()
 out:
 	for {
 		// Quit when the context is closed.

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -348,7 +348,8 @@ func (s *Server) disconnectClients() {
 	s.clientMtx.Unlock()
 }
 
-// addClient assigns the client an ID and adds it to the map.
+// addClient assigns the client an ID, adds it to the map, and attempts to
+// connect.
 func (s *Server) addClient(client *wsLink, ctx context.Context) (*dex.ConnectionMaster, error) {
 	s.clientMtx.Lock()
 	defer s.clientMtx.Unlock()

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/dex/ws"
 	"github.com/decred/dcrd/certgen"
@@ -226,7 +227,10 @@ func (s *Server) Run(ctx context.Context) {
 		// connections. We must wait on each websocketHandler to return in
 		// response to disconnectClients.
 		wg.Add(1)
-		go s.websocketHandler(&wg, wsConn, ip)
+		go func() {
+			defer wg.Done()
+			s.websocketHandler(ctx, wsConn, ip)
+		}()
 	})
 
 	// Start serving.
@@ -290,20 +294,24 @@ func (s *Server) banish(ip string) {
 // websocketHandler handles a new websocket client by creating a new wsClient,
 // starting it, and blocking until the connection closes. This method should be
 // run as a goroutine.
-func (s *Server) websocketHandler(wg *sync.WaitGroup, conn ws.Connection, ip string) {
-	defer wg.Done()
+func (s *Server) websocketHandler(ctx context.Context, conn ws.Connection, ip string) {
 	log.Debugf("New websocket client %s", ip)
 
 	// Create a new websocket client to handle the new websocket connection
 	// and wait for it to shutdown.  Once it has shutdown (and hence
 	// disconnected), remove it.
 	client := newWSLink(ip, conn)
-	s.addClient(client)
-	client.Start()
+	cm, err := s.addClient(client, ctx)
+	if err != nil {
+		log.Errorf("Failed to add client %s", ip)
+		return
+	}
+	defer s.removeClient(client.id)
+
 	// The connection remains until the connection is lost or the link's
 	// disconnect method is called (e.g. via disconnectClients).
-	client.WaitForShutdown()
-	s.removeClient(client.id)
+	cm.Wait()
+
 	// If the ban flag is set, quarantine the client's IP address.
 	if client.ban {
 		s.banish(client.IP())
@@ -341,12 +349,14 @@ func (s *Server) disconnectClients() {
 }
 
 // addClient assigns the client an ID and adds it to the map.
-func (s *Server) addClient(client *wsLink) {
+func (s *Server) addClient(client *wsLink, ctx context.Context) (*dex.ConnectionMaster, error) {
 	s.clientMtx.Lock()
+	defer s.clientMtx.Unlock()
 	client.id = s.counter
 	s.counter++
 	s.clients[client.id] = client
-	s.clientMtx.Unlock()
+	cm := dex.NewConnectionMaster(client)
+	return cm, cm.Connect(ctx)
 }
 
 // Remove the client from the map.


### PR DESCRIPTION
Resolves #394

Eliminate sloppy `time.Sleep` sync patterns in tests. Improves `WSLink.Send` synchronization so that a graceful shutdown will wait for messages to finish sending. 