### PR TITLE
client/core: fix btc wallet cfg in simnet tests, other improvements

### DIFF
--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -310,15 +310,17 @@ func simpleTradeTest(qty, rate uint64, finalStatus order.MatchStatus) error {
 
 	// Check if any refunds are necessary and wait to ensure the refunds
 	// are completed.
-	refundsWaiter, ctx := errgroup.WithContext(context.Background())
-	refundsWaiter.Go(func() error {
-		return checkAndWaitForRefunds(ctx, client1, c1OrderID)
-	})
-	refundsWaiter.Go(func() error {
-		return checkAndWaitForRefunds(ctx, client2, c2OrderID)
-	})
-	if err = refundsWaiter.Wait(); err != nil {
-		return err
+	if finalStatus != order.MatchComplete {
+		refundsWaiter, ctx := errgroup.WithContext(context.Background())
+		refundsWaiter.Go(func() error {
+			return checkAndWaitForRefunds(ctx, client1, c1OrderID)
+		})
+		refundsWaiter.Go(func() error {
+			return checkAndWaitForRefunds(ctx, client2, c2OrderID)
+		})
+		if err = refundsWaiter.Wait(); err != nil {
+			return err
+		}
 	}
 
 	tLog.Infof("Trades ended at %s.", finalStatus)

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -437,7 +437,7 @@ func monitorTradeForTestOrder(ctx context.Context, client *tClient, orderID stri
 			// up action. Mining now without waiting may cause the other client
 			// to perform the follow up action before the goroutine captures
 			// this status change.
-			time.Sleep(1 * time.Second)
+			time.Sleep(5 * time.Second)
 
 			assetID, nBlocks := assetToMine.ID, uint16(assetToMine.SwapConf)
 			err := mineBlocks(assetID, nBlocks)
@@ -773,6 +773,8 @@ func (client *tClient) updateBalances() error {
 			return err
 		}
 		client.balances[assetID] = balances.Available + balances.Locked
+		client.log("%s available %f, locked %f", unbip(assetID),
+			fmtAmt(balances.Available), fmtAmt(balances.Locked))
 	}
 	return nil
 }
@@ -797,8 +799,8 @@ func (client *tClient) assertBalanceChanges() error {
 		}
 		balanceDiff := int64(client.balances[assetID] - prevBalances[assetID])
 		if balanceDiff < minExpectedDiff || balanceDiff > maxExpectedDiff {
-			return fmt.Errorf("client %d %s balance change not in expected range %.8f - %.8f, got %.8f",
-				client.id, unbip(assetID), fmtAmt(minExpectedDiff), fmtAmt(maxExpectedDiff), fmtAmt(balanceDiff))
+			return fmt.Errorf("%s balance change not in expected range %.8f - %.8f, got %.8f",
+				unbip(assetID), fmtAmt(minExpectedDiff), fmtAmt(maxExpectedDiff), fmtAmt(balanceDiff))
 		}
 		client.log("%s balance change %.8f is in expected range of %.8f - %.8f",
 			unbip(assetID), fmtAmt(balanceDiff), fmtAmt(minExpectedDiff), fmtAmt(maxExpectedDiff))


### PR DESCRIPTION
- Reported by @JoeGruffins, the simnet trade tests suite was using account field in the wallet config map, which was changed to walletname in #533; prevented the btc wallets from being set up on the test clients.
- Trace level logging for test clients.
- Mine 1 block more than the required reg fee confirms to ensure fee tx gets required confirms.
- Improve tryUntil function to delay 250ms between calls to tryFn.
- Improve code that checks for specific notification in client notification channel.