### PR TITLE
client/{core,db}: refactor db.MetaMatch struct, remove duplicate fields

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3213,7 +3213,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 		// Flag each of the missing matches as revoked.
 		for _, match := range missing {
 			c.log.Warnf("DEX %s did not report active match %s on order %s - assuming revoked.",
-				dc.acct.host, match.MatchID, oid)
+				dc.acct.host, match, oid)
 			// Must have been revoked while we were gone. Flag to allow recovery
 			// and subsequent retirement of the match and parent trade.
 			match.MetaData.Proof.SelfRevoked = true
@@ -3806,13 +3806,13 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 			if needsAuditInfo {
 				// Check for unresolvable states.
 				if len(counterSwap) == 0 {
-					match.swapErr = fmt.Errorf("missing counter-swap, order %s, match %s", tracker.ID(), match.MatchID)
+					match.swapErr = fmt.Errorf("missing counter-swap, order %s, match %s", tracker.ID(), match)
 					notifyErr(SubjectMatchStatusError, "Match %s for order %s is in state %s, but has no maker swap coin.", match.Side, tracker.token(), match.Status)
 					continue
 				}
 				counterContract := match.MetaData.Proof.CounterContract
 				if len(counterContract) == 0 {
-					match.swapErr = fmt.Errorf("missing counter-contract, order %s, match %s", tracker.ID(), match.MatchID)
+					match.swapErr = fmt.Errorf("missing counter-contract, order %s, match %s", tracker.ID(), match)
 					notifyErr(SubjectMatchStatusError, "Match %s for order %s is in state %s, but has no maker swap contract.", match.Side, tracker.token(), match.Status)
 					continue
 				}
@@ -3838,7 +3838,7 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 						if err != nil {
 							match.swapErr = fmt.Errorf("audit error: %w", err)
 							c.log.Debugf("AuditContract error for match %v status %v, refunded = %v, revoked = %v: %v",
-								match.MatchID, match.Status, len(match.MetaData.Proof.RefundCoin) > 0,
+								match, match.Status, len(match.MetaData.Proof.RefundCoin) > 0,
 								match.MetaData.Proof.IsRevoked(), err)
 							notifyErr(SubjectMatchRecoveryError, "Error auditing counter-party's swap contract (%s %v) during swap recovery on order %s: %v",
 								unbip(wallets.toAsset.ID), contractStr, tracker.token(), err)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -507,7 +507,7 @@ func (dc *dexConnection) compareServerMatches(srvMatches map[order.OrderID]*serv
 				extra = append(extra, msgMatch)
 				continue
 			}
-			if mt.Match.Status != order.MatchStatus(msgMatch.Status) {
+			if mt.Status != order.MatchStatus(msgMatch.Status) {
 				conflict := statusConflicts[oid]
 				if conflict == nil {
 					conflict = &matchStatusConflict{trade: match.tracker}
@@ -563,7 +563,7 @@ func (dc *dexConnection) compareServerMatches(srvMatches map[order.OrderID]*serv
 		// matches for this trade.
 		var missing []*matchTracker
 		for _, match := range activeMatches { // each local match
-			if !in(tradeMatches.msgMatches, match.id[:]) { // against reported matches
+			if !in(tradeMatches.msgMatches, match.MatchID[:]) { // against reported matches
 				missing = append(missing, match)
 			}
 		}
@@ -3213,7 +3213,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 		// Flag each of the missing matches as revoked.
 		for _, match := range missing {
 			c.log.Warnf("DEX %s did not report active match %s on order %s - assuming revoked.",
-				dc.acct.host, match.id, oid)
+				dc.acct.host, match.MatchID, oid)
 			// Must have been revoked while we were gone. Flag to allow recovery
 			// and subsequent retirement of the match and parent trade.
 			match.MetaData.Proof.SelfRevoked = true
@@ -3257,7 +3257,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 							continue
 						}
 						c.log.Infof("Queueing match status resolution for newly discovered match %v (%s) "+
-							"as taker to MakerSwapCast status.", matchID, match.Match.Status) // had better be NewlyMatched!
+							"as taker to MakerSwapCast status.", matchID, match.Status) // had better be NewlyMatched!
 
 						oid := trade.ID()
 						conflicts := matchConflicts[oid]
@@ -3599,12 +3599,11 @@ func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, e
 		for _, dbMatch := range dbMatches {
 			// Only trade matches are added to the matches map. Detect and skip
 			// cancel order matches, which have an empty Address field.
-			if dbMatch.Match.Address == "" {
+			if dbMatch.Address == "" {
 				// tracker.cancel is set from LinkedOrder with cancelTrade.
 				continue
 			}
-			tracker.matches[dbMatch.Match.MatchID] = &matchTracker{
-				id:        dbMatch.Match.MatchID,
+			tracker.matches[dbMatch.MatchID] = &matchTracker{
 				prefix:    tracker.Prefix(),
 				trade:     tracker.Trade(),
 				MetaMatch: *dbMatch,
@@ -3783,42 +3782,41 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 		isActive := tracker.metaData.Status == order.OrderStatusBooked || tracker.metaData.Status == order.OrderStatusEpoch
 		var matchesNeedingCoins []*matchTracker
 		for _, match := range tracker.matches {
-			dbMatch, metaData := match.Match, match.MetaData
 			var needsAuditInfo bool
 			var counterSwap []byte
-			if dbMatch.Side == order.Maker {
-				if dbMatch.Status < order.MakerSwapCast {
+			if match.Side == order.Maker {
+				if match.Status < order.MakerSwapCast {
 					matchesNeedingCoins = append(matchesNeedingCoins, match)
 				}
-				if dbMatch.Status == order.TakerSwapCast {
+				if match.Status == order.TakerSwapCast {
 					needsAuditInfo = true // maker needs AuditInfo for takers contract
-					counterSwap = metaData.Proof.TakerSwap
+					counterSwap = match.MetaData.Proof.TakerSwap
 				}
 			} else { // Taker
-				if dbMatch.Status < order.TakerSwapCast {
+				if match.Status < order.TakerSwapCast {
 					matchesNeedingCoins = append(matchesNeedingCoins, match)
 				}
-				if dbMatch.Status < order.MatchComplete && dbMatch.Status >= order.MakerSwapCast {
+				if match.Status < order.MatchComplete && match.Status >= order.MakerSwapCast {
 					needsAuditInfo = true // taker needs AuditInfo for maker's contract
-					counterSwap = metaData.Proof.MakerSwap
+					counterSwap = match.MetaData.Proof.MakerSwap
 				}
 			}
 			c.log.Tracef("Trade %v match %v needs coins = %v, needs audit info = %v",
-				tracker.ID(), match.id, len(matchesNeedingCoins) > 0, needsAuditInfo)
+				tracker.ID(), match.MatchID, len(matchesNeedingCoins) > 0, needsAuditInfo)
 			if needsAuditInfo {
 				// Check for unresolvable states.
 				if len(counterSwap) == 0 {
-					match.swapErr = fmt.Errorf("missing counter-swap, order %s, match %s", tracker.ID(), match.id)
-					notifyErr(SubjectMatchStatusError, "Match %s for order %s is in state %s, but has no maker swap coin.", dbMatch.Side, tracker.token(), dbMatch.Status)
+					match.swapErr = fmt.Errorf("missing counter-swap, order %s, match %s", tracker.ID(), match.MatchID)
+					notifyErr(SubjectMatchStatusError, "Match %s for order %s is in state %s, but has no maker swap coin.", match.Side, tracker.token(), match.Status)
 					continue
 				}
-				counterContract := metaData.Proof.CounterContract
+				counterContract := match.MetaData.Proof.CounterContract
 				if len(counterContract) == 0 {
-					match.swapErr = fmt.Errorf("missing counter-contract, order %s, match %s", tracker.ID(), match.id)
-					notifyErr(SubjectMatchStatusError, "Match %s for order %s is in state %s, but has no maker swap contract.", dbMatch.Side, tracker.token(), dbMatch.Status)
+					match.swapErr = fmt.Errorf("missing counter-contract, order %s, match %s", tracker.ID(), match.MatchID)
+					notifyErr(SubjectMatchStatusError, "Match %s for order %s is in state %s, but has no maker swap contract.", match.Side, tracker.token(), match.Status)
 					continue
 				}
-				counterTxData := metaData.Proof.CounterTxData
+				counterTxData := match.MetaData.Proof.CounterTxData
 
 				// Obtaining AuditInfo will fail if it's unmined AND gone from
 				// mempool, or the wallet is otherwise not ready. Note that this
@@ -3840,7 +3838,7 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 						if err != nil {
 							match.swapErr = fmt.Errorf("audit error: %w", err)
 							c.log.Debugf("AuditContract error for match %v status %v, refunded = %v, revoked = %v: %v",
-								match.id, match.MetaData.Status, len(match.MetaData.Proof.RefundCoin) > 0,
+								match.MatchID, match.Status, len(match.MetaData.Proof.RefundCoin) > 0,
 								match.MetaData.Proof.IsRevoked(), err)
 							notifyErr(SubjectMatchRecoveryError, "Error auditing counter-party's swap contract (%s %v) during swap recovery on order %s: %v",
 								unbip(wallets.toAsset.ID), contractStr, tracker.token(), err)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1773,7 +1773,7 @@ func TestLogin(t *testing.T) {
 	defer tracker.mtx.Unlock()
 	match = tracker.matches[extraID]
 	if !bytes.Equal(match.MetaData.Proof.CounterContract, missedContract) {
-		t.Errorf("Missed maker contract not retrieved, %s, %s", match.MatchID, hex.EncodeToString(match.MetaData.Proof.CounterContract))
+		t.Errorf("Missed maker contract not retrieved, %s, %s", match, hex.EncodeToString(match.MetaData.Proof.CounterContract))
 	}
 }
 

--- a/client/core/status.go
+++ b/client/core/status.go
@@ -15,7 +15,7 @@ import (
 // statusResolutionID is just a string with the basic information about a match.
 // This is used often while logging during status resolution.
 func statusResolutionID(dc *dexConnection, trade *trackedTrade, match *matchTracker) string {
-	return fmt.Sprintf("host = %s, order = %s, match = %s", dc.acct.host, trade.ID(), match.MatchID)
+	return fmt.Sprintf("host = %s, order = %s, match = %s", dc.acct.host, trade.ID(), match)
 }
 
 // resolveMatchConflicts attempts to resolve conflicts between the server's
@@ -201,7 +201,7 @@ func resolveMissedMakerAudit(dc *dexConnection, trade *trackedTrade, match *matc
 			match.MetaData.Proof.SelfRevoked = true
 			err = trade.db.UpdateMatch(&match.MetaMatch)
 			if err != nil {
-				trade.dc.log.Errorf("Error updating database for match %v: %v", match.MatchID, err)
+				trade.dc.log.Errorf("Error updating database for match %s: %v", match, err)
 			}
 		}
 	}()
@@ -244,7 +244,7 @@ func resolveMissedTakerAudit(dc *dexConnection, trade *trackedTrade, match *matc
 			match.MetaData.Proof.SelfRevoked = true
 			err = trade.db.UpdateMatch(&match.MetaMatch)
 			if err != nil {
-				trade.dc.log.Errorf("Error updating database for match %v: %v", match.MatchID, err)
+				trade.dc.log.Errorf("Error updating database for match %s: %v", match, err)
 			}
 		}
 	}()

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -189,12 +189,12 @@ func matchFromMetaMatch(ord order.Order, metaMatch *db.MetaMatch) *Match {
 // and sets the confirmations for swaps-in-waiting.
 func matchFromMetaMatchWithConfs(ord order.Order, metaMatch *db.MetaMatch, swapConfs, swapReq, counterSwapConfs, counterReq int64) *Match {
 	if _, isCancel := ord.(*order.CancelOrder); isCancel {
-		fmt.Println("matchFromMetaMatchWithConfs got a cancel order for match", metaMatch.Match.MatchID)
+		fmt.Println("matchFromMetaMatchWithConfs got a cancel order for match", metaMatch.MatchID)
 		return &Match{}
 	}
-	side := metaMatch.Match.Side
+	side := metaMatch.Side
 	sell := ord.Trade().Sell
-	status := metaMatch.Match.Status
+	status := metaMatch.Status
 
 	fromID, toID := ord.Quote(), ord.Base()
 	if sell {
@@ -239,7 +239,7 @@ func matchFromMetaMatchWithConfs(ord order.Order, metaMatch *db.MetaMatch, swapC
 		counterRedeem = NewCoin(fromID, counterRedeemCoin)
 	}
 
-	userMatch, proof := metaMatch.Match, &metaMatch.MetaData.Proof
+	userMatch, proof := metaMatch.UserMatch, &metaMatch.MetaData.Proof
 	match := &Match{
 		MatchID:       userMatch.MatchID[:],
 		Status:        userMatch.Status,

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -189,7 +189,7 @@ func matchFromMetaMatch(ord order.Order, metaMatch *db.MetaMatch) *Match {
 // and sets the confirmations for swaps-in-waiting.
 func matchFromMetaMatchWithConfs(ord order.Order, metaMatch *db.MetaMatch, swapConfs, swapReq, counterSwapConfs, counterReq int64) *Match {
 	if _, isCancel := ord.(*order.CancelOrder); isCancel {
-		fmt.Println("matchFromMetaMatchWithConfs got a cancel order for match", metaMatch.MatchID)
+		fmt.Println("matchFromMetaMatchWithConfs got a cancel order for match", metaMatch)
 		return &Match{}
 	}
 	side := metaMatch.Side

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -843,16 +843,16 @@ func TestMatches(t *testing.T) {
 		}
 		m := &db.MetaMatch{
 			MetaData: &db.MatchMetaData{
-				Status: status,
-				Proof:  *dbtest.RandomMatchProof(0.5),
-				DEX:    acct.Host,
-				Base:   base,
-				Quote:  quote,
-				Stamp:  rand.Uint64(),
+				Proof: *dbtest.RandomMatchProof(0.5),
+				DEX:   acct.Host,
+				Base:  base,
+				Quote: quote,
+				Stamp: rand.Uint64(),
 			},
-			Match: ordertest.RandomUserMatch(),
+			UserMatch: ordertest.RandomUserMatch(),
 		}
-		matchIndex[m.Match.MatchID] = m
+		m.Status = status
+		matchIndex[m.MatchID] = m
 		metaMatches = append(metaMatches, m)
 	})
 	tStart := time.Now()
@@ -874,9 +874,9 @@ func TestMatches(t *testing.T) {
 	}
 	activeOrders := make(map[order.OrderID]bool)
 	for _, m1 := range activeMatches {
-		activeOrders[m1.Match.OrderID] = true
-		m2 := matchIndex[m1.Match.MatchID]
-		ordertest.MustCompareUserMatch(t, m1.Match, m2.Match)
+		activeOrders[m1.OrderID] = true
+		m2 := matchIndex[m1.MatchID]
+		ordertest.MustCompareUserMatch(t, m1.UserMatch, m2.UserMatch)
 		dbtest.MustCompareMatchMetaData(t, m1.MetaData, m2.MetaData)
 	}
 	t.Logf("%d milliseconds to retrieve and compare %d active MetaMatch", time.Since(tStart)/time.Millisecond, numActive)
@@ -896,15 +896,15 @@ func TestMatches(t *testing.T) {
 
 	m := &db.MetaMatch{
 		MetaData: &db.MatchMetaData{
-			Status: order.NewlyMatched,
-			Proof:  *dbtest.RandomMatchProof(0.5),
-			DEX:    acct.Host,
-			Base:   base,
-			Quote:  quote,
-			Stamp:  rand.Uint64(),
+			Proof: *dbtest.RandomMatchProof(0.5),
+			DEX:   acct.Host,
+			Base:  base,
+			Quote: quote,
+			Stamp: rand.Uint64(),
 		},
-		Match: ordertest.RandomUserMatch(),
+		UserMatch: ordertest.RandomUserMatch(),
 	}
+	m.Status = order.NewlyMatched
 
 	m.MetaData.DEX = ""
 	err = boltdb.UpdateMatch(m)
@@ -916,7 +916,7 @@ func TestMatches(t *testing.T) {
 	m.MetaData.Base, m.MetaData.Quote = 0, 0
 	err = boltdb.UpdateMatch(m)
 	if err == nil {
-		t.Fatalf("no error on double zero base/quote")
+		t.Fatalf("no error on same base and quote")
 	}
 	m.MetaData.Base, m.MetaData.Quote = base, quote
 

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -188,9 +188,6 @@ func MustCompareMatchAuth(t testKiller, a1, a2 *db.MatchAuth) {
 // MustCompareMatchMetaData ensure the two MatchMetaData are identical, calling
 // the Fatalf method of the testKiller if not.
 func MustCompareMatchMetaData(t testKiller, m1, m2 *db.MatchMetaData) {
-	if m1.Status != m2.Status {
-		t.Fatalf("Status mismatch. %d != %d", m1.Status, m2.Status)
-	}
 	if m1.DEX != m2.DEX {
 		t.Fatalf("DEX mismatch. %d != %d", m1.DEX, m2.DEX)
 	}

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -193,29 +193,21 @@ type OrderMetaData struct {
 	MaxFeeRate uint64
 }
 
-// MetaMatch is the match and its metadata.
+// MetaMatch is a match and its metadata.
 type MetaMatch struct {
+	// UserMatch is the match info.
+	*order.UserMatch
 	// MetaData is important auxiliary information about the match.
 	MetaData *MatchMetaData
-	// Match is the match info.
-	Match *order.UserMatch
 }
 
-// SetStatus sets the match status in both the UserMatch and the MatchMetaData.
-func (m *MetaMatch) SetStatus(status order.MatchStatus) {
-	m.MetaData.Status = status
-	m.Match.Status = status
-}
-
-// ID is a unique ID for the match-order pair.
-func (m *MetaMatch) ID() []byte {
-	return hashKey(append(m.Match.MatchID[:], m.Match.OrderID[:]...))
+// MatchOrderUniqueID is a unique ID for the match-order pair.
+func (m *MetaMatch) MatchOrderUniqueID() []byte {
+	return hashKey(append(m.MatchID[:], m.OrderID[:]...))
 }
 
 // MatchMetaData is important auxiliary information about the match.
 type MatchMetaData struct {
-	// Status is the last known match status.
-	Status order.MatchStatus
 	// Proof is the signatures and other verification-related data for the match.
 	Proof MatchProof
 	// DEX is the URL of the server that this match is associated with.

--- a/dex/order/match.go
+++ b/dex/order/match.go
@@ -187,6 +187,11 @@ type UserMatch struct {
 	// TODO: include Sell bool?
 }
 
+// String is the match ID string, implements fmt.Stringer.
+func (m *UserMatch) String() string {
+	return m.MatchID.String()
+}
+
 // A constructor for a Match with Status = NewlyMatched. This is the preferred
 // method of making a Match, since it pre-calculates and caches the match ID.
 func newMatch(taker Order, maker *LimitOrder, qty, rate uint64, epochID EpochID) *Match {


### PR DESCRIPTION
Remove following duplicate fields:
- ~`matchTracker.id`~ => `matchTracker.Match.MatchID` (from `order.UserMatch` embedded via `db.MetaMatch`)
- ~`db.MetaMatch.MetaData.Status`~ => `db.MetaMatch.Status` (from embedded `order.UserMatch`); this change also reflects in ~`matchTracker.MetaData.Status`~ => `matchTracker.Status`, `matchTracker` embeds `db.MetaMatch`.

Having duplicate fields in different paths of the same object means both fields have to be simultaneously updated otherwise an error could result. Primary motivation for this is making it tougher to shoot ourselves in the foot in this regard.

The issue with the duplicate id fields came to the fore when I needed to use both `matchTracker.id` and `db.MetaMatch.Match.MatchID` fields in a recent modification to the core_tests (67e2c6c1d33e7d64302e572034a4c62cdf157714) and noticed I had to manually set both to the same value in different places.

Haven't ran into an issue with the duplicate status fields yet, but having a single updateable status field will come in handy in #957, where status updates may require updating the `match.Retired` field as well; updating the "wrong" status field could prevent a match from being retired. There exists a `db.MetaMatch.SetStatus()` method that should prevent potential issues by updating both status fields but since neither status fields are private, they can easily be modified without using the `SetStatus` method and we can proactively prevent this unwanted behaviour by keeping just a single status field.