### PR TITLE
market: default to presist book (on ctrl+C quit)

### DIFF
--- a/server/market/market.go
+++ b/server/market/market.go
@@ -157,6 +157,7 @@ func NewMarket(mktInfo *dex.MarketInfo, storage db.DEXArchivist, swapper Swapper
 		marketInfo:       mktInfo,
 		book:             Book,
 		matcher:          matcher.New(),
+		persistBook:      true,
 		epochCommitments: make(map[order.Commitment]order.OrderID),
 		epochOrders:      make(map[order.OrderID]order.Order),
 		swapper:          swapper,
@@ -1133,6 +1134,7 @@ func (m *Market) epochStart(orders []order.Order) (cSum []byte, ordersRevealed [
 	// Penalize accounts with misses. TODO: consider if Penalize can be an async
 	// function call.
 	for _, ord := range misses {
+		log.Infof("No preimage received for order %v from user %v. Penalizing.", ord.ID(), ord.User())
 		m.auth.Penalize(ord.User(), account.PreimageReveal)
 	}
 


### PR DESCRIPTION
When the market suspend functions were added, the behavior of a CTRL+C shutdown was inadvertently changed to flush the books since the `persistBook` boolean added then was not set in the constructor (it was left as false).  This sets it to `true` in `NewMarket` so that unless a Suspend command is issued that explicitly sets it, a shutdown of the market due to context cancellation will not flush the book.