### PR TITLE
app: attempt wallet config load from default path

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -80,9 +80,10 @@ var (
 			Description: "<addr> or <addr>:<port> (default 'localhost')",
 		},
 		{
-			Key:         "rpcport",
-			DisplayName: "JSON-RPC Port",
-			Description: "Port for RPC connections (if not set in Address)",
+			Key:          "rpcport",
+			DisplayName:  "JSON-RPC Port",
+			Description:  "Port for RPC connections (if not set in rpcbind)",
+			DefaultValue: "8332",
 		},
 		{
 			Key:          fallbackFeeKey,

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -75,9 +75,10 @@ var (
 			NoEcho:      true,
 		},
 		{
-			Key:         "rpcbind",
-			DisplayName: "JSON-RPC Address",
-			Description: "<addr> or <addr>:<port> (default 'localhost')",
+			Key:          "rpcbind",
+			DisplayName:  "JSON-RPC Address",
+			Description:  "<addr> or <addr>:<port> (default 'localhost')",
+			DefaultValue: "127.0.0.1",
 		},
 		{
 			Key:          "rpcport",

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -63,9 +64,10 @@ var (
 	fallbackFeeKey = "fallbackfee"
 	configOpts     = []*asset.ConfigOption{
 		{
-			Key:         "account",
-			DisplayName: "Account Name",
-			Description: "dcrwallet account name",
+			Key:          "account",
+			DisplayName:  "Account Name",
+			Description:  "dcrwallet account name",
+			DefaultValue: "default",
 		},
 		{
 			Key:         "username",
@@ -79,14 +81,16 @@ var (
 			NoEcho:      true,
 		},
 		{
-			Key:         "rpclisten",
-			DisplayName: "RPC Address",
-			Description: "dcrwallet's address (host or host:port) (default port: 9109, testnet: 19109)",
+			Key:          "rpclisten",
+			DisplayName:  "RPC Address",
+			Description:  "dcrwallet's address (host or host:port) (default port: 9110)",
+			DefaultValue: "127.0.0.1:9110",
 		},
 		{
-			Key:         "rpccert",
-			DisplayName: "TLS Certificate",
-			Description: "Path to the dcrwallet TLS certificate file",
+			Key:          "rpccert",
+			DisplayName:  "TLS Certificate",
+			Description:  "Path to the dcrwallet TLS certificate file",
+			DefaultValue: filepath.Join(dcrwHomeDir, "rpc.cert"),
 		},
 		{
 			Key:          fallbackFeeKey,

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -64,10 +64,9 @@ var (
 	fallbackFeeKey = "fallbackfee"
 	configOpts     = []*asset.ConfigOption{
 		{
-			Key:          "account",
-			DisplayName:  "Account Name",
-			Description:  "dcrwallet account name",
-			DefaultValue: "default",
+			Key:         "account",
+			DisplayName: "Account Name",
+			Description: "dcrwallet account name",
 		},
 		{
 			Key:         "username",

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -42,9 +42,10 @@ var (
 			NoEcho:      true,
 		},
 		{
-			Key:         "rpcbind",
-			DisplayName: "JSON-RPC Address",
-			Description: "<addr> or <addr>:<port> (default 'localhost')",
+			Key:          "rpcbind",
+			DisplayName:  "JSON-RPC Address",
+			Description:  "<addr> or <addr>:<port> (default 'localhost')",
+			DefaultValue: "127.0.0.1",
 		},
 		{
 			Key:          "rpcport",

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -47,9 +47,10 @@ var (
 			Description: "<addr> or <addr>:<port> (default 'localhost')",
 		},
 		{
-			Key:         "rpcport",
-			DisplayName: "JSON-RPC Port",
-			Description: "Port for RPC connections (if not set in Address)",
+			Key:          "rpcport",
+			DisplayName:  "JSON-RPC Port",
+			Description:  "Port for RPC connections (if not set in rpcbind)",
+			DefaultValue: "9332",
 		},
 		{
 			Key:          fallbackFeeKey,

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1270,8 +1270,9 @@ func (c *Core) AutoWalletConfig(assetID uint32) (map[string]string, error) {
 		return nil, fmt.Errorf("asset.Info error: %w", err)
 	}
 	settings, err := config.Parse(winfo.DefaultConfigPath)
+	log.Infof("%d %s configuration settings loaded from file at default location %s", len(settings), unbip(assetID), winfo.DefaultConfigPath)
 	if err != nil {
-		log.Debug("config.Parse could not load settings from default path")
+		log.Debugf("config.Parse could not load settings from default path: %v", err)
 		return make(map[string]string), nil
 	}
 	return settings, nil

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -25,6 +25,7 @@ import (
 	"decred.org/dcrdex/client/db/bolt"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
+	"decred.org/dcrdex/dex/config"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/encrypt"
 	"decred.org/dcrdex/dex/msgjson"
@@ -1258,6 +1259,22 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 	c.notify(newWalletConfigNote("Wallet Password Updated", details, db.Success, wallet.state()))
 
 	return nil
+}
+
+// DefaultWalletConfig attempts to load setting from a wallet package's
+// asset.WalletInfo.DefaultConfigPath. If settings are not found, an empty map
+// is returned.
+func (c *Core) DefaultWalletConfig(assetID uint32) (map[string]string, error) {
+	winfo, err := asset.Info(assetID)
+	if err != nil {
+		return nil, fmt.Errorf("asset.Info error: %w", err)
+	}
+	settings, err := config.Parse(winfo.DefaultConfigPath)
+	if err != nil {
+		log.Debug("config.Parse could not load settings from default path")
+		return make(map[string]string), nil
+	}
+	return settings, nil
 }
 
 func (c *Core) isRegistered(host string) bool {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1261,10 +1261,10 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 	return nil
 }
 
-// DefaultWalletConfig attempts to load setting from a wallet package's
+// AutoWalletConfig attempts to load setting from a wallet package's
 // asset.WalletInfo.DefaultConfigPath. If settings are not found, an empty map
 // is returned.
-func (c *Core) DefaultWalletConfig(assetID uint32) (map[string]string, error) {
+func (c *Core) AutoWalletConfig(assetID uint32) (map[string]string, error) {
 	winfo, err := asset.Info(assetID)
 	if err != nil {
 		return nil, fmt.Errorf("asset.Info error: %w", err)

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -335,7 +335,7 @@ func (s *WebServer) apiDefaultWalletCfg(w http.ResponseWriter, r *http.Request) 
 	if !readPost(w, r, form) {
 		return
 	}
-	cfg, err := s.core.DefaultWalletConfig(form.AssetID)
+	cfg, err := s.core.AutoWalletConfig(form.AssetID)
 	if err != nil {
 		s.writeAPIError(w, "error getting wallet config: %v", err)
 		return

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -326,6 +326,29 @@ func (s *WebServer) apiSetWalletPass(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, simpleAck(), s.indent)
 }
 
+// apiDefaultWalletCfg attempts to load configuration settings from the
+// asset's default path on the server.
+func (s *WebServer) apiDefaultWalletCfg(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		AssetID uint32 `json:"assetID"`
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+	cfg, err := s.core.DefaultWalletConfig(form.AssetID)
+	if err != nil {
+		s.writeAPIError(w, "error getting wallet config: %v", err)
+		return
+	}
+	writeJSON(w, struct {
+		OK     bool              `json:"ok"`
+		Config map[string]string `json:"config"`
+	}{
+		OK:     true,
+		Config: cfg,
+	}, s.indent)
+}
+
 // apiReconfig sets new configuration details for the wallet.
 func (s *WebServer) apiReconfig(w http.ResponseWriter, r *http.Request) {
 	form := &struct {

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -637,13 +637,10 @@ func (c *TCore) User() *core.User {
 	return user
 }
 
-func (c *TCore) DefaultWalletConfig(assetID uint32) (map[string]string, error) {
+func (c *TCore) AutoWalletConfig(assetID uint32) (map[string]string, error) {
 	return map[string]string{
-		"account":   "default",
-		"username":  "tacotime",
-		"password":  "abc123",
-		"rpclisten": "localhost:9109",
-		"rpccert":   "/home/you/.dcrwallet/rpc.cert",
+		"username": "tacotime",
+		"password": "abc123",
 	}, nil
 }
 

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -637,6 +637,16 @@ func (c *TCore) User() *core.User {
 	return user
 }
 
+func (c *TCore) DefaultWalletConfig(assetID uint32) (map[string]string, error) {
+	return map[string]string{
+		"account":   "default",
+		"username":  "tacotime",
+		"password":  "abc123",
+		"rpclisten": "localhost:9109",
+		"rpccert":   "/home/you/.dcrwallet/rpc.cert",
+	}, nil
+}
+
 func (c *TCore) SupportedAssets() map[uint32]*core.SupportedAsset {
 	c.mtx.RLock()
 	defer c.mtx.RUnlock()
@@ -750,7 +760,7 @@ func TestServer(t *testing.T) {
 	numSells = 10
 	feedPeriod = 2000 * time.Millisecond
 	initialize := false
-	register := true
+	register := false
 	forceDisconnectWallet = true
 	gapWidthFactor = 0.2
 

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -332,6 +332,11 @@ hr.dashed {
 }
 
 .dynamicopts {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  flex-wrap: wrap;
+
   & > div {
     min-height: 55px;
     margin-top: 10px;

--- a/client/webserver/site/src/css/typography.scss
+++ b/client/webserver/site/src/css/typography.scss
@@ -38,6 +38,10 @@
   font-style: normal;
 }
 
+.fs8 {
+  font-size: 8px;
+}
+
 .fs11 {
   font-size: 11px;
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=MQq4VTue">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=H4jqdeSE" rel="stylesheet">
+  <link href="/css/style.css?v=0c2lC6c" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="poke-note px-2 fs14 d-flex align-items-center" id="pokeNote"><span>Here is a poke note.</span></div>
@@ -61,7 +61,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=Gx9fqk8E"></script>
+<script src="/js/entry.js?v=VBByg6"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -4,16 +4,29 @@
   <div data-tmpl="fileSelector" class="d-inline-block hoverbg pointer fs14"><span class="ico-textfile mr-1"></span> load from file</div>
   <input data-tmpl="fileInput" type="file" class="form-control select d-none">
 </div>
-<div data-tmpl="dynamicOpts" class="d-flex align-items-stretch justify-content-between flex-wrap dynamicopts">
-  <div data-tmpl="textInput" class="px-0 d-flex flex-column justify-content-end">
-    <label class="pl-1 mb-1 small"> <span class="ico-info"></span></label>
-    <input type="text" class="form-control select">
+<div data-tmpl="allSettings">
+  <div data-tmpl="dynamicOpts" class="dynamicopts">
+    <div data-tmpl="textInput" class="px-0 d-flex flex-column justify-content-end">
+      <label class="pl-1 mb-1 small"> <span class="ico-info"></span></label>
+      <input type="text" class="form-control select">
+    </div>
+    <div data-tmpl="checkbox" class="pl-4 d-flex align-items-center justify-content-center">
+      <div>
+        <input class="form-check-input" type="checkbox" value="">
+        <label class="form-check-label fs14"> <span class="ico-info fs13"></span></label>
+      </div>
+    </div>
   </div>
-  <div data-tmpl="checkbox" class="pl-4 d-flex align-items-center justify-content-center">
-    <div>
-      <input class="form-check-input" type="checkbox" value="">
-      <label class="form-check-label fs14"> <span class="ico-info fs13"></span></label>
-    </div>        
+  <div data-tmpl="showOther" class="d-hide mt-3 mb-1 pointer d-flex align-items-center justify-content-start">
+    <span data-tmpl="showIcon" class="ico-plus fs8 pl-1"></span>
+    <span data-tmpl="hideIcon" class="ico-minus fs8 pl-1"></span>
+    <span data-tmpl="showHideMsg" class="d-inline-block pl-1 pb-1"></span>
+  </div>
+  <div data-tmpl="otherSettings" class="d-hide">
+    <div data-tmpl="loadedSettingsMsg" class="fs15 pt-3 pb-1 pl-1">&mdash; loaded from file &mdash;</div>
+    <div data-tmpl="loadedSettings" class="dynamicopts"></div>
+    <div data-tmpl="defaultSettingsMsg" class="fs15 pt-3 pb-1 pl-1">&mdash; defaults &mdash;</div>
+    <div data-tmpl="defaultSettings" class="dynamicopts"></div>
   </div>
 </div>
 <div data-tmpl="errMsg" class="fs15 pt-3 text-center d-hide errcolor"></div>

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -17,7 +17,7 @@ export class NewWalletForm {
     ])
 
     // WalletConfigForm will set the global app variable.
-    this.subform = new WalletConfigForm(application, fields.walletSettings)
+    this.subform = new WalletConfigForm(application, fields.walletSettings, true)
 
     bind(form, fields.submitAdd, async () => {
       if (fields.newWalletPass.value === '') {
@@ -81,7 +81,7 @@ export class NewWalletForm {
       this.setError(res.msg)
       return
     }
-    this.subform.setConfig(res.config)
+    this.subform.setLoadedConfig(res.config)
   }
 }
 
@@ -90,11 +90,17 @@ export class NewWalletForm {
  * asset-specific wallet configuration options.
 */
 export class WalletConfigForm {
-  constructor (application, form) {
+  constructor (application, form, sectionize) {
     app = application
     this.form = form
+    // A configElement is a div containing an input and its label.
+    this.configElements = {}
+    // configOpts is the wallet options provided by core.
+    this.configOpts = []
+    this.sectionize = sectionize
 
     // Get template elements
+    this.allSettings = Doc.tmplElement(form, 'allSettings')
     this.dynamicOpts = Doc.tmplElement(form, 'dynamicOpts')
     this.textInputTmpl = Doc.tmplElement(form, 'textInput')
     this.textInputTmpl.remove()
@@ -103,69 +109,175 @@ export class WalletConfigForm {
     this.fileSelector = Doc.tmplElement(form, 'fileSelector')
     this.fileInput = Doc.tmplElement(form, 'fileInput')
     this.errMsg = Doc.tmplElement(form, 'errMsg')
+    this.showOther = Doc.tmplElement(form, 'showOther')
+    this.showIcon = Doc.tmplElement(form, 'showIcon')
+    this.hideIcon = Doc.tmplElement(form, 'hideIcon')
+    this.showHideMsg = Doc.tmplElement(form, 'showHideMsg')
+    this.otherSettings = Doc.tmplElement(form, 'otherSettings')
+    this.loadedSettingsMsg = Doc.tmplElement(form, 'loadedSettingsMsg')
+    this.loadedSettings = Doc.tmplElement(form, 'loadedSettings')
+    this.defaultSettingsMsg = Doc.tmplElement(form, 'defaultSettingsMsg')
+    this.defaultSettings = Doc.tmplElement(form, 'defaultSettings')
+
+    if (!sectionize) Doc.hide(this.showOther)
 
     Doc.bind(this.fileSelector, 'click', () => this.fileInput.click())
 
     // config file upload
-    Doc.bind(this.fileInput, 'change', async () => {
-      if (!this.fileInput.value) return
-      app.loading(form)
-      const config = await this.fileInput.files[0].text()
-      if (!config) return
-      const res = await postJSON('/api/parseconfig', {
-        configtext: config
-      })
-      app.loaded()
-      if (!app.checkResponse(res)) {
-        this.errMsg.textContent = res.msg
-        Doc.show(this.errMsg)
-        return
-      }
-      this.setConfig(res.map)
+    Doc.bind(this.fileInput, 'change', async () => this.fileInputChanged())
+
+    Doc.bind(this.showOther, 'click', () => {
+      this.setOtherSettingsViz(this.hideIcon.classList.contains('d-hide'))
     })
   }
 
+  /*
+   * fileInputChanged will read the selected file and attempt to load the
+   * configuration settings. All loaded settings will be made visible for
+   * inspection by the user.
+   */
+  async fileInputChanged () {
+    if (!this.fileInput.value) return
+    app.loading(this.form)
+    const config = await this.fileInput.files[0].text()
+    if (!config) return
+    const res = await postJSON('/api/parseconfig', {
+      configtext: config
+    })
+    app.loaded()
+    if (!app.checkResponse(res)) {
+      this.errMsg.textContent = res.msg
+      Doc.show(this.errMsg)
+      return
+    }
+    if (Object.keys(res.map).length === 0) return
+    this.dynamicOpts.append(...this.setConfig(res.map))
+    this.reorder(this.dynamicOpts)
+    const [loadedOpts, defaultOpts] = [this.loadedSettings.children.length, this.defaultSettings.children.length]
+    if (loadedOpts === 0) Doc.hide(this.loadedSettings, this.loadedSettingsMsg)
+    if (defaultOpts === 0) Doc.hide(this.defaultSettings, this.defaultSettingsMsg)
+    if (loadedOpts + defaultOpts === 0) Doc.hide(this.showOther, this.otherSettings)
+  }
+
+  /*
+   * update creates the dynamic form.
+   */
   update (walletInfo) {
-    Doc.empty(this.dynamicOpts)
-    for (const opt of walletInfo.configopts) {
+    this.configElements = {}
+    this.configOpts = walletInfo.configopts
+    Doc.empty(this.dynamicOpts, this.otherSettings)
+    this.setOtherSettingsViz(false)
+    Doc.hide(
+      this.loadedSettingsMsg, this.loadedSettings,
+      this.defaultSettingsMsg, this.defaultSettings,
+      this.errMsg
+    )
+    const defaultedOpts = []
+    const addOpt = (box, opt) => {
       const elID = 'wcfg-' + opt.key
       const el = opt.isboolean ? this.checkboxTmpl.cloneNode(true) : this.textInputTmpl.cloneNode(true)
+      this.configElements[opt.key] = el
       const input = el.querySelector('input')
       input.id = elID
       input.configOpt = opt
       const label = el.querySelector('label')
       label.htmlFor = elID // 'for' attribute, but 'for' is a keyword
       label.prepend(opt.displayname)
-      this.dynamicOpts.appendChild(el)
+      box.appendChild(el)
       if (opt.noecho) input.type = 'password'
       if (opt.description) label.dataset.tooltip = opt.description
       if (opt.isboolean) input.checked = opt.default
-      else input.value = opt.default ? opt.default : ''
+      else input.value = opt.default !== null ? opt.default : ''
     }
-    Doc.hide(this.errMsg)
-    app.bindTooltips(this.form)
+    for (const opt of this.configOpts) {
+      if (this.sectionize && opt.default !== null) defaultedOpts.push(opt)
+      else addOpt(this.dynamicOpts, opt)
+    }
+    if (defaultedOpts.length) {
+      for (const opt of defaultedOpts) addOpt(this.defaultSettings, opt)
+      Doc.show(this.showOther, this.defaultSettingsMsg, this.defaultSettings)
+    } else {
+      Doc.hide(this.showOther)
+    }
+    app.bindTooltips(this.allSettings)
   }
 
-  setConfig (configMap) {
-    this.dynamicOpts.querySelectorAll('input').forEach(input => {
-      const v = configMap[input.configOpt.key]
-      if (!v) return
+  /*
+   * setOtherSettingsViz sets the visibility of the additional settings section.
+   */
+  setOtherSettingsViz (visible) {
+    if (visible) {
+      Doc.hide(this.showIcon)
+      Doc.show(this.hideIcon, this.otherSettings)
+      this.showHideMsg.textContent = 'hide additional settings'
+      return
+    }
+    Doc.hide(this.hideIcon, this.otherSettings)
+    Doc.show(this.showIcon)
+    this.showHideMsg.textContent = 'show additional settings'
+  }
+
+  /*
+   * setConfig looks for inputs with configOpt keys matching the cfg object, and
+   * sets the inputs value to the corresponding cfg value. A list of matching
+   * configElements is returned.
+   */
+  setConfig (cfg) {
+    const finds = []
+    this.allSettings.querySelectorAll('input').forEach(input => {
+      const k = input.configOpt.key
+      const v = cfg[k]
+      if (typeof v === 'undefined') return
+      finds.push(this.configElements[k])
       if (input.configOpt.isboolean) input.checked = isTruthyString(v)
       else input.value = v
     })
+    return finds
   }
 
+  /*
+   * setLoadedConfig sets the input values for the entries in cfg, and moves
+   * them to the loadedSettings box.
+   */
+  setLoadedConfig (cfg) {
+    const finds = this.setConfig(cfg)
+    if (!this.sectionize || finds.length === 0) return
+    this.loadedSettings.append(...finds)
+    this.reorder(this.loadedSettings)
+    Doc.show(this.loadedSettings, this.loadedSettingsMsg)
+    if (this.defaultSettings.children.length === 0) Doc.hide(this.defaultSettings, this.defaultSettingsMsg)
+  }
+
+  /*
+   * map reads all inputs and constructs an object from the configOpt keys and
+   * values.
+   */
   map () {
     const config = {}
-    this.dynamicOpts.querySelectorAll('input').forEach(input => {
+    this.allSettings.querySelectorAll('input').forEach(input => {
       if (input.configOpt.isboolean && input.configOpt.key) config[input.configOpt.key] = input.checked ? '1' : '0'
       else if (input.value) config[input.configOpt.key] = input.value
     })
 
     return config
   }
-}
 
+  /*
+   * reorder sorts the configElements in the box by the order of the
+   * server-provided configOpts array.
+   */
+  reorder (box) {
+    const els = {}
+    box.querySelectorAll('input').forEach(el => {
+      const k = el.configOpt.key
+      els[k] = this.configElements[k]
+    })
+    for (const opt of this.configOpts) {
+      const el = els[opt.key]
+      if (el) box.append(el)
+    }
+  }
+}
 /*
  * bindOpenWallet should be used with the "unlockWalletForm" template. The
  * enclosing <form> element should be second argument.

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -43,8 +43,7 @@ export class NewWalletForm {
       var res = await postJSON('/api/newwallet', createForm)
       app.loaded()
       if (!app.checkResponse(res)) {
-        fields.newWalletErr.textContent = res.msg
-        Doc.show(fields.newWalletErr)
+        this.setError(res.msg)
         return
       }
       fields.newWalletPass.value = ''
@@ -61,6 +60,28 @@ export class NewWalletForm {
     fields.newWalletPass.value = ''
     this.subform.update(asset.info)
     Doc.hide(fields.newWalletErr)
+  }
+
+  /* setError sets and shows the in-form error message. */
+  async setError (errMsg) {
+    this.fields.newWalletErr.textContent = errMsg
+    Doc.show(this.fields.newWalletErr)
+  }
+
+  /*
+   * loadDefaults attempts to load the ExchangeWallet configuration from the
+   * default wallet config path on the server and will auto-fill the fields on
+   * the subform if settings are found.
+   */
+  async loadDefaults () {
+    app.loading(this.form)
+    var res = await postJSON('/api/defaultwalletcfg', { assetID: this.currentAsset.id })
+    app.loaded()
+    if (!app.checkResponse(res)) {
+      this.setError(res.msg)
+      return
+    }
+    this.subform.setConfig(res.config)
   }
 }
 

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -56,6 +56,9 @@ export default class RegistrationPage extends BasePage {
 
     // SUBMIT DEX REGISTRATION
     bindForm(page.confirmRegForm, page.submitConfirm, () => { this.registerDEX() })
+
+    // Attempt to load the dcrwallet configuration from the default location.
+    this.walletForm.loadDefaults()
   }
 
   /* Swap this currently displayed form1 for form2 with an animation. */

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -82,7 +82,7 @@ export default class WalletsPage extends BasePage {
     this.walletForm = new NewWalletForm(app, page.walletForm, () => { this.createWalletSuccess() })
 
     // Bind the wallet reconfig form.
-    this.walletReconfig = new WalletConfigForm(app, page.reconfigInputs)
+    this.walletReconfig = new WalletConfigForm(app, page.reconfigInputs, false)
 
     // Bind the wallet unlock form.
     bindOpenWallet(app, page.openForm, () => { this.openWalletSuccess() })

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -211,6 +211,7 @@ export default class WalletsPage extends BasePage {
     this.walletAsset = assetID
     this.walletForm.setAsset(asset)
     this.animation = this.showBox(box)
+    await this.walletForm.loadDefaults()
   }
 
   /* Show the form used to unlock a wallet. */

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -72,6 +72,7 @@ type clientCore interface {
 	WalletSettings(uint32) (map[string]string, error)
 	ReconfigureWallet([]byte, uint32, map[string]string) error
 	SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error
+	DefaultWalletConfig(assetID uint32) (map[string]string, error)
 	User() *core.User
 	GetFee(url, cert string) (uint64, error)
 	SupportedAssets() map[uint32]*core.SupportedAsset
@@ -232,6 +233,7 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 		r.Post("/reconfigurewallet", s.apiReconfig)
 		r.Post("/walletsettings", s.apiWalletSettings)
 		r.Post("/setwalletpass", s.apiSetWalletPass)
+		r.Post("/defaultwalletcfg", s.apiDefaultWalletCfg)
 	})
 
 	// Files

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -72,7 +72,7 @@ type clientCore interface {
 	WalletSettings(uint32) (map[string]string, error)
 	ReconfigureWallet([]byte, uint32, map[string]string) error
 	SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error
-	DefaultWalletConfig(assetID uint32) (map[string]string, error)
+	AutoWalletConfig(assetID uint32) (map[string]string, error)
 	User() *core.User
 	GetFee(url, cert string) (uint64, error)
 	SupportedAssets() map[uint32]*core.SupportedAsset

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -107,6 +107,7 @@ func (c *TCore) Wallets() []*core.WalletState                                   
 func (c *TCore) WalletSettings(uint32) (map[string]string, error)                         { return nil, nil }
 func (c *TCore) ReconfigureWallet(pw []byte, assetID uint32, cfg map[string]string) error { return nil }
 func (c *TCore) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error       { return nil }
+func (c *TCore) DefaultWalletConfig(assetID uint32) (map[string]string, error)            { return nil, nil }
 func (c *TCore) User() *core.User                                                         { return nil }
 func (c *TCore) SupportedAssets() map[uint32]*core.SupportedAsset {
 	return make(map[uint32]*core.SupportedAsset)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -107,7 +107,7 @@ func (c *TCore) Wallets() []*core.WalletState                                   
 func (c *TCore) WalletSettings(uint32) (map[string]string, error)                         { return nil, nil }
 func (c *TCore) ReconfigureWallet(pw []byte, assetID uint32, cfg map[string]string) error { return nil }
 func (c *TCore) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error       { return nil }
-func (c *TCore) DefaultWalletConfig(assetID uint32) (map[string]string, error)            { return nil, nil }
+func (c *TCore) AutoWalletConfig(assetID uint32) (map[string]string, error)               { return nil, nil }
 func (c *TCore) User() *core.User                                                         { return nil }
 func (c *TCore) SupportedAssets() map[uint32]*core.SupportedAsset {
 	return make(map[uint32]*core.SupportedAsset)


### PR DESCRIPTION
Resolves #616. Browsers do not permit loading from the client computer without a file selection dialog. Load them from the dexc machine (likely the same machine) upon request from the browser instead. 