### PR TITLE
Handle all the errors when creating DEX.

### DIFF
--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -560,7 +560,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	// Start the AuthManager and Swapper subsystems after populating the markets
 	// map used by the unbook callbacks, and setting the AuthManager's unbook
 	// timers for the users with currently booked orders.
-	//
+
 	// This subsystem is a dex.Runner, it doesn't return errors.
 	_ = startSubSys("Auth manager", authMgr)
 

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -560,18 +560,12 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	// Start the AuthManager and Swapper subsystems after populating the markets
 	// map used by the unbook callbacks, and setting the AuthManager's unbook
 	// timers for the users with currently booked orders.
-	const authManagerName = "Auth manager"
-	err = startSubSys(authManagerName, authMgr)
-	if err != nil {
-		abort()
-		return nil, fmt.Errorf("start subsystems for %s: %w", authManagerName, err)
-	}
-	const swapperName = "Swapper"
-	err = startSubSys(swapperName, swapper)
-	if err != nil {
-		abort()
-		return nil, fmt.Errorf("start subsystems for %s: %w", swapperName, err)
-	}
+	//
+	// This subsystem is a dex.Runner, it doesn't return errors.
+	_ = startSubSys("Auth manager", authMgr)
+
+	// This subsystem is a dex.Runner, it doesn't return errors.
+	_ = startSubSys("Swapper", swapper)
 
 	// Set start epoch index for each market. Also create BookSources for the
 	// BookRouter, and MarketTunnels for the OrderRouter.
@@ -596,14 +590,10 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		})
 	}
 
-	// Book router
+	// Book router.
 	bookRouter := market.NewBookRouter(bookSources, feeMgr)
-	const bookRouterName = "BookRouter"
-	err = startSubSys(bookRouterName, bookRouter)
-	if err != nil {
-		abort()
-		return nil, fmt.Errorf("start subsystems for %s: %w", bookRouterName, err)
-	}
+	// This subsystem is a dex.Runner, it doesn't return errors.
+	_ = startSubSys("BookRouter", bookRouter)
 
 	// The data API gets the order book from the book router.
 	dataAPI.SetBookSource(bookRouter)
@@ -611,11 +601,8 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	// Market, now that book router is running.
 	for name, mkt := range markets {
 		mktName := marketSubSysName(name)
-		err = startSubSys(mktName, mkt)
-		if err != nil {
-			abort()
-			return nil, fmt.Errorf("start subsystems for %s: %w", mktName, err)
-		}
+		// This subsystem is a dex.Runner, it doesn't return errors.
+		_ = startSubSys(mktName, mkt)
 	}
 
 	// Order router
@@ -625,12 +612,8 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		Markets:     marketTunnels,
 		FeeSource:   feeMgr,
 	})
-	const orderRouterName = "OrderRouter"
-	err = startSubSys(orderRouterName, orderRouter)
-	if err != nil {
-		abort()
-		return nil, fmt.Errorf("start subsystems for %s: %w", orderRouterName, err)
-	}
+	// This subsystem is a dex.Runner, it doesn't return errors.
+	_ = startSubSys("OrderRouter", orderRouter)
 
 	if err := ctx.Err(); err != nil {
 		abort()
@@ -666,12 +649,8 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 
 	comms.RegisterHTTP(msgjson.ConfigRoute, dexMgr.handleDEXConfig)
 
-	const commsServerName = "Comms Server"
-	err = startSubSys(commsServerName, server)
-	if err != nil {
-		abort()
-		return nil, fmt.Errorf("start subsystems for %s: %w", commsServerName, err)
-	}
+	// This subsystem is a dex.Runner, it doesn't return errors.
+	_ = startSubSys("Comms Server", server)
 
 	return dexMgr, nil
 }


### PR DESCRIPTION
I've been looking at `DEX` codebase lately, and one of the things I've noticed (addressing it via this PR) is unhandled errors when creating `DEX` instance.
It seems to me, `err` should be propagated further from `NewDEX` if any of the `subsystems` failed to `Connect` (cause I doubt there are attempts to re-connect a subsystem if it fails to connect on the very first try, are there ?).

Or, if that's not the case, then maybe we should ignore `error`s from `startSubSys` explicitely (to show our intentions) ? Leaving a comment for why we ignore error would help as well.

Disclamer: this is my first contribution to `DEX`.