### PR TITLE
multi: handle unmatched cancel orders

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -246,6 +246,11 @@ func (dc *dexConnection) tryCancel(oid order.OrderID) (found bool, err error) {
 		return
 	}
 
+	if tracker.cancel != nil {
+		err = fmt.Errorf("order %s - only one cancel order can be submitted per epoch. still waiting on cancel order %s to match", oid, tracker.cancel.ID())
+		return
+	}
+
 	// Construct the order.
 	prefix := tracker.Prefix()
 	preImg := newPreimage()

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -230,7 +230,7 @@ func (t *trackedTrade) nomatch(oid order.OrderID) error {
 		// DB linked order from the trade, but not the cancel.
 		cid := t.cancel.ID()
 		log.Warnf("cancel order %s did not match for order %s.", cid, t.ID())
-		err := t.db.LinkOrder(cid, order.OrderID{})
+		err := t.db.LinkOrder(t.ID(), order.OrderID{})
 		if err != nil {
 			log.Errorf("DB error unlinking cancel order %s for trade %s: %w", cid, t.ID(), err)
 		}

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -609,7 +609,11 @@ func (db *BoltDB) LinkOrder(oid, linkedID order.OrderID) error {
 		if oBkt == nil {
 			return fmt.Errorf("LinkOrder - order %s not found", oid)
 		}
-		return oBkt.Put(linkedKey, linkedID[:])
+		linkedB := linkedID[:]
+		if linkedID.IsZero() {
+			linkedB = nil
+		}
+		return oBkt.Put(linkedKey, linkedB)
 	})
 }
 

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -302,16 +302,17 @@
               </thead>
               <tbody id="liveList">
                 <tr id="liveTemplate">
-                  <td data-col="type"></td>
-                  <td data-col="side"></td>
-                  <td data-col="age"></td>
-                  <td data-col="rate"></td>
-                  <td data-col="qty"></td>
-                  <td data-col="filled"></td>
-                  <td data-col="settled"></td>
-                  <td data-col="status"></td>
-                  <td data-col="cancel" class="text-center">
-                    <span class="ico-cross d-hide"></span>
+                  <td data-tmpl="type"></td>
+                  <td data-tmpl="side"></td>
+                  <td data-tmpl="age"></td>
+                  <td data-tmpl="rate"></td>
+                  <td data-tmpl="qty"></td>
+                  <td data-tmpl="filled"></td>
+                  <td data-tmpl="settled"></td>
+                  <td data-tmpl="status"></td>
+                  <td class="text-center">
+                    <span data-tmpl="cancelBttn" class="ico-cross d-hide"></span>
+                    <span data-tmpl="cancelStatus" class="d-hide"></span>
                   </td>
                 </tr>
               </tbody>

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -387,7 +387,7 @@
       <div class="p-3">
         Enter your password to submit a cancel order for the remaining
         <span id="cancelRemain"></span>
-        <span id="cancelUnit"></span>
+        <span id="cancelUnit"></span>.<br>
         The remaining amount may change before the cancel order is matched.
       </div>
       <hr class="dashed mt-2">

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -62,17 +62,17 @@
             <span class="fs20">{{.Info.Name}}</span>
             <span class="fs15">({{toUpper .Symbol}})</span>
           </td>
-          <td data-col="balance" data-balance-target="{{.ID}}">
+          <td data-balance-target="{{.ID}}">
             {{if .Wallet}}
               {{printf "%.8f" (fromAtoms .Wallet.Balance.Available)}}
             {{else}}
               0.00000000
             {{end}}
           </td>
-          <td data-col="status" class="status-col fs16">
+          <td class="status-col fs16">
             {{template "stateIcons" .}}
           </td>
-          <td data-col="actions">
+          <td">
             {{template "actionButtons" .}}
           </td>
         </tr>

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -72,7 +72,7 @@
           <td class="status-col fs16">
             {{template "stateIcons" .}}
           </td>
-          <td">
+          <td>
             {{template "actionButtons" .}}
           </td>
         </tr>

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -79,7 +79,8 @@ export default class MarketsPage extends BasePage {
       // Active orders
       'liveTemplate', 'liveList',
       // Cancel order form
-      'cancelForm', 'cancelRemain', 'cancelUnit', 'cancelPass', 'cancelSubmit'
+      'cancelForm', 'cancelRemain', 'cancelUnit', 'cancelPass', 'cancelSubmit',
+      'cancelStatus'
     ])
     this.market = null
     this.registrationStatus = {}
@@ -88,6 +89,7 @@ export default class MarketsPage extends BasePage {
     this.openFunc = null
     this.currentCreate = null
     this.book = null
+    this.cancelData = null
     this.metaOrders = {}
     const reporters = {
       price: p => { this.reportPrice(p) }
@@ -168,7 +170,7 @@ export default class MarketsPage extends BasePage {
     // Order verification form
     bindForm(page.verifyForm, page.vSubmit, async () => { this.submitOrder() })
     // Cancel order form
-    bind(page.cancelSubmit, 'click', this.submitCancel)
+    bind(page.cancelSubmit, 'click', async () => { this.submitCancel() })
 
     // If the user clicks outside of a form, it should close the page overlay.
     bind(page.forms, 'mousedown', e => {
@@ -249,7 +251,7 @@ export default class MarketsPage extends BasePage {
     // Start a ticker to update time-since values.
     this.secondTicker = setInterval(() => {
       for (const metaOrder of Object.values(this.metaOrders)) {
-        const td = metaOrder.row.querySelector('[data-col=age]')
+        const td = Doc.tmplElement(metaOrder.row, 'age')
         td.textContent = Doc.timeSince(metaOrder.order.stamp)
       }
     }, 1000)
@@ -568,11 +570,11 @@ export default class MarketsPage extends BasePage {
       updateUserOrderRow(row, order)
       if (order.type === LIMIT) {
         if (order.tif === standingTiF && order.status < statusExecuted) {
-          const icon = row.querySelector('[data-col=cancel] > span')
+          const icon = Doc.tmplElement(row, 'cancelBttn')
           Doc.show(icon)
-          bind(icon, 'click', e => {
+          bind(row, 'click', e => {
             e.stopPropagation()
-            this.showCancel(icon, order.id)
+            this.showCancel(row, order.id)
           })
         }
       }
@@ -716,7 +718,8 @@ export default class MarketsPage extends BasePage {
   async submitCancel () {
     // this will be the page.cancelSubmit button (evt.currentTarget)
     const page = this.page
-    const order = this.cancelData.order
+    const cancelData = this.cancelData
+    const order = cancelData.order
     const req = {
       orderID: order.id,
       pw: page.cancelPass.value
@@ -724,14 +727,15 @@ export default class MarketsPage extends BasePage {
     page.cancelPass.value = ''
     var res = await postJSON('/api/cancel', req)
     app.loaded()
-    Doc.hide(page.forms)
     if (!app.checkResponse(res)) return
-    this.cancelData.bttn.parentNode.textContent = 'cancelling'
+    cancelData.status.textContent = 'cancelling'
+    Doc.hide(cancelData.bttn, page.forms)
+    Doc.show(cancelData.status)
     order.cancelling = true
   }
 
   /* showCancel shows a form to confirm submission of a cancel order. */
-  showCancel (bttn, orderID) {
+  showCancel (row, orderID) {
     const order = this.metaOrders[orderID].order
     const page = this.page
     const remaining = order.qty - order.filled
@@ -739,11 +743,9 @@ export default class MarketsPage extends BasePage {
     const symbol = isMarketBuy(order) ? this.market.quote.symbol : this.market.base.symbol
     page.cancelUnit.textContent = symbol.toUpperCase()
     this.showForm(page.cancelForm)
-    // Provide data to the event handler via the cancelSubmit object. This
-    // allows duplicate handlers to be automatically removed.
-    page.cancelSubmit.page = page
-    page.cancelSubmit.cancelData = {
-      bttn: bttn,
+    this.cancelData = {
+      bttn: Doc.tmplElement(row, 'cancelBttn'),
+      status: Doc.tmplElement(row, 'cancelStatus'),
       order: order
     }
   }
@@ -801,20 +803,30 @@ export default class MarketsPage extends BasePage {
    */
   handleOrderNote (note) {
     const order = note.order
-    if (order.targetID && note.subject === 'cancel') {
-      this.metaOrders[order.targetID].row.querySelector('[data-col=cancel]').textContent = 'canceled'
-    } else if (order.targetID && note.subject === 'revoke') {
-      this.metaOrders[order.targetID].row.querySelector('[data-col=cancel]').textContent = 'revoked'
-    } else {
-      const metaOrder = this.metaOrders[order.id]
-      if (!metaOrder) return
-      metaOrder.order = order
-      updateUserOrderRow(metaOrder.row, order)
-      if (order.filled === order.qty) {
-        // Remove the cancellation button.
-        updateDataCol(metaOrder.row, 'cancel', '')
+    if (order.targetID) {
+      const status = Doc.tmplElement(this.metaOrders[order.targetID].row, 'cancelStatus')
+      if (note.subject === 'cancel') {
+        Doc.hide(status)
+        status.textContent = 'canceled'
+      } else if (note.subject === 'revoke') {
+        status.textContent = 'revoked'
+        Doc.show(status)
       }
+      return
     }
+    const metaOrder = this.metaOrders[order.id]
+    if (!metaOrder) return
+    metaOrder.order = order
+    const bttn = Doc.tmplElement(metaOrder.row, 'cancelBttn')
+    if (note.subject === 'Missed cancel') {
+      Doc.hide(Doc.tmplElement(metaOrder.row, 'cancelStatus'))
+      Doc.show(bttn)
+    }
+    if (order.filled === order.qty) {
+      // Remove the cancellation button.
+      Doc.hide(bttn)
+    }
+    updateUserOrderRow(metaOrder.row, order)
   }
 
   /*
@@ -830,7 +842,7 @@ export default class MarketsPage extends BasePage {
     for (const metaOrder of Object.values(this.metaOrders)) {
       const order = metaOrder.order
       const alreadyMatched = note.epoch > order.epoch
-      const statusTD = metaOrder.row.querySelector('[data-col=status]')
+      const statusTD = Doc.tmplElement(metaOrder.row, 'status')
       switch (true) {
         case order.type === LIMIT && order.status === statusEpoch && alreadyMatched:
           statusTD.textContent = order.tif === immediateTiF ? 'executed' : 'booked'
@@ -1497,11 +1509,10 @@ function statusString (order) {
 }
 
 /*
- * updateDataCol sets the value of data-col=[col] <td> element that is a child
- * of the specified <tr>.
+ * updateDataCol sets the textContent of descendent template element.
  */
 function updateDataCol (tr, col, s) {
-  tr.querySelector(`[data-col=${col}]`).textContent = s
+  Doc.tmplElement(tr, col).textContent = s
 }
 
 /*

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -572,7 +572,7 @@ export default class MarketsPage extends BasePage {
         if (order.tif === standingTiF && order.status < statusExecuted) {
           const icon = Doc.tmplElement(row, 'cancelBttn')
           Doc.show(icon)
-          bind(row, 'click', e => {
+          bind(icon, 'click', e => {
             e.stopPropagation()
             this.showCancel(row, order.id)
           })

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -32,7 +32,7 @@ cat > "./markets.json" <<EOF
         {
             "base": "DCR_simnet",
             "quote": "BTC_simnet",
-            "epochDuration": 6000,
+            "epochDuration": 15000,
             "marketBuyBuffer": 1.2
         }
     ],

--- a/server/market/integ/booker_matcher_test.go
+++ b/server/market/integ/booker_matcher_test.go
@@ -1266,8 +1266,8 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 		newCancel(bookSellOrders[nSell-1].ID(), cancelTime), // 15
 	}
 	// cancel some the epoch queue orders too
-	epochQueue = append(epochQueue, newCancel(epochQueue[7].Order.ID(), cancelTime)) // 16
-	epochQueue = append(epochQueue, newCancel(epochQueue[5].Order.ID(), cancelTime)) // 17
+	epochQueue = append(epochQueue, newCancel(epochQueue[7].Order.ID(), cancelTime)) // 16 cancels 7 (miss)
+	epochQueue = append(epochQueue, newCancel(epochQueue[5].Order.ID(), cancelTime)) // 17 cancels 5 (miss)
 
 	epochQueueInit := make([]*matcher.OrderRevealed, len(epochQueue))
 	copy(epochQueueInit, epochQueue)
@@ -1299,7 +1299,7 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 	expectedPartial := []int{}
 	expectedBooked := []int{5, 7, 1} // all StandingTiF
 	expectedNumUnbooked := 8
-	expectedNumNomatched := 4
+	expectedNumNomatched := 6
 
 	// order book from bookBuyOrders and bookSellOrders
 	b := newBook(t)

--- a/server/matcher/match.go
+++ b/server/matcher/match.go
@@ -188,6 +188,7 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 					o.ID(), o.TargetOrderID)
 				failed = append(failed, q)
 				updates.CancelsFailed = append(updates.CancelsFailed, o)
+				nomatched = append(nomatched, q)
 				continue
 			}
 

--- a/server/matcher/match_test.go
+++ b/server/matcher/match_test.go
@@ -560,6 +560,7 @@ func TestMatch_cancelOnly(t *testing.T) {
 		wantNumUnbooked        int
 		wantNumCancelsExecuted int
 		wantNumTradesCanceled  int
+		wantNumNomatched       int
 	}{
 		{
 			name: "cancel standing ok",
@@ -612,6 +613,7 @@ func TestMatch_cancelOnly(t *testing.T) {
 			wantNumUnbooked:        0,
 			wantNumCancelsExecuted: 0,
 			wantNumTradesCanceled:  0,
+			wantNumNomatched:       1,
 		},
 	}
 	for _, tt := range tests {
@@ -621,7 +623,7 @@ func TestMatch_cancelOnly(t *testing.T) {
 
 			numBuys0 := tt.args.book.BuyCount()
 
-			seed, matches, passed, failed, doneOK, partial, booked, _, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
+			seed, matches, passed, failed, doneOK, partial, booked, nomatched, unbooked, updates := me.Match(tt.args.book, tt.args.queue)
 			matchMade := len(matches) > 0 && matches[0] != nil
 			if tt.doesMatch != matchMade {
 				t.Errorf("Match expected = %v, got = %v", tt.doesMatch, matchMade)
@@ -654,6 +656,9 @@ func TestMatch_cancelOnly(t *testing.T) {
 			}
 			if len(unbooked) != tt.wantNumUnbooked {
 				t.Errorf("number unbooked %d, expected %d", len(unbooked), tt.wantNumUnbooked)
+			}
+			if len(nomatched) != tt.wantNumNomatched {
+				t.Errorf("number nomatched %d, expected %d", len(nomatched), tt.wantNumNomatched)
 			}
 
 			if len(updates.CancelsExecuted) != tt.wantNumCancelsExecuted {


### PR DESCRIPTION
- **server/matcher**: Add missed cancel orders to `nomatches`.
- **client/core**: Delete missed cancel from (*trackedTrade).cancel. Update DB status for cancel order.
- **app**: Re-show cancel button when a cancel misses. Other minor code improvements.