### PR TITLE
client/core: make copy of spot price map

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -941,11 +941,11 @@ func (dc *dexConnection) subPriceFeed() {
 	}
 
 	// We expect there to be a map in handlePriceUpdateNote.
-	if spots == nil {
-		spots = make(map[string]*msgjson.Spot)
+	spotsCopy := make(map[string]*msgjson.Spot, len(spots))
+	for mkt, spot := range spots {
+		spotsCopy[mkt] = spot
 	}
-
-	dc.notify(newSpotPriceNote(dc.acct.host, spots)) // before putting the map in dc.spots
+	dc.notify(newSpotPriceNote(dc.acct.host, spotsCopy)) // consumers read spotsCopy async with this call
 
 	dc.spotsMtx.Lock()
 	dc.spots = spots


### PR DESCRIPTION
This is a second crack at avoiding a data race with the spot price map. Initially "fixed" in https://github.com/decred/dcrdex/pull/1240.

The notification consumers process the spot price map
asynchronously, so we have to make a copy of the map
that we intend to store in dc.spots.

<details>

```
==================
WARNING: DATA RACE
Write at 0x00c0152baa20 by goroutine 52:
  runtime.mapassign_faststr()
      /home/jon/go117/src/runtime/map_faststr.go:202 +0x0
  decred.org/dcrdex/client/core.handlePriceUpdateNote()
      /home/jon/github/decred/dcrdex/client/core/bookie.go:967 +0x33d
  decred.org/dcrdex/client/core.(*Core).listen.func1()
      /home/jon/github/decred/dcrdex/client/core/core.go:5513 +0x16f
  decred.org/dcrdex/client/core.(*Core).listen.func2()
      /home/jon/github/decred/dcrdex/client/core/core.go:5527 +0xd9

Previous read at 0x00c0152baa20 by goroutine 88:
  reflect.maplen()
      /home/jon/go117/src/runtime/map.go:1360 +0x0
  reflect.Value.Len()
      /home/jon/go117/src/reflect/value.go:1496 +0x268
  encoding/json.mapEncoder.encode()
      /home/jon/go117/src/encoding/json/encode.go:797 +0x3e4
  encoding/json.mapEncoder.encode-fm()
      /home/jon/go117/src/encoding/json/encode.go:779 +0x90
  encoding/json.structEncoder.encode()
      /home/jon/go117/src/encoding/json/encode.go:761 +0x2ba
  encoding/json.structEncoder.encode-fm()
      /home/jon/go117/src/encoding/json/encode.go:732 +0xdb
  encoding/json.ptrEncoder.encode()
      /home/jon/go117/src/encoding/json/encode.go:945 +0x3f1
  encoding/json.ptrEncoder.encode-fm()
      /home/jon/go117/src/encoding/json/encode.go:930 +0x90
  encoding/json.(*encodeState).reflectValue()
      /home/jon/go117/src/encoding/json/encode.go:360 +0x88
  encoding/json.(*encodeState).marshal()
      /home/jon/go117/src/encoding/json/encode.go:332 +0x22e
  encoding/json.Marshal()
      /home/jon/go117/src/encoding/json/encode.go:161 +0x51
  decred.org/dcrdex/dex/msgjson.NewNotification()
      /home/jon/github/decred/dcrdex/dex/msgjson/types.go:397 +0x6a
  decred.org/dcrdex/client/websocket.(*Server).Notify()
      /home/jon/github/decred/dcrdex/client/websocket/websocket.go:172 +0x84
  decred.org/dcrdex/client/webserver.(*WebServer).readNotifications()
      /home/jon/github/decred/dcrdex/client/webserver/webserver.go:610 +0xb5
  decred.org/dcrdex/client/webserver.(*WebServer).Connect.func4()
      /home/jon/github/decred/dcrdex/client/webserver/webserver.go:460 +0xbc

Goroutine 52 (running) created at:
  decred.org/dcrdex/client/core.(*Core).listen()
      /home/jon/github/decred/dcrdex/client/core/core.go:5524 +0x444
  decred.org/dcrdex/client/core.(*Core).connectDEX·dwrap·63()
      /home/jon/github/decred/dcrdex/client/core/core.go:5168 +0x47

Goroutine 88 (running) created at:
  decred.org/dcrdex/client/webserver.(*WebServer).Connect()
      /home/jon/github/decred/dcrdex/client/webserver/webserver.go:458 +0x86d
  decred.org/dcrdex/dex.(*ConnectionMaster).Connect()
      /home/jon/github/decred/dcrdex/dex/runner.go:106 +0x9b
  main.mainCore.func5()
      /home/jon/github/decred/dcrdex/client/cmd/dexc/main.go:175 +0x185
==================

```

</details>