### PR TITLE
[0.2.1] backports

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -757,6 +757,7 @@ func (btc *ExchangeWallet) feeRateWithFallback(confTarget, feeSuggestion uint64)
 // estimate based on current network conditions, and will be <= the fees
 // associated with nfo.MaxFeeRate. For quote assets, the caller will have to
 // calculate lotSize based on a rate conversion from the base asset's lot size.
+// lotSize must not be zero and will cause a panic if so.
 func (btc *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*asset.SwapEstimate, error) {
 	_, maxEst, err := btc.maxOrder(lotSize, feeSuggestion, nfo)
 	return maxEst, err
@@ -766,14 +767,19 @@ func (btc *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asse
 // []*compositeUTXO to be used for further order estimation without additional
 // calls to listunspent.
 func (btc *ExchangeWallet) maxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (utxos []*compositeUTXO, est *asset.SwapEstimate, err error) {
+	if lotSize == 0 {
+		return nil, nil, errors.New("cannot divide by lotSize zero")
+	}
+
 	btc.fundingMtx.RLock()
 	utxos, _, avail, err := btc.spendableUTXOs(0)
 	btc.fundingMtx.RUnlock()
 	if err != nil {
 		return nil, nil, fmt.Errorf("error parsing unspent outputs: %w", err)
 	}
-	// Start by attempting max lots with no fees.
-	lots := avail / lotSize
+	// Start by attempting max lots with a basic fee.
+	basicFee := nfo.SwapSize * nfo.MaxFeeRate
+	lots := avail / (lotSize + basicFee)
 	for lots > 0 {
 		est, _, err := btc.estimateSwap(lots, lotSize, feeSuggestion, utxos, nfo, btc.useSplitTx)
 		// The only failure mode of estimateSwap -> btc.fund is when there is

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -588,6 +588,21 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 		return nil, fmt.Errorf("Decred Wallet connect error: %w", err)
 	}
 
+	// The websocket client is connected now, so if any of the following checks
+	// fails and we return with a non-nil error, we must shutdown the rpc client
+	// or subsequent reconnect attempts will be met with "websocket client has
+	// already connected".
+	var success bool
+	defer func() {
+		if !success {
+			dcr.client.Shutdown()
+			// NOTE: WaitForShutdown hangs because of an rpcclient bug, so just
+			// Shutdown to close the websocket. rpcclient.Connect leaks a
+			// goroutine until the context is cancelled, which is acceptable.
+			// See dcrd@c9521b468f957479cd0802b1f5c250e9ecc1b947
+		}
+	}()
+
 	// Check the required API versions.
 	versions, err := dcr.client.Version(ctx)
 	if err != nil {
@@ -629,6 +644,7 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 
 	dcr.log.Infof("Connected to dcrwallet (JSON-RPC API v%s) proxying dcrd (JSON-RPC API v%s) on %v",
 		walletSemver, nodeSemver, curnet)
+	success = true
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -93,7 +93,8 @@ type Wallet interface {
 	// associated fees that the wallet can support for the specified DEX. The
 	// fees are an estimate based on current network conditions, and will be <=
 	// the fees associated with the Asset.MaxFeeRate. For quote assets, lotSize
-	// will be an estimate based on current market conditions.
+	// will be an estimate based on current market conditions. lotSize should
+	// not be zero.
 	MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*SwapEstimate, error)
 	// PreSwap gets a pre-swap estimate for the specified order size.
 	PreSwap(*PreSwapForm) (*PreSwap, error)

--- a/client/cmd/dexc/version/version.go
+++ b/client/cmd/dexc/version/version.go
@@ -25,7 +25,7 @@ const (
 	AppName  string = "dexc"
 	AppMajor uint   = 0
 	AppMinor uint   = 2
-	AppPatch uint   = 0
+	AppPatch uint   = 1
 )
 
 // go build -v -ldflags "-X decred.org/dcrdex/client/cmd/dexc/version.appPreRelease= -X decred.org/dcrdex/client/cmd/dexc/version.appBuild=$(git rev-parse --short HEAD)"

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2629,6 +2629,11 @@ func (c *Core) MaxBuy(host string, base, quote uint32, rate uint64) (*MaxOrderEs
 		return nil, err
 	}
 
+	quoteLotEst := calc.BaseToQuote(rate, baseAsset.LotSize)
+	if quoteLotEst == 0 {
+		return nil, errors.New("cannot divide by lot size zero")
+	}
+
 	dc, _, err := c.dex(host)
 	if err != nil {
 		return nil, err
@@ -2644,7 +2649,6 @@ func (c *Core) MaxBuy(host string, base, quote uint32, rate uint64) (*MaxOrderEs
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(base), host)
 	}
 
-	quoteLotEst := calc.BaseToQuote(rate, baseAsset.LotSize)
 	maxBuy, err := quoteWallet.MaxOrder(quoteLotEst, swapFeeSuggestion, quoteAsset)
 	if err != nil {
 		return nil, fmt.Errorf("%s wallet MaxOrder error: %v", unbip(quote), err)
@@ -2671,6 +2675,10 @@ func (c *Core) MaxSell(host string, base, quote uint32) (*MaxOrderEstimate, erro
 	baseAsset, _, baseWallet, quoteWallet, err := c.marketWallets(host, base, quote)
 	if err != nil {
 		return nil, err
+	}
+
+	if baseAsset.LotSize == 0 {
+		return nil, errors.New("cannot divide by lot size zero")
 	}
 
 	dc, _, err := c.dex(host)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1131,7 +1131,7 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 			c.log.Errorf("refreshUnlock error redeeming %s: %v", t.wallets.toAsset.Symbol, err)
 		}
 		if didUnlock {
-			c.log.Infof("Unexpected unlock needed for the %s wallet while sending a redemption", t.wallets.fromAsset.Symbol)
+			c.log.Infof("Unexpected unlock needed for the %s wallet while sending a redemption", t.wallets.toAsset.Symbol)
 		}
 		toAsset := t.wallets.toAsset.ID
 		assets.count(toAsset)

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -650,20 +650,21 @@ export default class MarketsPage extends BasePage {
   previewQuoteAmt (show) {
     const page = this.page
     const order = this.parseOrder()
+    const adjusted = this.adjustedRate()
     page.orderErr.textContent = ''
-    if (order.rate) {
+    if (adjusted) {
       if (order.sell) this.preSell()
       else this.preBuy()
     }
     this.depthLines.input = []
-    if (order.rate && this.isLimit()) {
+    if (adjusted && this.isLimit()) {
       this.depthLines.input = [{
         rate: order.rate / 1e8,
         color: order.sell ? this.chart.theme.sellLine : this.chart.theme.buyLine
       }]
     }
     this.drawChartLines()
-    if (!show || !order.rate || !order.qty) {
+    if (!show || !adjusted || !order.qty) {
       page.orderPreview.textContent = ''
       this.drawChartLines()
       return
@@ -1409,15 +1410,15 @@ export default class MarketsPage extends BasePage {
    * input.
    */
   rateFieldChanged () {
-    const order = this.parseOrder()
-    if (order.rate <= 0) {
+    // Truncate to rate step. If it is a market buy order, do not adjust.
+    const adjusted = this.adjustedRate()
+    if (adjusted <= 0) {
       this.depthLines.input = []
       this.drawChartLines()
       this.page.rateField.value = 0
       return
     }
-    // Truncate to rate step. If it is a market buy order, do not adjust.
-    const adjusted = this.adjustedRate()
+    const order = this.parseOrder()
     const v = (adjusted / 1e8)
     this.page.rateField.value = v
     this.depthLines.input = [{

--- a/server/cmd/dcrdex/version.go
+++ b/server/cmd/dcrdex/version.go
@@ -25,7 +25,7 @@ const (
 	AppName  string = "dcrdex"
 	AppMajor uint   = 0
 	AppMinor uint   = 2
-	AppPatch uint   = 0
+	AppPatch uint   = 1
 )
 
 // go build -v -ldflags "-X main.appPreRelease= -X main.appBuild=$(git rev-parse --short HEAD)"


### PR DESCRIPTION
This bumps the app versions to 0.2.1 and backports the following:

- client/asset/trade: incorrect asset symbol logged
- client/asset/dcr: shutdown ws client on Connect error
- max order size computations could easily cause hang while iterating on max lots given no initial fees and large number of lots

The `OrderBook` race fix is more nuanced so that is separate: https://github.com/decred/dcrdex/pull/1131