### PR TITLE
client/webserver/site: showCancel must not register multiple handlers

### DIFF
--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -701,7 +701,7 @@ export default class MarketsPage extends BasePage {
     const page = this.page
     const remaining = order.qty - order.filled
     page.cancelRemain.textContent = Doc.formatCoinValue(remaining / 1e8)
-    const symbol = order.sell ? this.market.base.symbol : this.market.quote.symbol
+    const symbol = isMarketBuy(order) ? this.market.quote.symbol : this.market.base.symbol
     page.cancelUnit.textContent = symbol.toUpperCase()
     this.showForm(page.cancelForm)
     // Provide data to the event handler via the cancelSubmit object. This

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -676,10 +676,10 @@ export default class MarketsPage extends BasePage {
     const page = this.page
     const remaining = order.qty - order.filled
     page.cancelRemain.textContent = Doc.formatCoinValue(remaining / 1e8)
-    const symbol = isMarketBuy(order) ? this.market.quote.symbol : this.market.base.symbol
+    const symbol = order.sell ? this.market.base.symbol : this.market.quote.symbol
     page.cancelUnit.textContent = symbol.toUpperCase()
     this.showForm(page.cancelForm)
-    bind(page.cancelSubmit, 'click', async () => {
+    page.cancelSubmit.addEventListener('click', async function handler () {
       const pw = page.cancelPass.value
       page.cancelPass.value = ''
       const req = {
@@ -692,7 +692,14 @@ export default class MarketsPage extends BasePage {
       if (!app.checkResponse(res)) return
       bttn.parentNode.textContent = 'cancelling'
       order.cancelling = true
-    })
+
+      // If "once" option is not supported by most browsers, we will need to
+      // unbind this function:
+      // Doc.unbind(page.cancelSubmit,'click', handler)
+
+      // What if the user clicks off the cancel form instead?  The cancelSubmit
+      // would bind another listener.
+    }, { once: true })
   }
 
   /* showCreate shows the new wallet creation form. */

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -165,7 +165,7 @@ export default class MarketsPage extends BasePage {
     // Main order form
     forms.bind(page.orderForm, page.submitBttn, async () => { this.stepSubmit() })
     // Order verification form
-    forms.bind(page.verifyForm, page.vSubmit, async () => { this.submitOrder() }) // why not just ..., this.submitOrder)?
+    forms.bind(page.verifyForm, page.vSubmit, async () => { this.submitOrder() })
     // Cancel order form
     bind(page.cancelSubmit, 'click', this.submitCancel)
 
@@ -680,7 +680,6 @@ export default class MarketsPage extends BasePage {
 
   async submitCancel () {
     // this will be the page.cancelSubmit button (evt.currentTarget)
-    console.log(this)
     const page = this.page
     const order = this.cancelData.order
     const req = {

--- a/client/webserver/site/src/js/ws.js
+++ b/client/webserver/site/src/js/ws.js
@@ -102,9 +102,8 @@ class MessageSocket {
         this.connected = false
         forward('close', null, this.handlers)
         retrys++
-        // 1.2, 1.6, 2.0, 2.4, 3.1, 3.8, 4.8, 6.0, 7.5, 9.3, 11.6, 14.6, 18.2,
-        // 22.7, 28.4, 30, 30 ...
-        const delay = Math.min(Math.pow(1.25, retrys), 30)
+        // 1.2, 1.6, 2.0, 2.4, 3.1, 3.8, 4.8, 6.0, 7.5, 9.3, ...
+        const delay = Math.min(Math.pow(1.25, retrys), 10)
         console.log(`websocket disconnected, trying again in ${delay.toFixed(1)} seconds`)
         setTimeout(() => {
           go()


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/517

If you attempt to cancel more than one order on the browser interface, successive cancels trigger repeated `/api/cancel` POSTs.

For example, book two orders, cancel the first one successfully:

![image](https://user-images.githubusercontent.com/9373513/87181625-3e13ca00-c2a8-11ea-9a95-99909245b8b1.png)


Then, try to cancel the second:

![image](https://user-images.githubusercontent.com/9373513/87181583-2f2d1780-c2a8-11ea-9b58-6f518c998b04.png)

This action makes **two** immediate POSTs to `/api/cancel`, both invalid:

![image](https://user-images.githubusercontent.com/9373513/87181675-52f05d80-c2a8-11ea-805d-40b7faa9f228.png)

Note that one has an empty `pw` but the correct target `orderID`, while the other has the password, but the previously canceled `orderID` from the first sucessful cancel.

This does not happen if you refresh the page between cancels.

Apparently the `submitCancel` event listeners remained.  An anonymous handler function is a bit harder to unregister, but it can be done by calling `removeEventListener` at the end of the hander function, or with the `{ once: true }` options for `addEventListener`.  This was the approach taken in the first commit of this PR (https://github.com/decred/dcrdex/pull/540/commits/86296e7997040501d015bd61081b9b625f8e8f2d), but to also deal with the need to unregister the handle when clicking off the cancel form without submitting, this was revised to simply register a named event handler.

TODO: Similar to order submission/verification, also register the `'submit'` event in addition to the `'click'` event that cancel requires.