### PR TITLE
loadbot: beta uses unlockaccount, use 0 for indefinite dur

### DIFF
--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -145,6 +145,11 @@ adminsrvon=1
 adminsrvpass=adminpass
 adminsrvaddr=127.0.0.1:16542
 bcasttimeout=1m
+freecancels=1
+maxepochcancels=128
+inittakerlotlimit=40
+abstakerlotlimit=1200
+httpprof=1
 EOF
 
 # Set the postgres user pass if provided. 

--- a/dex/testing/loadbot/loadbot.go
+++ b/dex/testing/loadbot/loadbot.go
@@ -273,6 +273,7 @@ func main() {
 
 	// Unlock wallets, since they may have been locked on a previous shutdown.
 	<-harnessCtl(dcr, "./alpha", "walletpassphrase", "abc", "0")
+	<-harnessCtl(dcr, "./beta", "walletpassphrase", "abc", "0") // creating new accounts requires wallet unlocked
 	<-harnessCtl(dcr, "./beta", "unlockaccount", "default", "abc")
 	<-harnessCtl(btc, "./alpha", "walletpassphrase", "abc", "4294967295")
 	<-harnessCtl(btc, "./beta", "walletpassphrase", "abc", "4294967295")

--- a/dex/testing/loadbot/loadbot.go
+++ b/dex/testing/loadbot/loadbot.go
@@ -272,8 +272,8 @@ func main() {
 	betaAddrBTC = getAddress(btc, "./beta", "getnewaddress", "''", "bech32")
 
 	// Unlock wallets, since they may have been locked on a previous shutdown.
-	<-harnessCtl(dcr, "./alpha", "walletpassphrase", "abc", "4294967295")
-	<-harnessCtl(dcr, "./beta", "walletpassphrase", "abc", "4294967295")
+	<-harnessCtl(dcr, "./alpha", "walletpassphrase", "abc", "0")
+	<-harnessCtl(dcr, "./beta", "unlockaccount", "default", "abc")
 	<-harnessCtl(btc, "./alpha", "walletpassphrase", "abc", "4294967295")
 	<-harnessCtl(btc, "./beta", "walletpassphrase", "abc", "4294967295")
 


### PR DESCRIPTION
With https://github.com/decred/dcrdex/pull/1023, the "beta" DCR wallet was converted to an individually-encrypted account, but I did not update loadbot's unlocking command for beta.

This also changes the `walletpassphrase` duration argument for "alpha" to 0, which means indefinitely unlocked.