### PR TITLE
client/rpcserver: Require password.

### DIFF
--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -169,6 +169,10 @@ func SetLogger(logger dex.Logger) {
 // New is the constructor for an RPCServer.
 func New(cfg *Config) (*RPCServer, error) {
 
+	if cfg.Pass == "" {
+		return nil, fmt.Errorf("missing RPC password")
+	}
+
 	// Find or create the key pair.
 	keyExists := fileExists(cfg.Key)
 	certExists := fileExists(cfg.Cert)
@@ -211,12 +215,10 @@ func New(cfg *Config) (*RPCServer, error) {
 	}
 
 	// Create authSHA to verify requests against.
-	if cfg.User != "" && cfg.Pass != "" {
-		login := cfg.User + ":" + cfg.Pass
-		auth := "Basic " +
-			base64.StdEncoding.EncodeToString([]byte(login))
-		s.authSHA = sha256.Sum256([]byte(auth))
-	}
+	login := cfg.User + ":" + cfg.Pass
+	auth := "Basic " +
+		base64.StdEncoding.EncodeToString([]byte(login))
+	s.authSHA = sha256.Sum256([]byte(auth))
 
 	// Middleware
 	mux.Use(middleware.Recoverer)

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/elliptic"
 	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -80,7 +81,7 @@ type RPCServer struct {
 	addr      string
 	tlsConfig *tls.Config
 	srv       *http.Server
-	authsha   [32]byte
+	authSHA   [32]byte
 	wg        sync.WaitGroup
 }
 
@@ -209,12 +210,12 @@ func New(cfg *Config) (*RPCServer, error) {
 		wsServer:  websocket.New(cfg.Core, log.SubLogger("WS")),
 	}
 
-	// Create authsha to verify requests against.
+	// Create authSHA to verify requests against.
 	if cfg.User != "" && cfg.Pass != "" {
 		login := cfg.User + ":" + cfg.Pass
 		auth := "Basic " +
 			base64.StdEncoding.EncodeToString([]byte(login))
-		s.authsha = sha256.Sum256([]byte(auth))
+		s.authSHA = sha256.Sum256([]byte(auth))
 	}
 
 	// Middleware
@@ -317,11 +318,19 @@ func (s *RPCServer) parseHTTPRequest(w http.ResponseWriter, req *msgjson.Message
 // authMiddleware checks incoming requests for authentication.
 func (s *RPCServer) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		auth := r.Header["Authorization"]
-		if len(auth) == 0 || s.authsha != sha256.Sum256([]byte(auth[0])) {
-			log.Warnf("authentication failure from ip: %s with auth: %s", r.RemoteAddr, auth)
+		fail := func() {
+			log.Warnf("authentication failure from ip: %s", r.RemoteAddr)
 			w.Header().Add("WWW-Authenticate", `Basic realm="dex RPC"`)
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		}
+		auth := r.Header["Authorization"]
+		if len(auth) == 0 {
+			fail()
+			return
+		}
+		authSHA := sha256.Sum256([]byte(auth[0]))
+		if subtle.ConstantTimeCompare(s.authSHA[:], authSHA[:]) != 1 {
+			fail()
 			return
 		}
 		log.Debugf("authenticated user with ip: %s", r.RemoteAddr)

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -312,7 +312,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, test := range authTests {
 		s, shutdown := newTServer(t, false, test[0], test[1])
-		auth := base64.StdEncoding.EncodeToString((s.authsha[:]))
+		auth := base64.StdEncoding.EncodeToString((s.authSHA[:]))
 		if auth != test[2] {
 			t.Fatalf("expected auth %s but got %s", test[2], auth)
 		}
@@ -355,7 +355,7 @@ func TestAuthMiddleware(t *testing.T) {
 	login := user + ":" + pass
 	h := "Basic "
 	auth := h + base64.StdEncoding.EncodeToString([]byte(login))
-	s.authsha = sha256.Sum256([]byte(auth))
+	s.authSHA = sha256.Sum256([]byte(auth))
 
 	tests := []authMiddlewareTest{
 		{"auth ok", user, pass, h, true, false},

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -114,13 +115,21 @@ func (c *TCore) Withdraw(pw []byte, assetID uint32, value uint64, addr string) (
 }
 
 func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, func()) {
+	tSrv, fn, err := newTServerWErr(t, start, user, pass)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tSrv, fn
+}
+func newTServerWErr(t *testing.T, start bool, user, pass string) (*RPCServer, func(), error) {
 	t.Helper()
 
 	var shutdown func()
 	ctx, killCtx := context.WithCancel(tCtx)
 	tempDir, err := ioutil.TempDir("", "rpcservertest")
 	if err != nil {
-		t.Fatalf("error creating temporary directory: %v", err)
+		killCtx()
+		return nil, nil, fmt.Errorf("error creating temporary directory: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
 
@@ -135,13 +144,15 @@ func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, func()
 	}
 	s, err := New(cfg)
 	if err != nil {
-		t.Fatalf("error creating server: %v", err)
+		killCtx()
+		return nil, nil, fmt.Errorf("error creating server: %v", err)
 	}
 	if start {
 		cm := dex.NewConnectionMaster(s)
 		err := cm.Connect(ctx)
 		if err != nil {
-			t.Fatalf("Error starting RPCServer: %v", err)
+			killCtx()
+			return nil, nil, fmt.Errorf("error starting RPCServer: %v", err)
 		}
 		shutdown = func() {
 			killCtx()
@@ -150,7 +161,7 @@ func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, func()
 	} else {
 		shutdown = killCtx
 	}
-	return s, shutdown
+	return s, shutdown, nil
 }
 
 func TestMain(m *testing.M) {
@@ -164,7 +175,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestConnectBindError(t *testing.T) {
-	s0, shutdown := newTServer(t, true, "", "")
+	s0, shutdown := newTServer(t, true, "", "abc")
 	defer shutdown()
 
 	tempDir, err := ioutil.TempDir("", "rpcservertest")
@@ -178,7 +189,7 @@ func TestConnectBindError(t *testing.T) {
 		Core: &TCore{},
 		Addr: s0.addr,
 		User: "",
-		Pass: "",
+		Pass: "abc",
 		Cert: cert,
 		Key:  key,
 	}
@@ -212,7 +223,7 @@ func (w *tResponseWriter) WriteHeader(statusCode int) {
 }
 
 func TestParseHTTPRequest(t *testing.T) {
-	s, shutdown := newTServer(t, false, "", "")
+	s, shutdown := newTServer(t, false, "", "abc")
 	defer shutdown()
 	var r *http.Request
 
@@ -298,30 +309,46 @@ func TestParseHTTPRequest(t *testing.T) {
 	ensureMsgErr("bad params", msgjson.RPCParseError)
 }
 
-type authMiddlewareTest struct {
-	name, user, pass, header string
-	hasAuth, wantErr         bool
-}
-
 func TestNew(t *testing.T) {
-	authTests := [][]string{
-		{"user", "pass", "AK+rg3mIGeouojwZwNRMjBjZouASr4mu4FWMTXQQcD0="},
-		{"", "", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="},
-		{`&!"#$%&'()~=`, `+<>*?,:.;/][{}`,
-			"Te4g4+Ke9Q07MYo3iT1OCqq5qXX2ZcB47FBiVaT41hQ="},
-	}
+	authTests := []struct {
+		name, user, pass, wantAuth string
+		wantErr                    bool
+	}{{
+		name:     "ok",
+		user:     "user",
+		pass:     "pass",
+		wantAuth: "AK+rg3mIGeouojwZwNRMjBjZouASr4mu4FWMTXQQcD0=",
+	}, {
+		name:     "ok various input",
+		user:     `&!"#$%&'()~=`,
+		pass:     `+<>*?,:.;/][{}`,
+		wantAuth: "Te4g4+Ke9Q07MYo3iT1OCqq5qXX2ZcB47FBiVaT41hQ=",
+	}, {
+		name:    "no password",
+		user:    "user",
+		wantErr: true,
+	}}
 	for _, test := range authTests {
-		s, shutdown := newTServer(t, false, test[0], test[1])
+		s, shutdown, err := newTServerWErr(t, false, test.user, test.pass)
+		if test.wantErr {
+			if err == nil {
+				t.Fatalf("expected error for test %s", test.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("unexpected error for test %s: %v", test.name, err)
+		}
 		auth := base64.StdEncoding.EncodeToString((s.authSHA[:]))
-		if auth != test[2] {
-			t.Fatalf("expected auth %s but got %s", test[2], auth)
+		if auth != test.wantAuth {
+			t.Fatalf("expected auth %s but got %s", test.wantAuth, auth)
 		}
 		shutdown()
 	}
 }
 
 func TestAuthMiddleware(t *testing.T) {
-	s, shutdown := newTServer(t, false, "", "")
+	s, shutdown := newTServer(t, false, "", "abc")
 	defer shutdown()
 	am := s.authMiddleware(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -357,13 +384,45 @@ func TestAuthMiddleware(t *testing.T) {
 	auth := h + base64.StdEncoding.EncodeToString([]byte(login))
 	s.authSHA = sha256.Sum256([]byte(auth))
 
-	tests := []authMiddlewareTest{
-		{"auth ok", user, pass, h, true, false},
-		{"wrong pass", user, "password123", h, true, true},
-		{"unknown user", "Jules", pass, h, true, true},
-		{"no header", user, pass, h, false, true},
-		{"malformed header", user, pass, "basic ", true, true},
-	}
+	tests := []struct {
+		name, user, pass, header string
+		hasAuth, wantErr         bool
+	}{{
+		name:    "auth ok",
+		user:    user,
+		pass:    pass,
+		header:  h,
+		hasAuth: true,
+		wantErr: false,
+	}, {
+		name:    "wrong pass",
+		user:    user,
+		pass:    "password123",
+		header:  h,
+		hasAuth: true,
+		wantErr: true,
+	}, {
+		name:    "unknown user",
+		user:    "Jules",
+		pass:    pass,
+		header:  h,
+		hasAuth: true,
+		wantErr: true,
+	}, {
+		name:    "no header",
+		user:    user,
+		pass:    pass,
+		header:  h,
+		hasAuth: false,
+		wantErr: true,
+	}, {
+		name:    "malformed header",
+		user:    user,
+		pass:    pass,
+		header:  "basic ",
+		hasAuth: true,
+		wantErr: true,
+	}}
 	for _, test := range tests {
 		login = test.user + ":" + test.pass
 		auth = test.header + base64.StdEncoding.EncodeToString([]byte(login))


### PR DESCRIPTION
    client/rpcserver: Use subtle.ConstantTimeCompare.

    client/rpcserver: Require password to create.