### PR TITLE
client/asset/btc: log the acct xpub on start

### DIFF
--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -1065,6 +1065,13 @@ func (w *spvWallet) startWallet() error {
 		bailOnWalletAndDB()
 	}
 
+	props, err := btcw.AccountProperties(waddrmgr.KeyScopeBIP0084, w.acctNum)
+	if err != nil || props.AccountPubKey == nil {
+		w.log.Warnf("Unable to retrieve account properties: %v", err)
+	} else {
+		w.log.Tracef("Account extended public key (do not share): %v", props.AccountPubKey.String())
+	}
+
 	w.cl = chainService
 	w.chainClient = chain.NewNeutrinoClient(w.chainParams, chainService)
 	w.wallet = &walletExtender{btcw, w.chainParams}

--- a/server/asset/btc/addresser_test.go
+++ b/server/asset/btc/addresser_test.go
@@ -51,6 +51,9 @@ func TestAddressDeriver(t *testing.T) {
 	// params := &chaincfg.TestNet3Params
 	// zpub := "vpub5UpDTWU6Nuj9uuU5TZnxjS97SAjKwY4UiLvvnYNRC6vmvbDa5toZRG1BkqCnLSRmNYuLuqLDPtdDq6YvELoMUSPjVSFTsX1H42kabkJDwWD"
 	// xpubWant := "tpubD8rNb5dcPYmZtJ3AaUMJMXfV7E7spAYY6CZfhtDLJ2SRn5WjfRymopzJ3HCjrkgqyjfs2N3CrKANHrGf4bUcxMDEHiPcisJVBSUH8wNhdoA"
+	// params := &chaincfg.RegressionNetParams
+	// zpub := "vpub5YqS5eyUTyzmeuQiyW96jgBcRiCNSEMapKkUcF6L8kWSrma29AXi9Zr4e5rxCjk4eZnP8sTpeXNJDdFr6kMGjh8ZqraXpYyyq1XfaaPwt32"
+	// xpubWant := "tpubDCsbDE8zUd3BdHyp6QhSMmhz6mavJrqeCBPDXawFEg26iFsBihhvY8qAvXruj419FkYuFQAp6wuSgNyaw12YDbx4e8igfuHBxRFN7kRdZbM"
 
 	net := params.Net
 


### PR DESCRIPTION
The btcwallet account extended public key for the p2wpkh keys are useful
for a variety of reasons, so add a trace log in startWallet to show it.