### PR TITLE
server/auth: prevent multiple fee coin waiters for one account

### DIFF
--- a/dex/runner.go
+++ b/dex/runner.go
@@ -108,13 +108,14 @@ func (c *ConnectionMaster) Connect(ctx context.Context) (err error) {
 
 // Disconnect closes the connection and waits for shutdown.
 func (c *ConnectionMaster) Disconnect() {
-	c.mtx.RLock()
 	c.cancel()
-	defer c.mtx.RUnlock()
+	c.mtx.RLock()
 	c.wg.Wait()
+	c.mtx.RUnlock()
 }
 
 // Wait waits for the the WaitGroup returned by Connect.
 func (c *ConnectionMaster) Wait() {
 	c.wg.Wait()
+	c.cancel() // if not called from Disconnect, would leak context
 }

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -196,6 +196,9 @@ type AuthManager struct {
 	// latencyQ is a queue for fee coin waiters to deal with latency.
 	latencyQ *wait.TickerQueue
 
+	feeWaiterMtx sync.Mutex
+	feeWaiterIdx map[account.AccountID]struct{}
+
 	connMtx   sync.RWMutex
 	users     map[account.AccountID]*clientInfo
 	conns     map[uint64]*clientInfo
@@ -349,6 +352,7 @@ func NewAuthManager(cfg *Config) *AuthManager {
 		feeConfs:       cfg.FeeConfs,
 		cancelThresh:   cfg.CancelThreshold,
 		latencyQ:       wait.NewTickerQueue(recheckInterval),
+		feeWaiterIdx:   make(map[account.AccountID]struct{}),
 		matchOutcomes:  make(map[account.AccountID]*latest),
 		preimgOutcomes: make(map[account.AccountID]*latest),
 	}

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -1396,9 +1396,10 @@ func TestHandleNotifyFee(t *testing.T) {
 	// the first attempt is actually synchronous, so not need for synchronization
 	// as long as there is no PayFee error.
 	doWaiter := func(msg *msgjson.Message) *msgjson.Error {
+		t.Helper()
 		msgErr := rig.mgr.handleNotifyFee(user.conn, msg)
 		if msgErr != nil {
-			t.Fatal("never made it to the waiter", msgErr.Code, msgErr.Message)
+			t.Fatalf("never made it to the waiter: %d: %v", msgErr.Code, msgErr.Message)
 		}
 		sent := user.conn.getSend()
 		if sent == nil {

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -294,7 +294,7 @@ func (s *Server) banish(ip string) {
 // starting it, and blocking until the connection closes. This method should be
 // run as a goroutine.
 func (s *Server) websocketHandler(ctx context.Context, conn ws.Connection, ip string) {
-	log.Debugf("New websocket client %s", ip)
+	log.Tracef("New websocket client %s", ip)
 
 	// Create a new websocket client to handle the new websocket connection
 	// and wait for it to shutdown.  Once it has shutdown (and hence


### PR DESCRIPTION
This tracks actively running fee coin waiters by account ID.  An account is only permitted to start one waiter at a time.

Also fixes two leaks: a ticker leak in `dex/ws.WsLink`, and a context leak in `dex.ConnectionMaster`.  BTW, the `RWMutex` locking in the `ConnectionMaster` methods seems unnecessary if `Disconnect` and `Wait` are never called before `Connect`.