### PR TITLE
multi: Remove all io/ioutil usage.

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -12,8 +12,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -548,7 +548,7 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, chainParams *cha
 // newClient attempts to create a new websocket connection to a dcrwallet
 // instance with the given credentials and notification handlers.
 func newClient(host, user, pass, cert string, logger dex.Logger) (*rpcclient.Client, error) {
-	certs, err := ioutil.ReadFile(cert)
+	certs, err := os.ReadFile(cert)
 	if err != nil {
 		return nil, fmt.Errorf("TLS certificate read error: %w", err)
 	}

--- a/client/asset/eth/node.go
+++ b/client/asset/eth/node.go
@@ -7,7 +7,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -195,7 +194,7 @@ func runNode(cfg *nodeConfig) (*node.Node, error) {
 		if simnetGenesis == "" {
 			homeDir := os.Getenv("HOME")
 			genesisFile := filepath.Join(homeDir, "dextest", "eth", "genesis.json")
-			genBytes, err := ioutil.ReadFile(genesisFile)
+			genBytes, err := os.ReadFile(genesisFile)
 			if err != nil {
 				return nil, fmt.Errorf("error reading genesis file: %v", err)
 			}

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -28,7 +28,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"os/exec"
@@ -126,7 +125,7 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		}
 	}
-	addrBytes, err := ioutil.ReadFile(contractAddrFile)
+	addrBytes, err := os.ReadFile(contractAddrFile)
 	if err != nil {
 		fmt.Printf("error reading contract address: %v\n", err)
 		os.Exit(1)

--- a/client/cmd/dexcctl/dexcctl_test.go
+++ b/client/cmd/dexcctl/dexcctl_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -60,7 +59,7 @@ func TestConfigure(t *testing.T) {
 	cfgFile := tmp + "/testconfig"
 	defer os.Remove(cfgFile)
 	b := []byte("rpcaddr=1.2.3.4:3000\nproxyuser=jorb\n")
-	err = ioutil.WriteFile(cfgFile, b, 0644)
+	err = os.WriteFile(cfgFile, b, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/cmd/dexcctl/httpclient.go
+++ b/client/cmd/dexcctl/httpclient.go
@@ -9,10 +9,11 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 
 	"decred.org/dcrdex/dex/msgjson"
 	"github.com/decred/go-socks/socks"
@@ -39,7 +40,7 @@ func newHTTPClient(cfg *config, urlStr string) (*http.Client, error) {
 	}
 
 	// Configure TLS.
-	pem, err := ioutil.ReadFile(cfg.RPCCert)
+	pem, err := os.ReadFile(cfg.RPCCert)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +104,7 @@ func sendPostRequest(marshalledJSON []byte, cfg *config) (*msgjson.Message, erro
 	}
 
 	// Read the raw bytes and close the response.
-	respBytes, err := ioutil.ReadAll(httpResponse.Body)
+	respBytes, err := io.ReadAll(httpResponse.Body)
 	httpResponse.Body.Close()
 	if err != nil {
 		err = fmt.Errorf("error reading json reply: %v", err)

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -118,7 +117,7 @@ func readTextFile(cmd string, args []string) error {
 	if !fileExists(path) {
 		return fmt.Errorf("no file found at %s", path)
 	}
-	fileContents, err := ioutil.ReadFile(path)
+	fileContents, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("error reading %s: %v", path, err)
 	}

--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -43,10 +42,10 @@ func genCertPair(certFile, keyFile string, altDNSNames []string) error {
 	}
 
 	// Write cert and key files.
-	if err = ioutil.WriteFile(certFile, cert, 0644); err != nil {
+	if err = os.WriteFile(certFile, cert, 0644); err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(keyFile, key, 0600); err != nil {
+	if err = os.WriteFile(keyFile, key, 0600); err != nil {
 		os.Remove(certFile)
 		return err
 	}
@@ -176,14 +175,14 @@ func TestWsConn(t *testing.T) {
 		}()
 	}
 
-	certFile, err := ioutil.TempFile("", "certfile")
+	certFile, err := os.CreateTemp("", "certfile")
 	if err != nil {
 		t.Fatalf("unable to create temp certfile: %s", err)
 	}
 	certFile.Close()
 	defer os.Remove(certFile.Name())
 
-	keyFile, err := ioutil.TempFile("", "keyfile")
+	keyFile, err := os.CreateTemp("", "keyfile")
 	if err != nil {
 		t.Fatalf("unable to create temp keyfile: %s", err)
 	}
@@ -195,7 +194,7 @@ func TestWsConn(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	certB, err := ioutil.ReadFile(certFile.Name())
+	certB, err := os.ReadFile(certFile.Name())
 	if err != nil {
 		t.Fatalf("file reading error: %v", err)
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -9,10 +9,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net"
 	"net/url"
+	"os"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -6014,7 +6014,7 @@ func parseCert(host string, certI interface{}) ([]byte, error) {
 		if len(c) == 0 {
 			return CertStore[host], nil
 		}
-		cert, err := ioutil.ReadFile(c)
+		cert, err := os.ReadFile(c)
 		if err != nil {
 			return nil, newError(fileReadErr, "failed to read certificate file from %s: %v", c, err)
 		}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -6868,7 +6867,7 @@ func TestParseCert(t *testing.T) {
 		t.Fatalf("byte cert note returned unmodified. expected %x, got %x", byteCert, cert)
 	}
 	byteCert = []byte{0x05, 0x06}
-	certFile, _ := ioutil.TempFile("", "dumbcert")
+	certFile, _ := os.CreateTemp("", "dumbcert")
 	defer os.Remove(certFile.Name())
 	certFile.Write(byteCert)
 	certFile.Close()

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -27,7 +27,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -86,7 +85,7 @@ var (
 
 func readWalletCfgsAndDexCert() error {
 	readCert := func(path string) ([]byte, error) {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -187,7 +186,7 @@ func teardown(cancelCtx context.CancelFunc) {
 }
 
 func TestMain(m *testing.M) {
-	tmpDir, _ = ioutil.TempDir("", "")
+	tmpDir, _ = os.MkdirTemp("", "")
 	defer os.RemoveAll(tmpDir)
 	os.Exit(m.Run())
 }

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -47,7 +46,7 @@ func TestMain(m *testing.M) {
 	defer os.Stdout.Sync()
 	doIt := func() int {
 		var err error
-		tDir, err = ioutil.TempDir("", "dbtest")
+		tDir, err = os.MkdirTemp("", "dbtest")
 		if err != nil {
 			fmt.Println("error creating temporary directory:", err)
 			return -1

--- a/client/db/bolt/upgrades_test.go
+++ b/client/db/bolt/upgrades_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,7 +37,7 @@ var dbUpgradeTests = [...]struct {
 }
 
 func TestUpgrades(t *testing.T) {
-	d, err := ioutil.TempDir("", "dcrdex_test_upgrades")
+	d, err := os.MkdirTemp("", "dcrdex_test_upgrades")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +289,7 @@ func checkVersion(dbtx *bbolt.Tx, expectedVersion uint32) error {
 
 func unpack(t *testing.T, db string) (string, func()) {
 	t.Helper()
-	d, err := ioutil.TempDir("", "dcrdex_test_upgrades")
+	d, err := os.MkdirTemp("", "dcrdex_test_upgrades")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -6,7 +6,7 @@ package db
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -662,12 +662,12 @@ func decodeAccountBackup(b []byte) (*AccountBackup, error) {
 // Save persists an account backup to file.
 func (ab *AccountBackup) Save(path string) error {
 	backup := ab.Serialize()
-	return ioutil.WriteFile(path, backup, 0o600)
+	return os.WriteFile(path, backup, 0o600)
 }
 
 // RestoreAccountBackup generates a user account from a backup file.
 func RestoreAccountBackup(path string) (*AccountBackup, error) {
-	backup, err := ioutil.ReadFile(path)
+	backup, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -14,7 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sync"
@@ -99,10 +99,10 @@ func genCertPair(certFile, keyFile string, hosts []string) error {
 	}
 
 	// Write cert and key files.
-	if err = ioutil.WriteFile(certFile, cert, 0644); err != nil {
+	if err = os.WriteFile(certFile, cert, 0644); err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(keyFile, key, 0600); err != nil {
+	if err = os.WriteFile(keyFile, key, 0600); err != nil {
 		os.Remove(certFile)
 		return err
 	}
@@ -143,7 +143,7 @@ func (s *RPCServer) handleJSON(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	r.Close = true
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
 		http.Error(w, "error reading request body", http.StatusBadRequest)

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -13,7 +13,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -131,7 +130,7 @@ func newTServerWErr(t *testing.T, start bool, user, pass string) (*RPCServer, fu
 
 	var shutdown func()
 	ctx, killCtx := context.WithCancel(tCtx)
-	tempDir, err := ioutil.TempDir("", "rpcservertest")
+	tempDir, err := os.MkdirTemp("", "rpcservertest")
 	if err != nil {
 		killCtx()
 		return nil, nil, fmt.Errorf("error creating temporary directory: %w", err)
@@ -183,7 +182,7 @@ func TestConnectBindError(t *testing.T) {
 	s0, shutdown := newTServer(t, true, "", "abc")
 	defer shutdown()
 
-	tempDir, err := ioutil.TempDir("", "rpcservertest")
+	tempDir, err := os.MkdirTemp("", "rpcservertest")
 	if err != nil {
 		t.Fatalf("error creating temporary directory: %v", err)
 	}

--- a/client/webserver/site/template-builder/main.go
+++ b/client/webserver/site/template-builder/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -51,7 +50,7 @@ func main() {
 		baseName := fi.Name()
 		fmt.Println(baseName)
 		rawTmplPath := filepath.Join(templateDir, baseName)
-		rawTmpl, err := ioutil.ReadFile(rawTmplPath)
+		rawTmpl, err := os.ReadFile(rawTmplPath)
 		if err != nil {
 			return fmt.Errorf("ReadFile error: %w", err)
 		}
@@ -91,7 +90,7 @@ func main() {
 			// name := baseName[:len(baseName)-len(ext)]
 			// localizedName := filepath.Join(outputDirectory, name+"_"+lang+ext)
 			fmt.Println("Writing", localizedName)
-			if err := ioutil.WriteFile(localizedName, tmpl, 0644); err != nil {
+			if err := os.WriteFile(localizedName, tmpl, 0644); err != nil {
 				return fmt.Errorf("error writing localized template %s: %v", localizedName, err)
 			}
 		}

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -349,7 +349,7 @@ func (s *WebServer) buildTemplates(lang string) error {
 
 	htmlDir := filepath.Join(s.siteDir, "src", "localized_html")
 
-	fileInfos, err := ioutil.ReadDir(htmlDir)
+	fileInfos, err := os.ReadDir(htmlDir)
 	if err != nil {
 		return fmt.Errorf("ReadDir error: %w", err)
 	}
@@ -611,7 +611,7 @@ func (s *WebServer) readNotifications(ctx context.Context) {
 
 // readPost unmarshals the request body into the provided interface.
 func readPost(w http.ResponseWriter, r *http.Request, thing interface{}) bool {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
 		log.Debugf("Error reading request body: %v", err)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -289,7 +288,7 @@ func TestNew_siteError(t *testing.T) {
 	}
 
 	// Change to a directory with no "site" or "../../webserver/site" folder.
-	dir, _ := ioutil.TempDir("", "test")
+	dir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(dir)
 	defer os.Chdir(cwd) // leave the temp dir before trying to delete it
 

--- a/dex/config/config_test.go
+++ b/dex/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func makeConfigPtr() *config {
 func TestConfigParsing(t *testing.T) {
 	var testConfig = defaultConfig()
 
-	tempDir, err := ioutil.TempDir("", "configtest")
+	tempDir, err := os.MkdirTemp("", "configtest")
 	if err != nil {
 		t.Fatalf("error creating temporary directory: %v", err)
 	}

--- a/dex/logging.go
+++ b/dex/logging.go
@@ -6,7 +6,6 @@ package dex
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -17,7 +16,7 @@ import (
 var Disabled Logger = &logger{
 	Logger:  slog.Disabled,
 	level:   LevelOff,
-	backend: slog.NewBackend(ioutil.Discard),
+	backend: slog.NewBackend(io.Discard),
 }
 
 // Level constants.

--- a/dex/testing/loadbot/loadbot.go
+++ b/dex/testing/loadbot/loadbot.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -217,7 +216,7 @@ func main() {
 
 	// Get the server harness configuration file. We'll want these parameters
 	// before we get them from 'config'.
-	f, err := ioutil.ReadFile(filepath.Join(dextestDir, "dcrdex", "markets.json"))
+	f, err := os.ReadFile(filepath.Join(dextestDir, "dcrdex", "markets.json"))
 	if err != nil {
 		fmt.Println("error reading simnet dcrdex markets.json file:", err)
 		return

--- a/docs/examples/rpcclient/main.go
+++ b/docs/examples/rpcclient/main.go
@@ -10,7 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -101,7 +101,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	notification, err := ioutil.ReadAll(r)
+	notification, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ type config struct {
 // newHTTPClient returns a new HTTP client
 func newHTTPClient(cfg *config, urlStr string) (*http.Client, error) {
 	// Configure TLS.
-	pem, err := ioutil.ReadFile(cfg.RPCCert)
+	pem, err := os.ReadFile(cfg.RPCCert)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func newHTTPClient(cfg *config, urlStr string) (*http.Client, error) {
 func newWSClient(cfg *config) (*websocket.Conn, error) {
 	urlStr := "wss://" + cfg.RPCAddr + "/ws"
 	// Configure TLS.
-	pem, err := ioutil.ReadFile(cfg.RPCCert)
+	pem, err := os.ReadFile(cfg.RPCCert)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func sendPostRequest(marshalledJSON []byte, urlStr string, cfg *config, httpClie
 	}
 
 	// Read the raw bytes and close the response.
-	respBytes, err := ioutil.ReadAll(httpResponse.Body)
+	respBytes, err := io.ReadAll(httpResponse.Body)
 	httpResponse.Body.Close()
 	if err != nil {
 		err = fmt.Errorf("error reading json reply: %v", err)

--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -577,7 +577,7 @@ func (s *Server) apiForgiveMatchFail(w http.ResponseWriter, r *http.Request) {
 }
 
 func toNote(r *http.Request) (*msgjson.Message, int, error) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("unable to read request body: %w", err)

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -228,10 +227,10 @@ func genCertPair(certFile, keyFile string) error {
 	}
 
 	// Write cert and key files.
-	if err = ioutil.WriteFile(certFile, cert, 0644); err != nil {
+	if err = os.WriteFile(certFile, cert, 0644); err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(keyFile, key, 0600); err != nil {
+	if err = os.WriteFile(keyFile, key, 0600); err != nil {
 		os.Remove(certFile)
 		return err
 	}
@@ -245,7 +244,7 @@ var tPort = 5555
 // If start is true, the Server's Run goroutine is started, and the shutdown
 // func must be called when finished with the Server.
 func newTServer(t *testing.T, start bool, authSHA [32]byte) (*Server, func()) {
-	tmp, err := ioutil.TempDir("", "admin")
+	tmp, err := os.MkdirTemp("", "admin")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -56,7 +55,7 @@ func TestConfig(t *testing.T) {
 	cfg := &dexbtc.Config{}
 	parsedCfg := &dexbtc.Config{}
 
-	tempDir, err := ioutil.TempDir("", "btctest")
+	tempDir, err := os.MkdirTemp("", "btctest")
 	if err != nil {
 		t.Fatalf("error creating temporary directory: %v", err)
 	}

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -11,8 +11,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -1052,7 +1052,7 @@ func (dcr *Backend) getMainchainDcrBlock(ctx context.Context, height uint32) (*d
 // with the given credentials and notification handlers.
 func connectNodeRPC(host, user, pass, cert string) (*rpcclient.Client, error) {
 
-	dcrdCerts, err := ioutil.ReadFile(cert)
+	dcrdCerts, err := os.ReadFile(cert)
 	if err != nil {
 		return nil, fmt.Errorf("TLS certificate read error: %w", err)
 	}

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -50,7 +49,7 @@ func TestLoadConfig(t *testing.T) {
 	cfg := &config{}
 	parsedCfg := &config{}
 
-	tempDir, err := ioutil.TempDir("", "btctest")
+	tempDir, err := os.MkdirTemp("", "btctest")
 	if err != nil {
 		t.Fatalf("error creating temporary directory: %v", err)
 	}

--- a/server/cmd/dcrdex/key.go
+++ b/server/cmd/dcrdex/key.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"decred.org/dcrdex/dex/encode"
@@ -35,7 +34,7 @@ func dexKey(path string, pass []byte) (*secp256k1.PrivateKey, error) {
 
 func loadKeyFile(path string, pass []byte) (*secp256k1.PrivateKey, error) {
 	// Load and decrypt it.
-	pkFileBuffer, err := ioutil.ReadFile(path)
+	pkFileBuffer, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("ReadFile: %v", err)
 	}
@@ -97,7 +96,7 @@ func createAndStoreKey(path string, pass []byte) (*secp256k1.PrivateKey, error) 
 
 	// Store it.
 	data := encode.BuildyBytes{0}.AddData(keyParams).AddData(encKey)
-	err = ioutil.WriteFile(path, data, 0644)
+	err = os.WriteFile(path, data, 0644)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write DEX signing key: %v", err)
 	}

--- a/server/cmd/dcrdex/key_test.go
+++ b/server/cmd/dcrdex/key_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +13,7 @@ import (
 )
 
 func Test_createAndStoreKey(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "test")
+	dir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(dir)
 
 	file := "newkey"
@@ -62,7 +61,7 @@ func Test_createAndStoreKey(t *testing.T) {
 }
 
 func Test_loadKeyFile(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "test")
+	dir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(dir)
 
 	fullFile := filepath.Join(dir, "newkey")
@@ -120,7 +119,7 @@ func Test_loadKeyFile(t *testing.T) {
 }
 
 func Test_dexKey(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "test")
+	dir, _ := os.MkdirTemp("", "test")
 	defer os.RemoveAll(dir)
 
 	file := "newkey"

--- a/server/cmd/dcrdex/settings.go
+++ b/server/cmd/dcrdex/settings.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -39,7 +38,7 @@ func loadMarketConfFile(network dex.Network, marketsJSON string) ([]*dex.MarketI
 }
 
 func loadMarketConf(network dex.Network, src io.Reader) ([]*dex.MarketInfo, []*dexsrv.AssetConf, error) {
-	settings, err := ioutil.ReadAll(src)
+	settings, err := io.ReadAll(src)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -654,7 +653,7 @@ func TestClientResponses(t *testing.T) {
 }
 
 func TestOnline(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "example")
+	tempDir, err := os.MkdirTemp("", "example")
 	if err != nil {
 		t.Fatalf("TempDir error: %v", err)
 	}
@@ -718,7 +717,7 @@ func TestOnline(t *testing.T) {
 	}
 
 	// Read in the cert file
-	certs, err := ioutil.ReadFile(certPath)
+	certs, err := os.ReadFile(certPath)
 	if err != nil {
 		t.Fatalf("Failed to append %q to RootCAs: %v", certPath, err)
 	}

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -494,10 +493,10 @@ func genCertPair(certFile, keyFile string, altDNSNames []string) error {
 	}
 
 	// Write cert and key files.
-	if err = ioutil.WriteFile(certFile, cert, 0644); err != nil {
+	if err = os.WriteFile(certFile, cert, 0644); err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(keyFile, key, 0600); err != nil {
+	if err = os.WriteFile(keyFile, key, 0600); err != nil {
 		os.Remove(certFile)
 		return err
 	}

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
@@ -267,7 +266,7 @@ func newTestMarket(stor ...*TArchivist) (*Market, *TArchivist, *TAuth, func(), e
 		preimagesByOrdID: make(map[string]order.Preimage),
 	}
 
-	swapDataDir, err := ioutil.TempDir("", "swapstates")
+	swapDataDir, err := os.MkdirTemp("", "swapstates")
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
    io/ioutil is deprecated in go 1.16. Replace methods with os and io
    methods.

closes #1165