### PR TITLE
core: properly handle client->server request errors during trade

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -128,7 +128,7 @@ func (op *output) Confirmations() (uint32, error) {
 		return 0, fmt.Errorf("error finding coin: %v", err)
 	}
 	if txOut == nil {
-		return 0, asset.CoinSpentError
+		return 0, asset.CoinNotFoundError
 	}
 	return uint32(txOut.Confirmations), nil
 }
@@ -794,9 +794,6 @@ func (btc *ExchangeWallet) AuditContract(coinID dex.Bytes, contract dex.Bytes) (
 	if txOut == nil {
 		return nil, asset.CoinNotFoundError
 	}
-	if txOut == nil {
-		return nil, asset.CoinSpentError
-	}
 	pkScript, err := hex.DecodeString(txOut.ScriptPubKey.Hex)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding pubkey script from hex '%s': %v",
@@ -997,7 +994,7 @@ func (btc *ExchangeWallet) Refund(coinID, contract dex.Bytes, nfo *dex.Asset) (d
 		return nil, fmt.Errorf("error finding unspent contract: %v", err)
 	}
 	if utxo == nil {
-		return nil, asset.CoinSpentError
+		return nil, asset.CoinNotFoundError
 	}
 	val := toSatoshi(utxo.Value)
 	sender, _, lockTime, _, err := dexbtc.ExtractSwapDetails(contract, btc.chainParams)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -106,21 +106,21 @@ func newOutput(node rpcClient, txHash *chainhash.Hash, vout uint32, value uint64
 }
 
 // Value returns the value of the output. Part of the asset.Coin interface.
-func (output *output) Value() uint64 {
-	return output.value
+func (op *output) Value() uint64 {
+	return op.value
 }
 
 // Confirmations is the number of confirmations on the output's block.
 // Confirmations always pulls the block information fresh from the blockchain,
 // and will return an error if the output has been spent. Part of the
 // asset.Coin interface.
-func (output *output) Confirmations() (uint32, error) {
-	txOut, err := output.node.GetTxOut(&output.txHash, output.vout, true)
+func (op *output) Confirmations() (uint32, error) {
+	txOut, err := op.node.GetTxOut(&op.txHash, op.vout, true)
 	if err != nil {
 		return 0, fmt.Errorf("error finding unspent contract: %v", err)
 	}
 	if txOut == nil {
-		return 0, asset.CoinSpentError
+		return 0, asset.CoinNotFoundError
 	}
 	return uint32(txOut.Confirmations), nil
 }
@@ -1021,7 +1021,7 @@ func (dcr *ExchangeWallet) Refund(coinID, contract dex.Bytes, nfo *dex.Asset) (d
 		return nil, fmt.Errorf("error finding unspent contract: %v", err)
 	}
 	if utxo == nil {
-		return nil, asset.CoinSpentError
+		return nil, asset.CoinNotFoundError
 	}
 	val := toAtoms(utxo.Value)
 	sender, _, lockTime, _, err := dexdcr.ExtractSwapDetails(contract, chainParams)
@@ -1335,7 +1335,7 @@ func (dcr *ExchangeWallet) convertCoin(coin asset.Coin) (*output, error) {
 		return nil, fmt.Errorf("error finding unspent output %s:%d: %v", txHash, vout, err)
 	}
 	if txOut == nil {
-		return nil, asset.CoinSpentError
+		return nil, asset.CoinNotFoundError
 	}
 	pkScript, err := hex.DecodeString(txOut.ScriptPubKey.Hex)
 	if err != nil {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -11,14 +11,11 @@ import (
 	"decred.org/dcrdex/dex/config"
 )
 
-// CoinNotFoundError is returned from AuditContract when the counter-party's
-// swap transaction coin cannot be found.
+// CoinNotFoundError is returned when a coin cannot be found, either because
+// it has been spent or it never existed. This error may be returned from
+// AuditContract, Refund or Redeem as those methods expect the provided coin
+// to exist and be unspent.
 const CoinNotFoundError = dex.Error("coin not found")
-
-// CoinSpentError is returned when an attempt is made to treat a spent coin as
-// unspent. This error may be returned from AuditContract, Refund and Redeem
-// as those methods expect the provided coin to be unspent.
-const CoinSpentError = dex.Error("coin has been spent")
 
 // WalletInfo is auxiliary information about an ExchangeWallet.
 type WalletInfo struct {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -866,7 +866,8 @@ func (t *trackedTrade) refundMatches(matches []*matchTracker) (uint64, error) {
 
 		refundCoin, err := refundWallet.Refund(dex.Bytes(swapCoinID), contractToRefund, refundAsset)
 		if err != nil {
-			if err == asset.CoinSpentError {
+			if err == asset.CoinNotFoundError {
+				// Could not fund the contract coin, which means it has been spent.
 				// TODO: begin find redemption
 				// NOTE: may be that swap was actually refunded, so FindRedemption
 				// should account for that.


### PR DESCRIPTION
One potential cause for trade disruption as documented in #361 is when notifying the DEX after taking a required action results in an error such as when [sending `init` request after broadcasting swap tx](https://github.com/decred/dcrdex/blob/deaa965813825dd1505e948e1856abdd2bde11ba/client/core/trade.go#L618-L629) or when [sending `redeem` request after redeeming the counter-party swap](https://github.com/decred/dcrdex/blob/deaa965813825dd1505e948e1856abdd2bde11ba/client/core/trade.go#L698-L704).

Currently, the client does not update the match status to indicate that the required action has been executed and also does not re-attempt sending the request (unless dexc is restarted). 

Also, as mentioned in https://github.com/decred/dcrdex/issues/302#issuecomment-630744659, for `init` errors, the client is unable to perform auto-refund when the swap's locktime expires.

This corrects the behaviour for failed client->server requests by
- saving relevant details to database regardless of request success or failure
- re-trying the request in the next `trade.tick()` (aka every 1/3rd `bcastTimeout` until the match is revoked or the client's swap is refunded, whichever happens first)
- performing auto-refund for consistent `init` failures up till expiration of the client's swap locktime.

Worth noting that with this PR, all auto-refund cases should be covered. If there's a potential refund scenario not yet considered, please mention.