### PR TITLE
client: fix db store of enc pass in ReconfigureWallet

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1896,6 +1896,9 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 			wallet.Disconnect()
 			return err
 		}
+		// Update dbWallet so db.UpdateWallet below reflects the new password.
+		dbWallet.EncryptedPW = make([]byte, len(wallet.encPass))
+		copy(dbWallet.EncryptedPW, wallet.encPass)
 	} else if oldWallet.locallyUnlocked() {
 		// If the password was not changed, carry over any cached password
 		// regardless of backend lock state. loadWallet already copied encPW, so


### PR DESCRIPTION
When `ReconfigureWallet` is used to change the wallet's passphrase, there
are two DB updates, but the second one was using the original
`EncryptedPW`.  The resolution is to simply update the `EncryptedPW` field
of the client/db.Wallet instance passed to `db.UpdateWallet` in
`ReconfigureWallet` after updating the wallet balance. While two DB writes
is inefficient, this still uses the `(*Core).setWalletPassword` method as is
since it also checks the password and emits a notification.

This also revises `(*BoltDB).SetWalletPassword` so that it does not bother
to decode the current wallet's `db.Balance` since only the wallet encoding
bucket (`walletKey`) is updated, not the balance bucket (`balanceKey`).
A deep copy of the new encrypted PW is also done out of caution.

Resolves https://github.com/decred/dcrdex/issues/1036