### PR TITLE
eth/client: Implement MaxOrder

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -307,9 +307,7 @@ func (eth *ExchangeWallet) MaxOrder(lotSize uint64, feeSuggestion uint64, nfo *d
 	now := time.Now().Unix()
 	var secretHash [32]byte
 	copy(secretHash[:], encode.RandomBytes(32))
-	// TODO: replace with configured contract address
-	contractAddress := common.HexToAddress("2f68e723b8989ba1c6a9f03e42f33cb7dc9d606f")
-	initGas, err := eth.node.initiateGas(eth.ctx, now, secretHash, &eth.acct.Address, &contractAddress)
+	initGas, err := eth.node.initiateGas(eth.ctx, now, secretHash, &eth.acct.Address, &mainnetContractAddr)
 	if err != nil {
 		eth.log.Warnf("error getting init gas, falling back to server's value: %v", err)
 		initGas = nfo.SwapSize

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -40,6 +40,8 @@ const (
 	BipID              = 60
 	defaultGasFee      = 82  // gwei
 	defaultGasFeeLimit = 200 // gwei
+
+	RedeemGas = 63000 // gas
 )
 
 var (

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -121,7 +121,7 @@ type ethFetcher interface {
 	importAccount(pw string, privKeyB []byte) (*accounts.Account, error)
 	listWallets(ctx context.Context) ([]rawWallet, error)
 	initiate(opts *bind.TransactOpts, netID int64, refundTimestamp int64, secretHash [32]byte, participant *common.Address) (*types.Transaction, error)
-	initiateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
+	estimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)
 	lock(ctx context.Context, acct *accounts.Account) error
 	nodeInfo(ctx context.Context) (*p2p.NodeInfo, error)
 	pendingTransactions(ctx context.Context) ([]*types.Transaction, error)
@@ -316,7 +316,7 @@ func (eth *ExchangeWallet) getInitGas() (uint64, error) {
 		Gas:   0,
 		Data:  data,
 	}
-	return eth.node.initiateGas(eth.ctx, msg)
+	return eth.node.estimateGas(eth.ctx, msg)
 }
 
 // MaxOrder generates information about the maximum order size and associated

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -299,22 +299,22 @@ func (eth *ExchangeWallet) Balance() (*asset.Balance, error) {
 
 // getInitGas gets an estimate for the gas required for initiating a swap.
 func (eth *ExchangeWallet) getInitGas() (uint64, error) {
-	now := time.Now().Unix()
 	var secretHash [32]byte
 	copy(secretHash[:], encode.RandomBytes(32))
 	parsedAbi, err := abi.JSON(strings.NewReader(swap.ETHSwapABI))
 	if err != nil {
 		return 0, err
 	}
-	data, err := parsedAbi.Pack("initiate", big.NewInt(now), secretHash, &eth.acct.Address)
+	data, err := parsedAbi.Pack("initiate", big.NewInt(1), secretHash, &eth.acct.Address)
 	if err != nil {
 		return 0, err
 	}
 	msg := ethereum.CallMsg{
-		From: eth.acct.Address,
-		To:   &mainnetContractAddr,
-		Gas:  0,
-		Data: data,
+		From:  eth.acct.Address,
+		To:    &mainnetContractAddr,
+		Value: big.NewInt(1),
+		Gas:   0,
+		Data:  data,
 	}
 	return eth.node.initiateGas(eth.ctx, msg)
 }

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -119,7 +119,7 @@ func (n *testNode) transactionReceipt(ctx context.Context, txHash common.Hash) (
 func (n *testNode) peers(ctx context.Context) ([]*p2p.PeerInfo, error) {
 	return n.peerInfo, n.peersErr
 }
-func (n *testNode) initiateGas(ctx context.Context, refundTimestamp int64, secretHash [32]byte, participant *common.Address, contractAddress *common.Address) (uint64, error) {
+func (n *testNode) initiateGas(ctx context.Context, callMsg ethereum.CallMsg) (uint64, error) {
 	return n.initGas, n.initGasErr
 }
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -119,7 +119,7 @@ func (n *testNode) transactionReceipt(ctx context.Context, txHash common.Hash) (
 func (n *testNode) peers(ctx context.Context) ([]*p2p.PeerInfo, error) {
 	return n.peerInfo, n.peersErr
 }
-func (n *testNode) initiateGas(ctx context.Context, callMsg ethereum.CallMsg) (uint64, error) {
+func (n *testNode) estimateGas(ctx context.Context, callMsg ethereum.CallMsg) (uint64, error) {
 	return n.initGas, n.initGasErr
 }
 

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -256,13 +256,8 @@ func (c *rpcclient) initiate(txOpts *bind.TransactOpts, netID int64, refundTimes
 	return c.es.Initiate(txOpts, big.NewInt(refundTimestamp), secretHash, *participant)
 }
 
-// initiateGas checks the amount of gas that is used for a call to the initiate function.
-func (c *rpcclient) initiateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
-	return c.ec.EstimateGas(ctx, msg)
-}
-
-// redeemGas checks the amount of gas that is used for a call to the redeem function.
-func (c *rpcclient) redeemGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+// estimateGas checks the amount of gas that is used for a function call.
+func (c *rpcclient) estimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
 	return c.ec.EstimateGas(ctx, msg)
 }
 

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -7,12 +7,10 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"strings"
 
 	swap "decred.org/dcrdex/dex/networks/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
@@ -259,53 +257,13 @@ func (c *rpcclient) initiate(txOpts *bind.TransactOpts, netID int64, refundTimes
 }
 
 // initiateGas checks the amount of gas that is used for a call to the initiate function.
-func (c *rpcclient) initiateGas(ctx context.Context, refundTimestamp int64, secretHash [32]byte, participant *common.Address, contractAddress *common.Address) (uint64, error) {
-	parsedAbi, err := abi.JSON(strings.NewReader(swap.ETHSwapABI))
-	if err != nil {
-		return 0, err
-	}
-	data, err := parsedAbi.Pack("initiate", big.NewInt(refundTimestamp), secretHash, participant)
-	if err != nil {
-		return 0, err
-	}
-	msg := ethereum.CallMsg{
-		From:  *participant,
-		To:    contractAddress,
-		Gas:   0,
-		Value: big.NewInt(1),
-		Data:  data,
-	}
-	gas, err := c.ec.EstimateGas(ctx, msg)
-	if err != nil {
-		return 0, err
-	}
-
-	return gas, nil
+func (c *rpcclient) initiateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	return c.ec.EstimateGas(ctx, msg)
 }
 
 // redeemGas checks the amount of gas that is used for a call to the redeem function.
-func (c *rpcclient) redeemGas(ctx context.Context, secret, secretHash [32]byte, participant *common.Address, contractAddress *common.Address) (uint64, error) {
-	parsedAbi, err := abi.JSON(strings.NewReader(swap.ETHSwapABI))
-	if err != nil {
-		return 0, err
-	}
-
-	data, err := parsedAbi.Pack("redeem", secret, secretHash)
-	if err != nil {
-		return 0, err
-	}
-	msg := ethereum.CallMsg{
-		From: *participant,
-		To:   contractAddress,
-		Gas:  0,
-		Data: data,
-	}
-	gas, err := c.ec.EstimateGas(ctx, msg)
-	if err != nil {
-		return 0, err
-	}
-
-	return gas, nil
+func (c *rpcclient) redeemGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
+	return c.ec.EstimateGas(ctx, msg)
 }
 
 // redeem redeems a swap contract. The redeemer will be the account at txOpts.From.

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 
 	swap "decred.org/dcrdex/dex/networks/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
@@ -254,6 +256,56 @@ func (c *rpcclient) initiate(txOpts *bind.TransactOpts, netID int64, refundTimes
 		return nil, err
 	}
 	return c.es.Initiate(txOpts, big.NewInt(refundTimestamp), secretHash, *participant)
+}
+
+// initiateGas checks the amount of gas that is used for a call to the initiate function.
+func (c *rpcclient) initiateGas(ctx context.Context, refundTimestamp int64, secretHash [32]byte, participant *common.Address, contractAddress *common.Address) (uint64, error) {
+	parsedAbi, err := abi.JSON(strings.NewReader(swap.ETHSwapABI))
+	if err != nil {
+		return 0, err
+	}
+	data, err := parsedAbi.Pack("initiate", big.NewInt(refundTimestamp), secretHash, participant)
+	if err != nil {
+		return 0, err
+	}
+	msg := ethereum.CallMsg{
+		From:  *participant,
+		To:    contractAddress,
+		Gas:   0,
+		Value: big.NewInt(1),
+		Data:  data,
+	}
+	gas, err := c.ec.EstimateGas(ctx, msg)
+	if err != nil {
+		return 0, err
+	}
+
+	return gas, nil
+}
+
+// redeemGas checks the amount of gas that is used for a call to the redeem function.
+func (c *rpcclient) redeemGas(ctx context.Context, secret, secretHash [32]byte, participant *common.Address, contractAddress *common.Address) (uint64, error) {
+	parsedAbi, err := abi.JSON(strings.NewReader(swap.ETHSwapABI))
+	if err != nil {
+		return 0, err
+	}
+
+	data, err := parsedAbi.Pack("redeem", secret, secretHash)
+	if err != nil {
+		return 0, err
+	}
+	msg := ethereum.CallMsg{
+		From: *participant,
+		To:   contractAddress,
+		Gas:  0,
+		Data: data,
+	}
+	gas, err := c.ec.EstimateGas(ctx, msg)
+	if err != nil {
+		return 0, err
+	}
+
+	return gas, nil
 }
 
 // redeem redeems a swap contract. The redeemer will be the account at txOpts.From.

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -377,22 +377,22 @@ func TestPeers(t *testing.T) {
 }
 
 func TestInitiateGas(t *testing.T) {
-	now := time.Now().Unix()
 	var secretHash [32]byte
 	copy(secretHash[:], encode.RandomBytes(32))
 	parsedAbi, err := abi.JSON(strings.NewReader(swap.ETHSwapABI))
 	if err != nil {
 		t.Fatalf("unexpected error parsing abi: %v", err)
 	}
-	data, err := parsedAbi.Pack("initiate", big.NewInt(now), secretHash, &participantAddr)
+	data, err := parsedAbi.Pack("initiate", big.NewInt(1), secretHash, &participantAddr)
 	if err != nil {
 		t.Fatalf("unexpected error packing abi: %v", err)
 	}
 	msg := ethereum.CallMsg{
-		From: participantAddr,
-		To:   &contractAddr,
-		Gas:  0,
-		Data: data,
+		From:  participantAddr,
+		To:    &contractAddr,
+		Value: big.NewInt(1),
+		Gas:   0,
+		Data:  data,
 	}
 	gas, err := ethClient.initiateGas(ctx, msg)
 	if err != nil {

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -372,6 +372,23 @@ func TestPeers(t *testing.T) {
 	spew.Dump(peers)
 }
 
+func TestInitiateGas(t *testing.T) {
+	now := time.Now().Unix()
+	var secretHash [32]byte
+	copy(secretHash[:], encode.RandomBytes(32))
+	gas, err := ethClient.initiateGas(ctx, now, secretHash, &participantAddr, &contractAddr)
+	if err != nil {
+		t.Fatalf("unexpected error from initiateGas: %v", err)
+	}
+	if gas > eth.InitGas {
+		t.Fatalf("actual gas %v is greater than eth.InitGas %v", gas, eth.InitGas)
+	}
+	if gas+10000 < eth.InitGas {
+		t.Fatalf("actual gas %v is much less than eth.InitGas %v", gas, eth.InitGas)
+	}
+	fmt.Printf("Gas used for initiate: %v \n", gas)
+}
+
 func TestInitiate(t *testing.T) {
 	now := time.Now().Unix()
 	var secretHash [32]byte
@@ -456,6 +473,33 @@ func TestInitiate(t *testing.T) {
 			t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, test.finalState, state)
 		}
 	}
+}
+
+func TestRedeemGas(t *testing.T) {
+	now := time.Now().Unix()
+	amt := big.NewInt(1e18)
+	txOpts := newTxOpts(ctx, &simnetAddr, amt)
+	var secret [32]byte
+	copy(secret[:], encode.RandomBytes(32))
+	secretHash := sha256.Sum256(secret[:])
+	_, err := ethClient.initiate(txOpts, simnetID, now, secretHash, &participantAddr)
+	if err != nil {
+		t.Fatalf("Unable to initiate swap: %v ", err)
+	}
+	if err := waitForMined(t, time.Second*8, true); err != nil {
+		t.Fatalf("unexpected error while waiting to mine: %v", err)
+	}
+	gas, err := ethClient.redeemGas(ctx, secret, secretHash, &participantAddr, &contractAddr)
+	if err != nil {
+		t.Fatalf("Error getting gas for redeem function: %v", err)
+	}
+	if gas > eth.RedeemGas {
+		t.Fatalf("actual gas %v is greater than eth.RedeemGas %v", gas, eth.RedeemGas)
+	}
+	if gas+3000 < eth.RedeemGas {
+		t.Fatalf("actual gas %v is much less than eth.RedeemGas %v", gas, eth.InitGas)
+	}
+	fmt.Printf("Gas used for redeem: %v \n", gas)
 }
 
 func TestRedeem(t *testing.T) {

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -493,11 +493,11 @@ func TestRedeemGas(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting gas for redeem function: %v", err)
 	}
-	if gas > eth.RedeemGas {
-		t.Fatalf("actual gas %v is greater than eth.RedeemGas %v", gas, eth.RedeemGas)
+	if gas > RedeemGas {
+		t.Fatalf("actual gas %v is greater than RedeemGas %v", gas, RedeemGas)
 	}
-	if gas+3000 < eth.RedeemGas {
-		t.Fatalf("actual gas %v is much less than eth.RedeemGas %v", gas, eth.InitGas)
+	if gas+3000 < RedeemGas {
+		t.Fatalf("actual gas %v is much less than RedeemGas %v", gas, RedeemGas)
 	}
 	fmt.Printf("Gas used for redeem: %v \n", gas)
 }

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -394,9 +394,9 @@ func TestInitiateGas(t *testing.T) {
 		Gas:   0,
 		Data:  data,
 	}
-	gas, err := ethClient.initiateGas(ctx, msg)
+	gas, err := ethClient.estimateGas(ctx, msg)
 	if err != nil {
-		t.Fatalf("unexpected error from initiateGas: %v", err)
+		t.Fatalf("unexpected error from estimateGas: %v", err)
 	}
 	if gas > eth.InitGas {
 		t.Fatalf("actual gas %v is greater than eth.InitGas %v", gas, eth.InitGas)
@@ -522,9 +522,9 @@ func TestRedeemGas(t *testing.T) {
 		Gas:  0,
 		Data: data,
 	}
-	gas, err := ethClient.redeemGas(ctx, msg)
+	gas, err := ethClient.estimateGas(ctx, msg)
 	if err != nil {
-		t.Fatalf("Error getting gas for redeem function: %v", err)
+		t.Fatalf("Error estimating gas for redeem function: %v", err)
 	}
 	if gas > RedeemGas {
 		t.Fatalf("actual gas %v is greater than RedeemGas %v", gas, RedeemGas)

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -74,8 +74,6 @@ const (
 	// TODO: When the contract is solidified, break down evm functions
 	// called and the gas used for each. (◍•﹏•)
 	InitGas = 180000 // gas
-
-	RedeemGas = 63000 // gas
 )
 
 // ToGwei converts a *big.Int in wei (1e18 unit) to gwei (1e9 unit) as a uint64.

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -74,6 +74,8 @@ const (
 	// TODO: When the contract is solidified, break down evm functions
 	// called and the gas used for each. (◍•﹏•)
 	InitGas = 180000 // gas
+
+	RedeemGas = 63000 // gas
 )
 
 // ToGwei converts a *big.Int in wei (1e18 unit) to gwei (1e9 unit) as a uint64.


### PR DESCRIPTION
This diff completes the MaxOrder function for ETH and also adds
functions that calculate the gas needed for initializing and
redeeming a swap on ETH. The gas calculation is function is used
in MaxOrder, but in case of a calculation failure, the hardcoded
gas value that is returned from the server is used.

Part of #1154