### PR TITLE
change dcrdex harness port

### DIFF
--- a/client/cmd/dexcctl/simnet-setup.sh
+++ b/client/cmd/dexcctl/simnet-setup.sh
@@ -12,7 +12,7 @@ echo configuring Bitcoin wallet
 echo configuring Litecoin wallet
 ./dexcctl -p abc -p "" --simnet newwallet 2 ~/dextest/ltc/alpha/alpha.conf '{"walletname":"gamma"}'
 echo registering with DEX
-./dexcctl -p abc --simnet register 127.0.0.1:17273 100000000 ~/dextest/dcrdex/rpc.cert
+./dexcctl -p abc --simnet register 127.0.0.1:17232 100000000 ~/dextest/dcrdex/rpc.cert
 echo mining fee confirmation blocks
 tmux send-keys -t dcr-harness:0 "./mine-alpha 1" C-m
 sleep 2

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -65,7 +65,7 @@ var (
 	}
 	clients = []*tClient{client1, client2}
 
-	dexHost = "127.0.0.1:17273"
+	dexHost = "127.0.0.1:17232"
 	dexCert []byte
 
 	// dex/testing/harness.sh => markets.json settings

--- a/dex/testing/dcrdex/README.md
+++ b/dex/testing/dcrdex/README.md
@@ -14,7 +14,7 @@ The [DCR Test Harness](../dcr/README.md) and [BTC Simnet Test Harness](../btc/RE
 must be running to use the dcrdex harness.
 
 The dcrdex config file created and used by the harness sets
-`pgdbname=dcrdex_simnet_test` and `rpclisten=127.0.0.1:17273`.
+`pgdbname=dcrdex_simnet_test` and `rpclisten=127.0.0.1:17232`.
 You can override these or set additional config opts by passing them as
 arguments when executing the harness script e.g.:
 
@@ -26,7 +26,7 @@ The harness script will drop any existing `dcrdex_simnet_test` PostgreSQL db
 and create a fresh database for the session. The script will also create a
 markets.json file referencing dcr and btc node config files created by the
 respective node harnesses; and start a dcrdex instance listening at
-`127.0.0.1:17273` or any address you specify in cli args.
+`127.0.0.1:17232` or any address you specify in cli args.
 
 The rpc cert for the dcrdex instance will be created in `~/dextest/dcrdex/rpc.cert`
 with the following content:

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -88,7 +88,7 @@ cat > "./dcrdex.conf" <<EOF
 regfeexpub=spubVWKGn9TGzyo7M4b5xubB5UV4joZ5HBMNBmMyGvYEaoZMkSxVG4opckpmQ26E85iHg8KQxrSVTdex56biddqtXBerG9xMN8Dvb3eNQVFFwpE
 pgdbname=${TEST_DB}
 simnet=1
-rpclisten=127.0.0.1:17273
+rpclisten=127.0.0.1:17232
 debuglevel=trace
 loglocal=true
 regfeeconfirms=1

--- a/dex/testing/loadbot/loadbot.go
+++ b/dex/testing/loadbot/loadbot.go
@@ -51,7 +51,7 @@ var (
 	btcID, _ = dex.BipSymbolID("btc")
 	// ltcID, _    = dex.BipSymbolID("ltc") // TODO
 	loggerMaker *dex.LoggerMaker
-	hostAddr    = "127.0.0.1:17273"
+	hostAddr    = "127.0.0.1:17232"
 	pass        = []byte("abc")
 	log         dex.Logger
 	unbip       = dex.BipIDSymbol

--- a/docs/examples/rpcclient/main.go
+++ b/docs/examples/rpcclient/main.go
@@ -26,7 +26,7 @@ const (
 	user    = "user"
 	pass    = "pass"
 	addr    = "127.0.0.1:5757"
-	dexAddr = "127.0.0.1:17273"
+	dexAddr = "127.0.0.1:17232"
 )
 
 func main() {


### PR DESCRIPTION
dcrdex listens on 7232 by default.  For some reason our harnesses use 172**73**, which deviates from the usual tweak of adding or modifying a single digit.  I suspect this was a typo from months ago that just stuck.  However, every so often I try to interact manually with the dcrdex harness and it takes me a while to recall this oddity.  This changes the port to 17232 (i.e. 7232 + 10000)