### PR TITLE
client/{asset,core}: do not disconnect wallets in setWalletPassword

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -561,9 +561,19 @@ func (dcr *ExchangeWallet) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
+// var logup uint32
+
+// func rpclog(log dex.Logger) {
+// 	if atomic.CompareAndSwapUint32(&logup, 0, 1) {
+// 		rpcclient.UseLogger(log)
+// 	}
+// }
+
 // Connect connects the wallet to the RPC server. Satisfies the dex.Connector
-// interface.
+// interface. WARNING: Once stopped, it cannot reconnect, requiring NewWallet to
+// construct a new ExchangeWallet to Connect again.
 func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
+	// rpclog(dcr.log)
 	dcr.ctx = ctx
 	err := dcr.client.Connect(ctx, false)
 	if err != nil {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -67,6 +67,8 @@ type WalletConfig struct {
 // Wallet is a common interface to be implemented by cryptocurrency wallet
 // software.
 type Wallet interface {
+	// It should be assumed that once disconnected, subsequent Connect calls
+	// will fail, requiring a new Wallet instance.
 	dex.Connector
 	// Info returns a set of basic information about the wallet.
 	Info() *WalletInfo

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1781,27 +1781,28 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 			assetID, unbip(assetID), err)
 	}
 
-	isSettingNewPW := newWalletPW != nil // Includes empty but non-nil
-	// If newWalletPW is non-nil, update the wallet's password.
-	if isSettingNewPW {
-		err = c.setWalletPassword(wallet, newWalletPW, crypter)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Must connect to ensure settings are good.
+	// Must connect to ensure settings are good. This comes before
+	// setWalletPassword since it would use connectAndUpdateWallet, which
+	// performs additional deposit address validation and balance updates that
+	// are redundant with the rest of this function.
 	dbWallet.Address, err = c.connectWallet(wallet)
 	if err != nil {
 		return err
 	}
 
-	// If the password was not changed, carry over any cached password
-	// regardless of backend lock state. loadWallet already copied encPW, so
-	// this will decrypt pw rather than actually copying it, and it will
-	// ensure the backend is also unlocked.
-	if !isSettingNewPW && oldWallet.locallyUnlocked() {
-		err := wallet.Unlock(crypter)
+	// If newWalletPW is non-nil, update the wallet's password.
+	if newWalletPW != nil { // includes empty non-nil slice
+		err = c.setWalletPassword(wallet, newWalletPW, crypter)
+		if err != nil {
+			wallet.Disconnect()
+			return err
+		}
+	} else if oldWallet.locallyUnlocked() {
+		// If the password was not changed, carry over any cached password
+		// regardless of backend lock state. loadWallet already copied encPW, so
+		// this will decrypt pw rather than actually copying it, and it will
+		// ensure the backend is also unlocked.
+		err := wallet.Unlock(crypter) // decrypt encPW if set and unlock the backend
 		if err != nil {
 			wallet.Disconnect()
 			return newError(walletAuthErr, "wallet successfully connected, but failed to unlock. "+
@@ -1880,8 +1881,9 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 	return nil
 }
 
-// SetWalletPassword updates the (encrypted) password for the wallet.
-// Returns passwordErr if provided newPW is nil.
+// SetWalletPassword updates the (encrypted) password for the wallet. Returns
+// passwordErr if provided newPW is nil. The wallet will be connected if it is
+// not already.
 func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error {
 	// Ensure newPW isn't nil.
 	if newPW == nil {
@@ -1902,13 +1904,9 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 		return newError(missingWalletErr, "wallet for %s (%d) is not known", unbip(assetID), assetID)
 	}
 
-	// Set new password.
-	err = c.setWalletPassword(wallet, newPW, crypter)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	// Set new password, connecting to it if necessary to verify. It is left
+	// connected since it is in the wallets map.
+	return c.setWalletPassword(wallet, newPW, crypter)
 }
 
 // setWalletPassword updates the (encrypted) password for the wallet.
@@ -1956,13 +1954,10 @@ func (c *Core) setWalletPassword(wallet *xcWallet, newPW []byte, crypter encrypt
 			c.log.Warnf("Unable to relock %s wallet: %v", unbip(wallet.AssetID), err)
 		}
 	}
-	// Disconnect if it was not previously connected.
-	if !wasConnected {
-		wallet.Disconnect()
-	}
 
-	details := fmt.Sprintf("Password for %s wallet has been updated.",
-		unbip(wallet.AssetID))
+	// Do not disconnect because the Wallet may not allow reconnection.
+
+	details := fmt.Sprintf("Password for %s wallet has been updated.", unbip(wallet.AssetID))
 	c.notify(newWalletConfigNote(SubjectWalletPasswordUpdated, details,
 		db.Success, wallet.state()))
 


### PR DESCRIPTION
When an `asset.Wallet` is disconnected, it may not be possible to
reconnect it.  Document this with the `asset.Wallet` interface.
This is the case with Decred's rpcclient-powered `ExchangeWallet`
where calls to `rpcclient.(*Client).Connect` after having `Shutdown`
a previous connection will be met with the error:

`websocket client has already connected`

Always leave wallets connected in `setWalletPassword`. Callers like
`SetWalletPassword` have the `xcWallet` in the wallets map, so it should
stay live and usable.

In `ReconfigureWallet`, call `connectWallet` before `setWalletPassword`
anyway because the connection approach used by `setWalletPassword`
was too involved for the fresh `xcWallet` created by `ReconfigureWallet`
that is not yet in Core's wallets map.