### PR TITLE
core: fix locktime handling

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1969,7 +1969,7 @@ func TestTradeTracking(t *testing.T) {
 	// Send the counter-party's init info.
 	auditQty := calc.BaseToQuote(rate, matchSize)
 	audit, auditInfo := tMsgAudit(loid, mid, addr, auditQty, proof.SecretHash)
-	auditInfo.expiration = matchTime.Add(24 * time.Hour)
+	auditInfo.expiration = matchTime.Add(dex.LockTimeTaker)
 	tBtcWallet.auditInfo = auditInfo
 	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
 
@@ -2111,7 +2111,7 @@ func TestTradeTracking(t *testing.T) {
 	// Now send through the audit request for the maker's init.
 	audit, auditInfo = tMsgAudit(loid, mid, addr, matchSize, nil)
 	tBtcWallet.auditInfo = auditInfo
-	auditInfo.expiration = matchTime.Add(48 * time.Hour)
+	auditInfo.expiration = matchTime.Add(dex.LockTimeMaker)
 	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
 	err = handleAuditRoute(tCore, rig.dc, msg)
 	if err != nil {
@@ -2310,13 +2310,16 @@ func TestRefunds(t *testing.T) {
 
 	// MAKER REFUND, INVALID TAKER COUNTERSWAP
 	//
+
+	matchTime := time.Now()
 	msgMatch := &msgjson.Match{
-		OrderID:  loid[:],
-		MatchID:  mid[:],
-		Quantity: matchSize,
-		Rate:     rate,
-		Address:  "counterparty-address",
-		Side:     uint8(order.Maker),
+		OrderID:    loid[:],
+		MatchID:    mid[:],
+		Quantity:   matchSize,
+		Rate:       rate,
+		Address:    "counterparty-address",
+		Side:       uint8(order.Maker),
+		ServerTime: encode.UnixMilliU(matchTime),
 	}
 	counterSwapID := encode.RandomBytes(36)
 	tDcrWallet.swapReceipts = []asset.Receipt{&tReceipt{coin: &tCoin{id: counterSwapID}}}
@@ -2340,6 +2343,7 @@ func TestRefunds(t *testing.T) {
 	auditQty := calc.BaseToQuote(rate, matchSize)
 	audit, auditInfo := tMsgAudit(loid, mid, addr, auditQty, proof.SecretHash)
 	tBtcWallet.auditInfo = auditInfo
+	auditInfo.expiration = matchTime.Add(dex.LockTimeMaker)
 	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
 
 	// Check audit errors.
@@ -2381,6 +2385,7 @@ func TestRefunds(t *testing.T) {
 	// Send through the audit request for the maker's init.
 	audit, auditInfo = tMsgAudit(loid, mid, addr, matchSize, nil)
 	tBtcWallet.auditInfo = auditInfo
+	auditInfo.expiration = matchTime.Add(dex.LockTimeMaker)
 	tBtcWallet.auditErr = nil
 	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
 	err = handleAuditRoute(tCore, rig.dc, msg)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1969,7 +1969,7 @@ func TestTradeTracking(t *testing.T) {
 	// Send the counter-party's init info.
 	auditQty := calc.BaseToQuote(rate, matchSize)
 	audit, auditInfo := tMsgAudit(loid, mid, addr, auditQty, proof.SecretHash)
-	auditInfo.expiration = matchTime.Add(dex.LockTimeTaker)
+	auditInfo.expiration = encode.DropMilliseconds(matchTime.Add(dex.LockTimeTaker))
 	tBtcWallet.auditInfo = auditInfo
 	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
 
@@ -2111,7 +2111,7 @@ func TestTradeTracking(t *testing.T) {
 	// Now send through the audit request for the maker's init.
 	audit, auditInfo = tMsgAudit(loid, mid, addr, matchSize, nil)
 	tBtcWallet.auditInfo = auditInfo
-	auditInfo.expiration = matchTime.Add(dex.LockTimeMaker)
+	auditInfo.expiration = encode.DropMilliseconds(matchTime.Add(dex.LockTimeMaker))
 	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
 	err = handleAuditRoute(tCore, rig.dc, msg)
 	if err != nil {
@@ -2343,7 +2343,7 @@ func TestRefunds(t *testing.T) {
 	auditQty := calc.BaseToQuote(rate, matchSize)
 	audit, auditInfo := tMsgAudit(loid, mid, addr, auditQty, proof.SecretHash)
 	tBtcWallet.auditInfo = auditInfo
-	auditInfo.expiration = matchTime.Add(dex.LockTimeMaker)
+	auditInfo.expiration = encode.DropMilliseconds(matchTime.Add(dex.LockTimeMaker))
 	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
 
 	// Check audit errors.
@@ -2385,7 +2385,7 @@ func TestRefunds(t *testing.T) {
 	// Send through the audit request for the maker's init.
 	audit, auditInfo = tMsgAudit(loid, mid, addr, matchSize, nil)
 	tBtcWallet.auditInfo = auditInfo
-	auditInfo.expiration = matchTime.Add(dex.LockTimeMaker)
+	auditInfo.expiration = encode.DropMilliseconds(matchTime.Add(dex.LockTimeMaker))
 	tBtcWallet.auditErr = nil
 	msg, _ = msgjson.NewRequest(1, msgjson.AuditRoute, audit)
 	err = handleAuditRoute(tCore, rig.dc, msg)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -949,7 +949,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 	auth.AuditSig = audit.Sig
 	proof.CounterScript = audit.Contract
 	matchTime := encode.UnixTimeMilli(int64(auth.MatchStamp))
-	reqLockTime := matchTime.Add(dex.LockTimeMaker) // counterparty = maker, their locktime = 48 hours.
+	reqLockTime := matchTime.Add(dex.LockTimeMaker).Truncate(time.Millisecond) // counterparty = maker, their locktime = 48 hours.
 	if dbMatch.Side == order.Maker {
 		// Check that the secret hash is correct.
 		if !bytes.Equal(proof.SecretHash, auditInfo.SecretHash()) {
@@ -958,7 +958,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 		match.setStatus(order.TakerSwapCast)
 		proof.TakerSwap = []byte(audit.CoinID)
 		// counterparty = taker, their locktime = 24 hours.
-		reqLockTime = matchTime.Add(dex.LockTimeTaker)
+		reqLockTime = matchTime.Add(dex.LockTimeTaker).Truncate(time.Millisecond)
 	} else {
 		proof.SecretHash = auditInfo.SecretHash()
 		match.setStatus(order.MakerSwapCast)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -949,7 +949,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 	auth.AuditSig = audit.Sig
 	proof.CounterScript = audit.Contract
 	matchTime := encode.UnixTimeMilli(int64(auth.MatchStamp))
-	reqLockTime := matchTime.Add(48 * time.Hour) // counterparty = maker, their locktime = 48 hours.
+	reqLockTime := matchTime.Add(dex.LockTimeMaker) // counterparty = maker, their locktime = 48 hours.
 	if dbMatch.Side == order.Maker {
 		// Check that the secret hash is correct.
 		if !bytes.Equal(proof.SecretHash, auditInfo.SecretHash()) {
@@ -958,7 +958,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 		match.setStatus(order.TakerSwapCast)
 		proof.TakerSwap = []byte(audit.CoinID)
 		// counterparty = taker, their locktime = 24 hours.
-		reqLockTime = matchTime.Add(24 * time.Hour)
+		reqLockTime = matchTime.Add(dex.LockTimeTaker)
 	} else {
 		proof.SecretHash = auditInfo.SecretHash()
 		match.setStatus(order.MakerSwapCast)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -949,7 +949,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 	auth.AuditSig = audit.Sig
 	proof.CounterScript = audit.Contract
 	matchTime := encode.UnixTimeMilli(int64(auth.MatchStamp))
-	reqLockTime := matchTime.Add(dex.LockTimeMaker).Truncate(time.Millisecond) // counterparty = maker, their locktime = 48 hours.
+	reqLockTime := encode.DropMilliseconds(matchTime.Add(dex.LockTimeMaker)) // counterparty = maker, their locktime = 48 hours.
 	if dbMatch.Side == order.Maker {
 		// Check that the secret hash is correct.
 		if !bytes.Equal(proof.SecretHash, auditInfo.SecretHash()) {
@@ -958,7 +958,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 		match.setStatus(order.TakerSwapCast)
 		proof.TakerSwap = []byte(audit.CoinID)
 		// counterparty = taker, their locktime = 24 hours.
-		reqLockTime = matchTime.Add(dex.LockTimeTaker).Truncate(time.Millisecond)
+		reqLockTime = encode.DropMilliseconds(matchTime.Add(dex.LockTimeTaker))
 	} else {
 		proof.SecretHash = auditInfo.SecretHash()
 		match.setStatus(order.MakerSwapCast)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -625,12 +625,12 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 			value = calc.BaseToQuote(dbMatch.Rate, dbMatch.Quantity)
 		}
 		matchTime := encode.UnixTimeMilli(int64(auth.MatchStamp))
-		lockTime := matchTime.Add(time.Hour * 24).UTC().Unix()
+		lockTime := matchTime.Add(dex.LockTimeTaker).UTC().Unix()
 		if dbMatch.Side == order.Maker {
 			proof.Secret = encode.RandomBytes(32)
 			secretHash := sha256.Sum256(proof.Secret)
 			proof.SecretHash = secretHash[:]
-			lockTime = matchTime.Add(time.Hour * 48).UTC().Unix()
+			lockTime = matchTime.Add(dex.LockTimeMaker).UTC().Unix()
 		}
 
 		contract := &asset.Contract{

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -200,7 +200,7 @@ export default class MarketsPage extends BasePage {
     // Fetch the first market in the list, or the users last selected market, if
     // it exists.
     var selected = (data && data.market) ? data.market : State.fetch(lastMarketKey)
-    if (!this.marketList.exists(selected.host, selected.base, selected.quote)) {
+    if (!selected || !this.marketList.exists(selected.host, selected.base, selected.quote)) {
       selected = this.marketList.first()
     }
     this.setMarket(selected.host, selected.base, selected.quote)

--- a/dex/asset.go
+++ b/dex/asset.go
@@ -6,6 +6,7 @@ package dex
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type Error string
@@ -14,6 +15,8 @@ func (err Error) Error() string { return string(err) }
 
 const (
 	UnsupportedScriptError = Error("unsupported script type")
+	LockTimeTaker          = 24 * time.Hour
+	LockTimeMaker          = 48 * time.Hour
 )
 
 // Network flags passed to asset backends to signify which network to use.

--- a/dex/encode/encode.go
+++ b/dex/encode/encode.go
@@ -87,6 +87,11 @@ func UnixTimeMilli(msEpoch int64) time.Time {
 	return time.Unix(sec, msec*1e6).UTC()
 }
 
+// DropMilliseconds returns the time truncated to the previous second.
+func DropMilliseconds(t time.Time) time.Time {
+	return t.Truncate(time.Second)
+}
+
 // DecodeUTime interprets bytes as a uint64 millisecond Unix timestamp and
 // creates a time.Time.
 func DecodeUTime(b []byte) time.Time {

--- a/dex/order/match.go
+++ b/dex/order/match.go
@@ -8,7 +8,9 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"time"
 
+	"decred.org/dcrdex/dex/encode"
 	"github.com/decred/dcrd/crypto/blake256"
 )
 
@@ -129,6 +131,11 @@ type Signatures struct {
 type EpochID struct {
 	Idx uint64
 	Dur uint64
+}
+
+// End is the end time of the epoch.
+func (e *EpochID) End() time.Time {
+	return encode.UnixTimeMilli(int64((e.Idx + 1) * e.Dur))
 }
 
 // Match represents a match between two orders.

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -5,6 +5,7 @@ package asset
 
 import (
 	"fmt"
+	"time"
 
 	"decred.org/dcrdex/dex"
 )
@@ -90,6 +91,8 @@ type Contract interface {
 	FeeRate() uint64
 	// Script is the contract redeem script.
 	Script() []byte
+	// LockTime is the refund locktime.
+	LockTime() time.Time
 }
 
 // BlockUpdate is sent over the update channel when a tip change is detected.

--- a/server/asset/dcr/utxo.go
+++ b/server/asset/dcr/utxo.go
@@ -6,6 +6,7 @@ package dcr
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"decred.org/dcrdex/dex"
 	dexdcr "decred.org/dcrdex/dex/dcr"
@@ -184,6 +185,8 @@ type UTXO struct {
 	value uint64
 	// address is populated for swap contract outputs
 	address string
+	// lockTime is populated for swap contract outputs.
+	lockTime time.Time
 }
 
 // Check that UTXO satisfies the asset.Contract interface
@@ -336,11 +339,12 @@ func (utxo *UTXO) auditContract() error {
 	if !bytes.Equal(dcrutil.Hash160(utxo.redeemScript), scriptHash) {
 		return fmt.Errorf("swap contract hash mismatch for %s:%d", tx.hash, utxo.vout)
 	}
-	_, receiver, err := extractSwapAddresses(utxo.redeemScript)
+	_, receiver, lockTime, _, err := dexdcr.ExtractSwapDetails(utxo.redeemScript, chainParams)
 	if err != nil {
-		return fmt.Errorf("error extracting address from swap contract for %s:%d", tx.hash, utxo.vout)
+		return fmt.Errorf("error parsing swap contract for %s:%d: %v", tx.hash, utxo.redeemScript, err)
 	}
-	utxo.address = receiver
+	utxo.address = receiver.String()
+	utxo.lockTime = time.Unix(int64(lockTime), 0)
 	return nil
 }
 
@@ -363,4 +367,10 @@ func (utxo *UTXO) Value() uint64 {
 // Address is the receiving address if this is a swap contract.
 func (utxo *UTXO) Address() string {
 	return utxo.address
+}
+
+// LockTime is a method on the asset.Contract interface for reading the locktime
+// in the contract script.
+func (utxo *UTXO) LockTime() time.Time {
+	return utxo.lockTime
 }

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -350,6 +350,7 @@ func (u *tUTXO) SpendsCoin([]byte) (bool, error) { return true, nil }
 func (u *tUTXO) Value() uint64                   { return u.val }
 func (u *tUTXO) FeeRate() uint64                 { return 0 }
 func (u *tUTXO) Script() []byte                  { return nil }
+func (u *tUTXO) LockTime() time.Time             { return time.Time{} }
 
 type tUser struct {
 	acct    account.AccountID

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/dex/order"
@@ -85,6 +86,7 @@ type matchTracker struct {
 	mtx sync.RWMutex // Match.Sigs and Match.Status
 	*order.Match
 	time        time.Time
+	matchTime   time.Time
 	makerStatus *swapStatus
 	takerStatus *swapStatus
 }
@@ -1090,6 +1092,16 @@ func (s *Swapper) processInit(msg *msgjson.Message, params *msgjson.Init, stepIn
 		return wait.DontTryAgain
 	}
 
+	reqLockTime := stepInfo.match.matchTime.Add(dex.LockTimeTaker)
+	if stepInfo.actor.isMaker {
+		reqLockTime = stepInfo.match.matchTime.Add(dex.LockTimeMaker)
+	}
+	if contract.LockTime().Before(reqLockTime) {
+		s.respondError(msg.ID, actor.user, msgjson.ContractError,
+			fmt.Sprintf("contract error. expected lock time >= %s, got %s", reqLockTime, contract.LockTime()))
+		return wait.DontTryAgain
+	}
+
 	// Update the match.
 	swapTime := unixMsNow()
 	matchID := stepInfo.match.Match.ID()
@@ -1513,8 +1525,9 @@ func (s *Swapper) readMatches(matchSets []*order.MatchSet) []*matchTracker {
 			}
 
 			matches = append(matches, &matchTracker{
-				Match: match,
-				time:  nowMs,
+				Match:     match,
+				time:      nowMs,
+				matchTime: match.Epoch.End(),
 				makerStatus: &swapStatus{
 					swapAsset: makerSwapAsset,
 				},
@@ -1540,7 +1553,7 @@ func extractAddress(ord order.Order) string {
 // matchNotifications creates a pair of msgjson.MatchNotification from a
 // matchTracker.
 func matchNotifications(match *matchTracker) (makerMsg *msgjson.Match, takerMsg *msgjson.Match) {
-	stamp := (match.Epoch.Idx + 1) * match.Epoch.Dur
+	stamp := encode.UnixMilliU(match.matchTime)
 	return &msgjson.Match{
 			OrderID:    idToBytes(match.Maker.ID()),
 			MatchID:    idToBytes(match.ID()),

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1092,9 +1092,9 @@ func (s *Swapper) processInit(msg *msgjson.Message, params *msgjson.Init, stepIn
 		return wait.DontTryAgain
 	}
 
-	reqLockTime := stepInfo.match.matchTime.Add(dex.LockTimeTaker)
+	reqLockTime := encode.DropMilliseconds(stepInfo.match.matchTime.Add(dex.LockTimeTaker))
 	if stepInfo.actor.isMaker {
-		reqLockTime = stepInfo.match.matchTime.Add(dex.LockTimeMaker)
+		reqLockTime = encode.DropMilliseconds(stepInfo.match.matchTime.Add(dex.LockTimeMaker))
 	}
 	if contract.LockTime().Before(reqLockTime) {
 		s.respondError(msg.ID, actor.user, msgjson.ContractError,

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -1029,9 +1029,9 @@ func tNewSwap(matchInfo *tMatch, oid order.OrderID, recipient string, user *tUse
 		id:        coinID,
 	}
 
-	swap.lockTime = matchInfo.match.Epoch.End().Add(dex.LockTimeTaker)
+	swap.lockTime = encode.DropMilliseconds(matchInfo.match.Epoch.End().Add(dex.LockTimeTaker))
 	if user == matchInfo.maker {
-		swap.lockTime = matchInfo.match.Epoch.End().Add(dex.LockTimeMaker)
+		swap.lockTime = encode.DropMilliseconds(matchInfo.match.Epoch.End().Add(dex.LockTimeMaker))
 	}
 
 	if !tLockTimeSpoofer.IsZero() {

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -321,6 +321,7 @@ type TCoin struct {
 	confsErr  error
 	auditAddr string
 	auditVal  uint64
+	lockTime  time.Time
 }
 
 func (coin *TCoin) Confirmations() (int64, error) {
@@ -331,6 +332,10 @@ func (coin *TCoin) Confirmations() (int64, error) {
 
 func (coin *TCoin) Address() string {
 	return coin.auditAddr
+}
+
+func (coin *TCoin) LockTime() time.Time {
+	return coin.lockTime
 }
 
 func (coin *TCoin) setConfs(confs int64) {
@@ -1009,6 +1014,7 @@ type tSwap struct {
 
 var tValSpoofer uint64 = 1
 var tRecipientSpoofer = ""
+var tLockTimeSpoofer time.Time
 
 func tNewSwap(matchInfo *tMatch, oid order.OrderID, recipient string, user *tUser) *tSwap {
 	auditVal := matchInfo.qty
@@ -1016,12 +1022,22 @@ func tNewSwap(matchInfo *tMatch, oid order.OrderID, recipient string, user *tUse
 		auditVal = matcher.BaseToQuote(matchInfo.rate, matchInfo.qty)
 	}
 	coinID := randBytes(36)
-	makerSwap := &TCoin{
+	swap := &TCoin{
 		confs:     0,
 		auditAddr: recipient + tRecipientSpoofer,
 		auditVal:  auditVal * tValSpoofer,
 		id:        coinID,
 	}
+
+	swap.lockTime = matchInfo.match.Epoch.End().Add(dex.LockTimeTaker)
+	if user == matchInfo.maker {
+		swap.lockTime = matchInfo.match.Epoch.End().Add(dex.LockTimeMaker)
+	}
+
+	if !tLockTimeSpoofer.IsZero() {
+		swap.lockTime = tLockTimeSpoofer
+	}
+
 	contract := "01234567" + user.sigHex
 	req, _ := msgjson.NewRequest(1, msgjson.InitRoute, &msgjson.Init{
 		OrderID: oid[:],
@@ -1033,7 +1049,7 @@ func tNewSwap(matchInfo *tMatch, oid order.OrderID, recipient string, user *tUse
 	})
 
 	return &tSwap{
-		coin:     makerSwap,
+		coin:     swap,
 		req:      req,
 		contract: contract,
 	}
@@ -1546,6 +1562,11 @@ func TestMalformedSwap(t *testing.T) {
 	ensureNilErr(rig.sendSwap_maker(false))
 	checkContractErr(matchInfo.maker)
 	tRecipientSpoofer = ""
+	// Bad locktime
+	tLockTimeSpoofer = time.Unix(1, 0)
+	ensureNilErr(rig.sendSwap_maker(false))
+	checkContractErr(matchInfo.maker)
+	tLockTimeSpoofer = time.Time{}
 	// Now make sure it works.
 	ensureNilErr(rig.sendSwap_maker(true))
 }


### PR DESCRIPTION
Locktime was not being set correctly. The server [intentionally sets](https://github.com/decred/dcrdex/blob/2ed220b0af975fe28b3fb33f9e2c0ec252e069a7/server/swap/swap.go#L1543) the `msgjson.Match.ServerTime` based on the match epoch so that locktime can be based off of a common point for both maker and taker. Plus, taker wasn't setting their locktime correctly when constructing the contract, which is now fixed. 