### PR TITLE
client/asset: correct available and locked balance calculations

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -480,7 +480,7 @@ func (btc *ExchangeWallet) Balance() (*asset.Balance, error) {
 	}
 
 	return &asset.Balance{
-		Available: toSatoshi(balances.Mine.Trusted),
+		Available: toSatoshi(balances.Mine.Trusted) - locked,
 		Immature:  toSatoshi(balances.Mine.Immature + balances.Mine.Untrusted),
 		Locked:    locked,
 	}, err

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -358,8 +358,8 @@ func TestAvailableFund(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error for 1 utxo: %v", err)
 	}
-	if bal.Available != littleFunds {
-		t.Fatalf("expected available = %d for confirmed utxos, got %d", littleOrder, bal.Available)
+	if bal.Available != littleFunds-lockedVal {
+		t.Fatalf("expected available = %d for confirmed utxos, got %d", littleOrder-lockedVal, bal.Available)
 	}
 	if bal.Immature != 0 {
 		t.Fatalf("expected immature = 0, got %d", bal.Immature)
@@ -389,8 +389,8 @@ func TestAvailableFund(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error for 2 utxos: %v", err)
 	}
-	if bal.Available != littleFunds+lottaFunds {
-		t.Fatalf("expected available = %d for 2 outputs, got %d", littleFunds+lottaFunds, bal.Available)
+	if bal.Available != littleFunds+lottaFunds-lockedVal {
+		t.Fatalf("expected available = %d for 2 outputs, got %d", littleFunds+lottaFunds-lockedVal, bal.Available)
 	}
 	if bal.Immature != 0 {
 		t.Fatalf("expected immature = 0 for 2 outputs, got %d", bal.Immature)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -44,6 +45,8 @@ const (
 	// splitTxBaggage is the total number of additional bytes associated with
 	// using a split transaction to fund a swap.
 	splitTxBaggage = dexdcr.MsgTxOverhead + dexdcr.P2PKHInputSize + 2*dexdcr.P2PKHOutputSize
+	// Use RawRequest to unspent outputs in an account.
+	methodListUnspent = "listunspent"
 )
 
 var (
@@ -113,7 +116,6 @@ type rpcClient interface {
 	GetBlockVerbose(blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error)
 	GetRawMempool(txType chainjson.GetRawMempoolTxTypeCmd) ([]*chainhash.Hash, error)
 	GetRawTransactionVerbose(txHash *chainhash.Hash) (*chainjson.TxRawResult, error)
-	ListUnspentMin(minConf int) ([]walletjson.ListUnspentResult, error)
 	LockUnspent(unlock bool, ops []*wire.OutPoint) error
 	ListLockUnspent() ([]*wire.OutPoint, error)
 	GetRawChangeAddress(account string, net dcrutil.AddressParams) (dcrutil.Address, error)
@@ -124,6 +126,7 @@ type rpcClient interface {
 	WalletLock() error
 	WalletPassphrase(passphrase string, timeoutSecs int64) error
 	Disconnected() bool
+	RawRequest(method string, params []json.RawMessage) (json.RawMessage, error)
 }
 
 // outPoint is the hash and output index of a transaction output.
@@ -530,7 +533,7 @@ func (dcr *ExchangeWallet) FundOrder(value uint64, immediate bool, nfo *dex.Asse
 		return sum+toAtoms(unspent.rpc.Amount) >= reqFunds
 	}
 
-	coins, inputsSize, fundingCoins, err := dcr.fund(0, enough)
+	coins, inputsSize, fundingCoins, err := dcr.fund(enough)
 	if err != nil {
 		return nil, err
 	}
@@ -545,43 +548,35 @@ func (dcr *ExchangeWallet) FundOrder(value uint64, immediate bool, nfo *dex.Asse
 	return coins, nil
 }
 
-// unspents fetches unspent outputs for the ExchangeWallet account.
+// unspents fetches unspent outputs for the ExchangeWallet account using rpc
+// RawRequest.
 func (dcr *ExchangeWallet) unspents() ([]walletjson.ListUnspentResult, error) {
-	walletUnspents, err := dcr.node.ListUnspentMin(0)
-	if err != nil {
-		return nil, fmt.Errorf("ListUnspentMin error: %w", err)
-	}
-
-	// Filter out the unspents for other accounts.
 	var unspents []walletjson.ListUnspentResult
-	for _, unspent := range walletUnspents {
-		if unspent.Account != dcr.acct {
-			continue
-		}
-		unspents = append(unspents, unspent)
-	}
-	return unspents, nil
+	// minconf, maxconf (rpcdefault=9999999), [address], account
+	params := anylist{0, 9999999, nil, dcr.acct}
+	err := dcr.nodeRawRequest(methodListUnspent, params, &unspents)
+	return unspents, err
 }
 
 // fund finds coins for the specified value. A function is provided that can
 // check whether adding the provided output would be enough to satisfy the
-// needed value.
-func (dcr *ExchangeWallet) fund(confs uint32,
-	enough func(sum uint64, size uint32, unspent *compositeUTXO) bool) (asset.Coins, uint64, []*fundingCoin, error) {
+// needed value. Preference is given to selecting coins with 1 or more confs,
+// falling back to 0-conf coins where there are not enough 1+ confs coins.
+func (dcr *ExchangeWallet) fund(enough func(sum uint64, size uint32, unspent *compositeUTXO) bool) (asset.Coins, uint64, []*fundingCoin, error) {
 
 	unspents, err := dcr.unspents()
 	if err != nil {
 		return nil, 0, nil, err
 	}
+	if len(unspents) == 0 {
+		return nil, 0, nil, fmt.Errorf("insufficient funds. 0 DCR available in %q account", dcr.acct)
+	}
 
-	// Sort in ascending order by amount (smallest first).
-	sort.Slice(unspents, func(i, j int) bool { return unspents[i].Amount < unspents[j].Amount })
-	utxos, avail, err := dcr.spendableUTXOs(unspents, confs)
+	// Parse utxos to include script size for spending input.
+	// Returned utxos will be sorted in ascending order by amount (smallest first).
+	utxos, _, err := dcr.parseUTXOs(unspents)
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("error parsing unspent outputs: %v", err)
-	}
-	if len(utxos) == 0 {
-		return nil, 0, nil, fmt.Errorf("insufficient funds. %.8f available", float64(avail)/1e8)
 	}
 
 	var sum uint64
@@ -1521,37 +1516,38 @@ type compositeUTXO struct {
 	// TODO: consider including isDexChange bool for consumer
 }
 
-// spendableUTXOs filters the RPC utxos to those that are spendable according to
-// provided minimum confirmations. The UTXOs will be sorted by ascending value.
-func (dcr *ExchangeWallet) spendableUTXOs(unspents []walletjson.ListUnspentResult, confs uint32) ([]*compositeUTXO, uint64, error) {
+// parseUTXOs constructs and returns a list of compositeUTXOs from the provided
+// set of RPC utxos, including basic information required to spend each rpc utxo.
+// The returned list is sorted by ascending value.
+func (dcr *ExchangeWallet) parseUTXOs(unspents []walletjson.ListUnspentResult) ([]*compositeUTXO, uint64, error) {
 	var sum uint64
 	utxos := make([]*compositeUTXO, 0, len(unspents))
 	for _, txout := range unspents {
-		if txout.Confirmations >= int64(confs) {
-			scriptPK, err := hex.DecodeString(txout.ScriptPubKey)
-			if err != nil {
-				return nil, 0, fmt.Errorf("error decoding pubkey script for %s, script = %s: %v", txout.TxID, txout.ScriptPubKey, err)
-			}
-			redeemScript, err := hex.DecodeString(txout.RedeemScript)
-			if err != nil {
-				return nil, 0, fmt.Errorf("error decoding redeem script for %s, script = %s: %v", txout.TxID, txout.RedeemScript, err)
-			}
-
-			nfo, err := dexdcr.InputInfo(scriptPK, redeemScript, chainParams)
-			if err != nil {
-				if errors.Is(err, dex.UnsupportedScriptError) {
-					continue
-				}
-				return nil, 0, fmt.Errorf("error reading asset info: %v", err)
-			}
-			utxos = append(utxos, &compositeUTXO{
-				rpc:   txout,
-				input: nfo,
-				confs: txout.Confirmations,
-			})
-			sum += toAtoms(txout.Amount)
+		scriptPK, err := hex.DecodeString(txout.ScriptPubKey)
+		if err != nil {
+			return nil, 0, fmt.Errorf("error decoding pubkey script for %s, script = %s: %v", txout.TxID, txout.ScriptPubKey, err)
 		}
+		redeemScript, err := hex.DecodeString(txout.RedeemScript)
+		if err != nil {
+			return nil, 0, fmt.Errorf("error decoding redeem script for %s, script = %s: %v", txout.TxID, txout.RedeemScript, err)
+		}
+
+		nfo, err := dexdcr.InputInfo(scriptPK, redeemScript, chainParams)
+		if err != nil {
+			if errors.Is(err, dex.UnsupportedScriptError) {
+				continue
+			}
+			return nil, 0, fmt.Errorf("error reading asset info: %v", err)
+		}
+		utxos = append(utxos, &compositeUTXO{
+			rpc:   txout,
+			input: nfo,
+			confs: txout.Confirmations,
+		})
+		sum += toAtoms(txout.Amount)
 	}
+	// Sort in ascending order by amount (smallest first).
+	sort.Slice(utxos, func(i, j int) bool { return utxos[i].rpc.Amount < utxos[j].rpc.Amount })
 	return utxos, sum, nil
 }
 
@@ -1623,7 +1619,7 @@ func (dcr *ExchangeWallet) sendMinusFees(addr dcrutil.Address, val, feeRate uint
 	enough := func(sum uint64, size uint32, unspent *compositeUTXO) bool {
 		return sum+toAtoms(unspent.rpc.Amount) >= val
 	}
-	coins, _, _, err := dcr.fund(0, enough)
+	coins, _, _, err := dcr.fund(enough)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1638,7 +1634,7 @@ func (dcr *ExchangeWallet) sendRegFee(addr dcrutil.Address, regfee, netFeeRate u
 		txFee := uint64(size+unspent.input.Size()) * netFeeRate
 		return sum+toAtoms(unspent.rpc.Amount) >= regfee+txFee
 	}
-	coins, _, _, err := dcr.fund(0, enough)
+	coins, _, _, err := dcr.fund(enough)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1913,6 +1909,32 @@ func (dcr *ExchangeWallet) wireBytes(tx *wire.MsgTx) []byte {
 		dcr.log.Errorf("error serializing transaction: %v", err)
 	}
 	return s
+}
+
+// anylist is a list of RPC parameters to be converted to []json.RawMessage and
+// sent via nodeRawRequest.
+type anylist []interface{}
+
+// nodeRawRequest is used to  marshal parameters and send requests to the RPC
+// server via (*rpcclient.Client).RawRequest. If `thing` is non-nil, the result
+// will be marshaled into `thing`.
+func (dcr *ExchangeWallet) nodeRawRequest(method string, args anylist, thing interface{}) error {
+	params := make([]json.RawMessage, 0, len(args))
+	for i := range args {
+		p, err := json.Marshal(args[i])
+		if err != nil {
+			return err
+		}
+		params = append(params, p)
+	}
+	b, err := dcr.node.RawRequest(method, params)
+	if err != nil {
+		return fmt.Errorf("rawrequest error: %v", err)
+	}
+	if thing != nil {
+		return json.Unmarshal(b, thing)
+	}
+	return nil
 }
 
 // Convert the DCR value to atoms.

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -472,7 +472,7 @@ func (dcr *ExchangeWallet) Balance() (*asset.Balance, error) {
 		ab := &balances.Balances[i]
 		if ab.AccountName == dcr.acct {
 			acctFound = true
-			balance.Available = toAtoms(ab.Spendable)
+			balance.Available = toAtoms(ab.Spendable) - locked
 			balance.Immature = toAtoms(ab.ImmatureCoinbaseRewards) +
 				toAtoms(ab.ImmatureStakeGeneration)
 			balance.Locked = locked + toAtoms(ab.LockedByTickets)

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -352,8 +352,9 @@ func TestAvailableFund(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error for 1 utxo: %v", err)
 	}
-	if bal.Available != littleFunds {
-		t.Fatalf("expected available = %d for confirmed utxos, got %d", littleFunds, bal.Available)
+	// 1*tLotSize is locked, available balance should be total balance - locked
+	if bal.Available != littleFunds-tLotSize {
+		t.Fatalf("expected available = %d for confirmed utxos, got %d", littleFunds-tLotSize, bal.Available)
 	}
 	if bal.Immature != 0 {
 		t.Fatalf("expected immature = %d, got %d", 0, bal.Immature)
@@ -380,8 +381,9 @@ func TestAvailableFund(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error for 2 utxos: %v", err)
 	}
-	if bal.Available != littleFunds+lottaFunds {
-		t.Fatalf("expected available = %d for 2 outputs, got %d", littleFunds+lottaFunds, bal.Available)
+	// locked balance is still 1*tLotSize
+	if bal.Available != littleFunds+lottaFunds-tLotSize {
+		t.Fatalf("expected available = %d for 2 outputs, got %d", littleFunds+lottaFunds-tLotSize, bal.Available)
 	}
 	if bal.Immature != 0 {
 		t.Fatalf("expected unconf = 0 for 2 outputs, got %d", bal.Immature)

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -107,6 +107,9 @@ func newTxOutResult(script []byte, value uint64, confs int64) *chainjson.GetTxOu
 func tNewWallet() (*ExchangeWallet, *tRPCClient, func()) {
 	client := newTRPCClient()
 	walletCfg := &asset.WalletConfig{
+		Settings: map[string]string{
+			"account": "default",
+		},
 		TipChange: func(error) {},
 	}
 	walletCtx, shutdown := context.WithCancel(tCtx)
@@ -152,8 +155,8 @@ type tRPCClient struct {
 	verboseBlocks   map[string]*chainjson.GetBlockVerboseResult
 	mainchain       map[int64]*chainhash.Hash
 	bestHash        chainhash.Hash
-	lluCoins        []*wire.OutPoint // Returned from ListLockUnspent
-	lockedCoins     []*wire.OutPoint // Last submitted to LockUnspent
+	lluCoins        []walletjson.ListUnspentResult // Returned from ListLockUnspent
+	lockedCoins     []*wire.OutPoint               // Last submitted to LockUnspent
 	listLockedErr   error
 }
 
@@ -240,10 +243,6 @@ func (c *tRPCClient) LockUnspent(unlock bool, ops []*wire.OutPoint) error {
 	return c.lockUnspentErr
 }
 
-func (c *tRPCClient) ListLockUnspent() ([]*wire.OutPoint, error) {
-	return c.lluCoins, c.listLockedErr
-}
-
 func (c *tRPCClient) GetRawChangeAddress(account string, net dcrutil.AddressParams) (dcrutil.Address, error) {
 	return c.changeAddr, c.changeAddrErr
 }
@@ -282,20 +281,46 @@ func (c *tRPCClient) RawRequest(method string, params []json.RawMessage) (json.R
 		if c.unspentErr != nil {
 			return nil, c.unspentErr
 		}
-		var unspents []walletjson.ListUnspentResult
-		if len(params) < 4 {
-			// no acct param, return all unspent
-			unspents = c.unspent
-		} else {
-			var acct string
+
+		var acct string
+		if len(params) > 3 {
+			// filter with provided acct param
 			_ = json.Unmarshal(params[3], &acct)
-			for _, unspent := range c.unspent {
-				if unspent.Account == acct {
-					unspents = append(unspents, unspent)
-				}
+		}
+		allAccts := acct == "" || acct == "*"
+
+		var unspents []walletjson.ListUnspentResult
+		for _, unspent := range c.unspent {
+			if allAccts || unspent.Account == acct {
+				unspents = append(unspents, unspent)
 			}
 		}
 		response, _ := json.Marshal(unspents)
+		return response, nil
+
+	case methodListLockUnspent:
+		if c.listLockedErr != nil {
+			return nil, c.listLockedErr
+		}
+
+		var acct string
+		if len(params) > 0 {
+			_ = json.Unmarshal(params[0], &acct)
+		}
+		allAccts := acct == "" || acct == "*"
+
+		var locked []chainjson.TransactionInput
+		for _, utxo := range c.lluCoins {
+			if allAccts || utxo.Account == acct {
+				locked = append(locked, chainjson.TransactionInput{
+					Txid:   utxo.TxID,
+					Amount: utxo.Amount,
+					Vout:   utxo.Vout,
+					Tree:   utxo.Tree,
+				})
+			}
+		}
+		response, _ := json.Marshal(locked)
 		return response, nil
 	}
 	return c.rawRes[method], c.rawErr[method]
@@ -345,72 +370,82 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("expected unconf = 0, got %d", bal.Immature)
 	}
 
+	var vout uint32
+	addUtxo := func(atomAmt uint64, confs int64, lock bool) {
+		utxo := walletjson.ListUnspentResult{
+			TxID:          tTxID,
+			Vout:          vout,
+			Address:       tPKHAddr.String(),
+			Account:       wallet.acct,
+			Amount:        float64(atomAmt) / 1e8,
+			Confirmations: confs,
+			ScriptPubKey:  hex.EncodeToString(tP2PKHScript),
+		}
+		if lock {
+			node.lluCoins = append(node.lluCoins, utxo)
+		} else {
+			unspents = append(unspents, utxo)
+			node.unspent = unspents
+		}
+		// update balance
+		balanceResult.Balances[0].Spendable += utxo.Amount
+		vout++
+	}
+
+	// Add 1 unspent output and check balance
 	littleOrder := tLotSize * 6
 	littleFunds := calc.RequiredOrderFunds(littleOrder, dexdcr.P2PKHInputSize, tDCR)
-	littleUTXO := walletjson.ListUnspentResult{
-		TxID:          tTxID,
-		Address:       tPKHAddr.String(),
-		Amount:        float64(littleFunds) / 1e8,
-		Confirmations: 0,
-		ScriptPubKey:  hex.EncodeToString(tP2PKHScript),
-	}
-	node.unspent = []walletjson.ListUnspentResult{littleUTXO}
-
-	balanceResult = &walletjson.GetBalanceResult{
-		Balances: []walletjson.GetAccountBalanceResult{
-			{
-				AccountName: wallet.acct,
-				Spendable:   float64(littleFunds) / 1e8,
-			},
-		},
-	}
-	node.balanceResult = balanceResult
-	node.lluCoins = []*wire.OutPoint{
-		{
-			Hash: *tTxHash,
-		},
-	}
-	node.txOutRes[newOutPoint(tTxHash, 0)] = makeGetTxOutRes(1, 1, tP2PKHScript)
-
+	addUtxo(littleFunds, 0, false)
 	bal, err = wallet.Balance()
 	if err != nil {
 		t.Fatalf("error for 1 utxo: %v", err)
 	}
-	// 1*tLotSize is locked, available balance should be total balance - locked
-	if bal.Available != littleFunds-tLotSize {
-		t.Fatalf("expected available = %d for confirmed utxos, got %d", littleFunds-tLotSize, bal.Available)
+	if bal.Available != littleFunds {
+		t.Fatalf("expected available = %d for confirmed utxos, got %d", littleFunds, bal.Available)
 	}
 	if bal.Immature != 0 {
 		t.Fatalf("expected immature = %d, got %d", 0, bal.Immature)
 	}
-	if bal.Locked != tLotSize {
-		t.Fatalf("expected locked = %d, got %d", tLotSize, bal.Locked)
+	if bal.Locked != 0 {
+		t.Fatalf("expected locked = %d, got %d", 0, bal.Locked)
 	}
 
-	lottaOrder := tLotSize * 100
-	// Add funding for an extra input to accommodate the later combined tests.
-	lottaFunds := calc.RequiredOrderFunds(lottaOrder, 2*dexdcr.P2PKHInputSize, tDCR)
-	balanceResult.Balances[0].Spendable += float64(lottaFunds) / 1e8
-	lottaUTXO := walletjson.ListUnspentResult{
-		TxID:          tTxID,
-		Address:       tPKHAddr.String(),
-		Amount:        float64(lottaFunds) / 1e8,
-		Confirmations: 1,
-		Vout:          1,
-		ScriptPubKey:  hex.EncodeToString(tP2PKHScript),
-	}
-	unspents = []walletjson.ListUnspentResult{littleUTXO, lottaUTXO}
-	node.unspent = unspents
+	// Add a second utxo, lock it and check balance.
+	lockedBit := tLotSize * 2
+	addUtxo(lockedBit, 1, true)
 	bal, err = wallet.Balance()
 	if err != nil {
 		t.Fatalf("error for 2 utxos: %v", err)
 	}
-	// locked balance is still 1*tLotSize
-	if bal.Available != littleFunds+lottaFunds-tLotSize {
-		t.Fatalf("expected available = %d for 2 outputs, got %d", littleFunds+lottaFunds-tLotSize, bal.Available)
+	// Available balance should exclude locked utxo amount.
+	if bal.Available != littleFunds {
+		t.Fatalf("expected available = %d for confirmed utxos, got %d", littleFunds, bal.Available)
+	}
+	if bal.Immature != 0 {
+		t.Fatalf("expected immature = %d, got %d", 0, bal.Immature)
+	}
+	if bal.Locked != lockedBit {
+		t.Fatalf("expected locked = %d, got %d", lockedBit, bal.Locked)
+	}
+
+	// Add a third utxo.
+	lottaOrder := tLotSize * 100
+	// Add funding for an extra input to accommodate the later combined tests.
+	lottaFunds := calc.RequiredOrderFunds(lottaOrder, 2*dexdcr.P2PKHInputSize, tDCR)
+	addUtxo(lottaFunds, 1, false)
+	bal, err = wallet.Balance()
+	if err != nil {
+		t.Fatalf("error for 3 utxos: %v", err)
+	}
+	if bal.Available != littleFunds+lottaFunds {
+		t.Fatalf("expected available = %d for 2 outputs, got %d", littleFunds+lottaFunds, bal.Available)
 	}
 	if bal.Immature != 0 {
 		t.Fatalf("expected unconf = 0 for 2 outputs, got %d", bal.Immature)
+	}
+	// locked balance should remain same as utxo2 amount.
+	if bal.Locked != lockedBit {
+		t.Fatalf("expected locked = %d, got %d", lockedBit, bal.Locked)
 	}
 
 	// Zero value
@@ -443,7 +478,8 @@ func TestAvailableFund(t *testing.T) {
 	}
 	node.lockUnspentErr = nil
 
-	// Fund a little bit.
+	// Fund littleOrder, littleFunds should be sufficient but is unconfirmed,
+	// so lottaFunds should be selected.
 	spendables, err := wallet.FundOrder(littleOrder, false, tDCR)
 	if err != nil {
 		t.Fatalf("error funding small amount: %v", err)
@@ -458,7 +494,6 @@ func TestAvailableFund(t *testing.T) {
 
 	// Now confirm the little bit and have it selected.
 	unspents[0].Confirmations++
-	littleUTXO.Confirmations++ // for consistency (no indirection from unspents)
 	spendables, err = wallet.FundOrder(littleOrder, false, tDCR)
 	if err != nil {
 		t.Fatalf("error funding small amount: %v", err)
@@ -485,14 +520,12 @@ func TestAvailableFund(t *testing.T) {
 	}
 
 	// Not enough to cover transaction fees.
-	littleUTXO.Amount -= 1e-7
-	node.unspent = []walletjson.ListUnspentResult{littleUTXO, lottaUTXO}
+	node.unspent[0].Amount -= 1e-7
 	_, err = wallet.FundOrder(lottaOrder+littleOrder, false, tDCR)
 	if err == nil {
 		t.Fatalf("no error when not enough to cover tx fees")
 	}
-	littleUTXO.Amount += 1e-7
-	node.unspent = []walletjson.ListUnspentResult{littleUTXO, lottaUTXO}
+	node.unspent[0].Amount += 1e-7
 
 	// Prepare for a split transaction.
 	baggageFees := tDCR.MaxFeeRate * splitTxBaggage
@@ -520,8 +553,7 @@ func TestAvailableFund(t *testing.T) {
 	}
 
 	// With a little more locked, the split should be performed.
-	lottaUTXO.Amount += float64(baggageFees) / 1e8
-	node.unspent = []walletjson.ListUnspentResult{littleUTXO, lottaUTXO}
+	node.unspent[1].Amount += float64(baggageFees) / 1e8
 	coins, err = wallet.FundOrder(extraLottaOrder, false, tDCR)
 	if err != nil {
 		t.Fatalf("error for split tx: %v", err)
@@ -560,13 +592,22 @@ func TestAvailableFund(t *testing.T) {
 	}
 
 	// Not enough funds, because littleUnspent is a different account.
-	littleUTXO.Account = "wrong account" // for consistency
-	node.unspent = []walletjson.ListUnspentResult{littleUTXO, lottaUTXO}
+	node.unspent[0].Account = "wrong account" // littleUTXO
 	_, err = wallet.FundOrder(extraLottaOrder, false, tDCR)
 	if err == nil {
 		t.Fatalf("no error for wrong account")
 	}
-	littleUTXO.Account = ""
+	node.unspent[0].Account = wallet.acct
+
+	// Place locked utxo in different account, check locked balance.
+	node.lluCoins[0].Account = "wrong account"
+	bal, err = wallet.Balance()
+	if err != nil {
+		t.Fatalf("error for 3 utxos, with locked utxo in wrong acct: %v", err)
+	}
+	if bal.Locked != 0 {
+		t.Fatalf("expected locked = %d, got %d", 0, bal.Locked)
+	}
 }
 
 // Since ReturnCoins takes the wallet.Coin interface, make sure any interface
@@ -646,6 +687,7 @@ func TestFundingCoins(t *testing.T) {
 		TxID:    tTxID,
 		Vout:    vout,
 		Address: tPKHAddr.String(),
+		Account: wallet.acct,
 	}
 
 	node.unspent = []walletjson.ListUnspentResult{p2pkhUnspent}
@@ -722,6 +764,7 @@ func TestFundEdges(t *testing.T) {
 	p2pkhUnspent := walletjson.ListUnspentResult{
 		TxID:          tTxID,
 		Address:       tPKHAddr.String(),
+		Account:       wallet.acct,
 		Amount:        float64(swapVal+fees-1) / 1e8, // one atom less than needed
 		Confirmations: 5,
 		ScriptPubKey:  hex.EncodeToString(tP2PKHScript),
@@ -1383,6 +1426,7 @@ func testSender(t *testing.T, senderType tSenderType) {
 	node.unspent = []walletjson.ListUnspentResult{{
 		TxID:          tTxID,
 		Address:       tPKHAddr.String(),
+		Account:       wallet.acct,
 		Amount:        float64(unspentVal) / 1e8,
 		Confirmations: 5,
 		ScriptPubKey:  hex.EncodeToString(tP2PKHScript),


### PR DESCRIPTION
Recent testing with the simnet trade harness uncovered this bug with balance reporting.
- Available balance should exclude locked balance.
- Restrict locked balance for dcr to the configured account, to match available balance reporting that uses configured account's available balance rather than the entire wallet's available balance.

dcr wallet's `listlockedunspent` was previously found to sometimes return spent outputs, which causes the calculated locked balance amount to be higher than it actually is (see #453). This has been fixed in https://github.com/decred/dcrwallet/pull/1753, ensuring that `listlockedunspent` only returns unspent outputs. Thus, the locked balance calculation in `dcr.lockedAtoms()` now fully relies on the results of the `listlockedunspent` cmd to determine locked unspent outputs, instead of cross-checking the returned results against the `dcr.fundingCoins` map and the `gettxout` rpc.

The `confs` arg is also removed from the `dcr.fund` method as it was pretty much made obsolete when the fundConf requirement was eliminated in #499. The method's doc is updated to indicate that utxos with 1+ confs are given preference when selecting new tx inputs, and unconfirmed utxos are included in the selection if confirmed utxos are insufficient.