### PR TITLE
client/asset/btc: sendrawtransaction syntax change

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -411,6 +411,8 @@ func tNewWallet(segwit bool) (*ExchangeWallet, *tRPCClient, func()) {
 	wallet.tipMtx.Lock()
 	wallet.currentTip = &block{height: client.GetBestBlockHeight(), hash: bestHash.String()}
 	wallet.tipMtx.Unlock()
+	wallet.useNewBalanceCmd = true // normally set on Connect
+	wallet.useNewSendRawTxCmd = true
 	go wallet.run(walletCtx)
 
 	return wallet, client, shutdown

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -6,7 +6,6 @@ package btc
 import (
 	"bytes"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -225,26 +224,11 @@ func (wc *walletClient) GetWalletInfo() (*GetWalletInfoResult, error) {
 	return wi, wc.call(methodGetWalletInfo, nil, wi)
 }
 
-// call is used internally to  marshal parmeters and send requests to  the RPC
-// server via (*rpcclient.Client).RawRequest. If `thing` is non-nil, the result
-// will be marshaled into `thing`.
+// call marshals parmeters and send requests to the RPC server via
+// rpcclient.RawRequest. If thing is non-nil, the result will be unmarshaled
+// into thing.
 func (wc *walletClient) call(method string, args anylist, thing interface{}) error {
-	params := make([]json.RawMessage, 0, len(args))
-	for i := range args {
-		p, err := json.Marshal(args[i])
-		if err != nil {
-			return err
-		}
-		params = append(params, p)
-	}
-	b, err := wc.node.RawRequest(method, params)
-	if err != nil {
-		return fmt.Errorf("rawrequest error: %v", err)
-	}
-	if thing != nil {
-		return json.Unmarshal(b, thing)
-	}
-	return nil
+	return call(wc.node, method, args, thing)
 }
 
 // serializeMsgTx serializes the wire.MsgTx.

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -18,8 +18,10 @@ const (
 	BipID = 2
 	// The default fee is passed to the user as part of the asset.WalletInfo
 	// structure.
-	defaultFee        = 8
-	minNetworkVersion = 180100
+	defaultFee             = 8
+	minNetworkVersion      = 180100
+	newSendrawtxNetVersion = 190000 // but LTC seems like they will jump straight from 0.18 to 0.20
+	newBalanceNetVersion   = 190000
 )
 
 var (
@@ -141,8 +143,9 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		ChainParams:        params,
 		Ports:              ports,
 		DefaultFallbackFee: defaultFee,
-		LegacyBalance:      true,
 		Segwit:             false,
+		NewBalanceNetVer:   newBalanceNetVersion,
+		NewSendRawTxNetVer: newSendrawtxNetVersion,
 	}
 
 	return btc.BTCCloneWallet(cloneCFG)


### PR DESCRIPTION
From node version 0.19, the `sendrawtransaction` RPC changed the
`allowHighFees` boolean argument to a `maxFeeRate` numeric argument.
btcd's rpclient detects which to use depending on the version obtained
from `getnetworkinfo`, however this detection is broken for nodes that
report a subversion that is not of the form "/Satoshi:0.20.1/". For
example, rpcclient fails to recognize "/LitecoinCore:0.20.1/" as
requiring the boolean argument and tries to send a numberic fee rate.

To fix this, implement `sendrawtransaction` with `rawrequest`.
The `(*ExchangeWallet).SendRawTransaction` method will use the correct
argument type according to the integer network version (e.g. 200100)
detected on `ExchangeWallet` construction.

Tested with:
- litecoind v0.18.1
- litecoind v0.20.0.0-649aea5fc from thrasher- branch
- bitcoind v0.20.1.0