### PR TITLE
client/core: avoid potential wallet reconfigure deadlock

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -492,13 +492,18 @@ func newWallet(cfg *BTCCloneCFG, btcCfg *dexbtc.Config, node rpcClient) (*Exchan
 	}
 	cfg.Logger.Tracef("Redeem conf target set to %d blocks", redeemConfTarget)
 
+	// Make tipChange an asynchronous call to the opaque callback, which could
+	// take any amount of time and for which we do not need to wait.
+	tipChange := func(err error) {
+		go cfg.WalletCFG.TipChange(err)
+	}
 	return &ExchangeWallet{
 		node:                node,
 		wallet:              newWalletClient(node, cfg.Segwit, cfg.ChainParams),
 		symbol:              cfg.Symbol,
 		chainParams:         cfg.ChainParams,
 		log:                 cfg.Logger,
-		tipChange:           cfg.WalletCFG.TipChange,
+		tipChange:           tipChange,
 		fundingCoins:        make(map[outPoint]*utxo),
 		findRedemptionQueue: make(map[outPoint]*findRedemptionReq),
 		minNetworkVersion:   cfg.MinNetworkVersion,

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -480,11 +480,16 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, chainParams *cha
 	}
 	logger.Tracef("Redeem conf target set to %d blocks", redeemConfTarget)
 
+	// Make tipChange an asynchronous call to the opaque callback, which could
+	// take any amount of time and for which we do not need to wait.
+	tipChange := func(err error) {
+		go cfg.TipChange(err)
+	}
 	return &ExchangeWallet{
 		log:                 logger,
 		chainParams:         chainParams,
 		acct:                cfg.Settings["account"],
-		tipChange:           cfg.TipChange,
+		tipChange:           tipChange,
 		fundingCoins:        make(map[outPoint]*fundingCoin),
 		findRedemptionQueue: make(map[outPoint]*findRedemptionReq),
 		fallbackFeeRate:     fallbackFeesPerByte,

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -54,11 +54,13 @@ type WalletConfig struct {
 	// Settings are supplied by the user according the the WalletInfo's
 	// ConfigOpts.
 	Settings map[string]string
-	// TipChange is a function that will be called when the blockchain monitoring
-	// loop detects a new block. If the error supplied is nil, the client should
-	// check the confirmations on any negotiating swaps to see if action is
-	// needed. If the error is non-nil, the wallet monitoring loop encountered an
-	// error while retrieving tip information.
+	// TipChange is a function that will be called when the blockchain
+	// monitoring loop detects a new block. If the error supplied is nil, the
+	// client should check the confirmations on any negotiating swaps to see if
+	// action is needed. If the error is non-nil, the wallet monitoring loop
+	// encountered an error while retrieving tip information. This function
+	// should not be blocking, and Wallet implementations should not rely on any
+	// specific side effect of the function call.
 	TipChange func(error)
 }
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1452,7 +1452,7 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 	walletCfg := &asset.WalletConfig{
 		Settings: dbWallet.Settings,
 		TipChange: func(err error) {
-			go c.tipChange(assetID, err)
+			c.tipChange(assetID, err)
 		},
 	}
 	logger := c.log.SubLogger(unbip(assetID))

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1452,7 +1452,11 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 	walletCfg := &asset.WalletConfig{
 		Settings: dbWallet.Settings,
 		TipChange: func(err error) {
-			c.tipChange(assetID, err)
+			// asset.Wallet implementations should not need wait for the
+			// callback, as they don't know what it is, and will likely launch
+			// TipChange as a goroutine. However, guard against the possibility
+			// of deadlocking a Core method that calls Wallet.Disconnect.
+			go c.tipChange(assetID, err)
 		},
 	}
 	logger := c.log.SubLogger(unbip(assetID))

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1590,7 +1590,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 		Settings:    cfg,
 		Balance:     &db.Balance{}, // in case retrieving new balance after connect fails
 		EncryptedPW: oldWallet.encPW,
-		Address:     oldWallet.address,
+		Address:     oldWallet.currentDepositAddress(),
 	}
 	// Reload the wallet with the new settings.
 	wallet, err := c.loadWallet(dbWallet)


### PR DESCRIPTION
This prevents a deadlock on wallet reconfigure that would happen if the client asset backend's tip change handler (a Core method) attempted to acquire the Core.walletMtx because it was already locked in ReconfigureWallet.  The deadlock was on `oldWallet.Disconnect` inside `ReconfigureWallet` because it would be waiting for the block monitor goroutine to return that was likely to itself be waiting on `Core`'s `walletMtx` (e.g. monitorBlocks>checkForNewBlocks>tipChange).

I hit the deadlock in testing release-0.1 today.

The `tipChange` goroutine that tried to re-lock `walletMtx` inside `refreshUser` via `updateBalances`:

```
goroutine 15952 [semacquire, 5 minutes]:
sync.runtime_SemacquireMutex(0xc0002b1ef4, 0x0, 0x0)
	/home/jon/go115/src/runtime/sema.go:71 +0x47
sync.(*RWMutex).RLock(0xc0002b1ee8)
	/home/jon/go115/src/sync/rwmutex.go:50 +0xa6
decred.org/dcrdex/client/core.(*Core).SupportedAssets(0xc0002b1e40, 0x0)
	/home/jon/github/decred/dcrdex/client/core/core.go:1269 +0xc8
decred.org/dcrdex/client/core.(*Core).refreshUser(0xc0002b1e40)
	/home/jon/github/decred/dcrdex/client/core/core.go:1302 +0xbc
decred.org/dcrdex/client/core.(*Core).updateBalances(0xc0002b1e40, 0xc000fbda68)
	/home/jon/github/decred/dcrdex/client/core/core.go:1244 +0x3ce
decred.org/dcrdex/client/core.(*Core).tipChange(0xc0002b1e40, 0xc00000002a, 0x0, 0x0)
	/home/jon/github/decred/dcrdex/client/core/core.go:4399 +0x545
decred.org/dcrdex/client/core.(*Core).loadWallet.func1(0x0, 0x0)
	/home/jon/github/decred/dcrdex/client/core/core.go:1433 +0x5d
decred.org/dcrdex/client/asset/dcr.(*ExchangeWallet).checkForNewBlocks(0xc004c9a240)
	/home/jon/github/decred/dcrdex/client/asset/dcr/dcr.go:2341 +0x476
decred.org/dcrdex/client/asset/dcr.(*ExchangeWallet).monitorBlocks(0xc004c9a240, 0x1357da0, 0xc0012482c0)
	/home/jon/github/decred/dcrdex/client/asset/dcr/dcr.go:2309 +0xbb
decred.org/dcrdex/client/asset/dcr.(*ExchangeWallet).Connect.func1(0xc000500550, 0xc004c9a240, 0x1357da0, 0xc0012482c0)
	/home/jon/github/decred/dcrdex/client/asset/dcr/dcr.go:529 +0x8a
created by decred.org/dcrdex/client/asset/dcr.(*ExchangeWallet).Connect
	/home/jon/github/decred/dcrdex/client/asset/dcr/dcr.go:527 +0xdfa
```

The `ReconfigureWallet` goroutine that was holding `walletMtx` and then called `oldWallet.Disconnect`:

```
goroutine 16881 [semacquire, 5 minutes]:
sync.runtime_Semacquire(0xc000500558)
	/home/jon/go115/src/runtime/sema.go:56 +0x45
sync.(*WaitGroup).Wait(0xc000500550)
	/home/jon/go115/src/sync/waitgroup.go:130 +0xe5
decred.org/dcrdex/dex.(*ConnectionMaster).Disconnect(0xc0002422d0)
	/home/jon/github/decred/dcrdex/dex/runner.go:113 +0x89
decred.org/dcrdex/client/core.(*xcWallet).Disconnect(0xc0002743c0)
	/home/jon/github/decred/dcrdex/client/core/wallet.go:211 +0x57
decred.org/dcrdex/client/core.(*Core).ReconfigureWallet(0xc0002b1e40, 0xc00024957d, 0x1, 0x1, 0xc00000002a, 0xc004ed13b0, 0x0, 0x0)
	/home/jon/github/decred/dcrdex/client/core/core.go:1629 +0x1707
decred.org/dcrdex/client/webserver.(*WebServer).apiReconfig(0xc000900000, 0x7faee57ef560, 0xc001248180, 0xc0008b5f00)
	/home/jon/github/decred/dcrdex/client/webserver/api.go:437 +0x242
```

`Disconnect` was deadlocked because `ExchangeWallet.Connect` was waiting forever for its `monitorBlocks` goroutine.