### PR TITLE
fidelity bonds (proof of concept)

### DIFF
--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -340,6 +340,10 @@ func (c *tRPCClient) GetBlockChainInfo(_ context.Context) (*chainjson.GetBlockCh
 	return c.blockchainInfo, c.blockchainInfoErr
 }
 
+func (c *tRPCClient) FundRawTransaction(ctx context.Context, rawhex string, fundAccount string, options walletjson.FundRawTransactionOptions) (*walletjson.FundRawTransactionResult, error) {
+	return nil, fmt.Errorf("method FundRawTransaction not implemented")
+}
+
 func (c *tRPCClient) SendRawTransaction(_ context.Context, tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error) {
 	c.sentRawTx = tx
 	if c.sendRawErr == nil && c.sendRawHash == nil {

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -28,6 +28,9 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/config"
 	dexdcr "decred.org/dcrdex/dex/networks/dcr"
+	"github.com/decred/dcrd/dcrec/secp256k1/v3"
+	"github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa"
+	"github.com/decred/dcrd/dcrutil/v4"
 )
 
 const (
@@ -144,6 +147,94 @@ func TestMain(m *testing.M) {
 		return m.Run()
 	}
 	os.Exit(doIt())
+}
+
+func TestMakeBondTx(t *testing.T) {
+	rig := newTestRig(t, func(name string, err error) {
+		tLogger.Infof("%s has reported a new block, error = %v", name, err)
+	})
+	defer rig.close(t)
+
+	acctID := randBytes(32)
+	fee := uint64(10_2030_4050) //  ~10.2 DCR
+
+	wallet := rig.beta()
+
+	// Unlock the wallet to sign the tx and get keys.
+	err := wallet.Unlock(walletPassword)
+	if err != nil {
+		t.Fatalf("error unlocking beta wallet: %v", err)
+	}
+
+	lockTime := time.Now().Add(5 * time.Minute)
+	bond, err := wallet.MakeBondTx(fee, lockTime, acctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coinhash, _, err := decodeCoinID(bond.CoinID)
+	t.Logf("bond txid %v\n", coinhash)
+	t.Logf("signed tx: %x\n", bond.SignedTx)
+	t.Logf("unsigned tx: %x\n", bond.UnsignedTx)
+	t.Logf("bond script: %x\n", bond.BondScript)
+	t.Logf("redeem tx: %x\n", bond.RedeemTx)
+	bondMsgTx, err := msgTxFromBytes(bond.SignedTx)
+	if err != nil {
+		t.Fatalf("invalid bond tx: %v", err)
+	}
+	bondOutVersion := bondMsgTx.TxOut[0].Version
+
+	msg := sha256.Sum256(acctID)
+	pubkey, origPkCompressed, err := ecdsa.RecoverCompact(bond.BondAcctSig, msg[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pkB []byte
+	if origPkCompressed {
+		pkB = pubkey.SerializeCompressed()
+	} else {
+		pkB = pubkey.SerializeUncompressed()
+	}
+
+	pkh := dcrutil.Hash160(pkB)
+
+	lockTimeUint, pkhPush, err := dexdcr.ExtractBondDetails(bondOutVersion, bond.BondScript)
+	if err != nil {
+		t.Fatalf("ExtractBondDetails: %v", err)
+	}
+
+	if !bytes.Equal(pkh, pkhPush) {
+		t.Fatalf("mismatching pubkeyhash in bond script and signature (%x != %x)", pkh, pkhPush)
+	}
+	// That verifies the message by recovering the correct pubkey.
+
+	if lockTime.Unix() != int64(lockTimeUint) {
+		t.Fatalf("mismatching locktimes (%d != %d)", lockTime.Unix(), lockTimeUint)
+	}
+	lockTimePush := time.Unix(int64(lockTimeUint), 0)
+	t.Logf("lock time in bond script: %v", lockTimePush)
+
+	priv := secp256k1.PrivKeyFromBytes(bond.BondPrivKey)
+	pk := priv.PubKey()
+	if !pk.IsEqual(pubkey) {
+		t.Fatalf("privkey does not match pubkey from bond script and bond signature")
+	}
+
+	sendBondTx, err := wallet.SendTransaction(bond.SignedTx)
+	if err != nil {
+		t.Fatalf("RefundBond: %v", err)
+	}
+	sendBondTxid, _, err := decodeCoinID(sendBondTx)
+	t.Logf("sendBondTxid: %v\n", sendBondTxid)
+
+	waitNetwork() // wait for alpha to see the txn
+	mineAlpha()
+	waitNetwork() // wait for beta to see the new block (bond must be mined for RefundBond)
+
+	refundTxNew, err := wallet.RefundBond(bond.CoinID, bond.BondScript, bond.BondPrivKey)
+	if err != nil {
+		t.Fatalf("RefundBond: %v", err)
+	}
+	t.Logf("refundTxNew: %x\n", refundTxNew)
 }
 
 func TestWallet(t *testing.T) {

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -30,7 +30,6 @@ import (
 	dexdcr "decred.org/dcrdex/dex/networks/dcr"
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
 	"github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa"
-	"github.com/decred/dcrd/dcrutil/v4"
 )
 
 const (
@@ -195,15 +194,13 @@ func TestMakeBondTx(t *testing.T) {
 		pkB = pubkey.SerializeUncompressed()
 	}
 
-	pkh := dcrutil.Hash160(pkB)
-
-	lockTimeUint, pkhPush, err := dexdcr.ExtractBondDetails(bondOutVersion, bond.BondScript)
+	lockTimeUint, pkPush, err := dexdcr.ExtractBondDetails(bondOutVersion, bond.BondScript)
 	if err != nil {
 		t.Fatalf("ExtractBondDetails: %v", err)
 	}
 
-	if !bytes.Equal(pkh, pkhPush) {
-		t.Fatalf("mismatching pubkeyhash in bond script and signature (%x != %x)", pkh, pkhPush)
+	if !bytes.Equal(pkB, pkPush) {
+		t.Fatalf("mismatching pubkeyhash in bond script and signature (%x != %x)", pkB, pkPush)
 	}
 	// That verifies the message by recovering the correct pubkey.
 

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -365,9 +365,15 @@ func (*ExchangeWallet) AuditContract(coinID, contract, txData dex.Bytes) (*asset
 	return nil, asset.ErrNotImplemented
 }
 
-// LocktimeExpired returns true if the specified contract's locktime has
+// LockTimeExpired returns true if the specified locktime has expired, making it
+// possible to redeem the locked coins.
+func (*ExchangeWallet) LockTimeExpired(lockTime time.Time) (bool, error) {
+	return false, asset.ErrNotImplemented
+}
+
+// ContractLockTimeExpired returns true if the specified contract's locktime has
 // expired, making it possible to issue a Refund.
-func (*ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
+func (*ExchangeWallet) ContractLockTimeExpired(contract dex.Bytes) (bool, time.Time, error) {
 	return false, time.Time{}, asset.ErrNotImplemented
 }
 
@@ -440,6 +446,17 @@ func (*ExchangeWallet) PayFee(address string, regFee uint64) (asset.Coin, error)
 	return nil, asset.ErrNotImplemented
 }
 
+// MakeBondTx creates a time-locked fidelity bond transaction.
+func (*ExchangeWallet) MakeBondTx(amt uint64, lockTime time.Time, acctID []byte) (*asset.Bond, error) {
+	return nil, asset.ErrNotImplemented
+}
+
+// RefundBond refunds a bond output to a new wallet address given the redeem
+// script and private key.
+func (*ExchangeWallet) RefundBond(coinID, script []byte, privKey []byte) ([]byte, error) {
+	return nil, asset.ErrNotImplemented
+}
+
 // sendToAddr sends funds from acct to addr.
 func (eth *ExchangeWallet) sendToAddr(addr common.Address, amt, gasPrice *big.Int) (common.Hash, error) {
 	tx := map[string]string{
@@ -449,6 +466,11 @@ func (eth *ExchangeWallet) sendToAddr(addr common.Address, amt, gasPrice *big.In
 		"gasPrice": fmt.Sprintf("0x%x", gasPrice),
 	}
 	return eth.node.sendTransaction(eth.ctx, tx)
+}
+
+// SendTransaction broadcasts the raw transaction.
+func (*ExchangeWallet) SendTransaction(rawTx []byte) ([]byte, error) {
+	return nil, asset.ErrNotImplemented
 }
 
 // Withdraw withdraws funds to the specified address. Value is gwei.

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -59,6 +59,7 @@ var promptPasswords = map[string][]string{
 	"newwallet":  {"App password:", "Wallet password:"},
 	"openwallet": {"App password:"},
 	"register":   {"App password:"},
+	"addbond":    {"App password:"},
 	"trade":      {"App password:"},
 	"withdraw":   {"App password:"},
 	"appseed":    {"App password:"},
@@ -68,9 +69,9 @@ var promptPasswords = map[string][]string{
 // the text content of a file, where the file path _may_ be found in the route's
 // cmd args at the specified index.
 var optionalTextFiles = map[string]int{
-	"getfee":    1,
-	"register":  2,
-	"newwallet": 1,
+	"bondassets": 1,
+	"register":   3,
+	"newwallet":  1,
 }
 
 // promptPWs prompts for passwords on stdin and returns an error if prompting

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -3,7 +3,6 @@
 package core
 
 import (
-	"bytes"
 	"encoding/hex"
 	"errors"
 	"testing"
@@ -12,6 +11,7 @@ import (
 	"decred.org/dcrdex/dex/order"
 )
 
+/* TODO: rework TestAccountExport
 func TestAccountExport(t *testing.T) {
 	rig := newTestRig()
 	tCore := rig.core
@@ -20,7 +20,7 @@ func TestAccountExport(t *testing.T) {
 
 	setupRigAccountProof(host, rig)
 
-	accountResponse, err := tCore.AccountExport(tPW, host)
+	accountResponse, _ , err := tCore.AccountExport(tPW, host)
 	if err != nil {
 		t.Fatalf("account keys error: %v", err)
 	}
@@ -52,6 +52,7 @@ func TestAccountExport(t *testing.T) {
 		t.Fatal("unexpected FeeProofStamp")
 	}
 }
+*/
 
 // If account is not paid then AccountProof should contain unset values
 func TestAccountExportNoAccountProof(t *testing.T) {
@@ -62,7 +63,7 @@ func TestAccountExportNoAccountProof(t *testing.T) {
 
 	setupRigAccountProof(host, rig)
 
-	accountResponse, err := tCore.AccountExport(tPW, host)
+	accountResponse, _ /*bonds*/, err := tCore.AccountExport(tPW, host)
 	if err != nil {
 		t.Fatalf("account keys error: %v", err)
 	}
@@ -182,7 +183,7 @@ func TestAccountExportPasswordError(t *testing.T) {
 	tCore := rig.core
 	host := tCore.conns[tDexHost].acct.host
 	rig.crypter.(*tCrypter).recryptErr = tErr
-	_, err := tCore.AccountExport(tPW, host)
+	_, _, err := tCore.AccountExport(tPW, host)
 	if !errorHasCode(err, passwordErr) {
 		t.Fatalf("expected password error, actual error: '%v'", err)
 	}
@@ -192,7 +193,7 @@ func TestAccountExportAddressError(t *testing.T) {
 	rig := newTestRig()
 	tCore := rig.core
 	host := ":bad:"
-	_, err := tCore.AccountExport(tPW, host)
+	_, _, err := tCore.AccountExport(tPW, host)
 	if !errorHasCode(err, addressParseErr) {
 		t.Fatalf("expected address parse error, actual error: '%v'", err)
 	}
@@ -206,7 +207,7 @@ func TestAccountExportUnknownDEX(t *testing.T) {
 	tCore.connMtx.Lock()
 	delete(tCore.conns, tDexHost)
 	tCore.connMtx.Unlock()
-	_, err := tCore.AccountExport(tPW, host)
+	_, _, err := tCore.AccountExport(tPW, host)
 	if !errorHasCode(err, unknownDEXErr) {
 		t.Fatalf("expected unknown DEX error, actual error: '%v'", err)
 	}
@@ -217,7 +218,7 @@ func TestAccountExportAccountKeyError(t *testing.T) {
 	tCore := rig.core
 	host := tCore.conns[tDexHost].acct.host
 	rig.crypter.(*tCrypter).decryptErr = tErr
-	_, err := tCore.AccountExport(tPW, host)
+	_, _, err := tCore.AccountExport(tPW, host)
 	if !errorHasCode(err, passwordErr) {
 		t.Fatalf("expected password error, actual error: '%v'", err)
 	}
@@ -229,14 +230,14 @@ func TestAccountExportAccountProofError(t *testing.T) {
 	host := tCore.conns[tDexHost].acct.host
 	tCore.conns[tDexHost].acct.isPaid = true
 	rig.db.accountProofErr = tErr
-	_, err := tCore.AccountExport(tPW, host)
+	_, _, err := tCore.AccountExport(tPW, host)
 	if !errorHasCode(err, accountProofErr) {
 		t.Fatalf("expected account proof error, actual error: '%v'", err)
 	}
 }
 
-func buildTestAccount(host string) Account {
-	return Account{
+func buildTestAccount(host string) *Account {
+	return &Account{
 		Host:          host,
 		AccountID:     tDexAccountID.String(),
 		DEXPubKey:     hex.EncodeToString(tDexKey.SerializeCompressed()),
@@ -248,6 +249,7 @@ func buildTestAccount(host string) Account {
 	}
 }
 
+/* TODO: rework AccountImport
 func TestAccountImport(t *testing.T) {
 	rig := newTestRig()
 	tCore := rig.core
@@ -264,22 +266,22 @@ func TestAccountImport(t *testing.T) {
 	if !rig.db.verifyCreateAccount {
 		t.Fatalf("expected execution of db.CreateAccount")
 	}
-	if rig.db.acct.Host != host {
-		t.Fatalf("unexpected accountInfo Host")
+	if rig.db.accountInfoPersisted.Host != host {
+		t.Fatalf("unexprected accountInfo Host")
 	}
 	DEXpubKey, _ := hex.DecodeString(account.DEXPubKey)
-	if !bytes.Equal(rig.db.acct.DEXPubKey.SerializeCompressed(), DEXpubKey) {
+	if !bytes.Equal(rig.db.accountInfoPersisted.DEXPubKey.SerializeCompressed(), DEXpubKey) {
 		t.Fatal("unexpected DEXPubKey")
 	}
 	feeCoin, _ := hex.DecodeString(account.FeeCoin)
-	if !bytes.Equal(rig.db.acct.FeeCoin, feeCoin) {
+	if !bytes.Equal(rig.db.accountInfoPersisted.FeeCoin, feeCoin) {
 		t.Fatal("unexpected FeeCoin")
 	}
 	cert, _ := hex.DecodeString(account.Cert)
-	if !bytes.Equal(rig.db.acct.Cert, cert) {
+	if !bytes.Equal(rig.db.accountInfoPersisted.Cert, cert) {
 		t.Fatal("unexpected Cert")
 	}
-	if !rig.db.acct.Paid {
+	if !rig.db.accountInfoPersisted.Paid {
 		t.Fatal("unexpected Paid value")
 	}
 	if rig.db.accountProofPersisted.Host != host {
@@ -293,6 +295,7 @@ func TestAccountImport(t *testing.T) {
 		t.Fatal("unexpected FeeProofStamp")
 	}
 }
+*/
 
 func TestAccountImportEmptyFeeProofSig(t *testing.T) {
 	rig := newTestRig()
@@ -301,7 +304,7 @@ func TestAccountImportEmptyFeeProofSig(t *testing.T) {
 	account := buildTestAccount(host)
 	account.FeeProofSig = ""
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil /* bonds */)
 	if err != nil {
 		t.Fatalf("account import error: %v", err)
 	}
@@ -313,24 +316,24 @@ func TestAccountImportEmptyFeeProofSig(t *testing.T) {
 	}
 }
 
-func TestAccountImportEmptyFeeProofStamp(t *testing.T) {
-	rig := newTestRig()
-	tCore := rig.core
-	host := tCore.conns[tDexHost].acct.host
-	account := buildTestAccount(host)
-	account.FeeProofStamp = 0
-	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
-	if err != nil {
-		t.Fatalf("account import error: %v", err)
-	}
-	if rig.db.verifyAccountPaid {
-		t.Fatalf("not expecting execution of db.AccountPaid")
-	}
-	if !rig.db.verifyCreateAccount {
-		t.Fatalf("expected execution of db.CreateAccount")
-	}
-}
+// func TestAccountImportEmptyFeeProofStamp(t *testing.T) {
+// 	rig := newTestRig()
+// 	tCore := rig.core
+// 	host := tCore.conns[tDexHost].acct.host
+// 	account := buildTestAccount(host)
+// 	account.FeeProofStamp = 0
+// 	rig.queueConfig()
+// 	err := tCore.AccountImport(tPW, account)
+// 	if err != nil {
+// 		t.Fatalf("account import error: %v", err)
+// 	}
+// 	if rig.db.verifyAccountPaid {
+// 		t.Fatalf("not expecting execution of db.AccountPaid")
+// 	}
+// 	if !rig.db.verifyCreateAccount {
+// 		t.Fatalf("expected execution of db.CreateAccount")
+// 	}
+// }
 
 func TestAccountImportPasswordError(t *testing.T) {
 	rig := newTestRig()
@@ -339,7 +342,7 @@ func TestAccountImportPasswordError(t *testing.T) {
 	account := buildTestAccount(host)
 	rig.queueConfig()
 	rig.crypter.(*tCrypter).recryptErr = tErr
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, passwordErr) {
 		t.Fatalf("expected password error, actual error: '%v'", err)
 	}
@@ -351,7 +354,7 @@ func TestAccountImportAddressError(t *testing.T) {
 	host := ":bad:"
 	account := buildTestAccount(host)
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, addressParseErr) {
 		t.Fatalf("expected address parse error, actual error: '%v'", err)
 	}
@@ -364,7 +367,7 @@ func TestAccountImportDecodePubKeyError(t *testing.T) {
 	account := buildTestAccount(host)
 	account.DEXPubKey = "bad"
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, decodeErr) {
 		t.Fatalf("expected decode error, actual error: '%v'", err)
 	}
@@ -377,7 +380,7 @@ func TestAccountImportParsePubKeyError(t *testing.T) {
 	account := buildTestAccount(host)
 	account.DEXPubKey = hex.EncodeToString([]byte("bad"))
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, parseKeyErr) {
 		t.Fatalf("expected parse key error, actual error: '%v'", err)
 	}
@@ -390,7 +393,7 @@ func TestAccountImportDecodeCertError(t *testing.T) {
 	account := buildTestAccount(host)
 	account.Cert = "bad"
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, decodeErr) {
 		t.Fatalf("expected decode error, actual error: '%v'", err)
 	}
@@ -403,7 +406,7 @@ func TestAccountImportDecodeFeeCoinError(t *testing.T) {
 	account := buildTestAccount(host)
 	account.FeeCoin = "bad"
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, decodeErr) {
 		t.Fatalf("expected decode error, actual error: '%v'", err)
 	}
@@ -417,7 +420,7 @@ func TestAccountImportAccountVerificationError(t *testing.T) {
 	account.FeeProofSig = ""
 	account.FeeCoin = ""
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, accountVerificationErr) {
 		t.Fatalf("expected account verification error, actual error: '%v'", err)
 	}
@@ -430,7 +433,7 @@ func TestAccountImportDecodePrivKeyError(t *testing.T) {
 	account := buildTestAccount(host)
 	account.PrivKey = "bad"
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, decodeErr) {
 		t.Fatalf("expected decode error, actual error: '%v'", err)
 	}
@@ -443,7 +446,7 @@ func TestAccountImportEncryptPrivKeyError(t *testing.T) {
 	account := buildTestAccount(host)
 	rig.crypter.(*tCrypter).encryptErr = tErr
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, encryptionErr) {
 		t.Fatalf("expected encryption error, actual error: '%v'", err)
 	}
@@ -456,7 +459,7 @@ func TestAccountImportDecodeFeeProofSigError(t *testing.T) {
 	account := buildTestAccount(host)
 	account.FeeProofSig = "bad"
 	rig.queueConfig()
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, decodeErr) {
 		t.Fatalf("expected decode error, actual error: '%v'", err)
 	}
@@ -469,7 +472,7 @@ func TestAccountImportAccountPaidError(t *testing.T) {
 	account := buildTestAccount(host)
 	rig.queueConfig()
 	rig.db.accountPaidErr = tErr
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, dbErr) {
 		t.Fatalf("expected db error, actual error: '%v'", err)
 	}
@@ -482,7 +485,7 @@ func TestAccountImportAccountCreateAccountError(t *testing.T) {
 	account := buildTestAccount(host)
 	rig.queueConfig()
 	rig.db.createAccountErr = tErr
-	err := tCore.AccountImport(tPW, account)
+	err := tCore.AccountImport(tPW, account, nil)
 	if !errorHasCode(err, dbErr) {
 		t.Fatalf("expected db error, actual error: '%v'", err)
 	}

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -19,7 +19,7 @@ const (
 	signatureErr
 	zeroFeeErr
 	feeMismatchErr
-	feeSendErr
+	bondPostErr // TODO
 	passwordErr
 	emptyHostErr
 	connectionErr
@@ -42,6 +42,8 @@ const (
 	unknownDEXErr
 	accountRetrieveErr
 	accountDisableErr
+	bondAmtErr
+	bondTimeErr
 )
 
 // Error is an error message and an error code.

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -12,7 +12,7 @@ import (
 
 // Notifications should use the following note type strings.
 const (
-	NoteTypeFeePayment   = "feepayment"
+	NoteTypeBondPost     = "bondpost"
 	NoteTypeWithdraw     = "withdraw"
 	NoteTypeOrder        = "order"
 	NoteTypeMatch        = "match"
@@ -129,36 +129,44 @@ func newSecurityNote(subject, details string, severity db.Severity) *SecurityNot
 	}
 }
 
-// FeePaymentNote is a notification regarding registration fee payment.
-type FeePaymentNote struct {
+// BondPostNote is a notification regarding bond posting.
+type BondPostNote struct {
 	db.Notification
-	Confirmations *uint32 `json:"confirmations,omitempty"`
-	Dex           string  `json:"dex,omitempty"`
+	Confirmations *int32 `json:"confirmations,omitempty"`
+	Tier          *int64 `json:"tier,omitempty"`
+	Dex           string `json:"dex,omitempty"`
 }
 
 const (
-	SubjectFeePaymentInProgress    = "Fee payment in progress"
-	SubjectRegUpdate               = "regupdate"
-	SubjectFeePaymentError         = "Fee payment error"
-	SubjectAccountRegistered       = "Account registered"
-	SubjectAccountUnlockError      = "Account unlock error"
-	SubjectFeeCoinError            = "Fee coin error"
+	SubjectRegUpdate          = "regupdate"
+	SubjectBondConfirming     = "Bond confirmation in progress"
+	SubjectBondPostError      = "Bond post error"
+	SubjectBondCoinError      = "Bond coin error"
+	SubjectAccountRegistered  = "Account registered"
+	SubjectAccountUnlockError = "Account unlock error"
+
 	SubjectWalletConnectionWarning = "Wallet connection warning"
 	SubjectWalletUnlockError       = "Wallet unlock error"
 )
 
-func newFeePaymentNote(subject, details string, severity db.Severity, dexAddr string) *FeePaymentNote {
+func newBondPostNote(subject, details string, severity db.Severity, dexAddr string) *BondPostNote {
 	host, _ := addrHost(dexAddr)
-	return &FeePaymentNote{
-		Notification: db.NewNotification(NoteTypeFeePayment, subject, details, severity),
+	return &BondPostNote{
+		Notification: db.NewNotification(NoteTypeBondPost, subject, details, severity),
 		Dex:          host,
 	}
 }
 
-func newFeePaymentNoteWithConfirmations(subject, details string, severity db.Severity, currConfs uint32, dexAddr string) *FeePaymentNote {
-	feePmtNt := newFeePaymentNote(subject, details, severity, dexAddr)
-	feePmtNt.Confirmations = &currConfs
-	return feePmtNt
+func newBondPostNoteWithConfirmations(subject, details string, severity db.Severity, currConfs int32, dexAddr string) *BondPostNote {
+	bondPmtNt := newBondPostNote(subject, details, severity, dexAddr)
+	bondPmtNt.Confirmations = &currConfs
+	return bondPmtNt
+}
+
+func newBondPostNoteWithTier(subject, details string, severity db.Severity, dexAddr string, tier int64) *BondPostNote {
+	bondPmtNt := newBondPostNote(subject, details, severity, dexAddr)
+	bondPmtNt.Tier = &tier
+	return bondPmtNt
 }
 
 // WithdrawNote is a notification regarding a requested withdraw.
@@ -332,6 +340,8 @@ const (
 	SubjectDexAuthError     = "DEX auth error"
 	SubjectUnknownOrders    = "DEX reported unknown orders"
 	SubjectOrdersReconciled = "Orders reconciled with DEX"
+	SubjectBondConfirmed    = "Bond confirmed"
+	SubjectBondExpired      = "Bond expired"
 )
 
 func newDEXAuthNote(subject, host string, authenticated bool, details string, severity db.Severity) *DEXAuthNote {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -997,7 +997,7 @@ func (t *trackedTrade) isRefundable(match *matchTracker) bool {
 	}
 
 	// Issue a refund if our swap's locktime has expired.
-	swapLocktimeExpired, contractExpiry, err := wallet.LocktimeExpired(match.MetaData.Proof.Script)
+	swapLocktimeExpired, contractExpiry, err := wallet.ContractLockTimeExpired(match.MetaData.Proof.Script)
 	if err != nil {
 		t.dc.log.Errorf("error checking if locktime has expired for %s contract on order %s, match %s: %v",
 			match.Side, t.ID(), match, err)

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -50,51 +50,62 @@ var (
 // Bolt works on []byte keys and values. These are some commonly used key and
 // value encodings.
 var (
+	// bucket keys
 	appBucket              = []byte("appBucket")
 	accountsBucket         = []byte("accounts")
+	bondsSubBucket         = []byte("bonds")
 	disabledAccountsBucket = []byte("disabledAccounts")
 	activeOrdersBucket     = []byte("activeOrders")
 	archivedOrdersBucket   = []byte("orders")
 	matchesBucket          = []byte("matches")
 	walletsBucket          = []byte("wallets")
 	notesBucket            = []byte("notes")
-	versionKey             = []byte("version")
-	linkedKey              = []byte("linked")
-	feeProofKey            = []byte("feecoin")
-	statusKey              = []byte("status")
-	baseKey                = []byte("base")
-	quoteKey               = []byte("quote")
-	orderKey               = []byte("order")
-	matchKey               = []byte("match")
-	orderIDKey             = []byte("orderID")
-	matchIDKey             = []byte("matchID")
-	proofKey               = []byte("proof")
-	activeKey              = []byte("active")
-	dexKey                 = []byte("dex")
-	updateTimeKey          = []byte("utime")
-	accountKey             = []byte("account")
-	balanceKey             = []byte("balance")
-	walletKey              = []byte("wallet")
-	changeKey              = []byte("change")
-	noteKey                = []byte("note")
-	stampKey               = []byte("stamp")
-	severityKey            = []byte("severity")
-	ackKey                 = []byte("ack")
-	swapFeesKey            = []byte("swapFees")
-	maxFeeRateKey          = []byte("maxFeeRate")
-	redemptionFeesKey      = []byte("redeemFees")
-	typeKey                = []byte("type")
 	credentialsBucket      = []byte("credentials")
-	encSeedKey             = []byte("encSeed")
-	encInnerKeyKey         = []byte("encInnerKey")
-	innerKeyParamsKey      = []byte("innerKeyParams")
-	outerKeyParamsKey      = []byte("outerKeyParams")
-	legacyKeyParamsKey     = []byte("keyParams")
-	byteTrue               = encode.ByteTrue
-	byteFalse              = encode.ByteFalse
-	byteEpoch              = uint16Bytes(uint16(order.OrderStatusEpoch))
-	byteBooked             = uint16Bytes(uint16(order.OrderStatusBooked))
-	backupDir              = "backup"
+
+	// value keys
+	versionKey         = []byte("version")
+	linkedKey          = []byte("linked")
+	feeProofKey        = []byte("feecoin")
+	statusKey          = []byte("status")
+	baseKey            = []byte("base")
+	quoteKey           = []byte("quote")
+	orderKey           = []byte("order")
+	matchKey           = []byte("match")
+	orderIDKey         = []byte("orderID")
+	matchIDKey         = []byte("matchID")
+	proofKey           = []byte("proof")
+	activeKey          = []byte("active")
+	bondKey            = []byte("bond")
+	confirmedKey       = []byte("confirmed")
+	refundedKey        = []byte("refunded")
+	lockTimeKey        = []byte("lockTime")
+	dexKey             = []byte("dex")
+	updateTimeKey      = []byte("utime")
+	accountKey         = []byte("account")
+	balanceKey         = []byte("balance")
+	walletKey          = []byte("wallet")
+	changeKey          = []byte("change")
+	noteKey            = []byte("note")
+	stampKey           = []byte("stamp")
+	severityKey        = []byte("severity")
+	ackKey             = []byte("ack")
+	swapFeesKey        = []byte("swapFees")
+	maxFeeRateKey      = []byte("maxFeeRate")
+	redemptionFeesKey  = []byte("redeemFees")
+	typeKey            = []byte("type")
+	encSeedKey         = []byte("encSeed")
+	encInnerKeyKey     = []byte("encInnerKey")
+	innerKeyParamsKey  = []byte("innerKeyParams")
+	outerKeyParamsKey  = []byte("outerKeyParams")
+	legacyKeyParamsKey = []byte("keyParams")
+
+	// values
+	byteTrue   = encode.ByteTrue
+	byteFalse  = encode.ByteFalse
+	byteEpoch  = uint16Bytes(uint16(order.OrderStatusEpoch))
+	byteBooked = uint16Bytes(uint16(order.OrderStatusBooked))
+
+	backupDir = "backup"
 )
 
 // BoltDB is a bbolt-based database backend for a DEX client. BoltDB satisfies
@@ -352,27 +363,57 @@ func (db *BoltDB) ListAccounts() ([]string, error) {
 	})
 }
 
+func loadAccountInfo(acct *bbolt.Bucket) (*db.AccountInfo, error) {
+	acctB := getCopy(acct, accountKey)
+	if acctB == nil {
+		return nil, fmt.Errorf("empty account")
+	}
+	acctInfo, err := dexdb.DecodeAccountInfo(acctB)
+	if err != nil {
+		return nil, err
+	}
+	acctInfo.LegacyFeePaid = len(acct.Get(feeProofKey)) > 0
+
+	bondsBkt := acct.Bucket(bondsSubBucket)
+	if bondsBkt == nil {
+		return nil, nil // no bonds, OK for legacy account
+	}
+
+	c := bondsBkt.Cursor()
+	for bondUID, _ := c.First(); bondUID != nil; bondUID, _ = c.Next() {
+		bond := bondsBkt.Bucket(bondUID)
+		if acct == nil {
+			return nil, fmt.Errorf("bond sub-bucket %x not a nested bucket", bondUID)
+		}
+		dbBond, err := dexdb.DecodeBond(getCopy(bond, bondKey))
+		if err != nil {
+			fmt.Printf("invalid bond data encoding: %x", err)
+			continue
+		}
+		dbBond.Confirmed = bEqual(bond.Get(confirmedKey), byteTrue)
+		dbBond.Refunded = bEqual(bond.Get(refundedKey), byteTrue)
+		acctInfo.Bonds = append(acctInfo.Bonds, dbBond)
+	}
+
+	return acctInfo, nil
+}
+
 // Accounts returns a list of DEX Accounts. The DB is designed to have a single
-// account per DEX, so the account itself is identified by the DEX URL.
+// account per DEX, so the account itself is identified by the DEX host. TODO:
+// allow bonds filter based on lockTime.
 func (db *BoltDB) Accounts() ([]*dexdb.AccountInfo, error) {
 	var accounts []*dexdb.AccountInfo
 	return accounts, db.acctsView(func(accts *bbolt.Bucket) error {
 		c := accts.Cursor()
-		// key, _ := c.First()
 		for acctKey, _ := c.First(); acctKey != nil; acctKey, _ = c.Next() {
 			acct := accts.Bucket(acctKey)
 			if acct == nil {
 				return fmt.Errorf("account bucket %s value not a nested bucket", string(acctKey))
 			}
-			acctB := getCopy(acct, accountKey)
-			if acctB == nil {
-				return fmt.Errorf("empty account found for %s", string(acctKey))
-			}
-			acctInfo, err := dexdb.DecodeAccountInfo(acctB)
+			acctInfo, err := loadAccountInfo(acct)
 			if err != nil {
 				return err
 			}
-			acctInfo.Paid = len(acct.Get(feeProofKey)) > 0
 			accounts = append(accounts, acctInfo)
 		}
 		return nil
@@ -383,23 +424,13 @@ func (db *BoltDB) Accounts() ([]*dexdb.AccountInfo, error) {
 func (db *BoltDB) Account(url string) (*dexdb.AccountInfo, error) {
 	var acctInfo *dexdb.AccountInfo
 	acctKey := []byte(url)
-	return acctInfo, db.acctsView(func(accts *bbolt.Bucket) error {
+	return acctInfo, db.acctsView(func(accts *bbolt.Bucket) (err error) {
 		acct := accts.Bucket(acctKey)
 		if acct == nil {
-			return fmt.Errorf("account not found for %s", url)
+			return dexdb.ErrAcctNotFound
 		}
-		acctB := getCopy(acct, accountKey)
-		if acctB == nil {
-			return fmt.Errorf("empty account found for %s", url)
-		}
-		var err error
-		acctInfo, err = dexdb.DecodeAccountInfo(acctB)
-		if err != nil {
-			return err
-		}
-		acctInfo.Paid = len(acct.Get(feeProofKey)) > 0
-
-		return nil
+		acctInfo, err = loadAccountInfo(acct)
+		return
 	})
 }
 
@@ -425,10 +456,29 @@ func (db *BoltDB) CreateAccount(ai *dexdb.AccountInfo) error {
 		if err != nil {
 			return fmt.Errorf("accountKey put error: %w", err)
 		}
-		err = acct.Put(activeKey, byteTrue)
+		err = acct.Put(activeKey, byteTrue) // huh?
 		if err != nil {
 			return fmt.Errorf("activeKey put error: %w", err)
 		}
+
+		bonds, err := acct.CreateBucket(bondsSubBucket)
+		if err != nil {
+			return fmt.Errorf("unable to create bonds sub-bucket for account for %s: %w", ai.Host, err)
+		}
+
+		for _, bond := range ai.Bonds {
+			bondUID := bond.UniqueID()
+			bondBkt, err := bonds.CreateBucketIfNotExists(bondUID)
+			if err != nil {
+				return fmt.Errorf("failed to create bond %x bucket: %w", bondUID, err)
+			}
+
+			err = db.storeBond(bondBkt, bond)
+			if err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 }
@@ -508,8 +558,9 @@ func (db *BoltDB) AccountProof(url string) (*dexdb.AccountProof, error) {
 	})
 }
 
-// AccountPaid marks the account as paid by setting the "fee proof".
-func (db *BoltDB) AccountPaid(proof *dexdb.AccountProof) error {
+// StoreAccountProof marks the account as paid with the legacy registration fee
+// by setting the "fee proof".
+func (db *BoltDB) StoreAccountProof(proof *dexdb.AccountProof) error {
 	acctKey := []byte(proof.Host)
 	return db.acctsUpdate(func(accts *bbolt.Bucket) error {
 		acct := accts.Bucket(acctKey)
@@ -538,6 +589,96 @@ func (db *BoltDB) disabledAcctsView(f bucketFunc) error {
 // disabledAcctsUpdate is a convenience function for inserting into the disabledAccounts bucket.
 func (db *BoltDB) disabledAcctsUpdate(f bucketFunc) error {
 	return db.withBucket(disabledAccountsBucket, db.Update, f)
+}
+
+func (db *BoltDB) storeBond(bondBkt *bbolt.Bucket, bond *db.Bond) error {
+	err := bondBkt.Put(bondKey, bond.Encode())
+	if err != nil {
+		return fmt.Errorf("bondKey put error: %w", err)
+	}
+
+	confirmed := encode.ByteFalse
+	if bond.Confirmed {
+		confirmed = encode.ByteTrue
+	}
+	err = bondBkt.Put(confirmedKey, confirmed)
+	if err != nil {
+		return fmt.Errorf("confirmedKey put error: %w", err)
+	}
+
+	refunded := encode.ByteFalse
+	if bond.Refunded {
+		refunded = encode.ByteTrue
+	}
+	err = bondBkt.Put(refundedKey, refunded)
+	if err != nil {
+		return fmt.Errorf("confirmedKey put error: %w", err)
+	}
+
+	err = bondBkt.Put(lockTimeKey, uint64Bytes(bond.LockTime)) // also in bond encoding
+	if err != nil {
+		return fmt.Errorf("lockTimeKey put error: %w", err)
+	}
+
+	return nil
+}
+
+// AddBond saves a new Bond for an existing DEX account.
+func (db *BoltDB) AddBond(host string, bond *db.Bond) error {
+	acctKey := []byte(host)
+	db.acctsUpdate(func(accts *bbolt.Bucket) error {
+		acct := accts.Bucket(acctKey)
+		if acct == nil {
+			return fmt.Errorf("account not found for %s", host)
+		}
+
+		bonds, err := acct.CreateBucketIfNotExists(bondsSubBucket)
+		if err != nil {
+			return fmt.Errorf("unable to access bonds sub-bucket for account for %s: %w", host, err)
+		}
+
+		bondUID := bond.UniqueID()
+		bondBkt, err := bonds.CreateBucketIfNotExists(bondUID)
+		if err != nil {
+			return fmt.Errorf("failed to create bond %x bucket: %w", bondUID, err)
+		}
+
+		return db.storeBond(bondBkt, bond)
+	})
+	return nil
+}
+
+func (db *BoltDB) setBondFlag(host string, assetID uint32, bondCoinID []byte, flagKey []byte) error {
+	acctKey := []byte(host)
+	return db.acctsUpdate(func(accts *bbolt.Bucket) error {
+		acct := accts.Bucket(acctKey)
+		if acct == nil {
+			return fmt.Errorf("account not found for %s", host)
+		}
+
+		bonds := acct.Bucket(bondsSubBucket)
+		if bonds == nil {
+			return fmt.Errorf("bonds sub-bucket not found for account for %s", host)
+		}
+
+		bondUID := dexdb.BondUID(assetID, bondCoinID)
+		bondBkt := bonds.Bucket(bondUID)
+		if bondBkt == nil {
+			return fmt.Errorf("bond bucket does not exist: %x", bondUID)
+		}
+
+		return bondBkt.Put(flagKey, byteTrue)
+	})
+}
+
+// ConfirmBond marks a DEX account bond as confirmed by the DEX.
+func (db *BoltDB) ConfirmBond(host string, assetID uint32, bondCoinID []byte) error {
+	return db.setBondFlag(host, assetID, bondCoinID, confirmedKey)
+}
+
+// BondRefunded marks a DEX account bond as refunded by the client wallet.
+func (db *BoltDB) BondRefunded(host string, assetID uint32, bondCoinID []byte) error {
+	return db.setBondFlag(host, assetID, bondCoinID, refundedKey)
 }
 
 // UpdateOrder saves the order information in the database. Any existing order

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -239,16 +239,19 @@ func TestAccounts(t *testing.T) {
 	// Test account proofs.
 	zerothHost := accts[0].Host
 	zerothAcct, _ := boltdb.Account(zerothHost)
-	if zerothAcct.Paid {
+	if zerothAcct.Confirmed {
 		t.Fatalf("Account marked as paid before account proof set")
 	}
-	boltdb.AccountPaid(&db.AccountProof{
-		Host:  zerothAcct.Host,
-		Stamp: 123456789,
-		Sig:   []byte("some signature here"),
-	})
+	err = boltdb.AccountPaid(zerothAcct.Host, []byte(`feecoinasdf`), []byte("some signature here"))
+	if err != nil {
+		t.Fatalf("AccountPaid error: %v", err)
+	}
+	err = boltdb.ConfirmAccount(zerothAcct.Host)
+	if err != nil {
+		t.Fatalf("ConfirmAccount error: %v", err)
+	}
 	reAcct, _ := boltdb.Account(zerothHost)
-	if !reAcct.Paid {
+	if !reAcct.Confirmed {
 		t.Fatalf("Account not marked as paid after account proof set")
 	}
 }
@@ -284,31 +287,6 @@ func TestDisableAccount(t *testing.T) {
 	}
 	if actualDisabledAccount == nil {
 		t.Fatalf("Expected to retrieve a disabledAccount.")
-	}
-}
-
-func TestAccountProof(t *testing.T) {
-	boltdb := newTestDB(t)
-	acct := dbtest.RandomAccountInfo()
-	host := acct.Host
-
-	err := boltdb.CreateAccount(acct)
-	if err != nil {
-		t.Fatalf("Unexpected CreateAccount error: %v", err)
-	}
-
-	boltdb.AccountPaid(&db.AccountProof{
-		Host:  acct.Host,
-		Stamp: 123456789,
-		Sig:   []byte("some signature here"),
-	})
-
-	accountProof, err := boltdb.AccountProof(host)
-	if err != nil {
-		t.Fatalf("Unexpected AccountProof error: %v", err)
-	}
-	if accountProof == nil {
-		t.Fatal("AccountProof not found")
 	}
 }
 

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -23,7 +23,7 @@ type DB interface {
 		walletUpdates map[uint32][]byte, acctUpdates map[string][]byte, err error)
 	// ListAccounts returns a list of DEX URLs. The DB is designed to have a
 	// single account per DEX, so the account is uniquely identified by the DEX
-	// URL.
+	// host.
 	ListAccounts() ([]string, error)
 	// Accounts retrieves all accounts.
 	Accounts() ([]*AccountInfo, error)
@@ -31,12 +31,17 @@ type DB interface {
 	Account(host string) (*AccountInfo, error)
 	// CreateAccount saves the AccountInfo.
 	CreateAccount(ai *AccountInfo) error
+	// AddBond saves a new Bond for a DEX.
+	AddBond(host string, bond *Bond) error
+	ConfirmBond(host string, assetID uint32, bondCoinID []byte) error
+	BondRefunded(host string, assetID uint32, bondCoinID []byte) error
 	// DisableAccount sets the AccountInfo disabled status to true.
 	DisableAccount(host string) error
-	// AccountProof retrieves the AccountPoof value specified by url.
+	// AccountProof retrieves the AccountPoof value specified by url. DEPRECATED
 	AccountProof(host string) (*AccountProof, error)
-	// AccountPaid marks the account as paid.
-	AccountPaid(proof *AccountProof) error
+	// StoreAccountProof stores an AccountProof, marking the account as paid
+	// with the legacy registration fee. DEPRECATED
+	StoreAccountProof(proof *AccountProof) error
 	// UpdateOrder saves the order information in the database. Any existing
 	// order info will be overwritten without indication.
 	UpdateOrder(m *MetaOrder) error

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -33,11 +33,11 @@ func randString(maxLen int) string {
 func RandomAccountInfo() *db.AccountInfo {
 	return &db.AccountInfo{
 		Host: ordertest.RandomAddress(),
-		// LegacyEncKey: randBytes(32),
-		EncKeyV2:  randBytes(32),
-		DEXPubKey: randomPubKey(),
-		FeeCoin:   randBytes(32),
-		Cert:      randBytes(100),
+		// LegacyEncKey:  randBytes(32),
+		EncKeyV2:      randBytes(32),
+		DEXPubKey:     randomPubKey(),
+		LegacyFeeCoin: randBytes(32),
+		Cert:          randBytes(100),
 	}
 }
 
@@ -158,6 +158,7 @@ func RandomNotification(maxTime uint64) *db.Notification {
 }
 
 type testKiller interface {
+	Helper()
 	Fatalf(string, ...interface{})
 }
 
@@ -247,6 +248,7 @@ func MustCompareMatchProof(t testKiller, m1, m2 *db.MatchProof) {
 // MustCompareAccountInfo ensures the two AccountInfo are identical, calling the
 // Fatalf method of the testKiller if not.
 func MustCompareAccountInfo(t testKiller, a1, a2 *db.AccountInfo) {
+	t.Helper()
 	if a1.Host != a2.Host {
 		t.Fatalf("Host mismatch. %s != %s", a1.Host, a2.Host)
 	}
@@ -260,8 +262,8 @@ func MustCompareAccountInfo(t testKiller, a1, a2 *db.AccountInfo) {
 		t.Fatalf("EncKey mismatch. %x != %x",
 			a1.DEXPubKey.SerializeCompressed(), a2.DEXPubKey.SerializeCompressed())
 	}
-	if !bytes.Equal(a1.FeeCoin, a2.FeeCoin) {
-		t.Fatalf("EncKey mismatch. %x != %x", a1.FeeCoin, a2.FeeCoin)
+	if !bytes.Equal(a1.LegacyFeeCoin, a2.LegacyFeeCoin) {
+		t.Fatalf("EncKey mismatch. %x != %x", a1.LegacyFeeCoin, a2.LegacyFeeCoin)
 	}
 }
 

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -187,6 +187,8 @@ func TestHandleVersion(t *testing.T) {
 	}
 }
 
+// TestHandleGetDEXConfig
+/*
 func TestHandleGetFee(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -226,6 +228,7 @@ func TestHandleGetFee(t *testing.T) {
 		}
 	}
 }
+*/
 
 func TestHandleInit(t *testing.T) {
 	pw := encode.PassBytes("password123")
@@ -454,7 +457,7 @@ func TestHandleRegister(t *testing.T) {
 		name:        "core.GetFee error",
 		params:      params,
 		getFeeErr:   errors.New("error"),
-		wantErrCode: msgjson.RPCGetFeeError,
+		wantErrCode: msgjson.RPCGetDexConfError,
 	}, {
 		name:        "bad params",
 		params:      &RawParams{},

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -64,8 +64,9 @@ type clientCore interface {
 	Login(appPass []byte) (*core.LoginResult, error)
 	Logout() error
 	OpenWallet(assetID uint32, appPass []byte) error
-	GetFee(addr string, cert interface{}) (fee uint64, err error)
+	GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error)
 	Register(form *core.RegisterForm) (*core.RegisterResult, error)
+	AddBond(form *core.AddBondForm) (*core.AddBondResult, error)
 	Trade(appPass []byte, form *core.TradeForm) (order *core.Order, err error)
 	Wallets() (walletsStates []*core.WalletState)
 	WalletState(assetID uint32) *core.WalletState

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -32,8 +32,8 @@ var (
 )
 
 type TCore struct {
-	regFee              uint64
-	getFeeErr           error
+	dexConfig           *core.Exchange
+	getDEXConfigErr     error
 	balanceErr          error
 	syncErr             error
 	createWalletErr     error
@@ -45,6 +45,8 @@ type TCore struct {
 	initializeClientErr error
 	registerResult      *core.RegisterResult
 	registerErr         error
+	addBondResult       *core.AddBondResult
+	addBondErr          error
 	exchanges           map[string]*core.Exchange
 	loginErr            error
 	loginResult         *core.LoginResult
@@ -93,11 +95,14 @@ func (c *TCore) Logout() error {
 func (c *TCore) OpenWallet(assetID uint32, pw []byte) error {
 	return c.openWalletErr
 }
-func (c *TCore) GetFee(url string, cert interface{}) (uint64, error) {
-	return c.regFee, c.getFeeErr
+func (c *TCore) GetDEXConfig(url string, cert interface{}) (*core.Exchange, error) {
+	return c.dexConfig, c.getDEXConfigErr
 }
 func (c *TCore) Register(*core.RegisterForm) (*core.RegisterResult, error) {
 	return c.registerResult, c.registerErr
+}
+func (c *TCore) AddBond(*core.AddBondForm) (*core.AddBondResult, error) {
+	return c.addBondResult, c.addBondErr
 }
 func (c *TCore) SyncBook(dex string, base, quote uint32) (*core.BookFeed, error) {
 	return core.NewBookFeed(func(*core.BookFeed) {}), c.syncErr

--- a/client/rpcserver/types_test.go
+++ b/client/rpcserver/types_test.go
@@ -252,6 +252,8 @@ func TestCheckBoolArg(t *testing.T) {
 	}
 }
 
+// TODO: TestParseBondAssetArgs
+/*
 func TestParseGetFeeArgs(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -283,6 +285,7 @@ func TestParseGetFeeArgs(t *testing.T) {
 		}
 	}
 }
+*/
 
 func TestParseRegisterArgs(t *testing.T) {
 	paramsWithFee := func(fee string) *RawParams {

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -272,11 +272,11 @@ var tExchanges = map[string]*core.Exchange{
 			mkid(3, 22): mkMrkt("doge", "mona"),
 		},
 		Connected: true,
-		Fee: &core.FeeAsset{
-			ID:    42,
-			Confs: 1,
-			Amt:   1e8,
-		},
+		// Fee: &core.FeeAsset{
+		// 	ID:    42,
+		// 	Confs: 1,
+		// 	Amt:   1e8,
+		// },
 	},
 	secondDEX: {
 		Host:   "thisdexwithalongname.com",
@@ -287,11 +287,11 @@ var tExchanges = map[string]*core.Exchange{
 			mkid(22, 141): mkMrkt("mona", "kmd"),
 		},
 		Connected: true,
-		Fee: &core.FeeAsset{
-			ID:    42,
-			Confs: 1,
-			Amt:   1e8,
-		},
+		// Fee: &core.FeeAsset{
+		// 	ID:    42,
+		// 	Confs: 1,
+		// 	Amt:   1e8,
+		// },
 	},
 }
 

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -147,8 +147,8 @@
 <div class="p-4">
   <div class="fs16">
     Enter your app password to confirm DEX registration.
-    When you submit this form, <span id="feeDisplay"></span> DCR will be spent from your Decred wallet to pay
-    registration fees.
+    When you submit this form, <span id="bondDisplay"></span> DCR will be spent from your Decred wallet
+    to post a fidelity bond.
   </div>
   <div class="fs16 mt-4">
     The DCR lot size for the <span id="dcrBaseMarketName" class="mono"></span> market is <span id="dexDCRLotSize"></span> DCR.

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -120,7 +120,7 @@
                   <div class="p-0 w-100">
                     <div class="d-flex flex-column justify-content-center align-items-center">
                       <span id="regStatusTitle" class="title"></span>
-                      <p id="regStatusMessage">In order to trade at <span id="regStatusDex"></span>, the registration fee payment
+                      <p id="regStatusMessage">In order to trade at <span id="regStatusDex"></span>, a bond transaction
                         needs <span id="confReq"></span> confirmations.
                       </p>
                       <span id="regStatusConfsDisplay"></span>

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -74,8 +74,7 @@
         </div>
       </div>
       <div class="order-datum">
-        <div>Fees <span class="ico-info fs12" data-tooltip="On-chain transaction fees, typically collected by the miner. Decred DEX collects no trading fees."></span></div>
-        <div>
+        <div>Fees <span class="ico-info fs12" data-tooltip="On-chain transaction fees, typically collected by the miner. Decred DEX collects no fees of any kind."></span></div>        <div>
           {{$ord.SwapFeesString}} {{template "microIcon" $ord.FromSymbol}},
           {{$ord.RedemptionFeesString}} {{template "microIcon" $ord.ToSymbol}}
         </div>

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -32,12 +32,12 @@
 
     {{- /* Set up the Decred wallet. Only shown if user has not connected their Decred wallet. */ -}}
     <form class="card mx-auto my-5 bg1{{if not .WalletStep}} d-hide{{end}}" id="newWalletForm">
-      {{template "newWalletForm" "Your Decred wallet is required to pay registration fees."}}
+      {{template "newWalletForm" "Your Decred wallet is required to post bond."}}
     </form>
 
     {{- /* Unlock Decred wallet. Only shown if not already unlocked. */ -}}
     <form class="card mx-auto my-5 bg1{{if not .OpenStep}} d-hide{{end}}" id="unlockWalletForm">
-      {{template "unlockWalletForm" "Unlock your Decred wallet to pay registration fees."}}
+      {{template "unlockWalletForm" "Unlock your Decred wallet to post bond."}}
     </form>
 
     {{- /* DEX ADDRESS FORM */ -}}
@@ -50,8 +50,13 @@
       <div class="bg2 px-2 py-1 text-center fs18">Confirm Registration</div>
       <div class="p-4">
         <div class="fs16">
-          When you submit this form, <span id="feeDisplay"></span> DCR will be spent from your Decred wallet to pay registration fees.
+          When you submit this form, <span id="bondDisplay"></span> DCR will be spent from your Decred wallet to post a fidelity bond.
         </div>
+        <div class="fs16 mt-4">
+          This amount still belongs to you! It will just be locked on-chain by network consensus until <span id="bondExpirySpan"></span>.
+        </div>
+        <!-- here goes a field for number of bonds to post -->
+        <!-- here goes an option to maintain this target number of bonds -->
         <div class="fs16 mt-4">
           The lot size for the <span id="dcrBaseMarketName" class="mono"></span> market is <span id="dexDCRLotSize"></span> DCR.
           All trades on this market are in multiples of this lot size.

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -34,6 +34,7 @@
             {{end}}</span>
             <button data-tmpl="exportAccount-{{$host}}" class="bg0 {{if eq (len $xc.AcctID) 0}}d-hide{{end}}">Export Account</button>
             <button data-tmpl="disableAccount-{{$host}}" class="bg0 {{if eq (len $xc.AcctID) 0}}d-hide{{end}}">Disable Account</button>
+            <!-- here goes some form to set the number of active bonds to maintain -->
           </div>
         {{end}}
       </div>

--- a/client/webserver/site/src/js/constants.js
+++ b/client/webserver/site/src/js/constants.js
@@ -1,5 +1,5 @@
 // Code errors from client/core/errors.go
 // Need to be careful for not losing sync between them.
-export const feeSendErr = 8
+export const bondPostErr = 8
 
 // end of errors.

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -407,7 +407,7 @@ export class DEXAddressForm {
       return
     }
 
-    if (res.paid) {
+    if (res.xc.tier > 0 || res.xc.bondsPending) {
       await app.fetchUser()
       app.loadPage('markets')
       return

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -45,7 +45,18 @@ type registrationForm struct {
 	Addr     string           `json:"addr"`
 	Cert     string           `json:"cert"`
 	Password encode.PassBytes `json:"pass"`
-	Fee      uint64           `json:"fee"`
+	Bond     uint64           `json:"bond"`
+	LockTime uint64           `json:"lockTime"`
+	// TODO: BondAssetID
+}
+
+// addBondForm is used to post a new bond for an existing DEX account.
+type addBondForm struct {
+	Addr     string           `json:"addr"`
+	Password encode.PassBytes `json:"pass"`
+	Bond     uint64           `json:"bond"`
+	LockTime uint64           `json:"lockTime"`
+	// TODO: BondAssetID
 }
 
 // newWalletForm is information necessary to create a new wallet.
@@ -89,7 +100,7 @@ type accountExportForm struct {
 
 type accountImportForm struct {
 	Pass    encode.PassBytes `json:"pw"`
-	Account core.Account     `json:"account"`
+	Account *core.Account    `json:"account"`
 }
 
 type accountDisableForm struct {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -18,6 +18,7 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/order"
@@ -57,6 +58,7 @@ type TCore struct {
 	syncFeed        *core.BookFeed
 	syncErr         error
 	regErr          error
+	addBondErr      error
 	loginErr        error
 	logoutErr       error
 	initErr         error
@@ -71,9 +73,8 @@ type TCore struct {
 	notOpen         bool
 }
 
-func (c *TCore) Network() dex.Network                       { return dex.Mainnet }
-func (c *TCore) Exchanges() map[string]*core.Exchange       { return nil }
-func (c *TCore) GetFee(string, interface{}) (uint64, error) { return 1e8, c.getFeeErr }
+func (c *TCore) Network() dex.Network                 { return dex.Mainnet }
+func (c *TCore) Exchanges() map[string]*core.Exchange { return nil }
 func (c *TCore) GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error) {
 	return nil, c.getFeeErr // TODO along with test for apiUser / Exchanges() / User()
 }
@@ -82,6 +83,7 @@ func (c *TCore) PreRegister(dexAddr string, pw []byte, certI interface{}) (*core
 	return nil, false, nil
 }
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
+func (c *TCore) AddBond(r *core.AddBondForm) (*core.AddBondResult, error)    { return nil, c.addBondErr }
 func (c *TCore) InitializeClient(pw, seed []byte) error                      { return c.initErr }
 func (c *TCore) Login(pw []byte) (*core.LoginResult, error)                  { return &core.LoginResult{}, c.loginErr }
 func (c *TCore) IsInitialized() bool                                         { return c.isInited }
@@ -158,10 +160,10 @@ func (c *TCore) MaxSell(host string, base, quote uint32) (*core.MaxOrderEstimate
 func (c *TCore) PreOrder(*core.TradeForm) (*core.OrderEstimate, error) {
 	return nil, nil
 }
-func (c *TCore) AccountExport(pw []byte, host string) (*core.Account, error) {
-	return nil, nil
+func (c *TCore) AccountExport(pw []byte, host string) (*core.Account, []*db.Bond, error) {
+	return nil, nil, nil
 }
-func (c *TCore) AccountImport(pw []byte, account core.Account) error {
+func (c *TCore) AccountImport(pw []byte, account *core.Account, bonds []*db.Bond) error {
 	return nil
 }
 func (c *TCore) AccountDisable(pw []byte, host string) error { return nil }
@@ -463,6 +465,8 @@ func TestAPIInit(t *testing.T) {
 	tCore.initErr = nil
 }
 
+// TODO: TestAPIGetDEXConfig
+/*
 func TestAPIGetFee(t *testing.T) {
 	writer := new(TWriter)
 	var body interface{}
@@ -482,6 +486,7 @@ func TestAPIGetFee(t *testing.T) {
 	ensure(fmt.Sprintf(`{"ok":false,"msg":"%s"}`, tErr))
 	tCore.getFeeErr = nil
 }
+*/
 
 func TestAPINewWallet(t *testing.T) {
 	writer := new(TWriter)

--- a/dex/asset.go
+++ b/dex/asset.go
@@ -14,6 +14,12 @@ const (
 
 	defaultLockTimeTaker = 8 * time.Hour
 	defaultlockTimeMaker = 20 * time.Hour
+
+	secondsPerMinute  int64 = 60
+	secondsPerDay           = 24 * 60 * secondsPerMinute
+	BondExpiryMainnet       = 30 * secondsPerDay
+	BondExpiryTestnet       = 90 * secondsPerMinute
+	BondExpirySimnet        = 4 * secondsPerMinute
 )
 
 var (

--- a/dex/encode/encode.go
+++ b/dex/encode/encode.go
@@ -4,7 +4,6 @@
 package encode
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
@@ -17,13 +16,13 @@ import (
 var (
 	// IntCoder is the DEX-wide integer byte-encoding order.
 	IntCoder = binary.BigEndian
-	// A byte-slice representation of boolean false.
+	// ByteFalse is a byte-slice representation of boolean false.
 	ByteFalse = []byte{0}
-	// A byte-slice representation of boolean true.
+	// ByteTrue is a byte-slice representation of boolean true.
 	ByteTrue = []byte{1}
-	maxU16   = int(^uint16(0))
-	bEqual   = bytes.Equal
 )
+
+const maxU16 = int(^uint16(0))
 
 // Uint64Bytes converts the uint16 to a length-2, big-endian encoded byte slice.
 func Uint16Bytes(i uint16) []byte {

--- a/dex/encode/encode_test.go
+++ b/dex/encode/encode_test.go
@@ -1,6 +1,7 @@
 package encode
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -39,7 +40,7 @@ func TestBuildyBytes(t *testing.T) {
 		for _, p := range tt.pushes {
 			b = b.AddData(p)
 		}
-		if !bEqual(b, tt.exp) {
+		if !bytes.Equal(b, tt.exp) {
 			t.Fatalf("test %d failed", i)
 		}
 	}
@@ -90,7 +91,7 @@ func TestDecodeBlob(t *testing.T) {
 		}
 		for j, push := range pushes {
 			check := tt.exp[j]
-			if !bEqual(check, push) {
+			if !bytes.Equal(check, push) {
 				t.Fatalf("push %d:%d incorrect. wanted %x, got %x", i, j, check, push)
 			}
 		}

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -31,7 +31,7 @@ const (
 	RPCOpenWalletError                // 12
 	RPCWalletExistsError              // 13
 	RPCCloseWalletError               // 14
-	RPCGetFeeError                    // 15
+	RPCGetDexConfError                // 15
 	RPCRegisterError                  // 16
 	RPCArgumentsError                 // 17
 	RPCTradeError                     // 18
@@ -75,6 +75,7 @@ const (
 	AccountExistsError                // 56
 	AccountSuspendedError             // 57
 	RPCExportSeedError                // 58
+	BondError                         // 57
 )
 
 // Routes are destinations for a "payload" of data. The type of data being
@@ -156,6 +157,21 @@ const (
 	// DEX that the fee has been paid and has the requisite number of
 	// confirmations.
 	NotifyFeeRoute = "notifyfee"
+	// PostBondRoute is the client-originating request used to post a new
+	// fidelity bond protocol. This can create a new account or it can add bond
+	// to an existing account.
+	PostBondRoute = "postbond"
+	// BondConfirmedRoute is a server-originating notification when a bond
+	// posted with postbond reaches the required confirmations. This
+	// notification is not sent if the bond is either not found on the network
+	// or is at the required confirmations when the postbond response is sent.
+	BondConfirmedRoute = "bondconfirmed"
+	// BondExpiredRoute is a server-originating notification when a bond expires
+	// according to the configure bond expiry duration and the bond's lock time.
+	BondExpiredRoute = "bondexpired"
+	// TierChange is a server-originating notification sent to a connected user
+	// who's tier changes for any reason.
+	TierChangeRoute = "tierchange" // (TODO: use in many auth mgr events)
 	// ConfigRoute is the client-originating request-type message requesting the
 	// DEX configuration information.
 	ConfigRoute = "config"
@@ -271,6 +287,8 @@ type ResponsePayload struct {
 // decoded depends on its MessageType.
 type MessageType uint8
 
+// There are presently three recognized message types: request, response, and
+// notification.
 const (
 	InvalidMessageType MessageType = iota // 0
 	Request                               // 1
@@ -461,7 +479,7 @@ func (m *Match) Serialize() []byte {
 	return append(s, uint64Bytes(m.FeeRateQuote)...)
 }
 
-// Nomatch is the payload for a server-originating NoMatchRoute notification.
+// NoMatch is the payload for a server-originating NoMatchRoute notification.
 type NoMatch struct {
 	OrderID Bytes `json:"orderid"`
 }
@@ -474,7 +492,7 @@ type MatchRequest struct {
 	MatchID Bytes  `json:"matchid"`
 }
 
-// MatchStatus is the successful result for the MatchStatusRoute request.
+// MatchStatusResult is the successful result for the MatchStatusRoute request.
 type MatchStatusResult struct {
 	MatchID       Bytes `json:"matchid"`
 	Status        uint8 `json:"status"`
@@ -621,6 +639,9 @@ func (r *Redemption) Serialize() []byte {
 	return append(s, uint64Bytes(r.Time)...)
 }
 
+// Certain order properties are specified with the following constants. These
+// properties include buy/sell (side), standing/immediate (force),
+// limit/market/cancel (order type).
 const (
 	BuyOrderNum       = 1
 	SellOrderNum      = 2
@@ -792,12 +813,12 @@ type BookOrderNote struct {
 	TradeNote
 }
 
-// UnbookOrderRoute is the DEX-originating notification-type message informing
+// UnbookOrderNote is the DEX-originating notification-type message informing
 // the client to remove an order from the order book.
 type UnbookOrderNote OrderNote
 
-// EpochOrderRoute is the DEX-originating notification-type message informing
-// the client about an order added to the epoch queue.
+// EpochOrderNote is the DEX-originating notification-type message informing the
+// client about an order added to the epoch queue.
 type EpochOrderNote struct {
 	BookOrderNote
 	Commit    Bytes  `json:"com"`
@@ -885,6 +906,16 @@ func (c *Connect) Serialize() []byte {
 	return append(s, uint64Bytes(c.Time)...)
 }
 
+// Bond is information on a fidelity bond. This is part of the ConnectResult and
+// PostBondResult payloads.
+type Bond struct {
+	Amount  uint64 `json:"amt"`
+	Expiry  uint64 `json:"expiry"` // when it expires, not the lock time
+	CoinID  Bytes  `json:"coinid"`
+	AssetID uint32 `json:"assetid"`
+	Pending bool   `json:"pending,omitempty"` // omit when at required confs
+}
+
 // ConnectResult is the result for the ConnectRoute request.
 //
 // TODO: Include penalty data as specified in the spec.
@@ -893,6 +924,9 @@ type ConnectResult struct {
 	ActiveOrderStatuses []*OrderStatus `json:"activeorderstatuses"`
 	ActiveMatches       []*Match       `json:"activematches"`
 	Score               int32          `json:"score"`
+	Tier                int64          `json:"tier"` // 1+ means bonded and may trade, a function of active bond amounts and conduct
+	ActiveBonds         []*Bond        `json:"activeBonds"`
+	// Violations []Violation `json:"violations"` // TODO: active violations
 }
 
 // PenaltyNote is the payload of a Penalty notification.
@@ -906,7 +940,7 @@ type PenaltyNote struct {
 type Penalty struct {
 	Rule     account.Rule `json:"rule"`
 	Time     uint64       `json:"timestamp"`
-	Duration uint64       `json:"duration"`
+	Duration uint64       `json:"duration,omitempty"` // DEPRECATED with bonding tiers, but must remain in serialization until v1
 	Details  string       `json:"details"`
 }
 
@@ -921,6 +955,82 @@ func (n *PenaltyNote) Serialize() []byte {
 	b = append(b, uint64Bytes(p.Duration)...)
 	return append(b, []byte(p.Details)...)
 }
+
+// PostBond should include unsigned transaction for validation prior to
+// broadcasting the signed transaction so the client hasn't needlessly locked
+// funds if the transaction is rejected by the server.
+type PostBond struct {
+	Signature
+	AcctPubKey Bytes  `json:"acctPubKey"` // acctID = blake256(blake256(acctPubKey))
+	AssetID    uint32 `json:"assetID"`
+	BondTx     Bytes  `json:"bondTx"`
+	BondScript Bytes  `json:"bondScript"`
+	BondSig    Bytes  `json:"bondSig"` // account id signed by key from bond script's pubkey
+
+	// LegacyFeeRefundAddr is an optional field for the client to specify a
+	// return address so they may *request* a refund of their legacy
+	// registration fee, if they had paid it.
+	LegacyFeeRefundAddr string `json:"legacyFeeRefundAddress,omitempty"`
+}
+
+// Serialize serializes the PostBond data for the signature.
+func (pb *PostBond) Serialize() []byte {
+	// serialization: client pubkey (33) + asset ID (4) + raw tx (variable) +
+	// bond script (variable)
+	sz := len(pb.AcctPubKey) + 4 + len(pb.BondTx) + len(pb.BondScript)
+	b := make([]byte, 0, sz)
+	b = append(b, pb.AcctPubKey...)
+	b = append(b, uint32Bytes(pb.AssetID)...)
+	b = append(b, pb.BondTx...)
+	return append(b, pb.BondScript...) // BondSig not included
+}
+
+// PostBondResult is the response to the client's PostBond request. If Confs is
+// -1, the bond tx was not found on the network, but was otherwise validated.
+type PostBondResult struct {
+	Signature        // message is BondID | AccountID
+	AccountID Bytes  `json:"accountid"`
+	AssetID   uint32 `json:"assetID"`
+	Amt       uint64 `json:"amt"`
+	Expiry    int64  `json:"expiry"` // not locktime, but time when bond expires for dex
+	BondID    Bytes  `json:"bondID"`
+	Confs     int64  `json:"confs"`
+	Tier      int64  `json:"tier"`
+	// BondTotal uint64 `json:"bondTotal"`
+}
+
+// Serialize serializes the PostBondResult data for the signature.
+func (pbr *PostBondResult) Serialize() []byte {
+	sz := len(pbr.AccountID) + len(pbr.BondID)
+	b := make([]byte, 0, sz)
+	b = append(b, pbr.AccountID...)
+	return append(b, pbr.BondID...)
+}
+
+// BondConfirmedNotification is a courtesy notification when a bond tx reaches
+// the required number of confirmations. This will not be sent for postbond
+// requests for fully-confirmed txns.
+type BondConfirmedNotification struct {
+	Signature
+	AccountID  Bytes  `json:"accountid"`
+	AssetID    uint32 `json:"assetid"`
+	BondCoinID Bytes  `json:"coinid"`
+	Tier       int64  `json:"tier"`
+}
+
+// Serialize serializes the BondConfirmedNotification data.
+func (bc *BondConfirmedNotification) Serialize() []byte {
+	sz := 4 + len(bc.AccountID) + 4 + len(bc.BondCoinID) + 8
+	b := make([]byte, 0, sz)
+	b = append(b, bc.AccountID...)
+	b = append(b, uint32Bytes(bc.AssetID)...)
+	b = append(b, bc.BondCoinID...)
+	return append(b, uint64Bytes(uint64(bc.Tier))...) // correct bytes for int64 (signed)?
+}
+
+// BondExpiredNotification has the same structure and method (serialization) as
+// BondConfirmedNotification.
+type BondExpiredNotification = BondConfirmedNotification // alias to get methods without having to instantiate literals with BondConfirmedNotification
 
 // Register is the payload for the RegisterRoute request.
 type Register struct {
@@ -1035,17 +1145,37 @@ type Asset struct {
 	SwapConf     uint16 `json:"swapconf"`
 }
 
-// ConfigResult is the successful result for the ConfigRoute.
+// BondAsset describes an asset for which fidelity bonds are supported.
+type BondAsset struct {
+	ID    uint32 `json:"id"`
+	Confs uint32 `json:"confs"`
+	Amt   uint64 `json:"amount"`
+}
+
+// Client should send bond info when their bond tx is fully-confirmed. Server
+// should start waiting for required confs when it receives the 'postbond'
+// request if the txn is found. Client is responsible for submitting 'postbond'
+// for their bond txns when they reach required confs, or when the client
+// restarts and finds bonds recorded in their DB that have are flagged as
+// neither accepted or expired (also maybe if not listed in the 'connect'
+// response).
+
+// ConfigResult is the successful result for the ConfigRoute. A bond expires
+// when the time remaining until lockTime is less than BondExpiry. As such,
+// bonds should be created with a considerably longer lockTime.
 type ConfigResult struct {
-	CancelMax        float64   `json:"cancelmax"`
-	BroadcastTimeout uint64    `json:"btimeout"`
-	RegFeeConfirms   uint16    `json:"regfeeconfirms"`
-	Assets           []*Asset  `json:"assets"`
-	Markets          []*Market `json:"markets"`
-	Fee              uint64    `json:"fee"`
-	APIVersion       uint16    `json:"apiver"`
-	BinSizes         []string  `json:"binSizes"` // Just apidata.BinSizes for now.
-	DEXPubKey        Bytes     `json:"pubkey"`
+	APIVersion       uint16                `json:"apiver"`
+	DEXPubKey        dex.Bytes             `json:"dexpubkey"`
+	CancelMax        float64               `json:"cancelmax"`
+	BroadcastTimeout uint64                `json:"btimeout"`
+	Assets           []*Asset              `json:"assets"`
+	Markets          []*Market             `json:"markets"`
+	BondExpiry       uint64                `json:"bondExpiry"`
+	BondAssets       map[string]*BondAsset `json:"bondAssets"`
+	BinSizes         []string              `json:"binSizes"` // Just apidata.BinSizes for now.
+
+	Fee            uint64 `json:"fee"`            // DEPRECATED
+	RegFeeConfirms uint16 `json:"regfeeconfirms"` // DEPRECATED
 }
 
 // Spot is a snapshot of a market at the end of a match cycle. A slice of Spot

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -48,7 +48,7 @@ MINE_SLEEP=3
 if [ -f ./harnesschain.tar.gz ]; then
   echo "Seeding blockchain from compressed file"
   MINE=0
-  MINE_SLEEP=0.5
+  MINE_SLEEP=0.75
   mkdir -p "${NODES_ROOT}/alpha/data"
   mkdir -p "${NODES_ROOT}/beta/data"
   tar -xzf ./harnesschain.tar.gz -C ${NODES_ROOT}/alpha/data

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/btcsuite/btcutil v1.0.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210715032435-c9521b468f95
+	github.com/decred/dcrd/blockchain/v4 v4.0.0-20210525214639-70483c835b7f
 	github.com/decred/dcrd/certgen v1.1.2-0.20210715032435-c9521b468f95
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.3-0.20210715032435-c9521b468f95
 	github.com/decred/dcrd/chaincfg/v3 v3.0.1-0.20210715032435-c9521b468f95

--- a/go.sum
+++ b/go.sum
@@ -119,7 +119,9 @@ github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210525214639-70483c835b7f/go
 github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210715032435-c9521b468f95 h1:y1XUDb5vPBcZB6A0AuGkaCk0my4FJOpYYKZtYKsq1mU=
 github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210715032435-c9521b468f95/go.mod h1:l0WWtO2D4lhDJDWjFPFClNDBJ5gp6CI5dfk9QsWS59Q=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.0.0/go.mod h1:t2qaZ3hNnxHZ5kzVJDgW5sp47/8T5hYJt7SR+/JtRhI=
+github.com/decred/dcrd/blockchain/standalone/v2 v2.0.1-0.20210525214639-70483c835b7f h1:U6KxL7cTlkqYGRnmMS6yn3h8vnUPCOBpXPFiZ7+iR8c=
 github.com/decred/dcrd/blockchain/standalone/v2 v2.0.1-0.20210525214639-70483c835b7f/go.mod h1:t2qaZ3hNnxHZ5kzVJDgW5sp47/8T5hYJt7SR+/JtRhI=
+github.com/decred/dcrd/blockchain/v4 v4.0.0-20210525214639-70483c835b7f h1:jIzjp2KFcBpzaRlGE/5krg8CERf+jVlcx6v3spF2QGI=
 github.com/decred/dcrd/blockchain/v4 v4.0.0-20210525214639-70483c835b7f/go.mod h1:9IU+i0k9FY68p7P21aFeOYSGTT4q87UxSLWb47NEegU=
 github.com/decred/dcrd/certgen v1.1.2-0.20210525214639-70483c835b7f/go.mod h1:ivkPLChfjdAgFh7ZQOtl6kJRqVkfrCq67dlq3AbZBQE=
 github.com/decred/dcrd/certgen v1.1.2-0.20210715032435-c9521b468f95 h1:ZGdWjeRWFdzKuckO0ONnyL5+oL+3+LGQyiU5+MZn8bA=
@@ -172,6 +174,7 @@ github.com/decred/dcrd/gcs/v3 v3.0.0-20210715032435-c9521b468f95/go.mod h1:LFTyj
 github.com/decred/dcrd/hdkeychain/v3 v3.0.1-0.20210525214639-70483c835b7f/go.mod h1:A9Aqp4kStmkAwbZeuIlS1hZjTeDkxgVXSg+nSo4FJCs=
 github.com/decred/dcrd/hdkeychain/v3 v3.0.1-0.20210715032435-c9521b468f95 h1:1RQbVRX/Si9OB2zb8VkB9bL40BVow+hQAjgsu8LNPRY=
 github.com/decred/dcrd/hdkeychain/v3 v3.0.1-0.20210715032435-c9521b468f95/go.mod h1:A9Aqp4kStmkAwbZeuIlS1hZjTeDkxgVXSg+nSo4FJCs=
+github.com/decred/dcrd/lru v1.1.0 h1:QwT6v8LFKOL3xQ3qtucgRk4pdiawrxIfCbUXWpm+JL4=
 github.com/decred/dcrd/lru v1.1.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210129200153-14fd1a785bf2/go.mod h1:9izQEJ5wU0ZwYHESMaaOIvE6H6y3IvDsQL3ByYGn9oc=
 github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210525214639-70483c835b7f/go.mod h1:9izQEJ5wU0ZwYHESMaaOIvE6H6y3IvDsQL3ByYGn9oc=

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -8,21 +8,15 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"decred.org/dcrdex/server/account/pki"
 	"github.com/decred/dcrd/crypto/blake256"
 	"github.com/decred/dcrd/dcrec/secp256k1/v3"
 )
 
-var (
-	HashFunc = blake256.Sum256
-	century  = time.Hour * 24 * 365 * 100
-)
+var HashFunc = blake256.Sum256
 
-const (
-	HashSize = blake256.Size
-)
+const HashSize = blake256.Size
 
 type AccountID [HashSize]byte
 
@@ -118,7 +112,6 @@ const (
 // details holds rule specific details.
 type details struct {
 	name, description string
-	duration          time.Duration
 }
 
 // ruleDetails maps rules to rule details.
@@ -126,27 +119,22 @@ var ruleDetails = map[Rule]details{
 	NoRule: {
 		name:        "NoRule",
 		description: "no rules have been broken",
-		duration:    0,
 	},
 	PreimageReveal: {
 		name:        "PreimageReveal",
 		description: "failed to respond with a valid preimage for an order during epoch processing",
-		duration:    century,
 	},
 	FailureToAct: {
 		name:        "FailureToAct",
 		description: "did not follow through on a swap negotiation step",
-		duration:    century,
 	},
 	CancellationRate: {
 		name:        "CancellationRate",
 		description: "cancellation rate dropped below the acceptable level",
-		duration:    century,
 	},
 	LowFees: {
 		name:        "LowFees",
 		description: "did not pay transaction mining fees at the requisite level",
-		duration:    century,
 	},
 }
 
@@ -164,14 +152,6 @@ func (r Rule) Description() string {
 		return d.description
 	}
 	return "description not specified"
-}
-
-// Duration returns the penalty duration of the rule being broken.
-func (r Rule) Duration() time.Duration {
-	if d, ok := ruleDetails[r]; ok {
-		return d.duration
-	}
-	return century
 }
 
 // Punishable returns whether breaking this rule incurs a penalty.

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -66,8 +66,6 @@ type SvrCore interface {
 	MarketStatuses() map[string]*market.Status
 	SuspendMarket(name string, tSusp time.Time, persistBooks bool) (*market.SuspendEpoch, error)
 	ResumeMarket(name string, asSoonAs time.Time) (startEpoch int64, startTime time.Time, err error)
-	Penalize(aid account.AccountID, rule account.Rule, details string) error
-	Unban(aid account.AccountID) error
 	ForgiveMatchFail(aid account.AccountID, mid order.MatchID) (forgiven, unbanned bool, err error)
 	BookOrders(base, quote uint32) (orders []*order.LimitOrder, err error)
 	EpochOrders(base, quote uint32) (orders []order.Order, err error)
@@ -152,8 +150,6 @@ func NewServer(cfg *SrvConfig) (*Server, error) {
 		r.Get("/enabledataapi/{"+yesKey+"}", s.apiEnableDataAPI)
 		r.Route("/account/{"+accountIDKey+"}", func(rm chi.Router) {
 			rm.Get("/", s.apiAccountInfo)
-			rm.Get("/ban", s.apiBan)
-			rm.Get("/unban", s.apiUnban)
 			rm.Get("/forgive_match/{"+matchIDKey+"}", s.apiForgiveMatchFail)
 			rm.Post("/notify", s.apiNotify)
 		})

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -19,14 +19,17 @@ import (
 
 	"decred.org/dcrdex/dex"
 	dexdcr "decred.org/dcrdex/dex/networks/dcr"
+	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/asset"
 	"github.com/decred/dcrd/blockchain/stake/v4"
+	"github.com/decred/dcrd/blockchain/v4"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson/v3"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/hdkeychain/v3"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 )
@@ -84,6 +87,7 @@ type dcrNode interface {
 	GetBestBlockHash(ctx context.Context) (*chainhash.Hash, error)
 	GetBlockChainInfo(ctx context.Context) (*chainjson.GetBlockChainInfoResult, error)
 	GetRawTransaction(ctx context.Context, txHash *chainhash.Hash) (*dcrutil.Tx, error)
+	SendRawTransaction(ctx context.Context, tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error)
 }
 
 // The rpcclient package functions will return a rpcclient.ErrRequestCanceled
@@ -93,6 +97,125 @@ func translateRPCCancelErr(err error) error {
 		err = asset.ErrRequestTimeout
 	}
 	return err
+}
+
+// ParseBondTx performs basic validation of a serialized time-locked fidelity
+// bond transaction given the bond's P2SH redeem script.
+//
+// The transaction must have at least two outputs: out 0 pays to a P2SH address
+// (the bond), and out 1 is a nulldata output that commits to an account ID.
+// There may also be a change output.
+//
+// Returned: The bond's coin ID (i.e. encoded UTXO) of the bond output. The bond
+// output's amount and P2SH address. The lockTime and pubkey hash data pushes
+// from the script. The account ID from the second output is also returned.
+//
+// Properly formed transactions:
+//
+//  1. The bond output (vout 0) must be a P2SH output.
+//  2. The bond's redeem script must be of the form:
+//     (locktime 4-bytes) OP_CHECKLOCKTIMEVERIFY OP_DROP OP_DUP OP_HASH160 <pubkeyhash[20]> OP_EQUALVERIFY OP_CHECKSIG
+//     NOTE: Considering "OP_CHECKLOCKTIMEVERIFY OP_DROP <pubkey[32]> OP_CHECKSIG"
+//     since the pubkey must be revealed anyway. Also maybe have this be the
+//     *account* pubkey rather than an arbitrary one that the client controls.
+//  3. The null data output (vout 1) must have a 32-byte data push (account ID).
+//  4. The transaction must have a zero locktime and expiry.
+//  5. All inputs must have the max sequence num set (finalized).
+//  6. The transaction must pass the checks in the
+//     blockchain.CheckTransactionSanity function.
+//
+// TODO: consider fee rate, which is not important yet for DCR.
+func ParseBondTx(rawTx, bondScript []byte) (bondCoinID []byte, amt int64, bondAddr string,
+	bondPubKeyHash []byte, lockTime int64, acct account.AccountID, err error) {
+	// While the dcr package uses a package-level chainParams variable, ensure
+	// that a backend has been instantiated (or loadConfig run another way).
+	if chainParams == nil {
+		err = errors.New("dcr asset package config not yet loaded")
+		return
+	}
+	msgTx := wire.NewMsgTx()
+	if err = msgTx.Deserialize(bytes.NewReader(rawTx)); err != nil {
+		return
+	}
+
+	if msgTx.LockTime != 0 {
+		err = errors.New("transaction locktime not zero")
+		return
+	}
+	if msgTx.Expiry != wire.NoExpiryValue {
+		err = errors.New("transaction has an expiration")
+		return
+	}
+
+	if err = blockchain.CheckTransactionSanity(msgTx, chainParams); err != nil {
+		return
+	}
+
+	if len(msgTx.TxOut) < 2 {
+		err = fmt.Errorf("expected at least 2 outputs, found %d", len(msgTx.TxOut))
+		return
+	}
+
+	for _, txIn := range msgTx.TxIn {
+		if txIn.Sequence != wire.MaxTxInSequenceNum {
+			err = errors.New("input has non-max sequence number")
+			return
+		}
+	}
+
+	feeOut := msgTx.TxOut[0]
+
+	class, addrs, numRequired, err := txscript.ExtractPkScriptAddrs(feeOut.Version, feeOut.PkScript, chainParams, true)
+	if err != nil {
+		err = fmt.Errorf("bad bond pkScript: %v", err)
+		return
+	}
+	if class != txscript.ScriptHashTy || numRequired != 1 || len(addrs) != 1 {
+		err = fmt.Errorf("bad bond pkScript (class = %v)", class)
+		return
+	}
+
+	scriptHash := txscript.ExtractScriptHash(feeOut.PkScript)
+	if !bytes.Equal(dcrutil.Hash160(bondScript), scriptHash) {
+		err = fmt.Errorf("script hash check failed for output 0 of %s", msgTx.TxHash())
+		return
+	}
+
+	// Fidelity bond output (output 0)
+	lock, pkh, err := dexdcr.ExtractBondDetails(feeOut.Version, bondScript)
+	if err != nil {
+		err = fmt.Errorf("invalid bond redeem script: %w", err)
+		return
+	}
+
+	// NOTE: Caller should check ownership by verifying a message signed with
+	// the correspond pubkey. (get the pubkey from ecdsa.RecoverCompact(sig,
+	// messageHash) and verify it's the same pubkey)
+
+	// Ensure output 1 script is OP_RETURN <push data for account id>
+	acctCommitOut := msgTx.TxOut[1]
+	commitScript := acctCommitOut.PkScript
+	wantPushSize := account.HashSize
+	if acctCommitOut.Version != 0 || len(commitScript) != 2+wantPushSize || commitScript[0] != txscript.OP_RETURN {
+		fmt.Printf("ver = %d, len(commitScript) = %d, commitScript[0]\n", acctCommitOut.Version, len(commitScript), commitScript[0])
+		err = errors.New("bad account commitment output")
+		return
+	}
+	if commitScript[1] != txscript.OP_DATA_32 {
+		fmt.Printf("commitScript[1] = %v\n", commitScript[1])
+		err = errors.New("invalid account commitment")
+		return
+	}
+	copy(acct[:], commitScript[2:]) // data after [OP_RETURN OP_DATA_32]
+
+	txid := msgTx.TxHash()
+	bondCoinID = toCoinID(&txid, 0)
+	amt = feeOut.Value
+	bondAddr = addrs[0].String() // don't convert address, must match type we specified
+	lockTime = int64(lock)
+	bondPubKeyHash = pkh
+
+	return
 }
 
 // Backend is an asset backend for Decred. It has methods for fetching output
@@ -275,6 +398,22 @@ func (dcr *Backend) BlockChannel(size int) <-chan *asset.BlockUpdate {
 	return c
 }
 
+// SendRawTransaction broadcasts a raw transaction, returning a coin ID.
+func (dcr *Backend) SendRawTransaction(rawtx []byte) (coinID []byte, err error) {
+	msgTx := wire.NewMsgTx()
+	if err = msgTx.Deserialize(bytes.NewReader(rawtx)); err != nil {
+		return nil, err
+	}
+
+	var hash *chainhash.Hash
+	hash, err = dcr.node.SendRawTransaction(dcr.ctx, msgTx, false) // or allow high fees?
+	if err != nil {
+		return
+	}
+	coinID = toCoinID(hash, 0)
+	return
+}
+
 // Contract is part of the asset.Backend interface. An asset.Contract is an
 // output that has been validated as a swap contract for the passed redeem
 // script. A spendable output is one that can be spent in the next block. Every
@@ -358,7 +497,7 @@ func (dcr *Backend) FundingCoin(ctx context.Context, coinID []byte, redeemScript
 
 // ValidateXPub validates the base-58 encoded extended key, and ensures that it
 // is an extended public, not private, key.
-func (dcr *Backend) ValidateXPub(xpub string) error {
+func ValidateXPub(xpub string) error {
 	xp, err := hdkeychain.NewKeyFromString(xpub, chainParams)
 	if err != nil {
 		return err
@@ -451,13 +590,22 @@ func (dcr *Backend) FeeCoin(coinID []byte) (addr string, val uint64, confs int64
 		return
 	}
 
+	// No stake outputs, and no multisig.
 	if len(txOut.Addresses) != 1 || txOut.SigsRequired != 1 ||
-		txOut.ScriptType != dexdcr.ScriptP2PKH /* no schorr or edwards */ ||
 		txOut.ScriptType&dexdcr.ScriptStake != 0 {
 		return "", 0, -1, dex.UnsupportedScriptError
 	}
+
+	// Needs to work for legacy fee and new bond txns.
+	switch txOut.ScriptType {
+	case dexdcr.ScriptP2SH, dexdcr.ScriptP2PKH:
+	default:
+		return "", 0, -1, dex.UnsupportedScriptError
+	}
+
 	addr = txOut.Addresses[0]
 	val = txOut.Value
+
 	return
 }
 
@@ -487,7 +635,7 @@ func (dcr *Backend) OutputSummary(txHash *chainhash.Hash, vout uint32) (txOut *T
 	}
 
 	if int(vout) > len(verboseTx.Vout)-1 {
-		err = asset.CoinNotFoundError // should be something fatal?
+		err = fmt.Errorf("invalid output index for tx with %d outputs", len(verboseTx.Vout))
 		return
 	}
 
@@ -569,7 +717,7 @@ func (dcr *Backend) transaction(txHash *chainhash.Hash, verboseTx *chainjson.TxR
 		sumOut += toAtoms(output.Value)
 		outputs = append(outputs, txOut{
 			value:    toAtoms(output.Value),
-			version:  output.Version, // output.ScriptPubKey.Version with dcrd 1.7 *release*, not yet
+			version:  output.Version, // output.ScriptPubKey.Version with dcrd 1.7
 			pkScript: pkScript,
 		})
 	}

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -20,6 +20,7 @@ import (
 
 	"decred.org/dcrdex/dex"
 	dexdcr "decred.org/dcrdex/dex/networks/dcr"
+	"decred.org/dcrdex/server/account"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec"
@@ -202,6 +203,11 @@ func (*testNode) GetTxOut(_ context.Context, txHash *chainhash.Hash, index uint3
 	out := testChain.txOuts[outID]
 	// Unfound is not an error for GetTxOut.
 	return out, nil
+}
+
+func (*testNode) SendRawTransaction(ctx context.Context, tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error) {
+	hash := tx.TxHash()
+	return &hash, nil
 }
 
 // Part of the dcrNode interface.
@@ -1515,23 +1521,21 @@ func TestValidateXPub(t *testing.T) {
 		t.Fatalf("failed to generate master extended key: %v", err)
 	}
 
-	be := &Backend{}
-
 	// fail for private key
 	xprivStr := master.String()
-	if err = be.ValidateXPub(xprivStr); err == nil {
+	if err = ValidateXPub(xprivStr); err == nil {
 		t.Errorf("no error for extended private key")
 	}
 
 	// succeed for public key
 	xpub := master.Neuter()
 	xpubStr := xpub.String()
-	if err = be.ValidateXPub(xpubStr); err != nil {
+	if err = ValidateXPub(xpubStr); err != nil {
 		t.Error(err)
 	}
 
 	// fail for invalid key of wrong length
-	if err = be.ValidateXPub(xpubStr[2:]); err == nil {
+	if err = ValidateXPub(xpubStr[2:]); err == nil {
 		t.Errorf("no error for invalid key")
 	}
 
@@ -1541,7 +1545,7 @@ func TestValidateXPub(t *testing.T) {
 		t.Fatalf("failed to generate master extended key: %v", err)
 	}
 	xpubTestnet := masterTestnet.Neuter()
-	if err = be.ValidateXPub(xpubTestnet.String()); err == nil {
+	if err = ValidateXPub(xpubTestnet.String()); err == nil {
 		t.Errorf("no error for invalid wrong network")
 	}
 }
@@ -1642,4 +1646,94 @@ func TestSynced(t *testing.T) {
 		t.Fatalf("getblockchaininfo error not propagated")
 	}
 	tNode.blockchainInfoErr = nil
+}
+
+func TestParseBondTx(t *testing.T) {
+	var feeAmt int64 = 1e8
+	txOK := wire.NewMsgTx()
+	txIn := wire.NewTxIn(&wire.OutPoint{}, 1, []byte{2, 2, 3}) // junk input
+	txOK.AddTxIn(txIn)
+
+	pkh := randomBytes(20)
+	addr, err := dcrutil.NewAddressPubKeyHash(pkh, chainParams, dcrec.STEcdsaSecp256k1)
+	if err != nil {
+		t.Fatalf("NewAddressPubKeyHash error: %v\n", err)
+	}
+	feePkScript, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		t.Fatalf("PayToAddrScript error: %v\n", err)
+	}
+	feeOut := wire.NewTxOut(feeAmt, feePkScript)
+	txOK.AddTxOut(feeOut)
+
+	priv, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		fmt.Printf("s256Auth error: %v\n", err)
+	}
+	pubkey := priv.PubKey().SerializeCompressed()
+	acct, err := account.NewAccountFromPubKey(pubkey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	commitPkScript, err := txscript.NewScriptBuilder().
+		AddOp(txscript.OP_RETURN).
+		AddData(acct.ID[:]).
+		Script()
+	if err != nil {
+		fmt.Printf("script building error in testMsgTxSwapInit: %v", err)
+	}
+	acctOut := wire.NewTxOut(0, commitPkScript)
+	txOK.AddTxOut(acctOut)
+
+	txRaw, err := txOK.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// t.Logf("%x", txRaw)
+
+	gotFeeAddr, gotAcct, err := ParseBondTx(txRaw, feeAmt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantFeeAddr := addr.Address()
+	if wantFeeAddr != gotFeeAddr {
+		t.Errorf("wrong fee address, wanted %v, got %v", wantFeeAddr, gotFeeAddr)
+	}
+
+	if gotAcct != acct.ID {
+		t.Errorf("wrong account, wanted %v, got %v", acct.ID, gotAcct)
+	}
+
+	// TODO: restructure test and check all expected errors
+
+	// type args struct {
+	// 	rawTx   []byte
+	// 	wantFee int64
+	// }
+	// tests := []struct {
+	// 	name        string
+	// 	args        args
+	// 	wantFeeAddr string
+	// 	wantAcct    account.AccountID
+	// 	wantErr     bool
+	// }{
+	// 	// TODO: Add test cases.
+	// }
+	// for _, tt := range tests {
+	// 	t.Run(tt.name, func(t *testing.T) {
+	// 		gotFeeAddr, gotAcct, err := ParseBondTx(tt.args.rawTx, tt.args.wantFee)
+	// 		if (err != nil) != tt.wantErr {
+	// 			t.Errorf("ParseBondTx() error = %v, wantErr %v", err, tt.wantErr)
+	// 			return
+	// 		}
+	// 		if gotFeeAddr != tt.wantFeeAddr {
+	// 			t.Errorf("ParseBondTx() gotFeeAddr = %v, want %v", gotFeeAddr, tt.wantFeeAddr)
+	// 		}
+	// 		if !reflect.DeepEqual(gotAcct, tt.wantAcct) {
+	// 			t.Errorf("ParseBondTx() gotAcct = %v, want %v", gotAcct, tt.wantAcct)
+	// 		}
+	// 	})
+	// }
 }

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -82,7 +82,7 @@ type FeeChecker func(coinID []byte) (addr string, val uint64, confs int64, err e
 // the first output of the transaction, which must be the actual bond output.
 // The returned account ID is from the second output.
 type BondTxParser func(rawTx, bondScript []byte) (bondCoinID []byte, amt int64, bondAddr string,
-	bondPubKeyHash []byte, lockTime int64, acct account.AccountID, err error)
+	bondPubKey []byte, lockTime int64, acct account.AccountID, err error)
 
 // TxDataSource retrieves the raw transaction for a coin ID.
 type TxDataSource func(coinID []byte) (rawTx []byte, err error)

--- a/server/auth/registrar.go
+++ b/server/auth/registrar.go
@@ -4,10 +4,13 @@
 package auth
 
 import (
+	"bytes"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"time"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/dex/wait"
@@ -15,6 +18,9 @@ import (
 	"decred.org/dcrdex/server/asset"
 	"decred.org/dcrdex/server/comms"
 	"decred.org/dcrdex/server/db"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v3/ecdsa"
+	"github.com/decred/dcrd/dcrutil/v4" // for hash160, might eliminate
 )
 
 var (
@@ -25,7 +31,376 @@ var (
 	txWaitExpiration = time.Minute
 )
 
+const regFeeAssetID = 42 // DCR, TODO: make AuthManager field
+
+// bondKey creates a unique map key for a bond by its asset ID and coin ID.
+func bondKey(assetID uint32, coinID []byte) string {
+	return string(append(encode.Uint32Bytes(assetID), coinID...))
+}
+
+func (auth *AuthManager) registerBondWaiter(key string) bool {
+	auth.bondWaiterMtx.Lock()
+	defer auth.bondWaiterMtx.Unlock()
+	if _, found := auth.bondWaiterIdx[key]; found {
+		return false
+	}
+	auth.bondWaiterIdx[key] = struct{}{}
+	return true
+}
+
+func (auth *AuthManager) removeBondWaiter(key string) {
+	auth.bondWaiterMtx.Lock()
+	delete(auth.bondWaiterIdx, key)
+	auth.bondWaiterMtx.Unlock()
+}
+
+// handlePostBond handles the 'postbond' request.
+//
+// The request payload includes the user's account public key and the serialized
+// bond post transaction itself (not just the txid), the bond output's redeem
+// script, and a signature of the account ID with the key to which the bond
+// redeem script pays to demonstrate ownership of the bond by the account.
+//
+// The parseBondTx function is used to validate the transaction, and extract
+// bond details (amount, locktime, pubkey hash, etc.) and the account ID to
+// which it commits. This also checks that the account commitment corresponds to
+// the user's public key provided in the payload. If these requirements are
+// satisfied, the client will receive a PostBondResult in the response.
+//
+// Once the raw transaction is validated, the relevant asset node is used to
+// locate the transaction on the network.
+//
+//   - If it is not found, a PostBondResult is sent immediately with
+//     Confs=-1 set.  The bond is NOT stored in the DB. This was a courtesy
+//     pre-validation. The user should then broadcast the transaction, wait for
+//     the required number of confirmations, and send 'postbond' again.
+//   - If the located transaction has the required number of confirmations,
+//     the bond is stored in the DB as active, and a response is sent.
+//   - Otherwise, a response is sent with the observed confirmation count, and a
+//     coin waiter is started to watch for the txn to reach the required number
+//     of confirmations. The bond is stored in DB as pending. When the
+//     transaction reaches the required confirmations, it is flagged active in
+//     the DB and a 'bondconfirmed' notification is sent.
+//
+// NOTE: This presently only supports Decred bonds.
+func (auth *AuthManager) handlePostBond(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
+	postBond := new(msgjson.PostBond)
+	err := msg.Unmarshal(&postBond)
+	if err != nil || postBond == nil {
+		return msgjson.NewError(msgjson.BondError, "error parsing postbond request")
+	}
+
+	// TODO: allow different assets for bond, switching parse functions, etc.
+	assetID := postBond.AssetID
+	if assetID != regFeeAssetID {
+		return msgjson.NewError(msgjson.BondError, "only DCR bonds supported presently")
+	}
+
+	// Create an account.Account from the provided pubkey.
+	acct, err := account.NewAccountFromPubKey(postBond.AcctPubKey)
+	if err != nil {
+		return msgjson.NewError(msgjson.BondError, "error parsing account pubkey: "+err.Error())
+	}
+	acctID := acct.ID
+
+	// Authenticate the message for the supposed account.
+	sigMsg := postBond.Serialize()
+	err = checkSigS256(sigMsg, postBond.SigBytes(), acct.PubKey)
+	if err != nil {
+		return &msgjson.Error{
+			Code:    msgjson.SignatureError,
+			Message: "signature error: " + err.Error(),
+		}
+	}
+
+	// A bond's lockTime must be after bonExpiry from now.
+	lockTimeThresh := time.Now().Add(auth.bondExpiry)
+
+	// Decode raw tx, check fee output (0) and account commitment output (1).
+	bondCoinID, amt, bondAddr, bondPKH, lockTime, commitAcct, err := auth.parseBondTx(postBond.BondTx, postBond.BondScript) // i.e. dcr.ParseBondTx presently, but should switch on asset
+	if err != nil {
+		return msgjson.NewError(msgjson.BondError, "invalid bond transaction: %v", err)
+	}
+	if amt < int64(auth.minBond) {
+		return msgjson.NewError(msgjson.BondError, "insufficient bond amount %d, needed %d", amt, auth.minBond)
+	}
+	if lockTime < lockTimeThresh.Unix() {
+		return msgjson.NewError(msgjson.BondError, "insufficient lock time %d, needed at least %d", lockTime, lockTimeThresh.Unix())
+	}
+
+	// Must be equal to account ID computed from pubkey in the PayFee message.
+	if commitAcct != acctID {
+		return msgjson.NewError(msgjson.BondError, "invalid bond transaction - account commitment does not match pubkey")
+	}
+
+	// Verify that the user has the private keys to the bond pubkey by verifying
+	// the BondSig against the message (acct ID) and bond script's pubkey hash.
+	msgHash := sha256.Sum256(acctID[:])
+	sigPK, _, err := ecdsa.RecoverCompact(postBond.BondSig, msgHash[:])
+	if err != nil {
+		return msgjson.NewError(msgjson.BondError, "invalid bond signature: %v", err)
+	}
+	// This uses dcrutil's hash160, which is different from other coins... maybe
+	// have a p2pk redeem script instead? Or switch to asset-specific pk-hashing
+	// function? Or require bond scripts to pay to the *account* pubkey?
+	sigPKH := dcrutil.Hash160(sigPK.SerializeCompressed())
+	if !bytes.Equal(bondPKH, sigPKH) {
+		return msgjson.NewError(msgjson.BondError, "bond signature does not match bond pubkey")
+	}
+
+	// All good. The client gets a PostBondResult (no error) unless the confirms
+	// check has an unexpected error.
+	expireTime := time.Unix(lockTime, 0).Add(-auth.bondExpiry)
+	postBondRes := &msgjson.PostBondResult{
+		AssetID: assetID,
+		Amt:     uint64(amt),
+		Expiry:  expireTime.Unix(),
+		BondID:  bondCoinID,
+		// Confs is set below.
+	}
+	auth.Sign(postBondRes)
+
+	// See if the account exists, and get known unexpired bonds. Also see if the
+	// account has previously paid a legacy registration fee.
+	dbAcct, bonds, legacyFeePaid := auth.storage.Account(acctID, lockTimeThresh)
+
+	// See if we already have this bond in DB. We still process the request
+	// regardless, but this changes how we proceed.
+	var dbBond *db.Bond
+	for _, bond := range bonds {
+		if bond.AssetID == assetID && bytes.Equal(bond.CoinID, bondCoinID) {
+			dbBond = bond
+			break
+		}
+	}
+	// if dbBond != nil && !dbBond.Pending { /* respond now with dummy confs = reqConfs to save RPCs? */ }
+
+	bondStr := coinIDString(assetID, bondCoinID)
+	bondAssetSym := dex.BipIDSymbol(assetID)
+
+	// Determine if it is pending (found, unconfirmed, fully-confirmed, etc.):
+	// - check confirmations e.g. gettxout
+	// - if tx not found, no error, just confs=-1, respond / break, no DB store (just pre-validate unsigned bond tw)
+	// - store bond info in DB (updating pending flag if already stored)
+	// - if confs >= required, mark bond active and adjust acct tier, no waiter
+	// - if confs < required, start waiter
+	chkAddr, chkAmt, confs, err := auth.checkFee(bondCoinID)
+	if err != nil {
+		// Not found is expected if this is a pre-broadcast validation request.
+		if !errors.Is(err, asset.CoinNotFoundError) {
+			return msgjson.NewError(msgjson.BondError, "unable to check bond with node: %v", err)
+		}
+
+		// OK. Respond with confs=-1. They may now broadcast, wait for the
+		// required confirms, and postbond again.
+		log.Debugf("Validated prospective bond txn output %s (%s) paying %d for user %v", bondStr, bondAssetSym, amt, acctID)
+		postBondRes.Confs = -1
+		resp, err := msgjson.NewResponse(msg.ID, postBondRes, nil)
+		if err != nil { // shouldn't be possible
+			return msgjson.NewError(msgjson.RPCInternalError, "internal encoding error")
+		}
+		err = conn.Send(resp)
+		if err != nil {
+			log.Warnf("error sending postbond result to link: %v", err)
+		}
+		return nil
+	}
+
+	if int64(chkAmt) != amt {
+		return msgjson.NewError(msgjson.BondError, "node reports incorrect bond amount: %d != %d", chkAmt, amt)
+	}
+
+	if chkAddr != bondAddr {
+		return msgjson.NewError(msgjson.BondError, "node reports incorrect bond address: %d != %d", chkAddr, bondAddr)
+	}
+
+	reqConfs := auth.feeConfs // will be from bondassets config (TODO)
+	pending := confs < reqConfs
+
+	// Only store if this is a new bond. If existing, just respond and possibly
+	// start waiting for confirmations and/or flag as active in DB.
+	if dbBond == nil {
+		dbBond = &db.Bond{
+			AssetID:  assetID,
+			CoinID:   bondCoinID,
+			Script:   postBond.BondScript,
+			Amount:   amt,
+			LockTime: lockTime,
+			Pending:  pending,
+		}
+
+		// The user may be posting their initial bond (new account) or topping up.
+		newAcct := dbAcct == nil
+		if newAcct {
+			log.Infof("Creating new user account %v from %v, posted first bond in %v (%s) / %v",
+				acctID, conn.Addr(), bondStr, bondAssetSym, bondAddr)
+			err = auth.storage.CreateAccountWithBond(acct, dbBond)
+		} else {
+			log.Infof("Adding bond for existing user account %v from %v, with bond in %v (%s) / %v",
+				acctID, conn.Addr(), bondStr, bondAssetSym, bondAddr)
+			err = auth.storage.AddBond(acct.ID, dbBond)
+		}
+		if err != nil {
+			log.Errorf("Failure while storing bond for acct %v (new = %v): %v", acct, newAcct, err)
+			return &msgjson.Error{
+				Code:    msgjson.RPCInternalError,
+				Message: "failed to store bond",
+			}
+		}
+	} else if dbBond.Pending && !pending {
+		// If the bond is fully confirmed, and it is not already in the DB as
+		// confirmed, mark the bond active before sending response.
+		log.Infof("Activating bond %s (%s) for acct %v", bondStr, bondAssetSym, acct)
+		dbBond.Pending = false
+		err = auth.storage.ActivateBond(acctID, assetID, bondCoinID)
+		if err != nil {
+			log.Errorf("Activating bond for acct %v failed: %v", acct, err)
+			return &msgjson.Error{
+				Code:    msgjson.RPCInternalError,
+				Message: "failed to store bond",
+			}
+		}
+	}
+
+	if !pending {
+		// Update client info if they are already authenticated.
+		auth.addBond(acctID, dbBond) // idempotent
+
+		if legacyFeePaid && postBond.LegacyFeeRefundAddr != "" {
+			log.Warnf("Account %v posting bond requests a legacy fee refund to %v",
+				acctID, postBond.LegacyFeeRefundAddr) // signature checked above
+			// To actually do this, the operator would need to manually send funds
+			// to the address, then use an admin endpoint to somehow delete the old
+			// fee coin ID from the table.
+		}
+	}
+
+	// Respond with the actual confirmation count and user tier.
+	postBondRes.Confs = confs
+	postBondRes.Tier, _ = auth.ComputeUserTier(acct.ID) // integrate score and active bond amounts
+	resp, err := msgjson.NewResponse(msg.ID, postBondRes, nil)
+	if err != nil { // shouldn't be possible
+		return msgjson.NewError(msgjson.RPCInternalError, "internal encoding error")
+	}
+	err = conn.Send(resp)
+	if err != nil {
+		// Client should attempt postbond again.
+		log.Warnf("Error sending postbond result to user %v: %v", acctID, err)
+	}
+
+	if !pending {
+		// No need it start a waiter since the bond is already active.
+		return nil
+	}
+
+	// Start a block waiter to activate the bond when it is fully-confirmed.
+	bondIDKey := bondKey(assetID, bondCoinID)
+	if !auth.registerBondWaiter(bondIDKey) {
+		// Waiter already running, and this postbond response already sent.
+		return nil
+	}
+
+	// TODO: Startup of AuthManager could recreate waiters for pending bonds,
+	// otherwise clients will have to resubmit their postbond request.
+
+	auth.latencyQ.Wait(&wait.Waiter{
+		Expiration: time.Now().Add(time.Hour),
+		TryFunc: func() bool {
+			res := auth.waitBondConfs(conn, dbBond, acctID, reqConfs)
+			if res == wait.DontTryAgain {
+				auth.removeBondWaiter(bondIDKey)
+			}
+			return res
+		},
+		ExpireFunc: func() {
+			auth.removeBondWaiter(bondIDKey)
+			// User may retry postbond periodically or on reconnect.
+		},
+	})
+
+	return nil
+}
+
+// waitBondConfs is a coin waiter that should be started after validating a bond
+// transaction in the postbond request handler. This waits for the transaction
+// output referenced by coinID to reach reqConfs, and then re-validates the
+// amount and address to which the coinID pays. If the checks pass, the account
+// is marked as paid in storage by saving the coinID for the accountID. Finally,
+// a FeePaidNotification is sent to the provided conn. In case the notification
+// fails to send (e.g. connection no longer active), the user should check paid
+// status on 'connect'.
+func (auth *AuthManager) waitBondConfs(conn comms.Link, bond *db.Bond, acctID account.AccountID, reqConfs int64) bool {
+	coinID := bond.CoinID
+	addr, val, confs, err := auth.checkFee(coinID) // e.g. FeeCoin
+	if err != nil {
+		// This is unexpected because we we already validated everything, so
+		// hopefully this is a transient failure such as RPC connectivity.
+		log.Warnf("Unexpected error checking bond coin: %v", err)
+		return wait.TryAgain
+	}
+	if confs < reqConfs {
+		return wait.TryAgain
+	}
+
+	// Verify the bond amount as a spot check. This should be redundant with the
+	// parseBondTx checks. If it disagrees, there is a bug in the fee asset
+	// backend, and the operator will need to intervene.
+	if int64(val) != bond.Amount {
+		log.Errorf("checkFee: account %v fee coin %x pays %d; expected %d",
+			acctID, coinID, val, bond.Amount)
+		return wait.DontTryAgain
+	}
+
+	// Update bond status in storage.
+	err = auth.storage.ActivateBond(acctID, bond.AssetID, coinID)
+	if err != nil {
+		log.Errorf("Failed to mark account %v as paid with coin %x", acctID, coinID)
+		return wait.DontTryAgain
+	}
+
+	// Integrate active bonds and score to report tier.
+	bondTotal, tier := auth.addBond(acctID, bond)
+	if bondTotal == -1 { // user not authenticated, use DB
+		tier, bondTotal = auth.ComputeUserTier(acctID)
+	}
+
+	log.Infof("Bond accepted: acct %v from %v locked %d in %v (%v). Bond total %d, tier %d",
+		acctID, conn.Addr(), val, coinIDString(bond.AssetID, coinID), addr, bondTotal, tier)
+
+	// PostBondResult was sent immediately after PostBond was handled. Now we
+	// notify that the tranaction has reached reqConfs, but client can watch the
+	// confirmation count theirself.
+	bondConfNtfn := &msgjson.BondConfirmedNotification{
+		AssetID:    bond.AssetID,
+		BondCoinID: coinID,
+		AccountID:  acctID[:],
+		Tier:       tier,
+	}
+	auth.Sign(bondConfNtfn)
+	resp, err := msgjson.NewNotification(msgjson.BondConfirmedRoute, bondConfNtfn)
+	if err != nil {
+		log.Error("BondConfirmedRoute encoding error: %v", err)
+		return wait.DontTryAgain // they will have to discover their tier and active bonds on reconnect
+	}
+
+	// First attempt to send the bondconfirmed notification on the provided link. If
+	// it is down, attempt to send to via the auth manager by account ID.
+	err = conn.Send(resp)
+	if err != nil {
+		// The original link may be lost. See if they have an authenticated
+		// connection.
+		if err = auth.Send(acctID, resp); err != nil {
+			log.Warnf("Error sending feepaid notification to account %v: %v", acctID, err)
+			// The user will need to 'connect' to see confirmed status.
+		}
+	}
+
+	return wait.DontTryAgain
+}
+
 // handleRegister handles requests to the 'register' route.
+//
+// DEPRECATED
 func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
 	// Unmarshal.
 	register := new(msgjson.Register)
@@ -89,7 +464,7 @@ func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *
 		ClientPubKey: register.PubKey,
 		Address:      feeAddr,
 		Fee:          auth.regFee,
-		Time:         encode.UnixMilliU((unixMsNow())),
+		Time:         encode.UnixMilliU(unixMsNow()),
 	}
 	auth.Sign(regRes)
 
@@ -111,6 +486,8 @@ func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *
 }
 
 // handleNotifyFee handles requests to the 'notifyfee' route.
+//
+// DEPRECATED
 func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) *msgjson.Error {
 	// Unmarshal.
 	notifyFee := new(msgjson.NotifyFee)
@@ -133,23 +510,19 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 	var acctID account.AccountID
 	copy(acctID[:], notifyFee.AccountID)
 
-	acct, paid, open := auth.storage.Account(acctID)
+	acct, _, paid := auth.storage.Account(acctID, time.Now()) // don't need bonds
 	if acct == nil {
 		return &msgjson.Error{
 			Code:    msgjson.AuthenticationError,
 			Message: "no account found for ID " + notifyFee.AccountID.String(),
 		}
 	}
-	if !open {
-		return &msgjson.Error{
-			Code:    msgjson.AuthenticationError,
-			Message: "account closed and cannot be reopen",
-		}
-	}
 	if paid {
 		return &msgjson.Error{
-			Code:    msgjson.AuthenticationError,
-			Message: "'notifyfee' send for paid account",
+			// Client should recognize this code and mark their account paid
+			// (TODO client-side).
+			Code:    msgjson.AccountExistsError,
+			Message: "'notifyfee' sent for paid account",
 		}
 	}
 
@@ -209,8 +582,13 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 	return nil
 }
 
-// validateFee is a coin waiter that validates a client's notifyFee request and
-// responds with an Acknowledgement.
+// validateFee is a coin waiter that validates a client's notifyfee request and
+// responds with an Acknowledgement when it reaches the required number of
+// confirmations (feeConfs). The database's PayAccount method is used to store
+// the coinID of the fully-confirmed fee transaction, which is the current
+// indicator that the account is paid with a legacy registration fee.
+//
+// DEPRECATED
 func (auth *AuthManager) validateFee(conn comms.Link, acctID account.AccountID, notifyFee *msgjson.NotifyFee, msgID uint64, coinID []byte, regAddr string) bool {
 	addr, val, confs, err := auth.checkFee(coinID)
 	if err != nil || confs < auth.feeConfs {

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -52,8 +52,9 @@ const (
 	defaultBanScore            = 20
 
 	defaultCancelThresh     = 0.95 // 19 cancels : 1 success
-	defaultRegFeeConfirms   = 4
-	defaultRegFeeAmount     = 1e8
+	defaultRegFeeConfirms   = 2
+	defaultRegFeeAmount     = 1e7              // 0.1 DCR
+	defaultBondIncrement    = 10e8             // 10 DCR
 	defaultBroadcastTimeout = 12 * time.Minute // accommodate certain known long block download timeouts
 )
 
@@ -70,6 +71,7 @@ type procOpts struct {
 type dexConf struct {
 	DataDir           string
 	Network           dex.Network
+	BondIncrement     uint64
 	DBName            string
 	DBUser            string
 	DBPass            string
@@ -124,6 +126,7 @@ type flagsData struct {
 	MarketsConfPath  string        `long:"marketsconfpath" description:"Path to the markets configuration JSON file."`
 	BroadcastTimeout time.Duration `long:"bcasttimeout" description:"The broadcast timeout specifies how long clients have to broadcast an expected transaction when it is their turn to act. Matches without the expected action by this time are revoked and the actor is penalized."`
 	DEXPrivKeyPath   string        `long:"dexprivkeypath" description:"The path to a file containing the DEX private key for message signing."`
+	BondIncrement    uint64        `long:"bondincrement" description:"Bond increment amount."`
 	RegFeeXPub       string        `long:"regfeexpub" description:"The extended public key for deriving Decred addresses to which DEX registration fees should be paid."`
 	RegFeeConfirms   int64         `long:"regfeeconfirms" description:"The number of confirmations required to consider a registration fee paid."`
 	RegFeeAmount     uint64        `long:"regfeeamount" description:"The registration fee amount in atoms."`
@@ -313,6 +316,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		DEXPrivKeyPath:   defaultDEXPrivKeyFilename,
 		RegFeeConfirms:   defaultRegFeeConfirms,
 		RegFeeAmount:     defaultRegFeeAmount,
+		BondIncrement:    defaultBondIncrement,
 		BroadcastTimeout: defaultBroadcastTimeout,
 		CancelThreshold:  defaultCancelThresh,
 		MaxUserCancels:   defaultMaxUserCancels,
@@ -577,6 +581,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 	dexCfg := &dexConf{
 		DataDir:           cfg.DataDir,
 		Network:           network,
+		BondIncrement:     cfg.BondIncrement,
 		DBName:            cfg.PGDBName,
 		DBHost:            dbHost,
 		DBPort:            dbPort,

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -117,11 +117,12 @@ func mainCore(ctx context.Context) error {
 
 	// Create the DEX manager.
 	dexConf := &dexsrv.DexConf{
-		DataDir:    cfg.DataDir,
-		LogBackend: cfg.LogMaker,
-		Markets:    markets,
-		Assets:     assets,
-		Network:    cfg.Network,
+		DataDir:       cfg.DataDir,
+		LogBackend:    cfg.LogMaker,
+		Markets:       markets,
+		Assets:        assets,
+		Network:       cfg.Network,
+		BondIncrement: cfg.BondIncrement,
 		DBConf: &dexsrv.DBConf{
 			DBName:       cfg.DBName,
 			Host:         cfg.DBHost,

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -553,27 +553,6 @@ func (a *Archiver) storeOrder(ord order.Order, epochIdx, epochDur int64, status 
 		}
 	}
 
-	// If enabled, search all tables for the order to ensure it is not already
-	// stored somewhere.
-	// if a.checkedStores {
-	// 	var foundStatus pgOrderStatus
-	// 	switch ord.Type() {
-	// 	case order.MarketOrderType, order.LimitOrderType:
-	// 		foundStatus, _, _, err = orderStatus(a.db, ord.ID(), a.dbName, marketSchema)
-	// 	case order.CancelOrderType:
-	// 		foundStatus, err = cancelOrderStatus(a.db, ord.ID(), a.dbName, marketSchema)
-	// 	}
-	//
-	// 	if err == nil {
-	// 		return fmt.Errorf("attempted to store a %s order while it exists "+
-	// 			"in another table as %s", pgToMarketStatus(status), pgToMarketStatus(foundStatus))
-	// 	}
-	// 	if !db.IsErrOrderUnknown(err) {
-	// 		a.fatalBackendErr(err)
-	// 		return fmt.Errorf("findOrder failed: %v", err)
-	// 	}
-	// }
-
 	// Check for order commitment duplicates. This also covers order ID since
 	// commitment is part of order serialization. Note that it checks ALL
 	// markets, so this may be excessive. This check may be more appropriate in

--- a/server/db/driver/pg/system.go
+++ b/server/db/driver/pg/system.go
@@ -57,6 +57,7 @@ type sqlExecutor interface {
 
 type sqlQueryer interface {
 	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryRow(query string, args ...interface{}) *sql.Row
 }
 
 // sqlExec executes the SQL statement string with any optional arguments, and
@@ -146,6 +147,16 @@ func schemaExists(db sqlQueryer, tableName string) (bool, error) {
 type sqlQueryExecutor interface {
 	sqlQueryer
 	sqlExecutor
+}
+
+func createIndexStmt(db sqlQueryExecutor, fmtStmt, indexName, fullTableName string) error {
+	stmt := fmt.Sprintf(fmtStmt, indexName, fullTableName)
+	log.Debugf("Creating index %q on the %q table.", indexName, fullTableName)
+	_, err := db.Exec(stmt)
+	if errors.Is(err, sql.ErrNoRows) {
+		err = nil
+	}
+	return err
 }
 
 // createTableStmt creates a table with the given name using the provided SQL

--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -69,9 +69,8 @@ func openDB() (func() error, error) {
 		ShowPGConfig: false,
 		QueryTimeout: 0, // zero to use the default
 		MarketCfg:    []*dex.MarketInfo{mktInfo, mktInfo2},
-		//CheckedStores: true,
-		Net:    dex.Mainnet,
-		FeeKey: "dprv3hCznBesA6jBu1MaSqEBewG76yGtnG6LWMtEXHQvh3MVo6rqesTk7FPMSrczDtEELReV4aGMcrDxc9htac5mBDUEbTi9rgCA8Ss5FkasKM3",
+		Net:          dex.Mainnet,
+		FeeKey:       "dprv3hCznBesA6jBu1MaSqEBewG76yGtnG6LWMtEXHQvh3MVo6rqesTk7FPMSrczDtEELReV4aGMcrDxc9htac5mBDUEbTi9rgCA8Ss5FkasKM3",
 	}
 
 	numMarkets = len(dbi.MarketCfg)
@@ -180,7 +179,7 @@ func cleanTables(db *sql.DB) error {
 		return err
 	}
 
-	return archie.CreateKeyEntry(archie.keyHash)
+	return archie.createKeyEntry(archie.keyHash)
 }
 
 func Test_sqlExec(t *testing.T) {

--- a/server/db/driver/pg/tables.go
+++ b/server/db/driver/pg/tables.go
@@ -18,6 +18,10 @@ const (
 	metaTableName     = "meta"
 	feeKeysTableName  = "fee_keys"
 	accountsTableName = "accounts"
+	bondsTableName    = "bonds"
+
+	indexBondsOnAccountName  = "idx_bonds_on_acct"
+	indexBondsOnLockTimeName = "idx_bonds_on_locktime"
 
 	// market schema tables
 	matchesTableName         = "matches"
@@ -42,6 +46,17 @@ var createDEXTableStatements = []tableStmt{
 var createAccountTableStatements = []tableStmt{
 	{feeKeysTableName, internal.CreateFeeKeysTable},
 	{accountsTableName, internal.CreateAccountsTable},
+	{bondsTableName, internal.CreateBondsTable},
+}
+
+type indexStmt struct {
+	idxName string
+	stmt    string
+}
+
+var createBondIndexesStatements = []indexStmt{
+	{indexBondsOnAccountName, internal.CreateBondsAcctIndex},
+	{indexBondsOnLockTimeName, internal.CreateBondsLockTimeIndex},
 }
 
 var createMarketTableStatements = []tableStmt{

--- a/server/db/types.go
+++ b/server/db/types.go
@@ -12,7 +12,6 @@ import (
 type Account struct {
 	AccountID  account.AccountID `json:"accountid"`
 	Pubkey     dex.Bytes         `json:"pubkey"`
-	FeeAddress string            `json:"feeaddress"`
-	FeeCoin    dex.Bytes         `json:"feecoin"`
-	BrokenRule account.Rule      `json:"brokenrule"`
+	FeeAddress string            `json:"feeaddress"` // DEPRECATED
+	FeeCoin    dex.Bytes         `json:"feecoin"`    // DEPRECATED
 }

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1411,8 +1411,8 @@ func (m *Market) processOrder(rec *orderRecord, epoch *EpochQueue, notifyChan ch
 	// Disallow trade orders from suspended accounts. Cancel orders are allowed.
 	if rec.order.Type() != order.CancelOrderType {
 		// Do not bother the auth manager for cancel orders.
-		if _, suspended := m.auth.Suspended(rec.order.User()); suspended {
-			log.Debugf("Account %v not allowed to submit order %v", rec.order.User(), rec.order.ID())
+		if _, tier := m.auth.AcctStatus(rec.order.User()); tier < 1 {
+			log.Debugf("Account %v with tier %d not allowed to submit order %v", rec.order.User(), tier, rec.order.ID())
 			errChan <- ErrSuspendedAccount
 			return nil
 		}

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -29,7 +29,7 @@ import (
 type AuthManager interface {
 	Route(route string, handler func(account.AccountID, *msgjson.Message) *msgjson.Error)
 	Auth(user account.AccountID, msg, sig []byte) error
-	Suspended(user account.AccountID) (found, suspended bool)
+	AcctStatus(user account.AccountID) (connected bool, tier int64)
 	Sign(...msgjson.Signable)
 	Send(account.AccountID, *msgjson.Message) error
 	Request(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message)) error
@@ -212,8 +212,8 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 		return rpcErr
 	}
 
-	if _, suspended := r.auth.Suspended(user); suspended {
-		return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account %v may not submit trade orders", user)
+	if _, tier := r.auth.AcctStatus(user); tier < 1 {
+		return msgjson.NewError(msgjson.AccountClosedError, "account %v with tier %d may not submit trade orders", user, tier)
 	}
 
 	tunnel, coins, sell, rpcErr := r.extractMarketDetails(&limit.Prefix, &limit.Trade)
@@ -229,7 +229,8 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 
 	// Check that OrderType is set correctly
 	if limit.OrderType != msgjson.LimitOrderNum {
-		return msgjson.NewError(msgjson.OrderParameterError, "wrong order type set for limit order. wanted %d, got %d", msgjson.LimitOrderNum, limit.OrderType)
+		return msgjson.NewError(msgjson.OrderParameterError, "wrong order type set for limit order. wanted %d, got %d",
+			msgjson.LimitOrderNum, limit.OrderType)
 	}
 
 	// Check that the rate is non-zero and obeys the rate step interval.
@@ -436,8 +437,8 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 		return rpcErr
 	}
 
-	if _, suspended := r.auth.Suspended(user); suspended {
-		return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account %v may not submit trade orders", user)
+	if _, tier := r.auth.AcctStatus(user); tier < 1 {
+		return msgjson.NewError(msgjson.AccountClosedError, "account %v with tier %d may not submit trade orders", user, tier)
 	}
 
 	tunnel, assets, sell, rpcErr := r.extractMarketDetails(&market.Prefix, &market.Trade)


### PR DESCRIPTION
### Summary

**Status**: Working. Tests need fixing.  Some frontend issues to address.

See [TODOs](#todos).

Replaces PR https://github.com/decred/dcrdex/pull/1017, tossing out 2,306 loc for a better solution.

This PR replaces the registration fee, which was paid to an address provided by the server operator, with a **time-locked fidelity bond, which is redeemable by the user who posted the bond after a certain time**. This creates a time cost to use DCRDEX instead of a monetary cost.

The DEX considers a user's bond as active when the bond script's `lockTime` (when it can be redeemed by the user) is at least `bondExpiry` in the future. That is, the bond remains locked for a period even after it becomes inactive for DEX purposes.

This also introduces an **account tier system**. Previously, paying the registration fee would mark the account paid, and it could be closed permanently if the user's violations exceed a certain score (binary and permanent). Now, posting a bond increases a user's tier, which offsets violations and in future work will also scale user order limits. When a bond expires, their tier is reduced. To trade, a user must have a tier > 0.

### Bond Transaction Structure

There must be at least two outputs: the bond output (P2SH) and an account commitment (nulldata).

See:
- [`dex/networks/dcr.ExtractBondDetails`](https://github.com/decred/dcrdex/blob/6358bea6e101f356a7c4fd38f88639b6a7a743f3/dex/networks/dcr/script.go#L439)
- [`client/asset/dcr.(*ExchangeWallet).{MakeBondTx,RefundBond}`](https://github.com/decred/dcrdex/blob/6358bea6e101f356a7c4fd38f88639b6a7a743f3/client/asset/dcr/dcr.go#L2212)
- [`server/assset/dcr.ParseBondTx`](https://github.com/decred/dcrdex/blob/6358bea6e101f356a7c4fd38f88639b6a7a743f3/server/asset/dcr/dcr.go#L101)

#### Time-locked Bond (output 0)

Output 0 of the fidelity bond transaction must be a P2SH output paying to the bond script.

The redeem script looks similar to the refund path of an atomic swap script:

`<locktime[4]> OP_CHECKLOCKTIMEVERIFY OP_DROP <pubkey[33]> OP_CHECKSIG`

The above uses P2PK, and we can do P2PKH instead, but since part of validation requires the pubkey we probably don't gain anything from this:

`<locktime[4]> OP_CHECKLOCKTIMEVERIFY OP_DROP OP_DUP OP_HASH160 <pubkeyhash[20]> OP_EQUALVERIFY OP_CHECKSIG`

I've tested both formats, and I will probably switch to the non-hashed version because validation becomes even more asset-specific given hash160 is not a standard (e.g. ripemd160 of either sha256 for Bitcoin or blake256 for Decred).

Server validates that this P2SH output actually pays to the provided redeem script.

The pubkey referenced by the script need not be controlled by the user's wallet, but in this implementation it comes from their wallet. The client could even use their account pubkey in the script, but for security reasons it is best not to reuse pubkeys in this bond outputs, which are unspent on the blockchain for long periods.

The `lockTime` must be after a bond expiry time, the `lockTimeThreshold`. A bond becomes expired for a DEX account when duration until `lockTime` is less than a `bondExpiry` duration, which is on the order of a month. This, a user should create a bond with a `lockTime` at least `bondExpiry` in the future, but a practical `lockTime` would be more like 2x `bondExpiry` in the future so the account is active on the DEX for `bondExpiry`.

User must demonstrate ownership of the locked funds: sign something with private key corresponding to the pubkey in the TL redeemscript.

#### DEX Account commitment (output 1)

The account commitment OP_RETURN output should reference the account ID that corresponds to the account pubkey in the `postbond` request.

Having it in the raw like this allows the txn alone to identify the account, and without requiring the bond output pay to the account's private keys.

### Protocol

New `postbond` route replaces `register`, but with no fee address and instead a txn with time-locked output (P2SH) and a DEX account commitment output (OP_RETURN).

`postbond` need not be used only for new accounts. Existing accounts may top-up / supplement their bond.

The `config` response should be consulted for bond requirements, including: expiry time, supported bond assets, amounts, and required confirmations.

The user may submit an initial `postbond` **prior to broadcasting the bond transaction** request containing the raw unsigned transaction for validation. The bond script to which the P2SH bond output pays must also be provided in the `postbond` request for validation by the DEX (correct script structure and lock time).  The payload:

```go
// PostBond should include the unsigned bond transaction for validation prior to
// broadcasting the signed transaction so the client hasn't needlessly locked
// funds if the transaction is rejected.
type PostBond struct {
	Signature
	AcctPubKey Bytes  `json:"acctPubKey"` // acctID = blake256(blake256(acctPubKey))
	AssetID    uint32 `json:"assetID"`
	BondTx     Bytes  `json:"bondTx"`
	BondScript Bytes  `json:"bondScript"`
	BondSig    Bytes  `json:"bondSig"` // account id signed by key from bond script's pubkey

	// LegacyFeeRefundAddr is an optional field for the client to specify a
	// return address so they may *request* a refund of their legacy
	// registration fee, if they had paid it.
	LegacyFeeRefundAddr string `json:"legacyFeeRefundAddress,omitempty"`
}
```

Server must use provided account pubkey to verify signed `postbond` request, otherwise the user could be spamming or putting up a bond for a bogus account or someone else's account.

Further validation is described in subsequent sections of this PR description.

The response payload:

```go
// PostBondResult is the response to the client's PostBond request. If Confs is
// -1, the bond tx was not found on the network, but was otherwise validated.
type PostBondResult struct {
	Signature        // message is BondID | AccountID
	AccountID Bytes  `json:"accountid"`
	AssetID   uint32 `json:"assetID"`
	Amt       uint64 `json:"amt"`
	Expiry    int64  `json:"expiry"` // not locktime, but time when bond expires for dex
	BondID    Bytes  `json:"bondID"`
	Confs     int64  `json:"confs"`
	Tier      int64  `json:"tier"`
}
```

After validation of the provided data, the DEX attempts to locate the bond transaction on the asset network:

  - If it is not found, a `PostBondResult` is sent immediately with `Confs=-1` set.  The bond is NOT stored in the DB. This was a courtesy pre-validation. The user should then broadcast the transaction, wait for the required number of confirmations, and send `postbond` again.
  - If the located transaction has the required number of confirmations, the bond is stored in the DB as active, and a response is sent.
  - Otherwise, a response is sent with the observed confirmation count, and a coin waiter is started to watch for the txn to reach the required number of confirmations. The bond is stored in DB as pending. When the transaction reaches the required confirmations, it is flagged active in the DB and a `bondconfirmed` notification is sent.

When the client receives the initial successful response prior to broadcast, they should then broadcast the bond txn, wait for the required confirmations, and resubmit `postbond`.

Server must record all known bond txns and their amounts and expiry times. There is no explicit invalidation of bonds due to conduct, and instead a user's tier is a balance between bond "strength" (a function of the active bond total amounts) and their conduct score.

### TODOs

Auto add bond in `client.Core`.  There are comments in the code regarding an option to automatically postbond when previous bonds are about to expire on DEX.  There are questions pertaining to timing, UI, and UX.  Presently this PR requires using dexcctl to call the `addbond` RPC (or a direct http API call to the endpoint of the same name, which is created for said UI plans).

Bond amount.  It's pretty clear the bond amount has to be at least an order of magnitude more than the previous registration fee since you get it back, and it's only an opportunity cost having it locked up.  I'm thinking like 5 DCR per tier (the bond increment).

Related to bond amount, the violation weights can use rebalancing.  Specifically, increase weight for "no swap as taker" (currently 11, increase to 18 or 20) and "no redeem as maker" (currently 7, increase to 12 to 14), the violations that lock counterparty funds (20hr / 8 hr, respectively).  Maybe even higher.

Make the tier system scale up order size limits. This was planned outside of fidelity bond work, in terms of conduct score, but it's more intuitive in terms of tier, which is a function of both account bond level and score.

Scale penalty (score change) with amount locked due to violation (e.g. lots/10 * violation score).  This was planned regardless of fidelity bonds, but it dovetails nicely with the tier system.

### Open Questions

What problems would be solved and/or create by using `OP_CHECKSEQUENCEVERIFY` (relative time lock) instead of `OP_CHECKLOCKTIMEVERIFY`?

When and if accounts go away, would output 1 commit to a magic DEX network key instead of account ID?

Is this transaction structure and account commitment output sufficient to prevent txns from being dual purposed for other services with similar TL output structure?

