### PR TITLE
bolt/upgrades: Remove redundant fetchDBVersion.

### DIFF
--- a/client/db/bolt/upgrades.go
+++ b/client/db/bolt/upgrades.go
@@ -101,8 +101,7 @@ func getVersionTx(tx *bbolt.Tx) (uint32, error) {
 	}
 	versionB := bucket.Get(versionKey)
 	if versionB == nil {
-		// A nil version indicates a version 0 database.
-		return 0, nil
+		return 0, fmt.Errorf("database version not found")
 	}
 	return intCoder.Uint32(versionB), nil
 }

--- a/client/db/bolt/upgrades.go
+++ b/client/db/bolt/upgrades.go
@@ -33,20 +33,6 @@ var upgrades = [...]upgradefunc{
 // upgrades prevent reverting to older software).
 const DBVersion = uint32(len(upgrades))
 
-func fetchDBVersion(tx *bbolt.Tx) (uint32, error) {
-	bucket := tx.Bucket(appBucket)
-	if bucket == nil {
-		return 0, fmt.Errorf("app bucket not found")
-	}
-
-	versionB := bucket.Get(versionKey)
-	if versionB == nil {
-		return 0, fmt.Errorf("database version not found")
-	}
-
-	return intCoder.Uint32(versionB), nil
-}
-
 func setDBVersion(tx *bbolt.Tx, newVersion uint32) error {
 	bucket := tx.Bucket(appBucket)
 	if bucket == nil {
@@ -142,7 +128,7 @@ func v1Upgrade(dbtx *bbolt.Tx) error {
 func v2Upgrade(dbtx *bbolt.Tx) error {
 	const oldVersion = 1
 
-	dbVersion, err := fetchDBVersion(dbtx)
+	dbVersion, err := getVersionTx(dbtx)
 	if err != nil {
 		return fmt.Errorf("error fetching database version: %w", err)
 	}
@@ -195,7 +181,7 @@ func v3Upgrade(dbtx *bbolt.Tx) error {
 }
 
 func ensureVersion(tx *bbolt.Tx, ver uint32) error {
-	dbVersion, err := fetchDBVersion(tx)
+	dbVersion, err := getVersionTx(tx)
 	if err != nil {
 		return fmt.Errorf("error fetching database version: %w", err)
 	}


### PR DESCRIPTION
Using an old database on master, I was getting:

```
./dexc
2021-05-07 05:11:03.456 [INF] DEXC: dexc version 0.2.0-pre+dev (Go version go1.16)
2021-05-07 05:11:03.456 [INF] DEXC: Logging with UTC time stamps. Current local time is 14:11:03 JST
2021-05-07 05:11:03.459 [INF] CORE[DB]: Upgrading database from version 0 to 3
2021-05-07 05:11:03.459 [DBG] CORE[DB]: Upgrading to version 1...
error creating client core: database initialization error: error upgrading DB: error fetching database version: database version not found
```
Although `getVersionTx` returns version 0 for no bucket, `fetchDBVersion` would error. I can't see the purpose is having both of these, so removing one.

This probably means that our gzipped test database has a version with value 0.