### PR TITLE
spec: remove funding confirmations requirement

### DIFF
--- a/spec/admin.mediawiki
+++ b/spec/admin.mediawiki
@@ -38,8 +38,6 @@ possible.
 |-
 | fee&nbsp;rate  || atoms/byte || the minimum fee rate for swap transactions
 |-
-| coin&nbsp;confirmations|| count || the Minimum confirmations for backing coins
-|-
 | swap&nbsp;confirmations|| count || the Minimum confirmations before acting on a swap transaction
 |}
 

--- a/spec/fundamentals.mediawiki
+++ b/spec/fundamentals.mediawiki
@@ -67,14 +67,10 @@ The DEX operator specifies an on-chain transaction '''fee rate'''
 [[orders.mediawiki/#Calculating_Transaction_Fees|calculating the fees]] for
 initialization transactions.
 
-Each asset has two distinct '''minimum numbers of confirmations'''. The
-<code>fundconf</code> is the number of confirmations required for
-[[orders.mediawiki/#Order_Preparation|coins to fund an order]]. The
-<code>swapconf</code> is the number of confirmations required during settlement
-on the first swap transaction, before the second swap transaction is broadcast.
-
-The minimum confirmation rule is waived for a change output from a transaction
-involved in a DEX-monitored trade.
+The <code>swapconf</code> is the number of confirmations required during
+settlement on the first swap transaction, before the second swap transaction is
+broadcast, as well as on the second swap transaction, before the first
+redemption is broadcast.
 
 ===Market Variables===
 
@@ -131,8 +127,6 @@ respond with its current configuration.
 | swapsize || int || the size of the initialization transaction (bytes)
 |-
 | swapconf || int || minimum confirmations for swap transactions
-|-
-| fundconf || int || minimum confirmations for funding coins
 |}
 
 '''Market object'''

--- a/spec/orders.mediawiki
+++ b/spec/orders.mediawiki
@@ -217,10 +217,6 @@ The DEX will verify the coin sum before accepting the order.
 
 ===Coin Preparation===
 
-All backing [[comm.mediawiki/#Coin_ID|coins]] must have a minimum number of confirmations. The exact number,
-<code>swapconf</code>, is an [[fundamentals.mediawiki/#Exchange_Variables|asset variable]] set by the
-DEX operator.
-
 With the exception of market buy orders, which are detailed below, for an order
 of quantity '''''Q''''', the sum value of the selected coins, '''''V''''',
 must satisfy the relation


### PR DESCRIPTION
Drops the minimum funding confirmations requirement. 

1. Confirmation requirements for funding outputs add no real security and some major programming and UX issues.
2. The user is required to lock up more funds than they are trading if their order doesn't match immediately, since transaction outputs can't be sized at trade time. Solutions such as pre-splitting transactions to lot-sized or multi-lot-sized outputs is possible, but would increase realized transaction fees, make small lot sizes infeasible even for low-tx-fee-rate assets, and still delays the users ability to trade after funding their exchange wallet.
3. The funding confirmation requirement also requires a lot of special handling of outputs, such as the change output monitoring for the client and special handling likely requiring deep DB scans for
the server.

For these reasons, dropping the confirmation requirement is proposed here.

There are some possibly valid counter-arguments to this proposal. Please try to keep most discussion here on github for documentation and transparency. 