### PR TITLE
server/{auth,db,market,swap}: user order quantity limits

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1948,8 +1948,9 @@ func (dcr *ExchangeWallet) sendMinusFees(addr dcrutil.Address, val, feeRate uint
 	}
 	coins, _, _, _, _, err := dcr.fund(enough)
 	if err != nil {
-		return nil, 0, fmt.Errorf("error funding request for %d DCR to address %s with feeRate %d: %w",
-			val, addr, feeRate, err)
+		valDCR := dcrutil.Amount(val).ToCoin()
+		return nil, 0, fmt.Errorf("unable to send %f DCR to address %s with feeRate %d atoms/byte: %w",
+			valDCR, addr, feeRate, err)
 	}
 	return dcr.sendCoins(addr, coins, val, feeRate, true)
 }
@@ -1964,8 +1965,9 @@ func (dcr *ExchangeWallet) sendRegFee(addr dcrutil.Address, regFee, netFeeRate u
 	}
 	coins, _, _, _, _, err := dcr.fund(enough)
 	if err != nil {
-		return nil, 0, fmt.Errorf("error funding fee of %d DCR to address %s with feeRate %d: %w",
-			regFee, addr, netFeeRate, err)
+		regFeeDCR := dcrutil.Amount(regFee).ToCoin()
+		return nil, 0, fmt.Errorf("unable to pay registration fee of %f DCR to address %s with fee rate of %d atoms/byte: %w",
+			regFeeDCR, addr, netFeeRate, err)
 	}
 	return dcr.sendCoins(addr, coins, regFee, netFeeRate, false)
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2451,7 +2451,7 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	err = dc.signAndRequest(msgOrder, route, result, fundingTxWait+DefaultResponseTimeout)
 	if err != nil {
 		unlockCoins()
-		return nil, 0, fmt.Errorf("new order request with DEX server %v failed: %w", dc.acct.host, err)
+		return nil, 0, fmt.Errorf("new order request with DEX server %v market %v failed: %w", dc.acct.host, mktID, err)
 	}
 
 	// If we encounter an error, perform some basic logging.

--- a/dex/calc/convert.go
+++ b/dex/calc/convert.go
@@ -25,6 +25,9 @@ func BaseToQuote(rate uint64, base uint64) (quote uint64) {
 // and an integer representation of the price rate. That is,
 //    baseAmt = quoteAmt * atomsPerCoin / rate
 func QuoteToBase(rate uint64, quote uint64) (base uint64) {
+	if rate == 0 {
+		return 0 // caller handle rate==0, but don't panic
+	}
 	bigRate := big.NewInt(int64(rate))
 	bigQuote := big.NewInt(int64(quote))
 	bigQuote.Mul(bigQuote, bigAtomsPerCoin)

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -69,6 +69,7 @@ const (
 	AccountNotFoundError              // 50
 	UnpaidAccountError                // 51
 	InvalidRequestError               // 52
+	OrderQuantityTooHigh              // 53
 )
 
 // Routes are destinations for a "payload" of data. The type of data being

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -587,18 +587,6 @@ func (auth *AuthManager) RequestWithTimeout(user account.AccountID, msg *msgjson
 	return auth.request(user, msg, f, expireTimeout, expire)
 }
 
-// SwapAmounts breaks down the quantities of completed swaps in four rough
-// categories: successfully swapped (Swapped), failed with counterparty funds
-// locked for the long/maker lock time (StuckLong), failed with counterparty
-// funds locked for the short/taker lock time (StuckShort), and failed to
-// initiate swap following match with no funds locked in contracts (Spoofed).
-type SwapAmounts struct {
-	Swapped    int64
-	StuckLong  int64
-	StuckShort int64
-	Spoofed    int64
-}
-
 // userSwapAmountHistory retrieves the summary of recent swap amounts for the
 // given user and market. The user should be connected.
 func (auth *AuthManager) userSwapAmountHistory(user account.AccountID, base, quote uint32) *SwapAmounts {

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -616,7 +616,7 @@ const (
 	// this number to get the limit in units of the base asset. This is
 	// potentially a per-market setting instead of an auth constant.
 	InitUserTakerLotLimit = 6
-	AbsTakerLotLimit      = 40
+	AbsTakerLotLimit      = 150
 	BookedLotLimit        = 1200
 
 	// These coefficients are used to compute a user's swap limit adjustment via

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -623,8 +623,8 @@ const (
 	// UserOrderLimitAdjustment based on the cumulative amounts in the different
 	// match outcomes.
 	successWeight    int64 = 2
-	stuckLongWeight  int64 = -6
-	stuckShortWeight int64 = -3
+	stuckLongWeight  int64 = -4
+	stuckShortWeight int64 = -2
 	spoofedWeight    int64 = -1
 )
 

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -34,6 +34,11 @@ func randBytes(l int) []byte {
 	return b
 }
 
+func randomMatchID() (mid order.MatchID) {
+	rand.Read(mid[:])
+	return
+}
+
 type ratioData struct {
 	oidsCompleted  []order.OrderID
 	timesCompleted []int64
@@ -460,7 +465,7 @@ func nextTime() int64 {
 	return t0
 }
 
-func newMatchOutcome(status order.MatchStatus, fail bool, t int64) *db.MatchOutcome {
+func newMatchOutcome(status order.MatchStatus, mid order.MatchID, fail bool, val uint64, t int64) *db.MatchOutcome {
 	switch status {
 	case order.NewlyMatched, order.MakerSwapCast, order.TakerSwapCast:
 		if !fail {
@@ -473,8 +478,10 @@ func newMatchOutcome(status order.MatchStatus, fail bool, t int64) *db.MatchOutc
 	}
 	return &db.MatchOutcome{
 		Status: status,
+		ID:     mid,
 		Fail:   fail,
 		Time:   t,
+		Value:  val,
 	}
 }
 
@@ -487,15 +494,15 @@ func newPreimageResult(miss bool, t int64) *db.PreimageResult {
 
 func setViolations() (wantScore int32) {
 	rig.storage.userMatchOutcomes = []*db.MatchOutcome{
-		newMatchOutcome(order.NewlyMatched, true, nextTime()),
-		newMatchOutcome(order.MatchComplete, false, nextTime()), // success
-		newMatchOutcome(order.NewlyMatched, true, nextTime()),
-		newMatchOutcome(order.MakerSwapCast, true, nextTime()), // noSwapAsTaker at index 3
-		newMatchOutcome(order.TakerSwapCast, true, nextTime()),
-		newMatchOutcome(order.MakerRedeemed, false, nextTime()), // success (for maker)
-		newMatchOutcome(order.MakerRedeemed, true, nextTime()),
-		newMatchOutcome(order.MatchComplete, false, nextTime()), // success
-		newMatchOutcome(order.MatchComplete, false, nextTime()), // success
+		newMatchOutcome(order.NewlyMatched, randomMatchID(), true, 7, nextTime()),
+		newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()), // success
+		newMatchOutcome(order.NewlyMatched, randomMatchID(), true, 7, nextTime()),
+		newMatchOutcome(order.MakerSwapCast, randomMatchID(), true, 7, nextTime()), // noSwapAsTaker at index 3
+		newMatchOutcome(order.TakerSwapCast, randomMatchID(), true, 7, nextTime()),
+		newMatchOutcome(order.MakerRedeemed, randomMatchID(), false, 7, nextTime()), // success (for maker)
+		newMatchOutcome(order.MakerRedeemed, randomMatchID(), true, 7, nextTime()),
+		newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()), // success
+		newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()), // success
 	}
 	t0 -= 4000
 	rig.storage.userPreimageResults = []*db.PreimageResult{newPreimageResult(true, nextTime())}
@@ -525,7 +532,7 @@ func TestAuthManager_loadUserScore(t *testing.T) {
 
 	// add one NoSwapAsTaker (match inactive at MakerSwapCast)
 	rig.storage.userMatchOutcomes = append(rig.storage.userMatchOutcomes,
-		newMatchOutcome(order.MakerSwapCast, true, nextTime()))
+		newMatchOutcome(order.MakerSwapCast, randomMatchID(), true, 7, nextTime()))
 	wantScore += noSwapAsTakerScore
 
 	score, err = rig.mgr.loadUserScore(user.acctID)
@@ -547,10 +554,10 @@ func TestAuthManager_loadUserScore(t *testing.T) {
 			name: "negative",
 			user: user.acctID,
 			matchOutcomes: []*db.MatchOutcome{
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
 			},
 			wantScore: -4,
 		},
@@ -564,10 +571,10 @@ func TestAuthManager_loadUserScore(t *testing.T) {
 			name: "balance",
 			user: user.acctID,
 			matchOutcomes: []*db.MatchOutcome{
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
 			},
 			preimageMisses: []*db.PreimageResult{
 				newPreimageResult(true, nextTime()),
@@ -579,15 +586,15 @@ func TestAuthManager_loadUserScore(t *testing.T) {
 			name: "tipping red",
 			user: user.acctID,
 			matchOutcomes: []*db.MatchOutcome{
-				newMatchOutcome(order.NewlyMatched, true, nextTime()),
-				newMatchOutcome(order.MakerSwapCast, true, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.NewlyMatched, true, nextTime()),
-				newMatchOutcome(order.MakerRedeemed, true, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
-				newMatchOutcome(order.MatchComplete, false, nextTime()),
+				newMatchOutcome(order.NewlyMatched, randomMatchID(), true, 7, nextTime()),
+				newMatchOutcome(order.MakerSwapCast, randomMatchID(), true, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.NewlyMatched, randomMatchID(), true, 7, nextTime()),
+				newMatchOutcome(order.MakerRedeemed, randomMatchID(), true, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
+				newMatchOutcome(order.MatchComplete, randomMatchID(), false, 7, nextTime()),
 			},
 			preimageMisses: []*db.PreimageResult{
 				newPreimageResult(true, nextTime()),

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -19,6 +19,7 @@ import (
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/dex/order"
+	ordertest "decred.org/dcrdex/dex/order/test"
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/comms"
 	"decred.org/dcrdex/server/db"
@@ -34,10 +35,7 @@ func randBytes(l int) []byte {
 	return b
 }
 
-func randomMatchID() (mid order.MatchID) {
-	rand.Read(mid[:])
-	return
-}
+var randomMatchID = ordertest.RandomMatchID
 
 type ratioData struct {
 	oidsCompleted  []order.OrderID

--- a/server/auth/latest.go
+++ b/server/auth/latest.go
@@ -4,40 +4,52 @@
 package auth
 
 import (
+	"bytes"
 	"sort"
 	"sync"
+
+	"decred.org/dcrdex/dex/order"
 )
 
-type stampedFlag struct {
+type matchOutcome struct {
+	// sorting is done by time and match ID
 	time int64
-	flag int64
+	mid  order.MatchID
+
+	// match outcome and value
+	outcome     Violation
+	base, quote uint32 // market
+	value       uint64
 }
 
-func lessByTime(ti, tj *stampedFlag) bool {
+func lessByTimeThenMID(ti, tj *matchOutcome) bool {
+	if ti.time == tj.time {
+		return bytes.Compare(ti.mid[:], tj.mid[:]) < 0 // ascending (smaller ID first)
+	}
 	return ti.time < tj.time // ascending (newest last in slice)
 }
 
-type latest struct {
+type latestMatchOutcomes struct {
 	mtx      sync.Mutex
 	cap      int16
-	stampeds []*stampedFlag
+	outcomes []*matchOutcome
 }
 
-func newLatest(cap int16) *latest {
-	return &latest{
+func newLatestMatchOutcomes(cap int16) *latestMatchOutcomes {
+	return &latestMatchOutcomes{
 		cap:      cap,
-		stampeds: make([]*stampedFlag, 0, cap+1), // cap+1 since an old item is popped *after* a new one is pushed
+		outcomes: make([]*matchOutcome, 0, cap+1), // cap+1 since an old item is popped *after* a new one is pushed
 	}
 }
 
-func (la *latest) add(t *stampedFlag) {
+func (la *latestMatchOutcomes) add(mo *matchOutcome) {
 	la.mtx.Lock()
 	defer la.mtx.Unlock()
 
 	// Use sort.Search and insert it at the right spot.
-	n := len(la.stampeds)
+	n := len(la.outcomes)
 	i := sort.Search(n, func(i int) bool {
-		return lessByTime(la.stampeds[n-1-i], t)
+		return lessByTimeThenMID(la.outcomes[n-1-i], mo)
 	})
 	if i == int(la.cap) /* i == n && n == int(la.cap) */ {
 		// The new one is the oldest/smallest, but already at capacity.
@@ -45,20 +57,103 @@ func (la *latest) add(t *stampedFlag) {
 	}
 	// Insert at proper location.
 	i = n - i // i-1 is first location that stays
-	la.stampeds = append(la.stampeds[:i], append([]*stampedFlag{t}, la.stampeds[i:]...)...)
+	la.outcomes = append(la.outcomes[:i], append([]*matchOutcome{mo}, la.outcomes[i:]...)...)
 
 	// Pop one stamped if the slice was at capacity prior to pushing the new one.
-	if len(la.stampeds) > int(la.cap) {
+	if len(la.outcomes) > int(la.cap) {
 		// pop front, the oldest stamped
-		la.stampeds[0] = nil // avoid memory leak
-		la.stampeds = la.stampeds[1:]
+		la.outcomes[0] = nil // avoid memory leak
+		la.outcomes = la.outcomes[1:]
 	}
 }
 
-func (la *latest) bin() map[int64]int64 {
-	bins := make(map[int64]int64)
-	for _, th := range la.stampeds {
-		bins[th.flag]++
+func (la *latestMatchOutcomes) binViolations() map[Violation]int64 {
+	bins := make(map[Violation]int64)
+	for _, mo := range la.outcomes {
+		bins[mo.outcome]++
 	}
 	return bins
+}
+
+func (sa *SwapAmounts) addAmt(v Violation, value int64) {
+	switch v {
+	case ViolationSwapSuccess:
+		sa.Swapped += value
+	case ViolationNoSwapAsTaker:
+		sa.StuckLong += value
+	case ViolationNoRedeemAsMaker:
+		sa.StuckShort += value
+	case ViolationNoSwapAsMaker:
+		sa.Spoofed += value
+	}
+}
+
+func (la *latestMatchOutcomes) mktSwapAmounts(base, quote uint32) *SwapAmounts {
+	sa := new(SwapAmounts)
+	for _, mo := range la.outcomes {
+		if mo.base == base && mo.quote == quote {
+			sa.addAmt(mo.outcome, int64(mo.value))
+		}
+	}
+	return sa
+}
+
+type preimageOutcome struct {
+	time int64
+	oid  order.OrderID
+	miss bool
+}
+
+func lessByTimeThenOID(ti, tj *preimageOutcome) bool {
+	if ti.time == tj.time {
+		return bytes.Compare(ti.oid[:], tj.oid[:]) < 0 // ascending (smaller ID first)
+	}
+	return ti.time < tj.time // ascending (newest last in slice)
+}
+
+type latestPreimageOutcomes struct {
+	mtx      sync.Mutex
+	cap      int16
+	outcomes []*preimageOutcome
+}
+
+func newLatestPreimageOutcomes(cap int16) *latestPreimageOutcomes {
+	return &latestPreimageOutcomes{
+		cap:      cap,
+		outcomes: make([]*preimageOutcome, 0, cap+1), // cap+1 since an old item is popped *after* a new one is pushed
+	}
+}
+
+func (la *latestPreimageOutcomes) add(po *preimageOutcome) {
+	la.mtx.Lock()
+	defer la.mtx.Unlock()
+
+	// Use sort.Search and insert it at the right spot.
+	n := len(la.outcomes)
+	i := sort.Search(n, func(i int) bool {
+		return lessByTimeThenOID(la.outcomes[n-1-i], po)
+	})
+	if i == int(la.cap) /* i == n && n == int(la.cap) */ {
+		// The new one is the oldest/smallest, but already at capacity.
+		return
+	}
+	// Insert at proper location.
+	i = n - i // i-1 is first location that stays
+	la.outcomes = append(la.outcomes[:i], append([]*preimageOutcome{po}, la.outcomes[i:]...)...)
+
+	// Pop one stamped if the slice was at capacity prior to pushing the new one.
+	if len(la.outcomes) > int(la.cap) {
+		// pop front, the oldest stamped
+		la.outcomes[0] = nil // avoid memory leak
+		la.outcomes = la.outcomes[1:]
+	}
+}
+
+func (la *latestPreimageOutcomes) misses() (misses int32) {
+	for _, th := range la.outcomes {
+		if th.miss {
+			misses++
+		}
+	}
+	return
 }

--- a/server/auth/latest.go
+++ b/server/auth/latest.go
@@ -83,10 +83,18 @@ func (sa *SwapAmounts) addAmt(v Violation, value int64) {
 		sa.StuckLong += value
 	case ViolationNoRedeemAsMaker:
 		sa.StuckShort += value
-	case ViolationNoSwapAsMaker:
+	case ViolationNoSwapAsMaker, ViolationPreimageMiss: // ! preimage misses are presently in preimageOutcome
 		sa.Spoofed += value
 	}
 }
+
+// func (la *latestMatchOutcomes) swapAmounts() *SwapAmounts {
+// 	sa := new(SwapAmounts)
+// 	for _, mo := range la.outcomes {
+// 		sa.addAmt(mo.outcome, int64(mo.value)) // must be same units (e.g. lots)!
+// 	}
+// 	return sa
+// }
 
 func (la *latestMatchOutcomes) mktSwapAmounts(base, quote uint32) *SwapAmounts {
 	sa := new(SwapAmounts)

--- a/server/auth/latest.go
+++ b/server/auth/latest.go
@@ -75,6 +75,18 @@ func (la *latestMatchOutcomes) binViolations() map[Violation]int64 {
 	return bins
 }
 
+// SwapAmounts breaks down the quantities of completed swaps in four rough
+// categories: successfully swapped (Swapped), failed with counterparty funds
+// locked for the long/maker lock time (StuckLong), failed with counterparty
+// funds locked for the short/taker lock time (StuckShort), and failed to
+// initiate swap following match with no funds locked in contracts (Spoofed).
+type SwapAmounts struct {
+	Swapped    int64
+	StuckLong  int64
+	StuckShort int64
+	Spoofed    int64
+}
+
 func (sa *SwapAmounts) addAmt(v Violation, value int64) {
 	switch v {
 	case ViolationSwapSuccess:

--- a/server/auth/latest_test.go
+++ b/server/auth/latest_test.go
@@ -1,14 +1,17 @@
 package auth
 
 import (
+	"bytes"
 	"math/rand"
 	"sort"
 	"testing"
+
+	"decred.org/dcrdex/dex/order"
 )
 
-func Test_latest(t *testing.T) {
+func Test_latestMatchOutcomes(t *testing.T) {
 	cap := int16(10)
-	ordList := newLatest(cap)
+	ordList := newLatestMatchOutcomes(cap)
 
 	randTime := func() int64 {
 		return 1600477631 + rand.Int63n(987654)
@@ -19,8 +22,9 @@ func Test_latest(t *testing.T) {
 	for i := 0; i < N; i++ {
 		t := randTime()
 		times[i] = t
-		ordList.add(&stampedFlag{
+		ordList.add(&matchOutcome{
 			time: t,
+			// zero OrderID
 		})
 	}
 
@@ -28,16 +32,105 @@ func Test_latest(t *testing.T) {
 		return times[i] < times[j] // ascending
 	})
 
-	if len(ordList.stampeds) != int(cap) {
-		t.Fatalf("latest list is length %d, wanted %d", len(ordList.stampeds), cap)
+	if len(ordList.outcomes) != int(cap) {
+		t.Fatalf("latest list is length %d, wanted %d", len(ordList.outcomes), cap)
 	}
 
 	// ensure the ordList contains the N most recent items, with the oldest at
 	// the front of the list.
 	wantStampedTimes := times[len(times)-int(cap):] // grab the last cap items in the sorted ground truth list
-	for i, st := range ordList.stampeds {
+	for i, st := range ordList.outcomes {
 		if st.time != wantStampedTimes[i] {
 			t.Fatalf("Time #%d is %d, wanted %d", i, st.time, wantStampedTimes[i])
+		}
+	}
+
+	// Add 3 orders with the same time, different order IDs.
+	nextTime := 1 + wantStampedTimes[len(wantStampedTimes)-1] // new
+	mids := []order.MatchID{randomMatchID(), randomMatchID(), randomMatchID()}
+	for i := range mids {
+		ordList.add(&matchOutcome{
+			time: nextTime,
+			mid:  mids[i],
+		})
+	}
+
+	sort.Slice(mids, func(i, j int) bool {
+		return bytes.Compare(mids[i][:], mids[j][:]) < 0
+	})
+
+	if len(ordList.outcomes) != int(cap) {
+		t.Fatalf("latest list is length %d, wanted %d", len(ordList.outcomes), cap)
+	}
+
+	// Verify that the last three outcomes are the three we just added with the
+	// newest time stamp, and that they are storted according to oid.
+	for i, oc := range ordList.outcomes[cap-3 : cap] {
+		if oc.mid != mids[i] {
+			t.Errorf("Wrong mid #%d. got %v, want %v", i, oc.mid, mids[i])
+		}
+	}
+}
+
+func Test_latestPreimageOutcomes(t *testing.T) {
+	cap := int16(10)
+	ordList := newLatestPreimageOutcomes(cap)
+
+	randTime := func() int64 {
+		return 1600477631 + rand.Int63n(987654)
+	}
+
+	N := int(cap + 20)
+	times := make([]int64, N)
+	for i := 0; i < N; i++ {
+		t := randTime()
+		times[i] = t
+		ordList.add(&preimageOutcome{
+			time: t,
+			// zero OrderID
+		})
+	}
+
+	sort.Slice(times, func(i, j int) bool {
+		return times[i] < times[j] // ascending
+	})
+
+	if len(ordList.outcomes) != int(cap) {
+		t.Fatalf("latest list is length %d, wanted %d", len(ordList.outcomes), cap)
+	}
+
+	// ensure the ordList contains the N most recent items, with the oldest at
+	// the front of the list.
+	wantStampedTimes := times[len(times)-int(cap):] // grab the last cap items in the sorted ground truth list
+	for i, st := range ordList.outcomes {
+		if st.time != wantStampedTimes[i] {
+			t.Fatalf("Time #%d is %d, wanted %d", i, st.time, wantStampedTimes[i])
+		}
+	}
+
+	// Add 3 orders with the same time, different order IDs.
+	nextTime := 1 + wantStampedTimes[len(wantStampedTimes)-1] // new
+	oids := []order.OrderID{randomOrderID(), randomOrderID(), randomOrderID()}
+	for i := range oids {
+		ordList.add(&preimageOutcome{
+			time: nextTime,
+			oid:  oids[i],
+		})
+	}
+
+	sort.Slice(oids, func(i, j int) bool {
+		return bytes.Compare(oids[i][:], oids[j][:]) < 0
+	})
+
+	if len(ordList.outcomes) != int(cap) {
+		t.Fatalf("latest list is length %d, wanted %d", len(ordList.outcomes), cap)
+	}
+
+	// Verify that the last three outcomes are the three we just added with the
+	// newest time stamp, and that they are storted according to oid.
+	for i, oc := range ordList.outcomes[cap-3 : cap] {
+		if oc.oid != oids[i] {
+			t.Errorf("Wrong oid #%d. got %v, want %v", i, oc.oid, oids[i])
 		}
 	}
 }

--- a/server/book/book.go
+++ b/server/book/book.go
@@ -156,7 +156,8 @@ func (b *Book) Order(oid order.OrderID) *order.LimitOrder {
 }
 
 // UserOrderTotals returns the total amount in booked orders and the number of
-// booked orders, for both the buy and sell sides of the book.
+// booked orders, for both the buy and sell sides of the book. Both amounts are
+// in units of the base asset, and should be multiples of the market's lot size.
 func (b *Book) UserOrderTotals(user account.AccountID) (buyAmt, sellAmt, buyCount, sellCount uint64) {
 	b.mtx.RLock()
 	buyAmt, buyCount = b.buys.UserOrderTotals(user)

--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -125,7 +125,7 @@ const (
 	CompletedOrAtFaultMatchesLastN = `
 		WITH acct (aid) AS ( VALUES($1::BYTEA) )
 
-		SELECT status, (status=4 OR (status=3 AND makerAccount = aid AND takerAccount != aid)) AS success,
+		SELECT matchid, status, quantity, (status=4 OR (status=3 AND makerAccount = aid AND takerAccount != aid)) AS success,
 			GREATEST((epochIdx+1)*epochDur, aContractTime, bContractTime, aRedeemTime, bRedeemTime) AS lastTime
 		FROM %s, acct
 		WHERE takerSell IS NOT NULL      -- exclude cancel order matches

--- a/server/db/driver/pg/internal/orders.go
+++ b/server/db/driver/pg/internal/orders.go
@@ -47,7 +47,7 @@ const (
 		commit, coins, quantity, rate, force, filled
 	FROM %s WHERE status = $1;`
 
-	PreimageResultsLastN = `SELECT (preimage IS NULL AND status=$3) AS preimageMiss, 
+	PreimageResultsLastN = `SELECT oid, (preimage IS NULL AND status=$3) AS preimageMiss, 
 		(epoch_idx+1) * epoch_dur as epochCloseTime   -- when preimages are requested
 	FROM %s -- e.g. dcr_btc.orders_archived
 	WHERE account_id = $1
@@ -187,7 +187,7 @@ const (
 		commit, target_order, status
 	FROM %s WHERE oid = $1;`
 
-	CancelPreimageResultsLastN = `SELECT (preimage IS NULL AND status=$3) AS preimageMiss,  -- orderStatusRevoked
+	CancelPreimageResultsLastN = `SELECT oid, (preimage IS NULL AND status=$3) AS preimageMiss,  -- orderStatusRevoked
 		(epoch_idx+1) * epoch_dur AS epochCloseTime   -- when preimages are requested
 	FROM %s -- e.g. dcr_btc.cancels_archived
 	WHERE account_id = $1

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -753,13 +753,15 @@ func (a *Archiver) PreimageStats(user account.AccountID, lastN int) ([]*db.Preim
 		for rows.Next() {
 			var miss bool
 			var time int64
-			err = rows.Scan(&miss, &time)
+			var oid order.OrderID
+			err = rows.Scan(&oid, &miss, &time)
 			if err != nil {
 				return err
 			}
 			outcomes = append(outcomes, &db.PreimageResult{
 				Miss: miss,
 				Time: time,
+				ID:   oid,
 			})
 		}
 

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -37,10 +37,7 @@ type OrderStatus struct {
 type PreimageResult struct {
 	Miss bool
 	Time int64
-	// NOTE: There can be multiple results with the same time (same epoch) but
-	// since there is unlikely to be a mix of misses and successes in the same
-	// epoch, the sorting ambiguity is acceptable. If that proves to be a
-	// problem, order ID can be added to this struct.
+	ID   order.OrderID
 }
 
 // DEXArchivist will be composed of several different interfaces. Starting with
@@ -295,9 +292,12 @@ func MatchID(match *order.Match) MarketMatchID {
 // confirms. These times must match the reference times provided to the auth
 // manager when registering new swap outcomes.
 type MatchOutcome struct {
-	Status order.MatchStatus
-	Fail   bool // taker must reach MatchComplete, maker succeeds at MakerRedeemed
-	Time   int64
+	Status      order.MatchStatus
+	ID          order.MatchID
+	Fail        bool // taker must reach MatchComplete, maker succeeds at MakerRedeemed
+	Time        int64
+	Value       uint64
+	Base, Quote uint32 // the market
 }
 
 // MatchArchiver is the interface required for storage and retrieval of all

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1076,9 +1076,9 @@ func (m *Market) processOrder(rec *orderRecord, epoch *EpochQueue, notifyChan ch
 		case midGap == 0:
 			return false // empty market: could be taker, but assume not
 		case lo.Sell:
-			return lo.Rate < bestBuy
+			return lo.Rate <= bestBuy
 		default:
-			return lo.Rate > bestSell
+			return lo.Rate >= bestSell
 		}
 	}
 	// Note: bestSell and bestBuy do not include other epoch orders with

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1073,6 +1073,8 @@ func (m *Market) processOrder(rec *orderRecord, epoch *EpochQueue, notifyChan ch
 		}
 		// Infer from best buy/sell to be conservative, ignoring other side.
 		switch {
+		case midGap == 0:
+			return false // empty market: could be taker, but assume not
 		case lo.Sell:
 			return lo.Rate < bestSell
 		default:

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1071,14 +1071,14 @@ func (m *Market) processOrder(rec *orderRecord, epoch *EpochQueue, notifyChan ch
 		if !ok || lo.Force == order.ImmediateTiF {
 			return true
 		}
-		// Infer from best buy/sell to be conservative, ignoring other side.
+		// Must cross the spread to be a taker (not so conservative).
 		switch {
 		case midGap == 0:
 			return false // empty market: could be taker, but assume not
 		case lo.Sell:
-			return lo.Rate < bestSell
+			return lo.Rate < bestBuy
 		default:
-			return lo.Rate > bestBuy
+			return lo.Rate > bestSell
 		}
 	}
 	// Note: bestSell and bestBuy do not include other epoch orders with

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -748,7 +748,7 @@ func TestMarket_Run(t *testing.T) {
 
 	// Make an order for the first epoch.
 	clientTimeMSec := startEpochIdx*epochDurationMSec + 10 // 10 ms after epoch start
-	lots := srvauth.InitUserLotLimit
+	lots := srvauth.InitUserTakerLotLimit
 	qty := uint64(dcrLotSize * lots)
 	rate := uint64(1000) * dcrRateStep
 	aid := test.NextAccount()
@@ -1326,7 +1326,7 @@ func TestMarket_Cancelable(t *testing.T) {
 
 	// Make an order for the first epoch.
 	clientTimeMSec := startEpochIdx*epochDurationMSec + 10 // 10 ms after epoch start
-	lots := srvauth.InitUserLotLimit
+	lots := srvauth.InitUserTakerLotLimit
 	qty := uint64(dcrLotSize * lots)
 	rate := uint64(1000) * dcrRateStep
 	aid := test.NextAccount()

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -25,6 +25,7 @@ import (
 	"decred.org/dcrdex/dex/order"
 	"decred.org/dcrdex/dex/order/test"
 	"decred.org/dcrdex/server/account"
+	srvauth "decred.org/dcrdex/server/auth"
 	"decred.org/dcrdex/server/coinlock"
 	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/swap"
@@ -747,7 +748,7 @@ func TestMarket_Run(t *testing.T) {
 
 	// Make an order for the first epoch.
 	clientTimeMSec := startEpochIdx*epochDurationMSec + 10 // 10 ms after epoch start
-	lots := 10
+	lots := srvauth.InitUserLotLimit
 	qty := uint64(dcrLotSize * lots)
 	rate := uint64(1000) * dcrRateStep
 	aid := test.NextAccount()
@@ -1325,7 +1326,7 @@ func TestMarket_Cancelable(t *testing.T) {
 
 	// Make an order for the first epoch.
 	clientTimeMSec := startEpochIdx*epochDurationMSec + 10 // 10 ms after epoch start
-	lots := 10
+	lots := srvauth.InitUserLotLimit
 	qty := uint64(dcrLotSize * lots)
 	rate := uint64(1000) * dcrRateStep
 	aid := test.NextAccount()
@@ -1393,7 +1394,7 @@ func TestMarket_Cancelable(t *testing.T) {
 	// Submit the standing limit order into the current epoch.
 	err = mkt.SubmitOrder(&oRecord)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !mkt.Cancelable(lo.ID()) {

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -36,6 +36,7 @@ type AuthManager interface {
 	PreimageSuccess(user account.AccountID, refTime time.Time, oid order.OrderID)
 	MissedPreimage(user account.AccountID, refTime time.Time, oid order.OrderID)
 	RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time)
+	UserOrderLimitAdjustment(user account.AccountID, base, quote uint32) int64
 }
 
 const (
@@ -43,8 +44,7 @@ const (
 	fundingTxWait  = time.Minute
 )
 
-// MarketTunnel is a connection to a market and information about existing
-// swaps.
+// MarketTunnel is a connection to a market.
 type MarketTunnel interface {
 	// SubmitOrder submits the order to the market for insertion into the epoch
 	// queue.
@@ -354,8 +354,12 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 			// Send the order to the epoch queue where it will be time stamped.
 			log.Tracef("Found and validated %s coins %v for new limit order", fundingAsset.Symbol, coinStrs)
 			if err := tunnel.SubmitOrder(oRecord); err != nil {
-				log.Warnf("Market failed to SubmitOrder: %v", err)
-				r.respondError(msg.ID, user, msgjson.NewError(msgjson.UnknownMarketError, "failed to submit order"))
+				if errors.Is(err, ErrInternalServer) {
+					log.Errorf("Market failed to SubmitOrder: %v", err)
+				} else {
+					log.Debugf("Market failed to SubmitOrder: %v", err)
+				}
+				r.respondError(msg.ID, user, msgjson.NewError(msgjson.UnknownMarketError, err.Error()))
 			}
 			return wait.DontTryAgain
 		},
@@ -544,8 +548,12 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 			// Send the order to the epoch queue where it will be time stamped.
 			log.Tracef("Found and validated %s coins %v for new market order", fundingAsset.Symbol, coinStrs)
 			if err := tunnel.SubmitOrder(oRecord); err != nil {
-				log.Warnf("Market failed to SubmitOrder: %v", err)
-				r.respondError(msg.ID, user, msgjson.NewError(msgjson.UnknownMarketError, "failed to submit order"))
+				if errors.Is(err, ErrInternalServer) {
+					log.Errorf("Market failed to SubmitOrder: %v", err)
+				} else {
+					log.Debugf("Market failed to SubmitOrder: %v", err)
+				}
+				r.respondError(msg.ID, user, msgjson.NewError(msgjson.UnknownMarketError, err.Error()))
 			}
 			return wait.DontTryAgain
 		},
@@ -635,8 +643,10 @@ func (r *OrderRouter) handleCancel(user account.AccountID, msg *msgjson.Message)
 		msgID: msg.ID,
 	}
 	if err := tunnel.SubmitOrder(oRecord); err != nil {
-		log.Warnf("Market failed to SubmitOrder: %v", err)
-		return msgjson.NewError(msgjson.UnknownMarketError, "failed to submit order")
+		if errors.Is(err, ErrInternalServer) {
+			log.Errorf("Market failed to SubmitOrder: %v", err)
+		}
+		return msgjson.NewError(msgjson.UnknownMarketError, err.Error())
 	}
 	return nil
 }

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -23,6 +23,7 @@ import (
 	"decred.org/dcrdex/server/auth"
 	"decred.org/dcrdex/server/book"
 	"decred.org/dcrdex/server/comms"
+	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/matcher"
 	"decred.org/dcrdex/server/swap"
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
@@ -229,8 +230,12 @@ func (a *TAuth) RequestWithTimeout(user account.AccountID, msg *msgjson.Message,
 
 func (a *TAuth) PreimageSuccess(user account.AccountID, refTime time.Time, oid order.OrderID) {}
 func (a *TAuth) MissedPreimage(user account.AccountID, refTime time.Time, oid order.OrderID)  {}
-func (a *TAuth) SwapSuccess(user account.AccountID, refTime time.Time)                        {}
-func (a *TAuth) Inaction(user account.AccountID, step auth.NoActionStep, refTime time.Time, oid order.OrderID, mid order.MatchID) {
+func (a *TAuth) SwapSuccess(user account.AccountID, mmid db.MarketMatchID, value uint64, refTime time.Time) {
+}
+func (a *TAuth) Inaction(user account.AccountID, step auth.NoActionStep, mmid db.MarketMatchID, matchValue uint64, refTime time.Time, oid order.OrderID) {
+}
+func (a *TAuth) UserOrderLimitAdjustment(user account.AccountID, base, quote uint32) int64 {
+	return 0 // everyone gets a clean slate
 }
 
 func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time) {}
@@ -238,7 +243,6 @@ func (a *TAuth) RecordCancel(aid account.AccountID, coid, oid order.OrderID, t t
 	a.cancelOrder = coid
 	a.canceledOrder = oid
 }
-func (a *TAuth) Unban(account.AccountID) error { return nil }
 
 type TMarketTunnel struct {
 	adds       []*orderRecord

--- a/server/matcher/match_test.go
+++ b/server/matcher/match_test.go
@@ -1935,6 +1935,15 @@ func TestQuoteToBase(t *testing.T) {
 			wantBase: 4200000000,
 		},
 		{
+			name: "don't panic on 0 rate",
+			args: args{
+				rate:      0,
+				rateFloat: 0,
+				quote:     51833544,
+			},
+			wantBase: 0,
+		},
+		{
 			name: "ok >>1",
 			args: args{
 				rate:      19900000022,

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -58,11 +58,10 @@ type AuthManager interface {
 	Request(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message)) error
 	RequestWithTimeout(user account.AccountID, req *msgjson.Message, handlerFunc func(comms.Link, *msgjson.Message),
 		expireTimeout time.Duration, expireFunc func()) error
-	SwapSuccess(user account.AccountID, refTime time.Time)
-	Inaction(user account.AccountID, step auth.NoActionStep, refTime time.Time, oid order.OrderID, mid order.MatchID)
+	SwapSuccess(user account.AccountID, mmid db.MarketMatchID, value uint64, refTime time.Time)
+	Inaction(user account.AccountID, misstep auth.NoActionStep, mmid db.MarketMatchID, matchValue uint64, refTime time.Time, oid order.OrderID)
 	RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time)
 	RecordCompletedOrder(user account.AccountID, oid order.OrderID, t time.Time)
-	Unban(user account.AccountID) error
 }
 
 // Storage updates match data in what is presumably a database.
@@ -301,8 +300,9 @@ type Swapper struct {
 	// actions.
 	unbookHook func(lo *order.LimitOrder) bool
 	// The matches map and the contained matches are protected by the matchMtx.
-	matchMtx sync.RWMutex
-	matches  map[order.MatchID]*matchTracker
+	matchMtx    sync.RWMutex
+	matches     map[order.MatchID]*matchTracker
+	userMatches map[account.AccountID]map[order.MatchID]*matchTracker
 	// orders tracks order status and active swaps.
 	orders *orderSwapTracker
 	// The broadcast timeout.
@@ -389,6 +389,7 @@ func NewSwapper(cfg *Config) (*Swapper, error) {
 		unbookHook:    cfg.UnbookHook,
 		latencyQ:      wait.NewTickerQueue(recheckInterval),
 		matches:       make(map[order.MatchID]*matchTracker),
+		userMatches:   make(map[account.AccountID]map[order.MatchID]*matchTracker),
 		orders:        newOrderSwapTracker(),
 		bTimeout:      cfg.BroadcastTimeout,
 		lockTimeTaker: cfg.LockTimeTaker,
@@ -465,6 +466,63 @@ func NewSwapper(cfg *Config) (*Swapper, error) {
 	return swapper, nil
 }
 
+// addMatch registers a match. The matchMtx must be locked.
+func (s *Swapper) addMatch(mt *matchTracker) {
+	mid := mt.ID()
+	s.matches[mid] = mt
+
+	// Add the match to both maker's and taker's match maps.
+	for _, user := range []account.AccountID{mt.Maker.User(), mt.Taker.User()} {
+		userMatches, found := s.userMatches[user]
+		if !found {
+			s.userMatches[user] = map[order.MatchID]*matchTracker{
+				mid: mt,
+			}
+		} else {
+			userMatches[mid] = mt // may overwrite for self-match (ok)
+		}
+	}
+}
+
+// deleteMatch unregisters a match. The matchMtx must be locked.
+func (s *Swapper) deleteMatch(mt *matchTracker) {
+	mid := mt.ID()
+	delete(s.matches, mid)
+
+	// Remove the match from both maker's and taker's match maps.
+	for _, user := range []account.AccountID{mt.Maker.User(), mt.Taker.User()} {
+		userMatches, found := s.userMatches[user]
+		if !found {
+			// Should not happen if consistently using addMatch.
+			log.Errorf("deleteMatch: No matches for user %v found!", user)
+			continue
+		}
+		if len(userMatches) == 1 {
+			delete(s.userMatches, user)
+		} else {
+			delete(userMatches, mid)
+		}
+	}
+}
+
+// UserSwappingAmt gets the total amount in active swaps for a user in a
+// specified market. This help the market compute a user's order size limit.
+func (s *Swapper) UserSwappingAmt(user account.AccountID, base, quote uint32) (amt, count uint64) {
+	s.matchMtx.RLock()
+	defer s.matchMtx.RUnlock()
+	um, found := s.userMatches[user]
+	if !found {
+		return
+	}
+	for _, mt := range um {
+		if mt.Maker.BaseAsset == base && mt.Maker.QuoteAsset == quote {
+			amt += mt.Quantity
+			count++
+		}
+	}
+	return
+}
+
 func (s *Swapper) restoreState(state *State, allowPartial bool) error {
 	// State binary version check should be done when State is loaded.
 
@@ -513,6 +571,7 @@ func (s *Swapper) restoreState(state *State, allowPartial bool) error {
 	}
 
 	s.matches = make(map[order.MatchID]*matchTracker, len(state.MatchTrackers))
+	s.userMatches = make(map[account.AccountID]map[order.MatchID]*matchTracker)
 	for mid, mtd := range state.MatchTrackers {
 		// Check and skip matches for missing assets.
 		makerSwapAsset := mtd.MakerStatus.SwapAsset
@@ -549,7 +608,7 @@ func (s *Swapper) restoreState(state *State, allowPartial bool) error {
 			continue
 		}
 
-		s.matches[mid] = mt
+		s.addMatch(mt)
 	}
 
 	// Order completion/failure tracking data
@@ -1005,7 +1064,7 @@ func (s *Swapper) failMatch(match *matchTracker) {
 	}
 
 	// Register the failure to act violation, adjusting the user's score.
-	s.authMgr.Inaction(orderAtFault.User(), misstep, refTime, orderAtFault.ID(), match.ID())
+	s.authMgr.Inaction(orderAtFault.User(), misstep, db.MatchID(match.Match), match.Quantity, refTime, orderAtFault.ID())
 
 	// Send the revoke_match messages, and solicit acks.
 	s.revoke(match)
@@ -1071,7 +1130,7 @@ func (s *Swapper) checkInactionEventBased() {
 	}
 
 	for _, match := range deletions {
-		delete(s.matches, match.ID())
+		s.deleteMatch(match)
 	}
 }
 
@@ -1135,7 +1194,7 @@ func (s *Swapper) checkInactionBlockBased(assetID uint32) {
 	}
 
 	for _, match := range deletions {
-		delete(s.matches, match.ID())
+		s.deleteMatch(match)
 	}
 }
 
@@ -1625,14 +1684,14 @@ func (s *Swapper) processRedeem(msg *msgjson.Message, params *msgjson.Redeem, st
 	if newStatus == order.MatchComplete { // actor is taker
 		log.Debugf("Deleting completed match %v", matchID)
 		s.matchMtx.Lock()
-		delete(s.matches, matchID)
+		s.deleteMatch(match)
 		s.matchMtx.Unlock()
 		// SaveRedeemB flags the match as inactive in the DB.
 	}
 
 	// Credit the user for completing the swap, adjusting the user's score.
 	if actor.user != counterParty.user || newStatus == order.MatchComplete { // is user is both sides, only credit on MatchComplete (taker done too)
-		s.authMgr.SwapSuccess(actor.user, redeemTime)
+		s.authMgr.SwapSuccess(actor.user, db.MatchID(match.Match), match.Quantity, redeemTime)
 	}
 
 	// Store the swap contract and the coinID (e.g. txid:vout) containing the
@@ -2395,10 +2454,10 @@ func (s *Swapper) Negotiate(matchSets []*order.MatchSet, finalSwap map[order.Ord
 		s.orders.canceled(lo)
 	}
 
-	// Add the matches to the map.
+	// Add the matches to the matches/userMatches maps.
 	s.matchMtx.Lock()
 	for _, match := range toMonitor {
-		s.matches[match.ID()] = match
+		s.addMatch(match)
 	}
 	s.matchMtx.Unlock()
 

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -473,7 +473,7 @@ func (s *Swapper) addMatch(mt *matchTracker) {
 
 	// Add the match to both maker's and taker's match maps.
 	maker, taker := mt.Maker.User(), mt.Taker.User()
-	for _, user := range []account.AccountID{mt.Maker.User(), mt.Taker.User()} {
+	for _, user := range []account.AccountID{maker, taker} {
 		userMatches, found := s.userMatches[user]
 		if !found {
 			s.userMatches[user] = map[order.MatchID]*matchTracker{
@@ -513,7 +513,7 @@ func (s *Swapper) deleteMatch(mt *matchTracker) {
 }
 
 // UserSwappingAmt gets the total amount in active swaps for a user in a
-// specified market. This help the market compute a user's order size limit.
+// specified market. This helps the market compute a user's order size limit.
 func (s *Swapper) UserSwappingAmt(user account.AccountID, base, quote uint32) (amt, count uint64) {
 	s.matchMtx.RLock()
 	defer s.matchMtx.RUnlock()

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -193,8 +193,9 @@ func (m *TAuthManager) Route(string,
 	func(account.AccountID, *msgjson.Message) *msgjson.Error) {
 }
 
-func (m *TAuthManager) SwapSuccess(id account.AccountID, refTime time.Time) {}
-func (m *TAuthManager) Inaction(id account.AccountID, step auth.NoActionStep, refTime time.Time, oid order.OrderID, mid order.MatchID) {
+func (m *TAuthManager) SwapSuccess(id account.AccountID, mmid db.MarketMatchID, value uint64, refTime time.Time) {
+}
+func (m *TAuthManager) Inaction(id account.AccountID, step auth.NoActionStep, mmid db.MarketMatchID, matchValue uint64, refTime time.Time, oid order.OrderID) {
 	// banscore of zero => immediate penalize
 	m.penalize(id, account.FailureToAct)
 }
@@ -209,7 +210,6 @@ func (m *TAuthManager) penalize(id account.AccountID, rule account.Rule) {
 
 func (m *TAuthManager) RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time) {}
 func (m *TAuthManager) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time)            {}
-func (m *TAuthManager) Unban(account.AccountID) error                                               { return nil }
 
 func (m *TAuthManager) flushPenalty(user account.AccountID) (found bool, rule account.Rule) {
 	m.mtx.Lock()


### PR DESCRIPTION
This implements a concept for limiting user order quantities.

- Users are limited in the amount they can have in active swaps ("settling"). The limit is computed based on the user's match history.
- Only orders that are considered "likely taker" are subject to this limit.  Likely taker includes: market order, limit with TiF immediate, limit with TiF standing and a rate that is within the spread.
- Separate to the taker order limit, there is an constant limit for booked order quantity in lots, to which all submitted standing limit orders are subject to.  To be conservative, an order may be considered "likely taker" AND be subjected to this book limit at the same time.

- Match outcome history now includes value of the match (swapped, stuck long, stuck short, and spoofed).  The match outcome history depth is the same as the scoring system's depth (same data structure presently).
- Users are granted an init/base limit that is defined in number of lots.  The market converts this to an amount based on the current lot size.
- The quantity of new orders are validated according to the user's current active amount (booked + swapping in the market) and their active amount limit (determined by historical match outcomes for the market and the base limit).
- Limits, active amounts, and match history are per-market values.
- The user only finds out if they hit the limit when submitting the order. This may be inconvenient when tx split is enabled as it creates an on-chain transaction.  Server could provide the user's current limit in the connect response, and the client could track their limit based on the formula.

```go
// SwapAmounts breaks down the quantities of completed swaps in four rough
// categories: successfully swapped (Swapped), failed with counterparty funds
// locked for the long/maker lock time (StuckLong), failed with counterparty
// funds locked for the short/taker lock time (StuckShort), and failed to
// initiate swap following match with no funds locked in contracts (Spoofed).
type SwapAmounts struct {
	Swapped    int64
	StuckLong  int64
	StuckShort int64
	Spoofed    int64
}
```

```go
const (
	// InitUserLotLimit is the number of lots a new user is permitted to have in
	// active orders and swaps. The market should multiply their lot size by
	// this number to get the limit in units of the base asset. This is
	// potentially a per-market setting instead of an auth constant.
	InitUserLotLimit = 6

	// These coefficients are used to compute a user's swap limit adjustment via
	// UserOrderLimitAdjustment based on the cumulative amounts in the different
	// match outcomes.
	successWeight    int64 = 2
	stuckLongWeight  int64 = -6
	stuckShortWeight int64 = -3
	spoofedWeight    int64 = -1
)
```

And an adjustment to the init/base lot size limt is computed as `sa.Swapped*successWeight + sa.StuckLong*stuckLongWeight + sa.StuckShort*stuckShortWeight + sa.Spoofed*spoofedWeight`

When a client tries to submit an order that exceeds the allowed amount for their account:

![image](https://user-images.githubusercontent.com/9373513/96182022-799edf80-0efa-11eb-9d5c-250de13767b7.png)

dcrdex

`[TRC] MKT: Received order 88f114ed513804333b70741daee35537a20a8e7402f1f92eab66c65e9722d052 at 2020-10-15 20:22:24.508 +0000 UTC`
`[DBG] MKT: User placing order on market dcr_btc worth 20000000000 (dcr units) of 16000000000 allowed. User's unsettled dcr amounts: 2000000000 in 1 buy orders, 2000000000 in 1 sell orders, 0 in 0 active swaps => 4000000000 (40.000000 x10^8) total in active orders.`
`[INF] MKT: Rejecting user 19891edff0e8578ad96ef74afebea68150772344a4a4613cfe71efceb534e533 order 88f114ed513804333b70741daee35537a20a8e7402f1f92eab66c65e9722d052: qty 20000000000 > 16000000000 allowed (4000000000 active of 20000000000 limit)`
`[DBG] MKT: Market failed to SubmitOrder: order quantity exceeds user limit: Order quantity 20000000000 too large. Current limit: 16000000000 (you have 4000000000 booked or settling already)`
`[DBG] MKT: Error going to user 19891edff0e8578ad96ef74afebea68150772344a4a4613cfe71efceb534e533: error code 34: order quantity exceeds user limit: Order quantity 20000000000 too large. Current limit: 16000000000 (you have 4000000000 booked or settling already)`
