### PR TITLE
networks/eth: Add methods to decode tx data.

### DIFF
--- a/client/asset/eth/config.go
+++ b/client/asset/eth/config.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/client/asset/eth/config.go
+++ b/client/asset/eth/config.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/client/asset/eth/doc.go
+++ b/client/asset/eth/doc.go
@@ -1,13 +1,14 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 //
 // This package also imports go-ethereum code and so carries the burden of
 // go-ethereum's GNU Lesser General Public License.
 
+//go:build lgpl
+// +build lgpl
+
 // Package eth implements methods to work with ethereum swap contracts and
-// transactions. The code is unique as it requires a more restrictive liscense
-// and connot be used in proprietary software.
+// transactions. The LGPL is a more restrictive license that may be more of a
+// burden for closed source software. As such, the "lpgl" build tag is required
+// for this package.
 package eth

--- a/client/asset/eth/doc.go
+++ b/client/asset/eth/doc.go
@@ -1,0 +1,13 @@
+//go:build gpl
+// +build gpl
+//
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+//
+// This package also imports go-ethereum code and so carries the burden of
+// go-ethereum's GNU Lesser General Public License.
+
+// Package eth implements methods to work with ethereum swap contracts and
+// transactions. The code is unique as it requires a more restrictive liscense
+// and connot be used in proprietary software.
+package eth

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1,5 +1,5 @@
-//go:build !harness
-// +build !harness
+//go:build !harness && gpl
+// +build !harness,gpl
 
 // These tests will not be run if the harness build tag is set.
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1,5 +1,5 @@
-//go:build !harness && gpl
-// +build !harness,gpl
+//go:build !harness && lgpl
+// +build !harness,lgpl
 
 // These tests will not be run if the harness build tag is set.
 

--- a/client/asset/eth/node.go
+++ b/client/asset/eth/node.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/client/asset/eth/node.go
+++ b/client/asset/eth/node.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -1,5 +1,5 @@
-//go:build harness
-// +build harness
+//go:build harness && gpl
+// +build harness,gpl
 
 // This test requires that the testnet harness be running and the unix socket
 // be located at $HOME/dextest/eth/gamma/node/geth.ipc

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -1,5 +1,5 @@
-//go:build harness && gpl
-// +build harness,gpl
+//go:build harness && lgpl
+// +build harness,lgpl
 
 // This test requires that the testnet harness be running and the unix socket
 // be located at $HOME/dextest/eth/gamma/node/geth.ipc

--- a/client/cmd/dexc/gplimport.go
+++ b/client/cmd/dexc/gplimport.go
@@ -1,0 +1,16 @@
+//go:build gpl
+// +build gpl
+//
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+//
+// When using eth, this app also imports go-ethereum code and so carries the
+// burden of go-ethereum's GNU Lesser General Public License.
+
+package main
+
+// import (
+// 	ETH is commented to prevent go-ethereum goroutines from launching via
+// 	it's init(). Uncomment this when ETH is ready:
+// 	_ "decred.org/dcrdex/client/asset/eth" // register eth asset
+// )

--- a/client/cmd/dexc/importlgpl.go
+++ b/client/cmd/dexc/importlgpl.go
@@ -1,11 +1,11 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 //
 // When using eth, this app also imports go-ethereum code and so carries the
 // burden of go-ethereum's GNU Lesser General Public License.
+
+//go:build lgpl
+// +build lgpl
 
 package main
 

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -21,10 +21,6 @@ import (
 	_ "decred.org/dcrdex/client/asset/dcr" // register dcr asset
 	_ "decred.org/dcrdex/client/asset/ltc" // register ltc asset
 
-	// ETH is commented to prevent go-ethereum goroutines from launching via
-	// it's init(). Uncomment this when ETH is ready:
-	// _ "decred.org/dcrdex/client/asset/eth" // register eth asset
-
 	"decred.org/dcrdex/client/cmd/dexc/version"
 	"decred.org/dcrdex/client/core"
 	"decred.org/dcrdex/client/rpcserver"

--- a/dex/networks/eth/abi.go
+++ b/dex/networks/eth/abi.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //

--- a/dex/networks/eth/abi.go
+++ b/dex/networks/eth/abi.go
@@ -1,0 +1,166 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// This file lifted ver-batim from go-ethereum/signer/fourbyte at v1.10.6 commit
+// 576681f29b895dd39e559b7ba17fcd89b42e4833.
+package eth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// decodedCallData is an internal type to represent a method call parsed according
+// to an ABI method signature.
+type decodedCallData struct {
+	signature string
+	name      string
+	inputs    []decodedArgument
+}
+
+// decodedArgument is an internal type to represent an argument parsed according
+// to an ABI method signature.
+type decodedArgument struct {
+	soltype abi.Argument
+	value   interface{}
+}
+
+// String implements stringer interface, tries to use the underlying value-type
+func (arg decodedArgument) String() string {
+	var value string
+	switch val := arg.value.(type) {
+	case fmt.Stringer:
+		value = val.String()
+	default:
+		value = fmt.Sprintf("%v", val)
+	}
+	return fmt.Sprintf("%v: %v", arg.soltype.Type.String(), value)
+}
+
+// String implements stringer interface for decodedCallData
+func (cd decodedCallData) String() string {
+	args := make([]string, len(cd.inputs))
+	for i, arg := range cd.inputs {
+		args[i] = arg.String()
+	}
+	return fmt.Sprintf("%s(%s)", cd.name, strings.Join(args, ","))
+}
+
+// verifySelector checks whether the ABI encoded data blob matches the requested
+// function signature.
+func verifySelector(selector string, calldata []byte) (*decodedCallData, error) {
+	// Parse the selector into an ABI JSON spec
+	abidata, err := parseSelector(selector)
+	if err != nil {
+		return nil, err
+	}
+	// Parse the call data according to the requested selector
+	return parseCallData(calldata, string(abidata))
+}
+
+// selectorRegexp is used to validate that a 4byte database selector corresponds
+// to a valid ABI function declaration.
+//
+// Note, although uppercase letters are not part of the ABI spec, this regexp
+// still accepts it as the general format is valid. It will be rejected later
+// by the type checker.
+var selectorRegexp = regexp.MustCompile(`^([^\)]+)\(([A-Za-z0-9,\[\]]*)\)`)
+
+// parseSelector converts a method selector into an ABI JSON spec. The returned
+// data is a valid JSON string which can be consumed by the standard abi package.
+func parseSelector(unescapedSelector string) ([]byte, error) {
+	// Define a tiny fake ABI struct for JSON marshalling
+	type fakeArg struct {
+		Type string `json:"type"`
+	}
+	type fakeABI struct {
+		Name   string    `json:"name"`
+		Type   string    `json:"type"`
+		Inputs []fakeArg `json:"inputs"`
+	}
+	// Validate the unescapedSelector and extract it's components
+	groups := selectorRegexp.FindStringSubmatch(unescapedSelector)
+	if len(groups) != 3 {
+		return nil, fmt.Errorf("invalid selector %q (%v matches)", unescapedSelector, len(groups))
+	}
+	name := groups[1]
+	args := groups[2]
+
+	// Reassemble the fake ABI and constuct the JSON
+	arguments := make([]fakeArg, 0)
+	if len(args) > 0 {
+		for _, arg := range strings.Split(args, ",") {
+			arguments = append(arguments, fakeArg{arg})
+		}
+	}
+	return json.Marshal([]fakeABI{{name, "function", arguments}})
+}
+
+// parseCallData matches the provided call data against the ABI definition and
+// returns a struct containing the actual go-typed values.
+func parseCallData(calldata []byte, unescapedAbidata string) (*decodedCallData, error) {
+	// Validate the call data that it has the 4byte prefix and the rest divisible by 32 bytes
+	if len(calldata) < 4 {
+		return nil, fmt.Errorf("invalid call data, incomplete method signature (%d bytes < 4)", len(calldata))
+	}
+	sigdata := calldata[:4]
+
+	argdata := calldata[4:]
+	if len(argdata)%32 != 0 {
+		return nil, fmt.Errorf("invalid call data; length should be a multiple of 32 bytes (was %d)", len(argdata))
+	}
+	// Validate the called method and upack the call data accordingly
+	abispec, err := abi.JSON(strings.NewReader(unescapedAbidata))
+	if err != nil {
+		return nil, fmt.Errorf("invalid method signature (%q): %v", unescapedAbidata, err)
+	}
+	method, err := abispec.MethodById(sigdata)
+	if err != nil {
+		return nil, err
+	}
+	values, err := method.Inputs.UnpackValues(argdata)
+	if err != nil {
+		return nil, fmt.Errorf("signature %q matches, but arguments mismatch: %v", method.String(), err)
+	}
+	// Everything valid, assemble the call infos for the signer
+	decoded := decodedCallData{signature: method.Sig, name: method.RawName}
+	for i := 0; i < len(method.Inputs); i++ {
+		decoded.inputs = append(decoded.inputs, decodedArgument{
+			soltype: method.Inputs[i],
+			value:   values[i],
+		})
+	}
+	// We're finished decoding the data. At this point, we encode the decoded data
+	// to see if it matches with the original data. If we didn't do that, it would
+	// be possible to stuff extra data into the arguments, which is not detected
+	// by merely decoding the data.
+	encoded, err := method.Inputs.PackValues(values)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(encoded, argdata) {
+		was := common.Bytes2Hex(encoded)
+		exp := common.Bytes2Hex(argdata)
+		return nil, fmt.Errorf("WARNING: Supplied data is stuffed with extra data. \nWant %s\nHave %s\nfor method %v", exp, was, method.Sig)
+	}
+	return &decoded, nil
+}

--- a/dex/networks/eth/abi.go
+++ b/dex/networks/eth/abi.go
@@ -1,6 +1,3 @@
-//go:build gpl
-// +build gpl
-//
 // Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
@@ -17,7 +14,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// This file lifted ver-batim from go-ethereum/signer/fourbyte at v1.10.6 commit
+//go:build lgpl
+// +build lgpl
+
+// This file lifted verbatim from go-ethereum/signer/fourbyte at v1.10.6 commit
 // 576681f29b895dd39e559b7ba17fcd89b42e4833.
 package eth
 

--- a/dex/networks/eth/abi_test.go
+++ b/dex/networks/eth/abi_test.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //

--- a/dex/networks/eth/abi_test.go
+++ b/dex/networks/eth/abi_test.go
@@ -1,6 +1,3 @@
-//go:build gpl
-// +build gpl
-//
 // Copyright 2019 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //
@@ -17,7 +14,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-// This file lifted ver-batim from go-ethereum/signer/fourbyte at v1.10.6 commit
+//go:build lgpl
+// +build lgpl
+
+// This file lifted verbatim from go-ethereum/signer/fourbyte at v1.10.6 commit
 // 576681f29b895dd39e559b7ba17fcd89b42e4833.
 package eth
 

--- a/dex/networks/eth/abi_test.go
+++ b/dex/networks/eth/abi_test.go
@@ -1,0 +1,176 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// This file lifted ver-batim from go-ethereum/signer/fourbyte at v1.10.6 commit
+// 576681f29b895dd39e559b7ba17fcd89b42e4833.
+package eth
+
+import (
+	"math/big"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func verify(t *testing.T, jsondata, calldata string, exp []interface{}) {
+	abispec, err := abi.JSON(strings.NewReader(jsondata))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cd := common.Hex2Bytes(calldata)
+	sigdata, argdata := cd[:4], cd[4:]
+	method, err := abispec.MethodById(sigdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := method.Inputs.UnpackValues(argdata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != len(exp) {
+		t.Fatalf("Mismatched length, expected %d, got %d", len(exp), len(data))
+	}
+	for i, elem := range data {
+		if !reflect.DeepEqual(elem, exp[i]) {
+			t.Fatalf("Unpack error, arg %d, got %v, want %v", i, elem, exp[i])
+		}
+	}
+}
+
+func TestNewUnpacker(t *testing.T) {
+	type unpackTest struct {
+		jsondata string
+		calldata string
+		exp      []interface{}
+	}
+	testcases := []unpackTest{
+		{ // https://solidity.readthedocs.io/en/develop/abi-spec.html#use-of-dynamic-types
+			`[{"type":"function","name":"f", "inputs":[{"type":"uint256"},{"type":"uint32[]"},{"type":"bytes10"},{"type":"bytes"}]}]`,
+			// 0x123, [0x456, 0x789], "1234567890", "Hello, world!"
+			"8be65246" + "00000000000000000000000000000000000000000000000000000000000001230000000000000000000000000000000000000000000000000000000000000080313233343536373839300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000004560000000000000000000000000000000000000000000000000000000000000789000000000000000000000000000000000000000000000000000000000000000d48656c6c6f2c20776f726c642100000000000000000000000000000000000000",
+			[]interface{}{
+				big.NewInt(0x123),
+				[]uint32{0x456, 0x789},
+				[10]byte{49, 50, 51, 52, 53, 54, 55, 56, 57, 48},
+				common.Hex2Bytes("48656c6c6f2c20776f726c6421"),
+			},
+		}, { // https://docs.soliditylang.org/en/develop/abi-spec.html#examples
+			`[{"type":"function","name":"sam","inputs":[{"type":"bytes"},{"type":"bool"},{"type":"uint256[]"}]}]`,
+			//  "dave", true and [1,2,3]
+			"a5643bf20000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000464617665000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003",
+			[]interface{}{
+				[]byte{0x64, 0x61, 0x76, 0x65},
+				true,
+				[]*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(3)},
+			},
+		}, {
+			`[{"type":"function","name":"send","inputs":[{"type":"uint256"}]}]`,
+			"a52c101e0000000000000000000000000000000000000000000000000000000000000012",
+			[]interface{}{big.NewInt(0x12)},
+		}, {
+			`[{"type":"function","name":"compareAndApprove","inputs":[{"type":"address"},{"type":"uint256"},{"type":"uint256"}]}]`,
+			"751e107900000000000000000000000000000133700000deadbeef00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+			[]interface{}{
+				common.HexToAddress("0x00000133700000deadbeef000000000000000000"),
+				new(big.Int).SetBytes([]byte{0x00}),
+				big.NewInt(0x1),
+			},
+		},
+	}
+	for _, c := range testcases {
+		verify(t, c.jsondata, c.calldata, c.exp)
+	}
+}
+
+func TestCalldataDecoding(t *testing.T) {
+	// send(uint256)                              : a52c101e
+	// compareAndApprove(address,uint256,uint256) : 751e1079
+	// issue(address[],uint256)                   : 42958b54
+	jsondata := `
+[
+	{"type":"function","name":"send","inputs":[{"name":"a","type":"uint256"}]},
+	{"type":"function","name":"compareAndApprove","inputs":[{"name":"a","type":"address"},{"name":"a","type":"uint256"},{"name":"a","type":"uint256"}]},
+	{"type":"function","name":"issue","inputs":[{"name":"a","type":"address[]"},{"name":"a","type":"uint256"}]},
+	{"type":"function","name":"sam","inputs":[{"name":"a","type":"bytes"},{"name":"a","type":"bool"},{"name":"a","type":"uint256[]"}]}
+]`
+	// Expected failures
+	for i, hexdata := range []string{
+		"a52c101e00000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000042",
+		"a52c101e000000000000000000000000000000000000000000000000000000000000001200",
+		"a52c101e00000000000000000000000000000000000000000000000000000000000000",
+		"a52c101e",
+		"a52c10",
+		"",
+		// Too short
+		"751e10790000000000000000000000000000000000000000000000000000000000000012",
+		"751e1079FFffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		// Not valid multiple of 32
+		"deadbeef00000000000000000000000000000000000000000000000000000000000000",
+		// Too short 'issue'
+		"42958b5400000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000042",
+		// Too short compareAndApprove
+		"a52c101e00ff0000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000042",
+		// From https://docs.soliditylang.org/en/develop/abi-spec.html
+		// contains a bool with illegal values
+		"a5643bf20000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000464617665000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003",
+	} {
+		_, err := parseCallData(common.Hex2Bytes(hexdata), jsondata)
+		if err == nil {
+			t.Errorf("test %d: expected decoding to fail: %s", i, hexdata)
+		}
+	}
+	// Expected success
+	for i, hexdata := range []string{
+		// From https://docs.soliditylang.org/en/develop/abi-spec.html
+		"a5643bf20000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000464617665000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003",
+		"a52c101e0000000000000000000000000000000000000000000000000000000000000012",
+		"a52c101eFFffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		"751e1079000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+		"42958b54" +
+			// start of dynamic type
+			"0000000000000000000000000000000000000000000000000000000000000040" +
+			// uint256
+			"0000000000000000000000000000000000000000000000000000000000000001" +
+			// length of  array
+			"0000000000000000000000000000000000000000000000000000000000000002" +
+			// array values
+			"000000000000000000000000000000000000000000000000000000000000dead" +
+			"000000000000000000000000000000000000000000000000000000000000beef",
+	} {
+		_, err := parseCallData(common.Hex2Bytes(hexdata), jsondata)
+		if err != nil {
+			t.Errorf("test %d: unexpected failure on input %s:\n %v (%d bytes) ", i, hexdata, err, len(common.Hex2Bytes(hexdata)))
+		}
+	}
+}
+
+func TestMaliciousABIStrings(t *testing.T) {
+	tests := []string{
+		"func(uint256,uint256,[]uint256)",
+		"func(uint256,uint256,uint256,)",
+		"func(,uint256,uint256,uint256)",
+	}
+	data := common.Hex2Bytes("4401a6e40000000000000000000000000000000000000000000000000000000000000012")
+	for i, tt := range tests {
+		_, err := verifySelector(tt, data)
+		if err == nil {
+			t.Errorf("test %d: expected error for selector '%v'", i, tt)
+		}
+	}
+}

--- a/dex/networks/eth/doc.go
+++ b/dex/networks/eth/doc.go
@@ -1,13 +1,14 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 //
 // This package also imports go-ethereum code and so carries the burden of
 // go-ethereum's GNU Lesser General Public License.
 
+//go:build lgpl
+// +build lgpl
+
 // Package eth implements methods to work with ethereum swap contracts and
-// transactions. The code is unique as it requires a more restrictive liscense
-// and connot be used in proprietary software.
+// transactions. The LGPL is a more restrictive license that may be more of a
+// burden for closed source software. As such, the "lpgl" build tag is required
+// for this package.
 package eth

--- a/dex/networks/eth/doc.go
+++ b/dex/networks/eth/doc.go
@@ -1,0 +1,13 @@
+//go:build gpl
+// +build gpl
+//
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+//
+// This package also imports go-ethereum code and so carries the burden of
+// go-ethereum's GNU Lesser General Public License.
+
+// Package eth implements methods to work with ethereum swap contracts and
+// transactions. The code is unique as it requires a more restrictive liscense
+// and connot be used in proprietary software.
+package eth

--- a/dex/networks/eth/txdata.go
+++ b/dex/networks/eth/txdata.go
@@ -1,0 +1,93 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package eth
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+const (
+	initiateFuncName = "initiate"
+	numInputArgs     = 3
+	redeemFuncName   = "redeem"
+	numRedeemArgs    = 2
+)
+
+// ParseInitiateData accepts call data from a transaction that pays to a
+// contract with extra data. It will error if the call data does not call
+// initiate with expected argument types. It returns the participant address,
+// the secret hash, and locktime.
+func ParseInitiateData(calldata []byte) (*common.Address, [32]byte, int64, error) {
+	fail := func(err error) (*common.Address, [32]byte, int64, error) {
+		return nil, [32]byte{}, 0, err
+	}
+	decoded, err := parseCallData(calldata, ETHSwapABI)
+	if err != nil {
+		return fail(fmt.Errorf("unable to parse call data: %v", err))
+	}
+	if decoded.name != initiateFuncName {
+		return fail(fmt.Errorf("expected %v function but got %v", initiateFuncName, decoded.name))
+	}
+	args := decoded.inputs
+	// Any difference in number of args and types than what we expect
+	// should be caught by parseCallData, but checking again anyway.
+	//
+	// TODO: If any of the checks prove redundant, remove them.
+	if len(args) != numInputArgs {
+		return fail(fmt.Errorf("expected %v input args but got %v", numInputArgs, len(args)))
+	}
+	locktime, ok := args[0].value.(*big.Int)
+	if !ok {
+		return fail(fmt.Errorf("expected first arg of type *big.Int but got %T", args[0].value))
+	}
+	if !locktime.IsInt64() {
+		return fail(fmt.Errorf("locktime %v cannot be expressed as an int64", locktime))
+	}
+	secretHash, ok := args[1].value.([32]byte)
+	if !ok {
+		return fail(fmt.Errorf("expected second arg of type [32]byte but got %T", args[1].value))
+	}
+	participantAddr, ok := args[2].value.(common.Address)
+	if !ok {
+		return fail(fmt.Errorf("expected third arg of type common.Address but got %T", args[2].value))
+	}
+	return &participantAddr, secretHash, locktime.Int64(), nil
+}
+
+// ParseRedeemData accepts call data from a transaction that pays to a
+// contract with extra data. It will error if the call data does not call
+// redeem with expected argument types. It returns the secret and secret hash
+// in that order.
+func ParseRedeemData(calldata []byte) (secret [32]byte, secretHash [32]byte, err error) {
+	fail := func(err error) ([32]byte, [32]byte, error) {
+		return [32]byte{}, [32]byte{}, err
+	}
+	decoded, err := parseCallData(calldata, ETHSwapABI)
+	if err != nil {
+		return fail(fmt.Errorf("unable to parse call data: %v", err))
+	}
+	if decoded.name != redeemFuncName {
+		return fail(fmt.Errorf("expected %v function but got %v", redeemFuncName, decoded.name))
+	}
+	args := decoded.inputs
+	// Any difference in number of args and types than what we expect
+	// should be caught by parseCallData, but checking again anyway.
+	//
+	// TODO: If any of the checks prove redundant, remove them.
+	if len(args) != numRedeemArgs {
+		return fail(fmt.Errorf("expected %v redeem args but got %v", numRedeemArgs, len(args)))
+	}
+	secret, ok := args[0].value.([32]byte)
+	if !ok {
+		return fail(fmt.Errorf("expected first arg of type [32]byte but got %T", args[0].value))
+	}
+	secretHash, ok = args[1].value.([32]byte)
+	if !ok {
+		return fail(fmt.Errorf("expected second arg of type [32]byte but got %T", args[1].value))
+	}
+	return secret, secretHash, nil
+}

--- a/dex/networks/eth/txdata.go
+++ b/dex/networks/eth/txdata.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/dex/networks/eth/txdata.go
+++ b/dex/networks/eth/txdata.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/dex/networks/eth/txdata_test.go
+++ b/dex/networks/eth/txdata_test.go
@@ -1,5 +1,5 @@
-//go:build gpl
-// +build gpl
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/dex/networks/eth/txdata_test.go
+++ b/dex/networks/eth/txdata_test.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+
 package eth
 
 import (

--- a/dex/networks/eth/txdata_test.go
+++ b/dex/networks/eth/txdata_test.go
@@ -1,0 +1,123 @@
+package eth
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func mustParseHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func TestParseInitiateData(t *testing.T) {
+	participantAddr := common.HexToAddress("345853e21b1d475582E71cC269124eD5e2dD3422")
+	secretHashSlice := mustParseHex("4aec4dc47fc6bd1fd5091c1aa4067c7fbd6bbcdb476209756354ec784d6082dc")
+	var secretHash [32]byte
+	copy(secretHash[:], secretHashSlice)
+	locktime := int64(1632112916)
+	calldata := mustParseHex("ae0521470000000000000000000000000000000000" +
+		"0000000000000000000000614811144aec4dc47fc6bd1fd5091c1aa4067" +
+		"c7fbd6bbcdb476209756354ec784d6082dc000000000000000000000000" +
+		"345853e21b1d475582e71cc269124ed5e2dd3422")
+
+	redeemCalldata := mustParseHex("b31597ad87eac09638c0c38b4e735b79f053" +
+		"cb869167ee770640ac5df5c4ab030813122aebdc4c31b88d0c8f4d64459" +
+		"1a8e00e92b607f920ad8050deb7c7469767d9c561")
+
+	tests := []struct {
+		name     string
+		calldata []byte
+		wantErr  bool
+	}{{
+		name:     "ok",
+		calldata: calldata,
+	}, {
+		name:     "unable to parse call data",
+		calldata: calldata[1:],
+		wantErr:  true,
+	}, {
+		name:     "wrong function name",
+		calldata: redeemCalldata,
+		wantErr:  true,
+	}}
+
+	for _, test := range tests {
+		addr, sh, lt, err := ParseInitiateData(test.calldata)
+		if test.wantErr {
+			if err == nil {
+				t.Fatalf("expected error for test %q", test.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("unexpected error for test %q: %v", test.name, err)
+		}
+		if *addr != participantAddr {
+			t.Fatalf("want participant address %x but got %x for test %q", participantAddr, addr, test.name)
+		}
+		if sh != secretHash {
+			t.Fatalf("want secret hash %x but got %x for test %q", secretHash, sh, test.name)
+		}
+		if lt != locktime {
+			t.Fatalf("want locktime %d but got %d for test %q", locktime, lt, test.name)
+		}
+	}
+}
+
+func TestParseRedeemData(t *testing.T) {
+	secretHashSlice := mustParseHex("ebdc4c31b88d0c8f4d644591a8e00e92b607f920ad8050deb7c7469767d9c561")
+	secretSlice := mustParseHex("87eac09638c0c38b4e735b79f053cb869167ee770640ac5df5c4ab030813122a")
+	secretHash, secret := [32]byte{}, [32]byte{}
+	copy(secretHash[:], secretHashSlice)
+	copy(secret[:], secretSlice)
+	calldata := mustParseHex("b31597ad87eac09638c0c38b4e735b79f053cb8691" +
+		"67ee770640ac5df5c4ab030813122aebdc4c31b88d0c8f4d644591a8e00" +
+		"e92b607f920ad8050deb7c7469767d9c561")
+
+	initiateCalldata := mustParseHex("ae05214700000000000000000000000000" +
+		"000000000000000000000000000000614811144aec4dc47fc6bd1fd5091" +
+		"c1aa4067c7fbd6bbcdb476209756354ec784d6082dc0000000000000000" +
+		"00000000345853e21b1d475582e71cc269124ed5e2dd3422")
+
+	tests := []struct {
+		name     string
+		calldata []byte
+		wantErr  bool
+	}{{
+		name:     "ok",
+		calldata: calldata,
+	}, {
+		name:     "unable to parse call data",
+		calldata: calldata[1:],
+		wantErr:  true,
+	}, {
+		name:     "wrong function name",
+		calldata: initiateCalldata,
+		wantErr:  true,
+	}}
+
+	for _, test := range tests {
+		s, sh, err := ParseRedeemData(test.calldata)
+		if test.wantErr {
+			if err == nil {
+				t.Fatalf("expected error for test %q", test.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("unexpected error for test %q: %v", test.name, err)
+		}
+		if sh != secretHash {
+			t.Fatalf("want secret hash %x but got %x for test %q", secretHash, sh, test.name)
+		}
+		if s != secret {
+			t.Fatalf("want secret %x but got %x for test %q", secret, s, test.name)
+		}
+	}
+}

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -22,7 +22,7 @@ cd ${HARNESS_DIR}/../../../server/cmd/dcrdex/
 go build -o ${DCRDEX_DATA_DIR}/dcrdex -ldflags \
     "-X 'decred.org/dcrdex/dex.testLockTimeTaker=30s' \
     -X 'decred.org/dcrdex/dex.testLockTimeMaker=1m'" \
-    --tags gpl
+    --tags lgpl
 EOF
 chmod +x "${DCRDEX_DATA_DIR}/build"
 

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -21,7 +21,8 @@ cat > "${DCRDEX_DATA_DIR}/build" <<EOF
 cd ${HARNESS_DIR}/../../../server/cmd/dcrdex/
 go build -o ${DCRDEX_DATA_DIR}/dcrdex -ldflags \
     "-X 'decred.org/dcrdex/dex.testLockTimeTaker=30s' \
-    -X 'decred.org/dcrdex/dex.testLockTimeMaker=1m'"
+    -X 'decred.org/dcrdex/dex.testLockTimeMaker=1m'" \
+    --tags gpl
 EOF
 chmod +x "${DCRDEX_DATA_DIR}/build"
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -37,7 +37,7 @@ do
 
 	# build and run tests
 	if [ "$m" != '.' ]; then go build; fi
-	env GORACE="halt_on_error=1" go test -race -short -count 1 ./...
+	env GORACE="halt_on_error=1" go test --tags plg -race -short -count 1 ./...
 done
 
 cd "$dir"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -37,7 +37,7 @@ do
 
 	# build and run tests
 	if [ "$m" != '.' ]; then go build; fi
-	env GORACE="halt_on_error=1" go test --tags plg -race -short -count 1 ./...
+	env GORACE="halt_on_error=1" go test --tags lgpl -race -short -count 1 ./...
 done
 
 cd "$dir"

--- a/server/asset/eth/cache.go
+++ b/server/asset/eth/cache.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/server/asset/eth/cache.go
+++ b/server/asset/eth/cache.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/server/asset/eth/config.go
+++ b/server/asset/eth/config.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/server/asset/eth/config.go
+++ b/server/asset/eth/config.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/server/asset/eth/doc.go
+++ b/server/asset/eth/doc.go
@@ -1,13 +1,14 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 //
 // This package also imports go-ethereum code and so carries the burden of
 // go-ethereum's GNU Lesser General Public License.
 
+//go:build lgpl
+// +build lgpl
+
 // Package eth implements methods to work with ethereum swap contracts and
-// transactions. The code is unique as it requires a more restrictive liscense
-// and connot be used in proprietary software.
+// transactions. The LGPL is a more restrictive license that may be more of a
+// burden for closed source software. As such, the "lpgl" build tag is required
+// for this package.
 package eth

--- a/server/asset/eth/doc.go
+++ b/server/asset/eth/doc.go
@@ -1,0 +1,13 @@
+//go:build gpl
+// +build gpl
+//
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+//
+// This package also imports go-ethereum code and so carries the burden of
+// go-ethereum's GNU Lesser General Public License.
+
+// Package eth implements methods to work with ethereum swap contracts and
+// transactions. The code is unique as it requires a more restrictive liscense
+// and connot be used in proprietary software.
+package eth

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -1,6 +1,6 @@
-//go:build !harness
-// +build !harness
-
+//go:build !harness && gpl
+// +build !harness,gpl
+//
 // These tests will not be run if the harness build tag is set.
 
 package eth

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -1,6 +1,6 @@
-//go:build !harness && gpl
-// +build !harness,gpl
-//
+//go:build !harness && lgpl
+// +build !harness,lgpl
+
 // These tests will not be run if the harness build tag is set.
 
 package eth

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -1,8 +1,8 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
 
 package eth
 

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -1,3 +1,6 @@
+//go:build gpl
+// +build gpl
+//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -1,5 +1,5 @@
-//go:build harness && gpl
-// +build harness,gpl
+//go:build harness && lgpl
+// +build harness,lgpl
 
 // This test requires that the testnet harness be running and the unix socket
 // be located at $HOME/dextest/eth/alpha/node/geth.ipc

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -1,5 +1,5 @@
-//go:build harness
-// +build harness
+//go:build harness && gpl
+// +build harness,gpl
 
 // This test requires that the testnet harness be running and the unix socket
 // be located at $HOME/dextest/eth/alpha/node/geth.ipc

--- a/server/cmd/dcrdex/gplimport.go
+++ b/server/cmd/dcrdex/gplimport.go
@@ -1,0 +1,14 @@
+//go:build gpl
+// +build gpl
+//
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+//
+// When using eth, this app also imports go-ethereum code and so carries the
+// burden of go-ethereum's GNU Lesser General Public License.
+
+package main
+
+import (
+	_ "decred.org/dcrdex/server/asset/eth" // register eth asset
+)

--- a/server/cmd/dcrdex/importlgpl.go
+++ b/server/cmd/dcrdex/importlgpl.go
@@ -1,11 +1,11 @@
-//go:build gpl
-// +build gpl
-//
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 //
 // When using eth, this app also imports go-ethereum code and so carries the
 // burden of go-ethereum's GNU Lesser General Public License.
+
+//go:build lgpl
+// +build lgpl
 
 package main
 

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -21,7 +21,6 @@ import (
 	_ "decred.org/dcrdex/server/asset/bch"
 	_ "decred.org/dcrdex/server/asset/btc" // register btc asset
 	_ "decred.org/dcrdex/server/asset/dcr" // register dcr asset
-	_ "decred.org/dcrdex/server/asset/eth" // register eth asset
 	_ "decred.org/dcrdex/server/asset/ltc" // register ltc asset
 	dexsrv "decred.org/dcrdex/server/dex"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"


### PR DESCRIPTION
    In order to check data in a mempool transaction is formatted as we
    expect and in order to read its arguments, add package methods that are
    able to parse and validate Initiate and Redeem transaction data.

    Some of this code is taken directly from the go-ethereum repository
    where it is unexported there. abi.go and abi_test.go should be updated
    if they change over there.

