### PR TITLE
Fix maxOrder when not enough balance

### DIFF
--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -173,9 +173,6 @@
                           <span id="maxToAmt"></span>
                           <span id="maxToTicker"></span>
                         </span>
-                        <span id="maxNotEnough" class="d-hide warn">
-                          Not enough funds for a single lot at this rate
-                        </span>
                       </div>
                     </div>
 

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -173,6 +173,9 @@
                           <span id="maxToAmt"></span>
                           <span id="maxToTicker"></span>
                         </span>
+                        <span id="maxNotEnough" class="d-hide warn">
+                          Not enough funds for a single lot at this rate
+                        </span>
                       </div>
                     </div>
 

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -65,7 +65,7 @@ export default class MarketsPage extends BasePage {
       'hoverVolume', 'chartLegend', 'chartErrMsg',
       // Max order section
       'maxOrd', 'maxLbl', 'maxFromLots', 'maxFromAmt', 'maxFromTicker',
-      'maxToAmt', 'maxToTicker', 'maxAboveZero', 'maxNotEnough', 'maxLotBox', 'maxFromLotsLbl',
+      'maxToAmt', 'maxToTicker', 'maxAboveZero', 'maxLotBox', 'maxFromLotsLbl',
       'maxBox'
     ])
     this.main = main
@@ -742,7 +742,6 @@ export default class MarketsPage extends BasePage {
 
     Doc.show(page.maxOrd, page.maxLotBox)
     Doc.hide(page.maxAboveZero)
-    Doc.hide(page.maxNotEnough)
     page.maxFromLots.textContent = 'calculating...'
     page.maxFromLotsLbl.textContent = ''
     this.preorderTimer = window.setTimeout(async () => {
@@ -776,8 +775,6 @@ export default class MarketsPage extends BasePage {
     page.maxFromLots.textContent = maxOrder.lots.toString()
     page.maxFromLotsLbl.textContent = maxOrder.lots === 1 ? 'lot' : 'lots'
     if (maxOrder.lots === 0) {
-      // show not enough funds for purchasing.
-      Doc.show(page.maxNotEnough)
       Doc.hide(page.maxAboveZero)
       return
     }

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -675,8 +675,8 @@ export default class MarketsPage extends BasePage {
     const quoteAsset = app.assets[order.quote]
     const total = Doc.formatCoinValue(order.rate / 1e8 * order.qty / 1e8)
     page.orderPreview.textContent = `Total: ${total} ${quoteAsset.symbol.toUpperCase()}`
-    const isSell = this.isSell()
-    isSell ? this.preSell() : this.preBuy()
+    if (this.isSell()) this.preSell()
+    else this.preBuy()
   }
 
   /**


### PR DESCRIPTION
This PR closes #1097.

It also adds a `Not enough funds` message when not having balance for the purchase.

![image](https://user-images.githubusercontent.com/15069783/125510791-cf66d4b7-937a-4d0f-977f-76032812c7f9.png)
