### PR TITLE
client/asset/btc: use known block hash

### DIFF
--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -1407,7 +1407,7 @@ search:
 						res.spend = &spendingInput{
 							txHash:      tx.TxHash(),
 							vin:         uint32(vin),
-							blockHash:   *block.Hash(),
+							blockHash:   *blockHash,
 							blockHeight: uint32(height),
 						}
 						w.log.Tracef("Found txn %v spending %v in block %v (%d)", res.spend.txHash,
@@ -1427,7 +1427,7 @@ search:
 			}
 			for _, txOut := range tx.TxOut {
 				if bytes.Equal(txOut.PkScript, pkScript) {
-					res.blockHash = block.Hash()
+					res.blockHash = blockHash
 					res.blockHeight = uint32(height)
 					res.txOut = txOut
 					w.log.Tracef("Found txn %v in block %v (%d)", txHash, res.blockHash, height)


### PR DESCRIPTION
Use the known block `Hash` instead of using the `btcutil.(*Block).Hash` method.  That method mutates a field of the `Block` to cache the hash, unfortunately it is not thread-safe, and it is in use concurrent with other goroutines inside neutrino including `VerifyBasicBlockFilter`.

https://github.com/btcsuite/btcutil/blob/9cdf59f60c5150188dc0fadac6e9383522fddb74/block.go#L93-L106

<details>
<summary>race 1</summary>

```
==================
WARNING: DATA RACE
Read at 0x00c000d7f618 by goroutine 53:
  github.com/btcsuite/btcutil.(*Block).Hash()
      /home/jon/go/pkg/mod/github.com/btcsuite/btcutil@v1.0.3-0.20210527170813-e2ba6805a890/block.go:98 +0x52
  decred.org/dcrdex/client/asset/btc.(*spvWallet).filterScanFromHeight()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:1430 +0xf98
  decred.org/dcrdex/client/asset/btc.(*spvWallet).scanFilters()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:1272 +0x512
  decred.org/dcrdex/client/asset/btc.(*spvWallet).swapConfirmations()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:812 +0x6f0
  decred.org/dcrdex/client/asset/btc.(*spvWallet).swapConfirmations()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:810 +0x6a1
  decred.org/dcrdex/client/asset/btc.(*spvWallet).swapConfirmations()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:785 +0x47d
  decred.org/dcrdex/client/asset/btc.(*ExchangeWallet).SwapConfirmations()
      /home/jon/github/decred/dcrdex/client/asset/btc/btc.go:2372 +0x165
  decred.org/dcrdex/client/core.(*xcWallet).SwapConfirmations()
      /home/jon/github/decred/dcrdex/client/core/wallet.go:254 +0x193
  decred.org/dcrdex/client/core.(*trackedTrade).isSwappable()
      /home/jon/github/decred/dcrdex/client/core/trade.go:883 +0xcf5
  decred.org/dcrdex/client/core.(*Core).tick()
      /home/jon/github/decred/dcrdex/client/core/trade.go:1104 +0x6dd
  decred.org/dcrdex/client/core.(*Core).listen.func3()
      /home/jon/github/decred/dcrdex/client/core/core.go:5579 +0x7eb
  decred.org/dcrdex/client/core.(*Core).listen.func4()
      /home/jon/github/decred/dcrdex/client/core/core.go:5609 +0x3d1
  decred.org/dcrdex/client/core.(*Core).listen.func3()
      /home/jon/github/decred/dcrdex/client/core/core.go:5579 +0x7eb
  decred.org/dcrdex/client/core.(*Core).listen.func4()
      /home/jon/github/decred/dcrdex/client/core/core.go:5609 +0x3d1
  decred.org/dcrdex/client/core.(*Core).listen.func3()
      /home/jon/github/decred/dcrdex/client/core/core.go:5579 +0x7eb
  decred.org/dcrdex/client/core.(*Core).listen.func4()
      /home/jon/github/decred/dcrdex/client/core/core.go:5609 +0x3d1

Previous write at 0x00c000d7f618 by goroutine 136:
  github.com/btcsuite/btcutil.(*Block).Hash()
      /home/jon/go/pkg/mod/github.com/btcsuite/btcutil@v1.0.3-0.20210527170813-e2ba6805a890/block.go:104 +0xec
  github.com/lightninglabs/neutrino.VerifyBasicBlockFilter()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/verification.go:20 +0x52
  github.com/lightninglabs/neutrino.extractBlockMatches()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:964 +0x129
  github.com/lightninglabs/neutrino.notifyBlockWithFilter()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:1045 +0xd8
  github.com/lightninglabs/neutrino.rescan.func2()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:592 +0xb59
  github.com/lightninglabs/neutrino.rescan()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:717 +0x2298
  github.com/lightninglabs/neutrino.(*Rescan).Start.func1()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:1320 +0x22f

Goroutine 53 (running) created at:
  decred.org/dcrdex/client/core.(*Core).listen()
      /home/jon/github/decred/dcrdex/client/core/core.go:5594 +0x733
  decred.org/dcrdex/client/core.(*Core).connectDEX·dwrap·63()
      /home/jon/github/decred/dcrdex/client/core/core.go:5173 +0x47

Goroutine 136 (running) created at:
  github.com/lightninglabs/neutrino.(*Rescan).Start()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:1316 +0x118
  github.com/btcsuite/btcwallet/chain.(*NeutrinoClient).Rescan()
      /home/jon/go/pkg/mod/github.com/btcsuite/btcwallet@v0.12.0/chain/neutrino.go:430 +0x15b6
  github.com/btcsuite/btcwallet/wallet.(*Wallet).rescanRPCHandler()
      /home/jon/go/pkg/mod/github.com/btcsuite/btcwallet@v0.12.0/wallet/rescan.go:257 +0x4a1
  github.com/btcsuite/btcwallet/wallet.(*Wallet).SynchronizeRPC·dwrap·18()
      /home/jon/go/pkg/mod/github.com/btcsuite/btcwallet@v0.12.0/wallet/wallet.go:197 +0x39
==================
```
</details>

<details>
<summary>race 2</summary>

```
==================
WARNING: DATA RACE
Read at 0x00c00014b3c0 by goroutine 53:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  fmt.(*pp).handleMethods()
      /home/jon/go117/src/fmt/print.go:626 +0x6cf
  fmt.(*pp).printArg()
      /home/jon/go117/src/fmt/print.go:709 +0xca9
  fmt.(*pp).doPrintf()
      /home/jon/go117/src/fmt/print.go:1026 +0x46f
  fmt.Fprintf()
      /home/jon/go117/src/fmt/print.go:204 +0x7e
  github.com/decred/slog.(*Backend).printf()
      /home/jon/go/pkg/mod/github.com/decred/slog@v1.2.0/log.go:336 +0x418
  github.com/decred/slog.(*slog).Tracef()
      /home/jon/go/pkg/mod/github.com/decred/slog@v1.2.0/log.go:378 +0xd1
  decred.org/dcrdex/dex.(*logger).Tracef()
      <autogenerated>:1 +0x92
  decred.org/dcrdex/client/asset/btc.(*spvWallet).filterScanFromHeight()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:1433 +0x11fc
  decred.org/dcrdex/client/asset/btc.(*spvWallet).scanFilters()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:1272 +0x512
  decred.org/dcrdex/client/asset/btc.(*spvWallet).swapConfirmations()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:812 +0x6f0
  decred.org/dcrdex/client/asset/btc.(*spvWallet).swapConfirmations()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:810 +0x6a1
  decred.org/dcrdex/client/asset/btc.(*spvWallet).swapConfirmations()
      /home/jon/github/decred/dcrdex/client/asset/btc/spv.go:785 +0x47d
  decred.org/dcrdex/client/asset/btc.(*ExchangeWallet).SwapConfirmations()
      /home/jon/github/decred/dcrdex/client/asset/btc/btc.go:2372 +0x165
  decred.org/dcrdex/client/core.(*xcWallet).SwapConfirmations()
      /home/jon/github/decred/dcrdex/client/core/wallet.go:254 +0x193
  decred.org/dcrdex/client/core.(*trackedTrade).isSwappable()
      /home/jon/github/decred/dcrdex/client/core/trade.go:883 +0xcf5
  decred.org/dcrdex/client/core.(*Core).tick()
      /home/jon/github/decred/dcrdex/client/core/trade.go:1104 +0x6dd
  decred.org/dcrdex/client/core.(*Core).listen.func3()
      /home/jon/github/decred/dcrdex/client/core/core.go:5579 +0x7eb
  decred.org/dcrdex/client/core.(*Core).listen.func4()
      /home/jon/github/decred/dcrdex/client/core/core.go:5609 +0x3d1
  decred.org/dcrdex/client/core.(*Core).listen.func3()
      /home/jon/github/decred/dcrdex/client/core/core.go:5579 +0x7eb
  decred.org/dcrdex/client/core.(*Core).listen.func4()
      /home/jon/github/decred/dcrdex/client/core/core.go:5609 +0x3d1
  decred.org/dcrdex/client/core.(*Core).listen.func3()
      /home/jon/github/decred/dcrdex/client/core/core.go:5579 +0x7eb
  decred.org/dcrdex/client/core.(*Core).listen.func4()
      /home/jon/github/decred/dcrdex/client/core/core.go:5609 +0x3d1

Previous write at 0x00c00014b3c0 by goroutine 136:
  github.com/btcsuite/btcutil.(*Block).Hash()
      /home/jon/go/pkg/mod/github.com/btcsuite/btcutil@v1.0.3-0.20210527170813-e2ba6805a890/block.go:103 +0xcc
  github.com/lightninglabs/neutrino.VerifyBasicBlockFilter()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/verification.go:20 +0x52
  github.com/lightninglabs/neutrino.extractBlockMatches()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:964 +0x129
  github.com/lightninglabs/neutrino.notifyBlockWithFilter()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:1045 +0xd8
  github.com/lightninglabs/neutrino.rescan.func2()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:592 +0xb59
  github.com/lightninglabs/neutrino.rescan()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:717 +0x2298
  github.com/lightninglabs/neutrino.(*Rescan).Start.func1()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:1320 +0x22f

Goroutine 53 (running) created at:
  decred.org/dcrdex/client/core.(*Core).listen()
      /home/jon/github/decred/dcrdex/client/core/core.go:5594 +0x733
  decred.org/dcrdex/client/core.(*Core).connectDEX·dwrap·63()
      /home/jon/github/decred/dcrdex/client/core/core.go:5173 +0x47

Goroutine 136 (running) created at:
  github.com/lightninglabs/neutrino.(*Rescan).Start()
      /home/jon/go/pkg/mod/github.com/lightninglabs/neutrino@v0.12.3/rescan.go:1316 +0x118
  github.com/btcsuite/btcwallet/chain.(*NeutrinoClient).Rescan()
      /home/jon/go/pkg/mod/github.com/btcsuite/btcwallet@v0.12.0/chain/neutrino.go:430 +0x15b6
  github.com/btcsuite/btcwallet/wallet.(*Wallet).rescanRPCHandler()
      /home/jon/go/pkg/mod/github.com/btcsuite/btcwallet@v0.12.0/wallet/rescan.go:257 +0x4a1
  github.com/btcsuite/btcwallet/wallet.(*Wallet).SynchronizeRPC·dwrap·18()
      /home/jon/go/pkg/mod/github.com/btcsuite/btcwallet@v0.12.0/wallet/wallet.go:197 +0x39
==================

```
</details>