### PR TITLE
client/core: fix incorrect fill amount when missing inactive matches

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2111,6 +2111,8 @@ func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, e
 		}
 	}
 
+	// NOTE: We have not loaded old/inactive matches for active dex orders.
+
 	cancels := make(map[order.OrderID]*order.CancelOrder)
 	cancelPreimages := make(map[order.OrderID]order.Preimage)
 	trackers := make(map[order.OrderID]*trackedTrade, len(dbOrders))

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -430,17 +430,11 @@ func (t *Trade) Filled() uint64 {
 }
 
 // AddFill increases the filled amount.
-func (t *Trade) AddFill(amt uint64) {
+func (t *Trade) AddFill(amt uint64) uint64 {
 	t.fillAmtMtx.Lock()
+	defer t.fillAmtMtx.Unlock()
 	t.FillAmt += amt
-	t.fillAmtMtx.Unlock()
-}
-
-// SetFill sets the filled amount.
-func (t *Trade) SetFill(amt uint64) {
-	t.fillAmtMtx.Lock()
-	t.FillAmt = amt
-	t.fillAmtMtx.Unlock()
+	return t.FillAmt
 }
 
 // SwapAddress returns the order's payment address.

--- a/dex/order/serialize.go
+++ b/dex/order/serialize.go
@@ -128,6 +128,12 @@ func decodeTrade_v0(pushes [][]byte) (mrkt *Trade, err error) {
 	if bEqual(sellB, encode.ByteFalse) {
 		sell = false
 	}
+	if len(qtyB) != 8 {
+		return nil, fmt.Errorf("quantity bytes length %v, expected 8", len(qtyB))
+	}
+	if len(filledB) != 8 {
+		return nil, fmt.Errorf("filled amount bytes length %v, expected 8", len(filledB))
+	}
 	return &Trade{
 		Coins:    coins,
 		Sell:     sell,


### PR DESCRIPTION
When dexc is restarted with a partially filled order where the previous
match(es) that partially filled the order are inactive, the fill amount
computation in `(*trackedTrade).negotiate` was incorrect.

This change adds the filled quantity for new matches rather than trying
to recompute and set the whole match amount.

`(*trackedTrade).negotiate` now attempts to process all matches even if
one of them fails for some reason.