### PR TITLE
set 0.1 in dexc and dcrdex versions

### DIFF
--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	_ "decred.org/dcrdex/client/asset/dcr" // register dcr asset
 	_ "decred.org/dcrdex/client/asset/ltc" // register ltc asset
 	"decred.org/dcrdex/client/cmd/dexc/ui"
+	"decred.org/dcrdex/client/cmd/dexc/version"
 	"decred.org/dcrdex/client/core"
 	"decred.org/dcrdex/client/rpcserver"
 	"decred.org/dcrdex/client/webserver"
@@ -62,6 +64,7 @@ func main() {
 	}
 	logMaker := ui.InitLogging(logStdout, cfg.DebugLevel, utc)
 	log = logMaker.Logger("DEXC")
+	log.Infof("%s version %v (Go version %s)", version.AppName, version.Version(), runtime.Version())
 	if utc {
 		log.Infof("Logging with UTC time stamps. Current local time is %v",
 			time.Now().Local().Format("15:04:05 MST"))

--- a/client/cmd/dexc/ui/config.go
+++ b/client/cmd/dexc/ui/config.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 
+	"decred.org/dcrdex/client/cmd/dexc/version"
 	"decred.org/dcrdex/dex"
 	"github.com/decred/dcrd/dcrutil/v2"
 	flags "github.com/jessevdk/go-flags"
@@ -72,6 +73,7 @@ type Config struct {
 	ReloadHTML bool   `long:"reload-html" description:"Reload the webserver's page template with every request. For development purposes."`
 	DebugLevel string `long:"log" description:"Logging level {trace, debug, info, warn, error, critical}"`
 	LocalLogs  bool   `long:"loglocal" description:"Use local time zone time stamps in log entries."`
+	ShowVer    bool   `short:"V" long:"version" description:"Display version information and exit"`
 	Net        dex.Network
 }
 
@@ -103,6 +105,13 @@ func Configure() (*Config, error) {
 			os.Exit(0)
 		}
 		return nil, flagerr
+	}
+
+	// Show the version and exit if the version flag was specified.
+	if preCfg.ShowVer {
+		fmt.Printf("%s version %s (Go version %s %s/%s)\n",
+			version.AppName, version.Version(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		os.Exit(0)
 	}
 
 	// If the app directory has been changed, but the config file path hasn't,

--- a/client/cmd/dexc/version/version.go
+++ b/client/cmd/dexc/version/version.go
@@ -1,7 +1,7 @@
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
-package main
+package version
 
 import (
 	"bytes"
@@ -22,13 +22,13 @@ const (
 // These constants define the application version and follow the semantic
 // versioning 2.0.0 spec (http://semver.org/).
 const (
-	AppName  string = "dcrdex"
+	AppName  string = "dexc"
 	AppMajor uint   = 0
 	AppMinor uint   = 1
 	AppPatch uint   = 0
 )
 
-// go build -v -ldflags "-X main.appPreRelease= -X main.appBuild=$(git rev-parse --short HEAD)"
+// go build -v -ldflags "-X decred.org/dcrdex/client/cmd/dexc/version.appPreRelease= -X decred.org/dcrdex/client/cmd/dexc/version.appBuild=$(git rev-parse --short HEAD)"
 var (
 	// appPreRelease is defined as a variable so it can be overridden during the
 	// build process. It MUST only contain characters from semanticAlphabet per

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -327,8 +327,8 @@ func loadConfig() (*dexConf, *procOpts, error) {
 
 	// Show the version and exit if the version flag was specified.
 	if preCfg.ShowVersion {
-		fmt.Printf("dcrdex version %s (Go version %s %s/%s)\n",
-			Version(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("%s version %s (Go version %s %s/%s)\n",
+			AppName, Version(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This is all reused code, so fairly trivial.

dexc has a version package because config is still in the ui package, while dcrdex does not.  This will all likely change.

```
$    go build
$    ./dexc -V
dexc version 0.1.0-pre+dev (Go version go1.15.3 linux/amd64)
$    go build -ldflags "-X decred.org/dcrdex/client/cmd/dexc/version.appPreRelease=release -X decred.org/dcrdex/client/cmd/dexc/version.appBuild="
$    ./dexc -V
dexc version 0.1.0-release (Go version go1.15.3 linux/amd64)
$    go build -ldflags "-X decred.org/dcrdex/client/cmd/dexc/version.appPreRelease= -X decred.org/dcrdex/client/cmd/dexc/version.appBuild=$(git rev-parse --short HEAD)"
$    ./dexc -V
dexc version 0.1.0+05350967 (Go version go1.15.3 linux/amd64)
```

```
$    ./dcrdex -V
dcrdex version 0.1.0-pre+dev (Go version go1.15.3 linux/amd64)
$    go build -ldflags "-X main.appPreRelease= -X main.appBuild=$(git rev-parse --short HEAD)"
$    ./dcrdex -V
dcrdex version 0.1.0+05350967 (Go version go1.15.3 linux/amd64)
```