### PR TITLE
Fix max order UI.

### DIFF
--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -764,6 +764,10 @@ export default class MarketsPage extends BasePage {
       if (!app.checkResponse(res, true)) {
         console.warn('max order estimate not available:', res)
         page.maxFromLots.textContent = 'estimate unavailable'
+        if (this.maxLoaded) {
+          this.maxLoaded()
+          this.maxLoaded = null
+        }
         return
       }
       success(res)


### PR DESCRIPTION
There were multiple issues with the max order UI. There would be a console
error saying the the maxLoaded function was null. This would happen if there
were two concurrent requests where the one that started first finished last.
Also, if a cached value was input while a another value was being fetched,
the cached result would be overridden by the value being fetched from the
client causing a mismatch between the rate in the input box and the result
on the screen.

Closes #1169.