### PR TITLE
ui: fix depth chart ratio change improperly resizing chart

### DIFF
--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -299,7 +299,7 @@ export default class MarketsPage extends BasePage {
 
       page.marketChart.style.height = `${h}px`
 
-      this.chart.resize(h)
+      this.chart.resize() // resize gets height from parent (marketChart)
     }
     const chartDivRatio = State.fetch(chartRatioKey)
     if (chartDivRatio) {


### PR DESCRIPTION
Relating to https://github.com/decred/dcrdex/pull/1152/files#r683601740, this fixes the chart ratio change handler to call the `resize` function with no parent height argument because `resize` gets it from its parent (`marketChart`).  This could also call like `resize_(h)`.