### PR TITLE
client: Fee rate limit setting

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -127,9 +127,9 @@ var (
 			DisplayName: "Pre-size funding inputs",
 			Description: "When placing an order, create a \"split\" transaction to " +
 				"fund the order without locking more of the wallet balance than " +
-				"necessary. Otherwise, excess funds may be reserved to fund the order" +
+				"necessary. Otherwise, excess funds may be reserved to fund the order " +
 				"until the first swap contract is broadcast during match settlement, " +
-				"or the order is canceled. This an extra transaction for which network" +
+				"or the order is canceled. This an extra transaction for which network " +
 				"mining fees are paid. Used only for standing-type orders, e.g. limit " +
 				"orders without immediate time-in-force.",
 			IsBoolean: true,

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -53,7 +53,8 @@ const (
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
 	defaultRedeemConfTarget = 2
-	smallestUnit            = 1e8
+	// Smallest unit is 1 satoshi = 1e-8 BTC
+	smallestUnit = 1e8
 
 	minNetworkVersion  = 190000
 	minProtocolVersion = 70015

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -47,8 +47,6 @@ const (
 	// The default fee is passed to the user as part of the asset.WalletInfo
 	// structure.
 	defaultFee = 100
-	// defaultFeeLimit is the default value for feelimit.
-	//defaultFeeLimit = 600
 	// defaultRedeemConfTarget is the default redeem transaction confirmation
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
@@ -107,7 +105,7 @@ var (
 		{
 			Key:         "feelimit",
 			DisplayName: "Highest acceptable fee rate",
-			Description: "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand. Units: BTC/kB",
+			Description: "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand. Units: sats/kB",
 		},
 		{
 			Key:          "redeemconftarget",

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -111,14 +111,14 @@ var (
 			Description: "This is the highest network fee rate you are willing to " +
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
-				"wallet.  Units: sats/byte",
+				"wallet.  Units: BTC/kB",
 			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
 		},
 		{
 			Key:         "redeemconftarget",
 			DisplayName: "Redeem confirmation target",
 			Description: "The target number of blocks for the redeem transaction " +
-				"to get a confirmation. Used to set the transaction's fee rate. " +
+				"to be mined. Used to set the transaction's fee rate. " +
 				"(default: 2 blocks)",
 			DefaultValue: defaultRedeemConfTarget,
 		},

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -47,6 +47,8 @@ const (
 	// The default fee is passed to the user as part of the asset.WalletInfo
 	// structure.
 	defaultFee = 100
+	// defaultFeeRateLimit is the default value for the feeratelimit.
+	defaultFeeRateLimit = 600
 	// defaultRedeemConfTarget is the default redeem transaction confirmation
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
@@ -103,9 +105,10 @@ var (
 			DefaultValue: defaultFee * 1000 / 1e8,
 		},
 		{
-			Key:         "feelimit",
-			DisplayName: "Highest acceptable fee rate",
-			Description: "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand. Units: sats/kB",
+			Key:          "feeratelimit",
+			DisplayName:  "Highest acceptable fee rate",
+			Description:  "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand. Units: sats/byte",
+			DefaultValue: defaultFeeRateLimit,
 		},
 		{
 			Key:          "redeemconftarget",

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -106,7 +106,7 @@ var (
 		},
 		{
 			Key:          "feelimit",
-			DisplayName:  "Fee rate limit",
+			DisplayName:  "Highest acceptable fee rate",
 			Description:  "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand. Units: BTC/kB",
 			DefaultValue: defaultFeeLimit * 1000 / 1e8,
 		},

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -48,7 +48,7 @@ const (
 	// structure.
 	defaultFee = 100
 	// defaultFeeLimit is the default value for feelimit.
-	defaultFeeLimit = 600
+	//defaultFeeLimit = 600
 	// defaultRedeemConfTarget is the default redeem transaction confirmation
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
@@ -105,10 +105,9 @@ var (
 			DefaultValue: defaultFee * 1000 / 1e8,
 		},
 		{
-			Key:          "feelimit",
-			DisplayName:  "Highest acceptable fee rate",
-			Description:  "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand. Units: BTC/kB",
-			DefaultValue: defaultFeeLimit * 1000 / 1e8,
+			Key:         "feelimit",
+			DisplayName: "Highest acceptable fee rate",
+			Description: "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand. Units: BTC/kB",
 		},
 		{
 			Key:          "redeemconftarget",
@@ -160,7 +159,6 @@ type BTCCloneCFG struct {
 	ChainParams        *chaincfg.Params
 	Ports              dexbtc.NetPorts
 	DefaultFallbackFee uint64 // sats/byte
-	DefaultFeeLimit    uint64 // sats/byte
 	// LegacyBalance is for clones that don't yet support the 'getbalances' RPC
 	// call.
 	LegacyBalance bool
@@ -347,7 +345,6 @@ type ExchangeWallet struct {
 	tipChange         func(error)
 	minNetworkVersion uint64
 	fallbackFeeRate   uint64
-	feeRateLimit      uint64
 	redeemConfTarget  uint64
 	useSplitTx        bool
 	useLegacyBalance  bool
@@ -413,7 +410,6 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		ChainParams:        params,
 		Ports:              dexbtc.RPCPorts,
 		DefaultFallbackFee: defaultFee,
-		DefaultFeeLimit:    defaultFeeLimit,
 		Segwit:             true,
 	}
 
@@ -459,14 +455,6 @@ func newWallet(cfg *BTCCloneCFG, btcCfg *dexbtc.Config, node rpcClient) *Exchang
 	cfg.Logger.Tracef("Fallback fees set at %d %s/vbyte",
 		fallbackFeesPerByte, cfg.WalletInfo.Units)
 
-	// If set in the user config, the max fee rate will be in units of DCR/kB.
-	// Convert to sats/B.
-	feesLimitPerByte := toSatoshi(btcCfg.FeeRateLimit / 1000)
-	if feesLimitPerByte == 0 {
-		feesLimitPerByte = cfg.DefaultFeeLimit
-	}
-	cfg.Logger.Tracef("Fees rate limit set at %d sats/byte", feesLimitPerByte)
-
 	redeemConfTarget := btcCfg.RedeemConfTarget
 	if redeemConfTarget == 0 {
 		redeemConfTarget = defaultRedeemConfTarget
@@ -484,7 +472,6 @@ func newWallet(cfg *BTCCloneCFG, btcCfg *dexbtc.Config, node rpcClient) *Exchang
 		findRedemptionQueue: make(map[outPoint]*findRedemptionReq),
 		minNetworkVersion:   cfg.MinNetworkVersion,
 		fallbackFeeRate:     fallbackFeesPerByte,
-		feeRateLimit:        feesLimitPerByte,
 		redeemConfTarget:    redeemConfTarget,
 		useSplitTx:          btcCfg.UseSplitTx,
 		useLegacyBalance:    cfg.LegacyBalance,

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -461,7 +461,6 @@ func BTCCloneWallet(cfg *BTCCloneCFG) (*ExchangeWallet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating BTC ExchangeWallet: %v", err)
 	}
-	btc.client = client
 
 	return btc, nil
 }

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -109,9 +109,9 @@ var (
 			Key:         "feeratelimit",
 			DisplayName: "Highest acceptable fee rate",
 			Description: "This is the highest network fee rate you are willing to " +
-				"pay on swap transactions. If you set this too low, you may not be " +
-				"able to place orders with servers that allow for higher swap rates as" +
-				" network conditions demand. Units: sats/byte",
+				"pay on swap transactions. If feeratelimit is lower than a market's " +
+				"maxfeerate, you will not be able to trade on that market with this " +
+				"wallet.  Units: sats/byte",
 			DefaultValue: defaultFeeRateLimit,
 		},
 		{

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -112,7 +112,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: sats/byte",
-			DefaultValue: defaultFeeRateLimit,
+			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
 		},
 		{
 			Key:         "redeemconftarget",
@@ -460,7 +460,7 @@ func BTCCloneWallet(cfg *BTCCloneCFG) (*ExchangeWallet, error) {
 // newWallet creates the ExchangeWallet and starts the block monitor.
 func newWallet(cfg *BTCCloneCFG, btcCfg *dexbtc.Config, node rpcClient) *ExchangeWallet {
 	// If set in the user config, the fallback fee will be in conventional units
-	// per kB, e.g. BTC/kB. Translate that to sats/B.
+	// per kB, e.g. BTC/kB. Translate that to sats/byte.
 	fallbackFeesPerByte := toSatoshi(btcCfg.FallbackFeeRate / 1000)
 	if fallbackFeesPerByte == 0 {
 		fallbackFeesPerByte = cfg.DefaultFallbackFee
@@ -468,9 +468,9 @@ func newWallet(cfg *BTCCloneCFG, btcCfg *dexbtc.Config, node rpcClient) *Exchang
 	cfg.Logger.Tracef("Fallback fees set at %d %s/vbyte",
 		fallbackFeesPerByte, cfg.WalletInfo.Units)
 
-	// If set in the user config, the fee rate limit will be in units of
-	// sats/byte.
-	feesLimitPerByte := btcCfg.FeeRateLimit
+	// If set in the user config, the fee rate limit will be in units of BTC/KB.
+	// Convert to sats/byte.
+	feesLimitPerByte := toSatoshi(btcCfg.FeeRateLimit / 1000)
 	if feesLimitPerByte == 0 {
 		feesLimitPerByte = cfg.DefaultFeeRateLimit
 	}

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -99,30 +99,39 @@ var (
 			DefaultValue: "8332",
 		},
 		{
-			Key:          "fallbackfee",
-			DisplayName:  "Fallback fee rate",
-			Description:  "The fee rate to use for fee payment and withdrawals when estimatesmartfee is not available. Units: BTC/kB",
+			Key:         "fallbackfee",
+			DisplayName: "Fallback fee rate",
+			Description: "The fee rate to use for fee payment and withdrawals when" +
+				" estimatesmartfee is not available. Units: BTC/kB",
 			DefaultValue: defaultFee * 1000 / 1e8,
 		},
 		{
-			Key:          "feeratelimit",
-			DisplayName:  "Highest acceptable fee rate",
-			Description:  "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand. Units: sats/byte",
+			Key:         "feeratelimit",
+			DisplayName: "Highest acceptable fee rate",
+			Description: "This is the highest network fee rate you are willing to " +
+				"pay on swap transactions. If you set this too low, you may not be " +
+				"able to place orders with servers that allow for higher swap rates as" +
+				" network conditions demand. Units: sats/byte",
 			DefaultValue: defaultFeeRateLimit,
 		},
 		{
-			Key:          "redeemconftarget",
-			DisplayName:  "Redeem confirmation target",
-			Description:  "The target number of blocks for the redeem transaction to get a confirmation. Used to set the transaction's fee rate. (default: 2 blocks)",
+			Key:         "redeemconftarget",
+			DisplayName: "Redeem confirmation target",
+			Description: "The target number of blocks for the redeem transaction " +
+				"to get a confirmation. Used to set the transaction's fee rate. " +
+				"(default: 2 blocks)",
 			DefaultValue: defaultRedeemConfTarget,
 		},
 		{
 			Key:         "txsplit",
 			DisplayName: "Pre-size funding inputs",
-			Description: "When placing an order, create a \"split\" transaction to fund the order without locking more of the wallet balance than " +
-				"necessary. Otherwise, excess funds may be reserved to fund the order until the first swap contract is broadcast " +
-				"during match settlement, or the order is canceled. This an extra transaction for which network mining fees are paid. " +
-				"Used only for standing-type orders, e.g. limit orders without immediate time-in-force.",
+			Description: "When placing an order, create a \"split\" transaction to " +
+				"fund the order without locking more of the wallet balance than " +
+				"necessary. Otherwise, excess funds may be reserved to fund the order" +
+				"until the first swap contract is broadcast during match settlement, " +
+				"or the order is canceled. This an extra transaction for which network" +
+				"mining fees are paid. Used only for standing-type orders, e.g. limit " +
+				"orders without immediate time-in-force.",
 			IsBoolean: true,
 		},
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -141,8 +141,6 @@ func newTRPCClient() *tRPCClient {
 
 func (c *tRPCClient) EstimateSmartFee(confTarget int64, mode *btcjson.EstimateSmartFeeMode) (*btcjson.EstimateSmartFeeResult, error) {
 	optimalRate := float64(optimalFeeRate) * 1e-5 // ~0.00024
-	//fmt.Println((float64(optimalFeeRate) * 1e-5) - optimalRate)
-	//fmt.Println(uint64(math.Round(feefloat * 1e5)))
 	return &btcjson.EstimateSmartFeeResult{
 		Blocks:  2,
 		FeeRate: &optimalRate,

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -376,7 +376,7 @@ func newTxOutResult(script []byte, value uint64, confs int64) *btcjson.GetTxOutR
 	}
 }
 
-func tNewWallet(segwit bool) (*ExchangeWallet, *tRPCClient, func()) {
+func tNewWallet(segwit bool) (*ExchangeWallet, *tRPCClient, func(), error) {
 	if segwit {
 		tBTC.SwapSize = dexbtc.InitTxSizeSegwit
 		tBTC.SwapSizeBase = dexbtc.InitTxSizeBaseSegwit
@@ -400,7 +400,11 @@ func tNewWallet(segwit bool) (*ExchangeWallet, *tRPCClient, func()) {
 		DefaultFeeRateLimit: defaultFeeRateLimit,
 		Segwit:              segwit,
 	}
-	wallet := newWallet(cfg, &dexbtc.Config{}, client)
+	wallet, err := newWallet(cfg, &dexbtc.Config{}, client)
+	if err != nil {
+		shutdown()
+		return nil, nil, nil, err
+	}
 	// Initialize the best block.
 	bestHash, _ := client.GetBestBlockHash() // does not return error
 	wallet.tipMtx.Lock()
@@ -408,7 +412,7 @@ func tNewWallet(segwit bool) (*ExchangeWallet, *tRPCClient, func()) {
 	wallet.tipMtx.Unlock()
 	go wallet.run(walletCtx)
 
-	return wallet, client, shutdown
+	return wallet, client, shutdown, nil
 }
 
 func mustMarshal(t *testing.T, thing interface{}) []byte {
@@ -437,8 +441,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestAvailableFund(t *testing.T) {
-	wallet, node, shutdown := tNewWallet(true)
+	wallet, node, shutdown, err := tNewWallet(true)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// With an empty list returned, there should be no error, but the value zero
 	// should be returned.
@@ -760,15 +767,18 @@ func (c *tCoin) Value() uint64                                 { return 100 }
 func (c *tCoin) Confirmations(context.Context) (uint32, error) { return 2, nil }
 
 func TestReturnCoins(t *testing.T) {
-	wallet, node, shutdown := tNewWallet(true)
+	wallet, node, shutdown, err := tNewWallet(true)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Test it with the local output type.
 	coins := asset.Coins{
 		newOutput(tTxHash, 0, 1),
 	}
 	node.rawRes[methodLockUnspent] = []byte(`true`)
-	err := wallet.ReturnCoins(coins)
+	err = wallet.ReturnCoins(coins)
 	if err != nil {
 		t.Fatalf("error with output type coins: %v", err)
 	}
@@ -795,8 +805,11 @@ func TestReturnCoins(t *testing.T) {
 }
 
 func TestFundingCoins(t *testing.T) {
-	wallet, node, shutdown := tNewWallet(true)
+	wallet, node, shutdown, err := tNewWallet(true)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	vout := uint32(123)
 	coinID := toCoinID(tTxHash, vout)
@@ -890,8 +903,11 @@ func checkMaxOrder(t *testing.T, wallet *ExchangeWallet, lots, swapVal, maxFees,
 }
 
 func TestFundEdges(t *testing.T) {
-	wallet, node, shutdown := tNewWallet(false)
+	wallet, node, shutdown, err := tNewWallet(false)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 	swapVal := uint64(1e7)
 	lots := swapVal / tBTC.LotSize
 	node.rawRes[methodLockUnspent] = mustMarshal(t, true)
@@ -949,7 +965,7 @@ func TestFundEdges(t *testing.T) {
 	estFeeReduction := swapSize * estFeeRate
 	checkMax(lots-1, swapVal-tBTC.LotSize, backingFees-feeReduction, totalBytes*estFeeRate-estFeeReduction, swapVal+backingFees-1)
 
-	_, _, err := wallet.FundOrder(ord)
+	_, _, err = wallet.FundOrder(ord)
 	if err == nil {
 		t.Fatalf("no error when not enough funds in single p2pkh utxo")
 	}
@@ -1102,8 +1118,11 @@ func TestFundEdges(t *testing.T) {
 }
 
 func TestFundEdgesSegwit(t *testing.T) {
-	wallet, node, shutdown := tNewWallet(true)
+	wallet, node, shutdown, err := tNewWallet(true)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 	swapVal := uint64(1e7)
 	lots := swapVal / tBTC.LotSize
 	node.rawRes[methodLockUnspent] = mustMarshal(t, true)
@@ -1160,7 +1179,7 @@ func TestFundEdgesSegwit(t *testing.T) {
 	estFeeReduction := swapSize * estFeeRate
 	checkMax(lots-1, swapVal-tBTC.LotSize, backingFees-feeReduction, totalBytes*estFeeRate-estFeeReduction, swapVal+backingFees-1)
 
-	_, _, err := wallet.FundOrder(ord)
+	_, _, err = wallet.FundOrder(ord)
 	if err == nil {
 		t.Fatalf("no error when not enough funds in single p2wpkh utxo")
 	}
@@ -1220,8 +1239,11 @@ func TestSwap(t *testing.T) {
 }
 
 func testSwap(t *testing.T, segwit bool) {
-	wallet, node, shutdown := tNewWallet(segwit)
+	wallet, node, shutdown, err := tNewWallet(segwit)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 	swapVal := toSatoshi(5)
 	coins := asset.Coins{
 		newOutput(tTxHash, 0, toSatoshi(3)),
@@ -1349,8 +1371,11 @@ func TestRedeem(t *testing.T) {
 }
 
 func testRedeem(t *testing.T, segwit bool) {
-	wallet, node, shutdown := tNewWallet(segwit)
+	wallet, node, shutdown, err := tNewWallet(segwit)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 	swapVal := toSatoshi(5)
 	secret := randBytes(32)
 	secretHash := sha256.Sum256(secret)
@@ -1467,8 +1492,11 @@ func testRedeem(t *testing.T, segwit bool) {
 }
 
 func TestSignMessage(t *testing.T) {
-	wallet, node, shutdown := tNewWallet(true)
+	wallet, node, shutdown, err := tNewWallet(true)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	vout := uint32(5)
 	privBytes, _ := hex.DecodeString("b07209eec1a8fb6cfe5cb6ace36567406971a75c330db7101fb21bc679bc5330")
@@ -1565,8 +1593,11 @@ func TestAuditContract(t *testing.T) {
 }
 
 func testAuditContract(t *testing.T, segwit bool) {
-	wallet, node, shutdown := tNewWallet(segwit)
+	wallet, node, shutdown, err := tNewWallet(segwit)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 	vout := uint32(5)
 	swapVal := toSatoshi(5)
 	secretHash, _ := hex.DecodeString("5124208c80d33507befa517c08ed01aa8d33adbf37ecd70fb5f9352f7a51a88d")
@@ -1669,7 +1700,10 @@ func testFindRedemption(t *testing.T, segwit bool) {
 		DefaultFeeRateLimit: defaultFeeRateLimit,
 		Segwit:              segwit,
 	}
-	wallet := newWallet(cfg, &dexbtc.Config{}, node)
+	wallet, err := newWallet(cfg, &dexbtc.Config{}, node)
+	if err != nil {
+		t.Fatal(err)
+	}
 	wallet.currentTip = &block{} // since we're not using Connect, run checkForNewBlocks after adding blocks
 
 	contractHeight := node.GetBestBlockHeight() + 1
@@ -1826,8 +1860,11 @@ func TestRefund(t *testing.T) {
 }
 
 func testRefund(t *testing.T, segwit bool) {
-	wallet, node, shutdown := tNewWallet(segwit)
+	wallet, node, shutdown, err := tNewWallet(segwit)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	secret := randBytes(32)
 	secretHash := sha256.Sum256(secret)
@@ -1936,13 +1973,16 @@ func testRefund(t *testing.T, segwit bool) {
 }
 
 func TestLockUnlock(t *testing.T) {
-	wallet, node, shutdown := tNewWallet(true)
+	wallet, node, shutdown, err := tNewWallet(true)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// just checking that the errors come through.
 	node.rawRes[methodUnlock] = mustMarshal(t, true)
 	node.rawRes[methodLockUnspent] = []byte(`true`)
-	err := wallet.Unlock("pass")
+	err = wallet.Unlock("pass")
 	if err != nil {
 		t.Fatalf("unlock error: %v", err)
 	}
@@ -1973,7 +2013,11 @@ const (
 )
 
 func testSender(t *testing.T, senderType tSenderType) {
-	wallet, node, shutdown := tNewWallet(true)
+	wallet, node, shutdown, err := tNewWallet(true)
+	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 	sender := func(addr string, val uint64) (asset.Coin, error) {
 		return wallet.PayFee(addr, val)
 	}
@@ -1982,7 +2026,6 @@ func testSender(t *testing.T, senderType tSenderType) {
 			return wallet.Withdraw(addr, val)
 		}
 	}
-	defer shutdown()
 	addr := tP2PKHAddr
 	fee := float64(1) // BTC
 	node.rawRes[methodSetTxFee] = mustMarshal(t, true)
@@ -2010,7 +2053,7 @@ func testSender(t *testing.T, senderType tSenderType) {
 	}}
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
 
-	_, err := sender(addr, toSatoshi(fee))
+	_, err = sender(addr, toSatoshi(fee))
 	if err != nil {
 		t.Fatalf("PayFee error: %v", err)
 	}
@@ -2047,8 +2090,11 @@ func TestWithdraw(t *testing.T) {
 }
 
 func TestConfirmations(t *testing.T) {
-	wallet, node, shutdown := tNewWallet(true)
+	wallet, node, shutdown, err := tNewWallet(true)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	coinID := make([]byte, 36)
 	copy(coinID[:32], tTxHash[:])
@@ -2108,8 +2154,11 @@ func TestSendEdges(t *testing.T) {
 }
 
 func testSendEdges(t *testing.T, segwit bool) {
-	wallet, node, shutdown := tNewWallet(segwit)
+	wallet, node, shutdown, err := tNewWallet(segwit)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	const feeRate uint64 = 3
 
@@ -2188,8 +2237,11 @@ func testSendEdges(t *testing.T, segwit bool) {
 }
 
 func TestSyncStatus(t *testing.T) {
-	wallet, node, shutdown := tNewWallet(false)
+	wallet, node, shutdown, err := tNewWallet(false)
 	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
 	node.rawRes[methodGetBlockchainInfo] = mustMarshal(t, &getBlockchainInfoResult{
 		Headers: 100,
 		Blocks:  99,

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -393,13 +393,14 @@ func tNewWallet(segwit bool) (*ExchangeWallet, *tRPCClient, func()) {
 	}
 	walletCtx, shutdown := context.WithCancel(tCtx)
 	cfg := &BTCCloneCFG{
-		WalletCFG:          walletCfg,
-		Symbol:             "btc",
-		Logger:             tLogger,
-		ChainParams:        &chaincfg.MainNetParams,
-		WalletInfo:         WalletInfo,
-		DefaultFallbackFee: defaultFee,
-		Segwit:             segwit,
+		WalletCFG:           walletCfg,
+		Symbol:              "btc",
+		Logger:              tLogger,
+		ChainParams:         &chaincfg.MainNetParams,
+		WalletInfo:          WalletInfo,
+		DefaultFallbackFee:  defaultFee,
+		DefaultFeeRateLimit: defaultFeeRateLimit,
+		Segwit:              segwit,
 	}
 	wallet := newWallet(cfg, &dexbtc.Config{}, client)
 	// Initialize the best block.
@@ -1662,12 +1663,13 @@ func testFindRedemption(t *testing.T, segwit bool) {
 		WalletCFG: &asset.WalletConfig{
 			TipChange: func(error) {},
 		},
-		Symbol:             "btc",
-		Logger:             tLogger,
-		ChainParams:        &chaincfg.MainNetParams,
-		WalletInfo:         WalletInfo,
-		DefaultFallbackFee: defaultFee,
-		Segwit:             segwit,
+		Symbol:              "btc",
+		Logger:              tLogger,
+		ChainParams:         &chaincfg.MainNetParams,
+		WalletInfo:          WalletInfo,
+		DefaultFallbackFee:  defaultFee,
+		DefaultFeeRateLimit: defaultFeeRateLimit,
+		Segwit:              segwit,
 	}
 	wallet := newWallet(cfg, &dexbtc.Config{}, node)
 	wallet.currentTip = &block{} // since we're not using Connect, run checkForNewBlocks after adding blocks

--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -38,7 +38,6 @@ type Config struct {
 	RPCCert          string  `ini:"rpccert"`
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
-	FeeRateLimit     float64 `ini:"feelimit"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 	// Context should be canceled when the application exits. This will cause
 	// some cleanup to be performed during shutdown.

--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	RPCCert          string  `ini:"rpccert"`
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
+	MaxFeeRate       float64 `ini:"maxfee"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 	// Context should be canceled when the application exits. This will cause
 	// some cleanup to be performed during shutdown.

--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	RPCCert          string  `ini:"rpccert"`
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
-	MaxFeeRate       float64 `ini:"maxfee"`
+	FeeRateLimit     float64 `ini:"maxfee"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 	// Context should be canceled when the application exits. This will cause
 	// some cleanup to be performed during shutdown.

--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	RPCCert          string  `ini:"rpccert"`
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
-	FeeRateLimit     float64 `ini:"maxfee"`
+	FeeRateLimit     float64 `ini:"feelimit"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 	// Context should be canceled when the application exits. This will cause
 	// some cleanup to be performed during shutdown.

--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	RPCCert          string  `ini:"rpccert"`
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
-	FeeRateLimit     uint64  `ini:"feeratelimit"`
+	FeeRateLimit     float64 `ini:"feeratelimit"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 	// Context should be canceled when the application exits. This will cause
 	// some cleanup to be performed during shutdown.

--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	RPCCert          string  `ini:"rpccert"`
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
+	FeeRateLimit     uint64  `ini:"feeratelimit"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 	// Context should be canceled when the application exits. This will cause
 	// some cleanup to be performed during shutdown.

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -114,7 +114,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: atoms/byte",
-			DefaultValue: defaultFeeRateLimit,
+			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
 		},
 		{
 			Key:         "redeemconftarget",
@@ -457,9 +457,9 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, logger dex.Logge
 	}
 	logger.Tracef("Fallback fees set at %d atoms/byte", fallbackFeesPerByte)
 
-	// If set in the user config, the fee rate limit will be in units of
-	// atoms/byte.
-	feesLimitPerByte := dcrCfg.FeeRateLimit
+	// If set in the user config, the fee rate limit will be in units of DCR/KB.
+	// Convert to atoms/byte.
+	feesLimitPerByte := toAtoms(dcrCfg.FeeRateLimit / 1000)
 	if feesLimitPerByte == 0 {
 		feesLimitPerByte = defaultFeeRateLimit
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -465,6 +465,7 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, logger dex.Logge
 // newClient attempts to create a new websocket connection to a dcrwallet
 // instance with the given credentials and notification handlers.
 func newClient(host, user, pass, cert string) (*rpcclient.Client, error) {
+
 	certs, err := ioutil.ReadFile(cert)
 	if err != nil {
 		return nil, fmt.Errorf("TLS certificate read error: %w", err)
@@ -778,7 +779,9 @@ func (dcr *ExchangeWallet) unspents() ([]walletjson.ListUnspentResult, error) {
 // check whether adding the provided output would be enough to satisfy the
 // needed value. Preference is given to selecting coins with 1 or more confs,
 // falling back to 0-conf coins where there are not enough 1+ confs coins.
-func (dcr *ExchangeWallet) fund(enough func(sum uint64, size uint32, unspent *compositeUTXO) bool) (asset.Coins, []dex.Bytes, uint64, uint64, []*fundingCoin, error) {
+func (dcr *ExchangeWallet) fund(enough func(sum uint64, size uint32, unspent *compositeUTXO) bool) (
+	coins asset.Coins, redeemScripts []dex.Bytes, sum, size uint64, spents []*fundingCoin, err error) {
+
 	// Keep a consistent view of spendable and locked coins in the wallet and
 	// the fundingCoins map to make this safe for concurrent use.
 	dcr.fundingMtx.Lock()         // before listing unspents in wallet
@@ -927,6 +930,7 @@ func (dcr *ExchangeWallet) tryFund(utxos []*compositeUTXO, enough func(sum uint6
 // would already have an output of just the right size, and that would be
 // recognized here.
 func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, inputsSize uint64, fundingCoins []*fundingCoin, nfo *dex.Asset) (asset.Coins, bool, error) {
+
 	// Calculate the extra fees associated with the additional inputs, outputs,
 	// and transaction overhead, and compare to the excess that would be locked.
 	baggageFees := nfo.MaxFeeRate * splitTxBaggage

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -111,9 +111,9 @@ var (
 			Key:         "feeratelimit",
 			DisplayName: "Highest acceptable fee rate",
 			Description: "This is the highest network fee rate you are willing to " +
-				"pay on swap transactions. If you set this too low, you may not be able" +
-				" to place orders with servers that allow for higher swap rates as " +
-				" network conditions demand.  Units: atoms/byte",
+				"pay on swap transactions. If feeratelimit is lower than a market's " +
+				"maxfeerate, you will not be able to trade on that market with this " +
+				"wallet.  Units: atoms/byte",
 			DefaultValue: defaultFeeRateLimit,
 		},
 		{

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -46,8 +46,8 @@ const (
 
 	// defaultFee is the default value for the fallbackfee.
 	defaultFee = 20
-	// defaultMaxFee is the default value for maxFee.
-	defaultMaxFee = 100
+	// defaultFeeLimit is the default value for feelimit.
+	defaultFeeLimit = 100
 	// defaultRedeemConfTarget is the default redeem transaction confirmation
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
@@ -107,10 +107,10 @@ var (
 			DefaultValue: defaultFee * 1000 / 1e8,
 		},
 		{
-			Key:          "maxfee",
-			DisplayName:  "Fee rate limit",
-			Description:  "The fee rate threshold to use for fee payment and withdrawals.  Units: DCR/kB",
-			DefaultValue: defaultMaxFee * 1000 / 1e8,
+			Key:          "feelimit",
+			DisplayName:  "Highest acceptable fee rate",
+			Description:  "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand.  Units: DCR/kB",
+			DefaultValue: defaultFeeLimit * 1000 / 1e8,
 		},
 		{
 			Key:          "redeemconftarget",
@@ -361,7 +361,7 @@ type ExchangeWallet struct {
 	acct             string
 	tipChange        func(error)
 	fallbackFeeRate  uint64
-	maxFeeRate       uint64
+	feeRateLimit     uint64
 	redeemConfTarget uint64
 	useSplitTx       bool
 
@@ -450,11 +450,11 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, logger dex.Logge
 
 	// If set in the user config, the max fee rate will be in units of DCR/kB.
 	// Convert to atoms/B.
-	maxFeesPerByte := toAtoms(dcrCfg.MaxFeeRate / 1000)
-	if maxFeesPerByte == 0 {
-		maxFeesPerByte = defaultMaxFee
+	feesLimitPerByte := toAtoms(dcrCfg.FeeRateLimit / 1000)
+	if feesLimitPerByte == 0 {
+		feesLimitPerByte = defaultFeeLimit
 	}
-	logger.Tracef("Max fees rate set at %d atoms/byte", maxFeesPerByte)
+	logger.Tracef("Fees rate limit set at %d atoms/byte", feesLimitPerByte)
 
 	redeemConfTarget := dcrCfg.RedeemConfTarget
 	if redeemConfTarget == 0 {
@@ -469,7 +469,7 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, logger dex.Logge
 		fundingCoins:        make(map[outPoint]*fundingCoin),
 		findRedemptionQueue: make(map[outPoint]*findRedemptionReq),
 		fallbackFeeRate:     fallbackFeesPerByte,
-		maxFeeRate:          maxFeesPerByte,
+		feeRateLimit:        feesLimitPerByte,
 		redeemConfTarget:    redeemConfTarget,
 		useSplitTx:          dcrCfg.UseSplitTx,
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -46,6 +46,8 @@ const (
 
 	// defaultFee is the default value for the fallbackfee.
 	defaultFee = 20
+	// defaultFeeRateLimit is the default value for the feeratelimit.
+	defaultFeeRateLimit = 100
 	// defaultRedeemConfTarget is the default redeem transaction confirmation
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
@@ -105,9 +107,10 @@ var (
 			DefaultValue: defaultFee * 1000 / 1e8,
 		},
 		{
-			Key:         "feelimit",
-			DisplayName: "Highest acceptable fee rate",
-			Description: "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand.  Units: atoms/kB",
+			Key:          "feeratelimit",
+			DisplayName:  "Highest acceptable fee rate",
+			Description:  "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand.  Units: atoms/byte",
+			DefaultValue: defaultFeeRateLimit,
 		},
 		{
 			Key:          "redeemconftarget",

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -101,30 +101,39 @@ var (
 			DefaultValue: filepath.Join(dcrwHomeDir, "rpc.cert"),
 		},
 		{
-			Key:          "fallbackfee",
-			DisplayName:  "Fallback fee rate",
-			Description:  "The fee rate to use for fee payment and withdrawals when estimatesmartfee is not available. Units: DCR/kB",
+			Key:         "fallbackfee",
+			DisplayName: "Fallback fee rate",
+			Description: "The fee rate to use for fee payment and withdrawals when " +
+				"estimatesmartfee is not available. Units: DCR/kB",
 			DefaultValue: defaultFee * 1000 / 1e8,
 		},
 		{
-			Key:          "feeratelimit",
-			DisplayName:  "Highest acceptable fee rate",
-			Description:  "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand.  Units: atoms/byte",
+			Key:         "feeratelimit",
+			DisplayName: "Highest acceptable fee rate",
+			Description: "This is the highest network fee rate you are willing to " +
+				"pay on swap transactions. If you set this too low, you may not be able" +
+				" to place orders with servers that allow for higher swap rates as " +
+				" network conditions demand.  Units: atoms/byte",
 			DefaultValue: defaultFeeRateLimit,
 		},
 		{
-			Key:          "redeemconftarget",
-			DisplayName:  "Redeem confirmation target",
-			Description:  "The target number of blocks for the redeem transaction to get a confirmation. Used to set the transaction's fee rate. (default: 1 block)",
+			Key:         "redeemconftarget",
+			DisplayName: "Redeem confirmation target",
+			Description: "The target number of blocks for the redeem transaction " +
+				"to get a confirmation. Used to set the transaction's fee rate." +
+				" (default: 1 block)",
 			DefaultValue: defaultRedeemConfTarget,
 		},
 		{
 			Key:         "txsplit",
 			DisplayName: "Pre-size funding inputs",
-			Description: "When placing an order, create a \"split\" transaction to fund the order without locking more of the wallet balance than " +
-				"necessary. Otherwise, excess funds may be reserved to fund the order until the first swap contract is broadcast " +
-				"during match settlement, or the order is canceled. This an extra transaction for which network mining fees are paid. " +
-				"Used only for standing-type orders, e.g. limit orders without immediate time-in-force.",
+			Description: "When placing an order, create a \"split\" transaction to " +
+				"fund the order without locking more of the wallet balance than " +
+				"necessary. Otherwise, excess funds may be reserved to fund the order " +
+				"until the first swap contract is broadcast during match settlement, or" +
+				"the order is canceled. This an extra transaction for which network " +
+				"mining fees are paid.  Used only for standing-type orders, e.g. " +
+				"limit orders without immediate time-in-force.",
 			IsBoolean: true,
 		},
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -47,7 +47,7 @@ const (
 	// defaultFee is the default value for the fallbackfee.
 	defaultFee = 20
 	// defaultFeeLimit is the default value for feelimit.
-	defaultFeeLimit = 100
+	// defaultFeeLimit = 100
 	// defaultRedeemConfTarget is the default redeem transaction confirmation
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
@@ -107,10 +107,9 @@ var (
 			DefaultValue: defaultFee * 1000 / 1e8,
 		},
 		{
-			Key:          "feelimit",
-			DisplayName:  "Highest acceptable fee rate",
-			Description:  "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand.  Units: DCR/kB",
-			DefaultValue: defaultFeeLimit * 1000 / 1e8,
+			Key:         "feelimit",
+			DisplayName: "Highest acceptable fee rate",
+			Description: "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand.  Units: DCR/kB",
 		},
 		{
 			Key:          "redeemconftarget",
@@ -361,7 +360,6 @@ type ExchangeWallet struct {
 	acct             string
 	tipChange        func(error)
 	fallbackFeeRate  uint64
-	feeRateLimit     uint64
 	redeemConfTarget uint64
 	useSplitTx       bool
 
@@ -448,14 +446,6 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, logger dex.Logge
 	}
 	logger.Tracef("Fallback fees set at %d atoms/byte", fallbackFeesPerByte)
 
-	// If set in the user config, the max fee rate will be in units of DCR/kB.
-	// Convert to atoms/B.
-	feesLimitPerByte := toAtoms(dcrCfg.FeeRateLimit / 1000)
-	if feesLimitPerByte == 0 {
-		feesLimitPerByte = defaultFeeLimit
-	}
-	logger.Tracef("Fees rate limit set at %d atoms/byte", feesLimitPerByte)
-
 	redeemConfTarget := dcrCfg.RedeemConfTarget
 	if redeemConfTarget == 0 {
 		redeemConfTarget = defaultRedeemConfTarget
@@ -469,7 +459,6 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, logger dex.Logge
 		fundingCoins:        make(map[outPoint]*fundingCoin),
 		findRedemptionQueue: make(map[outPoint]*findRedemptionReq),
 		fallbackFeeRate:     fallbackFeesPerByte,
-		feeRateLimit:        feesLimitPerByte,
 		redeemConfTarget:    redeemConfTarget,
 		useSplitTx:          dcrCfg.UseSplitTx,
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -497,8 +497,7 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, logger dex.Logge
 
 // newClient attempts to create a new websocket connection to a dcrwallet
 // instance with the given credentials and notification handlers.
-func newClient(host, user, pass, cert string) (*rpcclient.Client, error) {
-
+func newClient(host, user, pass, cert string, logger dex.Logger) (*rpcclient.Client, error) {
 	certs, err := ioutil.ReadFile(cert)
 	if err != nil {
 		return nil, fmt.Errorf("TLS certificate read error: %w", err)
@@ -821,7 +820,7 @@ func (dcr *ExchangeWallet) unspents() ([]walletjson.ListUnspentResult, error) {
 // needed value. Preference is given to selecting coins with 1 or more confs,
 // falling back to 0-conf coins where there are not enough 1+ confs coins.
 func (dcr *ExchangeWallet) fund(enough func(sum uint64, size uint32, unspent *compositeUTXO) bool) (
-	coins asset.Coins, redeemScripts []dex.Bytes, sum, size uint64, spents []*fundingCoin, err error) {
+	coins asset.Coins, redeemScripts []dex.Bytes, sum, size uint64, err error) {
 
 	// Keep a consistent view of spendable and locked coins in the wallet and
 	// the fundingCoins map to make this safe for concurrent use.
@@ -970,7 +969,7 @@ func (dcr *ExchangeWallet) tryFund(utxos []*compositeUTXO, enough func(sum uint6
 // order is canceled partially filled, and then the remainder resubmitted. We
 // would already have an output of just the right size, and that would be
 // recognized here.
-func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, inputsSize uint64, fundingCoins []*fundingCoin, nfo *dex.Asset) (asset.Coins, bool, error) {
+func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, inputsSize uint64, nfo *dex.Asset) (asset.Coins, bool, error) {
 
 	// Calculate the extra fees associated with the additional inputs, outputs,
 	// and transaction overhead, and compare to the excess that would be locked.

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -52,7 +52,7 @@ const (
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
 	defaultRedeemConfTarget = 1
-	// Smallest unit is 1 atom = 1e8 DCR.
+	// Smallest unit is 1 atom = 1e-8 DCR.
 	smallestUnit = 1e8
 
 	// splitTxBaggage is the total number of additional bytes associated with

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -113,7 +113,7 @@ var (
 			Description: "This is the highest network fee rate you are willing to " +
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
-				"wallet.  Units: atoms/byte",
+				"wallet.  Units: DCR/kB",
 			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
 		},
 		{

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -46,8 +46,6 @@ const (
 
 	// defaultFee is the default value for the fallbackfee.
 	defaultFee = 20
-	// defaultFeeLimit is the default value for feelimit.
-	// defaultFeeLimit = 100
 	// defaultRedeemConfTarget is the default redeem transaction confirmation
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
@@ -109,7 +107,7 @@ var (
 		{
 			Key:         "feelimit",
 			DisplayName: "Highest acceptable fee rate",
-			Description: "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand.  Units: DCR/kB",
+			Description: "This is the highest network fee rate you are willing to pay on swap transactions. If you set this too low, you may not be able to place orders with servers that allow for higher swap rates as network conditions demand.  Units: atoms/kB",
 		},
 		{
 			Key:          "redeemconftarget",

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -130,7 +130,7 @@ var (
 			Description: "When placing an order, create a \"split\" transaction to " +
 				"fund the order without locking more of the wallet balance than " +
 				"necessary. Otherwise, excess funds may be reserved to fund the order " +
-				"until the first swap contract is broadcast during match settlement, or" +
+				"until the first swap contract is broadcast during match settlement, or " +
 				"the order is canceled. This an extra transaction for which network " +
 				"mining fees are paid.  Used only for standing-type orders, e.g. " +
 				"limit orders without immediate time-in-force.",

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -21,7 +21,7 @@ const (
 	defaultFee = 10
 	// defaultFeeRateLimit is the default value for the feeratelimit.
 	defaultFeeRateLimit = 100
-	// smallest unit is 1/1e8 LTC
+	// Smallest unit is 1/1e-8 LTC
 	smallestUnit      = 1e8
 	minNetworkVersion = 180100
 )

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -15,11 +15,13 @@ import (
 )
 
 const (
+	// BipID is the BIP-0044 asset ID.
 	BipID = 2
-	// The default fee is passed to the user as part of the asset.WalletInfo
-	// structure.
-	defaultFee        = 10
-	minNetworkVersion = 180100
+	// defaultFee is the default value for the fallbackfee.
+	defaultFee = 10
+	// defaultFeeRateLimit is the default value for the feeratelimit.
+	defaultFeeRateLimit = 100
+	minNetworkVersion   = 180100
 )
 
 var (
@@ -57,6 +59,15 @@ var (
 			DisplayName:  "Fallback fee rate",
 			Description:  "Litecoin's 'fallbackfee' rate. Units: LTC/kB",
 			DefaultValue: defaultFee * 1000 / 1e8,
+		},
+		{
+			Key:         "feeratelimit",
+			DisplayName: "Highest acceptable fee rate",
+			Description: "This is the highest network fee rate you are willing to " +
+				"pay on swap transactions. If feeratelimit is lower than a market's " +
+				"maxfeerate, you will not be able to trade on that market with this " +
+				"wallet.  Units: LTC/kB",
+			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
 		},
 		{
 			Key:          "redeemconftarget",

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -21,7 +21,9 @@ const (
 	defaultFee = 10
 	// defaultFeeRateLimit is the default value for the feeratelimit.
 	defaultFeeRateLimit = 100
-	minNetworkVersion   = 180100
+	// smallest unit is 1/1e8 LTC
+	smallestUnit      = 1e8
+	minNetworkVersion = 180100
 )
 
 var (
@@ -58,7 +60,7 @@ var (
 			Key:          "fallbackfee",
 			DisplayName:  "Fallback fee rate",
 			Description:  "Litecoin's 'fallbackfee' rate. Units: LTC/kB",
-			DefaultValue: defaultFee * 1000 / 1e8,
+			DefaultValue: defaultFee * 1000 / smallestUnit,
 		},
 		{
 			Key:         "feeratelimit",
@@ -67,7 +69,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: LTC/kB",
-			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
+			DefaultValue: defaultFeeRateLimit * 1000 / smallestUnit,
 		},
 		{
 			Key:          "redeemconftarget",
@@ -143,17 +145,18 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		Simnet:  "19443",
 	}
 	cloneCFG := &btc.BTCCloneCFG{
-		WalletCFG:          cfg,
-		MinNetworkVersion:  minNetworkVersion,
-		WalletInfo:         WalletInfo,
-		Symbol:             "ltc",
-		Logger:             logger,
-		Network:            network,
-		ChainParams:        params,
-		Ports:              ports,
-		DefaultFallbackFee: defaultFee,
-		LegacyBalance:      true,
-		Segwit:             false,
+		WalletCFG:           cfg,
+		MinNetworkVersion:   minNetworkVersion,
+		WalletInfo:          WalletInfo,
+		Symbol:              "ltc",
+		Logger:              logger,
+		Network:             network,
+		ChainParams:         params,
+		Ports:               ports,
+		DefaultFallbackFee:  defaultFee,
+		DefaultFeeRateLimit: defaultFeeRateLimit,
+		LegacyBalance:       true,
+		Segwit:              false,
 	}
 
 	return btc.BTCCloneWallet(cloneCFG)

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -21,9 +21,7 @@ const (
 	defaultFee = 10
 	// defaultFeeRateLimit is the default value for the feeratelimit.
 	defaultFeeRateLimit = 100
-	// Smallest unit is 1/1e-8 LTC
-	smallestUnit      = 1e8
-	minNetworkVersion = 180100
+	minNetworkVersion   = 180100
 )
 
 var (
@@ -60,7 +58,7 @@ var (
 			Key:          "fallbackfee",
 			DisplayName:  "Fallback fee rate",
 			Description:  "Litecoin's 'fallbackfee' rate. Units: LTC/kB",
-			DefaultValue: defaultFee * 1000 / smallestUnit,
+			DefaultValue: defaultFee * 1000 / 1e8,
 		},
 		{
 			Key:         "feeratelimit",
@@ -69,7 +67,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: LTC/kB",
-			DefaultValue: defaultFeeRateLimit * 1000 / smallestUnit,
+			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
 		},
 		{
 			Key:          "redeemconftarget",

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2673,8 +2673,6 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	fromWallet, toWallet, fromAsset, toAsset := wallets.fromWallet,
 		wallets.toWallet, wallets.fromAsset, wallets.toAsset
 
-	c.log.Tracef("fdfdfdfdfd %v %v %v %v \n\n\n\n\n", fromWallet.feeRateLimit, fromAsset.MaxFeeRate,
-		toWallet.feeRateLimit, toAsset.MaxFeeRate)
 	// Check wallets fee rate limit against server's max fee rate
 	if fromWallet.feeRateLimit < fromAsset.MaxFeeRate {
 		return nil, 0, newError(orderParamsErr,

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1449,19 +1449,6 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating wallet: %w", err)
 	}
-	// Parse fee rate limit
-	// NOTE We parse fee rate limit 'feeratelimit' settings and store it on xcWallet
-	// unlike other settings which are being configured and set on each asset's
-	// ExchangeWallet instance (see above asset.Setup call) as it required on
-	// order placement time
-	feeLimit := walletCfg.Settings["feeratelimit"]
-	if feeLimit != "" {
-		uintLimit, err := strconv.ParseUint(feeLimit, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		wallet.feeRateLimit = uintLimit
-	}
 
 	// Construct the unconnected xcWallet.
 	contractLockedAmt, orderLockedAmt := c.lockedAmounts(assetID)
@@ -1478,7 +1465,6 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 		address: dbWallet.Address,
 		dbID:    dbWallet.ID(),
 	}, nil
-	wallet.Wallet = w
 }
 
 // WalletState returns the *WalletState for the asset ID.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -49,6 +49,9 @@ const (
 	// tickCheckDivisions is how many times to tick trades per broadcast timeout
 	// interval. e.g. 12 min btimeout / 8 divisions = 90 sec between checks.
 	tickCheckDivisions = 8
+	// defaultFeeRateLimit is used to as default when no fee rate limit value
+	// specified by user. unit/kB
+	defaultFeeRateLimit = 10000
 )
 
 var (
@@ -1461,6 +1464,9 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 			return nil, err
 		}
 		wallet.feeRateLimit = uint32(floatLimit)
+	} else {
+		// If user didn't provide limit use default limit
+		wallet.feeRateLimit = defaultFeeRateLimit
 	}
 
 	// Construct the unconnected xcWallet.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1449,6 +1449,15 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating wallet: %w", err)
 	}
+	// Parse fee rate limit
+	feeLimit := walletCfg.Settings["feelimit"]
+	if feeLimit != "" {
+		floatLimit, err := strconv.ParseFloat(feeLimit, 32)
+		if err != nil {
+			return nil, err
+		}
+		wallet.feeRateLimit = float32(floatLimit)
+	}
 
 	// Construct the unconnected xcWallet.
 	contractLockedAmt, orderLockedAmt := c.lockedAmounts(assetID)
@@ -1465,6 +1474,7 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 		address: dbWallet.Address,
 		dbID:    dbWallet.ID(),
 	}, nil
+	wallet.Wallet = w
 }
 
 // WalletState returns the *WalletState for the asset ID.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2670,24 +2670,7 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	if err != nil {
 		return nil, 0, err
 	}
-	fromWallet, toWallet, fromAsset, toAsset := wallets.fromWallet,
-		wallets.toWallet, wallets.fromAsset, wallets.toAsset
-
-	// Check wallets fee rate limit against server's max fee rate
-	if fromWallet.feeRateLimit < fromAsset.MaxFeeRate {
-		return nil, 0, newError(orderParamsErr,
-			"%v: server's max fee rate %v higher than configued fee rate limit %v",
-			fromAsset.Symbol,
-			fromAsset.MaxFeeRate,
-			fromWallet.feeRateLimit)
-	}
-	if toWallet.feeRateLimit < toAsset.MaxFeeRate {
-		return nil, 0, newError(orderParamsErr,
-			"%v: server's max fee rate %v higher than configued fee rate limit %v",
-			toAsset.Symbol,
-			toAsset.MaxFeeRate,
-			toWallet.feeRateLimit)
-	}
+	fromWallet, toWallet := wallets.fromWallet, wallets.toWallet
 
 	prepareWallet := func(w *xcWallet) error {
 		// NOTE: If the wallet is already internally unlocked (the decrypted

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1450,6 +1450,10 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 		return nil, fmt.Errorf("error creating wallet: %w", err)
 	}
 	// Parse fee rate limit
+	// NOTE We parse fee rate limit 'feelimit' settings and store it on xcWallet
+	// unlike other settings which are being configured and set on each asset's
+	// ExchangeWallet instance (see above asset.Setup call) as it required on
+	// order placement time
 	feeLimit := walletCfg.Settings["feelimit"]
 	if feeLimit != "" {
 		floatLimit, err := strconv.ParseFloat(feeLimit, 32)

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -28,7 +28,7 @@ type xcWallet struct {
 	hookedUp     bool
 	synced       bool
 	syncProgress float32
-	feeRateLimit float32
+	feeRateLimit uint32
 }
 
 // Unlock unlocks the wallet backend and caches the decrypted wallet password so

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -28,7 +28,6 @@ type xcWallet struct {
 	hookedUp     bool
 	synced       bool
 	syncProgress float32
-	feeRateLimit uint64
 }
 
 // Unlock unlocks the wallet backend and caches the decrypted wallet password so

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -28,6 +28,7 @@ type xcWallet struct {
 	hookedUp     bool
 	synced       bool
 	syncProgress float32
+	feeRateLimit float32
 }
 
 // Unlock unlocks the wallet backend and caches the decrypted wallet password so

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -28,7 +28,7 @@ type xcWallet struct {
 	hookedUp     bool
 	synced       bool
 	syncProgress float32
-	feeRateLimit uint32
+	feeRateLimit uint64
 }
 
 // Unlock unlocks the wallet backend and caches the decrypted wallet password so

--- a/dex/networks/btc/config.go
+++ b/dex/networks/btc/config.go
@@ -45,7 +45,7 @@ type Config struct {
 
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
-	MaxFeeRate       float64 `ini:"maxfee"`
+	FeeRateLimit     float64 `ini:"feelimit"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 }
 

--- a/dex/networks/btc/config.go
+++ b/dex/networks/btc/config.go
@@ -45,7 +45,7 @@ type Config struct {
 
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
-	FeeRateLimit     uint64  `ini:"feeratelimit"`
+	FeeRateLimit     float64 `ini:"feeratelimit"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 }
 

--- a/dex/networks/btc/config.go
+++ b/dex/networks/btc/config.go
@@ -45,6 +45,7 @@ type Config struct {
 
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
+	MaxFeeRate       float64 `ini:"maxfee"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 }
 

--- a/dex/networks/btc/config.go
+++ b/dex/networks/btc/config.go
@@ -45,6 +45,7 @@ type Config struct {
 
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
+	FeeRateLimit     uint64  `ini:"feeratelimit"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 }
 

--- a/dex/networks/btc/config.go
+++ b/dex/networks/btc/config.go
@@ -45,7 +45,7 @@ type Config struct {
 
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
-	FeeRateLimit     float64 `ini:"feelimit"`
+	FeeRateLimit     uint64  `ini:"feelimit"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 }
 

--- a/dex/networks/btc/config.go
+++ b/dex/networks/btc/config.go
@@ -45,7 +45,6 @@ type Config struct {
 
 	UseSplitTx       bool    `ini:"txsplit"`
 	FallbackFeeRate  float64 `ini:"fallbackfee"`
-	FeeRateLimit     uint64  `ini:"feelimit"`
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 }
 


### PR DESCRIPTION
This diff adds new fee rate threshold wallet setting which will be checked against server `maxFeeRate` when placing and order.
if `maxFeeRate` is greater than the threshold, client throws an error.

Part of #858 