### PR TITLE
client/db: export CandleCache candles

### DIFF
--- a/server/db/candles.go
+++ b/server/db/candles.go
@@ -30,17 +30,17 @@ type Candle struct {
 // re-allocations.
 type CandleCache struct {
 	Candles []Candle
+	BinSize uint64
 	cap     int
 	// cursor will be the index of the last inserted candle.
-	cursor  int
-	binSize uint64
+	cursor int
 }
 
 // NewCandleCache is a constructor for a CandleCache.
 func NewCandleCache(cap int, binSize uint64) *CandleCache {
 	return &CandleCache{
 		cap:     cap,
-		binSize: binSize,
+		BinSize: binSize,
 	}
 }
 
@@ -135,7 +135,7 @@ func (c *CandleCache) last() *Candle {
 // combineCandles attempts to add the candidate candle to the target candle
 // in-place, if they're in the same bin, otherwise returns false.
 func (c *CandleCache) combineCandles(target, candidate *Candle) bool {
-	if target.EndStamp/c.binSize != candidate.EndStamp/c.binSize {
+	if target.EndStamp/c.BinSize != candidate.EndStamp/c.BinSize {
 		// The candidate candle cannot be added.
 		return false
 	}

--- a/server/db/candles.go
+++ b/server/db/candles.go
@@ -29,7 +29,7 @@ type Candle struct {
 // slice until it reaches capacity, when it becomes a "circular array" to avoid
 // re-allocations.
 type CandleCache struct {
-	candles []Candle
+	Candles []Candle
 	cap     int
 	// cursor will be the index of the last inserted candle.
 	cursor  int
@@ -48,9 +48,9 @@ func NewCandleCache(cap int, binSize uint64) *CandleCache {
 // responsible to ensure that candles added with Add are always newer than
 // the last candle added.
 func (c *CandleCache) Add(candle *Candle) {
-	sz := len(c.candles)
+	sz := len(c.Candles)
 	if sz == 0 {
-		c.candles = append(c.candles, *candle)
+		c.Candles = append(c.Candles, *candle)
 		return
 	}
 	if c.combineCandles(c.last(), candle) {
@@ -58,10 +58,10 @@ func (c *CandleCache) Add(candle *Candle) {
 	}
 	if sz == c.cap { // circular mode
 		c.cursor = (c.cursor + 1) % c.cap
-		c.candles[c.cursor] = *candle
+		c.Candles[c.cursor] = *candle
 		return
 	}
-	c.candles = append(c.candles, *candle)
+	c.Candles = append(c.Candles, *candle)
 	c.cursor = sz // len(c.candles) - 1
 }
 
@@ -70,13 +70,13 @@ func (c *CandleCache) Add(candle *Candle) {
 // those available will be returned, with no indication of error.
 func (c *CandleCache) WireCandles(count int) *msgjson.WireCandles {
 	n := count
-	sz := len(c.candles)
+	sz := len(c.Candles)
 	if sz < n {
 		n = sz
 	}
 	wc := msgjson.NewWireCandles(n)
 	for i := sz - n; i < sz; i++ {
-		candle := &c.candles[(c.cursor+1+i)%sz]
+		candle := &c.Candles[(c.cursor+1+i)%sz]
 		wc.StartStamps = append(wc.StartStamps, candle.StartStamp)
 		wc.EndStamps = append(wc.EndStamps, candle.EndStamp)
 		wc.MatchVolumes = append(wc.MatchVolumes, candle.MatchVolume)
@@ -98,14 +98,14 @@ func (c *CandleCache) WireCandles(count int) *msgjson.WireCandles {
 // be of little value.
 func (c *CandleCache) Delta(since time.Time) (changePct float64, vol uint64) {
 	cutoff := encode.UnixMilliU(since)
-	sz := len(c.candles)
+	sz := len(c.Candles)
 	if sz == 0 {
 		return 0, 0
 	}
 	endRate := c.last().EndRate
 	var startRate uint64
 	for i := 0; i < sz; i++ {
-		candle := &c.candles[(c.cursor+sz-i)%sz]
+		candle := &c.Candles[(c.cursor+sz-i)%sz]
 		if candle.EndStamp <= cutoff {
 			break
 		} else if candle.StartStamp <= cutoff {
@@ -129,7 +129,7 @@ func (c *CandleCache) Delta(since time.Time) (changePct float64, vol uint64) {
 
 // last gets the most recent candle in the cache.
 func (c *CandleCache) last() *Candle {
-	return &c.candles[c.cursor]
+	return &c.Candles[c.cursor]
 }
 
 // combineCandles attempts to add the candidate candle to the target candle

--- a/server/db/candles_test.go
+++ b/server/db/candles_test.go
@@ -17,8 +17,8 @@ func TestCandleCache(t *testing.T) {
 	const cacheCapacity = 5
 	cache := NewCandleCache(cacheCapacity, binSize)
 
-	if cache.binSize != binSize {
-		t.Fatalf("wrong bin size. wanted %d, got %d", binSize, cache.binSize)
+	if cache.BinSize != binSize {
+		t.Fatalf("wrong bin size. wanted %d, got %d", binSize, cache.BinSize)
 	}
 
 	makeCandle := func(startStamp, endStamp, matchVol, quoteVol, bookVol, startRate, endRate, lowRate, highRate uint64) *Candle {

--- a/server/db/candles_test.go
+++ b/server/db/candles_test.go
@@ -72,7 +72,7 @@ func TestCandleCache(t *testing.T) {
 
 	// Check basic functionality.
 	cache.Add(makeCandle(11, 12, 100, 101, 100, 100, 100, 50, 150)) // start rate 100
-	if len(cache.candles) != 1 {
+	if len(cache.Candles) != 1 {
 		t.Fatalf("Add didn't add")
 	}
 	lastCandle := cache.last()
@@ -87,7 +87,7 @@ func TestCandleCache(t *testing.T) {
 	cache.Add(makeCandle(12, 13, 100, 101, 100, 100, 100, 25, 100)) // low rate 25
 	cache.Add(makeCandle(13, 14, 100, 101, 100, 100, 100, 50, 200)) // high rate 200
 	cache.Add(makeCandle(14, 15, 100, 101, 150, 100, 125, 50, 100)) // end book volume 150, end rate 125
-	if len(cache.candles) != 1 {
+	if len(cache.Candles) != 1 {
 		t.Fatalf("Add didn't add")
 	}
 	checkCandleStamps(cache.last(), 11, 15)
@@ -97,7 +97,7 @@ func TestCandleCache(t *testing.T) {
 	// Two candles each in a new bin.
 	cache.Add(makeCandle(25, 27, 10, 11, 12, 13, 14, 15, 16))
 	cache.Add(makeCandle(41, 48, 17, 18, 19, 20, 21, 22, 23))
-	if len(cache.candles) != 3 {
+	if len(cache.Candles) != 3 {
 		t.Fatalf("New candles didn't add")
 	}
 	checkCandleStamps(cache.last(), 41, 48)
@@ -106,19 +106,19 @@ func TestCandleCache(t *testing.T) {
 
 	// Candle combination is based on end stamp only.
 	cache.Add(makeCandle(49, 51, 24, 25, 26, 27, 28, 29, 30))
-	if len(cache.candles) != 4 {
+	if len(cache.Candles) != 4 {
 		t.Fatalf("straddling candle didn't create new entry")
 	}
 
 	// Adding two more should only increase length by 1, since capacity is 5.
 	cache.Add(makeCandle(61, 69, 24, 25, 26, 27, 28, 29, 30))
 	cache.Add(makeCandle(71, 79, 54321, 25, 26, 27, 28, 29, 30))
-	if len(cache.candles) != cacheCapacity {
-		t.Fatalf("cache size not at capacity. wanted %d, found %d", cacheCapacity, len(cache.candles))
+	if len(cache.Candles) != cacheCapacity {
+		t.Fatalf("cache size not at capacity. wanted %d, found %d", cacheCapacity, len(cache.Candles))
 	}
 	// The cache becomes circular, so the most recent will be at the previously
 	// oldest index, 0.
-	if cache.last() != &cache.candles[0] {
+	if cache.last() != &cache.Candles[0] {
 		t.Fatalf("cache didn't wrap")
 	}
 


### PR DESCRIPTION
`CandleCache` is designed to be used by clients, who may want access to the cached candles directly. Currently the only way to access the data is with `WireCandles`, which is not always efficient. Both dcrdata's `ExchangeBot` and dexc will benefit from having the candles exported.