### PR TITLE
ws: Newconnection only replies with error if not handshake error

### DIFF
--- a/client/rpcserver/websocket.go
+++ b/client/rpcserver/websocket.go
@@ -31,7 +31,6 @@ var (
 	pingPeriod = (pongWait * 9) / 10
 	// A client id counter.
 	cidCounter int32
-	unbip      = dex.BipIDSymbol
 )
 
 type wsClient struct {
@@ -61,7 +60,6 @@ func (s *RPCServer) handleWS(w http.ResponseWriter, r *http.Request) {
 	wsConn, err := ws.NewConnection(w, r, pongWait)
 	if err != nil {
 		log.Errorf("ws connection error: %v", err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 	go s.websocketHandler(wsConn, ip)

--- a/client/webserver/websocket.go
+++ b/client/webserver/websocket.go
@@ -59,7 +59,6 @@ func (s *WebServer) handleWS(w http.ResponseWriter, r *http.Request) {
 	wsConn, err := ws.NewConnection(w, r, pongWait)
 	if err != nil {
 		log.Errorf("ws connection error: %v", err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 	go s.websocketHandler(wsConn, ip)

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -218,7 +218,6 @@ func (s *Server) Run(ctx context.Context) {
 		wsConn, err := ws.NewConnection(w, r, pongWait)
 		if err != nil {
 			log.Errorf("ws connection error: %v", err)
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
Based on https://github.com/decred/dcrdex/pull/484, the relevant diff for this PR is https://github.com/decred/dcrdex/pull/485/commits/5dd77ea6800d3fc48357d1628cb0d344c0309a21

Fixes superfluous header write in the event of upgrade errors.

ws: `NewConnection` only replies with error if not handshake error

Use `dex.NewError` to wrap handshake error on `gorilla/websocket.HandshakeError` with details from `upgrader.Upgrade`'s error.

client/{rpcserver,webserver},server/comms: do not `http.Error` on upgrade error