### PR TITLE
client/webserver: fix match's TimeString for order details page

### DIFF
--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -410,7 +410,7 @@ func (m *matchReader) OrderPortion() string {
 // TimeString is a formatted string of the match's timestamp.
 func (m *matchReader) TimeString() string {
 	t := encode.UnixTimeMilli(int64(m.Stamp)).Local()
-	return t.Format("Jan 2 2008, 15:04:05 MST")
+	return t.Format("Jan 2 2006, 15:04:05 MST")
 }
 
 // InSwapCast will be true if the last match step was us broadcasting our swap

--- a/client/webserver/types_test.go
+++ b/client/webserver/types_test.go
@@ -1,0 +1,34 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package webserver
+
+import (
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/client/core"
+)
+
+func Test_matchReader_TimeString(t *testing.T) {
+	stamp := uint64(1607189329)
+	mr := &matchReader{
+		Match: &core.Match{
+			Stamp: stamp * 1000,
+		},
+	}
+
+	gotTimeStr := mr.TimeString()
+
+	// Verify the time string can be parsed and matches the expected Time.
+	layout := "Jan 2 2006, 15:04:05 MST"
+	gotTime, err := time.Parse(layout, gotTimeStr)
+	if err != nil {
+		t.Fatalf("got bad time string: %v", err)
+	}
+
+	wantTime := time.Unix(int64(stamp), 0)
+	if !gotTime.Equal(wantTime) {
+		t.Errorf("wanted time %q, got %q", wantTime, gotTime)
+	}
+}


### PR DESCRIPTION
This fixes the incorrect year that is displayed for a matches "Time" in the order's page.