### PR TITLE
client/asset/dcr: totalToSync divide by zero check

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1980,7 +1980,10 @@ func (dcr *ExchangeWallet) SyncStatus() (bool, float32, error) {
 	if chainInfo.InitialBlockDownload || toGo > 1 {
 		ogTip := atomic.LoadInt64(&dcr.tipAtConnect)
 		totalToSync := chainInfo.Headers - ogTip
-		progress := 1 - (float32(toGo) / float32(totalToSync))
+		var progress float32 = 1
+		if totalToSync > 0 {
+			progress = 1 - (float32(toGo) / float32(totalToSync))
+		}
 		return false, progress, nil
 	}
 	return true, 1, nil


### PR DESCRIPTION
This mirrors the divide-by-zero check used with btc when computing "sync status"
https://github.com/decred/dcrdex/commit/726d8ee566a1fa16c0fd2704547f941ba3b3cb81#diff-1b07e494f4bdd99b2a617ac110fbadc081e5b6ae1abf23f64032bbee5ebebef1R579-R582

This prevents a JSON encoding error with a NaN value (`WEB: JSON encode error: json: unsupported value: NaN`).