### PR TITLE
[0.1] client/core: don't panic on reconfigure of disconnected wallet

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1627,7 +1627,9 @@ func (c *Core) ReconfigureWallet(appPW []byte, assetID uint32, cfg map[string]st
 
 	c.wallets[assetID] = wallet
 
-	go oldWallet.Disconnect()
+	if oldWallet.connected() {
+		go oldWallet.Disconnect()
+	}
 
 	c.notify(newBalanceNote(assetID, balances)) // redundant with wallet config note?
 	details := fmt.Sprintf("Configuration for %s wallet has been updated. Deposit address = %s", unbip(assetID), wallet.address)
@@ -3067,8 +3069,7 @@ func (c *Core) initialize() {
 			continue
 		}
 		// Wallet is loaded from the DB, but not yet connected.
-		c.log.Infof("Loaded %s wallet configuration. Deposit address = %s",
-			unbip(aid), dbWallet.Address)
+		c.log.Infof("Loaded %s wallet configuration.", unbip(aid))
 		c.wallets[dbWallet.AssetID] = wallet
 	}
 	numWallets := len(c.wallets)


### PR DESCRIPTION
Backport of https://github.com/decred/dcrdex/pull/947 to the `release-0.1` branch.