### PR TITLE
client/front-end: Export orders as CSV.

### DIFF
--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -542,7 +542,7 @@ func (s *WebServer) createCSVFromOrders(ords []*core.Order, windowsUser bool) (s
 	if err != nil {
 		return "", fmt.Errorf("failed to write CSV: %v", err)
 	}
-	return string(buffer.String()), nil
+	return buffer.String(), nil
 }
 
 // apiOrdersCsv responds with a csv containing data of a filtered list of

--- a/client/webserver/site/src/css/orders.scss
+++ b/client/webserver/site/src/css/orders.scss
@@ -28,6 +28,20 @@
   }
 }
 
+.export-bttn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  button {
+    font-size: 13px;
+    font-family: $demi-sans;
+    padding: 2px 8px;
+    border: 1px solid #7777;
+    border-radius: 2px;
+  }
+}
+
 #ordersTable {
   width: 100%;
   // max-width: 90%;

--- a/client/webserver/site/src/html/orders.tmpl
+++ b/client/webserver/site/src/html/orders.tmpl
@@ -35,6 +35,9 @@
         {{end}}
         <div class="apply-bttn d-hide"><button class="bg2 demi">apply</button></div>
       </div>
+      <div id="exportOrders" class="export-bttn">
+        <button class="bg2 demi">Export Trades</button>
+      </div>
     </div>
     <div class="flex-grow-1">
       <table class="orderstable" id="ordersTable">

--- a/client/webserver/site/src/js/orders.js
+++ b/client/webserver/site/src/js/orders.js
@@ -167,7 +167,10 @@ export default class OrdersPage extends BasePage {
   /* exportOrders opens a new page that downloads a csv of orders based on the
    * current filters */
   async exportOrders () {
-    console.log('wtf')
+    const currentFilter = { ...this.currentFilter() }
+    // return all orders instead of only the ones on the current page
+    currentFilter.n = 0
+    currentFilter.offset = ''
     const res = await postJSON('/api/orderscsv', this.currentFilter())
     if (res.ok) {
       // eslint-disable-next-line no-undef
@@ -180,6 +183,7 @@ export default class OrdersPage extends BasePage {
       a.download = 'dcrdex-orders.csv'
       a.click()
       window.URL.revokeObjectURL(url)
+      document.body.removeChild(a)
     }
   }
 

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -214,6 +214,14 @@ func (ord *orderReader) FilledPercent() string {
 	return ord.percent(filledFilter)
 }
 
+// SideString is "sell" for sell orders and "buy" for buy orders.
+func (ord *orderReader) SideString() string {
+	if ord.Sell {
+		return "sell"
+	}
+	return "buy"
+}
+
 func (ord *orderReader) percent(filter func(match *core.Match) bool) string {
 	var sum uint64
 	if ord.Sell {
@@ -327,6 +335,11 @@ func (ord *orderReader) StatusString() string {
 	return "unknown"
 }
 
+// SimpleRateString is the formatted match rate.
+func (ord *orderReader) SimpleRateString() string {
+	return precision8(ord.Rate)
+}
+
 // RateString is a formatted rate with units.
 func (ord *orderReader) RateString() string {
 	if ord.Type == order.MarketOrderType {
@@ -394,11 +407,6 @@ func (m *matchReader) StatusString() string {
 		return "Match Complete"
 	}
 	return "Unknown Order Status"
-}
-
-// SimpleRateString is the formatted match rate.
-func (ord *orderReader) SimpleRateString() string {
-	return precision8(ord.Rate)
 }
 
 // RateString is the formatted match rate, with units.

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -396,6 +396,11 @@ func (m *matchReader) StatusString() string {
 	return "Unknown Order Status"
 }
 
+// SimpleRateString is the formatted match rate.
+func (ord *orderReader) SimpleRateString() string {
+	return precision8(ord.Rate)
+}
+
 // RateString is the formatted match rate, with units.
 func (m *matchReader) RateString() string {
 	return fmt.Sprintf("%s %s/%s", precision8(m.Rate), m.ord.QuoteSymbol, m.ord.BaseSymbol)

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -289,6 +289,7 @@ func New(core clientCore, addr, customSiteDir string, logger dex.Logger, reloadH
 			apiAuth.Post("/changeapppass", s.apiChangeAppPass)
 			apiAuth.Post("/walletsettings", s.apiWalletSettings)
 			apiAuth.Post("/orders", s.apiOrders)
+			apiAuth.Post("/orderscsv", s.apiOrdersCsv)
 			apiAuth.Post("/order", s.apiOrder)
 			apiAuth.Post("/withdraw", s.apiWithdraw)
 			apiAuth.Post("/maxbuy", s.apiMaxBuy)


### PR DESCRIPTION
This PR adds a button on the orders page that allows the user to download their orders in CSV format.

Closes #382 