### PR TITLE
app: drop ids arg to parsePage

### DIFF
--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -240,63 +240,57 @@ export default class Application {
     this.popupTmpl = Doc.tmplElement(this.popupNotes, 'note')
     this.popupTmpl.remove()
     this.tooltip = idel(document.body, 'tooltip')
-    const pg = this.page = Doc.parsePage(this.header, [
-      'noteIndicator', 'noteList', 'noteTmpl', 'marketsMenuEntry',
-      'walletsMenuEntry', 'noteMenuEntry', 'loader', 'profileMenuEntry',
-      'profileIndicator', 'profileSignout', 'innerNoteIcon', 'innerProfileIcon',
-      'noteBox', 'profileBox', 'pokeCat', 'noteCat', 'pokeBox', 'pokeList',
-      'pokeTmpl'
-    ])
-    delete pg.noteTmpl.id
-    pg.noteTmpl.remove()
-    delete pg.pokeTmpl.id
-    pg.pokeTmpl.remove()
-    pg.loader.remove()
-    pg.loader.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
-    Doc.show(pg.loader)
+    const page = this.page = Doc.idDescendants(this.header)
+    delete page.noteTmpl.id
+    page.noteTmpl.remove()
+    delete page.pokeTmpl.id
+    page.pokeTmpl.remove()
+    page.loader.remove()
+    page.loader.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
+    Doc.show(page.loader)
 
-    bind(pg.noteMenuEntry, 'click', async () => {
-      Doc.hide(pg.pokeList)
-      Doc.show(pg.noteList)
+    bind(page.noteMenuEntry, 'click', async () => {
+      Doc.hide(page.pokeList)
+      Doc.show(page.noteList)
       this.ackNotes()
-      pg.noteCat.classList.add('active')
-      pg.pokeCat.classList.remove('active')
-      this.showDropdown(pg.noteMenuEntry, pg.noteBox)
-      Doc.hide(pg.noteIndicator)
+      page.noteCat.classList.add('active')
+      page.pokeCat.classList.remove('active')
+      this.showDropdown(page.noteMenuEntry, page.noteBox)
+      Doc.hide(page.noteIndicator)
       for (const note of this.notes) {
         if (note.acked) {
           note.el.classList.remove('firstview')
         }
       }
-      this.setNoteTimes(pg.noteList)
-      this.setNoteTimes(pg.pokeList)
+      this.setNoteTimes(page.noteList)
+      this.setNoteTimes(page.pokeList)
       this.storeNotes()
     })
 
-    bind(pg.profileMenuEntry, 'click', () => {
-      this.showDropdown(pg.profileMenuEntry, pg.profileBox)
+    bind(page.profileMenuEntry, 'click', () => {
+      this.showDropdown(page.profileMenuEntry, page.profileBox)
     })
 
-    bind(pg.innerNoteIcon, 'click', () => { Doc.hide(pg.noteBox) })
-    bind(pg.innerProfileIcon, 'click', () => { Doc.hide(pg.profileBox) })
+    bind(page.innerNoteIcon, 'click', () => { Doc.hide(page.noteBox) })
+    bind(page.innerProfileIcon, 'click', () => { Doc.hide(page.profileBox) })
 
-    bind(pg.profileSignout, 'click', async e => await this.signOut())
+    bind(page.profileSignout, 'click', async e => await this.signOut())
 
-    bind(pg.pokeCat, 'click', () => {
-      this.setNoteTimes(pg.pokeList)
-      pg.pokeCat.classList.add('active')
-      pg.noteCat.classList.remove('active')
-      Doc.hide(pg.noteList)
-      Doc.show(pg.pokeList)
+    bind(page.pokeCat, 'click', () => {
+      this.setNoteTimes(page.pokeList)
+      page.pokeCat.classList.add('active')
+      page.noteCat.classList.remove('active')
+      Doc.hide(page.noteList)
+      Doc.show(page.pokeList)
       this.ackNotes()
     })
 
-    bind(pg.noteCat, 'click', () => {
-      this.setNoteTimes(pg.noteList)
-      pg.noteCat.classList.add('active')
-      pg.pokeCat.classList.remove('active')
-      Doc.hide(pg.pokeList)
-      Doc.show(pg.noteList)
+    bind(page.noteCat, 'click', () => {
+      this.setNoteTimes(page.noteList)
+      page.noteCat.classList.add('active')
+      page.pokeCat.classList.remove('active')
+      Doc.hide(page.pokeList)
+      Doc.show(page.noteList)
       this.ackNotes()
     })
   }
@@ -346,7 +340,7 @@ export default class Application {
 
   /*
    * bindInternalNavigation hijacks navigation by click on any local links that
-   * are descendents of ancestor.
+   * are descendants of ancestor.
    */
   bindInternalNavigation (ancestor) {
     const pageURL = new URL(window.location)
@@ -391,21 +385,21 @@ export default class Application {
    * and when the user registers a DEX.
    */
   updateMenuItemsDisplay () {
-    const pg = this.page
-    if (!pg) {
+    const page = this.page
+    if (!page) {
       // initial page load, header elements not yet attached but menu items
       // would already be hidden/displayed as appropriate.
       return
     }
     if (!this.user.authed) {
-      Doc.hide(pg.noteMenuEntry, pg.walletsMenuEntry, pg.marketsMenuEntry, pg.profileMenuEntry)
+      Doc.hide(page.noteMenuEntry, page.walletsMenuEntry, page.marketsMenuEntry, page.profileMenuEntry)
       return
     }
-    Doc.show(pg.noteMenuEntry, pg.walletsMenuEntry, pg.profileMenuEntry)
+    Doc.show(page.noteMenuEntry, page.walletsMenuEntry, page.profileMenuEntry)
     if (Object.keys(this.user.exchanges).length > 0) {
-      Doc.show(pg.marketsMenuEntry)
+      Doc.show(page.marketsMenuEntry)
     } else {
-      Doc.hide(pg.marketsMenuEntry)
+      Doc.hide(page.marketsMenuEntry)
     }
   }
 

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -182,16 +182,14 @@ export default class Doc {
   }
 
   /*
-   * parsePage constructs a page object from the supplied list of id strings.
-   * The properties of the returned object have names matching the supplied
-   * id strings, with the corresponding value being the Element object. It is
-   * not an error if an element does not exist for an id in the list.
+   * idDescendants creates an object mapping to elements which are descendants
+   * of the ancestor and have id attributes. Elements are keyed by their id
+   * value.
    */
-  static parsePage (main, ids) {
-    const get = s => Doc.idel(main, s)
-    const page = {}
-    ids.forEach(id => { page[id] = get(id) })
-    return page
+  static idDescendants (ancestor) {
+    const d = {}
+    for (const el of ancestor.querySelectorAll('[id]')) d[el.id] = el
+    return d
   }
 
   /*

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -15,11 +15,7 @@ export class NewWalletForm {
     this.form = form
     this.currentAsset = null
     this.pwCache = pwCache
-    const fields = this.fields = Doc.parsePage(form, [
-      'nwAssetLogo', 'nwAssetName', 'newWalletPass', 'nwAppPass',
-      'walletSettings', 'selectCfgFile', 'cfgFile', 'submitAdd', 'newWalletErr',
-      'newWalletAppPWBox'
-    ])
+    const fields = this.fields = Doc.idDescendants(form)
     this.refresh()
 
     if (closerFn) {
@@ -303,11 +299,7 @@ export class WalletConfigForm {
  */
 export class ConfirmRegistrationForm {
   constructor (application, form, { getDexAddr, getCertFile }, success, insufficientFundsFail, setupWalletFn) {
-    this.fields = Doc.parsePage(form, [
-      'marketRowTemplate', 'marketsTableRows', 'appPass', 'appPassBox',
-      'appPassSpan', 'submitConfirm', 'regErr', 'feeRowTemplate',
-      'feeTableRows', 'setupWallet'
-    ])
+    this.fields = Doc.idDescendants(form)
     app = application
     this.getDexAddr = getDexAddr
     this.getCertFile = getCertFile
@@ -458,10 +450,7 @@ export class ConfirmRegistrationForm {
 
 export class UnlockWalletForm {
   constructor (application, form, success, pwCache) {
-    this.fields = Doc.parsePage(form, [
-      'uwAssetLogo', 'uwAssetName', 'uwAppPassBox', 'uwAppPass', 'submitUnlock',
-      'unlockErr', 'submitUnlockDiv'
-    ])
+    this.fields = Doc.idDescendants(form)
     app = application
     this.form = form
     this.pwCache = pwCache
@@ -533,11 +522,7 @@ export class DEXAddressForm {
     this.pwCache = pwCache
     this.defaultTLSText = 'none selected'
 
-    const page = this.page = Doc.parsePage(form, [
-      'dexAddr', 'dexShowMore', 'dexCertBox', 'dexNeedCert', 'certFile',
-      'removeCert', 'addCert', 'selectedCert', 'dexAddrAppPWBox', 'dexAddrAppPW',
-      'submitDEXAddr', 'dexAddrErr'
-    ])
+    const page = this.page = Doc.idDescendants(form)
 
     page.selectedCert.textContent = this.defaultTLSText
     Doc.bind(page.certFile, 'change', () => this.onCertFileChange())

--- a/client/webserver/site/src/js/login.js
+++ b/client/webserver/site/src/js/login.js
@@ -10,9 +10,7 @@ export default class LoginPage extends BasePage {
   constructor (application, body) {
     super()
     app = application
-    const page = this.page = Doc.parsePage(body, [
-      'submit', 'errMsg', 'loginForm', 'pw', 'rememberPass'
-    ])
+    const page = this.page = Doc.idDescendants(body)
     forms.bind(page.loginForm, page.submit, () => { this.login() })
     page.pw.focus()
   }

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -39,44 +39,7 @@ export default class MarketsPage extends BasePage {
   constructor (application, main, data) {
     super()
     app = application
-    const page = this.page = Doc.parsePage(main, [
-      // Templates, loaders, chart div...
-      'marketLoader', 'marketList', 'rowTemplate', 'buyRows', 'sellRows',
-      'marketSearch', 'rightSide',
-      // Registration status
-      'registrationStatus', 'regStatusTitle', 'regStatusMessage', 'regStatusConfsDisplay',
-      'regStatusDex', 'confReq',
-      // Order form
-      'orderForm', 'priceBox', 'buyBttn', 'sellBttn', 'limitBttn', 'marketBttn',
-      'tifBox', 'submitBttn', 'qtyField', 'rateField', 'orderErr',
-      'baseWalletIcons', 'quoteWalletIcons', 'lotSize', 'rateStep', 'lotField',
-      'tifNow', 'mktBuyBox', 'mktBuyLots', 'mktBuyField', 'minMktBuy', 'qtyBox',
-      'loaderMsg', 'balanceTable', 'orderPreview',
-      // Wallet unlock form
-      'forms', 'openForm', 'uwAppPass',
-      // Order submission is verified with the user's password.
-      'verifyForm', 'vHeader', 'vSideHeader', 'vSide', 'vQty', 'vBase', 'vRate',
-      'vTotal', 'vQuote', 'vPass', 'vSideSubmit', 'vBaseSubmit', 'vSubmit',
-      'vLoader', 'verifyLimit', 'verifyMarket',
-      'vmTotal', 'vmAsset', 'vmLots', 'mktBuyScore', 'vErr',
-      // Create wallet form
-      'walletForm',
-      // Active orders
-      'liveTemplate', 'liveList', 'liveTable',
-      // Cancel order form
-      'cancelForm', 'cancelRemain', 'cancelUnit', 'cancelPass', 'cancelSubmit',
-      // Chart and legend
-      'marketChart', 'chartResizer', 'sellBookedBase', 'sellBookedQuote',
-      'buyBookedBase', 'buyBookedQuote', 'hoverData', 'hoverPrice',
-      'hoverVolume', 'chartLegend', 'chartErrMsg', 'candlestickBttn',
-      'depthBttn', 'epochLine', 'durBttnTemplate', 'durBttnBox',
-      'depthHoverData', 'candleHoverData', 'candleHigh', 'candleLow',
-      'candleStart', 'candleEnd', 'candleVol', 'depthSummary',
-      // Max order section
-      'maxOrd', 'maxLbl', 'maxFromLots', 'maxFromAmt', 'maxFromTicker',
-      'maxToAmt', 'maxToTicker', 'maxAboveZero', 'maxLotBox', 'maxFromLotsLbl',
-      'maxBox'
-    ])
+    const page = this.page = Doc.idDescendants(main)
     this.main = main
     this.loaded = app.loading(this.main.parentElement)
     this.maxLoaded = null
@@ -2046,14 +2009,7 @@ class MarketRow {
  */
 class BalanceWidget {
   constructor (table) {
-    const els = Doc.parsePage(table, [
-      'baseAvail', 'quoteAvail', 'baseNewWalletRow', 'quoteNewWalletRow',
-      'baseNewButton', 'quoteNewButton', 'baseLocked', 'quoteLocked',
-      'baseImmature', 'quoteImmature', 'baseImg', 'quoteImg',
-      'quoteUnsupported', 'baseUnsupported', 'baseExpired', 'quoteExpired',
-      'baseConnect', 'quoteConnect', 'baseSpinner', 'quoteSpinner',
-      'baseWalletState', 'quoteWalletState'
-    ])
+    const els = Doc.idDescendants(table)
     this.base = {
       id: 0,
       cfg: null,

--- a/client/webserver/site/src/js/order.js
+++ b/client/webserver/site/src/js/order.js
@@ -25,10 +25,7 @@ export default class OrderPage extends BasePage {
     // app.order can only access active orders. If the order is not active,
     // we'll need to get the data from the database.
     if (!this.order) this.fetchOrder()
-    const page = this.page = Doc.parsePage(main, [
-      'cancelBttn', 'cancelRemain', 'cancelUnit', 'cancelForm', 'forms',
-      'cancelSubmit', 'cancelPass', 'status', 'matchBox', 'matchesLabel'
-    ])
+    const page = this.page = Doc.idDescendants(main)
 
     if (page.cancelBttn) {
       Doc.bind(page.cancelBttn, 'click', () => {

--- a/client/webserver/site/src/js/orders.js
+++ b/client/webserver/site/src/js/orders.js
@@ -16,10 +16,7 @@ export default class OrdersPage extends BasePage {
     // never-ending scrolling.
     this.offset = ''
     this.loading = false
-    const page = this.page = Doc.parsePage(main, [
-      'rowTmpl', 'tableBody', 'hostFilter', 'assetFilter', 'statusFilter',
-      'orderLoader', 'ordersTable', 'exportOrders'
-    ])
+    const page = this.page = Doc.idDescendants(main)
     this.orderTmpl = page.rowTmpl
     this.orderTmpl.remove()
 

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -15,19 +15,7 @@ export default class RegistrationPage extends BasePage {
     this.body = body
     this.notifiers = {}
     this.pwCache = {}
-    const page = this.page = Doc.parsePage(body, [
-      // Form 1: Set the application password
-      'appPWForm', 'appPW', 'appPWAgain', 'appPWSubmit', 'appPWErrMsg',
-      'showSeedRestore', 'seedRestore', 'seedInput', 'rememberPass',
-      // Form 2: Create Decred wallet
-      'newWalletForm',
-      // Form 3: Unlock Decred wallet
-      'unlockWalletForm',
-      // Form 4: Configure DEX server
-      'dexAddrForm', 'dexAddr',
-      // Form 5: Confirm DEX registration and pay fee
-      'confirmRegForm', 'failedRegForm', 'regFundsErr'
-    ])
+    const page = this.page = Doc.idDescendants(body)
 
     // Hide the form closers for the registration process.
     body.querySelectorAll('.form-closer').forEach(el => Doc.hide(el))

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -14,32 +14,7 @@ export default class SettingsPage extends BasePage {
     super()
     app = application
     this.body = body
-    const page = this.page = Doc.parsePage(body, [
-      'darkMode', 'commitHash',
-      'addADex',
-      // Form to configure DEX server
-      'dexAddrForm', 'dexAddr', 'certFile', 'selectedCert', 'removeCert', 'addCert',
-      'submitDEXAddr', 'dexAddrErr',
-      // Form to confirm DEX registration and pay fee
-      'forms', 'confirmRegForm',
-      // Export Account
-      'exchanges', 'authorizeAccountExportForm', 'exportAccountAppPass', 'authorizeExportAccountConfirm',
-      'exportAccountHost', 'exportAccountErr',
-      // Import Account
-      'importAccount', 'authorizeAccountImportForm', 'authorizeImportAccountConfirm', 'importAccountAppPass',
-      'accountFile', 'selectedAccount', 'removeAccount', 'addAccount', 'importAccountErr',
-      // Disable Account
-      'disableAccount', 'disableAccountForm', 'disableAccountConfirm', 'disableAccountAppPW',
-      'disableAccountHost', 'disableAccountErr',
-      // Change App Password
-      'changeAppPW', 'changeAppPWForm', 'appPW', 'newAppPW', 'confirmNewPW',
-      'submitNewPW', 'changePWErrMsg',
-      // Application seed
-      'exportSeedAuth', 'exportSeedPW', 'exportSeedSubmit', 'exportSeedErr',
-      'exportSeed', 'authorizeSeedDisplay', 'seedDiv',
-      // Others
-      'showPokes'
-    ])
+    const page = this.page = Doc.idDescendants(body)
 
     this.forms = page.forms.querySelectorAll(':scope > form')
 

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -15,27 +15,7 @@ export default class WalletsPage extends BasePage {
     super()
     app = application
     this.body = body
-    const page = this.page = Doc.parsePage(body, [
-      'rightBox',
-      // Table Rows
-      'assetArrow', 'balanceArrow', 'statusArrow', 'walletTable',
-      // Available markets
-      'markets', 'dexTitle', 'marketsBox', 'oneMarket', 'marketsFor',
-      'marketsCard',
-      // New wallet, unlock wallet, wallet settings
-      'walletForm', 'openForm',
-      // Wallet configuration
-      'walletReconfig', 'recfgAssetLogo', 'recfgAssetName', 'reconfigInputs',
-      'submitReconfig', 'reconfigErr', 'appPW', 'showChangePW', 'changePW',
-      'switchPWMsg', 'hideIcon', 'showIcon', 'newPW',
-      // Deposit
-      'deposit', 'depositName', 'depositAddress', 'newDepAddrBttn',
-      'depositErr', 'depositLogo',
-      // Withdraw
-      'withdrawForm', 'withdrawLogo', 'withdrawName', 'withdrawAddr',
-      'withdrawAmt', 'withdrawAvail', 'submitWithdraw', // 'withdrawFee',
-      'withdrawUnit', 'withdrawPW', 'withdrawErr'
-    ])
+    const page = this.page = Doc.idDescendants(body)
 
     // Read the document, storing some info about each asset's row.
     const getAction = (row, name) => row.querySelector(`[data-action=${name}]`)


### PR DESCRIPTION
Maintaining ID lists was tedious. Instead, create an object with all descendants that have id attributes set. The `page` object will be slightly larger in some places, since we'll pick up some form elements we're not using directly, but I'm looking to move those to `data-tmpl` attributes anyway.