### PR TITLE
eth/config: Add contract address to configs.

### DIFF
--- a/client/asset/eth/config.go
+++ b/client/asset/eth/config.go
@@ -4,10 +4,12 @@
 package eth
 
 import (
+	"errors"
 	"fmt"
 
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/config"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // Config holds the parameters needed to initialize an ETH wallet.
@@ -15,6 +17,7 @@ type Config struct {
 	AppDir         string  `ini:"appdir"`
 	NodeListenAddr string  `ini:"nodelistenaddr"`
 	GasFee         float64 `ini:"gasfee"`
+	ContractAddr   string  `ini:"contractaddr"`
 }
 
 // loadConfig loads the Config from a setting map and checks the network.
@@ -33,5 +36,13 @@ func loadConfig(settings map[string]string, network dex.Network) (*Config, error
 	default:
 		return nil, fmt.Errorf("unknown network ID: %d", uint8(network))
 	}
+
+	if cfg.ContractAddr == "" {
+		return nil, errors.New("no swap contract address specified in config file")
+	}
+	if !common.IsHexAddress(cfg.ContractAddr) {
+		return nil, errors.New("contract address is structually invalid")
+	}
+
 	return cfg, nil
 }

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -119,21 +119,34 @@ func (n *testNode) peers(ctx context.Context) ([]*p2p.PeerInfo, error) {
 }
 
 func TestLoadConfig(t *testing.T) {
+	goodAddr := "0x2f68e723b8989ba1c6a9f03e42f33cb7dc9d606f"
 	tests := []struct {
-		name    string
-		network dex.Network
-		wantErr bool
+		name     string
+		settings map[string]string
+		network  dex.Network
+		wantErr  bool
 	}{{
-		name:    "ok",
-		network: dex.Simnet,
+		name:     "ok",
+		settings: map[string]string{"contractaddr": goodAddr},
+		network:  dex.Simnet,
 	}, {
 		name:    "mainnet not allowed",
 		network: dex.Mainnet,
 		wantErr: true,
+	}, {
+		name:     "no contract addr",
+		settings: map[string]string{"contractaddr": ""},
+		network:  dex.Simnet,
+		wantErr:  true,
+	}, {
+		name:     "bad contract addr",
+		settings: map[string]string{"contractaddr": "123"},
+		network:  dex.Simnet,
+		wantErr:  true,
 	}}
 
 	for _, test := range tests {
-		_, err := loadConfig(nil, test.network)
+		_, err := loadConfig(test.settings, test.network)
 		if test.wantErr {
 			if err == nil {
 				t.Fatalf("expected error for test %v", test.name)

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -33,6 +33,7 @@ type rpcclient struct {
 	// ec wraps the client with some useful calls.
 	ec *ethclient.Client
 	n  *node.Node
+	// es is a wrapper for contract calls.
 	es *swap.ETHSwap
 }
 

--- a/client/cmd/dexcctl/simnet-setup.sh
+++ b/client/cmd/dexcctl/simnet-setup.sh
@@ -37,7 +37,8 @@ fi
 
 if [ $ETH_ON -eq 0 ]; then
 	echo configuring Eth wallet
-	./dexcctl -p abc -p "" --simnet newwallet 60 "" '{"appDir":"~/dextest/eth/testnode"}'
+	CONTRACT_ADDR=$(cat ~/dextest/eth/contract_addr.txt)
+	./dexcctl -p abc -p "" --simnet newwallet 60 "" '{"appDir":"~/dextest/eth/testnode", "contractaddr" :"'$CONTRACT_ADDR'"}'
 fi
 
 echo registering with DEX

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -163,7 +163,7 @@ if [ $ETH_ON -eq 0 ]; then
             "network": "simnet",
             "maxFeeRate": 200,
             "swapConf": 2,
-            "configPath": "${TEST_ROOT}/eth/alpha/node/geth.ipc"
+            "configPath": "${TEST_ROOT}/eth/alpha/alpha.conf"
 EOF
 fi
 

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -240,6 +240,12 @@ cat > "${NODES_ROOT}/contract_addr.txt" <<EOF
 ${CONTRACT_ADDR}
 EOF
 
+# Add config to alpha node directory.
+cat > "${NODES_ROOT}/alpha/alpha.conf" <<EOF
+ipc=${NODES_ROOT}/alpha/node/geth.ipc
+contractaddr=${CONTRACT_ADDR}
+EOF
+
 # Reenable history and attach to the control session.
 tmux select-window -t $SESSION:0
 tmux send-keys -t $SESSION:0 "set -o history" C-m

--- a/server/asset/eth/config.go
+++ b/server/asset/eth/config.go
@@ -4,11 +4,15 @@
 package eth
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"decred.org/dcrdex/dex"
 	"github.com/decred/dcrd/dcrutil/v4"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/jessevdk/go-flags"
 )
 
 var (
@@ -19,12 +23,15 @@ var (
 type config struct {
 	// IPC is the location of the inner process communication socket.
 	IPC string `long:"ipc" description:"Location of the geth ipc socket."`
+	// ContractAddr is the base 58 address of the already deployed swap
+	// contract to use in swaps.
+	ContractAddr string `long:"contractaddr" description:"Address of the deployed eth swap contract."`
 }
 
 // load checks the network and sets the ipc location if not supplied.
 //
 // TODO: Test this with windows.
-func load(IPC string, network dex.Network) (*config, error) {
+func loadConfig(configPath string, network dex.Network) (*config, error) {
 	switch network {
 	case dex.Simnet:
 	case dex.Testnet:
@@ -35,12 +42,28 @@ func load(IPC string, network dex.Network) (*config, error) {
 		return nil, fmt.Errorf("unknown network ID: %d", uint8(network))
 	}
 
-	cfg := &config{
-		IPC: IPC,
+	cfg := new(config)
+
+	parser := flags.NewParser(cfg, flags.None)
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("no %q config file found at %s", assetName, configPath)
+	}
+
+	// The config file exists, so attempt to parse it.
+	err := flags.NewIniParser(parser).ParseFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing %q config file: %w", assetName, err)
 	}
 
 	if cfg.IPC == "" {
 		cfg.IPC = defaultIPC
+	}
+
+	if cfg.ContractAddr == "" {
+		return nil, errors.New("no swap contract address specified in config file")
+	}
+	if !common.IsHexAddress(cfg.ContractAddr) {
+		return nil, errors.New("contract address is structually invalid")
 	}
 
 	return cfg, nil

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -61,7 +61,7 @@ type ethFetcher interface {
 	bestBlockHash(ctx context.Context) (common.Hash, error)
 	bestHeader(ctx context.Context) (*types.Header, error)
 	block(ctx context.Context, hash common.Hash) (*types.Block, error)
-	connect(ctx context.Context, IPC string) error
+	connect(ctx context.Context, cfg *config) error
 	shutdown()
 	suggestGasPrice(ctx context.Context) (*big.Int, error)
 	syncProgress(ctx context.Context) (*ethereum.SyncProgress, error)
@@ -111,8 +111,8 @@ func unconnectedETH(logger dex.Logger, cfg *config) *Backend {
 
 // NewBackend is the exported constructor by which the DEX will import the
 // Backend.
-func NewBackend(ipc string, logger dex.Logger, network dex.Network) (*Backend, error) {
-	cfg, err := load(ipc, network)
+func NewBackend(configFile string, logger dex.Logger, network dex.Network) (*Backend, error) {
+	cfg, err := loadConfig(configFile, network)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (eth *Backend) shutdown() {
 // Connect connects to the node RPC server and initializes some variables.
 func (eth *Backend) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	c := rpcclient{}
-	if err := c.connect(ctx, eth.cfg.IPC); err != nil {
+	if err := c.connect(ctx, eth.cfg); err != nil {
 		return nil, err
 	}
 	eth.node = &c


### PR DESCRIPTION
    server/eth/config: Add contract address.

    Add ability to parse a config file rather than just the ipc location.

    client/eth/settings: Add contract address.

    Rather than use a hardcoded address, require the address be set upon
    initializaion of the wallet.



Was part of #1159 but decided to make a separate pr. I believe this is the correct direction to go for which contract to use. The contract must still have the same byte code as the hard-coded one, but we don't currently have a way to verify that. I wonder if a different contract will cause initial binding to fail? Need to look into that.