### PR TITLE
client/asset/dcr: support account-based locking

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -65,7 +65,7 @@ const (
 )
 
 var (
-	requiredWalletVersion = dex.Semver{Major: 8, Minor: 4, Patch: 0}
+	requiredWalletVersion = dex.Semver{Major: 8, Minor: 5, Patch: 0}
 	requiredNodeVersion   = dex.Semver{Major: 6, Minor: 1, Patch: 2}
 )
 
@@ -166,6 +166,9 @@ type rpcClient interface {
 	GetTransaction(ctx context.Context, txHash *chainhash.Hash) (*walletjson.GetTransactionResult, error)
 	WalletLock(ctx context.Context) error
 	WalletPassphrase(ctx context.Context, passphrase string, timeoutSecs int64) error
+	AccountUnlocked(ctx context.Context, account string) (*walletjson.AccountUnlockedResult, error)
+	LockAccount(ctx context.Context, account string) error
+	UnlockAccount(ctx context.Context, account, passphrase string) error
 	Disconnected() bool
 	RawRequest(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error)
 	WalletInfo(ctx context.Context) (*walletjson.WalletInfoResult, error)
@@ -630,6 +633,11 @@ func (dcr *ExchangeWallet) OwnsAddress(address string) (bool, error) {
 	}
 	va, err := dcr.node.ValidateAddress(dcr.ctx, a)
 	if err != nil {
+		// Work around a bug with dcrwallet that prevents validateaddress for
+		// locked accounts.
+		if isAccountNotEncryptedErr(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	return va.IsMine && dcr.acct == va.Account, nil
@@ -881,7 +889,7 @@ func (dcr *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes
 	// Check wallet's fee rate limit against server's max fee rate
 	if dcr.feeRateLimit < ord.DEXConfig.MaxFeeRate {
 		return nil, nil, fmt.Errorf(
-			"%v: server's max fee rate %v higher than configued fee rate limit %v",
+			"%v: server's max fee rate %v higher than configured fee rate limit %v",
 			ord.DEXConfig.Symbol,
 			ord.DEXConfig.MaxFeeRate,
 			dcr.feeRateLimit)
@@ -2031,9 +2039,35 @@ func (dcr *ExchangeWallet) Address() (string, error) {
 	return addr.String(), nil
 }
 
+func (dcr *ExchangeWallet) accountUnlocked(ctx context.Context, acct string) (encrypted, unlocked bool, err error) {
+	var res *walletjson.AccountUnlockedResult
+	res, err = dcr.node.AccountUnlocked(ctx, acct)
+	if err != nil {
+		err = translateRPCCancelErr(err)
+		return
+	}
+	encrypted = res.Encrypted
+	if res.Unlocked != nil { // should only be when encrypted
+		unlocked = *res.Unlocked
+	}
+	return
+}
+
 // Unlock unlocks the exchange wallet.
 func (dcr *ExchangeWallet) Unlock(pw string) error {
-	return translateRPCCancelErr(dcr.node.WalletPassphrase(dcr.ctx, pw, int64(time.Duration(math.MaxInt64)/time.Second)))
+	encryptedAcct, unlocked, err := dcr.accountUnlocked(dcr.ctx, dcr.acct)
+	if err != nil {
+		return err
+	}
+	if !encryptedAcct {
+		return translateRPCCancelErr(dcr.node.WalletPassphrase(dcr.ctx, pw, 0))
+
+	}
+	if unlocked {
+		return nil
+	}
+
+	return translateRPCCancelErr(dcr.node.UnlockAccount(dcr.ctx, dcr.acct, pw))
 }
 
 // Lock locks the exchange wallet.
@@ -2041,17 +2075,46 @@ func (dcr *ExchangeWallet) Lock() error {
 	if dcr.client.Disconnected() {
 		return asset.ErrConnectionDown
 	}
+
 	// Since hung calls to Lock() may block shutdown of the consumer and thus
 	// cancellation of the ExchangeWallet subsystem's Context, dcr.ctx, give
 	// this a timeout in case the connection goes down or the RPC hangs for
 	// other reasons.
 	ctx, cancel := context.WithTimeout(dcr.ctx, 5*time.Second)
 	defer cancel()
-	return translateRPCCancelErr(dcr.node.WalletLock(ctx))
+
+	encryptedAcct, unlocked, err := dcr.accountUnlocked(ctx, dcr.acct)
+	if err != nil {
+		return err
+	}
+	if !encryptedAcct {
+		return translateRPCCancelErr(dcr.node.WalletLock(ctx))
+	}
+	if !unlocked {
+		return nil
+	}
+
+	err = dcr.node.LockAccount(dcr.ctx, dcr.acct)
+	if isAccountLockedErr(err) {
+		return nil // it's already locked
+	}
+	return translateRPCCancelErr(err)
 }
 
 // Locked will be true if the wallet is currently locked.
+// Q: why are we ignoring RPC errors in this?
 func (dcr *ExchangeWallet) Locked() bool {
+	// First return locked status of the account, falling back to walletinfo if
+	// the account is not individually password protected.
+	encrypted, unlocked, err := dcr.accountUnlocked(dcr.ctx, dcr.acct)
+	if err != nil {
+		dcr.log.Errorf("accountunlocked error: %v", err)
+		// return false // or try walletinfo???
+	} else if encrypted {
+		return !unlocked
+	}
+
+	// The account is not individually encrypted, so check walletinfo.
 	walletInfo, err := dcr.node.WalletInfo(dcr.ctx)
 	if err != nil {
 		dcr.log.Errorf("walletinfo error: %v", err)
@@ -2784,6 +2847,18 @@ func reduceMsgTx(tx *wire.MsgTx) (in, out, fees, rate, size uint64) {
 func isTxNotFoundErr(err error) bool {
 	var rpcErr *dcrjson.RPCError
 	return errors.As(err, &rpcErr) && rpcErr.Code == dcrjson.ErrRPCNoTxInfo
+}
+
+func isAccountNotEncryptedErr(err error) bool {
+	var rpcErr *dcrjson.RPCError
+	return errors.As(err, &rpcErr) && rpcErr.Code == dcrjson.ErrRPCWallet &&
+		strings.Contains(rpcErr.Message, "account is not encrypted") // ... with a unique passphrase
+}
+
+func isAccountLockedErr(err error) bool {
+	var rpcErr *dcrjson.RPCError
+	return errors.As(err, &rpcErr) && rpcErr.Code == dcrjson.ErrRPCWalletUnlockNeeded &&
+		strings.Contains(rpcErr.Message, "account is already locked")
 }
 
 // toDCR returns a float representation in conventional units for the given

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -361,6 +361,13 @@ func (c *tRPCClient) GetTransaction(_ context.Context, txHash *chainhash.Hash) (
 	return c.walletTx, c.walletTxErr
 }
 
+func (c *tRPCClient) AccountUnlocked(_ context.Context, acct string) (*walletjson.AccountUnlockedResult, error) {
+	return &walletjson.AccountUnlockedResult{}, nil // go the walletlock/walletpassphrase route
+}
+
+func (c *tRPCClient) LockAccount(_ context.Context, acct string) error       { return nil }
+func (c *tRPCClient) UnlockAccount(_ context.Context, acct, pw string) error { return nil }
+
 func (c *tRPCClient) WalletLock(_ context.Context) error {
 	return c.lockErr
 }

--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -431,7 +431,7 @@ func (conn *wsConn) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	if err != nil {
 		// The read loop would normally trigger keepAlive, but it wasn't started
 		// on account of a connect error.
-		conn.log.Errorf("Initial connection failed, starting reconnect loop.")
+		conn.log.Errorf("Initial connection failed, starting reconnect loop: %v", err)
 		time.AfterFunc(5*time.Second, func() {
 			conn.reconnectCh <- struct{}{}
 		})

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1967,6 +1967,8 @@ func TestConnectDEX(t *testing.T) {
 	if err != nil {
 		t.Fatalf("final connectDEX error: %v", err)
 	}
+
+	// TODO: test temporary, ensure listen isn't running, somehow
 }
 
 func TestInitializeClient(t *testing.T) {

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -136,6 +136,7 @@ export default class Application {
    */
   reconnected () {
     window.location.reload() // This triggers another websocket disconnect/connect (!)
+    // a fetchUser() and loadPage(window.history.state.page) might work
   }
 
   /*
@@ -510,8 +511,10 @@ export default class Application {
         if (ord) updateMatch(ord, note.match)
         break
       }
-      case 'conn':
-        this.reconnected()
+      case 'conn': {
+        const dex = this.user.exchanges[note.host]
+        if (dex) dex.connected = note.connected
+      }
     }
 
     // Inform the page.

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -212,12 +212,11 @@ sleep 3
 # dcrwallets
 ################################################################################
 
-# Re-using $MINE to signal whether the wallets need to be created
-# from scratch, or if they were loaded from file.
 echo "Creating simnet alpha wallet"
 ENABLE_TICKET_BUYER="1"
 "${HARNESS_DIR}/create-wallet.sh" "$SESSION:3" "alpha" ${ALPHA_WALLET_SEED} \
 ${ALPHA_WALLET_PORT} ${ENABLE_TICKET_BUYER}
+# alpha uses walletpassphrase/walletlock.
 
 echo "Creating simnet beta wallet"
 ENABLE_TICKET_BUYER="0"
@@ -236,6 +235,13 @@ ENABLE_TICKET_BUYER="0"
 ${TRADING_WALLET2_PORT} ${ENABLE_TICKET_BUYER}
 
 sleep 15
+
+# Give beta's "default" account a password, so it uses unlockaccount/lockaccount.
+tmux send-keys -t $SESSION:0 "./beta setaccountpassphrase default ${WALLET_PASS}${WAIT}" C-m\; wait-for donedcr
+# Lock the wallet so we know we can function with just account unlocking. There
+# is also a bug in dcrwallet that breaks validateaddress if the wallet is
+# unlocked but not the account, so keep the wallet locked.
+tmux send-keys -t $SESSION:0 "./beta walletlock${WAIT}" C-m\; wait-for donedcr
 
 # Create fee account on alpha wallet for use by dcrdex simnet instances.
 tmux send-keys -t $SESSION:0 "./alpha createnewaccount server_fees${WAIT}" C-m\; wait-for donedcr

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module decred.org/dcrdex
 go 1.15
 
 require (
-	decred.org/dcrwallet v1.6.0-rc4
+	decred.org/dcrwallet v1.6.3-0.20210324151833-873c564976fd
 	github.com/btcsuite/btcd v0.20.1-beta.0.20200615134404-e4f59022a387
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 decred.org/cspp v0.3.0/go.mod h1:UygjYilC94dER3BEU65Zzyoqy9ngJfWCD2rdJqvUs2A=
-decred.org/dcrwallet v1.6.0-rc4 h1:5IT6mFa+2YMqenu6aE2LetD0N8QSUVFyAFl205PvIIE=
-decred.org/dcrwallet v1.6.0-rc4/go.mod h1:lsrNbuKxkPGeHXPufxNTckwQopCEDz0r3t0a8JCKAmU=
+decred.org/dcrwallet v1.6.3-0.20210324151833-873c564976fd h1:tAaRGZmA8aj0F88oeFGhNXjtoV29E/jbuTYjVEVYU14=
+decred.org/dcrwallet v1.6.3-0.20210324151833-873c564976fd/go.mod h1:hNOGyvH53gWdgFB601/ubGRzCPfPtWnEVAi9Grs90y4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OpenBazaar/jsonpb v0.0.0-20171123000858-37d32ddf4eef/go.mod h1:55mCznBcN9WQgrtgaAkv+p2LxeW/tQRdidyyE9D0I5k=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
@@ -200,7 +200,6 @@ golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=


### PR DESCRIPTION
This supports Decred account-based encryption/passwords.

The `(*ExchangeWallet).Lock/Unlock` methods use the new `accountunlocked` wallet RPC being added in https://github.com/decred/dcrwallet/pull/2020 to reliably determine how (un)locking should be performed.  This also uses `accountunlocked` in the `Locked` method. I briefly considered a flag to indicate account vs. wallet locking that get's figured out on walletreconfigure/creation/startup/etc, but this is far simpler, and it won't get confused if the user sets the account pass while the ExchangeWallet is running.

Also note that unlike `walletlock`, `lockaccount` throws an error if already locked, so we catch that too.

NOTE: to test, you must use dcrwallet built from github.com/chappjc/dcrwallet v1.6.3-0.20210324151833-873c564976fd
