### PR TITLE
frontend: order status for unfilled non-standing orders

### DIFF
--- a/client/webserver/site/src/js/orderutil.js
+++ b/client/webserver/site/src/js/orderutil.js
@@ -59,7 +59,7 @@ export function statusString (order) {
       return isLive ? 'booked/settling' : 'booked'
     case StatusExecuted:
       if (isLive) return 'settling'
-      return (order.filled === 0) ? 'expired' : 'executed'
+      return (order.filled === 0) ? 'no match' : 'executed'
     case StatusCanceled: return isLive ? 'canceled/settling' : 'canceled'
     case StatusRevoked: return isLive ? 'revoked/settling' : 'revoked'
   }

--- a/client/webserver/site/src/js/orderutil.js
+++ b/client/webserver/site/src/js/orderutil.js
@@ -54,8 +54,12 @@ export function statusString (order) {
   switch (order.status) {
     case StatusUnknown: return 'unknown'
     case StatusEpoch: return 'epoch'
-    case StatusBooked: return order.cancelling ? 'cancelling' : 'booked'
-    case StatusExecuted: return isLive ? 'settling' : 'executed'
+    case StatusBooked:
+      if (order.cancelling) return 'cancelling'
+      return isLive ? 'booked/settling' : 'booked'
+    case StatusExecuted:
+      if (isLive) return 'settling'
+      return (order.filled === 0) ? 'expired' : 'executed'
     case StatusCanceled: return isLive ? 'canceled/settling' : 'canceled'
     case StatusRevoked: return isLive ? 'revoked/settling' : 'revoked'
   }

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -310,7 +310,7 @@ func (ord *orderReader) StatusString() string {
 			return "settling"
 		}
 		if ord.Filled == 0 {
-			return "expired"
+			return "no match"
 		}
 		return "executed"
 	case order.OrderStatusCanceled:

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -301,10 +301,16 @@ func (ord *orderReader) StatusString() string {
 		if ord.Cancelling {
 			return "cancelling"
 		}
+		if isLive {
+			return "booked/settling"
+		}
 		return "booked"
 	case order.OrderStatusExecuted:
 		if isLive {
 			return "settling"
+		}
+		if ord.Filled == 0 {
+			return "expired"
 		}
 		return "executed"
 	case order.OrderStatusCanceled:


### PR DESCRIPTION
This PR updates the status string for executed orders with 0% filled to "expired" (mentioned in #945), and for orders that are partially booked and partially currently settling to "booked/settling".

Closes #1084.