### PR TITLE
core,ui: add confirmation for currently waiting swap

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2115,7 +2115,9 @@ func (c *Core) Orders(filter *OrderFilter) ([]*Order, error) {
 }
 
 // coreOrderFromMetaOrder creates an *Order from a *db.MetaOrder, including
-// loading matches from the database.
+// loading matches from the database. The order is presumed to be inactive, so
+// swap coin confirmations will not be set. For active orders, get the
+// *trackedTrade and use the coreOrder method.
 func (c *Core) coreOrderFromMetaOrder(mOrd *db.MetaOrder) (*Order, error) {
 	corder := coreOrderFromTrade(mOrd.Order, mOrd.MetaData)
 	oid := mOrd.Order.ID()
@@ -2125,7 +2127,7 @@ func (c *Core) coreOrderFromMetaOrder(mOrd *db.MetaOrder) (*Order, error) {
 	}
 	corder.Matches = make([]*Match, 0, len(matches))
 	for _, match := range matches {
-		corder.Matches = append(corder.Matches, matchFromMetaMatch(match))
+		corder.Matches = append(corder.Matches, matchFromMetaMatch(mOrd.Order, match))
 	}
 	return corder, nil
 }
@@ -2137,6 +2139,20 @@ func (c *Core) Order(oidB dex.Bytes) (*Order, error) {
 	}
 	var oid order.OrderID
 	copy(oid[:], oidB)
+	// See if its an active order first.
+	var tracker *trackedTrade
+	c.connMtx.RLock()
+	for _, dc := range c.conns {
+		tracker, _, _ = dc.findOrder(oid)
+		if tracker != nil {
+			break
+		}
+	}
+	c.connMtx.RUnlock()
+	if tracker != nil {
+		return tracker.coreOrder(), nil
+	}
+	// Must not be an active order. Get it from the database.
 	mOrd, err := c.db.Order(oid)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving order %s: %w", oid, err)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -764,7 +764,7 @@ func newTestRig() *testRig {
 
 	crypter := &tCrypter{}
 
-	return &testRig{
+	rig := &testRig{
 		core: &Core{
 			ctx:      tCtx,
 			cfg:      &Config{},
@@ -793,6 +793,8 @@ func newTestRig() *testRig {
 		acct:    acct,
 		crypter: crypter,
 	}
+	rig.core.refreshUser()
+	return rig
 }
 
 func (rig *testRig) queueConfig() {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -192,10 +192,9 @@ type MatchNote struct {
 }
 
 func newMatchNote(subject, details string, severity db.Severity, t *trackedTrade, match *matchTracker) *MatchNote {
-	oid := t.ID()
 	return &MatchNote{
 		Notification: db.NewNotification(NoteTypeMatch, subject, details, severity),
-		OrderID:      oid[:],
+		OrderID:      t.ID().Bytes(),
 		Match: matchFromMetaMatchWithConfs(t.Order, &match.MetaMatch, match.swapConfirms,
 			int64(t.wallets.fromAsset.SwapConf), match.counterConfirms, int64(t.wallets.toAsset.SwapConf)),
 		Host:     t.dc.acct.host,

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -784,16 +784,15 @@ func (t *trackedTrade) isSwappable(match *matchTracker) bool {
 					match.id, confs, req)
 			}
 			return ready
-		} else {
-			// If we're the maker, check the confirmations anyway so we can
-			// notify.
-			confs, err := wallet.Confirmations([]byte(metaData.Proof.MakerSwap))
-			if err != nil {
-				t.dc.log.Errorf("error getting confirmation for our own swap transaction: %v", err)
-			}
-			match.swapConfirms = int64(confs)
-			t.notify(newMatchNote("confirms", "", db.Data, t, match))
 		}
+		// If we're the maker, check the confirmations anyway so we can
+		// notify.
+		confs, err := wallet.Confirmations([]byte(metaData.Proof.MakerSwap))
+		if err != nil {
+			t.dc.log.Errorf("error getting confirmation for our own swap transaction: %v", err)
+		}
+		match.swapConfirms = int64(confs)
+		t.notify(newMatchNote("confirms", "", db.Data, t, match))
 		return false
 	}
 	if dbMatch.Side == order.Maker && metaData.Status == order.NewlyMatched {
@@ -832,14 +831,13 @@ func (t *trackedTrade) isRedeemable(match *matchTracker) bool {
 					match.id, confs, req)
 			}
 			return ready
-		} else {
-			confs, err := t.wallets.fromWallet.Confirmations([]byte(metaData.Proof.TakerSwap))
-			if err != nil {
-				t.dc.log.Errorf("error getting confirmation for our own swap transaction: %v", err)
-			}
-			match.swapConfirms = int64(confs)
-			t.notify(newMatchNote("confirms", "", db.Data, t, match))
 		}
+		confs, err := t.wallets.fromWallet.Confirmations([]byte(metaData.Proof.TakerSwap))
+		if err != nil {
+			t.dc.log.Errorf("error getting confirmation for our own swap transaction: %v", err)
+		}
+		match.swapConfirms = int64(confs)
+		t.notify(newMatchNote("confirms", "", db.Data, t, match))
 		return false
 	}
 	if dbMatch.Side == order.Taker && metaData.Status == order.MakerRedeemed {

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -422,6 +422,11 @@ div.form-closer {
   }
 }
 
+.micro-icon {
+  position: relative;
+  bottom: 2px;
+}
+
 #tooltip {
   position: absolute;
   left: -10000px;

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -230,6 +230,7 @@ table.balance-table {
   .micro-icon {
     width: 13px;
     height: 13px;
+    bottom: 1px;
   }
 }
 

--- a/client/webserver/site/src/css/order.scss
+++ b/client/webserver/site/src/css/order.scss
@@ -19,11 +19,6 @@ div.order-datum {
   a:last-child {
     padding: 4px 15px;
   }
-
-  .micro-icon {
-    position: relative;
-    bottom: 2px;
-  }
 }
 
 div.match-header {

--- a/client/webserver/site/src/css/orders.scss
+++ b/client/webserver/site/src/css/orders.scss
@@ -54,9 +54,4 @@
       background-color: #7774;
     }
   }
-
-  .micro-icon {
-    position: relative;
-    bottom: 1px;
-  }
 }

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -87,112 +87,118 @@
     </div> {{- /* END DATA CARDS */ -}}
 
     {{- /* MATCHES */ -}}
-    {{if len $ord.Matches}}
-      <div class="fs18 demi pt-4 pb-2">Matches</div>
-      <div class="d-flex align-items-stretch justify-content-start flex-wrap">
-      {{range $match := $ord.MatchReaders}}
-        <div class="match-card">
-          <div class="match-header">
-            <div class="d-flex justify-content-start align-items-center">
-              <span class="match-data-label ml-3">Match ID</span>
-            </div>
-            <div class="mono mx-3 fs15">{{$match.MatchID}}</div>
+    <div class="fs18 demi pt-4 pb-2{{if eq (len $ord.Matches) 0}} d-hide{{end}}" id="matchesLabel">Matches</div>
+    <div class="d-flex align-items-stretch justify-content-start flex-wrap" id="matchBox">
+    {{range $match := $ord.MatchReaders}}
+      <div class="match-card" data-match-i-d="{{$match.MatchID}}">
+        <div class="match-header">
+          <div class="d-flex justify-content-between align-items-center">
+            <span class="match-data-label ml-3">Match ID</span>
+          </div>
+          <div class="mono mx-3 fs15">{{$match.MatchID}}</div>
+        </div>
+
+        <div class="row py-2">
+          <div class="col-10 text-center">
+            <span class="match-data-label">Status</span><br>
+            <span class="fs15" data-tmpl="status">
+              {{$match.StatusString}}
+            </span>
+          </div>
+          <div class="col-14 text-center">
+            <span class="match-data-label">Time</span><br>
+            <span class="fs15">{{$match.TimeString}}</span>
+            <span class="fs14">(<span class="fs15" data-stamp="{{$match.Stamp}}"></span> ago)</span>
+          </div>
+        </div>
+
+        {{if $match.IsCancel}}
+          <div class="text-center fs20 red">Cancellation</div>
+          <div class="text-center fs16">{{$match.FromQuantityString}} {{template "microIcon" $ord.FromSymbol}} ({{$match.OrderPortion}}%)</div>
+        {{else}}
+          <div class="text-center demi fs20 py-2">
+            {{$match.FromQuantityString}} {{template "microIcon" $ord.FromSymbol}}
+            &rarr;
+            {{$match.ToQuantityString}} {{template "microIcon" $ord.ToSymbol}}
           </div>
 
           <div class="row py-2">
             <div class="col-10 text-center">
-              <span class="match-data-label">Status</span><br>
+              <span class="match-data-label">Rate</span><br>
               <span class="fs15">
-                {{$match.StatusString}}
+                {{$match.RateString}}
               </span>
             </div>
-            <div class="col-14 text-center">
-              <span class="match-data-label">Time</span><br>
-              <span class="fs15">{{$match.TimeString}}</span> 
-              <span class="fs14">(<span class="fs15" data-stamp="{{$match.Stamp}}"></span> ago)</span>
+            <div class="col-7 text-center">
+              <span class="match-data-label">Side</span><br>
+              <span class="fs15">{{$match.Side}}</span>
             </div>
-
+            <div class="col-7 text-center">
+              <span class="match-data-label">Order Portion</span><br>
+              <span class="fs15">
+                {{$match.OrderPortion}}%
+              </span>
+            </div>
           </div>
+        {{end}}
 
-          {{if $match.IsCancel}}
-            <div class="text-center fs20 red">Cancellation</div>
-            <div class="text-center fs16">{{$match.FromQuantityString}} {{template "microIcon" $ord.FromSymbol}} ({{$match.OrderPortion}}%)</div>
-          {{else}}
-            <div class="text-center demi fs20 py-2">
-              {{$match.FromQuantityString}} {{template "microIcon" $ord.FromSymbol}}
-              &rarr;
-              {{$match.ToQuantityString}} {{template "microIcon" $ord.ToSymbol}}
-            </div>
-
-            <div class="row py-2">
-              <div class="col-10 text-center">
-                <span class="match-data-label">Rate</span><br>
-                <span class="fs15">
-                  {{$match.RateString}}
+        <div class="pt-3">
+          {{$coin := $match.Swap}}
+          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="swap">
+            <div class="d-inline-block">
+              <div class="d-flex align-items-center justify-content-between">
+                <span class="match-data-label">Swap ({{$ord.FromSymbol}}, you)</span>
+                <span class="match-data-label{{if not $match.InSwapCast}} d-hide{{end}}" data-tmpl="swapMsg">
+                  {{$match.SwapConfirmString}}
                 </span>
               </div>
-              <div class="col-7 text-center">
-                <span class="match-data-label">Side</span><br>
-                <span class="fs15">{{$match.Side}}</span>
-              </div>
-              <div class="col-7 text-center">
-                <span class="match-data-label">Order Portion</span><br>
-                <span class="fs15">
-                  {{$match.OrderPortion}}%
+              <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.FromID}}"
+                data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="swapCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
+            </div>
+          </div>
+          {{$coin = $match.CounterSwap}}
+          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="counterSwap">
+            <div class="d-inline-block">
+              <div class="d-flex align-items-center justify-content-between">
+                <span class="match-data-label">Swap ({{$ord.ToSymbol}}, them)</span>
+                <span class="match-data-label{{if not $match.InCounterSwapCast}} d-hide{{end}}" data-tmpl="counterSwapMsg">
+                  {{$match.CounterSwapConfirmString}}
                 </span>
               </div>
-            </div>
-          {{end}}
-
-          <div class="pt-3">
-            {{if len $match.Swap}}
-            <div class="px-3 pb-3">
-              <span class="match-data-label">Swap ({{$ord.FromSymbol}}, you)</span><br>
-              <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.FromID}}"
-                data-explorer-coin="{{$match.SwapString}}">{{$match.SwapString}}</a>
-            </div>
-            {{end}}
-            {{if len $match.CounterSwap}}
-            <div class="px-3 pb-3">
-              <span class="match-data-label">Swap ({{$ord.ToSymbol}}, them)</span><br>
               <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.ToID}}"
-                data-explorer-coin="{{$match.CounterSwapString}}">{{$match.CounterSwapString}}</a>
+                data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="counterSwapCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
             </div>
-            {{end}}
-            {{if len $match.Redeem}}
-            <div class="px-3 pb-3">
-              <span class="match-data-label">Redemption ({{$ord.ToSymbol}}, you)</span><br>
-              <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.ToID}}"
-                data-explorer-coin="{{$match.RedeemString}}">{{$match.RedeemString}}</a>
-            </div>
-            {{end}}
-            {{if len $match.CounterRedeem}}
-            <div class="px-3 pb-3">
-              <span class="match-data-label">Redemption ({{$ord.FromSymbol}}, them)</span><br>
-              <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.FromID}}"
-                data-explorer-coin="{{$match.CounterRedeemString}}">{{$match.CounterRedeemString}}</a>
-            </div>
-            {{end}}
-            {{if len $match.Refund}}
-            <div class="px-3 pb-3">
-              <span class="match-data-label red">Refund ({{$ord.FromSymbol}}, you)</span><br>
-              <a target="_blank" class="mono plainlink red" data-explorer-id="{{$ord.FromID}}"
-                data-explorer-coin="{{$match.RefundString}}">{{$match.RefundString}}</a>
-            </div>
-            {{end}}
           </div>
-
+          {{$coin = $match.Redeem}}
+          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="redeem">
+            <span class="match-data-label">Redemption ({{$ord.ToSymbol}}, you)</span><br>
+            <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.ToID}}"
+              data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="redeemCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
+          </div>
+          {{$coin = $match.CounterRedeem}}
+          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="counterRedeem">
+            <span class="match-data-label">Redemption ({{$ord.FromSymbol}}, them)</span><br>
+            <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.FromID}}"
+              data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="counterRedeemCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
+          </div>
+          {{$coin = $match.Refund}}
+          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="refund">
+            <span class="match-data-label red">Refund ({{$ord.FromSymbol}}, you)</span><br>
+            <a target="_blank" class="mono plainlink red" data-explorer-id="{{$ord.FromID}}"
+              data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="refundCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
+          </div>
         </div>
-      {{end}}
+
       </div>
     {{end}}
+    </div>
 
     {{- /* FUNDING COINS */ -}}
     <div class="order-datum d-inline-block my-3">
       <div class="text-left">Funding Coins</div>
       <div class="fs14 text-left">
-        {{range $ord.FundingCoinIDs}}
-          <a class="plainlink mono" data-explorer-id="{{$ord.FromID}}" data-explorer-coin="{{.}}">{{.}}</a><br>
+        {{range $ord.FundingCoins}}
+          <a class="plainlink mono" data-explorer-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
         {{end}}
       </div>
     </div>

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -486,6 +486,12 @@ export default class Application {
         this.walletMap[wallet.assetID] = wallet
         const balances = this.main.querySelectorAll(`[data-balance-target="${wallet.assetID}"]`)
         balances.forEach(el => { el.textContent = (wallet.balance.available / 1e8).toFixed(8) })
+        break
+      }
+      case 'match': {
+        const ord = this.order(note.orderID)
+        if (ord) updateMatch(ord, note.match)
+        break
       }
     }
 
@@ -704,4 +710,16 @@ function nowString () {
 function setSeverityClass (el, severity) {
   el.classList.remove('bad', 'warn', 'good')
   el.classList.add(severityClassMap[severity])
+}
+
+/* updateMatch updates the match in or adds the match to the order. */
+function updateMatch (order, match) {
+  for (const i in order.matches) {
+    const m = order.matches[i]
+    if (m.matchID === match.matchID) {
+      order.matches[i] = match
+      return
+    }
+  }
+  order.matches.push(match)
 }

--- a/client/webserver/site/src/js/orderutil.js
+++ b/client/webserver/site/src/js/orderutil.js
@@ -72,3 +72,26 @@ export function settled (order) {
     return redeemed ? settled + qty(match) : settled
   }, 0)
 }
+
+/*
+ * matchStatusString is a string used to create a displayable string describing
+ * describing the match status.
+ */
+export function matchStatusString (status, side) {
+  switch (status) {
+    case NewlyMatched:
+      return '(0 / 4) Newly Matched'
+    case MakerSwapCast:
+      return '(1 / 4) First Swap Sent'
+    case TakerSwapCast:
+      return '(2 / 4) Second Swap Sent'
+    case MakerRedeemed:
+      if (side === Maker) {
+        return 'Match Complete'
+      }
+      return '(3 / 4) Maker Redeemed'
+    case MatchComplete:
+      return 'Match Complete'
+  }
+  return 'Unknown Order Status'
+}

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -416,7 +416,7 @@ func (m *matchReader) TimeString() string {
 // InSwapCast will be true if the last match step was us broadcasting our swap
 // transaction.
 func (m *matchReader) InSwapCast() bool {
-	if m.Revoked {
+	if m.Revoked || m.Refund != nil {
 		return false
 	}
 	return (m.Match.Status == order.TakerSwapCast && m.Match.Side == order.Taker) ||
@@ -425,7 +425,7 @@ func (m *matchReader) InSwapCast() bool {
 
 // SwapConfirmString returns a string indicating the current confirmation
 // progress of the our swap contract, if and only if the counter-party has not
-// yet redeemed the swap, otherwise, and empty string is returned.
+// yet redeemed the swap, otherwise an empty string is returned.
 func (m *matchReader) SwapConfirmString() string {
 	if !m.InSwapCast() || m.Swap == nil {
 		return ""
@@ -440,7 +440,7 @@ func (m *matchReader) SwapConfirmString() string {
 // InCounterSwapCast will be true if the last match step was the counter-party
 // broadcasting their swap transaction.
 func (m *matchReader) InCounterSwapCast() bool {
-	if m.Revoked {
+	if m.Revoked || m.Refund != nil {
 		return false
 	}
 	return (m.Match.Status == order.MakerSwapCast && m.Match.Side == order.Taker) ||
@@ -449,7 +449,7 @@ func (m *matchReader) InCounterSwapCast() bool {
 
 // CounterSwapConfirmString returns a string indicating the current confirmation
 // progress of the other party's swap contract, if and only if we have not yet
-// redeemed the swap, otherwise, and empty string is returned.
+// redeemed the swap, otherwise an empty string is returned.
 func (m *matchReader) CounterSwapConfirmString() string {
 	if !m.InCounterSwapCast() || m.CounterSwap == nil {
 		return ""


### PR DESCRIPTION
Add confirmation count to match cards on the order details page, for matches in `MakerSwapCast` or `TakerSwapCast`. It's a bigger job than it sounds like, because 1) we weren't tracking confirmation count on our own swaps yet, and 2) I didn't think we should add the count unless it updated live, so the count, match status, and various coin ID links will update live now. 

<img src="https://user-images.githubusercontent.com/6109680/97868751-ddd0ea00-1cd5-11eb-9051-7b8e06033e9a.png" width="250">

There are just a few more pieces needed to make the whole page update live. Will save the rest for another PR.