### PR TITLE
server/admin: allow compilation on Windows

### DIFF
--- a/server/admin/prompt.go
+++ b/server/admin/prompt.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"syscall"
+	"os"
 
 	"decred.org/dcrdex/dex/encode"
 	"golang.org/x/crypto/ssh/terminal"
@@ -22,7 +22,7 @@ type passwordReadResponse struct {
 // empty string.
 func PasswordPrompt(ctx context.Context, prompt string) ([]byte, error) {
 	// Get the initial state of the terminal.
-	initialTermState, err := terminal.GetState(syscall.Stdin)
+	initialTermState, err := terminal.GetState(int(os.Stdin.Fd()))
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func PasswordPrompt(ctx context.Context, prompt string) ([]byte, error) {
 
 	go func() {
 		fmt.Print(prompt)
-		pass, err := terminal.ReadPassword(syscall.Stdin)
+		pass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		fmt.Println()
 		passwordReadChan <- passwordReadResponse{
 			password: pass,
@@ -41,7 +41,7 @@ func PasswordPrompt(ctx context.Context, prompt string) ([]byte, error) {
 
 	select {
 	case <-ctx.Done():
-		_ = terminal.Restore(syscall.Stdin, initialTermState)
+		_ = terminal.Restore(int(os.Stdin.Fd()), initialTermState)
 		return nil, ctx.Err()
 
 	case res := <-passwordReadChan:


### PR DESCRIPTION
Unfortunately this is required to build dexcctl on Windows too since it uses server/admin for a PromptPassword function.