### PR TITLE
client/core,server/auth: silence logging of inactive matches in tick

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2411,7 +2411,7 @@ func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, e
 	// Prepare active orders, according to the DB.
 	dbOrders, err := c.db.ActiveDEXOrders(dc.acct.host)
 	if err != nil {
-		return nil, fmt.Errorf("database error when fetching orders for %s: %x", dc.acct.host, err)
+		return nil, fmt.Errorf("database error when fetching orders for %s: %v", dc.acct.host, err)
 	}
 	log.Infof("Loaded %d active orders.", len(dbOrders))
 
@@ -2908,7 +2908,7 @@ func handleRevokeMatchMsg(c *Core, dc *dexConnection, msg *msgjson.Message) erro
 	}
 
 	if len(revocation.MatchID) != order.MatchIDSize {
-		return fmt.Errorf("invalid match ID %x", revocation.MatchID)
+		return fmt.Errorf("invalid match ID %v", revocation.MatchID)
 	}
 
 	var matchID order.MatchID

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -913,6 +913,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 
 	// Send pending requests for this user.
 	for _, pr := range pendingReqs {
+		log.Debugf("Sending pending '%s' request to user %v: %v", pr.req.Route, pr.user, pr.req.String())
 		// Use the AuthManager method to send so that failed requests, which
 		// result in client removal, will go back into the client's pending
 		// requests. Subsequent requests that follow removal also fail and go
@@ -931,6 +932,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 
 	// Send pending messages for this user.
 	for _, pr := range pendingMsgs {
+		log.Debugf("Sending pending %s to user %v: %v", pr.msg.Type, pr.user, pr.msg.String())
 		connectTimeout := DefaultConnectTimeout
 		// Decrement the connect timeout for repeated attempts.
 		if !pr.lastAttempt.IsZero() {


### PR DESCRIPTION
When there is a refunded or inactive revoked match for an order that is still active because it is either still booked or has other active matches, you get spammed a bit by `tick()` when the inactive matches pass through all the redeemable/swappable/refundable checks.  This skips them in the `tick()` loop.