### PR TITLE
client/asset: redeem confirmation target blocks

### DIFF
--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -32,12 +32,13 @@ var (
 // Config holds the parameters needed to initialize an RPC connection to a dcr
 // wallet. Default values are used for RPCListen and/or RPCCert if not set.
 type Config struct {
-	RPCUser         string  `ini:"username"`
-	RPCPass         string  `ini:"password"`
-	RPCListen       string  `ini:"rpclisten"`
-	RPCCert         string  `ini:"rpccert"`
-	UseSplitTx      bool    `ini:"txsplit"`
-	FallbackFeeRate float64 `ini:"fallbackfee"`
+	RPCUser          string  `ini:"username"`
+	RPCPass          string  `ini:"password"`
+	RPCListen        string  `ini:"rpclisten"`
+	RPCCert          string  `ini:"rpccert"`
+	UseSplitTx       bool    `ini:"txsplit"`
+	FallbackFeeRate  float64 `ini:"fallbackfee"`
+	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 	// Context should be canceled when the application exits. This will cause
 	// some cleanup to be performed during shutdown.
 	Context context.Context `ini:"-"`

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -23,8 +23,7 @@ const (
 )
 
 var (
-	fallbackFeeKey = "fallbackfee"
-	configOpts     = []*asset.ConfigOption{
+	configOpts = []*asset.ConfigOption{
 		{
 			Key:         "walletname",
 			DisplayName: "Wallet Name",
@@ -54,10 +53,16 @@ var (
 			DefaultValue: "9332",
 		},
 		{
-			Key:          fallbackFeeKey,
+			Key:          "fallbackfee",
 			DisplayName:  "Fallback fee rate",
 			Description:  "Litecoin's 'fallbackfee' rate. Units: LTC/kB",
 			DefaultValue: defaultFee * 1000 / 1e8,
+		},
+		{
+			Key:          "redeemconftarget",
+			DisplayName:  "Redeem transaction confirmation target",
+			Description:  "The target number of blocks for the redeem transaction to get a confirmation. Used to set the transaction's fee rate. (default: 2 blocks)",
+			DefaultValue: 2,
 		},
 		{
 			Key:         "txsplit",

--- a/dex/networks/btc/config.go
+++ b/dex/networks/btc/config.go
@@ -43,8 +43,9 @@ type Config struct {
 
 	// Below fields are only used on the client.
 
-	UseSplitTx      bool    `ini:"txsplit"`
-	FallbackFeeRate float64 `ini:"fallbackfee"`
+	UseSplitTx       bool    `ini:"txsplit"`
+	FallbackFeeRate  float64 `ini:"fallbackfee"`
+	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 }
 
 // LoadConfigFromPath loads the configuration settings from the specified filepath.

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -1101,7 +1101,9 @@ func testRedemption(t *testing.T, segwit bool) {
 	}
 
 	// Missing transaction
+	testChainMtx.Lock()
 	delete(testChain.txRaws, *txHash)
+	testChainMtx.Unlock()
 	_, err = btc.Redemption(redemptionID, spentID)
 	if err == nil {
 		t.Fatalf("No error for missing transaction")


### PR DESCRIPTION
Given the recently reduced importance of the redeem transactions being mined promptly, this introduces a new client exchange wallet option to set the confirmation target for the redeem transaction.

The contract transaction may already be created with segwit inputs to lower fees (and accounting for this is corrected in https://github.com/decred/dcrdex/pull/729), but the redeem transactions will need [p2wsh contract prevouts](https://github.com/decred/dcrdex/issues/733) as their inputs to get the segwit discounts as well.  However, quickly mining the redeem txns is not nearly important as with the swap contract txns.  Thus, the user should have the ability to use lower fee rates for the redeem txns.

![image](https://user-images.githubusercontent.com/9373513/95625250-d2bfcc80-0a3d-11eb-9c3b-52b09dbe69bf.png)

The default for BTC is 2 blocks; default for DCR is 1 block.

This also sneaks in a test data race fix for server/asset/dcr, and tweaks the swap tests as there were needlessly low timeouts in places.