### PR TITLE
go:build migration and gofmt fixes

### DIFF
--- a/client/asset/bch/regnet_test.go
+++ b/client/asset/bch/regnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package bch

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1,3 +1,4 @@
+//go:build !harness
 // +build !harness
 
 package btc

--- a/client/asset/btc/livetest/regnet_test.go
+++ b/client/asset/btc/livetest/regnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package livetest

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1,3 +1,4 @@
+//go:build !harness
 // +build !harness
 
 package dcr

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package dcr

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1,5 +1,6 @@
+//go:build !harness
 // +build !harness
-//
+
 // These tests will not be run if the harness build tag is set.
 
 package eth

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -1,5 +1,6 @@
+//go:build harness
 // +build harness
-//
+
 // This test requires that the testnet harness be running and the unix socket
 // be located at $HOME/dextest/eth/gamma/node/geth.ipc
 //

--- a/client/asset/ltc/regnet_test.go
+++ b/client/asset/ltc/regnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package ltc

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -1,3 +1,4 @@
+//go:build !harness
 // +build !harness
 
 package core

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1,3 +1,4 @@
+//go:build !harness
 // +build !harness
 
 package core

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package core

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -1,6 +1,7 @@
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
+//go:build !live
 // +build !live
 
 package rpcserver

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1,4 +1,6 @@
+//go:build live
 // +build live
+
 // Run a test server with
 // go test -v -tags live -run Server -timeout 60m
 // test server will run for 1 hour and serve randomness.

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -1,3 +1,4 @@
+//go:build !live
 // +build !live
 
 package webserver

--- a/client/websocket/websocket_test.go
+++ b/client/websocket/websocket_test.go
@@ -1,3 +1,4 @@
+//go:build !live
 // +build !live
 
 package websocket

--- a/server/asset/bch/live_test.go
+++ b/server/asset/bch/live_test.go
@@ -1,5 +1,6 @@
+//go:build bchlive
 // +build bchlive
-//
+
 // go test -v -tags bchlive -run UTXOStats
 // -----------------------------------
 // Grab the most recent block and iterate it's outputs, taking account of

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -1,5 +1,6 @@
+//go:build !btclive
 // +build !btclive
-//
+
 // These tests will not be run if the btclive build tag is set. In that case,
 // the live_test.go tests will run.
 

--- a/server/asset/btc/live_test.go
+++ b/server/asset/btc/live_test.go
@@ -1,5 +1,6 @@
+//go:build btclive
 // +build btclive
-//
+
 // Since at least one live test runs for an hour, you should run live tests
 // individually using the -run flag. All of these tests will only run with the
 // 'btclive' build tag, specified with the -tags flag.

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -1,5 +1,6 @@
+//go:build !dcrlive
 // +build !dcrlive
-//
+
 // These tests will not be run if the dcrlive build tag is set.
 
 package dcr

--- a/server/asset/dcr/live_test.go
+++ b/server/asset/dcr/live_test.go
@@ -1,5 +1,6 @@
+//go:build dcrlive
 // +build dcrlive
-//
+
 // Since at least one live test runs for an hour, you should run live tests
 // individually using the -run flag. All of these tests will only run with the
 // 'dcrlive' build tag, specified with the -tags flag.

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -1,5 +1,6 @@
+//go:build !harness
 // +build !harness
-//
+
 // These tests will not be run if the harness build tag is set.
 
 package eth

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -1,5 +1,6 @@
+//go:build harness
 // +build harness
-//
+
 // This test requires that the testnet harness be running and the unix socket
 // be located at $HOME/dextest/eth/alpha/node/geth.ipc
 

--- a/server/asset/ltc/live_test.go
+++ b/server/asset/ltc/live_test.go
@@ -1,5 +1,6 @@
+//go:build ltclive
 // +build ltclive
-//
+
 // go test -v -tags ltclive -run UTXOStats
 // -----------------------------------
 // Grab the most recent block and iterate it's outputs, taking account of

--- a/server/db/driver/pg/accounts_online_test.go
+++ b/server/db/driver/pg/accounts_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/matches_online_test.go
+++ b/server/db/driver/pg/matches_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/orders_online_test.go
+++ b/server/db/driver/pg/orders_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/orders_test.go
+++ b/server/db/driver/pg/orders_test.go
@@ -1,3 +1,4 @@
+//go:build !pgonline
 // +build !pgonline
 
 // This code is available on the terms of the project LICENSE.md file,

--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/tables_online_test.go
+++ b/server/db/driver/pg/tables_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/upgrades_test.go
+++ b/server/db/driver/pg/upgrades_test.go
@@ -1,4 +1,6 @@
+//go:build pgonline
 // +build pgonline
+
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 


### PR DESCRIPTION
Begin transition from "// +build" lines to "//go:build".
See https://golang.org/design/draft-gobuild