### PR TITLE
auth,db,++: ban score accounting, cancel order limits and controls

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2585,8 +2585,8 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	}
 
 	// Set the account as authenticated.
-	log.Debugf("Authenticated connection to %s, %d active orders, %d active matches",
-		dc.acct.host, len(result.ActiveOrderStatuses), len(result.ActiveMatches))
+	log.Debugf("Authenticated connection to %s, %d active orders, %d active matches, score %d",
+		dc.acct.host, len(result.ActiveOrderStatuses), len(result.ActiveMatches), result.Score)
 	dc.acct.auth()
 
 	// Associate the matches with known trades.
@@ -3506,10 +3506,10 @@ func handlePenaltyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	if err != nil {
 		return newError(signatureErr, "handlePenaltyMsg: DEX signature validation error: %v", err)
 	}
-	t := encode.UnixTimeMilli(int64(note.Penalty.Time) * 1000)
-	d := time.Duration(note.Penalty.Duration)
-	details := fmt.Sprintf("Penalty from DEX at %s\nlast broken rule: %s\ntime: %v\nduration: %v\ndetails: %q\n",
-		dc.acct.host, note.Penalty.Rule, t, d, note.Penalty.Details)
+	t := encode.UnixTimeMilli(int64(note.Penalty.Time))
+	// d := time.Duration(note.Penalty.Duration) * time.Millisecond
+	details := fmt.Sprintf("Penalty from DEX at %s\nlast broken rule: %s\ntime: %v\ndetails:\n\"%s\"\n",
+		dc.acct.host, note.Penalty.Rule, t, note.Penalty.Details)
 	n := db.NewNotification("penalty", dc.acct.host, details, db.WarningLevel)
 	c.notify(&n)
 	return nil

--- a/dex/market.go
+++ b/dex/market.go
@@ -5,17 +5,19 @@ package dex
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
 // MarketInfo specifies a market that the Archiver must support.
 type MarketInfo struct {
-	Name            string
-	Base            uint32
-	Quote           uint32
-	LotSize         uint64
-	EpochDuration   uint64 // msec
-	MarketBuyBuffer float64
+	Name                   string
+	Base                   uint32
+	Quote                  uint32
+	LotSize                uint64
+	EpochDuration          uint64 // msec
+	MarketBuyBuffer        float64
+	MaxUserCancelsPerEpoch uint32
 }
 
 func marketName(base, quote string) string {
@@ -50,12 +52,13 @@ func NewMarketInfo(base, quote uint32, lotSize, epochDuration uint64, marketBuyB
 		return nil, err
 	}
 	return &MarketInfo{
-		Name:            name,
-		Base:            base,
-		Quote:           quote,
-		LotSize:         lotSize,
-		EpochDuration:   epochDuration,
-		MarketBuyBuffer: marketBuyBuffer,
+		Name:                   name,
+		Base:                   base,
+		Quote:                  quote,
+		LotSize:                lotSize,
+		EpochDuration:          epochDuration,
+		MarketBuyBuffer:        marketBuyBuffer,
+		MaxUserCancelsPerEpoch: math.MaxUint32,
 	}, nil
 }
 
@@ -76,11 +79,12 @@ func NewMarketInfoFromSymbols(base, quote string, lotSize, epochDuration uint64,
 	}
 
 	return &MarketInfo{
-		Name:            marketName(base, quote),
-		Base:            baseID,
-		Quote:           quoteID,
-		LotSize:         lotSize,
-		EpochDuration:   epochDuration,
-		MarketBuyBuffer: marketBuyBuffer,
+		Name:                   marketName(base, quote),
+		Base:                   baseID,
+		Quote:                  quoteID,
+		LotSize:                lotSize,
+		EpochDuration:          epochDuration,
+		MarketBuyBuffer:        marketBuyBuffer,
+		MaxUserCancelsPerEpoch: math.MaxUint32,
 	}, nil
 }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -858,6 +858,7 @@ type ConnectResult struct {
 	Sig                 Bytes          `json:"sig"`
 	ActiveOrderStatuses []*OrderStatus `json:"activeorderstatuses"`
 	ActiveMatches       []*Match       `json:"activematches"`
+	Score               int32          `json:"score"`
 }
 
 // PenaltyNote is the payload of a Penalty notification.

--- a/dex/order/status.go
+++ b/dex/order/status.go
@@ -52,8 +52,8 @@ const (
 
 	// OrderStatusRevoked is DEX-revoked orders that were not canceled by
 	// matching with the client's cancel order but by DEX policy. This includes
-	// standing limit orders that were matched, but have failed to swap.
-	// (neither executed nor canceled).
+	// standing limit orders that were matched but have failed to swap (neither
+	// executed nor canceled), and preimage misses.
 	OrderStatusRevoked
 )
 

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/dex/order"
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/market"
@@ -34,8 +35,8 @@ const (
 
 	marketNameKey = "market"
 	accountIDKey  = "account"
+	matchIDKey    = "match"
 	ruleToken     = "rule"
-	messageToken  = "message"
 	timeoutToken  = "timeout"
 )
 
@@ -57,6 +58,7 @@ type SvrCore interface {
 	ResumeMarket(name string, asSoonAs time.Time) (startEpoch int64, startTime time.Time, err error)
 	Penalize(aid account.AccountID, rule account.Rule, details string) error
 	Unban(aid account.AccountID) error
+	ForgiveMatchFail(aid account.AccountID, mid order.MatchID) (forgiven, unbanned bool, err error)
 }
 
 // Server is a multi-client https server.
@@ -137,6 +139,7 @@ func NewServer(cfg *SrvConfig) (*Server, error) {
 			rm.Get("/", s.apiAccountInfo)
 			rm.Get("/ban", s.apiBan)
 			rm.Get("/unban", s.apiUnban)
+			rm.Get("/forgive_match/{"+matchIDKey+"}", s.apiForgiveMatchFail)
 			rm.Post("/notify", s.apiNotify)
 		})
 		r.Post("/notifyall", s.apiNotifyAll)

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -26,6 +26,7 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/dex/order"
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/market"
@@ -165,6 +166,9 @@ func (c *TCore) Penalize(_ account.AccountID, _ account.Rule, _ string) error {
 }
 func (c *TCore) Unban(_ account.AccountID) error {
 	return c.unbanErr
+}
+func (c *TCore) ForgiveMatchFail(_ account.AccountID, _ order.MatchID) (bool, bool, error) {
+	return false, false, nil // TODO: tests
 }
 func (c *TCore) Notify(_ account.AccountID, _ *msgjson.Message) {}
 func (c *TCore) NotifyAll(_ *msgjson.Message)                   {}

--- a/server/admin/types.go
+++ b/server/admin/types.go
@@ -76,3 +76,11 @@ type UnbanResult struct {
 	AccountID string  `json:"accountid"`
 	UnbanTime APITime `json:"unbantime"`
 }
+
+// ForgiveResult holds the result of a forgive_match.
+type ForgiveResult struct {
+	AccountID   string  `json:"accountid"`
+	Forgiven    bool    `json:"forgiven"`
+	Unbanned    bool    `json:"unbanned"`
+	ForgiveTime APITime `json:"forgivetime"`
+}

--- a/server/auth/cancel.go
+++ b/server/auth/cancel.go
@@ -89,7 +89,7 @@ func (lo *latestOrders) add(o *oidStamped) {
 	lo.mtx.Lock()
 	defer lo.mtx.Unlock()
 
-	// Use sort.Search and insert it as the right spot.
+	// Use sort.Search and insert it at the right spot.
 	n := len(lo.orders)
 	i := sort.Search(n, func(i int) bool {
 		return less(lo.orders[n-1-i], o)

--- a/server/auth/latest.go
+++ b/server/auth/latest.go
@@ -1,0 +1,64 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package auth
+
+import (
+	"sort"
+	"sync"
+)
+
+type stampedFlag struct {
+	time int64
+	flag int64
+}
+
+func lessByTime(ti, tj *stampedFlag) bool {
+	return ti.time < tj.time // ascending (newest last in slice)
+}
+
+type latest struct {
+	mtx      sync.Mutex
+	cap      int16
+	stampeds []*stampedFlag
+}
+
+func newLatest(cap int16) *latest {
+	return &latest{
+		cap:      cap,
+		stampeds: make([]*stampedFlag, 0, cap+1), // cap+1 since an old item is popped *after* a new one is pushed
+	}
+}
+
+func (la *latest) add(t *stampedFlag) {
+	la.mtx.Lock()
+	defer la.mtx.Unlock()
+
+	// Use sort.Search and insert it at the right spot.
+	n := len(la.stampeds)
+	i := sort.Search(n, func(i int) bool {
+		return lessByTime(la.stampeds[n-1-i], t)
+	})
+	if i == int(la.cap) /* i == n && n == int(la.cap) */ {
+		// The new one is the oldest/smallest, but already at capacity.
+		return
+	}
+	// Insert at proper location.
+	i = n - i // i-1 is first location that stays
+	la.stampeds = append(la.stampeds[:i], append([]*stampedFlag{t}, la.stampeds[i:]...)...)
+
+	// Pop one stamped if the slice was at capacity prior to pushing the new one.
+	if len(la.stampeds) > int(la.cap) {
+		// pop front, the oldest stamped
+		la.stampeds[0] = nil // avoid memory leak
+		la.stampeds = la.stampeds[1:]
+	}
+}
+
+func (la *latest) bin() map[int64]int64 {
+	bins := make(map[int64]int64)
+	for _, th := range la.stampeds {
+		bins[th.flag]++
+	}
+	return bins
+}

--- a/server/auth/latest_test.go
+++ b/server/auth/latest_test.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+func Test_latest(t *testing.T) {
+	cap := int16(10)
+	ordList := newLatest(cap)
+
+	randTime := func() int64 {
+		return 1600477631 + rand.Int63n(987654)
+	}
+
+	N := int(cap + 20)
+	times := make([]int64, N)
+	for i := 0; i < N; i++ {
+		t := randTime()
+		times[i] = t
+		ordList.add(&stampedFlag{
+			time: t,
+		})
+	}
+
+	sort.Slice(times, func(i, j int) bool {
+		return times[i] < times[j] // ascending
+	})
+
+	if len(ordList.stampeds) != int(cap) {
+		t.Fatalf("latest list is length %d, wanted %d", len(ordList.stampeds), cap)
+	}
+
+	// ensure the ordList contains the N most recent items, with the oldest at
+	// the front of the list.
+	wantStampedTimes := times[len(times)-int(cap):] // grab the last cap items in the sorted ground truth list
+	for i, st := range ordList.stampeds {
+		if st.time != wantStampedTimes[i] {
+			t.Fatalf("Time #%d is %d, wanted %d", i, st.time, wantStampedTimes[i])
+		}
+	}
+}

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -89,6 +89,12 @@ func mainCore(ctx context.Context) error {
 	}
 	log.Infof("Found %d assets, loaded %d markets, for network %s",
 		len(assets), len(markets), strings.ToUpper(cfg.Network.String()))
+	// NOTE: If MaxUserCancelsPerEpoch is ultimately a setting we want to keep,
+	// bake it into the markets.json file and load it per-market in settings.go.
+	// For now, patch it into each dex.MarketInfo.
+	for _, mkt := range markets {
+		mkt.MaxUserCancelsPerEpoch = cfg.MaxUserCancels
+	}
 
 	// Load, or create and save, the DEX signing key.
 	var privKey *secp256k1.PrivateKey
@@ -125,6 +131,8 @@ func mainCore(ctx context.Context) error {
 		BroadcastTimeout: cfg.BroadcastTimeout,
 		CancelThreshold:  cfg.CancelThreshold,
 		Anarchy:          cfg.Anarchy,
+		FreeCancels:      cfg.FreeCancels,
+		BanScore:         cfg.BanScore,
 		DEXPrivKey:       privKey,
 		CommsCfg: &dexsrv.RPCConfig{
 			RPCCert:     cfg.RPCCert,

--- a/server/db/driver/pg/accounts_online_test.go
+++ b/server/db/driver/pg/accounts_online_test.go
@@ -46,7 +46,6 @@ func TestAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error creating account: %v", err)
 	}
-	t.Logf("created registration address: %s", regAddr)
 
 	checkAddr, err := archie.AccountRegAddr(tAcctID)
 	if err != nil {

--- a/server/db/driver/pg/internal/accounts.go
+++ b/server/db/driver/pg/internal/accounts.go
@@ -14,7 +14,7 @@ const (
 		pubkey BYTEA,
 		fee_address TEXT,
 		fee_coin BYTEA,
-		broken_rule INT2 DEFAULT 0
+		broken_rule INT2 DEFAULT 0 -- TODO: change to banned BOOL
 		);`
 
 	// InsertKeyIfMissing creates an entry for the specified key hash, if it
@@ -33,7 +33,7 @@ const (
 	// that the account is closed.
 	CloseAccount = `UPDATE %s SET broken_rule = $1 WHERE account_id = $2;`
 
-	// SelectAccount gathers account details for the specified accound ID. The
+	// SelectAccount gathers account details for the specified account ID. The
 	// details returned from this query are sufficient to determine 1) whether the
 	// registration fee has been paid, or 2) whether the account has been closed.
 	SelectAccount = `SELECT pubkey, fee_coin, broken_rule

--- a/server/db/driver/pg/system.go
+++ b/server/db/driver/pg/system.go
@@ -148,7 +148,7 @@ func createTable(db *sql.DB, fmtStmt, schema, tableName string) (bool, error) {
 		log.Tracef(`Table "%s" exists.`, nameSpacedTable)
 	}
 
-	return created, err
+	return created, nil
 }
 
 func dropTable(db sqlExecutor, tableName string) error {

--- a/server/db/driver/pg/tables.go
+++ b/server/db/driver/pg/tables.go
@@ -16,6 +16,14 @@ const (
 	metaTableName     = "meta"
 	feeKeysTableName  = "fee_keys"
 	accountsTableName = "accounts"
+
+	// market schema tables
+	matchesTableName         = "matches"
+	epochsTableName          = "epochs"
+	ordersArchivedTableName  = "orders_archived"
+	ordersActiveTableName    = "orders_active"
+	cancelsArchivedTableName = "cancels_archived"
+	cancelsActiveTableName   = "cancels_active"
 )
 
 type tableStmt struct {
@@ -34,12 +42,12 @@ var createAccountTableStatements = []tableStmt{
 }
 
 var createMarketTableStatements = []tableStmt{
-	{"orders_archived", internal.CreateOrdersTable},
-	{"orders_active", internal.CreateOrdersTable},
-	{"cancels_archived", internal.CreateCancelOrdersTable},
-	{"cancels_active", internal.CreateCancelOrdersTable},
-	{"matches", internal.CreateMatchesTable}, // just one matches table per market for now
-	{"epochs", internal.CreateEpochsTable},
+	{ordersArchivedTableName, internal.CreateOrdersTable},
+	{ordersActiveTableName, internal.CreateOrdersTable},
+	{cancelsArchivedTableName, internal.CreateCancelOrdersTable},
+	{cancelsActiveTableName, internal.CreateCancelOrdersTable},
+	{matchesTableName, internal.CreateMatchesTable}, // just one matches table per market for now
+	{epochsTableName, internal.CreateEpochsTable},
 }
 
 var tableMap = func() map[string]string {
@@ -60,9 +68,9 @@ var tableMap = func() map[string]string {
 func fullOrderTableName(dbName, marketSchema string, active bool) string {
 	var orderTable string
 	if active {
-		orderTable = "orders_active"
+		orderTable = ordersActiveTableName
 	} else {
-		orderTable = "orders_archived"
+		orderTable = ordersArchivedTableName
 	}
 
 	return fullTableName(dbName, marketSchema, orderTable)
@@ -71,20 +79,20 @@ func fullOrderTableName(dbName, marketSchema string, active bool) string {
 func fullCancelOrderTableName(dbName, marketSchema string, active bool) string {
 	var orderTable string
 	if active {
-		orderTable = "cancels_active"
+		orderTable = cancelsActiveTableName
 	} else {
-		orderTable = "cancels_archived"
+		orderTable = cancelsArchivedTableName
 	}
 
 	return fullTableName(dbName, marketSchema, orderTable)
 }
 
 func fullMatchesTableName(dbName, marketSchema string) string {
-	return dbName + "." + marketSchema + ".matches"
+	return dbName + "." + marketSchema + "." + matchesTableName
 }
 
 func fullEpochsTableName(dbName, marketSchema string) string {
-	return dbName + "." + marketSchema + ".epochs"
+	return dbName + "." + marketSchema + "." + epochsTableName
 }
 
 // CreateTable creates one of the known tables by name. The table will be
@@ -116,7 +124,6 @@ func PrepareTables(db *sql.DB, mktConfig []*dex.MarketInfo) error {
 		if err != nil {
 			return fmt.Errorf("failed to create row for meta table")
 		}
-
 	}
 
 	// Create the markets table in the public schema.

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -146,6 +146,13 @@ func (ta *TArchivist) MatchByID(mid order.MatchID, base, quote uint32) (*db.Matc
 func (ta *TArchivist) UserMatches(aid account.AccountID, base, quote uint32) ([]*db.MatchData, error) {
 	return nil, nil
 }
+func (ta *TArchivist) CompletedAndAtFaultMatchStats(aid account.AccountID, lastN int) ([]*db.MatchOutcome, error) {
+	return nil, nil
+}
+func (ta *TArchivist) PreimageStats(user account.AccountID, lastN int) ([]*db.PreimageResult, error) {
+	return nil, nil
+}
+func (ta *TArchivist) ForgiveMatchFail(order.MatchID) (bool, error) { return false, nil }
 func (ta *TArchivist) AllActiveUserMatches(account.AccountID) ([]*db.MatchData, error) {
 	return nil, nil
 }
@@ -1046,7 +1053,7 @@ func TestMarket_Run(t *testing.T) {
 }
 
 func TestMarket_enqueueEpoch(t *testing.T) {
-	// This tests processing of a closed epoch by epochStart (for preimage
+	// This tests processing of a closed epoch by prepEpoch (for preimage
 	// collection) and processReadyEpoch (for sending the expected book and
 	// unbook messages to book subscribers registered via OrderFeed) via
 	// enqueueEpoch and the epochPump.
@@ -1159,7 +1166,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 		for ep := range ePump.ready {
 			t.Logf("processReadyEpoch: %d orders revealed\n", len(ep.ordersRevealed))
 
-			// epochStart has completed preimage collection.
+			// prepEpoch has completed preimage collection.
 			mkt.processReadyEpoch(ep, notifyChan) // notify is async!
 			goForIt <- struct{}{}
 		}

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -33,7 +33,8 @@ type AuthManager interface {
 	Send(account.AccountID, *msgjson.Message) error
 	Request(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message)) error
 	RequestWithTimeout(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message), time.Duration, func()) error
-	Penalize(user account.AccountID, rule account.Rule, details string) error
+	PreimageSuccess(user account.AccountID, refTime time.Time, oid order.OrderID)
+	MissedPreimage(user account.AccountID, refTime time.Time, oid order.OrderID)
 	RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time)
 }
 

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -19,6 +19,7 @@ import (
 	ordertest "decred.org/dcrdex/dex/order/test"
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/asset"
+	"decred.org/dcrdex/server/auth"
 	"decred.org/dcrdex/server/book"
 	"decred.org/dcrdex/server/comms"
 	"decred.org/dcrdex/server/matcher"
@@ -223,9 +224,11 @@ func (a *TAuth) RequestWithTimeout(user account.AccountID, msg *msgjson.Message,
 	}
 	return nil
 }
-func (a *TAuth) Penalize(user account.AccountID, rule account.Rule, _ string) error {
-	log.Infof("Penalize for user %v", user)
-	return nil
+
+func (a *TAuth) PreimageSuccess(user account.AccountID, refTime time.Time, oid order.OrderID) {}
+func (a *TAuth) MissedPreimage(user account.AccountID, refTime time.Time, oid order.OrderID)  {}
+func (a *TAuth) SwapSuccess(user account.AccountID, refTime time.Time)                        {}
+func (a *TAuth) Inaction(user account.AccountID, step auth.NoActionStep, refTime time.Time, oid order.OrderID, mid order.MatchID) {
 }
 
 func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time) {}


### PR DESCRIPTION
NOTE: Several out-of-spec changes here.

The main goal of this work is to provide some leeway to the user with respect to enforcement of the common inaction rule violations.  We need to start learning about user behavior to define a scoring system that is fair and still discourages bad behavior, and this is a start in that direction by tracking user actions and integrating them in some way with respect to severity.  There are a couple of tweaks to the handling of cancels as well.

Three main changes to the violation tracking and penalization system:
1. Added a `--freecancels      No cancellation rate enforcement (unlimited cancel orders). Implied by --anarchy`. Does not disable enforcement of other rules (e.g. inaction violations).
2. Added `--maxepochcancels= The maximum number of cancel orders allowed for a user in a given epoch.`
3. Added `--banscore=        The accumulated penalty score at which when an account gets closed.`

The first two are small, but the ban score system is more involved.  Various violations are assigned a badness score.  Presently just the preimage miss and swap inaction violations are defined, although rule 4 (contract amount) could be included too:

```go
// violation badness
const (
	// preimage miss
	preimageMissScore = 2 // book spoof, no match, no stuck funds

	// failure to act violations
	noSwapAsMakerScore   = 4  // book spoof, match with taker order affected, no stuck funds
	noSwapAsTakerScore   = 11 // maker has contract stuck for 20 hrs
	noRedeemAsMakerScore = 7  // taker has contract stuck for 8 hrs
	noRedeemAsTakerScore = 1  // just dumb, counterparty not inconvenienced

	successScore = -1 // offsets the violations

	defaultBanScore = 20
)
```

I'm not sure how to integrate cancels into this system, but we'd certainly need to redefine [rule 3](**url**) entirely.  

Since a user can be *both* maker and taker on a match, there is special handling on such self-matches so that the user is only credited with `success` once per match.

Some dcrdex logs with some trades and violations.

```
[DBG] SWAP: processRedeem: valid redemption {txid = 2d182c10a97700e18920f715267931209ba4cac791e6d32c8c00efd90497c478, vin = 0} (dcr) spending contract {txid = a66a218c08a66ad06ba94430cb9ed17a5011213188302c5c230f79fe42a24d2c, vout = 0} received at 2020-09-23 15:15:27.961 +0000 UTC from d94ad34986db42d487c5447c8050d965eae07dcb0769afe1c1c023e8af2a6e82 (taker) for match dabfa3cfc208bb8abe9fe2fec3730a11a776d88cd50595d5cf119a2eff5a304a, swapStatus MakerRedeemed => MatchComplete
[DBG] AUTH: Registering outcome "swap success" (badness -1) for user d94ad34986db42d487c5447c8050d965eae07dcb0769afe1c1c023e8af2a6e82, new score = -1

[DBG] SWAP: processRedeem: valid redemption {txid = 8f73b5edaa5cab15934399feb5ca73cfa9c496f41bc2d41e8004aee74a48e5b5, vin = 0} (dcr) spending contract {txid = fd224365ba9bbd725d7e80386a634e6ac2322c1858de18b65c0824f29471ca04, vout = 0} received at 2020-09-23 15:16:21.961 +0000 UTC from d94ad34986db42d487c5447c8050d965eae07dcb0769afe1c1c023e8af2a6e82 (taker) for match 76551a5abd31d6f0917f6e8509240b669c07ff38a78a249a8f8ea77272f22e52, swapStatus MakerRedeemed => MatchComplete
[DBG] AUTH: Registering outcome "swap success" (badness -1) for user d94ad34986db42d487c5447c8050d965eae07dcb0769afe1c1c023e8af2a6e82, new score = -2

[DBG] SWAP: Swap {txid = 645b2d18d689b9c18164acb380b1dfc1bac55d0d389169819936517743528f14, vout = 0} (btc) has reached 1 confirmations (1 required)
... timeout
[DBG] SWAP: failMatch: swap 94b6ef89038759d6f0b6288ab377d378bbe8939cffa9e584b3e4988d8ef04892 failing (maker fault = false) at MakerSwapCast
NOTE that it strikes in the cancel rate too since the order is complete but not swapped --> [TRC] AUTH: User d94ad34986db42d487c5447c8050d965eae07dcb0769afe1c1c023e8af2a6e82 cancellation rate is now 0 (0 cancels : 5 successes). Violation = false
[DBG] AUTH: Registering outcome "no swap as taker" (badness 11) for user d94ad34986db42d487c5447c8050d965eae07dcb0769afe1c1c023e8af2a6e82, new score = 9

<new match in TakerSwapCast this time>
[DBG] SWAP: Swap {txid = 394f9ce66057410b346e3eb7826676cd0e70f2c2bb0ffebe220510fdcdf14515, vout = 0} (dcr) has reached 1 confirmations (1 required)

[DBG] SWAP: failMatch: swap 447a5d82222f691ee242836f9e2929f350caf587237866b3ac4e44e05a06936c failing (maker fault = true) at TakerSwapCast
[DBG] AUTH: Registering outcome "no redeem as maker" (badness 7) for user d94ad34986db42d487c5447c8050d965eae07dcb0769afe1c1c023e8af2a6e82, new score = 16

<complete a swap>
[DBG] SWAP: processRedeem: valid redemption {txid = e0e4c83bd93085f5e3fe034427a872aad75e05c06fb28a11a1066256737d561a, vin = 0} (btc) spending contract {txid = a8ee480ab04d7a84f43cb203be7046a1d3cd4580536eb1a855dedd458e7e8b2c, vout = 0} received at 2020-09-23 15:28:47.587 +0000 UTC from d94ad34986db42d487c5447c8050d965eae07dcb0769afe1c1c023e8af2a6e82 (taker) for match 707375649b01341e41fca825343f0e8da68defee50665aa67fe5442d586a3a21, swapStatus MakerRedeemed => MatchComplete
[DBG] AUTH: Registering outcome "swap success" (badness -1) for user d94ad34986db42d487c5447c8050d965eae07dcb0769afe1c1c023e8af2a6e82, new score = 15
```

dcrdex on connect example with different user

```
2020-09-23 20:18:35.236 [DBG] AUTH: User 01752f933bfbe4ea0d184d2540e1c167a6a74a18c70b7c8057e603f9e8e1c34d score = 20: 22 (violations) - 2 (2 successes) - 0 (forgiveness)
```