### PR TITLE
.dexcctl folder

### DIFF
--- a/client/cmd/dexcctl/config.go
+++ b/client/cmd/dexcctl/config.go
@@ -115,6 +115,9 @@ func configure() (*config, []string, bool, error) {
 		if !fileExists(cfg.RPCCert) { // Then in ~/.dexc
 			cfg.RPCCert = cleanAndExpandPath(filepath.Join(dexcAppDir, defaultRPCCertFile))
 		}
+	} else {
+		// Handle environment variable and tilde expansion in the given path.
+		cfg.RPCCert = cleanAndExpandPath(cfg.RPCCert)
 	}
 
 	if cfg.RPCAddr == "" {

--- a/client/cmd/dexcctl/config.go
+++ b/client/cmd/dexcctl/config.go
@@ -19,14 +19,14 @@ import (
 )
 
 const (
-	defaultRPCAddr            = "localhost:5757"
-	defaultConfigFilename     = "dexcctl.conf"
-	defaultRPCCertFile        = "rpc.cert"
-	defaultDexcConfigFilename = "dexc.conf"
+	defaultRPCAddr        = "localhost:5757"
+	defaultConfigFilename = "dexcctl.conf"
+	defaultRPCCertFile    = "rpc.cert"
 )
 
 var (
-	appDir            = dcrutil.AppDataDir("dexc", false)
+	appDir            = dcrutil.AppDataDir("dexcctl", false)
+	dexcAppDir        = dcrutil.AppDataDir("dexc", false)
 	defaultConfigPath = filepath.Join(appDir, defaultConfigFilename)
 )
 
@@ -110,15 +110,16 @@ func configure() (*config, []string, bool, error) {
 	}
 
 	if cfg.RPCCert == "" {
-		cfg.RPCCert = filepath.Join(appDir, defaultRPCCertFile)
+		// Check in ~/.dexcctl first.
+		cfg.RPCCert = cleanAndExpandPath(filepath.Join(appDir, defaultRPCCertFile))
+		if !fileExists(cfg.RPCCert) { // Then in ~/.dexc
+			cfg.RPCCert = cleanAndExpandPath(filepath.Join(dexcAppDir, defaultRPCCertFile))
+		}
 	}
 
 	if cfg.RPCAddr == "" {
 		cfg.RPCAddr = defaultRPCAddr
 	}
-
-	// Handle environment variable expansion in the RPC certificate path.
-	cfg.RPCCert = cleanAndExpandPath(cfg.RPCCert)
 
 	return cfg, remainingArgs, false, nil
 }


### PR DESCRIPTION
Look for the dexcctl.conf file in ~/.dexcctl (or appdata(dexc, false)) instead of ~/.dexc.

dexcctl will also look for rpc.cert in .dexcctl if not specified on the command line, but if it is not found there, it will check in ~/.dexc.