### PR TITLE
app: order book table and chart fixes

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -61,7 +61,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=VBByg6"></script>
+<script src="/js/entry.js?v=Y16ori"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -1045,12 +1045,13 @@ export default class MarketsPage extends BasePage {
 
   /* removeTableOrder removes a single order from its table. */
   removeTableOrder (order) {
-    const tbody = order.sell ? this.page.sellRows : this.page.buyRows
     const token = order.token
-    for (const tr of Array.from(tbody.children)) {
-      if (tr.order.token === token) {
-        tr.remove()
-        return
+    for (const tbody of [this.page.sellRows, this.page.buyRows]) {
+      for (const tr of Array.from(tbody.children)) {
+        if (tr.order.token === token) {
+          tr.remove()
+          return
+        }
       }
     }
   }

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -504,7 +504,8 @@ export default class MarketsPage extends BasePage {
 
   /* handleBook accepts the data sent in the 'book' notification. */
   handleBook (data) {
-    this.book = new OrderBook(data, this.market.baseCfg.symbol, this.market.quoteCfg.symbol)
+    const [b, q] = [this.market.baseCfg, this.market.quoteCfg]
+    this.book = new OrderBook(data, b.symbol, q.symbol)
     this.loadTable()
     for (const order of (data.book.epoch || [])) {
       if (order.rate > 0) this.book.add(order)
@@ -516,7 +517,7 @@ export default class MarketsPage extends BasePage {
       Doc.empty(this.page.sellRows)
       return
     }
-    this.chart.set(this.book)
+    this.chart.set(this.book, b.lotSize, q.rateStep)
   }
 
   /*


### PR DESCRIPTION
1. Fixes a bug with order unbooking that was leaving orders in the sell table 
2. Depth chart now maintains a fixed zoom (#625)
3. Depth chart tick marks now align with increments of lot size and rate step
