### PR TITLE
multi: fee rate estimate feed

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -90,7 +90,7 @@ type Wallet interface {
 	// fees are an estimate based on current network conditions, and will be <=
 	// the fees associated with the Asset.MaxFeeRate. For quote assets, lotSize
 	// will be an estimate based on current market conditions.
-	MaxOrder(lotSize uint64, nfo *dex.Asset) (*SwapEstimate, error)
+	MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*SwapEstimate, error)
 	// PreSwap gets a pre-swap estimate for the specified order size.
 	PreSwap(*PreSwapForm) (*PreSwap, error)
 	// PreRedeem gets a pre-redeem estimate for the specified order size.
@@ -273,6 +273,13 @@ type Redemption struct {
 // expanded in in-progress work to accommodate order-time options.
 type RedeemForm struct {
 	Redemptions []*Redemption
+	// FeeSuggestion is a suggested fee from the server. For redemptions, the
+	// suggestion is provided as a convenience for wallets without full
+	// chain backing which cannot get an estimate otherwise. Since this is the
+	// redemption, there is no obligation on the client to use the fee
+	// suggestion in any way, but obviously fees that are too low may result in
+	// the redemption getting stuck in mempool.
+	FeeSuggestion uint64
 }
 
 // Order is order details needed for FundOrder.
@@ -297,6 +304,10 @@ type Order struct {
 	// standing order, likely a market order or a limit order with immediate
 	// time-in-force.
 	Immediate bool
+	// FeeSuggestion is a suggested fee from the server. If a split transaction
+	// is used, the fee rate used should be at least the suggested fee, else
+	// zero-conf coins might be rejected.
+	FeeSuggestion uint64
 }
 
 // SwapEstimate is an estimate of the fees and locked amounts associated with
@@ -346,6 +357,10 @@ type PreSwapForm struct {
 	// standing order, likely a market order or a limit order with immediate
 	// time-in-force.
 	Immediate bool
+	// FeeSuggestion is a suggested fee from the server. If a split transaction
+	// is used, the fee rate used should be at least the suggested fee, else
+	// zero-conf coins might be rejected.
+	FeeSuggestion uint64
 }
 
 // SwapOption is an OrderEstimate and it's associated ConfigOption.
@@ -370,6 +385,8 @@ type PreRedeemForm struct {
 	LotSize uint64
 	// Lots is the number of lots in the order.
 	Lots uint64
+	// FeeSuggestion is a suggested fee from the server.
+	FeeSuggestion uint64
 }
 
 // PreRedeem is an estimate of the fees for redemption. The struct will be

--- a/client/orderbook/bookside.go
+++ b/client/orderbook/bookside.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"decred.org/dcrdex/dex/calc"
-	"decred.org/dcrdex/dex/order"
 )
 
 // orderPreference represents ordering preference for a sort.
@@ -110,21 +109,20 @@ func (d *bookSide) Remove(order *Order) error {
 	return fmt.Errorf("order %s not found", order.OrderID)
 }
 
-// UpdateRemaining updates the remaining quantity for an order. If the order is
-// found it will be returned, else nil.
-func (d *bookSide) UpdateRemaining(oid order.OrderID, remaining uint64) *Order {
+// ReplaceOrder replaces the order with the matching ID with a new version.
+func (d *bookSide) ReplaceOrder(ord *Order) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
+	oid := ord.OrderID
 	for _, bin := range d.bins {
-		for _, ord := range bin {
-			if ord.OrderID == oid {
-				ord.Quantity = remaining
-				return ord
+		for i := range bin {
+			if bin[i].OrderID == oid {
+				bin[i] = ord
+				return
 			}
 		}
 	}
-	return nil
 }
 
 // orders is all orders for the side, sorted.

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -179,6 +179,9 @@ const (
 	// SpotsRoute is the HTTP or WebSocket request to get the spot price and
 	// volume for the DEX's markets.
 	SpotsRoute = "spots"
+	// FeeRateRoute is the client-originating request asking for the most
+	// recently recorded transaction fee estimate for an asset.
+	FeeRateRoute = "fee_rate"
 	// CandlesRoute is the HTTP request to get the set of candlesticks
 	// representing market activity history.
 	CandlesRoute = "candles"
@@ -816,7 +819,9 @@ type OrderBook struct {
 	// DRAFT NOTE: We might want to use a different structure for bulk updates.
 	// Sending a struct of arrays rather than an array of structs could
 	// potentially cut the encoding effort and encoded size substantially.
-	Orders []*BookOrderNote `json:"orders"`
+	Orders       []*BookOrderNote `json:"orders"`
+	BaseFeeRate  uint64           `json:"baseFeeRate"`
+	QuoteFeeRate uint64           `json:"quoteFeeRate"`
 }
 
 // MatchProofNote is the match_proof notification payload.
@@ -1116,9 +1121,11 @@ func (wc *WireCandles) Candles() []*Candle {
 // EpochReportNote is a report about an epoch sent after all of the epoch's
 // book updates.
 type EpochReportNote struct {
-	Seq      uint64 `json:"seq"`
-	MarketID string `json:"marketid"`
-	Epoch    uint64 `json:"epoch"`
+	Seq          uint64 `json:"seq"`
+	MarketID     string `json:"marketid"`
+	Epoch        uint64 `json:"epoch"`
+	BaseFeeRate  uint64 `json:"baseFeeRate"`
+	QuoteFeeRate uint64 `json:"quoteFeeRate"`
 	Candle
 }
 

--- a/dex/order/match.go
+++ b/dex/order/match.go
@@ -194,13 +194,15 @@ func (m *UserMatch) String() string {
 
 // A constructor for a Match with Status = NewlyMatched. This is the preferred
 // method of making a Match, since it pre-calculates and caches the match ID.
-func newMatch(taker Order, maker *LimitOrder, qty, rate uint64, epochID EpochID) *Match {
+func newMatch(taker Order, maker *LimitOrder, qty, rate, feeRateBase, feeRateQuote uint64, epochID EpochID) *Match {
 	m := &Match{
-		Taker:    taker,
-		Maker:    maker,
-		Quantity: qty,
-		Rate:     rate,
-		Epoch:    epochID,
+		Taker:        taker,
+		Maker:        maker,
+		Quantity:     qty,
+		Rate:         rate,
+		Epoch:        epochID,
+		FeeRateBase:  feeRateBase,
+		FeeRateQuote: feeRateQuote,
 	}
 	// Pre-cache the ID.
 	m.ID()
@@ -230,19 +232,21 @@ func (match *Match) ID() MatchID {
 // corresponding Maker order, indicating a partial fill of the Maker. The sum
 // of the amounts, Total, is provided for convenience.
 type MatchSet struct {
-	Epoch   EpochID
-	Taker   Order
-	Makers  []*LimitOrder
-	Amounts []uint64
-	Rates   []uint64
-	Total   uint64
+	Epoch        EpochID
+	Taker        Order
+	Makers       []*LimitOrder
+	Amounts      []uint64
+	Rates        []uint64
+	Total        uint64
+	FeeRateBase  uint64
+	FeeRateQuote uint64
 }
 
 // Matches converts the MatchSet to a []*Match.
 func (set *MatchSet) Matches() []*Match {
 	matches := make([]*Match, 0, len(set.Makers))
 	for i, maker := range set.Makers {
-		match := newMatch(set.Taker, maker, set.Amounts[i], set.Rates[i], set.Epoch)
+		match := newMatch(set.Taker, maker, set.Amounts[i], set.Rates[i], set.FeeRateBase, set.FeeRateQuote, set.Epoch)
 		matches = append(matches, match)
 	}
 	return matches

--- a/server/dex/feemgr.go
+++ b/server/dex/feemgr.go
@@ -1,0 +1,85 @@
+package dex
+
+import (
+	"strconv"
+	"sync/atomic"
+
+	"decred.org/dcrdex/server/asset"
+	"decred.org/dcrdex/server/market"
+)
+
+// FeeManager manages fee fetchers and a fee cache.
+type FeeManager struct {
+	assets map[uint32]*asset.BackedAsset
+	cache  map[uint32]*uint64
+}
+
+var _ market.FeeSource = (*FeeManager)(nil)
+
+// NewFeeManager is the constructor for a FeeManager.
+func NewFeeManager() *FeeManager {
+	return &FeeManager{
+		assets: make(map[uint32]*asset.BackedAsset),
+		cache:  make(map[uint32]*uint64),
+	}
+}
+
+// AddFetcher adds a fee fetcher (a *BackedAsset) and primes the cache.
+func (m *FeeManager) AddFetcher(asset *asset.BackedAsset) {
+	rate, err := asset.Backend.FeeRate()
+	if err != nil {
+		log.Warnf("Error priming fee cache for %s: %v", asset.Symbol, err)
+	}
+	m.cache[asset.ID] = &rate
+	m.assets[asset.ID] = asset
+}
+
+// FeeFetcher creates and returns an asset-specific fetcher that satisfies
+// market.FeeFetcher, implemented by *feeFetcher.
+func (m *FeeManager) FeeFetcher(assetID uint32) market.FeeFetcher {
+	asset := m.assets[assetID]
+	if asset == nil {
+		panic("no fetcher for " + strconv.Itoa(int(assetID)))
+	}
+	return newFeeFetcher(asset, m.cache[assetID])
+}
+
+// LastRate is the last rate cached for the specified asset.
+func (m *FeeManager) LastRate(assetID uint32) uint64 {
+	r := m.cache[assetID]
+	if r == nil {
+		return 0
+	}
+	return atomic.LoadUint64(r)
+}
+
+// feeFetcher implements market.FeeFetcher and updates the last fee rate cache.
+type feeFetcher struct {
+	*asset.BackedAsset
+	lastRate *uint64
+}
+
+var _ market.FeeFetcher = (*feeFetcher)(nil)
+
+// newFeeFetcher is the constructor for a *feeFetcher.
+func newFeeFetcher(asset *asset.BackedAsset, lastRate *uint64) *feeFetcher {
+	return &feeFetcher{
+		BackedAsset: asset,
+		lastRate:    lastRate,
+	}
+}
+
+// FeeRate fetches a new fee rate and updates the cache.
+func (f *feeFetcher) FeeRate() uint64 {
+	r, err := f.Backend.FeeRate()
+	if err != nil {
+		log.Errorf("Error retrieving fee rate for %s: %v", f.Symbol, err)
+	}
+	atomic.StoreUint64(f.lastRate, r)
+	return r
+}
+
+// MaxFeeRate is a getter for the BackedAsset's dex.Asset.MaxFeeRate
+func (f *feeFetcher) MaxFeeRate() uint64 {
+	return f.Asset.MaxFeeRate
+}


### PR DESCRIPTION
Add the most recent fee rate estimate to 1) The `orderbook` response, 2) the `epoch_report` notification, and 3) a custom `fee_rate` endpoint. There are two major reason for this.

1. SPV clients will have no way to estimate fees. They can use the suggested fee rate with some basic sanity checks.
2. This finally closes a small vulnerability regarding fee rates on zero-conf funding coins. Previously, we handled this only client side by ensuring a reasonably high fee rate. But since the server's latest fee rate is available at the client now, we can more justifiably reject low-fee zero-conf coin-funded orders. Right now, the filter is set to >= 90% of the most recently procured rate estimate.

Order estimates should also be more accurate now.