### PR TITLE
eth/client: Lock funds for possible refund

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -554,8 +554,9 @@ func decodeCoinID(coinID []byte) (*coin, error) {
 // selected coins, but since there are no redeem scripts in Ethereum, nil is returned.
 // Equal number of coins and redeem scripts must be returned.
 func (eth *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, error) {
-	maxFees := ord.DEXConfig.MaxFeeRate * ord.DEXConfig.SwapSize * ord.MaxSwapCount
-	fundsNeeded := ord.Value + maxFees
+	maxSwapFees := ord.DEXConfig.MaxFeeRate * ord.DEXConfig.SwapSize * ord.MaxSwapCount
+	refundFees := srveth.RefundGas * ord.DEXConfig.MaxFeeRate
+	fundsNeeded := ord.Value + maxSwapFees + refundFees
 
 	var nonce [8]byte
 	copy(nonce[:], encode.RandomBytes(8))

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -1065,6 +1065,56 @@ func TestRedeem(t *testing.T) {
 		}
 	}
 }
+
+func TestRefundGas(t *testing.T) {
+	amt := big.NewInt(1e18)
+	txOpts := newTxOpts(ctx, &simnetAddr, amt)
+	var secret [32]byte
+	copy(secret[:], encode.RandomBytes(32))
+	secretHash := sha256.Sum256(secret[:])
+	err := ethClient.unlock(ctx, pw, simnetAcct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initiations := []dexeth.ETHSwapInitiation{{
+		RefundTimestamp: big.NewInt(1),
+		SecretHash:      secretHash,
+		Participant:     participantAddr,
+		Value:           amt,
+	}}
+	_, err = ethClient.initiate(txOpts, simnetID, initiations)
+	if err != nil {
+		t.Fatalf("Unable to initiate swap: %v ", err)
+	}
+	if err := waitForMined(t, time.Second*8, true); err != nil {
+		t.Fatalf("unexpected error while waiting to mine: %v", err)
+	}
+	parsedAbi, err := abi.JSON(strings.NewReader(dexeth.ETHSwapABI))
+	if err != nil {
+		t.Fatalf("unexpected error parsing abi: %v", err)
+	}
+
+	data, err := parsedAbi.Pack("refund", secretHash)
+	if err != nil {
+		t.Fatalf("unexpected error packing abi: %v", err)
+	}
+	msg := ethereum.CallMsg{
+		From: simnetAddr,
+		To:   &contractAddr,
+		Gas:  0,
+		Data: data,
+	}
+	gas, err := ethClient.estimateGas(ctx, msg)
+	if err != nil {
+		t.Fatalf("Error estimating gas for refund function: %v", err)
+	}
+	if gas > srveth.RefundGas || gas < srveth.RefundGas/100*95 {
+		t.Fatalf("expected refund gas to be near %d, but got %d",
+			srveth.RefundGas, gas)
+	}
+	fmt.Printf("Gas used for refund: %v \n", gas)
+}
+
 func TestRefund(t *testing.T) {
 	amt := big.NewInt(1e18)
 	locktime := time.Second * 12

--- a/server/asset/eth/common.go
+++ b/server/asset/eth/common.go
@@ -264,6 +264,8 @@ const (
 	// AdditionalRedeemGas is the amount of gas needed to redeem
 	// additional swaps in the same transaction.
 	AdditionalRedeemGas = 32000
+	// RefundGas is the amount of gas it costs to refund a swap.
+	RefundGas = 43000
 )
 
 // ToGwei converts a *big.Int in wei (1e18 unit) to gwei (1e9 unit) as a uint64.


### PR DESCRIPTION
Prior to this, `FundOrder` did not lock funds to use for the gas fees in the case of a refund.