### PR TITLE
client/rpcserver: getfee expects cert bytes, not filename

### DIFF
--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -239,7 +239,7 @@ func handleGetFee(s *RPCServer, params *RawParams) *msgjson.ResponsePayload {
 	if err != nil {
 		return usage(getFeeRoute, err)
 	}
-	fee, err := s.core.GetFee(host, cert)
+	fee, err := s.core.GetFee(host, cert) // cert is file contents, not name
 	if err != nil {
 		resErr := msgjson.NewError(msgjson.RPCGetFeeError, err.Error())
 		return createResponse(getFeeRoute, nil, resErr)

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -195,12 +195,12 @@ func TestHandleGetFee(t *testing.T) {
 		wantErrCode int
 	}{{
 		name:        "ok",
-		params:      &RawParams{Args: []string{"dex", "cert"}},
+		params:      &RawParams{Args: []string{"dex", "cert bytes"}},
 		regFee:      5,
 		wantErrCode: -1,
 	}, {
 		name:        "core.getFee error",
-		params:      &RawParams{Args: []string{"dex", "cert"}},
+		params:      &RawParams{Args: []string{"dex", "cert bytes"}},
 		getFeeErr:   errors.New("error"),
 		wantErrCode: msgjson.RPCGetFeeError,
 	}, {

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -290,14 +290,14 @@ func parseCloseWalletArgs(params *RawParams) (uint32, error) {
 	return uint32(assetID), nil
 }
 
-func parseGetFeeArgs(params *RawParams) (host, cert string, err error) {
+func parseGetFeeArgs(params *RawParams) (host string, cert []byte, err error) {
 	if err := checkNArgs(params, []int{0}, []int{1, 2}); err != nil {
-		return "", "", err
+		return "", nil, err
 	}
 	if len(params.Args) == 1 {
-		return params.Args[0], "", nil
+		return params.Args[0], nil, nil
 	}
-	return params.Args[0], params.Args[1], nil
+	return params.Args[0], []byte(params.Args[1]), nil
 }
 
 func parseRegisterArgs(params *RawParams) (*core.RegisterForm, error) {

--- a/client/rpcserver/types_test.go
+++ b/client/rpcserver/types_test.go
@@ -244,6 +244,37 @@ func TestCheckBoolArg(t *testing.T) {
 	}
 }
 
+func TestParseGetFeeArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  *RawParams
+		wantErr error
+	}{{
+		name:   "host and cert",
+		params: &RawParams{PWArgs: nil, Args: []string{"host", "cert bytes"}},
+	}, {
+		name:    "just host",
+		params:  &RawParams{PWArgs: nil, Args: []string{"host"}},
+		wantErr: errArgs,
+	}}
+	for _, test := range tests {
+		host, cert, err := parseGetFeeArgs(test.params)
+		if err != nil {
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("unexpected error %v for test %s",
+					err, test.name)
+			}
+			continue
+		}
+		if host != test.params.Args[0] {
+			t.Fatalf("url doesn't match")
+		}
+		if len(test.params.Args) > 1 && string(cert) != test.params.Args[1] {
+			t.Fatalf("cert doesn't match")
+		}
+	}
+}
+
 func TestParseRegisterArgs(t *testing.T) {
 	paramsWithFee := func(fee string) *RawParams {
 		pw := encode.PassBytes("password123")


### PR DESCRIPTION
This follows up on https://github.com/decred/dcrdex/pull/821, which changed the cert argument to both `Register` and `GetFee` to be an `interface{}` (either `[]byte` or `string`).  However, the client/rpcserver's `parseGetFeeArgs` was keeping the cert as a `string` even though it was the cert *contents* not file name.

This can be tested with the dcrdex harness using `./dexcctl --simnet -p a getfee 127.0.0.1:17273 ~/dextest/dcrdex/rpc.cert`.  On master it spits out an error showing the full contents of the cert file saying file not found.