### PR TITLE
app: auto-find redemption when Maker goes dark after Taker swap

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1240,7 +1240,7 @@ func (btc *ExchangeWallet) FindRedemption(coinID dex.Bytes) (chan *asset.FindRed
 	msgTx := wire.NewMsgTx(wire.TxVersion)
 	err = msgTx.Deserialize(bytes.NewBuffer(tx.Hex))
 	if err != nil {
-		return nil, fmt.Errorf("invalid contract tx hex: %v", err)
+		return nil, fmt.Errorf("invalid contract tx hex %s: %v", tx.Hex.String(), err)
 	}
 	if int(vout) > len(msgTx.TxOut)-1 {
 		return nil, fmt.Errorf("vout index %d out of range for transaction %s", vout, txHash)

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -297,6 +297,39 @@ func makeRawTx(txid string, pkScripts []dex.Bytes, inputs []btcjson.Vin) *btcjso
 	return tx
 }
 
+func makeTxHex(txid string, pkScripts []dex.Bytes, inputs []btcjson.Vin) ([]byte, error) {
+	msgTx := wire.NewMsgTx(wire.TxVersion)
+	for _, input := range inputs {
+		prevOutHash, err := chainhash.NewHashFromStr(input.Txid)
+		if err != nil {
+			return nil, err
+		}
+		sigScript, err := hex.DecodeString(input.ScriptSig.Hex)
+		if err != nil {
+			return nil, err
+		}
+		witness := make([][]byte, len(input.Witness))
+		for i, witnessHex := range input.Witness {
+			witness[i], err = hex.DecodeString(witnessHex)
+			if err != nil {
+				return nil, err
+			}
+		}
+		txIn := wire.NewTxIn(wire.NewOutPoint(prevOutHash, input.Vout), sigScript, witness)
+		msgTx.AddTxIn(txIn)
+	}
+	for _, pkScript := range pkScripts {
+		txOut := wire.NewTxOut(100000000, pkScript)
+		msgTx.AddTxOut(txOut)
+	}
+	txBuf := bytes.NewBuffer(make([]byte, 0, msgTx.SerializeSize()))
+	err := msgTx.Serialize(txBuf)
+	if err != nil {
+		return nil, err
+	}
+	return txBuf.Bytes(), nil
+}
+
 func makeRPCVin(txid string, vout uint32, sigScript []byte) btcjson.Vin {
 	return btcjson.Vin{
 		Txid: txid,
@@ -1325,6 +1358,10 @@ func TestFindRedemption(t *testing.T) {
 	inputs := []btcjson.Vin{makeRPCVin(otherTxid, 0, otherSpendScript)}
 	// Add the contract transaction. Put the pay-to-contract script at index 1.
 	blockHash, _ := node.addRawTx(contractHeight, makeRawTx(contractTxid, []dex.Bytes{otherScript, pkScript}, inputs))
+	txHex, err := makeTxHex(contractTxid, []dex.Bytes{otherScript, pkScript}, inputs)
+	if err != nil {
+		t.Fatalf("error generating hex for contract tx: %v", err)
+	}
 	getTxRes := &GetTransactionResult{
 		BlockHash:  blockHash.String(),
 		BlockIndex: contractHeight,
@@ -1335,11 +1372,12 @@ func TestFindRedemption(t *testing.T) {
 				Vout:     contractVout,
 			},
 		},
+		Hex: txHex,
 	}
 	node.rawRes[methodGetTransaction] = mustMarshal(t, getTxRes)
 
 	// Begin find redemption.
-	findRedemptionResultCh, err := wallet.FindRedemption(coinID, contract)
+	findRedemptionResultCh, err := wallet.FindRedemption(coinID)
 	if err != nil {
 		t.Fatalf("unexpected FindRedemption error: %v", err)
 	}
@@ -1380,7 +1418,7 @@ func TestFindRedemption(t *testing.T) {
 
 	// gettransaction error
 	node.rawErr[methodGetTransaction] = tErr
-	_, err = wallet.FindRedemption(coinID, contract)
+	_, err = wallet.FindRedemption(coinID)
 	if err == nil {
 		t.Fatalf("no error for gettransaction rpc error")
 	}
@@ -1388,7 +1426,7 @@ func TestFindRedemption(t *testing.T) {
 
 	// Expect FindRedemption to error because of bad input sig.
 	redeemBlock.RawTx[0].Vin[1].ScriptSig.Hex = hex.EncodeToString(randBytes(100))
-	findRedemptionResultCh, err = wallet.FindRedemption(coinID, contract)
+	findRedemptionResultCh, err = wallet.FindRedemption(coinID)
 	if err != nil {
 		t.Fatalf("unexpected FindRedemption error: %v", err)
 	}
@@ -1403,7 +1441,7 @@ func TestFindRedemption(t *testing.T) {
 	redeemBlock.RawTx[0].Vin[1].ScriptSig.Hex = hex.EncodeToString(redemptionScript)
 
 	// Sanity check to make sure it passes again.
-	findRedemptionResultCh, err = wallet.FindRedemption(coinID, contract)
+	findRedemptionResultCh, err = wallet.FindRedemption(coinID)
 	if err != nil {
 		t.Fatalf("unexpected FindRedemption error: %v", err)
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1318,9 +1318,10 @@ func TestFindRedemption(t *testing.T) {
 	node.mpVerboseTxs[contractTxid] = contractTx
 
 	// Begin find redemption.
-	findRedemptionResultCh := make(chan asset.FindRedemptionResult)
-	go wallet.FindRedemption([]dex.Bytes{coinID}, findRedemptionResultCh)
-
+	findRedemptionResultCh, err := wallet.FindRedemption(coinID)
+	if err != nil {
+		t.Errorf("unexpected FindRedemption error: %v", err)
+	}
 	// Expect to NOT find redemption yet.
 	select {
 	case frr := <-findRedemptionResultCh:
@@ -1358,7 +1359,10 @@ func TestFindRedemption(t *testing.T) {
 
 	// Expect FindRedemption to error because of bad input sig.
 	redeemBlock.RawTx[0].Vin[1].ScriptSig.Hex = hex.EncodeToString(randBytes(100))
-	go wallet.FindRedemption([]dex.Bytes{coinID}, findRedemptionResultCh)
+	findRedemptionResultCh, err = wallet.FindRedemption(coinID)
+	if err != nil {
+		t.Errorf("unexpected FindRedemption error: %v", err)
+	}
 	select {
 	case frr := <-findRedemptionResultCh:
 		if frr.Err == nil {
@@ -1371,19 +1375,17 @@ func TestFindRedemption(t *testing.T) {
 
 	// Expect FindRedemption to error because of wrong script type for contract output
 	contractBlock.RawTx[0].Vout[1].ScriptPubKey.Hex = hex.EncodeToString(otherScript)
-	go wallet.FindRedemption([]dex.Bytes{coinID}, findRedemptionResultCh)
-	select {
-	case frr := <-findRedemptionResultCh:
-		if frr.Err == nil {
-			t.Fatalf("no error for wrong script type")
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatalf("no error for wrong script type after 2 seconds")
+	_, err = wallet.FindRedemption(coinID)
+	if err == nil {
+		t.Fatalf("no error for wrong script type")
 	}
 	contractBlock.RawTx[0].Vout[1].ScriptPubKey.Hex = hex.EncodeToString(pkScript)
 
 	// Sanity check to make sure it passes again.
-	go wallet.FindRedemption([]dex.Bytes{coinID}, findRedemptionResultCh)
+	findRedemptionResultCh, err = wallet.FindRedemption(coinID)
+	if err != nil {
+		t.Errorf("unexpected FindRedemption error: %v", err)
+	}
 	select {
 	case frr := <-findRedemptionResultCh:
 		if frr.Err != nil {

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -97,8 +97,6 @@ type tRPCClient struct {
 	txOutErr      error
 	rawRes        map[string]json.RawMessage
 	rawErr        map[string]error
-	lastMethod    string
-	lastParams    []json.RawMessage
 	signFunc      func([]json.RawMessage) (json.RawMessage, error)
 	signMsgFunc   func([]json.RawMessage) (json.RawMessage, error)
 	blockchainMtx sync.RWMutex
@@ -211,8 +209,6 @@ func (c *tRPCClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjson.
 }
 
 func (c *tRPCClient) RawRequest(method string, params []json.RawMessage) (json.RawMessage, error) {
-	c.lastMethod = method
-	c.lastParams = params
 	switch method {
 	case methodSignTx:
 		if c.rawErr[method] == nil {
@@ -329,7 +325,6 @@ func tNewWallet() (*ExchangeWallet, *tRPCClient, func()) {
 	}
 	wallet := newWallet(cfg, &dexbtc.Config{}, client)
 	go wallet.run(walletCtx)
-	go wallet.processFindRedemptionRequests(walletCtx)
 
 	return wallet, client, shutdown
 }

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -234,14 +234,13 @@ func (c *tRPCClient) RawRequest(method string, params []json.RawMessage) (json.R
 		}
 		// block may get modified concurrently, lock mtx before reading fields.
 		c.blockchainMtx.RLock()
-		blkVerbose := &verboseBlockTxs{
+		defer c.blockchainMtx.RUnlock()
+		return json.Marshal(&verboseBlockTxs{
 			Hash:     block.Hash,
 			Height:   uint64(block.Height),
 			NextHash: block.NextHash,
 			Tx:       block.RawTx,
-		}
-		c.blockchainMtx.RUnlock()
-		return json.Marshal(blkVerbose)
+		})
 	case methodGetBlockHeader:
 		var blkHash string
 		_ = json.Unmarshal(params[0], &blkHash)
@@ -251,14 +250,13 @@ func (c *tRPCClient) RawRequest(method string, params []json.RawMessage) (json.R
 		}
 		// block may get modified concurrently, lock mtx before reading fields.
 		c.blockchainMtx.RLock()
-		blkHeader := &blockHeader{
+		defer c.blockchainMtx.RUnlock()
+		return json.Marshal(&blockHeader{
 			Hash:          block.Hash,
 			Height:        block.Height,
 			Confirmations: block.Confirmations,
 			Time:          block.Time,
-		}
-		c.blockchainMtx.RUnlock()
-		return json.Marshal(blkHeader)
+		})
 	case methodLockUnspent:
 		coins := make([]*RPCOutpoint, 0)
 		_ = json.Unmarshal(params[1], &coins)

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -304,8 +304,10 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 
 	// Find the redemption
 	swapCoin := receipts[0].Coin()
-	findRedemptionResultCh := make(chan asset.FindRedemptionResult)
-	go rig.gamma().FindRedemption([]dex.Bytes{swapCoin.ID()}, findRedemptionResultCh)
+	findRedemptionResultCh, err := rig.gamma().FindRedemption(swapCoin.ID())
+	if err != nil {
+		t.Errorf("unexpected find unconfirmed redemption error: %v", err)
+	}
 	select {
 	case frr := <-findRedemptionResultCh:
 		if frr.Err != nil {
@@ -326,7 +328,10 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	}
 	// Check that there is 1 confirmation on the swap
 	checkConfs(1)
-	go rig.gamma().FindRedemption([]dex.Bytes{swapCoin.ID()}, findRedemptionResultCh)
+	findRedemptionResultCh, err = rig.gamma().FindRedemption(swapCoin.ID())
+	if err != nil {
+		t.Errorf("unexpected find confirmed redemption error: %v", err)
+	}
 	select {
 	case frr := <-findRedemptionResultCh:
 		if frr.Err != nil {

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -304,7 +304,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 
 	// Find the redemption
 	swapCoin := receipts[0].Coin()
-	findRedemptionResultCh, err := rig.gamma().FindRedemption(swapCoin.ID())
+	findRedemptionResultCh, err := rig.gamma().FindRedemption(swapCoin.ID(), swapCoin.Redeem())
 	if err != nil {
 		t.Errorf("unexpected find unconfirmed redemption error: %v", err)
 	}
@@ -328,7 +328,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	}
 	// Check that there is 1 confirmation on the swap
 	checkConfs(1)
-	findRedemptionResultCh, err = rig.gamma().FindRedemption(swapCoin.ID())
+	findRedemptionResultCh, err = rig.gamma().FindRedemption(swapCoin.ID(), swapCoin.Redeem())
 	if err != nil {
 		t.Errorf("unexpected find confirmed redemption error: %v", err)
 	}

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -304,7 +304,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 
 	// Find the redemption
 	swapCoin := receipts[0].Coin()
-	findRedemptionResultCh, err := rig.gamma().FindRedemption(swapCoin.ID(), swapCoin.Redeem())
+	findRedemptionResultCh, err := rig.gamma().FindRedemption(swapCoin.ID())
 	if err != nil {
 		t.Errorf("unexpected find unconfirmed redemption error: %v", err)
 	}
@@ -328,7 +328,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	}
 	// Check that there is 1 confirmation on the swap
 	checkConfs(1)
-	findRedemptionResultCh, err = rig.gamma().FindRedemption(swapCoin.ID(), swapCoin.Redeem())
+	findRedemptionResultCh, err = rig.gamma().FindRedemption(swapCoin.ID())
 	if err != nil {
 		t.Errorf("unexpected find confirmed redemption error: %v", err)
 	}

--- a/client/asset/btc/wallettypes.go
+++ b/client/asset/btc/wallettypes.go
@@ -64,7 +64,7 @@ type GetTransactionResult struct {
 	Time           uint64             `json:"time"`
 	TimeReceived   uint64             `json:"timereceived"`
 	BipReplaceable string             `json:"bip125-replaceable"`
-	Hex            dex.Bytes          `json:"dex"`
+	Hex            dex.Bytes          `json:"hex"`
 	Details        []*WalletTxDetails `json:"details"`
 }
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -358,9 +358,19 @@ type block struct {
 	hash   *chainhash.Hash
 }
 
+// findRedemptionReq represents a request to find a contract's redemption,
+// which is added to the findRedemptionQueue with the contract outpoint as
+// key.
 type findRedemptionReq struct {
 	contractHash []byte
-	resultChan   chan *asset.FindRedemptionResult
+	resultChan   chan *findRedemptionResult
+}
+
+// findRedemptionResult models the result of a find redemption attempt.
+type findRedemptionResult struct {
+	RedemptionCoinID dex.Bytes
+	Secret           dex.Bytes
+	Err              error
 }
 
 // Check that ExchangeWallet satisfies the Wallet interface.
@@ -1256,78 +1266,125 @@ func (dcr *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time,
 	return time.Now().UTC().After(contractExpiry), contractExpiry, nil
 }
 
-// FindRedemption starts a goroutine to attempt finding the inputs that spends
-// the specified coin, and return the secret key for the contract when it does.
-// The goroutine scans every input of every block starting at the block in which
-// the contract was mined up till the current best block.
-// Redemption search is also triggered when a tip change is detected, to handle
+// FindRedemption watches for the input that spends the specified contract
+// coin, and returns the spending input and the contract's secret key when it
+// finds a spender.
+// If the coin is unmined, an initial search goroutine is started to scan all
+// mempool tx inputs in an attempt to find the input that spends the contract
+// coin. If the contract is mined, the initial search goroutine scans every
+// input of every block starting at the block in which the contract was mined
+// up till the current best block.
+// More search goroutines are started for every detected tip change, to handle
 // cases where the contract is redeemed in a transaction mined after the current
 // best block.
-// The returned channel is used to notify the caller when the secret key is found
-// or if an error occurs during the search.
-func (dcr *ExchangeWallet) FindRedemption(coinID dex.Bytes) (chan *asset.FindRedemptionResult, error) {
+// When any of the search goroutines finds an input that spends this contract,
+// the input and the contract's secret key are communicated to this method via
+// a redemption result channel created specifically for this contract. This
+// method waits on that channel before returning a response to the caller.
+//
+// TODO: Improve redemption search in mined blocks by scanning block filters
+// rather than every input of every tx in a block.
+func (dcr *ExchangeWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
+	txHash, vout, err := decodeCoinID(coinID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot decode contract coin id: %v", err)
+	}
+
+	contractOutpoint := newOutPoint(txHash, vout)
+	resultChan, contractBlock, err := dcr.queueFindRedemptionRequest(contractOutpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Run initial search for redemption. If the contract's spender is
+	// not found in this initial search attempt, the contract's find
+	// redemption request remains in the findRedemptionQueue to ensure
+	// continued search for redemption on new or re-orged blocks.
+	if contractBlock == nil {
+		// Mempool contracts may only be spent by another mempool tx.
+		go dcr.findRedemptionInMempool(contractOutpoint)
+	} else {
+		// Begin searching for redemption for this contract from the block
+		// in which this contract was mined up till the current best block.
+		dcr.tipMtx.RLock()
+		bestBlock := dcr.currentTip
+		dcr.tipMtx.RUnlock()
+		go dcr.findRedemptionsInBlockRange(contractBlock, bestBlock, []outPoint{contractOutpoint})
+	}
+
+	var result *findRedemptionResult
+	select {
+	case result = <-resultChan:
+	case <-ctx.Done():
+	}
+	// If this contract is still in the findRedemptionQueue, close the result
+	// channel and remove from the queue to prevent further redemption search
+	// attempts for this contract.
+	dcr.findRedemptionMtx.Lock()
+	if req, exists := dcr.findRedemptionQueue[contractOutpoint]; exists {
+		close(req.resultChan)
+		delete(dcr.findRedemptionQueue, contractOutpoint)
+	}
+	dcr.findRedemptionMtx.Unlock()
+	// result would be nil if ctx is canceled or the result channel
+	// is closed without data, which would happen if the redemption
+	// search is aborted when this ExchangeWallet is shut down.
+	if result != nil {
+		return result.RedemptionCoinID, result.Secret, result.Err
+	}
+	return nil, nil, fmt.Errorf("aborted search for redemption of contract %s", contractOutpoint.String())
+}
+
+// queueFindRedemptionRequest extracts the contract hash and tx block (if mined)
+// of the provided contract outpoint, creates a find redemption request and adds
+// it to the findRedemptionQueue. Returns error if a find redemption request is
+// already queued for the contract or if the contract hash or block info cannot
+// be extracted.
+func (dcr *ExchangeWallet) queueFindRedemptionRequest(contractOutpoint outPoint) (chan *findRedemptionResult, *block, error) {
 	dcr.findRedemptionMtx.Lock()
 	defer dcr.findRedemptionMtx.Unlock()
 
-	txHash, vout, err := decodeCoinID(coinID)
-	if err != nil {
-		return nil, fmt.Errorf("cannot decode contract coin id: %v", err)
+	if _, inQueue := dcr.findRedemptionQueue[contractOutpoint]; inQueue {
+		return nil, nil, fmt.Errorf("duplicate find redemption request for %s", contractOutpoint.String())
 	}
-	contractOutpoint := newOutPoint(txHash, vout)
-	if existingReq, inQueue := dcr.findRedemptionQueue[contractOutpoint]; inQueue {
-		dcr.log.Warnf("duplicate FindRedemption request for %s", contractOutpoint.String())
-		return existingReq.resultChan, nil
-	}
-	tx, err := dcr.node.GetTransaction(txHash)
+	txHash, vout := contractOutpoint.txHash, contractOutpoint.vout
+	tx, err := dcr.node.GetTransaction(&txHash)
 	if err != nil {
 		if isTxNotFoundErr(err) {
-			return nil, asset.CoinNotFoundError
+			return nil, nil, asset.CoinNotFoundError
 		}
-		return nil, fmt.Errorf("error finding transaction %s in wallet: %v", txHash, err)
+		return nil, nil, fmt.Errorf("error finding transaction %s in wallet: %v", txHash, err)
 	}
 	msgTx, err := msgTxFromHex(tx.Hex)
 	if err != nil {
-		return nil, fmt.Errorf("invalid contract tx hex %s: %v", tx.Hex, err)
+		return nil, nil, fmt.Errorf("invalid contract tx hex %s: %v", tx.Hex, err)
 	}
 	if int(vout) > len(msgTx.TxOut)-1 {
-		return nil, fmt.Errorf("vout index %d out of range for transaction %s", vout, txHash)
+		return nil, nil, fmt.Errorf("vout index %d out of range for transaction %s", vout, txHash)
 	}
 	contractHash := dexdcr.ExtractScriptHash(msgTx.TxOut[vout].PkScript)
 	if contractHash == nil {
-		return nil, fmt.Errorf("coin %s not a valid contract", contractOutpoint.String())
+		return nil, nil, fmt.Errorf("coin %s not a valid contract", contractOutpoint.String())
 	}
 	var contractBlock *block
 	if tx.BlockHash != "" {
 		blockHash, err := chainhash.NewHashFromStr(tx.BlockHash)
 		if err != nil {
-			return nil, fmt.Errorf("invalid blockhash %s for contract %s: %v", tx.BlockHash, contractOutpoint.String(), err)
+			return nil, nil, fmt.Errorf("invalid blockhash %s for contract %s: %v", tx.BlockHash, contractOutpoint.String(), err)
 		}
 		txBlock, err := dcr.node.GetBlockVerbose(blockHash, false)
 		if err != nil {
-			return nil, fmt.Errorf("error fetching verbose block %s for contract %s: %v", tx.BlockHash, contractOutpoint.String(), err)
+			return nil, nil, fmt.Errorf("error fetching verbose block %s for contract %s: %v", tx.BlockHash, contractOutpoint.String(), err)
 		}
 		contractBlock = &block{height: txBlock.Height, hash: blockHash}
 	}
 
-	resultChan := make(chan *asset.FindRedemptionResult, 1)
+	resultChan := make(chan *findRedemptionResult, 1)
 	dcr.findRedemptionQueue[contractOutpoint] = &findRedemptionReq{
 		contractHash: contractHash,
 		resultChan:   resultChan,
 	}
-
-	// Mempool contracts may only be spent by another mempool tx.
-	if contractBlock == nil {
-		go dcr.findRedemptionInMempool(contractOutpoint)
-		return resultChan, nil
-	}
-
-	// Begin searching for redemption for this contract from the block
-	// in which this contract was mined up till the current best block.
-	dcr.tipMtx.RLock()
-	bestBlock := dcr.currentTip
-	dcr.tipMtx.RUnlock()
-	go dcr.findRedemptionsInBlockRange(contractBlock, bestBlock, []outPoint{contractOutpoint})
-	return resultChan, nil
+	return resultChan, contractBlock, nil
 }
 
 // findRedemptionInMempool attempts to find spending info for the specified
@@ -1457,15 +1514,13 @@ func (dcr *ExchangeWallet) findRedemptionsInTx(scanPoint string, tx *chainjson.T
 			if err != nil {
 				dcr.log.Debugf("error parsing contract secret for %s from tx input %s:%d in %s: %v",
 					contractOutpoint.String(), tx.Txid, inputIndex, scanPoint, err)
-				req.resultChan <- &asset.FindRedemptionResult{
-					ContractCoinID: toCoinID(&contractOutpoint.txHash, contractOutpoint.vout),
-					Err:            err,
+				req.resultChan <- &findRedemptionResult{
+					Err: err,
 				}
 			} else {
 				dcr.log.Debugf("redemption for contract %s found in tx input %s:%d in %s",
 					contractOutpoint.String(), tx.Txid, inputIndex, scanPoint)
-				req.resultChan <- &asset.FindRedemptionResult{
-					ContractCoinID:   toCoinID(&contractOutpoint.txHash, contractOutpoint.vout),
+				req.resultChan <- &findRedemptionResult{
 					RedemptionCoinID: toCoinID(redeemTxHash, uint32(inputIndex)),
 					Secret:           secret,
 				}
@@ -1492,9 +1547,8 @@ func (dcr *ExchangeWallet) fatalFindRedemptionsError(err error, contractOutpoint
 		if !exists {
 			continue
 		}
-		req.resultChan <- &asset.FindRedemptionResult{
-			ContractCoinID: toCoinID(&contractOutpoint.txHash, contractOutpoint.vout),
-			Err:            err,
+		req.resultChan <- &findRedemptionResult{
+			Err: err,
 		}
 		close(req.resultChan)
 		delete(dcr.findRedemptionQueue, contractOutpoint)
@@ -2116,13 +2170,14 @@ func (dcr *ExchangeWallet) checkForNewBlocks() {
 	sameTip := dcr.currentTip.hash.IsEqual(newTip.hash)
 	dcr.tipMtx.RUnlock()
 	if sameTip {
-		return // tip has not changed
+		return
 	}
 
 	dcr.tipMtx.Lock()
+	defer dcr.tipMtx.Unlock()
+
 	prevTip := dcr.currentTip
 	dcr.currentTip = newTip
-	dcr.tipMtx.Unlock()
 	dcr.log.Debugf("tip change: %d (%s) => %d (%s)", prevTip.height, prevTip.hash, newTip.height, newTip.hash)
 	dcr.tipChange(nil)
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1287,7 +1287,7 @@ func (dcr *ExchangeWallet) FindRedemption(coinID dex.Bytes) (chan *asset.FindRed
 	}
 	msgTx, err := msgTxFromHex(tx.Hex)
 	if err != nil {
-		return nil, fmt.Errorf("invalid contract tx hex: %v", err)
+		return nil, fmt.Errorf("invalid contract tx hex %s: %v", tx.Hex, err)
 	}
 	if int(vout) > len(msgTx.TxOut)-1 {
 		return nil, fmt.Errorf("vout index %d out of range for transaction %s", vout, txHash)

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1325,7 +1325,7 @@ func TestFindRedemption(t *testing.T) {
 
 	_, bestBlockHeight, err := node.GetBestBlock()
 	if err != nil {
-		t.Fatalf("unexpected best block error: %v", err)
+		t.Fatalf("unexpected GetBestBlock error: %v", err)
 	}
 	contractHeight := bestBlockHeight + 1
 	contractTxid := "e1b7c47df70d7d8f4c9c26f8ba9a59102c10885bd49024d32fdef08242f0c26c"

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -116,62 +117,66 @@ func tNewWallet() (*ExchangeWallet, *tRPCClient, func()) {
 	wallet := unconnectedWallet(walletCfg, &Config{}, tLogger)
 	wallet.node = client
 	go wallet.monitorBlocks(walletCtx)
+	go wallet.processFindRedemptionRequests(walletCtx)
 
 	return wallet, client, shutdown
 }
 
 type tRPCClient struct {
-	sendRawHash     *chainhash.Hash
-	sendRawErr      error
-	sentRawTx       *wire.MsgTx
-	txOutRes        map[outPoint]*chainjson.GetTxOutResult
-	txOutErr        error
-	bestBlockHash   *chainhash.Hash
-	bestBlockHeight int64
-	bestBlockErr    error
-	mempool         []*chainhash.Hash
-	mempoolErr      error
-	rawTx           *chainjson.TxRawResult
-	rawTxErr        error
-	unspent         []walletjson.ListUnspentResult
-	unspentErr      error
-	balanceResult   *walletjson.GetBalanceResult
-	balanceErr      error
-	lockUnspentErr  error
-	changeAddr      dcrutil.Address
-	changeAddrErr   error
-	newAddr         dcrutil.Address
-	newAddrErr      error
-	signFunc        func(tx *wire.MsgTx) (*wire.MsgTx, bool, error)
-	privWIF         *dcrutil.WIF
-	privWIFErr      error
-	walletTx        *walletjson.GetTransactionResult
-	walletTxErr     error
-	lockErr         error
-	passErr         error
-	disconnected    bool
-	rawRes          map[string]json.RawMessage
-	rawErr          map[string]error
-	verboseBlocks   map[string]*chainjson.GetBlockVerboseResult
-	mainchain       map[int64]*chainhash.Hash
-	bestHash        chainhash.Hash
-	lluCoins        []walletjson.ListUnspentResult // Returned from ListLockUnspent
-	lockedCoins     []*wire.OutPoint               // Last submitted to LockUnspent
-	listLockedErr   error
+	sendRawHash    *chainhash.Hash
+	sendRawErr     error
+	sentRawTx      *wire.MsgTx
+	txOutRes       map[outPoint]*chainjson.GetTxOutResult
+	txOutErr       error
+	bestBlockErr   error
+	mempool        []*chainhash.Hash
+	mempoolErr     error
+	rawTx          *chainjson.TxRawResult
+	rawTxErr       error
+	unspent        []walletjson.ListUnspentResult
+	unspentErr     error
+	balanceResult  *walletjson.GetBalanceResult
+	balanceErr     error
+	lockUnspentErr error
+	changeAddr     dcrutil.Address
+	changeAddrErr  error
+	newAddr        dcrutil.Address
+	newAddrErr     error
+	signFunc       func(tx *wire.MsgTx) (*wire.MsgTx, bool, error)
+	privWIF        *dcrutil.WIF
+	privWIFErr     error
+	walletTx       *walletjson.GetTransactionResult
+	walletTxErr    error
+	lockErr        error
+	passErr        error
+	disconnected   bool
+	rawRes         map[string]json.RawMessage
+	rawErr         map[string]error
+	blockchainMtx  sync.RWMutex
+	verboseBlocks  map[string]*chainjson.GetBlockVerboseResult
+	mainchain      map[int64]*chainhash.Hash
+	lluCoins       []walletjson.ListUnspentResult // Returned from ListLockUnspent
+	lockedCoins    []*wire.OutPoint               // Last submitted to LockUnspent
+	listLockedErr  error
 }
 
 func defaultSignFunc(tx *wire.MsgTx) (*wire.MsgTx, bool, error) { return tx, true, nil }
 
 func newTRPCClient() *tRPCClient {
+	// setup genesis block, required by bestblock polling goroutine
+	var newHash chainhash.Hash
+	copy(newHash[:], randBytes(32))
 	return &tRPCClient{
-		txOutRes:      make(map[outPoint]*chainjson.GetTxOutResult),
-		verboseBlocks: make(map[string]*chainjson.GetBlockVerboseResult),
-		mainchain:     make(map[int64]*chainhash.Hash),
-		bestHash:      chainhash.Hash{},
-		bestBlockHash: &chainhash.Hash{},
-		signFunc:      defaultSignFunc,
-		rawRes:        make(map[string]json.RawMessage),
-		rawErr:        make(map[string]error),
+		txOutRes: make(map[outPoint]*chainjson.GetTxOutResult),
+		verboseBlocks: map[string]*chainjson.GetBlockVerboseResult{
+			newHash.String(): {},
+		},
+		mainchain: map[int64]*chainhash.Hash{
+			0: &newHash,
+		},
+		signFunc: defaultSignFunc,
+		rawRes:   make(map[string]json.RawMessage),
+		rawErr:   make(map[string]error),
 	}
 }
 
@@ -195,10 +200,25 @@ func (c *tRPCClient) GetTxOut(txHash *chainhash.Hash, vout uint32, mempool bool)
 }
 
 func (c *tRPCClient) GetBestBlock() (*chainhash.Hash, int64, error) {
-	return c.bestBlockHash, c.bestBlockHeight, c.bestBlockErr
+	if c.bestBlockErr != nil {
+		return nil, -1, c.bestBlockErr
+	}
+	c.blockchainMtx.RLock()
+	defer c.blockchainMtx.RUnlock()
+	var bestHash *chainhash.Hash
+	var bestBlkHeight int64
+	for height, hash := range c.mainchain {
+		if height >= bestBlkHeight {
+			bestBlkHeight = height
+			bestHash = hash
+		}
+	}
+	return bestHash, bestBlkHeight, nil
 }
 
 func (c *tRPCClient) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
+	c.blockchainMtx.RLock()
+	defer c.blockchainMtx.RUnlock()
 	h, found := c.mainchain[blockHeight]
 	if !found {
 		return nil, fmt.Errorf("no test block at height %d", blockHeight)
@@ -207,6 +227,8 @@ func (c *tRPCClient) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
 }
 
 func (c *tRPCClient) GetBlockVerbose(blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error) {
+	c.blockchainMtx.RLock()
+	defer c.blockchainMtx.RUnlock()
 	blk, found := c.verboseBlocks[blockHash.String()]
 	if !found {
 		return nil, fmt.Errorf("no test block found for %s", blockHash)
@@ -223,12 +245,24 @@ func (c *tRPCClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*chainjso
 }
 
 func (c *tRPCClient) addRawTx(blockHeight int64, tx *chainjson.TxRawResult) (*chainhash.Hash, *chainjson.GetBlockVerboseResult) {
+	c.blockchainMtx.Lock()
+	defer c.blockchainMtx.Unlock()
 	blkHash, found := c.mainchain[blockHeight]
 	if !found {
 		var newHash chainhash.Hash
 		copy(newHash[:], randBytes(32))
-		c.verboseBlocks[newHash.String()] = &chainjson.GetBlockVerboseResult{}
 		blkHash = &newHash
+		prevBlockHash := c.mainchain[blockHeight-1]
+		// Modifying c.verboseBlocks[prevBlockHash.String()].NextHash causes
+		// race errors.
+		prevBlock := *c.verboseBlocks[prevBlockHash.String()]
+		prevBlock.NextHash = blkHash.String()
+		c.verboseBlocks[prevBlockHash.String()] = &prevBlock
+		c.verboseBlocks[newHash.String()] = &chainjson.GetBlockVerboseResult{
+			Height:       blockHeight,
+			Hash:         blkHash.String(),
+			PreviousHash: prevBlockHash.String(),
+		}
 		c.mainchain[blockHeight] = blkHash
 	}
 	block := c.verboseBlocks[blkHash.String()]
@@ -1289,7 +1323,11 @@ func TestFindRedemption(t *testing.T) {
 	wallet, node, shutdown := tNewWallet()
 	defer shutdown()
 
-	contractHeight := int64(5000)
+	_, bestBlockHeight, err := node.GetBestBlock()
+	if err != nil {
+		t.Fatalf("unexpected best block error: %v", err)
+	}
+	contractHeight := bestBlockHeight + 1
 	contractTxid := "e1b7c47df70d7d8f4c9c26f8ba9a59102c10885bd49024d32fdef08242f0c26c"
 	contractTxHash, _ := chainhash.NewHashFromStr(contractTxid)
 	otherTxid := "7a7b3b5c3638516bc8e7f19b4a3dec00f052a599fed5036c2b89829de2367bb6"
@@ -1318,81 +1356,86 @@ func TestFindRedemption(t *testing.T) {
 	// Prepare the "blockchain"
 	inputs := []chainjson.Vin{makeRPCVin(otherTxid, 0, otherSpendScript)}
 	// Add the contract transaction. Put the pay-to-contract script at index 1.
-	blockHash, contractBlock := node.addRawTx(contractHeight, makeRawTx(contractTxid, []dex.Bytes{otherScript, pkScript}, inputs))
-	getTxRes := &walletjson.GetTransactionResult{
-		BlockHash:     blockHash.String(),
-		Confirmations: 1,
-		Details: []walletjson.GetTransactionDetailsResult{
-			{
-				Address:  contractAddr.String(),
-				Category: txCatSend,
-				Vout:     contractVout,
-			},
-		},
+	contractTx := makeRawTx(contractTxid, []dex.Bytes{otherScript, pkScript}, inputs)
+	blockHash, contractBlock := node.addRawTx(contractHeight, contractTx)
+	contractTx.BlockHash = blockHash.String()
+	contractTx.BlockHeight = contractBlock.Height
+	node.rawTx = contractTx
+
+	// Begin find redemption.
+	findRedemptionResultCh := make(chan asset.FindRedemptionResult)
+	go wallet.FindRedemption([]dex.Bytes{coinID}, findRedemptionResultCh)
+
+	// Expect to NOT find redemption yet.
+	select {
+	case frr := <-findRedemptionResultCh:
+		t.Errorf("unexpected FindRedemption result %v", frr)
+	case <-time.After(2 * time.Second):
 	}
-	node.walletTx = getTxRes
+
 	// Add an intermediate block for good measure.
-	h, middleBlock := node.addRawTx(contractHeight+1, makeRawTx(otherTxid, []dex.Bytes{otherScript}, inputs))
-	contractBlock.NextHash = h.String()
+	node.addRawTx(contractHeight+1, makeRawTx(otherTxid, []dex.Bytes{otherScript}, inputs))
+
+	// Expect to NOT find redemption still.
+	select {
+	case frr := <-findRedemptionResultCh:
+		t.Fatalf("unexpected FindRedemption result %v", frr)
+	case <-time.After(2 * time.Second):
+	}
+
 	// Now add the redemption.
 	inputs = append(inputs, makeRPCVin(contractTxid, contractVout, redemptionScript))
 	rawRedeem := makeRawTx(otherTxid, []dex.Bytes{otherScript}, inputs)
-	h, redeemBlock := node.addRawTx(contractHeight+2, rawRedeem)
-	middleBlock.NextHash = h.String()
-	// Add the redeem transaction to the verbose block.
+	_, redeemBlock := node.addRawTx(contractHeight+2, rawRedeem)
 
-	checkSecret, err := wallet.FindRedemption(tCtx, coinID)
-	if err != nil {
-		t.Fatalf("error finding redemption: %v", err)
-	}
-	if !bytes.Equal(checkSecret, secret) {
-		t.Fatalf("wrong secret. expected %x, got %x", secret, checkSecret)
-	}
-
-	// gettransaction error
-	node.walletTxErr = tErr
-	_, err = wallet.FindRedemption(tCtx, coinID)
-	if err == nil {
-		t.Fatalf("no error for gettransaction rpc error")
-	}
-	node.walletTxErr = nil
-
-	// missing redemption
-	redeemBlock.RawTx[0].Vin[1].Txid = otherTxid
-	k, err := wallet.FindRedemption(tCtx, coinID)
-	if err == nil {
-		t.Fatalf("no error for missing redemption rpc error: %s", k.String())
-	}
-	redeemBlock.RawTx[0].Vin[1].Txid = contractTxid
-
-	// Canceled context
-	deadCtx, shutdown := context.WithCancel(context.Background())
-	shutdown()
-	_, err = wallet.FindRedemption(deadCtx, coinID)
-	if err == nil {
-		t.Fatalf("no error for canceled context")
+	// Expect to find redemption now.
+	select {
+	case frr := <-findRedemptionResultCh:
+		if frr.Err != nil {
+			t.Fatalf("error finding redemption: %v", frr.Err)
+		}
+		if !bytes.Equal(frr.Secret, secret) {
+			t.Fatalf("wrong secret. expected %x, got %x", secret, frr.Secret)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("redemption not found after 2 seconds")
 	}
 
-	// Wrong redemption
+	// Expect FindRedemption to error because of bad input sig.
 	redeemBlock.RawTx[0].Vin[1].ScriptSig.Hex = hex.EncodeToString(randBytes(100))
-	_, err = wallet.FindRedemption(tCtx, coinID)
-	if err == nil {
-		t.Fatalf("no error for wrong redemption")
+	go wallet.FindRedemption([]dex.Bytes{coinID}, findRedemptionResultCh)
+	select {
+	case frr := <-findRedemptionResultCh:
+		if frr.Err == nil {
+			t.Fatalf("no error for wrong redemption")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no error for wrong redemption after 2 seconds")
 	}
 	redeemBlock.RawTx[0].Vin[1].ScriptSig.Hex = hex.EncodeToString(redemptionScript)
 
-	// Wrong script type for output
+	// Expect FindRedemption to error because of wrong script type for contract output
 	contractBlock.RawTx[0].Vout[1].ScriptPubKey.Hex = hex.EncodeToString(otherScript)
-	_, err = wallet.FindRedemption(tCtx, coinID)
-	if err == nil {
-		t.Fatalf("no error for wrong script type")
+	go wallet.FindRedemption([]dex.Bytes{coinID}, findRedemptionResultCh)
+	select {
+	case frr := <-findRedemptionResultCh:
+		if frr.Err == nil {
+			t.Fatalf("no error for wrong script type")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("no error for wrong script type after 2 seconds")
 	}
 	contractBlock.RawTx[0].Vout[1].ScriptPubKey.Hex = hex.EncodeToString(pkScript)
 
 	// Sanity check to make sure it passes again.
-	_, err = wallet.FindRedemption(tCtx, coinID)
-	if err != nil {
-		t.Fatalf("error after clearing errors: %v", err)
+	go wallet.FindRedemption([]dex.Bytes{coinID}, findRedemptionResultCh)
+	select {
+	case frr := <-findRedemptionResultCh:
+		if frr.Err != nil {
+			t.Fatalf("error after clearing errors: %v", frr.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("redemption not found after 2 seconds")
 	}
 }
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -117,7 +117,6 @@ func tNewWallet() (*ExchangeWallet, *tRPCClient, func()) {
 	wallet := unconnectedWallet(walletCfg, &Config{}, tLogger)
 	wallet.node = client
 	go wallet.monitorBlocks(walletCtx)
-	go wallet.processFindRedemptionRequests(walletCtx)
 
 	return wallet, client, shutdown
 }
@@ -1435,7 +1434,7 @@ func TestFindRedemption(t *testing.T) {
 			t.Fatalf("error after clearing errors: %v", frr.Err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatalf("redemption not found after 2 seconds")
+		t.Fatalf("redemption (re-check) not found after 2 seconds")
 	}
 }
 

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -332,7 +332,7 @@ func runTest(t *testing.T, splitTx bool) {
 	// Find the redemption
 	swapCoin := receipts[0].Coin()
 	waitNetwork()
-	findRedemptionResultCh, err := rig.beta().FindRedemption(swapCoin.ID(), swapCoin.Redeem())
+	findRedemptionResultCh, err := rig.beta().FindRedemption(swapCoin.ID())
 	if err != nil {
 		t.Errorf("unexpected find unconfirmed redemption error: %v", err)
 	}
@@ -356,7 +356,7 @@ func runTest(t *testing.T, splitTx bool) {
 	if !blockReported {
 		t.Fatalf("no block reported")
 	}
-	findRedemptionResultCh, err = rig.beta().FindRedemption(swapCoin.ID(), swapCoin.Redeem())
+	findRedemptionResultCh, err = rig.beta().FindRedemption(swapCoin.ID())
 	if err != nil {
 		t.Errorf("unexpected find confirmed redemption error: %v", err)
 	}

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -332,7 +332,7 @@ func runTest(t *testing.T, splitTx bool) {
 	// Find the redemption
 	swapCoin := receipts[0].Coin()
 	waitNetwork()
-	findRedemptionResultCh, err := rig.beta().FindRedemption(swapCoin.ID())
+	findRedemptionResultCh, err := rig.beta().FindRedemption(swapCoin.ID(), swapCoin.Redeem())
 	if err != nil {
 		t.Errorf("unexpected find unconfirmed redemption error: %v", err)
 	}
@@ -356,7 +356,7 @@ func runTest(t *testing.T, splitTx bool) {
 	if !blockReported {
 		t.Fatalf("no block reported")
 	}
-	findRedemptionResultCh, err = rig.beta().FindRedemption(swapCoin.ID())
+	findRedemptionResultCh, err = rig.beta().FindRedemption(swapCoin.ID(), swapCoin.Redeem())
 	if err != nil {
 		t.Errorf("unexpected find confirmed redemption error: %v", err)
 	}

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -332,8 +332,10 @@ func runTest(t *testing.T, splitTx bool) {
 	// Find the redemption
 	swapCoin := receipts[0].Coin()
 	waitNetwork()
-	findRedemptionResultCh := make(chan asset.FindRedemptionResult)
-	go rig.beta().FindRedemption([]dex.Bytes{swapCoin.ID()}, findRedemptionResultCh)
+	findRedemptionResultCh, err := rig.beta().FindRedemption(swapCoin.ID())
+	if err != nil {
+		t.Errorf("unexpected find unconfirmed redemption error: %v", err)
+	}
 	select {
 	case frr := <-findRedemptionResultCh:
 		if frr.Err != nil {
@@ -354,7 +356,10 @@ func runTest(t *testing.T, splitTx bool) {
 	if !blockReported {
 		t.Fatalf("no block reported")
 	}
-	go rig.beta().FindRedemption([]dex.Bytes{swapCoin.ID()}, findRedemptionResultCh)
+	findRedemptionResultCh, err = rig.beta().FindRedemption(swapCoin.ID())
+	if err != nil {
+		t.Errorf("unexpected find confirmed redemption error: %v", err)
+	}
 	select {
 	case frr := <-findRedemptionResultCh:
 		if frr.Err != nil {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -103,11 +103,11 @@ type Wallet interface {
 	// lock. For example, in Bitcoin the median of the last 11 blocks must be
 	// past the expiry time, not the current time.
 	LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
-	// FindRedemption attempts to find the inputs that spend the specified coins,
-	// and return the secret key for each contract when it does.
+	// FindRedemption starts a goroutine to attempt finding the inputs that spends
+	// the specified coin, and return the secret key for the contract when it does.
 	// For typical blockchains, every input of every block starting at the
 	// contract block will need to be scanned until a spending input is found.
-	// The result channel is used to notify callers when a secret key is found
+	// The returned channel is used to notify callers when a secret key is found
 	// or if an error occurs during the search.
 	//
 	// NOTE: FindRedemption is necessary to deal with the case of a maker
@@ -118,7 +118,7 @@ type Wallet interface {
 	// the swap is broadcast. Realistically, though, the taker should start
 	// looking for the maker's redemption beginning at swapconf confirmations
 	// regardless of whether the server sends the 'redemption' message or not.
-	FindRedemption(coinIDs []dex.Bytes, resultChan chan FindRedemptionResult)
+	FindRedemption(coinID dex.Bytes) (chan *FindRedemptionResult, error)
 	// Refund refunds a contract. This can only be used after the time lock has
 	// expired AND if the contract has not been redeemed/refunded.
 	// NOTE: The contract cannot be retrieved from the unspent coin info as the

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -103,8 +103,8 @@ type Wallet interface {
 	// lock. For example, in Bitcoin the median of the last 11 blocks must be
 	// past the expiry time, not the current time.
 	LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
-	// FindRedemption starts a goroutine to attempt finding the inputs that spends
-	// the specified coin, and return the secret key for the contract when it does.
+	// FindRedemption watches for the input that spends the specified coin, and
+	// returns the secret key for the contract when it does.
 	// For typical blockchains, every input of every block starting at the
 	// contract block will need to be scanned until a spending input is found.
 	// The returned channel is used to notify callers when a secret key is found
@@ -239,8 +239,8 @@ type Redemption struct {
 }
 
 // FindRedemptionResult models the result of a FindRedemption attempt, returning
-// either the secret extracted from the redemption (when found) or any unexpected
-// error that occurs during the FindRedemption attempt.
+// either the secret extracted from the redemption (when found) or any error that
+// occurs during the FindRedemption attempt.
 type FindRedemptionResult struct {
 	ContractCoinID   dex.Bytes
 	RedemptionCoinID dex.Bytes

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -103,11 +103,11 @@ type Wallet interface {
 	// lock. For example, in Bitcoin the median of the last 11 blocks must be
 	// past the expiry time, not the current time.
 	LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
-	// FindRedemption attempts to find the input that spends the specified coins,
-	// and return the secret key when it does.
+	// FindRedemption attempts to find the inputs that spend the specified coins,
+	// and return the secret key for each contract when it does.
 	// For typical blockchains, every input of every block starting at the
-	// contract block will need to be scanned until the spending input is found.
-	// The result channel is used to notify callers when the secret key is found
+	// contract block will need to be scanned until a spending input is found.
+	// The result channel is used to notify callers when a secret key is found
 	// or if an error occurs during the search.
 	//
 	// NOTE: FindRedemption is necessary to deal with the case of a maker

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -118,7 +118,7 @@ type Wallet interface {
 	// the swap is broadcast. Realistically, though, the taker should start
 	// looking for the maker's redemption beginning at swapconf confirmations
 	// regardless of whether the server sends the 'redemption' message or not.
-	FindRedemption(coinID, contract dex.Bytes) (chan *FindRedemptionResult, error)
+	FindRedemption(coinID dex.Bytes) (chan *FindRedemptionResult, error)
 	// Refund refunds a contract. This can only be used after the time lock has
 	// expired AND if the contract has not been redeemed/refunded.
 	// NOTE: The contract cannot be retrieved from the unspent coin info as the

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -4,6 +4,7 @@
 package asset
 
 import (
+	"context"
 	"time"
 
 	"decred.org/dcrdex/dex"
@@ -103,22 +104,20 @@ type Wallet interface {
 	// lock. For example, in Bitcoin the median of the last 11 blocks must be
 	// past the expiry time, not the current time.
 	LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
-	// FindRedemption watches for the input that spends the specified coin, and
-	// returns the secret key for the contract when it does.
-	// For typical blockchains, every input of every block starting at the
-	// contract block will need to be scanned until a spending input is found.
-	// The returned channel is used to notify callers when a secret key is found
-	// or if an error occurs during the search.
+	// FindRedemption watches for the input that spends the specified contract
+	// coin, and returns the spending input and the contract's secret key when
+	// it finds a spender.
+	// For typical blockchains, every input of every block tx (starting at the
+	// contract block) will need to be scanned until a spending input is found.
 	//
-	// NOTE: FindRedemption is necessary to deal with the case of a maker
-	// redeeming but not forwarding their redemption information. The DEX does not
-	// monitor for this case. While it will result in the counter-party being
-	// penalized, the input still needs to be found so the swap can be completed.
-	// This could potentially be an expensive operation if performed long after
-	// the swap is broadcast. Realistically, though, the taker should start
-	// looking for the maker's redemption beginning at swapconf confirmations
-	// regardless of whether the server sends the 'redemption' message or not.
-	FindRedemption(coinID dex.Bytes) (chan *FindRedemptionResult, error)
+	// FindRedemption is necessary to deal with the case of a maker redeeming but
+	// not forwarding their redemption information. The DEX does not monitor for
+	// this case. While it will result in the counter-party being penalized, the
+	// input still needs to be found so the swap can be completed.
+	//
+	// NOTE: This could potentially be a long and expensive operation if performed
+	// long after the swap is broadcast; might be better executed from a goroutine.
+	FindRedemption(ctx context.Context, coinID dex.Bytes) (redemptionCoin, secret dex.Bytes, err error)
 	// Refund refunds a contract. This can only be used after the time lock has
 	// expired AND if the contract has not been redeemed/refunded.
 	// NOTE: The contract cannot be retrieved from the unspent coin info as the
@@ -236,16 +235,6 @@ type Redemption struct {
 	Spends AuditInfo
 	// Secret is the secret key needed to satisfy the swap contract.
 	Secret dex.Bytes
-}
-
-// FindRedemptionResult models the result of a FindRedemption attempt, returning
-// either the secret extracted from the redemption (when found) or any error that
-// occurs during the FindRedemption attempt.
-type FindRedemptionResult struct {
-	ContractCoinID   dex.Bytes
-	RedemptionCoinID dex.Bytes
-	Secret           dex.Bytes
-	Err              error
 }
 
 // Order is order details needed for FundOrder.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -118,7 +118,7 @@ type Wallet interface {
 	// the swap is broadcast. Realistically, though, the taker should start
 	// looking for the maker's redemption beginning at swapconf confirmations
 	// regardless of whether the server sends the 'redemption' message or not.
-	FindRedemption(coinID dex.Bytes) (chan *FindRedemptionResult, error)
+	FindRedemption(coinID, contract dex.Bytes) (chan *FindRedemptionResult, error)
 	// Refund refunds a contract. This can only be used after the time lock has
 	// expired AND if the contract has not been redeemed/refunded.
 	// NOTE: The contract cannot be retrieved from the unspent coin info as the

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -496,10 +496,6 @@ func (dc *dexConnection) runMatches(tradeMatches map[order.OrderID]*serverMatche
 // Reported matches with missing trackers are already checked by parseMatches,
 // but we also must check for incomplete matches that the server is not
 // reporting.
-//
-// DRAFT NOTE: Right now, the matches are just checked and notifications sent,
-// but it may be a good place to trigger a FindRedemption if the conditions
-// warrant.
 func (dc *dexConnection) compareServerMatches(matches map[order.OrderID]*serverMatches) {
 	for _, match := range matches {
 		// readConnectMatches sends notifications for any problems encountered.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -577,7 +577,7 @@ func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
 	return true, time.Now().Add(-time.Minute), nil
 }
 
-func (w *TXCWallet) FindRedemption(coinID dex.Bytes) (chan *asset.FindRedemptionResult, error) {
+func (w *TXCWallet) FindRedemption(coinID, contract dex.Bytes) (chan *asset.FindRedemptionResult, error) {
 	return nil, fmt.Errorf("not mocked")
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -577,7 +577,7 @@ func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
 	return true, time.Now().Add(-time.Minute), nil
 }
 
-func (w *TXCWallet) FindRedemption(coinID, contract dex.Bytes) (chan *asset.FindRedemptionResult, error) {
+func (w *TXCWallet) FindRedemption(coinID dex.Bytes) (chan *asset.FindRedemptionResult, error) {
 	return nil, fmt.Errorf("not mocked")
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -577,8 +577,7 @@ func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
 	return true, time.Now().Add(-time.Minute), nil
 }
 
-func (w *TXCWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (dex.Bytes, error) {
-	return nil, nil
+func (w *TXCWallet) FindRedemption(coinIDs []dex.Bytes, resultChan chan asset.FindRedemptionResult) {
 }
 
 func (w *TXCWallet) Refund(dex.Bytes, dex.Bytes) (dex.Bytes, error) {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -577,7 +577,8 @@ func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
 	return true, time.Now().Add(-time.Minute), nil
 }
 
-func (w *TXCWallet) FindRedemption(coinIDs []dex.Bytes, resultChan chan asset.FindRedemptionResult) {
+func (w *TXCWallet) FindRedemption(coinID dex.Bytes) (chan *asset.FindRedemptionResult, error) {
+	return nil, fmt.Errorf("not mocked")
 }
 
 func (w *TXCWallet) Refund(dex.Bytes, dex.Bytes) (dex.Bytes, error) {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -577,8 +577,8 @@ func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
 	return true, time.Now().Add(-time.Minute), nil
 }
 
-func (w *TXCWallet) FindRedemption(coinID dex.Bytes) (chan *asset.FindRedemptionResult, error) {
-	return nil, fmt.Errorf("not mocked")
+func (w *TXCWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
+	return nil, nil, fmt.Errorf("not mocked")
 }
 
 func (w *TXCWallet) Refund(dex.Bytes, dex.Bytes) (dex.Bytes, error) {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1345,6 +1345,13 @@ func (t *trackedTrade) waitForRedemptions() {
 			continue
 		}
 
+		if match.Match.Status != order.TakerSwapCast {
+			t.mtx.Unlock()
+			log.Errorf("received find redemption result at wrong step, order %s, match %s, status %s",
+				t.ID(), match.id, match.Match.Status)
+			continue
+		}
+
 		_, _, proof, _ := match.parts()
 		// TODO: Is this validation necessary?
 		if !t.wallets.toWallet.ValidateSecret(frr.Secret, proof.SecretHash) {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -112,21 +112,22 @@ func newTrackedTrade(dbOrder *db.MetaOrder, preImg order.Preimage, dc *dexConnec
 
 	ord := dbOrder.Order
 	t := &trackedTrade{
-		Order:         ord,
-		metaData:      dbOrder.MetaData,
-		dc:            dc,
-		db:            db,
-		latencyQ:      latencyQ,
-		wallets:       wallets,
-		preImg:        preImg,
-		mktID:         marketName(ord.Base(), ord.Quote()),
-		coins:         mapifyCoins(coins),
-		lockTimeTaker: lockTimeTaker,
-		lockTimeMaker: lockTimeMaker,
-		matches:       make(map[order.MatchID]*matchTracker),
-		notify:        notify,
-		epochLen:      epochLen,
-		fromAssetID:   fromID,
+		Order:              ord,
+		metaData:           dbOrder.MetaData,
+		dc:                 dc,
+		db:                 db,
+		latencyQ:           latencyQ,
+		wallets:            wallets,
+		preImg:             preImg,
+		mktID:              marketName(ord.Base(), ord.Quote()),
+		coins:              mapifyCoins(coins),
+		lockTimeTaker:      lockTimeTaker,
+		lockTimeMaker:      lockTimeMaker,
+		matches:            make(map[order.MatchID]*matchTracker),
+		awaitingRedemption: make(map[string]order.MatchID),
+		notify:             notify,
+		epochLen:           epochLen,
+		fromAssetID:        fromID,
 	}
 	return t
 }

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1,5 +1,3 @@
-// +build harness
-
 package core
 
 // The btc, dcr and dcrdex harnesses should be running before executing this
@@ -181,10 +179,11 @@ func TestTrading(t *testing.T) {
 
 	// run subtests
 	tests := map[string]func(*testing.T){
-		"success":         testTradeSuccess,
-		"no maker swap":   testNoMakerSwap,
-		"no taker swap":   testNoTakerSwap,
-		"no maker redeem": testNoMakerRedeem,
+		"success":                  testTradeSuccess,
+		"no maker swap":            testNoMakerSwap,
+		"no taker swap":            testNoTakerSwap,
+		"no maker redeem":          testNoMakerRedeem,
+		"maker ghost after redeem": testMakerRedeemRunAway,
 	}
 
 	for test, testFn := range tests {
@@ -238,6 +237,77 @@ func testNoMakerRedeem(t *testing.T) {
 	}
 }
 
+func testMakerRedeemRunAway(t *testing.T) {
+	var qty, rate uint64 = 5 * 1e8, 2.5 * 1e4 // 5DCR at 0.00025 BTC/DCR
+	client1.isSeller, client2.isSeller = true, false
+
+	c1OrderID, c2OrderID, err := placeTestOrders(qty, rate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Monitor trades and stop at order.TakerSwapCast
+	monitorTrades, ctx := errgroup.WithContext(context.Background())
+	monitorTrades.Go(func() error {
+		return monitorOrderMatchingAndTradeNeg(ctx, client1, c1OrderID, order.TakerSwapCast)
+	})
+	monitorTrades.Go(func() error {
+		return monitorOrderMatchingAndTradeNeg(ctx, client2, c2OrderID, order.TakerSwapCast)
+	})
+	if err = monitorTrades.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Resume trades but disable Maker's ability to notify the server
+	// after redeming Taker's swap.
+	resumeTrade := func(ctx context.Context, client *tClient, orderID string) error {
+		dc := client.dc()
+		tracker, err := client.findOrder(orderID)
+		if err != nil {
+			return err
+		}
+		finalStatus := order.MatchComplete
+		dc.tradeMtx.Lock()
+		for _, match := range tracker.matches {
+			if match.Match.Side == order.Maker {
+				client.dc().connMaster.Disconnect()
+				finalStatus = order.MakerRedeemed // maker shouldn't get past this state
+			}
+			match.failErr = nil // remove next action blocker on match
+		}
+		dc.tradeMtx.Unlock()
+		// force next action since trade.tick() will not be called for disconnected dcs.
+		tracker.tick()
+		return monitorTrackedTrade(ctx, client, tracker, finalStatus)
+	}
+	resumeTrades, ctx := errgroup.WithContext(context.Background())
+	resumeTrades.Go(func() error {
+		return resumeTrade(ctx, client1, c1OrderID)
+	})
+	resumeTrades.Go(func() error {
+		return resumeTrade(ctx, client2, c2OrderID)
+	})
+	if err = resumeTrades.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Allow some time for balance changes to be properly reported.
+	// There is usually a split-second window where a locked output
+	// has been spent but the spending tx is still in mempool. This
+	// will cause the txout to be included in the wallets locked
+	// balance, causing a higher than actual balance report.
+	time.Sleep(1 * time.Second)
+
+	for _, client := range clients {
+		if err = client.assertBalanceChanges(); err != nil {
+			t.Fatalf("client %d balance check error: %v", client.id, err)
+		}
+	}
+
+	tLog.Infof("Trades completed. Maker went dark at %s, Taker continued till %s.",
+		order.MakerRedeemed, order.MatchComplete)
+}
+
 // simpleTradeTest uses client1 and client2 to place similar orders but on
 // either sides that get matched and monitors the resulting trades up till the
 // specified final status.
@@ -248,32 +318,9 @@ func simpleTradeTest(qty, rate uint64, finalStatus order.MatchStatus) error {
 		return fmt.Errorf("both client 1 and 2 cannot be sellers")
 	}
 
-	// Unlock wallets to place orders.
-	// Also update starting balances for wallets to enable accurate
-	// balance change assertion after the test completes.
-	for _, client := range clients {
-		if err := client.unlockWallets(); err != nil {
-			return fmt.Errorf("client %d unlock wallet error: %v", client.id, err)
-		}
-		if client.atFault {
-			client.log("reconnecting DEX for at fault client")
-			err := client.connectDEX(context.Background())
-			if err != nil {
-				return fmt.Errorf("client %d re-connect DEX error: %v", client.id, err)
-			}
-		}
-		if err := client.updateBalances(); err != nil {
-			return fmt.Errorf("client %d balance update error: %v", client.id, err)
-		}
-	}
-
-	c1OrderID, err := client1.placeOrder(qty, rate)
+	c1OrderID, c2OrderID, err := placeTestOrders(qty, rate)
 	if err != nil {
-		return fmt.Errorf("client1 place %s order error: %v", sellString(client1.isSeller), err)
-	}
-	c2OrderID, err := client2.placeOrder(qty, rate)
-	if err != nil {
-		return fmt.Errorf("client2 place %s order error: %v", sellString(client2.isSeller), err)
+		return err
 	}
 
 	if finalStatus == order.NewlyMatched {
@@ -287,10 +334,10 @@ func simpleTradeTest(qty, rate uint64, finalStatus order.MatchStatus) error {
 
 	monitorTrades, ctx := errgroup.WithContext(context.Background())
 	monitorTrades.Go(func() error {
-		return monitorTradeForTestOrder(ctx, client1, c1OrderID, finalStatus)
+		return monitorOrderMatchingAndTradeNeg(ctx, client1, c1OrderID, finalStatus)
 	})
 	monitorTrades.Go(func() error {
-		return monitorTradeForTestOrder(ctx, client2, c2OrderID, finalStatus)
+		return monitorOrderMatchingAndTradeNeg(ctx, client2, c2OrderID, finalStatus)
 	})
 	if err = monitorTrades.Wait(); err != nil {
 		return err
@@ -328,21 +375,52 @@ func simpleTradeTest(qty, rate uint64, finalStatus order.MatchStatus) error {
 	return nil
 }
 
-func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID string, finalStatus order.MatchStatus) error {
-	errs := newErrorSet("[client %d] ", client.id)
-	dc := client.dc()
-
-	oid, err := order.IDFromHex(orderID)
-	if err != nil {
-		return errs.add("error parsing order id %s -> %v", orderID, err)
+func placeTestOrders(qty, rate uint64) (string, string, error) {
+	// Unlock wallets to place orders.
+	// Also update starting balances for wallets to enable accurate
+	// balance change assertion after the test completes.
+	for _, client := range clients {
+		if err := client.unlockWallets(); err != nil {
+			return "", "", fmt.Errorf("client %d unlock wallet error: %v", client.id, err)
+		}
+		if client.atFault {
+			client.log("reconnecting DEX for at fault client")
+			err := client.connectDEX(context.Background())
+			if err != nil {
+				return "", "", fmt.Errorf("client %d re-connect DEX error: %v", client.id, err)
+			}
+		}
+		if err := client.updateBalances(); err != nil {
+			return "", "", fmt.Errorf("client %d balance update error: %v", client.id, err)
+		}
+		// Reset the expected balance changes for this client, to be updated
+		// later in the monitorTrackedTrade function as swaps and redeems are
+		// executed.
+		client.expectBalanceDiffs = map[uint32]int64{dcr.BipID: 0, btc.BipID: 0}
 	}
 
-	oidShort := token(oid.Bytes())
-	tracker, _, _ := dc.findOrder(oid)
+	c1OrderID, err := client1.placeOrder(qty, rate)
+	if err != nil {
+		return "", "", fmt.Errorf("client1 place %s order error: %v", sellString(client1.isSeller), err)
+	}
+	c2OrderID, err := client2.placeOrder(qty, rate)
+	if err != nil {
+		return "", "", fmt.Errorf("client2 place %s order error: %v", sellString(client2.isSeller), err)
+	}
+	return c1OrderID, c2OrderID, nil
+}
+
+func monitorOrderMatchingAndTradeNeg(ctx context.Context, client *tClient, orderID string, finalStatus order.MatchStatus) error {
+	errs := newErrorSet("[client %d] ", client.id)
+
+	tracker, err := client.findOrder(orderID)
+	if err != nil {
+		return errs.addErr(err)
+	}
 
 	// Wait a max of 2 epochLen durations for this order to get matched.
 	maxMatchDuration := 2 * time.Duration(tracker.epochLen) * time.Millisecond
-	client.log("Waiting %s for matches on order %s", maxMatchDuration, oidShort)
+	client.log("Waiting %s for matches on order %s", maxMatchDuration, tracker.token())
 	matched := client.findNotification(ctx, maxMatchDuration, func(n Notification) bool {
 		orderNote, isOrderNote := n.(*OrderNote)
 		return isOrderNote && n.Subject() == "Matches made" && orderNote.Order.ID == orderID
@@ -351,30 +429,24 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 		return nil
 	}
 	if !matched {
-		return errs.add("order %s not matched after %s", oidShort, maxMatchDuration)
+		return errs.add("order %s not matched after %s", tracker.token(), maxMatchDuration)
 	}
 
 	tracker.mtx.RLock()
-	client.log("%d match(es) received for order %s", len(tracker.matches), oidShort)
+	client.log("%d match(es) received for order %s", len(tracker.matches), tracker.token())
 	for _, match := range tracker.matches {
 		client.log("%s on match %s, amount %.8f %s", match.Match.Side.String(),
 			token(match.id.Bytes()), fmtAmt(match.Match.Quantity), unbip(tracker.Base()))
 	}
-
-	// Save last processed status for each match to accurately identify status
-	// changes and prevent re-processing the same status for a match.
-	// Set the initial processed match statuses to order.NewlyMatched to ignore
-	// matches whose status have not progressed beyond the matched stage until
-	// their status changes.
-	lastProcessedStatus := make(map[order.MatchID]order.MatchStatus, len(tracker.matches))
-	for _, match := range tracker.matches {
-		lastProcessedStatus[match.id] = order.NewlyMatched
-	}
 	tracker.mtx.RUnlock()
 
-	// the expected balance changes for this client will be updated
-	// as swaps and redeems are executed
-	client.expectBalanceDiffs = map[uint32]int64{dcr.BipID: 0, btc.BipID: 0}
+	return monitorTrackedTrade(ctx, client, tracker, finalStatus)
+}
+
+func monitorTrackedTrade(ctx context.Context, client *tClient, tracker *trackedTrade, finalStatus order.MatchStatus) error {
+	makerAtFault := finalStatus == order.NewlyMatched || finalStatus == order.TakerSwapCast
+	takerAtFault := finalStatus == order.MakerSwapCast || finalStatus == order.MakerRedeemed
+
 	recordBalanceChanges := func(assetID uint32, isSwap bool, qty, rate uint64) {
 		amt := qty
 		if client.isSeller != isSwap {
@@ -390,8 +462,12 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 		}
 	}
 
-	makerAtFault := finalStatus == order.NewlyMatched || finalStatus == order.TakerSwapCast
-	takerAtFault := finalStatus == order.MakerSwapCast || finalStatus == order.MakerRedeemed
+	// Save last processed status for each match to accurately identify status
+	// changes and prevent re-processing the same status for a match.
+	dc := client.dc()
+	dc.tradeMtx.RLock()
+	lastProcessedStatus := make(map[order.MatchID]order.MatchStatus, len(tracker.matches))
+	dc.tradeMtx.RUnlock()
 
 	// run a repeated check for match status changes to mine blocks as necessary.
 	maxTradeDuration := 2 * time.Minute
@@ -411,7 +487,11 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 				}
 				completedTrades++
 			}
-			if status == lastProcessedStatus[match.id] || status > finalStatus {
+			if status > finalStatus {
+				continue
+			}
+			lastStatus, wasProcessed := lastProcessedStatus[match.id]
+			if wasProcessed && status == lastStatus {
 				continue
 			}
 			lastProcessedStatus[match.id] = status
@@ -471,14 +551,14 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 	for _, match := range tracker.matches {
 		if match.Match.Status < finalStatus {
 			incompleteTrades++
-			client.log("incomplete trade: order %s, match %s, status %s, side %s", oidShort,
+			client.log("incomplete trade: order %s, match %s, status %s, side %s", tracker.token(),
 				token(match.ID()), match.Match.Status, match.Match.Side)
 		}
 	}
 	tracker.mtx.RUnlock()
 	if incompleteTrades > 0 {
 		return fmt.Errorf("client %d reported %d incomplete trades for order %s after %s",
-			client.id, incompleteTrades, oidShort, maxTradeDuration)
+			client.id, incompleteTrades, tracker.token(), maxTradeDuration)
 	}
 
 	return nil
@@ -496,13 +576,13 @@ func checkAndWaitForRefunds(ctx context.Context, client *tClient, orderID string
 		return sentSwap && noRedeems
 	}
 
-	oid, err := order.IDFromHex(orderID)
+	tracker, err := client.findOrder(orderID)
 	if err != nil {
-		return fmt.Errorf("client %d: error parsing order id %s -> %v", client.id, orderID, err)
+		return err
 	}
 
-	tracker, _, _ := client.dc().findOrder(oid)
-	tracker.mtx.RLock()
+	dc := client.dc()
+	dc.tradeMtx.RLock()
 	for _, match := range tracker.matches {
 		if !hasRefundableSwap(match) {
 			continue
@@ -524,7 +604,7 @@ func checkAndWaitForRefunds(ctx context.Context, client *tClient, orderID string
 			furthestLockTime = swapLockTime
 		}
 	}
-	tracker.mtx.RUnlock()
+	dc.tradeMtx.RUnlock()
 
 	if ctx.Err() != nil { // context canceled
 		return nil
@@ -870,6 +950,15 @@ func (client *tClient) dc() *dexConnection {
 	client.core.connMtx.RLock()
 	defer client.core.connMtx.RUnlock()
 	return client.core.conns[dexHost]
+}
+
+func (client *tClient) findOrder(orderID string) (*trackedTrade, error) {
+	oid, err := order.IDFromHex(orderID)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing order id %s -> %v", orderID, err)
+	}
+	tracker, _, _ := client.dc().findOrder(oid)
+	return tracker, nil
 }
 
 func (client *tClient) dcrw() *tWallet {

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -932,9 +932,9 @@ func (client *tClient) updateBalances() error {
 		if err != nil {
 			return err
 		}
-		client.balances[assetID] = balances.Available + balances.Locked
-		client.log("%s available %f, locked %f", unbip(assetID),
-			fmtAmt(balances.Available), fmtAmt(balances.Locked))
+		client.balances[assetID] = balances.Available + balances.Immature + balances.Locked
+		client.log("%s available %f, immature %f, locked %f", unbip(assetID),
+			fmtAmt(balances.Available), fmtAmt(balances.Immature), fmtAmt(balances.Locked))
 	}
 	return nil
 }
@@ -959,8 +959,8 @@ func (client *tClient) assertBalanceChanges() error {
 		}
 		balanceDiff := int64(client.balances[assetID] - prevBalances[assetID])
 		if balanceDiff < minExpectedDiff || balanceDiff > maxExpectedDiff {
-			return fmt.Errorf("%s balance change not in expected range %.8f - %.8f, got %.8f",
-				unbip(assetID), fmtAmt(minExpectedDiff), fmtAmt(maxExpectedDiff), fmtAmt(balanceDiff))
+			return fmt.Errorf("[client %d] %s balance change not in expected range %.8f - %.8f, got %.8f",
+				client.id, unbip(assetID), fmtAmt(minExpectedDiff), fmtAmt(maxExpectedDiff), fmtAmt(balanceDiff))
 		}
 		client.log("%s balance change %.8f is in expected range of %.8f - %.8f",
 			unbip(assetID), fmtAmt(balanceDiff), fmtAmt(minExpectedDiff), fmtAmt(maxExpectedDiff))

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -180,17 +180,20 @@ func TestTrading(t *testing.T) {
 	tLog.Info("=== SETUP COMPLETED")
 
 	// run subtests
-	tests := map[string]func(*testing.T){
-		"success":                  testTradeSuccess,
-		"no maker swap":            testNoMakerSwap,
-		"no taker swap":            testNoTakerSwap,
-		"no maker redeem":          testNoMakerRedeem,
-		"maker ghost after redeem": testMakerGhostingAfterTakerRedeem,
+	tests := []struct {
+		name string
+		fn   func(*testing.T)
+	}{
+		{"success", testTradeSuccess},
+		{"no maker swap", testNoMakerSwap},
+		{"no taker swap", testNoTakerSwap},
+		{"no maker redeem", testNoMakerRedeem},
+		{"maker ghost after redeem", testMakerGhostingAfterTakerRedeem},
 	}
 
-	for test, testFn := range tests {
+	for _, test := range tests {
 		fmt.Println() // empty line to separate test logs for better readability
-		if !t.Run(test, testFn) {
+		if !t.Run(test.name, test.fn) {
 			break
 		}
 	}
@@ -274,7 +277,7 @@ func testMakerGhostingAfterTakerRedeem(t *testing.T) {
 	}
 
 	// Resume trades but disable Maker's ability to notify the server
-	// after redeming Taker's swap.
+	// after redeeming Taker's swap.
 	resumeTrade := func(ctx context.Context, client *tClient, orderID string) error {
 		tracker, err := client.findOrder(orderID)
 		if err != nil {

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -289,6 +289,8 @@ func testMakerGhostingAfterTakerRedeem(t *testing.T) {
 				client.log("%s: disconnecting DEX before redeeming Taker's swap", side)
 				client.dc().connMaster.Disconnect()
 				finalStatus = order.MakerRedeemed // maker shouldn't get past this state
+			} else {
+				client.log("%s: resuming trade negotiations to audit Maker's redeem", side)
 			}
 			match.failErr = nil // remove next action blocker on match
 		}
@@ -567,6 +569,9 @@ func monitorTrackedTrade(ctx context.Context, client *tClient, tracker *trackedT
 		if match.Match.Status < finalStatus {
 			incompleteTrades++
 			client.log("incomplete trade: order %s, match %s, status %s, side %s", tracker.token(),
+				token(match.ID()), match.Match.Status, match.Match.Side)
+		} else {
+			client.log("trade for order %s, match %s monitored successfully till %s, side %s", tracker.token(),
 				token(match.ID()), match.Match.Status, match.Match.Side)
 		}
 	}


### PR DESCRIPTION
Auto-trigger find redemption for Taker swaps that have gotten at least `swapConf` confirmations, has neither been redeemed by Maker or refunded to Taker.

The `FindRedemption` method is refactored to allow batching multiple contract coin ids in one call.

The dcr and btc implementations of the `FindRedemption` method are also modified to push find redemption requests to a goroutine dedicated to scanning blocks for potential contract spends.

There are 2 motivations for using a separate goroutine for processing find redemption requests:
- enable loading block txs once for multiple contracts (including multiple batches of contracts from different calls to `FindRedemption`)
- keeping the redemption search alive when a contract's spender is not found up till the current best block. When that occurs, the goroutine persistently waits for new blocks and searches them for spending information until all contracts's redemption info are found. Previously, FindRedemption returns "redemption not found" error for such contracts and if the client recalls FindRedemption at a later time, the FindRedemption method rescans blocks that were scanned in the previous attempt.