### PR TITLE
app: abandon pre-order results if a new request is queued

### DIFF
--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -745,6 +745,9 @@ export default class MarketsPage extends BasePage {
         quote: qid,
         ...args
       })
+      // If a new timer is set, a change was made while fetching the pre-order.
+      // Abandon this result.
+      if (this.preorderTimer) return
       this.maxLoaded()
       this.maxLoaded = null
 


### PR DESCRIPTION
Resolves #998