### PR TITLE
dex/order,client/asset: fix UserMatch DB serialization, and change address assumption

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -695,7 +695,12 @@ func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	for i := range opIDs {
 		delete(btc.fundingCoins, opIDs[i])
 	}
-	return receipts, change, nil
+	// If change is nil, return a nil asset.Coin.
+	var changeCoin asset.Coin
+	if change != nil {
+		changeCoin = change
+	}
+	return receipts, changeCoin, nil
 }
 
 // Redeem sends the redemption transaction, completing the atomic swap.

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -224,6 +224,7 @@ func Run(t testKiller, newWallet WalletConstructor, address string, dexAsset *de
 	swaps := &asset.Swaps{
 		Inputs:    append(utxos1, utxos2...),
 		Contracts: []*asset.Contract{contract1, contract2},
+		FeeRate:   dexAsset.MaxFeeRate,
 	}
 
 	receipts, _, err := rig.gamma().Swap(swaps)
@@ -335,6 +336,7 @@ func Run(t testKiller, newWallet WalletConstructor, address string, dexAsset *de
 	swaps = &asset.Swaps{
 		Inputs:    utxos,
 		Contracts: []*asset.Contract{contract},
+		FeeRate:   dexAsset.MaxFeeRate,
 	}
 
 	time.Sleep(time.Second)

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -234,6 +234,7 @@ func TestWallet(t *testing.T) {
 	swaps := &asset.Swaps{
 		Inputs:    append(utxos1, utxos2...),
 		Contracts: []*asset.Contract{contract1, contract2},
+		FeeRate:   tDCR.MaxFeeRate,
 	}
 
 	receipts, _, err := rig.beta().Swap(swaps)
@@ -346,6 +347,7 @@ func TestWallet(t *testing.T) {
 	swaps = &asset.Swaps{
 		Inputs:    utxos,
 		Contracts: []*asset.Contract{contract},
+		FeeRate:   tDCR.MaxFeeRate,
 	}
 
 	receipts, _, err = rig.beta().Swap(swaps)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -700,12 +700,12 @@ func (c *Core) updateBalances(counts assetCounter) {
 		if !exists {
 			// This should never be the case, but log an error in case I'm
 			// wrong or something changes.
-			log.Errorf("non-existent wallet should exist")
+			log.Errorf("non-existent %d wallet should exist", assetID)
 			continue
 		}
 		_, err := c.walletBalances(w)
 		if err != nil {
-			log.Error("error updateing balance after tick: %v", err)
+			log.Errorf("error updating %q balance: %v", unbip(assetID), err)
 			continue
 		}
 	}

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -728,10 +728,13 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 	log.Infof("Broadcasted transaction with %d swap contracts for order %v. Fee rate = %d. Receipts: %v",
 		len(receipts), t.ID(), swaps.FeeRate, receipts)
 
-	t.change = change
-	t.coins[hex.EncodeToString(change.ID())] = change
-	t.metaData.ChangeCoin = []byte(change.ID())
-	t.db.SetChangeCoin(t.ID(), t.metaData.ChangeCoin) // TODO: lock the change coin in the wallet if the order is still on the book
+	if change != nil {
+		log.Debugf("storing change coin %v", change.String())
+		t.change = change
+		t.coins[hex.EncodeToString(change.ID())] = change
+		t.metaData.ChangeCoin = []byte(change.ID())
+		t.db.SetChangeCoin(t.ID(), t.metaData.ChangeCoin) // TODO: lock the change coin in the wallet if the order is still on the book
+	}
 
 	// Process the swap for each match by sending the `init` request
 	// to the DEX and updating the match with swap details.

--- a/dex/encode/encode.go
+++ b/dex/encode/encode.go
@@ -104,7 +104,7 @@ func DecodeUTime(b []byte) time.Time {
 }
 
 // ExtractPushes parses the linearly-encoded 2D byte slice into a slice of
-// slices.
+// slices. Empty pushes are nil slices.
 func ExtractPushes(b []byte) ([][]byte, error) {
 	pushes := make([][]byte, 0)
 	for {
@@ -123,6 +123,11 @@ func ExtractPushes(b []byte) ([][]byte, error) {
 		if len(b) < l {
 			return nil, fmt.Errorf("data too short for pop of %d bytes", l)
 		}
+		if l == 0 {
+			// If data length is zero, append nil instead of an empty slice.
+			pushes = append(pushes, nil)
+			continue
+		}
 		pushes = append(pushes, b[:l])
 		b = b[l:]
 	}
@@ -130,7 +135,7 @@ func ExtractPushes(b []byte) ([][]byte, error) {
 }
 
 // DecodeBlob decodes a versioned blob into its version and the pushes extracted
-// from its data.
+// from its data. Empty pushes will be nil.
 func DecodeBlob(b []byte) (byte, [][]byte, error) {
 	if len(b) == 0 {
 		return 0, nil, fmt.Errorf("zero length blob not allowed")

--- a/dex/order/test/helpers.go
+++ b/dex/order/test/helpers.go
@@ -250,13 +250,14 @@ func CompareTrade(t1, t2 *order.Trade) error {
 // RandomUserMatch creates a random UserMatch.
 func RandomUserMatch() *order.UserMatch {
 	return &order.UserMatch{
-		OrderID:  RandomOrderID(),
-		MatchID:  RandomMatchID(),
-		Quantity: randUint64(),
-		Rate:     randUint64(),
-		Address:  RandomAddress(),
-		Status:   order.MatchStatus(rand.Intn(5)),
-		Side:     order.MatchSide(rand.Intn(2)),
+		OrderID:     RandomOrderID(),
+		MatchID:     RandomMatchID(),
+		Quantity:    randUint64(),
+		Rate:        randUint64(),
+		Address:     RandomAddress(),
+		Status:      order.MatchStatus(rand.Intn(5)),
+		Side:        order.MatchSide(rand.Intn(2)),
+		FeeRateSwap: randUint64(),
 	}
 }
 
@@ -284,16 +285,21 @@ func CompareUserMatch(m1, m2 *order.UserMatch) error {
 	if m1.Side != m2.Side {
 		return fmt.Errorf("Side mismatch. %d != %d", m1.Side, m2.Side)
 	}
+	if m1.FeeRateSwap != m2.FeeRateSwap {
+		return fmt.Errorf("FeeRateSwap mismatch. %d != %d", m1.FeeRateSwap, m2.FeeRateSwap)
+	}
 	return nil
 }
 
 type testKiller interface {
+	Helper()
 	Fatalf(string, ...interface{})
 }
 
 // MustComparePrefix compares the Prefix field-by-field and calls the Fatalf
 // method on the supplied testKiller if a mismatch is encountered.
 func MustComparePrefix(t testKiller, p1, p2 *order.Prefix) {
+	t.Helper()
 	err := ComparePrefix(p1, p2)
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -303,6 +309,7 @@ func MustComparePrefix(t testKiller, p1, p2 *order.Prefix) {
 // MustCompareTrade compares the MarketOrders field-by-field and calls the
 // Fatalf method on the supplied testKiller if a mismatch is encountered.
 func MustCompareTrade(t testKiller, t1, t2 *order.Trade) {
+	t.Helper()
 	err := CompareTrade(t1, t2)
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -312,6 +319,7 @@ func MustCompareTrade(t testKiller, t1, t2 *order.Trade) {
 // MustCompareUserMatch compares the UserMatches field-by-field and calls the
 // Fatalf method on the supplied testKiller if a mismatch is encountered.
 func MustCompareUserMatch(t testKiller, m1, m2 *order.UserMatch) {
+	t.Helper()
 	err := CompareUserMatch(m1, m2)
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -321,6 +329,7 @@ func MustCompareUserMatch(t testKiller, m1, m2 *order.UserMatch) {
 // MustCompareUserMatch compares the LimitOrders field-by-field and calls the
 // Fatalf method on the supplied testKiller if a mismatch is encountered.
 func MustCompareLimitOrders(t testKiller, l1, l2 *order.LimitOrder) {
+	t.Helper()
 	MustComparePrefix(t, &l1.P, &l2.P)
 	MustCompareTrade(t, &l1.T, &l2.T)
 	if l1.Rate != l2.Rate {
@@ -341,6 +350,7 @@ func MustCompareMarketOrders(t testKiller, m1, m2 *order.MarketOrder) {
 // MustCompareCancelOrders compares the CancelOrders field-by-field and calls
 // the Fatalf method on the supplied testKiller if a mismatch is encountered.
 func MustCompareCancelOrders(t testKiller, c1, c2 *order.CancelOrder) {
+	t.Helper()
 	MustComparePrefix(t, &c1.P, &c2.P)
 	if !bytes.Equal(c1.TargetOrderID[:], c2.TargetOrderID[:]) {
 		t.Fatalf("wrong target order ID. wanted %s, got %s", c1.TargetOrderID, c2.TargetOrderID)
@@ -350,6 +360,7 @@ func MustCompareCancelOrders(t testKiller, c1, c2 *order.CancelOrder) {
 // MustCompareOrders compares the Orders field-by-field and calls
 // the Fatalf method on the supplied testKiller if a mismatch is encountered.
 func MustCompareOrders(t testKiller, o1, o2 order.Order) {
+	t.Helper()
 	switch ord1 := o1.(type) {
 	case *order.LimitOrder:
 		ord2, ok := o2.(*order.LimitOrder)

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -265,8 +265,7 @@ type MatchArchiver interface {
 	InsertMatch(match *order.Match) error
 	MatchByID(mid order.MatchID, base, quote uint32) (*MatchData, error)
 	UserMatches(aid account.AccountID, base, quote uint32) ([]*MatchData, error)
-	// ActiveMatches retrieves the current active matches for an account.
-	ActiveMatches(account.AccountID) ([]*order.UserMatch, error)
+	AllActiveUserMatches(aid account.AccountID) ([]*MatchData, error)
 }
 
 // SwapArchiver is the interface required for storage and retrieval of swap

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -140,7 +140,7 @@ func (ta *TArchivist) MatchByID(mid order.MatchID, base, quote uint32) (*db.Matc
 func (ta *TArchivist) UserMatches(aid account.AccountID, base, quote uint32) ([]*db.MatchData, error) {
 	return nil, nil
 }
-func (ta *TArchivist) ActiveMatches(account.AccountID) ([]*order.UserMatch, error) {
+func (ta *TArchivist) AllActiveUserMatches(account.AccountID) ([]*db.MatchData, error) {
 	return nil, nil
 }
 func (ta *TArchivist) SwapData(mid db.MarketMatchID) (order.MatchStatus, *db.SwapData, error) {


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/529

The `order.UserMatch` was not being serialized with the new `FeeRateSwap` field so it was being loaded from DB as 0 by default.

In addition, the `'connect'` response was not setting either base or quote fee rates, but it was also missing the recently added `MatchTime` that the client needs for lock time computation.

The server/db changes provide the data needed by `(*AuthManager).handleConnect` to provide this new match data to clients on connect.

In client/asset/{dcr,btc}, `(*ExchangeWallet).sendWithReturn` was assuming a certain change address format when computing the updated tx size.  This fixes that and refactors a bit so the functions mirror each other more closely, and to log more information about the generated transaction and its fees.

EDIT:  Another `'connect'` bug was that only one msgjson.Match was being sent if the user was on both sides of the match.  This is fixed to send two matches now as is done when the matches are initially made.  <s>Even with this though the client will fail to act if `dexc` is restart in `TakerSwapCast` status.</s>. Finally, the dex/encode package is updated to load empty data pushes as nil instead is a zero length non-nil slice.