### PR TITLE
Fix sorted column width jump on sort columns switch.

### DIFF
--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -435,7 +435,8 @@ table.balance-table button:hover {
     }
 
     .ico-arrowdown {
-      display: none;
+      display: inline-block;
+      visibility: hidden;
       vertical-align: middle;
       font-size: 10px;
       margin-left: 5px;
@@ -443,13 +444,13 @@ table.balance-table button:hover {
 
     &.sorted-dsc {
       .ico-arrowdown {
-        display: inline-block;
+        visibility: visible;
       }
     }
 
     &.sorted-asc {
       .ico-arrowdown {
-        display: inline-block;
+        visibility: visible;
         transform: rotate(180deg);
       }
     }


### PR DESCRIPTION
This is a small follow up and one last bit regarding #955 - I've discussed it with @buck54321 and haven't documented the it on the PR.

Before this switching to sort by a different column caused column width change, see video below:
https://user-images.githubusercontent.com/10324528/109538967-61a2b380-7ac9-11eb-9d05-f26752975ecc.mov

This fixes that jump by using the `visibility` css property instead of `display` which keeps the elements in the DOM tree while they are hidden.

