### PR TITLE
core: ignore tx not found errors in fee confirmations trigger

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -28,6 +28,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
+	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/dcrutil/v2"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/rpcclient/v5"
@@ -1657,7 +1658,6 @@ func fees(tx *wire.MsgTx) (uint64, float64) {
 // isTxNotFoundErr will return true if the error indicates that the requested
 // transaction is not known.
 func isTxNotFoundErr(err error) bool {
-	// TODO: Could probably do this right with errors.As if we enforce an RPC
-	// version when connecting.
-	return strings.HasPrefix(err.Error(), "-5:")
+	var rpcErr *dcrjson.RPCError
+	return errors.As(err, &rpcErr) && rpcErr.Code == dcrjson.ErrRPCNoTxInfo
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1157,7 +1157,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 }
 
 // verifyRegistrationFee waits the required amount of confirmations for the
-// registration fee payment. Once the requirment is met the server is notified.
+// registration fee payment. Once the requirement is met the server is notified.
 // If the server acknowledgment is successfull, the account is set as 'paid' in
 // the database. Notifications about confirmations increase, errors and success
 // events are broadcasted to all subscribers.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1164,18 +1164,12 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 func (c *Core) verifyRegistrationFee(wallet *xcWallet, dc *dexConnection, coinID []byte, assetID uint32) {
 	reqConfs := dc.cfg.RegFeeConfirms
 
-	regConfs, err := wallet.Confirmations(coinID)
-	if err != nil {
-		log.Errorf("Error getting confirmations for %s: %v", hex.EncodeToString(coinID), err)
-		return
-	}
-
-	dc.setRegConfirms(regConfs)
+	dc.setRegConfirms(0)
 	c.refreshUser()
 
 	trigger := func() (bool, error) {
 		confs, err := wallet.Confirmations(coinID)
-		if err != nil {
+		if err != nil && !errors.Is(err, asset.CoinNotFoundError) {
 			return false, fmt.Errorf("Error getting confirmations for %s: %v", hex.EncodeToString(coinID), err)
 		}
 		details := fmt.Sprintf("Fee payment confirmations %v/%v", confs, uint32(reqConfs))

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -21,6 +22,7 @@ import (
 	"decred.org/dcrdex/server/asset"
 	"github.com/decred/dcrd/blockchain/stake/v2"
 	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/dcrutil/v2"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/rpcclient/v5"
@@ -951,7 +953,6 @@ func toAtoms(v float64) uint64 {
 // isTxNotFoundErr will return true if the error indicates that the requested
 // transaction is not known.
 func isTxNotFoundErr(err error) bool {
-	// TODO: Could probably do this right with errors.As if we enforce an RPC
-	// version when connecting.
-	return strings.HasPrefix(err.Error(), "-5:")
+	var rpcErr *dcrjson.RPCError
+	return errors.As(err, &rpcErr) && rpcErr.Code == dcrjson.ErrRPCNoTxInfo
 }


### PR DESCRIPTION
Tests show that `gettransaction` **may** return `tx not found error` for the fee tx if `gettransaction` is invoked immediately the tx is broadcasted.

This modifies the fee confirmations trigger to ignore such errors (assume network latency) and continue the check for required confirmations.

Also modifies asset methods that call `gettransaction` to return `asset.CoinNotFoundError` when the requested tx is not found.