### PR TITLE
scripts: force bash with shebang.

### DIFF
--- a/client/cmd/dexcctl/simnet-setup.sh
+++ b/client/cmd/dexcctl/simnet-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Set up DCR and BTC wallets and register with the DEX.
 # dcrdex, dexc, and the wallet simnet harnesses should all be running before
 # calling this script.

--- a/dex/testing/btc/base-harness.sh
+++ b/dex/testing/btc/base-harness.sh
@@ -26,6 +26,8 @@ WAIT="wait-for ${SYMBOL}"
 
 SESSION="${SYMBOL}-harness"
 
+export SHELL=$(which bash)
+
 ################################################################################
 # Load prepared wallet if the files exist.
 ################################################################################
@@ -39,7 +41,7 @@ else
   mkdir -p "${BETA_DIR}"
 fi
 
-cd ${NODES_ROOT} && tmux new-session -d -s $SESSION
+cd ${NODES_ROOT} && tmux new-session -d -s $SESSION $SHELL
 
 ################################################################################
 # Write config files.
@@ -86,7 +88,7 @@ sleep 3
 # Setup the beta node.
 ################################################################################
 
-tmux new-window -t $SESSION:1 -n 'beta'
+tmux new-window -t $SESSION:1 -n 'beta' $SHELL
 tmux send-keys -t $SESSION:1 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${BETA_DIR}" C-m
 
@@ -101,7 +103,7 @@ sleep 3
 # Setup the harness-ctl directory
 ################################################################################
 
-tmux new-window -t $SESSION:2 -n 'harness-ctl'
+tmux new-window -t $SESSION:2 -n 'harness-ctl' $SHELL
 tmux send-keys -t $SESSION:2 "set +o history" C-m
 tmux send-keys -t $SESSION:2 "cd ${HARNESS_DIR}" C-m
 sleep 1
@@ -109,43 +111,43 @@ sleep 1
 cd ${HARNESS_DIR}
 
 cat > "./alpha" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 ${CLI} ${ALPHA_CLI_CFG} "\$@"
 EOF
 chmod +x "./alpha"
 
 cat > "./mine-alpha" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 ${CLI} ${ALPHA_CLI_CFG} generatetoaddress \$1 ${ALPHA_MINING_ADDR}
 EOF
 chmod +x "./mine-alpha"
 
 cat > "./gamma" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 ${CLI} ${GAMMA_CLI_CFG} "\$@"
 EOF
 chmod +x "./gamma"
 
 cat > "./delta" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 ${CLI} -rpcwallet=delta -rpcport=${BETA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass "\$@"
 EOF
 chmod +x "./delta"
 
 cat > "./beta" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 ${CLI} ${BETA_CLI_CFG} "\$@"
 EOF
 chmod +x "./beta"
 
 cat > "./mine-beta" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 ${CLI} ${BETA_CLI_CFG} generatetoaddress \$1 ${BETA_MINING_ADDR}
 EOF
 chmod +x "./mine-beta"
 
 cat > "./reorg" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 set -x
 echo "Disconnecting beta from alpha"
 sleep 1
@@ -163,13 +165,13 @@ EOF
 chmod +x "./reorg"
 
 cat > "./new-wallet" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 ./\$1 createwallet \$2
 EOF
 chmod +x "./new-wallet"
 
 cat > "${HARNESS_DIR}/quit" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 tmux send-keys -t $SESSION:0 C-c
 tmux send-keys -t $SESSION:1 C-c
 tmux wait-for alpha${SYMBOL}

--- a/dex/testing/btc/base-harness.sh
+++ b/dex/testing/btc/base-harness.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Tmux script that sets up a simnet harness.
 set -ex
 NODES_ROOT=~/dextest/${SYMBOL}
@@ -73,7 +73,7 @@ EOF
 ################################################################################
 
 tmux rename-window -t $SESSION:0 'alpha'
-tmux send-keys -t $SESSION:0 "set +o history" C-m
+tmux send-keys -t $SESSION:0 "set +o nolog" C-m
 tmux send-keys -t $SESSION:0 "cd ${ALPHA_DIR}" C-m
 echo "Starting simnet alpha node"
 tmux send-keys -t $SESSION:0 "${DAEMON} -rpcuser=user -rpcpassword=pass \
@@ -87,7 +87,7 @@ sleep 3
 ################################################################################
 
 tmux new-window -t $SESSION:1 -n 'beta'
-tmux send-keys -t $SESSION:1 "set +o history" C-m
+tmux send-keys -t $SESSION:1 "set +o nolog" C-m
 tmux send-keys -t $SESSION:1 "cd ${BETA_DIR}" C-m
 
 echo "Starting simnet beta node"
@@ -102,7 +102,7 @@ sleep 3
 ################################################################################
 
 tmux new-window -t $SESSION:2 -n 'harness-ctl'
-tmux send-keys -t $SESSION:2 "set +o history" C-m
+tmux send-keys -t $SESSION:2 "set +o nolog" C-m
 tmux send-keys -t $SESSION:2 "cd ${HARNESS_DIR}" C-m
 sleep 1
 
@@ -291,6 +291,6 @@ done
 tmux send-keys -t $SESSION:2 "./mine-alpha 2${DONE}" C-m\; ${WAIT}
 
 
-# Reenable history and attach to the control session.
-tmux send-keys -t $SESSION:2 "set -o history" C-m
+# Reenable log and attach to the control session.
+tmux send-keys -t $SESSION:2 "set -o nolog" C-m
 tmux attach-session -t $SESSION

--- a/dex/testing/btc/base-harness.sh
+++ b/dex/testing/btc/base-harness.sh
@@ -73,7 +73,7 @@ EOF
 ################################################################################
 
 tmux rename-window -t $SESSION:0 'alpha'
-tmux send-keys -t $SESSION:0 "set +o nolog" C-m
+tmux send-keys -t $SESSION:0 "set +o history" C-m
 tmux send-keys -t $SESSION:0 "cd ${ALPHA_DIR}" C-m
 echo "Starting simnet alpha node"
 tmux send-keys -t $SESSION:0 "${DAEMON} -rpcuser=user -rpcpassword=pass \
@@ -87,7 +87,7 @@ sleep 3
 ################################################################################
 
 tmux new-window -t $SESSION:1 -n 'beta'
-tmux send-keys -t $SESSION:1 "set +o nolog" C-m
+tmux send-keys -t $SESSION:1 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${BETA_DIR}" C-m
 
 echo "Starting simnet beta node"
@@ -102,7 +102,7 @@ sleep 3
 ################################################################################
 
 tmux new-window -t $SESSION:2 -n 'harness-ctl'
-tmux send-keys -t $SESSION:2 "set +o nolog" C-m
+tmux send-keys -t $SESSION:2 "set +o history" C-m
 tmux send-keys -t $SESSION:2 "cd ${HARNESS_DIR}" C-m
 sleep 1
 
@@ -291,6 +291,6 @@ done
 tmux send-keys -t $SESSION:2 "./mine-alpha 2${DONE}" C-m\; ${WAIT}
 
 
-# Reenable log and attach to the control session.
-tmux send-keys -t $SESSION:2 "set -o nolog" C-m
+# Reenable history and attach to the control session.
+tmux send-keys -t $SESSION:2 "set -o history" C-m
 tmux attach-session -t $SESSION

--- a/dex/testing/btc/harness.sh
+++ b/dex/testing/btc/harness.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 export SYMBOL="btc"
 export DAEMON="bitcoind"
 export CLI="bitcoin-cli"

--- a/dex/testing/dcr/create-wallet.sh
+++ b/dex/testing/dcr/create-wallet.sh
@@ -70,7 +70,7 @@ EOF
 
 # create and unlock the wallet
 tmux new-window -t $TMUX_WIN_ID -n w-"${NAME}"
-tmux send-keys -t $TMUX_WIN_ID "set +o nolog" C-m
+tmux send-keys -t $TMUX_WIN_ID "set +o history" C-m
 tmux send-keys -t $TMUX_WIN_ID "cd ${WALLET_DIR}" C-m
 
 echo "Creating simnet ${NAME} wallet"

--- a/dex/testing/dcr/create-wallet.sh
+++ b/dex/testing/dcr/create-wallet.sh
@@ -70,7 +70,7 @@ EOF
 
 # create and unlock the wallet
 tmux new-window -t $TMUX_WIN_ID -n w-"${NAME}"
-tmux send-keys -t $TMUX_WIN_ID "set +o history" C-m
+tmux send-keys -t $TMUX_WIN_ID "set +o nolog" C-m
 tmux send-keys -t $TMUX_WIN_ID "cd ${WALLET_DIR}" C-m
 
 echo "Creating simnet ${NAME} wallet"

--- a/dex/testing/dcr/create-wallet.sh
+++ b/dex/testing/dcr/create-wallet.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Script for creating dcr wallets, dcr harness should be running before executing.
 set -e
 
@@ -11,6 +11,8 @@ ENABLE_VOTING=$5
 
 WALLET_DIR="${NODES_ROOT}/${NAME}"
 mkdir -p ${WALLET_DIR}
+
+export SHELL=$(which bash)
 
 # Connect to alpha or beta node
 DCRD_RPC_PORT="19570"
@@ -55,7 +57,7 @@ EOF
 
 # wallet ctl script
 cat > "${NODES_ROOT}/harness-ctl/${NAME}" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 dcrctl -C "${WALLET_DIR}/${NAME}-ctl.conf" --wallet \$*
 EOF
 chmod +x "${NODES_ROOT}/harness-ctl/${NAME}"
@@ -69,7 +71,7 @@ ${SEED}
 EOF
 
 # create and unlock the wallet
-tmux new-window -t $TMUX_WIN_ID -n w-"${NAME}"
+tmux new-window -t $TMUX_WIN_ID -n w-"${NAME}" $SHELL
 tmux send-keys -t $TMUX_WIN_ID "set +o history" C-m
 tmux send-keys -t $TMUX_WIN_ID "cd ${WALLET_DIR}" C-m
 

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -169,7 +169,7 @@ EOF
 echo "Starting harness"
 tmux new-session -d -s $SESSION
 tmux rename-window -t $SESSION:0 'harness-ctl'
-tmux send-keys -t $SESSION:0 "set +o nolog" C-m
+tmux send-keys -t $SESSION:0 "set +o history" C-m
 tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
 
 ################################################################################
@@ -177,7 +177,7 @@ tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
 ################################################################################
 
 tmux new-window -t $SESSION:1 -n 'alpha'
-tmux send-keys -t $SESSION:1 "set +o nolog" C-m
+tmux send-keys -t $SESSION:1 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${NODES_ROOT}/alpha" C-m
 
 echo "Starting simnet alpha node"
@@ -190,7 +190,7 @@ tmux send-keys -t $SESSION:1 "dcrd --appdata=${NODES_ROOT}/alpha \
 --simnet; tmux wait-for -S alphadcr" C-m
 
 tmux new-window -t $SESSION:2 -n 'beta'
-tmux send-keys -t $SESSION:2 "set +o nolog" C-m
+tmux send-keys -t $SESSION:2 "set +o history" C-m
 tmux send-keys -t $SESSION:2 "cd ${NODES_ROOT}/beta" C-m
 
 echo "Starting simnet beta node"
@@ -286,6 +286,6 @@ done
 sleep 0.5
 tmux send-keys -t $SESSION:0 "./mine-alpha 2${WAIT}" C-m\; wait-for donedcr
 
-# Reenable log and attach to the control session.
-tmux send-keys -t $SESSION:0 "set -o nolog" C-m
+# Reenable history and attach to the control session.
+tmux send-keys -t $SESSION:0 "set -o history" C-m
 tmux attach-session -t $SESSION

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -30,6 +30,8 @@ WAIT="; tmux wait-for -S donedcr"
 NODES_ROOT=~/dextest/dcr
 export NODES_ROOT
 
+export SHELL=$(which bash)
+
 if [ -d "${NODES_ROOT}" ]; then
   rm -R "${NODES_ROOT}"
 fi
@@ -63,7 +65,7 @@ cp "${HARNESS_DIR}/create-wallet.sh" "${NODES_ROOT}/harness-ctl/create-wallet"
 
 # Script to send funds from alpha to address
 cat > "${NODES_ROOT}/harness-ctl/fund" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 ./alpha sendtoaddress \$@
 sleep 0.5
 ./mine-alpha 1
@@ -72,7 +74,7 @@ chmod +x "${NODES_ROOT}/harness-ctl/fund"
 
 # Alpha mine script
 cat > "${NODES_ROOT}/harness-ctl/mine-alpha" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
   case \$1 in
       ''|*[!0-9]*)  ;;
       *) NUM=\$1 ;;
@@ -90,7 +92,7 @@ chmod +x "${NODES_ROOT}/harness-ctl/mine-alpha"
 
 # Beta mine script
 cat > "${NODES_ROOT}/harness-ctl/mine-beta" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 NUM=1
   case \$1 in
       ''|*[!0-9]*)  ;;
@@ -109,7 +111,7 @@ chmod +x "${NODES_ROOT}/harness-ctl/mine-beta"
 
 # Reorg script
 cat > "${NODES_ROOT}/harness-ctl/reorg" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 echo "Disconnecting beta from alpha"
 sleep 1
 ./beta addnode 127.0.0.1:${ALPHA_NODE_PORT} remove
@@ -128,7 +130,7 @@ chmod +x "${NODES_ROOT}/harness-ctl/reorg"
 
 # Shutdown script
 cat > "${NODES_ROOT}/harness-ctl/quit" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 tmux send-keys -t $SESSION:3 C-c
 tmux send-keys -t $SESSION:4 C-c
 tmux send-keys -t $SESSION:5 C-c
@@ -143,7 +145,7 @@ EOF
 chmod +x "${NODES_ROOT}/harness-ctl/quit"
 
 cat > "${NODES_ROOT}/harness-ctl/new-wallet" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 ./\$1 createnewaccount \$2
 EOF
 chmod +x "${NODES_ROOT}/harness-ctl/new-wallet"
@@ -167,7 +169,7 @@ EOF
 ################################################################################
 
 echo "Starting harness"
-tmux new-session -d -s $SESSION
+tmux new-session -d -s $SESSION $SHELL
 tmux rename-window -t $SESSION:0 'harness-ctl'
 tmux send-keys -t $SESSION:0 "set +o history" C-m
 tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
@@ -176,7 +178,7 @@ tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
 # dcrd Nodes
 ################################################################################
 
-tmux new-window -t $SESSION:1 -n 'alpha'
+tmux new-window -t $SESSION:1 -n 'alpha' $SHELL
 tmux send-keys -t $SESSION:1 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${NODES_ROOT}/alpha" C-m
 
@@ -189,7 +191,7 @@ tmux send-keys -t $SESSION:1 "dcrd --appdata=${NODES_ROOT}/alpha \
 --whitelist=127.0.0.0/8 --whitelist=::1 \
 --simnet; tmux wait-for -S alphadcr" C-m
 
-tmux new-window -t $SESSION:2 -n 'beta'
+tmux new-window -t $SESSION:2 -n 'beta' $SHELL
 tmux send-keys -t $SESSION:2 "set +o history" C-m
 tmux send-keys -t $SESSION:2 "cd ${NODES_ROOT}/beta" C-m
 

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Tmux script that sets up a simnet harness.
 set -ex
 SESSION="dcr-harness"
@@ -169,7 +169,7 @@ EOF
 echo "Starting harness"
 tmux new-session -d -s $SESSION
 tmux rename-window -t $SESSION:0 'harness-ctl'
-tmux send-keys -t $SESSION:0 "set +o history" C-m
+tmux send-keys -t $SESSION:0 "set +o nolog" C-m
 tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
 
 ################################################################################
@@ -177,7 +177,7 @@ tmux send-keys -t $SESSION:0 "cd ${NODES_ROOT}/harness-ctl" C-m
 ################################################################################
 
 tmux new-window -t $SESSION:1 -n 'alpha'
-tmux send-keys -t $SESSION:1 "set +o history" C-m
+tmux send-keys -t $SESSION:1 "set +o nolog" C-m
 tmux send-keys -t $SESSION:1 "cd ${NODES_ROOT}/alpha" C-m
 
 echo "Starting simnet alpha node"
@@ -190,7 +190,7 @@ tmux send-keys -t $SESSION:1 "dcrd --appdata=${NODES_ROOT}/alpha \
 --simnet; tmux wait-for -S alphadcr" C-m
 
 tmux new-window -t $SESSION:2 -n 'beta'
-tmux send-keys -t $SESSION:2 "set +o history" C-m
+tmux send-keys -t $SESSION:2 "set +o nolog" C-m
 tmux send-keys -t $SESSION:2 "cd ${NODES_ROOT}/beta" C-m
 
 echo "Starting simnet beta node"
@@ -286,6 +286,6 @@ done
 sleep 0.5
 tmux send-keys -t $SESSION:0 "./mine-alpha 2${WAIT}" C-m\; wait-for donedcr
 
-# Reenable history and attach to the control session.
-tmux send-keys -t $SESSION:0 "set -o history" C-m
+# Reenable log and attach to the control session.
+tmux send-keys -t $SESSION:0 "set -o nolog" C-m
 tmux attach-session -t $SESSION

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Tmux script that configures and runs dcrdex.
 
 set -e

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -133,7 +133,7 @@ EOF
 
 # DEX admin script
 cat > "${DCRDEX_DATA_DIR}/dexadm" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 if [[ "\$#" -eq "2" ]]; then
     curl --cacert ${DCRDEX_DATA_DIR}/rpc.cert --basic -u u:adminpass --header "Content-Type: text/plain" --data-binary "\$2" https://127.0.0.1:16542/api/\$1
 else
@@ -144,9 +144,11 @@ chmod +x "${DCRDEX_DATA_DIR}/dexadm"
 
 SESSION="dcrdex-harness"
 
+export SHELL=$(which bash)
+
 # Shutdown script
 cat > "${DCRDEX_DATA_DIR}/quit" <<EOF
-#!/bin/sh
+#!/usr/bin/env bash
 tmux send-keys -t $SESSION:0 C-c
 tmux wait-for donedex
 tmux kill-session -t $SESSION
@@ -154,7 +156,7 @@ EOF
 chmod +x "${DCRDEX_DATA_DIR}/quit"
 
 echo "Starting dcrdex"
-tmux new-session -d -s $SESSION
+tmux new-session -d -s $SESSION $SHELL
 tmux rename-window -t $SESSION:0 'dcrdex'
 tmux send-keys -t $SESSION:0 "dcrdex --appdata=$(pwd) $*; tmux wait-for -S donedex" C-m
 tmux attach-session -t $SESSION

--- a/dex/testing/loadbot/run
+++ b/dex/testing/loadbot/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e;
 go build;
 ./loadbot -p $@ | tee -i bot.log;

--- a/dex/testing/ltc/harness.sh
+++ b/dex/testing/ltc/harness.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 export SYMBOL="ltc"
 export DAEMON="litecoind"
 export CLI="litecoin-cli"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -ex
 
 dir=$(pwd)


### PR DESCRIPTION
This makes all the scripts specify bash in their shebang - using `#!/usr/bin/env bash`.
I still needed to change the scripts to use `nolog` option instead of `history` to make run on macOS.

Closes #951.