### PR TITLE
testing: Add Ethereum simnet harness.

### DIFF
--- a/client/websocket/websocket.go
+++ b/client/websocket/websocket.go
@@ -253,7 +253,7 @@ out:
 			}
 			err = m.cl.Send(note)
 			if err != nil {
-				m.log.Debug("send error. ending market feed: %v", err)
+				m.log.Debugf("send error. ending market feed: %v", err)
 				break out
 			}
 		case <-ctx.Done():

--- a/dex/testing/eth/README.md
+++ b/dex/testing/eth/README.md
@@ -1,0 +1,43 @@
+# Ethereum Test Harness
+
+The harness is a collection of tmux scripts that collectively creates a
+sandboxed environment for testing dex swap transactions.
+
+## Dependencies
+
+The harness depends on [geth](https://github.com/ethereum/go-ethereum/tree/master/cmd/geth) to run.
+
+## Using
+
+You must have `geth` in `PATH` to use the harness.
+
+The harness script will create two connected private nodes both with mining
+abilities and pre-funded addresses.
+
+## Harness control scripts
+
+The `./harness.sh` script will drop you into a tmux window in a directory
+called `harness-ctl`. Inside of this directory are a number of scripts to
+allow you to perform RPC calls against each wallet.
+
+`./alpha` and `./beta` are just `geth` configured for their respective data
+directories.
+
+Try `./alpha attach`, for example. This will put you in an interactive console
+with the alpha node.
+
+`./quit` shuts down the nodes and closes the tmux session.
+
+`./mine-alpha n` and `./mine-beta n` will mine n blocks on the respective node.
+
+## Dev Stuff
+
+If things aren't looking right, you may need to look at the node windows to
+see errors. In tmux, you can navigate between windows by typing `Ctrl+b` and
+then the window number. The window numbers are listed at the bottom
+of the tmux window. `Ctrl+b` followed by the number `0`, for example, will
+change to the alpha node window. Examining the node output to look for errors
+is usually a good first debugging step.
+
+If you encouter a problem, the harness can be killed from another terminal with
+`tmux kill-session -t eth-harness`.

--- a/dex/testing/eth/create-node.sh
+++ b/dex/testing/eth/create-node.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Script for creating eth nodes.
+set -e
+
+# The following are required script arguments
+TMUX_WIN_ID=$1
+NAME=$2
+NODE_PORT=$3
+CHAIN_ADDRESS=$4
+CHAIN_PASSWORD=$5
+CHAIN_ADDRESS_JSON=$6
+CHAIN_ADDRESS_JSON_FILE_NAME=$7
+ADDRESS=$8
+ADDRESS_PASSWORD=$9
+ADDRESS_JSON=${10}
+ADDRESS_JSON_FILE_NAME=${11}
+NODE_KEY=${12}
+
+WALLET_DIR="${NODES_ROOT}/${NAME}"
+mkdir -p "${WALLET_DIR}"
+
+# Write wallet ctl script.
+cat > "${NODES_ROOT}/harness-ctl/${NAME}" <<EOF
+#!/bin/sh
+geth --datadir="${WALLET_DIR}" \$*
+EOF
+chmod +x "${NODES_ROOT}/harness-ctl/${NAME}"
+
+# Write mine script.
+cat > "${NODES_ROOT}/harness-ctl/mine-${NAME}" <<EOF
+#!/bin/sh
+  case \$1 in
+      ''|*[!0-9]*)  ;;
+      *) NUM=\$1 ;;
+  esac
+  for i in \$(seq \$NUM) ; do
+    ./${NAME} attach --preload "${MINE_JS}" --exec 'mine()'
+  done
+EOF
+chmod +x "${NODES_ROOT}/harness-ctl/mine-${NAME}"
+
+
+# Write password file to unlock accounts later.
+cat > "${WALLET_DIR}/password" <<EOF
+$CHAIN_PASSWORD
+$ADDRESS_PASSWORD
+EOF
+
+# Create a tmux window.
+tmux new-window -t "$TMUX_WIN_ID" -n "${NAME}"
+tmux send-keys -t "$TMUX_WIN_ID" "set +o history" C-m
+tmux send-keys -t "$TMUX_WIN_ID" "cd ${WALLET_DIR}" C-m
+
+# Create and wait for a wallet initiated with a predefined genesis json.
+echo "Creating simnet ${NAME} wallet"
+tmux send-keys -t "$TMUX_WIN_ID" "${NODES_ROOT}/harness-ctl/${NAME} init "\
+	"$GENESIS_JSON_FILE_LOCATION; tmux wait-for -S ${NAME}" C-m
+tmux wait-for "${NAME}"
+
+# Create two accounts. The first is used to mine blocks. The second contains
+# funds.
+echo "Creating account"
+cat > "${WALLET_DIR}/keystore/$CHAIN_ADDRESS_JSON_FILE_NAME" <<EOF
+$CHAIN_ADDRESS_JSON
+EOF
+cat > "${WALLET_DIR}/keystore/$ADDRESS_JSON_FILE_NAME" <<EOF
+$ADDRESS_JSON
+EOF
+
+# The node key lets us control the enode address value.
+echo "Setting node key"
+cat > "${WALLET_DIR}/geth/nodekey" <<EOF
+$NODE_KEY
+EOF
+
+# Start the eth node with both accounts unlocked, listening restricted to
+# localhost, and syncmode set to full.
+echo "Starting simnet ${NAME} wallet"
+tmux send-keys -t "$TMUX_WIN_ID" "${NODES_ROOT}/harness-ctl/${NAME} --port " \
+	"${NODE_PORT} --nodiscover --unlock ${CHAIN_ADDRESS},${ADDRESS} " \
+	"--password ${WALLET_DIR}/password --miner.etherbase ${CHAIN_ADDRESS} " \
+	"--syncmode full --netrestrict 127.0.0.1/32" C-m

--- a/dex/testing/eth/create-node.sh
+++ b/dex/testing/eth/create-node.sh
@@ -61,6 +61,28 @@ $CHAIN_PASSWORD
 $ADDRESS_PASSWORD
 EOF
 
+cat > "${NODE_DIR}/eth.conf" <<EOF
+[Eth]
+NetworkId = 42
+SyncMode = "full"
+
+[Eth.Miner]
+Etherbase = "0x${CHAIN_ADDRESS}"
+
+[Eth.Ethash]
+DatasetDir = "${NODE_DIR}/.ethash"
+
+[Node]
+DataDir = "${NODE_DIR}"
+
+[Node.P2P]
+NoDiscovery = true
+BootstrapNodes = []
+BootstrapNodesV5 = []
+ListenAddr = ":${NODE_PORT}"
+NetRestrict = [ "127.0.0.1/32" ]
+EOF
+
 # Create a tmux window.
 tmux new-window -t "$TMUX_WIN_ID" -n "${NAME}"
 tmux send-keys -t "$TMUX_WIN_ID" "set +o history" C-m
@@ -91,7 +113,6 @@ EOF
 # Start the eth node with both accounts unlocked, listening restricted to
 # localhost, and syncmode set to full.
 echo "Starting simnet ${NAME} node"
-tmux send-keys -t "$TMUX_WIN_ID" "${NODES_ROOT}/harness-ctl/${NAME} --port " \
-	"${NODE_PORT} --nodiscover --unlock ${CHAIN_ADDRESS},${ADDRESS} " \
-	"--password ${GROUP_DIR}/password --miner.etherbase ${CHAIN_ADDRESS} " \
-	"--syncmode full --netrestrict 127.0.0.1/32" C-m
+tmux send-keys -t "$TMUX_WIN_ID" "${NODES_ROOT}/harness-ctl/${NAME} --nodiscover " \
+	"--config ${NODE_DIR}/eth.conf --unlock ${CHAIN_ADDRESS},${ADDRESS} " \
+	"--password ${GROUP_DIR}/password" C-m

--- a/dex/testing/eth/create-node.sh
+++ b/dex/testing/eth/create-node.sh
@@ -31,6 +31,7 @@ chmod +x "${NODES_ROOT}/harness-ctl/${NAME}"
 # Write mine script.
 cat > "${NODES_ROOT}/harness-ctl/mine-${NAME}" <<EOF
 #!/bin/sh
+  NUM=1
   case \$1 in
       ''|*[!0-9]*)  ;;
       *) NUM=\$1 ;;

--- a/dex/testing/eth/create-node.sh
+++ b/dex/testing/eth/create-node.sh
@@ -23,14 +23,14 @@ mkdir -p "${NODE_DIR}"
 
 # Write node ctl script.
 cat > "${NODES_ROOT}/harness-ctl/${NAME}" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 geth --datadir="${NODE_DIR}" \$*
 EOF
 chmod +x "${NODES_ROOT}/harness-ctl/${NAME}"
 
 # Write mine script.
 cat > "${NODES_ROOT}/harness-ctl/mine-${NAME}" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
   NUM=1
   case \$1 in
       ''|*[!0-9]*)  ;;

--- a/dex/testing/eth/create-node.sh
+++ b/dex/testing/eth/create-node.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Script for creating eth nodes.
 set -e
 
@@ -80,11 +80,11 @@ NoDiscovery = true
 BootstrapNodes = []
 BootstrapNodesV5 = []
 ListenAddr = ":${NODE_PORT}"
-NetRestrict = [ "127.0.0.1/32" ]
+NetRestrict = [ "127.0.0.1/8", "::1/128" ]
 EOF
 
 # Create a tmux window.
-tmux new-window -t "$TMUX_WIN_ID" -n "${NAME}"
+tmux new-window -t "$TMUX_WIN_ID" -n "${NAME}" "${SHELL}"
 tmux send-keys -t "$TMUX_WIN_ID" "set +o history" C-m
 tmux send-keys -t "$TMUX_WIN_ID" "cd ${NODE_DIR}" C-m
 

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -44,7 +44,7 @@ echo "Writing ctl scripts"
 
 # Write genesis json. ".*Block" fields represent block height where certain
 # protocols take effect. "clique" is our proof of authority scheme. One block
-# can be mined per second with the a signature belonging to the address in
+# can be mined per second with a signature belonging to the address in
 # "extradata". The addresses in the "alloc" field are allocated "balance".
 cat > "${NODES_ROOT}/genesis.json" <<EOF
 {

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# Tmux script that sets up a simnet harness.
+set -ex
+
+SESSION="eth-harness"
+
+CHAIN_ADDRESS_JSON_FILE_NAME="UTC--2021-01-27T08-20-38.123221057Z--9ebba10a6136607688ca4f27fab70e23938cd027"
+CHAIN_ADDRESS="9ebba10a6136607688ca4f27fab70e23938cd027"
+CHAIN_ADDRESS_JSON='{"address":"9ebba10a6136607688ca4f27fab70e23938cd027","crypto":{"cipher":"aes-128-ctr","ciphertext":"dcfbe17de6f315c732855111b782496d76b2d703169afddaaa69e1bc9e02ec51","cipherparams":{"iv":"907e5e050649d1c5c0be782ec7db5cf1"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"060f4e16d601069a6bccae0693a15cd72090baf1ab20e408c89883117d4f7c51"},"mac":"b9ca7dad75a04b77dc7751a814c051f32752603334e4bb4046caf927196a5579"},"id":"74805e39-6a2f-46eb-8125-70c41d12c6d9","version":3}'
+
+ALPHA_ADDRESS="18d65fb8d60c1199bb1ad381be47aa692b482605"
+ALPHA_ADDRESS_JSON_FILE_NAME="UTC--2021-01-28T08-47-02.993754951Z--18d65fb8d60c1199bb1ad381be47aa692b482605"
+ALPHA_ADDRESS_JSON='{"address":"18d65fb8d60c1199bb1ad381be47aa692b482605","crypto":{"cipher":"aes-128-ctr","ciphertext":"927bc2432492fc4bbe9acfe0042f5cd2cef25aff251ac1fb2f420ee85e3b6ee4","cipherparams":{"iv":"89e7333535aed5284abd52f841d30c95"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"6fe29ea59d166989be533da62d79802a6b0cef26a9766fa363c7a4bb4c263b5f"},"mac":"c7e2b6c4538c373b2c4e0be7b343db618d39cc68fa872909059357ff36743ca0"},"id":"0e2b9cef-d659-4a26-8739-879129ed0b63","version":3}'
+ALPHA_NODE_KEY="71d810d39333296b518c846a3e49eca55f998fd7994998bb3e5048567f2f073c"
+# ALPHA_ENODE="897c84f6e4f18195413c1d02927e6a4093f5e7574b52bdec6f20844c4f1f6dd3f16036a9e600bd8681ab50fd8dd144df4a6ba9dd8722bb578a86aaa8222c964f"
+ALPHA_NODE_PORT="30302"
+
+BETA_ADDRESS="4f8ef3892b65ed7fc356ff473a2ef2ae5ec27a06"
+BETA_ADDRESS_JSON_FILE_NAME="UTC--2021-01-27T08-20-58.179642501Z--4f8ef3892b65ed7fc356ff473a2ef2ae5ec27a06"
+BETA_ADDRESS_JSON='{"address":"4f8ef3892b65ed7fc356ff473a2ef2ae5ec27a06","crypto":{"cipher":"aes-128-ctr","ciphertext":"c5672bb829df9e209ca8ce18dbdd1fed69c603d639e06ab09127b672a609c121","cipherparams":{"iv":"24460eb2934c8b61cee3ad0aa7b843c0"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"1f85da881994ca7b4a23f0698da70500a4b79f97a4450b83b129ebf3b4c28f50"},"mac":"1ecea707f1bffa1f6f944cb47e83118d8179e8a5005b83c88610b7e8692a1197"},"id":"56633762-6fb1-4cbf-8396-3a2e4661f7d4","version":3}'
+BETA_NODE_KEY="0f3f23a0f14202da009bd59a96457098acea901986629e54d5be1eea32fc404a"
+BETA_ENODE="b1d3e358ee5c9b268e911f2cab47bc12d0e65c80a6d2b453fece34facc9ac3caed14aa3bc7578166bb08c5bc9719e5a2267ae14e0b42da393f4d86f6d5829061"
+BETA_NODE_PORT="30303"
+
+# PASSWORD is the password used to unlock all accounts/wallets/addresses.
+PASSWORD="abc"
+
+export NODES_ROOT=~/dextest/eth
+export GENESIS_JSON_FILE_LOCATION="${NODES_ROOT}/genesis.json"
+export MINE_JS="${NODES_ROOT}/mine.js"
+
+if [ -d "${NODES_ROOT}" ]; then
+  rm -R "${NODES_ROOT}"
+fi
+
+mkdir -p "${NODES_ROOT}/alpha"
+mkdir -p "${NODES_ROOT}/beta"
+mkdir -p "${NODES_ROOT}/harness-ctl"
+
+echo "Writing ctl scripts"
+################################################################################
+# Control Scripts
+################################################################################
+
+# Write genesis json. ".*Block" fields represent block height where certain
+# protocols take effect. "clique" is our proof of authority scheme. One block
+# can be mined per second with the a signature belonging to the address in
+# "extradata". The addresses in the "alloc" field are allocated "balance".
+cat > "${NODES_ROOT}/genesis.json" <<EOF
+{
+  "config": {
+    "chainId": 42,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "clique": {
+      "period": 1,
+      "epoch": 30000
+    }
+  },
+  "difficulty": "1",
+  "gasLimit": "8000000",
+  "extradata": "0x00000000000000000000000000000000000000000000000000000000000000009ebba10a6136607688ca4f27fab70e23938cd0270000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "alloc": {
+    "18d65fb8d60c1199bb1ad381be47aa692b482605": {
+        "balance": "1000000000000"
+    },
+    "4f8ef3892b65ed7fc356ff473a2ef2ae5ec27a06": {
+        "balance": "1000000000000"
+    }
+  }
+}
+EOF
+
+# Write mining javascript.
+# NOTE: This sometimes mines more than one block. It is a race.
+cat > "${MINE_JS}" <<EOF
+function mine() {
+  miner.start();
+  miner.stop();
+  admin.sleep(1.1);
+  return true;
+}
+EOF
+
+# Add wallet script.
+HARNESS_DIR=$(dirname "$0")
+cp "${HARNESS_DIR}/create-node.sh" "${NODES_ROOT}/harness-ctl/create-node"
+
+# Reorg script
+# TODO: Make this.
+
+# Shutdown script
+cat > "${NODES_ROOT}/harness-ctl/quit" <<EOF
+#!/bin/sh
+tmux send-keys -t $SESSION:1 C-c
+tmux send-keys -t $SESSION:2 C-c
+tmux kill-session
+EOF
+chmod +x "${NODES_ROOT}/harness-ctl/quit"
+
+################################################################################
+# Start harness
+################################################################################
+
+echo "Starting harness"
+tmux new-session -d -s $SESSION
+tmux rename-window -t $SESSION:0 'harness-ctl'
+tmux send-keys -t $SESSION:0 "set +o history" C-m
+tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
+
+################################################################################
+# Eth nodes
+################################################################################
+
+echo "Starting simnet alpha node"
+"${HARNESS_DIR}/create-node.sh" "$SESSION:1" "alpha" "$ALPHA_NODE_PORT " \
+	"$CHAIN_ADDRESS" "$PASSWORD" "$CHAIN_ADDRESS_JSON " \
+	"$CHAIN_ADDRESS_JSON_FILE_NAME" "$ALPHA_ADDRESS" "$PASSWORD" \
+	"$ALPHA_ADDRESS_JSON " "$ALPHA_ADDRESS_JSON_FILE_NAME" "$ALPHA_NODE_KEY"
+
+echo "Starting simnet beta node"
+"${HARNESS_DIR}/create-node.sh" "$SESSION:2" "beta" "$BETA_NODE_PORT " \
+	"$CHAIN_ADDRESS" "$PASSWORD" "$CHAIN_ADDRESS_JSON " \
+	"$CHAIN_ADDRESS_JSON_FILE_NAME" "$BETA_ADDRESS" "$PASSWORD" \
+	"$BETA_ADDRESS_JSON " "$BETA_ADDRESS_JSON_FILE_NAME" "$BETA_NODE_KEY"
+
+# NOTE: This will cause beta to connect automatically to alpha.
+echo "Connecting nodes"
+"${NODES_ROOT}/harness-ctl/alpha" "attach --exec admin.addPeer('enode://${BETA_ENODE}@127.0.0.1:$BETA_NODE_PORT')"
+
+# Reenable history and attach to the control session.
+tmux select-window -t $SESSION:0
+tmux send-keys -t $SESSION:0 "set -o history" C-m
+tmux attach-session -t $SESSION

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -77,13 +77,16 @@ cat > "${NODES_ROOT}/genesis.json" <<EOF
 EOF
 
 # Write mining javascript.
-# NOTE: This sometimes mines more than one block. It is a race.
+# NOTE: This sometimes mines more than one block. It is a race. This returns
+# the number of blocks mined within the lifespan of the function, but one more
+# MAY be mined after returning.
 cat > "${MINE_JS}" <<EOF
 function mine() {
+  blkN = eth.blockNumber;
   miner.start();
   miner.stop();
   admin.sleep(1.1);
-  return true;
+  return eth.blockNumber - blkN;
 }
 EOF
 

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -84,7 +84,7 @@ cp "${HARNESS_DIR}/create-node.sh" "${NODES_ROOT}/harness-ctl/create-node"
 
 # Shutdown script
 cat > "${NODES_ROOT}/harness-ctl/quit" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 tmux send-keys -t $SESSION:1 C-c
 tmux send-keys -t $SESSION:2 C-c
 tmux kill-session

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -13,14 +13,14 @@ ALPHA_ADDRESS_JSON_FILE_NAME="UTC--2021-01-28T08-47-02.993754951Z--18d65fb8d60c1
 ALPHA_ADDRESS_JSON='{"address":"18d65fb8d60c1199bb1ad381be47aa692b482605","crypto":{"cipher":"aes-128-ctr","ciphertext":"927bc2432492fc4bbe9acfe0042f5cd2cef25aff251ac1fb2f420ee85e3b6ee4","cipherparams":{"iv":"89e7333535aed5284abd52f841d30c95"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"6fe29ea59d166989be533da62d79802a6b0cef26a9766fa363c7a4bb4c263b5f"},"mac":"c7e2b6c4538c373b2c4e0be7b343db618d39cc68fa872909059357ff36743ca0"},"id":"0e2b9cef-d659-4a26-8739-879129ed0b63","version":3}'
 ALPHA_NODE_KEY="71d810d39333296b518c846a3e49eca55f998fd7994998bb3e5048567f2f073c"
 # ALPHA_ENODE="897c84f6e4f18195413c1d02927e6a4093f5e7574b52bdec6f20844c4f1f6dd3f16036a9e600bd8681ab50fd8dd144df4a6ba9dd8722bb578a86aaa8222c964f"
-ALPHA_NODE_PORT="30302"
+ALPHA_NODE_PORT="30304"
 
 BETA_ADDRESS="4f8ef3892b65ed7fc356ff473a2ef2ae5ec27a06"
 BETA_ADDRESS_JSON_FILE_NAME="UTC--2021-01-27T08-20-58.179642501Z--4f8ef3892b65ed7fc356ff473a2ef2ae5ec27a06"
 BETA_ADDRESS_JSON='{"address":"4f8ef3892b65ed7fc356ff473a2ef2ae5ec27a06","crypto":{"cipher":"aes-128-ctr","ciphertext":"c5672bb829df9e209ca8ce18dbdd1fed69c603d639e06ab09127b672a609c121","cipherparams":{"iv":"24460eb2934c8b61cee3ad0aa7b843c0"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"1f85da881994ca7b4a23f0698da70500a4b79f97a4450b83b129ebf3b4c28f50"},"mac":"1ecea707f1bffa1f6f944cb47e83118d8179e8a5005b83c88610b7e8692a1197"},"id":"56633762-6fb1-4cbf-8396-3a2e4661f7d4","version":3}'
 BETA_NODE_KEY="0f3f23a0f14202da009bd59a96457098acea901986629e54d5be1eea32fc404a"
 BETA_ENODE="b1d3e358ee5c9b268e911f2cab47bc12d0e65c80a6d2b453fece34facc9ac3caed14aa3bc7578166bb08c5bc9719e5a2267ae14e0b42da393f4d86f6d5829061"
-BETA_NODE_PORT="30303"
+BETA_NODE_PORT="30305"
 
 # PASSWORD is the password used to unlock all accounts/wallets/addresses.
 PASSWORD="abc"
@@ -106,19 +106,20 @@ tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
 ################################################################################
 
 echo "Starting simnet alpha node"
-"${HARNESS_DIR}/create-node.sh" "$SESSION:1" "alpha" "$ALPHA_NODE_PORT " \
+"${HARNESS_DIR}/create-node.sh" "$SESSION:1" "alpha" "$ALPHA_NODE_PORT" \
 	"$CHAIN_ADDRESS" "$PASSWORD" "$CHAIN_ADDRESS_JSON " \
 	"$CHAIN_ADDRESS_JSON_FILE_NAME" "$ALPHA_ADDRESS" "$PASSWORD" \
-	"$ALPHA_ADDRESS_JSON " "$ALPHA_ADDRESS_JSON_FILE_NAME" "$ALPHA_NODE_KEY"
+	"$ALPHA_ADDRESS_JSON" "$ALPHA_ADDRESS_JSON_FILE_NAME" "$ALPHA_NODE_KEY"
 
 echo "Starting simnet beta node"
-"${HARNESS_DIR}/create-node.sh" "$SESSION:2" "beta" "$BETA_NODE_PORT " \
+"${HARNESS_DIR}/create-node.sh" "$SESSION:2" "beta" "$BETA_NODE_PORT" \
 	"$CHAIN_ADDRESS" "$PASSWORD" "$CHAIN_ADDRESS_JSON " \
 	"$CHAIN_ADDRESS_JSON_FILE_NAME" "$BETA_ADDRESS" "$PASSWORD" \
-	"$BETA_ADDRESS_JSON " "$BETA_ADDRESS_JSON_FILE_NAME" "$BETA_NODE_KEY"
+	"$BETA_ADDRESS_JSON" "$BETA_ADDRESS_JSON_FILE_NAME" "$BETA_NODE_KEY"
 
 # NOTE: This will cause beta to connect automatically to alpha.
 echo "Connecting nodes"
+
 "${NODES_ROOT}/harness-ctl/alpha" "attach --exec admin.addPeer('enode://${BETA_ENODE}@127.0.0.1:$BETA_NODE_PORT')"
 
 # Reenable history and attach to the control session.

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Tmux script that sets up a simnet harness.
 set -ex
 
@@ -96,7 +96,7 @@ chmod +x "${NODES_ROOT}/harness-ctl/quit"
 ################################################################################
 
 echo "Starting harness"
-tmux new-session -d -s $SESSION
+tmux new-session -d -s $SESSION "${SHELL}"
 tmux rename-window -t $SESSION:0 'harness-ctl'
 tmux send-keys -t $SESSION:0 "set +o history" C-m
 tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -119,7 +119,6 @@ echo "Starting simnet beta node"
 
 # NOTE: This will cause beta to connect automatically to alpha.
 echo "Connecting nodes"
-
 "${NODES_ROOT}/harness-ctl/alpha" "attach --exec admin.addPeer('enode://${BETA_ENODE}@127.0.0.1:$BETA_NODE_PORT')"
 
 # Reenable history and attach to the control session.

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -27,7 +27,6 @@ PASSWORD="abc"
 
 export NODES_ROOT=~/dextest/eth
 export GENESIS_JSON_FILE_LOCATION="${NODES_ROOT}/genesis.json"
-export MINE_JS="${NODES_ROOT}/mine.js"
 
 if [ -d "${NODES_ROOT}" ]; then
   rm -R "${NODES_ROOT}"
@@ -67,30 +66,16 @@ cat > "${NODES_ROOT}/genesis.json" <<EOF
   "extradata": "0x00000000000000000000000000000000000000000000000000000000000000009ebba10a6136607688ca4f27fab70e23938cd0270000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
   "alloc": {
     "18d65fb8d60c1199bb1ad381be47aa692b482605": {
-        "balance": "1000000000000"
+        "balance": "1000000000000000"
     },
     "4f8ef3892b65ed7fc356ff473a2ef2ae5ec27a06": {
-        "balance": "1000000000000"
+        "balance": "1000000000000000"
     }
   }
 }
 EOF
 
-# Write mining javascript.
-# NOTE: This sometimes mines more than one block. It is a race. This returns
-# the number of blocks mined within the lifespan of the function, but one more
-# MAY be mined after returning.
-cat > "${MINE_JS}" <<EOF
-function mine() {
-  blkN = eth.blockNumber;
-  miner.start();
-  miner.stop();
-  admin.sleep(1.1);
-  return eth.blockNumber - blkN;
-}
-EOF
-
-# Add wallet script.
+# Add node script.
 HARNESS_DIR=$(dirname "$0")
 cp "${HARNESS_DIR}/create-node.sh" "${NODES_ROOT}/harness-ctl/create-node"
 

--- a/spec/atomic.mediawiki
+++ b/spec/atomic.mediawiki
@@ -66,7 +66,7 @@ within a specified amount of time.
 
 Before Alice can '''prepare her initialization transaction''', she must generate
 a key known only to herself.
-From the key, Alice generates a &#x201C;lock&#x201D; and constructs an swap contract
+From the key, Alice generates a &#x201C;lock&#x201D; and constructs a swap contract
 such that if someone can provide both Alice&#x2019;s key and the pubkey for Bob&#x2019;s
 specified address, they can spend the output.
 In practice, the key is simply a random 32-byte sequence, and the lock is its


### PR DESCRIPTION
This adds a basic ethereum private network testing harness.

This network relies on proof of authority. More about this can be found here https://eips.ethereum.org/EIPS/eip-225

It creates two nodes, either of which can add new blocks to the network. Each node starts with funds that can be sent to addresses that we later create in tests.

The harness does not start an rpc client. I think it is best that we use ipc (Inter-process communication) as this seems to be the most secure. Other options are an http or ws server, but neither is permissioned. They can be restricted to the local network, but at that point it doesn't seem much different than using ipc.

closes #940