### PR TITLE
client/webserver/site: allow clicking on expired balance ico to unlock

### DIFF
--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -106,6 +106,8 @@ export default class MarketsPage extends BasePage {
       const quoteIcons = wgt.quote.stateIcons.icons
       bind(wgt.base.connect, 'click', () => { this.showOpen(this.market.base, this.walletUnlocked) })
       bind(wgt.quote.connect, 'click', () => { this.showOpen(this.market.quote, this.walletUnlocked) })
+      bind(wgt.base.expired, 'click', () => { this.showOpen(this.market.base, this.walletUnlocked) })
+      bind(wgt.quote.expired, 'click', () => { this.showOpen(this.market.quote, this.walletUnlocked) })
       bind(baseIcons.sleeping, 'click', () => { this.showOpen(this.market.base, this.walletUnlocked) })
       bind(quoteIcons.sleeping, 'click', () => { this.showOpen(this.market.quote, this.walletUnlocked) })
       bind(baseIcons.locked, 'click', () => { this.showOpen(this.market.base, this.walletUnlocked) })


### PR DESCRIPTION
This allows you to click on the red thing as well as the lock icon:

![image](https://user-images.githubusercontent.com/9373513/92282794-f97d6700-eec3-11ea-9ad7-69c873a583bc.png)
