### PR TITLE
core: match status resolution fixes

### DIFF
--- a/client/core/status.go
+++ b/client/core/status.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"fmt"
+	"sync"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex/msgjson"
@@ -17,37 +18,27 @@ func statusResolutionID(dc *dexConnection, trade *trackedTrade, match *matchTrac
 	return fmt.Sprintf("host = %s, order = %s, match = %s", dc.acct.host, trade.ID(), match.id)
 }
 
-// resolveMatchConflicts accepts a dexConnection and a slice of match status
-// conflicts. resolveMatchConflicts will block until the call to match_status
-// returns, but then goroutines are started to handle the actual resolution.
-// The trackedTrades' mutexes will remain locked until resolution completes.
-func (c *Core) resolveMatchConflicts(dc *dexConnection, statusConflicts []*matchStatusConflict) {
+// resolveMatchConflicts attempts to resolve conflicts between the server's
+// reported match status and our own. This involves a 'match_status' request to
+// the server and possibly some wallet operations. ResolveMatchConflicts will
+// block until resolution is complete.
+func (c *Core) resolveMatchConflicts(dc *dexConnection, statusConflicts map[order.OrderID]*matchStatusConflict) {
 
 	statusRequests := make([]*msgjson.MatchRequest, 0, len(statusConflicts))
-	// Lock the trade mutexes now until we're done. The other option would be
-	// to lock the trade mutexes in resolveConflictWithServerData, but that
-	// might allow a tick to occur between the match_status request and
-	// resolveConflictWithServerData. Our resolvers never send any requests or
-	// or responses. The longest running functions only request some wallet
-	// data, so I wouldn't expect these locks to be held for long. Regardless,
-	// we'll run each resolveConflictWithServerData below as a goroutine just to
-	// make sure we're not stacking those wallet calls.
 	for _, conflict := range statusConflicts {
-		conflict.trade.mtx.Lock()
-		statusRequests = append(statusRequests, &msgjson.MatchRequest{
-			Base:    conflict.trade.Base(),
-			Quote:   conflict.trade.Quote(),
-			MatchID: conflict.match.id[:],
-		})
+		for _, match := range conflict.matches {
+			statusRequests = append(statusRequests, &msgjson.MatchRequest{
+				Base:    conflict.trade.Base(),
+				Quote:   conflict.trade.Quote(),
+				MatchID: match.id[:],
+			})
+		}
 	}
 
 	var msgStatuses []*msgjson.MatchStatusResult
 	err := sendRequest(dc.WsConn, msgjson.MatchStatusRoute, statusRequests, &msgStatuses, DefaultResponseTimeout)
 	if err != nil {
-		for _, conflict := range statusConflicts {
-			conflict.trade.mtx.Unlock()
-		}
-		c.log.Errorf("match_status request error for %s requesting %d match statuses. %s: %v", dc.acct.host, len(statusRequests), err)
+		c.log.Errorf("match_status request error for %s requesting %d match statuses: %v", dc.acct.host, len(statusRequests), err)
 		return
 	}
 
@@ -59,32 +50,31 @@ func (c *Core) resolveMatchConflicts(dc *dexConnection, statusConflicts []*match
 		resMap[matchID] = msgStatus
 	}
 
+	var wg sync.WaitGroup
 	for _, conflict := range statusConflicts {
-		srvData := resMap[conflict.match.id]
-		if srvData == nil {
-			// I don't really know how this would happen, considering the server
-			// reported the match as active in the connect response. I'm also
-			// not sure what action to take. Maybe just revoke the match.
-			c.log.Errorf("Server did not report a status for match during resolution. %s", statusResolutionID(dc, conflict.trade, conflict.match))
-			// revokeMatch only returns an error for a missing match ID,
-			// and we already checked in compareServerMatches.
-			conflict.trade.revokeMatch(conflict.match.id, false)
-			conflict.trade.mtx.Unlock()
-			continue
-		}
-
-		if order.MatchStatus(srvData.Status) != order.MatchComplete && !srvData.Active {
-			// Server has revoked the match. We'll still go through
-			// resolveConflictWithServerData to collect any extra data the
-			// server has, but setting ServerRevoked will prevent us from
-			// trying to update the state with the server.
-			conflict.match.MetaData.Proof.ServerRevoked = true
-		}
-		go func(trade *trackedTrade, match *matchTracker) {
-			c.resolveConflictWithServerData(dc, trade, match, srvData)
-			trade.mtx.Unlock()
-		}(conflict.trade, conflict.match)
+		wg.Add(1)
+		go func(trade *trackedTrade, matches []*matchTracker) {
+			defer wg.Done()
+			trade.mtx.Lock()
+			defer trade.mtx.Unlock()
+			for _, match := range matches {
+				srvData := resMap[match.id]
+				if srvData == nil {
+					// I don't really know how this would happen, considering the server
+					// reported the match as active in the connect response. I'm also
+					// not sure what action to take. Maybe just revoke the match.
+					c.log.Errorf("Server did not report a status for match during resolution. %s", statusResolutionID(dc, trade, match))
+					// revokeMatch only returns an error for a missing match ID,
+					// and we already checked in compareServerMatches.
+					trade.revokeMatch(match.id, false)
+					continue
+				}
+				c.resolveConflictWithServerData(dc, trade, match, srvData)
+			}
+		}(conflict.trade, conflict.matches)
 	}
+
+	wg.Wait()
 }
 
 // The matchConflictResolver is unique to a MatchStatus pair and handles
@@ -128,6 +118,14 @@ func conflictResolver(ours, servers order.MatchStatus) matchConflictResolver {
 // self-revoked.
 func (c *Core) resolveConflictWithServerData(dc *dexConnection, trade *trackedTrade, match *matchTracker, srvData *msgjson.MatchStatusResult) {
 	srvStatus := order.MatchStatus(srvData.Status)
+
+	if srvStatus != order.MatchComplete && !srvData.Active {
+		// Server has revoked the match. We'll still go through
+		// resolveConflictWithServerData to collect any extra data the
+		// server has, but setting ServerRevoked will prevent us from
+		// trying to update the state with the server.
+		match.MetaData.Proof.ServerRevoked = true
+	}
 
 	if srvStatus == match.MetaData.Status || match.MetaData.Proof.IsRevoked() {
 		// On startup, there's no chance for a tick between the connect request

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1279,14 +1279,14 @@ func (s *Swapper) step(user account.AccountID, matchID order.MatchID) (*stepInfo
 			nextStep = order.MakerSwapCast
 			isBaseAsset = maker.Sell // maker swap: base asset if sell
 			if len(match.Sigs.MakerMatch) == 0 {
-				log.Debugf("swap %v at status %v missing MakerMatch signature(s) needed for NewlyMatched->MakerSwapCast",
+				log.Debugf("swap %v at status %v missing MakerMatch signature(s) expected before NewlyMatched->MakerSwapCast",
 					match.ID(), match.Status)
 			}
 		} else /* TakerSwapCast */ {
 			nextStep = order.MakerRedeemed
 			isBaseAsset = !maker.Sell // maker redeem: base asset if buy
 			if len(match.Sigs.MakerAudit) == 0 {
-				log.Debugf("swap %v at status %v missing MakerAudit signature(s) needed for TakerSwapCast->MakerRedeemed",
+				log.Debugf("Swap %v at status %v missing MakerAudit signature(s) expected before TakerSwapCast->MakerRedeemed",
 					match.ID(), match.Status)
 			}
 		}
@@ -1301,11 +1301,11 @@ func (s *Swapper) step(user account.AccountID, matchID order.MatchID) (*stepInfo
 			nextStep = order.TakerSwapCast
 			isBaseAsset = !maker.Sell // taker swap: base asset if sell (maker buy)
 			if len(match.Sigs.TakerMatch) == 0 {
-				log.Debugf("swap %v at status %v missing TakerMatch signature(s) needed for MakerSwapCast->TakerSwapCast",
+				log.Debugf("Swap %v at status %v missing TakerMatch signature(s) expected before MakerSwapCast->TakerSwapCast",
 					match.ID(), match.Status)
 			}
 			if len(match.Sigs.TakerAudit) == 0 {
-				log.Debugf("swap %v at status %v missing TakerAudit signature(s) needed for MakerSwapCast->TakerSwapCast",
+				log.Debugf("Swap %v at status %v missing TakerAudit signature(s) expected before MakerSwapCast->TakerSwapCast",
 					match.ID(), match.Status)
 			}
 		} else /* MakerRedeemed */ {
@@ -1314,7 +1314,7 @@ func (s *Swapper) step(user account.AccountID, matchID order.MatchID) (*stepInfo
 			// counterparties acknowledge the redemptions.
 			isBaseAsset = maker.Sell // taker redeem: base asset if buy (maker sell)
 			if len(match.Sigs.TakerRedeem) == 0 {
-				log.Debugf("swap %v at status %v missing TakerRedeem signature(s) needed for MakerRedeemed->MatchComplete",
+				log.Debugf("Swap %v at status %v missing TakerRedeem signature(s) expected before MakerRedeemed->MatchComplete",
 					match.ID(), match.Status)
 			}
 		}


### PR DESCRIPTION
Fixes some issues with match status resolution, the worst of which could result in client deadlock. 

1. chappjc's `extras` loop bug fix from #802 
2. bug with locking the `matchStatusConflict` in a loop, because we were creating a `matchStatusConflict` for every match instead of one per order. That is resolved, and the offending locking pattern has been remedied.