### PR TITLE
client/db/test: make -short tests, remove usless code

### DIFF
--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -17,8 +17,9 @@ import (
 
 // Generate a public key on the secp256k1 curve.
 func randomPubKey() *secp256k1.PublicKey {
-	_, pub := secp256k1.PrivKeyFromBytes(randBytes(32))
-	return pub
+	// _, pub := secp256k1.PrivKeyFromBytes(randBytes(32))
+	// return pub
+	return secp256k1.NewPublicKey(secp256k1.S256().ScalarBaseMult(randBytes(32)))
 }
 
 func randString(maxLen int) string {

--- a/client/db/test/types_test.go
+++ b/client/db/test/types_test.go
@@ -11,8 +11,9 @@ import (
 
 func TestAccountInfo(t *testing.T) {
 	spins := 10000
-	ais := make([]*db.AccountInfo, 0, spins)
-	nTimes(spins, func(int) { ais = append(ais, RandomAccountInfo()) })
+	if testing.Short() {
+		spins = 1000
+	}
 	tStart := time.Now()
 	nTimes(spins, func(i int) {
 		ai := RandomAccountInfo()
@@ -28,6 +29,9 @@ func TestAccountInfo(t *testing.T) {
 
 func TestMatchProof(t *testing.T) {
 	spins := 10000
+	if testing.Short() {
+		spins = 1000
+	}
 	proofs := make([]*db.MatchProof, 0, spins)
 	// Generate proofs with an average of 20% sparsity. Empty fields should not
 	// affect accurate encoding/decoding.
@@ -47,6 +51,9 @@ func TestMatchProof(t *testing.T) {
 
 func TestOrderProof(t *testing.T) {
 	spins := 10000
+	if testing.Short() {
+		spins = 1000
+	}
 	proofs := make([]*db.OrderProof, 0, spins)
 	nTimes(spins, func(int) {
 		proofs = append(proofs, &db.OrderProof{

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -84,7 +84,8 @@ func (ai *AccountInfo) Encode() []byte {
 		AddData(ai.Cert)
 }
 
-// DecodeAccountInfo decodes the versioned blob into an *AccountInfo.
+// DecodeAccountInfo decodes the versioned blob into an *AccountInfo. The byte
+// slice fields of AccountInfo reference the underlying buffer of the the input.
 func DecodeAccountInfo(b []byte) (*AccountInfo, error) {
 	ver, pushes, err := encode.DecodeBlob(b)
 	if err != nil {


### PR DESCRIPTION
The race detector makes randBytes very very slow.  The test is typically ~40 seconds.

This adds a `-short` test option with fewer iterations, reducing the test time to about 4 seconds.