### PR TITLE
server: MarketMatches includes swap/redeem coins

### DIFF
--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -272,7 +272,32 @@ func (s *Server) apiMarketMatches(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("failed to obtain match data: %v", err), http.StatusInternalServerError)
 		return
 	}
-	writeJSON(w, matches)
+	matchData := make([]*MatchData, len(matches))
+	for i, match := range matches {
+		matchData[i] = &MatchData{
+			TakerSell:   match.TakerSell,
+			ID:          match.ID.String(),
+			Maker:       match.Maker.String(),
+			MakerAcct:   match.MakerAcct.String(),
+			MakerSwap:   match.MakerSwap,
+			MakerRedeem: match.MakerRedeem,
+			MakerAddr:   match.MakerAddr,
+			Taker:       match.Taker.String(),
+			TakerAcct:   match.TakerAcct.String(),
+			TakerSwap:   match.TakerSwap,
+			TakerRedeem: match.TakerRedeem,
+			TakerAddr:   match.TakerAddr,
+			EpochIdx:    match.Epoch.Idx,
+			EpochDur:    match.Epoch.Dur,
+			Quantity:    match.Quantity,
+			Rate:        match.Rate,
+			BaseRate:    match.BaseRate,
+			QuoteRate:   match.QuoteRate,
+			Active:      match.Active,
+			Status:      match.Status.String(),
+		}
+	}
+	writeJSON(w, matchData)
 }
 
 // hander for route '/market/{marketName}/resume?t=UNIXMS'

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -23,6 +23,7 @@ import (
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/asset"
 	"decred.org/dcrdex/server/db"
+	dexsrv "decred.org/dcrdex/server/dex"
 	"decred.org/dcrdex/server/market"
 	"github.com/decred/slog"
 	"github.com/go-chi/chi/v5"
@@ -69,7 +70,7 @@ type SvrCore interface {
 	ForgiveMatchFail(aid account.AccountID, mid order.MatchID) (forgiven, unbanned bool, err error)
 	BookOrders(base, quote uint32) (orders []*order.LimitOrder, err error)
 	EpochOrders(base, quote uint32) (orders []order.Order, err error)
-	MarketMatches(base, quote uint32, includeInactive bool) ([]*db.MatchData, error)
+	MarketMatches(base, quote uint32, includeInactive bool) ([]*dexsrv.MatchData, error)
 	EnableDataAPI(yes bool)
 }
 

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -31,6 +31,7 @@ import (
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/asset"
 	"decred.org/dcrdex/server/db"
+	dexsrv "decred.org/dcrdex/server/dex"
 	"decred.org/dcrdex/server/market"
 	"github.com/decred/dcrd/certgen"
 	"github.com/decred/slog"
@@ -65,7 +66,7 @@ type TCore struct {
 	bookErr          error
 	epochOrders      []order.Order
 	epochOrdersErr   error
-	marketMatches    []*db.MatchData
+	marketMatches    []*dexsrv.MatchData
 	marketMatchesErr error
 	dataEnabled      uint32
 }
@@ -135,7 +136,7 @@ func (c *TCore) EpochOrders(_, _ uint32) ([]order.Order, error) {
 	return c.epochOrders, c.epochOrdersErr
 }
 
-func (c *TCore) MarketMatches(_, _ uint32, _ bool) ([]*db.MatchData, error) {
+func (c *TCore) MarketMatches(_, _ uint32, _ bool) ([]*dexsrv.MatchData, error) {
 	return c.marketMatches, c.marketMatchesErr
 }
 
@@ -661,28 +662,28 @@ func TestMarketMatches(t *testing.T) {
 	tests := []struct {
 		name, mkt, token    string
 		running, tokenValue bool
-		marketMatches       []*db.MatchData
+		marketMatches       []*dexsrv.MatchData
 		marketMatchesErr    error
 		wantCode            int
 	}{{
 		name:          "ok no token",
 		mkt:           "dcr_btc",
 		running:       true,
-		marketMatches: []*db.MatchData{},
+		marketMatches: []*dexsrv.MatchData{},
 		wantCode:      http.StatusOK,
 	}, {
 		name:          "ok with token",
 		mkt:           "dcr_btc",
 		running:       true,
 		token:         "?" + includeInactiveKey + "=true",
-		marketMatches: []*db.MatchData{},
+		marketMatches: []*dexsrv.MatchData{},
 		wantCode:      http.StatusOK,
 	}, {
 		name:          "bad token",
 		mkt:           "dcr_btc",
 		running:       true,
 		token:         "?" + includeInactiveKey + "=blue",
-		marketMatches: []*db.MatchData{},
+		marketMatches: []*dexsrv.MatchData{},
 		wantCode:      http.StatusBadRequest,
 	}, {
 		name:     "no market",
@@ -709,7 +710,7 @@ func TestMarketMatches(t *testing.T) {
 			t.Fatalf("%q: apiMarketMatches returned code %d, expected %d", test.name, w.Code, test.wantCode)
 		}
 		if w.Code == http.StatusOK {
-			res := new([]*db.MatchData)
+			res := new([]*dexsrv.MatchData)
 			if err := json.Unmarshal(w.Body.Bytes(), res); err != nil {
 				t.Errorf("%q: unexpected response %v: %v", test.name, w.Body.String(), err)
 			}

--- a/server/admin/types.go
+++ b/server/admin/types.go
@@ -34,6 +34,30 @@ type MarketStatus struct {
 	PersistBook   *bool  `json:"persistbook,omitempty"`
 }
 
+// MatchData describes a match.
+type MatchData struct {
+	ID          string `json:"id"`
+	TakerSell   bool   `json:"takerSell"`
+	Maker       string `json:"makerOrder"`
+	MakerAcct   string `json:"makerAcct"`
+	MakerSwap   string `json:"makerSwap"`
+	MakerRedeem string `json:"makerRedeem"`
+	MakerAddr   string `json:"makerAddr"`
+	Taker       string `json:"takerOrder"`
+	TakerAcct   string `json:"takerAcct"`
+	TakerSwap   string `json:"takerSwap"`
+	TakerRedeem string `json:"takerRedeem"`
+	TakerAddr   string `json:"takerAddr"`
+	EpochIdx    uint64 `json:"epochIdx"`
+	EpochDur    uint64 `json:"epochDur"`
+	Quantity    uint64 `json:"quantity"`
+	Rate        uint64 `json:"rate"`
+	BaseRate    uint64 `json:"baseFeeRate"`
+	QuoteRate   uint64 `json:"quoteFeeRate"`
+	Active      bool   `json:"active"`
+	Status      string `json:"status"`
+}
+
 // APITime marshals and unmarshals a time value in time.RFC3339Nano format.
 type APITime struct {
 	time.Time

--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -123,7 +123,8 @@ const (
 	RetrieveMarketMatches = `SELECT matchid, active, takerSell,
 		takerOrder, takerAccount, takerAddress,
 		makerOrder, makerAccount, makerAddress,
-		epochIdx, epochDur, quantity, rate, baseRate, quoteRate, status
+		epochIdx, epochDur, quantity, rate, baseRate, quoteRate, status,
+		aContractCoinID, bContractCoinID, aRedeemCoinID, bRedeemCoinID
 	FROM %s
 	WHERE takerSell IS NOT NULL -- not a cancel order
 	ORDER BY epochIdx * epochDur DESC;`
@@ -131,7 +132,8 @@ const (
 	RetrieveActiveMarketMatches = `SELECT matchid, takerSell,
 		takerOrder, takerAccount, takerAddress,
 		makerOrder, makerAccount, makerAddress,
-		epochIdx, epochDur, quantity, rate, baseRate, quoteRate, status
+		epochIdx, epochDur, quantity, rate, baseRate, quoteRate, status,
+		aContractCoinID, bContractCoinID, aRedeemCoinID, bRedeemCoinID
 	FROM %s
 	WHERE takerSell IS NOT NULL -- not a cancel order
 		AND active

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -243,6 +243,16 @@ type MatchData struct {
 	Status    order.MatchStatus // note that failed swaps, where Active=false, can have any status
 }
 
+// MatchDataWithCoins pairs MatchData (embedded) with the encode swap and redeem
+// coin IDs blobs for both maker and taker.
+type MatchDataWithCoins struct {
+	MatchData
+	MakerSwapCoin   []byte
+	MakerRedeemCoin []byte
+	TakerSwapCoin   []byte
+	TakerRedeemCoin []byte
+}
+
 // MatchStatus is the current status of a match, its known contracts and coin
 // IDs, and its secret, if known.
 type MatchStatus struct {
@@ -331,7 +341,7 @@ type MatchArchiver interface {
 	CompletedAndAtFaultMatchStats(aid account.AccountID, lastN int) ([]*MatchOutcome, error)
 	ForgiveMatchFail(mid order.MatchID) (bool, error)
 	AllActiveUserMatches(aid account.AccountID) ([]*MatchData, error)
-	MarketMatches(base, quote uint32, includeInactive bool) ([]*MatchData, error)
+	MarketMatches(base, quote uint32, includeInactive bool) ([]*MatchDataWithCoins, error)
 	MatchStatuses(aid account.AccountID, base, quote uint32, matchIDs []order.MatchID) ([]*MatchStatus, error)
 }
 

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -164,7 +164,7 @@ type Storage interface {
 	Fatal() <-chan struct{}
 	Close() error
 	InsertEpoch(ed *db.EpochResults) error
-	MarketMatches(base, quote uint32, includeInactive bool) ([]*db.MatchData, error)
+	MarketMatches(base, quote uint32, includeInactive bool) ([]*db.MatchDataWithCoins, error)
 }
 
 // NewMarket creates a new Market for the provided base and quote assets, with

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -56,7 +56,7 @@ func (ta *TArchivist) BookOrders(base, quote uint32) ([]*order.LimitOrder, error
 func (ta *TArchivist) EpochOrders(base, quote uint32) ([]order.Order, error) {
 	return nil, nil
 }
-func (ta *TArchivist) MarketMatches(base, quote uint32, includeInactive bool) ([]*db.MatchData, error) {
+func (ta *TArchivist) MarketMatches(base, quote uint32, includeInactive bool) ([]*db.MatchDataWithCoins, error) {
 	return nil, nil
 }
 func (ta *TArchivist) FlushBook(base, quote uint32) (sells, buys []order.OrderID, err error) {


### PR DESCRIPTION
This modifies the admin endpoint at `/api/market/{marketID}/matches` to return decoded swap and redeem coin IDs and idiomatic json field names.

Before

```json
[
    {
        "ID": "513855f29eaf0783eac3290e5e0d545d9f04f588741f3c372c027715d38d895f",
        "Taker": "d3e2b7bf0e5e6f55deed4991c75751a1f70bbd7ad88d5ed8a1ecb673b2ee2e92",
        "TakerAcct": "b37eeb6e7be5824594d5fb69491766f12cad9ba37d04f49d4a97613954eaebd2",
        "TakerAddr": "SssSuedGa2bkFHHXJ9hYBDVxDGLHoq3ytxt",
        "TakerSell": false,
        "Maker": "b5e5bc4ae87fd756a718531f57f1252b0720d454d98a68b048828192f23ff2eb",
        "MakerAcct": "b37eeb6e7be5824594d5fb69491766f12cad9ba37d04f49d4a97613954eaebd2",
        "MakerAddr": "bcrt1q2yfrdausj2dwsgjwg2wpmdrrevervjfq5v66ru",
        "Epoch": {
            "Idx": 107936073,
            "Dur": 15000
        },
        "Quantity": 1000000000,
        "Rate": 1000000,
        "BaseRate": 10,
        "QuoteRate": 1,
        "Active": false,
        "Status": 4
    }
]
```

After

```json
[
    {
        "id": "513855f29eaf0783eac3290e5e0d545d9f04f588741f3c372c027715d38d895f",
        "takerSell": false,
        "makerOrder": "b5e5bc4ae87fd756a718531f57f1252b0720d454d98a68b048828192f23ff2eb",
        "makerAcct": "b37eeb6e7be5824594d5fb69491766f12cad9ba37d04f49d4a97613954eaebd2",
        "makerSwap": "fd7b5a6b5130f42da368ed400dc88ef4bb5d247414690944d552c65c9ffe297b:0",
        "makerRedeem": "48dd66328f4c2de3e249c3bc9d6104bc88dede8e2e8315b8b0876b7321778de4:0",
        "makerAddr": "bcrt1q2yfrdausj2dwsgjwg2wpmdrrevervjfq5v66ru",
        "takerOrder": "d3e2b7bf0e5e6f55deed4991c75751a1f70bbd7ad88d5ed8a1ecb673b2ee2e92",
        "takerAcct": "b37eeb6e7be5824594d5fb69491766f12cad9ba37d04f49d4a97613954eaebd2",
        "takerSwap": "263b5ca408e939c8402b9dd103541158c02799b480f01dedf31a9e5a560d7367:0",
        "takerRedeem": "3670b643052ce864cad2009adb4f733a17c2cddf165526a4e49286bf629cb872:0",
        "takerAddr": "SssSuedGa2bkFHHXJ9hYBDVxDGLHoq3ytxt",
        "epochIdx": 107936073,
        "epochDur": 15000,
        "quantity": 1000000000,
        "rate": 1000000,
        "baseFeeRate": 10,
        "quoteFeeRate": 1,
        "active": false,
        "status": "MatchComplete"
    }
]

```

The `MarketMatches` db method has a modified query with the 4 extra coin IDs.  The consumers are the admin server and the market constructor, which only uses the order IDs and quantities of active orders.