### PR TITLE
core/app: bug roundup

### DIFF
--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -257,6 +257,7 @@ export default class Application {
         }
       }
       this.setNoteTimes(pg.noteList)
+      this.setNoteTimes(pg.pokeList)
       this.storeNotes()
     })
 
@@ -270,6 +271,7 @@ export default class Application {
     bind(pg.profileSignout, 'click', async e => await this.signOut())
 
     bind(pg.pokeCat, 'click', () => {
+      this.setNoteTimes(pg.pokeList)
       pg.pokeCat.classList.add('active')
       pg.noteCat.classList.remove('active')
       Doc.hide(pg.noteList)
@@ -278,6 +280,7 @@ export default class Application {
     })
 
     bind(pg.noteCat, 'click', () => {
+      this.setNoteTimes(pg.noteList)
       pg.noteCat.classList.add('active')
       pg.pokeCat.classList.remove('active')
       Doc.hide(pg.pokeList)

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -411,7 +411,6 @@ export default class MarketsPage extends BasePage {
     }
     this.page.marketLoader.classList.remove('d-none')
     ws.request('loadmarket', makeMarket(host, base, quote))
-
     this.setLoaderMsgVisibility()
     this.setRegistrationStatusVisibility()
     this.resolveOrderFormVisibility()


### PR DESCRIPTION
1. Unlock the `dexAccount` when the user logs back in after logging out.
2. Don't try to connect to already connected wallets. It can cause an error and leave the wallet connected but with a `nil` `WaitGroup` (Resolves #751).
3. `refreshMarkets` and `refreshUser` after DEX reconnect. Fixes an issues where orders weren't showing in the "My Orders" table after reconnect.
4. UI: Update times for notifications and activity feed more often.