### PR TITLE
client/{core,asset}: lock/unlock swap change coins

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -75,8 +75,11 @@ type Wallet interface {
 	// externally. This method will only return funding coins, e.g. unspent
 	// transaction outputs.
 	FundingCoins([]dex.Bytes) (Coins, error)
-	// Swap sends the swaps in a single transaction. The Receipts returned can be
-	// used to refund a failed transaction.
+	// Swap sends the swaps in a single transaction. The Receipts returned can
+	// be used to refund a failed transaction. The change coin is locked with
+	// the wallet in case it is still required to fund chained swaps for an
+	// order. The caller should unlock the change coin via ReturnCoins if it is
+	// no longer required to fund additional swaps for the parent order.
 	Swap(*Swaps, *dex.Asset) ([]Receipt, Coin, error)
 	// Redeem sends the redemption transaction, which may contain more than one
 	// redemption. The input coin IDs and the output Coin are returned.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2444,7 +2444,7 @@ func handleMatchProofMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error
 }
 
 // handleRevokeMatchMsg is called when a revoke_match message is received.
-func handleRevokeMatchMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) error {
+func handleRevokeMatchMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	var revocation msgjson.RevokeMatch
 	err := msg.Unmarshal(&revocation)
 	if err != nil {
@@ -2457,6 +2457,10 @@ func handleRevokeMatchMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) erro
 	tracker, _, _ := dc.findOrder(oid)
 	if tracker == nil {
 		return fmt.Errorf("no order found with id %s", oid.String())
+	}
+
+	if len(revocation.MatchID) != order.MatchIDSize {
+		return fmt.Errorf("invalid match ID %x", revocation.MatchID)
 	}
 
 	var matchID order.MatchID
@@ -2472,11 +2476,77 @@ func handleRevokeMatchMsg(_ *Core, dc *dexConnection, msg *msgjson.Message) erro
 	}
 	tracker.matchMtx.RUnlock()
 	if revokedMatch == nil {
-		return fmt.Errorf("no match found with id %s for order %s", matchID, oid.String())
+		return fmt.Errorf("no match found with id %s for order %v", matchID, oid)
 	}
 
+	errs := newErrorSet("handleRevokeMatchMsg (order %v, match %v): ", oid, matchID)
+
+	// Set the match as revoked.
 	revokedMatch.MetaMatch.MetaData.Proof.IsRevoked = true
-	return tracker.db.UpdateMatch(&revokedMatch.MetaMatch)
+	err = tracker.db.UpdateMatch(&revokedMatch.MetaMatch)
+	if err != nil {
+		errs.add("unable to update match: %v", err)
+	}
+
+	// Notify the user of the failed match.
+	corder, _ := tracker.coreOrder() // no cancel order
+	tracker.notify(newOrderNote("Match revoked", fmt.Sprintf("Match %s has been revoked",
+		tracker.token()), db.WarningLevel, corder))
+
+	// Also set the order as revoked.
+	metaOrder := tracker.metaOrder()
+	metaOrder.MetaData.Status = order.OrderStatusRevoked
+	err = tracker.db.UpdateOrder(metaOrder)
+	if err != nil {
+		errs.add("unable to update order: %v", err)
+	}
+
+	// Notify the user of the revoked order.
+	details := fmt.Sprintf("%s order on %s-%s at %s has been revoked (%s)",
+		strings.Title(sellString(tracker.Trade().Sell)), unbip(tracker.Base()),
+		unbip(tracker.Quote()), dc.acct.host, tracker.token())
+	tracker.notify(newOrderNote("Order revoked", details, db.WarningLevel, corder))
+
+	// Send out a data notification with the revoke information.
+	cancelOrder := &Order{
+		Host:     tracker.dc.acct.host,
+		MarketID: tracker.mktID,
+		Type:     order.CancelOrderType,
+		Stamp:    encode.UnixMilliU(time.Now()),
+		Epoch:    corder.Epoch,
+		TargetID: corder.ID, // the important part for the frontend
+	}
+	tracker.notify(newOrderNote("revoke", "", db.Data, cancelOrder))
+
+	// Unlock funding coins if they are not already unlocked. Do this one at a
+	// time if wallet fails if just one cannot be unlocked.
+	for _, coin := range tracker.coins {
+		err = tracker.wallets.fromWallet.ReturnCoins(asset.Coins{coin})
+		if err != nil {
+			log.Warnf("unable to unlock coin %v: %v", coin, err)
+		}
+	}
+
+	// Tick asset to trigger recovery if the match was revoked during
+	// swap and either refund or redeem is needed. Or not?
+	counts, err := tracker.tick()
+	if err != nil {
+		errs.addErr(err)
+	}
+	if len(counts) > 0 {
+		dc.refreshMarkets()
+		c.updateBalances(counts)
+	}
+
+	log.Warnf("Match %v revoked in status %v for order %v", matchID, revokedMatch.Match.Status, oid)
+
+	// Respond to DEX.
+	err = dc.ack(msg.ID, matchID, &revocation)
+	if err != nil {
+		errs.add("Audit error: %v", err)
+	}
+
+	return errs.ifany()
 }
 
 // handleTradeSuspensionMsg is called when a trade suspension notification is received.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2533,16 +2533,9 @@ func handleRevokeMatchMsg(c *Core, dc *dexConnection, msg *msgjson.Message) erro
 		}
 	}
 
-	// Tick asset to trigger recovery if the match was revoked during
-	// swap and either refund or redeem is needed. Or not?
-	counts, err := tracker.tick()
-	if err != nil {
-		errs.addErr(err)
-	}
-	if len(counts) > 0 {
-		dc.refreshMarkets()
-		c.updateBalances(counts)
-	}
+	// Update market orders, and the balance to account for unlocked coins.
+	dc.refreshMarkets()
+	c.updateAssetBalance(tracker.wallets.fromAsset.ID)
 
 	log.Warnf("Match %v revoked in status %v for order %v", matchID, revokedMatch.Match.Status, oid)
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -218,7 +218,10 @@ func (dc *dexConnection) hasActiveOrders() bool {
 		if checkMatchOrderStatus(trade) {
 			return true
 		}
-		if trade.metaData.Status == order.OrderStatusBooked || trade.metaData.Status == order.OrderStatusEpoch {
+		//trade.mtx.RLock() // ?
+		status := trade.metaData.Status
+		//trade.mtx.RUnlock()
+		if status == order.OrderStatusBooked || status == order.OrderStatusEpoch {
 			return true
 		}
 	}
@@ -1148,7 +1151,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 
 // verifyRegistrationFee waits the required amount of confirmations for the
 // registration fee payment. Once the requirement is met the server is notified.
-// If the server acknowledgment is successfull, the account is set as 'paid' in
+// If the server acknowledgment is successful, the account is set as 'paid' in
 // the database. Notifications about confirmations increase, errors and success
 // events are broadcasted to all subscribers.
 func (c *Core) verifyRegistrationFee(wallet *xcWallet, dc *dexConnection, coinID []byte, confs uint32) {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2523,7 +2523,13 @@ func handleRevokeMatchMsg(c *Core, dc *dexConnection, msg *msgjson.Message) erro
 	for _, coin := range tracker.coins {
 		err = tracker.wallets.fromWallet.ReturnCoins(asset.Coins{coin})
 		if err != nil {
-			log.Warnf("unable to unlock coin %v: %v", coin, err)
+			log.Warnf("unable to unlock funding coin %v: %v", coin, err)
+		}
+	}
+	if tracker.change != nil {
+		err = tracker.wallets.fromWallet.ReturnCoins(asset.Coins{tracker.change})
+		if err != nil {
+			log.Warnf("unable to unlock change coin %v: %v", tracker.change, err)
 		}
 	}
 

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -324,8 +324,6 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		}
 	}
 
-	initFilled := trade.Filled()
-
 	// Calculate the new filled value for the order.
 	isMarketBuy := t.Type() == order.MarketOrderType && !trade.Sell
 	var filled uint64
@@ -375,16 +373,8 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		// Set the order status for both orders.
 		t.metaData.Status = order.OrderStatusCanceled
 		t.db.UpdateOrderStatus(t.cancel.ID(), order.OrderStatusExecuted)
-		// If the order's backing coins are unused, unlock them, otherwise they
-		// have been or will be spent by a swap.
-		if !includesTrades && initFilled == 0 {
-			for _, coin := range t.coins {
-				err = t.wallets.fromWallet.ReturnCoins(asset.Coins{coin})
-				if err != nil {
-					log.Warnf("unable to unlock coin %v: %v", coin, err)
-				}
-			}
-		}
+		// TODO: If the order's backing coins/change are unused, unlock them,
+		// otherwise they have been or will be spent by a swap.
 	}
 	if includesTrades {
 		fillRatio := float64(trade.Filled()) / float64(trade.Quantity)

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -57,7 +57,8 @@ type DB interface {
 	// returned. since = 0 is equivalent to disabling the time filter, since
 	// no orders were created before before 1970.
 	MarketOrders(dex string, base, quote uint32, n int, since uint64) ([]*MetaOrder, error)
-	// SetChangeCoin stores the change coin for the order.
+	// SetChangeCoin stores the current change coin for the order. This coin
+	// will change each time a chained swap occurs for this order.
 	SetChangeCoin(order.OrderID, order.CoinID) error
 	// UpdateOrderStatus sets the order status for an order.
 	UpdateOrderStatus(oid order.OrderID, status order.OrderStatus) error

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -178,7 +178,7 @@ type OrderMetaData struct {
 	// ChangeCoin is a change coin from a match. Change coins are "daisy-chained"
 	// for matches. All funding coins go into the first match, and the change coin
 	// from the initiation transaction is used to fund the next match. The
-	// change from that matches ini tx funds the next match, etc.
+	// change from that matches init tx funds the next match, etc.
 	ChangeCoin order.CoinID
 }
 

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -733,7 +733,7 @@ export default class MarketsPage extends BasePage {
 
   /*
    * handleFeePayment is the handler for the 'feepayment' notification type.
-   * This is used to update the registration status of the currrent exchange.
+   * This is used to update the registration status of the current exchange.
    */
   handleFeePayment (note) {
     const dexAddr = note.dex
@@ -751,6 +751,8 @@ export default class MarketsPage extends BasePage {
     const order = note.order
     if (order.targetID && note.subject === 'cancel') {
       this.orderRows[order.targetID].querySelector('[data-col=cancel]').textContent = 'canceled'
+    } else if (order.targetID && note.subject === 'revoke') {
+      this.orderRows[order.targetID].querySelector('[data-col=cancel]').textContent = 'revoked'
     } else {
       const row = this.orderRows[order.id]
       if (!row) return

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -365,9 +365,9 @@ func (auth *AuthManager) rmUserConnectMsgs(user account.AccountID) []*pendingMes
 	if userMsgs == nil {
 		return nil
 	}
-	msgs := make([]*pendingMessage, len(userMsgs))
-	for i, tr := range userMsgs {
-		msgs[i] = tr.pendingMessage
+	msgs := make([]*pendingMessage, 0, len(userMsgs))
+	for _, tr := range userMsgs {
+		msgs = append(msgs, tr.pendingMessage)
 		// Stop the timer. It's ok if already fired since this timedMessage
 		// would have been removed if we lost the race with AfterFunc's call to
 		// rmUserConnectMsg. Since we're here, we beat the timer.
@@ -507,9 +507,9 @@ func (auth *AuthManager) rmUserConnectReqs(user account.AccountID) []*pendingReq
 	if userReqs == nil {
 		return nil
 	}
-	reqs := make([]*pendingRequest, len(userReqs))
-	for i, tr := range userReqs {
-		reqs[i] = tr.pendingRequest
+	reqs := make([]*pendingRequest, 0, len(userReqs))
+	for _, tr := range userReqs {
+		reqs = append(reqs, tr.pendingRequest)
 		// Stop the timer. It's ok if already fired since this timedRequest
 		// would have been removed if we lost the race with AfterFunc's call to
 		// rmUserConnectReq. Since we're here, we beat the timer.

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -164,7 +164,8 @@ func (c *wsLink) Request(msg *msgjson.Message, f func(conn Link, msg *msgjson.Me
 		// Neither expire nor the handler should run. Stop the expire timer
 		// created by logReq and delete the response handler it added. The
 		// caller receives a non-nil error to deal with it.
-		log.Debugf("(*wsLink).Request Send error, unregistering msg ID %d handler", msg.ID)
+		log.Debugf("(*wsLink).Request(route '%s') Send error, unregistering msg ID %d handler",
+			msg.Route, msg.ID)
 		c.respHandler(msg.ID) // drop the removed responseHandler
 	}
 	return err

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -388,11 +388,12 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 	authMgr := auth.NewAuthManager(&authCfg)
 	startSubSys("Auth manager", authMgr)
 
+	// Create an unbook dispatcher for the Swapper.
 	markets := make(map[string]*market.Market, len(cfg.Markets))
 	marketUnbookHook := func(lo *order.LimitOrder) bool {
 		name, err := dex.MarketName(lo.BaseAsset, lo.QuoteAsset)
 		if err != nil {
-			log.Error(err)
+			log.Errorf("unbook hook: %v", err)
 			return false
 		}
 

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -389,10 +389,10 @@ out:
 
 				// Depending on resume handling, maybe kill the book router.
 				// Presently the Market closes the order feed channels, so quit.
-				log.Infof("Book order feed closed for market %q after epoch %d, persist book = %v.",
+				log.Infof("Market %q suspended after epoch %d, persist book = %v.",
 					book.name, sigData.finalEpoch, sigData.persistBook)
+
 				// Stay running for Swapper unbook callbacks.
-				//break out
 
 			default:
 				panic(fmt.Sprintf("unknown orderbook update action %d", u.action))

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -278,7 +278,7 @@ out:
 		select {
 		case u, ok := <-feed:
 			if !ok {
-				log.Errorf("Book order feed closed for market %q at epoch %d without a suspend signal",
+				log.Errorf("Book order feed closed for market %q at epoch %d",
 					book.name, book.epoch())
 				break out
 			}
@@ -391,7 +391,8 @@ out:
 				// Presently the Market closes the order feed channels, so quit.
 				log.Infof("Book order feed closed for market %q after epoch %d, persist book = %v.",
 					book.name, sigData.finalEpoch, sigData.persistBook)
-				break out
+				// Stay running for Swapper unbook callbacks.
+				//break out
 
 			default:
 				panic(fmt.Sprintf("unknown orderbook update action %d", u.action))

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -50,8 +50,6 @@ const (
 // Swapper coordinates atomic swaps for one or more matchsets.
 type Swapper interface {
 	Negotiate(matchSets []*order.MatchSet, offBook map[order.OrderID]bool)
-	LockCoins(asset uint32, coins map[order.OrderID][]order.CoinID)
-	LockOrdersCoins(orders []order.Order)
 	CheckUnspent(asset uint32, coinID []byte) error
 }
 
@@ -426,6 +424,29 @@ func (m *Market) OrderFeed() <-chan *updateSignal {
 	return bookUpdates
 }
 
+func (m *Market) FeedDone(feed <-chan *updateSignal) bool {
+	m.orderFeedMtx.Lock()
+	defer m.orderFeedMtx.Unlock()
+	for i := range m.orderFeeds {
+		if m.orderFeeds[i] == feed {
+			close(m.orderFeeds[i])
+			m.orderFeeds[i] = m.orderFeeds[len(m.orderFeeds)-1]
+			m.orderFeeds = m.orderFeeds[:len(m.orderFeeds)-1]
+			//m.orderFeeds = append(m.orderFeeds[:i], m.orderFeeds[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Market) sendToFeeds(sig *updateSignal) {
+	m.orderFeedMtx.RLock()
+	for _, s := range m.orderFeeds {
+		s <- sig
+	}
+	m.orderFeedMtx.RUnlock()
+}
+
 type orderUpdateSignal struct {
 	rec     *orderRecord
 	errChan chan error // should be buffered
@@ -649,14 +670,9 @@ func (m *Market) Run(ctx context.Context) {
 		close(notifyChan)
 		wgFeeds.Wait()
 
-		// Close and delete the outgoing order feed channels as a signal to
-		// subscribers that the Market has terminated.
-		m.orderFeedMtx.Lock()
-		for _, s := range m.orderFeeds {
-			close(s)
-		}
-		m.orderFeeds = nil
-		m.orderFeedMtx.Unlock()
+		// Retain the outgoing order feed channels, which are the links to the
+		// book router and any other consumers, for possible Market resume, and
+		// for Swapper's unbook callback to function using sendToFeeds.
 
 		// persistBook is set under epochMtx lock.
 		m.epochMtx.RLock()
@@ -673,13 +689,7 @@ func (m *Market) Run(ctx context.Context) {
 	go func() {
 		defer wgFeeds.Done()
 		for sig := range notifyChan {
-			// send to each receiver
-			m.orderFeedMtx.RLock()
-			feeds := m.orderFeeds
-			m.orderFeedMtx.RUnlock()
-			for _, s := range feeds {
-				s <- sig
-			}
+			m.sendToFeeds(sig)
 		}
 	}()
 
@@ -1279,6 +1289,41 @@ func (m *Market) epochStart(orders []order.Order) (cSum []byte, ordersRevealed [
 	}
 
 	return
+}
+
+// Unbook is a callback for the swapper to request unbooking an order.
+func (m *Market) Unbook(lo *order.LimitOrder) bool {
+	// Ensure we do not unbook during matching.
+	m.bookMtx.Lock()
+	_, removed := m.book.Remove(lo.ID())
+	m.bookMtx.Unlock()
+
+	m.unlockOrderCoins(lo)
+
+	if !removed {
+		return false
+	}
+
+	// Create the server-generated cancel order, and register it with
+	// the AuthManager for cancellation ratio computation.
+	coid, revTime, err := m.storage.RevokeOrder(lo)
+	if err == nil {
+		m.auth.RecordCancel(lo.User(), coid, lo.ID(), revTime)
+	} else {
+		log.Errorf("Failed to revoke order %v with a new cancel order: %v",
+			lo.UID(), err)
+	}
+
+	// Send "unbook" notification to order book subscribers.
+	m.sendToFeeds(&updateSignal{
+		action: unbookAction,
+		data: sigDataUnbookedOrder{
+			order:    lo,
+			epochIdx: -1, // NOTE: no epoch
+		},
+	})
+
+	return true
 }
 
 // processReadyEpoch performs the following operations for a closed epoch that

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -121,6 +121,8 @@ type TAuth struct {
 	preimagesByOrdID   map[string]order.Preimage
 	handlePreimageDone chan struct{}
 	suspensions        map[account.AccountID]bool
+	canceledOrder      order.OrderID
+	cancelOrder        order.OrderID
 }
 
 func (a *TAuth) Route(route string, handler func(account.AccountID, *msgjson.Message) *msgjson.Error) {
@@ -224,8 +226,11 @@ func (a *TAuth) Penalize(user account.AccountID, rule account.Rule) {
 	log.Infof("Penalize for user %v", user)
 }
 
-func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time)        {}
-func (a *TAuth) RecordCancel(account.AccountID, order.OrderID, order.OrderID, time.Time) {}
+func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time) {}
+func (a *TAuth) RecordCancel(aid account.AccountID, coid, oid order.OrderID, t time.Time) {
+	a.cancelOrder = coid
+	a.canceledOrder = oid
+}
 
 type TMarketTunnel struct {
 	adds       []*orderRecord

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -1318,6 +1318,7 @@ func TestRouter(t *testing.T) {
 	}
 
 	findBookOrder := func(id msgjson.Bytes, src *TBookSource) *order.LimitOrder {
+		t.Helper()
 		return findOrder(id, src.buys, src.sells)
 	}
 

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -275,7 +275,11 @@ type Swapper struct {
 	// storage is a Database backend.
 	storage Storage
 	// authMgr is an AuthManager for client messaging and authentication.
-	authMgr    AuthManager
+	authMgr AuthManager
+	// unbookHook is a callback the the Swapper's controller (e.g. DEX manager)
+	// for removing an order from the book. This should be called when a swap is
+	// revoked due to failure of the order's owner to complete the necessary
+	// actions.
 	unbookHook func(lo *order.LimitOrder) bool
 	// The matches map and the contained matches are protected by the matchMtx.
 	matchMtx sync.RWMutex

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -534,6 +534,7 @@ func tNewTestRig(matchInfo *tMatch, conf ...*rigData) (*testRig, func()) {
 		BroadcastTimeout: txWaitExpiration * 5,
 		LockTimeTaker:    dex.LockTimeTaker(dex.Testnet),
 		LockTimeMaker:    dex.LockTimeMaker(dex.Testnet),
+		UnbookHook:       func(*order.LimitOrder) bool { return true },
 	})
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
This is based on PR https://github.com/decred/dcrdex/pull/475, so the relevant diffs for this change are https://github.com/decred/dcrdex/pull/511/commits/80e601894e286377990820533df69efd8d40014e and https://github.com/decred/dcrdex/pull/511/commits/751b7e23eb88e97109e8b13f5a3e62a8e002618d (so far)

For partially filled limit orders that are still on the books, subsequent swaps will attempt to use the recorded change coin to fund the chained swaps.  This adds the necessary wallet outpoint locking of these coins in `Swap`, where the caller is responsible for determining if those change coins need to remain locked.