### PR TITLE
server: new user cancel ratio exception

### DIFF
--- a/server/account/account.go
+++ b/server/account/account.go
@@ -93,9 +93,9 @@ const (
 	// FailureToAct means that an account has not followed through on one of their
 	// swap negotiation steps.
 	FailureToAct
-	// CancellationRatio means the account's cancellation ratio has dropped below
+	// CancellationRate means the account's cancellation rate  has dropped below
 	// the acceptable level.
-	CancellationRatio
+	CancellationRate
 	// LowFees means an account made a transaction that didn't pay fees at the
 	// requisite level.
 	LowFees

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"sync"
 	"time"
 

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -939,7 +939,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 		suspended:    !open,
 	}
 	cancels, completions, rate, penalize := auth.checkCancelRate(client)
-	if penalize && !auth.anarchy {
+	if penalize && open && !auth.anarchy {
 		// Account should already be closed, but perhaps the server crashed
 		// or the account was not penalized before shutdown.
 		client.suspended = true

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -277,7 +277,7 @@ func (auth *AuthManager) recordOrderDone(user account.AccountID, oid order.Order
 
 	// Recompute cancellation and penalize violation.
 	cancels, completions, rate, penalize := auth.checkCancelRate(client)
-	log.Tracef("User %v cancellation rate is now %v (%d:%d). Violation = %v", user,
+	log.Tracef("User %v cancellation rate is now %v (%d cancels : %d successes). Violation = %v", user,
 		rate, cancels, completions, penalize)
 	if penalize && !auth.anarchy && !client.suspended {
 		log.Infof("Suspending user %v for exceeding the cancellation rate threshold %.2f%%. "+
@@ -946,7 +946,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 		// The account might now be closed if the cancellation rate was
 		// exceeded while the server was running in anarchy mode.
 		auth.storage.CloseAccount(acctInfo.ID, account.CancellationRate)
-		log.Debugf("Suspended account %v (cancellation rate = %d:%d = %.2f%%) connected.",
+		log.Debugf("Suspended account %v (cancellation rate = %.2f%%, %d cancels : %d successes) connected.",
 			acctInfo.ID, cancels, completions, 100*rate)
 	}
 

--- a/server/auth/cancel.go
+++ b/server/auth/cancel.go
@@ -97,11 +97,10 @@ func (lo *latestOrders) add(o *oidStamped) {
 	if i == int(lo.cap) /* i == n && n == int(lo.cap) */ {
 		// The new one is the oldest/smallest, but already at capacity.
 		return
-	} else {
-		// Insert at proper location.
-		i = n - i // i-1 is first location that stays
-		lo.orders = append(lo.orders[:i], append([]*oidStamped{o}, lo.orders[i:]...)...)
 	}
+	// Insert at proper location.
+	i = n - i // i-1 is first location that stays
+	lo.orders = append(lo.orders[:i], append([]*oidStamped{o}, lo.orders[i:]...)...)
 
 	// Pop one order if the slice was at capacity prior to pushing the new one.
 	if len(lo.orders) > int(lo.cap) {

--- a/server/auth/cancel_test.go
+++ b/server/auth/cancel_test.go
@@ -14,7 +14,7 @@ func randomOrderID() (oid order.OrderID) {
 }
 
 func Test_latestOrders(t *testing.T) {
-	cap := int16(25)
+	cap := int16(cancelThreshWindow)
 	ordList := newLatestOrders(cap)
 
 	maybeCancel := func() *order.OrderID {

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -49,7 +49,7 @@ const (
 	defaultRPCPort             = "7232"
 	defaultAdminSrvAddr        = "127.0.0.1:6542"
 
-	defaultCancelThresh     = 0.6
+	defaultCancelThresh     = 8.0
 	defaultRegFeeConfirms   = 4
 	defaultRegFeeAmount     = 1e8
 	defaultBroadcastTimeout = time.Minute

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -49,7 +49,7 @@ const (
 	defaultRPCPort             = "7232"
 	defaultAdminSrvAddr        = "127.0.0.1:6542"
 
-	defaultCancelThresh     = 8.0
+	defaultCancelThresh     = 0.95 // 19 cancels : 1 success
 	defaultRegFeeConfirms   = 4
 	defaultRegFeeAmount     = 1e8
 	defaultBroadcastTimeout = time.Minute
@@ -118,7 +118,7 @@ type flagsData struct {
 	RegFeeXPub       string        `long:"regfeexpub" description:"The extended public key for deriving Decred addresses to which DEX registration fees should be paid."`
 	RegFeeConfirms   int64         `long:"regfeeconfirms" description:"The number of confirmations required to consider a registration fee paid."`
 	RegFeeAmount     uint64        `long:"regfeeamount" description:"The registration fee amount in atoms."`
-	CancelThreshold  float64       `long:"cancelthresh" description:"Cancellation ratio threshold (cancels/completed)."`
+	CancelThreshold  float64       `long:"cancelthresh" description:"Cancellation rate threshold (cancels/all_completed)."`
 	Anarchy          bool          `long:"anarchy" description:"Do not enforce any rules."`
 	DEXPrivKeyPath   string        `long:"dexprivkeypath" description:"The path to a file containing the DEX private key for message signing."`
 

--- a/server/db/driver/pg/orders_online_test.go
+++ b/server/db/driver/pg/orders_online_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
+const cancelThreshWindow = 100 // spec
+
 func TestStoreOrder(t *testing.T) {
 	if err := cleanTables(archie.db); err != nil {
 		t.Fatalf("cleanTables: %v", err)
@@ -436,7 +438,7 @@ func TestFlushBook(t *testing.T) {
 		t.Fatalf("got %d user orders, expected %d", len(ordersOut), wantNumOrders)
 	}
 
-	coids, targets, _, err := archie.ExecutedCancelsForUser(lo.User(), 25)
+	coids, targets, _, err := archie.ExecutedCancelsForUser(lo.User(), cancelThreshWindow)
 	if err != nil {
 		t.Errorf("ExecutedCancelsForUser failed: %v", err)
 	}
@@ -452,7 +454,7 @@ func TestFlushBook(t *testing.T) {
 	// Query for the revoke associated cancels without the exemption filter.
 	cancelTableName := fullCancelOrderTableName(archie.dbName, mktInfo.Name, false)
 	stmt := fmt.Sprintf(internal.SelectRevokeCancels, cancelTableName)
-	rows, err := archie.db.QueryContext(context.Background(), stmt, lo.User(), orderStatusRevoked, 25)
+	rows, err := archie.db.QueryContext(context.Background(), stmt, lo.User(), orderStatusRevoked, cancelThreshWindow)
 	if err != nil {
 		t.Fatalf("QueryContext failed: %v", err)
 	}
@@ -1430,7 +1432,7 @@ func TestCompletedUserOrders(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oids, compTimes, err := archie.CompletedUserOrders(tt.acctID, 25)
+			oids, compTimes, err := archie.CompletedUserOrders(tt.acctID, cancelThreshWindow)
 			if err != tt.wantedErr {
 				t.Fatal(err)
 			}
@@ -1546,7 +1548,7 @@ func TestExecutedCancelsForUser(t *testing.T) {
 	}
 
 	user := co.User()
-	oids, targets, compTimes, err := archie.ExecutedCancelsForUser(user, 25)
+	oids, targets, compTimes, err := archie.ExecutedCancelsForUser(user, cancelThreshWindow)
 	if err != nil {
 		t.Errorf("ExecutedCancelsForUser failed: %v", err)
 	}
@@ -1595,7 +1597,7 @@ func TestExecutedCancelsForUser(t *testing.T) {
 	}
 
 	user2 := co2.User()
-	oids, targets, compTimes, err = archie.ExecutedCancelsForUser(user2, 25)
+	oids, targets, compTimes, err = archie.ExecutedCancelsForUser(user2, cancelThreshWindow)
 	if err != nil {
 		t.Errorf("ExecutedCancelsForUser failed: %v", err)
 	}
@@ -1631,7 +1633,7 @@ func TestExecutedCancelsForUser(t *testing.T) {
 	}
 
 	user3 := co3.User()
-	oids, targets, compTimes, err = archie.ExecutedCancelsForUser(user3, 25)
+	oids, targets, compTimes, err = archie.ExecutedCancelsForUser(user3, cancelThreshWindow)
 	if err != nil {
 		t.Errorf("ExecutedCancelsForUser failed: %v", err)
 	}
@@ -1653,7 +1655,7 @@ func TestExecutedCancelsForUser(t *testing.T) {
 	}
 
 	user4 := co4.User()
-	oids, targets, compTimes, err = archie.ExecutedCancelsForUser(user4, 25)
+	oids, targets, compTimes, err = archie.ExecutedCancelsForUser(user4, cancelThreshWindow)
 	if err != nil {
 		t.Errorf("ExecutedCancelsForUser failed: %v", err)
 	}

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -358,16 +358,19 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		return nil, fmt.Errorf("db.Open: %v", err)
 	}
 
+	cancelThresh := cfg.CancelThreshold
 	authCfg := auth.Config{
 		Storage:         storage,
 		Signer:          cfg.DEXPrivKey,
 		RegistrationFee: cfg.RegFeeAmount,
 		FeeConfs:        cfg.RegFeeConfirms,
 		FeeChecker:      dcrBackend.FeeCoin,
-		CancelThreshold: cfg.CancelThreshold,
+		CancelThreshold: cancelThresh,
 		Anarchy:         cfg.Anarchy,
 	}
 
+	log.Infof("Cancellation ratio threshold %f, new user grace period %d cancels",
+		cancelThresh, int(cancelThresh))
 	authMgr := auth.NewAuthManager(&authCfg)
 	startSubSys("Auth manager", authMgr)
 

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -369,10 +369,11 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		Anarchy:         cfg.Anarchy,
 	}
 
-	log.Infof("Cancellation ratio threshold %f, new user grace period %d cancels",
-		cancelThresh, int(cancelThresh))
 	authMgr := auth.NewAuthManager(&authCfg)
 	startSubSys("Auth manager", authMgr)
+
+	log.Infof("Cancellation rate threshold %f, new user grace period %d cancels",
+		cancelThresh, authMgr.GraceLimit())
 
 	// Create an unbook dispatcher for the Swapper.
 	markets := make(map[string]*market.Market, len(cfg.Markets))

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1314,7 +1314,7 @@ func (m *Market) Unbook(lo *order.LimitOrder) bool {
 	}
 
 	// Create the server-generated cancel order, and register it with
-	// the AuthManager for cancellation ratio computation.
+	// the AuthManager for cancellation rate computation.
 	coid, revTime, err := m.storage.RevokeOrder(lo)
 	if err == nil {
 		m.auth.RecordCancel(lo.User(), coid, lo.ID(), revTime)
@@ -1382,7 +1382,7 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 	}
 
 	// Store data in epochs table, including matchTime so that cancel execution
-	// times can be obtained from the DB for cancellation ratio computation.
+	// times can be obtained from the DB for cancellation rate computation.
 	oidsRevealed := make([]order.OrderID, 0, len(ordersRevealed))
 	for _, or := range ordersRevealed {
 		oidsRevealed = append(oidsRevealed, or.Order.ID())

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -169,7 +169,7 @@ type orderSwapStat struct {
 	HasFailed bool
 }
 
-// orderSwapTracker facilitates cancellation ratio computation without complex,
+// orderSwapTracker facilitates cancellation rate computation without complex,
 // costly, and frequent DB queries.
 type orderSwapTracker struct {
 	mtx          sync.Mutex
@@ -1068,7 +1068,7 @@ func (s *Swapper) processBlock(block *blockNotification) {
 
 	for _, match := range completions {
 		// Note that orders are not considered completed for the purposes of
-		// cancellation ratio until the user sends their redeem ack.
+		// cancellation rate until the user sends their redeem ack.
 
 		s.unlockOrderCoins(match.Taker)
 		s.unlockOrderCoins(match.Maker)
@@ -1494,7 +1494,7 @@ func (s *Swapper) processAck(msg *msgjson.Message, acker *messageAcker) {
 	defer s.rmLiveAckers(msg.ID)
 
 	// The time that the ack is received is stored for redeem acks to facilitate
-	// cancellation ratio enforcement.
+	// cancellation rate enforcement.
 	tAck := time.Now()
 
 	ack := new(msgjson.Acknowledgement)


### PR DESCRIPTION
server/auth: cancel ratio grace period

Implement the new user grace period by not enforcing until
total / (1+total) > threshold

This also begins enforcing the cancellation ratio as orders are canceled
and orders fully settled.  Previously it was just checked on connect.

The default latest orders window is now 100, up from 25.

The spec changes are in https://github.com/decred/dcrdex/pull/671