### PR TITLE
eth: Add CoinID flags.

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -108,15 +108,15 @@ type rawWallet struct {
 type ethFetcher interface {
 	accounts() []*accounts.Account
 	addPeer(ctx context.Context, peer string) error
-	balance(ctx context.Context, addr common.Address) (*big.Int, error)
+	balance(ctx context.Context, addr *common.Address) (*big.Int, error)
 	bestBlockHash(ctx context.Context) (common.Hash, error)
 	bestHeader(ctx context.Context) (*types.Header, error)
 	block(ctx context.Context, hash common.Hash) (*types.Block, error)
 	blockNumber(ctx context.Context) (uint64, error)
-	connect(ctx context.Context, node *node.Node, contractAddr common.Address) error
+	connect(ctx context.Context, node *node.Node, contractAddr *common.Address) error
 	importAccount(pw string, privKeyB []byte) (*accounts.Account, error)
 	listWallets(ctx context.Context) ([]rawWallet, error)
-	initiate(opts *bind.TransactOpts, netID int64, refundTimestamp int64, secretHash [32]byte, participant common.Address) (*types.Transaction, error)
+	initiate(opts *bind.TransactOpts, netID int64, refundTimestamp int64, secretHash [32]byte, participant *common.Address) (*types.Transaction, error)
 	lock(ctx context.Context, acct *accounts.Account) error
 	nodeInfo(ctx context.Context) (*p2p.NodeInfo, error)
 	pendingTransactions(ctx context.Context) ([]*types.Transaction, error)
@@ -192,7 +192,7 @@ func (eth *ExchangeWallet) shutdown() {
 // Connect connects to the node RPC server. A dex.Connector.
 func (eth *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	c := rpcclient{}
-	err := c.connect(ctx, eth.internalNode, mainnetContractAddr)
+	err := c.connect(ctx, eth.internalNode, &mainnetContractAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (eth *ExchangeWallet) Balance() (*asset.Balance, error) {
 	if eth.acct == nil {
 		return nil, errors.New("account not set")
 	}
-	bigBal, err := eth.node.balance(eth.ctx, eth.acct.Address)
+	bigBal, err := eth.node.balance(eth.ctx, &eth.acct.Address)
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -46,7 +46,7 @@ type testNode struct {
 	balErr         error
 }
 
-func (n *testNode) connect(ctx context.Context, node *node.Node, addr common.Address) error {
+func (n *testNode) connect(ctx context.Context, node *node.Node, addr *common.Address) error {
 	return n.connectErr
 }
 func (n *testNode) shutdown() {}
@@ -62,7 +62,7 @@ func (n *testNode) block(ctx context.Context, hash common.Hash) (*types.Block, e
 func (n *testNode) accounts() []*accounts.Account {
 	return nil
 }
-func (n *testNode) balance(ctx context.Context, acct common.Address) (*big.Int, error) {
+func (n *testNode) balance(ctx context.Context, acct *common.Address) (*big.Int, error) {
 	return n.bal, n.balErr
 }
 func (n *testNode) sendTransaction(ctx context.Context, tx map[string]string) (common.Hash, error) {
@@ -98,7 +98,7 @@ func (n *testNode) syncProgress(ctx context.Context) (*ethereum.SyncProgress, er
 func (n *testNode) pendingTransactions(ctx context.Context) ([]*types.Transaction, error) {
 	return nil, nil
 }
-func (n *testNode) initiate(opts *bind.TransactOpts, netID int64, refundTimestamp int64, secretHash [32]byte, participant common.Address) (*types.Transaction, error) {
+func (n *testNode) initiate(opts *bind.TransactOpts, netID int64, refundTimestamp int64, secretHash [32]byte, participant *common.Address) (*types.Transaction, error) {
 	return nil, nil
 }
 func (n *testNode) redeem(opts *bind.TransactOpts, netID int64, secret, secretHash [32]byte) (*types.Transaction, error) {

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -38,7 +38,7 @@ type rpcclient struct {
 
 // connect connects to a node. It then wraps ethclient's client and
 // bundles commands in a form we can easily use.
-func (c *rpcclient) connect(ctx context.Context, node *node.Node, contractAddr common.Address) error {
+func (c *rpcclient) connect(ctx context.Context, node *node.Node, contractAddr *common.Address) error {
 	client, err := node.Attach()
 	if err != nil {
 		return fmt.Errorf("unable to dial rpc: %v", err)
@@ -46,7 +46,7 @@ func (c *rpcclient) connect(ctx context.Context, node *node.Node, contractAddr c
 	c.c = client
 	c.ec = ethclient.NewClient(client)
 	c.n = node
-	c.es, err = swap.NewETHSwap(contractAddr, c.ec)
+	c.es, err = swap.NewETHSwap(*contractAddr, c.ec)
 	if err != nil {
 		return fmt.Errorf("unable to find swap contract: %v", err)
 	}
@@ -104,8 +104,8 @@ func (c *rpcclient) accounts() []*accounts.Account {
 }
 
 // balance gets the current balance of an address.
-func (c *rpcclient) balance(ctx context.Context, addr common.Address) (*big.Int, error) {
-	return c.ec.BalanceAt(ctx, addr, nil)
+func (c *rpcclient) balance(ctx context.Context, addr *common.Address) (*big.Int, error) {
+	return c.ec.BalanceAt(ctx, *addr, nil)
 }
 
 // unlock uses a raw request to unlock an account indefinitely.
@@ -248,12 +248,12 @@ func (c *rpcclient) addSignerToOpts(txOpts *bind.TransactOpts, netID int64) erro
 // initiate creates a swap contract. The initiator will be the account at
 // txOpts.From. Any on-chain failure, such as this secret hash already existing
 // in the swaps map, will not cause this to error.
-func (c *rpcclient) initiate(txOpts *bind.TransactOpts, netID int64, refundTimestamp int64, secretHash [32]byte, participant common.Address) (*types.Transaction, error) {
+func (c *rpcclient) initiate(txOpts *bind.TransactOpts, netID int64, refundTimestamp int64, secretHash [32]byte, participant *common.Address) (*types.Transaction, error) {
 	err := c.addSignerToOpts(txOpts, netID)
 	if err != nil {
 		return nil, err
 	}
-	return c.es.Initiate(txOpts, big.NewInt(refundTimestamp), secretHash, participant)
+	return c.es.Initiate(txOpts, big.NewInt(refundTimestamp), secretHash, *participant)
 }
 
 // redeem redeems a swap contract. The redeemer will be the account at txOpts.From.

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -67,12 +67,12 @@ var (
 	participantAcct  = &accounts.Account{Address: participantAddr}
 	contractAddr     common.Address
 	simnetID         = int64(42)
-	newTxOpts        = func(ctx context.Context, from common.Address, value *big.Int) *bind.TransactOpts {
+	newTxOpts        = func(ctx context.Context, from *common.Address, value *big.Int) *bind.TransactOpts {
 		return &bind.TransactOpts{
 			GasPrice: gasPrice,
 			GasLimit: 1e6,
 			Context:  ctx,
-			From:     from,
+			From:     *from,
 			Value:    value,
 		}
 	}
@@ -152,7 +152,8 @@ func TestMain(m *testing.M) {
 		wallet.internalNode.Close()
 		wallet.internalNode.Wait()
 	}()
-	if err := ethClient.connect(ctx, wallet.internalNode, common.HexToAddress(addrStr)); err != nil {
+	addr := common.HexToAddress(addrStr)
+	if err := ethClient.connect(ctx, wallet.internalNode, &addr); err != nil {
 		fmt.Printf("connect error: %v\n", err)
 		os.Exit(1)
 	}
@@ -255,7 +256,7 @@ func TestAccounts(t *testing.T) {
 }
 
 func TestBalance(t *testing.T) {
-	bal, err := ethClient.balance(ctx, simnetAddr)
+	bal, err := ethClient.balance(ctx, &simnetAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,7 +376,7 @@ func TestInitiate(t *testing.T) {
 		t.Fatal(err)
 	}
 	amt := big.NewInt(1e18)
-	txOpts := newTxOpts(ctx, simnetAddr, amt)
+	txOpts := newTxOpts(ctx, &simnetAddr, amt)
 	swap, err := ethClient.swap(ctx, simnetAcct, secretHash)
 	if err != nil {
 		t.Fatal("unable to get swap state")
@@ -402,12 +403,12 @@ func TestInitiate(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		originalBal, err := ethClient.balance(ctx, simnetAddr)
+		originalBal, err := ethClient.balance(ctx, &simnetAddr)
 		if err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
 		}
 
-		tx, err := ethClient.initiate(txOpts, simnetID, now, secretHash, participantAddr)
+		tx, err := ethClient.initiate(txOpts, simnetID, now, secretHash, &participantAddr)
 		if err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
 		}
@@ -428,7 +429,7 @@ func TestInitiate(t *testing.T) {
 		// whether initiate completed successfully on-chain. If
 		// unsuccessful the fee is subtracted. If successful, amt is
 		// also subtracted.
-		bal, err := ethClient.balance(ctx, simnetAddr)
+		bal, err := ethClient.balance(ctx, &simnetAddr)
 		if err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
 		}
@@ -495,7 +496,7 @@ func TestRedeem(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		txOpts := newTxOpts(ctx, simnetAddr, amt)
+		txOpts := newTxOpts(ctx, &simnetAddr, amt)
 		var secret [32]byte
 		copy(secret[:], encode.RandomBytes(32))
 		secretHash := sha256.Sum256(secret[:])
@@ -515,7 +516,7 @@ func TestRedeem(t *testing.T) {
 		}
 
 		inLocktime := time.Now().Add(locktime).Unix()
-		_, err = ethClient.initiate(txOpts, simnetID, inLocktime, secretHash, participantAddr)
+		_, err = ethClient.initiate(txOpts, simnetID, inLocktime, secretHash, &participantAddr)
 		if err != nil {
 			t.Fatalf("unable to initiate swap for test %v: %v ", test.name, err)
 		}
@@ -524,11 +525,11 @@ func TestRedeem(t *testing.T) {
 		if err := waitForMined(t, test.sleep, true); err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
 		}
-		originalBal, err := ethClient.balance(ctx, test.redeemer.Address)
+		originalBal, err := ethClient.balance(ctx, &test.redeemer.Address)
 		if err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
 		}
-		txOpts = newTxOpts(ctx, test.redeemer.Address, nil)
+		txOpts = newTxOpts(ctx, &test.redeemer.Address, nil)
 		tx, err := ethClient.redeem(txOpts, simnetID, secret, secretHash)
 		if err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
@@ -550,7 +551,7 @@ func TestRedeem(t *testing.T) {
 		// depending on whether redeem completed successfully on-chain.
 		// If unsuccessful the fee is subtracted. If successful, amt is
 		// added.
-		bal, err := ethClient.balance(ctx, test.redeemer.Address)
+		bal, err := ethClient.balance(ctx, &test.redeemer.Address)
 		if err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
 		}
@@ -616,7 +617,7 @@ func TestRefund(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		txOpts := newTxOpts(ctx, simnetAddr, amt)
+		txOpts := newTxOpts(ctx, &simnetAddr, amt)
 		var secret [32]byte
 		copy(secret[:], encode.RandomBytes(32))
 		secretHash := sha256.Sum256(secret[:])
@@ -631,7 +632,7 @@ func TestRefund(t *testing.T) {
 		}
 
 		inLocktime := time.Now().Add(locktime).Unix()
-		_, err = ethClient.initiate(txOpts, simnetID, inLocktime, secretHash, participantAddr)
+		_, err = ethClient.initiate(txOpts, simnetID, inLocktime, secretHash, &participantAddr)
 		if err != nil {
 			t.Fatalf("unable to initiate swap for test %v: %v ", test.name, err)
 		}
@@ -640,7 +641,7 @@ func TestRefund(t *testing.T) {
 			if err := waitForMined(t, time.Second*8, false); err != nil {
 				t.Fatalf("unexpected error for test %v: %v", test.name, err)
 			}
-			txOpts = newTxOpts(ctx, participantAddr, nil)
+			txOpts = newTxOpts(ctx, &participantAddr, nil)
 			_, err := ethClient.redeem(txOpts, simnetID, secret, secretHash)
 			if err != nil {
 				t.Fatalf("unexpected error for test %v: %v", test.name, err)
@@ -652,12 +653,12 @@ func TestRefund(t *testing.T) {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
 		}
 
-		originalBal, err := ethClient.balance(ctx, test.refunder.Address)
+		originalBal, err := ethClient.balance(ctx, &test.refunder.Address)
 		if err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
 		}
 
-		txOpts = newTxOpts(ctx, test.refunder.Address, nil)
+		txOpts = newTxOpts(ctx, &test.refunder.Address, nil)
 		tx, err := ethClient.refund(txOpts, simnetID, secretHash)
 		if err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
@@ -679,7 +680,7 @@ func TestRefund(t *testing.T) {
 		// depending on whether redeem completed successfully on-chain.
 		// If unsuccessful the fee is subtracted. If successful, amt is
 		// added.
-		bal, err := ethClient.balance(ctx, test.refunder.Address)
+		bal, err := ethClient.balance(ctx, &test.refunder.Address)
 		if err != nil {
 			t.Fatalf("unexpected error for test %v: %v", test.name, err)
 		}
@@ -710,7 +711,7 @@ func TestReplayAttack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txOpts := newTxOpts(ctx, simnetAddr, nil)
+	txOpts := newTxOpts(ctx, &simnetAddr, nil)
 	err = ethClient.addSignerToOpts(txOpts, simnetID)
 	if err != nil {
 		t.Fatal(err)
@@ -725,7 +726,7 @@ func TestReplayAttack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	originalContractBal, err := ethClient.balance(ctx, contractAddr)
+	originalContractBal, err := ethClient.balance(ctx, &contractAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -741,7 +742,7 @@ func TestReplayAttack(t *testing.T) {
 
 		if i != 4 {
 			inLocktime := time.Now().Add(time.Hour).Unix()
-			_, err = ethClient.initiate(txOpts, simnetID, inLocktime, secretHash, participantAddr)
+			_, err = ethClient.initiate(txOpts, simnetID, inLocktime, secretHash, &participantAddr)
 			if err != nil {
 				t.Fatalf("unable to initiate swap: %v ", err)
 			}
@@ -785,7 +786,7 @@ func TestReplayAttack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	originalAcctBal, err := ethClient.balance(ctx, simnetAddr)
+	originalAcctBal, err := ethClient.balance(ctx, &simnetAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -805,7 +806,7 @@ func TestReplayAttack(t *testing.T) {
 	txFee := big.NewInt(0).Mul(big.NewInt(int64(receipt.GasUsed)), gasPrice)
 	wantBal := big.NewInt(0).Sub(originalAcctBal, txFee)
 
-	bal, err := ethClient.balance(ctx, simnetAddr)
+	bal, err := ethClient.balance(ctx, &simnetAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -831,7 +832,7 @@ func TestReplayAttack(t *testing.T) {
 
 	// The contract should hold four more ether because initiation of one
 	// swap failed.
-	bal, err = ethClient.balance(ctx, contractAddr)
+	bal, err = ethClient.balance(ctx, &contractAddr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -383,8 +383,8 @@ func TestInitiate(t *testing.T) {
 	}
 	spew.Dump(swap)
 	state := eth.SwapState(swap.State)
-	if state != eth.None {
-		t.Fatalf("unexpected swap state: want %s got %s", eth.None, state)
+	if state != eth.SSNone {
+		t.Fatalf("unexpected swap state: want %s got %s", eth.SSNone, state)
 	}
 
 	tests := []struct {
@@ -393,13 +393,13 @@ func TestInitiate(t *testing.T) {
 		finalState eth.SwapState
 	}{{
 		name:       "ok",
-		finalState: eth.Initiated,
+		finalState: eth.SSInitiated,
 		subAmt:     true,
 	}, {
 		// If the hash already exists, the contract should subtract only
 		// the tx fee from the account.
 		name:       "secret hash already exists",
-		finalState: eth.Initiated,
+		finalState: eth.SSInitiated,
 	}}
 
 	for _, test := range tests {
@@ -466,24 +466,24 @@ func TestRedeem(t *testing.T) {
 		name:       "ok before locktime",
 		sleep:      time.Second * 8,
 		redeemer:   participantAcct,
-		finalState: eth.Redeemed,
+		finalState: eth.SSRedeemed,
 		addAmt:     true,
 	}, {
 		name:       "ok after locktime",
 		sleep:      time.Second * 16,
 		redeemer:   participantAcct,
-		finalState: eth.Redeemed,
+		finalState: eth.SSRedeemed,
 		addAmt:     true,
 	}, {
 		name:       "bad secret",
 		sleep:      time.Second * 8,
 		redeemer:   participantAcct,
-		finalState: eth.Initiated,
+		finalState: eth.SSInitiated,
 		badSecret:  true,
 	}, {
 		name:       "wrong redeemer",
 		sleep:      time.Second * 8,
-		finalState: eth.Initiated,
+		finalState: eth.SSInitiated,
 		redeemer:   simnetAcct,
 	}}
 
@@ -506,8 +506,8 @@ func TestRedeem(t *testing.T) {
 			t.Fatal("unable to get swap state")
 		}
 		state := eth.SwapState(swap.State)
-		if state != eth.None {
-			t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, eth.None, state)
+		if state != eth.SSNone {
+			t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, eth.SSNone, state)
 		}
 
 		// Create a secret that doesn't has to secretHash.
@@ -589,23 +589,23 @@ func TestRefund(t *testing.T) {
 		sleep:      time.Second * 16,
 		refunder:   simnetAcct,
 		addAmt:     true,
-		finalState: eth.Refunded,
+		finalState: eth.SSRefunded,
 	}, {
 		name:       "before locktime",
 		sleep:      time.Second * 8,
 		refunder:   simnetAcct,
-		finalState: eth.Initiated,
+		finalState: eth.SSInitiated,
 	}, {
 		name:       "wrong refunder",
 		sleep:      time.Second * 16,
 		refunder:   participantAcct,
-		finalState: eth.Initiated,
+		finalState: eth.SSInitiated,
 	}, {
 		name:       "already redeemed",
 		sleep:      time.Second * 16,
 		refunder:   simnetAcct,
 		redeem:     true,
-		finalState: eth.Redeemed,
+		finalState: eth.SSRedeemed,
 	}}
 
 	for _, test := range tests {
@@ -627,8 +627,8 @@ func TestRefund(t *testing.T) {
 			t.Fatal("unable to get swap state")
 		}
 		state := eth.SwapState(swap.State)
-		if state != eth.None {
-			t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, eth.None, state)
+		if state != eth.SSNone {
+			t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, eth.SSNone, state)
 		}
 
 		inLocktime := time.Now().Add(locktime).Unix()
@@ -819,15 +819,15 @@ func TestReplayAttack(t *testing.T) {
 			"or a difference of %v", wantBal, bal, diff)
 	}
 
-	// The exploit failed and status should be None because initiation also
+	// The exploit failed and status should be SSNone because initiation also
 	// failed.
 	swap, err := ethClient.swap(ctx, simnetAcct, secretHash)
 	if err != nil {
 		t.Fatal(err)
 	}
 	state := eth.SwapState(swap.State)
-	if state != eth.None {
-		t.Fatalf("unexpected swap state: want %s got %s", eth.None, state)
+	if state != eth.SSNone {
+		t.Fatalf("unexpected swap state: want %s got %s", eth.SSNone, state)
 	}
 
 	// The contract should hold four more ether because initiation of one

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -101,8 +101,7 @@ func CoinIDToString(coinID []byte) (string, error) {
 // ToCoinID converts the address and secret hash, or txid to a coin ID.
 func ToCoinID(flags CoinIDFlag, addr *common.Address, hash []byte) []byte {
 	b := make([]byte, coinIDSize)
-	b[0] = byte(flags >> 8)
-	b[1] = byte(flags)
+	binary.BigEndian.PutUint16(b[:2], uint16(flags))
 	if IsSwapCoinID(flags) {
 		copy(b[2:], addr[:])
 	}

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -78,15 +78,17 @@ func (ss SwapState) String() string {
 
 // DecodeCoinID decodes the coin ID into flags, a contract address which may be
 // zeroed, and hash that represents either a secret or txid depending on flags.
-func DecodeCoinID(coinID []byte) (CoinIDFlag, common.Address, []byte, error) {
+func DecodeCoinID(coinID []byte) (CoinIDFlag, *common.Address, []byte, error) {
+	var addr common.Address
 	if len(coinID) != coinIDSize {
-		return 0, common.Address{}, nil, fmt.Errorf("coin ID wrong length. expected %d, got %d",
+		return 0, &addr, nil, fmt.Errorf("coin ID wrong length. expected %d, got %d",
 			coinIDSize, len(coinID))
 	}
 	hash := make([]byte, 32)
 	copy(hash, coinID[22:])
+	copy(addr[:], coinID[2:22])
 	return CoinIDFlag(binary.BigEndian.Uint16(coinID[:2])),
-		common.BytesToAddress(coinID[2:22]), hash, nil
+		&addr, hash, nil
 }
 
 // CoinIDToString converts coinID into a human readable string.

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -81,7 +81,7 @@ func (ss SwapState) String() string {
 func DecodeCoinID(coinID []byte) (CoinIDFlag, *common.Address, []byte, error) {
 	var addr common.Address
 	if len(coinID) != coinIDSize {
-		return 0, &addr, nil, fmt.Errorf("coin ID wrong length. expected %d, got %d",
+		return 0, nil, nil, fmt.Errorf("coin ID wrong length. expected %d, got %d",
 			coinIDSize, len(coinID))
 	}
 	hash := make([]byte, 32)

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -180,7 +180,7 @@ func TestDecodeCoinID(t *testing.T) {
 			t.Fatalf("want flags value of %v but got %v for test %v",
 				test.wantFlags, flags, test.name)
 		}
-		if !bytes.Equal(addr[:], test.wantAddr[:]) {
+		if *addr != *test.wantAddr {
 			t.Fatalf("want addr value of %v but got %v for test %v",
 				test.wantAddr, addr, test.name)
 		}

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -123,7 +123,7 @@ func TestDecodeCoinID(t *testing.T) {
 	tests := []struct {
 		name                   string
 		wantFlags              CoinIDFlag
-		wantAddr               common.Address
+		wantAddr               *common.Address
 		coinID, wantSecretHash []byte
 		wantErr                bool
 	}{{
@@ -139,7 +139,7 @@ func TestDecodeCoinID(t *testing.T) {
 			0x56, 0x7f, 0x2f, 0x07, 0x3c, // 32 byte secret hash
 		},
 		wantFlags: TxIDFlag,
-		wantAddr: common.Address{
+		wantAddr: &common.Address{
 			0x18, 0xd6, 0x5f, 0xb8, 0xd6, 0x0c, 0x11, 0x99, 0xbb,
 			0x1a, 0xd3, 0x81, 0xbe, 0x47, 0xaa, 0x69, 0x2b, 0x48,
 			0x26, 0x05,
@@ -180,7 +180,7 @@ func TestDecodeCoinID(t *testing.T) {
 			t.Fatalf("want flags value of %v but got %v for test %v",
 				test.wantFlags, flags, test.name)
 		}
-		if addr != test.wantAddr {
+		if !bytes.Equal(addr[:], test.wantAddr[:]) {
 			t.Fatalf("want addr value of %v but got %v for test %v",
 				test.wantAddr, addr, test.name)
 		}

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -138,7 +138,7 @@ func TestDecodeCoinID(t *testing.T) {
 			0x8f, 0xd7, 0x99, 0x49, 0x98, 0xbb, 0x3e, 0x50, 0x48,
 			0x56, 0x7f, 0x2f, 0x07, 0x3c, // 32 byte secret hash
 		},
-		wantFlags: TxIDFlag,
+		wantFlags: CIDTxID,
 		wantAddr: &common.Address{
 			0x18, 0xd6, 0x5f, 0xb8, 0xd6, 0x0c, 0x11, 0x99, 0xbb,
 			0x1a, 0xd3, 0x81, 0xbe, 0x47, 0xaa, 0x69, 0x2b, 0x48,
@@ -192,7 +192,7 @@ func TestDecodeCoinID(t *testing.T) {
 }
 
 func TestCoinIDToString(t *testing.T) {
-	flags := SwapFlag
+	flags := CIDSwap
 	addr := "18d65fb8d60c1199bb1ad381be47aa692b482605"
 	secretHash := "71d810d39333296b518c846a3e49eca55f998fd7994998bb3e5048567f2f073c"
 	tests := []struct {
@@ -397,54 +397,54 @@ func TestSynced(t *testing.T) {
 	}
 }
 
-func TestIsTxIDCoinID(t *testing.T) {
+func TestIsCIDTxID(t *testing.T) {
 	tests := []struct {
 		name string
 		flag CoinIDFlag
 		want bool
 	}{{
 		name: "true",
-		flag: TxIDFlag,
+		flag: CIDTxID,
 		want: true,
 	}, {
 		name: "false zero",
 	}, {
 		name: "false other",
-		flag: SwapFlag,
+		flag: CIDSwap,
 	}, {
 		name: "false txid and other",
-		flag: TxIDFlag | SwapFlag,
+		flag: CIDTxID | CIDSwap,
 	}}
 
 	for _, test := range tests {
-		got := IsTxIDCoinID(test.flag)
+		got := IsCIDTxID(test.flag)
 		if got != test.want {
 			t.Fatalf("want %v but got %v for test %v", test.want, got, test.name)
 		}
 	}
 }
 
-func TestIsSwapCoinID(t *testing.T) {
+func TestCIDSwap(t *testing.T) {
 	tests := []struct {
 		name string
 		flag CoinIDFlag
 		want bool
 	}{{
 		name: "true",
-		flag: SwapFlag,
+		flag: CIDSwap,
 		want: true,
 	}, {
 		name: "false zero",
 	}, {
 		name: "false other",
-		flag: TxIDFlag,
+		flag: CIDTxID,
 	}, {
 		name: "false txid and other",
-		flag: TxIDFlag | SwapFlag,
+		flag: CIDTxID | CIDSwap,
 	}}
 
 	for _, test := range tests {
-		got := IsSwapCoinID(test.flag)
+		got := IsCIDSwap(test.flag)
 		if got != test.want {
 			t.Fatalf("want %v but got %v for test %v", test.want, got, test.name)
 		}
@@ -464,7 +464,7 @@ func TestToCoinID(t *testing.T) {
 		want []byte
 	}{{
 		name: "txid",
-		flag: TxIDFlag,
+		flag: CIDTxID,
 		want: []byte{
 			0x00, 0x01, // 2 byte flags
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -477,7 +477,7 @@ func TestToCoinID(t *testing.T) {
 		},
 	}, {
 		name: "swap",
-		flag: SwapFlag,
+		flag: CIDSwap,
 		want: []byte{
 			0x00, 0x02, // 2 byte flags
 			0x18, 0xd6, 0x5f, 0xb8, 0xd6, 0x0c, 0x11, 0x99, 0xbb,


### PR DESCRIPTION
    Add TxIDFlag and SwapFlag in order to specify that a coin ID represents
    either a txid or a swap. IsTxIDCoinID and IsSwapCoinID package methods
    are included so that callers can easily discern if they have the right
    type of coin ID for the operation they are performing.

related to #1021