### PR TITLE
server/{db,market}: book purge does not affect cancellation ratio

### DIFF
--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -22,7 +22,6 @@ const (
 
 var (
 	archie            *Archiver
-	sqlDb             *sql.DB
 	mktInfo, mktInfo2 *dex.MarketInfo
 	numMarkets        int
 )

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -138,10 +138,16 @@ type OrderArchiver interface {
 	// "revoked", and RevokeOrder should be used to set this status.
 	CancelOrder(*order.LimitOrder) error
 
-	// RevokeOrder puts an order into the revoked state. Orders should be
-	// revoked by the DEX according to policy on failed orders. For canceling an
-	// order that was matched with a cancel order, use CancelOrder.
+	// RevokeOrder puts an order into the revoked state, and generates a cancel
+	// order to record the action. Orders should be revoked by the DEX according
+	// to policy on failed orders. For canceling an order that was matched with
+	// a cancel order, use CancelOrder.
 	RevokeOrder(order.Order) (cancelID order.OrderID, t time.Time, err error)
+
+	// RevokeOrderUncounted is like RevokeOrder except that the generated cancel
+	// order will not be counted against the user. i.e. ExecutedCancelsForUser
+	// should not return the cancel orders created this way.
+	RevokeOrderUncounted(order.Order) (cancelID order.OrderID, t time.Time, err error)
 
 	// FailCancelOrder puts an unmatched cancel order into the executed state.
 	// For matched cancel orders, use ExecuteOrder.

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -180,7 +180,8 @@ ordersLoop:
 			}
 
 			delete(bookOrdersByID, id)
-			if _, _, err = storage.RevokeOrder(lo); err != nil {
+			// Revoke the order, but do not count this against the user.
+			if _, _, err = storage.RevokeOrderUncounted(lo); err != nil {
 				log.Errorf("Failed to revoke order %v: %v", lo, err)
 			}
 			// No penalization here presently since the market was down, but if
@@ -223,7 +224,8 @@ ordersLoop:
 		log.Warnf("Revoking book order %v with already locked coins.", oid)
 		bad := bookOrdersByID[oid]
 		delete(bookOrdersByID, oid)
-		if _, _, err = storage.RevokeOrder(bad); err != nil {
+		// Revoke the order, but do not count this against the user.
+		if _, _, err = storage.RevokeOrderUncounted(bad); err != nil {
 			log.Errorf("Failed to revoke order %v: %v", bad, err)
 			// But still not added back on the book.
 		}
@@ -238,7 +240,8 @@ ordersLoop:
 			// maybe a revoke failed.
 			log.Errorf("Not rebooking order %v with amount (%v/%v) incompatible with current lot size (%v)",
 				lo.FillAmt, lo.Quantity, mktInfo.LotSize)
-			if _, _, err = storage.RevokeOrder(lo); err != nil {
+			// Revoke the order, but do not count this against the user.
+			if _, _, err = storage.RevokeOrderUncounted(lo); err != nil {
 				log.Errorf("Failed to revoke order %v: %v", lo, err)
 				// But still not added back on the book.
 			}

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -124,6 +124,9 @@ func (ta *TArchivist) CancelOrder(*order.LimitOrder) error { return nil }
 func (ta *TArchivist) RevokeOrder(order.Order) (order.OrderID, time.Time, error) {
 	return order.OrderID{}, time.Now(), nil
 }
+func (ta *TArchivist) RevokeOrderUncounted(order.Order) (order.OrderID, time.Time, error) {
+	return order.OrderID{}, time.Now(), nil
+}
 func (ta *TArchivist) SetOrderCompleteTime(ord order.Order, compTime int64) error { return nil }
 func (ta *TArchivist) FailCancelOrder(*order.CancelOrder) error                   { return nil }
 func (ta *TArchivist) UpdateOrderFilled(*order.LimitOrder) error                  { return nil }


### PR DESCRIPTION
Resolves issue https://github.com/decred/dcrdex/issues/451 in conjunction with PR https://github.com/decred/dcrdex/pull/462

dex/order: zero value `Commitment` `Value`/`Scan` to/from sql `NULL` `BYTEA`

server/db: `FlushBook` makes exempt cancels

`(*Archiver).FlushBook` now creates exempt cancel orders, which do not not
count in the user's cancellation ratio, to record the change of status of the
flushed orders from booked => revoked.

`OrderArchiver.RevokeOrderUncounted` revokes an order like `RevokeOrder`,
but the generated cancel is exempt.

server/db/driver/pg: two categories of server-generated cancel orders

Eliminate random `Commitment`s for revoke cancels, now `NULL`.

Server-generated cancel orders for revoked orders are now stored with
`NULL` in the commit column, which loads as the zero-value `Commitment`.

These special cancels have two categories:
 * counted: affects cancellation ratio, and encoded with epoch  index 0
   (`countedEpochIdx`) and dur 1 (`dummyEpochDur`)
 * uncounted/exempt: does not affect cancellation ratio, and encoded
   with epoch index -1 (`exemptEpochIdx`) and dur 1 (`dummyEpochDur`)

`ExecutedCancelsForUser` *excludes* exempt cancels.

market: revokes in `NewMarket` are uncounted/exempt