### PR TITLE
client/core: app seed optimisations

### DIFF
--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -39,8 +39,8 @@ func (s *WebServer) apiGetFee(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp, s.indent)
 }
 
-// apiPreRegister is the handler for the '/preregister' API request.
-func (s *WebServer) apiPreRegister(w http.ResponseWriter, r *http.Request) {
+// DiscoverAccount is the handler for the '/discoveracct' API request.
+func (s *WebServer) apiDiscoverAccount(w http.ResponseWriter, r *http.Request) {
 	form := new(registrationForm)
 	if !readPost(w, r, form) {
 		return
@@ -51,7 +51,7 @@ func (s *WebServer) apiPreRegister(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
 		return
 	}
-	exchangeInfo, paid, err := s.core.PreRegister(form.Addr, pass, cert)
+	exchangeInfo, paid, err := s.core.DiscoverAccount(form.Addr, pass, cert)
 	if err != nil {
 		s.writeAPIError(w, err)
 		return

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -397,8 +397,8 @@ func (c *TCore) GetDEXConfig(host string, certI interface{}) (*core.Exchange, er
 	return tExchanges[host], nil
 }
 
-// PreRegister - use secondDEX = "thisdexwithalongname.com" to get paid = true.
-func (c *TCore) PreRegister(dexAddr string, pw []byte, certI interface{}) (*core.Exchange, bool, error) {
+// DiscoverAccount - use secondDEX = "thisdexwithalongname.com" to get paid = true.
+func (c *TCore) DiscoverAccount(dexAddr string, pw []byte, certI interface{}) (*core.Exchange, bool, error) {
 	xc := tExchanges[dexAddr]
 	if xc == nil {
 		xc = tExchanges[firstDEX]

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -506,7 +506,7 @@ export class DEXAddressForm {
 
     const loaded = app.loading(this.form)
 
-    const res = await postJSON('/api/preregister', {
+    const res = await postJSON('/api/discoveracct', {
       addr: addr,
       cert: cert,
       pass: pw

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -93,7 +93,7 @@ type clientCore interface {
 	User() *core.User
 	GetFee(url string, cert interface{}) (uint64, error)
 	GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error)
-	PreRegister(dexAddr string, pass []byte, certI interface{}) (*core.Exchange, bool, error)
+	DiscoverAccount(dexAddr string, pass []byte, certI interface{}) (*core.Exchange, bool, error)
 	SupportedAssets() map[uint32]*core.SupportedAsset
 	Withdraw(pw []byte, assetID uint32, value uint64, address string) (asset.Coin, error)
 	Trade(pw []byte, form *core.TradeForm) (*core.Order, error)
@@ -300,7 +300,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiInit.Post("/login", s.apiLogin)
 			apiInit.Post("/getfee", s.apiGetFee)
 			apiInit.Post("/getdexinfo", s.apiGetDEXInfo)
-			apiInit.Post("/preregister", s.apiPreRegister)
+			apiInit.Post("/discoveracct", s.apiDiscoverAccount)
 		})
 
 		r.Group(func(apiAuth chi.Router) {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -79,7 +79,7 @@ func (c *TCore) GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange,
 	return nil, c.getFeeErr // TODO along with test for apiUser / Exchanges() / User()
 }
 
-func (c *TCore) PreRegister(dexAddr string, pw []byte, certI interface{}) (*core.Exchange, bool, error) {
+func (c *TCore) DiscoverAccount(dexAddr string, pw []byte, certI interface{}) (*core.Exchange, bool, error) {
 	return nil, false, nil
 }
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }


### PR DESCRIPTION
Primarily resolves #1172.

Also splits `core.register` into `core.registerHD` and `core.registerLegacy`. `core.PreRegister` now only attempts HD account registration to determine if an account exists and can be restored.