### PR TITLE
client: Return RegisterResult from Register.

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1094,7 +1094,7 @@ func TestRegister(t *testing.T) {
 		tCore.connMtx.Unlock()
 
 		tWallet.setConfs(tDCR.FundConf)
-		err = tCore.Register(form)
+		_, err = tCore.Register(form)
 	}
 
 	getNotification := func(tag string) interface{} {

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -458,6 +458,12 @@ type LoginResult struct {
 	DEXes         []*DEXBrief        `json:"dexes"`
 }
 
+// RegisterResult holds data returned from Register.
+type RegisterResult struct {
+	FeeID       string `json:"feeID"`
+	ReqConfirms uint16 `json:"reqConfirms"`
+}
+
 // assetCounter tracks a count for a series of assets and provides methods for
 // adding to the count and combining assetCounters. Methods return the receiver
 // for convenience.

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -33,7 +33,6 @@ const (
 
 const (
 	initializedStr    = "app initialized"
-	feePaidStr        = "the DEX fee of %v has been paid"
 	walletCreatedStr  = "%s wallet created and unlocked"
 	walletLockedStr   = "%s wallet locked"
 	walletUnlockedStr = "%s wallet unlocked"
@@ -260,15 +259,13 @@ func handleRegister(s *RPCServer, params *RawParams) *msgjson.ResponsePayload {
 		resErr := msgjson.NewError(msgjson.RPCRegisterError, errMsg)
 		return createResponse(registerRoute, nil, resErr)
 	}
-	err = s.core.Register(form)
+	res, err := s.core.Register(form)
 	if err != nil {
 		resErr := &msgjson.Error{Code: msgjson.RPCRegisterError, Message: err.Error()}
 		return createResponse(registerRoute, nil, resErr)
 	}
 
-	resp := fmt.Sprintf(feePaidStr, form.Fee)
-
-	return createResponse(registerRoute, &resp, nil)
+	return createResponse(registerRoute, res, nil)
 }
 
 // handleExchanges handles requests for exchangess. It takes no arguments and
@@ -601,7 +598,10 @@ Registration is complete after the fee transaction has been confirmed.`,
     fee (int): The DEX fee.
     cert (string): Optional. The TLS certificate path.`,
 		returns: `Returns:
-    string: The message "` + fmt.Sprintf(feePaidStr, "[fee]") + `"`,
+    {
+      "feeID" (string): The fee transactions's txid and output index.
+      "reqConfirms" (int): The number of confirmations required to start trading.
+    }`,
 	},
 	exchangesRoute: {
 		pwArgsShort: ``,
@@ -661,10 +661,10 @@ Registration is complete after the fee transaction has been confirmed.`,
 	      can be traded.
           },...
 		},
-        "confsrequired": (int) The number of confirmations needed for the 
-        registration fee payment
+        "confsrequired": (int) The number of confirmations needed for the
+          registration fee payment
         "confs" (int): The current number of confirmations for the registration
-        fee payment. This is only present during the registration process.
+          fee payment. This is only present during the registration process.
       },...
     }`,
 	},

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -436,8 +436,8 @@ func TestHandleRegister(t *testing.T) {
 		}
 		r := &RPCServer{core: tc}
 		payload := handleRegister(r, test.params)
-		res := ""
-		if err := verifyResponse(payload, &res, test.wantErrCode); err != nil {
+		res := new(core.RegisterResult)
+		if err := verifyResponse(payload, res, test.wantErrCode); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -61,8 +61,8 @@ type ClientCore interface {
 	Login(appPass []byte) (*core.LoginResult, error)
 	OpenWallet(assetID uint32, appPass []byte) error
 	GetFee(addr, cert string) (fee uint64, err error)
-	Register(form *core.RegisterForm) error
-	Sync(host string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error)
+	Register(form *core.RegisterForm) (*core.RegisterResult, error)
+	Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error)
 	Trade(appPass []byte, form *core.TradeForm) (order *core.Order, err error)
 	WalletState(assetID uint32) (walletState *core.WalletState)
 	Wallets() (walletsStates []*core.WalletState)

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -48,6 +48,7 @@ type TCore struct {
 	closeWalletErr      error
 	wallets             []*core.WalletState
 	initializeClientErr error
+	registerResult      *core.RegisterResult
 	registerErr         error
 	exchanges           map[string]*core.Exchange
 	loginErr            error
@@ -88,8 +89,8 @@ func (c *TCore) OpenWallet(assetID uint32, pw []byte) error {
 func (c *TCore) GetFee(url, cert string) (uint64, error) {
 	return c.regFee, c.getFeeErr
 }
-func (c *TCore) Register(*core.RegisterForm) error {
-	return c.registerErr
+func (c *TCore) Register(*core.RegisterForm) (*core.RegisterResult, error) {
+	return c.registerResult, c.registerErr
 }
 func (c *TCore) Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
 	return nil, core.NewBookFeed(func(*core.BookFeed) {}), c.syncErr

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -56,7 +56,7 @@ func (s *WebServer) apiRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := s.core.Register(&core.RegisterForm{
+	_, err := s.core.Register(&core.RegisterForm{
 		Addr:    reg.Addr,
 		Cert:    reg.Cert,
 		AppPass: reg.Password,

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -306,10 +306,10 @@ func (c *TCore) GetFee(host, cert string) (uint64, error) {
 	return 1e8, nil
 }
 
-func (c *TCore) Register(r *core.RegisterForm) error {
+func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) {
 	randomDelay()
 	c.reg = r
-	return nil
+	return nil, nil
 }
 func (c *TCore) Login([]byte) (*core.LoginResult, error) { return &core.LoginResult{}, nil }
 func (c *TCore) Logout() error                           { return nil }

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -61,7 +61,7 @@ var (
 // clientCore is satisfied by core.Core.
 type clientCore interface {
 	Exchanges() map[string]*core.Exchange
-	Register(*core.RegisterForm) error
+	Register(*core.RegisterForm) (*core.RegisterResult, error)
 	Login(pw []byte) (*core.LoginResult, error)
 	InitializeClient(pw []byte) error
 	Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -74,11 +74,11 @@ type TCore struct {
 	notOpen         bool
 }
 
-func (c *TCore) Exchanges() map[string]*core.Exchange       { return nil }
-func (c *TCore) GetFee(string, string) (uint64, error)      { return 1e8, c.getFeeErr }
-func (c *TCore) Register(r *core.RegisterForm) error        { return c.regErr }
-func (c *TCore) InitializeClient(pw []byte) error           { return c.initErr }
-func (c *TCore) Login(pw []byte) (*core.LoginResult, error) { return &core.LoginResult{}, c.loginErr }
+func (c *TCore) Exchanges() map[string]*core.Exchange                        { return nil }
+func (c *TCore) GetFee(string, string) (uint64, error)                       { return 1e8, c.getFeeErr }
+func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
+func (c *TCore) InitializeClient(pw []byte) error                            { return c.initErr }
+func (c *TCore) Login(pw []byte) (*core.LoginResult, error)                  { return &core.LoginResult{}, c.loginErr }
 func (c *TCore) Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
 	return c.syncBook, c.syncFeed, c.syncErr
 }


### PR DESCRIPTION
In order to pass the fee's txid and number of needed confirmations
needed onto the callers of the register route, return a new
RegisterResult that holds that information.

closes #332 