### PR TITLE
align 64-bit fields for atomic

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -342,6 +342,9 @@ func init() {
 // client app communicates with the BTC blockchain and wallet. ExchangeWallet
 // satisfies the dex.Wallet interface.
 type ExchangeWallet struct {
+	// 64-bit atomic variables first. See
+	// https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	tipAtConnect      int64
 	client            *rpcclient.Client
 	node              rpcClient
 	wallet            *walletClient
@@ -350,7 +353,6 @@ type ExchangeWallet struct {
 	log               dex.Logger
 	symbol            string
 	tipChange         func(error)
-	tipAtConnect      int64
 	minNetworkVersion uint64
 	fallbackFeeRate   uint64
 	redeemConfTarget  uint64

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -349,12 +349,14 @@ func init() {
 // client app communicates with the Decred blockchain and wallet. ExchangeWallet
 // satisfies the dex.Wallet interface.
 type ExchangeWallet struct {
+	// 64-bit atomic variables first. See
+	// https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	tipAtConnect     int64
 	client           *rpcclient.Client
 	node             rpcClient
 	log              dex.Logger
 	acct             string
 	tipChange        func(error)
-	tipAtConnect     int64
 	fallbackFeeRate  uint64
 	redeemConfTarget uint64
 	useSplitTx       bool

--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -99,10 +99,12 @@ type WsCfg struct {
 
 // wsConn represents a client websocket connection.
 type wsConn struct {
+	// 64-bit atomic variables first. See
+	// https://golang.org/pkg/sync/atomic/#pkg-note-BUG.
+	rID    uint64
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 	log    dex.Logger
-	rID    uint64
 	cfg    *WsCfg
 	tlsCfg *tls.Config
 	readCh chan *msgjson.Message


### PR DESCRIPTION
See https://golang.org/pkg/sync/atomic/#pkg-note-BUG. Have seen a panic in the wild.