### PR TITLE
multi: add blockcache to client/asset/dcr

### DIFF
--- a/client/asset/dcr/blockcache.go
+++ b/client/asset/dcr/blockcache.go
@@ -1,0 +1,130 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package dcr
+
+import (
+	"fmt"
+	"sync"
+
+	"decred.org/dcrdex/dex"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
+)
+
+// dcrBlock defines basic information about a block.
+type dcrBlock struct {
+	Hash         *chainhash.Hash
+	Height       int64
+	PreviousHash string
+}
+
+// blockCache caches block information to prevent repeated calls to
+// rpcclient.GetblockVerbose.
+type blockCache struct {
+	mtx       sync.RWMutex
+	blocks    map[chainhash.Hash]*dcrBlock
+	mainchain map[int64]*chainhash.Hash
+	bestBlock struct {
+		hash   *chainhash.Hash
+		height int64
+	}
+	log dex.Logger
+}
+
+func newBlockCache(log dex.Logger) *blockCache {
+	return &blockCache{
+		blocks:    make(map[chainhash.Hash]*dcrBlock),
+		mainchain: make(map[int64]*chainhash.Hash),
+		log:       log,
+	}
+}
+
+// add adds a block to the BlockCache. This method will translate the RPC result
+// to a *Block, returning the *Block. If the block is not orphaned, it will be
+// added to the mainchain.
+func (cache *blockCache) add(verboseBlk *chainjson.GetBlockVerboseResult) (*dcrBlock, error) {
+	cache.mtx.Lock()
+	defer cache.mtx.Unlock()
+
+	hash, err := chainhash.NewHashFromStr(verboseBlk.Hash)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding block hash %s: %w", verboseBlk.Hash, err)
+	}
+
+	blk := &dcrBlock{
+		Hash:         hash,
+		Height:       verboseBlk.Height,
+		PreviousHash: verboseBlk.PreviousHash,
+	}
+	cache.blocks[*hash] = blk
+
+	// Orphaned blocks will have -1 confirmations. Don't add them to mainchain.
+	if verboseBlk.Confirmations > -1 {
+		cache.mainchain[verboseBlk.Height] = hash
+		if verboseBlk.Height > cache.bestBlock.height {
+			cache.bestBlock.height = verboseBlk.Height
+			cache.bestBlock.hash = hash
+		}
+	}
+
+	return blk, nil
+}
+
+// tip returns the best known block hash and height for the blockCache.
+func (cache *blockCache) tip() (*chainhash.Hash, int64) {
+	cache.mtx.RLock()
+	defer cache.mtx.RUnlock()
+	return cache.bestBlock.hash, cache.bestBlock.height
+}
+
+// mainchainHash returns the hash for the mainchain block at the specified height.
+// This method does not attempt to fetch the required hash from the blockchain
+// if it is not cached.
+func (cache *blockCache) mainchainHash(blockHeight int64) (*chainhash.Hash, bool) {
+	cache.mtx.RLock()
+	defer cache.mtx.RUnlock()
+	hash, found := cache.mainchain[blockHeight]
+	return hash, found
+}
+
+// blockAt returns basic information about the block with the specified height.
+// If withTxs is true, the returned block object will contain all transactions
+// in the block, otherwise only the transaction IDs will be returned with the block.
+func (cache *blockCache) blockAt(height int64) (*dcrBlock, bool) {
+	blockHash, found := cache.mainchainHash(height)
+	if !found {
+		return nil, false
+	}
+	return cache.block(blockHash)
+}
+
+// block returns basic information about the block with the specified hash. This
+// method does not attempt to fetch the required hash from the blockchain if it
+// is not cached.
+func (cache *blockCache) block(hash *chainhash.Hash) (*dcrBlock, bool) {
+	cache.mtx.RLock()
+	defer cache.mtx.RUnlock()
+	block, found := cache.blocks[*hash]
+	return block, found
+}
+
+// purgeMainchainBlocks deletes all blocks at and above the specified height
+// from the mainchain but not the blocks map. This should be done if a reorg
+// occurs on the blockchain or it is no longer certain that the blocks in the
+// specified range still belong in the mainchain.
+// NOTE: purgeMainchainBlocks clears the best block, so should always be followed
+// with the addition of a new mainchain block which would become the best block.
+func (cache *blockCache) purgeMainchainBlocks(fromHeight int64) {
+	if fromHeight < 0 {
+		return
+	}
+
+	cache.mtx.Lock()
+	defer cache.mtx.Unlock()
+	for blockHeight := fromHeight; blockHeight <= cache.bestBlock.height; blockHeight++ {
+		delete(cache.mainchain, blockHeight)
+	}
+	cache.bestBlock.hash = nil
+	cache.bestBlock.height = 0
+}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1675,9 +1675,7 @@ func (dcr *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time,
 // calcPastMedianTime calculates the median time of the previous few blocks
 // prior to, and including, the best block.
 func (dcr *ExchangeWallet) calcPastMedianTime() (time.Time, error) {
-	dcr.tipMtx.RLock()
-	hash := dcr.currentTip.hash
-	dcr.tipMtx.RUnlock()
+	hash, _ := dcr.blockCache.Tip()
 
 	// Look at the last 11 blocks, which is consistent with dcrd.
 	timestamps := make([]int64, 0, 11)

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -162,11 +162,7 @@ func tNewWallet() (*ExchangeWallet, *tRPCClient, func(), error) {
 	wallet.node = client
 	wallet.ctx = walletCtx
 
-	// Initialize the best block.
-	wallet.tipMtx.Lock()
-	wallet.currentTip, _ = wallet.getBestBlock(walletCtx)
-	wallet.tipMtx.Unlock()
-
+	wallet.initBestBlock()
 	go wallet.monitorBlocks(walletCtx)
 
 	return wallet, client, shutdown, nil

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -2253,11 +2253,8 @@ func TestCalcPastMedianTime(t *testing.T) {
 		prefix += "00"
 	}
 
-	hash, err := chainhash.NewHashFromStr(fmt.Sprintf("%v00", prefix))
-	if err != nil {
-		t.Fatalf("error creating chain hash: %v", err)
-	}
-	wallet.currentTip.hash = hash
+	// Initialize best block cache at height 0.
+	wallet.blockCache.Add(&chainjson.GetBlockVerboseResult{Hash: fmt.Sprintf("%v00", prefix)})
 
 	blockHeaders := func(n int) map[string]*chainjson.GetBlockHeaderVerboseResult {
 		m := make(map[string]*chainjson.GetBlockHeaderVerboseResult)

--- a/dex/networks/dcr/blockcache.go
+++ b/dex/networks/dcr/blockcache.go
@@ -36,10 +36,12 @@ type BlockCache struct {
 }
 
 func NewBlockCache() *BlockCache {
-	return &BlockCache{
+	cache := &BlockCache{
 		blocks:    make(map[chainhash.Hash]*Block),
 		mainchain: make(map[int64]*chainhash.Hash),
 	}
+	cache.bestBlock.height = -1
+	return cache
 }
 
 // Add adds a block to the BlockCache. This method will translate the RPC result

--- a/dex/networks/dcr/blockcache.go
+++ b/dex/networks/dcr/blockcache.go
@@ -12,18 +12,19 @@ import (
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 )
 
-// dcrBlock defines basic information about a block.
-type dcrBlock struct {
+// Block defines basic information about a block.
+type Block struct {
 	Hash         *chainhash.Hash
 	Height       int64
 	PreviousHash string
+	Vote         bool // stakeholder vote result for the previous block
 }
 
-// blockCache caches block information to prevent repeated calls to
+// BlockCache caches block information to prevent repeated calls to
 // rpcclient.GetblockVerbose.
-type blockCache struct {
+type BlockCache struct {
 	mtx       sync.RWMutex
-	blocks    map[chainhash.Hash]*dcrBlock
+	blocks    map[chainhash.Hash]*Block
 	mainchain map[int64]*chainhash.Hash
 	bestBlock struct {
 		hash   *chainhash.Hash
@@ -32,38 +33,39 @@ type blockCache struct {
 	log dex.Logger
 }
 
-func newBlockCache(log dex.Logger) *blockCache {
-	return &blockCache{
-		blocks:    make(map[chainhash.Hash]*dcrBlock),
+func NewBlockCache(log dex.Logger) *BlockCache {
+	return &BlockCache{
+		blocks:    make(map[chainhash.Hash]*Block),
 		mainchain: make(map[int64]*chainhash.Hash),
 		log:       log,
 	}
 }
 
-// add adds a block to the BlockCache. This method will translate the RPC result
+// Add adds a block to the BlockCache. This method will translate the RPC result
 // to a *Block, returning the *Block. If the block is not orphaned, it will be
 // added to the mainchain.
-func (cache *blockCache) add(verboseBlk *chainjson.GetBlockVerboseResult) (*dcrBlock, error) {
+func (cache *BlockCache) Add(block *chainjson.GetBlockVerboseResult) (*Block, error) {
 	cache.mtx.Lock()
 	defer cache.mtx.Unlock()
 
-	hash, err := chainhash.NewHashFromStr(verboseBlk.Hash)
+	hash, err := chainhash.NewHashFromStr(block.Hash)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding block hash %s: %w", verboseBlk.Hash, err)
+		return nil, fmt.Errorf("error decoding block hash %s: %w", block.Hash, err)
 	}
 
-	blk := &dcrBlock{
+	blk := &Block{
 		Hash:         hash,
-		Height:       verboseBlk.Height,
-		PreviousHash: verboseBlk.PreviousHash,
+		Height:       block.Height,
+		PreviousHash: block.PreviousHash,
+		Vote:         block.VoteBits&1 != 0,
 	}
 	cache.blocks[*hash] = blk
 
 	// Orphaned blocks will have -1 confirmations. Don't add them to mainchain.
-	if verboseBlk.Confirmations > -1 {
-		cache.mainchain[verboseBlk.Height] = hash
-		if verboseBlk.Height > cache.bestBlock.height {
-			cache.bestBlock.height = verboseBlk.Height
+	if block.Confirmations > -1 {
+		cache.mainchain[block.Height] = hash
+		if block.Height > cache.bestBlock.height {
+			cache.bestBlock.height = block.Height
 			cache.bestBlock.hash = hash
 		}
 	}
@@ -71,51 +73,51 @@ func (cache *blockCache) add(verboseBlk *chainjson.GetBlockVerboseResult) (*dcrB
 	return blk, nil
 }
 
-// tip returns the best known block hash and height for the blockCache.
-func (cache *blockCache) tip() (*chainhash.Hash, int64) {
+// Tip returns the best known block hash and height for the blockCache.
+func (cache *BlockCache) Tip() (*chainhash.Hash, int64) {
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
 	return cache.bestBlock.hash, cache.bestBlock.height
 }
 
-// mainchainHash returns the hash for the mainchain block at the specified height.
+// MainchainHash returns the hash for the mainchain block at the specified height.
 // This method does not attempt to fetch the required hash from the blockchain
 // if it is not cached.
-func (cache *blockCache) mainchainHash(blockHeight int64) (*chainhash.Hash, bool) {
+func (cache *BlockCache) MainchainHash(blockHeight int64) (*chainhash.Hash, bool) {
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
 	hash, found := cache.mainchain[blockHeight]
 	return hash, found
 }
 
-// blockAt returns basic information about the block with the specified height.
+// BlockAt returns basic information about the block with the specified height.
 // If withTxs is true, the returned block object will contain all transactions
 // in the block, otherwise only the transaction IDs will be returned with the block.
-func (cache *blockCache) blockAt(height int64) (*dcrBlock, bool) {
-	blockHash, found := cache.mainchainHash(height)
+func (cache *BlockCache) BlockAt(height int64) (*Block, bool) {
+	blockHash, found := cache.MainchainHash(height)
 	if !found {
 		return nil, false
 	}
-	return cache.block(blockHash)
+	return cache.Block(blockHash)
 }
 
-// block returns basic information about the block with the specified hash. This
+// Block returns basic information about the block with the specified hash. This
 // method does not attempt to fetch the required hash from the blockchain if it
 // is not cached.
-func (cache *blockCache) block(hash *chainhash.Hash) (*dcrBlock, bool) {
+func (cache *BlockCache) Block(hash *chainhash.Hash) (*Block, bool) {
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
 	block, found := cache.blocks[*hash]
 	return block, found
 }
 
-// purgeMainchainBlocks deletes all blocks at and above the specified height
+// PurgeMainchainBlocks deletes all blocks at and above the specified height
 // from the mainchain but not the blocks map. This should be done if a reorg
 // occurs on the blockchain or it is no longer certain that the blocks in the
 // specified range still belong in the mainchain.
-// NOTE: purgeMainchainBlocks clears the best block, so should always be followed
+// NOTE: PurgeMainchainBlocks clears the best block, so should always be followed
 // with the addition of a new mainchain block which would become the best block.
-func (cache *blockCache) purgeMainchainBlocks(fromHeight int64) {
+func (cache *BlockCache) PurgeMainchainBlocks(fromHeight int64) {
 	if fromHeight < 0 {
 		return
 	}
@@ -125,6 +127,20 @@ func (cache *blockCache) purgeMainchainBlocks(fromHeight int64) {
 	for blockHeight := fromHeight; blockHeight <= cache.bestBlock.height; blockHeight++ {
 		delete(cache.mainchain, blockHeight)
 	}
+	cache.clearBestBlock()
+}
+
+// Reset resets the block cache.
+func (cache *BlockCache) Reset() {
+	cache.mtx.Lock()
+	defer cache.mtx.Unlock()
+	cache.blocks = make(map[chainhash.Hash]*Block)
+	cache.mainchain = make(map[int64]*chainhash.Hash)
+	cache.clearBestBlock()
+}
+
+// mtx must be locked for write.
+func (cache *BlockCache) clearBestBlock() {
 	cache.bestBlock.hash = nil
 	cache.bestBlock.height = 0
 }

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -113,7 +113,7 @@ type Backend struct {
 	blockChans map[chan *asset.BlockUpdate]struct{}
 	// The block cache stores just enough info about the blocks to prevent future
 	// calls to GetBlockVerbose.
-	blockCache *blockCache
+	blockCache *dexdcr.BlockCache
 	// A logger will be provided by the DEX. All logging should use the provided
 	// logger.
 	log dex.Logger
@@ -127,7 +127,7 @@ var _ asset.Backend = (*Backend)(nil)
 func unconnectedDCR(logger dex.Logger, cfg *config) *Backend {
 	return &Backend{
 		cfg:        cfg,
-		blockCache: newBlockCache(logger),
+		blockCache: dexdcr.NewBlockCache(logger),
 		log:        logger,
 		blockChans: make(map[chan *asset.BlockUpdate]struct{}),
 	}
@@ -520,9 +520,9 @@ func (dcr *Backend) transaction(txHash *chainhash.Hash, verboseTx *chainjson.TxR
 	var blockHash *chainhash.Hash
 	var lastLookup *chainhash.Hash
 	if verboseTx.BlockHash == "" {
-		tipHash := dcr.blockCache.tipHash()
-		if tipHash != zeroHash {
-			lastLookup = &tipHash
+		tipHash, _ := dcr.blockCache.Tip()
+		if tipHash != nil {
+			lastLookup = tipHash
 		}
 	} else {
 		blockHash, err = chainhash.NewHashFromStr(verboseTx.BlockHash)
@@ -590,7 +590,7 @@ func (dcr *Backend) run(ctx context.Context) {
 	blockPoll := time.NewTicker(blockPollInterval)
 	defer blockPoll.Stop()
 	addBlock := func(block *chainjson.GetBlockVerboseResult, reorg bool) {
-		_, err := dcr.blockCache.add(block)
+		_, err := dcr.blockCache.Add(block)
 		if err != nil {
 			dcr.log.Errorf("error adding new best block to cache: %v", err)
 		}
@@ -641,13 +641,13 @@ out:
 	for {
 		select {
 		case <-blockPoll.C:
-			tip := dcr.blockCache.tip()
+			tipHash, tipHeight := dcr.blockCache.Tip()
 			bestHash, err := dcr.node.GetBestBlockHash(ctx)
 			if err != nil {
 				sendErr(asset.NewConnectionError("error retrieving best block: %w", translateRPCCancelErr(err)))
 				continue
 			}
-			if *bestHash == tip.hash {
+			if bestHash.IsEqual(tipHash) {
 				continue
 			}
 
@@ -664,7 +664,7 @@ out:
 				continue
 			}
 			// If it builds on the best block or the cache is empty, it's good to add.
-			if *prevHash == tip.hash || tip.height == 0 {
+			if prevHash.IsEqual(tipHash) || tipHash == nil {
 				dcr.log.Debugf("New block %s (%d)", bestHash, block.Height)
 				addBlock(block, false)
 				continue
@@ -673,10 +673,10 @@ out:
 			// It is either a reorg, or the previous block is not the cached
 			// best block. Crawl blocks backwards until finding a mainchain
 			// block, flagging blocks from the cache as orphans along the way.
-			iHash := &tip.hash
+			iHash := tipHash
 			reorgHeight := int64(0)
 			for {
-				if *iHash == zeroHash {
+				if iHash == nil {
 					break
 				}
 				iBlock, err := dcr.node.GetBlockVerbose(ctx, iHash, false)
@@ -708,8 +708,8 @@ out:
 			if reorgHeight > 0 {
 				reorg = true
 				dcr.log.Infof("Tip change from %s (%d) to %s (%d) detected (reorg or just fast blocks).",
-					tip.hash, tip.height, bestHash, block.Height)
-				dcr.blockCache.reorg(reorgHeight)
+					tipHash, tipHeight, bestHash, block.Height)
+				dcr.blockCache.PurgeMainchainBlocks(reorgHeight)
 			}
 
 			// Now add the new block.
@@ -725,12 +725,9 @@ out:
 
 // blockInfo returns block information for the verbose transaction data. The
 // current tip hash is also returned as a convenience.
-func (dcr *Backend) blockInfo(ctx context.Context, verboseTx *chainjson.TxRawResult) (blockHeight uint32, blockHash chainhash.Hash, tipHash *chainhash.Hash, err error) {
-	blockHeight = uint32(verboseTx.BlockHeight)
-	tip := dcr.blockCache.tipHash()
-	if tip != zeroHash {
-		tipHash = &tip
-	}
+func (dcr *Backend) blockInfo(ctx context.Context, verboseTx *chainjson.TxRawResult) (blockHeight int64, blockHash chainhash.Hash, tipHash *chainhash.Hash, err error) {
+	blockHeight = verboseTx.BlockHeight
+	tipHash, _ = dcr.blockCache.Tip()
 	// Assumed to be valid while in mempool, so skip the validity check.
 	if verboseTx.Confirmations > 0 {
 		if blockHeight == 0 {
@@ -738,13 +735,13 @@ func (dcr *Backend) blockInfo(ctx context.Context, verboseTx *chainjson.TxRawRes
 				"non-zero confirmation count (%s has %d confirmations)", verboseTx.Txid, verboseTx.Confirmations)
 			return
 		}
-		var blk *dcrBlock
+		var blk *dexdcr.Block
 		blk, err = dcr.getBlockInfo(ctx, verboseTx.BlockHash)
 		if err != nil {
 			return
 		}
-		blockHeight = blk.height
-		blockHash = blk.hash
+		blockHeight = blk.Height
+		blockHash = *blk.Hash
 	}
 	return
 }
@@ -963,7 +960,7 @@ func (dcr *Backend) getTxOutInfo(ctx context.Context, txHash *chainhash.Hash, vo
 
 // Get the block information, checking the cache first. Same as
 // getDcrBlock, but takes a string argument.
-func (dcr *Backend) getBlockInfo(ctx context.Context, blockid string) (*dcrBlock, error) {
+func (dcr *Backend) getBlockInfo(ctx context.Context, blockid string) (*dexdcr.Block, error) {
 	blockHash, err := chainhash.NewHashFromStr(blockid)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode block hash from %s", blockid)
@@ -972,8 +969,8 @@ func (dcr *Backend) getBlockInfo(ctx context.Context, blockid string) (*dcrBlock
 }
 
 // Get the block information, checking the cache first.
-func (dcr *Backend) getDcrBlock(ctx context.Context, blockHash *chainhash.Hash) (*dcrBlock, error) {
-	cachedBlock, found := dcr.blockCache.block(blockHash)
+func (dcr *Backend) getDcrBlock(ctx context.Context, blockHash *chainhash.Hash) (*dexdcr.Block, error) {
+	cachedBlock, found := dcr.blockCache.Block(blockHash)
 	if found {
 		return cachedBlock, nil
 	}
@@ -981,16 +978,16 @@ func (dcr *Backend) getDcrBlock(ctx context.Context, blockHash *chainhash.Hash) 
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving block %s: %w", blockHash, translateRPCCancelErr(err))
 	}
-	return dcr.blockCache.add(blockVerbose)
+	return dcr.blockCache.Add(blockVerbose)
 }
 
 // Get the mainchain block at the given height, checking the cache first.
-func (dcr *Backend) getMainchainDcrBlock(ctx context.Context, height uint32) (*dcrBlock, error) {
-	cachedBlock, found := dcr.blockCache.atHeight(height)
+func (dcr *Backend) getMainchainDcrBlock(ctx context.Context, height int64) (*dexdcr.Block, error) {
+	cachedBlock, found := dcr.blockCache.BlockAt(height)
 	if found {
 		return cachedBlock, nil
 	}
-	hash, err := dcr.node.GetBlockHash(ctx, int64(height))
+	hash, err := dcr.node.GetBlockHash(ctx, height)
 	if err != nil {
 		// Likely not mined yet. Not an error.
 		return nil, nil

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -127,7 +127,7 @@ var _ asset.Backend = (*Backend)(nil)
 func unconnectedDCR(logger dex.Logger, cfg *config) *Backend {
 	return &Backend{
 		cfg:        cfg,
-		blockCache: dexdcr.NewBlockCache(logger),
+		blockCache: dexdcr.NewBlockCache(),
 		log:        logger,
 		blockChans: make(map[chan *asset.BlockUpdate]struct{}),
 	}

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -1199,7 +1199,7 @@ func TestReorg(t *testing.T) {
 	var tipHash *chainhash.Hash
 	reset := func() {
 		cleanTestChain()
-		dcr.blockCache = dexdcr.NewBlockCache(dcr.log)
+		dcr.blockCache = dexdcr.NewBlockCache()
 		for h := int64(0); h <= tipHeight; h++ {
 			blockHash := testAddBlockVerbose(nil, tipHeight-h+1, h, 1)
 			// force dcr to get and cache the block

--- a/server/asset/dcr/live_test.go
+++ b/server/asset/dcr/live_test.go
@@ -386,7 +386,7 @@ func TestBlockMonitor(t *testing.T) {
 	fmt.Printf("Starting BlockMonitor test. Test will last for %d minutes\n", int(testDuration.Minutes()))
 	blockChan := dcr.BlockChannel(5)
 	expire := time.NewTimer(testDuration).C
-	lastHeight := dcr.blockCache.tipHeight()
+	_, lastHeight := dcr.blockCache.Tip()
 out:
 	for {
 		select {
@@ -394,7 +394,7 @@ out:
 			if update.Err != nil {
 				t.Fatalf("error encountered while monitoring blocks: %v", update.Err)
 			}
-			tipHeight := dcr.blockCache.tipHeight()
+			_, tipHeight := dcr.blockCache.Tip()
 			if update.Reorg {
 				fmt.Printf("block received at height %d causes a %d block reorg\n", tipHeight, lastHeight-tipHeight+1)
 			} else {


### PR DESCRIPTION
The blockcache currently only caches basic block information but will ultimately include transactions and block filters.