### PR TITLE
client/orderbook: fix csum computation with missed preimages

### DIFF
--- a/client/orderbook/orderbook_test.go
+++ b/client/orderbook/orderbook_test.go
@@ -951,10 +951,8 @@ func TestValidateMatchProof(t *testing.T) {
 		t.Fatalf("[Enqueue]: unexpected error: %v", err)
 	}
 
-	expectedCSum, _ := hex.DecodeString("9db8c0547f3b80574df730c3b7005ccef" +
-		"4310e93f766442110fc2c9353230985")
-	expectedSeed, _ := hex.DecodeString("e2b770f60baab7ac877edfa55bd1443b59" +
-		"1c1cdd461667c6eb737ae0c65daf2d")
+	expectedCSum, _ := hex.DecodeString("9db8c0547f3b80574df730c3b7005ccef4310e93f766442110fc2c9353230985")
+	expectedSeed, _ := hex.DecodeString("e2b770f60baab7ac877edfa55bd1443b591c1cdd461667c6eb737ae0c65daf2d")
 
 	matchProofNote := msgjson.MatchProofNote{
 		MarketID:  mid,
@@ -987,10 +985,8 @@ func TestValidateMatchProof(t *testing.T) {
 		t.Fatalf("[Enqueue]: unexpected error: %v", err)
 	}
 
-	expectedSeedWithMisses, _ := hex.DecodeString("01a161289f06be16ea9b5a5a" +
-		"5492f5664f3e92750dc5ce3fa5775eb9be225730")
-	expectedCSumWithMisses, _ := hex.DecodeString("0433a2dec5f3b9f530fba28a" +
-		"d1b4c15c454b4b41ab3bd0ba8f30a6d1de2a1128")
+	expectedCSumWithMisses := expectedCSum // csum not affected by misses
+	expectedSeedWithMisses, _ := hex.DecodeString("01a161289f06be16ea9b5a5a5492f5664f3e92750dc5ce3fa5775eb9be225730")
 
 	matchProofNoteWithMisses := msgjson.MatchProofNote{
 		MarketID:  mid,
@@ -1034,11 +1030,6 @@ func TestValidateMatchProof(t *testing.T) {
 		t.Fatalf("[Enqueue]: unexpected error: %v", err)
 	}
 
-	expectedCSum, _ = hex.DecodeString("9db8c0547f3b80574df730c3b7005ccef" +
-		"4310e93f766442110fc2c9353230985")
-	expectedSeed, _ = hex.DecodeString("e2b770f60baab7ac877edfa55bd1443b59" +
-		"1c1cdd461667c6eb737ae0c65daf2d")
-
 	matchProofNote = msgjson.MatchProofNote{
 		MarketID:  mid,
 		Epoch:     epoch,
@@ -1071,10 +1062,7 @@ func TestValidateMatchProof(t *testing.T) {
 		t.Fatalf("[Enqueue]: unexpected error: %v", err)
 	}
 
-	expectedCSum, _ = hex.DecodeString("0433a2dec5f3b9f530fba28a" +
-		"d1b4c15c454b4b41ab3bd0ba8f30a6d1de2a1128")
-	expectedSeed, _ = hex.DecodeString("e2b770f60baab7ac877edfa55bd1443b59" +
-		"1c1cdd461667c6eb737ae0c65daf2d")
+	junkSeed, _ := hex.DecodeString("e2b770f60baab7ac877edfa55bd1443b591c1cdd461667c6eb737ae0c65daf2d")
 
 	matchProofNote = msgjson.MatchProofNote{
 		MarketID:  mid,
@@ -1082,13 +1070,13 @@ func TestValidateMatchProof(t *testing.T) {
 		Preimages: []msgjson.Bytes{n1Pimg[:], n3Pimg[:]},
 		Misses:    []msgjson.Bytes{n2.OrderID},
 		CSum:      expectedCSum,
-		Seed:      expectedSeed,
+		Seed:      junkSeed,
 	}
 
 	// Ensure a invalid match proof message (invalid seed) gets detected
 	// as expected.
 	if err := ob.ValidateMatchProof(matchProofNote); err == nil {
-		t.Fatalf("[ValidateMatchProof (inavlid seed)]: unexpected error: %v", err)
+		t.Fatalf("[ValidateMatchProof (invalid seed)]: unexpected error: %v", err)
 	}
 
 	ob = NewOrderBook(tLogger)
@@ -1108,23 +1096,20 @@ func TestValidateMatchProof(t *testing.T) {
 		t.Fatalf("[Enqueue]: unexpected error: %v", err)
 	}
 
-	expectedCSum, _ = hex.DecodeString("9db8c0547f3b80574df730c3b7005ccef" +
-		"4310e93f766442110fc2c9353230985")
-	expectedSeed, _ = hex.DecodeString("01a161289f06be16ea9b5a5a" +
-		"5492f5664f3e92750dc5ce3fa5775eb9be225730")
+	junkCSum, _ := hex.DecodeString("000000000f3b80574df730c3b7005ccef4310e93f766442110fc2c9353230985")
 
 	matchProofNote = msgjson.MatchProofNote{
 		MarketID:  mid,
 		Epoch:     epoch,
 		Preimages: []msgjson.Bytes{n1Pimg[:], n3Pimg[:]},
 		Misses:    []msgjson.Bytes{n2.OrderID},
-		CSum:      expectedCSum,
-		Seed:      expectedSeed,
+		CSum:      junkCSum,
+		Seed:      expectedSeedWithMisses,
 	}
 
 	// Ensure a invalid match proof message (invalid csum) gets detected
 	// as expected.
 	if err := ob.ValidateMatchProof(matchProofNote); err == nil {
-		t.Fatalf("[ValidateMatchProof (inavlid csum)]: unexpected error: %v", err)
+		t.Fatalf("[ValidateMatchProof (invalid csum)]: unexpected error: %v", err)
 	}
 }

--- a/server/matcher/match_test.go
+++ b/server/matcher/match_test.go
@@ -2210,3 +2210,55 @@ func compareMatchStats(t *testing.T, sWant, sHave *MatchCycleStats) {
 		t.Errorf("wrong EndRate. wanted %d, got %d", sWant.EndRate, sHave.EndRate)
 	}
 }
+
+func TestCSum(t *testing.T) {
+	// This is just a smoke test to ensure a known result does not change. It
+	// also corresponds to a csum used in market_test:
+	//   a64ee6372a49f9465910ca0b556818dbc765f3c7fa21d5f40ab25bf4b73f45ed
+	// and in client's epochqueue_test:
+	//   8c743c3225b89ffbb50b5d766d3e078cd8e2658fa8cb6e543c4101e1d59a8e8e.
+
+	pi0B, _ := hex.DecodeString("e1f796fa0fc16ba7bb90be2a33e87c3d60ab628471a420834383661801bb0bfd")
+	var pi0 order.Preimage
+	copy(pi0[:], pi0B)
+	fmt.Printf("%x\n", pi0)
+	com0 := pi0.Commit() // aba75140b1f6edf26955a97e1b09d7b17abdc9c0b099fc73d9729501652fbf66
+	lo0 := &order.LimitOrder{
+		P: order.Prefix{
+			Commit: com0,
+		},
+	}
+
+	pi1B, _ := hex.DecodeString("8e6c140071db1eb2f7a18194f1a045a94c078835c75dff2f3e836180baad9e95")
+	var pi1 order.Preimage
+	copy(pi1[:], pi1B)
+	com1 := pi1.Commit() // 0f4bc030d392cef3f44d0781870ab7fcb78a0cda36c73e50b88c741b4f851600
+	lo1 := &order.LimitOrder{
+		P: order.Prefix{
+			Commit: com1,
+		},
+	}
+
+	wantCSum, _ := hex.DecodeString("a64ee6372a49f9465910ca0b556818dbc765f3c7fa21d5f40ab25bf4b73f45ed")
+	csum := CSum([]order.Order{lo0, lo1})
+	if !bytes.Equal(wantCSum, csum) {
+		t.Errorf("got csum %x, wanted %x", csum, wantCSum)
+	}
+
+	// a third for the matching client-side test in epochqueue_test
+	pi2B, _ := hex.DecodeString("e1f796fa0fc16ba7bb90be2a33e87c3d60ab628471a420834383661801bb0bfd")
+	var pi2 order.Preimage
+	copy(pi2[:], pi2B)
+	com2 := pi2.Commit() // aba75140b1f6edf26955a97e1b09d7b17abdc9c0b099fc73d9729501652fbf66
+	lo2 := &order.LimitOrder{
+		P: order.Prefix{
+			Commit: com2,
+		},
+	}
+
+	wantCSum, _ = hex.DecodeString("8c743c3225b89ffbb50b5d766d3e078cd8e2658fa8cb6e543c4101e1d59a8e8e")
+	csum = CSum([]order.Order{lo0, lo1, lo2})
+	if !bytes.Equal(wantCSum, csum) {
+		t.Errorf("got csum %x, wanted %x", csum, wantCSum)
+	}
+}

--- a/spec/fundamentals.mediawiki
+++ b/spec/fundamentals.mediawiki
@@ -274,11 +274,13 @@ The process continues with the next order in the list and iterates until all
 orders have been processed.
 
 The preimages and seed are published at the start of the matching process. In
-addition, a '''''checksum''''', which is the Blake-256 hash of the
-lexicographically sorted order commitments, is sent to the client. Because
-the client already has the commitments from their order book subscription,
-the checksum allows the client to check that the orders underlying the preimages
-are indeed the same set received in their order notification feed.
+addition, a '''''checksum''''' defined as the Blake-256 hash of the
+concatenation of the lexicographically sorted commitments of all orders in the
+epoch queue, is sent to the client. Because the client already has the
+commitments from their order book subscription, the checksum allows the client
+to check that the orders underlying the preimages are indeed the same set
+received in their order notification feed, and that no received orders were
+omitted from either preimage collection or shuffling.
 
 For the special case of an epoch with no orders, the checksum will be null.
 


### PR DESCRIPTION
client/orderbook: fix csum computation with missed preimages

The commitment checksum is computed from **all** orders in the epoch queue.
The shuffle seed is computed from the received preimages, but the csum
includes all the orders received in an epoch that were send to orderbook
subscribers in the `epoch_order` notes.

This fixes `(*EpochQueue).GenerateMatchProof` to use all epoch queue
commitments in csum computation, and it prints a message when
there are epoch queue orders that were not accounted for in either the
preimages or misses slices. An error is not thrown in this case since
one of the shuffle seed or commitment checksum will mismatch.

Now server and client compute the same csums when there are missed
preimages.  Their shuffle seeds already matched with misses.

Common test vectors are now used between all the client and server
packages that work with the csum.