### PR TITLE
server/eth: Implement FundingCoin.

### DIFF
--- a/server/asset/eth/coiner.go
+++ b/server/asset/eth/coiner.go
@@ -52,7 +52,7 @@ type swapCoin struct {
 // an error is returned then if something is different than expected. As such,
 // the swapCoin expects Confirmations to be called with confirmations
 // available at least once before the swap be trusted for swap initializations.
-func newSwapCoin(backend *Backend, coinID []byte, sct swapCoinType) (*swapCoin, error) {
+func (backend *Backend) newSwapCoin(coinID []byte, sct swapCoinType) (*swapCoin, error) {
 	switch sct {
 	case sctInit, sctRedeem:
 	default:
@@ -294,7 +294,7 @@ type amountCoin struct {
 	cID     *AmountCoinID
 }
 
-func newAmountCoin(backend *Backend, coinID []byte) (*amountCoin, error) {
+func (backend *Backend) newAmountCoin(coinID []byte) (*amountCoin, error) {
 	cID, err := DecodeCoinID(coinID)
 	if err != nil {
 		return nil, err
@@ -303,7 +303,7 @@ func newAmountCoin(backend *Backend, coinID []byte) (*amountCoin, error) {
 	if !ok {
 		return nil, errors.New("coin ID not an amount")
 	}
-	bal, pendingBal, err := accountBalance(backend, &aCoinID.Address)
+	bal, pendingBal, err := backend.accountBalance(&aCoinID.Address)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func newAmountCoin(backend *Backend, coinID []byte) (*amountCoin, error) {
 	}, nil
 }
 
-func accountBalance(backend *Backend, addr *common.Address) (balance, pendingBalance uint64, err error) {
+func (backend *Backend) accountBalance(addr *common.Address) (balance, pendingBalance uint64, err error) {
 	bigPendingBal, err := backend.node.pendingBalance(backend.rpcCtx, addr)
 	if err != nil {
 		return 0, 0, err
@@ -340,7 +340,7 @@ func accountBalance(backend *Backend, addr *common.Address) (balance, pendingBal
 // Confirmations returns one if an account currently has the funds to satisfy
 // its funding amount.
 func (c *amountCoin) Confirmations(_ context.Context) (int64, error) {
-	bal, pendingBal, err := accountBalance(c.backend, &c.cID.Address)
+	bal, pendingBal, err := c.backend.accountBalance(&c.cID.Address)
 	if err != nil {
 		return -1, err
 	}

--- a/server/asset/eth/coiner.go
+++ b/server/asset/eth/coiner.go
@@ -394,7 +394,7 @@ func (c *amountCoin) FeeRate() uint64 {
 }
 
 // Auth ensures that a user really has the keys to spend a funding coin by
-// sending a message signed by the funding coin address and its signature.
+// verifying a message signed by the funding coin address.
 func (c *amountCoin) Auth(pubkeys, sigs [][]byte, msg []byte) error {
 	if len(pubkeys) != 1 {
 		return fmt.Errorf("expected one pubkey but got %d", len(pubkeys))

--- a/server/asset/eth/coiner_test.go
+++ b/server/asset/eth/coiner_test.go
@@ -144,7 +144,7 @@ func TestNewSwapCoin(t *testing.T) {
 			node:         node,
 			contractAddr: *contractAddr,
 		}
-		sc, err := newSwapCoin(eth, test.coinID, test.ct)
+		sc, err := eth.newSwapCoin(test.coinID, test.ct)
 		if test.wantErr {
 			if err == nil {
 				t.Fatalf("expected error for test %q", test.name)
@@ -301,7 +301,7 @@ func TestConfirmations(t *testing.T) {
 			contractAddr: *contractAddr,
 		}
 
-		sc, err := newSwapCoin(eth, txCoinIDBytes, test.ct)
+		sc, err := eth.newSwapCoin(txCoinIDBytes, test.ct)
 		if err != nil {
 			t.Fatalf("unexpected error for test %q: %v", test.name, err)
 		}
@@ -452,7 +452,7 @@ func TestNewAmountCoin(t *testing.T) {
 		eth := &Backend{
 			node: node,
 		}
-		cnr, err := newAmountCoin(eth, test.acID)
+		cnr, err := eth.newAmountCoin(test.acID)
 		if test.wantErr {
 			if err == nil {
 				t.Fatalf("expected error for test %q", test.name)
@@ -513,7 +513,7 @@ func TestAccountBalance(t *testing.T) {
 		eth := &Backend{
 			node: node,
 		}
-		bal, pendingBal, err := accountBalance(eth, addr)
+		bal, pendingBal, err := eth.accountBalance(addr)
 		if test.wantErr {
 			if err == nil {
 				t.Fatalf("expected error for test %q", test.name)

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -261,6 +261,9 @@ const (
 // Errors if the amount of gwei is too big to fit fully into a uint64. The
 // passed wei parameter value is changed and is no longer useable.
 func ToGwei(wei *big.Int) (uint64, error) {
+	if wei.Cmp(big.NewInt(0)) == -1 {
+		return 0, fmt.Errorf("cannot convert negative wei value of %v to gwei", wei)
+	}
 	gweiFactorBig := big.NewInt(GweiFactor)
 	wei.Div(wei, gweiFactorBig)
 	if !wei.IsUint64() {

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -96,6 +96,8 @@ type ethFetcher interface {
 	peers(ctx context.Context) ([]*p2p.PeerInfo, error)
 	swap(ctx context.Context, secretHash [32]byte) (*swap.ETHSwapSwap, error)
 	transaction(ctx context.Context, hash common.Hash) (tx *types.Transaction, isMempool bool, err error)
+	balance(ctx context.Context, addr *common.Address) (bigBal *big.Int, err error)
+	pendingBalance(ctx context.Context, addr *common.Address) (bigPendingBal *big.Int, err error)
 }
 
 // Backend is an asset backend for Ethereum. It has methods for fetching output
@@ -317,9 +319,10 @@ func (eth *Backend) Redemption(redeemCoinID, contractCoinID []byte) (asset.Coin,
 	return cnr, nil
 }
 
-// FundingCoin is an unspent output.
-func (eth *Backend) FundingCoin(ctx context.Context, coinID []byte, redeemScript []byte) (asset.FundingCoin, error) {
-	return nil, notImplementedErr
+// FundingCoin is an unspent amount on the blockchain. It points to an account
+// that should maintain at least a certain value.
+func (eth *Backend) FundingCoin(ctx context.Context, coinID []byte, _ []byte) (asset.FundingCoin, error) {
+	return newAmountCoin(eth, coinID)
 }
 
 // ValidateCoinID attempts to decode the coinID.

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -98,6 +98,7 @@ type ethFetcher interface {
 	transaction(ctx context.Context, hash common.Hash) (tx *types.Transaction, isMempool bool, err error)
 	balance(ctx context.Context, addr *common.Address) (bigBal *big.Int, err error)
 	pendingBalance(ctx context.Context, addr *common.Address) (bigPendingBal *big.Int, err error)
+	txpoolContent(ctx context.Context) (txsMap map[string]map[string]map[int]*types.Transaction, err error)
 }
 
 // Backend is an asset backend for Ethereum. It has methods for fetching output

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -251,7 +251,7 @@ func (eth *Backend) BlockChannel(size int) <-chan *asset.BlockUpdate {
 
 // Contract is part of the asset.Backend interface.
 func (eth *Backend) Contract(coinID, _ []byte) (*asset.Contract, error) {
-	sc, err := newSwapCoin(eth, coinID, sctInit)
+	sc, err := eth.newSwapCoin(coinID, sctInit)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create coiner: %w", err)
 	}
@@ -301,7 +301,7 @@ func (eth *Backend) Synced() (bool, error) {
 // should be the transaction that sent a redemption, while contractCoinID is the
 // swap contract this redemption redeems.
 func (eth *Backend) Redemption(redeemCoinID, contractCoinID []byte) (asset.Coin, error) {
-	cnr, err := newSwapCoin(eth, redeemCoinID, sctRedeem)
+	cnr, err := eth.newSwapCoin(redeemCoinID, sctRedeem)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create coiner: %w", err)
 	}
@@ -322,7 +322,7 @@ func (eth *Backend) Redemption(redeemCoinID, contractCoinID []byte) (asset.Coin,
 // FundingCoin is an unspent amount on the blockchain. It points to an account
 // that should maintain at least a certain value.
 func (eth *Backend) FundingCoin(ctx context.Context, coinID []byte, _ []byte) (asset.FundingCoin, error) {
-	return newAmountCoin(eth, coinID)
+	return eth.newAmountCoin(coinID)
 }
 
 // ValidateCoinID attempts to decode the coinID.

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -76,6 +76,8 @@ type testNode struct {
 	balErr         error
 	pendingBal     *big.Int
 	pendingBalErr  error
+	txpoolCont     map[string]map[string]map[int]*types.Transaction
+	txpoolContErr  error
 }
 
 func (n *testNode) connect(ctx context.Context, ipc string, contractAddr *common.Address) error {
@@ -126,6 +128,10 @@ func (n *testNode) balance(ctx context.Context, addr *common.Address) (bigBal *b
 
 func (n *testNode) pendingBalance(ctx context.Context, addr *common.Address) (bigPendingBal *big.Int, err error) {
 	return n.pendingBal, n.pendingBalErr
+}
+
+func (n *testNode) txpoolContent(ctx context.Context) (map[string]map[string]map[int]*types.Transaction, error) {
+	return n.txpoolCont, n.txpoolContErr
 }
 
 func tSwap(bn int64, locktime, value *big.Int, state SwapState, participantAddr *common.Address) *swap.ETHSwapSwap {

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -72,6 +72,10 @@ type testNode struct {
 	tx             *types.Transaction
 	txIsMempool    bool
 	txErr          error
+	bal            *big.Int
+	balErr         error
+	pendingBal     *big.Int
+	pendingBalErr  error
 }
 
 func (n *testNode) connect(ctx context.Context, ipc string, contractAddr *common.Address) error {
@@ -114,6 +118,14 @@ func (n *testNode) swap(ctx context.Context, secretHash [32]byte) (*swap.ETHSwap
 
 func (n *testNode) transaction(ctx context.Context, hash common.Hash) (tx *types.Transaction, isMempool bool, err error) {
 	return n.tx, n.txIsMempool, n.txErr
+}
+
+func (n *testNode) balance(ctx context.Context, addr *common.Address) (bigBal *big.Int, err error) {
+	return n.bal, n.balErr
+}
+
+func (n *testNode) pendingBalance(ctx context.Context, addr *common.Address) (bigPendingBal *big.Int, err error) {
+	return n.pendingBal, n.pendingBalErr
 }
 
 func tSwap(bn int64, locktime, value *big.Int, state SwapState, participantAddr *common.Address) *swap.ETHSwapSwap {

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -120,3 +120,15 @@ func (c *rpcclient) swap(ctx context.Context, secretHash [32]byte) (*swap.ETHSwa
 func (c *rpcclient) transaction(ctx context.Context, hash common.Hash) (tx *types.Transaction, isMempool bool, err error) {
 	return c.ec.TransactionByHash(ctx, hash)
 }
+
+// balance gets the current balance held by an address.
+func (c *rpcclient) balance(ctx context.Context, addr *common.Address) (*big.Int, error) {
+	// The last argument is block number. nil will use the latest know
+	// block.
+	return c.ec.BalanceAt(ctx, *addr, nil)
+}
+
+// pendingBalance gets the current pending balance held by an address.
+func (c *rpcclient) pendingBalance(ctx context.Context, addr *common.Address) (*big.Int, error) {
+	return c.ec.PendingBalanceAt(ctx, *addr)
+}

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -132,3 +132,9 @@ func (c *rpcclient) balance(ctx context.Context, addr *common.Address) (*big.Int
 func (c *rpcclient) pendingBalance(ctx context.Context, addr *common.Address) (*big.Int, error) {
 	return c.ec.PendingBalanceAt(ctx, *addr)
 }
+
+// txpoolContent retrieves all transactions from the mempool.
+func (c *rpcclient) txpoolContent(ctx context.Context) (map[string]map[string]map[int]*types.Transaction, error) {
+	var m map[string]map[string]map[int]*types.Transaction
+	return m, c.c.CallContext(ctx, &m, "txpool_content")
+}

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -73,9 +73,12 @@ func TestBestBlockHash(t *testing.T) {
 }
 
 func TestBestHeader(t *testing.T) {
-	_, err := ethClient.bestHeader(ctx)
+	bh, err := ethClient.bestHeader(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if bh == nil {
+		t.Fatal("nil return")
 	}
 }
 
@@ -84,9 +87,12 @@ func TestBlock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = ethClient.block(ctx, h)
+	b, err := ethClient.block(ctx, h)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if b == nil {
+		t.Fatal("nil return")
 	}
 }
 
@@ -98,9 +104,12 @@ func TestBlockNumber(t *testing.T) {
 }
 
 func TestPeers(t *testing.T) {
-	_, err := ethClient.peers(ctx)
+	p, err := ethClient.peers(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if p == nil {
+		t.Fatal("nil return")
 	}
 }
 
@@ -109,21 +118,28 @@ func TestSyncProgress(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// syncProgress may return nil and is documented as such.
 }
 
 func TestSuggestGasPrice(t *testing.T) {
-	_, err := ethClient.suggestGasPrice(ctx)
+	sgp, err := ethClient.suggestGasPrice(ctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if sgp == nil {
+		t.Fatal("nil return")
 	}
 }
 
 func TestSwap(t *testing.T) {
 	var secretHash [32]byte
 	copy(secretHash[:], encode.RandomBytes(32))
-	_, err := ethClient.swap(ctx, secretHash)
+	s, err := ethClient.swap(ctx, secretHash)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if s == nil {
+		t.Fatal("nil return")
 	}
 }
 
@@ -139,16 +155,22 @@ func TestTransaction(t *testing.T) {
 
 func TestBalance(t *testing.T) {
 	addr := new(common.Address)
-	_, err := ethClient.balance(ctx, addr)
+	b, err := ethClient.balance(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if b == nil {
+		t.Fatal("nil return")
 	}
 }
 
 func TestPendingBalance(t *testing.T) {
 	addr := new(common.Address)
-	_, err := ethClient.pendingBalance(ctx, addr)
+	pb, err := ethClient.pendingBalance(ctx, addr)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if pb == nil {
+		t.Fatal("nil return")
 	}
 }

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -136,3 +136,19 @@ func TestTransaction(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestBalance(t *testing.T) {
+	addr := new(common.Address)
+	_, err := ethClient.balance(ctx, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPendingBalance(t *testing.T) {
+	addr := new(common.Address)
+	_, err := ethClient.pendingBalance(ctx, addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -174,3 +174,13 @@ func TestPendingBalance(t *testing.T) {
 		t.Fatal("nil return")
 	}
 }
+
+func TestTxPoolContent(t *testing.T) {
+	content, err := ethClient.txpoolContent(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content == nil {
+		t.Fatal("nil return")
+	}
+}


### PR DESCRIPTION
    A funding coin represents value on the blockchain. For utxo this is a
    concrete value, but for account based coins it is nebulous and changing.
    For ethereum, the funding coin is represented by an address or account
    and a value that account must have.

    Authorization of the use of those funds is very similar to other coins,
    but the user only need prove they own the keys for one account or
    address.

part of #1154 