### PR TITLE
direct seeded wallet password setup on reconfigure

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1829,13 +1829,18 @@ func (c *Core) assetSeedAndPass(assetID uint32, crypter encrypt.Crypter) (seed, 
 		return nil, nil, fmt.Errorf("app seed decryption error: %w", err)
 	}
 
+	seed, pass = assetSeedAndPass(assetID, appSeed)
+	return seed, pass, nil
+}
+
+func assetSeedAndPass(assetID uint32, appSeed []byte) ([]byte, []byte) {
 	b := make([]byte, len(appSeed)+4)
 	copy(b, appSeed)
 	binary.BigEndian.PutUint32(b[len(appSeed):], assetID)
 
 	s := blake256.Sum256(b)
 	p := blake256.Sum256(s[:])
-	return s[:], p[:], nil
+	return s[:], p[:]
 }
 
 // assetDataDirectory is a directory for a wallet to use for local storage.


### PR DESCRIPTION
When reconfiguring a seeded wallet (new or existing), where the password is now deterministic and not user-changeable, avoid calling `setWalletPassword`, which unlocks and locks the wallet to test the password's validity. Just set the `pw` and `encPW` directly.

This also prevents `SetWalletPassword` from updating the password on a seeded wallet.