### PR TITLE
app: improved notifications UI

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1841,7 +1841,7 @@ func (c *Core) Login(pw []byte) (*LoginResult, error) {
 	}
 
 	dexStats := c.initializeDEXConnections(crypter)
-	notes, err := c.db.NotificationsN(10)
+	notes, err := c.db.NotificationsN(100)
 	if err != nil {
 		c.log.Errorf("Login -> NotificationsN error: %v", err)
 	}
@@ -2747,12 +2747,6 @@ func (c *Core) initialize() {
 						"Discarding account.", acct.Host)
 					return
 				}
-				c.log.Infof("Incomplete registration detected for DEX %s. "+
-					"Registration will be completed when the Decred wallet is unlocked.",
-					acct.Host)
-				details := fmt.Sprintf("Unlock your Decred wallet to complete registration for %s", acct.Host)
-				c.notify(newFeePaymentNote("Incomplete registration", details, db.WarningLevel, acct.Host))
-				// checkUnpaidFees will pay the fees if the wallet is unlocked
 			}
 			c.connMtx.Lock()
 			c.conns[host] = dc

--- a/client/webserver/middleware.go
+++ b/client/webserver/middleware.go
@@ -49,7 +49,7 @@ func (s *WebServer) authMiddleware(next http.Handler) http.Handler {
 
 // extractBooleanCookie extracts the cookie value with key k from the Request,
 // and interprets the value as true only if it's equal to the string "1".
-func extractBooleanCookie(r *http.Request, k string, deFault bool) bool {
+func extractBooleanCookie(r *http.Request, k string, defaultVal bool) bool {
 	cookie, err := r.Cookie(k)
 	switch err {
 	// Dark mode is the default
@@ -59,7 +59,7 @@ func extractBooleanCookie(r *http.Request, k string, deFault bool) bool {
 	default:
 		log.Errorf("Cookie %q retrieval error: %v", k, err)
 	}
-	return deFault
+	return defaultVal
 }
 
 // requireInit ensures that the core app is initialized before allowing the

--- a/client/webserver/site/src/css/application.scss
+++ b/client/webserver/site/src/css/application.scss
@@ -63,3 +63,4 @@ $mono: 'mono', monospace;
 @import "./wallets_dark.scss";
 @import "./orders.scss";
 @import "./order.scss";
+@import "./settings.scss";

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -30,6 +30,11 @@ button {
   outline: none;
 }
 
+// bootstrap override
+.form-check-input {
+  margin-top: 0.4em;
+}
+
 // Hide number arrows.
 // Chrome, Safari, Edge, Opera
 input::-webkit-outer-spin-button,
@@ -112,11 +117,6 @@ button:focus {
   form label {
     font-size: 15px;
     font-family: $demi-sans;
-  }
-
-  // bootstrap override
-  .form-check-input {
-    margin-top: 0.4em;
   }
 }
 
@@ -221,41 +221,60 @@ input[type=number] {
   }
 }
 
+.max-h-100 {
+  max-height: 100%;
+}
+
 div.note-indicator {
-  width: 8px;
-  height: 8px;
-  border-radius: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 3px;
+
+  &.good {
+    background-color: #2d2e;
+  }
+
+  &.bad {
+    background-color: #d22e;
+  }
+
+  &.warn {
+    background-color: #f82e;
+  }
 }
 
 #noteIndicator {
   position: absolute;
   top: 0;
   left: 20px;
+  font-size: 16px;
+  line-height: 1;
+  font-family: $demi-sans;
   z-index: 2;
+
+  &.good {
+    color: #2d2e;
+  }
+
+  &.bad {
+    color: #d22e;
+  }
+
+  &.warn {
+    color: #f82e;
+  }
 }
 
-div.note-indicator.good {
-  background-color: green;
-}
-
-div.note-indicator.bad {
-  background-color: red;
-}
-
-div.note-indicator.warn {
-  background-color: orange;
-}
-
-div.poke-note {
+div.popup-notes {
   position: fixed;
-  right: 20px;
+  right: 5px;
   bottom: 0;
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   border-radius: 4px;
   z-index: 1000;
-  max-width: 90%;
+  max-width: 750px;
 
   & > span {
     display: inline-block;
@@ -269,41 +288,67 @@ div.poke-note {
     padding: 4px 10px;
     line-height: 1;
     margin: 3px 0 0;
+    max-width: 100%;
+  }
+
+  .note-indicator {
+    margin-bottom: 2px;
   }
 }
 
 #noteBox,
 #profileBox {
-  position: absolute;
-  display: none;
-  top: -6px;
-  right: 20px;
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   background-color: white;
-  border: 1px solid black;
-  z-index: 1;
+  border: 1px solid #7777;
+  z-index: 100;
   font-family: $sans;
   min-width: 150px;
-  line-height: 2;
+  line-height: 1.5;
+  max-height: 90%;
 
   .icon {
     position: absolute;
-    right: 5px;
-    top: 5px;
+    right: 15px;
+    top: 8px;
+  }
+
+  .header {
+    border-bottom: 1px solid #7777;
+
+    & > div {
+      margin-right: 20px;
+      opacity: 0.5;
+      cursor: pointer;
+
+      &.active {
+        opacity: 1;
+      }
+    }
   }
 }
 
 #noteBox {
-  min-width: 400px;
+  width: 425px;
+
+  div.note.firstview {
+    background-color: #7772;
+  }
+
+  div.note:not(:last-child) {
+    border-bottom-style: solid;
+    border-width: 1px;
+    border-color: #7777;
+  }
 }
 
 #profileBox {
   min-width: 250px;
-}
-
-div.note:not(:last-child) {
-  border-bottom-style: solid;
-  border-width: 1px;
-  border-color: #aaa;
+  font-size: 15px;
+  padding: 10px;
 }
 
 @keyframes spin {

--- a/client/webserver/site/src/css/main_dark.scss
+++ b/client/webserver/site/src/css/main_dark.scss
@@ -87,10 +87,9 @@ body.dark {
   #noteBox,
   #profileBox {
     background-color: $dark_bg_1;
-    border-color: white;
   }
 
-  div.poke-note > span {
+  div.popup-notes > span {
     background-color: white;
     color: $font-color-light;
   }

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -1,5 +1,5 @@
 div.marketlist {
-  width: 200px;
+  width: 175px;
   border-right: 1px solid #626262;
   z-index: 99;
   background-color: #dbdbdb;
@@ -9,11 +9,16 @@ div.marketlist {
     border-width: 1px;
     border-color: #aaa;
   }
+
+  .header {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 div.marketrow {
   font-size: 17px;
-  padding: 0.5em;
+  padding: 0.3em;
   font-family: 'demi-sans', sans-serif;
   cursor: pointer;
 }
@@ -32,6 +37,12 @@ label.market-search {
 
   input {
     border: none;
+    width: 150px;
+  }
+
+  span {
+    width: 25px;
+    text-align: center;
   }
 }
 
@@ -72,10 +83,6 @@ div.popupforms {
   cursor: ns-resize;
 }
 
-.marketorders {
-  overflow: hidden;
-}
-
 table.ordertable {
   border-collapse: collapse;
   border: none;
@@ -94,7 +101,7 @@ table.ordertable {
   td,
   th {
     font-size: 14px;
-    padding: 2px 0;
+    padding: 3px 0;
   }
 
   tr {

--- a/client/webserver/site/src/css/market_dark.scss
+++ b/client/webserver/site/src/css/market_dark.scss
@@ -1,8 +1,4 @@
 body.dark {
-  .marketorders {
-    background-color: black;
-  }
-
   input[type=number] {
     border-color: #444;
   }
@@ -16,6 +12,14 @@ body.dark {
 
     tbody > tr:hover {
       background-color: #1d2936;
+    }
+  }
+
+  div.marketorders {
+    background-color: #080808;
+
+    table.ordertable tr {
+      border-bottom: 1px solid #131313;
     }
   }
 

--- a/client/webserver/site/src/css/settings.scss
+++ b/client/webserver/site/src/css/settings.scss
@@ -1,0 +1,24 @@
+div.settings {
+  width: 500px;
+
+  & > div {
+    position: relative;
+    padding: 10px;
+    border-bottom: 1px solid #7777;
+  }
+
+  & > div:first-child {
+    border-top: 1px solid #7777;
+  }
+
+  & > div.form-check {
+    padding-left: 35px;
+  }
+}
+
+span.settings-gear {
+  display: inline-block;
+  font-size: 40px;
+  opacity: 0.6;
+  margin: 10px;
+}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,11 +8,14 @@
   <link rel="icon" href="/img/favicon.png?v=MQq4VTue">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=Ueawg" rel="stylesheet">
+  <link href="/css/style.css?v=Ueawh" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
-  <div class="poke-note" id="pokeNote">
-    <span data-tmpl="note"></span>
+  <div class="popup-notes" id="popupNotes">
+    <span data-tmpl="note">
+      <div class="note-indicator d-inline-block" data-tmpl="indicator"></div>
+      <span data-tmpl="text"></span>
+    </span>
   </div>
   <div id="tooltip" class="flex-center"></div>
   {{template "header" .}}
@@ -31,30 +34,11 @@
 
     <div class="d-inline-block position-relative{{if not $authed}} d-hide{{end}}" id="noteMenuEntry">
       <span class="ico-bell fs20 hoverbright" id="noteBell"></span>
-      <div class="note-indicator" id="noteIndicator"></div>
-      <div id="noteBox" class="pl-2 pb-2">
-        <div class="icon fs20 ico-bell p-1"></div>
-        <span class="fs17 demi hoverbright">Notifications</span><br>
-        <div id="noteList">
-          <div id="noteTemplate" class="note fs14 p-2">
-            <div class="d-flex justify-content-center align-items-center px-1">
-              <div class="note-indicator d-inline-block mr-2"></div>
-              <div class="note-subject flex-grow-1 d-inline-block fs16 demi mb-1"></div>
-              <div class="note-time fs14 pr-2"></div> ago
-            </div>
-            <div class="note-details px-2"></div>
-          </div>
-        </div>
-      </div>
+      <div id="noteIndicator" class="d-hide"></div>
     </div>
 
     <div class="d-inline-block position-relative{{if not $authed}} d-hide{{end}}" id="profileMenuEntry">
       <span class="ico-profile fs20 hoverbright" id="profileIcon"></span>
-      <div id="profileBox" class="pl-2 pt-1 pb-2 fs15">
-        <div class="icon fs20 ico-profile p-1"></div>
-        <span class="demi hoverbright" id="profileSignout">Sign Out</span><br>
-        <a href="/orders" class="demi hoverbright plainlink">Order History</a>
-      </div>
     </div>
 
     <a href="/settings" class="ico-settings hoverbright fs24"></a>
@@ -63,11 +47,45 @@
   <div id="loader" class="fill-abs flex-center d-hide">
     <div class="ico-spinner spinner"></div>
   </div>
+
+  <div id="noteBox" class="d-hide">
+    <div class="icon fs20 ico-bell p-1" id="innerNoteIcon"></div>
+    <div class="header d-flex align-items-center justify-content-start fs17 demi hoverbright px-3 py-2">
+      <div id="noteCat" class="active">Notifications</div>
+      <div id="pokeCat" >Recent Activity</div>
+    </div>
+    <div id="noteList" class="flex-grow-1 stylish-overflow">
+      <div id="noteTmpl" class="note firstview p-2">
+        <div class="d-flex justify-content-center align-items-center px-1">
+          <div class="note-indicator d-inline-block mr-2"></div>
+          <div class="note-subject flex-grow-1 d-inline-block fs16 demi"></div>
+          <span class="note-time pr-2"></span>
+        </div>
+        <div class="note-details fs15 px-3"></div>
+      </div>
+    </div>
+    <div id="pokeList" class="d-hide flex-grow-1 stylish-overflow">
+      <div id="pokeTmpl" class="note fs15 p-2">
+        <div class="d-flex justify-content-center align-items-center px-1">
+          <div class="flex-grow-1 d-inline-block fs16" data-tmpl="dateTime"></div>
+          <span class="note-time"></span>
+        </div>
+        <div class="fs15 px-1" data-tmpl="details"></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="profileBox" class="d-hide">
+    <div class="icon fs20 ico-profile p-1" id="innerProfileIcon"></div>
+    <span class="demi hoverbright pointer" id="profileSignout">Sign Out</span>
+    <a href="/orders" class="demi hoverbright plainlink pt-2">Order History</a>
+  </div>
+
 </header>
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=nntTxe"></script>
+<script src="/js/entry.js?v=nntTxf"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -51,7 +51,7 @@
   <div>
     {{if .}}
     <label for="newWalletPass" class="pt-3 pl-1 mb-0">Wallet Password</label>
-    <div class="fs14 px-1 mb-1">This is the password you have configured with your wallet backend.</div>
+    <div class="fs14 px-1 mb-1">This is the password you have configured with your wallet software.</div>
     {{else}}
     <label for="newWalletPass" class="pt-3 pl-1 mb-1">Wallet Password
       {{if not .}} {{- /* Don't show this for registration (when . is set), since Decred always requires a password. */ -}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -14,14 +14,14 @@
 
     {{- /* SEARCH INPUT */ -}}
     <label class="market-search">
-        <input class="flex-grow-1 pl-2" type="text" id="marketSearch">
-        <span class="ico-search px-1"></span>
+      <div><span class="ico-search px-2"></span></div>
+      <div><input type="text" id="marketSearch" class="w-100 px-1"></div>
     </label>
 
     {{- /* LIST OF EXCHANGE SECTIONS WITH MARKETS */ -}}
     <div id="marketList">
       <div data-tmpl="xc">
-        <div class="fs16 py-1 pl-2 bg1" data-tmpl="header">
+        <div class="header fs16 py-1 pl-2 bg1" data-tmpl="header">
           <span class="ico-disconnected" title="disconnected" data-tmpl="disconnected"></span>
         </div>
         <div data-tmpl="mkts">
@@ -57,25 +57,27 @@
           {{- /* BUY ORDER LIST */ -}}
           <div class="marketorders col-7 p-0 bg1">
             <div class="market-header text-center fs14 py-1">Buy Orders</div>
-            <table class="ordertable bg0">
-              {{block "thead" .}}
-              <thead>
-                <tr>
-                  <th class="text-left pl-2">Quantity</th>
-                  <th class="text-right pr-2">Rate</th>
-                  <th class="text-right pr-2">Epoch</th>
-                </tr>
-              </thead>
-              {{end}}
-              <tbody id="buyRows">
-                {{- /* This row is used by the app as a template. */ -}}
-                <tr id="rowTemplate">
-                  <td class="text-left pl-2" data-type="qty">-</td>
-                  <td class="text-right pr-2" data-type="rate">-</td>
-                  <td class="text-right pr-3" data-type="epoch"></td>
-                </tr>
-              </tbody>
-            </table>
+            <div class="max-h-100 stylish-overflow">
+              <table class="ordertable">
+                {{block "thead" .}}
+                <thead>
+                  <tr>
+                    <th class="text-left pl-2">Quantity</th>
+                    <th class="text-right pr-2">Rate</th>
+                    <th class="text-right pr-2">Epoch</th>
+                  </tr>
+                </thead>
+                {{end}}
+                <tbody id="buyRows">
+                  {{- /* This row is used by the app as a template. */ -}}
+                  <tr id="rowTemplate">
+                    <td class="text-left pl-2" data-type="qty">-</td>
+                    <td class="text-right pr-2" data-type="rate">-</td>
+                    <td class="text-right pr-3" data-type="epoch"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
 
           {{- /* ORDER PANEL */ -}}
@@ -272,10 +274,12 @@
           {{- /* SELL ORDER LIST */ -}}
           <div class="marketorders col-7 p-0 bg1">
             <div class="market-header text-center fs14 py-1">Sell Orders</div>
-            <table class="ordertable bg0">
-              {{template "thead"}}
-              <tbody id="sellRows"></tbody>
-            </table>
+            <div class="max-h-100 stylish-overflow">
+              <table class="ordertable">
+                {{template "thead"}}
+                <tbody id="sellRows"></tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -2,17 +2,29 @@
 {{template "top" .}}
 <div id="main" data-handler="settings" class="main align-items-center justify-content-center flex-column">
 
-  <div class="d-inline-block">
+  <span class="settings-gear ico-settings"></span>
+
+  <div class="settings">
     <div class="form-check">
       <input class="form-check-input" type="checkbox" value="" id="darkMode"{{if .UserInfo.DarkMode}} checked{{end}}>
       <label class="form-check-label" for="darkMode">
         Dark Mode
       </label>
     </div>
-    <div class="mt-2 {{if not .UserInfo.Authed}} d-hide{{end}}">
-      <button id="addADex" class="col bg2 selected">Add a DEX</button>
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" value="" id="showPokes"{{if .UserInfo.ShowPopups}} checked{{end}}>
+      <label class="form-check-label" for="showPokes">
+        Show pop-up notifications
+      </label>
     </div>
-    <div class="pt-2">Build ID: <span id="commitHash" class="mono"></span></div>
+    <div{{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+      <p>
+        The Decred DEX Client supports simultaneous use of any number of DEX
+        servers.
+      </p>
+      <button id="addADex" class="bg2 selected">Add a DEX</button>
+    </div>
+    <div>Build ID: <span id="commitHash" class="mono"></span></div>
   </div>
 
   {{- /* POP-UP FORMS */ -}}

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -540,8 +540,7 @@ export default class Application {
     this.pokes.push(note)
     while (this.pokes.length > noteCacheSize) this.pokes.shift()
     const el = this.makePoke(note)
-    const noteList = this.page.pokeList
-    this.prependListElement(noteList, note, el)
+    this.prependListElement(this.page.pokeList, note, el)
   }
 
   prependNoteElement (note) {
@@ -552,7 +551,7 @@ export default class Application {
     this.prependListElement(noteList, note, el)
     this.storeNotes()
     // Set the indicator color.
-    if (this.notes.length === 0 || (Doc.isDisplayed(this.page.noteBox) && Doc.isDisplayed(this.page.noteList))) return
+    if (this.notes.length === 0 || (Doc.isDisplayed(this.page.noteBox) && Doc.isDisplayed(noteList))) return
     var unacked = 0
     const severity = this.notes.reduce((s, note) => {
       if (!note.acked) unacked++

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -102,6 +102,11 @@ export default class Doc {
     return el.classList.contains('d-hide')
   }
 
+  /* isDisplayed returns true if the specified element is not hidden */
+  static isDisplayed (el) {
+    return !el.classList.contains('d-hide')
+  }
+
   /*
    * animate runs the supplied function, which should be a "progress" function
    * accepting one argument. The progress function will be called repeatedly

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -19,8 +19,11 @@ export default class SettingsPage extends BasePage {
       'dexAddrForm', 'dexAddr', 'certFile', 'selectedCert', 'removeCert', 'addCert',
       'submitDEXAddr', 'dexAddrErr',
       // Form to confirm DEX registration and pay fee
-      'forms', 'confirmRegForm', 'feeDisplay', 'appPass', 'submitConfirm', 'regErr'
+      'forms', 'confirmRegForm', 'feeDisplay', 'appPass', 'submitConfirm', 'regErr',
+      // Others
+      'showPokes'
     ])
+
     Doc.bind(page.darkMode, 'click', () => {
       State.dark(page.darkMode.checked)
       if (page.darkMode.checked) {
@@ -29,6 +32,13 @@ export default class SettingsPage extends BasePage {
         document.body.classList.remove('dark')
       }
     })
+
+    Doc.bind(page.showPokes, 'click', () => {
+      const show = page.showPokes.checked
+      State.setCookie('popups', show ? '1' : '0')
+      app.showPopups = show
+    })
+
     page.commitHash.textContent = app.commitHash.substring(0, 7)
     Doc.bind(page.addADex, 'click', () => this.showForm(page.dexAddrForm))
     Doc.bind(page.certFile, 'change', () => this.onCertFileChange())

--- a/client/webserver/site/src/js/state.js
+++ b/client/webserver/site/src/js/state.js
@@ -1,5 +1,6 @@
 const darkModeCK = 'darkMode'
 const authCK = 'dexauth'
+const popupsCK = 'popups'
 
 // State is a set of static methods for working with the user state. It has
 // utilities for setting and retrieving cookies and storing user configuration
@@ -70,3 +71,4 @@ export default class State {
 
 // If the dark-mode cookie is not set, set it to dark mode on.
 if (State.getCookie(darkModeCK) === null) State.setCookie(darkModeCK, '1')
+if (State.getCookie(popupsCK) === null) State.setCookie(popupsCK, '1')

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -42,6 +42,8 @@ const (
 	darkModeCK = "darkMode"
 	// authCK is the authorization token cookie key.
 	authCK = "dexauth"
+	// popupsCK is the cookie key for the user's preference for showing popups.
+	popupsCK = "popups"
 	// ctxKeyUserInfo is used in the authorization middleware for saving user
 	// info in http request contexts.
 	ctxKeyUserInfo = contextKey("userinfo")
@@ -376,8 +378,9 @@ func readPost(w http.ResponseWriter, r *http.Request, thing interface{}) bool {
 // and cookies.
 type userInfo struct {
 	*core.User
-	Authed   bool
-	DarkMode bool
+	Authed     bool
+	DarkMode   bool
+	ShowPopups bool
 }
 
 // Extract the userInfo from the request context.


### PR DESCRIPTION
The note bell gets a number instead of a dot. All notifications > POKE now show in the poke notes (renamed to popup notes). POKE-severity notification history is now available as through the bell dropdown as a "Recent Activity" feed, but is not persistent across sessions. 

Up to 100 notifications will be shown in the bell dropdown now (used to be 10).

The popup notifications can now be disabled on the settings page. Default is on.

Settings page is given a proper layout.

A handful of other CSS tweaks.

<img src="https://user-images.githubusercontent.com/6109680/95743975-3887a080-0c58-11eb-96b9-0a9a3186ce48.png" width="400">

<img src="https://user-images.githubusercontent.com/6109680/95744156-86040d80-0c58-11eb-9071-980627e78746.png" width="400">




