### PR TITLE
chart: stop the wheel event propagation.

### DIFF
--- a/client/webserver/site/src/js/charts.js
+++ b/client/webserver/site/src/js/charts.js
@@ -116,6 +116,7 @@ export class DepthChart {
   // wheel is a mousewheel event handler.
   wheel (e) {
     this.zoom(e.deltaY < 0)
+    e.preventDefault()
   }
 
   // zoom zooms the current view in or out. bigger=true is zoom in.


### PR DESCRIPTION
This stops the wheel event propagation to prevent the page scroll bug when having long orders list.

Closes #1063.