### PR TITLE
core: remove cached User struct

### DIFF
--- a/client/core/account.go
+++ b/client/core/account.go
@@ -131,6 +131,5 @@ func (c *Core) AccountImport(pw []byte, acct Account) error {
 		}
 	}
 
-	c.refreshUser()
 	return nil
 }

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -174,15 +174,12 @@ func (dc *dexConnection) syncBook(base, quote uint32) (*BookFeed, error) {
 	dc.booksMtx.Lock()
 	defer dc.booksMtx.Unlock()
 
-	mkt := marketName(base, quote)
-	booky, found := dc.books[mkt]
+	mktID := marketName(base, quote)
+	booky, found := dc.books[mktID]
 	if !found {
 		// Make sure the market exists.
-		dc.marketMtx.RLock()
-		_, found = dc.marketMap[mkt]
-		dc.marketMtx.RUnlock()
-		if !found {
-			return nil, fmt.Errorf("unknown market %s", mkt)
+		if dc.market(mktID) == nil {
+			return nil, fmt.Errorf("unknown market %s", mktID)
 		}
 
 		obRes, err := dc.subscribe(base, quote)
@@ -190,12 +187,12 @@ func (dc *dexConnection) syncBook(base, quote uint32) (*BookFeed, error) {
 			return nil, err
 		}
 
-		booky = newBookie(dc.log.SubLogger(mkt), func() { dc.stopBook(base, quote) })
+		booky = newBookie(dc.log.SubLogger(mktID), func() { dc.stopBook(base, quote) })
 		err = booky.Sync(obRes)
 		if err != nil {
 			return nil, err
 		}
-		dc.books[mkt] = booky
+		dc.books[mktID] = booky
 	}
 
 	// Get the feed and the book under a single lock to make sure the first
@@ -207,7 +204,7 @@ func (dc *dexConnection) syncBook(base, quote uint32) (*BookFeed, error) {
 	feed.C <- &BookUpdate{
 		Action:   FreshBookAction,
 		Host:     dc.acct.host,
-		MarketID: mkt,
+		MarketID: mktID,
 		Payload: &MarketOrderBook{
 			Base:  base,
 			Quote: quote,
@@ -461,6 +458,7 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 	if mkt == nil {
 		return fmt.Errorf("no market found with ID %s", sp.MarketID)
 	}
+	mktName, baseID, quoteID := mkt.Name, mkt.Base, mkt.Quote
 
 	// Update the data in the stored ConfigResponse.
 	dc.setMarketFinalEpoch(sp.MarketID, sp.FinalEpoch, sp.Persist)
@@ -503,11 +501,11 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 	// Return any non-nil error, but still revoke purged orders.
 
 	// Revoke all active orders of the suspended market for the dex.
-	c.log.Warnf("Revoking all active orders for market %s at %s.", mkt.Name, dc.acct.host)
+	c.log.Warnf("Revoking all active orders for market %s at %s.", mktName, dc.acct.host)
 	updatedAssets := make(assetMap)
 	dc.tradeMtx.RLock()
 	for _, tracker := range dc.trades {
-		if tracker.Order.Base() == mkt.BaseID && tracker.Order.Quote() == mkt.QuoteID &&
+		if tracker.Order.Base() == baseID && tracker.Order.Quote() == quoteID &&
 			tracker.metaData.Host == dc.acct.host && tracker.metaData.Status == order.OrderStatusBooked {
 			// Locally revoke the purged book order.
 			tracker.revoke()
@@ -524,17 +522,14 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 		Host:     dc.acct.host,
 		MarketID: sp.MarketID,
 		Payload: &MarketOrderBook{
-			Base:  mkt.BaseID,
-			Quote: mkt.QuoteID,
+			Base:  baseID,
+			Quote: quoteID,
 			Book:  book.book(), // empty
 		},
 	})
 
-	dc.refreshMarkets()
 	if len(updatedAssets) > 0 {
 		c.updateBalances(updatedAssets)
-	} else {
-		c.refreshUser() // would be called by updateBalances
 	}
 
 	return err
@@ -603,7 +598,7 @@ func (dc *dexConnection) refreshServerConfig() error {
 	defer dc.cfgMtx.Unlock()
 	dc.cfg = cfg
 
-	assets, markets, epochs, err := generateDEXMaps(dc.acct.host, cfg)
+	assets, epochs, err := generateDEXMaps(dc.acct.host, cfg)
 	if err != nil {
 		return fmt.Errorf("Inconsistent 'config' response: %w", err)
 	}
@@ -616,10 +611,6 @@ func (dc *dexConnection) refreshServerConfig() error {
 	dc.epochMtx.Lock()
 	dc.epoch = epochs
 	dc.epochMtx.Unlock()
-
-	dc.marketMtx.Lock()
-	dc.marketMap = markets
-	dc.marketMtx.Unlock()
 
 	return nil
 }
@@ -716,10 +707,6 @@ func handleEpochOrderMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error
 	err := msg.Unmarshal(note)
 	if err != nil {
 		return fmt.Errorf("epoch order note unmarshal error: %w", err)
-	}
-
-	if dc.setEpoch(note.MarketID, note.Epoch) {
-		c.refreshUser() // maybe remove if this was pre-nomatch
 	}
 
 	dc.booksMtx.RLock()

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -154,15 +154,16 @@ func (dc *dexConnection) marketMap() map[string]*Market {
 }
 
 // marketTrades is a slice of trades in the trades map.
-func (dc *dexConnection) marketTrades(mktID string) (trades []*trackedTrade) {
+func (dc *dexConnection) marketTrades(mktID string) []*trackedTrade {
 	dc.tradeMtx.RLock()
 	defer dc.tradeMtx.RUnlock()
+	trades := make([]*trackedTrade, 0, len(dc.trades))
 	for _, trade := range dc.trades {
 		if trade.mktID == mktID {
 			trades = append(trades, trade)
 		}
 	}
-	return
+	return trades
 }
 
 // getRegConfirms returns the number of confirmations received for the

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -165,15 +165,6 @@ func testDexConnection() (*dexConnection, *TWebsocket, *dexAccount) {
 	connMaster := dex.NewConnectionMaster(conn)
 	connMaster.Connect(tCtx)
 	acct := tNewAccount()
-	mkt := &Market{
-		Name:            tDcrBtcMktName,
-		BaseID:          tDCR.ID,
-		BaseSymbol:      tDCR.Symbol,
-		QuoteID:         tBTC.ID,
-		QuoteSymbol:     tBTC.Symbol,
-		EpochLen:        60000,
-		MarketBuyBuffer: 1.1,
-	}
 	return &dexConnection{
 		WsConn:     conn,
 		log:        tLogger,
@@ -209,7 +200,6 @@ func testDexConnection() (*dexConnection, *TWebsocket, *dexAccount) {
 		},
 		tickInterval: time.Millisecond * 1000 / 3,
 		notify:       func(Notification) {},
-		marketMap:    map[string]*Market{tDcrBtcMktName: mkt},
 		trades:       make(map[order.OrderID]*trackedTrade),
 		epoch:        map[string]uint64{tDcrBtcMktName: 0},
 		connected:    true,
@@ -825,7 +815,7 @@ func newTestRig() *testRig {
 		acct:    acct,
 		crypter: crypter,
 	}
-	rig.core.refreshUser()
+
 	return rig
 }
 
@@ -919,11 +909,12 @@ func TestMarkets(t *testing.T) {
 	rig.dc.cfgMtx.Lock()
 	rig.dc.cfg.Markets = nil
 	rig.dc.cfgMtx.Unlock()
+	numMarkets := 10
 
 	tCore := rig.core
 	// Simulate 10 markets.
 	marketIDs := make(map[string]struct{})
-	for i := 0; i < 10; i++ {
+	for i := 0; i < numMarkets; i++ {
 		base, quote := randomMsgMarket()
 		marketIDs[marketName(base.ID, quote.ID)] = struct{}{}
 		rig.dc.cfgMtx.RLock()
@@ -941,7 +932,6 @@ func TestMarkets(t *testing.T) {
 		rig.dc.assets[quote.ID] = convertAssetInfo(quote)
 		rig.dc.assetsMtx.Unlock()
 	}
-	rig.dc.refreshMarkets()
 
 	// Just check that the information is coming through correctly.
 	xcs := tCore.Exchanges()
@@ -2818,6 +2808,7 @@ func TestTradeTracking(t *testing.T) {
 	if len(proof.SecretHash) != 0 {
 		t.Fatalf("secret hash set for taker")
 	}
+
 	// Now send through the audit request for the maker's init.
 	audit, auditInfo = tMsgAudit(loid, mid, addr, matchSize, nil)
 	tBtcWallet.auditInfo = auditInfo
@@ -2858,6 +2849,7 @@ func TestTradeTracking(t *testing.T) {
 	if len(proof.TakerSwap) != 0 {
 		t.Fatalf("swap broadcast before confirmations")
 	}
+
 	// Now with the confirmations.
 	tBtcWallet.setConfs(auditInfo.coin.ID(), tBTC.SwapConf, nil)
 	swapID := encode.RandomBytes(36)
@@ -3024,10 +3016,10 @@ func TestReconcileTrades(t *testing.T) {
 	rig := newTestRig()
 	dc := rig.dc
 
-	mkt := rig.dc.market(tDcrBtcMktName)
-	rig.core.wallets[mkt.BaseID], _ = newTWallet(mkt.BaseID)
-	rig.core.wallets[mkt.QuoteID], _ = newTWallet(mkt.QuoteID)
-	walletSet, err := rig.core.walletSet(dc, mkt.BaseID, mkt.QuoteID, true)
+	mkt := dc.market(tDcrBtcMktName)
+	rig.core.wallets[mkt.Base], _ = newTWallet(mkt.Base)
+	rig.core.wallets[mkt.Quote], _ = newTWallet(mkt.Quote)
+	walletSet, err := rig.core.walletSet(dc, mkt.Base, mkt.Quote, true)
 	if err != nil {
 		t.Fatalf("walletSet error: %v", err)
 	}
@@ -3223,7 +3215,7 @@ func TestReconcileTrades(t *testing.T) {
 	}
 }
 
-func makeTradeTracker(rig *testRig, mkt *Market, walletSet *walletSet, force order.TimeInForce, status order.OrderStatus) *trackedTrade {
+func makeTradeTracker(rig *testRig, mkt *msgjson.Market, walletSet *walletSet, force order.TimeInForce, status order.OrderStatus) *trackedTrade {
 	qty := 4 * tDCR.LotSize
 	lo, dbOrder, preImg, _ := makeLimitOrder(rig.dc, true, qty, tBTC.RateStep)
 	lo.Force = force
@@ -3237,6 +3229,7 @@ func makeTradeTracker(rig *testRig, mkt *Market, walletSet *walletSet, force ord
 }
 
 func TestRefunds(t *testing.T) {
+	rig := newTestRig()
 	checkStatus := func(tag string, match *matchTracker, wantStatus order.MatchStatus) {
 		t.Helper()
 		if match.Match.Status != wantStatus {
@@ -3284,7 +3277,6 @@ func TestRefunds(t *testing.T) {
 		}
 	}
 
-	rig := newTestRig()
 	dc := rig.dc
 	tCore := rig.core
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
@@ -3437,7 +3429,7 @@ func TestNotifications(t *testing.T) {
 	select {
 	case n := <-ch:
 		dbtest.MustCompareNotifications(t, n.DBNote(), &typedNote.Notification)
-	default:
+	case <-time.After(time.Second):
 		t.Fatalf("no notification received over the notification channel")
 	}
 }
@@ -4072,22 +4064,8 @@ func TestLogout(t *testing.T) {
 	}
 	rig.dc.trades[ord.ID()] = tracker
 
-	dc, _, _ := testDexConnection()
-	initUserAssets := func() {
-		tCore.user = new(User)
-		dc.assetsMtx.Lock()
-		tCore.user.Assets = make(map[uint32]*SupportedAsset, len(dc.assets))
-		for assetsID := range dc.assets {
-			tCore.user.Assets[assetsID] = &SupportedAsset{
-				ID: assetsID,
-			}
-		}
-		dc.assetsMtx.Unlock()
-	}
-
 	ensureErr := func(tag string) {
 		t.Helper()
-		initUserAssets()
 		err := tCore.Logout()
 		if err == nil {
 			t.Fatalf("%s: no error", tag)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -213,12 +213,7 @@ func (t *trackedTrade) coreOrderInternal() *Order {
 	corder := coreOrderFromTrade(t.Order, t.metaData)
 
 	corder.Epoch = t.dc.marketEpoch(t.mktID, t.Prefix().ServerTime)
-
-	if t.coinsLocked {
-		corder.LockedAmt = sumCoinMap(t.coins)
-	} else if t.changeLocked {
-		corder.LockedAmt = t.change.Value()
-	}
+	corder.LockedAmt = t.lockedAmount()
 
 	for _, mt := range t.matches {
 		corder.Matches = append(corder.Matches, matchFromMetaMatchWithConfs(t,
@@ -2216,11 +2211,4 @@ func sellString(sell bool) string {
 		return "sell"
 	}
 	return "buy"
-}
-
-func sumCoinMap(cs map[string]asset.Coin) (sum uint64) {
-	for _, c := range cs {
-		sum += c.Value()
-	}
-	return
 }

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1253,8 +1253,8 @@ func (client *tClient) placeOrder(qty, rate uint64, tifNow bool) (string, error)
 	if dcrBtcMkt == nil {
 		return "", fmt.Errorf("no dcr_btc market found")
 	}
-	baseAsset := dc.assets[dcrBtcMkt.BaseID]
-	quoteAsset := dc.assets[dcrBtcMkt.QuoteID]
+	baseAsset := dc.assets[dcrBtcMkt.Base]
+	quoteAsset := dc.assets[dcrBtcMkt.Quote]
 
 	tradeForm := &TradeForm{
 		Host:    dexHost,

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1249,7 +1249,7 @@ func (n *notificationReader) find(ctx context.Context, waitDuration time.Duratio
 
 func (client *tClient) placeOrder(qty, rate uint64, tifNow bool) (string, error) {
 	dc := client.dc()
-	dcrBtcMkt := dc.market("dcr_btc")
+	dcrBtcMkt := dc.marketConfig("dcr_btc")
 	if dcrBtcMkt == nil {
 		return "", fmt.Errorf("no dcr_btc market found")
 	}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -389,16 +389,16 @@ func (m *Market) sideContractLocked(sell bool) (amt uint64) {
 		if ord.Sell != sell {
 			continue
 		}
-		for _, m := range ord.Matches {
-			if m.Status >= order.MakerRedeemed || m.Refund != nil {
+		for _, match := range ord.Matches {
+			if match.Status >= order.MakerRedeemed || match.Refund != nil {
 				continue
 			}
-			if (m.Side == order.Maker && m.Status >= order.MakerSwapCast) ||
-				(m.Side == order.Taker && m.Status == order.TakerSwapCast) {
+			if (match.Side == order.Maker && match.Status >= order.MakerSwapCast) ||
+				(match.Side == order.Taker && match.Status == order.TakerSwapCast) {
 
-				swapAmount := m.Qty
+				swapAmount := match.Qty
 				if !ord.Sell {
-					swapAmount = calc.BaseToQuote(m.Rate, m.Qty)
+					swapAmount = calc.BaseToQuote(match.Rate, match.Qty)
 				}
 				amt += swapAmount
 			}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -284,7 +284,6 @@ type Order struct {
 	FeesPaid     *FeeBreakdown     `json:"feesPaid"`
 	FundingCoins []*Coin           `json:"fundingCoins"`
 	LockedAmt    uint64            `json:"lockedamt"`
-	Change       *Coin             `json:"change"`
 	Rate         uint64            `json:"rate"` // limit only
 	TimeInForce  order.TimeInForce `json:"tif"`  // limit only
 }

--- a/dex/testing/loadbot/go.sum
+++ b/dex/testing/loadbot/go.sum
@@ -89,6 +89,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/go-chi/chi v1.5.1 h1:kfTK3Cxd/dkMu/rKs5ZceWYp+t5CtiE7vmaTv3LjC6w=
+github.com/go-chi/chi v1.5.1/go.mod h1:REp24E+25iKvxgeTfHmdUoL5x15kBiDBlnIl5bCwe2k=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=


### PR DESCRIPTION
Resolves #379

I experimented with some different schemes for updating the cached `*User` struct and then creating copies on calls to `(*Core).User`, but ultimately decided that we don't really need to cache a `*User` at all, and the cleanest solution is to just get rid of it.

- remove `user` and `userMtx` fields from `Core`. `(*Core).User` now generates a new `*core.User` on demand.
- remove the `marketMap` field from `Core`. Anything that used the `core.Market` from the `marketMap` now uses the `msgjson.Market` from `cfg` instead.
- `dexConnections` and `xcWallets` methods to relieve some lock contention
- `*OrderLocked` and `*ContractLocked` fields changed to methods (breaking change)