### PR TITLE
server: ensure all fee rates are capped by config

### DIFF
--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -61,6 +61,7 @@ func (s *Server) apiConfig(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, s.core.ConfigMsg())
 }
 
+// apiAsset is the handler for the '/asset/{assetID}' API request.
 func (s *Server) apiAsset(w http.ResponseWriter, r *http.Request) {
 	assetSymbol := strings.ToLower(chi.URLParam(r, assetSymKey))
 	assetID, found := dex.BipSymbolID(assetSymbol)
@@ -82,6 +83,10 @@ func (s *Server) apiAsset(w http.ResponseWriter, r *http.Request) {
 		errs = append(errs, fmt.Sprintf("unable to get current fee rate: %v", err))
 	} else {
 		scaledFeeRate = s.core.ScaleFeeRate(assetID, currentFeeRate)
+		// Limit the scaled fee rate just as in (*Market).processReadyEpoch.
+		if scaledFeeRate > asset.MaxFeeRate {
+			scaledFeeRate = asset.MaxFeeRate
+		}
 	}
 
 	synced, err := backend.Synced()

--- a/server/admin/types.go
+++ b/server/admin/types.go
@@ -14,7 +14,9 @@ type AssetPost struct {
 	FeeRateScale *float64 `json:"feeRateScale,omitempty"`
 }
 
-// AssetInfo is the result of the asset GET.
+// AssetInfo is the result of the asset GET. Note that ScaledFeeRate is
+// CurrentFeeRate multiplied by an operator-specified fee scale rate for this
+// asset, and then limited by the dex.Asset.MaxFeeRate.
 type AssetInfo struct {
 	dex.Asset
 	CurrentFeeRate uint64   `json:"currentFeeRate,omitempty"`

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -558,7 +558,7 @@ func (r *BookRouter) msgOrderBook(book *msgBook) *msgjson.OrderBook {
 		MarketID:     book.name,
 		Epoch:        uint64(epochIdx),
 		Orders:       ords,
-		BaseFeeRate:  r.feeSource.LastRate(book.baseID),
+		BaseFeeRate:  r.feeSource.LastRate(book.baseID), // MaxFeeRate applied inside feeSource
 		QuoteFeeRate: r.feeSource.LastRate(book.quoteID),
 	}
 }
@@ -646,6 +646,7 @@ func (r *BookRouter) handleFeeRate(conn comms.Link, msg *msgjson.Message) *msgjs
 		}
 	}
 
+	// Note that MaxFeeRate is applied inside feeSource.
 	resp, err := msgjson.NewResponse(msg.ID, r.feeSource.LastRate(assetID), nil)
 	if err != nil {
 		log.Errorf("failed to encode fee_rate response: %v", err)

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -634,7 +634,7 @@ func (r *OrderRouter) checkZeroConfs(dexCoin asset.FundingCoin, fundingAsset *as
 	if confs > 0 {
 		return nil
 	}
-	lastKnownFeeRate := r.feeSource.LastRate(fundingAsset.ID)
+	lastKnownFeeRate := r.feeSource.LastRate(fundingAsset.ID) // MaxFeeRate applied inside feeSource
 	feeMinimum := uint64(math.Round(float64(lastKnownFeeRate) * ZeroConfFeeRateThreshold))
 	feeRate := dexCoin.FeeRate()
 	if lastKnownFeeRate > 0 && feeRate < feeMinimum {


### PR DESCRIPTION
Both `BoookRouter` and `OrderRouter` use `FeeManager.LastRate` to obtain
fee rates, and these need to have the configured `MaxFeeRate` applied.
This could be done in the caller but the `FeeManager` embeds the `dex.Asset`
and thus should obey the known limits itself.

The rate from `FeeFetcher.FeeRate` is also now capped, but consumers scale
this and apply the limit after scaling anyway. `(*Market).processReadyEpoch`
already applied the `MaxFeeRate` after scale, but `(*Server).apiAsset` was
neglecting this cap and it is now applied.  e.g. the limit being applied at match-time
to a bad rate from a bad DCR `estimatesmartfee` result:

```
[DBG] SWAP: Optimal fee rate for "dcr": 630
[WRN] SWAP: Optimal fee rate 630 > max fee rate 10, using max fee rate.
```

The above check and limit was only being done for rates provided with matches.
This PR also limits to the rates returned by the `'orderbook'` and `'fee_rate'`
responses from the `BookRouter`.  Huge DCR rates were making it to clients
through these routes without the limit applied.

This also applies to the zero-conf funding coin check performed by the
`OrderRouter` in `checkZeroConf`. Previously zero-conf coins were
held to a different and potentially higher fee rate than swaps that
could exceed `MaxFeeRate`.  This would cause pre-split backed orders to
be rejected quite easily, especially given the large discrepancies we have
seen between nodes w.r.t. their `estimatesmartfee` results.

This replaces PR https://github.com/decred/dcrdex/pull/1057.