### PR TITLE
comms/test: Use ipv4 in TestOnline.

### DIFF
--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -665,7 +665,7 @@ func TestOnline(t *testing.T) {
 	pongWait = time.Millisecond * 500
 	pingPeriod = (pongWait * 9) / 10
 	server, err := NewServer(&RPCConfig{
-		ListenAddrs: []string{":0"},
+		ListenAddrs: []string{"127.0.0.1:0"},
 		RPCKey:      keyPath,
 		RPCCert:     certPath,
 	})


### PR DESCRIPTION
So, this is kinda a selfish pr, but I have been unable to run the server tests for a while because I have ipv6 disabled at the kernel level on my machine. This changes this test to use tcp4??? On master I cannot run tests with the failure:
```
--- FAIL: TestOnline (0.02s)
    comms_test.go:673: server constructor error: Can't listen on :0: listen tcp6 :0: socket: address family not supported by protocol
```