### PR TITLE
prevent wallet Lock from blocking shutdown

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -138,6 +138,7 @@ type rpcClient interface {
 	GetRawMempool() ([]*chainhash.Hash, error)
 	GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjson.TxRawResult, error)
 	RawRequest(method string, params []json.RawMessage) (json.RawMessage, error)
+	Disconnected() bool
 }
 
 // BTCCloneCFG holds clone specific parameters.
@@ -345,7 +346,6 @@ type ExchangeWallet struct {
 	// 64-bit atomic variables first. See
 	// https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	tipAtConnect      int64
-	client            *rpcclient.Client
 	node              rpcClient
 	wallet            *walletClient
 	walletInfo        *asset.WalletInfo
@@ -451,10 +451,7 @@ func BTCCloneWallet(cfg *BTCCloneCFG) (*ExchangeWallet, error) {
 		return nil, fmt.Errorf("error creating BTC RPC client: %w", err)
 	}
 
-	btc := newWallet(cfg, btcCfg, client)
-	btc.client = client
-
-	return btc, nil
+	return newWallet(cfg, btcCfg, client), nil
 }
 
 // newWallet creates the ExchangeWallet and starts the block monitor.
@@ -1083,6 +1080,9 @@ func (btc *ExchangeWallet) Unlock(pw string) error {
 
 // Lock locks the ExchangeWallet and the underlying bitcoind wallet.
 func (btc *ExchangeWallet) Lock() error {
+	if btc.node.Disconnected() {
+		return asset.ErrConnectionDown
+	}
 	return btc.wallet.Lock()
 }
 

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -227,6 +227,8 @@ func (c *tRPCClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjson.
 	return c.mpVerboseTxs[txHash.String()], c.rawVerboseErr
 }
 
+func (c *tRPCClient) Disconnected() bool { return false }
+
 func (c *tRPCClient) RawRequest(method string, params []json.RawMessage) (json.RawMessage, error) {
 	switch method {
 	case methodSignTx:

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -429,7 +429,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 	logger.Infof("Setting up new DCR wallet at %s with TLS certificate %q.",
 		walletCfg.RPCListen, walletCfg.RPCCert)
 	dcr.client, err = newClient(walletCfg.RPCListen, walletCfg.RPCUser,
-		walletCfg.RPCPass, walletCfg.RPCCert)
+		walletCfg.RPCPass, walletCfg.RPCCert, logger)
 	if err != nil {
 		return nil, fmt.Errorf("DCR ExchangeWallet.Run error: %w", err)
 	}
@@ -470,7 +470,7 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, logger dex.Logge
 
 // newClient attempts to create a new websocket connection to a dcrwallet
 // instance with the given credentials and notification handlers.
-func newClient(host, user, pass, cert string) (*rpcclient.Client, error) {
+func newClient(host, user, pass, cert string, logger dex.Logger) (*rpcclient.Client, error) {
 
 	certs, err := ioutil.ReadFile(cert)
 	if err != nil {
@@ -486,7 +486,13 @@ func newClient(host, user, pass, cert string) (*rpcclient.Client, error) {
 		DisableConnectOnNew: true,
 	}
 
-	cl, err := rpcclient.New(config, nil)
+	ntfnHandlers := &rpcclient.NotificationHandlers{
+		// Setup an on-connect handler for logging (re)connects.
+		OnClientConnected: func() {
+			logger.Infof("Connected to Decred wallet at %s", host)
+		},
+	}
+	cl, err := rpcclient.New(config, ntfnHandlers)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to start dcrwallet RPC client: %w", err)
 	}
@@ -1860,7 +1866,16 @@ func (dcr *ExchangeWallet) Unlock(pw string) error {
 
 // Lock locks the exchange wallet.
 func (dcr *ExchangeWallet) Lock() error {
-	return translateRPCCancelErr(dcr.node.WalletLock(dcr.ctx))
+	if dcr.client.Disconnected() {
+		return asset.ErrConnectionDown
+	}
+	// Since hung calls to Lock() may block shutdown of the consumer and thus
+	// cancellation of the ExchangeWallet subsystem's Context, dcr.ctx, give
+	// this a timeout in case the connection goes down or the RPC hangs for
+	// other reasons.
+	ctx, cancel := context.WithTimeout(dcr.ctx, 5*time.Second)
+	defer cancel()
+	return translateRPCCancelErr(dcr.node.WalletLock(ctx))
 }
 
 // Locked will be true if the wallet is currently locked.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -17,6 +17,7 @@ import (
 const (
 	CoinNotFoundError = dex.ErrorKind("coin not found")
 	ErrRequestTimeout = dex.ErrorKind("request timeout")
+	ErrConnectionDown = dex.ErrorKind("wallet not connected")
 )
 
 // WalletInfo is auxiliary information about an ExchangeWallet.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1076,8 +1076,8 @@ func (c *Core) connectWallet(w *xcWallet) error {
 				case <-ticker.C:
 					synced, progress, err := w.SyncStatus()
 					if err != nil {
-						c.log.Errorf("error monitoring sync status for %s", unbip(w.AssetID))
-						return
+						c.log.Errorf("Unable to get wallet/node sync status for %s: %v", unbip(w.AssetID), err)
+						continue // keep trying since the loop will break if connection really drops
 					}
 					w.mtx.Lock()
 					w.synced = synced

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1451,7 +1451,7 @@ func TestRegister(t *testing.T) {
 	// wallet not found
 	delete(tCore.wallets, tDCR.ID)
 	run()
-	if !errorHasCode(err, walletErr) {
+	if !errorHasCode(err, missingWalletErr) {
 		t.Fatalf("wrong missing wallet error: %v", err)
 	}
 	tCore.wallets[tDCR.ID] = wallet
@@ -4757,7 +4757,7 @@ func TestReconfigureWallet(t *testing.T) {
 	// Connect error
 	tXyzWallet.connectErr = tErr
 	err = tCore.ReconfigureWallet(tPW, assetID, newSettings)
-	if !errorHasCode(err, connectErr) {
+	if !errorHasCode(err, connectWalletErr) {
 		t.Fatalf("wrong error when expecting connection error: %v", err)
 	}
 	tXyzWallet.connectErr = nil

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -26,7 +26,7 @@ const (
 	orderParamsErr
 	dbErr
 	authErr
-	connectErr
+	connectWalletErr
 	missingWalletErr
 	encryptionErr
 	marketErr


### PR DESCRIPTION
The first commit, https://github.com/decred/dcrdex/pull/893/commits/3910136e938918698764bf219bd1d8b6c07b6e04, prevents hanging on shutdown with a disconnected wallet.  Shutdown would hang because the subsystem context was not canceled by `PromptShutdown` until *after* wallets were locked. This modifies both dcr and btc `(*ExchangeWallet).Lock` methods to check node disconnected status, and modifies the dcr method with a 5 second timeout since it has context-enabled RPC methods unlike btc.  This commit also adds a basic dcr `OnClientConnected` notification handler to log when the client (re)connects.

The second commit, https://github.com/decred/dcrdex/pull/893/commits/905b1be23e460150b2b838fb0effa7c1124883f3, consistently uses the `(*Core).connectWallet` method instead of calling `(*ExchangeWallet).Connect` directly.  This ensures that the sync status loop is always started regardless of the path used to connect the wallet.  Previously only `(*Core).connectAndUnlock` was calling `connectWallet`, although `(*ExchangeWallet).Connect` at least checked `SyncStatus` once.

Commit https://github.com/decred/dcrdex/pull/893/commits/0441ddaed67c46d792b68daff07994c194fde0d9 has the `connectWallet` loop on SyncStatus continue on errors.  It will still break out if the wallet is disconnected.  This helps because the underlying rpcs (e.g. getblockchaininfo) can return unexpected errors even though it is connected.  We may also consider modifying `(*ExchangeWallet).Connect` so that it does not error out on `SyncStatus` as long as it connects successfully because in this case there is no connect retry loop.  Even more generally, we should change `Core`'s wallet connection logic so that it continually tries to make a connection to the wallet when it fails, since while a wallet does try to reconnect once initially connected, we do not have a way to continually try to establish a new connection (e.g. on login).