### PR TITLE
client/asset/ltc: make Litecoin work again

### DIFF
--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -33,6 +33,7 @@ const (
 	methodGetTransaction    = "gettransaction"
 	methodSendToAddress     = "sendtoaddress"
 	methodSetTxFee          = "settxfee"
+	methodGetWalletInfo     = "getwalletinfo"
 )
 
 // walletClient is a bitcoind wallet RPC client that uses rpcclient.Client's
@@ -210,6 +211,12 @@ func (wc *walletClient) SendToAddress(address string, value, feeRate uint64, sub
 		return nil, err
 	}
 	return chainhash.NewHashFromStr(txid)
+}
+
+// GetWalletInfo gets the getwalletinfo RPC result.
+func (wc *walletClient) GetWalletInfo() (*GetWalletInfoResult, error) {
+	wi := new(GetWalletInfoResult)
+	return wi, wc.call(methodGetWalletInfo, nil, wi)
 }
 
 // call is used internally to  marshal parmeters and send requests to  the RPC

--- a/client/asset/btc/wallettypes.go
+++ b/client/asset/btc/wallettypes.go
@@ -114,8 +114,10 @@ type GetWalletInfoResult struct {
 	PriveyKeysEnabled bool   `json:"private_keys_enabled"`
 	// AvoidReuse and Scanning were added in Bitcoin Core 0.19
 	AvoidReuse bool `json:"avoid_reuse"`
-	Scanning   struct {
-		Duration uint32  `json:"duration"`
-		Progress float32 `json:"progress"`
-	} `json:"scanning"`
+	// Scanning is either a struct or boolean false, and since we're not using
+	// it, commenting avoids having to deal with marshaling for now.
+	// Scanning   struct {
+	// 	Duration uint32  `json:"duration"`
+	// 	Progress float32 `json:"progress"`
+	// } `json:"scanning"`
 }

--- a/client/asset/btc/wallettypes.go
+++ b/client/asset/btc/wallettypes.go
@@ -99,16 +99,23 @@ type RPCOutpoint struct {
 // GetWalletInfoResult models the data from the getwalletinfo command.
 type GetWalletInfoResult struct {
 	WalletName            string  `json:"walletname"`
-	WalletVersion         int     `json:"walletversion"`
+	WalletVersion         uint32  `json:"walletversion"`
 	Balance               float64 `json:"balance"`
 	UnconfirmedBalance    float64 `json:"unconfirmed_balance"`
 	ImmatureBalance       float64 `json:"immature_balance"`
-	TxCount               int     `json:"txcount"`
+	TxCount               uint32  `json:"txcount"`
 	KeyPoolOldest         uint64  `json:"keypoololdest"`
-	KeyPoolSize           int     `json:"keypoolsize"`
-	KeyPoolSizeHDInternal int     `json:"keypoolsize_hd_internal"`
+	KeyPoolSize           uint32  `json:"keypoolsize"`
+	KeyPoolSizeHDInternal uint32  `json:"keypoolsize_hd_internal"`
 	PayTxFee              float64 `json:"paytxfee"`
 	HdSeedID              string  `json:"hdseedid"`
-	HdMasterKeyID         string  `json:"hdmasterkeyid"`
-	PriveyKeysEnabled     bool    `json:"private_keys_enabled"`
+	// HDMasterKeyID is dropped in Bitcoin Core 0.18
+	HdMasterKeyID     string `json:"hdmasterkeyid"`
+	PriveyKeysEnabled bool   `json:"private_keys_enabled"`
+	// AvoidReuse and Scanning were added in Bitcoin Core 0.19
+	AvoidReuse bool `json:"avoid_reuse"`
+	Scanning   struct {
+		Duration uint32  `json:"duration"`
+		Progress float32 `json:"progress"`
+	} `json:"scanning"`
 }

--- a/client/asset/btc/wallettypes.go
+++ b/client/asset/btc/wallettypes.go
@@ -95,3 +95,20 @@ type RPCOutpoint struct {
 	TxID string `json:"txid"`
 	Vout uint32 `json:"vout"`
 }
+
+// GetWalletInfoResult models the data from the getwalletinfo command.
+type GetWalletInfoResult struct {
+	WalletName            string  `json:"walletname"`
+	WalletVersion         int     `json:"walletversion"`
+	Balance               float64 `json:"balance"`
+	UnconfirmedBalance    float64 `json:"unconfirmed_balance"`
+	ImmatureBalance       float64 `json:"immature_balance"`
+	TxCount               int     `json:"txcount"`
+	KeyPoolOldest         uint64  `json:"keypoololdest"`
+	KeyPoolSize           int     `json:"keypoolsize"`
+	KeyPoolSizeHDInternal int     `json:"keypoolsize_hd_internal"`
+	PayTxFee              float64 `json:"paytxfee"`
+	HdSeedID              string  `json:"hdseedid"`
+	HdMasterKeyID         string  `json:"hdmasterkeyid"`
+	PriveyKeysEnabled     bool    `json:"private_keys_enabled"`
+}

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -134,6 +134,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		ChainParams:        params,
 		Ports:              ports,
 		DefaultFallbackFee: defaultFee,
+		LegacyBalance:      true,
 	}
 
 	return btc.BTCCloneWallet(cloneCFG)

--- a/client/cmd/dexcctl/simnet-setup.sh
+++ b/client/cmd/dexcctl/simnet-setup.sh
@@ -9,6 +9,8 @@ echo configuring Decred wallet
 ./dexcctl -p abc -p abc newwallet 42 ~/dextest/dcr/alpha/w-alpha.conf '{"account":"default"}'
 echo configuring Bitcoin wallet
 ./dexcctl -p abc -p abc newwallet 0 ~/dextest/btc/harness-ctl/alpha.conf '{"walletname":"gamma"}'
+echo configuring Litecoin wallet
+./dexcctl -p abc -p abc newwallet 2 ~/dextest/ltc/harness-ctl/alpha.conf '{"walletname":"gamma"}'
 echo registering with DEX
 ./dexcctl -p abc register 127.0.0.1:17273 100000000 ~/dextest/dcrdex/rpc.cert
 echo mining fee confirmation blocks

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -567,7 +567,7 @@ func (t *trackedTrade) isSwappable(match *matchTracker) bool {
 				match.id, t.UID(), coin)
 			return false
 		}
-		assetCfg := t.wallets.fromAsset
+		assetCfg := t.wallets.toAsset
 		ok := confs >= assetCfg.SwapConf
 		if !ok {
 			log.Debugf("Match %v not yet swappable: current confs = %d, required confs = %d",

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -34,6 +34,12 @@ cat > "./markets.json" <<EOF
             "quote": "BTC_simnet",
             "epochDuration": 15000,
             "marketBuyBuffer": 1.2
+        },
+        {
+            "base": "DCR_simnet",
+            "quote": "LTC_simnet",
+            "epochDuration": 15000,
+            "marketBuyBuffer": 1.2
         }
     ],
     "assets": {
@@ -54,6 +60,15 @@ cat > "./markets.json" <<EOF
             "maxFeeRate": 100,
             "swapConf": 1,
             "configPath": "${TEST_ROOT}/btc/harness-ctl/alpha.conf"
+        },
+        "LTC_simnet": {
+            "bip44symbol": "ltc",
+            "network": "simnet",
+            "lotSize": 1000000,
+            "rateStep": 1000000,
+            "maxFeeRate": 20,
+            "swapConf": 2,
+            "configPath": "${TEST_ROOT}/ltc/harness-ctl/alpha.conf"
         }
     }
 }


### PR DESCRIPTION
Introduces a new **btc.ExchangeWallet** method, `legacyBalance` that uses the `getwalletinfo` RPC to get mature and immature balance. The use of `legacyBalance` is triggered by setting a new boolean field, `LegacyBalance` in the `BTCCloneCFG`.

A couple of bug fixes too.