### PR TITLE
multi: Fix maxOrders panic.

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -767,6 +767,10 @@ func (btc *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asse
 // []*compositeUTXO to be used for further order estimation without additional
 // calls to listunspent.
 func (btc *ExchangeWallet) maxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (utxos []*compositeUTXO, est *asset.SwapEstimate, err error) {
+	if lotSize == 0 {
+		return nil, nil, errors.New("cannot divide by lotSize zero")
+	}
+
 	btc.fundingMtx.RLock()
 	utxos, _, avail, err := btc.spendableUTXOs(0)
 	btc.fundingMtx.RUnlock()

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -757,6 +757,7 @@ func (btc *ExchangeWallet) feeRateWithFallback(confTarget, feeSuggestion uint64)
 // estimate based on current network conditions, and will be <= the fees
 // associated with nfo.MaxFeeRate. For quote assets, the caller will have to
 // calculate lotSize based on a rate conversion from the base asset's lot size.
+// lotSize must not be zero and will cause a panic if so.
 func (btc *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*asset.SwapEstimate, error) {
 	_, maxEst, err := btc.maxOrder(lotSize, feeSuggestion, nfo)
 	return maxEst, err
@@ -766,9 +767,6 @@ func (btc *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asse
 // []*compositeUTXO to be used for further order estimation without additional
 // calls to listunspent.
 func (btc *ExchangeWallet) maxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (utxos []*compositeUTXO, est *asset.SwapEstimate, err error) {
-	if lotSize == 0 {
-		return nil, nil, errors.New("cannot divide by lotSize zero")
-	}
 	btc.fundingMtx.RLock()
 	utxos, _, avail, err := btc.spendableUTXOs(0)
 	btc.fundingMtx.RUnlock()

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -752,6 +752,10 @@ func (dcr *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asse
 // []*compositeUTXO and network fee rate to be used for further order estimation
 // without additional calls to listunspent.
 func (dcr *ExchangeWallet) maxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (utxos []*compositeUTXO, est *asset.SwapEstimate, err error) {
+	if lotSize == 0 {
+		return nil, nil, errors.New("cannot divide by lotSize zero")
+	}
+
 	utxos, err = dcr.spendableUTXOs()
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing unspent outputs: %w", err)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -742,6 +742,7 @@ func (a amount) String() string {
 // estimate based on current network conditions, and will be <= the fees
 // associated with nfo.MaxFeeRate. For quote assets, the caller will have to
 // calculate lotSize based on a rate conversion from the base asset's lot size.
+// lotSize must not be zero and will cause a panic if so.
 func (dcr *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*asset.SwapEstimate, error) {
 	_, est, err := dcr.maxOrder(lotSize, feeSuggestion, nfo)
 	return est, err
@@ -751,10 +752,6 @@ func (dcr *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asse
 // []*compositeUTXO and network fee rate to be used for further order estimation
 // without additional calls to listunspent.
 func (dcr *ExchangeWallet) maxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (utxos []*compositeUTXO, est *asset.SwapEstimate, err error) {
-	if lotSize == 0 {
-		return nil, nil, errors.New("cannot divide by lotSize zero")
-	}
-
 	utxos, err = dcr.spendableUTXOs()
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing unspent outputs: %w", err)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -751,6 +751,9 @@ func (dcr *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asse
 // []*compositeUTXO and network fee rate to be used for further order estimation
 // without additional calls to listunspent.
 func (dcr *ExchangeWallet) maxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (utxos []*compositeUTXO, est *asset.SwapEstimate, err error) {
+	if lotSize == 0 {
+		return nil, nil, errors.New("cannot divide by lotSize zero")
+	}
 
 	utxos, err = dcr.spendableUTXOs()
 	if err != nil {
@@ -761,8 +764,9 @@ func (dcr *ExchangeWallet) maxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asse
 		avail += toAtoms(utxo.rpc.Amount)
 	}
 
-	// Start by attempting max lots with no fees.
-	lots := avail / lotSize
+	// Start by attempting max lots with a basic fee.
+	basicFee := nfo.SwapSize * nfo.MaxFeeRate
+	lots := avail / (lotSize + basicFee)
 	for lots > 0 {
 		est, _, err := dcr.estimateSwap(lots, lotSize, feeSuggestion, utxos, nfo, dcr.useSplitTx)
 		// The only failure mode of estimateSwap -> dcr.fund is when there is

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -93,8 +93,8 @@ type Wallet interface {
 	// associated fees that the wallet can support for the specified DEX. The
 	// fees are an estimate based on current network conditions, and will be <=
 	// the fees associated with the Asset.MaxFeeRate. For quote assets, lotSize
-	// will be an estimate based on current market conditions. lotSize must
-	// not be zero and will cause a panic if so.
+	// will be an estimate based on current market conditions. lotSize should
+	// not be zero.
 	MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*SwapEstimate, error)
 	// PreSwap gets a pre-swap estimate for the specified order size.
 	PreSwap(*PreSwapForm) (*PreSwap, error)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -93,7 +93,8 @@ type Wallet interface {
 	// associated fees that the wallet can support for the specified DEX. The
 	// fees are an estimate based on current network conditions, and will be <=
 	// the fees associated with the Asset.MaxFeeRate. For quote assets, lotSize
-	// will be an estimate based on current market conditions.
+	// will be an estimate based on current market conditions. lotSize must
+	// not be zero and will cause a panic if so.
 	MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*SwapEstimate, error)
 	// PreSwap gets a pre-swap estimate for the specified order size.
 	PreSwap(*PreSwapForm) (*PreSwap, error)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2718,6 +2718,11 @@ func (c *Core) MaxBuy(host string, base, quote uint32, rate uint64) (*MaxOrderEs
 	}
 
 	quoteLotEst := calc.BaseToQuote(rate, baseAsset.LotSize)
+
+	if quoteLotEst == 0 {
+		return nil, errors.New("cannot divide by lot size zero")
+	}
+
 	maxBuy, err := quoteWallet.MaxOrder(quoteLotEst, swapFeeSuggestion, quoteAsset)
 	if err != nil {
 		return nil, fmt.Errorf("%s wallet MaxOrder error: %v", unbip(quote), err)
@@ -2766,6 +2771,10 @@ func (c *Core) MaxSell(host string, base, quote uint32) (*MaxOrderEstimate, erro
 	redeemFeeSuggestion := c.feeSuggestion(dc, quote, false)
 	if redeemFeeSuggestion == 0 {
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(quote), host)
+	}
+
+	if baseAsset.LotSize == 0 {
+		return nil, errors.New("cannot divide by lot size zero")
 	}
 
 	maxSell, err := baseWallet.MaxOrder(baseAsset.LotSize, swapFeeSuggestion, baseAsset)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2702,6 +2702,11 @@ func (c *Core) MaxBuy(host string, base, quote uint32, rate uint64) (*MaxOrderEs
 		return nil, err
 	}
 
+	quoteLotEst := calc.BaseToQuote(rate, baseAsset.LotSize)
+	if quoteLotEst == 0 {
+		return nil, errors.New("cannot divide by lot size zero")
+	}
+
 	dc, _, err := c.dex(host)
 	if err != nil {
 		return nil, err
@@ -2715,12 +2720,6 @@ func (c *Core) MaxBuy(host string, base, quote uint32, rate uint64) (*MaxOrderEs
 	redeemFeeSuggestion := c.feeSuggestion(dc, base, false)
 	if redeemFeeSuggestion == 0 {
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(base), host)
-	}
-
-	quoteLotEst := calc.BaseToQuote(rate, baseAsset.LotSize)
-
-	if quoteLotEst == 0 {
-		return nil, errors.New("cannot divide by lot size zero")
 	}
 
 	maxBuy, err := quoteWallet.MaxOrder(quoteLotEst, swapFeeSuggestion, quoteAsset)
@@ -2751,6 +2750,10 @@ func (c *Core) MaxSell(host string, base, quote uint32) (*MaxOrderEstimate, erro
 		return nil, err
 	}
 
+	if baseAsset.LotSize == 0 {
+		return nil, errors.New("cannot divide by lot size zero")
+	}
+
 	dc, _, err := c.dex(host)
 	if err != nil {
 		return nil, err
@@ -2771,10 +2774,6 @@ func (c *Core) MaxSell(host string, base, quote uint32) (*MaxOrderEstimate, erro
 	redeemFeeSuggestion := c.feeSuggestion(dc, quote, false)
 	if redeemFeeSuggestion == 0 {
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(quote), host)
-	}
-
-	if baseAsset.LotSize == 0 {
-		return nil, errors.New("cannot divide by lot size zero")
 	}
 
 	maxSell, err := baseWallet.MaxOrder(baseAsset.LotSize, swapFeeSuggestion, baseAsset)

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -650,20 +650,21 @@ export default class MarketsPage extends BasePage {
   previewQuoteAmt (show) {
     const page = this.page
     const order = this.parseOrder()
+    const adjusted = this.adjustedRate()
     page.orderErr.textContent = ''
-    if (order.rate) {
+    if (adjusted) {
       if (order.sell) this.preSell()
       else this.preBuy()
     }
     this.depthLines.input = []
-    if (order.rate && this.isLimit()) {
+    if (adjusted && this.isLimit()) {
       this.depthLines.input = [{
         rate: order.rate / 1e8,
         color: order.sell ? this.chart.theme.sellLine : this.chart.theme.buyLine
       }]
     }
     this.drawChartLines()
-    if (!show || !order.rate || !order.qty) {
+    if (!show || !adjusted || !order.qty) {
       page.orderPreview.textContent = ''
       this.drawChartLines()
       return
@@ -1409,15 +1410,15 @@ export default class MarketsPage extends BasePage {
    * input.
    */
   rateFieldChanged () {
-    const order = this.parseOrder()
-    if (order.rate <= 0) {
+    // Truncate to rate step. If it is a market buy order, do not adjust.
+    const adjusted = this.adjustedRate()
+    if (adjusted <= 0) {
       this.depthLines.input = []
       this.drawChartLines()
       this.page.rateField.value = 0
       return
     }
-    // Truncate to rate step. If it is a market buy order, do not adjust.
-    const adjusted = this.adjustedRate()
+    const order = this.parseOrder()
     const v = (adjusted / 1e8)
     this.page.rateField.value = v
     this.depthLines.input = [{


### PR DESCRIPTION
    Ignore prices below the rate step in markets.js.

    Error on zero lots in MaxOrder.

    Use an estimation for number of starting lots that includes a basic fee.
    This lets estimations for very large orders start closer to the final
    fee.

closes #1085