### PR TITLE
btc spv: give wallet precedence for block notifications

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2456,7 +2456,6 @@ func (btc *ExchangeWallet) watchBlocks(ctx context.Context) {
 				}
 				blockAllowance := walletBlockAllowance
 				syncStatus, err := btc.node.syncStatus()
-
 				if err != nil {
 					btc.log.Errorf("Error retreiving sync status before queuing polled block: %v", err)
 				} else if syncStatus.Syncing {

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -775,7 +775,7 @@ func (btc *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		btc.watchBlocks(ctx)
+		btc.watchBlocks(ctx, blockTicker, walletBlockAllowance)
 		btc.shutdown()
 	}()
 	return &wg, nil
@@ -2393,8 +2393,8 @@ func (btc *ExchangeWallet) RegFeeConfirmations(_ context.Context, id dex.Bytes) 
 
 // watchBlocks pings for new blocks and runs the tipChange callback function
 // when the block changes.
-func (btc *ExchangeWallet) watchBlocks(ctx context.Context) {
-	ticker := time.NewTicker(blockTicker)
+func (btc *ExchangeWallet) watchBlocks(ctx context.Context, blockPeriod, walletAllowance time.Duration) {
+	ticker := time.NewTicker(blockPeriod)
 	defer ticker.Stop()
 
 	var walletBlock <-chan *block
@@ -2462,7 +2462,7 @@ func (btc *ExchangeWallet) watchBlocks(ctx context.Context) {
 				}
 				queuedBlock = &polledBlock{
 					block: newTip,
-					queue: time.AfterFunc(walletBlockAllowance, func() {
+					queue: time.AfterFunc(walletAllowance, func() {
 						dequeuedBlock <- newTip
 					}),
 				}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -630,7 +630,7 @@ func tNewWallet(segwit bool, walletType string) (*ExchangeWallet, *testData, fun
 		hash:   *bestHash,
 	}
 	wallet.tipMtx.Unlock()
-	go wallet.watchBlocks(walletCtx)
+	go wallet.watchBlocks(walletCtx, blockTicker, walletBlockAllowance)
 
 	return wallet, data, shutdown, nil
 }

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -605,7 +605,7 @@ func tNewWallet(segwit bool, walletType string) (*ExchangeWallet, *testData, fun
 				chainParams: &chaincfg.MainNetParams,
 				wallet:      &tBtcWallet{data},
 				cl:          neutrinoClient,
-				tipChan:     make(chan *block),
+				tipChan:     make(chan *block, 1),
 				chainClient: nil,
 				acctNum:     0,
 				txBlocks:    data.dbBlockForTx,

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -617,8 +617,10 @@ func tNewWallet(segwit bool, walletType string) (*ExchangeWallet, *testData, fun
 		return nil, nil, nil, err
 	}
 	wallet.tipMtx.Lock()
-	wallet.currentTip = &block{height: data.GetBestBlockHeight(),
-		hash: bestHash.String()}
+	wallet.currentTip = &block{
+		height: data.GetBestBlockHeight(),
+		hash:   *bestHash,
+	}
 	wallet.tipMtx.Unlock()
 	go wallet.run(walletCtx)
 
@@ -2058,7 +2060,10 @@ func testFindRedemption(t *testing.T, segwit bool, walletType string) {
 	node.getCFilterScripts[*redeemBlockHash] = [][]byte{pkScript}
 
 	// Update currentTip from "RPC". Normally run() would do this.
-	wallet.checkForNewBlocks(tCtx)
+	wallet.reportNewTip(tCtx, &block{
+		hash:   *redeemBlockHash,
+		height: contractHeight + 2,
+	})
 
 	// Check find redemption result.
 	_, checkSecret, err := wallet.FindRedemption(tCtx, coinID)

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -221,7 +221,7 @@ func (wc *rpcClient) getBestBlockHeight() (int32, error) {
 	if err != nil {
 		return -1, err
 	}
-	header, err := wc.getBlockHeader(tipHash.String())
+	header, err := wc.getBlockHeader(tipHash)
 	if err != nil {
 		return -1, err
 	}
@@ -503,10 +503,10 @@ func (wc *rpcClient) swapConfirmations(txHash *chainhash.Hash, vout uint32, _ []
 }
 
 // getBlockHeader gets the block header for the specified block hash.
-func (wc *rpcClient) getBlockHeader(blockHash string) (*blockHeader, error) {
+func (wc *rpcClient) getBlockHeader(blockHash *chainhash.Hash) (*blockHeader, error) {
 	blkHeader := new(blockHeader)
 	err := wc.call(methodGetBlockHeader,
-		anylist{blockHash, true}, blkHeader)
+		anylist{blockHash.String(), true}, blkHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -514,8 +514,8 @@ func (wc *rpcClient) getBlockHeader(blockHash string) (*blockHeader, error) {
 }
 
 // getBlockHeight gets the mainchain height for the specified block.
-func (wc *rpcClient) getBlockHeight(h *chainhash.Hash) (int32, error) {
-	hdr, err := wc.getBlockHeader(h.String())
+func (wc *rpcClient) getBlockHeight(blockHash *chainhash.Hash) (int32, error) {
+	hdr, err := wc.getBlockHeader(blockHash)
 	if err != nil {
 		return -1, err
 	}

--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -303,7 +303,7 @@ func loadSPVWallet(dbDir string, logger dex.Logger, connectPeers []string, chain
 		checkpoints:  make(map[outPoint]*scanCheckpoint),
 		log:          logger,
 		connectPeers: connectPeers,
-		tipChan:      make(chan *block, 1),
+		tipChan:      make(chan *block, 8),
 	}
 }
 
@@ -925,10 +925,9 @@ func (w *spvWallet) connect(ctx context.Context, wg *sync.WaitGroup) error {
 	notes := make(<-chan interface{})
 	if w.chainClient != nil {
 		notes = w.chainClient.Notifications()
-		if err := w.chainClient.NotifyBlocks(); err != nil {
+		if err = w.chainClient.NotifyBlocks(); err != nil {
 			return fmt.Errorf("failed to subscribe to block notifications: %w", err)
 		}
-
 	}
 
 	// Nanny for the caches checkpoints and txBlocks caches.

--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -963,6 +963,13 @@ func (w *spvWallet) connect(ctx context.Context, wg *sync.WaitGroup) error {
 				if len(note.AttachedBlocks) > 0 {
 					lastBlock := note.AttachedBlocks[len(note.AttachedBlocks)-1]
 					syncTarget := atomic.LoadInt32(&w.syncTarget)
+
+					for ib := range note.AttachedBlocks {
+						for _, nt := range note.AttachedBlocks[ib].Transactions {
+							w.log.Debugf("Block %d contains wallet transaction %v", note.AttachedBlocks[ib].Height, nt.Hash)
+						}
+					}
+
 					if syncTarget == 0 || (lastBlock.Height < syncTarget && lastBlock.Height%10_000 != 0) {
 						continue
 					}

--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -480,7 +480,12 @@ func (w *spvWallet) syncStatus() (*syncStatus, error) {
 		synced = true
 	}
 
-	atomic.StoreInt32(&w.syncTarget, target)
+	if atomic.SwapInt32(&w.syncTarget, target) == 0 && target > 0 {
+		w.tipChan <- &block{
+			hash:   blk.Hash,
+			height: int64(blk.Height),
+		}
+	}
 
 	return &syncStatus{
 		Target:  target,

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -9,6 +9,7 @@ package btc
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -752,6 +753,9 @@ func TestTryBlocksWithNotifier(t *testing.T) {
 	}
 
 	addBlock()
+
+	// Prime the sync target to avoid the syncStatus tip send here.
+	atomic.StoreInt32(&spv.syncTarget, 1)
 
 	// It should not come through on the block tick, since it will be cached.
 	if getNote(blockTicker * 2) {

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -267,6 +267,10 @@ func (c *tBtcWallet) signTransaction(tx *wire.MsgTx) error {
 	return nil
 }
 
+func (c *tBtcWallet) txNotifications() wallet.TransactionNotificationsClient {
+	return wallet.TransactionNotificationsClient{}
+}
+
 type tNeutrinoClient struct {
 	*testData
 }

--- a/client/asset/btc/wallet.go
+++ b/client/asset/btc/wallet.go
@@ -37,10 +37,14 @@ type Wallet interface {
 	locked() bool
 	syncStatus() (*syncStatus, error)
 	swapConfirmations(txHash *chainhash.Hash, vout uint32, contract []byte, startTime time.Time) (confs uint32, spent bool, err error)
-	getBlockHeader(blockHash string) (*blockHeader, error)
+	getBlockHeader(blockHash *chainhash.Hash) (*blockHeader, error)
 	ownsAddress(addr btcutil.Address) (bool, error)
 	getWalletTransaction(txHash *chainhash.Hash) (*GetTransactionResult, error)
 	searchBlockForRedemptions(ctx context.Context, reqs map[outPoint]*findRedemptionReq, blockHash chainhash.Hash) (discovered map[outPoint]*findRedemptionResult)
 	findRedemptionsInMempool(ctx context.Context, reqs map[outPoint]*findRedemptionReq) (discovered map[outPoint]*findRedemptionResult)
 	getBlock(h chainhash.Hash) (*wire.MsgBlock, error)
+}
+
+type tipNotifier interface {
+	tipFeed() <-chan *block
 }

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -935,7 +935,7 @@ func (dc *dexConnection) subPriceFeed() {
 		var msgErr *msgjson.Error
 		// Ignore old servers' errors.
 		if !errors.As(err, &msgErr) || msgErr.Code != msgjson.UnknownMessageType {
-			dc.log.Errorf("unable to fetch market overview: %w", err)
+			dc.log.Errorf("unable to fetch market overview: %v", err)
 		}
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	decred.org/dcrwallet/v2 v2.0.0-20210913145543-714c2f555f04
-	github.com/btcsuite/btcd v0.22.0-beta.0.20210803133449-f5a1fb9965e4
+	github.com/btcsuite/btcd v0.22.0-beta.0.20211026140004-31791ba4dc6e
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/btcutil v1.0.3-0.20210527170813-e2ba6805a890 // note: hoists btcd's own require of btcutil
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,9 @@ github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcug
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.21.0-beta.0.20201208033208-6bd4c64a54fa/go.mod h1:Sv4JPQ3/M+teHz9Bo5jBpkNcP0x6r7rdihlNL/7tTAs=
 github.com/btcsuite/btcd v0.21.0-beta.0.20210426180113-7eba688b65e5/go.mod h1:9n5ntfhhHQBIhUvlhDvD3Qg6fRUj4jkN0VB8L8svzOA=
-github.com/btcsuite/btcd v0.22.0-beta.0.20210803133449-f5a1fb9965e4 h1:EmyLrldY44jDVa3dQ2iscj1S6ExuVJhRzCZBOXo93r0=
 github.com/btcsuite/btcd v0.22.0-beta.0.20210803133449-f5a1fb9965e4/go.mod h1:9n5ntfhhHQBIhUvlhDvD3Qg6fRUj4jkN0VB8L8svzOA=
+github.com/btcsuite/btcd v0.22.0-beta.0.20211026140004-31791ba4dc6e h1:d0NkvbJGQThTkhypOdtf5Orxe2+dUHLB86pQ4EXwrTo=
+github.com/btcsuite/btcd v0.22.0-beta.0.20211026140004-31791ba4dc6e/go.mod h1:3PH+KbvLFfzBTCevQenPiDedjGQGt6aa70dVjJDWGTA=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=


### PR DESCRIPTION
This solves a couple of issues with bitcoin SPV syncing. 

1. Neutrino stores the block header before requesting filter headers and looking for wallet scripts, so the `balanceUpdate` requested by `Core` can come before the wallet has seen new funds. This was obvious during testnet syncing when outputs from even 1000s of blocks ago were not seen (block headers are stored in batches during initial sync) until an additional block was mined after sync.
2. Block notifications were being sent from `ExchangeWallet` before the `xcWallet` was added to the `wallets` map in `*Core`, resulting in error messages saying `non-existent 0 wallet should exist`.

This solution gives wallet notifications precedence by queuing polled new tips temporarily to allow the wallet notifications to come through. This is important, because neutrino stores the block headers before requesting filters, and doesn't send the `FilteredBlockConnected` notification until after the filters are received and processed, allowing ample time for a poll to sneak in and grab a header whose corresponding filter hasn't been checked yet.