### PR TITLE
client/asset/btc: use vbytes when computing fee rate

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -26,6 +26,7 @@ import (
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -33,7 +34,6 @@ import (
 )
 
 const (
-	assetName = "btc"
 	// Use RawRequest to get the verbose block header for a blockhash.
 	methodGetBlockHeader = "getblockheader"
 	// Use RawRequest to get the verbose block with verbose txs, as the btcd
@@ -1611,18 +1611,18 @@ func (btc *ExchangeWallet) Refund(coinID, contract dex.Bytes) (dex.Bytes, error)
 	// Sign it.
 	refundSig, refundPubKey, err := btc.createSig(msgTx, 0, contract, sender)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("createSig: %v", err)
 	}
 	redeemSigScript, err := dexbtc.RefundP2SHContract(contract, refundSig, refundPubKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("RefundP2SHContract: %v", err)
 	}
 	txIn.SignatureScript = redeemSigScript
 	// Send it.
 	checkHash := msgTx.TxHash()
 	refundHash, err := btc.node.SendRawTransaction(msgTx, false)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("SendRawTransaction: %v", err)
 	}
 	if *refundHash != checkHash {
 		return nil, fmt.Errorf("refund sent, but received unexpected transaction ID back from RPC server. "+
@@ -1834,6 +1834,13 @@ func (btc *ExchangeWallet) convertCoin(coin asset.Coin) (*output, error) {
 	return newOutput(btc.node, txHash, vout, coin.Value()), nil
 }
 
+// msgTxVBytes returns the transaction's virtual size, which accounts for the
+// segwit input weighting.
+func msgTxVBytes(msgTx *wire.MsgTx) uint64 {
+	tx := btcutil.NewTx(msgTx)
+	return uint64(mempool.GetTxVirtualSize(tx))
+}
+
 // sendWithReturn sends the unsigned transaction with an added output (unless
 // dust) for the change.
 func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Address,
@@ -1849,8 +1856,8 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 	if err != nil {
 		return makeErr("signing error: %v, raw tx: %x", err, btc.wireBytes(baseTx))
 	}
-	size := msgTx.SerializeSize()
-	minFee := feeRate * uint64(size)
+	vSize := msgTxVBytes(msgTx)
+	minFee := feeRate * vSize
 	remaining := totalIn - totalOut
 	if minFee > remaining {
 		return makeErr("not enough funds to cover minimum fee rate. %d < %d, raw tx: %x",
@@ -1870,13 +1877,13 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 	changeAdded := !dexbtc.IsDust(changeOutput, feeRate)
 	if changeAdded {
 		// Add the change output.
-		size0 := baseTx.SerializeSize()
+		vSize0 := msgTxVBytes(baseTx)
 		baseTx.AddTxOut(changeOutput)
-		changeSize := baseTx.SerializeSize() - size0 // may be dexbtc.P2WPKHOutputSize
+		changeSize := msgTxVBytes(baseTx) - vSize0 // may be dexbtc.P2WPKHOutputSize
 		btc.log.Debugf("Change output size = %d, addr = %s", changeSize, addr.String())
 
-		size += changeSize
-		fee := feeRate * uint64(size)
+		vSize += changeSize
+		fee := feeRate * vSize
 		changeOutput.Value = int64(remaining - fee)
 
 		// Find the best fee rate by closing in on it in a loop.
@@ -1888,8 +1895,8 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 			if err != nil {
 				return makeErr("signing error: %v, raw tx: %x", err, btc.wireBytes(baseTx))
 			}
-			size = msgTx.SerializeSize() // recompute the size with new tx signature
-			reqFee := feeRate * uint64(size)
+			vSize = msgTxVBytes(msgTx) // recompute the size with new tx signature
+			reqFee := feeRate * vSize
 			if reqFee > remaining {
 				// I can't imagine a scenario where this condition would be true, but
 				// I'd hate to be wrong.
@@ -1923,11 +1930,11 @@ func (btc *ExchangeWallet) sendWithReturn(baseTx *wire.MsgTx, addr btcutil.Addre
 	}
 
 	fee := totalIn - totalOut
-	actualFeeRate := fee / uint64(size)
+	actualFeeRate := fee / vSize
 	checkHash := msgTx.TxHash()
 	btc.log.Debugf("%d signature cycles to converge on fees for tx %s: "+
 		"min rate = %d, actual fee rate = %d (%v for %v bytes), change = %v",
-		sigCycles, checkHash, feeRate, actualFeeRate, fee, size, changeAdded)
+		sigCycles, checkHash, feeRate, actualFeeRate, fee, vSize, changeAdded)
 
 	txHash, err := btc.node.SendRawTransaction(msgTx, false)
 	if err != nil {

--- a/client/cmd/dexc/go.sum
+++ b/client/cmd/dexc/go.sum
@@ -1,6 +1,7 @@
 decred.org/cspp v0.2.0/go.mod h1:KVnB49sueBFCldRa/ivZCaWZbrPNEiXWwxHCf1jTYKI=
 github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
@@ -132,6 +133,7 @@ github.com/jrick/wsrpc/v2 v2.0.0/go.mod h1:naH/fojac6vQWYgAA0e7b9TX/bShsWoVL7Cwr
 github.com/jrick/wsrpc/v2 v2.2.0/go.mod h1:naH/fojac6vQWYgAA0e7b9TX/bShsWoVL7CwrdvFmUk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/client/cmd/dexcctl/go.sum
+++ b/client/cmd/dexcctl/go.sum
@@ -1,4 +1,5 @@
 decred.org/cspp v0.2.0/go.mod h1:KVnB49sueBFCldRa/ivZCaWZbrPNEiXWwxHCf1jTYKI=
+github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
@@ -125,6 +126,7 @@ github.com/jrick/wsrpc/v2 v2.0.0/go.mod h1:naH/fojac6vQWYgAA0e7b9TX/bShsWoVL7Cwr
 github.com/jrick/wsrpc/v2 v2.2.0/go.mod h1:naH/fojac6vQWYgAA0e7b9TX/bShsWoVL7CwrdvFmUk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/dex/networks/btc/script_test.go
+++ b/dex/networks/btc/script_test.go
@@ -499,3 +499,65 @@ func TestExtractContractHash(t *testing.T) {
 		t.Fatalf("hash mismatch. wanted %x, got %x", addrs.wsh.ScriptAddress(), checkHash)
 	}
 }
+
+func TestMsgTxVBytes(t *testing.T) {
+	// segwit txn
+	segwitTx := "010000000001015018feb13925a5ea9a548ff1af92bca55d3004dc8b1020" +
+		"d99978878f073142d80000000000ffffffff02406c85000000000017a914" +
+		"1feef1e6f0b360d639dba54c5aa337954f09a48087cba6aa000000000016" +
+		"00147916d4dc770017806a316bd907668429b5778b480247304402203d39" +
+		"c9b8088d19beafae1fbb531ae58d3ff2b4d374304729bd8df9ab1d1047d2" +
+		"022061cb714f12d0b60197da46199ed7151426284ec929a23fe457e65417" +
+		"c9b35b980121030375b9725c21dba1dbb6fdb1627a647357052f09bacdde" +
+		"9fc2d05e1a36e6180e00000000"
+	wantSerSize := 223
+	wantVSize := 142
+
+	txHex, _ := hex.DecodeString(segwitTx)
+	msgTx := wire.NewMsgTx(wire.TxVersion)
+	err := msgTx.Deserialize(bytes.NewBuffer(txHex))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotSerSize := msgTx.SerializeSize()
+	if gotSerSize != wantSerSize {
+		t.Fatalf("wanted serialized tx size %d, got %d", wantSerSize, gotSerSize)
+	}
+	gotVSize := MsgTxVBytes(msgTx)
+	if gotVSize != uint64(wantVSize) {
+		t.Errorf("wanted tx virtual size %d, got %d", wantVSize, gotVSize)
+	}
+
+	// non-segwit txn
+	nonSegwitTX := "01000000019bb9e11de8c39f2102def30807b3124e92a2cb8b2474f85f9e" +
+		"a36d177f74f68100000000f04830450221009f0ea5ba317c1648aefa5864" +
+		"c1bafe9b86b3be742a877a6d362b0fdb7cce81d40220625604c3a0fd89b9" +
+		"3cfc5096fe0af98d32e5e9fe36f65736bee65ea7329641b60121022d099d" +
+		"2055bea94164527afcb0d6bf06a06ddb1186b87331ed48737302b0ec7d20" +
+		"179581e2e2e8abbaadf0231c52071e4f88588fccb78ad5afc0644f88011f" +
+		"a5d4514c616382012088a820c6de3217594af525fb57eaf1f2aae04c305d" +
+		"dc67d465edd325151685fc5a5e428876a914e05c5d2a5f850eee37d12242" +
+		"b64dafdf030a0fb467042609865eb17576a914e9288d333d5a8f343169f0" +
+		"709cb9b577fc758a506888acfeffffff01b860800200000000160014805b" +
+		"83e6b86fc7511f47d4cf95a3048954d3282e00000000"
+
+	wantSerSize = 322
+	wantVSize = 322
+
+	txHex, _ = hex.DecodeString(nonSegwitTX)
+	msgTx = wire.NewMsgTx(wire.TxVersion)
+	err = msgTx.Deserialize(bytes.NewBuffer(txHex))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotSerSize = msgTx.SerializeSize()
+	if gotSerSize != wantSerSize {
+		t.Fatalf("wanted serialized tx size %d, got %d", wantSerSize, gotSerSize)
+	}
+	gotVSize = MsgTxVBytes(msgTx)
+	if gotVSize != uint64(wantVSize) {
+		t.Errorf("wanted tx virtual size %d, got %d", wantVSize, gotVSize)
+	}
+}

--- a/server/asset/btc/tx.go
+++ b/server/asset/btc/tx.go
@@ -23,7 +23,7 @@ type Tx struct {
 	// Used to conditionally skip block lookups on mempool transactions during
 	// calls to Confirmations.
 	lastLookup *chainhash.Hash
-	// The calculated transaction fee rate, in satoshis/byte
+	// The calculated transaction fee rate, in satoshis/vbyte
 	feeRate uint64
 }
 

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1614,8 +1614,8 @@ func (s *Swapper) processInit(msg *msgjson.Message, params *msgjson.Init, stepIn
 	s.matchMtx.RUnlock()
 
 	log.Debugf("processInit: valid contract %v (%s) received at %v from user %v (%s) for match %v, "+
-		"swapStatus %v => %v", contract, stepInfo.asset.Symbol, swapTime, actor.user,
-		makerTaker(actor.isMaker), matchID, stepInfo.step, stepInfo.nextStep)
+		"fee rate = %d, swapStatus %v => %v", contract, stepInfo.asset.Symbol, swapTime, actor.user,
+		makerTaker(actor.isMaker), matchID, contract.FeeRate(), stepInfo.step, stepInfo.nextStep)
 
 	// Issue a positive response to the actor.
 	s.authMgr.Sign(params)


### PR DESCRIPTION
Server was already using vbytes for fee rate in the contract audit. This changes the client's btc backend to use vsize (not serialized tx size) in computing BTC txn fee rates, and updates the server's logging of the fee rate on the audited contract.

**dexc** on this PR

`[DBG] CORE[btc]: 2 signature cycles to converge on fees for tx 5ca1b392...: min rate = 6, actual fee rate = 6 (852 for 142 bytes), change = true`
`[INF] CORE: Broadcasted transaction with 1 swap contracts for order 62332bf.... Fee rate = 6. Receipts (btc): [5ca1b392:0]`

(note **852 for 142 bytes** and **actual fee rate = 6**)

**dcrdex**  on this PR

`[DBG] SWAP: Optimal fee rate for "btc": 6`
...
`[DBG] SWAP: processInit: valid contract {txid = 5ca1b392, vout = 0} (btc) received at 2020-10-08 18:33:06.319 +0000 UTC from user 358f9fd5276563c29904b0c020226a436d3174785ace7a76b91bc9078570c33c (maker) for match bba9336..., fee rate = 6, swapStatus NewlyMatched => MakerSwapCast`

(note **fee rate = 6**, which matches the client, indicating they are both doing it the same way)

compared to...

**dexc** on master

`[DBG] CORE[btc]: 2 signature cycles to converge on fees for tx 732fae7e4359666985a588de0548cbb88163f04cd4b7c4078877920782ceeb35: min rate = 5, actual fee rate = 5 (1115 for 223 bytes), change = true`
`[INF] CORE: Broadcasted transaction with 1 swap contracts for order 20954062a284c4ea05d40c8d938c4ecc3c46ca5ac7d2def4e093ded9f044d3b2. Fee rate = 5. Receipts (btc): [732fae7e4359666985a588de0548cbb88163f04cd4b7c4078877920782ceeb35:0]`

(note **1115 for 223 bytes** and **actual fee rate = 5**)

**dcrdex** on this PR for the logging change

`[DBG] SWAP: Optimal fee rate for "btc": 5` (changed based on estimatesmartfee)
...
`[DBG] SWAP: processInit: valid contract {txid = 732fae7e4359666985a588de0548cbb88163f04cd4b7c4078877920782ceeb35, vout = 0} (btc) received at 2020-10-08 18:42:15.341 +0000 UTC from user 358f9fd5276563c29904b0c020226a436d3174785ace7a76b91bc9078570c33c (taker) for match 63c2cd560fc037723c5205edd43de64e56cb6638072f1be45f7071de19005068, fee rate = 7, swapStatus MakerSwapCast => TakerSwapCast`

(note **fee rate = 7**, indicating server was doing it differently, and correctly, recognizing the client's over payment of fees)