### PR TITLE
web: setEpoch should keep orders with no epoch property

### DIFF
--- a/client/webserver/site/src/js/orderbook.js
+++ b/client/webserver/site/src/js/orderbook.js
@@ -64,7 +64,7 @@ export default class OrderBook {
    * setEpoch sets the current epoch and clear any orders from previous epochs.
    */
   setEpoch (epochIdx) {
-    const approve = ord => ord.epoch === 0 || ord.epoch === epochIdx
+    const approve = ord => ord.epoch === undefined || ord.epoch === 0 || ord.epoch === epochIdx
     this.sells = this.sells.filter(approve)
     this.buys = this.buys.filter(approve)
   }


### PR DESCRIPTION
Orders loaded on startup do not have an epoch property set. This changes
OrderBook's setEpoch method to keep orders where the epoch property is
undefined in addition to 0 or the new epochIndex.

Resolves https://github.com/decred/dcrdex/issues/568 and probably https://github.com/decred/dcrdex/issues/553 too