### PR TITLE
client/db/bolt: revert to db version 0

### DIFF
--- a/client/db/bolt/upgrades.go
+++ b/client/db/bolt/upgrades.go
@@ -15,7 +15,7 @@ type upgradefunc func(tx *bbolt.Tx) error
 // Each database upgrade function should be keyed by the database
 // version it upgrades.
 var upgrades = [...]upgradefunc{
-	v1Upgrade, // v0 => v1 adds a version key.
+	//v1Upgrade, // v0 => v1 adds a version key.
 }
 
 // DBVersion is the latest version of the database that is understood. Databases


### PR DESCRIPTION
It has become clear that there are going to be multiple client DB scheme changes prior to release.  Writing upgrades for each of these will be a waste of time since the software is still pre-release.

This reverts the bolt db to version 0.

When we decide the DB scheme is stable and ready for release, the v1 upgrade that sets the version key can simple be uncommented.  The v0 test data does not need to be updated.