### PR TITLE
client/webserver: connect and update client map under lock

### DIFF
--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -270,6 +269,8 @@ func (s *WebServer) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Can't listen on %s. web server quitting: %v", s.addr, err)
 	}
+	// Update the listening address in case a :0 was provided.
+	s.addr = listener.Addr().String()
 
 	// Shutdown the server on context cancellation.
 	var wg sync.WaitGroup
@@ -473,15 +474,4 @@ func writeJSONWithStatus(w http.ResponseWriter, thing interface{}, code int, ind
 	if err := encoder.Encode(thing); err != nil {
 		log.Infof("JSON encode error: %v", err)
 	}
-}
-
-// filesExists reports whether the named file or directory exists.
-func fileExists(name string) bool {
-	_, err := os.Stat(name)
-	return !os.IsNotExist(err)
-}
-
-// Create a unique ID for a market.
-func marketID(base, quote uint32) string {
-	return strconv.Itoa(int(base)) + "_" + strconv.Itoa(int(quote))
 }

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -250,13 +250,11 @@ func newLink() *tLink {
 	}
 }
 
-var tPort int = 5142
-
 func newTServer(t *testing.T, start bool) (*WebServer, *TCore, func(), error) {
 	c := &TCore{}
 	var shutdown func()
 	ctx, killCtx := context.WithCancel(tCtx)
-	s, err := New(c, fmt.Sprintf("localhost:%d", tPort), tLogger, false)
+	s, err := New(c, "127.0.0.1:0", tLogger, false)
 	if err != nil {
 		t.Errorf("error creating server: %v", err)
 	}
@@ -323,10 +321,11 @@ func TestConnectStart(t *testing.T) {
 }
 
 func TestConnectBindError(t *testing.T) {
-	_, _, shutdown, _ := newTServer(t, true)
+	s0, _, shutdown, _ := newTServer(t, true)
 	defer shutdown()
 
-	s, err := New(&TCore{}, fmt.Sprintf("localhost:%d", tPort), tLogger, false)
+	tAddr := s0.addr
+	s, err := New(&TCore{}, tAddr, tLogger, false)
 	if err != nil {
 		t.Fatalf("error creating server: %v", err)
 	}
@@ -651,7 +650,6 @@ func TestClientMap(t *testing.T) {
 	// RPCServer's client map.
 	<-resp
 
-	// While we're here, check that the client is properly mapped.
 	var cl *wsClient
 	s.mtx.Lock()
 	i := len(s.clients)


### PR DESCRIPTION
Make webserver connect and clients map update atomic so that any
connected client will be found in the map when accessed under lock,
and vice versa.

Bind the webserver to a random port in tests.

Remove dead code.