### PR TITLE
multi: graceful support for json unmarshal of null

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -446,6 +446,12 @@ func (conn *wsConn) Stop() {
 	conn.cancel()
 }
 
+func (conn *wsConn) SendRaw(b []byte) error {
+	conn.wsMtx.Lock()
+	defer conn.wsMtx.Unlock()
+	return conn.ws.WriteMessage(websocket.TextMessage, b)
+}
+
 // Send pushes outgoing messages over the websocket connection. Sending of the
 // message is synchronous, so a nil error guarantees that the message was
 // successfully sent. A non-nil error may indicate that the connection is known

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -299,7 +299,7 @@ func (s *RPCServer) handleRequest(req *msgjson.Message) *msgjson.ResponsePayload
 	}
 
 	params := new(RawParams)
-	err := req.Unmarshal(params)
+	err := req.Unmarshal(params) // NOT &params to prevent setting it to nil for []byte("null") Payload
 	if err != nil {
 		log.Debugf("cannot unmarshal params for route %s", req.Route)
 		payload.Error = msgjson.NewError(msgjson.RPCParseError, "unable to unmarshal request")

--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -262,7 +262,7 @@ out:
 			c.SendError(1, msgjson.NewError(msgjson.RPCParseError, "failed to parse message"))
 			continue
 		}
-		if msg.ID == 0 {
+		if msg.ID == 0 { // also covers msgBytes []byte("null")
 			c.SendError(1, msgjson.NewError(msgjson.RPCParseError, "request id cannot be zero"))
 			continue
 		}

--- a/server/auth/registrar.go
+++ b/server/auth/registrar.go
@@ -4,7 +4,6 @@
 package auth
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -27,8 +26,8 @@ var (
 func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
 	// Unmarshal.
 	register := new(msgjson.Register)
-	err := json.Unmarshal(msg.Payload, &register)
-	if err != nil {
+	err := msg.Unmarshal(&register)
+	if err != nil || register == nil /* null payload */ {
 		return &msgjson.Error{
 			Code:    msgjson.RPCParseError,
 			Message: "error parsing register request",
@@ -97,8 +96,8 @@ func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *
 func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
 	// Unmarshal.
 	notifyFee := new(msgjson.NotifyFee)
-	err := json.Unmarshal(msg.Payload, &notifyFee)
-	if err != nil {
+	err := msg.Unmarshal(&notifyFee)
+	if err != nil || notifyFee == nil /* null payload */ {
 		return &msgjson.Error{
 			Code:    msgjson.RPCParseError,
 			Message: "error parsing notifyfee request",

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -5,7 +5,6 @@ package market
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -542,8 +541,8 @@ func (r *BookRouter) msgOrderBook(book *msgBook) *msgjson.OrderBook {
 // notifications.
 func (r *BookRouter) handleOrderBook(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
 	sub := new(msgjson.OrderBookSubscription)
-	err := json.Unmarshal(msg.Payload, sub)
-	if err != nil {
+	err := msg.Unmarshal(&sub)
+	if err != nil || sub == nil {
 		return &msgjson.Error{
 			Code:    msgjson.RPCParseError,
 			Message: "error parsing orderbook request",
@@ -573,8 +572,8 @@ func (r *BookRouter) handleOrderBook(conn comms.Link, msg *msgjson.Message) *msg
 // order book.
 func (r *BookRouter) handleUnsubOrderBook(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
 	unsub := new(msgjson.UnsubOrderBook)
-	err := json.Unmarshal(msg.Payload, unsub)
-	if err != nil {
+	err := msg.Unmarshal(&unsub)
+	if err != nil || unsub == nil {
 		return &msgjson.Error{
 			Code:    msgjson.RPCParseError,
 			Message: "error parsing unsub_orderbook request",

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -180,8 +179,8 @@ func fundingCoin(backend asset.Backend, coinID []byte, redeemScript []byte) (ass
 // order.LimitOrder and submits it to the epoch queue.
 func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
 	limit := new(msgjson.LimitOrder)
-	err := json.Unmarshal(msg.Payload, limit)
-	if err != nil {
+	err := msg.Unmarshal(&limit)
+	if err != nil || limit == nil {
 		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'limit' payload")
 	}
 
@@ -398,8 +397,8 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 // order.MarketOrder and submits it to the epoch queue.
 func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
 	market := new(msgjson.MarketOrder)
-	err := json.Unmarshal(msg.Payload, market)
-	if err != nil {
+	err := msg.Unmarshal(&market)
+	if err != nil || market == nil {
 		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'market' payload")
 	}
 
@@ -598,8 +597,8 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 // order.CancelOrder and submits it to the epoch queue.
 func (r *OrderRouter) handleCancel(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
 	cancel := new(msgjson.CancelOrder)
-	err := json.Unmarshal(msg.Payload, cancel)
-	if err != nil {
+	err := msg.Unmarshal(&cancel)
+	if err != nil || cancel == nil {
 		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'cancel' payload")
 	}
 

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -6,7 +6,6 @@ package swap
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -998,8 +997,8 @@ func (s *Swapper) respondError(id uint64, user account.AccountID, code int, errM
 		return // this should not be possible, but don't pass nil msg to Send
 	}
 	if err := s.authMgr.Send(user, msg); err != nil {
-		log.Infof("Unable to send %s error response (code = %d, msg = %s) to disconnected user %v: %q",
-			msg.Route, code, errMsg, user, err)
+		log.Infof("Unable to send error response (code = %d, msg = %s) to disconnected user %v: %q",
+			code, errMsg, user, err)
 	}
 }
 
@@ -1011,7 +1010,7 @@ func (s *Swapper) respondSuccess(id uint64, user account.AccountID, result inter
 		return // this should not be possible, but don't pass nil msg to Send
 	}
 	if err := s.authMgr.Send(user, msg); err != nil {
-		log.Infof("Unable to send %s success response to disconnected user %v: %v", msg.Route, user, err)
+		log.Infof("Unable to send success response to disconnected user %v: %v", user, err)
 	}
 }
 
@@ -1579,8 +1578,8 @@ func (s *Swapper) handleInit(user account.AccountID, msg *msgjson.Message) *msgj
 	}
 
 	params := new(msgjson.Init)
-	err := json.Unmarshal(msg.Payload, &params)
-	if err != nil {
+	err := msg.Unmarshal(&params)
+	if err != nil || params == nil {
 		return &msgjson.Error{
 			Code:    msgjson.RPCParseError,
 			Message: "Error decoding 'init' method params",
@@ -1696,9 +1695,8 @@ func (s *Swapper) handleRedeem(user account.AccountID, msg *msgjson.Message) *ms
 	}
 
 	params := new(msgjson.Redeem)
-
-	err := json.Unmarshal(msg.Payload, &params)
-	if err != nil {
+	err := msg.Unmarshal(&params)
+	if err != nil || params == nil {
 		return &msgjson.Error{
 			Code:    msgjson.RPCParseError,
 			Message: "Error decoding 'redeem' request payload",


### PR DESCRIPTION
A number of `json.Unmarshal` calls now properly handle a `Payload`
of the JSON `null` value, which depending on the caller's use of
`json.Unmarshal` can set a pointer of the type to `nil`.

The docs for `(*Message).Unmarshal` now call out the `null` `Payload`
handling explicitly. A `null` `Payload` is not an error however, since
the caller may be happy to accept (or even expect) a `null` `Payload`.
Further, for the caller to even allow their input to be set to `nil`, they must
call `Unmarshal` with sufficient indirection. For example,

```go
t := new(T) // *T
err := json.Unmarshal(msg.Payload, &t) // passed **T, can set t to nil
```

Only with the above approach can `json.Unmarshal` or `(*Message).Unmarshal`
set `t` to `nil`. Callers can either pass a `*T` instead and accept a
zero-value `T` in the case of a `null` `Payload`, or pass a `**T` and check
`if err != nil || t == nil` when they need to identify this case.

For example, the client's RPC server's `handleRequest` method permits,
and in the case of the version RPC expects, a `null` `Payload` without
error and as such unmarshals with:

```go
params := new(RawParams)
err := req.Unmarshal(params) // NOT &params - cannot be set to nil for []byte("null") Payload
```

For the client RPC server, this is the safest approach, and a `nil`
error is _required_. Similarly, `dex/ws.(*WSLink).inhandler` expects no
error for a `null` `Payload` and recognizes it with a specific check:

```go
msg := new(msgjson.Message)
err = json.Unmarshal(msgBytes, msg) // *Message
...
if msg.ID == 0 { // also covers msgBytes []byte("null")
    c.SendError(1, msgjson.NewError(msgjson.RPCParseError, "request id cannot be zero"))
```

The `(*Message).Response` method unmarshals with a `**T`, and is updated
with this `nil` check, and returns an error:

```go
fmt.Errorf("null response payload").
```

The docs for `msgjson.DecodeMessage` are updated to reflect that the
both returned `*Message` and error can be `nil` in this `null` case.
`DecodeMessage` is only used in tests presently.

Each of the following route handlers require detecting a `null` payload,
and are thus updated with post `Unmarshal` checks: `handleConnect`,
`handleRegister`, `handleNotifyFee`, `handleInit`, and `handleRedeem`.
All routes were called from a helper with a deferred recover.

This also adds the method `client/comms.(*wsConn).SendRaw([]byte)` for
testing purposes. It is not part of the `WsConn interface` however.

NOTE: This is [well-documented behavior of `json.Unmarshal`](https://golang.org/pkg/encoding/json/#Unmarshal), but here's an illustration: https://play.golang.org/p/YbLpU9IQUtn