### PR TITLE
client/core: do not disconnect on config timeout

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -587,7 +587,6 @@ func (dc *dexConnection) refreshServerConfig() error {
 	cfg := new(msgjson.ConfigResult)
 	err := sendRequest(dc.WsConn, msgjson.ConfigRoute, nil, cfg, DefaultResponseTimeout)
 	if err != nil {
-		dc.connMaster.Disconnect()
 		return fmt.Errorf("unable to fetch server config: %w", err)
 	}
 


### PR DESCRIPTION
If the config request started by refreshServerConfig on reconnect times
out, it should not disconnect the current connection.  The wsConn's
reconnect / keepAlive loop will deal with it.

Some matrix discussion: https://matrix.to/#/!SFRQQFIHUUNXARfvew:decred.org/$i36zRmdeCzI_VV7zStk7ksQJ3oD1x3NFtzl3wXiA0QY?via=decred.org&via=matrix.org&via=planetdecred.org