### PR TITLE
new account regn protocol: preregister/payfee

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2153,6 +2153,22 @@ func (btc *ExchangeWallet) PayFee(address string, regFee uint64) (asset.Coin, er
 	return newOutput(txHash, vout, sent), nil
 }
 
+func (btc *ExchangeWallet) MakeRegFeeTx(address string, regFee uint64, acctID []byte) ([]byte, []byte, error) {
+	return nil, nil, fmt.Errorf("not implemented")
+}
+
+func (btc *ExchangeWallet) SendTransaction(rawTx []byte) ([]byte, error) {
+	msgTx, err := msgTxFromBytes(rawTx)
+	if err != nil {
+		return nil, err
+	}
+	txHash, err := btc.node.SendRawTransaction(msgTx, false)
+	if err != nil {
+		return nil, err
+	}
+	return toCoinID(txHash, 0), nil
+}
+
 // Withdraw withdraws funds to the specified address. Fees are subtracted from
 // the value. feeRate is in units of atoms/byte.
 func (btc *ExchangeWallet) Withdraw(address string, value uint64) (asset.Coin, error) {

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -250,6 +250,10 @@ func (c *tRPCClient) GetBlockChainInfo(_ context.Context) (*chainjson.GetBlockCh
 	return c.blockchainInfo, c.blockchainInfoErr
 }
 
+func (c *tRPCClient) FundRawTransaction(ctx context.Context, rawhex string, fundAccount string, options walletjson.FundRawTransactionOptions) (*walletjson.FundRawTransactionResult, error) {
+	return nil, fmt.Errorf("method FundRawTransaction not implemented")
+}
+
 func (c *tRPCClient) SendRawTransaction(_ context.Context, tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error) {
 	c.sentRawTx = tx
 	if c.sendRawErr == nil && c.sendRawHash == nil {

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"fmt"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -143,6 +144,23 @@ func TestMain(m *testing.M) {
 		return m.Run()
 	}
 	os.Exit(doIt())
+}
+
+func TestMakeRegFeeTx(t *testing.T) {
+	rig := newTestRig(t, func(name string, err error) {
+		tLogger.Infof("%s has reported a new block, error = %v", name, err)
+	})
+	defer rig.close(t)
+
+	acctID := randBytes(32)
+	fee := uint64(1020304050) //  ~10.2 DCR
+
+	wallet := rig.beta()
+	rawFeeTx, coinID, err := wallet.MakeRegFeeTx(alphaAddress, fee, acctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("%x: %x\n", decodeCoinID(coinID), rawFeeTx)
 }
 
 func TestWallet(t *testing.T) {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -161,6 +161,8 @@ type Wallet interface {
 	// PayFee sends the dex registration fee. Transaction fees are in addition to
 	// the registration fee, and the fee rate is taken from the DEX configuration.
 	PayFee(address string, feeAmt uint64) (Coin, error)
+	MakeRegFeeTx(address string, regFee uint64, acctID []byte) (RawTx []byte, FeeCoin []byte, err error)
+	SendTransaction(rawTx []byte) ([]byte, error)
 	// Confirmations gets the number of confirmations for the specified coin ID.
 	// If the coin is not unspent, and is not known to this wallet,
 	// Confirmations may return an error. The value of spent should be ignored

--- a/client/core/account.go
+++ b/client/core/account.go
@@ -35,27 +35,25 @@ func (c *Core) AccountExport(pw []byte, host string) (*Account, error) {
 	privKey := hex.EncodeToString(dc.acct.privKey.Serialize())
 	dc.acct.keyMtx.RUnlock()
 
+	// TODO: toast AccountProof
 	feeProofSig := ""
-	var feeProofStamp uint64
 	if dc.acct.isPaid {
 		accountProof, err := c.db.AccountProof(host)
 		if err != nil {
 			return nil, codedError(accountProofErr, err)
 		}
 		feeProofSig = hex.EncodeToString(accountProof.Sig)
-		feeProofStamp = accountProof.Stamp
 	}
 
 	// Account ID is exported for informational purposes only, it is not used during import.
 	acct := &Account{
-		Host:          host,
-		AccountID:     accountID,
-		PrivKey:       privKey,
-		DEXPubKey:     hex.EncodeToString(dc.acct.dexPubKey.SerializeCompressed()),
-		Cert:          hex.EncodeToString(dc.acct.cert),
-		FeeCoin:       hex.EncodeToString(dc.acct.feeCoin),
-		FeeProofSig:   feeProofSig,
-		FeeProofStamp: feeProofStamp,
+		Host:        host,
+		AccountID:   accountID,
+		PrivKey:     privKey,
+		DEXPubKey:   hex.EncodeToString(dc.acct.dexPubKey.SerializeCompressed()),
+		Cert:        hex.EncodeToString(dc.acct.cert),
+		FeeCoin:     hex.EncodeToString(dc.acct.feeCoin),
+		FeeProofSig: feeProofSig,
 	}
 	return acct, nil
 }
@@ -101,7 +99,7 @@ func (c *Core) AccountImport(pw []byte, acct Account) error {
 		return codedError(encryptionErr, err)
 	}
 
-	accountInfo.Paid = acct.FeeProofSig != "" && acct.FeeProofStamp != 0
+	// accountInfo.Paid = acct.FeeProofSig != "" && acct.FeeProofStamp != 0
 
 	// verifyAccount makes a connection to the DEX.
 	if !c.verifyAccount(&accountInfo) {
@@ -113,21 +111,21 @@ func (c *Core) AccountImport(pw []byte, acct Account) error {
 		return codedError(dbErr, err)
 	}
 
-	if accountInfo.Paid {
-		sig, err := hex.DecodeString(acct.FeeProofSig)
-		if err != nil {
-			return codedError(decodeErr, err)
-		}
-		accountProof := db.AccountProof{
-			Host:  host,
-			Stamp: acct.FeeProofStamp,
-			Sig:   sig,
-		}
-		err = c.db.AccountPaid(&accountProof)
-		if err != nil {
-			return codedError(dbErr, err)
-		}
-	}
+	// if accountInfo.Paid {
+	// 	sig, err := hex.DecodeString(acct.FeeProofSig)
+	// 	if err != nil {
+	// 		return codedError(decodeErr, err)
+	// 	}
+	// 	accountProof := db.AccountProof{
+	// 		Host:  host,
+	// 		Stamp: acct.FeeProofStamp,
+	// 		Sig:   sig,
+	// 	}
+	// 	err = c.db.AccountPaid(&accountProof)
+	// 	if err != nil {
+	// 		return codedError(dbErr, err)
+	// 	}
+	// }
 
 	return nil
 }

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -3,53 +3,53 @@
 package core
 
 import (
-	"bytes"
 	"encoding/hex"
 	"testing"
 
 	"decred.org/dcrdex/client/db"
 )
 
-func TestAccountExport(t *testing.T) {
-	rig := newTestRig()
-	tCore := rig.core
-	host := tCore.conns[tDexHost].acct.host
-	tCore.conns[tDexHost].acct.isPaid = true
+// TODO: rework TestAccountExport
+// func TestAccountExport(t *testing.T) {
+// 	rig := newTestRig()
+// 	tCore := rig.core
+// 	host := tCore.conns[tDexHost].acct.host
+// 	tCore.conns[tDexHost].acct.isPaid = true
 
-	setupRigAccountProof(host, rig)
+// 	setupRigAccountProof(host, rig)
 
-	accountResponse, err := tCore.AccountExport(tPW, host)
-	if err != nil {
-		t.Fatalf("account keys error: %v", err)
-	}
-	if accountResponse == nil {
-		t.Fatalf("accountResponse is nil")
-	}
-	if host != accountResponse.Host {
-		t.Fatalf("host key not equal to account host")
-	}
-	if accountResponse.AccountID != rig.acct.id.String() {
-		t.Fatal("unexpected AccountID")
-	}
-	if accountResponse.DEXPubKey != hex.EncodeToString(rig.acct.dexPubKey.SerializeCompressed()) {
-		t.Fatal("unexpected DEXPubKey")
-	}
-	if accountResponse.PrivKey != hex.EncodeToString(rig.acct.privKey.Serialize()) {
-		t.Fatal("unexpected PrivKey")
-	}
-	if accountResponse.FeeCoin != hex.EncodeToString(rig.acct.feeCoin) {
-		t.Fatal("unexpected FeeCoin")
-	}
-	if accountResponse.Cert != hex.EncodeToString(rig.acct.cert) {
-		t.Fatal("unexpected Cert")
-	}
-	if accountResponse.FeeProofSig != hex.EncodeToString(rig.db.accountProof.Sig) {
-		t.Fatal("unexpected FeeProofSig")
-	}
-	if accountResponse.FeeProofStamp != rig.db.accountProof.Stamp {
-		t.Fatal("unexpected FeeProofStamp")
-	}
-}
+// 	accountResponse, err := tCore.AccountExport(tPW, host)
+// 	if err != nil {
+// 		t.Fatalf("account keys error: %v", err)
+// 	}
+// 	if accountResponse == nil {
+// 		t.Fatalf("accountResponse is nil")
+// 	}
+// 	if host != accountResponse.Host {
+// 		t.Fatalf("host key not equal to account host")
+// 	}
+// 	if accountResponse.AccountID != rig.acct.id.String() {
+// 		t.Fatal("unexpected AccountID")
+// 	}
+// 	if accountResponse.DEXPubKey != hex.EncodeToString(rig.acct.dexPubKey.SerializeCompressed()) {
+// 		t.Fatal("unexpected DEXPubKey")
+// 	}
+// 	if accountResponse.PrivKey != hex.EncodeToString(rig.acct.privKey.Serialize()) {
+// 		t.Fatal("unexpected PrivKey")
+// 	}
+// 	if accountResponse.FeeCoin != hex.EncodeToString(rig.acct.feeCoin) {
+// 		t.Fatal("unexpected FeeCoin")
+// 	}
+// 	if accountResponse.Cert != hex.EncodeToString(rig.acct.cert) {
+// 		t.Fatal("unexpected Cert")
+// 	}
+// 	if accountResponse.FeeProofSig != hex.EncodeToString(rig.db.accountProof.Sig) {
+// 		t.Fatal("unexpected FeeProofSig")
+// 	}
+// 	if accountResponse.FeeProofStamp != rig.db.accountProof.Stamp {
+// 		t.Fatal("unexpected FeeProofStamp")
+// 	}
+// }
 
 // If account is not paid then AccountProof should contain unset values
 func TestAccountExportNoAccountProof(t *testing.T) {
@@ -71,9 +71,10 @@ func TestAccountExportNoAccountProof(t *testing.T) {
 	if accountResponse.FeeProofSig != "" {
 		t.Fatal("unexpected FeeProofSig")
 	}
-	if accountResponse.FeeProofStamp != 0 {
-		t.Fatal("unexpected FeeProofStamp")
-	}
+	// TODO: update!
+	// if accountResponse.FeeProofStamp != 0 {
+	// 	t.Fatal("unexpected FeeProofStamp")
+	// }
 }
 
 var tFeeProofStamp uint64 = 123456789
@@ -134,76 +135,78 @@ func TestAccountExportAccountKeyError(t *testing.T) {
 	}
 }
 
-func TestAccountExportAccountProofError(t *testing.T) {
-	rig := newTestRig()
-	tCore := rig.core
-	host := tCore.conns[tDexHost].acct.host
-	tCore.conns[tDexHost].acct.isPaid = true
-	rig.db.accountProofErr = tErr
-	_, err := tCore.AccountExport(tPW, host)
-	if !errorHasCode(err, accountProofErr) {
-		t.Fatalf("expected account proof error, actual error: '%v'", err)
-	}
-}
+// func TestAccountExportAccountProofError(t *testing.T) {
+// 	rig := newTestRig()
+// 	tCore := rig.core
+// 	host := tCore.conns[tDexHost].acct.host
+// 	tCore.conns[tDexHost].acct.isPaid = true
+// 	rig.db.accountProofErr = tErr
+// 	_, err := tCore.AccountExport(tPW, host)
+// 	if !errorHasCode(err, accountProofErr) {
+// 		t.Fatalf("expected account proof error, actual error: '%v'", err)
+// 	}
+// }
 
 func buildTestAccount(host string) Account {
 	return Account{
-		Host:          host,
-		AccountID:     tDexAccountID.String(),
-		DEXPubKey:     hex.EncodeToString(tDexKey.SerializeCompressed()),
-		PrivKey:       hex.EncodeToString(tDexPriv.Serialize()),
-		Cert:          hex.EncodeToString([]byte{}),
-		FeeCoin:       hex.EncodeToString([]byte("somecoin")),
-		FeeProofSig:   hex.EncodeToString(tFeeProofSig),
-		FeeProofStamp: tFeeProofStamp,
+		Host:      host,
+		AccountID: tDexAccountID.String(),
+		DEXPubKey: hex.EncodeToString(tDexKey.SerializeCompressed()),
+		PrivKey:   hex.EncodeToString(tDexPriv.Serialize()),
+		Cert:      hex.EncodeToString([]byte{}),
+		FeeCoin:   hex.EncodeToString([]byte("somecoin")),
+		// TODO FeeTx
+		FeeProofSig: hex.EncodeToString(tFeeProofSig),
+		//FeeProofStamp: tFeeProofStamp,
 	}
 }
 
-func TestAccountImport(t *testing.T) {
-	rig := newTestRig()
-	tCore := rig.core
-	host := tCore.conns[tDexHost].acct.host
-	account := buildTestAccount(host)
-	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
-	if err != nil {
-		t.Fatalf("account import error: %v", err)
-	}
-	if !rig.db.verifyAccountPaid {
-		t.Fatalf("expected execution of db.AccountPaid")
-	}
-	if !rig.db.verifyCreateAccount {
-		t.Fatalf("expected execution of db.CreateAccount")
-	}
-	if rig.db.accountInfoPersisted.Host != host {
-		t.Fatalf("unexprected accountInfo Host")
-	}
-	DEXpubKey, _ := hex.DecodeString(account.DEXPubKey)
-	if !bytes.Equal(rig.db.accountInfoPersisted.DEXPubKey.SerializeCompressed(), DEXpubKey) {
-		t.Fatal("unexpected DEXPubKey")
-	}
-	feeCoin, _ := hex.DecodeString(account.FeeCoin)
-	if !bytes.Equal(rig.db.accountInfoPersisted.FeeCoin, feeCoin) {
-		t.Fatal("unexpected FeeCoin")
-	}
-	cert, _ := hex.DecodeString(account.Cert)
-	if !bytes.Equal(rig.db.accountInfoPersisted.Cert, cert) {
-		t.Fatal("unexpected Cert")
-	}
-	if !rig.db.accountInfoPersisted.Paid {
-		t.Fatal("unexpected Paid value")
-	}
-	if rig.db.accountProofPersisted.Host != host {
-		t.Fatal("unexpected accountProof Host")
-	}
-	feeProofSig, _ := hex.DecodeString(account.FeeProofSig)
-	if !bytes.Equal(rig.db.accountProofPersisted.Sig, feeProofSig) {
-		t.Fatal("unset FeeProofSig")
-	}
-	if rig.db.accountProofPersisted.Stamp != account.FeeProofStamp {
-		t.Fatal("unexpected FeeProofStamp")
-	}
-}
+// TODO: rework AccountImport
+// func TestAccountImport(t *testing.T) {
+// 	rig := newTestRig()
+// 	tCore := rig.core
+// 	host := tCore.conns[tDexHost].acct.host
+// 	account := buildTestAccount(host)
+// 	rig.queueConfig()
+// 	err := tCore.AccountImport(tPW, account)
+// 	if err != nil {
+// 		t.Fatalf("account import error: %v", err)
+// 	}
+// 	if !rig.db.verifyAccountPaid {
+// 		t.Fatalf("expected execution of db.AccountPaid")
+// 	}
+// 	if !rig.db.verifyCreateAccount {
+// 		t.Fatalf("expected execution of db.CreateAccount")
+// 	}
+// 	if rig.db.accountInfoPersisted.Host != host {
+// 		t.Fatalf("unexprected accountInfo Host")
+// 	}
+// 	DEXpubKey, _ := hex.DecodeString(account.DEXPubKey)
+// 	if !bytes.Equal(rig.db.accountInfoPersisted.DEXPubKey.SerializeCompressed(), DEXpubKey) {
+// 		t.Fatal("unexpected DEXPubKey")
+// 	}
+// 	feeCoin, _ := hex.DecodeString(account.FeeCoin)
+// 	if !bytes.Equal(rig.db.accountInfoPersisted.FeeCoin, feeCoin) {
+// 		t.Fatal("unexpected FeeCoin")
+// 	}
+// 	cert, _ := hex.DecodeString(account.Cert)
+// 	if !bytes.Equal(rig.db.accountInfoPersisted.Cert, cert) {
+// 		t.Fatal("unexpected Cert")
+// 	}
+// 	if !rig.db.accountInfoPersisted.Paid {
+// 		t.Fatal("unexpected Paid value")
+// 	}
+// 	if rig.db.accountProofPersisted.Host != host {
+// 		t.Fatal("unexpected accountProof Host")
+// 	}
+// 	feeProofSig, _ := hex.DecodeString(account.FeeProofSig)
+// 	if !bytes.Equal(rig.db.accountProofPersisted.Sig, feeProofSig) {
+// 		t.Fatal("unset FeeProofSig")
+// 	}
+// 	if rig.db.accountProofPersisted.Stamp != account.FeeProofStamp {
+// 		t.Fatal("unexpected FeeProofStamp")
+// 	}
+// }
 
 func TestAccountImportEmptyFeeProofSig(t *testing.T) {
 	rig := newTestRig()
@@ -224,24 +227,24 @@ func TestAccountImportEmptyFeeProofSig(t *testing.T) {
 	}
 }
 
-func TestAccountImportEmptyFeeProofStamp(t *testing.T) {
-	rig := newTestRig()
-	tCore := rig.core
-	host := tCore.conns[tDexHost].acct.host
-	account := buildTestAccount(host)
-	account.FeeProofStamp = 0
-	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
-	if err != nil {
-		t.Fatalf("account import error: %v", err)
-	}
-	if rig.db.verifyAccountPaid {
-		t.Fatalf("not expecting execution of db.AccountPaid")
-	}
-	if !rig.db.verifyCreateAccount {
-		t.Fatalf("expected execution of db.CreateAccount")
-	}
-}
+// func TestAccountImportEmptyFeeProofStamp(t *testing.T) {
+// 	rig := newTestRig()
+// 	tCore := rig.core
+// 	host := tCore.conns[tDexHost].acct.host
+// 	account := buildTestAccount(host)
+// 	account.FeeProofStamp = 0
+// 	rig.queueConfig()
+// 	err := tCore.AccountImport(tPW, account)
+// 	if err != nil {
+// 		t.Fatalf("account import error: %v", err)
+// 	}
+// 	if rig.db.verifyAccountPaid {
+// 		t.Fatalf("not expecting execution of db.AccountPaid")
+// 	}
+// 	if !rig.db.verifyCreateAccount {
+// 		t.Fatalf("expected execution of db.CreateAccount")
+// 	}
+// }
 
 func TestAccountImportPasswordError(t *testing.T) {
 	rig := newTestRig()

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -20,20 +20,21 @@ type DB interface {
 	ValueExists(k string) (bool, error)
 	// ListAccounts returns a list of DEX URLs. The DB is designed to have a
 	// single account per DEX, so the account is uniquely identified by the DEX
-	// URL.
+	// host.
 	ListAccounts() ([]string, error)
 	// Accounts retrieves all accounts.
 	Accounts() ([]*AccountInfo, error)
 	// Account gets the AccountInfo associated with the specified DEX node.
-	Account(url string) (*AccountInfo, error)
+	Account(host string) (*AccountInfo, error)
 	// CreateAccount saves the AccountInfo.
 	CreateAccount(ai *AccountInfo) error
 	// DisableAccount sets the AccountInfo disabled status to true.
 	DisableAccount(ai *AccountInfo) error
 	// AccountProof retrieves the AccountPoof value specified by url.
-	AccountProof(url string) (*AccountProof, error)
-	// AccountPaid marks the account as paid.
-	AccountPaid(proof *AccountProof) error
+	AccountProof(host string) (*AccountProof, error)
+	// AccountPaid marks the account as paid (fee tx sent to server).
+	AccountPaid(host string, sig []byte) error
+	ConfirmAccount(host string) error
 	// UpdateOrder saves the order information in the database. Any existing
 	// order info will be overwritten without indication.
 	UpdateOrder(m *MetaOrder) error

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -32,11 +32,14 @@ func randString(maxLen int) string {
 // RandomAccountInfo creates an AccountInfo with random values.
 func RandomAccountInfo() *db.AccountInfo {
 	return &db.AccountInfo{
-		Host:      ordertest.RandomAddress(),
-		EncKey:    randBytes(32),
-		DEXPubKey: randomPubKey(),
-		FeeCoin:   randBytes(32),
-		Cert:      randBytes(100),
+		Host:        ordertest.RandomAddress(),
+		Cert:        randBytes(100),
+		DEXPubKey:   randomPubKey(),
+		EncKey:      randBytes(32),
+		ReqFeeConfs: rand.Uint32(),
+		FeeAssetID:  rand.Uint32(),
+		FeeTx:       randBytes(123),
+		// FeeCoin:     randBytes(32),
 	}
 }
 
@@ -147,6 +150,7 @@ func RandomNotification(maxTime uint64) *db.Notification {
 }
 
 type testKiller interface {
+	Helper()
 	Fatalf(string, ...interface{})
 }
 
@@ -239,6 +243,7 @@ func MustCompareMatchProof(t testKiller, m1, m2 *db.MatchProof) {
 // MustCompareAccountInfo ensures the two AccountInfo are identical, calling the
 // Fatalf method of the testKiller if not.
 func MustCompareAccountInfo(t testKiller, a1, a2 *db.AccountInfo) {
+	t.Helper()
 	if a1.Host != a2.Host {
 		t.Fatalf("Host mismatch. %s != %s", a1.Host, a2.Host)
 	}
@@ -249,8 +254,20 @@ func MustCompareAccountInfo(t testKiller, a1, a2 *db.AccountInfo) {
 		t.Fatalf("EncKey mismatch. %x != %x",
 			a1.DEXPubKey.SerializeCompressed(), a2.DEXPubKey.SerializeCompressed())
 	}
-	if !bytes.Equal(a1.FeeCoin, a2.FeeCoin) {
-		t.Fatalf("EncKey mismatch. %x != %x", a1.FeeCoin, a2.FeeCoin)
+	// if !bytes.Equal(a1.FeeCoin, a2.FeeCoin) {
+	// 	t.Fatalf("EncKey mismatch. %x != %x", a1.FeeCoin, a2.FeeCoin)
+	// }
+
+	// TODO: FeeCoin is not part of encoding anymore, but now ReqFeeConfs,
+	// FeeAssetID, and FeeTx are, so test with those.
+	if a1.FeeAssetID != a2.FeeAssetID {
+		t.Fatalf("FeeAssetID mismatch. %s != %s", a1.FeeAssetID, a2.FeeAssetID)
+	}
+	if a1.ReqFeeConfs != a2.ReqFeeConfs {
+		t.Fatalf("ReqFeeConfs mismatch. %s != %s", a1.ReqFeeConfs, a2.ReqFeeConfs)
+	}
+	if !bytes.Equal(a1.FeeTx, a2.FeeTx) {
+		t.Fatalf("FeeTx mismatch. %x != %x", a1.FeeTx, a2.FeeTx)
 	}
 }
 

--- a/dex/encode/encode.go
+++ b/dex/encode/encode.go
@@ -4,7 +4,6 @@
 package encode
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
@@ -17,13 +16,13 @@ import (
 var (
 	// IntCoder is the DEX-wide integer byte-encoding order.
 	IntCoder = binary.BigEndian
-	// A byte-slice representation of boolean false.
+	// ByteFalse is a byte-slice representation of boolean false.
 	ByteFalse = []byte{0}
-	// A byte-slice representation of boolean true.
+	// ByteTrue is a byte-slice representation of boolean true.
 	ByteTrue = []byte{1}
-	maxU16   = int(^uint16(0))
-	bEqual   = bytes.Equal
 )
+
+const maxU16 = int(^uint16(0))
 
 // Uint64Bytes converts the uint16 to a length-2, big-endian encoded byte slice.
 func Uint16Bytes(i uint16) []byte {

--- a/dex/encode/encode_test.go
+++ b/dex/encode/encode_test.go
@@ -1,6 +1,7 @@
 package encode
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -39,7 +40,7 @@ func TestBuildyBytes(t *testing.T) {
 		for _, p := range tt.pushes {
 			b = b.AddData(p)
 		}
-		if !bEqual(b, tt.exp) {
+		if !bytes.Equal(b, tt.exp) {
 			t.Fatalf("test %d failed", i)
 		}
 	}
@@ -90,7 +91,7 @@ func TestDecodeBlob(t *testing.T) {
 		}
 		for j, push := range pushes {
 			check := tt.exp[j]
-			if !bEqual(check, push) {
+			if !bytes.Equal(check, push) {
 				t.Fatalf("push %d:%d incorrect. wanted %x, got %x", i, j, check, push)
 			}
 		}

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -241,6 +241,10 @@ sleep 15
 tmux send-keys -t $SESSION:0 "./alpha createnewaccount server_fees${WAIT}" C-m\; wait-for donedcr
 tmux send-keys -t $SESSION:0 "./alpha getmasterpubkey server_fees${WAIT}" C-m\; wait-for donedcr
 
+# Create fee account on beta wallet for use by dcrdex simnet instances.
+tmux send-keys -t $SESSION:0 "./beta createnewaccount server_fees${WAIT}" C-m\; wait-for donedcr
+tmux send-keys -t $SESSION:0 "./beta getmasterpubkey server_fees${WAIT}" C-m\; wait-for donedcr
+
 ################################################################################
 # Prepare the wallets
 ################################################################################

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -133,7 +133,10 @@ EOF
 
 # Write dcrdex.conf. The regfeexpub comes from the alpha>server_fees account.
 cat << EOF >> ./dcrdex.conf
+; alpha wallet server_fees account xpub
 regfeexpub=spubVWKGn9TGzyo7M4b5xubB5UV4joZ5HBMNBmMyGvYEaoZMkSxVG4opckpmQ26E85iHg8KQxrSVTdex56biddqtXBerG9xMN8Dvb3eNQVFFwpE
+; beta wallet server_fees account xpub
+regfeexpubnew=spubVW3qcqEFFCudsQCCm2PDReXS7ZcQfV7vWYgcXk1vzVVELPFeixrhFW5HFfCZdoGEbih6nnjoYLCUCgm63eDcbKqkAtU4z655tHqy4r9YrFa
 pgdbname=${TEST_DB}
 simnet=1
 rpclisten=127.0.0.1:17273

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/blockchain/stake/v3 v3.0.0
+	github.com/decred/dcrd/blockchain/v3 v3.0.2
 	github.com/decred/dcrd/certgen v1.1.1
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v3 v3.0.0
 	github.com/decred/dcrd/crypto/blake256 v1.0.0
+	github.com/decred/dcrd/crypto/ripemd160 v1.0.1
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.1
 	github.com/decred/dcrd/dcrec/secp256k1/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -41,7 +41,9 @@ github.com/decred/base58 v1.0.3/go.mod h1:pXP9cXCfM2sFLb2viz2FNIdeMWmZDBKG3ZBYbi
 github.com/decred/dcrd/addrmgr v1.2.0/go.mod h1:QlZF9vkzwYh0qs25C76SAFZBRscjETga/K28GEE6qIc=
 github.com/decred/dcrd/blockchain/stake/v3 v3.0.0 h1:vr0o0ICjuEzg1End6YtBfwgDuPkg+FYIwGVEz18kFg0=
 github.com/decred/dcrd/blockchain/stake/v3 v3.0.0/go.mod h1:5GIUwsrHQCJauacgCegIR6t92SaeVi28Qls/BLN9vOw=
+github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0 h1:9gUuH0u/IZNPWBK9K3CxgAWPG7nTqVSsZefpGY4Okns=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0/go.mod h1:t2qaZ3hNnxHZ5kzVJDgW5sp47/8T5hYJt7SR+/JtRhI=
+github.com/decred/dcrd/blockchain/v3 v3.0.2 h1:jrM7dTmNsvY3dzYhVOL090A3mnUnTlZdI5zt2l5SyAM=
 github.com/decred/dcrd/blockchain/v3 v3.0.2/go.mod h1:LD5VA95qdb+DlRiPI8VLBimDqvlDCAJsidZ5oD6nc/U=
 github.com/decred/dcrd/certgen v1.1.1 h1:MYPG5jCysnbF4OiJ1++YumFEu2p/MsM/zxmmqC9mVFg=
 github.com/decred/dcrd/certgen v1.1.1/go.mod h1:ivkPLChfjdAgFh7ZQOtl6kJRqVkfrCq67dlq3AbZBQE=

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -17,6 +17,7 @@ import (
 const (
 	CoinNotFoundError = dex.ErrorKind("coin not found")
 	ErrRequestTimeout = dex.ErrorKind("request timeout")
+	ErrCoinDecode     = dex.ErrorKind("invalid coin id")
 )
 
 // The Backend interface is an interface for a blockchain backend.

--- a/server/asset/dcr/addrpool.go
+++ b/server/asset/dcr/addrpool.go
@@ -1,0 +1,184 @@
+package dcr
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/decred/dcrd/crypto/ripemd160"
+	"github.com/decred/dcrd/dcrec"
+	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/decred/dcrd/hdkeychain/v3"
+)
+
+type AddressPool struct {
+	*pkhPool
+	addrParams dcrutil.AddressParams
+	storeIdx   func(uint32) // e.g. callback to a DB update
+}
+
+type HDKeyIndexer interface {
+	KeyIndex(pubKey []byte) (uint32, error)
+	SetKeyIndex(idx uint32, pubKey []byte) error
+}
+
+func NewAddressPool(acctXPub string, size uint32, keyIndexer HDKeyIndexer /*, net dex.Network */) (*AddressPool, error) {
+	key, err := hdkeychain.NewKeyFromString(acctXPub, chainParams)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing master pubkey: %w", err)
+	}
+	external, err := key.Child(0)
+	if err != nil {
+		return nil, err
+	}
+	pubkey := external.SerializedPubKey()
+	next, err := keyIndexer.KeyIndex(pubkey)
+	if err != nil {
+		return nil, err
+	}
+	hashPool := newPkhPool(external, size, next)
+	storKey := func(idx uint32) {
+		if err := keyIndexer.SetKeyIndex(idx, pubkey); err != nil {
+			fmt.Println(err)
+		}
+	}
+	return &AddressPool{
+		pkhPool:    hashPool,
+		addrParams: chainParams,
+		storeIdx:   storKey,
+	}, nil
+}
+
+// func (ap *AddressPool) PubKeyBytes() []byte {
+// 	return ap.pkhPool.xpub.SerializedPubKey()
+// }
+
+func (ap *AddressPool) Get() string {
+	next := ap.next
+	hash, i := ap.get()
+	// Record index if it is higher than previous best.
+	if i >= next {
+		ap.storeIdx(i)
+	}
+	addr, err := dcrutil.NewAddressPubKeyHash(hash[:], ap.addrParams, dcrec.STEcdsaSecp256k1)
+	if err != nil {
+		panic(err.Error()) // only errors if hash is not 20 bytes (ripemd160.Size), but we guarantee that
+	}
+	addrStr := addr.Address()
+	fmt.Printf("Retrieved address index %v: %v\n", i, addrStr)
+	return addrStr
+}
+
+func (ap *AddressPool) Owns(address string) bool {
+	addr, err := dcrutil.DecodeAddress(address, ap.addrParams)
+	if err != nil {
+		return false
+	}
+	hash := addr.Hash160()
+	if hash == nil {
+		return false // dcrutil concrete types shouldn't do this
+	}
+	return ap.owns(*hash)
+}
+
+func (ap *AddressPool) Used(address string) {
+	addr, err := dcrutil.DecodeAddress(address, ap.addrParams)
+	if err != nil {
+		fmt.Printf("(*AddressPool).Used: bad address %v: %v\n", address, err)
+		return
+	}
+	hash := addr.Hash160()
+	fmt.Printf("Marking address %v (hash160 %x) used\n", addr.Address(), hash)
+	ap.used(*hash)
+}
+
+// type pubkey [secp256k1.PubKeyBytesLenCompressed]byte
+type h160 [ripemd160.Size]byte
+
+type pkhPool struct {
+	xpub  *hdkeychain.ExtendedKey
+	size  uint32 // size of pool
+	pool  map[h160]uint32
+	next  uint32          // next child index to generate
+	owned map[h160]uint32 // pool plus used
+}
+
+func newPkhPool(key *hdkeychain.ExtendedKey, size, next uint32) *pkhPool {
+	ap := &pkhPool{
+		xpub:  key,
+		pool:  make(map[h160]uint32, size),
+		owned: make(map[h160]uint32, next+size),
+		size:  size, // must not be zero
+	}
+
+	// Fill out owned up to next.
+	for ap.next < next {
+		child, i := getChild(ap.xpub, ap.next)
+		if child == nil {
+			panic("can't make child key")
+		}
+
+		pkb := child.SerializedPubKey()
+		hashBytes := dcrutil.Hash160(pkb)
+		var hash h160
+		copy(hash[:], hashBytes)
+		ap.owned[hash] = i
+		ap.next = i + 1
+		// pool is empty to start. Next get() will derive new for pool.
+	}
+
+	return ap
+}
+
+func (ap *pkhPool) get() (hash h160, i uint32) {
+	// Only derive if pool hasn't filled yet.
+	if len(ap.pool) < int(ap.size) {
+		// Generate a new one for the pool.
+		var child *hdkeychain.ExtendedKey
+		child, i = getChild(ap.xpub, ap.next)
+		pkb := child.SerializedPubKey()
+		hashBytes := dcrutil.Hash160(pkb)
+		copy(hash[:], hashBytes)
+		ap.pool[hash] = i
+		ap.owned[hash] = i
+		ap.next = i + 1
+		return hash, i
+	}
+
+	// Grab a random one from the pool.
+	for hash, i = range ap.pool {
+		break
+	}
+	return hash, i
+}
+
+func (ap *pkhPool) owns(hash h160) bool {
+	// First check the smaller pool, then the full set.
+	_, found := ap.pool[hash]
+	if !found {
+		_, found = ap.owned[hash]
+	}
+	return found
+}
+
+func (ap *pkhPool) used(hash h160) {
+	if idx, found := ap.pool[hash]; found {
+		delete(ap.pool, hash)
+		fmt.Printf("Deleting hash160 %x, index %d from pool\n", hash, idx)
+	}
+	// If delete removed it, next get() will derive new for pool.
+}
+
+func getChild(xkey *hdkeychain.ExtendedKey, i uint32) (*hdkeychain.ExtendedKey, uint32) {
+	for {
+		child, err := xkey.Child(i)
+		switch {
+		case errors.Is(err, hdkeychain.ErrInvalidChild):
+			i++
+			continue
+		case err == nil:
+			return child, i
+		default:
+			panic(err.Error()) // bad xkey or something
+		}
+	}
+}

--- a/server/asset/dcr/addrpool_test.go
+++ b/server/asset/dcr/addrpool_test.go
@@ -1,0 +1,54 @@
+package dcr
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/dcrec"
+	"github.com/decred/dcrd/dcrutil/v3"
+	"github.com/decred/dcrd/hdkeychain/v3"
+)
+
+func TestChildSearch(t *testing.T) {
+	feeKey := "spubVWKGn9TGzyo7M4b5xubB5UV4joZ5HBMNBmMyGvYEaoZMkSxVG4opckpmQ26E85iHg8KQxrSVTdex56biddqtXBerG9xMN8Dvb3eNQVFFwpE"
+	params := chaincfg.SimNetParams()
+
+	findAddrStr := "SsehuQp6u2rXaKDHiyPoV6PusbatnsE5o96"
+	findAddr, _ := dcrutil.DecodeAddress(findAddrStr, params)
+	// findIdx := uint32(4271)
+
+	// Get the master extended public key.
+	masterKey, err := hdkeychain.NewKeyFromString(feeKey, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	feeKeyBranch, err := masterKey.Child(0) // external branch
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pool := newPkhPool(feeKeyBranch, 20, 10_000)
+
+	// num := uint32(10_000)
+	// addrs := make(map[h160]uint32, num)
+
+	for i := uint32(0); i < 10; i++ {
+		hash, _ := pool.get()
+		_, err := dcrutil.NewAddressPubKeyHash(hash[:], params, dcrec.STEcdsaSecp256k1)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if !pool.owns(*findAddr.Hash160()) {
+		t.Error("not found")
+	}
+
+	// idx, found := addrs[*findAddr.Hash160()]
+	// if !found {
+	// 	t.Fatal("not found")
+	// }
+	// if idx != findIdx {
+	// 	t.Errorf("%d != %d", idx, findIdx)
+	// }
+}

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -101,7 +101,10 @@ func (s *TStorage) AllActiveUserMatches(account.AccountID) ([]*db.MatchData, err
 func (s *TStorage) MatchStatuses(aid account.AccountID, base, quote uint32, matchIDs []order.MatchID) ([]*db.MatchStatus, error) {
 	return s.matchStatuses, nil
 }
-func (s *TStorage) CreateAccount(*account.Account) (string, error)   { return s.acctAddr, s.acctErr }
+func (s *TStorage) CreateAccount(*account.Account) (string, error) { return s.acctAddr, s.acctErr }
+func (s *TStorage) CreateAccountWithTx(acct *account.Account, regAddr string, rawTx []byte) error {
+	return s.acctErr
+}
 func (s *TStorage) AccountRegAddr(account.AccountID) (string, error) { return s.regAddr, s.regErr }
 func (s *TStorage) PayAccount(account.AccountID, []byte) error       { return s.payErr }
 func (s *TStorage) setRatioData(dat *ratioData) {
@@ -116,10 +119,12 @@ func (s *TStorage) ExecutedCancelsForUser(aid account.AccountID, _ int) (oids, t
 
 // TSigner satisfies the Signer interface
 type TSigner struct {
-	sig    *ecdsa.Signature
+	sig *ecdsa.Signature
+	//privKey *secp256k1.PrivateKey
 	pubkey *secp256k1.PublicKey
 }
 
+// Maybe actually change this to an ecdsa.Sign with a private key instead?
 func (s *TSigner) Sign(hash []byte) *ecdsa.Signature { return s.sig }
 func (s *TSigner) PubKey() *secp256k1.PublicKey      { return s.pubkey }
 
@@ -214,14 +219,15 @@ type tUser struct {
 	privKey *secp256k1.PrivateKey
 }
 
+// makes a new user with its own account ID, tRPCClient
 func tNewUser(t *testing.T) *tUser {
 	conn := tNewRPCClient()
-	// register the RPCClient with a 'connect' Message
-	acctID := newAccountID()
+	// acctID := newAccountID()
 	privKey, err := secp256k1.GeneratePrivateKey()
 	if err != nil {
 		t.Fatalf("error generating private key: %v", err)
 	}
+	acctID := account.NewID(privKey.PubKey().SerializeCompressed())
 	return &tUser{
 		conn:    conn,
 		acctID:  acctID,
@@ -240,6 +246,20 @@ type testRig struct {
 }
 
 var rig *testRig
+
+type tAddrPooler struct {
+	addr string
+}
+
+var _ AddressPooler = (*tAddrPooler)(nil)
+
+func (ap *tAddrPooler) Get() string {
+	return ap.addr
+}
+func (ap *tAddrPooler) Owns(address string) bool {
+	return address == ap.addr
+}
+func (ap *tAddrPooler) Used(address string) {}
 
 type tSignable struct {
 	b   []byte
@@ -327,10 +347,25 @@ var (
 	tCheckFeeVal   uint64 = 500_000_000
 	tCheckFeeConfs int64  = 5
 	tCheckFeeErr   error
+
+	tParseFeeTxAddr string
+	tParseFeeTxAcct account.AccountID
+	tParseFeeTxErr  error
+
+	tSentFeeCoinID []byte
+	tSendFeeTxErr  error
 )
 
 func tCheckFee([]byte) (addr string, val uint64, confs int64, err error) {
 	return tCheckFeeAddr, tCheckFeeVal, tCheckFeeConfs, tCheckFeeErr
+}
+
+func tParseTxFee(rawTx []byte, wantFee int64) (addr string, acct account.AccountID, err error) {
+	return tParseFeeTxAddr, tParseFeeTxAcct, tParseFeeTxErr
+}
+
+func tSendFeeTx(rawTx []byte) (coinid []byte, err error) {
+	return tSentFeeCoinID, tSendFeeTxErr
 }
 
 const (
@@ -355,18 +390,22 @@ func TestMain(m *testing.M) {
 		ctx, shutdown := context.WithCancel(context.Background())
 		defer shutdown()
 		storage := &TStorage{acctAddr: tFeeAddr, regAddr: tCheckFeeAddr}
+		// secp256k1.PrivKeyFromBytes
 		dexKey, _ := secp256k1.ParsePubKey(tDexPubKeyBytes)
 		signer := &TSigner{pubkey: dexKey}
 		authMgr := NewAuthManager(&Config{
-			Storage:         storage,
-			Signer:          signer,
-			RegistrationFee: tRegFee,
-			FeeConfs:        tCheckFeeConfs,
-			FeeChecker:      tCheckFee,
-			UserUnbooker:    func(account.AccountID) {},
-			MiaUserTimeout:  90 * time.Second, // TODO: test
-			CancelThreshold: 0.9,
-			TxDataSources:   make(map[uint32]TxDataSource),
+			Storage:          storage,
+			Signer:           signer,
+			RegistrationFee:  tRegFee,
+			FeeConfs:         tCheckFeeConfs,
+			FeeChecker:       tCheckFee,
+			FeeTxParser:      tParseTxFee,
+			FeeTxSender:      tSendFeeTx,
+			FeeAddressPooler: &tAddrPooler{}, // TODO: set an address
+			UserUnbooker:     func(account.AccountID) {},
+			MiaUserTimeout:   90 * time.Second, // TODO: test
+			CancelThreshold:  0.9,
+			TxDataSources:    make(map[uint32]TxDataSource),
 		})
 		go authMgr.Run(ctx)
 		rig = &testRig{
@@ -838,7 +877,10 @@ func TestConnect(t *testing.T) {
 	connectUser(t, reuser)
 	a10 := &tPayload{A: 10}
 	msg, _ = msgjson.NewRequest(comms.NextID(), "request", a10)
-	rig.mgr.RequestWithTimeout(reuser.acctID, msg, func(comms.Link, *msgjson.Message) {}, time.Minute, func() {})
+	err = rig.mgr.RequestWithTimeout(reuser.acctID, msg, func(comms.Link, *msgjson.Message) {}, time.Minute, func() {})
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
 	// The a10 message should be in the new connection
 	if user.conn.getReq() != nil {
 		t.Fatalf("old connection received a request after reconnection")
@@ -924,7 +966,8 @@ func TestAccountErrors(t *testing.T) {
 	if client == nil {
 		t.Fatalf("client not found")
 	}
-	if !client.isSuspended() {
+	_, suspended := client.acctStatus()
+	if !suspended {
 		t.Errorf("client should have been in suspended state")
 	}
 
@@ -1245,8 +1288,100 @@ func TestHandleResponse(t *testing.T) {
 	client.mtx.Unlock()
 }
 
+func TestHandlePreregister(t *testing.T) {
+	user := tNewUser(t)
+	rig.mgr.feeAddrPool.(*tAddrPooler).addr = tFeeAddr
+	req := msgjson.PreRegister{AssetID: 42}
+	msg, err := msgjson.NewRequest(comms.NextID(), msgjson.PreRegisterRoute, &req)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+
+	// ensure there are no sends waiting first
+	respMsg := user.conn.getSend()
+	if respMsg != nil {
+		b, _ := json.Marshal(respMsg)
+		t.Fatalf("unexpected response: %s", string(b))
+	}
+
+	rig.signer.sig = user.randomSignature()
+	rpcErr := rig.mgr.handlePreRegister(user.conn, msg)
+	if rpcErr != nil {
+		t.Fatalf("error for valid registration: %s", rpcErr.Message)
+	}
+	respMsg = user.conn.getSend()
+	if respMsg == nil {
+		t.Fatalf("no preregister response")
+	}
+	resp, _ := respMsg.Response()
+	preregRes := new(msgjson.PreRegisterResult)
+	err = json.Unmarshal(resp.Result, preregRes)
+	if err != nil {
+		t.Fatalf("error unmarshaling payload")
+	}
+
+	if preregRes.DEXPubKey.String() != tDexPubKeyHex {
+		t.Fatalf("wrong DEX pubkey. expected %s, got %s", tDexPubKeyHex, preregRes.DEXPubKey.String())
+	}
+	if preregRes.Address != tFeeAddr {
+		t.Fatalf("wrong fee address. expected %s, got %s", tFeeAddr, preregRes.Address)
+	}
+	if preregRes.Fee != tRegFee {
+		t.Fatalf("wrong fee. expected %d, got %d", tRegFee, preregRes.Fee)
+	}
+}
+
+func TestHandlePayFee(t *testing.T) {
+	user := tNewUser(t)
+	resetStorage()
+	rig.mgr.feeAddrPool.(*tAddrPooler).addr = tFeeAddr
+
+	payfee := &msgjson.PayFee{
+		PubKey:   user.privKey.PubKey().SerializeCompressed(),
+		AssetID:  42,
+		RawFeeTx: nil, // TODO: make a tx that decodes
+	}
+	sigMsg := payfee.Serialize()
+	sig := ecdsa.Sign(user.privKey, sigMsg)
+	payfee.SetSig(sig.Serialize())
+
+	msg, err := msgjson.NewRequest(comms.NextID(), msgjson.PayFeeRoute, payfee)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+
+	// ensure there are no sends waiting first
+	respMsg := user.conn.getSend()
+	if respMsg != nil {
+		b, _ := json.Marshal(respMsg)
+		t.Fatalf("unexpected response: %s", string(b))
+	}
+
+	// Make parseFeeTx return the address in the pooler and the account
+	// commitment for this user.
+	tParseFeeTxAddr = tFeeAddr
+	tParseFeeTxAcct = user.acctID
+	tParseFeeTxErr = nil
+	rig.signer.sig = user.randomSignature()
+	rpcErr := rig.mgr.handlePayFee(user.conn, msg)
+	if rpcErr != nil {
+		t.Fatalf("error for valid registration: %s", rpcErr.Message)
+	}
+	respMsg = user.conn.getSend()
+	if respMsg == nil {
+		t.Fatalf("no payfee response")
+	}
+	resp, _ := respMsg.Response()
+	payfeeRes := new(msgjson.PayFeeResult)
+	err = json.Unmarshal(resp.Result, payfeeRes)
+	if err != nil {
+		t.Fatalf("error unmarshaling payload")
+	}
+}
+
 func TestHandleRegister(t *testing.T) {
 	user := tNewUser(t)
+	resetStorage()
 	dummyError := fmt.Errorf("test error")
 
 	newReg := func() *msgjson.Register {
@@ -1275,6 +1410,10 @@ func TestHandleRegister(t *testing.T) {
 	ensureErr := makeEnsureErr(t)
 
 	msg := newMsg(newReg())
+	msg.Payload = []byte(`null`)
+	ensureErr(do(msg), "null payload", msgjson.RPCParseError)
+
+	msg = newMsg(newReg())
 	msg.Payload = []byte(`?`)
 	ensureErr(do(msg), "bad payload", msgjson.RPCParseError)
 
@@ -1405,7 +1544,7 @@ func TestHandleNotifyFee(t *testing.T) {
 	rig.storage.acct = userAcct
 
 	// account already paid
-	ensureErr(do(newMsg(newNotify())), "already paid", msgjson.AuthenticationError)
+	ensureErr(do(newMsg(newNotify())), "already paid", msgjson.AccountExistsError)
 
 	// Signature error
 	rig.storage.unpaid = true // notifyfee cannot be sent for paid account

--- a/server/auth/registrar.go
+++ b/server/auth/registrar.go
@@ -17,18 +17,321 @@ import (
 
 var (
 	// The coin waiters will query for transaction data every recheckInterval.
+	// TODO: increase this duration when notifyfee is removed and all clients do
+	// payfee instead since only the former are expected to be at feeConfs
+	// initially; with payfee they start unconfirmed.
 	recheckInterval = time.Second * 5
 	// txWaitExpiration is the longest the AuthManager will wait for a coin
 	// waiter. This could be thought of as the maximum allowable backend latency.
 	txWaitExpiration = time.Minute
 )
 
+const regFeeAssetID = 42 // DCR, TODO: make AuthManager field
+
+// handlePreRegister handles the 'preregister' request. A fee address is
+// obtained from the pool, and returned along with the fee amount and the DEX
+// pubkey in a PreRegisterResult. The user should then generate a fee payment
+// transaction according to server/asset/dcr.ParseFeeTx and provide it via the
+// 'payfee' request.
+func (auth *AuthManager) handlePreRegister(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
+	preReg := new(msgjson.PreRegister)
+	err := json.Unmarshal(msg.Payload, &preReg)
+	if err != nil || preReg == nil {
+		return msgjson.NewError(msgjson.FeeError, "error parsing preregister request")
+	}
+
+	if preReg.AssetID != regFeeAssetID {
+		// TODO: handle multiple fee assets
+		return &msgjson.Error{
+			Code:    msgjson.RPCInternalError,
+			Message: "unsupported registration fee asset",
+		}
+	}
+
+	feeAddr := auth.feeAddrPool.Get()
+	if feeAddr == "" {
+		log.Errorf("Failed to acquire new fee address.")
+		return &msgjson.Error{
+			Code:    msgjson.RPCInternalError,
+			Message: "internal error",
+		}
+	}
+
+	log.Infof("Sending fee address %v (asset %d) and amount %v to client from %v",
+		feeAddr, regFeeAssetID, auth.regFee, conn.Addr())
+
+	regRes := &msgjson.PreRegisterResult{
+		DEXPubKey: auth.signer.PubKey().SerializeCompressed(),
+		AssetID:   regFeeAssetID,
+		Address:   feeAddr,
+		Fee:       auth.regFee,
+	}
+	auth.Sign(regRes)
+
+	resp, err := msgjson.NewResponse(msg.ID, regRes, nil)
+	if err != nil {
+		log.Errorf("error creating new response for registration result: %v", err)
+		return &msgjson.Error{
+			Code:    msgjson.RPCInternalError,
+			Message: "internal error",
+		}
+	}
+
+	err = conn.Send(resp)
+	if err != nil {
+		log.Warnf("Error sending register result to link: %v", err)
+	}
+
+	return nil
+}
+
+func (auth *AuthManager) feeWaiterExists(acctID account.AccountID) bool {
+	auth.feeWaiterMtx.Lock()
+	defer auth.feeWaiterMtx.Unlock()
+	_, found := auth.feeWaiterIdx[acctID]
+	return found
+}
+
+func (auth *AuthManager) registerFeeWaiter(acctID account.AccountID) bool {
+	auth.feeWaiterMtx.Lock()
+	defer auth.feeWaiterMtx.Unlock()
+	if _, found := auth.feeWaiterIdx[acctID]; found {
+		return false
+	}
+	auth.feeWaiterIdx[acctID] = struct{}{}
+	return true
+}
+
+func (auth *AuthManager) removeFeeWaiter(acctID account.AccountID) {
+	auth.feeWaiterMtx.Lock()
+	delete(auth.feeWaiterIdx, acctID)
+	auth.feeWaiterMtx.Unlock()
+}
+
+// handlePayFee handles the 'payfee' request, which follows a 'preregister'
+// request. The request payload includes the user's account public key and the
+// serialized fee payment transaction itself (not just the txid). The
+// AuthManager's parseFeeTx function (a field) is used to perform basic
+// validation of the transaction, and extract the used fee address and account
+// ID to which it commits. handlePayFee then checks that the fee address is
+// owned by the feeAddrPool, and that the account to which the transaction
+// commits corresponds to the user's public key provided in the PayFee payload.
+// If these requirements are satisfied, the transaction is broadcasted with the
+// AuthManager's sendFee function. If the transaction is accepted by the asset
+// backend (should be a fully-validating node), the fee address is "returned" to
+// the address pool so it will not be issued in future preregister request, and
+// the user's account is created in the database. Finally, a fee waiter
+// goroutine is launched to wait for the transaction to reach feeConfs. The fee
+// waiter uses the same check function (the validateFee method) as used in the
+// legacy notifyfee protocol.
+func (auth *AuthManager) handlePayFee(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
+	payFee := new(msgjson.PayFee)
+	err := json.Unmarshal(msg.Payload, &payFee)
+	if err != nil || payFee == nil {
+		return msgjson.NewError(msgjson.FeeError, "error parsing payfee request")
+	}
+
+	if payFee.AssetID != regFeeAssetID {
+		// TODO: handle multiple fee assets
+		return &msgjson.Error{
+			Code:    msgjson.RPCInternalError,
+			Message: "unsupported registration fee asset",
+		}
+	}
+
+	// Create account.Account from pubkey.
+	acct, err := account.NewAccountFromPubKey(payFee.PubKey)
+	if err != nil {
+		return msgjson.NewError(msgjson.FeeError, "error parsing account pubkey: "+err.Error())
+	}
+	acctID := acct.ID
+
+	// Check signature first to ensure this message is from the account owner.
+	sigMsg := payFee.Serialize()
+	err = checkSigS256(sigMsg, payFee.SigBytes(), acct.PubKey)
+	if err != nil {
+		return msgjson.NewError(msgjson.FeeError, "signature error: "+err.Error())
+	}
+
+	// Stop if the account already exists or is already paid.
+	if dbAcct, paid, _, _ := auth.storage.Account(acctID); dbAcct != nil {
+		if paid {
+			// if !confirmed && !auth.feeWaiterExists(acctID) { /* start over with new tx? */ }
+			return &msgjson.Error{
+				// Client should recognize this code and mark their account paid
+				// (TODO client-side).
+				Code:    msgjson.AccountExistsError,
+				Message: "account already exists",
+			}
+			// Instead, server could issue positive response again if we could
+			// verify the account was created with same data.
+		}
+
+		// The account would only exist if they already used payfee or the old
+		// 'register' route, which should not be mixed with payfee.
+		return &msgjson.Error{
+			Code:    msgjson.AuthenticationError,
+			Message: "existing unpaid account is invalid with payfee (want notify_fee?)",
+		}
+	}
+
+	// decode raw tx, check fee output (0) and account commitment output (1)
+	feeAddr, commitAcct, err := auth.parseFeeTx(payFee.RawFeeTx, int64(auth.regFee))
+	if err != nil {
+		return msgjson.NewError(msgjson.FeeError, "invalid fee transaction: %v", err)
+	}
+
+	// Must be equal to account ID computed from pubkey in the PayFee message.
+	if commitAcct != acctID {
+		return msgjson.NewError(msgjson.FeeError, "invalid fee transaction - account commitment does not match pubkey")
+	}
+
+	if !auth.feeAddrPool.Owns(feeAddr) {
+		return msgjson.NewError(msgjson.FeeError, "invalid fee transaction - invalid fee address")
+	}
+
+	// Broadcast the txn.
+	log.Infof("Broadcasting fee transaction %v for account %v", payFee.RawFeeTx, acctID)
+	feeCoin, err := auth.sendFee(payFee.RawFeeTx)
+	if err != nil {
+		return msgjson.NewError(msgjson.FeeError, "invalid fee transaction: %v", err.Error())
+	}
+
+	auth.feeAddrPool.Used(feeAddr)
+
+	log.Infof("Created new user account %v from %v with fee address %v, paid in %x",
+		acctID, conn.Addr(), feeAddr, feeCoin)
+
+	// Register account. When the tx is fully confirmed, storage.PayAccount
+	// should be called to store the feeCoin (see waitFeeConfs).
+	err = auth.storage.CreateAccountWithTx(acct, feeAddr, payFee.RawFeeTx)
+	if err != nil {
+		log.Debugf("CreateAccount(%v) failed: %v", acct, err)
+		return &msgjson.Error{
+			Code:    msgjson.RPCInternalError,
+			Message: "failed to create new account (already registered?)",
+		}
+	}
+
+	// Respond with a PayFeeResult.
+	payFeeRes := &msgjson.PayFeeResult{FeeCoin: feeCoin}
+	auth.Sign(payFee) // signature in our response is our signature of their request
+	payFeeRes.SetSig(payFee.SigBytes())
+	resp, err := msgjson.NewResponse(msg.ID, payFeeRes, nil)
+	if err != nil { // shouldn't be possible
+		return msgjson.NewError(msgjson.RPCInternalError, "internal encoding error")
+	}
+
+	err = conn.Send(resp)
+	if err != nil {
+		// If client attempts payfee again, they should recognize the
+		// AccountExistsError error and mark their account paid.
+		log.Warnf("error sending payfee result to link: %v", err)
+	}
+
+	// Start waiter, which marks the account paid by storing the fee coin ID.
+	if !auth.registerFeeWaiter(acctID) {
+		// This should be impossible since payfee prevents existing accounts
+		// from getting here.
+		return msgjson.NewError(msgjson.FeeWaiterRunningError,
+			"already waiting for your fee transaction to reach the required confirmations")
+	}
+
+	// TODO: Startup of AuthManager should recreate waiters for accounts with a
+	// raw tx recorded but not yet paid.
+
+	auth.latencyQ.Wait(&wait.Waiter{
+		Expiration: time.Now().Add(24 * time.Hour), // waiting for auth.feeConfs
+		TryFunc: func() bool {
+			res := auth.waitFeeConfs(conn, feeCoin, acctID, feeAddr)
+			if res == wait.DontTryAgain {
+				auth.removeFeeWaiter(acctID)
+			}
+			return res
+		},
+		ExpireFunc: func() {
+			auth.removeFeeWaiter(acctID)
+			auth.coinNotFound(acctID, msg.ID, feeCoin)
+		},
+	})
+	return nil
+}
+
+// waitFeeConfs is a coin waiter that should be started after validating and
+// broadcasting a fee payment transaction in the payfee request handler. This
+// waits for the transaction output referenced by coinID to reach auth.feeConfs,
+// and then re-validates the amount and address to which the coinID pays. If the
+// checks pass, the account is marked as paid in storage by saving the coinID
+// for the accountID. Finally, a FeePaidNotification is sent to the provided
+// conn. In case the notification fails to send (e.g. connection no longer
+// active), the user should check paid status on 'connect'.
+func (auth *AuthManager) waitFeeConfs(conn comms.Link, coinID []byte, acctID account.AccountID, regAddr string) bool {
+	addr, val, confs, err := auth.checkFee(coinID)
+	if err != nil || confs < auth.feeConfs {
+		return wait.TryAgain // TODO: consider other errors that should fail instead, e.g. errcoindecode
+	}
+
+	// Verify the fee amount and address. This should be redundant for payfee
+	// requests, but it is possible that checkFee could disagree. If these
+	// happen there is a bug in the fee asset backend, and the operator will
+	// need to intervene.
+	if val < auth.regFee {
+		log.Errorf("checkFee: account %v fee coin %x pays %d; expected %d",
+			acctID, coinID, val, auth.regFee)
+		return wait.DontTryAgain
+	}
+	if addr != regAddr {
+		log.Errorf("checkFee: account %v fee coin %x pays to %s; %s",
+			acctID, coinID, addr, regAddr)
+		return wait.DontTryAgain
+	}
+
+	// Mark the account as paid by storing the coin ID.
+	err = auth.storage.PayAccount(acctID, coinID)
+	if err != nil {
+		log.Errorf("Failed to mark account %v as paid with coin %x", acctID, coinID)
+		return wait.DontTryAgain
+	}
+	if client := auth.user(acctID); client != nil {
+		client.confirm()
+	}
+
+	log.Infof("New user registered: acct %v from %v paid %d to %v", acctID, conn.Addr(), val, addr)
+
+	// PayFeeResult was sent immediately after broadcast. Now we notify that the
+	// tranaction has reached feeConfs, but client can watch the confirmation
+	// count theirself.
+	feePaidNtfn := &msgjson.FeePaidNotification{AccountID: acctID[:]}
+	auth.Sign(feePaidNtfn)
+	resp, err := msgjson.NewNotification(msgjson.FeePaidRoute, feePaidNtfn)
+	if err != nil {
+		log.Error("FeePaidRoute encoding error: %v", err)
+		return wait.DontTryAgain
+	}
+
+	// First attempt to send the feepaid notification on the provided link. If
+	// it is down, attempt to send to via the auth manager by account ID.
+	err = conn.Send(resp)
+	if err != nil {
+		// The original link may be lost. See if they have an authenticated
+		// connection.
+		if err = auth.Send(acctID, resp); err != nil {
+			log.Warnf("Error sending feepaid notification to account %v: %v", acctID, err)
+			// The user will need to 'connect' to see confirmed status.
+		}
+	}
+
+	return wait.DontTryAgain
+}
+
 // handleRegister handles requests to the 'register' route.
+//
+// DEPRECATED
 func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
 	// Unmarshal.
 	register := new(msgjson.Register)
 	err := json.Unmarshal(msg.Payload, &register)
-	if err != nil {
+	if err != nil || register == nil {
 		return &msgjson.Error{
 			Code:    msgjson.RPCParseError,
 			Message: "error parsing register request",
@@ -72,7 +375,7 @@ func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *
 		ClientPubKey: register.PubKey,
 		Address:      feeAddr,
 		Fee:          auth.regFee,
-		Time:         encode.UnixMilliU((unixMsNow())),
+		Time:         encode.UnixMilliU(unixMsNow()),
 	}
 	auth.Sign(regRes)
 
@@ -94,11 +397,13 @@ func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *
 }
 
 // handleNotifyFee handles requests to the 'notifyfee' route.
+//
+// DEPRECATED
 func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
 	// Unmarshal.
 	notifyFee := new(msgjson.NotifyFee)
 	err := json.Unmarshal(msg.Payload, &notifyFee)
-	if err != nil {
+	if err != nil || notifyFee == nil {
 		return &msgjson.Error{
 			Code:    msgjson.RPCParseError,
 			Message: "error parsing notifyfee request",
@@ -116,7 +421,7 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 	var acctID account.AccountID
 	copy(acctID[:], notifyFee.AccountID)
 
-	acct, paid, open := auth.storage.Account(acctID)
+	acct, paid, confirmed, open := auth.storage.Account(acctID)
 	if acct == nil {
 		return &msgjson.Error{
 			Code:    msgjson.AuthenticationError,
@@ -130,9 +435,15 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 		}
 	}
 	if paid {
+		if !confirmed {
+			// they shouldn't be using notify_fee, but maybe we could stat waitFeeConfs
+			return &msgjson.Error{Code: msgjson.FeeError, Message: "route not applicable"}
+		}
 		return &msgjson.Error{
-			Code:    msgjson.AuthenticationError,
-			Message: "'notifyfee' send for paid account",
+			// Client should recognize this code and mark their account paid
+			// (TODO client-side).
+			Code:    msgjson.AccountExistsError,
+			Message: "'notifyfee' sent for paid account",
 		}
 	}
 
@@ -192,12 +503,18 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 	return nil
 }
 
-// validateFee is a coin waiter that validates a client's notifyFee request and
-// responds with an Acknowledgement.
-func (auth *AuthManager) validateFee(conn comms.Link, acctID account.AccountID, notifyFee *msgjson.NotifyFee, msgID uint64, coinID []byte, regAddr string) bool {
+// validateFee is a coin waiter that validates a client's notifyfee request and
+// responds with an Acknowledgement when it reaches the required number of
+// confirmations (feeConfs). The database's PayAccount method is used to store
+// the coinID of the fully-confirmed fee transaction, which is the current
+// indicator that the account is paid. This is done for backward compatibility
+// and may change a future DB scheme.
+//
+// DEPRECATED
+func (auth *AuthManager) validateFee(conn comms.Link, acctID account.AccountID, clientReq msgjson.Signable, msgID uint64, coinID []byte, regAddr string) bool {
 	addr, val, confs, err := auth.checkFee(coinID)
 	if err != nil || confs < auth.feeConfs {
-		return wait.TryAgain
+		return wait.TryAgain // TODO: consider other errors that should fail instead, e.g. errcoindecode
 	}
 	var msgErr *msgjson.Error
 	defer func() {
@@ -213,6 +530,8 @@ func (auth *AuthManager) validateFee(conn comms.Link, acctID account.AccountID, 
 			}
 		}
 	}()
+
+	// Verify the fee amount and address.
 	if val < auth.regFee {
 		msgErr = &msgjson.Error{
 			Code:    msgjson.FeeError,
@@ -228,7 +547,7 @@ func (auth *AuthManager) validateFee(conn comms.Link, acctID account.AccountID, 
 		return wait.DontTryAgain
 	}
 
-	// Mark the account as paid
+	// Mark the account as paid by storing the coin ID.
 	err = auth.storage.PayAccount(acctID, coinID)
 	if err != nil {
 		log.Errorf("Failed to mark account %v as paid with coin %x", acctID, coinID)
@@ -242,9 +561,9 @@ func (auth *AuthManager) validateFee(conn comms.Link, acctID account.AccountID, 
 	log.Infof("New user registered: acct %v from %v paid %d to %v", acctID, conn.Addr(), val, addr)
 
 	// Create, sign, and send the the response.
-	auth.Sign(notifyFee)
+	auth.Sign(clientReq)
 	notifyRes := new(msgjson.NotifyFeeResult)
-	notifyRes.SetSig(notifyFee.SigBytes())
+	notifyRes.SetSig(clientReq.SigBytes())
 	resp, err := msgjson.NewResponse(msgID, notifyRes, nil)
 	if err != nil {
 		msgErr = &msgjson.Error{
@@ -253,6 +572,7 @@ func (auth *AuthManager) validateFee(conn comms.Link, acctID account.AccountID, 
 		}
 		return wait.DontTryAgain
 	}
+
 	err = conn.Send(resp)
 	if err != nil {
 		log.Warnf("error sending notifyfee result to link: %v", err)

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -78,6 +78,7 @@ type dexConf struct {
 	ShowPGConfig      bool
 	MarketsConfPath   string
 	RegFeeXPub        string
+	RegFeeXPubNEW     string
 	RegFeeConfirms    int64
 	RegFeeAmount      uint64
 	CancelThreshold   float64
@@ -125,6 +126,7 @@ type flagsData struct {
 	BroadcastTimeout time.Duration `long:"bcasttimeout" description:"The broadcast timeout specifies how long clients have to broadcast an expected transaction when it is their turn to act. Matches without the expected action by this time are revoked and the actor is penalized."`
 	DEXPrivKeyPath   string        `long:"dexprivkeypath" description:"The path to a file containing the DEX private key for message signing."`
 	RegFeeXPub       string        `long:"regfeexpub" description:"The extended public key for deriving Decred addresses to which DEX registration fees should be paid."`
+	RegFeeXPubNew    string        `long:"regfeexpubnew" description:"The extended public key for deriving Decred addresses to which DEX registration fees should be paid (new scheme)."`
 	RegFeeConfirms   int64         `long:"regfeeconfirms" description:"The number of confirmations required to consider a registration fee paid."`
 	RegFeeAmount     uint64        `long:"regfeeamount" description:"The registration fee amount in atoms."`
 
@@ -587,6 +589,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		RegFeeAmount:      cfg.RegFeeAmount,
 		RegFeeConfirms:    cfg.RegFeeConfirms,
 		RegFeeXPub:        cfg.RegFeeXPub,
+		RegFeeXPubNEW:     cfg.RegFeeXPubNew,
 		CancelThreshold:   cfg.CancelThreshold,
 		MaxUserCancels:    cfg.MaxUserCancels,
 		Anarchy:           cfg.Anarchy,

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -127,6 +127,7 @@ func mainCore(ctx context.Context) error {
 			ShowPGConfig: cfg.ShowPGConfig,
 		},
 		RegFeeXPub:        cfg.RegFeeXPub,
+		RegFeeXPubNEW:     cfg.RegFeeXPubNEW,
 		RegFeeAmount:      cfg.RegFeeAmount,
 		RegFeeConfirms:    cfg.RegFeeConfirms,
 		BroadcastTimeout:  cfg.BroadcastTimeout,

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -529,27 +529,6 @@ func (a *Archiver) storeOrder(ord order.Order, epochIdx, epochDur int64, status 
 		}
 	}
 
-	// If enabled, search all tables for the order to ensure it is not already
-	// stored somewhere.
-	// if a.checkedStores {
-	// 	var foundStatus pgOrderStatus
-	// 	switch ord.Type() {
-	// 	case order.MarketOrderType, order.LimitOrderType:
-	// 		foundStatus, _, _, err = orderStatus(a.db, ord.ID(), a.dbName, marketSchema)
-	// 	case order.CancelOrderType:
-	// 		foundStatus, err = cancelOrderStatus(a.db, ord.ID(), a.dbName, marketSchema)
-	// 	}
-	//
-	// 	if err == nil {
-	// 		return fmt.Errorf("attempted to store a %s order while it exists "+
-	// 			"in another table as %s", pgToMarketStatus(status), pgToMarketStatus(foundStatus))
-	// 	}
-	// 	if !db.IsErrOrderUnknown(err) {
-	// 		a.fatalBackendErr(err)
-	// 		return fmt.Errorf("findOrder failed: %v", err)
-	// 	}
-	// }
-
 	// Check for order commitment duplicates. This also covers order ID since
 	// commitment is part of order serialization. Note that it checks ALL
 	// markets, so this may be excessive. This check may be more appropriate in

--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -69,9 +69,8 @@ func openDB() (func() error, error) {
 		ShowPGConfig: false,
 		QueryTimeout: 0, // zero to use the default
 		MarketCfg:    []*dex.MarketInfo{mktInfo, mktInfo2},
-		//CheckedStores: true,
-		Net:    dex.Mainnet,
-		FeeKey: "dprv3hCznBesA6jBu1MaSqEBewG76yGtnG6LWMtEXHQvh3MVo6rqesTk7FPMSrczDtEELReV4aGMcrDxc9htac5mBDUEbTi9rgCA8Ss5FkasKM3",
+		Net:          dex.Mainnet,
+		FeeKey:       "dprv3hCznBesA6jBu1MaSqEBewG76yGtnG6LWMtEXHQvh3MVo6rqesTk7FPMSrczDtEELReV4aGMcrDxc9htac5mBDUEbTi9rgCA8Ss5FkasKM3",
 	}
 
 	numMarkets = len(dbi.MarketCfg)
@@ -180,7 +179,7 @@ func cleanTables(db *sql.DB) error {
 		return err
 	}
 
-	return archie.CreateKeyEntry(archie.keyHash)
+	return archie.createKeyEntry(archie.keyHash)
 }
 
 func Test_sqlExec(t *testing.T) {

--- a/server/db/errors.go
+++ b/server/db/errors.go
@@ -54,6 +54,7 @@ const (
 	ErrReusedCommit
 	ErrOrderNotExecuted
 	ErrUpdateCount
+	ErrUnknownKey
 )
 
 func (ae ArchiveError) Error() string {
@@ -75,6 +76,8 @@ func (ae ArchiveError) Error() string {
 		desc = "order not in executed status"
 	case ErrUpdateCount:
 		desc = "unexpected number of rows updated"
+	case ErrUnknownKey:
+		desc = "unknown key"
 	}
 
 	if ae.Detail == "" {
@@ -148,4 +151,11 @@ func IsErrOrderNotExecuted(err error) bool {
 func IsErrUpdateCount(err error) bool {
 	var errA ArchiveError
 	return errors.As(err, &errA) && errA.Code == ErrUpdateCount
+}
+
+// IsErrKeyUnknown returns true if the error is of type ArchiveError and has
+// code ErrUnknownKey.
+func IsErrKeyUnknown(err error) bool {
+	var errA ArchiveError
+	return errors.As(err, &errA) && errA.Code == ErrUnknownKey
 }

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -133,9 +133,10 @@ type TAuth struct {
 func (a *TAuth) Route(route string, handler func(account.AccountID, *msgjson.Message) *msgjson.Error) {
 	log.Infof("Route for %s", route)
 }
-func (a *TAuth) Suspended(user account.AccountID) (found, suspended bool) {
+func (a *TAuth) Suspended(user account.AccountID) (found, unconfirmed, suspended bool) {
 	suspended, found = a.suspensions[user]
-	return // TODO: test suspended account handling (no trades, just cancels)
+	unconfirmed = false // TODO: test!
+	return              // TODO: test suspended account handling (no trades, just cancels)
 }
 func (a *TAuth) Auth(user account.AccountID, msg, sig []byte) error {
 	//log.Infof("Auth for user %v", user)

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -178,10 +178,11 @@ func (m *TAuthManager) Sign(signables ...msgjson.Signable) {
 		signable.SetSig(sig.Serialize())
 	}
 }
-func (m *TAuthManager) Suspended(user account.AccountID) (found, suspended bool) {
+func (m *TAuthManager) Suspended(user account.AccountID) (found, unconfirmed, suspended bool) {
 	var rule account.Rule
 	rule, found = m.suspensions[user]
 	suspended = rule != account.NoRule
+	unconfirmed = false
 	return // TODO: test suspended account handling (no trades, just cancels)
 }
 func (m *TAuthManager) Auth(user account.AccountID, msg, sig []byte) error {


### PR DESCRIPTION
**WARNING**: The scope of this PR is extensive. There are a number of TODOs, but it is functional on the positive paths and most of the easy-to-hit edge cases. Ignore the unit tests (for the most part) as there is a lot of updating to do.  Account import/export is presently broken because of client DB changes. And generally it is fairly rough.

The **primary goal** of this PR is to replace the current registration protocol (`register`/`notifyfee`) with a new one that involves transmitting the raw fee payment transaction to the server, and only then creating an account.  This involves the following new routes: `'preregister'` client-originating request to obtain fee payment details given an (optional) specified asset, `'payfee'` client-originating request to provide the fee payment transaction, and `'feepaid'` (optional) server-originating notification to inform the connected client that the fee txn is confirmed and their account is thus "confirmed". The `'connect'` response is also modified to convey "confirmed" status as well.

A **secondary goal** of this work is to design for fee payments with various assets configurable by the server operator.

Presently I am able to complete registration in the most likely scenarios: no connection or process interruptions, restart dexc and then mine the fee txn, and shutdown dexc and restart it after confirming the fee txn.  Each scenario has a different path for ensuring completion of the account confirmation process.  There is work toward allowing recovery of failed `'payfee'` request that may or may not have created an account server-side, but this is untested. Also, the server needs work to reattempt account confirmation for pending fee transactions _on restart_; presently it forgets to check the confirmations of pending fee txns.

How to review this PR in it's current state:
1. Start with server/auth/registrar.go and read the docs for how `'preregister'` and `'payfee'` are meant to work. The `'preregister'` response from the server is signed so that the fee address, amount, and asset details are provably assigned by the server.  A successful `'payfee'` request creates the account when the txn is validated and accepted by the network.  Importantly, this means that "account found" actually means "paid" now, unlike when the legacy `'register'` request merely associated an account ID with a fee address to be used.  However, the account is not "confirmed" until the tx reaches the required number of confirmations.
2. See `ParseFeeTx` in server/asset/dcr/dcr.go for details on what constitutes a valid fee payment transaction. Note that a fee transaction commits to a specific account ID, and as such the "fee address" need not be unique to the account. This commitment also prevents others from claiming the fee payment as their own if it is broadcasted before the `'payfee'` request.
3. See `(*ExchangeWallet).MakeRegFeeTx` in client/asset/dcr/dcr.go for how the client constructs a Decred fee payment transaction to satisfy `ParseFeeTx` given the instructions from the `'preregister'` response.
4. Note the new address pool concept used in server/auth, and how server/asset/dcr/addrpool.go implements it for DCR fee payments.  Notably, the auth manager may hand out the same address to multiple registrants if there are enough simultaneous pending `'preregister'` requests not yet met with `'payfee'` requests.  Possibility for address reuse is in the design.
5. See the new `(*Core).Register` method in client/core/core.go. Skip the "account already exists" handling at first and note the beginnings of support for fee payment in multiple assets as specified by the server's config (`feeAsset`). Note that the new account data including the raw fee tx is stored in the client's DB _after_ `'preregister'` and generation of the fee transaction, but _before_ `'payfee'` and broadcasting of the transaction. `PayFeeSig` is stored after successful `'payfee'` request via `c.db.AccountPaid`, while `Confirmed` is stored  via `c.db.ConfirmAccount` after required confirmations are reached and a `'feepaid'` notification is received or the server's `'connect'` response indicates the account is confirmed.
6. Note that after a successful `'payfee'` request but before reaching "confirmed" status, the account ID may `'connect'` (`authDEX`), but not trade, similar to suspended accounts.

Side note about account ID commitment in fee transaction: In a mesh configuration, this may be helpful to tie a transaction to a certain account, although the consensus for defining acceptable amount and payment address is still unclear. I can imagine including the server's `'preregister'` signature, but in a mesh anyone can run a server so what exactly does that prove to the other nodes in the mesh? This needs more thought, but the general approach of providing the raw transaction via `'payfee'` to actually create an account entry is the goal of this work.