### PR TITLE
client/front-end: Export orders in csv file

### DIFF
--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -199,6 +199,7 @@ func (s *WebServer) handleOrders(w http.ResponseWriter, r *http.Request) {
 func (s *WebServer) handleExportOrders(w http.ResponseWriter, r *http.Request) {
 	wf, ok := w.(http.Flusher)
 	if !ok {
+		log.Errorf("unable to flush streamed data")
 		http.Error(w, "unable to flush streamed data", http.StatusBadRequest)
 		return
 	}
@@ -215,7 +216,7 @@ func (s *WebServer) handleExportOrders(w http.ResponseWriter, r *http.Request) {
 	assets := r.Form["assets"]
 	filter.Assets = make([]uint32, len(assets))
 	for k, assetStrID := range assets {
-		assetNumID, err := strconv.Atoi(assetStrID)
+		assetNumID, err := strconv.ParseUint(assetStrID, 0, 64)
 		if err != nil {
 			log.Errorf("error parsing asset id: %v", err)
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
@@ -278,7 +279,7 @@ func (s *WebServer) handleExportOrders(w http.ResponseWriter, r *http.Request) {
 
 	for _, ord := range ords {
 		ordReader := orderReader{ord}
-		timestamp, err := encode.UnixTimeMilli(int64(ord.Stamp)).MarshalText()
+		timestamp, err := encode.UnixTimeMilliLocal(int64(ord.Stamp)).MarshalText()
 		if err != nil {
 			log.Errorf("error writing CSV: %v", err)
 			return

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -216,7 +216,7 @@ func (s *WebServer) handleExportOrders(w http.ResponseWriter, r *http.Request) {
 	assets := r.Form["assets"]
 	filter.Assets = make([]uint32, len(assets))
 	for k, assetStrID := range assets {
-		assetNumID, err := strconv.ParseUint(assetStrID, 0, 64)
+		assetNumID, err := strconv.ParseUint(assetStrID, 10, 32)
 		if err != nil {
 			log.Errorf("error parsing asset id: %v", err)
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
@@ -227,7 +227,7 @@ func (s *WebServer) handleExportOrders(w http.ResponseWriter, r *http.Request) {
 	statuses := r.Form["statuses"]
 	filter.Statuses = make([]order.OrderStatus, len(statuses))
 	for k, statusStrID := range statuses {
-		statusNumID, err := strconv.Atoi(statusStrID)
+		statusNumID, err := strconv.ParseUint(statusStrID, 10, 16)
 		if err != nil {
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 			log.Errorf("error parsing status id: %v", err)

--- a/client/webserver/site/src/css/orders.scss
+++ b/client/webserver/site/src/css/orders.scss
@@ -28,6 +28,20 @@
   }
 }
 
+.export-bttn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  button {
+    font-size: 13px;
+    font-family: $demi-sans;
+    padding: 2px 8px;
+    border: 1px solid #7777;
+    border-radius: 2px;
+  }
+}
+
 #ordersTable {
   width: 100%;
   // max-width: 90%;

--- a/client/webserver/site/src/html/orders.tmpl
+++ b/client/webserver/site/src/html/orders.tmpl
@@ -35,6 +35,9 @@
         {{end}}
         <div class="apply-bttn d-hide"><button class="bg2 demi">apply</button></div>
       </div>
+      <div id="exportOrders" class="export-bttn">
+        <button class="bg2 demi">Export Trades</button>
+      </div>
     </div>
     <div class="flex-grow-1">
       <table class="orderstable" id="ordersTable">

--- a/client/webserver/site/src/js/orders.js
+++ b/client/webserver/site/src/js/orders.js
@@ -18,7 +18,7 @@ export default class OrdersPage extends BasePage {
     this.loading = false
     const page = this.page = Doc.parsePage(main, [
       'rowTmpl', 'tableBody', 'hostFilter', 'assetFilter', 'statusFilter',
-      'orderLoader', 'ordersTable'
+      'orderLoader', 'ordersTable', 'exportOrders'
     ])
     this.orderTmpl = page.rowTmpl
     this.orderTmpl.remove()
@@ -78,6 +78,10 @@ export default class OrdersPage extends BasePage {
       if (belowBottom < 0) {
         this.nextPage()
       }
+    })
+
+    Doc.bind(page.exportOrders, 'click', () => {
+      this.exportOrders()
     })
 
     this.submitFilter()
@@ -148,26 +152,6 @@ export default class OrdersPage extends BasePage {
     filterState.hosts = parseSubFilter(page.hostFilter)
     filterState.assets = parseSubFilter(page.assetFilter)
     filterState.statuses = parseSubFilter(page.statusFilter)
-
-    const url = new URL(window.location)
-    const search = new URLSearchParams(url.search)
-    search.delete('offset')
-
-    const setQuery = (k) => {
-      const subFilter = filterState[k]
-      if (subFilter.length === 0) {
-        search.delete(k)
-      } else {
-        search.set(k, subFilter.join(','))
-      }
-    }
-    setQuery('hosts')
-    setQuery('assets')
-    setQuery('statuses')
-
-    url.search = search.toString()
-    window.history.replaceState({ page: 'orders' }, '', url)
-
     this.setOrders(await this.fetchOrders())
   }
 
@@ -177,6 +161,26 @@ export default class OrdersPage extends BasePage {
     const res = await postJSON('/api/orders', this.currentFilter())
     loaded()
     return res.orders
+  }
+
+  /* exportOrders downloads a csv of the user's orders based on the current filter. */
+  exportOrders () {
+    this.offset = ''
+    const filterState = this.currentFilter()
+    const url = new URL(window.location)
+    const search = new URLSearchParams('')
+    const setQuery = (k) => {
+      const subFilter = filterState[k]
+      subFilter.forEach(e => {
+        search.append(k, e)
+      })
+    }
+    setQuery('hosts')
+    setQuery('assets')
+    setQuery('statuses')
+    url.search = search.toString()
+    url.pathname = '/orders/export'
+    window.open(url.toString())
   }
 
   /*

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -214,6 +214,14 @@ func (ord *orderReader) FilledPercent() string {
 	return ord.percent(filledFilter)
 }
 
+// SideString is "sell" for sell orders and "buy" for buy orders.
+func (ord *orderReader) SideString() string {
+	if ord.Sell {
+		return "sell"
+	}
+	return "buy"
+}
+
 func (ord *orderReader) percent(filter func(match *core.Match) bool) string {
 	var sum uint64
 	if ord.Sell {
@@ -325,6 +333,11 @@ func (ord *orderReader) StatusString() string {
 		return "revoked"
 	}
 	return "unknown"
+}
+
+// SimpleRateString is the formatted match rate.
+func (ord *orderReader) SimpleRateString() string {
+	return precision8(ord.Rate)
 }
 
 // RateString is a formatted rate with units.

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -246,6 +246,7 @@ func New(core clientCore, addr, customSiteDir string, logger dex.Logger, reloadH
 				webAuth.Get(walletsRoute, s.handleWallets)
 				webAuth.With(orderIDCtx).Get("/order/{oid}", s.handleOrder)
 				webAuth.Get(ordersRoute, s.handleOrders)
+				webAuth.Get(exportOrderRoute, s.handleExportOrders)
 
 				// These handlers require a DEX connection.
 				webAuth.Group(func(webDC chi.Router) {

--- a/dex/encode/encode.go
+++ b/dex/encode/encode.go
@@ -95,14 +95,6 @@ func UnixTimeMilli(msEpoch int64) time.Time {
 	return time.Unix(sec, msec*1e6).UTC()
 }
 
-// UnixTimeMilliLocal returns a Time for an elapsed time in milliseconds since
-// the Unix Epoch. The time will have Location set to the local machine time.
-func UnixTimeMilliLocal(msEpoch int64) time.Time {
-	sec := msEpoch / 1000
-	msec := msEpoch % 1000
-	return time.Unix(sec, msec*1e6).Local()
-}
-
 // DropMilliseconds returns the time truncated to the previous second.
 func DropMilliseconds(t time.Time) time.Time {
 	return t.Truncate(time.Second)

--- a/dex/encode/encode.go
+++ b/dex/encode/encode.go
@@ -95,6 +95,14 @@ func UnixTimeMilli(msEpoch int64) time.Time {
 	return time.Unix(sec, msec*1e6).UTC()
 }
 
+// UnixTimeMilliLocal returns a Time for an elapsed time in milliseconds since
+// the Unix Epoch. The time will have Location set to the local machine time.
+func UnixTimeMilliLocal(msEpoch int64) time.Time {
+	sec := msEpoch / 1000
+	msec := msEpoch % 1000
+	return time.Unix(sec, msec*1e6).Local()
+}
+
 // DropMilliseconds returns the time truncated to the previous second.
 func DropMilliseconds(t time.Time) time.Time {
 	return t.Truncate(time.Second)


### PR DESCRIPTION
This PR adds a button on the orders page that allows the user to download their orders in CSV format.

Closes #382