### PR TITLE
webserver: add isinitialized web api endpoint

### DIFF
--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -275,6 +275,22 @@ func (s *WebServer) apiInit(w http.ResponseWriter, r *http.Request) {
 	s.actuallyLogin(w, r, login)
 }
 
+// apiIsInitialized is the handler for the '/isinitialized' request.
+func (s *WebServer) apiIsInitialized(w http.ResponseWriter, r *http.Request) {
+	inited, err := s.core.IsInitialized()
+	if err != nil {
+		s.writeAPIError(w, "isinitialized error: %v", err)
+		return
+	}
+	writeJSON(w, &struct {
+		OK          bool `json:"ok"`
+		Initialized bool `json:"initialized"`
+	}{
+		OK:          true,
+		Initialized: inited,
+	}, s.indent)
+}
+
 // apiLogin handles the 'login' API request.
 func (s *WebServer) apiLogin(w http.ResponseWriter, r *http.Request) {
 	login := new(loginForm)

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -388,6 +388,7 @@ func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) {
 	return nil, nil
 }
 func (c *TCore) Login([]byte) (*core.LoginResult, error) { return &core.LoginResult{}, nil }
+func (c *TCore) IsInitialized() (bool, error)            { return true, nil }
 func (c *TCore) Logout() error                           { return nil }
 
 var orderAssets = []string{"dcr", "btc", "ltc", "doge", "mona", "vtc"}

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -92,6 +92,7 @@ type clientCore interface {
 	MaxSell(host string, base, quote uint32) (*core.MaxOrderEstimate, error)
 	AccountExport(pw []byte, host string) (*core.Account, error)
 	AccountImport(pw []byte, account core.Account) error
+	IsInitialized() (bool, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -235,6 +236,7 @@ func New(core clientCore, addr string, logger dex.Logger, reloadHTML bool) (*Web
 	mux.Route("/api", func(r chi.Router) {
 		r.Use(middleware.AllowContentType("application/json"))
 		r.Post("/init", s.apiInit)
+		r.Get("/isinitialized", s.apiIsInitialized)
 
 		r.Group(func(apiInit chi.Router) {
 			apiInit.Use(s.rejectUninited)


### PR DESCRIPTION
Since the `/user` route is behind the auth cookie now, web API users have no way to know whether the client is already initialized. 

We already had the exported `Core` method, we just needed to expose it. 