### PR TITLE
client/asset: retrieve funding coins from locked outpoints

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -771,7 +771,7 @@ func TestFundingCoins(t *testing.T) {
 
 	ensureErr := func(tag string) {
 		// Clear the cache.
-		wallet.fundingCoins = make(map[outPoint]*compositeUTXO)
+		wallet.fundingCoins = make(map[outPoint]*utxo)
 		_, err := wallet.FundingCoins(coinIDs)
 		if err == nil {
 			t.Fatalf("%s: no error", tag)
@@ -1218,7 +1218,7 @@ func TestSignMessage(t *testing.T) {
 	sig := signature.Serialize()
 
 	pt := newOutPoint(tTxHash, vout)
-	utxo := &compositeUTXO{address: tP2PKHAddr}
+	utxo := &utxo{address: tP2PKHAddr}
 	wallet.fundingCoins[pt] = utxo
 	node.rawRes[methodPrivKeyForAddress] = mustMarshal(t, wif.String())
 	node.signMsgFunc = func(params []json.RawMessage) (json.RawMessage, error) {

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -754,6 +754,7 @@ func TestFundingCoins(t *testing.T) {
 		Safe:         true,
 	}
 	unspents := []*ListUnspentResult{p2pkhUnspent}
+	node.rawRes[methodListLockUnspent] = mustMarshal(t, []*RPCOutpoint{})
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
 	node.rawRes[methodLockUnspent] = mustMarshal(t, true)
 	coinIDs := []dex.Bytes{coinID}
@@ -794,6 +795,18 @@ func TestFundingCoins(t *testing.T) {
 	ensureErr("bad coin ID")
 	coinIDs = ogIDs
 
+	// Coins locked but not in wallet.fundingCoins.
+	node.rawRes[methodListLockUnspent] = mustMarshal(t, []*RPCOutpoint{
+		{TxID: p2pkhUnspent.TxID, Vout: p2pkhUnspent.Vout},
+	})
+	node.rawRes[methodListUnspent] = mustMarshal(t, []*ListUnspentResult{})
+	node.txOutRes = &btcjson.GetTxOutResult{
+		Value: p2pkhUnspent.Amount,
+		ScriptPubKey: btcjson.ScriptPubKeyResult{
+			Hex:       hex.EncodeToString(p2pkhUnspent.ScriptPubKey),
+			Addresses: []string{p2pkhUnspent.Address},
+		},
+	}
 	ensureGood()
 }
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -53,7 +53,7 @@ const (
 )
 
 var (
-	requiredWalletVersion = dex.Semver{Major: 8, Minor: 2, Patch: 0}
+	requiredWalletVersion = dex.Semver{Major: 8, Minor: 3, Patch: 0}
 	requiredNodeVersion   = dex.Semver{Major: 6, Minor: 1, Patch: 2}
 )
 

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -221,6 +221,12 @@ func runTest(t *testing.T, splitTx bool) {
 	}
 	rig.beta().ReturnCoins(utxos)
 
+	if splitTx {
+		// Wait a bit before calling FundOrder to prevent listunspent
+		// from returning coins spent in previous split txs.
+		time.Sleep(time.Second)
+	}
+
 	// Get a separate set of UTXOs for each contract.
 	setOrderValue(contractValue)
 	utxos1, _, err := rig.beta().FundOrder(ord)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -72,7 +72,7 @@ type Wallet interface {
 	// Fund selects coins for use in an order. The coins will be locked, and will
 	// not be returned in subsequent calls to Fund or calculated in calls to
 	// Available, unless they are unlocked with ReturnCoins.
-	FundOrder(*Order) (Coins, error)
+	FundOrder(*Order) (Coins, []dex.Bytes, error)
 	// ReturnCoins unlocks coins. This would be necessary in the case of a
 	// canceled order.
 	ReturnCoins(Coins) error
@@ -172,8 +172,6 @@ type Coin interface {
 	// Confirmations is the number of confirmations on this Coin's block. If the
 	// coin becomes spent, Confirmations should return an error.
 	Confirmations() (uint32, error)
-	// Redeem is any redeem script required to spend the coin.
-	Redeem() dex.Bytes
 }
 
 // Coins a collection of coins as returned by Fund.
@@ -185,6 +183,8 @@ type Receipt interface {
 	Expiration() time.Time
 	// Coin is the contract's coin.
 	Coin() Coin
+	// Contract is the contract script.
+	Contract() dex.Bytes
 	// String provides a human-readable representation of the contract's Coin.
 	String() string
 }
@@ -198,6 +198,8 @@ type AuditInfo interface {
 	Expiration() time.Time
 	// Coin is the coin that contains the contract.
 	Coin() Coin
+	// Contract is the contract script.
+	Contract() dex.Bytes
 	// SecretHash is the contract's secret hash.
 	SecretHash() dex.Bytes
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -69,10 +69,14 @@ type Wallet interface {
 	// confirmations for which to calculate maturity, and returns a list of
 	// corresponding *Balance.
 	Balance() (*Balance, error)
-	// Fund selects coins for use in an order. The coins will be locked, and will
-	// not be returned in subsequent calls to Fund or calculated in calls to
-	// Available, unless they are unlocked with ReturnCoins.
-	FundOrder(*Order) (Coins, []dex.Bytes, error)
+	// FundOrder selects coins for use in an order. The coins will be locked,
+	// and will not be returned in subsequent calls to FundOrder or calculated
+	// in calls to Available, unless they are unlocked with ReturnCoins. The
+	// returned []dex.Bytes contains the redeem scripts for the selected coins.
+	// Equal number of coins and redeemed scripts must be returned. A nil or
+	// empty dex.Bytes should be appended to the redeem scripts collection for
+	// coins with no redeem script.
+	FundOrder(*Order) (coins Coins, redeemScripts []dex.Bytes, err error)
 	// ReturnCoins unlocks coins. This would be necessary in the case of a
 	// canceled order.
 	ReturnCoins(Coins) error

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -398,10 +398,10 @@ func (tdb *TDB) Backup() error {
 func (tdb *TDB) AckNotification(id []byte) error { return nil }
 
 type tCoin struct {
-	id, script []byte
-	confs      uint32
-	confsErr   error
-	val        uint64
+	id       []byte
+	confs    uint32
+	confsErr error
+	val      uint64
 }
 
 func (c *tCoin) ID() dex.Bytes {
@@ -420,17 +420,18 @@ func (c *tCoin) Confirmations() (uint32, error) {
 	return c.confs, c.confsErr
 }
 
-func (c *tCoin) Redeem() dex.Bytes {
-	return c.script
-}
-
 type tReceipt struct {
 	coin       *tCoin
+	contract   []byte
 	expiration time.Time
 }
 
 func (r *tReceipt) Coin() asset.Coin {
 	return r.coin
+}
+
+func (r *tReceipt) Contract() dex.Bytes {
+	return r.contract
 }
 
 func (r *tReceipt) Expiration() time.Time {
@@ -445,6 +446,7 @@ type tAuditInfo struct {
 	recipient  string
 	expiration time.Time
 	coin       *tCoin
+	contract   []byte
 	secretHash []byte
 }
 
@@ -460,37 +462,42 @@ func (ai *tAuditInfo) Coin() asset.Coin {
 	return ai.coin
 }
 
+func (ai *tAuditInfo) Contract() dex.Bytes {
+	return ai.contract
+}
+
 func (ai *tAuditInfo) SecretHash() dex.Bytes {
 	return ai.secretHash
 }
 
 type TXCWallet struct {
-	mtx            sync.RWMutex
-	payFeeCoin     *tCoin
-	payFeeErr      error
-	fundCoins      asset.Coins
-	fundErr        error
-	addrErr        error
-	signCoinErr    error
-	lastSwaps      *asset.Swaps
-	swapReceipts   []asset.Receipt
-	auditInfo      asset.AuditInfo
-	auditErr       error
-	refundCoin     dex.Bytes
-	refundErr      error
-	redeemCoins    []dex.Bytes
-	badSecret      bool
-	fundedVal      uint64
-	fundedSwaps    uint64
-	connectErr     error
-	unlockErr      error
-	balErr         error
-	bal            *asset.Balance
-	fundingCoins   asset.Coins
-	returnedCoins  asset.Coins
-	fundingCoinErr error
-	lockErr        error
-	changeCoin     *tCoin
+	mtx               sync.RWMutex
+	payFeeCoin        *tCoin
+	payFeeErr         error
+	fundCoins         asset.Coins
+	fundRedeemScripts []dex.Bytes
+	fundErr           error
+	addrErr           error
+	signCoinErr       error
+	lastSwaps         *asset.Swaps
+	swapReceipts      []asset.Receipt
+	auditInfo         asset.AuditInfo
+	auditErr          error
+	refundCoin        dex.Bytes
+	refundErr         error
+	redeemCoins       []dex.Bytes
+	badSecret         bool
+	fundedVal         uint64
+	fundedSwaps       uint64
+	connectErr        error
+	unlockErr         error
+	balErr            error
+	bal               *asset.Balance
+	fundingCoins      asset.Coins
+	returnedCoins     asset.Coins
+	fundingCoinErr    error
+	lockErr           error
+	changeCoin        *tCoin
 }
 
 func newTWallet(assetID uint32) (*xcWallet, *TXCWallet) {
@@ -531,10 +538,10 @@ func (w *TXCWallet) FeeRate() (uint64, error) {
 	return 24, nil
 }
 
-func (w *TXCWallet) FundOrder(ord *asset.Order) (asset.Coins, error) {
+func (w *TXCWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, error) {
 	w.fundedVal = ord.Value
 	w.fundedSwaps = ord.MaxSwapCount
-	return w.fundCoins, w.fundErr
+	return w.fundCoins, w.fundRedeemScripts, w.fundErr
 }
 
 func (w *TXCWallet) ReturnCoins(coins asset.Coins) error {
@@ -1818,6 +1825,7 @@ func TestTrade(t *testing.T) {
 		val: qty * 2,
 	}
 	tDcrWallet.fundCoins = asset.Coins{dcrCoin}
+	tDcrWallet.fundRedeemScripts = []dex.Bytes{nil}
 
 	btcVal := calc.BaseToQuote(rate, qty*2)
 	btcCoin := &tCoin{
@@ -1825,6 +1833,7 @@ func TestTrade(t *testing.T) {
 		val: btcVal,
 	}
 	tBtcWallet.fundCoins = asset.Coins{btcCoin}
+	tBtcWallet.fundRedeemScripts = []dex.Bytes{nil}
 
 	book := newBookie(func() {})
 	rig.dc.books[tDcrBtcMktName] = book
@@ -2793,7 +2802,7 @@ func TestRefunds(t *testing.T) {
 	}
 	swapID := encode.RandomBytes(36)
 	contract := encode.RandomBytes(36)
-	tDcrWallet.swapReceipts = []asset.Receipt{&tReceipt{coin: &tCoin{id: swapID, script: contract}}}
+	tDcrWallet.swapReceipts = []asset.Receipt{&tReceipt{coin: &tCoin{id: swapID}, contract: contract}}
 	sign(tDexPriv, msgMatch)
 	msg, _ := msgjson.NewRequest(1, msgjson.MatchRoute, []*msgjson.Match{msgMatch})
 	rig.ws.queueResponse(msgjson.InitRoute, initAcker)
@@ -2870,7 +2879,7 @@ func TestRefunds(t *testing.T) {
 	auditInfo.coin.confs = tBTC.SwapConf
 	counterSwapID := encode.RandomBytes(36)
 	counterScript := encode.RandomBytes(36)
-	tDcrWallet.swapReceipts = []asset.Receipt{&tReceipt{coin: &tCoin{id: counterSwapID, script: counterScript}}}
+	tDcrWallet.swapReceipts = []asset.Receipt{&tReceipt{coin: &tCoin{id: counterSwapID}, contract: counterScript}}
 	rig.ws.queueResponse(msgjson.InitRoute, initAcker)
 	dc.tickAsset(tBTC.ID)
 
@@ -3388,6 +3397,7 @@ func tMsgAudit(oid order.OrderID, mid order.MatchID, recipient string, val uint6
 	auditInfo := &tAuditInfo{
 		recipient:  recipient,
 		coin:       auditCoin,
+		contract:   auditContract,
 		secretHash: secretHash,
 	}
 	return audit, auditInfo

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1169,11 +1169,11 @@ func (t *trackedTrade) swapMatches(matches []*matchTracker) error {
 		match := matches[i]
 		coin := receipt.Coin()
 		log.Infof("Contract coin %v (%s), value = %d, refundable at %v (script = %v)",
-			coin, t.wallets.fromAsset.Symbol, coin.Value(), receipt.Expiration(), coin.Redeem())
+			coin, t.wallets.fromAsset.Symbol, coin.Value(), receipt.Expiration(), receipt.Contract())
 		if secret := match.MetaData.Proof.Secret; len(secret) > 0 {
 			log.Tracef("Contract coin %v secret = %x", coin, secret)
 		}
-		err := t.finalizeSwapAction(match, coin.ID(), coin.Redeem())
+		err := t.finalizeSwapAction(match, coin.ID(), receipt.Contract())
 		if err != nil {
 			errs.addErr(err)
 		}

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -727,9 +727,6 @@ func (tCoin) Value() uint64 {
 func (tCoin) Confirmations() (uint32, error) {
 	return 0, nil
 }
-func (tCoin) Redeem() dex.Bytes {
-	return nil
-}
 
 func TestHandleWithdraw(t *testing.T) {
 	pw := encode.PassBytes("password123")

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -265,10 +265,6 @@ func (c *tCoin) Confirmations() (uint32, error) {
 	return c.confs, c.confsErr
 }
 
-func (c *tCoin) Redeem() dex.Bytes {
-	return nil
-}
-
 type tWalletState struct {
 	open     bool
 	running  bool

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -51,10 +51,6 @@ func (c *tCoin) Confirmations() (uint32, error) {
 	return c.confs, c.confsErr
 }
 
-func (c *tCoin) Redeem() dex.Bytes {
-	return nil
-}
-
 type TCore struct {
 	balanceErr      error
 	syncBook        *core.OrderBook


### PR DESCRIPTION
Funding coins are no longer unlocked when ExchangeWallets shuts down,
so trying to retrieve funding coins from unspent outputs may fail, unless
the coins were manually unlocked.

Also fixed issues with redeem script being required, but unset for some coins
such as when parsing `listunspent` results in `dcr.parseUTXOs` and when
loading funding coins from `listlockunspent` results in `btc.FundingCoins`.