### PR TITLE
client/core: update asset balance on tip change

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1726,7 +1726,7 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 // are loaded, even if there are inactive matches for the same order, but it may
 // be desirable to load all matches, so this behavior may change.
 func (c *Core) resolveActiveTrades(crypter encrypt.Crypter) (loaded int) {
-	failed := make(map[uint32]struct{}) // TODO: use this after loadDBTrades!
+	failed := make(map[uint32]struct{}) // TODO: either remove this or use it after loadDBTrades
 	relocks := make(assetMap)
 	c.connMtx.RLock()
 	defer c.connMtx.RUnlock()

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3337,6 +3337,9 @@ func (c *Core) tipChange(assetID uint32, nodeErr error) {
 		}
 	}
 	c.connMtx.RUnlock()
+	// Ensure we always at least update this asset's balance regardless of trade
+	// status changes.
+	counts[assetID]++
 	c.updateBalances(counts)
 }
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1726,7 +1726,7 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 // are loaded, even if there are inactive matches for the same order, but it may
 // be desirable to load all matches, so this behavior may change.
 func (c *Core) resolveActiveTrades(crypter encrypt.Crypter) (loaded int) {
-	failed := make(map[uint32]struct{}) // TODO: either remove this or use it after loadDBTrades
+	failed := make(map[uint32]struct{})
 	relocks := make(assetMap)
 	c.connMtx.RLock()
 	defer c.connMtx.RUnlock()

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1223,7 +1223,7 @@ func TestRegister(t *testing.T) {
 		Cert:    "required",
 	}
 
-	tWallet.payFeeCoin = &tCoin{id: []byte("abcdef")}
+	tWallet.payFeeCoin = &tCoin{id: encode.RandomBytes(36)}
 
 	ch := tCore.NotificationFeed()
 
@@ -1253,18 +1253,21 @@ func TestRegister(t *testing.T) {
 
 	getBalanceNote := func() *BalanceNote {
 		t.Helper()
-		note, ok := getNotification("balance").(*BalanceNote)
+
+		ntfn := getNotification("balance")
+		note, ok := ntfn.(*BalanceNote)
 		if !ok {
-			t.Fatalf("wrong notification. Expected BalanceNote")
+			t.Fatalf("wrong notification (%T). Expected BalanceNote", ntfn)
 		}
 		return note
 	}
 
 	getFeeNote := func() *FeePaymentNote {
 		t.Helper()
-		note, ok := getNotification("feepayment").(*FeePaymentNote)
+		ntfn := getNotification("feepayment")
+		note, ok := ntfn.(*FeePaymentNote)
 		if !ok {
-			t.Fatalf("wrong notification. Expected FeePaymentNote")
+			t.Fatalf("wrong notification (%T). Expected FeePaymentNote", ntfn)
 		}
 		return note
 	}
@@ -1281,6 +1284,7 @@ func TestRegister(t *testing.T) {
 	if feeNote.Severity() != db.Success {
 		t.Fatalf("fee payment error notification: %s: %s", feeNote.Subject(), feeNote.Details())
 	}
+	getBalanceNote()
 	feeNote = getFeeNote()
 	if feeNote.Severity() != db.Success {
 		t.Fatalf("fee payment error notification: %s: %s", feeNote.Subject(), feeNote.Details())
@@ -1441,6 +1445,7 @@ func TestRegister(t *testing.T) {
 	if feeNote.Severity() != db.Success {
 		t.Fatalf("fee payment error notification: %s: %s", feeNote.Subject(), feeNote.Details())
 	}
+	getBalanceNote()
 	// 2nd note is fee error
 	feeNote = getFeeNote()
 	if feeNote.Severity() != db.ErrorLevel {
@@ -2868,7 +2873,7 @@ func TestResolveActiveTrades(t *testing.T) {
 	}
 
 	oid := lo.ID()
-	changeCoinID := encode.RandomBytes(32)
+	changeCoinID := encode.RandomBytes(36)
 	changeCoin := &tCoin{id: changeCoinID}
 
 	dbOrder := &db.MetaOrder{

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -3527,28 +3527,19 @@ func TestAssetBalance(t *testing.T) {
 }
 
 func TestAssetCounter(t *testing.T) {
-	counts := make(assetCounter)
-	counts.add(1, 1)
-	if len(counts) != 1 {
+	assets := make(assetMap)
+	assets.count(1)
+	if len(assets) != 1 {
 		t.Fatalf("count not added")
 	}
-	counts.add(1, 3)
-	if counts[1] != 4 {
-		t.Fatalf("counts not incremented properly")
+
+	newCounts := assetMap{
+		1: struct{}{},
+		2: struct{}{},
 	}
-	newCounts := assetCounter{
-		1: 100,
-		2: 2,
-	}
-	counts.absorb(newCounts)
-	if len(counts) != 2 {
+	assets.merge(newCounts)
+	if len(assets) != 2 {
 		t.Fatalf("counts not absorbed properly")
-	}
-	if counts[2] != 2 {
-		t.Fatalf("absorbed counts not set correctly")
-	}
-	if counts[1] != 104 {
-		t.Fatalf("absorbed counts not combined correctly")
 	}
 }
 

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -763,11 +763,11 @@ func (t *trackedTrade) isRefundable(match *matchTracker) bool {
 }
 
 // tick will check for and perform any match actions necessary.
-func (t *trackedTrade) tick() (assetCounter, error) {
+func (t *trackedTrade) tick() (assetMap, error) {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	var swaps, redeems, refunds []*matchTracker
-	counts := make(assetCounter)
+	assets := make(assetMap)
 	errs := newErrorSet(t.dc.acct.host + " tick: ")
 
 	// Check all matches for and resend pending requests as necessary.
@@ -807,9 +807,8 @@ func (t *trackedTrade) tick() (assetCounter, error) {
 	}
 
 	fromID := t.wallets.fromAsset.ID
-	nSwapsAndRefunds := len(swaps) + len(refunds)
-	if nSwapsAndRefunds > 0 {
-		counts[fromID] = nSwapsAndRefunds
+	if len(swaps) > 0 || len(refunds) > 0 {
+		assets.count(fromID)
 	}
 
 	if len(swaps) > 0 {
@@ -836,7 +835,7 @@ func (t *trackedTrade) tick() (assetCounter, error) {
 
 	if len(redeems) > 0 {
 		toAsset := t.wallets.toAsset.ID
-		counts[toAsset] = len(redeems)
+		assets.count(toAsset)
 		qty := received
 		if t.Trade().Sell {
 			qty = quoteReceived
@@ -868,7 +867,7 @@ func (t *trackedTrade) tick() (assetCounter, error) {
 		}
 	}
 
-	return counts, errs.ifAny()
+	return assets, errs.ifAny()
 }
 
 // resendPendingRequests checks all matches for this order to re-attempt

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -475,8 +475,8 @@ type RegisterResult struct {
 	ReqConfirms uint16 `json:"reqConfirms"`
 }
 
-// assetMap tracks a series of assets and provides methods for adding and asset
-// and merging with another assetMap.
+// assetMap tracks a series of assets and provides methods for registering an
+// asset and merging with another assetMap.
 type assetMap map[uint32]struct{}
 
 // count registers a new asset.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -475,21 +475,18 @@ type RegisterResult struct {
 	ReqConfirms uint16 `json:"reqConfirms"`
 }
 
-// assetCounter tracks a count for a series of assets and provides methods for
-// adding to the count and combining assetCounters. Methods return the receiver
-// for convenience.
-type assetCounter map[uint32]int
+// assetMap tracks a series of assets and provides methods for adding and asset
+// and merging with another assetMap.
+type assetMap map[uint32]struct{}
 
-// add increments the count for a specific asset.
-func (c assetCounter) add(assetID uint32, increment int) assetCounter {
-	c[assetID] = c[assetID] + increment
-	return c
+// count registers a new asset.
+func (c assetMap) count(assetID uint32) {
+	c[assetID] = struct{}{}
 }
 
-// absorb adds the counts from another assetCounter to the current counts.
-func (c assetCounter) absorb(otherCounter assetCounter) assetCounter {
-	for assetID, count := range otherCounter {
-		c.add(assetID, count)
+// merge merges the entries of another assetMap.
+func (c assetMap) merge(other assetMap) {
+	for assetID := range other {
+		c[assetID] = struct{}{}
 	}
-	return c
 }


### PR DESCRIPTION
The asset balances should update on tip change regardless of new trade
actions that may have occurred.

e.g. even with on trade activity:

```
[TRC] CORE: notify: |DATA| (epoch) - Index: 266382840
[TRC] CORE: processing tip change for dcr
[TRC] CORE: notify: |DATA| (balance) balance updated
[TRC] CORE: notify: |DATA| (epoch) - Index: 266382841
```

Resolves https://github.com/decred/dcrdex/issues/620