### PR TITLE
ui: fix settled calculations and displayed values

### DIFF
--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -93,9 +93,8 @@
       {{range $match := $ord.MatchReaders}}
         <div class="match-card">
           <div class="match-header">
-            <div class="d-flex justify-content-between align-items-center">
+            <div class="d-flex justify-content-start align-items-center">
               <span class="match-data-label ml-3">Match ID</span>
-              {{if $match.IsCancel}}<span class="red mr-3">cancellation</span>{{end}}
             </div>
             <div class="mono mx-3 fs15">{{$match.MatchID}}</div>
           </div>
@@ -115,30 +114,35 @@
 
           </div>
 
-          <div class="text-center demi fs20 py-2">
-            {{$match.FromQuantityString}}  {{template "microIcon" $ord.FromSymbol}}
-            &rarr;
-            {{$match.ToQuantityString}} {{template "microIcon" $ord.ToSymbol}}
-          </div>
+          {{if $match.IsCancel}}
+            <div class="text-center fs20 red">Cancellation</div>
+            <div class="text-center fs16">{{$match.FromQuantityString}} {{template "microIcon" $ord.FromSymbol}} ({{$match.OrderPortion}}%)</div>
+          {{else}}
+            <div class="text-center demi fs20 py-2">
+              {{$match.FromQuantityString}} {{template "microIcon" $ord.FromSymbol}}
+              &rarr;
+              {{$match.ToQuantityString}} {{template "microIcon" $ord.ToSymbol}}
+            </div>
 
-          <div class="row py-2">
-            <div class="col-10 text-center">
-              <span class="match-data-label">Rate</span><br>
-              <span class="fs15">
-                {{$match.RateString}}
-              </span>
+            <div class="row py-2">
+              <div class="col-10 text-center">
+                <span class="match-data-label">Rate</span><br>
+                <span class="fs15">
+                  {{$match.RateString}}
+                </span>
+              </div>
+              <div class="col-7 text-center">
+                <span class="match-data-label">Side</span><br>
+                <span class="fs15">{{$match.Side}}</span>
+              </div>
+              <div class="col-7 text-center">
+                <span class="match-data-label">Order Portion</span><br>
+                <span class="fs15">
+                  {{$match.OrderPortion}}%
+                </span>
+              </div>
             </div>
-            <div class="col-7 text-center">
-              <span class="match-data-label">Side</span><br>
-              <span class="fs15">{{$match.Side}}</span>
-            </div>
-            <div class="col-7 text-center">
-              <span class="match-data-label">Order Portion</span><br>
-              <span class="fs15">
-                {{$match.OrderPortion}}%
-              </span>
-            </div>
-          </div>
+          {{end}}
 
           <div class="pt-3">
             {{if len $match.Swap}}

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -186,12 +186,12 @@ func (ord *orderReader) SettledPercent() string {
 
 // FilledFrom is the sum filled in units of the outgoing asset.
 func (ord *orderReader) FilledFrom() string {
-	return precision8(ord.sumFrom(filledFilter))
+	return precision8(ord.sumFrom(filledNonCancelFilter))
 }
 
 // FilledTo is the sum filled in units of the incoming asset.
 func (ord *orderReader) FilledTo() string {
-	return precision8(ord.sumTo(filledFilter))
+	return precision8(ord.sumTo(filledNonCancelFilter))
 }
 
 // FilledPercent is the percent of the order that has filled, without percent
@@ -211,6 +211,9 @@ func (ord *orderReader) percent(filter func(match *core.Match) bool) string {
 }
 
 func settledFilter(match *core.Match) bool {
+	if match.IsCancel {
+		return false
+	}
 	return (match.Side == order.Taker && match.Status == order.MatchComplete) ||
 		(match.Side == order.Maker && (match.Status == order.MakerRedeemed || match.Status == order.MatchComplete))
 }
@@ -221,6 +224,10 @@ func settlingFilter(match *core.Match) bool {
 }
 
 func filledFilter(match *core.Match) bool { return true }
+
+func filledNonCancelFilter(match *core.Match) bool {
+	return !match.IsCancel
+}
 
 // sumFrom will sum the match quantities in units of the outgoing asset.
 func (ord *orderReader) sumFrom(filter func(match *core.Match) bool) uint64 {


### PR DESCRIPTION
1.Cancel matches are not considered for the "settled" calculation on /orders or /order. Also fixes a misleading part of the filled display that should have excluded cancellations.
2.The match card for a cancellation no longer shows trade-specific details.

<img src="https://user-images.githubusercontent.com/6109680/98239041-f5ee7680-1f2c-11eb-9837-35cff4c11f78.png" width="150">
