### PR TITLE
server/{db,swap},client/core: no maker redemption ack, no redeem confs

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3109,9 +3109,11 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				}
 				auditInfo, err := wallets.toWallet.AuditContract(counterSwap, counterContract)
 				if err != nil {
-					c.log.Debugf("Match %v status %v, refunded = %v, revoked = %v", match.id, match.MetaData.Status, len(match.MetaData.Proof.RefundCoin) > 0, match.MetaData.Proof.IsRevoked)
+					c.log.Debugf("Match %v status %v, refunded = %v, revoked = %v", match.id, match.MetaData.Status,
+						len(match.MetaData.Proof.RefundCoin) > 0, match.MetaData.Proof.IsRevoked())
 					match.failErr = fmt.Errorf("audit error, order %s, match %s: %v", tracker.ID(), match.id, err)
-					notifyErr("Match recovery error", "Error auditing counter-party's swap contract (%v) during swap recovery on order %s: %v", tracker.token(), coinIDString(wallets.toAsset.ID, counterSwap), err)
+					notifyErr("Match recovery error", "Error auditing counter-party's swap contract (%v) during swap recovery on order %s: %v",
+						tracker.token(), coinIDString(wallets.toAsset.ID, counterSwap), err)
 					continue
 				}
 				match.counterSwap = auditInfo

--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -56,8 +56,7 @@ const (
 
 		-- participant/B (taker) REDEEM data
 		bRedeemCoinID BYTEA,
-		bRedeemTime INT8,         -- server time stamp
-		aSigAckOfBRedeem BYTEA   -- counterparty's (initiator) sig with ack of participant REDEEM data
+		bRedeemTime INT8          -- server time stamp
 	)`
 
 	AddMatchesForgivenColumn = `ALTER TABLE %s
@@ -67,7 +66,7 @@ const (
 		aContractCoinID, aContract, aContractTime, bSigAckOfAContract,
 		bContractCoinID, bContract, bContractTime, aSigAckOfBContract,
 		aRedeemCoinID, aRedeemSecret, aRedeemTime, bSigAckOfARedeem,
-		bRedeemCoinID, bRedeemTime, aSigAckOfBRedeem
+		bRedeemCoinID, bRedeemTime
 	FROM %s WHERE matchid = $1;`
 
 	InsertMatch = `INSERT INTO %s (matchid, takerSell,
@@ -172,21 +171,11 @@ const (
 		aRedeemCoinID = $3, aRedeemSecret = $4, aRedeemTime = $5
 	WHERE matchid = $1;`
 	SetParticipantRedeemData = `UPDATE %s SET status = $2,
-		bRedeemCoinID = $3, bRedeemTime = $4
+		bRedeemCoinID = $3, bRedeemTime = $4, active = FALSE
 	WHERE matchid = $1;`
 
-	// Both SetParticipantRedeemAckSig and SetInitiatorRedeemAckSig may set
-	// active=FALSE since this can be the final step in swap negotiation. Either
-	// party may ack first. Note that this can happen before status is set to
-	// MatchComplete on account of the confirmation requirement.
-
 	SetParticipantRedeemAckSig = `UPDATE %s
-		SET bSigAckOfARedeem = $2,
-			active = (aSigAckOfBRedeem IS NULL) -- set inactive if aSigAckOfBRedeem is set
-		WHERE matchid = $1;`
-	SetInitiatorRedeemAckSig = `UPDATE %s
-		SET aSigAckOfBRedeem = $2,
-			active = (bSigAckOfARedeem IS NULL) -- set inactive if bSigAckOfARedeem is set
+		SET bSigAckOfARedeem = $2
 		WHERE matchid = $1;`
 
 	SetSwapDone = `UPDATE %s SET active = FALSE

--- a/server/db/driver/pg/matches_online_test.go
+++ b/server/db/driver/pg/matches_online_test.go
@@ -376,24 +376,6 @@ func TestSetSwapData(t *testing.T) {
 			swapData.RedeemBTime, redeemBTime)
 	}
 
-	// Party A's signature for acknowledgement of B's redemption
-	redeemAckSigA := randomBytes(73)
-	if err = archie.SaveRedeemAckSigA(mid, redeemAckSigA); err != nil {
-		t.Fatal(err)
-	}
-
-	status, swapData, err = archie.SwapData(mid)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if status != order.MatchComplete {
-		t.Errorf("Got status %v, expected %v", status, order.MatchComplete)
-	}
-	if !bytes.Equal(swapData.RedeemBAckSig, redeemAckSigA) {
-		t.Fatalf("RedeemBAckSig incorrect. got %v, expected %v",
-			swapData.RedeemBAckSig, redeemAckSigA)
-	}
-
 	// Check active flag via MatchByID.
 	if err = checkMatch(order.MatchComplete, false); err != nil {
 		t.Fatal(err)
@@ -886,8 +868,8 @@ func TestMatchStatuses(t *testing.T) {
 		generateMatch(t, order.MakerSwapCast, false, user1, user2),                         // 1
 		generateMatch(t, order.TakerSwapCast, true, user1, user2),                          // 2
 		generateMatch(t, order.MakerRedeemed, true, user1, user2),                          // 3
-		generateMatch(t, order.MatchComplete, false, user1, user2),                         // 4
-		generateMatch(t, order.MatchComplete, false, randomAccountID(), randomAccountID()), // 5
+		generateMatch(t, order.MatchComplete, false, user1, user2),                         // 4 -- inactive via SaveRedeemB
+		generateMatch(t, order.MakerRedeemed, false, randomAccountID(), randomAccountID()), // 5
 	}
 
 	idList := func(idxs ...int) []order.MatchID {
@@ -918,12 +900,12 @@ func TestMatchStatuses(t *testing.T) {
 			req:  idList(1, 5),
 			exp:  []int{1},
 		},
-		// user 2 hit 5
+		// user 2 hit 4
 		{
-			name: "find5",
+			name: "find4",
 			user: user2,
-			req:  idList(0, 1, 2, 3, 4),
-			exp:  []int{0, 1, 2, 3, 4},
+			req:  idList(0, 1, 2, 3),
+			exp:  []int{0, 1, 2, 3},
 		},
 	}
 

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -958,22 +958,6 @@ func (rig *testRig) ackRedemption_taker(checkSig bool) error {
 	return nil
 }
 
-// Maker: Acknowledge the DEX 'redemption' request.
-func (rig *testRig) ackRedemption_maker(checkSig bool) error {
-	matchInfo := rig.matchInfo
-	err := rig.ackRedemption(matchInfo.maker, matchInfo.makerOID, matchInfo.db.takerRedeem)
-	if err != nil {
-		return err
-	}
-	if checkSig {
-		tracker := rig.getTracker()
-		if !bytes.Equal(tracker.Sigs.MakerRedeem, matchInfo.maker.sig) {
-			return fmt.Errorf("expected maker redemption signature '%x', got '%x'", matchInfo.maker.sig, tracker.Sigs.MakerRedeem)
-		}
-	}
-	return nil
-}
-
 func (rig *testRig) ackRedemption(user *tUser, oid order.OrderID, redeem *tRedeem) error {
 	if redeem == nil {
 		return fmt.Errorf("nil redeem info")

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -914,8 +914,8 @@ func (rig *testRig) redeem_taker(checkStatus bool) error {
 	tracker := rig.getTracker()
 	// Check the match status
 	if checkStatus {
-		if tracker.Status != order.MatchComplete {
-			return fmt.Errorf("unexpected swap status %d after taker redeem notification", tracker.Status)
+		if tracker != nil {
+			return fmt.Errorf("expected match to be removed, found it, in status %v", tracker.Status)
 		}
 		err := rig.checkResponse(matchInfo.taker, "redeem")
 		if err != nil {
@@ -1405,7 +1405,6 @@ func testSwap(t *testing.T, rig *testRig) {
 		ensureNilErr(rig.redeem_maker(true))
 		ensureNilErr(rig.ackRedemption_taker(true))
 		ensureNilErr(rig.redeem_taker(true))
-		ensureNilErr(rig.ackRedemption_maker(true))
 	}
 }
 
@@ -1810,7 +1809,6 @@ func TestSigErrors(t *testing.T) {
 	testAction(rig.redeem_maker, maker)
 	testAction(rig.ackRedemption_taker, taker)
 	testAction(rig.redeem_taker, taker)
-	testAction(rig.ackRedemption_maker, maker)
 }
 
 func TestMalformedSwap(t *testing.T) {
@@ -2260,10 +2258,9 @@ func TestState(t *testing.T) {
 	// "broadcast" the redeem and signal a new block.
 	xyz.setRedemption(makerRedeem.coin, true)
 	makerRedeem.coin.setConfs(int64(rig.xyz.SwapConf))
-	sendBlock(xyz) // trigger processBlock, redeem status check (not needed!)
-	// processRedeem should have succeeded, requesting an ack from taker of the
-	// maker's redeem.
+	// sendBlock(xyz) // trigger processBlock, redeem status check (not needed!)
 	reqTimeout(recheckInterval * 2) // 'redemption' sent, but no ack resp yet
+	// processRedeem should have succeeded, requesting an ack from taker of the maker's redeem.
 
 	matchInfo.db.makerRedeem = makerRedeem // for taker's redeem ack
 
@@ -2336,11 +2333,11 @@ func TestState(t *testing.T) {
 	// "broadcast" the redeem and signal a new block.
 	abc.setRedemption(takerRedeem.coin, true)
 	takerRedeem.coin.setConfs(int64(rig.abc.SwapConf))
-	sendBlock(abc) // trigger processBlock, redeem status check (not needed!)
-	// processRedeem should have succeeded, requesting an ack from maker of the taker's redeem.
-	reqTimeout(recheckInterval * 2) // 'redemption' sent, but no ack resp yet
+	// sendBlock(abc) // trigger processBlock, redeem status check (not needed!)
+	tickMempool() // latencyQ recheck
+	// processRedeem should have succeeded, deleting the match, no more requests.
 
-	matchInfo.db.takerRedeem = takerRedeem // for maker's redeem ack
+	matchInfo.db.takerRedeem = takerRedeem
 
 	// The match status should now be MatchComplete, and there should be one ack
 	// (maker redemption ack request).
@@ -2349,6 +2346,10 @@ func TestState(t *testing.T) {
 
 	if tracker.Status != order.MatchComplete {
 		t.Fatalf("match not marked as MatchComplete: %v", tracker.Status)
+	}
+	tracker = rig.getTracker()
+	if tracker != nil {
+		t.Fatalf("match not deleted")
 	}
 
 	state, err = loadLatestState()
@@ -2360,31 +2361,20 @@ func TestState(t *testing.T) {
 		t.Fatalf("expected 0 live coin waiter, got %d", len(state.LiveWaiters))
 	}
 
-	if state.MatchTrackers[matchInfo.matchID].Match.Status != order.MatchComplete {
-		t.Fatalf("state's match tracker in status %v, expected %v",
-			state.MatchTrackers[matchInfo.matchID].Match.Status, order.MatchComplete)
+	if state.MatchTrackers[matchInfo.matchID] != nil {
+		t.Fatalf("state's match tracker in status %v, expected it to be deleted",
+			state.MatchTrackers[matchInfo.matchID].Match.Status)
 	}
 
 	rig, stop = tNewTestRig(matchInfo, rig)
 	defer stop()
 
-	if len(rig.swapper.matches) != 1 {
-		t.Errorf("expected 1 tracked match, got %d", len(rig.swapper.matches))
+	if len(rig.swapper.matches) != 0 {
+		t.Errorf("expected 0 tracked match, got %d", len(rig.swapper.matches))
 	}
 
-	tracker = rig.getTracker()
-	if tracker.Status != order.MatchComplete {
-		t.Fatalf("match not marked as MatchComplete: %v", tracker.Status)
+	// match should be gone now
+	if rig.getTracker() != nil {
+		t.Fatalf("expected matchTracker to be removed")
 	}
-
-	// TODO: Don't require maker redemption acknowledgement. Sending a block
-	// here should cause the match to be removed from Swapper.
-
-	// sendBlock(abc)
-	// tickMempool() // processBlock -> match removed
-
-	// // match should be gone now
-	// if rig.getTracker() != nil {
-	// 	t.Fatalf("expected matchTracker to be removed")
-	// }
 }


### PR DESCRIPTION
NOTE: This PR is now targeting on the `status-integ`.

**server/db**

- Remove `aSigAckOfBRedeem` column from matches table.
- Storing the participant (taker) redeem coin sets `active = FALSE`.  Previously this was set when both redemption acks were received.

Now any match in the table with status `MatchComplete` will also be inactive.  Previously matches could be (and often were) `MatchComplete` but also active.  This was not great.

**server/swap**

- `processBlock` no longer checks the redeem txns for their confirmations.  We were checking against swapConf, but confirmations on the redeem txns never were important, only that both parties could author and bcast their redeem txns (the secret was shared and both parties used it to spend the respective contract outputs).
- `processBlock` just checks swap txns against swapConf, and it now unlocks the order funding coins for the order when the swap txn that spent them reaches swapConf (previously it waited to do this when the entire match was completed). This reflects the "event-based" and "block-based" inaction check distinction.
- `processRedeem` is now the spot where a match is deleted, when the taker's redeem is validated (when `MatchComplete` and `active=FALSE` are set).  Note that this means there will no longer be matches in `Swapper` memory with `MatchComplete` status.
- `processRedeem` now does the cancellation rate accounting that was previously done in `processAck` since it is the `'redeem'` validation that marks the end of the match for the user, not the redemption ack.
- `processRedeem` no longer sends a `'redemption'` request to the maker.
- `processAck` no longer processes `'redemption'` acks from the maker.

**UPDATE for `status-integ` rebase:**

**client/core**

- Maker no longer requires `'redemption'` request following taker's redeem to move to `MatchComplete`.
- Maker is only `MakerRedeemed` if their `'redeem'` request following the actual broadcast fails, otherwise they jump straight to `MatchComplete`.  This is switched by `auth.RedeemSig`.
- Fix some calls references to `MatchProof.IsRevoked` in logging statements not being called as a function.