### PR TITLE
rpc: Add appseed endpoint.

### DIFF
--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -26,7 +26,11 @@ const (
 	listCmdMessage  = "Specify -l to list available commands"
 )
 
-var version = semver{major: 0, minor: 3, patch: 0}
+// version is the dexcctl version and should correspond to the rpcclient's
+// version. rpcclients with a higher minor are newer with newer features while
+// a higher major indicates breaking changes and dexcctl should be updated
+// before attempting to communicate.
+var version = semver{major: 0, minor: 4, patch: 0}
 
 // semver holds dexcctl's semver values.
 type semver struct {
@@ -60,6 +64,7 @@ var promptPasswords = map[string][]string{
 	"register":   {"App password:"},
 	"trade":      {"App password:"},
 	"withdraw":   {"App password:"},
+	"appseed":    {"App password:"},
 }
 
 // optionalTextFiles is a map of routes to arg index for routes that should read

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -26,11 +26,8 @@ const (
 	listCmdMessage  = "Specify -l to list available commands"
 )
 
-// version is the dexcctl version and should correspond to the rpcclient's
-// version. rpcclients with a higher minor are newer with newer features while
-// a higher major indicates breaking changes and dexcctl should be updated
-// before attempting to communicate.
-var version = semver{major: 0, minor: 4, patch: 0}
+// version is the dex server's release version.
+var version = semver{major: 0, minor: 3, patch: 0}
 
 // semver holds dexcctl's semver values.
 type semver struct {

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -36,9 +36,12 @@ const (
 	// is closed.
 	rpcTimeoutSeconds = 10
 
-	// RPC version
+	// RPC version. Move major up one for breaking changes. Move minor for
+	// backwards compatible features. Move patch for bug fixes. It is
+	// intended that this always match dexcctl's version, so also update
+	// there accordingly.
 	rpcSemverMajor = 0
-	rpcSemverMinor = 0
+	rpcSemverMinor = 4
 	rpcSemverPatch = 0
 )
 
@@ -69,6 +72,7 @@ type clientCore interface {
 	Wallets() (walletsStates []*core.WalletState)
 	WalletState(assetID uint32) *core.WalletState
 	Withdraw(appPass []byte, assetID uint32, value uint64, addr string) (asset.Coin, error)
+	ExportSeed(pw []byte) ([]byte, error)
 }
 
 // RPCServer is a single-client http and websocket server enabling a JSON

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -37,11 +37,9 @@ const (
 	rpcTimeoutSeconds = 10
 
 	// RPC version. Move major up one for breaking changes. Move minor for
-	// backwards compatible features. Move patch for bug fixes. It is
-	// intended that this always match dexcctl's version, so also update
-	// there accordingly.
+	// backwards compatible features. Move patch for bug fixes.
 	rpcSemverMajor = 0
-	rpcSemverMinor = 4
+	rpcSemverMinor = 1
 	rpcSemverPatch = 0
 )
 

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -56,6 +56,8 @@ type TCore struct {
 	logoutErr           error
 	book                *core.OrderBook
 	bookErr             error
+	exportSeed          []byte
+	exportSeedErr       error
 }
 
 func (c *TCore) Balance(uint32) (uint64, error) {
@@ -111,6 +113,9 @@ func (c *TCore) WalletState(assetID uint32) *core.WalletState {
 }
 func (c *TCore) Withdraw(pw []byte, assetID uint32, value uint64, addr string) (asset.Coin, error) {
 	return c.coin, c.withdrawErr
+}
+func (c *TCore) ExportSeed(pw []byte) ([]byte, error) {
+	return c.exportSeed, c.exportSeedErr
 }
 
 func newTServer(t *testing.T, start bool, user, pass string) (*RPCServer, func()) {

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -472,3 +472,10 @@ func parseMyOrdersArgs(params *RawParams) (*myOrdersForm, error) {
 	}
 	return req, nil
 }
+
+func parseAppSeedArgs(params *RawParams) (encode.PassBytes, error) {
+	if err := checkNArgs(params, []int{1}, []int{0}); err != nil {
+		return nil, err
+	}
+	return params.PWArgs[0], nil
+}

--- a/client/rpcserver/types_test.go
+++ b/client/rpcserver/types_test.go
@@ -60,14 +60,14 @@ func TestCheckNArgs(t *testing.T) {
 			pwArgs[i] = encode.PassBytes(testValue)
 		}
 		err := checkNArgs(&RawParams{PWArgs: pwArgs, Args: test.have}, test.wantNArgs, test.wantNArgs)
-		if err != nil {
-			if test.wantErr {
+		if test.wantErr {
+			if err != nil {
 				continue
 			}
-			t.Fatalf("unexpected error for test %s: %v", test.name, err)
+			t.Fatalf("expected error for test %v", test.name)
 		}
-		if test.wantErr {
-			t.Fatalf("expected error for test %s", test.name)
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 	}
 }
@@ -96,12 +96,14 @@ func TestParseNewWalletArgs(t *testing.T) {
 	}}
 	for _, test := range tests {
 		nwf, err := parseNewWalletArgs(test.params)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if !bytes.Equal(nwf.appPass, test.params.PWArgs[0]) {
 			t.Fatalf("appPass doesn't match")
@@ -143,12 +145,14 @@ func TestParseOpenWalletArgs(t *testing.T) {
 	}}
 	for _, test := range tests {
 		owf, err := parseOpenWalletArgs(test.params)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if !bytes.Equal(owf.appPass, test.params.PWArgs[0]) {
 			t.Fatalf("appPass doesn't match")
@@ -189,12 +193,14 @@ func TestCheckUIntArg(t *testing.T) {
 	}}
 	for _, test := range tests {
 		res, err := checkUIntArg(test.arg, "name", test.bitSize)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if res != test.want {
 			t.Fatalf("expected %d but got %d for test %q", test.want, res, test.name)
@@ -231,12 +237,14 @@ func TestCheckBoolArg(t *testing.T) {
 	}}
 	for _, test := range tests {
 		res, err := checkBoolArg(test.arg, "name")
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if res != test.want {
 			t.Fatalf("wanted %v but got %v for test %v", test.want, res, test.name)
@@ -253,18 +261,19 @@ func TestParseGetFeeArgs(t *testing.T) {
 		name:   "host and cert",
 		params: &RawParams{PWArgs: nil, Args: []string{"host", "cert bytes"}},
 	}, {
-		name:    "just host",
-		params:  &RawParams{PWArgs: nil, Args: []string{"host"}},
-		wantErr: errArgs,
+		name:   "just host",
+		params: &RawParams{PWArgs: nil, Args: []string{"host"}},
 	}}
 	for _, test := range tests {
 		host, cert, err := parseGetFeeArgs(test.params)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if host != test.params.Args[0] {
 			t.Fatalf("url doesn't match")
@@ -296,12 +305,14 @@ func TestParseRegisterArgs(t *testing.T) {
 	}}
 	for _, test := range tests {
 		reg, err := parseRegisterArgs(test.params)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if !bytes.Equal(reg.AppPass, test.params.PWArgs[0]) {
 			t.Fatalf("appPass doesn't match")
@@ -342,12 +353,14 @@ func TestParseHelpArgs(t *testing.T) {
 	}}
 	for _, test := range tests {
 		form, err := parseHelpArgs(&RawParams{Args: test.args})
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if len(test.args) > 0 && form.helpWith != test.args[0] {
 			t.Fatalf("helpwith doesn't match")
@@ -420,12 +433,14 @@ func TestTradeArgs(t *testing.T) {
 	}}
 	for _, test := range tests {
 		reg, err := parseTradeArgs(test.params)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if !bytes.Equal(reg.appPass, test.params.PWArgs[0]) {
 			t.Fatalf("AppPass doesn't match")
@@ -481,12 +496,14 @@ func TestParseCancelArgs(t *testing.T) {
 	}}
 	for _, test := range tests {
 		reg, err := parseCancelArgs(test.params)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %q",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if !bytes.Equal(reg.appPass, test.params.PWArgs[0]) {
 			t.Fatalf("appPass doesn't match")
@@ -522,12 +539,14 @@ func TestParseWithdrawArgs(t *testing.T) {
 	}}
 	for _, test := range tests {
 		res, err := parseWithdrawArgs(test.params)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if !bytes.Equal(res.appPass, test.params.PWArgs[0]) {
 			t.Fatalf("appPass doesn't match")
@@ -579,12 +598,14 @@ func TestParseOrderBookArgs(t *testing.T) {
 	}}
 	for _, test := range tests {
 		res, err := parseOrderBookArgs(test.params)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if res.host != test.params.Args[0] {
 			t.Fatalf("host doesn't match")
@@ -640,12 +661,14 @@ func TestMyOrdersArgs(t *testing.T) {
 	}}
 	for _, test := range tests {
 		res, err := parseMyOrdersArgs(test.params)
-		if err != nil {
-			if !errors.Is(err, test.wantErr) {
-				t.Fatalf("unexpected error %v for test %s",
-					err, test.name)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
 			}
-			continue
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
 		}
 		if len(test.params.Args) > 0 && res.host != test.params.Args[0] {
 			t.Fatalf("host doesn't match")
@@ -655,6 +678,39 @@ func TestMyOrdersArgs(t *testing.T) {
 		}
 		if len(test.params.Args) > 2 && fmt.Sprint(*res.quote) != test.params.Args[2] {
 			t.Fatalf("quote doesn't match")
+		}
+	}
+}
+
+func TestParseAppSeedArgs(t *testing.T) {
+	pw := encode.PassBytes("password123")
+	pwArgs := []encode.PassBytes{pw}
+	args := &RawParams{PWArgs: pwArgs}
+	tests := []struct {
+		name    string
+		params  *RawParams
+		wantErr error
+	}{{
+		name:   "ok",
+		params: args,
+	}, {
+		name:    "no pass",
+		params:  &RawParams{},
+		wantErr: errArgs,
+	}}
+	for _, test := range tests {
+		appPass, err := parseAppSeedArgs(test.params)
+		if test.wantErr != nil {
+			if errors.Is(err, test.wantErr) {
+				continue
+			}
+			t.Fatalf("expected error for test %v", test.name)
+		}
+		if err != nil {
+			t.Fatalf("unexpected error %v for test %s", err, test.name)
+		}
+		if !bytes.Equal(appPass, test.params.PWArgs[0]) {
+			t.Fatalf("appPass doesn't match")
 		}
 	}
 }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -74,6 +74,7 @@ const (
 	RouteUnavailableError             // 55
 	AccountExistsError                // 56
 	AccountSuspendedError             // 57
+	RPCExportSeedError                // 58
 )
 
 // Routes are destinations for a "payload" of data. The type of data being


### PR DESCRIPTION
appseed is able to return the app's seed as hex if supplied the correct
application password.

While here, fix error checking of type tests to not ignore expected
errors when no error happens.

Bump the rpcserver minor version to four because dexcctl was already at
three for some reason, and this adds a feature that is backwards
compatible because it is just a new endpoint.

closes #1147 