### PR TITLE
core: fix some order book feed bugs

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -357,6 +357,7 @@ func translateBookSide(ins []*orderbook.Order) (outs []*MiniOrder) {
 			Rate:  float64(o.Rate) / conversionFactor,
 			Sell:  o.Side == msgjson.SellOrderNum,
 			Token: token(o.OrderID[:]),
+			Epoch: o.Epoch,
 		})
 	}
 	return
@@ -501,6 +502,6 @@ func minifyOrder(oid dex.Bytes, trade *msgjson.TradeNote, epoch uint64) *MiniOrd
 		Rate:  float64(trade.Rate) / conversionFactor,
 		Sell:  trade.Side == msgjson.SellOrderNum,
 		Token: token(oid),
-		Epoch: &epoch,
+		Epoch: epoch,
 	}
 }

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -893,11 +893,11 @@ func TestDexConnectionOrderBook(t *testing.T) {
 	}
 
 	// Sync to unknown dex
-	_, _, err = tCore.SyncBook("unknown dex", tDCR.ID, tBTC.ID)
+	_, err = tCore.SyncBook("unknown dex", tDCR.ID, tBTC.ID)
 	if err == nil {
 		t.Fatalf("no error for unknown dex")
 	}
-	_, _, err = tCore.SyncBook(tDexHost, tDCR.ID, 12345)
+	_, err = tCore.SyncBook(tDexHost, tDCR.ID, 12345)
 	if err == nil {
 		t.Fatalf("no error for nonsense market")
 	}
@@ -907,11 +907,11 @@ func TestDexConnectionOrderBook(t *testing.T) {
 		f(bookMsg)
 		return nil
 	})
-	_, feed1, err := tCore.SyncBook(tDexHost, tDCR.ID, tBTC.ID)
+	feed1, err := tCore.SyncBook(tDexHost, tDCR.ID, tBTC.ID)
 	if err != nil {
 		t.Fatalf("SyncBook 1 error: %v", err)
 	}
-	_, feed2, err := tCore.SyncBook(tDexHost, tDCR.ID, tBTC.ID)
+	feed2, err := tCore.SyncBook(tDexHost, tDCR.ID, tBTC.ID)
 	if err != nil {
 		t.Fatalf("SyncBook 2 error: %v", err)
 	}
@@ -924,6 +924,18 @@ func TestDexConnectionOrderBook(t *testing.T) {
 	// Should have one buy order
 	if len(book.Buys) != 1 {
 		t.Fatalf("no buy orders found. expected 1")
+	}
+
+	// Both channels should have a full orderbook.
+	select {
+	case <-feed1.C:
+	default:
+		t.Fatalf("no book on feed 1")
+	}
+	select {
+	case <-feed2.C:
+	default:
+		t.Fatalf("no book on feed 2")
 	}
 
 	err = handleBookOrderMsg(tCore, dc, bookNote)

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -316,7 +316,7 @@ func newDisplayIDFromSymbols(base, quote string) string {
 type MiniOrder struct {
 	Qty   float64 `json:"qty"`
 	Rate  float64 `json:"rate"`
-	Epoch *uint64 `json:"epoch,omitempty"`
+	Epoch uint64  `json:"epoch,omitempty"`
 	Sell  bool    `json:"sell"`
 	Token string  `json:"token"`
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -338,8 +338,9 @@ type OrderBook struct {
 // MarketOrderBook is used as the BookUpdate's Payload with the FreshBookAction.
 // The subscriber will likely need to translate into a JSON tagged type.
 type MarketOrderBook struct {
-	Base, Quote uint32
-	Book        *OrderBook
+	Base  uint32     `json:"base"`
+	Quote uint32     `json:"quote"`
+	Book  *OrderBook `json:"book"`
 }
 
 const (

--- a/client/order/epochqueue.go
+++ b/client/order/epochqueue.go
@@ -186,6 +186,7 @@ func (eq *EpochQueue) Orders() (orders []*Order) {
 			Side:     ord.Side,
 			Quantity: ord.Quantity,
 			Rate:     ord.Rate,
+			Epoch:    ord.epoch,
 		})
 	}
 	return

--- a/client/order/orderbook.go
+++ b/client/order/orderbook.go
@@ -25,6 +25,8 @@ type Order struct {
 	Quantity uint64
 	Rate     uint64
 	Time     uint64
+	// Epoch is only used in the epoch queue, otherwise it is ignored.
+	Epoch uint64
 }
 
 // RemoteOrderBook defines the functions a client tracked order book

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -876,8 +876,8 @@ Registration is complete after the fee transaction has been confirmed.`,
           "qty" (float): The number of coins base asset being bought or sold.
           "rate" (float): The coins quote asset to accept per coin base asset.
           "sell" (bool): Whether this order is a sell order.
-		  "token" (string): The first 8 bytes of the order id, coded in hex.
-		  "epoch" (int): The order's epoch.
+          "token" (string): The first 8 bytes of the order id, coded in hex.
+          "epoch" (int): The order's epoch.
         },...
       ],
     }`,

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -876,7 +876,8 @@ Registration is complete after the fee transaction has been confirmed.`,
           "qty" (float): The number of coins base asset being bought or sold.
           "rate" (float): The coins quote asset to accept per coin base asset.
           "sell" (bool): Whether this order is a sell order.
-          "token" (string): The first 8 bytes of the order id, coded in hex.
+		  "token" (string): The first 8 bytes of the order id, coded in hex.
+		  "epoch" (int): The order's epoch.
         },...
       ],
     }`,

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -97,8 +97,8 @@ func (c *TCore) GetFee(url, cert string) (uint64, error) {
 func (c *TCore) Register(*core.RegisterForm) (*core.RegisterResult, error) {
 	return c.registerResult, c.registerErr
 }
-func (c *TCore) SyncBook(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
-	return nil, core.NewBookFeed(func(*core.BookFeed) {}), c.syncErr
+func (c *TCore) SyncBook(dex string, base, quote uint32) (*core.BookFeed, error) {
+	return core.NewBookFeed(func(*core.BookFeed) {}), c.syncErr
 }
 func (c *TCore) Trade(appPass []byte, form *core.TradeForm) (order *core.Order, err error) {
 	return c.order, c.tradeErr

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -205,7 +205,7 @@ func randomOrder(sell bool, maxQty, midGap, marketWidth float64, epoch bool) *co
 		Rate:  rate,
 		Sell:  sell,
 		Token: nextToken(),
-		Epoch: &epochIdx,
+		Epoch: epochIdx,
 	}
 }
 
@@ -908,7 +908,6 @@ out:
 			for _, o := range c.epochOrders {
 				miniOrder := o.Payload.(*core.MiniOrder)
 				if miniOrder.Rate > 0 {
-					miniOrder.Epoch = new(uint64)
 					o.Action = msgjson.BookOrderRoute
 					c.trySend(o)
 					if miniOrder.Sell {

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -459,7 +459,7 @@ export default class Application {
    * ws.........Websocket connection status changes.
    */
   log (loggerID, ...msg) {
-    if (this.loggers[loggerID]) console.log(`${nowString()}[${loggerID}]:`, ...msg)    
+    if (this.loggers[loggerID]) console.log(`${nowString()}[${loggerID}]:`, ...msg)
     if (this.recorders[loggerID]) {
       this.recorders[loggerID].push({
         time: nowString(),
@@ -604,6 +604,7 @@ function handlerFromPath (path) {
   return path.replace(/^\//, '').split('/')[0].split('?')[0].split('#')[0]
 }
 
+/* nowString creates a string formatted like HH:MM:SS.xxx */
 function nowString () {
   const stamp = new Date()
   const h = stamp.getHours().toString().padStart(2, '0')

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -18,6 +18,7 @@ const unbind = Doc.unbind
 
 const notificationRoute = 'notify'
 const loggersKey = 'loggers'
+const recordersKey = 'recorders'
 
 /* constructors is a map to page constructors. */
 const constructors = {
@@ -39,15 +40,8 @@ export default class Application {
       wallets: {}
     }
     this.commitHash = commitHash
-    window.log = (...a) => { this.log(...a) }
     console.log('Decred DEX Client App, Build', this.commitHash.substring(0, 7))
-  }
 
-  /**
-   * Start the application. This is the only thing done from the index.js entry
-   * point. Read the id = main element and attach handlers.
-   */
-  async start () {
     // Loggers can be enabled by setting a truthy value to the loggerID using
     // enableLogger. Settings are stored across sessions. See docstring for the
     // log method for more info.
@@ -56,8 +50,43 @@ export default class Application {
       if (state) this.loggers[loggerID] = true
       else delete this.loggers[loggerID]
       State.store(loggersKey, this.loggers)
-      return `[${loggerID}] logger ${state ? 'enabled' : 'disabled'}`
+      return `${loggerID} logger ${state ? 'enabled' : 'disabled'}`
     }
+    // Enable logging from anywhere.
+    window.log = (...a) => { this.log(...a) }
+
+    // Recorders can record log messages, and then save them to file on request.
+    const recorderKeys = State.fetch(recordersKey) || []
+    this.recorders = {}
+    for (const loggerID of recorderKeys) {
+      console.log('recording', loggerID)
+      this.recorders[loggerID] = []
+    }
+    window.recordLogger = (loggerID, on) => {
+      if (on) this.recorders[loggerID] = []
+      else delete this.recorders[loggerID]
+      State.store(recordersKey, Object.keys(this.recorders))
+      return `${loggerID} recorder ${on ? 'enabled' : 'disabled'}`
+    }
+    window.dumpLogger = loggerID => {
+      const record = this.recorders[loggerID]
+      if (!record) return `no recorder for logger ${loggerID}`
+      const a = document.createElement('a')
+      a.href = `data:application/octet-stream;base64,${window.btoa(JSON.stringify(record, null, 4))}`
+      a.download = `${loggerID}.json`
+      document.body.appendChild(a)
+      a.click()
+      setTimeout(() => {
+        document.body.removeChild(a)
+      }, 0)
+    }
+  }
+
+  /**
+   * Start the application. This is the only thing done from the index.js entry
+   * point. Read the id = main element and attach handlers.
+   */
+  async start () {
     // The "user" is a large data structure that contains nearly all state
     // information, including exchanges, markets, wallets, and orders. It must
     // be loaded immediately.
@@ -430,13 +459,13 @@ export default class Application {
    * ws.........Websocket connection status changes.
    */
   log (loggerID, ...msg) {
-    if (!this.loggers[loggerID]) return
-    const stamp = new Date()
-    const h = stamp.getHours().toString().padStart(2, '0')
-    const m = stamp.getMinutes().toString().padStart(2, '0')
-    const s = stamp.getSeconds().toString().padStart(2, '0')
-    const ms = stamp.getMilliseconds().toString().padStart(3, '0')
-    console.log(`${`${h}:${m}:${s}.${ms}`}[${loggerID}]:`, ...msg)
+    if (this.loggers[loggerID]) console.log(`${nowString()}[${loggerID}]:`, ...msg)    
+    if (this.recorders[loggerID]) {
+      this.recorders[loggerID].push({
+        time: nowString(),
+        msg: msg
+      })
+    }
   }
 
   /* setNoteElements re-builds the drop-down notification list. */
@@ -573,4 +602,13 @@ function setSeverityClass (el, severity) {
 /* handlerFromPath parses the handler name from the path. */
 function handlerFromPath (path) {
   return path.replace(/^\//, '').split('/')[0].split('?')[0].split('#')[0]
+}
+
+function nowString () {
+  const stamp = new Date()
+  const h = stamp.getHours().toString().padStart(2, '0')
+  const m = stamp.getMinutes().toString().padStart(2, '0')
+  const s = stamp.getSeconds().toString().padStart(2, '0')
+  const ms = stamp.getMilliseconds().toString().padStart(3, '0')
+  return `${h}:${m}:${s}.${ms}`
 }

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -651,8 +651,8 @@ export default class MarketsPage extends BasePage {
     app.log('book', 'handleEpochOrderRoute:', data)
     if (data.host !== this.market.dex.host || data.marketID !== this.market.sid) return
     const order = data.payload
-    if (order.rate > 0) this.book.add(order)
-    this.addTableOrder(order)
+    if (order.rate > 0) this.book.add(order) // No cancels or market orders
+    if (order.qty > 0) this.addTableOrder(order) // No cancel orders
     this.chart.draw()
   }
 

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -579,21 +579,22 @@ export default class MarketsPage extends BasePage {
    * in response to a new market subscription. The data received will contain
    * the entire order book.
    */
-  handleBookRoute (data) {
-    app.log('book', 'handleOrderBook:', data)
+  handleBookRoute (note) {
+    app.log('book', 'handleBookRoute:', note)
+    const mktBook = note.payload
     const market = this.market
     const page = this.page
     const host = market.dex.host
     const [b, q] = [market.baseCfg, market.quoteCfg]
-    if (data.base !== b.id || data.quote !== q.id) return
-    this.handleBook(data)
+    if (mktBook.base !== b.id || mktBook.quote !== q.id) return
+    this.handleBook(mktBook)
     page.marketLoader.classList.add('d-none')
     this.marketList.select(host, b.id, q.id)
 
     State.store(lastMarketKey, {
-      host: data.host,
-      base: data.base,
-      quote: data.quote
+      host: note.host,
+      base: mktBook.base,
+      quote: mktBook.quote
     })
 
     page.lotSize.textContent = Doc.formatCoinValue(market.baseCfg.lotSize / 1e8)
@@ -838,6 +839,7 @@ export default class MarketsPage extends BasePage {
    * handleEpochNote handles notifications signalling the start of a new epoch.
    */
   handleEpochNote (note) {
+    app.log('book', 'handleEpochNote:', note)
     if (note.host !== this.market.dex.host || note.marketID !== this.market.sid) return
     if (this.book) {
       this.book.setEpoch(note.epoch)

--- a/client/webserver/site/src/js/orderbook.js
+++ b/client/webserver/site/src/js/orderbook.js
@@ -1,12 +1,12 @@
 export default class OrderBook {
-  constructor (market, baseSymbol, quoteSymbol) {
-    this.base = market.base
+  constructor (mktBook, baseSymbol, quoteSymbol) {
+    this.base = mktBook.base
     this.baseSymbol = baseSymbol
-    this.quote = market.quote
+    this.quote = mktBook.quote
     this.quoteSymbol = quoteSymbol
     // Books are sorted mid-gap first.
-    this.buys = market.book.buys || []
-    this.sells = market.book.sells || []
+    this.buys = mktBook.book.buys || []
+    this.sells = mktBook.book.sells || []
   }
 
   /* add adds an order to the order book. */

--- a/client/webserver/site/src/js/ws.js
+++ b/client/webserver/site/src/js/ws.js
@@ -73,7 +73,7 @@ class MessageSocket {
       payload: payload
     })
 
-    if (window.loggingDebug) console.log('send', message)
+    window.log('ws', 'sending', message)
     this.connection.send(message)
   }
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -54,7 +54,6 @@ func (c *tCoin) Confirmations() (uint32, error) {
 
 type TCore struct {
 	balanceErr      error
-	syncBook        *core.OrderBook
 	syncFeed        *core.BookFeed
 	syncErr         error
 	regErr          error
@@ -77,8 +76,8 @@ func (c *TCore) GetFee(string, string) (uint64, error)                       { r
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
 func (c *TCore) InitializeClient(pw []byte) error                            { return c.initErr }
 func (c *TCore) Login(pw []byte) (*core.LoginResult, error)                  { return &core.LoginResult{}, c.loginErr }
-func (c *TCore) SyncBook(dex string, base, quote uint32) (*core.OrderBook, *core.BookFeed, error) {
-	return c.syncBook, c.syncFeed, c.syncErr
+func (c *TCore) SyncBook(dex string, base, quote uint32) (*core.BookFeed, error) {
+	return c.syncFeed, c.syncErr
 }
 func (c *TCore) Book(dex string, base, quote uint32) (*core.OrderBook, error) {
 	return &core.OrderBook{}, nil


### PR DESCRIPTION
Moves responsibility for sending initial order book notification from **webserver** to **core**. Just populate the new order book feed with the initial `FreshBookAction` update as soon as it's created, under lock. This solves some bugs where the book is processed client side before `book_order` messages that came first, leading to double entries. This also precludes the fancy handling of the `webserver.marketResponse` that we were doing. That type is eliminated now, and the `MarketPage` handles the `BookUpdate` directly.

Include the epoch index in the **OrderBook**'s `epochQueue` orders. The fixes a `MarketPage` bug where epoch orders [were being added to the book](https://github.com/decred/dcrdex/blob/05e5254242d6f91ef7bb8ab49644f8bf45eb8b18/client/webserver/site/src/js/markets.js#L495-L496), but were not recognized as epoch orders.

