### PR TITLE
client: don't lock in PromptShutdown, do it on Core shutdown

### DIFF
--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -72,6 +72,7 @@ func main() {
 	go func() {
 		for range killChan {
 			if clientCore.PromptShutdown() {
+				log.Infof("Shutting down...")
 				cancel()
 				return
 			}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1670,9 +1670,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 	c.wallets[assetID] = wallet
 	c.walletMtx.Unlock()
 
-	if oldWallet.connected() {
-		go oldWallet.Disconnect()
-	}
+	go oldWallet.Disconnect()
 
 	c.notify(newBalanceNote(assetID, balances)) // redundant with wallet config note?
 	details := fmt.Sprintf("Configuration for %s wallet has been updated. Deposit address = %s",
@@ -4563,8 +4561,6 @@ func (c *Core) tipChange(assetID uint32, nodeErr error) {
 // or if the user has confirmed they want to shutdown with active orders.
 func (c *Core) PromptShutdown() bool {
 	conns := c.dexConnections()
-
-
 	var haveActive bool
 	for _, dc := range conns {
 		if dc.hasActiveOrders() {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -891,11 +891,11 @@ func New(cfg *Config) (*Core, error) {
 
 // Run runs the core. Satisfies the runner.Runner interface.
 func (c *Core) Run(ctx context.Context) {
-	c.log.Infof("started DEX client core")
+	c.log.Infof("Starting DEX client core")
 	// Store the context as a field, since we will need to spawn new DEX threads
 	// when new accounts are registered.
 	c.ctx = ctx
-	c.initialize()
+	c.initialize() // connectDEX gets ctx for the wsConn
 	close(c.ready)
 
 	// The DB starts first and stops last.
@@ -913,11 +913,35 @@ func (c *Core) Run(ctx context.Context) {
 		c.latencyQ.Run(ctx)
 	}()
 
-	c.wg.Wait()
+	c.wg.Wait() // block here until all goroutines except DB complete
 
 	// Stop the DB after dexConnections and other goroutines are done.
 	stopDB()
 	dbWG.Wait()
+
+	// Lock and disconnect the wallets.
+	c.walletMtx.Lock()
+	for assetID, wallet := range c.wallets {
+		symb := strings.ToUpper(unbip(assetID))
+		c.log.Infof("Locking %s wallet", symb)
+		if err := wallet.Lock(); err != nil {
+			c.log.Errorf("Failed to lock %v wallet: %v", symb, err)
+		}
+		wallet.Disconnect()
+		delete(c.wallets, assetID)
+	}
+	c.walletMtx.Unlock()
+
+	// Clear account private keys and wait for the DEX ws connections that began
+	// shutting down on context cancellation.
+	c.connMtx.Lock()
+	defer c.connMtx.Unlock()
+	for _, dc := range c.conns {
+		// context should be canceled allowing just a Wait(), but just in case
+		// use Disconnect otherwise this could hang forever.
+		dc.connMaster.Disconnect()
+		dc.acct.lock()
+	}
 
 	c.log.Infof("DEX client core off")
 }
@@ -1110,7 +1134,7 @@ func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 // synching, this also starts a goroutine to monitor sync status, emitting
 // WalletStateNotes on each progress update.
 func (c *Core) connectWallet(w *xcWallet) (depositAddr string, err error) {
-	err = w.Connect(c.ctx) // ensures valid deposit address
+	err = w.Connect() // ensures valid deposit address
 	if err != nil {
 		return "", codedError(connectWalletErr, err)
 	}
@@ -4534,72 +4558,43 @@ func (c *Core) tipChange(assetID uint32, nodeErr error) {
 	c.updateBalances(assets)
 }
 
-// PromptShutdown asks confirmation to shutdown the dexc when has active orders.
-// If the user answers in the affirmative, the wallets are locked and true is
-// returned. The provided channel is used to allow an OS signal to break the
-// prompt and force the shutdown with out answering the prompt in the
-// affirmative.
+// PromptShutdown checks if their are active orders and asks confirmation to
+// shutdown if there are. The return value indicates if it is safe to stop Core
+// or if the user has confirmed they want to shutdown with active orders.
 func (c *Core) PromptShutdown() bool {
 	conns := c.dexConnections()
 
-	lockWallets := func() {
-		// Lock wallets
-		for _, w := range c.xcWallets() {
-			if w.connected() {
-				if err := w.Lock(); err != nil {
-					c.log.Errorf("error locking wallet: %v", err)
-				}
-			}
-		}
-		// If all wallets locked, lock each dex account.
-		for _, dc := range conns {
-			dc.acct.lock()
-		}
-	}
 
-	ok := true
+	var haveActive bool
 	for _, dc := range conns {
 		if dc.hasActiveOrders() {
-			ok = false
+			haveActive = true
 			break
 		}
 	}
 
-	if !ok {
-		fmt.Print("You have active orders. Shutting down now may result in failed swaps and account penalization.\n" +
-			"Do you want to quit anyway? ('y' to quit, 'n' or enter to abort shutdown):")
-		scanner := bufio.NewScanner(os.Stdin)
-		scanner.Scan()
-		if err := scanner.Err(); err != nil {
-			fmt.Printf("Input error: %v", err)
-			return false
-		}
-
-		switch strings.ToLower(scanner.Text()) {
-		case "y", "yes":
-			ok = true
-		case "n", "no":
-			fallthrough
-		default:
-			fmt.Println("Shutdown aborted.")
-		}
+	if !haveActive {
+		return true
 	}
 
-	if ok {
-		lockWallets()
+	fmt.Print("You have active orders. Shutting down now may result in failed swaps and account penalization.\n" +
+		"Do you want to quit anyway? ('yes' to quit, or enter to abort shutdown): ")
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan() // waiting for user input
+	if err := scanner.Err(); err != nil {
+		fmt.Printf("Input error: %v", err)
+		return false
 	}
 
-	return ok
-}
-
-// ForceShutdown shuts down the client, ignoring any active trades.
-func (c *Core) ForceShutdown() {
-	for _, wallet := range c.xcWallets() {
-		wallet.Lock()
+	switch resp := strings.ToLower(scanner.Text()); resp {
+	case "y", "yes":
+		return true
+	case "n", "no", "":
+	default: // anything else aborts, but warn about it
+		fmt.Printf("Unrecognized response %q. ", resp)
 	}
-	for _, dc := range c.dexConnections() {
-		dc.acct.lock()
-	}
+	fmt.Println("Shutdown aborted.")
+	return false
 }
 
 // convertAssetInfo converts from a *msgjson.Asset to the nearly identical

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -531,7 +531,6 @@ type TXCWallet struct {
 	locked            bool
 	changeCoin        *tCoin
 	syncStatus        func() (bool, float32, error)
-	connectWG         *sync.WaitGroup
 	confsMtx          sync.RWMutex
 	confs             map[string]uint32
 	confsErr          map[string]error
@@ -541,7 +540,6 @@ func newTWallet(assetID uint32) (*xcWallet, *TXCWallet) {
 	w := &TXCWallet{
 		changeCoin: &tCoin{id: encode.RandomBytes(36)},
 		syncStatus: func() (synced bool, progress float32, err error) { return true, 1, nil },
-		connectWG:  &sync.WaitGroup{},
 		confs:      make(map[string]uint32),
 		confsErr:   make(map[string]error),
 	}
@@ -567,10 +565,14 @@ func (w *TXCWallet) OwnsAddress(address string) (bool, error) {
 }
 
 func (w *TXCWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
-	return w.connectWG, w.connectErr
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		<-ctx.Done()
+		wg.Done()
+	}()
+	return &wg, w.connectErr
 }
-
-func (w *TXCWallet) Run(ctx context.Context) { <-ctx.Done() }
 
 func (w *TXCWallet) Balance() (*asset.Balance, error) {
 	if w.balErr != nil {
@@ -4767,7 +4769,10 @@ func TestReconfigureWallet(t *testing.T) {
 			return xyzWallet.Wallet, nil
 		},
 	})
-	xyzWallet.Connect(tCtx)
+	if err = xyzWallet.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	defer xyzWallet.Disconnect()
 
 	// Connect error
 	tXyzWallet.connectErr = tErr
@@ -5749,11 +5754,10 @@ func TestWalletSyncing(t *testing.T) {
 
 	noteFeed := tCore.NotificationFeed()
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
-	tDcrWallet.connectWG.Add(1)
-	defer tDcrWallet.connectWG.Done()
 	dcrWallet.synced = false
 	dcrWallet.syncProgress = 0
-	dcrWallet.Connect(tCtx)
+	_ = dcrWallet.Connect()
+	defer dcrWallet.Disconnect()
 
 	tStart := time.Now()
 	testDuration := 100 * time.Millisecond
@@ -5772,7 +5776,8 @@ func TestWalletSyncing(t *testing.T) {
 		t.Fatalf("connectWallet error: %v", err)
 	}
 
-	timeout := time.NewTimer(time.Second).C
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
 	var progressNotes int
 out:
 	for {
@@ -5786,15 +5791,16 @@ out:
 				break out
 			}
 			progressNotes++
-		case <-timeout:
+		case <-timeout.C:
 			t.Fatalf("timed out waiting for synced wallet note. Received %d progress notes", progressNotes)
 		}
 	}
 	// Should get 9 notes, but just make sure we get at least half of them to
 	// avoid github vm false positives.
-	if progressNotes < 5 {
-		t.Fatalf("expected 23 progress notes, got %d", progressNotes)
+	if progressNotes < 5 /* 9? */ {
+		t.Fatalf("expected 9 progress notes, got %d", progressNotes)
 	}
+	// t.Logf("got %d progress notes", progressNotes)
 }
 
 func TestParseCert(t *testing.T) {

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -172,9 +172,11 @@ func (w *xcWallet) connected() bool {
 }
 
 // Connect calls the dex.Connector's Connect method, sets the xcWallet.hookedUp
-// flag to true, and validates the deposit address.
-func (w *xcWallet) Connect(ctx context.Context) error {
-	err := w.connector.Connect(ctx)
+// flag to true, and validates the deposit address. Use Disconnect to cleanly
+// shutdown the wallet.
+func (w *xcWallet) Connect() error {
+	// No parent context; use Disconnect instead.
+	err := w.connector.Connect(context.Background())
 	if err != nil {
 		return err
 	}

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -180,8 +180,12 @@ func (w *xcWallet) Connect() error {
 	if err != nil {
 		return err
 	}
+	// Now that we are connected, we must Disconnect if any calls fail below
+	// since we are considering this wallet not "hookedUp".
+
 	synced, progress, err := w.SyncStatus()
 	if err != nil {
+		w.connector.Disconnect()
 		return err
 	}
 
@@ -191,12 +195,14 @@ func (w *xcWallet) Connect() error {
 	if haveAddress {
 		haveAddress, err = w.OwnsAddress(w.address)
 		if err != nil {
+			w.connector.Disconnect()
 			return err
 		}
 	}
 	if !haveAddress {
 		w.address, err = w.Address()
 		if err != nil {
+			w.connector.Disconnect()
 			return fmt.Errorf("%s Wallet.Address error: %w", unbip(w.AssetID), err)
 		}
 	}

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -108,26 +108,15 @@ func (c *ConnectionMaster) Connect(ctx context.Context) (err error) {
 	return err
 }
 
-// Disconnect closes the connection and waits for shutdown. This is safe to use
-// on an unconnected ConnectionMaster as long as it was constructed with
-// NewConnectionMaster.
+// Disconnect closes the connection and waits for shutdown.
 func (c *ConnectionMaster) Disconnect() {
-	c.mtx.RLock()
-	defer c.mtx.RUnlock()
-	if c.ctx == nil {
-		// The contextManager was never initialized via Connect.
-		return
-	}
 	c.cancel()
-	if c.wg == nil {
-		// The Connector failed on Connect, assigning a nil *WaitGroup.
-		return
-	}
+	c.mtx.RLock()
 	c.wg.Wait()
+	c.mtx.RUnlock()
 }
 
-// Wait waits for the the WaitGroup returned by Connect. This is NOT safe to use
-// unless Connect has already been called without error.
+// Wait waits for the the WaitGroup returned by Connect.
 func (c *ConnectionMaster) Wait() {
 	c.wg.Wait()
 	c.cancel() // if not called from Disconnect, would leak context

--- a/dex/testing/loadbot/mantle.go
+++ b/dex/testing/loadbot/mantle.go
@@ -110,7 +110,8 @@ out:
 		}
 	}
 
-	m.ForceShutdown()
+	// Let Core shutdown and lock up.
+	m.waiter.WaitForShutdown()
 }
 
 // A Mantle is a wrapper for *core.Core that adds some useful LoadBot methods


### PR DESCRIPTION
Previously we gave `(*Core).PromptShutdown` the expanded responsibility of not just checking and prompting if a shutdown was OK but also locking the wallets.  This was not the right place to do that for several reasons:

1. `PromptShutdown` is just a check and prompt function, not a "partial shutdown" function.  Shutdown via context cancellation is the correct approach.
2. `Core` consumers could and were not using `PromptShutdown`, and instead just cancelling `Core`'s context thus leaving the wallets unlocked after shutdown, thus leading to the now-fixed "wallet not unlocked" bug (https://github.com/decred/dcrdex/pull/915) that was requiring such consumers to also restart their wallets when restarting.
3. Locking the wallets and the dex accounts before shutting down `(*Core).Run` goroutine was incorrect. After the DB and `dexConnection`s stop, the wallets may be locked and dex account private keys cleared.

<s>A secondary bug resolved here is that while the prompt was shown (`"You have active orders. Shutting down now may result in..."`) the `connMtx` was held, and blocked just about all critical `Core` functions.</s> EDIT: independently resolved in https://github.com/decred/dcrdex/commit/c75c5797a3b62a1e9197361791a590dcb4931034