### PR TITLE
testing/dcr: allow dcr harness to run forever

### DIFF
--- a/dex/testing/dcr/create-wallet.sh
+++ b/dex/testing/dcr/create-wallet.sh
@@ -46,7 +46,7 @@ if [ "${ENABLE_VOTING}" = "1" ]; then
   cat >> "${WALLET_DIR}/w-${NAME}.conf" <<EOF
 enablevoting=1
 enableticketbuyer=1
-ticketbuyer.limit=5
+ticketbuyer.limit=6
 ticketbuyer.balancetomaintainabsolute=1000
 EOF
 fi


### PR DESCRIPTION
Resolving https://github.com/decred/dcrdex/issues/413.

The harness ran over night and is at block 4021 and counting.  Turns out it was because of the one block in a sdiff window where wallet refuses to make a purchase that makes `ticketbuyer.limit=5` inadequate over long enough.