### PR TITLE
client/asset: Use max sequence only for refunds.

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1688,9 +1688,6 @@ func (btc *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 		addresses = append(addresses, receiver)
 		contracts = append(contracts, contract)
 		txIn := wire.NewTxIn(cinfo.output.wireOutPoint(), nil, nil)
-		// Enable locktime
-		// https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#Spending_wallet_policy
-		txIn.Sequence = wire.MaxTxInSequenceNum - 1
 		msgTx.AddTxIn(txIn)
 		values = append(values, cinfo.output.value)
 		totalIn += cinfo.output.value
@@ -2228,6 +2225,9 @@ func (btc *ExchangeWallet) refundTx(txHash *chainhash.Hash, vout uint32, contrac
 	msgTx.LockTime = uint32(lockTime)
 	prevOut := wire.NewOutPoint(txHash, vout)
 	txIn := wire.NewTxIn(prevOut, []byte{}, nil)
+	// Enable the OP_CHECKLOCKTIMEVERIFY opcode to be used.
+	//
+	// https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#Spending_wallet_policy
 	txIn.Sequence = wire.MaxTxInSequenceNum - 1
 	msgTx.AddTxIn(txIn)
 	// Calculate fees and add the change output.

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1379,11 +1379,6 @@ func (dcr *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 		contracts = append(contracts, contract)
 		prevOut := cinfo.output.wireOutPoint()
 		txIn := wire.NewTxIn(prevOut, int64(cinfo.output.value), []byte{})
-		// Sequence = 0xffffffff - 1 is special value that marks the transaction as
-		// irreplaceable and enables the use of lock time.
-		//
-		// https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#Spending_wallet_policy
-		txIn.Sequence = wire.MaxTxInSequenceNum - 1
 		msgTx.AddTxIn(txIn)
 		totalIn += cinfo.output.value
 	}
@@ -2122,6 +2117,9 @@ func (dcr *ExchangeWallet) refundTx(coinID, contract dex.Bytes, val uint64, refu
 	msgTx.LockTime = uint32(lockTime)
 	prevOut := wire.NewOutPoint(txHash, vout, wire.TxTreeRegular)
 	txIn := wire.NewTxIn(prevOut, int64(val), []byte{})
+	// Enable the OP_CHECKLOCKTIMEVERIFY opcode to be used.
+	//
+	// https://github.com/decred/dcrd/blob/8f5270b707daaa1ecf24a1ba02b3ff8a762674d3/txscript/opcode.go#L981-L998
 	txIn.Sequence = wire.MaxTxInSequenceNum - 1
 	msgTx.AddTxIn(txIn)
 	// Calculate fees and add the change output.


### PR DESCRIPTION
    Both bitcoin and decred do not need the sequence to be set to one less
    than max in order to redeem, only to refund. Remove the unneeded
    assignments and move the doc. Point decred's doc at decred material.