### PR TITLE
multi: no Seq in msgjson.EpochReportNote

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -602,7 +602,9 @@ func (dc *dexConnection) refreshServerConfig() error {
 	bTimeout := time.Millisecond * time.Duration(cfg.BroadcastTimeout)
 	tickInterval := bTimeout / tickCheckDivisions
 	dc.log.Debugf("Server %v broadcast timeout %v. Tick interval %v", dc.acct.host, bTimeout, tickInterval)
-	dc.ticker.Reset(tickInterval)
+	if dc.ticker.Dur() != tickInterval {
+		dc.ticker.Reset(tickInterval)
+	}
 
 	// Update the dex connection with the new config details, including
 	// StartEpoch and FinalEpoch, and rebuild the market data maps.

--- a/client/orderbook/orderbook.go
+++ b/client/orderbook/orderbook.go
@@ -390,9 +390,10 @@ func (ob *OrderBook) UpdateRemaining(note *msgjson.UpdateRemainingNote) error {
 	return ob.updateRemaining(note, false)
 }
 
-// LogEpochReport just checks the notification sequence.
+// LogEpochReport is currently a no-op, and will update market history charts in
+// the future.
 func (ob *OrderBook) LogEpochReport(note *msgjson.EpochReportNote) error {
-	ob.setSeq(note.Seq)
+	// TODO: update future candlestick charts.
 	atomic.StoreUint64(&ob.feeRates.base, note.BaseFeeRate)
 	atomic.StoreUint64(&ob.feeRates.quote, note.QuoteFeeRate)
 	return nil

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1118,10 +1118,10 @@ func (wc *WireCandles) Candles() []*Candle {
 	return candles
 }
 
-// EpochReportNote is a report about an epoch sent after all of the epoch's
-// book updates.
+// EpochReportNote is a report about an epoch sent after all of the epoch's book
+// updates. Like TradeResumption, and TradeSuspension when Persist is true, Seq
+// is omitted since it doesn't modify the book.
 type EpochReportNote struct {
-	Seq          uint64 `json:"seq"`
 	MarketID     string `json:"marketid"`
 	Epoch        uint64 `json:"epoch"`
 	BaseFeeRate  uint64 `json:"baseFeeRate"`


### PR DESCRIPTION
Since there's no book or order updates with `epoch_report`, it should not increment `Seq`.  Having seq incremented in a message route that 0.1.x client's don't understand also breaks backward compatibility with 0.2 servers.

The book router messages that don't reflect book changes don't increment or include seq. For example, `MatchProof`, `TradeResumption`, and `TradeSuspension` when `Persist` is true.

This also updates the docs for `seq` in the `server/market.subscribers` struct to reflect the purpose of the [`Seq` value as per the spec](https://github.com/decred/dcrdex/blob/master/spec/orders.mediawiki/#order-book-subscriptions):

> The order book and all updates include a sequence ID, which increments by +1 whenever the DEX accepts, removes, or modifies an order. The client is responsible for tracking the sequence ID to ensure all order updates are received. If an update appears to be missing, the client should re-subscribe to the market to synchronize the order book from scratch. 