### PR TITLE
app: require auth for user and defaultwalletcfg API endpoints

### DIFF
--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1108,8 +1108,8 @@ func TestServer(t *testing.T) {
 	numBuys = 10
 	numSells = 10
 	feedPeriod = 5000 * time.Millisecond
-	initialize := true
-	register := true
+	initialize := false
+	register := false
 	forceDisconnectWallet = true
 	gapWidthFactor = 0.2
 	randomPokes = true

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -41,14 +41,12 @@ export default class RegistrationPage extends BasePage {
     this.walletForm = new NewWalletForm(app, page.newWalletForm, () => {
       this.changeForm(page.newWalletForm, page.dexAddrForm)
     })
-    this.walletForm.setAsset(app.assets[DCR_ID])
 
     // OPEN DCR WALLET
     // This form is only shown if there is a wallet, but it's not open.
     bindOpenWallet(app, page.unlockWalletForm, () => {
       this.changeForm(page.unlockWalletForm, page.dexAddrForm)
     })
-    page.unlockWalletForm.setAsset(app.assets[DCR_ID])
 
     // ADD DEX
     // tls certificate upload
@@ -67,6 +65,14 @@ export default class RegistrationPage extends BasePage {
     bindForm(page.confirmRegForm, page.submitConfirm, () => { this.registerDEX() })
 
     // Attempt to load the dcrwallet configuration from the default location.
+    if (app.user.authed) this.auth()
+  }
+
+  // auth should be called once user is known to be authed with the server.
+  async auth () {
+    await app.fetchUser()
+    this.walletForm.setAsset(app.assets[DCR_ID])
+    this.page.unlockWalletForm.setAsset(app.assets[DCR_ID])
     this.walletForm.loadDefaults()
   }
 
@@ -118,7 +124,7 @@ export default class RegistrationPage extends BasePage {
       Doc.show(page.appErrMsg)
       return
     }
-    app.user.authed = true // no need to call app.fetchUser(), much hasn't changed.
+    this.auth()
     app.updateMenuItemsDisplay()
     this.changeForm(page.appPWForm, page.newWalletForm)
   }

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -201,7 +201,7 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 	mux.Group(func(web chi.Router) {
 		// The register page and settings page are always allowed.
 		// The register page performs init if needed, along with
-		// initial setup and is also used to register more DEXs
+		// initial setup and settings is used to register more DEXs
 		// after initial setup.
 		web.Get(registerRoute, s.handleRegister)
 		web.Get(settingsRoute, s.handleSettings)
@@ -235,12 +235,6 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 		r.Use(middleware.AllowContentType("application/json"))
 		r.Post("/init", s.apiInit)
 
-		// TODO: Allow register page to not require /user and /defaultwalletcfg
-		// until authorized with a cookie. These currently must be accessible to
-		// set the app password on the browser.
-		r.Get("/user", s.apiUser)
-		r.Post("/defaultwalletcfg", s.apiDefaultWalletCfg)
-
 		r.Group(func(apiInit chi.Router) {
 			apiInit.Use(s.rejectUninited)
 			apiInit.Post("/login", s.apiLogin)
@@ -249,6 +243,8 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 
 		r.Group(func(apiAuth chi.Router) {
 			apiAuth.Use(s.rejectUnauthed)
+			apiAuth.Get("/user", s.apiUser)
+			apiAuth.Post("/defaultwalletcfg", s.apiDefaultWalletCfg)
 			apiAuth.Post("/register", s.apiRegister)
 			apiAuth.Post("/newwallet", s.apiNewWallet)
 			apiAuth.Post("/openwallet", s.apiOpenWallet)


### PR DESCRIPTION
re: https://github.com/decred/dcrdex/pull/753#discussion_r507247831

Moves the **/user** and **/defaultwalletcfg** endpoints behind the user auth middleware.