### PR TITLE
server/db: Update lot sizes when necessary.

### DIFF
--- a/client/cmd/dexcctl/simnet-setup.sh
+++ b/client/cmd/dexcctl/simnet-setup.sh
@@ -41,7 +41,7 @@ if [ $ETH_ON -eq 0 ]; then
 fi
 
 echo registering with DEX
-./dexcctl -p abc --simnet register 127.0.0.1:17273 100000000 ~/dextest/dcrdex/rpc.cert
+./dexcctl -p abc --simnet register 127.0.0.1:17273 100000000 42 ~/dextest/dcrdex/rpc.cert
 
 echo mining fee confirmation blocks
 tmux send-keys -t dcr-harness:0 "./mine-alpha 1" C-m

--- a/client/cmd/dexcctl/simnet-setup.sh
+++ b/client/cmd/dexcctl/simnet-setup.sh
@@ -41,7 +41,7 @@ if [ $ETH_ON -eq 0 ]; then
 fi
 
 echo registering with DEX
-./dexcctl -p abc --simnet register 127.0.0.1:17273 100000000 42 ~/dextest/dcrdex/rpc.cert
+./dexcctl -p abc --simnet register 127.0.0.1:17273 100000000 ~/dextest/dcrdex/rpc.cert
 
 echo mining fee confirmation blocks
 tmux send-keys -t dcr-harness:0 "./mine-alpha 1" C-m

--- a/server/db/driver/pg/internal/markets.go
+++ b/server/db/driver/pg/internal/markets.go
@@ -21,4 +21,7 @@ const (
 	// InsertMarket inserts a new market in to the markets tables
 	InsertMarket = `INSERT INTO %s (name, base, quote, lot_size)
 		VALUES ($1, $2, $3, $4);`
+
+	// UpdateLotSize updates the market's lot size.
+	UpdateLotSize = `UPDATE %s SET lot_size = $2 WHERE name = $1;`
 )

--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -176,7 +176,7 @@ func cleanTables(db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	err = prepareTables(context.Background(), db, mktConfig())
+	_, err = prepareTables(context.Background(), db, mktConfig())
 	if err != nil {
 		return err
 	}

--- a/server/db/driver/pg/tables_online_test.go
+++ b/server/db/driver/pg/tables_online_test.go
@@ -31,33 +31,85 @@ func TestPrepareTables(t *testing.T) {
 
 	// Create new tables and schemas.
 	markets := []*dex.MarketInfo{mktConfig}
-	err = prepareTables(context.Background(), archie.db, markets)
+	purgeMkts, err := prepareTables(context.Background(), archie.db, markets)
 	if err != nil {
 		t.Error(err)
+	}
+	if purgeMkts != nil {
+		t.Error("expected no purged markets for new table")
 	}
 
 	// Cover the cases where the tables already exist (OK). This hits the
 	// upgradeDB path, which returns early with current == dbVersion.
-	err = prepareTables(context.Background(), archie.db, markets)
+	purgeMkts, err = prepareTables(context.Background(), archie.db, markets)
+	if err != nil {
+		t.Error(err)
+	}
+	if purgeMkts != nil {
+		t.Error("expected no purged markets for no config changes")
+	}
+
+	// Mutated existing market. Should return mutated markets in purge
+	// returns.
+	mktConfig, err = dex.NewMarketInfoFromSymbols("DCR", "BTC", 1e8, RateStep, EpochDuration, MarketBuyBuffer) // lot size change
+	if err != nil {
+		t.Fatal(err)
+	}
+	purgeMkts, err = prepareTables(context.Background(), archie.db, []*dex.MarketInfo{mktConfig})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(purgeMkts) != 1 || purgeMkts[0] != "dcr_btc" {
+		t.Error("expected a dcr_btc purge markets return for changed lot size")
+	}
+
+	// Add a new market.
+	mktConfig, _ = dex.NewMarketInfoFromSymbols("dcr", "ltc", 1e9, RateStep, EpochDuration, MarketBuyBuffer)
+	purgeMkts, err = prepareTables(context.Background(), archie.db, []*dex.MarketInfo{mktConfig})
+	if err != nil {
+		t.Error(err)
+	}
+	if purgeMkts != nil {
+		t.Error("expected no purged markets for new market")
+	}
+}
+
+func TestUpdateLotSize(t *testing.T) {
+	if err := nukeAll(archie.db); err != nil {
+		t.Fatal(err)
+	}
+
+	// valid market
+	mktConfig, err := dex.NewMarketInfoFromSymbols("DCR", "BTC", 1e9, RateStep, EpochDuration, MarketBuyBuffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create new tables and schemas.
+	markets := []*dex.MarketInfo{mktConfig}
+	_, err = prepareTables(context.Background(), archie.db, markets)
 	if err != nil {
 		t.Error(err)
 	}
 
-	// Mutated existing market (not supported, will panic).
-	mktConfig, _ = dex.NewMarketInfoFromSymbols("DCR", "BTC", 1e8, RateStep, EpochDuration, MarketBuyBuffer) // lot size change
-	func() {
-		defer func() {
-			if recover() == nil {
-				t.Error("prepareTables should have paniced with lot size change.")
-			}
-		}()
-		_ = prepareTables(context.Background(), archie.db, []*dex.MarketInfo{mktConfig})
-	}()
-
-	// Add a new market.
-	mktConfig, _ = dex.NewMarketInfoFromSymbols("dcr", "ltc", 1e9, RateStep, EpochDuration, MarketBuyBuffer)
-	err = prepareTables(context.Background(), archie.db, []*dex.MarketInfo{mktConfig})
+	mkts, err := loadMarkets(archie.db, marketsTableName)
 	if err != nil {
 		t.Error(err)
+	}
+	if mkts[0].LotSize != 1e9 {
+		t.Error("unexpected lot size before updating")
+	}
+
+	err = updateLotSize(archie.db, publicSchema, "dcr_btc", 1337)
+	if err != nil {
+		t.Error(err)
+	}
+
+	mkts, err = loadMarkets(archie.db, marketsTableName)
+	if err != nil {
+		t.Error(err)
+	}
+	if mkts[0].LotSize != 1337 {
+		t.Error("lot size is not 1337 after updating")
 	}
 }


### PR DESCRIPTION
    server/db: Update lot sizes when necessary.

    No longer panic when lot size changes. If lot sizes changed, update them
    in the db. Then, flush all persisted orders belonging to that market.

depends on #1202
closes #1174