### PR TITLE
client/core: locked wallet means missing password or locked backend

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -565,7 +565,7 @@ func (dcr *ExchangeWallet) OwnsAddress(address string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return va.IsMine, nil
+	return va.IsMine && dcr.acct == va.Account, nil
 }
 
 // Balance should return the total available funds in the wallet. Note that

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1027,67 +1027,75 @@ func (c *Core) encryptionKey(pw []byte) (encrypt.Crypter, error) {
 	}
 	return crypter, nil
 }
+func (c *Core) storeDepositAddress(wdbID []byte, addr string) error {
+	// Store the new address in the DB.
+	dbWallet, err := c.db.Wallet(wdbID)
+	if err != nil {
+		return fmt.Errorf("error retreiving DB wallet: %w", err)
+	}
+	dbWallet.Address = addr
+	return c.db.UpdateWallet(dbWallet)
+}
+
+func (c *Core) connectAndUpdateWallet(w *xcWallet) error {
+	assetID := w.AssetID
+	c.log.Infof("Connecting wallet for %s", unbip(assetID))
+	addr := w.currentDepositAddress()
+	newAddr, err := c.connectWallet(w)
+	if err != nil {
+		return err // core.Error with code connectWalletErr
+	}
+	if newAddr != addr {
+		c.log.Infof("New deposit address for %v wallet: %v", unbip(assetID), newAddr)
+		if err = c.storeDepositAddress(w.dbID, newAddr); err != nil {
+			return err
+		}
+	}
+	// First update balances since it is included in WalletState. Ignore errors
+	// because some wallets may not reveal balance until unlocked.
+	_, err = c.walletBalances(w)
+	if err != nil {
+		// Warn because the balances will be stale.
+		c.log.Warnf("Could not retrieve balances from %s wallet: %v", unbip(assetID), err)
+	}
+
+	walletState := w.state() // includes updated balances
+	c.setUserWalletState(walletState)
+	c.notify(newWalletStateNote(walletState))
+	return nil
+}
 
 // connectedWallet fetches a wallet and will connect the wallet if it is not
-// already connected.
+// already connected. If the wallet gets connected, this also emits WalletState
+// and WalletBalance notification.
 func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 	wallet, exists := c.wallet(assetID)
 	if !exists {
 		return nil, newError(missingWalletErr, "no configured wallet found %s (%d)", unbip(assetID), assetID)
 	}
 	if !wallet.connected() {
-		c.log.Infof("Connecting wallet for %s", unbip(assetID))
-		_, err := c.connectWallet(wallet)
+		err := c.connectAndUpdateWallet(wallet)
 		if err != nil {
-			return nil, err // core.Error with code connectWalletErr
-		}
-		// If first connecting the wallet, try to get the balance. Ignore errors
-		// here with the assumption that some wallets may not reveal balance
-		// until unlocked.
-		_, err = c.walletBalances(wallet)
-		if err != nil {
-			// Warn because the balances will be stale.
-			c.log.Warnf("Could not retrieve balances %s wallet: %v", unbip(assetID), err)
+			return nil, err
 		}
 	}
 	return wallet, nil
 }
 
-// connectWallet connects to wallet and validates the known deposit address
-// after successful connection.
-// If address found & it does not belong to wallet, it generates new address,
-// then updates xcWallet and dbWallet.
-// If connectWallet generates new address then first returned bool will
-// be set to true.
-func (c *Core) connectWallet(w *xcWallet) (generatedNewAddr bool, err error) {
-	err = w.Connect(c.ctx)
+// connectWallet connects to the wallet and returns the deposit address
+// validated by the xcWallet after connecting. If the wallet backend is still
+// synching, this also starts a goroutine to monitor sync status, emitting
+// WalletStateNotes on each progress update.
+func (c *Core) connectWallet(w *xcWallet) (depositAddr string, err error) {
+	err = w.Connect(c.ctx) // ensures valid deposit address
 	if err != nil {
-		return false, codedError(connectWalletErr, err)
+		return "", codedError(connectWalletErr, err)
 	}
-	// If xcWallet has deposit address ensure that it belongs to connected
-	// wallet.
-	w.mtx.RLock()
-	addr := w.address
-	w.mtx.RUnlock()
-	var mine bool
 
-	if addr != "" {
-		mine, err = w.OwnsAddress(addr)
-		if err != nil {
-			return generatedNewAddr, err
-		}
-		// If Existing address doesn't belong to connected wallet,
-		// generate new one.
-		if !mine {
-			nAddr, err := c.newDepositAddress(w)
-			if err != nil {
-				return generatedNewAddr, err
-			}
-			generatedNewAddr = true
-			c.log.Warnf("[%v]: Deposit address %v does not belong to connected wallet"+
-				", generated new address: %v", unbip(w.AssetID), addr, nAddr)
-		}
-	}
+	w.mtx.RLock()
+	defer w.mtx.RUnlock()
+	depositAddr = w.address
+
 	// If the wallet is not synced, start a loop to check the sync status until
 	// it is.
 	if !w.synced {
@@ -1125,14 +1133,16 @@ func (c *Core) connectWallet(w *xcWallet) (generatedNewAddr bool, err error) {
 			}
 		}()
 	}
-	return generatedNewAddr, nil
+
+	return
 }
 
 // Connect to the wallet if not already connected. Unlock the wallet if not
 // already unlocked.
 func (c *Core) connectAndUnlock(crypter encrypt.Crypter, wallet *xcWallet) error {
 	if !wallet.connected() {
-		_, err := c.connectWallet(wallet)
+		c.log.Infof("Connecting wallet for %s", unbip(wallet.AssetID))
+		err := c.connectAndUpdateWallet(wallet)
 		if err != nil {
 			return err
 		}
@@ -1348,7 +1358,7 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 		return fmt.Errorf("error loading wallet for %d -> %s: %w", assetID, symbol, err)
 	}
 
-	_, err = c.connectWallet(wallet)
+	dbWallet.Address, err = c.connectWallet(wallet)
 	if err != nil {
 		return err
 	}
@@ -1362,12 +1372,6 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 	if err != nil {
 		return initErr("%s wallet authentication error: %v", symbol, err)
 	}
-
-	dbWallet.Address, err = wallet.Address()
-	if err != nil {
-		return initErr("error getting deposit address for %s: %v", symbol, err)
-	}
-	wallet.setAddress(dbWallet.Address)
 
 	// Store the wallet in the database.
 	err = c.db.UpdateWallet(dbWallet)
@@ -1564,7 +1568,7 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 	}
 
 	// Must connect to ensure settings are good.
-	generatedNewAddress, err := c.connectWallet(wallet)
+	dbWallet.Address, err = c.connectWallet(wallet)
 	if err != nil {
 		return err
 	}
@@ -1574,11 +1578,6 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 			wallet.Disconnect()
 			return newError(walletAuthErr, "wallet successfully connected, but errored unlocking. reconfiguration not saved: %v", err)
 		}
-	}
-
-	// If connectWallet generated new xcWallet address store it on dbWallet.
-	if generatedNewAddress {
-		dbWallet.Address = wallet.address
 	}
 
 	err = c.db.UpdateWallet(dbWallet)
@@ -1608,7 +1607,7 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 	}
 	c.wallets[assetID] = wallet
 
-	details := fmt.Sprintf("Configuration for %s wallet has been updated.", unbip(assetID))
+	details := fmt.Sprintf("Configuration for %s wallet has been updated. Deposit address = %s", unbip(assetID), wallet.address)
 	c.notify(newWalletConfigNote(SubjectWalletConfigurationUpdated, details, db.Success, wallet.state()))
 
 	// Clear any existing tickGovernors for suspect matches.
@@ -1659,7 +1658,7 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 	// Connect if necessary.
 	wasConnected := wallet.connected()
 	if !wasConnected {
-		if _, err = c.connectWallet(wallet); err != nil {
+		if err = c.connectAndUpdateWallet(wallet); err != nil {
 			return newError(connectionErr, "SetWalletPassword connection error: %v", err)
 		}
 	}
@@ -1702,46 +1701,30 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 	return nil
 }
 
-// newDepositAddress retrieves a new deposit address from given xcWallet.
-func (c *Core) newDepositAddress(w *xcWallet) (string, error) {
-	if !w.connected() {
-		return "", fmt.Errorf("cannot get address from unconnected %s wallet",
-			unbip(w.AssetID))
-	}
-
-	addr, err := w.Address()
-	if err != nil {
-		return "", fmt.Errorf("%s Wallet.Address error: %w", unbip(w.AssetID), err)
-	}
-	// Set xcWallet's new address
-	w.setAddress(addr)
-
-	dbWallet, err := c.db.Wallet(w.dbID)
-	if err != nil {
-		return "", fmt.Errorf("error retreiving DB wallet: %w", err)
-	}
-	dbWallet.Address = addr
-	err = c.db.UpdateWallet(dbWallet)
-	if err != nil {
-		return "", fmt.Errorf("UpdateWallet error for %s: %w", unbip(w.AssetID), err)
-	}
-	// Update wallet state on user struct
-	walletState := w.state()
-	c.setUserWalletState(walletState)
-	c.notify(newWalletStateNote(walletState))
-
-	return addr, nil
-}
-
 // NewDepositAddress retrieves a new deposit address from the specified asset's
-// wallet and saves it to the database.
+// wallet, saves it to the database, and emits a notification.
 func (c *Core) NewDepositAddress(assetID uint32) (string, error) {
 	w, exists := c.wallet(assetID)
 	if !exists {
 		return "", newError(missingWalletErr, "no wallet found for %s", unbip(assetID))
 	}
 
-	return c.newDepositAddress(w)
+	// Retrieve a fresh deposit address.
+	addr, err := w.refreshDepositAddress()
+	if err != nil {
+		return "", err
+	}
+
+	if err = c.storeDepositAddress(w.dbID, addr); err != nil {
+		return "", err
+	}
+
+	// Update wallet state in the User data struct and emit a WalletStateNote.
+	walletState := w.state()
+	c.setUserWalletState(walletState)
+	c.notify(newWalletStateNote(walletState))
+
+	return addr, nil
 }
 
 // AutoWalletConfig attempts to load setting from a wallet package's
@@ -2071,7 +2054,7 @@ func (c *Core) Login(pw []byte) (*LoginResult, error) {
 	// wallet is needed for active trades, it will be unlocked in
 	// resolveActiveTrades and the balance updated there.
 	var wg sync.WaitGroup
-	var connectCount, balanceCount uint32
+	var connectCount uint32
 	c.walletMtx.Lock()
 	walletCount := len(c.wallets)
 	for _, wallet := range c.wallets {
@@ -2079,7 +2062,7 @@ func (c *Core) Login(pw []byte) (*LoginResult, error) {
 		go func(wallet *xcWallet) {
 			defer wg.Done()
 			if !wallet.connected() {
-				_, err := c.connectWallet(wallet)
+				err := c.connectAndUpdateWallet(wallet)
 				if err != nil {
 					c.log.Errorf("Unable to connect to %s wallet (start and sync wallets BEFORE starting dex!): %v",
 						unbip(wallet.AssetID), err)
@@ -2087,16 +2070,12 @@ func (c *Core) Login(pw []byte) (*LoginResult, error) {
 				}
 			}
 			atomic.AddUint32(&connectCount, 1)
-			_, err := c.walletBalances(wallet)
-			if err == nil {
-				atomic.AddUint32(&balanceCount, 1)
-			}
 		}(wallet)
 	}
 	c.walletMtx.Unlock()
 	wg.Wait()
 	if walletCount > 0 {
-		c.log.Infof("Connected to %d of %d wallets. Updated %d balances.", connectCount, walletCount, balanceCount)
+		c.log.Infof("Connected to %d of %d wallets.", connectCount, walletCount)
 	}
 
 	loaded := c.resolveActiveTrades(crypter)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1027,6 +1027,7 @@ func (c *Core) encryptionKey(pw []byte) (encrypt.Crypter, error) {
 	}
 	return crypter, nil
 }
+
 func (c *Core) storeDepositAddress(wdbID []byte, addr string) error {
 	// Store the new address in the DB.
 	dbWallet, err := c.db.Wallet(wdbID)
@@ -1053,7 +1054,7 @@ func (c *Core) connectAndUpdateWallet(w *xcWallet) error {
 	}
 	// First update balances since it is included in WalletState. Ignore errors
 	// because some wallets may not reveal balance until unlocked.
-	_, err = c.walletBalances(w)
+	_, err = c.updateWalletBalance(w)
 	if err != nil {
 		// Warn because the balances will be stale.
 		c.log.Warnf("Could not retrieve balances from %s wallet: %v", unbip(assetID), err)
@@ -1162,28 +1163,40 @@ func (c *Core) connectAndUnlock(crypter encrypt.Crypter, wallet *xcWallet) error
 	return nil
 }
 
-// walletBalances retrieves balances for the wallet.
-func (c *Core) walletBalances(wallet *xcWallet) (*WalletBalance, error) {
-	c.connMtx.RLock()
-	defer c.connMtx.RUnlock()
+// walletBalance gets the xcWallet's current WalletBalance, which includes the
+// db.Balance plus order/contract locked amounts. The data is not stored. Use
+// updateWalletBalance instead to also update xcWallet.balance and the DB.
+func (c *Core) walletBalance(wallet *xcWallet) (*WalletBalance, error) {
 	bal, err := wallet.Balance()
 	if err != nil {
 		return nil, err
 	}
 	contractLockedAmt, orderLockedAmt := c.lockedAmounts(wallet.AssetID)
-	walletBal := &WalletBalance{
+	return &WalletBalance{
 		Balance: &db.Balance{
 			Balance: *bal,
 			Stamp:   time.Now(),
 		},
-		ContractLocked: contractLockedAmt,
 		OrderLocked:    orderLockedAmt,
+		ContractLocked: contractLockedAmt,
+	}, nil
+}
+
+// updateWalletBalance retrieves balances for the wallet, updates
+// xcWallet.balance and the balance in the DB, and emits a BalanceNote.
+func (c *Core) updateWalletBalance(wallet *xcWallet) (*WalletBalance, error) {
+	walletBal, err := c.walletBalance(wallet)
+	if err != nil {
+		return nil, err
 	}
 	wallet.setBalance(walletBal)
+
+	// Store the db.Balance.
 	err = c.db.UpdateBalance(wallet.dbID, walletBal.Balance)
 	if err != nil {
 		return nil, fmt.Errorf("error updating %s balance in database: %w", unbip(wallet.AssetID), err)
 	}
+
 	c.notify(newBalanceNote(wallet.AssetID, walletBal))
 	return walletBal, nil
 }
@@ -1192,9 +1205,9 @@ func (c *Core) walletBalances(wallet *xcWallet) (*WalletBalance, error) {
 // swaps (contractLocked) and the total amount locked by orders for future
 // swaps (orderLocked). Only applies to trades where the specified assetID is
 // the fromAssetID.
-//
-// The connMtx lock MUST be held for reads.
 func (c *Core) lockedAmounts(assetID uint32) (contractLocked, orderLocked uint64) {
+	c.connMtx.RLock()
+	defer c.connMtx.RUnlock()
 	for _, dc := range c.conns {
 		dc.tradeMtx.RLock()
 		for _, tracker := range dc.trades {
@@ -1224,7 +1237,7 @@ func (c *Core) updateBalances(assets assetMap) {
 			c.log.Errorf("non-existent %d wallet should exist", assetID)
 			continue
 		}
-		_, err := c.walletBalances(w)
+		_, err := c.updateWalletBalance(w)
 		if err != nil {
 			c.log.Errorf("error updating %q balance: %v", unbip(assetID), err)
 			continue
@@ -1354,9 +1367,9 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 
 	dbWallet := &db.Wallet{
 		AssetID:     assetID,
-		Balance:     &db.Balance{},
 		Settings:    form.Config,
 		EncryptedPW: encPW,
+		// Balance and Address are set after connect.
 	}
 
 	wallet, err := c.loadWallet(dbWallet)
@@ -1376,21 +1389,20 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 
 	err = wallet.Unlock(crypter)
 	if err != nil {
-		return initErr("%s wallet authentication error: %v", symbol, err)
+		return initErr("%s wallet authentication error: %w", symbol, err)
 	}
+
+	balances, err := c.walletBalance(wallet)
+	if err != nil {
+		return initErr("error getting wallet balance for %s: %w", symbol, err)
+	}
+	wallet.balance = balances           // update xcWallet's WalletBalance
+	dbWallet.Balance = balances.Balance // store the db.Balance
 
 	// Store the wallet in the database.
 	err = c.db.UpdateWallet(dbWallet)
 	if err != nil {
-		return initErr("error storing wallet credentials: %v", err)
-	}
-
-	// walletBalances will update the database record with the current balance.
-	// UpdateWallet must be called to create the database record before
-	// walletBalances is used.
-	balances, err := c.walletBalances(wallet)
-	if err != nil {
-		return initErr("error getting wallet balance for %s: %v", symbol, err)
+		return initErr("error storing wallet credentials: %w", err)
 	}
 
 	c.log.Infof("Created %s wallet. Balance available = %d / "+
@@ -1405,6 +1417,7 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 
 	c.refreshUser()
 
+	c.notify(newBalanceNote(assetID, balances)) // redundant with wallet state note?
 	c.notify(newWalletStateNote(wallet.state()))
 
 	return nil
@@ -1413,34 +1426,35 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 // loadWallet uses the data from the database to construct a new exchange
 // wallet. The returned wallet is running but not connected.
 func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
-	c.connMtx.RLock() // required to calculate contractlocked amount
-	defer c.connMtx.RUnlock()
-	contractLockedAmt, orderLockedAmt := c.lockedAmounts(dbWallet.AssetID)
-	wallet := &xcWallet{
-		AssetID: dbWallet.AssetID,
+	// Create the client/asset.Wallet.
+	assetID := dbWallet.AssetID
+	walletCfg := &asset.WalletConfig{
+		Settings: dbWallet.Settings,
+		TipChange: func(err error) {
+			c.tipChange(assetID, err)
+		},
+	}
+	logger := c.log.SubLogger(unbip(assetID))
+	w, err := asset.Setup(assetID, walletCfg, logger, c.net)
+	if err != nil {
+		return nil, fmt.Errorf("error creating wallet: %w", err)
+	}
+
+	// Construct the unconnected xcWallet.
+	contractLockedAmt, orderLockedAmt := c.lockedAmounts(assetID)
+	return &xcWallet{
+		Wallet:    w,
+		connector: dex.NewConnectionMaster(w),
+		AssetID:   assetID,
 		balance: &WalletBalance{
 			Balance:        dbWallet.Balance,
-			ContractLocked: contractLockedAmt,
 			OrderLocked:    orderLockedAmt,
+			ContractLocked: contractLockedAmt,
 		},
 		encPW:   dbWallet.EncryptedPW,
 		address: dbWallet.Address,
 		dbID:    dbWallet.ID(),
-	}
-	walletCfg := &asset.WalletConfig{
-		Settings: dbWallet.Settings,
-		TipChange: func(err error) {
-			c.tipChange(dbWallet.AssetID, err)
-		},
-	}
-	logger := c.log.SubLogger(unbip(dbWallet.AssetID))
-	w, err := asset.Setup(dbWallet.AssetID, walletCfg, logger, c.net)
-	if err != nil {
-		return nil, fmt.Errorf("error creating wallet: %w", err)
-	}
-	wallet.Wallet = w
-	wallet.connector = dex.NewConnectionMaster(w)
-	return wallet, nil
+	}, nil
 }
 
 // WalletState returns the *WalletState for the asset ID.
@@ -1471,7 +1485,7 @@ func (c *Core) OpenWallet(assetID uint32, appPW []byte) error {
 	}
 
 	state := wallet.state()
-	balances, err := c.walletBalances(wallet)
+	balances, err := c.updateWalletBalance(wallet)
 	if err != nil {
 		return err
 	}
@@ -1552,11 +1566,9 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 	dbWallet := &db.Wallet{
 		AssetID:     oldWallet.AssetID,
 		Settings:    cfg,
+		Balance:     &db.Balance{}, // in case retrieving new balance after connect fails
 		EncryptedPW: oldWallet.encPW,
 		Address:     oldWallet.address,
-	}
-	if oldWallet.balance != nil {
-		dbWallet.Balance = oldWallet.balance.Balance
 	}
 	// Reload the wallet with the new settings.
 	wallet, err := c.loadWallet(dbWallet)
@@ -1577,8 +1589,18 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 		err := wallet.Unlock(crypter)
 		if err != nil {
 			wallet.Disconnect()
-			return newError(walletAuthErr, "wallet successfully connected, but errored unlocking. reconfiguration not saved: %v", err)
+			return newError(walletAuthErr, "wallet successfully connected, but failed to unlock. "+
+				"reconfiguration not saved: %v", err)
 		}
+	}
+
+	balances, err := c.walletBalance(wallet)
+	if err != nil {
+		c.log.Warnf("Error getting balance for wallet %s: %v", unbip(assetID), err)
+		// Do not fail in case this requires an unlocked wallet.
+	} else {
+		wallet.balance = balances           // update xcWallet's WalletBalance
+		dbWallet.Balance = balances.Balance // store the db.Balance
 	}
 
 	err = c.db.UpdateWallet(dbWallet)
@@ -1587,6 +1609,7 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 		return newError(dbErr, "error saving wallet configuration: %v", err)
 	}
 
+	// Update all relevant trackedTrades' toWallet and fromWallet.
 	c.connMtx.RLock()
 	for _, dc := range c.conns {
 		dc.tradeMtx.RLock()
@@ -1608,6 +1631,7 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 	}
 	c.wallets[assetID] = wallet
 
+	c.notify(newBalanceNote(assetID, balances)) // redundant with wallet config note?
 	details := fmt.Sprintf("Configuration for %s wallet has been updated. Deposit address = %s", unbip(assetID), wallet.address)
 	c.notify(newWalletConfigNote(SubjectWalletConfigurationUpdated, details, db.Success, wallet.state()))
 
@@ -2052,9 +2076,9 @@ func (c *Core) Login(pw []byte) (*LoginResult, error) {
 	// Attempt to connect to and retrieve balance from all known wallets. It is
 	// not an error if we can't connect, unless we need the wallet for active
 	// trades, but that condition is checked later in resolveActiveTrades.
-	// Ignoring walletBalances errors here too, to accommodate wallets that must
-	// be unlocked to get the balance. We won't try to unlock here, but if the
-	// wallet is needed for active trades, it will be unlocked in
+	// Ignore updateWalletBalance errors here too, to accommodate wallets that
+	// must be unlocked to get the balance. We won't try to unlock here, but if
+	// the wallet is needed for active trades, it will be unlocked in
 	// resolveActiveTrades and the balance updated there.
 	var wg sync.WaitGroup
 	var connectCount uint32
@@ -3097,13 +3121,13 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	return nil
 }
 
-// AssetBalance retrieves the current wallet balance.
+// AssetBalance retrieves and updates the current wallet balance.
 func (c *Core) AssetBalance(assetID uint32) (*WalletBalance, error) {
 	wallet, err := c.connectedWallet(assetID)
 	if err != nil {
 		return nil, fmt.Errorf("%d -> %s wallet error: %w", assetID, unbip(assetID), err)
 	}
-	return c.walletBalances(wallet)
+	return c.updateWalletBalance(wallet)
 }
 
 // initialize pulls the known DEXes from the database and attempts to connect

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -13,18 +13,19 @@ import (
 	"decred.org/dcrdex/dex/encrypt"
 )
 
-// xcWallet is a wallet.
+// xcWallet is a wallet. Use (*Core).loadWallet to construct a xcWallet.
 type xcWallet struct {
 	asset.Wallet
-	connector    *dex.ConnectionMaster
-	AssetID      uint32
+	connector *dex.ConnectionMaster
+	AssetID   uint32
+	dbID      []byte
+	encPW     []byte // empty means wallet not password protected
+
 	mtx          sync.RWMutex
-	hookedUp     bool
 	balance      *WalletBalance
-	encPW        []byte
 	pw           string
 	address      string
-	dbID         []byte
+	hookedUp     bool
 	synced       bool
 	syncProgress float32
 }


### PR DESCRIPTION
This resolves issues with the internal wallet lock state that could occur when starting dexc with both an unlocked wallet and active orders or swaps.

It also refactors much of the wallet balance code including updating balance on ReconfigureWallet.

These changes are in 2nd and third commits: https://github.com/decred/dcrdex/compare/d695d6e...de38eb6. The [first commit](https://github.com/decred/dcrdex/pull/910/commits/d695d6e61fc509d71c84e81f69eca009fc5bad07) is a follow up on the deposit address validation changes. 