### PR TITLE
[0.2.1] btc: with dcrd's rpcclient, errors are dcrjson.RPCError

### DIFF
--- a/client/asset/btc/walletclient.go
+++ b/client/asset/btc/walletclient.go
@@ -45,8 +45,9 @@ const (
 	methodGetRawTransaction  = "getrawtransaction"
 )
 
-// RawRequester defines dcred's rpcclient RawRequest func where all RPC
-// requests sent through. For testing, it can be satisfied by a stub.
+// RawRequester is for sending context-aware RPC requests, and has methods for
+// shutting down the underlying connection.  For testing, it can be satisfied
+// by a stub. The returned error should be of type dcrjson.RPCError if non-nil.
 type RawRequester interface {
 	RawRequest(context.Context, string, []json.RawMessage) (json.RawMessage, error)
 }

--- a/dex/testing/btc/base-harness.sh
+++ b/dex/testing/btc/base-harness.sh
@@ -79,7 +79,7 @@ tmux send-keys -t $SESSION:0 "set +o history" C-m
 tmux send-keys -t $SESSION:0 "cd ${ALPHA_DIR}" C-m
 echo "Starting simnet alpha node"
 tmux send-keys -t $SESSION:0 "${DAEMON} -rpcuser=user -rpcpassword=pass \
-  -rpcport=${ALPHA_RPC_PORT} -datadir=${ALPHA_DIR} \
+  -rpcport=${ALPHA_RPC_PORT} -debug=rpc -datadir=${ALPHA_DIR} \
   -whitelist=127.0.0.0/8 -whitelist=::1 \
   -txindex=1 -regtest=1 -port=${ALPHA_LISTEN_PORT} -fallbackfee=0.00001 \
   ${EXTRA_ARGS}; tmux wait-for -S alpha${SYMBOL}" C-m
@@ -95,7 +95,7 @@ tmux send-keys -t $SESSION:1 "cd ${BETA_DIR}" C-m
 
 echo "Starting simnet beta node"
 tmux send-keys -t $SESSION:1 "${DAEMON} -rpcuser=user -rpcpassword=pass \
-  -rpcport=${BETA_RPC_PORT} -datadir=${BETA_DIR} -txindex=1 -regtest=1 \
+  -rpcport=${BETA_RPC_PORT} -debug=rpc -datadir=${BETA_DIR} -txindex=1 -regtest=1 \
   -whitelist=127.0.0.0/8 -whitelist=::1 \
   -port=${BETA_LISTEN_PORT} -fallbackfee=0.00001 ${EXTRA_ARGS}; \
   tmux wait-for -S beta${SYMBOL}" C-m


### PR DESCRIPTION
This is a backport of the *client* portion of https://github.com/decred/dcrdex/pull/1128 for `release-v0.2`

With the client btc asset backend using dcrd's rpcclient,
the error type from all methods including `RawRequest` would be
`dcrjson.RPCError` not `btcjson.RPCError`.

The numeric codes will still pertain the `btcjson` constants, even though
the `dcrjson.RPCError.Code` field is of type `dcrjson.RPCErrorCode`.

Thus, error matching first interprets the error as a `dcrjson.RPCError`,
and then compares the int representation of `Code` to the expected
int code form `btcjson`.