### PR TITLE
intl: add missing translations. refactor locales.js

### DIFF
--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -166,4 +166,8 @@ var EnUS = map[string]string{
 	"Import Account":         "Import Account",
 	"no_wallet":              "no wallet",
 	"create_a_x_wallet":      "Create a {{.Info.Name}} Wallet", // .Info.Name will be an asset symbol like DCR
+	"dont_share":             "Don't share it. Don't lose it.",
+	"Show Me":                "Show Me",
+	"Wallet Settings":        "Wallet Settings",
+	"Add a":                  "Add a",
 }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -169,5 +169,8 @@ var EnUS = map[string]string{
 	"dont_share":             "Don't share it. Don't lose it.",
 	"Show Me":                "Show Me",
 	"Wallet Settings":        "Wallet Settings",
-	"Add a":                  "Add a",
+	"add_a_x_wallet":         `Add a <img id="nwAssetLogo" class="micro-icon mx-1"> <span id="nwAssetName"></span> Wallet`,
+	"ready":                  "ready",
+	"off":                    "off",
+	"Export Trades":          "Export Trades",
 }

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -34,10 +34,7 @@
 
 {{define "newWalletForm"}}
 <div class="bg2 px-2 py-1 text-center fs18 position-relative">
-  [[[Add a]]]
-  <img id="nwAssetLogo" class="micro-icon mx-1">
-  <span id="nwAssetName"></span>
-  [[[Wallet]]]
+  [[[add_a_x_wallet]]]
   <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
 </div>
 <div class="p-4">

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -1,6 +1,6 @@
 {{define "walletConfigTemplates"}}
 <div class="py-2 px-1 d-flex justify-content-between align-items-center">
-  Wallet Settings
+  [[[Wallet Settings]]]
   <div data-tmpl="fileSelector" class="d-inline-block hoverbg pointer fs14"><span class="ico-textfile mr-1"></span> [[[load from file]]]</div>
   <input data-tmpl="fileInput" type="file" class="form-control select d-none">
 </div>
@@ -34,10 +34,10 @@
 
 {{define "newWalletForm"}}
 <div class="bg2 px-2 py-1 text-center fs18 position-relative">
-  Add a
+  [[[Add a]]]
   <img id="nwAssetLogo" class="micro-icon mx-1">
   <span id="nwAssetName"></span>
-  Wallet
+  [[[Wallet]]]
   <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
 </div>
 <div class="p-4">

--- a/client/webserver/site/src/html/orders.tmpl
+++ b/client/webserver/site/src/html/orders.tmpl
@@ -36,7 +36,7 @@
         <div class="apply-bttn d-hide"><button class="bg2 demi">[[[apply]]]</button></div>
       </div>
       <div id="exportOrders" class="export-bttn">
-        <button class="bg2 demi">Export Trades</button>
+        <button class="bg2 demi">[[[Export Trades]]]</button>
       </div>
     </div>
     <div class="flex-grow-1">

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -97,11 +97,11 @@
       </div>
       <hr class="dashed my-4">
       <div>
-        <label for="exportSeedPW" class="pl-1 mb-1">Password</label>
+        <label for="exportSeedPW" class="pl-1 mb-1">[[[Password]]]</label>
         <input type="password" class="form-control select" id="exportSeedPW" autocomplete="current-password">
       </div>
       <div class="d-flex justify-content-end mt-4">
-        <button id="exportSeedSubmit" type="button" class="col-8 justify-content-center fs15 bg2 selected">Show Me</button>
+        <button id="exportSeedSubmit" type="button" class="col-8 justify-content-center fs15 bg2 selected">[[[Show Me]]]</button>
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor" id="exportSeedErr"></div>
     </form>
@@ -109,7 +109,7 @@
     {{- /* SEED DISPLAY */ -}}
     <form class="card bg1 p-4 position-relative d-hide" id="authorizeSeedDisplay">
       <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-      Don't share it. Don't lose it.
+      [[[dont_share]]]
       <div id="seedDiv"></div>
     </form>
 

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -9,7 +9,7 @@
     <span data-state="syncing" 
       class="ico-sync fs12{{if or (not $w.Running) $w.Synced}} d-hide{{end}}"
       data-tooltip="wallet is {{printf "%.2f" (x100  $w.SyncProgress)}}% synced"></span>
-    <span data-state="status" class="txt-status">{{walletStatusString $w}}</span>
+    <span data-state="status" class="txt-status">{{if $w.Open}}[[[ready]]]{{else if $w.Running}}[[[locked]]]{{else}}[[[off]]]{{end}}</span>
   {{else}}
     <span data-state="sleeping" class="ico-sleeping fs17 grey d-hide"></span>
     <span data-state="locked" class="ico-locked grey d-hide"></span>

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -10,7 +10,7 @@ import OrderPage from './order'
 import { getJSON, postJSON } from './http'
 import * as ntfn from './notifications'
 import ws from './ws'
-import Locales from './locales'
+import { setLocale } from './locales'
 
 const idel = Doc.idel // = element by id
 const bind = Doc.bind
@@ -91,7 +91,7 @@ export default class Application {
     }
 
     // use user current locale set by backend
-    window.locales = new Locales()
+    setLocale()
   }
 
   /**

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -1,10 +1,4 @@
-import {
-  ID_OFF,
-  ID_LOCKED,
-  ID_READY,
-  ID_NOWALLET,
-  ID_WALLET_SYNC_PROGRESS
-} from './locales'
+import * as intl from './locales'
 
 const parser = new window.DOMParser()
 
@@ -247,7 +241,7 @@ export class WalletIcons {
     const i = this.icons
     Doc.hide(i.locked, i.unlocked, i.nowallet, i.syncing)
     Doc.show(i.sleeping)
-    if (this.status) this.status.textContent = window.locales.formatDetails(ID_OFF)
+    if (this.status) this.status.textContent = intl.prep(intl.ID_OFF)
   }
 
   /*
@@ -257,7 +251,7 @@ export class WalletIcons {
     const i = this.icons
     Doc.hide(i.unlocked, i.nowallet, i.sleeping)
     Doc.show(i.locked)
-    if (this.status) this.status.textContent = window.locales.formatDetails(ID_LOCKED)
+    if (this.status) this.status.textContent = intl.prep(intl.ID_LOCKED)
   }
 
   /*
@@ -268,7 +262,7 @@ export class WalletIcons {
     const i = this.icons
     Doc.hide(i.locked, i.nowallet, i.sleeping)
     Doc.show(i.unlocked)
-    if (this.status) this.status.textContent = window.locales.formatDetails(ID_READY)
+    if (this.status) this.status.textContent = intl.prep(intl.ID_READY)
   }
 
   /* sleeping sets the icons to indicate that no wallet exists. */
@@ -276,7 +270,7 @@ export class WalletIcons {
     const i = this.icons
     Doc.hide(i.locked, i.unlocked, i.sleeping, i.syncing)
     Doc.show(i.nowallet)
-    if (this.status) this.status.textContent = window.locales.formatDetails(ID_NOWALLET)
+    if (this.status) this.status.textContent = intl.prep(intl.ID_NOWALLET)
   }
 
   setSyncing (wallet) {
@@ -287,7 +281,7 @@ export class WalletIcons {
     }
     if (!wallet.synced) {
       Doc.show(icon)
-      icon.dataset.tooltip = window.locales.formatDetails(ID_WALLET_SYNC_PROGRESS, { syncProgress: (wallet.syncProgress * 100).toFixed(1) })
+      icon.dataset.tooltip = intl.prep(intl.ID_WALLET_SYNC_PROGRESS, { syncProgress: (wallet.syncProgress * 100).toFixed(1) })
     } else Doc.hide(icon)
   }
 

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -2,11 +2,7 @@ import Doc from './doc'
 import { postJSON } from './http'
 import State from './state'
 import { feeSendErr } from './constants'
-import {
-  ID_HIDE_ADDIIONAL_SETTINGS,
-  ID_NO_APP_PASS_ERROR_MSG,
-  ID_SHOW_ADDIIONAL_SETTINGS
-} from './locales'
+import * as intl from './locales'
 
 let app
 
@@ -32,7 +28,7 @@ export class NewWalletForm {
     bind(form, fields.submitAdd, async () => {
       const pw = fields.nwAppPass.value || (this.pwCache ? this.pwCache.pw : '')
       if (!pw && !State.passwordIsCached()) {
-        fields.newWalletErr.textContent = window.locales.formatDetails(ID_NO_APP_PASS_ERROR_MSG)
+        fields.newWalletErr.textContent = intl.prep(intl.ID_NO_APP_PASS_ERROR_MSG)
         Doc.show(fields.newWalletErr)
         return
       }
@@ -228,12 +224,12 @@ export class WalletConfigForm {
     if (visible) {
       Doc.hide(this.showIcon)
       Doc.show(this.hideIcon, this.otherSettings)
-      this.showHideMsg.textContent = window.locales.formatDetails(ID_HIDE_ADDIIONAL_SETTINGS)
+      this.showHideMsg.textContent = intl.prep(intl.ID_HIDE_ADDITIONAL_SETTINGS)
       return
     }
     Doc.hide(this.hideIcon, this.otherSettings)
     Doc.show(this.showIcon)
-    this.showHideMsg.textContent = window.locales.formatDetails(ID_SHOW_ADDIIONAL_SETTINGS)
+    this.showHideMsg.textContent = intl.prep(intl.ID_SHOW_ADDIIONAL_SETTINGS)
   }
 
   /*
@@ -434,7 +430,7 @@ export class UnlockWalletForm {
     const fields = this.fields
     const pw = fields.uwAppPass.value || (this.pwCache ? this.pwCache.pw : '')
     if (!pw && !State.passwordIsCached()) {
-      fields.unlockErr.textContent = window.locales.formatDetails(ID_NO_APP_PASS_ERROR_MSG)
+      fields.unlockErr.textContent = intl.prep(intl.ID_NO_APP_PASS_ERROR_MSG)
       Doc.show(fields.unlockErr)
       return
     }

--- a/client/webserver/site/src/js/locales.js
+++ b/client/webserver/site/src/js/locales.js
@@ -7,7 +7,7 @@ export const ID_READY = 'ID_READY'
 export const ID_LOCKED = 'ID_LOCKED'
 export const ID_NOWALLET = 'ID_NOWALLET'
 export const ID_WALLET_SYNC_PROGRESS = 'ID_WALLET_SYNC_PROGRESS'
-export const ID_HIDE_ADDIIONAL_SETTINGS = 'ID_HIDE_ADDIIONAL_SETTINGS'
+export const ID_HIDE_ADDITIONAL_SETTINGS = 'ID_HIDE_ADDITIONAL_SETTINGS'
 export const ID_SHOW_ADDIIONAL_SETTINGS = 'ID_SHOW_ADDIIONAL_SETTINGS'
 export const ID_BUY = 'ID_BUY'
 export const ID_SELL = 'ID_SELL'
@@ -29,6 +29,12 @@ export const ID_KEEP_WALLET_PASS = 'ID_KEEP_WALLET_PASS'
 export const ID_NEW_WALLET_PASS = 'ID_NEW_WALLET_PASS'
 export const ID_LOT = 'ID_LOT'
 export const ID_LOTS = 'ID_LOTS'
+export const ID_UNKNOWN = 'ID_UNKNOWN'
+export const ID_EPOCH = 'ID_EPOCH'
+export const ID_SETTLING = 'ID_SETTLING'
+export const ID_NO_MATCH = 'ID_NO_MATCH'
+export const ID_CANCELED = 'ID_CANCELED'
+export const ID_REVOKED = 'ID_REVOKED'
 
 export const templateKeys = {
   [ID_NO_PASS_ERROR_MSG]: 'password cannot be empty',
@@ -41,7 +47,7 @@ export const templateKeys = {
   [ID_LOCKED]: 'locked',
   [ID_NOWALLET]: 'no wallet',
   [ID_WALLET_SYNC_PROGRESS]: 'wallet is {{ syncProgress }}% synced',
-  [ID_HIDE_ADDIIONAL_SETTINGS]: 'hide additional settings',
+  [ID_HIDE_ADDITIONAL_SETTINGS]: 'hide additional settings',
   [ID_SHOW_ADDIIONAL_SETTINGS]: 'show additional settings',
   [ID_BUY]: 'Buy',
   [ID_SELL]: 'Sell',
@@ -60,37 +66,47 @@ export const templateKeys = {
   [ID_ACCT_UNDEFINED]: 'Account undefined.',
   [ID_KEEP_WALLET_PASS]: 'keep current wallet password',
   [ID_NEW_WALLET_PASS]: 'set a new wallet password',
-  [ID_LOT]: 'lote',
-  [ID_LOTS]: 'lotes'
+  [ID_LOT]: 'lot',
+  [ID_LOTS]: 'lots',
+  [ID_UNKNOWN]: 'unknown',
+  [ID_EPOCH]: 'epoch',
+  [ID_SETTLING]: 'settling',
+  [ID_NO_MATCH]: 'no match',
+  [ID_CANCELED]: 'canceled',
+  [ID_REVOKED]: 'revoked'
 }
 
 const localesMap = {
   'en-us': templateKeys
 }
 
-export default class Locales {
-  constructor (locale) {
-    // lang is hardcoded at the <html lang=...>
-    this.locale = (document.documentElement.lang).toLowerCase()
-  }
+/* locale will hold the locale loaded via setLocale. */
+let locale
 
-  // formatDetails will format the message to its locale.
-  // need to add one for plurals
-  formatDetails (stringKey, args = undefined) {
-    return this.stringTemplateParser(localesMap[this.locale][stringKey], args)
-  }
+/*
+ * setLocale read the language tag from the current document's html element lang
+ * attribute and sets the locale. setLocale should be called once by the
+ * application before prep is used.
+*/
+export function setLocale () { locale = localesMap[document.documentElement.lang.toLowerCase()] }
 
-  // stringTemplateParser is a template string matcher, where expression is any
-  // text. It switches what is inside double brackets (e.g. 'buy {{ asset }}')
-  // for the value described into valueObj. valueObj is an object with keys
-  // equal to the placeholder keys. (e.g. {"asset": "dcr"}).
-  // So that will be switched for: 'asset dcr'.
-  stringTemplateParser (expression, valueObj) {
-    // templateMatcher matches any text which:
-    // is some {{ text }} between two brackets, and a space between them.
-    // It is global, therefore it will change all occurrences found.
-    // text can be anything, but brackets '{}' and space '\s'
-    const templateMatcher = /{{\s?([^{}\s]*)\s?}}/g
-    return expression.replace(templateMatcher, (_, value) => valueObj[value])
-  }
+/* prep will format the message to the current locale. */
+export function prep (k, args = undefined) {
+  return stringTemplateParser(locale[k], args)
+}
+
+/*
+ * stringTemplateParser is a template string matcher, where expression is any
+ * text. It switches what is inside double brackets (e.g. 'buy {{ asset }}')
+ * for the value described into valueObj. valueObj is an object with keys
+ * equal to the placeholder keys. (e.g. {"asset": "dcr"}).
+ * So that will be switched for: 'asset dcr'.
+ */
+function stringTemplateParser (expression, valueObj) {
+  // templateMatcher matches any text which:
+  // is some {{ text }} between two brackets, and a space between them.
+  // It is global, therefore it will change all occurrences found.
+  // text can be anything, but brackets '{}' and space '\s'
+  const templateMatcher = /{{\s?([^{}\s]*)\s?}}/g
+  return expression.replace(templateMatcher, (_, value) => valueObj[value])
 }

--- a/client/webserver/site/src/js/login.js
+++ b/client/webserver/site/src/js/login.js
@@ -2,7 +2,7 @@ import Doc from './doc'
 import BasePage from './basepage'
 import { postJSON } from './http'
 import * as forms from './forms'
-import { ID_NO_PASS_ERROR_MSG } from './locales'
+import * as intl from './locales'
 
 let app
 
@@ -25,7 +25,7 @@ export default class LoginPage extends BasePage {
     page.pw.value = ''
     const rememberPass = page.rememberPass.checked
     if (pw === '') {
-      page.errMsg.textContent = window.locales.formatDetails(ID_NO_PASS_ERROR_MSG)
+      page.errMsg.textContent = intl.prep(intl.ID_NO_PASS_ERROR_MSG)
       Doc.show(page.errMsg)
       return
     }

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -7,23 +7,7 @@ import { postJSON } from './http'
 import { NewWalletForm, UnlockWalletForm, bind as bindForm } from './forms'
 import * as Order from './orderutil'
 import ws from './ws'
-import {
-  ID_BOOKED,
-  ID_BUY,
-  ID_EXECUTED,
-  ID_ORDER_PREVIEW,
-  ID_SELL,
-  ID_TRADE,
-  ID_SET_BUTTON_BUY,
-  ID_NOT_SUPPORTED,
-  ID_SET_BUTTON_SELL,
-  ID_CONNECTION_FAILED,
-  ID_CALCULATING,
-  ID_ESTIMATE_UNAVAILABLE,
-  ID_NO_ZERO_RATE,
-  ID_NO_ZERO_QUANTITY,
-  ID_NO_ASSET_WALLET
-} from './locales'
+import * as intl from './locales'
 
 let app
 const bind = Doc.bind
@@ -162,7 +146,7 @@ export default class MarketsPage extends BasePage {
       swapBttns(page.sellBttn, page.buyBttn)
       page.submitBttn.classList.remove('sellred')
       page.submitBttn.classList.add('buygreen')
-      page.maxLbl.textContent = window.locales.formatDetails(ID_BUY)
+      page.maxLbl.textContent = intl.prep(intl.ID_BUY)
       this.setOrderBttnText()
       this.setOrderVisibility()
       this.drawChartLines()
@@ -171,7 +155,7 @@ export default class MarketsPage extends BasePage {
       swapBttns(page.buyBttn, page.sellBttn)
       page.submitBttn.classList.add('sellred')
       page.submitBttn.classList.remove('buygreen')
-      page.maxLbl.textContent = window.locales.formatDetails(ID_SELL)
+      page.maxLbl.textContent = intl.prep(intl.ID_SELL)
       this.setOrderBttnText()
       this.setOrderVisibility()
       this.drawChartLines()
@@ -459,7 +443,7 @@ export default class MarketsPage extends BasePage {
     }
     const symbol = (!base && this.market.baseCfg.symbol) || (!quote && this.market.quoteCfg.symbol)
 
-    page.loaderMsg.textContent = window.locales.formatDetails(ID_NOT_SUPPORTED, { asset: symbol.toUpperCase() })
+    page.loaderMsg.textContent = intl.prep(intl.ID_NOT_SUPPORTED, { asset: symbol.toUpperCase() })
     Doc.show(page.loaderMsg)
   }
 
@@ -528,8 +512,8 @@ export default class MarketsPage extends BasePage {
 
   setOrderBttnText () {
     if (this.isSell()) {
-      this.page.submitBttn.textContent = window.locales.formatDetails(ID_SET_BUTTON_SELL, { asset: this.market.base.symbol.toUpperCase() })
-    } else this.page.submitBttn.textContent = window.locales.formatDetails(ID_SET_BUTTON_BUY, { asset: this.market.base.symbol.toUpperCase() })
+      this.page.submitBttn.textContent = intl.prep(intl.ID_SET_BUTTON_SELL, { asset: this.market.base.symbol.toUpperCase() })
+    } else this.page.submitBttn.textContent = intl.prep(intl.ID_SET_BUTTON_BUY, { asset: this.market.base.symbol.toUpperCase() })
   }
 
   /* setMarket sets the currently displayed market. */
@@ -541,7 +525,7 @@ export default class MarketsPage extends BasePage {
     // established, at which time handleConnNote will refresh and reload.
     if (!dex.connected) {
       this.market = { dex: dex }
-      page.chartErrMsg.textContent = window.locales.formatDetails(ID_CONNECTION_FAILED)
+      page.chartErrMsg.textContent = intl.prep(intl.ID_CONNECTION_FAILED)
       Doc.show(page.chartErrMsg)
       this.loaded()
       this.main.style.opacity = 1
@@ -694,7 +678,7 @@ export default class MarketsPage extends BasePage {
     }
     const quoteAsset = app.assets[order.quote]
     const total = Doc.formatCoinValue(order.rate / 1e8 * order.qty / 1e8)
-    page.orderPreview.textContent = window.locales.formatDetails(ID_ORDER_PREVIEW, { total, asset: quoteAsset.symbol.toUpperCase() })
+    page.orderPreview.textContent = intl.prep(intl.ID_ORDER_PREVIEW, { total, asset: quoteAsset.symbol.toUpperCase() })
     if (this.isSell()) this.preSell()
     else this.preBuy()
   }
@@ -764,7 +748,7 @@ export default class MarketsPage extends BasePage {
 
     Doc.show(page.maxOrd, page.maxLotBox)
     Doc.hide(page.maxAboveZero)
-    page.maxFromLots.textContent = window.locales.formatDetails(ID_CALCULATING)
+    page.maxFromLots.textContent = intl.prep(intl.ID_CALCULATING)
     page.maxFromLotsLbl.textContent = ''
     const counter = this.maxOrderUpdateCounter
     this.preorderTimer = window.setTimeout(async () => {
@@ -779,7 +763,7 @@ export default class MarketsPage extends BasePage {
       if (counter !== this.maxOrderUpdateCounter) return
       if (!app.checkResponse(res, true)) {
         console.warn('max order estimate not available:', res)
-        page.maxFromLots.textContent = window.locales.formatDetails(ID_ESTIMATE_UNAVAILABLE)
+        page.maxFromLots.textContent = intl.prep(intl.ID_ESTIMATE_UNAVAILABLE)
         if (this.maxLoaded) {
           this.maxLoaded()
           this.maxLoaded = null
@@ -823,12 +807,12 @@ export default class MarketsPage extends BasePage {
     const page = this.page
     if (order.isLimit && !order.rate) {
       Doc.show(page.orderErr)
-      page.orderErr.textContent = window.locales.formatDetails(ID_NO_ZERO_RATE)
+      page.orderErr.textContent = intl.prep(intl.ID_NO_ZERO_RATE)
       return false
     }
     if (!order.qty) {
       Doc.show(page.orderErr)
-      page.orderErr.textContent = window.locales.formatDetails(ID_NO_ZERO_QUANTITY)
+      page.orderErr.textContent = intl.prep(intl.ID_NO_ZERO_QUANTITY)
       return false
     }
     return true
@@ -1125,7 +1109,7 @@ export default class MarketsPage extends BasePage {
     const fromAsset = isSell ? baseAsset : quoteAsset
 
     page.vQty.textContent = Doc.formatCoinValue(order.qty / 1e8)
-    page.vSideHeader.textContent = isSell ? window.locales.formatDetails(ID_SELL) : window.locales.formatDetails(ID_BUY)
+    page.vSideHeader.textContent = isSell ? intl.prep(intl.ID_SELL) : intl.prep(intl.ID_BUY)
     page.vSideSubmit.textContent = page.vSideHeader.textContent
     page.vBaseSubmit.textContent = baseAsset.symbol.toUpperCase()
     if (order.isLimit) {
@@ -1135,11 +1119,11 @@ export default class MarketsPage extends BasePage {
       page.vQuote.textContent = quoteAsset.symbol.toUpperCase()
       page.vTotal.textContent = Doc.formatCoinValue(order.rate / 1e8 * order.qty / 1e8)
       page.vBase.textContent = baseAsset.symbol.toUpperCase()
-      page.vSide.textContent = isSell ? window.locales.formatDetails(ID_SELL).toLowerCase() : window.locales.formatDetails(ID_BUY).toLowerCase()
+      page.vSide.textContent = isSell ? intl.prep(intl.ID_SELL).toLowerCase() : intl.prep(intl.ID_BUY).toLowerCase()
     } else {
       Doc.hide(page.verifyLimit)
       Doc.show(page.verifyMarket)
-      page.vSide.textContent = window.locales.formatDetails(ID_TRADE)
+      page.vSide.textContent = intl.prep(intl.ID_TRADE)
       page.vBase.textContent = fromAsset.symbol.toUpperCase()
       const gap = this.midGap()
       if (gap) {
@@ -1228,12 +1212,12 @@ export default class MarketsPage extends BasePage {
     const baseWallet = app.walletMap[market.base.id]
     const quoteWallet = app.walletMap[market.quote.id]
     if (!baseWallet) {
-      page.orderErr.textContent = window.locales.formatDetails(ID_NO_ASSET_WALLET, { asset: market.base.symbol })
+      page.orderErr.textContent = intl.prep(intl.ID_NO_ASSET_WALLET, { asset: market.base.symbol })
       Doc.show(page.orderErr)
       return
     }
     if (!quoteWallet) {
-      page.orderErr.textContent = window.locales.formatDetails(ID_NO_ASSET_WALLET, { asset: market.quote.symbol })
+      page.orderErr.textContent = intl.prep(intl.ID_NO_ASSET_WALLET, { asset: market.quote.symbol })
       Doc.show(page.orderErr)
       return
     }
@@ -1304,12 +1288,12 @@ export default class MarketsPage extends BasePage {
       const statusTD = Doc.tmplElement(metaOrder.row, 'status')
       switch (true) {
         case order.type === Order.Limit && order.status === Order.StatusEpoch && alreadyMatched:
-          statusTD.textContent = order.tif === Order.ImmediateTiF ? window.locales.formatDetails(ID_EXECUTED) : window.locales.formatDetails(ID_BOOKED)
+          statusTD.textContent = order.tif === Order.ImmediateTiF ? intl.prep(intl.ID_EXECUTED) : intl.prep(intl.ID_BOOKED)
           order.status = order.tif === Order.ImmediateTiF ? Order.StatusExecuted : Order.StatusBooked
           break
         case order.type === Order.Market && order.status === Order.StatusEpoch:
           // Technically don't know if this should be 'executed' or 'settling'.
-          statusTD.textContent = window.locales.formatDetails(ID_EXECUTED)
+          statusTD.textContent = intl.prep(intl.ID_EXECUTED)
           order.status = Order.StatusExecuted
           break
       }

--- a/client/webserver/site/src/js/order.js
+++ b/client/webserver/site/src/js/order.js
@@ -3,7 +3,7 @@ import BasePage from './basepage'
 import * as Order from './orderutil'
 import { bind as bindForm } from './forms'
 import { postJSON } from './http'
-import { ID_CANCELING } from './locales'
+import * as intl from './locales'
 
 const Mainnet = 0
 const Testnet = 1
@@ -118,7 +118,7 @@ export default class OrderPage extends BasePage {
     const res = await postJSON('/api/cancel', req)
     loaded()
     if (!app.checkResponse(res)) return
-    page.status.textContent = window.locales.formatDetails(ID_CANCELING)
+    page.status.textContent = intl.prep(intl.ID_CANCELING)
     Doc.hide(page.forms)
     order.cancelling = true
   }

--- a/client/webserver/site/src/js/orderutil.js
+++ b/client/webserver/site/src/js/orderutil.js
@@ -1,4 +1,5 @@
 import Doc from './doc'
+import * as intl from './locales'
 
 export const Limit = 1
 export const Market = 2
@@ -52,16 +53,18 @@ export function hasLiveMatches (order) {
 export function statusString (order) {
   const isLive = hasLiveMatches(order)
   switch (order.status) {
-    case StatusUnknown: return 'unknown'
-    case StatusEpoch: return 'epoch'
+    case StatusUnknown: return intl.prep(intl.ID_UNKNOWN)
+    case StatusEpoch: return intl.prep(intl.ID_EPOCH)
     case StatusBooked:
-      if (order.cancelling) return 'cancelling'
-      return isLive ? 'booked/settling' : 'booked'
+      if (order.cancelling) return intl.prep(intl.ID_CANCELING)
+      return isLive ? `${intl.prep(intl.ID_BOOKED)}/${intl.prep(intl.ID_SETTLING)}` : intl.prep(intl.ID_BOOKED)
     case StatusExecuted:
-      if (isLive) return 'settling'
-      return (order.filled === 0) ? 'no match' : 'executed'
-    case StatusCanceled: return isLive ? 'canceled/settling' : 'canceled'
-    case StatusRevoked: return isLive ? 'revoked/settling' : 'revoked'
+      if (isLive) return intl.prep(intl.ID_SETTLING)
+      return (order.filled === 0) ? intl.prep(intl.ID_NO_MATCH) : intl.prep(intl.ID_EXECUTED)
+    case StatusCanceled:
+      return isLive ? `${intl.prep(intl.ID_CANCELED)}/${intl.prep(intl.ID_SETTLING)}` : intl.prep(intl.ID_CANCELED)
+    case StatusRevoked:
+      return isLive ? `${intl.prep(intl.ID_REVOKED)}/${intl.prep(intl.ID_SETTLING)}` : intl.prep(intl.ID_REVOKED)
   }
 }
 

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -2,7 +2,7 @@ import Doc from './doc'
 import BasePage from './basepage'
 import { postJSON } from './http'
 import { NewWalletForm, UnlockWalletForm, DEXAddressForm, ConfirmRegistrationForm, bind as bindForm } from './forms'
-import { ID_NO_PASS_ERROR_MSG, ID_PASSWORD_NOT_MATCH } from './locales'
+import * as intl from './locales'
 
 const DCR_ID = 42
 const animationLength = 300
@@ -125,12 +125,12 @@ export default class RegistrationPage extends BasePage {
     const pw = page.appPW.value
     const pwAgain = page.appPWAgain.value
     if (pw === '') {
-      page.appPWErrMsg.textContent = window.locales.formatDetails(ID_NO_PASS_ERROR_MSG)
+      page.appPWErrMsg.textContent = intl.prep(intl.ID_NO_PASS_ERROR_MSG)
       Doc.show(page.appPWErrMsg)
       return
     }
     if (pw !== pwAgain) {
-      page.appPWErrMsg.textContent = window.locales.formatDetails(ID_PASSWORD_NOT_MATCH)
+      page.appPWErrMsg.textContent = intl.prep(intl.ID_PASSWORD_NOT_MATCH)
       Doc.show(page.appPWErrMsg)
       return
     }

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -3,7 +3,7 @@ import BasePage from './basepage'
 import State from './state'
 import { postJSON } from './http'
 import * as forms from './forms'
-import { ID_NO_APP_PASS_ERROR_MSG, ID_ACCT_UNDEFINED, ID_PASSWORD_NOT_MATCH } from './locales'
+import * as intl from './locales'
 
 const animationLength = 300
 
@@ -233,7 +233,7 @@ export default class SettingsPage extends BasePage {
       return
     }
     if (typeof account === 'undefined') {
-      page.importAccountErr.textContent = window.locales.formatDetails(ID_ACCT_UNDEFINED)
+      page.importAccountErr.textContent = intl.prep(intl.ID_ACCT_UNDEFINED)
       Doc.show(page.importAccountErr)
       return
     }
@@ -338,14 +338,14 @@ export default class SettingsPage extends BasePage {
     }
     // Ensure password fields are nonempty.
     if (!page.appPW.value || !page.newAppPW.value || !page.confirmNewPW.value) {
-      page.changePWErrMsg.textContent = window.locales.formatDetails(ID_NO_APP_PASS_ERROR_MSG)
+      page.changePWErrMsg.textContent = intl.prep(intl.ID_NO_APP_PASS_ERROR_MSG)
       Doc.show(page.changePWErrMsg)
       clearValues()
       return
     }
     // Ensure password confirmation matches.
     if (page.newAppPW.value !== page.confirmNewPW.value) {
-      page.changePWErrMsg.textContent = window.locales.formatDetails(ID_PASSWORD_NOT_MATCH)
+      page.changePWErrMsg.textContent = intl.prep(intl.ID_PASSWORD_NOT_MATCH)
       Doc.show(page.changePWErrMsg)
       clearValues()
       return

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -4,7 +4,7 @@ import { postJSON } from './http'
 import { NewWalletForm, WalletConfigForm, UnlockWalletForm, bind as bindForm } from './forms'
 import * as ntfn from './notifications'
 import State from './state'
-import { ID_NO_APP_PASS_ERROR_MSG, ID_KEEP_WALLET_PASS, ID_NEW_WALLET_PASS } from './locales'
+import * as intl from './locales'
 
 const bind = Doc.bind
 const animationLength = 300
@@ -163,12 +163,12 @@ export default class WalletsPage extends BasePage {
     if (visible) {
       Doc.hide(this.page.showIcon)
       Doc.show(this.page.hideIcon, this.page.changePW)
-      this.page.switchPWMsg.textContent = window.locales.formatDetails(ID_KEEP_WALLET_PASS)
+      this.page.switchPWMsg.textContent = intl.prep(intl.ID_KEEP_WALLET_PASS)
       return
     }
     Doc.hide(this.page.hideIcon, this.page.changePW)
     Doc.show(this.page.showIcon)
-    this.page.switchPWMsg.textContent = window.locales.formatDetails(ID_NEW_WALLET_PASS)
+    this.page.switchPWMsg.textContent = intl.prep(intl.ID_NEW_WALLET_PASS)
   }
 
   /*
@@ -426,7 +426,7 @@ export default class WalletsPage extends BasePage {
     const page = this.page
     Doc.hide(page.reconfigErr)
     if (!page.appPW.value && !State.passwordIsCached()) {
-      page.reconfigErr.textContent = window.locales.formatDetails(ID_NO_APP_PASS_ERROR_MSG)
+      page.reconfigErr.textContent = intl.prep(intl.ID_NO_APP_PASS_ERROR_MSG)
       Doc.show(page.reconfigErr)
       return
     }

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -34,10 +34,7 @@
 
 {{define "newWalletForm"}}
 <div class="bg2 px-2 py-1 text-center fs18 position-relative">
-  Add a
-  <img id="nwAssetLogo" class="micro-icon mx-1">
-  <span id="nwAssetName"></span>
-  Wallet
+  Add a <img id="nwAssetLogo" class="micro-icon mx-1"> <span id="nwAssetName"></span> Wallet
   <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
 </div>
 <div class="p-4">

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -9,7 +9,7 @@
     <span data-state="syncing" 
       class="ico-sync fs12{{if or (not $w.Running) $w.Synced}} d-hide{{end}}"
       data-tooltip="wallet is {{printf "%.2f" (x100  $w.SyncProgress)}}% synced"></span>
-    <span data-state="status" class="txt-status">{{walletStatusString $w}}</span>
+    <span data-state="status" class="txt-status">{{if $w.Open}}ready{{else if $w.Running}}locked{{else}}off{{end}}</span>
   {{else}}
     <span data-state="sleeping" class="ico-sleeping fs17 grey d-hide"></span>
     <span data-state="locked" class="ico-locked grey d-hide"></span>

--- a/client/webserver/template.go
+++ b/client/webserver/template.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"decred.org/dcrdex/client/core"
 	"decred.org/dcrdex/client/webserver/locales"
 )
 
@@ -204,16 +203,6 @@ var templateFuncs = template.FuncMap{
 	},
 	"fromAtoms": func(v uint64) float64 {
 		return float64(v) / 1e8
-	},
-	"walletStatusString": func(status *core.WalletState) string {
-		switch {
-		case status.Open:
-			return "ready"
-		case status.Running:
-			return "locked"
-		default:
-			return "off"
-		}
 	},
 	"x100": func(v float32) float32 {
 		return v * 100


### PR DESCRIPTION
- Adds a couple of missed translations. I wanted to sneak this in before #1185.

- Refactors **locales.js**. I think the changes make the import and use of the module cleaner.

