### PR TITLE
client/asset/dcr: shutdown ws client on Connect error

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -588,6 +588,18 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 		return nil, fmt.Errorf("Decred Wallet connect error: %w", err)
 	}
 
+	// The websocket client is connected now, so if any of the following checks
+	// fails and we return with a non-nil error, we must shutdown the rpc client
+	// or subsequent reconnect attempts will be met with "websocket client has
+	// already connected".
+	var success bool
+	defer func() {
+		if !success {
+			dcr.client.Shutdown()
+			dcr.client.WaitForShutdown()
+		}
+	}()
+
 	// Check the required API versions.
 	versions, err := dcr.client.Version(ctx)
 	if err != nil {
@@ -629,6 +641,7 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 
 	dcr.log.Infof("Connected to dcrwallet (JSON-RPC API v%s) proxying dcrd (JSON-RPC API v%s) on %v",
 		walletSemver, nodeSemver, curnet)
+	success = true
 
 	var wg sync.WaitGroup
 	wg.Add(1)


### PR DESCRIPTION
This makes dcr's `(*ExchangeWallet).Connect` shutdown the websocket RPC client if there are errors from any of the checks after establishing the connection that cause `Connect` to return a non-nil error.

e.g. the automatic wallet connection on login might error because of RPC version:

`[ERR] CORE: Unable to connect to dcr wallet (start and sync wallets BEFORE starting dex!): dcrd has an incompatible JSON-RPC version: got 6.2.0, expected 7.0.0`

Then the markets or wallets page will be unable to attempt a new connection because it is still connected:

`[ERR] WEB: balance error: 42 -> dcr wallet error: Decred Wallet connect error: websocket client has already connected`

