### PR TITLE
assets: implement segwit btc swap contracts

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2030,8 +2030,8 @@ func (btc *ExchangeWallet) createWitnessSig(tx *wire.MsgTx, idx int, pkScript []
 	if err != nil {
 		return nil, nil, err
 	}
-	sig, err = txscript.RawTxInWitnessSignature(tx, txscript.NewTxSigHashes(tx), idx,
-		int64(val), pkScript, txscript.SigHashAll, privKey)
+	sig, err = txscript.RawTxInWitnessSignature(tx, sigHashes, idx, int64(val),
+		pkScript, txscript.SigHashAll, privKey)
 
 	if err != nil {
 		return nil, nil, err
@@ -2221,14 +2221,15 @@ func (btc *ExchangeWallet) externalAddress() (btcutil.Address, error) {
 	return btc.wallet.AddressPKH()
 }
 
-// hashContract hashes the contract. The hash function used depends on whether
-// the wallet is configured for segwit.
+// hashContract hashes the contract for use in a p2sh or p2wsh pubkey script.
+// The hash function used depends on whether the wallet is configured for
+// segwit. Non-segwit uses Hash160, segwit uses SHA256.
 func (btc *ExchangeWallet) hashContract(contract []byte) []byte {
 	if btc.segwit {
-		h := sha256.Sum256(contract)
+		h := sha256.Sum256(contract) // BIP141
 		return h[:]
 	}
-	return btcutil.Hash160(contract)
+	return btcutil.Hash160(contract) // BIP16
 }
 
 // scriptHashAddress returns a new p2sh or p2wsh address, depending on whether

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -970,11 +970,11 @@ func TestFundEdges(t *testing.T) {
 		t.Fatalf("error when should be enough funding in two utxos: %v", err)
 	}
 
-	// P2WPKH witness: RedeemP2WPKHInputWitnessWeight = 108
-	// P2WPKH input size = overhead(40) + no sigScript(1+0) + witness(ceil(108/4)) = 68 vbytes
-	// backing fees: 68 * fee_rate(34) = 2312 satoshi
-	// total: base_fees(71434) + 2312 = 73746 satoshi
-	backingFees = 73746
+	// P2WPKH witness: RedeemP2WPKHInputWitnessWeight = 109
+	// P2WPKH input size = overhead(40) + no sigScript(1+0) + witness(ceil(109/4)) = 69 vbytes
+	// backing fees: 69 * fee_rate(34) = 2346 satoshi
+	// total: base_fees(71434) + 2346 = 73780 satoshi
+	backingFees = 73780
 	p2wpkhAddr := tP2WPKHAddr
 	p2wpkhPkScript, _ := hex.DecodeString("0014054a40a6aa7c1f6bd15f286debf4f33cef0e21a1")
 	p2wpkhUnspent := &ListUnspentResult{
@@ -1045,10 +1045,9 @@ func TestFundEdgesSegwit(t *testing.T) {
 	// Base Fees
 	// fee_rate: 34 satoshi / vbyte (MaxFeeRate)
 
-	// swap_size: 152 bytes (InitTxSizeSegwit)
-	// pw2pk_witness_vbytes = (RedeemP2WPKHInputWitnessWeight + 3) / 4 = 27
-	// p2wpkh input: 68 bytes (RedeemP2WPKHInputVBytes)
-	// swap_size_base: 84 bytes (152 - 68 p2pkh input) (InitTxSizeBaseSegwit)
+	// swap_size: 153 bytes (InitTxSizeSegwit)
+	// p2wpkh input, incl. marker and flag: 69 bytes (RedeemP2WPKHInputSize + ((RedeemP2WPKHInputWitnessWeight + 2 + 3) / 4))
+	// swap_size_base: 84 bytes (153 - 69 p2pkh input) (InitTxSizeBaseSegwit)
 
 	// lot_size: 1e6
 	// swap_value: 1e7
@@ -1058,14 +1057,14 @@ func TestFundEdgesSegwit(t *testing.T) {
 	//   first_swap_size = swap_size_base + backing_bytes
 	//   total_bytes  = swap_size_base + backing_bytes + (lots - 1) * swap_size
 	//   base_tx_bytes = total_bytes - backing_bytes
-	// base_tx_bytes = (lots - 1) * swap_size + swap_size_base = 9 * 152 + 84 = 1452
-	// base_fees = base_tx_bytes * fee_rate = 1452 * 34 = 49401
-	// backing_bytes: 1x P2WPKH-spending input = p2wpkh input = 68 bytes
-	// backing_fees: 68 * fee_rate(34 atoms/byte) = 2312 atoms
-	// total_bytes  = base_tx_bytes + backing_bytes = 1452 + 68 = 1520
-	// total_fees: base_fees + backing_fees = 49402 + 2312 = 51341 atoms
-	//          OR total_bytes * fee_rate = 1521 * 34 = 51714
-	backingFees := uint64(1520) * tBTC.MaxFeeRate // total_bytes * fee_rate
+	// base_tx_bytes = (lots - 1) * swap_size + swap_size_base = 9 * 153 + 84 = 1461
+	// base_fees = base_tx_bytes * fee_rate = 1461 * 34 = 49674
+	// backing_bytes: 1x P2WPKH-spending input = p2wpkh input = 69 bytes
+	// backing_fees: 69 * fee_rate(34 atoms/byte) = 2346 atoms
+	// total_bytes  = base_tx_bytes + backing_bytes = 1461 + 69 = 1530
+	// total_fees: base_fees + backing_fees = 49674 + 2346 = 52020 atoms
+	//          OR total_bytes * fee_rate = 1530 * 34 = 52020
+	backingFees := uint64(1530) * tBTC.MaxFeeRate // total_bytes * fee_rate
 	p2wpkhUnspent := &ListUnspentResult{
 		TxID:          tTxID,
 		Address:       tP2WPKHAddr,
@@ -1102,7 +1101,7 @@ func TestFundEdgesSegwit(t *testing.T) {
 	node.signFunc = func(params []json.RawMessage) (json.RawMessage, error) {
 		return signFunc(t, params, 0, true, wallet.segwit)
 	}
-	backingFees = uint64(1520+splitTxBaggageSegwit) * tBTC.MaxFeeRate
+	backingFees = uint64(1530+splitTxBaggageSegwit) * tBTC.MaxFeeRate
 	v := swapVal + backingFees - 1
 	p2wpkhUnspent.Amount = float64(v) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -267,7 +267,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 		// Alpha should be able to redeem.
 		ci, err := rig.alpha().AuditContract(receipt.Coin().ID(), receipt.Contract())
 		if err != nil {
-			t.Fatalf("error auditing contract")
+			t.Fatalf("error auditing contract: %v", err)
 		}
 		auditCoin := ci.Coin()
 		if ci.Recipient() != address {

--- a/client/asset/btc/livetest/regnet_test.go
+++ b/client/asset/btc/livetest/regnet_test.go
@@ -12,15 +12,15 @@ import (
 )
 
 const (
-	alphaAddress = "mjqAiNeRe8jWzTUnEYL9CYa2YKjFWQDjJY"
+	alphaAddress = "bcrt1qy7agjj62epx0ydnqskgwlcfwu52xjtpj36hr0d"
 )
 
 var (
 	tBTC = &dex.Asset{
 		ID:           0,
 		Symbol:       "btc",
-		SwapSize:     dexbtc.InitTxSize,
-		SwapSizeBase: dexbtc.InitTxSizeBase,
+		SwapSize:     dexbtc.InitTxSizeSegwit,
+		SwapSizeBase: dexbtc.InitTxSizeBaseSegwit,
 		MaxFeeRate:   10,
 		LotSize:      1e6,
 		RateStep:     10,

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -41,13 +41,15 @@ const (
 type walletClient struct {
 	node        rpcClient
 	chainParams *chaincfg.Params
+	segwit      bool
 }
 
 // newWalletClient is the constructor for a walletClient.
-func newWalletClient(node rpcClient, chainParams *chaincfg.Params) *walletClient {
+func newWalletClient(node rpcClient, segwit bool, chainParams *chaincfg.Params) *walletClient {
 	return &walletClient{
 		node:        node,
 		chainParams: chainParams,
+		segwit:      segwit,
 	}
 }
 
@@ -99,7 +101,12 @@ func (wc *walletClient) ListLockUnspent() ([]*RPCOutpoint, error) {
 // be bech32-encoded (P2WPKH).
 func (wc *walletClient) ChangeAddress() (btcutil.Address, error) {
 	var addrStr string
-	err := wc.call(methodChangeAddress, anylist{"bech32"}, &addrStr)
+	var err error
+	if wc.segwit {
+		err = wc.call(methodChangeAddress, anylist{"bech32"}, &addrStr)
+	} else {
+		err = wc.call(methodChangeAddress, anylist{"legacy"}, &addrStr)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1719,3 +1719,72 @@ func TestConfirmations(t *testing.T) {
 		t.Fatalf("coin error: %v", err)
 	}
 }
+
+func TestSendEdges(t *testing.T) {
+	wallet, node, shutdown := tNewWallet()
+	defer shutdown()
+
+	const feeRate uint64 = 3
+
+	const swapVal = 2e8 // leaving untyped. NewTxOut wants int64
+
+	contractAddr, _ := dcrutil.NewAddressScriptHash(randBytes(20), chainParams)
+	// See dexdcr.IsDust for the source of this dustCoverage voodoo.
+	dustCoverage := (dexdcr.P2PKHOutputSize + 165) * feeRate * 3
+	dexReqFees := dexdcr.InitTxSize * feeRate
+
+	pkScript, _ := txscript.PayToAddrScript(contractAddr)
+
+	newBaseTx := func(funding uint64) *wire.MsgTx {
+		baseTx := wire.NewMsgTx()
+		baseTx.AddTxIn(wire.NewTxIn(new(wire.OutPoint), int64(funding), nil))
+		baseTx.AddTxOut(wire.NewTxOut(swapVal, pkScript))
+		return baseTx
+	}
+
+	node.signFunc = func(tx *wire.MsgTx) (*wire.MsgTx, bool, error) {
+		return signFunc(tx, dexdcr.P2PKHSigScriptSize)
+	}
+
+	tests := []struct {
+		name      string
+		funding   uint64
+		expChange bool
+	}{
+		{
+			name:    "not enough for change output",
+			funding: swapVal + dexReqFees - 1,
+		},
+		{
+			// Still dust here, but a different path.
+			name:    "exactly enough for change output",
+			funding: swapVal + dexReqFees,
+		},
+		{
+			name:    "more than enough for change output but still dust",
+			funding: swapVal + dexReqFees + 1,
+		},
+		{
+			name:    "1 atom short to not be dust",
+			funding: swapVal + dexReqFees + dustCoverage - 1,
+		},
+		{
+			name:      "exactly enough to not be dust",
+			funding:   swapVal + dexReqFees + dustCoverage,
+			expChange: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tx, _, _, err := wallet.sendWithReturn(newBaseTx(tt.funding), tPKHAddr, tt.funding, swapVal, feeRate, nil)
+		if err != nil {
+			t.Fatalf("sendWithReturn error: %v", err)
+		}
+
+		if len(tx.TxOut) == 1 && tt.expChange {
+			t.Fatalf("%s: no change added", tt.name)
+		} else if len(tx.TxOut) == 2 && !tt.expChange {
+			t.Fatalf("%s: change output added for dust. Output value = %d", tt.name, tx.TxOut[1].Value)
+		}
+	}
+}

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -137,6 +137,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		Ports:              ports,
 		DefaultFallbackFee: defaultFee,
 		LegacyBalance:      true,
+		Segwit:             false,
 	}
 
 	return btc.BTCCloneWallet(cloneCFG)

--- a/dex/networks/btc/script.go
+++ b/dex/networks/btc/script.go
@@ -59,8 +59,13 @@ const (
 	//   - 32 bytes secret key
 	//   - OP_1
 	//   - varint 97
-	//   - 97 bytes secret key
+	//   - 97 bytes redeem script
 	RedeemSwapSigScriptSize = 1 + DERSigLength + 1 + 33 + 1 + 32 + 1 + 2 + 97
+
+	// RedeemSwapWitnessVSize is the byte-size of the witness script. It is
+	// identical to the byte size of the non-segwit sig script, but will
+	// receive the segwit discount when evaluating virtual bytes.
+	RedeemSwapWitnessVSize = (RedeemSwapSigScriptSize + 3) / 4
 
 	// RefundSigScriptSize is the worst case (largest) serialize size
 	// of a transaction input script that refunds a compressed P2PKH output.
@@ -74,6 +79,8 @@ const (
 	//   - varint 97 => OP_PUSHDATA1(0x4c) + 0x61
 	//   - 97 bytes contract
 	RefundSigScriptSize = 1 + DERSigLength + 1 + 33 + 1 + 2 + 97
+
+	RefundWitnessVSize = (RefundSigScriptSize + 3) / 4
 
 	// Overhead for a wire.TxIn. See wire.TxIn.SerializeSize.
 	// hash 32 bytes + index 4 bytes + sequence 4 bytes.

--- a/dex/networks/btc/script.go
+++ b/dex/networks/btc/script.go
@@ -706,6 +706,9 @@ func FindKeyPush(txIn *wire.TxIn, contractHash []byte, segwit bool, chainParams 
 }
 
 func findKeyPush(redeemScript, secret, contractHash []byte, chainParams *chaincfg.Params, hasher func([]byte) []byte) ([]byte, error) {
+	// Doesn't matter what we pass for the bool segwit argument, since we're not
+	// using the addresses, and the contract's 20-byte pubkey hashes are
+	// compatible with both address types.
 	_, _, _, keyHash, err := ExtractSwapDetails(redeemScript, true, chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting atomic swap details: %v", err)

--- a/dex/networks/btc/script.go
+++ b/dex/networks/btc/script.go
@@ -62,11 +62,6 @@ const (
 	//   - 97 bytes redeem script
 	RedeemSwapSigScriptSize = 1 + DERSigLength + 1 + 33 + 1 + 32 + 1 + 2 + 97
 
-	// RedeemSwapWitnessVSize is the byte-size of the witness script. It is
-	// identical to the byte size of the non-segwit sig script, but will
-	// receive the segwit discount when evaluating virtual bytes.
-	RedeemSwapWitnessVSize = (RedeemSwapSigScriptSize + 3) / 4
-
 	// RefundSigScriptSize is the worst case (largest) serialize size
 	// of a transaction input script that refunds a compressed P2PKH output.
 	// It is calculated as:
@@ -79,8 +74,6 @@ const (
 	//   - varint 97 => OP_PUSHDATA1(0x4c) + 0x61
 	//   - 97 bytes contract
 	RefundSigScriptSize = 1 + DERSigLength + 1 + 33 + 1 + 2 + 97
-
-	RefundWitnessVSize = (RefundSigScriptSize + 3) / 4
 
 	// Overhead for a wire.TxIn. See wire.TxIn.SerializeSize.
 	// hash 32 bytes + index 4 bytes + sequence 4 bytes.
@@ -165,11 +158,6 @@ const (
 	//   - 0 bytes signature script
 	RedeemP2WPKHInputSize = TxInOverhead + 1
 
-	// RedeemP2WPKHInputVBytes is the size of an input that redeems a p2wpkh
-	// output, in units of virtual bytes.
-	// 41 + 27 = 68
-	RedeemP2WPKHInputVBytes = RedeemP2WPKHInputSize + ((RedeemP2WPKHInputWitnessWeight + 3) / 4)
-
 	// RedeemP2WPKHInputWitnessWeight is the worst case weight of
 	// a witness for spending P2WPKH and nested P2WPKH outputs. It
 	// is calculated as:
@@ -180,7 +168,7 @@ const (
 	//   - 1 wu compact int encoding value 33
 	//   - 33 wu serialized compressed pubkey
 	// NOTE: witness data is not script.
-	RedeemP2WPKHInputWitnessWeight = 1 + DERSigLength + 1 + 33 // 108
+	RedeemP2WPKHInputWitnessWeight = 1 + 1 + DERSigLength + 1 + 33 // 109
 
 	// RedeemP2WSHInputWitnessWeight depends on the number of redeem scrpit and
 	// number of signatures.
@@ -226,10 +214,11 @@ const (
 	InitTxSizeBaseSegwit = MinimumTxOverhead + P2WPKHOutputSize + P2WSHOutputSize
 
 	// InitTxSizeSegwit is InitTxSizeSegwit + 1 P2WPKH input.
-	// RedeemP2WPKHInputWitnessWeight is actually a perfect multiple of 4, but
-	// using the round up formula for good practice.
-	// 84 + 41 + 27 = 152
-	InitTxSizeSegwit = InitTxSizeBaseSegwit + RedeemP2WPKHInputVBytes
+	// 84 vbytes base tx
+	// 41 vbytes base tx input
+	// 109wu witness +  2wu segwit marker and flag = 28 vbytes
+	// total = 153 vbytes
+	InitTxSizeSegwit = InitTxSizeBaseSegwit + RedeemP2WPKHInputSize + ((RedeemP2WPKHInputWitnessWeight + 2 + 3) / 4)
 
 	witnessWeight = blockchain.WitnessScaleFactor
 )

--- a/dex/networks/btc/script.go
+++ b/dex/networks/btc/script.go
@@ -364,18 +364,20 @@ func MakeContract(recipient, sender string, secretHash []byte, lockTime int64, s
 // IsDust returns whether or not the passed transaction output amount is
 // considered dust or not based on the passed minimum transaction relay fee.
 // Dust is defined in terms of the minimum transaction relay fee.
-// Based on btcutil/policy isDust. See btcutil/policy for further documentation.
+// Based on btcd/policy isDust. See btcd/policy for further documentation.
 func IsDust(txOut *wire.TxOut, minRelayTxFee uint64) bool {
 	if txscript.IsUnspendable(txOut.PkScript) {
 		return true
 	}
 	totalSize := txOut.SerializeSize() + 41
 	if txscript.IsWitnessProgram(txOut.PkScript) {
+		// This function is taken from btcd, but noting here that we are not
+		// rounding up and probably should be.
 		totalSize += (107 / witnessWeight)
 	} else {
 		totalSize += 107
 	}
-	return txOut.Value*1000/(3*int64(totalSize)) < int64(minRelayTxFee)
+	return txOut.Value/(3*int64(totalSize)) < int64(minRelayTxFee)
 }
 
 // BtcScriptAddrs is information about the pubkeys or pubkey hashes present in

--- a/dex/networks/btc/script_test.go
+++ b/dex/networks/btc/script_test.go
@@ -223,20 +223,20 @@ func TestIsDust(t *testing.T) {
 		{
 			"38 byte public key script with value 584",
 			wire.TxOut{Value: 584, PkScript: pkScript},
-			1000,
+			1,
 			true,
 		},
 		{
 			"38 byte public key script with value 585",
 			wire.TxOut{Value: 585, PkScript: pkScript},
-			1000,
+			1,
 			false,
 		},
 		{
 			// Maximum allowed value is never dust.
 			"max satoshi amount is never dust",
 			wire.TxOut{Value: btcutil.MaxSatoshi, PkScript: pkScript},
-			btcutil.MaxSatoshi,
+			btcutil.MaxSatoshi / 1000,
 			false,
 		},
 		{

--- a/dex/networks/btc/script_test.go
+++ b/dex/networks/btc/script_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	tStamp        = int64(1574264305)
-	tParams       = &chaincfg.MainNetParams
-	invalidScript = []byte{txscript.OP_DATA_75}
+	tStamp         = int64(1574264305)
+	tParams        = &chaincfg.MainNetParams
+	invalidScript  = []byte{txscript.OP_DATA_75}
+	invalidWitness = [][]byte{{txscript.OP_DATA_75}}
 )
 
 func randBytes(l int) []byte {
@@ -129,44 +130,64 @@ func TestParseScriptType(t *testing.T) {
 }
 
 func TestMakeContract(t *testing.T) {
-	ra, _ := btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+	t.Run("segwit", func(t *testing.T) {
+		testMakeContract(t, true)
+	})
+	t.Run("non-segwit", func(t *testing.T) {
+		testMakeContract(t, false)
+	})
+}
+
+func testMakeContract(t *testing.T, segwit bool) {
+	var ra, sa, p2sh, p2pkh btcutil.Address
+	if segwit {
+		ra, _ = btcutil.NewAddressWitnessPubKeyHash(randBytes(20), tParams)
+		sa, _ = btcutil.NewAddressWitnessPubKeyHash(randBytes(20), tParams)
+		p2sh, _ = btcutil.NewAddressScriptHash(randBytes(50), tParams)
+		p2pkh, _ = btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+	} else {
+		ra, _ = btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+		sa, _ = btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+		p2sh, _ = btcutil.NewAddressScriptHash(randBytes(50), tParams)
+		p2pkh, _ = btcutil.NewAddressWitnessPubKeyHash(randBytes(20), tParams)
+	}
+
 	recipient := ra.String()
-	sa, _ := btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
 	sender := sa.String()
 	badAddr := "notanaddress"
 
 	// Bad recipient
-	_, err := MakeContract(badAddr, sender, randBytes(32), tStamp, tParams)
+	_, err := MakeContract(badAddr, sender, randBytes(32), tStamp, segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for bad recipient")
 	}
 	// Wrong recipient address type
-	p2sh, _ := btcutil.NewAddressScriptHash(randBytes(50), tParams)
-	_, err = MakeContract(p2sh.String(), sender, randBytes(32), tStamp, tParams)
+
+	_, err = MakeContract(p2sh.String(), sender, randBytes(32), tStamp, segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for wrong recipient address type")
 	}
 
 	// Bad sender
-	_, err = MakeContract(recipient, badAddr, randBytes(32), tStamp, tParams)
+	_, err = MakeContract(recipient, badAddr, randBytes(32), tStamp, segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for bad sender")
 	}
 	// Wrong sender address type.
-	p2wpkh, _ := btcutil.NewAddressWitnessPubKeyHash(randBytes(20), tParams)
-	_, err = MakeContract(recipient, p2wpkh.String(), randBytes(32), tStamp, tParams)
+
+	_, err = MakeContract(recipient, p2pkh.String(), randBytes(32), tStamp, segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for wrong sender address type")
 	}
 
 	// Bad secret hash
-	_, err = MakeContract(recipient, sender, randBytes(10), tStamp, tParams)
+	_, err = MakeContract(recipient, sender, randBytes(10), tStamp, segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for bad secret hash")
 	}
 
 	// Good to go
-	_, err = MakeContract(recipient, sender, randBytes(32), tStamp, tParams)
+	_, err = MakeContract(recipient, sender, randBytes(32), tStamp, segwit, tParams)
 	if err != nil {
 		t.Fatalf("error for valid contract parameters: %v", err)
 	}
@@ -298,17 +319,33 @@ func TestExtractScriptAddrs(t *testing.T) {
 }
 
 func TestExtractSwapDetails(t *testing.T) {
-	rAddr, _ := btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+	t.Run("segwit", func(t *testing.T) {
+		testExtractSwapDetails(t, true)
+	})
+	t.Run("non-segwit", func(t *testing.T) {
+		testExtractSwapDetails(t, false)
+	})
+}
+
+func testExtractSwapDetails(t *testing.T, segwit bool) {
+	var rAddr, sAddr btcutil.Address
+	if segwit {
+		rAddr, _ = btcutil.NewAddressWitnessPubKeyHash(randBytes(20), tParams)
+		sAddr, _ = btcutil.NewAddressWitnessPubKeyHash(randBytes(20), tParams)
+	} else {
+		rAddr, _ = btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+		sAddr, _ = btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+	}
+
 	recipient := rAddr.String()
-	sAddr, _ := btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
 	sender := sAddr.String()
 	keyHash := randBytes(32)
-	contract, err := MakeContract(recipient, sender, keyHash, tStamp, tParams)
+	contract, err := MakeContract(recipient, sender, keyHash, tStamp, segwit, tParams)
 	if err != nil {
 		t.Fatalf("error creating contract: %v", err)
 	}
 
-	sa, ra, lockTime, secretHash, err := ExtractSwapDetails(contract, tParams)
+	sa, ra, lockTime, secretHash, err := ExtractSwapDetails(contract, segwit, tParams)
 	if err != nil {
 		t.Fatalf("error for valid contract: %v", err)
 	}
@@ -326,7 +363,7 @@ func TestExtractSwapDetails(t *testing.T) {
 	}
 
 	// incorrect length
-	_, _, _, _, err = ExtractSwapDetails(contract[:len(contract)-1], tParams)
+	_, _, _, _, err = ExtractSwapDetails(contract[:len(contract)-1], segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for vandalized contract")
 	} else if !strings.HasPrefix(err.Error(), "incorrect swap contract length") {
@@ -335,7 +372,7 @@ func TestExtractSwapDetails(t *testing.T) {
 
 	// bad secret size
 	contract[3] = 250
-	_, _, _, _, err = ExtractSwapDetails(contract, tParams)
+	_, _, _, _, err = ExtractSwapDetails(contract, segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for contract with invalid secret size")
 	} else if !strings.HasPrefix(err.Error(), "invalid secret size") {
@@ -403,21 +440,53 @@ func TestInputInfo(t *testing.T) {
 }
 
 func TestFindKeyPush(t *testing.T) {
-	rAddr, _ := btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+	t.Run("segwit", func(t *testing.T) {
+		testFindKeyPush(t, true)
+	})
+	t.Run("non-segwit", func(t *testing.T) {
+		testFindKeyPush(t, false)
+	})
+}
+
+func testFindKeyPush(t *testing.T, segwit bool) {
+	dummyPrevOut := new(wire.OutPoint)
+	var rAddr, sAddr btcutil.Address
+	if segwit {
+		rAddr, _ = btcutil.NewAddressWitnessPubKeyHash(randBytes(20), tParams)
+		sAddr, _ = btcutil.NewAddressWitnessPubKeyHash(randBytes(20), tParams)
+	} else {
+		rAddr, _ = btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+		sAddr, _ = btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
+	}
 	recipient := rAddr.String()
-	sAddr, _ := btcutil.NewAddressPubKeyHash(randBytes(20), tParams)
 	sender := sAddr.String()
 
 	secret := randBytes(32)
 	secretHash := sha256.Sum256(secret)
-	contract, _ := MakeContract(recipient, sender, secretHash[:], tStamp, tParams)
-	contractHash := btcutil.Hash160(contract)
-	sigScript, err := RedeemP2SHContract(contract, randBytes(73), randBytes(33), secret)
-	if err != nil {
-		t.Fatalf("error creating redeem script: %v", err)
+	contract, _ := MakeContract(recipient, sender, secretHash[:], tStamp, segwit, tParams)
+	randomContract, _ := MakeContract(recipient, sender, randBytes(32), tStamp, segwit, tParams)
+
+	var sigScript, contractHash, randoSigScript []byte
+	var witness, randoWitness [][]byte
+	var err error
+	if segwit {
+		witness = RedeemP2WSHContract(contract, randBytes(73), randBytes(33), secret)
+		h := sha256.Sum256(contract)
+		contractHash = h[:]
+		randoWitness = RedeemP2WSHContract(randomContract, randBytes(73), randBytes(33), secret)
+
+	} else {
+		sigScript, err = RedeemP2SHContract(contract, randBytes(73), randBytes(33), secret)
+		if err != nil {
+			t.Fatalf("error creating redeem script: %v", err)
+		}
+		contractHash = btcutil.Hash160(contract)
+		randoSigScript, _ = RedeemP2SHContract(randomContract, randBytes(73), randBytes(33), secret)
 	}
 
-	key, err := FindKeyPush(sigScript, contractHash, tParams)
+	txIn := wire.NewTxIn(dummyPrevOut, sigScript, witness)
+
+	key, err := FindKeyPush(txIn, contractHash, segwit, tParams)
 	if err != nil {
 		t.Fatalf("findKeyPush error: %v", err)
 	}
@@ -426,24 +495,22 @@ func TestFindKeyPush(t *testing.T) {
 	}
 
 	// Empty script is an error.
-	_, err = FindKeyPush([]byte{}, contractHash, tParams)
+	badTx := wire.NewTxIn(dummyPrevOut, nil, nil)
+	_, err = FindKeyPush(badTx, contractHash, segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for empty script")
 	}
 
 	// Bad script
-	_, err = FindKeyPush(invalidScript, contractHash, tParams)
+	badTx = wire.NewTxIn(dummyPrevOut, invalidScript, invalidWitness)
+	_, err = FindKeyPush(badTx, contractHash, segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for bad script")
 	}
 
 	// Random but valid contract won't work.
-	contract, _ = MakeContract(recipient, sender, randBytes(32), tStamp, tParams)
-	sigScript, err = RedeemP2SHContract(contract, randBytes(73), randBytes(33), secret)
-	if err != nil {
-		t.Fatalf("error creating contract: %v", err)
-	}
-	_, err = FindKeyPush(sigScript, contractHash, tParams)
+	badTx = wire.NewTxIn(dummyPrevOut, randoSigScript, randoWitness)
+	_, err = FindKeyPush(badTx, contractHash, segwit, tParams)
 	if err == nil {
 		t.Fatalf("no error for bad script")
 	}

--- a/server/asset/btc/testing.go
+++ b/server/asset/btc/testing.go
@@ -128,7 +128,7 @@ out:
 					case txscript.WitnessV0ScriptHashTy:
 						stats.p2wsh++
 					default:
-						_, _, _, _, err = dexbtc.ExtractSwapDetails(redeemScript, btc.chainParams)
+						_, _, _, _, err = dexbtc.ExtractSwapDetails(redeemScript, btc.segwit, btc.chainParams)
 						if err == nil {
 							stats.swaps++
 							continue

--- a/server/asset/ltc/ltc.go
+++ b/server/asset/ltc/ltc.go
@@ -62,5 +62,5 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 		configPath = dexbtc.SystemConfigPath("litecoin")
 	}
 
-	return btc.NewBTCClone(assetName, configPath, logger, network, params, ports)
+	return btc.NewBTCClone(assetName, false, configPath, logger, network, params, ports)
 }

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -309,6 +309,15 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 
 			delete(neededCoins, key) // don't check this coin again
 			valSum += dexCoin.Value()
+			// NOTE: Summing like this is actually not quite sufficient to
+			// estimate the size associated with the input, because if it's a
+			// BTC segwit output, we would also have to account for the marker
+			// and flag weight, but only once per tx. The weight would add
+			// either 0 or 1 byte to the tx virtual size, so we have a chance of
+			// under-estimating by 1 byte to the advantage of the client. It
+			// won't ever cause issues though, because we also require funding
+			// for a change output in the final swap, which is actually not
+			// needed, so there's some buffer.
 			spendSize += dexCoin.SpendSize()
 		}
 
@@ -474,6 +483,7 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 
 			delete(neededCoins, key) // don't check this coin again
 			valSum += dexCoin.Value()
+			// SEE NOTE above in handleLimit regarding underestimation for BTC.
 			spendSize += dexCoin.SpendSize()
 		}
 


### PR DESCRIPTION
Using segwit contracts saves us something like 30% in transaction fees. This will give us a little bit of wiggle room on Bitcoin markets where on-chain fees are outrageous.

Segwit is implemented as an option for the wallet backends and server's asset backends. Bitcoin is configured to use segwit by defualt. Litecoin will too, and I've tested it, but I'm leaving it in non-segwit just to demonstrate the option. It's important to offer the option, because even though some bitcoin forks won't have segwit, our clone backend might still be useful.