### PR TITLE
client/{core,webserver}: getdexinfo instead of getfee

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2122,11 +2122,11 @@ func (c *Core) isRegistered(host string) bool {
 // Returns an error if user is already registered to the DEX. A TLS certificate,
 // certI, can be provided as either a string filename, or []byte file contents.
 func (c *Core) GetFee(dexAddr string, certI interface{}) (uint64, error) {
-	exch, err := c.GetDEXConfig(dexAddr, certI)
+	xc, err := c.GetDEXConfig(dexAddr, certI)
 	if err != nil {
 		return 0, err
 	}
-	return exch.Fee.Amt, nil
+	return xc.Fee.Amt, nil
 }
 
 // GetDEXConfig creates a temporary connection to the specified DEX Server and
@@ -2160,6 +2160,8 @@ func (c *Core) GetDEXConfig(dexAddr string, certI interface{}) (*Exchange, error
 		return nil, codedError(connectionErr, err)
 	}
 
+	// Since connectDEX succeeded, we have the server config. exchangeInfo is
+	// guaranteed to return and *Exchange with full asset and market info.
 	return dc.exchangeInfo(), nil
 }
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -453,9 +453,9 @@ type Exchange struct {
 	Assets        map[uint32]*dex.Asset `json:"assets"`
 	FeePending    bool                  `json:"feePending"`
 	Connected     bool                  `json:"connected"`
-	ConfsRequired uint32                `json:"confsrequired"`
+	ConfsRequired uint32                `json:"confsrequired"` // DEPRECATED. RegFees will support multi-asset reg
 	RegConfirms   *uint32               `json:"confs,omitempty"`
-	Fee           *FeeAsset             `json:"feeAsset"`
+	Fee           *FeeAsset             `json:"feeAsset"` // DEPRECATED
 	// RegFees       map[string]*FeeAsset  `json:"regfees"`
 }
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -438,6 +438,13 @@ func (m *Market) marketName() string {
 	return marketName(m.BaseID, m.QuoteID)
 }
 
+// FeeAsset will also be a msgjson type with preregister/payfee PR 1017.
+type FeeAsset struct {
+	ID    uint32 `json:"id"`
+	Confs uint32 `json:"confs"`
+	Amt   uint64 `json:"amount"`
+}
+
 // Exchange represents a single DEX with any number of markets.
 type Exchange struct {
 	Host          string                `json:"host"`
@@ -448,6 +455,8 @@ type Exchange struct {
 	Connected     bool                  `json:"connected"`
 	ConfsRequired uint32                `json:"confsrequired"`
 	RegConfirms   *uint32               `json:"confs,omitempty"`
+	Fee           *FeeAsset             `json:"feeAsset"`
+	// RegFees       map[string]*FeeAsset  `json:"regfees"`
 }
 
 // newDisplayID creates a display-friendly market ID for a base/quote ID pair.
@@ -558,7 +567,7 @@ func (a *dexAccount) ID() account.AccountID {
 func (a *dexAccount) updateKeysEncryption(oldCrypter, newCrypter encrypt.Crypter) error {
 	a.keyMtx.Lock()
 	defer a.keyMtx.Unlock()
-	// Decrypt the encrpyted key with old crypter.
+	// Decrypt the encrypted key with old crypter.
 	key, err := oldCrypter.Decrypt(a.encKey)
 	if err != nil {
 		return fmt.Errorf("error decrypting acct enc key: %w", err)

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -51,7 +51,7 @@ func (s *WebServer) apiGetDEXInfo(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := struct {
 		OK       bool           `json:"ok"`
-		Exchange *core.Exchange `json:"exch,omitempty"`
+		Exchange *core.Exchange `json:"xc,omitempty"`
 	}{
 		OK:       true,
 		Exchange: exchangeInfo,

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -37,6 +37,28 @@ func (s *WebServer) apiGetFee(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp, s.indent)
 }
 
+// apiGetDEXInfo is the handler for the '/getdexinfo' API request.
+func (s *WebServer) apiGetDEXInfo(w http.ResponseWriter, r *http.Request) {
+	form := new(registrationForm)
+	if !readPost(w, r, form) {
+		return
+	}
+	cert := []byte(form.Cert)
+	exchangeInfo, err := s.core.GetDEXConfig(form.Addr, cert)
+	if err != nil {
+		s.writeAPIError(w, err.Error())
+		return
+	}
+	resp := struct {
+		OK       bool           `json:"ok"`
+		Exchange *core.Exchange `json:"exch,omitempty"`
+	}{
+		OK:       true,
+		Exchange: exchangeInfo,
+	}
+	writeJSON(w, resp, s.indent)
+}
+
 // apiRegister is the handler for the '/register' API request.
 func (s *WebServer) apiRegister(w http.ResponseWriter, r *http.Request) {
 	reg := new(registrationForm)

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -272,6 +272,11 @@ var tExchanges = map[string]*core.Exchange{
 			mkid(3, 22): mkMrkt("doge", "mona"),
 		},
 		Connected: true,
+		Fee: &core.FeeAsset{
+			ID:    42,
+			Confs: 1,
+			Amt:   1e8,
+		},
 	},
 	secondDEX: {
 		Host:   "thisdexwithalongname.com",
@@ -282,6 +287,11 @@ var tExchanges = map[string]*core.Exchange{
 			mkid(22, 141): mkMrkt("mona", "kmd"),
 		},
 		Connected: true,
+		Fee: &core.FeeAsset{
+			ID:    42,
+			Confs: 1,
+			Amt:   1e8,
+		},
 	},
 }
 
@@ -379,7 +389,10 @@ func (c *TCore) InitializeClient(pw []byte) error {
 	return nil
 }
 func (c *TCore) GetFee(host string, cert interface{}) (uint64, error) {
-	return 1e8, nil
+	return tExchanges[host].Fee.Amt, nil
+}
+func (c *TCore) GetDEXConfig(host string, certI interface{}) (*core.Exchange, error) {
+	return tExchanges[host], nil
 }
 
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) {

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -140,6 +140,12 @@
     When you submit this form, <span id="feeDisplay"></span> DCR will be spent from your Decred wallet to pay
     registration fees.
   </div>
+  <div class="fs16 mt-4">
+    The DCR lot size for this DEX is <span id="dexDCRLotSize"></span> DCR.
+    All trades are in multiples of this lot size.
+    This is the minimum possible trade amount in DCR.
+    <!-- this will change when lot size is a market setting, not an asset setting -->
+  </div>
   <hr class="dashed my-4">
   <div>
     <label for="appPass" class="pl-1 mb-1">Password</label>

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -144,7 +144,7 @@
     The DCR lot size for this DEX is <span id="dexDCRLotSize"></span> DCR.
     All trades are in multiples of this lot size.
     This is the minimum possible trade amount in DCR.
-    <!-- this will change when lot size is a market setting, not an asset setting -->
+    {{- /*  this will change when lot size is a market setting, not an asset setting */ -}}
   </div>
   <hr class="dashed my-4">
   <div>

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -71,6 +71,12 @@
           Enter your app password to confirm DEX registration.
           When you submit this form, <span id="feeDisplay"></span> DCR will be spent from your Decred wallet to pay registration fees.
         </div>
+        <div class="fs16 mt-4">
+          The DCR lot size for this DEX is <span id="dexDCRLotSize"></span> DCR.
+          All trades are in multiples of this lot size.
+          This is the minimum possible trade amount in DCR.
+          <!-- this will change when lot size is a market setting, not an asset setting -->
+        </div>
         <hr class="dashed mt-4">
         <div>
           <label for="appPass" class="pl-1 mb-1">Password</label>

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -75,7 +75,7 @@
           The DCR lot size for this DEX is <span id="dexDCRLotSize"></span> DCR.
           All trades are in multiples of this lot size.
           This is the minimum possible trade amount in DCR.
-          <!-- this will change when lot size is a market setting, not an asset setting -->
+          {{- /*  this will change when lot size is a market setting, not an asset setting */ -}}
         </div>
         <hr class="dashed mt-4">
         <div>

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -26,7 +26,7 @@ export default class RegistrationPage extends BasePage {
       'addCert', 'submitDEXAddr', 'dexAddrErr', 'dexCertFile', 'dexNeedCert',
       'dexShowMore',
       // Form 5: Confirm DEX registration and pay fee
-      'confirmRegForm', 'feeDisplay', 'appPass', 'submitConfirm', 'regErr',
+      'confirmRegForm', 'feeDisplay', 'dexDCRLotSize', 'appPass', 'submitConfirm', 'regErr',
       'dexCertBox'
     ])
 
@@ -146,7 +146,7 @@ export default class RegistrationPage extends BasePage {
     }
 
     const loaded = app.loading(page.dexAddrForm)
-    const res = await postJSON('/api/getfee', {
+    const res = await postJSON('/api/getdexinfo', {
       addr: addr,
       cert: cert
     })
@@ -162,9 +162,11 @@ export default class RegistrationPage extends BasePage {
 
       return
     }
-    this.fee = res.fee
+    this.fee = res.exch.feeAsset.amount
 
-    page.feeDisplay.textContent = Doc.formatCoinValue(res.fee / 1e8)
+    page.feeDisplay.textContent = Doc.formatCoinValue(this.fee / 1e8)
+    const dcrAsset = res.exch.assets['42'] // res.exch.markets['dcr_btc']
+    if (dcrAsset) page.dexDCRLotSize.textContent = Doc.formatCoinValue(dcrAsset.lotSize / 1e8)
     await this.changeForm(page.dexAddrForm, page.confirmRegForm)
   }
 

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -162,10 +162,10 @@ export default class RegistrationPage extends BasePage {
 
       return
     }
-    this.fee = res.exch.feeAsset.amount
+    this.fee = res.xc.feeAsset.amount
 
     page.feeDisplay.textContent = Doc.formatCoinValue(this.fee / 1e8)
-    const dcrAsset = res.exch.assets['42'] // res.exch.markets['dcr_btc']
+    const dcrAsset = res.xc.assets['42']
     if (dcrAsset) page.dexDCRLotSize.textContent = Doc.formatCoinValue(dcrAsset.lotSize / 1e8)
     await this.changeForm(page.dexAddrForm, page.confirmRegForm)
   }

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -303,10 +303,10 @@ export default class SettingsPage extends BasePage {
       Doc.show(page.dexAddrErr)
       return
     }
-    this.fee = res.exch.feeAsset.amount
+    this.fee = res.xc.feeAsset.amount
 
     page.feeDisplay.textContent = Doc.formatCoinValue(this.fee / 1e8)
-    const dcrAsset = res.exch.assets['42'] // res.exch.markets['dcr_btc']
+    const dcrAsset = res.xc.assets['42']
     if (dcrAsset) page.dexDCRLotSize.textContent = Doc.formatCoinValue(dcrAsset.lotSize / 1e8)
     await this.showForm(page.confirmRegForm)
   }

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -20,7 +20,7 @@ export default class SettingsPage extends BasePage {
       'dexAddrForm', 'dexAddr', 'certFile', 'selectedCert', 'removeCert', 'addCert',
       'submitDEXAddr', 'dexAddrErr',
       // Form to confirm DEX registration and pay fee
-      'forms', 'confirmRegForm', 'feeDisplay', 'appPass', 'submitConfirm', 'regErr',
+      'forms', 'confirmRegForm', 'feeDisplay', 'dexDCRLotSize', 'appPass', 'submitConfirm', 'regErr',
       // Export Account
       'exchanges', 'authorizeAccountExportForm', 'exportAccountAppPass', 'authorizeExportAccountConfirm',
       'exportAccountHost', 'exportAccountErr',
@@ -293,7 +293,7 @@ export default class SettingsPage extends BasePage {
     }
 
     const loaded = app.loading(page.dexAddrForm)
-    const res = await postJSON('/api/getfee', {
+    const res = await postJSON('/api/getdexinfo', {
       addr: addr,
       cert: cert
     })
@@ -303,9 +303,11 @@ export default class SettingsPage extends BasePage {
       Doc.show(page.dexAddrErr)
       return
     }
-    this.fee = res.fee
+    this.fee = res.exch.feeAsset.amount
 
-    page.feeDisplay.textContent = Doc.formatCoinValue(res.fee / 1e8)
+    page.feeDisplay.textContent = Doc.formatCoinValue(this.fee / 1e8)
+    const dcrAsset = res.exch.assets['42'] // res.exch.markets['dcr_btc']
+    if (dcrAsset) page.dexDCRLotSize.textContent = Doc.formatCoinValue(dcrAsset.lotSize / 1e8)
     await this.showForm(page.confirmRegForm)
   }
 

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -81,6 +81,7 @@ type clientCore interface {
 	AutoWalletConfig(assetID uint32) (map[string]string, error)
 	User() *core.User
 	GetFee(url string, cert interface{}) (uint64, error)
+	GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error)
 	SupportedAssets() map[uint32]*core.SupportedAsset
 	Withdraw(pw []byte, assetID uint32, value uint64, address string) (asset.Coin, error)
 	Trade(pw []byte, form *core.TradeForm) (*core.Order, error)
@@ -266,6 +267,7 @@ func New(core clientCore, addr, customSiteDir string, logger dex.Logger, reloadH
 			apiInit.Use(s.rejectUninited)
 			apiInit.Post("/login", s.apiLogin)
 			apiInit.Post("/getfee", s.apiGetFee)
+			apiInit.Post("/getdexinfo", s.apiGetDEXInfo)
 		})
 
 		r.Group(func(apiAuth chi.Router) {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -72,9 +72,12 @@ type TCore struct {
 	notOpen         bool
 }
 
-func (c *TCore) Network() dex.Network                                        { return dex.Mainnet }
-func (c *TCore) Exchanges() map[string]*core.Exchange                        { return nil }
-func (c *TCore) GetFee(string, interface{}) (uint64, error)                  { return 1e8, c.getFeeErr }
+func (c *TCore) Network() dex.Network                       { return dex.Mainnet }
+func (c *TCore) Exchanges() map[string]*core.Exchange       { return nil }
+func (c *TCore) GetFee(string, interface{}) (uint64, error) { return 1e8, c.getFeeErr }
+func (c *TCore) GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error) {
+	return nil, c.getFeeErr // TODO along with test for apiUser / Exchanges() / User()
+}
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
 func (c *TCore) InitializeClient(pw []byte) error                            { return c.initErr }
 func (c *TCore) Login(pw []byte) (*core.LoginResult, error)                  { return &core.LoginResult{}, c.loginErr }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9373513/113906702-22d3dd80-979a-11eb-8e2d-d225e8767408.png)

Resolves https://github.com/decred/dcrdex/issues/1041

The idea is the user should have all the information about the DEX markets and assets before they shell out to register, and lot size is arguably the most important (what if they wanted to trade less than lot size?).

I'm aware that if the DEX does not have DCR supported this will be lacking a value, but presently DEX servers must support it.  Also, this message will have to change to something more informative about all the markets at some point, as will the fee amount shown when multiple reg fee assets becomes supported.