### PR TITLE
geth/harness: Use snap mode for server nodes.

### DIFF
--- a/dex/testing/eth/create-node.sh
+++ b/dex/testing/eth/create-node.sh
@@ -125,12 +125,13 @@ $NODE_KEY
 EOF
 
 echo "Starting simnet ${NAME} node"
-if [ "${SYNC_MODE}" = "fast" ]; then
+if [ "${SYNC_MODE}" = "snap" ]; then
   # Start the eth node with the chain account unlocked, listening restricted to
   # localhost, and our custom configuration file.
   tmux send-keys -t "$TMUX_WIN_ID" "${NODES_ROOT}/harness-ctl/${NAME} --nodiscover " \
 	  "--config ${NODE_DIR}/eth.conf --unlock ${CHAIN_ADDRESS} " \
-	  "--password ${GROUP_DIR}/password --light.serve 25" C-m
+	  "--password ${GROUP_DIR}/password --light.serve 25 --datadir.ancient " \
+	  "${NODE_DIR}/geth-ancient" C-m
 
 else
   # Start the eth node listening restricted to localhost and our custom

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -132,13 +132,13 @@ echo "Starting simnet alpha node"
 "${HARNESS_DIR}/create-node.sh" "$SESSION:1" "alpha" "$ALPHA_NODE_PORT" \
 	"$CHAIN_ADDRESS" "$PASSWORD" "$CHAIN_ADDRESS_JSON" \
 	"$CHAIN_ADDRESS_JSON_FILE_NAME" "$ALPHA_ADDRESS_JSON" "$ALPHA_ADDRESS_JSON_FILE_NAME" \
-	"$ALPHA_NODE_KEY" "fast"
+	"$ALPHA_NODE_KEY" "snap"
 
 echo "Starting simnet beta node"
 "${HARNESS_DIR}/create-node.sh" "$SESSION:2" "beta" "$BETA_NODE_PORT" \
 	"$CHAIN_ADDRESS" "$PASSWORD" "$CHAIN_ADDRESS_JSON" \
 	"$CHAIN_ADDRESS_JSON_FILE_NAME" "$BETA_ADDRESS_JSON" "$BETA_ADDRESS_JSON_FILE_NAME" \
-	"$BETA_NODE_KEY" "fast"
+	"$BETA_NODE_KEY" "snap"
 
 echo "Starting simnet gamma node"
 "${HARNESS_DIR}/create-node.sh" "$SESSION:3" "gamma" "$GAMMA_NODE_PORT" \


### PR DESCRIPTION
As mentioned [here](https://gist.github.com/chappjc/4feefe593f870cd008180c00f72f85ca) use snap nodes for the server as they greatly reduce the resources needed by the server after caught up. Also incorporate `datadir.ancient` which further helps with the cost of running an eth full node by saving some data on cheaper hdd's. Afaik other data must still be stored on an ssd due to the large number of reads and writes. Requires geth 1.10+