### PR TITLE
allow apps to listen on IPv6 addresses

### DIFF
--- a/client/cmd/dexc/config.go
+++ b/client/cmd/dexc/config.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -184,10 +185,10 @@ func configure() (*Config, error) {
 	// If web or RPC server addresses not set, use network specific
 	// defaults
 	if cfg.WebAddr == "" {
-		cfg.WebAddr = defaultHost + ":" + defaultWebPort
+		cfg.WebAddr = net.JoinHostPort(defaultHost, defaultWebPort)
 	}
 	if cfg.RPCAddr == "" {
-		cfg.RPCAddr = defaultHost + ":" + defaultRPCPort
+		cfg.RPCAddr = net.JoinHostPort(defaultHost, defaultRPCPort)
 	}
 
 	if cfg.RPCCert == "" {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -946,7 +946,8 @@ func addrHost(addr string) (string, error) {
 		// Any address with no colons is appended with the default port.
 		var addrErr *net.AddrError
 		if errors.As(splitErr, &addrErr) && addrErr.Err == missingPort {
-			return addr + ":" + defaultDEXPort, nil
+			host = strings.Trim(addrErr.Addr, "[]") // JoinHostPort expects no brackets for ipv6 hosts
+			return net.JoinHostPort(host, defaultDEXPort), nil
 		}
 		// These are addresses with at least one colon in an unexpected
 		// position.
@@ -958,7 +959,7 @@ func addrHost(addr string) (string, error) {
 		host, port = a.Hostname(), a.Port()
 		// If the address parses but there is no port, append the default port.
 		if port == "" {
-			return host + ":" + defaultDEXPort, nil
+			return net.JoinHostPort(host, defaultDEXPort), nil
 		}
 	}
 	// We have a port but no host. Replace with localhost.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -4169,6 +4169,10 @@ func TestAddrHost(t *testing.T) {
 		addr: "https://localhost:5758",
 		want: "localhost:5758",
 	}, {
+		name: "scheme, ipv6 host, and port",
+		addr: "https://[::1]:5758",
+		want: "[::1]:5758",
+	}, {
 		name: "host and port",
 		addr: "localhost:5758",
 		want: "localhost:5758",

--- a/server/cmd/dcrdex/config_test.go
+++ b/server/cmd/dcrdex/config_test.go
@@ -1,0 +1,52 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package main
+
+import "testing"
+
+const (
+	defaultHost = "127.0.0.1"
+	defaultPort = "17232"
+)
+
+func Test_normalizeNetworkAddress(t *testing.T) {
+	tests := []struct {
+		listen  string
+		want    string
+		wantErr bool
+	}{
+		{
+			listen: "[::1]",
+			want:   "[::1]:17232",
+		},
+		{
+			listen: "[::]:",
+			want:   "[::]:17232",
+		},
+		{
+			listen: "",
+			want:   "127.0.0.1:17232",
+		},
+		{
+			listen: "127.0.0.2",
+			want:   "127.0.0.2:17232",
+		},
+		{
+			listen: ":7222",
+			want:   "127.0.0.1:7222",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.listen, func(t *testing.T) {
+			got, err := normalizeNetworkAddress(tt.listen, defaultHost, defaultPort)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("normalizeNetworkAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("normalizeNetworkAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is based on PR #882, so the commit of interest is https://github.com/decred/dcrdex/commit/bfb407e2ccd4005c3dccaf783a1b6ddfb5148cfa.

The issue is that `host + ":" port` is not always correct for IPv6 because the host needs brackets around it when joined with a port.  This updates all the listen address parsing and construction code to work properly with IPv6.

For dcrdex with `--rpclisten=[::1]:17232`:

**before**

`NewServer failed: address ::1:17232: too many colons in address`

**after**

`[INF] COMM: RPC server listening on [::1]:17232`

A similar fix is applied to client.