### PR TITLE
multi: add loglocal flag, default to utc

### DIFF
--- a/client/cmd/dexc/go.mod
+++ b/client/cmd/dexc/go.mod
@@ -7,7 +7,7 @@ replace decred.org/dcrdex => ../../../
 require (
 	decred.org/dcrdex v0.0.0-00010101000000-000000000000
 	github.com/decred/dcrd/dcrutil/v2 v2.0.1
-	github.com/decred/slog v1.0.0
+	github.com/decred/slog v1.1.0
 	github.com/gdamore/tcell v1.3.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0

--- a/client/cmd/dexc/go.sum
+++ b/client/cmd/dexc/go.sum
@@ -101,8 +101,9 @@ github.com/decred/dcrwallet/wallet/v3 v3.1.1-0.20191230143837-6a86dc4676f0 h1:3E
 github.com/decred/dcrwallet/wallet/v3 v3.1.1-0.20191230143837-6a86dc4676f0/go.mod h1:SJ+++gtMdcUeqMv6iIO3gVGlGJfM+4iY2QSaAakhbUw=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
-github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=
+github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"time"
 
 	_ "decred.org/dcrdex/client/asset/btc" // register btc asset
 	_ "decred.org/dcrdex/client/asset/dcr" // register dcr asset
@@ -55,9 +56,12 @@ func main() {
 	logStdout := func(msg []byte) {
 		os.Stdout.Write(msg)
 	}
-	logMaker := ui.InitLogging(logStdout, cfg.DebugLevel)
+	logMaker := ui.InitLogging(logStdout, cfg.DebugLevel, !cfg.LocalLogs)
 	core.UseLoggerMaker(logMaker)
 	log = logMaker.Logger("DEXC")
+	if !cfg.LocalLogs {
+		log.Infof("Logging with UTC time stamps. Current local time is %v", time.Now().Local().Format("15:04:05 MST"))
+	}
 
 	clientCore, err := core.New(&core.Config{
 		DBPath: cfg.DBPath, // global set in config.go

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -56,11 +56,16 @@ func main() {
 	logStdout := func(msg []byte) {
 		os.Stdout.Write(msg)
 	}
-	logMaker := ui.InitLogging(logStdout, cfg.DebugLevel, !cfg.LocalLogs)
+	utc := !cfg.LocalLogs
+	if cfg.Net == dex.Simnet {
+		utc = false
+	}
+	logMaker := ui.InitLogging(logStdout, cfg.DebugLevel, utc)
 	core.UseLoggerMaker(logMaker)
 	log = logMaker.Logger("DEXC")
-	if !cfg.LocalLogs {
-		log.Infof("Logging with UTC time stamps. Current local time is %v", time.Now().Local().Format("15:04:05 MST"))
+	if utc {
+		log.Infof("Logging with UTC time stamps. Current local time is %v",
+			time.Now().Local().Format("15:04:05 MST"))
 	}
 
 	clientCore, err := core.New(&core.Config{

--- a/client/cmd/dexc/ui/config.go
+++ b/client/cmd/dexc/ui/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	Simnet     bool   `long:"simnet" description:"use simnet"`
 	ReloadHTML bool   `long:"reload-html" description:"Reload the webserver's page template with every request. For development purposes."`
 	DebugLevel string `long:"log" description:"Logging level {trace, debug, info, warn, error, critical}"`
+	LocalLogs  bool   `long:"loglocal" description:"Use local time zone time stamps in log entries."`
 	Net        dex.Network
 }
 

--- a/client/cmd/dexc/ui/log.go
+++ b/client/cmd/dexc/ui/log.go
@@ -66,11 +66,7 @@ func CustomLogMaker(f func(p []byte), utc bool) (*dex.LoggerMaker, error) {
 	if f == nil {
 		f = func([]byte) {}
 	}
-	var opts []dex.BackendOption
-	if utc {
-		opts = append(opts, dex.InUTC())
-	}
-	return dex.NewLoggerMaker(logWriter{f: f}, debugLevel, opts...)
+	return dex.NewLoggerMaker(logWriter{f: f}, debugLevel, utc)
 }
 
 // Close closes the log rotator.

--- a/client/cmd/dexc/ui/serverview.go
+++ b/client/cmd/dexc/ui/serverview.go
@@ -39,7 +39,7 @@ func newServerView(tag, addr string, runFunc func(context.Context, string, dex.L
 	logTag := strings.ToUpper(tag) + "SVR"
 	lm, err := CustomLogMaker(func(p []byte) {
 		serverJournal.Write(p)
-	})
+	}, false)
 	if err != nil {
 		log.Errorf("error creating " + logTag + " logger")
 	}

--- a/client/cmd/dexc/ui/widgets.go
+++ b/client/cmd/dexc/ui/widgets.go
@@ -58,7 +58,7 @@ func Run(ctx context.Context) {
 	appJournal = newJournal("Application Log", handleAppLogKey)
 	InitLogging(func(p []byte) {
 		appJournal.Write(p)
-	}, cfg.DebugLevel)
+	}, cfg.DebugLevel, false)
 	// Close closes the log rotator.
 	defer Close()
 	// Create the UI and start the app.
@@ -101,7 +101,7 @@ var welcomeMessage = "Welcome to Decred DEX. Use [#838ac7]Up[white] and " +
 // createApp creates the Screen and adds the menu and the initial view.
 func createApp() {
 	var err error
-	lm, err := CustomLogMaker(nil)
+	lm, err := CustomLogMaker(nil, false)
 	if err != nil {
 		log.Errorf("error creating core logger")
 	}

--- a/client/cmd/dexcctl/go.sum
+++ b/client/cmd/dexcctl/go.sum
@@ -99,8 +99,9 @@ github.com/decred/dcrwallet/wallet/v3 v3.1.1-0.20191230143837-6a86dc4676f0 h1:3E
 github.com/decred/dcrwallet/wallet/v3 v3.1.1-0.20191230143837-6a86dc4676f0/go.mod h1:SJ+++gtMdcUeqMv6iIO3gVGlGJfM+4iY2QSaAakhbUw=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
-github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=
+github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=

--- a/dex/logging.go
+++ b/dex/logging.go
@@ -77,9 +77,15 @@ func (lggr *logger) SubLogger(name string) Logger {
 	}
 }
 
+type BackendOption = slog.BackendOption
+
+func InUTC() BackendOption {
+	return slog.WithFlags(slog.LUTC)
+}
+
 // NewLogger creates a new Logger with the given name, log level, and io.Writer.
-func NewLogger(name string, lvl slog.Level, writer io.Writer) Logger {
-	backend := slog.NewBackend(writer)
+func NewLogger(name string, lvl slog.Level, writer io.Writer, backendOpts ...BackendOption) Logger {
+	backend := slog.NewBackend(writer, backendOpts...)
 	lggr := backend.Logger(name)
 	lggr.SetLevel(lvl)
 	return &logger{
@@ -93,8 +99,8 @@ func NewLogger(name string, lvl slog.Level, writer io.Writer) Logger {
 
 // StdOutLogger creates a Logger with the provided name with lvl as the log
 // level and prints to standard out.
-func StdOutLogger(name string, lvl slog.Level) Logger {
-	backend := slog.NewBackend(os.Stdout)
+func StdOutLogger(name string, lvl slog.Level, backendOpts ...BackendOption) Logger {
+	backend := slog.NewBackend(os.Stdout, backendOpts...)
 	lggr := backend.Logger(name)
 	lggr.SetLevel(lvl)
 	return &logger{
@@ -108,9 +114,9 @@ func StdOutLogger(name string, lvl slog.Level) Logger {
 
 // NewLoggerMaker creates a new LoggerMaker from the provided io.Writer and
 // debug level string. See SetLevels for details on the debug level string.
-func NewLoggerMaker(writer io.Writer, debugLevel string) (*LoggerMaker, error) {
+func NewLoggerMaker(writer io.Writer, debugLevel string, backendOpts ...BackendOption) (*LoggerMaker, error) {
 	lm := &LoggerMaker{
-		Backend:      slog.NewBackend(writer),
+		Backend:      slog.NewBackend(writer, backendOpts...),
 		Levels:       make(map[string]slog.Level),
 		DefaultLevel: DefaultLogLevel,
 	}

--- a/dex/logging.go
+++ b/dex/logging.go
@@ -77,17 +77,15 @@ func (lggr *logger) SubLogger(name string) Logger {
 	}
 }
 
-type BackendOption = slog.BackendOption
-
-func InUTC() BackendOption {
+func inUTC() slog.BackendOption {
 	return slog.WithFlags(slog.LUTC)
 }
 
 // NewLogger creates a new Logger with the given name, log level, and io.Writer.
 func NewLogger(name string, lvl slog.Level, writer io.Writer, utc ...bool) Logger {
-	var opts []BackendOption
+	var opts []slog.BackendOption
 	if len(utc) > 0 && utc[0] {
-		opts = append(opts, InUTC())
+		opts = append(opts, inUTC())
 	}
 	backend := slog.NewBackend(writer, opts...)
 	lggr := backend.Logger(name)
@@ -104,9 +102,9 @@ func NewLogger(name string, lvl slog.Level, writer io.Writer, utc ...bool) Logge
 // StdOutLogger creates a Logger with the provided name with lvl as the log
 // level and prints to standard out.
 func StdOutLogger(name string, lvl slog.Level, utc ...bool) Logger {
-	var opts []BackendOption
+	var opts []slog.BackendOption
 	if len(utc) > 0 && utc[0] {
-		opts = append(opts, InUTC())
+		opts = append(opts, inUTC())
 	}
 	backend := slog.NewBackend(os.Stdout, opts...)
 	lggr := backend.Logger(name)
@@ -123,9 +121,9 @@ func StdOutLogger(name string, lvl slog.Level, utc ...bool) Logger {
 // NewLoggerMaker creates a new LoggerMaker from the provided io.Writer and
 // debug level string. See SetLevels for details on the debug level string.
 func NewLoggerMaker(writer io.Writer, debugLevel string, utc ...bool) (*LoggerMaker, error) {
-	var opts []BackendOption
+	var opts []slog.BackendOption
 	if len(utc) > 0 && utc[0] {
-		opts = append(opts, InUTC())
+		opts = append(opts, inUTC())
 	}
 	lm := &LoggerMaker{
 		Backend:      slog.NewBackend(writer, opts...),

--- a/dex/logging.go
+++ b/dex/logging.go
@@ -84,8 +84,12 @@ func InUTC() BackendOption {
 }
 
 // NewLogger creates a new Logger with the given name, log level, and io.Writer.
-func NewLogger(name string, lvl slog.Level, writer io.Writer, backendOpts ...BackendOption) Logger {
-	backend := slog.NewBackend(writer, backendOpts...)
+func NewLogger(name string, lvl slog.Level, writer io.Writer, utc ...bool) Logger {
+	var opts []BackendOption
+	if len(utc) > 0 && utc[0] {
+		opts = append(opts, InUTC())
+	}
+	backend := slog.NewBackend(writer, opts...)
 	lggr := backend.Logger(name)
 	lggr.SetLevel(lvl)
 	return &logger{
@@ -99,8 +103,12 @@ func NewLogger(name string, lvl slog.Level, writer io.Writer, backendOpts ...Bac
 
 // StdOutLogger creates a Logger with the provided name with lvl as the log
 // level and prints to standard out.
-func StdOutLogger(name string, lvl slog.Level, backendOpts ...BackendOption) Logger {
-	backend := slog.NewBackend(os.Stdout, backendOpts...)
+func StdOutLogger(name string, lvl slog.Level, utc ...bool) Logger {
+	var opts []BackendOption
+	if len(utc) > 0 && utc[0] {
+		opts = append(opts, InUTC())
+	}
+	backend := slog.NewBackend(os.Stdout, opts...)
 	lggr := backend.Logger(name)
 	lggr.SetLevel(lvl)
 	return &logger{
@@ -114,9 +122,13 @@ func StdOutLogger(name string, lvl slog.Level, backendOpts ...BackendOption) Log
 
 // NewLoggerMaker creates a new LoggerMaker from the provided io.Writer and
 // debug level string. See SetLevels for details on the debug level string.
-func NewLoggerMaker(writer io.Writer, debugLevel string, backendOpts ...BackendOption) (*LoggerMaker, error) {
+func NewLoggerMaker(writer io.Writer, debugLevel string, utc ...bool) (*LoggerMaker, error) {
+	var opts []BackendOption
+	if len(utc) > 0 && utc[0] {
+		opts = append(opts, InUTC())
+	}
 	lm := &LoggerMaker{
-		Backend:      slog.NewBackend(writer, backendOpts...),
+		Backend:      slog.NewBackend(writer, opts...),
 		Levels:       make(map[string]slog.Level),
 		DefaultLevel: DefaultLogLevel,
 	}

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -81,6 +81,7 @@ pgdbname=${TEST_DB}
 simnet=1
 rpclisten=127.0.0.1:17273
 debuglevel=trace
+loglocal=true
 regfeeconfirms=1
 signingkeypass=keypass
 adminsrvon=1

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/decred/dcrd/wire v1.3.0
 	github.com/decred/dcrwallet/rpc/jsonrpc/types v1.4.0
 	github.com/decred/dcrwallet/wallet/v3 v3.1.1-0.20191230143837-6a86dc4676f0
-	github.com/decred/slog v1.0.0
+	github.com/decred/slog v1.1.0
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/gorilla/websocket v1.4.1
 	github.com/jessevdk/go-flags v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,9 @@ github.com/decred/dcrwallet/wallet/v3 v3.1.1-0.20191230143837-6a86dc4676f0 h1:3E
 github.com/decred/dcrwallet/wallet/v3 v3.1.1-0.20191230143837-6a86dc4676f0/go.mod h1:SJ+++gtMdcUeqMv6iIO3gVGlGJfM+4iY2QSaAakhbUw=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
-github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=
+github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -212,11 +212,7 @@ func supportedSubsystems() []string {
 // invalid.
 func parseAndSetDebugLevels(debugLevel string, UTC bool) (*dex.LoggerMaker, error) {
 	// Create a LoggerMaker with the level string.
-	var opts []dex.BackendOption
-	if UTC {
-		opts = append(opts, dex.InUTC())
-	}
-	lm, err := dex.NewLoggerMaker(logWriter{}, debugLevel, opts...)
+	lm, err := dex.NewLoggerMaker(logWriter{}, debugLevel, UTC)
 	if err != nil {
 		return nil, err
 	}

--- a/server/cmd/dcrdex/go.sum
+++ b/server/cmd/dcrdex/go.sum
@@ -99,8 +99,9 @@ github.com/decred/dcrwallet/wallet/v3 v3.1.1-0.20191230143837-6a86dc4676f0 h1:3E
 github.com/decred/dcrwallet/wallet/v3 v3.1.1-0.20191230143837-6a86dc4676f0/go.mod h1:SJ+++gtMdcUeqMv6iIO3gVGlGJfM+4iY2QSaAakhbUw=
 github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U=
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
-github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=
+github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=

--- a/server/cmd/dexcoin/go.sum
+++ b/server/cmd/dexcoin/go.sum
@@ -4,11 +4,13 @@ github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7I
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
+github.com/btcsuite/btcd v0.20.1-beta.0.20200615134404-e4f59022a387 h1:iVL7ov1l3x6J1WZTqQQJssmO3g3Er6AxnM5c+RIpvo8=
 github.com/btcsuite/btcd v0.20.1-beta.0.20200615134404-e4f59022a387/go.mod h1:Yktc19YNjh/Iz2//CX0vfRTS4IJKM/RKO5YZ9Fn+Pgo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
@@ -98,6 +100,8 @@ github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
+github.com/decred/slog v1.1.0 h1:uz5ZFfmaexj1rEDgZvzQ7wjGkoSPjw2LCh8K+K1VrW4=
+github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
@@ -144,8 +148,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4 h1:QmwruyY+bKbDDL0BaglrbZABEali68eoMFhTZpCjYVA=
-golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 h1:cg5LA/zNPRzIXIWSCxQW10Rvpy94aQh3LT/ShoCpkHw=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
This adds a `--loglocal` switch to use the local time zone in log entries, with the default to log UTC time stamps.
Without `--loglocal`, it displays the following for a reference:
`2020-09-03 19:06:50.697 [INF] MAIN: Logging with UTC time stamps. Current local time is 14:06:50 CDT`