### PR TITLE
use decred's rpcclient for BTC

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -641,7 +641,7 @@ func (btc *ExchangeWallet) Balance() (*asset.Balance, error) {
 	if btc.useLegacyBalance {
 		return btc.legacyBalance()
 	}
-	balances, err := btc.wallet.Balances(btc.ctx)
+	balances, err := btc.wallet.Balances()
 	if err != nil {
 		return nil, err
 	}
@@ -2353,7 +2353,6 @@ type utxo struct {
 	vout    uint32
 	address string
 	amount  uint64
-	tree    int8
 }
 
 // Combines utxo info with the spending input information.

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -465,7 +465,9 @@ func BTCCloneWallet(cfg *BTCCloneCFG) (*ExchangeWallet, error) {
 
 	requester, err := newRequester(endpoint, btcCfg.RPCUser, btcCfg.RPCPass,
 		cfg.Symbol, cfg.Logger)
-
+	if err != nil {
+		return nil, err
+	}
 	btc, err := newWallet(requester, cfg, btcCfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating %s ExchangeWallet: %v", cfg.Symbol,

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -440,16 +440,11 @@ func newRequester(host, user, pass, symbol string, logger dex.Logger) (*rpcclien
 		Pass:         pass,
 	}
 
-	ntfnHandlers := &rpcclient.NotificationHandlers{
-		// Setup an on-connect handler for logging (re)connects.
-		OnClientConnected: func() {
-			logger.Infof("Connected to %s wallet at %s", symbol, host)
-		},
-	}
-	cl, err := rpcclient.New(config, ntfnHandlers)
+	cl, err := rpcclient.New(config, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating %s ExchangeWallet: %v", symbol, err)
 	}
+	logger.Infof("Connected to %s wallet at %s", symbol, host)
 
 	return cl, nil
 }

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -344,7 +344,6 @@ type ExchangeWallet struct {
 	// 64-bit atomic variables first. See
 	// https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	tipAtConnect      int64
-	ctx               context.Context // the asset subsystem starts with Connect(ctx)
 	node              *walletClient
 	wallet            *walletClient
 	walletInfo        *asset.WalletInfo

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -48,7 +48,7 @@ const (
 	// structure.
 	defaultFee = 100
 	// defaultFeeRateLimit is the default value for the feeratelimit.
-	defaultFeeRateLimit = 600
+	defaultFeeRateLimit = 1400
 	// defaultRedeemConfTarget is the default redeem transaction confirmation
 	// target in blocks used by estimatesmartfee to get the optimal fee for a
 	// redeem transaction.
@@ -2026,8 +2026,7 @@ func (btc *ExchangeWallet) sendRawTransaction(tx *wire.MsgTx) (*chainhash.Hash, 
 		return nil, err
 	}
 	var txid string
-	err = btc.node.call(methodSendRawTx,
-		anylist{hex.EncodeToString(b), float64(btc.feeRateLimit) * 1e-5}, &txid)
+	err = btc.node.call(methodSendRawTx, anylist{hex.EncodeToString(b)}, &txid)
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -222,9 +222,12 @@ func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.
 		if c.rawVerboseErr != nil {
 			return nil, c.rawVerboseErr
 		}
-		var txHash *chainhash.Hash
-		_ = json.Unmarshal(params[0], txHash)
-		return json.Marshal(c.mpVerboseTxs[txHash.String()])
+		var txHash string
+		err := json.Unmarshal(params[0], &txHash)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(c.mpVerboseTxs[txHash])
 	case methodSignTx:
 		if c.rawErr[method] == nil {
 			return c.signFunc(params)

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -114,8 +114,6 @@ type tRPCClient struct {
 	blockchainMtx sync.RWMutex
 	verboseBlocks map[string]*btcjson.GetBlockVerboseResult
 	mainchain     map[int64]*chainhash.Hash
-	mempoolTxs    []*chainhash.Hash
-	mpErr         error
 	mpVerboseTxs  map[string]*btcjson.TxRawResult
 	rawVerboseErr error
 	lockedCoins   []*RPCOutpoint
@@ -174,7 +172,8 @@ func (c *tRPCClient) GetBestBlockHeight() int64 {
 
 func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	switch method {
-	// TODO: handle methodGetBlockHash and add test to cover it.
+	// TODO: handle methodGetBlockHash, methodGetRawMempool  and add actual tests
+	// to cover them.
 	case methodEstimateSmartFee:
 		optimalRate := float64(optimalFeeRate) * 1e-5 // ~0.00024
 		return json.Marshal(&btcjson.EstimateSmartFeeResult{
@@ -218,10 +217,7 @@ func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.
 		}
 		return json.Marshal(bestHash)
 	case methodGetRawMempool:
-		if c.mpErr != nil {
-			return nil, c.mpErr
-		}
-		return json.Marshal(c.mempoolTxs)
+		return json.Marshal([]string{})
 	case methodGetRawTransaction:
 		if c.rawVerboseErr != nil {
 			return nil, c.rawVerboseErr

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -405,7 +405,7 @@ func tNewWallet(segwit bool) (*ExchangeWallet, *tRPCClient, func(), error) {
 		return nil, nil, nil, err
 	}
 	// Initialize the best block.
-	bestHash, err := wallet.wallet.GetBestBlockHash()
+	bestHash, err := wallet.node.GetBestBlockHash()
 	if err != nil {
 		shutdown()
 		return nil, nil, nil, err

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -172,7 +172,7 @@ func (c *tRPCClient) GetBestBlockHeight() int64 {
 
 func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	switch method {
-	// TODO: handle methodGetBlockHash, methodGetRawMempool  and add actual tests
+	// TODO: handle methodGetBlockHash, methodGetRawMempool and add actual tests
 	// to cover them.
 	case methodEstimateSmartFee:
 		optimalRate := float64(optimalFeeRate) * 1e-5 // ~0.00024

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -217,7 +217,7 @@ func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.
 		}
 		return json.Marshal(bestHash)
 	case methodGetRawMempool:
-		return json.Marshal([]string{})
+		return json.Marshal(&[]string{})
 	case methodGetRawTransaction:
 		if c.rawVerboseErr != nil {
 			return nil, c.rawVerboseErr

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -215,7 +215,7 @@ func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.
 				bestHash = hash
 			}
 		}
-		return json.Marshal(bestHash)
+		return json.Marshal(bestHash.String())
 	case methodGetRawMempool:
 		return json.Marshal(&[]string{})
 	case methodGetRawTransaction:
@@ -405,19 +405,14 @@ func tNewWallet(segwit bool) (*ExchangeWallet, *tRPCClient, func(), error) {
 		return nil, nil, nil, err
 	}
 	// Initialize the best block.
-	var bestHash *chainhash.Hash
-	res, err := client.RawRequest(nil, methodGetBestBlockHash, nil)
-	if err != nil {
-		shutdown()
-		return nil, nil, nil, err
-	}
-	err = json.Unmarshal(res, &bestHash)
+	bestHash, err := wallet.wallet.GetBestBlockHash()
 	if err != nil {
 		shutdown()
 		return nil, nil, nil, err
 	}
 	wallet.tipMtx.Lock()
-	wallet.currentTip = &block{height: client.GetBestBlockHeight(), hash: bestHash.String()}
+	wallet.currentTip = &block{height: client.GetBestBlockHeight(),
+		hash: bestHash.String()}
 	wallet.tipMtx.Unlock()
 	go wallet.run(walletCtx)
 

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -225,8 +225,6 @@ func (c *tRPCClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjson.
 	return c.mpVerboseTxs[txHash.String()], c.rawVerboseErr
 }
 
-func (c *tRPCClient) Disconnected() bool { return false }
-
 func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	switch method {
 	case methodSignTx:

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -227,7 +227,7 @@ func (c *tRPCClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjson.
 
 func (c *tRPCClient) Disconnected() bool { return false }
 
-func (c *tRPCClient) RawRequest(method string, params []json.RawMessage) (json.RawMessage, error) {
+func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	switch method {
 	case methodSignTx:
 		if c.rawErr[method] == nil {
@@ -400,7 +400,7 @@ func tNewWallet(segwit bool) (*ExchangeWallet, *tRPCClient, func(), error) {
 		DefaultFeeRateLimit: defaultFeeRateLimit,
 		Segwit:              segwit,
 	}
-	wallet, err := newWallet(cfg, &dexbtc.Config{}, client)
+	wallet, err := newWallet(client, cfg, &dexbtc.Config{})
 	if err != nil {
 		shutdown()
 		return nil, nil, nil, err
@@ -1700,7 +1700,7 @@ func testFindRedemption(t *testing.T, segwit bool) {
 		DefaultFeeRateLimit: defaultFeeRateLimit,
 		Segwit:              segwit,
 	}
-	wallet, err := newWallet(cfg, &dexbtc.Config{}, node)
+	wallet, err := newWallet(node, cfg, &dexbtc.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -255,7 +255,7 @@ func (wc *walletClient) Unlock(pass string) error {
 	return wc.call(methodUnlock, anylist{pass, 100000000}, nil)
 }
 
-// Lock locks the wallet
+// Lock locks the wallet.
 func (wc *walletClient) Lock() error {
 	return wc.call(methodLock, nil, nil)
 }

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -85,9 +85,11 @@ func (wc *walletClient) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (
 }
 
 func (wc *walletClient) GetTxOut(txHash *chainhash.Hash, index uint32, mempool bool) (*btcjson.GetTxOutResult, error) {
-	res := new(btcjson.GetTxOutResult)
+	// Note that we pass to call pointer to a pointer (&res) so that
+	//json.Unmarshal can  nil the pointer if the method returns the JSON null.
+	var res *btcjson.GetTxOutResult
 	return res, wc.call(methodGetTxOut, anylist{txHash.String(), index, mempool},
-		res)
+		&res)
 }
 
 func (wc *walletClient) callHashGetter(method string, args anylist) (*chainhash.Hash, error) {
@@ -113,7 +115,7 @@ func (wc *walletClient) GetRawMempool() ([]*chainhash.Hash, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Convert recieved hex hashes to chainhash.Hash
+	// Convert received hex hashes to chainhash.Hash
 	hashes := make([]*chainhash.Hash, 0, len(mempool))
 	for _, h := range mempool {
 		hash, err := chainhash.NewHashFromStr(h)

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -44,22 +44,24 @@ const (
 	methodGetRawTransaction  = "getrawtransaction"
 )
 
+// RawRequester defines dcred's rpcclient RawRequest func where all RPC
+// requests sent through. For testing, it can be satisfied by a stub.
 type RawRequester interface {
 	RawRequest(context.Context, string, []json.RawMessage) (json.RawMessage, error)
 }
 
-// walletClient is a bitcoind wallet RPC client that uses rpcclient.Client's
+// rpcClient is a bitcoind wallet RPC client that uses rpcclient.Client's
 // RawRequest for wallet-related calls.
-type walletClient struct {
+type rpcClient struct {
 	ctx         context.Context
 	requester   RawRequester
 	chainParams *chaincfg.Params
 	segwit      bool
 }
 
-// newWalletClient is the constructor for a walletClient.
-func newWalletClient(requester RawRequester, segwit bool, chainParams *chaincfg.Params) *walletClient {
-	return &walletClient{
+// newWalletClient is the constructor for a rpcClient.
+func newWalletClient(requester RawRequester, segwit bool, chainParams *chaincfg.Params) *rpcClient {
+	return &rpcClient{
 		requester:   requester,
 		chainParams: chainParams,
 		segwit:      segwit,
@@ -70,12 +72,16 @@ func newWalletClient(requester RawRequester, segwit bool, chainParams *chaincfg.
 // sent via RawRequest.
 type anylist []interface{}
 
-func (wc *walletClient) EstimateSmartFee(confTarget int64, mode *btcjson.EstimateSmartFeeMode) (*btcjson.EstimateSmartFeeResult, error) {
+// EstimateSmartFee requests the server to estimate a fee level based on the
+// given parameters.
+func (wc *rpcClient) EstimateSmartFee(confTarget int64, mode *btcjson.EstimateSmartFeeMode) (*btcjson.EstimateSmartFeeResult, error) {
 	res := new(btcjson.EstimateSmartFeeResult)
 	return res, wc.call(methodEstimateSmartFee, anylist{confTarget, mode}, res)
 }
 
-func (wc *walletClient) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error) {
+// SendRawTransaction submits the encoded transaction to the server which will
+// then relay it to the network.
+func (wc *rpcClient) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error) {
 	txBytes, err := serializeMsgTx(tx)
 	if err != nil {
 		return nil, err
@@ -84,15 +90,17 @@ func (wc *walletClient) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (
 		hex.EncodeToString(txBytes), allowHighFees})
 }
 
-func (wc *walletClient) GetTxOut(txHash *chainhash.Hash, index uint32, mempool bool) (*btcjson.GetTxOutResult, error) {
+// GetTxOut returns the transaction output info if it's unspent and
+// nil, otherwise.
+func (wc *rpcClient) GetTxOut(txHash *chainhash.Hash, index uint32, mempool bool) (*btcjson.GetTxOutResult, error) {
 	// Note that we pass to call pointer to a pointer (&res) so that
-	//json.Unmarshal can  nil the pointer if the method returns the JSON null.
+	// json.Unmarshal can nil the pointer if the method returns the JSON null.
 	var res *btcjson.GetTxOutResult
 	return res, wc.call(methodGetTxOut, anylist{txHash.String(), index, mempool},
 		&res)
 }
 
-func (wc *walletClient) callHashGetter(method string, args anylist) (*chainhash.Hash, error) {
+func (wc *rpcClient) callHashGetter(method string, args anylist) (*chainhash.Hash, error) {
 	var txid string
 	err := wc.call(method, args, &txid)
 	if err != nil {
@@ -101,15 +109,20 @@ func (wc *walletClient) callHashGetter(method string, args anylist) (*chainhash.
 	return chainhash.NewHashFromStr(txid)
 }
 
-func (wc *walletClient) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
+// GetBlockHash returns the hash of the block in the best block chain at the
+// given height.
+func (wc *rpcClient) GetBlockHash(blockHeight int64) (*chainhash.Hash, error) {
 	return wc.callHashGetter(methodGetBlockHash, anylist{blockHeight})
 }
 
-func (wc *walletClient) GetBestBlockHash() (*chainhash.Hash, error) {
+// GetBestBlockHash returns the hash of the best block in the longest block
+// chain.
+func (wc *rpcClient) GetBestBlockHash() (*chainhash.Hash, error) {
 	return wc.callHashGetter(methodGetBestBlockHash, nil)
 }
 
-func (wc *walletClient) GetRawMempool() ([]*chainhash.Hash, error) {
+// GetRawMempool returns the hashes of all transactions in the memory pool.
+func (wc *rpcClient) GetRawMempool() ([]*chainhash.Hash, error) {
 	var mempool []string
 	err := wc.call(methodGetRawMempool, nil, &mempool)
 	if err != nil {
@@ -127,20 +140,22 @@ func (wc *walletClient) GetRawMempool() ([]*chainhash.Hash, error) {
 	return hashes, nil
 }
 
-func (wc *walletClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjson.TxRawResult, error) {
+// GetRawTransactionVerbose retrieves tx's information with verbose flag set
+// to true.
+func (wc *rpcClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjson.TxRawResult, error) {
 	res := new(btcjson.TxRawResult)
 	return res, wc.call(methodGetRawTransaction, anylist{txHash.String(),
 		true}, res)
 }
 
 // Balances retrieves a wallet's balance details.
-func (wc *walletClient) Balances() (*GetBalancesResult, error) {
+func (wc *rpcClient) Balances() (*GetBalancesResult, error) {
 	var balances GetBalancesResult
 	return &balances, wc.call(methodGetBalances, nil, &balances)
 }
 
 // ListUnspent retrieves a list of the wallet's UTXOs.
-func (wc *walletClient) ListUnspent() ([]*ListUnspentResult, error) {
+func (wc *rpcClient) ListUnspent() ([]*ListUnspentResult, error) {
 	unspents := make([]*ListUnspentResult, 0)
 	// TODO: listunspent 0 9999999 []string{}, include_unsafe=false
 	return unspents, wc.call(methodListUnspent, anylist{uint8(0)}, &unspents)
@@ -149,7 +164,7 @@ func (wc *walletClient) ListUnspent() ([]*ListUnspentResult, error) {
 // LockUnspent locks and unlocks outputs for spending. An output that is part of
 // an order, but not yet spent, should be locked until spent or until the order
 // is  canceled or fails.
-func (wc *walletClient) LockUnspent(unlock bool, ops []*output) error {
+func (wc *rpcClient) LockUnspent(unlock bool, ops []*output) error {
 	var rpcops []*RPCOutpoint // To clear all, this must be nil, not empty slice.
 	for _, op := range ops {
 		rpcops = append(rpcops, &RPCOutpoint{
@@ -167,7 +182,7 @@ func (wc *walletClient) LockUnspent(unlock bool, ops []*output) error {
 
 // ListLockUnspent returns a slice of outpoints for all unspent outputs marked
 // as locked by a wallet.
-func (wc *walletClient) ListLockUnspent() ([]*RPCOutpoint, error) {
+func (wc *rpcClient) ListLockUnspent() ([]*RPCOutpoint, error) {
 	var unspents []*RPCOutpoint
 	err := wc.call(methodListLockUnspent, nil, &unspents)
 	return unspents, err
@@ -175,7 +190,7 @@ func (wc *walletClient) ListLockUnspent() ([]*RPCOutpoint, error) {
 
 // ChangeAddress gets a new internal address from the wallet. The address will
 // be bech32-encoded (P2WPKH).
-func (wc *walletClient) ChangeAddress() (btcutil.Address, error) {
+func (wc *rpcClient) ChangeAddress() (btcutil.Address, error) {
 	var addrStr string
 	var err error
 	if wc.segwit {
@@ -191,19 +206,19 @@ func (wc *walletClient) ChangeAddress() (btcutil.Address, error) {
 
 // AddressPKH gets a new base58-encoded (P2PKH) external address from the
 // wallet.
-func (wc *walletClient) AddressPKH() (btcutil.Address, error) {
+func (wc *rpcClient) AddressPKH() (btcutil.Address, error) {
 	return wc.address("legacy")
 }
 
 // AddressWPKH gets a new bech32-encoded (P2WPKH) external address from the
 // wallet.
-func (wc *walletClient) AddressWPKH() (btcutil.Address, error) {
+func (wc *rpcClient) AddressWPKH() (btcutil.Address, error) {
 	return wc.address("bech32")
 }
 
 // address is used internally for fetching addresses of various types from the
 // wallet.
-func (wc *walletClient) address(aType string) (btcutil.Address, error) {
+func (wc *rpcClient) address(aType string) (btcutil.Address, error) {
 	var addrStr string
 	err := wc.call(methodNewAddress, anylist{"", aType}, &addrStr)
 	if err != nil {
@@ -213,7 +228,7 @@ func (wc *walletClient) address(aType string) (btcutil.Address, error) {
 }
 
 // SignTx attempts to have the wallet sign the transaction inputs.
-func (wc *walletClient) SignTx(inTx *wire.MsgTx) (*wire.MsgTx, error) {
+func (wc *rpcClient) SignTx(inTx *wire.MsgTx) (*wire.MsgTx, error) {
 	txBytes, err := serializeMsgTx(inTx)
 	if err != nil {
 		return nil, fmt.Errorf("tx serialization error: %w", err)
@@ -241,7 +256,7 @@ func (wc *walletClient) SignTx(inTx *wire.MsgTx) (*wire.MsgTx, error) {
 
 // PrivKeyForAddress retrieves the private key associated with the specified
 // address.
-func (wc *walletClient) PrivKeyForAddress(addr string) (*btcec.PrivateKey, error) {
+func (wc *rpcClient) PrivKeyForAddress(addr string) (*btcec.PrivateKey, error) {
 	var keyHex string
 	err := wc.call(methodPrivKeyForAddress, anylist{addr}, &keyHex)
 	if err != nil {
@@ -255,7 +270,7 @@ func (wc *walletClient) PrivKeyForAddress(addr string) (*btcec.PrivateKey, error
 }
 
 // GetTransaction retrieves the specified wallet-related transaction.
-func (wc *walletClient) GetTransaction(txid string) (*GetTransactionResult, error) {
+func (wc *rpcClient) GetTransaction(txid string) (*GetTransactionResult, error) {
 	res := new(GetTransactionResult)
 	err := wc.call(methodGetTransaction, anylist{txid}, res)
 	if err != nil {
@@ -264,20 +279,20 @@ func (wc *walletClient) GetTransaction(txid string) (*GetTransactionResult, erro
 	return res, nil
 }
 
-// Unlock unlocks the wallet.
-func (wc *walletClient) Unlock(pass string) error {
+// WalletUnlock unlocks the wallet.
+func (wc *rpcClient) WalletUnlock(pass string) error {
 	// 100000000 comes from bitcoin-cli help walletpassphrase
 	return wc.call(methodUnlock, anylist{pass, 100000000}, nil)
 }
 
-// Lock locks the wallet.
-func (wc *walletClient) Lock() error {
+// WalletLock locks the wallet.
+func (wc *rpcClient) WalletLock() error {
 	return wc.call(methodLock, nil, nil)
 }
 
 // SendToAddress sends the amount to the address. feeRate is in units of
 // atoms/byte.
-func (wc *walletClient) SendToAddress(address string, value, feeRate uint64, subtract bool) (*chainhash.Hash, error) {
+func (wc *rpcClient) SendToAddress(address string, value, feeRate uint64, subtract bool) (*chainhash.Hash, error) {
 	var success bool
 	// 1e-5 = 1e-8 for satoshis * 1000 for kB.
 	err := wc.call(methodSetTxFee, anylist{float64(feeRate) / 1e5}, &success)
@@ -298,14 +313,14 @@ func (wc *walletClient) SendToAddress(address string, value, feeRate uint64, sub
 }
 
 // GetWalletInfo gets the getwalletinfo RPC result.
-func (wc *walletClient) GetWalletInfo() (*GetWalletInfoResult, error) {
+func (wc *rpcClient) GetWalletInfo() (*GetWalletInfoResult, error) {
 	wi := new(GetWalletInfoResult)
 	return wi, wc.call(methodGetWalletInfo, nil, wi)
 }
 
 // GetAddressInfo gets information about the given address by calling
 // getaddressinfo RPC command.
-func (wc *walletClient) GetAddressInfo(address string) (*GetAddressInfoResult, error) {
+func (wc *rpcClient) GetAddressInfo(address string) (*GetAddressInfoResult, error) {
 	ai := new(GetAddressInfoResult)
 	return ai, wc.call(methodGetAddressInfo, anylist{address}, ai)
 }
@@ -313,7 +328,7 @@ func (wc *walletClient) GetAddressInfo(address string) (*GetAddressInfoResult, e
 // call is used internally to marshal parmeters and send requests to the RPC
 // server via (*rpcclient.Client).RawRequest. If `thing` is non-nil, the result
 // will be marshaled into `thing`.
-func (wc *walletClient) call(method string, args anylist, thing interface{}) error {
+func (wc *rpcClient) call(method string, args anylist, thing interface{}) error {
 	params := make([]json.RawMessage, 0, len(args))
 	for i := range args {
 		p, err := json.Marshal(args[i])

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -108,8 +108,21 @@ func (wc *walletClient) GetBestBlockHash() (*chainhash.Hash, error) {
 }
 
 func (wc *walletClient) GetRawMempool() ([]*chainhash.Hash, error) {
-	var mempool []*chainhash.Hash
-	return mempool, wc.call(methodGetRawMempool, nil, &mempool)
+	var mempool []string
+	err := wc.call(methodGetRawMempool, nil, &mempool)
+	if err != nil {
+		return nil, err
+	}
+	// Convert recieved hex hashes to chainhash.Hash
+	hashes := make([]*chainhash.Hash, len(mempool))
+	for _, h := range mempool {
+		hash, err := chainhash.NewHashFromStr(h)
+		if err != nil {
+			return nil, err
+		}
+		hashes = append(hashes, hash)
+	}
+	return hashes, nil
 }
 
 func (wc *walletClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjson.TxRawResult, error) {

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -114,7 +114,7 @@ func (wc *walletClient) GetRawMempool() ([]*chainhash.Hash, error) {
 		return nil, err
 	}
 	// Convert recieved hex hashes to chainhash.Hash
-	hashes := make([]*chainhash.Hash, len(mempool))
+	hashes := make([]*chainhash.Hash, 0, len(mempool))
 	for _, h := range mempool {
 		hash, err := chainhash.NewHashFromStr(h)
 		if err != nil {

--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -111,7 +111,7 @@ func (wc *walletClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjs
 }
 
 // Balances retrieves a wallet's balance details.
-func (wc *walletClient) Balances(ctx context.Context) (*GetBalancesResult, error) {
+func (wc *walletClient) Balances() (*GetBalancesResult, error) {
 	var balances GetBalancesResult
 	return &balances, wc.call(methodGetBalances, nil, &balances)
 }

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -234,7 +234,7 @@ func (btc *Backend) Contract(coinID []byte, redeemScript []byte) (asset.Contract
 	return contract, nil
 }
 
-// VerifySecret checks that the secret satisfies the contract.
+// ValidateSecret checks that the secret satisfies the contract.
 func (btc *Backend) ValidateSecret(secret, contract []byte) bool {
 	_, _, _, secretHash, err := dexbtc.ExtractSwapDetails(contract, btc.segwit, btc.chainParams)
 	if err != nil {


### PR DESCRIPTION
This uses decred's `rpcclient/v6` for BTC wallet that all RPC calls are sent through `RawRequest`.


Closes #841 