### PR TITLE
spec: Add penalize notifications.

### DIFF
--- a/spec/README.mediawiki
+++ b/spec/README.mediawiki
@@ -129,6 +129,8 @@ to which clients interacting with the DEX must adhere.
 
 * [[community.mediawiki/#Rules_of_Community_Conduct|Rules of Community Conduct]]
 * [[community.mediawiki/#Penalties|Penalties]]
+** [[community.mediawiki/#Penalization_Notification|Penalization Notification]]
+*** [[community.mediawiki/#Penalty_Object|Penalty Object]]
 
 '''&#91;9&#93; [[references.mediawiki|References]]''' lists references used in the development
 of the specification.

--- a/spec/comm.mediawiki
+++ b/spec/comm.mediawiki
@@ -189,17 +189,11 @@ of their penalization.
 {|
 ! field   !! type   !! description
 |-
-| matches          || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
+| matches || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
 |-
-| broken rule      || int || the client's last broken [[community.mediawiki/#Rules_of_Community_Conduct|rule]]. omitted if in good standing
+| penalty || object || the client's most recent [[community.mediawiki/#Rules_of_Community_Conduct|broken rule]]. omitted if in good standing
 |-
-| penalty time     || int || the UNIX time in milliseconds at which the penalization occured. omitted if in good standing
-|-
-| penalty duration || int || the duration in milliseconds of the penalization. omitted if in good standing
-|-
-| penalty details  || string || a message describing the penalization. omitted if in good standing
-|-
-| sig              || string || hex-encoded server's signature of the serialized connection data
+| sig     || string || hex-encoded server's signature of the serialized connection data
 |}
 
 ==HTTP==

--- a/spec/comm.mediawiki
+++ b/spec/comm.mediawiki
@@ -182,14 +182,24 @@ connection is established, the client will supply their account ID and signature
 
 If a client unexpectedly disconnects with active orders, the orders may match in
 the client's absence. A list of any pending matches is included in the response.
+If the client has a broken rule, they will not be able to trade for the duration
+of their penalization.
 
 <code>result</code>
 {|
 ! field   !! type   !! description
 |-
-| matches || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
+| matches      || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
 |-
-| sig     || string || hex-encoded server's signature of the serialized connection data
+| broken rule  || int || the client's current [[community.mediawiki/#Rules_of_Community_Conduct|rule status]]
+|-
+| ban time     || int || the UNIX time in milliseconds at which the penalization occured if applicable
+|-
+| ban duration || int || the duration in milliseconds of the penalization if applicable
+|-
+| ban details  || string || a message describing the penalization if applicable
+|-
+| sig          || string || hex-encoded server's signature of the serialized connection data
 |}
 
 ==HTTP==

--- a/spec/comm.mediawiki
+++ b/spec/comm.mediawiki
@@ -189,17 +189,17 @@ of their penalization.
 {|
 ! field   !! type   !! description
 |-
-| matches      || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
+| matches          || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
 |-
-| broken rule  || int || the client's current [[community.mediawiki/#Rules_of_Community_Conduct|rule status]]
+| broken rule      || int || the client's last broken [[community.mediawiki/#Rules_of_Community_Conduct|rule]]. omitted if in good standing
 |-
-| ban time     || int || the UNIX time in milliseconds at which the penalization occured if applicable
+| penalty time     || int || the UNIX time in milliseconds at which the penalization occured. omitted if in good standing
 |-
-| ban duration || int || the duration in milliseconds of the penalization if applicable
+| penalty duration || int || the duration in milliseconds of the penalization. omitted if in good standing
 |-
-| ban details  || string || a message describing the penalization if applicable
+| penalty details  || string || a message describing the penalization. omitted if in good standing
 |-
-| sig          || string || hex-encoded server's signature of the serialized connection data
+| sig              || string || hex-encoded server's signature of the serialized connection data
 |}
 
 ==HTTP==

--- a/spec/comm.mediawiki
+++ b/spec/comm.mediawiki
@@ -191,7 +191,7 @@ of their penalization.
 |-
 | matches || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
 |-
-| penalty || object || the client's most recent [[community.mediawiki/#Rules_of_Community_Conduct|broken rule]]. omitted if in good standing
+| penalty || object || a [[community.mediawiki/#Penalty_object|Penalty object]]. omitted if in good standing
 |-
 | sig     || string || hex-encoded server's signature of the serialized connection data
 |}

--- a/spec/comm.mediawiki
+++ b/spec/comm.mediawiki
@@ -191,7 +191,7 @@ of their penalization.
 |-
 | matches || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
 |-
-| penalty || object || a [[community.mediawiki/#Penalty_object|Penalty object]]. omitted if in good standing
+| penalty || object || a [[community.mediawiki/#Penalty_Object|Penalty Object]]. omitted if in good standing
 |-
 | sig     || string || hex-encoded server's signature of the serialized connection data
 |}

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -66,6 +66,14 @@ be sent in the [[comm.mediawiki/#Session_Authentication|connect response]].
 
 <code>payload</code>
 {|
+! field   !! type   !! description
+|-
+| penalty || object || a Penalty object (definition below)
+|}
+
+
+====Penalty object====
+{|
 ! field      !! type   !! description
 |-
 | brokenrule || int    || the rule that was broken

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -59,25 +59,22 @@ for minor, first-time or infrequent conduct violations.
 ===Penalization Notification===
 
 In the event that a rule is broken, the client will be sent a notification that
-includes the broken rule, a detailed description of the offense, the time of
-the penalization, and the duration. If the client is offline, this information
-can be found in the [[comm.mediawiki/#Session_Authentication|connect response]].
+includes penalization details. If the client is offline, this information will
+be sent in the [[comm.mediawiki/#Session_Authentication|connect response]].
 
-'''Notification route:''' <code>penalize</code>, '''originator: ''' dex
+'''Notification route:''' <code>penalty</code>, '''originator: ''' DEX
 
 <code>payload</code>
 {|
 ! field      !! type   !! description
 |-
-| accountid   || string || hex encoding of the client's account ID
+| brokenrule || int    || the rule that was broken
 |-
-| broken rule || int || the rule that was broken
+| timestamp  || int    || the UNIX timestamp in milliseconds at which the penalization occured
 |-
-| timestamp   || int || the UNIX time in milliseconds at which the penalization occured
+| duration   || int    || the duration in milliseconds of the penalization
 |-
-| duration    || int || the duration in milliseconds of the penalization
+| details    || string || a message describing the penalization
 |-
-| details     || string || a message describing the penalization
-|-
-| sig         || string || hex-encoded server's signature of the serialized penalization data
+| sig        || string || hex-encoded server's signature of the serialized penalization data
 |}

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -55,3 +55,29 @@ of any unfilled orders.
 
 Less drastic punitive measures such as a cool-down period may be considered
 for minor, first-time or infrequent conduct violations.
+
+===Penalization Notification===
+
+In the event that a rule is broken, the client will be sent a notification that
+includes the broken rule, a detailed description of the offense, the time of
+the penalization, and the duration. If the client is offline, this information
+can be found in the [[comm.mediawiki/#Session_Authentication|connect response]].
+
+'''Notification route:''' <code>penalize</code>, '''originator: ''' dex
+
+<code>payload</code>
+{|
+! field      !! type   !! description
+|-
+| accountid   || string || hex encoding of the client's account ID
+|-
+| broken rule || int || the rule that was broken
+|-
+| timestamp   || int || the UNIX time in milliseconds at which the penalization occured
+|-
+| duration    || int || the duration in milliseconds of the penalization
+|-
+| details     || string || a message describing the penalization
+|-
+| sig         || string || hex-encoded server's signature of the serialized penalization data
+|}

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -69,20 +69,20 @@ be sent in the [[comm.mediawiki/#Session_Authentication|connect response]].
 ! field   !! type   !! description
 |-
 | penalty || object || a Penalty object (definition below)
+|-
+| sig     || string || hex-encoded server's signature of the serialized penalization data
 |}
 
-
 ====Penalty object====
+
 {|
-! field      !! type   !! description
+! field !! size (bytes) !! type !! description
 |-
-| brokenrule || int    || the rule that was broken
+| brokenrule || 1      || int    || the rule that was broken
 |-
-| timestamp  || int    || the UNIX timestamp in milliseconds at which the penalization occured
+| timestamp  || 8      || int    || the UNIX timestamp in milliseconds at which the penalization occured
 |-
-| duration   || int    || the duration in milliseconds of the penalization
+| duration   || 8      || int    || the duration in milliseconds of the penalization
 |-
-| details    || string || a message describing the penalization
-|-
-| sig        || string || hex-encoded server's signature of the serialized penalization data
+| details    || string || string || a message describing the penalization
 |}

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -73,7 +73,7 @@ be sent in the [[comm.mediawiki/#Session_Authentication|connect response]].
 | sig     || string || hex-encoded signature of the serialized Penalty object
 |}
 
-====Penalty object====
+====Penalty Object====
 
 {|
 ! field      !! type   !! description

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -98,5 +98,5 @@ be sent in the [[comm.mediawiki/#Session_Authentication|connect response]].
 |-
 | duration   || 8            || duration (milliseconds)
 |-
-| details    || string       || a message
+| details    || string       || a message (UTF-8)
 |}

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -70,19 +70,33 @@ be sent in the [[comm.mediawiki/#Session_Authentication|connect response]].
 |-
 | penalty || object || a Penalty object (definition below)
 |-
-| sig     || string || hex-encoded server's signature of the serialized penalization data
+| sig     || string || hex-encoded signature of the serialized Penalty object
 |}
 
 ====Penalty object====
 
 {|
-! field !! size (bytes) !! type !! description
+! field      !! type   !! description
 |-
-| brokenrule || 1      || int    || the rule that was broken
+| brokenrule || int    || the rule that was broken
 |-
-| timestamp  || 8      || int    || the UNIX timestamp in milliseconds at which the penalization occured
+| timestamp  || int    || the UNIX timestamp in milliseconds at which the penalization occured
 |-
-| duration   || 8      || int    || the duration in milliseconds of the penalization
+| duration   || int    || the duration in milliseconds of the penalization
 |-
-| details    || string || string || a message describing the penalization
+| details    || string || a message describing the penalization
+|}
+
+'''Penalty serialization'''
+
+{|
+! field      !! size (bytes) !! description
+|-
+| brokenrule || 1            || the rule
+|-
+| timestamp  || 8            || server's UNIX timestamp (milliseconds)
+|-
+| duration   || 8            || duration (milliseconds)
+|-
+| details    || string       || a message
 |}


### PR DESCRIPTION
part of #444 

It was discussed that the notification be tried on reconnect, and to add it to connect, but I thought just adding it to the connect response would be enough/better.

Also:
>message (e.g. state connected to complete swaps or risk further penalty or loss of reg fee!)

I think can be hard coded into the client, since it will be true for all bans

Can be viewed [here](https://github.com/decred/dcrdex/blob/a91ad6aaa874bca72df3bc1024483bedef102e0e/spec/community.mediawiki/#Penalties)