### PR TITLE
client/orderbook: fix copy Order operation in updateRemaining

### DIFF
--- a/client/orderbook/bookside.go
+++ b/client/orderbook/bookside.go
@@ -154,9 +154,9 @@ func (d *bookSide) BestNOrders(n int) ([]*Order, bool) {
 		if count == 0 {
 			return false
 		}
-		// Return copies for thread-safe access to the Quantity field.
-		ordCopy := *ord
-		best = append(best, &ordCopy)
+		// Quantity is immutable for a given *Order instance (see
+		// UpdateRemaining), so there is no need to make a deep copy here.
+		best = append(best, ord)
 		count--
 		return true
 	})

--- a/client/orderbook/bookside_test.go
+++ b/client/orderbook/bookside_test.go
@@ -397,7 +397,8 @@ func TestBookSideRemove(t *testing.T) {
 	}
 
 	for idx, tc := range tests {
-		err := tc.side.Remove(tc.entry)
+		ord := tc.entry
+		err := tc.side.Remove(ord.OrderID, ord.Rate)
 		if (err != nil) != tc.wantErr {
 			t.Fatalf("[BookSide.Remove] #%d: error: %v, wantErr: %v",
 				idx+1, err, tc.wantErr)

--- a/client/orderbook/orderbook_test.go
+++ b/client/orderbook/orderbook_test.go
@@ -64,7 +64,7 @@ func makeOrderBook(seq uint64, marketID string, orders []*Order, cachedOrders []
 	ob.seq = seq
 
 	for _, order := range orders {
-		ob.orders[order.OrderID] = order
+		ob.orders[order.OrderID] = rateSell{order.Rate, order.sell()}
 
 		switch order.Side {
 		case msgjson.BuyOrderNum:

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -31,10 +31,10 @@ echo "Writing markets.json and dcrdex.conf"
 
 set +e
 
-~/dextest/bch/harness-ctl/alpha getblockchaininfo > /dev/null
+~/dextest/bch/harness-ctl/alpha getblockchaininfo &> /dev/null
 BCH_ON=$?
 
-~/dextest/ltc/harness-ctl/alpha getblockchaininfo > /dev/null
+~/dextest/ltc/harness-ctl/alpha getblockchaininfo &> /dev/null
 LTC_ON=$?
 
 set -e
@@ -61,6 +61,7 @@ if [ $LTC_ON -eq 0 ]; then
             "epochDuration": ${EPOCH_DURATION},
             "marketBuyBuffer": 1.2
 EOF
+else echo "WARNING: Litecoin is not running. Configuring dcrdex markets without LTC."
 fi
 
 if [ $BCH_ON -eq 0 ]; then
@@ -72,6 +73,7 @@ if [ $BCH_ON -eq 0 ]; then
             "epochDuration": ${EPOCH_DURATION},
             "marketBuyBuffer": 1.2
 EOF
+else echo "WARNING: Bitcoin Cash is not running. Configuring dcrdex markets without BCH."
 fi
 
 cat << EOF >> "./markets.json"


### PR DESCRIPTION
This fixes a copy operation not being performed on account of a go compiler
simplification.  See staticcheck SA4001 / https://play.golang.org/p/1X44V19HxFj

Instead of making multiple copies on each add/book, go back to storing
pointers, but now `bookSide` is responsible for modifying `Quantity`, and
making copies when returning an `Order` from it's methods.

This also resolves an issue with the `OrderBook.{buys,sells}` fields being
overwritten unsafely in the `Reset` method.  The resolution is a new
`(*bookSide).reset` method to clear the internal structures. This is also
less error prone as the initial `orderPreference` cannot be changed.