### PR TITLE
multi: sign connect response

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -666,7 +666,10 @@ func (rig *testRig) queueNotifyFee() {
 
 func (rig *testRig) queueConnect() {
 	rig.ws.queueResponse(msgjson.ConnectRoute, func(msg *msgjson.Message, f msgFunc) error {
-		result := &msgjson.ConnectResult{}
+		connect := new(msgjson.Connect)
+		msg.Unmarshal(connect)
+		sign(tDexPriv, connect)
+		result := &msgjson.ConnectResult{Sig: connect.Sig}
 		resp, _ := msgjson.NewResponse(msg.ID, result, nil)
 		f(resp)
 		return nil

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -767,6 +767,7 @@ func (c *Connect) Serialize() []byte {
 
 // ConnectResult is the result result for the ConnectRoute request.
 type ConnectResult struct {
+	Sig     Bytes    `json:"sig"`
 	Matches []*Match `json:"matches"`
 }
 

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -757,7 +757,18 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 			Side:     uint8(match.Side),
 		})
 	}
+
+	sig, err := auth.signer.Sign(sigMsg)
+	if err != nil {
+		log.Errorf("handleConnect signature error: %v", err)
+		return &msgjson.Error{
+			Code:    msgjson.RPCInternalError,
+			Message: "internal error",
+		}
+	}
+
 	resp := &msgjson.ConnectResult{
+		Sig:     sig.Serialize(),
 		Matches: msgMatches,
 	}
 	respMsg, err := msgjson.NewResponse(msg.ID, resp, nil)


### PR DESCRIPTION
Resolves #273. The 'connect' response is now signed. The message is the `msgjson.Connect` serialization.