### PR TITLE
multi: Add penalties table.

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3276,7 +3276,7 @@ func handleNotifyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	return nil
 }
 
-// handlePenaltyMsg is called when a notify notification is received.
+// handlePenaltyMsg is called when a Penalty notification is received.
 func handlePenaltyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	var note msgjson.PenaltyNote
 	err := msg.Unmarshal(&note)
@@ -3290,8 +3290,8 @@ func handlePenaltyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	}
 	t := encode.UnixTimeMilli(int64(note.Penalty.Time) * 1000)
 	d := time.Duration(note.Penalty.Duration)
-	details := fmt.Sprintf("Penalty from DEX at %s\nbroken rule: %d\ntime: %v\nduration: %v\ndetails: \"%s\"\n",
-		dc.acct.host, note.Penalty.Rule, t, d, note.Penalty.Details)
+	details := fmt.Sprintf("Penalty from DEX at %s\nbroken rule: %s\ntime: %v\nduration: %v\ndetails: \"%s\"\n",
+		dc.acct.host, note.Penalty.Rule, t, d, fmt.Sprintf("%s\n%s", note.Penalty.Rule.Details(), note.Penalty.Details))
 	n := db.NewNotification("penalty", dc.acct.host, details, db.WarningLevel)
 	c.notify(&n)
 	return nil

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3292,8 +3292,8 @@ func handlePenaltyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	}
 	t := encode.UnixTimeMilli(int64(note.Penalty.Time) * 1000)
 	d := time.Duration(note.Penalty.Duration)
-	details := fmt.Sprintf("Penalty from DEX at %s\nbroken rule: %s\ntime: %v\nduration: %v\ndetails: \"%s\"\n",
-		dc.acct.host, note.Penalty.Rule, t, d, note.Penalty.Details)
+	details := fmt.Sprintf("Penalty from DEX at %s\nbroken rule: %s\ntime: %v\nduration: %v\naccountID: %v\ndetails: \"%s\"\n",
+		dc.acct.host, note.Penalty.Rule, t, d, note.Penalty.AccountID, note.Penalty.Details)
 	n := db.NewNotification("penalty", dc.acct.host, details, db.WarningLevel)
 	c.notify(&n)
 	return nil

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3290,6 +3290,9 @@ func handlePenaltyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	if err != nil {
 		return newError(signatureErr, "handlePenaltyMsg: DEX signature validation error: %v", err)
 	}
+	if !bytes.Equal(note.Penalty.AccountID, dc.acct.id[:]) {
+		return fmt.Errorf("received penalty addressed to wrong accountID: %v", note.Penalty.AccountID)
+	}
 	t := encode.UnixTimeMilli(int64(note.Penalty.Time) * 1000)
 	d := time.Duration(note.Penalty.Duration)
 	details := fmt.Sprintf("Penalty from DEX at %s\nbroken rule: %s\ntime: %v\nduration: %v\naccountID: %v\ndetails: \"%s\"\n",

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3290,13 +3290,13 @@ func handlePenaltyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	if err != nil {
 		return newError(signatureErr, "handlePenaltyMsg: DEX signature validation error: %v", err)
 	}
-	if !bytes.Equal(note.Penalty.AccountID, dc.acct.id[:]) {
+	if !bytes.Equal(note.Penalty.AccountID[:], dc.acct.id[:]) {
 		return fmt.Errorf("received penalty addressed to wrong accountID: %v", note.Penalty.AccountID)
 	}
 	t := encode.UnixTimeMilli(int64(note.Penalty.Time) * 1000)
 	d := time.Duration(note.Penalty.Duration)
 	details := fmt.Sprintf("Penalty from DEX at %s\nbroken rule: %s\ntime: %v\nduration: %v\naccountID: %v\ndetails: \"%s\"\n",
-		dc.acct.host, note.Penalty.Rule, t, d, note.Penalty.AccountID, note.Penalty.Details)
+		dc.acct.host, note.Penalty.BrokenRule, t, d, note.Penalty.AccountID, note.Penalty.Details)
 	n := db.NewNotification("penalty", dc.acct.host, details, db.WarningLevel)
 	c.notify(&n)
 	return nil

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3277,6 +3277,8 @@ func handleNotifyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 }
 
 // handlePenaltyMsg is called when a Penalty notification is received.
+//
+// TODO: Consider other steps needed to take immediately after being banned.
 func handlePenaltyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	var note msgjson.PenaltyNote
 	err := msg.Unmarshal(&note)
@@ -3284,14 +3286,14 @@ func handlePenaltyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 		return fmt.Errorf("penalty note unmarshal error: %v", err)
 	}
 	// Check the signature.
-	err = dc.acct.checkSig(note.Penalty.Serialize(), note.Sig)
+	err = dc.acct.checkSig(note.Serialize(), note.Sig)
 	if err != nil {
-		return newError(signatureErr, "DEX signature validation error: %v", err)
+		return newError(signatureErr, "handlePenaltyMsg: DEX signature validation error: %v", err)
 	}
 	t := encode.UnixTimeMilli(int64(note.Penalty.Time) * 1000)
 	d := time.Duration(note.Penalty.Duration)
 	details := fmt.Sprintf("Penalty from DEX at %s\nbroken rule: %s\ntime: %v\nduration: %v\ndetails: \"%s\"\n",
-		dc.acct.host, note.Penalty.Rule, t, d, fmt.Sprintf("%s\n%s", note.Penalty.Rule.Details(), note.Penalty.Details))
+		dc.acct.host, note.Penalty.Rule, t, d, note.Penalty.Details)
 	n := db.NewNotification("penalty", dc.acct.host, details, db.WarningLevel)
 	c.notify(&n)
 	return nil

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -4195,6 +4195,8 @@ func TestHandlePenaltyMsg(t *testing.T) {
 		Duration: uint64(3153600000000000000),
 		Details:  "You may no longer trade. Leave your client running to finish pending trades.",
 	}
+	rigAcctID := rig.dc.acct.id[:]
+	diffAcctID := append(rig.dc.acct.id[1:], 1)
 	diffKey, _ := secp256k1.GeneratePrivateKey()
 	noMatch, err := msgjson.NewNotification(msgjson.NoMatchRoute, "fake")
 	if err != nil {
@@ -4204,11 +4206,13 @@ func TestHandlePenaltyMsg(t *testing.T) {
 		name    string
 		key     *secp256k1.PrivateKey
 		payload interface{}
+		acctID  []byte
 		wantErr bool
 	}{{
 		name:    "ok",
 		key:     tDexPriv,
 		payload: penalty,
+		acctID:  rigAcctID,
 	}, {
 		name:    "bad note",
 		key:     tDexPriv,
@@ -4218,6 +4222,13 @@ func TestHandlePenaltyMsg(t *testing.T) {
 		name:    "wrong sig",
 		key:     diffKey,
 		payload: penalty,
+		acctID:  rigAcctID,
+		wantErr: true,
+	}, {
+		name:    "wrong acct",
+		key:     tDexPriv,
+		payload: penalty,
+		acctID:  diffAcctID,
 		wantErr: true,
 	}}
 	for _, test := range tests {
@@ -4225,6 +4236,7 @@ func TestHandlePenaltyMsg(t *testing.T) {
 		var note *msgjson.Message
 		switch v := test.payload.(type) {
 		case *msgjson.Penalty:
+			v.AccountID = test.acctID
 			penaltyNote := &msgjson.PenaltyNote{
 				Penalty: v,
 			}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -4190,7 +4190,7 @@ func TestHandlePenaltyMsg(t *testing.T) {
 	tCore := rig.core
 	dc := rig.dc
 	penalty := &msgjson.Penalty{
-		Rule:     []byte{1},
+		Rule:     account.Rule(1),
 		Time:     uint64(1598929305),
 		Duration: uint64(3153600000000000000),
 		Details:  "You may no longer trade. Leave your client running to finish pending trades.",

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -4190,13 +4190,14 @@ func TestHandlePenaltyMsg(t *testing.T) {
 	tCore := rig.core
 	dc := rig.dc
 	penalty := &msgjson.Penalty{
-		Rule:     account.Rule(1),
-		Time:     uint64(1598929305),
-		Duration: uint64(3153600000000000000),
-		Details:  "You may no longer trade. Leave your client running to finish pending trades.",
+		BrokenRule: account.Rule(1),
+		Time:       uint64(1598929305),
+		Duration:   uint64(3153600000000000000),
+		Details:    "You may no longer trade. Leave your client running to finish pending trades.",
 	}
-	rigAcctID := rig.dc.acct.id[:]
-	diffAcctID := append(rig.dc.acct.id[1:], 1)
+	rigAcctID := rig.dc.acct.id
+	diffAcctID := account.AccountID{}
+	copy(diffAcctID[:], append(rig.dc.acct.id[1:], 1))
 	diffKey, _ := secp256k1.GeneratePrivateKey()
 	noMatch, err := msgjson.NewNotification(msgjson.NoMatchRoute, "fake")
 	if err != nil {
@@ -4206,7 +4207,7 @@ func TestHandlePenaltyMsg(t *testing.T) {
 		name    string
 		key     *secp256k1.PrivateKey
 		payload interface{}
-		acctID  []byte
+		acctID  account.AccountID
 		wantErr bool
 	}{{
 		name:    "ok",

--- a/dex/msgjson/msg_test.go
+++ b/dex/msgjson/msg_test.go
@@ -820,7 +820,8 @@ func TestConnect(t *testing.T) {
 }
 
 func TestPenalty(t *testing.T) {
-	// serialization: rule(1) + time (8) + duration (8) + accountid (32) + details (variable, ~100) = 149 bytes
+	// serialization: rule(1) + time (8) + duration (8) + strikes (1) +
+	// accountid (32) + details (variable, ~100) = 150 bytes
 	acctIDSlice, _ := hex.DecodeString("14ae3cbc703587122d68ac6fa9194dfdc8466fb5dec9f47d2805374adff3e016")
 	acctID := account.AccountID{}
 	copy(acctID[:], acctIDSlice)
@@ -828,6 +829,7 @@ func TestPenalty(t *testing.T) {
 		BrokenRule: account.Rule(1),
 		Time:       uint64(1598929305),
 		Duration:   uint64(3153600000000000000),
+		Strikes:    1,
 		AccountID:  acctID,
 		Details:    "You may no longer trade. Leave your client running to finish pending trades.",
 	}
@@ -840,6 +842,8 @@ func TestPenalty(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, 0x5f, 0x4d, 0xb9, 0x99,
 		// Duration 8 bytes.
 		0x2b, 0xc3, 0xd6, 0x7d, 0xd3, 0xac, 0x00, 0x00,
+		// Strikes 1 byte.
+		0x01,
 		// Account ID 32 bytes
 		0x14, 0xae, 0x3c, 0xbc, 0x70, 0x35, 0x87, 0x12, 0x2d, 0x68,
 		0xac, 0x6f, 0xa9, 0x19, 0x4d, 0xfd, 0xc8, 0x46, 0x6f, 0xb5,
@@ -880,6 +884,9 @@ func TestPenalty(t *testing.T) {
 	}
 	if penaltyBack.Duration != penalty.Duration {
 		t.Fatal(penaltyBack.Duration, penalty.Duration)
+	}
+	if penaltyBack.Strikes != penalty.Strikes {
+		t.Fatal(penaltyBack.Strikes, penalty.Strikes)
 	}
 	if !bytes.Equal(penaltyBack.AccountID[:], penalty.AccountID[:]) {
 		t.Fatal(penaltyBack.AccountID, penalty.AccountID)

--- a/dex/msgjson/msg_test.go
+++ b/dex/msgjson/msg_test.go
@@ -820,13 +820,14 @@ func TestConnect(t *testing.T) {
 }
 
 func TestPenalty(t *testing.T) {
-	// serialization: rule(1) + time (8) + duration (8) details (variable,
-	// ~100) = 117 bytes
+	// serialization: rule(1) + time (8) + duration (8) + accountid (32) + details (variable, ~100) = 149 bytes
+	acctID, _ := hex.DecodeString("14ae3cbc703587122d68ac6fa9194dfdc8466fb5dec9f47d2805374adff3e016")
 	penalty := &Penalty{
-		Rule:     account.Rule(1),
-		Time:     uint64(1598929305),
-		Duration: uint64(3153600000000000000),
-		Details:  "You may no longer trade. Leave your client running to finish pending trades.",
+		Rule:      account.Rule(1),
+		Time:      uint64(1598929305),
+		Duration:  uint64(3153600000000000000),
+		AccountID: acctID,
+		Details:   "You may no longer trade. Leave your client running to finish pending trades.",
 	}
 	penaltyNote := &PenaltyNote{Penalty: penalty}
 
@@ -837,6 +838,11 @@ func TestPenalty(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, 0x5f, 0x4d, 0xb9, 0x99,
 		// Duration 8 bytes.
 		0x2b, 0xc3, 0xd6, 0x7d, 0xd3, 0xac, 0x00, 0x00,
+		// Account ID 32 bytes
+		0x14, 0xae, 0x3c, 0xbc, 0x70, 0x35, 0x87, 0x12, 0x2d, 0x68,
+		0xac, 0x6f, 0xa9, 0x19, 0x4d, 0xfd, 0xc8, 0x46, 0x6f, 0xb5,
+		0xde, 0xc9, 0xf4, 0x7d, 0x28, 0x05, 0x37, 0x4a, 0xdf, 0xf3,
+		0xe0, 0x16,
 		// Details 76 bytes.
 		0x59, 0x6f, 0x75, 0x20, 0x6d, 0x61, 0x79, 0x20, 0x6e, 0x6f,
 		0x20, 0x6c, 0x6f, 0x6e, 0x67, 0x65, 0x72, 0x20, 0x74, 0x72,
@@ -872,6 +878,9 @@ func TestPenalty(t *testing.T) {
 	}
 	if penaltyBack.Duration != penalty.Duration {
 		t.Fatal(penaltyBack.Duration, penalty.Duration)
+	}
+	if !bytes.Equal(penaltyBack.AccountID[:], penalty.AccountID[:]) {
+		t.Fatal(penaltyBack.AccountID, penalty.AccountID)
 	}
 	if penaltyBack.Details != penalty.Details {
 		t.Fatal(penaltyBack.Details, penalty.Details)

--- a/dex/msgjson/msg_test.go
+++ b/dex/msgjson/msg_test.go
@@ -828,6 +828,7 @@ func TestPenalty(t *testing.T) {
 		Duration: uint64(3153600000000000000),
 		Details:  "You may no longer trade. Leave your client running to finish pending trades.",
 	}
+	penaltyNote := &PenaltyNote{Penalty: penalty}
 
 	exp := []byte{
 		// Rule 1 byte.
@@ -847,7 +848,7 @@ func TestPenalty(t *testing.T) {
 		0x72, 0x61, 0x64, 0x65, 0x73, 0x2e,
 	}
 
-	b := penalty.Serialize()
+	b := penaltyNote.Serialize()
 	if !bytes.Equal(b, exp) {
 		t.Fatalf("unexpected serialization. Wanted %x, got %x", exp, b)
 	}

--- a/dex/msgjson/msg_test.go
+++ b/dex/msgjson/msg_test.go
@@ -817,6 +817,64 @@ func TestConnect(t *testing.T) {
 	}
 }
 
+func TestPenalty(t *testing.T) {
+	// serialization: rule(1) + time (8) + duration (8) details (variable,
+	// ~100) = 117 bytes
+	penalty := &Penalty{
+		Rule:     []byte{1},
+		Time:     uint64(1598929305),
+		Duration: uint64(3153600000000000000),
+		Details:  "You may no longer trade. Leave your client running to finish pending trades.",
+	}
+
+	exp := []byte{
+		// Rule 1 byte.
+		0x01,
+		// Time 8 bytes.
+		0x00, 0x00, 0x00, 0x00, 0x5f, 0x4d, 0xb9, 0x99,
+		// Duration 8 bytes.
+		0x2b, 0xc3, 0xd6, 0x7d, 0xd3, 0xac, 0x00, 0x00,
+		// Details 76 bytes.
+		0x59, 0x6f, 0x75, 0x20, 0x6d, 0x61, 0x79, 0x20, 0x6e, 0x6f,
+		0x20, 0x6c, 0x6f, 0x6e, 0x67, 0x65, 0x72, 0x20, 0x74, 0x72,
+		0x61, 0x64, 0x65, 0x2e, 0x20, 0x4c, 0x65, 0x61, 0x76, 0x65,
+		0x20, 0x79, 0x6f, 0x75, 0x72, 0x20, 0x63, 0x6c, 0x69, 0x65,
+		0x6e, 0x74, 0x20, 0x72, 0x75, 0x6e, 0x6e, 0x69, 0x6e, 0x67,
+		0x20, 0x74, 0x6f, 0x20, 0x66, 0x69, 0x6e, 0x69, 0x73, 0x68,
+		0x20, 0x70, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67, 0x20, 0x74,
+		0x72, 0x61, 0x64, 0x65, 0x73, 0x2e,
+	}
+
+	b := penalty.Serialize()
+	if !bytes.Equal(b, exp) {
+		t.Fatalf("unexpected serialization. Wanted %x, got %x", exp, b)
+	}
+
+	penaltyB, err := json.Marshal(penalty)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+
+	var penaltyBack Penalty
+	err = json.Unmarshal(penaltyB, &penaltyBack)
+	if err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	if !bytes.Equal(penaltyBack.Rule, penalty.Rule) {
+		t.Fatal(penaltyBack.Rule, penalty.Rule)
+	}
+	if penaltyBack.Time != penalty.Time {
+		t.Fatal(penaltyBack.Time, penalty.Time)
+	}
+	if penaltyBack.Duration != penalty.Duration {
+		t.Fatal(penaltyBack.Duration, penalty.Duration)
+	}
+	if penaltyBack.Details != penalty.Details {
+		t.Fatal(penaltyBack.Details, penalty.Details)
+	}
+}
+
 func TestRegister(t *testing.T) {
 	// serialization: pubkey (33) + time (8) = 41
 	pk, _ := hex.DecodeString("f06e5cf13fc6debb8b90776da6624991ba50a11e784efed53d0a81c3be98397982")

--- a/dex/msgjson/msg_test.go
+++ b/dex/msgjson/msg_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"math/rand"
 	"testing"
+
+	"decred.org/dcrdex/server/account"
 )
 
 func TestExtractMatchID(t *testing.T) {
@@ -821,7 +823,7 @@ func TestPenalty(t *testing.T) {
 	// serialization: rule(1) + time (8) + duration (8) details (variable,
 	// ~100) = 117 bytes
 	penalty := &Penalty{
-		Rule:     []byte{1},
+		Rule:     account.Rule(1),
 		Time:     uint64(1598929305),
 		Duration: uint64(3153600000000000000),
 		Details:  "You may no longer trade. Leave your client running to finish pending trades.",
@@ -861,7 +863,7 @@ func TestPenalty(t *testing.T) {
 		t.Fatalf("unmarshal error: %v", err)
 	}
 
-	if !bytes.Equal(penaltyBack.Rule, penalty.Rule) {
+	if penaltyBack.Rule != penalty.Rule {
 		t.Fatal(penaltyBack.Rule, penalty.Rule)
 	}
 	if penaltyBack.Time != penalty.Time {

--- a/dex/msgjson/msg_test.go
+++ b/dex/msgjson/msg_test.go
@@ -821,13 +821,15 @@ func TestConnect(t *testing.T) {
 
 func TestPenalty(t *testing.T) {
 	// serialization: rule(1) + time (8) + duration (8) + accountid (32) + details (variable, ~100) = 149 bytes
-	acctID, _ := hex.DecodeString("14ae3cbc703587122d68ac6fa9194dfdc8466fb5dec9f47d2805374adff3e016")
+	acctIDSlice, _ := hex.DecodeString("14ae3cbc703587122d68ac6fa9194dfdc8466fb5dec9f47d2805374adff3e016")
+	acctID := account.AccountID{}
+	copy(acctID[:], acctIDSlice)
 	penalty := &Penalty{
-		Rule:      account.Rule(1),
-		Time:      uint64(1598929305),
-		Duration:  uint64(3153600000000000000),
-		AccountID: acctID,
-		Details:   "You may no longer trade. Leave your client running to finish pending trades.",
+		BrokenRule: account.Rule(1),
+		Time:       uint64(1598929305),
+		Duration:   uint64(3153600000000000000),
+		AccountID:  acctID,
+		Details:    "You may no longer trade. Leave your client running to finish pending trades.",
 	}
 	penaltyNote := &PenaltyNote{Penalty: penalty}
 
@@ -870,8 +872,8 @@ func TestPenalty(t *testing.T) {
 		t.Fatalf("unmarshal error: %v", err)
 	}
 
-	if penaltyBack.Rule != penalty.Rule {
-		t.Fatal(penaltyBack.Rule, penalty.Rule)
+	if penaltyBack.BrokenRule != penalty.BrokenRule {
+		t.Fatal(penaltyBack.BrokenRule, penalty.BrokenRule)
 	}
 	if penaltyBack.Time != penalty.Time {
 		t.Fatal(penaltyBack.Time, penalty.Time)

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -159,7 +159,7 @@ const (
 	// delivering text messages from the operator.
 	NotifyRoute = "notify"
 	// PenaltyRoute is the DEX-originating notification-type message
-	// informing of a broken rule and the subsequent penalty.
+	// informing of a broken rule and the resulting penalty.
 	PenaltyRoute = "penalty"
 )
 
@@ -832,6 +832,8 @@ func (c *Connect) Serialize() []byte {
 }
 
 // ConnectResult is the result for the ConnectRoute request.
+//
+// TODO: Include penalty data as specified in the spec.
 type ConnectResult struct {
 	Sig     Bytes    `json:"sig"`
 	Matches []*Match `json:"matches"`
@@ -839,22 +841,22 @@ type ConnectResult struct {
 
 // PenaltyNote is the payload of a Penalty notification.
 type PenaltyNote struct {
-	Sig     Bytes    `json:"sig"`
+	Signature
 	Penalty *Penalty `json:"penalty"`
 }
 
 // Penalty is part of the payload for a dex-originating Penalty notification
 // and part of the connect response.
 type Penalty struct {
-	Signature
 	Rule     account.Rule `json:"rule"`
 	Time     uint64       `json:"timestamp"`
 	Duration uint64       `json:"duration"`
 	Details  string       `json:"details"`
 }
 
-// Serialize serializes the Penalty data.
-func (p *Penalty) Serialize() []byte {
+// Serialize serializes the PenaltyNote data.
+func (n *PenaltyNote) Serialize() []byte {
+	p := n.Penalty
 	// serialization: rule(1) + time (8) + duration (8) details (variable,
 	// ~100) = 117 bytes
 	b := make([]byte, 0, 117)

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -157,6 +157,9 @@ const (
 	// NotifyRoute is the DEX-originating notification-type message
 	// delivering text messages from the operator.
 	NotifyRoute = "notify"
+	// PenaltyRoute is the DEX-originating notification-type message
+	// informing of a broken rule and the subsequent penalty.
+	PenaltyRoute = "penalty"
 )
 
 type Bytes = dex.Bytes
@@ -827,10 +830,37 @@ func (c *Connect) Serialize() []byte {
 	return append(s, uint64Bytes(c.Time)...)
 }
 
-// ConnectResult is the result result for the ConnectRoute request.
+// ConnectResult is the result for the ConnectRoute request.
 type ConnectResult struct {
 	Sig     Bytes    `json:"sig"`
 	Matches []*Match `json:"matches"`
+}
+
+// PenaltyNote is the payload of a Penalty notification.
+type PenaltyNote struct {
+	Sig     Bytes    `json:"sig"`
+	Penalty *Penalty `json:"penalty"`
+}
+
+// Penalty is part of the payload for a dex-originating Penalty notification
+// and part of the connect response.
+type Penalty struct {
+	Signature
+	Rule     Bytes  `json:"rule"`
+	Time     uint64 `json:"timestamp"`
+	Duration uint64 `json:"duration"`
+	Details  string `json:"details"`
+}
+
+// Serialize serializes the Penalty data.
+func (p *Penalty) Serialize() []byte {
+	// serialization: rule(1) + time (8) + duration (8) details (variable,
+	// ~100) = 117 bytes
+	b := make([]byte, 0, 117)
+	b = append(b, p.Rule...)
+	b = append(b, uint64Bytes(p.Time)...)
+	b = append(b, uint64Bytes(p.Duration)...)
+	return append(b, []byte(p.Details)...)
 }
 
 // Register is the payload for the RegisterRoute request.

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/account"
 )
 
 // Error codes
@@ -846,10 +847,10 @@ type PenaltyNote struct {
 // and part of the connect response.
 type Penalty struct {
 	Signature
-	Rule     Bytes  `json:"rule"`
-	Time     uint64 `json:"timestamp"`
-	Duration uint64 `json:"duration"`
-	Details  string `json:"details"`
+	Rule     account.Rule `json:"rule"`
+	Time     uint64       `json:"timestamp"`
+	Duration uint64       `json:"duration"`
+	Details  string       `json:"details"`
 }
 
 // Serialize serializes the Penalty data.
@@ -857,7 +858,7 @@ func (p *Penalty) Serialize() []byte {
 	// serialization: rule(1) + time (8) + duration (8) details (variable,
 	// ~100) = 117 bytes
 	b := make([]byte, 0, 117)
-	b = append(b, p.Rule...)
+	b = append(b, byte(p.Rule))
 	b = append(b, uint64Bytes(p.Time)...)
 	b = append(b, uint64Bytes(p.Duration)...)
 	return append(b, []byte(p.Details)...)

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -848,11 +848,11 @@ type PenaltyNote struct {
 // Penalty is part of the payload for a dex-originating Penalty notification
 // and part of the connect response.
 type Penalty struct {
-	Rule      account.Rule `json:"rule"`
-	Time      uint64       `json:"timestamp"`
-	Duration  uint64       `json:"duration"`
-	AccountID Bytes        `json:"accountid"`
-	Details   string       `json:"details"`
+	BrokenRule account.Rule      `json:"brokenrule"`
+	Time       uint64            `json:"timestamp"`
+	Duration   uint64            `json:"duration"`
+	AccountID  account.AccountID `json:"accountid"`
+	Details    string            `json:"details"`
 }
 
 // Serialize serializes the PenaltyNote data.
@@ -861,10 +861,10 @@ func (n *PenaltyNote) Serialize() []byte {
 	// serialization: rule(1) + time (8) + duration (8) + accountid (32) +
 	// details (variable, ~100) = 149 bytes
 	b := make([]byte, 0, 117)
-	b = append(b, byte(p.Rule))
+	b = append(b, byte(p.BrokenRule))
 	b = append(b, uint64Bytes(p.Time)...)
 	b = append(b, uint64Bytes(p.Duration)...)
-	b = append(b, p.AccountID...)
+	b = append(b, p.AccountID[:]...)
 	return append(b, []byte(p.Details)...)
 }
 

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -848,21 +848,23 @@ type PenaltyNote struct {
 // Penalty is part of the payload for a dex-originating Penalty notification
 // and part of the connect response.
 type Penalty struct {
-	Rule     account.Rule `json:"rule"`
-	Time     uint64       `json:"timestamp"`
-	Duration uint64       `json:"duration"`
-	Details  string       `json:"details"`
+	Rule      account.Rule `json:"rule"`
+	Time      uint64       `json:"timestamp"`
+	Duration  uint64       `json:"duration"`
+	AccountID Bytes        `json:"accountid"`
+	Details   string       `json:"details"`
 }
 
 // Serialize serializes the PenaltyNote data.
 func (n *PenaltyNote) Serialize() []byte {
 	p := n.Penalty
-	// serialization: rule(1) + time (8) + duration (8) details (variable,
-	// ~100) = 117 bytes
+	// serialization: rule(1) + time (8) + duration (8) + accountid (32) +
+	// details (variable, ~100) = 149 bytes
 	b := make([]byte, 0, 117)
 	b = append(b, byte(p.Rule))
 	b = append(b, uint64Bytes(p.Time)...)
 	b = append(b, uint64Bytes(p.Duration)...)
+	b = append(b, p.AccountID...)
 	return append(b, []byte(p.Details)...)
 }
 

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -852,18 +852,20 @@ type Penalty struct {
 	Time       uint64            `json:"timestamp"`
 	Duration   uint64            `json:"duration"`
 	AccountID  account.AccountID `json:"accountid"`
+	Strikes    uint8             `json:"strikes"`
 	Details    string            `json:"details"`
 }
 
 // Serialize serializes the PenaltyNote data.
 func (n *PenaltyNote) Serialize() []byte {
 	p := n.Penalty
-	// serialization: rule(1) + time (8) + duration (8) + accountid (32) +
-	// details (variable, ~100) = 149 bytes
+	// serialization: rule (1) + time (8) + duration (8) + strikes (1) +
+	// accountid (32) + details (variable, ~100) = 150 bytes
 	b := make([]byte, 0, 117)
 	b = append(b, byte(p.BrokenRule))
 	b = append(b, uint64Bytes(p.Time)...)
 	b = append(b, uint64Bytes(p.Duration)...)
+	b = append(b, p.Strikes)
 	b = append(b, p.AccountID[:]...)
 	return append(b, []byte(p.Details)...)
 }

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -131,6 +131,7 @@ const (
 // details holds rule specific details.
 type details struct {
 	name, description string
+	strikes           uint8
 	duration          time.Duration
 }
 
@@ -139,26 +140,31 @@ var ruleDetails = map[Rule]details{
 	NoRule: {
 		name:        "NoRule",
 		description: "no rules have been broken",
+		strikes:     0,
 		duration:    0,
 	},
 	PreimageReveal: {
 		name:        "PreimageReveal",
 		description: "failed to respond with a valid preimage for an order during epoch processing",
+		strikes:     1,
 		duration:    century,
 	},
 	FailureToAct: {
 		name:        "FailureToAct",
 		description: "did not follow through on a swap negotiation step",
+		strikes:     1,
 		duration:    century,
 	},
 	CancellationRate: {
 		name:        "CancellationRate",
 		description: "cancellation rate dropped below the acceptable level",
+		strikes:     1,
 		duration:    century,
 	},
 	LowFees: {
 		name:        "LowFees",
 		description: "did not pay transaction mining fees at the requisite level",
+		strikes:     1,
 		duration:    century,
 	},
 }
@@ -184,7 +190,15 @@ func (r Rule) Duration() time.Duration {
 	if d, ok := ruleDetails[r]; ok {
 		return d.duration
 	}
-	return century
+	return 0
+}
+
+// Strikes return the number of strikes breaking this penalty gives.
+func (r Rule) Strikes() uint8 {
+	if d, ok := ruleDetails[r]; ok {
+		return d.strikes
+	}
+	return 0
 }
 
 // Punishable returns whether breaking this rule incurs a penalty.

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -96,6 +96,10 @@ const (
 	NoRule Rule = iota
 	// FailureToAct means that an account has not followed through on one of their
 	// swap negotiation steps.
+	PreimageReveal
+	// MaxRule in not an actual rule. It is a placeholder that is used to
+	// determine the total number of rules. It must always be the last
+	// definition in this list.
 	FailureToAct
 	// CancellationRate means the account's cancellation rate  has dropped below
 	// the acceptable level.
@@ -105,20 +109,16 @@ const (
 	LowFees
 	// PreimageReveal means an account failed to respond with a valid preimage
 	// for their order during epoch processing.
-	PreimageReveal
-	// MaxRule in not an actual rule. It is a placeholder that is used to
-	// determine the total number of rules. It must always be the last
-	// definition in this list.
 	MaxRule
 )
 
 // ruleNames is a map of rules to names.
 var ruleNames = map[Rule]string{
 	NoRule:            "NoRule",
+	PreimageReveal:    "PreimageReveal",
 	FailureToAct:      "FailureToAct",
 	CancellationRatio: "CancellationRatio",
 	LowFees:           "LowFees",
-	PreimageReveal:    "PreimageReveal",
 }
 
 // String satisfies the Stringer interface.
@@ -132,10 +132,10 @@ func (r Rule) String() string {
 // ruleDetails is a map of rules to details.
 var ruleDetails = map[Rule]string{
 	NoRule:            "no rules have been broken",
+	PreimageReveal:    "failed to respond with a valid preimage for an order during epoch processing",
 	FailureToAct:      "did not follow through on a swap negotiation step",
 	CancellationRatio: "cancellation rate dropped below the acceptable level",
 	LowFees:           "did not pay transaction mining fees at the requisite level",
-	PreimageReveal:    "failed to respond with a valid preimage for an order during epoch processing",
 }
 
 // Details returns details about the rule.
@@ -149,10 +149,10 @@ func (r Rule) Details() string {
 // ruleDuration is a map of rules to penalty durations.
 var ruleDurations = map[Rule]time.Duration{
 	NoRule:            0,
+	PreimageReveal:    century,
 	FailureToAct:      century,
 	CancellationRatio: century,
 	LowFees:           century,
-	PreimageReveal:    century,
 }
 
 // Duration returns the penalty duration of the rule being broken.

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -114,36 +114,36 @@ const (
 
 // details holds rule specific details.
 type details struct {
-	name, details string
-	duration      time.Duration
+	name, description string
+	duration          time.Duration
 }
 
 // ruleDetails maps rules to rule details.
 var ruleDetails = map[Rule]details{
 	NoRule: {
-		name:     "NoRule",
-		details:  "no rules have been broken",
-		duration: 0,
+		name:        "NoRule",
+		description: "no rules have been broken",
+		duration:    0,
 	},
 	PreimageReveal: {
-		name:     "PreimageReveal",
-		details:  "failed to respond with a valid preimage for an order during epoch processing",
-		duration: century,
+		name:        "PreimageReveal",
+		description: "failed to respond with a valid preimage for an order during epoch processing",
+		duration:    century,
 	},
 	FailureToAct: {
-		name:     "FailureToAct",
-		details:  "did not follow through on a swap negotiation step",
-		duration: century,
+		name:        "FailureToAct",
+		description: "did not follow through on a swap negotiation step",
+		duration:    century,
 	},
-	CancellationRatio: {
-		name:     "CancellationRatio",
-		details:  "cancellation rate dropped below the acceptable level",
-		duration: century,
+	CancellationRate: {
+		name:        "CancellationRate",
+		description: "cancellation rate dropped below the acceptable level",
+		duration:    century,
 	},
 	LowFees: {
-		name:     "LowFees",
-		details:  "did not pay transaction mining fees at the requisite level",
-		duration: century,
+		name:        "LowFees",
+		description: "did not pay transaction mining fees at the requisite level",
+		duration:    century,
 	},
 }
 
@@ -155,12 +155,12 @@ func (r Rule) String() string {
 	return "unknown rule"
 }
 
-// Details returns details about the rule.
-func (r Rule) Details() string {
+// Description returns a description of the rule.
+func (r Rule) Description() string {
 	if d, ok := ruleDetails[r]; ok {
-		return d.details
+		return d.description
 	}
-	return "details not specified"
+	return "description not specified"
 }
 
 // Duration returns the penalty duration of the rule being broken.

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -94,12 +94,11 @@ const (
 	// NoRule indicates that no rules have been broken. This may be an invalid
 	// value in some contexts.
 	NoRule Rule = iota
+	// PreimageReveal means an account failed to respond with a valid preimage
+	// for their order during epoch processing.
+	PreimageReveal
 	// FailureToAct means that an account has not followed through on one of their
 	// swap negotiation steps.
-	PreimageReveal
-	// MaxRule in not an actual rule. It is a placeholder that is used to
-	// determine the total number of rules. It must always be the last
-	// definition in this list.
 	FailureToAct
 	// CancellationRate means the account's cancellation rate  has dropped below
 	// the acceptable level.
@@ -107,58 +106,67 @@ const (
 	// LowFees means an account made a transaction that didn't pay fees at the
 	// requisite level.
 	LowFees
-	// PreimageReveal means an account failed to respond with a valid preimage
-	// for their order during epoch processing.
+	// MaxRule in not an actual rule. It is a placeholder that is used to
+	// determine the total number of rules. It must always be the last
+	// definition in this list.
 	MaxRule
 )
 
-// ruleNames is a map of rules to names.
-var ruleNames = map[Rule]string{
-	NoRule:            "NoRule",
-	PreimageReveal:    "PreimageReveal",
-	FailureToAct:      "FailureToAct",
-	CancellationRatio: "CancellationRatio",
-	LowFees:           "LowFees",
+// details holds rule specific details.
+type details struct {
+	name, details string
+	duration      time.Duration
+}
+
+// ruleDetails maps rules to rule details.
+var ruleDetails = map[Rule]details{
+	NoRule: {
+		name:     "NoRule",
+		details:  "no rules have been broken",
+		duration: 0,
+	},
+	PreimageReveal: {
+		name:     "PreimageReveal",
+		details:  "failed to respond with a valid preimage for an order during epoch processing",
+		duration: century,
+	},
+	FailureToAct: {
+		name:     "FailureToAct",
+		details:  "did not follow through on a swap negotiation step",
+		duration: century,
+	},
+	CancellationRatio: {
+		name:     "CancellationRatio",
+		details:  "cancellation rate dropped below the acceptable level",
+		duration: century,
+	},
+	LowFees: {
+		name:     "LowFees",
+		details:  "did not pay transaction mining fees at the requisite level",
+		duration: century,
+	},
 }
 
 // String satisfies the Stringer interface.
 func (r Rule) String() string {
-	if name, ok := ruleNames[r]; ok {
-		return name
+	if d, ok := ruleDetails[r]; ok {
+		return d.name
 	}
 	return "unknown rule"
 }
 
-// ruleDetails is a map of rules to details.
-var ruleDetails = map[Rule]string{
-	NoRule:            "no rules have been broken",
-	PreimageReveal:    "failed to respond with a valid preimage for an order during epoch processing",
-	FailureToAct:      "did not follow through on a swap negotiation step",
-	CancellationRatio: "cancellation rate dropped below the acceptable level",
-	LowFees:           "did not pay transaction mining fees at the requisite level",
-}
-
 // Details returns details about the rule.
 func (r Rule) Details() string {
-	if details, ok := ruleDetails[r]; ok {
-		return details
+	if d, ok := ruleDetails[r]; ok {
+		return d.details
 	}
 	return "details not specified"
 }
 
-// ruleDuration is a map of rules to penalty durations.
-var ruleDurations = map[Rule]time.Duration{
-	NoRule:            0,
-	PreimageReveal:    century,
-	FailureToAct:      century,
-	CancellationRatio: century,
-	LowFees:           century,
-}
-
 // Duration returns the penalty duration of the rule being broken.
 func (r Rule) Duration() time.Duration {
-	if duration, ok := ruleDurations[r]; ok {
-		return duration
+	if d, ok := ruleDetails[r]; ok {
+		return d.duration
 	}
 	return century
 }

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -42,6 +42,22 @@ func (aid AccountID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(aid.String())
 }
 
+// UnarshalJSON satisfies the json.Unmarshaller interface, and will unmarshal
+// the id.
+func (aid *AccountID) UnmarshalJSON(data []byte) error {
+	// Unmarshalling from the byte representation of the hex string.
+	s := ""
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	copy(aid[:], b)
+	return nil
+}
+
 // Value implements the sql/driver.Valuer interface.
 func (aid AccountID) Value() (driver.Value, error) {
 	return aid[:], nil // []byte

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -189,7 +189,7 @@ func (s *Server) apiAccountInfo(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("failed to retrieve account: %v", err), http.StatusInternalServerError)
 		return
 	}
-	// If verbose expired and forgiven penalties will be included.
+	// If verbose, expired and forgiven penalties will be included.
 	dbPenalties, err := s.core.Penalties(acctID, verbose)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to retrieve penalties: %v", err), http.StatusInternalServerError)

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -221,8 +221,9 @@ func (s *Server) apiBan(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("bad rule: %v", err), http.StatusBadRequest)
 		return
 	}
-	if ruleInt < 1 || ruleInt >= int(account.MaxRule) {
-		http.Error(w, "bad rule: not known or not punishable", http.StatusBadRequest)
+	if !account.Rule(ruleInt).Punishable() {
+		msg := fmt.Sprintf("bad rule (%d): not known or not punishable", ruleInt)
+		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
 	if err := s.core.Penalize(acctID, account.Rule(ruleInt)); err != nil {

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -239,14 +239,10 @@ func (s *Server) apiBan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// TODO: Allow operator supplied details to go with the ban.
-	if err := s.core.Penalize(acctID, account.Rule(ruleInt), ""); err != nil {
+	res, err := s.core.Penalize(acctID, account.Rule(ruleInt), "")
+	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to ban account: %v", err), http.StatusInternalServerError)
 		return
-	}
-	res := BanResult{
-		AccountID:  acctIDStr,
-		BrokenRule: byte(ruleInt),
-		BanTime:    APITime{time.Now()},
 	}
 	writeJSON(w, res)
 }

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -226,7 +226,8 @@ func (s *Server) apiBan(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
-	if err := s.core.Penalize(acctID, account.Rule(ruleInt)); err != nil {
+	// TODO: Allow operator supplied details to go with the ban.
+	if err := s.core.Penalize(acctID, account.Rule(ruleInt), ""); err != nil {
 		http.Error(w, fmt.Sprintf("failed to ban account: %v", err), http.StatusInternalServerError)
 		return
 	}

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -190,7 +190,7 @@ func (s *Server) apiAccountInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// If verbose, expired and forgiven penalties will be included.
-	dbPenalties, err := s.core.Penalties(acctID, verbose)
+	dbPenalties, _, err := s.core.Penalties(acctID, 0, verbose)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to retrieve penalties: %v", err), http.StatusInternalServerError)
 		return

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -49,7 +49,7 @@ type SvrCore interface {
 	Accounts() (accts []*db.Account, err error)
 	AccountInfo(acctID account.AccountID) (*db.Account, error)
 	Notify(acctID account.AccountID, msg *msgjson.Message, timeout time.Duration)
-	Penalties(acctID account.AccountID, all bool) ([]*db.Penalty, error)
+	Penalties(acctID account.AccountID, strikeThreshold int, all bool) ([]*db.Penalty, time.Time, error)
 	NotifyAll(msg *msgjson.Message)
 	ConfigMsg() json.RawMessage
 	MarketRunning(mktName string) (found, running bool)

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -37,6 +37,7 @@ const (
 	ruleToken     = "rule"
 	messageToken  = "message"
 	timeoutToken  = "timeout"
+	verboseToken  = "verbose"
 )
 
 var (
@@ -48,6 +49,7 @@ type SvrCore interface {
 	Accounts() (accts []*db.Account, err error)
 	AccountInfo(acctID account.AccountID) (*db.Account, error)
 	Notify(acctID account.AccountID, msg *msgjson.Message, timeout time.Duration)
+	Penalties(acctID account.AccountID, all bool) ([]*db.Penalty, error)
 	NotifyAll(msg *msgjson.Message)
 	ConfigMsg() json.RawMessage
 	MarketRunning(mktName string) (found, running bool)

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -54,7 +54,7 @@ type SvrCore interface {
 	MarketStatus(mktName string) *market.Status
 	MarketStatuses() map[string]*market.Status
 	SuspendMarket(name string, tSusp time.Time, persistBooks bool) *market.SuspendEpoch
-	Penalize(aid account.AccountID, rule account.Rule) error
+	Penalize(aid account.AccountID, rule account.Rule, details string) error
 	Unban(aid account.AccountID) error
 }
 

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -56,7 +56,7 @@ type SvrCore interface {
 	MarketStatus(mktName string) *market.Status
 	MarketStatuses() map[string]*market.Status
 	SuspendMarket(name string, tSusp time.Time, persistBooks bool) *market.SuspendEpoch
-	Penalize(aid account.AccountID, rule account.Rule, details string) error
+	Penalize(aid account.AccountID, rule account.Rule, details string) (*db.Penalty, error)
 	Unban(aid account.AccountID) error
 }
 

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -775,7 +775,6 @@ func TestAccounts(t *testing.T) {
 		Pubkey:     dex.Bytes(pubkey),
 		FeeAddress: "DsdQFmH3azyoGKJHt2ArJNxi35LCEgMqi8k",
 		FeeCoin:    dex.Bytes(feeCoin),
-		BrokenRule: account.Rule(byte(255)),
 	}
 	core.accounts = append(core.accounts, acct)
 
@@ -794,8 +793,7 @@ func TestAccounts(t *testing.T) {
         "accountid": "0a9912205b2cbab0c25c2de30bda9074de0ae23b065489a99199bad763f102cc",
         "pubkey": "0204988a498d5d19514b217e872b4dbd1cf071d365c4879e64ed5919881c97eb19",
         "feeaddress": "DsdQFmH3azyoGKJHt2ArJNxi35LCEgMqi8k",
-        "feecoin": "6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005",
-        "brokenrule": 255
+        "feecoin": "6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005"
     }
 ]
 `

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -150,8 +150,8 @@ func (c *TCore) Accounts() ([]*db.Account, error) { return c.accounts, c.account
 func (c *TCore) AccountInfo(_ account.AccountID) (*db.Account, error) {
 	return c.accountInfo, c.accountInfoErr
 }
-func (c *TCore) Penalties(_ account.AccountID, _ bool) ([]*db.Penalty, error) {
-	return c.penalties, c.penaltiesErr
+func (c *TCore) Penalties(acctID account.AccountID, strikeThreshold int, all bool) ([]*db.Penalty, time.Time, error) {
+	return c.penalties, time.Time{}, c.penaltiesErr
 }
 func (c *TCore) Penalize(_ account.AccountID, _ account.Rule, _ string) (*db.Penalty, error) {
 	return c.penalize, c.penalizeErr

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -147,7 +147,7 @@ func (c *TCore) Accounts() ([]*db.Account, error) { return c.accounts, c.account
 func (c *TCore) AccountInfo(_ account.AccountID) (*db.Account, error) {
 	return c.account, c.accountErr
 }
-func (c *TCore) Penalize(_ account.AccountID, _ account.Rule) error {
+func (c *TCore) Penalize(_ account.AccountID, _ account.Rule, _ string) error {
 	return c.penalizeErr
 }
 func (c *TCore) Unban(_ account.AccountID) error {

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -55,6 +55,7 @@ type TCore struct {
 	accountInfoErr error
 	penalties      []*db.Penalty
 	penaltiesErr   error
+	penalize       *db.Penalty
 	penalizeErr    error
 	unbanErr       error
 }
@@ -152,8 +153,8 @@ func (c *TCore) AccountInfo(_ account.AccountID) (*db.Account, error) {
 func (c *TCore) Penalties(_ account.AccountID, _ bool) ([]*db.Penalty, error) {
 	return c.penalties, c.penaltiesErr
 }
-func (c *TCore) Penalize(_ account.AccountID, _ account.Rule, _ string) error {
-	return c.penalizeErr
+func (c *TCore) Penalize(_ account.AccountID, _ account.Rule, _ string) (*db.Penalty, error) {
+	return c.penalize, c.penalizeErr
 }
 func (c *TCore) Unban(_ account.AccountID) error {
 	return c.unbanErr
@@ -961,7 +962,7 @@ func TestBan(t *testing.T) {
 			t.Fatalf("%q: apiBan returned code %d, expected %d", test.name, w.Code, test.wantCode)
 		}
 		if w.Code == http.StatusOK {
-			res := new(BanResult)
+			res := new(db.Penalty)
 			if err := json.Unmarshal(w.Body.Bytes(), res); err != nil {
 				t.Errorf("%q: unexpected response %v: %v", test.name, w.Body.String(), err)
 			}

--- a/server/admin/types.go
+++ b/server/admin/types.go
@@ -2,6 +2,8 @@ package admin
 
 import (
 	"time"
+
+	"decred.org/dcrdex/server/db"
 )
 
 // MarketStatus summarizes the operational status of a market.
@@ -65,4 +67,10 @@ type BanResult struct {
 type UnbanResult struct {
 	AccountID string  `json:"accountid"`
 	UnbanTime APITime `json:"unbantime"`
+}
+
+// AccountInfoResult holds the result of apiAccountInfo.
+type AccountInfoResult struct {
+	*db.Account
+	Penalties []*db.Penalty `json:"penalties,omitempty"`
 }

--- a/server/admin/types.go
+++ b/server/admin/types.go
@@ -56,13 +56,6 @@ func (at *APITime) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// BanResult holds the result of a ban.
-type BanResult struct {
-	AccountID  string  `json:"accountid"`
-	BrokenRule byte    `json:"brokenrule"`
-	BanTime    APITime `json:"bantime"`
-}
-
 // UnbanResult holds the result of an unban.
 type UnbanResult struct {
 	AccountID string  `json:"accountid"`

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -698,7 +698,7 @@ func (auth *AuthManager) Penalize(user account.AccountID, rule account.Rule, ext
 	if auth.anarchy {
 		details = "You were penalized but the penalty will not be counted against you."
 	}
-	details = fmt.Sprintf("%s\nRule Details: %s\n%s", details, rule.Details(), extraDetails)
+	details = fmt.Sprintf("%s\nRule Details: %s\n%s", details, rule.Description(), extraDetails)
 	penalty := &msgjson.Penalty{
 		Rule:      rule,
 		Time:      uint64(unixMsNow().Unix()),

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -694,21 +694,25 @@ func (auth *AuthManager) Notify(acctID account.AccountID, msg *msgjson.Message, 
 // their account should be penalized.
 func (auth *AuthManager) Penalize(user account.AccountID, rule account.Rule) error {
 	// Notify user of penalty.
-	details := "You may no longer trade. Leave your client running to complete outstanding trades."
+	details := "Ordering has been suspended for this account. Contact the exchange operator to reinstate privileges."
+	if auth.anarchy {
+		details = "You were penalized but the penalty will not be counted against you."
+	}
+	details = fmt.Sprintf("%s\n%s", details, rule.Details())
 	penalty := &msgjson.Penalty{
 		Rule:     rule,
 		Time:     uint64(unixMsNow().Unix()),
-		Duration: uint64(time.Hour * 24 * 365 * 100), // 100 years
+		Duration: uint64(rule.Duration()),
 		Details:  details,
 	}
-	sig, err := auth.signer.Sign(penalty.Serialize())
+	penaltyNote := &msgjson.PenaltyNote{
+		Penalty: penalty,
+	}
+	sig, err := auth.signer.Sign(penaltyNote.Serialize())
 	if err != nil {
 		return fmt.Errorf("signature error: %v", err)
 	}
-	penaltyNote := &msgjson.PenaltyNote{
-		Sig:     sig.Serialize(),
-		Penalty: penalty,
-	}
+	penaltyNote.Sig = sig.Serialize()
 	note, err := msgjson.NewNotification(msgjson.PenaltyRoute, penaltyNote)
 	if err != nil {
 		return fmt.Errorf("error creating penalty notification: %v", err)

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -78,10 +78,10 @@ func (s *TStorage) CompletedUserOrders(aid account.AccountID, N int) (oids []ord
 func (s *TStorage) ExecutedCancelsForUser(aid account.AccountID, N int) (oids, targets []order.OrderID, execTimes []int64, err error) {
 	return s.ratio.oidsCancels, s.ratio.oidsCanceled, s.ratio.timesCanceled, nil
 }
-func (s *TStorage) InsertPenalty(penalty *db.Penalty) int64 {
+func (s *TStorage) InsertPenalty(penalty *db.Penalty) (int64, error) {
 	s.closedID = penalty.AccountID
 	s.penalties = []*db.Penalty{penalty}
-	return 0
+	return 0, nil
 }
 func (s *TStorage) ForgivePenalty(id int64) error { return nil }
 func (s *TStorage) ForgivePenalties(aid account.AccountID) error {
@@ -89,11 +89,8 @@ func (s *TStorage) ForgivePenalties(aid account.AccountID) error {
 	s.penalties = nil
 	return nil
 }
-func (s *TStorage) Penalties(aid account.AccountID) (penalties []*db.Penalty, err error) {
+func (s *TStorage) Penalties(aid account.AccountID, all bool) (penalties []*db.Penalty, err error) {
 	return s.penalties, nil
-}
-func (s *TStorage) AllPenalties(aid account.AccountID) (penalties []*db.Penalty, err error) {
-	return nil, nil
 }
 
 // TSigner satisfies the Signer interface

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -961,12 +961,12 @@ func TestPenalize(t *testing.T) {
 
 	// Cannot set account as suspended in the clients map if they are not
 	// connected, but should still suspend in DB.
-	rig.mgr.Penalize(foreigner.acctID, 0)
+	rig.mgr.Penalize(foreigner.acctID, 0, "details")
 	var zeroAcct account.AccountID
 	// if rig.storage.closedID != zeroAcct {
 	// 	t.Fatalf("foreigner penalty stored")
 	// }
-	rig.mgr.Penalize(user.acctID, 0)
+	rig.mgr.Penalize(user.acctID, 0, "details")
 	if rig.storage.closedID != user.acctID {
 		t.Fatalf("penalty not stored")
 	}

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -85,6 +85,15 @@ func (s *TStorage) CompletedUserOrders(aid account.AccountID, N int) (oids []ord
 func (s *TStorage) ExecutedCancelsForUser(aid account.AccountID, N int) (oids, targets []order.OrderID, execTimes []int64, err error) {
 	return s.ratio.oidsCancels, s.ratio.oidsCanceled, s.ratio.timesCanceled, nil
 }
+func (s *TStorage) InsertPenalty(penalty *db.Penalty) error      { return nil }
+func (s *TStorage) ForgivePenalty(id int64) error                { return nil }
+func (s *TStorage) ForgivePenalties(aid account.AccountID) error { return nil }
+func (s *TStorage) Penalties(aid account.AccountID) (penalties []*db.Penalty, err error) {
+	return nil, nil
+}
+func (s *TStorage) AllPenalties(aid account.AccountID) (penalties []*db.Penalty, err error) {
+	return nil, nil
+}
 
 // TSigner satisfies the Signer interface
 type TSigner struct {

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -78,10 +78,10 @@ func (s *TStorage) CompletedUserOrders(aid account.AccountID, N int) (oids []ord
 func (s *TStorage) ExecutedCancelsForUser(aid account.AccountID, N int) (oids, targets []order.OrderID, execTimes []int64, err error) {
 	return s.ratio.oidsCancels, s.ratio.oidsCanceled, s.ratio.timesCanceled, nil
 }
-func (s *TStorage) InsertPenalty(penalty *db.Penalty) error {
+func (s *TStorage) InsertPenalty(penalty *db.Penalty) int64 {
 	s.closedID = penalty.AccountID
 	s.penalties = []*db.Penalty{penalty}
-	return nil
+	return 0
 }
 func (s *TStorage) ForgivePenalty(id int64) error { return nil }
 func (s *TStorage) ForgivePenalties(aid account.AccountID) error {

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -89,8 +89,12 @@ func (s *TStorage) ForgivePenalties(aid account.AccountID) error {
 	s.penalties = nil
 	return nil
 }
-func (s *TStorage) Penalties(aid account.AccountID, all bool) (penalties []*db.Penalty, err error) {
-	return s.penalties, nil
+func (s *TStorage) Penalties(aid account.AccountID, strikeThreshold int, all bool) (penalties []*db.Penalty, bannedUntil time.Time, err error) {
+	t := time.Time{}
+	if len(s.penalties) > 0 {
+		t = time.Now().Add(time.Second * 10)
+	}
+	return s.penalties, t, nil
 }
 
 // TSigner satisfies the Signer interface

--- a/server/auth/registrar.go
+++ b/server/auth/registrar.go
@@ -137,10 +137,10 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 	if paid {
 		return &msgjson.Error{
 			Code:    msgjson.AuthenticationError,
-			Message: "'notifyfee' send for paid account",
+			Message: "'notifyfee' sent for paid account",
 		}
 	}
-	penalties, err := auth.storage.Penalties(acctID)
+	penalties, err := auth.storage.Penalties(acctID, false)
 	if err != nil {
 		log.Errorf("Penalties(%x): %v", acctID, err)
 		return &msgjson.Error{
@@ -151,7 +151,7 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 	if len(penalties) > 0 {
 		return &msgjson.Error{
 			Code:    msgjson.AuthenticationError,
-			Message: "account closed and cannot be reopen",
+			Message: "account closed and cannot be reopened",
 		}
 	}
 

--- a/server/db/driver/pg/internal/accounts.go
+++ b/server/db/driver/pg/internal/accounts.go
@@ -13,8 +13,7 @@ const (
 		account_id BYTEA PRIMARY KEY,  -- UNIQUE INDEX
 		pubkey BYTEA,
 		fee_address TEXT,
-		fee_coin BYTEA,
-		broken_rule INT2 DEFAULT 0
+		fee_coin BYTEA
 		);`
 
 	// InsertKeyIfMissing creates an entry for the specified key hash, if it
@@ -29,14 +28,10 @@ const (
 		WHERE key_hash = $1
 		RETURNING child;`
 
-	// CloseAccount sets the broken_rule column for the account, which signifies
-	// that the account is closed.
-	CloseAccount = `UPDATE %s SET broken_rule = $1 WHERE account_id = $2;`
-
 	// SelectAccount gathers account details for the specified accound ID. The
 	// details returned from this query are sufficient to determine 1) whether the
 	// registration fee has been paid, or 2) whether the account has been closed.
-	SelectAccount = `SELECT pubkey, fee_coin, broken_rule
+	SelectAccount = `SELECT pubkey, fee_coin
 		FROM %s
 		WHERE account_id = $1;`
 

--- a/server/db/driver/pg/internal/penalties.go
+++ b/server/db/driver/pg/internal/penalties.go
@@ -1,0 +1,43 @@
+package internal
+
+const (
+	// CreatePenaltyTable created the penalties table. It is keyed by id
+	// which is an int64 that is incremented automatically by the database.
+	CreatePenaltyTable = `CREATE TABLE IF NOT EXISTS %s (
+		id BIGSERIAL PRIMARY KEY,   -- UNIQUE INDEX
+		account_id BYTEA,
+		broken_rule INT2,
+		time INT8,
+		duration INT8,
+		details TEXT,
+		forgiven INT2 DEFAULT 0
+	);`
+
+	// InsertPenalty inserts a row. The id is assigned automatically, and
+	// forgiven is left as the default of 0.
+	InsertPenalty = `INSERT INTO %s (account_id, broken_rule, time, duration, details)
+		VALUES ($1, $2, $3, $4, $5);`
+
+	// ForgivePenalty sets forgiven for a record with id to 1.
+	ForgivePenalty = `UPDATE %s
+		SET forgiven = 1
+		WHERE id = $1;`
+
+	// ForgivePenalties sets forgiven for not expired records with
+	// account_id to 1.
+	ForgivePenalties = `UPDATE %s
+		SET forgiven = 1
+		WHERE account_id = $1
+		AND time+duration > $2;`
+
+	// SelectPenalties selects all not forgiven, not expired rows for
+	// account_id.
+	SelectPenalties = `SELECT * FROM %s
+		WHERE account_id = $1
+		AND forgiven = 0
+		AND time+duration > $2;`
+
+	// SelectAllPenalties selects all rows for account_id.
+	SelectAllPenalties = `SELECT * FROM %s
+		WHERE account_id = $1;`
+)

--- a/server/db/driver/pg/internal/penalties.go
+++ b/server/db/driver/pg/internal/penalties.go
@@ -9,14 +9,15 @@ const (
 		broken_rule INT2,
 		time INT8,
 		duration INT8,
+		strikes INT2,
 		details TEXT,
 		forgiven INT2 DEFAULT 0
 	);`
 
 	// InsertPenalty inserts a row. The id is assigned automatically, and
 	// forgiven is left as the default of 0.
-	InsertPenalty = `INSERT INTO %s (account_id, broken_rule, time, duration, details)
-		VALUES ($1, $2, $3, $4, $5)
+	InsertPenalty = `INSERT INTO %s (account_id, broken_rule, time, duration, strikes, details)
+		VALUES ($1, $2, $3, $4, $5, $6)
 		RETURNING id;`
 
 	// ForgivePenalty sets forgiven for a record with id to 1.

--- a/server/db/driver/pg/internal/penalties.go
+++ b/server/db/driver/pg/internal/penalties.go
@@ -1,7 +1,7 @@
 package internal
 
 const (
-	// CreatePenaltyTable created the penalties table. It is keyed by id
+	// CreatePenaltyTable creates the penalties table. It is keyed by id
 	// which is an int64 that is incremented automatically by the database.
 	CreatePenaltyTable = `CREATE TABLE IF NOT EXISTS %s (
 		id BIGSERIAL PRIMARY KEY,   -- UNIQUE INDEX

--- a/server/db/driver/pg/internal/penalties.go
+++ b/server/db/driver/pg/internal/penalties.go
@@ -16,7 +16,8 @@ const (
 	// InsertPenalty inserts a row. The id is assigned automatically, and
 	// forgiven is left as the default of 0.
 	InsertPenalty = `INSERT INTO %s (account_id, broken_rule, time, duration, details)
-		VALUES ($1, $2, $3, $4, $5);`
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id;`
 
 	// ForgivePenalty sets forgiven for a record with id to 1.
 	ForgivePenalty = `UPDATE %s

--- a/server/db/driver/pg/penalties.go
+++ b/server/db/driver/pg/penalties.go
@@ -1,0 +1,76 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package pg
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/server/account"
+	"decred.org/dcrdex/server/db"
+	"decred.org/dcrdex/server/db/driver/pg/internal"
+)
+
+// InsertPenalty adds penalty to the penalties table. The passed ID and Forgiven
+// fields are ignored.
+func (a *Archiver) InsertPenalty(penalty *db.Penalty) error {
+	stmt := fmt.Sprintf(internal.InsertPenalty, penaltiesTableName)
+	_, err := a.db.Exec(stmt, penalty.AccountID, penalty.BrokenRule, penalty.Time, penalty.Duration, penalty.Details)
+	return err
+}
+
+// ForgivePenalties forgives all penalties currenty held by a user.
+func (a *Archiver) ForgivePenalties(aid account.AccountID) error {
+	stmt := fmt.Sprintf(internal.ForgivePenalties, penaltiesTableName)
+	_, err := a.db.Exec(stmt, aid, encode.UnixMilli(time.Now()))
+	return err
+}
+
+// ForgivePenalty forgives a penalty.
+func (a *Archiver) ForgivePenalty(id int64) error {
+	stmt := fmt.Sprintf(internal.ForgivePenalty, penaltiesTableName)
+	_, err := a.db.Exec(stmt, id)
+	return err
+}
+
+// Penalties returns penalties that are currently in effect for a user.
+// Forgiven and expired penalties are not included.
+func (a *Archiver) Penalties(aid account.AccountID) ([]*db.Penalty, error) {
+	stmt := fmt.Sprintf(internal.SelectPenalties, penaltiesTableName)
+	return penalties(a.db, stmt, aid, encode.UnixMilli(time.Now()))
+}
+
+// AllPenalties returns all penalties for a user, even those that are forgiven
+// or expired.
+func (a *Archiver) AllPenalties(aid account.AccountID) ([]*db.Penalty, error) {
+	stmt := fmt.Sprintf(internal.SelectAllPenalties, penaltiesTableName)
+	return penalties(a.db, stmt, aid)
+}
+
+// penalties returns a slice of penalties for a user, depending on the passed
+// statement and arguments.
+func penalties(dbe *sql.DB, stmt string, args ...interface{}) ([]*db.Penalty, error) {
+	rows, err := dbe.Query(stmt, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var penalties []*db.Penalty
+	var details sql.NullString
+	for rows.Next() {
+		p := new(db.Penalty)
+		err = rows.Scan(&p.ID, &p.AccountID, &p.BrokenRule, &p.Time, &p.Duration, &details, &p.Forgiven)
+		if err != nil {
+			return nil, err
+		}
+		p.Details = details.String
+		penalties = append(penalties, p)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return penalties, nil
+}

--- a/server/db/driver/pg/penalties.go
+++ b/server/db/driver/pg/penalties.go
@@ -6,6 +6,7 @@ package pg
 import (
 	"database/sql"
 	"fmt"
+	"sort"
 	"time"
 
 	"decred.org/dcrdex/dex/encode"
@@ -21,7 +22,7 @@ func (a *Archiver) InsertPenalty(penalty *db.Penalty) (int64, error) {
 	stmt := fmt.Sprintf(internal.InsertPenalty, penaltiesTableName)
 	var id int64
 	err := a.db.QueryRow(stmt, penalty.AccountID, penalty.BrokenRule,
-		int64(penalty.Time), penalty.Duration, penalty.Details).Scan(&id)
+		int64(penalty.Time), penalty.Duration, penalty.Strikes, penalty.Details).Scan(&id)
 	if err != nil {
 		return 0, err
 	}
@@ -43,14 +44,48 @@ func (a *Archiver) ForgivePenalty(id int64) error {
 }
 
 // Penalties returns penalties that are currently in effect for a user.
-// Forgiven and expired penalties are not included unless all is true.
-func (a *Archiver) Penalties(aid account.AccountID, all bool) ([]*db.Penalty, error) {
+// Forgiven and expired penalties are not included unless all is true. If the
+// user has enough strikes to bring them to the strike threshold, the latest
+// expiration time that brings them under the strike threshold is returned. If
+// not, or the strike threshold is 0, zero time is returned.
+func (a *Archiver) Penalties(aid account.AccountID, strikeThreshold int, all bool) ([]*db.Penalty, time.Time, error) {
+	var (
+		pens     []*db.Penalty
+		err      error
+		zeroTime = time.Time{}
+	)
 	if all {
 		stmt := fmt.Sprintf(internal.SelectAllPenalties, penaltiesTableName)
-		return penalties(a.db, stmt, aid)
+		pens, err = penalties(a.db, stmt, aid)
+		if err != nil {
+			return nil, zeroTime, err
+		}
+	} else {
+		stmt := fmt.Sprintf(internal.SelectPenalties, penaltiesTableName)
+		pens, err = penalties(a.db, stmt, aid, encode.UnixMilli(time.Now()))
+		if err != nil {
+			return nil, zeroTime, err
+		}
 	}
-	stmt := fmt.Sprintf(internal.SelectPenalties, penaltiesTableName)
-	return penalties(a.db, stmt, aid, encode.UnixMilli(time.Now()))
+	if strikeThreshold == 0 {
+		return pens, zeroTime, nil
+	}
+	strikes := 0
+	times := make([]uint64, 0)
+	for _, p := range pens {
+		strikes += int(p.Strikes)
+		// Add one entry to times per strike.
+		for i := 0; i < int(p.Strikes); i++ {
+			times = append(times, p.Time+p.Duration)
+		}
+	}
+	if strikes < strikeThreshold {
+		return pens, zeroTime, nil
+	}
+	sort.Slice(times, func(i, j int) bool { return times[i] < times[j] })
+	// Ban time is until the last time within the strike threshold.
+	bannedUntil := times[strikes-strikeThreshold]
+	return pens, encode.UnixTimeMilli(int64(bannedUntil)), nil
 }
 
 // penalties returns a slice of penalties for a user, depending on the passed
@@ -69,7 +104,7 @@ func penalties(dbe *sql.DB, stmt string, args ...interface{}) ([]*db.Penalty, er
 	for rows.Next() {
 		p := &db.Penalty{Penalty: new(msgjson.Penalty)}
 
-		err = rows.Scan(&p.ID, &p.AccountID, &p.BrokenRule, &t, &p.Duration, &details, &p.Forgiven)
+		err = rows.Scan(&p.ID, &p.AccountID, &p.BrokenRule, &t, &p.Duration, &p.Strikes, &details, &p.Forgiven)
 		if err != nil {
 			return nil, err
 		}

--- a/server/db/driver/pg/penalties.go
+++ b/server/db/driver/pg/penalties.go
@@ -16,11 +16,12 @@ import (
 )
 
 // InsertPenalty adds penalty to the penalties table. The passed ID and Forgiven
-// fields are ignored.
-func (a *Archiver) InsertPenalty(penalty *db.Penalty) error {
+// fields are ignored. The db decided id is returned.
+func (a *Archiver) InsertPenalty(penalty *db.Penalty) (id int64) {
 	stmt := fmt.Sprintf(internal.InsertPenalty, penaltiesTableName)
-	_, err := a.db.Exec(stmt, penalty.AccountID, penalty.BrokenRule, int64(penalty.Time), penalty.Duration, penalty.Details)
-	return err
+	a.db.QueryRow(stmt, penalty.AccountID, penalty.BrokenRule,
+		int64(penalty.Time), penalty.Duration, penalty.Details).Scan(&id)
+	return id
 }
 
 // ForgivePenalties forgives all penalties currenty held by a user.

--- a/server/db/driver/pg/penalties.go
+++ b/server/db/driver/pg/penalties.go
@@ -19,8 +19,11 @@ import (
 // fields are ignored. The db decided id is returned.
 func (a *Archiver) InsertPenalty(penalty *db.Penalty) (id int64) {
 	stmt := fmt.Sprintf(internal.InsertPenalty, penaltiesTableName)
-	a.db.QueryRow(stmt, penalty.AccountID, penalty.BrokenRule,
-		int64(penalty.Time), penalty.Duration, penalty.Details).Scan(&id)
+	if err := a.db.QueryRow(stmt, penalty.AccountID, penalty.BrokenRule,
+		int64(penalty.Time), penalty.Duration, penalty.Details).Scan(&id); err != nil {
+		a.fatalBackendErr(err)
+		return 0
+	}
 	return id
 }
 

--- a/server/db/driver/pg/penalties_online_test.go
+++ b/server/db/driver/pg/penalties_online_test.go
@@ -1,0 +1,160 @@
+// +build pgonline
+
+package pg
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/server/account"
+	"decred.org/dcrdex/server/db"
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestPenalties(t *testing.T) {
+	// Clear penalties table before testing.
+	truncatePenalties := `TRUNCATE %s;`
+	stmt := fmt.Sprintf(truncatePenalties, penaltiesTableName)
+	if _, err := sqlExec(archie.db, stmt); err != nil {
+		t.Fatalf("error truncating penalties: %v", err)
+	}
+
+	acctID := account.AccountID{
+		0x0a, 0x99, 0x12, 0x20, 0x5b, 0x2c, 0xba, 0xb0, 0xc2, 0x5c, 0x2d, 0xe3, 0x0b,
+		0xda, 0x90, 0x74, 0xde, 0x0a, 0xe2, 0x3b, 0x06, 0x54, 0x89, 0xa9, 0x91, 0x99,
+		0xba, 0xd7, 0x63, 0xf1, 0x02, 0xcc,
+	}
+	anotherAcctID := account.AccountID{
+		0x0b, 0x99, 0x12, 0x20, 0x5b, 0x2c, 0xba, 0xb0, 0xc2, 0x5c, 0x2d, 0xe3, 0x0b,
+		0xda, 0x90, 0x74, 0xde, 0x0a, 0xe2, 0x3b, 0x06, 0x54, 0x89, 0xa9, 0x91, 0x99,
+		0xba, 0xd7, 0x63, 0xf1, 0x02, 0xcc,
+	}
+	twoSecs := (time.Second * 2).Milliseconds()
+	tenSecs := (time.Second * 10).Milliseconds()
+	nowInMS := encode.UnixMilli(time.Now())
+	penaltyTwoSec := &db.Penalty{
+		AccountID:  acctID,
+		BrokenRule: 1,
+		Time:       nowInMS,
+		Duration:   twoSecs,
+		Details:    "details",
+	}
+	penaltyTenSec := &db.Penalty{
+		AccountID:  acctID,
+		BrokenRule: 1,
+		Time:       nowInMS,
+		Duration:   tenSecs,
+		Details:    "details",
+	}
+	penaltyTenSecDiffUser := &db.Penalty{
+		AccountID:  anotherAcctID,
+		BrokenRule: 1,
+		Time:       nowInMS,
+		Duration:   tenSecs,
+		Details:    "details",
+	}
+	// Add penalties.
+	if err := archie.InsertPenalty(penaltyTwoSec); err != nil {
+		t.Fatal(err)
+	}
+	if err := archie.InsertPenalty(penaltyTenSec); err != nil {
+		t.Fatal(err)
+	}
+	if err := archie.InsertPenalty(penaltyTenSecDiffUser); err != nil {
+		t.Fatal(err)
+	}
+	// Check penalties
+	penalties, err := archie.Penalties(acctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(penalties) != 2 {
+		t.Fatal("wrong number of penalties")
+	}
+	// IDs were added upon inserting.
+	penaltyTwoSec.ID = penalties[0].ID
+	penaltyTenSec.ID = penalties[1].ID
+	if !reflect.DeepEqual(penalties[0], penaltyTwoSec) {
+		t.Fatalf("first penalty not equal: expected %v got %v", spew.Sdump(penaltyTwoSec), spew.Sdump(penalties[0]))
+	}
+	if !reflect.DeepEqual(penalties[1], penaltyTenSec) {
+		t.Fatalf("second penalty not equal: expected %v got %v", spew.Sdump(penaltyTenSec), spew.Sdump(penalties[1]))
+	}
+	// Wait the duration of the first penalty.
+	time.Sleep(time.Second*2 + time.Millisecond)
+	// Check penalties. The expired penalty should not be returned.
+	penalties, err = archie.Penalties(acctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(penalties) != 1 {
+		t.Fatal("wrong number of penalties")
+	}
+	if !reflect.DeepEqual(penalties[0], penaltyTenSec) {
+		t.Fatalf("first penalty not equal: expected %v got %v", spew.Sdump(penaltyTenSec), spew.Sdump(penalties[0]))
+	}
+	// Forgive the active penalty.
+	id := penaltyTenSec.ID
+	if err := archie.ForgivePenalty(id); err != nil {
+		t.Fatal(err)
+	}
+	// Check penalties. One is expired and the other forgiven, so none
+	// should be returned.
+	penalties, err = archie.Penalties(acctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(penalties) != 0 {
+		t.Fatal("wrong number of penalties")
+	}
+	// They should still show up for AllPenalties.
+	penalties, err = archie.AllPenalties(acctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(penalties) != 2 {
+		t.Fatal("wrong number of penalties")
+	}
+	// Add two more.
+	if err := archie.InsertPenalty(penaltyTenSec); err != nil {
+		t.Fatal(err)
+	}
+	if err := archie.InsertPenalty(penaltyTenSec); err != nil {
+		t.Fatal(err)
+	}
+	// They are currently in effect.
+	penalties, err = archie.Penalties(acctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(penalties) != 2 {
+		t.Fatal("wrong number of penalties")
+	}
+	// Forgive all penalties for this user.
+	if err := archie.ForgivePenalties(acctID); err != nil {
+		t.Fatal(err)
+	}
+	// Check that they are forgiven.
+	penalties, err = archie.Penalties(acctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(penalties) != 0 {
+		t.Fatal("wrong number of penalties")
+	}
+	// The other user's penalty is still in effect.
+	penalties, err = archie.Penalties(anotherAcctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(penalties) != 1 {
+		t.Fatal("wrong number of penalties")
+	}
+	penaltyTenSecDiffUser.ID = penalties[0].ID
+	if !reflect.DeepEqual(penalties[0], penaltyTenSecDiffUser) {
+		t.Fatalf("second penalty not equal: expected %v got %v", spew.Sdump(penaltyTenSecDiffUser), spew.Sdump(penalties[0]))
+	}
+}

--- a/server/db/driver/pg/penalties_online_test.go
+++ b/server/db/driver/pg/penalties_online_test.go
@@ -64,11 +64,20 @@ func TestPenalties(t *testing.T) {
 		},
 	}
 	// Add penalties.
-	idTwoSec := archie.InsertPenalty(penaltyTwoSec)
-	idTenSec := archie.InsertPenalty(penaltyTenSec)
-	archie.InsertPenalty(penaltyTenSecDiffUser)
+	idTwoSec, err := archie.InsertPenalty(penaltyTwoSec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idTenSec, err := archie.InsertPenalty(penaltyTenSec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = archie.InsertPenalty(penaltyTenSecDiffUser)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Check penalties
-	penalties, err := archie.Penalties(acctID)
+	penalties, err := archie.Penalties(acctID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +96,7 @@ func TestPenalties(t *testing.T) {
 	// Wait the duration of the first penalty.
 	time.Sleep(time.Second*2 + time.Millisecond)
 	// Check penalties. The expired penalty should not be returned.
-	penalties, err = archie.Penalties(acctID)
+	penalties, err = archie.Penalties(acctID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,15 +112,15 @@ func TestPenalties(t *testing.T) {
 	}
 	// Check penalties. One is expired and the other forgiven, so none
 	// should be returned.
-	penalties, err = archie.Penalties(acctID)
+	penalties, err = archie.Penalties(acctID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(penalties) != 0 {
 		t.Fatal("wrong number of penalties")
 	}
-	// They should still show up for AllPenalties.
-	penalties, err = archie.AllPenalties(acctID)
+	// They should still show up for all penalties.
+	penalties, err = archie.Penalties(acctID, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -119,10 +128,16 @@ func TestPenalties(t *testing.T) {
 		t.Fatal("wrong number of penalties")
 	}
 	// Add two more.
-	archie.InsertPenalty(penaltyTenSec)
-	archie.InsertPenalty(penaltyTenSec)
+	_, err = archie.InsertPenalty(penaltyTenSec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = archie.InsertPenalty(penaltyTenSec)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// They are currently in effect.
-	penalties, err = archie.Penalties(acctID)
+	penalties, err = archie.Penalties(acctID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +149,7 @@ func TestPenalties(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Check that they are forgiven.
-	penalties, err = archie.Penalties(acctID)
+	penalties, err = archie.Penalties(acctID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +157,7 @@ func TestPenalties(t *testing.T) {
 		t.Fatal("wrong number of penalties")
 	}
 	// The other user's penalty is still in effect.
-	penalties, err = archie.Penalties(anotherAcctID)
+	penalties, err = archie.Penalties(anotherAcctID, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/db/driver/pg/penalties_online_test.go
+++ b/server/db/driver/pg/penalties_online_test.go
@@ -64,15 +64,9 @@ func TestPenalties(t *testing.T) {
 		},
 	}
 	// Add penalties.
-	if err := archie.InsertPenalty(penaltyTwoSec); err != nil {
-		t.Fatal(err)
-	}
-	if err := archie.InsertPenalty(penaltyTenSec); err != nil {
-		t.Fatal(err)
-	}
-	if err := archie.InsertPenalty(penaltyTenSecDiffUser); err != nil {
-		t.Fatal(err)
-	}
+	idTwoSec := archie.InsertPenalty(penaltyTwoSec)
+	idTenSec := archie.InsertPenalty(penaltyTenSec)
+	archie.InsertPenalty(penaltyTenSecDiffUser)
 	// Check penalties
 	penalties, err := archie.Penalties(acctID)
 	if err != nil {
@@ -82,8 +76,8 @@ func TestPenalties(t *testing.T) {
 		t.Fatal("wrong number of penalties")
 	}
 	// IDs were added upon inserting.
-	penaltyTwoSec.ID = penalties[0].ID
-	penaltyTenSec.ID = penalties[1].ID
+	penaltyTwoSec.ID = idTwoSec
+	penaltyTenSec.ID = idTenSec
 	if !reflect.DeepEqual(penalties[0], penaltyTwoSec) {
 		t.Fatalf("first penalty not equal: expected %v got %v", spew.Sdump(penaltyTwoSec), spew.Sdump(penalties[0]))
 	}
@@ -104,8 +98,7 @@ func TestPenalties(t *testing.T) {
 		t.Fatalf("first penalty not equal: expected %v got %v", spew.Sdump(penaltyTenSec), spew.Sdump(penalties[0]))
 	}
 	// Forgive the active penalty.
-	id := penaltyTenSec.ID
-	if err := archie.ForgivePenalty(id); err != nil {
+	if err := archie.ForgivePenalty(idTenSec); err != nil {
 		t.Fatal(err)
 	}
 	// Check penalties. One is expired and the other forgiven, so none
@@ -126,12 +119,8 @@ func TestPenalties(t *testing.T) {
 		t.Fatal("wrong number of penalties")
 	}
 	// Add two more.
-	if err := archie.InsertPenalty(penaltyTenSec); err != nil {
-		t.Fatal(err)
-	}
-	if err := archie.InsertPenalty(penaltyTenSec); err != nil {
-		t.Fatal(err)
-	}
+	archie.InsertPenalty(penaltyTenSec)
+	archie.InsertPenalty(penaltyTenSec)
 	// They are currently in effect.
 	penalties, err = archie.Penalties(acctID)
 	if err != nil {

--- a/server/db/driver/pg/penalties_online_test.go
+++ b/server/db/driver/pg/penalties_online_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
 	"github.com/davecgh/go-spew/spew"
@@ -32,29 +33,35 @@ func TestPenalties(t *testing.T) {
 		0xda, 0x90, 0x74, 0xde, 0x0a, 0xe2, 0x3b, 0x06, 0x54, 0x89, 0xa9, 0x91, 0x99,
 		0xba, 0xd7, 0x63, 0xf1, 0x02, 0xcc,
 	}
-	twoSecs := (time.Second * 2).Milliseconds()
-	tenSecs := (time.Second * 10).Milliseconds()
-	nowInMS := encode.UnixMilli(time.Now())
+	twoSecs := uint64((time.Second * 2).Milliseconds())
+	tenSecs := uint64((time.Second * 10).Milliseconds())
+	nowInMS := encode.UnixMilliU(time.Now())
 	penaltyTwoSec := &db.Penalty{
-		AccountID:  acctID,
-		BrokenRule: 1,
-		Time:       nowInMS,
-		Duration:   twoSecs,
-		Details:    "details",
+		Penalty: &msgjson.Penalty{
+			AccountID:  acctID,
+			BrokenRule: 1,
+			Time:       nowInMS,
+			Duration:   twoSecs,
+			Details:    "details",
+		},
 	}
 	penaltyTenSec := &db.Penalty{
-		AccountID:  acctID,
-		BrokenRule: 1,
-		Time:       nowInMS,
-		Duration:   tenSecs,
-		Details:    "details",
+		Penalty: &msgjson.Penalty{
+			AccountID:  acctID,
+			BrokenRule: 1,
+			Time:       nowInMS,
+			Duration:   tenSecs,
+			Details:    "details",
+		},
 	}
 	penaltyTenSecDiffUser := &db.Penalty{
-		AccountID:  anotherAcctID,
-		BrokenRule: 1,
-		Time:       nowInMS,
-		Duration:   tenSecs,
-		Details:    "details",
+		Penalty: &msgjson.Penalty{
+			AccountID:  anotherAcctID,
+			BrokenRule: 1,
+			Time:       nowInMS,
+			Duration:   tenSecs,
+			Details:    "details",
+		},
 	}
 	// Add penalties.
 	if err := archie.InsertPenalty(penaltyTwoSec); err != nil {

--- a/server/db/driver/pg/tables.go
+++ b/server/db/driver/pg/tables.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	marketsTableName  = "markets"
-	metaTableName     = "meta"
-	feeKeysTableName  = "fee_keys"
-	accountsTableName = "accounts"
+	marketsTableName   = "markets"
+	metaTableName      = "meta"
+	feeKeysTableName   = "fee_keys"
+	accountsTableName  = "accounts"
+	penaltiesTableName = "penalties"
 )
 
 type tableStmt struct {
@@ -31,6 +32,10 @@ var createDEXTableStatements = []tableStmt{
 var createAccountTableStatements = []tableStmt{
 	{feeKeysTableName, internal.CreateFeeKeysTable},
 	{accountsTableName, internal.CreateAccountsTable},
+}
+
+var createPenaltyTableStatements = []tableStmt{
+	{penaltiesTableName, internal.CreatePenaltyTable},
 }
 
 var createMarketTableStatements = []tableStmt{
@@ -52,6 +57,9 @@ var tableMap = func() map[string]string {
 		m[pair.name] = pair.stmt
 	}
 	for _, pair := range createAccountTableStatements {
+		m[pair.name] = pair.stmt
+	}
+	for _, pair := range createPenaltyTableStatements {
 		m[pair.name] = pair.stmt
 	}
 	return m
@@ -137,6 +145,11 @@ func PrepareTables(db *sql.DB, mktConfig []*dex.MarketInfo) error {
 
 	// Prepare the account and registration key counter tables.
 	err = createAccountTables(db)
+	if err != nil {
+		return err
+	}
+
+	_, err = CreateTable(db, "", penaltiesTableName)
 	if err != nil {
 		return err
 	}

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -80,6 +80,7 @@ type DEXArchivist interface {
 	AccountArchiver
 	MatchArchiver
 	SwapArchiver
+	PenaltyArchiver
 }
 
 // OrderArchiver is the interface required for storage and retrieval of all
@@ -384,4 +385,22 @@ func ValidateOrder(ord order.Order, status order.OrderStatus, mkt *dex.MarketInf
 	}
 
 	return order.ValidateOrder(ord, status, mkt.LotSize) == nil
+}
+
+// PenaltyArchiver is the interface required for storage and retrieval of all
+// Penalty data.
+type PenaltyArchiver interface {
+	// InsertPenalty adds penalty to the penalties table. The passed ID and
+	// Forgiven fields are ignored.
+	InsertPenalty(penalty *Penalty) error
+	// ForgivePenalty forgives a penalty.
+	ForgivePenalty(id int64) error
+	// ForgivePenalties forgives all penalties currenty held by a user.
+	ForgivePenalties(aid account.AccountID) error
+	// Penalties returns penalties that are currently in effect for a user.
+	// Forgiven and expired penalties are not included.
+	Penalties(aid account.AccountID) (penalties []*Penalty, err error)
+	// AllPenalties returns all penalties for a user, even those that are
+	// forgiven or expired.
+	AllPenalties(aid account.AccountID) (penalties []*Penalty, err error)
 }

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -386,15 +386,12 @@ func ValidateOrder(ord order.Order, status order.OrderStatus, mkt *dex.MarketInf
 type PenaltyArchiver interface {
 	// InsertPenalty adds penalty to the penalties table. The passed ID and
 	// Forgiven fields are ignored. The db decided id is returned.
-	InsertPenalty(penalty *Penalty) (id int64)
+	InsertPenalty(penalty *Penalty) (id int64, err error)
 	// ForgivePenalty forgives a penalty.
 	ForgivePenalty(id int64) error
 	// ForgivePenalties forgives all penalties currenty held by a user.
 	ForgivePenalties(aid account.AccountID) error
 	// Penalties returns penalties that are currently in effect for a user.
-	// Forgiven and expired penalties are not included.
-	Penalties(aid account.AccountID) (penalties []*Penalty, err error)
-	// AllPenalties returns all penalties for a user, even those that are
-	// forgiven or expired.
-	AllPenalties(aid account.AccountID) (penalties []*Penalty, err error)
+	// Forgiven and expired penalties are not included unless all is true.
+	Penalties(aid account.AccountID, all bool) (penalties []*Penalty, err error)
 }

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -178,16 +178,10 @@ type OrderArchiver interface {
 // AccountArchiver is the interface required for storage and retrieval of all
 // account data.
 type AccountArchiver interface {
-	// CloseAccount closes an account for violating a rule of community conduct.
-	CloseAccount(account.AccountID, account.Rule) error
-
-	// RestoreAccount opens an account that was previously closed by CloseAccount.
-	RestoreAccount(account.AccountID) error
-
 	// Account retrieves the account information for the specified account ID.
 	// The registration fee payment status is returned as well. A nil pointer
 	// will be returned for unknown or closed accounts.
-	Account(account.AccountID) (acct *account.Account, paid, open bool)
+	Account(account.AccountID) (acct *account.Account, paid bool)
 
 	// CreateAccount stores a new account. The account is considered unpaid until
 	// PayAccount is used to set the payment details.

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -393,5 +393,10 @@ type PenaltyArchiver interface {
 	ForgivePenalties(aid account.AccountID) error
 	// Penalties returns penalties that are currently in effect for a user.
 	// Forgiven and expired penalties are not included unless all is true.
-	Penalties(aid account.AccountID, all bool) (penalties []*Penalty, err error)
+	// strikeThreshold is the number of strikes a user can have until they
+	// are considered banned. If strikeThreshold is not zero, the time a
+	// user is banned until is calculated and return. If zero or the user
+	// does not have enough strikes to meet the strikeThreshold, zero time
+	// is returned.
+	Penalties(aid account.AccountID, strikeThreshold int, all bool) (penalties []*Penalty, bannedUntil time.Time, err error)
 }

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -385,8 +385,8 @@ func ValidateOrder(ord order.Order, status order.OrderStatus, mkt *dex.MarketInf
 // Penalty data.
 type PenaltyArchiver interface {
 	// InsertPenalty adds penalty to the penalties table. The passed ID and
-	// Forgiven fields are ignored.
-	InsertPenalty(penalty *Penalty) error
+	// Forgiven fields are ignored. The db decided id is returned.
+	InsertPenalty(penalty *Penalty) (id int64)
 	// ForgivePenalty forgives a penalty.
 	ForgivePenalty(id int64) error
 	// ForgivePenalties forgives all penalties currenty held by a user.

--- a/server/db/types.go
+++ b/server/db/types.go
@@ -16,3 +16,14 @@ type Account struct {
 	FeeCoin    dex.Bytes         `json:"feecoin"`
 	BrokenRule account.Rule      `json:"brokenrule"`
 }
+
+// Penalty holds data stored in the Penalty table.
+type Penalty struct {
+	ID         int64             `json:"id"`
+	AccountID  account.AccountID `json:"accountid"`
+	BrokenRule account.Rule      `json:"brokenrule"`
+	Time       int64             `json:"timestamp"`
+	Duration   int64             `json:"duration"`
+	Details    string            `json:"details"`
+	Forgiven   bool              `json:"forgiven"`
+}

--- a/server/db/types.go
+++ b/server/db/types.go
@@ -5,6 +5,7 @@ package db
 
 import (
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/server/account"
 )
 
@@ -14,16 +15,11 @@ type Account struct {
 	Pubkey     dex.Bytes         `json:"pubkey"`
 	FeeAddress string            `json:"feeaddress"`
 	FeeCoin    dex.Bytes         `json:"feecoin"`
-	BrokenRule account.Rule      `json:"brokenrule"`
 }
 
 // Penalty holds data stored in the Penalty table.
 type Penalty struct {
-	ID         int64             `json:"id"`
-	AccountID  account.AccountID `json:"accountid"`
-	BrokenRule account.Rule      `json:"brokenrule"`
-	Time       int64             `json:"timestamp"`
-	Duration   int64             `json:"duration"`
-	Details    string            `json:"details"`
-	Forgiven   bool              `json:"forgiven"`
+	*msgjson.Penalty
+	ID       int64 `json:"id"`
+	Forgiven bool  `json:"forgiven"`
 }

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -570,6 +570,15 @@ func (dm *DEX) AccountInfo(aid account.AccountID) (*db.Account, error) {
 	return dm.storage.AccountInfo(aid)
 }
 
+// Penalties returns penalties for an account. all determines whether expired
+// and forgiven penalties are included.
+func (dm *DEX) Penalties(aid account.AccountID, all bool) ([]*db.Penalty, error) {
+	if all {
+		return dm.storage.AllPenalties(aid)
+	}
+	return dm.storage.Penalties(aid)
+}
+
 // Penalize bans an account by canceling the client's orders and setting their rule
 // status to rule.
 func (dm *DEX) Penalize(aid account.AccountID, rule account.Rule, details string) error {

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -580,8 +580,8 @@ func (dm *DEX) Penalties(aid account.AccountID, all bool) ([]*db.Penalty, error)
 }
 
 // Penalize bans an account by canceling the client's orders and setting their rule
-// status to rule.
-func (dm *DEX) Penalize(aid account.AccountID, rule account.Rule, details string) error {
+// status to rule. The penalty is returned.
+func (dm *DEX) Penalize(aid account.AccountID, rule account.Rule, details string) (*db.Penalty, error) {
 	return dm.authMgr.Penalize(aid, rule, details)
 }
 

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -573,10 +573,7 @@ func (dm *DEX) AccountInfo(aid account.AccountID) (*db.Account, error) {
 // Penalties returns penalties for an account. all determines whether expired
 // and forgiven penalties are included.
 func (dm *DEX) Penalties(aid account.AccountID, all bool) ([]*db.Penalty, error) {
-	if all {
-		return dm.storage.AllPenalties(aid)
-	}
-	return dm.storage.Penalties(aid)
+	return dm.storage.Penalties(aid, all)
 }
 
 // Penalize bans an account by canceling the client's orders and setting their rule

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -572,8 +572,8 @@ func (dm *DEX) AccountInfo(aid account.AccountID) (*db.Account, error) {
 
 // Penalize bans an account by canceling the client's orders and setting their rule
 // status to rule.
-func (dm *DEX) Penalize(aid account.AccountID, rule account.Rule) error {
-	return dm.authMgr.Penalize(aid, rule)
+func (dm *DEX) Penalize(aid account.AccountID, rule account.Rule, details string) error {
+	return dm.authMgr.Penalize(aid, rule, details)
 }
 
 // Unban reverses a ban and allows a client to resume trading.

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -572,8 +572,8 @@ func (dm *DEX) AccountInfo(aid account.AccountID) (*db.Account, error) {
 
 // Penalties returns penalties for an account. all determines whether expired
 // and forgiven penalties are included.
-func (dm *DEX) Penalties(aid account.AccountID, all bool) ([]*db.Penalty, error) {
-	return dm.storage.Penalties(aid, all)
+func (dm *DEX) Penalties(aid account.AccountID, strikeThreshold int, all bool) ([]*db.Penalty, time.Time, error) {
+	return dm.storage.Penalties(aid, strikeThreshold, all)
 }
 
 // Penalize bans an account by canceling the client's orders and setting their rule

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1279,7 +1279,8 @@ func (m *Market) epochStart(orders []order.Order) (cSum []byte, ordersRevealed [
 	for _, ord := range misses {
 		log.Infof("No preimage received for order %v from user %v. Penalizing user and revoking order.",
 			ord.ID(), ord.User())
-		m.auth.Penalize(ord.User(), account.PreimageReveal)
+		details := fmt.Sprintf("Order ID: %s", ord.ID())
+		m.auth.Penalize(ord.User(), account.PreimageReveal, details)
 		// Unlock the order's coins locked in processOrder.
 		m.unlockOrderCoins(ord) // could also be done in processReadyEpoch
 		// Change the order status from orderStatusEpoch to orderStatusRevoked.

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -191,8 +191,8 @@ func (ta *TArchivist) SetStateHash([]byte) error                          { retu
 func (ta *TArchivist) InsertPenalty(penalty *db.Penalty) (int64, error) { return 0, nil }
 func (ta *TArchivist) ForgivePenalty(id int64) error                    { return nil }
 func (ta *TArchivist) ForgivePenalties(aid account.AccountID) error     { return nil }
-func (ta *TArchivist) Penalties(aid account.AccountID, all bool) (penalties []*db.Penalty, err error) {
-	return nil, nil
+func (ta *TArchivist) Penalties(aid account.AccountID, strikeThreshold int, all bool) (penalties []*db.Penalty, bannedUntil time.Time, err error) {
+	return nil, time.Time{}, nil
 }
 
 func randomOrderID() order.OrderID {

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -190,6 +190,16 @@ func (ta *TArchivist) Close() error                                       { retu
 func (ta *TArchivist) GetStateHash() ([]byte, error)                      { return nil, nil }
 func (ta *TArchivist) SetStateHash([]byte) error                          { return nil }
 
+func (ta *TArchivist) InsertPenalty(penalty *db.Penalty) error      { return nil }
+func (ta *TArchivist) ForgivePenalty(id int64) error                { return nil }
+func (ta *TArchivist) ForgivePenalties(aid account.AccountID) error { return nil }
+func (ta *TArchivist) Penalties(aid account.AccountID) (penalties []*db.Penalty, err error) {
+	return nil, nil
+}
+func (ta *TArchivist) AllPenalties(aid account.AccountID) (penalties []*db.Penalty, err error) {
+	return nil, nil
+}
+
 func randomOrderID() order.OrderID {
 	pk := randomBytes(order.OrderIDSize)
 	var id order.OrderID

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -188,13 +188,10 @@ func (ta *TArchivist) Close() error                                       { retu
 func (ta *TArchivist) GetStateHash() ([]byte, error)                      { return nil, nil }
 func (ta *TArchivist) SetStateHash([]byte) error                          { return nil }
 
-func (ta *TArchivist) InsertPenalty(penalty *db.Penalty) int64      { return 0 }
-func (ta *TArchivist) ForgivePenalty(id int64) error                { return nil }
-func (ta *TArchivist) ForgivePenalties(aid account.AccountID) error { return nil }
-func (ta *TArchivist) Penalties(aid account.AccountID) (penalties []*db.Penalty, err error) {
-	return nil, nil
-}
-func (ta *TArchivist) AllPenalties(aid account.AccountID) (penalties []*db.Penalty, err error) {
+func (ta *TArchivist) InsertPenalty(penalty *db.Penalty) (int64, error) { return 0, nil }
+func (ta *TArchivist) ForgivePenalty(id int64) error                    { return nil }
+func (ta *TArchivist) ForgivePenalties(aid account.AccountID) error     { return nil }
+func (ta *TArchivist) Penalties(aid account.AccountID, all bool) (penalties []*db.Penalty, err error) {
 	return nil, nil
 }
 

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -175,11 +175,9 @@ func (ta *TArchivist) SaveRedeemB(mid db.MarketMatchID, coinID []byte, timestamp
 func (ta *TArchivist) SaveRedeemAckSigA(mid db.MarketMatchID, sig []byte) error {
 	return nil
 }
-func (ta *TArchivist) SetMatchInactive(mid db.MarketMatchID) error        { return nil }
-func (ta *TArchivist) CloseAccount(account.AccountID, account.Rule) error { return nil }
-func (ta *TArchivist) RestoreAccount(account.AccountID) error             { return nil }
-func (ta *TArchivist) Account(account.AccountID) (acct *account.Account, paid, open bool) {
-	return nil, false, false
+func (ta *TArchivist) SetMatchInactive(mid db.MarketMatchID) error { return nil }
+func (ta *TArchivist) Account(account.AccountID) (acct *account.Account, paid bool) {
+	return nil, false
 }
 func (ta *TArchivist) CreateAccount(*account.Account) (string, error)     { return "", nil }
 func (ta *TArchivist) AccountRegAddr(account.AccountID) (string, error)   { return "", nil }

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -188,7 +188,7 @@ func (ta *TArchivist) Close() error                                       { retu
 func (ta *TArchivist) GetStateHash() ([]byte, error)                      { return nil, nil }
 func (ta *TArchivist) SetStateHash([]byte) error                          { return nil }
 
-func (ta *TArchivist) InsertPenalty(penalty *db.Penalty) error      { return nil }
+func (ta *TArchivist) InsertPenalty(penalty *db.Penalty) int64      { return 0 }
 func (ta *TArchivist) ForgivePenalty(id int64) error                { return nil }
 func (ta *TArchivist) ForgivePenalties(aid account.AccountID) error { return nil }
 func (ta *TArchivist) Penalties(aid account.AccountID) (penalties []*db.Penalty, err error) {

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -17,6 +17,7 @@ import (
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/asset"
 	"decred.org/dcrdex/server/comms"
+	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/matcher"
 )
 
@@ -33,7 +34,7 @@ type AuthManager interface {
 	SendWhenConnected(account.AccountID, *msgjson.Message, time.Duration, func())
 	Request(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message)) error
 	RequestWithTimeout(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message), time.Duration, func()) error
-	Penalize(user account.AccountID, rule account.Rule, details string) error
+	Penalize(user account.AccountID, rule account.Rule, details string) (*db.Penalty, error)
 	RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time)
 }
 

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -33,7 +33,7 @@ type AuthManager interface {
 	SendWhenConnected(account.AccountID, *msgjson.Message, time.Duration, func())
 	Request(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message)) error
 	RequestWithTimeout(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message), time.Duration, func()) error
-	Penalize(user account.AccountID, rule account.Rule) error
+	Penalize(user account.AccountID, rule account.Rule, details string) error
 	RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time)
 }
 

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -21,6 +21,7 @@ import (
 	"decred.org/dcrdex/server/asset"
 	"decred.org/dcrdex/server/book"
 	"decred.org/dcrdex/server/comms"
+	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/matcher"
 	"decred.org/dcrdex/server/swap"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
@@ -221,9 +222,9 @@ func (a *TAuth) RequestWithTimeout(user account.AccountID, msg *msgjson.Message,
 	}
 	return nil
 }
-func (a *TAuth) Penalize(user account.AccountID, rule account.Rule, _ string) error {
+func (a *TAuth) Penalize(user account.AccountID, rule account.Rule, _ string) (*db.Penalty, error) {
 	log.Infof("Penalize for user %v", user)
-	return nil
+	return nil, nil
 }
 
 func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time) {}

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -221,7 +221,7 @@ func (a *TAuth) RequestWithTimeout(user account.AccountID, msg *msgjson.Message,
 	}
 	return nil
 }
-func (a *TAuth) Penalize(user account.AccountID, rule account.Rule) error {
+func (a *TAuth) Penalize(user account.AccountID, rule account.Rule, _ string) error {
 	log.Infof("Penalize for user %v", user)
 	return nil
 }

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -62,7 +62,7 @@ type AuthManager interface {
 		expireTimeout time.Duration, expireFunc func()) error
 	RequestWhenConnected(user account.AccountID, req *msgjson.Message, handlerFunc func(comms.Link, *msgjson.Message),
 		expireTimeout, connectTimeout time.Duration, expireFunc func())
-	Penalize(user account.AccountID, rule account.Rule) error
+	Penalize(user account.AccountID, rule account.Rule, details string) error
 	RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time)
 	RecordCompletedOrder(user account.AccountID, oid order.OrderID, t time.Time)
 	Unban(user account.AccountID) error
@@ -1208,7 +1208,8 @@ func (s *Swapper) checkInaction(assetID uint32) {
 			// may become less severe than account closure (e.g. temporary
 			// suspension, cool down, or order throttling), and restored
 			// accounts will still require a record of the revoked order.
-			s.authMgr.Penalize(orderAtFault.User(), account.FailureToAct)
+			details := fmt.Sprintf("Match ID: %s", match.ID())
+			s.authMgr.Penalize(orderAtFault.User(), account.FailureToAct, details)
 
 			// Send the revoke_match messages, and solicit acks.
 			s.revoke(match)

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -62,7 +62,7 @@ type AuthManager interface {
 		expireTimeout time.Duration, expireFunc func()) error
 	RequestWhenConnected(user account.AccountID, req *msgjson.Message, handlerFunc func(comms.Link, *msgjson.Message),
 		expireTimeout, connectTimeout time.Duration, expireFunc func())
-	Penalize(user account.AccountID, rule account.Rule, details string) error
+	Penalize(user account.AccountID, rule account.Rule, details string) (*db.Penalty, error)
 	RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time)
 	RecordCompletedOrder(user account.AccountID, oid order.OrderID, t time.Time)
 	Unban(user account.AccountID) error

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -191,7 +191,7 @@ func (m *TAuthManager) Route(string,
 	func(account.AccountID, *msgjson.Message) *msgjson.Error) {
 }
 
-func (m *TAuthManager) Penalize(id account.AccountID, rule account.Rule) error {
+func (m *TAuthManager) Penalize(id account.AccountID, rule account.Rule, _ string) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	m.suspensions[id] = rule

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -191,11 +191,11 @@ func (m *TAuthManager) Route(string,
 	func(account.AccountID, *msgjson.Message) *msgjson.Error) {
 }
 
-func (m *TAuthManager) Penalize(id account.AccountID, rule account.Rule, _ string) error {
+func (m *TAuthManager) Penalize(id account.AccountID, rule account.Rule, _ string) (*db.Penalty, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	m.suspensions[id] = rule
-	return nil
+	return nil, nil
 }
 
 func (m *TAuthManager) RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time) {}

--- a/spec/admin.mediawiki
+++ b/spec/admin.mediawiki
@@ -55,7 +55,7 @@ The server will provide an HTTP API for performing various adminstrative tasks.
 |-
 | /accounts || GET || lists information about all known accounts
 |-
-| /account/{accountID} || GET || list information about a specific account
+| /account/{accountID}?verbose=BOOL || GET || list information about a specific account. verbose will report extended information, such as expired penalties
 |-
 | /account/{accountID}/unban || GET || clear an account's penalties and re-enable trading
 |-

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -84,6 +84,8 @@ be sent in the [[comm.mediawiki/#Session_Authentication|connect response]].
 |-
 | duration   || int    || the duration in milliseconds of the penalization
 |-
+| accountid  || string || account ID
+|-
 | details    || string || a message describing the penalization
 |}
 
@@ -97,6 +99,8 @@ be sent in the [[comm.mediawiki/#Session_Authentication|connect response]].
 | timestamp  || 8            || server's UNIX timestamp (milliseconds)
 |-
 | duration   || 8            || duration (milliseconds)
+|-
+| account ID || 32           || client [[accounts.mediawiki/#Step_1_Registration|account ID]]
 |-
 | details    || string       || a message (UTF-8)
 |}


### PR DESCRIPTION
    multi: Add penalties table.
    
    Because banning a user will become more complicated than just banned/not
    banned, the banned information we hold for a user must be more detailed.
    The best way to organize this new data is with a new table that holds
    penalties. A combination of these penalties will decide wether or not a
    user is banned.
    
    Fields that are stored are:
     1. AccountID - the user involved
     2. BrokenRule - the broken rule
     3. Time - the time the penalization was enforced
     4. Duration - the length of penalization
     5. Details - a description of the infraction
     6. Forgiven - whether this penalization has been forgiven by the
        operator
    
    Every Penalty is keyed by an incrementing id that is decided by the
    database upon insertion.

    account: Add details and durations to Rule.

    multi: Remove accounts broken_rule field.

    multi: Return id when inserting penalty.
    
    In order to inform the operator of all the details of a ban, including
    the penalty id, change InsertPenalty to return the id and Penalize to
    return the penalty.

Work towards #444 

While starting to add penalties as now outlined in the spec, it because clear that it is not possible to inform a client of the details of their ban if we do not know those details. To that end, this pr creates a table to store detailed penalties.