### PR TITLE
client/core: handle trade resumption messages. 

### DIFF
--- a/client/core/types.go
+++ b/client/core/types.go
@@ -262,6 +262,7 @@ type Market struct {
 	MarketBuyBuffer float64  `json:"buybuffer"`
 	Orders          []*Order `json:"orders"`
 	pendingSuspend  *time.Timer
+	pendingResume   *time.Timer
 	suspended       bool
 	mtx             sync.Mutex
 }


### PR DESCRIPTION
Included in and superseded by PR #705 

This adds a trade resumption handler to the client core as well as associated tests.

**Dependent on #269**
