### PR TITLE
app: allow depth chart zoom up to +/- 100%

### DIFF
--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -744,12 +744,13 @@ out:
 }
 
 func TestServer(t *testing.T) {
-	numBuys = 150
-	numSells = 150
-	feedPeriod = 500 * time.Millisecond
+	numBuys = 10
+	numSells = 10
+	feedPeriod = 2000 * time.Millisecond
 	initialize := false
-	register := false
+	register := true
 	forceDisconnectWallet = true
+	gapWidthFactor = 0.2
 
 	var shutdown context.CancelFunc
 	tCtx, shutdown = context.WithCancel(context.Background())

--- a/client/webserver/site/src/js/charts.js
+++ b/client/webserver/site/src/js/charts.js
@@ -188,8 +188,8 @@ export class DepthChart {
     var low = zoom.low || (lastBuy ? lastBuy.rate : midGap)
 
     // Clamp the zoom between 0.5% and 100% of mid-gap.
-    const minRange = Math.max(gapWidth * 2, midGap * 0.005)
-    const halfRange = clamp(high - low, minRange, midGap) / 2
+    const minHalfRange = Math.max(gapWidth, midGap * 0.0025)
+    const halfRange = clamp((high - low) / 2, minHalfRange, midGap)
     zoom.high = high = midGap + halfRange
     zoom.low = low = midGap - halfRange
     const buyDepth = []


### PR DESCRIPTION
Zoom was constrained to +/- 50% of the mid-gap rate, but could accommodate double that width without major changes to other parts. 

Allowing more is possible, but there are tradeoffs for > 100%, as either a) the charts will need to be reconfigured to allow an off-center mid-gap, or b) the chart will expose a negative scale on the left. 

For now, I'm hoping this is an improvement and enough to resolve #553.