### PR TITLE
market: Fix preimage log.

### DIFF
--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1570,9 +1570,10 @@ func (m *Market) handlePreimageResp(msg *msgjson.Message, reqData *piData) {
 	piCommit := pi.Commit()
 	if reqData.ord.Commitment() != piCommit {
 		sendPI(nil)
+		oc := reqData.ord.Commitment()
 		m.respondError(msg.ID, reqData.ord.User(), msgjson.PreimageCommitmentMismatch,
 			fmt.Sprintf("preimage hash %x does not match order commitment %x",
-				piCommit, reqData.ord.Commitment()))
+				piCommit[:], oc[:]))
 		return
 	}
 


### PR DESCRIPTION
From:
`MKT: sending error to user cbd16ee56d4e7ccdbd484dea290251f1e423474d1ec8d21d8edfcd0a7db4bd1d, code: 45, msg: preimage hash 30356636616334376163636433333864333239636331366636643539663334303963633862666537366132373265316565633631326534396331313531343564 does not match order commitment 36613631393132326636356434656264326465313633656163366134663761303331626565613434626162646165353863666330386361386330626166663934`

To:
`MKT: sending error to user 41ac6276df3a138f71d61aaf81536ef5c54f085f5ce91853d6b74e76e3ac4d6a, code: 45, msg: preimage hash 05f6ac47accd338d329cc16f6d59f3409cc8bfe76a272e1eec612e49c115145d does not match order commitment 0146d824953597ae8c0f2dadb0a4520e2840c8f3eff6581be3f4e6d2a4422b5f`

The client also shows `2021-08-03 18:36:45.001 [ERR] CORE[wss://127.0.0.1:17273/ws]: No handler found for response: {"type":2,"id":15,"paylo...`

Was there an issue about that?