### PR TITLE
ui: Display order errors on the form.

### DIFF
--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -425,6 +425,10 @@ table.balance-table button:hover {
       background-color: #99302b99;
     }
   }
+
+  .loader {
+    height: 40px;
+  }
 }
 
 div.numorders {

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -440,6 +440,9 @@
               <span id="vSideSubmit"></span>
               <span id="vBaseSubmit"></span>
             </button>
+            <div id="vLoader" class="loader flex-center d-hide">
+              <div class="ico-spinner spinner"></div>
+            </div>
           </div>
         </div>
         <div class="fs15 pt-3 text-center d-hide errcolor" id="vErr"></div>

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -442,6 +442,7 @@
             </button>
           </div>
         </div>
+        <div class="fs15 pt-3 text-center d-hide errcolor" id="vErr"></div>
         <hr class="dashed my-3">
         <div class="disclaimer mt-2 fs14">
           <span class="red">IMPORTANT</span>: Trades take time to settle, and you cannot turn off the DEX client software,

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -1326,7 +1326,6 @@ export default class MarketsPage extends BasePage {
    */
   async submitOrder () {
     const page = this.page
-    const market = this.market
     Doc.hide(page.forms)
     const order = this.parseOrder()
     const pw = page.vPass.value
@@ -1337,14 +1336,10 @@ export default class MarketsPage extends BasePage {
     }
     if (!this.validateOrder(order)) return
     const res = await postJSON('/api/trade', req)
-    if (!app.checkResponse(res)) return
-    // If the wallets are not open locally, they must have been opened during
-    // ordering. Grab updated info.
-    const baseWallet = app.walletMap[market.base.id]
-    const quoteWallet = app.walletMap[market.quote.id]
-    if (!baseWallet.open || !quoteWallet.open) {
-      this.balanceWgt.updateAsset(market.base.id)
-      this.balanceWgt.updateAsset(market.quote.id)
+    if (!app.checkResponse(res, true)) {
+      page.orderErr.textContent = res.msg
+      Doc.show(page.orderErr)
+      return
     }
     this.refreshActiveOrders()
     this.chart.draw()

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -51,7 +51,8 @@ export default class MarketsPage extends BasePage {
       'forms', 'openForm', 'uwAppPass',
       // Order submission is verified with the user's password.
       'verifyForm', 'vHeader', 'vSideHeader', 'vSide', 'vQty', 'vBase', 'vRate',
-      'vTotal', 'vQuote', 'vPass', 'vSideSubmit', 'vBaseSubmit', 'vSubmit', 'verifyLimit', 'verifyMarket',
+      'vTotal', 'vQuote', 'vPass', 'vSideSubmit', 'vBaseSubmit', 'vSubmit',
+      'vLoader', 'verifyLimit', 'verifyMarket',
       'vmTotal', 'vmAsset', 'vmLots', 'mktBuyScore', 'vErr',
       // Create wallet form
       'walletForm',
@@ -1326,7 +1327,6 @@ export default class MarketsPage extends BasePage {
    */
   async submitOrder () {
     const page = this.page
-    page.vSubmit.disabled = true
     Doc.hide(page.orderErr, page.vErr)
     const order = this.parseOrder()
     const pw = page.vPass.value
@@ -1336,17 +1336,21 @@ export default class MarketsPage extends BasePage {
       pw: pw
     }
     if (!this.validateOrder(order)) return
+    // Show loader and hide submit button.
+    page.vSubmit.classList.add('d-hide')
+    page.vLoader.classList.remove('d-hide')
     const res = await postJSON('/api/trade', req)
+    // Hide loader and show submit button.
+    page.vSubmit.classList.remove('d-hide')
+    page.vLoader.classList.add('d-hide')
     // If errors display error on confirmation modal.
     if (!app.checkResponse(res, true)) {
       page.vErr.textContent = res.msg
       Doc.show(page.vErr)
-      page.vSubmit.disabled = false
       return
     }
     // Hide confirmation modal only on success.
     Doc.hide(page.forms)
-    page.vSubmit.disabled = false
     this.refreshActiveOrders()
     this.chart.draw()
   }

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -52,7 +52,7 @@ export default class MarketsPage extends BasePage {
       // Order submission is verified with the user's password.
       'verifyForm', 'vHeader', 'vSideHeader', 'vSide', 'vQty', 'vBase', 'vRate',
       'vTotal', 'vQuote', 'vPass', 'vSideSubmit', 'vBaseSubmit', 'vSubmit', 'verifyLimit', 'verifyMarket',
-      'vmTotal', 'vmAsset', 'vmLots', 'mktBuyScore',
+      'vmTotal', 'vmAsset', 'vmLots', 'mktBuyScore', 'vErr',
       // Create wallet form
       'walletForm',
       // Active orders
@@ -1326,7 +1326,8 @@ export default class MarketsPage extends BasePage {
    */
   async submitOrder () {
     const page = this.page
-    Doc.hide(page.forms)
+    page.vSubmit.disabled = true
+    Doc.hide(page.orderErr, page.vErr)
     const order = this.parseOrder()
     const pw = page.vPass.value
     page.vPass.value = ''
@@ -1336,11 +1337,16 @@ export default class MarketsPage extends BasePage {
     }
     if (!this.validateOrder(order)) return
     const res = await postJSON('/api/trade', req)
+    // If errors display error on confirmation modal.
     if (!app.checkResponse(res, true)) {
-      page.orderErr.textContent = res.msg
-      Doc.show(page.orderErr)
+      page.vErr.textContent = res.msg
+      Doc.show(page.vErr)
+      page.vSubmit.disabled = false
       return
     }
+    // Hide confirmation modal only on success.
+    Doc.hide(page.forms)
+    page.vSubmit.disabled = false
     this.refreshActiveOrders()
     this.chart.draw()
   }


### PR DESCRIPTION
Closes #1045.

> As a general rule, any error encountered when submitting a form should be displayed on the form itself, not the notification bell. 

We will need to skip notification in checkResponse function and just return false if there is an error, and then display `res.msg` in related form's error section for all other forms.