### PR TITLE
multi: Version server API.

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -595,8 +595,8 @@ func handleTradeResumptionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 }
 
 // refreshServerConfig fetches and replaces server configuration data. It also
-// initially checks that a server's API version is one of apiVers.
-func (dc *dexConnection) refreshServerConfig(apiVers []int) error {
+// initially checks that a server's API version is one of serverAPIVers.
+func (dc *dexConnection) refreshServerConfig() error {
 	// Fetch the updated DEX configuration.
 	cfg := new(msgjson.ConfigResult)
 	err := sendRequest(dc.WsConn, msgjson.ConfigRoute, nil, cfg, DefaultResponseTimeout)
@@ -609,14 +609,8 @@ func (dc *dexConnection) refreshServerConfig(apiVers []int) error {
 	cfgAPIVer := int32(cfg.APIVersion)
 
 	if apiVer != cfgAPIVer {
-		// If not initiation, do not allow api changes
-		// between connections.
-		if apiVer != -1 {
-			return fmt.Errorf("server API version unexpectedly changed from %v to %v",
-				apiVer, cfgAPIVer)
-		}
 		if found := func() bool {
-			for _, version := range apiVers {
+			for _, version := range serverAPIVers {
 				ver := int32(version)
 				if cfgAPIVer == ver {
 					dc.log.Debugf("Setting server api version to %v.", ver)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -67,6 +67,10 @@ var (
 	syncTickerPeriod = 10 * time.Second
 	// serverAPIVers are the DEX server API versions this client is capable
 	// of communicating with.
+	//
+	// NOTE: API version may change at any time. Keep this in mind when
+	// updating the API. Long-running operations may start and end with
+	// differing versions.
 	serverAPIVers = []int{serverdex.PreAPIVersion}
 )
 
@@ -4417,7 +4421,7 @@ func (c *Core) connectDEX(acctInfo *db.AccountInfo, temporary ...bool) (*dexConn
 	}
 
 	// Request the market configuration.
-	err = dc.refreshServerConfig(serverAPIVers) // handleReconnect must too
+	err = dc.refreshServerConfig() // handleReconnect must too
 	if err != nil {
 		if errors.Is(err, outdatedClientErr) {
 			sendOutdatedClientNotification(c, dc)
@@ -4444,7 +4448,7 @@ func (c *Core) handleReconnect(host string) {
 
 	// The server's configuration may have changed, so retrieve the current
 	// server configuration.
-	err := dc.refreshServerConfig(serverAPIVers)
+	err := dc.refreshServerConfig()
 	if err != nil {
 		if errors.Is(err, outdatedClientErr) {
 			sendOutdatedClientNotification(c, dc)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -39,6 +39,7 @@ import (
 	ordertest "decred.org/dcrdex/dex/order/test"
 	"decred.org/dcrdex/dex/wait"
 	"decred.org/dcrdex/server/account"
+	serverdex "decred.org/dcrdex/server/dex"
 	"github.com/decred/dcrd/crypto/blake256"
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
 	"github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa"
@@ -204,6 +205,7 @@ func testDexConnection(ctx context.Context) (*dexConnection, *TWebsocket, *dexAc
 		notify:    func(Notification) {},
 		trades:    make(map[order.OrderID]*trackedTrade),
 		epoch:     map[string]uint64{tDcrBtcMktName: 0},
+		apiVer:    serverdex.InitialAPIVersion,
 		connected: 1,
 	}, conn, acct
 }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1037,6 +1037,7 @@ type ConfigResult struct {
 	Assets           []*Asset  `json:"assets"`
 	Markets          []*Market `json:"markets"`
 	Fee              uint64    `json:"fee"`
+	APIVersion       uint16    `json:"apiver"`
 	BinSizes         []string  `json:"binSizes"` // Just apidata.BinSizes for now.
 }
 

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -32,11 +32,11 @@ import (
 )
 
 const (
-	// InitialAPIVersion is the initial dex server API version.
-	InitialAPIVersion = iota
+	// PreAPIVersion covers all API iterations before versioning started.
+	PreAPIVersion = iota
 
 	// APIVersion is the current API version.
-	APIVersion = InitialAPIVersion
+	APIVersion = PreAPIVersion
 )
 
 // AssetConf is like dex.Asset except it lacks the BIP44 integer ID, has Network

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -31,6 +31,14 @@ import (
 	"github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa"
 )
 
+const (
+	// InitialAPIVersion is the initial dex server API version.
+	InitialAPIVersion = iota
+
+	// APIVersion is the current API version.
+	APIVersion = InitialAPIVersion
+)
+
 // AssetConf is like dex.Asset except it lacks the BIP44 integer ID, has Network
 // and ConfigPath strings, and has JSON tags.
 type AssetConf struct {
@@ -138,6 +146,7 @@ func newConfigResponse(cfg *DexConf, cfgAssets []*msgjson.Asset, cfgMarkets []*m
 		Assets:           cfgAssets,
 		Markets:          cfgMarkets,
 		Fee:              cfg.RegFeeAmount,
+		APIVersion:       uint16(APIVersion),
 		BinSizes:         apidata.BinSizes,
 	}
 

--- a/spec/README.mediawiki
+++ b/spec/README.mediawiki
@@ -76,6 +76,7 @@ the features described above.
 ** [[fundamentals.mediawiki/#Asset_Variables|Asset Variables]]
 ** [[fundamentals.mediawiki/#Market_Variables|Market Variables]]
 ** [[fundamentals.mediawiki/#Configuration_Data_Request|Configuration Data Request]]
+** [[fundamentals.mediawiki/#API_Version|API Version]]
 * [[fundamentals.mediawiki/#Epochbased_Order_Matching|Epoch-based Order Matching]]
 ** [[fundamentals.mediawiki/#Epoch_Time|Epoch Time]]
 ** [[fundamentals.mediawiki/#Pseudorandom_Order_Matching|Pseudorandom Order Matching]]

--- a/spec/fundamentals.mediawiki
+++ b/spec/fundamentals.mediawiki
@@ -104,6 +104,10 @@ respond with its current configuration.
 |-
 | regfeeconfirms || int   || required confirmations for the registration fee payment transaction
 |-
+| apiver         || int   || the server's [[#API_Version|api version]]
+|-
+| binSizes       || <nowiki>[string]</nowiki>  || bin sizes for candlestick data sets (i.e. <nowiki>["24h", "1h", "5m"]</nowiki>)
+|-
 | assets         || &#91;object&#93; || list of Asset objects (definition below)
 |-
 | markets        || &#91;object&#93; || list of Market objects (definition below)
@@ -331,3 +335,15 @@ There are then two ways to import the asset backend into the server software.
 With the exception of a small handful of assets which will be implemented during
 initial phases of DEX development, it is expected that development communities
 will release their own appropriately vetted plugins.
+
+
+==API Version==
+
+Since DEX v0.2, the dex server has an Application Programming Interface version.
+Clients should check this version before attempting to communicate further with
+the server. An unknown or incompatible version means that communications will
+fail, possibly resulting in penalties or a ban.
+
+===v1===
+
+The server's initial api version.

--- a/spec/fundamentals.mediawiki
+++ b/spec/fundamentals.mediawiki
@@ -344,6 +344,6 @@ Clients should check this version before attempting to communicate further with
 the server. An unknown or incompatible version means that communications will
 fail, possibly resulting in penalties or a ban.
 
-===v1===
+===v0===
 
-The server's initial api version.
+The server's pre-versioning api version with an apiver value of 0.


### PR DESCRIPTION
Add a version to the server that is communicated in the Config response.
Client checks and saves the version. The burden of conforming to an
API version is placed completely on the client.

depends on #1046 
closes #530