### PR TITLE
client/core: discover account via connect instead of register

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -4362,7 +4362,7 @@ func TestResolveActiveTrades(t *testing.T) {
 	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
 	tCore.wallets[tDCR.ID] = dcrWallet
 
-	rig.acct.auth() // Short path through initializeDEXConnections
+	rig.acct.auth(false) // Short path through initializeDEXConnections
 
 	// Create an order
 	qty := dcrBtcLotSize * 5

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -42,6 +42,7 @@ const (
 	unknownDEXErr
 	accountRetrieveErr
 	accountDisableErr
+	suspendedAcctErr
 )
 
 // Error is an error message and an error code.

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -894,6 +894,7 @@ type ConnectResult struct {
 	ActiveOrderStatuses []*OrderStatus `json:"activeorderstatuses"`
 	ActiveMatches       []*Match       `json:"activematches"`
 	Score               int32          `json:"score"`
+	Suspended           *bool          `json:"suspended,omitempty"` // will be implied (obsolete) with tiers and bonds
 }
 
 // PenaltyNote is the payload of a Penalty notification.

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -1284,6 +1284,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 		ActiveOrderStatuses: msgOrderStatuses,
 		ActiveMatches:       msgMatches,
 		Score:               score,
+		Suspended:           &client.suspended,
 	}
 	respMsg, err := msgjson.NewResponse(msg.ID, resp, nil)
 	if err != nil {
@@ -1300,8 +1301,8 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 		return nil
 	}
 
-	log.Infof("Authenticated account %v from %v with %d active orders, %d active matches",
-		user, conn.Addr(), len(msgOrderStatuses), len(msgMatches))
+	log.Infof("Authenticated account %v from %v with %d active orders, %d active matches (score = %d, suspended = %v)",
+		user, conn.Addr(), len(msgOrderStatuses), len(msgMatches), score, client.suspended)
 	auth.addClient(client)
 	return nil
 }


### PR DESCRIPTION
This is a prerequisite for multi-asset registration fee support.

Instead of using the `'register'` route to discover an existing account when restoring from an seed, use `'connect'` (`authDEX`).  Initially suggested https://github.com/decred/dcrdex/pull/1015#discussion_r666440449

This allows account discovery without having to request a registration address.  More importantly, when registration may be done with more than one asset, this avoids having to commit to a certain registration asset in order to discover an existing account.  This is because the `'register'` route will require an asset ID in a multi-asset registration scheme.

This eliminates the "in-process"/"incomplete" registration field and simplifies some logic in `Register`.