### PR TITLE
[0.2.2] msgjson,server/dex: dexpubkey in config

### DIFF
--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1032,6 +1032,7 @@ type Asset struct {
 
 // ConfigResult is the successful result for the ConfigRoute.
 type ConfigResult struct {
+	DEXPubKey        Bytes     `json:"dexpubkey,omitempty"` // empty prior to 0.2.2
 	CancelMax        float64   `json:"cancelmax"`
 	BroadcastTimeout uint64    `json:"btimeout"`
 	RegFeeConfirms   uint16    `json:"regfeeconfirms"`

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -141,6 +141,7 @@ type configResponse struct {
 
 func newConfigResponse(cfg *DexConf, cfgAssets []*msgjson.Asset, cfgMarkets []*msgjson.Market) (*configResponse, error) {
 	configMsg := &msgjson.ConfigResult{
+		DEXPubKey:        cfg.DEXPrivKey.PubKey().SerializeCompressed(),
 		BroadcastTimeout: uint64(cfg.BroadcastTimeout.Milliseconds()),
 		CancelMax:        cfg.CancelThreshold,
 		RegFeeConfirms:   uint16(cfg.RegFeeConfirms),


### PR DESCRIPTION
To smooth the big coming 0.3 update, it would be very helpful to have the dex public key in the config response for 0.2.x servers so 0.3 clients are not forced to use the legacy account key path instead of HD key derivation.

See https://github.com/decred/dcrdex/pull/1015/files/07b2eddb074f4ae1230299a3d9bdf381f89fcbb7#r685272694 and https://github.com/decred/dcrdex/pull/1015/files/07b2eddb074f4ae1230299a3d9bdf381f89fcbb7#r681461826

Consider that we are jumping through hoops in code to deal with the possibility of legacy servers, but there is only one public server presently.  Just getting that server on 0.2.2 well in advance of 0.3 will make this a more pleasant experience.  Any private servers that might exist probably have close coordination with their clients.