### PR TITLE
client: Validate known deposit address after wallet connection

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -565,6 +565,15 @@ func (btc *ExchangeWallet) SyncStatus() (bool, float32, error) {
 	return true, 1, nil
 }
 
+// IsAddressMine returns wether given address belongs to wallet or not
+func (btc *ExchangeWallet) IsAddressMine(address string) (bool, error) {
+	ai, err := btc.wallet.GetAddressInfo(address)
+	if err != nil {
+		return false, err
+	}
+	return ai.IsMine, nil
+}
+
 // Balance returns the total available funds in the wallet. Part of the
 // asset.Wallet interface.
 func (btc *ExchangeWallet) Balance() (*asset.Balance, error) {

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -565,8 +565,8 @@ func (btc *ExchangeWallet) SyncStatus() (bool, float32, error) {
 	return true, 1, nil
 }
 
-// IsAddressMine returns wether given address belongs to wallet or not
-func (btc *ExchangeWallet) IsAddressMine(address string) (bool, error) {
+// ValidateAddress returns wether given address belongs to wallet or not
+func (btc *ExchangeWallet) ValidateAddress(address string) (bool, error) {
 	ai, err := btc.wallet.GetAddressInfo(address)
 	if err != nil {
 		return false, err

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -565,7 +565,7 @@ func (btc *ExchangeWallet) SyncStatus() (bool, float32, error) {
 	return true, 1, nil
 }
 
-// ValidateAddress returns wether given address belongs to wallet or not
+// ValidateAddress indicates if an address belongs to the wallet.
 func (btc *ExchangeWallet) ValidateAddress(address string) (bool, error) {
 	ai, err := btc.wallet.GetAddressInfo(address)
 	if err != nil {

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -565,8 +565,8 @@ func (btc *ExchangeWallet) SyncStatus() (bool, float32, error) {
 	return true, 1, nil
 }
 
-// ValidateAddress indicates if an address belongs to the wallet.
-func (btc *ExchangeWallet) ValidateAddress(address string) (bool, error) {
+// OwnsAddress indicates if an address belongs to the wallet.
+func (btc *ExchangeWallet) OwnsAddress(address string) (bool, error) {
 	ai, err := btc.wallet.GetAddressInfo(address)
 	if err != nil {
 		return false, err

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -32,6 +32,7 @@ const (
 	methodSendToAddress     = "sendtoaddress"
 	methodSetTxFee          = "settxfee"
 	methodGetWalletInfo     = "getwalletinfo"
+	methodGetAddressInfo    = "getaddressinfo"
 )
 
 // walletClient is a bitcoind wallet RPC client that uses rpcclient.Client's
@@ -225,7 +226,14 @@ func (wc *walletClient) GetWalletInfo() (*GetWalletInfoResult, error) {
 	return wi, wc.call(methodGetWalletInfo, nil, wi)
 }
 
-// call is used internally to  marshal parmeters and send requests to  the RPC
+// GetAddressInfo gets information about given address by calling
+// getaddressinfo RPC command.
+func (wc *walletClient) GetAddressInfo(address string) (*GetAddressInfoResult, error) {
+	ai := new(GetAddressInfoResult)
+	return ai, wc.call(methodGetAddressInfo, anylist{address}, ai)
+}
+
+// call is used internally to marshal parmeters and send requests to the RPC
 // server via (*rpcclient.Client).RawRequest. If `thing` is non-nil, the result
 // will be marshaled into `thing`.
 func (wc *walletClient) call(method string, args anylist, thing interface{}) error {

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -226,7 +226,7 @@ func (wc *walletClient) GetWalletInfo() (*GetWalletInfoResult, error) {
 	return wi, wc.call(methodGetWalletInfo, nil, wi)
 }
 
-// GetAddressInfo gets information about given address by calling
+// GetAddressInfo gets information about the given address by calling
 // getaddressinfo RPC command.
 func (wc *walletClient) GetAddressInfo(address string) (*GetAddressInfoResult, error) {
 	ai := new(GetAddressInfoResult)

--- a/client/asset/btc/wallettypes.go
+++ b/client/asset/btc/wallettypes.go
@@ -125,3 +125,8 @@ type GetWalletInfoResult struct {
 	// 	Progress float32 `json:"progress"`
 	// } `json:"scanning"`
 }
+
+// GetAddressInfoResult models the data from the getaddressinfo command.
+type GetAddressInfoResult struct {
+	IsMine bool `json:"ismine"`
+}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -394,7 +394,7 @@ type combinedClient struct {
 	*walletClient
 }
 
-// ValidateAddress disambiguates the node and wallet methods
+// ValidateAddress disambiguates the node and wallet methods.
 func (cc *combinedClient) ValidateAddress(ctx context.Context, address dcrutil.Address) (*walletjson.ValidateAddressWalletResult, error) {
 	return cc.walletClient.ValidateAddress(ctx, address)
 }

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -554,8 +554,8 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 	return &wg, nil
 }
 
-// IsAddressMine returns wether given address belongs to wallet or not
-func (dcr *ExchangeWallet) IsAddressMine(address string) (bool, error) {
+// ValidateAddress returns wether given address belongs to wallet or not
+func (dcr *ExchangeWallet) ValidateAddress(address string) (bool, error) {
 	a, err := dcrutil.DecodeAddress(address, chainParams)
 	va, err := dcr.node.ValidateAddress(dcr.ctx, a)
 	if err != nil {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -394,6 +394,10 @@ type combinedClient struct {
 	*walletClient
 }
 
+func (cc *combinedClient) ValidateAddress(ctx context.Context, address dcrutil.Address) (*walletjson.ValidateAddressWalletResult, error) {
+	return cc.walletClient.ValidateAddress(ctx, address)
+}
+
 // Check that ExchangeWallet satisfies the Wallet interface.
 var _ asset.Wallet = (*ExchangeWallet)(nil)
 
@@ -418,7 +422,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		return nil, fmt.Errorf("DCR ExchangeWallet.Run error: %w", err)
 	}
 	// Beyond this point, only node
-	dcr.node = combinedClient{dcr.client, dcrwallet.NewClient(dcrwallet.RawRequestCaller(dcr.client), chainParams)}
+	dcr.node = &combinedClient{dcr.client, dcrwallet.NewClient(dcrwallet.RawRequestCaller(dcr.client), chainParams)}
 
 	return dcr, nil
 }

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -151,6 +151,7 @@ type rpcClient interface {
 	Disconnected() bool
 	RawRequest(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error)
 	WalletInfo(ctx context.Context) (*walletjson.WalletInfoResult, error)
+	ValidateAddress(ctx context.Context, address dcrutil.Address) (*walletjson.ValidateAddressWalletResult, error)
 }
 
 // The rpcclient package functions will return a rpcclient.ErrRequestCanceled
@@ -547,6 +548,16 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 		dcr.shutdown()
 	}()
 	return &wg, nil
+}
+
+// IsAddressMine returns wether given address belongs to wallet or not
+func (dcr *ExchangeWallet) IsAddressMine(address string) (bool, error) {
+	a, err := dcrutil.DecodeAddress(address, chainParams)
+	va, err := dcr.node.ValidateAddress(dcr.ctx, a)
+	if err != nil {
+		return false, err
+	}
+	return va.IsMine, nil
 }
 
 // Balance should return the total available funds in the wallet. Note that

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -394,6 +394,7 @@ type combinedClient struct {
 	*walletClient
 }
 
+// ValidateAddress disambiguates the node and wallet methods
 func (cc *combinedClient) ValidateAddress(ctx context.Context, address dcrutil.Address) (*walletjson.ValidateAddressWalletResult, error) {
 	return cc.walletClient.ValidateAddress(ctx, address)
 }

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -555,8 +555,8 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 	return &wg, nil
 }
 
-// ValidateAddress returns wether given address belongs to wallet or not
-func (dcr *ExchangeWallet) ValidateAddress(address string) (bool, error) {
+// OwnsAddress returns wether given address belongs to wallet or not
+func (dcr *ExchangeWallet) OwnsAddress(address string) (bool, error) {
 	a, err := dcrutil.DecodeAddress(address, chainParams)
 	if err != nil {
 		return false, err

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -555,7 +555,7 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 	return &wg, nil
 }
 
-// OwnsAddress returns wether given address belongs to wallet or not
+// OwnsAddress indicates if an address belongs to the wallet.
 func (dcr *ExchangeWallet) OwnsAddress(address string) (bool, error) {
 	a, err := dcrutil.DecodeAddress(address, chainParams)
 	if err != nil {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -557,6 +557,9 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 // ValidateAddress returns wether given address belongs to wallet or not
 func (dcr *ExchangeWallet) ValidateAddress(address string) (bool, error) {
 	a, err := dcrutil.DecodeAddress(address, chainParams)
+	if err != nil {
+		return false, err
+	}
 	va, err := dcr.node.ValidateAddress(dcr.ctx, a)
 	if err != nil {
 		return false, err

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -366,8 +366,8 @@ func (c *tRPCClient) WalletInfo(_ context.Context) (*walletjson.WalletInfoResult
 	}, nil
 }
 
-func (c *tRPCClient) ValidateAddress(_ context.Context) (*walletjson.ValidateAddressResult, error) {
-	return &walletjson.ValidateAddressResult{
+func (c *tRPCClient) ValidateAddress(_ context.Context, address dcrutil.Address) (*walletjson.ValidateAddressWalletResult, error) {
+	return &walletjson.ValidateAddressWalletResult{
 		IsMine: true,
 	}, nil
 }

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -366,6 +366,12 @@ func (c *tRPCClient) WalletInfo(_ context.Context) (*walletjson.WalletInfoResult
 	}, nil
 }
 
+func (c *tRPCClient) ValidateAddress(_ context.Context) (*walletjson.ValidateAddressResult, error) {
+	return &walletjson.ValidateAddressResult{
+		IsMine: true,
+	}, nil
+}
+
 func (c *tRPCClient) Disconnected() bool {
 	return c.disconnected
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -147,8 +147,8 @@ type Wallet interface {
 	Refund(coinID, contract dex.Bytes) (dex.Bytes, error)
 	// Address returns an address for the exchange wallet.
 	Address() (string, error)
-	// IsAddressMine returns wether given address belongs to wallet or not
-	IsAddressMine(address string) (bool, error)
+	// ValidateAddress returns wether given address belongs to wallet or not
+	ValidateAddress(address string) (bool, error)
 	// Unlock unlocks the exchange wallet.
 	Unlock(pw string) error
 	// Lock locks the exchange wallet.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -147,8 +147,8 @@ type Wallet interface {
 	Refund(coinID, contract dex.Bytes) (dex.Bytes, error)
 	// Address returns an address for the exchange wallet.
 	Address() (string, error)
-	// ValidateAddress indicates if an address belongs to the wallet.
-	ValidateAddress(address string) (bool, error)
+	// OwnsAddress indicates if an address belongs to the wallet.
+	OwnsAddress(address string) (bool, error)
 	// Unlock unlocks the exchange wallet.
 	Unlock(pw string) error
 	// Lock locks the exchange wallet.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -147,7 +147,7 @@ type Wallet interface {
 	Refund(coinID, contract dex.Bytes) (dex.Bytes, error)
 	// Address returns an address for the exchange wallet.
 	Address() (string, error)
-	// ValidateAddress returns wether given address belongs to wallet or not
+	// ValidateAddress indicates if an address belongs to the wallet.
 	ValidateAddress(address string) (bool, error)
 	// Unlock unlocks the exchange wallet.
 	Unlock(pw string) error

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -147,6 +147,8 @@ type Wallet interface {
 	Refund(coinID, contract dex.Bytes) (dex.Bytes, error)
 	// Address returns an address for the exchange wallet.
 	Address() (string, error)
+	// IsAddressMine returns wether given address belongs to wallet or not
+	IsAddressMine(address string) (bool, error)
 	// Unlock unlocks the exchange wallet.
 	Unlock(pw string) error
 	// Lock locks the exchange wallet.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1577,9 +1577,7 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 
 	// If connectWallet generated new xcWallet address store it on dbWallet.
 	if generatedNewAddress {
-		wallet.mtx.RLock()
 		dbWallet.Address = wallet.address
-		wallet.mtx.RUnlock()
 	}
 
 	err = c.db.UpdateWallet(dbWallet)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1063,7 +1063,7 @@ func (c *Core) connectWallet(w *xcWallet) error {
 	}
 	// Check if known address belongs to connected wallet
 	addr := w.address
-	mine, err := w.ValidateAddress(addr)
+	mine, err := w.OwnsAddress(addr)
 	if err != nil {
 		return err
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1053,17 +1053,16 @@ func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 }
 
 // connectWallet connects to wallet and validates the known deposit address
-// after successful connection, if address found & it does not belong to
-// wallet, it generates new address then updates xcWallet and dbWallet,
-// therefore it might hold the wallet lock
+// after successful connection.
+// If address found & it does not belong to wallet, it generates new address,
+// then updates xcWallet and dbWallet.
 func (c *Core) connectWallet(w *xcWallet) error {
 	err := w.Connect(c.ctx)
 	if err != nil {
 		return codedError(connectWalletErr, err)
 	}
-	// If wallet has deposit address check if it's belongs to connected
+	// If xcWallet has deposit address ensure that it belongs to connected
 	// wallet.
-	// If found address doesn't belong to wallet generate new one.
 	w.mtx.RLock()
 	addr := w.address
 	w.mtx.RUnlock()
@@ -1073,7 +1072,8 @@ func (c *Core) connectWallet(w *xcWallet) error {
 		if err != nil {
 			return err
 		}
-		// Found address doesn't belong to connected wallet
+		// If Existing address doesn't belong to connected wallet,
+		// generate new one.
 		if !mine {
 			nAddr, err := c.newDepositAddress(w)
 			if err != nil {
@@ -1276,8 +1276,7 @@ func (c *Core) refreshUser() {
 	c.userMtx.Unlock()
 }
 
-// setUserWalletState updates user's struct wallet state to the given wallet
-// state
+// setUserWalletState updates wallet state on current User.
 func (c *Core) setUserWalletState(state *WalletState) {
 	c.userMtx.Lock()
 	defer c.userMtx.Unlock()
@@ -1692,7 +1691,7 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 	return nil
 }
 
-// newDepositAddress retrieves a new deposit address from specific xcWallet.
+// newDepositAddress retrieves a new deposit address from given xcWallet.
 func (c *Core) newDepositAddress(w *xcWallet) (string, error) {
 	if !w.connected() {
 		return "", fmt.Errorf("cannot get address from unconnected %s wallet",

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1557,6 +1557,11 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 	if err != nil {
 		return newError(walletErr, "error loading wallet for %d -> %s: %v", assetID, unbip(assetID), err)
 	}
+	err = c.db.UpdateWallet(dbWallet)
+	if err != nil {
+		wallet.Disconnect()
+		return newError(dbErr, "error saving wallet configuration: %v", err)
+	}
 
 	// Must connect to ensure settings are good.
 	err = c.connectWallet(wallet)
@@ -1569,11 +1574,6 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 			wallet.Disconnect()
 			return newError(walletAuthErr, "wallet successfully connected, but errored unlocking. reconfiguration not saved: %v", err)
 		}
-	}
-	err = c.db.UpdateWallet(dbWallet)
-	if err != nil {
-		wallet.Disconnect()
-		return newError(dbErr, "error saving wallet configuration: %v", err)
 	}
 
 	c.connMtx.RLock()

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1053,7 +1053,7 @@ func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 }
 
 // connectWallet connects to wallet and validate the known deposit address
-// after successful connection, if deposit address does not belong to
+// after successful connection, if the deposit address does not belong to
 // wallet it generates new address and updates xcWallet and dbWallet, therefore
 // it might hold the wallet lock
 func (c *Core) connectWallet(w *xcWallet) error {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1053,7 +1053,7 @@ func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 }
 
 // connectWallet connects to wallet and validate the known deposit address
-// after successfull connection, if deposit address does not belong to
+// after successful connection, if deposit address does not belong to
 // wallet it generates new address and updates xcWallet and dbWallet, therefore
 // it might hold the wallet lock
 func (c *Core) connectWallet(w *xcWallet) error {
@@ -1276,7 +1276,8 @@ func (c *Core) setUserWalletState(state *WalletState) {
 
 	sa, found := c.user.Assets[state.AssetID]
 	if !found {
-		c.log.Errorf("Unknown assed %d", state.AssetID)
+		c.log.Errorf("Unknown asset %d", state.AssetID)
+		return
 	}
 	sa.Wallet = state
 }
@@ -1722,12 +1723,7 @@ func (c *Core) NewDepositAddress(assetID uint32) (string, error) {
 		return "", newError(missingWalletErr, "no wallet found for %s", unbip(assetID))
 	}
 
-	addr, err := c.newDepositAddress(w)
-	if err != nil {
-		return "", err
-	}
-
-	return addr, nil
+	return c.newDepositAddress(w)
 }
 
 // AutoWalletConfig attempts to load setting from a wallet package's

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1057,6 +1057,9 @@ func (c *Core) connectWallet(w *xcWallet) error {
 	if err != nil {
 		return codedError(connectWalletErr, err)
 	}
+	// Check if known address belongs to connected wallet
+	mine, err := w.IsAddressMine(w.address)
+	c.log.Tracef("%v address is mine %v", w.address, mine)
 	// If the wallet is not synced, start a loop to check the sync status until
 	// it is.
 	if !w.synced {
@@ -1530,7 +1533,7 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 		return newError(addrErr, "error getting wallet address: %v", err)
 	}
 	dbWallet.Address = addr
-	wallet.address = addr
+	wallet.setAddress(addr)
 	if oldWallet.unlocked() {
 		err := unlockWallet(wallet, crypter)
 		if err != nil {
@@ -1677,7 +1680,7 @@ func (c *Core) NewDepositAddress(assetID uint32) (string, error) {
 	}
 
 	c.walletMtx.Lock()
-	w.address = addr
+	w.setAddress(addr)
 	c.walletMtx.Unlock()
 
 	dbWallet, err := c.db.Wallet(w.dbID)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2050,15 +2050,15 @@ func (c *Core) Login(pw []byte) (*LoginResult, error) {
 			defer wg.Done()
 			if !wallet.connected() {
 				err := c.connectWallet(wallet)
-				// We wait for connectWalleet to finish before holding the lock as it
-				// may update the deposit address
-				c.walletMtx.Lock()
 				if err != nil {
 					c.log.Errorf("Unable to connect to %s wallet (start and sync wallets BEFORE starting dex!): %v",
 						unbip(wallet.AssetID), err)
 					return
 				}
 			}
+			// We wait for connectWalleet to finish before holding the lock as it
+			// may update the deposit address
+			c.walletMtx.Lock()
 			atomic.AddUint32(&connectCount, 1)
 			_, err := c.walletBalances(wallet)
 			if err == nil {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1053,7 +1053,7 @@ func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 }
 
 // connectWallet connects to wallet and validate the known deposit address
-// after successfull connectection, if deposit address does not belong to
+// after successfull connection, if deposit address does not belong to
 // wallet it generates new address and updates xcWallet and dbWallet, therefore
 // it might hold the wallet lock
 func (c *Core) connectWallet(w *xcWallet) error {
@@ -1266,6 +1266,19 @@ func (c *Core) refreshUser() {
 	c.userMtx.Lock()
 	c.user = u
 	c.userMtx.Unlock()
+}
+
+// setUserWalletState updates user's struct wallet state to the given wallet
+// state
+func (c *Core) setUserWalletState(state *WalletState) {
+	c.userMtx.Lock()
+	defer c.userMtx.Unlock()
+
+	sa, found := c.user.Assets[state.AssetID]
+	if !found {
+		c.log.Errorf("Unknown assed %d", state.AssetID)
+	}
+	sa.Wallet = state
 }
 
 // CreateWallet creates a new exchange wallet.
@@ -1677,7 +1690,6 @@ func (c *Core) newDepositAddress(w *xcWallet) (string, error) {
 			unbip(w.AssetID))
 	}
 
-	c.log.Tracef("tttttt")
 	addr, err := w.Address()
 	if err != nil {
 		return "", fmt.Errorf("%s Wallet.Address error: %w", unbip(w.AssetID), err)
@@ -1685,7 +1697,6 @@ func (c *Core) newDepositAddress(w *xcWallet) (string, error) {
 	// Set xcWallet's new address
 	w.setAddress(addr)
 
-	c.log.Tracef("fdfdfd")
 	dbWallet, err := c.db.Wallet(w.dbID)
 	if err != nil {
 		return "", fmt.Errorf("error retreiving DB wallet: %w", err)
@@ -1695,12 +1706,11 @@ func (c *Core) newDepositAddress(w *xcWallet) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("UpdateWallet error for %s: %w", unbip(w.AssetID), err)
 	}
+	// Update wallet state on user struct
+	walletState := w.state()
+	c.setUserWalletState(walletState)
+	c.notify(newWalletStateNote(walletState))
 
-	c.refreshUser()
-
-	c.notify(newWalletStateNote(w.state()))
-
-	c.log.Tracef("fffffffff \n\n\n")
 	return addr, nil
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -553,7 +553,7 @@ func (w *TXCWallet) Info() *asset.WalletInfo {
 	return &asset.WalletInfo{}
 }
 
-func (w *TXCWallet) ValidateAddress(adress string) (bool, error) {
+func (w *TXCWallet) OwnsAddress(adress string) (bool, error) {
 	return true, nil
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -553,6 +553,10 @@ func (w *TXCWallet) Info() *asset.WalletInfo {
 	return &asset.WalletInfo{}
 }
 
+func (w *TXCWallet) ValidateAddress(adress string) (bool, error) {
+	return true, nil
+}
+
 func (w *TXCWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	return w.connectWG, w.connectErr
 }

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -553,7 +553,7 @@ func (w *TXCWallet) Info() *asset.WalletInfo {
 	return &asset.WalletInfo{}
 }
 
-func (w *TXCWallet) OwnsAddress(adress string) (bool, error) {
+func (w *TXCWallet) OwnsAddress(address string) (bool, error) {
 	return true, nil
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -5733,7 +5733,7 @@ func TestWalletSyncing(t *testing.T) {
 		return false, progress, nil
 	}
 
-	err := tCore.connectWallet(dcrWallet)
+	_, err := tCore.connectWallet(dcrWallet)
 	if err != nil {
 		t.Fatalf("connectWallet error: %v", err)
 	}

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -180,7 +180,7 @@
       </div>
       <hr class="dashed my-2 mx-4">
       <div class="px-4 my-2">
-        Note: Changing to a different wallet while having active trades might cause funds loss. 
+        Note: Changing to a different wallet while having active trades might cause funds to be lost. 
       </div>
       <div class="d-flex px-4 mt-1">
         <div class="col-12 p-0">

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -179,6 +179,9 @@
         {{template "walletConfigTemplates"}}
       </div>
       <hr class="dashed my-2 mx-4">
+      <div class="px-4 my-2">
+        Note: Changing to a different wallet while having active trades might cause funds loss. 
+      </div>
       <div class="d-flex px-4 mt-1">
         <div class="col-12 p-0">
           <label for="reconfigPW" class="pl-1 mb-1">App Password</label>


### PR DESCRIPTION
This fixes #879 by validating deposit address for each wallet after successful connection.

I wiped a running wallet dir and created fresh one as #879 describes and the client
validated the deposit address and generated new one.