### PR TITLE
dcr: do not use estimatesmartfee

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -689,7 +689,18 @@ func (dcr *ExchangeWallet) Balance() (*asset.Balance, error) {
 	return &balance, err
 }
 
-// FeeRate returns the current optimal fee rate in atoms / byte.
+// feeRate returns the current optimal fee rate in atoms / byte.
+func (dcr *ExchangeWallet) feeRate(confTarget uint64) (uint64, error) {
+	// estimatesmartfee with Decred is presently (1) pointless given block
+	// utilization, and (2) based on the bitcoin core algorithm that tends to
+	// provide excessively high estimates for several reason including the lack
+	// of any block fullness metric or any special handling for a backlog of
+	// tickets in mempool that is unrelated to the fee market on account of the
+	// 20 ticket max per block.
+	return 10, nil // 0.0001 DCR/kB,
+}
+
+/*
 func (dcr *ExchangeWallet) feeRate(confTarget uint64) (uint64, error) {
 	// estimatesmartfee 1 returns extremely high rates on DCR.
 	if confTarget < 2 {
@@ -707,6 +718,7 @@ func (dcr *ExchangeWallet) feeRate(confTarget uint64) (uint64, error) {
 	// zero value if the atoms/KB is less than 1000.
 	return 1 + uint64(atomsPerKB)/1000, nil // dcrPerKB * 1e8 / 1e3
 }
+*/
 
 // feeRateWithFallback attempts to get the optimal fee rate in atoms / byte via
 // FeeRate. If that fails, it will return the configured fallback fee rate.

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -46,7 +46,7 @@ var (
 		RateStep:     100,
 		SwapConf:     1,
 	}
-	optimalFeeRate uint64 = 22
+	optimalFeeRate uint64 = 10
 	tErr                  = fmt.Errorf("test error")
 	tTxID                 = "308e9a3675fc3ea3862b7863eeead08c621dcc37ff59de597dd3cdab41450ad9"
 	tTxHash        *chainhash.Hash
@@ -238,6 +238,11 @@ func newTRPCClient() *tRPCClient {
 	}
 }
 
+// NOTE: EstimateSmartFee is not currently used by the Backend implementation
+// since Decred's estimatesmartfee is both pointless at present and not
+// particularly sophisticated. However, it is still part of the rpcClient
+// interface required by the Backend, so we will define one, and use it in the
+// future.
 func (c *tRPCClient) EstimateSmartFee(_ context.Context, confirmations int64, mode chainjson.EstimateSmartFeeMode) (float64, error) {
 	if c.estFeeErr != nil {
 		return 0, c.estFeeErr

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -241,6 +241,17 @@ func (dcr *Backend) InitTxSizeBase() uint32 {
 
 // FeeRate returns the current optimal fee rate in atoms / byte.
 func (dcr *Backend) FeeRate() (uint64, error) {
+	// estimatesmartfee with Decred is presently (1) pointless given block
+	// utilization, and (2) based on the bitcoin core algorithm that tends to
+	// provide excessively high estimates for several reason including the lack
+	// of any block fullness metric or any special handling for a backlog of
+	// tickets in mempool that is unrelated to the fee market on account of the
+	// 20 ticket max per block.
+	return 10, nil // 0.0001 DCR/kB, the default relay fee
+}
+
+/*
+func (dcr *Backend) FeeRate() (uint64, error) {
 	// estimatesmartfee 1 returns extremely high rates on DCR.
 	dcrPerKB, err := dcr.node.EstimateSmartFee(dcr.ctx, 2, chainjson.EstimateSmartFeeConservative)
 	if err != nil {
@@ -256,6 +267,7 @@ func (dcr *Backend) FeeRate() (uint64, error) {
 	}
 	return atomsPerB, nil
 }
+*/
 
 // BlockChannel creates and returns a new channel on which to receive block
 // updates. If the returned channel is ever blocking, there will be no error


### PR DESCRIPTION
estimatesmartfee with Decred is presently (1) pointless given block
utilization, and (2) based on the bitcoin core algorithm that tends to
provide excessively high estimates for several reason including the lack
of any block fullness metric or any special handling for a backlog of
tickets in mempool that is unrelated to the fee market on account of the
20 ticket max per block.

This changes the client and server dcr asset backend to return a
static fee rate of 10 atoms/B, which is the current default relay fee.

The motivation for this change is that we have observed the smart fee
algorithm recently responding is unpredictable ways to txns that sit
too long in mempool, and inconsistently between different nodes.
Using these fee rates will create a very poor experience for users.