### PR TITLE
core: avoid wallet locked errors

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -988,13 +988,28 @@ func (btc *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 
 // Unlock unlocks the ExchangeWallet. The pw supplied should be the same as the
 // password for the underlying bitcoind wallet which will also be unlocked.
-func (btc *ExchangeWallet) Unlock(pw string, dur time.Duration) error {
-	return btc.wallet.Unlock(pw, dur)
+func (btc *ExchangeWallet) Unlock(pw string) error {
+	return btc.wallet.Unlock(pw)
 }
 
 // Lock locks the ExchangeWallet and the underlying bitcoind wallet.
 func (btc *ExchangeWallet) Lock() error {
 	return btc.wallet.Lock()
+}
+
+// Locked will be true if the wallet is currently locked.
+func (btc *ExchangeWallet) Locked() bool {
+	walletInfo, err := btc.wallet.GetWalletInfo()
+	if err != nil {
+		btc.log.Errorf("GetWalletInfo error: %w", err)
+		return false
+	}
+	if walletInfo.UnlockedUntil == nil {
+		// This wallet is not encrypted.
+		return false
+	}
+
+	return time.Unix(*walletInfo.UnlockedUntil, 0).Before(time.Now())
 }
 
 // fundedTx creates and returns a new MsgTx with the provided coins as inputs.

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1857,12 +1857,12 @@ func TestLockUnlock(t *testing.T) {
 	// just checking that the errors come through.
 	node.rawRes[methodUnlock] = mustMarshal(t, true)
 	node.rawRes[methodLockUnspent] = []byte(`true`)
-	err := wallet.Unlock("pass", time.Hour*24*365)
+	err := wallet.Unlock("pass")
 	if err != nil {
 		t.Fatalf("unlock error: %v", err)
 	}
 	node.rawErr[methodUnlock] = tErr
-	err = wallet.Unlock("pass", time.Hour*24*365)
+	err = wallet.Unlock("pass")
 	if err == nil {
 		t.Fatalf("no error for walletpassphrase error")
 	}

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -164,7 +164,7 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 	}
 
 	// Unlock the wallet for use.
-	err := rig.gamma().Unlock(walletPassword, time.Hour*24)
+	err := rig.gamma().Unlock(walletPassword)
 	if err != nil {
 		t.Fatalf("error unlocking gamma wallet: %v", err)
 	}

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -188,8 +187,9 @@ func (wc *walletClient) GetTransaction(txid string) (*GetTransactionResult, erro
 }
 
 // Unlock unlocks the wallet.
-func (wc *walletClient) Unlock(pass string, dur time.Duration) error {
-	return wc.call(methodUnlock, anylist{pass, dur / time.Second}, nil)
+func (wc *walletClient) Unlock(pass string) error {
+	// 100000000 comes from bitcoin-cli help walletpassphrase
+	return wc.call(methodUnlock, anylist{pass, 100000000}, nil)
 }
 
 // Lock locks the wallet.

--- a/client/asset/btc/wallettypes.go
+++ b/client/asset/btc/wallettypes.go
@@ -109,6 +109,10 @@ type GetWalletInfoResult struct {
 	KeyPoolSizeHDInternal uint32  `json:"keypoolsize_hd_internal"`
 	PayTxFee              float64 `json:"paytxfee"`
 	HdSeedID              string  `json:"hdseedid"`
+	// UnlockedUntil is a pointer because for encrypted locked wallets, it will
+	// be zero, but for unencrypted wallets the field won't be present in the
+	// response.
+	UnlockedUntil *int64 `json:"unlocked_until"`
 	// HDMasterKeyID is dropped in Bitcoin Core 0.18
 	HdMasterKeyID     string `json:"hdmasterkeyid"`
 	PriveyKeysEnabled bool   `json:"private_keys_enabled"`

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -361,6 +361,12 @@ func (c *tRPCClient) WalletPassphrase(passphrase string, timeoutSecs int64) erro
 	return c.passErr
 }
 
+func (c *tRPCClient) WalletInfo() (*walletjson.WalletInfoResult, error) {
+	return &walletjson.WalletInfoResult{
+		Unlocked: true,
+	}, nil
+}
+
 func (c *tRPCClient) Disconnected() bool {
 	return c.disconnected
 }

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -185,7 +185,7 @@ func runTest(t *testing.T, splitTx bool) {
 	}
 
 	// Unlock the wallet for use.
-	err := rig.beta().Unlock(walletPassword, time.Hour*24)
+	err := rig.beta().Unlock(walletPassword)
 	if err != nil {
 		t.Fatalf("error unlocking beta wallet: %v", err)
 	}
@@ -284,7 +284,7 @@ func runTest(t *testing.T, splitTx bool) {
 	checkConfs(0)
 
 	// Unlock the wallet for use.
-	err = rig.alpha().Unlock(walletPassword, time.Hour*24)
+	err = rig.alpha().Unlock(walletPassword)
 	if err != nil {
 		t.Fatalf("error unlocking alpha wallet: %v", err)
 	}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -135,9 +135,11 @@ type Wallet interface {
 	// Address returns an address for the exchange wallet.
 	Address() (string, error)
 	// Unlock unlocks the exchange wallet.
-	Unlock(pw string, dur time.Duration) error
+	Unlock(pw string) error
 	// Lock locks the exchange wallet.
 	Lock() error
+	// Locked will be true if the wallet is currently locked.
+	Locked() bool
 	// PayFee sends the dex registration fee. Transaction fees are in addition to
 	// the registration fee, and the fee rate is taken from the DEX configuration.
 	PayFee(address string, feeAmt uint64) (Coin, error)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1297,7 +1297,7 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 		return fmt.Errorf(s, a...)
 	}
 
-	err = wallet.Unlock(crypter, aYear)
+	err = wallet.Unlock(crypter)
 	if err != nil {
 		return initErr("%s wallet authentication error: %v", symbol, err)
 	}
@@ -1421,7 +1421,7 @@ func (c *Core) OpenWallet(assetID uint32, appPW []byte) error {
 
 // unlockWallet unlocks the wallet with the crypter.
 func unlockWallet(wallet *xcWallet, crypter encrypt.Crypter) error {
-	err := wallet.Unlock(crypter, aYear)
+	err := wallet.Unlock(crypter)
 	if err != nil {
 		return fmt.Errorf("unlockWallet unlock error: %v", err)
 	}
@@ -1609,7 +1609,7 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 	// this step, since an empty password signifies an unencrypted wallet.
 	wasUnlocked := wallet.unlocked()
 	if newPasswordSet {
-		err = wallet.Wallet.Unlock(string(newPW), aYear)
+		err = wallet.Wallet.Unlock(string(newPW))
 		if err != nil {
 			return newError(authErr, "Error unlocking wallet. Is the new password correct?: %v", err)
 		}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -49,7 +49,6 @@ const (
 
 var (
 	unbip = dex.BipIDSymbol
-	aYear = time.Hour * 24 * 365
 	// The coin waiters will query for transaction data every recheckInterval.
 	recheckInterval = time.Second * 5
 	// When waiting for a wallet to sync, a SyncStatus check will be performed


### PR DESCRIPTION
This PR introduces wallet password caching and some additional logic to ensure wallets are unlocked when needed. Another important change is that the `asset.Wallet` interface now has a `Locked() bool` method that needs to be implemented. Already done for **dcr** and **btc** obviously.