### PR TITLE
multi: specify lots as a parameter to RequiredOrderFunds

### DIFF
--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -140,7 +140,8 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	rig.backends["beta"], rig.connectionMasters["beta"] = tBackend(t, tCtx, newWallet, dexAsset.Symbol, "beta", "", tLogger, blkFunc, splitTx)
 	rig.backends["gamma"], rig.connectionMasters["gamma"] = tBackend(t, tCtx, newWallet, dexAsset.Symbol, "alpha", "gamma", tLogger, blkFunc, splitTx)
 	defer rig.close()
-	contractValue := 2 * dexAsset.LotSize
+	var lots uint64 = 2
+	contractValue := lots * dexAsset.LotSize
 
 	inUTXOs := func(utxo asset.Coin, utxos []asset.Coin) bool {
 		for _, u := range utxos {
@@ -167,35 +168,48 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 		t.Fatalf("error unlocking gamma wallet: %v", err)
 	}
 
+	ord := &asset.Order{
+		Value:        contractValue * 3,
+		MaxSwapCount: lots * 3,
+		DEXConfig:    dexAsset,
+	}
+	setOrderValue := func(v uint64) {
+		ord.Value = v
+		ord.MaxSwapCount = v / dexAsset.LotSize
+	}
+
 	// Gamma should only have 10 BTC utxos, so calling fund for less should only
 	// return 1 utxo.
-	utxos, err := rig.gamma().FundOrder(contractValue*3, false, dexAsset)
+
+	utxos, err := rig.gamma().FundOrder(ord)
 	if err != nil {
 		t.Fatalf("Funding error: %v", err)
 	}
 	utxo := utxos[0]
 
 	// UTXOs should be locked
-	utxos, _ = rig.gamma().FundOrder(contractValue*3, false, dexAsset)
+	utxos, _ = rig.gamma().FundOrder(ord)
 	if inUTXOs(utxo, utxos) {
 		t.Fatalf("received locked output")
 	}
 	rig.gamma().ReturnCoins([]asset.Coin{utxo})
 	rig.gamma().ReturnCoins(utxos)
 	// Make sure we get the first utxo back with Fund.
-	utxos, _ = rig.gamma().FundOrder(contractValue*3, false, dexAsset)
+	utxos, _ = rig.gamma().FundOrder(ord)
 	if !splitTx && !inUTXOs(utxo, utxos) {
 		t.Fatalf("unlocked output not returned")
 	}
 	rig.gamma().ReturnCoins(utxos)
 
 	// Get a separate set of UTXOs for each contract.
-	utxos1, err := rig.gamma().FundOrder(contractValue, false, dexAsset)
+	setOrderValue(contractValue)
+	utxos1, err := rig.gamma().FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding first contract: %v", err)
 	}
 	// Get a separate set of UTXOs for each contract.
-	utxos2, err := rig.gamma().FundOrder(contractValue*2, false, dexAsset)
+	setOrderValue(contractValue * 2)
+	utxos2, err := rig.gamma().FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding second contract: %v", err)
 	}
@@ -325,7 +339,8 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	lockTime = time.Now().Add(-24 * time.Hour)
 
 	// Have gamma send a swap contract to the alpha address.
-	utxos, _ = rig.gamma().FundOrder(contractValue, false, dexAsset)
+	setOrderValue(contractValue)
+	utxos, _ = rig.gamma().FundOrder(ord)
 	contract := &asset.Contract{
 		Address:    address,
 		Value:      contractValue,

--- a/client/webserver/site/webpack/dev.js
+++ b/client/webserver/site/webpack/dev.js
@@ -1,4 +1,4 @@
-const merge = require('webpack-merge')
+const { merge } = require('webpack-merge')
 const common = require('./common.js')
 
 module.exports = merge(common, {

--- a/dex/calc/fees.go
+++ b/dex/calc/fees.go
@@ -1,23 +1,17 @@
 package calc
 
 import (
-	"math"
-
 	"decred.org/dcrdex/dex"
 )
 
 // RequiredOrderFunds calculates the required amount needed to fulfill the swap
 // amount and pay transaction fees. swapVal is the total quantity needed to
 // fulfill an order. inputsSize is the size of the serialized inputs associated
-// with a set of UTXOs to be spent in the *first* swap txn. The chained swap
-// txns will be the standard size as they will spend a previous swap's change
-// output.
-func RequiredOrderFunds(swapVal, inputsSize uint64, coin *dex.Asset) uint64 {
-	maxSwaps := swapVal / coin.LotSize
-	if maxSwaps == 0 {
-		return math.MaxUint64 // caller messed up
-	}
-
+// with a set of UTXOs to be spent in the *first* swap txn. maxSwaps is the
+// number of lots in the order. For the quote asset, maxSwaps is not swapVal /
+// coin.LotSize, so it must be a separate parameter. The chained swap txns will
+// be the standard size as they will spend a previous swap's change output.
+func RequiredOrderFunds(swapVal, inputsSize, maxSwaps uint64, coin *dex.Asset) uint64 {
 	baseBytes := maxSwaps * coin.SwapSize
 	// SwapSize already includes one input, replace the size of the first swap
 	// in the chain with the given size of the actual inputs + SwapSizeBase.


### PR DESCRIPTION
`RequiredOrderFunds` was calculating the maximum number of possible transactions (`maxSwaps` = # lots) internally based on the order quantity and the lot size. But for the quote asset, the maximum number of possible transactions is **not** based on the quote asset lot size, it's based on the rate-equivalent quantity of base asset and it's lot size. This was causing [@chappjc's over-allocation from here](https://github.com/decred/dcrdex/pull/562#issuecomment-668785417), because the BTC lot size was set relatively low. This could also go the other way, and under-allocate, potentially causing trouble. 

Rule of thumb: Lot size is only meaningful for the base asset.

I'm leaving this in draft for a minute while I look it through and think about testing.