### PR TITLE
client/core: epoch tracking right

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -698,7 +698,7 @@ func handleEpochOrderMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error
 	}
 
 	if dc.setEpoch(note.MarketID, note.Epoch) {
-		c.refreshUser()
+		c.refreshUser() // maybe remove if this was pre-nomatch
 	}
 
 	dc.booksMtx.RLock()
@@ -715,7 +715,7 @@ func handleEpochOrderMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error
 		return fmt.Errorf("failed to Enqueue epoch order: %w", err)
 	}
 
-	// Send a mini-order for book updates.
+	// Send a MiniOrder for book updates.
 	book.send(&BookUpdate{
 		Action:   msg.Route,
 		Host:     dc.acct.host,

--- a/client/orderbook/bookside.go
+++ b/client/orderbook/bookside.go
@@ -12,13 +12,11 @@ import (
 	"decred.org/dcrdex/dex/order"
 )
 
-// OrderPreference reprsents ordering preference for a sort.
-type OrderPreference int
+// orderPreference represents ordering preference for a sort.
+type orderPreference int
 
 const (
-	// Ascending denotes ascending order.
-	ascending OrderPreference = iota
-	// Descending denotes descending order.
+	ascending orderPreference = iota
 	descending
 )
 
@@ -32,15 +30,15 @@ type fill struct {
 type bookSide struct {
 	bins      map[uint64][]*Order
 	rateIndex *rateIndex
-	orderPref OrderPreference
+	orderPref orderPreference
 	mtx       sync.RWMutex
 }
 
-// NewBookSide creates a new book side depth.
-func NewBookSide(pref OrderPreference) *bookSide {
+// newBookSide creates a new book side depth.
+func newBookSide(pref orderPreference) *bookSide {
 	return &bookSide{
 		bins:      make(map[uint64][]*Order),
-		rateIndex: NewRateIndex(),
+		rateIndex: newRateIndex(),
 		orderPref: pref,
 	}
 }

--- a/client/orderbook/bookside_test.go
+++ b/client/orderbook/bookside_test.go
@@ -10,7 +10,7 @@ import (
 
 // makeBookSideDepth creates a new book side depth from the provided
 // group and sort order.
-func makeBookSide(groups map[uint64][]*Order, rateIndex *rateIndex, orderPref OrderPreference) *bookSide {
+func makeBookSide(groups map[uint64][]*Order, rateIndex *rateIndex, orderPref orderPreference) *bookSide {
 	return &bookSide{
 		bins:      groups,
 		rateIndex: rateIndex,
@@ -604,7 +604,7 @@ func TestBookSideBestFill(t *testing.T) {
 		label     string
 		side      *bookSide
 		quantity  uint64
-		orderPref OrderPreference
+		orderPref orderPreference
 		expected  []*fill
 		wantErr   bool
 	}{

--- a/client/orderbook/rateindex.go
+++ b/client/orderbook/rateindex.go
@@ -18,8 +18,8 @@ type rateIndex struct {
 	Rates []uint64
 }
 
-// NewRateIndex creates a new rate index.
-func NewRateIndex() *rateIndex {
+// newRateIndex creates a new rate index.
+func newRateIndex() *rateIndex {
 	return &rateIndex{
 		Rates: make([]uint64, 0, defaultCapacity),
 	}

--- a/client/orderbook/rateindex_test.go
+++ b/client/orderbook/rateindex_test.go
@@ -12,7 +12,7 @@ func makeRateIndex(index []uint64) *rateIndex {
 		}
 	}
 
-	return NewRateIndex()
+	return newRateIndex()
 }
 
 func TestRateIndexAdd(t *testing.T) {


### PR DESCRIPTION
match_proof notifications are not in sequence with other book messages and should not be used to indicate a transition from one epoch to another.
Since match_proof lags epoch close by up to preimage request timeout and some additional latency, the `OrderBook` needs to track several epochs for the purposes of evaluating these lagging match proofs.

Resolves https://github.com/decred/dcrdex/issues/824 and https://github.com/decred/dcrdex/issues/628