### PR TITLE
client/webserver: fix websocket Connect/Send data race

### DIFF
--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -351,7 +351,6 @@ func (s *WebServer) readNotifications(ctx context.Context) {
 		select {
 		case n := <-ch:
 			s.notify(notifyRoute, n)
-			// log.Trace("%s: %s: %s", n.Severity(), n.Subject(), n.Details())
 		case <-ctx.Done():
 			return
 		}

--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -142,7 +142,8 @@ func (c *WSLink) SendError(id uint64, rpcErr *msgjson.Error) {
 	}
 }
 
-// Connect begins processing input and output messages.
+// Connect begins processing input and output messages. Do not send messages
+// until connected.
 func (c *WSLink) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	// Set the initial read deadline now that the ping ticker is about to be
 	// started. The pong handler will set subsequent read deadlines. 2x ping


### PR DESCRIPTION
Add the client to the `WebServer`'s clients map only after it is connected
so that notify does not attempt to send to this client before the
`wsClient` is ready.