### PR TITLE
client/core: fix shallow map copy causing concurrent map write

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -317,7 +317,7 @@ func (c *Core) Book(dex string, base, quote uint32) (*OrderBook, error) {
 		}
 		err = dc.Unsubscribe(base, quote)
 		if err != nil {
-			log.Errorf("failed to subscribe to book: %v", err)
+			log.Errorf("Failed to unsubscribe to %q book: %v", mkt, err)
 		}
 		ob = orderbook.NewOrderBook()
 		if err = ob.Sync(snap); err != nil {

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -25,7 +25,6 @@ var (
 // longer using the feed.
 type BookFeed struct {
 	C     chan *BookUpdate
-	off   chan struct{}
 	id    uint32
 	close func(*BookFeed)
 }
@@ -35,7 +34,6 @@ type BookFeed struct {
 func NewBookFeed(close func(feed *BookFeed)) *BookFeed {
 	return &BookFeed{
 		C:     make(chan *BookUpdate, 256),
-		off:   make(chan struct{}),
 		id:    atomic.AddUint32(&feederID, 1),
 		close: close,
 	}
@@ -43,18 +41,7 @@ func NewBookFeed(close func(feed *BookFeed)) *BookFeed {
 
 // Close the BookFeed.
 func (f *BookFeed) Close() {
-	f.close(f)
-	close(f.off)
-}
-
-// on is used internally to see whether the caller has Close()d the feed.
-func (f *BookFeed) on() bool {
-	select {
-	case <-f.off:
-		return false
-	default:
-	}
-	return true
+	f.close(f) // i.e. (*bookie).closeFeed(feed *BookFeed)
 }
 
 // bookie is a BookFeed manager. bookie will maintain any number of order book
@@ -66,7 +53,7 @@ type bookie struct {
 	orderbook.OrderBook
 	mtx        sync.Mutex
 	feeds      map[uint32]*BookFeed
-	close      func() // e.g. dexConnection.Unsub
+	close      func() // e.g. dexConnection.StopBook
 	closeTimer *time.Timer
 }
 
@@ -81,6 +68,15 @@ func newBookie(close func()) *bookie {
 	}
 }
 
+// resets the bookie with a new OrderBook based on the provided book snapshot
+// from the server.
+func (b *bookie) reset(snapshot *msgjson.OrderBook) error {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	b.OrderBook = *orderbook.NewOrderBook()
+	return b.OrderBook.Sync(snapshot)
+}
+
 // feed gets a new *BookFeed and cancels the close timer.
 func (b *bookie) feed() *BookFeed {
 	b.mtx.Lock()
@@ -91,26 +87,34 @@ func (b *bookie) feed() *BookFeed {
 		// must be OK with that, or the close func must be able to detect when
 		// new feeds exist and abort. To solve the race, the caller of feed()
 		// must synchronize with the close func. e.g. Sync locks bookMtx before
-		// creating new feeds, and Unsub locks bookMtx to check for feeds before
-		// unsubscribing.
+		// creating new feeds, and StopBook locks bookMtx to check for feeds
+		// before unsubscribing.
 		b.closeTimer.Stop()
 		b.closeTimer = nil
 	}
-	feed := NewBookFeed(b.closeFeed)
+	feed := NewBookFeed(b.CloseFeed)
 	b.feeds[feed.id] = feed
 	return feed
 }
 
-// closeFeed is ultimately called when the BookFeed subscriber closes the feed.
+// CloseFeed is ultimately called when the BookFeed subscriber closes the feed.
 // If this was the last feed for this bookie aka market, set a timer to
 // unsubscribe unless another feed is requested.
-func (b *bookie) closeFeed(feed *BookFeed) {
+func (b *bookie) CloseFeed(feed *BookFeed) {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
-	beforeLen := len(b.feeds)
+	_, found := b.feeds[feed.id]
+	if !found {
+		return
+	}
+	b.closeFeed(feed)
+}
+
+func (b *bookie) closeFeed(feed *BookFeed) {
 	delete(b.feeds, feed.id)
+
 	// If that was the last BookFeed, set a timer to unsubscribe w/ server.
-	if beforeLen == 1 && len(b.feeds) == 0 {
+	if len(b.feeds) == 0 {
 		if b.closeTimer != nil {
 			b.closeTimer.Stop()
 		}
@@ -138,15 +142,12 @@ func (b *bookie) send(u *BookUpdate) {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
 	for fid, feed := range b.feeds {
-		if !feed.on() {
-			delete(b.feeds, fid)
-			continue
-		}
 		select {
 		case feed.C <- u:
 		default:
-			log.Errorf("closing blocking book update channel")
-			delete(b.feeds, fid)
+			log.Warnf("bookie %p: Closing book update feed %d with no receiver. "+
+				"The receiver should have closed the feed before going away.", b, fid)
+			b.closeFeed(feed) // delete it and maybe start a delayed bookie close
 		}
 	}
 }
@@ -161,21 +162,17 @@ func (b *bookie) book() *OrderBook {
 	}
 }
 
-// Sync subscribes to the order book and returns the book and a BookFeed to
+// SyncBook subscribes to the order book and returns the book and a BookFeed to
 // receive order book updates. The BookFeed must be Close()d when it is no
-// longer in use.
-func (dc *dexConnection) Sync(base, quote uint32) (*OrderBook, *BookFeed, error) {
+// longer in use. Use StopBook to unsubscribed and clean up the feed.
+func (dc *dexConnection) SyncBook(base, quote uint32) (*OrderBook, *BookFeed, error) {
 	dc.booksMtx.Lock()
 	defer dc.booksMtx.Unlock()
-	return dc.sync(base, quote)
-}
 
-// sync is the same as Sync but the booksMtx is not locked, so this is not
-// thread-safe; the caller must lock it.
-func (dc *dexConnection) sync(base, quote uint32) (*OrderBook, *BookFeed, error) {
 	mkt := marketName(base, quote)
 	booky, found := dc.books[mkt]
 	if found {
+		// Get the order book and a NEW feed.
 		return booky.book(), booky.feed(), nil
 	}
 
@@ -187,29 +184,13 @@ func (dc *dexConnection) sync(base, quote uint32) (*OrderBook, *BookFeed, error)
 		return nil, nil, fmt.Errorf("unknown market %s", mkt)
 	}
 
-	// Subscribe via the 'orderbook' request.
-	req, err := msgjson.NewRequest(dc.NextID(), msgjson.OrderBookRoute, &msgjson.OrderBookSubscription{
-		Base:  base,
-		Quote: quote,
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("error encoding 'orderbook' request: %v", err)
-	}
-	errChan := make(chan error, 1)
-	result := new(msgjson.OrderBook)
-	err = dc.Request(req, func(msg *msgjson.Message) {
-		errChan <- msg.UnmarshalResult(result)
-	})
-	if err != nil {
-		return nil, nil, fmt.Errorf("error subscribing to %s orderbook: %v", mkt, err)
-	}
-	err = extractError(errChan, requestTimeout, msgjson.OrderBookRoute)
+	obRes, err := dc.Subscribe(base, quote)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	booky = newBookie(func() { dc.Unsub(mkt) })
-	err = booky.Sync(result)
+	booky = newBookie(func() { dc.StopBook(base, quote) })
+	err = booky.Sync(obRes)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -218,9 +199,40 @@ func (dc *dexConnection) sync(base, quote uint32) (*OrderBook, *BookFeed, error)
 	return booky.book(), booky.feed(), nil
 }
 
-// Unsub is the close callback passed to the bookie, and will be called when
+// Subscribe subscribes to the given market's order book via the 'orderbook'
+// request. The response, which includes book's snapshot, is returned. Proper
+// synchronization is required by the caller to ensure that order feed messages
+// aren't processed before they are prepared to handle this subscription.
+func (dc *dexConnection) Subscribe(base, quote uint32) (*msgjson.OrderBook, error) {
+	mkt := marketName(base, quote)
+	// Subscribe via the 'orderbook' request.
+	log.Debugf("Subscribing to the %v order book for %v", mkt, dc.acct.host)
+	req, err := msgjson.NewRequest(dc.NextID(), msgjson.OrderBookRoute, &msgjson.OrderBookSubscription{
+		Base:  base,
+		Quote: quote,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error encoding 'orderbook' request: %v", err)
+	}
+	errChan := make(chan error, 1)
+	result := new(msgjson.OrderBook)
+	err = dc.Request(req, func(msg *msgjson.Message) {
+		errChan <- msg.UnmarshalResult(result)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error subscribing to %s orderbook: %v", mkt, err)
+	}
+	err = extractError(errChan, requestTimeout, msgjson.OrderBookRoute)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// StopBook is the close callback passed to the bookie, and will be called when
 // there are no more subscribers and the close delay period has expired.
-func (dc *dexConnection) Unsub(mkt string) {
+func (dc *dexConnection) StopBook(base, quote uint32) {
+	mkt := marketName(base, quote)
 	dc.booksMtx.Lock()
 	defer dc.booksMtx.Unlock() // hold it locked until unsubscribe request is completed
 
@@ -231,20 +243,27 @@ func (dc *dexConnection) Unsub(mkt string) {
 		numFeeds := len(booky.feeds)
 		booky.mtx.Unlock()
 		if numFeeds > 0 {
-			log.Debugf("Aborting unsubscribe for market %s with active feeds", mkt)
+			log.Warnf("Aborting booky %p unsubscribe for market %s with active feeds", booky, mkt)
 			return
 		}
 		// No BookFeeds, delete the bookie.
 		delete(dc.books, mkt)
 	}
 
-	log.Debugf("Unsubscribing from %s", mkt)
+	if err := dc.Unsubscribe(base, quote); err != nil {
+		log.Error(err)
+	}
+}
+
+// Unsubscribe unsubscribes from to the given market's order book.
+func (dc *dexConnection) Unsubscribe(base, quote uint32) error {
+	mkt := marketName(base, quote)
+	log.Debugf("Unsubscribing from the %v order book for %v", mkt, dc.acct.host)
 	req, err := msgjson.NewRequest(dc.NextID(), msgjson.UnsubOrderBookRoute, &msgjson.UnsubOrderBook{
 		MarketID: mkt,
 	})
 	if err != nil {
-		log.Errorf("unsub_orderbook message encoding error: %v", err)
-		return
+		return fmt.Errorf("unsub_orderbook message encoding error: %w", err)
 	}
 	err = dc.Request(req, func(msg *msgjson.Message) {
 		var res bool
@@ -254,8 +273,9 @@ func (dc *dexConnection) Unsub(mkt string) {
 		}
 	})
 	if err != nil {
-		log.Errorf("request error unsubscribing from %s orderbook: %v", mkt, err)
+		return fmt.Errorf("request error unsubscribing from %s orderbook: %w", mkt, err)
 	}
+	return nil
 }
 
 // Sync subscribes to the order book and returns the book and a BookFeed to
@@ -269,7 +289,7 @@ func (c *Core) Sync(host string, base, quote uint32) (*OrderBook, *BookFeed, err
 		return nil, nil, fmt.Errorf("unknown DEX '%s'", host)
 	}
 
-	return dc.Sync(base, quote)
+	return dc.SyncBook(base, quote)
 }
 
 // Book fetches the order book. If a subscription doesn't exist, one will be
@@ -287,17 +307,27 @@ func (c *Core) Book(dex string, base, quote uint32) (*OrderBook, error) {
 	dc.booksMtx.RLock()
 	defer dc.booksMtx.RUnlock() // hold it locked until any transient sub/unsub is completed
 	book, found := dc.books[mkt]
+	var ob *orderbook.OrderBook
 	// If not found, attempt to make a temporary subscription and return the
 	// initial book.
 	if !found {
-		book, bookFeed, err := dc.sync(base, quote)
+		snap, err := dc.Subscribe(base, quote)
 		if err != nil {
+			return nil, fmt.Errorf("unable to subscribe to book: %v", err)
+		}
+		err = dc.Unsubscribe(base, quote)
+		if err != nil {
+			log.Errorf("failed to subscribe to book: %v", err)
+		}
+		ob = orderbook.NewOrderBook()
+		if err = ob.Sync(snap); err != nil {
 			return nil, fmt.Errorf("unable to sync book: %v", err)
 		}
-		bookFeed.Close()
-		return book, nil
+	} else {
+		ob = &book.OrderBook
 	}
-	buys, sells, epoch := book.Orders()
+
+	buys, sells, epoch := ob.Orders()
 	return &OrderBook{
 		Buys:  translateBookSide(buys),
 		Sells: translateBookSide(sells),

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -848,11 +848,11 @@ func TestDexConnectionOrderBook(t *testing.T) {
 	}
 
 	// Sync to unknown dex
-	_, _, err = tCore.Sync("unknown dex", tDCR.ID, tBTC.ID)
+	_, _, err = tCore.SyncBook("unknown dex", tDCR.ID, tBTC.ID)
 	if err == nil {
 		t.Fatalf("no error for unknown dex")
 	}
-	_, _, err = tCore.Sync(tDexHost, tDCR.ID, 12345)
+	_, _, err = tCore.SyncBook(tDexHost, tDCR.ID, 12345)
 	if err == nil {
 		t.Fatalf("no error for nonsense market")
 	}
@@ -862,13 +862,13 @@ func TestDexConnectionOrderBook(t *testing.T) {
 		f(bookMsg)
 		return nil
 	})
-	_, feed1, err := tCore.Sync(tDexHost, tDCR.ID, tBTC.ID)
+	_, feed1, err := tCore.SyncBook(tDexHost, tDCR.ID, tBTC.ID)
 	if err != nil {
-		t.Fatalf("Sync 1 error: %v", err)
+		t.Fatalf("SyncBook 1 error: %v", err)
 	}
-	_, feed2, err := tCore.Sync(tDexHost, tDCR.ID, tBTC.ID)
+	_, feed2, err := tCore.SyncBook(tDexHost, tDCR.ID, tBTC.ID)
 	if err != nil {
-		t.Fatalf("Sync 2 error: %v", err)
+		t.Fatalf("SyncBook 2 error: %v", err)
 	}
 
 	// Should be able to retrieve the book now.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -219,7 +219,15 @@ type OrderBook struct {
 	Epoch []*MiniOrder `json:"epoch"`
 }
 
+// MarketOrderBook is used as the BookUpdate's Payload with the FreshBookAction.
+// The subscriber will likely need to translate into a JSON tagged type.
+type MarketOrderBook struct {
+	Base, Quote uint32
+	Book        *OrderBook
+}
+
 const (
+	FreshBookAction   = "book"
 	BookOrderAction   = "book_order"
 	EpochOrderAction  = "epoch_order"
 	UnbookOrderAction = "unbook_order"

--- a/client/order/orderbook.go
+++ b/client/order/orderbook.go
@@ -170,8 +170,7 @@ func (ob *OrderBook) processCachedNotes() error {
 	return nil
 }
 
-// Sync updates a client tracked order book with an order
-// book snapshot.
+// Sync updates a client tracked order book with an order book snapshot.
 func (ob *OrderBook) Sync(snapshot *msgjson.OrderBook) error {
 	if ob.isSynced() {
 		return fmt.Errorf("order book is already synced")

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -65,7 +65,7 @@ type ClientCore interface {
 	OpenWallet(assetID uint32, appPass []byte) error
 	GetFee(addr, cert string) (fee uint64, err error)
 	Register(form *core.RegisterForm) (*core.RegisterResult, error)
-	Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error)
+	SyncBook(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error)
 	Trade(appPass []byte, form *core.TradeForm) (order *core.Order, err error)
 	WalletState(assetID uint32) (walletState *core.WalletState)
 	Wallets() (walletsStates []*core.WalletState)

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -104,7 +104,7 @@ func (c *TCore) GetFee(url, cert string) (uint64, error) {
 func (c *TCore) Register(*core.RegisterForm) (*core.RegisterResult, error) {
 	return c.registerResult, c.registerErr
 }
-func (c *TCore) Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
+func (c *TCore) SyncBook(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
 	return nil, core.NewBookFeed(func(*core.BookFeed) {}), c.syncErr
 }
 func (c *TCore) Trade(appPass []byte, form *core.TradeForm) (order *core.Order, err error) {

--- a/client/rpcserver/websocket.go
+++ b/client/rpcserver/websocket.go
@@ -236,8 +236,9 @@ func wsLoadMarket(s *RPCServer, cl *wsClient, msg *msgjson.Message) *msgjson.Err
 }
 
 // wsUnmarket is the handler for the 'unmarket' websocket endpoint. This empty
-// message is sent when the user leaves the markets page. Unsubscribes from the
-// current market.
+// message is sent when the user leaves the markets page. This closes the feed,
+// and potentially unsubscribes from orderbook with the server if there are no
+// other consumers.
 func wsUnmarket(_ *RPCServer, cl *wsClient, _ *msgjson.Message) *msgjson.Error {
 	cl.mtx.Lock()
 	defer cl.mtx.Unlock()

--- a/client/rpcserver/websocket.go
+++ b/client/rpcserver/websocket.go
@@ -209,7 +209,7 @@ func wsLoadMarket(s *RPCServer, cl *wsClient, msg *msgjson.Message) *msgjson.Err
 		return msgjson.NewError(msgjson.RPCInternal, errMsg)
 	}
 
-	book, feed, err := s.core.Sync(market.Host, market.Base, market.Quote)
+	book, feed, err := s.core.SyncBook(market.Host, market.Base, market.Quote)
 	if err != nil {
 		errMsg := fmt.Sprintf("error getting order feed: %v", err)
 		log.Errorf(errMsg)

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -332,7 +332,7 @@ func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) {
 func (c *TCore) Login([]byte) (*core.LoginResult, error) { return &core.LoginResult{}, nil }
 func (c *TCore) Logout() error                           { return nil }
 
-func (c *TCore) Sync(dexAddr string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
+func (c *TCore) SyncBook(dexAddr string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
 	c.midGap = randomMagnitude(-2, 4)
 	c.maxQty = randomMagnitude(-2, 4)
 	mktID, _ := dex.MarketName(base, quote)

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -64,7 +64,7 @@ type clientCore interface {
 	Register(*core.RegisterForm) (*core.RegisterResult, error)
 	Login(pw []byte) (*core.LoginResult, error)
 	InitializeClient(pw []byte) error
-	Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error)
+	SyncBook(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error)
 	AssetBalance(assetID uint32) (*db.Balance, error)
 	WalletState(assetID uint32) *core.WalletState
 	CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -80,7 +80,7 @@ func (c *TCore) GetFee(string, string) (uint64, error)                       { r
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
 func (c *TCore) InitializeClient(pw []byte) error                            { return c.initErr }
 func (c *TCore) Login(pw []byte) (*core.LoginResult, error)                  { return &core.LoginResult{}, c.loginErr }
-func (c *TCore) Sync(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
+func (c *TCore) SyncBook(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
 	return c.syncBook, c.syncFeed, c.syncErr
 }
 func (c *TCore) Book(dex string, base, quote uint32) (*core.OrderBook, error) {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -245,6 +245,7 @@ type tLink struct {
 func newLink() *tLink {
 	conn := &TConn{
 		respReady: make(chan []byte, 1),
+		close:     make(chan struct{}, 1),
 	}
 	cl := newWSClient("", conn, func(*msgjson.Message) *msgjson.Error { return nil })
 	return &tLink{
@@ -346,11 +347,21 @@ func TestLoadMarket(t *testing.T) {
 	link := newLink()
 	s, tCore, shutdown, _ := newTServer(t, false)
 	defer shutdown()
-	_, err := link.cl.Connect(tCtx)
+	linkWg, err := link.cl.Connect(tCtx)
 	if err != nil {
 		t.Fatalf("WSLink Start: %v", err)
 	}
-	defer link.cl.Disconnect()
+
+	// This test is not running WebServer or calling handleWS/websocketHandler,
+	// so manually stop the marketSyncer started by wsLoadMarket and the WSLink
+	// before returning from this test.
+	defer func() {
+		link.cl.feedLoop.Stop()
+		link.cl.feedLoop.WaitForShutdown()
+		link.cl.Disconnect()
+		linkWg.Wait()
+	}()
+
 	params := &marketLoad{
 		Host:  "abc",
 		Base:  uint32(1),
@@ -361,6 +372,7 @@ func TestLoadMarket(t *testing.T) {
 	tCore.syncBook = &core.OrderBook{}
 
 	extractMessage := func() *msgjson.Message {
+		t.Helper()
 		select {
 		case msgB := <-link.conn.respReady:
 			msg := new(msgjson.Message)
@@ -373,6 +385,7 @@ func TestLoadMarket(t *testing.T) {
 	}
 
 	ensureGood := func() {
+		t.Helper()
 		// Create a new feed for every request because a Close()d feed cannot be
 		// reused.
 		tCore.syncFeed = core.NewBookFeed(func(feed *core.BookFeed) {})
@@ -599,6 +612,10 @@ func TestHandleMessage(t *testing.T) {
 	link := newLink()
 	s, _, shutdown, _ := newTServer(t, false)
 	defer shutdown()
+
+	// NOTE: link is not started because the handlers in this test do not
+	// actually use it.
+
 	var msg *msgjson.Message
 
 	ensureErr := func(name string, wantCode int) {

--- a/client/webserver/websocket.go
+++ b/client/webserver/websocket.go
@@ -217,8 +217,9 @@ func wsLoadMarket(s *WebServer, cl *wsClient, msg *msgjson.Message) *msgjson.Err
 }
 
 // wsUnmarket is the handler for the 'unmarket' websocket endpoint. This empty
-// message is sent when the user leaves the markets page. Unsubscribes from the
-// current market.
+// message is sent when the user leaves the markets page. This closes the feed,
+// and potentially unsubscribes from orderbook with the server if there are no
+// other consumers
 func wsUnmarket(_ *WebServer, cl *wsClient, _ *msgjson.Message) *msgjson.Error {
 	cl.mtx.Lock()
 	defer cl.mtx.Unlock()

--- a/client/webserver/websocket.go
+++ b/client/webserver/websocket.go
@@ -99,6 +99,7 @@ func (s *WebServer) websocketHandler(conn ws.Connection, ip string) {
 		cl.mtx.Lock()
 		if cl.feedLoop != nil {
 			cl.feedLoop.Stop()
+			cl.feedLoop.WaitForShutdown()
 		}
 		cl.mtx.Unlock()
 
@@ -149,9 +150,12 @@ func (s *WebServer) handleMessage(conn *wsClient, msg *msgjson.Message) *msgjson
 	return msgjson.NewError(msgjson.UnknownMessageType, "web server only handles requests")
 }
 
+// All request handlers must be defined with this signature.
+type wsHandler func(*WebServer, *wsClient, *msgjson.Message) *msgjson.Error
+
 // wsHandlers is the map used by the server to locate the router handler for a
 // request.
-var wsHandlers = map[string]func(*WebServer, *wsClient, *msgjson.Message) *msgjson.Error{
+var wsHandlers = map[string]wsHandler{
 	"loadmarket": wsLoadMarket,
 	"unmarket":   wsUnmarket,
 	"acknotes":   wsAckNotes,
@@ -175,7 +179,7 @@ type marketResponse struct {
 }
 
 // wsLoadMarket is the handler for the 'loadmarket' websocket endpoint.
-// Subscribes the client to the notification feed by sends the order book.
+// Subscribes the client to the notification feed and sends the order book.
 func wsLoadMarket(s *WebServer, cl *wsClient, msg *msgjson.Message) *msgjson.Error {
 	market := new(marketLoad)
 	err := json.Unmarshal(msg.Payload, market)
@@ -195,11 +199,12 @@ func wsLoadMarket(s *WebServer, cl *wsClient, msg *msgjson.Message) *msgjson.Err
 	cl.mtx.Lock()
 	if cl.feedLoop != nil {
 		cl.feedLoop.Stop()
+		cl.feedLoop.WaitForShutdown()
 	}
 	cl.feedLoop = newMarketSyncer(s.ctx, cl, feed)
 	cl.mtx.Unlock()
 
-	note, err := msgjson.NewNotification("book", &marketResponse{
+	note, err := msgjson.NewNotification(core.FreshBookAction, &marketResponse{
 		Host:  market.Host,
 		Book:  book,
 		Base:  market.Base,
@@ -225,6 +230,7 @@ func wsUnmarket(_ *WebServer, cl *wsClient, _ *msgjson.Message) *msgjson.Error {
 	defer cl.mtx.Unlock()
 	if cl.feedLoop != nil {
 		cl.feedLoop.Stop()
+		cl.feedLoop.WaitForShutdown()
 		cl.feedLoop = nil
 	}
 	return nil

--- a/client/webserver/websocket.go
+++ b/client/webserver/websocket.go
@@ -189,7 +189,7 @@ func wsLoadMarket(s *WebServer, cl *wsClient, msg *msgjson.Message) *msgjson.Err
 		return msgjson.NewError(msgjson.RPCInternal, errMsg)
 	}
 
-	book, feed, err := s.core.Sync(market.Host, market.Base, market.Quote)
+	book, feed, err := s.core.SyncBook(market.Host, market.Base, market.Quote)
 	if err != nil {
 		errMsg := fmt.Sprintf("error getting order feed: %v", err)
 		log.Errorf(errMsg)

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -394,6 +394,7 @@ out:
 					book.name, sigData.finalEpoch, sigData.persistBook)
 
 				// Stay running for Swapper unbook callbacks.
+				continue // no note to send presently, but need one
 
 			default:
 				panic(fmt.Sprintf("unknown orderbook update action %d", u.action))


### PR DESCRIPTION
This resolves a data race on the `bookie.feeds` map caused by the `handleReconnect` function making a shallow copy of the map.

This also refactors the `bookie`, `BookFeed`, and reconnect handling quite a bit. Main problems that are resolved:
1. `BookFeeds` were being copied to a new `bookie` in `handleReconnect`, but the `BookFeed.close` function was a method an the old `bookie` instance.  Now the `bookie` (and its `BookFeed`s) are not replaced, and instead a manual resubscribe is performed.
2. When reconnect resubscribed with the server, the feed receivers (e.g. web frontend) needed a fresh book since book/unbook/epoch messages are likely to have been missed.  This is resolved with a `FreshBookAction` notification type.
3. AfterFunc timer race between the bookie's close timer that called Unsub with the creation of new feeds in Sync that expect the subscription to be valid, not about to be unsubscribed.