### PR TITLE
server/book: automatic book reallocation

### DIFF
--- a/server/book/book_test.go
+++ b/server/book/book_test.go
@@ -91,7 +91,7 @@ var (
 func newBook(t *testing.T) *Book {
 	resetMakers()
 
-	b := New(LotSize, DefaultBookHalfCapacity)
+	b := New(LotSize)
 
 	for _, o := range bookBuyOrders {
 		if ok := b.Insert(o); !ok {
@@ -156,7 +156,9 @@ func TestBook(t *testing.T) {
 			len(buys), b.BuyCount())
 	}
 
-	b.Realloc(DefaultBookHalfCapacity * 2)
+	// Hit the OrderPQ's Realloc function manually.
+	b.buys.realloc(initBookHalfCapacity * 2)
+	b.sells.realloc(initBookHalfCapacity * 2)
 
 	buys2 := b.BuyOrders()
 	if len(buys) != len(buys2) {


### PR DESCRIPTION
This hides the notion of capacity from `Book` consumers by creating a book with modestly-sized buy/sell priority queues instead of the mammoth defaults of before, and the underlying `OrderPQ`s automatically reallocate into a larger queue when `Insert`s push the queue to capacity.

The queue increases by the larger of `minCapIncrement` (4096) or 1/8th of the current utilization (note that utilization is the same as capacity when realloc is triggered by `Insert`->`Push`).

The queue will also automatically reallocate to a *smaller* capacity when `Extract*`/`Remove*`/`Pop` reduces the utilization of the queue to a point where the ideal capacity is significantly below the current capacity, specifically `savings > deallocThresh && savings > pq.capacity/3` where `deallocThresh = 10 * minCapIncrement`.