### PR TITLE
[0.2] assets: use script versions meticulously

### DIFF
--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1520,7 +1520,7 @@ func TestAuditContract(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	vout := uint32(5)
+	vout := uint32(2)
 	secretHash, _ := hex.DecodeString("5124208c80d33507befa517c08ed01aa8d33adbf37ecd70fb5f9352f7a51a88d")
 	lockTime := time.Now().Add(time.Hour * 12)
 	addrStr := tPKHAddr.String()
@@ -1534,7 +1534,19 @@ func TestAuditContract(t *testing.T) {
 		t.Fatalf("bad address %s (%T)", addr, addr)
 	}
 
-	node.txOutRes[newOutPoint(tTxHash, vout)] = makeGetTxOutRes(1, 5, pkScript)
+	txoutRes := makeGetTxOutRes(1, 5, pkScript) // 1 conf
+	node.txOutRes[newOutPoint(tTxHash, vout)] = txoutRes
+
+	// need getblock, getblockhash, and getrawtransaction results too
+	_, bestBlockHeight, err := node.GetBestBlock(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected GetBestBlock error: %v", err)
+	}
+	contractHeight := bestBlockHeight + 1
+	inputs := []chainjson.Vin{makeRPCVin("feeddabeef", 0, nil)}
+	newBlockHash, _ := node.addRawTx(contractHeight, makeRawTx(tTxHash.String(), []dex.Bytes{nil, nil, pkScript /* vout 2 */}, inputs))
+
+	txoutRes.BestBlock = newBlockHash.String() // with 1 conf and this best block hash, the tx is in this block
 
 	audit, err := wallet.AuditContract(toCoinID(tTxHash, vout), contract, nil)
 	if err != nil {

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -90,7 +90,7 @@ func mainCore() error {
 
 	// Catch interrupt signal (e.g. ctrl+c), prompting to shutdown if the user
 	// is logged in, and there are active orders or matches.
-	killChan := make(chan os.Signal)
+	killChan := make(chan os.Signal, 1)
 	signal.Notify(killChan, os.Interrupt)
 	go func() {
 		for range killChan {

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -185,7 +185,7 @@ tmux new-window -t $SESSION:1 -n 'alpha' $SHELL
 tmux send-keys -t $SESSION:1 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${NODES_ROOT}/alpha" C-m
 
-echo "Starting simnet alpha node"
+echo "Starting simnet alpha node (txindex for server)"
 tmux send-keys -t $SESSION:1 "dcrd --appdata=${NODES_ROOT}/alpha \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --miningaddr=${ALPHA_MINING_ADDR} --rpclisten=:${ALPHA_RPC_PORT} \
@@ -198,12 +198,12 @@ tmux new-window -t $SESSION:2 -n 'beta' $SHELL
 tmux send-keys -t $SESSION:2 "set +o history" C-m
 tmux send-keys -t $SESSION:2 "cd ${NODES_ROOT}/beta" C-m
 
-echo "Starting simnet beta node"
+echo "Starting simnet beta node (no txindex for a typical client)"
 tmux send-keys -t $SESSION:2 "dcrd --appdata=${NODES_ROOT}/beta \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --listen=:${BETA_NODE_PORT} --rpclisten=:${BETA_RPC_PORT} \
 --miningaddr=${BETA_MINING_ADDR} \
---txindex --connect=127.0.0.1:${ALPHA_NODE_PORT} \
+--connect=127.0.0.1:${ALPHA_NODE_PORT} \
 --debuglevel=debug \
 --whitelist=127.0.0.0/8 --whitelist=::1 \
 --simnet; tmux wait-for -S betadcr" C-m

--- a/dex/testing/loadbot/go.sum
+++ b/dex/testing/loadbot/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 decred.org/cspp v0.3.0/go.mod h1:UygjYilC94dER3BEU65Zzyoqy9ngJfWCD2rdJqvUs2A=
-decred.org/dcrwallet v1.6.3-0.20210324151833-873c564976fd h1:tAaRGZmA8aj0F88oeFGhNXjtoV29E/jbuTYjVEVYU14=
-decred.org/dcrwallet v1.6.3-0.20210324151833-873c564976fd/go.mod h1:hNOGyvH53gWdgFB601/ubGRzCPfPtWnEVAi9Grs90y4=
+decred.org/dcrwallet v1.7.0 h1:U/ew00YBdUlx3rJAynt2OdKDgGzBKK4O89FijBq8iVg=
+decred.org/dcrwallet v1.7.0/go.mod h1:hNOGyvH53gWdgFB601/ubGRzCPfPtWnEVAi9Grs90y4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OpenBazaar/jsonpb v0.0.0-20171123000858-37d32ddf4eef/go.mod h1:55mCznBcN9WQgrtgaAkv+p2LxeW/tQRdidyyE9D0I5k=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=

--- a/dex/testing/loadbot/loadbot.go
+++ b/dex/testing/loadbot/loadbot.go
@@ -287,7 +287,7 @@ func main() {
 	}
 
 	// Catch ctrl+c for a clean shutdown.
-	killChan := make(chan os.Signal)
+	killChan := make(chan os.Signal, 1)
 	signal.Notify(killChan, os.Interrupt)
 	go func() {
 		<-killChan

--- a/server/asset/dcr/live_test.go
+++ b/server/asset/dcr/live_test.go
@@ -160,10 +160,10 @@ func TestLiveUTXO(t *testing.T) {
 				if out.Value == 0 {
 					continue
 				}
-				if out.Version != dexdcr.CurrentScriptVersion {
+				if out.Version != 0 {
 					continue
 				}
-				scriptType := dexdcr.ParseScriptType(dexdcr.CurrentScriptVersion, out.PkScript, nil)
+				scriptType := dexdcr.ParseScriptType(out.Version, out.PkScript, nil)
 				// We can't do P2SH during live testing, because we don't have the
 				// scripts. Just count them for now.
 				if scriptType.IsP2SH() {

--- a/server/asset/dcr/tx.go
+++ b/server/asset/dcr/tx.go
@@ -41,6 +41,7 @@ type txIn struct {
 // A txOut holds information about a transaction output.
 type txOut struct {
 	value    uint64
+	version  uint16
 	pkScript []byte
 }
 


### PR DESCRIPTION
`gettxout` version is the transaction version, not script, and there is no `GetTxOutResult.ScriptPubKey.Version` in dcrd 1.6.  So, for audit with dcrd 1.6 we have no choice but to pull blocks to get the raw transaction if the transaction is confirmed.  If it is still unconfirmed we can use `getrawtransaction`.

harness beta node now does not enable txindex