### PR TITLE
app: display the commit hash

### DIFF
--- a/client/webserver/site/package.json
+++ b/client/webserver/site/package.json
@@ -30,6 +30,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-standard": "^4.0.1",
+    "git-revision-webpack-plugin": "^3.0.6",
     "mini-css-extract-plugin": "^0.9.0",
     "node-sass": "^4.14.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -2,11 +2,14 @@
 {{template "top" .}}
 <div id="main" data-handler="settings" class="main align-items-center justify-content-center flex-column">
 
-  <div class="form-check">
-    <input class="form-check-input" type="checkbox" value="" id="darkMode"{{if .UserInfo.DarkMode}} checked{{end}}>
-    <label class="form-check-label" for="darkMode">
-      Dark Mode
-    </label>
+  <div class="d-inline-block">
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" value="" id="darkMode"{{if .UserInfo.DarkMode}} checked{{end}}>
+      <label class="form-check-label" for="darkMode">
+        Dark Mode
+      </label>
+    </div>
+    <div class="pt-2">Build ID: <span id="commitHash" class="mono"></span></div>
   </div>
 
 </div>

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -6,7 +6,7 @@ import WalletsPage from './wallets'
 import SettingsPage from './settings'
 import MarketsPage, { marketID } from './markets'
 import { getJSON, postJSON } from './http'
-
+import commitHash from 'commitHash'
 import * as ntfn from './notifications'
 import ws from './ws'
 
@@ -34,6 +34,8 @@ export default class Application {
       accounts: {},
       wallets: {}
     }
+    this.commitHash = commitHash
+    console.log('Decred DEX Client App, Build', this.commitHash.substring(0, 7))
   }
 
   /**

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -2,17 +2,21 @@ import Doc from './doc'
 import BasePage from './basepage'
 import State from './state'
 
+var app
+
 export default class SettingsPage extends BasePage {
   constructor (application, body) {
     super()
-    const darkMode = Doc.idel(body, 'darkMode')
-    Doc.bind(darkMode, 'click', () => {
-      State.dark(darkMode.checked)
-      if (darkMode.checked) {
+    app = application
+    const page = this.page = Doc.parsePage(body, ['darkMode', 'commitHash'])
+    Doc.bind(page.darkMode, 'click', () => {
+      State.dark(page.darkMode.checked)
+      if (page.darkMode.checked) {
         document.body.classList.add('dark')
       } else {
         document.body.classList.remove('dark')
       }
     })
+    page.commitHash.textContent = app.commitHash.substring(0, 7)
   }
 }

--- a/client/webserver/site/webpack/common.js
+++ b/client/webserver/site/webpack/common.js
@@ -2,6 +2,7 @@ const path = require('path')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const StyleLintPlugin = require('stylelint-webpack-plugin')
+const GitRevisionPlugin = require('git-revision-webpack-plugin')
 
 module.exports = {
   entry: {
@@ -50,5 +51,8 @@ module.exports = {
   // https://github.com/webpack/webpack/issues/2297#issuecomment-289291324
   watchOptions: {
     poll: true
+  },
+  externals: {
+    commitHash: JSON.stringify(new GitRevisionPlugin().commithash())
   }
 }


### PR DESCRIPTION
Hopefully enough for #429. As of right now, the shortened commit hash is just displayed in the settings view and printed to the top of the console. If we add a footer later, it can go there too.

You'll need to `npm install` the new dev dependency. 
 
<img src="https://user-images.githubusercontent.com/6109680/83467521-c39d9200-a43f-11ea-905c-3e144a9ac59d.png" width="210">

<img src="https://user-images.githubusercontent.com/6109680/83469752-2560fa80-a446-11ea-8d03-b57d7b1713ea.png" width="341">

