### PR TITLE
client/asset/dcr: do not include fee address in sendRegFee

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2100,8 +2100,8 @@ func (dcr *ExchangeWallet) sendRegFee(addr dcrutil.Address, regFee, netFeeRate u
 	}
 	coins, _, _, _, _, err := dcr.fund(enough)
 	if err != nil {
-		return nil, 0, fmt.Errorf("unable to pay registration fee of %.8f DCR to address %s with fee rate of %d atoms/byte: %w",
-			toDCR(regFee), addr, netFeeRate, err)
+		return nil, 0, fmt.Errorf("unable to pay registration fee of %.8f DCR with fee rate of %d atoms/byte: %w",
+			toDCR(regFee), netFeeRate, err)
 	}
 	return dcr.sendCoins(addr, coins, regFee, netFeeRate, false)
 }


### PR DESCRIPTION
The Confirm Registration dialog error was showing the address it was trying to send to even though that address is of no use at best, and resulted in users manually sending funds there (e.g. dcrctl sendtoaddress) when that would not complete the registration.

![image](https://user-images.githubusercontent.com/9373513/103241781-e16d9f80-4919-11eb-92ab-9a5dccf826d6.png)

This PR simply removes the "to address %s" part of the error message to avoid this pitfall.