### PR TITLE
[0.3] dexc: comment eth import for release

### DIFF
--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -19,8 +19,12 @@ import (
 	_ "decred.org/dcrdex/client/asset/bch" // register bch asset
 	_ "decred.org/dcrdex/client/asset/btc" // register btc asset
 	_ "decred.org/dcrdex/client/asset/dcr" // register dcr asset
-	_ "decred.org/dcrdex/client/asset/eth" // register eth asset
 	_ "decred.org/dcrdex/client/asset/ltc" // register ltc asset
+
+	// ETH is commented to prevent go-ethereum goroutines from launching via
+	// it's init(). Uncomment this when ETH is ready:
+	// _ "decred.org/dcrdex/client/asset/eth" // register eth asset
+
 	"decred.org/dcrdex/client/cmd/dexc/version"
 	"decred.org/dcrdex/client/core"
 	"decred.org/dcrdex/client/rpcserver"


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1176

The base branch to which this PR applies will need to be changed when we branch `release-0.3`.  I'm putting this up now so I do not forget.