### PR TITLE
client/core: don't panic on reconfigure of disconnected wallet

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1667,7 +1667,9 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 	c.wallets[assetID] = wallet
 	c.walletMtx.Unlock()
 
-	go oldWallet.Disconnect()
+	if oldWallet.connected() {
+		go oldWallet.Disconnect()
+	}
 
 	c.notify(newBalanceNote(assetID, balances)) // redundant with wallet config note?
 	details := fmt.Sprintf("Configuration for %s wallet has been updated. Deposit address = %s",
@@ -3221,8 +3223,7 @@ func (c *Core) initialize() {
 			continue
 		}
 		// Wallet is loaded from the DB, but not yet connected.
-		c.log.Infof("Loaded %s wallet configuration. Deposit address = %s",
-			unbip(aid), dbWallet.Address)
+		c.log.Infof("Loaded %s wallet configuration.", unbip(aid))
 		c.wallets[dbWallet.AssetID] = wallet
 	}
 	numWallets := len(c.wallets)


### PR DESCRIPTION
A regression was introduced in https://github.com/decred/dcrdex/pull/925 where attempting to reconfigure a never-connected wallet would panic.  This can be reproduced as follows:

- configure a dexc and shutdown
- stop one of the wallets (e.g. dcrwallet)
- start dexc and login (`initialize()` creates the `xcWallet`s and leaves in the wallets map any that failed to connect on login)
- go to /wallets page and attempt to reconfigure the down wallet -> panic

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4d9574]

goroutine 962 [running]:
sync.(*WaitGroup).state(...)
	/home/jon/go115/src/sync/waitgroup.go:33
sync.(*WaitGroup).Wait(0x0)
	/home/jon/go115/src/sync/waitgroup.go:104 +0x34
decred.org/dcrdex/dex.(*ConnectionMaster).Disconnect(0xc0001a8280)
	/home/jon/github/decred/dcrdex/dex/runner.go:113 +0x89
decred.org/dcrdex/client/core.(*xcWallet).Disconnect(0xc0001ca780)
	/home/jon/github/decred/dcrdex/client/core/wallet.go:211 +0x57
created by decred.org/dcrdex/client/core.(*Core).ReconfigureWallet
	/home/jon/github/decred/dcrdex/client/core/core.go:1630 +0xf4a
```

The only resolution is to ensure the wallet is running and with the expected configuration (RPC, ports, etc) and start again.  If that is not possible, there is no resolution.