### PR TITLE
client/core: batch trade ticks for audit and redemption reqs

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4086,7 +4086,7 @@ func (c *Core) schedTradeTick(tracker *trackedTrade) {
 	}
 
 	// Schedule a tick for this trade.
-	delay := time.Duration(numMatches) * time.Second / 10 // 1 sec delay for every 10 active matches
+	delay := 2*time.Second + time.Duration(numMatches)*time.Second/10 // 1 sec extra delay for every 10 active matches
 	if delay > 5*time.Second {
 		delay = 5 * time.Second
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -264,6 +264,7 @@ type TDB struct {
 	activeDEXOrders    []*db.MetaOrder
 	matchesForOID      []*db.MetaMatch
 	matchesForOIDErr   error
+	updateMatchChan    chan order.MatchStatus
 	activeMatchOIDs    []order.OrderID
 	activeMatchOIDSErr error
 	lastStatusID       order.OrderID
@@ -349,6 +350,9 @@ func (tdb *TDB) LinkOrder(oid, linkedID order.OrderID) error {
 }
 
 func (tdb *TDB) UpdateMatch(m *db.MetaMatch) error {
+	if tdb.updateMatchChan != nil {
+		tdb.updateMatchChan <- m.Match.Status
+	}
 	return nil
 }
 
@@ -415,9 +419,16 @@ func (tdb *TDB) AckNotification(id []byte) error { return nil }
 
 type tCoin struct {
 	id       []byte
+	confsMtx sync.RWMutex
 	confs    uint32
 	confsErr error
 	val      uint64
+}
+
+func (c *tCoin) setConfs(confs uint32) {
+	c.confsMtx.Lock()
+	c.confs = confs
+	c.confsMtx.Unlock()
 }
 
 func (c *tCoin) ID() dex.Bytes {
@@ -433,6 +444,8 @@ func (c *tCoin) Value() uint64 {
 }
 
 func (c *tCoin) Confirmations() (uint32, error) {
+	c.confsMtx.RLock()
+	defer c.confsMtx.RUnlock()
 	return c.confs, c.confsErr
 }
 
@@ -503,6 +516,7 @@ type TXCWallet struct {
 	redeemCoins       []dex.Bytes
 	redeemCounter     int
 	redeemErr         error
+	redeemErrChan     chan error
 	badSecret         bool
 	fundedVal         uint64
 	fundedSwaps       uint64
@@ -597,6 +611,11 @@ func (w *TXCWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, uint6
 }
 
 func (w *TXCWallet) Redeem([]*asset.Redemption) ([]dex.Bytes, asset.Coin, uint64, error) {
+	defer func() {
+		if w.redeemErrChan != nil {
+			w.redeemErrChan <- w.redeemErr
+		}
+	}()
 	w.redeemCounter++
 	if w.redeemErr != nil {
 		return nil, nil, 0, w.redeemErr
@@ -744,6 +763,7 @@ func newTestRig() *testRig {
 			wallets:       make(map[uint32]*xcWallet),
 			blockWaiters:  make(map[uint64]*blockWaiter),
 			piSyncers:     make(map[order.OrderID]chan struct{}),
+			tickSched:     make(map[order.OrderID]*time.Timer),
 			wsConstructor: func(*comms.WsCfg) (comms.WsConn, error) {
 				return conn, nil
 			},
@@ -2638,9 +2658,12 @@ func TestTradeTracking(t *testing.T) {
 	if auth.AuditStamp != audit.Time {
 		t.Fatalf("audit time not set")
 	}
+	time.Sleep(250 * time.Millisecond) // let async tick do nothing
+
 	// Confirming the counter-swap triggers a redemption.
-	auditInfo.coin.confs = tBTC.SwapConf
+	auditInfo.coin.setConfs(tBTC.SwapConf)
 	redeemCoin := encode.RandomBytes(36)
+	//<-tBtcWallet.redeemErrChan
 	tBtcWallet.redeemCoins = []dex.Bytes{redeemCoin}
 	rig.ws.queueResponse(msgjson.RedeemRoute, redeemAcker)
 	tCore.tickAsset(dc, tBTC.ID)
@@ -2705,6 +2728,7 @@ func TestTradeTracking(t *testing.T) {
 	if err != nil {
 		t.Fatalf("taker's match message error: %v", err)
 	}
+	time.Sleep(250 * time.Millisecond) // let async tick do nothing
 
 	auditInfo.expiration = matchTime.Add(tracker.lockTimeMaker - time.Hour)
 	err = handleAuditRoute(tCore, rig.dc, msg)
@@ -2732,7 +2756,7 @@ func TestTradeTracking(t *testing.T) {
 		t.Fatalf("swap broadcast before confirmations")
 	}
 	// Now with the confirmations.
-	auditInfo.coin.confs = tBTC.SwapConf
+	auditInfo.coin.setConfs(tBTC.SwapConf)
 	swapID := encode.RandomBytes(36)
 	tDcrWallet.swapReceipts = []asset.Receipt{&tReceipt{coin: &tCoin{id: swapID}}}
 	rig.ws.queueResponse(msgjson.InitRoute, initAcker)
@@ -2763,18 +2787,40 @@ func TestTradeTracking(t *testing.T) {
 	}
 	tBtcWallet.badSecret = false
 
+	tBtcWallet.redeemErrChan = make(chan error, 1)
+	rig.db.updateMatchChan = make(chan order.MatchStatus, 1)
+	defer func() {
+		rig.db.updateMatchChan = nil
+		tBtcWallet.redeemErrChan = nil
+	}()
 	rig.ws.queueResponse(msgjson.RedeemRoute, redeemAcker)
 	err = handleRedemptionRoute(tCore, rig.dc, msg)
 	if err != nil {
 		t.Fatalf("redemption message error: %v", err)
 	}
-	checkStatus("taker complete", order.MatchComplete)
+	err = <-tBtcWallet.redeemErrChan
+	if err != nil {
+		t.Fatalf("should have worked, got: %v", err)
+	}
+	// For taker there's one status update to MakerRedeemed on bcast...
+	status := <-rig.db.updateMatchChan
+	if status != order.MakerRedeemed {
+		t.Fatalf("wrong match status wanted %v, got %v", order.MakerRedeemed, status)
+	}
+	// and another to MatchComplete when the 'redeem' request back to the server
+	// succeeds.
+	status = <-rig.db.updateMatchChan
+	if status != order.MatchComplete {
+		t.Fatalf("wrong match status wanted %v, got %v", order.MatchComplete, status)
+	}
 	if !bytes.Equal(proof.MakerRedeem, redemptionCoin) {
 		t.Fatalf("redemption coin ID not logged")
 	}
 	if len(proof.TakerRedeem) == 0 {
 		t.Fatalf("taker redemption not sent")
 	}
+	rig.db.updateMatchChan = nil
+	tBtcWallet.redeemErrChan = nil
 
 	// CANCEL ORDER MATCH
 	//
@@ -3250,7 +3296,8 @@ func TestRefunds(t *testing.T) {
 		t.Fatalf("taker's match message error: %v", err)
 	}
 	checkStatus("taker counter-party swapped", match, order.MakerSwapCast)
-	auditInfo.coin.confs = tBTC.SwapConf
+	time.Sleep(250 * time.Millisecond) // let async tick from successful handleAuditRoute do nothing
+	auditInfo.coin.setConfs(tBTC.SwapConf)
 	counterSwapID := encode.RandomBytes(36)
 	counterScript := encode.RandomBytes(36)
 	tDcrWallet.swapReceipts = []asset.Receipt{&tReceipt{coin: &tCoin{id: counterSwapID}, contract: counterScript}}
@@ -4604,7 +4651,7 @@ func TestReconfigureWallet(t *testing.T) {
 			toWallet:   &xcWallet{},
 		},
 		matches: map[order.MatchID]*matchTracker{
-			order.MatchID{}: match,
+			{}: match,
 		},
 	}
 

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1929,7 +1929,7 @@ func (t *trackedTrade) processMakersRedemption(match *matchTracker, coinID, secr
 	secretHash := proof.SecretHash
 	wallet := t.wallets.toWallet
 	if !wallet.ValidateSecret(secret, secretHash) {
-		return fmt.Errorf("secret %s received does not hash to the reported secret hash, %s",
+		return fmt.Errorf("secret %x received does not hash to the reported secret hash, %x",
 			secret, secretHash)
 	}
 


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/780

This delays a trade's tick that is usually launched by the redemption (and audit) requests to allow for multiple redemptions to be batched more effectively. Specifically, the handlers now process the message and update the trade and match fields so that when tick happens after a delay, there can be multiple redeems provided to `redeemMatches` instead of one at a time several times.