### PR TITLE
core: don't fail match on misses and redeem errors

### DIFF
--- a/client/cmd/dexc/ui/config.go
+++ b/client/cmd/dexc/ui/config.go
@@ -24,7 +24,7 @@ const (
 	defaultRPCKeyFile  = "rpc.key"
 	defaultWebAddr     = "localhost:5758"
 	configFilename     = "dexc.conf"
-	defaultLogLevel    = "info"
+	defaultLogLevel    = "debug"
 )
 
 var (

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2733,7 +2733,6 @@ func (c *Core) authDEX(dc *dexConnection) error {
 		for _, match := range missing {
 			c.log.Warnf("DEX %s did not report active match %s on order %s - assuming revoked.",
 				dc.acct.host, match.id, oid)
-			match.failErr = fmt.Errorf("order not reported by the server on connect")
 			// Must have been revoked while we were gone. Flag to allow recovery
 			// and subsequent retirement of the match and parent trade.
 			match.MetaData.Proof.SelfRevoked = true

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1654,9 +1654,6 @@ func TestLogin(t *testing.T) {
 		t.Fatalf("final Login error: %v", err)
 	}
 
-	if tracker.matches[missingID].failErr == nil {
-		t.Errorf("failErr not set for missing match tracker")
-	}
 	if !tracker.matches[missingID].MetaData.Proof.SelfRevoked {
 		t.Errorf("SelfRevoked not true for missing match tracker")
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -201,11 +201,12 @@ func testDexConnection() (*dexConnection, *TWebsocket, *dexAccount) {
 			},
 			Fee: tFee,
 		},
-		notify:    func(Notification) {},
-		marketMap: map[string]*Market{tDcrBtcMktName: mkt},
-		trades:    make(map[order.OrderID]*trackedTrade),
-		epoch:     map[string]uint64{tDcrBtcMktName: 0},
-		connected: true,
+		tickInterval: time.Millisecond * 1000 / 3,
+		notify:       func(Notification) {},
+		marketMap:    map[string]*Market{tDcrBtcMktName: mkt},
+		trades:       make(map[order.OrderID]*trackedTrade),
+		epoch:        map[string]uint64{tDcrBtcMktName: 0},
+		connected:    true,
 	}, conn, acct
 }
 
@@ -5342,8 +5343,8 @@ func TestSuspectTrades(t *testing.T) {
 	setSwaps()
 	tDcrWallet.swapErr = tErr
 	_, err = tCore.tick(tracker)
-	if err == nil {
-		t.Fatalf("swap error not propagated")
+	if err == nil || !strings.Contains(err.Error(), "error sending swap transaction") {
+		t.Fatalf("swap error not propagated, err = %v", err)
 	}
 	if tDcrWallet.swapCounter != 1 {
 		t.Fatalf("never swapped")
@@ -5415,8 +5416,8 @@ func TestSuspectTrades(t *testing.T) {
 	setRedeems()
 	tBtcWallet.redeemErr = tErr
 	_, err = tCore.tick(tracker)
-	if err == nil {
-		t.Fatalf("redeem error not propagated")
+	if err == nil || !strings.Contains(err.Error(), "error sending redeem transaction") {
+		t.Fatalf("redeem error not propagated. err = %v", err)
 	}
 	if tBtcWallet.redeemCounter != 1 {
 		t.Fatalf("never redeemed")

--- a/client/core/status.go
+++ b/client/core/status.go
@@ -144,13 +144,13 @@ func (c *Core) resolveConflictWithServerData(dc *dexConnection, trade *trackedTr
 	if resolver != nil {
 		resolver(dc, trade, match, srvData)
 	} else {
-		// We don't know how to handle this. Set the failErr, and self-revoke
+		// We don't know how to handle this. Set the swapErr, and self-revoke
 		// the match. This condition would be virtually impossible, because it
 		// would mean that the client and server were at least two steps out of
 		// sync.
-		match.failErr = fmt.Errorf("status conflict (%s -> %s) has no handler. %s",
+		match.swapErr = fmt.Errorf("status conflict (%s -> %s) has no handler. %s",
 			match.MetaData.Status, srvStatus, logID)
-		c.log.Error(match.failErr)
+		c.log.Error(match.swapErr)
 		match.MetaData.Proof.SelfRevoked = true
 		err := c.db.UpdateMatch(&match.MetaMatch)
 		if err != nil {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1494,6 +1494,7 @@ func (t *trackedTrade) findMakersRedemption(match *matchTracker) {
 		proof.MakerRedeem = []byte(redemptionCoinID)
 		proof.Secret = secret
 		proof.SelfRevoked = true // Set match as revoked.
+		match.failErr = nil
 		err = t.db.UpdateMatch(&match.MetaMatch)
 		if err != nil {
 			t.dc.log.Errorf("waitForRedemptions: error storing match info in database: %v", err)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1457,7 +1457,7 @@ func (c *Core) redeemMatchGroup(t *trackedTrade, matches []*matchTracker, errs *
 			}
 			t.delayTicks(match, waitTime)
 		}
-		errs.addErr(err)
+		errs.add("error sending redeem transaction: %v", err)
 		return
 	}
 

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -549,7 +549,7 @@ func TestOrderStatusReconciliation(t *testing.T) {
 		// revocation due to match inaction.
 		var isTaker bool
 		for _, match := range tracker.matches {
-			match.failErr = fmt.Errorf("ditch match")
+			match.swapErr = fmt.Errorf("ditch match")
 			isTaker = match.Match.Side == order.Taker
 			break // only interested in first match
 		}
@@ -827,9 +827,9 @@ func monitorTrackedTrade(ctx context.Context, client *tClient, tracker *trackedT
 			side, status := match.Match.Side, match.Match.Status
 			if status >= finalStatus {
 				// We've done the needful for this match,
-				// - prevent further action by blocking the match with a failErr
+				// - prevent further action by blocking the match with a swapErr
 				// - check if this client will be suspended for inaction
-				match.failErr = fmt.Errorf("take no further action")
+				match.swapErr = fmt.Errorf("take no further action")
 				if (side == order.Maker && makerAtFault) || (side == order.Taker && takerAtFault) {
 					client.atFault = true
 				}

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -301,7 +301,6 @@ func TestMakerGhostingAfterTakerRedeem(t *testing.T) {
 			} else {
 				client.log("%s: resuming trade negotiations to audit Maker's redeem", side)
 			}
-			match.failErr = nil // remove next action blocker on match
 		}
 		tracker.mtx.Unlock()
 		// force next action since trade.tick() will not be called for disconnected dcs.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -43,7 +43,7 @@ func (set *errorSet) addErr(err error) *errorSet {
 	return set
 }
 
-// If any returns the error set if there are any errors, else nil.
+// ifAny returns the error set if there are any errors, else nil.
 func (set *errorSet) ifAny() error {
 	if len(set.errs) > 0 {
 		return set


### PR DESCRIPTION
**dexc**
- Set default log level to debug.

**core**
- Allow retries of failed swaps until the broadcast timeout has expired
- Allow retries of redemptions frequently until the broadcast timeout, and less frequently afterwards until resolution.
- Do not group swaps or redemptions for retries.
- Retries on failed swaps and redeems are metered so that they don't run every tick, but reconfiguring a wallet clears the tick meterer.
