### PR TITLE
include order commitment in preimage request

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -322,7 +322,11 @@ func (c *Core) tryCancelTrade(dc *dexConnection, tracker *trackedTrade) error {
 	var result = new(msgjson.OrderResult)
 	err = dc.signAndRequest(msgOrder, route, result, DefaultResponseTimeout)
 	if err != nil {
-		return err
+		// At this point there is a possibility that the server got the request
+		// and created the cancel order, but we lost the connection before
+		// receiving the response with the cancel's order ID. Any preimage
+		// request will be unrecognized. This order is ABANDONED.
+		return fmt.Errorf("failed to submit cancel order targeting trade %v: %w", oid, err)
 	}
 	err = validateOrderResponse(dc, result, co, msgOrder)
 	if err != nil {
@@ -375,8 +379,9 @@ func (c *Core) syncOrderPlaced(oid order.OrderID) {
 		close(syncChan)
 		delete(c.piSyncers, oid)
 	} else {
-		// If there is no channel, the preimage request hasn't come yet. Add the
-		// channel to signal readiness.
+		// If there is no channel, the preimage request hasn't come yet. Add a
+		// channel to signal readiness. Could insert nil unless syncOrderPlaced
+		// is erroneously called twice for the same order ID.
 		c.piSyncers[oid] = make(chan struct{})
 	}
 	c.piSyncMtx.Unlock()
@@ -3112,23 +3117,23 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	err = dc.signAndRequest(msgOrder, route, result, fundingTxWait+DefaultResponseTimeout)
 	if err != nil {
 		unlockCoins()
+		// At this point there is a possibility that the server got the request
+		// and created the trade order, but we lost the connection before
+		// receiving the response with the trade's order ID. Any preimage
+		// request will be unrecognized. This order is ABANDONED.
 		return nil, 0, fmt.Errorf("new order request with DEX server %v market %v failed: %w", dc.acct.host, mktID, err)
 	}
 
 	// If we encounter an error, perform some basic logging.
-	//
-	// TODO: Notify the client somehow.
 	logAbandon := func(err interface{}) {
-		c.log.Errorf("Abandoning order. "+
-			"preimage: %x, server time: %d: %v",
+		c.log.Errorf("Abandoning order. preimage: %x, server time: %d: %v",
 			preImg[:], result.ServerTime, err)
 	}
 
-	err = validateOrderResponse(dc, result, ord, msgOrder)
+	err = validateOrderResponse(dc, result, ord, msgOrder) // stamps the order, giving it a valid ID
 	if err != nil {
 		unlockCoins()
-		c.log.Errorf("Abandoning order. preimage: %x, server time: %d: %v",
-			preImg[:], result.ServerTime, err)
+		logAbandon(fmt.Sprintf("order response validation failure: %v", err))
 		return nil, 0, fmt.Errorf("validateOrderResponse error: %w", err)
 	}
 
@@ -4486,7 +4491,8 @@ func (c *Core) listen(dc *dexConnection) {
 	lastTick := time.Now()
 
 	// Messages must be run in the order in which they are received, but they
-	// should not be blocking or run concurrently.
+	// should not be blocking or run concurrently. TODO: figure out which if any
+	// can run asynchronously, maybe all.
 	type msgJob struct {
 		hander routeHandler
 		msg    *msgjson.Message
@@ -4641,7 +4647,8 @@ out:
 }
 
 // handlePreimageRequest handles a DEX-originating request for an order
-// preimage.
+// preimage. If the order id in the request is not known, it may launch a
+// goroutine to wait for a market/limit/cancel request to finish processing.
 func handlePreimageRequest(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	req := new(msgjson.PreimageRequest)
 	err := msg.Unmarshal(req)
@@ -4649,56 +4656,62 @@ func handlePreimageRequest(c *Core, dc *dexConnection, msg *msgjson.Message) err
 		return fmt.Errorf("preimage request parsing error: %w", err)
 	}
 
+	if len(req.OrderID) != order.OrderIDSize {
+		return fmt.Errorf("invalid order ID in preimage request")
+	}
+
 	var oid order.OrderID
 	copy(oid[:], req.OrderID)
 
-	// Sync with order placement.
+	// Sync with order placement, the response from which provides the order ID.
 	c.piSyncMtx.Lock()
-	syncChan, found := c.piSyncers[oid]
-	if found {
-		// If we found the channel, the tracker is already in the map, and we
-		// can go ahead.
+	if _, found := c.piSyncers[oid]; found {
+		// If we found a map entry, the tracker is already in the trades map,
+		// and we can go ahead.
 		delete(c.piSyncers, oid)
-	} else {
-		// If we didn't find the channel, Trade is still running. Add the chan
-		// and wait for Trade to close it.
-		syncChan = make(chan struct{})
-		c.piSyncers[oid] = syncChan
+		c.piSyncMtx.Unlock()
+		return processPreimageRequest(c, dc, msg.ID, oid)
 	}
+
+	// If we didn't find an entry, Trade is still running. Add a chan and wait
+	// for Trade to close it.
+	syncChan := make(chan struct{})
+	c.piSyncers[oid] = syncChan
 	c.piSyncMtx.Unlock()
 
-	deletePiSyncer := func() {
+	// The order submission could be timing out waiting for a response, or this
+	// could be a bogus preimage request, so we do not want to block the caller,
+	// (*Core).listen if this hangs. Preimage requests are ok to handle
+	// asynchronously since there can be no matches until we respond to this.
+	c.log.Warnf("Got preimage request for %v before we got an order submission response!", oid)
+	go func() {
+		select {
+		case <-syncChan:
+			if err := processPreimageRequest(c, dc, msg.ID, oid); err != nil {
+				c.log.Errorf("processPreimageRequest for %v failed: %v", oid, err)
+			} else {
+				c.log.Debugf("processPreimageRequest for %v succeeded", oid)
+			}
+			// The channel is deleted from the piSyncers map by syncOrderPlaced.
+			return
+		case <-time.After(DefaultResponseTimeout):
+			c.log.Errorf("timed out syncing preimage request for %s, order %s", dc.acct.host, oid)
+		case <-c.ctx.Done():
+		}
 		c.piSyncMtx.Lock()
 		delete(c.piSyncers, oid)
 		c.piSyncMtx.Unlock()
-	}
+	}()
 
-	if !found {
-		select {
-		case <-syncChan:
-		case <-time.After(time.Minute):
-			deletePiSyncer()
-			return fmt.Errorf("timed out syncing preimage request for %s, order %s", dc.acct.host, oid)
-		case <-c.ctx.Done():
-			deletePiSyncer()
-			return nil
-		}
-	}
+	return nil
+}
 
+func processPreimageRequest(c *Core, dc *dexConnection, reqID uint64, oid order.OrderID) error {
 	tracker, preImg, isCancel := dc.findOrder(oid)
 	if tracker == nil {
-		// Hack around the race in prepareTrackedTrade from submitting the
-		// order, receiving the order result, and registering the tracked trade.
-		// It's possible that the dc.trades map won't have the oid yet after
-		// submitting the order, so if (1) we didn't find this oid, AND (2)
-		// we're in that window, that order result is about to be stored, so
-		// wait for it and check again.
-		tracker, preImg, isCancel = dc.findOrder(oid)
-		if tracker == nil {
-			return fmt.Errorf("no active order found for preimage request for %s", oid)
-		}
+		return fmt.Errorf("no active order found for preimage request for %s", oid)
 	}
-	resp, err := msgjson.NewResponse(msg.ID, &msgjson.PreimageResponse{
+	resp, err := msgjson.NewResponse(reqID, &msgjson.PreimageResponse{
 		Preimage: preImg[:],
 	}, nil)
 	if err != nil {
@@ -5132,7 +5145,7 @@ func messageOrder(ord order.Order, coins []*msgjson.Coin) (string, msgjson.Stamp
 }
 
 // validateOrderResponse validates the response against the order and the order
-// message.
+// message, and stamps the order with the ServerTime, giving it a valid OrderID.
 func validateOrderResponse(dc *dexConnection, result *msgjson.OrderResult, ord order.Order, msgOrder msgjson.Stampable) error {
 	if result.ServerTime == 0 {
 		return fmt.Errorf("OrderResult cannot have servertime = 0")

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -122,7 +122,7 @@ type dexConnection struct {
 // successfully sent.
 const (
 	DefaultResponseTimeout = comms.DefaultResponseTimeout
-	fundingTxWait          = 2 * time.Minute
+	fundingTxWait          = time.Minute // TODO: share var with server/market or put in config
 )
 
 // running returns the status of the provided market.
@@ -316,6 +316,12 @@ func (c *Core) tryCancelTrade(dc *dexConnection, tracker *trackedTrade) error {
 	if err != nil {
 		return err
 	}
+
+	commitSig := make(chan struct{})
+	defer close(commitSig) // signals on both success and failure, unlike syncOrderPlaced/piSyncers
+	c.sentCommitsMtx.Lock()
+	c.sentCommits[co.Commit] = commitSig
+	c.sentCommitsMtx.Unlock()
 
 	// Create and send the order message. Check the response before using it.
 	route, msgOrder := messageOrder(co, nil)
@@ -924,6 +930,9 @@ type Core struct {
 
 	piSyncMtx sync.Mutex
 	piSyncers map[order.OrderID]chan struct{}
+
+	sentCommitsMtx sync.Mutex
+	sentCommits    map[order.Commitment]chan struct{}
 }
 
 // New is the constructor for a new Core.
@@ -953,6 +962,7 @@ func New(cfg *Config) (*Core, error) {
 		lockTimeMaker: dex.LockTimeMaker(cfg.Net),
 		blockWaiters:  make(map[string]*blockWaiter),
 		piSyncers:     make(map[order.OrderID]chan struct{}),
+		sentCommits:   make(map[order.Commitment]chan struct{}),
 		tickSched:     make(map[order.OrderID]*time.Timer),
 		// Allowing to change the constructor makes testing a lot easier.
 		wsConstructor: comms.NewWsConn,
@@ -3109,6 +3119,12 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 		return nil, 0, fmt.Errorf("wallet %v failed to sign coins: %w", wallets.fromAsset.ID, err)
 	}
 
+	commitSig := make(chan struct{})
+	defer close(commitSig) // signals on both success and failure, unlike syncOrderPlaced/piSyncers
+	c.sentCommitsMtx.Lock()
+	c.sentCommits[prefix.Commit] = commitSig
+	c.sentCommitsMtx.Unlock()
+
 	// Everything is ready. Send the order.
 	route, msgOrder := messageOrder(ord, msgCoins)
 
@@ -4663,6 +4679,46 @@ func handlePreimageRequest(c *Core, dc *dexConnection, msg *msgjson.Message) err
 	var oid order.OrderID
 	copy(oid[:], req.OrderID)
 
+	// NEW protocol with commitment specified.
+	if len(req.Commitment) == order.CommitmentSize {
+		// See if we recognize that commitment, and if we do, just wait for the
+		// order ID, and process the request.
+		var commit order.Commitment
+		copy(commit[:], req.Commitment)
+
+		c.sentCommitsMtx.Lock()
+		defer c.sentCommitsMtx.Unlock()
+		commitSig, found := c.sentCommits[commit]
+		if !found { // this is the main benefit of a commitment index
+			return fmt.Errorf("received preimage request for unknown commitment %v, order %v",
+				req.Commitment, oid)
+		}
+		delete(c.sentCommits, commit)
+
+		dc.log.Debugf("Received preimage request for order %v with known commitment %v", oid, commit)
+
+		// Go async while waiting.
+		go func() {
+			// Order request success OR fail closes the channel.
+			<-commitSig
+			if err := processPreimageRequest(c, dc, msg.ID, oid); err != nil {
+				c.log.Errorf("async processPreimageRequest for %v failed: %v", oid, err)
+			} else {
+				c.log.Debugf("async processPreimageRequest for %v succeeded", oid)
+			}
+
+			// There or not, delete this oid entry from the deprecated map.
+			c.piSyncMtx.Lock()
+			delete(c.piSyncers, oid)
+			c.piSyncMtx.Unlock()
+		}()
+
+		return nil
+	} // else no or invalid commitment, eventually error (v0 DEPRECATION)
+
+	// OLD protocol below without the commitment is DEPRECATED. Remove when
+	// protocol version reaches 1.
+
 	// Sync with order placement, the response from which provides the order ID.
 	c.piSyncMtx.Lock()
 	if _, found := c.piSyncers[oid]; found {
@@ -4670,11 +4726,12 @@ func handlePreimageRequest(c *Core, dc *dexConnection, msg *msgjson.Message) err
 		// and we can go ahead.
 		delete(c.piSyncers, oid)
 		c.piSyncMtx.Unlock()
+		dc.log.Debugf("Received preimage request for known order %v", oid)
 		return processPreimageRequest(c, dc, msg.ID, oid)
 	}
 
-	// If we didn't find an entry, Trade is still running. Add a chan and wait
-	// for Trade to close it.
+	// If we didn't find an entry, Trade or Cancel is still running. Add a chan
+	// and wait for Trade to close it.
 	syncChan := make(chan struct{})
 	c.piSyncers[oid] = syncChan
 	c.piSyncMtx.Unlock()
@@ -4683,19 +4740,19 @@ func handlePreimageRequest(c *Core, dc *dexConnection, msg *msgjson.Message) err
 	// could be a bogus preimage request, so we do not want to block the caller,
 	// (*Core).listen if this hangs. Preimage requests are ok to handle
 	// asynchronously since there can be no matches until we respond to this.
-	c.log.Warnf("Got preimage request for %v before we got an order submission response!", oid)
+	c.log.Warnf("Received preimage request for %v with no corresponding order submission response! Waiting...", oid)
 	go func() {
 		select {
 		case <-syncChan:
 			if err := processPreimageRequest(c, dc, msg.ID, oid); err != nil {
-				c.log.Errorf("processPreimageRequest for %v failed: %v", oid, err)
+				c.log.Errorf("async processPreimageRequest for %v failed: %v", oid, err)
 			} else {
-				c.log.Debugf("processPreimageRequest for %v succeeded", oid)
+				c.log.Debugf("async processPreimageRequest for %v succeeded", oid)
 			}
 			// The channel is deleted from the piSyncers map by syncOrderPlaced.
 			return
 		case <-time.After(DefaultResponseTimeout):
-			c.log.Errorf("timed out syncing preimage request for %s, order %s", dc.acct.host, oid)
+			c.log.Errorf("Timed out syncing preimage request from %s, order %s", dc.acct.host, oid)
 		case <-c.ctx.Done():
 		}
 		c.piSyncMtx.Lock()
@@ -4711,6 +4768,14 @@ func processPreimageRequest(c *Core, dc *dexConnection, reqID uint64, oid order.
 	if tracker == nil {
 		return fmt.Errorf("no active order found for preimage request for %s", oid)
 	}
+	// Clean up the sentCommits now that we loaded the commitment. This can be
+	// removed when the old piSyncers method is removed.
+	defer func() {
+		// Note the commitment is not tracker.Commitment() for cancel orders.
+		c.sentCommitsMtx.Lock()
+		delete(c.sentCommits, preImg.Commit()) // redundant if the commitment was in request
+		c.sentCommitsMtx.Unlock()
+	}()
 	resp, err := msgjson.NewResponse(reqID, &msgjson.PreimageResponse{
 		Preimage: preImg[:],
 	}, nil)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2438,6 +2438,7 @@ func TestHandlePreimageRequest(t *testing.T) {
 		metaData: &db.OrderMetaData{},
 	}
 
+	// Simulate an order submission request having completed.
 	loadSyncer := func() {
 		rig.core.piSyncMtx.Lock()
 		rig.core.piSyncers[oid] = make(chan struct{})

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -839,6 +839,7 @@ func newTestRig() *testRig {
 			wallets:       make(map[uint32]*xcWallet),
 			blockWaiters:  make(map[string]*blockWaiter),
 			piSyncers:     make(map[order.OrderID]chan struct{}),
+			sentCommits:   make(map[order.Commitment]chan struct{}),
 			tickSched:     make(map[order.OrderID]*time.Timer),
 			wsConstructor: func(*comms.WsCfg) (comms.WsConn, error) {
 				// This is not very realistic since it doesn't start a fresh
@@ -2427,12 +2428,14 @@ func TestHandlePreimageRequest(t *testing.T) {
 	preImg := newPreimage()
 	payload := &msgjson.PreimageRequest{
 		OrderID: oid[:],
+		// No commitment in this request.
 	}
-	req, _ := msgjson.NewRequest(rig.dc.NextID(), msgjson.PreimageRoute, payload)
+	reqNoCommit, _ := msgjson.NewRequest(rig.dc.NextID(), msgjson.PreimageRoute, payload)
 
 	tracker := &trackedTrade{
 		Order:    ord,
 		preImg:   preImg,
+		mktID:    tDcrBtcMktName,
 		db:       rig.db,
 		dc:       rig.dc,
 		metaData: &db.OrderMetaData{},
@@ -2441,33 +2444,88 @@ func TestHandlePreimageRequest(t *testing.T) {
 	// Simulate an order submission request having completed.
 	loadSyncer := func() {
 		rig.core.piSyncMtx.Lock()
-		rig.core.piSyncers[oid] = make(chan struct{})
+		rig.core.piSyncers[oid] = nil // set nil to ensure it's just a map entry
 		rig.core.piSyncMtx.Unlock()
 	}
 
 	rig.dc.trades[oid] = tracker
 	loadSyncer()
-	err := handlePreimageRequest(rig.core, rig.dc, req)
+	err := handlePreimageRequest(rig.core, rig.dc, reqNoCommit)
 	if err != nil {
 		t.Fatalf("handlePreimageRequest error: %v", err)
 	}
 
-	ensureErr := func(tag string) {
+	// Test the new path with rig.core.sentCommits.
+	readyCommitment := func(commit order.Commitment) chan struct{} {
+		commitSig := make(chan struct{}) // close after fake order submission is "done"
+		rig.core.sentCommitsMtx.Lock()
+		rig.core.sentCommits[commit] = commitSig
+		rig.core.sentCommitsMtx.Unlock()
+		return commitSig
+	}
+
+	commit := preImg.Commit()
+	commitSig := readyCommitment(commit)
+	payload = &msgjson.PreimageRequest{
+		OrderID:    oid[:],
+		Commitment: commit[:],
+	}
+	reqCommit, _ := msgjson.NewRequest(rig.dc.NextID(), msgjson.PreimageRoute, payload)
+
+	notes := rig.core.NotificationFeed()
+
+	rig.dc.trades[oid] = tracker
+	err = handlePreimageRequest(rig.core, rig.dc, reqCommit)
+	if err != nil {
+		t.Fatalf("handlePreimageRequest error: %v", err)
+	}
+	// It has gone async now, waiting for commitSig.
+	// i.e. "Received preimage request for %v with no corresponding order submission response! Waiting..."
+	close(commitSig) // pretend like the order submission just finished
+
+	select {
+	case note := <-notes:
+		if note.Subject() != SubjectPreimageSent {
+			t.Fatalf("note subject is %v, not %v", note.Subject(), SubjectPreimageSent)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no order note from preimage request handling")
+	}
+
+	// negative paths
+	ensureErr := func(tag string, req *msgjson.Message, errPrefix string) {
 		t.Helper()
 		loadSyncer()
+		commitSig := readyCommitment(commit)
+		close(commitSig) // ready before preimage request
 		err := handlePreimageRequest(rig.core, rig.dc, req)
 		if err == nil {
 			t.Fatalf("%s: no error", tag)
 		}
+		if !strings.HasPrefix(err.Error(), errPrefix) {
+			t.Fatalf("expected error starting with %q, got %q", errPrefix, err)
+		}
 	}
 
-	delete(rig.dc.trades, oid)
-	ensureErr("no tracker")
-	rig.dc.trades[oid] = tracker
+	// unknown commitment in request
+	payloadBad := &msgjson.PreimageRequest{
+		OrderID:    oid[:],
+		Commitment: encode.RandomBytes(order.CommitmentSize), // junk, but correct length
+	}
+	reqCommitBad, _ := msgjson.NewRequest(rig.dc.NextID(), msgjson.PreimageRoute, payloadBad)
+	ensureErr("unknown commitment", reqCommitBad, "received preimage request for unknown commitment")
+	// all other errors for
 
+	// Trade-not-found error only returned on synchronous non-commitment request
+	// handling, so use reqNoCommit to test that part of processPreimageRequest.
+	delete(rig.dc.trades, oid)
+	ensureErr("no tracker", reqNoCommit, "no active order found for preimage request")
+	rig.dc.trades[oid] = tracker // reset
+
+	// Response send error also only returned on synchronous request handling.
 	rig.ws.sendErr = tErr
-	ensureErr("send error")
-	rig.ws.sendErr = nil
+	ensureErr("send error", reqNoCommit, "preimage send error")
+	rig.ws.sendErr = nil // reset
 }
 
 func TestHandleRevokeOrderMsg(t *testing.T) {

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -841,6 +841,7 @@ type TradeResumption struct {
 // PreimageRequest is the server-originating preimage request payload.
 type PreimageRequest struct {
 	OrderID        Bytes `json:"orderid"`
+	Commitment     Bytes `json:"commit"`
 	CommitChecksum Bytes `json:"csum"`
 }
 

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1558,10 +1558,11 @@ func (m *Market) collectPreimages(orders []order.Order) (cSum []byte, ordersReve
 	preimages := make(map[order.Order]chan *order.Preimage, len(orders))
 	for _, ord := range orders {
 		// Make the 'preimage' request.
+		commit := ord.Commitment()
 		piReqParams := &msgjson.PreimageRequest{
 			OrderID:        idToBytes(ord.ID()),
+			Commitment:     commit[:],
 			CommitChecksum: cSum,
-			// TODO: include this order's commitment so client can recognize it prior to submission response
 		}
 		req, err := msgjson.NewRequest(comms.NextID(), msgjson.PreimageRoute, piReqParams)
 		if err != nil {

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1561,6 +1561,7 @@ func (m *Market) collectPreimages(orders []order.Order) (cSum []byte, ordersReve
 		piReqParams := &msgjson.PreimageRequest{
 			OrderID:        idToBytes(ord.ID()),
 			CommitChecksum: cSum,
+			// TODO: include this order's commitment so client can recognize it prior to submission response
 		}
 		req, err := msgjson.NewRequest(comms.NextID(), msgjson.PreimageRoute, piReqParams)
 		if err != nil {


### PR DESCRIPTION
This builds on https://github.com/decred/dcrdex/pull/1008 by including the `Commitment` in the `PreimageRequest`, which solves multiple issues with the current race between order submission response processing and incoming preimage requests.  Namely, we can record the commitment *before* submitting the order/cancel request, thus avoiding a race necessitating the `piSyncers` map hoop jumping.  More importantly however, we can reject outright preimage requests containing unrecognized commitments.  Without this, we had to blindly wait for an arbitrary timeout (was 1 min) to see if we got an order submission response back with the order ID of interest.