### PR TITLE
processAudit runs txn search async, redo match res. locking

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3819,7 +3819,9 @@ func handleRevokeMatchMsg(c *Core, dc *dexConnection, msg *msgjson.Message) erro
 	var matchID order.MatchID
 	copy(matchID[:], revocation.MatchID)
 
+	tracker.mtx.Lock()
 	err = tracker.revokeMatch(matchID, true)
+	tracker.mtx.Unlock()
 	if err != nil {
 		return fmt.Errorf("unable to revoke match %s for order %s: %w", matchID, tracker.ID(), err)
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -5442,7 +5442,7 @@ func TestMatchStatusResolution(t *testing.T) {
 	rig.db.updateMatchChan = make(chan order.MatchStatus, 4)
 	tCore.authDEX(dc)
 	for i := 0; i < 4; i++ {
-		fmt.Println(<-rig.db.updateMatchChan)
+		<-rig.db.updateMatchChan
 	}
 	trade.mtx.Lock()
 	newStatus1 := match.MetaData.Status

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -134,7 +134,9 @@ type TWebsocket struct {
 	reqErr     error
 	connectErr error
 	msgs       <-chan *msgjson.Message
-	handlers   map[string][]func(*msgjson.Message, msgFunc) error
+	// handlers simulates a peer (server) response for request, and handles the
+	// response with the msgFunc.
+	handlers map[string][]func(*msgjson.Message, msgFunc) error
 }
 
 func newTWebsocket() *TWebsocket {
@@ -4972,6 +4974,7 @@ func TestMatchStatusResolution(t *testing.T) {
 	secretHash := sha256.Sum256(secret)
 
 	lo, dbOrder, preImg, addr := makeLimitOrder(dc, true, qty, tBTC.RateStep*10)
+	dbOrder.MetaData.Status = order.OrderStatusExecuted // so there is no order_status request for this
 	oid := lo.ID()
 	trade := newTrackedTrade(dbOrder, preImg, dc, mkt.EpochLen, rig.core.lockTimeTaker, rig.core.lockTimeMaker,
 		rig.db, rig.queue, walletSet, nil, rig.core.notify)

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -241,6 +241,7 @@ type MatchNote struct {
 
 const (
 	SubjectAudit           = "audit"
+	SubjectAuditTrouble    = "Audit trouble"
 	SubjectNewMatch        = "new_match"
 	SubjectCounterConfirms = "counterconfirms"
 	SubjectConfirms        = "confirms"

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1882,9 +1882,9 @@ func (t *trackedTrade) processAuditMsg(msgID uint64, audit *msgjson.Audit) error
 }
 
 // auditContract audits the contract for the match and relevant MatchProof
-// fields are set. The changes are not saved to the database. This may block for
-// a long period, and should be run in a goroutine. The trackedTrade mtx must
-// NOT be locked. The match is updated in the DB if the audit succeeds.
+// fields are set. This may block for a long period, and should be run in a
+// goroutine. The trackedTrade mtx must NOT be locked. The match is updated in
+// the DB if the audit succeeds.
 func (t *trackedTrade) auditContract(match *matchTracker, coinID []byte, contract []byte) error {
 	// Get the asset.AuditInfo from the ExchangeWallet. Handle network latency.
 	// The coin waiter will run once every recheckInterval until successful or

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -684,6 +684,24 @@ func (t *trackedTrade) isActive() bool {
 	return false
 }
 
+func (t *trackedTrade) MatchIsRevoked(match *matchTracker) bool {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	return match.MetaData.Proof.IsRevoked()
+}
+
+func (t *trackedTrade) MatchStatus(match *matchTracker) order.MatchStatus {
+	t.mtx.RLock()
+	defer t.mtx.RUnlock()
+	return match.MetaData.Status
+}
+
+func (t *trackedTrade) SelfRevokeMatch(match *matchTracker) {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	match.MetaData.Proof.SelfRevoked = true
+}
+
 // Matches are inactive if: (1) status is complete, (2) it is refunded, or (3)
 // it is revoked and this side of the match requires no further action like
 // refund or auto-redeem.
@@ -1182,9 +1200,10 @@ func (t *trackedTrade) revoke() {
 	t.maybeReturnCoins()
 }
 
-// revokeMatch sets the status as revoked for the specified match. revokeMatch
-// must be called with the mtx write-locked.
+// revokeMatch sets the status as revoked for the specified match.
 func (t *trackedTrade) revokeMatch(matchID order.MatchID, fromServer bool) error {
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
 	var revokedMatch *matchTracker
 	for _, match := range t.matches {
 		if match.id == matchID {
@@ -1804,81 +1823,113 @@ func (t *trackedTrade) refundMatches(matches []*matchTracker) (uint64, error) {
 	return refundedQty, errs.ifAny()
 }
 
-// processAudit processes the audit request from the server.
-func (t *trackedTrade) processAudit(msgID uint64, audit *msgjson.Audit) error {
+// processAuditMsg processes the audit request from the server. A non-nil error
+// is only returned if the match referenced by the Audit message is not known.
+func (t *trackedTrade) processAuditMsg(msgID uint64, audit *msgjson.Audit) error {
 	t.mtx.Lock()
 	defer t.mtx.Unlock()
 	// Find the match and check the server's signature.
 	var mid order.MatchID
 	copy(mid[:], audit.MatchID)
-	errs := newErrorSet("processAudit - order %s, match %s -", t.ID(), mid)
 	match, found := t.matches[mid]
 	if !found {
-		return errs.add("match ID not known")
+		return fmt.Errorf("processAuditMsg: match %v not found for order %s", mid, t.ID())
 	}
 	// Check the server signature.
 	sigMsg := audit.Serialize()
 	err := t.dc.acct.checkSig(sigMsg, audit.Sig)
 	if err != nil {
-		// Log, but don't quit.
-		errs.add("server audit signature error: %v", err)
+		// Log, but don't quit. If the audit passes, great.
+		t.dc.log.Warnf("Server audit signature error: %v", err)
 	}
 
-	err = t.auditContract(match, audit.CoinID, audit.Contract)
-	if err != nil {
-		return errs.addErr(err)
-	}
+	// Start searching for and audit the contract. This can take some time
+	// depending on node connectivity, so this is run in a goroutine. If the
+	// contract and coin (amount) are successfully validated, the matchTracker
+	// data are updated.
+	go func() {
+		// Search until it's known to be revoked.
+		err := t.auditContract(match, audit.CoinID, audit.Contract, 48*time.Hour)
+		if err != nil {
+			contractID := coinIDString(t.wallets.toAsset.ID, audit.CoinID)
+			t.dc.log.Error("Failed to audit contract coin %v (%s) for match %v: %v",
+				contractID, t.wallets.toAsset.Symbol, match.id, err)
+			return
+		}
 
-	auth := &match.MetaMatch.MetaData.Proof.Auth
-	auth.AuditStamp = audit.Time
-	auth.AuditSig = audit.Sig
+		// The audit succeeded. Update and store match data.
+		t.mtx.Lock()
+		auth := &match.MetaMatch.MetaData.Proof.Auth
+		auth.AuditStamp, auth.AuditSig = audit.Time, audit.Sig
+		t.notify(newMatchNote(SubjectAudit, "", db.Data, t, match))
+		err = t.db.UpdateMatch(&match.MetaMatch)
+		t.mtx.Unlock()
+		if err != nil {
+			t.dc.log.Errorf("Error updating database for match %v: %v", match.id, err)
+		}
 
-	t.notify(newMatchNote(SubjectAudit, "", db.Data, t, match))
+		// Respond to DEX, but this is not consequential.
+		err = t.dc.ack(msgID, match.id, audit)
+		if err != nil {
+			t.dc.log.Debugf("Error acknowledging audit to server (not necessarily an error): %v", err)
+			// The server's response timeout may have just passed, but we got
+			// what we needed to do our swap or redeem if the match is still
+			// live, so do not log this as an error.
+		}
+	}()
 
-	err = t.db.UpdateMatch(&match.MetaMatch)
-	if err != nil {
-		return errs.add("error updating database: %v", err)
-	}
-
-	// Respond to DEX.
-	err = t.dc.ack(msgID, match.id, audit)
-	if err != nil {
-		return errs.add("Audit error: %v", err)
-	}
 	return nil
 }
 
 // auditContract audits the contract for the match and relevant MatchProof
-// fields are set. The changes are not saved to the database. auditContract must
-// be called with the trackedTrade.mtx locked.
-func (t *trackedTrade) auditContract(match *matchTracker, coinID []byte, contract []byte) error {
+// fields are set. The changes are not saved to the database. This may block for
+// a long period, and should be run in a goroutine. The trackedTrade mtx must
+// NOT be locked.
+func (t *trackedTrade) auditContract(match *matchTracker, coinID []byte, contract []byte, timeout time.Duration) error {
 	// Get the asset.AuditInfo from the ExchangeWallet. Handle network latency.
 	// The coin waiter will run once every recheckInterval until successful or
-	// until expiration after broadcast timeout. The client is asked by the
-	// server to audit a contract transaction, and they have until broadcast
-	// timeout to do it before they get penalized and the match revoked. Thus,
-	// there is no reason to give up on the request sooner since the server will
-	// not ask again.
+	// until the match is revoked. The client is asked by the server to audit a
+	// contract transaction, and they have until broadcast timeout to do it
+	// before they get penalized and the match revoked. Thus, there is no reason
+	// to give up on the request sooner since the server will not ask again and
+	// the client will not solicit the counterparty contract data again except
+	// on reconnect.
 	errChan := make(chan error, 1)
 	var auditInfo asset.AuditInfo
+	var tries int
+	contractID, contractSymb := coinIDString(t.wallets.toAsset.ID, coinID), t.wallets.toAsset.Symbol
 	t.latencyQ.Wait(&wait.Waiter{
-		Expiration: time.Now().Add(t.broadcastTimeout()),
+		Expiration: time.Now().Add(timeout),
 		TryFunc: func() bool {
 			var err error
 			auditInfo, err = t.wallets.toWallet.AuditContract(coinID, contract)
-			if err != nil {
-				if errors.Is(err, asset.CoinNotFoundError) {
-					return wait.TryAgain
-				}
-				errChan <- err
+			if err == nil {
+				// Success.
+				errChan <- nil
 				return wait.DontTryAgain
 			}
-			errChan <- nil
+			if errors.Is(err, asset.CoinNotFoundError) {
+				// Didn't find it that time.
+				if t.MatchIsRevoked(match) {
+					errChan <- ExpirationErr(fmt.Sprintf("match revoked while waiting to find counterparty contract coin %v (%s). "+
+						"Check your internet and wallet connections!", contractID, contractSymb))
+					return wait.DontTryAgain
+				}
+				if tries > 2 {
+					t.dc.log.Infof("Still searching for contract coin %v (%s) for match %v. "+
+						"Is your internet and wallet connection good?", contractID, contractSymb, match.id)
+					// t.dc.notify(newOrderNotification) // I'm afraid of breaking consumers now, but we should tell GUI.
+				}
+				tries++
+				return wait.TryAgain
+			}
+			errChan <- err
 			return wait.DontTryAgain
+
 		},
 		ExpireFunc: func() {
-			errChan <- ExpirationErr(fmt.Sprintf("timed out waiting for AuditContract coin %v",
-				coinIDString(t.wallets.toAsset.ID, coinID)))
+			errChan <- ExpirationErr(fmt.Sprintf("failed to find counterparty contract coin %v (%s). "+
+				"Check your internet and wallet connections!", contractID, contractSymb))
 		},
 	})
 	// Wait for the coin waiter to find and audit the contract coin, or timeout.
@@ -1891,18 +1942,20 @@ func (t *trackedTrade) auditContract(match *matchTracker, coinID []byte, contrac
 	// 1. Recipient Address
 	// 2. Contract value
 	// 3. Secret hash: maker compares, taker records
-	dbMatch, proof := match.Match, &match.MetaData.Proof
 	match.counterSwap = auditInfo
 	if auditInfo.Recipient() != t.Trade().Address {
-		return fmt.Errorf("swap recipient %s is not the order address %s.", auditInfo.Recipient(), t.Trade().Address)
+		return fmt.Errorf("swap recipient %s in contract coin %v (%s) is not the order address %s",
+			auditInfo.Recipient(), contractID, contractSymb, t.Trade().Address)
 	}
 
+	dbMatch := match.Match
 	auditQty := dbMatch.Quantity
 	if t.Trade().Sell {
 		auditQty = calc.BaseToQuote(dbMatch.Rate, auditQty)
 	}
 	if auditInfo.Coin().Value() < auditQty {
-		return fmt.Errorf("swap contract value %d was lower than expected %d", auditInfo.Coin().Value(), auditQty)
+		return fmt.Errorf("swap contract coin %v (%s) value %d was lower than expected %d",
+			contractID, contractSymb, auditInfo.Coin().Value(), auditQty)
 	}
 
 	// TODO: Consider having the server supply the contract txn's fee rate to
@@ -1913,11 +1966,14 @@ func (t *trackedTrade) auditContract(match *matchTracker, coinID []byte, contrac
 	// as they can only wait for it to be mined to redeem it, in which case the
 	// fee rate no longer matters, or wait for the lock time to expire to refund.
 
-	// Check or store the secret hash and update the database.
-	match.MetaData.Proof.CounterScript = contract
+	// Check and store the counterparty contract data.
+	t.mtx.Lock()
+	defer t.mtx.Unlock()
+	proof := &match.MetaData.Proof
+	proof.CounterScript = contract
 
 	matchTime := match.matchTime()
-	reqLockTime := encode.DropMilliseconds(matchTime.Add(t.lockTimeMaker)) // counterparty = maker
+	reqLockTime := encode.DropMilliseconds(matchTime.Add(t.lockTimeMaker)) // counterparty == maker
 	if dbMatch.Side == order.Maker {
 		// Check that the secret hash is correct.
 		if !bytes.Equal(proof.SecretHash, auditInfo.SecretHash()) {
@@ -1926,7 +1982,7 @@ func (t *trackedTrade) auditContract(match *matchTracker, coinID []byte, contrac
 		}
 		match.SetStatus(order.TakerSwapCast)
 		proof.TakerSwap = coinID
-		// counterparty = taker
+		// counterparty == taker
 		reqLockTime = encode.DropMilliseconds(matchTime.Add(t.lockTimeTaker))
 	} else {
 		proof.SecretHash = auditInfo.SecretHash()

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1910,7 +1910,7 @@ func (t *trackedTrade) auditContract(match *matchTracker, coinID []byte, contrac
 			}
 			if errors.Is(err, asset.CoinNotFoundError) {
 				// Didn't find it that time.
-				t.dc.log.Tracef("Still searching for counterparty's contract coin %v (%s) for match %v. ", contractID, contractSymb, match.id)
+				t.dc.log.Tracef("Still searching for counterparty's contract coin %v (%s) for match %v.", contractID, contractSymb, match.id)
 				if t.matchIsRevoked(match) {
 					errChan <- ExpirationErr(fmt.Sprintf("match revoked while waiting to find counterparty contract coin %v (%s). "+
 						"Check your internet and wallet connections!", contractID, contractSymb))
@@ -1919,7 +1919,7 @@ func (t *trackedTrade) auditContract(match *matchTracker, coinID []byte, contrac
 				if tries > 0 && tries%12 == 0 {
 					detail := fmt.Sprintf("Still searching for counterparty's contract coin %v (%s) for match %v. "+
 						"Are your internet and wallet connections good?", contractID, contractSymb, match.id)
-					t.notify(newOrderNote("Audit trouble", detail, db.WarningLevel, t.coreOrder()))
+					t.notify(newOrderNote(SubjectAuditTrouble, detail, db.WarningLevel, t.coreOrder()))
 				}
 				tries++
 				return wait.TryAgain


### PR DESCRIPTION
This prevents contract auditing from blocking all incoming messages (and pretty much any other activities for the trade in question).

Instead of expiring the coin waiter after broadcast timeout, it just goes until it finds the contract or the match is revoked.

The trackedTrade locking is also changed a great deal in match status resolution, no longer locking a trackedTrade unless and until needed.