### PR TITLE
client/webserver/site: websocket connect timeout

### DIFF
--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -90,7 +90,7 @@ export default class Application {
    * reconnected is called by the websocket client when a reconnection is made.
    */
   reconnected () {
-    window.location.reload()
+    window.location.reload() // This triggers another websocket disconnect/connect (!)
   }
 
   /*
@@ -466,9 +466,9 @@ export default class Application {
   }
 
   /**
-   * signOut call to /api/logout, if response with no errors occured clear all store,
-   * remove auth, darkMode cookies and reload the page,
-   * otherwise will show a notification
+   * signOut call to /api/logout, if response with no errors occurred clear all
+   * store, remove auth, darkMode cookies and reload the page, otherwise will
+   * show a notification
    */
   async signOut () {
     const res = await postJSON('/api/logout')

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -1220,7 +1220,7 @@ class MarketList {
     this.selected.row.classList.add('selected')
   }
 
-  /* setConnectionStatus sets the visiblity of the disconnected icon based
+  /* setConnectionStatus sets the visibility of the disconnected icon based
    * on the core.ConnEventNote.
    */
   setConnectionStatus (note) {


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/583

Apparently when the browser (Firefox in this case) attempts `new window.WebSocket(uri)` enough times, it takes longer and longer to fail connecting and instead hangs for longer and longer.  This delayed connect timeout state seems to be browser-wide effecting all tabs and apparently persists across hard-refresh for some time.

To address this, we set a connect timeout to prevent these attempts from taking longer than 0.5 seconds.

There is a remaining issue of the app's `reconnected` reloading the page when websocket connects, which in turn disconnects and reconnects the just reconnected websocket.  Not ideal, but it does work.