### PR TITLE
rpcserver: Add myorders route.

### DIFF
--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -483,7 +483,6 @@ func parseCoreOrder(co *core.Order, b, q uint32) *myOrder {
 		Cancelling:  cancelling,
 		Canceled:    co.Canceled,
 		TimeInForce: co.TimeInForce.String(),
-		TargetID:    co.TargetID, // cancel orders are not shown, so always zero value
 	}
 }
 

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -473,8 +473,8 @@ func parseCoreOrder(co *core.Order, b, q uint32) *myOrder {
 		ID:          co.ID,
 		Type:        co.Type.String(),
 		Sell:        co.Sell,
-		Age:         age.Milliseconds(),
-		AgeStr:      age.String(),
+		Stamp:       co.Stamp,
+		Age:         age.String(),
 		Rate:        co.Rate,
 		Quantity:    co.Qty,
 		Filled:      co.Filled,
@@ -900,9 +900,8 @@ Registration is complete after the fee transaction has been confirmed.`,
       "id" (string): The order's unique hex ID.
       "type" (string): The type of order. "limit", "market", or "cancel".
       "sell" (string): Whether this order is selling.
-      "age" (int): The time in milliseconds that this order has been active.
-      "agestr" (string): The time that this order has been active in human
-        readable form.
+      "stamp" (int): Time the order was made in milliseconds since 00:00:00 Jan 1 1970.
+      "age" (string): The time that this order has been active in human readable form.
       "rate" (int): The exchange rate limit. Limit orders only. Units: quote
         asset per unit base asset.
       "quantity" (int): The amount being traded.
@@ -912,8 +911,8 @@ Registration is complete after the fee transaction has been confirmed.`,
         "canceled", or "revoked".
       "cancelling" (bool): Whether this order is in the process of cancelling.
       "canceled" (bool): Whether this order has been canceled.
-      "tif" (string): "immediate" if this order is for only one epoch. "standing"
-        if this order is or will be recorded on the books.
+      "tif" (string): "immediate" if this limit order will only match for one epoch.
+        "standing" if the order can continue matching until filled or cancelled.
     },...
   ]`,
 	},

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -291,18 +291,6 @@ func handleExchanges(s *RPCServer, _ *RawParams) *msgjson.ResponsePayload {
 		}
 		return m
 	}
-	// Convert something to a []interface{}.
-	convA := func(in interface{}) []interface{} {
-		var a []interface{}
-		b, err := json.Marshal(in)
-		if err != nil {
-			panic(err)
-		}
-		if err = json.Unmarshal(b, &a); err != nil {
-			panic(err)
-		}
-		return a
-	}
 	res := s.core.Exchanges()
 	exchanges := convM(res)
 	// Interate through exchanges converting structs into maps in order to
@@ -317,16 +305,7 @@ func handleExchanges(s *RPCServer, _ *RawParams) *msgjson.ResponsePayload {
 			marketDetails := convM(market)
 			// Remove redundant name field.
 			delete(marketDetails, "name")
-			orders := convA(marketDetails["orders"])
-			for i, order := range orders {
-				orderDetails := convM(order)
-				// Remove redundant address field.
-				delete(orderDetails, "dex")
-				// Remove redundant market name field.
-				delete(orderDetails, "market")
-				orders[i] = orderDetails
-			}
-			marketDetails["orders"] = orders
+			delete(marketDetails, "orders")
 			markets[k] = marketDetails
 		}
 		assets := convM(exchangeDetails["assets"])
@@ -736,29 +715,6 @@ Registration is complete after the fee transaction has been confirmed.`,
             "startepoch" (int): Time of start of the last epoch in milliseconds
 	      since 00:00:00 Jan 1 1970.
             "buybuffer" (float): The minimum order size for a market buy order.
-            "orders" (map): {
-              "type" (int): 0 for market or 1 for limit.
-              "id" (string): A unique trade ID.
-              "stamp" (int): The unix trade timestamp. Seconds since 00:00:00
-	        Jan 1 1970.
-              "qty" (bool): Number of units offered in the trade.
-              "sell" (bool): Whether this is a sell order.
-              "filled" (int): How much of the order has been filled.
-              "matches": [
-	        {
-                  "matchID" (string): A unique match ID.
-                  "status" (string): The match status.
-                  "rate" (int): Atoms quote asset per unit base asset.
-                  "qty" (int): Number of units offered in the trade.
-		},...
-	      ]
-              "cancelling" (bool): Whether this trade is in the process of being
-	        cancelled.
-              "canceled" (bool): Whether this trade has been canceled.
-              "rate" (int): Atoms quote asset per unit base asset.
-              "tif" (int): The number of epochs this trade is good for.
-              "targetID" (string): The order ID of the order being canceled.
-	      },...
           },...
         },
         "assets": {

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -471,20 +471,46 @@ func TestHandleRegister(t *testing.T) {
 }
 
 /*
-   handleExchanges removes some redundant fields from the response.
-   $ diff in out
-   3d2
-   <     "host": "https://127.0.0.1:7232",
-   6d4
-   <         "name": "dcr_btc",
-   16,17d13
-   <             "dex": "https://127.0.0.1:7232",
-   <             "market": "dcr_btc",
-   42d37
-   <         "id": 0,
-   52d46
-   <         "id": 42,
+  $diff exchangeIn exchangeOut
+  3d2
+  <     "host": "https://127.0.0.1:7232",
+  6d4
+  <         "name": "dcr_btc",
+  13,38c11
+  <         "buybuffer": 1.25,
+  <         "orders": [
+  <           {
+  <             "dex": "https://127.0.0.1:7232",
+  <             "market": "dcr_btc",
+  <             "type": 1,
+  <             "id": "e016a563ff5b845e9af20718af72224af630e65ca53edf2a3342d175dc6d3738",
+  <             "stamp": 1588913556583,
+  <             "qty": 100000000,
+  <             "sell": false,
+  <             "sig": "3045022100c5ef66cbf3c2d305408b666108ae384478f22b558893942b8f66abfb613a5bf802205eb22a0250e5286244b2f5205f0b6d6b4fa6a60930be2ff30f35c3cf6bf969c8",
+  <             "filled": 0,
+  <             "matches": [
+  <               {
+  <                 "matchID": "1472deb169fb359a48676161be8ca81983201f28abe8cc9b504950032d6f14ec",
+  <                 "qty": 100000000,
+  <                 "rate": 100000000,
+  <                 "step": 1
+  <               }
+  <             ],
+  <             "cancelling": false,
+  <             "canceled": false,
+  <             "rate": 100000000,
+  <             "tif": 1
+  <           }
+  <         ]
+  ---
+  >         "buybuffer": 1.25
+  43d15
+  <         "id": 0,
+  53d24
+  <         "id": 42,
 */
+
 const exchangeIn = `{
   "https://127.0.0.1:7232": {
     "host": "https://127.0.0.1:7232",
@@ -547,10 +573,11 @@ const exchangeIn = `{
         "swapConf": 1
       }
     },
-	"confsrequired": 1,
-	"confs": null
+    "confsrequired": 1,
+    "confs": null
   }
 }`
+
 const exchangeOut = `{
   "https://127.0.0.1:7232": {
     "markets": {
@@ -561,30 +588,7 @@ const exchangeOut = `{
         "quotesymbol": "btc",
         "epochlen": 10000,
         "startepoch": 158891349,
-        "buybuffer": 1.25,
-        "orders": [
-          {
-            "type": 1,
-            "id": "e016a563ff5b845e9af20718af72224af630e65ca53edf2a3342d175dc6d3738",
-            "stamp": 1588913556583,
-            "qty": 100000000,
-            "sell": false,
-            "sig": "3045022100c5ef66cbf3c2d305408b666108ae384478f22b558893942b8f66abfb613a5bf802205eb22a0250e5286244b2f5205f0b6d6b4fa6a60930be2ff30f35c3cf6bf969c8",
-            "filled": 0,
-            "matches": [
-              {
-                "matchID": "1472deb169fb359a48676161be8ca81983201f28abe8cc9b504950032d6f14ec",
-                "qty": 100000000,
-                "rate": 100000000,
-                "step": 1
-              }
-            ],
-            "cancelling": false,
-            "canceled": false,
-            "rate": 100000000,
-            "tif": 1
-          }
-        ]
+        "buybuffer": 1.25
       }
     },
     "assets": {
@@ -629,7 +633,7 @@ func TestHandleExchanges(t *testing.T) {
 		panic(err)
 	}
 	if !reflect.DeepEqual(res, exchangesOut) {
-		t.Fatal("result does not have expected fields removed")
+		t.Fatalf("expected %v but got %v", spew.Sdump(exchangesOut), spew.Sdump(res))
 	}
 }
 

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -470,47 +470,6 @@ func TestHandleRegister(t *testing.T) {
 	}
 }
 
-/*
-  $diff exchangeIn exchangeOut
-  3d2
-  <     "host": "https://127.0.0.1:7232",
-  6d4
-  <         "name": "dcr_btc",
-  13,38c11
-  <         "buybuffer": 1.25,
-  <         "orders": [
-  <           {
-  <             "dex": "https://127.0.0.1:7232",
-  <             "market": "dcr_btc",
-  <             "type": 1,
-  <             "id": "e016a563ff5b845e9af20718af72224af630e65ca53edf2a3342d175dc6d3738",
-  <             "stamp": 1588913556583,
-  <             "qty": 100000000,
-  <             "sell": false,
-  <             "sig": "3045022100c5ef66cbf3c2d305408b666108ae384478f22b558893942b8f66abfb613a5bf802205eb22a0250e5286244b2f5205f0b6d6b4fa6a60930be2ff30f35c3cf6bf969c8",
-  <             "filled": 0,
-  <             "matches": [
-  <               {
-  <                 "matchID": "1472deb169fb359a48676161be8ca81983201f28abe8cc9b504950032d6f14ec",
-  <                 "qty": 100000000,
-  <                 "rate": 100000000,
-  <                 "step": 1
-  <               }
-  <             ],
-  <             "cancelling": false,
-  <             "canceled": false,
-  <             "rate": 100000000,
-  <             "tif": 1
-  <           }
-  <         ]
-  ---
-  >         "buybuffer": 1.25
-  43d15
-  <         "id": 0,
-  53d24
-  <         "id": 42,
-*/
-
 const exchangeIn = `{
   "https://127.0.0.1:7232": {
     "host": "https://127.0.0.1:7232",
@@ -1024,11 +983,13 @@ func TestParseCoreOrder(t *testing.T) {
     "type": "limit",
     "sell": false,
     "age": 2664424,
+    "agestr": "2.664424s",
     "rate": 200000000,
     "quantity": 400000000,
     "filled": 300000000,
     "settled": 100000000,
-    "status": "booked"
+    "status": "booked",
+    "tif": "standing"
   }`
 	coreOrder := new(core.Order)
 	if err := json.Unmarshal([]byte(co), coreOrder); err != nil {
@@ -1042,6 +1003,7 @@ func TestParseCoreOrder(t *testing.T) {
 	res := parseCoreOrder(coreOrder, 42, 0)
 	// Age will differ as it is based on the current time.
 	myOrder.Age = res.Age
+	myOrder.AgeStr = res.AgeStr
 	if !reflect.DeepEqual(myOrder, res) {
 		t.Fatalf("expected %v but got %v", spew.Sdump(myOrder), spew.Sdump(res))
 	}

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
+	"github.com/davecgh/go-spew/spew"
 )
 
 func verifyResponse(payload *msgjson.ResponsePayload, res interface{}, wantErrCode int) error {
@@ -469,23 +470,22 @@ func TestHandleRegister(t *testing.T) {
 	}
 }
 
-func TestHandleExchanges(t *testing.T) {
-	/*
-	   handleExchanges removes some redundant fields from the response.
-	   $ diff in out
-	   3d2
-	   <     "host": "https://127.0.0.1:7232",
-	   6d4
-	   <         "name": "dcr_btc",
-	   16,17d13
-	   <             "dex": "https://127.0.0.1:7232",
-	   <             "market": "dcr_btc",
-	   42d37
-	   <         "id": 0,
-	   52d46
-	   <         "id": 42,
-	*/
-	in := `{
+/*
+   handleExchanges removes some redundant fields from the response.
+   $ diff in out
+   3d2
+   <     "host": "https://127.0.0.1:7232",
+   6d4
+   <         "name": "dcr_btc",
+   16,17d13
+   <             "dex": "https://127.0.0.1:7232",
+   <             "market": "dcr_btc",
+   42d37
+   <         "id": 0,
+   52d46
+   <         "id": 42,
+*/
+const exchangeIn = `{
   "https://127.0.0.1:7232": {
     "host": "https://127.0.0.1:7232",
     "markets": {
@@ -551,7 +551,7 @@ func TestHandleExchanges(t *testing.T) {
 	"confs": null
   }
 }`
-	out := `{
+const exchangeOut = `{
   "https://127.0.0.1:7232": {
     "markets": {
       "dcr_btc": {
@@ -611,8 +611,10 @@ func TestHandleExchanges(t *testing.T) {
     "confs": null
   }
 }`
+
+func TestHandleExchanges(t *testing.T) {
 	var exchangesIn map[string]*core.Exchange
-	if err := json.Unmarshal([]byte(in), &exchangesIn); err != nil {
+	if err := json.Unmarshal([]byte(exchangeIn), &exchangesIn); err != nil {
 		panic(err)
 	}
 	tc := &TCore{exchanges: exchangesIn}
@@ -623,7 +625,7 @@ func TestHandleExchanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	var exchangesOut map[string]*core.Exchange
-	if err := json.Unmarshal([]byte(out), &exchangesOut); err != nil {
+	if err := json.Unmarshal([]byte(exchangeOut), &exchangesOut); err != nil {
 		panic(err)
 	}
 	if !reflect.DeepEqual(res, exchangesOut) {
@@ -925,5 +927,118 @@ func TestTruncateOrderBook(t *testing.T) {
 	}
 	if book.Sells[0].Rate != lowRate {
 		t.Fatal("expected low rate order")
+	}
+}
+
+func TestHandleMyOrders(t *testing.T) {
+	var exchangesIn map[string]*core.Exchange
+	if err := json.Unmarshal([]byte(exchangeIn), &exchangesIn); err != nil {
+		panic(err)
+	}
+	paramsWithArgs := func(ss ...string) *RawParams {
+		args := []string{}
+		args = append(args, ss...)
+		return &RawParams{Args: args}
+	}
+	tests := []struct {
+		name        string
+		params      *RawParams
+		wantErrCode int
+	}{{
+		name:        "ok no params",
+		params:      paramsWithArgs(),
+		wantErrCode: -1,
+	}, {
+		name:        "ok with host param",
+		params:      paramsWithArgs("127.0.0.1:7232"),
+		wantErrCode: -1,
+	}, {
+		name:        "ok with host and baseID/quoteID params",
+		params:      paramsWithArgs("127.0.0.1:7232", "42", "0"),
+		wantErrCode: -1,
+	}, {
+		name:        "ok with no host and baseID/quoteID params",
+		params:      paramsWithArgs("", "42", "0"),
+		wantErrCode: -1,
+	}, {
+		name:        "bad params",
+		params:      paramsWithArgs("", "42"), // missing quote ID
+		wantErrCode: msgjson.RPCArgumentsError,
+	}}
+	for _, test := range tests {
+		tc := &TCore{exchanges: exchangesIn}
+		r := &RPCServer{core: tc}
+		payload := handleMyOrders(r, test.params)
+		res := new(myOrdersResponse)
+		if err := verifyResponse(payload, res, test.wantErrCode); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestParseCoreOrder(t *testing.T) {
+	co := `{
+    "canceled": false,
+    "cancelling": false,
+    "epoch": 159650082,
+    "filled": 300000000,
+    "host": "127.0.0.1:7232",
+    "id": "ca0097c87dbf01169d76b6f2a318f88fe0ea678df3139f09d756d7d3e2c602dd",
+    "market": "dcr_btc",
+    "matches": [
+      {
+        "matchID": "992f15e89bbd670663b690b4da4a859609d83866e200f3c4cd5c916442b8ea46",
+        "qty": 100000000,
+        "rate": 200000000,
+        "side": 0,
+        "status": 4
+      },
+      {
+        "matchID": "69d7453d8ad3b52851c2c9925499a1b158301e8a08da594428ef0ad4cd6fd3a5",
+        "qty": 200000000,
+        "rate": 200000000,
+        "side": 0,
+        "status": 1
+      }
+    ],
+    "qty": 400000000,
+    "rate": 200000000,
+    "sell": false,
+    "sig": "30450221008eaf7fa3e5b4374800d11e50af419d3fa7c75362dce136df98a25eccc84e61380220458132451b40aa6951ab5b61d6b55c478fd9535c3d24fd4957070c7879e465ff",
+    "stamp": 1596500829705,
+    "status": 2,
+    "tif": 1,
+    "type": 1
+  }`
+
+	mo := `{
+    "host": "127.0.0.1:7232",
+    "marketName": "dcr_btc",
+    "baseID": 42,
+    "quoteID": 0,
+    "id": "ca0097c87dbf01169d76b6f2a318f88fe0ea678df3139f09d756d7d3e2c602dd",
+    "type": "limit",
+    "sell": false,
+    "age": 2664424,
+    "rate": 200000000,
+    "quantity": 400000000,
+    "filled": 300000000,
+    "settled": 100000000,
+    "status": "booked"
+  }`
+	coreOrder := new(core.Order)
+	if err := json.Unmarshal([]byte(co), coreOrder); err != nil {
+		panic(err)
+	}
+	myOrder := new(myOrder)
+	if err := json.Unmarshal([]byte(mo), myOrder); err != nil {
+		panic(err)
+	}
+
+	res := parseCoreOrder(coreOrder, 42, 0)
+	// Age will differ as it is based on the current time.
+	myOrder.Age = res.Age
+	if !reflect.DeepEqual(myOrder, res) {
+		t.Fatalf("expected %v but got %v", spew.Sdump(myOrder), spew.Sdump(res))
 	}
 }

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -982,8 +982,8 @@ func TestParseCoreOrder(t *testing.T) {
     "id": "ca0097c87dbf01169d76b6f2a318f88fe0ea678df3139f09d756d7d3e2c602dd",
     "type": "limit",
     "sell": false,
-    "age": 2664424,
-    "agestr": "2.664424s",
+    "stamp": 1596500829705,
+    "age": "2.664424s",
     "rate": 200000000,
     "quantity": 400000000,
     "filled": 300000000,
@@ -1003,7 +1003,6 @@ func TestParseCoreOrder(t *testing.T) {
 	res := parseCoreOrder(coreOrder, 42, 0)
 	// Age will differ as it is based on the current time.
 	myOrder.Age = res.Age
-	myOrder.AgeStr = res.AgeStr
 	if !reflect.DeepEqual(myOrder, res) {
 		t.Fatalf("expected %v but got %v", spew.Sdump(myOrder), spew.Sdump(res))
 	}

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -75,7 +75,6 @@ type myOrder struct {
 	Cancelling  bool   `json:"cancelling,omitempty"`
 	Canceled    bool   `json:"canceled,omitempty"`
 	TimeInForce string `json:"tif,omitempty"`
-	TargetID    string `json:"targetID,omitempty"`
 }
 
 // openWalletForm is information necessary to open a wallet.

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -65,8 +65,8 @@ type myOrder struct {
 	ID          string `json:"id"`
 	Type        string `json:"type"`
 	Sell        bool   `json:"sell"`
-	Age         int64  `json:"age"`
-	AgeStr      string `json:"agestr"`
+	Stamp       uint64 `json:"stamp"`
+	Age         string `json:"age"`
 	Rate        uint64 `json:"rate,omitempty"`
 	Quantity    uint64 `json:"quantity"`
 	Filled      uint64 `json:"filled"`

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -54,6 +54,25 @@ type tradeResponse struct {
 	Stamp   uint64 `json:"stamp"`
 }
 
+// myOrdersResponse is used when responding to the myorders route.
+type myOrdersResponse []*myOrder
+
+type myOrder struct {
+	Host       string `json:"host"`
+	MarketName string `json:"marketName"`
+	BaseID     uint32 `json:"baseID"`
+	QuoteID    uint32 `json:"quoteID"`
+	ID         string `json:"id"`
+	Type       string `json:"type"`
+	Sell       bool   `json:"sell"`
+	Age        uint64 `json:"age"`
+	Rate       uint64 `json:"rate"`
+	Quantity   uint64 `json:"quantity"`
+	Filled     uint64 `json:"filled"`
+	Settled    uint64 `json:"settled"`
+	Status     string `json:"status"`
+}
+
 // openWalletForm is information necessary to open a wallet.
 type openWalletForm struct {
 	assetID uint32
@@ -100,6 +119,13 @@ type orderBookForm struct {
 	base    uint32
 	quote   uint32
 	nOrders uint64
+}
+
+// myOrdersForm is information necessary to fetch the user's orders.
+type myOrdersForm struct {
+	host  string
+	base  *uint32
+	quote *uint32
 }
 
 // checkNArgs checks that args and pwArgs are the correct length.
@@ -374,6 +400,38 @@ func parseOrderBookArgs(params *RawParams) (*orderBookForm, error) {
 		base:    uint32(base),
 		quote:   uint32(quote),
 		nOrders: nOrders,
+	}
+	return req, nil
+}
+
+func parseMyOrdersArgs(params *RawParams) (*myOrdersForm, error) {
+	if err := checkNArgs(params, []int{0}, []int{0, 3}); err != nil {
+		return nil, err
+	}
+	req := new(myOrdersForm)
+	switch len(params.Args) {
+	case 3:
+		// Args 1 and 2 should be base ID and quote ID. If present,
+		// they are a pair.
+		quote, err := checkUIntArg(params.Args[2], "quote", 32)
+		if err != nil {
+			return nil, err
+		}
+		q := uint32(quote)
+		req.quote = &q
+
+		base, err := checkUIntArg(params.Args[1], "base", 32)
+		if err != nil {
+			return nil, err
+		}
+		b := uint32(base)
+		req.base = &b
+		fallthrough
+	case 1:
+		req.host = params.Args[0]
+	case 2:
+		// Received a base ID but no quote ID.
+		return nil, fmt.Errorf("%w: no market quote ID", errArgs)
 	}
 	return req, nil
 }

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -58,19 +58,24 @@ type tradeResponse struct {
 type myOrdersResponse []*myOrder
 
 type myOrder struct {
-	Host       string `json:"host"`
-	MarketName string `json:"marketName"`
-	BaseID     uint32 `json:"baseID"`
-	QuoteID    uint32 `json:"quoteID"`
-	ID         string `json:"id"`
-	Type       string `json:"type"`
-	Sell       bool   `json:"sell"`
-	Age        uint64 `json:"age"`
-	Rate       uint64 `json:"rate"`
-	Quantity   uint64 `json:"quantity"`
-	Filled     uint64 `json:"filled"`
-	Settled    uint64 `json:"settled"`
-	Status     string `json:"status"`
+	Host        string `json:"host"`
+	MarketName  string `json:"marketName"`
+	BaseID      uint32 `json:"baseID"`
+	QuoteID     uint32 `json:"quoteID"`
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	Sell        bool   `json:"sell"`
+	Age         int64  `json:"age"`
+	AgeStr      string `json:"agestr"`
+	Rate        uint64 `json:"rate,omitempty"`
+	Quantity    uint64 `json:"quantity"`
+	Filled      uint64 `json:"filled"`
+	Settled     uint64 `json:"settled"`
+	Status      string `json:"status"`
+	Cancelling  bool   `json:"cancelling,omitempty"`
+	Canceled    bool   `json:"canceled,omitempty"`
+	TimeInForce string `json:"tif,omitempty"`
+	TargetID    string `json:"targetID,omitempty"`
 }
 
 // openWalletForm is information necessary to open a wallet.

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -147,7 +147,7 @@ func (t TimeInForce) String() string {
 	case StandingTiF:
 		return "standing"
 	}
-	return string(t)
+	return fmt.Sprintf("unknown (%d)", t)
 }
 
 // Order specifies the methods required for a type to function as a DEX order.

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -139,6 +139,17 @@ const (
 	StandingTiF
 )
 
+// String satisfies the Stringer interface.
+func (t TimeInForce) String() string {
+	switch t {
+	case ImmediateTiF:
+		return "immediate"
+	case StandingTiF:
+		return "standing"
+	}
+	return string(t)
+}
+
 // Order specifies the methods required for a type to function as a DEX order.
 // See the concrete implementations of MarketOrder, LimitOrder, and CancelOrder.
 type Order interface {


### PR DESCRIPTION
    rpcserver: Add myorders route.
    
    While my orders were accessible through the exchanges endpoint, the data
    was raw and unorganized. This adds some pre-computed, useful information
    such as age of the order and amount settled. It also allows for
    filtering by exchange and/or market.

    rpcserver: Remove orders from exchanges endpoint.
    
    Because orders can now be accessed through the myorders endpoint, they
    can be removed from exchanges.
