### PR TITLE
client/{asset,core}: make order funding thread-safe

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -336,6 +336,8 @@ func TestAvailableFund(t *testing.T) {
 		Amount:        float64(littleFunds) / 1e8,
 		Confirmations: 0,
 		ScriptPubKey:  tP2PKH,
+		Spendable:     true,
+		Solvable:      true,
 		Safe:          true,
 	}
 	unspents = append(unspents, littleUTXO)
@@ -378,6 +380,8 @@ func TestAvailableFund(t *testing.T) {
 		Confirmations: 1,
 		Vout:          1,
 		ScriptPubKey:  tP2PKH,
+		Spendable:     true,
+		Solvable:      true,
 		Safe:          true,
 	}
 	unspents = append(unspents, lottaUTXO)
@@ -623,6 +627,8 @@ func TestFundingCoins(t *testing.T) {
 		TxID:         tTxID,
 		Vout:         vout,
 		ScriptPubKey: tP2PKH,
+		Spendable:    true,
+		Solvable:     true,
 		Safe:         true,
 	}
 	unspents := []*ListUnspentResult{p2pkhUnspent}
@@ -701,6 +707,8 @@ func TestFundEdges(t *testing.T) {
 		Amount:        float64(swapVal+backingFees-1) / 1e8,
 		Confirmations: 5,
 		ScriptPubKey:  tP2PKH,
+		Spendable:     true,
+		Solvable:      true,
 		Safe:          true,
 	}
 	unspents := []*ListUnspentResult{p2pkhUnspent}
@@ -736,6 +744,8 @@ func TestFundEdges(t *testing.T) {
 		Confirmations: 10,
 		ScriptPubKey:  p2shScriptPubKey,
 		RedeemScript:  p2shRedeem,
+		Spendable:     true,
+		Solvable:      true,
 		Safe:          true,
 	}
 	p2pkhUnspent.Amount = float64(halfSwap+backingFees-1) / 1e8
@@ -765,6 +775,8 @@ func TestFundEdges(t *testing.T) {
 		Amount:        float64(swapVal+backingFees-1) / 1e8,
 		Confirmations: 3,
 		ScriptPubKey:  p2wpkhPkScript,
+		Spendable:     true,
+		Solvable:      true,
 		Safe:          true,
 	}
 	unspents = []*ListUnspentResult{p2wpkhUnspent}
@@ -797,6 +809,8 @@ func TestFundEdges(t *testing.T) {
 		Confirmations: 7,
 		ScriptPubKey:  p2wshPkScript,
 		RedeemScript:  p2wpkhRedeemScript,
+		Spendable:     true,
+		Solvable:      true,
 		Safe:          true,
 	}
 	unspents = []*ListUnspentResult{p2wpshUnspent}

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -63,6 +63,7 @@ func (wc *walletClient) Balances() (*GetBalancesResult, error) {
 // ListUnspent retrieves a list of the wallet's UTXOs.
 func (wc *walletClient) ListUnspent() ([]*ListUnspentResult, error) {
 	unspents := make([]*ListUnspentResult, 0)
+	// TODO: listunspent 0 9999999 []string{}, include_unsafe=false
 	return unspents, wc.call(methodListUnspent, anylist{uint8(0)}, &unspents)
 }
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1703,13 +1703,6 @@ var waiterID uint64
 func (c *Core) wait(assetID uint32, trigger func() (bool, error), action func(error)) {
 	c.waiterMtx.Lock()
 	defer c.waiterMtx.Unlock()
-	// TODO: While under lock, check the trigger before adding the waiter in
-	// case it is already satisfied.
-	// if ok, _ := trigger(); ok {
-	// 	log.Debugf("Got it on the first try. No waiter needed.")
-	// 	action(nil)
-	// 	return
-	// }
 	c.blockWaiters[atomic.AddUint64(&waiterID, 1)] = &blockWaiter{
 		assetID: assetID,
 		trigger: trigger,

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -3291,7 +3291,17 @@ func TestLogout(t *testing.T) {
 			MetaData: &db.MatchMetaData{
 				Status: order.NewlyMatched,
 			},
+			Match: &order.UserMatch{
+				OrderID: ord.ID(),
+				MatchID: mid,
+				Status:  order.NewlyMatched,
+				Side:    order.Maker,
+			},
 		},
+		prefix:         ord.Prefix(),
+		trade:          ord.Trade(),
+		contractExpiry: time.Now().Add(time.Hour).UTC(),
+		id:             mid,
 	}
 	// Active orders with matches error.
 	ensureErr("active orders matches")

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -587,8 +587,8 @@ func (t *trackedTrade) isActive() bool {
 
 	// Status of all matches for the order.
 	for _, match := range t.matches {
-		// log.Tracef("Checking match %v (%v) in status %v. Refund coin: %v, Script: %x", match.id,
-		// 	match.Match.Side, match.MetaData.Status, match.MetaData.Proof.RefundCoin, match.MetaData.Proof.Script)
+		log.Tracef("Checking match %v (%v) in status %v. Order: %v, Refund coin: %v, Script: %x", match.id,
+			match.Match.Side, match.MetaData.Status, t.ID(), match.MetaData.Proof.RefundCoin, match.MetaData.Proof.Script)
 		if match.MetaData.Status == order.MatchComplete {
 			continue
 		}


### PR DESCRIPTION
The client/asset order funding functions now keep a consistent view of
locked coins in both wallet and the funding coins map, preventing issues
with concurrent calls to e.g. FundOrder, FundingCoins, etc.

The btc backend now ensures funding coins are also tagged as "spendable"
in the listunspent result, ensuring the wallet has the keys to spend.

client/core: tweak logs and error messages