### PR TITLE
Client must allow only one preimage request per order

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5085,7 +5085,7 @@ func processPreimageRequest(c *Core, dc *dexConnection, reqID uint64, oid order.
 	// server may have used the knowledge of this preimage we are sending them
 	// now to alter the epoch shuffle.
 	//
-	// Allow to initialize csum just once per order to prevent possible
+	// Allow to initialize csum only once per order to prevent possible
 	// malicious behavior.
 	tracker.mtx.Lock()
 	if isCancel {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5080,16 +5080,8 @@ func processPreimageRequest(c *Core, dc *dexConnection, reqID uint64, oid order.
 		return fmt.Errorf("no active order found for preimage request for %s", oid)
 	}
 
-	// Record the commitment checksum so we can verify that the subsequent
-	// match_proof with this order has the same checksum. If it does not, the
-	// server may have used the knowledge of this preimage we are sending them
-	// now to alter the epoch shuffle.
-	//
-	// Allow to initialize csum only once per order to prevent possible
-	// malicious behavior.
-	tracker.mtx.Lock()
-	if isCancel {
-		if tracker.cancel.csum != nil {
+	checkCsum := func(csum dex.Bytes) error {
+		if csum != nil {
 			csumErr := errors.New("csum is already initialized")
 			resp, err := msgjson.NewResponse(reqID, nil,
 				msgjson.NewError(msgjson.InvalidRequestError, csumErr.Error()))
@@ -5102,20 +5094,25 @@ func processPreimageRequest(c *Core, dc *dexConnection, reqID uint64, oid order.
 			}
 			return csumErr
 		}
+		return nil
+	}
+
+	// Record the commitment checksum so we can verify that the subsequent
+	// match_proof with this order has the same checksum. If it does not, the
+	// server may have used the knowledge of this preimage we are sending them
+	// now to alter the epoch shuffle.
+	//
+	// Allow to initialize csum only once per order to prevent possible
+	// malicious behavior.
+	tracker.mtx.Lock()
+	if isCancel {
+		if err := checkCsum(tracker.cancel.csum); err != nil {
+			return err
+		}
 		tracker.cancel.csum = commitChecksum
 	} else {
-		if tracker.csum != nil {
-			csumErr := errors.New("csum is already initialized")
-			resp, err := msgjson.NewResponse(reqID, nil,
-				msgjson.NewError(msgjson.InvalidRequestError, csumErr.Error()))
-			if err != nil {
-				return fmt.Errorf("preimage response encoding error: %w", err)
-			}
-			err = dc.Send(resp)
-			if err != nil {
-				return fmt.Errorf("preimage send error: %w", err)
-			}
-			return csumErr
+		if err := checkCsum(tracker.csum); err != nil {
+			return err
 		}
 		tracker.csum = commitChecksum
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2776,15 +2776,15 @@ func TestHandlePreimageRequest(t *testing.T) {
 		firstCSum := dex.Bytes{2, 3, 5, 7, 11, 13}
 
 		tracker := &trackedTrade{
-			Order:  ord,
-			preImg: preImg,
-			mktID:  tDcrBtcMktName,
-			db:     rig.db,
-			dc:     rig.dc,
+			Order:    ord,
+			preImg:   preImg,
+			mktID:    tDcrBtcMktName,
+			db:       rig.db,
+			dc:       rig.dc,
 			metaData: &db.OrderMetaData{},
 			cancel: &trackedCancel{
 				// Simulate first preimage request by initializing csum here.
-				csum:     firstCSum,
+				csum: firstCSum,
 				CancelOrder: order.CancelOrder{
 					P: order.Prefix{
 						AccountID:  rig.dc.acct.ID(),

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2486,8 +2486,8 @@ func TestHandlePreimageRequest(t *testing.T) {
 			t.Fatalf("handlePreimageRequest error: %v", err)
 		}
 
-		// Reset csum for the second preimage request since further tests rely
-		// on this tracker object.
+		// Reset csum for further preimage request since the tests below rely on
+		// this tracker object.
 		tracker.mtx.Lock()
 		tracker.csum = nil
 		tracker.mtx.Unlock()
@@ -2517,6 +2517,12 @@ func TestHandlePreimageRequest(t *testing.T) {
 			t.Fatalf("handlePreimageRequest error: %v", err)
 		}
 
+		// Reset csum for further preimage request since the tests below rely on
+		// this tracker object.
+		tracker.mtx.Lock()
+		tracker.csum = nil
+		tracker.mtx.Unlock()
+
 		// It has gone async now, waiting for commitSig.
 		// i.e. "Received preimage request for %v with no corresponding order submission response! Waiting..."
 		close(commitSig) // pretend like the order submission just finished
@@ -2543,6 +2549,12 @@ func TestHandlePreimageRequest(t *testing.T) {
 			if !strings.HasPrefix(err.Error(), errPrefix) {
 				t.Fatalf("expected error starting with %q, got %q", errPrefix, err)
 			}
+
+			// Reset csum for further preimage request since the tests below rely on
+			// this tracker object.
+			tracker.mtx.Lock()
+			tracker.csum = nil
+			tracker.mtx.Unlock()
 		}
 
 		// unknown commitment in request
@@ -2562,7 +2574,7 @@ func TestHandlePreimageRequest(t *testing.T) {
 
 		// Response send error also only returned on synchronous request handling.
 		rig.ws.sendErr = tErr
-		ensureErr("send error", reqNoCommit, "accept csum: preimage send error")
+		ensureErr("send error", reqNoCommit, "preimage send error")
 		rig.ws.sendErr = nil // reset
 	})
 	t.Run("csum for order", func(t *testing.T) {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2486,8 +2486,8 @@ func TestHandlePreimageRequest(t *testing.T) {
 			t.Fatalf("handlePreimageRequest error: %v", err)
 		}
 
-		// Reset csum for the second preimage request since testing is done with
-		// the same tracker object.
+		// Reset csum for the second preimage request since further tests rely
+		// on this tracker object.
 		tracker.mtx.Lock()
 		tracker.csum = nil
 		tracker.mtx.Unlock()

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2562,7 +2562,7 @@ func TestHandlePreimageRequest(t *testing.T) {
 
 		// Response send error also only returned on synchronous request handling.
 		rig.ws.sendErr = tErr
-		ensureErr("send error", reqNoCommit, "preimage send error")
+		ensureErr("send error", reqNoCommit, "accept csum: preimage send error")
 		rig.ws.sendErr = nil // reset
 	})
 	t.Run("csum for order", func(t *testing.T) {

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1533,6 +1533,11 @@ func (m *Market) handlePreimageResp(msg *msgjson.Message, reqData *piData) {
 			"error parsing preimage notification response")
 		return
 	}
+	if resp.Error != nil {
+		log.Warnf("Client failed to handle preimage request: %v", resp.Error)
+		sendPI(nil)
+		return
+	}
 	err = json.Unmarshal(resp.Result, &piResp)
 	if err != nil {
 		sendPI(nil)


### PR DESCRIPTION
This PR builds upon https://github.com/decred/dcrdex/pull/1077 to provide basic protection against malicious server behavior described in https://github.com/decred/dcrdex/issues/1020.
