### PR TITLE
server/{dex,asset/dcr}: validate regfeexpub earlier in startup

### DIFF
--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -24,6 +24,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson/v3"
 	"github.com/decred/dcrd/dcrutil/v2"
+	"github.com/decred/dcrd/hdkeychain/v2"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/rpcclient/v5"
 	"github.com/decred/dcrd/wire"
@@ -264,6 +265,20 @@ func (dcr *Backend) FundingCoin(coinID []byte, redeemScript []byte) (asset.Fundi
 		return nil, fmt.Errorf("non-standard script")
 	}
 	return utxo, nil
+}
+
+// ValidateXPub validates the base-58 encoded extended key, and ensures that it
+// is an extended public, not private, key.
+func (dcr *Backend) ValidateXPub(xpub string) error {
+	xp, err := hdkeychain.NewKeyFromString(xpub, chainParams)
+	if err != nil {
+		return err
+	}
+	if xp.IsPrivate() {
+		xp.Zero()
+		return fmt.Errorf("extended key is a private key")
+	}
+	return nil
 }
 
 // ValidateCoinID attempts to decode the coinID.

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2/schnorr"
 	"github.com/decred/dcrd/dcrutil/v2"
+	"github.com/decred/dcrd/hdkeychain/v2"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/txscript/v2"
 	"github.com/decred/dcrd/wire"
@@ -1380,6 +1381,48 @@ func TestCheckAddress(t *testing.T) {
 	}
 }
 
+func TestValidateXPub(t *testing.T) {
+	seed := randomBytes(hdkeychain.MinSeedBytes)
+	master, err := hdkeychain.NewMaster(seed, chainParams)
+	if err != nil {
+		t.Fatalf("failed to generate master extended key: %v", err)
+	}
+
+	be := &Backend{}
+
+	// fail for private key
+	xprivStr := master.String()
+	if err = be.ValidateXPub(xprivStr); err == nil {
+		t.Errorf("no error for extended private key")
+	}
+
+	xpub, err := master.Neuter()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// succeed for public key
+	xpubStr := xpub.String()
+	if err = be.ValidateXPub(xpubStr); err != nil {
+		t.Error(err)
+	}
+
+	// fail for invalid key of wrong length
+	if err = be.ValidateXPub(xpubStr[2:]); err == nil {
+		t.Errorf("no error for invalid key")
+	}
+
+	// fail for wrong network
+	masterTestnet, err := hdkeychain.NewMaster(seed, chaincfg.TestNet3Params())
+	if err != nil {
+		t.Fatalf("failed to generate master extended key: %v", err)
+	}
+	xpubTestnet, _ := masterTestnet.Neuter()
+	if err = be.ValidateXPub(xpubTestnet.String()); err == nil {
+		t.Errorf("no error for invalid wrong network")
+	}
+}
+
 func TestDriver_DecodeCoinID(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -1416,6 +1459,21 @@ func TestDriver_DecodeCoinID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &Driver{}
 			got, err := d.DecodeCoinID(tt.coinID)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Driver.DecodeCoinID() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Driver.DecodeCoinID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	// Same tests with ValidateCoinID
+	be := &Backend{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := be.ValidateCoinID(tt.coinID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Driver.DecodeCoinID() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -357,6 +357,16 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		})
 	}
 
+	// Ensure their is a DCR asset backend.
+	if dcrBackend == nil {
+		abort()
+		return nil, fmt.Errorf("no DCR backend configured")
+	}
+	// Validate the registration fee extended public key.
+	if err := dcrBackend.ValidateXPub(cfg.RegFeeXPub); err != nil {
+		return nil, fmt.Errorf("invalid regfeexpub: %w", err)
+	}
+
 	for _, mkt := range cfg.Markets {
 		mkt.Name = strings.ToLower(mkt.Name)
 	}


### PR DESCRIPTION
Add `server/asset/dcr.(*Backend).ValidateXPub`.

In `server/dex.NewDEX`, validate the string provided in the `--regfeexpub`
config setting.  Also ensure `dcrBackend` exists.

The database would error on construction, but this catches the invalid xpub earlier.