### PR TITLE
app: indicate immediate time-in-force for user orders on markets view

### DIFF
--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -91,8 +91,12 @@ func userOrders() (ords []*core.Order) {
 			}
 		}
 		var tif order.TimeInForce
-		if isLimit && rand.Float32() > 0.66 {
-			tif = order.StandingTiF
+		if isLimit {
+			if rand.Float32() < 0.25 {
+				tif = order.ImmediateTiF
+			} else {
+				tif = order.StandingTiF
+			}
 		}
 		ords = append(ords, &core.Order{
 			ID:     ordertest.RandomOrderID().String(),

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -1508,7 +1508,7 @@ function updateDataCol (tr, col, s) {
  * updateUserOrderRow sets the td contents of the user's order table row.
  */
 function updateUserOrderRow (tr, order) {
-  updateDataCol(tr, 'type', order.type === LIMIT ? 'limit' : 'market')
+  updateDataCol(tr, 'type', order.type === LIMIT ? (order.tif === immediateTiF ? 'limit (i)' : 'limit') : 'market')
   updateDataCol(tr, 'side', order.sell ? 'sell' : 'buy')
   updateDataCol(tr, 'age', Doc.timeSince(order.stamp))
   updateDataCol(tr, 'rate', Doc.formatCoinValue(order.rate / 1e8))


### PR DESCRIPTION
In the "Your Orders" table on the markets view, if a limit order has time-in-force = immediate, shows the type as `Limit (i)`. 

![image](https://user-images.githubusercontent.com/6109680/89466376-56f18d00-d739-11ea-8f0f-a432db748e19.png)
