### PR TITLE
client/asset, core: lock and return coins when needed

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -683,25 +683,10 @@ func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	}
 
 	// Sign, add change, and send the transaction.
-	msgTx, change, err := btc.sendWithReturn(baseTx, changeAddr, totalIn, totalOut, swaps.FeeRate)
+	msgTx, change, changeScript, err := btc.sendWithReturn(baseTx, changeAddr, totalIn, totalOut, swaps.FeeRate)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	if swaps.LockChange {
-		err = btc.wallet.LockUnspent(false, []*output{change})
-		if err != nil {
-			// The swap transaction is already broadcasted, so don't fail now.
-			btc.log.Errorf("failed to lock change output: %v", err)
-		}
-	}
-
-	// Delete the UTXOs from the cache.
-	btc.fundingMtx.Lock()
-	for _, spent := range spents {
-		delete(btc.fundingCoins, outpointID(spent.txHash.String(), spent.vout))
-	}
-	btc.fundingMtx.Unlock()
 
 	// Prepare the receipts.
 	receipts := make([]asset.Receipt, 0, swapCount)
@@ -718,6 +703,40 @@ func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	if change != nil {
 		changeCoin = change
 	}
+
+	btc.fundingMtx.Lock()
+	defer btc.fundingMtx.Unlock()
+	if swaps.LockChange {
+		// Lock the change output
+		err = btc.wallet.LockUnspent(false, []*output{change})
+		if err != nil {
+			// The swap transaction is already broadcasted, so don't fail now.
+			btc.log.Errorf("failed to lock change output: %v", err)
+		}
+
+		// Log it as a fundingCoin, since it is expected that this will be
+		// chained into further matches.
+		nfo, err := dexbtc.InputInfo(changeScript, nil, btc.chainParams)
+		if err != nil {
+			// This would be virtually impossible at this point.
+			return nil, nil, fmt.Errorf("error getting spend info: %v", err)
+		}
+
+		btc.fundingCoins[outpointID(change.txHash.String(), change.vout)] = &compositeUTXO{
+			txHash:       &change.txHash,
+			vout:         change.vout,
+			address:      changeAddr.String(),
+			redeemScript: nil,
+			amount:       change.value,
+			input:        nfo,
+		}
+	}
+
+	// Delete the UTXOs from the cache.
+	for _, spent := range spents {
+		delete(btc.fundingCoins, outpointID(spent.txHash.String(), spent.vout))
+	}
+
 	return receipts, changeCoin, nil
 }
 
@@ -812,15 +831,15 @@ func (btc *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes,
 // specified unspent coin. A slice of pubkeys required to spend the coin and a
 // signature for each pubkey are returned.
 func (btc *ExchangeWallet) SignMessage(coin asset.Coin, msg dex.Bytes) (pubkeys, sigs []dex.Bytes, err error) {
-	output, err := btc.convertCoin(coin)
+	op, err := btc.convertCoin(coin)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error converting coin: %v", err)
 	}
 	btc.fundingMtx.RLock()
-	utxo := btc.fundingCoins[output.String()]
+	utxo := btc.fundingCoins[outpointID(op.txHash.String(), op.vout)]
 	btc.fundingMtx.RUnlock()
 	if utxo == nil {
-		return nil, nil, fmt.Errorf("no utxo found for %s", output)
+		return nil, nil, fmt.Errorf("no utxo found for %s", op)
 	}
 	privKey, err := btc.wallet.PrivKeyForAddress(utxo.address)
 	if err != nil {
@@ -1234,26 +1253,26 @@ func (btc *ExchangeWallet) convertCoin(coin asset.Coin) (*output, error) {
 // sendWithReturn sends the unsigned transaction with an added output (unless
 // dust) for the change.
 func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Address,
-	totalIn, totalOut, feeRate uint64) (*wire.MsgTx, *output, error) {
+	totalIn, totalOut, feeRate uint64) (*wire.MsgTx, *output, []byte, error) {
 	// Sign the transaction to get an initial size estimate and calculate whether
 	// a change output would be dust.
 	sigCycles := 1
 	msgTx, err := btc.wallet.SignTx(baseTx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("signing error: %v", err)
+		return nil, nil, nil, fmt.Errorf("signing error: %v", err)
 	}
 	size := msgTx.SerializeSize()
 	minFee := feeRate * uint64(size)
 	remaining := totalIn - totalOut
 	if minFee > remaining {
-		return nil, nil, fmt.Errorf("not enough funds to cover minimum fee rate. %d < %d",
+		return nil, nil, nil, fmt.Errorf("not enough funds to cover minimum fee rate. %d < %d",
 			totalIn, minFee+totalOut)
 	}
 
 	// Create a change output.
 	changeScript, err := txscript.PayToAddrScript(addr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating change script: %v", err)
+		return nil, nil, nil, fmt.Errorf("error creating change script: %v", err)
 	}
 	changeIdx := len(baseTx.TxOut)
 	changeOutput := wire.NewTxOut(int64(remaining-minFee), changeScript)
@@ -1279,7 +1298,7 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 			sigCycles++
 			msgTx, err = btc.wallet.SignTx(baseTx)
 			if err != nil {
-				return nil, nil, fmt.Errorf("signing error: %v", err)
+				return nil, nil, nil, fmt.Errorf("signing error: %v", err)
 			}
 			size = msgTx.SerializeSize() // recompute the size with new tx signature
 			reqFee := feeRate * uint64(size)
@@ -1288,7 +1307,7 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 				// I'd hate to be wrong.
 				btc.log.Errorf("reached the impossible place. in = %d, out = %d, reqFee = %d, lastFee = %d",
 					totalIn, totalOut, reqFee, fee)
-				return nil, nil, fmt.Errorf("change error")
+				return nil, nil, nil, fmt.Errorf("change error")
 			}
 			if fee == reqFee || (fee > reqFee && tried[reqFee]) {
 				// If a lower fee appears available, but it's already been attempted and
@@ -1307,7 +1326,7 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 				// missed.
 				btc.log.Errorf("reached the impossible place. in = %d, out = %d, reqFee = %d, lastFee = %d",
 					totalIn, totalOut, reqFee, fee)
-				return nil, nil, fmt.Errorf("dust error")
+				return nil, nil, nil, fmt.Errorf("dust error")
 			}
 			continue
 		}
@@ -1324,10 +1343,10 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 
 	txHash, err := btc.node.SendRawTransaction(msgTx, false)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if *txHash != checkHash {
-		return nil, nil, fmt.Errorf("transaction sent, but received unexpected transaction ID back from RPC server. "+
+		return nil, nil, nil, fmt.Errorf("transaction sent, but received unexpected transaction ID back from RPC server. "+
 			"expected %s, got %s", checkHash, *txHash)
 	}
 
@@ -1336,7 +1355,7 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 		btc.addChange(txHash.String(), uint32(changeIdx))
 		change = newOutput(btc.node, txHash, uint32(changeIdx), uint64(changeOutput.Value), nil)
 	}
-	return msgTx, change, nil
+	return msgTx, change, changeScript, nil
 }
 
 // createSig creates and returns the serialized raw signature and compressed

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1354,6 +1354,8 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 	if changeAdded {
 		btc.addChange(txHash.String(), uint32(changeIdx))
 		change = newOutput(btc.node, txHash, uint32(changeIdx), uint64(changeOutput.Value), nil)
+	} else {
+		changeScript = nil
 	}
 	return msgTx, change, changeScript, nil
 }

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -696,11 +696,7 @@ func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 		}
 	}
 
-	// Unlock the utxos and delete them from the cache.
-	err = btc.wallet.LockUnspent(true, spents)
-	if err != nil {
-		btc.log.Errorf("failed to unlock spent outputs: %v", err)
-	}
+	// Delete the UTXOs from the cache.
 	btc.fundingMtx.Lock()
 	for _, spent := range spents {
 		delete(btc.fundingCoins, outpointID(spent.txHash.String(), spent.vout))

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -521,6 +521,7 @@ func (btc *ExchangeWallet) ReturnCoins(unspents asset.Coins) error {
 		return fmt.Errorf("cannot return zero coins")
 	}
 	ops := make([]*output, 0, len(unspents))
+	btc.log.Debugf("returning coins %s", unspents)
 	btc.fundingMtx.Lock()
 	defer btc.fundingMtx.Unlock()
 	for _, unspent := range unspents {
@@ -708,6 +709,7 @@ func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	defer btc.fundingMtx.Unlock()
 	if swaps.LockChange {
 		// Lock the change output
+		btc.log.Debugf("locking change coin %s", change)
 		err = btc.wallet.LockUnspent(false, []*output{change})
 		if err != nil {
 			// The swap transaction is already broadcasted, so don't fail now.

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -511,6 +511,8 @@ out:
 	}
 	btc.fundingMtx.Unlock()
 
+	btc.log.Debugf("funding %d %s order with coins %v", value, btc.walletInfo.Units, coins)
+
 	return coins, nil
 }
 
@@ -598,6 +600,9 @@ func (btc *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	btc.log.Debugf("locking coins %v", coins)
+
 	return coins, nil
 }
 

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -75,6 +75,7 @@ type tRPCClient struct {
 	mpErr         error
 	mpVerboseTxs  map[string]*btcjson.TxRawResult
 	rawVerboseErr error
+	lockedCoins   []*RPCOutpoint
 }
 
 func newTRPCClient() *tRPCClient {
@@ -164,6 +165,10 @@ func (c *tRPCClient) RawRequest(method string, params []json.RawMessage) (json.R
 			Tx:     block.RawTx,
 		})
 		return b, nil
+	case methodLockUnspent:
+		coins := make([]*RPCOutpoint, 0)
+		_ = json.Unmarshal(params[1], &coins)
+		c.lockedCoins = coins
 	}
 	return c.rawRes[method], c.rawErr[method]
 }
@@ -764,9 +769,18 @@ func TestSwap(t *testing.T) {
 	}
 
 	// This time should succeed.
-	_, _, err := wallet.Swap(swaps)
+	_, changeCoin, err := wallet.Swap(swaps)
 	if err != nil {
 		t.Fatalf("swap error: %v", err)
+	}
+
+	// Make sure the change coin is locked.
+	if len(node.lockedCoins) != 1 {
+		t.Fatalf("did not lock change coin")
+	}
+	txHash, _, _ := decodeCoinID(changeCoin.ID())
+	if node.lockedCoins[0].TxID != txHash.String() {
+		t.Fatalf("wrong coin locked during swap")
 	}
 
 	// Not enough funds

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -168,7 +168,9 @@ func (c *tRPCClient) RawRequest(method string, params []json.RawMessage) (json.R
 	case methodLockUnspent:
 		coins := make([]*RPCOutpoint, 0)
 		_ = json.Unmarshal(params[1], &coins)
-		c.lockedCoins = coins
+		if string(params[0]) == "false" {
+			c.lockedCoins = coins
+		}
 	}
 	return c.rawRes[method], c.rawErr[method]
 }
@@ -726,8 +728,9 @@ func TestSwap(t *testing.T) {
 	}
 
 	swaps := &asset.Swaps{
-		Inputs:    coins,
-		Contracts: []*asset.Contract{contract},
+		Inputs:     coins,
+		Contracts:  []*asset.Contract{contract},
+		LockChange: true,
 	}
 
 	signTxRes := SignTxResult{

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -237,6 +237,7 @@ func tNewWallet() (*ExchangeWallet, *tRPCClient, func()) {
 		Symbol:      "btc",
 		Logger:      tLogger,
 		ChainParams: &chaincfg.MainNetParams,
+		WalletInfo:  walletInfo,
 	}
 	wallet := newWallet(cfg, client)
 	go wallet.run(walletCtx)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -583,6 +583,7 @@ func (dcr *ExchangeWallet) ReturnCoins(unspents asset.Coins) error {
 	}
 	ops := make([]*wire.OutPoint, 0, len(unspents))
 
+	dcr.log.Debugf("returning coins %s", unspents)
 	dcr.fundingMtx.Lock()
 	defer dcr.fundingMtx.Unlock()
 	for _, unspent := range unspents {
@@ -744,6 +745,7 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 
 	// Lock the change coin, if requested.
 	if swaps.LockChange {
+		dcr.log.Debugf("locking change coin %s", change)
 		err = dcr.lockFundingCoins([]*fundingCoin{{
 			op:   change,
 			addr: changeAddr.String(),

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -668,10 +668,7 @@ func (dcr *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 }
 
 // Swap sends the swaps in a single transaction. The Receipts returned can be
-// used to refund a failed transaction. The change output is locked with the
-// wallet in case it is still required to fund chained swaps for an order. The
-// caller should unlock the change coin via ReturnCoins if it is no longer
-// required to fund additional swaps for the parent order.
+// used to refund a failed transaction.
 func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, error) {
 	var totalOut uint64
 	// Start with an empty MsgTx.
@@ -745,8 +742,7 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	}
 	dcr.fundingMtx.Unlock()
 
-	// Lock the change coin, as it's expected that it will be used in another
-	// swap.
+	// Lock the change coin, if requested.
 	if swaps.LockChange {
 		err = dcr.lockFundingCoins([]*fundingCoin{{
 			op:   change,

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -449,6 +449,12 @@ func (dcr *ExchangeWallet) FundOrder(value uint64, nfo *dex.Asset) (asset.Coins,
 		return sum+toAtoms(unspent.rpc.Amount) >= reqFunds
 	}
 	coins, err := dcr.fund(0, enough)
+	if err != nil {
+		return nil, err
+	}
+
+	dcr.log.Debugf("funding %d atom order with coins %v", value, coins)
+
 	return coins, err
 }
 
@@ -665,6 +671,9 @@ func (dcr *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	dcr.log.Debugf("locking coins %v", coins)
+
 	return coins, nil
 }
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -668,7 +668,10 @@ func (dcr *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 }
 
 // Swap sends the swaps in a single transaction. The Receipts returned can be
-// used to refund a failed transaction.
+// used to refund a failed transaction. The change output is locked with the
+// wallet in case it is still required to fund chained swaps for an order. The
+// caller should unlock the change coin via ReturnCoins if it is no longer
+// required to fund additional swaps for the parent order.
 func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, error) {
 	var totalOut uint64
 	// Start with an empty MsgTx.
@@ -710,21 +713,41 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	if totalIn < totalOut {
 		return nil, nil, fmt.Errorf("unfunded contract. %d < %d", totalIn, totalOut)
 	}
+
+	// Ensure we have enough outputs before broadcasting.
+	swapCount := len(swaps.Contracts)
+	if len(baseTx.TxOut) < swapCount {
+		return nil, nil, fmt.Errorf("fewer outputs than swaps. %d < %d", len(baseTx.TxOut), swapCount)
+	}
+
 	// Grab a change address.
 	changeAddr, err := dcr.node.GetRawChangeAddress(dcr.acct, chainParams)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating change address: %v", err)
 	}
+
 	// Add change, sign, and send the transaction.
 	msgTx, change, err := dcr.sendWithReturn(baseTx, changeAddr, totalIn, totalOut, swaps.FeeRate, nil)
 	if err != nil {
 		return nil, nil, err
 	}
-	// Prepare the receipts.
-	swapCount := len(swaps.Contracts)
-	if len(baseTx.TxOut) < swapCount {
-		return nil, nil, fmt.Errorf("fewer outputs than swaps. %d < %d", len(baseTx.TxOut), swapCount)
+
+	// Delete the utxos from the cache.
+	dcr.fundingMtx.Lock()
+	for _, coin := range swaps.Inputs {
+		delete(dcr.fundingCoins, coin.String())
 	}
+	dcr.fundingMtx.Unlock()
+
+	// Lock the funding coin.
+	err = dcr.lockFundingCoins([]*fundingCoin{{
+		op:   change,
+		addr: changeAddr.String(),
+	}})
+	if err != nil {
+		dcr.log.Warnf("Failed to lock dcr change coin %s", change)
+	}
+
 	receipts := make([]asset.Receipt, 0, swapCount)
 	txHash := msgTx.TxHash()
 	for i, contract := range swaps.Contracts {
@@ -733,11 +756,7 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 			expiration: time.Unix(int64(contract.LockTime), 0).UTC(),
 		})
 	}
-	dcr.fundingMtx.Lock()
-	for _, coin := range swaps.Inputs {
-		delete(dcr.fundingCoins, coin.String())
-	}
-	dcr.fundingMtx.Unlock()
+
 	// If change is nil, return a nil asset.Coin.
 	var changeCoin asset.Coin
 	if change != nil {

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -694,8 +694,9 @@ func TestSwap(t *testing.T) {
 	}
 
 	swaps := &asset.Swaps{
-		Inputs:    coins,
-		Contracts: []*asset.Contract{contract},
+		Inputs:     coins,
+		Contracts:  []*asset.Contract{contract},
+		LockChange: true,
 	}
 
 	// Aim for 3 signature cycles.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -80,10 +80,7 @@ type Wallet interface {
 	// transaction outputs.
 	FundingCoins([]dex.Bytes) (Coins, error)
 	// Swap sends the swaps in a single transaction. The Receipts returned can
-	// be used to refund a failed transaction. The change coin is locked with
-	// the wallet in case it is still required to fund chained swaps for an
-	// order. The caller should unlock the change coin via ReturnCoins if it is
-	// no longer required to fund additional swaps for the parent order.
+	// be used to refund a failed transaction.
 	Swap(*Swaps) ([]Receipt, Coin, error)
 	// Redeem sends the redemption transaction, which may contain more than one
 	// redemption. The input coin IDs and the output Coin are returned.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -208,6 +208,9 @@ type Swaps struct {
 	Contracts []*Contract
 	// FeeRate is the required fee rate in atoms/byte.
 	FeeRate uint64
+	// LockChange can be set to true if the change should be locked for
+	// subsequent matches.
+	LockChange bool
 }
 
 // Contract is a swap contract.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -79,8 +79,11 @@ type Wallet interface {
 	// externally. This method will only return funding coins, e.g. unspent
 	// transaction outputs.
 	FundingCoins([]dex.Bytes) (Coins, error)
-	// Swap sends the swaps in a single transaction. The Receipts returned can be
-	// used to refund a failed transaction.
+	// Swap sends the swaps in a single transaction. The Receipts returned can
+	// be used to refund a failed transaction. The change coin is locked with
+	// the wallet in case it is still required to fund chained swaps for an
+	// order. The caller should unlock the change coin via ReturnCoins if it is
+	// no longer required to fund additional swaps for the parent order.
 	Swap(*Swaps) ([]Receipt, Coin, error)
 	// Redeem sends the redemption transaction, which may contain more than one
 	// redemption. The input coin IDs and the output Coin are returned.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1596,6 +1596,7 @@ func (c *Core) Trade(pw []byte, form *TradeForm) (*Order, error) {
 
 	// Refresh the markets.
 	dc.refreshMarkets()
+	c.refreshUser()
 
 	return corder, nil
 }
@@ -2636,6 +2637,7 @@ var noteHandlers = map[string]routeHandler{
 	msgjson.UpdateRemainingRoute: handleUpdateRemainingMsg,
 	msgjson.SuspensionRoute:      handleTradeSuspensionMsg,
 	msgjson.NotifyRoute:          handleNotifyMsg,
+	msgjson.NomatchRoute:         handleNomatchRoute,
 }
 
 // listen monitors the DEX websocket connection for server requests and

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1860,6 +1860,7 @@ func TestCancel(t *testing.T) {
 	rig := newTestRig()
 	dc := rig.dc
 	lo, dbOrder, preImg, _ := makeLimitOrder(dc, true, 0, 0)
+	lo.Force = order.StandingTiF
 	oid := lo.ID()
 	mkt := dc.market(tDcrBtcMktName)
 	tracker := newTrackedTrade(dbOrder, preImg, dc, mkt.EpochLen, rig.core.lockTimeTaker, rig.core.lockTimeMaker,
@@ -3542,11 +3543,11 @@ func TestHandleNomatch(t *testing.T) {
 	dc.trades[marketOID] = marketTracker
 
 	runNomatch := func(tag string, oid order.OrderID, expStatus order.OrderStatus) {
-		payload := &msgjson.Nomatch{OrderID: oid[:]}
-		req, _ := msgjson.NewRequest(dc.NextID(), msgjson.NomatchRoute, payload)
-		err := handleNomatchRoute(tCore, dc, req)
+		payload := &msgjson.NoMatch{OrderID: oid[:]}
+		req, _ := msgjson.NewRequest(dc.NextID(), msgjson.NoMatchRoute, payload)
+		err := handleNoMatchRoute(tCore, dc, req)
 		if err != nil {
-			t.Fatalf("handleNomatchRoute error: %v", err)
+			t.Fatalf("handleNoMatchRoute error: %v", err)
 		}
 		tracker, _, _ := dc.findOrder(oid)
 		if tracker == nil {
@@ -3570,9 +3571,9 @@ func TestHandleNomatch(t *testing.T) {
 
 	// Unknown order should error.
 	oid := ordertest.RandomOrderID()
-	payload := &msgjson.Nomatch{OrderID: oid[:]}
-	req, _ := msgjson.NewRequest(dc.NextID(), msgjson.NomatchRoute, payload)
-	err = handleNomatchRoute(tCore, dc, req)
+	payload := &msgjson.NoMatch{OrderID: oid[:]}
+	req, _ := msgjson.NewRequest(dc.NextID(), msgjson.NoMatchRoute, payload)
+	err = handleNoMatchRoute(tCore, dc, req)
 	if !errorHasCode(err, unknownOrderErr) {
 		t.Fatalf("wrong error for unknown order ID: %v", err)
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -3196,7 +3196,7 @@ func TestSetEpoch(t *testing.T) {
 		if metaData.Status != status {
 			t.Fatalf("wrong status for %s. expected %s, got %s", tag, status, metaData.Status)
 		}
-		corder, _ := tracker.coreOrderInternal()
+		corder, _ := tracker.coreOrder()
 		if corder.Status != status {
 			t.Fatalf("wrong core order status for %s. expected %s, got %s", tag, status, corder.Status)
 		}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2335,9 +2335,6 @@ func TestTradeTracking(t *testing.T) {
 	if len(proof.TakerSwap) != 0 {
 		t.Fatalf("swap broadcast before confirmations")
 	}
-	// Set the tracker status as cancelled, and make sure the change coin is
-	// returned
-	tracker.metaData.Status = order.OrderStatusCanceled
 	// Now with the confirmations.
 	auditInfo.coin.confs = tBTC.SwapConf
 	swapID := encode.RandomBytes(36)
@@ -2349,12 +2346,6 @@ func TestTradeTracking(t *testing.T) {
 		t.Fatalf("swap not broadcast with confirmations")
 	}
 
-	// Check that change coin was returned. Use the tradeMtx for synchronization.
-	if len(tDcrWallet.returnedCoins) != 1 || !bytes.Equal(tDcrWallet.returnedCoins[0].ID(), tDcrWallet.changeCoin.id) {
-		t.Fatalf("change coin not returned")
-	}
-
-	tracker.metaData.Status = order.OrderStatusBooked
 	// Receive the maker's redemption.
 	redemptionCoin = encode.RandomBytes(36)
 	redemption = &msgjson.Redemption{

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -22,6 +22,7 @@ const (
 	emptyHostErr
 	connectionErr
 	acctKeyErr
+	unknownOrderErr
 )
 
 // Error is an error message and an error code.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -880,10 +880,7 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 	// If these are the last swaps, and the order is filled or canceled or
 	// revoked, then we don't need to lock the change coin.
 	isLastSwaps := len(matches)+alreadySwapped == len(t.matches)
-	isFilled := trade.Filled() == trade.Quantity
-	notMatchable := t.metaData.Status > order.OrderStatusBooked
-	skipChange := isLastSwaps && (isFilled || notMatchable)
-	if skipChange {
+	if isLastSwaps && t.metaData.Status > order.OrderStatusBooked {
 		t.changeLocked = false
 	} else {
 		swaps.LockChange = true

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -582,6 +582,12 @@ func (t *trackedTrade) tick() (assetCounter, error) {
 	// Check all matches and send swap, redeem or refund as necessary.
 	var sent, quoteSent, received, quoteReceived uint64
 	for _, match := range t.matches {
+		if (match.Match.Side == order.Maker && match.MetaData.Status >= order.MakerRedeemed) ||
+			(match.Match.Side == order.Taker && match.MetaData.Status >= order.MatchComplete) {
+
+			continue
+		}
+
 		switch {
 		case t.isSwappable(match):
 			log.Debugf("swappable match %v", match.id)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -507,8 +507,6 @@ func (t *trackedTrade) isSwappable(match *matchTracker) bool {
 	if dbMatch.Side == order.Maker && metaData.Status == order.NewlyMatched {
 		return true
 	}
-	log.Tracef("Match %v not swappable: match side = %v, status = %v",
-		match.id, dbMatch.Side, metaData.Status)
 	return false
 }
 
@@ -562,8 +560,6 @@ func (t *trackedTrade) isRedeemable(match *matchTracker) bool {
 	if dbMatch.Side == order.Taker && metaData.Status == order.MakerRedeemed {
 		return true
 	}
-	log.Tracef("Match %v not redeemable: match side = %v, status = %v",
-		match.id, dbMatch.Side, metaData.Status)
 	return false
 }
 
@@ -603,9 +599,6 @@ func (t *trackedTrade) isRefundable(match *matchTracker) bool {
 		log.Errorf("error checking if locktime has expired for %s contract on order %s, match %s: %v",
 			dbMatch.Side, t.ID(), match.id, err)
 		return false
-	}
-	if !swapLocktimeExpired {
-		log.Tracef("Match %v not refundable: lock time not expired.", match.id)
 	}
 	return swapLocktimeExpired
 }

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -324,6 +324,7 @@ func simpleTradeTest(qty, rate uint64, finalStatus order.MatchStatus) error {
 
 func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID string, finalStatus order.MatchStatus) error {
 	errs := newErrorSet("[client %d] ", client.id)
+	dc := client.dc()
 
 	oid, err := order.IDFromHex(orderID)
 	if err != nil {
@@ -331,7 +332,9 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 	}
 
 	oidShort := token(oid.Bytes())
-	tracker, _, _ := client.dc().findOrder(oid)
+	dc.tradeMtx.RLock()
+	tracker, _, _ := dc.findOrder(oid)
+	dc.tradeMtx.RUnlock()
 
 	// Wait a max of 2 epochLen durations for this order to get matched.
 	maxMatchDuration := 2 * time.Duration(tracker.epochLen) * time.Millisecond
@@ -352,6 +355,7 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 		return errs.add("order %s not matched after %s", oidShort, maxMatchDuration)
 	}
 
+	dc.tradeMtx.RLock()
 	client.log("%d match(es) received for order %s", len(tracker.matches), oidShort)
 	for _, match := range tracker.matches {
 		client.log("%s on match %s, amount %.8f %s", match.Match.Side.String(),
@@ -367,6 +371,7 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 	for _, match := range tracker.matches {
 		lastProcessedStatus[match.id] = order.NewlyMatched
 	}
+	dc.tradeMtx.RUnlock()
 
 	// the expected balance changes for this client will be updated
 	// as swaps and redeems are executed
@@ -393,8 +398,8 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 	maxTradeDuration := 1 * time.Minute
 	tryUntil(ctx, maxTradeDuration, func() bool {
 		var completedTrades int
-		tracker.matchMtx.RLock()
-		defer tracker.matchMtx.RUnlock()
+		dc.tradeMtx.Lock()
+		defer dc.tradeMtx.Unlock()
 		for _, match := range tracker.matches {
 			side, status := match.Match.Side, match.Match.Status
 			if status >= finalStatus {
@@ -452,6 +457,7 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 	}
 
 	var incompleteTrades int
+	dc.tradeMtx.RLock()
 	for _, match := range tracker.matches {
 		if match.Match.Status < finalStatus {
 			incompleteTrades++
@@ -459,6 +465,7 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 				token(match.ID()), match.Match.Status, match.Match.Side)
 		}
 	}
+	dc.tradeMtx.RUnlock()
 	if incompleteTrades > 0 {
 		return fmt.Errorf("client %d reported %d incomplete trades for order %s after %s",
 			client.id, incompleteTrades, oidShort, maxTradeDuration)
@@ -470,6 +477,7 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 func checkAndWaitForRefunds(ctx context.Context, client *tClient, orderID string) error {
 	// check if client has pending refunds
 	client.log("checking if refunds are necessary")
+	dc := client.dc()
 	refundAmts := map[uint32]int64{dcr.BipID: 0, btc.BipID: 0}
 	var furthestLockTime time.Time
 
@@ -484,8 +492,8 @@ func checkAndWaitForRefunds(ctx context.Context, client *tClient, orderID string
 		return fmt.Errorf("client %d: error parsing order id %s -> %v", client.id, orderID, err)
 	}
 
+	dc.tradeMtx.RLock()
 	tracker, _, _ := client.dc().findOrder(oid)
-	tracker.matchMtx.RLock()
 	for _, match := range tracker.matches {
 		if !hasRefundableSwap(match) {
 			continue
@@ -507,7 +515,7 @@ func checkAndWaitForRefunds(ctx context.Context, client *tClient, orderID string
 			furthestLockTime = swapLockTime
 		}
 	}
-	tracker.matchMtx.RUnlock()
+	dc.tradeMtx.RUnlock()
 
 	if ctx.Err() != nil { // context canceled
 		return nil
@@ -552,8 +560,8 @@ func checkAndWaitForRefunds(ctx context.Context, client *tClient, orderID string
 	var notRefundedSwaps int
 	refundWaitTimeout := 30 * time.Second
 	refundedSwaps := tryUntil(ctx, refundWaitTimeout, func() bool {
-		tracker.matchMtx.RLock()
-		defer tracker.matchMtx.RUnlock()
+		dc.tradeMtx.RLock()
+		defer dc.tradeMtx.RUnlock()
 		notRefundedSwaps = 0
 		for _, match := range tracker.matches {
 			if hasRefundableSwap(match) && match.MetaData.Proof.RefundCoin == nil {

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -72,9 +72,9 @@ const (
 	// MatchRoute is the route of a DEX-originating request-type message notifying
 	// the client of a match and initiating swap negotiation.
 	MatchRoute = "match"
-	// NomatchRoute is the route of a DEX-originating notification-type message
+	// NoMatchRoute is the route of a DEX-originating notification-type message
 	// notifying the client that an order did not match during its match cycle.
-	NomatchRoute = "nomatch"
+	NoMatchRoute = "nomatch"
 	// InitRoute is the route of a client-originating request-type message
 	// notifying the DEX, and subsequently the match counter-party, of the details
 	// of a swap contract.
@@ -408,8 +408,8 @@ func (m *Match) Serialize() []byte {
 	return append(s, uint64Bytes(m.FeeRateQuote)...)
 }
 
-// Nomatch is the payload for a server-originating NomatchRoute notification.
-type Nomatch struct {
+// Nomatch is the payload for a server-originating NoMatchRoute notification.
+type NoMatch struct {
 	OrderID Bytes `json:"orderid"`
 }
 

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -72,6 +72,9 @@ const (
 	// MatchRoute is the route of a DEX-originating request-type message notifying
 	// the client of a match and initiating swap negotiation.
 	MatchRoute = "match"
+	// NomatchRoute is the route of a DEX-originating notification-type message
+	// notifying the client that an order did not match during its match cycle.
+	NomatchRoute = "nomatch"
 	// InitRoute is the route of a client-originating request-type message
 	// notifying the DEX, and subsequently the match counter-party, of the details
 	// of a swap contract.
@@ -403,6 +406,11 @@ func (m *Match) Serialize() []byte {
 	s = append(s, []byte(m.Address)...)
 	s = append(s, uint64Bytes(m.FeeRateBase)...)
 	return append(s, uint64Bytes(m.FeeRateQuote)...)
+}
+
+// Nomatch is the payload for a server-originating NomatchRoute request.
+type Nomatch struct {
+	OrderID Bytes `json:"orderid"`
 }
 
 // Init is the payload for a client-originating InitRoute request.

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -408,7 +408,7 @@ func (m *Match) Serialize() []byte {
 	return append(s, uint64Bytes(m.FeeRateQuote)...)
 }
 
-// Nomatch is the payload for a server-originating NomatchRoute request.
+// Nomatch is the payload for a server-originating NomatchRoute notification.
 type Nomatch struct {
 	OrderID Bytes `json:"orderid"`
 }

--- a/server/market/integ/booker_matcher_test.go
+++ b/server/market/integ/booker_matcher_test.go
@@ -278,16 +278,17 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 		queue []*matcher.OrderRevealed
 	}
 	tests := []struct {
-		name            string
-		args            args
-		doesMatch       bool
-		wantMatches     []*order.MatchSet
-		wantNumPassed   int
-		wantNumFailed   int
-		wantDoneOK      int
-		wantNumPartial  int
-		wantNumBooked   int
-		wantNumUnbooked int
+		name             string
+		args             args
+		doesMatch        bool
+		wantMatches      []*order.MatchSet
+		wantNumPassed    int
+		wantNumFailed    int
+		wantDoneOK       int
+		wantNumPartial   int
+		wantNumBooked    int
+		wantNumUnbooked  int
+		wantNumNomatched int
 	}{
 		{
 			name: "limit buy immediate rate match",
@@ -299,12 +300,13 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 			wantMatches: []*order.MatchSet{
 				newMatchSet(takers[0].Order, []*order.LimitOrder{bookSellOrders[nSell-1]}),
 			},
-			wantNumPassed:   1,
-			wantNumFailed:   0,
-			wantDoneOK:      1,
-			wantNumPartial:  0,
-			wantNumBooked:   0,
-			wantNumUnbooked: 1,
+			wantNumPassed:    1,
+			wantNumFailed:    0,
+			wantDoneOK:       1,
+			wantNumPartial:   0,
+			wantNumBooked:    0,
+			wantNumUnbooked:  1,
+			wantNumNomatched: 0,
 		},
 		{
 			name: "limit buy standing partial taker inserted to book",
@@ -316,12 +318,13 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 			wantMatches: []*order.MatchSet{
 				newMatchSet(takers[1].Order, []*order.LimitOrder{bookSellOrders[nSell-1]}),
 			},
-			wantNumPassed:   1,
-			wantNumFailed:   0,
-			wantDoneOK:      0,
-			wantNumPartial:  1,
-			wantNumBooked:   1,
-			wantNumUnbooked: 1,
+			wantNumPassed:    1,
+			wantNumFailed:    0,
+			wantDoneOK:       0,
+			wantNumPartial:   1,
+			wantNumBooked:    1,
+			wantNumUnbooked:  1,
+			wantNumNomatched: 0,
 		},
 		{
 			name: "limit buy immediate partial taker unfilled",
@@ -333,12 +336,13 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 			wantMatches: []*order.MatchSet{
 				newMatchSet(takers[2].Order, []*order.LimitOrder{bookSellOrders[nSell-1]}),
 			},
-			wantNumPassed:   1,
-			wantNumFailed:   0,
-			wantDoneOK:      1,
-			wantNumPartial:  1,
-			wantNumBooked:   0,
-			wantNumUnbooked: 1,
+			wantNumPassed:    1,
+			wantNumFailed:    0,
+			wantDoneOK:       1,
+			wantNumPartial:   1,
+			wantNumBooked:    0,
+			wantNumUnbooked:  1,
+			wantNumNomatched: 0,
 		},
 		{
 			name: "limit buy immediate unfilled fail",
@@ -346,14 +350,15 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 				book:  newBook(t),
 				queue: []*matcher.OrderRevealed{takers[3]},
 			},
-			doesMatch:       false,
-			wantMatches:     nil,
-			wantNumPassed:   0,
-			wantNumFailed:   1,
-			wantDoneOK:      0,
-			wantNumPartial:  0,
-			wantNumBooked:   0,
-			wantNumUnbooked: 0,
+			doesMatch:        false,
+			wantMatches:      nil,
+			wantNumPassed:    0,
+			wantNumFailed:    1,
+			wantDoneOK:       0,
+			wantNumPartial:   0,
+			wantNumBooked:    0,
+			wantNumUnbooked:  0,
+			wantNumNomatched: 1,
 		},
 		{
 			name: "bad lot size order",
@@ -361,14 +366,15 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 				book:  newBook(t),
 				queue: []*matcher.OrderRevealed{badLotsizeOrder},
 			},
-			doesMatch:       false,
-			wantMatches:     nil,
-			wantNumPassed:   0,
-			wantNumFailed:   1,
-			wantDoneOK:      0,
-			wantNumPartial:  0,
-			wantNumBooked:   0,
-			wantNumUnbooked: 0,
+			doesMatch:        false,
+			wantMatches:      nil,
+			wantNumPassed:    0,
+			wantNumFailed:    1,
+			wantDoneOK:       0,
+			wantNumPartial:   0,
+			wantNumBooked:    0,
+			wantNumUnbooked:  0,
+			wantNumNomatched: 0,
 		},
 		{
 			name: "limit buy standing partial taker inserted to book, then filled by down-queue sell",
@@ -387,12 +393,13 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 					Total:   1 * LotSize,
 				},
 			},
-			wantNumPassed:   2,
-			wantNumFailed:   0,
-			wantDoneOK:      1,
-			wantNumPartial:  1,
-			wantNumBooked:   1,
-			wantNumUnbooked: 2,
+			wantNumPassed:    2,
+			wantNumFailed:    0,
+			wantDoneOK:       1,
+			wantNumPartial:   1,
+			wantNumBooked:    1,
+			wantNumUnbooked:  2,
+			wantNumNomatched: 0,
 		},
 		{
 			name: "limit sell immediate rate overlap",
@@ -407,12 +414,13 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 					[]*order.LimitOrder{bookBuyOrders[nBuy-1], bookBuyOrders[nBuy-2], bookBuyOrders[nBuy-3]},
 					1*LotSize),
 			},
-			wantNumPassed:   1,
-			wantNumFailed:   0,
-			wantDoneOK:      1,
-			wantNumPartial:  0,
-			wantNumBooked:   0,
-			wantNumUnbooked: 2,
+			wantNumPassed:    1,
+			wantNumFailed:    0,
+			wantDoneOK:       1,
+			wantNumPartial:   0,
+			wantNumBooked:    0,
+			wantNumUnbooked:  2,
+			wantNumNomatched: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -422,7 +430,7 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 			resetMakers()
 
 			// Ignore the seed since it is tested in the matcher unit tests.
-			_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
+			_, matches, passed, failed, doneOK, partial, booked, nomatched, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -452,6 +460,10 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 			}
 			if len(unbooked) != tt.wantNumUnbooked {
 				t.Errorf("number unbooked %d, expected %d", len(unbooked), tt.wantNumUnbooked)
+			}
+
+			if len(nomatched) != tt.wantNumNomatched {
+				t.Errorf("number nomatched %d, expected %d", len(nomatched), tt.wantNumNomatched)
 			}
 		})
 	}
@@ -546,14 +558,14 @@ func TestMatchWithBook_limitsOnly_multipleQueued(t *testing.T) {
 
 	// -> Shuffles to [1, 6, 0, 3, 4, 5, 2]
 	// 1 -> partial match, inserted into book (passed, partial inserted)
-	// 6 -> unmatched, inserted into book (inserted)
-	// 0 -> is unfilled (failed)
-	// 3 -> is unfilled (failed)
+	// 6 -> unmatched, inserted into book (inserted, nomatched)
+	// 0 -> is unfilled (failed, nomatched)
+	// 3 -> is unfilled (failed, nomatched)
 	// 4 -> fills against order 1, which was just inserted (passed)
 	// 5 -> is filled (passed)
-	// 2 -> is unfilled (failed)
+	// 2 -> is unfilled (failed, nomatched)
 	// matches: [1, 4, 5], passed: [1, 4], failed: [0, 3, 2]
-	// partial: [1], inserted: [1, 6]
+	// partial: [1], inserted: [1, 6], nomatched: [6, 0, 3, 2]
 
 	// order book from bookBuyOrders and bookSellOrders
 	b := newBook(t)
@@ -577,7 +589,7 @@ func TestMatchWithBook_limitsOnly_multipleQueued(t *testing.T) {
 	resetMakers()
 
 	// Ignore the seed since it is tested in the matcher unit tests.
-	_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(b, epochQueue)
+	_, matches, passed, failed, doneOK, partial, booked, nomatched, unbooked, _ := me.Match(b, epochQueue)
 	//t.Log(matches, passed, failed, doneOK, partial, booked, unbooked)
 
 	// PASSED orders
@@ -668,6 +680,20 @@ func TestMatchWithBook_limitsOnly_multipleQueued(t *testing.T) {
 		t.Errorf("Order not in unbooked slice.")
 	} else if loc != expectedLoc {
 		t.Errorf("Order not at expected location in unbooked slice: %d", loc)
+	}
+
+	// NOMATCHED orders
+
+	// We don't know the exact order, since there is an intermediate map used
+	// for tracking.
+	if len(nomatched) != 4 {
+		t.Errorf("Wrong number of nomatched orders. Wanted 4, got %d", len(nomatched))
+	} else {
+		for _, i := range []int{6, 0, 3, 2} {
+			if orderInSlice(epochQueueInit[i], nomatched) == -1 {
+				t.Errorf("Epoch queue order %d not in nomatched slice", i)
+			}
+		}
 	}
 
 	// epoch order 5 (sell, 4 lots, immediate @ 4300000) is match 1, matched
@@ -773,7 +799,7 @@ func TestMatch_cancelOnly(t *testing.T) {
 			numBuys0 := tt.args.book.BuyCount()
 
 			// Ignore the seed since it is tested in the matcher unit tests.
-			_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
+			_, matches, passed, failed, doneOK, partial, booked, _, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -852,16 +878,17 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 		queue []*matcher.OrderRevealed
 	}
 	tests := []struct {
-		name            string
-		args            args
-		doesMatch       bool
-		wantMatches     []*order.MatchSet
-		wantNumPassed   int
-		wantNumFailed   int
-		wantDoneOK      int
-		wantNumPartial  int
-		wantNumBooked   int
-		wantNumUnbooked int
+		name             string
+		args             args
+		doesMatch        bool
+		wantMatches      []*order.MatchSet
+		wantNumPassed    int
+		wantNumFailed    int
+		wantDoneOK       int
+		wantNumPartial   int
+		wantNumBooked    int
+		wantNumUnbooked  int
+		wantNumNomatched int
 	}{
 		{
 			name: "market sell, 1 maker match",
@@ -873,12 +900,13 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 			wantMatches: []*order.MatchSet{
 				newMatchSet(takers[0].Order, []*order.LimitOrder{bookBuyOrders[nBuy-1]}),
 			},
-			wantNumPassed:   1,
-			wantNumFailed:   0,
-			wantDoneOK:      1,
-			wantNumPartial:  0,
-			wantNumBooked:   0,
-			wantNumUnbooked: 1,
+			wantNumPassed:    1,
+			wantNumFailed:    0,
+			wantDoneOK:       1,
+			wantNumPartial:   0,
+			wantNumBooked:    0,
+			wantNumUnbooked:  1,
+			wantNumNomatched: 0,
 		},
 		{
 			name: "market sell, 2 maker match",
@@ -890,12 +918,13 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 			wantMatches: []*order.MatchSet{
 				newMatchSet(takers[1].Order, []*order.LimitOrder{bookBuyOrders[nBuy-1], bookBuyOrders[nBuy-2]}),
 			},
-			wantNumPassed:   1,
-			wantNumFailed:   0,
-			wantDoneOK:      1,
-			wantNumPartial:  0,
-			wantNumBooked:   0,
-			wantNumUnbooked: 2,
+			wantNumPassed:    1,
+			wantNumFailed:    0,
+			wantDoneOK:       1,
+			wantNumPartial:   0,
+			wantNumBooked:    0,
+			wantNumUnbooked:  2,
+			wantNumNomatched: 0,
 		},
 		{
 			name: "market sell, 2 maker match, partial maker fill",
@@ -907,12 +936,13 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 			wantMatches: []*order.MatchSet{
 				newMatchSet(takers[2].Order, []*order.LimitOrder{bookBuyOrders[nBuy-1], bookBuyOrders[nBuy-2], bookBuyOrders[nBuy-3]}, 2*LotSize),
 			},
-			wantNumPassed:   1,
-			wantNumFailed:   0,
-			wantDoneOK:      1,
-			wantNumPartial:  0,
-			wantNumBooked:   0,
-			wantNumUnbooked: 2,
+			wantNumPassed:    1,
+			wantNumFailed:    0,
+			wantDoneOK:       1,
+			wantNumPartial:   0,
+			wantNumBooked:    0,
+			wantNumUnbooked:  2,
+			wantNumNomatched: 0,
 		},
 		{
 			name: "market sell bad lot size",
@@ -920,14 +950,31 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 				book:  newBook(t),
 				queue: []*matcher.OrderRevealed{badLotsizeOrder},
 			},
-			doesMatch:       false,
-			wantMatches:     nil,
-			wantNumPassed:   0,
-			wantNumFailed:   1,
-			wantDoneOK:      0,
-			wantNumPartial:  0,
-			wantNumBooked:   0,
-			wantNumUnbooked: 0,
+			doesMatch:        false,
+			wantMatches:      nil,
+			wantNumPassed:    0,
+			wantNumFailed:    1,
+			wantDoneOK:       0,
+			wantNumPartial:   0,
+			wantNumBooked:    0,
+			wantNumUnbooked:  0,
+			wantNumNomatched: 0,
+		},
+		{
+			name: "market sell against empty book",
+			args: args{
+				book:  book.New(LotSize),
+				queue: []*matcher.OrderRevealed{takers[0]},
+			},
+			doesMatch:        false,
+			wantMatches:      nil,
+			wantNumPassed:    0,
+			wantNumFailed:    1,
+			wantDoneOK:       0,
+			wantNumPartial:   0,
+			wantNumBooked:    0,
+			wantNumUnbooked:  0,
+			wantNumNomatched: 1,
 		},
 	}
 	for _, tt := range tests {
@@ -939,7 +986,7 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 			//fmt.Printf("%v\n", takers)
 
 			// Ignore the seed since it is tested in the matcher unit tests.
-			_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
+			_, matches, passed, failed, doneOK, partial, booked, nomatched, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -969,6 +1016,10 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 			}
 			if len(unbooked) != tt.wantNumUnbooked {
 				t.Errorf("number unbooked %d, expected %d", len(unbooked), tt.wantNumUnbooked)
+			}
+
+			if len(nomatched) != tt.wantNumNomatched {
+				t.Errorf("number nomatched %d, expected %d", len(nomatched), tt.wantNumNomatched)
 			}
 		})
 	}
@@ -1142,7 +1193,7 @@ func TestMatch_marketBuysOnly(t *testing.T) {
 			resetMakers()
 
 			// Ignore the seed since it is tested in the matcher unit tests.
-			_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
+			_, matches, passed, failed, doneOK, partial, booked, _, unbooked, _ := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -1199,11 +1250,11 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 		// buys
 		newLimit(false, 4550000, 1, order.ImmediateTiF, 0), // 0: buy, 1 lot, immediate
 		newLimit(false, 4550000, 2, order.StandingTiF, 0),  // 1: buy, 2 lot, standing
-		newLimit(false, 4550000, 2, order.ImmediateTiF, 0), // 2: buy, 2 lot, immediate
-		newLimit(false, 4100000, 1, order.ImmediateTiF, 0), // 3: buy, 1 lot, immediate
+		newLimit(false, 4550000, 2, order.ImmediateTiF, 0), // 2: buy, 2 lot, immediate, unmatched
+		newLimit(false, 4100000, 1, order.ImmediateTiF, 0), // 3: buy, 1 lot, immediate, unmatched
 		// sells
 		newLimit(true, 4540000, 1, order.ImmediateTiF, 0), // 4: sell, 1 lot, immediate
-		newLimit(true, 4800000, 4, order.StandingTiF, 0),  // 5: sell, 4 lot, immediate
+		newLimit(true, 4800000, 4, order.StandingTiF, 0),  // 5: sell, 4 lot, immediate, unmatched
 		newLimit(true, 4300000, 4, order.ImmediateTiF, 0), // 6: sell, 4 lot, immediate
 		newLimit(true, 4800000, 40, order.StandingTiF, 1), // 7: sell, 40 lot, standing, unfilled insert
 		// market
@@ -1251,6 +1302,7 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 	expectedPartial := []int{}
 	expectedBooked := []int{5, 7, 1} // all StandingTiF
 	expectedNumUnbooked := 8
+	expectedNumNomatched := 4
 
 	// order book from bookBuyOrders and bookSellOrders
 	b := newBook(t)
@@ -1271,7 +1323,7 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 	resetMakers()
 
 	// Ignore the seed since it is tested in the matcher unit tests.
-	_, matches, passed, failed, doneOK, partial, booked, unbooked, _ := me.Match(b, epochQueue)
+	_, matches, passed, failed, doneOK, partial, booked, nomatched, unbooked, _ := me.Match(b, epochQueue)
 	//t.Log("Matches:", matches)
 	// s := "Passed: "
 	// for _, o := range passed {
@@ -1295,6 +1347,11 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 	// t.Log(s)
 	// s = "Booked: "
 	// for _, o := range booked {
+	// 	s += fmt.Sprintf("%p ", o.Order)
+	// }
+	// t.Log(s)
+	// s := "Nomatched: "
+	// for _, o := range nomatched {
 	// 	s += fmt.Sprintf("%p ", o.Order)
 	// }
 	// t.Log(s)
@@ -1347,6 +1404,10 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 
 	if len(unbooked) != expectedNumUnbooked {
 		t.Errorf("Incorrect number of unbooked orders. Got %d, expected %d", len(unbooked), expectedNumUnbooked)
+	}
+
+	if len(nomatched) != expectedNumNomatched {
+		t.Errorf("Incorrect number of nomatched orders. Got %d, expected %d", len(nomatched), expectedNumNomatched)
 	}
 
 	if len(matches) != expectedNumMatches {

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1573,7 +1573,7 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 	// Send "nomatch" notifications.
 	for _, ord := range nomatched {
 		oid := ord.Order.ID()
-		msg, err := msgjson.NewNotification(msgjson.NomatchRoute, &msgjson.Nomatch{
+		msg, err := msgjson.NewNotification(msgjson.NoMatchRoute, &msgjson.NoMatch{
 			OrderID: oid[:],
 		})
 		if err != nil {
@@ -1581,7 +1581,7 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 			log.Errorf("Failed to encode 'nomatch' notification.")
 			continue
 		}
-		m.auth.Send(ord.Order.Prefix().AccountID, msg)
+		m.auth.Send(ord.Order.User(), msg)
 	}
 
 	// Send "update_remaining" notifications to order book subscribers.

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1570,7 +1570,7 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 		notifyChan <- sig
 	}
 
-	// Send "nomatch" notifications to order book subscribers.
+	// Send "nomatch" notifications.
 	for _, ord := range nomatched {
 		oid := ord.Order.ID()
 		msg, err := msgjson.NewNotification(msgjson.NomatchRoute, &msgjson.Nomatch{

--- a/server/matcher/match.go
+++ b/server/matcher/match.go
@@ -141,7 +141,7 @@ func (ou *OrdersUpdated) String() string {
 // include orders that are not in the queue. Each of partial are in passed.
 //
 // TODO: Eliminate order slice return args in favor of just the *OrdersUpdated.
-func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, matches []*order.MatchSet, passed, failed, doneOK, partial, booked []*OrderRevealed, unbooked []*order.LimitOrder, updates *OrdersUpdated) {
+func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, matches []*order.MatchSet, passed, failed, doneOK, partial, booked, nomatched []*OrderRevealed, unbooked []*order.LimitOrder, updates *OrdersUpdated) {
 	// Apply the deterministic pseudorandom shuffling.
 	seed = shuffleQueue(queue)
 
@@ -150,6 +150,23 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 	// Store partially filled limit orders in a map to avoid duplicate
 	// entries.
 	partialMap := make(map[order.OrderID]*order.LimitOrder)
+
+	// Track initially unmatched standing limit orders and remove them if they
+	// are matched down-queue so that they aren't added to the nomatched slice.
+	nomatchStanding := make(map[order.OrderID]*OrderRevealed)
+
+	tallyMakers := func(makers []*order.LimitOrder) {
+		for _, maker := range makers {
+			delete(nomatchStanding, maker.ID())
+			if maker.Remaining() == 0 {
+				unbooked = append(unbooked, maker)
+				updates.TradesCompleted = append(updates.TradesCompleted, maker)
+				delete(partialMap, maker.ID())
+			} else {
+				partialMap[maker.ID()] = maker
+			}
+		}
+	}
 
 	// For each order in the queue, find the best match in the book.
 	for _, q := range queue {
@@ -190,28 +207,24 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 			// limit-limit order matching
 			var makers []*order.LimitOrder
 			matchSet := matchLimitOrder(book, o)
+
 			if matchSet != nil {
 				matches = append(matches, matchSet)
 				makers = matchSet.Makers
-			} else if o.Force == order.ImmediateTiF {
-				// There was no match and TiF is Immediate. Fail.
-				failed = append(failed, q)
-				updates.TradesFailed = append(updates.TradesFailed, o)
-				break
+			} else {
+				nomatchStanding[q.Order.ID()] = q
+				if o.Force == order.ImmediateTiF {
+					// There was no match and TiF is Immediate. Fail.
+					failed = append(failed, q)
+					updates.TradesFailed = append(updates.TradesFailed, o)
+					break
+				}
 			}
 
 			// Either matched or standing unmatched => passed.
 			passed = append(passed, q)
 
-			// Unbook matched makers with no remaining amount.
-			for _, maker := range makers {
-				if maker.Remaining() == 0 {
-					unbooked = append(unbooked, maker)
-					updates.TradesCompleted = append(updates.TradesCompleted, maker)
-				} else {
-					partialMap[maker.ID()] = maker
-				}
-			}
+			tallyMakers(makers)
 
 			var wasBooked bool
 			if o.Remaining() > 0 {
@@ -254,17 +267,11 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 				// There was no match and this is a market order. Fail.
 				failed = append(failed, q)
 				updates.TradesFailed = append(updates.TradesFailed, o)
+				nomatched = append(nomatched, q)
 				break
 			}
 
-			for _, maker := range matchSet.Makers {
-				if maker.Remaining() == 0 {
-					unbooked = append(unbooked, maker)
-					updates.TradesCompleted = append(updates.TradesCompleted, maker)
-				} else {
-					partialMap[maker.ID()] = maker
-				}
-			}
+			tallyMakers(matchSet.Makers)
 
 			// Regardless of remaining amount, market orders never go on the book.
 		}
@@ -277,6 +284,10 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 		if lo.Remaining() > 0 {
 			updates.TradesPartial = append(updates.TradesPartial, lo)
 		}
+	}
+
+	for _, q := range nomatchStanding {
+		nomatched = append(nomatched, q)
 	}
 
 	return

--- a/server/matcher/match_test.go
+++ b/server/matcher/match_test.go
@@ -623,7 +623,7 @@ func TestMatch_cancelOnly(t *testing.T) {
 
 			numBuys0 := tt.args.book.BuyCount()
 
-			seed, matches, passed, failed, doneOK, partial, booked, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
+			seed, matches, passed, failed, doneOK, partial, booked, _, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -732,6 +732,7 @@ func TestMatch_limitsOnly(t *testing.T) {
 		wantNumTradesCanceled  int
 		wantNumTradesCompleted int
 		wantNumTradesFailed    int
+		wantNumNomatched       int
 	}{
 		{
 			name: "limit buy immediate rate match",
@@ -755,6 +756,7 @@ func TestMatch_limitsOnly(t *testing.T) {
 			wantNumInserted:        0,
 			wantNumUnbooked:        1,
 			wantNumTradesCompleted: 2,
+			wantNumNomatched:       0,
 		},
 		{
 			name: "limit buy standing partial taker inserted to book",
@@ -779,6 +781,7 @@ func TestMatch_limitsOnly(t *testing.T) {
 			wantNumUnbooked:        1,
 			wantNumTradesBooked:    1,
 			wantNumTradesCompleted: 1,
+			wantNumNomatched:       0,
 		},
 		{
 			name: "limit buy immediate partial taker unfilled",
@@ -802,6 +805,7 @@ func TestMatch_limitsOnly(t *testing.T) {
 			wantNumInserted:        0,
 			wantNumUnbooked:        1,
 			wantNumTradesCompleted: 2, // not in partial since they are done
+			wantNumNomatched:       0,
 		},
 		{
 			name: "limit buy immediate unfilled fail",
@@ -823,6 +827,7 @@ func TestMatch_limitsOnly(t *testing.T) {
 			wantNumInserted:     0,
 			wantNumUnbooked:     0,
 			wantNumTradesFailed: 1,
+			wantNumNomatched:    1,
 		},
 		{
 			name: "bad lot size order",
@@ -844,6 +849,7 @@ func TestMatch_limitsOnly(t *testing.T) {
 			wantNumInserted:     0,
 			wantNumUnbooked:     0,
 			wantNumTradesFailed: 1,
+			wantNumNomatched:    0,
 		},
 		{
 			name: "limit buy standing partial taker inserted to book, then filled by down-queue sell",
@@ -886,7 +892,7 @@ func TestMatch_limitsOnly(t *testing.T) {
 			resetTakers()
 			resetMakers()
 
-			seed, matches, passed, failed, doneOK, partial, booked, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
+			seed, matches, passed, failed, doneOK, partial, booked, nomatched, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -929,6 +935,9 @@ func TestMatch_limitsOnly(t *testing.T) {
 			}
 			if len(updates.TradesFailed) != tt.wantNumTradesFailed {
 				t.Errorf("number of trades failed %d, expected %d", len(updates.TradesFailed), tt.wantNumTradesFailed)
+			}
+			if len(nomatched) != tt.wantNumNomatched {
+				t.Errorf("number of trades nomatched %d, expected %d", len(nomatched), tt.wantNumNomatched)
 			}
 		})
 	}
@@ -1164,7 +1173,7 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 
 			fmt.Printf("%v\n", takers)
 
-			seed, matches, passed, failed, doneOK, partial, booked, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
+			seed, matches, passed, failed, doneOK, partial, booked, _, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -1405,7 +1414,7 @@ func TestMatch_marketBuysOnly(t *testing.T) {
 			resetTakers()
 			resetMakers()
 
-			seed, matches, passed, failed, doneOK, partial, booked, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
+			seed, matches, passed, failed, doneOK, partial, booked, _, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)


### PR DESCRIPTION
Lock change coin in `ExchangeWallet.Swap`. Return unused coins when an order is canceled, or when a market is suspended with  `persist = false`.