### PR TITLE
client/{core,webserver}: show match revoked status

### DIFF
--- a/client/core/types.go
+++ b/client/core/types.go
@@ -140,6 +140,7 @@ type RegisterForm struct {
 type Match struct {
 	MatchID       dex.Bytes         `json:"matchID"`
 	Status        order.MatchStatus `json:"status"`
+	Active        bool              `json:"active"`
 	Revoked       bool              `json:"revoked"`
 	Rate          uint64            `json:"rate"`
 	Qty           uint64            `json:"qty"`
@@ -257,6 +258,7 @@ func matchFromMetaMatchWithConfs(ord order.Order, metaMatch *db.MetaMatch, swapC
 	match := &Match{
 		MatchID:       userMatch.MatchID[:],
 		Status:        userMatch.Status,
+		Active:        db.MatchIsActive(userMatch, proof),
 		Revoked:       proof.IsRevoked(),
 		Rate:          userMatch.Rate,
 		Qty:           userMatch.Quantity,


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/922

Supplement `core.Match` with an `Active` field, set via `db.MatchIsActive`.

Update `(*orderReader).hasLiveMatches` to consult the `Active` field instead of just comparing `Status < MakerRedeemed`.

Update `(*matchReader).StatusString` with text for revoked matches.
When revoked and also active show "Revoked - Refund PENDING".
When revoked and not active, show if it was refunded, (auto)redeemed, or simply complete when no txns are needed.

**Revoked and waiting to refund**

![image](https://user-images.githubusercontent.com/9373513/141378857-09c78f4b-41f5-43be-9cc3-6a335a021650.png)

**Revoked with nothing to do (inactive)**

![image](https://user-images.githubusercontent.com/9373513/141378869-5b691b09-7846-4aa4-b35c-e2b5920d5e59.png)

**Revoked and auto-redeemed**

![image](https://user-images.githubusercontent.com/9373513/141378950-99fe1078-ad36-429f-8cd4-31cd9e546212.png)
