### PR TITLE
trade_simnet_test fixes

### DIFF
--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -780,7 +780,10 @@ func (w *spvWallet) swapConfirmations(txHash *chainhash.Hash, vout uint32, pkScr
 	var assumedMempool bool
 	switch err {
 	case WalletTransactionNotFound:
+		w.log.Tracef("swapConfirmations - WalletTransactionNotFound: %v:%d", txHash, vout)
 	case SpentStatusUnknown:
+		w.log.Tracef("swapConfirmations - SpentStatusUnknown: %v:%d (block %v, confs %d)",
+			txHash, vout, blockHash, confs)
 		if blockHash == nil {
 			// We generated this swap, but it probably hasn't been mined yet.
 			// It's SpentStatusUnknown because the wallet doesn't track the
@@ -804,6 +807,8 @@ func (w *spvWallet) swapConfirmations(txHash *chainhash.Hash, vout uint32, pkScr
 	}
 
 	// Our last option is neutrino.
+	w.log.Tracef("swapConfirmations - scanFilters: %v:%d (block %v, start time %v)",
+		txHash, vout, blockHash, startTime)
 	utxo, err := w.scanFilters(txHash, vout, pkScript, startTime, blockHash)
 	if err != nil {
 		return 0, false, err
@@ -811,6 +816,8 @@ func (w *spvWallet) swapConfirmations(txHash *chainhash.Hash, vout uint32, pkScr
 
 	if utxo.spend == nil && utxo.blockHash == nil {
 		if assumedMempool {
+			w.log.Tracef("swapConfirmations - scanFilters did not find %v:%d, assuming in mempool.",
+				txHash, vout)
 			return 0, false, nil
 		}
 		return 0, false, fmt.Errorf("output %s:%v not found with search parameters startTime = %s, pkScript = %x",
@@ -1273,6 +1280,8 @@ func (w *spvWallet) scanFilters(txHash *chainhash.Hash, vout uint32, pkScript []
 	// If we found a block, let's store a reference in our local database so we
 	// can maybe bypass a long search next time.
 	if utxo.blockHash != nil {
+		w.log.Debugf("cfilters scan SUCCEEDED for %v:%d. block hash: %v, spent: %v",
+			txHash, vout, utxo.blockHash, utxo.spend != nil)
 		w.storeTxBlock(*txHash, *utxo.blockHash)
 	}
 
@@ -1380,6 +1389,7 @@ search:
 			continue search
 		}
 		// Pull the block.
+		w.log.Tracef("Block %v matched pkScript %v. Pulling the block...", blockHash, pkScript)
 		block, err := w.cl.GetBlock(*blockHash)
 		if err != nil {
 			return nil, fmt.Errorf("GetBlock error: %v", err)
@@ -1400,6 +1410,8 @@ search:
 							blockHash:   *block.Hash(),
 							blockHeight: uint32(height),
 						}
+						w.log.Tracef("Found txn %v spending %v in block %v (%d)", res.spend.txHash,
+							txHash, res.spend.blockHash, res.spend.blockHeight)
 						if res.blockHash != nil {
 							break search
 						}
@@ -1418,6 +1430,7 @@ search:
 					res.blockHash = block.Hash()
 					res.blockHeight = uint32(height)
 					res.txOut = txOut
+					w.log.Tracef("Found txn %v in block %v (%d)", txHash, res.blockHash, height)
 					if res.spend != nil {
 						break search
 					}

--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -1370,7 +1370,7 @@ search:
 		if res.spend != nil && res.blockHash == nil {
 			w.log.Warnf("A spending input (%s) was found during the scan but the output (%s) "+
 				"itself wasn't found. Was the startBlockHeight early enough?",
-				newOutPoint(&res.spend.blockHash, res.spend.vin),
+				newOutPoint(&res.spend.txHash, res.spend.vin),
 				newOutPoint(&txHash, vout),
 			)
 			return res, nil

--- a/client/core/harness_norace.go
+++ b/client/core/harness_norace.go
@@ -1,0 +1,6 @@
+//go:build !race && harness
+// +build !race,harness
+
+package core
+
+const race = false

--- a/client/core/harness_race.go
+++ b/client/core/harness_race.go
@@ -1,0 +1,6 @@
+//go:build race && harness
+// +build race,harness
+
+package core
+
+const race = true

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -880,6 +880,9 @@ func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) boo
 	if match.Status == order.MakerSwapCast {
 		// Get the confirmation count on the maker's coin.
 		if match.Side == order.Taker {
+			toAssetID := t.wallets.toAsset.ID
+			t.dc.log.Tracef("Checking confirmations on COUNTERPARTY swap txn %v (%s)...",
+				coinIDString(toAssetID, match.MetaData.Proof.MakerSwap), unbip(toAssetID))
 			// If the maker is the counterparty, we can determine swappability
 			// based on the confirmations.
 			confs, req, changed, spent := t.counterPartyConfirms(ctx, match)
@@ -896,6 +899,8 @@ func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) boo
 			return ready
 		}
 		// If we're the maker, check the confirmations anyway so we can notify.
+		t.dc.log.Tracef("Checking confirmations on our OWN swap txn %v (%s)...",
+			coinIDString(wallet.AssetID, match.MetaData.Proof.MakerSwap), unbip(wallet.AssetID))
 		confs, spent, err := wallet.SwapConfirmations(ctx, match.MetaData.Proof.MakerSwap,
 			match.MetaData.Proof.Script, match.MetaData.Stamp)
 		if err != nil {


### PR DESCRIPTION
Work toward fixing https://github.com/decred/dcrdex/issues/1246, just the trade tests though, not the order status or pending requests tests.

Allow spv wallet to sync before funding it.  Wait a bit after funding it for it to filter the new blocks and update balance.

Add a sleepFactor that multiplies various test sleeps when the race detector is enabled.

Add a sleep in places before mining blocks, where it follows an SPV wallet doing a broadcast.  The send transaction commands return from wallet before the txn actually reaches miners.  Always was a race we were winning until SPV.