### PR TITLE
dex/ws: tests, Close control prior to disconnect, queue cap limit

### DIFF
--- a/dex/ws/wslink_test.go
+++ b/dex/ws/wslink_test.go
@@ -1,0 +1,199 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package ws
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex/msgjson"
+	"github.com/decred/slog"
+	"github.com/gorilla/websocket"
+)
+
+type ConnStub struct {
+	inMsg  chan []byte
+	inErr  chan error
+	closed int32
+}
+
+func (c *ConnStub) Close() error {
+	// make ReadMessage return with a close error
+	atomic.StoreInt32(&c.closed, 1)
+	c.inErr <- &websocket.CloseError{
+		Code: websocket.CloseNormalClosure,
+		Text: "bye",
+	}
+	return nil
+}
+func (c *ConnStub) SetReadDeadline(t time.Time) error {
+	return nil
+}
+func (c *ConnStub) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+func (c *ConnStub) ReadMessage() (int, []byte, error) {
+	if atomic.LoadInt32(&c.closed) == 1 {
+		return 0, nil, &websocket.CloseError{
+			Code: websocket.CloseAbnormalClosure,
+			Text: io.ErrUnexpectedEOF.Error(),
+		}
+	}
+	select {
+	case msg := <-c.inMsg:
+		return len(msg), msg, nil
+	case err := <-c.inErr:
+		return 0, nil, err
+	}
+}
+
+const (
+	stdDev = 500.0
+	min    = int64(50)
+)
+
+func microSecDelay(stdDev float64, min int64) time.Duration {
+	return time.Microsecond * time.Duration(int64(stdDev*math.Abs(rand.NormFloat64()))+min)
+}
+
+var lastID int64 = -1 // first msg.ID should be 0
+
+func (c *ConnStub) WriteMessage(_ int, b []byte) error {
+	if atomic.LoadInt32(&c.closed) == 1 {
+		return websocket.ErrCloseSent
+	}
+	msg, err := msgjson.DecodeMessage(b)
+	if err != nil {
+		return err
+	}
+	if msg.ID != uint64(lastID+1) {
+		return fmt.Errorf("sent out of sequence. got %d, want %v", msg.ID, uint64(lastID+1))
+	}
+	lastID++
+	//writeDuration := time.Microsecond * time.Duration(1+rand.Int63n(40000))
+	writeDuration := microSecDelay(stdDev, min)
+	//fmt.Printf(" <ConnStub> writing message in %v: %v\n", writeDuration, string(b))
+	time.Sleep(writeDuration)
+	return nil
+}
+func (c *ConnStub) WriteControl(messageType int, data []byte, deadline time.Time) error {
+	switch messageType {
+	case websocket.PingMessage:
+		fmt.Println(" <ConnStub> ping sent to peer")
+	case websocket.TextMessage:
+		fmt.Println(" <ConnStub> message sent to peer:", string(data))
+	case websocket.CloseMessage:
+		fmt.Println(" <ConnStub> close control frame sent to peer")
+	default:
+		fmt.Printf(" <ConnStub> message type %d sent to peer\n", messageType)
+	}
+	return nil
+}
+
+func TestWSLink_send(t *testing.T) {
+	//rand.Seed(int64(time.Now().Nanosecond()))
+	backendLogger := slog.NewBackend(os.Stdout)
+	defer os.Stdout.Sync()
+	log := backendLogger.Logger("ws_TEST")
+	log.SetLevel(slog.LevelTrace)
+	UseLogger(log)
+
+	inMsgHandler := func(msg *msgjson.Message) *msgjson.Error {
+		return nil
+	}
+
+	conn := &ConnStub{
+		inMsg: make(chan []byte, 1),
+		inErr: make(chan error, 1),
+	}
+	wsLink := NewWSLink("127.0.0.1", conn, time.Second, inMsgHandler)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// start the in/out/pingHandlers, and the initial read deadline
+	wg, err := wsLink.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	defer wg.Wait()
+
+	// hit the inHandler once before testing sends
+	msg, _ := msgjson.NewRequest(12, "beep", "boop")
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.inMsg <- b
+
+	// sends
+	stuff := struct {
+		Thing int    `json:"thing"`
+		Blah  string `json:"stuff"`
+	}{
+		12, "asdf",
+	}
+	msg, _ = msgjson.NewNotification("blah", stuff)
+
+	err = wsLink.SendNow(msg)
+	if err != nil {
+		t.Error(err)
+	}
+	msg.ID++ // not normally used for ntfns, just in this test
+
+	// slightly slower than send rate, bouncing off of 0 queue length
+	sendStdDev := stdDev * 20 / 19
+	sendMin := min
+
+	sendCount := 10000
+	if testing.Short() {
+		sendCount = 1000
+	}
+	t.Logf("Sending %v messages at the same average rate as write latency.", sendCount)
+	for i := 0; i < sendCount; i++ {
+		err = wsLink.Send(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg.ID++
+		time.Sleep(microSecDelay(sendStdDev, sendMin))
+	}
+
+	// send much faster briefly, building queue up a bit to be drained on disconnect
+	sendStdDev = stdDev * 4 / 5
+	sendMin = min / 2
+	t.Logf("Sending %v messages faster than the average write latency.", sendCount)
+	for i := 0; i < sendCount; i++ {
+		err = wsLink.Send(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		msg.ID++
+		time.Sleep(microSecDelay(sendStdDev, sendMin))
+	}
+
+	// This message may be sent by the main write loop in (*WSLink).outHandler,
+	// or in the deferred drain/send of queued messages.
+	// err = wsLink.Send(msg)
+	// if err != nil {
+	// 	t.Error(err)
+	// }
+
+	wsLink.Disconnect()
+
+	// Make like a good connection manager and wait for the wsLink to shutdown.
+	wg.Wait()
+
+	if lastID != int64(msg.ID-1) {
+		t.Errorf("final message %d not sent, last ID is %d", msg.ID-1, lastID)
+	}
+}


### PR DESCRIPTION
The added test provides come coverage for the `dex/ws` package and
exercises the `dex/ws.WSLink` type, especially the `outHandler` method.
One test causes the queue to bounce off zero while writing at the same
rate as `Send`ing/queueing. The following test queues more quickly than
the write rate, causing the queue to grow, reallocate, and drain on
disconnect.

`(*WSLink).outHandler` now remembers a write error and prevents further
write attempts of queued message as they will just fail, instead sending
an immediate error reply to the `Send`/`SendNow` caller.

`(*WSLink).outHandler` now writes a Close (1000) control message before
closing the underlying `net.Conn`, but only if there were no prior write
errors that would make the `WriteControl` fail.

`(*WSLink).outHandler` now limits the capacity of the outgoing message
queue.  If the capacity exceeds at certain threshold, the `WSLink` is
stopped and queued messages are sent before disconnect.  This is to
prevent pathological states with either client or server from eating too
much memory or cpu when shifting the queue.