### PR TITLE
ui: fix position of new wallet form

### DIFF
--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -103,7 +103,7 @@
     </div>
 
     {{- /* NEW WALLET */ -}}
-    <form class="card bg1 m-auto d-hide" id="walletForm" autocomplete="off">
+    <form class="card bg1 position-relative d-hide" id="walletForm" autocomplete="off">
       {{template "newWalletForm"}}
     </form>
 


### PR DESCRIPTION
The create new wallet form was displaying much lower than the other boxes on the wallet screen. It wasn't so noticeable on firefox but very obvious in brave.