### PR TITLE
server: Allow cancel orders while market is suspended.

### DIFF
--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -752,6 +752,16 @@ func ValidateOrder(ord Order, status OrderStatus, lotSize uint64) error {
 	return nil
 }
 
+// ExtractAddress extracts the address from the order. If the order is a cancel
+// order, an empty string is returned.
+func ExtractAddress(ord Order) string {
+	trade := ord.Trade()
+	if trade == nil {
+		return ""
+	}
+	return trade.Address
+}
+
 // Some commonly used time transformations.
 var unixMilli = encode.UnixMilli
 var unixMilliU = encode.UnixMilliU

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -206,7 +206,6 @@ func (a *Archiver) NewArchivedCancel(ord *order.CancelOrder, epochID, epochDur i
 	if N != 1 {
 		err = fmt.Errorf("failed to store order %v: %d rows affected, expected 1",
 			ord.UID(), N)
-		a.fatalBackendErr(err)
 		return err
 	}
 

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -172,6 +172,11 @@ type OrderArchiver interface {
 	// should not return the cancel orders created this way.
 	RevokeOrderUncounted(order.Order) (cancelID order.OrderID, t time.Time, err error)
 
+	// NewArchivedCancel stores a cancel order directly in the executed state. This
+	// is used for orders that are canceled when the market is suspended, and therefore
+	// do not need to be matched.
+	NewArchivedCancel(ord *order.CancelOrder, epochID, epochDur int64) error
+
 	// FailCancelOrder puts an unmatched cancel order into the executed state.
 	// For matched cancel orders, use ExecuteOrder.
 	FailCancelOrder(*order.CancelOrder) error

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -681,7 +681,6 @@ func (m *Market) processCancelOrderWhileSuspended(rec *orderRecord, errChan chan
 	}
 
 	errChan <- sendResponseErr
-	return
 }
 
 // SubmitOrderAsync submits a new order for inclusion into the current epoch.

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -673,11 +673,6 @@ func (r *OrderRouter) handleCancel(user account.AccountID, msg *msgjson.Message)
 		return rpcErr
 	}
 
-	if !tunnel.Running() {
-		mktName, _ := dex.MarketName(cancel.Base, cancel.Quote)
-		return msgjson.NewError(msgjson.MarketNotRunningError, "market closed to new orders: %s", mktName)
-	}
-
 	if len(cancel.TargetID) != order.OrderIDSize {
 		return msgjson.NewError(msgjson.OrderParameterError, "invalid target ID format")
 	}

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -127,6 +127,7 @@ type TAuth struct {
 	preimagesByMsgID   map[uint64]order.Preimage
 	preimagesByOrdID   map[string]order.Preimage
 	handlePreimageDone chan struct{}
+	handleMatchDone    chan *msgjson.Message
 	suspensions        map[account.AccountID]bool
 	canceledOrder      order.OrderID
 	cancelOrder        order.OrderID
@@ -227,6 +228,10 @@ func (a *TAuth) RequestWithTimeout(user account.AccountID, msg *msgjson.Message,
 				a.handlePreimageDone <- struct{}{}
 			}
 		}()
+	} else if msg.Route == msgjson.MatchRoute {
+		if a.handleMatchDone != nil {
+			a.handleMatchDone <- msg
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds the ability for clients to submit cancel orders while a market is suspended.

The database entries after a cancel order during a market suspension will be identical to one that gets matched while the market is running, except the preimage will not be recorded. Also there will be no entry in the epochs table for the epoch in which this order was "matched". 

Closes #792 