### PR TITLE
client: track order fees

### DIFF
--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -238,7 +238,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 		FeeRate:   dexAsset.MaxFeeRate,
 	}
 
-	receipts, _, err := rig.gamma().Swap(swaps)
+	receipts, _, _, err := rig.gamma().Swap(swaps)
 	if err != nil {
 		t.Fatalf("error sending swap transaction: %v", err)
 	}
@@ -297,7 +297,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 		makeRedemption(contractValue*2, receipts[1], secretKey2),
 	}
 
-	_, _, err = rig.alpha().Redeem(redemptions)
+	_, _, _, err = rig.alpha().Redeem(redemptions)
 	if err != nil {
 		t.Fatalf("redemption error: %v", err)
 	}
@@ -355,7 +355,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 
 	time.Sleep(time.Second)
 
-	receipts, _, err = rig.gamma().Swap(swaps)
+	receipts, _, _, err = rig.gamma().Swap(swaps)
 	if err != nil {
 		t.Fatalf("error sending swap transaction: %v", err)
 	}

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -258,7 +258,7 @@ func runTest(t *testing.T, splitTx bool) {
 		FeeRate:   tDCR.MaxFeeRate,
 	}
 
-	receipts, _, err := rig.beta().Swap(swaps)
+	receipts, _, _, err := rig.beta().Swap(swaps)
 	if err != nil {
 		t.Fatalf("error sending swap transaction: %v", err)
 	}
@@ -324,7 +324,7 @@ func runTest(t *testing.T, splitTx bool) {
 		makeRedemption(contractValue*2, receipts[1], secretKey2),
 	}
 
-	_, _, err = rig.alpha().Redeem(redemptions)
+	_, _, _, err = rig.alpha().Redeem(redemptions)
 	if err != nil {
 		t.Fatalf("redemption error: %v", err)
 	}
@@ -381,7 +381,7 @@ func runTest(t *testing.T, splitTx bool) {
 		FeeRate:   tDCR.MaxFeeRate,
 	}
 
-	receipts, _, err = rig.beta().Swap(swaps)
+	receipts, _, _, err = rig.beta().Swap(swaps)
 	if err != nil {
 		t.Fatalf("error sending swap transaction: %v", err)
 	}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -83,10 +83,10 @@ type Wallet interface {
 	FundingCoins([]dex.Bytes) (Coins, error)
 	// Swap sends the swaps in a single transaction. The Receipts returned can
 	// be used to refund a failed transaction.
-	Swap(*Swaps) ([]Receipt, Coin, error)
+	Swap(*Swaps) (receipts []Receipt, changeCoin Coin, feesPaid uint64, err error)
 	// Redeem sends the redemption transaction, which may contain more than one
 	// redemption. The input coin IDs and the output Coin are returned.
-	Redeem(redeems []*Redemption) ([]dex.Bytes, Coin, error)
+	Redeem(redeems []*Redemption) (ins []dex.Bytes, out Coin, feesPaid uint64, err error)
 	// SignMessage signs the coin ID with the private key associated with the
 	// specified Coin. A slice of pubkeys required to spend the Coin and a
 	// signature for each pubkey are returned.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -62,15 +62,17 @@ var (
 		RateStep:     10,
 		SwapConf:     1,
 	}
-	tDexPriv         *secp256k1.PrivateKey
-	tDexKey          *secp256k1.PublicKey
-	tPW                     = []byte("dexpw")
-	wPW                     = "walletpw"
-	tDexHost                = "somedex.tld"
-	tDcrBtcMktName          = "dcr_btc"
-	tErr                    = fmt.Errorf("test error")
-	tFee             uint64 = 1e8
-	tUnparseableHost        = string([]byte{0x7f})
+	tDexPriv            *secp256k1.PrivateKey
+	tDexKey             *secp256k1.PublicKey
+	tPW                        = []byte("dexpw")
+	wPW                        = "walletpw"
+	tDexHost                   = "somedex.tld"
+	tDcrBtcMktName             = "dcr_btc"
+	tErr                       = fmt.Errorf("test error")
+	tFee                uint64 = 1e8
+	tUnparseableHost           = string([]byte{0x7f})
+	tSwapFeesPaid       uint64 = 500
+	tRedemptionFeesPaid uint64 = 350
 )
 
 type tMsg = *msgjson.Message
@@ -311,7 +313,7 @@ func (tdb *TDB) MarketOrders(dex string, base, quote uint32, n int, since uint64
 	return nil, nil
 }
 
-func (tdb *TDB) SetChangeCoin(order.OrderID, order.CoinID) error {
+func (tdb *TDB) UpdateOrderMetaData(order.OrderID, *db.OrderMetaData) error {
 	return nil
 }
 
@@ -556,13 +558,13 @@ func (w *TXCWallet) FundingCoins([]dex.Bytes) (asset.Coins, error) {
 	return w.fundingCoins, w.fundingCoinErr
 }
 
-func (w *TXCWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, error) {
+func (w *TXCWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, uint64, error) {
 	w.lastSwaps = swaps
-	return w.swapReceipts, w.changeCoin, nil
+	return w.swapReceipts, w.changeCoin, tSwapFeesPaid, nil
 }
 
-func (w *TXCWallet) Redeem([]*asset.Redemption) ([]dex.Bytes, asset.Coin, error) {
-	return w.redeemCoins, &tCoin{id: []byte{0x0c, 0x0d}}, nil
+func (w *TXCWallet) Redeem([]*asset.Redemption) ([]dex.Bytes, asset.Coin, uint64, error) {
+	return w.redeemCoins, &tCoin{id: []byte{0x0c, 0x0d}}, tRedemptionFeesPaid, nil
 }
 
 func (w *TXCWallet) SignMessage(asset.Coin, dex.Bytes) (pubkeys, sigs []dex.Bytes, err error) {
@@ -2431,6 +2433,15 @@ func TestTradeTracking(t *testing.T) {
 	checkStatus("maker match complete", order.MatchComplete)
 	if !bytes.Equal(redemptionCoin, proof.TakerRedeem) {
 		t.Fatalf("taker redemption coin not recorded")
+	}
+
+	// Check that fees were incremented appropriately.
+	if tracker.metaData.SwapFeesPaid != tSwapFeesPaid {
+		t.Fatalf("wrong fees recorded for swap. expected %d, got %d", tSwapFeesPaid, tracker.metaData.SwapFeesPaid)
+	}
+	// Check that fees were incremented appropriately.
+	if tracker.metaData.RedemptionFeesPaid != tRedemptionFeesPaid {
+		t.Fatalf("wrong fees recorded for redemption. expected %d, got %d", tRedemptionFeesPaid, tracker.metaData.SwapFeesPaid)
 	}
 
 	// TAKER MATCH

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -169,6 +169,10 @@ func (t *trackedTrade) coreOrderInternal() (*Order, *Order) {
 		Cancelling:  cancelling,
 		Canceled:    canceled,
 		TimeInForce: tif,
+		FeesPaid: &FeeBreakdown{
+			Swap:       t.metaData.SwapFeesPaid,
+			Redemption: t.metaData.RedemptionFeesPaid,
+		},
 	}
 	for _, match := range t.matches {
 		dbMatch := match.Match
@@ -178,6 +182,7 @@ func (t *trackedTrade) coreOrderInternal() (*Order, *Order) {
 			Rate:    dbMatch.Rate,
 			Qty:     dbMatch.Quantity,
 			Side:    dbMatch.Side,
+			FeeRate: dbMatch.FeeRateSwap,
 		})
 	}
 	var cancelOrder *Order
@@ -1030,7 +1035,7 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 		FeeRate:    highestFeeRate,
 		LockChange: t.changeLocked,
 	}
-	receipts, change, err := t.wallets.fromWallet.Swap(swaps)
+	receipts, change, fees, err := t.wallets.fromWallet.Swap(swaps)
 	if err != nil {
 		// Set the error on the matches.
 		for _, match := range matches {
@@ -1042,6 +1047,8 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 	log.Infof("Broadcasted transaction with %d swap contracts for order %v. Fee rate = %d. Receipts: %v",
 		len(receipts), t.ID(), swaps.FeeRate, receipts)
 
+	t.metaData.SwapFeesPaid += fees
+
 	if change == nil {
 		t.metaData.ChangeCoin = nil
 	} else {
@@ -1051,7 +1058,7 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 	t.change = change
 	log.Debugf("Saving change coin %v (%v) to DB for order %v",
 		coinIDString(fromAsset.ID, t.metaData.ChangeCoin), fromAsset.Symbol, t.ID())
-	t.db.SetChangeCoin(t.ID(), t.metaData.ChangeCoin)
+	t.db.UpdateOrderMetaData(t.ID(), t.metaData)
 
 	// Process the swap for each match by sending the `init` request
 	// to the DEX and updating the match with swap details.
@@ -1145,7 +1152,7 @@ func (t *trackedTrade) redeemMatches(matches []*matchTracker) error {
 
 	// Send the transaction.
 	redeemWallet, redeemAsset := t.wallets.toWallet, t.wallets.toAsset // this is our redeem
-	coinIDs, outCoin, err := redeemWallet.Redeem(redemptions)
+	coinIDs, outCoin, fees, err := redeemWallet.Redeem(redemptions)
 	// If an error was encountered, fail all of the matches. A failed match will
 	// not run again on during ticks.
 	if err != nil {
@@ -1157,6 +1164,13 @@ func (t *trackedTrade) redeemMatches(matches []*matchTracker) error {
 
 	log.Infof("Broadcasted redeem transaction spending %d contracts for order %v, paying to %s:%s",
 		len(redemptions), t.ID(), redeemAsset.Symbol, outCoin)
+
+	t.metaData.RedemptionFeesPaid += fees
+
+	err = t.db.UpdateOrderMetaData(t.ID(), t.metaData)
+	if err != nil {
+		log.Errorf("error updating order metadata for order %s: %w", t.ID(), err)
+	}
 
 	for _, match := range matches {
 		log.Infof("Match %s complete: %s %d %s", match.id,

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -110,6 +110,7 @@ type Match struct {
 	Rate    uint64            `json:"rate"`
 	Qty     uint64            `json:"qty"`
 	Side    order.MatchSide   `json:"side"`
+	FeeRate uint64            `json:"feeRate"`
 }
 
 // Order is core's general type for an order. An order may be a market, limit,
@@ -129,9 +130,16 @@ type Order struct {
 	Matches     []*Match          `json:"matches"`
 	Cancelling  bool              `json:"cancelling"`
 	Canceled    bool              `json:"canceled"`
+	FeesPaid    *FeeBreakdown     `json:"feesPaid"`
 	Rate        uint64            `json:"rate"`               // limit only
 	TimeInForce order.TimeInForce `json:"tif"`                // limit only
 	TargetID    string            `json:"targetID,omitempty"` // cancel only
+}
+
+// FeeBreakdown is categorized fee information.
+type FeeBreakdown struct {
+	Swap       uint64 `json:"swap"`
+	Redemption uint64 `json:"redemption"`
 }
 
 // Market is market info.

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -59,8 +59,8 @@ type DB interface {
 	// returned. since = 0 is equivalent to disabling the time filter, since
 	// no orders were created before before 1970.
 	MarketOrders(dex string, base, quote uint32, n int, since uint64) ([]*MetaOrder, error)
-	// SetChangeCoin stores the change coin for the order.
-	SetChangeCoin(order.OrderID, order.CoinID) error
+	// UpdateOrderMetaData updates the order metadata, not including the Host.
+	UpdateOrderMetaData(order.OrderID, *OrderMetaData) error
 	// UpdateOrderStatus sets the order status for an order.
 	UpdateOrderStatus(oid order.OrderID, status order.OrderStatus) error
 	// LinkOrder sets the LinkedOrder field of the specified order's

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -183,6 +183,11 @@ type OrderMetaData struct {
 	// LinkedOrder is used to specify the cancellation order for a trade, or
 	// vice-versa.
 	LinkedOrder order.OrderID
+	// SwapFeesPaid is the sum of the actual fees paid for all swaps.
+	SwapFeesPaid uint64
+	// RedemptionFeesPaid is the sum of the actual fees paid for all
+	// redemptions.
+	RedemptionFeesPaid uint64
 }
 
 // MetaMatch is the match and its metadata.

--- a/client/webserver/site/webpack/analyze.js
+++ b/client/webserver/site/webpack/analyze.js
@@ -1,4 +1,4 @@
-const merge = require('webpack-merge')
+const { merge } = require('webpack-merge')
 const common = require('./common.js')
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 

--- a/dex/order/match.go
+++ b/dex/order/match.go
@@ -156,7 +156,7 @@ type Match struct {
 }
 
 // A UserMatch is similar to a Match, but contains less information about the
-// counter-party, and is clarifies which side the user is on. This is the
+// counter-party, and it clarifies which side the user is on. This is the
 // information that might be provided to the client when they are resyncing
 // their matches after a reconnect.
 type UserMatch struct {


### PR DESCRIPTION
Modifies the `client/asset.Wallet` interface to return realized fees for the `Swap` and `Redeem` methods. Tracks the fees in **core**. Fee data is persisted in client DB.

Unfortunately requires a client DB wipe.