### PR TITLE
app: auto-revoke matches when conditions warrant

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1444,6 +1444,52 @@ func (btc *ExchangeWallet) Confirmations(id dex.Bytes) (uint32, error) {
 	return uint32(tx.Confirmations), nil
 }
 
+// ConfirmTime returns the UTC time the passed coin ID received the specified
+// number of confirmations. Also returns the current coin confirmation count.
+// A zero time value is returned if the coin's current confirmation count is
+// less than requested.
+func (btc *ExchangeWallet) ConfirmTime(id dex.Bytes, nConfs uint32) (time.Time, uint32, error) {
+	zeroTime := time.Time{}
+
+	txHash, _, err := decodeCoinID(id)
+	if err != nil {
+		return zeroTime, 0, err
+	}
+	tx, err := btc.wallet.GetTransaction(txHash.String())
+	if err != nil {
+		return zeroTime, 0, err
+	}
+	currentConfs := uint32(tx.Confirmations)
+	if currentConfs < nConfs {
+		return zeroTime, currentConfs, err
+	}
+	if nConfs == 1 {
+		return time.Unix(int64(tx.BlockTime), 0).UTC(), currentConfs, nil
+	}
+
+	blockHeaderAt1Conf, err := btc.getBlockHeader(tx.BlockHash)
+	if err != nil {
+		return zeroTime, currentConfs, err
+	}
+	var blockHashAtNConfs string
+	if nConfs == 2 {
+		blockHashAtNConfs = blockHeaderAt1Conf.NextHash
+	} else {
+		blockHeightAtNConfs := blockHeaderAt1Conf.Height + int64(nConfs-1)
+		hashAtNConfs, err := btc.node.GetBlockHash(blockHeightAtNConfs)
+		if err != nil {
+			return zeroTime, currentConfs, err
+		}
+		blockHashAtNConfs = hashAtNConfs.String()
+	}
+
+	blockHeaderAtNConfs, err := btc.getBlockHeader(blockHashAtNConfs)
+	if err != nil {
+		return zeroTime, currentConfs, err
+	}
+	return time.Unix(blockHeaderAtNConfs.Time, 0).UTC(), currentConfs, nil
+}
+
 // run pings for new blocks and runs the tipChange callback function when the
 // block changes.
 func (btc *ExchangeWallet) run(ctx context.Context) {
@@ -1729,9 +1775,11 @@ func toSatoshi(v float64) uint64 {
 type blockHeader struct {
 	Hash          string `json:"hash"`
 	Confirmations int64  `json:"confirmations"`
-	Height        int32  `json:"height"`
+	Height        int64  `json:"height"`
 	Time          int64  `json:"time"`
 	MedianTime    int64  `json:"mediantime"`
+	PreviousHash  string `json:"previousblockhash,omitempty"`
+	NextHash      string `json:"nextblockhash,omitempty"`
 }
 
 // getBlockHeader gets the block header for the specified block hash.

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -206,6 +206,10 @@ func (c *tRPCClient) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
 	return h, nil
 }
 
+func (c *tRPCClient) GetBlockHeaderVerbose(hash *chainhash.Hash) (*chainjson.GetBlockHeaderVerboseResult, error) {
+	return nil, fmt.Errorf("not test data yet")
+}
+
 func (c *tRPCClient) GetBlockVerbose(blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error) {
 	blk, found := c.verboseBlocks[blockHash.String()]
 	if !found {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -138,6 +138,11 @@ type Wallet interface {
 	// The ID need not represent an unspent coin, but coin IDs unknown to this
 	// wallet may return an error.
 	Confirmations(id dex.Bytes) (uint32, error)
+	// ConfirmTime returns the UTC time the passed coin ID received the specified
+	// number of confirmations. Also returns the current coin confirmation count.
+	// A zero time value is returned if the coin's current confirmation count is
+	// less than requested.
+	ConfirmTime(id dex.Bytes, nConfs uint32) (time.Time, uint32, error)
 	// Withdraw withdraws funds to the specified address. Fees are subtracted from
 	// the value.
 	Withdraw(address string, value uint64) (Coin, error)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2808,12 +2808,13 @@ func TestRefunds(t *testing.T) {
 	//
 	mid = ordertest.RandomMatchID()
 	msgMatch = &msgjson.Match{
-		OrderID:  loid[:],
-		MatchID:  mid[:],
-		Quantity: matchSize,
-		Rate:     rate,
-		Address:  "counterparty-address",
-		Side:     uint8(order.Taker),
+		OrderID:    loid[:],
+		MatchID:    mid[:],
+		Quantity:   matchSize,
+		Rate:       rate,
+		Address:    "counterparty-address",
+		Side:       uint8(order.Taker),
+		ServerTime: encode.UnixMilliU(matchTime),
 	}
 	sign(tDexPriv, msgMatch)
 	msg, _ = msgjson.NewRequest(1, msgjson.MatchRoute, []*msgjson.Match{msgMatch})


### PR DESCRIPTION
Add a `trackedTrade.maybeRevoke` method to auto-detect and revoke matches that remain in a status longer than expected, and with the expectation/assumption that such matches would have been revoked by the server.

This is an initial attempt at handling cases where a client misses `revoke_match` messages as described in #643. As mentioned in #643, a complete resolution would likely require adding a new `match_status` route for detecting revoked matches.

This first pass helps to resolve the following issues identified in #643 relating to revoked matches being considered active by a client:
- prevents clients from taking their next action on a match if the match has been idle for longer than expected.
- makes it possible for clients to auto-redeem counter swaps sooner than later; auto-redemption are not executed for unrevoked matches.
- enable early unlocking of funding and change coins when the  last match of an order is revoked before the final swap was sent but the revoke_match request was missed. Without detecting the revocation, such coins would remain locked until client restart. Related #648.

Also resolves #629 by triggering swap confirmation checks on tip change rather than on tick.
