### PR TITLE
suspend/resume

### DIFF
--- a/client/cmd/dexc/ui/config.go
+++ b/client/cmd/dexc/ui/config.go
@@ -39,7 +39,7 @@ var (
 func setNet(applicationDirectory, net string) string {
 	netDirectory = filepath.Join(applicationDirectory, net)
 	logDirectory = filepath.Join(netDirectory, "logs")
-	logFilename = filepath.Join(logDirectory, "dex.log")
+	logFilename = filepath.Join(logDirectory, "dexc.log")
 	err := os.MkdirAll(netDirectory, 0700)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create net directory: %v\n", err)

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -534,8 +534,9 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 }
 
 // handleTradeResumptionMsg is called when a trade resumption notification is
-// received. This may be an orderbook message at the time of resumption or a
-// general notification at any time prior to market suspend.
+// received. This may be an orderbook message at the time of resumption, or a
+// notification of a newly-schedule resumption while the market is suspended
+// (prior to the market resume).
 func handleTradeResumptionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	var rs msgjson.TradeResumption
 	err := msg.Unmarshal(&rs)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -91,43 +91,15 @@ const (
 	fundingTxWait          = 2 * time.Minute
 )
 
-// suspended returns the suspended status of the provided market.
-func (dc *dexConnection) suspended(mkt string) bool {
-	dc.marketMtx.Lock()
-	defer dc.marketMtx.Unlock()
-	market, ok := dc.marketMap[mkt]
-	if !ok {
-		return false
+// running returns the status of the provided market.
+func (dc *dexConnection) running(mkt string) bool {
+	dc.cfgMtx.RLock()
+	defer dc.cfgMtx.RUnlock()
+	mktCfg := dc.marketConfig(mkt)
+	if mktCfg == nil {
+		return false // not found means not running
 	}
-	return market.Suspended()
-}
-
-// suspend halts trading for the provided market.
-func (dc *dexConnection) suspend(mkt string) error {
-	dc.marketMtx.Lock()
-	market, ok := dc.marketMap[mkt]
-	dc.marketMtx.Unlock()
-	if !ok {
-		return fmt.Errorf("no market found with ID %s", mkt)
-	}
-
-	market.setSuspended(true)
-
-	return nil
-}
-
-// resume commences trading for the provided market.
-func (dc *dexConnection) resume(mkt string) error {
-	dc.marketMtx.Lock()
-	market, ok := dc.marketMap[mkt]
-	dc.marketMtx.Unlock()
-	if !ok {
-		return fmt.Errorf("no market found with ID %s", mkt)
-	}
-
-	market.setSuspended(false)
-
-	return nil
+	return mktCfg.Running()
 }
 
 // refreshMarkets rebuilds, saves, and returns the market map. The map itself
@@ -135,7 +107,7 @@ func (dc *dexConnection) resume(mkt string) error {
 // dc.marketMap under lock, and can be safely accessed with
 // dexConnection.markets. refreshMarkets is used when a change to the status of
 // a market or the user's orders on a market has changed.
-func (dc *dexConnection) refreshMarkets() map[string]*Market {
+func (dc *dexConnection) refreshMarkets() {
 	dc.cfgMtx.RLock()
 	defer dc.cfgMtx.RUnlock()
 
@@ -155,7 +127,6 @@ func (dc *dexConnection) refreshMarkets() map[string]*Market {
 			EpochLen:        mkt.EpochLen,
 			StartEpoch:      mkt.StartEpoch,
 			MarketBuyBuffer: mkt.MarketBuyBuffer,
-			suspended:       dc.suspended(mkt.Name),
 		}
 		mid := market.marketName()
 		dc.tradeMtx.RLock()
@@ -171,12 +142,12 @@ func (dc *dexConnection) refreshMarkets() map[string]*Market {
 			corder, _ := trade.coreOrder()
 			market.Orders = append(market.Orders, corder)
 		}
-		marketMap[market.marketName()] = market
+		marketMap[mid] = market
 	}
+
 	dc.marketMtx.Lock()
 	dc.marketMap = marketMap
 	dc.marketMtx.Unlock()
-	return marketMap
 }
 
 // markets returns the current market map.
@@ -2178,8 +2149,8 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 
 	// Proceed with the order if there is no trade suspension
 	// scheduled for the market.
-	if mkt.Suspended() {
-		return nil, 0, fmt.Errorf("%s market suspended", mktID)
+	if !dc.running(mktID) {
+		return nil, 0, fmt.Errorf("%s market trading is suspended", mktID)
 	}
 
 	rate, qty := form.Rate, form.Qty
@@ -3042,8 +3013,8 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 	return relocks
 }
 
-// generateDEXMaps creates the associated assets, market and epoch maps of
-// the dexs from the provided configuration.
+// generateDEXMaps creates the associated assets, market and epoch maps of the
+// DEXs from the provided configuration.
 func generateDEXMaps(host string, cfg *msgjson.ConfigResult) (map[uint32]*dex.Asset, map[string]*Market, map[string]uint64, error) {
 	assets := make(map[uint32]*dex.Asset, len(cfg.Assets))
 	for _, asset := range cfg.Assets {
@@ -3076,6 +3047,7 @@ func generateDEXMaps(host string, cfg *msgjson.ConfigResult) (map[uint32]*dex.As
 			EpochLen:        mkt.EpochLen,
 			StartEpoch:      mkt.StartEpoch,
 			MarketBuyBuffer: mkt.MarketBuyBuffer,
+			// no Orders yet
 		}
 		marketMap[mkt.Name] = market
 		epochMap[mkt.Name] = 0
@@ -3306,93 +3278,6 @@ func handleRevokeMatchMsg(c *Core, dc *dexConnection, msg *msgjson.Message) erro
 	return dc.ack(msg.ID, matchID, &revocation)
 }
 
-// handleTradeSuspensionMsg is called when a trade suspension notification is received.
-func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
-	var sp msgjson.TradeSuspension
-	err := msg.Unmarshal(&sp)
-	if err != nil {
-		return fmt.Errorf("trade suspension unmarshal error: %v", err)
-	}
-
-	// Ensure the provided market exists for the dex.
-	dc.marketMtx.Lock()
-	mkt, ok := dc.marketMap[sp.MarketID]
-	dc.marketMtx.Unlock()
-	if !ok {
-		return fmt.Errorf("no market found with ID %s", sp.MarketID)
-	}
-
-	// Ensure the market is not already suspended.
-	mkt.mtx.Lock()
-	defer mkt.mtx.Unlock()
-
-	if mkt.suspended {
-		return fmt.Errorf("market %s for dex %s is already suspended",
-			sp.MarketID, dc.acct.host)
-	}
-
-	// Stop the current pending suspend.
-	if mkt.pendingSuspend != nil {
-		if !mkt.pendingSuspend.Stop() {
-			// TODO: too late, timer already fired. Need to request the
-			// current configuration for the market at this point.
-			return fmt.Errorf("unable to stop previously scheduled "+
-				"suspend for market %s on dex %s", sp.MarketID, dc.acct.host)
-		}
-	}
-
-	// Set a new scheduled suspend.
-	duration := time.Until(encode.UnixTimeMilli(int64(sp.SuspendTime)))
-	mkt.pendingSuspend = time.AfterFunc(duration, func() {
-		mkt.mtx.Lock()
-		mkt.pendingSuspend = nil
-		mkt.mtx.Unlock()
-		// Update the market as suspended.
-		err := dc.suspend(sp.MarketID)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-
-		// Clear the bookie associated with the suspended market.
-		dc.booksMtx.Lock()
-		if bookie := dc.books[sp.MarketID]; bookie != nil {
-			// TODO: This is wrong. The server subscription remains. Also the
-			// BookFeed receivers are still waiting on the old bookie. Fixing
-			// this will require some thought to keep the bookie, but signal to
-			// the receivers of an empty book, while maintaining the proper
-			// order book message seq.
-
-			// Old bookie and it's feeds get garbage collected. Any orderbook
-			// subscriptions remain, and are handled by the new bookie.
-			dc.books[sp.MarketID] = newBookie(func() { dc.stopBook(mkt.BaseID, mkt.QuoteID) })
-		}
-		dc.booksMtx.Unlock()
-
-		if !sp.Persist {
-			// Revoke all active orders of the suspended market for the dex.
-			updatedAssets := make(assetMap)
-			dc.tradeMtx.RLock()
-			for _, tracker := range dc.trades {
-
-				if tracker.Order.Base() == mkt.BaseID &&
-					tracker.Order.Quote() == mkt.QuoteID &&
-					tracker.metaData.Host == dc.acct.host {
-
-					tracker.revoke()
-					updatedAssets.count(tracker.fromAssetID)
-				}
-			}
-			dc.tradeMtx.RUnlock()
-
-			dc.refreshMarkets()
-			c.updateBalances(updatedAssets)
-		}
-	})
-
-	return nil
-}
-
 // handleNotifyMsg is called when a notify notification is received.
 func handleNotifyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	var txt string
@@ -3402,94 +3287,6 @@ func handleNotifyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	}
 	txt = fmt.Sprintf("Message from DEX at %s:\n\n\"%s\"\n", dc.acct.host, txt)
 	c.notify(newServerNotifyNote(dc.acct.host, txt, db.WarningLevel))
-	return nil
-}
-
-// handleTradeResumptionMsg is called when a trade resumption notification is received.
-func handleTradeResumptionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
-	var rs msgjson.TradeResumption
-	err := msg.Unmarshal(&rs)
-	if err != nil {
-		return fmt.Errorf("trade resumption unmarshal error: %v", err)
-	}
-
-	// Ensure the provided market exists for the dex.
-	dc.marketMtx.RLock()
-	mkt, ok := dc.marketMap[rs.MarketID]
-	dc.marketMtx.RUnlock()
-	if !ok {
-		return fmt.Errorf("no market found with ID %s", rs.MarketID)
-	}
-
-	// Ensure the market is suspended.
-	mkt.mtx.Lock()
-	defer mkt.mtx.Unlock()
-
-	if !mkt.suspended {
-		return fmt.Errorf("market %s for dex %s is not suspended",
-			rs.MarketID, dc.acct.host)
-	}
-
-	// Stop the current pending resume.
-	if mkt.pendingResume != nil {
-		if !mkt.pendingResume.Stop() {
-			// TODO: too late, timer already fired. The market has resumed.
-			return fmt.Errorf("unable to stop previously scheduled "+
-				"resume for market %s on dex %s", rs.MarketID, dc.acct.host)
-		}
-	}
-
-	// TODO: the server on sending the resumption message would know the exact
-	// resumption time, perhaps the message should send that instead of the
-	// EpochLen here?
-	resumeTime := rs.StartEpoch * rs.EpochLen
-
-	// Set the new scheduled resume.
-	duration := time.Until(encode.UnixTimeMilli(int64(resumeTime)))
-	mkt.pendingSuspend = time.AfterFunc(duration, func() {
-		mkt.mtx.Lock()
-		mkt.pendingSuspend = nil
-		mkt.mtx.Unlock()
-
-		// Update the market as resumed.
-		err := dc.resume(rs.MarketID)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-
-		// Fetch the updated DEX configuration.
-		cfg := new(msgjson.ConfigResult)
-		err = sendRequest(dc.WsConn, msgjson.ConfigRoute, nil, cfg, DefaultResponseTimeout)
-		if err != nil {
-			dc.connMaster.Disconnect()
-			log.Errorf("unable to fetch DEX server config: %v", err)
-			return
-		}
-
-		assets, markets, epochs, err := generateDEXMaps(dc.acct.host, cfg)
-		if err != nil {
-			log.Error(err)
-		}
-
-		// Update the dex connection wih the new config details.
-		dc.cfgMtx.Lock()
-		dc.cfg = cfg
-		dc.cfgMtx.Unlock()
-
-		dc.marketMtx.Lock()
-		dc.marketMap = markets
-		dc.marketMtx.Unlock()
-
-		dc.epochMtx.Lock()
-		dc.epoch = epochs
-		dc.epochMtx.Unlock()
-
-		dc.assetsMtx.Lock()
-		dc.assets = assets
-		dc.assetsMtx.Unlock()
-	})
-
 	return nil
 }
 
@@ -3534,10 +3331,10 @@ var noteHandlers = map[string]routeHandler{
 	msgjson.UnbookOrderRoute:     handleUnbookOrderMsg,
 	msgjson.UpdateRemainingRoute: handleUpdateRemainingMsg,
 	msgjson.SuspensionRoute:      handleTradeSuspensionMsg,
+	msgjson.ResumptionRoute:      handleTradeResumptionMsg,
 	msgjson.NotifyRoute:          handleNotifyMsg,
 	msgjson.PenaltyRoute:         handlePenaltyMsg,
 	msgjson.NoMatchRoute:         handleNoMatchRoute,
-	msgjson.ResumptionRoute:      handleTradeResumptionMsg,
 }
 
 // listen monitors the DEX websocket connection for server requests and

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3144,7 +3144,17 @@ func (c *Core) handleReconnect(host string) {
 		log.Errorf("handleReconnect: Unable to find previous connection to DEX at %s", host)
 		return
 	}
-	if err := c.authDEX(dc); err != nil {
+
+	// The server's configuration may have changed, so retrieve the current
+	// server configuration.
+	err := dc.refreshServerConfig()
+	if err != nil {
+		log.Errorf("handleReconnect: Unable to apply new configuration for DEX at %s: %v", host, err)
+		return
+	}
+
+	err = c.authDEX(dc)
+	if err != nil {
 		log.Errorf("handleReconnect: Unable to authorize DEX at %s: %v", host, err)
 		return
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -164,7 +164,6 @@ func testDexConnection() (*dexConnection, *TWebsocket, *dexAccount) {
 		QuoteSymbol:     tBTC.Symbol,
 		EpochLen:        60000,
 		MarketBuyBuffer: 1.1,
-		suspended:       false,
 	}
 	return &dexConnection{
 		WsConn:     conn,
@@ -189,6 +188,11 @@ func testDexConnection() (*dexConnection, *TWebsocket, *dexAccount) {
 					Quote:           tBTC.ID,
 					EpochLen:        60000,
 					MarketBuyBuffer: 1.1,
+					MarketStatus: msgjson.MarketStatus{
+						StartEpoch: 12, // since the stone age
+						FinalEpoch: 0,  // no scheduled suspend
+						// Persist:   nil,
+					},
 				},
 			},
 			Fee: tFee,
@@ -3807,6 +3811,8 @@ func TestHandleTradeSuspensionMsg(t *testing.T) {
 	mkt := dc.market(tDcrBtcMktName)
 	walletSet, _ := tCore.walletSet(dc, tDCR.ID, tBTC.ID, true)
 
+	rig.dc.books[tDcrBtcMktName] = newBookie(func() {})
+
 	addTracker := func(coins asset.Coins) *trackedTrade {
 		lo, dbOrder, preImg, _ := makeLimitOrder(dc, true, 0, 0)
 		oid := lo.ID()
@@ -3829,14 +3835,7 @@ func TestHandleTradeSuspensionMsg(t *testing.T) {
 	req, _ := msgjson.NewRequest(rig.dc.NextID(), msgjson.SuspensionRoute, payload)
 	err := handleTradeSuspensionMsg(rig.core, rig.dc, req)
 	if err == nil {
-		t.Fatal("[handleTradeSuspensionMsg] expected a market " +
-			"ID not found error: %v")
-	}
-
-	// Ensure a suspended market cannot be resuspended.
-	err = rig.dc.suspend(tDcrBtcMktName)
-	if err != nil {
-		t.Fatalf("[handleTradeSuspensionMsg] unexpected error: %v", err)
+		t.Fatal("[handleTradeSuspensionMsg] expected a market ID not found error")
 	}
 
 	newPayload := func() *msgjson.TradeSuspension {
@@ -3848,27 +3847,19 @@ func TestHandleTradeSuspensionMsg(t *testing.T) {
 		}
 	}
 
-	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.SuspensionRoute, newPayload())
-	err = handleTradeSuspensionMsg(rig.core, rig.dc, req)
-	if err == nil {
-		t.Fatal("[handleTradeSuspensionMsg] expected a market " +
-			"suspended error: %v")
-	}
+	// Suspend a running market.
+	rig.dc.cfgMtx.Lock()
+	mktConf := rig.dc.marketConfig(tDcrBtcMktName)
+	mktConf.StartEpoch = 12
+	rig.dc.cfgMtx.Unlock()
 
-	// Suspend a market.
-	err = rig.dc.resume(tDcrBtcMktName)
-	if err != nil {
-		t.Fatalf("[handleTradeSuspensionMsg] unexpected error: %v", err)
-	}
-
-	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.SuspensionRoute, newPayload())
+	payload = newPayload()
+	payload.SuspendTime = 0 // now
+	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.SuspensionRoute, payload)
 	err = handleTradeSuspensionMsg(rig.core, rig.dc, req)
 	if err != nil {
 		t.Fatalf("[handleTradeSuspensionMsg] unexpected error: %v", err)
 	}
-
-	// Wait for the suspend to execute.
-	time.Sleep(time.Millisecond * 40)
 
 	// Check that the funding coin was returned. Use the tradeMtx for
 	// synchronization.
@@ -3884,14 +3875,16 @@ func TestHandleTradeSuspensionMsg(t *testing.T) {
 	changeCoinID := encode.RandomBytes(36)
 	swappedTracker.change = &tCoin{id: changeCoinID}
 	swappedTracker.changeLocked = true
-	_ = rig.dc.resume(tDcrBtcMktName)
-	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.SuspensionRoute, newPayload())
+	rig.dc.cfgMtx.Lock()
+	mktConf.StartEpoch = 12 // make it appear running again first
+	mktConf.FinalEpoch = 0
+	mktConf.Persist = nil
+	rig.dc.cfgMtx.Unlock()
+	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.SuspensionRoute, payload)
 	err = handleTradeSuspensionMsg(rig.core, rig.dc, req)
 	if err != nil {
 		t.Fatalf("[handleTradeSuspensionMsg] unexpected error: %v", err)
 	}
-	// Wait for the suspend to execute.
-	time.Sleep(time.Millisecond * 40)
 	// Check that the funding coin was returned.
 	dc.tradeMtx.Lock()
 	if len(tDcrWallet.returnedCoins) != 1 || !bytes.Equal(tDcrWallet.returnedCoins[0].ID(), changeCoinID) {
@@ -3911,14 +3904,14 @@ func TestHandleTradeSuspensionMsg(t *testing.T) {
 		counterConfirms: -1,
 	}
 	swappedTracker.matches[mid] = match
-	_ = rig.dc.resume(tDcrBtcMktName)
-	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.SuspensionRoute, newPayload())
+	rig.dc.cfgMtx.Lock()
+	mktConf.StartEpoch = 12 // make it appear running again first
+	rig.dc.cfgMtx.Unlock()
+	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.SuspensionRoute, payload)
 	err = handleTradeSuspensionMsg(rig.core, rig.dc, req)
 	if err != nil {
 		t.Fatalf("[handleTradeSuspensionMsg] unexpected error: %v", err)
 	}
-	// Wait for the suspend to execute.
-	time.Sleep(time.Millisecond * 40)
 	dc.tradeMtx.Lock()
 	if tDcrWallet.returnedCoins != nil {
 		t.Fatalf("change coin returned with active matches")
@@ -4232,6 +4225,8 @@ func TestHandleTradeResumptionMsg(t *testing.T) {
 	tCore.wallets[tBTC.ID] = btcWallet
 	btcWallet.Unlock(wPW, time.Hour)
 
+	epochLen := rig.dc.market(tDcrBtcMktName).EpochLen
+
 	handleLimit := func(msg *msgjson.Message, f msgFunc) error {
 		// Need to stamp and sign the message with the server's key.
 		msgOrder := new(msgjson.LimitOrder)
@@ -4244,59 +4239,7 @@ func TestHandleTradeResumptionMsg(t *testing.T) {
 		return nil
 	}
 
-	rig.ws.queueResponse(msgjson.LimitRoute, handleLimit)
-
-	// Ensure a non-existent market cannot be suspended.
-	payload := &msgjson.TradeResumption{
-		MarketID: "dcr_dcr",
-	}
-
-	req, _ := msgjson.NewRequest(rig.dc.NextID(), msgjson.ResumptionRoute, payload)
-	err := handleTradeResumptionMsg(rig.core, rig.dc, req)
-	if err == nil {
-		t.Fatal("[handleTradeResumptionMsg] expected a market " +
-			"ID not found error: %v")
-	}
-
-	mkt := tDcrBtcMktName
-
-	// Ensure an already resumed market cannot be re-resumed.
-	err = rig.dc.resume(mkt)
-	if err != nil {
-		t.Fatalf("[handleTradeResumptionMsg] unexpected error: %v", err)
-	}
-
-	newPayload := func() *msgjson.TradeResumption {
-		return &msgjson.TradeResumption{
-			MarketID:   tDcrBtcMktName,
-			EpochLen:   100,
-			StartEpoch: encode.UnixMilliU(time.Now().Add(time.Millisecond*20)) / uint64(100),
-		}
-	}
-
-	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.ResumptionRoute, newPayload())
-	err = handleTradeResumptionMsg(rig.core, rig.dc, req)
-	if err == nil {
-		t.Fatal("[handleTradeResumptionMsg] expected a market resumption error")
-	}
-
-	// Resume a market.
-	err = rig.dc.suspend(mkt)
-	if err != nil {
-		t.Fatalf("[handleTradeResumptionMsg] unexpected error: %v", err)
-	}
-
-	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.ResumptionRoute, newPayload())
-	err = handleTradeResumptionMsg(rig.core, rig.dc, req)
-	if err != nil {
-		t.Fatalf("[handleTradeResumptionMsg] unexpected error: %v", err)
-	}
-
-	// Wait for the resume to execute.
-	time.Sleep(time.Millisecond * 40)
-
-	// Ensure trades for a resumed market are processed without error.
-	form := &TradeForm{
+	tradeForm := &TradeForm{
 		Host:    tDexHost,
 		IsLimit: true,
 		Sell:    true,
@@ -4307,7 +4250,61 @@ func TestHandleTradeResumptionMsg(t *testing.T) {
 		TifNow:  false,
 	}
 
-	_, err = rig.core.Trade(tPW, form)
+	rig.ws.queueResponse(msgjson.LimitRoute, handleLimit)
+
+	// Ensure a non-existent market cannot be suspended.
+	payload := &msgjson.TradeResumption{
+		MarketID: "dcr_dcr",
+	}
+
+	req, _ := msgjson.NewRequest(rig.dc.NextID(), msgjson.ResumptionRoute, payload)
+	err := handleTradeResumptionMsg(rig.core, rig.dc, req)
+	if err == nil {
+		t.Fatal("[handleTradeResumptionMsg] expected a market ID not found error")
+	}
+
+	var resumeTime uint64
+	newPayload := func() *msgjson.TradeResumption {
+		return &msgjson.TradeResumption{
+			MarketID:   tDcrBtcMktName,
+			ResumeTime: resumeTime, // set the time to test the scheduling notification case, zero it for immediate resume
+			StartEpoch: resumeTime / epochLen,
+		}
+	}
+
+	// Notify of scheduled resume.
+	rig.dc.cfgMtx.Lock()
+	mktConf := rig.dc.marketConfig(tDcrBtcMktName)
+	mktConf.StartEpoch = 12
+	mktConf.FinalEpoch = mktConf.StartEpoch + 1 // long since closed
+	rig.dc.cfgMtx.Unlock()
+
+	resumeTime = encode.UnixMilliU(time.Now().Add(time.Hour))
+	payload = newPayload()
+	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.ResumptionRoute, payload)
+	err = handleTradeResumptionMsg(rig.core, rig.dc, req)
+	if err != nil {
+		t.Fatalf("[handleTradeResumptionMsg] unexpected error: %v", err)
+	}
+
+	// Should be suspended still, no trades
+	_, err = rig.core.Trade(tPW, tradeForm)
+	if err == nil {
+		t.Fatal("trade was accepted for suspended market")
+	}
+
+	// Resume the market immediately.
+	resumeTime = encode.UnixMilliU(time.Now())
+	payload = newPayload()
+	payload.ResumeTime = 0 // resume now, not scheduled
+	req, _ = msgjson.NewRequest(rig.dc.NextID(), msgjson.ResumptionRoute, payload)
+	err = handleTradeResumptionMsg(rig.core, rig.dc, req)
+	if err != nil {
+		t.Fatalf("[handleTradeResumptionMsg] unexpected error: %v", err)
+	}
+
+	// Ensure trades for a resumed market are processed without error.
+	_, err = rig.core.Trade(tPW, tradeForm)
 	if err != nil {
 		t.Fatalf("unexpected trade error %v", err)
 	}

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -23,11 +23,13 @@ const (
 	connectionErr
 	acctKeyErr
 	unknownOrderErr
+	orderParamsErr
 	dbErr
 	authErr
 	connectErr
 	missingWalletErr
 	encryptionErr
+	marketErr
 )
 
 // Error is an error message and an error code.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -987,6 +987,17 @@ func (t *trackedTrade) revoke() {
 		log.Errorf("unable to update order: %v", err)
 	}
 
+	// Send out a data notification with the revoke information.
+	// corder, _ := t.coreOrderInternal()
+	cancelOrder := &Order{
+		Host:     t.dc.acct.host,
+		MarketID: t.mktID,
+		Type:     order.CancelOrderType,
+		Stamp:    encode.UnixMilliU(time.Now()),
+		TargetID: t.ID().Bytes(), // the important part for the frontend
+	}
+	t.notify(newOrderNote("revoke", "", db.Data, cancelOrder))
+
 	// Return coins if there are no matches that MAY later require sending swaps.
 	t.maybeReturnCoins()
 }

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -988,7 +988,6 @@ func (t *trackedTrade) revoke() {
 	}
 
 	// Send out a data notification with the revoke information.
-	// corder, _ := t.coreOrderInternal()
 	cancelOrder := &Order{
 		Host:     t.dc.acct.host,
 		MarketID: t.mktID,

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/db"
@@ -261,10 +260,6 @@ type Market struct {
 	StartEpoch      uint64   `json:"startepoch"`
 	MarketBuyBuffer float64  `json:"buybuffer"`
 	Orders          []*Order `json:"orders"`
-	pendingSuspend  *time.Timer
-	pendingResume   *time.Timer
-	suspended       bool
-	mtx             sync.Mutex
 }
 
 // Display returns an ID string suitable for displaying in a UI.
@@ -275,20 +270,6 @@ func (m *Market) Display() string {
 // mktID is a string ID constructed from the asset IDs.
 func (m *Market) marketName() string {
 	return marketName(m.BaseID, m.QuoteID)
-}
-
-// suspended returns the market's suspended state.
-func (m *Market) Suspended() bool {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	return m.suspended
-}
-
-// setSuspended sets the market's suspended state.
-func (m *Market) setSuspended(state bool) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	m.suspended = state
 }
 
 // Exchange represents a single DEX with any number of markets.

--- a/client/order/orderbook.go
+++ b/client/order/orderbook.go
@@ -175,12 +175,18 @@ func (ob *OrderBook) processCachedNotes() error {
 	return nil
 }
 
-// Sync updates a client tracked order book with an order book snapshot.
+// Sync updates a client tracked order book with an order book snapshot. It is
+// an error if the the OrderBook is already synced.
 func (ob *OrderBook) Sync(snapshot *msgjson.OrderBook) error {
 	if ob.isSynced() {
 		return fmt.Errorf("order book is already synced")
 	}
+	return ob.Reset(snapshot)
+}
 
+// Reset forcibly updates a client tracked order book with an order book
+// snapshot. This resets the sequence.
+func (ob *OrderBook) Reset(snapshot *msgjson.OrderBook) error {
 	// Don't use setSeq here, since this message is the seed and is not expected
 	// to be 1 more than the current seq value.
 	ob.seqMtx.Lock()

--- a/client/order/orderbook.go
+++ b/client/order/orderbook.go
@@ -428,8 +428,8 @@ func (ob *OrderBook) Orders() ([]*Order, []*Order, []*Order) {
 	return ob.buys.orders(), ob.sells.orders(), ob.epochQueue.Orders()
 }
 
-// BestFIll returns the best fill for a quantity from the provided side.
-func (ob *OrderBook) BestFill(qty uint64, side uint8) ([]*fill, error) {
+// bestFill returns the best fill for a quantity from the provided side.
+func (ob *OrderBook) bestFill(qty uint64, side uint8) ([]*fill, error) {
 	if !ob.isSynced() {
 		return nil, fmt.Errorf("order book is unsynced")
 	}

--- a/client/order/orderbook_test.go
+++ b/client/order/orderbook_test.go
@@ -909,7 +909,7 @@ func TestOrderBookBestFill(t *testing.T) {
 	}
 
 	for idx, tc := range tests {
-		best, err := tc.orderBook.BestFill(tc.qty, tc.side)
+		best, err := tc.orderBook.bestFill(tc.qty, tc.side)
 		if (err != nil) != tc.wantErr {
 			t.Fatalf("[OrderBook.BestFill] #%d: error: %v, wantErr: %v",
 				idx+1, err, tc.wantErr)

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -815,8 +815,8 @@ export default class MarketsPage extends BasePage {
         Doc.hide(status)
         status.textContent = 'canceled'
       } else if (note.subject === 'revoke') {
+        Doc.hide(status)
         status.textContent = 'revoked'
-        Doc.show(status)
       }
       return
     }

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -810,16 +810,18 @@ export default class MarketsPage extends BasePage {
   handleOrderNote (note) {
     const order = note.order
     if (order.targetID) {
-      const status = Doc.tmplElement(this.metaOrders[order.targetID].row, 'cancelStatus')
+      const targetOrder = this.metaOrders[order.targetID]
+      if (!targetOrder) return
+      Doc.hide(Doc.tmplElement(targetOrder.row, 'cancelStatus'))
       if (note.subject === 'cancel') {
-        Doc.hide(status)
-        status.textContent = 'canceled'
+        targetOrder.order.status = Order.StatusCanceled
       } else if (note.subject === 'revoke') {
-        Doc.hide(status)
-        status.textContent = 'revoked'
+        targetOrder.order.status = Order.StatusRevoked
       }
+      updateUserOrderRow(targetOrder.row, targetOrder)
       return
     }
+
     const metaOrder = this.metaOrders[order.id]
     if (!metaOrder) return
     metaOrder.order = order

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex"
-	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/server/account"
 )
 
 // Error codes

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -816,13 +816,12 @@ type TradeSuspension struct {
 }
 
 // TradeResumption is the ResumptionRoute notification payload. It is part of
-// the orderbook subscription. EpochLen is specified if the market configuration
-// change, and the client should also hit the 'config' route for full details.
+// the orderbook subscription.
 type TradeResumption struct {
 	MarketID   string `json:"marketid"`
 	ResumeTime uint64 `json:"resumetime,omitempty"` // only set in advance of resume
 	StartEpoch uint64 `json:"startepoch"`
-	// EpochLen   uint64 `json:"epochlen,omitempty"` // maybe just ConfigChange bool `json:"configchange"`
+	// TODO: ConfigChange bool or entire Config Market here.
 }
 
 // PreimageRequest is the server-originating preimage request payload.

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -33,7 +33,7 @@ func (cm *contextManager) On() bool {
 // Runner is satisfied by DEX subsystems, which must start any of their
 // goroutines via the Run method.
 type Runner interface {
-	Run(ctx context.Context) //error
+	Run(ctx context.Context)
 }
 
 // StartStopWaiter wraps a Runner, providing the non-blocking Start and Stop
@@ -59,6 +59,7 @@ func (ssw *StartStopWaiter) Start(ctx context.Context) {
 	ssw.wg.Add(1)
 	go func() {
 		ssw.runner.Run(ssw.ctx)
+		ssw.cancel() // in case it stopped on its own
 		ssw.wg.Done()
 	}()
 }

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -138,10 +138,12 @@ func (s *Server) apiResume(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	resEpoch, resTime := s.core.ResumeMarket(mkt, resTime)
-	if resEpoch == 0 {
+	resEpoch, resTime, err := s.core.ResumeMarket(mkt, resTime)
+	if resEpoch == 0 || err != nil {
 		// Should not happen.
-		http.Error(w, "failed to resume market "+mkt, http.StatusInternalServerError)
+		msg := fmt.Sprintf("Failed to resume market: %v", err)
+		log.Errorf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 
@@ -196,10 +198,12 @@ func (s *Server) apiSuspend(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	suspEpoch := s.core.SuspendMarket(mkt, suspTime, persistBook)
-	if suspEpoch == nil {
+	suspEpoch, err := s.core.SuspendMarket(mkt, suspTime, persistBook)
+	if suspEpoch == nil || err != nil {
 		// Should not happen.
-		http.Error(w, "failed to suspend market "+mkt, http.StatusInternalServerError)
+		msg := fmt.Sprintf("Failed to suspend market: %v", err)
+		log.Errorf(msg)
+		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -108,7 +108,7 @@ func (s *Server) apiMarketInfo(w http.ResponseWriter, r *http.Request) {
 
 // hander for route '/market/{marketName}/resume?t=UNIXMS'
 func (s *Server) apiResume(w http.ResponseWriter, r *http.Request) {
-	// Ensure the market exists and is running.
+	// Ensure the market exists and is not running.
 	mkt := strings.ToLower(chi.URLParam(r, marketNameKey))
 	found, running := s.core.MarketRunning(mkt)
 	if !found {

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -54,6 +54,7 @@ type SvrCore interface {
 	MarketStatus(mktName string) *market.Status
 	MarketStatuses() map[string]*market.Status
 	SuspendMarket(name string, tSusp time.Time, persistBooks bool) *market.SuspendEpoch
+	ResumeMarket(name string, asSoonAs time.Time) (startEpoch int64, startTime time.Time)
 	Penalize(aid account.AccountID, rule account.Rule, details string) error
 	Unban(aid account.AccountID) error
 }
@@ -143,6 +144,7 @@ func NewServer(cfg *SrvConfig) (*Server, error) {
 		r.Route("/market/{"+marketNameKey+"}", func(rm chi.Router) {
 			rm.Get("/", s.apiMarketInfo)
 			rm.Get("/suspend", s.apiSuspend)
+			rm.Get("/resume", s.apiResume)
 		})
 	})
 

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -53,8 +53,8 @@ type SvrCore interface {
 	MarketRunning(mktName string) (found, running bool)
 	MarketStatus(mktName string) *market.Status
 	MarketStatuses() map[string]*market.Status
-	SuspendMarket(name string, tSusp time.Time, persistBooks bool) *market.SuspendEpoch
-	ResumeMarket(name string, asSoonAs time.Time) (startEpoch int64, startTime time.Time)
+	SuspendMarket(name string, tSusp time.Time, persistBooks bool) (*market.SuspendEpoch, error)
+	ResumeMarket(name string, asSoonAs time.Time) (startEpoch int64, startTime time.Time, err error)
 	Penalize(aid account.AccountID, rule account.Rule, details string) error
 	Unban(aid account.AccountID) error
 }

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -62,7 +62,9 @@ func (c *TCore) ConfigMsg() json.RawMessage { return nil }
 func (c *TCore) Suspend(tSusp time.Time, persistBooks bool) map[string]*market.SuspendEpoch {
 	return nil
 }
-
+func (c *TCore) ResumeMarket(name string, tRes time.Time) (int64, time.Time) {
+	return 0, time.Time{} // test TODO
+}
 func (c *TCore) SuspendMarket(name string, tSusp time.Time, persistBooks bool) *market.SuspendEpoch {
 	tMkt := c.markets[name]
 	if tMkt == nil {

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -40,11 +40,14 @@ func init() {
 }
 
 type TMarket struct {
-	running bool
-	ep0, ep int64
-	dur     uint64
-	suspend *market.SuspendEpoch
-	persist bool
+	running     bool
+	dur         uint64
+	suspend     *market.SuspendEpoch
+	startEpoch  int64
+	activeEpoch int64
+	resumeEpoch int64
+	resumeTime  time.Time
+	persist     bool
 }
 
 type TCore struct {
@@ -62,8 +65,14 @@ func (c *TCore) ConfigMsg() json.RawMessage { return nil }
 func (c *TCore) Suspend(tSusp time.Time, persistBooks bool) map[string]*market.SuspendEpoch {
 	return nil
 }
-func (c *TCore) ResumeMarket(name string, tRes time.Time) (int64, time.Time) {
-	return 0, time.Time{} // test TODO
+func (c *TCore) ResumeMarket(name string, tRes time.Time) (startEpoch int64, startTime time.Time) {
+	tMkt := c.markets[name]
+	if tMkt == nil {
+		return
+	}
+	tMkt.resumeEpoch = 1 + encode.UnixMilli(tRes)/int64(tMkt.dur)
+	tMkt.resumeTime = encode.UnixTimeMilli(tMkt.resumeEpoch * int64(tMkt.dur))
+	return tMkt.resumeEpoch, tMkt.resumeTime
 }
 func (c *TCore) SuspendMarket(name string, tSusp time.Time, persistBooks bool) *market.SuspendEpoch {
 	tMkt := c.markets[name]
@@ -95,8 +104,8 @@ func (c *TCore) MarketStatus(mktName string) *market.Status {
 	return &market.Status{
 		Running:       mkt.running,
 		EpochDuration: mkt.dur,
-		ActiveEpoch:   mkt.ep,
-		StartEpoch:    mkt.ep0,
+		ActiveEpoch:   mkt.activeEpoch,
+		StartEpoch:    mkt.startEpoch,
 		SuspendEpoch:  suspendEpoch,
 		PersistBook:   mkt.persist,
 	}
@@ -112,8 +121,8 @@ func (c *TCore) MarketStatuses() map[string]*market.Status {
 		mktStatuses[name] = &market.Status{
 			Running:       mkt.running,
 			EpochDuration: mkt.dur,
-			ActiveEpoch:   mkt.ep,
-			StartEpoch:    mkt.ep0,
+			ActiveEpoch:   mkt.activeEpoch,
+			StartEpoch:    mkt.startEpoch,
 			SuspendEpoch:  suspendEpoch,
 			PersistBook:   mkt.persist,
 		}
@@ -284,10 +293,10 @@ func TestMarkets(t *testing.T) {
 	dur := uint64(1234)
 	idx := int64(12345)
 	tMkt := &TMarket{
-		running: true,
-		dur:     dur,
-		ep0:     12340,
-		ep:      12343,
+		running:     true,
+		dur:         dur,
+		startEpoch:  12340,
+		activeEpoch: 12343,
 	}
 	core.markets["dcr_btc"] = tMkt
 
@@ -479,8 +488,115 @@ func TestMarketInfo(t *testing.T) {
 	}
 }
 
-func TestSuspend(t *testing.T) {
+func TestResume(t *testing.T) {
+	core := &TCore{
+		markets: make(map[string]*TMarket),
+	}
+	srv := &Server{
+		core: core,
+	}
 
+	mux := chi.NewRouter()
+	mux.Get("/market/{"+marketNameKey+"}/resume", srv.apiResume)
+
+	// Non-existent market
+	name := "dcr_btc"
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "https://localhost/market/"+name+"/resume", nil)
+	r.RemoteAddr = "localhost"
+
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("apiResume returned code %d, expected %d", w.Code, http.StatusBadRequest)
+	}
+
+	// With the market, but already running
+	tMkt := &TMarket{
+		running: true,
+		dur:     6000,
+	}
+	core.markets[name] = tMkt
+
+	w = httptest.NewRecorder()
+	r, _ = http.NewRequest("GET", "https://localhost/market/"+name+"/resume", nil)
+	r.RemoteAddr = "localhost"
+
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("apiResume returned code %d, expected %d", w.Code, http.StatusOK)
+	}
+	wantMsg := "market \"dcr_btc\" running\n"
+	if w.Body.String() != wantMsg {
+		t.Errorf("expected body %q, got %q", wantMsg, w.Body)
+	}
+
+	// Now stopped.
+	tMkt.running = false
+	w = httptest.NewRecorder()
+	r, _ = http.NewRequest("GET", "https://localhost/market/"+name+"/resume", nil)
+	r.RemoteAddr = "localhost"
+
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("apiResume returned code %d, expected %d", w.Code, http.StatusOK)
+	}
+	resRes := new(ResumeResult)
+	err := json.Unmarshal(w.Body.Bytes(), &resRes)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal result: %v", err)
+	}
+	if resRes.Market != name {
+		t.Errorf("incorrect market name %q, expected %q", resRes.Market, name)
+	}
+
+	if resRes.StartTime.IsZero() {
+		t.Errorf("start time not set")
+	}
+	if resRes.StartEpoch == 0 {
+		t.Errorf("start epoch not sest")
+	}
+
+	// reset
+	tMkt.resumeEpoch = 0
+	tMkt.resumeTime = time.Time{}
+
+	// Time in past
+	w = httptest.NewRecorder()
+	r, _ = http.NewRequest("GET", "https://localhost/market/"+name+"/resume?t=12", nil)
+	r.RemoteAddr = "localhost"
+
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("apiResume returned code %d, expected %d", w.Code, http.StatusOK)
+	}
+	resp := w.Body.String()
+	wantPrefix := "specified market resume time is in the past"
+	if !strings.HasPrefix(resp, wantPrefix) {
+		t.Errorf("Expected error message starting with %q, got %q", wantPrefix, resp)
+	}
+
+	// Bad suspend time (not a time)
+	w = httptest.NewRecorder()
+	r, _ = http.NewRequest("GET", "https://localhost/market/"+name+"/resume?t=QWERT", nil)
+	r.RemoteAddr = "localhost"
+
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("apiResume returned code %d, expected %d", w.Code, http.StatusBadRequest)
+	}
+	resp = w.Body.String()
+	wantPrefix = "invalid resume time"
+	if !strings.HasPrefix(resp, wantPrefix) {
+		t.Errorf("Expected error message starting with %q, got %q", wantPrefix, resp)
+	}
+}
+
+func TestSuspend(t *testing.T) {
 	core := &TCore{
 		markets: make(map[string]*TMarket),
 	}
@@ -564,7 +680,7 @@ func TestSuspend(t *testing.T) {
 	mux.ServeHTTP(w, r)
 
 	if w.Code != http.StatusBadRequest {
-		t.Fatalf("apiSuspend returned code %d, expected %d", w.Code, http.StatusOK)
+		t.Fatalf("apiSuspend returned code %d, expected %d", w.Code, http.StatusBadRequest)
 	}
 	resp := w.Body.String()
 	wantPrefix := "specified market suspend time is in the past"
@@ -580,7 +696,7 @@ func TestSuspend(t *testing.T) {
 	mux.ServeHTTP(w, r)
 
 	if w.Code != http.StatusBadRequest {
-		t.Fatalf("apiSuspend returned code %d, expected %d", w.Code, http.StatusOK)
+		t.Fatalf("apiSuspend returned code %d, expected %d", w.Code, http.StatusBadRequest)
 	}
 	resp = w.Body.String()
 	wantPrefix = "invalid suspend time"
@@ -658,7 +774,7 @@ func TestSuspend(t *testing.T) {
 	mux.ServeHTTP(w, r)
 
 	if w.Code != http.StatusBadRequest {
-		t.Fatalf("apiSuspend returned code %d, expected %d", w.Code, http.StatusOK)
+		t.Fatalf("apiSuspend returned code %d, expected %d", w.Code, http.StatusBadRequest)
 	}
 	resp = w.Body.String()
 	wantPrefix = "invalid persist book boolean"

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -65,24 +65,26 @@ func (c *TCore) ConfigMsg() json.RawMessage { return nil }
 func (c *TCore) Suspend(tSusp time.Time, persistBooks bool) map[string]*market.SuspendEpoch {
 	return nil
 }
-func (c *TCore) ResumeMarket(name string, tRes time.Time) (startEpoch int64, startTime time.Time) {
+func (c *TCore) ResumeMarket(name string, tRes time.Time) (startEpoch int64, startTime time.Time, err error) {
 	tMkt := c.markets[name]
 	if tMkt == nil {
+		err = fmt.Errorf("unknown market %s", name)
 		return
 	}
 	tMkt.resumeEpoch = 1 + encode.UnixMilli(tRes)/int64(tMkt.dur)
 	tMkt.resumeTime = encode.UnixTimeMilli(tMkt.resumeEpoch * int64(tMkt.dur))
-	return tMkt.resumeEpoch, tMkt.resumeTime
+	return tMkt.resumeEpoch, tMkt.resumeTime, nil
 }
-func (c *TCore) SuspendMarket(name string, tSusp time.Time, persistBooks bool) *market.SuspendEpoch {
+func (c *TCore) SuspendMarket(name string, tSusp time.Time, persistBooks bool) (suspEpoch *market.SuspendEpoch, err error) {
 	tMkt := c.markets[name]
 	if tMkt == nil {
-		return nil
+		err = fmt.Errorf("unknown market %s", name)
+		return
 	}
 	tMkt.persist = persistBooks
 	tMkt.suspend.Idx = encode.UnixMilli(tSusp)
 	tMkt.suspend.End = tSusp.Add(time.Millisecond)
-	return tMkt.suspend
+	return tMkt.suspend, nil
 }
 
 func (c *TCore) market(name string) *TMarket {

--- a/server/admin/types.go
+++ b/server/admin/types.go
@@ -33,6 +33,13 @@ type SuspendResult struct {
 	SuspendTime APITime `json:"supendtime"`
 }
 
+// ResumeResult is the result of a market resume request.
+type ResumeResult struct {
+	Market     string  `json:"market"`
+	StartEpoch int64   `json:"startepoch"`
+	StartTime  APITime `json:"starttime"`
+}
+
 // RFC3339Milli is the RFC3339 time formatting with millisecond precision.
 const RFC3339Milli = "2006-01-02T15:04:05.999Z07:00"
 

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -587,8 +587,8 @@ func (dm *DEX) findSubsys(name string) int {
 	return -1
 }
 
-// ResumeMarket launches a stopped market subsystem as earlier as the given
-// time. The actual time the market will resume depends on the configure epoch
+// ResumeMarket launches a stopped market subsystem as early as the given time.
+// The actual time the market will resume depends on the configure epoch
 // duration, as the market only starts at the beginning of an epoch.
 func (dm *DEX) ResumeMarket(name string, asSoonAs time.Time) (startEpoch int64, startTime time.Time) {
 	name = strings.ToLower(name)
@@ -597,7 +597,7 @@ func (dm *DEX) ResumeMarket(name string, asSoonAs time.Time) (startEpoch int64, 
 		return
 	}
 
-	// Get the next available start epoch given the earliers allowed time.
+	// Get the next available start epoch given the earliest allowed time.
 	// Requires the market to be stopped already.
 	startEpoch = mkt.ResumeEpoch(asSoonAs)
 	if startEpoch == 0 {

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -148,20 +148,19 @@ func (cr *configResponse) setMktSuspend(name string, finalEpoch uint64, persist 
 			return
 		}
 	}
-	log.Errorf("Failed to set MarketStatus for market %q", name)
+	log.Errorf("Failed to update MarketStatus for market %q", name)
 }
 
 func (cr *configResponse) setMktResume(name string, startEpoch uint64) (epochLen uint64) {
 	for _, mkt := range cr.configMsg.Markets {
 		if mkt.Name == name {
-			// mkt.EpochLen = newEpochLen // TODO: reconfig
 			mkt.MarketStatus.StartEpoch = startEpoch
 			mkt.MarketStatus.FinalEpoch = 0
 			cr.remarshal()
 			return mkt.EpochLen
 		}
 	}
-	log.Errorf("Failed to set MarketStatus for market %q", name)
+	log.Errorf("Failed to update MarketStatus for market %q", name)
 	return 0
 }
 
@@ -634,7 +633,6 @@ func (dm *DEX) ResumeMarket(name string, asSoonAs time.Time) (startEpoch int64, 
 		MarketID:   name,
 		ResumeTime: uint64(startTimeMS),
 		StartEpoch: uint64(startEpoch),
-		// EpochLen:   epochLen, // no change (reconfig TODO)
 	})
 	if err != nil {
 		log.Errorf("Failed to create resume notification: %v", err)

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -6,7 +6,6 @@ package market
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"sync"
 
 	"decred.org/dcrdex/dex"
@@ -44,6 +43,8 @@ const (
 	matchProofAction
 	// suspendAction means the market has suspended.
 	suspendAction
+	// resumeAction means the market has resumed.
+	resumeAction
 )
 
 // String provides a string representation of a updateAction. This is primarily
@@ -99,8 +100,12 @@ type sigDataNewEpoch struct {
 
 type sigDataSuspend struct {
 	finalEpoch  int64
-	stopTime    int64
 	persistBook bool
+}
+
+type sigDataResume struct {
+	epochIdx int64
+	epochLen int64
 }
 
 type sigDataMatchProof struct {
@@ -400,25 +405,38 @@ out:
 				}
 
 			case sigDataSuspend:
-				// Consider sending a TradeSuspension here too:
-				// note = &msgjson.TradeSuspension{
-				// 	MarketID:    book.name,
-				// 	FinalEpoch:  uint64(sigData.finalEpoch),
-				// 	SuspendTime: uint64(sigData.stopTime),
-				// 	Persist:     sigData.persistBook,
-				// }
-				// r.sendNote(msgjson.SuspensionRoute, subs, note)
+				// When sent with seq set, it indicates immediate stop, and may
+				// also indicate to purge the book.
+				route = msgjson.SuspensionRoute
+				susp := &msgjson.TradeSuspension{
+					MarketID: book.name,
+					// SuspendTime of 0 means now.
+					FinalEpoch: uint64(sigData.finalEpoch),
+					Persist:    sigData.persistBook,
+				}
+				// Only set Seq if there is a book update.
+				if !sigData.persistBook {
+					susp.Seq = subs.nextSeq() // book purge
+				}
+				note = susp
 
-				// Depending on resume handling, maybe kill the book router.
-				// Presently the Market closes the order feed channels, so quit.
 				log.Infof("Market %q suspended after epoch %d, persist book = %v.",
 					book.name, sigData.finalEpoch, sigData.persistBook)
 
-				// Stay running for Swapper unbook callbacks.
-				continue // no note to send presently, but need one
+			case sigDataResume:
+				route = msgjson.ResumptionRoute
+				note = &msgjson.TradeResumption{
+					MarketID: book.name,
+					// ResumeTime of 0 means now.
+					StartEpoch: uint64(sigData.epochIdx),
+					// EpochLen:   uint64(sigData.epochLen), // config change is TODO
+				} // no Seq for the resume since it doesn't modify the book
+
+				log.Infof("Market %q resumed at epoch %d", book.name, sigData.epochIdx)
 
 			default:
-				panic(fmt.Sprintf("unknown orderbook update action %d", u.action))
+				log.Errorf("Unknown orderbook update action %d", u.action)
+				continue
 			}
 
 			r.sendNote(route, subs, note)

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -105,7 +105,7 @@ type sigDataSuspend struct {
 
 type sigDataResume struct {
 	epochIdx int64
-	epochLen int64
+	// TODO: indicate config change if applicable
 }
 
 type sigDataMatchProof struct {
@@ -429,7 +429,6 @@ out:
 					MarketID: book.name,
 					// ResumeTime of 0 means now.
 					StartEpoch: uint64(sigData.epochIdx),
-					// EpochLen:   uint64(sigData.epochLen), // config change is TODO
 				} // no Seq for the resume since it doesn't modify the book
 
 				log.Infof("Market %q resumed at epoch %d", book.name, sigData.epochIdx)

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -327,12 +327,6 @@ func (m *Market) Suspend(asSoonAs time.Time, persistBook bool) (finalEpochIdx in
 	return
 }
 
-// ResumeEpochNext gets the next available resume epoch index for the currently
-// configured epoch duration for the market.
-func (m *Market) ResumeEpochNext() (startEpochIdx int64) {
-	return m.ResumeEpoch(time.Now())
-}
-
 // ResumeEpoch gets the next available resume epoch index for the currently
 // configured epoch duration for the market and the provided earliest allowable
 // start time. The market must be running, otherwise the zero index is returned.

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -817,7 +817,7 @@ func (m *Market) Run(ctx context.Context) {
 					action: resumeAction,
 					data: sigDataResume{
 						epochIdx: currentEpoch.Epoch,
-						epochLen: epochDuration,
+						// TODO: signal config or new config
 					},
 				}
 			}

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -348,7 +348,7 @@ func (m *Market) ResumeEpoch(asSoonAs time.Time) (startEpochIdx int64) {
 	nextEpochIdx := 1 + now/dur
 
 	ms := encode.UnixMilli(asSoonAs)
-	startEpochIdx = ms / dur
+	startEpochIdx = 1 + ms/dur
 
 	if startEpochIdx < nextEpochIdx {
 		startEpochIdx = nextEpochIdx

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -690,9 +690,7 @@ func (r *OrderRouter) SuspendMarket(mktName string, asSoonAs time.Time, persistB
 	}
 }
 
-// Suspend is like SuspendMarket, but for all known markets. TODO: use this in a
-// "suspend all as soon as" DEX function with rather than shutting down in the
-// middle of an active epoch as SIGINT shutdown presently does.
+// Suspend is like SuspendMarket, but for all known markets.
 func (r *OrderRouter) Suspend(asSoonAs time.Time, persistBooks bool) map[string]*SuspendEpoch {
 
 	suspendTimes := make(map[string]*SuspendEpoch, len(r.tunnels))


### PR DESCRIPTION
This is rebased on https://github.com/decred/dcrdex/pull/442, and wraps up the market suspend/resume functionality.

In summary, this is communicated in the following places:
- `'config'` response, which includes market status for each market:

```go
type MarketStatus struct {
	StartEpoch uint64 `json:"startepoch"`
	FinalEpoch uint64 `json:"finalepoch,omitempty"`
	Persist    *bool  `json:"persistbook,omitempty"` // nil and omitted when finalepoch is omitted
}
```

- The `'suspension'` and `'resumption'` routes sent by the server *at the time  the status change happens*.  These are sent to `'orderbook'` subscribers, and are sequenced with other book updates when appropriate.
- The `'suspension'` and `'resumption'` routes sent by the server *when the operator initially schedules it* via the administrative API.  These are _broadcasted_ notifications ahead of the actual event.

```go
type TradeSuspension struct {
	MarketID    string `json:"marketid"`
	Seq         uint64 `json:"seq,omitempty"`         // only set at suspend time and if Persist==false
	SuspendTime uint64 `json:"suspendtime,omitempty"` // only set in advance of suspend
	FinalEpoch  uint64 `json:"finalepoch"`
	Persist     bool   `json:"persistbook"`
}

type TradeResumption struct {
	MarketID   string `json:"marketid"`
	ResumeTime uint64 `json:"resumetime,omitempty"` // only set in advance of resume
	StartEpoch uint64 `json:"startepoch"`
}
```

When the messages are sent at time of scheduling (in advance of the actual event), scheduled time is communicated for display to the user and recorded in the stored market config.

When the time roles around, the market uses the `'orderbook'` subscription to mark the event at the right time and in sequence with other book note.  The `'suspension'` message received at this time is handled by the client by storing the `FinalEpoch` and `Perist` flags the in the relevant markets config thus marking it suspended (possibly redundant unless they missed the initial scheduling note), and if the `Persist` flag requires it, purging the order book.  The `'resumption'` message received at time of resume updates `MarketStatus` with `StartEpoch` and clears `FinalEpoch` and `Persist`.

The `'config'` request is no longer placed by the trade resumption handler since we have not implemented host market config changes with the server.  Plus it seems likely that the best way to handle this is to include the full `msgjson.Market` config for the resuming market *in* the trade resumption message at the time of resume.

Having these in the `'orderbook'` subscription message sequence ensures the market is marked running/stopped at the proper time.  This replaces the timers.

dcrdex

```
<dexadm market/dcr_btc/suspend?persist=false>
17:14:39.351 [INF] COMM: Broadcasting notification for route suspension to 1 clients...
17:14:39.351 [TRC] COMM: Broadcast: "{\"type\":3,\"route\":\"suspension\",\"payload\":{\"marketid\":\"dcr_btc\",\"suspendtime\":1601054082000,\"finalepoch\":266842346,\"persistbook\":false}}"
17:14:42.000 [INF] MKT: Market "dcr_btc" suspended after epoch 266842346, persist book = false.
17:14:42.000 [DBG] MKT: epoch pump drained for market dcr_btc
17:14:42.002 [INF] MKT: Flushed 1 sell orders and 1 buy orders from market "dcr_btc" book
17:14:42.045 [INF] MKT: Market "dcr_btc" stopped.
....
 <dexadm market/dcr_btc/resume>
17:16:47.774 [INF] ADMN: server authenticated ip: 127.0.0.1:44702
17:16:47.774 [INF] COMM: Broadcasting notification for route resumption to 1 clients...
17:16:47.774 [TRC] COMM: Broadcast: "{\"type\":3,\"route\":\"resumption\",\"payload\":{\"marketid\":\"dcr_btc\",\"resumetime\":1601054208000,\"startepoch\":266842368}}"
17:16:48.000 [INF] MKT: Market dcr_btc now accepting orders, epoch 266842368:6000
17:16:48.000 [INF] MKT: Market "dcr_btc" resumed at epoch 266842368

```

dexc

```
12:14:39.353 [WRN] CORE: notify: |WARNING| (notify) market suspend scheduled - Market dcr_btc is now scheduled for suspension at 2020-09-25 17:14:42 +0000 UTC
12:14:42.003 [WRN] CORE: notify: |WARNING| (notify) market suspended - Market dcr_btc is now suspended
12:14:42.004 [TRC] CORE: notify: |DATA| (order) revoke - Order: 
12:14:42.004 [DBG] CORE[dcr]: returning coins [0aa0f59bec41329c26d1ca8661c1f81837e3e445da4b9d969696960093a55481:0 495bd395597f85469d7a6639ce3db20a76eb3e967a7cd143467ada5351d37470:1]
12:14:42.006 [TRC] CORE: notify: |DATA| (order) revoke - Order: 
12:14:42.006 [DBG] CORE[btc]: returning coins [b62f939f3486b10bd98abe304cc385c5d7caf7e6b46216eb6854f2ad7c86c9a5:1]
12:14:42.010 [TRC] CORE: notify: |DATA| (balance) balance updated
12:14:42.015 [TRC] CORE: notify: |DATA| (balance) balance updated
...
12:14:57.498 [INF] CORE: Retiring inactive order 57a4455de551821aec0883c3748c7f9ac828300623d3269f020c44ccec78f0ef in status revoked
12:14:57.498 [INF] CORE: Retiring inactive order 740ecf38395b6c29340dca30661a719864d82f0ae972c1ec2c2ac8686031970e in status revoked
...
12:16:47.776 [WRN] CORE: notify: |WARNING| (notify) market resume scheduled - Market dcr_btc is now scheduled for resumption at 2020-09-25 17:16:48 +0000 UTC
12:16:48.002 [WRN] CORE: notify: |WARNING| (notify) market resumed - Market dcr_btc has resumed trading at epoch 266842368
12:16:54.001 [TRC] CORE: notify: |DATA| (epoch) - Index: 266842369
```