### PR TITLE
drop go 1.13, test go 1.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.13, 1.14]
+        go: [1.14, 1.15]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -16,7 +16,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0"
 
       - name: Test
         env:

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Please ensure you are building from a current snapshot of the master branch.
 1. [Go >= 1.14](https://golang.org/doc/install)
 2. [Node 12+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) is used to bundle resources for the browser interface.
 3. [dcrd](https://github.com/decred/dcrd/tree/master) and [dcrwallet](https://github.com/decred/dcrwallet/tree/master) (non-SPV) built from the `master` branch.
-4. [Bitcoin Core v0.20.x](https://bitcoincore.org/en/download/) (bitcoind or bitcoin-qt) wallet.
+4. [Bitcoin Core v0.20.x](https://bitcoincore.org/en/download/) (bitcoind or bitcoin-qt) wallet, **encrypted**.
 
 See the [wiki](../../wiki/Testnet-Testing) for details on preparing the wallets.
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ from **server/cmd/dcrdex**.
 
 ## Client Installation
 
-The client is still immature and changing rapidly, but it is fully functional.
+The client is still immature and changing rapidly, but it is mostly functional.
+There are a few incomplete items, so **do not use it on Mainnet yet**.
 Please ensure you are building from a current snapshot of the master branch.
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ poke around and offer feedback, there are a number of ways to do that.
 ### Dependencies
 
 1. Linux or MacOS
-2. [Go >= 1.13](https://golang.org/doc/install)
+2. [Go >= 1.14](https://golang.org/doc/install)
 3. [PostgreSQL 11+](https://www.postgresql.org/download/), [tuned](https://pgtune.leopard.in.ua/) and running.
+4. Decred (dcrd) and Bitcoin (bitcoind) full nodes, both with `txindex` enabled.
 
 ### Set up the database
 
@@ -155,18 +156,22 @@ from **server/cmd/dcrdex**.
 
 ## Client Installation
 
-The client is in early development, and is not fully functional. Instructions
-are listed for development purposes.
+The client is still immature and changing rapidly, but it is fully functional.
+Please ensure you are building from a current snapshot of the master branch.
 
 ### Dependencies
 
-1. [Go >= 1.13](https://golang.org/doc/install)
+1. [Go >= 1.14](https://golang.org/doc/install)
 2. [Node 12+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) is used to bundle resources for the browser interface.
+3. [dcrd](https://github.com/decred/dcrd/tree/master) and [dcrwallet](https://github.com/decred/dcrwallet/tree/master) (non-SPV) built from the `master` branch.
+4. [Bitcoin Core v0.20.x](https://bitcoincore.org/en/download/) (bitcoind or bitcoin-qt) wallet.
+
+See the [wiki](../../wiki/Testnet-Testing) for details on preparing the wallets.
 
 **Build the web assets** from *client/webserver/site/*.
 
 ```
-npm install
+npm clean-install
 npm run build
 ```
 
@@ -178,6 +183,11 @@ go build
 ```
 
 Connect to the client from your browser at `localhost:5758`.
+
+While `dexc` may be run from within the git workspace as described above, the
+`dexc` binary executable generated with `go build` and the entire `site` folder
+may be copied into a different folder as long as `site` is in the same directory
+as `dexc` (e.g. `/opt/dcrdex/dexc` and `/opt/dcrdex/site`).
 
 ## Contribute
 

--- a/client/cmd/dexc/go.mod
+++ b/client/cmd/dexc/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrdex/client/cmd/dexc
 
-go 1.13
+go 1.14
 
 replace decred.org/dcrdex => ../../../
 

--- a/client/cmd/dexcctl/go.mod
+++ b/client/cmd/dexcctl/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrdex/client/cmd/dexcctl
 
-go 1.13
+go 1.14
 
 replace decred.org/dcrdex => ../../../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrdex
 
-go 1.13
+go 1.14
 
 require (
 	github.com/btcsuite/btcd v0.20.1-beta.0.20200615134404-e4f59022a387

--- a/server/cmd/dcrdex/go.mod
+++ b/server/cmd/dcrdex/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrdex/server/cmd/dcrdex
 
-go 1.13
+go 1.14
 
 replace decred.org/dcrdex => ../../..
 

--- a/server/cmd/dexcoin/go.mod
+++ b/server/cmd/dexcoin/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrdex/server/cmd/dexcoin
 
-go 1.13
+go 1.14
 
 replace decred.org/dcrdex => ../../..
 


### PR DESCRIPTION
This changes the Go requirement from 1.13/1.14 to 1.14/1.15.

Also some tweaks to the wording in README.md to reflect the client status better.