### PR TITLE
[0.2.1] client/core: fix bookie.OrderBook race

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -56,7 +56,7 @@ func (f *BookFeed) Close() {
 // subscribe before the timer expires, then the bookie will invoke it's caller
 // supplied close() callback.
 type bookie struct {
-	orderbook.OrderBook
+	*orderbook.OrderBook
 	log         dex.Logger
 	mtx         sync.Mutex
 	feeds       map[uint32]*BookFeed
@@ -70,7 +70,7 @@ type bookie struct {
 // expired.
 func newBookie(base, quote uint32, logger dex.Logger, close func()) *bookie {
 	return &bookie{
-		OrderBook: *orderbook.NewOrderBook(logger.SubLogger("book")),
+		OrderBook: orderbook.NewOrderBook(logger.SubLogger("book")),
 		log:       logger,
 		feeds:     make(map[uint32]*BookFeed, 1),
 		close:     close,
@@ -84,7 +84,7 @@ func newBookie(base, quote uint32, logger dex.Logger, close func()) *bookie {
 func (b *bookie) reset(snapshot *msgjson.OrderBook) error {
 	b.mtx.Lock()
 	defer b.mtx.Unlock()
-	b.OrderBook = *orderbook.NewOrderBook(b.log)
+	b.OrderBook = orderbook.NewOrderBook(b.log)
 	return b.OrderBook.Sync(snapshot)
 }
 
@@ -361,7 +361,7 @@ func (c *Core) Book(dex string, base, quote uint32) (*OrderBook, error) {
 			return nil, fmt.Errorf("unable to sync book: %w", err)
 		}
 	} else {
-		ob = &book.OrderBook
+		ob = book.OrderBook
 	}
 
 	buys, sells, epoch := ob.Orders()


### PR DESCRIPTION
This is a backport of https://github.com/decred/dcrdex/pull/1124 to the `release-v0.2` branch.
I had not initially planned to backport on account of the race, however the fix avoids another more problematic bug:

```
fatal error: sync: unlock of unlocked mutex

goroutine 69 [running]:
runtime.throw(0xcbf405, 0x1e)
	runtime/panic.go:1117 +0x72 fp=0xc004c13af0 sp=0xc004c13ac0 pc=0x437f72
sync.throw(0xcbf405, 0x1e)
	runtime/panic.go:1103 +0x35 fp=0xc004c13b10 sp=0xc004c13af0 pc=0x46c7f5
sync.(*Mutex).unlockSlow(0xc00057607c, 0xc0ffffffff)
	sync/mutex.go:196 +0xd8 fp=0xc004c13b38 sp=0xc004c13b10 pc=0x48a138
sync.(*Mutex).Unlock(0xc00057607c)
	sync/mutex.go:190 +0x48 fp=0xc004c13b58 sp=0xc004c13b38 pc=0x48a048
decred.org/dcrdex/client/orderbook.(*OrderBook).ValidateMatchProof.func1(0x0, 0xee6d60, 0xc0002bece0)
	decred.org/dcrdex/client/orderbook/orderbook.go:519 +0x21b fp=0xc004c13c08 sp=0xc004c13b58 pc=0x9605fb
decred.org/dcrdex/client/orderbook.(*OrderBook).ValidateMatchProof(0xc000576000, 0xc0004702a0, 0x7, 0x9b210c1, 0xc000bdd440, 0x1, 0x4, 0x1312e40, 0x0, 0x0, ...)
	decred.org/dcrdex/client/orderbook/orderbook.go:522 +0xcc fp=0xc004c13da8 sp=0xc004c13c08 pc=0x95e70c
decred.org/dcrdex/client/core.handleMatchProofMsg(0xc00035e420, 0xc000148000, 0xc00026c8c0, 0x0, 0xc000a2dec0)
	decred.org/dcrdex/client/core/core.go:4579 +0x218 fp=0xc004c13ed8 sp=0xc004c13da8 pc=0xa70fd8
...
```

This is another consequence of the assignment to the embedded-by-value `OrderBook` modifying the individual fields rather than making a new instance of `OrderBook` for `bookie`.  One of these individual fields is a mutex.

https://github.com/decred/dcrdex/blob/90612110a52cd42b8d3315c872e04cc260a57a77/client/orderbook/orderbook.go#L506-L521

Looking at the above code, it seems impossible that `ob.epochMtx.Unlock()` could be unlocking an unlocked mutex, but I think this is  happening because `ob.epochMtx` is reassigned.