### PR TITLE
client/core: fix bookie.OrderBook race

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -56,7 +56,7 @@ func (f *BookFeed) Close() {
 // subscribe before the timer expires, then the bookie will invoke it's caller
 // supplied close() callback.
 type bookie struct {
-	orderbook.OrderBook
+	*orderbook.OrderBook
 	log         dex.Logger
 	mtx         sync.Mutex
 	feeds       map[uint32]*BookFeed
@@ -70,7 +70,7 @@ type bookie struct {
 // expired.
 func newBookie(base, quote uint32, logger dex.Logger, close func()) *bookie {
 	return &bookie{
-		OrderBook: *orderbook.NewOrderBook(logger.SubLogger("book")),
+		OrderBook: orderbook.NewOrderBook(logger.SubLogger("book")),
 		log:       logger,
 		feeds:     make(map[uint32]*BookFeed, 1),
 		close:     close,
@@ -84,7 +84,7 @@ func newBookie(base, quote uint32, logger dex.Logger, close func()) *bookie {
 func (b *bookie) reset(snapshot *msgjson.OrderBook) error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
-	b.OrderBook = *orderbook.NewOrderBook(b.log)
+	b.OrderBook = orderbook.NewOrderBook(b.log)
 	return b.OrderBook.Sync(snapshot)
 }
 
@@ -361,7 +361,7 @@ func (c *Core) Book(dex string, base, quote uint32) (*OrderBook, error) {
 			return nil, fmt.Errorf("unable to sync book: %w", err)
 		}
 	} else {
-		ob = &book.OrderBook
+		ob = book.OrderBook
 	}
 
 	buys, sells, epoch := ob.Orders()


### PR DESCRIPTION
`bookie` embedded the `orderbook.OrderBook` type by value, which when assigning to it as a field like `b.OrderBook = orderbook.OrderBook{}` would overwrite each original field rather than treating `OrderBook` as a distinct object that could be replaced entirely.

This changes `bookie` so that it embeds a `*orderbook.OrderBook` (pointer), which forces assignment to `b.OrderBook` to leave the fields of the existing `OrderBook` alone.

The race is between `(*bookie).reset` writing a new `OrderBook` into the `bookie`:

https://github.com/decred/dcrdex/blob/9b012f9242bea5e82431726cd27bbd7d2372294e/client/core/bookie.go#L84-L87

and `(*OrderBook).LogEpochReport`  writing to the `feeRates` fields:

https://github.com/decred/dcrdex/blob/9b012f9242bea5e82431726cd27bbd7d2372294e/client/orderbook/orderbook.go#L389-L392

It's not obvious, but copying by value like `b.OrderBook = *orderbook.NewOrderBook(b.log)` modifies all of the existing fields rather than storing a new `OrderBook`.  https://play.golang.org/p/sfrhEDccJsg

```
==================
WARNING: DATA RACE
Write at 0x00c0001d2280 by goroutine 134:
  decred.org/dcrdex/client/core.(*bookie).reset()
      /home/jon/github/decred/dcrdex/client/core/bookie.go:87 +0x537
  decred.org/dcrdex/client/core.(*Core).handleReconnect.func1()
      /home/jon/github/decred/dcrdex/client/core/core.go:4583 +0x306
  decred.org/dcrdex/client/core.(*Core).handleReconnect()
      /home/jon/github/decred/dcrdex/client/core/core.go:4615 +0x679

Previous write at 0x00c0001d2280 by goroutine 53:
  sync/atomic.StoreInt64()
      /home/jon/go116/src/runtime/race_amd64.s:248 +0xb
  decred.org/dcrdex/client/orderbook.(*OrderBook).LogEpochReport()
      /home/jon/github/decred/dcrdex/client/orderbook/orderbook.go:391 +0x6c
  decred.org/dcrdex/client/core.handleEpochReportMsg()
      /home/jon/github/decred/dcrdex/client/core/bookie.go:731 +0x1e5
  decred.org/dcrdex/client/core.(*Core).listen.func1()
      /home/jon/github/decred/dcrdex/client/core/core.go:4832 +0x163
  decred.org/dcrdex/client/core.(*Core).listen.func2()
      /home/jon/github/decred/dcrdex/client/core/core.go:4846 +0x92

Goroutine 134 (running) created at:
  decred.org/dcrdex/client/core.(*Core).connectDEX.func1()
      /home/jon/github/decred/dcrdex/client/core/core.go:4481 +0x67
  decred.org/dcrdex/client/comms.(*wsConn).keepAlive()
      /home/jon/github/decred/dcrdex/client/comms/wsconn.go:388 +0x6bd
  decred.org/dcrdex/client/comms.(*wsConn).Connect.func1()
      /home/jon/github/decred/dcrdex/client/comms/wsconn.go:412 +0x90

Goroutine 53 (running) created at:
  decred.org/dcrdex/client/core.(*Core).listen()
      /home/jon/github/decred/dcrdex/client/core/core.go:4843 +0x344
==================
```
And a second race with line 392 (`ob.feeRates.quote`)