### PR TITLE
server/auth,multi: connect resp excludes revoked match requests

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -621,11 +621,12 @@ out:
 		utxos = utxos[:len(utxos)-1]
 	}
 
-	btc.log.Debugf("funding %d %s order with coins %v worth %d", ord.Value, btc.walletInfo.Units, coins, sum)
-
 	if btc.useSplitTx && !ord.Immediate {
 		return btc.split(ord.Value, ord.MaxSwapCount, spents, uint64(size), fundingCoins, ord.DEXConfig)
 	}
+
+	btc.log.Infof("Funding %d %s order with coins %v worth %d",
+		ord.Value, btc.walletInfo.Units, coins, sum)
 
 	err = btc.wallet.LockUnspent(false, spents)
 	if err != nil {
@@ -685,7 +686,10 @@ func (btc *ExchangeWallet) split(value uint64, lots uint64, outputs []*output, i
 
 	excess := coinSum - calc.RequiredOrderFunds(value, inputsSize, lots, nfo)
 	if baggageFees > excess {
-		btc.log.Infof("skipping split transaction because cost is greater than potential over-lock. %d > %d", baggageFees, excess)
+		btc.log.Debugf("Skipping split transaction because cost is greater than potential over-lock. "+
+			"%d > %d", baggageFees, excess)
+		btc.log.Infof("Funding %d %s order with coins %v worth %d",
+			value, btc.walletInfo.Units, coins, coinSum)
 		return coins, nil
 	}
 
@@ -733,7 +737,10 @@ func (btc *ExchangeWallet) split(value uint64, lots uint64, outputs []*output, i
 		input:        spendInfo,
 	}}
 
-	btc.log.Infof("sent split transaction %s to accommodate swap of size %d + fees = %d", op.txHash(), value, reqFunds)
+	btc.log.Infof("Funding %d %s order with split output coin %v from original coins %v",
+		value, btc.walletInfo.Units, op, coins)
+	btc.log.Infof("Sent split transaction %s to accommodate swap of size %d + fees = %d",
+		op.txHash(), value, reqFunds)
 
 	// Assign to coins so the deferred function will lock the output.
 	outputs = []*output{op}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -576,12 +576,12 @@ func (dcr *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, error) {
 			ord.Value, err)
 	}
 
-	dcr.log.Debugf("funding %d atom order with coins %v worth %d", ord.Value, coins, sum)
-
 	// Send a split, if preferred.
 	if dcr.useSplitTx && !ord.Immediate {
 		return dcr.split(ord.Value, ord.MaxSwapCount, coins, inputsSize, fundingCoins, ord.DEXConfig)
 	}
+
+	dcr.log.Infof("Funding %d atom order with coins %v worth %d", ord.Value, coins, sum)
 
 	return coins, nil
 }
@@ -741,8 +741,8 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 
 	excess := coinSum - calc.RequiredOrderFunds(value, inputsSize, lots, nfo)
 	if baggageFees > excess {
-		dcr.log.Infof("skipping split transaction because cost is greater than potential over-lock. %d > %d.", baggageFees, excess)
-		dcr.log.Debugf("funding %d atom order with coins %v", value, coins)
+		dcr.log.Debugf("Skipping split transaction because cost is greater than potential over-lock. %d > %d.", baggageFees, excess)
+		dcr.log.Infof("Funding %d atom order with coins %v worth", value, coins, coinSum)
 		return coins, nil
 	}
 
@@ -794,8 +794,8 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 	// Instead, we'll keep them locked until the split output is spent.
 	dcr.splitFunds[op.pt] = fundingCoins
 
-	dcr.log.Debugf("funding %d atom order with split output coin %v from original coins %v", value, op, coins)
-	dcr.log.Infof("sent split transaction %s to accommodate swap of size %d + fees = %d", op.txHash(), value, reqFunds)
+	dcr.log.Infof("Funding %d atom order with split output coin %v from original coins %v", value, op, coins)
+	dcr.log.Infof("Sent split transaction %s to accommodate swap of size %d + fees = %d", op.txHash(), value, reqFunds)
 
 	return asset.Coins{op}, nil
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1620,9 +1620,9 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 			for _, disabledAccountHost := range disabledAccountHosts {
 				c.conns[disabledAccountHost].connMaster.Disconnect()
 				delete(c.conns, disabledAccountHost)
-				log.Warnf("Account at dex: %v not found. The account has been "+
-					"disabled. It is disconnected and has been removed from core "+
-					"connections.", disabledAccountHost)
+				log.Warnf("Account at dex %v not found. The account has been disabled. "+
+					"It is disconnected and has been removed from core connections.",
+					disabledAccountHost)
 			}
 			c.connMtx.Unlock()
 		}

--- a/client/core/log.go
+++ b/client/core/log.go
@@ -8,6 +8,7 @@ import (
 	"decred.org/dcrdex/client/db/bolt"
 	orderbook "decred.org/dcrdex/client/order"
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/ws"
 )
 
 // log is a logger that is initialized with no output filters. This means the
@@ -23,6 +24,7 @@ func DisableLog() {
 // UseLogger uses a specified Logger to output package logging info.
 func UseLoggerMaker(maker *dex.LoggerMaker) {
 	log = maker.Logger("CORE")
+	ws.UseLogger(maker.Logger("WS"))
 	orderbook.UseLogger(maker.Logger("ORDBOOK"))
 	comms.UseLogger(maker.Logger("COMMS"))
 	bolt.UseLogger(maker.Logger("DB"))

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -305,9 +305,14 @@ func (t *trackedTrade) readConnectMatches(msgMatches []*msgjson.Match) {
 
 	for _, match := range t.matches {
 		if !ids[match.id] && match.MetaData.Status < order.MatchComplete {
-			log.Debugf("missing match: %v", match.id)
 			missing = append(missing, match.id)
 			match.failErr = fmt.Errorf("order not reported by the server on connect")
+			// Must have been revoked while we were gone. Flag to allow recovery
+			// and subsequent retirement of the match and parent trade.
+			match.MetaData.Proof.IsRevoked = true
+			if err := t.db.UpdateMatch(&match.MetaMatch); err != nil {
+				log.Errorf("Failed to update missing/revoked match: %v", err)
+			}
 		}
 	}
 
@@ -318,12 +323,13 @@ func (t *trackedTrade) readConnectMatches(msgMatches []*msgjson.Match) {
 		corder, _ := t.coreOrderInternal()
 		t.notify(newOrderNote("Missing matches", details, db.ErrorLevel, corder))
 		for _, mid := range missing {
-			log.Errorf("%s did not report active match %s on order %s", host, mid, t.ID())
+			log.Warnf("%s did not report active match %s on order %s", host, mid, t.ID())
 		}
 	}
 	if len(extras) > 0 {
 		details := fmt.Sprintf("%d matches reported by %s were not found for %s.", len(extras), host, t.token())
 		t.notify(newOrderNote("Match resolution error", details, db.ErrorLevel, corder))
+		// t.negotiate(extras) // missed match message request, but match not revoked (?!)
 		for _, extra := range extras {
 			log.Errorf("%s reported match %s which is not a known active match for order %s", host, extra.MatchID, extra.OrderID)
 		}
@@ -353,6 +359,14 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		copy(oid[:], msgMatch.OrderID)
 		if oid != t.ID() {
 			return fmt.Errorf("negotiate called for wrong order. %s != %s", oid, t.ID())
+		}
+		// Do not process matches with existing matchTrackers. e.g. In case we
+		// start "extra" matches from the 'connect' response negotiating via
+		// authDEX>readConnectMatches, and a subsequent resent 'match' request
+		// leads us here again or vice versa. Or just duplicate match requests.
+		if t.matches[mid] != nil {
+			log.Warnf("Skipping match %v that is already negotiating.", mid)
+			continue
 		}
 
 		// First check if this is a match with a cancel order, in which case the
@@ -475,7 +489,7 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		details := fmt.Sprintf("%s order on %s-%s %.1f%% filled (%s)",
 			strings.Title(sellString(trade.Sell)), unbip(t.Base()), unbip(t.Quote()), fillPct, t.token())
 		log.Debugf("Trade order %v matched with %d orders: +%d filled, total fill %d / %d (%.1f%%)",
-			t.ID(), len(msgMatches), newFill, filled, trade.Quantity, fillPct)
+			t.ID(), len(newTrackers), newFill, filled, trade.Quantity, fillPct)
 		t.notify(newOrderNote("Matches made", details, db.Poke, corder))
 	}
 

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1038,7 +1038,7 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 	for _, match := range t.matches {
 		if (match.Match.Side == order.Maker && match.Match.Status >= order.MakerSwapCast) ||
 			(match.Match.Side == order.Taker && match.Match.Status >= order.TakerSwapCast) {
-			alreadySwapped += 1
+			alreadySwapped++
 		}
 	}
 	// If these are the last swaps, and the order is filled or canceled or
@@ -1087,8 +1087,8 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 		return errs.add("error sending swap transaction: %v", err)
 	}
 
-	log.Infof("Broadcasted transaction with %d swap contracts for order %v. Fee rate = %d. Receipts: %v",
-		len(receipts), t.ID(), swaps.FeeRate, receipts)
+	log.Infof("Broadcasted transaction with %d swap contracts for order %v. Fee rate = %d. Receipts (%s): %v",
+		len(receipts), t.ID(), swaps.FeeRate, t.wallets.fromAsset.Symbol, receipts)
 
 	t.metaData.SwapFeesPaid += fees
 
@@ -1205,8 +1205,8 @@ func (t *trackedTrade) redeemMatches(matches []*matchTracker) error {
 		return errs.addErr(err)
 	}
 
-	log.Infof("Broadcasted redeem transaction spending %d contracts for order %v, paying to %s:%s",
-		len(redemptions), t.ID(), redeemAsset.Symbol, outCoin)
+	log.Infof("Broadcasted redeem transaction spending %d contracts for order %v, paying to %s (%s)",
+		len(redemptions), t.ID(), outCoin, redeemAsset.Symbol)
 
 	t.metaData.RedemptionFeesPaid += fees
 

--- a/client/websocket/websocket.go
+++ b/client/websocket/websocket.go
@@ -117,7 +117,7 @@ func (s *Server) HandleConnect(ctx context.Context, w http.ResponseWriter, r *ht
 		s.connect(ctx, wsConn, ip)
 	}()
 
-	s.log.Info("HandleConnect done.")
+	s.log.Trace("HandleConnect done.")
 }
 
 // connect handles a new websocket client by creating a new wsClient, starting

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -381,6 +381,28 @@ func (msg *Message) String() string {
 	return string(b)
 }
 
+// ExtractMatchID attempts to extract a "matchid" value from a request-typed
+// Message's Payload. The request must have one of the following routes:
+// AuditRoute, RedemptionRoute, RedeemRoute, MatchRoute, or RevokeMatchRoute.
+// A non-nil error is only returned if unmarshalling the payload fails.
+func (msg *Message) ExtractMatchID() (Bytes, error) {
+	// Name the targeted request routes.
+	switch msg.Route {
+	case AuditRoute, RedemptionRoute, RedeemRoute, MatchRoute,
+		RevokeMatchRoute:
+	default:
+		return nil, nil
+	}
+
+	var payload struct {
+		MatchID dex.Bytes `json:"matchid"`
+	}
+	if err := msg.Unmarshal(&payload); err != nil {
+		return nil, err
+	}
+	return payload.MatchID, nil
+}
+
 // Match is the params for a DEX-originating MatchRoute request.
 type Match struct {
 	Signature

--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -460,9 +460,7 @@ func NewConnection(w http.ResponseWriter, r *http.Request, readTimeout time.Dura
 	}
 
 	// Configure the pong handler.
-	reqAddr := r.RemoteAddr
 	ws.SetPongHandler(func(string) error {
-		log.Tracef("got pong from %v", reqAddr)
 		return ws.SetReadDeadline(time.Now().Add(readTimeout))
 	})
 

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -689,7 +689,7 @@ func (btc *Backend) Run(ctx context.Context) {
 			btc.log.Errorf("error adding new best block to cache: %v", err)
 		}
 		btc.signalMtx.RLock()
-		btc.log.Debugf("Notifying %d %s asset consumers of new block at height %d",
+		btc.log.Tracef("Notifying %d %s asset consumers of new block at height %d",
 			len(btc.blockChans), btc.name, block.Height)
 		for c := range btc.blockChans {
 			select {
@@ -757,7 +757,7 @@ out:
 			}
 			// If it builds on the best block or the cache is empty, it's good to add.
 			if *prevHash == tip.hash || tip.height == 0 {
-				btc.log.Debugf("Run: Processing new block %s", bestHash)
+				btc.log.Debugf("New block %s (%d)", bestHash, block.Height)
 				addBlock(block, false)
 				continue
 			}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -284,7 +284,11 @@ func (auth *AuthManager) Route(route string, handler func(account.AccountID, *ms
 				Message: "cannot use route '" + route + "' on an unauthorized connection",
 			}
 		}
-		return handler(client.acct.ID, msg)
+		msgErr := handler(client.acct.ID, msg)
+		if msgErr != nil {
+			log.Debugf("Handling of '%s' request for user %v failed: %v", route, client.acct.ID, msgErr)
+		}
+		return msgErr
 	})
 }
 

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -390,6 +391,13 @@ func (auth *AuthManager) rmUserConnectMsgs(user account.AccountID) []*pendingMes
 		// rmUserConnectMsg. Since we're here, we beat the timer.
 		tr.T.Stop()
 	}
+	// Non-request message IDs can be server-generated IDs for notifications, or
+	// client-generated request IDs for responses, so this sort only ensures
+	// that the same kind of messages (responses or notifications) are in order
+	// from oldest to newest, but the two types are potentially interleaved.
+	sort.Slice(msgs, func(i, j int) bool {
+		return msgs[i].msg.ID < msgs[j].msg.ID
+	})
 	delete(auth.pendingMessages, user)
 	return msgs
 }
@@ -537,6 +545,11 @@ func (auth *AuthManager) rmUserConnectReqs(user account.AccountID) []*pendingReq
 		tr.T.Stop()
 	}
 	delete(auth.pendingRequests, user)
+	// Request IDs are server generated and monotonically increasing, so this
+	// puts the requests in order from oldest to newest.
+	sort.Slice(reqs, func(i, j int) bool {
+		return reqs[i].req.ID < reqs[j].req.ID
+	})
 	return reqs
 }
 
@@ -568,18 +581,21 @@ const DefaultRequestTimeout = 30 * time.Second
 
 func (auth *AuthManager) request(user account.AccountID, msg *msgjson.Message, f func(comms.Link, *msgjson.Message),
 	expireTimeout, connectTimeout time.Duration, expire func()) error {
-	stamp := time.Now().UTC()
+	addPending := func() {
+		auth.addUserConnectReq(&pendingRequest{
+			user:            user,
+			req:             msg,
+			handlerFunc:     f,
+			responseTimeout: expireTimeout,
+			lastAttempt:     time.Now().UTC(),
+			expireFunc:      expire,
+		}, connectTimeout)
+	}
+
 	client := auth.user(user)
 	if client == nil {
 		if connectTimeout > 0 {
-			auth.addUserConnectReq(&pendingRequest{
-				user:            user,
-				req:             msg,
-				handlerFunc:     f,
-				responseTimeout: expireTimeout,
-				lastAttempt:     stamp,
-				expireFunc:      expire,
-			}, connectTimeout)
+			addPending()
 			return nil
 		}
 		log.Errorf("Send requested for unknown user %v", user)
@@ -599,14 +615,7 @@ func (auth *AuthManager) request(user account.AccountID, msg *msgjson.Message, f
 		// Remove client asssuming connection is broken, requiring reconnect.
 		auth.removeClient(client)
 		if connectTimeout > 0 {
-			auth.addUserConnectReq(&pendingRequest{
-				user:            user,
-				req:             msg,
-				handlerFunc:     f,
-				responseTimeout: expireTimeout,
-				lastAttempt:     stamp,
-				expireFunc:      expire,
-			}, connectTimeout)
+			addPending()
 			return nil
 		}
 	}
@@ -817,7 +826,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 		case side == order.Maker && user == match.MakerAcct:
 			addr = match.TakerAddr // counterparty
 			oid = match.Maker[:]
-			// sell = !match.TakerSell{
+			// sell = !match.TakerSell
 		case side == order.Taker && user == match.TakerAcct:
 			addr = match.MakerAddr // counterparty
 			oid = match.Taker[:]
@@ -840,7 +849,9 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 	}
 
 	// For each db match entry, create at least one msgjson.Match.
+	activeMatchIDs := make(map[order.MatchID]bool, len(matches))
 	for _, match := range matches {
+		activeMatchIDs[match.ID] = true
 		msgMatchForSide(match, order.Maker)
 		msgMatchForSide(match, order.Taker)
 	}
@@ -922,12 +933,33 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 
 	// Send pending requests for this user.
 	for _, pr := range pendingReqs {
+		// Certain match-related messages should only be sent if the match is
+		// still active.
+		mid, err := pr.req.ExtractMatchID()
+		if err != nil {
+			log.Errorf("Failed to read matchid field from '%s' payload: %v", pr.req.Route, err)
+			// just send it
+		} else if mid != nil && pr.req.Route != msgjson.RevokeMatchRoute {
+			// Always send revoke_match, but only send others with matchid set
+			// if the match is still active.
+			var matchID order.MatchID
+			copy(matchID[:], mid)
+			if !activeMatchIDs[matchID] {
+				log.Debugf("Not sending pending '%s' request to %v for inactive match %v.",
+					pr.req.Route, user, matchID)
+				continue // don't send this request
+			}
+		}
+
 		log.Debugf("Sending pending '%s' request to user %v: %v", pr.req.Route, pr.user, pr.req.String())
 		// Use the AuthManager method to send so that failed requests, which
 		// result in client removal, will go back into the client's pending
 		// requests. Subsequent requests that follow removal also fail and go
 		// back into the pending requests.
 		connectTimeout := DefaultConnectTimeout
+		if pr.req.Route == msgjson.RevokeMatchRoute {
+			connectTimeout = 4 * time.Hour // a little extra time for revoke_match to be courteous
+		}
 		// Decrement the connect timeout for repeated attempts.
 		if !pr.lastAttempt.IsZero() {
 			connectTimeout -= time.Since(pr.lastAttempt)
@@ -941,6 +973,8 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 
 	// Send pending messages for this user.
 	for _, pr := range pendingMsgs {
+		// The only match-related response is Acknowledgement (to an init or
+		// redeem request from client), which are harmless for inactive matches.
 		log.Debugf("Sending pending %s to user %v: %v", pr.msg.Type, pr.user, pr.msg.String())
 		connectTimeout := DefaultConnectTimeout
 		// Decrement the connect timeout for repeated attempts.

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -96,11 +96,7 @@ func handleMessage(c *wsLink, msg *msgjson.Message) *msgjson.Error {
 			return msgjson.NewError(msgjson.RPCUnknownRoute, "unknown route "+msg.Route)
 		}
 		// Handle the request.
-		rpcError := handler(c, msg)
-		if rpcError != nil {
-			return rpcError
-		}
-		return nil
+		return handler(c, msg)
 	case msgjson.Response:
 		// NOTE: In the event of an error, we respond to a response, which makes
 		// no sense. A new mechanism is needed with appropriate client handling.

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -299,7 +299,7 @@ func (s *Server) websocketHandler(ctx context.Context, conn ws.Connection, ip st
 	// and wait for it to shutdown.  Once it has shutdown (and hence
 	// disconnected), remove it.
 	client := newWSLink(ip, conn)
-	cm, err := s.addClient(client, ctx)
+	cm, err := s.addClient(ctx, client)
 	if err != nil {
 		log.Errorf("Failed to add client %s", ip)
 		return
@@ -348,7 +348,7 @@ func (s *Server) disconnectClients() {
 
 // addClient assigns the client an ID, adds it to the map, and attempts to
 // connect.
-func (s *Server) addClient(client *wsLink, ctx context.Context) (*dex.ConnectionMaster, error) {
+func (s *Server) addClient(ctx context.Context, client *wsLink) (*dex.ConnectionMaster, error) {
 	s.clientMtx.Lock()
 	defer s.clientMtx.Unlock()
 	client.id = s.counter

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -2177,7 +2177,7 @@ func (s *Swapper) revoke(match *matchTracker) {
 		s.setLiveAcker(req, ack)
 		s.authMgr.RequestWhenConnected(user, req, func(_ comms.Link, resp *msgjson.Message) {
 			s.processAck(resp, ack)
-		}, auth.DefaultRequestTimeout, auth.DefaultConnectTimeout, expireFunc)
+		}, auth.DefaultRequestTimeout, 4*time.Hour, expireFunc)
 	}
 
 	takerParams, takerReq, makerParams, makerReq, err := s.revocationRequests(match)


### PR DESCRIPTION
**server/auth**: `'connect'` response excludes match-related requests for revoked matches

The `'connect'` response includes a list of active matches. connect also triggers
sending pending requests and messages. This change excludes match-
related requests from being sent if the match in question is not included
in the list of active matches. Only pending `revoke_match` requests are
allowed in this case, purely as a courtesy to the client. Similarly, the connect
timeout for `revoke_match` requests is now 4 hours.

Test `RequestWhenConnected`/`SendWhenConnected`.

**dex/msgjson**: add `(*Message).ExtractMatchID`

**client/core**: missing matches are assumed revoked

Also improve logging on the most important client and server events.  INF level for a trade (both sides):

Maker, sell 20 DCR

> [INF] CORE[dcr]: Funding 2000000000 atom order with coins [30ae25a069befcab83baa5403011f6e938483f2194c543768d05d4c602a11a75:1] worth 2770311969
> [INF] CORE: Standing order 915f1f4d did not match and is now booked.
> [INF] CORE: Starting negotiation for match f55e612d42b1a37efbcadd0925e830c5dad0f628088e7e5fcb3e6cbc5ed0960a for order 915f1f4daea970686b73386d281fb9c6da2e4ce74ed8919b12412cffcafec1a3 with swap fee rate = 11, quantity = 2000000000
> [INF] CORE: Broadcasted transaction with 1 swap contracts for order 915f1f4daea970686b73386d281fb9c6da2e4ce74ed8919b12412cffcafec1a3. Fee rate = 11. Receipts (dcr): [2cff5647a82a00367456770cb56041dde7eaadd6231ca83495770b5a3445a749:0]
> [INF] CORE: Contract coin 2cff5647a82a00367456770cb56041dde7eaadd6231ca83495770b5a3445a749:0 (dcr), value = 2000000000, refundable at 2020-09-01 18:02:42 +0000 UTC (script = 6382012088c02034a78b5a8bb7de90a8a277908fe44024af48533218bf17892155f6e8725ff4bd8876a914a399bcd68ad4712a866f7cda1a6bbffc105bde636704c28c4e5fb17576a914436f588809e8739a3192caf710edc679ef6f23b76888ac)
...
> [INF] CORE: Audited contract (btc: b20dc8f32a833f53c864e4175c2008b935692bec3025f4bda0982944d5eb9867:0) paying to mthNc66CoTwzay75UQBfST8azrXphsa4i4 for order 915f1f4daea970686b73386d281fb9c6da2e4ce74ed8919b12412cffcafec1a3...
...
> [INF] CORE: Broadcasted redeem transaction spending 1 contracts for order 915f1f4daea970686b73386d281fb9c6da2e4ce74ed8919b12412cffcafec1a3, paying to d4f742143aaef48cf55bc0f437584a5b6918953add06b931d533df1f2651df6b:0 (btc)
> [INF] CORE: Match f55e612d42b1a37efbcadd0925e830c5dad0f628088e7e5fcb3e6cbc5ed0960a complete: sell 2000000000 dcr
> [INF] CORE: Retiring inactive order 915f1f4daea970686b73386d281fb9c6da2e4ce74ed8919b12412cffcafec1a3

Taker, buy 20 DCR

> [INF] CORE[btc]: Funding 200000000 Satoshis order with coins [7606b5f128500f60f648adfa6d7f23d6aa84d34d6b3229036bb7e485c40e46e6:1] worth 700000000
> [INF] CORE: Starting negotiation for match f55e612d42b1a37efbcadd0925e830c5dad0f628088e7e5fcb3e6cbc5ed0960a for order ac3fdd0a1eef8aaa989df8f754a8843c2fc0776e5379f4eebef5a4121d9b90b9 with swap fee rate = 2, quantity = 2000000000
> [INF] CORE: Audited contract (dcr: 2cff5647a82a00367456770cb56041dde7eaadd6231ca83495770b5a3445a749:0) paying to SsjGK154NT8u8yCujSAHD6AeRDXUWz5vQqr for order ac3fdd0a1eef8aaa989df8f754a8843c2fc0776e5379f4eebef5a4121d9b90b9...
...
> [INF] CORE: Broadcasted transaction with 1 swap contracts for order ac3fdd0a1eef8aaa989df8f754a8843c2fc0776e5379f4eebef5a4121d9b90b9. Fee rate = 2. Receipts (btc): [b20dc8f32a833f53c864e4175c2008b935692bec3025f4bda0982944d5eb9867:0]
> [INF] CORE: Contract coin b20dc8f32a833f53c864e4175c2008b935692bec3025f4bda0982944d5eb9867:0 (btc), value = 200000000, refundable at 2020-09-01 06:02:42 +0000 UTC (script = 6382012088a82034a78b5a8bb7de90a8a277908fe44024af48533218bf17892155f6e8725ff4bd8876a914909216abbf35703740dc1ec35b63c57d68ce8b01670402e44d5fb17576a9140ff0fdc3f0eebee74763dd41bc8c18fa9c1f692e6888ac)
...
> [INF] CORE: Notified of maker's redemption (btc: d4f742143aaef48cf55bc0f437584a5b6918953add06b931d533df1f2651df6b:0) and validated secret for order ac3fdd0a1eef8aaa989df8f754a8843c2fc0776e5379f4eebef5a4121d9b90b9...
> [INF] CORE: Broadcasted redeem transaction spending 1 contracts for order ac3fdd0a1eef8aaa989df8f754a8843c2fc0776e5379f4eebef5a4121d9b90b9, paying to 36371fc8511e31f2a97bc86c28191e82bdb6ec3f9df8e35862a3f3cfb558fb28:0 (dcr)
> [INF] CORE: Match f55e612d42b1a37efbcadd0925e830c5dad0f628088e7e5fcb3e6cbc5ed0960a complete: buy 2000000000 dcr
> [INF] CORE: Retiring inactive order ac3fdd0a1eef8aaa989df8f754a8843c2fc0776e5379f4eebef5a4121d9b90b9
