### PR TITLE
server/comms: more fine grained websocket route limiter

### DIFF
--- a/client/core/localetest/main.go
+++ b/client/core/localetest/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+const key = "key"
+
+func main() {
+	icelandicTmpl := "%.2f gígavött"
+	englishTmpl := "%.2f gigawatts"
+
+	err := message.SetString(language.Icelandic, key, icelandicTmpl)
+	if err != nil {
+		panic(err.Error())
+	}
+	err = message.SetString(language.AmericanEnglish, key, englishTmpl)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	icelandicPrinter := message.NewPrinter(language.Icelandic)
+	englishPrinter := message.NewPrinter(language.AmericanEnglish)
+
+	fmt.Println("Icelandic (using key):", icelandicPrinter.Sprintf(key, 1.21))
+	fmt.Println("Icelandic (direct):   ", icelandicPrinter.Sprintf(icelandicTmpl, 1.21))
+
+	fmt.Println("English (using key):  ", englishPrinter.Sprintf(key, 1.21))
+	fmt.Println("English (direct):     ", englishPrinter.Sprintf(englishTmpl, 1.21))
+}

--- a/dex/ip.go
+++ b/dex/ip.go
@@ -12,7 +12,14 @@ import (
 type IPKey [net.IPv6len]byte
 
 // NewIPKey parses an IP address string into an IPKey. For an IPV6 address, this
-// drops the interface identifier, which is the second half of the address
+// drops the interface identifier, which is the second half of the address. The
+// first half of the address comprises 48-bits for the prefix, which is the
+// public topology of a network that is assigned by an ISP, and 16-bits for the
+// Site-Level Aggregation Identifier (SLA). However, any number of the SLA bits
+// may be assigned by a provider, potentially giving a single link the freedom
+// to use multiple subnets, thus expanding the set of addresses they may use
+// freely. As such, IPv6 addresses with just the interface bits masked may not
+// be sufficient to identify a single remote uplink.
 func NewIPKey(addr string) IPKey {
 	host, _, err := net.SplitHostPort(addr)
 	if err == nil && host != "" {
@@ -45,4 +52,27 @@ func NewIPKey(addr string) IPKey {
 // repeatedly or in hot paths.
 func (ipk IPKey) String() string {
 	return net.IP(ipk[:]).String()
+}
+
+// PrefixV6 returns the first 48-bits of an IPv6 address, or nil for an IPv4
+// address. This may be used to identify multiple remote hosts from the same
+// public topology but different subnets. A heuristic may be defined to treat
+// hosts with the same prefix as the same host if there are many such hosts.
+func (ipk IPKey) PrefixV6() *IPKey {
+	if net.IP(ipk[:]).To4() != nil {
+		return nil
+	}
+	var prefix IPKey
+	copy(prefix[:], ipk[:6]) // 48 bit prefix
+	return &prefix
+}
+
+// IsLoopback reports whether the IPKey represents a loopback address.
+func (ipk IPKey) IsLoopback() bool {
+	return net.IP(ipk[:]).IsLoopback()
+}
+
+// IsUnspecified reports whether the IPKey is zero (unspecified).
+func (ipk IPKey) IsUnspecified() bool {
+	return ipk == IPKey{} // net.IP(ipk[:]).Equal(net.IPv6unspecified)
 }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -75,6 +75,7 @@ const (
 	AccountExistsError                // 56
 	AccountSuspendedError             // 57
 	RPCExportSeedError                // 58
+	TooManyRequestsError              // 59
 )
 
 // Routes are destinations for a "payload" of data. The type of data being

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -966,6 +966,7 @@ func TestWSRateLimiter(t *testing.T) {
 	conn := newWsStub()
 	conn.addChan()     // for <-conn.recv
 	conn.addNextChan() // for <-conn.nextRead, each time ReadMessage is called
+	defer close(conn.nextRead)
 
 	wg.Add(1)
 	go func() {
@@ -991,7 +992,7 @@ func TestWSRateLimiter(t *testing.T) {
 		select {
 		case <-handled:
 			return 0
-		case resp := <-conn.recv: // test handers only return resp with error (rate limit)
+		case resp := <-conn.recv: // test handlers only return resp with error (rate limit)
 			// t.Log("handler error message:", string(resp))
 			msg, err := msgjson.DecodeMessage(resp)
 			if err != nil {
@@ -1046,6 +1047,7 @@ func TestWSRateLimiter(t *testing.T) {
 	conn = newWsStub()
 	conn.addChan()     // for <-conn.recv
 	conn.addNextChan() // for <-conn.nextRead, each time ReadMessage is called
+	defer close(conn.nextRead)
 
 	wg.Add(1)
 	go func() {

--- a/server/comms/middleware.go
+++ b/server/comms/middleware.go
@@ -24,7 +24,7 @@ const (
 )
 
 // limitRate is rate-limiting middleware that checks whether a request can be
-// fulfilled.
+// fulfilled. This is intended for the /api HTTP endpoints.
 func (s *Server) limitRate(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		code, err := s.meterIP(dex.NewIPKey(r.RemoteAddr))
@@ -36,8 +36,10 @@ func (s *Server) limitRate(next http.Handler) http.Handler {
 	})
 }
 
-// meterIP checks the dataEnabled flag, the global rate limiter, and the
-// more restrictive ip-based rate limiter.
+// meterIP applies the dataEnabled flag, the global HTTP rate limiter, and the
+// more restrictive IP-based rate limiter. This is only intended for the data
+// API. The other websocket route handlers have different limiters that are
+// shared between connections from the same IP, but not globally.
 func (s *Server) meterIP(ip dex.IPKey) (int, error) {
 	if atomic.LoadUint32(&s.dataEnabled) != 1 {
 		return http.StatusServiceUnavailable, fmt.Errorf("data API is disabled")

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -37,12 +37,27 @@ const (
 	// allowed.
 	rpcMaxClients = 10000
 
+	// rpcMaxConnsPerIP is the maximum number of active websocket connections
+	// allowed per IP, loopback excluded.
+	rpcMaxConnsPerIP = 8
+
 	// banishTime is the default duration of a client quarantine.
 	banishTime = time.Hour
 
-	// Per-ip rate limits for HTTP routes.
+	// Per-ip rate limits for market data API routes.
 	ipMaxRatePerSec = 1
 	ipMaxBurstSize  = 5
+
+	// Per-websocket-connection request limits. Rate should be a reasonable
+	// sustained rate, while burst should consider bulk reconnect operations.
+	wsRateStatus, wsBurstStatus     = 10, 500     // order_status and match_status (combined)
+	wsRateOrder, wsBurstOrder       = 5, 100      // market, limit, and cancel (combined)
+	wsRateInfo, wsBurstInfo         = 10, 200     // low-cost route limiter for: config, fee_rate  (combined)
+	wsRateBook, wsBurstBook         = 1, 100      // orderbook, assuming 100 markets subscribed max
+	wsRateRegister, wsBurstRegister = 1 / 60.0, 1 // register, rate.Every(time.Minute) but const
+	// The cumulative rates below would need to be less than sum of above to
+	// actually trip unless it is also applied to unspecified routes.
+	wsRateTotal, wsBurstTotal = 40, 1000
 )
 
 var (
@@ -62,7 +77,9 @@ var (
 	// non-critical routes, including all routes registered as HTTP routes.
 	globalHTTPRateLimiter = rate.NewLimiter(100, 1000) // rate per sec, max burst
 
-	// ipRateLimiter is a per-client rate limiter.
+	// ipRateLimiter is a per-client rate limiter for the HTTP endpoints
+	// requests and httpRoutes (the market data API). The Server manages
+	// separate limiters used with the websocket routes, rpcRoutes.
 	ipHTTPRateLimiter = make(map[dex.IPKey]*ipRateLimiter)
 	rateLimiterMtx    sync.RWMutex
 )
@@ -75,7 +92,9 @@ type ipRateLimiter struct {
 	lastHit time.Time
 }
 
-// Get an ipRateLimiter for the IP. Creates a new one if it doesn't exist.
+// Get an ipRateLimiter for the IP. Creates a new one if it doesn't exist. This
+// is for use with the HTTP endpoints and httpRoutes (the data API), not the
+// websocket request routes in rpcRoutes.
 func getIPLimiter(ip dex.IPKey) *ipRateLimiter {
 	rateLimiterMtx.Lock()
 	defer rateLimiterMtx.Unlock()
@@ -158,30 +177,100 @@ type RPCConfig struct {
 	DisableDataAPI bool
 }
 
+// allower is satisfied by rate.Limiter.
+type allower interface {
+	Allow() bool
+}
+
+// routeLimiter contains a set of rate limiters for individual routes, and a
+// cumulative limiter applied after defined routers are applied. No limiter is
+// applied to an unspecified route.
+type routeLimiter struct {
+	routes     map[string]allower
+	cumulative allower // only used for defined routes
+}
+
+func (rl *routeLimiter) allow(route string) bool {
+	// To apply the cumulative limiter to all routes including those without
+	// their own limiter, we would apply it here. Maybe go with this if we are
+	// confident it's not going to interfere with init/redeem or others.
+	// if !rl.cumulative.Allow() {
+	// 	return false
+	// }
+	limiter := rl.routes[route]
+	if limiter == nil {
+		return true // free
+	}
+	return rl.cumulative.Allow() && limiter.Allow()
+}
+
+// newRouteLimiter creates a route-based rate limiter. It should be applied to
+// all connections from a given IP address.
+func newRouteLimiter() *routeLimiter {
+	// Some routes share a limiter to aggregate request stats:
+	statusLimiter := rate.NewLimiter(wsRateStatus, wsBurstStatus)
+	orderLimiter := rate.NewLimiter(wsRateOrder, wsBurstOrder)
+	infoLimiter := rate.NewLimiter(wsRateInfo, wsBurstInfo)
+	return &routeLimiter{
+		cumulative: rate.NewLimiter(wsRateTotal, wsBurstTotal),
+		routes: map[string]allower{
+			// Meter the 'register' route the most.
+			msgjson.RegisterRoute: rate.NewLimiter(wsRateRegister, wsBurstRegister),
+			// Status checking of matches and orders
+			msgjson.MatchStatusRoute: statusLimiter,
+			msgjson.OrderStatusRoute: statusLimiter,
+			// Order submission
+			msgjson.LimitRoute:  orderLimiter,
+			msgjson.MarketRoute: orderLimiter,
+			msgjson.CancelRoute: orderLimiter,
+			// Order book subscription with full snapshot
+			msgjson.OrderBookRoute: rate.NewLimiter(wsRateBook, wsBurstBook),
+			// Config and fee rate
+			msgjson.FeeRateRoute: infoLimiter,
+			msgjson.ConfigRoute:  infoLimiter,
+		},
+	}
+}
+
+// ipWsLimiter facilitates connection counting for a source IP address to
+// aggregate requests stats by a single rate limiter.
+type ipWsLimiter struct {
+	conns   int64
+	cleaner *time.Timer // when conns drops to zero, set a cleanup timer
+	*routeLimiter
+}
+
 // Server is a low-level communications hub. It supports websocket clients
 // and an HTTP API.
 type Server struct {
 	// One listener for each address specified at (RPCConfig).ListenAddrs.
 	listeners []net.Listener
-	// Protect the client map, which maps the (link).id to the client itself.
+
+	// The client map indexes each wsLink by its id.
 	clientMtx sync.RWMutex
 	clients   map[uint64]*wsLink
-	// A simple counter for generating unique client IDs. The counter is also
-	// protected by the clientMtx.
-	counter uint64
+	counter   uint64 // for generating unique client IDs
+
+	// wsLimiters manages per-IP per-route websocket connection request rate
+	// limiters that are not subject to server-wide rate limits or affected by
+	// disabling of the data API (Server.dataEnabled).
+	wsLimiterMtx sync.Mutex // the map and the fields of each limiter
+	wsLimiters   map[dex.IPKey]*ipWsLimiter
+	v6Prefixes   map[dex.IPKey]int // just debugging presently
+
 	// The quarantine map maps IP addresses to a time in which the quarantine will
 	// be lifted.
-	banMtx      sync.RWMutex
-	quarantine  map[dex.IPKey]time.Time
-	dataEnabled uint32
+	banMtx     sync.RWMutex
+	quarantine map[dex.IPKey]time.Time
+
+	dataEnabled uint32 // atomic
 }
 
-// A constructor for an Server. The Server handles a map of clients, each
-// with at least 3 goroutines for communications. The server is TLS-only, and
-// will generate a key pair with a self-signed certificate if one is not
-// provided as part of the RPCConfig. The server also maintains a IP-based
-// quarantine to short-circuit to an error response for misbehaving clients, if
-// necessary.
+// NewServer constructs a Server that should be started with Run. The server is
+// TLS-only, and will generate a key pair with a self-signed certificate if one
+// is not provided as part of the RPCConfig. The server also maintains a
+// IP-based quarantine to short-circuit to an error response for misbehaving
+// clients, if necessary.
 func NewServer(cfg *RPCConfig) (*Server, error) {
 	// Find or create the key pair.
 	keyExists := fileExists(cfg.RPCKey)
@@ -236,6 +325,8 @@ func NewServer(cfg *RPCConfig) (*Server, error) {
 	return &Server{
 		listeners:   listeners,
 		clients:     make(map[uint64]*wsLink),
+		wsLimiters:  make(map[dex.IPKey]*ipWsLimiter),
+		v6Prefixes:  make(map[dex.IPKey]int),
 		quarantine:  make(map[dex.IPKey]time.Time),
 		dataEnabled: dataEnabled,
 	}, nil
@@ -269,6 +360,13 @@ func (s *Server) Run(ctx context.Context) {
 		}
 		if s.clientCount() >= rpcMaxClients {
 			http.Error(w, "server at maximum capacity", http.StatusServiceUnavailable)
+			return
+		}
+		// Check websocket connection count for this IP before upgrading the
+		// conn so we can send an HTTP error code, but check again after
+		// upgrade/hijack so they cannot initiate many simultaneously.
+		if s.ipConnCount(ip) >= rpcMaxConnsPerIP {
+			http.Error(w, "too many connections from your address", http.StatusServiceUnavailable)
 			return
 		}
 		wsConn, err := ws.NewConnection(w, r, pongWait)
@@ -380,6 +478,108 @@ func (s *Server) banish(ip dex.IPKey) {
 	s.quarantine[ip] = time.Now().Add(banishTime)
 }
 
+// wsLimiter gets any existing routeLimiter for an IP incrementing the
+// connection count for the address, or creates a new one. The caller should use
+// wsLimiterDone after the connection that uses routeLimiter is closed. Loopback
+// addresses always get a new unshared limiter. NewIPKey should be used to
+// create an IPKey with interface bits masked out. This is not perfect with
+// respect to remote IPv6 hosts assigned multiple subnets (up to 16 bits worth).
+// Disable IPv6 if this is not acceptable.
+func (s *Server) wsLimiter(ip dex.IPKey) *routeLimiter {
+	// If the ip is a loopback address, this likely indicates a hidden service
+	// or misconfigured reverse proxy, and it is undesirable for many such
+	// connections to share a common limiter. To avoid this, return a new
+	// untracked limiter for such clients.
+	if ip.IsLoopback() {
+		return newRouteLimiter()
+	}
+
+	s.wsLimiterMtx.Lock()
+	defer s.wsLimiterMtx.Unlock()
+	prefix := ip.PrefixV6()
+	if prefix != nil { // not ipv4
+		if n := s.v6Prefixes[*prefix]; n > 0 {
+			log.Infof("Detected %d active IPv6 connections with same prefix %v", n, prefix)
+			// ip = *prefix // Use a prefix-aggregated limiter.
+		}
+	}
+
+	if l := s.wsLimiters[ip]; l != nil {
+		if l.conns >= rpcMaxConnsPerIP {
+			return nil
+		}
+		l.conns++
+		if prefix != nil {
+			s.v6Prefixes[*prefix]++
+		}
+		if l.cleaner != nil { // l.conns was zero
+			log.Debugf("Restoring active rate limiter for %v", ip)
+			// Even if the timer already fired, we won the race to the lock and
+			// incremented conns so the cleaner func will be a no-op.
+			l.cleaner.Stop() // false means timer fired already
+			l.cleaner = nil
+		}
+		return l.routeLimiter
+	}
+
+	limiter := newRouteLimiter()
+	s.wsLimiters[ip] = &ipWsLimiter{
+		conns:        1,
+		routeLimiter: limiter,
+	}
+	if prefix != nil {
+		s.v6Prefixes[*prefix]++
+	}
+	return limiter
+}
+
+// wsLimiterDone decrements the connection count for the IP address'
+// routeLimiter, and deletes it entirely if there are no remaining connections
+// from this address.
+func (s *Server) wsLimiterDone(ip dex.IPKey) {
+	s.wsLimiterMtx.Lock()
+	defer s.wsLimiterMtx.Unlock()
+
+	if prefix := ip.PrefixV6(); prefix != nil {
+		switch s.v6Prefixes[*prefix] {
+		case 0:
+		case 1:
+			delete(s.v6Prefixes, *prefix)
+		default:
+			s.v6Prefixes[*prefix]--
+		}
+	}
+
+	wsLimiter := s.wsLimiters[ip]
+	if wsLimiter == nil {
+		return // untracked limiter
+		/*
+			// Try a prefix-aggregated limiter.
+			if prefix == nil {
+				return
+			}
+			wsLimiter = s.wsLimiters[*prefix]
+			if wsLimiter == nil {
+				return
+			}
+			ip = *prefix
+		*/
+	}
+
+	wsLimiter.conns--
+	if wsLimiter.conns < 1 {
+		// Start a cleanup timer.
+		wsLimiter.cleaner = time.AfterFunc(time.Minute, func() {
+			s.wsLimiterMtx.Lock()
+			defer s.wsLimiterMtx.Unlock()
+			if wsLimiter.conns < 1 {
+				log.Debugf("Forgetting rate limiter for %v", ip)
+				delete(s.wsLimiters, ip)
+			} // else lost the race to the mutex, don't remove
+		})
+	}
+}
+
 // websocketHandler handles a new websocket client by creating a new wsClient,
 // starting it, and blocking until the connection closes. This method should be
 // run as a goroutine.
@@ -390,8 +590,14 @@ func (s *Server) websocketHandler(ctx context.Context, conn ws.Connection, ip de
 	// Create a new websocket client to handle the new websocket connection
 	// and wait for it to shutdown.  Once it has shutdown (and hence
 	// disconnected), remove it.
-	meter := func() (int, error) { return s.meterIP(ip) }
-	client := newWSLink(addr, conn, meter)
+	dataRoutesMeter := func() (int, error) { return s.meterIP(ip) } // includes global limiter and may be disabled
+	wsLimiter := s.wsLimiter(ip)
+	if wsLimiter == nil { // too many active ws conns from this IP
+		log.Warnf("Too many websocket connections from %v", ip)
+		return
+	}
+	defer s.wsLimiterDone(ip)
+	client := newWSLink(addr, conn, wsLimiter, dataRoutesMeter)
 	cm, err := s.addClient(ctx, client)
 	if err != nil {
 		log.Errorf("Failed to add client %s", addr)
@@ -472,6 +678,17 @@ func (s *Server) clientCount() uint64 {
 	s.clientMtx.RLock()
 	defer s.clientMtx.RUnlock()
 	return uint64(len(s.clients))
+}
+
+// Get the number of websocket connections for a given IP, excluding loopback.
+func (s *Server) ipConnCount(ip dex.IPKey) int64 {
+	s.wsLimiterMtx.Lock()
+	defer s.wsLimiterMtx.Unlock()
+	wsl := s.wsLimiters[ip]
+	if wsl == nil {
+		return 0
+	}
+	return wsl.conns
 }
 
 // filesExists reports whether the named file or directory exists.

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -48,8 +48,9 @@ const (
 	ipMaxRatePerSec = 1
 	ipMaxBurstSize  = 5
 
-	// Per-websocket-connection request limits. Rate should be a reasonable
-	// sustained rate, while burst should consider bulk reconnect operations.
+	// Per-websocket-connection limits in requests per second. Rate should be a
+	// reasonable sustained rate, while burst should consider bulk reconnect
+	// operations. Consider which routes are authenticated when setting these.
 	wsRateStatus, wsBurstStatus     = 10, 500     // order_status and match_status (combined)
 	wsRateOrder, wsBurstOrder       = 5, 100      // market, limit, and cancel (combined)
 	wsRateInfo, wsBurstInfo         = 10, 200     // low-cost route limiter for: config, fee_rate  (combined)


### PR DESCRIPTION
Several of the websocket routes are assigned both sustained and burst
rate limits of their own.

Despite challenges of DDoS, address spoofing, and large IPv6 subnets,
limiters are created by remote IP, with uniqueness determined by
`dex.IPKey`, which masks interface bits of IPv6 addresses, and provides
a method to retrieve the 48-bit prefix (public topology).

An IP's limiter is removed from memory a minute after last conn
is disconnected.  This is done to prevent churning connections
to reset limits.

`rpcMaxConnsPerIP` is the maximum number of active websocket connections
allowed per IP, loopback excluded.

This adds code to help devise possible prefix aggregation according to
some heuristic based on the number of different subnets in use from
the same prefix. Just logging of such connections at present.

Use `NewIPKey` in `TestWSRateLimiter`.