### PR TITLE
core: constant subjects for notifications

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -470,7 +470,7 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 		// This is just a warning about a scheduled suspension.
 		suspendTime := encode.UnixTimeMilli(int64(sp.SuspendTime))
 		detail := fmt.Sprintf("Market %s at %s is now scheduled for suspension at %v", sp.MarketID, dc.acct.host, suspendTime)
-		c.notify(newServerNotifyNote("market suspend scheduled", detail, db.WarningLevel))
+		c.notify(newServerNotifyNote(MarketSuspendScheduledSubject, detail, db.WarningLevel))
 		return nil
 	}
 
@@ -478,7 +478,7 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 	if !sp.Persist {
 		detail += " All booked orders are now PURGED."
 	}
-	c.notify(newServerNotifyNote("market suspended", detail, db.WarningLevel))
+	c.notify(newServerNotifyNote(MarketSuspendedSubject, detail, db.WarningLevel))
 
 	if sp.Persist {
 		// No book changes. Just wait for more order notes.
@@ -560,7 +560,7 @@ func handleTradeResumptionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 		dc.setMarketStartEpoch(rs.MarketID, rs.StartEpoch, false) // set the start epoch, leaving any final/persist data
 		resTime := encode.UnixTimeMilli(int64(rs.ResumeTime))
 		detail := fmt.Sprintf("Market %s at %s is now scheduled for resumption at %v", rs.MarketID, dc.acct.host, resTime)
-		c.notify(newServerNotifyNote("market resume scheduled", detail, db.WarningLevel))
+		c.notify(newServerNotifyNote(MarketResumeScheduledSubject, detail, db.WarningLevel))
 		return nil
 	}
 
@@ -579,7 +579,7 @@ func handleTradeResumptionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 
 	detail := fmt.Sprintf("Market %s at %s has resumed trading at epoch %d",
 		rs.MarketID, dc.acct.host, rs.StartEpoch)
-	c.notify(newServerNotifyNote("market resumed", detail, db.Success))
+	c.notify(newServerNotifyNote(MarketResumedSubject, detail, db.Success))
 
 	// Book notes may resume at any time. Seq not set since no book changes.
 

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -470,7 +470,7 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 		// This is just a warning about a scheduled suspension.
 		suspendTime := encode.UnixTimeMilli(int64(sp.SuspendTime))
 		detail := fmt.Sprintf("Market %s at %s is now scheduled for suspension at %v", sp.MarketID, dc.acct.host, suspendTime)
-		c.notify(newServerNotifyNote(MarketSuspendScheduledSubject, detail, db.WarningLevel))
+		c.notify(newServerNotifyNote(SubjectMarketSuspendScheduled, detail, db.WarningLevel))
 		return nil
 	}
 
@@ -478,7 +478,7 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 	if !sp.Persist {
 		detail += " All booked orders are now PURGED."
 	}
-	c.notify(newServerNotifyNote(MarketSuspendedSubject, detail, db.WarningLevel))
+	c.notify(newServerNotifyNote(SubjectMarketSuspended, detail, db.WarningLevel))
 
 	if sp.Persist {
 		// No book changes. Just wait for more order notes.
@@ -560,7 +560,7 @@ func handleTradeResumptionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 		dc.setMarketStartEpoch(rs.MarketID, rs.StartEpoch, false) // set the start epoch, leaving any final/persist data
 		resTime := encode.UnixTimeMilli(int64(rs.ResumeTime))
 		detail := fmt.Sprintf("Market %s at %s is now scheduled for resumption at %v", rs.MarketID, dc.acct.host, resTime)
-		c.notify(newServerNotifyNote(MarketResumeScheduledSubject, detail, db.WarningLevel))
+		c.notify(newServerNotifyNote(SubjectMarketResumeScheduled, detail, db.WarningLevel))
 		return nil
 	}
 
@@ -579,7 +579,7 @@ func handleTradeResumptionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 
 	detail := fmt.Sprintf("Market %s at %s has resumed trading at epoch %d",
 		rs.MarketID, dc.acct.host, rs.StartEpoch)
-	c.notify(newServerNotifyNote(MarketResumedSubject, detail, db.Success))
+	c.notify(newServerNotifyNote(SubjectMarketResumed, detail, db.Success))
 
 	// Book notes may resume at any time. Seq not set since no book changes.
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -328,7 +328,7 @@ func (c *Core) tryCancel(dc *dexConnection, oid order.OrderID) (found bool, err 
 	c.log.Infof("Cancel order %s targeting order %s at %s has been placed",
 		co.ID(), oid, dc.acct.host)
 
-	c.notify(newOrderNote(CancellingOrderSubject, "A cancel order has been submitted for order "+tracker.token(), db.Poke, tracker.coreOrderInternal()))
+	c.notify(newOrderNote(SubjectCancellingOrder, "A cancel order has been submitted for order "+tracker.token(), db.Poke, tracker.coreOrderInternal()))
 
 	return
 }
@@ -638,7 +638,7 @@ func (dc *dexConnection) reconcileTrades(srvOrderStatuses []*msgjson.OrderStatus
 		}
 
 		details := fmt.Sprintf("Status of order %v revised from %v to %v", trade.token(), previousStatus, newStatus)
-		dc.notify(newOrderNote(OrderStatusUpdateSubject, details, db.WarningLevel, trade.coreOrderInternal()))
+		dc.notify(newOrderNote(SubjectOrderStatusUpdate, details, db.WarningLevel, trade.coreOrderInternal()))
 	}
 
 	// Compare the status reported by the server for each known active trade. Orders
@@ -1547,7 +1547,7 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 	c.wallets[assetID] = wallet
 
 	details := fmt.Sprintf("Configuration for %s wallet has been updated.", unbip(assetID))
-	c.notify(newWalletConfigNote(WalletConfigurationUpdatedSubject, details, db.Success, wallet.state()))
+	c.notify(newWalletConfigNote(SubjectWalletConfigurationUpdated, details, db.Success, wallet.state()))
 
 	// Clear any existing tickGovernors for suspect matches.
 	c.connMtx.RLock()
@@ -1636,7 +1636,7 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 	wallet.encPW = encPW
 
 	details := fmt.Sprintf("Password for %s wallet has been updated.", unbip(assetID))
-	c.notify(newWalletConfigNote(WalletPasswordUpdatedSubject, details, db.Success, wallet.state()))
+	c.notify(newWalletConfigNote(SubjectWalletPasswordUpdated, details, db.Success, wallet.state()))
 
 	return nil
 }
@@ -1877,7 +1877,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	dc.cfgMtx.RUnlock()
 
 	details := fmt.Sprintf("Waiting for %d confirmations before trading at %s", requiredConfs, dc.acct.host)
-	c.notify(newFeePaymentNote(FeePaymentInProgressSubject, details, db.Success, dc.acct.host))
+	c.notify(newFeePaymentNote(SubjectFeePaymentInProgress, details, db.Success, dc.acct.host))
 
 	// Set up the coin waiter, which waits for the required number of
 	// confirmations to notify the DEX and establish an authenticated
@@ -1913,7 +1913,7 @@ func (c *Core) verifyRegistrationFee(assetID uint32, dc *dexConnection, coinID [
 		if confs < reqConfs {
 			dc.setRegConfirms(confs)
 			c.refreshUser()
-			c.notify(newFeePaymentNoteWithConfirmations(RegUpdateSubject, details, db.Data, confs, dc.acct.host))
+			c.notify(newFeePaymentNoteWithConfirmations(SubjectRegUpdate, details, db.Data, confs, dc.acct.host))
 		}
 
 		return confs >= reqConfs, nil
@@ -1925,12 +1925,12 @@ func (c *Core) verifyRegistrationFee(assetID uint32, dc *dexConnection, coinID [
 		defer func() {
 			if err != nil {
 				details := fmt.Sprintf("Error encountered while paying fees to %s: %v", dc.acct.host, err)
-				c.notify(newFeePaymentNote(FeePaymentErrorSubject, details, db.ErrorLevel, dc.acct.host))
+				c.notify(newFeePaymentNote(SubjectFeePaymentError, details, db.ErrorLevel, dc.acct.host))
 			} else {
 				details := fmt.Sprintf("You may now trade at %s", dc.acct.host)
 				dc.setRegConfirms(regConfirmationsPaid)
 				c.refreshUser()
-				c.notify(newFeePaymentNote(AccountRegisteredSubject, details, db.Success, dc.acct.host))
+				c.notify(newFeePaymentNote(SubjectAccountRegistered, details, db.Success, dc.acct.host))
 			}
 		}()
 		if err != nil {
@@ -2214,7 +2214,7 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 		err := dc.acct.unlock(crypter)
 		if err != nil {
 			details := fmt.Sprintf("error unlocking account for %s: %v", dc.acct.host, err)
-			c.notify(newFeePaymentNote(AccountUnlockErrorSubject, details, db.ErrorLevel, dc.acct.host))
+			c.notify(newFeePaymentNote(SubjectAccountUnlockError, details, db.ErrorLevel, dc.acct.host))
 			result.AuthErr = details
 			continue
 		}
@@ -2228,7 +2228,7 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 		if !dc.acct.feePaid() {
 			if len(dc.acct.feeCoin) == 0 {
 				details := fmt.Sprintf("Empty fee coin for %s.", dc.acct.host)
-				c.notify(newFeePaymentNote(FeeCoinErrorSubject, details, db.ErrorLevel, dc.acct.host))
+				c.notify(newFeePaymentNote(SubjectFeeCoinError, details, db.ErrorLevel, dc.acct.host))
 				result.AuthErr = details
 				continue
 			}
@@ -2238,7 +2238,7 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 			if err != nil {
 				c.log.Debugf("Failed to connect for reFee at %s with error: %v", dc.acct.host, err)
 				details := fmt.Sprintf("Incomplete registration detected for %s, but failed to connect to the Decred wallet", dc.acct.host)
-				c.notify(newFeePaymentNote(WalletConnectionWarningSubject, details, db.WarningLevel, dc.acct.host))
+				c.notify(newFeePaymentNote(SubjectWalletConnectionWarning, details, db.WarningLevel, dc.acct.host))
 				result.AuthErr = details
 				continue
 			}
@@ -2246,7 +2246,7 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 				err = unlockWallet(dcrWallet, crypter)
 				if err != nil {
 					details := fmt.Sprintf("Connected to Decred wallet to complete registration at %s, but failed to unlock: %v", dc.acct.host, err)
-					c.notify(newFeePaymentNote(WalletUnlockErrorSubject, details, db.ErrorLevel, dc.acct.host))
+					c.notify(newFeePaymentNote(SubjectWalletUnlockError, details, db.ErrorLevel, dc.acct.host))
 					result.AuthErr = details
 					continue
 				}
@@ -2260,7 +2260,7 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 			err := c.authDEX(dc)
 			if err != nil {
 				details := fmt.Sprintf("%s: %v", dc.acct.host, err)
-				c.notify(newDEXAuthNote(DexAuthErrorSubject, dc.acct.host, false, details, db.ErrorLevel))
+				c.notify(newDEXAuthNote(SubjectDexAuthError, dc.acct.host, false, details, db.ErrorLevel))
 				result.AuthErr = details
 				// Disable account on AccountNotFoundError.
 				var mErr *msgjson.Error
@@ -2305,7 +2305,7 @@ func (c *Core) resolveActiveTrades(crypter encrypt.Crypter) (loaded int) {
 		ready, err := c.loadDBTrades(dc, crypter, failed)
 		if err != nil {
 			details := fmt.Sprintf("Some orders failed to load from the database: %v", err)
-			c.notify(newOrderNote(OrderLoadFailureSubject, details, db.ErrorLevel, nil))
+			c.notify(newOrderNote(SubjectOrderLoadFailure, details, db.ErrorLevel, nil))
 		}
 		if len(ready) > 0 {
 			locks := c.resumeTrades(dc, ready) // fills out dc.trades
@@ -2707,7 +2707,7 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 		details = fmt.Sprintf("%sing %.8f %s, rate = %s (%s)",
 			sellString(corder.Sell), float64(corder.Qty)/conversionFactor, unbip(form.Base), rateString, tracker.token())
 	}
-	c.notify(newOrderNote(OrderPlacedSubject, details, db.Poke, corder))
+	c.notify(newOrderNote(SubjectOrderPlaced, details, db.Poke, corder))
 
 	return corder, wallets.fromWallet.AssetID, nil
 }
@@ -2880,7 +2880,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 
 			details := fmt.Sprintf("%d matches for order %s were not reported by %q and are considered revoked",
 				len(missing), trade.token(), dc.acct.host)
-			c.notify(newOrderNote(MissingMatchesSubject, details, db.ErrorLevel, trade.coreOrderInternal()))
+			c.notify(newOrderNote(SubjectMissingMatches, details, db.ErrorLevel, trade.coreOrderInternal()))
 		}
 
 		// Start negotiation for extra matches for this trade.
@@ -2891,7 +2891,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 					oid, dc.acct.host, err)
 				details := fmt.Sprintf("%d matches reported by %s were not found for %s.",
 					len(extras), dc.acct.host, trade.token())
-				c.notify(newOrderNote(MatchResolutionErrorSubject, details, db.ErrorLevel, trade.coreOrderInternal()))
+				c.notify(newOrderNote(SubjectMatchResolutionError, details, db.ErrorLevel, trade.coreOrderInternal()))
 			} else {
 				// For taker matches in MakerSwapCast, queue up match status
 				// resolution to retrieve the maker's contract and coin.
@@ -2930,11 +2930,11 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	if unknownOrdersCount > 0 {
 		details := fmt.Sprintf("%d active orders reported by DEX %s were not found.",
 			unknownOrdersCount, dc.acct.host)
-		c.notify(newDEXAuthNote(UnknownOrdersSubject, dc.acct.host, false, details, db.Poke))
+		c.notify(newDEXAuthNote(SubjectUnknownOrders, dc.acct.host, false, details, db.Poke))
 	}
 	if reconciledOrdersCount > 0 {
 		details := fmt.Sprintf("Statuses updated for %d orders.", reconciledOrdersCount)
-		c.notify(newDEXAuthNote(OrdersReconciledSubject, dc.acct.host, false, details, db.Poke))
+		c.notify(newDEXAuthNote(SubjectOrdersReconciled, dc.acct.host, false, details, db.Poke))
 	}
 
 	if len(matchConflicts) > 0 {
@@ -3107,11 +3107,11 @@ func (c *Core) reFee(dcrWallet *xcWallet, dc *dexConnection) {
 		if err != nil {
 			c.log.Errorf("reFee %s - notifyfee error: %v", dc.acct.host, err)
 			details := fmt.Sprintf("Error encountered while paying fees to %s: %v", dc.acct.host, err)
-			c.notify(newFeePaymentNote(FeePaymentErrorSubject, details, db.ErrorLevel, dc.acct.host))
+			c.notify(newFeePaymentNote(SubjectFeePaymentError, details, db.ErrorLevel, dc.acct.host))
 		} else {
 			c.log.Infof("Fee paid at %s", dc.acct.host)
 			details := fmt.Sprintf("You may now trade at %s.", dc.acct.host)
-			c.notify(newFeePaymentNote(AccountRegisteredSubject, details, db.Success, dc.acct.host))
+			c.notify(newFeePaymentNote(SubjectAccountRegistered, details, db.Success, dc.acct.host))
 			// dc.acct.pay() and c.authDEX????
 			dc.acct.markFeePaid()
 			err = c.authDEX(dc)
@@ -3348,7 +3348,7 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 		// Make sure we have the necessary wallets.
 		wallets, err := c.walletSet(dc, tracker.Base(), tracker.Quote(), trade.Sell)
 		if err != nil {
-			notifyErr(WalletMissingSubject, "Wallet retrieval error for active order %s: %v", tracker.token(), err)
+			notifyErr(SubjectWalletMissing, "Wallet retrieval error for active order %s: %v", tracker.token(), err)
 			continue
 		}
 
@@ -3383,13 +3383,13 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				// Check for unresolvable states.
 				if len(counterSwap) == 0 {
 					match.swapErr = fmt.Errorf("missing counter-swap, order %s, match %s", tracker.ID(), match.id)
-					notifyErr(MatchStatusErrorSubject, "Match %s for order %s is in state %s, but has no maker swap coin.", dbMatch.Side, tracker.token(), dbMatch.Status)
+					notifyErr(SubjectMatchStatusError, "Match %s for order %s is in state %s, but has no maker swap coin.", dbMatch.Side, tracker.token(), dbMatch.Status)
 					continue
 				}
 				counterContract := metaData.Proof.CounterScript
 				if len(counterContract) == 0 {
 					match.swapErr = fmt.Errorf("missing counter-contract, order %s, match %s", tracker.ID(), match.id)
-					notifyErr(MatchStatusErrorSubject, "Match %s for order %s is in state %s, but has no maker swap contract.", dbMatch.Side, tracker.token(), dbMatch.Status)
+					notifyErr(SubjectMatchStatusError, "Match %s for order %s is in state %s, but has no maker swap contract.", dbMatch.Side, tracker.token(), dbMatch.Status)
 					continue
 				}
 				auditInfo, err := wallets.toWallet.AuditContract(counterSwap, counterContract)
@@ -3398,7 +3398,7 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 						match.id, match.MetaData.Status, len(match.MetaData.Proof.RefundCoin) > 0, match.MetaData.Proof.IsRevoked(), err)
 					match.swapErr = fmt.Errorf("audit error, order %s, match %s: %w", tracker.ID(), match.id, err)
 					match.MetaData.Proof.SelfRevoked = true
-					notifyErr(MatchRecoveryErrorSubject, "Error auditing counter-party's swap contract (%v) during swap recovery on order %s: %v",
+					notifyErr(SubjectMatchRecoveryError, "Error auditing counter-party's swap contract (%v) during swap recovery on order %s: %v",
 						tracker.token(), coinIDString(wallets.toAsset.ID, counterSwap), err)
 					continue
 				}
@@ -3415,7 +3415,7 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				coinIDs = []order.CoinID{tracker.metaData.ChangeCoin}
 			}
 			if len(coinIDs) == 0 {
-				notifyErr(NoFundingCoinsSubject, "Order %s has no %s funding coins", tracker.token(), unbip(wallets.fromAsset.ID))
+				notifyErr(SubjectNoFundingCoins, "Order %s has no %s funding coins", tracker.token(), unbip(wallets.fromAsset.ID))
 				continue
 			}
 			byteIDs := make([]dex.Bytes, 0, len(coinIDs))
@@ -3423,12 +3423,12 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				byteIDs = append(byteIDs, []byte(cid))
 			}
 			if len(byteIDs) == 0 {
-				notifyErr(OrderCoinErrorSubject, "No coins for loaded order %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
+				notifyErr(SubjectOrderCoinError, "No coins for loaded order %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
 				continue
 			}
 			coins, err := wallets.fromWallet.FundingCoins(byteIDs)
 			if err != nil {
-				notifyErr(OrderCoinErrorSubject, "Source coins retrieval error for %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
+				notifyErr(SubjectOrderCoinError, "Source coins retrieval error for %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
 				continue
 			}
 			// NOTE: change and changeLocked are not set even if the funding
@@ -4105,9 +4105,9 @@ func handlePreimageRequest(c *Core, dc *dexConnection, msg *msgjson.Message) err
 	if err != nil {
 		return fmt.Errorf("preimage send error: %w", err)
 	}
-	subject := PreimageSentSubject
+	subject := SubjectPreimageSent
 	if isCancel {
-		subject = CancelPreimageSentSubject
+		subject = SubjectCancelPreimageSent
 	}
 	c.notify(newOrderNote(subject, "", db.Data, tracker.coreOrder()))
 	return nil

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2408,12 +2408,12 @@ func (c *Core) Withdraw(pw []byte, assetID uint32, value uint64, address string)
 	coin, err := wallet.Withdraw(address, value)
 	if err != nil {
 		details := fmt.Sprintf("Error encountered during %s withdraw: %v", unbip(assetID), err)
-		c.notify(newWithdrawNote(WithdrawErrorSubject, details, db.ErrorLevel))
+		c.notify(newWithdrawNote(SubjectWithdrawError, details, db.ErrorLevel))
 		return nil, err
 	}
 
 	details := fmt.Sprintf("Withdraw of %s has completed successfully. Coin ID = %s", unbip(assetID), coin)
-	c.notify(newWithdrawNote(WithdrawSendSubject, details, db.Success))
+	c.notify(newWithdrawNote(SubjectWithdrawSend, details, db.Success))
 
 	c.updateAssetBalance(assetID)
 	return coin, nil

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -175,8 +175,8 @@ type WithdrawNote struct {
 }
 
 const (
-	WithdrawErrorSubject = "Withdraw error"
-	WithdrawSendSubject  = "Withdraw sent"
+	SubjectWithdrawError = "Withdraw error"
+	SubjectWithdrawSend  = "Withdraw sent"
 )
 
 func newWithdrawNote(subject, details string, severity db.Severity) *WithdrawNote {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -146,14 +146,14 @@ type FeePaymentNote struct {
 }
 
 const (
-	FeePaymentInProgressSubject    = "Fee payment in progress"
-	RegUpdateSubject               = "regupdate"
-	FeePaymentErrorSubject         = "Fee payment error"
-	AccountRegisteredSubject       = "Account registered"
-	AccountUnlockErrorSubject      = "Account unlock error"
-	FeeCoinErrorSubject            = "Fee coin error"
-	WalletConnectionWarningSubject = "Wallet connection warning"
-	WalletUnlockErrorSubject       = "Wallet unlock error"
+	SubjectFeePaymentInProgress    = "Fee payment in progress"
+	SubjectRegUpdate               = "regupdate"
+	SubjectFeePaymentError         = "Fee payment error"
+	SubjectAccountRegistered       = "Account registered"
+	SubjectAccountUnlockError      = "Account unlock error"
+	SubjectFeeCoinError            = "Fee coin error"
+	SubjectWalletConnectionWarning = "Wallet connection warning"
+	SubjectWalletUnlockError       = "Wallet unlock error"
 )
 
 func newFeePaymentNote(subject, details string, severity db.Severity, dexAddr string) *FeePaymentNote {
@@ -193,35 +193,35 @@ type OrderNote struct {
 }
 
 const (
-	OrderLoadFailureSubject     = "Order load failure"
-	OrderPlacedSubject          = "Order placed"
-	MissingMatchesSubject       = "Missing matches"
-	WalletMissingSubject        = "Wallet missing"
-	MatchStatusErrorSubject     = "Match status error"
-	MatchRecoveryErrorSubject   = "Match recovery error"
-	NoFundingCoinsSubject       = "No funding coins"
-	OrderCoinErrorSubject       = "Order coin error"
-	PreimageSentSubject         = "preimage sent"
-	CancelPreimageSentSubject   = "cancel preimage sent"
-	MissedCancelSubject         = "Missed cancel"
-	OrderBookedSubject          = "Order booked"
-	NoMatchSubject              = "No match"
-	OrderCanceledSubject        = "Order canceled"
-	CancelSubject               = "cancel"
-	MatchesMadeSubject          = "Matches made"
-	SwapErrorSubject            = "Swap error"
-	SwapsInitiatedSubject       = "Swaps initiated"
-	RedemptionErrorSubject      = "Redemption error"
-	MatchCompleteSubject        = "Match complete"
-	RefundFailureSubject        = "Refund Failure"
-	MatchesRefundedSubject      = "Matches Refunded"
-	MatchRevokedSubject         = "Match revoked"
-	RevokeSubject               = "revoke"
-	MatchRecoveredSubject       = "Match recovered"
-	CancellingOrderSubject      = "Cancelling order"
-	OrderStatusUpdateSubject    = "Order status update"
-	MatchResolutionErrorSubject = "Match resolution error"
-	FailedCancelSubject         = "Failed cancel"
+	SubjectOrderLoadFailure     = "Order load failure"
+	SubjectOrderPlaced          = "Order placed"
+	SubjectMissingMatches       = "Missing matches"
+	SubjectWalletMissing        = "Wallet missing"
+	SubjectMatchStatusError     = "Match status error"
+	SubjectMatchRecoveryError   = "Match recovery error"
+	SubjectNoFundingCoins       = "No funding coins"
+	SubjectOrderCoinError       = "Order coin error"
+	SubjectPreimageSent         = "preimage sent"
+	SubjectCancelPreimageSent   = "cancel preimage sent"
+	SubjectMissedCancel         = "Missed cancel"
+	SubjectOrderBooked          = "Order booked"
+	SubjectNoMatch              = "No match"
+	SubjectOrderCanceled        = "Order canceled"
+	SubjectCancel               = "cancel"
+	SubjectMatchesMade          = "Matches made"
+	SubjectSwapError            = "Swap error"
+	SubjectSwapsInitiated       = "Swaps initiated"
+	SubjectRedemptionError      = "Redemption error"
+	SubjectMatchComplete        = "Match complete"
+	SubjectRefundFailure        = "Refund Failure"
+	SubjectMatchesRefunded      = "Matches Refunded"
+	SubjectMatchRevoked         = "Match revoked"
+	SubjectRevoke               = "revoke"
+	SubjectMatchRecovered       = "Match recovered"
+	SubjectCancellingOrder      = "Cancelling order"
+	SubjectOrderStatusUpdate    = "Order status update"
+	SubjectMatchResolutionError = "Match resolution error"
+	SubjectFailedCancel         = "Failed cancel"
 )
 
 func newOrderNote(subject, details string, severity db.Severity, corder *Order) *OrderNote {
@@ -268,8 +268,8 @@ type MatchNote struct {
 }
 
 const (
-	AuditSubject    = "audit"
-	NewMatchSubject = "new_match"
+	SubjectAudit    = "audit"
+	SubjectNewMatch = "new_match"
 )
 
 func newMatchNote(subject, details string, severity db.Severity, corder *Order, matchID order.MatchID) *MatchNote {
@@ -347,9 +347,9 @@ type DEXAuthNote struct {
 }
 
 const (
-	DexAuthErrorSubject     = "DEX auth error"
-	UnknownOrdersSubject    = "DEX reported unknown orders"
-	OrdersReconciledSubject = "Orders reconciled with DEX"
+	SubjectDexAuthError     = "DEX auth error"
+	SubjectUnknownOrders    = "DEX reported unknown orders"
+	SubjectOrdersReconciled = "Orders reconciled with DEX"
 )
 
 func newDEXAuthNote(subject, host string, authenticated bool, details string, severity db.Severity) *DEXAuthNote {
@@ -368,8 +368,8 @@ type WalletConfigNote struct {
 }
 
 const (
-	WalletConfigurationUpdatedSubject = "Wallet Configuration Updated"
-	WalletPasswordUpdatedSubject      = "Wallet Password Updated"
+	SubjectWalletConfigurationUpdated = "Wallet Configuration Updated"
+	SubjectWalletPasswordUpdated      = "Wallet Password Updated"
 )
 
 func newWalletConfigNote(subject, details string, severity db.Severity, walletState *WalletState) *WalletConfigNote {
@@ -397,10 +397,10 @@ type ServerNotifyNote struct {
 }
 
 const (
-	MarketSuspendScheduledSubject = "market suspend scheduled"
-	MarketSuspendedSubject        = "market suspended"
-	MarketResumeScheduledSubject  = "market resume scheduled"
-	MarketResumedSubject          = "market resumed"
+	SubjectMarketSuspendScheduled = "market suspend scheduled"
+	SubjectMarketSuspended        = "market suspended"
+	SubjectMarketResumeScheduled  = "market resume scheduled"
+	SubjectMarketResumed          = "market resumed"
 )
 
 func newServerNotifyNote(subject, details string, severity db.Severity) *ServerNotifyNote {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -9,7 +9,6 @@ import (
 
 	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
-	"decred.org/dcrdex/dex/order"
 )
 
 // Notifications should use the following note type strings.
@@ -240,6 +239,13 @@ type MatchNote struct {
 	MarketID string    `json:"marketID"`
 }
 
+const (
+	SubjectAudit           = "audit"
+	SubjectNewMatch        = "new_match"
+	SubjectCounterConfirms = "counterconfirms"
+	SubjectConfirms        = "confirms"
+)
+
 func newMatchNote(subject, details string, severity db.Severity, t *trackedTrade, match *matchTracker) *MatchNote {
 	return &MatchNote{
 		Notification: db.NewNotification(NoteTypeMatch, subject, details, severity),
@@ -259,32 +265,6 @@ func (on *OrderNote) String() string {
 		return base
 	}
 	return fmt.Sprintf("%s - Order: %s", base, on.Order.ID)
-}
-
-type MatchNote struct {
-	db.Notification
-	Order *Order `json:"order"`
-	Match *Match `json:"match"`
-}
-
-const (
-	SubjectAudit    = "audit"
-	SubjectNewMatch = "new_match"
-)
-
-func newMatchNote(subject, details string, severity db.Severity, corder *Order, matchID order.MatchID) *MatchNote {
-	midStr := matchID.String()
-	var coreMatch *Match
-	for _, match := range corder.Matches {
-		if match.MatchID.String() == midStr {
-			coreMatch = match
-		}
-	}
-	return &MatchNote{
-		Notification: db.NewNotification(NoteTypeMatch, subject, details, severity),
-		Order:        corder,
-		Match:        coreMatch,
-	}
 }
 
 // EpochNotification is a data notification that a new epoch has begun.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -284,7 +284,7 @@ func (t *trackedTrade) nomatch(oid order.OrderID) (assetMap, error) {
 		t.metaData.LinkedOrder = order.OrderID{}
 
 		details := fmt.Sprintf("Cancel order did not match for order %s. This can happen if the cancel order is submitted in the same epoch as the trade or if the target order is fully executed before matching with the cancel order.", t.token())
-		t.notify(newOrderNote("Missed cancel", details, db.WarningLevel, t.coreOrderInternal()))
+		t.notify(newOrderNote(MissedCancelSubject, details, db.WarningLevel, t.coreOrderInternal()))
 		return assets, t.db.UpdateOrderStatus(oid, order.OrderStatusExecuted)
 	}
 
@@ -296,13 +296,13 @@ func (t *trackedTrade) nomatch(oid order.OrderID) (assetMap, error) {
 	if lo, ok := t.Order.(*order.LimitOrder); ok && lo.Force == order.StandingTiF {
 		t.dc.log.Infof("Standing order %s did not match and is now booked.", t.token())
 		t.metaData.Status = order.OrderStatusBooked
-		t.notify(newOrderNote("Order booked", "", db.Data, t.coreOrderInternal()))
+		t.notify(newOrderNote(OrderBookedSubject, "", db.Data, t.coreOrderInternal()))
 	} else {
 		t.returnCoins()
 		assets.count(t.wallets.fromAsset.ID)
 		t.dc.log.Infof("Non-standing order %s did not match.", t.token())
 		t.metaData.Status = order.OrderStatusExecuted
-		t.notify(newOrderNote("No match", "", db.Data, t.coreOrderInternal()))
+		t.notify(newOrderNote(NoMatchSubject, "", db.Data, t.coreOrderInternal()))
 	}
 	return assets, t.db.UpdateOrderStatus(t.ID(), t.metaData.Status)
 }
@@ -458,17 +458,24 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 	if cancelMatch != nil {
 		details := fmt.Sprintf("%s order on %s-%s at %s has been canceled (%s)",
 			strings.Title(sellString(trade.Sell)), unbip(t.Base()), unbip(t.Quote()), t.dc.acct.host, t.token())
-		t.notify(newOrderNote("Order canceled", details, db.Success, corder))
+		t.notify(newOrderNote(OrderCanceledSubject, details, db.Success, corder))
 		// Also send out a data notification with the cancel order information.
-		t.notify(newOrderNote("cancel", "", db.Data, corder))
+		t.notify(newOrderNote(CancelSubject, "", db.Data, corder))
 	}
 	if len(newTrackers) > 0 {
 		fillPct := 100 * float64(filled) / float64(trade.Quantity)
-		details := fmt.Sprintf("%s order on %s-%s %.1f%% filled (%s)",
-			strings.Title(sellString(trade.Sell)), unbip(t.Base()), unbip(t.Quote()), fillPct, t.token())
 		t.dc.log.Debugf("Trade order %v matched with %d orders: +%d filled, total fill %d / %d (%.1f%%)",
 			t.ID(), len(newTrackers), newFill, filled, trade.Quantity, fillPct)
-		t.notify(newOrderNote("Matches made", details, db.Poke, corder))
+
+		// Match notifications.
+		for _, match := range newTrackers {
+			t.notify(newMatchNote(NewMatchSubject, "", db.Data, t.coreOrderInternal(), match.id))
+		}
+
+		// A single order notification.
+		details := fmt.Sprintf("%s order on %s-%s %.1f%% filled (%s)",
+			strings.Title(sellString(trade.Sell)), unbip(t.Base()), unbip(t.Quote()), fillPct, t.token())
+		t.notify(newOrderNote(MatchesMadeSubject, details, db.Poke, corder))
 	}
 
 	err := t.db.UpdateOrder(t.metaOrder())
@@ -648,7 +655,7 @@ func (t *trackedTrade) deleteStaleCancelOrder() {
 	}
 
 	details := fmt.Sprintf("Cancel order for order %s stuck in Epoch status for 2 epochs and is now deleted.", t.token())
-	t.notify(newOrderNote("Failed cancel", details, db.WarningLevel, t.coreOrderInternal()))
+	t.notify(newOrderNote(FailedCancelSubject, details, db.WarningLevel, t.coreOrderInternal()))
 }
 
 // isActive will be true if the trade is booked or epoch, or if any of the
@@ -1040,11 +1047,11 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 			errs.addErr(err)
 			details := fmt.Sprintf("Error encountered sending a swap output(s) worth %.8f %s on order %s",
 				float64(qty)/conversionFactor, unbip(fromID), t.token())
-			t.notify(newOrderNote("Swap error", details, db.ErrorLevel, corder))
+			t.notify(newOrderNote(SwapErrorSubject, details, db.ErrorLevel, corder))
 		} else {
 			details := fmt.Sprintf("Sent swaps worth %.8f %s on order %s",
 				float64(qty)/conversionFactor, unbip(fromID), t.token())
-			t.notify(newOrderNote("Swaps initiated", details, db.Poke, corder))
+			t.notify(newOrderNote(SwapsInitiatedSubject, details, db.Poke, corder))
 		}
 	}
 
@@ -1070,11 +1077,12 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 			errs.addErr(err)
 			details := fmt.Sprintf("Error encountered sending redemptions worth %.8f %s on order %s",
 				float64(qty)/conversionFactor, unbip(toAsset), t.token())
-			t.notify(newOrderNote("Redemption error", details, db.ErrorLevel, corder))
+			t.notify(newOrderNote(RedemptionErrorSubject, details, db.ErrorLevel, corder))
+			c.log.Errorf("redemption error details: %v", details, err)
 		} else {
 			details := fmt.Sprintf("Redeemed %.8f %s on order %s",
 				float64(qty)/conversionFactor, unbip(toAsset), t.token())
-			t.notify(newOrderNote("Match complete", details, db.Poke, corder))
+			t.notify(newOrderNote(MatchCompleteSubject, details, db.Poke, corder))
 		}
 	}
 
@@ -1093,9 +1101,9 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 			float64(refunded)/conversionFactor, unbip(fromID), t.token())
 		if err != nil {
 			errs.addErr(err)
-			t.notify(newOrderNote("Refund Failure", details+", with some errors", db.ErrorLevel, corder))
+			t.notify(newOrderNote(RefundFailureSubject, details+", with some errors", db.ErrorLevel, corder))
 		} else {
-			t.notify(newOrderNote("Matches Refunded", details, db.WarningLevel, corder))
+			t.notify(newOrderNote(MatchesRefundedSubject, details, db.WarningLevel, corder))
 		}
 	}
 
@@ -1168,7 +1176,7 @@ func (t *trackedTrade) revoke() {
 		t.dc.log.Errorf("unable to update order: %v", err)
 	}
 
-	t.notify(newOrderNote("revoke", "", db.Data, t.coreOrderInternal()))
+	t.notify(newOrderNote(RevokeSubject, "", db.Data, t.coreOrderInternal()))
 
 	// Return coins if there are no matches that MAY later require sending swaps.
 	t.maybeReturnCoins()
@@ -1201,7 +1209,7 @@ func (t *trackedTrade) revokeMatch(matchID order.MatchID, fromServer bool) error
 
 	// Notify the user of the failed match.
 	corder := t.coreOrderInternal() // no cancel order
-	t.notify(newOrderNote("Match revoked", fmt.Sprintf("Match %s has been revoked",
+	t.notify(newOrderNote(MatchRevokedSubject, fmt.Sprintf("Match %s has been revoked",
 		token(matchID[:])), db.WarningLevel, corder))
 
 	// Unlock coins if we're not expecting future matches for this
@@ -1714,7 +1722,7 @@ func (t *trackedTrade) findMakersRedemption(match *matchTracker) {
 
 		details := fmt.Sprintf("Found maker's redemption (%s: %v) and validated secret for match %s",
 			fromAsset.Symbol, coinIDString(fromAsset.ID, redemptionCoinID), match.id)
-		t.notify(newOrderNote("Match recovered", details, db.Poke, t.coreOrderInternal()))
+		t.notify(newOrderNote(MatchRecoveredSubject, details, db.Poke, t.coreOrderInternal()))
 	}()
 }
 
@@ -1824,6 +1832,8 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 	auth := &match.MetaMatch.MetaData.Proof.Auth
 	auth.AuditStamp = audit.Time
 	auth.AuditSig = audit.Sig
+
+	t.notify(newMatchNote(AuditSubject, "", db.Data, t.coreOrderInternal(), mid))
 
 	err = t.db.UpdateMatch(&match.MetaMatch)
 	if err != nil {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -284,7 +284,7 @@ func (t *trackedTrade) nomatch(oid order.OrderID) (assetMap, error) {
 		t.metaData.LinkedOrder = order.OrderID{}
 
 		details := fmt.Sprintf("Cancel order did not match for order %s. This can happen if the cancel order is submitted in the same epoch as the trade or if the target order is fully executed before matching with the cancel order.", t.token())
-		t.notify(newOrderNote(MissedCancelSubject, details, db.WarningLevel, t.coreOrderInternal()))
+		t.notify(newOrderNote(SubjectMissedCancel, details, db.WarningLevel, t.coreOrderInternal()))
 		return assets, t.db.UpdateOrderStatus(oid, order.OrderStatusExecuted)
 	}
 
@@ -296,13 +296,13 @@ func (t *trackedTrade) nomatch(oid order.OrderID) (assetMap, error) {
 	if lo, ok := t.Order.(*order.LimitOrder); ok && lo.Force == order.StandingTiF {
 		t.dc.log.Infof("Standing order %s did not match and is now booked.", t.token())
 		t.metaData.Status = order.OrderStatusBooked
-		t.notify(newOrderNote(OrderBookedSubject, "", db.Data, t.coreOrderInternal()))
+		t.notify(newOrderNote(SubjectOrderBooked, "", db.Data, t.coreOrderInternal()))
 	} else {
 		t.returnCoins()
 		assets.count(t.wallets.fromAsset.ID)
 		t.dc.log.Infof("Non-standing order %s did not match.", t.token())
 		t.metaData.Status = order.OrderStatusExecuted
-		t.notify(newOrderNote(NoMatchSubject, "", db.Data, t.coreOrderInternal()))
+		t.notify(newOrderNote(SubjectNoMatch, "", db.Data, t.coreOrderInternal()))
 	}
 	return assets, t.db.UpdateOrderStatus(t.ID(), t.metaData.Status)
 }
@@ -458,9 +458,9 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 	if cancelMatch != nil {
 		details := fmt.Sprintf("%s order on %s-%s at %s has been canceled (%s)",
 			strings.Title(sellString(trade.Sell)), unbip(t.Base()), unbip(t.Quote()), t.dc.acct.host, t.token())
-		t.notify(newOrderNote(OrderCanceledSubject, details, db.Success, corder))
+		t.notify(newOrderNote(SubjectOrderCanceled, details, db.Success, corder))
 		// Also send out a data notification with the cancel order information.
-		t.notify(newOrderNote(CancelSubject, "", db.Data, corder))
+		t.notify(newOrderNote(SubjectCancel, "", db.Data, corder))
 	}
 	if len(newTrackers) > 0 {
 		fillPct := 100 * float64(filled) / float64(trade.Quantity)
@@ -469,13 +469,13 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 
 		// Match notifications.
 		for _, match := range newTrackers {
-			t.notify(newMatchNote(NewMatchSubject, "", db.Data, t.coreOrderInternal(), match.id))
+			t.notify(newMatchNote(SubjectNewMatch, "", db.Data, t.coreOrderInternal(), match.id))
 		}
 
 		// A single order notification.
 		details := fmt.Sprintf("%s order on %s-%s %.1f%% filled (%s)",
 			strings.Title(sellString(trade.Sell)), unbip(t.Base()), unbip(t.Quote()), fillPct, t.token())
-		t.notify(newOrderNote(MatchesMadeSubject, details, db.Poke, corder))
+		t.notify(newOrderNote(SubjectMatchesMade, details, db.Poke, corder))
 	}
 
 	err := t.db.UpdateOrder(t.metaOrder())
@@ -655,7 +655,7 @@ func (t *trackedTrade) deleteStaleCancelOrder() {
 	}
 
 	details := fmt.Sprintf("Cancel order for order %s stuck in Epoch status for 2 epochs and is now deleted.", t.token())
-	t.notify(newOrderNote(FailedCancelSubject, details, db.WarningLevel, t.coreOrderInternal()))
+	t.notify(newOrderNote(SubjectFailedCancel, details, db.WarningLevel, t.coreOrderInternal()))
 }
 
 // isActive will be true if the trade is booked or epoch, or if any of the
@@ -1047,11 +1047,11 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 			errs.addErr(err)
 			details := fmt.Sprintf("Error encountered sending a swap output(s) worth %.8f %s on order %s",
 				float64(qty)/conversionFactor, unbip(fromID), t.token())
-			t.notify(newOrderNote(SwapErrorSubject, details, db.ErrorLevel, corder))
+			t.notify(newOrderNote(SubjectSwapError, details, db.ErrorLevel, corder))
 		} else {
 			details := fmt.Sprintf("Sent swaps worth %.8f %s on order %s",
 				float64(qty)/conversionFactor, unbip(fromID), t.token())
-			t.notify(newOrderNote(SwapsInitiatedSubject, details, db.Poke, corder))
+			t.notify(newOrderNote(SubjectSwapsInitiated, details, db.Poke, corder))
 		}
 	}
 
@@ -1077,12 +1077,12 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 			errs.addErr(err)
 			details := fmt.Sprintf("Error encountered sending redemptions worth %.8f %s on order %s",
 				float64(qty)/conversionFactor, unbip(toAsset), t.token())
-			t.notify(newOrderNote(RedemptionErrorSubject, details, db.ErrorLevel, corder))
+			t.notify(newOrderNote(SubjectRedemptionError, details, db.ErrorLevel, corder))
 			c.log.Errorf("redemption error details: %v", details, err)
 		} else {
 			details := fmt.Sprintf("Redeemed %.8f %s on order %s",
 				float64(qty)/conversionFactor, unbip(toAsset), t.token())
-			t.notify(newOrderNote(MatchCompleteSubject, details, db.Poke, corder))
+			t.notify(newOrderNote(SubjectMatchComplete, details, db.Poke, corder))
 		}
 	}
 
@@ -1101,9 +1101,9 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 			float64(refunded)/conversionFactor, unbip(fromID), t.token())
 		if err != nil {
 			errs.addErr(err)
-			t.notify(newOrderNote(RefundFailureSubject, details+", with some errors", db.ErrorLevel, corder))
+			t.notify(newOrderNote(SubjectRefundFailure, details+", with some errors", db.ErrorLevel, corder))
 		} else {
-			t.notify(newOrderNote(MatchesRefundedSubject, details, db.WarningLevel, corder))
+			t.notify(newOrderNote(SubjectMatchesRefunded, details, db.WarningLevel, corder))
 		}
 	}
 
@@ -1176,7 +1176,7 @@ func (t *trackedTrade) revoke() {
 		t.dc.log.Errorf("unable to update order: %v", err)
 	}
 
-	t.notify(newOrderNote(RevokeSubject, "", db.Data, t.coreOrderInternal()))
+	t.notify(newOrderNote(SubjectRevoke, "", db.Data, t.coreOrderInternal()))
 
 	// Return coins if there are no matches that MAY later require sending swaps.
 	t.maybeReturnCoins()
@@ -1209,7 +1209,7 @@ func (t *trackedTrade) revokeMatch(matchID order.MatchID, fromServer bool) error
 
 	// Notify the user of the failed match.
 	corder := t.coreOrderInternal() // no cancel order
-	t.notify(newOrderNote(MatchRevokedSubject, fmt.Sprintf("Match %s has been revoked",
+	t.notify(newOrderNote(SubjectMatchRevoked, fmt.Sprintf("Match %s has been revoked",
 		token(matchID[:])), db.WarningLevel, corder))
 
 	// Unlock coins if we're not expecting future matches for this
@@ -1722,7 +1722,7 @@ func (t *trackedTrade) findMakersRedemption(match *matchTracker) {
 
 		details := fmt.Sprintf("Found maker's redemption (%s: %v) and validated secret for match %s",
 			fromAsset.Symbol, coinIDString(fromAsset.ID, redemptionCoinID), match.id)
-		t.notify(newOrderNote(MatchRecoveredSubject, details, db.Poke, t.coreOrderInternal()))
+		t.notify(newOrderNote(SubjectMatchRecovered, details, db.Poke, t.coreOrderInternal()))
 	}()
 }
 
@@ -1833,7 +1833,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 	auth.AuditStamp = audit.Time
 	auth.AuditSig = audit.Sig
 
-	t.notify(newMatchNote(AuditSubject, "", db.Data, t.coreOrderInternal(), mid))
+	t.notify(newMatchNote(SubjectAudit, "", db.Data, t.coreOrderInternal(), mid))
 
 	err = t.db.UpdateMatch(&match.MetaMatch)
 	if err != nil {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -469,7 +469,7 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 
 		// Match notifications.
 		for _, match := range newTrackers {
-			t.notify(newMatchNote(SubjectNewMatch, "", db.Data, t.coreOrderInternal(), match.id))
+			t.notify(newMatchNote(SubjectNewMatch, "", db.Data, t, match))
 		}
 
 		// A single order notification.
@@ -586,7 +586,7 @@ func (t *trackedTrade) counterPartyConfirms(match *matchTracker) (have, needed u
 		changed = true
 	}
 
-	t.notify(newMatchNote("counterconfirms", "", db.Data, t, match))
+	t.notify(newMatchNote(SubjectCounterConfirms, "", db.Data, t, match))
 
 	return
 }
@@ -801,7 +801,7 @@ func (t *trackedTrade) isSwappable(match *matchTracker) bool {
 			t.dc.log.Errorf("error getting confirmation for our own swap transaction: %v", err)
 		}
 		match.swapConfirms = int64(confs)
-		t.notify(newMatchNote("confirms", "", db.Data, t, match))
+		t.notify(newMatchNote(SubjectConfirms, "", db.Data, t, match))
 		return false
 	}
 	if dbMatch.Side == order.Maker && metaData.Status == order.NewlyMatched {
@@ -848,7 +848,7 @@ func (t *trackedTrade) isRedeemable(match *matchTracker) bool {
 			t.dc.log.Errorf("error getting confirmation for our own swap transaction: %v", err)
 		}
 		match.swapConfirms = int64(confs)
-		t.notify(newMatchNote("confirms", "", db.Data, t, match))
+		t.notify(newMatchNote(SubjectConfirms, "", db.Data, t, match))
 		return false
 	}
 	if dbMatch.Side == order.Taker && metaData.Status == order.MakerRedeemed {
@@ -1833,7 +1833,7 @@ func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
 	auth.AuditStamp = audit.Time
 	auth.AuditSig = audit.Sig
 
-	t.notify(newMatchNote(SubjectAudit, "", db.Data, t.coreOrderInternal(), mid))
+	t.notify(newMatchNote(SubjectAudit, "", db.Data, t, match))
 
 	err = t.db.UpdateMatch(&match.MetaMatch)
 	if err != nil {

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -721,5 +721,6 @@ function updateMatch (order, match) {
       return
     }
   }
+  order.matches = order.matches || []
   order.matches.push(match)
 }


### PR DESCRIPTION
Broken off from #717. Includes `MatchNote` changes that aren't yet used, and a correction for the details of an `OrderNote`.