### PR TITLE
revert dropped capacity for the redemption result chan

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1790,7 +1790,7 @@ func (btc *ExchangeWallet) FindRedemption(ctx context.Context, coinID dex.Bytes)
 		outPt:        outPt,
 		blockHash:    blockHash,
 		blockHeight:  blockHeight,
-		resultChan:   make(chan *findRedemptionResult),
+		resultChan:   make(chan *findRedemptionResult, 1),
 		pkScript:     pkScript,
 		contractHash: dexbtc.ExtractScriptHash(pkScript),
 	}


### PR DESCRIPTION
I zeroed the `resultChan` capacity in [one of the last commits](https://github.com/decred/dcrdex/pull/1089/commits/fc1b11cc98cf76f193609f4ad8628902a34b3a8d) to #1098, and it looks like we were able to [miss a result ](https://github.com/buck54321/dcrdex/runs/3738084200?check_suite_focus=true). 