### PR TITLE
unbreak cancel orders in Your Ordrs

### DIFF
--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -812,13 +812,13 @@ export default class MarketsPage extends BasePage {
     if (order.targetID) {
       const targetOrder = this.metaOrders[order.targetID]
       if (!targetOrder) return
-      Doc.hide(Doc.tmplElement(targetOrder.row, 'cancelStatus'))
       if (note.subject === 'cancel') {
-        targetOrder.order.status = Order.StatusCanceled
+        const cancelStatus = Doc.tmplElement(this.metaOrders[order.targetID].row, 'cancelStatus')
+        cancelStatus.textContent = 'canceled'
       } else if (note.subject === 'revoke') {
         targetOrder.order.status = Order.StatusRevoked
+        updateUserOrderRow(targetOrder.row, targetOrder)
       }
-      updateUserOrderRow(targetOrder.row, targetOrder)
       return
     }
 

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -813,8 +813,7 @@ export default class MarketsPage extends BasePage {
       const targetOrder = this.metaOrders[order.targetID]
       if (!targetOrder) return
       if (note.subject === 'cancel') {
-        const cancelStatus = Doc.tmplElement(this.metaOrders[order.targetID].row, 'cancelStatus')
-        cancelStatus.textContent = 'canceled'
+        Doc.tmplElement(targetOrder.row, 'cancelStatus').textContent = 'canceled'
       } else if (note.subject === 'revoke') {
         targetOrder.order.status = Order.StatusRevoked
         updateUserOrderRow(targetOrder.row, targetOrder)


### PR DESCRIPTION
While fixing the Your Orders update for *revoked* orders, I broke the update for canceled orders, as shown in https://github.com/decred/dcrdex/issues/715.

This fixes it, but the original code that did `Doc.hide(status)` makes no sense to me since we are setting that element's `textContent` to `'canceled'` so why would we hide it?

I've also noticed that the order status in the order details page does not necessarily match what's in Your Orders, and have absolutely no idea why.

In any case, cancelling orders now updates the table as expected, and revoked orders still get updated as expected (verified with suspend?persist=false, but applies to revoked match orders).