### PR TITLE
client/db/bolt: backup before upgrade

### DIFF
--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -1174,6 +1174,13 @@ func (db *BoltDB) withBucket(bkt []byte, viewer txFunc, f bucketFunc) error {
 
 // Backup makes a copy of the database.
 func (db *BoltDB) Backup() error {
+	return db.backup("")
+}
+
+// backup makes a copy of the database to the specified file name in the backup
+// subfolder of the current DB file's folder. If fileName is empty, the current
+// DB's file name is used.
+func (db *BoltDB) backup(fileName string) error {
 	dir := filepath.Join(filepath.Dir(db.Path()), backupDir)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		err := os.Mkdir(dir, 0700)
@@ -1182,7 +1189,10 @@ func (db *BoltDB) Backup() error {
 		}
 	}
 
-	path := filepath.Join(dir, filepath.Base(db.Path()))
+	if fileName == "" {
+		fileName = filepath.Base(db.Path())
+	}
+	path := filepath.Join(dir, fileName)
 	err := db.View(func(tx *bbolt.Tx) error {
 		return tx.CopyFile(path, 0600)
 	})

--- a/client/db/bolt/upgrades_test.go
+++ b/client/db/bolt/upgrades_test.go
@@ -196,5 +196,6 @@ func unpack(t *testing.T, db string) (string, func()) {
 	return dbPath, func() {
 		dbFile.Close()
 		archive.Close()
+		os.RemoveAll(d)
 	}
 }


### PR DESCRIPTION
This creates a special backup of the dexc.db file prior to upgrade to a new version.
For example, if upgrading from version 1 to 2, it first writes a "dexc.db.v1.bak" file
in the backup subdirectory.
This is valuable for the following reasons:
1. Users have accidentally run on `master`, which is not advised since users should be on a release branch, and after the upgrade there is no way to go back
2. If the upgrade malfunctions in some fatal way, it would be great to have a pristine backup at the previous version.