### PR TITLE
core: fix issue with regConfirms field of dexConnection

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -75,7 +75,7 @@ type dexConnection struct {
 	connected bool
 
 	regConfMtx  sync.RWMutex
-	regConfirms uint32
+	regConfirms *uint32
 }
 
 // refreshMarkets rebuilds, saves, and returns the market map. The map itself
@@ -128,11 +128,7 @@ func (dc *dexConnection) markets() map[string]*Market {
 func (dc *dexConnection) getRegConfirms() *uint32 {
 	dc.regConfMtx.RLock()
 	defer dc.regConfMtx.RUnlock()
-	if dc.regConfirms == regConfirmationsPaid {
-		return nil
-	}
-	confs := dc.regConfirms
-	return &confs
+	return dc.regConfirms
 }
 
 // setRegConfirms sets the number of confirmations received
@@ -140,7 +136,7 @@ func (dc *dexConnection) getRegConfirms() *uint32 {
 func (dc *dexConnection) setRegConfirms(confs uint32) {
 	dc.regConfMtx.Lock()
 	defer dc.regConfMtx.Unlock()
-	dc.regConfirms = confs
+	dc.regConfirms = &confs
 }
 
 // hasOrders checks whether there are any open orders or negotiating matches for

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -38,8 +38,8 @@ const (
 	conversionFactor  = 1e8
 	regFeeAssetSymbol = "dcr" // Hard-coded to Decred for registration fees, for now.
 
-	// highest uint32 number to be assigned to 'regConfirms' in 'dexConnection'
-	// when the registration is completed
+	// regConfirmationsPaid is used to indicate completed registration to
+	// (*Core).setRegConfirms.
 	regConfirmationsPaid uint32 = math.MaxUint32
 )
 
@@ -75,7 +75,7 @@ type dexConnection struct {
 	connected bool
 
 	regConfMtx  sync.RWMutex
-	regConfirms *uint32
+	regConfirms *uint32 // nil regConfirms means no pending registration.
 }
 
 // refreshMarkets rebuilds, saves, and returns the market map. The map itself
@@ -136,6 +136,11 @@ func (dc *dexConnection) getRegConfirms() *uint32 {
 func (dc *dexConnection) setRegConfirms(confs uint32) {
 	dc.regConfMtx.Lock()
 	defer dc.regConfMtx.Unlock()
+	if confs == regConfirmationsPaid {
+		// A nil regConfirms indicates that there is no pending registration.
+		dc.regConfirms = nil
+		return
+	}
 	dc.regConfirms = &confs
 }
 

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -228,7 +228,8 @@ export default class MarketsPage extends BasePage {
 
   /* hasFeePending is true if the fee payment is pending */
   hasFeePending () {
-    return typeof this.market.dex.confs === 'number'
+    const dex = this.market.dex
+    return typeof dex.confs === 'number' && dex.confs < dex.confsrequired
   }
 
   /* assetsAreSupported is true if all the assets of the current market are


### PR DESCRIPTION
The field was changed to a reference in a later commit of #353, but that meant that it was recognized as waiting for confirmations on startup, since it would be zero. Pointer works better in this case.

Resolves #452