### PR TITLE
client/core,asset: ensure coins are unlocked when no longer needed

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -901,11 +901,11 @@ func (btc *ExchangeWallet) Lock() error {
 }
 
 // fundedTx creates and returns a new MsgTx with the provided coins as inputs.
-func (btc *ExchangeWallet) fundedTx(coins asset.Coins) (*wire.MsgTx, uint64, []*output, error) {
+func (btc *ExchangeWallet) fundedTx(coins asset.Coins) (*wire.MsgTx, uint64, []outPoint, error) {
 	baseTx := wire.NewMsgTx(wire.TxVersion)
 	var totalIn uint64
 	// Add the funding utxos.
-	pts := make([]*output, 0, len(coins))
+	pts := make([]outPoint, 0, len(coins))
 	for _, coin := range coins {
 		op, err := btc.convertCoin(coin)
 		if err != nil {
@@ -917,21 +917,20 @@ func (btc *ExchangeWallet) fundedTx(coins asset.Coins) (*wire.MsgTx, uint64, []*
 		totalIn += op.value
 		txIn := wire.NewTxIn(op.wireOutPoint(), []byte{}, nil)
 		baseTx.AddTxIn(txIn)
-		pts = append(pts, op)
+		pts = append(pts, op.pt)
 	}
 	return baseTx, totalIn, pts, nil
 }
 
-// Swap sends the swaps in a single transaction. The Receipts returned can be
-// used to refund a failed transaction. The Input coins are perfunctorily
-// unlocked to ensure accurate balance reporting in cases where the wallet
-// includes spent coins as part of the locked balance just because they were
-// previously locked.
+// Swap sends the swaps in a single transaction and prepares the receipts. The
+// Receipts returned can be used to refund a failed transaction. The Input coins
+// are NOT manually unlocked because they're auto-unlocked when the transaction
+// is broadcasted.
 func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, uint64, error) {
 	contracts := make([][]byte, 0, len(swaps.Contracts))
 	var totalOut uint64
 	// Start with an empty MsgTx.
-	baseTx, totalIn, spentOps, err := btc.fundedTx(swaps.Inputs)
+	baseTx, totalIn, pts, err := btc.fundedTx(swaps.Inputs)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -1033,10 +1032,9 @@ func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	}
 
 	// Delete the UTXOs from the cache.
-	for _, spentOp := range spentOps {
-		delete(btc.fundingCoins, spentOp.pt)
+	for _, pt := range pts {
+		delete(btc.fundingCoins, pt)
 	}
-	btc.wallet.LockUnspent(true, spentOps)
 
 	return receipts, changeCoin, fees, nil
 }

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -961,10 +961,9 @@ func (dcr *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 }
 
 // Swap sends the swaps in a single transaction. The Receipts returned can be
-// used to refund a failed transaction. The Input coins are perfunctorily
-// unlocked to ensure accurate balance reporting in cases where the wallet
-// includes spent coins as part of the locked balance just because they were
-// previously locked.
+// used to refund a failed transaction. The Input coins are manually unlocked
+// because they're not auto-unlocked by the wallet and therefore inaccurately
+// included as part of the locked balance despite being spent.
 func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, uint64, error) {
 	var totalOut uint64
 	// Start with an empty MsgTx.

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -961,7 +961,10 @@ func (dcr *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 }
 
 // Swap sends the swaps in a single transaction. The Receipts returned can be
-// used to refund a failed transaction.
+// used to refund a failed transaction. The Input coins are perfunctorily
+// unlocked to ensure accurate balance reporting in cases where the wallet
+// includes spent coins as part of the locked balance just because they were
+// previously locked.
 func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, uint64, error) {
 	var totalOut uint64
 	// Start with an empty MsgTx.

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"decred.org/dcrdex/client/asset"
@@ -336,15 +335,13 @@ type ExchangeWallet struct {
 	log             dex.Logger
 	acct            string
 	tipChange       func(error)
-	hasConnected    uint32
 	fallbackFeeRate uint64
 	useSplitTx      bool
 
 	tipMtx     sync.RWMutex
 	currentTip *block
 
-	// Coins returned by Fund are cached for quick reference and for cleanup on
-	// shutdown.
+	// Coins returned by Fund are cached for quick reference.
 	fundingMtx   sync.RWMutex
 	fundingCoins map[outPoint]*fundingCoin
 	splitFunds   map[outPoint][]*fundingCoin
@@ -505,14 +502,6 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 	dcr.log.Infof("Connected to dcrwallet (JSON-RPC API v%s) proxying dcrd (JSON-RPC API v%s) on %v",
 		walletSemver, nodeSemver, curnet)
 
-	// If this is the first time connecting, clear the locked coins. This should
-	// have been done at shutdown, but shutdown may not have been clean.
-	if atomic.SwapUint32(&dcr.hasConnected, 1) == 0 {
-		err := dcr.node.LockUnspent(true, nil)
-		if err != nil {
-			return nil, err
-		}
-	}
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -613,7 +602,11 @@ func (dcr *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, error) {
 
 	// Send a split, if preferred.
 	if dcr.useSplitTx && !ord.Immediate {
-		return dcr.split(ord.Value, ord.MaxSwapCount, coins, inputsSize, fundingCoins, ord.DEXConfig)
+		splitCoins, err := dcr.split(ord.Value, ord.MaxSwapCount, coins, inputsSize, fundingCoins, ord.DEXConfig)
+		if err != nil {
+			dcr.returnCoins(coins)
+		}
+		return splitCoins, err
 	}
 
 	dcr.log.Infof("Funding %d atom order with coins %v worth %d", ord.Value, coins, sum)
@@ -816,6 +809,19 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 	// spent immediately, so subsequent calls to FundOrder might result in a
 	// `-4: rejected transaction: transaction in the pool already spends the
 	// same coins` error.
+	// TODO: Could this cause balance report inaccuracy, where the locked atoms
+	// returned by dcrwallet includes both the funding coins and the split tx
+	// output?
+	// E.g. total of 100 DCR (locked) split to produce a desired output of 40 DCR
+	// that is also locked:
+	// dcr balance before split, total = 200 DCR, locked = 0
+	// dcr balance after split, total = 199 DCR (-split tx fee), locked = 140 DCR
+	// If this inaccurate report is a possibility, might be better to unlock the
+	// funding coins sooner rather than later and prevent FundOrder double spends
+	// by checking listunspent results against `dcr.splitFunds`.
+	// If the split fund txout is later unlocked without being spent, the initial
+	// funding coins will be deleted from dcr.splitFunds, making them re-spendable
+	// by dcr.FundOrder.
 	// // Unlock the spent coins.
 	// err = dcr.returnCoins(coins)
 	// if err != nil {
@@ -1759,13 +1765,7 @@ func (dcr *ExchangeWallet) addInputCoins(msgTx *wire.MsgTx, coins asset.Coins) (
 	return totalIn, nil
 }
 
-// Shutdown down the rpcclient.Client.
 func (dcr *ExchangeWallet) shutdown() {
-	// Unlock any locked outputs.
-	err := dcr.node.LockUnspent(true, nil)
-	if err != nil {
-		dcr.log.Errorf("failed to unlock DCR outputs on shutdown: %v", err)
-	}
 	// Close all open channels for contract redemption searches
 	// to prevent leakages and ensure goroutines that are started
 	// to wait on these channels end gracefully.
@@ -1775,6 +1775,8 @@ func (dcr *ExchangeWallet) shutdown() {
 		delete(dcr.findRedemptionQueue, contractOutpoint)
 	}
 	dcr.findRedemptionMtx.Unlock()
+
+	// Shut down the rpcclient.Client.
 	if dcr.client != nil {
 		dcr.client.Shutdown()
 		dcr.client.WaitForShutdown()

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -82,8 +82,8 @@ type Wallet interface {
 	// transaction outputs.
 	FundingCoins([]dex.Bytes) (Coins, error)
 	// Swap sends the swaps in a single transaction. The Receipts returned can
-	// be used to refund a failed transaction. The Input coins are perfunctorily
-	// unlocked to ensure accurate balance reporting in cases where the wallet
+	// be used to refund a failed transaction. The Input coins are unlocked where
+	// necessary to ensure accurate balance reporting in cases where the wallet
 	// includes spent coins as part of the locked balance just because they were
 	// previously locked.
 	Swap(*Swaps) (receipts []Receipt, changeCoin Coin, feesPaid uint64, err error)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -82,7 +82,10 @@ type Wallet interface {
 	// transaction outputs.
 	FundingCoins([]dex.Bytes) (Coins, error)
 	// Swap sends the swaps in a single transaction. The Receipts returned can
-	// be used to refund a failed transaction.
+	// be used to refund a failed transaction. The Input coins are perfunctorily
+	// unlocked to ensure accurate balance reporting in cases where the wallet
+	// includes spent coins as part of the locked balance just because they were
+	// previously locked.
 	Swap(*Swaps) (receipts []Receipt, changeCoin Coin, feesPaid uint64, err error)
 	// Redeem sends the redemption transaction, which may contain more than one
 	// redemption. The input coin IDs and the output Coin are returned.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2662,6 +2662,7 @@ func TestTradeTracking(t *testing.T) {
 		tracker.matches = make(map[order.MatchID]*matchTracker)
 		tracker.change = nil
 		tracker.metaData.ChangeCoin = nil
+		tracker.coinsLocked = true
 	}
 
 	// If there is no change coin and no matches, the funding coin should be
@@ -3828,6 +3829,7 @@ func TestHandleTradeSuspensionMsg(t *testing.T) {
 	swappedTracker := addTracker(nil)
 	changeCoinID := encode.RandomBytes(36)
 	swappedTracker.change = &tCoin{id: changeCoinID}
+	swappedTracker.changeLocked = true
 	_ = rig.dc.resume(tDcrBtcMktName)
 	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.SuspensionRoute, newPayload())
 	err = handleTradeSuspensionMsg(rig.core, rig.dc, req)
@@ -3839,7 +3841,7 @@ func TestHandleTradeSuspensionMsg(t *testing.T) {
 	// Check that the funding coin was returned.
 	dc.tradeMtx.Lock()
 	if len(tDcrWallet.returnedCoins) != 1 || !bytes.Equal(tDcrWallet.returnedCoins[0].ID(), changeCoinID) {
-		t.Fatalf("funding coin not returned")
+		t.Fatalf("change coin not returned")
 	}
 	tDcrWallet.returnedCoins = nil
 	dc.tradeMtx.Unlock()

--- a/dex/order/status.go
+++ b/dex/order/status.go
@@ -22,7 +22,7 @@ const (
 	// such, when an order with this "booked" status is matched with another
 	// order, it should have its filled amount updated, and its status should
 	// only be changed to OrderStatusExecuted if the remaining quantity becomes
-	// less than the lot size, or perhaps to OrderStatusCanceled if the swap has
+	// less than the lot size, or perhaps to OrderStatusRevoked if the swap has
 	// failed and DEX conduct policy requires that it be removed from the order
 	// book.
 	OrderStatusBooked

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1307,6 +1307,10 @@ func (m *Market) Unbook(lo *order.LimitOrder) bool {
 	_, removed := m.book.Remove(lo.ID())
 	m.bookMtx.Unlock()
 
+	// TODO: Should not unlock coins if there are active/unrevoked
+	// matches for this order and no swaps have been sent.
+	// If any swap has been sent, the funding coins would have been
+	// spent and it would be theoretically safe to unlock the coins.
 	m.unlockOrderCoins(lo)
 
 	if !removed {

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1307,10 +1307,6 @@ func (m *Market) Unbook(lo *order.LimitOrder) bool {
 	_, removed := m.book.Remove(lo.ID())
 	m.bookMtx.Unlock()
 
-	// TODO: Should not unlock coins if there are active/unrevoked
-	// matches for this order and no swaps have been sent.
-	// If any swap has been sent, the funding coins would have been
-	// spent and it would be theoretically safe to unlock the coins.
 	m.unlockOrderCoins(lo)
 
 	if !removed {


### PR DESCRIPTION
Coins are currently unlocked when
- a market order or limit order with tif immediate does not get matched
- an order is canceled (i.e. by user action)
- a market is suspended with persist=false

Other times to unlock coins (implemented in this PR):
- when new orders could not be submitted to the server, e.g. if sending the
  request or validating the server's response fails.
- when all matches are either swapped or revoked for unbooked orders, i.e.
  orders that will not receive future matches.
- after sending a swap, unlock the spent outputs to ensure accurate balance
  reporting.

~Also revoke orders in UnbookOrder note handler to ensure that coins are
unlocked for server-revoked orders. If such orders remain at status Booked,
their coins will never be unlocked because the expectation would be that the
order would receive new matches in the future.~

UPDATE: As @chappjc pointed out, revoking orders in the UnbookOrder note
handler is a hack at best, and not a very good one. The client currently has no
way of detecting revoked orders; with the implication that coins for such orders
will remain perpetually locked.

Resolves #631.