### PR TITLE
spec: clarify audit and next step sequence

### DIFF
--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1475,9 +1475,10 @@ type messageAcker struct {
 	isAudit bool
 }
 
-// processAck processes a match msgjson.Acknowledgement, validating the
-// signature and updating the (order.Match).Sigs record. This is required by
-// processInit, processRedeem, and revoke.
+// processAck processes a msgjson.Acknowledgement to the audit, redeem, and
+// revoke_match requests, validating the signature and updating the
+// (order.Match).Sigs record. This is required by processInit, processRedeem,
+// and revoke. Match Acknowledgements are handled by processMatchAck.
 func (s *Swapper) processAck(msg *msgjson.Message, acker *messageAcker) {
 	// Remove the live acker from Swapper's tracking.
 	defer s.rmLiveAckers(msg.ID)

--- a/spec/orders.mediawiki
+++ b/spec/orders.mediawiki
@@ -701,7 +701,7 @@ When the taker receives the <code>audit</code> notification, they will audit the
 maker's contract and after that contract asset's configured swap confirmation
 requirement is reached, broadcast their own initialization.
 When the maker receives the <code>audit</code> notification, they will audit the
-taker's contract and after the required confirmations, issue their own redemption.
+taker's contract and after the required confirmations, issue their redemption.
 
 '''Request route:''' <code>audit</code>, '''originator:''' DEX
 

--- a/spec/orders.mediawiki
+++ b/spec/orders.mediawiki
@@ -698,9 +698,10 @@ The DEX will respond with an acknowledgement.
 The DEX will send each client a notification when the counterparty has broadcast
 their initialization transaction.
 When the taker receives the <code>audit</code> notification, they will audit the
-contract and broadcast their own initialization.
+maker's contract and after that contract asset's configured swap confirmation
+requirement is reached, broadcast their own initialization.
 When the maker receives the <code>audit</code> notification, they will audit the
-contract and issue their redemption.
+taker's contract and after the required confirmations, issue their own redemption.
 
 '''Request route:''' <code>audit</code>, '''originator:''' DEX
 


### PR DESCRIPTION
The orders section of the spec seems to suggest that upon receiving an audit request, a client will respond with an ack (assuming the audit passes) **and** broadcast their txns right away.  However the next txn step requires the configured number of confirmations for whatever asset the audited contract is on.