### PR TITLE
server/swap: refactor swap state loading

### DIFF
--- a/dex/encode/encode.go
+++ b/dex/encode/encode.go
@@ -6,8 +6,11 @@ package encode
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"io"
+	"os"
 	"time"
 )
 
@@ -176,4 +179,18 @@ func (b BuildyBytes) AddData(d []byte) BuildyBytes {
 		lBytes = []byte{byte(l)}
 	}
 	return append(b, append(lBytes, d...)...)
+}
+
+// FileHash generates the SHA256 hash of the specified file.
+func FileHash(name string) ([]byte, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, fmt.Errorf("error opening file %s for hashing: %w", name, err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, fmt.Errorf("error copying file %s for hashing: %w", name, err)
+	}
+	return h.Sum(nil), nil
 }

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -80,6 +80,8 @@ type dexConf struct {
 	AdminSrvOn       bool
 	AdminSrvAddr     string
 	AdminSrvPW       []byte
+	IgnoreState      bool
+	StatePath        string
 }
 
 type flagsData struct {
@@ -121,6 +123,9 @@ type flagsData struct {
 	AdminSrvOn         bool   `long:"adminsrvon" description:"Turn on the admin server"`
 	AdminSrvAddr       string `long:"adminsrvaddr" description:"Administration HTTPS server address (default: 127.0.0.1:6542)"`
 	AdminSrvPassword   string `long:"adminsrvpass" description:"Admin server password. INSECURE. Do not set unless absolutely necessary."`
+
+	IgnorePrevState bool   `long:"ignoreprevstate" description:"Do not attempt to load the stored swap state."`
+	PrevStatePath   string `long:"prevstatepath" description:"Load the swap state from provided file path. --prevstatepath supercedes --ignoreprevstate"`
 }
 
 // cleanAndExpandPath expands environment variables and leading ~ in the passed
@@ -542,6 +547,8 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		AdminSrvAddr:     adminSrvAddr,
 		AdminSrvOn:       cfg.AdminSrvOn,
 		AdminSrvPW:       []byte(cfg.AdminSrvPassword),
+		IgnoreState:      cfg.IgnorePrevState,
+		StatePath:        cfg.PrevStatePath,
 	}
 
 	opts := &procOpts{

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -4,10 +4,8 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
@@ -24,7 +22,6 @@ import (
 	_ "decred.org/dcrdex/server/asset/dcr" // register dcr asset
 	_ "decred.org/dcrdex/server/asset/ltc" // register ltc asset
 	dexsrv "decred.org/dcrdex/server/dex"
-	"decred.org/dcrdex/server/swap"
 	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 )
 
@@ -107,61 +104,8 @@ func mainCore(ctx context.Context) error {
 		return err
 	}
 
-	// TODO: add dcrdex flags and config options: 1) specify state file, 2) do
-	// not load state, 3) load latest state without prompt.
-	log.Infof("Searching for swap state files in %q", cfg.DataDir)
-	stateFile, err := swap.LatestStateFile(cfg.DataDir)
-	if err != nil {
-		return fmt.Errorf("unable to read datadir: %v", err)
-	}
-	var state *swap.State
-	if stateFile != nil {
-		fmt.Printf("Load swapper state from file %q with time stamp %v? (y, n, or enter to abort) ",
-			stateFile.Name, encode.UnixTimeMilli(stateFile.Stamp))
-		scanner := bufio.NewScanner(os.Stdin)
-		scan := make(chan bool)
-		go func() {
-			scan <- scanner.Scan()
-		}()
-		// Wait for scanned line ending with newline or context done.
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-scan:
-		}
-		promptResp := scanner.Text()
-		err = scanner.Err()
-		if err != nil {
-			return fmt.Errorf("input failed: %v", err)
-		}
-
-		var doLoad bool
-		switch strings.ToLower(promptResp) {
-		case "y", "yes":
-			doLoad = true
-		case "n", "no":
-		case "":
-			return errors.New("input aborted")
-		default:
-			return fmt.Errorf("invalid response: %q", promptResp)
-		}
-
-		if doLoad {
-			state, err = swap.LoadStateFile(stateFile.Name)
-			if err != nil {
-				return fmt.Errorf("failed to load swap state file %v: %v", stateFile.Name, err)
-			}
-			log.Infof("Loaded swap state file %q, containing %d live matches with "+
-				"%d pending client acks and %d live coin waiters", stateFile.Name,
-				len(state.MatchTrackers), len(state.LiveAckers), len(state.LiveWaiters))
-		}
-	} else {
-		log.Info("No swap state files found.")
-	}
-
 	// Create the DEX manager.
 	dexConf := &dexsrv.DexConf{
-		SwapState:  state,
 		DataDir:    cfg.DataDir,
 		LogBackend: cfg.LogMaker,
 		Markets:    markets,
@@ -188,6 +132,8 @@ func mainCore(ctx context.Context) error {
 			ListenAddrs: cfg.RPCListen,
 			AltDNSNames: cfg.AltDNSNames,
 		},
+		IgnoreState: cfg.IgnoreState,
+		StatePath:   cfg.StatePath,
 	}
 	dexMan, err := dexsrv.NewDEX(dexConf)
 	if err != nil {

--- a/server/db/driver/pg/internal/meta.go
+++ b/server/db/driver/pg/internal/meta.go
@@ -1,0 +1,17 @@
+package internal
+
+const (
+	// CreateMetaTable creates a table to hold DEX metadata.
+	CreateMetaTable = `CREATE TABLE IF NOT EXISTS %s (
+		state_hash BYTEA -- hash of the swapper state file
+	);`
+
+	// CreateMetaRow creates the single row of the meta table.
+	CreateMetaRow = "INSERT INTO meta DEFAULT VALUES;"
+
+	// RetrieveStateHash retrieves the last stored swap state file hash.
+	RetrieveStateHash = "SELECT state_hash FROM meta;"
+
+	// SetStateHash sets the hash of the swap state file.
+	SetStateHash = "UPDATE meta SET state_hash = $1;"
+)

--- a/server/db/driver/pg/meta.go
+++ b/server/db/driver/pg/meta.go
@@ -1,0 +1,24 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package pg
+
+import (
+	"decred.org/dcrdex/server/db/driver/pg/internal"
+	_ "github.com/lib/pq" // Start the PostgreSQL sql driver
+)
+
+// GetStateHash retrieves that last stored swap state file hash.
+func (a *Archiver) GetStateHash() ([]byte, error) {
+	var h []byte
+	if err := a.db.QueryRow(internal.RetrieveStateHash).Scan(&h); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// SetStateHash stores the swap state file hash.
+func (a *Archiver) SetStateHash(h []byte) error {
+	_, err := a.db.Exec(internal.SetStateHash, h)
+	return err
+}

--- a/server/db/driver/pg/meta.go
+++ b/server/db/driver/pg/meta.go
@@ -5,7 +5,6 @@ package pg
 
 import (
 	"decred.org/dcrdex/server/db/driver/pg/internal"
-	_ "github.com/lib/pq" // Start the PostgreSQL sql driver
 )
 
 // GetStateHash retrieves that last stored swap state file hash.

--- a/server/db/driver/pg/meta_online_test.go
+++ b/server/db/driver/pg/meta_online_test.go
@@ -1,0 +1,30 @@
+// +build pgonline
+
+package pg
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"testing"
+)
+
+func TestStateHash(t *testing.T) {
+	if err := cleanTables(archie.db); err != nil {
+		t.Fatalf("cleanTables: %v", err)
+	}
+
+	tHash := randomBytes(sha256.Size)
+	err := archie.SetStateHash(tHash)
+	if err != nil {
+		t.Fatalf("error setting state hash: %v", err)
+	}
+
+	checkHash, err := archie.GetStateHash()
+	if err != nil {
+		t.Fatalf("error retrieving state hash: %v", err)
+	}
+
+	if !bytes.Equal(checkHash, tHash) {
+		t.Fatalf("wrong state hash returned: %x != %x", checkHash, tHash)
+	}
+}

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -70,6 +70,12 @@ type DEXArchivist interface {
 	// InsertEpoch stores the results of a newly-processed epoch.
 	InsertEpoch(ed *EpochResults) error
 
+	// GetStateHash retrieves that last stored swap state file hash.
+	GetStateHash() ([]byte, error)
+
+	// SetStateHash stores the swap state file hash.
+	SetStateHash([]byte) error
+
 	OrderArchiver
 	AccountArchiver
 	MatchArchiver

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -88,7 +88,6 @@ func (lm *LoggerMaker) NewLogger(name string, level ...slog.Level) dex.Logger {
 
 // DexConf is the configuration data required to create a new DEX.
 type DexConf struct {
-	SwapState        *swap.State
 	DataDir          string
 	LogBackend       *dex.LoggerMaker
 	Markets          []*dex.MarketInfo
@@ -103,6 +102,8 @@ type DexConf struct {
 	Anarchy          bool
 	DEXPrivKey       *secp256k1.PrivateKey
 	CommsCfg         *RPCConfig
+	IgnoreState      bool
+	StatePath        string
 }
 
 type subsystem struct {
@@ -418,7 +419,6 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 
 	// Create the swapper.
 	swapperCfg := &swap.Config{
-		State:            cfg.SwapState,
 		DataDir:          cfg.DataDir,
 		Assets:           lockableAssets,
 		Storage:          storage,
@@ -427,6 +427,8 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		LockTimeTaker:    dex.LockTimeTaker(cfg.Network),
 		LockTimeMaker:    dex.LockTimeMaker(cfg.Network),
 		UnbookHook:       marketUnbookHook,
+		IgnoreState:      cfg.IgnoreState,
+		StatePath:        cfg.StatePath,
 	}
 
 	swapper, err := swap.NewSwapper(swapperCfg)

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -184,6 +184,8 @@ func (ta *TArchivist) PayAccount(account.AccountID, []byte) error         { retu
 func (ta *TArchivist) Accounts() ([]*db.Account, error)                   { return nil, nil }
 func (ta *TArchivist) AccountInfo(account.AccountID) (*db.Account, error) { return nil, nil }
 func (ta *TArchivist) Close() error                                       { return nil }
+func (ta *TArchivist) GetStateHash() ([]byte, error)                      { return nil, nil }
+func (ta *TArchivist) SetStateHash([]byte) error                          { return nil }
 
 func randomOrderID() order.OrderID {
 	pk := randomBytes(order.OrderIDSize)

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -430,7 +430,7 @@ func NewSwapper(cfg *Config) (*Swapper, error) {
 				if err != nil {
 					return nil, fmt.Errorf("failed to load swap state file %v: %v", stateFile.Name, err)
 				}
-				log.Infof("most recent swap state file is %q", stateFile.Name)
+				log.Infof("loaded the most recent swap state file from %q", stateFile.Name)
 			}
 
 		} else {


### PR DESCRIPTION
- Default behavior is auto-load based on most recent file in `DataDir`. 
- New flags to ignore previous state or to load from a specific file path.
- Implements a hash consistency check. Creates a single-row metadata table in the server database to store the swap state file hash. The `meta` table is also needed for #522.