### PR TITLE
client/webserver: allow multiple authorized sessions

### DIFF
--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -328,6 +328,10 @@ func (s *WebServer) apiLogout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// With Core locked up, invalidate all known auth tokens to force any other
+	// sessions to login again.
+	s.deauth()
+
 	http.SetCookie(w, &http.Cookie{
 		Name:     authCK,
 		Path:     "/",


### PR DESCRIPTION
This allow multiple authenticated client http sessions by tracking multiple cookies in the WebServer. You can now login in different browsers without one login invalidating the other's auth cookie.

Logout ends all authenticated sessions however.  This is done because the logout route also performs `(*Core).Logout`, crippling other authenticated http sessions.  Also, if we just removed the auth token for the one session performing the logout, the backend would really have no way to keep the map clean and it could conceivable keep filling up if requests kept reauthing and not logging out.