### PR TITLE
server: address RPC hangs with disconnected RPC server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/decred/dcrd/gcs/v3 v3.0.0-20210715032435-c9521b468f95
 	github.com/decred/dcrd/hdkeychain/v3 v3.0.1-0.20210715032435-c9521b468f95
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210715032435-c9521b468f95
-	github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210715032435-c9521b468f95
+	github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210819154602-48627ee18c3d
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210715032435-c9521b468f95
 	github.com/decred/dcrd/wire v1.4.1-0.20210715032435-c9521b468f95
 	github.com/decred/go-socks v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210129200153-14fd1a785bf2/g
 github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210525214639-70483c835b7f/go.mod h1:9izQEJ5wU0ZwYHESMaaOIvE6H6y3IvDsQL3ByYGn9oc=
 github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210715032435-c9521b468f95 h1:+sKcEQYVoc0xZ4eaD1NT+u5KUvkUlrJ5THydWNmi1OQ=
 github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0-20210715032435-c9521b468f95/go.mod h1:9izQEJ5wU0ZwYHESMaaOIvE6H6y3IvDsQL3ByYGn9oc=
-github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210715032435-c9521b468f95 h1:/pCbsrqXsSElVeWxDiZTimZzZjt44eGdXk82FUhNuLY=
-github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210715032435-c9521b468f95/go.mod h1:I5Zy4x6Pyt9T+XzSzpo0CofTftWRl9OunpFMuf0g230=
+github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210819154602-48627ee18c3d h1:GTxOteWdXV/aFXJFWhnB+lWbjoipG8PhcEsyF2Xdo3Q=
+github.com/decred/dcrd/rpcclient/v7 v7.0.0-20210819154602-48627ee18c3d/go.mod h1:McAn73oY1SeAVUBQAlkjFivR67oTcoJqWsjWalRFxmo=
 github.com/decred/dcrd/txscript/v4 v4.0.0-20210129190127-4ebd135a82f1/go.mod h1:EnS4vtxTESoI59geLo9M8AUOvIprJy+O4gSVsQp6/h4=
 github.com/decred/dcrd/txscript/v4 v4.0.0-20210330065944-a2366e6e0b3b/go.mod h1:G6b6ERb4KkSqMOCcfSS6m5QV2dgXKVohRpK0HEECw5Q=
 github.com/decred/dcrd/txscript/v4 v4.0.0-20210415215133-96b98390a9a9/go.mod h1:LBGwMZRfpS50huRsc0Bihy7w2Sl9vK3TNqv8nhCRj0U=

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -79,7 +79,7 @@ func (s *Server) apiAsset(w http.ResponseWriter, r *http.Request) {
 	var errs []string
 	backend := asset.Backend
 	var scaledFeeRate uint64
-	currentFeeRate, err := backend.FeeRate()
+	currentFeeRate, err := backend.FeeRate(r.Context())
 	if err != nil {
 		errs = append(errs, fmt.Sprintf("unable to get current fee rate: %v", err))
 	} else {

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -381,7 +381,7 @@ func (btc *Backend) InitTxSizeBase() uint32 {
 }
 
 // FeeRate returns the current optimal fee rate in sat / byte.
-func (btc *Backend) FeeRate() (uint64, error) {
+func (btc *Backend) FeeRate(_ context.Context) (uint64, error) {
 	return btc.estimateFee(btc.node)
 }
 

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -19,7 +19,9 @@ const (
 	ErrRequestTimeout = dex.ErrorKind("request timeout")
 )
 
-// The Backend interface is an interface for a blockchain backend.
+// The Backend interface is an interface for a blockchain backend. TODO: Plumb
+// every method with a cancellable request with a Context, which will prevent
+// backend shutdown from cancelling requests, but is more idiomatic these days.
 type Backend interface {
 	// It is expected that Connect from dex.Connector is called and returns
 	// before use of the asset, and that it is only called once for the life
@@ -63,7 +65,7 @@ type Backend interface {
 	// for more UTXO data.
 	VerifyUnspentCoin(ctx context.Context, coinID []byte) error
 	// FeeRate returns the current optimal fee rate in atoms / byte.
-	FeeRate() (uint64, error)
+	FeeRate(context.Context) (uint64, error)
 	// Synced should return true when the blockchain is synced and ready for
 	// fee rate estimation.
 	Synced() (bool, error)

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -36,6 +36,13 @@ type Driver struct{}
 
 // Setup creates the DCR backend. Start the backend with its Run method.
 func (d *Driver) Setup(configPath string, logger dex.Logger, network dex.Network) (asset.Backend, error) {
+	// With a websocket RPC client with auto-reconnect, setup a logging
+	// subsystem for the rpcclient.
+	logger = logger.SubLogger("RPC")
+	if logger.Level() == dex.LevelTrace {
+		logger.SetLevel(dex.LevelDebug)
+	}
+	rpcclient.UseLogger(logger)
 	return NewBackend(configPath, logger, network)
 }
 

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -173,8 +173,8 @@ func (eth *Backend) InitTxSizeBase() uint32 {
 }
 
 // FeeRate returns the current optimal fee rate in gwei / gas.
-func (eth *Backend) FeeRate() (uint64, error) {
-	bigGP, err := eth.node.suggestGasPrice(eth.rpcCtx)
+func (eth *Backend) FeeRate(ctx context.Context) (uint64, error) {
+	bigGP, err := eth.node.suggestGasPrice(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -320,7 +320,7 @@ func TestFeeRate(t *testing.T) {
 			rpcCtx: ctx,
 			log:    tLogger,
 		}
-		fee, err := eth.FeeRate()
+		fee, err := eth.FeeRate(ctx)
 		cancel()
 		if test.wantErr {
 			if err == nil {

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -227,7 +227,7 @@ type tFeeFetcher struct {
 	maxFeeRate uint64
 }
 
-func (*tFeeFetcher) FeeRate() uint64 {
+func (*tFeeFetcher) FeeRate(context.Context) uint64 {
 	return 10
 }
 

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -402,7 +402,7 @@ func (b *TBackend) VerifyUnspentCoin(_ context.Context, coinID []byte) error {
 	_, err := b.utxo(coinID)
 	return err
 }
-func (b *TBackend) FeeRate() (uint64, error) {
+func (b *TBackend) FeeRate(context.Context) (uint64, error) {
 	return 9, nil
 }
 

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -402,7 +402,7 @@ func (a *TAsset) ValidateContract(contract []byte) error {
 func (a *TAsset) BlockChannel(size int) <-chan *asset.BlockUpdate          { return a.bChan }
 func (a *TAsset) InitTxSize() uint32                                       { return 100 }
 func (a *TAsset) InitTxSizeBase() uint32                                   { return 66 }
-func (a *TAsset) FeeRate() (uint64, error)                                 { return 10, nil }
+func (a *TAsset) FeeRate(context.Context) (uint64, error)                  { return 10, nil }
 func (a *TAsset) CheckAddress(string) bool                                 { return true }
 func (a *TAsset) Connect(context.Context) (*sync.WaitGroup, error)         { return nil, nil }
 func (a *TAsset) ValidateSecret(secret, contract []byte) bool              { return true }


### PR DESCRIPTION
When using rpcclient with dcrd with a WebSocket connection and its auto-reconnect feature, RPCs will hang until the client reconnects or the `Context` provided to them is cancelled.  `asset.Backend` methods sometimes accept a `Context` from consumers, and sometimes we use a `Backend`'s built-in "RPC context" to cancel RPCs when the `Backend` subsystem stops.  Unfortunately, because subsystems that consume `Backends` (e.g. `Market`) are generally shutdown *before* the `Backend`s, their shutdown can hang on RPCs.  This suggests that we really do have to have every `Backend` method that performs an RPC accept a `Context`.  (Shutting down the `Backend`s first is not desirable.)  This also may suggest we should not use auto-reconnect.

I'm not prepared to take that leap to contextifying everything yet, so this PR trials two approaches with the heavily used `FeeRate` and `Synced` methods:
- Give `FeeRate` a context arg, where consumer decided timeouts are reasonable. Unfortunately, a `Backend` can't cancel RPCs on shutdown now, but stopping the `rpcclient.Client` _should_ have the same effect if it  happens to be shutdown before consumers.
- Try a different solution for the `Synced` method: add an internal 2 second timeout. This minimizes API changes and continues to allow RPC cancellation by the `Backend` subsystem shutdown, which using an external `Context` precludes with out serious acrobatics and extra goroutine overhead.

Together with dcrd PR https://github.com/decred/dcrd/pull/2696, the dcrdex process no longer hangs when trying to shutdown with an rpcclient in it's reconnect loop.  In draft until that is merged and the rpcclient/v7 require is updated.

Modify `server/dex.feeFetcher` with the context arg, and add a `LastRate` method for consumers to use as a fallback if `FeeRate` fails. Use the `LastRate` fallback in `market.(*Market).getFeeRate`.

Also fix a `feeFetcher` issue where a zero rate would be cached on `FeeRate` error.

Example of changes when rpcclient's reconnect loop starts (note the new logging subsystem, FeeRate timeouts, and LastRate fallback):

```
2021-08-04 15:24:08.911 [ERR] ASSET[dcr][RPC]: Websocket receive error from 127.0.0.1:19570: websocket: close 1006 (abnormal closure): unexpected EOF
2021-08-04 15:24:08.911 [INF] ASSET[dcr][RPC]: Failed to connect to 127.0.0.1:19570: dial tcp 127.0.0.1:19570: connect: connection refused           
2021-08-04 15:24:08.911 [INF] ASSET[dcr][RPC]: Retrying connection to 127.0.0.1:19570 in 5s                                                          
2021-08-04 15:24:13.912 [INF] ASSET[dcr][RPC]: Failed to connect to 127.0.0.1:19570: dial tcp 127.0.0.1:19570: connect: connection refused           
2021-08-04 15:24:13.912 [INF] ASSET[dcr][RPC]: Retrying connection to 127.0.0.1:19570 in 10s                                                         
2021-08-04 15:24:16.001 [ERR] DEX: Error retrieving fee rate for dcr: request timeout                                                                
2021-08-04 15:24:16.001 [WRN] MKT: Failed to get latest fee rate for dcr. Using last known rate 10.                                                  
2021-08-04 15:24:16.001 [ERR] DEX: Error retrieving fee rate for dcr: request timeout                                                                
2021-08-04 15:24:16.001 [WRN] MKT: Failed to get latest fee rate for dcr. Using last known rate 10.                                                  
```

Previously it would hang *in the epoch processing* pipeline forever.