### PR TITLE
client/core: retire orders stuck at epoch status for unusually long

### DIFF
--- a/client/core/types.go
+++ b/client/core/types.go
@@ -465,7 +465,7 @@ func (a *dexAccount) locked() bool {
 }
 
 // authed will be true if the account has been authenticated i.e. the 'connect'
-// request has been succesfully sent.
+// request has been successfully sent.
 func (a *dexAccount) authed() bool {
 	a.authMtx.RLock()
 	defer a.authMtx.RUnlock()


### PR DESCRIPTION
Retire orders (including cancel orders) stuck at Epoch status for unreasonably long.
Unreasonably long is 30+ minutes (15+ minutes for cancel orders) past the end of the
order's epoch. The correct status for such stale orders cannot be determined yet, so
the statuses of such orders are not updated when they're retired. This means that the
orders will be reloaded from db in subsequent client restarts and almost immediately
retired again. This is a temporary behaviour and will be corrected once order_status
route is implemented. Stale cancel orders are not affected by this; they are assumed
to be executed but unmatched and their statuses updated accordingly in db.

Stale orders that are loaded from db are not retired immediately. The intent is to allow
core load coins locked for such orders and return those coins a bit later in the DEX's
trade ticker.

**Some notes:**
- Stale cancel orders might have missed the preimage request and gotten revoked but
 they'd be considered executed because we have no way of telling whether or not preimage
 was sent for the orders.
- Stale cancel orders might actually be matched and the target orders canceled but they're
 currently considered unmatched and the target orders left on the client books. Any new
 attempt to cancel such already canceled target orders will fail and the target orders will
 continue on the client books. However, the orders will get retired if they were at epoch status
 and they remain so more than 30 minutes past the end of the order's epoch; but even then,
 the orders will not be updated to status Canceled until order_status is implemented and
 all stale orders can be properly retired.
- There is an off chance that a standing limit order stuck at epoch status is actually booked
 and thus active, _if_ 
  - the order was not matched and the client missed the nomatch request or
  - the order was matched and the client missed the match request but the client is surprisingly
 not guilty of inaction on any of the matches (e.g. client is taker in all those matches and maker
 always failed to act).
- Cases like the above where active orders are considered inactive because of remaining at
 epoch status unreasonably long, will be corrected when the order_status route is implemented.
 In the interim, the client will be unable to receive and negotiate future matches for the order
 and the order will eventually get revoked as the client will be the maker on any new matches
 and will be guilty of inaction. If the order luckily does not get new matches in this interim, it will
 be restored to activity and tracked by core when order_status is implemented and the order is
 confirmed to be Booked, not Revoked or Executed. The client will then be able to negotiate
 future matches for the order.

**Additional improvements**
- Prevent core tests from blocking indefinitely if a request is sent without a queued response.