### PR TITLE
dex/testing: whitelist loopback peers in harness

### DIFF
--- a/dex/testing/btc/base-harness.sh
+++ b/dex/testing/btc/base-harness.sh
@@ -66,6 +66,7 @@ tmux send-keys -t $SESSION:0 "cd ${ALPHA_DIR}" C-m
 echo "Starting simnet alpha node"
 tmux send-keys -t $SESSION:0 "${DAEMON} -rpcuser=user -rpcpassword=pass \
   -rpcport=${ALPHA_RPC_PORT} -datadir=${ALPHA_DIR} \
+  -whitelist=127.0.0.0/8 -whitelist=::1 \
   -txindex=1 -regtest=1 -port=${ALPHA_LISTEN_PORT} -fallbackfee=0.00001; tmux wait-for -S alpha${SYMBOL}" C-m
 sleep 3
 
@@ -79,6 +80,7 @@ tmux send-keys -t $SESSION:1 "cd ${BETA_DIR}" C-m
 echo "Starting simnet beta node"
 tmux send-keys -t $SESSION:1 "${DAEMON} -rpcuser=user -rpcpassword=pass \
   -rpcport=${BETA_RPC_PORT} -datadir=${BETA_DIR} -txindex=1 -regtest=1 \
+  -whitelist=127.0.0.0/8 -whitelist=::1 \
   -port=${BETA_LISTEN_PORT} -fallbackfee=0.00001; tmux wait-for -S beta${SYMBOL}" C-m
 sleep 3
 

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -146,6 +146,7 @@ tmux send-keys -t $SESSION:1 "dcrd --appdata=${NODES_ROOT}/alpha \
 --miningaddr=${ALPHA_MINING_ADDR} --rpclisten=127.0.0.1:${ALPHA_RPC_PORT} \
 --txindex --listen=127.0.0.1:${ALPHA_PORT} \
 --debuglevel=debug \
+--whitelist=127.0.0.0/8 --whitelist=::1 \
 --simnet; tmux wait-for -S alphadcr" C-m
 
 tmux new-window -t $SESSION:2 -n 'beta'
@@ -158,6 +159,7 @@ tmux send-keys -t $SESSION:2 "dcrd --appdata=${NODES_ROOT}/beta \
 --miningaddr=${BETA_MINING_ADDR} \
 --txindex --connect=127.0.0.1:${ALPHA_PORT} \
 --debuglevel=debug \
+--whitelist=127.0.0.0/8 --whitelist=::1 \
 --simnet; tmux wait-for -S betadcr" C-m
 
 sleep 3


### PR DESCRIPTION
I've had the alpha/beta DCR simnet nodes ban each other.  This should prevent that from happening.