### PR TITLE
core/app: don't send cancel order for OrderNote

### DIFF
--- a/client/core/types.go
+++ b/client/core/types.go
@@ -181,9 +181,8 @@ type Order struct {
 	Canceled     bool              `json:"canceled"`
 	FeesPaid     *FeeBreakdown     `json:"feesPaid"`
 	FundingCoins []dex.Bytes       `json:"fundingCoins"`
-	Rate         uint64            `json:"rate"`               // limit only
-	TimeInForce  order.TimeInForce `json:"tif"`                // limit only
-	TargetID     dex.Bytes         `json:"targetID,omitempty"` // cancel only
+	Rate         uint64            `json:"rate"` // limit only
+	TimeInForce  order.TimeInForce `json:"tif"`  // limit only
 }
 
 // FeeBreakdown is categorized fee information.
@@ -206,7 +205,7 @@ func coreOrderFromTrade(ord order.Order, metaData *db.OrderMetaData) *Order {
 
 	var cancelling, canceled bool
 	if !metaData.LinkedOrder.IsZero() {
-		if trade.Filled() == trade.Quantity {
+		if metaData.Status == order.OrderStatusCanceled {
 			canceled = true
 		} else {
 			cancelling = true

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -314,7 +314,6 @@
                   <td data-tmpl="status"></td>
                   <td class="text-right">
                     <span data-tmpl="cancelBttn" class="ico-cross d-hide" data-tooltip="cancel order"></span>
-                    <span data-tmpl="cancelStatus" class="d-hide"></span>
                     <a data-tmpl="link" class="ico-open fs13 pointer ml-2 plainlink" data-tooltip="order details"></a>
                   </td>
                 </tr>

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -57,8 +57,7 @@ export default class MarketsPage extends BasePage {
       // Active orders
       'liveTemplate', 'liveList',
       // Cancel order form
-      'cancelForm', 'cancelRemain', 'cancelUnit', 'cancelPass', 'cancelSubmit',
-      'cancelStatus'
+      'cancelForm', 'cancelRemain', 'cancelUnit', 'cancelPass', 'cancelSubmit'
     ])
     this.main = main
     app.loading(this.main.parentElement)
@@ -734,9 +733,7 @@ export default class MarketsPage extends BasePage {
     var res = await postJSON('/api/cancel', req)
     app.loaded()
     if (!app.checkResponse(res)) return
-    cancelData.status.textContent = 'cancelling'
     Doc.hide(cancelData.bttn, page.forms)
-    Doc.show(cancelData.status)
     order.cancelling = true
   }
 
@@ -751,7 +748,6 @@ export default class MarketsPage extends BasePage {
     this.showForm(page.cancelForm)
     this.cancelData = {
       bttn: Doc.tmplElement(row, 'cancelBttn'),
-      status: Doc.tmplElement(row, 'cancelStatus'),
       order: order
     }
   }
@@ -805,29 +801,15 @@ export default class MarketsPage extends BasePage {
 
   /*
    * handleOrderNote is the handler for the 'order'-type notification, which are
-   * used to update an order's status.
+   * used to update a user's order's status.
    */
   handleOrderNote (note) {
     const order = note.order
-    if (order.targetID) {
-      const targetOrder = this.metaOrders[order.targetID]
-      if (!targetOrder) return
-      Doc.hide(Doc.tmplElement(targetOrder.row, 'cancelStatus'))
-      if (note.subject === 'cancel') {
-        targetOrder.order.status = Order.StatusCanceled
-      } else if (note.subject === 'revoke') {
-        targetOrder.order.status = Order.StatusRevoked
-      }
-      updateUserOrderRow(targetOrder.row, targetOrder)
-      return
-    }
-
     const metaOrder = this.metaOrders[order.id]
     if (!metaOrder) return
     metaOrder.order = order
     const bttn = Doc.tmplElement(metaOrder.row, 'cancelBttn')
     if (note.subject === 'Missed cancel') {
-      Doc.hide(Doc.tmplElement(metaOrder.row, 'cancelStatus'))
       Doc.show(bttn)
     }
     if (order.filled === order.qty) {


### PR DESCRIPTION
The only thing we were using the cancel order for was its `targetID` to find the target order. Might as well just send the target order. This also solves the weird thing with the `cancelStatus` element. That element is gone now in favor of just using the order status column. One new notification was required.