### PR TITLE
[0.1] order fee estimation

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -654,72 +654,155 @@ func (btc *ExchangeWallet) feeRateWithFallback(confTarget uint64) uint64 {
 // estimate based on current network conditions, and will be <= the fees
 // associated with nfo.MaxFeeRate. For quote assets, the caller will have to
 // calculate lotSize based on a rate conversion from the base asset's lot size.
-func (btc *ExchangeWallet) MaxOrder(lotSize uint64, nfo *dex.Asset) (*asset.OrderEstimate, error) {
+func (btc *ExchangeWallet) MaxOrder(lotSize uint64, nfo *dex.Asset) (*asset.SwapEstimate, error) {
+	_, _, maxEst, err := btc.maxOrder(lotSize, nfo)
+	return maxEst, err
+}
+
+// maxOrder gets the estimate for MaxOrder, and also returns the
+// []*compositeUTXO to be used for further order estimation without additional
+// calls to listunspent.
+func (btc *ExchangeWallet) maxOrder(lotSize uint64, nfo *dex.Asset) (utxos []*compositeUTXO, feeRate uint64, est *asset.SwapEstimate, err error) {
 	networkFeeRate, err := btc.feeRate(1)
 	if err != nil {
-		return nil, fmt.Errorf("error getting network fee estimate: %w", err)
+		return nil, 0, nil, fmt.Errorf("error getting network fee estimate: %w", err)
 	}
 	btc.fundingMtx.RLock()
 	utxos, _, avail, err := btc.spendableUTXOs(0)
 	btc.fundingMtx.RUnlock()
 	if err != nil {
-		return nil, fmt.Errorf("error parsing unspent outputs: %w", err)
+		return nil, 0, nil, fmt.Errorf("error parsing unspent outputs: %w", err)
 	}
 	// Start by attempting max lots with no fees.
 	lots := avail / lotSize
 	for lots > 0 {
-		val := lots * lotSize
-		sum, size, _, _, _, _, err := btc.fund(val, lots, utxos, nfo)
-		// The only failure mode of btc.fund is when there is not enough funds,
-		// so if an error is encountered, count down the lots and repeat until
-		// we have enough.
+		est, _, err := btc.estimateSwap(lots, lotSize, networkFeeRate, utxos, nfo, btc.useSplitTx)
+		// The only failure mode of estimateSwap -> btc.fund is when there is
+		// not enough funds, so if an error is encountered, count down the lots
+		// and repeat until we have enough.
 		if err != nil {
 			lots--
 			continue
 		}
-		reqFunds := calc.RequiredOrderFunds(val, uint64(size), lots, nfo)
-		maxFees := reqFunds - val
-		estFunds := calc.RequiredOrderFundsAlt(val, uint64(size), lots, nfo.SwapSizeBase, nfo.SwapSize, networkFeeRate)
-		estFees := estFunds - val
-		// Math for split transactions is a little different.
-		if btc.useSplitTx {
-			_, extraFees := btc.splitBaggageFees(nfo.MaxFeeRate)
-			_, extraEstFees := btc.splitBaggageFees(networkFeeRate)
-			if avail >= reqFunds+extraFees {
-				return &asset.OrderEstimate{
-					Lots:          lots,
-					Value:         val,
-					MaxFees:       maxFees + extraFees,
-					EstimatedFees: estFees + extraEstFees,
-					Locked:        val + maxFees + extraFees,
-				}, nil
-			}
-		}
-
-		// No split transaction.
-		return &asset.OrderEstimate{
-			Lots:          lots,
-			Value:         val,
-			MaxFees:       maxFees,
-			EstimatedFees: estFees,
-			Locked:        sum,
-		}, nil
+		return utxos, networkFeeRate, est, nil
 	}
-	return &asset.OrderEstimate{}, nil
+	return utxos, networkFeeRate, &asset.SwapEstimate{}, nil
 }
 
-// RedemptionFees is an estimate of the redemption fees for a 1-swap redemption.
-func (btc *ExchangeWallet) RedemptionFees() (uint64, error) {
+// PreSwap get order estimates based on the available funds and the wallet
+// configuration.
+func (btc *ExchangeWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, error) {
+	// Start with the maxOrder at the default configuration. This gets us the
+	// utxo set, the network fee rate, and the wallet's maximum order size.
+	// The utxo set can then be used repeatedly in estimateSwap at virtually
+	// zero cost since there are no more RPC calls.
+	// The utxo set is only used once right now, but when order-time options are
+	// implemented, the utxos will be used to calculate option availability and
+	// fees.
+	utxos, feeRate, maxEst, err := btc.maxOrder(req.LotSize, req.AssetConfig)
+	if err != nil {
+		return nil, err
+	}
+	if maxEst.Lots < req.Lots {
+		return nil, fmt.Errorf("%d lots available for %d-lot order", maxEst.Lots, req.Lots)
+	}
+
+	// Get the estimate for the requested number of lots.
+	est, _, err := btc.estimateSwap(req.Lots, req.LotSize, feeRate, utxos, req.AssetConfig, btc.useSplitTx)
+	if err != nil {
+		return nil, fmt.Errorf("estimation failed: %v", err)
+	}
+
+	return &asset.PreSwap{
+		Estimate: est,
+	}, nil
+}
+
+// estimateSwap prepares an *asset.SwapEstimate.
+func (btc *ExchangeWallet) estimateSwap(lots, lotSize, networkFeeRate uint64, utxos []*compositeUTXO,
+	nfo *dex.Asset, trySplit bool) (*asset.SwapEstimate, bool /*split used*/, error) {
+
+	var avail uint64
+	for _, utxo := range utxos {
+		avail += utxo.amount
+	}
+
+	val := lots * lotSize
+
+	sum, inputsSize, _, _, _, _, err := btc.fund(val, lots, utxos, nfo)
+	if err != nil {
+		return nil, false, err
+	}
+
+	reqFunds := calc.RequiredOrderFundsAlt(val, uint64(inputsSize), lots, nfo.SwapSizeBase, nfo.SwapSize, nfo.MaxFeeRate)
+	maxFees := reqFunds - val
+
+	estHighFunds := calc.RequiredOrderFundsAlt(val, uint64(inputsSize), lots, nfo.SwapSizeBase, nfo.SwapSize, networkFeeRate)
+	estHighFees := estHighFunds - val
+
+	estLowFunds := calc.RequiredOrderFundsAlt(val, uint64(inputsSize), 1, nfo.SwapSizeBase, nfo.SwapSize, networkFeeRate)
+	if btc.segwit {
+		estLowFunds += dexbtc.P2WSHOutputSize * (lots - 1) * networkFeeRate
+	} else {
+		estLowFunds += dexbtc.P2SHOutputSize * (lots - 1) * networkFeeRate
+	}
+
+	estLowFees := estLowFunds - val
+
+	// Math for split transactions is a little different.
+	if trySplit {
+		_, extraMaxFees := btc.splitBaggageFees(nfo.MaxFeeRate)
+		_, splitFees := btc.splitBaggageFees(networkFeeRate)
+
+		if avail >= reqFunds+extraMaxFees {
+			return &asset.SwapEstimate{
+				Lots:               lots,
+				Value:              val,
+				MaxFees:            maxFees + extraMaxFees,
+				RealisticBestCase:  estLowFees + splitFees,
+				RealisticWorstCase: estHighFees + splitFees,
+				Locked:             val + maxFees + extraMaxFees,
+			}, true, nil
+		}
+	}
+
+	return &asset.SwapEstimate{
+		Lots:               lots,
+		Value:              val,
+		MaxFees:            maxFees,
+		RealisticBestCase:  estLowFees,
+		RealisticWorstCase: estHighFees,
+		Locked:             sum,
+	}, false, nil
+}
+
+// PreRedeem generates an estimate of the range of redemption fees that could
+// be assessed.
+func (btc *ExchangeWallet) PreRedeem(req *asset.PreRedeemForm) (*asset.PreRedeem, error) {
 	feeRate := btc.feeRateWithFallback(btc.redeemConfTarget)
-	var size uint64 = dexbtc.MinimumTxOverhead + dexbtc.TxInOverhead + dexbtc.TxOutOverhead
+	// Best is one transaction with req.Lots inputs and 1 output.
+	var best uint64 = dexbtc.MinimumTxOverhead
+	// Worst is req.Lots transactions, each with one input and one output.
+	var worst uint64 = dexbtc.MinimumTxOverhead * req.Lots
+	var inputSize, outputSize uint64
 	if btc.segwit {
 		// Add the marker and flag weight here.
-		var witnessVBytes uint64 = (dexbtc.RedeemSwapSigScriptSize + 2 + 3) / 4
-		size += witnessVBytes + dexbtc.P2WPKHOutputSize
+		inputSize = dexbtc.TxInOverhead + (dexbtc.RedeemSwapSigScriptSize+2+3)/4
+		outputSize = dexbtc.P2WPKHOutputSize
+
 	} else {
-		size += dexbtc.RedeemSwapSigScriptSize + dexbtc.P2PKHOutputSize
+		inputSize = dexbtc.TxInOverhead + dexbtc.RedeemSwapSigScriptSize
+		outputSize = dexbtc.P2PKHOutputSize
 	}
-	return size * feeRate, nil
+	best += inputSize*req.Lots + outputSize
+	worst += (inputSize + outputSize) * req.Lots
+
+	return &asset.PreRedeem{
+		Estimate: &asset.RedeemEstimate{
+			RealisticWorstCase: worst * feeRate,
+			RealisticBestCase:  best * feeRate,
+		},
+	}, nil
 }
 
 // FundOrder selects coins for use in an order. The coins will be locked, and
@@ -853,7 +936,9 @@ out:
 // order is canceled partially filled, and then the remainder resubmitted. We
 // would already have an output of just the right size, and that would be
 // recognized here.
-func (btc *ExchangeWallet) split(value uint64, lots uint64, outputs []*output, inputsSize uint64, fundingCoins map[outPoint]*utxo, nfo *dex.Asset) (asset.Coins, bool, error) {
+func (btc *ExchangeWallet) split(value uint64, lots uint64, outputs []*output,
+	inputsSize uint64, fundingCoins map[outPoint]*utxo, nfo *dex.Asset) (asset.Coins, bool, error) {
+
 	var err error
 	defer func() {
 		if err != nil {
@@ -879,7 +964,7 @@ func (btc *ExchangeWallet) split(value uint64, lots uint64, outputs []*output, i
 		coinSum += op.value
 	}
 
-	excess := coinSum - calc.RequiredOrderFunds(value, inputsSize, lots, nfo)
+	excess := coinSum - calc.RequiredOrderFundsAlt(value, inputsSize, lots, nfo.SwapSizeBase, nfo.SwapSize, nfo.MaxFeeRate)
 	if baggage > excess {
 		btc.log.Debugf("Skipping split transaction because cost is greater than potential over-lock. "+
 			"%.8f > %.8f", toBTC(baggage), toBTC(excess))
@@ -894,7 +979,7 @@ func (btc *ExchangeWallet) split(value uint64, lots uint64, outputs []*output, i
 		return nil, false, fmt.Errorf("error creating split transaction address: %v", err)
 	}
 
-	reqFunds := calc.RequiredOrderFunds(value, swapInputSize, lots, nfo)
+	reqFunds := calc.RequiredOrderFundsAlt(value, swapInputSize, lots, nfo.SwapSizeBase, nfo.SwapSize, nfo.MaxFeeRate)
 
 	baseTx, _, _, err := btc.fundedTx(coins)
 	splitScript, err := txscript.PayToAddrScript(addr)
@@ -909,13 +994,20 @@ func (btc *ExchangeWallet) split(value uint64, lots uint64, outputs []*output, i
 		return nil, false, fmt.Errorf("error creating change address: %v", err)
 	}
 
-	feeRate := btc.feeRateWithFallback(1) // these must fund swaps, so don't under-pay (is this an issue with no fundconf requirement?)
-	if feeRate > nfo.MaxFeeRate {
-		feeRate = nfo.MaxFeeRate
+	// This must fund swaps, so don't under-pay. TODO: get and use a fee rate
+	// from server, and have server check fee rate on unconf funding coins.
+	estFeeRate, err := btc.feeRate(1)
+	if err != nil {
+		// Fallback fee rate is NO GOOD here.
+		return nil, false, fmt.Errorf("unable to get optimal fee rate for pre-split transaction "+
+			"(disable the pre-size option or wait until your wallet is ready): %w", err)
+	}
+	if estFeeRate > nfo.MaxFeeRate {
+		estFeeRate = nfo.MaxFeeRate
 	}
 
 	// Sign, add change, and send the transaction.
-	msgTx, _, _, err := btc.sendWithReturn(baseTx, changeAddr, coinSum, reqFunds, feeRate)
+	msgTx, _, _, err := btc.sendWithReturn(baseTx, changeAddr, coinSum, reqFunds, estFeeRate)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1127,6 +1219,7 @@ func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	if err != nil {
 		return nil, nil, 0, err
 	}
+
 	// Add the contract outputs.
 	// TODO: Make P2WSH contract and P2WPKH change outputs instead of
 	// legacy/non-segwit swap contracts pkScripts.
@@ -1230,14 +1323,14 @@ func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 }
 
 // Redeem sends the redemption transaction, completing the atomic swap.
-func (btc *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes, asset.Coin, uint64, error) {
+func (btc *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Coin, uint64, error) {
 	// Create a transaction that spends the referenced contract.
 	msgTx := wire.NewMsgTx(wire.TxVersion)
 	var totalIn uint64
 	var contracts [][]byte
 	var addresses []btcutil.Address
 	var values []uint64
-	for _, r := range redemptions {
+	for _, r := range form.Redemptions {
 		cinfo, ok := r.Spends.(*auditInfo)
 		if !ok {
 			return nil, nil, 0, fmt.Errorf("Redemption contract info of wrong type")
@@ -1268,10 +1361,10 @@ func (btc *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes,
 	size := dexbtc.MsgTxVBytes(msgTx)
 	if btc.segwit {
 		// Add the marker and flag weight here.
-		witnessVBytes := (dexbtc.RedeemSwapSigScriptSize*uint64(len(redemptions)) + 2 + 3) / 4
+		witnessVBytes := (dexbtc.RedeemSwapSigScriptSize*uint64(len(form.Redemptions)) + 2 + 3) / 4
 		size += witnessVBytes + dexbtc.P2WPKHOutputSize
 	} else {
-		size += dexbtc.RedeemSwapSigScriptSize*uint64(len(redemptions)) + dexbtc.P2PKHOutputSize
+		size += dexbtc.RedeemSwapSigScriptSize*uint64(len(form.Redemptions)) + dexbtc.P2PKHOutputSize
 	}
 
 	feeRate := btc.feeRateWithFallback(btc.redeemConfTarget)
@@ -1279,6 +1372,7 @@ func (btc *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes,
 	if fee > totalIn {
 		return nil, nil, 0, fmt.Errorf("redeem tx not worth the fees")
 	}
+
 	// Send the funds back to the exchange wallet.
 	redeemAddr, err := btc.wallet.ChangeAddress()
 	if err != nil {
@@ -1297,7 +1391,7 @@ func (btc *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes,
 
 	if btc.segwit {
 		sigHashes := txscript.NewTxSigHashes(msgTx)
-		for i, r := range redemptions {
+		for i, r := range form.Redemptions {
 			contract := contracts[i]
 			redeemSig, redeemPubKey, err := btc.createWitnessSig(msgTx, i, contract, addresses[i], values[i], sigHashes)
 			if err != nil {
@@ -1306,7 +1400,7 @@ func (btc *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes,
 			msgTx.TxIn[i].Witness = dexbtc.RedeemP2WSHContract(contract, redeemSig, redeemPubKey, r.Secret)
 		}
 	} else {
-		for i, r := range redemptions {
+		for i, r := range form.Redemptions {
 			contract := contracts[i]
 			redeemSig, redeemPubKey, err := btc.createSig(msgTx, i, contract, addresses[i])
 			if err != nil {
@@ -1330,8 +1424,8 @@ func (btc *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes,
 			"expected %s, got %s", *txHash, checkHash)
 	}
 	// Log the change output.
-	coinIDs := make([]dex.Bytes, 0, len(redemptions))
-	for i := range redemptions {
+	coinIDs := make([]dex.Bytes, 0, len(form.Redemptions))
+	for i := range form.Redemptions {
 		coinIDs = append(coinIDs, toCoinID(txHash, uint32(i)))
 	}
 	return coinIDs, newOutput(txHash, 0, uint64(txOut.Value)), fee, nil

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -844,12 +844,40 @@ func TestFundingCoins(t *testing.T) {
 	ensureGood()
 }
 
+func checkMaxOrder(t *testing.T, wallet *ExchangeWallet, lots, swapVal, maxFees, estFees, locked uint64) {
+	t.Helper()
+	maxOrder, err := wallet.MaxOrder(tBTC.LotSize, tBTC)
+	if err != nil {
+		t.Fatalf("MaxOrder error: %v", err)
+	}
+	if maxOrder.Lots != lots {
+		t.Fatalf("MaxOrder has wrong Lots. wanted %d, got %d", lots, maxOrder.Lots)
+	}
+	if maxOrder.Value != swapVal {
+		t.Fatalf("MaxOrder has wrong Value. wanted %d, got %d", swapVal, maxOrder.Value)
+	}
+	if maxOrder.MaxFees != maxFees {
+		t.Fatalf("MaxOrder has wrong MaxFees. wanted %d, got %d", maxFees, maxOrder.MaxFees)
+	}
+	if maxOrder.EstimatedFees != estFees {
+		t.Fatalf("MaxOrder has wrong EstimatedFees. wanted %d, got %d", estFees, maxOrder.EstimatedFees)
+	}
+	if maxOrder.Locked != locked {
+		t.Fatalf("MaxOrder has wrong Locked. wanted %d, got %d", locked, maxOrder.Locked)
+	}
+}
+
 func TestFundEdges(t *testing.T) {
 	wallet, node, shutdown := tNewWallet(false)
 	defer shutdown()
 	swapVal := uint64(1e7)
 	lots := swapVal / tBTC.LotSize
 	node.rawRes[methodLockUnspent] = mustMarshal(t, true)
+	var estFeeRate = optimalFeeRate + 1 // +1 added in feeRate
+
+	checkMax := func(lots, swapVal, maxFees, estFees, locked uint64) {
+		checkMaxOrder(t, wallet, lots, swapVal, maxFees, estFees, locked)
+	}
 
 	// Base Fees
 	// fee_rate: 34 satoshi / vbyte (MaxFeeRate)
@@ -874,7 +902,9 @@ func TestFundEdges(t *testing.T) {
 	// total_bytes  = base_tx_bytes + backing_bytes = 2101 + 149 = 2250
 	// total_fees: base_fees + backing_fees = 71434 + 5066 = 76500 atoms
 	//          OR total_bytes * fee_rate = 2510 * 34 = 76500
-	backingFees := uint64(2250) * tBTC.MaxFeeRate // total_bytes * fee_rate
+	const swapSize = 225
+	const totalBytes = 2250
+	backingFees := uint64(totalBytes) * tBTC.MaxFeeRate // total_bytes * fee_rate
 	p2pkhUnspent := &ListUnspentResult{
 		TxID:          tTxID,
 		Address:       tP2PKHAddr,
@@ -892,6 +922,11 @@ func TestFundEdges(t *testing.T) {
 		MaxSwapCount: lots,
 		DEXConfig:    tBTC,
 	}
+
+	var feeReduction uint64 = swapSize * tBTC.MaxFeeRate
+	estFeeReduction := swapSize * estFeeRate
+	checkMax(lots-1, swapVal-tBTC.LotSize, backingFees-feeReduction, totalBytes*estFeeRate-estFeeReduction, swapVal+backingFees-1)
+
 	_, _, err := wallet.FundOrder(ord)
 	if err == nil {
 		t.Fatalf("no error when not enough funds in single p2pkh utxo")
@@ -899,6 +934,9 @@ func TestFundEdges(t *testing.T) {
 	// Now add the needed satoshi and try again.
 	p2pkhUnspent.Amount = float64(swapVal+backingFees) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
+	checkMax(lots, swapVal, backingFees, totalBytes*estFeeRate, swapVal+backingFees)
+
 	_, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error when should be enough funding in single p2pkh utxo: %v", err)
@@ -911,11 +949,12 @@ func TestFundEdges(t *testing.T) {
 	node.signFunc = func(params []json.RawMessage) (json.RawMessage, error) {
 		return signFunc(t, params, 0, true, wallet.segwit)
 	}
-	backingFees = uint64(2250+splitTxBaggage) * tBTC.MaxFeeRate
+	backingFees = uint64(totalBytes+splitTxBaggage) * tBTC.MaxFeeRate
 	// 1 too few atoms
 	v := swapVal + backingFees - 1
 	p2pkhUnspent.Amount = float64(v) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
 	coins, _, err := wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error when skipping split tx due to baggage: %v", err)
@@ -927,6 +966,9 @@ func TestFundEdges(t *testing.T) {
 	v = swapVal + backingFees
 	p2pkhUnspent.Amount = float64(v) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
+	checkMax(lots, swapVal, backingFees, (totalBytes+splitTxBaggage)*estFeeRate, v)
+
 	coins, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding split tx: %v", err)
@@ -1043,6 +1085,11 @@ func TestFundEdgesSegwit(t *testing.T) {
 	swapVal := uint64(1e7)
 	lots := swapVal / tBTC.LotSize
 	node.rawRes[methodLockUnspent] = mustMarshal(t, true)
+	var estFeeRate = optimalFeeRate + 1 // +1 added in feeRateWithFallback
+
+	checkMax := func(lots, swapVal, maxFees, estFees, locked uint64) {
+		checkMaxOrder(t, wallet, lots, swapVal, maxFees, estFees, locked)
+	}
 
 	// Base Fees
 	// fee_rate: 34 satoshi / vbyte (MaxFeeRate)
@@ -1066,7 +1113,9 @@ func TestFundEdgesSegwit(t *testing.T) {
 	// total_bytes  = base_tx_bytes + backing_bytes = 1461 + 69 = 1530
 	// total_fees: base_fees + backing_fees = 49674 + 2346 = 52020 atoms
 	//          OR total_bytes * fee_rate = 1530 * 34 = 52020
-	backingFees := uint64(1530) * tBTC.MaxFeeRate // total_bytes * fee_rate
+	const swapSize = 153
+	const totalBytes = 1530
+	backingFees := uint64(totalBytes) * tBTC.MaxFeeRate // total_bytes * fee_rate
 	p2wpkhUnspent := &ListUnspentResult{
 		TxID:          tTxID,
 		Address:       tP2WPKHAddr,
@@ -1084,6 +1133,11 @@ func TestFundEdgesSegwit(t *testing.T) {
 		MaxSwapCount: lots,
 		DEXConfig:    tBTC,
 	}
+
+	var feeReduction uint64 = swapSize * tBTC.MaxFeeRate
+	estFeeReduction := swapSize * estFeeRate
+	checkMax(lots-1, swapVal-tBTC.LotSize, backingFees-feeReduction, totalBytes*estFeeRate-estFeeReduction, swapVal+backingFees-1)
+
 	_, _, err := wallet.FundOrder(ord)
 	if err == nil {
 		t.Fatalf("no error when not enough funds in single p2wpkh utxo")
@@ -1091,6 +1145,9 @@ func TestFundEdgesSegwit(t *testing.T) {
 	// Now add the needed satoshi and try again.
 	p2wpkhUnspent.Amount = float64(swapVal+backingFees) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
+	checkMax(lots, swapVal, backingFees, totalBytes*estFeeRate, swapVal+backingFees)
+
 	_, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error when should be enough funding in single p2wpkh utxo: %v", err)
@@ -1103,7 +1160,7 @@ func TestFundEdgesSegwit(t *testing.T) {
 	node.signFunc = func(params []json.RawMessage) (json.RawMessage, error) {
 		return signFunc(t, params, 0, true, wallet.segwit)
 	}
-	backingFees = uint64(1530+splitTxBaggageSegwit) * tBTC.MaxFeeRate
+	backingFees = uint64(totalBytes+splitTxBaggageSegwit) * tBTC.MaxFeeRate
 	v := swapVal + backingFees - 1
 	p2wpkhUnspent.Amount = float64(v) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
@@ -1118,6 +1175,9 @@ func TestFundEdgesSegwit(t *testing.T) {
 	v = swapVal + backingFees
 	p2wpkhUnspent.Amount = float64(v) / 1e8
 	node.rawRes[methodListUnspent] = mustMarshal(t, unspents)
+
+	checkMax(lots, swapVal, backingFees, (totalBytes+splitTxBaggageSegwit)*estFeeRate, v)
+
 	coins, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding split tx: %v", err)

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -305,7 +305,9 @@ func Run(t *testing.T, newWallet WalletConstructor, address string, dexAsset *de
 		makeRedemption(contractValue*2, receipts[1], secretKey2),
 	}
 
-	_, _, _, err = rig.alpha().Redeem(redemptions)
+	_, _, _, err = rig.alpha().Redeem(&asset.RedeemForm{
+		Redemptions: redemptions,
+	})
 	if err != nil {
 		t.Fatalf("redemption error: %v", err)
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -620,14 +620,23 @@ func (dcr *ExchangeWallet) feeRateWithFallback(confTarget uint64) uint64 {
 // estimate based on current network conditions, and will be <= the fees
 // associated with nfo.MaxFeeRate. For quote assets, the caller will have to
 // calculate lotSize based on a rate conversion from the base asset's lot size.
-func (dcr *ExchangeWallet) MaxOrder(lotSize uint64, nfo *dex.Asset) (*asset.OrderEstimate, error) {
+func (dcr *ExchangeWallet) MaxOrder(lotSize uint64, nfo *dex.Asset) (*asset.SwapEstimate, error) {
+	_, _, est, err := dcr.maxOrder(lotSize, nfo)
+	return est, err
+}
+
+// maxOrder gets the estimate for MaxOrder, and also returns the
+// []*compositeUTXO and network fee rate to be used for further order estimation
+// without additional calls to listunspent.
+func (dcr *ExchangeWallet) maxOrder(lotSize uint64, nfo *dex.Asset) (utxos []*compositeUTXO, feeRate uint64, est *asset.SwapEstimate, err error) {
 	networkFeeRate, err := dcr.feeRate(1)
 	if err != nil {
-		return nil, fmt.Errorf("error getting network fee estimate: %w", err)
+		return nil, 0, nil, fmt.Errorf("error getting network fee estimate: %w", err)
 	}
-	utxos, err := dcr.spendableUTXOs()
+
+	utxos, err = dcr.spendableUTXOs()
 	if err != nil {
-		return nil, fmt.Errorf("error parsing unspent outputs: %w", err)
+		return nil, 0, nil, fmt.Errorf("error parsing unspent outputs: %w", err)
 	}
 	var avail uint64
 	for _, utxo := range utxos {
@@ -637,51 +646,119 @@ func (dcr *ExchangeWallet) MaxOrder(lotSize uint64, nfo *dex.Asset) (*asset.Orde
 	// Start by attempting max lots with no fees.
 	lots := avail / lotSize
 	for lots > 0 {
-		val := lots * lotSize
-		sum, size, _, _, _, err := dcr.tryFund(utxos, orderEnough(val, lots, nfo))
-		// The only failure mode of dcr.tryFund is when there is not enough funds,
-		// so if an error is encountered, count down the lots and repeat until
-		// we have enough.
+		est, _, err := dcr.estimateSwap(lots, lotSize, networkFeeRate, utxos, nfo, dcr.useSplitTx)
+		// The only failure mode of estimateSwap -> dcr.fund is when there is
+		// not enough funds, so if an error is encountered, count down the lots
+		// and repeat until we have enough.
 		if err != nil {
 			lots--
 			continue
 		}
-		reqFunds := calc.RequiredOrderFunds(val, uint64(size), lots, nfo)
-		maxFees := reqFunds - val
-		estFunds := calc.RequiredOrderFundsAlt(val, uint64(size), lots, nfo.SwapSizeBase, nfo.SwapSize, networkFeeRate)
-		estFees := estFunds - val
-		// Math for split transactions is a little different.
-		if dcr.useSplitTx {
-			extraFees := splitTxBaggage * nfo.MaxFeeRate
-			if avail >= reqFunds+extraFees {
-				return &asset.OrderEstimate{
-					Lots:          lots,
-					Value:         val,
-					MaxFees:       maxFees + extraFees,
-					EstimatedFees: estFees + (splitTxBaggage * networkFeeRate),
-					Locked:        val + maxFees + extraFees,
-				}, nil
-			}
-		}
-
-		// No split transaction.
-		return &asset.OrderEstimate{
-			Lots:          lots,
-			Value:         val,
-			MaxFees:       maxFees,
-			EstimatedFees: estFees,
-			Locked:        sum,
-		}, nil
+		return utxos, networkFeeRate, est, nil
 	}
-	return &asset.OrderEstimate{}, nil
+
+	return nil, 0, &asset.SwapEstimate{}, nil
 }
 
-// RedemptionFees is an estimate of the redemption fees for a 1-swap redemption.
-func (dcr *ExchangeWallet) RedemptionFees() (uint64, error) {
+// estimateSwap prepares an *asset.SwapEstimate.
+func (dcr *ExchangeWallet) estimateSwap(lots, lotSize, networkFeeRate uint64, utxos []*compositeUTXO,
+	nfo *dex.Asset, trySplit bool) (*asset.SwapEstimate, bool /*split used*/, error) {
+
+	var avail uint64
+	for _, utxo := range utxos {
+		avail += toAtoms(utxo.rpc.Amount)
+	}
+
+	val := lots * lotSize
+	sum, inputsSize, _, _, _, err := dcr.tryFund(utxos, orderEnough(val, lots, nfo))
+	if err != nil {
+		return nil, false, err
+	}
+	reqFunds := calc.RequiredOrderFunds(val, uint64(inputsSize), lots, nfo)
+	maxFees := reqFunds - val
+
+	estHighFunds := calc.RequiredOrderFundsAlt(val, uint64(inputsSize), lots, nfo.SwapSizeBase, nfo.SwapSize, networkFeeRate)
+	estHighFees := estHighFunds - val
+
+	estLowFunds := calc.RequiredOrderFundsAlt(val, uint64(inputsSize), 1, nfo.SwapSizeBase, nfo.SwapSize, networkFeeRate)
+	estLowFunds += dexdcr.P2SHOutputSize * (lots - 1) * networkFeeRate
+	estLowFees := estLowFunds - val
+
+	// Math for split transactions is a little different.
+	if dcr.useSplitTx {
+		extraFees := splitTxBaggage * nfo.MaxFeeRate
+		splitFees := splitTxBaggage * networkFeeRate
+		if avail >= reqFunds+extraFees {
+			return &asset.SwapEstimate{
+				Lots:               lots,
+				Value:              val,
+				MaxFees:            maxFees + extraFees,
+				RealisticBestCase:  estLowFees + splitFees,
+				RealisticWorstCase: estHighFees + splitFees,
+				Locked:             val + maxFees + extraFees,
+			}, true, nil
+		}
+	}
+
+	// No split transaction.
+	return &asset.SwapEstimate{
+		Lots:               lots,
+		Value:              val,
+		MaxFees:            maxFees,
+		RealisticBestCase:  estLowFees,
+		RealisticWorstCase: estHighFees,
+		Locked:             sum,
+	}, false, nil
+}
+
+// PreSwap get order estimates based on the available funds and the wallet
+// configuration.
+func (dcr *ExchangeWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, error) {
+	// Start with the maxOrder at the default configuration. This gets us the
+	// utxo set, the network fee rate, and the wallet's maximum order size.
+	// The utxo set can then be used repeatedly in estimateSwap at virtually
+	// zero cost since there are no more RPC calls.
+	// The utxo set is only used once right now, but when order-time options are
+	// implemented, the utxos will be used to calculate option availability and
+	// fees.
+	utxos, feeRate, maxEst, err := dcr.maxOrder(req.LotSize, req.AssetConfig)
+	if err != nil {
+		return nil, err
+	}
+	if maxEst.Lots < req.Lots {
+		return nil, fmt.Errorf("%d lots available for %d-lot order", maxEst.Lots, req.Lots)
+	}
+
+	// Get the estimate for the requested number of lots.
+	est, _, err := dcr.estimateSwap(req.Lots, req.LotSize, feeRate, utxos, req.AssetConfig, dcr.useSplitTx)
+	if err != nil {
+		return nil, fmt.Errorf("estimation failed: %v", err)
+	}
+
+	return &asset.PreSwap{
+		Estimate: est,
+	}, nil
+}
+
+// PreRedeem generates an estimate of the range of redemption fees that could
+// be assessed.
+func (dcr *ExchangeWallet) PreRedeem(req *asset.PreRedeemForm) (*asset.PreRedeem, error) {
 	feeRate := dcr.feeRateWithFallback(dcr.redeemConfTarget)
-	var size uint64 = dexdcr.MsgTxOverhead + dexdcr.TxInOverhead + dexdcr.TxOutOverhead +
-		dexdcr.RedeemSwapSigScriptSize + dexdcr.P2PKHOutputSize
-	return size * feeRate, nil
+	// Best is one transaction with req.Lots inputs and 1 output.
+	var best uint64 = dexdcr.MsgTxOverhead
+	// Worst is req.Lots transactions, each with one input and one output.
+	var worst uint64 = dexdcr.MsgTxOverhead * req.Lots
+	var inputSize uint64 = dexdcr.TxInOverhead + dexdcr.RedeemSwapSigScriptSize
+	var outputSize uint64 = dexdcr.P2PKHOutputSize
+	best += inputSize*req.Lots + outputSize
+	worst += (inputSize + outputSize) * req.Lots
+
+	return &asset.PreRedeem{
+		Estimate: &asset.RedeemEstimate{
+			RealisticWorstCase: worst * feeRate,
+			RealisticBestCase:  best * feeRate,
+		},
+	}, nil
 }
 
 // orderEnough generates a function that can be used as the enough argument to
@@ -1210,13 +1287,13 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 
 // Redeem sends the redemption transaction, which may contain more than one
 // redemption.
-func (dcr *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes, asset.Coin, uint64, error) {
+func (dcr *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Coin, uint64, error) {
 	// Create a transaction that spends the referenced contract.
 	msgTx := wire.NewMsgTx()
 	var totalIn uint64
 	var contracts [][]byte
 	var addresses []dcrutil.Address
-	for _, r := range redemptions {
+	for _, r := range form.Redemptions {
 		cinfo, ok := r.Spends.(*auditInfo)
 		if !ok {
 			return nil, nil, 0, fmt.Errorf("Redemption contract info of wrong type")
@@ -1246,7 +1323,7 @@ func (dcr *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes,
 	}
 
 	// Calculate the size and the fees.
-	size := msgTx.SerializeSize() + dexdcr.RedeemSwapSigScriptSize*len(redemptions) + dexdcr.P2PKHOutputSize
+	size := msgTx.SerializeSize() + dexdcr.RedeemSwapSigScriptSize*len(form.Redemptions) + dexdcr.P2PKHOutputSize
 	feeRate := dcr.feeRateWithFallback(dcr.redeemConfTarget)
 	fee := feeRate * uint64(size)
 	if fee > totalIn {
@@ -1263,7 +1340,7 @@ func (dcr *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes,
 	}
 	msgTx.AddTxOut(txOut)
 	// Sign the inputs.
-	for i, r := range redemptions {
+	for i, r := range form.Redemptions {
 		contract := contracts[i]
 		redeemSig, redeemPubKey, err := dcr.createSig(msgTx, i, contract, addresses[i])
 		if err != nil {
@@ -1285,8 +1362,8 @@ func (dcr *ExchangeWallet) Redeem(redemptions []*asset.Redemption) ([]dex.Bytes,
 		return nil, nil, 0, fmt.Errorf("redemption sent, but received unexpected transaction ID back from RPC server. "+
 			"expected %s, got %s", *txHash, checkHash)
 	}
-	coinIDs := make([]dex.Bytes, 0, len(redemptions))
-	for i := range redemptions {
+	coinIDs := make([]dex.Bytes, 0, len(form.Redemptions))
+	for i := range form.Redemptions {
 		coinIDs = append(coinIDs, toCoinID(txHash, uint32(i)))
 	}
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -926,11 +926,39 @@ func TestFundingCoins(t *testing.T) {
 	ensureGood()
 }
 
+func checkMaxOrder(t *testing.T, wallet *ExchangeWallet, lots, swapVal, maxFees, estFees, locked uint64) {
+	t.Helper()
+	maxOrder, err := wallet.MaxOrder(tDCR.LotSize, tDCR)
+	if err != nil {
+		t.Fatalf("MaxOrder error: %v", err)
+	}
+	if maxOrder.Lots != lots {
+		t.Fatalf("MaxOrder has wrong Lots. wanted %d, got %d", lots, maxOrder.Lots)
+	}
+	if maxOrder.Value != swapVal {
+		t.Fatalf("MaxOrder has wrong Value. wanted %d, got %d", swapVal, maxOrder.Value)
+	}
+	if maxOrder.MaxFees != maxFees {
+		t.Fatalf("MaxOrder has wrong MaxFees. wanted %d, got %d", maxFees, maxOrder.MaxFees)
+	}
+	if maxOrder.EstimatedFees != estFees {
+		t.Fatalf("MaxOrder has wrong EstimatedFees. wanted %d, got %d", estFees, maxOrder.EstimatedFees)
+	}
+	if maxOrder.Locked != locked {
+		t.Fatalf("MaxOrder has wrong Locked. wanted %d, got %d", locked, maxOrder.Locked)
+	}
+}
+
 func TestFundEdges(t *testing.T) {
 	wallet, node, shutdown := tNewWallet()
 	defer shutdown()
 	swapVal := uint64(1e8)
 	lots := swapVal / tDCR.LotSize
+	var estFeeRate uint64 = optimalFeeRate + 1 // +1 added in feeRate
+
+	checkMax := func(lots, swapVal, maxFees, estFees, locked uint64) {
+		checkMaxOrder(t, wallet, lots, swapVal, maxFees, estFees, locked)
+	}
 
 	// Swap fees
 	//
@@ -947,7 +975,9 @@ func TestFundEdges(t *testing.T) {
 	//  total_bytes  = base_tx_bytes + backing_bytes = 2344 + 166 = 2510
 	// total_fees: base_fees + backing_fees = 56256 + 3984 = 60240 atoms
 	//          OR total_bytes * fee_rate = 2510 * 24 = 60240
-	fees := uint64(2510) * tDCR.MaxFeeRate
+	const swapSize = 251
+	const totalBytes = 2510
+	fees := uint64(totalBytes) * tDCR.MaxFeeRate
 	p2pkhUnspent := walletjson.ListUnspentResult{
 		TxID:          tTxID,
 		Address:       tPKHAddr.String(),
@@ -963,6 +993,11 @@ func TestFundEdges(t *testing.T) {
 		MaxSwapCount: lots,
 		DEXConfig:    tDCR,
 	}
+
+	var feeReduction uint64 = swapSize * tDCR.MaxFeeRate
+	estFeeReduction := swapSize * estFeeRate
+	checkMax(lots-1, swapVal-tDCR.LotSize, fees-feeReduction, totalBytes*estFeeRate-estFeeReduction, swapVal+fees-1)
+
 	_, _, err := wallet.FundOrder(ord)
 	if err == nil {
 		t.Fatalf("no error when not enough funds in single p2pkh utxo")
@@ -970,6 +1005,9 @@ func TestFundEdges(t *testing.T) {
 	// Now add the needed atoms and try again.
 	p2pkhUnspent.Amount = float64(swapVal+fees) / 1e8
 	node.unspent = []walletjson.ListUnspentResult{p2pkhUnspent}
+
+	checkMax(lots, swapVal, fees, totalBytes*estFeeRate, swapVal+fees)
+
 	_, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("should be enough to fund with a single p2pkh utxo: %v", err)
@@ -982,7 +1020,8 @@ func TestFundEdges(t *testing.T) {
 	node.signFunc = func(msgTx *wire.MsgTx) (*wire.MsgTx, bool, error) {
 		return signFunc(msgTx, dexdcr.P2PKHSigScriptSize)
 	}
-	fees = uint64(2510+splitTxBaggage) * tDCR.MaxFeeRate
+
+	fees = uint64(totalBytes+splitTxBaggage) * tDCR.MaxFeeRate
 	v := swapVal + fees - 1
 	node.unspent[0].Amount = float64(v) / 1e8
 	coins, _, err := wallet.FundOrder(ord)
@@ -995,6 +1034,9 @@ func TestFundEdges(t *testing.T) {
 	// Now get the split.
 	v = swapVal + fees
 	node.unspent[0].Amount = float64(v) / 1e8
+
+	checkMax(lots, swapVal, fees, (totalBytes+splitTxBaggage)*estFeeRate, v)
+
 	coins, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding split tx: %v", err)

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -329,7 +329,9 @@ func runTest(t *testing.T, splitTx bool) {
 		makeRedemption(contractValue*2, receipts[1], secretKey2),
 	}
 
-	_, _, _, err = rig.alpha().Redeem(redemptions)
+	_, _, _, err = rig.alpha().Redeem(&asset.RedeemForm{
+		Redemptions: redemptions,
+	})
 	if err != nil {
 		t.Fatalf("redemption error: %v", err)
 	}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -80,6 +80,15 @@ type Wallet interface {
 	// empty dex.Bytes should be appended to the redeem scripts collection for
 	// coins with no redeem script.
 	FundOrder(*Order) (coins Coins, redeemScripts []dex.Bytes, err error)
+	// MaxOrder generates information about the maximum order size and
+	// associated fees that the wallet can support for the specified DEX. The
+	// fees are an estimate based on current network conditions, and will be <=
+	// the fees associated with the Asset.MaxFeeRate. For quote assets, lotSize
+	// will be an estimate based on current market conditions.
+	MaxOrder(lotSize uint64, nfo *dex.Asset) (*OrderEstimate, error)
+	// RedemptionFees is an estimate of the redemption fees for a 1-swap
+	// redemption.
+	RedemptionFees() (uint64, error)
 	// ReturnCoins unlocks coins. This would be necessary in the case of a
 	// canceled order.
 	ReturnCoins(Coins) error
@@ -276,4 +285,22 @@ type Order struct {
 	// standing order, likely a market order or a limit order with immediate
 	// time-in-force.
 	Immediate bool
+}
+
+// OrderEstimate is an estimate of the fees and locked amounts associated with
+// an order.
+type OrderEstimate struct {
+	// Lots is the number of lots in the order.
+	Lots uint64
+	// Value is the total value of the order.
+	Value uint64
+	// MaxFees is the maximum possible fees that can be assessed for the order's
+	// swaps.
+	MaxFees uint64
+	// EstimatedFees is an estimation of the fees that might be assessed for the
+	// order's swaps.
+	EstimatedFees uint64
+	// Locked is the amount that will be locked if this order is
+	// subsequently placed.
+	Locked uint64
 }

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -585,6 +585,11 @@ func (w *TXCWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, error
 	return w.fundingCoins, w.fundRedeemScripts, w.fundingCoinErr
 }
 
+func (w *TXCWallet) MaxOrder(lotSize uint64, nfo *dex.Asset) (*asset.OrderEstimate, error) {
+	return nil, nil
+}
+func (w *TXCWallet) RedemptionFees() (uint64, error) { return 0, nil }
+
 func (w *TXCWallet) ReturnCoins(coins asset.Coins) error {
 	w.returnedCoins = coins
 	coinInSlice := func(coin asset.Coin) bool {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1559,7 +1559,9 @@ func (c *Core) redeemMatchGroup(t *trackedTrade, matches []*matchTracker, errs *
 
 	// Send the transaction.
 	redeemWallet, redeemAsset := t.wallets.toWallet, t.wallets.toAsset // this is our redeem
-	coinIDs, outCoin, fees, err := redeemWallet.Redeem(redemptions)
+	coinIDs, outCoin, fees, err := redeemWallet.Redeem(&asset.RedeemForm{
+		Redemptions: redemptions,
+	})
 	// If an error was encountered, fail all of the matches. A failed match will
 	// not run again on during ticks.
 	if err != nil {

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -612,16 +612,15 @@ func (c assetMap) merge(other assetMap) {
 	}
 }
 
-// OrderEstimate is an estimate of the fees and locked amounts associated with
-// an order. This type differs from asset.OrderEstimate in the addition of the
-// RedemptionFees field, which comes from the other asset's wallet.
+// MaxOrderEstimate is an estimate of the fees and locked amounts associated
+// with an order.
+type MaxOrderEstimate struct {
+	Swap   *asset.SwapEstimate   `json:"swap"`
+	Redeem *asset.RedeemEstimate `json:"redeem"`
+}
+
+// OrderEstimate is a Core.PreOrder estimate.
 type OrderEstimate struct {
-	Lots          uint64 `json:"lots"`
-	Value         uint64 `json:"value"`
-	MaxFees       uint64 `json:"maxFees"`
-	EstimatedFees uint64 `json:"estimatedFees"`
-	Locked        uint64 `json:"locked"`
-	// RedemptionFees are the fees associated with redeeming the order one
-	// lot at a time, using the wallet's redemption fee rate.
-	RedemptionFees uint64 `json:"redemptionFees"`
+	Swap   *asset.PreSwap   `json:"swap"`
+	Redeem *asset.PreRedeem `json:"redeem"`
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -611,3 +611,17 @@ func (c assetMap) merge(other assetMap) {
 		c[assetID] = struct{}{}
 	}
 }
+
+// OrderEstimate is an estimate of the fees and locked amounts associated with
+// an order. This type differs from asset.OrderEstimate in the addition of the
+// RedemptionFees field, which comes from the other asset's wallet.
+type OrderEstimate struct {
+	Lots          uint64 `json:"lots"`
+	Value         uint64 `json:"value"`
+	MaxFees       uint64 `json:"maxFees"`
+	EstimatedFees uint64 `json:"estimatedFees"`
+	Locked        uint64 `json:"locked"`
+	// RedemptionFees are the fees associated with redeeming the order one
+	// lot at a time, using the wallet's redemption fee rate.
+	RedemptionFees uint64 `json:"redemptionFees"`
+}

--- a/client/orderbook/orderbook.go
+++ b/client/orderbook/orderbook.go
@@ -552,3 +552,20 @@ func (ob *OrderBook) MidGap() (uint64, error) {
 	}
 	return (s[0].Rate + b[0].Rate) / 2, nil
 }
+
+// BestFill is the best (rate, quantity) fill for an order of the type and
+// quantity specified. BestFill should be used when the exact quantity of base asset
+// is known, i.e. limit orders and market sell orders. For market buy orders,
+// use BestFillMarketBuy.
+func (ob *OrderBook) BestFill(sell bool, qty uint64) ([]*Fill, bool) {
+	if sell {
+		return ob.buys.BestFill(qty)
+	}
+	return ob.sells.BestFill(qty)
+}
+
+// BestFillMarketBuy is the best (rate, quantity) fill for a market buy order.
+// The qty given will be in units of quote asset.
+func (ob *OrderBook) BestFillMarketBuy(qty, lotSize uint64) ([]*Fill, bool) {
+	return ob.sells.bestFill(qty, true, lotSize)
+}

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -469,6 +469,57 @@ func (s *WebServer) apiWithdraw(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp, s.indent)
 }
 
+// apiMaxBuy handles the 'maxbuy' API request.
+func (s *WebServer) apiMaxBuy(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		Host  string `json:"host"`
+		Base  uint32 `json:"base"`
+		Quote uint32 `json:"quote"`
+		Rate  uint64 `json:"rate"`
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+	maxBuy, err := s.core.MaxBuy(form.Host, form.Base, form.Quote, form.Rate)
+	if err != nil {
+		s.writeAPIError(w, "max order estimation error: %v", err)
+		return
+	}
+	resp := struct {
+		OK     bool                `json:"ok"`
+		MaxBuy *core.OrderEstimate `json:"maxBuy"`
+	}{
+		OK:     true,
+		MaxBuy: maxBuy,
+	}
+	writeJSON(w, resp, s.indent)
+}
+
+// apiMaxSell handles the 'maxsell' API request.
+func (s *WebServer) apiMaxSell(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		Host  string `json:"host"`
+		Base  uint32 `json:"base"`
+		Quote uint32 `json:"quote"`
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+	maxSell, err := s.core.MaxSell(form.Host, form.Base, form.Quote)
+	if err != nil {
+		s.writeAPIError(w, "max order estimation error: %v", err)
+		return
+	}
+	resp := struct {
+		OK      bool                `json:"ok"`
+		MaxSell *core.OrderEstimate `json:"maxSell"`
+	}{
+		OK:      true,
+		MaxSell: maxSell,
+	}
+	writeJSON(w, resp, s.indent)
+}
+
 // apiActuallyLogin logs the user in.
 func (s *WebServer) actuallyLogin(w http.ResponseWriter, r *http.Request, login *loginForm) {
 	loginResult, err := s.core.Login(login.Pass)

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -486,8 +486,8 @@ func (s *WebServer) apiMaxBuy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := struct {
-		OK     bool                `json:"ok"`
-		MaxBuy *core.OrderEstimate `json:"maxBuy"`
+		OK     bool                   `json:"ok"`
+		MaxBuy *core.MaxOrderEstimate `json:"maxBuy"`
 	}{
 		OK:     true,
 		MaxBuy: maxBuy,
@@ -511,8 +511,8 @@ func (s *WebServer) apiMaxSell(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := struct {
-		OK      bool                `json:"ok"`
-		MaxSell *core.OrderEstimate `json:"maxSell"`
+		OK      bool                   `json:"ok"`
+		MaxSell *core.MaxOrderEstimate `json:"maxSell"`
 	}{
 		OK:      true,
 		MaxSell: maxSell,

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -89,6 +89,8 @@ type clientCore interface {
 	Logout() error
 	Orders(*core.OrderFilter) ([]*core.Order, error)
 	Order(oid dex.Bytes) (*core.Order, error)
+	MaxBuy(host string, base, quote uint32, rate uint64) (*core.OrderEstimate, error)
+	MaxSell(host string, base, quote uint32) (*core.OrderEstimate, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -264,6 +266,8 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 			apiAuth.Post("/orders", s.apiOrders)
 			apiAuth.Post("/order", s.apiOrder)
 			apiAuth.Post("/withdraw", s.apiWithdraw)
+			apiAuth.Post("/maxbuy", s.apiMaxBuy)
+			apiAuth.Post("/maxsell", s.apiMaxSell)
 		})
 	})
 

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -89,8 +89,8 @@ type clientCore interface {
 	Logout() error
 	Orders(*core.OrderFilter) ([]*core.Order, error)
 	Order(oid dex.Bytes) (*core.Order, error)
-	MaxBuy(host string, base, quote uint32, rate uint64) (*core.OrderEstimate, error)
-	MaxSell(host string, base, quote uint32) (*core.OrderEstimate, error)
+	MaxBuy(host string, base, quote uint32, rate uint64) (*core.MaxOrderEstimate, error)
+	MaxSell(host string, base, quote uint32) (*core.MaxOrderEstimate, error)
 }
 
 var _ clientCore = (*core.Core)(nil)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -137,10 +137,13 @@ func (c *TCore) Logout() error { return c.logoutErr }
 
 func (c *TCore) Orders(*core.OrderFilter) ([]*core.Order, error) { return nil, nil }
 func (c *TCore) Order(oid dex.Bytes) (*core.Order, error)        { return nil, nil }
-func (c *TCore) MaxBuy(host string, base, quote uint32, rate uint64) (*core.OrderEstimate, error) {
+func (c *TCore) MaxBuy(host string, base, quote uint32, rate uint64) (*core.MaxOrderEstimate, error) {
 	return nil, nil
 }
-func (c *TCore) MaxSell(host string, base, quote uint32) (*core.OrderEstimate, error) {
+func (c *TCore) MaxSell(host string, base, quote uint32) (*core.MaxOrderEstimate, error) {
+	return nil, nil
+}
+func (c *TCore) PreOrder(*core.TradeForm) (*core.OrderEstimate, error) {
 	return nil, nil
 }
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -137,6 +137,12 @@ func (c *TCore) Logout() error { return c.logoutErr }
 
 func (c *TCore) Orders(*core.OrderFilter) ([]*core.Order, error) { return nil, nil }
 func (c *TCore) Order(oid dex.Bytes) (*core.Order, error)        { return nil, nil }
+func (c *TCore) MaxBuy(host string, base, quote uint32, rate uint64) (*core.OrderEstimate, error) {
+	return nil, nil
+}
+func (c *TCore) MaxSell(host string, base, quote uint32) (*core.OrderEstimate, error) {
+	return nil, nil
+}
 
 type TWriter struct {
 	b []byte

--- a/dex/calc/fees.go
+++ b/dex/calc/fees.go
@@ -12,14 +12,20 @@ import (
 // fulfill an order. inputsSize is the size of the serialized inputs associated
 // with a set of UTXOs to be spent in the *first* swap txn. maxSwaps is the
 // number of lots in the order. For the quote asset, maxSwaps is not swapVal /
-// coin.LotSize, so it must be a separate parameter. The chained swap txns will
+// nfo.LotSize, so it must be a separate parameter. The chained swap txns will
 // be the standard size as they will spend a previous swap's change output.
-func RequiredOrderFunds(swapVal, inputsSize, maxSwaps uint64, coin *dex.Asset) uint64 {
-	baseBytes := maxSwaps * coin.SwapSize
+func RequiredOrderFunds(swapVal, inputsSize, maxSwaps uint64, nfo *dex.Asset) uint64 {
+	return RequiredOrderFundsAlt(swapVal, inputsSize, maxSwaps, nfo.SwapSizeBase, nfo.SwapSize, nfo.MaxFeeRate)
+}
+
+// RequiredOrderFundsAlt is the same as RequiredOrderFunds, but built-in type
+// parameters.
+func RequiredOrderFundsAlt(swapVal, inputsSize, maxSwaps uint64, swapSizeBase, swapSize, feeRate uint64) uint64 {
+	baseBytes := maxSwaps * swapSize
 	// SwapSize already includes one input, replace the size of the first swap
 	// in the chain with the given size of the actual inputs + SwapSizeBase.
-	firstSwapSize := inputsSize + coin.SwapSizeBase
-	totalBytes := baseBytes + firstSwapSize - coin.SwapSize // in this order because we are using unsigned integers
-	fee := totalBytes * coin.MaxFeeRate
+	firstSwapSize := inputsSize + swapSizeBase
+	totalBytes := baseBytes + firstSwapSize - swapSize // in this order because we are using unsigned integers
+	fee := totalBytes * feeRate
 	return swapVal + fee
 }


### PR DESCRIPTION
Backport just the Go components (no frontend) of https://github.com/decred/dcrdex/pull/842 and https://github.com/decred/dcrdex/pull/958

**Not slated for a patch** at present, just inclusion in the release-0.1 branch for Go consumers to have the following `Core` methods:

- `MaxBuy(host string, base, quote uint32, rate uint64) (*MaxOrderEstimate, error)`
- `MaxSell(host string, base, quote uint32) (*MaxOrderEstimate, error)`
- `PreOrder(form *TradeForm) (*OrderEstimate, error)`

where `TradeForm` is the same type used with the `Trade` method:

```go
type TradeForm struct {
	Host    string `json:"host"`
	IsLimit bool   `json:"isLimit"`
	Sell    bool   `json:"sell"`
	Base    uint32 `json:"base"`
	Quote   uint32 `json:"quote"`
	Qty     uint64 `json:"qty"`
	Rate    uint64 `json:"rate"`
	TifNow  bool   `json:"tifnow"`
}
```

With the new `OrderEstimate` type returned from `PreOrder`:

```go
// OrderEstimate is a Core.PreOrder estimate.
type OrderEstimate struct {
	Swap   *asset.PreSwap   `json:"swap"`
	Redeem *asset.PreRedeem `json:"redeem"`
}
```

and 

```go
type PreSwap struct {
	Estimate *SwapEstimate `json:"estimate"`
}
```

where `SwapEstimate` is:

```go
// SwapEstimate is an estimate of the fees and locked amounts associated with
// an order.
type SwapEstimate struct {
	// Lots is the number of lots in the order.
	Lots uint64 `json:"lots"`
	// Value is the total value of the order.
	Value uint64 `json:"value"`
	// MaxFees is the maximum possible fees that can be assessed for the order's
	// swaps.
	MaxFees uint64 `json:"maxFees"`
	// RealisticWorstCase is an estimation of the fees that might be assessed in
	// a worst-case scenario of 1 tx per 1 lot match, but at the prevailing fee
	// rate estimate.
	RealisticWorstCase uint64 `json:"realisticWorstCase"`
	// RealisticBestCase is an estimation of the fees that might be assessed in
	// a best-case scenario of 1 tx and 1 output for the entire order.
	RealisticBestCase uint64 `json:"realisticBestCase"`
	// Locked is the amount that will be locked if this order is
	// subsequently placed.
	Locked uint64 `json:"locked"`
}
```

plus

```go
type PreRedeem struct {
	Estimate *RedeemEstimate `json:"estimate"`
}
```

where `RedeemEstimate` is:

```go
// RedeemEstimate is an estimate of the range of fees that might realistically
// be assessed to the redemption transaction.
type RedeemEstimate struct {
	// RealisticBestCase is the best-case scenario fees of a single transaction
	// with a match covering the entire order, at the prevailing fee rate.
	RealisticBestCase uint64 `json:"realisticBestCase"`
	// RealisticWorstCase is the worst-case scenario fees of all 1-lot matches,
	// each with their own call to Redeem.
	RealisticWorstCase uint64 `json:"realisticWorstCase"`
}
```