### PR TITLE
multi: register with different assets, add BTC

### DIFF
--- a/client/cmd/dexcctl/dexcctl_test.go
+++ b/client/cmd/dexcctl/dexcctl_test.go
@@ -108,14 +108,14 @@ func TestReadTextFile(t *testing.T) {
 		wantErr                           bool
 	}{{
 		name:        "ok with cert",
-		cmd:         "getfee",
+		cmd:         "getdexconfig",
 		args:        []string{"1.2.3.4:3000", "./cert"},
 		txtFilePath: "./cert",
 		txtToSave:   certTxt,
 		want:        []string{"1.2.3.4:3000", certTxt},
 	}, {
 		name: "ok no cert",
-		cmd:  "getfee",
+		cmd:  "getdexconfig",
 		args: []string{"1.2.3.4:3000"},
 		want: []string{"1.2.3.4:3000"},
 	}, {
@@ -123,7 +123,7 @@ func TestReadTextFile(t *testing.T) {
 		cmd:  "not a real command",
 	}, {
 		name:    "no file at path",
-		cmd:     "getfee",
+		cmd:     "getdexconfig",
 		args:    []string{"1.2.3.4:3000", "./cert"},
 		wantErr: true,
 	}, {

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -67,9 +67,9 @@ var promptPasswords = map[string][]string{
 // the text content of a file, where the file path _may_ be found in the route's
 // cmd args at the specified index.
 var optionalTextFiles = map[string]int{
-	"getfee":    1,
-	"register":  2,
-	"newwallet": 1,
+	"getdexconfig": 1,
+	"register":     3,
+	"newwallet":    1,
 }
 
 // promptPWs prompts for passwords on stdin and returns an error if prompting

--- a/client/cmd/dexcctl/simnet-setup.sh
+++ b/client/cmd/dexcctl/simnet-setup.sh
@@ -41,7 +41,7 @@ if [ $ETH_ON -eq 0 ]; then
 fi
 
 echo registering with DEX
-./dexcctl -p abc --simnet register 127.0.0.1:17273 100000000 ~/dextest/dcrdex/rpc.cert
+./dexcctl -p abc --simnet register 127.0.0.1:17273 100000000 42 ~/dextest/dcrdex/rpc.cert
 
 echo mining fee confirmation blocks
 tmux send-keys -t dcr-harness:0 "./mine-alpha 1" C-m

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5067,7 +5067,7 @@ func (c *Core) handleReconnect(host string) {
 		return
 	}
 
-	if !dc.acct.locked() && len(dc.acct.feeCoin) > 0 {
+	if !dc.acct.locked() && dc.acct.feePaid() {
 		err = c.authDEX(dc)
 		if err != nil {
 			c.log.Errorf("handleReconnect: Unable to authorize DEX at %s: %v", host, err)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"net/url"
 	"os"
@@ -43,13 +42,8 @@ import (
 )
 
 const (
-	keyParamsKey      = "keyParams"
-	conversionFactor  = 1e8
-	regFeeAssetSymbol = "dcr" // Hard-coded to Decred for registration fees, for now.
-
-	// regConfirmationsPaid is used to indicate completed registration to
-	// (*Core).setRegConfirms.
-	regConfirmationsPaid uint32 = math.MaxUint32
+	keyParamsKey     = "keyParams"
+	conversionFactor = 1e8
 
 	// tickCheckDivisions is how many times to tick trades per broadcast timeout
 	// interval. e.g. 12 min btimeout / 8 divisions = 90 sec between checks.
@@ -99,6 +93,11 @@ func (dt *dexTicker) Dur() time.Duration {
 	return time.Duration(atomic.LoadInt64(&dt.dur))
 }
 
+type pendingFeeState struct {
+	confs uint32
+	asset uint32
+}
+
 // dexConnection is the websocket connection and the DEX configuration.
 type dexConnection struct {
 	comms.WsConn
@@ -129,8 +128,8 @@ type dexConnection struct {
 	// connected is a best guess on the ws connection status.
 	connected uint32
 
-	regConfMtx  sync.RWMutex
-	regConfirms *uint32 // nil regConfirms means no pending registration.
+	pendingFeeMtx sync.RWMutex
+	pendingFee    *pendingFeeState
 
 	reportingConnects uint32
 }
@@ -151,6 +150,16 @@ func (dc *dexConnection) running(mkt string) bool {
 		return false // not found means not running
 	}
 	return mktCfg.Running()
+}
+
+func (dc *dexConnection) feeAsset(assetID uint32) *msgjson.FeeAsset {
+	dc.cfgMtx.RLock()
+	defer dc.cfgMtx.RUnlock()
+	if dc.cfg == nil {
+		return nil
+	}
+	symb := unbip(assetID)
+	return dc.cfg.RegFees[symb]
 }
 
 // marketConfig is the market's configuration, as returned by the server in the
@@ -227,25 +236,32 @@ func (dc *dexConnection) marketTrades(mktID string) []*trackedTrade {
 	return trades
 }
 
-// getRegConfirms returns the number of confirmations received for the
-// dex registration or nil if the registration is completed
-func (dc *dexConnection) getRegConfirms() *uint32 {
-	dc.regConfMtx.RLock()
-	defer dc.regConfMtx.RUnlock()
-	return dc.regConfirms
+func (dc *dexConnection) setPendingFee(asset, confs uint32) {
+	dc.pendingFeeMtx.Lock()
+	dc.pendingFee = &pendingFeeState{asset: asset, confs: confs}
+	dc.pendingFeeMtx.Unlock()
 }
 
-// setRegConfirms sets the number of confirmations received
-// for the dex registration
-func (dc *dexConnection) setRegConfirms(confs uint32) {
-	dc.regConfMtx.Lock()
-	defer dc.regConfMtx.Unlock()
-	if confs == regConfirmationsPaid {
-		// A nil regConfirms indicates that there is no pending registration.
-		dc.regConfirms = nil
-		return
+func (dc *dexConnection) clearPendingFee() {
+	dc.pendingFeeMtx.Lock()
+	dc.pendingFee = nil
+	dc.pendingFeeMtx.Unlock()
+}
+
+// getPendingFee returns the PendingFeeState for the dex registration or nil if
+// no registration fee is pending.
+func (dc *dexConnection) getPendingFee() *PendingFeeState {
+	dc.pendingFeeMtx.RLock()
+	defer dc.pendingFeeMtx.RUnlock()
+	pf := dc.pendingFee
+	if pf == nil {
+		return nil
 	}
-	dc.regConfirms = &confs
+	return &PendingFeeState{
+		AssetID: pf.asset,
+		Symbol:  unbip(pf.asset),
+		Confs:   pf.confs,
+	}
 }
 
 func (dc *dexConnection) exchangeInfo() *Exchange {
@@ -263,9 +279,8 @@ func (dc *dexConnection) exchangeInfo() *Exchange {
 		return &Exchange{
 			Host:       dc.acct.host,
 			AcctID:     acctID,
-			FeePending: dc.acct.feePending(),
 			Connected:  atomic.LoadUint32(&dc.connected) == 1,
-			// RegConfirms:   dc.getRegConfirms(), // could show, but we don't know required
+			PendingFee: dc.getPendingFee(),
 		}
 	}
 
@@ -276,20 +291,33 @@ func (dc *dexConnection) exchangeInfo() *Exchange {
 	}
 	dc.assetsMtx.RUnlock()
 
-	return &Exchange{
-		Host:          dc.acct.host,
-		AcctID:        acctID,
-		Markets:       dc.marketMap(),
-		Assets:        assets,
-		FeePending:    dc.acct.feePending(),
-		Connected:     atomic.LoadUint32(&dc.connected) == 1,
-		ConfsRequired: uint32(cfg.RegFeeConfirms),
-		RegConfirms:   dc.getRegConfirms(),
-		Fee: &FeeAsset{ // v0 is only DCR, but there will be a RegFees map[string]*FeeAsset field
+	feeAssets := make(map[string]*FeeAsset, len(cfg.RegFees))
+	for symb, asset := range cfg.RegFees {
+		feeAssets[symb] = &FeeAsset{
+			ID:    asset.ID,
+			Confs: asset.Confs,
+			Amt:   asset.Amt,
+		}
+	}
+	dcrAsset := feeAssets["dcr"]
+	if dcrAsset == nil { // should have happened in refreshServerConfig
+		dcrAsset = &FeeAsset{
 			ID:    42,
 			Amt:   cfg.Fee,
 			Confs: uint32(cfg.RegFeeConfirms),
-		},
+		}
+		feeAssets["dcr"] = dcrAsset
+	}
+
+	return &Exchange{
+		Host:       dc.acct.host,
+		AcctID:     acctID,
+		Markets:    dc.marketMap(),
+		Assets:     assets,
+		Connected:  atomic.LoadUint32(&dc.connected) == 1,
+		Fee:        dcrAsset,
+		RegFees:    feeAssets,
+		PendingFee: dc.getPendingFee(),
 	}
 }
 
@@ -1413,7 +1441,8 @@ func (c *Core) connectAndUpdateWallet(w *xcWallet) error {
 func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 	wallet, exists := c.wallet(assetID)
 	if !exists {
-		return nil, newError(missingWalletErr, "no configured wallet found %s (%d)", unbip(assetID), assetID)
+		return nil, newError(missingWalletErr, "no configured wallet found for %s (%d)",
+			strings.ToUpper(unbip(assetID)), assetID)
 	}
 	if !wallet.connected() {
 		err := c.connectAndUpdateWallet(wallet)
@@ -1822,9 +1851,7 @@ func (c *Core) OpenWallet(assetID uint32, appPW []byte) error {
 		state.Symbol, balances.Available, balances.Locked, balances.ContractLocked,
 		state.Address)
 
-	if dcrID, _ := dex.BipSymbolID(regFeeAssetSymbol); assetID == dcrID {
-		go c.checkUnpaidFees(wallet)
-	}
+	go c.checkUnpaidFees(wallet)
 
 	c.notify(newWalletStateNote(state))
 
@@ -2208,18 +2235,6 @@ func (c *Core) isRegistered(host string) bool {
 	return len(dc.acct.encKey) > 0 // should be for all in conns map, but check
 }
 
-// GetFee creates a temporary connection to the specified DEX Server and fetches
-// the registration fee. The connection is closed after the fee is retrieved.
-// Returns an error if user is already registered to the DEX. A TLS certificate,
-// certI, can be provided as either a string filename, or []byte file contents.
-func (c *Core) GetFee(dexAddr string, certI interface{}) (uint64, error) {
-	xc, err := c.GetDEXConfig(dexAddr, certI)
-	if err != nil {
-		return 0, err
-	}
-	return xc.Fee.Amt, nil
-}
-
 // tempDexConnection creates an unauthenticated dexConnection. The caller must
 // dc.connMaster.Disconnect when done with the connection.
 func (c *Core) tempDexConnection(dexAddr string, certI interface{}) (*dexConnection, error) {
@@ -2345,6 +2360,7 @@ func (c *Core) DiscoverAccount(dexAddr string, appPW []byte, certI interface{}) 
 	// Actual fee asset ID and coin are unknown, but paid.
 	dc.acct.isPaid = true
 	dc.acct.feeCoin = []byte("DUMMY COIN")
+	dc.acct.feeAssetID = 42
 
 	err = c.db.CreateAccount(&db.AccountInfo{
 		Host:         dc.acct.host,
@@ -2352,6 +2368,7 @@ func (c *Core) DiscoverAccount(dexAddr string, appPW []byte, certI interface{}) 
 		DEXPubKey:    dc.acct.dexPubKey,
 		EncKeyV2:     encKey,
 		LegacyEncKey: nil,
+		FeeAssetID:   dc.acct.feeAssetID,
 		FeeCoin:      dc.acct.feeCoin,
 		// Paid set with AccountPaid below.
 	})
@@ -2403,7 +2420,13 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 		return nil, newError(dupeDEXErr, "already registered at %s", form.Addr)
 	}
 
-	regFeeAssetID, _ := dex.BipSymbolID(regFeeAssetSymbol)
+	// Default to using DCR unless specified.
+	regFeeAssetID := uint32(42)
+	if form.Asset != nil {
+		regFeeAssetID = *form.Asset
+	}
+	regFeeAssetSymbol := dex.BipIDSymbol(regFeeAssetID)
+
 	wallet, err := c.connectedWallet(regFeeAssetID)
 	if err != nil {
 		// Wrap the error from connectedWallet, a core.Error coded as
@@ -2435,6 +2458,17 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 		return nil, codedError(connectionErr, err)
 	}
 
+	// Ensure this DEX supports this asset for registration fees, and get the
+	// required confirmations and fee amount.
+	dc.cfgMtx.RLock()
+	feeAsset, supported := dc.cfg.RegFees[regFeeAssetSymbol]
+	dc.cfgMtx.RUnlock()
+	if !supported || feeAsset == nil {
+		return nil, newError(assetSupportErr, "dex server does not accept registration fees in asset %q", regFeeAssetSymbol)
+	}
+	reqConfs := feeAsset.Confs
+	// TODO: basic sanity check on required confirms, e.g. > 1000, but asset-specific
+
 	// close the connection to the dex server if the registration fails.
 	var registrationComplete bool
 	defer func() {
@@ -2443,23 +2477,16 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 		}
 	}()
 
-	dc.assetsMtx.RLock()
-	regAsset, found := dc.assets[regFeeAssetID]
-	dc.assetsMtx.RUnlock()
-	if !found {
-		return nil, newError(assetSupportErr, "dex server does not support %s asset", regFeeAssetSymbol)
-	}
-
 	var incompleteReg *incompleteRegistration
 	dexSupportsHDAccts := dc.acct.dexPubKey != nil
 	if dexSupportsHDAccts {
 		var paid bool
-		incompleteReg, paid, err = c.registerHD(dc, crypter)
+		incompleteReg, paid, err = c.registerHD(dc, crypter, feeAsset.ID)
 		if err != nil {
 			return nil, err
 		}
 		if paid {
-			res := &RegisterResult{FeeID: hex.EncodeToString(dc.acct.feeCoin), ReqConfirms: 0}
+			res := &RegisterResult{FeeID: hex.EncodeToString(dc.acct.feeCoin) /* NOTE: no asset ID */, ReqConfirms: 0}
 			return res, nil
 		}
 	}
@@ -2477,7 +2504,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 		c.log.Infof("Generating a legacy-style key to register with %s.", dc.acct.host)
 		var paid bool
 		dc.acct.resetKeys() // clear any previously set HD acct keys
-		incompleteReg, paid, err = c.registerLegacy(dc, crypter)
+		incompleteReg, paid, err = c.registerLegacy(dc, crypter, feeAsset.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -2498,9 +2525,8 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	if err := dc.acct.unlock(crypter); err != nil {
 		return nil, newError(authErr, "failed to unlock account: %v", err)
 	}
-	fee := dc.cfg.Fee
-
 	// Check that the fee is non-zero.
+	fee := feeAsset.Amt // expected amount according to DEX config
 	if incompleteReg.regRes.Fee == 0 {
 		return nil, newError(zeroFeeErr, "zero registration fees not allowed")
 	}
@@ -2515,7 +2541,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	acctID := account.NewID(incompleteReg.acctPub)
 	c.log.Infof("Attempting registration fee payment to %s, account ID %v, of %d units of %s. "+
 		"Do NOT manually send funds to this address even if this fails.",
-		incompleteReg.regRes.Address, acctID, incompleteReg.regRes.Fee, regAsset.Symbol)
+		incompleteReg.regRes.Address, acctID, incompleteReg.regRes.Fee, regFeeAssetSymbol)
 	coin, err := wallet.PayFee(incompleteReg.regRes.Address, incompleteReg.regRes.Fee)
 	if err != nil {
 		return nil, newError(feeSendErr, "error paying registration fee: %v", err)
@@ -2523,10 +2549,10 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 
 	// Set the dexConnection account fields and save account info to db.
 	dc.acct.feeCoin = coin.ID()
+	dc.acct.feeAssetID = feeAsset.ID
 
 	// Registration complete.
 	registrationComplete = true
-	requiredConfs := dc.cfg.RegFeeConfirms
 	c.connMtx.Lock()
 	c.conns[host] = dc
 	c.connMtx.Unlock()
@@ -2534,10 +2560,12 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	err = c.db.CreateAccount(&db.AccountInfo{
 		Host:         dc.acct.host,
 		Cert:         dc.acct.cert,
-		LegacyEncKey: incompleteReg.encKeyLegacy,
-		EncKeyV2:     incompleteReg.encKey,
 		DEXPubKey:    dc.acct.dexPubKey,
+		EncKeyV2:     incompleteReg.encKey,
+		LegacyEncKey: incompleteReg.encKeyLegacy,
+		FeeAssetID:   dc.acct.feeAssetID,
 		FeeCoin:      dc.acct.feeCoin,
+		// Paid set with AccountPaid after notifyFee.
 	})
 	if err != nil {
 		c.log.Errorf("error saving account: %v\n", err)
@@ -2546,15 +2574,14 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 
 	c.updateAssetBalance(regFeeAssetID)
 
-	subject, details := c.formatDetails(TopicFeePaymentInProgress, requiredConfs, dc.acct.host)
+	subject, details := c.formatDetails(TopicFeePaymentInProgress, reqConfs, dc.acct.host)
 	c.notify(newFeePaymentNote(TopicFeePaymentInProgress, subject, details, db.Success, dc.acct.host))
 
 	// Set up the coin waiter, which waits for the required number of
 	// confirmations to notify the DEX and establish an authenticated
 	// connection.
-	c.verifyRegistrationFee(wallet.AssetID, dc, coin.ID(), 0)
-
-	res := &RegisterResult{FeeID: coin.String(), ReqConfirms: requiredConfs}
+	c.verifyRegistrationFee(wallet.AssetID, dc, coin.ID(), 0, reqConfs)
+	res := &RegisterResult{FeeID: coin.String(), ReqConfirms: uint16(reqConfs)}
 	return res, nil
 }
 
@@ -2563,7 +2590,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 // indicates that this is a new account. The first return variable contains
 // info that the caller can use to complete this registration by paying the
 // fee where necessary.
-func (c *Core) registerHD(dc *dexConnection, crypter encrypt.Crypter) (*incompleteRegistration, bool, error) {
+func (c *Core) registerHD(dc *dexConnection, crypter encrypt.Crypter, assetID uint32) (*incompleteRegistration, bool, error) {
 	if dc.acct.dexPubKey == nil {
 		return nil, false, fmt.Errorf("DEX %s does not support HD account registration", dc.acct.host)
 	}
@@ -2574,7 +2601,7 @@ func (c *Core) registerHD(dc *dexConnection, crypter encrypt.Crypter) (*incomple
 		return nil, false, newError(acctKeyErr, "setupCryptoV2 error: %v", err)
 	}
 
-	return c.register(dc, encKey, nil, acctPubB)
+	return c.register(dc, encKey, nil, acctPubB, assetID)
 }
 
 // registerLegacy sets up a legacy-style account for this DEX and submits a new
@@ -2582,12 +2609,12 @@ func (c *Core) registerHD(dc *dexConnection, crypter encrypt.Crypter) (*incomple
 // response indicates that this is a new account. The first return variable
 // contains info that the caller can use to complete this registration by paying
 // the fee where necessary.
-func (c *Core) registerLegacy(dc *dexConnection, crypter encrypt.Crypter) (*incompleteRegistration, bool, error) {
+func (c *Core) registerLegacy(dc *dexConnection, crypter encrypt.Crypter, assetID uint32) (*incompleteRegistration, bool, error) {
 	encKeyLegacy, acctPubB, err := dc.acct.setupCryptoLegacy(crypter)
 	if err != nil {
 		return nil, false, codedError(acctKeyErr, err)
 	}
-	return c.register(dc, nil, encKeyLegacy, acctPubB)
+	return c.register(dc, nil, encKeyLegacy, acctPubB, assetID)
 }
 
 // register submits a new 'register' request to the server. Only one of encKey
@@ -2601,7 +2628,7 @@ func (c *Core) registerLegacy(dc *dexConnection, crypter encrypt.Crypter) (*inco
 // the account exists and fee is paid, the account is restored, the dc is auth'ed
 // and added to the conns map and a goroutine is started to listen for server
 // messages.
-func (c *Core) register(dc *dexConnection, encKey, encKeyLegacy, acctPubB []byte) (incompleteReg *incompleteRegistration, paid bool, err error) {
+func (c *Core) register(dc *dexConnection, encKey, encKeyLegacy, acctPubB []byte, assetID uint32) (incompleteReg *incompleteRegistration, paid bool, err error) {
 	if len(encKey) > 0 && len(encKeyLegacy) > 0 {
 		return nil, false, fmt.Errorf("cannot register with BOTH HD acct key and legacy acct key")
 	}
@@ -2609,6 +2636,7 @@ func (c *Core) register(dc *dexConnection, encKey, encKeyLegacy, acctPubB []byte
 	dexReg := &msgjson.Register{
 		PubKey: acctPubB,
 		Time:   encode.UnixMilliU(time.Now()),
+		Asset:  &assetID,
 	}
 	regRes := new(msgjson.RegisterResult)
 	err = dc.signAndRequest(dexReg, msgjson.RegisterRoute, regRes, DefaultResponseTimeout)
@@ -2635,6 +2663,13 @@ func (c *Core) register(dc *dexConnection, encKey, encKeyLegacy, acctPubB []byte
 		if err != nil {
 			return nil, false, newError(signatureErr, "%s pubkey error: %v", dc.acct.host, err)
 		}
+		// Compatibility with older servers that do not include asset ID.
+		if regRes.AssetID != nil && assetID != *regRes.AssetID {
+			return nil, false, fmt.Errorf("requested fee payment with asset %d, got details for %d", assetID, regRes.AssetID)
+		}
+		if regRes.AssetID == nil && assetID != 42 {
+			return nil, false, fmt.Errorf("server only supports registration with DCR")
+		}
 		// Fresh account registration success.
 		return
 	}
@@ -2656,13 +2691,13 @@ func (c *Core) register(dc *dexConnection, encKey, encKeyLegacy, acctPubB []byte
 			// This is now account recovery, which is great news since we don't
 			// have to pay the fee. Server provides fee coin as the error message.
 			c.log.Infof("%s is reporting that this account already exists. Skipping fee payment.", dc.acct.host)
+			dc.acct.feeAssetID = 42 // actual asset ID unknown, but paid
 			dc.acct.feeCoin, err = hex.DecodeString(msgErr.Message)
 			if err != nil || len(dc.acct.feeCoin) == 0 { // err may be nil but feeCoin is empty, e.g. if msgErr.Message == ""
 				c.log.Errorf("Failed to decode fee coin from pre-paid account info message = %q, err = %v", msgErr.Message, err)
 				dc.acct.feeCoin = []byte("DUMMY COIN")
 			} else {
-				regFeeAssetID, _ := dex.BipSymbolID(regFeeAssetSymbol)
-				cid, err := asset.DecodeCoinID(regFeeAssetID, dc.acct.feeCoin)
+				cid, err := asset.DecodeCoinID(dc.acct.feeAssetID, dc.acct.feeCoin)
 				if err != nil {
 					c.log.Errorf("Failed to decode coin ID for pre-paid account from feeCoin = %x, err = %v", dc.acct.feeCoin, err)
 				} else {
@@ -2673,10 +2708,12 @@ func (c *Core) register(dc *dexConnection, encKey, encKeyLegacy, acctPubB []byte
 			err = c.db.CreateAccount(&db.AccountInfo{
 				Host:         dc.acct.host,
 				Cert:         dc.acct.cert,
-				LegacyEncKey: encKeyLegacy,
-				EncKeyV2:     encKey,
 				DEXPubKey:    dc.acct.dexPubKey,
+				EncKeyV2:     encKey,
+				LegacyEncKey: encKeyLegacy,
+				FeeAssetID:   dc.acct.feeAssetID,
 				FeeCoin:      dc.acct.feeCoin,
+				// Paid set with AccountPaid below.
 			})
 			if err != nil {
 				// Shouldn't let the client trade with this server if we can't store
@@ -2725,12 +2762,8 @@ func (c *Core) register(dc *dexConnection, encKey, encKeyLegacy, acctPubB []byte
 // If the server acknowledgment is successful, the account is set as 'paid' in
 // the database. Notifications about confirmations increase, errors and success
 // events are broadcasted to all subscribers.
-func (c *Core) verifyRegistrationFee(assetID uint32, dc *dexConnection, coinID []byte, confs uint32) {
-	dc.cfgMtx.RLock()
-	reqConfs := uint32(dc.cfg.RegFeeConfirms)
-	dc.cfgMtx.RUnlock()
-
-	dc.setRegConfirms(confs)
+func (c *Core) verifyRegistrationFee(assetID uint32, dc *dexConnection, coinID []byte, confs, reqConfs uint32) {
+	dc.setPendingFee(assetID, confs)
 
 	trigger := func() (bool, error) {
 		// We already know the wallet is there by now.
@@ -2741,9 +2774,9 @@ func (c *Core) verifyRegistrationFee(assetID uint32, dc *dexConnection, coinID [
 		}
 
 		if confs < reqConfs {
-			dc.setRegConfirms(confs)
+			dc.setPendingFee(assetID, confs)
 			subject, details := c.formatDetails(TopicRegUpdate, confs, reqConfs)
-			c.notify(newFeePaymentNoteWithConfirmations(TopicRegUpdate, subject, details, db.Data, confs, dc.acct.host))
+			c.notify(newFeePaymentNoteWithConfirmations(TopicRegUpdate, subject, details, db.Data, assetID, confs, dc.acct.host))
 		}
 
 		return confs >= reqConfs, nil
@@ -2757,7 +2790,7 @@ func (c *Core) verifyRegistrationFee(assetID uint32, dc *dexConnection, coinID [
 				subject, details := c.formatDetails(TopicFeePaymentError, dc.acct.host, err)
 				c.notify(newFeePaymentNote(TopicFeePaymentError, subject, details, db.ErrorLevel, dc.acct.host))
 			} else {
-				dc.setRegConfirms(regConfirmationsPaid)
+				dc.clearPendingFee()
 				subject, details := c.formatDetails(TopicAccountRegistered, dc.acct.host)
 				c.notify(newFeePaymentNote(TopicAccountRegistered, subject, details, db.Success, dc.acct.host))
 			}
@@ -3323,7 +3356,7 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 			continue // authDEX already done
 		}
 		result.AcctID = dc.acct.ID().String()
-		dcrID, _ := dex.BipSymbolID(regFeeAssetSymbol)
+
 		if !dc.acct.feePaid() {
 			if len(dc.acct.feeCoin) == 0 {
 				subject, details := c.formatDetails(TopicFeeCoinError, dc.acct.host)
@@ -3331,9 +3364,9 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 				result.AuthErr = details
 				continue
 			}
-			// Try to unlock the Decred wallet, which should run the reFee cycle, and
+			// Try to unlock the fee wallet, which should run the reFee cycle, and
 			// in turn will run authDEX.
-			dcrWallet, err := c.connectedWallet(dcrID)
+			feeWallet, err := c.connectedWallet(dc.acct.feeAssetID)
 			if err != nil {
 				c.log.Debugf("Failed to connect for reFee at %s with error: %v", dc.acct.host, err)
 				subject, details := c.formatDetails(TopicWalletConnectionWarning, dc.acct.host)
@@ -3341,8 +3374,8 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 				result.AuthErr = details
 				continue
 			}
-			if !dcrWallet.unlocked() {
-				err = dcrWallet.Unlock(crypter)
+			if !feeWallet.unlocked() {
+				err = feeWallet.Unlock(crypter)
 				if err != nil {
 					subject, details := c.formatDetails(TopicWalletUnlockError, dc.acct.host, err)
 					c.notify(newFeePaymentNote(TopicWalletUnlockError, subject, details, db.ErrorLevel, dc.acct.host))
@@ -3350,9 +3383,10 @@ func (c *Core) initializeDEXConnections(crypter encrypt.Crypter) []*DEXBrief {
 					continue
 				}
 			}
-			c.reFee(dcrWallet, dc)
+			c.reFee(feeWallet, dc)
 			continue
 		}
+
 		wg.Add(1)
 		go func(dc *dexConnection) {
 			defer wg.Done()
@@ -4299,7 +4333,6 @@ func (c *Core) connectAccount(acct *db.AccountInfo) (dc *dexConnection, connecte
 	}
 
 	c.connMtx.Lock()
-
 	c.conns[host] = dc
 	c.connMtx.Unlock()
 
@@ -4312,7 +4345,7 @@ var feeLock uint32
 
 // checkUnpaidFees checks whether the registration fee info has an acceptable
 // state, and tries to rectify any inconsistencies.
-func (c *Core) checkUnpaidFees(dcrWallet *xcWallet) {
+func (c *Core) checkUnpaidFees(wallet *xcWallet) {
 	if !atomic.CompareAndSwapUint32(&feeLock, 0, 1) {
 		return
 	}
@@ -4321,13 +4354,16 @@ func (c *Core) checkUnpaidFees(dcrWallet *xcWallet) {
 		if dc.acct.feePaid() {
 			continue
 		}
+		if dc.acct.feeAssetID != wallet.AssetID {
+			continue // different wallet
+		}
 		if len(dc.acct.feeCoin) == 0 {
 			c.log.Errorf("empty fee coin found for unpaid account")
 			continue
 		}
 		wg.Add(1)
 		go func(dc *dexConnection) {
-			c.reFee(dcrWallet, dc)
+			c.reFee(wallet, dc)
 			wg.Done()
 		}(dc)
 	}
@@ -4338,19 +4374,16 @@ func (c *Core) checkUnpaidFees(dcrWallet *xcWallet) {
 // reFee attempts to finish the fee payment process for a DEX. reFee might be
 // called if the client was shutdown after a fee was paid, but before it had the
 // requisite confirmations for the 'notifyfee' message to be sent to the server.
-func (c *Core) reFee(dcrWallet *xcWallet, dc *dexConnection) {
-
-	// cfg can be null if connection to dex server fails.
-	dc.cfgMtx.RLock()
-	cfg := dc.cfg
-	dc.cfgMtx.RUnlock()
-	if cfg == nil {
+func (c *Core) reFee(wallet *xcWallet, dc *dexConnection) {
+	feeAsset := dc.feeAsset(wallet.AssetID)
+	if feeAsset == nil {
+		c.log.Errorf("DEX not connected, or does not accept registration fees in asset %q", unbip(wallet.AssetID))
 		return
 	}
+	reqConfs := feeAsset.Confs
 
 	// Return if the coin is already in blockWaiters.
-	regFeeAssetID, _ := dex.BipSymbolID(regFeeAssetSymbol)
-	if c.existsWaiter(coinIDString(regFeeAssetID, dc.acct.feeCoin)) {
+	if c.existsWaiter(coinIDString(dc.acct.feeAssetID, dc.acct.feeCoin)) {
 		return
 	}
 
@@ -4360,9 +4393,13 @@ func (c *Core) reFee(dcrWallet *xcWallet, dc *dexConnection) {
 		c.log.Errorf("reFee %s - error retrieving account info: %v", dc.acct.host, err)
 		return
 	}
-	// A couple sanity checks.
+	// A few sanity checks.
 	if !bytes.Equal(acctInfo.FeeCoin, dc.acct.feeCoin) {
 		c.log.Errorf("reFee %s - fee coin mismatch. %x != %x", dc.acct.host, acctInfo.FeeCoin, dc.acct.feeCoin)
+		return
+	}
+	if acctInfo.FeeAssetID != dc.acct.feeAssetID {
+		c.log.Errorf("reFee %s - fee asset mismatch. %d != %d", dc.acct.host, acctInfo.FeeAssetID, dc.acct.feeAssetID)
 		return
 	}
 	if acctInfo.Paid {
@@ -4370,13 +4407,13 @@ func (c *Core) reFee(dcrWallet *xcWallet, dc *dexConnection) {
 		return
 	}
 	// Get the coin for the fee.
-	confs, _, err := dcrWallet.Confirmations(c.ctx, acctInfo.FeeCoin)
+	confs, _, err := wallet.Confirmations(c.ctx, acctInfo.FeeCoin)
 	if err != nil {
 		c.log.Errorf("reFee %s - error getting coin confirmations: %v", dc.acct.host, err)
 		return
 	}
 
-	if confs >= uint32(cfg.RegFeeConfirms) {
+	if confs >= reqConfs {
 		err := c.notifyFee(dc, acctInfo.FeeCoin)
 		if err != nil {
 			c.log.Errorf("reFee %s - notifyfee error: %v", dc.acct.host, err)
@@ -4395,7 +4432,7 @@ func (c *Core) reFee(dcrWallet *xcWallet, dc *dexConnection) {
 		}
 		return
 	}
-	c.verifyRegistrationFee(dcrWallet.AssetID, dc, acctInfo.FeeCoin, confs)
+	c.verifyRegistrationFee(wallet.AssetID, dc, acctInfo.FeeCoin, confs, reqConfs)
 }
 
 func (c *Core) dbOrders(dc *dexConnection) ([]*db.MetaOrder, error) {
@@ -5030,7 +5067,7 @@ func (c *Core) handleReconnect(host string) {
 		return
 	}
 
-	if !dc.acct.locked() {
+	if !dc.acct.locked() && len(dc.acct.feeCoin) > 0 {
 		err = c.authDEX(dc)
 		if err != nil {
 			c.log.Errorf("handleReconnect: Unable to authorize DEX at %s: %v", host, err)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1740,7 +1740,7 @@ func testRegister(t *testing.T, legacyKeys bool) {
 		f(accountExistsResp)
 		return nil
 	})
-	queueResponses() // Queing an extra config response here, but we're done anyway.
+	queueResponses() // Queueing an extra config response here, but we're done anyway.
 
 	_, err = tCore.Register(form)
 	if err != nil {
@@ -1750,7 +1750,7 @@ func testRegister(t *testing.T, legacyKeys bool) {
 	if len(rig.db.acct.EncKeyV2) != 0 || len(rig.db.acct.LegacyEncKey) == 0 {
 		t.Fatalf("Keys not generated correctly for suspended account. %d %d", len(rig.db.acct.EncKeyV2), len(rig.db.acct.LegacyEncKey))
 	}
-	getFeeAndBalanceNote() // payment in progres
+	getFeeAndBalanceNote() // payment in progress
 	getFeeAndBalanceNote() // account registered
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -79,6 +79,7 @@ var (
 	tDcrBtcMktName             = "dcr_btc"
 	tErr                       = fmt.Errorf("test error")
 	tFee                uint64 = 1e8
+	tFeeAsset           uint32 = 42
 	tUnparseableHost           = string([]byte{0x7f})
 	tSwapFeesPaid       uint64 = 500
 	tRedemptionFeesPaid uint64 = 350
@@ -204,8 +205,9 @@ func testDexConnection(ctx context.Context) (*dexConnection, *TWebsocket, *dexAc
 					},
 				},
 			},
-			Fee:       tFee,
-			DEXPubKey: acct.dexPubKey.SerializeCompressed(),
+			Fee:            tFee,
+			RegFeeConfirms: 0,
+			DEXPubKey:      acct.dexPubKey.SerializeCompressed(),
 		},
 		notify:            func(Notification) {},
 		trades:            make(map[order.OrderID]*trackedTrade),
@@ -1382,39 +1384,6 @@ func TestCreateWallet(t *testing.T) {
 	}
 }
 
-func TestGetFee(t *testing.T) {
-	rig := newTestRig()
-	defer rig.shutdown()
-	tCore := rig.core
-	cert := []byte{}
-
-	// DEX already registered
-	_, err := tCore.GetFee(tDexHost, cert)
-	if !errorHasCode(err, dupeDEXErr) {
-		t.Fatalf("wrong account exists error: %v", err)
-	}
-
-	// Lose the dexConnection
-	tCore.connMtx.Lock()
-	delete(tCore.conns, tDexHost)
-	tCore.connMtx.Unlock()
-
-	// connectDEX error
-	_, err = tCore.GetFee(tUnparseableHost, cert)
-	if !errorHasCode(err, addressParseErr) {
-		t.Fatalf("wrong connectDEX error: %v", err)
-	}
-
-	// Queue a config response for success
-	rig.queueConfig()
-
-	// Success
-	_, err = tCore.GetFee(tDexHost, cert)
-	if err != nil {
-		t.Fatalf("GetFee error: %v", err)
-	}
-}
-
 func TestRegister(t *testing.T) {
 	t.Run("TestRegister_legacy", func(t *testing.T) {
 		testRegister(t, true)
@@ -1465,22 +1434,22 @@ func testRegister(t *testing.T, legacyKeys bool) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			t.Helper()
 			timeout := time.NewTimer(time.Second * 2)
 			for {
 				select {
-				case <-time.After(time.Millisecond):
-					timeout.Stop()
+				case <-time.After(10 * time.Millisecond):
 					tCore.waiterMtx.Lock()
 					waiterCount := len(tCore.blockWaiters)
 					tCore.waiterMtx.Unlock()
 					if waiterCount > 0 { // when verifyRegistrationFee adds a waiter, then we can trigger tip change
+						timeout.Stop()
 						tWallet.setConfs(tWallet.payFeeCoin.id, 0, nil)
 						tCore.tipChange(tDCR.ID, nil)
 						return
 					}
 				case <-timeout.C:
 					t.Errorf("failed to find waiter before timeout")
+					return
 				}
 			}
 		}()
@@ -1498,6 +1467,7 @@ func testRegister(t *testing.T, legacyKeys bool) {
 		Addr:    tDexHost,
 		AppPass: tPW,
 		Fee:     tFee,
+		Asset:   &tFeeAsset,
 		Cert:    []byte{},
 	}
 
@@ -1615,17 +1585,17 @@ func testRegister(t *testing.T, legacyKeys bool) {
 	}
 	form.Addr = tDexHost
 
-	// asset not found
-	cfgAssets := dc.cfg.Assets
+	// fee asset not found, no cfg.Fee fallback
 	mkts := dc.cfg.Markets
-	dc.cfg.Assets = dc.cfg.Assets[1:]
+	dc.cfg.RegFees = nil
+	dc.cfg.Fee = 0
 	dc.cfg.Markets = []*msgjson.Market{}
 	rig.queueConfig()
 	run()
 	if !errorHasCode(err, assetSupportErr) {
 		t.Fatalf("wrong error for missing asset: %v", err)
 	}
-	dc.cfg.Assets = cfgAssets
+	dc.cfg.Fee = tFee // next connect will patch up RegFees
 	dc.cfg.Markets = mkts
 
 	// error creating signing key
@@ -1734,6 +1704,7 @@ func testRegister(t *testing.T, legacyKeys bool) {
 	if feeNote.Severity() != db.Success {
 		t.Fatalf("fee payment error notification: %s: %s", feeNote.Subject(), feeNote.Details())
 	}
+	getFeeAndBalanceNote() // account registered
 
 	// Account recovery testing below doesn't apply to legacy servers.
 	if legacyKeys {
@@ -1754,6 +1725,8 @@ func testRegister(t *testing.T, legacyKeys bool) {
 	if err != nil {
 		t.Fatalf("Pre-paid Register error: %v", err)
 	}
+
+	// no fee payment notes
 
 	// Account suspended should force legacy credentials..
 	clearConn()
@@ -1777,6 +1750,8 @@ func testRegister(t *testing.T, legacyKeys bool) {
 	if len(rig.db.acct.EncKeyV2) != 0 || len(rig.db.acct.LegacyEncKey) == 0 {
 		t.Fatalf("Keys not generated correctly for suspended account. %d %d", len(rig.db.acct.EncKeyV2), len(rig.db.acct.LegacyEncKey))
 	}
+	getFeeAndBalanceNote() // payment in progres
+	getFeeAndBalanceNote() // account registered
 }
 
 func TestCredentialsUpgrade(t *testing.T) {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -150,6 +150,7 @@ func newSecurityNote(topic Topic, subject, details string, severity db.Severity)
 // FeePaymentNote is a notification regarding registration fee payment.
 type FeePaymentNote struct {
 	db.Notification
+	Asset         *uint32 `json:"asset,omitempty"`
 	Confirmations *uint32 `json:"confirmations,omitempty"`
 	Dex           string  `json:"dex,omitempty"`
 }
@@ -173,8 +174,9 @@ func newFeePaymentNote(topic Topic, subject, details string, severity db.Severit
 	}
 }
 
-func newFeePaymentNoteWithConfirmations(topic Topic, subject, details string, severity db.Severity, currConfs uint32, dexAddr string) *FeePaymentNote {
+func newFeePaymentNoteWithConfirmations(topic Topic, subject, details string, severity db.Severity, asset, currConfs uint32, dexAddr string) *FeePaymentNote {
 	feePmtNt := newFeePaymentNote(topic, subject, details, severity, dexAddr)
+	feePmtNt.Asset = &asset
 	feePmtNt.Confirmations = &currConfs
 	return feePmtNt
 }

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1319,10 +1319,16 @@ func (client *tClient) registerDEX(ctx context.Context) error {
 		client.core.connMtx.Unlock()
 	}
 
-	dexFee, err := client.core.GetFee(dexHost, dexCert)
+	dexConf, err := client.core.GetDEXConfig(dexHost, dexCert)
 	if err != nil {
 		return err
 	}
+	feeAsset := dexConf.RegFees["dcr"]
+	if feeAsset == nil {
+		return errors.New("dcr not supported!")
+	}
+	dexFee := feeAsset.Amt
+	assetID := feeAsset.ID
 
 	// connect dex and pay fee
 	regRes, err := client.core.Register(&RegisterForm{
@@ -1330,6 +1336,7 @@ func (client *tClient) registerDEX(ctx context.Context) error {
 		Cert:    dexCert,
 		AppPass: client.appPass,
 		Fee:     dexFee,
+		Asset:   &assetID,
 	})
 	if err != nil {
 		return err

--- a/client/db/test/dbtest.go
+++ b/client/db/test/dbtest.go
@@ -34,10 +34,11 @@ func RandomAccountInfo() *db.AccountInfo {
 	return &db.AccountInfo{
 		Host: ordertest.RandomAddress(),
 		// LegacyEncKey: randBytes(32),
-		EncKeyV2:  randBytes(32),
-		DEXPubKey: randomPubKey(),
-		FeeCoin:   randBytes(32),
-		Cert:      randBytes(100),
+		EncKeyV2:   randBytes(32),
+		DEXPubKey:  randomPubKey(),
+		FeeAssetID: uint32(rand.Intn(64)),
+		FeeCoin:    randBytes(32),
+		Cert:       randBytes(100),
 	}
 }
 

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -39,7 +39,7 @@ const (
 	// RPC version. Move major up one for breaking changes. Move minor for
 	// backwards compatible features. Move patch for bug fixes.
 	rpcSemverMajor = 0
-	rpcSemverMinor = 1
+	rpcSemverMinor = 2
 	rpcSemverPatch = 0
 )
 
@@ -64,7 +64,7 @@ type clientCore interface {
 	Login(appPass []byte) (*core.LoginResult, error)
 	Logout() error
 	OpenWallet(assetID uint32, appPass []byte) error
-	GetFee(addr string, cert interface{}) (fee uint64, err error)
+	GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error)
 	Register(form *core.RegisterForm) (*core.RegisterResult, error)
 	Trade(appPass []byte, form *core.TradeForm) (order *core.Order, err error)
 	Wallets() (walletsStates []*core.WalletState)

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -32,8 +32,8 @@ var (
 )
 
 type TCore struct {
-	regFee              uint64
-	getFeeErr           error
+	dexExchange         *core.Exchange
+	getDEXConfigErr     error
 	balanceErr          error
 	syncErr             error
 	createWalletErr     error
@@ -93,8 +93,8 @@ func (c *TCore) Logout() error {
 func (c *TCore) OpenWallet(assetID uint32, pw []byte) error {
 	return c.openWalletErr
 }
-func (c *TCore) GetFee(url string, cert interface{}) (uint64, error) {
-	return c.regFee, c.getFeeErr
+func (c *TCore) GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error) {
+	return c.dexExchange, c.getDEXConfigErr
 }
 func (c *TCore) Register(*core.RegisterForm) (*core.RegisterResult, error) {
 	return c.registerResult, c.registerErr

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -43,11 +43,6 @@ func (vr versionResponse) String() string {
 	return fmt.Sprintf("%d.%d.%d", vr.Major, vr.Minor, vr.Patch)
 }
 
-// getFeeResponse is used when responding to the getfee route.
-type getFeeResponse struct {
-	Fee uint64 `json:"fee"`
-}
-
 // tradeResponse is used when responding to the trade route.
 type tradeResponse struct {
 	OrderID string `json:"orderID"`
@@ -298,7 +293,7 @@ func parseCloseWalletArgs(params *RawParams) (uint32, error) {
 	return uint32(assetID), nil
 }
 
-func parseGetFeeArgs(params *RawParams) (host string, cert []byte, err error) {
+func parseGetDEXConfigArgs(params *RawParams) (host string, cert []byte, err error) {
 	if err := checkNArgs(params, []int{0}, []int{1, 2}); err != nil {
 		return "", nil, err
 	}
@@ -309,21 +304,27 @@ func parseGetFeeArgs(params *RawParams) (host string, cert []byte, err error) {
 }
 
 func parseRegisterArgs(params *RawParams) (*core.RegisterForm, error) {
-	if err := checkNArgs(params, []int{1}, []int{2, 3}); err != nil {
+	if err := checkNArgs(params, []int{1}, []int{3, 4}); err != nil {
 		return nil, err
 	}
 	fee, err := checkUIntArg(params.Args[1], "fee", 64)
 	if err != nil {
 		return nil, err
 	}
+	asset, err := checkUIntArg(params.Args[2], "asset", 32)
+	if err != nil {
+		return nil, err
+	}
+	asset32 := uint32(asset)
 	var cert []byte
-	if len(params.Args) > 2 {
-		cert = []byte(params.Args[2])
+	if len(params.Args) > 3 {
+		cert = []byte(params.Args[3])
 	}
 	req := &core.RegisterForm{
 		AppPass: params.PWArgs[0],
 		Addr:    params.Args[0],
 		Fee:     fee,
+		Asset:   &asset32,
 		Cert:    cert,
 	}
 	return req, nil

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -81,7 +81,7 @@ func (s *WebServer) apiRegister(w http.ResponseWriter, r *http.Request) {
 	}
 	wallet := s.core.WalletState(assetID)
 	if wallet == nil {
-		s.writeAPIError(w, errors.New("No Decred wallet"))
+		s.writeAPIError(w, errors.New("no wallet"))
 		return
 	}
 	pass, err := s.resolvePass(reg.Password, r)

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -95,6 +95,7 @@ func (s *WebServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 		CommonArguments: *cArgs,
 	}
 
+	// TODO: rework register page for paying with other assets.
 	feeAssetID, _ := dex.BipSymbolID("dcr")
 	feeWalletStatus := s.core.WalletState(feeAssetID)
 	feeWalletExists := feeWalletStatus != nil

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -390,9 +390,6 @@ func (c *TCore) InitializeClient(pw, seed []byte) error {
 	c.inited = true
 	return nil
 }
-func (c *TCore) GetFee(host string, cert interface{}) (uint64, error) {
-	return tExchanges[host].Fee.Amt, nil
-}
 func (c *TCore) GetDEXConfig(host string, certI interface{}) (*core.Exchange, error) {
 	return tExchanges[host], nil
 }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -27,7 +27,7 @@ var EnUS = map[string]string{
 	"Submit":                         "Submit",
 	"Confirm Registration":           "Confirm Registration",
 	"app_pw_reg":                     "Enter your app password to confirm DEX registration.",
-	"reg_confirm_submit":             `When you submit this form, <span id="feeDisplay"></span> DCR will be spent from your Decred wallet to pay registration fees.`,
+	"reg_confirm_submit":             `When you submit this form, <span id="feeDisplay"></span> will be spent to pay registration fees.`,
 	"provied_markets":                "This DEX provides the following markets:",
 	"base_header":                    "Base",
 	"quote_header":                   "Quote",
@@ -130,8 +130,8 @@ var EnUS = map[string]string{
 	"Set App Password":          "Set App Password",
 	"reg_set_app_pw_msg":        "Set your app password. This password will protect your DEX account keys and connected wallets.",
 	"Password Again":            "Password Again",
-	"reg_dcr_required":          "Your Decred wallet is required to pay registration fees.",
-	"reg_dcr_unlocked":          "Unlock your Decred wallet to pay registration fees.",
+	"reg_dcr_required":          "Your Decred wallet is required to pay registration fees.", // TODO
+	"reg_dcr_unlocked":          "Unlock your Decred wallet to pay registration fees.",      // TODO
 	"Add a DEX":                 "Add a DEX",
 	"reg_ssl_needed":            "Looks like we don't have an SSL certificate for this DEX. Add the server's certificate to continue.",
 	"Dark Mode":                 "Dark Mode",

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -27,7 +27,7 @@ var EnUS = map[string]string{
 	"Submit":                         "Submit",
 	"Confirm Registration":           "Confirm Registration",
 	"app_pw_reg":                     "Enter your app password to confirm DEX registration.",
-	"reg_confirm_submit":             `When you submit this form, <span id="feeDisplay"></span> will be spent to pay registration fees.`,
+	"reg_confirm_submit":             `When you submit this form, <span id="feeDisplay"></span> DCR will be spent from your Decred wallet to pay registration fees.`, // TODO for multi-asset reg
 	"provied_markets":                "This DEX provides the following markets:",
 	"base_header":                    "Base",
 	"quote_header":                   "Quote",

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -39,7 +39,7 @@
       {{template "newWalletForm" "[[[reg_dcr_required]]]"}}
     </form>
 
-    {{- /* Unlock Decred wallet. Only shown if not already unlocked. */ -}}
+    {{- /* Unlock wallet. Only shown if not already unlocked. */ -}}
     <form class="card mx-auto my-5 bg1{{if not .OpenStep}} d-hide{{end}}" id="unlockWalletForm">
       {{template "unlockWalletForm" "[[[reg_dcr_unlocked]]]"}}
     </form>

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -417,17 +417,18 @@ export default class Application {
    * updateExchangeRegistration updates the information for the exchange
    * registration payment
    */
-  updateExchangeRegistration (dexAddr, isPaid, confs) {
+  updateExchangeRegistration (dexAddr, isPaid, confs, asset) {
     const dex = this.exchanges[dexAddr]
 
     if (isPaid) {
       // setting the null value in the 'confs' field indicates that the fee
       // payment was completed
-      dex.confs = null
+      dex.pendingFee = null
       return
     }
 
-    dex.confs = confs
+    const symbol = this.assets[asset].symbol
+    dex.pendingFee = { confs, asset, symbol }
   }
 
   /*
@@ -437,7 +438,7 @@ export default class Application {
   handleFeePaymentNote (note) {
     switch (note.topic) {
       case 'RegUpdate':
-        this.updateExchangeRegistration(note.dex, false, note.confirmations)
+        this.updateExchangeRegistration(note.dex, false, note.confirmations, note.asset)
         break
       case 'AccountRegistered':
         this.updateExchangeRegistration(note.dex, true)

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -317,8 +317,9 @@ export class ConfirmRegistrationForm {
    */
   setExchange (xc) {
     const fields = this.fields
-    this.fee = xc.feeAsset.amount
-    fields.feeDisplay.textContent = Doc.formatCoinValue(this.fee / 1e8)
+    this.fees = xc.regFees
+    const dcr = this.fees.dcr // TODO: display all options and give choice
+    fields.feeDisplay.textContent = `${Doc.formatCoinValue(dcr.amount / 1e8)} ${app.assets[dcr.id].symbol.toUpperCase()}`
     while (fields.marketsTableRows.firstChild) {
       fields.marketsTableRows.removeChild(fields.marketsTableRows.firstChild)
     }
@@ -354,10 +355,12 @@ export class ConfirmRegistrationForm {
     Doc.hide(fields.regErr)
     const cert = await this.getCertFile()
     const dexAddr = this.getDexAddr()
+    const feeAsset = this.fees.dcr // this.fees[fields.symbol]
     const registration = {
       addr: dexAddr,
       pass: fields.appPass.value,
-      fee: this.fee,
+      fee: feeAsset.amount,
+      asset: feeAsset.id,
       cert: cert
     }
     fields.appPass.value = ''

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -56,7 +56,7 @@ export default class RegistrationPage extends BasePage {
 
     // ADD DEX
     this.dexAddrForm = new DEXAddressForm(app, page.dexAddrForm, async (xc) => {
-      const fee = xc.feeAsset.amount
+      const fee = xc.feeAsset.amount // DCR, special
       const balanceFeeRegistration = app.user.assets[DCR_ID].wallet.balance.available
       if (balanceFeeRegistration < fee) {
         const errorMsg = `Looks like there is not enough funds for

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -143,7 +143,7 @@
 <div class="p-4">
   <div class="fs16">
     <span id="appPassSpan">Enter your app password to confirm DEX registration.</span>
-    When you submit this form, <span id="feeDisplay"></span> will be spent to pay registration fees.
+    When you submit this form, <span id="feeDisplay"></span> DCR will be spent from your Decred wallet to pay registration fees.
   </div>
   <div class="fs16 mt-4">
     This DEX provides the following markets:

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -143,7 +143,7 @@
 <div class="p-4">
   <div class="fs16">
     <span id="appPassSpan">Enter your app password to confirm DEX registration.</span>
-    When you submit this form, <span id="feeDisplay"></span> DCR will be spent from your Decred wallet to pay registration fees.
+    When you submit this form, <span id="feeDisplay"></span> will be spent to pay registration fees.
   </div>
   <div class="fs16 mt-4">
     This DEX provides the following markets:

--- a/client/webserver/site/src/localized_html/en-US/register.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/register.tmpl
@@ -39,7 +39,7 @@
       {{template "newWalletForm" "Your Decred wallet is required to pay registration fees."}}
     </form>
 
-    {{- /* Unlock Decred wallet. Only shown if not already unlocked. */ -}}
+    {{- /* Unlock wallet. Only shown if not already unlocked. */ -}}
     <form class="card mx-auto my-5 bg1{{if not .OpenStep}} d-hide{{end}}" id="unlockWalletForm">
       {{template "unlockWalletForm" "Unlock your Decred wallet to pay registration fees."}}
     </form>

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -48,6 +48,7 @@ type registrationForm struct {
 	Cert     string           `json:"cert"`
 	Password encode.PassBytes `json:"pass"`
 	Fee      uint64           `json:"fee"`
+	AssetID  *uint32          `json:"asset,omitempty"` // prevent out-of-date frontend from paying fee in BTC
 }
 
 // newWalletForm is information necessary to create a new wallet.

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -91,7 +91,6 @@ type clientCore interface {
 	NewDepositAddress(assetID uint32) (string, error)
 	AutoWalletConfig(assetID uint32) (map[string]string, error)
 	User() *core.User
-	GetFee(url string, cert interface{}) (uint64, error)
 	GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error)
 	DiscoverAccount(dexAddr string, pass []byte, certI interface{}) (*core.Exchange, bool, error)
 	SupportedAssets() map[uint32]*core.SupportedAsset
@@ -114,7 +113,7 @@ type clientCore interface {
 var _ clientCore = (*core.Core)(nil)
 
 // cachedPassword consists of the seralized crypter and an encrypted password.
-// A key stored in the cookies is used to deserlialize the crypter, then
+// A key stored in the cookies is used to deserialize the crypter, then
 // the crypter is used to decrypt the password.
 type cachedPassword struct {
 	EncryptedPass     []byte
@@ -293,7 +292,6 @@ func New(cfg *Config) (*WebServer, error) {
 		r.Group(func(apiInit chi.Router) {
 			apiInit.Use(s.rejectUninited)
 			apiInit.Post("/login", s.apiLogin)
-			apiInit.Post("/getfee", s.apiGetFee)
 			apiInit.Post("/getdexinfo", s.apiGetDEXInfo)
 			apiInit.Post("/discoveracct", s.apiDiscoverAccount)
 		})

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -61,7 +61,7 @@ type TCore struct {
 	logoutErr       error
 	initErr         error
 	isInited        bool
-	getFeeErr       error
+	getDEXConfigErr error
 	createWalletErr error
 	openWalletErr   error
 	closeWalletErr  error
@@ -71,13 +71,11 @@ type TCore struct {
 	notOpen         bool
 }
 
-func (c *TCore) Network() dex.Network                       { return dex.Mainnet }
-func (c *TCore) Exchanges() map[string]*core.Exchange       { return nil }
-func (c *TCore) GetFee(string, interface{}) (uint64, error) { return 1e8, c.getFeeErr }
+func (c *TCore) Network() dex.Network                 { return dex.Mainnet }
+func (c *TCore) Exchanges() map[string]*core.Exchange { return nil }
 func (c *TCore) GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error) {
-	return nil, c.getFeeErr // TODO along with test for apiUser / Exchanges() / User()
+	return nil, c.getDEXConfigErr // TODO along with test for apiUser / Exchanges() / User()
 }
-
 func (c *TCore) DiscoverAccount(dexAddr string, pw []byte, certI interface{}) (*core.Exchange, bool, error) {
 	return nil, false, nil
 }
@@ -484,25 +482,7 @@ func TestAPIInit(t *testing.T) {
 	tCore.initErr = nil
 }
 
-func TestAPIGetFee(t *testing.T) {
-	writer := new(TWriter)
-	var body interface{}
-	reader := new(TReader)
-	s, tCore, shutdown, _ := newTServer(t, false)
-	defer shutdown()
-
-	ensure := func(want string) {
-		ensureResponse(t, s.apiGetFee, want, reader, writer, body, nil)
-	}
-
-	body = &registrationForm{Addr: "somedexaddress.org"}
-	ensure(`{"ok":true,"fee":100000000}`)
-
-	// getFee error
-	tCore.getFeeErr = tErr
-	ensure(fmt.Sprintf(`{"ok":false,"msg":"%s"}`, tErr))
-	tCore.getFeeErr = nil
-}
+// TODO: TesAPIGetDEXInfo
 
 func TestAPINewWallet(t *testing.T) {
 	writer := new(TWriter)

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -76,8 +76,7 @@ const (
 	AccountSuspendedError             // 57
 	RPCExportSeedError                // 58
 	TooManyRequestsError              // 59
-	AccountExistsUnpaidError          // 60
-	RPCGetDEXConfigError              // 61
+	RPCGetDEXConfigError              // 60
 )
 
 // Routes are destinations for a "payload" of data. The type of data being

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -76,6 +76,8 @@ const (
 	AccountSuspendedError             // 57
 	RPCExportSeedError                // 58
 	TooManyRequestsError              // 59
+	AccountExistsUnpaidError          // 60
+	RPCGetDEXConfigError              // 61
 )
 
 // Routes are destinations for a "payload" of data. The type of data being
@@ -927,38 +929,48 @@ func (n *PenaltyNote) Serialize() []byte {
 // Register is the payload for the RegisterRoute request.
 type Register struct {
 	Signature
-	PubKey Bytes  `json:"pubkey"`
-	Time   uint64 `json:"timestamp"`
+	PubKey Bytes   `json:"pubkey"`
+	Time   uint64  `json:"timestamp"`
+	Asset  *uint32 `json:"feeAsset,omitempty"` // default to 42 if not set by client
 }
 
 // Serialize serializes the Register data.
 func (r *Register) Serialize() []byte {
-	// serialization: pubkey (33) + time (8) = 41
-	s := make([]byte, 0, 41)
+	// serialization: pubkey (33) + time (8) + asset (4 if set) = 45
+	s := make([]byte, 0, 45)
 	s = append(s, r.PubKey...)
-	return append(s, uint64Bytes(r.Time)...)
+	s = append(s, uint64Bytes(r.Time)...)
+	if r.Asset != nil {
+		s = append(s, uint32Bytes(*r.Asset)...)
+	}
+	return s
 }
 
 // RegisterResult is the result for the response to Register.
 type RegisterResult struct {
 	Signature
-	DEXPubKey    Bytes  `json:"pubkey"`
-	ClientPubKey Bytes  `json:"-"`
-	Address      string `json:"address"`
-	Fee          uint64 `json:"fee"`
-	Time         uint64 `json:"timestamp"`
+	DEXPubKey    Bytes   `json:"pubkey"`
+	ClientPubKey Bytes   `json:"-"`
+	AssetID      *uint32 `json:"feeAsset,omitempty"` // default to 42 if not set by server
+	Address      string  `json:"address"`
+	Fee          uint64  `json:"fee"`
+	Time         uint64  `json:"timestamp"`
 }
 
 // Serialize serializes the RegisterResult data.
 func (r *RegisterResult) Serialize() []byte {
 	// serialization: pubkey (33) + client pubkey (33) + time (8) + fee (8) +
-	// address (35-ish) = 117
-	b := make([]byte, 0, 117)
+	// address (35-ish) + asset (4 if set) = 121
+	b := make([]byte, 0, 121)
 	b = append(b, r.DEXPubKey...)
 	b = append(b, r.ClientPubKey...)
 	b = append(b, uint64Bytes(r.Time)...)
 	b = append(b, uint64Bytes(r.Fee)...)
-	return append(b, []byte(r.Address)...)
+	b = append(b, []byte(r.Address)...)
+	if r.AssetID != nil {
+		b = append(b, uint32Bytes(*r.AssetID)...)
+	}
+	return b
 }
 
 // NotifyFee is the payload for a client-originating NotifyFeeRoute request.
@@ -1037,17 +1049,26 @@ type Asset struct {
 	SwapConf     uint16 `json:"swapconf"`
 }
 
+// FeeAsset describes an asset for which registration fees are supported.
+type FeeAsset struct {
+	ID    uint32 `json:"id"`
+	Confs uint32 `json:"confs"`
+	Amt   uint64 `json:"amount"`
+}
+
 // ConfigResult is the successful result for the ConfigRoute.
 type ConfigResult struct {
 	CancelMax        float64   `json:"cancelmax"`
 	BroadcastTimeout uint64    `json:"btimeout"`
-	RegFeeConfirms   uint16    `json:"regfeeconfirms"`
+	RegFeeConfirms   uint16    `json:"regfeeconfirms"` // DEPRECATED
 	Assets           []*Asset  `json:"assets"`
 	Markets          []*Market `json:"markets"`
-	Fee              uint64    `json:"fee"`
+	Fee              uint64    `json:"fee"` // DEPRECATED
 	APIVersion       uint16    `json:"apiver"`
 	BinSizes         []string  `json:"binSizes"` // Just apidata.BinSizes for now.
 	DEXPubKey        Bytes     `json:"pubkey"`
+
+	RegFees map[string]*FeeAsset `json:"regFees"`
 }
 
 // Spot is a snapshot of a market at the end of a match cycle. A slice of Spot

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -121,14 +121,20 @@ cat << EOF >> "./markets.json"
             "network": "simnet",
             "maxFeeRate": 10,
             "swapConf": 1,
-            "configPath": "${TEST_ROOT}/dcr/alpha/dcrd.conf"
+            "configPath": "${TEST_ROOT}/dcr/alpha/dcrd.conf",
+            "regConfs": 1,
+            "regFee": 100000000,
+            "regXPub": "spubVWKGn9TGzyo7M4b5xubB5UV4joZ5HBMNBmMyGvYEaoZMkSxVG4opckpmQ26E85iHg8KQxrSVTdex56biddqtXBerG9xMN8Dvb3eNQVFFwpE"
         },
         "BTC_simnet": {
             "bip44symbol": "btc",
             "network": "simnet",
             "maxFeeRate": 100,
             "swapConf": 1,
-            "configPath": "${TEST_ROOT}/btc/alpha/alpha.conf"
+            "configPath": "${TEST_ROOT}/btc/alpha/alpha.conf",
+            "regConfs": 2,
+            "regFee": 20000000,
+            "regXPub": "tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp"
 EOF
 
 if [ $LTC_ON -eq 0 ]; then
@@ -176,12 +182,12 @@ EOF
 # Write dcrdex.conf. The regfeexpub comes from the alpha>server_fees account.
 cat << EOF >> ./dcrdex.conf
 regfeexpub=spubVWKGn9TGzyo7M4b5xubB5UV4joZ5HBMNBmMyGvYEaoZMkSxVG4opckpmQ26E85iHg8KQxrSVTdex56biddqtXBerG9xMN8Dvb3eNQVFFwpE
+regfeeconfirms=1
 pgdbname=${TEST_DB}
 simnet=1
 rpclisten=127.0.0.1:17273
 debuglevel=trace
 loglocal=true
-regfeeconfirms=1
 signingkeypass=keypass
 adminsrvon=1
 adminsrvpass=adminpass

--- a/dex/testing/loadbot/loadbot.go
+++ b/dex/testing/loadbot/loadbot.go
@@ -60,8 +60,9 @@ var (
 	dextestDir = filepath.Join(usr.HomeDir, "dextest")
 	botDir     = filepath.Join(dextestDir, "loadbot")
 
-	defaultRegFee uint64 = 1e8
-	ctx, quit            = context.WithCancel(context.Background())
+	defaultRegFee   uint64 = 1e8
+	defaultRegAsset uint32 = dcrID
+	ctx, quit              = context.WithCancel(context.Background())
 
 	alphaAddrDCR, betaAddrDCR, alphaAddrBTC, betaAddrBTC string
 	alphaCfgDCR, betaCfgDCR,

--- a/dex/testing/loadbot/mantle.go
+++ b/dex/testing/loadbot/mantle.go
@@ -52,6 +52,7 @@ func runTrader(t Trader, name string) {
 		Addr:    hostAddr,
 		AppPass: pass,
 		Fee:     defaultRegFee,
+		Asset:   &defaultRegAsset,
 		Cert:    filepath.Join(dextestDir, "dcrdex", "rpc.cert"),
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	decred.org/dcrwallet/v2 v2.0.0-20210913145543-714c2f555f04
 	github.com/btcsuite/btcd v0.20.1-beta.0.20200615134404-e4f59022a387
-	github.com/btcsuite/btcutil v1.0.2
+	github.com/btcsuite/btcutil v1.0.3-0.20210527170813-e2ba6805a890 // note: hoists btcd's own require of btcutil
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0-20210914193033-2efb9bda71fe
 	github.com/decred/dcrd/certgen v1.1.2-0.20210901152745-8830d9c9cdba

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,9 @@ github.com/btcsuite/btcd v0.20.1-beta.0.20200615134404-e4f59022a387/go.mod h1:Yk
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
-github.com/btcsuite/btcutil v1.0.2 h1:9iZ1Terx9fMIOtq1VrwdqfsATL9MC2l8ZrUY6YZ2uts=
 github.com/btcsuite/btcutil v1.0.2/go.mod h1:j9HUFwoQRsZL3V4n+qG+CUnEGHOarIxfC3Le2Yhbcts=
+github.com/btcsuite/btcutil v1.0.3-0.20210527170813-e2ba6805a890 h1:9aGy5p7oXRUB4MCTmWm0+jzuh79GpjPIfv1leA5POD4=
+github.com/btcsuite/btcutil v1.0.3-0.20210527170813-e2ba6805a890/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
 github.com/btcsuite/goleveldb v1.0.0 h1:Tvd0BfvqX9o823q1j2UZ/epQo09eJh6dTcRp79ilIN4=

--- a/server/asset/btc/addresser.go
+++ b/server/asset/btc/addresser.go
@@ -17,7 +17,7 @@ import (
 // AddressDeriver generates unique addresses from an extended public key.
 type AddressDeriver struct {
 	params   *chaincfg.Params
-	storeIdx func(uint32) // e.g. callback to a DB update
+	storeIdx func(uint32) error // e.g. callback to a DB update
 	xpub     *hdkeychain.ExtendedKey
 
 	mtx  sync.Mutex
@@ -25,39 +25,39 @@ type AddressDeriver struct {
 }
 
 // NewAddressDeriver creates a new AddressDeriver for the provided extended
-// public key, HDKeyIndexer, and network parameters. Note that if the source
+// public key, KeyIndexer, and network parameters. Note that if the source
 // wallet has accounts, the extended key should be for an account.
-func NewAddressDeriver(xpub string, keyIndexer asset.HDKeyIndexer, chainParams *chaincfg.Params) (*AddressDeriver, error) {
+func NewAddressDeriver(xpub string, keyIndexer asset.KeyIndexer, chainParams *chaincfg.Params) (*AddressDeriver, uint32, error) {
 	key, err := hdkeychain.NewKeyFromString(xpub)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing master pubkey: %w", err)
+		return nil, 0, fmt.Errorf("error parsing master pubkey: %w", err)
 	}
 	if !key.IsForNet(chainParams) {
-		return nil, fmt.Errorf("key is for the wrong network, wanted %s", chainParams.Name)
+		return nil, 0, fmt.Errorf("key is for the wrong network, wanted %s", chainParams.Name)
 	}
 	if key.IsPrivate() {
-		return nil, errors.New("private key provided")
+		return nil, 0, errors.New("private key provided")
 	}
-	external, _ := getChild(key, 0) // derive from the external branch (not change addresses)
-	if external == nil {
-		return nil, errors.New("unexpected key derivation error")
+	external, _, err := getChild(key, 0) // derive from the external branch (not change addresses)
+	if err != nil {
+		return nil, 0, fmt.Errorf("unexpected key derivation error: %w", err)
 	}
 	next, err := keyIndexer.KeyIndex(xpub)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	storKey := func(idx uint32) {
-		keyIndexer.SetKeyIndex(idx, xpub)
+	storKey := func(idx uint32) error {
+		return keyIndexer.SetKeyIndex(idx, xpub)
 	}
 	return &AddressDeriver{
 		params:   chainParams,
 		storeIdx: storKey,
 		xpub:     external,
 		next:     next,
-	}, nil
+	}, next, nil
 }
 
-func getChild(xkey *hdkeychain.ExtendedKey, i uint32) (*hdkeychain.ExtendedKey, uint32) {
+func getChild(xkey *hdkeychain.ExtendedKey, i uint32) (*hdkeychain.ExtendedKey, uint32, error) {
 	for {
 		child, err := xkey.Derive(i) // standard BIP32, not compatible with Child method used in legacy btcwallets
 		switch {
@@ -65,9 +65,9 @@ func getChild(xkey *hdkeychain.ExtendedKey, i uint32) (*hdkeychain.ExtendedKey, 
 			i++
 			continue
 		case err == nil:
-			return child, i
+			return child, i, nil
 		default: // Should never happen with a valid xpub.
-			return nil, 0
+			return nil, 0, err
 		}
 	}
 }
@@ -75,22 +75,24 @@ func getChild(xkey *hdkeychain.ExtendedKey, i uint32) (*hdkeychain.ExtendedKey, 
 // NextAddress retrieves the pkh address for the next pubkey. While this should
 // always return a valid address, an empty string may be returned in the event
 // of an unexpected internal error.
-func (ap *AddressDeriver) NextAddress() string {
+func (ap *AddressDeriver) NextAddress() (string, error) {
 	ap.mtx.Lock()
 	defer ap.mtx.Unlock()
 
-	child, i := getChild(ap.xpub, ap.next)
-	if child == nil {
-		return "" // should never happen
+	child, i, err := getChild(ap.xpub, ap.next)
+	if err != nil {
+		return "", err // should never happen
 	}
 	addr, err := child.Address(ap.params)
 	if err != nil {
 		// Address cannot error presently because NewAddressPubKeyHash only
 		// errors if it is given a hash that is not 20 bytes, and Address calls
 		// Hash160 first. But be safe in case this changes.
-		return ""
+		return "", err
 	}
-	ap.storeIdx(i) // not necessarily ap.next++
+	if err = ap.storeIdx(i); err != nil {
+		return "", err
+	} // not necessarily ap.next++
 	ap.next = i + 1
 	hash := addr.Hash160()
 	addrP2WPKH, err := btcutil.NewAddressWitnessPubKeyHash(hash[:], ap.params)
@@ -98,7 +100,7 @@ func (ap *AddressDeriver) NextAddress() string {
 		// This can only error if hash is not 20 bytes (ripemd160.Size), but we
 		// guarantee it. Still, btcutil could change, so return an empty string
 		// so caller can treat this as an unsupported asset rather than panic.
-		return ""
+		return "", err
 	}
-	return addrP2WPKH.String()
+	return addrP2WPKH.String(), nil
 }

--- a/server/asset/btc/addresser.go
+++ b/server/asset/btc/addresser.go
@@ -46,11 +46,8 @@ func NewAddressDeriver(xpub string, keyIndexer asset.HDKeyIndexer, chainParams *
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("(btc) Starting at key index %d\n", next)
 	storKey := func(idx uint32) {
-		if err := keyIndexer.SetKeyIndex(idx, xpub); err != nil {
-			fmt.Println(err)
-		}
+		keyIndexer.SetKeyIndex(idx, xpub)
 	}
 	return &AddressDeriver{
 		params:   chainParams,
@@ -69,9 +66,7 @@ func getChild(xkey *hdkeychain.ExtendedKey, i uint32) (*hdkeychain.ExtendedKey, 
 			continue
 		case err == nil:
 			return child, i
-		default:
-			// Should never happen. Bad xkey or something?
-			fmt.Println("ExtendedKey.Derive:", err)
+		default: // Should never happen with a valid xpub.
 			return nil, 0
 		}
 	}

--- a/server/asset/btc/addresser.go
+++ b/server/asset/btc/addresser.go
@@ -1,0 +1,109 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package btc
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"decred.org/dcrdex/server/asset"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil"
+	"github.com/btcsuite/btcutil/hdkeychain"
+)
+
+// AddressDeriver generates unique addresses from an extended public key.
+type AddressDeriver struct {
+	params   *chaincfg.Params
+	storeIdx func(uint32) // e.g. callback to a DB update
+	xpub     *hdkeychain.ExtendedKey
+
+	mtx  sync.Mutex
+	next uint32 // next child index to generate
+}
+
+// NewAddressDeriver creates a new AddressDeriver for the provided extended
+// public key, HDKeyIndexer, and network parameters. Note that if the source
+// wallet has accounts, the extended key should be for an account.
+func NewAddressDeriver(xpub string, keyIndexer asset.HDKeyIndexer, chainParams *chaincfg.Params) (*AddressDeriver, error) {
+	key, err := hdkeychain.NewKeyFromString(xpub)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing master pubkey: %w", err)
+	}
+	if !key.IsForNet(chainParams) {
+		return nil, fmt.Errorf("key is for the wrong network, wanted %s", chainParams.Name)
+	}
+	if key.IsPrivate() {
+		return nil, errors.New("private key provided")
+	}
+	external, _ := getChild(key, 0) // derive from the external branch (not change addresses)
+	if external == nil {
+		return nil, errors.New("unexpected key derivation error")
+	}
+	next, err := keyIndexer.KeyIndex(xpub)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("(btc) Starting at key index %d\n", next)
+	storKey := func(idx uint32) {
+		if err := keyIndexer.SetKeyIndex(idx, xpub); err != nil {
+			fmt.Println(err)
+		}
+	}
+	return &AddressDeriver{
+		params:   chainParams,
+		storeIdx: storKey,
+		xpub:     external,
+		next:     next,
+	}, nil
+}
+
+func getChild(xkey *hdkeychain.ExtendedKey, i uint32) (*hdkeychain.ExtendedKey, uint32) {
+	for {
+		child, err := xkey.Derive(i) // standard BIP32, not compatible with Child method used in legacy btcwallets
+		switch {
+		case errors.Is(err, hdkeychain.ErrInvalidChild):
+			i++
+			continue
+		case err == nil:
+			return child, i
+		default:
+			// Should never happen. Bad xkey or something?
+			fmt.Println("ExtendedKey.Derive:", err)
+			return nil, 0
+		}
+	}
+}
+
+// NextAddress retrieves the pkh address for the next pubkey. While this should
+// always return a valid address, an empty string may be returned in the event
+// of an unexpected internal error.
+func (ap *AddressDeriver) NextAddress() string {
+	ap.mtx.Lock()
+	defer ap.mtx.Unlock()
+
+	child, i := getChild(ap.xpub, ap.next)
+	if child == nil {
+		return "" // should never happen
+	}
+	addr, err := child.Address(ap.params)
+	if err != nil {
+		// Address cannot error presently because NewAddressPubKeyHash only
+		// errors if it is given a hash that is not 20 bytes, and Address calls
+		// Hash160 first. But be safe in case this changes.
+		return ""
+	}
+	ap.storeIdx(i) // not necessarily ap.next++
+	ap.next = i + 1
+	hash := addr.Hash160()
+	addrP2WPKH, err := btcutil.NewAddressWitnessPubKeyHash(hash[:], ap.params)
+	if err != nil {
+		// This can only error if hash is not 20 bytes (ripemd160.Size), but we
+		// guarantee it. Still, btcutil could change, so return an empty string
+		// so caller can treat this as an unsupported asset rather than panic.
+		return ""
+	}
+	return addrP2WPKH.String()
+}

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -52,13 +52,13 @@ func (d *Driver) Version() uint32 {
 }
 
 // NewAddresser creates an asset.Addresser for deriving addresses for the given
-// extended public key. The HDKeyIndexer will be used for discovering the
-// current child index, and storing the index as new addresses are generated
-// with the NextAddress method of the Addresser.
-func (d *Driver) NewAddresser(xPub string, keyIndexer asset.HDKeyIndexer, network dex.Network) (asset.Addresser, error) {
+// extended public key. The KeyIndexer will be used for discovering the current
+// child index, and storing the index as new addresses are generated with the
+// NextAddress method of the Addresser.
+func (d *Driver) NewAddresser(xPub string, keyIndexer asset.KeyIndexer, network dex.Network) (asset.Addresser, uint32, error) {
 	params, err := netParams(network)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	return NewAddressDeriver(xPub, keyIndexer, params)

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -371,35 +371,35 @@ func (btc *Backend) FeeCoin(coinID []byte) (addr string, val uint64, confs int64
 		return
 	}
 
-	var txOut *TxOutData
-	txOut, confs, err = btc.OutputSummary(txHash, vout)
+	var txOut *txOutData
+	txOut, confs, err = btc.outputSummary(txHash, vout)
 	if err != nil {
 		return
 	}
 
 	// AddressDeriver gives out p2wpkh addresses.
-	if len(txOut.Addresses) != 1 || !txOut.ScriptType.IsP2WPKH() {
+	if len(txOut.addresses) != 1 || !txOut.scriptType.IsP2WPKH() {
 		return "", 0, -1, dex.UnsupportedScriptError
 	}
-	addr = txOut.Addresses[0]
-	val = txOut.Value
+	addr = txOut.addresses[0]
+	val = txOut.value
 	return
 }
 
-// TxOutData is transaction output data, including recipient addresses, value,
+// txOutData is transaction output data, including recipient addresses, value,
 // script type, and number of required signatures.
-type TxOutData struct {
-	Value        uint64
-	Addresses    []string
-	SigsRequired int
-	ScriptType   dexbtc.BTCScriptType
+type txOutData struct {
+	value        uint64
+	addresses    []string
+	sigsRequired int
+	scriptType   dexbtc.BTCScriptType
 }
 
-// OutputSummary gets transaction output data, including recipient addresses,
+// outputSummary gets transaction output data, including recipient addresses,
 // value, script type, and number of required signatures, plus the current
 // confirmations of a transaction output. If the output does not exist, an error
 // will be returned. Non-standard scripts are not an error.
-func (btc *Backend) OutputSummary(txHash *chainhash.Hash, vout uint32) (txOut *TxOutData, confs int64, err error) {
+func (btc *Backend) outputSummary(txHash *chainhash.Hash, vout uint32) (txOut *txOutData, confs int64, err error) {
 	var verboseTx *btcjson.TxRawResult
 	verboseTx, err = btc.node.GetRawTransactionVerbose(txHash)
 	if err != nil {
@@ -425,11 +425,11 @@ func (btc *Backend) OutputSummary(txHash *chainhash.Hash, vout uint32) (txOut *T
 		return nil, -1, dex.UnsupportedScriptError
 	}
 
-	txOut = &TxOutData{
-		Value:        toSat(out.Value),
-		Addresses:    addrs,       // out.ScriptPubKey.Addresses
-		SigsRequired: numRequired, // out.ScriptPubKey.ReqSigs
-		ScriptType:   scriptType,  // integer representation of the string in out.ScriptPubKey.Type
+	txOut = &txOutData{
+		value:        toSat(out.Value),
+		addresses:    addrs,       // out.ScriptPubKey.Addresses
+		sigsRequired: numRequired, // out.ScriptPubKey.ReqSigs
+		scriptType:   scriptType,  // integer representation of the string in out.ScriptPubKey.Type
 	}
 
 	confs = int64(verboseTx.Confirmations)

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -51,16 +51,28 @@ func (d *Driver) Version() uint32 {
 	return version
 }
 
-func init() {
-	asset.Register(assetName, &Driver{})
-}
-
 // NewAddresser creates an asset.Addresser for deriving addresses for the given
 // extended public key. The HDKeyIndexer will be used for discovering the
 // current child index, and storing the index as new addresses are generated
 // with the NextAddress method of the Addresser.
-func (btc *Backend) NewAddresser(xPub string, keyIndexer asset.HDKeyIndexer) (asset.Addresser, error) {
-	return NewAddressDeriver(xPub, keyIndexer, btc.chainParams)
+func (d *Driver) NewAddresser(xPub string, keyIndexer asset.HDKeyIndexer, network dex.Network) (asset.Addresser, error) {
+	var params *chaincfg.Params
+	switch network {
+	case dex.Simnet:
+		params = &chaincfg.RegressionNetParams
+	case dex.Testnet:
+		params = &chaincfg.TestNet3Params
+	case dex.Mainnet:
+		params = &chaincfg.MainNetParams
+	default:
+		return nil, fmt.Errorf("unknown network ID: %d", uint8(network))
+	}
+
+	return NewAddressDeriver(xPub, keyIndexer, params)
+}
+
+func init() {
+	asset.Register(assetName, &Driver{})
 }
 
 var (

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -13,13 +13,13 @@ import (
 
 // Addresser retrieves unique addresses.
 type Addresser interface {
-	NextAddress() string
+	NextAddress() (string, error)
 }
 
-// HDKeyIndexer retrieves and stores child indexes for an extended public key.
-type HDKeyIndexer interface {
+// KeyIndexer retrieves and stores child indexes for an extended public key.
+type KeyIndexer interface {
 	KeyIndex(xpub string) (uint32, error)
-	SetKeyIndex(idx uint32, xpub string)
+	SetKeyIndex(idx uint32, xpub string) error
 }
 
 // CoinNotFoundError is to be returned from Contract, Redemption, and

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -11,6 +11,17 @@ import (
 	"decred.org/dcrdex/dex"
 )
 
+// Addresser retrieves unique addresses.
+type Addresser interface {
+	NextAddress() string
+}
+
+// HDKeyIndexer retrieves and stores child indexes for an extended public key.
+type HDKeyIndexer interface {
+	KeyIndex(xpub string) (uint32, error)
+	SetKeyIndex(idx uint32, xpub string) error
+}
+
 // CoinNotFoundError is to be returned from Contract, Redemption, and
 // FundingCoin when the specified transaction cannot be found. Used by the
 // server to handle network latency.
@@ -19,9 +30,9 @@ const (
 	ErrRequestTimeout = dex.ErrorKind("request timeout")
 )
 
-// The Backend interface is an interface for a blockchain backend. TODO: Plumb
-// every method with a cancellable request with a Context, which will prevent
-// backend shutdown from cancelling requests, but is more idiomatic these days.
+// Backend is a blockchain backend. TODO: Plumb every method with a cancellable
+// request with a Context, which will prevent backend shutdown from cancelling
+// requests, but is more idiomatic these days.
 type Backend interface {
 	// It is expected that Connect from dex.Connector is called and returns
 	// before use of the asset, and that it is only called once for the life

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -19,7 +19,7 @@ type Addresser interface {
 // HDKeyIndexer retrieves and stores child indexes for an extended public key.
 type HDKeyIndexer interface {
 	KeyIndex(xpub string) (uint32, error)
-	SetKeyIndex(idx uint32, xpub string) error
+	SetKeyIndex(idx uint32, xpub string)
 }
 
 // CoinNotFoundError is to be returned from Contract, Redemption, and

--- a/server/asset/dcr/addresser.go
+++ b/server/asset/dcr/addresser.go
@@ -1,0 +1,105 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package dcr
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"decred.org/dcrdex/server/asset"
+	"github.com/decred/dcrd/dcrutil/v4"
+	"github.com/decred/dcrd/hdkeychain/v3"
+	"github.com/decred/dcrd/txscript/v4/stdaddr"
+)
+
+// AddressDeriver generates unique addresses from an extended public key.
+type AddressDeriver struct {
+	addrParams dcrutil.AddressParams
+	storeIdx   func(uint32) // e.g. callback to a DB update
+	xpub       *hdkeychain.ExtendedKey
+
+	mtx  sync.Mutex
+	next uint32 // next child index to generate
+}
+
+type NetParams interface {
+	hdkeychain.NetworkParams
+	dcrutil.AddressParams
+}
+
+// NewAddressDeriver creates a new AddressDeriver for the provided extended
+// public key for an account, and HDKeyIndexer, using the provided network
+// parameters (e.g. chaincfg.MainNetParams()).
+func NewAddressDeriver(xpub string, keyIndexer asset.HDKeyIndexer, params NetParams) (*AddressDeriver, error) {
+	key, err := hdkeychain.NewKeyFromString(xpub, params)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing master pubkey: %w", err)
+	}
+	if key.IsPrivate() {
+		return nil, errors.New("private key provided")
+	}
+	external, _ := getChild(key, 0) // derive from the external branch (not change addresses)
+	if external == nil {
+		return nil, errors.New("unexpected key derivation error")
+	}
+	next, err := keyIndexer.KeyIndex(xpub)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("(dcr) Starting at key index %d\n", next)
+	storKey := func(idx uint32) {
+		if err := keyIndexer.SetKeyIndex(idx, xpub); err != nil {
+			fmt.Println(err)
+		}
+	}
+	return &AddressDeriver{
+		addrParams: params,
+		storeIdx:   storKey,
+		xpub:       external,
+		next:       next,
+	}, nil
+}
+
+func getChild(xkey *hdkeychain.ExtendedKey, i uint32) (*hdkeychain.ExtendedKey, uint32) {
+	for {
+		child, err := xkey.Child(i)
+		switch {
+		case errors.Is(err, hdkeychain.ErrInvalidChild):
+			i++
+			continue
+		case err == nil:
+			return child, i
+		default:
+			// Should never happen. Bad xkey or something?
+			fmt.Println("ExtendedKey.Derive:", err)
+			return nil, 0
+		}
+	}
+}
+
+// NextAddress retrieves the pkh address for the next pubkey. While this should
+// always return a valid address, an empty string may be returned in the event
+// of an unexpected internal error.
+func (ap *AddressDeriver) NextAddress() string {
+	ap.mtx.Lock()
+	defer ap.mtx.Unlock()
+
+	child, i := getChild(ap.xpub, ap.next)
+	if child == nil {
+		return "" // should never happen
+	}
+	hash := dcrutil.Hash160(child.SerializedPubKey())
+	ap.storeIdx(i) // not necessarily ap.next++
+	ap.next = i + 1
+
+	addr, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(hash, ap.addrParams)
+	if err != nil {
+		// This can only error if hash is not 20 bytes (ripemd160.Size), but we
+		// guarantee it. Still, stdaddr could change, so return an empty string
+		// so caller can treat this as an unsupported asset rather than panic.
+		return ""
+	}
+	return addr.String()
+}

--- a/server/asset/dcr/addresser.go
+++ b/server/asset/dcr/addresser.go
@@ -48,11 +48,8 @@ func NewAddressDeriver(xpub string, keyIndexer asset.HDKeyIndexer, params NetPar
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("(dcr) Starting at key index %d\n", next)
 	storKey := func(idx uint32) {
-		if err := keyIndexer.SetKeyIndex(idx, xpub); err != nil {
-			fmt.Println(err)
-		}
+		keyIndexer.SetKeyIndex(idx, xpub)
 	}
 	return &AddressDeriver{
 		addrParams: params,
@@ -71,9 +68,7 @@ func getChild(xkey *hdkeychain.ExtendedKey, i uint32) (*hdkeychain.ExtendedKey, 
 			continue
 		case err == nil:
 			return child, i
-		default:
-			// Should never happen. Bad xkey or something?
-			fmt.Println("ExtendedKey.Derive:", err)
+		default: // Should never happen with a valid xkey.
 			return nil, 0
 		}
 	}

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -62,11 +62,11 @@ func (d *Driver) Version() uint32 {
 }
 
 // NewAddresser creates an asset.Addresser for deriving addresses for the given
-// extended public key. The HDKeyIndexer will be used for discovering the
-// current child index, and storing the index as new addresses are generated
-// with the NextAddress method of the Addresser. The Backend must have been
-// created with NewBackend (or Setup) to initialize the chain parameters.
-func (d *Driver) NewAddresser(xPub string, keyIndexer asset.HDKeyIndexer, network dex.Network) (asset.Addresser, error) {
+// extended public key. The KeyIndexer will be used for discovering the current
+// child index, and storing the index as new addresses are generated with the
+// NextAddress method of the Addresser. The Backend must have been created with
+// NewBackend (or Setup) to initialize the chain parameters.
+func (d *Driver) NewAddresser(xPub string, keyIndexer asset.KeyIndexer, network dex.Network) (asset.Addresser, uint32, error) {
 	var params NetParams
 	switch network {
 	case dex.Simnet:
@@ -76,7 +76,7 @@ func (d *Driver) NewAddresser(xPub string, keyIndexer asset.HDKeyIndexer, networ
 	case dex.Mainnet:
 		params = chaincfg.MainNetParams()
 	default:
-		return nil, fmt.Errorf("unknown network ID: %d", uint8(network))
+		return nil, 0, fmt.Errorf("unknown network ID: %d", uint8(network))
 	}
 
 	return NewAddressDeriver(xPub, keyIndexer, params)

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -465,36 +465,36 @@ func (dcr *Backend) FeeCoin(coinID []byte) (addr string, val uint64, confs int64
 		return
 	}
 
-	var txOut *TxOutData
-	txOut, confs, err = dcr.OutputSummary(txHash, vout)
+	var txOut *txOutData
+	txOut, confs, err = dcr.outputSummary(txHash, vout)
 	if err != nil {
 		return
 	}
 
-	if len(txOut.Addresses) != 1 || txOut.SigsRequired != 1 ||
-		txOut.ScriptType != dexdcr.ScriptP2PKH /* no schorr or edwards */ ||
-		txOut.ScriptType&dexdcr.ScriptStake != 0 {
+	if len(txOut.addresses) != 1 || txOut.sigsRequired != 1 ||
+		txOut.scriptType != dexdcr.ScriptP2PKH /* no schorr or edwards */ ||
+		txOut.scriptType&dexdcr.ScriptStake != 0 {
 		return "", 0, -1, dex.UnsupportedScriptError
 	}
-	addr = txOut.Addresses[0]
-	val = txOut.Value
+	addr = txOut.addresses[0]
+	val = txOut.value
 	return
 }
 
-// TxOutData is transaction output data, including recipient addresses, value,
+// txOutData is transaction output data, including recipient addresses, value,
 // script type, and number of required signatures.
-type TxOutData struct {
-	Value        uint64
-	Addresses    []string
-	SigsRequired int
-	ScriptType   dexdcr.DCRScriptType
+type txOutData struct {
+	value        uint64
+	addresses    []string
+	sigsRequired int
+	scriptType   dexdcr.DCRScriptType
 }
 
-// OutputSummary gets transaction output data, including recipient addresses,
+// outputSummary gets transaction output data, including recipient addresses,
 // value, script type, and number of required signatures, plus the current
 // confirmations of a transaction output. If the output does not exist, an error
 // will be returned. Non-standard scripts are not an error.
-func (dcr *Backend) OutputSummary(txHash *chainhash.Hash, vout uint32) (txOut *TxOutData, confs int64, err error) {
+func (dcr *Backend) outputSummary(txHash *chainhash.Hash, vout uint32) (txOut *txOutData, confs int64, err error) {
 	var verboseTx *chainjson.TxRawResult
 	verboseTx, err = dcr.node.GetRawTransactionVerbose(dcr.ctx, txHash)
 	if err != nil {
@@ -522,11 +522,11 @@ func (dcr *Backend) OutputSummary(txHash *chainhash.Hash, vout uint32) (txOut *T
 		return nil, -1, dex.UnsupportedScriptError
 	}
 
-	txOut = &TxOutData{
-		Value:        toAtoms(out.Value),
-		Addresses:    addrs,       // out.ScriptPubKey.Addresses
-		SigsRequired: numRequired, // out.ScriptPubKey.ReqSigs
-		ScriptType:   scriptType,  // integer representation of the string in out.ScriptPubKey.Type
+	txOut = &txOutData{
+		value:        toAtoms(out.Value),
+		addresses:    addrs,       // out.ScriptPubKey.Addresses
+		sigsRequired: numRequired, // out.ScriptPubKey.ReqSigs
+		scriptType:   scriptType,  // integer representation of the string in out.ScriptPubKey.Type
 	}
 
 	confs = verboseTx.Confirmations

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -526,11 +526,11 @@ func (dcr *Backend) outputSummary(txHash *chainhash.Hash, vout uint32) (txOut *t
 
 	out := verboseTx.Vout[vout]
 
-	scriptHex, err := hex.DecodeString(out.ScriptPubKey.Hex)
+	script, err := hex.DecodeString(out.ScriptPubKey.Hex)
 	if err != nil {
 		return nil, -1, dex.UnsupportedScriptError
 	}
-	scriptType, addrs, numRequired, err := dexdcr.ExtractScriptData(out.ScriptPubKey.Version, scriptHex, chainParams)
+	scriptType, addrs, numRequired, err := dexdcr.ExtractScriptData(out.ScriptPubKey.Version, script, chainParams)
 	if err != nil {
 		return nil, -1, dex.UnsupportedScriptError
 	}

--- a/server/asset/driver.go
+++ b/server/asset/driver.go
@@ -17,7 +17,7 @@ var (
 
 // AddresserFactory describes a type that can construct new Addressers.
 type AddresserFactory interface {
-	NewAddresser(acctXPub string, keyIndexer HDKeyIndexer, network dex.Network) (Addresser, error)
+	NewAddresser(acctXPub string, keyIndexer KeyIndexer, network dex.Network) (Addresser, uint32, error)
 }
 
 // Driver is the interface required of all assets. A Driver may or may not also
@@ -47,16 +47,16 @@ func DecodeCoinID(name string, coinID []byte) (string, error) {
 // NewAddresser creates an Addresser for a named asset for deriving addresses
 // for the given extended public key on a certain network while maintaining the
 // address index in an external HDKeyIndex.
-func NewAddresser(name string, acctXPub string, keyIndexer HDKeyIndexer, network dex.Network) (Addresser, error) {
+func NewAddresser(name string, acctXPub string, keyIndexer KeyIndexer, network dex.Network) (Addresser, uint32, error) {
 	driversMtx.Lock()
 	drv, ok := drivers[name]
 	driversMtx.Unlock()
 	if !ok {
-		return nil, fmt.Errorf("unknown asset driver %q", name)
+		return nil, 0, fmt.Errorf("unknown asset driver %q", name)
 	}
 	af, ok := drv.(AddresserFactory)
 	if !ok {
-		return nil, fmt.Errorf("asset does not support NewAddresser")
+		return nil, 0, fmt.Errorf("asset does not support NewAddresser")
 	}
 	return af.NewAddresser(acctXPub, keyIndexer, network)
 }

--- a/server/asset/driver.go
+++ b/server/asset/driver.go
@@ -15,7 +15,13 @@ var (
 	drivers    = make(map[string]Driver)
 )
 
-// Driver is the interface required of all assets.
+// AddresserFactory describes a type that can construct new Addressers.
+type AddresserFactory interface {
+	NewAddresser(acctXPub string, keyIndexer HDKeyIndexer, network dex.Network) (Addresser, error)
+}
+
+// Driver is the interface required of all assets. A Driver may or may not also
+// be an AddresserFactory.
 type Driver interface {
 	// Setup should create a Backend, but not start the backend connection.
 	Setup(configPath string, logger dex.Logger, network dex.Network) (Backend, error)
@@ -33,9 +39,26 @@ func DecodeCoinID(name string, coinID []byte) (string, error) {
 	drv, ok := drivers[name]
 	driversMtx.Unlock()
 	if !ok {
-		return "", fmt.Errorf("db: unknown asset driver %q", name)
+		return "", fmt.Errorf("unknown asset driver %q", name)
 	}
 	return drv.DecodeCoinID(coinID)
+}
+
+// NewAddresser creates an Addresser for a named asset for deriving addresses
+// for the given extended public key on a certain network while maintaining the
+// address index in an external HDKeyIndex.
+func NewAddresser(name string, acctXPub string, keyIndexer HDKeyIndexer, network dex.Network) (Addresser, error) {
+	driversMtx.Lock()
+	drv, ok := drivers[name]
+	driversMtx.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("unknown asset driver %q", name)
+	}
+	af, ok := drv.(AddresserFactory)
+	if !ok {
+		return nil, fmt.Errorf("asset does not support NewAddresser")
+	}
+	return af.NewAddresser(acctXPub, keyIndexer, network)
 }
 
 // Register should be called by the init function of an asset's package.

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -181,11 +181,6 @@ func (client *clientInfo) respHandler(id uint64) *respHandler {
 	return handler
 }
 
-type feeAsset struct {
-	confs uint32
-	amt   uint64
-}
-
 // AuthManager handles authentication-related tasks, including validating client
 // signatures, maintaining association between accounts and `comms.Link`s, and
 // signing messages with the DEX's private key. AuthManager manages requests to
@@ -198,7 +193,7 @@ type AuthManager struct {
 	unbookFun      func(account.AccountID)
 
 	feeAddress func(assetID uint32) string
-	feeAssets  map[uint32]*feeAsset
+	feeAssets  map[uint32]*msgjson.FeeAsset
 
 	anarchy           bool
 	freeCancels       bool
@@ -377,12 +372,10 @@ func NewAuthManager(cfg *Config) *AuthManager {
 	if absTakerLotLimit == 0 {
 		absTakerLotLimit = defaultAbsTakerLotLimit
 	}
-	feeAssets := make(map[uint32]*feeAsset)
+	// Re-key the map for efficiency in AuthManager methods.
+	feeAssets := make(map[uint32]*msgjson.FeeAsset)
 	for _, asset := range cfg.FeeAssets {
-		feeAssets[asset.ID] = &feeAsset{
-			amt:   asset.Amt,
-			confs: asset.Confs,
-		}
+		feeAssets[asset.ID] = asset
 	}
 	auth := &AuthManager{
 		storage:           cfg.Storage,

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -70,8 +70,7 @@ type Signer interface {
 	PubKey() *secp256k1.PublicKey
 }
 
-// FeeChecker is a function for retrieving the details for a fee payment. It
-// is satisfied by (dcr.Backend).FeeCoin.
+// FeeChecker is a function for retrieving the details for a fee payment.
 type FeeChecker func(assetID uint32, coinID []byte) (addr string, val uint64, confs int64, err error)
 
 type TxDataSource func([]byte) ([]byte, error)

--- a/server/auth/registrar.go
+++ b/server/auth/registrar.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/dex/wait"
@@ -56,12 +57,89 @@ func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *
 		}
 	}
 
-	// Register account and get a fee payment address.
-	feeAddr, err := auth.storage.CreateAccount(acct)
-	if err != nil {
+	sendRegRes := func(feeAsset uint32, feeAddr string, feeAmt uint64) *msgjson.Error {
+		// Prepare, sign, and send response.
+		regRes := &msgjson.RegisterResult{
+			DEXPubKey:    auth.signer.PubKey().SerializeCompressed(),
+			ClientPubKey: register.PubKey,
+			AssetID:      &feeAsset,
+			Address:      feeAddr,
+			Fee:          feeAmt,
+			Time:         encode.UnixMilliU(unixMsNow()),
+		}
+		auth.Sign(regRes)
+
+		resp, err := msgjson.NewResponse(msg.ID, regRes, nil)
+		if err != nil {
+			log.Errorf("error creating new response for registration result: %v", err)
+			return &msgjson.Error{
+				Code:    msgjson.RPCInternalError,
+				Message: "internal error",
+			}
+		}
+
+		err = conn.Send(resp)
+		if err != nil {
+			log.Warnf("Error sending register result to link: %v", err)
+		}
+		return nil
+	}
+
+	regAsset := uint32(42)
+	if register.Asset != nil {
+		regAsset = *register.Asset
+	}
+
+	// See if the account already exists. If it is paid, just respond with
+	// AccountExistsError and the known fee coin. If it exists but is not paid,
+	// resend the RegisterResult with the previously recorded fee address and
+	// asset ID. Note that this presently does not permit a user to change from
+	// the initially requested asset to another.
+	ai, err := auth.storage.AccountInfo(acct.ID)
+	if err == nil {
+		if len(ai.FeeCoin) > 0 {
+			return &msgjson.Error{
+				Code:    msgjson.AccountExistsError,
+				Message: ai.FeeCoin.String(), // Fee coin TODO: supplement with asset ID
+			}
+		}
+		// Resend RegisterResult with the existing fee address.
+		feeAsset := auth.feeAssets[ai.FeeAsset]
+		if feeAsset == nil || feeAsset.amt == 0 || ai.FeeAddress == "" ||
+			regAsset != ai.FeeAsset /* sanity */ {
+			// NOTE: Allowing register.Asset != ai.FeeAsset would require
+			// clearing this account's previously recorded fee address.
+			return &msgjson.Error{
+				Code:    msgjson.RPCInternalError,
+				Message: "asset not supported for registration",
+			}
+		}
+		return sendRegRes(ai.FeeAsset, ai.FeeAddress, feeAsset.amt)
+	}
+	if !db.IsErrAccountUnknown(err) {
+		log.Errorf("AccountInfo error for ID %s: %v", acct.ID, err)
+		return &msgjson.Error{
+			Code:    msgjson.RPCInternalError,
+			Message: "failed to create new account",
+		}
+	} // else account unknown, create it
+
+	// Try to get a fee address and amount for the requested asset.
+	feeAsset := auth.feeAssets[regAsset]
+	feeAddr := auth.feeAddress(regAsset)
+	if feeAsset == nil || feeAddr == "" {
+		return &msgjson.Error{
+			Code:    msgjson.RPCInternalError,
+			Message: "asset not supported for registration",
+		}
+	}
+
+	// Register the new account with the fee address.
+	if err = auth.storage.CreateAccount(acct, regAsset, feeAddr); err != nil {
 		log.Debugf("CreateAccount(%s) failed: %v", acct.ID, err)
-		var archiveErr *db.ArchiveError
+		var archiveErr db.ArchiveError // CreateAccount returns by value.
 		if errors.As(err, &archiveErr) {
+			// These cases should have been caught above.
 			switch archiveErr.Code {
 			case db.ErrAccountExists:
 				return &msgjson.Error{
@@ -77,37 +155,13 @@ func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *
 		}
 		return &msgjson.Error{
 			Code:    msgjson.RPCInternalError,
-			Message: "failed to create new account (already registered?)",
+			Message: "failed to create new account",
 		}
 	}
 
-	log.Infof("Created new user account %v from %v with fee address %v", acct.ID, conn.Addr(), feeAddr)
-
-	// Prepare, sign, and send response.
-	regRes := &msgjson.RegisterResult{
-		DEXPubKey:    auth.signer.PubKey().SerializeCompressed(),
-		ClientPubKey: register.PubKey,
-		Address:      feeAddr,
-		Fee:          auth.regFee,
-		Time:         encode.UnixMilliU((unixMsNow())),
-	}
-	auth.Sign(regRes)
-
-	resp, err := msgjson.NewResponse(msg.ID, regRes, nil)
-	if err != nil {
-		log.Errorf("error creating new response for registration result: %v", err)
-		return &msgjson.Error{
-			Code:    msgjson.RPCInternalError,
-			Message: "internal error",
-		}
-	}
-
-	err = conn.Send(resp)
-	if err != nil {
-		log.Warnf("Error sending register result to link: %v", err)
-	}
-
-	return nil
+	log.Infof("Created new user account %v from %v with fee address %v (%v)",
+		acct.ID, conn.Addr(), feeAddr, dex.BipIDSymbol(regAsset))
+	return sendRegRes(regAsset, feeAddr, feeAsset.amt)
 }
 
 // handleNotifyFee handles requests to the 'notifyfee' route.
@@ -133,34 +187,63 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 	var acctID account.AccountID
 	copy(acctID[:], notifyFee.AccountID)
 
-	acct, paid, open := auth.storage.Account(acctID)
-	if acct == nil {
+	ai, err := auth.storage.AccountInfo(acctID)
+	if ai == nil || err != nil {
 		return &msgjson.Error{
 			Code:    msgjson.AuthenticationError,
 			Message: "no account found for ID " + notifyFee.AccountID.String(),
 		}
 	}
-	if !open {
+	if ai.BrokenRule != account.NoRule {
 		return &msgjson.Error{
 			Code:    msgjson.AuthenticationError,
-			Message: "account closed and cannot be reopen",
-		}
-	}
-	if paid {
-		return &msgjson.Error{
-			Code:    msgjson.AuthenticationError,
-			Message: "'notifyfee' send for paid account",
+			Message: "account closed and cannot be reopened",
 		}
 	}
 
 	// Check signature
 	sigMsg := notifyFee.Serialize()
+	acct, err := account.NewAccountFromPubKey(ai.Pubkey)
+	if err != nil {
+		// Shouldn't happen.
+		log.Warnf("Pubkey decode failure for %v: %v", acctID, err)
+		return &msgjson.Error{
+			Code:    msgjson.AuthenticationError,
+			Message: "pubkey decode failure",
+		}
+	}
 	err = checkSigS256(sigMsg, notifyFee.SigBytes(), acct.PubKey)
 	if err != nil {
 		return &msgjson.Error{
 			Code:    msgjson.SignatureError,
 			Message: "signature error: " + err.Error(),
 		}
+	}
+
+	if len(ai.FeeCoin) > 0 {
+		// No need to search for txn, and storage.PayAccount would fail to store
+		// the Coin again, so just respond if fee coin matches.
+		if !notifyFee.CoinID.Equal(ai.FeeCoin) {
+			return &msgjson.Error{
+				Code:    msgjson.FeeError,
+				Message: "invalid fee coin",
+			}
+		}
+		// Account ID and fee coin are good, sign the request and respond.
+		auth.Sign(notifyFee)
+		notifyRes := new(msgjson.NotifyFeeResult)
+		notifyRes.SetSig(notifyFee.SigBytes())
+		resp, err := msgjson.NewResponse(msg.ID, notifyRes, nil)
+		if err != nil {
+			return &msgjson.Error{
+				Code:    msgjson.RPCInternalError,
+				Message: "internal encoding error",
+			}
+		}
+		if err = conn.Send(resp); err != nil {
+			log.Warnf("error sending notifyfee result to link: %v", err)
+		}
+		return nil
 	}
 
 	auth.feeWaiterMtx.Lock()
@@ -173,7 +256,7 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 	}
 
 	// Get the registration fee address assigned to the client's account.
-	regAddr, err := auth.storage.AccountRegAddr(acctID)
+	regAddr, assetID, err := auth.storage.AccountRegAddr(acctID)
 	if err != nil {
 		auth.feeWaiterMtx.Unlock()
 		log.Infof("AccountRegAddr failed to load info for account %v: %v", acctID, err)
@@ -195,7 +278,7 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 	auth.latencyQ.Wait(&wait.Waiter{
 		Expiration: time.Now().Add(txWaitExpiration),
 		TryFunc: func() bool {
-			res := auth.validateFee(conn, acctID, notifyFee, msg.ID, notifyFee.CoinID, regAddr)
+			res := auth.validateFee(conn, msg.ID, acctID, notifyFee, assetID, regAddr)
 			if res == wait.DontTryAgain {
 				removeWaiter()
 			}
@@ -211,30 +294,49 @@ func (auth *AuthManager) handleNotifyFee(conn comms.Link, msg *msgjson.Message) 
 
 // validateFee is a coin waiter that validates a client's notifyFee request and
 // responds with an Acknowledgement.
-func (auth *AuthManager) validateFee(conn comms.Link, acctID account.AccountID, notifyFee *msgjson.NotifyFee, msgID uint64, coinID []byte, regAddr string) bool {
-	addr, val, confs, err := auth.checkFee(coinID)
-	if err != nil || confs < auth.feeConfs {
-		if err != nil && !errors.Is(err, asset.CoinNotFoundError) {
+func (auth *AuthManager) validateFee(conn comms.Link, msgID uint64, acctID account.AccountID,
+	notifyFee *msgjson.NotifyFee, assetID uint32, regAddr string) bool {
+	// If there is a problem, respond with an error.
+	var msgErr *msgjson.Error
+	defer func() {
+		if msgErr == nil {
+			return
+		}
+		resp, err := msgjson.NewResponse(msgID, nil, msgErr)
+		if err != nil {
+			log.Errorf("error encoding notifyfee error response: %v", err)
+			return
+		}
+		err = conn.Send(resp)
+		if err != nil {
+			log.Warnf("error sending notifyfee error response: %v", err)
+		}
+	}()
+
+	// Required confirmations and amount.
+	feeAsset := auth.feeAssets[assetID]
+	if feeAsset == nil { // shouldn't be possible
+		msgErr = &msgjson.Error{
+			Code:    msgjson.FeeError,
+			Message: "unsupported asset",
+		}
+		return wait.DontTryAgain
+	}
+
+	coinID := notifyFee.CoinID
+	addr, val, confs, err := auth.checkFee(assetID, coinID)
+	if err != nil {
+		if !errors.Is(err, asset.CoinNotFoundError) {
 			log.Warnf("Unexpected error checking fee coin confirmations: %v", err)
 			// return wait.DontTryAgain // maybe
 		}
 		return wait.TryAgain
 	}
-	var msgErr *msgjson.Error
-	defer func() {
-		if msgErr != nil {
-			resp, err := msgjson.NewResponse(msgID, nil, msgErr)
-			if err != nil {
-				log.Errorf("error encoding notifyfee error response: %v", err)
-				return
-			}
-			err = conn.Send(resp)
-			if err != nil {
-				log.Warnf("error sending notifyfee result to link: %v", err)
-			}
-		}
-	}()
-	if val < auth.regFee {
+	if confs < int64(feeAsset.confs) {
+		return wait.TryAgain
+	}
+
+	if val < feeAsset.amt {
 		msgErr = &msgjson.Error{
 			Code:    msgjson.FeeError,
 			Message: "fee too low",

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -51,9 +51,7 @@ const (
 	defaultMaxUserCancels      = 2
 	defaultBanScore            = 20
 
-	defaultCancelThresh     = 0.95 // 19 cancels : 1 success
-	defaultRegFeeConfirms   = 4
-	defaultRegFeeAmount     = 1e8
+	defaultCancelThresh     = 0.95             // 19 cancels : 1 success
 	defaultBroadcastTimeout = 12 * time.Minute // accommodate certain known long block download timeouts
 )
 
@@ -124,9 +122,12 @@ type flagsData struct {
 	MarketsConfPath  string        `long:"marketsconfpath" description:"Path to the markets configuration JSON file."`
 	BroadcastTimeout time.Duration `long:"bcasttimeout" description:"The broadcast timeout specifies how long clients have to broadcast an expected transaction when it is their turn to act. Matches without the expected action by this time are revoked and the actor is penalized."`
 	DEXPrivKeyPath   string        `long:"dexprivkeypath" description:"The path to a file containing the DEX private key for message signing."`
-	RegFeeXPub       string        `long:"regfeexpub" description:"The extended public key for deriving Decred addresses to which DEX registration fees should be paid."`
-	RegFeeConfirms   int64         `long:"regfeeconfirms" description:"The number of confirmations required to consider a registration fee paid."`
-	RegFeeAmount     uint64        `long:"regfeeamount" description:"The registration fee amount in atoms."`
+
+	// Deprecated fields that specify the Decred-specific registration fee
+	// config. This information is now specified per-asset in markets.json.
+	RegFeeXPub     string `long:"regfeexpub" description:"DEPRECATED - use markets.json instead. The extended public key for deriving Decred addresses to which DEX registration fees should be paid."`
+	RegFeeConfirms int64  `long:"regfeeconfirms" description:"DEPRECATED - use markets.json instead. The number of confirmations required to consider a registration fee paid."`
+	RegFeeAmount   uint64 `long:"regfeeamount" description:"DEPRECATED - use markets.json instead. The registration fee amount in atoms."`
 
 	Anarchy           bool    `long:"anarchy" description:"Do not enforce any rules."`
 	CancelThreshold   float64 `long:"cancelthresh" description:"Cancellation rate threshold (cancels/all_completed)."`
@@ -311,8 +312,6 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		PGHost:           defaultPGHost,
 		MarketsConfPath:  defaultMarketsConfFilename,
 		DEXPrivKeyPath:   defaultDEXPrivKeyFilename,
-		RegFeeConfirms:   defaultRegFeeConfirms,
-		RegFeeAmount:     defaultRegFeeAmount,
 		BroadcastTimeout: defaultBroadcastTimeout,
 		CancelThreshold:  defaultCancelThresh,
 		MaxUserCancels:   defaultMaxUserCancels,

--- a/server/cmd/dcrdex/sample-dcrdex.conf
+++ b/server/cmd/dcrdex/sample-dcrdex.conf
@@ -77,17 +77,7 @@
 ; Registration fee settings
 ; ------------------------------------------------------------------------------
 
-; The extended public key for deriving Decred addresses to which DEX 
-; registration fees should be paid.
-; regfeexpub=
-
-; The number of confirmations required to consider a registration fee paid.
-; Default value is 4.
-; regfeeconfirms=4
-
-; The registration fee amount in atoms.
-; Default value is 1 DCR = 1e8 atoms.
-; regfeeamount=100000000
+; NOTE: registration fee settings are specified in markets.json per asset.
 
 ; ------------------------------------------------------------------------------
 ; PostgreSQL settings

--- a/server/cmd/dcrdex/sample-markets.json
+++ b/server/cmd/dcrdex/sample-markets.json
@@ -23,7 +23,10 @@
             "network": "mainnet",
             "maxFeeRate": 10,
             "swapConf": 4,
-            "configPath": "/home/dcrd/.dcrd/dcrd.conf"
+            "configPath": "/home/dcrd/.dcrd/dcrd.conf",
+            "regConfs": 2,
+            "regFee": 0.1,
+            "regXPub": "xpubdecredonlyadsf"
         },
         "DCR_testnet": {
             "bip44symbol": "dcr",
@@ -36,7 +39,10 @@
             "bip44symbol": "btc",
             "network": "mainnet",
             "maxFeeRate": 100,
-            "swapConf": 3
+            "swapConf": 3,
+            "regConfs": 2,
+            "regFee": 0.0005,
+            "regXPub": "xpubbitcoinonlyasdf"
         },
         "BTC_testnet": {
             "bip44symbol": "btc",

--- a/server/cmd/dcrdex/sample-markets.json
+++ b/server/cmd/dcrdex/sample-markets.json
@@ -25,7 +25,7 @@
             "swapConf": 4,
             "configPath": "/home/dcrd/.dcrd/dcrd.conf",
             "regConfs": 2,
-            "regFee": 0.1,
+            "regFee": 10000000,
             "regXPub": "xpubdecredonlyadsf"
         },
         "DCR_testnet": {
@@ -41,7 +41,7 @@
             "maxFeeRate": 100,
             "swapConf": 3,
             "regConfs": 2,
-            "regFee": 0.0005,
+            "regFee": 500000,
             "regXPub": "xpubbitcoinonlyasdf"
         },
         "BTC_testnet": {

--- a/server/db/driver/pg/accounts.go
+++ b/server/db/driver/pg/accounts.go
@@ -125,7 +125,7 @@ func (a *Archiver) CreateAccount(acct *account.Account, assetID uint32, regAddr 
 	return createAccount(a.db, a.tables.accounts, acct, assetID, regAddr)
 }
 
-// AccountRegAddr retrieves the registration fee address and corresponding the
+// AccountRegAddr retrieves the registration fee address and the corresponding
 // asset ID created for the the specified account.
 func (a *Archiver) AccountRegAddr(aid account.AccountID) (string, uint32, error) {
 	return accountRegAddr(a.db, a.tables.accounts, aid)

--- a/server/db/driver/pg/accounts.go
+++ b/server/db/driver/pg/accounts.go
@@ -11,7 +11,7 @@ import (
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/db/driver/pg/internal"
-	"github.com/decred/dcrd/dcrutil/v4" // deprecated usage, move to "crypto/sha256"
+	"github.com/decred/dcrd/dcrutil/v4" // TODO: consider a move to "crypto/sha256" instead of dcrutil.Hash160
 )
 
 // CloseAccount closes the account by setting the value of the rule column to

--- a/server/db/driver/pg/accounts.go
+++ b/server/db/driver/pg/accounts.go
@@ -11,9 +11,7 @@ import (
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
 	"decred.org/dcrdex/server/db/driver/pg/internal"
-	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/hdkeychain/v3"
-	"github.com/decred/dcrd/txscript/v4/stdaddr"
+	"github.com/decred/dcrd/dcrutil/v4" // deprecated usage, move to "crypto/sha256"
 )
 
 // CloseAccount closes the account by setting the value of the rule column to
@@ -67,12 +65,14 @@ func (a *Archiver) Accounts() ([]*db.Account, error) {
 	defer rows.Close()
 	var accts []*db.Account
 	var feeAddress sql.NullString
+	var feeAsset sql.NullInt32
 	for rows.Next() {
 		a := new(db.Account)
-		err = rows.Scan(&a.AccountID, &a.Pubkey, &feeAddress, &a.FeeCoin, &a.BrokenRule)
+		err = rows.Scan(&a.AccountID, &a.Pubkey, &feeAsset, &feeAddress, &a.FeeCoin, &a.BrokenRule)
 		if err != nil {
 			return nil, err
 		}
+		a.FeeAsset = uint32(feeAsset.Int32)
 		a.FeeAddress = feeAddress.String
 		accts = append(accts, a)
 	}
@@ -84,70 +84,56 @@ func (a *Archiver) Accounts() ([]*db.Account, error) {
 
 // AccountInfo returns data for an account.
 func (a *Archiver) AccountInfo(aid account.AccountID) (*db.Account, error) {
-
 	stmt := fmt.Sprintf(internal.SelectAccountInfo, a.tables.accounts)
 	acct := new(db.Account)
 	var feeAddress sql.NullString
-	if err := a.db.QueryRow(stmt, aid).Scan(&acct.AccountID, &acct.Pubkey, &feeAddress,
-		&acct.FeeCoin, &acct.BrokenRule); err != nil {
+	var feeAsset sql.NullInt32
+	if err := a.db.QueryRow(stmt, aid).Scan(&acct.AccountID, &acct.Pubkey, &feeAsset,
+		&feeAddress, &acct.FeeCoin, &acct.BrokenRule); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			err = db.ArchiveError{Code: db.ErrAccountUnknown}
+		}
 		return nil, err
 	}
 
+	acct.FeeAsset = uint32(feeAsset.Int32)
 	acct.FeeAddress = feeAddress.String
 	return acct, nil
 }
 
-// CreateAccount creates an entry for a new account in the accounts table. A
-// DCR registration fee address is created and returned.
-func (a *Archiver) CreateAccount(acct *account.Account) (string, error) {
+// CreateAccount creates an entry for a new account in the accounts table.
+func (a *Archiver) CreateAccount(acct *account.Account, assetID uint32, regAddr string) error {
 	ai, err := a.AccountInfo(acct.ID)
 	if err == nil {
+		if ai.FeeAddress != regAddr || ai.FeeAsset != assetID {
+			return db.ArchiveError{Code: db.ErrAccountBadFeeInfo}
+		}
 		if len(ai.FeeCoin) == 0 {
-			return ai.FeeAddress, nil
-
+			return nil // fee address and asset match, just unpaid
 		}
 		if ai.BrokenRule == account.NoRule {
-			return "", &db.ArchiveError{Code: db.ErrAccountExists, Detail: ai.FeeCoin.String()}
+			return db.ArchiveError{Code: db.ErrAccountExists, Detail: ai.FeeCoin.String()}
 		}
-		return "", &db.ArchiveError{Code: db.ErrAccountSuspended}
+		return db.ArchiveError{Code: db.ErrAccountSuspended}
 	}
-	if !errors.Is(err, sql.ErrNoRows) {
+	if !db.IsErrAccountUnknown(err) {
 		log.Errorf("AccountInfo error for ID %s: %v", acct.ID, err)
-		return "", db.ArchiveError{Code: db.ErrGeneralFailure}
+		return db.ArchiveError{Code: db.ErrGeneralFailure}
 	}
 
-	regAddr, err := a.getNextAddress()
-	if err != nil {
-		return "", fmt.Errorf("error creating registration address: %w", err)
-	}
-	err = createAccount(a.db, a.tables.accounts, acct, regAddr)
-	if err != nil {
-		return "", err
-	}
-	return regAddr, nil
+	// ErrAccountUnknown, so create the account.
+	return createAccount(a.db, a.tables.accounts, acct, assetID, regAddr)
 }
 
-// CreateKeyEntry creates an entry for the pubkey (hash) if one doesn't already
-// exist.
-func (a *Archiver) CreateKeyEntry(keyHash []byte) error {
-	return createKeyEntry(a.db, a.tables.feeKeys, keyHash)
-}
-
-// AccountRegAddr retrieves the registration fee address created for the
-// the specified account.
-func (a *Archiver) AccountRegAddr(aid account.AccountID) (string, error) {
+// AccountRegAddr retrieves the registration fee address and corresponding the
+// asset ID created for the the specified account.
+func (a *Archiver) AccountRegAddr(aid account.AccountID) (string, uint32, error) {
 	return accountRegAddr(a.db, a.tables.accounts, aid)
 }
 
 // PayAccount sets the registration fee payment details for the account,
 // effectively completing the registration process.
 func (a *Archiver) PayAccount(aid account.AccountID, coinID []byte) error {
-	// This check is fine for now. If support for an asset with a longer coin ID
-	// is implemented, this restriction would need to be loosened.
-	if len(coinID) != chainhash.HashSize+4 {
-		return fmt.Errorf("incorrect length transaction ID %x. wanted %d, got %d",
-			coinID, chainhash.MaxHashStringSize+4, len(coinID))
-	}
 	ok, err := payAccount(a.db, a.tables.accounts, aid, coinID)
 	if err != nil {
 		return err
@@ -158,37 +144,62 @@ func (a *Archiver) PayAccount(aid account.AccountID, coinID []byte) error {
 	return nil
 }
 
-// Get the next address for the current master pubkey.
-func (a *Archiver) getNextAddress() (string, error) {
-	stmt := fmt.Sprintf(internal.IncrementKey, feeKeysTableName)
-	var childExtKey *hdkeychain.ExtendedKey
-out:
-	for {
-		var child uint32
-		err := a.db.QueryRow(stmt, a.keyHash).Scan(&child)
-		if err != nil {
-			return "", err
-		}
-		childExtKey, err = a.feeKeyBranch.Child(child)
-		switch {
-		case errors.Is(err, hdkeychain.ErrInvalidChild):
-			continue
-		case err == nil:
-			break out
-		default:
-			log.Errorf("error creating child key: %v", err)
-			return "", fmt.Errorf("error generating fee address")
-		}
-	}
-
-	pubKeyBytes := childExtKey.SerializedPubKey()
-	addr, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(stdaddr.Hash160(pubKeyBytes), a.keyParams)
+// createKeyEntry creates an entry for the pubkey (hash) if it doesn't already
+// exist, and returns the child index.
+func createKeyEntry(db *sql.DB, tableName string, keyHash []byte) (uint32, error) {
+	stmt := fmt.Sprintf(internal.InsertKeyIfMissing, tableName)
+	var child uint32
+	err := db.QueryRow(stmt, keyHash).Scan(&child)
 	if err != nil {
-		log.Errorf("Failed to create creating new pubkey hash address: %v", err)
-		return "", fmt.Errorf("error encoding fee address: %w", err)
+		return 0, err
 	}
+	return child, nil
+}
 
-	return addr.String(), nil
+// CreateFeeKeyEntryFromPubKey an entry for the pubkey, which should be of
+// length secp256k1.PubKeyBytesLenCompressed. Decred's HASH160 will be applied
+// internally. The current child index is returned.
+func (a *Archiver) CreateFeeKeyEntryFromPubKey(xpub string) (child uint32, err error) {
+	keyHash := dcrutil.Hash160([]byte(xpub))
+	log.Debugf("Inserting key entry for xpub %.40s..., hash160 = %x", xpub, keyHash)
+	return createKeyEntry(a.db, a.tables.feeKeys, keyHash)
+}
+
+// FeeKeyIndex returns the current child index for the an xpub. If it is not
+// known, this returns an ErrUnknownFeeKey coded ArchiveError.
+func (a *Archiver) FeeKeyIndex(xpub string) (uint32, error) {
+	keyHash := dcrutil.Hash160([]byte(xpub))
+	stmt := fmt.Sprintf(internal.CurrentKeyIndex, feeKeysTableName)
+	var child uint32
+	err := a.db.QueryRow(stmt, keyHash).Scan(&child)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return 0, db.ArchiveError{Code: db.ErrUnknownFeeKey}
+	case err == nil:
+	default:
+		return 0, err
+	}
+	return child, nil
+}
+
+// SetFeeKeyIndex records the child index for an xpub. An error is returned
+// unless exactly 1 row is updated.
+func (a *Archiver) SetFeeKeyIndex(idx uint32, xpub string) error {
+	keyHash := dcrutil.Hash160([]byte(xpub))
+	log.Debugf("Recording new index %d for xpub %.40s... (%x)", idx, xpub, keyHash)
+	stmt := fmt.Sprintf(internal.SetKeyIndex, feeKeysTableName)
+	res, err := a.db.Exec(stmt, idx, keyHash)
+	if err != nil {
+		return err
+	}
+	N, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if N != 1 {
+		return fmt.Errorf("updated %d rows, expected 1", N)
+	}
+	return nil
 }
 
 // createAccountTables creates the accounts and fee_keys tables.
@@ -226,9 +237,10 @@ func setRule(dbe sqlExecutor, tableName string, aid account.AccountID, rule acco
 // registered, and whether the account is still open, in that order.
 func getAccount(dbe *sql.DB, tableName string, aid account.AccountID) (*account.Account, bool, bool, error) {
 	var coinID, pubkey []byte
+	var assetID sql.NullInt32
 	var rule uint8
 	stmt := fmt.Sprintf(internal.SelectAccount, tableName)
-	err := dbe.QueryRow(stmt, aid).Scan(&pubkey, &coinID, &rule)
+	err := dbe.QueryRow(stmt, aid).Scan(&pubkey, &assetID, &coinID, &rule)
 	if err != nil {
 		return nil, false, false, err
 	}
@@ -237,22 +249,23 @@ func getAccount(dbe *sql.DB, tableName string, aid account.AccountID) (*account.
 }
 
 // createAccount creates an entry for the account in the accounts table.
-func createAccount(dbe sqlExecutor, tableName string, acct *account.Account, regAddr string) error {
+func createAccount(dbe sqlExecutor, tableName string, acct *account.Account, feeAsset uint32, regAddr string) error {
 	stmt := fmt.Sprintf(internal.CreateAccount, tableName)
-	_, err := dbe.Exec(stmt, acct.ID, acct.PubKey.SerializeCompressed(), regAddr)
+	_, err := dbe.Exec(stmt, acct.ID, acct.PubKey.SerializeCompressed(), feeAsset, regAddr)
 	return err
 }
 
-// accountRegAddr gets the registration fee address created for the specified
-// account.
-func accountRegAddr(dbe *sql.DB, tableName string, aid account.AccountID) (string, error) {
+// accountRegAddr gets the registration fee address and its asset ID created for
+// the specified account.
+func accountRegAddr(dbe *sql.DB, tableName string, aid account.AccountID) (string, uint32, error) {
 	var addr string
+	var assetID sql.NullInt32
 	stmt := fmt.Sprintf(internal.SelectRegAddress, tableName)
-	err := dbe.QueryRow(stmt, aid).Scan(&addr)
+	err := dbe.QueryRow(stmt, aid).Scan(&assetID, &addr)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
-	return addr, nil
+	return addr, uint32(assetID.Int32), nil
 }
 
 // payAccount sets the registration fee payment details.
@@ -264,12 +277,4 @@ func payAccount(dbe *sql.DB, tableName string, aid account.AccountID, coinID []b
 	}
 	rows, err := res.RowsAffected()
 	return rows > 0, err
-}
-
-// createKeyEntry creates an entry for the pubkey (hash) if it doesn't already
-// exist.
-func createKeyEntry(db *sql.DB, tableName string, keyHash []byte) error {
-	stmt := fmt.Sprintf(internal.InsertKeyIfMissing, tableName)
-	_, err := db.Exec(stmt, keyHash)
-	return err
 }

--- a/server/db/driver/pg/accounts_online_test.go
+++ b/server/db/driver/pg/accounts_online_test.go
@@ -43,12 +43,14 @@ func TestAccounts(t *testing.T) {
 
 	acct := tNewAccount(t)
 
-	regAddr, err := archie.CreateAccount(acct)
+	assetID := uint32(42)
+	regAddr := "DsdQFmH3azyoGKJHt2ArJNxi35LCEgMqi8k"
+	err := archie.CreateAccount(acct, assetID, regAddr)
 	if err != nil {
 		t.Fatalf("error creating account: %v", err)
 	}
 
-	checkAddr, err := archie.AccountRegAddr(tAcctID)
+	checkAddr, checkAssetID, err := archie.AccountRegAddr(tAcctID)
 	if err != nil {
 		t.Fatalf("error getting registration address: %v", err)
 	}
@@ -56,6 +58,10 @@ func TestAccounts(t *testing.T) {
 	if checkAddr != regAddr {
 		t.Fatalf("unexpected address retrieved from the DB. wanted %s, got %s",
 			regAddr, checkAddr)
+	}
+	if checkAssetID != assetID {
+		t.Fatalf("unexpected asset ID retrieved from the DB. wanted %d, got %d",
+			assetID, checkAssetID)
 	}
 
 	// Get the account. It should be unpaid.
@@ -85,6 +91,7 @@ func TestAccounts(t *testing.T) {
 	}
 	if accts[0].AccountID.String() != "0a9912205b2cbab0c25c2de30bda9074de0ae23b065489a99199bad763f102cc" ||
 		accts[0].Pubkey.String() != "0204988a498d5d19514b217e872b4dbd1cf071d365c4879e64ed5919881c97eb19" ||
+		accts[0].FeeAsset != assetID ||
 		accts[0].FeeAddress != "DsdQFmH3azyoGKJHt2ArJNxi35LCEgMqi8k" ||
 		accts[0].FeeCoin.String() != "6e515ff861f2016fd0da2f3eccdf8290c03a9d116bfba2f6729e648bdc6e5aed00000005" ||
 		byte(accts[0].BrokenRule) != byte(0) {
@@ -161,7 +168,7 @@ func TestWrongAccount(t *testing.T) {
 
 	acct := tNewAccount(t)
 
-	_, err := archie.AccountRegAddr(tAcctID)
+	_, _, err := archie.AccountRegAddr(tAcctID)
 	if err == nil {
 		t.Fatalf("no error fetching registration address for unknown account")
 	}

--- a/server/db/driver/pg/internal/accounts.go
+++ b/server/db/driver/pg/internal/accounts.go
@@ -25,17 +25,16 @@ const (
 		ON CONFLICT (key_hash) DO NOTHING
 		RETURNING child;`
 
-	// IncrementKey increments the child counter and returns the new value.
-	IncrementKey = `UPDATE %s
-		SET child = child + 1
-		WHERE key_hash = $1
-		RETURNING child;`
-
 	CurrentKeyIndex = `SELECT child FROM %s WHERE key_hash = $1;`
 
 	SetKeyIndex = `UPDATE %s
 		SET child = $1
 		WHERE key_hash = $2;`
+
+	UpsertKeyIndex = `INSERT INTO %s (child, key_hash)
+		VALUES ($1, $2)
+		ON CONFLICT (key_hash) DO UPDATE
+		SET child = $1;`
 
 	// CloseAccount sets the broken_rule column for the account, which signifies
 	// that the account is closed.

--- a/server/db/driver/pg/internal/accounts.go
+++ b/server/db/driver/pg/internal/accounts.go
@@ -12,6 +12,7 @@ const (
 	CreateAccountsTable = `CREATE TABLE IF NOT EXISTS %s (
 		account_id BYTEA PRIMARY KEY,  -- UNIQUE INDEX
 		pubkey BYTEA,
+		fee_asset INT4, -- NOTE upgrade will add this column after broken_rule 
 		fee_address TEXT,
 		fee_coin BYTEA,
 		broken_rule INT2 DEFAULT 0 -- TODO: change to banned BOOL
@@ -21,13 +22,20 @@ const (
 	// doesn't already exist.
 	InsertKeyIfMissing = `INSERT INTO %s (key_hash)
 		VALUES ($1)
-		ON CONFLICT (key_hash) DO NOTHING;`
+		ON CONFLICT (key_hash) DO NOTHING
+		RETURNING child;`
 
 	// IncrementKey increments the child counter and returns the new value.
 	IncrementKey = `UPDATE %s
 		SET child = child + 1
 		WHERE key_hash = $1
 		RETURNING child;`
+
+	CurrentKeyIndex = `SELECT child FROM %s WHERE key_hash = $1;`
+
+	SetKeyIndex = `UPDATE %s
+		SET child = $1
+		WHERE key_hash = $2;`
 
 	// CloseAccount sets the broken_rule column for the account, which signifies
 	// that the account is closed.
@@ -36,23 +44,23 @@ const (
 	// SelectAccount gathers account details for the specified account ID. The
 	// details returned from this query are sufficient to determine 1) whether the
 	// registration fee has been paid, or 2) whether the account has been closed.
-	SelectAccount = `SELECT pubkey, fee_coin, broken_rule
+	SelectAccount = `SELECT pubkey, fee_asset, fee_coin, broken_rule
 		FROM %s
 		WHERE account_id = $1;`
 
 	// SelectAllAccounts retrieves all accounts.
-	SelectAllAccounts = `SELECT * FROM %s;`
+	SelectAllAccounts = `SELECT account_id, pubkey, fee_asset, fee_address, fee_coin, broken_rule FROM %s;`
 
 	// SelectAccountInfo retrieves all fields for an account.
-	SelectAccountInfo = `SELECT * FROM %s
+	SelectAccountInfo = `SELECT account_id, pubkey, fee_asset, fee_address, fee_coin, broken_rule FROM %s
 		WHERE account_id = $1;`
 
 	// CreateAccount creates an entry for a new account.
-	CreateAccount = `INSERT INTO %s (account_id, pubkey, fee_address)
-		VALUES ($1, $2, $3);`
+	CreateAccount = `INSERT INTO %s (account_id, pubkey, fee_asset, fee_address)
+		VALUES ($1, $2, $3, $4);`
 
 	// SelectRegAddress fetches the registration fee address for the account.
-	SelectRegAddress = `SELECT fee_address FROM %s WHERE account_id = $1;`
+	SelectRegAddress = `SELECT fee_asset, fee_address FROM %s WHERE account_id = $1;`
 
 	// SetRegOutput sets the registration fee payment transaction details for the
 	// account.

--- a/server/db/driver/pg/internal/markets.go
+++ b/server/db/driver/pg/internal/markets.go
@@ -16,7 +16,7 @@ const (
 	)`
 
 	// SelectAllMarkets retrieves the active market information.
-	SelectAllMarkets = `SELECT * FROM %s;`
+	SelectAllMarkets = `SELECT name, base, quote, lot_size FROM %s;`
 
 	// InsertMarket inserts a new market in to the markets tables
 	InsertMarket = `INSERT INTO %s (name, base, quote, lot_size)

--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -70,9 +70,6 @@ func openDB() (func() error, error) {
 		ShowPGConfig: false,
 		QueryTimeout: 0, // zero to use the default
 		MarketCfg:    []*dex.MarketInfo{mktInfo, mktInfo2},
-		//CheckedStores: true,
-		Net:    dex.Mainnet,
-		FeeKey: "dprv3hCznBesA6jBu1MaSqEBewG76yGtnG6LWMtEXHQvh3MVo6rqesTk7FPMSrczDtEELReV4aGMcrDxc9htac5mBDUEbTi9rgCA8Ss5FkasKM3",
 	}
 
 	numMarkets = len(dbi.MarketCfg)
@@ -177,11 +174,7 @@ func cleanTables(db *sql.DB) error {
 		return err
 	}
 	_, err = prepareTables(context.Background(), db, mktConfig())
-	if err != nil {
-		return err
-	}
-
-	return archie.CreateKeyEntry(archie.keyHash)
+	return err
 }
 
 func Test_sqlExec(t *testing.T) {

--- a/server/db/errors.go
+++ b/server/db/errors.go
@@ -56,6 +56,9 @@ const (
 	ErrUpdateCount
 	ErrAccountExists
 	ErrAccountSuspended
+	ErrAccountUnknown
+	ErrAccountBadFeeInfo
+	ErrUnknownFeeKey
 )
 
 func (ae ArchiveError) Error() string {
@@ -81,6 +84,12 @@ func (ae ArchiveError) Error() string {
 		desc = "account already exists"
 	case ErrAccountSuspended:
 		desc = "account suspended"
+	case ErrAccountUnknown:
+		desc = "account unknown"
+	case ErrAccountBadFeeInfo:
+		desc = "mismatching fee address or asset"
+	case ErrUnknownFeeKey:
+		desc = "unknown fee key"
 	}
 
 	if ae.Detail == "" {
@@ -154,4 +163,18 @@ func IsErrOrderNotExecuted(err error) bool {
 func IsErrUpdateCount(err error) bool {
 	var errA ArchiveError
 	return errors.As(err, &errA) && errA.Code == ErrUpdateCount
+}
+
+// IsErrAccountUnknown returns true if the error is of type ArchiveError and has
+// code ErrAccountUnknown.
+func IsErrAccountUnknown(err error) bool {
+	var errA ArchiveError
+	return errors.As(err, &errA) && errA.Code == ErrAccountUnknown
+}
+
+// IsErrUnknownFeeKey returns true if the error is of type ArchiveError and has
+// code ErrUnknownFeeKey.
+func IsErrUnknownFeeKey(err error) bool {
+	var errA ArchiveError
+	return errors.As(err, &errA) && errA.Code == ErrUnknownFeeKey
 }

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -52,12 +52,11 @@ type PreimageResult struct {
 	ID   order.OrderID
 }
 
-// FeeKeyIndexer are the functions required to track an extended public key and
+// KeyIndexer are the functions required to track an extended public key and
 // derived children by index.
-type FeeKeyIndexer interface {
-	FeeKeyIndex(xpub string) (uint32, error)
-	SetFeeKeyIndex(idx uint32, xpub string) error
-	CreateFeeKeyEntryFromPubKey(xpub string) (child uint32, err error)
+type KeyIndexer interface {
+	KeyIndex(xpub string) (uint32, error)
+	SetKeyIndex(idx uint32, xpub string) error
 }
 
 // DEXArchivist will be composed of several different interfaces. Starting with
@@ -83,7 +82,7 @@ type DEXArchivist interface {
 
 	OrderArchiver
 	AccountArchiver
-	FeeKeyIndexer
+	KeyIndexer
 	MatchArchiver
 	SwapArchiver
 }

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -52,6 +52,14 @@ type PreimageResult struct {
 	ID   order.OrderID
 }
 
+// FeeKeyIndexer are the functions required to track an extended public key and
+// derived children by index.
+type FeeKeyIndexer interface {
+	FeeKeyIndex(xpub string) (uint32, error)
+	SetFeeKeyIndex(idx uint32, xpub string) error
+	CreateFeeKeyEntryFromPubKey(xpub string) (child uint32, err error)
+}
+
 // DEXArchivist will be composed of several different interfaces. Starting with
 // OrderArchiver.
 type DEXArchivist interface {
@@ -75,6 +83,7 @@ type DEXArchivist interface {
 
 	OrderArchiver
 	AccountArchiver
+	FeeKeyIndexer
 	MatchArchiver
 	SwapArchiver
 }
@@ -210,12 +219,14 @@ type AccountArchiver interface {
 	// will be returned for unknown or closed accounts.
 	Account(account.AccountID) (acct *account.Account, paid, open bool)
 
-	// CreateAccount stores a new account. The account is considered unpaid until
-	// PayAccount is used to set the payment details.
-	CreateAccount(*account.Account) (string, error)
+	// CreateAccount stores a new account with an assigned registration address
+	// for a specific asset. The account is considered unpaid until PayAccount
+	// is used to set the payment transaction details.
+	CreateAccount(acct *account.Account, assetID uint32, regAddr string) error
 
-	// AccountRegAddr gets the registration fee address assigned to the account.
-	AccountRegAddr(account.AccountID) (string, error)
+	// AccountRegAddr gets the registration fee address and the corresponding
+	// asset ID for the account.
+	AccountRegAddr(account.AccountID) (string, uint32, error)
 
 	// PayAccount sets the registration fee payment transaction details for the
 	// account, completing the registration process.

--- a/server/db/types.go
+++ b/server/db/types.go
@@ -12,6 +12,7 @@ import (
 type Account struct {
 	AccountID  account.AccountID `json:"accountid"`
 	Pubkey     dex.Bytes         `json:"pubkey"`
+	FeeAsset   uint32            `json:"feeasset,omitempty"`
 	FeeAddress string            `json:"feeaddress"`
 	FeeCoin    dex.Bytes         `json:"feecoin"`
 	BrokenRule account.Rule      `json:"brokenrule"`

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -19,7 +19,6 @@ import (
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/apidata"
 	"decred.org/dcrdex/server/asset"
-	dcrasset "decred.org/dcrdex/server/asset/dcr"
 	"decred.org/dcrdex/server/auth"
 	"decred.org/dcrdex/server/coinlock"
 	"decred.org/dcrdex/server/comms"
@@ -50,6 +49,9 @@ type AssetConf struct {
 	MaxFeeRate  uint64 `json:"maxFeeRate"`
 	SwapConf    uint32 `json:"swapConf"`
 	ConfigPath  string `json:"configPath"`
+	RegFee      uint64 `json:"regFee,omitempty"`
+	RegConfs    uint32 `json:"regConfs,omitempty"`
+	RegXPub     string `json:"regXPub,omitempty"`
 }
 
 // DBConf groups the database configuration parameters.
@@ -73,9 +75,6 @@ type DexConf struct {
 	Assets            []*AssetConf
 	Network           dex.Network
 	DBConf            *DBConf
-	RegFeeXPub        string
-	RegFeeConfirms    int64
-	RegFeeAmount      uint64
 	BroadcastTimeout  time.Duration
 	CancelThreshold   float64
 	Anarchy           bool
@@ -139,18 +138,25 @@ type configResponse struct {
 	configEnc json.RawMessage
 }
 
-func newConfigResponse(cfg *DexConf, cfgAssets []*msgjson.Asset, cfgMarkets []*msgjson.Market) (*configResponse, error) {
+func newConfigResponse(cfg *DexConf, regAssets map[string]*msgjson.FeeAsset, cfgAssets []*msgjson.Asset, cfgMarkets []*msgjson.Market) (*configResponse, error) {
 	configMsg := &msgjson.ConfigResult{
 		BroadcastTimeout: uint64(cfg.BroadcastTimeout.Milliseconds()),
 		CancelMax:        cfg.CancelThreshold,
-		RegFeeConfirms:   uint16(cfg.RegFeeConfirms),
 		Assets:           cfgAssets,
 		Markets:          cfgMarkets,
-		Fee:              cfg.RegFeeAmount,
 		APIVersion:       uint16(APIVersion),
 		BinSizes:         apidata.BinSizes,
 		DEXPubKey:        cfg.DEXPrivKey.PubKey().SerializeCompressed(),
+		RegFees:          regAssets,
 	}
+
+	// Set the deprecated DCR fee fields.
+	dcrAsset := regAssets["dcr"]
+	if dcrAsset == nil {
+		return nil, fmt.Errorf("DCR is required as a fee asset for backward compatibility")
+	}
+	configMsg.Fee = dcrAsset.Amt
+	configMsg.RegFeeConfirms = uint16(dcrAsset.Confs)
 
 	// NOTE/TODO: To include active epoch in the market status objects, we need
 	// a channel from Market to push status changes back to DEX manager.
@@ -226,6 +232,17 @@ func (dm *DEX) handleDEXConfig(interface{}) (interface{}, error) {
 	dm.configRespMtx.RLock()
 	defer dm.configRespMtx.RUnlock()
 	return dm.configResp.configEnc, nil
+}
+
+// FeeCoiner describes a type that can check a transaction output, namely a fee
+// payment, for a particular asset.
+type FeeCoiner interface {
+	FeeCoin(coinID []byte) (addr string, val uint64, confs int64, err error)
+}
+
+// AddresserFactory describes a type that can construct new asset.Addressers.
+type AddresserFactory interface {
+	NewAddresser(acctXPub string, keyIndexer asset.HDKeyIndexer) (asset.Addresser, error)
 }
 
 // NewDEX creates the dex manager and starts all subsystems. Use Stop to
@@ -336,11 +353,48 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		}
 	}
 
+	// Create DEXArchivist with the pg DB driver. The fee Addressers require the
+	// archivist for key index storage and retrieval.
+	pgCfg := &pg.Config{
+		Host:         cfg.DBConf.Host,
+		Port:         strconv.Itoa(int(cfg.DBConf.Port)),
+		User:         cfg.DBConf.User,
+		Pass:         cfg.DBConf.Pass,
+		DBName:       cfg.DBConf.DBName,
+		ShowPGConfig: cfg.DBConf.ShowPGConfig,
+		QueryTimeout: 20 * time.Minute,
+		MarketCfg:    cfg.Markets,
+	}
+	// After DEX construction, the storage subsystem should be stopped
+	// gracefully with its Close method, and in coordination with other
+	// subsystems via Stop. To abort its setup, rig a temporary link to the
+	// caller's Context.
+	running := make(chan struct{})
+	defer close(running) // break the link
+	go func() {
+		select {
+		case <-ctx.Done(): // cancelled construction
+			cancelDB()
+		case <-running: // DB shutdown now only via dex.Stop=>db.Close
+		}
+	}()
+	storage, err := db.Open(ctxDB, "pg", pgCfg)
+	if err != nil {
+		return nil, fmt.Errorf("db.Open: %w", err)
+	}
+
+	dataAPI := apidata.NewDataAPI(storage)
+
 	// Create a MasterCoinLocker for each asset.
 	dexCoinLocker := coinlock.NewDEXCoinLocker(assetIDs)
 
+	// Prepare registration fee assets.
+	feeAssets := make(map[string]*msgjson.FeeAsset)
+	feeCoiners := make(map[uint32]FeeCoiner)
+	feeAddressers := make(map[uint32]asset.Addresser)
+	xpubs := make(map[string]string) // to enforce uniqueness
+
 	// Start asset backends.
-	var dcrBackend *dcrasset.Backend
 	lockableAssets := make(map[uint32]*swap.LockableAsset, len(cfg.Assets))
 	backedAssets := make(map[uint32]*asset.BackedAsset, len(cfg.Assets))
 	cfgAssets := make([]*msgjson.Asset, 0, len(cfg.Assets))
@@ -365,17 +419,39 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 			return nil, fmt.Errorf("failed to setup asset %q: %w", symbol, err)
 		}
 
-		if symbol == "dcr" {
-			var ok bool
-			dcrBackend, ok = be.(*dcrasset.Backend)
-			if !ok {
-				return nil, fmt.Errorf("dcr backend is invalid")
-			}
-		}
-
 		err = startSubSys(fmt.Sprintf("Asset[%s]", symbol), be)
 		if err != nil {
 			return nil, fmt.Errorf("failed to start asset %q: %w", symbol, err)
+		}
+
+		if assetConf.RegFee > 0 {
+			// Make sure we can check on fee transactions.
+			fc, ok := be.(FeeCoiner)
+			if !ok {
+				return nil, fmt.Errorf("asset %v is not a FeeCoiner", symbol)
+			}
+			// Make sure we can derive addresses from an extended public key.
+			af, ok := be.(AddresserFactory)
+			if !ok {
+				return nil, fmt.Errorf("asset %v is not an AddresserFactory", symbol)
+			}
+			addresser, err := af.NewAddresser(assetConf.RegXPub, &hdKeyIndexer{storage})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create fee addresser for asset %v: %w", symbol, err)
+			}
+			if other := xpubs[assetConf.RegXPub]; other != "" {
+				return nil, fmt.Errorf("reused xpub for assets %v and %v forbidden", other, symbol)
+			}
+			xpubs[assetConf.RegXPub] = symbol
+			feeAssets[symbol] = &msgjson.FeeAsset{
+				ID:    assetID,
+				Amt:   assetConf.RegFee,
+				Confs: assetConf.RegConfs,
+			}
+			feeCoiners[assetID] = fc
+			feeAddressers[assetID] = addresser
+			log.Infof("Registration fees permitted using %s: amount %d, confs %d",
+				symbol, assetConf.RegFee, assetConf.RegConfs)
 		}
 
 		initTxSize := uint64(be.InitTxSize())
@@ -416,15 +492,6 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		txDataSources[assetID] = be.TxData
 	}
 
-	// Ensure their is a DCR asset backend.
-	if dcrBackend == nil {
-		return nil, fmt.Errorf("no DCR backend configured")
-	}
-	// Validate the registration fee extended public key.
-	if err := dcrBackend.ValidateXPub(cfg.RegFeeXPub); err != nil {
-		return nil, fmt.Errorf("invalid regfeexpub: %w", err)
-	}
-
 	for _, mkt := range cfg.Markets {
 		mkt.Name = strings.ToLower(mkt.Name)
 	}
@@ -432,40 +499,6 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	// Create DEXArchivist with the pg DB driver.
-	pgCfg := &pg.Config{
-		Host:         cfg.DBConf.Host,
-		Port:         strconv.Itoa(int(cfg.DBConf.Port)),
-		User:         cfg.DBConf.User,
-		Pass:         cfg.DBConf.Pass,
-		DBName:       cfg.DBConf.DBName,
-		ShowPGConfig: cfg.DBConf.ShowPGConfig,
-		QueryTimeout: 20 * time.Minute,
-		MarketCfg:    cfg.Markets,
-		//CheckedStores: true,
-		Net:    cfg.Network,
-		FeeKey: cfg.RegFeeXPub,
-	}
-	// After DEX construction, the storage subsystem should be stopped
-	// gracefully with its Close method, and in coordination with other
-	// subsystems via Stop. To abort its setup, rig a temporary link to the
-	// caller's Context.
-	running := make(chan struct{})
-	defer close(running) // break the link
-	go func() {
-		select {
-		case <-ctx.Done(): // cancelled construction
-			cancelDB()
-		case <-running: // DB shutdown now only via dex.Stop=>db.Close
-		}
-	}()
-	storage, err := db.Open(ctxDB, "pg", pgCfg)
-	if err != nil {
-		return nil, fmt.Errorf("db.Open: %w", err)
-	}
-
-	dataAPI := apidata.NewDataAPI(storage)
 
 	// Create the user order unbook dispatcher for the AuthManager.
 	markets := make(map[string]*market.Market, len(cfg.Markets))
@@ -475,12 +508,29 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		}
 	}
 
+	feeAddresser := func(assetID uint32) string {
+		addresser := feeAddressers[assetID]
+		if addresser == nil {
+			return ""
+		}
+		return addresser.NextAddress()
+	}
+
+	feeChecker := func(assetID uint32, coinID []byte) (addr string, val uint64, confs int64, err error) {
+		fc := feeCoiners[assetID]
+		if fc == nil {
+			err = fmt.Errorf("unsupported fee asset")
+			return
+		}
+		return fc.FeeCoin(coinID)
+	}
+
 	authCfg := auth.Config{
 		Storage:           storage,
 		Signer:            signer{cfg.DEXPrivKey},
-		RegistrationFee:   cfg.RegFeeAmount,
-		FeeConfs:          cfg.RegFeeConfirms,
-		FeeChecker:        dcrBackend.FeeCoin,
+		FeeAddress:        feeAddresser,
+		FeeAssets:         feeAssets,
+		FeeChecker:        feeChecker,
 		UserUnbooker:      userUnbookFun,
 		MiaUserTimeout:    cfg.BroadcastTimeout,
 		CancelThreshold:   cfg.CancelThreshold,
@@ -636,7 +686,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		return nil, fmt.Errorf("NewServer failed: %w", err)
 	}
 
-	cfgResp, err := newConfigResponse(cfg, cfgAssets, cfgMarkets)
+	cfgResp, err := newConfigResponse(cfg, feeAssets, cfgAssets, cfgMarkets)
 	if err != nil {
 		return nil, err
 	}
@@ -662,6 +712,31 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	ready = true // don't shut down on return
 
 	return dexMgr, nil
+}
+
+// hdKeyIndexer translates between db.FeeKeyIndexer and asset.HDKeyIndexer.
+type hdKeyIndexer struct {
+	db.FeeKeyIndexer
+}
+
+// KeyIndex gets the current index for the given extended public key, or if it
+// is unknown, creates a new entry for the key and returns the initial index.
+func (ki *hdKeyIndexer) KeyIndex(xpub string) (uint32, error) {
+	idx, err := ki.FeeKeyIndex(xpub)
+	if err == nil {
+		log.Infof("Resuming fee keys at index %d for extended pubkey %s", idx, xpub)
+		return idx, nil
+	}
+	if !db.IsErrUnknownFeeKey(err) {
+		return 0, err
+	}
+	log.Infof("Creating new fee key entry for extended pubkey %s", xpub)
+	return ki.CreateFeeKeyEntryFromPubKey(xpub)
+}
+
+// SetKeyIndex stores an index for the given pubkey.
+func (ki *hdKeyIndexer) SetKeyIndex(idx uint32, xpub string) error {
+	return ki.SetFeeKeyIndex(idx, xpub)
 }
 
 // Asset retrieves an asset backend by its ID.

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -714,20 +714,20 @@ type hdKeyIndexer struct {
 func (ki *hdKeyIndexer) KeyIndex(xpub string) (uint32, error) {
 	idx, err := ki.FeeKeyIndex(xpub)
 	if err == nil {
-		log.Infof("Resuming fee keys at index %d for extended pubkey %s", idx, xpub)
+		log.Infof("Resuming fee keys at index %d for extended pubkey %.40s...", idx, xpub)
 		return idx, nil
 	}
 	if !db.IsErrUnknownFeeKey(err) {
 		return 0, err
 	}
-	log.Infof("Creating new fee key entry for extended pubkey %s", xpub)
+	log.Infof("Creating new fee key entry for extended pubkey %.40s...", xpub)
 	return ki.CreateFeeKeyEntryFromPubKey(xpub)
 }
 
 // SetKeyIndex stores an index for the given pubkey.
 func (ki *hdKeyIndexer) SetKeyIndex(idx uint32, xpub string) {
 	if err := ki.SetFeeKeyIndex(idx, xpub); err != nil {
-		log.Errorf("Failed to store key index for xpub %s: %v", xpub, err)
+		log.Errorf("Failed to store key index for xpub %.40s...: %v", xpub, err)
 	}
 }
 


### PR DESCRIPTION
This is built on https://github.com/decred/dcrdex/pull/1201 (first commit in this branch).

This allows registration fees to be paid in different assets, and implements BTC as an accepted asset with the server.

Tested and working (when I initially put this PR up).

**Next step for frontend is an asset selection dropdown on the confirmation dialog.**  Takers?


**dex/msgjson:** update `ConfigResult`, `Register`, `RegisterResult`.

`RegFees map[string]*FeeAsset json:"regFees"` is added to `ConfigResult`.


 **server/db:** external key derivation, add fee_asset

Add `FeeAsset uint32` to the `db.Account` type and accounts table.

HD key derivation and address generation is no longer the role of the database driver.

Add the `db.FeeKeyIndexer interface`, which retrieves and records an integer index for a `[]byte`, a serialized pubkey corresponding to a master pubkey's child and it's index. `DEXArchivist` is now required to be a `FeeKeyIndexer`.

`CreateAccount` now requires asset ID and reg address provided as inputs rather than it generating and returning a reg address.
`AccountRegAddr` now also returns asset ID with the address.


 **server/asset**: `Addresser` and `HDKeyIndexer` interfaces

Add fee address generators to DCR and BTC.

Implement `FeeCoin` (fee checker) in BTC.


**server/auth**: use multi-asset fee addressers and checkers


**server/cmd/dcrdex**: per-asset fee config


 **server/dex**: stitch together multi-asset fee addressers and checkers between DB, auth manager, and assets

`FeeCoiner` and `AddresserFactor` provide the helpers for the auth manager.

Set the `RegFees` field of the config response.

Start archivist before asset backends because the fee `Addressers` require it for key index storage and retrieval.


**client/db**:

Add `db.AccountInfo.FeeAssetID uint32`, and updates the DB encoding.

v2 `db.AccountInfo` encoding is updated, and fields reordered.
When earlier (v0/v1) blobs are loaded, `FeeAssetID` is loaded as 42.


**client/core**:

Add asset ID to `RegisterForm`.

Add `Exchange.RegFees map[string]*FeeAsset` field, and a `PendingFeeState` struct field that describes the asset and confs of the pending fee, removing the `RegConfirms` (`'confs'`) field.  Also remove the `ConfsRequired` (`'confsrequired'`) and `FeePending` (`'feePending'`) fields.

Add `feeAssetID uint32` to `dexAccount`.

In `Core`, use the `Exchange.RegFees` map, and deal with older servers providing the old config response.

Change `(*Core).GetFee` to `(*Core).GetRegFees`, which is unused.


 **client/rpcserver and dexcctl:** Kill `getfee`. Implement `getdexconfig` instead.


**client/webserver**: update, but use DCR only

Update `apiRegister` and `registrationForm` with asset ID.

Kill `apiGetFee`.

Modify js for `pendingFee` in `FeePaymentNote`, and removed `confs` and `confsrequired` from `Exchange` struct (`this.market.dex` in frontend).

Frontend still defaults to DCR/42, with no selection yet.