### PR TITLE
multi: Log swap refund txs.

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1355,8 +1355,8 @@ func (btc *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	// legacy/non-segwit swap contracts pkScripts.
 	for _, contract := range swaps.Contracts {
 		totalOut += contract.Value
-		// revokeAddr is the address that will receive the refund if the contract is
-		// abandoned.
+		// revokeAddr is the address belonging to the key that will be
+		// used to sign and refund a swap past its encoded refund locktime.
 		revokeAddr, err := btc.externalAddress()
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("error creating revocation address: %w", err)

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1308,6 +1308,7 @@ func testSwap(t *testing.T, segwit bool) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	swapVal := toSatoshi(5)
 	coins := asset.Coins{
 		newOutput(tTxHash, 0, toSatoshi(3)),
@@ -1321,6 +1322,14 @@ func testSwap(t *testing.T, segwit bool) {
 	node.rawRes[methodNewAddress] = mustMarshal(t, addrStr)
 	node.rawRes[methodChangeAddress] = mustMarshal(t, addrStr)
 	node.rawRes[methodLockUnspent] = []byte(`true`)
+
+	privBytes, _ := hex.DecodeString("b07209eec1a8fb6cfe5cb6ace36567406971a75c330db7101fb21bc679bc5330")
+	privKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), privBytes)
+	wif, err := btcutil.NewWIF(privKey, &chaincfg.MainNetParams, true)
+	if err != nil {
+		t.Fatalf("error encoding wif: %v", err)
+	}
+	node.rawRes[methodPrivKeyForAddress] = mustMarshal(t, wif.String())
 
 	secretHash, _ := hex.DecodeString("5124208c80d33507befa517c08ed01aa8d33adbf37ecd70fb5f9352f7a51a88d")
 	contract := &asset.Contract{

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -328,9 +328,10 @@ func convertAuditInfo(ai *asset.AuditInfo, chainParams *chaincfg.Params) (*audit
 // swapReceipt is information about a swap contract that was broadcast by this
 // wallet. Satisfies the asset.Receipt interface.
 type swapReceipt struct {
-	output     *output
-	contract   []byte
-	expiration time.Time
+	output       *output
+	contract     []byte
+	signedRefund []byte
+	expiration   time.Time
 }
 
 // Expiration is the time that the contract will expire, allowing the user to
@@ -353,6 +354,12 @@ func (r *swapReceipt) Coin() asset.Coin {
 // String provides a human-readable representation of the contract's Coin.
 func (r *swapReceipt) String() string {
 	return r.output.String()
+}
+
+// SignedRefund is a signed refund script that can be used to return
+// funds to the user in the case a contract expires.
+func (r *swapReceipt) SignedRefund() dex.Bytes {
+	return r.signedRefund
 }
 
 // fundingCoin is similar to output, but also stores the address. The
@@ -1350,6 +1357,7 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 		return nil, nil, 0, err
 	}
 	contracts := make([][]byte, 0, len(swaps.Contracts))
+	refundAddrs := make([]dcrutil.Address, 0, len(swaps.Contracts))
 	// Add the contract outputs.
 	for _, contract := range swaps.Contracts {
 		totalOut += contract.Value
@@ -1359,6 +1367,7 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("error creating revocation address: %w", translateRPCCancelErr(err))
 		}
+		refundAddrs = append(refundAddrs, revokeAddrV2)
 		// Create the contract, a P2SH redeem script.
 		contractScript, err := dexdcr.MakeContract(contract.Address, revokeAddrV2.String(), contract.SecretHash, int64(contract.LockTime), dcr.chainParams)
 		if err != nil {
@@ -1417,10 +1426,20 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	receipts := make([]asset.Receipt, 0, swapCount)
 	txHash := msgTx.TxHash()
 	for i, contract := range swaps.Contracts {
+		output := newOutput(&txHash, uint32(i), contract.Value, wire.TxTreeRegular)
+		signedRefundTx, err := dcr.refundTx(output.ID(), contracts[i], contract.Value, refundAddrs[i])
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("error creating refund tx: %w", err)
+		}
+		refundB, err := signedRefundTx.Bytes()
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("error serializing refund tx: %w", err)
+		}
 		receipts = append(receipts, &swapReceipt{
-			output:     newOutput(&txHash, uint32(i), contract.Value, wire.TxTreeRegular),
-			contract:   contracts[i],
-			expiration: time.Unix(int64(contract.LockTime), 0).UTC(),
+			output:       output,
+			contract:     contracts[i],
+			expiration:   time.Unix(int64(contract.LockTime), 0).UTC(),
+			signedRefund: refundB,
 		})
 	}
 
@@ -2014,19 +2033,42 @@ func (dcr *ExchangeWallet) fatalFindRedemptionsError(err error, contractOutpoint
 // was created. The client should store this information for persistence across
 // sessions.
 func (dcr *ExchangeWallet) Refund(coinID, contract dex.Bytes) (dex.Bytes, error) {
+	msgTx, err := dcr.refundTx(coinID, contract, 0, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating refund tx: %w", err)
+	}
+
+	checkHash := msgTx.TxHash()
+	refundHash, err := dcr.node.SendRawTransaction(dcr.ctx, msgTx, false)
+	if err != nil {
+		return nil, translateRPCCancelErr(err)
+	}
+	if *refundHash != checkHash {
+		return nil, fmt.Errorf("refund sent, but received unexpected transaction ID back from RPC server. "+
+			"expected %s, got %s", *refundHash, checkHash)
+	}
+	return toCoinID(refundHash, 0), nil
+}
+
+// refundTx crates and signs a contract`s refund transaction. If refundAddr is
+// not supplied, one will be requested from the wallet. If val is not supplied
+// it will be retrieved with gettxout.
+func (dcr *ExchangeWallet) refundTx(coinID, contract dex.Bytes, val uint64, refundAddr dcrutil.Address) (*wire.MsgTx, error) {
 	txHash, vout, err := decodeCoinID(coinID)
 	if err != nil {
 		return nil, err
 	}
-	// Grab the unspent output to make sure it's good and to get the value.
-	utxo, err := dcr.node.GetTxOut(dcr.ctx, txHash, vout, wire.TxTreeRegular, true)
-	if err != nil {
-		return nil, fmt.Errorf("error finding unspent contract: %w", translateRPCCancelErr(err))
+	// Grab the unspent output to make sure it's good and to get the value if not supplied.
+	if val == 0 {
+		utxo, err := dcr.node.GetTxOut(dcr.ctx, txHash, vout, wire.TxTreeRegular, true)
+		if err != nil {
+			return nil, fmt.Errorf("error finding unspent contract: %w", translateRPCCancelErr(err))
+		}
+		if utxo == nil {
+			return nil, asset.CoinNotFoundError
+		}
+		val = toAtoms(utxo.Value)
 	}
-	if utxo == nil {
-		return nil, asset.CoinNotFoundError
-	}
-	val := toAtoms(utxo.Value)
 	sender, _, lockTime, _, err := dexdcr.ExtractSwapDetails(contract, dcr.chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting swap addresses: %w", err)
@@ -2047,9 +2089,11 @@ func (dcr *ExchangeWallet) Refund(coinID, contract dex.Bytes) (dex.Bytes, error)
 		return nil, fmt.Errorf("refund tx not worth the fees")
 	}
 
-	refundAddr, err := dcr.node.GetNewAddressGapPolicy(dcr.ctx, dcr.acct, dcrwallet.GapPolicyIgnore)
-	if err != nil {
-		return nil, fmt.Errorf("error getting new address from the wallet: %w", translateRPCCancelErr(err))
+	if refundAddr == nil {
+		refundAddr, err = dcr.node.GetNewAddressGapPolicy(dcr.ctx, dcr.acct, dcrwallet.GapPolicyIgnore)
+		if err != nil {
+			return nil, fmt.Errorf("error getting new address from the wallet: %w", translateRPCCancelErr(err))
+		}
 	}
 	pkScript, err := txscript.PayToAddrScript(refundAddr)
 	if err != nil {
@@ -2071,17 +2115,7 @@ func (dcr *ExchangeWallet) Refund(coinID, contract dex.Bytes) (dex.Bytes, error)
 		return nil, err
 	}
 	txIn.SignatureScript = redeemSigScript
-	// Send it.
-	checkHash := msgTx.TxHash()
-	refundHash, err := dcr.node.SendRawTransaction(dcr.ctx, msgTx, false)
-	if err != nil {
-		return nil, translateRPCCancelErr(err)
-	}
-	if *refundHash != checkHash {
-		return nil, fmt.Errorf("refund sent, but received unexpected transaction ID back from RPC server. "+
-			"expected %s, got %s", *refundHash, checkHash)
-	}
-	return toCoinID(refundHash, 0), nil
+	return msgTx, nil
 }
 
 // Address returns an address for the exchange wallet.

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1361,8 +1361,8 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 	// Add the contract outputs.
 	for _, contract := range swaps.Contracts {
 		totalOut += contract.Value
-		// revokeAddrV2 is the address that will receive the refund if the
-		// contract is abandoned.
+		// revokeAddrV2 is the address belonging to the key that will be
+		// used to sign and refund a swap past its encoded refund locktime.
 		revokeAddrV2, err := dcr.node.GetNewAddressGapPolicy(dcr.ctx, dcr.acct, dcrwallet.GapPolicyIgnore)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("error creating revocation address: %w", translateRPCCancelErr(err))

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1183,6 +1183,14 @@ func TestSwap(t *testing.T) {
 		newOutput(tTxHash, 0, toAtoms(3), wire.TxTreeRegular),
 	}
 
+	privBytes, _ := hex.DecodeString("b07209eec1a8fb6cfe5cb6ace36567406971a75c330db7101fb21bc679bc5330")
+
+	node.changeAddr = tPKHAddr
+	node.privWIF, err = dcrutil.NewWIF(privBytes, tChainParams.PrivateKeyID, dcrec.STEcdsaSecp256k1)
+	if err != nil {
+		t.Fatalf("NewWIF error: %v", err)
+	}
+
 	node.newAddr = tPKHAddr
 	node.changeAddr = tPKHAddr
 

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -220,6 +220,9 @@ type Receipt interface {
 	Contract() dex.Bytes
 	// String provides a human-readable representation of the contract's Coin.
 	String() string
+	// SignedRefund is a signed refund script that can be used to return
+	// funds to the user in the case a contract expires.
+	SignedRefund() dex.Bytes
 }
 
 // AuditInfo is audit information about a swap contract needed to audit the

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -503,6 +503,10 @@ func (r *tReceipt) String() string {
 	return r.coin.String()
 }
 
+func (r *tReceipt) SignedRefund() dex.Bytes {
+	return nil
+}
+
 type TXCWallet struct {
 	mtx               sync.RWMutex
 	payFeeCoin        *tCoin

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1476,12 +1476,12 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 
 	c.log.Infof("Broadcasted transaction with %d swap contracts for order %v. Fee rate = %d. Receipts (%s): %v.",
 		len(receipts), t.ID(), swaps.FeeRate, t.wallets.fromAsset.Symbol, receipts)
-	c.log.Infof("The following are coin id mapped to raw refund transactions "+
-		"that are only valid after the swap contract expires. They can "+
-		"be used to return funds to your wallet in the case dexc no "+
-		"longer functions. They SHOULD NOT be used if dexc is running "+
-		"without error. dexc will refund failed contracts "+
-		"automatically.\nRefund Txs: {%s}", refundTxs)
+	c.log.Infof("The following are contract identifiers mapped to raw refund "+
+		"transactions that are only valid after the swap contract expires. "+
+		"These are fallback transactions that can be used to return funds "+
+		"to your wallet in the case dexc no longer functions. They SHOULD "+
+		"NOT be used if dexc is running without error. dexc will refund "+
+		"failed contracts automatically.\nRefund Txs: {%s}", refundTxs)
 
 	// If this is the first swap (and even if not), the funding coins
 	// would have been spent and unlocked.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1474,8 +1474,14 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 		}
 	}
 
-	c.log.Infof("Broadcasted transaction with %d swap contracts for order %v. Fee rate = %d. Receipts (%s): %v. Refund Txs: {%s}",
-		len(receipts), t.ID(), swaps.FeeRate, t.wallets.fromAsset.Symbol, receipts, refundTxs)
+	c.log.Infof("Broadcasted transaction with %d swap contracts for order %v. Fee rate = %d. Receipts (%s): %v.",
+		len(receipts), t.ID(), swaps.FeeRate, t.wallets.fromAsset.Symbol, receipts)
+	c.log.Infof("The following are coin id mapped to raw refund transactions "+
+		"that are only valid after the swap contract expires. They can "+
+		"be used to return funds to your wallet in the case dexc no "+
+		"longer functions. They SHOULD NOT be used if dexc is running "+
+		"without error. dexc will refund failed contracts "+
+		"automatically.\nRefund Txs: {%s}", refundTxs)
 
 	// If this is the first swap (and even if not), the funding coins
 	// would have been spent and unlocked.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1466,8 +1466,16 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 		return
 	}
 
-	c.log.Infof("Broadcasted transaction with %d swap contracts for order %v. Fee rate = %d. Receipts (%s): %v",
-		len(receipts), t.ID(), swaps.FeeRate, t.wallets.fromAsset.Symbol, receipts)
+	refundTxs := ""
+	for i, r := range receipts {
+		refundTxs = fmt.Sprintf("%s%q: %s", refundTxs, r.Coin(), r.SignedRefund())
+		if i != len(receipts)-1 {
+			refundTxs = fmt.Sprintf("%s, ", refundTxs)
+		}
+	}
+
+	c.log.Infof("Broadcasted transaction with %d swap contracts for order %v. Fee rate = %d. Receipts (%s): %v. Refund Txs: {%s}",
+		len(receipts), t.ID(), swaps.FeeRate, t.wallets.fromAsset.Symbol, receipts, refundTxs)
 
 	// If this is the first swap (and even if not), the funding coins
 	// would have been spent and unlocked.


### PR DESCRIPTION
    Add signed refund txs to the Receipt when swapping and log so that the
    user can salvage funds in the case that they lose access to the client
    but still have the logs.

closes #1087