### PR TITLE
dex/testing: harness improvements

### DIFF
--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -181,6 +181,12 @@ func teardown(cancelCtx context.CancelFunc) {
 	}
 }
 
+func TestMain(m *testing.M) {
+	tmpDir, _ = ioutil.TempDir("", "")
+	defer os.RemoveAll(tmpDir)
+	os.Exit(m.Run())
+}
+
 // TestTradeSuccess runs a simple trade test and ensures that the resulting
 // trades are completed successfully.
 func TestTradeSuccess(t *testing.T) {
@@ -347,12 +353,6 @@ func TestMakerGhostingAfterTakerRedeem(t *testing.T) {
 
 	tLog.Infof("Trades completed. Maker went dark at %s, Taker continued till %s.",
 		order.MakerRedeemed, order.MatchComplete)
-}
-
-func TestMain(m *testing.M) {
-	tmpDir, _ = ioutil.TempDir("", "")
-	defer os.RemoveAll(tmpDir)
-	os.Exit(m.Run())
 }
 
 // TestOrderStatusReconciliation simulates a few conditions that could cause a

--- a/dex/testing/dcr/create-wallet.sh
+++ b/dex/testing/dcr/create-wallet.sh
@@ -34,7 +34,6 @@ rpccert=${WALLET_DIR}/rpc.cert
 pass=${WALLET_PASS}
 rpcconnect=127.0.0.1:${DCRD_RPC_PORT}
 cafile=${DCRD_RPC_CERT}
-${VOTING_CFG}
 EOF
 
 if [ "${ENABLE_VOTING}" = "1" ]; then

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -277,6 +277,11 @@ if [ "$MINE" = "1" ]; then
   done
 fi
 
+# Hack to enable further mining on alpha or beta
+tmux send-keys -t $SESSION:0 "./mine-beta 1${WAIT}" C-m\; wait-for donedcr
+tmux send-keys -t $SESSION:0 "./beta addnode 127.0.0.1:${ALPHA_NODE_PORT} remove${WAIT}" C-m\; wait-for donedcr
+tmux send-keys -t $SESSION:0 "./beta addnode 127.0.0.1:${ALPHA_NODE_PORT} add${WAIT}" C-m\; wait-for donedcr
+
 # Have alpha share a little more wealth, esp. for trade_simnet_test.go
 RECIPIENTS="{\"${TRADING_WALLET1_ADDRESS}\":24,\"${TRADING_WALLET2_ADDRESS}\":24,\"${BETA_MINING_ADDR}\":24}"
 for i in {1..60}; do

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -277,11 +277,6 @@ if [ "$MINE" = "1" ]; then
   done
 fi
 
-# Hack to enable further mining on alpha or beta
-tmux send-keys -t $SESSION:0 "./mine-beta 1${WAIT}" C-m\; wait-for donedcr
-tmux send-keys -t $SESSION:0 "./beta addnode 127.0.0.1:${ALPHA_NODE_PORT} remove${WAIT}" C-m\; wait-for donedcr
-tmux send-keys -t $SESSION:0 "./beta addnode 127.0.0.1:${ALPHA_NODE_PORT} add${WAIT}" C-m\; wait-for donedcr
-
 # Have alpha share a little more wealth, esp. for trade_simnet_test.go
 RECIPIENTS="{\"${TRADING_WALLET1_ADDRESS}\":24,\"${TRADING_WALLET2_ADDRESS}\":24,\"${BETA_MINING_ADDR}\":24}"
 for i in {1..60}; do

--- a/dex/testing/dcrdex/README.md
+++ b/dex/testing/dcrdex/README.md
@@ -22,6 +22,13 @@ arguments when executing the harness script e.g.:
 ./harness.sh --pgpass=dexpass
 ```
 
+You can also override the default markets' epoch duration by passing a number
+(not less than 1000) as the first argument when executing the harness script:
+
+```sh
+./harness.sh 2000 --pgpass=dexpass # to set the epoch duration to 2000ms and also set the pgpass.
+```
+
 The harness script will drop any existing `dcrdex_simnet_test` PostgreSQL db
 and create a fresh database for the session. The script will also create a
 markets.json file referencing dcr and btc node config files created by the

--- a/dex/testing/dcrdex/README.md
+++ b/dex/testing/dcrdex/README.md
@@ -19,14 +19,21 @@ You can override these or set additional config opts by passing them as
 arguments when executing the harness script e.g.:
 
 ```sh
-./harness.sh --pgpass=dexpass
+./harness.sh --pgpass=dexpass # arguments will be passed verbatim to the dcrdex cmd
 ```
 
-You can also override the default markets' epoch duration by passing a number
-(not less than 1000) as the first argument when executing the harness script:
+To persist the postgres db password to the harness' dcrdex.conf (ideal if using
+the config file externally), set a `PG_PASS` env variable:
 
 ```sh
-./harness.sh 2000 --pgpass=dexpass # to set the epoch duration to 2000ms and also set the pgpass.
+PG_PASS=dexpass ./harness.sh # dcrdex.conf will include pgpass="${PG_PASS}"
+```
+
+You can also override the default markets' epoch duration (15000ms) by setting
+an `EPOCH` env variable (lowest value allowed is 1000, unit is ms)
+
+```sh
+EPOCH=20000 ./harness.sh # to set the epoch duration to 20000ms
 ```
 
 The harness script will drop any existing `dcrdex_simnet_test` PostgreSQL db

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -22,7 +22,7 @@ sudo -u postgres -H psql -c "DROP DATABASE IF EXISTS ${TEST_DB}" \
 -c "CREATE DATABASE ${TEST_DB} OWNER dcrdex"
 
 EPOCH_DURATION=15000
-if [ "$#" -eq 1 ]; then
+if [ "$1" -eq "$1" ]; then # check that arg1 is a number and not a flag to append to the dcrdex cmd below
     if [ "$1" -lt 1000 ]; then
         echo "epoch duration cannot be < 1000 ms"
         exit 1

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -21,13 +21,10 @@ TEST_DB=dcrdex_simnet_test
 sudo -u postgres -H psql -c "DROP DATABASE IF EXISTS ${TEST_DB}" \
 -c "CREATE DATABASE ${TEST_DB} OWNER dcrdex"
 
-EPOCH_DURATION=15000
-if [ "$1" -eq "$1" ]; then # check that arg1 is a number and not a flag to append to the dcrdex cmd below
-    if [ "$1" -lt 1000 ]; then
-        echo "epoch duration cannot be < 1000 ms"
-        exit 1
-    fi
-    EPOCH_DURATION=$1
+EPOCH_DURATION=${EPOCH:-15000} 
+if [ "${EPOCH_DURATION}" -lt 1000 ]; then
+    echo "epoch duration cannot be < 1000 ms"
+    exit 1
 fi
 
 echo "Writing markets.json and dcrdex.conf"


### PR DESCRIPTION
Modify dcrdex harness to receive custom epoch duration value from env variable rather than cli arg to retain support for relaying all cli args to dcrdex.

Update dcrdex harness readme to mention the supported `PG_PASS` and `EPOCH` env variables and the behaviour of passing cli args verbatim to dcrdex.