### PR TITLE
server,eth: add method for account balance retrieval

### DIFF
--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -78,6 +78,8 @@ type testNode struct {
 	tx             *types.Transaction
 	txIsMempool    bool
 	txErr          error
+	acctBal        *big.Int
+	acctBalErr     error
 }
 
 func (n *testNode) connect(ctx context.Context, ipc string, contractAddr *common.Address) error {
@@ -120,6 +122,10 @@ func (n *testNode) swap(ctx context.Context, secretHash [32]byte) (*swap.ETHSwap
 
 func (n *testNode) transaction(ctx context.Context, hash common.Hash) (tx *types.Transaction, isMempool bool, err error) {
 	return n.tx, n.txIsMempool, n.txErr
+}
+
+func (n *testNode) accountBalance(ctx context.Context, addr common.Address) (*big.Int, error) {
+	return n.acctBal, n.acctBalErr
 }
 
 func tSwap(bn int64, locktime, value *big.Int, state SwapState, participantAddr *common.Address) *swap.ETHSwapSwap {
@@ -712,5 +718,38 @@ func TestValidateContract(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error for test %q: %v", test.name, err)
 		}
+	}
+}
+
+func TestAccountBalance(t *testing.T) {
+	node := &testNode{}
+	eth := &Backend{node: node}
+
+	const gweiBal = 1e9
+	bigBal := big.NewInt(gweiBal)
+	node.acctBal = bigBal.Mul(bigBal, big.NewInt(GweiFactor))
+
+	// Initial success
+	bal, err := eth.AccountBalance("")
+	if err != nil {
+		t.Fatalf("AccountBalance error: %v", err)
+	}
+
+	if bal != gweiBal {
+		t.Fatalf("wrong balance. expected %f, got %d", gweiBal, bal)
+	}
+
+	// Only error path.
+	node.acctBalErr = errors.New("test error")
+	_, err = eth.AccountBalance("")
+	if err == nil {
+		t.Fatalf("no AccountBalance error when expected")
+	}
+	node.acctBalErr = nil
+
+	// Success again
+	_, err = eth.AccountBalance("")
+	if err != nil {
+		t.Fatalf("AccountBalance error: %v", err)
 	}
 }

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -120,3 +120,13 @@ func (c *rpcclient) swap(ctx context.Context, secretHash [32]byte) (*swap.ETHSwa
 func (c *rpcclient) transaction(ctx context.Context, hash common.Hash) (tx *types.Transaction, isMempool bool, err error) {
 	return c.ec.TransactionByHash(ctx, hash)
 }
+
+// accountBalance gets the account balance, including the effects of known
+// unmined transactions.
+func (c *rpcclient) accountBalance(ctx context.Context, addr common.Address) (*big.Int, error) {
+	bigBal, err := c.ec.PendingBalanceAt(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	return bigBal, nil
+}

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -186,9 +186,13 @@ func (r *OrderRouter) respondError(reqID uint64, user account.AccountID, msgErr 
 }
 
 func fundingCoin(backend asset.Backend, coinID []byte, redeemScript []byte) (asset.FundingCoin, error) {
+	outputTracker, is := backend.(asset.OutputTracker)
+	if !is {
+		return nil, fmt.Errorf("fundingCoin requested for incapable asset")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	return backend.FundingCoin(ctx, coinID, redeemScript)
+	return outputTracker.FundingCoin(ctx, coinID, redeemScript)
 }
 
 func coinConfirmations(coin asset.Coin) (int64, error) {

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1908,13 +1908,16 @@ func (s *Swapper) processMatchAcks(user account.AccountID, msg *msgjson.Message,
 // CheckUnspent attempts to verify a coin ID for a given asset by retrieving the
 // corresponding asset.Coin. If the coin is not found or spent, an
 // asset.CoinNotFoundError is returned.
-func (s *Swapper) CheckUnspent(ctx context.Context, asset uint32, coinID []byte) error {
-	backend := s.coins[asset]
+func (s *Swapper) CheckUnspent(ctx context.Context, assetID uint32, coinID []byte) error {
+	backend := s.coins[assetID]
 	if backend == nil {
-		return fmt.Errorf("unknown asset %d", asset)
+		return fmt.Errorf("unknown asset %d", assetID)
 	}
-
-	return backend.Backend.VerifyUnspentCoin(ctx, coinID)
+	outputTracker, is := backend.Backend.(asset.OutputTracker)
+	if !is {
+		return nil
+	}
+	return outputTracker.VerifyUnspentCoin(ctx, coinID)
 }
 
 // LockOrdersCoins locks the backing coins for the provided orders.


### PR DESCRIPTION
The interfaces are going to need to diverge when it comes to tracking funding ability. This PR is a first thrust at a reasonable interface scheme so that we can begin work in `Swapper`, `Market`, and `CoinLocker`.