### PR TITLE
client/asset/{btc,dcr}: enable split funding transactions

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -643,7 +643,7 @@ func TestFundingCoins(t *testing.T) {
 
 	ensureErr := func(tag string) {
 		// Clear the cache.
-		wallet.fundingCoins = make(map[string]*compositeUTXO)
+		wallet.fundingCoins = make(map[wire.OutPoint]*compositeUTXO)
 		_, err := wallet.FundingCoins(coinIDs)
 		if err == nil {
 			t.Fatalf("%s: no error", tag)
@@ -1048,9 +1048,9 @@ func TestSignMessage(t *testing.T) {
 	}
 	sig := signature.Serialize()
 
-	opID := outpointID(tTxID, vout)
+	pt := newOutPoint(tTxHash, vout)
 	utxo := &compositeUTXO{address: tP2PKHAddr}
-	wallet.fundingCoins[opID] = utxo
+	wallet.fundingCoins[pt] = utxo
 	node.rawRes[methodPrivKeyForAddress] = mustMarshal(t, wif.String())
 	node.signMsgFunc = func(params []json.RawMessage) (json.RawMessage, error) {
 		if len(params) != 2 {
@@ -1094,12 +1094,12 @@ func TestSignMessage(t *testing.T) {
 	}
 
 	// Unknown UTXO
-	delete(wallet.fundingCoins, opID)
+	delete(wallet.fundingCoins, pt)
 	_, _, err = wallet.SignMessage(coin, msg)
 	if err == nil {
 		t.Fatalf("no error for unknown utxo")
 	}
-	wallet.fundingCoins[opID] = utxo
+	wallet.fundingCoins[pt] = utxo
 
 	// dumpprivkey error
 	node.rawErr[methodPrivKeyForAddress] = tErr

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -17,6 +17,7 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/calc"
 	dexbtc "decred.org/dcrdex/dex/networks/btc"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/btcjson"
@@ -56,9 +57,41 @@ func randBytes(l int) []byte {
 	return b
 }
 
+func signFunc(t *testing.T, params []json.RawMessage, sizeTweak int, sigComplete bool) (json.RawMessage, error) {
+	signTxRes := SignTxResult{
+		Complete: sigComplete,
+	}
+	var msgHex string
+	err := json.Unmarshal(params[0], &msgHex)
+	if err != nil {
+		t.Fatalf("error unmarshaling transaction hex: %v", err)
+	}
+	msgBytes, _ := hex.DecodeString(msgHex)
+	txReader := bytes.NewReader(msgBytes)
+	msgTx := wire.NewMsgTx(wire.TxVersion)
+	err = msgTx.Deserialize(txReader)
+	if err != nil {
+		t.Fatalf("error deserializing contract: %v", err)
+	}
+	// Set the sigScripts to random bytes of the correct length for spending a
+	// p2pkh output.
+	scriptSize := dexbtc.RedeemP2PKHSigScriptSize + sizeTweak
+	for i := range msgTx.TxIn {
+		msgTx.TxIn[i].SignatureScript = randBytes(scriptSize)
+	}
+	buf := new(bytes.Buffer)
+	err = msgTx.Serialize(buf)
+	if err != nil {
+		t.Fatalf("error serializing contract: %v", err)
+	}
+	signTxRes.Hex = buf.Bytes()
+	return mustMarshal(t, signTxRes), nil
+}
+
 type tRPCClient struct {
 	sendHash      *chainhash.Hash
 	sendErr       error
+	sentRawTx     *wire.MsgTx
 	txOutRes      *btcjson.GetTxOutResult
 	txOutErr      error
 	rawRes        map[string]json.RawMessage
@@ -100,6 +133,7 @@ func (c *tRPCClient) EstimateSmartFee(confTarget int64, mode *btcjson.EstimateSm
 }
 
 func (c *tRPCClient) SendRawTransaction(tx *wire.MsgTx, _ bool) (*chainhash.Hash, error) {
+	c.sentRawTx = tx
 	if c.sendErr == nil && c.sendHash == nil {
 		h := tx.TxHash()
 		return &h, nil
@@ -294,18 +328,19 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("no wallet error for rpc error")
 	}
 	node.rawErr[methodGetBalances] = nil
-	littleBit := tLotSize * 12
-	littleUnspent := &ListUnspentResult{
+	littleOrder := tLotSize * 12
+	littleFunds := calc.RequiredOrderFunds(littleOrder, dexbtc.RedeemP2PKHInputSize, tBTC)
+	littleUTXO := &ListUnspentResult{
 		TxID:          tTxID,
 		Address:       "1Bggq7Vu5oaoLFV1NNp5KhAzcku83qQhgi",
-		Amount:        float64(littleBit) / 1e8,
+		Amount:        float64(littleFunds) / 1e8,
 		Confirmations: 0,
 		ScriptPubKey:  tP2PKH,
 		Safe:          true,
 	}
-	unspents = append(unspents, littleUnspent)
+	unspents = append(unspents, littleUTXO)
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
-	bals.Mine.Trusted = float64(littleBit) / 1e8
+	bals.Mine.Trusted = float64(littleFunds) / 1e8
 	node.rawRes[methodGetBalances] = mustMarshal(t, &bals)
 	lockedVal := uint64(1e6)
 	node.rawRes[methodListLockUnspent] = mustMarshal(t, []*RPCOutpoint{
@@ -323,8 +358,8 @@ func TestAvailableFund(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error for 1 utxo: %v", err)
 	}
-	if bal.Available != littleBit {
-		t.Fatalf("expected available = %d for confirmed utxos, got %d", littleBit, bal.Available)
+	if bal.Available != littleFunds {
+		t.Fatalf("expected available = %d for confirmed utxos, got %d", littleOrder, bal.Available)
 	}
 	if bal.Immature != 0 {
 		t.Fatalf("expected immature = 0, got %d", bal.Immature)
@@ -333,32 +368,33 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("expected locked = %d, got %d", lockedVal, bal.Locked)
 	}
 
-	lottaBit := tLotSize * 100
-	unspents = append(unspents, &ListUnspentResult{
+	lottaOrder := tLotSize * 100
+	// Add funding for an extra input to accommodate the later combined tests.
+	lottaFunds := calc.RequiredOrderFunds(lottaOrder, 2*dexbtc.RedeemP2PKHInputSize, tBTC)
+	lottaUTXO := &ListUnspentResult{
 		TxID:          tTxID,
 		Address:       "1Bggq7Vu5oaoLFV1NNp5KhAzcku83qQhgi",
-		Amount:        float64(lottaBit) / 1e8,
+		Amount:        float64(lottaFunds) / 1e8,
 		Confirmations: 1,
 		Vout:          1,
 		ScriptPubKey:  tP2PKH,
 		Safe:          true,
-	})
-	littleUnspent.Confirmations = 1
+	}
+	unspents = append(unspents, lottaUTXO)
+	littleUTXO.Confirmations = 1
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
-	bals.Mine.Trusted += float64(lottaBit) / 1e8
+	bals.Mine.Trusted += float64(lottaFunds) / 1e8
 	node.rawRes[methodGetBalances] = mustMarshal(t, &bals)
 	bal, err = wallet.Balance()
 	if err != nil {
 		t.Fatalf("error for 2 utxos: %v", err)
 	}
-	if bal.Available != littleBit+lottaBit {
-		t.Fatalf("expected available = %d for 2 outputs, got %d", littleBit+lottaBit, bal.Available)
+	if bal.Available != littleFunds+lottaFunds {
+		t.Fatalf("expected available = %d for 2 outputs, got %d", littleFunds+lottaFunds, bal.Available)
 	}
 	if bal.Immature != 0 {
 		t.Fatalf("expected immature = 0 for 2 outputs, got %d", bal.Immature)
 	}
-
-	fundLittle := littleBit - tLotSize
 
 	// Zero value
 	_, err = wallet.FundOrder(0, tBTC)
@@ -368,7 +404,7 @@ func TestAvailableFund(t *testing.T) {
 
 	// Nothing to spend
 	node.rawRes[methodListUnspent] = mustMarshal(t, []struct{}{})
-	_, err = wallet.FundOrder(fundLittle, tBTC)
+	_, err = wallet.FundOrder(littleOrder, tBTC)
 	if err == nil {
 		t.Fatalf("no error for zero utxos")
 	}
@@ -376,7 +412,7 @@ func TestAvailableFund(t *testing.T) {
 
 	// RPC error
 	node.rawErr[methodListUnspent] = tErr
-	_, err = wallet.FundOrder(fundLittle, tBTC)
+	_, err = wallet.FundOrder(littleOrder, tBTC)
 	if err == nil {
 		t.Fatalf("no funding error for rpc error")
 	}
@@ -384,17 +420,17 @@ func TestAvailableFund(t *testing.T) {
 
 	// Negative response when locking outputs.
 	node.rawRes[methodLockUnspent] = []byte(`false`)
-	_, err = wallet.FundOrder(fundLittle, tBTC)
+	_, err = wallet.FundOrder(littleOrder, tBTC)
 	if err == nil {
 		t.Fatalf("no error for lockunspent result = false: %v", err)
 	}
 	node.rawRes[methodLockUnspent] = []byte(`true`)
 
-	// Fund a little bit, with unsafe littleBit.
-	littleUnspent.Safe = false
-	littleUnspent.Confirmations = 0
+	// Fund a little bit, with unsafe littleOrder.
+	littleUTXO.Safe = false
+	littleUTXO.Confirmations = 0
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
-	spendables, err := wallet.FundOrder(fundLittle, tBTC)
+	spendables, err := wallet.FundOrder(littleOrder, tBTC)
 	if err != nil {
 		t.Fatalf("error funding small amount: %v", err)
 	}
@@ -402,14 +438,14 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("expected 1 spendable, got %d", len(spendables))
 	}
 	v := spendables[0].Value()
-	if v != lottaBit { // has to pick the larger output
-		t.Fatalf("expected spendable of value %d, got %d", lottaBit, v)
+	if v != lottaFunds { // has to pick the larger output
+		t.Fatalf("expected spendable of value %d, got %d", lottaFunds, v)
 	}
 
-	// Now with safe unconfirmed littleBit.
-	littleUnspent.Safe = true
+	// Now with safe unconfirmed littleOrder.
+	littleUTXO.Safe = true
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
-	spendables, err = wallet.FundOrder(fundLittle, tBTC)
+	spendables, err = wallet.FundOrder(littleOrder, tBTC)
 	if err != nil {
 		t.Fatalf("error funding small amount: %v", err)
 	}
@@ -417,12 +453,12 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("expected 1 spendable, got %d", len(spendables))
 	}
 	v = spendables[0].Value()
-	if v != littleBit { // now picks the smaller output
-		t.Fatalf("expected spendable of value %d, got %d", littleBit, v)
+	if v != littleFunds { // now picks the smaller output
+		t.Fatalf("expected spendable of value %d, got %d", littleFunds, v)
 	}
 
-	// Fund a lotta bit, covered by just the lottaBit UTXO.
-	spendables, err = wallet.FundOrder(lottaBit-littleBit/2 /* hefty fees for 95 lots */, tBTC)
+	// Fund a lotta bit, covered by just the lottaOrder UTXO.
+	spendables, err = wallet.FundOrder(lottaOrder /* hefty fees for 95 lots */, tBTC)
 	if err != nil {
 		t.Fatalf("error funding large amount: %v", err)
 	}
@@ -430,12 +466,13 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("expected 1 spendable, got %d", len(spendables))
 	}
 	v = spendables[0].Value()
-	if v != lottaBit {
-		t.Fatalf("expected spendable of value %d, got %d", lottaBit, v)
+	if v != lottaFunds {
+		t.Fatalf("expected spendable of value %d, got %d", lottaFunds, v)
 	}
 
 	// lotta bit++ to require both spendables
-	spendables, err = wallet.FundOrder(lottaBit+littleBit-littleBit/2, tBTC)
+	extraLottaOrder := littleOrder + lottaOrder
+	spendables, err = wallet.FundOrder(extraLottaOrder, tBTC)
 	if err != nil {
 		t.Fatalf("error funding large amount: %v", err)
 	}
@@ -443,14 +480,76 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("expected 2 spendable, got %d", len(spendables))
 	}
 	v = spendables[0].Value()
-	if v != lottaBit {
-		t.Fatalf("expected spendable of value %d, got %d", lottaBit, v)
+	if v != lottaFunds {
+		t.Fatalf("expected spendable of value %d, got %d", lottaFunds, v)
 	}
 
 	// Not enough to cover transaction fees.
-	_, err = wallet.FundOrder(lottaBit+littleBit-1, tBTC)
+	lottaUTXO.Amount -= 1e-6
+	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+	_, err = wallet.FundOrder(lottaOrder+littleOrder, tBTC)
 	if err == nil {
 		t.Fatalf("no error when not enough to cover tx fees")
+	}
+	lottaUTXO.Amount += 1e-6
+	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
+	// Prepare for a split transaction.
+	baggageFees := tBTC.MaxFeeRate * splitTxBaggage
+	node.rawRes[methodChangeAddress] = mustMarshal(t, tP2WPKHAddr)
+	wallet.useSplitTx = true
+	// No error when no split performed cuz math.
+	coins, err := wallet.FundOrder(extraLottaOrder, tBTC)
+	if err != nil {
+		t.Fatalf("error for no-split split: %v", err)
+	}
+
+	// Should be both coins.
+	if len(coins) != 2 {
+		t.Fatalf("no-split split didn't return both coins")
+	}
+
+	// With a little more locked, the split should be performed.
+	node.signFunc = func(params []json.RawMessage) (json.RawMessage, error) {
+		return signFunc(t, params, 0, true)
+	}
+	lottaUTXO.Amount += float64(baggageFees) / 1e8
+	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+	coins, err = wallet.FundOrder(extraLottaOrder, tBTC)
+	if err != nil {
+		t.Fatalf("error for split tx: %v", err)
+	}
+
+	// Should be just one coin.
+	if len(coins) != 1 {
+		t.Fatalf("split failed - coin count != 1")
+	}
+	if node.sentRawTx == nil {
+		t.Fatalf("split failed - no tx sent")
+	}
+
+	// // Hit some error paths.
+
+	// GetRawChangeAddress error
+	node.rawErr[methodChangeAddress] = tErr
+	_, err = wallet.FundOrder(extraLottaOrder, tBTC)
+	if err == nil {
+		t.Fatalf("no error for split tx change addr error")
+	}
+	node.rawErr[methodChangeAddress] = nil
+
+	// SendRawTx error
+	node.sendErr = tErr
+	_, err = wallet.FundOrder(extraLottaOrder, tBTC)
+	if err == nil {
+		t.Fatalf("no error for split tx send error")
+	}
+	node.sendErr = nil
+
+	// Success again.
+	_, err = wallet.FundOrder(extraLottaOrder, tBTC)
+	if err != nil {
+		t.Fatalf("error for split tx recovery run")
 	}
 }
 
@@ -731,42 +830,17 @@ func TestSwap(t *testing.T) {
 		LockChange: true,
 	}
 
-	signTxRes := SignTxResult{
-		Complete: true,
-	}
+	signatureComplete := true
 
 	// Aim for 3 signature cycles.
 	sigSizer := 0
 	node.signFunc = func(params []json.RawMessage) (json.RawMessage, error) {
-		var msgHex string
-		err := json.Unmarshal(params[0], &msgHex)
-		if err != nil {
-			t.Fatalf("error unmarshaling transaction hex: %v", err)
-		}
-		msgBytes, _ := hex.DecodeString(msgHex)
-		txReader := bytes.NewReader(msgBytes)
-		msgTx := wire.NewMsgTx(wire.TxVersion)
-		err = msgTx.Deserialize(txReader)
-		if err != nil {
-			t.Fatalf("error deserializing contract: %v", err)
-		}
-		// Set the sigScripts to random bytes of the correct length for spending a
-		// p2pkh output.
-		scriptSize := dexbtc.RedeemP2PKHSigScriptSize
+		var sizeTweak int
 		if sigSizer%2 == 0 {
-			scriptSize -= 2
+			sizeTweak = -2
 		}
 		sigSizer++
-		for i := range msgTx.TxIn {
-			msgTx.TxIn[i].SignatureScript = randBytes(scriptSize)
-		}
-		buf := new(bytes.Buffer)
-		err = msgTx.Serialize(buf)
-		if err != nil {
-			t.Fatalf("error serializing contract: %v", err)
-		}
-		signTxRes.Hex = buf.Bytes()
-		return mustMarshal(t, signTxRes), nil
+		return signFunc(t, params, sizeTweak, signatureComplete)
 	}
 
 	// This time should succeed.
@@ -817,12 +891,12 @@ func TestSwap(t *testing.T) {
 	node.rawErr[methodSignTx] = nil
 
 	// incomplete signatures
-	signTxRes.Complete = false
+	signatureComplete = false
 	_, _, err = wallet.Swap(swaps)
 	if err == nil {
 		t.Fatalf("no error for incomplete signature rpc error")
 	}
-	signTxRes.Complete = true
+	signatureComplete = true
 
 	// Make sure we can succeed again.
 	_, _, err = wallet.Swap(swaps)

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -643,7 +643,7 @@ func TestFundingCoins(t *testing.T) {
 
 	ensureErr := func(tag string) {
 		// Clear the cache.
-		wallet.fundingCoins = make(map[wire.OutPoint]*compositeUTXO)
+		wallet.fundingCoins = make(map[outPoint]*compositeUTXO)
 		_, err := wallet.FundingCoins(coinIDs)
 		if err == nil {
 			t.Fatalf("%s: no error", tag)

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -169,33 +169,33 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 
 	// Gamma should only have 10 BTC utxos, so calling fund for less should only
 	// return 1 utxo.
-	utxos, err := rig.gamma().FundOrder(contractValue*3, dexAsset)
+	utxos, err := rig.gamma().FundOrder(contractValue*3, false, dexAsset)
 	if err != nil {
 		t.Fatalf("Funding error: %v", err)
 	}
 	utxo := utxos[0]
 
 	// UTXOs should be locked
-	utxos, _ = rig.gamma().FundOrder(contractValue*3, dexAsset)
+	utxos, _ = rig.gamma().FundOrder(contractValue*3, false, dexAsset)
 	if inUTXOs(utxo, utxos) {
 		t.Fatalf("received locked output")
 	}
 	rig.gamma().ReturnCoins([]asset.Coin{utxo})
 	rig.gamma().ReturnCoins(utxos)
 	// Make sure we get the first utxo back with Fund.
-	utxos, _ = rig.gamma().FundOrder(contractValue*3, dexAsset)
+	utxos, _ = rig.gamma().FundOrder(contractValue*3, false, dexAsset)
 	if !splitTx && !inUTXOs(utxo, utxos) {
 		t.Fatalf("unlocked output not returned")
 	}
 	rig.gamma().ReturnCoins(utxos)
 
 	// Get a separate set of UTXOs for each contract.
-	utxos1, err := rig.gamma().FundOrder(contractValue, dexAsset)
+	utxos1, err := rig.gamma().FundOrder(contractValue, false, dexAsset)
 	if err != nil {
 		t.Fatalf("error funding first contract: %v", err)
 	}
 	// Get a separate set of UTXOs for each contract.
-	utxos2, err := rig.gamma().FundOrder(contractValue*2, dexAsset)
+	utxos2, err := rig.gamma().FundOrder(contractValue*2, false, dexAsset)
 	if err != nil {
 		t.Fatalf("error funding second contract: %v", err)
 	}
@@ -325,7 +325,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	lockTime = time.Now().Add(-24 * time.Hour)
 
 	// Have gamma send a swap contract to the alpha address.
-	utxos, _ = rig.gamma().FundOrder(contractValue, dexAsset)
+	utxos, _ = rig.gamma().FundOrder(contractValue, false, dexAsset)
 	contract := &asset.Contract{
 		Address:    address,
 		Value:      contractValue,

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -30,6 +30,8 @@ import (
 	"decred.org/dcrdex/dex/config"
 )
 
+const tPW = "abc"
+
 type WalletConstructor func(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error)
 
 // Convert the BTC value to satoshi.
@@ -38,7 +40,8 @@ func toSatoshi(v float64) uint64 {
 }
 
 func tBackend(t *testing.T, ctx context.Context, newWallet WalletConstructor, symbol, conf, name string,
-	logger dex.Logger, blkFunc func(string, error)) (*btc.ExchangeWallet, *dex.ConnectionMaster) {
+	logger dex.Logger, blkFunc func(string, error), splitTx bool) (*btc.ExchangeWallet, *dex.ConnectionMaster) {
+
 	user, err := user.Current()
 	if err != nil {
 		t.Fatalf("error getting current user: %v", err)
@@ -49,6 +52,9 @@ func tBackend(t *testing.T, ctx context.Context, newWallet WalletConstructor, sy
 		t.Fatalf("error reading config options: %v", err)
 	}
 	settings["walletname"] = name
+	if splitTx {
+		settings["txsplit"] = "1"
+	}
 	walletCfg := &asset.WalletConfig{
 		Settings: settings,
 		TipChange: func(err error) {
@@ -109,7 +115,7 @@ func randBytes(l int) []byte {
 	return b
 }
 
-func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *dex.Asset) {
+func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *dex.Asset, splitTx bool) {
 	tLogger := dex.StdOutLogger("TEST", dex.LevelTrace)
 	tCtx, shutdown := context.WithCancel(context.Background())
 	defer shutdown()
@@ -130,9 +136,9 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 		backends:          make(map[string]*btc.ExchangeWallet),
 		connectionMasters: make(map[string]*dex.ConnectionMaster, 3),
 	}
-	rig.backends["alpha"], rig.connectionMasters["alpha"] = tBackend(t, tCtx, newWallet, dexAsset.Symbol, "alpha", "", tLogger, blkFunc)
-	rig.backends["beta"], rig.connectionMasters["beta"] = tBackend(t, tCtx, newWallet, dexAsset.Symbol, "beta", "", tLogger, blkFunc)
-	rig.backends["gamma"], rig.connectionMasters["gamma"] = tBackend(t, tCtx, newWallet, dexAsset.Symbol, "alpha", "gamma", tLogger, blkFunc)
+	rig.backends["alpha"], rig.connectionMasters["alpha"] = tBackend(t, tCtx, newWallet, dexAsset.Symbol, "alpha", "", tLogger, blkFunc, splitTx)
+	rig.backends["beta"], rig.connectionMasters["beta"] = tBackend(t, tCtx, newWallet, dexAsset.Symbol, "beta", "", tLogger, blkFunc, splitTx)
+	rig.backends["gamma"], rig.connectionMasters["gamma"] = tBackend(t, tCtx, newWallet, dexAsset.Symbol, "alpha", "gamma", tLogger, blkFunc, splitTx)
 	defer rig.close()
 	contractValue := 2 * dexAsset.LotSize
 
@@ -154,6 +160,13 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 		tLogger.Debugf("%s %f available, %f immature, %f locked",
 			name, float64(bal.Available)/1e8, float64(bal.Immature)/1e8, float64(bal.Locked)/1e8)
 	}
+
+	// Unlock the wallet for use.
+	err := rig.gamma().Unlock(walletPassword, time.Hour*24)
+	if err != nil {
+		t.Fatalf("error unlocking gamma wallet: %v", err)
+	}
+
 	// Gamma should only have 10 BTC utxos, so calling fund for less should only
 	// return 1 utxo.
 	utxos, err := rig.gamma().FundOrder(contractValue*3, dexAsset)
@@ -167,12 +180,11 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	if inUTXOs(utxo, utxos) {
 		t.Fatalf("received locked output")
 	}
-	// Unlock
 	rig.gamma().ReturnCoins([]asset.Coin{utxo})
 	rig.gamma().ReturnCoins(utxos)
 	// Make sure we get the first utxo back with Fund.
 	utxos, _ = rig.gamma().FundOrder(contractValue*3, dexAsset)
-	if !inUTXOs(utxo, utxos) {
+	if !splitTx && !inUTXOs(utxo, utxos) {
 		t.Fatalf("unlocked output not returned")
 	}
 	rig.gamma().ReturnCoins(utxos)
@@ -186,12 +198,6 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	utxos2, err := rig.gamma().FundOrder(contractValue*2, dexAsset)
 	if err != nil {
 		t.Fatalf("error funding second contract: %v", err)
-	}
-
-	// Unlock the wallet for use.
-	err = rig.gamma().Unlock(walletPassword, time.Hour*24)
-	if err != nil {
-		t.Fatalf("error unlocking gamma wallet: %v", err)
 	}
 
 	secretKey1 := randBytes(32)

--- a/client/asset/btc/livetest/regnet_test.go
+++ b/client/asset/btc/livetest/regnet_test.go
@@ -3,6 +3,7 @@
 package livetest
 
 import (
+	"fmt"
 	"testing"
 
 	"decred.org/dcrdex/client/asset/btc"
@@ -20,7 +21,7 @@ var (
 		Symbol:       "btc",
 		SwapSize:     dexbtc.InitTxSize,
 		SwapSizeBase: dexbtc.InitTxSizeBase,
-		MaxFeeRate:   2,
+		MaxFeeRate:   10,
 		LotSize:      1e6,
 		RateStep:     10,
 		SwapConf:     1,
@@ -28,5 +29,8 @@ var (
 )
 
 func TestWallet(t *testing.T) {
-	Run(t, btc.NewWallet, alphaAddress, tBTC)
+	fmt.Println("////////// WITHOUT SPLIT FUNDING TRANSACTIONS //////////")
+	Run(t, btc.NewWallet, alphaAddress, tBTC, false)
+	fmt.Println("////////// WITH SPLIT FUNDING TRANSACTIONS //////////")
+	Run(t, btc.NewWallet, alphaAddress, tBTC, true)
 }

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -73,8 +73,8 @@ func (wc *walletClient) LockUnspent(unlock bool, ops []*output) error {
 	var rpcops []*RPCOutpoint // To clear all, this must be nil, not empty slice.
 	for _, op := range ops {
 		rpcops = append(rpcops, &RPCOutpoint{
-			TxID: op.txHash.String(),
-			Vout: op.vout,
+			TxID: op.txHash().String(),
+			Vout: op.vout(),
 		})
 	}
 	var success bool

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -190,33 +190,33 @@ func runTest(t *testing.T, splitTx bool) {
 	}
 
 	// Grab some coins.
-	utxos, err := rig.beta().FundOrder(contractValue*3, tDCR)
+	utxos, err := rig.beta().FundOrder(contractValue*3, false, tDCR)
 	if err != nil {
 		t.Fatalf("Funding error: %v", err)
 	}
 	utxo := utxos[0]
 
 	// Coins should be locked
-	utxos, _ = rig.beta().FundOrder(contractValue*3, tDCR)
+	utxos, _ = rig.beta().FundOrder(contractValue*3, false, tDCR)
 	if !splitTx && inUTXOs(utxo, utxos) {
 		t.Fatalf("received locked output")
 	}
 	rig.beta().ReturnCoins([]asset.Coin{utxo})
 	rig.beta().ReturnCoins(utxos)
 	// Make sure we get the first utxo back with Fund.
-	utxos, _ = rig.beta().FundOrder(contractValue*3, tDCR)
+	utxos, _ = rig.beta().FundOrder(contractValue*3, false, tDCR)
 	if !splitTx && !inUTXOs(utxo, utxos) {
 		t.Fatalf("unlocked output not returned")
 	}
 	rig.beta().ReturnCoins(utxos)
 
 	// Get a separate set of UTXOs for each contract.
-	utxos1, err := rig.beta().FundOrder(contractValue, tDCR)
+	utxos1, err := rig.beta().FundOrder(contractValue, false, tDCR)
 	if err != nil {
 		t.Fatalf("error funding first contract: %v", err)
 	}
 	// Get a separate set of UTXOs for each contract.
-	utxos2, err := rig.beta().FundOrder(contractValue*2, tDCR)
+	utxos2, err := rig.beta().FundOrder(contractValue*2, false, tDCR)
 	if err != nil {
 		t.Fatalf("error funding second contract: %v", err)
 	}
@@ -347,7 +347,7 @@ func runTest(t *testing.T, splitTx bool) {
 	lockTime = time.Now().Add(-24 * time.Hour)
 
 	// Have beta send a swap contract to the alpha address.
-	utxos, _ = rig.beta().FundOrder(contractValue, tDCR)
+	utxos, _ = rig.beta().FundOrder(contractValue, false, tDCR)
 	contract := &asset.Contract{
 		Address:    alphaAddress,
 		Value:      contractValue,

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -72,7 +72,7 @@ type Wallet interface {
 	// Fund selects coins for use in an order. The coins will be locked, and will
 	// not be returned in subsequent calls to Fund or calculated in calls to
 	// Available, unless they are unlocked with ReturnCoins.
-	FundOrder(uint64, *dex.Asset) (Coins, error)
+	FundOrder(value uint64, immediate bool, nfo *dex.Asset) (Coins, error)
 	// ReturnCoins unlocks coins. This would be necessary in the case of a
 	// canceled order.
 	ReturnCoins(Coins) error

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -57,12 +57,15 @@ var (
 			Description:  "Litecoin's 'fallbackfee' rate. Units: LTC/kB",
 			DefaultValue: defaultFee * 1000 / 1e8,
 		},
-		// {
-		// 	Key:         "txsplit",
-		// 	DisplayName: "Pre-split funding inputs",
-		// 	Description: "Pre-split funding inputs to prevent locking funds into an order for which a change output may not be immediately available. Only used for standing-type orders.",
-		// 	IsBoolean:   true,
-		// },
+		{
+			Key:         "txsplit",
+			DisplayName: "Pre-split funding inputs",
+			Description: "When placing an order, create a \"split\" transaction to fund the order without locking more of the wallet balance than " +
+				"necessary. Otherwise, excess funds may be reserved to fund the order until the first swap contract is broadcast " +
+				"during match settlement, or the order is canceled. This an extra transaction for which network mining fees are paid. " +
+				"Used only for standing-type orders, e.g. limit orders without immediate time-in-force.",
+			IsBoolean: true,
+		},
 	}
 	// WalletInfo defines some general information about a Litecoin wallet.
 	WalletInfo = &asset.WalletInfo{

--- a/client/asset/ltc/regnet_test.go
+++ b/client/asset/ltc/regnet_test.go
@@ -36,5 +36,5 @@ var tLTC = &dex.Asset{
 }
 
 func TestWallet(t *testing.T) {
-	livetest.Run(t, NewWallet, alphaAddress, tLTC)
+	livetest.Run(t, NewWallet, alphaAddress, tLTC, false)
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1827,7 +1827,10 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	if form.IsLimit && !form.Sell {
 		fundQty = calc.BaseToQuote(rate, fundQty)
 	}
-	coins, err := fromWallet.FundOrder(fundQty, wallets.fromAsset)
+
+	isImmediate := (!form.IsLimit || form.TifNow)
+
+	coins, err := fromWallet.FundOrder(fundQty, isImmediate, wallets.fromAsset)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -513,7 +513,7 @@ func (w *TXCWallet) FeeRate() (uint64, error) {
 	return 24, nil
 }
 
-func (w *TXCWallet) FundOrder(v uint64, _ *dex.Asset) (asset.Coins, error) {
+func (w *TXCWallet) FundOrder(v uint64, _ bool, _ *dex.Asset) (asset.Coins, error) {
 	w.fundedVal = v
 	return w.fundCoins, w.fundErr
 }

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -328,6 +328,7 @@ hr.dashed {
   background-color: #040012;
   border: 1px solid #333;
   color: white;
+  max-width: 500px;
 }
 
 .dynamicopts {


### PR DESCRIPTION
Creates a "split transaction" to pre-size inputs, with some minimum reasonable consideration for negative net effects. The split transaction is sent during a call to `FundOrder` if the user has specified such in their wallet configuration's `txsplit` value.

Resolves https://github.com/decred/dcrdex/issues/340