### PR TITLE
app: show multiple poke notes

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3125,13 +3125,11 @@ func (c *Core) handleConnectEvent(host string, connected bool) {
 	}
 	c.connMtx.Unlock()
 	statusStr := "connected"
-	lvl := db.Success
 	if !connected {
 		statusStr = "disconnected"
-		lvl = db.WarningLevel
 	}
 	details := fmt.Sprintf("DEX at %s has %s", host, statusStr)
-	c.notify(newConnEventNote(fmt.Sprintf("DEX %s", statusStr), host, connected, details, lvl))
+	c.notify(newConnEventNote(fmt.Sprintf("DEX %s", statusStr), host, connected, details, db.Poke))
 	c.refreshUser()
 }
 

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -253,7 +253,7 @@ div.poke-note {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  border-radius: 3px 3px 0 0;
+  border-radius: 4px;
   z-index: 1000;
   max-width: 90%;
 
@@ -266,12 +266,10 @@ div.poke-note {
     white-space: nowrap;
     font-size: 15px;
     border-bottom: 1px solid #7777;
-    padding: 2px 5px;
+    padding: 4px 10px;
+    line-height: 1;
+    margin: 3px 0 0;
   }
-}
-
-div.poke-note.active {
-  top: calc(100% - 30px);
 }
 
 #noteBox,

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -249,23 +249,24 @@ div.note-indicator.warn {
 div.poke-note {
   position: fixed;
   right: 20px;
-  top: 100%;
-  height: 30px;
-  transition: top 1s;
-  background-color: black;
-  color: $font-color-dark;
-  border-radius: 5px 5px 0 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  border-radius: 3px 3px 0 0;
   z-index: 1000;
-  border-width: 1px;
-  border-style: solid;
-  border-color: #444;
   max-width: 90%;
 
   & > span {
     display: inline-block;
+    background-color: black;
+    color: $font-color-dark;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    font-size: 15px;
+    border-bottom: 1px solid #7777;
+    padding: 2px 5px;
   }
 }
 

--- a/client/webserver/site/src/css/main_dark.scss
+++ b/client/webserver/site/src/css/main_dark.scss
@@ -90,10 +90,9 @@ body.dark {
     border-color: white;
   }
 
-  div.poke-note {
+  div.poke-note > span {
     background-color: white;
     color: $font-color-light;
-    border-color: #aaa;
   }
 
   .buycolor {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -11,7 +11,9 @@
   <link href="/css/style.css?v=Ueawg" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
-  <div class="poke-note px-2 fs14 d-flex align-items-center" id="pokeNote"><span>Here is a poke note.</span></div>
+  <div class="poke-note" id="pokeNote">
+    <span data-tmpl="note"></span>
+  </div>
   <div id="tooltip" class="flex-center"></div>
   {{template "header" .}}
 {{end}}

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -438,7 +438,7 @@ export default class Application {
           span.style.opacity = 1 - progress
         })
         span.remove()
-      }, 4000)
+      }, 6000)
       return
     }
     // Success and higher severity go to the bell dropdown.

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -223,7 +223,9 @@ export default class Application {
    */
   attachHeader () {
     this.header = idel(document.body, 'header')
-    this.pokeNote = idel(document.body, 'pokeNote')
+    this.pokeNotes = idel(document.body, 'pokeNote')
+    this.pokeTmpl = Doc.tmplElement(this.pokeNotes, 'note')
+    this.pokeTmpl.remove()
     this.tooltip = idel(document.body, 'tooltip')
     const pg = this.page = Doc.parsePage(this.header, [
       'noteIndicator', 'noteBox', 'noteList', 'noteTemplate',
@@ -428,15 +430,15 @@ export default class Application {
     if (note.severity < ntfn.POKE) return
     // Poke notifications have their own display.
     if (note.severity === ntfn.POKE) {
-      this.pokeNote.firstChild.textContent = `${note.subject}: ${note.details}`
-      this.pokeNote.classList.add('active')
-      if (this.pokeNote.timer) {
-        clearTimeout(this.pokeNote.timer)
-      }
-      this.pokeNote.timer = setTimeout(() => {
-        this.pokeNote.classList.remove('active')
-        delete this.pokeNote.timer
-      }, 5000)
+      const span = this.pokeTmpl.cloneNode(true)
+      span.textContent = `${note.subject}: ${note.details}`
+      this.pokeNotes.appendChild(span)
+      setTimeout(async () => {
+        await Doc.animate(500, progress => {
+          span.style.opacity = 1 - progress
+        })
+        span.remove()
+      }, 4000)
       return
     }
     // Success and higher severity go to the bell dropdown.


### PR DESCRIPTION
Before, only one poke-severity notification was shown at a time, and would be simply replaced if another notification came immediately after. This change makes all poke notes persist for ~4 seconds before fading away. If more than one is visible, they stack vertically.

Bonus: DEX connection and disconnection notes are now only poke-level. This resolves #428. We really don't need to persist those. If there's a problem, we'll see an error. 