### PR TITLE
client/core: fix resendPendingRequest sending wrong redeem coin

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3516,7 +3516,7 @@ func handleRevokeMatchMsg(c *Core, dc *dexConnection, msg *msgjson.Message) erro
 
 	tracker, _, _ := dc.findOrder(oid)
 	if tracker == nil {
-		return fmt.Errorf("no order found with id %s", oid.String())
+		return fmt.Errorf("no order found with id %s (not an error if you've completed your side of the swap)", oid.String())
 	}
 
 	if len(revocation.MatchID) != order.MatchIDSize {

--- a/client/core/status.go
+++ b/client/core/status.go
@@ -375,12 +375,12 @@ func resolveServerMissedMakerRedeem(dc *dexConnection, trade *trackedTrade, matc
 // defer to resendPendingRequests to handle it in the next tick.
 func resolveServerMissedTakerRedeem(dc *dexConnection, trade *trackedTrade, match *matchTracker, srvData *msgjson.MatchStatusResult) {
 	logID := statusResolutionID(dc, trade, match)
-	// If we're not the Taker, we can't do anything about this.
-	if match.Match.Side != order.Taker {
-		dc.log.Errorf("server reporting no taker redeem, but they've already sent us the redemption info. self-revoking. %s", logID)
+	// If we're the Maker, we really are done. The server is in MakerRedeemed as
+	// it's waiting on the taker.
+	if match.Match.Side == order.Maker {
 		return
 	}
-	// We are the taker, if we don't have an ack from the server, this will be
+	// We are the taker. If we don't have an ack from the server, this will be
 	// picked up in resendPendingRequests during the next tick.
 	if len(match.MetaData.Proof.Auth.RedeemSig) == 0 {
 		return

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -992,7 +992,7 @@ func (c *Core) resendPendingRequests(t *trackedTrade) error {
 		if len(swapCoinID) != 0 && len(auth.InitSig) == 0 { // resend pending `init` request
 			err = c.finalizeSwapAction(t, match, swapCoinID, proof.Script)
 		} else if len(redeemCoinID) != 0 && len(auth.RedeemSig) == 0 { // resend pending `redeem` request
-			err = c.finalizeRedeemAction(t, match, swapCoinID)
+			err = c.finalizeRedeemAction(t, match, redeemCoinID)
 		}
 		if err != nil {
 			errs.addErr(err)

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1119,6 +1119,7 @@ func (client *tClient) init(ctx context.Context) error {
 	client.core, err = New(&Config{
 		DBPath: filepath.Join(tmpDir, fmt.Sprintf("dex_%d.db", cNum)),
 		Net:    dex.Regtest,
+		Logger: dex.StdOutLogger("TCORE", dex.LevelTrace),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
The coins sent with the retried `'redeem'` requests were empty. This fixes
the `finalizeRedeemAction` call to use the redeem coin.

This also removes a misplaced log in `resolveServerMissedTakerRedeem`.
It is not unexpected for the maker to be at `MatchComplete` with the
server at `MakerRedeemed` if the taker hasn't done their `'redeem'`.

In trade_simnet_test.go, set `Core`'s logger in `core.Config`.  Note that
these simnet tests are presently failing due to recent changes on master.