### PR TITLE
client: markets page randomly spins

### DIFF
--- a/client/webserver/site/src/js/ws.js
+++ b/client/webserver/site/src/js/ws.js
@@ -127,8 +127,7 @@ class MessageSocket {
         // Ensure websocket is open when executing queued requests
         // to avoid infinite request/queue loops.
         while (this.queue.length &&
-                this.connection &&
-                this.connection.readyState === window.WebSocket.OPEN) {
+                conn.readyState === window.WebSocket.OPEN) {
           const [route, message] = this.queue.shift()
           this.request(route, message)
         }

--- a/client/webserver/site/src/js/ws.js
+++ b/client/webserver/site/src/js/ws.js
@@ -122,11 +122,11 @@ class MessageSocket {
         if (retrys > 0) {
           retrys = 0
           reloader()
-          return
         }
         forward('open', null, this.handlers)
-        while (this.queue.length) {
-          const [route, message] = this.queue.shift()
+        const queue = this.queue
+        this.queue = []
+        for (const [route, message] of queue) {
           this.request(route, message)
         }
       }

--- a/client/webserver/site/src/js/ws.js
+++ b/client/webserver/site/src/js/ws.js
@@ -122,15 +122,11 @@ class MessageSocket {
         if (retrys > 0) {
           retrys = 0
           reloader()
+          return
         }
         forward('open', null, this.handlers)
-        // Ensure websocket is open when executing queued requests
-        // to avoid infinite request/queue loops.
-        while (this.queue.length &&
-                conn.readyState === window.WebSocket.OPEN) {
-          const [route, message] = this.queue.shift()
-          this.request(route, message)
-        }
+        const [route, message] = this.queue.shift()
+        this.request(route, message)
       }
 
       conn.onerror = (evt) => {

--- a/client/webserver/site/src/js/ws.js
+++ b/client/webserver/site/src/js/ws.js
@@ -124,7 +124,11 @@ class MessageSocket {
           reloader()
         }
         forward('open', null, this.handlers)
-        while (this.queue.length) {
+        // Ensure websocket is open when executing queued requests
+        // to avoid infinite request/queue loops.
+        while (this.queue.length &&
+                this.connection &&
+                this.connection.readyState === window.WebSocket.OPEN) {
           const [route, message] = this.queue.shift()
           this.request(route, message)
         }

--- a/client/webserver/site/src/js/ws.js
+++ b/client/webserver/site/src/js/ws.js
@@ -125,8 +125,10 @@ class MessageSocket {
           return
         }
         forward('open', null, this.handlers)
-        const [route, message] = this.queue.shift()
-        this.request(route, message)
+        while (this.queue.length) {
+          const [route, message] = this.queue.shift()
+          this.request(route, message)
+        }
       }
 
       conn.onerror = (evt) => {


### PR DESCRIPTION
This pull request addresses https://github.com/decred/dcrdex/issues/583

In firefox executing a request when the websocket is not open would result in a blocking infinite loop. The initial request from the user would be put into the queue due to the websocket being closed. Then that queued request was executed in the onopen event. Then that request would be queued again and the cycle continued infinitely. 

It seems that firefox is blocked from fulfilling the request due to the loop, where chrome does actually fulfill the request which discards the looping action and the browser renders the page requested.