### PR TITLE
server/eth: Implement InitTxSize.

### DIFF
--- a/dex/calc/fees.go
+++ b/dex/calc/fees.go
@@ -20,7 +20,7 @@ func RequiredOrderFunds(swapVal, inputsSize, maxSwaps uint64, nfo *dex.Asset) ui
 
 // RequiredOrderFundsAlt is the same as RequiredOrderFunds, but built-in type
 // parameters.
-func RequiredOrderFundsAlt(swapVal, inputsSize, maxSwaps uint64, swapSizeBase, swapSize, feeRate uint64) uint64 {
+func RequiredOrderFundsAlt(swapVal, inputsSize, maxSwaps, swapSizeBase, swapSize, feeRate uint64) uint64 {
 	baseBytes := maxSwaps * swapSize
 	// SwapSize already includes one input, replace the size of the first swap
 	// in the chain with the given size of the actual inputs + SwapSizeBase.

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -63,6 +63,17 @@ const (
 	// GweiFactor is the amount of wei in one gwei. Eth balances are floored
 	// as gwei, or 1e9 wei. This is used in factoring.
 	GweiFactor = 1e9
+	// InitGas is the amount of gas needed to initialize an ethereum swap.
+	//
+	// The price of a normal transaction is 21000 gas. However, when
+	// contract methods are called it is difficult to descern where gas is
+	// used. The formal declaration of what costs how much can be found at
+	// https://ethereum.github.io/yellowpaper/paper.pdf in Appendix G.
+	// The current value here is an appoximation based on tests.
+	//
+	// TODO: When the contract is solidified, break down evm functions
+	// called and the gas used for each. (◍•﹏•)
+	InitGas = 180000 // gas
 )
 
 // ToGwei converts a *big.Int in wei (1e18 unit) to gwei (1e9 unit) as a uint64.

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -161,13 +161,19 @@ func (eth *Backend) TxData(coinID []byte) ([]byte, error) {
 	return nil, notImplementedErr
 }
 
-// InitTxSize is an asset.Backend method that must produce the max size of a
-// standardized atomic swap initialization transaction.
+// InitTxSize is not size for eth. In ethereum the size of a non-standard
+// transaction does not say anything about the processing power the ethereum
+// virtual machine will use in order to process it, and therefor gas needed
+// cannot be ascertained from it. Multiplying the required gas by the gas price
+// will give us the actual fee needed, so returning gas here.
 func (eth *Backend) InitTxSize() uint32 {
-	return 0
+	return InitGas
 }
 
-// InitTxSizeBase is InitTxSize not including an input.
+// InitTxSizeBase is used in fee.go in a fee calculation. Currently we are
+// unable to batch eth contract calls like UTXO coins so all contracts will
+// need to be per transaction. Setting this to zero produces the expected
+// result in fee calculations.
 func (eth *Backend) InitTxSizeBase() uint32 {
 	return 0
 }

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -508,10 +508,10 @@ func TestRequiredOrderFunds(t *testing.T) {
 	numSwaps := uint64(17)                       // swaps
 	initSizeBase := uint64(eth.InitTxSizeBase()) // 0 gas
 	initSize := uint64(eth.InitTxSize())         // init value gas
-	feeRate := uint64(30)                        // gwei
+	feeRate := uint64(30)                        // gwei / gas
 
-	// We want the fee calculation to simply be the gas used for each swap
-	// plus the initial value.
+	// We want the fee calculation to simply be the cost of the gas used
+	// for each swap plus the initial value.
 	want := swapVal + (numSwaps * initSize * feeRate)
 	nfo := &dex.Asset{
 		SwapSizeBase: initSizeBase,


### PR DESCRIPTION
    Also implement InitTxSizeBase.
    
    The size of a tx does not actually tell us how much a transaction paying
    to a contract with extra data will cost to send. The evm will determine
    how much gas will be used. The exact cost can probably be determined but
    will take a lot of digging, and will change if the contract changes. For
    now, use an approximation of used gas based off of tests.
    
    Our current implementation also does not allow for batch transactions.
    As such, return zero for InitTxSizeBase in order to ensure fee
    calculations equate to what we expect, which is a one for one
    initilizaion and gas fee.

Part of #1154