### PR TITLE
client: Update wallet's settings & password simultaneously

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1551,8 +1551,9 @@ func (c *Core) WalletSettings(assetID uint32) (map[string]string, error) {
 	return dbWallet.Settings, nil
 }
 
-// ReconfigureWallet updates the wallet configuration settings.
-func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]string) error {
+// ReconfigureWallet updates the wallet configuration settings, it also updates
+// the password if newWalletPW is non-nil.
+func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg map[string]string) error {
 	crypter, err := c.encryptionKey(appPW)
 	if err != nil {
 		return newError(authErr, "ReconfigureWallet password error: %v", err)
@@ -1561,7 +1562,8 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 	defer c.walletMtx.Unlock()
 	oldWallet, found := c.wallets[assetID]
 	if !found {
-		return newError(missingWalletErr, "%d -> %s wallet not found", assetID, unbip(assetID))
+		return newError(missingWalletErr, "%d -> %s wallet not found",
+			assetID, unbip(assetID))
 	}
 	dbWallet := &db.Wallet{
 		AssetID:     oldWallet.AssetID,
@@ -1573,7 +1575,21 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 	// Reload the wallet with the new settings.
 	wallet, err := c.loadWallet(dbWallet)
 	if err != nil {
-		return newError(walletErr, "error loading wallet for %d -> %s: %v", assetID, unbip(assetID), err)
+		return newError(walletErr, "error loading wallet for %d -> %s: %v",
+			assetID, unbip(assetID), err)
+	}
+
+	newPasswordSet := newWalletPW != nil // INcludes empty but non-nil
+	// If newWalletPW is non-nil, update the wallet's password.
+	if newPasswordSet {
+		encPW, err := crypter.Encrypt(newWalletPW) // TODO: not correct if string(newWalletPW) == ""
+		if err != nil {
+			return newError(encryptionErr, "encryption error: %v", err)
+		}
+		err = c.setWalletPassword(wallet, newWalletPW, encPW)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Must connect to ensure settings are good.
@@ -1582,10 +1598,11 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 		return err
 	}
 
-	// Carry over any cached password regardless of backend lock state.
-	// loadWallet already copied encPW, so this will decrypt pw rather than
-	// actually copying it, and it will ensure the backend is also unlocked.
-	if oldWallet.locallyUnlocked() {
+	// If the password was not changed, carry over any cached password
+	// regardless of backend lock state. loadWallet already copied encPW, so
+	// this will decrypt pw rather than actually copying it, and it will
+	// ensure the backend is also unlocked.
+	if !newPasswordSet && oldWallet.locallyUnlocked() {
 		err := wallet.Unlock(crypter)
 		if err != nil {
 			wallet.Disconnect()
@@ -1632,8 +1649,10 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 	c.wallets[assetID] = wallet
 
 	c.notify(newBalanceNote(assetID, balances)) // redundant with wallet config note?
-	details := fmt.Sprintf("Configuration for %s wallet has been updated. Deposit address = %s", unbip(assetID), wallet.address)
-	c.notify(newWalletConfigNote(SubjectWalletConfigurationUpdated, details, db.Success, wallet.state()))
+	details := fmt.Sprintf("Configuration for %s wallet has been updated. Deposit address = %s",
+		unbip(assetID), wallet.address)
+	c.notify(newWalletConfigNote(SubjectWalletConfigurationUpdated,
+		details, db.Success, wallet.state()))
 
 	// Clear any existing tickGovernors for suspect matches.
 	c.connMtx.RLock()
@@ -1670,7 +1689,7 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 		return newError(authErr, "SetWalletPassword password error: %v", err)
 	}
 
-	newPasswordSet := len(newPW) > 0
+	newPasswordSet := len(newPW) > 0 // excludes empty but non-nil
 
 	// Check that the specified wallet exists.
 	c.walletMtx.Lock()
@@ -1688,15 +1707,19 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 		}
 	}
 
-	// Check that the new password works. If the new password is empty, skip
-	// this step, since an empty password signifies an unencrypted wallet.
 	wasUnlocked := wallet.unlocked()
+	var encPW []byte
 	if newPasswordSet {
-		err = wallet.Wallet.Unlock(string(newPW))
+		encPW, err = crypter.Encrypt(newPW)
 		if err != nil {
-			return newError(authErr, "Error unlocking wallet. Is the new password correct?: %v", err)
+			return newError(encryptionErr, "encryption error: %v", err)
+		}
+		err = c.setWalletPassword(wallet, newPW, encPW)
+		if err != nil {
+			return err
 		}
 	}
+	// TODO: else wallet.encPW = nil?
 
 	if !wasConnected {
 		wallet.Disconnect()
@@ -1706,24 +1729,37 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 		}
 	}
 
-	// Encrypt the password.
-	var encPW []byte
+	return nil
+}
+
+// setWalletPassword updates the (encrypted) password for the wallet.
+func (c *Core) setWalletPassword(wallet *xcWallet, newPW, encNewPW []byte) error {
+	newPasswordSet := len(newPW) > 0 // excludes empty but non-nil
+
+	// Check that the new password works. If the new password is empty, skip
+	// this step, since an empty password signifies an unencrypted wallet.
+	// TODO: find a way to verify that the wallet actually is unencrypted or
+	// otherwise does not require a password. Perhaps an
+	// asset.Wallet.RequiresPassword wallet method?
 	if newPasswordSet {
-		encPW, err = crypter.Encrypt(newPW)
+		err := wallet.Wallet.Unlock(string(newPW))
 		if err != nil {
-			return newError(encryptionErr, "encryption error: %v", err)
+			return newError(authErr,
+				"setWalletPassword unlocking wallet error, is the new password correct?: %v", err)
 		}
 	}
 
-	err = c.db.SetWalletPassword(wallet.dbID, encPW)
+	err := c.db.SetWalletPassword(wallet.dbID, encNewPW)
 	if err != nil {
 		return codedError(dbErr, err)
 	}
 
-	wallet.encPW = encPW
+	wallet.encPW = encNewPW
 
-	details := fmt.Sprintf("Password for %s wallet has been updated.", unbip(assetID))
-	c.notify(newWalletConfigNote(SubjectWalletPasswordUpdated, details, db.Success, wallet.state()))
+	details := fmt.Sprintf("Password for %s wallet has been updated.",
+		unbip(wallet.AssetID))
+	c.notify(newWalletConfigNote(SubjectWalletPasswordUpdated, details,
+		db.Success, wallet.state()))
 
 	return nil
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1678,7 +1678,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 }
 
 // SetWalletPassword updates the (encrypted) password for the wallet.
-// Returns passwordErr is provided newPW is nil.
+// Returns passwordErr if provided newPW is nil.
 func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error {
 	// Ensure newPW isn't nil.
 	if newPW == nil {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1678,7 +1678,13 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 }
 
 // SetWalletPassword updates the (encrypted) password for the wallet.
+// Return passwordErr is provided newPW is nil.
 func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error {
+	// Ensure newPW isn't nil.
+	if newPW == nil {
+		return newError(passwordErr, "SetWalletPassword password can't be nil")
+	}
+
 	// Check the app password and get the crypter.
 	crypter, err := c.encryptionKey(appPW)
 	if err != nil {
@@ -1693,12 +1699,10 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 		return newError(missingWalletErr, "wallet for %s (%d) is not known", unbip(assetID), assetID)
 	}
 
-	isSettingNewPW := newPW != nil // includes empty but non-nil
-	if isSettingNewPW {
-		err = c.setWalletPassword(wallet, newPW, crypter)
-		if err != nil {
-			return err
-		}
+	// Set new password.
+	err = c.setWalletPassword(wallet, newPW, crypter)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1678,7 +1678,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 }
 
 // SetWalletPassword updates the (encrypted) password for the wallet.
-// Return passwordErr is provided newPW is nil.
+// Returns passwordErr is provided newPW is nil.
 func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error {
 	// Ensure newPW isn't nil.
 	if newPW == nil {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1579,9 +1579,9 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 			assetID, unbip(assetID), err)
 	}
 
-	newPasswordSet := newWalletPW != nil // Includes empty but non-nil
+	isSettingNewPW := newWalletPW != nil // Includes empty but non-nil
 	// If newWalletPW is non-nil, update the wallet's password.
-	if newPasswordSet {
+	if isSettingNewPW {
 		err = c.setWalletPassword(wallet, newWalletPW, crypter)
 		if err != nil {
 			return err
@@ -1598,7 +1598,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 	// regardless of backend lock state. loadWallet already copied encPW, so
 	// this will decrypt pw rather than actually copying it, and it will
 	// ensure the backend is also unlocked.
-	if !newPasswordSet && oldWallet.locallyUnlocked() {
+	if !isSettingNewPW && oldWallet.locallyUnlocked() {
 		err := wallet.Unlock(crypter)
 		if err != nil {
 			wallet.Disconnect()
@@ -1685,8 +1685,6 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 		return newError(authErr, "SetWalletPassword password error: %v", err)
 	}
 
-	newPasswordSet := len(newPW) > 0 // excludes empty but non-nil
-
 	// Check that the specified wallet exists.
 	c.walletMtx.Lock()
 	defer c.walletMtx.Unlock()
@@ -1695,7 +1693,8 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 		return newError(missingWalletErr, "wallet for %s (%d) is not known", unbip(assetID), assetID)
 	}
 
-	if newPasswordSet {
+	isSettingNewPW := newPW != nil // includes empty but non-nil
+	if isSettingNewPW {
 		err = c.setWalletPassword(wallet, newPW, crypter)
 		if err != nil {
 			return err

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -4836,11 +4836,17 @@ func TestSetWalletPassword(t *testing.T) {
 	newPW := []byte("def")
 	var assetID uint32 = 54321
 
-	// Password error
+	// Nil password error
+	err := tCore.SetWalletPassword(tPW, assetID, nil)
+	if !errorHasCode(err, passwordErr) {
+		t.Fatalf("wrong error for nil password error: %v", err)
+	}
+
+	// Auth error
 	rig.crypter.recryptErr = tErr
-	err := tCore.SetWalletPassword(tPW, assetID, newPW)
+	err = tCore.SetWalletPassword(tPW, assetID, newPW)
 	if !errorHasCode(err, authErr) {
-		t.Fatalf("wrong error for password error: %v", err)
+		t.Fatalf("wrong error for auth error: %v", err)
 	}
 	rig.crypter.recryptErr = nil
 

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -421,7 +421,7 @@ func (s *WebServer) apiReconfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update wallet settings
+	// Update wallet settings.
 	err := s.core.ReconfigureWallet(form.AppPW, form.NewWalletPW, form.AssetID,
 		form.Config)
 	if err != nil {

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -907,7 +907,7 @@ func (c *TCore) Wallets() []*core.WalletState {
 func (c *TCore) WalletSettings(assetID uint32) (map[string]string, error) {
 	return c.wallets[assetID].settings, nil
 }
-func (c *TCore) ReconfigureWallet(pw []byte, assetID uint32, cfg map[string]string) error {
+func (c *TCore) ReconfigureWallet(aPW, nPW []byte, assetID uint32, cfg map[string]string) error {
 	c.wallets[assetID].settings = cfg
 	return nil
 }

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -173,10 +173,26 @@
         <img id="recfgAssetLogo" class="micro-icon mx-1">
         <span id="recfgAssetName"></span>
         Wallet
-        <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+        <div class="form-closer recfg-form hoverbg"><span class="ico-cross"></span></div>
       </div>
       <div class="px-3 py-1" id="reconfigInputs">
         {{template "walletConfigTemplates"}}
+      </div>
+      <div id="showChangePW" class="px-3 py-1 mt-2 pointer d-flex align-items-center justify-content-start">
+        <span id="showIcon" class="ico-plus fs8 pl-1"></span>
+        <span id="hideIcon" class="ico-minus fs8 pl-1"></span>
+        <span id="switchPWMsg" class="d-inline-block pl-1 pb-1"></span>
+      </div>
+      <div id="changePW" class="px-4 py-1">
+        <div class="fs15">
+          Changing the password below does not change the password for your wallet software.
+          Use this form to update the DEX client after you have changed your password
+          with the wallet software directly.
+        </div>
+        <div class="pt-3">
+          <label for="newPW" class="mb-1">New Wallet Password</label>
+          <input type="password" class="form-control select" id="newPW" autocomplete="new-password">
+        </div>
       </div>
       <hr class="dashed my-2 mx-4">
       <div class="px-4 my-2">
@@ -184,8 +200,8 @@
       </div>
       <div class="d-flex px-4 mt-1">
         <div class="col-12 p-0">
-          <label for="reconfigPW" class="pl-1 mb-1">App Password</label>
-          <input type="password" class="form-control select" id="reconfigPW" autocomplete="off">
+          <label for="appPW" class="pl-1 mb-1">App Password</label>
+          <input type="password" class="form-control select" id="appPW" autocomplete="off">
         </div>
         <div class="col-12 p-0 text-right">
           <div>&nbsp;</div>
@@ -193,46 +209,6 @@
         </div>
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor" id="reconfigErr"></div>
-      <hr class="dashed mt-4 mx-4">
-      <div class="pt-2 pl-1">
-        <span class="mx-4">Or, you can...</span>
-        <ul class="fs15 mt-3 mr-4">
-          <li id="changePW" class="hoverbg pointer">
-            Update the wallet password
-            <span class="ico-info fs13" data-tooltip="Update the stored wallet password. Change the password directly with your wallet software first."></span></li>
-        </ul>
-      </div>
-    </form>
-
-    {{- /* CHANGE WALLET PASSWORD */ -}}
-    <form class="card bg1 pb-3 d-hide mt-3" id="walletRepw" autocomplete="off">
-      <div class="bg2 px-2 py-1 text-center position-relative fs18">
-        Change
-        <img id="repwAssetLogo" class="micro-icon mx-1">
-        <span id="repwAssetName"></span>
-        Wallet Password
-        <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-      </div>
-      <div class="px-4 pt-3 fs15">
-        Changing the password below does not change the password for your wallet software.
-        Use this form to update the DEX client after you have changed your password
-        with the wallet software directly.
-      </div>
-      <div class="px-4 pt-3">
-        <label for="repwNewPw" class="mb-1">New Wallet Password</label>
-        <input type="password" class="form-control select" id="repwNewPw" autocomplete="off">
-      </div>
-      <div class="d-flex px-4 mt-1">
-        <div class="col-12 p-0">
-          <label for="repwAppPw" class="mb-1">App Password</label>
-          <input type="password" class="form-control select" id="repwAppPw" autocomplete="off">
-        </div>
-        <div class="col-12 p-0 text-right">
-          <div>&nbsp;</div>
-          <button id="submitRepw" type="button" class="w-75 mt-1 justify-content-center fs15 bg2 selected">Submit</button>
-        </div>
-      </div>
-      <div class="fs15 pt-3 text-center d-hide errcolor" id="repwErr"></div>
     </form>
 
   </div>

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -24,10 +24,8 @@ export default class WalletsPage extends BasePage {
       'walletForm', 'openForm',
       // Wallet configuration
       'walletReconfig', 'recfgAssetLogo', 'recfgAssetName', 'reconfigInputs',
-      'submitReconfig', 'reconfigErr', 'reconfigPW', 'changePW',
-      // Wallet password change
-      'walletRepw', 'repwAssetLogo', 'repwAssetName', 'repwNewPw', 'repwAppPw',
-      'submitRepw', 'repwErr',
+      'submitReconfig', 'reconfigErr', 'appPW', 'showChangePW', 'changePW',
+      'switchPWMsg', 'hideIcon', 'showIcon', 'newPW',
       // Deposit
       'deposit', 'depositName', 'depositAddress', 'newDepAddrBttn',
       'depositErr', 'depositLogo',
@@ -133,12 +131,11 @@ export default class WalletsPage extends BasePage {
       page.withdrawAmt.value = page.withdrawAvail.textContent
     })
 
-    // A link on the wallet reconfiguration form to show the password change
-    // form.
-    bind(page.changePW, 'click', () => { this.showChangePW() })
-
-    // Submit the password change form.
-    bindForm(page.walletRepw, page.submitRepw, () => { this.submitChangePW() })
+    // A link on the wallet reconfiguration form to show/hide the password field.
+    bind(page.showChangePW, 'click', () => {
+      this.changeWalletPW = !this.changeWalletPW
+      this.setPWSettingViz(this.changeWalletPW)
+    })
 
     if (!firstRow) return
     this.showMarkets(firstRow.assetID)
@@ -148,6 +145,21 @@ export default class WalletsPage extends BasePage {
       walletstate: note => { this.handleWalletStateNote(note) },
       walletconfig: note => { this.handleWalletStateNote(note) }
     }
+  }
+
+  /*
+   * setPWSettingViz sets the visibility of the password field section.
+   */
+  setPWSettingViz (visible) {
+    if (visible) {
+      Doc.hide(this.page.showIcon)
+      Doc.show(this.page.hideIcon, this.page.changePW)
+      this.page.switchPWMsg.textContent = 'keep current wallet password'
+      return
+    }
+    Doc.hide(this.page.hideIcon, this.page.changePW)
+    Doc.show(this.page.showIcon)
+    this.page.switchPWMsg.textContent = 'set a new wallet password'
   }
 
   /*
@@ -239,6 +251,9 @@ export default class WalletsPage extends BasePage {
   async showReconfig (assetID) {
     const page = this.page
     Doc.hide(page.reconfigErr)
+    // Hide update password section by default
+    this.changeWalletPW = false
+    this.setPWSettingViz(this.changeWalletPW)
     const asset = app.assets[assetID]
     this.walletReconfig.update(asset.info)
     page.recfgAssetLogo.src = Doc.logoPath(asset.symbol)
@@ -257,46 +272,6 @@ export default class WalletsPage extends BasePage {
       return
     }
     this.walletReconfig.setConfig(res.map)
-  }
-
-  /* showChangePW shows the form to change the wallet password. */
-  async showChangePW () {
-    const page = this.page
-    Doc.hide(page.repwErr)
-    const assetID = this.lastFormAsset = this.reconfigAsset
-    const asset = app.assets[assetID]
-    page.repwAssetLogo.src = Doc.logoPath(asset.symbol)
-    page.repwAssetName.textContent = asset.info.name
-    await this.hideBox()
-    this.animation = this.showBox(page.walletRepw)
-  }
-
-  /*
-   * submitChangePW is called when the wallet password change form is submitted.
-   */
-  async submitChangePW () {
-    const page = this.page
-    Doc.hide(page.repwErr)
-    if (!page.repwAppPw.value) {
-      page.repwErr.textContent = 'app password cannot be empty'
-      Doc.show(page.repwErr)
-      return
-    }
-    const loaded = app.loading(page.walletRepw)
-    const res = await postJSON('/api/setwalletpass', {
-      assetID: this.reconfigAsset,
-      newPW: page.repwNewPw.value,
-      appPW: page.repwAppPw.value
-    })
-    page.repwNewPw.value = ''
-    page.repwAppPw.value = ''
-    loaded()
-    if (!app.checkResponse(res, true)) {
-      page.repwErr.textContent = res.msg
-      Doc.show(page.repwErr)
-      return
-    }
-    this.showMarkets(this.reconfigAsset)
   }
 
   /* Display a deposit address. */
@@ -419,18 +394,21 @@ export default class WalletsPage extends BasePage {
   async reconfig () {
     const page = this.page
     Doc.hide(page.reconfigErr)
-    if (!page.reconfigPW.value) {
+    if (!page.appPW.value) {
       page.reconfigErr.textContent = 'app password cannot be empty'
       Doc.show(page.reconfigErr)
       return
     }
     const loaded = app.loading(page.walletReconfig)
-    const res = await postJSON('/api/reconfigurewallet', {
+    const req = {
       assetID: this.reconfigAsset,
       config: this.walletReconfig.map(),
-      pw: page.reconfigPW.value
-    })
-    page.reconfigPW.value = ''
+      appPW: page.appPW.value
+    }
+    if (this.changeWalletPW) req.newWalletPW = page.newPW.value
+    const res = await postJSON('/api/reconfigurewallet', req)
+    page.appPW.value = ''
+    page.newPW.value = ''
     loaded()
     if (!app.checkResponse(res, true)) {
       page.reconfigErr.textContent = res.msg

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -75,8 +75,7 @@ type clientCore interface {
 	Wallets() []*core.WalletState
 	WalletState(assetID uint32) *core.WalletState
 	WalletSettings(uint32) (map[string]string, error)
-	ReconfigureWallet([]byte, uint32, map[string]string) error
-	SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error
+	ReconfigureWallet([]byte, []byte, uint32, map[string]string) error
 	NewDepositAddress(assetID uint32) (string, error)
 	AutoWalletConfig(assetID uint32) (map[string]string, error)
 	User() *core.User
@@ -262,7 +261,6 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 			apiAuth.Post("/parseconfig", s.apiParseConfig)
 			apiAuth.Post("/reconfigurewallet", s.apiReconfig)
 			apiAuth.Post("/walletsettings", s.apiWalletSettings)
-			apiAuth.Post("/setwalletpass", s.apiSetWalletPass)
 			apiAuth.Post("/orders", s.apiOrders)
 			apiAuth.Post("/order", s.apiOrder)
 			apiAuth.Post("/withdraw", s.apiWithdraw)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -97,16 +97,18 @@ func (c *TCore) WalletState(assetID uint32) *core.WalletState {
 func (c *TCore) CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error {
 	return c.createWalletErr
 }
-func (c *TCore) OpenWallet(assetID uint32, pw []byte) error                               { return c.openWalletErr }
-func (c *TCore) CloseWallet(assetID uint32) error                                         { return c.closeWalletErr }
-func (c *TCore) ConnectWallet(assetID uint32) error                                       { return nil }
-func (c *TCore) Wallets() []*core.WalletState                                             { return nil }
-func (c *TCore) WalletSettings(uint32) (map[string]string, error)                         { return nil, nil }
-func (c *TCore) ReconfigureWallet(pw []byte, assetID uint32, cfg map[string]string) error { return nil }
-func (c *TCore) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error       { return nil }
-func (c *TCore) NewDepositAddress(assetID uint32) (string, error)                         { return "", nil }
-func (c *TCore) AutoWalletConfig(assetID uint32) (map[string]string, error)               { return nil, nil }
-func (c *TCore) User() *core.User                                                         { return nil }
+func (c *TCore) OpenWallet(assetID uint32, pw []byte) error       { return c.openWalletErr }
+func (c *TCore) CloseWallet(assetID uint32) error                 { return c.closeWalletErr }
+func (c *TCore) ConnectWallet(assetID uint32) error               { return nil }
+func (c *TCore) Wallets() []*core.WalletState                     { return nil }
+func (c *TCore) WalletSettings(uint32) (map[string]string, error) { return nil, nil }
+func (c *TCore) ReconfigureWallet(aPW, nPW []byte, assetID uint32, cfg map[string]string) error {
+	return nil
+}
+func (c *TCore) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error { return nil }
+func (c *TCore) NewDepositAddress(assetID uint32) (string, error)                   { return "", nil }
+func (c *TCore) AutoWalletConfig(assetID uint32) (map[string]string, error)         { return nil, nil }
+func (c *TCore) User() *core.User                                                   { return nil }
 func (c *TCore) SupportedAssets() map[uint32]*core.SupportedAsset {
 	return make(map[uint32]*core.SupportedAsset)
 }


### PR DESCRIPTION
This adds the possibility to update wallet's settings/name & password simultaneously.
With this users which used an unencrypted wallet could switch to a different encrypted wallet.

Closes #855  