### PR TITLE
[0.1.5] client/{core,cmd/dexc}: load unfunded orders for recovery

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -259,10 +259,6 @@ func (c *Core) tryCancelTrade(dc *dexConnection, tracker *trackedTrade) error {
 	tracker.mtx.Lock()
 	defer tracker.mtx.Unlock()
 
-	if status := tracker.metaData.Status; status != order.OrderStatusEpoch && status != order.OrderStatusBooked {
-		return fmt.Errorf("order %v not cancellable in status %v", oid, status)
-	}
-
 	if tracker.cancel != nil {
 		// Existing cancel might be stale. Deleting it now allows this
 		// cancel attempt to proceed.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4361,7 +4361,7 @@ func handleMatchRoute(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	// matches in the 'match' request for the server to accept it, although the
 	// server doesn't require match acks. See (*Swapper).processMatchAcks.
 	for oid, srvMatch := range matches {
-		if srvMatch.tracker.hasFundingCoins() {
+		if !srvMatch.tracker.hasFundingCoins() {
 			c.log.Warnf("Received new match for unfunded order %v!", oid)
 			// In runMatches>tracker.negotiate we generate the matchTracker and
 			// set swapErr after updating order status and filled amount, and

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -244,16 +244,23 @@ func (dc *dexConnection) findOrder(oid order.OrderID) (tracker *trackedTrade, pr
 func (c *Core) tryCancel(dc *dexConnection, oid order.OrderID) (found bool, err error) {
 	tracker, _, _ := dc.findOrder(oid)
 	if tracker == nil {
-		return
+		return // false, nil
 	}
-	found = true
+	return true, c.tryCancelTrade(dc, tracker)
+}
+
+// tryCancelTrade attempts to cancel the order.
+func (c *Core) tryCancelTrade(dc *dexConnection, tracker *trackedTrade) error {
+	oid := tracker.ID()
+	if lo, ok := tracker.Order.(*order.LimitOrder); !ok || lo.Force != order.StandingTiF {
+		return fmt.Errorf("cannot cancel %s order %s that is not a standing limit order", tracker.Type(), oid)
+	}
 
 	tracker.mtx.Lock()
 	defer tracker.mtx.Unlock()
 
-	if lo, ok := tracker.Order.(*order.LimitOrder); !ok || lo.Force != order.StandingTiF {
-		err = fmt.Errorf("cannot cancel %s order %s that is not a standing limit order", tracker.Type(), oid)
-		return
+	if status := tracker.metaData.Status; status != order.OrderStatusEpoch && status != order.OrderStatusBooked {
+		return fmt.Errorf("order %v not cancellable in status %v", oid, status)
 	}
 
 	if tracker.cancel != nil {
@@ -262,8 +269,8 @@ func (c *Core) tryCancel(dc *dexConnection, oid order.OrderID) (found bool, err 
 		tracker.deleteStaleCancelOrder()
 
 		if tracker.cancel != nil {
-			err = fmt.Errorf("order %s - only one cancel order can be submitted per order per epoch. still waiting on cancel order %s to match", oid, tracker.cancel.ID())
-			return
+			return fmt.Errorf("order %s - only one cancel order can be submitted per order per epoch. "+
+				"still waiting on cancel order %s to match", oid, tracker.cancel.ID())
 		}
 	}
 
@@ -281,9 +288,9 @@ func (c *Core) tryCancel(dc *dexConnection, oid order.OrderID) (found bool, err 
 		},
 		TargetOrderID: oid,
 	}
-	err = order.ValidateOrder(co, order.OrderStatusEpoch, 0)
+	err := order.ValidateOrder(co, order.OrderStatusEpoch, 0)
 	if err != nil {
-		return
+		return err
 	}
 
 	// Create and send the order message. Check the response before using it.
@@ -291,20 +298,18 @@ func (c *Core) tryCancel(dc *dexConnection, oid order.OrderID) (found bool, err 
 	var result = new(msgjson.OrderResult)
 	err = dc.signAndRequest(msgOrder, route, result, DefaultResponseTimeout)
 	if err != nil {
-		return
+		return err
 	}
 	err = validateOrderResponse(dc, result, co, msgOrder)
 	if err != nil {
-		err = fmt.Errorf("Abandoning order. preimage: %x, server time: %d: %v",
+		return fmt.Errorf("Abandoning order. preimage: %x, server time: %d: %w",
 			preImg[:], result.ServerTime, err)
-		return
 	}
 
 	// Store the cancel order with the tracker.
 	err = tracker.cancelTrade(co, preImg)
 	if err != nil {
-		err = fmt.Errorf("error storing cancel order info %s: %w", co.ID(), err)
-		return
+		return fmt.Errorf("error storing cancel order info %s: %w", co.ID(), err)
 	}
 
 	// Now that the trackedTrade is updated, sync with the preimage request.
@@ -324,8 +329,7 @@ func (c *Core) tryCancel(dc *dexConnection, oid order.OrderID) (found bool, err 
 		Order: co,
 	})
 	if err != nil {
-		err = fmt.Errorf("failed to store order in database: %v", err)
-		return
+		return fmt.Errorf("failed to store order in database: %w", err)
 	}
 
 	c.log.Infof("Cancel order %s targeting order %s at %s has been placed",
@@ -333,7 +337,7 @@ func (c *Core) tryCancel(dc *dexConnection, oid order.OrderID) (found bool, err 
 
 	c.notify(newOrderNote("Cancelling order", "A cancel order has been submitted for order "+tracker.token(), db.Poke, tracker.coreOrderInternal()))
 
-	return
+	return nil
 }
 
 // Synchronize with the preimage request, in case that request came before
@@ -393,7 +397,9 @@ type serverMatches struct {
 	cancel     *msgjson.Match
 }
 
-// parseMatches sorts the list of matches and associates them with a trade.
+// parseMatches sorts the list of matches and associates them with a trade. This
+// may be called from handleMatchRoute on receipt of a new 'match' request, or
+// by authDEX with the list of active matches returned by the 'connect' request.
 func (dc *dexConnection) parseMatches(msgMatches []*msgjson.Match, checkSigs bool) (map[order.OrderID]*serverMatches, []msgjson.Acknowledgement, error) {
 	var acks []msgjson.Acknowledgement
 	matches := make(map[order.OrderID]*serverMatches)
@@ -3044,6 +3050,31 @@ func (c *Core) authDEX(dc *dexConnection) error {
 		c.resolveMatchConflicts(dc, matchConflicts)
 	}
 
+	// List and cancel standing limit orders that are in epoch or booked status,
+	// but without funding coins for new matches. This should be done after the
+	// order status resolution done above.
+	var brokenTrades []*trackedTrade
+	dc.tradeMtx.RLock()
+	for _, trade := range dc.trades {
+		if lo, ok := trade.Order.(*order.LimitOrder); !ok || lo.Force != order.StandingTiF {
+			continue // only standing limit orders need to be canceled
+		}
+		trade.mtx.RLock()
+		status := trade.metaData.Status
+		if (status == order.OrderStatusEpoch || status == order.OrderStatusBooked) &&
+			!trade.hasFundingCoins() {
+			brokenTrades = append(brokenTrades, trade)
+		}
+		trade.mtx.RUnlock()
+	}
+	dc.tradeMtx.RUnlock()
+	for _, trade := range brokenTrades {
+		c.log.Warnf("Canceling unfunded standing limit order %v", trade.ID())
+		if err = c.tryCancelTrade(dc, trade); err != nil {
+			c.log.Warnf("Unable to cancel unfunded trade %v: %v", trade.ID(), err)
+		}
+	}
+
 	// Order, match statuses should now be in sync with the DEX.
 	// Refresh the user's orders for each of the DEX's markets and
 	// log updated locked funds info.
@@ -3407,11 +3438,13 @@ func (c *Core) loadDBTrades(dc *dexConnection, crypter encrypt.Crypter, failed m
 			if err != nil {
 				baseFailed = true
 				failed[base] = struct{}{}
+				c.log.Errorf("Connecting to wallet %s failed: %v", unbip(base), err)
 			} else if !baseWallet.unlocked() {
 				err = baseWallet.Unlock(crypter)
 				if err != nil {
 					baseFailed = true
 					failed[base] = struct{}{}
+					c.log.Errorf("Unlock wallet %s failed: %v", unbip(base), err)
 				}
 			}
 		}
@@ -3420,11 +3453,13 @@ func (c *Core) loadDBTrades(dc *dexConnection, crypter encrypt.Crypter, failed m
 			if err != nil {
 				quoteFailed = true
 				failed[quote] = struct{}{}
+				c.log.Errorf("Connecting to wallet %s failed: %v", unbip(quote), err)
 			} else if !quoteWallet.unlocked() {
 				err = quoteWallet.Unlock(crypter)
 				if err != nil {
 					quoteFailed = true
 					failed[quote] = struct{}{}
+					c.log.Errorf("Unlock wallet %s failed: %v", unbip(quote), err)
 				}
 			}
 		}
@@ -3450,6 +3485,27 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 		detail := fmt.Sprintf(s, a...)
 		c.notify(newOrderNote(subject, detail, db.ErrorLevel, tracker.coreOrder()))
 	}
+
+	// markUnfunded is used to allow an unfunded order to enter the trades map
+	// so that status resolution and match negotiation for unaffected matches
+	// may continue. By not self-revoking, the user may have the opportunity to
+	// resolve any wallet issues that may have lead to a failure to find the
+	// funding coins. Otherwise the server will (or already did) revoke some or
+	// all of the matches and the order itself.
+	markUnfunded := func(trade *trackedTrade, matches []*matchTracker) {
+		// Block negotiating new matches.
+		trade.changeLocked = false
+		trade.coinsLocked = false
+		// Block swap txn attempts on matches needing funds.
+		for _, match := range matches {
+			match.swapErr = errors.New("no funding coins for swap")
+		}
+		// Will not be retired until revoke or cancel of the order and all
+		// matches, which may happen on status resolution after authenticating
+		// with the DEX server, or from a revoke_match/revoke_order notification
+		// after timeout. However, the order should be unconditionally canceled.
+	}
+
 	relocks := make(assetMap)
 	dc.tradeMtx.Lock()
 	defer dc.tradeMtx.Unlock()
@@ -3474,14 +3530,14 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 		// If matches haven't redeemed, but the counter-swap has been received,
 		// reload the audit info.
 		isActive := tracker.metaData.Status == order.OrderStatusBooked || tracker.metaData.Status == order.OrderStatusEpoch
-		var needsCoins bool
+		var matchesNeedingCoins []*matchTracker
 		for _, match := range tracker.matches {
 			dbMatch, metaData := match.Match, match.MetaData
 			var needsAuditInfo bool
 			var counterSwap []byte
 			if dbMatch.Side == order.Maker {
 				if dbMatch.Status < order.MakerSwapCast {
-					needsCoins = true
+					matchesNeedingCoins = append(matchesNeedingCoins, match)
 				}
 				if dbMatch.Status == order.TakerSwapCast {
 					needsAuditInfo = true // maker needs AuditInfo for takers contract
@@ -3489,13 +3545,15 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				}
 			} else { // Taker
 				if dbMatch.Status < order.TakerSwapCast {
-					needsCoins = true
+					matchesNeedingCoins = append(matchesNeedingCoins, match)
 				}
 				if dbMatch.Status < order.MatchComplete && dbMatch.Status >= order.MakerSwapCast {
 					needsAuditInfo = true // taker needs AuditInfo for maker's contract
 					counterSwap = metaData.Proof.MakerSwap
 				}
 			}
+			c.log.Tracef("Trade %v match %v needs coins = %v, needs audit info = %v",
+				tracker.ID(), match.id, len(matchesNeedingCoins) > 0, needsAuditInfo)
 			if needsAuditInfo {
 				// Check for unresolvable states.
 				if len(counterSwap) == 0 {
@@ -3549,39 +3607,51 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 			}
 		}
 
-		// Active orders and orders with matches with unsent swaps need the funding
-		// coin(s).
+		// Active orders and orders with matches with unsent swaps need funding
+		// coin(s). If they are not found, block new matches and swap attempts.
+		needsCoins := len(matchesNeedingCoins) > 0
 		if isActive || needsCoins {
 			coinIDs := trade.Coins
 			if len(tracker.metaData.ChangeCoin) != 0 {
 				coinIDs = []order.CoinID{tracker.metaData.ChangeCoin}
 			}
+			tracker.coins = map[string]asset.Coin{} // should already be
 			if len(coinIDs) == 0 {
-				notifyErr("No funding coins", "Order %s has no %s funding coins", tracker.token(), unbip(wallets.fromAsset.ID))
-				continue
+				notifyErr("Order coin error", "No funding coins recorded for active order %s", tracker.token())
+				markUnfunded(tracker, matchesNeedingCoins) // bug - no user resolution
+			} else {
+				byteIDs := make([]dex.Bytes, 0, len(coinIDs))
+				for _, cid := range coinIDs {
+					byteIDs = append(byteIDs, []byte(cid))
+				}
+				coins, err := wallets.fromWallet.FundingCoins(byteIDs)
+				if err != nil || len(coins) == 0 {
+					notifyErr("Order coin error", "Source coins retrieval error for order %s (%s): %v",
+						tracker.token(), unbip(wallets.fromAsset.ID), err)
+					// Block matches needing funding coins.
+					markUnfunded(tracker, matchesNeedingCoins)
+					// Note: tracker is still added to trades map for (1) status
+					// resolution, (2) continued settlement of matches that no
+					// longer require funding coins, and (3) cancellation in
+					// authDEX if the order is booked.
+					c.log.Warnf("Check the status of your %s wallet and the coins logged above! "+
+						"Resolve the wallet issue if possible and restart the DEX client.",
+						strings.ToUpper(unbip(wallets.fromAsset.ID)))
+					c.log.Warnf("Unfunded order %v will be canceled on connect, but %d active matches need funding coins!",
+						tracker.ID(), len(matchesNeedingCoins))
+					// If the funding coins are spent or inaccessible, the user
+					// can only wait for match revocation.
+				} else {
+					// NOTE: change and changeLocked are not set even if the
+					// funding coins were loaded from the DB's ChangeCoin.
+					tracker.coinsLocked = true
+					tracker.coins = mapifyCoins(coins)
+				}
 			}
-			byteIDs := make([]dex.Bytes, 0, len(coinIDs))
-			for _, cid := range coinIDs {
-				byteIDs = append(byteIDs, []byte(cid))
-			}
-			if len(byteIDs) == 0 {
-				notifyErr("Order coin error", "No coins for loaded order %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
-				continue
-			}
-			coins, err := wallets.fromWallet.FundingCoins(byteIDs)
-			if err != nil {
-				notifyErr("Order coin error", "Source coins retrieval error for %s %s: %v", unbip(wallets.fromAsset.ID), tracker.token(), err)
-				continue
-			}
-			// NOTE: change and changeLocked are not set even if the funding
-			// coins were loaded from the DB's ChangeCoin.
-			tracker.coinsLocked = true
-			tracker.coins = mapifyCoins(coins)
 		}
 
-		// Active orders and orders with matches with unsent swaps need the funding
-		// coin(s).
-		// Orders with sent but unspent swaps need to recompute contract-locked amts.
+		// Balances should be updated for any orders with locked wallet coins,
+		// or orders with funds locked in contracts.
 		if isActive || needsCoins || tracker.unspentContractAmounts() > 0 {
 			relocks.count(wallets.fromAsset.ID)
 		}
@@ -4286,17 +4356,32 @@ func handleMatchRoute(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 		// requirement, which requires changes to the server's handling.
 		return err
 	}
+
+	// Warn about new matches for unfunded orders. We still must ack all the
+	// matches in the 'match' request for the server to accept it, although the
+	// server doesn't require match acks. See (*Swapper).processMatchAcks.
+	for oid, srvMatch := range matches {
+		if srvMatch.tracker.hasFundingCoins() {
+			c.log.Warnf("Received new match for unfunded order %v!", oid)
+			// In runMatches>tracker.negotiate we generate the matchTracker and
+			// set swapErr after updating order status and filled amount, and
+			// storing the match to the DB. It may still be possible for the
+			// user to recover if the issue is just that the wrong wallet is
+			// connected by fixing wallet config and restarting. p.s. Hopefully
+			// we are maker.
+		}
+	}
+
 	resp, err := msgjson.NewResponse(msg.ID, acks, nil)
 	if err != nil {
 		return err
 	}
 
 	// Send the match acknowledgments.
-	// TODO: Consider a "QueueSend" or similar, but do not bail on the matches.
 	err = dc.Send(resp)
 	if err != nil {
+		// Do not bail on the matches on error, just log it.
 		c.log.Errorf("Send match response: %v", err)
-		// dc.addPendingSend(resp) // e.g.
 	}
 
 	// Begin match negotiation.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -208,7 +209,7 @@ func testDexConnection(ctx context.Context) (*dexConnection, *TWebsocket, *dexAc
 		marketMap:    map[string]*Market{tDcrBtcMktName: mkt},
 		trades:       make(map[order.OrderID]*trackedTrade),
 		epoch:        map[string]uint64{tDcrBtcMktName: 0},
-		connected:    true,
+		connected:    1,
 	}, conn, acct
 }
 
@@ -2146,12 +2147,12 @@ func TestTrade(t *testing.T) {
 	rig.dc.acct.unlock(rig.crypter)
 
 	// DEX not connected
-	rig.dc.connected = false
+	atomic.StoreUint32(&rig.dc.connected, 0)
 	_, err = tCore.Trade(tPW, form)
 	if err == nil {
 		t.Fatalf("no error for disconnected dex")
 	}
-	rig.dc.connected = true
+	atomic.StoreUint32(&rig.dc.connected, 1)
 
 	// No base asset
 	form.Base = 12345

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -156,10 +156,10 @@ func tNewAccount() *dexAccount {
 	}
 }
 
-func testDexConnection() (*dexConnection, *TWebsocket, *dexAccount) {
+func testDexConnection(ctx context.Context) (*dexConnection, *TWebsocket, *dexAccount) {
 	conn := newTWebsocket()
 	connMaster := dex.NewConnectionMaster(conn)
-	connMaster.Connect(tCtx)
+	connMaster.Connect(ctx)
 	acct := tNewAccount()
 	mkt := &Market{
 		Name:            tDcrBtcMktName,
@@ -741,13 +741,14 @@ func randomMsgMarket() (baseAsset, quoteAsset *msgjson.Asset) {
 }
 
 type testRig struct {
-	core    *Core
-	db      *TDB
-	queue   *wait.TickerQueue
-	ws      *TWebsocket
-	dc      *dexConnection
-	acct    *dexAccount
-	crypter *tCrypter
+	shutdown func()
+	core     *Core
+	db       *TDB
+	queue    *wait.TickerQueue
+	ws       *TWebsocket
+	dc       *dexConnection
+	acct     *dexAccount
+	crypter  *tCrypter
 }
 
 func newTestRig() *testRig {
@@ -767,15 +768,28 @@ func newTestRig() *testRig {
 
 	// Set the global waiter expiration, and start the waiter.
 	queue := wait.NewTickerQueue(time.Millisecond * 5)
-	go queue.Run(tCtx)
+	ctx, cancel := context.WithCancel(tCtx)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		queue.Run(ctx)
+	}()
 
-	dc, conn, acct := testDexConnection()
+	dc, conn, acct := testDexConnection(ctx)
+
+	shutdown := func() {
+		cancel()
+		wg.Wait()
+		dc.connMaster.Wait()
+	}
 
 	crypter := &tCrypter{}
 
 	return &testRig{
+		shutdown: shutdown,
 		core: &Core{
-			ctx:      tCtx,
+			ctx:      ctx,
 			cfg:      &Config{},
 			db:       tdb,
 			log:      tLogger,
@@ -889,6 +903,7 @@ func TestMain(m *testing.M) {
 
 func TestMarkets(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	// The test rig's dexConnection comes with a market. Clear that for this test.
 	rig.dc.cfgMtx.Lock()
 	rig.dc.cfg.Markets = nil
@@ -946,6 +961,7 @@ func TestMarkets(t *testing.T) {
 
 func TestDexConnectionOrderBook(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	dc := rig.dc
 
@@ -1168,6 +1184,7 @@ func (drv *tDriver) Info() *asset.WalletInfo {
 
 func TestCreateWallet(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 
 	// Create a new asset.
@@ -1261,6 +1278,7 @@ func TestCreateWallet(t *testing.T) {
 
 func TestGetFee(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 
 	// DEX already registered
@@ -1294,6 +1312,7 @@ func TestRegister(t *testing.T) {
 	// This test takes a little longer because the key is decrypted every time
 	// Register is called.
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	dc := rig.dc
 	delete(tCore.conns, tDexHost)
@@ -1590,6 +1609,7 @@ func TestRegister(t *testing.T) {
 
 func TestLogin(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	rig.acct.markFeePaid()
 
@@ -1622,6 +1642,7 @@ func TestLogin(t *testing.T) {
 
 	// 'connect' route error.
 	rig = newTestRig()
+	defer rig.shutdown()
 	tCore = rig.core
 	rig.acct.unauth()
 	rig.ws.queueResponse(msgjson.ConnectRoute, func(msg *msgjson.Message, f msgFunc) error {
@@ -1638,9 +1659,12 @@ func TestLogin(t *testing.T) {
 
 	// Success with some matches in the response.
 	rig = newTestRig()
+	defer rig.shutdown()
 	dc := rig.dc
 	qty := 3 * tDCR.LotSize
 	lo, dbOrder, preImg, addr := makeLimitOrder(dc, true, qty, tBTC.RateStep*10)
+	lo.Force = order.StandingTiF
+	dbOrder.MetaData.Status = order.OrderStatusBooked // leave unfunded to have it canceled on auth/'connect'
 	oid := lo.ID()
 	mkt := dc.market(tDcrBtcMktName)
 	dcrWallet, _ := newTWallet(tDCR.ID)
@@ -1649,7 +1673,7 @@ func TestLogin(t *testing.T) {
 	tCore.wallets[tBTC.ID] = btcWallet
 	walletSet, _ := tCore.walletSet(dc, tDCR.ID, tBTC.ID, true)
 	tracker := newTrackedTrade(dbOrder, preImg, dc, mkt.EpochLen, rig.core.lockTimeTaker, rig.core.lockTimeMaker,
-		rig.db, rig.queue, walletSet, nil, rig.core.notify)
+		rig.db, rig.queue, walletSet, nil, rig.core.notify) // nil means no funding coins
 	matchID := ordertest.RandomMatchID()
 	match := &matchTracker{
 		id: matchID,
@@ -1708,6 +1732,7 @@ func TestLogin(t *testing.T) {
 	tCore = rig.core
 	rig.acct.markFeePaid()
 	rig.queueConnect(nil, []*msgjson.Match{knownMsgMatch /* missing missingMatch! */, extraMsgMatch}, nil)
+	rig.queueCancel(nil) // for the unfunded order that gets canceled in authDEX
 	// Login>authDEX will do 4 match DB updates for these two matches:
 	// missing -> revoke -> update match
 	// extra -> negotiate -> newTrackers -> update match
@@ -1721,6 +1746,14 @@ func TestLogin(t *testing.T) {
 	}
 	for i := 0; i < 4; i++ {
 		<-rig.db.updateMatchChan
+	}
+
+	// check t.metaData.LinkedOrder or for db.LinkOrder call, then db.UpdateOrder call
+	if tracker.metaData.LinkedOrder.IsZero() {
+		t.Errorf("cancel order not set")
+	}
+	if rig.db.linkedFromID != oid || rig.db.linkedToID.IsZero() {
+		t.Errorf("automatic cancel order not linked")
 	}
 
 	if !tracker.matches[missingID].MetaData.Proof.SelfRevoked {
@@ -1747,6 +1780,7 @@ func TestLogin(t *testing.T) {
 
 func TestLoginAccountNotFoundError(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	rig.acct.markFeePaid()
 
@@ -1771,6 +1805,7 @@ func TestLoginAccountNotFoundError(t *testing.T) {
 
 func TestInitializeDEXConnectionsSuccess(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	rig.acct.markFeePaid()
 	rig.queueConnect(nil, nil, nil)
@@ -1789,6 +1824,7 @@ func TestInitializeDEXConnectionsSuccess(t *testing.T) {
 
 func TestInitializeDEXConnectionsAccountNotFoundError(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	rig.acct.markFeePaid()
 	expectedErrorMessage := "test account not found error"
@@ -1814,6 +1850,7 @@ func TestInitializeDEXConnectionsAccountNotFoundError(t *testing.T) {
 
 func TestConnectDEX(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 
 	ai := &db.AccountInfo{
@@ -1874,6 +1911,7 @@ func TestConnectDEX(t *testing.T) {
 
 func TestInitializeClient(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	rig.db.existValues[keyParamsKey] = false
 
@@ -1906,6 +1944,7 @@ func TestInitializeClient(t *testing.T) {
 
 func TestWithdraw(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	wallet, tWallet := newTWallet(tDCR.ID)
 	tCore.wallets[tDCR.ID] = wallet
@@ -1960,6 +1999,7 @@ func TestWithdraw(t *testing.T) {
 
 func TestTrade(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
 	tCore.wallets[tDCR.ID] = dcrWallet
@@ -2259,6 +2299,7 @@ func TestTrade(t *testing.T) {
 
 func TestCancel(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	dc := rig.dc
 	lo, dbOrder, preImg, _ := makeLimitOrder(dc, true, 0, 0)
 	lo.Force = order.StandingTiF
@@ -2320,6 +2361,7 @@ func TestCancel(t *testing.T) {
 
 func TestHandlePreimageRequest(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	ord := &order.LimitOrder{P: order.Prefix{ServerTime: time.Now()}}
 	oid := ord.ID()
 	preImg := newPreimage()
@@ -2369,6 +2411,7 @@ func TestHandlePreimageRequest(t *testing.T) {
 
 func TestHandleRevokeOrderMsg(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	dc := rig.dc
 	tCore := rig.core
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
@@ -2435,6 +2478,7 @@ func TestHandleRevokeOrderMsg(t *testing.T) {
 
 func TestHandleRevokeMatchMsg(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	dc := rig.dc
 	tCore := rig.core
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
@@ -2507,6 +2551,7 @@ func TestHandleRevokeMatchMsg(t *testing.T) {
 
 func TestTradeTracking(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	dc := rig.dc
 	tCore := rig.core
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
@@ -2978,6 +3023,7 @@ func TestTradeTracking(t *testing.T) {
 
 func TestReconcileTrades(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	dc := rig.dc
 
 	mkt := rig.dc.market(tDcrBtcMktName)
@@ -3193,10 +3239,12 @@ func makeTradeTracker(rig *testRig, mkt *Market, walletSet *walletSet, force ord
 }
 
 func TestRefunds(t *testing.T) {
+	rig := newTestRig()
+	defer rig.shutdown()
 	checkStatus := func(tag string, match *matchTracker, wantStatus order.MatchStatus) {
 		t.Helper()
 		if match.Match.Status != wantStatus {
-			t.Fatalf("%s: wrong status wanted %d, got %d", tag, match.Match.Status, wantStatus)
+			t.Fatalf("%s: wrong status wanted %v, got %v", tag, wantStatus, match.Match.Status)
 		}
 	}
 	checkRefund := func(tracker *trackedTrade, match *matchTracker, expectAmt uint64) {
@@ -3240,7 +3288,6 @@ func TestRefunds(t *testing.T) {
 		}
 	}
 
-	rig := newTestRig()
 	dc := rig.dc
 	tCore := rig.core
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
@@ -3264,8 +3311,11 @@ func TestRefunds(t *testing.T) {
 		t.Fatalf("walletSet error: %v", err)
 	}
 	mkt := dc.market(tDcrBtcMktName)
+	fundCoinsDCR := asset.Coins{&tCoin{id: encode.RandomBytes(36)}}
+	tDcrWallet.fundingCoins = fundCoinsDCR
+	tDcrWallet.fundRedeemScripts = []dex.Bytes{nil}
 	tracker := newTrackedTrade(dbOrder, preImgL, dc, mkt.EpochLen, rig.core.lockTimeTaker, rig.core.lockTimeMaker,
-		rig.db, rig.queue, walletSet, nil, rig.core.notify)
+		rig.db, rig.queue, walletSet, fundCoinsDCR, rig.core.notify)
 	rig.dc.trades[tracker.ID()] = tracker
 
 	// MAKER REFUND, INVALID TAKER COUNTERSWAP
@@ -3325,6 +3375,14 @@ func TestRefunds(t *testing.T) {
 
 	// TAKER REFUND, NO MAKER REDEEM
 	//
+	// Reset funding coins in the trackedTrade, wipe change coin.
+	tracker.mtx.Lock()
+	tracker.coins = mapifyCoins(fundCoinsDCR)
+	tracker.coinsLocked = true
+	tracker.changeLocked = false
+	tracker.change = nil
+	tracker.metaData.ChangeCoin = nil
+	tracker.mtx.Unlock()
 	mid = ordertest.RandomMatchID()
 	msgMatch = &msgjson.Match{
 		OrderID:  loid[:],
@@ -3383,11 +3441,13 @@ func TestRefunds(t *testing.T) {
 }
 
 func TestNotifications(t *testing.T) {
-	tCore := newTestRig().core
+	rig := newTestRig()
+	defer rig.shutdown()
 
 	// Insert a notification into the database.
 	typedNote := newOrderNote("abc", "def", 100, nil)
 
+	tCore := rig.core
 	ch := tCore.NotificationFeed()
 	tCore.notify(typedNote)
 	select {
@@ -3400,6 +3460,7 @@ func TestNotifications(t *testing.T) {
 
 func TestResolveActiveTrades(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 
 	btcWallet, tBtcWallet := newTWallet(tBTC.ID)
@@ -3426,7 +3487,8 @@ func TestResolveActiveTrades(t *testing.T) {
 			Quantity: qty,
 			Sell:     true,
 		},
-		Rate: rate,
+		Rate:  rate,
+		Force: order.StandingTiF, // we're calling it booked in OrderMetaData
 	}
 
 	oid := lo.ID()
@@ -3467,7 +3529,7 @@ func TestResolveActiveTrades(t *testing.T) {
 		Match: &order.UserMatch{
 			OrderID:  oid,
 			MatchID:  mid,
-			Quantity: qty,
+			Quantity: qty - tDCR.LotSize,
 			Rate:     rate,
 			Address:  addr,
 			Status:   order.MakerSwapCast,
@@ -3563,9 +3625,10 @@ func TestResolveActiveTrades(t *testing.T) {
 	tBtcWallet.unlockErr = nil
 	tBtcWallet.locked = false
 
-	// Funding coin error.
+	// Funding coin error still puts it in the trades map, just with no coins
+	// locked.
 	tDcrWallet.fundingCoinErr = tErr
-	ensureFail("funding coin")
+	ensureGood("funding coin", 0)
 	tDcrWallet.fundingCoinErr = nil
 
 	// No matches
@@ -3647,6 +3710,7 @@ func TestResolveActiveTrades(t *testing.T) {
 
 func TestCompareServerMatches(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	preImg := newPreimage()
 	dc := rig.dc
 
@@ -3905,6 +3969,7 @@ func tMsgAudit(oid order.OrderID, mid order.MatchID, recipient string, val uint6
 
 func TestHandleEpochOrderMsg(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	ord := &order.LimitOrder{P: order.Prefix{ServerTime: time.Now()}}
 	oid := ord.ID()
 	payload := &msgjson.EpochOrderNote{
@@ -3957,6 +4022,7 @@ func makeMatchProof(preimages []order.Preimage, commitments []order.Commitment) 
 
 func TestHandleMatchProofMsg(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	pimg := newPreimage()
 	cmt := pimg.Commit()
 
@@ -4008,6 +4074,7 @@ func TestHandleMatchProofMsg(t *testing.T) {
 
 func TestLogout(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
@@ -4028,7 +4095,7 @@ func TestLogout(t *testing.T) {
 	}
 	rig.dc.trades[ord.ID()] = tracker
 
-	dc, _, _ := testDexConnection()
+	dc, _, _ := testDexConnection(rig.core.ctx)
 	initUserAssets := func() {
 		tCore.user = new(User)
 		dc.assetsMtx.Lock()
@@ -4085,6 +4152,7 @@ func TestLogout(t *testing.T) {
 
 func TestSetEpoch(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	dc := rig.dc
 	dc.books[tDcrBtcMktName] = newBookie(tLogger, func() {})
 
@@ -4132,7 +4200,8 @@ func makeLimitOrder(dc *dexConnection, sell bool, qty, rate uint64) (*order.Limi
 			Commit:     preImg.Commit(),
 		},
 		T: order.Trade{
-			Sell:     true,
+			// Coins needed?
+			Sell:     sell,
 			Quantity: qty,
 			Address:  addr,
 		},
@@ -4227,6 +4296,7 @@ func TestAddrHost(t *testing.T) {
 
 func TestAssetBalance(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 
 	wallet, tWallet := newTWallet(tDCR.ID)
@@ -4266,6 +4336,7 @@ func TestAssetCounter(t *testing.T) {
 
 func TestHandleTradeSuspensionMsg(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 
 	tCore := rig.core
 	dc := rig.dc
@@ -4409,6 +4480,7 @@ func TestHandleTradeSuspensionMsg(t *testing.T) {
 
 func TestHandleTradeResumptionMsg(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 
 	tCore := rig.core
 	dcrWallet, _ := newTWallet(tDCR.ID)
@@ -4506,6 +4578,7 @@ func TestHandleTradeResumptionMsg(t *testing.T) {
 
 func TestHandleNomatch(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	dc := rig.dc
 	mkt := dc.market(tDcrBtcMktName)
@@ -4617,6 +4690,7 @@ func TestHandleNomatch(t *testing.T) {
 
 func TestWalletSettings(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	rig.db.wallet = &db.Wallet{
 		Settings: map[string]string{
@@ -4654,6 +4728,7 @@ func TestWalletSettings(t *testing.T) {
 
 func TestReconfigureWallet(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	rig.db.wallet = &db.Wallet{
 		Settings: map[string]string{
@@ -4749,6 +4824,7 @@ func TestReconfigureWallet(t *testing.T) {
 
 func TestSetWalletPassword(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	rig.db.wallet = &db.Wallet{
 		EncryptedPW: []byte("abc"),
@@ -4813,6 +4889,7 @@ func TestSetWalletPassword(t *testing.T) {
 
 func TestHandlePenaltyMsg(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	dc := rig.dc
 	penalty := &msgjson.Penalty{
@@ -4880,6 +4957,7 @@ func TestHandlePenaltyMsg(t *testing.T) {
 
 func TestPreimageSync(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
 	tCore.wallets[tDCR.ID] = dcrWallet
@@ -4972,6 +5050,7 @@ func TestPreimageSync(t *testing.T) {
 
 func TestMatchStatusResolution(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 	dc := rig.dc
 	mkt := dc.market(tDcrBtcMktName)
@@ -5459,6 +5538,7 @@ func TestMatchStatusResolution(t *testing.T) {
 
 func TestSuspectTrades(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	dc := rig.dc
 	tCore := rig.core
 
@@ -5648,6 +5728,7 @@ func TestSuspectTrades(t *testing.T) {
 
 func TestWalletSyncing(t *testing.T) {
 	rig := newTestRig()
+	defer rig.shutdown()
 	tCore := rig.core
 
 	noteFeed := tCore.NotificationFeed()


### PR DESCRIPTION
Backport of https://github.com/decred/dcrdex/pull/967 for 0.1.5

This addresses the issue of orders that lose their funding coins one way
or another (e.g. spend outside of dexc) can never be loaded. Prior to
this PR, that meant two things:

 - On login, the user will be forever spammed by an "Order coin error"
   / "Source coins retrieval error".
 - Matches for such orders can never be
   recovered, even if they do not require funding coins. This made
   recovery a manual task if there were matches in progress or requiring
   refund, etc.

Unfunded orders that require funding (epoch/booked or with matches
needing to send swap txns) are explicitly blocked from negotiating new
matches, and any offending matches that require funding coins are
blocked with swapErr. However, notably, the trackedTrade is added to the
dc.trades map, unlike before this change. In addition to allowing
unaffected matches to proceed, match status resolution can be performed
for the order and its matches, potentially revoking it, and
revoke_order/revoke_matches requests from the server will be recognized.

This allows recovery or completion of other unaffected matches belonging
to the trade. The order and the unfunded matches stay active (but halted
via swapErr) until they are either revoked or the user possibly resolves
a wallet issue that made the funding coins inaccessible and restarts
dexc to try loading the funding coins again. If the coins are not spent,
they probably are using the wrong wallet that does not control the
referenced coins.

Unfunded standing limit orders that are either epoch or booked are also
canceled to prevent further matches that will be likely to fail.