### PR TITLE
client: startup improvements and minor fixes

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2845,7 +2845,7 @@ func (c *Core) initialize() {
 	c.connMtx.RLock()
 	c.log.Infof("Successfully connected to %d out of %d DEX servers", len(c.conns), len(accts))
 	for dexName, dc := range c.conns {
-		activeOrders, _ := c.dbOrders(dc)
+		activeOrders, _ := c.dbOrders(dc) // non-nil error will load 0 orders, and any subsequent db error will cause a shutdown on dex auth or sooner
 		if n := len(activeOrders); n > 0 {
 			c.log.Warnf("\n\n\t ****  IMPORTANT: You have %d active orders on %s. LOGIN immediately!  **** \n", n, dexName)
 		}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3218,6 +3218,9 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				notifyErr("Order coin error", "Source coins retrieval error for %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
 				continue
 			}
+			// NOTE: change and changeLocked are not set even if the funding
+			// coins were loaded from the DB's ChangeCoin.
+			tracker.coinsLocked = true
 			tracker.coins = mapifyCoins(coins)
 		}
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2784,7 +2784,7 @@ func (c *Core) AssetBalance(assetID uint32) (*WalletBalance, error) {
 func (c *Core) initialize() {
 	accts, err := c.db.Accounts()
 	if err != nil {
-		c.log.Errorf("Error retrieve accounts from database: %v", err)
+		c.log.Errorf("Error retrieving accounts from database: %v", err) // panic?
 	}
 	var wg sync.WaitGroup
 	for _, acct := range accts {
@@ -2793,7 +2793,7 @@ func (c *Core) initialize() {
 			defer wg.Done()
 			host, err := addrHost(acct.Host)
 			if err != nil {
-				c.log.Errorf("skipping loading of %s due to address parse error: %w", acct.Host, err)
+				c.log.Errorf("skipping loading of %s due to address parse error: %v", acct.Host, err)
 				return
 			}
 			dc, err := c.connectDEX(acct)
@@ -2844,6 +2844,12 @@ func (c *Core) initialize() {
 	wg.Wait()
 	c.connMtx.RLock()
 	c.log.Infof("Successfully connected to %d out of %d DEX servers", len(c.conns), len(accts))
+	for dexName, dc := range c.conns {
+		activeOrders, _ := c.dbOrders(dc)
+		if n := len(activeOrders); n > 0 {
+			c.log.Warnf("\n\n\t ****  IMPORTANT: You have %d active orders on %s. LOGIN immediately!  **** \n", n, dexName)
+		}
+	}
 	c.connMtx.RUnlock()
 	c.refreshUser()
 }
@@ -2930,11 +2936,7 @@ func (c *Core) reFee(dcrWallet *xcWallet, dc *dexConnection) {
 	c.verifyRegistrationFee(dcrWallet.AssetID, dc, acctInfo.FeeCoin, confs)
 }
 
-// dbTrackers prepares trackedTrades based on active orders and matches in the
-// database. Since dbTrackers runs before sign in when wallets are not connected
-// or unlocked, wallets and coins are not added to the returned trackers. Use
-// resumeTrades with the app Crypter to prepare wallets and coins.
-func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, error) {
+func (c *Core) dbOrders(dc *dexConnection) ([]*db.MetaOrder, error) {
 	// Prepare active orders, according to the DB.
 	dbOrders, err := c.db.ActiveDEXOrders(dc.acct.host)
 	if err != nil {
@@ -2967,6 +2969,20 @@ func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, e
 			return nil, fmt.Errorf("database error fetching order %s for %s: %v", oid, dc.acct.host, err)
 		}
 		dbOrders = append(dbOrders, dbOrder)
+	}
+
+	return dbOrders, nil
+}
+
+// dbTrackers prepares trackedTrades based on active orders and matches in the
+// database. Since dbTrackers may run before sign in when wallets are not
+// connected or unlocked, wallets and coins are not added to the returned
+// trackers. Use resumeTrades with the app Crypter to prepare wallets and coins.
+func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, error) {
+	// Prepare active orders, according to the DB.
+	dbOrders, err := c.dbOrders(dc)
+	if err != nil {
+		return nil, err
 	}
 
 	trackers := make(map[order.OrderID]*trackedTrade, len(dbOrders))
@@ -3026,7 +3042,7 @@ func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, e
 		copy(pimg[:], metaCancel.MetaData.Proof.Preimage)
 		err = tracker.cancelTrade(co, pimg)
 		if err != nil {
-			c.log.Errorf("error setting cancel order info %s: %w", co.ID(), err)
+			c.log.Errorf("Error setting cancel order info %s: %v", co.ID(), err)
 		}
 		// TODO: The trackedTrade.cancel.matches is not being repopulated on
 		// startup. The consequences are that the Filled value will not include

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -127,8 +127,8 @@ func newTrackedTrade(dbOrder *db.MetaOrder, preImg order.Preimage, dc *dexConnec
 		wallets:       wallets,
 		preImg:        preImg,
 		mktID:         marketName(ord.Base(), ord.Quote()),
-		coins:         mapifyCoins(coins),
-		coinsLocked:   true,
+		coins:         mapifyCoins(coins), // must not be nil even if empty
+		coinsLocked:   len(coins) > 0,
 		lockTimeTaker: lockTimeTaker,
 		lockTimeMaker: lockTimeMaker,
 		matches:       make(map[order.MatchID]*matchTracker),
@@ -186,7 +186,7 @@ func (t *trackedTrade) coreOrderInternal() *Order {
 // BUY order.
 // lockedAmount should be called with the mtx >= RLocked.
 func (t *trackedTrade) lockedAmount() (locked uint64) {
-	if t.coinsLocked { // implies no swap has been sent
+	if t.coinsLocked { // implies no swap has been sent or the trade has been resumed on restart after swap
 		for _, coin := range t.coins {
 			locked += coin.Value()
 		}

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -186,7 +186,10 @@ func (t *trackedTrade) coreOrderInternal() *Order {
 // BUY order.
 // lockedAmount should be called with the mtx >= RLocked.
 func (t *trackedTrade) lockedAmount() (locked uint64) {
-	if t.coinsLocked { // implies no swap has been sent or the trade has been resumed on restart after swap
+	if t.coinsLocked {
+		// This implies either no swap has been sent, or the trade has been
+		// resumed on restart after a swap that produced locked change (partial
+		// fill and still booked) since restarting loads into coins/coinsLocked.
 		for _, coin := range t.coins {
 			locked += coin.Value()
 		}

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -316,7 +316,8 @@ func (s *WebServer) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		s.readNotifications(ctx)
 	}()
 
-	log.Infof("Web server listening on http://%s", s.addr)
+	log.Infof("Web server listening on %s", s.addr)
+	fmt.Printf("\n\t****  OPEN IN YOUR BROWSER TO TRADE  --->  http://%s  ****\n\n", s.addr)
 	return &wg, nil
 }
 


### PR DESCRIPTION
Startup now prints a couple helpful new messages:

```
2020-10-22 19:19:54.820 [INF] WEB: Web server listening on 127.0.0.1:6758

	****  OPEN IN YOUR BROWSER TO TRADE  --->  http://127.0.0.1:6758  ****

2020-10-22 19:19:55.118 [DBG] CORE: notify: |POKE| (conn) DEX connected - DEX at 127.0.0.1:7232 has connected
2020-10-22 19:19:55.120 [DBG] CORE: Broadcast timeout = 1m0s, ticking every 20s
2020-10-22 19:19:55.120 [INF] CORE: Connected to DEX server at 127.0.0.1:7232 and listening for messages.
2020-10-22 19:19:55.120 [DBG] CORE: connectDEX for 127.0.0.1:7232 completed, checking account...
2020-10-22 19:19:55.120 [DBG] CORE: dex connection to 127.0.0.1:7232 ready
2020-10-22 19:19:55.120 [INF] CORE: Successfully connected to 1 out of 1 DEX servers
2020-10-22 19:19:55.120 [INF] CORE: Loaded 1 active orders.
2020-10-22 19:19:55.120 [INF] CORE: Loaded 0 active match orders
2020-10-22 19:19:55.120 [WRN] CORE: 

	 ****  IMPORTANT: You have 1 active orders on 127.0.0.1:7232. LOGIN immediately!  **** 
```

The second "IMPORTANT" message is only displayed if there are active orders in the client DB.  This involves loading up the active orders prior to DEX auth, but they are discarded after being counted, to be loaded again on connect when the trackedTrades are created.  This is slightly inefficient, but it's simple.

The second commit fixes an issue where post-swap resumed trades had coinsLocked=true but no stored coins.  Normally coinsLocked is set to false in swapMatches, but on restart it creates a trackedTrade with it set to true always.  This was resulting in a harmless but confusing message when a trade got retired (`[WRN] CORE: Unable to return btc funding coins: cannot return zero coins`).