### PR TITLE
testing: do not save harness setup commands to shell history

### DIFF
--- a/dex/testing/btc/base-harness.sh
+++ b/dex/testing/btc/base-harness.sh
@@ -62,6 +62,7 @@ EOF
 ################################################################################
 
 tmux rename-window -t $SESSION:0 'alpha'
+tmux send-keys -t $SESSION:0 "set +o history" C-m
 tmux send-keys -t $SESSION:0 "cd ${ALPHA_DIR}" C-m
 echo "Starting simnet alpha node"
 tmux send-keys -t $SESSION:0 "${DAEMON} -rpcuser=user -rpcpassword=pass \
@@ -75,6 +76,7 @@ sleep 3
 ################################################################################
 
 tmux new-window -t $SESSION:1 -n 'beta'
+tmux send-keys -t $SESSION:1 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${BETA_DIR}" C-m
 
 echo "Starting simnet beta node"
@@ -89,6 +91,7 @@ sleep 3
 ################################################################################
 
 tmux new-window -t $SESSION:2 -n 'harness-ctl'
+tmux send-keys -t $SESSION:2 "set +o history" C-m
 tmux send-keys -t $SESSION:2 "cd ${HARNESS_DIR}" C-m
 sleep 1
 

--- a/dex/testing/btc/base-harness.sh
+++ b/dex/testing/btc/base-harness.sh
@@ -239,4 +239,6 @@ do
   tmux send-keys -t $SESSION:2 "./mine-alpha 1${DONE}" C-m\; ${WAIT}
 done
 
+# Reenable history and attach to the control session.
+tmux send-keys -t $SESSION:2 "set -o history" C-m
 tmux attach-session -t $SESSION

--- a/dex/testing/dcr/create-wallet.sh
+++ b/dex/testing/dcr/create-wallet.sh
@@ -76,6 +76,7 @@ EOF
 
 # create and unlock the wallet
 tmux new-window -t $TMUX_WIN_ID -n "w-${NAME}"
+tmux send-keys -t $TMUX_WIN_ID "set +o history" C-m
 tmux send-keys -t $TMUX_WIN_ID "cd ${WALLET_DIR}" C-m
 echo "Creating simnet ${NAME} wallet"
 tmux send-keys -t $TMUX_WIN_ID "dcrwallet -C w-${NAME}.conf --create < wallet.answers; tmux wait-for -S w-${NAME}" C-m

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -141,6 +141,7 @@ EOF
 echo "Starting harness"
 tmux new-session -d -s $SESSION
 tmux rename-window -t $SESSION:0 'harness-ctl'
+tmux send-keys -t $SESSION:0 "set +o history" C-m
 tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
 
 ################################################################################
@@ -148,6 +149,7 @@ tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
 ################################################################################
 
 tmux new-window -t $SESSION:1 -n 'alpha'
+tmux send-keys -t $SESSION:0 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${NODES_ROOT}/alpha" C-m
 
 echo "Starting simnet alpha node"
@@ -160,6 +162,7 @@ tmux send-keys -t $SESSION:1 "dcrd --appdata=${NODES_ROOT}/alpha \
 --simnet; tmux wait-for -S alphadcr" C-m
 
 tmux new-window -t $SESSION:2 -n 'beta'
+tmux send-keys -t $SESSION:2 "set +o history" C-m
 tmux send-keys -t $SESSION:2 "cd ${NODES_ROOT}/beta" C-m
 
 echo "Starting simnet beta node"

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -149,7 +149,7 @@ tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
 ################################################################################
 
 tmux new-window -t $SESSION:1 -n 'alpha'
-tmux send-keys -t $SESSION:0 "set +o history" C-m
+tmux send-keys -t $SESSION:1 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${NODES_ROOT}/alpha" C-m
 
 echo "Starting simnet alpha node"
@@ -230,4 +230,6 @@ done
 tmux send-keys -t $SESSION:0 "./alpha createnewaccount server_fees${WAIT}" C-m\; wait-for donedcr
 tmux send-keys -t $SESSION:0 "./alpha getmasterpubkey server_fees${WAIT}" C-m\; wait-for donedcr
 
+# Reenable history and attach to the control session.
+tmux send-keys -t $SESSION:0 "set -o history" C-m
 tmux attach-session -t $SESSION


### PR DESCRIPTION
Any shell commands executed inside a tmux window (e.g. via `send-keys`) are recorded in shell history.  This change prevents them from flooding the history file.