### PR TITLE
client/core: async req/ntfn handling, parallel new match negotiation

### DIFF
--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -15,10 +15,9 @@ import (
 )
 
 const (
-	defaultMainnet     = "localhost:9110"
-	defaultTestnet3    = "localhost:19110"
-	defaultSimnet      = "localhost:19557"
-	defaultAccountName = "default"
+	defaultMainnet  = "localhost:9110"
+	defaultTestnet3 = "localhost:19110"
+	defaultSimnet   = "localhost:19557"
 )
 
 var (
@@ -63,10 +62,6 @@ func loadConfig(settings map[string]string, network dex.Network) (*Config, error
 	}
 	if missing != "" {
 		return nil, fmt.Errorf("missing dcrwallet rpc credentials:%s", missing)
-	}
-
-	if cfg.FallbackFeeRate == 0 {
-		cfg.FallbackFeeRate = defaultFee
 	}
 
 	// Get network settings. Zero value is mainnet, but unknown non-zero cfg.Net

--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -418,12 +418,12 @@ func TestWsConn(t *testing.T) {
 	// Ensure the response handler is unlogged.
 	hndlr = wsc.respHandler(mId)
 	if hndlr != nil {
-		t.Fatal("expected an error for unlogged id")
+		t.Fatal("found a response handler for an unlogged request id")
 	}
 
 	pingCh <- struct{}{}
 
-	// Ensure a malformed request data (a send failure) does not leave a
+	// Ensure malformed request data (a send failure) does not leave a
 	// registered response handler or kill the connection.
 	sent.ID = wsc.NextID()
 	sent.Payload = []byte("{notjson")

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -44,7 +44,7 @@ func (set *errorSet) addErr(err error) *errorSet {
 }
 
 // If any returns the error set if there are any errors, else nil.
-func (set *errorSet) ifany() error {
+func (set *errorSet) ifAny() error {
 	if len(set.errs) > 0 {
 		return set
 	}
@@ -58,7 +58,7 @@ func (set *errorSet) Error() string {
 	for i := range set.errs {
 		errStrings = append(errStrings, set.errs[i].Error())
 	}
-	return set.prefix + strings.Join(errStrings, ", ")
+	return set.prefix + "{" + strings.Join(errStrings, ", ") + "}"
 }
 
 // WalletForm is information necessary to create a new exchange wallet.

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -193,6 +193,12 @@ type MetaMatch struct {
 	Match *order.UserMatch
 }
 
+// SetStatus sets the match status in both the UserMatch and the MatchMetaData.
+func (m *MetaMatch) SetStatus(status order.MatchStatus) {
+	m.MetaData.Status = status
+	m.Match.Status = status
+}
+
 // ID is a unique ID for the match-order pair.
 func (m *MetaMatch) ID() []byte {
 	return hashKey(append(m.Match.MatchID[:], m.Match.OrderID[:]...))

--- a/client/order/orderbook.go
+++ b/client/order/orderbook.go
@@ -90,7 +90,7 @@ func (ob *OrderBook) setSeq(seq uint64) {
 	ob.seqMtx.Lock()
 	defer ob.seqMtx.Unlock()
 	if seq != ob.seq+1 {
-		log.Errorf("notification received out of sync. %d != %d - 1\n", ob.seq, seq)
+		log.Errorf("notification received out of sync. %d != %d - 1", ob.seq, seq)
 	}
 	if seq > ob.seq {
 		ob.seq = seq

--- a/dex/order/serialize.go
+++ b/dex/order/serialize.go
@@ -128,6 +128,12 @@ func decodeTrade_v0(pushes [][]byte) (mrkt *Trade, err error) {
 	if bEqual(sellB, encode.ByteFalse) {
 		sell = false
 	}
+	if len(qtyB) != 8 {
+		return nil, fmt.Errorf("quantity bytes length %v, expected 8", len(qtyB))
+	}
+	if len(filledB) != 8 {
+		return nil, fmt.Errorf("filled amount bytes length %v, expected 8", len(filledB))
+	}
 	return &Trade{
 		Coins:    coins,
 		Sell:     sell,


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/554 and a few untracked issues

Main changes:
- Async incoming request/notification handling in client/core, no longer blocking
- Parallel client negotiation of trades with new matches (still sequential for a given trade)
- Configurable client request expiration
- Longer request timeouts for client's init and redeem requests, where the server
  may wait up to broadcast timeout to respond.
- Longer timeout on client's coin waiters for `processAudit` and `notifyFee`
- Longer timeout on server's audit request
- Fix client outgoing messages not first being validated before writing to link

**client/core**

Incoming requests and notifications queue the call to the registered
handler function in a dedicated runner goroutine now to prevent
blocking subsequent reqs/ntfns.  If the channel buffer fills, handling
becomes blocking again, as it was before this change.

`(*dexConnection).runMatches` now starts negotiation of a trade's new
matches in parallel since `runMatches`>`tick`>`{swap,redeem,refund}Matches`
can block for a long time waiting for a response from the server.

In `handleMatchRoute`, wait briefly before `runMatches` to reduce the chance
that the server will not have yet saved the match ack sig sent just
prior.  On the server side, `processMatchAcks` now locks all of the
involved `matchTrackers` right out of the gates, before processing the
client's acks.  This is still a race, but it cannot be fully resolved
until/unless the client can get an OK/done back from it's own ack
response to the original match requests.  However, `resendPendingRequests`
will retry failed `'init'` requests so this is not a show stopper bug.

Do not try to swap/redeem/refund cancel matches in `(*trackedTrade).tick`.

Tweak `errorSet` formatting to reflect a set, and rename `ifany` to `ifAny`.

**client/{core,comms}**

Add `comms.WsConn.RequestWithTimeout`, implemented by `wsConn`.
`RequestWithTimeout` has a expire/response timeout duration and expire
callback input args.

Add `comms.DefaultRequestTimeout` for use in vanilla `Request`, and by
consumers that wish to set an expire function, but no particular timeout.

`(*dexConnection).signAndRequest` now accepts a timeout duration.

Remove `core.txWaitExpiration`, which was arbitrary and not coordinated
with the server.  Instead use broadcast timeout in:
- `finalizeSwapAction`>`signAndRequest`, where the server waits for an
  unspecified time that could be up to broadcast timeout.
- `finalizeRedeemAction`>`signAndRequest`, for the same reasons as above
- `processAudit`>`latencyQ.Wait`, since there is no reason to give up sooner
- `notifyFee`, for the same reason as `processAudit`.

However, there may be reason to timeout sooner in the init and redeem
requests if the client thinks resending the request might help.

The `DefaultRequestTimeout` is used in:
- place cancel order request
- place trade order request
- register request
- connect request (`authDEX`)
- config request (`connectDEX`)

TODO: If the server responds to init or redeem with an `Error` payload
with `Code` `TransactionUndiscovered`, the client may try to rebroadcast the
transaction that the server couldn't find, specially if the response
comes well in advance of broadcast timeout (penalization time).

**server/swap**

The audit request timeout should be up to broadcast timeout, but not for
the redemption request where the client does not need to check the coin
network.

Also hold the match mtx locked and check that the match isn't revoked
before storing results in `processInit` and `processRedeem`.

**client/comms**: marshal before attempting link write

In `client/comms.(*wsConn).Send`, marshal the `Message` first so that we
do not send junk to the peer even if it fails to marshal completely,
which `WriteJSON` does.

Test marshal error with `Send`/`Request`, and removal of response handler
in this case with `Request`.

Test `RequestWithTimeout` expiration handler and response handler removal.