### PR TITLE
server/comms: add new routes to limiter

### DIFF
--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -181,8 +181,8 @@ const (
 	// PenaltyRoute is the DEX-originating notification-type message
 	// informing of a broken rule and the resulting penalty.
 	PenaltyRoute = "penalty"
-	// SpotsRoute is the HTTP or WebSocket request to get the spot price and
-	// volume for the DEX's markets.
+	// SpotsRoute is the client-originating HTTP or WebSocket request to get the
+	// spot price and volume for the DEX's markets.
 	SpotsRoute = "spots"
 	// FeeRateRoute is the client-originating request asking for the most
 	// recently recorded transaction fee estimate for an asset.

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -51,12 +51,12 @@ const (
 	// Per-websocket-connection limits in requests per second. Rate should be a
 	// reasonable sustained rate, while burst should consider bulk reconnect
 	// operations. Consider which routes are authenticated when setting these.
-	wsRateStatus, wsBurstStatus     = 10, 500     // order_status and match_status (combined)
-	wsRateOrder, wsBurstOrder       = 5, 100      // market, limit, and cancel (combined)
-	wsRateInfo, wsBurstInfo         = 10, 200     // low-cost route limiter for: config, fee_rate, spots, candles (combined)
-	wsRateSubs, wsBurstSubs         = 2, 100      // subscriptions: orderbook and price feed (combined)
-	wsRateRegister, wsBurstRegister = 1 / 60.0, 1 // register, rate.Every(time.Minute) but const
-	wsRateConnect, wsBurstConnect   = 4, 100      // connect, account discovery requires bursts - (*Core).discoverAccount
+	wsRateStatus, wsBurstStatus     = 10, 500      // order_status and match_status (combined)
+	wsRateOrder, wsBurstOrder       = 5, 100       // market, limit, and cancel (combined)
+	wsRateInfo, wsBurstInfo         = 10, 200      // low-cost route limiter for: config, fee_rate, spots, candles (combined)
+	wsRateSubs, wsBurstSubs         = 1 / 2.0, 100 // subscriptions: orderbook and price feed (combined)
+	wsRateRegister, wsBurstRegister = 1 / 60.0, 1  // register, rate.Every(time.Minute) but const
+	wsRateConnect, wsBurstConnect   = 1 / 5.0, 100 // connect, account discovery requires bursts - (*Core).discoverAccount
 	// The cumulative rates below would need to be less than sum of above to
 	// actually trip unless it is also applied to unspecified routes.
 	wsRateTotal, wsBurstTotal = 40, 1000


### PR DESCRIPTION
Add the newish price feed, spots, and candles to the `routeLimiter`.
The "info" limiter includes the spots and candles routes.
A new shared limiter for subscription routes is created for the `order_book` and the new `price_feed` routes.
Add the connect route with its own rates. Burst is still 100. Clients should self limit during account discover, as we do.