### PR TITLE
rpc/client: Minimum fee rate for swap transactions

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -942,12 +942,12 @@ func (btc *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes
 			btc.feeRateLimit)
 	}
 
-	// Check wallet's fee rate limit against user defined custom fee rate
-	if ord.CustomSwapFeeRate != nil && btc.feeRateLimit < *ord.CustomSwapFeeRate {
+	// Check wallet's fee rate limit against user defined minimum fee rate
+	if ord.MinSwapFeeRate != nil && btc.feeRateLimit < *ord.MinSwapFeeRate {
 		return nil, nil, fmt.Errorf(
-			"%v: custom swap fee %v higher than configured fee rate limit %v",
+			"%v: minimum swap fee %v higher than configured fee rate limit %v",
 			ord.DEXConfig.Symbol,
-			*ord.CustomSwapFeeRate,
+			*ord.MinSwapFeeRate,
 			btc.feeRateLimit)
 	}
 
@@ -964,8 +964,8 @@ func (btc *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes
 	}
 
 	var feeRate uint64
-	if ord.CustomSwapFeeRate != nil && *ord.CustomSwapFeeRate > ord.DEXConfig.MaxFeeRate {
-		feeRate = *ord.CustomSwapFeeRate
+	if ord.MinSwapFeeRate != nil && *ord.MinSwapFeeRate > ord.DEXConfig.MaxFeeRate {
+		feeRate = *ord.MinSwapFeeRate
 	} else {
 		feeRate = ord.DEXConfig.MaxFeeRate
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -675,8 +675,8 @@ func TestAvailableFund(t *testing.T) {
 	}
 	_ = wallet.ReturnCoins(spendables)
 
-	// Test that little funds are needed without a custom swap rate, but then
-	// lotta funds are needed with the custom swap rate.
+	// Test that little funds are needed without a minimum swap rate, but then
+	// lotta funds are needed with the minimum swap rate.
 	setOrderValue(littleOrder)
 	spendables, _, err = wallet.FundOrder(ord)
 	if err != nil {
@@ -691,8 +691,8 @@ func TestAvailableFund(t *testing.T) {
 	}
 	_ = wallet.ReturnCoins(spendables)
 
-	customSwapFeeRate := ord.DEXConfig.MaxFeeRate + 1
-	ord.CustomSwapFeeRate = &customSwapFeeRate
+	minSwapFeeRate := ord.DEXConfig.MaxFeeRate + 1
+	ord.MinSwapFeeRate = &minSwapFeeRate
 	spendables, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error for funding order")
@@ -704,22 +704,22 @@ func TestAvailableFund(t *testing.T) {
 	if v != lottaFunds {
 		t.Fatalf("expected spendable of value %d, got %d", lottaFunds, v)
 	}
-	ord.CustomSwapFeeRate = nil
+	ord.MinSwapFeeRate = nil
 	_ = wallet.ReturnCoins(spendables)
 
 	// Error with cusom fee rate higher than wallet fee rate limit
-	customSwapFeeRate = wallet.feeRateLimit + 1
-	ord.CustomSwapFeeRate = &customSwapFeeRate
+	minSwapFeeRate = wallet.feeRateLimit + 1
+	ord.MinSwapFeeRate = &minSwapFeeRate
 	_, _, err = wallet.FundOrder(ord)
 	if err == nil {
 		t.Fatalf("no error for too high fee rate")
 	}
 
 	// Success again.
-	ord.CustomSwapFeeRate = nil
+	ord.MinSwapFeeRate = nil
 	spendables, _, err = wallet.FundOrder(ord)
 	if err != nil {
-		t.Fatalf("error for custom fee recovery run")
+		t.Fatalf("error for minimum fee recovery run")
 	}
 	_ = wallet.ReturnCoins(spendables)
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -947,18 +947,18 @@ func (dcr *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes
 			dcr.feeRateLimit)
 	}
 
-	// Check wallet's fee rate limit against user defined custom fee rate
-	if ord.CustomSwapFeeRate != nil && dcr.feeRateLimit < *ord.CustomSwapFeeRate {
+	// Check wallet's fee rate limit against user defined minimum fee rate
+	if ord.MinSwapFeeRate != nil && dcr.feeRateLimit < *ord.MinSwapFeeRate {
 		return nil, nil, fmt.Errorf(
-			"%v: custom swap fee %v higher than configured fee rate limit %v",
+			"%v: minimum swap fee %v higher than configured fee rate limit %v",
 			ord.DEXConfig.Symbol,
-			*ord.CustomSwapFeeRate,
+			*ord.MinSwapFeeRate,
 			dcr.feeRateLimit)
 	}
 
 	var feeRate uint64
-	if ord.CustomSwapFeeRate != nil && *ord.CustomSwapFeeRate > ord.DEXConfig.MaxFeeRate {
-		feeRate = *ord.CustomSwapFeeRate
+	if ord.MinSwapFeeRate != nil && *ord.MinSwapFeeRate > ord.DEXConfig.MaxFeeRate {
+		feeRate = *ord.MinSwapFeeRate
 	} else {
 		feeRate = ord.DEXConfig.MaxFeeRate
 	}

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -852,8 +852,8 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("expected spendable of value %d, got %d", littleFunds, v)
 	}
 
-	// Test that little funds are needed without a custom swap rate, but then
-	// lotta funds are needed with the custom swap rate.
+	// Test that little funds are needed without a minimum swap rate, but then
+	// lotta funds are needed with the minimum swap rate.
 	setOrderValue(littleOrder)
 	spendables, _, err = wallet.FundOrder(ord)
 	if err != nil {
@@ -868,8 +868,8 @@ func TestAvailableFund(t *testing.T) {
 	}
 	_ = wallet.ReturnCoins(spendables)
 
-	customSwapFeeRate := ord.DEXConfig.MaxFeeRate + 1
-	ord.CustomSwapFeeRate = &customSwapFeeRate
+	minSwapFeeRate := ord.DEXConfig.MaxFeeRate + 1
+	ord.MinSwapFeeRate = &minSwapFeeRate
 	spendables, _, err = wallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error for funding order")
@@ -881,22 +881,22 @@ func TestAvailableFund(t *testing.T) {
 	if v != lottaFunds {
 		t.Fatalf("expected spendable of value %d, got %d", lottaFunds, v)
 	}
-	ord.CustomSwapFeeRate = nil
+	ord.MinSwapFeeRate = nil
 	_ = wallet.ReturnCoins(spendables)
 
-	// Error with cusom fee rate higher than wallet fee rate limit
-	customSwapFeeRate = wallet.feeRateLimit + 1
-	ord.CustomSwapFeeRate = &customSwapFeeRate
+	// Error with minimum fee rate higher than wallet fee rate limit
+	minSwapFeeRate = wallet.feeRateLimit + 1
+	ord.MinSwapFeeRate = &minSwapFeeRate
 	_, _, err = wallet.FundOrder(ord)
 	if err == nil {
 		t.Fatalf("no error for too high fee rate")
 	}
 
 	// Success again.
-	ord.CustomSwapFeeRate = nil
+	ord.MinSwapFeeRate = nil
 	spendables, _, err = wallet.FundOrder(ord)
 	if err != nil {
-		t.Fatalf("error for custom fee recovery run")
+		t.Fatalf("error for minimum fee recovery run")
 	}
 	_ = wallet.ReturnCoins(spendables)
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -852,6 +852,54 @@ func TestAvailableFund(t *testing.T) {
 		t.Fatalf("expected spendable of value %d, got %d", littleFunds, v)
 	}
 
+	// Test that little funds are needed without a custom swap rate, but then
+	// lotta funds are needed with the custom swap rate.
+	setOrderValue(littleOrder)
+	spendables, _, err = wallet.FundOrder(ord)
+	if err != nil {
+		t.Fatalf("error for funding order")
+	}
+	if len(spendables) != 1 {
+		t.Fatalf("only 1 coin expected but got %v", len(spendables))
+	}
+	v = spendables[0].Value()
+	if v != littleFunds {
+		t.Fatalf("expected spendable of value %d, got %d", littleFunds, v)
+	}
+	_ = wallet.ReturnCoins(spendables)
+
+	customSwapFeeRate := ord.DEXConfig.MaxFeeRate + 1
+	ord.CustomSwapFeeRate = &customSwapFeeRate
+	spendables, _, err = wallet.FundOrder(ord)
+	if err != nil {
+		t.Fatalf("error for funding order")
+	}
+	if len(spendables) != 1 {
+		t.Fatalf("only 1 coin expected but got %v", len(spendables))
+	}
+	v = spendables[0].Value()
+	if v != lottaFunds {
+		t.Fatalf("expected spendable of value %d, got %d", lottaFunds, v)
+	}
+	ord.CustomSwapFeeRate = nil
+	_ = wallet.ReturnCoins(spendables)
+
+	// Error with cusom fee rate higher than wallet fee rate limit
+	customSwapFeeRate = wallet.feeRateLimit + 1
+	ord.CustomSwapFeeRate = &customSwapFeeRate
+	_, _, err = wallet.FundOrder(ord)
+	if err == nil {
+		t.Fatalf("no error for too high fee rate")
+	}
+
+	// Success again.
+	ord.CustomSwapFeeRate = nil
+	spendables, _, err = wallet.FundOrder(ord)
+	if err != nil {
+		t.Fatalf("error for custom fee recovery run")
+	}
+	_ = wallet.ReturnCoins(spendables)
+
 	// Fund a lotta bit.
 	setOrderValue(lottaOrder)
 	spendables, _, err = wallet.FundOrder(ord)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -319,6 +319,9 @@ type Order struct {
 	// is used, the fee rate used should be at least the suggested fee, else
 	// zero-conf coins might be rejected.
 	FeeSuggestion uint64
+	// CustomSwapFeeRate is set by the user, and it is used as the fee rate for
+	// the swap transaction. It remains null if the user did not set a custom fee.
+	CustomSwapFeeRate *uint64
 }
 
 // SwapEstimate is an estimate of the fees and locked amounts associated with

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -319,9 +319,9 @@ type Order struct {
 	// is used, the fee rate used should be at least the suggested fee, else
 	// zero-conf coins might be rejected.
 	FeeSuggestion uint64
-	// CustomSwapFeeRate is set by the user, and it is used as the fee rate for
-	// the swap transaction. It remains null if the user did not set a custom fee.
-	CustomSwapFeeRate *uint64
+	// MinSwapFeeRate is set by the user, and it is used as the minimum fee rate for
+	// the swap transaction. It remains null if the user did not set a minimum fee.
+	MinSwapFeeRate *uint64
 }
 
 // SwapEstimate is an estimate of the fees and locked amounts associated with

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1377,6 +1377,10 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 		if match.FeeRateSwap > highestFeeRate {
 			highestFeeRate = match.FeeRateSwap
 		}
+		if t.metaData.CustomSwapFeeRate != nil &&
+			*t.metaData.CustomSwapFeeRate > highestFeeRate {
+			highestFeeRate = *t.metaData.CustomSwapFeeRate
+		}
 	}
 
 	lockChange := true

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1377,9 +1377,9 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 		if match.FeeRateSwap > highestFeeRate {
 			highestFeeRate = match.FeeRateSwap
 		}
-		if t.metaData.CustomSwapFeeRate != nil &&
-			*t.metaData.CustomSwapFeeRate > highestFeeRate {
-			highestFeeRate = *t.metaData.CustomSwapFeeRate
+		if t.metaData.MinSwapFeeRate != nil &&
+			*t.metaData.MinSwapFeeRate > highestFeeRate {
+			highestFeeRate = *t.metaData.MinSwapFeeRate
 		}
 	}
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -779,15 +779,15 @@ func (a *dexAccount) checkSig(msg []byte, sig []byte) error {
 
 // TradeForm is used to place a market or limit order
 type TradeForm struct {
-	Host              string  `json:"host"`
-	IsLimit           bool    `json:"isLimit"`
-	Sell              bool    `json:"sell"`
-	Base              uint32  `json:"base"`
-	Quote             uint32  `json:"quote"`
-	Qty               uint64  `json:"qty"`
-	Rate              uint64  `json:"rate"`
-	TifNow            bool    `json:"tifnow"`
-	CustomSwapFeeRate *uint64 `json:"customSwapFee,omitempty"`
+	Host           string  `json:"host"`
+	IsLimit        bool    `json:"isLimit"`
+	Sell           bool    `json:"sell"`
+	Base           uint32  `json:"base"`
+	Quote          uint32  `json:"quote"`
+	Qty            uint64  `json:"qty"`
+	Rate           uint64  `json:"rate"`
+	TifNow         bool    `json:"tifnow"`
+	MinSwapFeeRate *uint64 `json:"minSwapFeeRate,omitempty"`
 }
 
 // marketName is a string ID constructed from the asset IDs.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -779,14 +779,15 @@ func (a *dexAccount) checkSig(msg []byte, sig []byte) error {
 
 // TradeForm is used to place a market or limit order
 type TradeForm struct {
-	Host    string `json:"host"`
-	IsLimit bool   `json:"isLimit"`
-	Sell    bool   `json:"sell"`
-	Base    uint32 `json:"base"`
-	Quote   uint32 `json:"quote"`
-	Qty     uint64 `json:"qty"`
-	Rate    uint64 `json:"rate"`
-	TifNow  bool   `json:"tifnow"`
+	Host              string  `json:"host"`
+	IsLimit           bool    `json:"isLimit"`
+	Sell              bool    `json:"sell"`
+	Base              uint32  `json:"base"`
+	Quote             uint32  `json:"quote"`
+	Qty               uint64  `json:"qty"`
+	Rate              uint64  `json:"rate"`
+	TifNow            bool    `json:"tifnow"`
+	CustomSwapFeeRate *uint64 `json:"customSwapFee,omitempty"`
 }
 
 // marketName is a string ID constructed from the asset IDs.

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -83,7 +83,7 @@ var (
 	swapFeesKey            = []byte("swapFees")
 	maxFeeRateKey          = []byte("maxFeeRate")
 	redemptionFeesKey      = []byte("redeemFees")
-	customSwapFeeKey       = []byte("customswapfee")
+	minSwapFeeKey          = []byte("minSwapFee")
 	typeKey                = []byte("type")
 	credentialsBucket      = []byte("credentials")
 	encSeedKey             = []byte("encSeed")
@@ -587,15 +587,15 @@ func (db *BoltDB) UpdateOrder(m *dexdb.MetaOrder) error {
 			linkedB = md.LinkedOrder[:]
 		}
 
-		if md.CustomSwapFeeRate != nil {
+		if md.MinSwapFeeRate != nil {
 			err = newBucketPutter(oBkt).
-				put(customSwapFeeKey, uint64Bytes(*md.CustomSwapFeeRate)).
+				put(minSwapFeeKey, uint64Bytes(*md.MinSwapFeeRate)).
 				err()
 			if err != nil {
 				return err
 			}
 		} else {
-			oBkt.Delete(customSwapFeeKey)
+			oBkt.Delete(minSwapFeeKey)
 		}
 
 		return newBucketPutter(oBkt).
@@ -892,10 +892,10 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 		maxFeeRate = ^uint64(0) // should not happen for trade orders after v2 upgrade
 	}
 
-	var customSwapFeeRate *uint64
-	if customSwapFeeInDb := oBkt.Get(customSwapFeeKey); customSwapFeeInDb != nil {
-		fee := intCoder.Uint64(customSwapFeeInDb)
-		customSwapFeeRate = &fee
+	var minSwapFeeRate *uint64
+	if minSwapFeeInDb := oBkt.Get(minSwapFeeKey); minSwapFeeInDb != nil {
+		fee := intCoder.Uint64(minSwapFeeInDb)
+		minSwapFeeRate = &fee
 	}
 
 	return &dexdb.MetaOrder{
@@ -908,7 +908,7 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 			SwapFeesPaid:       intCoder.Uint64(oBkt.Get(swapFeesKey)),
 			MaxFeeRate:         maxFeeRate,
 			RedemptionFeesPaid: intCoder.Uint64(oBkt.Get(redemptionFeesKey)),
-			CustomSwapFeeRate:  customSwapFeeRate,
+			MinSwapFeeRate:     minSwapFeeRate,
 		},
 		Order: ord,
 	}, nil
@@ -971,15 +971,15 @@ func (db *BoltDB) UpdateOrderMetaData(oid order.OrderID, md *db.OrderMetaData) e
 			linkedB = md.LinkedOrder[:]
 		}
 
-		if md.CustomSwapFeeRate != nil {
+		if md.MinSwapFeeRate != nil {
 			err = newBucketPutter(oBkt).
-				put(customSwapFeeKey, uint64Bytes(*md.CustomSwapFeeRate)).
+				put(minSwapFeeKey, uint64Bytes(*md.MinSwapFeeRate)).
 				err()
 			if err != nil {
 				return err
 			}
 		} else {
-			oBkt.Delete(customSwapFeeKey)
+			oBkt.Delete(minSwapFeeKey)
 		}
 
 		return newBucketPutter(oBkt).

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -634,6 +634,31 @@ func TestOrders(t *testing.T) {
 	if err == nil {
 		t.Fatalf("no error encountered for updating unknown order's status")
 	}
+
+	// Update order to have custom swap fee rate and make sure it's persisted
+	customSwapFeeRate := uint64(100)
+	o := activeOrders[0]
+	o.MetaData.CustomSwapFeeRate = &customSwapFeeRate
+	boltdb.UpdateOrder(o)
+	mord, err = boltdb.Order(o.Order.ID())
+	if err != nil {
+		t.Fatalf("failed to retrieve order")
+	}
+	if *mord.MetaData.CustomSwapFeeRate != customSwapFeeRate {
+		t.Fatalf("failed to store custom fee rate")
+	}
+
+	// Remove custom swap fee and make sure it's persisted
+	md := o.MetaData
+	md.CustomSwapFeeRate = nil
+	boltdb.UpdateOrderMetaData(o.Order.ID(), md)
+	mord, err = boltdb.Order(o.Order.ID())
+	if err != nil {
+		t.Fatalf("failed to retrieve order")
+	}
+	if mord.MetaData.CustomSwapFeeRate != nil {
+		t.Fatalf("failed to delete custom fee rate")
+	}
 }
 
 func TestOrderFilters(t *testing.T) {

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -635,29 +635,29 @@ func TestOrders(t *testing.T) {
 		t.Fatalf("no error encountered for updating unknown order's status")
 	}
 
-	// Update order to have custom swap fee rate and make sure it's persisted
-	customSwapFeeRate := uint64(100)
+	// Update order to have minimum swap fee rate and make sure it's persisted
+	minSwapFeeRate := uint64(100)
 	o := activeOrders[0]
-	o.MetaData.CustomSwapFeeRate = &customSwapFeeRate
+	o.MetaData.MinSwapFeeRate = &minSwapFeeRate
 	boltdb.UpdateOrder(o)
 	mord, err = boltdb.Order(o.Order.ID())
 	if err != nil {
 		t.Fatalf("failed to retrieve order")
 	}
-	if *mord.MetaData.CustomSwapFeeRate != customSwapFeeRate {
-		t.Fatalf("failed to store custom fee rate")
+	if *mord.MetaData.MinSwapFeeRate != minSwapFeeRate {
+		t.Fatalf("failed to store minimum fee rate")
 	}
 
-	// Remove custom swap fee and make sure it's persisted
+	// Remove minimum swap fee and make sure it's persisted
 	md := o.MetaData
-	md.CustomSwapFeeRate = nil
+	md.MinSwapFeeRate = nil
 	boltdb.UpdateOrderMetaData(o.Order.ID(), md)
 	mord, err = boltdb.Order(o.Order.ID())
 	if err != nil {
 		t.Fatalf("failed to retrieve order")
 	}
-	if mord.MetaData.CustomSwapFeeRate != nil {
-		t.Fatalf("failed to delete custom fee rate")
+	if mord.MetaData.MinSwapFeeRate != nil {
+		t.Fatalf("failed to delete minimum fee rate")
 	}
 }
 

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -230,6 +230,9 @@ type OrderMetaData struct {
 	// MaxFeeRate is the dex.Asset.MaxFeeRate at the time of ordering. The rates
 	// assigned to matches will be validated against this value.
 	MaxFeeRate uint64
+	// CustomSwapFeeRate is set by the user, and it is used as the fee rate for
+	// the swap transaction. It remains null if the user did not set a custom fee.
+	CustomSwapFeeRate *uint64
 }
 
 // MetaMatch is a match and its metadata.

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -230,9 +230,9 @@ type OrderMetaData struct {
 	// MaxFeeRate is the dex.Asset.MaxFeeRate at the time of ordering. The rates
 	// assigned to matches will be validated against this value.
 	MaxFeeRate uint64
-	// CustomSwapFeeRate is set by the user, and it is used as the fee rate for
-	// the swap transaction. It remains null if the user did not set a custom fee.
-	CustomSwapFeeRate *uint64
+	// MinSwapFeeRate is set by the user, and it is used as the minimum fee rate for
+	// the swap transaction. It remains null if the user did not set a minimum fee.
+	MinSwapFeeRate *uint64
 }
 
 // MetaMatch is a match and its metadata.

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -850,7 +850,7 @@ Registration is complete after the fee transaction has been confirmed.`,
 	},
 	tradeRoute: {
 		pwArgsShort: `"appPass"`,
-		argsShort:   `"host" isLimit sell base quote qty rate immediate (customSwapFeeRate)`,
+		argsShort:   `"host" isLimit sell base quote qty rate immediate (minSwapFeeRate)`,
 		cmdSummary:  `Make an order to buy or sell an asset.`,
 		pwArgsLong: `Password Args:
     appPass (string): The DEX client password.`,
@@ -862,10 +862,13 @@ Registration is complete after the fee transaction has been confirmed.`,
     quote (int): The BIP-44 coin index for the market's quote asset.
     qty (int): The number of units to buy/sell. Must be a multiple of the lot size.
     rate (int): The atoms quote asset to pay/accept per unit base asset. e.g.
-	56000 satoshi/DCR for the DCR(base)_BTC(quote).
+      56000 satoshi/DCR for the DCR(base)_BTC(quote).
     immediate (bool): Require immediate match. Do not book the order.
-    customSwapFeeRate (int): Optional. Custom fee rate to use for swap transactions. The fee
-	may be higher if server's max fee rate is higher, but will never be lower.`,
+    minSwapFeeRate (int): Optional. Minimum fee rate to use for swap transactions. This
+      is used to set a higher fee rate than what might be prescribed by the server. The actual
+      fee may be higher if server's max fee rate is higher, but will never be lower. This fee
+      will be used for the asset you posess before the trade; i.e the base asset if sell=true or
+      the quote asset if sell=false.`,
 		returns: `Returns:
     obj: The order details.
     {

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -850,7 +850,7 @@ Registration is complete after the fee transaction has been confirmed.`,
 	},
 	tradeRoute: {
 		pwArgsShort: `"appPass"`,
-		argsShort:   `"host" isLimit sell base quote qty rate immediate`,
+		argsShort:   `"host" isLimit sell base quote qty rate immediate (customSwapFeeRate)`,
 		cmdSummary:  `Make an order to buy or sell an asset.`,
 		pwArgsLong: `Password Args:
     appPass (string): The DEX client password.`,
@@ -862,8 +862,10 @@ Registration is complete after the fee transaction has been confirmed.`,
     quote (int): The BIP-44 coin index for the market's quote asset.
     qty (int): The number of units to buy/sell. Must be a multiple of the lot size.
     rate (int): The atoms quote asset to pay/accept per unit base asset. e.g.
-      156000 satoshi/DCR for the DCR(base)_BTC(quote).
-    immediate (bool): Require immediate match. Do not book the order.`,
+	56000 satoshi/DCR for the DCR(base)_BTC(quote).
+    immediate (bool): Require immediate match. Do not book the order.
+    customSwapFeeRate (int): Optional. Custom fee rate to use for swap transactions. The fee
+	may be higher if server's max fee rate is higher, but will never be lower.`,
 		returns: `Returns:
     obj: The order details.
     {

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -361,26 +361,26 @@ func parseTradeArgs(params *RawParams) (*tradeForm, error) {
 	if err != nil {
 		return nil, err
 	}
-	var customSwapFeeRate *uint64
+	var minSwapFeeRate *uint64
 	if len(params.Args) > 8 {
-		fee, err := checkUIntArg(params.Args[8], "customSwapFeeRate", 64)
+		fee, err := checkUIntArg(params.Args[8], "minSwapFeeRate", 64)
 		if err != nil {
 			return nil, err
 		}
-		customSwapFeeRate = &fee
+		minSwapFeeRate = &fee
 	}
 	req := &tradeForm{
 		appPass: params.PWArgs[0],
 		srvForm: &core.TradeForm{
-			Host:              params.Args[0],
-			IsLimit:           isLimit,
-			Sell:              sell,
-			Base:              uint32(base),
-			Quote:             uint32(quote),
-			Qty:               qty,
-			Rate:              rate,
-			TifNow:            tifnow,
-			CustomSwapFeeRate: customSwapFeeRate,
+			Host:           params.Args[0],
+			IsLimit:        isLimit,
+			Sell:           sell,
+			Base:           uint32(base),
+			Quote:          uint32(quote),
+			Qty:            qty,
+			Rate:           rate,
+			TifNow:         tifnow,
+			MinSwapFeeRate: minSwapFeeRate,
 		},
 	}
 	return req, nil

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -330,7 +330,7 @@ func parseRegisterArgs(params *RawParams) (*core.RegisterForm, error) {
 }
 
 func parseTradeArgs(params *RawParams) (*tradeForm, error) {
-	if err := checkNArgs(params, []int{1}, []int{8}); err != nil {
+	if err := checkNArgs(params, []int{1}, []int{8, 9}); err != nil {
 		return nil, err
 	}
 	isLimit, err := checkBoolArg(params.Args[1], "isLimit")
@@ -361,17 +361,26 @@ func parseTradeArgs(params *RawParams) (*tradeForm, error) {
 	if err != nil {
 		return nil, err
 	}
+	var customSwapFeeRate *uint64
+	if len(params.Args) > 8 {
+		fee, err := checkUIntArg(params.Args[8], "customSwapFeeRate", 64)
+		if err != nil {
+			return nil, err
+		}
+		customSwapFeeRate = &fee
+	}
 	req := &tradeForm{
 		appPass: params.PWArgs[0],
 		srvForm: &core.TradeForm{
-			Host:    params.Args[0],
-			IsLimit: isLimit,
-			Sell:    sell,
-			Base:    uint32(base),
-			Quote:   uint32(quote),
-			Qty:     qty,
-			Rate:    rate,
-			TifNow:  tifnow,
+			Host:              params.Args[0],
+			IsLimit:           isLimit,
+			Sell:              sell,
+			Base:              uint32(base),
+			Quote:             uint32(quote),
+			Qty:               qty,
+			Rate:              rate,
+			TifNow:            tifnow,
+			CustomSwapFeeRate: customSwapFeeRate,
 		},
 	}
 	return req, nil


### PR DESCRIPTION
This PR adds the ability to specify a custom fee rate for swap transactions. The ability to specify it on the UI will be added in another PR. 

If the custom transaction fee is greater than the server's max transaction fee, then it will be the fee used in the transaction. A transaction fee less than the server's max transaction fee may also be specified, but in this case it acts as a minimum transaction fee. If in the match request sent from the server there is a higher fee rate than the one specified by the user, the higher fee will be used.