### PR TITLE
admin: Add trade info getter functions.

### DIFF
--- a/dex/order/match.go
+++ b/dex/order/match.go
@@ -7,6 +7,7 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -24,6 +25,12 @@ type MatchID [MatchIDSize]byte
 // MatchID implements fmt.Stringer.
 func (id MatchID) String() string {
 	return hex.EncodeToString(id[:])
+}
+
+// MarshalJSON satisfies the json.Marshaller interface, and will marshal the
+// id to a hex string.
+func (id MatchID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(id.String())
 }
 
 // Bytes returns the match ID as a []byte.

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -9,6 +9,7 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -48,6 +49,12 @@ func IDFromHex(sid string) (OrderID, error) {
 // fmt.Stringer.
 func (oid OrderID) String() string {
 	return hex.EncodeToString(oid[:])
+}
+
+// MarshalJSON satisfies the json.Marshaller interface, and will marshal the
+// id to a hex string.
+func (oid OrderID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(oid.String())
 }
 
 // Bytes returns the order ID as a []byte.

--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -117,6 +117,23 @@ const (
 	WHERE (takerAccount = $1 OR makerAccount = $1)
 		AND active;`
 
+	RetrieveMarketMatches = `SELECT matchid, active, takerSell,
+		takerOrder, takerAccount, takerAddress,
+		makerOrder, makerAccount, makerAddress,
+		epochIdx, epochDur, quantity, rate, baseRate, quoteRate, status
+	FROM %s
+	WHERE takerSell IS NOT NULL -- not a cancel order
+	ORDER BY epochIdx * epochDur DESC;`
+
+	RetrieveActiveMarketMatches = `SELECT matchid, takerSell,
+		takerOrder, takerAccount, takerAddress,
+		makerOrder, makerAccount, makerAddress,
+		epochIdx, epochDur, quantity, rate, baseRate, quoteRate, status
+	FROM %s
+	WHERE takerSell IS NOT NULL -- not a cancel order
+		AND active
+	ORDER BY epochIdx * epochDur DESC;`
+
 	// CompletedOrAtFaultMatchesLastN retrieves inactive matches for a user that
 	// are either successfully completed by the user (MatchComplete or
 	// MakerRedeemed with user as maker), or failed because of this user's

--- a/server/db/driver/pg/internal/orders.go
+++ b/server/db/driver/pg/internal/orders.go
@@ -187,6 +187,10 @@ const (
 		commit, target_order, status
 	FROM %s WHERE oid = $1;`
 
+	SelectCancelOrdersByStatus = `SELECT account_id, client_time, server_time,
+		commit, target_order
+	FROM %s WHERE status = $1;`
+
 	CancelPreimageResultsLastN = `SELECT oid, (preimage IS NULL AND status=$3) AS preimageMiss,  -- orderStatusRevoked
 		(epoch_idx+1) * epoch_dur AS epochCloseTime   -- when preimages are requested
 	FROM %s -- e.g. dcr_btc.cancels_archived

--- a/server/db/driver/pg/matches.go
+++ b/server/db/driver/pg/matches.go
@@ -158,9 +158,41 @@ func userMatches(ctx context.Context, dbe *sql.DB, tableName string, aid account
 	if err != nil {
 		return nil, err
 	}
+	return rowsToMatchData(rows, includeInactive)
+}
+
+// MarketMatches retrieves all active matches for a market. If includeInactive,
+// all matches are returned.
+func (a *Archiver) MarketMatches(base, quote uint32, includeInactive bool) ([]*db.MatchData, error) {
+	marketSchema, err := a.marketSchema(base, quote)
+	if err != nil {
+		return nil, err
+	}
+
+	matchesTableName := fullMatchesTableName(a.dbName, marketSchema)
+
+	ctx, cancel := context.WithTimeout(a.ctx, a.queryTimeout)
+	defer cancel()
+
+	query := internal.RetrieveActiveMarketMatches
+	if includeInactive {
+		query = internal.RetrieveMarketMatches
+	}
+	stmt := fmt.Sprintf(query, matchesTableName)
+	rows, err := a.db.QueryContext(ctx, stmt)
+	if err != nil {
+		return nil, err
+	}
+	return rowsToMatchData(rows, includeInactive)
+}
+
+func rowsToMatchData(rows *sql.Rows, includeInactive bool) ([]*db.MatchData, error) {
 	defer rows.Close()
 
-	var ms []*db.MatchData
+	var (
+		ms  []*db.MatchData
+		err error
+	)
 	for rows.Next() {
 		var m db.MatchData
 		var status uint8

--- a/server/db/driver/pg/testhelpers_test.go
+++ b/server/db/driver/pg/testhelpers_test.go
@@ -93,6 +93,10 @@ func newLimitOrderRevealed(sell bool, rate, quantityLots uint64, force order.Tim
 }
 
 func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce, timeOffset int64) *order.LimitOrder {
+	return newLimitOrderWithAssets(sell, rate, quantityLots, force, timeOffset, AssetDCR, AssetBTC)
+}
+
+func newLimitOrderWithAssets(sell bool, rate, quantityLots uint64, force order.TimeInForce, timeOffset int64, base, quote uint32) *order.LimitOrder {
 	addr := "DcqXswjTPnUcd4FRCkX4vRJxmVtfgGVa5ui"
 	if sell {
 		addr = "149RQGLaHf2gGiL4NXZdH7aA8nYEuLLrgm"
@@ -100,8 +104,8 @@ func newLimitOrder(sell bool, rate, quantityLots uint64, force order.TimeInForce
 	return &order.LimitOrder{
 		P: order.Prefix{
 			AccountID:  randomAccountID(),
-			BaseAsset:  AssetDCR,
-			QuoteAsset: AssetBTC,
+			BaseAsset:  base,
+			QuoteAsset: quote,
 			OrderType:  order.LimitOrderType,
 			ClientTime: time.Unix(1566497653+timeOffset, 0).UTC(),
 			ServerTime: time.Unix(1566497656+timeOffset, 0).UTC(),

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -80,6 +80,9 @@ type OrderArchiver interface {
 	// BookOrders returns all book orders for a market.
 	BookOrders(base, quote uint32) ([]*order.LimitOrder, error)
 
+	// EpochOrders returns all epoch orders for a market.
+	EpochOrders(base, quote uint32) ([]order.Order, error)
+
 	// FlushBook revokes all booked orders for a market.
 	FlushBook(base, quote uint32) (sellsRemoved, buysRemoved []order.OrderID, err error)
 
@@ -309,6 +312,7 @@ type MatchArchiver interface {
 	CompletedAndAtFaultMatchStats(aid account.AccountID, lastN int) ([]*MatchOutcome, error)
 	ForgiveMatchFail(mid order.MatchID) (bool, error)
 	AllActiveUserMatches(aid account.AccountID) ([]*MatchData, error)
+	MarketMatches(base, quote uint32, includeInactive bool) ([]*MatchData, error)
 	MatchStatuses(aid account.AccountID, base, quote uint32, matchIDs []order.MatchID) ([]*MatchStatus, error)
 }
 

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -755,3 +755,18 @@ func (dm *DEX) Notify(acctID account.AccountID, msg *msgjson.Message) {
 func (dm *DEX) NotifyAll(msg *msgjson.Message) {
 	dm.server.Broadcast(msg)
 }
+
+// BookOrders returns booked orders for market with base and quote.
+func (dm *DEX) BookOrders(base, quote uint32) ([]*order.LimitOrder, error) {
+	return dm.storage.BookOrders(base, quote)
+}
+
+// EpochOrders returns epoch orders for market with base and quote.
+func (dm *DEX) EpochOrders(base, quote uint32) ([]order.Order, error) {
+	return dm.storage.EpochOrders(base, quote)
+}
+
+// MarketMatches returns matches for market with base and quote.
+func (dm *DEX) MarketMatches(base, quote uint32, includeInactive bool) ([]*db.MatchData, error) {
+	return dm.storage.MarketMatches(base, quote, includeInactive)
+}

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -6,6 +6,7 @@ package market
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"decred.org/dcrdex/dex"
@@ -642,4 +643,17 @@ func marketOrderToMsgOrder(o *order.MarketOrder, mkt string) *msgjson.BookOrderN
 			// Rate and TiF not set for market orders.
 		},
 	}
+}
+
+// OrderToMsgOrder converts an order.Order into a *msgjson.BookOrderNote.
+func OrderToMsgOrder(ord order.Order, mkt string) (*msgjson.BookOrderNote, error) {
+	switch o := ord.(type) {
+	case *order.LimitOrder:
+		return limitOrderToMsgOrder(o, mkt), nil
+	case *order.MarketOrder:
+		return marketOrderToMsgOrder(o, mkt), nil
+	case *order.CancelOrder:
+		return cancelOrderToMsgOrder(o, mkt), nil
+	}
+	return nil, fmt.Errorf("unknown order type for %v: %T", ord.ID(), ord)
 }

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -390,6 +390,7 @@ type Status struct {
 	StartEpoch    int64
 	SuspendEpoch  int64
 	PersistBook   bool
+	Base, Quote   uint32
 }
 
 // Status returns the current operating state of the Market.
@@ -403,6 +404,8 @@ func (m *Market) Status() *Status {
 		StartEpoch:    m.startEpochIdx,
 		SuspendEpoch:  m.suspendEpochIdx,
 		PersistBook:   m.persistBook,
+		Base:          m.marketInfo.Base,
+		Quote:         m.marketInfo.Quote,
 	}
 }
 

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -51,6 +51,12 @@ func (ta *TArchivist) BookOrders(base, quote uint32) ([]*order.LimitOrder, error
 	defer ta.mtx.Unlock()
 	return ta.bookedOrders, nil
 }
+func (ta *TArchivist) EpochOrders(base, quote uint32) ([]order.Order, error) {
+	return nil, nil
+}
+func (ta *TArchivist) MarketMatches(base, quote uint32, includeInactive bool) ([]*db.MatchData, error) {
+	return nil, nil
+}
 func (ta *TArchivist) FlushBook(base, quote uint32) (sells, buys []order.OrderID, err error) {
 	ta.mtx.Lock()
 	defer ta.mtx.Unlock()

--- a/spec/admin.mediawiki
+++ b/spec/admin.mediawiki
@@ -67,6 +67,12 @@ The server will provide an HTTP API for performing various adminstrative tasks.
 |-
 | /market/{marketID} || GET || display status information for a specific market
 |-
+| /market/{marketID}/orderbook || GET || display the current order book for a specific market
+|-
+| /market/{marketID}/epochorders || GET || display current epoch orders for a specific market
+|-
+| /market/{marketID}/matches?includeinactive=BOOL || GET || display active matches for a specific market. If includeinactive, completed matches are also returned
+|-
 | /market/{marketID}/suspend?t=EPOCH-MS&persist=BOOL || GET || schedule a market suspension at the end of the current epoch
 |-
 | /notifyall || POST || send a notification containing text in the request body to all connected clients. Header Content-Type must be set to "text/plain"


### PR DESCRIPTION
closes #727 

Adds admin functions to retrieve market data. Separated into getting the orderbook, epoch orders, and matches for a specific market. Matches can also show inactive matches if a token is included.

While some of this data could be taken from memory in other places, I think trusting the database as the ultimate source of truth is reasonable.