### PR TITLE
app: fix markets view layout issues

### DIFF
--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -59,7 +59,7 @@ func randomMagnitude(low, high int) float64 {
 }
 
 func userOrders() (ords []*core.Order) {
-	orderCount := rand.Intn(5)
+	orderCount := rand.Intn(50)
 	for i := 0; i < orderCount; i++ {
 		qty := uint64(randomMagnitude(7, 11))
 		filled := uint64(rand.Float64() * float64(qty))
@@ -85,7 +85,7 @@ func userOrders() (ords []*core.Order) {
 			Stamp:  encode.UnixMilliU(time.Now()) - uint64(rand.Float64()*600_000),
 			Status: status,
 			Epoch:  epoch,
-			Rate:   uint64(randomMagnitude(-2, 4)),
+			Rate:   uint64(randomMagnitude(4, 12)),
 			Qty:    qty,
 			Sell:   rand.Intn(2) > 0,
 			Filled: filled,

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -152,6 +152,26 @@ input[type=number] {
   right: 0;
 }
 
+.stylish-overflow {
+  overflow: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #7774 #7771;
+
+  /* Works on Chrome/Edge/Safari */
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #7771;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: #7774;
+    border-radius: 4px;
+  }
+}
+
 div.note-indicator {
   width: 8px;
   height: 8px;

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -49,7 +49,7 @@ div.settingsforms {
 #marketChart {
   position: relative;
   background-color: white;
-  height: 250px;
+  height: 40%;
   border-bottom: 1px solid #626262;
 }
 
@@ -64,9 +64,16 @@ div.settingsforms {
   font-size: 40px;
 }
 
+#chartResizer {
+  position: absolute;
+  bottom: 0;
+  height: 6px;
+  width: 100%;
+  z-index: 2;
+  cursor: ns-resize;
+}
+
 .marketorders {
-  display: block;
-  min-height: 375px;
   overflow: hidden;
 }
 
@@ -325,6 +332,7 @@ table.balance-table button:hover {
   th,
   td {
     padding: 2px 10px;
+    white-space: nowrap;
   }
 
   .ico-cross {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=MQq4VTue">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=XBPSS" rel="stylesheet">
+  <link href="/css/style.css?v=wXhBeQ" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="poke-note px-2 fs14 d-flex align-items-center" id="pokeNote"><span>Here is a poke note.</span></div>
@@ -61,7 +61,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=oqf4n"></script>
+<script src="/js/entry.js?v=7FkTMQ"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -285,7 +285,7 @@
         <div class="market-header text-center fs14 py-1 brdrleft">Your Orders</div>
         <div class="brdrleft flex-grow-1 bg1 position-relative">
 
-          <div class="fill-abs px-4 stylish-overflow">
+          <div class="fill-abs stylish-overflow">
             <table id="liveTable" class="ordertable">
               <thead>
                 <tr>

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -36,280 +36,287 @@
   </div>
 
   {{- /* RIGHT COLUMN */ -}}
-  <div class="d-flex flex-column flex-grow-1">
+  <div id="rightSide" class="d-flex flex-column flex-grow-1">
 
     {{- /* CHART */ -}}
+
     <div id="marketChart" class="w-100">
       <div id="marketLoader" class="fill-abs flex-center">
         <div class="ico-spinner spinner"></div>
 
       </div>
+      <div id="chartResizer"></div>
     </div>
 
     {{- /* ORDERS */ -}}
-    <div id="orders" class="overflow-auto w-100 d-flex flex-grow-1 bg1">
+    <div id="orders" class="w-100 d-flex flex-grow-1 bg1">
 
-      <div class="col-14 d-flex justify-content-around align-items-stretch p-0">
+      <div class="col-14 p-0">
+        <div class="fill-abs d-flex justify-content-around align-items-stretch">
 
-        {{- /* BUY ORDER LIST */ -}}
-        <div class="marketorders col-7 p-0 bg1">
-          <div class="market-header text-center fs14 py-1">Buy Orders</div>
-          <table class="ordertable bg0">
-            {{block "thead" .}}
-            <thead>
-              <tr>
-                <th class="text-left pl-2">Quantity</th>
-                <th class="text-right pr-2">Rate</th>
-                <th class="text-right pr-2">Epoch</th>
-              </tr>
-            </thead>
-            {{end}}
-            <tbody id="buyRows">
-              {{- /* This row is used by the app as a template. */ -}}
-              <tr id="rowTemplate">
-                <td class="text-left pl-2" data-type="qty">-</td>
-                <td class="text-right pr-2" data-type="rate">-</td>
-                <td class="text-right pr-3" data-type="epoch"></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        {{- /* ORDER PANEL */ -}}
-        <div class="col-10 p-0 brdrleft brdrright">
-          <div class="market-header fs14 d-flex justify-content-start pl-4 align-items-stretch">
-            <button id="limitBttn" type="button" class="flex-center px-3 py-0 markettab brdrleft selected">Limit Order</button>
-            <button id="marketBttn" type="button" class="flex-center px-3 py-0 markettab brdrleft brdrright">Market Order</button>
+          {{- /* BUY ORDER LIST */ -}}
+          <div class="marketorders col-7 p-0 bg1">
+            <div class="market-header text-center fs14 py-1">Buy Orders</div>
+            <table class="ordertable bg0">
+              {{block "thead" .}}
+              <thead>
+                <tr>
+                  <th class="text-left pl-2">Quantity</th>
+                  <th class="text-right pr-2">Rate</th>
+                  <th class="text-right pr-2">Epoch</th>
+                </tr>
+              </thead>
+              {{end}}
+              <tbody id="buyRows">
+                {{- /* This row is used by the app as a template. */ -}}
+                <tr id="rowTemplate">
+                  <td class="text-left pl-2" data-type="qty">-</td>
+                  <td class="text-right pr-2" data-type="rate">-</td>
+                  <td class="text-right pr-3" data-type="epoch"></td>
+                </tr>
+              </tbody>
+            </table>
           </div>
 
-          <div class="px-4">
-
-            <div class="fs15 pt-3 text-center d-hide" id="loaderMsg"></div>
-            
-            {{- /* REGISTRATION STATUS */ -}}
-            <div class="d-hide p-2 mt-2" id="registrationStatus">
-              <div class="p-0 w-100">
-                <div class="d-flex flex-column justify-content-center align-items-center">
-                  <span id="regStatusTitle" class="title"></span>
-                  <p id="regStatusMessage">In order to trade at <span id="regStatusDex"></span>, the registration fee payment
-                    needs <span id="confReq"></span> confirmations.
-                  </p>
-                  <span id="regStatusConfsDisplay"></span>
-                </div>
-              </div>
+          {{- /* ORDER PANEL */ -}}
+          <div class="col-10 p-0 brdrleft brdrright d-flex flex-column">
+            <div class="market-header fs14 d-flex justify-content-start pl-4 align-items-stretch">
+              <button id="limitBttn" type="button" class="flex-center px-3 py-0 markettab brdrleft selected">Limit Order</button>
+              <button id="marketBttn" type="button" class="flex-center px-3 py-0 markettab brdrleft brdrright">Market Order</button>
             </div>
 
-            {{- /* ORDER FORM */ -}}
-            <form id="orderForm" class="bg1">
-              <div class="p-0 w-100">
+            <div class="flex-grow-1 position-relative">
+              <div class="fill-abs px-4 stylish-overflow">
 
-                {{- /* BUY - SELL SELECTOR */ -}}
-                <div class="d-flex justify-content-start pt-4 pb-2 fs14">
-                  <button id="buyBttn" type="button" class="bg2 selected">
-                    Buy
-                    <span data-unit="base"></span>
-                  </button>
-                  <button id="sellBttn" type="button" class="bg2 ml-2">
-                    Sell
-                    <span data-unit="base"></span>
-                  </button>
-                  <span></span>
-                </div>
+                <div class="fs15 pt-3 text-center d-hide" id="loaderMsg"></div>
 
-                {{- /* MARKET CONFIG */ -}}
-                <div class="d-flex justify-content-between my-2 fs14">
-                  <div>
-                    Lot Size:
-                    <span id="lotSize"></span>
-                    <span data-unit="base"></span>
-                  </div>
-                  <div>
-                    Rate Step:
-                    <span id="rateStep"></span>
-                    <span data-unit="quote"></span>
-                  </div>
-                </div>
-
-                {{- /* RATE AND QUANTITY INPUTS */ -}}
-                <div class="d-flex mt-3" id="priceBox">
-                  <label for="rateField" class="col-6 d-flex align-items-center p-0">Price</label>
-                  <div class="col-18 p-0 position-relative">
-                    <input type="number" class="form-control select bg1" id="rateField">
-                    <span class="unitbox"><span class="unit" data-unit="quote"></span>/<span class="unit" data-unit="base"></span></span>
-                  </div>
-                </div>
-                <div class="d-flex mt-4" id="qtyBox">
-                  <label for="qtyField" class="col-6 d-flex align-items-center p-0">Quantity</label>
-                  <div class="col-6 p-0 position-relative">
-                    <input type="number" class="form-control select bg1" id="lotField">
-                    <span class="unit unitbox">Lots</span>
-                  </div>
-                  <div class="col-1 p-0"></div> {{/* spacer */}}
-                  <div class="col-11 p-0">
-                    <input type="number" class="form-control select bg1" id="qtyField">
-                    <span class="unit unitbox" data-unit="base"></span>
-                  </div>
-                </div>
-
-                {{- /* MARKET BUY ORDER QUANTITY INPUT */ -}}
-                <div id="mktBuyBox" class="d-hide">
-                  <div class="text-center mt-2 fs15">
-                    min trade is about <span id="minMktBuy"></span> <span data-unit="quote"></span>
-                  </div>
-                  <div class="d-flex justify-content-center mt-2">
-                    <!-- <label for="mktBuyField" class="flex-center col-12 p-0">Trading</label> -->
-                    <div class="col-12 p-0 position-relative">
-                      <input type="number" class="form-control select bg1" id="mktBuyField">
-                      <span class="unit unitbox" data-unit="quote"></span>
+                {{- /* REGISTRATION STATUS */ -}}
+                <div class="d-hide p-2 mt-2" id="registrationStatus">
+                  <div class="p-0 w-100">
+                    <div class="d-flex flex-column justify-content-center align-items-center">
+                      <span id="regStatusTitle" class="title"></span>
+                      <p id="regStatusMessage">In order to trade at <span id="regStatusDex"></span>, the registration fee payment
+                        needs <span id="confReq"></span> confirmations.
+                      </p>
+                      <span id="regStatusConfsDisplay"></span>
                     </div>
                   </div>
-                  <div class="p-0 fs14 flex-center mt-1">
-                    <span>
-                      ~ <span id="mktBuyScore">0</span> <span data-unit="base"></span>
-                      @ <span id="mktBuyLots">0</span> <span >Lots</span><br>
+                </div>
 
-                    </span>
+                {{- /* ORDER FORM */ -}}
+                <form id="orderForm" class="bg1">
+                  <div class="p-0 w-100">
+
+                    {{- /* BUY - SELL SELECTOR */ -}}
+                    <div class="d-flex justify-content-start pt-4 pb-2 fs14">
+                      <button id="buyBttn" type="button" class="bg2 selected">
+                        Buy
+                        <span data-unit="base"></span>
+                      </button>
+                      <button id="sellBttn" type="button" class="bg2 ml-2">
+                        Sell
+                        <span data-unit="base"></span>
+                      </button>
+                      <span></span>
+                    </div>
+
+                    {{- /* MARKET CONFIG */ -}}
+                    <div class="d-flex justify-content-between my-2 fs14">
+                      <div>
+                        Lot Size:
+                        <span id="lotSize"></span>
+                        <span data-unit="base"></span>
+                      </div>
+                      <div>
+                        Rate Step:
+                        <span id="rateStep"></span>
+                        <span data-unit="quote"></span>
+                      </div>
+                    </div>
+
+                    {{- /* RATE AND QUANTITY INPUTS */ -}}
+                    <div class="d-flex mt-3" id="priceBox">
+                      <label for="rateField" class="col-6 d-flex align-items-center p-0">Price</label>
+                      <div class="col-18 p-0 position-relative">
+                        <input type="number" class="form-control select bg1" id="rateField">
+                        <span class="unitbox"><span class="unit" data-unit="quote"></span>/<span class="unit" data-unit="base"></span></span>
+                      </div>
+                    </div>
+                    <div class="d-flex mt-4" id="qtyBox">
+                      <label for="qtyField" class="col-6 d-flex align-items-center p-0">Quantity</label>
+                      <div class="col-6 p-0 position-relative">
+                        <input type="number" class="form-control select bg1" id="lotField">
+                        <span class="unit unitbox">Lots</span>
+                      </div>
+                      <div class="col-1 p-0"></div> {{/* spacer */}}
+                      <div class="col-11 p-0">
+                        <input type="number" class="form-control select bg1" id="qtyField">
+                        <span class="unit unitbox" data-unit="base"></span>
+                      </div>
+                    </div>
+
+                    {{- /* MARKET BUY ORDER QUANTITY INPUT */ -}}
+                    <div id="mktBuyBox" class="d-hide">
+                      <div class="text-center mt-2 fs15">
+                        min trade is about <span id="minMktBuy"></span> <span data-unit="quote"></span>
+                      </div>
+                      <div class="d-flex justify-content-center mt-2">
+                        <!-- <label for="mktBuyField" class="flex-center col-12 p-0">Trading</label> -->
+                        <div class="col-12 p-0 position-relative">
+                          <input type="number" class="form-control select bg1" id="mktBuyField">
+                          <span class="unit unitbox" data-unit="quote"></span>
+                        </div>
+                      </div>
+                      <div class="p-0 fs14 flex-center mt-1">
+                        <span>
+                          ~ <span id="mktBuyScore">0</span> <span data-unit="base"></span>
+                          @ <span id="mktBuyLots">0</span> <span >Lots</span><br>
+
+                        </span>
+                      </div>
+                    </div>
+
+                    {{- /* ORDER PREVIEW */ -}}
+                    <div class="mt-2 fs14 text-right" id="orderPreview"></div>
+
+                    {{- /* TIME-IN-FORCE CHECK BOX */ -}}
+                    <div class="mt-2 text-left pl-4" id="tifBox">
+                      <input id="tifNow" class="form-check-input" type="checkbox" value="">
+                      <label class="form-check-label" for="tifNow">
+                        Match for one epoch only
+                      </label>
+                    </div>
+
+                    {{- /* SUBMIT ORDER BUTTON */ -}}
+                    <div class="text-right">
+                      <button id="submitBttn" type="button" class="my-1 fs14 submit text-center">Submit Order</button>
+                    </div>
                   </div>
-                </div>
+                  <div class="fs15 pt-3 text-center d-hide errcolor" id="orderErr"></div>
+                </form>
 
-                {{- /* ORDER PREVIEW */ -}}
-                <div class="mt-2 fs14 text-right" id="orderPreview"></div>
-
-                {{- /* TIME-IN-FORCE CHECK BOX */ -}}
-                <div class="mt-2 text-left pl-4" id="tifBox">
-                  <input id="tifNow" class="form-check-input" type="checkbox" value="">
-                  <label class="form-check-label" for="tifNow">
-                    Match for one epoch only
-                  </label>
-                </div>
-
-                {{- /* SUBMIT ORDER BUTTON */ -}}
-                <div class="text-right">
-                  <button id="submitBttn" type="button" class="my-1 fs14 submit text-center">Submit Order</button>
+                {{- /* BALANCES */ -}}
+                <div class="market-bal pt-2 pb-1 my-3 position-relative">
+                  <span class="market-bal-lbl">Balances</span>
+                  <table class="balance-table" id="balanceTable">
+                    <thead>
+                      <tr>
+                        <th></th>
+                        <th>
+                          <div class="d-flex align-items-center pb-1" id="baseWalletIcons">
+                            <img id="baseImg" class="micro-icon mr-1">
+                            <span data-unit="base"></span>
+                            <div class="flex-grow-1"></div>
+                            <div id="baseWalletState" class="fs12">{{template "walletIcons"}}</div>
+                            <span class="ico-expired fs16 pl-1" id="baseExpired" data-tooltip="Balance may be outdated. Connect to the wallet to refresh."></span>
+                          </div>
+                        </th>
+                        <th>
+                          <div class="d-flex align-items-center pb-1" id="quoteWalletIcons">
+                            <img id="quoteImg" class="micro-icon mr-1">
+                            <span data-unit="quote"></span>
+                            <div class="flex-grow-1"></div>
+                            <div id="quoteWalletState" class="fs12">{{template "walletIcons"}}</div>
+                            <span class="ico-expired fs16 pl-1" id="quoteExpired" data-tooltip="Balance may be outdated. Connect to the wallet to refresh."></span>
+                          </div>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td class="fs16">available</td>
+                        <td id="baseUnsupported" rowspan="3">
+                          <div class="ico-cross"></div>
+                        </td>
+                        <td id="baseConnect" rowspan="3" class="pointer" data-tooltip="Click to connect and refresh">
+                          <div class="ico-sleeping"></div>
+                        </td>
+                        <td id="baseSpinner" rowspan="3">
+                          <div class="ico-spinner spinner"></div>
+                        </td>
+                        <td id="baseNewWalletRow" rowspan="3">
+                          <button id="baseNewButton" type="button" class="newwallet bg1 text-center">Add a<br><span data-unit="base"></span><br>wallet</button>
+                        </td>
+                        <td id="baseAvail" class="fs16"></td>
+                        <td id="quoteUnsupported" rowspan="3">
+                          <div class="ico-cross"></div>
+                        </td>
+                        <td id="quoteConnect" rowspan="3" class="pointer" data-tooltip="Click to connect and refresh">
+                          <div class="ico-sleeping"></div>
+                        </td>
+                        <td id="quoteSpinner" rowspan="3">
+                          <div class="ico-spinner spinner"></div>
+                        </td>
+                        <td id="quoteNewWalletRow" rowspan="3" class="brdr-left">
+                          <button id="quoteNewButton" type="button" class="newwallet bg1 text-center">Add a<br><span data-unit="quote"></span><br>wallet</button>
+                        </td>
+                        <td id="quoteAvail" class="brdr-left fs16"></td>
+                      </tr>
+                      <tr>
+                        <td>locked</td>
+                        <td id="baseLocked"></td>
+                        <td id="quoteLocked" class="brdr-left"></td>
+                      </tr>
+                      <tr>
+                        <td>immature</td>
+                        <td id="baseImmature"></td>
+                        <td id="quoteImmature" class="brdr-left"></td>
+                      </tr>
+                    </tbody>
+                  </table>
                 </div>
               </div>
-              <div class="fs15 pt-3 text-center d-hide errcolor" id="orderErr"></div>
-            </form>
-
-            {{- /* BALANCES */ -}}
-            <div class="market-bal pt-2 pb-1 mt-3 position-relative">
-              <span class="market-bal-lbl">Balances</span>
-              <table class="balance-table" id="balanceTable">
-                <thead>
-                  <tr>
-                    <th></th>
-                    <th>
-                      <div class="d-flex align-items-center pb-1" id="baseWalletIcons">
-                        <img id="baseImg" class="micro-icon mr-1">
-                        <span data-unit="base"></span>
-                        <div class="flex-grow-1"></div>
-                        <div id="baseWalletState" class="fs12">{{template "walletIcons"}}</div>
-                        <span class="ico-expired fs16 pl-1" id="baseExpired" data-tooltip="Balance may be outdated. Connect to the wallet to refresh."></span>
-                      </div>
-                    </th>
-                    <th>
-                      <div class="d-flex align-items-center pb-1" id="quoteWalletIcons">
-                        <img id="quoteImg" class="micro-icon mr-1">
-                        <span data-unit="quote"></span>
-                        <div class="flex-grow-1"></div>
-                        <div id="quoteWalletState" class="fs12">{{template "walletIcons"}}</div>
-                        <span class="ico-expired fs16 pl-1" id="quoteExpired" data-tooltip="Balance may be outdated. Connect to the wallet to refresh."></span>
-                      </div>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td class="fs16">available</td>
-                    <td id="baseUnsupported" rowspan="3">
-                      <div class="ico-cross"></div>
-                    </td>
-                    <td id="baseConnect" rowspan="3" class="pointer" data-tooltip="Click to connect and refresh">
-                      <div class="ico-sleeping"></div>
-                    </td>
-                    <td id="baseSpinner" rowspan="3">
-                      <div class="ico-spinner spinner"></div>
-                    </td>
-                    <td id="baseNewWalletRow" rowspan="3">
-                      <button id="baseNewButton" type="button" class="newwallet bg1 text-center">Add a<br><span data-unit="base"></span><br>wallet</button>
-                    </td>
-                    <td id="baseAvail" class="fs16"></td>
-                    <td id="quoteUnsupported" rowspan="3">
-                      <div class="ico-cross"></div>
-                    </td>
-                    <td id="quoteConnect" rowspan="3" class="pointer" data-tooltip="Click to connect and refresh">
-                      <div class="ico-sleeping"></div>
-                    </td>
-                    <td id="quoteSpinner" rowspan="3">
-                      <div class="ico-spinner spinner"></div>
-                    </td>
-                    <td id="quoteNewWalletRow" rowspan="3" class="brdr-left">
-                      <button id="quoteNewButton" type="button" class="newwallet bg1 text-center">Add a<br><span data-unit="quote"></span><br>wallet</button>
-                    </td>
-                    <td id="quoteAvail" class="brdr-left fs16"></td>
-                  </tr>
-                  <tr>
-                    <td>locked</td>
-                    <td id="baseLocked"></td>
-                    <td id="quoteLocked" class="brdr-left"></td>
-                  </tr>
-                  <tr>
-                    <td>immature</td>
-                    <td id="baseImmature"></td>
-                    <td id="quoteImmature" class="brdr-left"></td>
-                  </tr>
-                </tbody>
-              </table>
             </div>
+          </div>
 
+          {{- /* SELL ORDER LIST */ -}}
+          <div class="marketorders col-7 p-0 bg1">
+            <div class="market-header text-center fs14 py-1">Sell Orders</div>
+            <table class="ordertable bg0">
+              {{template "thead"}}
+              <tbody id="sellRows"></tbody>
+            </table>
           </div>
         </div>
-
-        {{- /* SELL ORDER LIST */ -}}
-        <div class="marketorders col-7 p-0 bg1">
-          <div class="market-header text-center fs14 py-1">Sell Orders</div>
-          <table class="ordertable bg0">
-            {{template "thead"}}
-            <tbody id="sellRows"></tbody>
-          </table>
-        </div>
-
       </div>
 
       {{- /* USER ORDERS: TODO */ -}}
       <div class="bg0 p-0 col-10 d-flex flex-column align-items-stretch">
         <div class="market-header text-center fs14 py-1 brdrleft">Your Orders</div>
-        <div class="brdrleft flex-grow-1 bg1">
-          <table id="liveTable" class="ordertable">
-            <thead>
-              <tr>
-                <th>Type</th>
-                <th>Side</th>
-                <th>Age</th>
-                <th>Rate</th>
-                <th>Quantity</th>
-                <th>Filled</th>
-                <th>Settled</th>
-                <th>Status</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody id="liveList">
-              <tr id="liveTemplate">
-                <td data-col="type"></td>
-                <td data-col="side"></td>
-                <td data-col="age"></td>
-                <td data-col="rate"></td>
-                <td data-col="qty"></td>
-                <td data-col="filled"></td>
-                <td data-col="settled"></td>
-                <td data-col="status"></td>
-                <td data-col="cancel" class="text-center">
-                  <span class="ico-cross d-hide"></span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="brdrleft flex-grow-1 bg1 position-relative">
+
+          <div class="fill-abs px-4 stylish-overflow">
+            <table id="liveTable" class="ordertable">
+              <thead>
+                <tr>
+                  <th>Type</th>
+                  <th>Side</th>
+                  <th>Age</th>
+                  <th>Rate</th>
+                  <th>Quantity</th>
+                  <th>Filled</th>
+                  <th>Settled</th>
+                  <th>Status</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="liveList">
+                <tr id="liveTemplate">
+                  <td data-col="type"></td>
+                  <td data-col="side"></td>
+                  <td data-col="age"></td>
+                  <td data-col="rate"></td>
+                  <td data-col="qty"></td>
+                  <td data-col="filled"></td>
+                  <td data-col="settled"></td>
+                  <td data-col="status"></td>
+                  <td data-col="cancel" class="text-center">
+                    <span class="ico-cross d-hide"></span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </div>

--- a/client/webserver/site/src/js/charts.js
+++ b/client/webserver/site/src/js/charts.js
@@ -74,12 +74,10 @@ export class DepthChart {
     this.wheeled = () => {
       this.wheelLimiter = setTimeout(() => { this.wheelLimiter = null }, 100)
     }
-    this.wheel = this.wheel_.bind(this)
-    bind(this.canvas, 'wheel', this.wheel)
-    this.resize = this.resize_.bind(this)
-    bind(window, 'resize', this.resize)
-    this.click = this.click_.bind(this)
-    bind(this.canvas, 'click', this.click)
+
+    bind(this.canvas, 'wheel', e => { this.wheel(e) })
+    bind(window, 'resize', e => { this.resize(e) })
+    bind(this.canvas, 'click', e => { this.click(e) })
     this.resize()
   }
 
@@ -89,7 +87,7 @@ export class DepthChart {
   }
 
   // resize_ is a 'resize' event handler.
-  resize_ () {
+  resize () {
     this.canvas.width = this.parent.clientWidth
     this.canvas.height = this.parent.clientHeight
     const xLblHeight = 30
@@ -107,8 +105,8 @@ export class DepthChart {
     if (this.book) this.draw()
   }
 
-  // wheel_ is a mousewheel event handler.
-  wheel_ (e) {
+  // wheel is a mousewheel event handler.
+  wheel (e) {
     this.zoom(e.deltaY < 0)
   }
 
@@ -135,8 +133,8 @@ export class DepthChart {
     this.draw()
   }
 
-  // click_ is the canvas 'click' event handler.
-  click_ (e) {
+  // click is the canvas 'click' event handler.
+  click (e) {
     if (!this.dataExtents) return
     const x = e.clientX - this.rect.left
     const y = e.clientY - this.rect.y

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -142,11 +142,10 @@ export default class Doc {
   static formatCoinValue (x) {
     var [whole, frac] = x.toLocaleString('en-us', fullPrecisionSpecs).split('.')
     // toLocalString gives precedence to minimumSignificantDigits, so the result
-    // can be > 8 fractional digits. Trim the extras.
-    if (!frac) {
-      console.error(`formatCoinValue has bad fractional part. input = ${x}`)
-      return 'NaN'
-    }
+    // can have no fractional part, despite the minimumFractionDigits setting.
+    if (!frac) return whole
+    // ... or it can have more than 8 fractional digits, despite of the
+    // maximumFractionDigits setting.
     frac = frac.substring(0, 8)
     if (frac === '00000000') return whole
     // Trim trailing zeros.

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -143,6 +143,10 @@ export default class Doc {
     var [whole, frac] = x.toLocaleString('en-us', fullPrecisionSpecs).split('.')
     // toLocalString gives precedence to minimumSignificantDigits, so the result
     // can be > 8 fractional digits. Trim the extras.
+    if (!frac) {
+      console.error(`formatCoinValue has bad fractional part. input = ${x}`)
+      return 'NaN'
+    }
     frac = frac.substring(0, 8)
     if (frac === '00000000') return whole
     // Trim trailing zeros.

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -14,9 +14,10 @@ const BipIDs = {
 const BipSymbols = Object.values(BipIDs)
 
 // Parameters for printing asset values.
-const coinValueSpecs = {
+const fullPrecisionSpecs = {
   minimumSignificantDigits: 4,
-  maximumSignificantDigits: 6,
+  maximumSignificantDigits: 8,
+  minimumFractionDigits: 8,
   maximumFractionDigits: 8
 }
 
@@ -139,7 +140,13 @@ export default class Doc {
 
   // formatCoinValue formats the asset value to a string.
   static formatCoinValue (x) {
-    return x.toLocaleString('en-us', coinValueSpecs)
+    var [whole, frac] = x.toLocaleString('en-us', fullPrecisionSpecs).split('.')
+    // toLocalString gives precedence to minimumSignificantDigits, so the result
+    // can be > 8 fractional digits. Trim the extras.
+    frac = frac.substring(0, 8)
+    if (frac === '00000000') return whole
+    // Trim trailing zeros.
+    return `${whole}.${frac.replace(/,+$/, '')}`
   }
 
   /*

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -34,7 +34,7 @@ const makerRedeemed = 3
 
 /* The time-in-force specifiers are a mirror of dex/order.TimeInForce. */
 const immediateTiF = 0
-// const standingTiF = 1
+const standingTiF = 1
 
 /* The order statuses are a mirror of dex/order.OrderStatus. */
 const statusUnknown = 0
@@ -88,7 +88,7 @@ export default class MarketsPage extends BasePage {
     this.openFunc = null
     this.currentCreate = null
     this.book = null
-    this.orderRows = {}
+    this.metaOrders = {}
     const reporters = {
       price: p => { this.reportPrice(p) }
     }
@@ -214,7 +214,6 @@ export default class MarketsPage extends BasePage {
     bind(page.chartResizer, 'mousedown', e => {
       if (e.button !== 0) return
       e.preventDefault()
-      // console.log("--startX", startX, "startY", startY)
       const trackMouse = ee => {
         ee.preventDefault()
         const box = page.rightSide.getBoundingClientRect()
@@ -248,9 +247,10 @@ export default class MarketsPage extends BasePage {
 
     // Start a ticker to update time-since values.
     this.secondTicker = setInterval(() => {
-      this.page.liveList.querySelectorAll('[data-col=age]').forEach(td => {
-        td.textContent = Doc.timeSince(td.parentNode.order.stamp)
-      })
+      for (const metaOrder of Object.values(this.metaOrders)) {
+        const td = metaOrder.row.querySelector('[data-col=age]')
+        td.textContent = Doc.timeSince(metaOrder.order.stamp)
+      }
     }, 1000)
 
     // set the initial state for the registration status
@@ -552,23 +552,26 @@ export default class MarketsPage extends BasePage {
   /* refreshActiveOrders refreshes the user's active order list. */
   refreshActiveOrders () {
     const page = this.page
-    const orderRows = this.orderRows
+    const metaOrders = this.metaOrders
     const market = this.market
-    for (const oid in orderRows) delete orderRows[oid]
+    for (const oid in metaOrders) delete metaOrders[oid]
     const orders = app.orders(market.dex.host, marketID(market.baseCfg.symbol, market.quoteCfg.symbol))
+
     Doc.empty(page.liveList)
     for (const order of orders) {
       const row = page.liveTemplate.cloneNode(true)
-      row.order = order
-      orderRows[order.id] = row
+      metaOrders[order.id] = {
+        row: row,
+        order: order
+      }
       updateUserOrderRow(row, order)
       if (order.type === LIMIT) {
-        if (!order.cancelling && order.filled !== order.qty) {
+        if (order.tif === standingTiF && order.status < statusExecuted) {
           const icon = row.querySelector('[data-col=cancel] > span')
           Doc.show(icon)
           bind(icon, 'click', e => {
             e.stopPropagation()
-            this.showCancel(icon, order)
+            this.showCancel(icon, order.id)
           })
         }
       }
@@ -727,7 +730,8 @@ export default class MarketsPage extends BasePage {
   }
 
   /* showCancel shows a form to confirm submission of a cancel order. */
-  showCancel (bttn, order) {
+  showCancel (bttn, orderID) {
+    const order = this.metaOrders[orderID].order
     const page = this.page
     const remaining = order.qty - order.filled
     page.cancelRemain.textContent = Doc.formatCoinValue(remaining / 1e8)
@@ -798,16 +802,17 @@ export default class MarketsPage extends BasePage {
   handleOrderNote (note) {
     const order = note.order
     if (order.targetID && note.subject === 'cancel') {
-      this.orderRows[order.targetID].querySelector('[data-col=cancel]').textContent = 'canceled'
+      this.metaOrders[order.targetID].row.querySelector('[data-col=cancel]').textContent = 'canceled'
     } else if (order.targetID && note.subject === 'revoke') {
-      this.orderRows[order.targetID].querySelector('[data-col=cancel]').textContent = 'revoked'
+      this.metaOrders[order.targetID].row.querySelector('[data-col=cancel]').textContent = 'revoked'
     } else {
-      const row = this.orderRows[order.id]
-      if (!row) return
-      updateUserOrderRow(row, order)
+      const metaOrder = this.metaOrders[order.id]
+      if (!metaOrder) return
+      metaOrder.order = order
+      updateUserOrderRow(metaOrder.row, order)
       if (order.filled === order.qty) {
         // Remove the cancellation button.
-        updateDataCol(row, 'cancel', '')
+        updateDataCol(metaOrder.row, 'cancel', '')
       }
     }
   }
@@ -822,10 +827,10 @@ export default class MarketsPage extends BasePage {
       this.chart.draw()
     }
     this.clearOrderTableEpochs(note.epoch)
-    for (const tr of Array.from(this.page.liveList.children)) {
-      const order = tr.order
+    for (const metaOrder of Object.values(this.metaOrders)) {
+      const order = metaOrder.order
       const alreadyMatched = note.epoch > order.epoch
-      const statusTD = tr.querySelector('[data-col=status]')
+      const statusTD = metaOrder.row.querySelector('[data-col=status]')
       switch (true) {
         case order.type === LIMIT && order.status === statusEpoch && alreadyMatched:
           statusTD.textContent = order.tif === immediateTiF ? 'executed' : 'booked'

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -214,16 +214,17 @@ export default class MarketsPage extends BasePage {
     bind(page.chartResizer, 'mousedown', e => {
       if (e.button !== 0) return
       e.preventDefault()
+      var chartRatio
       const trackMouse = ee => {
         ee.preventDefault()
         const box = page.rightSide.getBoundingClientRect()
         const h = box.bottom - box.top
-        var chartRatio = (ee.pageY - box.top) / h
+        chartRatio = (ee.pageY - box.top) / h
         setChartRatio(chartRatio)
-        State.store(chartRatioKey, chartRatio)
       }
       bind(document, 'mousemove', trackMouse)
       bind(document, 'mouseup', () => {
+        if (chartRatio) State.store(chartRatioKey, chartRatio)
         Doc.unbind(document, 'mousemove', trackMouse)
       })
     })

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -1303,9 +1303,9 @@ func TestAuxiliary(t *testing.T) {
 		t.Fatalf("expected 3 confirmations, got %d", confs)
 	}
 
-	txHashBad := txHash
-	txHashBad[0] = 22
-	_, _, _, err = dcr.FeeCoin(toCoinID(txHashBad, 0))
+	var txHashBad chainhash.Hash
+	copy(txHashBad[:], randomBytes(32))
+	_, _, _, err = dcr.FeeCoin(toCoinID(&txHashBad, 0))
 	if err == nil {
 		t.Fatal("FeeCoin found for non-existent txid")
 	}


### PR DESCRIPTION
Fixes issues where overflow and div sizing were acting weird on resize. 

Creates and uses a stylish scrollbar class. Enables manual chart div click-drag resizing and remembers the user's preference across sessions. 

Also corrects a recent regression where certain order form elements were not being hidden for market orders.

Most of the loc are just html indentation changes. Best tested with the [test app server](https://github.com/decred/dcrdex/wiki/Test-App-Server).

resolves #550, #514, #296, #539