### PR TITLE
client/db/bolt: omit copy of buffer and upgrade in separate db txns

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -386,7 +386,7 @@ func (tdb *TDB) ActiveMatches() ([]*db.MetaMatch, error) {
 	return nil, nil
 }
 
-func (tdb *TDB) MatchesForOrder(oid order.OrderID) ([]*db.MetaMatch, error) {
+func (tdb *TDB) MatchesForOrder(oid order.OrderID, excludeCancels bool) ([]*db.MetaMatch, error) {
 	return tdb.matchesForOID, tdb.matchesForOIDErr
 }
 

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -87,7 +87,7 @@ type DB interface {
 	// state.
 	DEXOrdersWithActiveMatches(dex string) ([]order.OrderID, error)
 	// MatchesForOrder gets the matches for the order ID.
-	MatchesForOrder(oid order.OrderID) ([]*MetaMatch, error)
+	MatchesForOrder(oid order.OrderID, excludeCancels bool) ([]*MetaMatch, error)
 	// Update wallets adds a wallet to the database, or updates the wallet
 	// credentials if the wallet already exists. A wallet is specified by the
 	// pair (asset ID, account name).

--- a/client/db/test/types_test.go
+++ b/client/db/test/types_test.go
@@ -40,11 +40,14 @@ func TestMatchProof(t *testing.T) {
 	nTimes(spins, func(i int) {
 		proof := proofs[i]
 		proofB := proof.Encode()
-		reProof, err := db.DecodeMatchProof(proofB)
+		reProof, ver, err := db.DecodeMatchProof(proofB)
 		if err != nil {
 			t.Fatalf("match decode error: %v", err)
 		}
 		MustCompareMatchProof(t, proof, reProof)
+		if ver != db.MatchProofVer {
+			t.Errorf("wanted match proof ver %d, got %d", db.MatchProofVer, ver)
+		}
 	})
 	t.Logf("encoded, decoded, and compared %d MatchProof in %d ms", spins, time.Since(tStart)/time.Millisecond)
 }

--- a/dex/encode/encode.go
+++ b/dex/encode/encode.go
@@ -108,8 +108,12 @@ func DecodeUTime(b []byte) time.Time {
 
 // ExtractPushes parses the linearly-encoded 2D byte slice into a slice of
 // slices. Empty pushes are nil slices.
-func ExtractPushes(b []byte) ([][]byte, error) {
-	pushes := make([][]byte, 0)
+func ExtractPushes(b []byte, preAlloc ...int) ([][]byte, error) {
+	allocPushes := 2
+	if len(preAlloc) > 0 {
+		allocPushes = preAlloc[0]
+	}
+	pushes := make([][]byte, 0, allocPushes)
 	for {
 		if len(b) == 0 {
 			break
@@ -139,13 +143,13 @@ func ExtractPushes(b []byte) ([][]byte, error) {
 
 // DecodeBlob decodes a versioned blob into its version and the pushes extracted
 // from its data. Empty pushes will be nil.
-func DecodeBlob(b []byte) (byte, [][]byte, error) {
+func DecodeBlob(b []byte, preAlloc ...int) (byte, [][]byte, error) {
 	if len(b) == 0 {
 		return 0, nil, fmt.Errorf("zero length blob not allowed")
 	}
 	ver := b[0]
 	b = b[1:]
-	pushes, err := ExtractPushes(b)
+	pushes, err := ExtractPushes(b, preAlloc...)
 	return ver, pushes, err
 }
 

--- a/dex/order/serialize.go
+++ b/dex/order/serialize.go
@@ -31,7 +31,7 @@ func EncodePrefix(p *Prefix) []byte {
 
 // DecodePrefix decodes the versioned blob to a *Prefix.
 func DecodePrefix(b []byte) (prefix *Prefix, err error) {
-	ver, pushes, err := encode.DecodeBlob(b)
+	ver, pushes, err := encode.DecodeBlob(b, 7)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func EncodeTrade(ord *Trade) []byte {
 // DecodeTrade decodes the versioned-blob market order, but does not populate
 // the embedded Prefix.
 func DecodeTrade(b []byte) (trade *Trade, err error) {
-	ver, pushes, err := encode.DecodeBlob(b)
+	ver, pushes, err := encode.DecodeBlob(b, 5)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func EncodeMatch(match *UserMatch) []byte {
 
 // DecodeMatch decodes the versioned blob into a UserMatch.
 func DecodeMatch(b []byte) (match *UserMatch, err error) {
-	ver, pushes, err := encode.DecodeBlob(b)
+	ver, pushes, err := encode.DecodeBlob(b, 8)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +252,7 @@ func EncodeOrder(ord Order) []byte {
 // DecodeOrder decodes the byte-encoded order. DecodeOrder accepts any type of
 // order.
 func DecodeOrder(b []byte) (ord Order, err error) {
-	ver, pushes, err := encode.DecodeBlob(b)
+	ver, pushes, err := encode.DecodeBlob(b, 4) // pushes actually depends on order type
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This attempts to address high memory utilization (both VIRT and RES) during a db upgrade with the following changes:

- Eliminate the copy of two buffers from a `db.Get` because they are not used outside the db.Tx and thus do not need to be copies.
- Put each upgrade into a separate transaction.  This reduced memory use in my tests noticeably, but this means that if one upgrade in series of several version upgrades fails, it does not rollback to the starting version in the series, just the one version.
- A handful of preallocation optimizations, excluding cancel matches when loading an orders matches with `MatchesForOrder`, and not re-saving cancel matches in `reloadMatchProofs` since they will always lack both revoke bools and txdata fields that are added in these upgrades.  https://github.com/decred/dcrdex/pull/1070/commits/d977162eb145d4276e3df85c81a81d5ca708b5e4  However, I'm uncertain now if `reloadMatchProofs` really needs to be done ever since `DecodeMatchProof` ensures old encodings load the same way as new encodings.
- The v2 upgrade no longer sets maxFeeRate for old cancel orders.  These are and should be stored as zero anyway (see `tryCancelTrade`), so `^uint8(0)` was incorrect here previously.  But the `maxFeeRate` is correctly ignored for cancel matches in `(*dexConnection).parseMatches`. Skipping these updates to cancel orders further improves memory utilization and speed. https://github.com/decred/dcrdex/pull/1070/commits/68a6cb356e2baadb8ef25ed2aebeb367c7385877

These changes will be needed for the 0.2 upgrade since there are some rather large client DBs out there that are going to have similar troubles.