### PR TITLE
server/swap: inaction check fixes

### DIFF
--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -225,9 +225,8 @@ sleep 5
 # Have alpha send some credits to the other wallets
 for i in 10 18 5 7 1 15 3 25
 do
-  tmux send-keys -t $SESSION:0 "./alpha sendtoaddress ${BETA_MINING_ADDR} ${i}${WAIT}" C-m\; wait-for donedcr
-  tmux send-keys -t $SESSION:0 "./alpha sendtoaddress ${TRADING_WALLET1_ADDRESS} ${i}${WAIT}" C-m\; wait-for donedcr
-  tmux send-keys -t $SESSION:0 "./alpha sendtoaddress ${TRADING_WALLET2_ADDRESS} ${i}${WAIT}" C-m\; wait-for donedcr
+  RECIPIENTS="{\"${BETA_MINING_ADDR}\":${i},\"${TRADING_WALLET1_ADDRESS}\":${i},\"${TRADING_WALLET2_ADDRESS}\":${i}}"
+  tmux send-keys -t $SESSION:0 "./alpha sendmany default '${RECIPIENTS}'${WAIT}" C-m\; wait-for donedcr
 done
 sleep 0.5
 tmux send-keys -t $SESSION:0 "./mine-alpha 1${WAIT}" C-m\; wait-for donedcr

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -62,9 +62,11 @@ cat > "${NODES_ROOT}/harness-ctl/mine-alpha" <<EOF
   esac
   for i in \$(seq \$NUM) ; do
     dcrctl -C ${NODES_ROOT}/alpha/alpha-ctl.conf regentemplate
-    sleep 0.1
+    sleep 0.05
     dcrctl -C ${NODES_ROOT}/alpha/alpha-ctl.conf generate 1
-    sleep 0.5
+    if [ $i != $NUM ]; then
+      sleep 0.5
+    fi
   done
 EOF
 chmod +x "${NODES_ROOT}/harness-ctl/mine-alpha"
@@ -79,9 +81,11 @@ NUM=1
   esac
   for i in \$(seq \$NUM) ; do
     dcrctl -C ${NODES_ROOT}/beta/beta-ctl.conf regentemplate
-    sleep 0.1
+    sleep 0.05
     dcrctl -C ${NODES_ROOT}/beta/beta-ctl.conf generate 1
-    sleep 0.5
+    if [ $i != $NUM ]; then
+      sleep 0.5
+    fi
   done
 EOF
 chmod +x "${NODES_ROOT}/harness-ctl/mine-beta"
@@ -221,10 +225,12 @@ sleep 5
 # Have alpha send some credits to the other wallets
 for i in 10 18 5 7 1 15 3 25
 do
-  tmux send-keys -t $SESSION:0 "./fund ${BETA_MINING_ADDR} ${i}${WAIT}" C-m\; wait-for donedcr
-  tmux send-keys -t $SESSION:0 "./fund ${TRADING_WALLET1_ADDRESS} ${i}${WAIT}" C-m\; wait-for donedcr
-  tmux send-keys -t $SESSION:0 "./fund ${TRADING_WALLET2_ADDRESS} ${i}${WAIT}" C-m\; wait-for donedcr
+  tmux send-keys -t $SESSION:0 "./alpha sendtoaddress ${BETA_MINING_ADDR} ${i}${WAIT}" C-m\; wait-for donedcr
+  tmux send-keys -t $SESSION:0 "./alpha sendtoaddress ${TRADING_WALLET1_ADDRESS} ${i}${WAIT}" C-m\; wait-for donedcr
+  tmux send-keys -t $SESSION:0 "./alpha sendtoaddress ${TRADING_WALLET2_ADDRESS} ${i}${WAIT}" C-m\; wait-for donedcr
 done
+sleep 0.5
+tmux send-keys -t $SESSION:0 "./mine-alpha 1${WAIT}" C-m\; wait-for donedcr
 
 # Create fee account on alpha wallet for use by dcrdex simnet instances.
 tmux send-keys -t $SESSION:0 "./alpha createnewaccount server_fees${WAIT}" C-m\; wait-for donedcr

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -87,6 +87,7 @@ signingkeypass=keypass
 adminsrvon=1
 adminsrvpass=adminpass
 adminsrvaddr=127.0.0.1:16542
+bcasttimeout=1m
 EOF
 
 # Set the postgres user pass if provided. 

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -52,7 +52,7 @@ const (
 	defaultCancelThresh     = 0.95 // 19 cancels : 1 success
 	defaultRegFeeConfirms   = 4
 	defaultRegFeeAmount     = 1e8
-	defaultBroadcastTimeout = time.Minute
+	defaultBroadcastTimeout = 5 * time.Minute
 )
 
 var (

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -796,7 +796,7 @@ func (a *Archiver) updateOrderStatusByID(oid order.OrderID, base, quote uint32, 
 	}
 
 	if initStatus == status && filled == initFilled {
-		log.Debugf("Not updating order with no status or filled amount change.")
+		log.Tracef("Not updating order with no status or filled amount change: %v.", oid)
 		return nil
 	}
 	if filled == -1 {

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -172,7 +172,7 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 	}
 
 	if _, suspended := r.auth.Suspended(user); suspended {
-		return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account may not submit trade orders")
+		return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account %v may not submit trade orders", user)
 	}
 
 	tunnel, coins, sell, rpcErr := r.extractMarketDetails(&limit.Prefix, &limit.Trade)
@@ -290,7 +290,7 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 	}
 
 	if _, suspended := r.auth.Suspended(user); suspended {
-		return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account may not submit trade orders")
+		return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account %v may not submit trade orders", user)
 	}
 
 	tunnel, assets, sell, rpcErr := r.extractMarketDetails(&market.Prefix, &market.Trade)

--- a/server/matcher/match.go
+++ b/server/matcher/match.go
@@ -184,7 +184,7 @@ func (m *Matcher) Match(book Booker, queue []*OrderRevealed) (seed []byte, match
 			removed, ok := book.Remove(o.TargetOrderID)
 			if !ok {
 				// The targeted order might be down queue or non-existent.
-				log.Debugf("Failed to remove order %v set by a cancel order %v",
+				log.Debugf("Order %v not removed by a cancel order %v (target either non-existent or down queue in this epoch)",
 					o.ID(), o.TargetOrderID)
 				failed = append(failed, q)
 				updates.CancelsFailed = append(updates.CancelsFailed, o)

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -2114,8 +2114,9 @@ func (s *Swapper) handleInit(user account.AccountID, msg *msgjson.Message) *msgj
 		},
 		ExpireFunc: func() {
 			s.rmLiveWaiter(user, msg.ID)
-			// Tell them to broadcast again or check their node before broadcast
-			// timeout is reached and the match is revoked.
+			// NOTE: We may consider a shorter expire time so the client can
+			// receive warning that their may be node connectivity trouble
+			// while they still have a chance to fix it.
 			s.respondError(msg.ID, user, msgjson.TransactionUndiscovered,
 				fmt.Sprintf("failed to find contract coin %v", coinStr))
 		},
@@ -2212,9 +2213,11 @@ func (s *Swapper) handleRedeem(user account.AccountID, msg *msgjson.Message) *ms
 		},
 		ExpireFunc: func() {
 			s.rmLiveWaiter(user, msg.ID)
+			// NOTE: We may consider a shorter expire time so the client can
+			// receive warning that their may be node connectivity trouble
+			// while they still have a chance to fix it.
 			s.respondError(msg.ID, user, msgjson.TransactionUndiscovered,
 				fmt.Sprintf("failed to find redeemed coin %v", coinStr))
-			// Client should retry the redeem request, maybe even rebroadcast.
 		},
 	})
 	return nil

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -2115,8 +2115,8 @@ func (s *Swapper) handleInit(user account.AccountID, msg *msgjson.Message) *msgj
 		ExpireFunc: func() {
 			s.rmLiveWaiter(user, msg.ID)
 			// NOTE: We may consider a shorter expire time so the client can
-			// receive warning that their may be node connectivity trouble
-			// while they still have a chance to fix it.
+			// receive warning that there may be node or wallet connectivity
+			// trouble while they still have a chance to fix it.
 			s.respondError(msg.ID, user, msgjson.TransactionUndiscovered,
 				fmt.Sprintf("failed to find contract coin %v", coinStr))
 		},
@@ -2214,8 +2214,8 @@ func (s *Swapper) handleRedeem(user account.AccountID, msg *msgjson.Message) *ms
 		ExpireFunc: func() {
 			s.rmLiveWaiter(user, msg.ID)
 			// NOTE: We may consider a shorter expire time so the client can
-			// receive warning that their may be node connectivity trouble
-			// while they still have a chance to fix it.
+			// receive warning that there may be node or wallet connectivity
+			// trouble while they still have a chance to fix it.
 			s.respondError(msg.ID, user, msgjson.TransactionUndiscovered,
 				fmt.Sprintf("failed to find redeemed coin %v", coinStr))
 		},

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -2234,10 +2234,11 @@ func TestState(t *testing.T) {
 
 	// "broadcast" the contract and signal a new block.
 	abc.setContract(makerSwap.coin, true)
+	// tickMempool() // latencyQ triggers processInit and audit request
 	makerSwap.coin.setConfs(int64(rig.abc.SwapConf))
-	sendBlock(abc) // wait recheckInterval*3/2 for the coin waiter, plus trigger processBlock
-	// processInit should have succeeded, requesting an ack from taker of the maker's contract.
-	reqTimeout(recheckInterval * 3 / 2) // 'audit' sent, but no ack resp yet
+	sendBlock(abc) // trigger processBlock, tryConfirmSwap
+	// processInit should have succeeded, requesting an audit ack from taker of the maker's contract.
+	reqTimeout(recheckInterval * 2) // 'audit' sent, but no ack resp yet
 
 	matchInfo.db.makerSwap = makerSwap // for taker's audit
 
@@ -2339,10 +2340,11 @@ func TestState(t *testing.T) {
 
 	// "broadcast" the contract and signal a new block.
 	xyz.setContract(takerSwap.coin, true)
+	// tickMempool() // latencyQ triggers processInit and audit request
 	takerSwap.coin.setConfs(int64(rig.xyz.SwapConf))
-	sendBlock(xyz) // wait recheckInterval*3/2 for the coin waiter, plus trigger processBlock
+	sendBlock(xyz) // trigger processBlock, tryConfirmSwap
 	// processInit should have succeeded, requesting an ack from taker of the maker's contract.
-	reqTimeout(recheckInterval * 3 / 2) // 'audit' sent, but no ack resp yet
+	reqTimeout(recheckInterval * 2) // 'audit' sent, but no ack resp yet
 
 	matchInfo.db.takerSwap = takerSwap // for maker's audit
 
@@ -2442,9 +2444,9 @@ func TestState(t *testing.T) {
 	// "broadcast" the redeem and signal a new block.
 	xyz.setRedemption(makerRedeem.coin, true)
 	makerRedeem.coin.setConfs(int64(rig.xyz.SwapConf))
-	sendBlock(xyz) // wait recheckInterval*3/2 for the coin waiter, plus trigger processBlock
+	sendBlock(xyz) // trigger processBlock, redeem status check (not needed!)
 	// processRedeem should have succeeded, requesting an ack from taker of the maker's redeem.
-	reqTimeout(recheckInterval * 3 / 2) // 'redemption' sent, but no ack resp yet
+	reqTimeout(recheckInterval * 2) // 'redemption' sent, but no ack resp yet
 
 	matchInfo.db.makerRedeem = makerRedeem // for taker's redeem ack
 
@@ -2538,9 +2540,9 @@ func TestState(t *testing.T) {
 	// "broadcast" the redeem and signal a new block.
 	abc.setRedemption(takerRedeem.coin, true)
 	takerRedeem.coin.setConfs(int64(rig.abc.SwapConf))
-	sendBlock(abc) // wait recheckInterval*3/2 for the coin waiter, plus trigger processBlock
+	sendBlock(abc) // trigger processBlock, redeem status check (not needed!)
 	// processRedeem should have succeeded, requesting an ack from maker of the taker's redeem.
-	reqTimeout(recheckInterval * 3 / 2) // 'redemption' sent, but no ack resp yet
+	reqTimeout(recheckInterval * 2) // 'redemption' sent, but no ack resp yet
 
 	matchInfo.db.takerRedeem = takerRedeem // for maker's redeem ack
 


### PR DESCRIPTION
The contains a number if fixes to the server's inaction checks:

- Fix inaction asset ID checks skipping checks because of incorrect swapAsset.
- Set swapConfirmed time from the block time, not time.Now, which was causing inaction check to pass by fractions of a second.
- On startup, schedule an inaction check for each asset.
- Separate block based and "event"-based checks.  `NewlyMatched`->`MakerSwapCast` timing starts at the time the match requests are sent (**event-based**), `MakerSwapCast`->`TakerSwapCast` starts at the time the maker's swap reaches swapConf (**block-based**), `TakerSwapCast`->`MakerRedeemed` starts at the time the taker's swap reaches swapConf (**block-based**), and `MakerRedeemed`->`MatchComplete` starts at the time the maker broadcasts their redeem, notifies server, and server informs taker (**event based**).

Other changes:
- Triggering of inaction checks is refactored, usings `AfterFunc`s.
- Default broadcast timeout is not 5 minutes, up from 1 minute, but the dcrdex harness still uses 1 min via the config setting.
- Swapper's txn waiter expiration is now 2 min, up from 1 min.
- On Swapper construction, the tx waiter expiration is checked against the configured bcast timeout so that it is never longer than bcast timeout.
- Swapper's coin recheck interval is slightly smaller (5 sec -> 3 sec)