### PR TITLE
webserver: retranslate template when --reload-html is used

### DIFF
--- a/client/webserver/locales/parse.go
+++ b/client/webserver/locales/parse.go
@@ -1,0 +1,13 @@
+package locales
+
+import "regexp"
+
+var keyRegExp = regexp.MustCompile(`\[\[\[([a-zA-Z0-9 _.-]+)\]\]\]`)
+
+// Tokens returns a slice of tuples (token, key), where token is just key with
+// triple square brackets, and could also be constructed simply as
+// "[[[" + key + "]]]"". The key is the lookup key for the Locales map. The
+// token is what must be replaced in the raw template.
+func Tokens(tmpl []byte) [][][]byte {
+	return keyRegExp.FindAllSubmatch(tmpl, -1)
+}

--- a/client/webserver/site/template-builder/main.go
+++ b/client/webserver/site/template-builder/main.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	"decred.org/dcrdex/client/webserver/locales"
 )
 
 var (
 	workingDirectory, _ = os.Getwd()
-	keyRegExp           = regexp.MustCompile(`\[\[\[([a-zA-Z0-9 _.-]+)\]\]\]`)
 )
 
 func main() {
@@ -65,8 +63,7 @@ func main() {
 			localizedTemplates[lang] = tmpl
 		}
 
-		matchGroups := keyRegExp.FindAllSubmatch(rawTmpl, -1)
-		for _, matchGroup := range matchGroups {
+		for _, matchGroup := range locales.Tokens(rawTmpl) {
 			if len(matchGroup) != 2 {
 				return fmt.Errorf("can't parse match group: %v", matchGroup)
 			}

--- a/client/webserver/template.go
+++ b/client/webserver/template.go
@@ -7,8 +7,8 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -59,6 +59,7 @@ func (t *templates) filepath(name string) string {
 
 // srcDir is the expected directory of the translation source templates. Only
 // used in development when the --reload-html flag is used.
+// <root>/localized_html/[lang] -> <root>/html
 func (t *templates) srcDir() string {
 	return filepath.Join(filepath.Dir(filepath.Dir(t.folder)), "html")
 }
@@ -74,7 +75,7 @@ func (t *templates) srcPath(name string) string {
 func (t *templates) retranslate(name string, preloads ...string) error {
 	for _, iName := range append(preloads, name) {
 		srcPath := t.srcPath(iName)
-		rawTmpl, err := ioutil.ReadFile(srcPath)
+		rawTmpl, err := os.ReadFile(srcPath)
 		if err != nil {
 			return fmt.Errorf("ReadFile error: %w", err)
 		}
@@ -92,7 +93,7 @@ func (t *templates) retranslate(name string, preloads ...string) error {
 			destTmpl = bytes.Replace(destTmpl, token, []byte(replacement), -1)
 		}
 
-		if err := ioutil.WriteFile(t.filepath(iName), destTmpl, 0644); err != nil {
+		if err := os.WriteFile(t.filepath(iName), destTmpl, 0644); err != nil {
 			return fmt.Errorf("error writing localized template %s: %v", t.filepath(iName), err)
 		}
 	}

--- a/client/webserver/template.go
+++ b/client/webserver/template.go
@@ -4,13 +4,16 @@
 package webserver
 
 import (
+	"bytes"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"net/url"
 	"path/filepath"
 	"strings"
 
 	"decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/client/webserver/locales"
 )
 
 // pageTemplate holds the information necessary to process a template. Also
@@ -24,18 +27,26 @@ type pageTemplate struct {
 type templates struct {
 	templates map[string]pageTemplate
 	folder    string
+	locale    map[string]string
 	exec      func(string, interface{}) (string, error)
 	addErr    error
 }
 
 // newTemplates constructs a new templates.
-func newTemplates(folder string, reload bool) *templates {
+func newTemplates(folder, lang string, reload bool) *templates {
 	t := &templates{
 		templates: make(map[string]pageTemplate),
 		folder:    folder,
 	}
 	t.exec = t.execTemplateToString
 	if reload {
+		var found bool
+		// Make sure we have the expected directory structure.
+		if !folderExists(t.srcDir()) {
+			t.addErr = fmt.Errorf("reload-html set but source directory not found at %s", t.srcDir())
+		} else if t.locale, found = locales.Locales[lang]; !found {
+			t.addErr = fmt.Errorf("no translation dictionary found for lang %q", lang)
+		}
 		t.exec = t.execWithReload
 	}
 	return t
@@ -44,6 +55,48 @@ func newTemplates(folder string, reload bool) *templates {
 // filepath constructs the template path from the template ID.
 func (t *templates) filepath(name string) string {
 	return filepath.Join(t.folder, name+".tmpl")
+}
+
+// srcDir is the expected directory of the translation source templates. Only
+// used in development when the --reload-html flag is used.
+func (t *templates) srcDir() string {
+	return filepath.Join(filepath.Dir(filepath.Dir(t.folder)), "html")
+}
+
+// srcPath is the path translation source. Only used in
+// development when the --reload-html flag is used.
+func (t *templates) srcPath(name string) string {
+	return filepath.Join(t.srcDir(), name+".tmpl")
+}
+
+// retranslate rebuilds the locallized html template. Only used in development
+// when the --reload-html flag is used.
+func (t *templates) retranslate(name string, preloads ...string) error {
+	for _, iName := range append(preloads, name) {
+		srcPath := t.srcPath(iName)
+		rawTmpl, err := ioutil.ReadFile(srcPath)
+		if err != nil {
+			return fmt.Errorf("ReadFile error: %w", err)
+		}
+		destTmpl := make([]byte, len(rawTmpl))
+		copy(destTmpl, rawTmpl)
+		for _, matchGroup := range locales.Tokens(rawTmpl) {
+			if len(matchGroup) != 2 {
+				return fmt.Errorf("can't parse match group: %v", matchGroup)
+			}
+			token, key := matchGroup[0], string(matchGroup[1])
+			replacement, found := t.locale[key]
+			if !found {
+				return fmt.Errorf("warning: no translation text for key %q", key)
+			}
+			destTmpl = bytes.Replace(destTmpl, token, []byte(replacement), -1)
+		}
+
+		if err := ioutil.WriteFile(t.filepath(iName), destTmpl, 0644); err != nil {
+			return fmt.Errorf("error writing localized template %s: %v", t.filepath(iName), err)
+		}
+	}
+	return nil
 }
 
 // addTemplate adds a new template. The template is specified with a name, which
@@ -121,6 +174,12 @@ func (t *templates) execWithReload(name string, data interface{}) (string, error
 	if !found {
 		return "", fmt.Errorf("template %s not found", name)
 	}
+
+	err := t.retranslate(name, tmpl.preloads...)
+	if err != nil {
+		return "", err
+	}
+
 	t.addTemplate(name, tmpl.preloads...)
 	log.Debugf("reloaded HTML template %q", name)
 	return t.execTemplateToString(name, data)

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -156,11 +156,6 @@ type WebServer struct {
 func New(cfg *Config) (*WebServer, error) {
 	log = cfg.Logger
 
-	folderExists := func(fp string) bool {
-		stat, err := os.Stat(fp)
-		return err == nil && stat.IsDir()
-	}
-
 	// Look for the "site" folder in the executable's path, the working
 	// directory, or the source path relative to [repo root]/client/cmd/dexc.
 	execPath, err := os.Executable() // e.g. /usr/bin/dexc
@@ -396,7 +391,7 @@ func (s *WebServer) buildTemplates(lang string) error {
 	log.Infof("Using HTML templates in %s", tmplDir)
 
 	bb := "bodybuilder"
-	s.html = newTemplates(tmplDir, s.reloadHTML).
+	s.html = newTemplates(tmplDir, match, s.reloadHTML).
 		addTemplate("login", bb).
 		addTemplate("register", bb, "forms").
 		addTemplate("markets", bb, "forms").
@@ -740,4 +735,9 @@ func writeJSONWithStatus(w http.ResponseWriter, thing interface{}, code int, ind
 	if err != nil {
 		log.Errorf("Write error: %v", err)
 	}
+}
+
+func folderExists(fp string) bool {
+	stat, err := os.Stat(fp)
+	return err == nil && stat.IsDir()
 }


### PR DESCRIPTION
When **`dexc`** is run with the `--reload-html` flag, re-translate templates on the fly. 

**You still can't update the maps in `locales.Locales`.** If you update one of those, you'll need to restart **`dexc`**.