### PR TITLE
client/core: delete stale cancel order on cancel re-attempt

### DIFF
--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -543,8 +543,6 @@ func (t *trackedTrade) counterPartyConfirms(match *matchTracker) (have, needed u
 // This method MUST be called with the trackedTrade mutex lock held for writes.
 func (t *trackedTrade) deleteStaleCancelOrder() {
 	if t.cancel == nil || t.metaData.Status != order.OrderStatusBooked {
-		log.Debugf("Ignoring delete cancel order attempt for order %v, status %v, pending cancel = %v",
-			t.ID(), t.metaData.Status, t.cancel != nil)
 		return
 	}
 


### PR DESCRIPTION
Before returning `only one cancel order can be submitted per order per epoch` error message, first check if the existing cancel order is stale and delete the cancel order to allow submission of new cancel order.