### PR TITLE
multi: 8 hr taker / 20 hr maker lock times

### DIFF
--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -218,7 +218,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	keyHash1 := sha256.Sum256(secretKey1)
 	secretKey2 := randBytes(32)
 	keyHash2 := sha256.Sum256(secretKey2)
-	lockTime := time.Now().Add(time.Hour * 24).UTC()
+	lockTime := time.Now().Add(time.Hour * 8).UTC()
 	// Have gamma send a swap contract to the alpha address.
 	contract1 := &asset.Contract{
 		Address:    address,
@@ -336,7 +336,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	// Now send another one with lockTime = now and try to refund it.
 	secretKey := randBytes(32)
 	keyHash := sha256.Sum256(secretKey)
-	lockTime = time.Now().Add(-24 * time.Hour)
+	lockTime = time.Now().Add(-8 * time.Hour)
 
 	// Have gamma send a swap contract to the alpha address.
 	setOrderValue(contractValue)

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -238,7 +238,7 @@ func runTest(t *testing.T, splitTx bool) {
 	keyHash1 := sha256.Sum256(secretKey1)
 	secretKey2 := randBytes(32)
 	keyHash2 := sha256.Sum256(secretKey2)
-	lockTime := time.Now().Add(time.Hour * 24).UTC()
+	lockTime := time.Now().Add(time.Hour * 8).UTC()
 	// Have beta send a swap contract to the alpha address.
 	contract1 := &asset.Contract{
 		Address:    alphaAddress,
@@ -364,7 +364,7 @@ func runTest(t *testing.T, splitTx bool) {
 	// Now send another one with lockTime = now and try to refund it.
 	secretKey := randBytes(32)
 	keyHash := sha256.Sum256(secretKey)
-	lockTime = time.Now().Add(-24 * time.Hour)
+	lockTime = time.Now().Add(-8 * time.Hour)
 
 	// Have beta send a swap contract to the alpha address.
 	setOrderValue(contractValue)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2384,12 +2384,12 @@ func TestTradeTracking(t *testing.T) {
 	}
 	auditInfo.recipient = addr
 
-	auditInfo.expiration = matchTime.Add(time.Hour * 23)
+	auditInfo.expiration = matchTime.Add(tracker.lockTimeTaker - time.Hour)
 	err = handleAuditRoute(tCore, rig.dc, msg)
 	if err == nil {
 		t.Fatalf("no maker error for early lock time")
 	}
-	auditInfo.expiration = matchTime.Add(time.Hour * 24)
+	auditInfo.expiration = matchTime.Add(tracker.lockTimeTaker)
 
 	err = handleAuditRoute(tCore, rig.dc, msg)
 	if err != nil {
@@ -2494,12 +2494,12 @@ func TestTradeTracking(t *testing.T) {
 		t.Fatalf("taker's match message error: %v", err)
 	}
 
-	auditInfo.expiration = matchTime.Add(time.Hour * 47)
+	auditInfo.expiration = matchTime.Add(tracker.lockTimeMaker - time.Hour)
 	err = handleAuditRoute(tCore, rig.dc, msg)
 	if err == nil {
 		t.Fatalf("no taker error for early lock time")
 	}
-	auditInfo.expiration = matchTime.Add(time.Hour * 48)
+	auditInfo.expiration = matchTime.Add(tracker.lockTimeMaker)
 
 	checkStatus("taker counter-party swapped", order.MakerSwapCast)
 	if len(proof.SecretHash) == 0 {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1433,7 +1433,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 	auth.AuditSig = audit.Sig
 	proof.CounterScript = audit.Contract
 	matchTime := encode.UnixTimeMilli(int64(auth.MatchStamp))
-	reqLockTime := encode.DropMilliseconds(matchTime.Add(t.lockTimeMaker)) // counterparty = maker, their locktime = 48 hours.
+	reqLockTime := encode.DropMilliseconds(matchTime.Add(t.lockTimeMaker)) // counterparty = maker
 	if dbMatch.Side == order.Maker {
 		// Check that the secret hash is correct.
 		if !bytes.Equal(proof.SecretHash, auditInfo.SecretHash()) {
@@ -1442,7 +1442,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 		}
 		match.SetStatus(order.TakerSwapCast)
 		proof.TakerSwap = []byte(audit.CoinID)
-		// counterparty = taker, their locktime = 24 hours.
+		// counterparty = taker
 		reqLockTime = encode.DropMilliseconds(matchTime.Add(t.lockTimeTaker))
 	} else {
 		proof.SecretHash = auditInfo.SecretHash()

--- a/dex/asset.go
+++ b/dex/asset.go
@@ -12,8 +12,8 @@ import (
 const (
 	UnsupportedScriptError = ErrorKind("unsupported script type")
 
-	defaultLockTimeTaker = 24 * time.Hour
-	defaultlockTimeMaker = 48 * time.Hour
+	defaultLockTimeTaker = 8 * time.Hour
+	defaultlockTimeMaker = 20 * time.Hour
 )
 
 var (

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -576,7 +576,7 @@ type testMsgTxSwap struct {
 // Create a swap (initialization) contract with random pubkeys and return the
 // pubkey script and addresses.
 func testSwapContract() ([]byte, btcutil.Address, btcutil.Address) {
-	lockTime := time.Now().Add(time.Hour * 24).Unix()
+	lockTime := time.Now().Add(time.Hour * 8).Unix()
 	secretHash := randomBytes(32)
 	_, receiverPKH := genPubkey()
 	_, senderPKH := genPubkey()

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -470,7 +470,7 @@ type testMsgTxSwap struct {
 // Create a swap (initialization) contract with random pubkeys and return the
 // pubkey script and addresses.
 func testSwapContract() ([]byte, dcrutil.Address, dcrutil.Address) {
-	lockTime := time.Now().Add(time.Hour * 24).Unix()
+	lockTime := time.Now().Add(time.Hour * 8).Unix()
 	secretKey := randomBytes(32)
 	_, receiverPKH := genPubkey()
 	_, senderPKH := genPubkey()

--- a/spec/atomic.mediawiki
+++ b/spec/atomic.mediawiki
@@ -74,7 +74,7 @@ hash.
 
 In addition, Alice constructs the contract with a second, alternative lock
 that allows her to spend the output herself, but only if the output remains
-unspent for a specified amount of time. Alice sets her timelock to 48 hours.
+unspent for a specified amount of time. Alice sets her timelock to 20 hours.
 
 '''Alice broadcasts her initialization transaction''' to the Decred network.
 She informs the DEX of the transaction details and sends the lock, which the
@@ -87,8 +87,8 @@ After the requisite number of confirmations, Bob prepares his initialization
 transaction'''. He uses Alice's lock here as well, and creates a swap contract
 satisfied by Alice&#x2019;s key and the pubkey for Alice&#x2019;s address.
 
-Bob sets his timelock to 24 hours.
-Bob should also check that the timelock in Alice's initialization is set to 48
+Bob sets his timelock to 8 hours.
+Bob should also check that the timelock in Alice's initialization is set to 20
 hours.
 If Alice&#x2019;s timelock duration is set near or below Bob&#x2019;s timelock duration, Alice
 could potentially spend the DCR output before Bob.
@@ -144,7 +144,7 @@ order is returned to the order book and is immediately able to match again.
 <img src="images/a-init-bc.png" align="right">
 '''B4''': As the maker, Alice goes first again.
 She groups her matches from the epoch and creates two different keys, one for
-Bob and one for Carl. She sets her timelocks to 48 hours.
+Bob and one for Carl. She sets her timelocks to 20 hours.
 '''Alice broadcasts her initialization transaction''' to the Decred network and
 informs the DEX about the transaction details, which the DEX relays to Bob and
 Carl.


### PR DESCRIPTION
The swap contract lock times are somewhat arbitrary, but they are meant to give the users plenty of time to pursue their refund if the swap does not go as planned.

For chains like BTC and DCR, where transaction finality plus potentially long delays for initial block inclusion, theoretically permit a taker lock time as short as 5 hrs (8 very slow back to back confirms) + 3 hrs (long delay for inclusion in a block).  However, going shorter is not advisable due to the human element (wake up after falling asleep during a swap to discover the counterparty has gone dark, necessitating a refund).

These changes would change the taker/maker contract lock times from 24/48 hrs to 12/24 hrs.

Would longer locktimes be desirable for long mempool backlogs?