### PR TITLE
eth/client/core: Derive account from app seed

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -98,9 +98,13 @@ func init() {
 // Driver implements asset.Driver.
 type Driver struct{}
 
-// Setup creates the BCH exchange wallet. Start the wallet with its Run method.
-func (d *Driver) Setup(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
+// Open opens the BCH exchange wallet. Start the wallet with its Run method.
+func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
 	return NewWallet(cfg, logger, network)
+}
+
+func (d *Driver) Create(params *asset.CreateWalletParams) error {
+	return fmt.Errorf("no creatable wallet types")
 }
 
 // DecodeCoinID creates a human-readable representation of a coin ID for

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -330,9 +330,13 @@ func (r *swapReceipt) SignedRefund() dex.Bytes {
 // Driver implements asset.Driver.
 type Driver struct{}
 
-// Setup creates the BTC exchange wallet. Start the wallet with its Run method.
-func (d *Driver) Setup(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
+// Open opens the BTC exchange wallet. Start the wallet with its Run method.
+func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
 	return NewWallet(cfg, logger, network)
+}
+
+func (d *Driver) Create(*asset.CreateWalletParams) error {
+	return fmt.Errorf("no creatable wallet types")
 }
 
 // DecodeCoinID creates a human-readable representation of a coin ID for

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -378,9 +378,13 @@ type fundingCoin struct {
 // Driver implements asset.Driver.
 type Driver struct{}
 
-// Setup creates the DCR exchange wallet. Start the wallet with its Run method.
-func (d *Driver) Setup(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
+// Open opens the DCR exchange wallet. Start the wallet with its Run method.
+func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
 	return NewWallet(cfg, logger, network)
+}
+
+func (d *Driver) Create(*asset.CreateWalletParams) error {
+	return fmt.Errorf("no creatable wallet types")
 }
 
 // DecodeCoinID creates a human-readable representation of a coin ID for Decred.

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -17,7 +17,7 @@ var (
 
 // CreateWalletParams are the parameters for internal wallet creation. The
 // Settings provided should be the same wallet configuration settings passed to
-// Create.
+// Open.
 type CreateWalletParams struct {
 	Seed     []byte
 	Pass     []byte

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -62,7 +62,7 @@ func Register(assetID uint32, driver Driver) {
 }
 
 // CreateWallet creates a new wallet. This method should only be used once to create a
-// seeded wallet, after which OpenWallet should be used to load and access the wallet.
+// built-in wallet, after which OpenWallet should be used to load and access the wallet.
 func CreateWallet(assetID uint32, seedParams *CreateWalletParams) error {
 	return withDriver(assetID, func(drv Driver) error {
 		return drv.Create(seedParams)

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -15,11 +15,33 @@ var (
 	drivers    = make(map[uint32]Driver)
 )
 
+// CreateWalletParams are the parameters for internal wallet creation. The
+// Settings provided should be the same wallet configuration settings passed to
+// Create.
+type CreateWalletParams struct {
+	Seed     []byte
+	Pass     []byte
+	Settings map[string]string
+	DataDir  string
+	Net      dex.Network
+}
+
 // Driver is the interface required of all exchange wallets.
 type Driver interface {
-	Setup(*WalletConfig, dex.Logger, dex.Network) (Wallet, error)
+	Create(*CreateWalletParams) error
+	Open(*WalletConfig, dex.Logger, dex.Network) (Wallet, error)
 	DecodeCoinID(coinID []byte) (string, error)
 	Info() *WalletInfo
+}
+
+func withDriver(assetID uint32, f func(Driver) error) error {
+	driversMtx.Lock()
+	defer driversMtx.Unlock()
+	drv, ok := drivers[assetID]
+	if !ok {
+		return fmt.Errorf("asset: unknown driver asset %d", assetID)
+	}
+	return f(drv)
 }
 
 // Register should be called by the init function of an asset's package.
@@ -39,27 +61,28 @@ func Register(assetID uint32, driver Driver) {
 	drivers[assetID] = driver
 }
 
-// Setup sets up the asset, returning the exchange wallet.
-func Setup(assetID uint32, cfg *WalletConfig, logger dex.Logger, network dex.Network) (Wallet, error) {
-	driversMtx.Lock()
-	drv, ok := drivers[assetID]
-	driversMtx.Unlock()
-	if !ok {
-		return nil, fmt.Errorf("asset: unknown asset driver %d", assetID)
-	}
-	return drv.Setup(cfg, logger, network)
+// CreateWallet creates a new wallet. Only use Create for seeded wallet types.
+func CreateWallet(assetID uint32, seedParams *CreateWalletParams) error {
+	return withDriver(assetID, func(drv Driver) error {
+		return drv.Create(seedParams)
+	})
+}
+
+// OpenWallet sets up the asset, returning the exchange wallet.
+func OpenWallet(assetID uint32, cfg *WalletConfig, logger dex.Logger, net dex.Network) (w Wallet, err error) {
+	return w, withDriver(assetID, func(drv Driver) error {
+		w, err = drv.Open(cfg, logger, net)
+		return err
+	})
 }
 
 // DecodeCoinID creates a human-readable representation of a coin ID for a named
 // asset with a corresponding driver registered with this package.
-func DecodeCoinID(assetID uint32, coinID []byte) (string, error) {
-	driversMtx.Lock()
-	drv, ok := drivers[assetID]
-	driversMtx.Unlock()
-	if !ok {
-		return "", fmt.Errorf("asset: unknown asset driver %d", assetID)
-	}
-	return drv.DecodeCoinID(coinID)
+func DecodeCoinID(assetID uint32, coinID []byte) (cid string, err error) {
+	return cid, withDriver(assetID, func(drv Driver) error {
+		cid, err = drv.DecodeCoinID(coinID)
+		return err
+	})
 }
 
 // A registered asset is information about a supported asset.

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -62,7 +62,7 @@ func Register(assetID uint32, driver Driver) {
 }
 
 // CreateWallet creates a new wallet. This method should only be used once to create a
-// built-in wallet, after which OpenWallet should be used to load and access the wallet.
+// seeded wallet, after which OpenWallet should be used to load and access the wallet.
 func CreateWallet(assetID uint32, seedParams *CreateWalletParams) error {
 	return withDriver(assetID, func(drv Driver) error {
 		return drv.Create(seedParams)

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -61,7 +61,8 @@ func Register(assetID uint32, driver Driver) {
 	drivers[assetID] = driver
 }
 
-// CreateWallet creates a new wallet. Only use Create for seeded wallet types.
+// CreateWallet creates a new wallet. This method should only be used once to create a
+// seeded wallet, after which OpenWallet should be used to load and access the wallet.
 func CreateWallet(assetID uint32, seedParams *CreateWalletParams) error {
 	return withDriver(assetID, func(drv Driver) error {
 		return drv.Create(seedParams)

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -92,6 +92,10 @@ var _ asset.Driver = (*Driver)(nil)
 // Driver implements asset.Driver.
 type Driver struct{}
 
+func (d *Driver) Create(params *asset.CreateWalletParams) error {
+	return CreateWallet(params)
+}
+
 // Open opens the ETH exchange wallet. Start the wallet with its Run method.
 func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
 	return NewWallet(cfg, logger, network)
@@ -109,10 +113,6 @@ func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
 // Info returns basic information about the wallet and asset.
 func (d *Driver) Info() *asset.WalletInfo {
 	return WalletInfo
-}
-
-func (d *Driver) Create(params *asset.CreateWalletParams) error {
-	return CreateWallet(params)
 }
 
 // rawWallet is an unexported return type from the eth client. Watch for changes at
@@ -135,7 +135,6 @@ type ethFetcher interface {
 	block(ctx context.Context, hash common.Hash) (*types.Block, error)
 	blockNumber(ctx context.Context) (uint64, error)
 	connect(ctx context.Context, node *node.Node, contractAddr *common.Address) error
-	importAccount(pw string, privKeyB []byte) (*accounts.Account, error)
 	listWallets(ctx context.Context) ([]rawWallet, error)
 	initiate(opts *bind.TransactOpts, netID int64, refundTimestamp int64, secretHash [32]byte, participant *common.Address) (*types.Transaction, error)
 	estimateGas(ctx context.Context, msg ethereum.CallMsg) (uint64, error)

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -214,12 +214,12 @@ func CreateWallet(createWalletParams *asset.CreateWalletParams) error {
 	}
 
 	privateKey, err := extKey.SerializedPrivKey()
-	defer keygen.ZeroBytes(privateKey)
+	defer encode.ClearBytes(privateKey)
 	if err != nil {
 		return err
 	}
 
-	importAccountToNode(node, privateKey, createWalletParams.Pass)
+	importKeyToNode(node, privateKey, createWalletParams.Pass)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, network dex.Netw
 	accounts := exportAccountsFromNode(node)
 	if len(accounts) != 1 {
 		return nil,
-			fmt.Errorf("NewWallet: eth node keystore should only contain 1 account, but contains %v",
+			fmt.Errorf("NewWallet: eth node keystore should only contain 1 account, but contains %d",
 				len(accounts))
 	}
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -93,9 +93,6 @@ func (n *testNode) lock(ctx context.Context, acct *accounts.Account) error {
 func (n *testNode) listWallets(ctx context.Context) ([]rawWallet, error) {
 	return nil, nil
 }
-func (n *testNode) importAccount(pw string, privKeyB []byte) (*accounts.Account, error) {
-	return nil, nil
-}
 func (n *testNode) addPeer(ctx context.Context, peer string) error {
 	return nil
 }
@@ -576,7 +573,7 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 
 	// Test funding coins with coin from different address
 	var differentAddress [20]byte
-	decodedHex, _ := hex.DecodeString("345853e21b1d475582E71cC269124eD5e2dD3422")
+	decodedHex, _ := hex.DecodeString("8d83B207674bfd53B418a6E47DA148F5bFeCc652")
 	copy(differentAddress[:], decodedHex)
 	var nonce [8]byte
 	copy(nonce[:], encode.RandomBytes(8))
@@ -1063,7 +1060,7 @@ func TestSignMessage(t *testing.T) {
 	}
 
 	// Error due to coin from with account than wallet
-	differentAddress := common.HexToAddress("345853e21b1d475582E71cC269124eD5e2dD3422")
+	differentAddress := common.HexToAddress("8d83B207674bfd53B418a6E47DA148F5bFeCc652")
 	nonce := [8]byte{}
 	coinDifferentAddress := coin{
 		id: dexeth.AmountCoinID{

--- a/client/asset/eth/node.go
+++ b/client/asset/eth/node.go
@@ -247,9 +247,9 @@ func startNode(node *node.Node, network dex.Network) error {
 	return nil
 }
 
-// importAccountToNode imports an account into the ethereum wallet by private key
-// that can be unlocked with password.
-func importAccountToNode(node *node.Node, privateKey, password []byte) error {
+// importKeyToNode imports an private key into an ethereum node that can be
+// unlocked with password.
+func importKeyToNode(node *node.Node, privateKey, password []byte) error {
 	ecdsaPrivateKey, err := crypto.ToECDSA(privateKey)
 	if err != nil {
 		return err
@@ -262,12 +262,12 @@ func importAccountToNode(node *node.Node, privateKey, password []byte) error {
 	} else if len(accounts) == 1 {
 		address := crypto.PubkeyToAddress(ecdsaPrivateKey.PublicKey)
 		if !bytes.Equal(accounts[0].Address.Bytes(), address.Bytes()) {
-			errMsg := "importAccountToNode: attemping to import account to eth wallet: %v, " +
+			errMsg := "importKeyToNode: attemping to import account to eth wallet: %v, " +
 				"but node already contains imported account: %v"
 			return fmt.Errorf(errMsg, address, accounts[0].Address)
 		}
 	} else {
-		return fmt.Errorf("importAccountToNode: eth wallet keystore contains %v accounts", accounts)
+		return fmt.Errorf("importKeyToNode: eth wallet keystore contains %v accounts", accounts)
 	}
 
 	return nil

--- a/client/asset/eth/node.go
+++ b/client/asset/eth/node.go
@@ -8,12 +8,15 @@ package eth
 
 import (
 	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"decred.org/dcrdex/dex"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/downloader"
@@ -133,7 +136,8 @@ func SetSimnetGenesis(sng string) {
 	simnetGenesis = sng
 }
 
-func runNode(cfg *nodeConfig) (*node.Node, error) {
+// prepareNode sets up a geth node, but does not start it.
+func prepareNode(cfg *nodeConfig) (*node.Node, error) {
 	stackConf := &node.Config{DataDir: cfg.appDir}
 
 	stackConf.Logger = &ethLogger{dl: cfg.logger}
@@ -190,8 +194,13 @@ func runNode(cfg *nodeConfig) (*node.Node, error) {
 		return nil, err
 	}
 
+	return stack, nil
+}
+
+// startNode starts a geth node.
+func startNode(node *node.Node, network dex.Network) error {
 	ethCfg := ethconfig.Defaults
-	switch cfg.net {
+	switch network {
 	case dex.Simnet:
 		var sp core.Genesis
 		if simnetGenesis == "" {
@@ -199,17 +208,17 @@ func runNode(cfg *nodeConfig) (*node.Node, error) {
 			genesisFile := filepath.Join(homeDir, "dextest", "eth", "genesis.json")
 			genBytes, err := os.ReadFile(genesisFile)
 			if err != nil {
-				return nil, fmt.Errorf("error reading genesis file: %v", err)
+				return fmt.Errorf("error reading genesis file: %v", err)
 			}
 			genLen := len(genBytes)
 			if genLen == 0 {
-				return nil, fmt.Errorf("no genesis found at %v", genesisFile)
+				return fmt.Errorf("no genesis found at %v", genesisFile)
 			}
 			genBytes = genBytes[:genLen-1]
 			SetSimnetGenesis(string(genBytes))
 		}
 		if err := json.Unmarshal([]byte(simnetGenesis), &sp); err != nil {
-			return nil, fmt.Errorf("unable to unmarshal simnet genesis: %v", err)
+			return fmt.Errorf("unable to unmarshal simnet genesis: %v", err)
 		}
 		ethCfg.Genesis = &sp
 		ethCfg.NetworkId = 42
@@ -219,22 +228,41 @@ func runNode(cfg *nodeConfig) (*node.Node, error) {
 	case dex.Mainnet:
 		// urls = params.MainnetBootnodes
 		// TODO: Allow.
-		return nil, fmt.Errorf("eth cannot be used on mainnet")
+		return fmt.Errorf("eth cannot be used on mainnet")
 	default:
-		return nil, fmt.Errorf("unknown network ID: %d", uint8(cfg.net))
+		return fmt.Errorf("unknown network ID: %d", uint8(network))
 	}
 
 	ethCfg.SyncMode = downloader.LightSync
 
-	if _, err := les.New(stack, &ethCfg); err != nil {
-		return nil, err
+	if _, err := les.New(node, &ethCfg); err != nil {
+		return err
 	}
 
-	if err := stack.Start(); err != nil {
-		return nil, err
+	if err := node.Start(); err != nil {
+		return err
 	}
 
-	return stack, nil
+	return nil
+}
+
+// importAccountToNode imports an account into the ethereum wallet by private key
+// that can be unlocked with password.
+func importAccountToNode(node *node.Node, privateKey, password []byte) error {
+	ecdsaPrivateKey, err := crypto.ToECDSA(privateKey)
+	if err != nil {
+		return err
+	}
+	ks := node.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
+	_, err = ks.ImportECDSA(ecdsaPrivateKey, hex.EncodeToString(password))
+	return err
+}
+
+// exportAccountsFromNode returns all the accounts for which a the ethereum wallet
+// has stored a private key.
+func exportAccountsFromNode(node *node.Node) []accounts.Account {
+	ks := node.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
+	return ks.Accounts()
 }
 
 //

--- a/client/asset/eth/node.go
+++ b/client/asset/eth/node.go
@@ -266,8 +266,11 @@ func importAccountToNode(node *node.Node, privateKey, password []byte) error {
 				"but node already contains imported account: %v"
 			return fmt.Errorf(errMsg, address, accounts[0].Address)
 		}
+	} else {
+		return fmt.Errorf("importAccountToNode: eth wallet keystore contains %v accounts", accounts)
 	}
-	return fmt.Errorf("importAccountToNode: eth wallet keystore contains %v accounts", accounts)
+
+	return nil
 }
 
 // exportAccountsFromNode returns all the accounts for which a the ethereum wallet

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -15,10 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -188,21 +186,6 @@ func (c *rpcclient) sendTransaction(ctx context.Context, tx map[string]string) (
 // syncProgress return the current sync progress. Returns no error and nil when not syncing.
 func (c *rpcclient) syncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
 	return c.ec.SyncProgress(ctx)
-}
-
-// importAccount imports an account into the ethereum wallet by private key
-// that can be unlocked with password.
-func (c *rpcclient) importAccount(pw string, privKeyB []byte) (*accounts.Account, error) {
-	privKey, err := crypto.ToECDSA(privKeyB)
-	if err != nil {
-		return new(accounts.Account), fmt.Errorf("error parsing private key: %v", err)
-	}
-	ks := c.n.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
-	acct, err := ks.ImportECDSA(privKey, pw)
-	if err != nil {
-		return nil, err
-	}
-	return &acct, nil
 }
 
 // peers returns connected peers.

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -136,17 +136,13 @@ func TestMain(m *testing.M) {
 		}()
 		// Create dir if none yet exists. This persists for the life of the
 		// testing harness.
-		if _, err := os.Stat(simnetWalletDir); os.IsNotExist(err) {
-			err := os.MkdirAll(simnetWalletDir, 0755)
-			if err != nil {
-				return 1, fmt.Errorf("error creating temp dir: %v\n", err)
-			}
+		err := os.MkdirAll(simnetWalletDir, 0755)
+		if err != nil {
+			return 1, fmt.Errorf("error creating simnet wallet dir dir: %v\n", err)
 		}
-		if _, err := os.Stat(participantWalletDir); os.IsNotExist(err) {
-			err := os.MkdirAll(participantWalletDir, 0755)
-			if err != nil {
-				return 1, fmt.Errorf("error creating temp dir: %v\n", err)
-			}
+		err = os.MkdirAll(participantWalletDir, 0755)
+		if err != nil {
+			return 1, fmt.Errorf("error creating participant wallet dir: %v\n", err)
 		}
 		addrBytes, err := os.ReadFile(contractAddrFile)
 		if err != nil {

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -42,8 +42,10 @@ import (
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
+	dexeth "decred.org/dcrdex/dex/networks/eth"
 	swap "decred.org/dcrdex/dex/networks/eth"
 	"decred.org/dcrdex/internal/eth/reentryattack"
+	"decred.org/dcrdex/server/asset/eth"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
@@ -55,9 +57,10 @@ import (
 )
 
 const (
-	pw        = "abc"
-	alphaNode = "enode://897c84f6e4f18195413c1d02927e6a4093f5e7574b52bdec6f20844c4f1f6dd3f16036a9e600bd8681ab50fd8dd144df4a6ba9dd8722bb578a86aaa8222c964f@127.0.0.1:30304"
-	alphaAddr = "18d65fb8d60c1199bb1ad381be47aa692b482605"
+	pw            = "abc"
+	alphaNode     = "enode://897c84f6e4f18195413c1d02927e6a4093f5e7574b52bdec6f20844c4f1f6dd3f16036a9e600bd8681ab50fd8dd144df4a6ba9dd8722bb578a86aaa8222c964f@127.0.0.1:30304"
+	alphaAddr     = "18d65fb8d60c1199bb1ad381be47aa692b482605"
+	walletSeedHex = "5c52e2ef5f5298ec41107e4e9573df4488577fb3504959cbc26c88437205dd2c0812f5244004217452059e2fd11603a511b5d0870ead753df76c966ce3c71531"
 )
 
 var (
@@ -151,7 +154,24 @@ func TestMain(m *testing.M) {
 			"appdir":         testDir,
 			"nodelistenaddr": "localhost:30355",
 		}
-		wallet, err := NewWallet(&asset.WalletConfig{Settings: settings}, tLogger, dex.Simnet)
+		walletSeed, _ := hex.DecodeString(walletSeedHex)
+		pass := encode.RandomBytes(64)
+		walletConfig := asset.WalletConfig{
+			Settings: settings,
+			DataDir:  testDir,
+		}
+		createWalletParams := asset.CreateWalletParams{
+			Seed:     walletSeed,
+			Pass:     pass,
+			Settings: settings,
+			DataDir:  testDir,
+			Net:      dex.Simnet,
+		}
+		err = CreateWallet(&createWalletParams)
+		if err != nil {
+			return 1, fmt.Errorf("error creating node: %v\n", err)
+		}
+		wallet, err := NewWallet(&walletConfig, tLogger, dex.Simnet)
 		if err != nil {
 			return 1, fmt.Errorf("error starting node: %v\n", err)
 		}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -41,7 +41,8 @@ type WalletInfo struct {
 	// UnitInfo is the information about unit names and conversion factors for
 	// the asset.
 	UnitInfo dex.UnitInfo `json:"unitinfo"`
-	// Seeded
+	// Seeded represents a built-in wallet. If Seeded is true, the wallet must be
+	// created with a deterministic seed using (Driver).Create before it can be opened.
 	Seeded bool
 }
 

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -41,6 +41,8 @@ type WalletInfo struct {
 	// UnitInfo is the information about unit names and conversion factors for
 	// the asset.
 	UnitInfo dex.UnitInfo `json:"unitinfo"`
+	// Seeded
+	Seeded bool
 }
 
 // ConfigOption is a wallet configuration option.

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -103,9 +103,13 @@ func init() {
 // Driver implements asset.Driver.
 type Driver struct{}
 
-// Setup creates the LTC exchange wallet. Start the wallet with its Run method.
-func (d *Driver) Setup(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
+// Open opens the LTC exchange wallet. Start the wallet with its Run method.
+func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
 	return NewWallet(cfg, logger, network)
+}
+
+func (d *Driver) Create(*asset.CreateWalletParams) error {
+	return fmt.Errorf("no creatable wallet types")
 }
 
 // DecodeCoinID creates a human-readable representation of a coin ID for

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1705,7 +1705,7 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 
 	if walletInfo.Seeded {
 		if len(walletPW) > 0 {
-			return fmt.Errorf("external password incompatible with built in wallet")
+			return fmt.Errorf("external password incompatible with built-in wallet")
 		}
 		walletPW, err = c.createSeededWallet(assetID, crypter, form)
 		if err != nil {
@@ -2001,7 +2001,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 	}
 	seeded := oldWallet.Info().Seeded
 	if seeded && len(newWalletPW) > 0 {
-		return newError(passwordErr, "cannot set a password on a seeded wallet")
+		return newError(passwordErr, "cannot set a password on a built-in wallet")
 	}
 	oldDepositAddr := oldWallet.currentDepositAddress()
 	dbWallet := &db.Wallet{

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1703,11 +1703,11 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 		}
 	}
 
-	if walletInfo.Seeded {
+	if walletInfo.BuiltIn {
 		if len(walletPW) > 0 {
 			return fmt.Errorf("external password incompatible with built in wallet")
 		}
-		walletPW, err = c.createSeededWallet(assetID, crypter, form)
+		walletPW, err = c.createBuiltInWallet(assetID, crypter, form)
 		if err != nil {
 			return err
 		}
@@ -1778,9 +1778,9 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 	return nil
 }
 
-// createSeededWallet creates a seeded wallet with an asset-specific seed derived
+// createBuiltInWallet creates a built-in wallet with an asset-specific seed derived
 // deterministically from the app seed.
-func (c *Core) createSeededWallet(assetID uint32, crypter encrypt.Crypter, form *WalletForm) ([]byte, error) {
+func (c *Core) createBuiltInWallet(assetID uint32, crypter encrypt.Crypter, form *WalletForm) ([]byte, error) {
 	creds := c.creds()
 	if creds == nil {
 		return nil, fmt.Errorf("no v2 credentials stored")
@@ -1999,9 +1999,9 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 		return newError(missingWalletErr, "%d -> %s wallet not found",
 			assetID, unbip(assetID))
 	}
-	seeded := oldWallet.Info().Seeded
-	if seeded && len(newWalletPW) > 0 {
-		return newError(passwordErr, "cannot set a password on a seeded wallet")
+	builtIn := oldWallet.Info().BuiltIn
+	if builtIn && len(newWalletPW) > 0 {
+		return newError(passwordErr, "cannot set a password on a built-in wallet")
 	}
 	oldDepositAddr := oldWallet.currentDepositAddress()
 	dbWallet := &db.Wallet{

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1703,11 +1703,11 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 		}
 	}
 
-	if walletInfo.BuiltIn {
+	if walletInfo.Seeded {
 		if len(walletPW) > 0 {
 			return fmt.Errorf("external password incompatible with built in wallet")
 		}
-		walletPW, err = c.createBuiltInWallet(assetID, crypter, form)
+		walletPW, err = c.createSeededWallet(assetID, crypter, form)
 		if err != nil {
 			return err
 		}
@@ -1778,9 +1778,9 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 	return nil
 }
 
-// createBuiltInWallet creates a built-in wallet with an asset-specific seed derived
+// createSeededWallet creates a seeded wallet with an asset-specific seed derived
 // deterministically from the app seed.
-func (c *Core) createBuiltInWallet(assetID uint32, crypter encrypt.Crypter, form *WalletForm) ([]byte, error) {
+func (c *Core) createSeededWallet(assetID uint32, crypter encrypt.Crypter, form *WalletForm) ([]byte, error) {
 	creds := c.creds()
 	if creds == nil {
 		return nil, fmt.Errorf("no v2 credentials stored")
@@ -1999,9 +1999,9 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, assetID uint32, cfg 
 		return newError(missingWalletErr, "%d -> %s wallet not found",
 			assetID, unbip(assetID))
 	}
-	builtIn := oldWallet.Info().BuiltIn
-	if builtIn && len(newWalletPW) > 0 {
-		return newError(passwordErr, "cannot set a password on a built-in wallet")
+	seeded := oldWallet.Info().Seeded
+	if seeded && len(newWalletPW) > 0 {
+		return newError(passwordErr, "cannot set a password on a seeded wallet")
 	}
 	oldDepositAddr := oldWallet.currentDepositAddress()
 	dbWallet := &db.Wallet{

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1372,8 +1372,12 @@ type tDriver struct {
 	winfo   *asset.WalletInfo
 }
 
-func (drv *tDriver) Setup(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (asset.Wallet, error) {
+func (drv *tDriver) Open(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (asset.Wallet, error) {
 	return drv.f(cfg, logger, net)
+}
+
+func (drv *tDriver) Create(params *asset.CreateWalletParams) error {
+	return fmt.Errorf("unimplemented")
 }
 
 func (drv *tDriver) DecodeCoinID(coinID []byte) (string, error) {

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -379,8 +379,12 @@ type TCore struct {
 // TDriver implements the interface required of all exchange wallets.
 type TDriver struct{}
 
-func (*TDriver) Setup(*asset.WalletConfig, dex.Logger, dex.Network) (asset.Wallet, error) {
+func (*TDriver) Open(*asset.WalletConfig, dex.Logger, dex.Network) (asset.Wallet, error) {
 	return nil, nil
+}
+
+func (*TDriver) Create(*asset.CreateWalletParams) error {
+	return nil
 }
 
 func (*TDriver) DecodeCoinID(coinID []byte) (string, error) {

--- a/dex/keygen/keygen.go
+++ b/dex/keygen/keygen.go
@@ -51,10 +51,3 @@ func GenDeepChild(seed []byte, kids []uint32) (*hdkeychain.ExtendedKey, error) {
 
 	return extKey, nil
 }
-
-// ZeroBytes assigns 0 to each element in a byte slice.
-func ZeroBytes(b []byte) {
-	for i := 0; i < len(b); i++ {
-		b[i] = byte(0)
-	}
-}

--- a/dex/keygen/keygen.go
+++ b/dex/keygen/keygen.go
@@ -1,0 +1,60 @@
+package keygen
+
+import (
+	"fmt"
+
+	"github.com/decred/dcrd/hdkeychain/v3"
+)
+
+// RootKeyParams implements hdkeychain.NetworkParams for master
+// hdkeychain.ExtendedKey creation.
+type RootKeyParams struct{}
+
+func (*RootKeyParams) HDPrivKeyVersion() [4]byte {
+	return [4]byte{0x74, 0x61, 0x63, 0x6f} // ASCII "taco"
+}
+func (*RootKeyParams) HDPubKeyVersion() [4]byte {
+	return [4]byte{0x64, 0x65, 0x78, 0x63} // ASCII "dexc"
+}
+
+// GenDeepChild derives the leaf of a path of children from a root extended key.
+func GenDeepChild(seed []byte, kids []uint32) (*hdkeychain.ExtendedKey, error) {
+	root, err := hdkeychain.NewMaster(seed, &RootKeyParams{})
+	defer root.Zero()
+	if err != nil {
+		return nil, err
+	}
+	genChild := func(parent *hdkeychain.ExtendedKey, childIdx uint32) (*hdkeychain.ExtendedKey, error) {
+		err := hdkeychain.ErrInvalidChild
+		for err == hdkeychain.ErrInvalidChild {
+			var kid *hdkeychain.ExtendedKey
+			kid, err = parent.Child(childIdx)
+			if err == nil {
+				return kid, nil
+			}
+			fmt.Printf("Child derive skipped a key index %d -> %d", childIdx, childIdx+1) // < 1 in 2^127 chance
+			childIdx++
+		}
+		return nil, err
+	}
+
+	extKey := root
+	for _, childIdx := range kids {
+		childExtKey, err := genChild(extKey, childIdx)
+		extKey.Zero()
+		extKey = childExtKey
+		if err != nil {
+			extKey.Zero()
+			return nil, fmt.Errorf("genChild error: %w", err)
+		}
+	}
+
+	return extKey, nil
+}
+
+// ZeroBytes assigns 0 to each element in a byte slice.
+func ZeroBytes(b []byte) {
+	for i := 0; i < len(b); i++ {
+		b[i] = byte(0)
+	}
+}

--- a/dex/keygen/keygen_test.go
+++ b/dex/keygen/keygen_test.go
@@ -50,11 +50,3 @@ func TestGenDeepChild(t *testing.T) {
 		t.Fatalf("private keys not equal:\n%x\n%x", expectedSerializedPrivKey, serializedPrivKey)
 	}
 }
-
-func TestZeroBytes(t *testing.T) {
-	b := []byte{1, 2, 3}
-	ZeroBytes(b)
-	if !bytes.Equal(b, []byte{0, 0, 0}) {
-		t.Fatalf("expected bytes to be zerod but got %v", b)
-	}
-}

--- a/dex/keygen/keygen_test.go
+++ b/dex/keygen/keygen_test.go
@@ -1,0 +1,60 @@
+package keygen
+
+import (
+	"bytes"
+	"testing"
+
+	"decred.org/dcrdex/dex/encode"
+	"github.com/decred/dcrd/hdkeychain/v3"
+)
+
+func TestGenDeepChild(t *testing.T) {
+	seed := encode.RandomBytes(64)
+
+	root, err := hdkeychain.NewMaster(seed, &RootKeyParams{})
+	if err != nil {
+		t.Fatalf("error getting HD keychain root: %v", err)
+	}
+
+	expectedChild, err := root.Child(1)
+	if err != nil {
+		t.Fatalf("error deriving child: %v", err)
+	}
+
+	expectedChild, err = expectedChild.Child(2)
+	if err != nil {
+		t.Fatalf("error deriving child: %v", err)
+	}
+
+	expectedChild, err = expectedChild.Child(3)
+	if err != nil {
+		t.Fatalf("error deriving child: %v", err)
+	}
+
+	child, err := GenDeepChild(seed, []uint32{1, 2, 3})
+	if err != nil {
+		t.Fatalf("error in GenDeepChild: %v", err)
+	}
+
+	expectedSerializedPrivKey, err := expectedChild.SerializedPrivKey()
+	if err != nil {
+		t.Fatalf("error serializing priv key: %v", err)
+	}
+
+	serializedPrivKey, err := child.SerializedPrivKey()
+	if err != nil {
+		t.Fatalf("error serializing priv key: %v", err)
+	}
+
+	if !bytes.Equal(expectedSerializedPrivKey, serializedPrivKey) {
+		t.Fatalf("private keys not equal:\n%x\n%x", expectedSerializedPrivKey, serializedPrivKey)
+	}
+}
+
+func TestZeroBytes(t *testing.T) {
+	b := []byte{1, 2, 3}
+	ZeroBytes(b)
+	if !bytes.Equal(b, []byte{0, 0, 0}) {
+		t.Fatalf("expected bytes to be zerod but got %v", b)
+	}
+}

--- a/dex/networks/eth/txdata_test.go
+++ b/dex/networks/eth/txdata_test.go
@@ -19,7 +19,7 @@ func mustParseHex(s string) []byte {
 }
 
 func TestParseInitiateData(t *testing.T) {
-	participantAddr := common.HexToAddress("345853e21b1d475582E71cC269124eD5e2dD3422")
+	participantAddr := common.HexToAddress("8d83B207674bfd53B418a6E47DA148F5bFeCc652")
 	secretHashSlice := mustParseHex("4aec4dc47fc6bd1fd5091c1aa4067c7fbd6bbcdb476209756354ec784d6082dc")
 	var secretHash [32]byte
 	copy(secretHash[:], secretHashSlice)
@@ -27,7 +27,7 @@ func TestParseInitiateData(t *testing.T) {
 	calldata := mustParseHex("ae0521470000000000000000000000000000000000" +
 		"0000000000000000000000614811144aec4dc47fc6bd1fd5091c1aa4067" +
 		"c7fbd6bbcdb476209756354ec784d6082dc000000000000000000000000" +
-		"345853e21b1d475582e71cc269124ed5e2dd3422")
+		"8d83B207674bfd53B418a6E47DA148F5bFeCc652")
 
 	redeemCalldata := mustParseHex("b31597ad87eac09638c0c38b4e735b79f053" +
 		"cb869167ee770640ac5df5c4ab030813122aebdc4c31b88d0c8f4d64459" +
@@ -86,7 +86,7 @@ func TestParseRedeemData(t *testing.T) {
 	initiateCalldata := mustParseHex("ae05214700000000000000000000000000" +
 		"000000000000000000000000000000614811144aec4dc47fc6bd1fd5091" +
 		"c1aa4067c7fbd6bbcdb476209756354ec784d6082dc0000000000000000" +
-		"00000000345853e21b1d475582e71cc269124ed5e2dd3422")
+		"000000008d83B207674bfd53B418a6E47DA148F5bFeCc652")
 
 	tests := []struct {
 		name     string

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -102,10 +102,10 @@ cat > "${NODES_ROOT}/genesis.json" <<EOF
     "4f8ef3892b65ed7fc356ff473a2ef2ae5ec27a06": {
         "balance": "11000000000000000000000"
     },
-    "2b84C791b79Ee37De042AD2ffF1A253c3ce9bc27": {
+    "dd93b447f7eBCA361805eBe056259853F3912E04": {
         "balance": "11000000000000000000000"
     },
-    "345853e21b1d475582E71cC269124eD5e2dD3422": {
+    "8d83B207674bfd53B418a6E47DA148F5bFeCc652": {
         "balance": "11000000000000000000000"
     }
   }

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -47,6 +47,7 @@ go test "${dumptags[@]}" harness ./client/asset/dcr
 go test "${dumptags[@]}" harness ./client/asset/btc/livetest
 go test "${dumptags[@]}" harness ./client/asset/ltc
 go test "${dumptags[@]}" harness ./client/asset/bch
+go test "${dumptags[@]}" harness,lgpl ./client/asset/eth
 go test "${dumptags[@]}" harness ./client/core
 go test "${dumptags[@]}" dcrlive ./server/asset/dcr
 go test "${dumptags[@]}" btclive ./server/asset/btc


### PR DESCRIPTION
`asset.Driver` is now updated with a `Create` function, which is used to initialize a seeded wallet, and `(Driver).Setup` has been renamed to `(Driver).Open`. The seed for seeded wallets is derived from the app seed using `blake256(appSeed|asssetID)`. The private key for the eth wallet is derived from this seed using the following BIP32 derivation path: `m/44'/60'/0'/0/0`.
