### PR TITLE
market: verify unspent status of unfilled orders

### DIFF
--- a/server/book/book.go
+++ b/server/book/book.go
@@ -184,3 +184,19 @@ func (b *Book) BuyOrders() []*order.LimitOrder {
 func (b *Book) BuyOrdersN(N int) []*order.LimitOrder {
 	return b.buys.OrdersN(N)
 }
+
+// UnfilledUserBuys retrieves all buy orders belonging to a given user that are
+// completely unfilled.
+func (b *Book) UnfilledUserBuys(user account.AccountID) []*order.LimitOrder {
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+	return b.buys.UnfilledForUser(user)
+}
+
+// UnfilledUserSells retrieves all sell orders belonging to a given user that
+// are completely unfilled.
+func (b *Book) UnfilledUserSells(user account.AccountID) []*order.LimitOrder {
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+	return b.sells.UnfilledForUser(user)
+}

--- a/server/book/orderpq.go
+++ b/server/book/orderpq.go
@@ -101,6 +101,19 @@ func (pq *OrderPQ) copy(newCap uint32) *OrderPQ {
 	return newPQ
 }
 
+// UnfilledForUser retrieves all completely unfilled orders for a given user.
+func (pq *OrderPQ) UnfilledForUser(user account.AccountID) []*order.LimitOrder {
+	pq.mtx.RLock()
+	var orders []*order.LimitOrder
+	for _, oe := range pq.oh {
+		if oe.order.AccountID == user && oe.order.Filled() == 0 {
+			orders = append(orders, oe.order)
+		}
+	}
+	pq.mtx.RUnlock()
+	return orders
+}
+
 // Orders copies all orders, sorted with the lessFn. The OrderPQ is unmodified.
 func (pq *OrderPQ) Orders() []*order.LimitOrder {
 	// Deep copy the orders.

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -631,10 +631,6 @@ orders:
 				coin, _ := asset.DecodeCoinID(dex.BipIDSymbol(assetID), lo.Coins[i]) // coin decoding succeeded in CheckUnspent
 				log.Warnf("Coin %s not unspent for unfilled order %v. "+
 					"Revoking the order.", coin, lo)
-				// NOTE: Client does not get a non-orderbook subscription
-				// message to signal that the order has been revoked. They're
-				// poking around getting into trouble, so they will have to
-				// restart their client to recheck coins and order statuses.
 				m.Unbook(lo)
 				unbooked = append(unbooked, lo)
 			}

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -606,6 +606,70 @@ func (m *Market) CancelableBy(oid order.OrderID, aid account.AccountID) bool {
 	return false
 }
 
+func (m *Market) checkUnfilledOrders(assetID uint32, unfilled []*order.LimitOrder) (unbooked []*order.LimitOrder) {
+orders:
+	for _, lo := range unfilled {
+		log.Tracef("Checking %d funding coins for order %v", len(lo.Coins), lo.ID())
+		for i := range lo.Coins {
+			err := m.swapper.CheckUnspent(assetID, lo.Coins[i])
+			if err == nil {
+				continue // unspent, check next coin
+			}
+
+			if !errors.Is(err, asset.CoinNotFoundError) {
+				// other failure (coinID decode, RPC, etc.)
+				log.Errorf("unexpected error checking coinID %v for order %v: %v",
+					lo.Coins[i], lo, err)
+				continue orders
+				// NOTE: This does not revoke orders from storage since this is
+				// likely to be a configuration or node issue.
+			}
+
+			// Final fill amount check in case it was matched after we pulled
+			// the list of unfilled orders from the book.
+			if lo.Filled() == 0 {
+				coin, _ := asset.DecodeCoinID(dex.BipIDSymbol(assetID), lo.Coins[i]) // coin decoding succeeded in CheckUnspent
+				log.Warnf("Coin %s not unspent for unfilled order %v. "+
+					"Revoking the order.", coin, lo)
+				// NOTE: Client does not get a non-orderbook subscription
+				// message to signal that the order has been revoked. They're
+				// poking around getting into trouble, so they will have to
+				// restart their client to recheck coins and order statuses.
+				m.Unbook(lo)
+				unbooked = append(unbooked, lo)
+			}
+			continue orders
+		}
+	}
+	return
+}
+
+// CheckUnfilled checks unfilled book orders belonging to a user and funded by
+// coins for a given asset to ensure that their funding coins are not spent. If
+// any of an order's funding coins are spent, the order is unbooked (removed
+// from the in-memory book, revoked in the DB, a cancellation marked against the
+// user, coins unlocked, and orderbook subscribers notified). See Unbook for
+// details.
+func (m *Market) CheckUnfilled(assetID uint32, user account.AccountID) (unbooked []*order.LimitOrder) {
+	base, quote := m.marketInfo.Base, m.marketInfo.Quote
+	if assetID != base && assetID != quote {
+		return
+	}
+	var unfilled []*order.LimitOrder
+	switch assetID {
+	case base:
+		// Sell orders are funded by the base asset.
+		unfilled = m.book.UnfilledUserSells(user)
+	case quote:
+		// Buy orders are funded by the quote asset.
+		unfilled = m.book.UnfilledUserBuys(user)
+	default:
+		return
+	}
+
+	return m.checkUnfilledOrders(assetID, unfilled)
+}
+
 // Book retrieves the market's current order book and the current epoch index.
 // If the Market is not yet running or the start epoch has not yet begun, the
 // epoch index will be zero.
@@ -702,6 +766,7 @@ func (m *Market) Run(ctx context.Context) {
 		// Stop and wait for epoch pump and processing pipeline goroutines.
 		cancel() // may already be done by suspend
 		wgEpochs.Wait()
+		// Book mod goroutines done, may purge if requested.
 
 		// persistBook is set under epochMtx lock.
 		m.epochMtx.Lock()

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -235,11 +235,6 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 	copy(commit[:], limit.Commit)
 
 	fundingAsset := coins.funding
-	unbookedUnfunded := tunnel.CheckUnfilled(fundingAsset.ID, user)
-	for _, badLo := range unbookedUnfunded {
-		log.Infof("Unbooked unfunded order %v for user %v", badLo, user)
-	}
-
 	coinIDs := make([]order.CoinID, 0, len(limit.Trade.Coins))
 	coinStrs := make([]string, 0, len(limit.Trade.Coins))
 	for _, coin := range limit.Trade.Coins {
@@ -424,11 +419,6 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 	copy(commit[:], market.Commit)
 
 	fundingAsset := assets.funding
-	unbookedUnfunded := tunnel.CheckUnfilled(fundingAsset.ID, user)
-	for _, badLo := range unbookedUnfunded {
-		log.Infof("Unbooked unfunded order %v for user %v", badLo, user)
-	}
-
 	coinIDs := make([]order.CoinID, 0, len(market.Trade.Coins))
 	coinStrs := make([]string, 0, len(market.Trade.Coins))
 	for _, coin := range market.Trade.Coins {
@@ -585,12 +575,7 @@ func (r *OrderRouter) handleCancel(user account.AccountID, msg *msgjson.Message)
 		return rpcErr
 	}
 
-	// Consideration: allow suspended accounts to submit cancel orders? Depends
-	// if their orders get canceled on suspension or if they simply cannot make
-	// new orders.
-	// if _, suspended := r.auth.Suspended(user); suspended {
-	// 	return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account may not submit cancel orders")
-	// }
+	// NOTE: Allow suspended accounts to submit cancel orders.
 
 	tunnel, rpcErr := r.extractMarket(&cancel.Prefix)
 	if rpcErr != nil {
@@ -815,6 +800,17 @@ func (r *OrderRouter) checkPrefixTrade(assets *assetSet, prefix *msgjson.Prefix,
 				"pubkey count %d not equal to signature count %d for coin %d",
 				len(coin.PubKeys), sigCount, i,
 			))
+		}
+	}
+
+	// Verify all of the user's unfilled book orders have unspent funding coins,
+	// unbooking them as necessary.
+	var user account.AccountID
+	copy(user[:], prefix.AccountID)
+	for mktName, tunnel := range r.tunnels {
+		unbookedUnfunded := tunnel.CheckUnfilled(assets.funding.ID, user)
+		for _, badLo := range unbookedUnfunded {
+			log.Infof("Unbooked unfunded order %v from market %s for user %v", badLo, mktName, user)
 		}
 	}
 

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -311,6 +311,10 @@ func (m *TMarketTunnel) Running() bool {
 	return true
 }
 
+func (m *TMarketTunnel) CheckUnfilled(assetID uint32, user account.AccountID) (unbooked []*order.LimitOrder) {
+	return
+}
+
 type TBackend struct {
 	utxoErr    error
 	utxos      map[string]uint64


### PR DESCRIPTION
Addressing https://github.com/decred/dcrdex/issues/615

When a user submits a new order, all of that user's unfilled book orders have their funding coins checked.  If any of them are spent, those orders are unbooked.  The newly submitted order is processed normally after that.  The idea behind checking on order placement is to prevent a user from moving the same bunch of coins around into new utxos to fund a large number of bogus (unfunded) orders.  Although a user could submit multiple orders with valid funding coins, then proceed to spend those coins, this user could affect similar disruption by simple not executing swaps on match, so continually checking funding coins for online users is not particularly useful.  PR #725 handles users going offline.

e.g.

```
[TRC] MKT: Checking 2 funding coins for order 8926f56b...
[WRN] MKT: Coin ad94f5c84...:0 not unspent for unfilled order 8926f56b.... Revoking the order.
[TRC] AUTH: User 6423e2d92710dba3e490986b02c2e02cf3be847f05e22ee9850e718be412158c cancellation rate is now 100.00% (1 cancels : 0 successes). Violation = false
[INF] MKT: Unbooked unfunded order 8926f56b... for user 6423e2d92710dba3e490986b02c2e02cf3be847f05e22ee9850e718be412158c
```

Notes:
- `revoke_order` is implemented in https://github.com/decred/dcrdex/pull/725, thus any unbooked orders are only removed from the book, but the owner does not revoke the order until they reconnect or dexc restarts.  This will change automatically with the updates to (*Market).Unbook in https://github.com/decred/dcrdex/pull/725
- This requires spending txns to be mined, not just in mempool, before the check detects the funding coins as spent.  This is the same with the check in `NewMarket`
- The check uses gettxout (for btc) on each coin ID, but a better check could involve pulling the blocks since the previous check and checking the block contents against a list of coins of interest.  DCR could use cfilters.  More complex, asset specific.
- Perhaps the best approach would be to register coin IDs with the backends so the backends watch and notify, but that's even more complex.