### PR TITLE
server/eth: Implement ValidateContract.

### DIFF
--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -59,6 +59,9 @@ const (
 	// which holds the ETH, an amount of ETH in gwei, and a random nonce to
 	// avoid duplicate coin IDs.
 	CIDAmount
+	// SecretHashSize is the byte-length of the hash of the secret key used
+	// in swaps.
+	SecretHashSize = 32
 )
 
 // CoinID is an interface that objects which represent different types of ETH

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -18,7 +18,7 @@ import (
 
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
-	swap "decred.org/dcrdex/dex/networks/eth"
+	dexeth "decred.org/dcrdex/dex/networks/eth"
 	"decred.org/dcrdex/server/asset"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -74,7 +74,7 @@ func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
 
 // UnitInfo returns the dex.UnitInfo for the asset.
 func (d *Driver) UnitInfo() dex.UnitInfo {
-	return swap.UnitInfo
+	return dexeth.UnitInfo
 }
 
 // ethFetcher represents a blockchain information fetcher. In practice, it is
@@ -94,7 +94,7 @@ type ethFetcher interface {
 	syncProgress(ctx context.Context) (*ethereum.SyncProgress, error)
 	blockNumber(ctx context.Context) (uint64, error)
 	peers(ctx context.Context) ([]*p2p.PeerInfo, error)
-	swap(ctx context.Context, secretHash [32]byte) (*swap.ETHSwapSwap, error)
+	swap(ctx context.Context, secretHash [32]byte) (*dexeth.ETHSwapSwap, error)
 	transaction(ctx context.Context, hash common.Hash) (tx *types.Transaction, isMempool bool, err error)
 }
 
@@ -346,9 +346,13 @@ func (eth *Backend) ValidateCoinID(coinID []byte) (string, error) {
 }
 
 // ValidateContract ensures that the swap contract is constructed properly, and
-// contains valid sender and receiver addresses.
-func (eth *Backend) ValidateContract(contract []byte) error {
-	return notImplementedErr
+// contains valid counterparty, secret hash, and locktime.
+func (eth *Backend) ValidateContract(txdata []byte) error {
+	_, err := dexeth.ParseInitiateData(txdata)
+	if err != nil {
+		return fmt.Errorf("unable to parse contract txdata: %w", err)
+	}
+	return nil
 }
 
 // CheckAddress checks that the given address is parseable.

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -345,12 +345,10 @@ func (eth *Backend) ValidateCoinID(coinID []byte) (string, error) {
 	return coinId.String(), nil
 }
 
-// ValidateContract ensures that the swap contract is constructed properly, and
-// contains valid counterparty, secret hash, and locktime.
-func (eth *Backend) ValidateContract(txdata []byte) error {
-	_, err := dexeth.ParseInitiateData(txdata)
-	if err != nil {
-		return fmt.Errorf("unable to parse contract txdata: %w", err)
+// ValidateContract ensures that the secret hash is the correct length.
+func (eth *Backend) ValidateContract(secretHash []byte) error {
+	if len(secretHash) != SecretHashSize {
+		return fmt.Errorf("secret hash is wrong size: want %d but got %d", SecretHashSize, len(secretHash))
 	}
 	return nil
 }

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -688,25 +688,21 @@ func TestTxData(t *testing.T) {
 }
 
 func TestValidateContract(t *testing.T) {
-	contractAddr := new(common.Address)
-	copy(contractAddr[:], encode.RandomBytes(20))
 	tests := []struct {
-		name    string
-		txdata  []byte
-		wantErr bool
+		name       string
+		secretHash []byte
+		wantErr    bool
 	}{{
-		name:   "ok",
-		txdata: initCalldata,
+		name:       "ok",
+		secretHash: make([]byte, 32),
 	}, {
-		name:    "bad contract",
-		txdata:  initCalldata[1:],
-		wantErr: true,
+		name:       "wrong size",
+		secretHash: make([]byte, 31),
+		wantErr:    true,
 	}}
 	for _, test := range tests {
-		eth := &Backend{
-			contractAddr: *contractAddr,
-		}
-		err := eth.ValidateContract(test.txdata)
+		eth := new(Backend)
+		err := eth.ValidateContract(test.secretHash)
 		if test.wantErr {
 			if err == nil {
 				t.Fatalf("expected error for test %q", test.name)

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -686,3 +686,35 @@ func TestTxData(t *testing.T) {
 		t.Fatalf("TxData error: %v", err)
 	}
 }
+
+func TestValidateContract(t *testing.T) {
+	contractAddr := new(common.Address)
+	copy(contractAddr[:], encode.RandomBytes(20))
+	tests := []struct {
+		name    string
+		txdata  []byte
+		wantErr bool
+	}{{
+		name:   "ok",
+		txdata: initCalldata,
+	}, {
+		name:    "bad contract",
+		txdata:  initCalldata[1:],
+		wantErr: true,
+	}}
+	for _, test := range tests {
+		eth := &Backend{
+			contractAddr: *contractAddr,
+		}
+		err := eth.ValidateContract(test.txdata)
+		if test.wantErr {
+			if err == nil {
+				t.Fatalf("expected error for test %q", test.name)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("unexpected error for test %q: %v", test.name, err)
+		}
+	}
+}


### PR DESCRIPTION
    server/eth: Implement ValidateContract.

    Require the the Contract field of msgjson.Init be filled with the txdata
    used to create the swap. Validate that txdata to be of the correct
    format sending the expected types of arguments.

work towards #1154 depends on #1235 