### PR TITLE
client/core: safe swap and comms tweaks

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -48,6 +48,7 @@ var ErrCertRequired = fmt.Errorf("certificate required")
 // WsConn is an interface for a websocket client.
 type WsConn interface {
 	NextID() uint64
+	IsDown() bool
 	Send(msg *msgjson.Message) error
 	Request(msg *msgjson.Message, respHandler func(*msgjson.Message)) error
 	RequestWithTimeout(msg *msgjson.Message, respHandler func(*msgjson.Message), expireTime time.Duration, expire func()) error
@@ -84,20 +85,23 @@ type WsCfg struct {
 
 // wsConn represents a client websocket connection.
 type wsConn struct {
-	cancel       context.CancelFunc
-	wg           sync.WaitGroup
-	reconnects   uint64
-	rID          uint64
-	cfg          *WsCfg
-	ws           *websocket.Conn
-	wsMtx        sync.Mutex
-	tlsCfg       *tls.Config
-	readCh       chan *msgjson.Message
-	reconnectCh  chan struct{}
-	reqMtx       sync.RWMutex
-	connected    bool
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+	rID    uint64
+	cfg    *WsCfg
+	tlsCfg *tls.Config
+	readCh chan *msgjson.Message
+
+	wsMtx sync.Mutex
+	ws    *websocket.Conn
+
 	connectedMtx sync.RWMutex
+	connected    bool
+
+	reqMtx       sync.RWMutex
 	respHandlers map[uint64]*responseHandler
+
+	reconnectCh chan struct{} // trigger for immediate reconnect
 }
 
 // NewWsConn creates a client websocket connection.
@@ -134,16 +138,16 @@ func NewWsConn(cfg *WsCfg) (WsConn, error) {
 		cfg:          cfg,
 		tlsCfg:       tlsConfig,
 		readCh:       make(chan *msgjson.Message, readBuffSize),
-		reconnectCh:  make(chan struct{}, 1),
 		respHandlers: make(map[uint64]*responseHandler),
+		reconnectCh:  make(chan struct{}, 1),
 	}, nil
 }
 
-// isConnected returns the connection connected state.
-func (conn *wsConn) isConnected() bool {
+// IsDown indicates if the connection is known to be down.
+func (conn *wsConn) IsDown() bool {
 	conn.connectedMtx.RLock()
 	defer conn.connectedMtx.RUnlock()
-	return conn.connected
+	return !conn.connected
 }
 
 // setConnected updates the connection's connected state and runs the
@@ -198,7 +202,8 @@ func (conn *wsConn) connect(ctx context.Context) error {
 		// Respond with a pong.
 		err = ws.WriteControl(websocket.PongMessage, []byte{}, now.Add(writeWait))
 		if err != nil {
-			log.Errorf("pong error: %v", err)
+			conn.close() // read loop handles reconnect unless context is cancelled
+			log.Errorf("pong write error: %v", err)
 			return err
 		}
 
@@ -209,12 +214,7 @@ func (conn *wsConn) connect(ctx context.Context) error {
 	// If keepAlive called connect, the wsConn's current websocket.Conn may need
 	// to be closed depending on the error that triggered the reconnect.
 	if conn.ws != nil {
-		// Attempt to send a close message in case the connection is still live.
-		msg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye")
-		conn.ws.WriteControl(websocket.CloseMessage, msg,
-			time.Now().Add(50*time.Millisecond)) // ignore any error
-		// Forcibly close the underlying connection.
-		conn.ws.Close()
+		conn.close()
 	}
 	conn.ws = ws
 	conn.wsMtx.Unlock()
@@ -229,9 +229,23 @@ func (conn *wsConn) connect(ctx context.Context) error {
 	return nil
 }
 
+func (conn *wsConn) close() {
+	// Attempt to send a close message in case the connection is still live.
+	msg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye")
+	_ = conn.ws.WriteControl(websocket.CloseMessage, msg,
+		time.Now().Add(50*time.Millisecond)) // ignore any error
+	// Forcibly close the underlying connection.
+	conn.ws.Close()
+}
+
 // read fetches and parses incoming messages for processing. This should be
 // run as a goroutine. Increment the wg before calling read.
 func (conn *wsConn) read(ctx context.Context) {
+	reconnect := func() {
+		conn.setConnected(false)
+		conn.reconnectCh <- struct{}{}
+	}
+
 	for {
 		msg := new(msgjson.Message)
 
@@ -248,6 +262,14 @@ func (conn *wsConn) read(ctx context.Context) {
 			return
 		}
 		if err != nil {
+			// Read timeout should flag the connection as down asap.
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				log.Errorf("Read timeout on connection to %s.", conn.cfg.URL)
+				reconnect()
+				return
+			}
+
 			var mErr *json.UnmarshalTypeError
 			if errors.As(err, &mErr) {
 				// JSON decode errors are not fatal, log and proceed.
@@ -265,7 +287,7 @@ func (conn *wsConn) read(ctx context.Context) {
 			if websocket.IsCloseError(err, websocket.CloseGoingAway,
 				websocket.CloseNormalClosure) ||
 				strings.Contains(err.Error(), "websocket: close sent") {
-				conn.reconnect()
+				reconnect()
 				return
 			}
 
@@ -273,15 +295,15 @@ func (conn *wsConn) read(ctx context.Context) {
 			if errors.As(err, &opErr) && opErr.Op == "read" {
 				if strings.Contains(opErr.Err.Error(),
 					"use of closed network connection") {
-					log.Errorf("read quiting: %v", err)
-					conn.reconnect()
+					log.Errorf("read quitting: %v", err)
+					reconnect()
 					return
 				}
 			}
 
 			// Log all other errors and trigger a reconnection.
 			log.Errorf("read error (%v), attempting reconnection", err)
-			conn.reconnect()
+			reconnect()
 			// Successful reconnect via connect() will start read() again.
 			return
 		}
@@ -311,7 +333,6 @@ func (conn *wsConn) read(ctx context.Context) {
 // keepAlive maintains an active websocket connection by reconnecting when
 // the established connection is broken. This should be run as a goroutine.
 func (conn *wsConn) keepAlive(ctx context.Context) {
-	maxReconnects := uint64(20000000) // TODO: reason to limit this?
 	rcInt := reconnectInterval
 	for {
 		select {
@@ -322,31 +343,22 @@ func (conn *wsConn) keepAlive(ctx context.Context) {
 				return
 			}
 
-			if conn.reconnects >= maxReconnects {
-				log.Error("Max reconnection attempts reached. Stopping connection.")
-				conn.cancel()
-				// The WaitGroup provided to the consumer by Connect will start
-				// to be decremented as goroutines shutdown.
-				return
-			}
-
 			log.Infof("Attempting to reconnect to %s...", conn.cfg.URL)
 			err := conn.connect(ctx)
 			if err != nil {
-				log.Errorf("Reconnect failed: %v", err)
-				conn.reconnects++
-				if conn.reconnects+1 < maxReconnects {
-					conn.queueReconnect(rcInt)
-					// Increment the wait up to PingWait.
-					if rcInt < maxReconnectInterval {
-						rcInt += reconnectInterval
-					}
+				log.Errorf("Reconnect failed. Scheduling reconnect to %s in %.1f seconds.",
+					conn.cfg.URL, rcInt.Seconds())
+				time.AfterFunc(rcInt, func() {
+					conn.reconnectCh <- struct{}{}
+				})
+				// Increment the wait up to PingWait.
+				if rcInt < maxReconnectInterval {
+					rcInt += reconnectInterval
 				}
 				continue
 			}
 
 			log.Info("Successfully reconnected.")
-			conn.reconnects = 0
 			rcInt = reconnectInterval
 
 			// Synchronize after a reconnection.
@@ -358,19 +370,6 @@ func (conn *wsConn) keepAlive(ctx context.Context) {
 			return
 		}
 	}
-}
-
-// reconnect begins reconnection immediately.
-func (conn *wsConn) reconnect() {
-	conn.setConnected(false)
-	conn.reconnectCh <- struct{}{}
-}
-
-// queueReconnect queues a reconnection attempt.
-func (conn *wsConn) queueReconnect(wait time.Duration) {
-	conn.setConnected(false)
-	log.Infof("Attempting reconnect to %s in %d seconds.", conn.cfg.URL, wait/time.Second)
-	time.AfterFunc(wait, func() { conn.reconnectCh <- struct{}{} })
 }
 
 // NextID returns the next request id.
@@ -400,10 +399,7 @@ func (conn *wsConn) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		conn.wsMtx.Lock()
 		if conn.ws != nil {
 			log.Debug("Sending close 1000 (normal) message.")
-			msg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye")
-			conn.ws.WriteControl(websocket.CloseMessage, msg,
-				time.Now().Add(writeWait))
-			conn.ws.Close()
+			conn.close()
 		}
 		conn.wsMtx.Unlock()
 		close(conn.readCh) // signal to receivers that the wsConn is dead
@@ -424,16 +420,8 @@ func (conn *wsConn) Stop() {
 // to be down, the message failed to marshall to JSON, or writing to the
 // websocket link failed.
 func (conn *wsConn) Send(msg *msgjson.Message) error {
-	if !conn.isConnected() {
+	if conn.IsDown() {
 		return fmt.Errorf("cannot send on a broken connection")
-	}
-
-	conn.wsMtx.Lock()
-	defer conn.wsMtx.Unlock()
-	err := conn.ws.SetWriteDeadline(time.Now().Add(writeWait))
-	if err != nil {
-		log.Errorf("failed to set write deadline: %v", err)
-		return err
 	}
 
 	// Marshal the Message first so that we don't send junk to the peer even if
@@ -443,9 +431,20 @@ func (conn *wsConn) Send(msg *msgjson.Message) error {
 		log.Errorf("Failed to marshal message: %v", err)
 		return err
 	}
+
+	conn.wsMtx.Lock()
+	defer conn.wsMtx.Unlock()
+	err = conn.ws.SetWriteDeadline(time.Now().Add(writeWait))
+	if err != nil {
+		log.Errorf("Send: failed to set write deadline: %v", err)
+		conn.close() // read loop handles reconnect unless context is cancelled
+		return err
+	}
+
 	err = conn.ws.WriteMessage(websocket.TextMessage, b)
 	if err != nil {
-		log.Errorf("write error: %v", err)
+		log.Errorf("Send: WriteMessage error: %v", err)
+		conn.close() // read loop handles reconnect unless context is cancelled
 		return err
 	}
 	return nil

--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -202,7 +202,7 @@ func (conn *wsConn) connect(ctx context.Context) error {
 		// Respond with a pong.
 		err = ws.WriteControl(websocket.PongMessage, []byte{}, now.Add(writeWait))
 		if err != nil {
-			conn.close() // read loop handles reconnect unless context is cancelled
+			// read loop handles reconnect
 			log.Errorf("pong write error: %v", err)
 			return err
 		}
@@ -437,14 +437,12 @@ func (conn *wsConn) Send(msg *msgjson.Message) error {
 	err = conn.ws.SetWriteDeadline(time.Now().Add(writeWait))
 	if err != nil {
 		log.Errorf("Send: failed to set write deadline: %v", err)
-		conn.close() // read loop handles reconnect unless context is cancelled
 		return err
 	}
 
 	err = conn.ws.WriteMessage(websocket.TextMessage, b)
 	if err != nil {
 		log.Errorf("Send: WriteMessage error: %v", err)
-		conn.close() // read loop handles reconnect unless context is cancelled
 		return err
 	}
 	return nil

--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -299,7 +299,7 @@ func TestWsConn(t *testing.T) {
 		runtime.Gosched()
 
 		// Wait for a reconnection.
-		for !wsc.isConnected() {
+		for wsc.IsDown() {
 			time.Sleep(time.Millisecond * 10)
 			continue
 		}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3259,6 +3259,8 @@ out:
 			if sinceLast >= 2*dc.tickInterval {
 				// The app likely just woke up from being suspended. Skip this
 				// tick to let DEX connections reconnect and resync matches.
+				log.Warnf("Long delay since previous trade check (just resumed?): %v. "+
+					"Skipping this check to allow reconnect.", sinceLast)
 				continue
 			}
 			updatedAssets := make(assetMap)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2772,8 +2772,9 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				}
 				auditInfo, err := wallets.toWallet.AuditContract(counterSwap, counterContract)
 				if err != nil {
+					log.Debugf("Match %v status %v, refunded = %v, revoked = %v", match.id, match.MetaData.Status, len(match.MetaData.Proof.RefundCoin) > 0, match.MetaData.Proof.IsRevoked)
 					match.failErr = fmt.Errorf("audit error, order %s, match %s: %v", tracker.ID(), match.id, err)
-					notifyErr("Match recovery error", "Error auditing counter-parties swap contract during swap recovery on order %s: %v", tracker.token(), err)
+					notifyErr("Match recovery error", "Error auditing counter-party's swap contract (%v) during swap recovery on order %s: %v", tracker.token(), coinIDString(wallets.toAsset.ID, counterSwap), err)
 					continue
 				}
 				match.counterSwap = auditInfo
@@ -3191,6 +3192,7 @@ func (c *Core) listen(dc *dexConnection) {
 	// Run a match check at the tick interval.
 	ticker := time.NewTicker(dc.tickInterval)
 	defer ticker.Stop()
+	lastTick := time.Now()
 
 	// Messages must be run in the order in which they are received, but they
 	// should not be blocking or run concurrently.
@@ -3252,6 +3254,13 @@ out:
 			nextJob <- &msgJob{handler, msg}
 
 		case <-ticker.C:
+			sinceLast := time.Since(lastTick)
+			lastTick = time.Now()
+			if sinceLast >= 2*dc.tickInterval {
+				// The app likely just woke up from being suspended. Skip this
+				// tick to let DEX connections reconnect and resync matches.
+				continue
+			}
 			updatedAssets := make(assetMap)
 			dc.tradeMtx.Lock()
 			for oid, trade := range dc.trades {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -233,6 +233,9 @@ func (conn *TWebsocket) RequestWithTimeout(msg *msgjson.Message, f func(*msgjson
 	return conn.reqErr
 }
 func (conn *TWebsocket) MessageSource() <-chan *msgjson.Message { return conn.msgs }
+func (conn *TWebsocket) IsDown() bool {
+	return false
+}
 func (conn *TWebsocket) Connect(context.Context) (*sync.WaitGroup, error) {
 	return &sync.WaitGroup{}, conn.connectErr
 }

--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -317,7 +317,7 @@ func (c *WSLink) outHandler(ctx context.Context) {
 			}
 		}
 		// Attempt sending all queued outgoing messages.
-		log.Infof("Sending %d queued outgoing messages for %v.", len(outQueue), c.ip)
+		log.Tracef("Sending %d queued outgoing messages for %v.", len(outQueue), c.ip)
 		for _, sd := range outQueue {
 			write(sd)
 		}


### PR DESCRIPTION
Swap contracts are no longer permitted to be broadcast if the DEX connection is known to be down.  This can happen when a computer or client process comes out of suspend and immediately tries to take their action, particularly the taker trying to bcast their swap.  The net connection's read timeout must still put the link into a failed state quickly for this to work during a resume, but this connectivity check is also valuable with normal connectivity trouble, not just machine/process suspend.

Triggering of ticks with the tick timer is also modified to skip tick execution if a long delay since the previous timer fire is detected (computer resume) to allow time for DEX re-connection.  This together with the swap check described above prevents needlessly broadcasting a swap contract for a match that is revoked unbeknownst to the client.  The swap check is still necessary however since asset tip changes also trigger a tick.

client/comms.WsConn reconnect logic is tweaked to prevent back-to-back or duplicate queued reconnect attempts.  This is especially necessary now since send errors in Send and the ping handler now also trigger reconnect.  Previously read errors would only trigger reconnect.  The (*wsConn).read loop now detects and logs timeouts immediately before all other error checks to hasten flagging the connection as down and to log the timeout as the cause in plain language.

```
^Z
[1]+  Stopped                 ./dexc --simnet --rpcaddr=localhost:6757 --webaddr=localhost:6758
$    fg 1
./dexc --simnet --rpcaddr=localhost:6757 --webaddr=localhost:6758
2020-09-03 17:21:00.365 [TRC] CORE: Since last tick: 2m31.813685043s
2020-09-03 17:21:00.365 [TRC] CORE: Skipping this tick.
2020-09-03 17:21:00.365 [ERR] WS: Websocket receive error from peer 127.0.0.1: read tcp 127.0.0.1:6758->127.0.0.1:37896: i/o timeout
2020-09-03 17:21:00.365 [TRC] WS: Websocket output handler done for peer 127.0.0.1
2020-09-03 17:21:00.365 [INF] WS: Sending 0 queued outgoing messages for 127.0.0.1.
2020-09-03 17:21:00.365 [ERR] COMMS: pong write error: write tcp 127.0.0.1:36142->127.0.0.1:7232: write: broken pipe
2020-09-03 17:21:00.365 [INF] COMMS: Attempting to reconnect to wss://127.0.0.1:7232/ws...
2020-09-03 17:21:00.365 [ERR] COMMS: read error (write tcp 127.0.0.1:36142->127.0.0.1:7232: write: broken pipe), attempting reconnection
2020-09-03 17:21:00.365 [DBG] COMMS: Already reconnecting.
2020-09-03 17:21:00.365 [DBG] WS: Sent 25 and dropped 0 messages to 127.0.0.1 before shutdown.
2020-09-03 17:21:00.365 [TRC] CORE: notify: |DATA| (epoch) - Index: 266528585
2020-09-03 17:21:00.366 [DBG] WS: Sending close 1000 (normal) message.
2020-09-03 17:21:00.366 [DBG] CORE[dcr]: tip change: 364 (6f2a3f15bd86fdc470ea4e852e76463124a824f44d77cfa7837e06b674cccea6) => 365 (1f72387413ae2459b27495a7a8f7ce2a41761e21a15b8a9dd878efcf59c49cba)
2020-09-03 17:21:00.367 [TRC] CORE: processing tip change for dcr
2020-09-03 17:21:00.367 [WRN] WEB[WS]: Failed to send notify notification to client 1 at 127.0.0.1: peer disconnected
2020-09-03 17:21:00.367 [TRC] WEB[WS]: Disconnected websocket client 127.0.0.1
2020-09-03 17:21:00.367 [TRC] CORE: notify: |DATA| (epoch) - Index: 266528586
2020-09-03 17:21:00.368 [TRC] CORE: notify: |DATA| (epoch) - Index: 266528587
2020-09-03 17:21:00.369 [WRN] CORE: notify: |WARNING| (conn) DEX disconnected - DEX at 127.0.0.1:7232 has disconnected
2020-09-03 17:21:00.371 [DBG] CORE[btc]: tip change: 318 (79999e936ec7e2ca59744fc2c1068f723bfb97794536e415f0652c11534c4a0f) => 321 (21792ad1199d2c94e2031195f4e4fcef92a2ab44a622923d8453df33ec48fa9c)
2020-09-03 17:21:00.371 [TRC] CORE: processing tip change for btc
2020-09-03 17:21:00.375 [DBG] CORE: Swappable match c3408198ead3a8f29d3206e8981ef5eaaaad348ad66e2371230e2e8f56430e98 for order a331c9490e965498164fda049ccc8008f0534e1723ed8659c4ee93cd38dc3899 (Taker)
2020-09-03 17:21:00.376 [ERR] CORE: notify: |ERROR| (order) Swap error - Error encountered sending a swap output(s) worth 20.00000000 dcr on order a331c949 - Order: a331c9490e965498164fda049ccc8008f0534e1723ed8659c4ee93cd38dc3899
2020-09-03 17:21:00.376 [ERR] CORE: 127.0.0.1:7232 tick error: 127.0.0.1:7232 tick: {swapMatches order a331c9490e965498164fda049ccc8008f0534e1723ed8659c4ee93cd38dc3899 - {not broadcasting swap while DEX 127.0.0.1:7232 connection is down (could be revoked)}}
2020-09-03 17:21:00.378 [DBG] CORE: Swappable match c3408198ead3a8f29d3206e8981ef5eaaaad348ad66e2371230e2e8f56430e98 for order a331c9490e965498164fda049ccc8008f0534e1723ed8659c4ee93cd38dc3899 (Taker)
2020-09-03 17:21:00.379 [ERR] CORE: notify: |ERROR| (order) Swap error - Error encountered sending a swap output(s) worth 20.00000000 dcr on order a331c949 - Order: a331c9490e965498164fda049ccc8008f0534e1723ed8659c4ee93cd38dc3899
2020-09-03 17:21:00.379 [ERR] CORE: 127.0.0.1:7232 tick error: 127.0.0.1:7232 tick: {swapMatches order a331c9490e965498164fda049ccc8008f0534e1723ed8659c4ee93cd38dc3899 - {not broadcasting swap while DEX 127.0.0.1:7232 connection is down (could be revoked)}}
2020-09-03 17:21:00.383 [TRC] CORE: notify: |DATA| (balance) balance updated
2020-09-03 17:21:00.384 [TRC] CORE: notify: |DATA| (balance) balance updated
2020-09-03 17:21:00.390 [TRC] CORE: notify: |DATA| (balance) balance updated
2020-09-03 17:21:00.477 [INF] COMMS: Successfully reconnected.
2020-09-03 17:21:00.478 [INF] CORE: notify: |SUCCESS| (conn) DEX connected - DEX at 127.0.0.1:7232 has connected
2020-09-03 17:21:00.494 [WRN] CORE: notify: |WARNING| (order) Match revoked - Match c3408198 has been revoked - Order: a331c9490e965498164fda049ccc8008f0534e1723ed8659c4ee93cd38dc3899
2020-09-03 17:21:00.494 [TRC] CORE: notify: |DATA| (order) revoke - Order: 
2020-09-03 17:21:00.494 [WRN] CORE: Match c3408198ead3a8f29d3206e8981ef5eaaaad348ad66e2371230e2e8f56430e98 revoked in status MakerSwapCast for order a331c9490e965498164fda049ccc8008f0534e1723ed8659c4ee93cd38dc3899
2020-09-03 17:21:00.495 [DBG] CORE: Authenticated connection to 127.0.0.1:7232, 0 active matches
2020-09-03 17:21:00.495 [TRC] CORE: Revoked match c3408198ead3a8f29d3206e8981ef5eaaaad348ad66e2371230e2e8f56430e98 (Taker) in status MakerSwapCast considered inactive.
2020-09-03 17:21:00.495 [WRN] CORE: DEX 127.0.0.1:7232 did not report active match c3408198ead3a8f29d3206e8981ef5eaaaad348ad66e2371230e2e8f56430e98 on order 6897f02e97c9dc919f829b6d96ab1049e37ad355e52a7767edcdbfd1e0356ca1 - assuming revoked.
2020-09-03 17:21:00.497 [ERR] CORE: notify: |ERROR| (order) Missing matches - 1 matches for order 6897f02e were not reported by "127.0.0.1:7232" and are considered revoked - Order: 6897f02e97c9dc919f829b6d96ab1049e37ad355e52a7767edcdbfd1e0356ca1
```