### PR TITLE
acct ID and address logging on auth and register

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3064,8 +3064,8 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	}
 
 	// Set the account as authenticated.
-	c.log.Debugf("Authenticated connection to %s, %d active orders, %d active matches, score %d",
-		dc.acct.host, len(result.ActiveOrderStatuses), len(result.ActiveMatches), result.Score)
+	c.log.Debugf("Authenticated connection to %s, acct %v, %d active orders, %d active matches, score %d",
+		dc.acct.host, acctID, len(result.ActiveOrderStatuses), len(result.ActiveMatches), result.Score)
 	dc.acct.auth()
 
 	// Associate the matches with known trades.

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -1223,10 +1223,12 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 
 	err = conn.Send(respMsg)
 	if err != nil {
-		log.Error("error sending connect response: " + err.Error())
+		log.Error("Failed to send connect response: " + err.Error())
 		return nil
 	}
 
+	log.Infof("Authenticated account %v from %v with %d active orders, %d active matches",
+		user, conn.Addr(), len(msgOrderStatuses), len(msgMatches))
 	auth.addClient(client)
 	return nil
 }

--- a/server/auth/registrar.go
+++ b/server/auth/registrar.go
@@ -64,7 +64,7 @@ func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *
 		}
 	}
 
-	log.Infof("Created new user account %v with fee address %v", acct.ID, feeAddr)
+	log.Infof("Created new user account %v from %v with fee address %v", acct.ID, conn.Addr(), feeAddr)
 
 	// Prepare, sign, and send response.
 	regRes := &msgjson.RegisterResult{
@@ -239,7 +239,7 @@ func (auth *AuthManager) validateFee(conn comms.Link, acctID account.AccountID, 
 		return wait.DontTryAgain
 	}
 
-	log.Infof("New user registered: acct %v, paid %d to %v", acctID, val, addr)
+	log.Infof("New user registered: acct %v from %v paid %d to %v", acctID, conn.Addr(), val, addr)
 
 	// Create, sign, and send the the response.
 	auth.Sign(notifyFee)


### PR DESCRIPTION
**server**

`handleConnect` now logs the auth event:

> [INF] AUTH: Created new user account 54154d3ef759845e34ee3c681842371046304b9bd05494297409223a213c629f from 127.0.0.1 with fee address SsbeD1czwoAwqxV8fiq1sbhT7JsypYN5LPK
> ...
> [INF] AUTH: New user registered: acct 54154d3ef759845e34ee3c681842371046304b9bd05494297409223a213c629f from 127.0.0.1 paid 100000000 to SsbeD1czwoAwqxV8fiq1sbhT7JsypYN5LPK
> ...
> [INF] AUTH: Authenticated account 54154d3ef759845e34ee3c681842371046304b9bd05494297409223a213c629f from 127.0.0.1 with 0 active orders, 0 active matches


**client**

`authDEX` already logged, but now it includes the acct ID.

> [DBG] CORE: Authenticated connection to 127.0.0.1:17273, acct 54154d3ef759845e34ee3c681842371046304b9bd05494297409223a213c629f, 0 active orders, 0 active matches, score 0

Note that the client can retrieve their acct IDs from either the /settings page or the `exchanges` RPC accessible with dexcctl.