### PR TITLE
client/asset/btc: favor confirmed utxos in FundOrder

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -922,11 +922,9 @@ func (btc *ExchangeWallet) split(value uint64, lots uint64, outputs []*output, i
 	// from server, and have server check fee rate on unconf funding coins.
 	feeRate, err := btc.feeRate(1)
 	if err != nil {
-		// fallback fee rate is NO good here.
-		// feeRate = nfo.MaxFeeRate // maybe
-		return nil, false, fmt.Errorf("Unable to get optimal fee rate for pre-split transaction: %v", err)
+		// Fallback fee rate is NO GOOD here.
+		return nil, false, fmt.Errorf("unable to get optimal fee rate for pre-split transaction: %w", err)
 	}
-	feeRate += feeRate / 10 // cost of chaining unconf txn, don't gamble.
 	if feeRate > nfo.MaxFeeRate {
 		feeRate = nfo.MaxFeeRate
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -177,7 +177,7 @@ func newOutPoint(txHash *chainhash.Hash, vout uint32) outPoint {
 }
 
 // String is a human-readable string representation of the outPoint.
-func (pt *outPoint) String() string {
+func (pt outPoint) String() string {
 	return pt.txHash.String() + ":" + strconv.Itoa(int(pt.vout))
 }
 
@@ -616,6 +616,12 @@ func (dcr *ExchangeWallet) feeRateWithFallback(confTarget uint64) uint64 {
 	return feeRate
 }
 
+type atoms uint64
+
+func (a atoms) String() string {
+	return strconv.FormatFloat(dcrutil.Amount(a).ToCoin(), 'f', -1, 64) // dec, but no trailing zeros
+}
+
 // MaxOrder generates information about the maximum order size and associated
 // fees that the wallet can support for the given DEX configuration. The fees are an
 // estimate based on current network conditions, and will be <= the fees
@@ -710,26 +716,27 @@ func (dcr *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes
 		return nil, nil, fmt.Errorf("cannot fund a zero-lot order")
 	}
 
-	coins, redeemScripts, sum, inputsSize, fundingCoins, err := dcr.fund(orderEnough(ord.Value, ord.MaxSwapCount, ord.DEXConfig))
+	coins, redeemScripts, sum, inputsSize, err := dcr.fund(orderEnough(ord.Value, ord.MaxSwapCount, ord.DEXConfig))
 	if err != nil {
-		return nil, nil, fmt.Errorf("error funding order value of %.8f DCR: %w",
-			toDCR(ord.Value), err)
+		return nil, nil, fmt.Errorf("error funding order value of %s DCR: %w",
+			atoms(ord.Value), err)
 	}
 
 	// Send a split, if preferred.
 	if dcr.useSplitTx && !ord.Immediate {
-		splitCoins, split, err := dcr.split(ord.Value, ord.MaxSwapCount, coins, inputsSize, fundingCoins, ord.DEXConfig)
+		splitCoins, split, err := dcr.split(ord.Value, ord.MaxSwapCount, coins, inputsSize, ord.DEXConfig)
 		if err != nil {
-			dcr.returnCoins(coins)
+			if errRet := dcr.returnCoins(coins); errRet != nil {
+				dcr.log.Warnf("Failed to unlock funding coins %v: %v", coins, errRet)
+			}
 			return nil, nil, err
 		} else if split {
 			return splitCoins, []dex.Bytes{nil}, nil // no redeem script required for split tx output
-		} else {
-			return splitCoins, redeemScripts, nil // splitCoins == coins
 		}
+		return splitCoins, redeemScripts, nil // splitCoins == coins
 	}
 
-	dcr.log.Infof("Funding %.8f DCR order with coins %v worth %.8f", toDCR(ord.Value), coins, toDCR(sum))
+	dcr.log.Infof("Funding %s DCR order with coins %v worth %s", atoms(ord.Value), coins, atoms(sum))
 
 	return coins, redeemScripts, nil
 }
@@ -749,7 +756,7 @@ func (dcr *ExchangeWallet) unspents() ([]walletjson.ListUnspentResult, error) {
 // needed value. Preference is given to selecting coins with 1 or more confs,
 // falling back to 0-conf coins where there are not enough 1+ confs coins.
 func (dcr *ExchangeWallet) fund(enough func(sum uint64, size uint32, unspent *compositeUTXO) bool) (
-	coins asset.Coins, redeemScripts []dex.Bytes, sum, size uint64, spents []*fundingCoin, err error) {
+	coins asset.Coins, redeemScripts []dex.Bytes, sum, size uint64, err error) {
 
 	// Keep a consistent view of spendable and locked coins in the wallet and
 	// the fundingCoins map to make this safe for concurrent use.
@@ -758,19 +765,19 @@ func (dcr *ExchangeWallet) fund(enough func(sum uint64, size uint32, unspent *co
 
 	utxos, err := dcr.spendableUTXOs()
 	if err != nil {
-		return nil, nil, 0, 0, nil, err
+		return nil, nil, 0, 0, err
 	}
 
 	sum, sz, coins, spents, redeemScripts, err := dcr.tryFund(utxos, enough)
 	if err != nil {
-		return nil, nil, 0, 0, nil, err
+		return nil, nil, 0, 0, err
 	}
 
 	err = dcr.lockFundingCoins(spents)
 	if err != nil {
-		return nil, nil, 0, 0, nil, err
+		return nil, nil, 0, 0, err
 	}
-	return coins, redeemScripts, sum, uint64(sz), spents, nil
+	return coins, redeemScripts, sum, uint64(sz), nil
 }
 
 // spendableUTXOs generates a slice of spendable *compositeUTXO.
@@ -872,7 +879,7 @@ func (dcr *ExchangeWallet) tryFund(utxos []*compositeUTXO, enough func(sum uint6
 			return 0, 0, nil, nil, nil, err
 		}
 		if !ok {
-			return 0, 0, nil, nil, nil, fmt.Errorf("not enough to cover requested funds. %.8f available", toDCR(sum))
+			return 0, 0, nil, nil, nil, fmt.Errorf("not enough to cover requested funds. %s DCR available", atoms(sum))
 		}
 	}
 
@@ -898,7 +905,7 @@ func (dcr *ExchangeWallet) tryFund(utxos []*compositeUTXO, enough func(sum uint6
 // order is canceled partially filled, and then the remainder resubmitted. We
 // would already have an output of just the right size, and that would be
 // recognized here.
-func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, inputsSize uint64, fundingCoins []*fundingCoin, nfo *dex.Asset) (asset.Coins, bool, error) {
+func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, inputsSize uint64, nfo *dex.Asset) (asset.Coins, bool, error) {
 
 	// Calculate the extra fees associated with the additional inputs, outputs,
 	// and transaction overhead, and compare to the excess that would be locked.
@@ -909,10 +916,12 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 		coinSum += coin.Value()
 	}
 
+	valStr := atoms(value).String()
+
 	excess := coinSum - calc.RequiredOrderFunds(value, inputsSize, lots, nfo)
 	if baggageFees > excess {
-		dcr.log.Debugf("Skipping split transaction because cost is greater than potential over-lock. %.8f > %.8f.", toDCR(baggageFees), toDCR(excess))
-		dcr.log.Infof("Funding %.8f DCR order with coins %v worth %.8f", toDCR(value), coins, toDCR(coinSum))
+		dcr.log.Debugf("Skipping split transaction because cost is greater than potential over-lock. %s > %s.", atoms(baggageFees), atoms(excess))
+		dcr.log.Infof("Funding %s DCR order with coins %v worth %s", valStr, coins, atoms(coinSum))
 		return coins, false, nil
 	}
 
@@ -957,8 +966,9 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 		dcr.log.Errorf("error returning coins spent in split transaction %v", coins)
 	}
 
-	dcr.log.Infof("Funding %.8f DCR order with split output coin %v from original coins %v", toDCR(value), op, coins)
-	dcr.log.Infof("Sent split transaction %s to accommodate swap of size %.8f + fees = %.8f", op.txHash(), toDCR(value), toDCR(reqFunds))
+	dcr.log.Infof("Funding %s DCR order with split output coin %v from original coins %v", valStr, op, coins)
+	dcr.log.Infof("Sent split transaction %s to accommodate swap of size %s + fees = %s DCR",
+		op.txHash(), valStr, atoms(reqFunds))
 
 	return asset.Coins{op}, true, nil
 }
@@ -2082,7 +2092,7 @@ func (dcr *ExchangeWallet) sendMinusFees(addr dcrutil.Address, val, feeRate uint
 	enough := func(sum uint64, size uint32, unspent *compositeUTXO) bool {
 		return sum+toAtoms(unspent.rpc.Amount) >= val
 	}
-	coins, _, _, _, _, err := dcr.fund(enough)
+	coins, _, _, _, err := dcr.fund(enough)
 	if err != nil {
 		return nil, 0, fmt.Errorf("unable to send %.8f DCR to address %s with feeRate %d atoms/byte: %w",
 			toDCR(val), addr, feeRate, err)
@@ -2098,10 +2108,10 @@ func (dcr *ExchangeWallet) sendRegFee(addr dcrutil.Address, regFee, netFeeRate u
 		txFee := uint64(size+unspent.input.Size()) * netFeeRate
 		return sum+toAtoms(unspent.rpc.Amount) >= regFee+txFee
 	}
-	coins, _, _, _, _, err := dcr.fund(enough)
+	coins, _, _, _, err := dcr.fund(enough)
 	if err != nil {
-		return nil, 0, fmt.Errorf("unable to pay registration fee of %.8f DCR with fee rate of %d atoms/byte: %w",
-			toDCR(regFee), netFeeRate, err)
+		return nil, 0, fmt.Errorf("unable to pay registration fee of %s DCR with fee rate of %d atoms/byte: %w",
+			atoms(regFee), netFeeRate, err)
 	}
 	return dcr.sendCoins(addr, coins, regFee, netFeeRate, false)
 }


### PR DESCRIPTION
The changes the client's BTC backend so that the FundOrder implementation will favor confirmed utxos.