### PR TITLE
dexc: disable account feature.

### DIFF
--- a/client/core/account.go
+++ b/client/core/account.go
@@ -51,7 +51,9 @@ func (c *Core) AccountDisable(pw []byte, addr string) error {
 				close(f.C)
 			}
 			b.feeds = make(map[uint32]*BookFeed, 1)
-			b.closeTimer.Stop()
+			if b.closeTimer != nil {
+				b.closeTimer.Stop()
+			}
 			b.mtx.Unlock()
 		}
 		dc.booksMtx.Unlock()
@@ -61,7 +63,7 @@ func (c *Core) AccountDisable(pw []byte, addr string) error {
 	dc.cfgMtx.RUnlock()
 	// Disconnect and delete connection from map.
 	dc.connMaster.Disconnect()
-	delete(c.conns, addr)
+	delete(c.conns, host)
 
 	return nil
 }

--- a/client/core/account.go
+++ b/client/core/account.go
@@ -44,9 +44,9 @@ func (c *Core) AccountDisable(pw []byte, host string) error {
 	if err != nil {
 		return newError(accountDisableErr, "Error disabling account: %v", err)
 	}
-	// Stop dexConnection books.
-	for _, market := range dc.marketMap() {
-		dc.stopBook(market.BaseID, market.QuoteID)
+	// Close dexConnection books.
+	for _, book := range dc.books {
+		book.close()
 	}
 	// Disconnect and delete connection from map.
 	dc.connMaster.Disconnect()

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -5,9 +5,11 @@ package core
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"testing"
 
 	"decred.org/dcrdex/client/db"
+	"decred.org/dcrdex/dex/order"
 )
 
 func TestAccountExport(t *testing.T) {
@@ -88,6 +90,93 @@ func setupRigAccountProof(host string, rig *testRig) {
 	rig.db.accountProof = accountProof
 }
 
+func TestAccountDisable(t *testing.T) {
+	activeTrades := map[order.OrderID]*trackedTrade{
+		order.OrderID{}: &trackedTrade{metaData: &db.OrderMetaData{Status: order.OrderStatusBooked}},
+	}
+
+	tests := []struct {
+		name, host                          string
+		recryptErr, acctErr, disableAcctErr error
+		wantErr, wantErrCode, loseConns     bool
+		activeTrades                        map[order.OrderID]*trackedTrade
+		errCode                             int
+	}{{
+		name: "ok",
+		host: tDexHost,
+	}, {
+		name:       "password error",
+		host:       tDexHost,
+		recryptErr: tErr,
+		wantErr:    true,
+		errCode:    passwordErr,
+	}, {
+		name:        "host error",
+		host:        ":bad:",
+		wantErr:     true,
+		wantErrCode: true,
+		errCode:     addressParseErr,
+	}, {
+		name:        "dex not in conns",
+		host:        tDexHost,
+		loseConns:   true,
+		wantErr:     true,
+		wantErrCode: true,
+		errCode:     unknownDEXErr,
+	}, {
+		name:         "has active orders",
+		host:         tDexHost,
+		activeTrades: activeTrades,
+		wantErr:      true,
+	}, {
+		name:        "retrieve account error",
+		host:        tDexHost,
+		acctErr:     errors.New(""),
+		wantErr:     true,
+		wantErrCode: true,
+		errCode:     accountRetrieveErr,
+	}, {
+		name:           "disable account error",
+		host:           tDexHost,
+		disableAcctErr: errors.New(""),
+		wantErr:        true,
+		wantErrCode:    true,
+		errCode:        accountDisableErr,
+	}}
+
+	for _, test := range tests {
+		rig := newTestRig()
+		tCore := rig.core
+		rig.crypter.recryptErr = test.recryptErr
+		rig.db.acctErr = test.acctErr
+		rig.db.disableAccountErr = test.disableAcctErr
+		tCore.connMtx.Lock()
+		tCore.conns[tDexHost].trades = test.activeTrades
+		if test.loseConns {
+			// Lose the dexConnection
+			delete(tCore.conns, tDexHost)
+		}
+		tCore.connMtx.Unlock()
+
+		err := tCore.AccountDisable(tPW, test.host)
+		if test.wantErr {
+			if err == nil {
+				t.Fatalf("expected error for test %v", test.name)
+			}
+			if test.wantErrCode && !errorHasCode(err, test.errCode) {
+				t.Fatalf("wanted errCode %v but got %v for test %v", test.errCode, err, test.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("unexpected error for test %v: %v", test.name, err)
+		}
+		if _, found := tCore.conns[test.host]; found {
+			t.Fatal("found disabled account dex connection")
+		}
+	}
+}
+
 func TestAccountExportPasswordError(t *testing.T) {
 	rig := newTestRig()
 	tCore := rig.core
@@ -130,7 +219,7 @@ func TestAccountExportAccountKeyError(t *testing.T) {
 	rig.crypter.decryptErr = tErr
 	_, err := tCore.AccountExport(tPW, host)
 	if !errorHasCode(err, acctKeyErr) {
-		t.Fatalf("expected password error, actual error: '%v'", err)
+		t.Fatalf("expected account key error, actual error: '%v'", err)
 	}
 }
 

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -129,13 +129,6 @@ func TestAccountDisable(t *testing.T) {
 		activeTrades: activeTrades,
 		wantErr:      true,
 	}, {
-		name:        "retrieve account error",
-		host:        tDexHost,
-		acctErr:     errors.New(""),
-		wantErr:     true,
-		wantErrCode: true,
-		errCode:     accountRetrieveErr,
-	}, {
 		name:           "disable account error",
 		host:           tDexHost,
 		disableAcctErr: errors.New(""),
@@ -146,9 +139,9 @@ func TestAccountDisable(t *testing.T) {
 
 	for _, test := range tests {
 		rig := newTestRig()
+		defer rig.shutdown()
 		tCore := rig.core
 		rig.crypter.recryptErr = test.recryptErr
-		rig.db.acctErr = test.acctErr
 		rig.db.disableAccountErr = test.disableAcctErr
 		tCore.connMtx.Lock()
 		tCore.conns[tDexHost].trades = test.activeTrades

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -115,7 +115,7 @@ func TestAccountDisable(t *testing.T) {
 		host:        ":bad:",
 		wantErr:     true,
 		wantErrCode: true,
-		errCode:     addressParseErr,
+		errCode:     unknownDEXErr,
 	}, {
 		name:        "dex not in conns",
 		host:        tDexHost,

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -167,6 +167,13 @@ func TestAccountDisable(t *testing.T) {
 		if _, found := tCore.conns[test.host]; found {
 			t.Fatal("found disabled account dex connection")
 		}
+		if rig.db.disabledAcct == nil {
+			t.Fatal("expected execution of db.DisableAccount")
+		}
+		if rig.db.disabledAcct.Host == test.host {
+			t.Fatalf("expected db disabled account to match test host, want: %v"+
+				" got: %v", test.host, rig.db.disabledAcct.Host)
+		}
 	}
 }
 

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -195,9 +195,7 @@ func (dc *dexConnection) syncBook(base, quote uint32) (*BookFeed, error) {
 		}
 
 		booky = newBookie(dc.log.SubLogger(mktID), func() {
-			if _, found := dc.books[mktID]; found {
-				dc.stopBook(base, quote)
-			}
+			dc.stopBook(base, quote)
 		})
 		err = booky.Sync(obRes)
 		if err != nil {

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -194,7 +194,11 @@ func (dc *dexConnection) syncBook(base, quote uint32) (*BookFeed, error) {
 			return nil, err
 		}
 
-		booky = newBookie(dc.log.SubLogger(mktID), func() { dc.stopBook(base, quote) })
+		booky = newBookie(dc.log.SubLogger(mktID), func() {
+			if _, found := dc.books[mktID]; found {
+				dc.stopBook(base, quote)
+			}
+		})
 		err = booky.Sync(obRes)
 		if err != nil {
 			return nil, err

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2549,12 +2549,7 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 				var mErr *msgjson.Error
 				if errors.As(err, &mErr) &&
 					mErr.Code == msgjson.AccountNotFoundError {
-					acctInfo, err := c.db.Account(dc.acct.host)
-					if err != nil {
-						c.log.Errorf("Error retrieving account: %v", err)
-						return
-					}
-					err = c.db.DisableAccount(acctInfo)
+					err = c.db.DisableAccount(dc.acct.host)
 					if err != nil {
 						c.log.Errorf("Error disabling account: %v", err)
 						return

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -306,7 +306,7 @@ func (tdb *TDB) CreateAccount(ai *db.AccountInfo) error {
 	return tdb.createAccountErr
 }
 
-func (tdb *TDB) DisableAccount(ai *db.AccountInfo) error {
+func (tdb *TDB) DisableAccount(url string) error {
 	tdb.accts = nil
 	return tdb.disableAccountErr
 }

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -283,6 +283,7 @@ type TDB struct {
 	verifyCreateAccount   bool
 	accountInfoPersisted  *db.AccountInfo
 	accountProofPersisted *db.AccountProof
+	disableAccountErr     error
 }
 
 func (tdb *TDB) Run(context.Context) {}
@@ -307,7 +308,7 @@ func (tdb *TDB) CreateAccount(ai *db.AccountInfo) error {
 
 func (tdb *TDB) DisableAccount(ai *db.AccountInfo) error {
 	tdb.accts = nil
-	return nil
+	return tdb.disableAccountErr
 }
 
 func (tdb *TDB) UpdateOrder(m *db.MetaOrder) error {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -258,7 +258,6 @@ type TDB struct {
 	encKeyErr             error
 	createAccountErr      error
 	accountPaidErr        error
-	accts                 []*db.AccountInfo
 	updateOrderErr        error
 	activeDEXOrders       []*db.MetaOrder
 	matchesForOID         []*db.MetaMatch
@@ -283,6 +282,7 @@ type TDB struct {
 	verifyCreateAccount   bool
 	accountInfoPersisted  *db.AccountInfo
 	accountProofPersisted *db.AccountProof
+	disabledAcct          *db.AccountInfo
 	disableAccountErr     error
 }
 
@@ -293,7 +293,7 @@ func (tdb *TDB) ListAccounts() ([]string, error) {
 }
 
 func (tdb *TDB) Accounts() ([]*db.AccountInfo, error) {
-	return tdb.accts, nil
+	return nil, nil
 }
 
 func (tdb *TDB) Account(url string) (*db.AccountInfo, error) {
@@ -307,7 +307,8 @@ func (tdb *TDB) CreateAccount(ai *db.AccountInfo) error {
 }
 
 func (tdb *TDB) DisableAccount(url string) error {
-	tdb.accts = nil
+	acct, _ := tdb.Account(url)
+	tdb.disabledAcct = acct
 	return tdb.disableAccountErr
 }
 
@@ -791,7 +792,6 @@ func newTestRig() *testRig {
 		Host: "somedex.com",
 	}
 	tdb.acct = ai
-	tdb.accts = append(tdb.accts, ai)
 
 	// Set the global waiter expiration, and start the waiter.
 	queue := wait.NewTickerQueue(time.Millisecond * 5)

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -38,6 +38,8 @@ const (
 	addrErr
 	fileReadErr
 	unknownDEXErr
+	accountRetrieveErr
+	accountDisableErr
 )
 
 // Error is an error message and an error code.

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -316,14 +316,20 @@ func (db *BoltDB) deleteAccount(host string) error {
 	})
 }
 
-// DisableAccount account disables the given account and archives it. The
-// Accounts and Account methods will no longer find the disabled account.
+// DisableAccount disables the account assocaited with the given host
+// and archives it. The Accounts and Account methods will no longer find
+// the disabled account.
 //
 // TODO: Add disabledAccounts method for retrieval of a disabled account and
 // possible recovery of the account data.
-func (db *BoltDB) DisableAccount(ai *dexdb.AccountInfo) error {
-	// Copy AccountInfo to disabledAccounts
-	err := db.disabledAcctsUpdate(func(disabledAccounts *bbolt.Bucket) error {
+func (db *BoltDB) DisableAccount(url string) error {
+	// Get account's info.
+	ai, err := db.Account(url)
+	if err != nil {
+		return err
+	}
+	// Copy AccountInfo to disabledAccounts.
+	err = db.disabledAcctsUpdate(func(disabledAccounts *bbolt.Bucket) error {
 		return disabledAccounts.Put(ai.EncKey, ai.Encode())
 	})
 	if err != nil {

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -223,7 +223,6 @@ func TestAccounts(t *testing.T) {
 }
 
 func TestDisableAccount(t *testing.T) {
-
 	boltdb := newTestDB(t)
 	acct := dbtest.RandomAccountInfo()
 	host := acct.Host
@@ -239,7 +238,7 @@ func TestDisableAccount(t *testing.T) {
 		t.Fatalf("Expected not to retrieve a disabledAccount.")
 	}
 
-	err = boltdb.DisableAccount(acct)
+	err = boltdb.DisableAccount(host)
 
 	if err != nil {
 		t.Fatalf("Unexpected DisableAccount error: %v", err)

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -29,7 +29,7 @@ type DB interface {
 	// CreateAccount saves the AccountInfo.
 	CreateAccount(ai *AccountInfo) error
 	// DisableAccount sets the AccountInfo disabled status to true.
-	DisableAccount(ai *AccountInfo) error
+	DisableAccount(url string) error
 	// AccountProof retrieves the AccountPoof value specified by url.
 	AccountProof(url string) (*AccountProof, error)
 	// AccountPaid marks the account as paid.

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -25,13 +25,13 @@ type DB interface {
 	// Accounts retrieves all accounts.
 	Accounts() ([]*AccountInfo, error)
 	// Account gets the AccountInfo associated with the specified DEX node.
-	Account(url string) (*AccountInfo, error)
+	Account(host string) (*AccountInfo, error)
 	// CreateAccount saves the AccountInfo.
 	CreateAccount(ai *AccountInfo) error
 	// DisableAccount sets the AccountInfo disabled status to true.
-	DisableAccount(url string) error
+	DisableAccount(host string) error
 	// AccountProof retrieves the AccountPoof value specified by url.
-	AccountProof(url string) (*AccountProof, error)
+	AccountProof(host string) (*AccountProof, error)
 	// AccountPaid marks the account as paid.
 	AccountPaid(proof *AccountProof) error
 	// UpdateOrder saves the order information in the database. Any existing

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -462,7 +462,7 @@ func (c *TCore) AccountExport(pw []byte, host string) (*core.Account, error) {
 func (c *TCore) AccountImport(pw []byte, account core.Account) error {
 	return nil
 }
-
+func (c *TCore) AccountDisable(pw []byte, host string) error { return nil }
 func toAtoms(v float64) uint64 {
 	return uint64(math.Round(v * 1e8))
 }

--- a/client/webserver/site/src/css/settings.scss
+++ b/client/webserver/site/src/css/settings.scss
@@ -28,3 +28,9 @@ div.settings-exchange {
   margin-bottom: 10px;
   background: rgba(0, 0, 0, 0.05);
 }
+
+#disableAccountForm {
+  .red {
+    color: #f55a;
+  }
+}

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -183,6 +183,11 @@
     Enter your app password to disable account: <span id="disableAccountHost"></span>.
   </div>
   <hr class="dashed my-4">
+  <div class="my-2">
+    <span class="red">Note:</span> This action is irreversible - once an account is disabled it can't 
+    be re-enabled.
+  </div>
+  <hr class="dashed my-4">
   <div>
     <label for="disableAccountAppPW" class="pl-1 mb-1">Password</label>
     <input type="password" class="form-control select" id="disableAccountAppPW" autocomplete="current-password">

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -173,6 +173,27 @@
 </div>
 {{end}}
 
+{{ define "disableAccountForm"}}
+<div class="bg2 px-2 py-1 text-center position-relative fs18">
+  Disable Account
+  <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+</div>
+<div class="p-4">
+  <div class="fs16">
+    Enter your app password to disable account: <span id="disableAccountHost"></span>.
+  </div>
+  <hr class="dashed my-4">
+  <div>
+    <label for="disableAccountAppPW" class="pl-1 mb-1">Password</label>
+    <input type="password" class="form-control select" id="disableAccountAppPW" autocomplete="current-password">
+  </div>
+  <div class="d-flex justify-content-end mt-4">
+    <button id="disableAccountConfirm" type="button" class="col-8 justify-content-center fs15 bg2 selected">Disable Account</button>
+  </div>
+  <div class="fs15 pt-3 text-center d-hide errcolor" id="disableAccountErr"></div>
+</div>
+{{end}}
+
 {{define "authorizeAccountImportForm"}}
 <div class="bg2 px-2 py-1 text-center position-relative fs18">
   Authorize Import

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -32,7 +32,8 @@
               {{$xc.AcctID}}
               <br>
             {{end}}</span>
-            <button data-tmpl="exportAccount-{{$host}}" class="bg0 {{if eq (len $xc.AcctID) 0}}d-hide{{end}}" >Export Account</button>
+            <button data-tmpl="exportAccount-{{$host}}" class="bg0 {{if eq (len $xc.AcctID) 0}}d-hide{{end}}">Export Account</button>
+            <button data-tmpl="disableAccount-{{$host}}" class="bg0 {{if eq (len $xc.AcctID) 0}}d-hide{{end}}">Disable Account</button>
           </div>
         {{end}}
       </div>
@@ -70,6 +71,11 @@
     {{- /* AUTHORIZE IMPORT ACCOUNT */ -}}
     <form class="card bg1" id="authorizeAccountImportForm">
       {{template "authorizeAccountImportForm"}}
+    </form>
+
+    {{- /* DISABLE ACCOUNT */ -}}
+    <form class="card bg1 d-hide" id="disableAccountForm">
+      {{template "disableAccountForm"}}
     </form>
 
   </div>

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -41,7 +41,7 @@ export default class MarketsPage extends BasePage {
       // Registration status
       'registrationStatus', 'regStatusTitle', 'regStatusMessage', 'regStatusConfsDisplay',
       'regStatusDex', 'confReq',
-      // Order form.
+      // Order form
       'orderForm', 'priceBox', 'buyBttn', 'sellBttn', 'limitBttn', 'marketBttn',
       'tifBox', 'submitBttn', 'qtyField', 'rateField', 'orderErr',
       'baseWalletIcons', 'quoteWalletIcons', 'lotSize', 'rateStep', 'lotField',

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -152,9 +152,10 @@ export default class SettingsPage extends BasePage {
     const loaded = app.loading(this.body)
     const res = await postJSON('/api/disableaccount', req)
     loaded()
-    if (!app.checkResponse(res)) {
-      page.disableAccountErr.textContet = res.msg
+    if (!app.checkResponse(res, true)) {
+      page.disableAccountErr.textContent = res.msg
       Doc.show(page.disableAccountErr)
+      return
     }
     Doc.hide(page.forms)
     // Initial method of removing disabled account.

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -139,7 +139,7 @@ export default class SettingsPage extends BasePage {
     Doc.hide(page.forms)
   }
 
-  // disableAccount disables the associated with the provided host.
+  // disableAccount disables the account associated with the provided host.
   async disableAccount () {
     const page = this.page
     const pw = page.disableAccountAppPW.value

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -239,7 +239,9 @@ export default class SettingsPage extends BasePage {
   async showForm (form) {
     const page = this.page
     this.currentForm = form
-    Doc.hide(page.dexAddrForm, page.confirmRegForm, page.authorizeAccountExportForm, page.authorizeAccountImportForm)
+    Doc.hide(page.dexAddrForm, page.confirmRegForm,
+      page.authorizeAccountExportForm, page.authorizeAccountImportForm,
+      page.disableAccountForm)
     form.style.right = '10000px'
     Doc.show(page.forms, form)
     const shift = (page.forms.offsetWidth + form.offsetWidth) / 2

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -33,8 +33,8 @@ type loginForm struct {
 	Pass encode.PassBytes `json:"pass"`
 }
 
-// registration is used to register a new DEX account.
-type registration struct {
+// registrationForm is used to register a new DEX account.
+type registrationForm struct {
 	Addr     string           `json:"addr"`
 	Cert     string           `json:"cert"`
 	Password encode.PassBytes `json:"pass"`
@@ -75,14 +75,19 @@ type withdrawForm struct {
 	Pass    encode.PassBytes `json:"pw"`
 }
 
-type accountExportAuthForm struct {
+type accountExportForm struct {
 	Pass encode.PassBytes `json:"pw"`
 	Host string           `json:"host"`
 }
 
-type accountImportAuthForm struct {
+type accountImportForm struct {
 	Pass    encode.PassBytes `json:"pw"`
 	Account core.Account     `json:"account"`
+}
+
+type accountDisableForm struct {
+	Pass encode.PassBytes `json:"pw"`
+	Host string           `json:"host"`
 }
 
 // orderReader wraps a core.Order and provides methods for info display.

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -92,6 +92,7 @@ type clientCore interface {
 	MaxSell(host string, base, quote uint32) (*core.MaxOrderEstimate, error)
 	AccountExport(pw []byte, host string) (*core.Account, error)
 	AccountImport(pw []byte, account core.Account) error
+	AccountDisable(pw []byte, host string) error
 	IsInitialized() (bool, error)
 }
 
@@ -268,6 +269,7 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 			apiAuth.Post("/maxsell", s.apiMaxSell)
 			apiAuth.Post("/exportaccount", s.apiAccountExport)
 			apiAuth.Post("/importaccount", s.apiAccountImport)
+			apiAuth.Post("/disableaccount", s.apiAccountDisable)
 		})
 	})
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -157,6 +157,7 @@ func (c *TCore) AccountExport(pw []byte, host string) (*core.Account, error) {
 func (c *TCore) AccountImport(pw []byte, account core.Account) error {
 	return nil
 }
+func (c *TCore) AccountDisable(pw []byte, host string) error { return nil }
 
 type TWriter struct {
 	b []byte
@@ -467,7 +468,7 @@ func TestAPIGetFee(t *testing.T) {
 		ensureResponse(t, s.apiGetFee, want, reader, writer, body)
 	}
 
-	body = &registration{Addr: "somedexaddress.org"}
+	body = &registrationForm{Addr: "somedexaddress.org"}
 	ensure(`{"ok":true,"fee":100000000}`)
 
 	// getFee error

--- a/client/websocket/websocket.go
+++ b/client/websocket/websocket.go
@@ -236,7 +236,7 @@ func newMarketSyncer(cl *wsClient, feed *core.BookFeed, log dex.Logger) *dex.Sta
 // Run starts the marketSyncer listening for BookUpdates, which it relays to the
 // websocket client as notifications.
 func (m *marketSyncer) Run(ctx context.Context) {
-	defer m.feed.Close()
+	m.feed.Close()
 out:
 	for {
 		select {

--- a/client/websocket/websocket.go
+++ b/client/websocket/websocket.go
@@ -236,14 +236,12 @@ func newMarketSyncer(cl *wsClient, feed *core.BookFeed, log dex.Logger) *dex.Sta
 // Run starts the marketSyncer listening for BookUpdates, which it relays to the
 // websocket client as notifications.
 func (m *marketSyncer) Run(ctx context.Context) {
-	m.feed.Close()
 out:
 	for {
 		select {
 		case update, ok := <-m.feed.C:
 			if !ok {
-				// Should not happen, but don't spin furiously.
-				m.log.Warnf("marketSyncer stopping on feed closed")
+				// We are skipping m.feed.Close if the feed were closed (external sig).
 				return
 			}
 			note, err := msgjson.NewNotification(update.Action, update)
@@ -260,6 +258,7 @@ out:
 			break out
 		}
 	}
+	m.feed.Close()
 }
 
 // wsLoadMarket is the handler for the 'loadmarket' websocket route. Subscribes


### PR DESCRIPTION
This adds a new button to dexc's GUI to disable account manually, this is useful when a user wants to
re-register a suspended account which required deleting the dexc.db before this commit.

Closes #961.