### PR TITLE
client: clean up inactive trades

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -973,22 +973,22 @@ func (btc *ExchangeWallet) AuditContract(coinID dex.Bytes, contract dex.Bytes) (
 
 // LocktimeExpired returns true if the specified contract's locktime has
 // expired, making it possible to issue a Refund.
-func (btc *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, error) {
+func (btc *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
 	_, _, locktime, _, err := dexbtc.ExtractSwapDetails(contract, btc.chainParams)
 	if err != nil {
-		return false, fmt.Errorf("error extracting contract locktime: %v", err)
+		return false, time.Time{}, fmt.Errorf("error extracting contract locktime: %v", err)
 	}
 	contractExpiry := time.Unix(int64(locktime), 0).UTC()
 	bestBlockHash, err := btc.node.GetBestBlockHash()
 	if err != nil {
-		return false, fmt.Errorf("get best block hash error: %v", err)
+		return false, time.Time{}, fmt.Errorf("get best block hash error: %v", err)
 	}
 	bestBlockHeader, err := btc.getBlockHeader(bestBlockHash.String())
 	if err != nil {
-		return false, fmt.Errorf("get best block header error: %v", err)
+		return false, time.Time{}, fmt.Errorf("get best block header error: %v", err)
 	}
 	bestBlockMedianTime := time.Unix(bestBlockHeader.MedianTime, 0).UTC()
-	return bestBlockMedianTime.After(contractExpiry), nil
+	return bestBlockMedianTime.After(contractExpiry), contractExpiry, nil
 }
 
 // FindRedemption attempts to find the input that spends the specified output,

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1047,13 +1047,13 @@ func (dcr *ExchangeWallet) AuditContract(coinID, contract dex.Bytes) (asset.Audi
 
 // LocktimeExpired returns true if the specified contract's locktime has
 // expired, making it possible to issue a Refund.
-func (dcr *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, error) {
+func (dcr *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
 	_, _, locktime, _, err := dexdcr.ExtractSwapDetails(contract, chainParams)
 	if err != nil {
-		return false, fmt.Errorf("error extracting contract locktime: %v", err)
+		return false, time.Time{}, fmt.Errorf("error extracting contract locktime: %v", err)
 	}
 	contractExpiry := time.Unix(int64(locktime), 0).UTC()
-	return time.Now().UTC().After(contractExpiry), nil
+	return time.Now().UTC().After(contractExpiry), contractExpiry, nil
 }
 
 // FindRedemption should attempt to find the input that spends the specified

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -98,8 +98,12 @@ type Wallet interface {
 	// to properly handle network latency.
 	AuditContract(coinID, contract dex.Bytes) (AuditInfo, error)
 	// LocktimeExpired returns true if the specified contract's locktime has
-	// expired, making it possible to issue a Refund.
-	LocktimeExpired(contract dex.Bytes) (bool, error)
+	// expired, making it possible to issue a Refund. The contract expiry time
+	// is also returned, but reaching this time does not necessarily mean the
+	// contract can be refunded since assets have different rules to satisfy the
+	// lock. For example, in Bitcoin the median of the last 11 blocks must be
+	// past the expiry time, not the current time.
+	LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
 	// FindRedemption should attempt to find the input that spends the specified
 	// coin, and return the secret key if it does.
 	//

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2375,9 +2375,10 @@ func (c *Core) loadDBTrades(dc *dexConnection, crypter encrypt.Crypter, failed m
 	errs := newErrorSet(dc.acct.host + ": ")
 	ready := make([]*trackedTrade, 0, len(dc.trades))
 	for _, trade := range trades {
-		// The DB loads refunded and revoked matches, so filter those out.
 		if !trade.isActive() {
-			log.Tracef("Loaded inactive trade %v from the DB.", trade.ID())
+			// In this event, there is a discrepancy between the active criteria
+			// between dbTrackers and isActive that should be resolved.
+			log.Warnf("Loaded inactive trade %v from the DB.", trade.ID())
 			continue
 		}
 		base, quote := trade.Base(), trade.Quote()

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -563,8 +563,8 @@ func (w *TXCWallet) AuditContract(coinID, contract dex.Bytes) (asset.AuditInfo, 
 	return w.auditInfo, w.auditErr
 }
 
-func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, error) {
-	return true, nil
+func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
+	return true, time.Now().Add(-time.Minute), nil
 }
 
 func (w *TXCWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (dex.Bytes, error) {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -573,7 +573,7 @@ func (t *trackedTrade) isSwappable(match *matchTracker) bool {
 	return false
 }
 
-// isActive will be true if the trade is <= OrderStatusBooked, or if any of the
+// isActive will be true if the trade is booked or epoch, or if any of the
 // matches are still negotiating.
 func (t *trackedTrade) isActive() bool {
 	t.mtx.RLock()

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -622,6 +622,25 @@ func (db *BoltDB) DEXOrdersWithActiveMatches(dex string) ([]order.OrderID, error
 			if status[0] == uint8(order.MatchComplete) {
 				return nil
 			}
+
+			// Exclude refunded swaps.
+			// proofB := getCopy(mBkt, proofKey)
+			// if len(proofB) == 0 {
+			// 	log.Errorf("empty match proof")
+			// 	return nil
+			// }
+			// proof, errM := dexdb.DecodeMatchProof(proofB)
+			// if errM != nil {
+			// 	log.Errorf("error decoding proof: %v", errM)
+			// 	return nil
+			// }
+			// if len(proof.RefundCoin) > 0 {
+			// 	return nil
+			// }
+
+			// TODO: Could also filter out certain revoked matches depending on
+			// status. See (*trackedTrade).isActive.
+
 			oidB := mBkt.Get(orderIDKey)
 			var oid order.OrderID
 			copy(oid[:], oidB)

--- a/dex/order/match.go
+++ b/dex/order/match.go
@@ -76,6 +76,7 @@ const (
 	// their redemption transaction. The DEX has validated the redemption and
 	// sent the details to the maker.
 	MatchComplete // 4
+	//MatchRefunded // 5?
 )
 
 // String satisfies fmt.Stringer.


### PR DESCRIPTION
client/core: filter and retire inactive trades

Update `(*trackedTrade).isActive` to exclude refunded matches, and some
revoked matches depending on match status and side.

For **revoked matches**:
 - `NewlyMatched` requires no further action from either side
 - `MakerSwapCast` requires no further action from the taker
 - (`TakerSwapCast` requires action on both sides)
 - `MakerRedeemed` requires no further action from the maker

TODO: Consider a new `dex/order.MatchRefunded` `MatchStatus`. For now we
check the `MatchProof.RefundCoin`.  Add a comment in `dex/order`'s
`MatchStatus` enum, and in `(*trackedTrade).refundMatches` where this status
would be set.

In the main trade ticker, clean out inactive trades from the
`dexConnection`'s `trackedTrades` map.

client/db/bolt: Make a note that we should consider filtering more
inactive matches (all refunded, revoked depending on status and side) in
`(*BoltDB).DEXOrdersWithActiveMatches`.

client/{asset,core}: return contract expiry from `LocktimeExpired`