### PR TITLE
app: show contract-locked amounts and update balances when needed

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2153,8 +2153,7 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	result := new(msgjson.OrderResult)
 	err = dc.signAndRequest(msgOrder, route, result, DefaultResponseTimeout)
 	if err != nil {
-		// Do NOT unlock the coins because the request may have actually reached
-		// the server.
+		unlockCoins()
 		return nil, 0, fmt.Errorf("new order request with DEX server %v failed: %w", dc.acct.host, err)
 	}
 
@@ -2189,7 +2188,7 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	}
 	err = c.db.UpdateOrder(dbOrder)
 	if err != nil {
-		// Do NOT unlock the coins, they're already locked by server.
+		unlockCoins()
 		logAbandon(fmt.Sprintf("failed to store order in database: %v", err))
 		return nil, 0, fmt.Errorf("Order abandoned due to database error: %w", err)
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2853,8 +2853,14 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				notifyErr("Order coin error", "Source coins retrieval error for %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
 				continue
 			}
-			relocks.count(wallets.fromAsset.ID)
 			tracker.coins = mapifyCoins(coins)
+		}
+
+		// Active orders and orders with matches with unsent swaps need the funding
+		// coin(s).
+		// Orders with sent but unspent swaps need to recompute contract-locked amts.
+		if isActive || needsCoins || tracker.unspentContractAmounts(wallets.fromAsset.ID) > 0 {
+			relocks.count(wallets.fromAsset.ID)
 		}
 
 		dc.trades[tracker.ID()] = tracker

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -3716,11 +3716,14 @@ func TestAssetBalance(t *testing.T) {
 		Locked:    2e8,
 	}
 	tWallet.bal = bal
-	balances, err := tCore.AssetBalance(tDCR.ID)
+	walletBal, err := tCore.AssetBalance(tDCR.ID)
 	if err != nil {
 		t.Fatalf("error retreiving asset balance: %v", err)
 	}
-	dbtest.MustCompareAssetBalances(t, "zero-conf", bal, &balances.Balance)
+	dbtest.MustCompareAssetBalances(t, "zero-conf", bal, &walletBal.Balance.Balance)
+	if walletBal.ContractLocked != 0 {
+		t.Fatalf("contractlocked balance %d > expected value 0", walletBal.ContractLocked)
+	}
 }
 
 func TestAssetCounter(t *testing.T) {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -204,11 +204,11 @@ func newConnEventNote(subject, host string, connected bool, details string, seve
 // BalanceNote is an update to a wallet's balance.
 type BalanceNote struct {
 	db.Notification
-	AssetID uint32      `json:"assetID"`
-	Balance *db.Balance `json:"balance"`
+	AssetID uint32         `json:"assetID"`
+	Balance *WalletBalance `json:"balance"`
 }
 
-func newBalanceNote(assetID uint32, bal *db.Balance) *BalanceNote {
+func newBalanceNote(assetID uint32, bal *WalletBalance) *BalanceNote {
 	return &BalanceNote{
 		Notification: db.NewNotification(NoteTypeBalance, "balance updated", "", db.Data),
 		AssetID:      assetID,

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -632,12 +632,13 @@ func (t *trackedTrade) activeMatches() []*matchTracker {
 
 // unspentContractAmounts returns the total amount locked in unspent swaps.
 func (t *trackedTrade) unspentContractAmounts(assetID uint32) (amount uint64) {
-	if t.wallets.fromAsset.ID != assetID {
+	if t.fromAssetID != assetID {
 		// Only swaps sent from the specified assetID should count.
 		return 0
 	}
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
+	swapSentFromQuoteAsset := t.fromAssetID == t.Quote()
 	for _, match := range t.matches {
 		side, status := match.Match.Side, match.Match.Status
 		if status >= order.MakerRedeemed || len(match.MetaData.Proof.RefundCoin) != 0 {
@@ -649,7 +650,7 @@ func (t *trackedTrade) unspentContractAmounts(assetID uint32) (amount uint64) {
 		if (side == order.Maker && status >= order.MakerSwapCast) ||
 			(side == order.Taker && status == order.TakerSwapCast) {
 			swapAmount := match.Match.Quantity
-			if t.Trade().Sell {
+			if swapSentFromQuoteAsset {
 				swapAmount = calc.BaseToQuote(match.Match.Rate, match.Match.Quantity)
 			}
 			amount += swapAmount

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -243,13 +243,14 @@ func (t *trackedTrade) cancelTrade(co *order.CancelOrder, preImg order.Preimage)
 }
 
 // nomatch sets the appropriate order status and returns funding coins.
-func (t *trackedTrade) nomatch(oid order.OrderID) error {
+func (t *trackedTrade) nomatch(oid order.OrderID) (assetMap, error) {
+	assets := make(assetMap)
 	// Check if this is the cancel order.
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	if t.ID() != oid {
 		if t.cancel == nil || t.cancel.ID() != oid {
-			return newError(unknownOrderErr, "nomatch order ID %s does not match trade or cancel order", oid)
+			return assets, newError(unknownOrderErr, "nomatch order ID %s does not match trade or cancel order", oid)
 		}
 		// This is a cancel order. Cancel status goes to executed, but the trade
 		// status will not be canceled. Remove the trackedCancel and remove the
@@ -267,12 +268,12 @@ func (t *trackedTrade) nomatch(oid order.OrderID) error {
 		details := fmt.Sprintf("Cancel order did not match for order %s. This can happen if the cancel order is submitted in the same epoch as the trade or if the target order is fully executed before matching with the cancel order.", t.token())
 		corder, _ := t.coreOrderInternal()
 		t.notify(newOrderNote("Missed cancel", details, db.WarningLevel, corder))
-		return t.db.UpdateOrderStatus(cid, order.OrderStatusExecuted)
+		return assets, t.db.UpdateOrderStatus(cid, order.OrderStatusExecuted)
 	}
 	// This is the trade. Return coins and set status based on whether this is
 	// a standing limit order or not.
 	if t.metaData.Status != order.OrderStatusEpoch {
-		return fmt.Errorf("nomatch sent for non-epoch order %s", oid)
+		return assets, fmt.Errorf("nomatch sent for non-epoch order %s", oid)
 	}
 	if lo, ok := t.Order.(*order.LimitOrder); ok && lo.Force == order.StandingTiF {
 		log.Infof("Standing order %s did not match and is now booked.", t.token())
@@ -281,12 +282,13 @@ func (t *trackedTrade) nomatch(oid order.OrderID) error {
 		t.notify(newOrderNote("Order booked", "", db.Data, corder))
 	} else {
 		t.returnCoins()
+		assets.count(t.wallets.fromAsset.ID)
 		log.Infof("Non-standing order %s did not match.", t.token())
 		t.metaData.Status = order.OrderStatusExecuted
 		corder, _ := t.coreOrderInternal()
 		t.notify(newOrderNote("No match", "", db.Data, corder))
 	}
-	return t.db.UpdateOrderStatus(t.ID(), t.metaData.Status)
+	return assets, t.db.UpdateOrderStatus(t.ID(), t.metaData.Status)
 }
 
 // negotiate creates and stores matchTrackers for the []*msgjson.Match, and
@@ -919,6 +921,7 @@ func (t *trackedTrade) tick() (assetMap, error) {
 	if len(redeems) > 0 {
 		toAsset := t.wallets.toAsset.ID
 		assets.count(toAsset)
+		assets.count(t.fromAssetID) // update the from wallet balance to reduce contractlocked balance
 		qty := received
 		if t.Trade().Sell {
 			qty = quoteReceived

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -68,15 +68,24 @@ type WalletForm struct {
 	Config  map[string]string
 }
 
+// WalletBalance is an exchange wallet's balance which includes contractlocked
+// amounts in addition to other balance details stored in db.
+type WalletBalance struct {
+	*db.Balance
+	// ContractLocked is the total amount of funds locked in unspent
+	// (i.e. unredeemed / unrefunded) swap contracts.
+	ContractLocked uint64 `json:"contractlocked"`
+}
+
 // WalletState is the current status of an exchange wallet.
 type WalletState struct {
-	Symbol  string      `json:"symbol"`
-	AssetID uint32      `json:"assetID"`
-	Open    bool        `json:"open"`
-	Running bool        `json:"running"`
-	Balance *db.Balance `json:"balance"`
-	Address string      `json:"address"`
-	Units   string      `json:"units"`
+	Symbol  string         `json:"symbol"`
+	AssetID uint32         `json:"assetID"`
+	Open    bool           `json:"open"`
+	Running bool           `json:"running"`
+	Balance *WalletBalance `json:"balance"`
+	Address string         `json:"address"`
+	Units   string         `json:"units"`
 }
 
 // User is information about the user's wallets and DEX accounts.

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/asset"
-	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
 )
 
@@ -21,7 +20,7 @@ type xcWallet struct {
 	mtx       sync.RWMutex
 	lockTime  time.Time
 	hookedUp  bool
-	balance   *db.Balance
+	balance   *WalletBalance
 	encPW     []byte
 	address   string
 	dbID      []byte
@@ -71,7 +70,7 @@ func (w *xcWallet) state() *WalletState {
 }
 
 // setBalance sets the wallet balance.
-func (w *xcWallet) setBalance(bal *db.Balance) {
+func (w *xcWallet) setBalance(bal *WalletBalance) {
 	w.mtx.Lock()
 	w.balance = bal
 	w.mtx.Unlock()

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -396,17 +396,13 @@ func decodeAssetBalance_v0(pushes [][]byte) (*asset.Balance, error) {
 // Balance represents a wallet's balance in various contexts.
 type Balance struct {
 	asset.Balance
-	// ContractLocked is the total amount of funds locked in unspent
-	// (i.e. unredeemed / unrefunded) swap contracts.
-	ContractLocked uint64    `json:"contractlocked"`
-	Stamp          time.Time `json:"stamp"`
+	Stamp time.Time `json:"stamp"`
 }
 
 // Encode encodes the Balance to a versioned blob.
 func (b *Balance) Encode() []byte {
 	return dbBytes{0}.
 		AddData(encodeAssetBalance(&b.Balance)).
-		AddData(uint64Bytes(b.ContractLocked)).
 		AddData(uint64Bytes(encode.UnixMilliU(b.Stamp)))
 }
 
@@ -424,18 +420,20 @@ func DecodeBalance(b []byte) (*Balance, error) {
 }
 
 func decodeBalance_v0(pushes [][]byte) (*Balance, error) {
-	if len(pushes) != 3 {
-		return nil, fmt.Errorf("decodeBalances_v0: expected 3 pushes. got %d", len(pushes))
+	if len(pushes) < 2 {
+		return nil, fmt.Errorf("decodeBalances_v0: expected >= 2 pushes. got %d", len(pushes))
+	}
+	if len(pushes)%2 != 0 {
+		return nil, fmt.Errorf("decodeBalances_v0: expected an even number of pushes, got %d", len(pushes))
 	}
 	bal, err := decodeAssetBalance(pushes[0])
 	if err != nil {
-		return nil, fmt.Errorf("decodeBalances_v0: error decoding asset balance: %v", err)
+		return nil, fmt.Errorf("decodeBalances_v0: error decoding zero conf balance: %v", err)
 	}
 
 	return &Balance{
-		Balance:        *bal,
-		ContractLocked: intCoder.Uint64(pushes[1]),
-		Stamp:          encode.UnixTimeMilli(int64(intCoder.Uint64(pushes[2]))),
+		Balance: *bal,
+		Stamp:   encode.UnixTimeMilli(int64(intCoder.Uint64(pushes[1]))),
 	}, nil
 }
 

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -22,7 +22,6 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/core"
-	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/client/websocket"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
@@ -54,7 +53,7 @@ var (
 // clientCore is satisfied by core.Core.
 type clientCore interface {
 	websocket.Core
-	AssetBalance(assetID uint32) (*db.Balance, error)
+	AssetBalance(assetID uint32) (*core.WalletBalance, error)
 	Book(host string, base, quote uint32) (orderBook *core.OrderBook, err error)
 	Cancel(appPass []byte, orderID string) error
 	CloseWallet(assetID uint32) error

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -19,7 +19,6 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/core"
-	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
 )
@@ -66,7 +65,7 @@ func (c *TCore) Book(dex string, base, quote uint32) (*core.OrderBook, error) {
 	return c.book, c.bookErr
 }
 func (c *TCore) AckNotes(ids []dex.Bytes) {}
-func (c *TCore) AssetBalance(uint32) (*db.Balance, error) {
+func (c *TCore) AssetBalance(uint32) (*core.WalletBalance, error) {
 	return nil, c.balanceErr
 }
 func (c *TCore) Cancel(pw []byte, sid string) error {

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -251,8 +251,8 @@ func (s *WebServer) apiGetBalance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := &struct {
-		OK      bool        `json:"ok"`
-		Balance *db.Balance `json:"balance"`
+		OK      bool                `json:"ok"`
+		Balance *core.WalletBalance `json:"balance"`
 	}{
 		OK:      true,
 		Balance: bal,

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -1432,11 +1432,11 @@ class BalanceWidget {
     // We have a wallet and a DEX-specific balance. Set all of the fields.
     Doc.show(side.avail, side.immature, side.locked)
     side.avail.textContent = Doc.formatCoinValue(bal.available / 1e8)
-    side.locked.textContent = Doc.formatCoinValue(bal.locked / 1e8)
+    side.locked.textContent = Doc.formatCoinValue((bal.locked + bal.contractlocked) / 1e8)
     side.immature.textContent = Doc.formatCoinValue(bal.immature / 1e8)
     // If the current balance update time is older than an hour, show the
     // expiration icon. Request a balance update, if possible.
-    const expired = new Date().getTime() - new Date(wallet.balance.stamp).getTime() > anHour
+    const expired = new Date().getTime() - new Date(bal.stamp).getTime() > anHour
     if (expired) {
       Doc.show(side.expired)
       if (wallet.running) this.fetchBalance(side.id)

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -22,7 +22,6 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/core"
-	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/client/websocket"
 	"decred.org/dcrdex/dex"
 	"github.com/go-chi/chi"
@@ -62,7 +61,7 @@ type clientCore interface {
 	Register(*core.RegisterForm) (*core.RegisterResult, error)
 	Login(pw []byte) (*core.LoginResult, error)
 	InitializeClient(pw []byte) error
-	AssetBalance(assetID uint32) (*db.Balance, error)
+	AssetBalance(assetID uint32) (*core.WalletBalance, error)
 	CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error
 	OpenWallet(assetID uint32, pw []byte) error
 	CloseWallet(assetID uint32) error

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -17,7 +17,6 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/core"
-	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/order"
@@ -85,7 +84,7 @@ func (c *TCore) SyncBook(dex string, base, quote uint32) (*core.OrderBook, *core
 func (c *TCore) Book(dex string, base, quote uint32) (*core.OrderBook, error) {
 	return &core.OrderBook{}, nil
 }
-func (c *TCore) AssetBalance(assetID uint32) (*db.Balance, error) { return nil, c.balanceErr }
+func (c *TCore) AssetBalance(assetID uint32) (*core.WalletBalance, error) { return nil, c.balanceErr }
 func (c *TCore) WalletState(assetID uint32) *core.WalletState {
 	if c.notHas {
 		return nil


### PR DESCRIPTION
Resolves #672.

**Show contract-locked amounts.**
- Core: when retrieving and setting a wallet's balance, calculate and include
 total amounts locked in unspent swap contracts, i.e. contracts sent by the client
 that have not been refunded by the client or redeemed by the counter-party (with
 the exception of maker contracts which are always considered spent if maker has
 redeemed taker's contract, even if maker's contract has not redeemed by taker.
- Webserver/site: display locked balance as bal.locked + bal.contractlocked.

**Update balances when coins are unlocked.**
The following actions that lead to coin unlocking already cause wallet
balances to be updated:
- match revocation (revoke_match handler -> tracker.revokeMatch)
- inactive order retirement (core.listen -> bcastTimeout ticker)

Update balances for the following additional actions that may lead to
coin unlocking:
- order executed with no matches (nomatch handler -> tracker.nomatch)
- order canceled (match req handler  -> runMatches -> tracker.negotiate),
- initial trade tick for new matches (match req handler -> runMatches)
- order revoked for suspended market with persist=false (trade suspension
 note handler -> tracker.revoke)
- match revoked on dex connect (core.authDEX)

Also...
- update both wallet balances on redeem to cause the toWallet balance to increase
 by the redeemed amount and the fromWallet contractlocked balance to reduce by
 the client's init swap value.
- unlock coins for orders that are abandoned immediately after they're sent to the
 server. Orders are abandoned if an error occurs when submitting the order to the
 server, when the server's response sig fails validation or if saving the order to db
 fails.
- retire epoch status orders that remain at epoch status longer than 30 minutes past
 the end of the epoch in which the order was placed as such orders would no longer
 be active. If the preimage request for such order was missed, the order would have
 been revoked shortly after the epoch ended. If the preimage was sent, fully matched
 orders and partially filled or unfilled non-standing orders would have been executed.
 Partially filled or unfilled standing orders that were initially booked would have been
 revoked because any queued match/nomatch messages for this client would have
 expired.