### PR TITLE
client/asset: clean up Wallet interfaces

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -212,8 +212,8 @@ type RPCCloneConfig struct {
 	// NonSegwitSigner can be true if the transaction signature hash data is not
 	// the standard for non-segwit Bitcoin. If nil, txscript.
 	NonSegwitSigner TxInSigner
-	// FeeEstimator provides a way to get fees given an RawRequest-enabled
-	// client and a confirmation target.
+	// FeeEstimator provides a way to get a current fee rate estimate targeting
+	// a certain number of confirmations.
 	FeeEstimator func(uint64) (uint64, error)
 }
 

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -605,7 +605,7 @@ func tNewWallet(segwit bool, walletType string) (*ExchangeWallet, *testData, fun
 		if err == nil {
 			neutrinoClient := &tNeutrinoClient{data}
 			wallet.node = &spvWallet{
-				WalletCore: &WalletCore{
+				SPVCore: &SPVCore{
 					CS: neutrinoClient,
 				},
 				chainParams: &chaincfg.MainNetParams,

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -50,12 +50,6 @@ const (
 	methodGetRawTransaction  = "getrawtransaction"
 )
 
-// RawRequester defines decred's rpcclient RawRequest func where all RPC
-// requests sent through. For testing, it can be satisfied by a stub.
-type RawRequester interface {
-	RawRequest(string, []json.RawMessage) (json.RawMessage, error)
-}
-
 // RawRequesterWithContext defines decred's rpcclient RawRequest func where all
 // RPC requests sent through. For testing, it can be satisfied by a stub.
 type RawRequesterWithContext interface {
@@ -299,9 +293,9 @@ func (wc *rpcClient) listLockUnspent() ([]*RPCOutpoint, error) {
 	return unspents, err
 }
 
-// changeAddress gets a new internal address from the wallet. The address will
+// internalAddress gets a new internal address from the wallet. The address will
 // be bech32-encoded (P2WPKH).
-func (wc *rpcClient) changeAddress() (btcutil.Address, error) {
+func (wc *rpcClient) internalAddress() (btcutil.Address, error) {
 	var addrStr string
 	var err error
 	switch {
@@ -328,6 +322,13 @@ func (wc *rpcClient) addressPKH() (btcutil.Address, error) {
 // wallet.
 func (wc *rpcClient) addressWPKH() (btcutil.Address, error) {
 	return wc.address("bech32")
+}
+
+func (wc *rpcClient) externalAddress() (btcutil.Address, error) {
+	if wc.segwit {
+		return wc.addressWPKH()
+	}
+	return wc.addressPKH()
 }
 
 // address is used internally for fetching addresses of various types from the

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -330,9 +330,11 @@ func (c *tNeutrinoClient) GetBlockHeader(blkHash *chainhash.Hash) (*wire.BlockHe
 }
 
 func (c *tNeutrinoClient) GetCFilter(blockHash chainhash.Hash, filterType wire.FilterType, options ...neutrino.QueryOption) (*gcs.Filter, error) {
+	c.blockchainMtx.RLock()
+	scripts := c.getCFilterScripts[blockHash]
+	c.blockchainMtx.RUnlock()
 	var key [gcs.KeySize]byte
 	copy(key[:], blockHash.CloneBytes()[:])
-	scripts := c.getCFilterScripts[blockHash]
 	scripts = append(scripts, encode.RandomBytes(10))
 	return gcs.BuildGCSFilter(builder.DefaultP, builder.DefaultM, key, scripts)
 }

--- a/client/asset/btc/wallet.go
+++ b/client/asset/btc/wallet.go
@@ -2,20 +2,46 @@ package btc
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
+	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/dex"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
 
+// WalletConstructor defines a function that can be invoked to create a custom
+// implementation of the Wallet interface.
+type WalletConstructor func(cfg *WalletConfig, chainParams *chaincfg.Params, logger dex.Logger) (Wallet, error)
+
+// customWalletConstructors are functions for setting up custom implementations
+// of the Wallet interface that may be used by the ExchangeWallet instead of the
+// default rpcWallet implementation.
+var customWalletConstructors = map[string]WalletConstructor{}
+
+// RegisterCustomWallet registers a function that should be used in creating a
+// Wallet implementation that the ExchangeWallet of the specified type will use
+// in place of the default spv implementation. External consumers can use
+// this function to provide alternative Wallet implementations.
+func RegisterCustomWallet(constructor WalletConstructor, def *asset.WalletDefinition) error {
+	for _, availableWallets := range WalletInfo.AvailableWallets {
+		if def.Type == availableWallets.Type {
+			return fmt.Errorf("already support %q wallets", def.Type)
+		}
+	}
+	customWalletConstructors[def.Type] = constructor
+	WalletInfo.AvailableWallets = append(WalletInfo.AvailableWallets, def)
+	return nil
+}
+
 type Wallet interface {
-	RawRequester
 	connect(ctx context.Context, wg *sync.WaitGroup) error
-	estimateSmartFee(confTarget int64, mode *btcjson.EstimateSmartFeeMode) (*btcjson.EstimateSmartFeeResult, error)
 	sendRawTransaction(tx *wire.MsgTx) (*chainhash.Hash, error)
 	getTxOut(txHash *chainhash.Hash, index uint32, pkScript []byte, startTime time.Time) (*wire.TxOut, uint32, error)
 	getBlockHash(blockHeight int64) (*chainhash.Hash, error)
@@ -26,9 +52,8 @@ type Wallet interface {
 	listUnspent() ([]*ListUnspentResult, error)
 	lockUnspent(unlock bool, ops []*output) error
 	listLockUnspent() ([]*RPCOutpoint, error)
-	changeAddress() (btcutil.Address, error)
-	addressPKH() (btcutil.Address, error)
-	addressWPKH() (btcutil.Address, error)
+	internalAddress() (btcutil.Address, error)
+	externalAddress() (btcutil.Address, error)
 	signTx(inTx *wire.MsgTx) (*wire.MsgTx, error)
 	privKeyForAddress(addr string) (*btcec.PrivateKey, error)
 	walletUnlock(pw []byte) error
@@ -41,8 +66,15 @@ type Wallet interface {
 	ownsAddress(addr btcutil.Address) (bool, error)
 	getWalletTransaction(txHash *chainhash.Hash) (*GetTransactionResult, error)
 	searchBlockForRedemptions(ctx context.Context, reqs map[outPoint]*findRedemptionReq, blockHash chainhash.Hash) (discovered map[outPoint]*findRedemptionResult)
-	findRedemptionsInMempool(ctx context.Context, reqs map[outPoint]*findRedemptionReq) (discovered map[outPoint]*findRedemptionResult)
 	getBlock(h chainhash.Hash) (*wire.MsgBlock, error)
+}
+
+type feeEstimator interface {
+	estimateSmartFee(confTarget int64, mode *btcjson.EstimateSmartFeeMode) (*btcjson.EstimateSmartFeeResult, error)
+}
+
+type mempoolFinder interface {
+	findRedemptionsInMempool(ctx context.Context, reqs map[outPoint]*findRedemptionReq) (discovered map[outPoint]*findRedemptionResult)
 }
 
 type tipNotifier interface {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -23,14 +23,12 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
 	dexdcr "decred.org/dcrdex/dex/networks/dcr"
-	"decred.org/dcrwallet/v2/rpc/client/dcrwallet"
 	walletjson "decred.org/dcrwallet/v2/rpc/jsonrpc/types"
 	"github.com/btcsuite/btcwallet/wallet"
 	"github.com/decred/dcrd/blockchain/stake/v4"
 	"github.com/decred/dcrd/blockchain/v4"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 	"github.com/decred/dcrd/dcrutil/v4"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
@@ -367,7 +365,6 @@ type ExchangeWallet struct {
 	wallet           Wallet
 	chainParams      *chaincfg.Params
 	log              dex.Logger
-	acct             string
 	tipChange        func(error)
 	fallbackFeeRate  uint64
 	feeRateLimit     uint64
@@ -482,7 +479,6 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, chainParams *cha
 	return &ExchangeWallet{
 		log:                 logger,
 		chainParams:         chainParams,
-		acct:                dcrCfg.Account,
 		tipChange:           cfg.TipChange,
 		fundingCoins:        make(map[outPoint]*fundingCoin),
 		findRedemptionQueue: make(map[outPoint]*findRedemptionReq),
@@ -533,14 +529,6 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 		}
 	}()
 
-	curnet, err := dcr.wallet.Network(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("unable to fetch wallet network: %w", err)
-	}
-	if curnet != dcr.chainParams.Net {
-		return nil, fmt.Errorf("unexpected wallet network %s, expected %s", curnet, dcr.chainParams.Net)
-	}
-
 	// Initialize the best block.
 	dcr.tipMtx.Lock()
 	dcr.currentTip, err = dcr.getBestBlock(ctx)
@@ -571,7 +559,11 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 
 // OwnsAddress indicates if an address belongs to the wallet.
 func (dcr *ExchangeWallet) OwnsAddress(address string) (bool, error) {
-	return dcr.wallet.AccountOwnsAddress(dcr.ctx, dcr.acct, address)
+	addr, err := stdaddr.DecodeAddress(address, dcr.chainParams)
+	if err != nil {
+		return false, err
+	}
+	return dcr.wallet.OwnsAddress(dcr.ctx, addr)
 }
 
 // Balance should return the total available funds in the wallet. Note that
@@ -584,7 +576,7 @@ func (dcr *ExchangeWallet) Balance() (*asset.Balance, error) {
 	if err != nil {
 		return nil, err
 	}
-	ab, err := dcr.wallet.AccountBalance(dcr.ctx, dcr.acct, 0)
+	ab, err := dcr.wallet.Balance(dcr.ctx, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -598,11 +590,15 @@ func (dcr *ExchangeWallet) Balance() (*asset.Balance, error) {
 
 // FeeRate returns the current optimal fee rate in atoms / byte.
 func (dcr *ExchangeWallet) feeRate(confTarget uint64) (uint64, error) {
+	estimator, is := dcr.wallet.(FeeRateEstimator)
+	if !is {
+		return 0, fmt.Errorf("fee rate estimation unavailable")
+	}
 	// estimatesmartfee 1 returns extremely high rates on DCR.
 	if confTarget < 2 {
 		confTarget = 2
 	}
-	estimatedFeeRate, err := dcr.wallet.EstimateSmartFeeRate(dcr.ctx, int64(confTarget), chainjson.EstimateSmartFeeConservative)
+	estimatedFeeRate, err := estimator.EstimateSmartFeeRate(dcr.ctx, int64(confTarget), chainjson.EstimateSmartFeeConservative)
 	if err != nil {
 		return 0, err
 	}
@@ -881,12 +877,12 @@ func (dcr *ExchangeWallet) fund(enough func(sum uint64, size uint32, unspent *co
 
 // spendableUTXOs generates a slice of spendable *compositeUTXO.
 func (dcr *ExchangeWallet) spendableUTXOs() ([]*compositeUTXO, error) {
-	unspents, err := dcr.wallet.Unspents(dcr.ctx, dcr.acct)
+	unspents, err := dcr.wallet.Unspents(dcr.ctx)
 	if err != nil {
 		return nil, err
 	}
 	if len(unspents) == 0 {
-		return nil, fmt.Errorf("insufficient funds. 0 DCR available to spend in %q account", dcr.acct)
+		return nil, fmt.Errorf("insufficient funds. 0 DCR available to spend")
 	}
 
 	// Parse utxos to include script size for spending input.
@@ -1027,7 +1023,7 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 	}
 
 	// Use an internal address for the sized output.
-	addr, err := dcr.wallet.GetChangeAddress(dcr.ctx, dcr.acct)
+	addr, err := dcr.wallet.InternalAddress(dcr.ctx)
 	if err != nil {
 		return nil, false, fmt.Errorf("error creating split transaction address: %w", err)
 	}
@@ -1156,7 +1152,7 @@ func (dcr *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 	}
 
 	// Check locked outputs for not found coins.
-	lockedOutputs, err := dcr.wallet.LockedOutputs(dcr.ctx, dcr.acct)
+	lockedOutputs, err := dcr.wallet.LockedOutputs(dcr.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1191,7 +1187,7 @@ func (dcr *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 
 	// Some funding coins still not found after checking locked outputs.
 	// Check wallet unspent outputs as last resort. Lock the coins if found.
-	unspents, err := dcr.wallet.Unspents(dcr.ctx, dcr.acct)
+	unspents, err := dcr.wallet.Unspents(dcr.ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -1253,7 +1249,7 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 		totalOut += contract.Value
 		// revokeAddrV2 is the address belonging to the key that will be
 		// used to sign and refund a swap past its encoded refund locktime.
-		revokeAddrV2, err := dcr.wallet.GetNewAddressGapPolicy(dcr.ctx, dcr.acct, dcrwallet.GapPolicyIgnore)
+		revokeAddrV2, err := dcr.wallet.ExternalAddress(dcr.ctx)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("error creating revocation address: %w", err)
 		}
@@ -1477,12 +1473,12 @@ func (dcr *ExchangeWallet) SignMessage(coin asset.Coin, msg dex.Bytes) (pubkeys,
 	if err != nil {
 		return nil, nil, fmt.Errorf("error decoding address: %w", err)
 	}
-	priv, pub, err := dcr.getKeys(address)
+	priv, err := dcr.wallet.AddressPrivKey(dcr.ctx, address)
 	if err != nil {
 		return nil, nil, err
 	}
 	signature := ecdsa.Sign(priv, msg)
-	pubkeys = append(pubkeys, pub.SerializeCompressed())
+	pubkeys = append(pubkeys, priv.PubKey().SerializeCompressed())
 	sigs = append(sigs, signature.Serialize())
 	return pubkeys, sigs, nil
 }
@@ -1669,14 +1665,41 @@ func (dcr *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time,
 	}
 	contractExpiry := time.Unix(int64(locktime), 0).UTC()
 	dcr.tipMtx.RLock()
-	hash := dcr.currentTip.hash
+	blockHash := dcr.currentTip.hash
 	dcr.tipMtx.RUnlock()
-	blockHeader, err := dcr.wallet.GetBlockHeaderVerbose(dcr.ctx, hash)
+	medianTimeStamp, err := dcr.medianTime(blockHash)
 	if err != nil {
-		return false, time.Time{}, fmt.Errorf("unable to retrieve block header: %w", err)
+		return false, time.Time{}, fmt.Errorf("unable to calculate median time: %w", err)
 	}
-	medianTime := time.Unix(blockHeader.MedianTime, 0)
-	return medianTime.After(contractExpiry), contractExpiry, nil
+	return time.Unix(medianTimeStamp, 0).After(contractExpiry), contractExpiry, nil
+}
+
+// medianTime calculates the median time of the previous few blocks
+// prior to, and including, the block node.
+//
+// Copy of btcd's (*blockNode).CalcPastMedianTime.
+func (dcr *ExchangeWallet) medianTime(blockHash *chainhash.Hash) (int64, error) {
+	// Calculate past median time. Look at the last 11 blocks, starting
+	// with the requested block, which is consistent with dcrd.
+	blockHeader, err := dcr.wallet.GetBlockHeader(dcr.ctx, blockHash)
+	if err != nil {
+		return 0, err
+	}
+	timestamps := make([]int64, 0, 11)
+	for iBlkHeader := blockHeader; ; {
+		timestamps = append(timestamps, iBlkHeader.Timestamp.Unix())
+		if iBlkHeader.Height == 0 || len(timestamps) == cap(timestamps) {
+			break
+		}
+		iBlkHeader, err = dcr.wallet.GetBlockHeader(dcr.ctx, &iBlkHeader.PrevBlock)
+		if err != nil {
+			return 0, fmt.Errorf("info not found for previous block: %v", err)
+		}
+	}
+	sort.Slice(timestamps, func(i, j int) bool {
+		return timestamps[i] < timestamps[j]
+	})
+	return timestamps[len(timestamps)/2], nil
 }
 
 // FindRedemption watches for the input that spends the specified contract
@@ -1790,12 +1813,13 @@ func (dcr *ExchangeWallet) queueFindRedemptionRequest(ctx context.Context, contr
 		if err != nil {
 			return nil, nil, fmt.Errorf("invalid blockhash %s for contract %s: %w", tx.BlockHash, contractOutpoint.String(), err)
 		}
-		txBlock, err := dcr.wallet.GetBlockVerbose(dcr.ctx, blockHash, false)
+		hdr, err := dcr.wallet.GetBlockHeader(dcr.ctx, blockHash)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error fetching verbose block %s for contract %s: %w",
 				tx.BlockHash, contractOutpoint.String(), err)
 		}
-		contractBlock = &block{height: txBlock.Height, hash: blockHash}
+		h := hdr.BlockHash()
+		contractBlock = &block{height: int64(hdr.Height), hash: &h}
 	}
 
 	resultChan := make(chan *findRedemptionResult, 1)
@@ -1831,14 +1855,22 @@ func (dcr *ExchangeWallet) findRedemptionsInMempool(contractOutpoints []outPoint
 			contractsCount-totalFound-totalCanceled, reason)
 	}
 
-	mempoolTxs, err := dcr.wallet.GetRawMempool(dcr.ctx, chainjson.GRMAll)
+	defer dcr.log.Debugf("%d redemptions found, %d canceled out of %d contracts in mempool",
+		totalFound, totalCanceled, contractsCount)
+
+	mempooler, is := dcr.wallet.(Mempooler)
+	if !is {
+		return
+	}
+
+	mempoolTxs, err := mempooler.GetRawMempool(dcr.ctx)
 	if err != nil {
 		logAbandon(fmt.Sprintf("error retrieving transactions: %v", err))
 		return
 	}
 
 	for _, txHash := range mempoolTxs {
-		tx, err := dcr.wallet.GetRawTransactionVerbose(dcr.ctx, txHash)
+		tx, err := dcr.wallet.GetRawTransaction(dcr.ctx, txHash)
 		if err != nil {
 			logAbandon(fmt.Sprintf("getrawtransactionverbose error for tx hash %v: %v", txHash, err))
 			return
@@ -1850,9 +1882,6 @@ func (dcr *ExchangeWallet) findRedemptionsInMempool(contractOutpoints []outPoint
 			break
 		}
 	}
-
-	dcr.log.Debugf("%d redemptions found, %d canceled out of %d contracts in mempool",
-		totalFound, totalCanceled, contractsCount)
 }
 
 // findRedemptionsInBlockRange attempts to find spending info for the specified
@@ -1908,21 +1937,19 @@ rangeBlocks:
 
 		// Get the cfilters for this block to check if any of the above p2sh scripts is
 		// possibly included in this block.
-		blkCFilter, err := dcr.getBlockFilterV2(dcr.ctx, blockHash)
+		key, filter, err := dcr.wallet.BlockFilter(dcr.ctx, blockHash)
 		if err != nil { // error retrieving a block's cfilters is a fatal error
 			err = fmt.Errorf("get cfilters error for block %d (%s): %w", blockHeight, blockHash, err)
 			dcr.fatalFindRedemptionsError(err, contractOutpoints)
 			return
 		}
-		if !blkCFilter.MatchAny(contractP2SHScripts) {
+		if !filter.MatchAny(key, contractP2SHScripts) {
 			lastScannedBlockHeight = blockHeight
 			continue // block does not reference any of these contracts, continue to next block
 		}
 
 		// Pull the block info to confirm if any of its inputs spends a contract of interest.
-		// TODO: We don't really need getblock with either verbose=true or verboseTx=true
-		// since with a block's bytes we could deserialize and work on the MsgTxs.
-		blk, err := dcr.wallet.GetBlockVerbose(dcr.ctx, blockHash, true)
+		blk, err := dcr.wallet.GetBlock(dcr.ctx, blockHash)
 		if err != nil { // error pulling a matching block's transactions is a fatal error
 			err = fmt.Errorf("error retrieving transactions for block %d (%s): %w",
 				blockHeight, blockHash, err)
@@ -1932,9 +1959,7 @@ rangeBlocks:
 
 		lastScannedBlockHeight = blockHeight
 		scanPoint := fmt.Sprintf("block %d", blockHeight)
-		blkTxs := append(blk.RawTx, blk.RawSTx...)
-		for t := range blkTxs {
-			tx := &blkTxs[t]
+		for _, tx := range blk.Transactions {
 			found, canceled := dcr.findRedemptionsInTx(scanPoint, tx, contractOutpoints)
 			totalFound += found
 			totalCanceled += canceled
@@ -1969,27 +1994,25 @@ rangeBlocks:
 // is returned to the redemption finder via the registered result chan; and the
 // contract is purged from the findRedemptionQueue.
 // Returns the number of redemptions found and canceled.
-func (dcr *ExchangeWallet) findRedemptionsInTx(scanPoint string, tx *chainjson.TxRawResult, contractOutpoints []outPoint) (found, cancelled int) {
+func (dcr *ExchangeWallet) findRedemptionsInTx(scanPoint string, tx *wire.MsgTx, contractOutpoints []outPoint) (found, cancelled int) {
 	dcr.findRedemptionMtx.Lock()
 	defer dcr.findRedemptionMtx.Unlock()
 
-	extractSecret := func(vin int, contractHash []byte, contractOutputScriptVer uint16) (*chainhash.Hash, []byte, error) {
-		redeemTxHash, err := chainhash.NewHashFromStr(tx.Txid)
-		if err != nil {
-			return nil, nil, err
+	redeemTxHash := tx.TxHash()
+
+	extractSecret := func(vin int, contractHash []byte, contractOutputScriptVer uint16) ([]byte, error) {
+		if len(tx.TxIn) <= vin {
+			return nil, fmt.Errorf("not enough inputs")
 		}
-		if tx.Vin[vin].ScriptSig == nil {
-			return nil, nil, fmt.Errorf("no sigScript")
-		}
-		sigScript, err := hex.DecodeString(tx.Vin[vin].ScriptSig.Hex)
-		if err != nil {
-			return nil, nil, err
+		sigScript := tx.TxIn[vin].SignatureScript
+		if len(sigScript) == 0 {
+			return nil, fmt.Errorf("no sigScript")
 		}
 		secret, err := dexdcr.FindKeyPush(contractOutputScriptVer, sigScript, contractHash, dcr.chainParams)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
-		return redeemTxHash, secret, nil
+		return secret, nil
 	}
 
 	for _, contractOutpoint := range contractOutpoints {
@@ -2003,25 +2026,25 @@ func (dcr *ExchangeWallet) findRedemptionsInTx(scanPoint string, tx *chainjson.T
 			continue // this find request has been cancelled
 		}
 
-		for i := range tx.Vin {
-			input := &tx.Vin[i]
-			if input.Vout != contractOutpoint.vout || input.Txid != contractOutpoint.txHash.String() {
+		for i, txIn := range tx.TxIn {
+			prevOut := &txIn.PreviousOutPoint
+			if prevOut.Index != contractOutpoint.vout || prevOut.Hash != contractOutpoint.txHash {
 				continue // input doesn't redeem this contract, check next input
 			}
 			found++
 
-			redeemTxHash, secret, err := extractSecret(i, dexdcr.ExtractScriptHash(req.contractP2SHScript), req.contractOutputScriptVer)
+			secret, err := extractSecret(i, dexdcr.ExtractScriptHash(req.contractP2SHScript), req.contractOutputScriptVer)
 			if err != nil {
 				dcr.log.Errorf("Error parsing contract secret for %s from tx input %s:%d in %s: %v",
-					contractOutpoint.String(), tx.Txid, i, scanPoint, err)
+					contractOutpoint.String(), redeemTxHash, i, scanPoint, err)
 				req.resultChan <- &findRedemptionResult{
 					Err: err,
 				}
 			} else {
 				dcr.log.Infof("Redemption for contract %s found in tx input %s:%d in %s",
-					contractOutpoint.String(), tx.Txid, i, scanPoint)
+					contractOutpoint.String(), redeemTxHash, i, scanPoint)
 				req.resultChan <- &findRedemptionResult{
-					RedemptionCoinID: toCoinID(redeemTxHash, uint32(i)),
+					RedemptionCoinID: toCoinID(&redeemTxHash, uint32(i)),
 					Secret:           secret,
 				}
 			}
@@ -2125,7 +2148,7 @@ func (dcr *ExchangeWallet) refundTx(coinID, contract dex.Bytes, val uint64, refu
 	}
 
 	if refundAddr == nil {
-		refundAddr, err = dcr.wallet.GetNewAddressGapPolicy(dcr.ctx, dcr.acct, dcrwallet.GapPolicyIgnore)
+		refundAddr, err = dcr.wallet.ExternalAddress(dcr.ctx)
 		if err != nil {
 			return nil, fmt.Errorf("error getting new address from the wallet: %w", err)
 		}
@@ -2152,85 +2175,40 @@ func (dcr *ExchangeWallet) refundTx(coinID, contract dex.Bytes, val uint64, refu
 
 // Address returns an address for the exchange wallet.
 func (dcr *ExchangeWallet) Address() (string, error) {
-	addr, err := dcr.wallet.GetNewAddressGapPolicy(dcr.ctx, dcr.acct, dcrwallet.GapPolicyIgnore)
+	addr, err := dcr.wallet.ExternalAddress(dcr.ctx)
 	if err != nil {
 		return "", err
 	}
 	return addr.String(), nil
 }
 
-func (dcr *ExchangeWallet) accountUnlocked(ctx context.Context, acct string) (encrypted, unlocked bool, err error) {
-	var res *walletjson.AccountUnlockedResult
-	res, err = dcr.wallet.AccountUnlocked(ctx, acct)
-	if err != nil {
-		return
-	}
-	encrypted = res.Encrypted
-	if res.Unlocked != nil { // should only be when encrypted
-		unlocked = *res.Unlocked
-	}
-	return
-}
-
 // Unlock unlocks the exchange wallet.
 func (dcr *ExchangeWallet) Unlock(pw []byte) error {
-	encryptedAcct, unlocked, err := dcr.accountUnlocked(dcr.ctx, dcr.acct)
+	unlocked, err := dcr.wallet.Unlocked(dcr.ctx)
 	if err != nil {
 		return err
-	}
-	if !encryptedAcct {
-		return dcr.wallet.UnlockWallet(dcr.ctx, string(pw), 0)
-
 	}
 	if unlocked {
 		return nil
 	}
 
-	return dcr.wallet.UnlockAccount(dcr.ctx, dcr.acct, string(pw))
+	return dcr.wallet.Unlock(dcr.ctx, pw)
 }
 
 // Lock locks the exchange wallet.
 func (dcr *ExchangeWallet) Lock() error {
-	if dcr.wallet.Disconnected() {
-		return asset.ErrConnectionDown
-	}
-
-	// Since hung calls to Lock() may block shutdown of the consumer and thus
-	// cancellation of the ExchangeWallet subsystem's Context, dcr.ctx, give
-	// this a timeout in case the connection goes down or the RPC hangs for
-	// other reasons.
-	ctx, cancel := context.WithTimeout(dcr.ctx, 5*time.Second)
-	defer cancel()
-
-	encryptedAcct, unlocked, err := dcr.accountUnlocked(ctx, dcr.acct)
-	if err != nil {
-		return err
-	}
-	if !encryptedAcct {
-		return dcr.wallet.LockWallet(ctx)
-	}
-	if !unlocked {
-		return nil
-	}
-
-	return dcr.wallet.LockAccount(dcr.ctx, dcr.acct)
+	return dcr.wallet.Lock(dcr.ctx)
 }
 
 // Locked will be true if the wallet is currently locked.
 // Q: why are we ignoring RPC errors in this?
 func (dcr *ExchangeWallet) Locked() bool {
-	// First return locked status of the account, falling back to walletinfo if
-	// the account is not individually password protected.
-	encrypted, unlocked, err := dcr.accountUnlocked(dcr.ctx, dcr.acct)
+	unlocked, err := dcr.wallet.Unlocked(dcr.ctx)
 	if err != nil {
-		dcr.log.Errorf("accountunlocked error: %v", err)
-		// return false // or try walletinfo???
-	} else if encrypted {
-		return !unlocked
+		dcr.log.Errorf("walletinfo error: %v", err)
+		return false // assume wallet is unlocked?
 	}
-
-	// The account is not individually encrypted, so check wallet lock status.
-	return !dcr.wallet.WalletUnlocked(dcr.ctx)
+	return !unlocked
 }
 
 // PayFee sends the dex registration fee. Transaction fees are in addition to
@@ -2372,7 +2350,7 @@ func (dcr *ExchangeWallet) SyncStatus() (bool, float32, error) {
 
 // Combines the RPC type with the spending input information.
 type compositeUTXO struct {
-	rpc   walletjson.ListUnspentResult
+	rpc   *walletjson.ListUnspentResult
 	input *dexdcr.SpendInfo
 	confs int64
 	// TODO: consider including isDexChange bool for consumer
@@ -2381,7 +2359,7 @@ type compositeUTXO struct {
 // parseUTXOs constructs and returns a list of compositeUTXOs from the provided
 // set of RPC utxos, including basic information required to spend each rpc utxo.
 // The returned list is sorted by ascending value.
-func (dcr *ExchangeWallet) parseUTXOs(unspents []walletjson.ListUnspentResult) ([]*compositeUTXO, error) {
+func (dcr *ExchangeWallet) parseUTXOs(unspents []*walletjson.ListUnspentResult) ([]*compositeUTXO, error) {
 	utxos := make([]*compositeUTXO, 0, len(unspents))
 	for _, txout := range unspents {
 		scriptPK, err := hex.DecodeString(txout.ScriptPubKey)
@@ -2415,7 +2393,7 @@ func (dcr *ExchangeWallet) parseUTXOs(unspents []walletjson.ListUnspentResult) (
 
 // lockedAtoms is the total value of locked outputs, as locked with LockUnspent.
 func (dcr *ExchangeWallet) lockedAtoms() (uint64, error) {
-	lockedOutpoints, err := dcr.wallet.LockedOutputs(dcr.ctx, dcr.acct)
+	lockedOutpoints, err := dcr.wallet.LockedOutputs(dcr.ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -2531,41 +2509,8 @@ func msgTxToHex(msgTx *wire.MsgTx) (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-// signTx attempts to sign all transaction inputs. If it fails to completely
-// sign the transaction, it is an error and a nil *wire.MsgTx is returned.
-func (dcr *ExchangeWallet) signTx(baseTx *wire.MsgTx) (*wire.MsgTx, error) {
-	txHex, err := msgTxToHex(baseTx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to encode MsgTx: %w", err)
-	}
-	res, err := dcr.wallet.SignRawTransaction(dcr.ctx, txHex)
-	if err != nil {
-		return nil, fmt.Errorf("signrawtransaction error: %w", err)
-	}
-
-	for i := range res.Errors {
-		sigErr := &res.Errors[i]
-		dcr.log.Errorf("Signing %v:%d, seq = %d, sigScript = %v, failed: %v (is wallet locked?)",
-			sigErr.TxID, sigErr.Vout, sigErr.Sequence, sigErr.ScriptSig, sigErr.Error)
-		// Will be incomplete below, so log each SignRawTransactionError and move on.
-	}
-
-	signedTx, err := msgTxFromHex(res.Hex)
-	if err != nil {
-		return nil, fmt.Errorf("failed to deserialize signed MsgTx: %w", err)
-	}
-
-	if !res.Complete {
-		dcr.log.Errorf("Incomplete raw transaction signatures (input tx: %x / incomplete signed tx: %x): ",
-			dcr.wireBytes(baseTx), dcr.wireBytes(signedTx))
-		return nil, fmt.Errorf("incomplete raw tx signatures (is wallet locked?)")
-	}
-
-	return signedTx, nil
-}
-
 func (dcr *ExchangeWallet) makeChangeOut(val uint64) (*wire.TxOut, stdaddr.Address, error) {
-	changeAddr, err := dcr.wallet.GetChangeAddress(dcr.ctx, dcr.acct)
+	changeAddr, err := dcr.wallet.InternalAddress(dcr.ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating change address: %w", err)
 	}
@@ -2593,7 +2538,7 @@ func (dcr *ExchangeWallet) signTxAndAddChange(baseTx *wire.MsgTx, feeRate uint64
 	// Sign the transaction to get an initial size estimate and calculate
 	// whether a change output would be dust.
 	sigCycles := 1
-	msgTx, err := dcr.signTx(baseTx)
+	msgTx, err := dcr.wallet.SignRawTransaction(dcr.ctx, baseTx)
 	if err != nil {
 		return nil, nil, "", 0, err
 	}
@@ -2660,7 +2605,7 @@ func (dcr *ExchangeWallet) signTxAndAddChange(baseTx *wire.MsgTx, feeRate uint64
 			// Each cycle, sign the transaction and see if there is a need to
 			// raise or lower the fees.
 			sigCycles++
-			msgTx, err = dcr.signTx(baseTx)
+			msgTx, err = dcr.wallet.SignRawTransaction(dcr.ctx, baseTx)
 			if err != nil {
 				return nil, nil, "", 0, err
 			}
@@ -2757,7 +2702,7 @@ func (dcr *ExchangeWallet) createSig(tx *wire.MsgTx, idx int, pkScript []byte, a
 		return nil, nil, err
 	}
 
-	priv, pub, err := dcr.getKeys(addr)
+	priv, err := dcr.wallet.AddressPrivKey(dcr.ctx, addr)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2767,18 +2712,7 @@ func (dcr *ExchangeWallet) createSig(tx *wire.MsgTx, idx int, pkScript []byte, a
 		return nil, nil, err
 	}
 
-	return sig, pub.SerializeCompressed(), nil
-}
-
-// getKeys fetches the private/public key pair for the specified address.
-func (dcr *ExchangeWallet) getKeys(addr stdaddr.Address) (*secp256k1.PrivateKey, *secp256k1.PublicKey, error) {
-	wif, err := dcr.wallet.AddressPrivKey(dcr.ctx, addr)
-	if err != nil {
-		return nil, nil, fmt.Errorf("%w (is wallet locked?)", err)
-	}
-
-	priv := secp256k1.PrivKeyFromBytes(wif.PrivKey())
-	return priv, priv.PubKey(), nil
+	return sig, priv.PubKey().SerializeCompressed(), nil
 }
 
 // monitorBlocks pings for new blocks and runs the tipChange callback function
@@ -2852,36 +2786,28 @@ func (dcr *ExchangeWallet) handleTipChange(newTipHash *chainhash.Hash, newTipHei
 	// Redemption search would typically resume from prevTipHeight + 1 unless the
 	// previous tip was re-orged out of the mainchain, in which case redemption
 	// search will resume from the mainchain ancestor of the previous tip.
-	prevTipHeader, err := dcr.wallet.GetBlockHeaderVerbose(dcr.ctx, prevTip.hash)
+	prevTipHeader, isMainchain, err := dcr.getMainchainHeader(prevTip.hash)
 	if err != nil {
 		// Redemption search cannot continue reliably without knowing if there
 		// was a reorg, cancel all find redemption requests in queue.
-		notifyFatalFindRedemptionError("GetBlockHeaderVerbose error for prev tip hash %s: %w",
+		notifyFatalFindRedemptionError("getMainchainHeader error for prev tip hash %s: %w",
 			prevTip.hash, err)
 		return
 	}
 
 	startHeight := int64(prevTipHeader.Height + 1)
-	if prevTipHeader.Confirmations < 0 {
+	if !isMainchain {
 		// The previous tip is no longer part of the mainchain. Crawl blocks
 		// backwards until finding a mainchain block. Start with the block
 		// that is the immediate ancestor to the previous tip.
-		ancestorBlockHash, err := chainhash.NewHashFromStr(prevTipHeader.PreviousHash)
-		if err != nil {
-			// Redemption search cannot continue reliably without knowing the mainchain
-			// ancestor of the previous tip, cancel all find redemption requests in queue.
-			notifyFatalFindRedemptionError("error decoding previous hash %s for orphaned block %s: %w",
-				prevTipHeader.PreviousHash, prevTipHeader.Hash, err)
-			return
-		}
-
+		ancestorBlockHash := &prevTipHeader.PrevBlock
 		for {
-			aBlock, err := dcr.wallet.GetBlockHeaderVerbose(dcr.ctx, ancestorBlockHash)
+			aBlock, isMainchain, err := dcr.getMainchainHeader(ancestorBlockHash)
 			if err != nil {
 				notifyFatalFindRedemptionError("GetBlockHeaderVerbose error for block %s: %w", ancestorBlockHash, err)
 				return
 			}
-			if aBlock.Confirmations > -1 {
+			if isMainchain {
 				// Found the mainchain ancestor of previous tip.
 				startHeight = int64(aBlock.Height)
 				dcr.log.Debugf("reorg detected from height %d to %d", aBlock.Height, newTipHeight)
@@ -2890,21 +2816,29 @@ func (dcr *ExchangeWallet) handleTipChange(newTipHash *chainhash.Hash, newTipHei
 			if aBlock.Height == 0 {
 				// Crawled back to genesis block without finding a mainchain ancestor
 				// for the previous tip. Should never happen!
-				notifyFatalFindRedemptionError("no mainchain ancestor for orphaned block %s", prevTipHeader.Hash)
+				notifyFatalFindRedemptionError("no mainchain ancestor for orphaned block %s", prevTip.hash)
 				return
 			}
-			ancestorBlockHash, err = chainhash.NewHashFromStr(aBlock.PreviousHash)
-			if err != nil {
-				notifyFatalFindRedemptionError("error decoding previous hash %s for orphaned block %s: %w",
-					aBlock.PreviousHash, aBlock.Hash, err)
-				return
-			}
+			ancestorBlockHash = &aBlock.PrevBlock
 		}
 	}
 
 	// Run the redemption search from the startHeight determined above up
 	// till the current tip height.
 	go dcr.findRedemptionsInBlockRange(startHeight, newTipHeight, contractOutpoints)
+}
+
+func (dcr *ExchangeWallet) getMainchainHeader(blockHash *chainhash.Hash) (*wire.BlockHeader, bool, error) {
+	hdr, err := dcr.wallet.GetBlockHeader(dcr.ctx, blockHash)
+	if err != nil {
+		return nil, false, fmt.Errorf("GetBlockHeader error: %w", err)
+	}
+
+	mainchain, err := dcr.wallet.IsValidMainchain(dcr.ctx, blockHash)
+	if err != nil {
+		return nil, false, fmt.Errorf("IsValidMainchain error: %w", err)
+	}
+	return hdr, mainchain, nil
 }
 
 func (dcr *ExchangeWallet) getBestBlock(ctx context.Context) (*block, error) {
@@ -2920,50 +2854,19 @@ func (dcr *ExchangeWallet) getBestBlock(ctx context.Context) (*block, error) {
 func (dcr *ExchangeWallet) mainchainAncestor(ctx context.Context, blockHash *chainhash.Hash) (*chainhash.Hash, int64, error) {
 	checkHash := blockHash
 	for {
-		checkBlock, err := dcr.wallet.GetBlockHeaderVerbose(ctx, checkHash)
+		checkBlock, isMainchain, err := dcr.getMainchainHeader(checkHash)
 		if err != nil {
 			return nil, 0, fmt.Errorf("getblockheader error for block %s: %w", checkHash, err)
 		}
-		if checkBlock.Confirmations > -1 {
+		if isMainchain {
 			// This is a mainchain block, return the hash and height.
 			return checkHash, int64(checkBlock.Height), nil
 		}
 		if checkBlock.Height == 0 {
-			return nil, 0, fmt.Errorf("no mainchain ancestor for block %s", blockHash.String())
+			return nil, 0, fmt.Errorf("no mainchain ancestor for block %s", blockHash)
 		}
-		checkHash, err = chainhash.NewHashFromStr(checkBlock.PreviousHash)
-		if err != nil {
-			return nil, 0, fmt.Errorf("error decoding previous hash %s for block %s: %w",
-				checkBlock.PreviousHash, checkHash.String(), err)
-		}
+		checkHash = &checkBlock.PrevBlock
 	}
-}
-
-func (dcr *ExchangeWallet) isMainchainBlock(ctx context.Context, block *block) (bool, error) {
-	blockHeader, err := dcr.wallet.GetBlockHeaderVerbose(ctx, block.hash)
-	if err != nil {
-		return false, fmt.Errorf("getblockheader error for block %s: %w", block.hash, err)
-	}
-	// First validation check.
-	if blockHeader.Confirmations < 0 || int64(blockHeader.Height) != block.height {
-		return false, nil
-	}
-	// Check if the next block invalidated this block's regular tree txs.
-	// This block checks out if there is no following block yet.
-	if blockHeader.NextHash == "" {
-		return true, nil
-	}
-	nextBlockHash, err := chainhash.NewHashFromStr(blockHeader.NextHash)
-	if err != nil {
-		return false, fmt.Errorf("block %s has invalid nexthash value %s: %v",
-			block.hash, blockHeader.NextHash, err)
-	}
-	nextBlockHeader, err := dcr.wallet.GetBlockHeaderVerbose(ctx, nextBlockHash)
-	if err != nil {
-		return false, fmt.Errorf("getblockheader error for block %s: %w", nextBlockHash, err)
-	}
-	validated := nextBlockHeader.VoteBits&1 != 0
-	return validated, nil
 }
 
 func (dcr *ExchangeWallet) cachedBestBlock() block {

--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
@@ -19,8 +20,11 @@ import (
 	walletjson "decred.org/dcrwallet/v2/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrjson/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
+	"github.com/decred/dcrd/gcs/v3"
+	"github.com/decred/dcrd/gcs/v3/blockcf2"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/rpcclient/v7"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
@@ -47,6 +51,7 @@ type rpcWallet struct {
 	chainParams *chaincfg.Params
 	log         dex.Logger
 	spvMode     bool
+	acctName    string
 
 	// rpcConnector is a rpcclient.Client, does not need to be
 	// set for testing.
@@ -60,6 +65,8 @@ type rpcWallet struct {
 
 // Ensure rpcWallet satisfies the Wallet interface.
 var _ Wallet = (*rpcWallet)(nil)
+var _ Mempooler = (*rpcWallet)(nil)
+var _ FeeRateEstimator = (*rpcWallet)(nil)
 
 type walletClient = dcrwallet.Client
 
@@ -96,10 +103,11 @@ type rpcClient interface {
 	GetBalanceMinConf(ctx context.Context, account string, minConfirms int) (*walletjson.GetBalanceResult, error)
 	GetBestBlock(ctx context.Context) (*chainhash.Hash, int64, error)
 	GetBlockHash(ctx context.Context, blockHeight int64) (*chainhash.Hash, error)
-	GetBlockVerbose(ctx context.Context, blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error)
+	GetBlock(ctx context.Context, blockHash *chainhash.Hash) (*wire.MsgBlock, error)
 	GetBlockHeaderVerbose(ctx context.Context, blockHash *chainhash.Hash) (*chainjson.GetBlockHeaderVerboseResult, error)
+	GetBlockHeader(ctx context.Context, blockHash *chainhash.Hash) (*wire.BlockHeader, error)
 	GetRawMempool(ctx context.Context, txType chainjson.GetRawMempoolTxTypeCmd) ([]*chainhash.Hash, error)
-	GetRawTransactionVerbose(ctx context.Context, txHash *chainhash.Hash) (*chainjson.TxRawResult, error)
+	GetRawTransaction(ctx context.Context, txHash *chainhash.Hash) (*dcrutil.Tx, error)
 	LockUnspent(ctx context.Context, unlock bool, ops []*wire.OutPoint) error
 	GetRawChangeAddress(ctx context.Context, account string, net stdaddr.AddressParams) (stdaddr.Address, error)
 	GetNewAddressGapPolicy(ctx context.Context, account string, gap dcrwallet.GapPolicy) (stdaddr.Address, error)
@@ -136,6 +144,7 @@ func newRPCWallet(cfg *Config, chainParams *chaincfg.Params, logger dex.Logger) 
 	rpcw := &rpcWallet{
 		chainParams: chainParams,
 		log:         log,
+		acctName:    cfg.Account,
 	}
 
 	log.Infof("Setting up rpc client to communicate with dcrwallet at %s with TLS certificate %q.",
@@ -250,6 +259,14 @@ func (w *rpcWallet) Connect(ctx context.Context) error {
 		return fmt.Errorf("dcrwallet connect error: %w", err)
 	}
 
+	net, err := w.rpcClient.GetCurrentNet(ctx)
+	if err != nil {
+		return translateRPCCancelErr(err)
+	}
+	if net != w.chainParams.Net {
+		return fmt.Errorf("unexpected wallet network %s, expected %s", net, w.chainParams.Net)
+	}
+
 	// The websocket client is connected now, so if the following check
 	// fails and we return with a non-nil error, we must shutdown the
 	// rpc client otherwise subsequent reconnect attempts will be met
@@ -271,11 +288,11 @@ func (w *rpcWallet) Disconnect() {
 	w.rpcConnector.WaitForShutdown()
 }
 
-// Disconnected returns true if the rpc client is not connected.
-// Part of the Wallet interface.
-func (w *rpcWallet) Disconnected() bool {
-	return w.rpcConnector.Disconnected()
-}
+// // Disconnected returns true if the rpc client is not connected.
+// // Part of the Wallet interface.
+// func (w *rpcWallet) disconnected() bool {
+// 	return w.rpcConnector.Disconnected()
+// }
 
 // Network returns the network of the connected wallet.
 // Part of the Wallet interface.
@@ -301,45 +318,41 @@ func (w *rpcWallet) NotifyOnTipChange(ctx context.Context, cb TipChangeCallback)
 	return false
 }
 
-// AccountOwnsAddress uses the validateaddress rpc to check if the provided
-// address belongs to the specified account.
+// OwnsAddress uses the validateaddress rpc to check if the provided address
+// belongs to the specified account.
 // Part of the Wallet interface.
-func (w *rpcWallet) AccountOwnsAddress(ctx context.Context, account, address string) (bool, error) {
-	a, err := stdaddr.DecodeAddress(address, w.chainParams)
-	if err != nil {
-		return false, err
-	}
-	va, err := w.rpcClient.ValidateAddress(ctx, a)
+func (w *rpcWallet) OwnsAddress(ctx context.Context, addr stdaddr.Address) (bool, error) {
+	va, err := w.rpcClient.ValidateAddress(ctx, addr)
 	if err != nil {
 		return false, translateRPCCancelErr(err)
 	}
-	return va.IsMine && va.Account == account, nil
+	return va.IsMine && va.Account == w.acctName, nil
 }
 
-// AccountBalance returns the balance breakdown for the specified account.
+// Balance returns the balance breakdown for the specified account.
 // Part of the Wallet interface.
-func (w *rpcWallet) AccountBalance(ctx context.Context, account string, confirms int32) (*walletjson.GetAccountBalanceResult, error) {
-	balances, err := w.rpcClient.GetBalanceMinConf(ctx, account, int(confirms))
+func (w *rpcWallet) Balance(ctx context.Context, confirms int32) (*walletjson.GetAccountBalanceResult, error) {
+	balances, err := w.rpcClient.GetBalanceMinConf(ctx, w.acctName, int(confirms))
 	if err != nil {
 		return nil, translateRPCCancelErr(err)
 	}
 
 	for i := range balances.Balances {
 		ab := &balances.Balances[i]
-		if ab.AccountName == account {
+		if ab.AccountName == w.acctName {
 			return ab, nil
 		}
 	}
 
-	return nil, fmt.Errorf("account not found: %q", account)
+	return nil, fmt.Errorf("account not found: %q", w.acctName)
 }
 
 // LockedOutputs fetches locked outputs for the specified account using rpc
 // RawRequest.
 // Part of the Wallet interface.
-func (w *rpcWallet) LockedOutputs(ctx context.Context, account string) ([]chainjson.TransactionInput, error) {
+func (w *rpcWallet) LockedOutputs(ctx context.Context) ([]chainjson.TransactionInput, error) {
 	var locked []chainjson.TransactionInput
-	err := w.rpcClientRawRequest(ctx, methodListLockUnspent, anylist{account}, &locked)
+	err := w.rpcClientRawRequest(ctx, methodListLockUnspent, anylist{w.acctName}, &locked)
 	return locked, translateRPCCancelErr(err)
 }
 
@@ -357,18 +370,18 @@ func (w *rpcWallet) EstimateSmartFeeRate(ctx context.Context, confTarget int64, 
 // Unspents fetches unspent outputs for the specified account using rpc
 // RawRequest.
 // Part of the Wallet interface.
-func (w *rpcWallet) Unspents(ctx context.Context, account string) ([]walletjson.ListUnspentResult, error) {
-	var unspents []walletjson.ListUnspentResult
+func (w *rpcWallet) Unspents(ctx context.Context) ([]*walletjson.ListUnspentResult, error) {
+	var unspents []*walletjson.ListUnspentResult
 	// minconf, maxconf (rpcdefault=9999999), [address], account
-	params := anylist{0, 9999999, nil, account}
+	params := anylist{0, 9999999, nil, w.acctName}
 	err := w.rpcClientRawRequest(ctx, methodListUnspent, params, &unspents)
 	return unspents, err
 }
 
-// GetChangeAddress returns a change address from the specified account.
+// InternalAddress returns a change address from the specified account.
 // Part of the Wallet interface.
-func (w *rpcWallet) GetChangeAddress(ctx context.Context, account string) (stdaddr.Address, error) {
-	addr, err := w.rpcClient.GetRawChangeAddress(ctx, account, w.chainParams)
+func (w *rpcWallet) InternalAddress(ctx context.Context) (stdaddr.Address, error) {
+	addr, err := w.rpcClient.GetRawChangeAddress(ctx, w.acctName, w.chainParams)
 	return addr, translateRPCCancelErr(err)
 }
 
@@ -428,38 +441,79 @@ func (w *rpcWallet) UnspentOutput(ctx context.Context, txHash *chainhash.Hash, i
 // GetNewAddressGapPolicy returns an address from the specified account using
 // the specified gap policy.
 // Part of the Wallet interface.
-func (w *rpcWallet) GetNewAddressGapPolicy(ctx context.Context, account string, gap dcrwallet.GapPolicy) (stdaddr.Address, error) {
-	addr, err := w.rpcClient.GetNewAddressGapPolicy(ctx, account, gap)
-	return addr, translateRPCCancelErr(err)
+func (w *rpcWallet) ExternalAddress(ctx context.Context) (stdaddr.Address, error) {
+	addr, err := w.rpcClient.GetNewAddressGapPolicy(ctx, w.acctName, dcrwallet.GapPolicyIgnore)
+	if err != nil {
+		return nil, translateRPCCancelErr(err)
+	}
+	return addr, nil
 }
 
 // SignRawTransaction signs the provided transaction using rpc RawRequest.
 // Part of the Wallet interface.
-func (w *rpcWallet) SignRawTransaction(ctx context.Context, txHex string) (*walletjson.SignRawTransactionResult, error) {
+func (w *rpcWallet) SignRawTransaction(ctx context.Context, baseTx *wire.MsgTx) (*wire.MsgTx, error) {
+	txHex, err := msgTxToHex(baseTx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode MsgTx: %w", err)
+	}
 	var res walletjson.SignRawTransactionResult
-	err := w.rpcClientRawRequest(ctx, methodSignRawTransaction, anylist{txHex}, &res)
-	return &res, err
+	err = w.rpcClientRawRequest(ctx, methodSignRawTransaction, anylist{txHex}, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range res.Errors {
+		sigErr := &res.Errors[i]
+		return nil, fmt.Errorf("signing %v:%d, seq = %d, sigScript = %v, failed: %v (is wallet locked?)",
+			sigErr.TxID, sigErr.Vout, sigErr.Sequence, sigErr.ScriptSig, sigErr.Error)
+		// Will be incomplete below, so log each SignRawTransactionError and move on.
+	}
+
+	if !res.Complete {
+		baseTxB, _ := baseTx.Bytes()
+		w.log.Errorf("Incomplete raw transaction signatures (input tx: %x / incomplete signed tx: %s): ",
+			baseTxB, res.Hex)
+		return nil, fmt.Errorf("incomplete raw tx signatures (is wallet locked?)")
+	}
+
+	return msgTxFromHex(res.Hex)
 }
 
-// SendRawTransaction broadcasts the provided transaction to the Decred network.
-// Part of the Wallet interface.
-func (w *rpcWallet) SendRawTransaction(ctx context.Context, tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error) {
-	hash, err := w.rpcClient.SendRawTransaction(ctx, tx, allowHighFees)
-	return hash, translateRPCCancelErr(err)
+func (w *rpcWallet) IsValidMainchain(ctx context.Context, blockHash *chainhash.Hash) (bool, error) {
+	blockHeader, err := w.GetBlockHeaderVerbose(ctx, blockHash)
+	if err != nil {
+		return false, fmt.Errorf("getblockheader error for block %s: %w", blockHash, err)
+	}
+	// First validation check.
+	if blockHeader.Confirmations < 0 {
+		return false, nil
+	}
+	// Check if the next block invalidated this block's regular tree txs.
+	// This block checks out if there is no following block yet.
+	if blockHeader.NextHash == "" {
+		return true, nil
+	}
+	nextBlockHash, err := chainhash.NewHashFromStr(blockHeader.NextHash)
+	if err != nil {
+		return false, fmt.Errorf("block %s has invalid nexthash value %s: %v",
+			blockHash, blockHeader.NextHash, err)
+	}
+	nextBlockHeader, err := w.GetBlockHeaderVerbose(ctx, nextBlockHash)
+	if err != nil {
+		return false, fmt.Errorf("getblockheader error for block %s: %w", nextBlockHash, err)
+	}
+	validated := nextBlockHeader.VoteBits&1 != 0
+	return !validated, nil
 }
 
-// GetBlockHeaderVerbose returns block header info for the specified block hash.
-// Part of the Wallet interface.
-func (w *rpcWallet) GetBlockHeaderVerbose(ctx context.Context, blockHash *chainhash.Hash) (*chainjson.GetBlockHeaderVerboseResult, error) {
-	blockHeader, err := w.rpcClient.GetBlockHeaderVerbose(ctx, blockHash)
-	return blockHeader, translateRPCCancelErr(err)
+func (w *rpcWallet) GetBlockHeader(ctx context.Context, blockHash *chainhash.Hash) (hdr *wire.BlockHeader, err error) {
+	return w.rpcClient.GetBlockHeader(ctx, blockHash)
 }
 
-// GetBlockVerbose returns information about a block, optionally including verbose
-// tx info.
+// GetBlock returns the MsgBlock.
 // Part of the Wallet interface.
-func (w *rpcWallet) GetBlockVerbose(ctx context.Context, blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error) {
-	blk, err := w.rpcClient.GetBlockVerbose(ctx, blockHash, verboseTx)
+func (w *rpcWallet) GetBlock(ctx context.Context, blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
+	blk, err := w.rpcClient.GetBlock(ctx, blockHash)
 	return blk, translateRPCCancelErr(err)
 }
 
@@ -478,19 +532,19 @@ func (w *rpcWallet) GetTransaction(ctx context.Context, txHash *chainhash.Hash) 
 	return tx, nil
 }
 
-// GetRawTransactionVerbose returns details of the tx with the provided hash.
-// Returns asset.CoinNotFoundError if the tx is not found.
-// Part of the Wallet interface.
-func (w *rpcWallet) GetRawTransactionVerbose(ctx context.Context, txHash *chainhash.Hash) (*chainjson.TxRawResult, error) {
-	tx, err := w.rpcClient.GetRawTransactionVerbose(ctx, txHash)
-	return tx, translateRPCCancelErr(err)
+func (w *rpcWallet) GetRawTransaction(ctx context.Context, txHash *chainhash.Hash) (*wire.MsgTx, error) {
+	utilTx, err := w.rpcClient.GetRawTransaction(ctx, txHash)
+	if err != nil {
+		return nil, err
+	}
+	return utilTx.MsgTx(), nil
 }
 
 // GetRawMempool returns hashes for all txs of the specified type in the node's
 // mempool.
 // Part of the Wallet interface.
-func (w *rpcWallet) GetRawMempool(ctx context.Context, txType chainjson.GetRawMempoolTxTypeCmd) ([]*chainhash.Hash, error) {
-	mempoolTxs, err := w.rpcClient.GetRawMempool(ctx, txType)
+func (w *rpcWallet) GetRawMempool(ctx context.Context) ([]*chainhash.Hash, error) {
+	mempoolTxs, err := w.rpcClient.GetRawMempool(ctx, chainjson.GRMAll)
 	return mempoolTxs, translateRPCCancelErr(err)
 }
 
@@ -508,61 +562,104 @@ func (w *rpcWallet) GetBlockHash(ctx context.Context, blockHeight int64) (*chain
 	return bh, translateRPCCancelErr(err)
 }
 
-// BlockCFilter fetches the block filter info for the specified block.
+// BlockFilter fetches the block filter info for the specified block.
 // Part of the Wallet interface.
-func (w *rpcWallet) BlockCFilter(ctx context.Context, blockHash *chainhash.Hash) (filter, key string, err error) {
+func (w *rpcWallet) BlockFilter(ctx context.Context, blockHash *chainhash.Hash) ([gcs.KeySize]byte, *gcs.FilterV2, error) {
 	var cfRes walletjson.GetCFilterV2Result
-	err = w.rpcClientRawRequest(ctx, methodGetCFilterV2, anylist{blockHash.String()}, &cfRes)
+	err := w.rpcClientRawRequest(ctx, methodGetCFilterV2, anylist{blockHash.String()}, &cfRes)
 	if err != nil {
-		return "", "", err
+		return [gcs.KeySize]byte{}, nil, err
 	}
-	return cfRes.Filter, cfRes.Key, nil
+
+	bf, key := cfRes.Filter, cfRes.Key
+	filterB, err := hex.DecodeString(bf)
+	if err != nil {
+		return [gcs.KeySize]byte{}, nil, fmt.Errorf("error decoding block filter: %w", err)
+	}
+	keyB, err := hex.DecodeString(key)
+	if err != nil {
+		return [gcs.KeySize]byte{}, nil, fmt.Errorf("error decoding block filter key: %w", err)
+	}
+	filter, err := gcs.FromBytesV2(blockcf2.B, blockcf2.M, filterB)
+	if err != nil {
+		return [gcs.KeySize]byte{}, nil, fmt.Errorf("error deserializing block filter: %w", err)
+	}
+
+	var bcf2Key [gcs.KeySize]byte
+	copy(bcf2Key[:], keyB)
+
+	return bcf2Key, filter, nil
 }
 
-// LockWallet locks the wallet.
+// lockWallet locks the wallet.
 // Part of the Wallet interface.
-func (w *rpcWallet) LockWallet(ctx context.Context) error {
+func (w *rpcWallet) lockWallet(ctx context.Context) error {
 	return translateRPCCancelErr(w.rpcClient.WalletLock(ctx))
 }
 
-// UnlockWallet unlocks the wallet.
+// unlockWallet unlocks the wallet.
 // Part of the Wallet interface.
-func (w *rpcWallet) UnlockWallet(ctx context.Context, passphrase string, timeoutSecs int64) error {
+func (w *rpcWallet) unlockWallet(ctx context.Context, passphrase string, timeoutSecs int64) error {
 	return translateRPCCancelErr(w.rpcClient.WalletPassphrase(ctx, passphrase, timeoutSecs))
 }
 
-// WalletUnlocked returns true if the wallet is unlocked.
+// Unlocked returns true if the specified account is unlocked.
 // Part of the Wallet interface.
-func (w *rpcWallet) WalletUnlocked(ctx context.Context) bool {
+func (w *rpcWallet) Unlocked(ctx context.Context) (bool, error) {
+	// First return locked status of the account, falling back to walletinfo if
+	// the account is not individually password protected.
+	var res *walletjson.AccountUnlockedResult
+	res, err := w.rpcClient.AccountUnlocked(ctx, w.acctName)
+	if err != nil {
+		return false, err
+	}
+	if res.Encrypted {
+		return *res.Unlocked, nil
+	}
+	// The account is not individually encrypted, so check wallet lock status.
 	walletInfo, err := w.rpcClient.WalletInfo(ctx)
 	if err != nil {
-		w.log.Errorf("walletinfo error: %v", err)
-		return true // assume wallet is unlocked?
+		return false, fmt.Errorf("walletinfo error: %w", err)
 	}
-	return walletInfo.Unlocked
+	return walletInfo.Unlocked, nil
 }
 
-// AccountUnlocked returns true if the specified account is unlocked.
+// Lock locks the specified account.
 // Part of the Wallet interface.
-func (w *rpcWallet) AccountUnlocked(ctx context.Context, account string) (*walletjson.AccountUnlockedResult, error) {
-	res, err := w.rpcClient.AccountUnlocked(ctx, account)
-	return res, translateRPCCancelErr(err)
-}
+func (w *rpcWallet) Lock(ctx context.Context) error {
+	if w.rpcConnector.Disconnected() {
+		return asset.ErrConnectionDown
+	}
 
-// LockAccount locks the specified account.
-// Part of the Wallet interface.
-func (w *rpcWallet) LockAccount(ctx context.Context, account string) error {
-	err := w.rpcClient.LockAccount(ctx, account)
+	// Since hung calls to Lock() may block shutdown of the consumer and thus
+	// cancellation of the ExchangeWallet subsystem's Context, dcr.ctx, give
+	// this a timeout in case the connection goes down or the RPC hangs for
+	// other reasons.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	res, err := w.rpcClient.AccountUnlocked(ctx, w.acctName)
+	if err != nil {
+		return err
+	}
+	if !res.Encrypted {
+		return w.lockWallet(ctx)
+	}
+	if res.Unlocked != nil && !*res.Unlocked {
+		return nil
+	}
+
+	err = w.rpcClient.LockAccount(ctx, w.acctName)
 	if isAccountLockedErr(err) {
 		return nil // it's already locked
 	}
 	return translateRPCCancelErr(err)
 }
 
-// UnlockAccount unlocks the specified account.
+// Unlock unlocks the specified account.
 // Part of the Wallet interface.
-func (w *rpcWallet) UnlockAccount(ctx context.Context, account, passphrase string) error {
-	return translateRPCCancelErr(w.rpcClient.UnlockAccount(ctx, account, passphrase))
+func (w *rpcWallet) Unlock(ctx context.Context, pw []byte) error {
+	return translateRPCCancelErr(w.rpcClient.UnlockAccount(ctx, w.acctName, string(pw)))
 }
 
 // SyncStatus returns the wallet's sync status.
@@ -579,9 +676,13 @@ func (w *rpcWallet) SyncStatus(ctx context.Context) (bool, float32, error) {
 
 // AddressPrivKey fetches the privkey for the specified address.
 // Part of the Wallet interface.
-func (w *rpcWallet) AddressPrivKey(ctx context.Context, address stdaddr.Address) (*dcrutil.WIF, error) {
+func (w *rpcWallet) AddressPrivKey(ctx context.Context, address stdaddr.Address) (*secp256k1.PrivateKey, error) {
 	wif, err := w.rpcClient.DumpPrivKey(ctx, address)
-	return wif, translateRPCCancelErr(err)
+	if err != nil {
+		return nil, translateRPCCancelErr(err)
+	}
+	priv := secp256k1.PrivKeyFromBytes(wif.PrivKey())
+	return priv, nil
 }
 
 // anylist is a list of RPC parameters to be converted to []json.RawMessage and

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -93,8 +93,10 @@ type Wallet interface {
 	SendRawTransaction(ctx context.Context, tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error)
 	// GetBlockHeader returns block header info for the specified block hash.
 	GetBlockHeader(ctx context.Context, blockHash *chainhash.Hash) (*wire.BlockHeader, error)
-	// IsValidMainchain returns true if the block is no orphaned or invalidated.
-	IsValidMainchain(ctx context.Context, hash *chainhash.Hash) (bool, error)
+	// IsValidMainchain returns true if the block is no orphaned or invalidated,
+	// so if this is not the current best block, the next block's vote bits
+	// should be checked.
+	IsValidMainchain(ctx context.Context, blockHash *chainhash.Hash) (bool, error)
 	// GetBlock returns the *wire.MsgBlock.
 	GetBlock(ctx context.Context, blockHash *chainhash.Hash) (*wire.MsgBlock, error)
 	// GetTransaction returns the details of a wallet tx, if the wallet contains a
@@ -112,9 +114,13 @@ type Wallet interface {
 	BlockFilter(ctx context.Context, blockHash *chainhash.Hash) ([gcs.KeySize]byte, *gcs.FilterV2, error)
 	// Unlocked returns true if the Wallet unlocked.
 	Unlocked(ctx context.Context) (bool, error)
-	// Lock locks the Wallet.
+	// Lock locks the Wallet. ExchangeWallet does not differentiate account
+	// locking vs wallet locking, but the underlying implementation may choose
+	// to lock only the account.
 	Lock(ctx context.Context) error
-	// Unlock unlocks the Wallet.
+	// Unlock unlocks the Wallet. ExchangeWallet does not differentiate account
+	// locking vs wallet locking, but the underlying implementation may choose
+	// to unlock only the account.
 	Unlock(ctx context.Context, passphrase []byte) error
 	// SyncStatus returns the wallet's sync status.
 	SyncStatus(ctx context.Context) (bool, float32, error)

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -9,11 +9,11 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
-	"decred.org/dcrwallet/v2/rpc/client/dcrwallet"
 	walletjson "decred.org/dcrwallet/v2/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
-	"github.com/decred/dcrd/dcrutil/v4"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/gcs/v3"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
@@ -48,18 +48,11 @@ type TipChangeCallback func(*chainhash.Hash, int64, error)
 
 // Wallet defines methods that the ExchangeWallet uses for communicating with
 // a Decred wallet and blockchain.
-// TODO: Where possible, replace walletjson and chainjson return types with
-// other types that define fewer fields e.g. *chainjson.TxRawResult with
-// *wire.MsgTx.
 type Wallet interface {
 	// Connect establishes a connection to the wallet.
 	Connect(ctx context.Context) error
 	//  Disconnect shuts down access to the wallet.
 	Disconnect()
-	// Disconnected returns true if the wallet is not connected.
-	Disconnected() bool
-	// Network returns the network of the connected wallet.
-	Network(ctx context.Context) (wire.CurrencyNet, error)
 	// SpvMode returns true if the wallet is connected to the Decred
 	// network via SPV peers.
 	SpvMode() bool
@@ -69,19 +62,14 @@ type Wallet interface {
 	// notification is unimplemented, monitorBlocks should be used to track
 	// tip changes.
 	NotifyOnTipChange(ctx context.Context, cb TipChangeCallback) bool
-	// AccountOwnsAddress checks if the provided address belongs to the
-	// specified account.
-	AccountOwnsAddress(ctx context.Context, account, address string) (bool, error)
-	// AccountBalance returns the balance breakdown for the specified account.
-	AccountBalance(ctx context.Context, account string, confirms int32) (*walletjson.GetAccountBalanceResult, error)
-	// LockedOutputs fetches locked outputs for the specified account.
-	LockedOutputs(ctx context.Context, account string) ([]chainjson.TransactionInput, error)
-	// EstimateSmartFeeRate returns a smart feerate estimate.
-	EstimateSmartFeeRate(ctx context.Context, confTarget int64, mode chainjson.EstimateSmartFeeMode) (float64, error)
-	// Unspents fetches unspent outputs for the specified account.
-	Unspents(ctx context.Context, account string) ([]walletjson.ListUnspentResult, error)
-	// GetChangeAddress returns a change address from the specified account.
-	GetChangeAddress(ctx context.Context, account string) (stdaddr.Address, error)
+	// OwnsAddress checks if the provided address belongs to the Wallet.
+	OwnsAddress(ctx context.Context, addr stdaddr.Address) (bool, error)
+	// Balance returns the balance breakdown for the Wallet.
+	Balance(ctx context.Context, confirms int32) (*walletjson.GetAccountBalanceResult, error)
+	// LockedOutputs fetches locked outputs for the Wallet.
+	LockedOutputs(ctx context.Context) ([]chainjson.TransactionInput, error)
+	// Unspents fetches unspent outputs for the Wallet.
+	Unspents(ctx context.Context) ([]*walletjson.ListUnspentResult, error)
 	// LockUnspent locks or unlocks the specified outpoint.
 	LockUnspent(ctx context.Context, unlock bool, ops []*wire.OutPoint) error
 	// UnspentOutput returns information about an unspent tx output, if found
@@ -92,51 +80,56 @@ type Wallet interface {
 	// for non-wallet outputs. Returns asset.CoinNotFoundError if the unspent
 	// output cannot be located.
 	UnspentOutput(ctx context.Context, txHash *chainhash.Hash, index uint32, tree int8) (*TxOutput, error)
-	// GetNewAddressGapPolicy returns an address from the specified account using
-	// the specified gap policy.
-	GetNewAddressGapPolicy(ctx context.Context, account string, gap dcrwallet.GapPolicy) (stdaddr.Address, error)
-	// SignRawTransaction signs the provided transaction.
-	SignRawTransaction(ctx context.Context, txHex string) (*walletjson.SignRawTransactionResult, error)
+	// ExternalAddress returns a new external address,
+	ExternalAddress(ctx context.Context) (stdaddr.Address, error)
+	// InternalAddress returns a change address from the Wallet.
+	InternalAddress(ctx context.Context) (stdaddr.Address, error)
+	// SignRawTransaction signs the provided transaction. SignRawTransaction
+	// is not used for redemptions, so previous outpoints and scripts should
+	// be known by the wallet.
+	SignRawTransaction(context.Context, *wire.MsgTx) (*wire.MsgTx, error)
 	// SendRawTransaction broadcasts the provided transaction to the Decred
 	// network.
 	SendRawTransaction(ctx context.Context, tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error)
-	// GetBlockHeaderVerbose returns block header info for the specified block hash.
-	GetBlockHeaderVerbose(ctx context.Context, blockHash *chainhash.Hash) (*chainjson.GetBlockHeaderVerboseResult, error)
-	// GetBlockVerbose returns information about a block, optionally including verbose
-	// tx info.
-	GetBlockVerbose(ctx context.Context, blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error)
+	// GetBlockHeader returns block header info for the specified block hash.
+	GetBlockHeader(ctx context.Context, blockHash *chainhash.Hash) (*wire.BlockHeader, error)
+	// IsValidMainchain returns true if the block is no orphaned or invalidated.
+	IsValidMainchain(ctx context.Context, hash *chainhash.Hash) (bool, error)
+	// GetBlock returns the *wire.MsgBlock.
+	GetBlock(ctx context.Context, blockHash *chainhash.Hash) (*wire.MsgBlock, error)
 	// GetTransaction returns the details of a wallet tx, if the wallet contains a
 	// tx with the provided hash. Returns asset.CoinNotFoundError if the tx is not
 	// found in the wallet.
 	GetTransaction(ctx context.Context, txHash *chainhash.Hash) (*walletjson.GetTransactionResult, error)
-	// GetRawTransactionVerbose returns details of the tx with the provided hash.
+	// GetRawTransaction returns details of the tx with the provided hash.
 	// Returns asset.CoinNotFoundError if the tx is not found.
-	GetRawTransactionVerbose(ctx context.Context, txHash *chainhash.Hash) (*chainjson.TxRawResult, error)
-	// GetRawMempool returns hashes for all txs of the specified type in the node's
-	// mempool.
-	GetRawMempool(ctx context.Context, txType chainjson.GetRawMempoolTxTypeCmd) ([]*chainhash.Hash, error)
+	GetRawTransaction(ctx context.Context, txHash *chainhash.Hash) (*wire.MsgTx, error)
 	// GetBestBlock returns the hash and height of the wallet's best block.
 	GetBestBlock(ctx context.Context) (*chainhash.Hash, int64, error)
 	// GetBlockHash returns the hash of the mainchain block at the specified height.
 	GetBlockHash(ctx context.Context, blockHeight int64) (*chainhash.Hash, error)
-	// BlockCFilter fetches the block filter info for the specified block.
-	BlockCFilter(ctx context.Context, blockHash *chainhash.Hash) (filter, key string, err error)
-	// LockWallet locks the wallet.
-	LockWallet(ctx context.Context) error
-	// UnlockWallet unlocks the wallet.
-	UnlockWallet(ctx context.Context, passphrase string, timeoutSecs int64) error
-	// WalletUnlocked returns true if the wallet is unlocked.
-	WalletUnlocked(ctx context.Context) bool
-	// AccountUnlocked returns true if the specified account is unlocked.
-	AccountUnlocked(ctx context.Context, account string) (*walletjson.AccountUnlockedResult, error)
-	// LockAccount locks the specified account.
-	LockAccount(ctx context.Context, account string) error
-	// UnlockAccount unlocks the specified account.
-	UnlockAccount(ctx context.Context, account, passphrase string) error
+	// BlockFilter fetches the block filter info for the specified block.
+	BlockFilter(ctx context.Context, blockHash *chainhash.Hash) ([gcs.KeySize]byte, *gcs.FilterV2, error)
+	// Unlocked returns true if the Wallet unlocked.
+	Unlocked(ctx context.Context) (bool, error)
+	// Lock locks the Wallet.
+	Lock(ctx context.Context) error
+	// Unlock unlocks the Wallet.
+	Unlock(ctx context.Context, passphrase []byte) error
 	// SyncStatus returns the wallet's sync status.
 	SyncStatus(ctx context.Context) (bool, float32, error)
 	// AddressPrivKey fetches the privkey for the specified address.
-	AddressPrivKey(ctx context.Context, address stdaddr.Address) (*dcrutil.WIF, error)
+	AddressPrivKey(ctx context.Context, address stdaddr.Address) (*secp256k1.PrivateKey, error)
+}
+
+type FeeRateEstimator interface {
+	// EstimateSmartFeeRate returns a smart feerate estimate.
+	EstimateSmartFeeRate(ctx context.Context, confTarget int64, mode chainjson.EstimateSmartFeeMode) (float64, error)
+}
+
+type Mempooler interface {
+	// GetRawMempool returns hashes for all txs in a node's mempool.
+	GetRawMempool(ctx context.Context) ([]*chainhash.Hash, error)
 }
 
 // TxOutput defines properties of a transaction output, including the

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -42,6 +42,9 @@ type WalletDefinition struct {
 	// description for each option. This can be used to request config info from
 	// users e.g. via dynamically generated GUI forms.
 	ConfigOpts []*ConfigOption `json:"configopts"`
+	// Managed can be set to true to disable wallet re-configuration through the
+	// standard UI.
+	Managed bool `json:"managed"`
 }
 
 // WalletInfo is auxiliary information about an ExchangeWallet.

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -152,7 +152,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 
 	// Designate the clone ports. These will be overwritten by any explicit
 	// settings in the configuration file.
-	cloneCFG := &btc.BTCCloneCFG{
+	cloneCFG := &btc.RPCCloneConfig{
 		WalletCFG:           cfg,
 		MinNetworkVersion:   minNetworkVersion,
 		WalletInfo:          WalletInfo,
@@ -168,5 +168,6 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		Segwit:              false,
 	}
 
-	return btc.BTCCloneWallet(cloneCFG)
+	w, _, err := btc.RPCCloneWallet(cloneCFG)
+	return w, err
 }

--- a/dex/networks/btc/clone.go
+++ b/dex/networks/btc/clone.go
@@ -26,7 +26,7 @@ func ReadCloneParams(cloneParams *CloneParams) *chaincfg.Params {
 // CloneParams are the parameters needed by BTC-clone-based Backend and
 // ExchangeWallet implementations. Pass a *CloneParams to ReadCloneParams to
 // create a *chaincfg.Params for server/asset/btc.NewBTCClone and
-// client/asset/btc.BTCCloneWallet.
+// client/asset/btc.RPCCloneWallet.
 type CloneParams struct {
 	// PubKeyHashAddrID: Net ID byte for a pubkey-hash address
 	PubKeyHashAddrID byte


### PR DESCRIPTION
**btc**: Instead of passing around a `RawRequester`, just return the
`rpcclient.Client` from the (renamed) `RPCCloneWallet` constructor.

Allow registration of external wallets using the same method as dcr,
which is to register a constructor alongside a `WalletDefinition`. Some
internal reorganization to accommodate. Adds an exported helper method
for constructing an SPV based wallet.

**dcr**: Change `Wallet` methods to use lower-level, common types instead
of json types, e.g. `wire.BlockHeader` instead of `chainjson.GetBlockHeaderVerboseResult`
and `secp256k1.PrivateKey` instead of `btcutil.WIF`.

Remove account argument from all methods and 'Account' from all method
names. The account is already passed into the constructor. In the same
vein, some rpc implementation-specific error handling is move to the
appropriate `rpcWallet` methods, such as `signrawtransaction` errors.