### PR TITLE
dex/networks: validate secret size in contract

### DIFF
--- a/dex/networks/btc/script_test.go
+++ b/dex/networks/btc/script_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -324,9 +325,21 @@ func TestExtractSwapDetails(t *testing.T) {
 		t.Fatalf("wrong secret hash. wanted %x, got %x", keyHash, secretHash)
 	}
 
+	// incorrect length
 	_, _, _, _, err = ExtractSwapDetails(contract[:len(contract)-1], tParams)
 	if err == nil {
 		t.Fatalf("no error for vandalized contract")
+	} else if !strings.HasPrefix(err.Error(), "incorrect swap contract length") {
+		t.Errorf("incorrect error for incorrect swap contract length: %v", err)
+	}
+
+	// bad secret size
+	contract[3] = 250
+	_, _, _, _, err = ExtractSwapDetails(contract, tParams)
+	if err == nil {
+		t.Fatalf("no error for contract with invalid secret size")
+	} else if !strings.HasPrefix(err.Error(), "invalid secret size") {
+		t.Errorf("incorrect error for invalid secret size: %v", err)
 	}
 }
 

--- a/dex/networks/dcr/script_test.go
+++ b/dex/networks/dcr/script_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -369,9 +370,21 @@ func TestExtractSwapDetails(t *testing.T) {
 		t.Fatalf("wrong secret hash. wanted %x, got %x", keyHash, secretHash)
 	}
 
+	// incorrect length
 	_, _, _, _, err = ExtractSwapDetails(contract[:len(contract)-1], tParams)
 	if err == nil {
 		t.Fatalf("no error for vandalized contract")
+	} else if !strings.HasPrefix(err.Error(), "incorrect swap contract length") {
+		t.Errorf("incorrect error for incorrect swap contract length: %v", err)
+	}
+
+	// bad secret size
+	contract[3] = 250
+	_, _, _, _, err = ExtractSwapDetails(contract, tParams)
+	if err == nil {
+		t.Fatalf("no error for contract with invalid secret size")
+	} else if !strings.HasPrefix(err.Error(), "invalid secret size") {
+		t.Errorf("incorrect error for invalid secret size: %v", err)
 	}
 }
 


### PR DESCRIPTION
We were neglecting to validate the secret size data push in the swap
contracts, which is important to prevent an attack whereby a swap is
initiated between coin with a longer maximum data push than
a different coin.  We were using the right contract format that included
the secret size for counter-party auditing, but we were not checking it.
Also, the contract was being built with the secret hash size instead of
the secret size itself, but it was the same so we didn't notice. 

`ExtractSwapDetails` now verifies that the secret size is as expected.
It also ensures the secret size is encoded with an `OP_DATA_1`.

`MakeContract` now uses `SecretKeySize` instead of `SecretHashSize`, but they
were the same value previously.
Note that the caller of `MakeContract` should ensure their secret hash was
derived from a secret of length `SecretKeySize`.

TODO:  Figure out a way to deal with possible future changes to `SecretKeySize`.