### PR TITLE
dex: improve and test (*Bytes).UnmarshalJSON

### DIFF
--- a/dex/marshal_test.go
+++ b/dex/marshal_test.go
@@ -1,0 +1,60 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package dex
+
+import "testing"
+
+func TestBytes_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		encHex  string
+		wantErr bool
+	}{
+		{
+			name:    "ok",
+			encHex:  `"0f0e"`,
+			wantErr: false,
+		},
+		{
+			name:    "odd, 1",
+			encHex:  `"f"`,
+			wantErr: true,
+		},
+		{
+			name:    "odd, 3",
+			encHex:  `"fff"`,
+			wantErr: true,
+		},
+		{
+			name:    "bad hex",
+			encHex:  `"adsf"`, // s not valid hex
+			wantErr: true,
+		},
+		{
+			name:    "too short",
+			encHex:  `2`,
+			wantErr: true,
+		},
+		{
+			name:    "ok empty",
+			encHex:  `""`,
+			wantErr: false,
+		},
+		{
+			name: "not quoted (also invalid hex to demo error printing)",
+			encHex: `abc
+			abc`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := new(Bytes)
+			err := b.UnmarshalJSON([]byte(tt.encHex))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Bytes.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This changes `(*Bytes).UnmarshalJSON` to use `hex.Decode` instead of `hex.DecodeString`, which eliminates two copy-conversions (one `[]byte` => `string` and one `string` => `[]bytes`), and the hilarious over-allocation of the resulting slice by `hex.DecodeString`.

This also adds a check to ensure the first and last characters in the marshalled json are `"`.

If hex decoding fails, the `Bytes` is not changed, whereas before `hex.DecodeString` would return the partially decoded slice in the even of an error.

Adds test coverage for `(*Bytes).UnmarshalJSON`.