### PR TITLE
rpcserver: add matches slice to myorders route reply

### DIFF
--- a/client/core/types.go
+++ b/client/core/types.go
@@ -139,7 +139,7 @@ type Match struct {
 	IsCancel      bool              `json:"isCancel"`
 }
 
-// A coin encodes both the coin ID and the asset-dependent string representation
+// Coin encodes both the coin ID and the asset-dependent string representation
 // of the coin ID.
 type Coin struct {
 	ID       dex.Bytes `json:"id"`

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -826,8 +826,8 @@ Registration is complete after the fee transaction has been confirmed.`,
     sell (bool): Whether the order is selling.
     base (int): The BIP-44 coin index for the market's base asset.
     quote (int): The BIP-44 coin index for the market's quote asset.
-    qty (int): The number of units to buy/sell. Must be a multiple of the lot siz          rate (int): The atoms quote asset to pay/accept per unit base asset. e.g.
-      156000 satoshi/DCR for the DCR(base)_BTC(quote).
+    qty (int): The number of units to buy/sell. Must be a multiple of the lot size.
+    rate (int): The atoms quote asset to pay/accept per unit base asset. e.g.
     immediate (bool): Require immediate match. Do not book the order.`,
 		returns: `Returns:
     obj: The order details.
@@ -946,15 +946,15 @@ Registration is complete after the fee transaction has been confirmed.`,
       "cancelling" (bool): Whether this order is in the process of cancelling.
       "canceled" (bool): Whether this order has been canceled.
       "tif" (string): "immediate" if this limit order will only match for one epoch.
-        "standing" if the order can continue matching until filled or cancelled.
-			"matches": (array): An array of matches associated with the order.
-			[
+      "standing" if the order can continue matching until filled or cancelled.
+      "matches": (array): An array of matches associated with the order.
+      [
         {
           "matchID (string): The match's ID."
           "status" (string): The match's status."
           "revoked" (bool): Indicates if match was revoked.
           "rate"    (int): The match's rate.
-					"qty"     (int): The match's amount.
+          "qty"     (int): The match's amount.
           "side"    (string): The match's side, "maker" or "taker".
           "feerate" (int): The match's fee rate.
           "swap"    (string): The match's swap transaction.

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -944,7 +944,7 @@ Registration is complete after the fee transaction has been confirmed.`,
       "cancelling" (bool): Whether this order is in the process of cancelling.
       "canceled" (bool): Whether this order has been canceled.
       "tif" (string): "immediate" if this limit order will only match for one epoch.
-      "standing" if the order can continue matching until filled or cancelled.
+        "standing" if the order can continue matching until filled or cancelled.
       "matches": (array): An array of matches associated with the order.
       [
         {

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -826,8 +826,7 @@ Registration is complete after the fee transaction has been confirmed.`,
     sell (bool): Whether the order is selling.
     base (int): The BIP-44 coin index for the market's base asset.
     quote (int): The BIP-44 coin index for the market's quote asset.
-    qty (int): The number of units to buy/sell. Must be a multiple of the lot size.
-    rate (int): The atoms quote asset to pay/accept per unit base asset. e.g.
+    qty (int): The number of units to buy/sell. Must be a multiple of the lot siz          rate (int): The atoms quote asset to pay/accept per unit base asset. e.g.
       156000 satoshi/DCR for the DCR(base)_BTC(quote).
     immediate (bool): Require immediate match. Do not book the order.`,
 		returns: `Returns:
@@ -948,6 +947,24 @@ Registration is complete after the fee transaction has been confirmed.`,
       "canceled" (bool): Whether this order has been canceled.
       "tif" (string): "immediate" if this limit order will only match for one epoch.
         "standing" if the order can continue matching until filled or cancelled.
+			"matches": (array): An array of matches associated with the order.
+			[
+        {
+          "matchID (string): The match's ID."
+          "status" (string): The match's status."
+          "revoked" (bool): Indicates if match was revoked.
+          "rate"    (int): The match's rate.
+					"qty"     (int): The match's amount.
+          "side"    (string): The match's side, "maker" or "taker".
+          "feerate" (int): The match's fee rate.
+          "swap"    (string): The match's swap transaction.
+          "counterSwap" (string): The match's counter swap transaction.
+          "refund" (string): The match's refund transaction.
+          "stamp" (int): The match's stamp.
+          "isCancel" (bool): Indicates if match is canceled.
+        },
+        ....
+      ]
     },...
   ]`,
 	},

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -452,6 +452,13 @@ func parseCoreOrder(co *core.Order, b, q uint32) *myOrder {
 	// has been settled/finalized.
 	parseMatches := func(matches []*core.Match) (ms []*match, settled uint64) {
 		ms = make([]*match, 0, len(matches))
+		// coinSafeString gets the Coin's StringID safely.
+		coinSafeString := func(c *core.Coin) string {
+			if c == nil {
+				return ""
+			}
+			return c.StringID
+		}
 		for _, m := range matches {
 			// Sum up settled value.
 			if (m.Side == order.Maker && m.Status >= order.MakerRedeemed) ||
@@ -469,13 +476,7 @@ func parseCoreOrder(co *core.Order, b, q uint32) *myOrder {
 				Stamp:    m.Stamp,
 				IsCancel: m.IsCancel,
 			}
-			// coinSafeString gets the Coin's StringID safely.
-			coinSafeString := func(c *core.Coin) string {
-				if c == nil {
-					return ""
-				}
-				return c.StringID
-			}
+
 			match.Swap = coinSafeString(m.Swap)
 			match.CounterSwap = coinSafeString(m.CounterSwap)
 			match.Redeem = coinSafeString(m.Redeem)

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -992,7 +992,41 @@ func TestParseCoreOrder(t *testing.T) {
     "filled": 300000000,
     "settled": 100000000,
     "status": "booked",
-    "tif": "standing"
+    "tif": "standing",
+ 		"matches": [                                                                                                                                                                                 
+			{                                                                                                                                                                                                         
+      	"matchID": "992f15e89bbd670663b690b4da4a859609d83866e200f3c4cd5c916442b8ea46",                                                                                                                             
+        "status": "MatchComplete",                                                                                                                                                                                 
+        "revoked": false,                                                                                                                                                                                                     
+        "rate": 200000000,
+        "qty": 100000000,
+        "side": "Maker",
+        "feeRate": 0,
+        "swap": "",
+        "counterSwap":"",
+        "redeem": "",
+        "counterRedeem": "",
+        "refund": "",
+        "stamp": 0,
+        "isCancel": false
+     	},
+      {
+      	"matchID": "69d7453d8ad3b52851c2c9925499a1b158301e8a08da594428ef0ad4cd6fd3a5",
+        "status": "MakerSwapCast",
+        "revoked": false,
+        "rate": 200000000,
+        "qty": 200000000,
+        "side": "Maker",
+        "feeRate": 0,
+        "swap": "",
+        "counterSwap": "",
+        "redeem": "",
+        "counterRedeem": "",
+        "refund": "",
+        "tamp": 0,
+        "isCancel": false
+			}
+    ]
   }`
 	coreOrder := new(core.Order)
 	if err := json.Unmarshal([]byte(co), coreOrder); err != nil {

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -993,9 +993,9 @@ func TestParseCoreOrder(t *testing.T) {
     "settled": 100000000,
     "status": "booked",
     "tif": "standing",
- 		"matches": [                                                                                                                                                                                 
-			{                                                                                                                                                                                                         
-      	"matchID": "992f15e89bbd670663b690b4da4a859609d83866e200f3c4cd5c916442b8ea46",                                                                                                                             
+    "matches": [                                                                                                                                                                                 
+      {                                                                                                                                                                                                         
+        "matchID": "992f15e89bbd670663b690b4da4a859609d83866e200f3c4cd5c916442b8ea46",                                                                                                                             
         "status": "MatchComplete",                                                                                                                                                                                 
         "revoked": false,                                                                                                                                                                                                     
         "rate": 200000000,
@@ -1011,7 +1011,7 @@ func TestParseCoreOrder(t *testing.T) {
         "isCancel": false
      	},
       {
-      	"matchID": "69d7453d8ad3b52851c2c9925499a1b158301e8a08da594428ef0ad4cd6fd3a5",
+        "matchID": "69d7453d8ad3b52851c2c9925499a1b158301e8a08da594428ef0ad4cd6fd3a5",
         "status": "MakerSwapCast",
         "revoked": false,
         "rate": 200000000,
@@ -1025,7 +1025,7 @@ func TestParseCoreOrder(t *testing.T) {
         "refund": "",
         "tamp": 0,
         "isCancel": false
-			}
+      }
     ]
   }`
 	coreOrder := new(core.Order)

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -58,24 +58,44 @@ type tradeResponse struct {
 // myOrdersResponse is used when responding to the myorders route.
 type myOrdersResponse []*myOrder
 
+// myOrder represents an order when responding to the myorders route.
 type myOrder struct {
-	Host        string `json:"host"`
-	MarketName  string `json:"marketName"`
-	BaseID      uint32 `json:"baseID"`
-	QuoteID     uint32 `json:"quoteID"`
-	ID          string `json:"id"`
-	Type        string `json:"type"`
-	Sell        bool   `json:"sell"`
-	Stamp       uint64 `json:"stamp"`
-	Age         string `json:"age"`
-	Rate        uint64 `json:"rate,omitempty"`
-	Quantity    uint64 `json:"quantity"`
-	Filled      uint64 `json:"filled"`
-	Settled     uint64 `json:"settled"`
-	Status      string `json:"status"`
-	Cancelling  bool   `json:"cancelling,omitempty"`
-	Canceled    bool   `json:"canceled,omitempty"`
-	TimeInForce string `json:"tif,omitempty"`
+	Host        string  `json:"host"`
+	MarketName  string  `json:"marketName"`
+	BaseID      uint32  `json:"baseID"`
+	QuoteID     uint32  `json:"quoteID"`
+	ID          string  `json:"id"`
+	Type        string  `json:"type"`
+	Sell        bool    `json:"sell"`
+	Stamp       uint64  `json:"stamp"`
+	Age         string  `json:"age"`
+	Rate        uint64  `json:"rate,omitempty"`
+	Quantity    uint64  `json:"quantity"`
+	Filled      uint64  `json:"filled"`
+	Settled     uint64  `json:"settled"`
+	Status      string  `json:"status"`
+	Cancelling  bool    `json:"cancelling,omitempty"`
+	Canceled    bool    `json:"canceled,omitempty"`
+	TimeInForce string  `json:"tif,omitempty"`
+	Matches     []match `json:"matches,omitempty"`
+}
+
+// match represents a match on an order. An order may have many matches.
+type match struct {
+	MatchID       string `json:"matchID"`
+	Status        string `json:"status"`
+	Revoked       bool   `json:"revoked"`
+	Rate          uint64 `json:"rate"`
+	Qty           uint64 `json:"qty"`
+	Side          string `json:"side"`
+	FeeRate       uint64 `json:"feeRate"`
+	Swap          string `json:"swap,omitempty"`
+	CounterSwap   string `json:"counterSwap,omitempty"`
+	Redeem        string `json:"redeem,omitempty"`
+	CounterRedeem string `json:"counterRedeem,omitempty"`
+	Refund        string `json:"refund,omitempty"`
+	Stamp         uint64 `json:"stamp"`
+	IsCancel      bool   `json:"isCancel"`
 }
 
 // openWalletForm is information necessary to open a wallet.

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -60,24 +60,24 @@ type myOrdersResponse []*myOrder
 
 // myOrder represents an order when responding to the myorders route.
 type myOrder struct {
-	Host        string  `json:"host"`
-	MarketName  string  `json:"marketName"`
-	BaseID      uint32  `json:"baseID"`
-	QuoteID     uint32  `json:"quoteID"`
-	ID          string  `json:"id"`
-	Type        string  `json:"type"`
-	Sell        bool    `json:"sell"`
-	Stamp       uint64  `json:"stamp"`
-	Age         string  `json:"age"`
-	Rate        uint64  `json:"rate,omitempty"`
-	Quantity    uint64  `json:"quantity"`
-	Filled      uint64  `json:"filled"`
-	Settled     uint64  `json:"settled"`
-	Status      string  `json:"status"`
-	Cancelling  bool    `json:"cancelling,omitempty"`
-	Canceled    bool    `json:"canceled,omitempty"`
-	TimeInForce string  `json:"tif,omitempty"`
-	Matches     []match `json:"matches,omitempty"`
+	Host        string   `json:"host"`
+	MarketName  string   `json:"marketName"`
+	BaseID      uint32   `json:"baseID"`
+	QuoteID     uint32   `json:"quoteID"`
+	ID          string   `json:"id"`
+	Type        string   `json:"type"`
+	Sell        bool     `json:"sell"`
+	Stamp       uint64   `json:"stamp"`
+	Age         string   `json:"age"`
+	Rate        uint64   `json:"rate,omitempty"`
+	Quantity    uint64   `json:"quantity"`
+	Filled      uint64   `json:"filled"`
+	Settled     uint64   `json:"settled"`
+	Status      string   `json:"status"`
+	Cancelling  bool     `json:"cancelling,omitempty"`
+	Canceled    bool     `json:"canceled,omitempty"`
+	TimeInForce string   `json:"tif,omitempty"`
+	Matches     []*match `json:"matches,omitempty"`
 }
 
 // match represents a match on an order. An order may have many matches.


### PR DESCRIPTION
This adds new `[]match` to the `myOrder` struct returned by the rpcserver's `myorders` route.


Closes #728 