### PR TITLE
client/core: fix conns data races

### DIFF
--- a/client/core/account.go
+++ b/client/core/account.go
@@ -50,7 +50,9 @@ func (c *Core) AccountDisable(pw []byte, addr string) error {
 	dc.cfgMtx.RUnlock()
 	// Disconnect and delete connection from map.
 	dc.connMaster.Disconnect()
+	c.connMtx.Lock()
 	delete(c.conns, dc.acct.host)
+	c.connMtx.Unlock()
 
 	return nil
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1366,8 +1366,9 @@ func (c *Core) dexConnections() []*dexConnection {
 // exchangeMap creates a map of *Exchange keyed by host, including markets and
 // orders.
 func (c *Core) exchangeMap() map[string]*Exchange {
-	infos := make(map[string]*Exchange, len(c.conns))
-	for _, dc := range c.dexConnections() {
+	dcs := c.dexConnections()
+	infos := make(map[string]*Exchange, len(dcs))
+	for _, dc := range dcs {
 		infos[dc.acct.host] = dc.exchangeInfo()
 	}
 	return infos


### PR DESCRIPTION
In testing https://github.com/decred/dcrdex/pull/1141 with manual account disable I hit some races with the `c.conns` maps.

The one in `(*Core).exchangeMap()` is a little surprising since that method is used all the time.