### PR TITLE
client/core: only subscribe to price feed for persistent conns

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -935,7 +935,7 @@ func (dc *dexConnection) subPriceFeed() {
 		var msgErr *msgjson.Error
 		// Ignore old servers' errors.
 		if !errors.As(err, &msgErr) || msgErr.Code != msgjson.UnknownMessageType {
-			dc.log.Errorf("unable to fetch market overview: %v", err)
+			dc.log.Errorf("subPriceFeed: unable to fetch market overview: %v", err)
 		}
 		return
 	}


### PR DESCRIPTION
Temporary DEX connections should not subscribe to the price feed.
This launches the `subPriceFeed` goroutine only when the listen goroutine
is started with a persistent dex connection.