### PR TITLE
app: soft load markets page

### DIFF
--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -69,6 +69,7 @@ div.main {
   flex-grow: 1;
   min-height: 0;
   position: relative;
+  opacity: 0; // Set by animation upon initial loading.
 }
 
 button.selected {

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -69,6 +69,9 @@ div.main {
   flex-grow: 1;
   min-height: 0;
   position: relative;
+}
+
+div.clear {
   opacity: 0; // Set by animation upon initial loading.
 }
 

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -7,7 +7,7 @@
 
 {{define "markets"}}
 {{template "top" .}}
-<div id="main" data-handler="markets" class="main align-items-stretch justify-content-center">
+<div id="main" data-handler="markets" class="main align-items-stretch justify-content-center clear">
 
   {{- /* MARKET LIST */ -}}
   <div class="marketlist">

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -82,6 +82,9 @@ export default class MarketsPage extends BasePage {
       'cancelForm', 'cancelRemain', 'cancelUnit', 'cancelPass', 'cancelSubmit',
       'cancelStatus'
     ])
+    this.main = main
+    app.loading(this.main.parentElement)
+    this.loaded = false
     this.market = null
     this.registrationStatus = {}
     this.currentForm = null
@@ -609,6 +612,13 @@ export default class MarketsPage extends BasePage {
     this.balanceWgt.setWallets(host, b.id, q.id)
     this.setMarketBuyOrderEstimate()
     this.refreshActiveOrders()
+    if (!this.loaded) {
+      this.loaded = true
+      app.loaded()
+      Doc.animate(250, progress => {
+        this.main.style.opacity = progress
+      })
+    }
   }
 
   /* handleBookOrderRoute is the handler for 'book_order' notifications. */


### PR DESCRIPTION
The markets page was briefly displaying an unnatractive state while loading. Show only a small loading icon until initial market data is recieved.

Might resolve #583.

