### PR TITLE
match note should have non-negative counter confs

### DIFF
--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -225,11 +225,17 @@ const (
 )
 
 func newMatchNote(subject, details string, severity db.Severity, t *trackedTrade, match *matchTracker) *MatchNote {
+	var counterConfs int64
+	if match.counterConfirms > 0 {
+		// This can be -1 before it is actually checked, but for purposes of the
+		// match note, it should be non-negative.
+		counterConfs = match.counterConfirms
+	}
 	return &MatchNote{
 		Notification: db.NewNotification(NoteTypeMatch, subject, details, severity),
 		OrderID:      t.ID().Bytes(),
 		Match: matchFromMetaMatchWithConfs(t.Order, &match.MetaMatch, match.swapConfirms,
-			int64(t.wallets.fromAsset.SwapConf), match.counterConfirms, int64(t.wallets.toAsset.SwapConf)),
+			int64(t.wallets.fromAsset.SwapConf), counterConfs, int64(t.wallets.toAsset.SwapConf)),
 		Host:     t.dc.acct.host,
 		MarketID: marketName(t.Base(), t.Quote()),
 	}


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1043

The initial `matchTracker.counterConfirms` value when the `matchTracker` is created in `negotiate` or `dbTrackers` is -1 so that the first time confirmations is actually obtained it is logged even if it is zero.  This had the effect of showing -1 in `MatchNote`s.
This changes `newMatchNote` so that it only uses non-negative confirmation values.