### PR TITLE
include omitted account constraint, needed for successes

### DIFF
--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -130,6 +130,7 @@ const (
 			GREATEST((epochIdx+1)*epochDur, aContractTime, bContractTime, aRedeemTime, bRedeemTime) AS lastTime
 		FROM %s, acct
 		WHERE takerSell IS NOT NULL      -- exclude cancel order matches
+			AND (makerAccount = aid OR takerAccount = aid)
 			AND (
 				-- swap successes
 				status=4                                       -- success for both

--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -126,16 +126,17 @@ const (
 	CompletedOrAtFaultMatchesLastN = `
 		WITH acct (aid) AS ( VALUES($1::BYTEA) )
 
-		SELECT status, (status=4 OR (status=3 AND makerAccount = aid)) AS success,
+		SELECT status, (status=4 OR (status=3 AND makerAccount = aid AND takerAccount != aid)) AS success,
 			GREATEST((epochIdx+1)*epochDur, aContractTime, bContractTime, aRedeemTime, bRedeemTime) AS lastTime
 		FROM %s, acct
 		WHERE takerSell IS NOT NULL      -- exclude cancel order matches
 			AND (makerAccount = aid OR takerAccount = aid)
 			AND (
-				-- swap successes
+				-- swap success for both
 				status=4                                       -- success for both
 				OR
-				(status=3 AND makerAccount = aid)              -- success for maker, active or revoked
+				-- swap success for maker unless maker==taker
+				(status=3 AND makerAccount = aid AND takerAccount != aid)
 				OR
 				( -- at-fault swap failures
 					NOT active -- failure means inactive/revoked


### PR DESCRIPTION
Every user was being credited for every other user's success when retrieving match outcomes from the DB.  This adds the account constraint that is required for successes.  Note that putting `AND (makerAccount = aid OR takerAccount = aid)` before all the status constraints results in a more optimized query plan according to `EXPLAIN ANALYZE`, esp. if we create indexes on these columns.