### PR TITLE
core: fix withdraw

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -603,6 +603,24 @@ func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 	return wallet, nil
 }
 
+// Connect to the wallet if not already connected. Unlock the wallet if not
+// already unlocked.
+func (c *Core) connectAndUnlock(crypter encrypt.Crypter, wallet *xcWallet) error {
+	if !wallet.connected() {
+		err := wallet.Connect(c.ctx)
+		if err != nil {
+			return fmt.Errorf("error connecting %s wallet: %v", unbip(wallet.AssetID), err)
+		}
+	}
+	if !wallet.unlocked() {
+		err := unlockWallet(wallet, crypter)
+		if err != nil {
+			return fmt.Errorf("failed to unlock %s wallet: %v", unbip(wallet.AssetID), err)
+		}
+	}
+	return nil
+}
+
 // walletBalances retrieves balances for the wallet.
 func (c *Core) walletBalances(wallet *xcWallet) (*BalanceSet, error) {
 	c.connMtx.RLock()
@@ -1426,8 +1444,8 @@ func (c *Core) notifyFee(dc *dexConnection, coinID []byte) error {
 
 // Withdraw initiates a withdraw from an exchange wallet. The client password
 // must be provided as an additional verification.
-func (c *Core) Withdraw(pw []byte, assetID uint32, value uint64) (asset.Coin, error) {
-	_, err := c.encryptionKey(pw)
+func (c *Core) Withdraw(pw []byte, assetID uint32, value uint64, address string) (asset.Coin, error) {
+	crypter, err := c.encryptionKey(pw)
 	if err != nil {
 		return nil, fmt.Errorf("Withdraw password error: %v", err)
 	}
@@ -1438,7 +1456,11 @@ func (c *Core) Withdraw(pw []byte, assetID uint32, value uint64) (asset.Coin, er
 	if !found {
 		return nil, fmt.Errorf("%s wallet not found", unbip(assetID))
 	}
-	coin, err := wallet.Withdraw(wallet.address, value, wallet.Info().DefaultFeeRate)
+	err = c.connectAndUnlock(crypter, wallet)
+	if err != nil {
+		return nil, err
+	}
+	coin, err := wallet.Withdraw(address, value, wallet.Info().DefaultFeeRate)
 	if err != nil {
 		details := fmt.Sprintf("Error encountered during %s withdraw: %v", unbip(assetID), err)
 		c.notify(newWithdrawNote("Withdraw error", details, db.ErrorLevel))
@@ -1485,31 +1507,13 @@ func (c *Core) Trade(pw []byte, form *TradeForm) (*Order, error) {
 	}
 
 	fromWallet, toWallet := wallets.fromWallet, wallets.toWallet
-	fromID, toID := fromWallet.AssetID, toWallet.AssetID
-
-	if !fromWallet.connected() {
-		err = fromWallet.Connect(c.ctx)
-		if err != nil {
-			return nil, fmt.Errorf("Error connecting wallet: %v", err)
-		}
+	err = c.connectAndUnlock(crypter, fromWallet)
+	if err != nil {
+		return nil, err
 	}
-	if !fromWallet.unlocked() {
-		err = unlockWallet(fromWallet, crypter)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unlock %s wallet: %v", unbip(fromID), err)
-		}
-	}
-	if !toWallet.connected() {
-		err = toWallet.Connect(c.ctx)
-		if err != nil {
-			return nil, fmt.Errorf("Error connecting wallet: %v", err)
-		}
-	}
-	if !toWallet.unlocked() {
-		err = unlockWallet(toWallet, crypter)
-		if err != nil {
-			return nil, fmt.Errorf("failed to unlock %s wallet: %v", unbip(toID), err)
-		}
+	err = c.connectAndUnlock(crypter, toWallet)
+	if err != nil {
+		return nil, err
 	}
 
 	// Get an address for the swap contract.

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -245,7 +245,7 @@ func (s *WebServer) apiWithdraw(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, "no wallet found for %s", unbip(form.AssetID))
 		return
 	}
-	coin, err := s.core.Withdraw(form.Pass, form.AssetID, form.Value)
+	coin, err := s.core.Withdraw(form.Pass, form.AssetID, form.Value, form.Address)
 	if err != nil {
 		s.writeAPIError(w, "withdraw error: %v", err)
 		return

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -634,7 +634,7 @@ func (c *TCore) SupportedAssets() map[uint32]*core.SupportedAsset {
 	}
 }
 
-func (c *TCore) Withdraw(pw []byte, assetID uint32, value uint64) (asset.Coin, error) {
+func (c *TCore) Withdraw(pw []byte, assetID uint32, value uint64, address string) (asset.Coin, error) {
 	return &tCoin{id: []byte{0xde, 0xc7, 0xed}}, nil
 }
 

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -75,7 +75,7 @@ type clientCore interface {
 	User() *core.User
 	GetFee(url, cert string) (uint64, error)
 	SupportedAssets() map[uint32]*core.SupportedAsset
-	Withdraw(pw []byte, assetID uint32, value uint64) (asset.Coin, error)
+	Withdraw(pw []byte, assetID uint32, value uint64, address string) (asset.Coin, error)
 	Trade(pw []byte, form *core.TradeForm) (*core.Order, error)
 	Cancel(pw []byte, sid string) error
 	NotificationFeed() <-chan core.Notification

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -108,7 +108,7 @@ func (c *TCore) User() *core.User                           { return nil }
 func (c *TCore) SupportedAssets() map[uint32]*core.SupportedAsset {
 	return make(map[uint32]*core.SupportedAsset)
 }
-func (c *TCore) Withdraw(pw []byte, assetID uint32, value uint64) (asset.Coin, error) {
+func (c *TCore) Withdraw(pw []byte, assetID uint32, value uint64, address string) (asset.Coin, error) {
 	return &tCoin{id: []byte{0xde, 0xc7, 0xed}}, c.withdrawErr
 }
 func (c *TCore) Trade(pw []byte, form *core.TradeForm) (*core.Order, error) {


### PR DESCRIPTION
Fixes an embarrassing bug in `(*Core).Withdraw`. Whoops. 

@JoeGruffins, you'll want these changes for #422 

Also adds auto-connect and auto-unlock to `(*Core).Withdraw`.