### PR TITLE
app: prevent epoch orders from pushing depth chart around

### DIFF
--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -921,8 +921,8 @@ func TestServer(t *testing.T) {
 	asset.Register(141, &TDriver{}) // kmd
 	asset.Register(3, &TDriver{})   // doge
 
-	numBuys = 10
-	numSells = 10
+	numBuys = 0
+	numSells = 0
 	feedPeriod = 2000 * time.Millisecond
 	initialize := false
 	register := true

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -65,7 +65,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=rwwys"></script>
+<script src="/js/entry.js?v=nntTxe"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/charts.js
+++ b/client/webserver/site/src/js/charts.js
@@ -504,12 +504,12 @@ export class DepthChart {
   }
 
   gap () {
-    const [b, s] = [this.book.buys, this.book.sells]
-    if (!b.length) {
-      if (!s.length) return [1, 0]
-      return [s[0].rate, 0]
-    } else if (!s.length) return [b[0].rate, 0]
-    return [(s[0].rate + b[0].rate) / 2, s[0].rate - b[0].rate]
+    const [b, s] = [this.book.bestGapBuy(), this.book.bestGapSell()]
+    if (!b) {
+      if (!s) return [1, 0]
+      return [s.rate, 0]
+    } else if (!s) return [b.rate, 0]
+    return [(s.rate + b.rate) / 2, s.rate - b.rate]
   }
 }
 

--- a/client/webserver/site/src/js/orderbook.js
+++ b/client/webserver/site/src/js/orderbook.js
@@ -78,6 +78,29 @@ export default class OrderBook {
   count () {
     return this.sells.length + this.buys.length
   }
+
+  /* bestGapOrder will return the best non-epoch order if one exists, or the
+   * best epoch order if there are only epoch orders, or null if there are no
+   * orders.
+   */
+  bestGapOrder (side) {
+    var best = null
+    for (const ord of side) {
+      if (!ord.epoch) return ord
+      if (!best) {
+        best = ord
+      }
+    }
+    return best
+  }
+
+  bestGapBuy () {
+    return this.bestGapOrder(this.buys)
+  }
+
+  bestGapSell () {
+    return this.bestGapOrder(this.sells)
+  }
 }
 
 /*


### PR DESCRIPTION
For the depth chart gap calculations, epoch orders are only considered if there are no booked orders on the side. This prevents some silly chart renders with illogical gaps based on epoch orders with matchable rates. 