### PR TITLE
spec: define cancel ratio new user period

### DIFF
--- a/spec/admin.mediawiki
+++ b/spec/admin.mediawiki
@@ -22,7 +22,7 @@ possible.
 |-
 | registration&nbsp;fees || [[fundamentals.mediawiki/#Fees|Fees]] || atoms || 1e8 (1 DCR)
 |-
-| cancellation&nbsp;threshold || [[community.mediawiki/#Rule_3_An_accounts_cancellation_ratio_must_remain_below_the_threshold|Rule 3]] || unitless ratio || 0.6
+| cancellation&nbsp;threshold || [[community.mediawiki/#Rule_3_An_accounts_cancellation_rate_must_not_exceed_the_threshold|Rule 3]] || unitless ratio || 0.6
 |-
 | broadcast&nbsp;timeout || [[fundamentals.mediawiki/#Exchange_Variables|Exchange Variables]] &amp; [[community.mediawiki/#rule-1-clients-must-respond-to-all-preimage-requests|Rule 1]] || milliseconds || 60,000
 |}

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -44,11 +44,10 @@ The cancellation threshold is set by the DEX operator.
 The cancellation rate is evaluated on a 100-order rolling window.
 
 A new user is exempt from the cancellation rate requirement while their
-completed order count (i.e. canceled + fully settled), <code>total</code>,
-is not greater than <code>threshold/(1-threshold)</code>. This follows from
-the possibility of the next completed order being fully-settled and just
-meeting the required cancellation rate threshold:
-<code>total / (total + 1) <= threshold</code>
+completed order count, <code>total</code>, is not greater than
+<code>threshold/(1-threshold)</code>. This follows from the possibility of the
+next completed order being fully-settled and just passing the required
+cancellation rate threshold: <code>total / (total + 1) <= threshold</code>
 
 ===Rule 4: Transaction outputs must be properly sized===
 

--- a/spec/community.mediawiki
+++ b/spec/community.mediawiki
@@ -27,17 +27,28 @@ replace the order.
 In the event that the taker fails to respond to the maker's initialization
 transaction, the maker will incur no violation.
 
-===Rule 3: An account's cancellation ratio must remain below the threshold===
+===Rule 3: An account's cancellation rate must not exceed the threshold===
 
-The cancellation ratio is the ratio of the count of canceled orders to the
-count of completed orders.
-The cancellation threshold is set by the DEX operator.
-An order is considered completed when all matches have fully settled.
+The cancellation rate is the ratio of the count of canceled orders to the
+count of all completed orders.
+The completed order count is the sum of canceled orders and fully settled
+orders.
+An order is considered fully settled if it is no longer booked, had at least
+one match, and has completed all swaps from matches made with the order.
+Failed swaps where the counter-party is at fault do not count against the user.
 An order is considered canceled when a cancel order is matched to a standing
 limit order. The server may also cancel an order if the client's connection is
 dropped and the client fails to reconnect for more than 1 epoch duration.
 Cancellation of a partially filled order is counted as a full cancellation.
-The cancellation ratio is evaluated on a 25-order rolling window.
+The cancellation threshold is set by the DEX operator.
+The cancellation rate is evaluated on a 100-order rolling window.
+
+A new user is exempt from the cancellation rate requirement while their
+completed order count (i.e. canceled + fully settled), <code>total</code>,
+is not greater than <code>threshold/(1-threshold)</code>. This follows from
+the possibility of the next completed order being fully-settled and just
+meeting the required cancellation rate threshold:
+<code>total / (total + 1) <= threshold</code>
 
 ===Rule 4: Transaction outputs must be properly sized===
 

--- a/spec/fundamentals.mediawiki
+++ b/spec/fundamentals.mediawiki
@@ -22,9 +22,9 @@ by the user immediately after connecting via the
 
 ===Global Variables===
 
-The cancellation ratio for a user is the ratio of their canceled order count to
-completed order count. A user's cancellation ratio must remain below the configured
-[[community.mediawiki/#Rule_3_An_accounts_cancellation_ratio_must_remain_below_the_threshold|'''cancellation threshold''']]
+The cancellation rate for a user is the ratio of their canceled order count to
+completed order count. A user's cancellation rate must remain below the configured
+[[community.mediawiki/#Rule_3_An_accounts_cancellation_rate_must_not_exceed_the_threshold|'''cancellation threshold''']]
 (<code>cancelmax</code>) to avoid penalty.
 
 The '''broadcast timeout''' (<code>btimeout</code>) is the amount of time a
@@ -96,7 +96,7 @@ respond with its current configuration.
 {|
 ! field          !! type  !! description
 |-
-| cancelmax      || float || the [[community.mediawiki/#Rule_3_An_accounts_cancellation_ratio_must_remain_below_the_threshold|cancellation threshold]]
+| cancelmax      || float || the [[community.mediawiki/#Rule_3_An_accounts_cancellation_ratio_must_not_exceed_the_threshold|cancellation threshold]]
 |-
 | btimeout       || int   || the broadcast timeout
 |-

--- a/spec/fundamentals.mediawiki
+++ b/spec/fundamentals.mediawiki
@@ -96,7 +96,7 @@ respond with its current configuration.
 {|
 ! field          !! type  !! description
 |-
-| cancelmax      || float || the [[community.mediawiki/#Rule_3_An_accounts_cancellation_ratio_must_not_exceed_the_threshold|cancellation threshold]]
+| cancelmax      || float || the [[community.mediawiki/#Rule_3_An_accounts_cancellation_rate_must_not_exceed_the_threshold|cancellation threshold]]
 |-
 | btimeout       || int   || the broadcast timeout
 |-


### PR DESCRIPTION
Define a new-user bring up / grace period with respect to the enforcement of cancellation ratio.  Implementation in https://github.com/decred/dcrdex/pull/638