### PR TITLE
dex/testing/dcr: fix reorg script

### DIFF
--- a/dex/testing/dcr/README.md
+++ b/dex/testing/dcr/README.md
@@ -34,10 +34,8 @@ Try `./alpha getbalance`, for example.
 undergo a 1-deep reorganization. The script takes the following optional
 arguments: `./reorg {node} {depth}`, where:
 - `node` is the node that should undergo a reorg, either "alpha" or "beta" (default: alpha)
-- `depth` is the number of blocks that should be reorged into `node` (default: 1 for alpha, 3 for beta).
-Currently, only 1 block (instead of `depth` blocks) can be purged from either
-nodes during reorg, but the reorged node will always see `depth` new blocks
-after the reorg.
+- `depth` is the number of blocks that should be purged from `node` (default: 2).
+At the end of the reorg, both nodes will have `depth+1` new blocks.
 
 `./quit` shuts down the nodes and closes the tmux session.
 

--- a/dex/testing/dcr/README.md
+++ b/dex/testing/dcr/README.md
@@ -30,8 +30,14 @@ allow you to perform RPC calls against each wallet.
 wallets.
 Try `./alpha getbalance`, for example.
 
-`./reorg` will step through a script that causes the alpha node to undergo a
-1-deep reorganization.
+`./reorg` will step through a script that causes the alpha or beta node to
+undergo a 1-deep reorganization. The script takes the following optional
+arguments: `./reorg {node} {depth}`, where:
+- `node` is the node that should undergo a reorg, either "alpha" or "beta" (default: alpha)
+- `depth` is the number of blocks that should be reorged into `node` (default: 1 for alpha, 3 for beta).
+Currently, only 1 block (instead of `depth` blocks) can be purged from either
+nodes during reorg, but the reorged node will always see `depth` new blocks
+after the reorg.
 
 `./quit` shuts down the nodes and closes the tmux session.
 

--- a/dex/testing/dcr/create-wallet.sh
+++ b/dex/testing/dcr/create-wallet.sh
@@ -16,10 +16,10 @@ mkdir -p ${WALLET_DIR}
 export SHELL=$(which bash)
 
 # Connect to alpha or beta node
-DCRD_RPC_PORT="19570"
+DCRD_RPC_PORT="${ALPHA_NODE_RPC_PORT}"
 DCRD_RPC_CERT="${NODES_ROOT}/alpha/rpc.cert"
-if [ "${NAME}" = "beta" ]; then
-  DCRD_RPC_PORT="19569"
+if [ "${NAME}" = "beta" ] || [ "${NAME}" = "alpha-clone" ]; then
+  DCRD_RPC_PORT="${BETA_NODE_RPC_PORT}"
   DCRD_RPC_CERT="${NODES_ROOT}/beta/rpc.cert"
 fi
 
@@ -39,17 +39,21 @@ rpcconnect=127.0.0.1:${DCRD_RPC_PORT}
 cafile=${DCRD_RPC_CERT}
 EOF
 
-if [ -n "${HTTPPROF_PORT}" ]; then
-echo "profile=127.0.0.1:${HTTPPROF_PORT}" >> "${WALLET_DIR}/${NAME}.conf"
+if [ "${ENABLE_VOTING}" = "1" ]; then
+echo "enablevoting=1" >> "${WALLET_DIR}/${NAME}.conf"
 fi
 
-if [ "${ENABLE_VOTING}" = "1" ]; then
+if [ "${ENABLE_VOTING}" = "2" ]; then
 cat >> "${WALLET_DIR}/${NAME}.conf" <<EOF
 enablevoting=1
 enableticketbuyer=1
 ticketbuyer.limit=6
 ticketbuyer.balancetomaintainabsolute=1000
 EOF
+fi
+
+if [ -n "${HTTPPROF_PORT}" ]; then
+echo "profile=127.0.0.1:${HTTPPROF_PORT}" >> "${WALLET_DIR}/${NAME}.conf"
 fi
 
 # wallet ctl config


### PR DESCRIPTION
The dcr reorg script is modified to accept 2 optional arguments:
`./reorg (node depth), where
- `node` is the node that should undergo a reorg, either "alpha" or "beta" (default: alpha)
- `depth` is the number of blocks that should be purged from `node` (default: 2).
At the end of the reorg, both nodes will have `depth+1` new blocks.

During reorg, a clone of the alpha wallet is connected to the beta node after the beta node
is disconnected from the alpha node. This is done to enable mining multiple blocks on the
beta node.
The alpha wallet clone uses the same seed as the alpha wallet and is thus able to vote on
tickets purchased by the alpha wallet when the alpha node was connected to the beta node,
supplying enough votes to the beta node to validate previous blocks and allow the creation
of new blocks.

Resolves #646.

