### PR TITLE
client/webserver: prefer site in cwd, improve error

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -398,6 +398,7 @@ func (conn *wsConn) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		defer conn.wg.Done()
 		<-ctxInternal.Done()
 		conn.setConnected(false)
+		conn.wsMtx.Lock()
 		if conn.ws != nil {
 			log.Debug("Sending close 1000 (normal) message.")
 			msg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye")
@@ -405,6 +406,7 @@ func (conn *wsConn) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 				time.Now().Add(writeWait))
 			conn.ws.Close()
 		}
+		conn.wsMtx.Unlock()
 		close(conn.readCh) // signal to receivers that the wsConn is dead
 	}()
 

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -105,21 +105,22 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 		return err == nil && stat.IsDir()
 	}
 
-	// Right now, it is expected that the working directory
-	// is either the dcrdex root directory, or the WebServer directory itself.
-	root := "../../webserver/site"
+	// Right now, it is expected that the working directory is either in the
+	// current working directory or the dcrdex root directory.
+	root := "site"
 	if !folderExists(root) {
-		root = "site"
+		root = "../../webserver/site"
 		if !folderExists(root) {
-			return nil, fmt.Errorf("no HTML template files found")
+			cwd, _ := os.Getwd()
+			return nil, fmt.Errorf("no HTML template files found. "+
+				"Place the 'site' folder in the program's working directory %q "+
+				"or run dexc from within the client/cmd/dexc source workspace folder.", cwd)
 		}
 	}
 
-	join := filepath.Join
-
 	// Prepare the templates.
 	bb := "bodybuilder"
-	tmpl := newTemplates(join(root, "src/html"), reloadHTML).
+	tmpl := newTemplates(filepath.Join(root, "src/html"), reloadHTML).
 		addTemplate("login", bb).
 		addTemplate("register", bb, "forms").
 		addTemplate("markets", bb, "forms").
@@ -212,10 +213,10 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 	})
 
 	// Files
-	fileServer(mux, "/js", join(root, "dist"))
-	fileServer(mux, "/css", join(root, "dist"))
-	fileServer(mux, "/img", join(root, "src/img"))
-	fileServer(mux, "/font", join(root, "src/font"))
+	fileServer(mux, "/js", filepath.Join(root, "dist"))
+	fileServer(mux, "/css", filepath.Join(root, "dist"))
+	fileServer(mux, "/img", filepath.Join(root, "src/img"))
+	fileServer(mux, "/font", filepath.Join(root, "src/font"))
 
 	return s, nil
 }

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -105,8 +105,8 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 		return err == nil && stat.IsDir()
 	}
 
-	// Right now, it is expected that the working directory is either in the
-	// current working directory or the dcrdex root directory.
+	// Look for the "site" folder in the current working directory or in the
+	// source path relative to [repo root]/client/cmd/dexc.
 	root := "site"
 	if !folderExists(root) {
 		root = "../../webserver/site"

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -236,19 +236,20 @@ func (c *TConn) Close() error {
 }
 
 func newTServer(t *testing.T, start bool) (*WebServer, *TCore, func(), error) {
+	t.Helper()
 	c := &TCore{}
 	var shutdown func()
 	ctx, killCtx := context.WithCancel(tCtx)
 	s, err := New(c, "127.0.0.1:0", tLogger, false)
 	if err != nil {
-		t.Errorf("error creating server: %v", err)
+		t.Fatalf("error creating server: %v", err)
 	}
 
 	if start {
 		cm := dex.NewConnectionMaster(s)
 		err := cm.Connect(ctx)
 		if err != nil {
-			t.Errorf("Error starting WebServer: %v", err)
+			t.Fatalf("Error starting WebServer: %v", err)
 		}
 		shutdown = func() {
 			killCtx()
@@ -261,6 +262,7 @@ func newTServer(t *testing.T, start bool) (*WebServer, *TCore, func(), error) {
 }
 
 func ensureResponse(t *testing.T, s *WebServer, f func(w http.ResponseWriter, r *http.Request), want string, reader *TReader, writer *TWriter, body interface{}) {
+	t.Helper()
 	var err error
 	reader.msg, err = json.Marshal(body)
 	if err != nil {
@@ -300,7 +302,7 @@ func TestNew_siteError(t *testing.T) {
 		t.Fatalf("cannot get current directory: %v", err)
 	}
 
-	// Change to a directory with no "site" or ""../../webserver/site" folder.
+	// Change to a directory with no "site" or "../../webserver/site" folder.
 	dir, _ := ioutil.TempDir("", "test")
 	defer os.RemoveAll(dir)
 	defer os.Chdir(cwd) // leave the temp dir before trying to delete it

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -311,10 +311,9 @@ func TestNew_siteError(t *testing.T) {
 
 	c := &TCore{}
 	_, err = New(c, "127.0.0.1:0", tLogger, false)
-	if err == nil && !strings.HasPrefix(err.Error(), "no HTML template files found") {
+	if err == nil || !strings.HasPrefix(err.Error(), "no HTML template files found") {
 		t.Errorf("Should have failed to start with no site folder.")
 	}
-	t.Log(err)
 }
 
 func TestConnectStart(t *testing.T) {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -8,8 +8,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -290,6 +292,23 @@ func TestMain(m *testing.M) {
 		return m.Run()
 	}
 	os.Exit(doIt())
+}
+
+func TestNew_siteError(t *testing.T) {
+	// Change to a directory with no "site" or ""../../webserver/site" folder.
+	dir, _ := ioutil.TempDir("", "test")
+	defer os.RemoveAll(dir)
+	err := os.Chdir(dir)
+	if err != nil {
+		t.Fatalf("Cannot cd to %q", dir)
+	}
+
+	c := &TCore{}
+	_, err = New(c, "127.0.0.1:0", tLogger, false)
+	if err == nil && !strings.HasPrefix(err.Error(), "no HTML template files found") {
+		t.Errorf("Should have failed to start with no site folder.")
+	}
+	t.Log(err)
 }
 
 func TestConnectStart(t *testing.T) {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -295,11 +295,17 @@ func TestMain(m *testing.M) {
 }
 
 func TestNew_siteError(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot get current directory: %v", err)
+	}
+
 	// Change to a directory with no "site" or ""../../webserver/site" folder.
 	dir, _ := ioutil.TempDir("", "test")
 	defer os.RemoveAll(dir)
-	err := os.Chdir(dir)
-	if err != nil {
+	defer os.Chdir(cwd) // leave the temp dir before trying to delete it
+
+	if err = os.Chdir(dir); err != nil {
 		t.Fatalf("Cannot cd to %q", dir)
 	}
 


### PR DESCRIPTION
Have client/webserver.WebServer look for the "site" directory in the executable directory, then current working directory, then the repo-relative path.  Supplement the error message when site is not found with more information about where the program looked and where the user should put it.