### PR TITLE
dex,market,swap: unbookHook for swapper

### DIFF
--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -373,6 +373,8 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		// Set the order status for both orders.
 		t.metaData.Status = order.OrderStatusCanceled
 		t.db.UpdateOrderStatus(t.cancel.ID(), order.OrderStatusExecuted)
+		// TODO: If the order's backing coins/change are unused, unlock them,
+		// otherwise they have been or will be spent by a swap.
 	}
 	if includesTrades {
 		fillRatio := float64(trade.Filled()) / float64(trade.Quantity)

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -733,7 +733,7 @@ export default class MarketsPage extends BasePage {
 
   /*
    * handleFeePayment is the handler for the 'feepayment' notification type.
-   * This is used to update the registration status of the currrent exchange.
+   * This is used to update the registration status of the current exchange.
    */
   handleFeePayment (note) {
     const dexAddr = note.dex
@@ -751,6 +751,8 @@ export default class MarketsPage extends BasePage {
     const order = note.order
     if (order.targetID && note.subject === 'cancel') {
       this.orderRows[order.targetID].querySelector('[data-col=cancel]').textContent = 'canceled'
+    } else if (order.targetID && note.subject === 'revoke') {
+      this.orderRows[order.targetID].querySelector('[data-col=cancel]').textContent = 'revoked'
     } else {
       const row = this.orderRows[order.id]
       if (!row) return

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -365,9 +365,9 @@ func (auth *AuthManager) rmUserConnectMsgs(user account.AccountID) []*pendingMes
 	if userMsgs == nil {
 		return nil
 	}
-	msgs := make([]*pendingMessage, len(userMsgs))
-	for i, tr := range userMsgs {
-		msgs[i] = tr.pendingMessage
+	msgs := make([]*pendingMessage, 0, len(userMsgs))
+	for _, tr := range userMsgs {
+		msgs = append(msgs, tr.pendingMessage)
 		// Stop the timer. It's ok if already fired since this timedMessage
 		// would have been removed if we lost the race with AfterFunc's call to
 		// rmUserConnectMsg. Since we're here, we beat the timer.
@@ -507,9 +507,9 @@ func (auth *AuthManager) rmUserConnectReqs(user account.AccountID) []*pendingReq
 	if userReqs == nil {
 		return nil
 	}
-	reqs := make([]*pendingRequest, len(userReqs))
-	for i, tr := range userReqs {
-		reqs[i] = tr.pendingRequest
+	reqs := make([]*pendingRequest, 0, len(userReqs))
+	for _, tr := range userReqs {
+		reqs = append(reqs, tr.pendingRequest)
 		// Stop the timer. It's ok if already fired since this timedRequest
 		// would have been removed if we lost the race with AfterFunc's call to
 		// rmUserConnectReq. Since we're here, we beat the timer.

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -164,7 +164,8 @@ func (c *wsLink) Request(msg *msgjson.Message, f func(conn Link, msg *msgjson.Me
 		// Neither expire nor the handler should run. Stop the expire timer
 		// created by logReq and delete the response handler it added. The
 		// caller receives a non-nil error to deal with it.
-		log.Debugf("(*wsLink).Request Send error, unregistering msg ID %d handler", msg.ID)
+		log.Debugf("(*wsLink).Request(route '%s') Send error, unregistering msg ID %d handler",
+			msg.Route, msg.ID)
 		c.respHandler(msg.ID) // drop the removed responseHandler
 	}
 	return err

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -12,6 +12,7 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/dex/order"
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/asset"
 	dcrasset "decred.org/dcrdex/server/asset/dcr"
@@ -387,6 +388,18 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 	authMgr := auth.NewAuthManager(&authCfg)
 	startSubSys("Auth manager", authMgr)
 
+	// Create an unbook dispatcher for the Swapper.
+	markets := make(map[string]*market.Market, len(cfg.Markets))
+	marketUnbookHook := func(lo *order.LimitOrder) bool {
+		name, err := dex.MarketName(lo.BaseAsset, lo.QuoteAsset)
+		if err != nil {
+			log.Errorf("unbook hook: %v", err)
+			return false
+		}
+
+		return markets[name].Unbook(lo)
+	}
+
 	// Create the swapper.
 	swapperCfg := &swap.Config{
 		State:            cfg.SwapState,
@@ -397,6 +410,7 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		BroadcastTimeout: cfg.BroadcastTimeout,
 		LockTimeTaker:    dex.LockTimeTaker(cfg.Network),
 		LockTimeMaker:    dex.LockTimeMaker(cfg.Network),
+		UnbookHook:       marketUnbookHook,
 	}
 
 	swapper, err := swap.NewSwapper(swapperCfg)
@@ -404,10 +418,8 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		abort()
 		return nil, fmt.Errorf("NewSwapper: %v", err)
 	}
-	startSubSys("Swapper", swapper)
 
 	// Markets
-	markets := make(map[string]*market.Market, len(cfg.Markets))
 	for _, mktInf := range cfg.Markets {
 		baseCoinLocker := dexCoinLocker.AssetLocker(mktInf.Base).Book()
 		quoteCoinLocker := dexCoinLocker.AssetLocker(mktInf.Quote).Book()
@@ -418,6 +430,8 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		}
 		markets[mktInf.Name] = mkt
 	}
+
+	startSubSys("Swapper", swapper) // after markets map set
 
 	// Set start epoch index for each market. Also create BookSources for the
 	// BookRouter, and MarketTunnels for the OrderRouter

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -278,7 +278,7 @@ out:
 		select {
 		case u, ok := <-feed:
 			if !ok {
-				log.Errorf("Book order feed closed for market %q at epoch %d without a suspend signal",
+				log.Errorf("Book order feed closed for market %q at epoch %d",
 					book.name, book.epoch())
 				break out
 			}
@@ -389,9 +389,10 @@ out:
 
 				// Depending on resume handling, maybe kill the book router.
 				// Presently the Market closes the order feed channels, so quit.
-				log.Infof("Book order feed closed for market %q after epoch %d, persist book = %v.",
+				log.Infof("Market %q suspended after epoch %d, persist book = %v.",
 					book.name, sigData.finalEpoch, sigData.persistBook)
-				break out
+
+				// Stay running for Swapper unbook callbacks.
 
 			default:
 				panic(fmt.Sprintf("unknown orderbook update action %d", u.action))

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -37,6 +37,7 @@ type TArchivist struct {
 	commitForKnownOrder  order.Commitment
 	bookedOrders         []*order.LimitOrder
 	epochInserted        chan struct{}
+	revoked              order.Order
 }
 
 func (ta *TArchivist) LastErr() error         { return nil }
@@ -121,8 +122,9 @@ func (ta *TArchivist) BookOrder(lo *order.LimitOrder) error {
 }
 func (ta *TArchivist) ExecuteOrder(ord order.Order) error  { return nil }
 func (ta *TArchivist) CancelOrder(*order.LimitOrder) error { return nil }
-func (ta *TArchivist) RevokeOrder(order.Order) (order.OrderID, time.Time, error) {
-	return order.OrderID{}, time.Now(), nil
+func (ta *TArchivist) RevokeOrder(ord order.Order) (order.OrderID, time.Time, error) {
+	ta.revoked = ord
+	return ord.ID(), time.Now(), nil
 }
 func (ta *TArchivist) RevokeOrderUncounted(order.Order) (order.OrderID, time.Time, error) {
 	return order.OrderID{}, time.Now(), nil
@@ -214,6 +216,7 @@ func newTestMarket(stor ...*TArchivist) (*Market, *TArchivist, *TAuth, func(), e
 	if err != nil {
 		panic(err.Error())
 	}
+	var mktUnbook func(lo *order.LimitOrder) bool
 	swapperCfg := &swap.Config{
 		DataDir: swapDataDir,
 		Assets: map[uint32]*swap.LockableAsset{
@@ -225,17 +228,13 @@ func newTestMarket(stor ...*TArchivist) (*Market, *TArchivist, *TAuth, func(), e
 		BroadcastTimeout: 10 * time.Second,
 		LockTimeTaker:    dex.LockTimeTaker(dex.Testnet),
 		LockTimeMaker:    dex.LockTimeMaker(dex.Testnet),
+		UnbookHook: func(lo *order.LimitOrder) bool {
+			return mktUnbook(lo)
+		},
 	}
 	swapper, err := swap.NewSwapper(swapperCfg)
 	if err != nil {
 		panic(err.Error())
-	}
-	ssw := dex.NewStartStopWaiter(swapper)
-	ssw.Start(testCtx)
-	cleanup := func() {
-		ssw.Stop()
-		ssw.WaitForShutdown()
-		os.RemoveAll(swapDataDir)
 	}
 
 	mbBuffer := 1.1
@@ -250,6 +249,16 @@ func newTestMarket(stor ...*TArchivist) (*Market, *TArchivist, *TAuth, func(), e
 	if err != nil {
 		return nil, nil, nil, func() {}, fmt.Errorf("Failed to create test market: %v", err)
 	}
+	mktUnbook = mkt.Unbook
+
+	ssw := dex.NewStartStopWaiter(swapper)
+	ssw.Start(testCtx)
+	cleanup := func() {
+		ssw.Stop()
+		ssw.WaitForShutdown()
+		os.RemoveAll(swapDataDir)
+	}
+
 	return mkt, storage, authMgr, cleanup, nil
 }
 
@@ -325,7 +334,7 @@ func TestMarket_NewMarket_BookOrders(t *testing.T) {
 }
 
 func TestMarket_Book(t *testing.T) {
-	mkt, _, _, cleanup, err := newTestMarket()
+	mkt, storage, auth, cleanup, err := newTestMarket()
 	if err != nil {
 		t.Fatalf("newTestMarket failure: %v", err)
 	}
@@ -367,6 +376,55 @@ func TestMarket_Book(t *testing.T) {
 		t.Errorf("Incorrect best sell order. Got %v, expected %v",
 			sells[0], bestSell)
 	}
+
+	// unbook something not on the book
+	if mkt.Unbook(makeLO(buyer3, 100, 1, order.StandingTiF)) {
+		t.Fatalf("unbooked and order that was not on the book")
+	}
+
+	// unbook the best buy order
+	feed := mkt.OrderFeed()
+
+	if !mkt.Unbook(bestBuy) {
+		t.Fatalf("Failed to unbook order")
+	}
+
+	sig := <-feed
+	if sig.action != unbookAction {
+		t.Fatalf("did not receive unbookAction signal")
+	}
+	sigData, ok := sig.data.(sigDataUnbookedOrder)
+	if !ok {
+		t.Fatalf("incorrect sigdata type")
+	}
+	if sigData.epochIdx != -1 {
+		t.Fatalf("expected epoch index -1, got %d", sigData.epochIdx)
+	}
+	loUnbooked, ok := sigData.order.(*order.LimitOrder)
+	if !ok {
+		t.Fatalf("incorrect unbooked order type")
+	}
+	if loUnbooked.ID() != bestBuy.ID() {
+		t.Errorf("unbooked order %v, wanted %v", loUnbooked.ID(), bestBuy.ID())
+	}
+
+	if auth.canceledOrder != bestBuy.ID() {
+		t.Errorf("revoke not recorded with auth manager")
+	}
+
+	if storage.revoked.ID() != bestBuy.ID() {
+		t.Errorf("revoke not recorded in storage")
+	}
+
+	if lockedCoins := mkt.coinsLocked(bestBuy); lockedCoins != nil {
+		t.Errorf("unbooked order still has locked coins: %v", lockedCoins)
+	}
+
+	bestBuy2, _ := mkt.book.Best()
+	if bestBuy2 == bestBuy {
+		t.Errorf("failed to unbook order")
+	}
+
 }
 
 func TestMarket_Suspend(t *testing.T) {
@@ -403,15 +461,9 @@ func TestMarket_Suspend(t *testing.T) {
 		mkt.Start(ctx, startEpochIdx)
 	}()
 
-	var wantClosedFeed bool
 	feed := mkt.OrderFeed()
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		for range feed {
-		}
-		if !wantClosedFeed {
-			t.Errorf("order feed should not be closed")
 		}
 	}()
 
@@ -452,7 +504,6 @@ func TestMarket_Suspend(t *testing.T) {
 	}
 
 	// Exactly at second epoch start, with same result.
-	wantClosedFeed = true // we intend to have this suspend happen
 	finalIdx, finalTime = mkt.Suspend(nextEpochTime, persist)
 	if finalIdx != nextEpochIdx-1 {
 		t.Fatalf("finalIdx = %d, wanted %d", finalIdx, nextEpochIdx-1)
@@ -481,6 +532,7 @@ func TestMarket_Suspend(t *testing.T) {
 	}
 
 	wg.Wait()
+	mkt.FeedDone(feed)
 
 	// Start up again (consumer resumes the Market manually)
 	startEpochIdx = 1 + encode.UnixMilli(time.Now())/epochDurationMSec
@@ -493,13 +545,8 @@ func TestMarket_Suspend(t *testing.T) {
 	}()
 
 	feed = mkt.OrderFeed()
-	wg.Add(1)
 	go func() {
-		defer wg.Done()
 		for range feed {
-		}
-		if !wantClosedFeed {
-			t.Errorf("order feed should not be closed")
 		}
 	}()
 
@@ -511,7 +558,6 @@ func TestMarket_Suspend(t *testing.T) {
 	}
 
 	// Suspend asap.
-	wantClosedFeed = true // allow the feed receiver goroutine to return w/o error
 	_, finalTime = mkt.SuspendASAP(persist)
 	<-time.After(time.Until(finalTime.Add(40 * time.Millisecond)))
 
@@ -520,15 +566,9 @@ func TestMarket_Suspend(t *testing.T) {
 		t.Fatal("the market should have been suspended")
 	}
 
-	// Ensure the feed is closed (Run returned).
-	select {
-	case <-feed:
-	default:
-		t.Errorf("order feed should be closed")
-	}
-
 	cancel()
 	wg.Wait()
+	mkt.FeedDone(feed)
 }
 
 func TestMarket_Suspend_Persist(t *testing.T) {
@@ -558,17 +598,9 @@ func TestMarket_Suspend_Persist(t *testing.T) {
 		mkt.Start(ctx, startEpochIdx)
 	}()
 
-	var wantClosedFeed bool
-
-	startFeedRecv := func() {
-		wg.Add(1)
+	startFeedRecv := func(feed <-chan *updateSignal) {
 		go func() {
-			defer wg.Done()
-			feed := mkt.OrderFeed()
 			for range feed {
-			}
-			if !wantClosedFeed {
-				t.Errorf("order feed should not be closed")
 			}
 		}()
 	}
@@ -589,7 +621,7 @@ func TestMarket_Suspend_Persist(t *testing.T) {
 
 	// Suspend asap with no resume.  The epoch with the limit order will be
 	// processed and then the market will suspend.
-	wantClosedFeed = true // allow the feed receiver goroutine to return w/o error
+	//wantClosedFeed = true // allow the feed receiver goroutine to return w/o error
 	persist := true
 	_, finalTime := mkt.SuspendASAP(persist)
 	<-time.After(time.Until(finalTime.Add(40 * time.Millisecond)))
@@ -617,6 +649,7 @@ func TestMarket_Suspend_Persist(t *testing.T) {
 	}
 
 	// Start it up again.
+	feed := mkt.OrderFeed()
 	startEpochIdx = 1 + encode.UnixMilli(time.Now())/epochDurationMSec
 	//startEpochTime = encode.UnixTimeMilli(startEpochIdx * epochDurationMSec)
 	wg.Add(1)
@@ -625,7 +658,7 @@ func TestMarket_Suspend_Persist(t *testing.T) {
 		mkt.Start(ctx, startEpochIdx)
 	}()
 
-	startFeedRecv()
+	startFeedRecv(feed)
 
 	mkt.waitForEpochOpen()
 
@@ -639,6 +672,7 @@ func TestMarket_Suspend_Persist(t *testing.T) {
 
 	// Wait for Run to return.
 	wg.Wait()
+	mkt.FeedDone(feed)
 
 	// Should be stopped
 	if mkt.Running() {
@@ -659,8 +693,10 @@ func TestMarket_Suspend_Persist(t *testing.T) {
 		t.Errorf("sell side of book not empty")
 	}
 
-	cancel()
-	wg.Wait()
+	if t.Failed() {
+		cancel()
+		wg.Wait()
+	}
 }
 
 func TestMarket_Run(t *testing.T) {

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -121,6 +121,8 @@ type TAuth struct {
 	preimagesByOrdID   map[string]order.Preimage
 	handlePreimageDone chan struct{}
 	suspensions        map[account.AccountID]bool
+	canceledOrder      order.OrderID
+	cancelOrder        order.OrderID
 }
 
 func (a *TAuth) Route(route string, handler func(account.AccountID, *msgjson.Message) *msgjson.Error) {
@@ -224,8 +226,11 @@ func (a *TAuth) Penalize(user account.AccountID, rule account.Rule) {
 	log.Infof("Penalize for user %v", user)
 }
 
-func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time)        {}
-func (a *TAuth) RecordCancel(account.AccountID, order.OrderID, order.OrderID, time.Time) {}
+func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time) {}
+func (a *TAuth) RecordCancel(aid account.AccountID, coid, oid order.OrderID, t time.Time) {
+	a.cancelOrder = coid
+	a.canceledOrder = oid
+}
 
 type TMarketTunnel struct {
 	adds       []*orderRecord
@@ -1318,6 +1323,7 @@ func TestRouter(t *testing.T) {
 	}
 
 	findBookOrder := func(id msgjson.Bytes, src *TBookSource) *order.LimitOrder {
+		t.Helper()
 		return findOrder(id, src.buys, src.sells)
 	}
 

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -276,6 +276,11 @@ type Swapper struct {
 	storage Storage
 	// authMgr is an AuthManager for client messaging and authentication.
 	authMgr AuthManager
+	// unbookHook is a callback the the Swapper's controller (e.g. DEX manager)
+	// for removing an order from the book. This should be called when a swap is
+	// revoked due to failure of the order's owner to complete the necessary
+	// actions.
+	unbookHook func(lo *order.LimitOrder) bool
 	// The matches map and the contained matches are protected by the matchMtx.
 	matchMtx sync.RWMutex
 	matches  map[order.MatchID]*matchTracker
@@ -338,6 +343,7 @@ type Config struct {
 	LockTimeTaker time.Duration
 	// LockTimeTaker is the locktime Swapper will use for auditing maker swaps.
 	LockTimeMaker time.Duration
+	UnbookHook    func(lo *order.LimitOrder) bool
 }
 
 // NewSwapper is a constructor for a Swapper.
@@ -357,6 +363,7 @@ func NewSwapper(cfg *Config) (*Swapper, error) {
 		coins:         cfg.Assets,
 		storage:       cfg.Storage,
 		authMgr:       authMgr,
+		unbookHook:    cfg.UnbookHook,
 		latencyQ:      wait.NewTickerQueue(recheckInterval),
 		matches:       make(map[order.MatchID]*matchTracker),
 		orders:        newOrderSwapTracker(),
@@ -1063,25 +1070,30 @@ func (s *Swapper) checkInaction(assetID uint32) {
 			// Record the end of this match's processing.
 			s.storage.SetMatchInactive(db.MatchID(match.Match))
 
-			// Create the server-generated cancel order, and register it with
-			// the AuthManager for cancellation ratio computation.
-			coid, revTime, err := s.storage.RevokeOrder(orderAtFault)
-			if err == nil {
-				s.authMgr.RecordCancel(orderAtFault.User(), coid, orderAtFault.ID(), revTime)
-			} else {
-				log.Errorf("Failed to revoke order %v with a new cancel order: %v",
-					orderAtFault.UID(), err)
+			// If the at-fault order is a limit order, signal that if it is
+			// still on the book is should be unbooked, changed to revoked
+			// status, counted against the user's cancellation ratio, and a
+			// server-generated cancel order recorded.
+			if lo, isLimit := orderAtFault.(*order.LimitOrder); isLimit {
+				if s.unbookHook(lo) {
+					s.orders.canceled(orderAtFault) // set as off-book and failed
+				}
 			}
 
-			// That's one less active swap for this order, and a failure.
+			// That's one less active swap for this order, and a failure. If
+			// this order has no other active swaps, it will be removed from the
+			// order swap tracker by decrementActiveSwapCount since it is
+			// off-book and no new swap negotiations can begin for this order.
 			s.orders.swapFailure(orderAtFault)
+
 			// The other order now has one less active swap too.
 			if s.orders.swapSuccess(otherOrder) {
 				// TODO: We should count this as a successful swap, but should
 				// it only be a completed order with the extra stipulation that
 				// it had already completed another swap?
-				s.authMgr.RecordCompletedOrder(otherOrder.User(), otherOrder.ID(), revTime)
-				if err = s.storage.SetOrderCompleteTime(otherOrder, encode.UnixMilli(revTime)); err != nil {
+				compTime := time.Now().UTC()
+				s.authMgr.RecordCompletedOrder(otherOrder.User(), otherOrder.ID(), compTime)
+				if err := s.storage.SetOrderCompleteTime(otherOrder, encode.UnixMilli(compTime)); err != nil {
 					if db.IsErrGeneralFailure(err) {
 						log.Errorf("fatal error with SetOrderCompleteTime for order %v: %v", otherOrder.UID(), err)
 					} else {
@@ -1998,17 +2010,13 @@ func (s *Swapper) revoke(match *matchTracker) {
 		// Expire function to unregister the outstanding request.
 		expireFunc := func() {
 			s.rmLiveAckers(req.ID)
-			//s.authMgr.Penalize(ack.user, account.FailureToAct) // really penalize again?
+			log.Infof("revoke_match request failed for user %v (taker)", user)
 		}
 		// Register that there is an outstanding request.
 		s.setLiveAcker(req, ack)
-		err := s.authMgr.RequestWithTimeout(user, req, func(_ comms.Link, resp *msgjson.Message) {
+		s.authMgr.RequestWhenConnected(user, req, func(_ comms.Link, resp *msgjson.Message) {
 			s.processAck(resp, ack)
-		}, auth.DefaultRequestTimeout, expireFunc)
-		if err != nil {
-			expireFunc() // unregister request and penalize
-			log.Infof("revoke_match request failed for user %v (taker): %v", user, err)
-		}
+		}, auth.DefaultRequestTimeout, auth.DefaultConnectTimeout, expireFunc)
 	}
 
 	takerParams, takerReq, makerParams, makerReq, err := s.revocationRequests(match)

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -534,6 +534,7 @@ func tNewTestRig(matchInfo *tMatch, conf ...*rigData) (*testRig, func()) {
 		BroadcastTimeout: txWaitExpiration * 5,
 		LockTimeTaker:    dex.LockTimeTaker(dex.Testnet),
 		LockTimeMaker:    dex.LockTimeMaker(dex.Testnet),
+		UnbookHook:       func(*order.LimitOrder) bool { return true },
 	})
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
It was a mistake for `(*Swapper).checkInaction` to revoke orders in
persistent storage, as they would have still been on `Market`'s
in-memory book.

When a match fails, there is no good way to unbook the faulty order.
This creates a `Swapper.unbookHook` field (a function) set on construction-
time via `Config`.  In the dex manager, this unbook hook is a simple
dispatcher to the appropriate `Market`'s new `Unbook` method.

Add `(*Market).Unbook` to remove the order from the in-memory book,
and if it was removed, unlock the coins, change the order's status to
revoked in storage via `RevokeOrder`, record the cancel with the
`AuthManager` via `RecordCancel` for cancellation ratio tracking, and
finally send a signal to the book router of the `unbookAction`.
The `Unbook` method does not require the `Market` to be running.

This also changes the shutdown behavior of `(*Market).Run` so that it does
not close the order feeds on shutdown.  This permits unbook
notifications to reach the book router after the `Market` has shut down.
This also causes the book router to stay running after `Market` suspend,
as a closed channel stops the book router. The book router now only
stops on context cancellation.

Add `(*Market).FeedDone` so the book router can release the feed channel,
but this should not be necessary for the book router to do since the
book router will be shutdown after the market when the dex manager
properly orders the shutdown sequence.