### PR TITLE
client/core: missing matches were incomplete

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -223,10 +223,13 @@ func (dc *dexConnection) hasActiveOrders() bool {
 func (dc *dexConnection) findOrder(oid order.OrderID) (tracker *trackedTrade, preImg order.Preimage, isCancel bool) {
 	dc.tradeMtx.RLock()
 	defer dc.tradeMtx.RUnlock()
+	// Try to find the order as a trade.
+	if tracker, found := dc.trades[oid]; found {
+		return tracker, tracker.preImg, false
+	}
+	// Search the cancel order IDs.
 	for _, tracker := range dc.trades {
-		if tracker.ID() == oid {
-			return tracker, tracker.preImg, false
-		} else if tracker.cancel != nil && tracker.cancel.ID() == oid {
+		if tracker.cancel != nil && tracker.cancel.ID() == oid {
 			return tracker, tracker.cancel.preImg, true
 		}
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -3089,83 +3089,83 @@ func TestResolveActiveTrades(t *testing.T) {
 	}
 }
 
-func TestReadConnectMatches(t *testing.T) {
-	rig := newTestRig()
-	preImg := newPreimage()
-	dc := rig.dc
+// func TestReadConnectMatches(t *testing.T) {
+// 	rig := newTestRig()
+// 	preImg := newPreimage()
+// 	dc := rig.dc
 
-	notes := make(map[string][]Notification)
-	notify := func(note Notification) {
-		notes[note.Type()] = append(notes[note.Type()], note)
-	}
+// 	notes := make(map[string][]Notification)
+// 	notify := func(note Notification) {
+// 		notes[note.Type()] = append(notes[note.Type()], note)
+// 	}
 
-	lo := &order.LimitOrder{
-		P: order.Prefix{
-			// 	OrderType:  order.LimitOrderType,
-			// 	BaseAsset:  tDCR.ID,
-			// 	QuoteAsset: tBTC.ID,
-			// 	ClientTime: time.Now(),
-			ServerTime: time.Now(),
-			// 	Commit:     preImg.Commit(),
-		},
-	}
-	oid := lo.ID()
-	dbOrder := &db.MetaOrder{
-		MetaData: &db.OrderMetaData{},
-		Order:    lo,
-	}
-	mkt := dc.market(tDcrBtcMktName)
-	tracker := newTrackedTrade(dbOrder, preImg, dc, mkt.EpochLen, rig.core.lockTimeTaker, rig.core.lockTimeMaker,
-		rig.db, rig.queue, nil, nil, notify)
-	metaMatch := db.MetaMatch{
-		MetaData: &db.MatchMetaData{},
-		Match:    &order.UserMatch{},
-	}
+// 	lo := &order.LimitOrder{
+// 		P: order.Prefix{
+// 			// 	OrderType:  order.LimitOrderType,
+// 			// 	BaseAsset:  tDCR.ID,
+// 			// 	QuoteAsset: tBTC.ID,
+// 			// 	ClientTime: time.Now(),
+// 			ServerTime: time.Now(),
+// 			// 	Commit:     preImg.Commit(),
+// 		},
+// 	}
+// 	oid := lo.ID()
+// 	dbOrder := &db.MetaOrder{
+// 		MetaData: &db.OrderMetaData{},
+// 		Order:    lo,
+// 	}
+// 	mkt := dc.market(tDcrBtcMktName)
+// 	tracker := newTrackedTrade(dbOrder, preImg, dc, mkt.EpochLen, rig.core.lockTimeTaker, rig.core.lockTimeMaker,
+// 		rig.db, rig.queue, nil, nil, notify)
+// 	metaMatch := db.MetaMatch{
+// 		MetaData: &db.MatchMetaData{},
+// 		Match:    &order.UserMatch{},
+// 	}
 
-	// Store a match
-	knownID := ordertest.RandomMatchID()
-	knownMatch := &matchTracker{
-		id:              knownID,
-		MetaMatch:       metaMatch,
-		counterConfirms: -1,
-	}
-	tracker.matches[knownID] = knownMatch
-	knownMsgMatch := &msgjson.Match{OrderID: oid[:], MatchID: knownID[:]}
+// 	// Store a match
+// 	knownID := ordertest.RandomMatchID()
+// 	knownMatch := &matchTracker{
+// 		id:              knownID,
+// 		MetaMatch:       metaMatch,
+// 		counterConfirms: -1,
+// 	}
+// 	tracker.matches[knownID] = knownMatch
+// 	knownMsgMatch := &msgjson.Match{OrderID: oid[:], MatchID: knownID[:]}
 
-	missingID := ordertest.RandomMatchID()
-	missingMatch := &matchTracker{
-		id:        missingID,
-		MetaMatch: metaMatch,
-	}
-	tracker.matches[missingID] = missingMatch
+// 	missingID := ordertest.RandomMatchID()
+// 	missingMatch := &matchTracker{
+// 		id:        missingID,
+// 		MetaMatch: metaMatch,
+// 	}
+// 	tracker.matches[missingID] = missingMatch
 
-	extraID := ordertest.RandomMatchID()
-	extraMsgMatch := &msgjson.Match{OrderID: oid[:], MatchID: extraID[:]}
+// 	extraID := ordertest.RandomMatchID()
+// 	extraMsgMatch := &msgjson.Match{OrderID: oid[:], MatchID: extraID[:]}
 
-	matches := []*msgjson.Match{knownMsgMatch, extraMsgMatch}
-	tracker.readConnectMatches(matches)
+// 	matches := []*msgjson.Match{knownMsgMatch, extraMsgMatch}
+// 	tracker.readConnectMatches(matches)
 
-	if knownMatch.failErr != nil {
-		t.Fatalf("error set for known and reported match")
-	}
+// 	if knownMatch.failErr != nil {
+// 		t.Fatalf("error set for known and reported match")
+// 	}
 
-	if missingMatch.failErr == nil {
-		t.Fatalf("error not set for missing match")
-	}
+// 	if missingMatch.failErr == nil {
+// 		t.Fatalf("error not set for missing match")
+// 	}
 
-	if len(notes["order"]) != 2 {
-		t.Fatalf("expected 2 core 'order'-type notifications, got %d", len(notes["order"]))
-	}
+// 	if len(notes["order"]) != 2 {
+// 		t.Fatalf("expected 2 core 'order'-type notifications, got %d", len(notes["order"]))
+// 	}
 
-	if notes["order"][0].Subject() != "Missing matches" {
-		t.Fatalf("no core notification sent for missing matches")
-	}
+// 	if notes["order"][0].Subject() != "Missing matches" {
+// 		t.Fatalf("no core notification sent for missing matches")
+// 	}
 
-	if notes["order"][1].Subject() != "Match resolution error" {
-		t.Fatalf("no core notification sent for unknown matches")
-	}
+// 	if notes["order"][1].Subject() != "Match resolution error" {
+// 		t.Fatalf("no core notification sent for unknown matches")
+// 	}
 
-}
+// }
 
 func convertMsgLimitOrder(msgOrder *msgjson.LimitOrder) *order.LimitOrder {
 	tif := order.ImmediateTiF

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -3235,50 +3235,47 @@ func Test_compareServerMatches(t *testing.T) {
 	}
 
 	exceptions := dc.compareServerMatches(srvMatches)
-	for oidExc, discrep := range exceptions {
-		t.Logf("%v: %#v\n", oidExc, discrep)
-	}
-
 	if len(exceptions) != 2 {
 		t.Fatalf("exceptions did not include both trades, just %d", len(exceptions))
 	}
 
-	if exc, ok := exceptions[oid]; !ok {
+	exc, ok := exceptions[oid]
+	if !ok {
 		t.Fatalf("exceptions did not include trade %v", oid)
-	} else {
-		if exc.trade.ID() != oid {
-			t.Errorf("wrong trade ID, got %v, want %v", exc.trade.ID(), oid)
-		}
-		if len(exc.missing) != 1 {
-			t.Errorf("found %d missing matches for trade %v, expected 1", len(exc.missing), oid)
-		}
-		if exc.missing[0].id != missingID {
-			t.Errorf("wrong missing match, got %v, expected %v", exc.missing[0].id, missingID)
-		}
-		if len(exc.extra) != 1 {
-			t.Errorf("found %d extra matches for trade %v, expected 1", len(exc.extra), oid)
-		}
-		if !bytes.Equal(exc.extra[0].MatchID, extraID[:]) {
-			t.Errorf("wrong extra match, got %v, expected %v", exc.extra[0].MatchID, extraID)
-		}
+	}
+	if exc.trade.ID() != oid {
+		t.Errorf("wrong trade ID, got %v, want %v", exc.trade.ID(), oid)
+	}
+	if len(exc.missing) != 1 {
+		t.Errorf("found %d missing matches for trade %v, expected 1", len(exc.missing), oid)
+	}
+	if exc.missing[0].id != missingID {
+		t.Errorf("wrong missing match, got %v, expected %v", exc.missing[0].id, missingID)
+	}
+	if len(exc.extra) != 1 {
+		t.Errorf("found %d extra matches for trade %v, expected 1", len(exc.extra), oid)
+	}
+	if !bytes.Equal(exc.extra[0].MatchID, extraID[:]) {
+		t.Errorf("wrong extra match, got %v, expected %v", exc.extra[0].MatchID, extraID)
 	}
 
-	if exc, ok := exceptions[oidMissing]; !ok {
+	exc, ok = exceptions[oidMissing]
+	if !ok {
 		t.Fatalf("exceptions did not include trade %v", oidMissing)
-	} else {
-		if exc.trade.ID() != oidMissing {
-			t.Errorf("wrong trade ID, got %v, want %v", exc.trade.ID(), oidMissing)
-		}
-		if len(exc.missing) != 1 { // no matchIDMissingInactive
-			t.Errorf("found %d missing matches for trade %v, expected 1", len(exc.missing), oid)
-		}
-		if exc.missing[0].id != matchIDMissing {
-			t.Errorf("wrong missing match, got %v, expected %v", exc.missing[0].id, matchIDMissing)
-		}
-		if len(exc.extra) != 0 {
-			t.Errorf("found %d extra matches for trade %v, expected 0", len(exc.extra), oid)
-		}
 	}
+	if exc.trade.ID() != oidMissing {
+		t.Errorf("wrong trade ID, got %v, want %v", exc.trade.ID(), oidMissing)
+	}
+	if len(exc.missing) != 1 { // no matchIDMissingInactive
+		t.Errorf("found %d missing matches for trade %v, expected 1", len(exc.missing), oid)
+	}
+	if exc.missing[0].id != matchIDMissing {
+		t.Errorf("wrong missing match, got %v, expected %v", exc.missing[0].id, matchIDMissing)
+	}
+	if len(exc.extra) != 0 {
+		t.Errorf("found %d extra matches for trade %v, expected 0", len(exc.extra), oid)
+	}
+
 }
 
 func convertMsgLimitOrder(msgOrder *msgjson.LimitOrder) *order.LimitOrder {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -290,59 +290,6 @@ func (t *trackedTrade) nomatch(oid order.OrderID) error {
 	return t.db.UpdateOrderStatus(t.ID(), t.metaData.Status)
 }
 
-// readConnectMatches resolves the matches reported by the server in the
-// 'connect' response against those in the match tracker map.
-func (t *trackedTrade) readConnectMatches(msgMatches []*msgjson.Match) {
-	ids := make(map[order.MatchID]bool)
-	var extras []*msgjson.Match
-	var missing []order.MatchID
-	corder, _ := t.coreOrder()
-	t.mtx.RLock()
-	defer t.mtx.RUnlock()
-	for _, msgMatch := range msgMatches {
-		var matchID order.MatchID
-		copy(matchID[:], msgMatch.MatchID)
-		ids[matchID] = true
-		_, found := t.matches[matchID]
-		if !found {
-			extras = append(extras, msgMatch)
-			continue
-		}
-	}
-
-	for _, match := range t.matches {
-		if !ids[match.id] && match.MetaData.Status < order.MatchComplete {
-			missing = append(missing, match.id)
-			match.failErr = fmt.Errorf("order not reported by the server on connect")
-			// Must have been revoked while we were gone. Flag to allow recovery
-			// and subsequent retirement of the match and parent trade.
-			match.MetaData.Proof.IsRevoked = true
-			if err := t.db.UpdateMatch(&match.MetaMatch); err != nil {
-				log.Errorf("Failed to update missing/revoked match: %v", err)
-			}
-		}
-	}
-
-	host := t.dc.acct.host
-	if len(missing) > 0 {
-		details := fmt.Sprintf("%d matches for order %s were not reported by %q and are in a failed state",
-			len(missing), t.ID(), host)
-		corder, _ := t.coreOrderInternal()
-		t.notify(newOrderNote("Missing matches", details, db.ErrorLevel, corder))
-		for _, mid := range missing {
-			log.Warnf("%s did not report active match %s on order %s", host, mid, t.ID())
-		}
-	}
-	if len(extras) > 0 {
-		details := fmt.Sprintf("%d matches reported by %s were not found for %s.", len(extras), host, t.token())
-		t.notify(newOrderNote("Match resolution error", details, db.ErrorLevel, corder))
-		// t.negotiate(extras) // missed match message request, but match not revoked (?!)
-		for _, extra := range extras {
-			log.Errorf("%s reported match %s which is not a known active match for order %s", host, extra.MatchID, extra.OrderID)
-		}
-	}
-}
-
 // negotiate creates and stores matchTrackers for the []*msgjson.Match, and
 // updates (UserMatch).Filled. Match negotiation can then be progressed by
 // calling (*trackedTrade).tick when a relevant event occurs, such as a request
@@ -660,6 +607,18 @@ func (match *matchTracker) isActive() bool {
 		}
 	}
 	return true
+}
+
+func (t *trackedTrade) activeMatches() []*matchTracker {
+	var actives []*matchTracker
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	for _, match := range t.matches {
+		if match.isActive() {
+			actives = append(actives, match)
+		}
+	}
+	return actives
 }
 
 // isSwappable will be true if the match is ready for a swap transaction to be

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -563,14 +563,17 @@ func (t *trackedTrade) isActive() bool {
 	defer t.mtx.RUnlock()
 
 	// Status of the order itself.
-	if t.metaData.Status == order.OrderStatusBooked || t.metaData.Status == order.OrderStatusEpoch {
+	if t.metaData.Status == order.OrderStatusBooked ||
+		t.metaData.Status == order.OrderStatusEpoch {
 		return true
 	}
 
 	// Status of all matches for the order.
 	for _, match := range t.matches {
-		log.Tracef("Checking match %v (%v) in status %v. Order: %v, Refund coin: %v, Script: %x", match.id,
-			match.Match.Side, match.MetaData.Status, t.ID(), match.MetaData.Proof.RefundCoin, match.MetaData.Proof.Script)
+		log.Tracef("Checking match %v (%v) in status %v. "+
+			"Order: %v, Refund coin: %v, Script: %x", match.id,
+			match.Match.Side, match.MetaData.Status, t.ID(),
+			match.MetaData.Proof.RefundCoin, match.MetaData.Proof.Script)
 		if match.isActive() {
 			return true
 		}

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -742,7 +742,7 @@ func (t *trackedTrade) isRefundable(match *matchTracker) bool {
 
 	// For the first check or hourly tick, log the time until expiration.
 	expiresIn := time.Until(contractExpiry) // may be negative
-	if match.lastExpireDur-expiresIn > time.Hour {
+	if match.lastExpireDur-expiresIn < time.Hour {
 		// Logged less than an hour ago.
 		return false
 	}


### PR DESCRIPTION
Each tracked trade needs to have it's matches checked as missing or not, but it was checked the other way around (each server match is checked against matches for the trades that are reported).


```
[DBG] CORE: Authenticated connection to 127.0.0.1:7232, 0 active matches
[TRC] CORE: Revoked match 9ad9a6e7feae2ffe8158ce9f182644c39d48a301cca9afc4855ce85b21c59575 (Taker) in status MakerSwapCast considered inactive.
[WRN] CORE: DEX 127.0.0.1:7232 did not report active match 9ad9a6e7feae2ffe8158ce9f182644c39d48a301cca9afc4855ce85b21c59575 on order 9a76f9da8c42f60a0c46d39588a027b08c3833fa4f88f7df8b482b36e5dbb2f1 - assuming revoked.
[ERR] CORE: notify: |ERROR| (order) Missing matches - 1 matches for order 9a76f9da were not reported by "127.0.0.1:7232" and are considered revoked - Order: 9a76f9da8c42f60a0c46d39588a027b08c3833fa4f88f7df8b482b36e5dbb2f1
[WRN] CORE: notify: |WARNING| (order) Match revoked - Match 9ad9a6e7 has been revoked - Order: 9a76f9da8c42f60a0c46d39588a027b08c3833fa4f88f7df8b482b36e5dbb2f1
[WRN] CORE: Match 9ad9a6e7feae2ffe8158ce9f182644c39d48a301cca9afc4855ce85b21c59575 revoked in status MakerSwapCast for order 9a76f9da8c42f60a0c46d39588a027b08c3833fa4f88f7df8b482b36e5dbb2f1
[INF] CORE: Retiring inactive order 40a1d2f4ae94d61627de8ef600dad44b6f8e9370da9cad39fcf580d916e75ad9
[TRC] CORE: Checking match 9ad9a6e7feae2ffe8158ce9f182644c39d48a301cca9afc4855ce85b21c59575 (Maker) in status MakerSwapCast. Order: 9a76f9da8c42f60a0c46d39588a027b08c3833fa4f88f7df8b482b36e5dbb2f1, Refund coin: , Script: 6382012088a82016f2ac7f1b7e5e92e5da2f1136
62ebc7a2d490e7fee318340b876704f01f515fb17576a91435f5c17280338aaf0e8e2ada680f7f6b83365d9b6888ac
[INF] CORE: Contract for match 9ad9a6e7feae2ffe8158ce9f182644c39d48a301cca9afc4855ce85b21c59575 with swap coin 1773e333c069a48c920720e6d5caf4477a1241ab36a6d9271cdba970c1736b98:0 (btc) has an expiry time of 2020-09-03 16:55:12 +0000 UTC (1m43s), not yet expired.
...
[DBG] CORE: Refundable match 9ad9a6e7feae2ffe8158ce9f182644c39d48a301cca9afc4855ce85b21c59575 for order 9a76f9da8c42f60a0c46d39588a027b08c3833fa4f88f7df8b482b36e5dbb2f1 (Maker)
[INF] CORE: Failed match, no valid counterswap received from Taker, refunding btc contract 1773e333c069a48c920720e6d5caf4477a1241ab36a6d9271cdba970c1736b98:0
[WRN] CORE: notify: |WARNING| (order) Matches Refunded - Refunded 2.00000000 btc on order 9a76f9da - Order: 9a76f9da8c42f60a0c46d39588a027b08c3833fa4f88f7df8b482b36e5dbb2f1
```