### PR TITLE
dex/testing: set btc harness debug levels per-subsystem

### DIFF
--- a/dex/testing/btc/base-harness.sh
+++ b/dex/testing/btc/base-harness.sh
@@ -79,7 +79,8 @@ tmux send-keys -t $SESSION:0 "set +o history" C-m
 tmux send-keys -t $SESSION:0 "cd ${ALPHA_DIR}" C-m
 echo "Starting simnet alpha node"
 tmux send-keys -t $SESSION:0 "${DAEMON} -rpcuser=user -rpcpassword=pass \
-  -rpcport=${ALPHA_RPC_PORT} -debug -datadir=${ALPHA_DIR} \
+  -rpcport=${ALPHA_RPC_PORT} -datadir=${ALPHA_DIR} \
+  -debug=rpc -debug=net -debug=mempool -debug=walletdb -debug=addrman -debug=mempoolrej \
   -whitelist=127.0.0.0/8 -whitelist=::1 \
   -txindex=1 -regtest=1 -port=${ALPHA_LISTEN_PORT} -fallbackfee=0.00001 \
   ${EXTRA_ARGS}; tmux wait-for -S alpha${SYMBOL}" C-m
@@ -95,7 +96,8 @@ tmux send-keys -t $SESSION:1 "cd ${BETA_DIR}" C-m
 
 echo "Starting simnet beta node"
 tmux send-keys -t $SESSION:1 "${DAEMON} -rpcuser=user -rpcpassword=pass \
-  -rpcport=${BETA_RPC_PORT} -debug -datadir=${BETA_DIR} -txindex=1 -regtest=1 \
+  -rpcport=${BETA_RPC_PORT} -datadir=${BETA_DIR} -txindex=1 -regtest=1 \
+  -debug=rpc -debug=net -debug=mempool -debug=walletdb -debug=addrman -debug=mempoolrej \
   -whitelist=127.0.0.0/8 -whitelist=::1 \
   -port=${BETA_LISTEN_PORT} -fallbackfee=0.00001 ${EXTRA_ARGS}; \
   tmux wait-for -S beta${SYMBOL}" C-m


### PR DESCRIPTION
This sets the bitcoind debug levels selectively.  I was getting spammed with libevent junk.