### PR TITLE
fix logs showing ipkey instead of address string

### DIFF
--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1210,7 +1210,7 @@ func (client *tClient) startNotificationReader(ctx context.Context) *notificatio
 				n.Lock()
 				n.notes = append(n.notes, note)
 				n.Unlock()
-				client.log(note.String())
+				client.log("%s", note)
 
 			case <-ctx.Done():
 				return

--- a/client/websocket/websocket_test.go
+++ b/client/websocket/websocket_test.go
@@ -117,7 +117,8 @@ func newLink() *tLink {
 		respReady: make(chan []byte, 1),
 		close:     make(chan struct{}, 1),
 	}
-	cl := newWSClient(dex.IPKey{}, "addr", conn, func(*msgjson.Message) *msgjson.Error { return nil }, dex.StdOutLogger("ws_TEST", dex.LevelTrace))
+	ipk := dex.IPKey{16, 16, 120, 120 /* ipv6 1010:7878:: */}
+	cl := newWSClient(ipk.String(), conn, func(*msgjson.Message) *msgjson.Error { return nil }, dex.StdOutLogger("ws_TEST", dex.LevelTrace))
 	return &tLink{
 		cl:   cl,
 		conn: conn,
@@ -263,7 +264,8 @@ func TestClientMap(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		srv.connect(ctx, conn, "someaddr", dex.IPKey{})
+		ipk := dex.IPKey{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255 /* ipv4 */, 127, 0, 0, 1}
+		srv.connect(ctx, conn, ipk.String())
 		wg.Done()
 	}()
 

--- a/dex/ip.go
+++ b/dex/ip.go
@@ -7,22 +7,38 @@ import (
 	"net"
 )
 
-// IPKey is a IP address byte array. For an IPV6 address, the IPKey drops the
-// interface identifier, which is the second half of the address.
-type IPKey [net.IPv6len / 2]byte
+// IPKey is a IP address byte array.
+type IPKey [net.IPv6len]byte
 
-// NewIPKey parses an IP address string into an IPKey.
+// NewIPKey parses an IP address string into an IPKey. For an IPV6 address, this
+// drops the interface identifier, which is the second half of the address
 func NewIPKey(addr string) IPKey {
 	host, _, err := net.SplitHostPort(addr)
 	if err == nil && host != "" {
 		addr = host
 	}
-	netIP := net.ParseIP(addr)
-	ip := netIP.To4()
+
+	ip := net.ParseIP(addr)
 	if ip == nil {
-		ip = netIP.To16()
+		return IPKey{}
+	}
+	// IPv4 is encoded in a net.IP of length IPv6len as
+	// 00:00:00:00:00:00:00:00:00:00:ff:ff:xx:xx:xx:xx
+	// Thus, must copy all 16 bytes for IPv4.
+	N := net.IPv6len
+	if ip.To4() == nil {
+		// Drop the last 64 bits (interface) of IPv6 addresses.
+		N = net.IPv6len / 2 // i.e. ip = ip.Mask(net.CIDRMask(64, 128))
 	}
 	var ipKey IPKey
-	copy(ipKey[:], ip)
+	copy(ipKey[:], ip[:N])
 	return ipKey
+}
+
+// String returns a readable IP address representation of the IPKey. This is
+// done by copying the bytes of the IPKey array, and invoking the
+// net.(IP).String method. As such it is inefficient and should not be invoked
+// repeatedly or in hot paths.
+func (ipk IPKey) String() string {
+	return net.IP(ipk[:]).String()
 }

--- a/dex/ip_test.go
+++ b/dex/ip_test.go
@@ -18,76 +18,90 @@ func TestIPKey(t *testing.T) {
 	tests := []struct {
 		name, addr1, addr2 string
 		wantEqual          bool
+		wantString1        string
 	}{
 		{
-			name:      "ipv4 unequal",
-			addr1:     "127.0.0.1",
-			addr2:     "127.0.0.2",
-			wantEqual: false,
+			name:        "bad",
+			addr1:       "",
+			addr2:       "xxx",
+			wantEqual:   true,
+			wantString1: "::",
 		},
 		{
-			name:      "ipv4 equal",
-			addr1:     "127.0.0.1",
-			addr2:     "127.0.0.1",
-			wantEqual: true,
+			name:        "ipv4 unequal",
+			addr1:       "127.0.0.1",
+			addr2:       "127.0.0.2",
+			wantEqual:   false,
+			wantString1: "127.0.0.1",
 		},
 		{
-			name:      "ipv4 port unequal",
-			addr1:     "127.0.0.1:1234",
-			addr2:     "127.0.0.2:1234",
-			wantEqual: false,
+			name:        "ipv4 equal",
+			addr1:       "127.0.0.1",
+			addr2:       "127.0.0.1",
+			wantEqual:   true,
+			wantString1: "127.0.0.1",
 		},
 		{
-			name:      "ipv4 port equal",
-			addr1:     "127.0.0.1:1234",
-			addr2:     "127.0.0.1:1234",
-			wantEqual: true,
+			name:        "ipv4 port unequal",
+			addr1:       "127.0.0.1:1234",
+			addr2:       "127.0.0.2:1234",
+			wantEqual:   false,
+			wantString1: "127.0.0.1",
 		},
 		{
-			name:      "ipv4 port equal noport",
-			addr1:     "127.0.0.1",
-			addr2:     "127.0.0.1:1234",
-			wantEqual: true,
+			name:        "ipv4 port equal",
+			addr1:       "127.0.0.1:1234",
+			addr2:       "127.0.0.1:1234",
+			wantEqual:   true,
+			wantString1: "127.0.0.1",
 		},
 		{
-			name:      "ipv6 port unequal",
-			addr1:     "[a:b:c:d::]:1234",
-			addr2:     "[a:b:c:e::]:1234",
-			wantEqual: false,
+			name:        "ipv4 port equal noport",
+			addr1:       "127.0.0.1",
+			addr2:       "127.0.0.1:1234",
+			wantEqual:   true,
+			wantString1: "127.0.0.1",
 		},
 		{
-			name:      "ipv6 port equal",
-			addr1:     "[a:b:c:d::]:1234",
-			addr2:     "[a:b:c:d::]:1234",
-			wantEqual: true,
+			name:        "ipv6 port unequal",
+			addr1:       "[a:b:c:d::]:1234",
+			addr2:       "[a:b:c:e::]:1234",
+			wantEqual:   false,
+			wantString1: "a:b:c:d::",
 		},
 		{
-			name:      "ipv6 port equal noport",
-			addr1:     "a:b:c:d::",
-			addr2:     "[a:b:c:d::]:1234",
-			wantEqual: true,
+			name:        "ipv6 port equal",
+			addr1:       "[a:b:c:d::]:1234",
+			addr2:       "[a:b:c:d::]:1234",
+			wantEqual:   true,
+			wantString1: "a:b:c:d::",
 		},
 		{
-			name:      "ipv6 mask equal",
-			addr1:     "[a:b:c:d:e:f:a:b]:1234",
-			addr2:     "[a:b:c:d:f:d:c:f]:1234",
-			wantEqual: true,
+			name:        "ipv6 port equal noport",
+			addr1:       "a:b:c:d::",
+			addr2:       "[a:b:c:d::]:1234",
+			wantEqual:   true,
+			wantString1: "a:b:c:d::",
+		},
+		{
+			name:        "ipv6 mask equal",
+			addr1:       "[a:b:c:d:e:f:a:b]:1234",
+			addr2:       "[a:b:c:d:f:d:c:f]:1234",
+			wantEqual:   true,
+			wantString1: "a:b:c:d::",
 		},
 	}
-
-	zeroKey := IPKey{}
 
 	for _, tt := range tests {
 		ipKey1 := NewIPKey(tt.addr1)
 		ipKey2 := NewIPKey(tt.addr2)
 
-		if ipKey1 == zeroKey || ipKey2 == zeroKey {
-			t.Fatalf("%s: zeroKey found. ipKey1 = %x, ipKey2 = %x", tt.name, ipKey1[:], ipKey2[:])
-		}
-
 		if (ipKey1 == ipKey2) != tt.wantEqual {
 			t.Fatalf("%s: wantEqual = %t, addr1 = %s, addr2 = %s, ipKey1 = %x, ipKey2 = %x",
 				tt.name, tt.wantEqual, tt.addr1, tt.addr2, ipKey1[:], ipKey2[:])
+		}
+		if tt.wantString1 != ipKey1.String() {
+			t.Errorf("expected ipKey1 string %s, got %s", tt.wantString1, ipKey1.String())
 		}
 	}
 }

--- a/dex/ip_test.go
+++ b/dex/ip_test.go
@@ -63,6 +63,13 @@ func TestIPKey(t *testing.T) {
 			wantString1: "127.0.0.1",
 		},
 		{
+			name:        "ipv6 loopback with and without port",
+			addr1:       "[::1]", // brackets to strip
+			addr2:       "[::1]:13245",
+			wantEqual:   true,
+			wantString1: "::1", // mask exception for ipv6 loopback
+		},
+		{
 			name:        "ipv6 port unequal",
 			addr1:       "[a:b:c:d::]:1234",
 			addr2:       "[a:b:c:e::]:1234",
@@ -79,6 +86,13 @@ func TestIPKey(t *testing.T) {
 		{
 			name:        "ipv6 port equal noport",
 			addr1:       "a:b:c:d::",
+			addr2:       "[a:b:c:d::]:1234",
+			wantEqual:   true,
+			wantString1: "a:b:c:d::",
+		},
+		{
+			name:        "ipv6 port equal noport with brackets",
+			addr1:       "[a:b:c:d::]", // brackets to strip
 			addr2:       "[a:b:c:d::]:1234",
 			wantEqual:   true,
 			wantString1: "a:b:c:d::",

--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -145,7 +145,7 @@ func (c *WSLink) SendError(id uint64, rpcErr *msgjson.Error) {
 	}
 	err = c.Send(msg)
 	if err != nil {
-		c.log.Debugf("SendError: failed to send message to peer %s: %v", c.ip, err)
+		c.log.Debugf("SendError: failed to send message to peer %s: %v", c.addr, err)
 	}
 }
 
@@ -166,10 +166,10 @@ func (c *WSLink) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	c.stopped = make(chan struct{}) // control signal to block send
 	err := c.conn.SetReadDeadline(time.Now().Add(c.pingPeriod * 2))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to set initial read deadline for %v: %w", c.ip, err)
+		return nil, fmt.Errorf("Failed to set initial read deadline for %v: %w", c.addr, err)
 	}
 
-	c.log.Tracef("Starting websocket messaging with peer %s", c.ip)
+	c.log.Tracef("Starting websocket messaging with peer %s", c.addr)
 	// Start processing input and output.
 	c.wg.Add(3)
 	go c.inHandler(linkCtx)
@@ -211,7 +211,7 @@ func (c *WSLink) handleMessage(msg *msgjson.Message) {
 	defer func() {
 		if pv := recover(); pv != nil {
 			c.log.Criticalf("Uh-oh! Panic while handling message from %v.\n\n"+
-				"Message:\n\n%#v\n\nPanic:\n\n%v\n\nStack:\n\n%v\n\n", c.ip, msg, pv, string(debug.Stack()))
+				"Message:\n\n%#v\n\nPanic:\n\n%v\n\nStack:\n\n%v\n\n", c.addr, msg, pv, string(debug.Stack()))
 			if msg.Type == msgjson.Request {
 				c.SendError(msg.ID, msgjson.NewError(msgjson.RPCInternalError, "internal error"))
 			}
@@ -252,7 +252,7 @@ out:
 				break out
 			}
 
-			c.log.Errorf("Websocket receive error from peer %s: %v (%T)", c.ip, err, err)
+			c.log.Errorf("Websocket receive error from peer %s: %v (%T)", c.addr, err, err)
 			break out
 		}
 		// Attempt to unmarshal the request. Only requests that successfully decode
@@ -354,7 +354,7 @@ func (c *WSLink) outHandler(ctx context.Context) {
 		// need to drain it, just the outQueue so SendNow never hangs.
 
 		c.log.Tracef("Sent %d and dropped %d messages to %v before shutdown.",
-			writeCount, lostCount, c.ip)
+			writeCount, lostCount, c.addr)
 	}()
 
 	// Top of defer stack: before clean-up, wait for writer goroutine
@@ -402,7 +402,7 @@ func (c *WSLink) outHandler(ctx context.Context) {
 			outQueue = append(outQueue, sd)
 			if newCap := cap(outQueue); newCap > initCap {
 				c.log.Infof("Outgoing message queue capacity increased from %d to %d for %v.",
-					initCap, newCap, c.ip)
+					initCap, newCap, c.addr)
 				// The capacity 7168 is a heuristic for when the slice shift on
 				// the pop front operation starts to become a performance issue.
 				// It is also a reasonable queue size limitation to prevent
@@ -411,7 +411,7 @@ func (c *WSLink) outHandler(ctx context.Context) {
 				// is spamming excessively.
 				if newCap >= 7168 {
 					c.log.Warnf("Stopping client %v with outgoing message queue of length %d, capacity %d",
-						c.ip, len(outQueue), newCap)
+						c.addr, len(outQueue), newCap)
 					c.stop()
 				}
 			}

--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -57,8 +57,6 @@ type Connection interface {
 type WSLink struct {
 	// log is the WSLink's logger
 	log dex.Logger
-	// ip is the peer's IP address key.
-	ip dex.IPKey
 	// addr is a string representation of the peer's IP address
 	addr string
 	// conn is the gorilla websocket.Conn, or a stub for testing.
@@ -88,9 +86,9 @@ type sendData struct {
 }
 
 // NewWSLink is a constructor for a new WSLink.
-func NewWSLink(ip dex.IPKey, addr string, conn Connection, pingPeriod time.Duration, handler func(*msgjson.Message) *msgjson.Error, logger dex.Logger) *WSLink {
+func NewWSLink(addr string, conn Connection, pingPeriod time.Duration, handler func(*msgjson.Message) *msgjson.Error, logger dex.Logger) *WSLink {
 	return &WSLink{
-		ip:         ip,
+		addr:       addr,
 		log:        logger,
 		conn:       conn,
 		outChan:    make(chan *sendData, outBufferSize),
@@ -454,11 +452,6 @@ out:
 // Off will return true if the link has disconnected.
 func (c *WSLink) Off() bool {
 	return atomic.LoadUint32(&c.on) == 0
-}
-
-// IP is the peer address passed to the constructor.
-func (c *WSLink) IP() dex.IPKey {
-	return c.ip
 }
 
 // Addr returns the string-encoded IP address.

--- a/dex/ws/wslink_test.go
+++ b/dex/ws/wslink_test.go
@@ -115,7 +115,8 @@ func TestWSLink_handleMessageRecover(t *testing.T) {
 		inMsg: make(chan []byte, 1),
 		inErr: make(chan error, 1),
 	}
-	wsLink := NewWSLink(dex.IPKey{}, "addr", conn, time.Second, inMsgHandler, tLogger)
+	ipk := dex.IPKey{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255 /* ipv4 */, 127, 0, 0, 1}
+	wsLink := NewWSLink(ipk.String(), conn, time.Second, inMsgHandler, tLogger)
 
 	msg := new(msgjson.Message)
 	wsLink.handleMessage(msg)
@@ -143,7 +144,8 @@ func TestWSLink_send(t *testing.T) {
 		inMsg: make(chan []byte, 1),
 		inErr: make(chan error, 1),
 	}
-	wsLink := NewWSLink(dex.IPKey{}, "addr", conn, time.Second, inMsgHandler, tLogger)
+	ipk := dex.IPKey{16, 16, 120, 120 /* ipv6 1010:7878:: */}
+	wsLink := NewWSLink(ipk.String(), conn, time.Second, inMsgHandler, tLogger)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -371,7 +371,7 @@ func TestClientRequests(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			server.websocketHandler(testCtx, conn, stubAddr, "addr")
+			server.websocketHandler(testCtx, conn, stubAddr)
 		}()
 
 		if !giveItASecond(func() bool {
@@ -562,7 +562,7 @@ func TestClientResponses(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			server.websocketHandler(testCtx, conn, stubAddr, "addr")
+			server.websocketHandler(testCtx, conn, stubAddr)
 		}()
 		getClient()
 	}


### PR DESCRIPTION
This fixes some log statements in dex/ws that were showing the illegible ip key.

NOTE: I'm still considering changing `dex.IPKey` to a full `net.IPv6len` array and using a CIDR mask in `NewIPKey` instead of a partial copy so that the `IPKey` can be converted to an IP string, right now it is an irreversible conversion from a `net.IP` to a `dex.IPKey` (can no longer distinguish ipv4 from ipv6).  Making this change would allow passing only the `IPKey` (or a `net.IP`) to the `WSLink` constructor, and the address string could be extracted on construction instead of passed as another input.