### PR TITLE
pg: fastUint64 scanner with no string conversion

### DIFF
--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -292,6 +292,9 @@ func (s *Server) Run(ctx context.Context) {
 
 	// Data API endpoints.
 	mux.Route("/api", func(rr chi.Router) {
+		if log.Level() == dex.LevelTrace {
+			rr.Use(middleware.Logger)
+		}
 		rr.Use(s.limitRate)
 		rr.Get("/config", routeHandler(msgjson.ConfigRoute))
 		rr.Get("/spots", routeHandler(msgjson.SpotsRoute))

--- a/server/db/driver/pg/types.go
+++ b/server/db/driver/pg/types.go
@@ -1,0 +1,45 @@
+package pg
+
+import (
+	"fmt"
+)
+
+// fastUint64 provides an efficient Scanner for 64-bit integer data. With a
+// regular uint64 or any other integer type that itself does not implement
+// Scanner, the database/sql.Scan implementation will coerce type by converting
+// to and from a string, so we avoid this expensive operation by implementing a
+// Scanner that uses a type assertion. This only works for columns with a
+// postgresql type of INT8 (8-byte integer) that scan a value of type int64.
+type fastUint64 uint64
+
+func (n *fastUint64) Scan(value interface{}) error {
+	if value == nil {
+		*n = 0
+		return fmt.Errorf("NULL not supported")
+	}
+
+	v, ok := value.(int64)
+	if !ok {
+		return fmt.Errorf("not a signed 64-bit integer: %T", value)
+	}
+	*n = fastUint64(v)
+	return nil
+
+	// NOTE: If we want to be able to scan all other interger types and coerce
+	// them into uint64, we can switch on each signed type. PostgreSQL has no
+	// unsigned types, so just int8, int16, int32, and int64.
+
+	// switch v := value.(type) {
+	// case int64:
+	// 	*n = fastUint64(v)
+	// case int32:
+	// 	*n = fastUint64(v)
+	// case int16:
+	// 	*n = fastUint64(v)
+	// case int8:
+	// 	*n = fastUint64(v)
+	// default:
+	// 	return fmt.Errorf("not a signed integer: %t", value)
+	// }
+	// return nil
+}

--- a/server/db/driver/pg/upgrades.go
+++ b/server/db/driver/pg/upgrades.go
@@ -75,14 +75,14 @@ func matchStatsForMarketEpoch(stmt *sql.Stmt, epochIdx, epochDur uint64) (rates,
 	defer rows.Close()
 
 	for rows.Next() {
-		var rate, quantity uint64
+		var rate, quantity fastUint64
 		var takerSell bool
 		err = rows.Scan(&quantity, &rate, &takerSell)
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		rates = append(rates, rate)
-		quantities = append(quantities, quantity)
+		rates = append(rates, uint64(rate))
+		quantities = append(quantities, uint64(quantity))
 		sell = append(sell, takerSell)
 	}
 


### PR DESCRIPTION
`convertAssignRows` in the database/sql core library converts to and from a string even for integers, which is kinda crazy and really slow