### PR TITLE
client/eth: Add functions for estimating gas usage

### DIFF
--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -293,6 +293,32 @@ func (c *rpcclient) initiateGas(ctx context.Context, contractAddress *common.Add
 	return gas, nil
 }
 
+// initiateGas checks the amount of gas that is used for a call to the redeem function.
+func (c *rpcclient) redeemGas(ctx context.Context, secret, secretHash [32]byte, participant *common.Address, contractAddress *common.Address) (uint64, error) {
+	parsedAbi, err := abi.JSON(strings.NewReader(swap.ETHSwapABI))
+	if err != nil {
+		return 0, err
+	}
+
+	data, err := parsedAbi.Pack("redeem", secret, secretHash)
+	if err != nil {
+		return 0, nil
+	}
+
+	msg := ethereum.CallMsg{
+		From: *participant,
+		To:   contractAddress,
+		Gas:  0,
+		Data: data,
+	}
+	gas, err := c.ec.EstimateGas(ctx, msg)
+	if err != nil {
+		return 0, err
+	}
+
+	return gas, nil
+}
+
 // redeem redeems a swap contract. The redeemer will be the account at txOpts.From.
 // Any on-chain failure, such as this secret not matching the hash, will not cause
 // this to error.

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -13,6 +13,7 @@ import (
 
 	"decred.org/dcrdex/dex/encode"
 	swap "decred.org/dcrdex/dex/networks/eth"
+	dexeth "decred.org/dcrdex/server/asset/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -282,7 +283,7 @@ func (c *rpcclient) initiateGas(ctx context.Context, contractAddress *common.Add
 		From:  participant,
 		To:    contractAddress,
 		Gas:   0,
-		Value: big.NewInt(100000000),
+		Value: big.NewInt(dexeth.GweiFactor),
 		Data:  data,
 	}
 	gas, err := c.ec.EstimateGas(ctx, msg)

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -379,7 +379,7 @@ func TestInitiateGas(t *testing.T) {
 	if gas+10000 < eth.InitGas {
 		t.Fatalf("actual gas %v is much less than eth.InitGas %v", gas, eth.InitGas)
 	}
-	fmt.Printf("Gas used for initiate: %v", gas)
+	fmt.Printf("Gas used for initiate: %v \n", gas)
 }
 
 func TestInitiate(t *testing.T) {
@@ -490,7 +490,7 @@ func TestRedeemGas(t *testing.T) {
 		t.Fatalf("actual gas %v is greater than eth.RedeemGas %v", gas, eth.RedeemGas)
 	}
 	if gas+3000 < eth.RedeemGas {
-		t.Fatalf("actual gas %v is much less than eth.InitGas %v", gas, eth.InitGas)
+		t.Fatalf("actual gas %v is much less than eth.RedeemGas %v", gas, eth.InitGas)
 	}
 	fmt.Printf("Gas used for redeem: %v \n", gas)
 }

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -368,6 +368,23 @@ func TestPeers(t *testing.T) {
 	spew.Dump(peers)
 }
 
+func TestInitiateGas(t *testing.T) {
+	gas, err := ethClient.initiateGas(ctx, &contractAddr)
+	if err != nil {
+		t.Fatalf("unexpected error from initiateGas: %v", err)
+	}
+
+	if gas > eth.InitGas {
+		t.Fatalf("actual gas %v is greater than eth.InitGas %v", gas, eth.InitGas)
+	}
+
+	if gas+10000 < eth.InitGas {
+		t.Fatalf("actual gas %v is much less than eth.InitGas %v", gas, eth.InitGas)
+	}
+
+	fmt.Sprintf("Gas used for initiate: %v", gas)
+}
+
 func TestInitiate(t *testing.T) {
 	now := time.Now().Unix()
 	var secretHash [32]byte

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -74,6 +74,8 @@ const (
 	// TODO: When the contract is solidified, break down evm functions
 	// called and the gas used for each. (◍•﹏•)
 	InitGas = 180000 // gas
+
+	RedeemGas = 63000
 )
 
 // ToGwei converts a *big.Int in wei (1e18 unit) to gwei (1e9 unit) as a uint64.

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -75,7 +75,7 @@ const (
 	// called and the gas used for each. (◍•﹏•)
 	InitGas = 180000 // gas
 
-	RedeemGas = 63000
+	RedeemGas = 63000 // gas
 )
 
 // ToGwei converts a *big.Int in wei (1e18 unit) to gwei (1e9 unit) as a uint64.


### PR DESCRIPTION
Adds functions to the rpcclient that estimate how much gas would be used to initiate/redeem a swap. They are currently only used in the rpcclient_harness_test to make sure that the hardcoded values for gas are accurate.