### PR TITLE
spec: add nomatch notification

### DIFF
--- a/spec/README.mediawiki
+++ b/spec/README.mediawiki
@@ -113,6 +113,7 @@ book and place orders.
 *** [[orders.mediawiki/#Market_Buy_Orders|Market Buy Orders]]
 ** [[orders.mediawiki/#Cancel_Order|Cancel Order]]
 * [[orders.mediawiki/#Preimage_Reveal|Preimage Handling]]
+* [[orders.mediawiki/#Unmatched_Orders|Unmatched Orders]]
 * [[orders.mediawiki/#Match_Revocation|Match Revocation]]
 * [[orders.mediawiki/#Match_negotiation|Match Negotiation]]
 * [[orders.mediawiki/#Trade_Suspension|Trade Suspension]]

--- a/spec/orders.mediawiki
+++ b/spec/orders.mediawiki
@@ -815,7 +815,7 @@ The client will respond with an acknowledgement.
 The taker will get the key from the maker's redemption and broadcast their own
 redemption transaction.
 
-It is also possible for an  order to go through the matching cycle without
+It is also possible for an order to go through the matching cycle without
 generating a match. This will be common for limit orders, but can also occur for
 market orders if there are no booked orders to match with. When the server fails
 to find any matches, a <code>nomatch</code> notification will be sent to the

--- a/spec/orders.mediawiki
+++ b/spec/orders.mediawiki
@@ -815,6 +815,21 @@ The client will respond with an acknowledgement.
 The taker will get the key from the maker's redemption and broadcast their own
 redemption transaction.
 
+It is also possible for an  order to go through the matching cycle without
+generating a match. This will be common for limit orders, but can also occur for
+market orders if there are no booked orders to match with. When the server fails
+to find any matches, a <code>nomatch</code> notification will be sent to the
+client.
+
+'''Notification route:''' <code>nomatch</code>, '''originator:''' DEX
+
+<code>payload</code>
+{|
+! field   !! type   !! description
+|-
+| orderid || string || order ID
+|}
+
 ==Match Revocation==
 
 A match can be revoked by the server if a client fails to act within the

--- a/spec/orders.mediawiki
+++ b/spec/orders.mediawiki
@@ -815,7 +815,7 @@ The client will respond with an acknowledgement.
 The taker will get the key from the maker's redemption and broadcast their own
 redemption transaction.
 
-It is also possible for an order to go through the matching cycle without
+It is also possible for an epoch order to go through the matching cycle without
 generating a match. This will be common for limit orders, but can also occur for
 market orders if there are no booked orders to match with. When the server fails
 to find any matches, a <code>nomatch</code> notification will be sent to the


### PR DESCRIPTION
If there is no match for an order, the client must currently infer that from the match proof. This PR adds a `nomatch` notification when the client's order does not match during the match cycle. The notification will be sent for market and limit orders (regardless of time-in-force). This is just one possible solution the issue raised in https://github.com/decred/dcrdex/pull/525#pullrequestreview-443328138.