### PR TITLE
assets: use script versions meticulously

### DIFF
--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -185,7 +185,7 @@ tmux new-window -t $SESSION:1 -n 'alpha' $SHELL
 tmux send-keys -t $SESSION:1 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${NODES_ROOT}/alpha" C-m
 
-echo "Starting simnet alpha node"
+echo "Starting simnet alpha node (txindex for server)"
 tmux send-keys -t $SESSION:1 "dcrd --appdata=${NODES_ROOT}/alpha \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --miningaddr=${ALPHA_MINING_ADDR} --rpclisten=:${ALPHA_RPC_PORT} \
@@ -198,12 +198,12 @@ tmux new-window -t $SESSION:2 -n 'beta' $SHELL
 tmux send-keys -t $SESSION:2 "set +o history" C-m
 tmux send-keys -t $SESSION:2 "cd ${NODES_ROOT}/beta" C-m
 
-echo "Starting simnet beta node"
+echo "Starting simnet beta node (no txindex for a typical client)"
 tmux send-keys -t $SESSION:2 "dcrd --appdata=${NODES_ROOT}/beta \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --listen=:${BETA_NODE_PORT} --rpclisten=:${BETA_RPC_PORT} \
 --miningaddr=${BETA_MINING_ADDR} \
---txindex --connect=127.0.0.1:${ALPHA_NODE_PORT} \
+--connect=127.0.0.1:${ALPHA_NODE_PORT} \
 --debuglevel=debug \
 --whitelist=127.0.0.0/8 --whitelist=::1 \
 --simnet; tmux wait-for -S betadcr" C-m

--- a/dex/testing/loadbot/go.sum
+++ b/dex/testing/loadbot/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 decred.org/cspp v0.3.0/go.mod h1:UygjYilC94dER3BEU65Zzyoqy9ngJfWCD2rdJqvUs2A=
-decred.org/dcrwallet v1.6.3-0.20210324151833-873c564976fd h1:tAaRGZmA8aj0F88oeFGhNXjtoV29E/jbuTYjVEVYU14=
-decred.org/dcrwallet v1.6.3-0.20210324151833-873c564976fd/go.mod h1:hNOGyvH53gWdgFB601/ubGRzCPfPtWnEVAi9Grs90y4=
+decred.org/dcrwallet v1.7.0 h1:U/ew00YBdUlx3rJAynt2OdKDgGzBKK4O89FijBq8iVg=
+decred.org/dcrwallet v1.7.0/go.mod h1:hNOGyvH53gWdgFB601/ubGRzCPfPtWnEVAi9Grs90y4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OpenBazaar/jsonpb v0.0.0-20171123000858-37d32ddf4eef/go.mod h1:55mCznBcN9WQgrtgaAkv+p2LxeW/tQRdidyyE9D0I5k=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -493,16 +493,17 @@ func (dcr *Backend) OutputSummary(txHash *chainhash.Hash, vout uint32) (txOut *T
 	if err != nil {
 		return nil, -1, dex.UnsupportedScriptError
 	}
-	scriptType, addrs, numRequired, err := dexdcr.ExtractScriptData(scriptHex, chainParams)
+	// out.ScriptPubKey.Version with dcrd 1.7 *release*, not yet
+	scriptType, addrs, numRequired, err := dexdcr.ExtractScriptData(out.Version, scriptHex, chainParams)
 	if err != nil {
 		return nil, -1, dex.UnsupportedScriptError
 	}
 
 	txOut = &TxOutData{
 		Value:        toAtoms(out.Value),
-		Addresses:    addrs,
-		SigsRequired: numRequired,
-		ScriptType:   scriptType,
+		Addresses:    addrs,       // out.ScriptPubKey.Addresses
+		SigsRequired: numRequired, // out.ScriptPubKey.ReqSigs
+		ScriptType:   scriptType,  // integer representation of the string in out.ScriptPubKey.Type
 	}
 
 	confs = verboseTx.Confirmations
@@ -564,6 +565,7 @@ func (dcr *Backend) transaction(txHash *chainhash.Hash, verboseTx *chainjson.TxR
 		sumOut += toAtoms(output.Value)
 		outputs = append(outputs, txOut{
 			value:    toAtoms(output.Value),
+			version:  output.Version, // output.ScriptPubKey.Version with dcrd 1.7 *release*, not yet
 			pkScript: pkScript,
 		})
 	}
@@ -758,8 +760,12 @@ func (dcr *Backend) utxo(ctx context.Context, txHash *chainhash.Hash, vout uint3
 	if err != nil {
 		return nil, err
 	}
+	if len(verboseTx.Vout) <= int(vout) { // shouldn't happen if gettxout worked
+		return nil, fmt.Errorf("only %d outputs, requested index %d", len(verboseTx.Vout), vout)
+	}
 
-	inputNfo, err := dexdcr.InputInfo(pkScript, redeemScript, chainParams)
+	scriptVersion := txOut.ScriptPubKey.Version // or verboseTx.Vout[vout].Version
+	inputNfo, err := dexdcr.InputInfo(scriptVersion, pkScript, redeemScript, chainParams)
 	if err != nil {
 		return nil, err
 	}
@@ -809,6 +815,7 @@ func (dcr *Backend) utxo(ctx context.Context, txHash *chainhash.Hash, vout uint3
 		},
 		vout:              vout,
 		scriptType:        scriptType,
+		scriptVersion:     scriptVersion,
 		nonStandardScript: inputNfo.NonStandardScript,
 		pkScript:          pkScript,
 		redeemScript:      redeemScript,
@@ -875,7 +882,7 @@ func (dcr *Backend) output(txHash *chainhash.Hash, vout uint32, redeemScript []b
 
 	txOut := txio.tx.outs[vout]
 	pkScript := txOut.pkScript
-	inputNfo, err := dexdcr.InputInfo(pkScript, redeemScript, chainParams)
+	inputNfo, err := dexdcr.InputInfo(txOut.version, pkScript, redeemScript, chainParams)
 	if err != nil {
 		return nil, err
 	}

--- a/server/asset/dcr/live_test.go
+++ b/server/asset/dcr/live_test.go
@@ -160,10 +160,10 @@ func TestLiveUTXO(t *testing.T) {
 				if out.Value == 0 {
 					continue
 				}
-				if out.Version != dexdcr.CurrentScriptVersion {
+				if out.Version != 0 {
 					continue
 				}
-				scriptType := dexdcr.ParseScriptType(dexdcr.CurrentScriptVersion, out.PkScript, nil)
+				scriptType := dexdcr.ParseScriptType(out.Version, out.PkScript, nil)
 				// We can't do P2SH during live testing, because we don't have the
 				// scripts. Just count them for now.
 				if scriptType.IsP2SH() {

--- a/server/asset/dcr/tx.go
+++ b/server/asset/dcr/tx.go
@@ -41,6 +41,7 @@ type txIn struct {
 // A txOut holds information about a transaction output.
 type txOut struct {
 	value    uint64
+	version  uint16
 	pkScript []byte
 }
 


### PR DESCRIPTION
On dcrd 1.7/master, use the new `GetTxOutResult.ScriptPubKey.Version` field.

Elsewhere, get output script version from either `TxRawResult.Vout[i].Version`
or the `wire.TxOut.Version`.

harness beta node now does **not** enable `txindex`