### PR TITLE
core: allow filename for tls cert

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1708,7 +1708,8 @@ func (c *Core) isRegistered(host string) bool {
 
 // GetFee creates a connection to the specified DEX Server and fetches the
 // registration fee. The connection is closed after the fee is retrieved.
-// Returns an error if user is already registered to the DEX.
+// Returns an error if user is already registered to the DEX. A TLS certificate,
+// certI, can be provided as either a string filename, or []byte file contents.
 func (c *Core) GetFee(dexAddr string, certI interface{}) (uint64, error) {
 	host, err := addrHost(dexAddr)
 	if err != nil {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -1253,9 +1254,10 @@ func TestCreateWallet(t *testing.T) {
 func TestGetFee(t *testing.T) {
 	rig := newTestRig()
 	tCore := rig.core
+	cert := []byte{}
 
 	// DEX already registered
-	_, err := tCore.GetFee(tDexHost, "")
+	_, err := tCore.GetFee(tDexHost, cert)
 	if !errorHasCode(err, dupeDEXErr) {
 		t.Fatalf("wrong account exists error: %v", err)
 	}
@@ -1266,7 +1268,7 @@ func TestGetFee(t *testing.T) {
 	tCore.connMtx.Unlock()
 
 	// connectDEX error
-	_, err = tCore.GetFee(tUnparseableHost, "")
+	_, err = tCore.GetFee(tUnparseableHost, cert)
 	if !errorHasCode(err, connectionErr) {
 		t.Fatalf("wrong connectDEX error: %v", err)
 	}
@@ -1275,7 +1277,7 @@ func TestGetFee(t *testing.T) {
 	rig.queueConfig()
 
 	// Success
-	_, err = tCore.GetFee(tDexHost, "")
+	_, err = tCore.GetFee(tDexHost, cert)
 	if err != nil {
 		t.Fatalf("GetFee error: %v", err)
 	}
@@ -1339,7 +1341,7 @@ func TestRegister(t *testing.T) {
 		Addr:    tDexHost,
 		AppPass: tPW,
 		Fee:     tFee,
-		Cert:    "required",
+		Cert:    []byte{},
 	}
 
 	tWallet.payFeeCoin = &tCoin{id: encode.RandomBytes(36)}
@@ -5624,5 +5626,35 @@ out:
 	// avoid github vm false positives.
 	if progressNotes < 5 {
 		t.Fatalf("expected 23 progress notes, got %d", progressNotes)
+	}
+}
+
+func TestParseCert(t *testing.T) {
+	byteCert := []byte{0x0a, 0x0b}
+	cert, err := parseCert("anyhost", []byte{0x0a, 0x0b})
+	if err != nil {
+		t.Fatalf("byte cert error: %v", err)
+	}
+	if !bytes.Equal(cert, byteCert) {
+		t.Fatalf("byte cert note returned unmodified. expected %x, got %x", byteCert, cert)
+	}
+	byteCert = []byte{0x05, 0x06}
+	certFile, _ := ioutil.TempFile("", "dumbcert")
+	defer os.Remove(certFile.Name())
+	certFile.Write(byteCert)
+	certFile.Close()
+	cert, err = parseCert("anyhost", certFile.Name())
+	if err != nil {
+		t.Fatalf("file cert error: %v", err)
+	}
+	if !bytes.Equal(cert, byteCert) {
+		t.Fatalf("byte cert note returned unmodified. expected %x, got %x", byteCert, cert)
+	}
+	cert, err = parseCert("dex-test.ssgen.io:7232", []byte(nil))
+	if err != nil {
+		t.Fatalf("CertStore cert error: %v", err)
+	}
+	if len(cert) == 0 {
+		t.Fatalf("no cert returned from cert store")
 	}
 }

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -32,6 +32,7 @@ const (
 	marketErr
 	addressParseErr
 	addrErr
+	fileReadErr
 )
 
 // Error is an error message and an error code.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -116,7 +116,9 @@ type RegisterForm struct {
 	Addr    string           `json:"url"`
 	AppPass encode.PassBytes `json:"appPass"`
 	Fee     uint64           `json:"fee"`
-	Cert    string           `json:"cert"`
+	// Cert can be a string, which is interpreted as a filepath, or a []byte,
+	// which is interpreted as the file contents of the certificate.
+	Cert interface{} `json:"cert"`
 }
 
 // Match represents a match on an order. An order may have many matches.

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -63,7 +63,7 @@ type clientCore interface {
 	Login(appPass []byte) (*core.LoginResult, error)
 	Logout() error
 	OpenWallet(assetID uint32, appPass []byte) error
-	GetFee(addr, cert string) (fee uint64, err error)
+	GetFee(addr string, cert interface{}) (fee uint64, err error)
 	Register(form *core.RegisterForm) (*core.RegisterResult, error)
 	Trade(appPass []byte, form *core.TradeForm) (order *core.Order, err error)
 	Wallets() (walletsStates []*core.WalletState)

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -91,7 +91,7 @@ func (c *TCore) Logout() error {
 func (c *TCore) OpenWallet(assetID uint32, pw []byte) error {
 	return c.openWalletErr
 }
-func (c *TCore) GetFee(url, cert string) (uint64, error) {
+func (c *TCore) GetFee(url string, cert interface{}) (uint64, error) {
 	return c.regFee, c.getFeeErr
 }
 func (c *TCore) Register(*core.RegisterForm) (*core.RegisterResult, error) {

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -288,9 +288,9 @@ func parseRegisterArgs(params *RawParams) (*core.RegisterForm, error) {
 	if err != nil {
 		return nil, err
 	}
-	cert := ""
+	var cert []byte
 	if len(params.Args) > 2 {
-		cert = params.Args[2]
+		cert = []byte(params.Args[2])
 	}
 	req := &core.RegisterForm{
 		AppPass: params.PWArgs[0],

--- a/client/rpcserver/types_test.go
+++ b/client/rpcserver/types_test.go
@@ -281,7 +281,7 @@ func TestParseRegisterArgs(t *testing.T) {
 		if fmt.Sprint(reg.Fee) != test.params.Args[1] {
 			t.Fatalf("fee doesn't match")
 		}
-		if fmt.Sprint(reg.Cert) != test.params.Args[2] {
+		if string(reg.Cert.([]byte)) != test.params.Args[2] {
 			t.Fatalf("cert doesn't match")
 		}
 	}

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -21,7 +21,8 @@ func (s *WebServer) apiGetFee(w http.ResponseWriter, r *http.Request) {
 	if !readPost(w, r, form) {
 		return
 	}
-	fee, err := s.core.GetFee(form.Addr, form.Cert)
+	cert := []byte(form.Cert)
+	fee, err := s.core.GetFee(form.Addr, cert)
 	if err != nil {
 		s.writeAPIError(w, err.Error())
 		return
@@ -52,7 +53,7 @@ func (s *WebServer) apiRegister(w http.ResponseWriter, r *http.Request) {
 
 	_, err := s.core.Register(&core.RegisterForm{
 		Addr:    reg.Addr,
-		Cert:    reg.Cert,
+		Cert:    []byte(reg.Cert),
 		AppPass: reg.Password,
 		Fee:     reg.Fee,
 	})

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -349,7 +349,7 @@ func (c *TCore) InitializeClient(pw []byte) error {
 	c.inited = true
 	return nil
 }
-func (c *TCore) GetFee(host, cert string) (uint64, error) {
+func (c *TCore) GetFee(host string, cert interface{}) (uint64, error) {
 	return 1e8, nil
 }
 

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -77,7 +77,7 @@ type clientCore interface {
 	NewDepositAddress(assetID uint32) (string, error)
 	AutoWalletConfig(assetID uint32) (map[string]string, error)
 	User() *core.User
-	GetFee(url, cert string) (uint64, error)
+	GetFee(url string, cert interface{}) (uint64, error)
 	SupportedAssets() map[uint32]*core.SupportedAsset
 	Withdraw(pw []byte, assetID uint32, value uint64, address string) (asset.Coin, error)
 	Trade(pw []byte, form *core.TradeForm) (*core.Order, error)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -72,7 +72,7 @@ type TCore struct {
 
 func (c *TCore) Network() dex.Network                                        { return dex.Mainnet }
 func (c *TCore) Exchanges() map[string]*core.Exchange                        { return nil }
-func (c *TCore) GetFee(string, string) (uint64, error)                       { return 1e8, c.getFeeErr }
+func (c *TCore) GetFee(string, interface{}) (uint64, error)                  { return 1e8, c.getFeeErr }
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
 func (c *TCore) InitializeClient(pw []byte) error                            { return c.initErr }
 func (c *TCore) Login(pw []byte) (*core.LoginResult, error)                  { return &core.LoginResult{}, c.loginErr }


### PR DESCRIPTION
Previously, caller had to load the file themselves. This allows a either the file name or the file contents. `Core` will load the file if a file name (`string`) is provided. `[]byte` will be assumed to be the certificate file contents and used unmodified.

This was originally part of #717.