### PR TITLE
server/market,client/{core,order}: fix epoch order note for cancel orders

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -387,8 +387,9 @@ func handleEpochOrderMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error
 
 	err = book.Enqueue(note)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to Enqueue epoch order: %v", err)
 	}
+
 	// Send a mini-order for book updates.
 	book.send(&BookUpdate{
 		Action:   msg.Route,

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -344,6 +344,7 @@ out:
 					epochNote.BookOrderNote = *marketOrderToMsgOrder(o, book.name)
 					epochNote.OrderType = msgjson.MarketOrderNum
 				case *order.CancelOrder:
+					epochNote.BookOrderNote = *cancelOrderToMsgOrder(o, book.name)
 					epochNote.OrderType = msgjson.CancelOrderNum
 					epochNote.TargetID = o.TargetOrderID[:]
 				}
@@ -533,6 +534,23 @@ func (r *BookRouter) sendNote(route string, subs *subscribers, note interface{})
 			delete(subs.conns, id)
 		}
 		subs.mtx.Unlock()
+	}
+}
+
+// cancelOrderToMsgOrder converts an *order.CancelOrder to a
+// *msgjson.BookOrderNote.
+func cancelOrderToMsgOrder(o *order.CancelOrder, mkt string) *msgjson.BookOrderNote {
+	oid := o.ID()
+	return &msgjson.BookOrderNote{
+		OrderNote: msgjson.OrderNote{
+			// Seq is set by book router.
+			MarketID: mkt,
+			OrderID:  oid[:],
+		},
+		TradeNote: msgjson.TradeNote{
+			// Side is 0 (neither buy or sell), so omitted.
+			Time: encode.UnixMilliU(o.ServerTime),
+		},
 	}
 }
 


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/446

server/market: fix book epoch order note for cancel orders

The epoch order note for a cancel order was not setting the order ID of
the cancel order itself, just the target ID.  Market ID and order time
stamp are also set now.

client/core: check market state in `Cancel`, improve messages

client/order: `ValidateMatchProof` short-circuits when order counts mismatch

When the number of preimages+misses in the match proof note does not
equal to the number of orders in the local epoch queue, skip the match
proof generation as it is guaranteed fail.