### PR TITLE
Show exchange disconnected if connection fails

### DIFF
--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -42,6 +42,7 @@
     {{- /* CHART */ -}}
 
     <div id="marketChart" class="w-100">
+      <div id="chartErrMsg" class="fs15 pt-3 text-center d-hide errcolor"></div>
       <div id="marketLoader" class="fill-abs flex-center">
         <div class="ico-spinner spinner"></div>
 
@@ -233,7 +234,7 @@
                 </form>
 
                 {{- /* BALANCES */ -}}
-                <div class="market-bal pt-2 pb-1 my-3 position-relative">
+                <div id="marketBalance" class="market-bal pt-2 pb-1 my-3 position-relative">
                   <span class="market-bal-lbl">Balances</span>
                   <table class="balance-table" id="balanceTable">
                     <thead>

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -496,6 +496,8 @@ export default class Application {
         break
       case 'walletstate':
       case 'walletconfig': {
+        // assets can be null if failed to connect to dex server.
+        if (!this.assets) return
         const wallet = note.wallet
         this.assets[wallet.assetID].wallet = wallet
         this.walletMap[wallet.assetID] = wallet
@@ -508,6 +510,8 @@ export default class Application {
         if (ord) updateMatch(ord, note.match)
         break
       }
+      case 'conn':
+        this.reconnected()
     }
 
     // Inform the page.

--- a/client/webserver/site/src/js/charts.js
+++ b/client/webserver/site/src/js/charts.js
@@ -175,6 +175,9 @@ export class DepthChart {
   // 6. Epoch line legend.
   // 7. Hover legend.
   draw () {
+    // if connection fails it is not possible to get book.
+    if (!this.book) return
+
     this.clear()
     // if (!this.book || this.book.empty()) return
 


### PR DESCRIPTION
closes #943

Right now I am appending the exchange host on `Core.conns[host]` in case of connection failure, instead of only appending it on succcess. This way it is possible to give a feedback in the client that the exchange is not connected.

~~Right now it stills a work in progress, because there is a loader which I am not being able to remove.~~

This is how it looks if a dex server connection fails:

![image](https://user-images.githubusercontent.com/15069783/110110103-1ddfd080-7d8d-11eb-8c39-145e3a7ce1e3.png)
