### PR TITLE
client/core: split locked balances in categories

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -159,10 +159,8 @@ type Balance struct {
 	// Immature is the balance that is not ready, but will be after some
 	// confirmations.
 	Immature uint64 `json:"immature"`
-	// Locked is the balance that that is currently locked for swap, but
-	// not actually swapped yet.
-	// TODO: this may actually be more than the balance locked for swap,
-	// if user manually locks some coins for example.
+	// Locked is the total amount locked in the wallet which includes but
+	// is not limited to funds locked for swap but not actually swapped yet.
 	Locked uint64 `json:"locked"`
 }
 

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -161,6 +161,8 @@ type Balance struct {
 	Immature uint64 `json:"immature"`
 	// Locked is the balance that that is currently locked for swap, but
 	// not actually swapped yet.
+	// TODO: this may actually be more than the balance locked for swap,
+	// if user manually locks some coins for example.
 	Locked uint64 `json:"locked"`
 }
 

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -181,6 +181,9 @@ func (t *trackedTrade) coreOrderInternal() *Order {
 // lockedAmount is the total value of all coins currently locked for this trade.
 // Returns the value sum of the initial funding coins if no swap has been sent,
 // otherwise, the value of the locked change coin is returned.
+// NOTE: This amount only applies to the wallet from which swaps are sent. This
+// is the BASE asset wallet for a SELL order and the QUOTE asset wallet for a
+// BUY order.
 // lockedAmount should be called with the mtx >= RLocked.
 func (t *trackedTrade) lockedAmount() (locked uint64) {
 	if t.coinsLocked { // implies no swap has been sent
@@ -650,9 +653,11 @@ func (t *trackedTrade) activeMatches() []*matchTracker {
 }
 
 // unspentContractAmounts returns the total amount locked in unspent swaps.
+// NOTE: This amount only applies to the wallet from which swaps are sent. This
+// is the BASE asset wallet for a SELL order and the QUOTE asset wallet for a
+// BUY order.
+// unspentContractAmounts should be called with the mtx >= RLocked.
 func (t *trackedTrade) unspentContractAmounts() (amount uint64) {
-	t.mtx.RLock()
-	defer t.mtx.RUnlock()
 	swapSentFromQuoteAsset := t.fromAssetID == t.Quote()
 	for _, match := range t.matches {
 		side, status := match.Match.Side, match.Match.Status

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -170,11 +170,27 @@ func (t *trackedTrade) coreOrder() *Order {
 func (t *trackedTrade) coreOrderInternal() *Order {
 	corder := coreOrderFromTrade(t.Order, t.metaData)
 	corder.Epoch = t.dc.marketEpoch(t.mktID, t.Prefix().ServerTime)
+	corder.LockedAmt = t.lockedAmount()
 
 	for _, mt := range t.matches {
 		corder.Matches = append(corder.Matches, matchFromMetaMatch(&mt.MetaMatch))
 	}
 	return corder
+}
+
+// lockedAmount is the total value of all coins currently locked for this trade.
+// Returns the value sum of the initial funding coins if no swap has been sent,
+// otherwise, the value of the locked change coin is returned.
+// lockedAmount should be called with the mtx >= RLocked.
+func (t *trackedTrade) lockedAmount() (locked uint64) {
+	if t.coinsLocked { // implies no swap has been sent
+		for _, coin := range t.coins {
+			locked += coin.Value()
+		}
+	} else if t.changeLocked && t.change != nil { // change may be returned but unlocked if the last swap has been sent
+		locked = t.change.Value()
+	}
+	return
 }
 
 // token is a shortened representation of the order ID.
@@ -634,11 +650,7 @@ func (t *trackedTrade) activeMatches() []*matchTracker {
 }
 
 // unspentContractAmounts returns the total amount locked in unspent swaps.
-func (t *trackedTrade) unspentContractAmounts(assetID uint32) (amount uint64) {
-	if t.fromAssetID != assetID {
-		// Only swaps sent from the specified assetID should count.
-		return 0
-	}
+func (t *trackedTrade) unspentContractAmounts() (amount uint64) {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 	swapSentFromQuoteAsset := t.fromAssetID == t.Quote()

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -188,7 +188,7 @@ type Order struct {
 	Canceled     bool              `json:"canceled"`
 	FeesPaid     *FeeBreakdown     `json:"feesPaid"`
 	FundingCoins []dex.Bytes       `json:"fundingCoins"`
-	LockedAmt    uint64
+	LockedAmt    uint64            `json:"lockedamt"`
 	Rate         uint64            `json:"rate"` // limit only
 	TimeInForce  order.TimeInForce `json:"tif"`  // limit only
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -71,6 +71,10 @@ type WalletForm struct {
 // amounts in addition to other balance details stored in db.
 type WalletBalance struct {
 	*db.Balance
+	// OrderLocked is the total amount of funds that is currently locked
+	// for swap, but not actually swapped yet. This amount is also included
+	// in the `Locked` balance value.
+	OrderLocked uint64 `json:"orderlocked"`
 	// ContractLocked is the total amount of funds locked in unspent
 	// (i.e. unredeemed / unrefunded) swap contracts.
 	ContractLocked uint64 `json:"contractlocked"`
@@ -184,6 +188,7 @@ type Order struct {
 	Canceled     bool              `json:"canceled"`
 	FeesPaid     *FeeBreakdown     `json:"feesPaid"`
 	FundingCoins []dex.Bytes       `json:"fundingCoins"`
+	LockedAmt    uint64
 	Rate         uint64            `json:"rate"` // limit only
 	TimeInForce  order.TimeInForce `json:"tif"`  // limit only
 }
@@ -253,15 +258,17 @@ func coreOrderFromTrade(ord order.Order, metaData *db.OrderMetaData) *Order {
 
 // Market is market info.
 type Market struct {
-	Name            string   `json:"name"`
-	BaseID          uint32   `json:"baseid"`
-	BaseSymbol      string   `json:"basesymbol"`
-	QuoteID         uint32   `json:"quoteid"`
-	QuoteSymbol     string   `json:"quotesymbol"`
-	EpochLen        uint64   `json:"epochlen"`
-	StartEpoch      uint64   `json:"startepoch"`
-	MarketBuyBuffer float64  `json:"buybuffer"`
-	Orders          []*Order `json:"orders"`
+	Name             string   `json:"name"`
+	BaseID           uint32   `json:"baseid"`
+	BaseSymbol       string   `json:"basesymbol"`
+	QuoteID          uint32   `json:"quoteid"`
+	QuoteSymbol      string   `json:"quotesymbol"`
+	EpochLen         uint64   `json:"epochlen"`
+	StartEpoch       uint64   `json:"startepoch"`
+	MarketBuyBuffer  float64  `json:"buybuffer"`
+	Orders           []*Order `json:"orders"`
+	BaseFundsLocked  uint64   `json:"basefundslocked"`
+	QuoteFundsLocked uint64   `json:"quotefundslocked"`
 }
 
 // Display returns an ID string suitable for displaying in a UI.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -258,17 +258,19 @@ func coreOrderFromTrade(ord order.Order, metaData *db.OrderMetaData) *Order {
 
 // Market is market info.
 type Market struct {
-	Name             string   `json:"name"`
-	BaseID           uint32   `json:"baseid"`
-	BaseSymbol       string   `json:"basesymbol"`
-	QuoteID          uint32   `json:"quoteid"`
-	QuoteSymbol      string   `json:"quotesymbol"`
-	EpochLen         uint64   `json:"epochlen"`
-	StartEpoch       uint64   `json:"startepoch"`
-	MarketBuyBuffer  float64  `json:"buybuffer"`
-	Orders           []*Order `json:"orders"`
-	BaseFundsLocked  uint64   `json:"basefundslocked"`
-	QuoteFundsLocked uint64   `json:"quotefundslocked"`
+	Name                string   `json:"name"`
+	BaseID              uint32   `json:"baseid"`
+	BaseSymbol          string   `json:"basesymbol"`
+	QuoteID             uint32   `json:"quoteid"`
+	QuoteSymbol         string   `json:"quotesymbol"`
+	EpochLen            uint64   `json:"epochlen"`
+	StartEpoch          uint64   `json:"startepoch"`
+	MarketBuyBuffer     float64  `json:"buybuffer"`
+	Orders              []*Order `json:"orders"`
+	BaseOrderLocked     uint64   `json:"baseorderlocked"`
+	QuoteOrderLocked    uint64   `json:"quoteorderlocked"`
+	BaseContractLocked  uint64   `json:"basecontractlocked"`
+	QuoteContractLocked uint64   `json:"quotecontractlocked"`
 }
 
 // Display returns an ID string suitable for displaying in a UI.


### PR DESCRIPTION
Resolves #735.

Compute the following locked amounts for each DEX market (across all active orders):
- `BaseOrderLocked` and `QuoteOrderLocked` - total funds currently locked for swap, but not actually swapped yet.
- `BaseContractLocked` and `QuoteContractLocked` - total funds locked in unspent (i.e. unredeemed / unrefunded) swap contracts.

Also adds an `xcWallet.balance.OrderLocked` to store the total amount of funds locked for swaps in a wallet, for all DEX markets.

Noting that while the new `xcWallet.balance.OrderLocked` field reports the total amount locked by the DEX client for order funding purposes, the existing `xcWallet.balance.Locked` amount continues to report the **total amount locked in a wallet** i.e. funds locked by `Core` for order funding purposes AND funds locked outside of the DEX client.