### PR TITLE
client/multi: add max order estimation

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -871,7 +871,7 @@ func TestFundEdges(t *testing.T) {
 	swapVal := uint64(1e7)
 	lots := swapVal / tBTC.LotSize
 	node.rawRes[methodLockUnspent] = mustMarshal(t, true)
-	var estFeeRate uint64 = optimalFeeRate + 1 // +1 added in feeRate
+	var estFeeRate = optimalFeeRate + 1 // +1 added in feeRate
 
 	checkMax := func(lots, swapVal, maxFees, estFees, locked uint64) {
 		checkMaxOrder(t, wallet, lots, swapVal, maxFees, estFees, locked)
@@ -1083,7 +1083,7 @@ func TestFundEdgesSegwit(t *testing.T) {
 	swapVal := uint64(1e7)
 	lots := swapVal / tBTC.LotSize
 	node.rawRes[methodLockUnspent] = mustMarshal(t, true)
-	var estFeeRate uint64 = optimalFeeRate + 1 // +1 added in feeRateWithFallback
+	var estFeeRate = optimalFeeRate + 1 // +1 added in feeRateWithFallback
 
 	checkMax := func(lots, swapVal, maxFees, estFees, locked uint64) {
 		checkMaxOrder(t, wallet, lots, swapVal, maxFees, estFees, locked)

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -842,12 +842,40 @@ func TestFundingCoins(t *testing.T) {
 	ensureGood()
 }
 
+func checkMaxOrder(t *testing.T, wallet *ExchangeWallet, lots, swapVal, maxFees, estFees, locked uint64) {
+	t.Helper()
+	maxOrder, err := wallet.MaxOrder(tBTC.LotSize, tBTC)
+	if err != nil {
+		t.Fatalf("MaxOrder error: %v", err)
+	}
+	if maxOrder.Lots != lots {
+		t.Fatalf("MaxOrder has wrong Lots. wanted %d, got %d", lots, maxOrder.Lots)
+	}
+	if maxOrder.Value != swapVal {
+		t.Fatalf("MaxOrder has wrong Value. wanted %d, got %d", swapVal, maxOrder.Value)
+	}
+	if maxOrder.MaxFees != maxFees {
+		t.Fatalf("MaxOrder has wrong MaxFees. wanted %d, got %d", maxFees, maxOrder.MaxFees)
+	}
+	if maxOrder.EstimatedFees != estFees {
+		t.Fatalf("MaxOrder has wrong EstimatedFees. wanted %d, got %d", estFees, maxOrder.EstimatedFees)
+	}
+	if maxOrder.Locked != locked {
+		t.Fatalf("MaxOrder has wrong Locked. wanted %d, got %d", locked, maxOrder.Locked)
+	}
+}
+
 func TestFundEdges(t *testing.T) {
 	wallet, node, shutdown := tNewWallet(false)
 	defer shutdown()
 	swapVal := uint64(1e7)
 	lots := swapVal / tBTC.LotSize
 	node.rawRes[methodLockUnspent] = mustMarshal(t, true)
+	var estFeeRate uint64 = optimalFeeRate + 1 // +1 added in feeRate
+
+	checkMax := func(lots, swapVal, maxFees, estFees, locked uint64) {
+		checkMaxOrder(t, wallet, lots, swapVal, maxFees, estFees, locked)
+	}
 
 	// Base Fees
 	// fee_rate: 34 satoshi / vbyte (MaxFeeRate)
@@ -872,7 +900,9 @@ func TestFundEdges(t *testing.T) {
 	// total_bytes  = base_tx_bytes + backing_bytes = 2101 + 149 = 2250
 	// total_fees: base_fees + backing_fees = 71434 + 5066 = 76500 atoms
 	//          OR total_bytes * fee_rate = 2510 * 34 = 76500
-	backingFees := uint64(2250) * tBTC.MaxFeeRate // total_bytes * fee_rate
+	const swapSize = 225
+	const totalBytes = 2250
+	backingFees := uint64(totalBytes) * tBTC.MaxFeeRate // total_bytes * fee_rate
 	p2pkhUnspent := &ListUnspentResult{
 		TxID:          tTxID,
 		Address:       tP2PKHAddr,
@@ -890,6 +920,11 @@ func TestFundEdges(t *testing.T) {
 		MaxSwapCount: lots,
 		DEXConfig:    tBTC,
 	}
+
+	var feeReduction uint64 = swapSize * tBTC.MaxFeeRate
+	estFeeReduction := swapSize * estFeeRate
+	checkMax(lots-1, swapVal-tBTC.LotSize, backingFees-feeReduction, totalBytes*estFeeRate-estFeeReduction, swapVal+backingFees-1)
+
 	_, _, err := wallet.FundOrder(ord)
 	if err == nil {
 		t.Fatalf("no error when not enough funds in single p2pkh utxo")
@@ -897,6 +932,9 @@ func TestFundEdges(t *testing.T) {
 	// Now add the needed satoshi and try again.
 	p2pkhUnspent.Amount = float64(swapVal+backingFees) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
+	checkMax(lots, swapVal, backingFees, totalBytes*estFeeRate, swapVal+backingFees)
+
 	_, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error when should be enough funding in single p2pkh utxo: %v", err)
@@ -909,11 +947,12 @@ func TestFundEdges(t *testing.T) {
 	node.signFunc = func(params []json.RawMessage) (json.RawMessage, error) {
 		return signFunc(t, params, 0, true, wallet.segwit)
 	}
-	backingFees = uint64(2250+splitTxBaggage) * tBTC.MaxFeeRate
+	backingFees = uint64(totalBytes+splitTxBaggage) * tBTC.MaxFeeRate
 	// 1 too few atoms
 	v := swapVal + backingFees - 1
 	p2pkhUnspent.Amount = float64(v) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
 	coins, _, err := wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error when skipping split tx due to baggage: %v", err)
@@ -925,6 +964,9 @@ func TestFundEdges(t *testing.T) {
 	v = swapVal + backingFees
 	p2pkhUnspent.Amount = float64(v) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
+	checkMax(lots, swapVal, backingFees, (totalBytes+splitTxBaggage)*estFeeRate, v)
+
 	coins, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding split tx: %v", err)
@@ -1041,6 +1083,11 @@ func TestFundEdgesSegwit(t *testing.T) {
 	swapVal := uint64(1e7)
 	lots := swapVal / tBTC.LotSize
 	node.rawRes[methodLockUnspent] = mustMarshal(t, true)
+	var estFeeRate uint64 = optimalFeeRate + 1 // +1 added in feeRateWithFallback
+
+	checkMax := func(lots, swapVal, maxFees, estFees, locked uint64) {
+		checkMaxOrder(t, wallet, lots, swapVal, maxFees, estFees, locked)
+	}
 
 	// Base Fees
 	// fee_rate: 34 satoshi / vbyte (MaxFeeRate)
@@ -1064,7 +1111,9 @@ func TestFundEdgesSegwit(t *testing.T) {
 	// total_bytes  = base_tx_bytes + backing_bytes = 1461 + 69 = 1530
 	// total_fees: base_fees + backing_fees = 49674 + 2346 = 52020 atoms
 	//          OR total_bytes * fee_rate = 1530 * 34 = 52020
-	backingFees := uint64(1530) * tBTC.MaxFeeRate // total_bytes * fee_rate
+	const swapSize = 153
+	const totalBytes = 1530
+	backingFees := uint64(totalBytes) * tBTC.MaxFeeRate // total_bytes * fee_rate
 	p2wpkhUnspent := &ListUnspentResult{
 		TxID:          tTxID,
 		Address:       tP2WPKHAddr,
@@ -1082,6 +1131,11 @@ func TestFundEdgesSegwit(t *testing.T) {
 		MaxSwapCount: lots,
 		DEXConfig:    tBTC,
 	}
+
+	var feeReduction uint64 = swapSize * tBTC.MaxFeeRate
+	estFeeReduction := swapSize * estFeeRate
+	checkMax(lots-1, swapVal-tBTC.LotSize, backingFees-feeReduction, totalBytes*estFeeRate-estFeeReduction, swapVal+backingFees-1)
+
 	_, _, err := wallet.FundOrder(ord)
 	if err == nil {
 		t.Fatalf("no error when not enough funds in single p2wpkh utxo")
@@ -1089,6 +1143,9 @@ func TestFundEdgesSegwit(t *testing.T) {
 	// Now add the needed satoshi and try again.
 	p2wpkhUnspent.Amount = float64(swapVal+backingFees) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
+	checkMax(lots, swapVal, backingFees, totalBytes*estFeeRate, swapVal+backingFees)
+
 	_, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error when should be enough funding in single p2wpkh utxo: %v", err)
@@ -1101,7 +1158,7 @@ func TestFundEdgesSegwit(t *testing.T) {
 	node.signFunc = func(params []json.RawMessage) (json.RawMessage, error) {
 		return signFunc(t, params, 0, true, wallet.segwit)
 	}
-	backingFees = uint64(1530+splitTxBaggageSegwit) * tBTC.MaxFeeRate
+	backingFees = uint64(totalBytes+splitTxBaggageSegwit) * tBTC.MaxFeeRate
 	v := swapVal + backingFees - 1
 	p2wpkhUnspent.Amount = float64(v) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
@@ -1116,6 +1173,9 @@ func TestFundEdgesSegwit(t *testing.T) {
 	v = swapVal + backingFees
 	p2wpkhUnspent.Amount = float64(v) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
+	checkMax(lots, swapVal, backingFees, (totalBytes+splitTxBaggageSegwit)*estFeeRate, v)
+
 	coins, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding split tx: %v", err)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -80,6 +80,15 @@ type Wallet interface {
 	// empty dex.Bytes should be appended to the redeem scripts collection for
 	// coins with no redeem script.
 	FundOrder(*Order) (coins Coins, redeemScripts []dex.Bytes, err error)
+	// MaxOrder generates information about the maximum order size and
+	// associated fees that the wallet can support for the specified DEX. The
+	// fees are an estimate based on current network conditions, and will be <=
+	// the fees associated with the Asset.MaxFeeRate. For quote assets, lotSize
+	// will be an estimate based on current market conditions.
+	MaxOrder(lotSize uint64, nfo *dex.Asset) (*OrderEstimate, error)
+	// RedemptionFees is an estimate of the redemption fees for a 1-swap
+	// redemption.
+	RedemptionFees() (uint64, error)
 	// ReturnCoins unlocks coins. This would be necessary in the case of a
 	// canceled order.
 	ReturnCoins(Coins) error
@@ -275,4 +284,22 @@ type Order struct {
 	// standing order, likely a market order or a limit order with immediate
 	// time-in-force.
 	Immediate bool
+}
+
+// OrderEstimate is an estimate of the fees and locked amounts associated with
+// an order.
+type OrderEstimate struct {
+	// Lots is the number of lots in the order.
+	Lots uint64
+	// Value is the total value of the order.
+	Value uint64
+	// MaxFees is the maximum possible fees that can be assessed for the order's
+	// swaps.
+	MaxFees uint64
+	// EstimatedFees is an estimation of the fees that might be assessed for the
+	// order's swaps.
+	EstimatedFees uint64
+	// Locked is the amount that will be locked if this order is
+	// subsequently placed.
+	Locked uint64
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2179,6 +2179,93 @@ func (c *Core) Order(oidB dex.Bytes) (*Order, error) {
 	return c.coreOrderFromMetaOrder(mOrd)
 }
 
+// marketWallets gets the 2 *dex.Assets and 2 *xcWallet associated with a
+// market. The wallets will be connected, but not necessarily unlocked.
+func (c *Core) marketWallets(host string, base, quote uint32) (ba, qa *dex.Asset, bw, qw *xcWallet, err error) {
+	c.connMtx.RLock()
+	dc, found := c.conns[host]
+	c.connMtx.RUnlock()
+	if !found {
+		return nil, nil, nil, nil, fmt.Errorf("Unknown host: %s", host)
+	}
+
+	ba, found = dc.assets[base]
+	if !found {
+		return nil, nil, nil, nil, fmt.Errorf("%s not supported by %s", unbip(base), host)
+	}
+	qa, found = dc.assets[quote]
+	if !found {
+		return nil, nil, nil, nil, fmt.Errorf("%s not supported by %s", unbip(quote), host)
+	}
+
+	bw, err = c.connectedWallet(base)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("%s wallet error: %v", unbip(base), err)
+	}
+	qw, err = c.connectedWallet(quote)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("%s wallet error: %v", unbip(quote), err)
+	}
+	return
+}
+
+// MaxBuy is the maximum-sized *OrderEstimate for a buy order on the specified
+// market. An order rate must be provided, since the number of lots available
+// for trading will vary based on the rate for a buy order (unlike a sell
+// order).
+func (c *Core) MaxBuy(host string, base, quote uint32, rate uint64) (*OrderEstimate, error) {
+	baseAsset, quoteAsset, baseWallet, quoteWallet, err := c.marketWallets(host, base, quote)
+	if err != nil {
+		return nil, err
+	}
+
+	quoteLotEst := calc.BaseToQuote(rate, baseAsset.LotSize)
+	maxBuy, err := quoteWallet.MaxOrder(quoteLotEst, quoteAsset)
+	if err != nil {
+		return nil, fmt.Errorf("%s wallet MaxOrder error: %v", unbip(quote), err)
+	}
+	buyRedemptionPer, err := baseWallet.RedemptionFees()
+	if err != nil {
+		return nil, fmt.Errorf("%s RedemptionFees error: %v", unbip(base), err)
+	}
+
+	return &OrderEstimate{
+		Lots:           maxBuy.Lots,
+		Value:          maxBuy.Value,
+		MaxFees:        maxBuy.MaxFees,
+		EstimatedFees:  maxBuy.EstimatedFees,
+		Locked:         maxBuy.Locked,
+		RedemptionFees: maxBuy.Lots * buyRedemptionPer,
+	}, nil
+}
+
+// MaxSell is the maximum-sized *OrderEstimate for a sell order on the specified
+// market.
+func (c *Core) MaxSell(host string, base, quote uint32) (*OrderEstimate, error) {
+	baseAsset, _, baseWallet, quoteWallet, err := c.marketWallets(host, base, quote)
+	if err != nil {
+		return nil, err
+	}
+
+	maxSell, err := baseWallet.MaxOrder(baseAsset.LotSize, baseAsset)
+	if err != nil {
+		return nil, fmt.Errorf("%s wallet MaxOrder error: %v", unbip(base), err)
+	}
+	sellRedemptionPer, err := quoteWallet.RedemptionFees()
+	if err != nil {
+		return nil, fmt.Errorf("%s RedemptionFees error: %v", unbip(quote), err)
+	}
+
+	return &OrderEstimate{
+		Lots:           maxSell.Lots,
+		Value:          maxSell.Value,
+		MaxFees:        maxSell.MaxFees,
+		EstimatedFees:  maxSell.EstimatedFees,
+		Locked:         maxSell.Locked,
+		RedemptionFees: maxSell.Lots * sellRedemptionPer,
+	}, nil
+}
+
 // initializeDEXConnections connects to the DEX servers in the conns map and
 // authenticates the connection. If registration is incomplete, reFee is run and
 // the connection will be authenticated once the `notifyfee` request is sent.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -588,6 +588,11 @@ func (w *TXCWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, error
 	return w.fundingCoins, w.fundRedeemScripts, w.fundingCoinErr
 }
 
+func (w *TXCWallet) MaxOrder(lotSize uint64, nfo *dex.Asset) (*asset.OrderEstimate, error) {
+	return nil, nil
+}
+func (w *TXCWallet) RedemptionFees() (uint64, error) { return 0, nil }
+
 func (w *TXCWallet) ReturnCoins(coins asset.Coins) error {
 	w.returnedCoins = coins
 	coinInSlice := func(coin asset.Coin) bool {

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -710,3 +710,17 @@ func (c assetMap) merge(other assetMap) {
 		c[assetID] = struct{}{}
 	}
 }
+
+// OrderEstimate is an estimate of the fees and locked amounts associated with
+// an order. This type differs from asset.OrderEstimate in the addition of the
+// RedemptionFees field, which comes from the other asset's wallet.
+type OrderEstimate struct {
+	Lots          uint64 `json:"lots"`
+	Value         uint64 `json:"value"`
+	MaxFees       uint64 `json:"maxFees"`
+	EstimatedFees uint64 `json:"estimatedFees"`
+	Locked        uint64 `json:"locked"`
+	// RedemptionFees are the fees associated with redeeming the order one
+	// lot at a time, using the wallet's redemption fee rate.
+	RedemptionFees uint64 `json:"redemptionFees"`
+}

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -470,6 +470,57 @@ func (s *WebServer) apiWithdraw(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp, s.indent)
 }
 
+// apiMaxBuy handles the 'maxbuy' API request.
+func (s *WebServer) apiMaxBuy(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		Host  string `json:"host"`
+		Base  uint32 `json:"base"`
+		Quote uint32 `json:"quote"`
+		Rate  uint64 `json:"rate"`
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+	maxBuy, err := s.core.MaxBuy(form.Host, form.Base, form.Quote, form.Rate)
+	if err != nil {
+		s.writeAPIError(w, "max order estimation error: %v", err)
+		return
+	}
+	resp := struct {
+		OK     bool                `json:"ok"`
+		MaxBuy *core.OrderEstimate `json:"maxBuy"`
+	}{
+		OK:     true,
+		MaxBuy: maxBuy,
+	}
+	writeJSON(w, resp, s.indent)
+}
+
+// apiMaxSell handles the 'maxsell' API request.
+func (s *WebServer) apiMaxSell(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		Host  string `json:"host"`
+		Base  uint32 `json:"base"`
+		Quote uint32 `json:"quote"`
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+	maxSell, err := s.core.MaxSell(form.Host, form.Base, form.Quote)
+	if err != nil {
+		s.writeAPIError(w, "max order estimation error: %v", err)
+		return
+	}
+	resp := struct {
+		OK      bool                `json:"ok"`
+		MaxSell *core.OrderEstimate `json:"maxSell"`
+	}{
+		OK:      true,
+		MaxSell: maxSell,
+	}
+	writeJSON(w, resp, s.indent)
+}
+
 // apiActuallyLogin logs the user in.
 func (s *WebServer) actuallyLogin(w http.ResponseWriter, r *http.Request, login *loginForm) {
 	loginResult, err := s.core.Login(login.Pass)

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -409,6 +409,41 @@ func (c *TCore) Orders(filter *core.OrderFilter) ([]*core.Order, error) {
 	return cords, nil
 }
 
+func (c *TCore) MaxBuy(host string, base, quote uint32, rate uint64) (*core.OrderEstimate, error) {
+	mktID, _ := dex.MarketName(base, quote)
+	midGap, maxQty := getMarketStats(mktID)
+	ord := randomOrder(rand.Float32() > 0.5, maxQty, midGap, gapWidthFactor*midGap, false)
+	qty := toAtoms(ord.Qty)
+	quoteQty := calc.BaseToQuote(rate, qty)
+	return &core.OrderEstimate{
+		Lots:           qty / tExchanges[host].Assets[base].LotSize,
+		Value:          quoteQty,
+		MaxFees:        quoteQty / 100,
+		EstimatedFees:  quoteQty / 200,
+		Locked:         quoteQty,
+		RedemptionFees: qty / 300,
+	}, nil
+}
+
+func (c *TCore) MaxSell(host string, base, quote uint32) (*core.OrderEstimate, error) {
+	mktID, _ := dex.MarketName(base, quote)
+	midGap, maxQty := getMarketStats(mktID)
+	ord := randomOrder(rand.Float32() > 0.5, maxQty, midGap, gapWidthFactor*midGap, false)
+	qty := toAtoms(ord.Qty)
+	return &core.OrderEstimate{
+		Lots:           qty / tExchanges[host].Assets[base].LotSize,
+		Value:          qty,
+		MaxFees:        qty / 100,
+		EstimatedFees:  qty / 200,
+		Locked:         qty,
+		RedemptionFees: 1,
+	}, nil
+}
+
+func toAtoms(v float64) uint64 {
+	return uint64(math.Round(v * 1e8))
+}
+
 func coreCoin() *core.Coin {
 	b := make([]byte, 36)
 	copy(b[:], encode.RandomBytes(32))

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -234,7 +234,8 @@ table.balance-table button:hover {
     color: #1e7d11;
   }
 
-  #orderPreview {
+  #orderPreview,
+  .h21 {
     height: 21px;
   }
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=MQq4VTue">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=Tl31" rel="stylesheet">
+  <link href="/css/style.css?v=rOIoK" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=35bN"></script>
+<script src="/js/entry.js?v=NeHb"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -152,6 +152,23 @@
                         <span data-unit="quote"></span>
                       </div>
                     </div>
+                    <div class="my-2 fs14 h21" id="maxBox">
+                      <div id="maxOrd" class="d-hide position-relative pointer">
+                        <span id="maxLotBox" class="d-hide">
+                          <span class="underline">Max <span id="maxLbl">Buy</span></span>:
+                          <span id="maxFromLots"></span>
+                          <span id="maxFromLotsLbl">lot</span>
+                        </span>
+                        <span id="maxAboveZero" class="d-hide">
+                          ,
+                          <span id="maxFromAmt"></span>
+                          <span id="maxFromTicker"></span>
+                          &rarr;
+                          <span id="maxToAmt"></span>
+                          <span id="maxToTicker"></span>
+                        </span>
+                      </div>
+                    </div>
 
                     {{- /* RATE AND QUANTITY INPUTS */ -}}
                     <div class="d-flex mt-3" id="priceBox">

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -615,12 +615,9 @@ export default class Application {
    * element until Application.loaded is called.
    */
   loading (el) {
-    el.appendChild(this.page.loader)
-  }
-
-  /* loaded hides the loading element as shown with Application.loading. */
-  loaded () {
-    this.page.loader.remove()
+    const loader = this.page.loader.cloneNode(true)
+    el.appendChild(loader)
+    return () => { loader.remove() }
   }
 
   /* orders retrieves a list of orders for the specified dex and market. */

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -34,9 +34,9 @@ export class NewWalletForm {
         appPass: fields.nwAppPass.value
       }
       fields.nwAppPass.value = ''
-      app.loading(form)
+      const loaded = app.loading(form)
       var res = await postJSON('/api/newwallet', createForm)
-      app.loaded()
+      loaded()
       if (!app.checkResponse(res)) {
         this.setError(res.msg)
         return
@@ -69,9 +69,9 @@ export class NewWalletForm {
    * the subform if settings are found.
    */
   async loadDefaults () {
-    app.loading(this.form)
+    const loaded = app.loading(this.form)
     var res = await postJSON('/api/defaultwalletcfg', { assetID: this.currentAsset.id })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) {
       this.setError(res.msg)
       return
@@ -133,13 +133,13 @@ export class WalletConfigForm {
    */
   async fileInputChanged () {
     if (!this.fileInput.value) return
-    app.loading(this.form)
+    const loaded = app.loading(this.form)
     const config = await this.fileInput.files[0].text()
     if (!config) return
     const res = await postJSON('/api/parseconfig', {
       configtext: config
     })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) {
       this.errMsg.textContent = res.msg
       Doc.show(this.errMsg)
@@ -301,9 +301,9 @@ export function bindOpenWallet (app, form, success) {
       pass: fields.uwAppPass.value
     }
     fields.uwAppPass.value = ''
-    app.loading(form)
+    const loaded = app.loading(form)
     var res = await postJSON('/api/openwallet', open)
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) {
       fields.unlockErr.textContent = res.msg
       Doc.show(fields.unlockErr)

--- a/client/webserver/site/src/js/login.js
+++ b/client/webserver/site/src/js/login.js
@@ -27,9 +27,9 @@ export default class LoginPage extends BasePage {
       Doc.show(page.errMsg)
       return
     }
-    app.loading(page.loginForm)
+    const loaded = app.loading(page.loginForm)
     var res = await postJSON('/api/login', { pass: pw })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) {
       page.errMsg.textContent = res.msg
       Doc.show(page.errMsg)

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -654,7 +654,11 @@ export default class MarketsPage extends BasePage {
     const [bWallet, qWallet] = [app.assets[bid].wallet, app.assets[qid].wallet]
     if (!bWallet || !bWallet.running || !qWallet || !qWallet.running) return
     if (this.preorderTimer) window.clearTimeout(this.preorderTimer)
-    Doc.show(page.maxOrd)
+
+    Doc.show(page.maxOrd, page.maxLotBox)
+    Doc.hide(page.maxAboveZero)
+    page.maxFromLots.textContent = 'calculating...'
+    page.maxFromLotsLbl.textContent = ''
     this.preorderTimer = window.setTimeout(async () => {
       this.preorderTimer = null
       const res = await postJSON(path, {
@@ -667,7 +671,8 @@ export default class MarketsPage extends BasePage {
       this.maxLoaded = null
 
       if (!app.checkResponse(res, true)) {
-        console.error(`${path} error: `, res)
+        console.warn('max order estimate not available:', res)
+        page.maxFromLots.textContent = 'estimate unavailable'
         return
       }
       success(res)

--- a/client/webserver/site/src/js/order.js
+++ b/client/webserver/site/src/js/order.js
@@ -113,9 +113,9 @@ export default class OrderPage extends BasePage {
       pw: page.cancelPass.value
     }
     page.cancelPass.value = ''
-    app.loading(page.cancelForm)
+    const loaded = app.loading(page.cancelForm)
     var res = await postJSON('/api/cancel', req)
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) return
     page.status.textContent = 'cancelling'
     Doc.hide(page.forms)

--- a/client/webserver/site/src/js/orders.js
+++ b/client/webserver/site/src/js/orders.js
@@ -173,9 +173,9 @@ export default class OrdersPage extends BasePage {
 
   /* fetchOrders fetches orders using the current filter. */
   async fetchOrders () {
-    app.loading(this.main)
+    const loaded = app.loading(this.main)
     const res = await postJSON('/api/orders', this.currentFilter())
-    app.loaded()
+    loaded()
     return res.orders
   }
 

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -110,9 +110,9 @@ export default class RegistrationPage extends BasePage {
     app.setNotes([])
     page.appPW.value = ''
     page.appPWAgain.value = ''
-    app.loading(page.appPWForm)
+    const loaded = app.loading(page.appPWForm)
     var res = await postJSON('/api/init', { pass: pw })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) {
       page.appErrMsg.textContent = res.msg
       Doc.show(page.appErrMsg)
@@ -139,12 +139,12 @@ export default class RegistrationPage extends BasePage {
       cert = await page.certFile.files[0].text()
     }
 
-    app.loading(page.dexAddrForm)
+    const loaded = app.loading(page.dexAddrForm)
     var res = await postJSON('/api/getfee', {
       addr: addr,
       cert: cert
     })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res, true)) {
       if (res.msg === 'certificate required') {
         Doc.hide(page.dexShowMore)
@@ -177,9 +177,9 @@ export default class RegistrationPage extends BasePage {
       cert: cert
     }
     page.appPass.value = ''
-    app.loading(page.confirmRegForm)
+    const loaded = app.loading(page.confirmRegForm)
     var res = await postJSON('/api/register', registration)
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) {
       page.regErr.textContent = res.msg
       Doc.show(page.regErr)

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -113,12 +113,12 @@ export default class SettingsPage extends BasePage {
       cert = await page.certFile.files[0].text()
     }
 
-    app.loading(page.dexAddrForm)
+    const loaded = app.loading(page.dexAddrForm)
     const res = await postJSON('/api/getfee', {
       addr: addr,
       cert: cert
     })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) {
       page.dexAddrErr.textContent = res.msg
       Doc.show(page.dexAddrErr)
@@ -145,18 +145,18 @@ export default class SettingsPage extends BasePage {
       cert: cert
     }
     page.appPass.value = ''
-    app.loading(page.confirmRegForm)
+    const loaded = app.loading(page.confirmRegForm)
     const res = await postJSON('/api/register', registration)
     if (!app.checkResponse(res)) {
       page.regErr.textContent = res.msg
       Doc.show(page.regErr)
-      app.loaded()
+      loaded()
       return
     }
     page.dexAddr.value = ''
     this.clearCertFile()
     Doc.hide(page.forms)
     await app.fetchUser()
-    app.loaded()
+    loaded()
   }
 }

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -246,11 +246,11 @@ export default class WalletsPage extends BasePage {
     this.reconfigAsset = this.lastFormAsset = assetID
     await this.hideBox()
     this.animation = this.showBox(page.walletReconfig)
-    app.loading(page.walletReconfig)
+    const loaded = app.loading(page.walletReconfig)
     var res = await postJSON('/api/walletsettings', {
       assetID: assetID
     })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res, true)) {
       page.reconfigErr.textContent = res.msg
       Doc.show(page.reconfigErr)
@@ -282,7 +282,7 @@ export default class WalletsPage extends BasePage {
       Doc.show(page.repwErr)
       return
     }
-    app.loading(page.walletRepw)
+    const loaded = app.loading(page.walletRepw)
     var res = await postJSON('/api/setwalletpass', {
       assetID: this.reconfigAsset,
       newPW: page.repwNewPw.value,
@@ -290,7 +290,7 @@ export default class WalletsPage extends BasePage {
     })
     page.repwNewPw.value = ''
     page.repwAppPw.value = ''
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res, true)) {
       page.repwErr.textContent = res.msg
       Doc.show(page.repwErr)
@@ -322,11 +322,11 @@ export default class WalletsPage extends BasePage {
   async newDepositAddress () {
     const page = this.page
     Doc.hide(page.depositErr)
-    app.loading(page.deposit)
+    const loaded = app.loading(page.deposit)
     const res = await postJSON('/api/depositaddress', {
       assetID: this.depositAsset
     })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res, true)) {
       page.depositErr.textContent = res.msg
       Doc.show(page.depositErr)
@@ -358,11 +358,11 @@ export default class WalletsPage extends BasePage {
 
   /* doConnect connects to a wallet via the connectwallet API route. */
   async doConnect (assetID) {
-    app.loading(this.body)
+    const loaded = app.loading(this.body)
     var res = await postJSON('/api/connectwallet', {
       assetID: assetID
     })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) return
     const rowInfo = this.rowInfos[assetID]
     Doc.hide(rowInfo.actions.connect)
@@ -404,9 +404,9 @@ export default class WalletsPage extends BasePage {
       value: parseInt(Math.round(page.withdrawAmt.value * 1e8)),
       pw: page.withdrawPW.value
     }
-    app.loading(page.withdrawForm)
+    const loaded = app.loading(page.withdrawForm)
     var res = await postJSON('/api/withdraw', open)
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res, true)) {
       page.withdrawErr.textContent = res.msg
       Doc.show(page.withdrawErr)
@@ -424,14 +424,14 @@ export default class WalletsPage extends BasePage {
       Doc.show(page.reconfigErr)
       return
     }
-    app.loading(page.walletReconfig)
+    const loaded = app.loading(page.walletReconfig)
     var res = await postJSON('/api/reconfigurewallet', {
       assetID: this.reconfigAsset,
       config: this.walletReconfig.map(),
       pw: page.reconfigPW.value
     })
     page.reconfigPW.value = ''
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res, true)) {
       page.reconfigErr.textContent = res.msg
       Doc.show(page.reconfigErr)
@@ -443,9 +443,9 @@ export default class WalletsPage extends BasePage {
   /* lock instructs the API to lock the wallet. */
   async lock (assetID, asset) {
     const page = this.page
-    app.loading(page.walletForm)
+    const loaded = app.loading(page.walletForm)
     var res = await postJSON('/api/closewallet', { assetID: assetID })
-    app.loaded()
+    loaded()
     if (!app.checkResponse(res)) return
     const a = asset.actions
     Doc.hide(a.withdraw, a.lock, a.deposit)

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -89,6 +89,8 @@ type clientCore interface {
 	Logout() error
 	Orders(*core.OrderFilter) ([]*core.Order, error)
 	Order(oid dex.Bytes) (*core.Order, error)
+	MaxBuy(host string, base, quote uint32, rate uint64) (*core.OrderEstimate, error)
+	MaxSell(host string, base, quote uint32) (*core.OrderEstimate, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -264,6 +266,8 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 			apiAuth.Post("/orders", s.apiOrders)
 			apiAuth.Post("/order", s.apiOrder)
 			apiAuth.Post("/withdraw", s.apiWithdraw)
+			apiAuth.Post("/maxbuy", s.apiMaxBuy)
+			apiAuth.Post("/maxsell", s.apiMaxSell)
 		})
 	})
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -137,6 +137,12 @@ func (c *TCore) Logout() error { return c.logoutErr }
 
 func (c *TCore) Orders(*core.OrderFilter) ([]*core.Order, error) { return nil, nil }
 func (c *TCore) Order(oid dex.Bytes) (*core.Order, error)        { return nil, nil }
+func (c *TCore) MaxBuy(host string, base, quote uint32, rate uint64) (*core.OrderEstimate, error) {
+	return nil, nil
+}
+func (c *TCore) MaxSell(host string, base, quote uint32) (*core.OrderEstimate, error) {
+	return nil, nil
+}
 
 type TWriter struct {
 	b []byte

--- a/dex/calc/fees.go
+++ b/dex/calc/fees.go
@@ -12,14 +12,20 @@ import (
 // fulfill an order. inputsSize is the size of the serialized inputs associated
 // with a set of UTXOs to be spent in the *first* swap txn. maxSwaps is the
 // number of lots in the order. For the quote asset, maxSwaps is not swapVal /
-// coin.LotSize, so it must be a separate parameter. The chained swap txns will
+// nfo.LotSize, so it must be a separate parameter. The chained swap txns will
 // be the standard size as they will spend a previous swap's change output.
-func RequiredOrderFunds(swapVal, inputsSize, maxSwaps uint64, coin *dex.Asset) uint64 {
-	baseBytes := maxSwaps * coin.SwapSize
+func RequiredOrderFunds(swapVal, inputsSize, maxSwaps uint64, nfo *dex.Asset) uint64 {
+	return RequiredOrderFundsAlt(swapVal, inputsSize, maxSwaps, nfo.SwapSizeBase, nfo.SwapSize, nfo.MaxFeeRate)
+}
+
+// RequiredOrderFundsAlt is the same as RequiredOrderFunds, but built-in type
+// parameters.
+func RequiredOrderFundsAlt(swapVal, inputsSize, maxSwaps uint64, swapSizeBase, swapSize, feeRate uint64) uint64 {
+	baseBytes := maxSwaps * swapSize
 	// SwapSize already includes one input, replace the size of the first swap
 	// in the chain with the given size of the actual inputs + SwapSizeBase.
-	firstSwapSize := inputsSize + coin.SwapSizeBase
-	totalBytes := baseBytes + firstSwapSize - coin.SwapSize // in this order because we are using unsigned integers
-	fee := totalBytes * coin.MaxFeeRate
+	firstSwapSize := inputsSize + swapSizeBase
+	totalBytes := baseBytes + firstSwapSize - swapSize // in this order because we are using unsigned integers
+	fee := totalBytes * feeRate
 	return swapVal + fee
 }


### PR DESCRIPTION
Get maximum order estimations for a given market and side based on the wallet balance and, in the case of buy orders, the rate in the rate input field. The data is sourced directly from the wallet, because the limits change based on available funding coins.

The data is shown in the UI as a small message above the rate field. When you click on the label, the quantity fields are pre-populated with the max order.

![image](https://user-images.githubusercontent.com/6109680/99582193-65417d00-29a7-11eb-826d-b144d6bbb9f9.png)

