### PR TITLE
server/{auth,db}: add order_status route

### DIFF
--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -82,6 +82,9 @@ const (
 	// MatchStatusRoute is the route of a client-originating request-type
 	// message to retrieve match data from the DEX.
 	MatchStatusRoute = "match_status"
+	// OrderStatusRoute is the route of a client-originating request-type
+	// message to retrieve order data from the DEX.
+	OrderStatusRoute = "order_status"
 	// InitRoute is the route of a client-originating request-type message
 	// notifying the DEX, and subsequently the match counter-party, of the details
 	// of a swap contract.
@@ -467,6 +470,21 @@ type MatchStatusResult struct {
 	TakerRedeem   Bytes `json:"takerredeem,omitempty"`
 	Secret        Bytes `json:"secret,omitempty"`
 	Active        bool  `json:"active"`
+}
+
+// OrderStatusRequest details an order for the OrderStatusRoute request. The
+// actual payload is a []OrderStatusRequest.
+type OrderStatusRequest struct {
+	Base    uint32 `json:"base"`
+	Quote   uint32 `json:"quote"`
+	OrderID Bytes  `json:"orderid"`
+}
+
+// OrderStatusResult is the successful result for the OrderStatusRoute request.
+type OrderStatusResult struct {
+	OrderID Bytes
+	Status  uint16
+	Fill    int64
 }
 
 // Init is the payload for a client-originating InitRoute request.

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -482,9 +482,9 @@ type OrderStatusRequest struct {
 
 // OrderStatusResult is the successful result for the OrderStatusRoute request.
 type OrderStatusResult struct {
-	OrderID Bytes
-	Status  uint16
-	Fill    int64
+	OrderID Bytes  `json:"orderid"`
+	Status  uint16 `json:"status"`
+	Fill    uint64 `json:"fill"`
 }
 
 // Init is the payload for a client-originating InitRoute request.

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -1187,7 +1187,7 @@ type marketOrders struct {
 	orderIDs map[order.OrderID]bool
 }
 
-// add adds a match ID to the marketMatches.
+// add adds a match ID to the marketOrders.
 func (mo *marketOrders) add(oid order.OrderID) bool {
 	_, found := mo.orderIDs[oid]
 	mo.orderIDs[oid] = true

--- a/server/db/driver/pg/internal/orders.go
+++ b/server/db/driver/pg/internal/orders.go
@@ -101,6 +101,11 @@ const (
 	// CancelOrderStatus.
 	OrderStatus = `SELECT type, status, filled FROM %s WHERE oid = $1;`
 
+	// OrderStatuses retrieves the order id, order status, and filled amount
+	// for orders with the given order IDs. This only applies to market and
+	// limit orders.
+	OrderStatuses = `SELECT oid, status, filled FROM %s WHERE account_id = $1 AND oid = ANY($2);`
+
 	// MoveOrder moves an order row from one table to another (e.g.
 	// orders_active to orders_archived), while updating the order's status and
 	// filled amounts.

--- a/server/db/driver/pg/orders_online_test.go
+++ b/server/db/driver/pg/orders_online_test.go
@@ -980,7 +980,7 @@ func TestOrderStatuses(t *testing.T) {
 			t.Errorf("Incorrect OrderStatus for retrieved order. Got %v, expected %v.",
 				orderOut.Status, statusIn)
 		}
-		if orderOut.Fill != int64(ordIn.Trade().Filled()) {
+		if orderOut.Fill != ordIn.Trade().Filled() {
 			t.Errorf("Incorrect FillAmt for retrieved order. Got %v, expected %v.",
 				orderOut.Fill, ordIn.Trade().Filled())
 		}
@@ -1009,7 +1009,7 @@ func TestOrderStatuses(t *testing.T) {
 			t.Errorf("Incorrect OrderStatus for retrieved order. Got %v, expected %v.",
 				orderOut.Status, statusIn)
 		}
-		if orderOut.Fill != int64(ordIn.Trade().Filled()) {
+		if orderOut.Fill != ordIn.Trade().Filled() {
 			t.Errorf("Incorrect FillAmt for retrieved order. Got %v, expected %v.",
 				orderOut.Fill, ordIn.Trade().Filled())
 		}

--- a/server/db/driver/pg/orders_online_test.go
+++ b/server/db/driver/pg/orders_online_test.go
@@ -715,10 +715,6 @@ func TestActiveOrderCoins(t *testing.T) {
 
 	var epochIdx, epochDur int64 = 13245678, 6000
 
-	// Do not use Stringers when dumping, and stop after 4 levels deep
-	spew.Config.MaxDepth = 4
-	spew.Config.DisableMethods = true
-
 	multiCoinLO := newLimitOrder(false, 4900000, 1, order.StandingTiF, 0)
 	multiCoinLO.Coins = append(multiCoinLO.Coins, order.CoinID{0x22, 0x23})
 
@@ -824,10 +820,6 @@ func TestOrderStatus(t *testing.T) {
 
 	var epochIdx, epochDur int64 = 13245678, 6000
 
-	// Do not use Stringers when dumping, and stop after 4 levels deep
-	spew.Config.MaxDepth = 4
-	spew.Config.DisableMethods = true
-
 	orderStatuses := []struct {
 		ord    order.Order
 		status order.OrderStatus
@@ -896,10 +888,6 @@ func TestOrderStatuses(t *testing.T) {
 
 	var epochIdx, epochDur int64 = 13245678, 6000
 
-	// Do not use Stringers when dumping, and stop after 4 levels deep
-	spew.Config.MaxDepth = 4
-	spew.Config.DisableMethods = true
-
 	orderStatuses := []struct {
 		ord    order.Order
 		status order.OrderStatus
@@ -933,8 +921,8 @@ func TestOrderStatuses(t *testing.T) {
 	unsavedOrder1 := newMarketBuyOrder(3000000000, 0)
 	unsavedOrder2 := newMarketSellOrder(4, 0)
 
-	orders := make([]order.Order, len(orderStatuses)+2)
-	orderIDs := make([]order.OrderID, len(orderStatuses)+2)
+	orders := make([]order.Order, 0, len(orderStatuses)+2)
+	orderIDs := make([]order.OrderID, 0, len(orderStatuses)+2)
 
 	// Add unsaved orders
 	orders = append(orders, unsavedOrder1, unsavedOrder2)

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -52,6 +52,13 @@ type EpochResults struct {
 	OrdersMissed      []order.OrderID
 }
 
+// OrderStatus is the current status of an order, including its fill.
+type OrderStatus struct {
+	ID     order.OrderID
+	Status order.OrderStatus
+	Fill   int64
+}
+
 // DEXArchivist will be composed of several different interfaces. Starting with
 // OrderArchiver.
 type DEXArchivist interface {
@@ -118,6 +125,9 @@ type OrderArchiver interface {
 
 	// OrderStatus gets the status, ID, and filled amount of the given order.
 	OrderStatus(order.Order) (order.OrderStatus, order.OrderType, int64, error)
+
+	// OrderStatuses gets the status and filled amount of the given orders.
+	OrderStatuses(aid account.AccountID, base, quote uint32, orderIDs []order.OrderID) ([]*OrderStatus, error)
 
 	// NewEpochOrder stores a new order with epoch status. Such orders are
 	// pending execution or insertion on a book (standing limit orders with a

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -56,7 +56,7 @@ type EpochResults struct {
 type OrderStatus struct {
 	ID     order.OrderID
 	Status order.OrderStatus
-	Fill   int64
+	Fill   uint64
 }
 
 // DEXArchivist will be composed of several different interfaces. Starting with

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -92,6 +92,9 @@ func (ta *TArchivist) ExecutedCancelsForUser(aid account.AccountID, N int) (oids
 func (ta *TArchivist) OrderStatus(order.Order) (order.OrderStatus, order.OrderType, int64, error) {
 	return order.OrderStatusUnknown, order.UnknownOrderType, -1, errors.New("boom")
 }
+func (ta *TArchivist) OrderStatuses(aid account.AccountID, base, quote uint32, orderIDs []order.OrderID) ([]*db.OrderStatus, error) {
+	return nil, errors.New("not mocked")
+}
 func (ta *TArchivist) NewEpochOrder(ord order.Order, epochIdx, epochDur int64) error {
 	ta.mtx.Lock()
 	defer ta.mtx.Unlock()


### PR DESCRIPTION
Similar in implementation to the match_status route, the order_status route
accepts a slice of `struct{Base,Quote,OrderID}` and returns the status and
fill amts for the requested **user-submitted** orders that are found in db.

Will put up a follow up with spec changes for the new `order_status` route
and the updated `connect` route.