### PR TITLE
server/{dex,market}: cleaner shutdown

### DIFF
--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -875,6 +875,8 @@ func (auth *AuthManager) addClient(client *clientInfo) {
 		if oldConnID == connID {
 			return // reused conn, just update maps
 		}
+		log.Warnf("User %v reauthorized from %v (id %d) with an existing connection from %v (id %d). Disconnecting the old one.",
+			user, client.conn.IP(), connID, oldClient.conn.IP(), oldConnID)
 		// When replacing with a new conn, manually deregister the old conn so
 		// that when it disconnects it does not remove the new clientInfo.
 		delete(auth.conns, oldConnID)

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -475,14 +475,6 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		}
 	}
 
-	// Client comms RPC server.
-	server, err := comms.NewServer(cfg.CommsCfg)
-	if err != nil {
-		abort()
-		return nil, fmt.Errorf("NewServer failed: %v", err)
-	}
-	startSubSys("Comms Server", server)
-
 	// Having enumerated all users with booked orders, configure the AuthManager
 	// to expect them to connect in a certain time period.
 	authMgr.ExpectUsers(usersWithOrders, cfg.BroadcastTimeout)
@@ -532,6 +524,14 @@ func NewDEX(cfg *DexConf) (*DEX, error) {
 		Markets:     marketTunnels,
 	})
 	startSubSys("OrderRouter", orderRouter)
+
+	// Client comms RPC server.
+	server, err := comms.NewServer(cfg.CommsCfg)
+	if err != nil {
+		abort()
+		return nil, fmt.Errorf("NewServer failed: %v", err)
+	}
+	startSubSys("Comms Server", server)
 
 	cfgResp, err := newConfigResponse(cfg, cfgAssets, cfgMarkets)
 	if err != nil {

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -790,6 +790,21 @@ func (m *Market) Run(ctx context.Context) {
 		}
 		m.persistBook = true // future resume default
 		m.activeEpochIdx = 0
+
+		// Revoke any unmatched epoch orders (if context was canceled, not a
+		// clean suspend stopped the market).
+		for oid, ord := range m.epochOrders {
+			log.Infof("Dropping epoch order %v", oid)
+			if co, ok := ord.(*order.CancelOrder); ok {
+				if err := m.storage.FailCancelOrder(co); err != nil {
+					log.Errorf("Failed set orphaned epoch cancel order %v as executed: %v", oid, err)
+				}
+				continue
+			}
+			if err := m.storage.ExecuteOrder(ord); err != nil {
+				log.Errorf("Failed set orphaned epoch trade order %v as executed: %v", oid, err)
+			}
+		}
 		m.epochMtx.Unlock()
 
 		// Stop and wait for the order feed goroutine.

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -797,12 +797,12 @@ func (m *Market) Run(ctx context.Context) {
 			log.Infof("Dropping epoch order %v", oid)
 			if co, ok := ord.(*order.CancelOrder); ok {
 				if err := m.storage.FailCancelOrder(co); err != nil {
-					log.Errorf("Failed set orphaned epoch cancel order %v as executed: %v", oid, err)
+					log.Errorf("Failed to set orphaned epoch cancel order %v as executed: %v", oid, err)
 				}
 				continue
 			}
 			if err := m.storage.ExecuteOrder(ord); err != nil {
-				log.Errorf("Failed set orphaned epoch trade order %v as executed: %v", oid, err)
+				log.Errorf("Failed to set orphaned epoch trade order %v as executed: %v", oid, err)
 			}
 		}
 		m.epochMtx.Unlock()


### PR DESCRIPTION
**server/dex**

This reorders the subsystem stack so that DEX manager shutdown is ordered properly now.  Namely:

- <s>comms server shuts down after the subsystems that use it (all but assets)</s> comms didn't move because we want it _started_ after the subsystems that use it are up for the sake of _incoming_ message handling, even though stopping it before those dependent subsystems stop can result in dropped _outgoing_ messages
- book router shuts down after the markets that use it

**server/market**

When a market is stopped by context cancellation (not a market suspend admin command), it does not wait for the current epoch to close, so any orders in that truncated epoch were just being dropped without changing their status from epoch to executed (how a no-match/fail is normally handled when epochs are processed by the matcher). This updates the primary defer function in `(*Market).Run` so that if there are orders left in the `epochOrders` map after the closed epoch pipeline is drained, their statuses are change in the DB so that they aren't reported to clients as active orders for eternity.

Resolves https://github.com/decred/dcrdex/issues/474, although it didn't hang any more.