### PR TITLE
comms: extend test wait times.

### DIFF
--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -75,7 +75,7 @@ func TestWsConn(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pingWait := time.Millisecond * 200
+	pingWait := time.Second
 
 	type conn struct {
 		sync.WaitGroup

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -610,7 +610,7 @@ func TestOnline(t *testing.T) {
 
 	keyPath := filepath.Join(tempDir, "rpc.key")
 	certPath := filepath.Join(tempDir, "rpc.cert")
-	pongWait = 100 * time.Millisecond
+	pongWait = time.Second
 	pingPeriod = (pongWait * 9) / 10
 	server, err := NewServer(&RPCConfig{
 		ListenAddrs: []string{":0"},

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -610,7 +610,7 @@ func TestOnline(t *testing.T) {
 
 	keyPath := filepath.Join(tempDir, "rpc.key")
 	certPath := filepath.Join(tempDir, "rpc.cert")
-	pongWait = time.Second
+	pongWait = time.Millisecond * 500
 	pingPeriod = (pongWait * 9) / 10
 	server, err := NewServer(&RPCConfig{
 		ListenAddrs: []string{":0"},

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -704,8 +704,8 @@ func TestOnline(t *testing.T) {
 		return err
 	}
 
-	// Sleep for a few  pongs to make sure the client doesn't disconnect.
-	time.Sleep(pongWait * 3)
+	// Sleep for a couple of pongs to make sure the client doesn't disconnect.
+	time.Sleep(pongWait * 2)
 
 	// Positive path.
 	err = sendToDEX("ok", "{}")


### PR DESCRIPTION
This extends test wait times to prevent timeouts on slow machines.

Resolves  #450