### PR TITLE
client/core: just unlock trade coins on retire

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3238,18 +3238,12 @@ out:
 					trade.mtx.RLock()
 					if trade.change != nil {
 						changeCoins := asset.Coins{trade.change}
-						if err := trade.wallets.fromWallet.ReturnCoins(changeCoins); err == nil {
-							log.Warnf("Unlocked change coins for order %v THAT SHOULD HAVE BEEN UNLOCKED: %v", oid, changeCoins)
-						} else {
-							log.Debugf("Unlocked order %v change coins: %v (expected wallet error = %v)", oid, changeCoins, err)
-						}
+						err := trade.wallets.fromWallet.ReturnCoins(changeCoins)
+						log.Debugf("Unlocked order %v change coins: %v (wallet error = %v)", oid, changeCoins, err)
 					}
 					tradeCoins := trade.coinList()
-					if err := trade.wallets.fromWallet.ReturnCoins(tradeCoins); err == nil {
-						log.Debugf("Unlocked funding coins for order %v THAT SHOULD HAVE BEEN UNLOCKED: %v", oid, tradeCoins)
-					} else {
-						log.Debugf("Unlocked funding coins for order %v: %v (expected wallet error = %v)", oid, tradeCoins, err)
-					}
+					err := trade.wallets.fromWallet.ReturnCoins(tradeCoins)
+					log.Debugf("Unlocked funding coins for order %v: %v (wallet error = %v)", oid, tradeCoins, err)
 					trade.mtx.RUnlock()
 					delete(dc.trades, oid)
 					updatedAssets.count(trade.wallets.fromAsset.ID)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3252,6 +3252,7 @@ out:
 					}
 					trade.mtx.RUnlock()
 					delete(dc.trades, oid)
+					updatedAssets.count(trade.wallets.fromAsset.ID)
 					continue
 				}
 				newUpdates, err := trade.tick()


### PR DESCRIPTION
When an order is retired (eligible according to `(*trackedTrade).isActive`), all funding and change coins are unlocked.  This will be redundant with other unlock sites, and likely much of PR #648.