### PR TITLE
admin: Add Accounts.

### DIFF
--- a/server/account/account.go
+++ b/server/account/account.go
@@ -3,6 +3,7 @@ package account
 import (
 	"database/sql/driver"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"decred.org/dcrdex/server/account/pki"
@@ -29,6 +30,12 @@ func NewID(pk []byte) AccountID {
 // implements fmt.Stringer.
 func (aid AccountID) String() string {
 	return hex.EncodeToString(aid[:])
+}
+
+// MarshalJSON satisfies the json.Marshaller interface, and will marshal the
+// id to a hex string.
+func (aid AccountID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(aid.String())
 }
 
 // Value implements the sql/driver.Valuer interface.

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -152,6 +152,7 @@ func (s *Server) apiAccounts(w http.ResponseWriter, _ *http.Request) {
 	accts, err := s.core.Accounts()
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to retrieve accounts: %v", err), http.StatusInternalServerError)
+		return
 	}
 	writeJSON(w, accts)
 }

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -146,3 +146,12 @@ func (s *Server) apiSuspend(w http.ResponseWriter, r *http.Request) {
 		SuspendTime: APITime{suspEpoch.End},
 	})
 }
+
+// apiAccounts is the handler for the '/accounts' API request.
+func (s *Server) apiAccounts(w http.ResponseWriter, _ *http.Request) {
+	accts, err := s.core.Accounts()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to retrieve accounts: %v", err), http.StatusInternalServerError)
+	}
+	writeJSON(w, accts)
+}

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/market"
 	"github.com/decred/slog"
 	"github.com/go-chi/chi"
@@ -38,6 +39,7 @@ var (
 
 // SvrCore is satisfied by server/dex.DEX.
 type SvrCore interface {
+	Accounts() ([]*db.Account, error)
 	ConfigMsg() json.RawMessage
 	MarketRunning(mktName string) (found, running bool)
 	MarketStatus(mktName string) *market.Status
@@ -118,6 +120,7 @@ func NewServer(cfg *SrvConfig) (*Server, error) {
 		r.Use(middleware.AllowContentType("application/json"))
 		r.Get("/ping", s.apiPing)
 		r.Get("/config", s.apiConfig)
+		r.Get("/accounts", s.apiAccounts)
 
 		r.Get("/markets", s.apiMarkets)
 		r.Route("/market/{"+marketNameKey+"}", func(rm chi.Router) {

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/elliptic"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,7 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/market"
 	"github.com/decred/dcrd/certgen"
@@ -729,13 +732,28 @@ func TestAccounts(t *testing.T) {
 		t.Errorf("incorrect response body: %q", respBody)
 	}
 
+	accountIDSlice, err := hex.DecodeString("0a9912205b2cbab0c25c2de30bda9074de0ae23b065489a99199bad763f102cc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var accountID account.AccountID
+	copy(accountID[:], accountIDSlice)
+	pubkey, err := hex.DecodeString("0204988a498d5d19514b217e872b4dbd1cf071d365c4879e64ed5919881c97eb19")
+	if err != nil {
+		t.Fatal(err)
+	}
+	feeCoin, err := hex.DecodeString("6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// An account.
 	acct := &db.Account{
-		AccountID:  "0a9912205b2cbab0c25c2de30bda9074de0ae23b065489a99199bad763f102cc",
-		Pubkey:     "0204988a498d5d19514b217e872b4dbd1cf071d365c4879e64ed5919881c97eb19",
+		AccountID:  accountID,
+		Pubkey:     dex.Bytes(pubkey),
 		FeeAddress: "DsdQFmH3azyoGKJHt2ArJNxi35LCEgMqi8k",
-		FeeCoin:    "6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005",
-		BrokenRule: byte(255),
+		FeeCoin:    dex.Bytes(feeCoin),
+		BrokenRule: account.Rule(byte(255)),
 	}
 	core.accounts = append(core.accounts, acct)
 
@@ -751,11 +769,11 @@ func TestAccounts(t *testing.T) {
 
 	exp := `[
     {
-        "AccountID": "0a9912205b2cbab0c25c2de30bda9074de0ae23b065489a99199bad763f102cc",
-        "Pubkey": "0204988a498d5d19514b217e872b4dbd1cf071d365c4879e64ed5919881c97eb19",
-        "FeeAddress": "DsdQFmH3azyoGKJHt2ArJNxi35LCEgMqi8k",
-        "FeeCoin": "6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005",
-        "BrokenRule": 255
+        "accountid": "0a9912205b2cbab0c25c2de30bda9074de0ae23b065489a99199bad763f102cc",
+        "pubkey": "0204988a498d5d19514b217e872b4dbd1cf071d365c4879e64ed5919881c97eb19",
+        "feeaddress": "DsdQFmH3azyoGKJHt2ArJNxi35LCEgMqi8k",
+        "feecoin": "6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005",
+        "brokenrule": 255
     }
 ]
 `

--- a/server/db/driver/pg/accounts.go
+++ b/server/db/driver/pg/accounts.go
@@ -5,7 +5,6 @@ package pg
 
 import (
 	"database/sql"
-	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -45,8 +44,7 @@ func (a *Archiver) Account(aid account.AccountID) (*account.Account, bool, bool)
 	return acct, isPaid, isOpen
 }
 
-// Accounts returns data for all accounts. Byte array fields in the database are
-// encoded as hex strings.
+// Accounts returns data for all accounts.
 func (a *Archiver) Accounts() ([]*db.Account, error) {
 	stmt := fmt.Sprintf(internal.SelectAllAccounts, a.tables.accounts)
 	rows, err := a.db.Query(stmt)
@@ -57,14 +55,10 @@ func (a *Archiver) Accounts() ([]*db.Account, error) {
 	var accts []*db.Account
 	for rows.Next() {
 		a := new(db.Account)
-		id, pubkey, feeCoin := []byte{}, []byte{}, []byte{}
-		err = rows.Scan(&id, &pubkey, &a.FeeAddress, &feeCoin, &a.BrokenRule)
+		err = rows.Scan(&a.AccountID, &a.Pubkey, &a.FeeAddress, &a.FeeCoin, &a.BrokenRule)
 		if err != nil {
 			return nil, err
 		}
-		a.AccountID = hex.EncodeToString(id)
-		a.Pubkey = hex.EncodeToString(pubkey)
-		a.FeeCoin = hex.EncodeToString(feeCoin)
 		accts = append(accts, a)
 	}
 	if err = rows.Err(); err != nil {

--- a/server/db/driver/pg/accounts_online_test.go
+++ b/server/db/driver/pg/accounts_online_test.go
@@ -77,6 +77,18 @@ func TestAccounts(t *testing.T) {
 		t.Fatalf("newly paid account marked as closed")
 	}
 
+	accts, err := archie.Accounts()
+	if err != nil {
+		t.Fatalf("error getting accounts: %v", err)
+	}
+	if accts[0].AccountID != "0a9912205b2cbab0c25c2de30bda9074de0ae23b065489a99199bad763f102cc" ||
+		accts[0].Pubkey != "0204988a498d5d19514b217e872b4dbd1cf071d365c4879e64ed5919881c97eb19" ||
+		accts[0].FeeAddress != "DsdQFmH3azyoGKJHt2ArJNxi35LCEgMqi8k" ||
+		accts[0].FeeCoin != "6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005" ||
+		accts[0].BrokenRule != byte(0) {
+		t.Fatal("accounts has unexpected data")
+	}
+
 	// Close the account for failure to complete a swap.
 	archie.CloseAccount(tAcctID, account.FailureToAct)
 	_, _, open = archie.Account(tAcctID)

--- a/server/db/driver/pg/accounts_online_test.go
+++ b/server/db/driver/pg/accounts_online_test.go
@@ -81,11 +81,11 @@ func TestAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting accounts: %v", err)
 	}
-	if accts[0].AccountID != "0a9912205b2cbab0c25c2de30bda9074de0ae23b065489a99199bad763f102cc" ||
-		accts[0].Pubkey != "0204988a498d5d19514b217e872b4dbd1cf071d365c4879e64ed5919881c97eb19" ||
+	if accts[0].AccountID.String() != "0a9912205b2cbab0c25c2de30bda9074de0ae23b065489a99199bad763f102cc" ||
+		accts[0].Pubkey.String() != "0204988a498d5d19514b217e872b4dbd1cf071d365c4879e64ed5919881c97eb19" ||
 		accts[0].FeeAddress != "DsdQFmH3azyoGKJHt2ArJNxi35LCEgMqi8k" ||
-		accts[0].FeeCoin != "6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005" ||
-		accts[0].BrokenRule != byte(0) {
+		accts[0].FeeCoin.String() != "6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005" ||
+		byte(accts[0].BrokenRule) != byte(0) {
 		t.Fatal("accounts has unexpected data")
 	}
 

--- a/server/db/driver/pg/internal/accounts.go
+++ b/server/db/driver/pg/internal/accounts.go
@@ -40,6 +40,9 @@ const (
 		FROM %s
 		WHERE account_id = $1;`
 
+	// SelectAllAccounts retrieves all accounts.
+	SelectAllAccounts = `SELECT * FROM %s;`
+
 	// CreateAccount creates an entry for a new account.
 	CreateAccount = `INSERT INTO %s (account_id, pubkey, fee_address)
 		VALUES ($1, $2, $3);`

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -180,8 +180,7 @@ type AccountArchiver interface {
 	// account, completing the registration process.
 	PayAccount(account.AccountID, []byte) error
 
-	// Accounts returns data for all accounts. Byte array fields in the
-	// database are encoded as hex strings.
+	// Accounts returns data for all accounts.
 	Accounts() ([]*Account, error)
 }
 

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -179,6 +179,10 @@ type AccountArchiver interface {
 	// PayAccount sets the registration fee payment transaction details for the
 	// account, completing the registration process.
 	PayAccount(account.AccountID, []byte) error
+
+	// Accounts returns data for all accounts. Byte array fields in the
+	// database are encoded as hex strings.
+	Accounts() ([]*Account, error)
 }
 
 // MatchData represents an order pair match, but with just the order IDs instead

--- a/server/db/types.go
+++ b/server/db/types.go
@@ -1,0 +1,14 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package db
+
+// Account holds data returned by Accounts. Byte array fields in the database
+// are encoded as hex strings.
+type Account struct {
+	AccountID  string
+	Pubkey     string
+	FeeAddress string
+	FeeCoin    string
+	BrokenRule byte
+}

--- a/server/db/types.go
+++ b/server/db/types.go
@@ -3,12 +3,16 @@
 
 package db
 
-// Account holds data returned by Accounts. Byte array fields in the database
-// are encoded as hex strings.
+import (
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/account"
+)
+
+// Account holds data returned by Accounts.
 type Account struct {
-	AccountID  string
-	Pubkey     string
-	FeeAddress string
-	FeeCoin    string
-	BrokenRule byte
+	AccountID  account.AccountID `json:"accountid"`
+	Pubkey     dex.Bytes         `json:"pubkey"`
+	FeeAddress string            `json:"feeaddress"`
+	FeeCoin    dex.Bytes         `json:"feecoin"`
+	BrokenRule account.Rule      `json:"brokenrule"`
 }

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -548,8 +548,7 @@ func (dm *DEX) SuspendMarket(name string, tSusp time.Time, persistBooks bool) *m
 // TODO: resume by relaunching the market subsystems (Run)
 // Resume / ResumeMarket
 
-// Accounts returns data for all accounts. Byte array fields in the database are
-// encoded as hex strings.
+// Accounts returns data for all accounts.
 func (dm *DEX) Accounts() ([]*db.Account, error) {
 	return dm.storage.Accounts()
 }

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -547,3 +547,9 @@ func (dm *DEX) SuspendMarket(name string, tSusp time.Time, persistBooks bool) *m
 
 // TODO: resume by relaunching the market subsystems (Run)
 // Resume / ResumeMarket
+
+// Accounts returns data for all accounts. Byte array fields in the database are
+// encoded as hex strings.
+func (dm *DEX) Accounts() ([]*db.Account, error) {
+	return dm.storage.Accounts()
+}

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -172,6 +172,7 @@ func (ta *TArchivist) Account(account.AccountID) (acct *account.Account, paid, o
 func (ta *TArchivist) CreateAccount(*account.Account) (string, error)   { return "", nil }
 func (ta *TArchivist) AccountRegAddr(account.AccountID) (string, error) { return "", nil }
 func (ta *TArchivist) PayAccount(account.AccountID, []byte) error       { return nil }
+func (ta *TArchivist) Accounts() ([]*db.Account, error)                 { return nil, nil }
 func (ta *TArchivist) Close() error                                     { return nil }
 
 func randomOrderID() order.OrderID {


### PR DESCRIPTION
In order to view account data in the database, add an api enpoint to the
admin server that retrieves all accounts and returns a slice of
accounts. Byte arrays are encoded in hex for readability.

part of #329 