### PR TITLE
server/{swap,market}: add funding checks for account-based assets

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -2928,12 +2928,12 @@ func testTryRedemptionRequests(t *testing.T, segwit bool, walletType string) {
 
 		node.truncateChains()
 		wallet.findRedemptionQueue = make(map[outPoint]*findRedemptionReq)
-		node.blockchainMtx.RLock()
+		node.blockchainMtx.Lock()
 		node.getBestBlockHashErr = nil
 		if tt.forcedErr {
 			node.getBestBlockHashErr = tErr
 		}
-		node.blockchainMtx.RUnlock()
+		node.blockchainMtx.Unlock()
 		addBlocks(tt.numBlocks)
 		var startBlock *chainhash.Hash
 		if tt.startBlockHeight >= 0 {

--- a/dex/asset.go
+++ b/dex/asset.go
@@ -118,7 +118,8 @@ type Asset struct {
 	Version      uint32   `json:"version"`
 	MaxFeeRate   uint64   `json:"maxFeeRate"`
 	SwapSize     uint64   `json:"swapSize"`
-	SwapSizeBase uint64   `json:"swapSizeBase"`
+	SwapSizeBase uint64   `json:"swapSizeBase"`         // = SwapSize for account-based assets
+	RedeemSize   uint64   `json:"redeemSize,omitempty"` // Account-based assets only
 	SwapConf     uint32   `json:"swapConf"`
 	UnitInfo     UnitInfo `json:"unitInfo"`
 }

--- a/dex/bip-id.go
+++ b/dex/bip-id.go
@@ -479,6 +479,7 @@ var bipIDs = map[uint32]string{
 	890:      "xsel",
 	900:      "lmo",
 	916:      "meta",
+	966:      "matic",
 	970:      "twins",
 	996:      "okp",
 	997:      "sum",

--- a/dex/calc/fees.go
+++ b/dex/calc/fees.go
@@ -14,12 +14,16 @@ import (
 // number of lots in the order. For the quote asset, maxSwaps is not swapVal /
 // lotSize, so it must be a separate parameter. The chained swap txns will be
 // the standard size as they will spend a previous swap's change output.
+// For account-based assets, inputsSize will be zero, and nfo.SwapSize =
+// nfo.SwapSizeBase.
 func RequiredOrderFunds(swapVal, inputsSize, maxSwaps uint64, nfo *dex.Asset) uint64 {
 	return RequiredOrderFundsAlt(swapVal, inputsSize, maxSwaps, nfo.SwapSizeBase, nfo.SwapSize, nfo.MaxFeeRate)
 }
 
 // RequiredOrderFundsAlt is the same as RequiredOrderFunds, but built-in type
 // parameters.
+// For account-based assets, inputsSize will be zero, and swapSize =
+// swapSizeBase.
 func RequiredOrderFundsAlt(swapVal, inputsSize, maxSwaps, swapSizeBase, swapSize, feeRate uint64) uint64 {
 	baseBytes := maxSwaps * swapSize
 	// SwapSize already includes one input, replace the size of the first swap

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -473,6 +473,42 @@ func (t *Trade) SwapAddress() string {
 	return t.Address
 }
 
+// FromAccount is the account that the order originates from. Only useful for
+// account-based assets. Use of this method assumes that account coin has
+// already been added.
+func (t *Trade) FromAccount() string {
+	if len(t.Coins) == 0 {
+		return "no coins?"
+	}
+	return string(t.Coins[0])
+}
+
+// ToAccount is the account that the order pays to. Only useful for
+// account-based assets.
+func (t *Trade) ToAccount() string {
+	return t.Address
+}
+
+// BaseAccount is the account address associated with the base asset for the
+// order. Only useful for account-based assets. Use of this method assumes that
+// account coin has already been added (when sell = true).
+func (t *Trade) BaseAccount() string {
+	if t.Sell {
+		return t.FromAccount()
+	}
+	return t.ToAccount()
+}
+
+// QuoteAccount is the account address associated with the quote asset for the
+// order. Only useful for account-based assets. Use of this method assumes that
+// account coin has already been added (when sell = false).
+func (t *Trade) QuoteAccount() string {
+	if t.Sell {
+		return t.ToAccount()
+	}
+	return t.FromAccount()
+}
+
 // serializeSize returns the length of the serialized Trade.
 func (t *Trade) serializeSize() int {
 	// Compute the size of the serialized Coin IDs.

--- a/dex/order/order.go
+++ b/dex/order/order.go
@@ -480,6 +480,8 @@ func (t *Trade) FromAccount() string {
 	if len(t.Coins) == 0 {
 		return "no coins?"
 	}
+	// The coin ID should be the UTF-8 encoded address string, not the address
+	// byte-array. t.Coins[0] = []byte(addrStr).
 	return string(t.Coins[0])
 }
 

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -62,6 +62,9 @@ type Backend interface {
 	CheckAddress(string) bool
 	// ValidateCoinID checks the coinID to ensure it can be decoded, returning a
 	// human-readable string if it is valid.
+	// Note: ValidateCoinID is NOT used for funding coin IDs for account-based
+	// assets. This rule is only enforced by code patterns right now, but we may
+	// consider adding separate methods in the future.
 	ValidateCoinID(coinID []byte) (string, error)
 	// ValidateContract ensures that the swap contract is constructed properly
 	// for the asset.

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -92,6 +92,9 @@ type OutputTracker interface {
 type AccountBalancer interface {
 	// AccountBalance retrieves the current account balance.
 	AccountBalance(addr string) (uint64, error)
+	// ValidateSignature checks that the pubkey is correct for the address and
+	// that the signature shows ownership of the associated private key.
+	ValidateSignature(addr string, pubkey, msg, sig []byte) error
 }
 
 // Coin represents a transaction input or output.

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -97,6 +97,10 @@ type AccountBalancer interface {
 	AccountBalance(addr string) (uint64, error)
 	// ValidateSignature checks that the pubkey is correct for the address and
 	// that the signature shows ownership of the associated private key.
+	// IMPORTANT: As part of signature validation, the asset backend should
+	// validate the address against a STRICT standard. Case, prefixes, suffixes,
+	// etc. must be exactly the same order-to-order, since the address string
+	// is used as a key for various accounting operations throughout DEX.
 	ValidateSignature(addr string, pubkey, msg, sig []byte) error
 }
 

--- a/server/asset/eth/coiner_test.go
+++ b/server/asset/eth/coiner_test.go
@@ -164,6 +164,7 @@ func TestNewSwapCoin(t *testing.T) {
 			node:         node,
 			log:          tLogger,
 			contractAddr: *contractAddr,
+			initTxSize:   uint32(dexeth.InitGas(1, 0)),
 		}
 		sc, err := eth.newSwapCoin(test.coinID, test.ct)
 		if test.wantErr {
@@ -321,6 +322,7 @@ func TestConfirmations(t *testing.T) {
 			node:         node,
 			log:          tLogger,
 			contractAddr: *contractAddr,
+			initTxSize:   uint32(dexeth.InitGas(1, 0)),
 		}
 
 		sc, err := eth.newSwapCoin(txCoinIDBytes, test.ct)

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -107,7 +107,6 @@ type ethFetcher interface {
 type Backend struct {
 	// A connection-scoped Context is used to cancel active RPCs on
 	// connection shutdown.
-	ver        uint32
 	rpcCtx     context.Context
 	cancelRPCs context.CancelFunc
 	cfg        *config
@@ -128,6 +127,8 @@ type Backend struct {
 	// case of updating where two contracts may be valid for some time,
 	// possibly disallowing initialization for the deprecated one only.
 	contractAddr common.Address
+	// initTxSize is the gas used for an initiation transaction with one swap.
+	initTxSize uint32
 }
 
 // Check that Backend satisfies the Backend interface.
@@ -158,6 +159,7 @@ func unconnectedETH(logger dex.Logger, cfg *config) *Backend {
 		log:          logger,
 		blockChans:   make(map[chan *asset.BlockUpdate]struct{}),
 		contractAddr: contractAddr,
+		initTxSize:   uint32(dexeth.InitGas(1, version)),
 	}
 }
 
@@ -226,21 +228,14 @@ func (eth *Backend) TxData(coinID []byte) ([]byte, error) {
 	return tx.MarshalBinary()
 }
 
-// InitTxSize is not size for eth. In ethereum the size of a non-standard
-// transaction does not say anything about the processing power the ethereum
-// virtual machine will use in order to process it, and therefor gas needed
-// cannot be ascertained from it. Multiplying the required gas by the gas price
-// will give us the actual fee needed, so returning gas here.
+// InitTxSize is an upper limit on the gas used for an initiation.
 func (eth *Backend) InitTxSize() uint32 {
-	return uint32(dexeth.InitGas(1, eth.ver))
+	return eth.initTxSize
 }
 
-// InitTxSizeBase is used in fee.go in a fee calculation. Currently we are
-// unable to batch eth contract calls like UTXO coins so all contracts will
-// need to be per transaction. Setting this to zero produces the expected
-// result in fee calculations.
+// InitTxSizeBase is the same as InitTxSize for ETH.
 func (eth *Backend) InitTxSizeBase() uint32 {
-	return uint32(dexeth.InitGas(1, eth.ver))
+	return eth.initTxSize
 }
 
 // FeeRate returns the current optimal fee rate in gwei / gas.

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -240,7 +240,7 @@ func (eth *Backend) InitTxSize() uint32 {
 // need to be per transaction. Setting this to zero produces the expected
 // result in fee calculations.
 func (eth *Backend) InitTxSizeBase() uint32 {
-	return 0
+	return uint32(dexeth.InitGas(1, eth.ver))
 }
 
 // FeeRate returns the current optimal fee rate in gwei / gas.

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -380,7 +380,9 @@ func TestSynced(t *testing.T) {
 // TestRequiredOrderFunds ensures that a fee calculation in the calc package
 // will come up with the correct required funds.
 func TestRequiredOrderFunds(t *testing.T) {
-	eth := new(Backend)
+	eth := &Backend{
+		initTxSize: uint32(dexeth.InitGas(1, 0)),
+	}
 	swapVal := uint64(1000000000)                // gwei
 	numSwaps := uint64(17)                       // swaps
 	initSizeBase := uint64(eth.InitTxSizeBase()) // 0 gas

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -395,8 +395,9 @@ func TestRequiredOrderFunds(t *testing.T) {
 		SwapSize:     initSize,
 		MaxFeeRate:   feeRate,
 	}
+
 	// Second argument called inputsSize same as another initSize.
-	got := calc.RequiredOrderFunds(swapVal, initSize, numSwaps, nfo)
+	got := calc.RequiredOrderFunds(swapVal, 0, numSwaps, nfo)
 	if got != want {
 		t.Fatalf("want %v got %v for fees", want, got)
 	}

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -22,7 +23,11 @@ import (
 )
 
 // Check that rpcclient satisfies the ethFetcher interface.
-var _ ethFetcher = (*rpcclient)(nil)
+var (
+	_ ethFetcher = (*rpcclient)(nil)
+
+	bigZero = new(big.Int)
+)
 
 type rpcclient struct {
 	// ec wraps a *rpc.Client with some useful calls.
@@ -124,9 +129,55 @@ func (c *rpcclient) transaction(ctx context.Context, hash common.Hash) (tx *type
 // accountBalance gets the account balance, including the effects of known
 // unmined transactions.
 func (c *rpcclient) accountBalance(ctx context.Context, addr common.Address) (*big.Int, error) {
-	bigBal, err := c.ec.PendingBalanceAt(ctx, addr)
+	tip, err := c.blockNumber(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("blockNumber error: %v", err)
+	}
+	currentBal, err := c.ec.BalanceAt(ctx, addr, big.NewInt(int64(tip)))
 	if err != nil {
 		return nil, err
 	}
-	return bigBal, nil
+
+	var txs map[string]map[string]*RPCTransaction
+	err = c.c.CallContext(ctx, &txs, "txpool_contentFrom", addr)
+	if err != nil {
+		return nil, fmt.Errorf("contentFrom error: %w", err)
+	}
+
+	outgoing := new(big.Int)
+	for _, group := range txs { // 2 groups, pending and queued
+		for _, tx := range group {
+			outgoing.Add(outgoing, tx.Value.ToInt())
+			gas := new(big.Int).SetUint64(uint64(tx.Gas))
+			if tx.GasPrice != nil && tx.GasPrice.ToInt().Cmp(bigZero) > 0 {
+				outgoing.Add(outgoing, new(big.Int).Mul(gas, tx.GasPrice.ToInt()))
+			} else if tx.GasFeeCap != nil {
+				outgoing.Add(outgoing, new(big.Int).Mul(gas, tx.GasFeeCap.ToInt()))
+			}
+		}
+	}
+
+	return currentBal.Sub(currentBal, outgoing), nil
+}
+
+type RPCTransaction struct {
+	Value     *hexutil.Big   `json:"value"`
+	Gas       hexutil.Uint64 `json:"gas"`
+	GasPrice  *hexutil.Big   `json:"gasPrice"`
+	GasFeeCap *hexutil.Big   `json:"maxFeePerGas,omitempty"`
+	// BlockHash        *common.Hash      `json:"blockHash"`
+	// BlockNumber      *hexutil.Big      `json:"blockNumber"`
+	// From             common.Address    `json:"from"`
+	// GasTipCap        *hexutil.Big      `json:"maxPriorityFeePerGas,omitempty"`
+	// Hash             common.Hash       `json:"hash"`
+	// Input            hexutil.Bytes     `json:"input"`
+	// Nonce            hexutil.Uint64    `json:"nonce"`
+	// To               *common.Address   `json:"to"`
+	// TransactionIndex *hexutil.Uint64   `json:"transactionIndex"`
+	// Type             hexutil.Uint64    `json:"type"`
+	// Accesses         *types.AccessList `json:"accessList,omitempty"`
+	// ChainID          *hexutil.Big      `json:"chainId,omitempty"`
+	// V                *hexutil.Big      `json:"v"`
+	// R                *hexutil.Big      `json:"r"`
+	// S                *hexutil.Big      `json:"s"`
 }

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -9,13 +9,16 @@ package eth
 import (
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"context"
 	"testing"
 
 	"decred.org/dcrdex/dex/encode"
+	dexeth "decred.org/dcrdex/dex/networks/eth"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -24,6 +27,8 @@ var (
 	homeDir          = os.Getenv("HOME")
 	ipc              = filepath.Join(homeDir, "dextest/eth/alpha/node/geth.ipc")
 	contractAddrFile = filepath.Join(homeDir, "dextest", "eth", "contract_addr.txt")
+	alphaAddress     = "18d65fb8d60c1199bb1ad381be47aa692b482605"
+	gammaAddress     = "41293c2032bac60aa747374e966f79f575d42379"
 	ethClient        = new(rpcclient)
 	ctx              context.Context
 )
@@ -135,4 +140,41 @@ func TestTransaction(t *testing.T) {
 	if !errors.Is(err, ethereum.NotFound) {
 		t.Fatal(err)
 	}
+}
+
+func TestAccountBalance(t *testing.T) {
+	addr := common.HexToAddress(alphaAddress)
+	const vGwei = 1e7
+
+	balBefore, err := ethClient.accountBalance(ctx, addr)
+	if err != nil {
+		t.Fatalf("accountBalance error: %v", err)
+	}
+
+	if err := tmuxSend(alphaAddress, gammaAddress, vGwei); err != nil {
+		t.Fatalf("send error: %v", err)
+	}
+
+	balAfter, err := ethClient.accountBalance(ctx, addr)
+	if err != nil {
+		t.Fatalf("accountBalance error: %v", err)
+	}
+
+	diff := new(big.Int).Sub(balBefore, balAfter)
+	if diff.Cmp(dexeth.GweiToWei(vGwei)) <= 0 {
+		t.Fatalf("account balance changed by %d. expected > %d", dexeth.WeiToGwei(diff), uint64(vGwei))
+	}
+}
+
+func tmuxRun(cmd string) error {
+	cmd += "; tmux wait-for -S harnessdone"
+	err := exec.Command("tmux", "send-keys", "-t", "eth-harness:0", cmd, "C-m").Run() // ; wait-for harnessdone
+	if err != nil {
+		return nil
+	}
+	return exec.Command("tmux", "wait-for", "harnessdone").Run()
+}
+
+func tmuxSend(from, to string, v uint64) error {
+	return tmuxRun(fmt.Sprintf("./alpha attach --preload send.js --exec \"send(\\\"%s\\\",\\\"%s\\\",%s)\"", from, to, dexeth.GweiToWei(v)))
 }

--- a/server/book/accounts.go
+++ b/server/book/accounts.go
@@ -34,7 +34,7 @@ func (a AccountTracking) quote() bool {
 // methods do nothing, so there's no harm in using a newAccountTracker(0) rather
 // than checking whether assets are actually account-based everywhere.
 // The accountTracker is not thread-safe. In use, synchronization is provided by
-// the *OrderPQ's mutex.
+// the *Books's mutex.
 type accountTracker struct {
 	tracking    AccountTracking
 	base, quote map[string]map[order.OrderID]*order.LimitOrder
@@ -45,10 +45,10 @@ func newAccountTracker(tracking AccountTracking) *accountTracker {
 	// not need tracking.
 	var base, quote map[string]map[order.OrderID]*order.LimitOrder
 	if tracking.base() {
-		base = make(map[string]map[order.OrderID]*order.LimitOrder)
+		base = make(map[string]map[order.OrderID]*order.LimitOrder, initBookHalfCapacity)
 	}
 	if tracking.quote() {
-		quote = make(map[string]map[order.OrderID]*order.LimitOrder)
+		quote = make(map[string]map[order.OrderID]*order.LimitOrder, initBookHalfCapacity)
 	}
 	return &accountTracker{
 		tracking: tracking,

--- a/server/book/accounts.go
+++ b/server/book/accounts.go
@@ -1,0 +1,124 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package book
+
+import (
+	"decred.org/dcrdex/dex/order"
+)
+
+// AccountTracking is a bitfield representing the assets which need account
+// tracking.
+type AccountTracking uint8
+
+const (
+	// AccountTrackingBase should be included if the base asset is
+	// account-based.
+	AccountTrackingBase AccountTracking = 1 << iota
+	// AccountTrackingQuote should be included if the quote asset is
+	// account-based.
+	AccountTrackingQuote
+)
+
+func (a AccountTracking) base() bool {
+	return (a & AccountTrackingBase) > 0
+}
+
+func (a AccountTracking) quote() bool {
+	return (a & AccountTrackingQuote) > 0
+}
+
+// accountTracker tracks orders for account-based assets. Account tracker only
+// tracks assets that are account-based, as specified in the constructor.
+// If neither base or quote is account-based, then all of accountTracker's
+// methods do nothing, so there's no harm in using a newAccountTracker(0) rather
+// than checking whether assets are actually account-based everywhere.
+// The accountTracker is not thread-safe. In use, synchronization is provided by
+// the *OrderPQ's mutex.
+type accountTracker struct {
+	tracking    AccountTracking
+	base, quote map[string]map[order.OrderID]*order.LimitOrder
+}
+
+func newAccountTracker(tracking AccountTracking) *accountTracker {
+	// nilness is used to signal that an asset is not account-based and does
+	// not need tracking.
+	var base, quote map[string]map[order.OrderID]*order.LimitOrder
+	if tracking.base() {
+		base = make(map[string]map[order.OrderID]*order.LimitOrder)
+	}
+	if tracking.quote() {
+		quote = make(map[string]map[order.OrderID]*order.LimitOrder)
+	}
+	return &accountTracker{
+		tracking: tracking,
+		base:     base,
+		quote:    quote,
+	}
+}
+
+// add an order to tracking.
+func (a *accountTracker) add(lo *order.LimitOrder) {
+	if a.base != nil {
+		addAccountOrder(lo.BaseAccount(), a.base, lo)
+	}
+	if a.quote != nil {
+		addAccountOrder(lo.QuoteAccount(), a.quote, lo)
+	}
+}
+
+// remove an order from tracking.
+func (a *accountTracker) remove(lo *order.LimitOrder) {
+	if a.base != nil {
+		removeAccountOrder(lo.BaseAccount(), a.base, lo.ID())
+	}
+	if a.quote != nil {
+		removeAccountOrder(lo.QuoteAccount(), a.quote, lo.ID())
+	}
+}
+
+// addAccountOrder adds the order to the account address -> orders map, creating
+// an entry if necessary.
+func addAccountOrder(addr string, acctOrds map[string]map[order.OrderID]*order.LimitOrder, lo *order.LimitOrder) {
+	ords, found := acctOrds[addr]
+	if !found {
+		ords = make(map[order.OrderID]*order.LimitOrder)
+		acctOrds[addr] = ords
+	}
+	ords[lo.ID()] = lo
+}
+
+// removeAccountOrder removes the order from the account address -> orders map,
+// deleting the map if empty.
+func removeAccountOrder(addr string, acctOrds map[string]map[order.OrderID]*order.LimitOrder, oid order.OrderID) {
+	ords, found := acctOrds[addr]
+	if !found {
+		return
+	}
+	delete(ords, oid)
+	if len(ords) == 0 {
+		delete(acctOrds, addr)
+	}
+}
+
+// iterateBaseAccount calls the provided function for every tracked order with a
+// base asset corresponding to the specified account address.
+func (a *accountTracker) iterateBaseAccount(acctAddr string, f func(*order.LimitOrder)) {
+	if a.base == nil {
+		return
+	}
+	for _, lo := range a.base[acctAddr] {
+		f(lo)
+	}
+}
+
+// iterateQuoteAccount calls the provided function for every tracked order with
+// a quote asset corresponding to the specified account address.
+func (a *accountTracker) iterateQuoteAccount(acctAddr string, f func(*order.LimitOrder)) {
+	if a.quote == nil {
+		return
+	}
+	for _, lo := range a.quote[acctAddr] {
+		f(lo)
+	}
+}

--- a/server/book/accounts_test.go
+++ b/server/book/accounts_test.go
@@ -1,0 +1,166 @@
+package book
+
+import (
+	"testing"
+
+	"decred.org/dcrdex/dex/order"
+)
+
+func TestAccounts(t *testing.T) {
+	sellerTo := "sellerTo"
+	sellerFrom := "sellerFrom"
+	loSell := newLimitOrder(true, 1e8, 10, order.StandingTiF, 0)
+	loSell.Coins = []order.CoinID{[]byte(sellerFrom)}
+	loSell.Address = sellerTo
+
+	seller2To := "seller2To"
+	seller2From := "seller2From"
+	loSell2 := newLimitOrder(true, 1e8, 10, order.StandingTiF, 0)
+	loSell2.Coins = []order.CoinID{[]byte(seller2From)}
+	loSell2.Address = seller2To
+
+	buyerTo := "buyerTo"
+	buyerFrom := "buyerFrom"
+	loBuy := newLimitOrder(false, 1e8, 10, order.StandingTiF, 0)
+	loBuy.Coins = []order.CoinID{[]byte(buyerFrom)}
+	loBuy.Address = buyerTo
+
+	// Same buyer, other order
+	loBuy2 := newLimitOrder(false, 2e8, 10, order.StandingTiF, 0)
+	loBuy2.Coins = []order.CoinID{[]byte(buyerFrom)}
+	loBuy2.Address = buyerTo
+
+	allAddrs := []string{sellerTo, sellerFrom, buyerTo, buyerFrom, seller2From, seller2To}
+	allOrds := []*order.LimitOrder{loSell, loSell2, loBuy, loBuy2}
+
+	ensureCount := func(tag string, addr string, n int, counter func(string, func(*order.LimitOrder))) {
+		t.Helper()
+		var count int
+		counter(addr, func(*order.LimitOrder) {
+			count++
+		})
+		if n != count {
+			t.Fatalf("%s: wrong %s base asset count: wanted %d, got %d", tag, addr, n, count)
+		}
+	}
+
+	ensureBaseCount := func(tag string, tracker *accountTracker, addr string, n int) {
+		t.Helper()
+		ensureCount(tag, addr, n, tracker.iterateBaseAccount)
+	}
+
+	ensureQuoteCount := func(tag string, tracker *accountTracker, addr string, n int) {
+		t.Helper()
+		ensureCount(tag, addr, n, tracker.iterateQuoteAccount)
+	}
+
+	type test struct {
+		name           string
+		tracker        *accountTracker
+		expBaseCounts  map[string]int
+		expQuoteCounts map[string]int
+	}
+
+	runTests := func(tests []*test, prep func(tracker *accountTracker)) {
+		for _, tt := range tests {
+			if tt.expBaseCounts == nil {
+				tt.expBaseCounts = make(map[string]int)
+			}
+			if tt.expQuoteCounts == nil {
+				tt.expQuoteCounts = make(map[string]int)
+			}
+			prep(tt.tracker)
+			for _, acctAddr := range allAddrs {
+				ensureBaseCount(tt.name, tt.tracker, acctAddr, tt.expBaseCounts[acctAddr])
+				ensureQuoteCount(tt.name, tt.tracker, acctAddr, tt.expQuoteCounts[acctAddr])
+			}
+		}
+	}
+
+	tests := []*test{
+		{
+			name:    "non-tracker",
+			tracker: newAccountTracker(0),
+		},
+		{
+			name:    "base-tracker",
+			tracker: newAccountTracker(AccountTrackingBase),
+			expBaseCounts: map[string]int{
+				buyerTo:     2,
+				sellerFrom:  1,
+				seller2From: 1,
+			},
+		},
+		{
+			name:    "quote-tracker",
+			tracker: newAccountTracker(AccountTrackingQuote),
+			expQuoteCounts: map[string]int{
+				buyerFrom: 2,
+				sellerTo:  1,
+				seller2To: 1,
+			},
+		},
+		{
+			name:    "both-tracker",
+			tracker: newAccountTracker(AccountTrackingQuote | AccountTrackingBase),
+			expQuoteCounts: map[string]int{
+				buyerFrom: 2,
+				sellerTo:  1,
+				seller2To: 1,
+			},
+			expBaseCounts: map[string]int{
+				buyerTo:     2,
+				sellerFrom:  1,
+				seller2From: 1,
+			},
+		},
+	}
+
+	runTests(tests, func(tracker *accountTracker) {
+		for _, ord := range allOrds {
+			tracker.add(ord)
+		}
+	})
+
+	// For the next tests, we'll add all of the orders, but then remove one of
+	// the buyer's orders.
+	tests = []*test{
+		{
+			name:    "remove-a-buy",
+			tracker: newAccountTracker(AccountTrackingBase | AccountTrackingQuote),
+			expQuoteCounts: map[string]int{
+				buyerFrom: 1,
+				sellerTo:  1,
+				seller2To: 1,
+			},
+			expBaseCounts: map[string]int{
+				buyerTo:     1,
+				sellerFrom:  1,
+				seller2From: 1,
+			},
+		},
+	}
+
+	runTests(tests, func(tracker *accountTracker) {
+		for _, ord := range allOrds {
+			tracker.add(ord)
+		}
+		tracker.remove(loBuy2)
+	})
+
+	// Add all, remove all, and make sure the book is empty.
+	tests = []*test{
+		{
+			name:    "remove-all",
+			tracker: newAccountTracker(AccountTrackingBase | AccountTrackingQuote),
+		},
+	}
+	runTests(tests, func(tracker *accountTracker) {
+		for _, ord := range allOrds {
+			tracker.add(ord)
+		}
+		for _, ord := range allOrds {
+			tracker.remove(ord)
+		}
+	})
+}

--- a/server/book/book_test.go
+++ b/server/book/book_test.go
@@ -91,7 +91,7 @@ var (
 func newBook(t *testing.T) *Book {
 	resetMakers()
 
-	b := New(LotSize)
+	b := New(LotSize, 0)
 
 	for _, o := range bookBuyOrders {
 		if ok := b.Insert(o); !ok {

--- a/server/book/orderpq.go
+++ b/server/book/orderpq.go
@@ -25,12 +25,13 @@ type orderHeap []*orderEntry
 // price rate. A max-oriented queue with highest rates on top is constructed via
 // NewMaxOrderPQ, while a min-oriented queue is constructed via NewMinOrderPQ.
 type OrderPQ struct {
-	mtx        sync.RWMutex
-	oh         orderHeap
-	capacity   uint32
-	lessFn     func(bi, bj *order.LimitOrder) bool
-	orders     map[order.OrderID]*orderEntry
-	userOrders map[account.AccountID]map[order.OrderID]*order.LimitOrder
+	mtx         sync.RWMutex
+	oh          orderHeap
+	capacity    uint32
+	lessFn      func(bi, bj *order.LimitOrder) bool
+	orders      map[order.OrderID]*orderEntry
+	userOrders  map[account.AccountID]map[order.OrderID]*order.LimitOrder
+	acctTracker *accountTracker
 }
 
 // Copy makes a deep copy of the OrderPQ. The orders are the same; each
@@ -55,6 +56,7 @@ func (pq *OrderPQ) realloc(newCap uint32) {
 	pq.orders = newPQ.orders
 	pq.oh = newPQ.oh
 	pq.userOrders = newPQ.userOrders
+	pq.acctTracker = newPQ.acctTracker
 }
 
 // Cap returns the current capacity of the OrderPQ.
@@ -76,6 +78,8 @@ func (pq *OrderPQ) push(oe *orderEntry) {
 	} else {
 		pq.userOrders[lo.AccountID] = map[order.OrderID]*order.LimitOrder{oid: lo}
 	}
+	// Track accounts.
+	pq.acctTracker.add(oe.order)
 }
 
 // copy makes a deep copy of the OrderPQ. The orders are the same; each
@@ -86,7 +90,8 @@ func (pq *OrderPQ) copy(newCap uint32) *OrderPQ {
 		panic(fmt.Sprintf("len %d > newCap %d", len(pq.oh), int(newCap)))
 	}
 	// Initialize the new OrderPQ.
-	newPQ := newOrderPQ(newCap, pq.lessFn)
+	// TODO: Pre-allocate the accountTracker somehow.
+	newPQ := newOrderPQ(newCap, pq.lessFn, pq.acctTracker.tracking)
 	newPQ.userOrders = make(map[account.AccountID]map[order.OrderID]*order.LimitOrder, len(pq.userOrders))
 	for aid, uos := range pq.userOrders {
 		newPQ.userOrders[aid] = make(map[order.OrderID]*order.LimitOrder, len(uos)) // actual *LimitOrders copied in push
@@ -119,6 +124,22 @@ func (pq *OrderPQ) UnfilledForUser(user account.AccountID) []*order.LimitOrder {
 	}
 	pq.mtx.RUnlock()
 	return orders
+}
+
+// IterateBaseAccount calls the provided function for every tracked order with
+// a base asset corresponding to the specified account address.
+func (pq *OrderPQ) IterateBaseAccount(acctAddr string, f func(*order.LimitOrder)) {
+	pq.mtx.RLock()
+	pq.acctTracker.iterateBaseAccount(acctAddr, f)
+	pq.mtx.RUnlock()
+}
+
+// IterateQuoteAccount calls the provided function for every tracked order with
+// a quote asset corresponding to the specified account address.
+func (pq *OrderPQ) IterateQuoteAccount(acctAddr string, f func(*order.LimitOrder)) {
+	pq.mtx.RLock()
+	pq.acctTracker.iterateQuoteAccount(acctAddr, f)
+	pq.mtx.RUnlock()
 }
 
 // Orders copies all orders, sorted with the lessFn. The OrderPQ is unmodified.
@@ -173,24 +194,25 @@ func (pq *OrderPQ) ExtractN(count int) []*order.LimitOrder {
 // NewMinOrderPQ is the constructor for OrderPQ that initializes an empty heap
 // with the given capacity, and sets the default LessFn for a min heap. Use
 // OrderPQ.SetLessFn to redefine the comparator.
-func NewMinOrderPQ(capacity uint32) *OrderPQ {
-	return newOrderPQ(capacity, LessByPriceThenTime)
+func NewMinOrderPQ(capacity uint32, acctTracking AccountTracking) *OrderPQ {
+	return newOrderPQ(capacity, LessByPriceThenTime, acctTracking)
 }
 
 // NewMaxOrderPQ is the constructor for OrderPQ that initializes an empty heap
 // with the given capacity, and sets the default LessFn for a max heap. Use
 // OrderPQ.SetLessFn to redefine the comparator.
-func NewMaxOrderPQ(capacity uint32) *OrderPQ {
-	return newOrderPQ(capacity, GreaterByPriceThenTime)
+func NewMaxOrderPQ(capacity uint32, acctTracking AccountTracking) *OrderPQ {
+	return newOrderPQ(capacity, GreaterByPriceThenTime, acctTracking)
 }
 
-func newOrderPQ(cap uint32, lessFn func(bi, bj *order.LimitOrder) bool) *OrderPQ {
+func newOrderPQ(cap uint32, lessFn func(bi, bj *order.LimitOrder) bool, acctTracking AccountTracking) *OrderPQ {
 	return &OrderPQ{
-		oh:         make(orderHeap, 0, cap),
-		capacity:   cap,
-		lessFn:     lessFn,
-		orders:     make(map[order.OrderID]*orderEntry, cap),
-		userOrders: make(map[account.AccountID]map[order.OrderID]*order.LimitOrder),
+		oh:          make(orderHeap, 0, cap),
+		capacity:    cap,
+		lessFn:      lessFn,
+		orders:      make(map[order.OrderID]*orderEntry, cap),
+		userOrders:  make(map[account.AccountID]map[order.OrderID]*order.LimitOrder),
+		acctTracker: newAccountTracker(acctTracking),
 	}
 }
 
@@ -287,6 +309,7 @@ func (pq *OrderPQ) Pop() interface{} {
 	} else {
 		fmt.Printf("(*OrderPQ).Pop: no userOrders for %v found when popping order %v!", user, oid)
 	}
+	pq.acctTracker.remove(lo)
 
 	// If the heap has shrunk well below capacity, realloc smaller.
 	if pq.capacity > deallocThresh {
@@ -392,6 +415,7 @@ func (pq *OrderPQ) Reset(orders []*order.LimitOrder) {
 	pq.oh = make([]*orderEntry, 0, len(orders))
 	pq.orders = make(map[order.OrderID]*orderEntry, len(pq.oh))
 	pq.userOrders = make(map[account.AccountID]map[order.OrderID]*order.LimitOrder)
+	pq.acctTracker = newAccountTracker(pq.acctTracker.tracking)
 	for i, lo := range orders {
 		entry := &orderEntry{
 			order:   lo,
@@ -469,6 +493,7 @@ func (pq *OrderPQ) RemoveUserOrders(user account.AccountID) (removed []*order.Li
 	removed = make([]*order.LimitOrder, 0, len(uos))
 	for oid, lo := range uos {
 		pq.removeOrder(pq.orders[oid])
+		pq.acctTracker.remove(lo)
 		removed = append(removed, lo)
 	}
 	return

--- a/server/book/orderpq_test.go
+++ b/server/book/orderpq_test.go
@@ -56,15 +56,16 @@ func genBigList(listSize int) {
 
 	bigList = make([]*Order, 0, listSize)
 	for i := 0; i < listSize; i++ {
-		order := newLimitOrder(false, uint64(rand.Int63n(90000000)), uint64(rand.Int63n(6))+1, order.StandingTiF, rand.Int63n(240)-120)
-		order.Address = newFakeAddr()
+		lo := newLimitOrder(false, uint64(rand.Int63n(90000000)), uint64(rand.Int63n(6))+1, order.StandingTiF, rand.Int63n(240)-120)
+		lo.Address = newFakeAddr()
+		lo.Coins = []order.CoinID{[]byte(newFakeAddr())}
 		// duplicate some prices
 		if (i+1)%(listSize/dupRate) == 0 {
-			order.Rate = bigList[i/2].Rate
-			order.Quantity = bigList[i/2].Quantity + 1
+			lo.Rate = bigList[i/2].Rate
+			lo.Quantity = bigList[i/2].Quantity + 1
 		}
-		_ = order.ID() // compute and cache the OrderID
-		bigList = append(bigList, order)
+		_ = lo.ID() // compute and cache the OrderID
+		bigList = append(bigList, lo)
 	}
 }
 
@@ -85,7 +86,7 @@ func TestMain(m *testing.M) {
 
 func TestLargeOrderMaxPriorityQueue(t *testing.T) {
 	// Max oriented queue
-	pq := NewMaxOrderPQ(uint32(len(bigList) - len(bigList)/16)) // a little smaller to force a realloc
+	pq := NewMaxOrderPQ(uint32(len(bigList)-len(bigList)/16), 0) // a little smaller to force a realloc
 	for i, o := range bigList {
 		ok := pq.Insert(o)
 		if !ok {
@@ -161,7 +162,7 @@ func TestLargeOrderMaxPriorityQueue(t *testing.T) {
 
 func TestLargeOrderMinPriorityQueue(t *testing.T) {
 	// Min oriented queue
-	pq := NewMinOrderPQ(uint32(len(bigList) - len(bigList)/16)) // a little smaller to force a realloc
+	pq := NewMinOrderPQ(uint32(len(bigList)-len(bigList)/16), 0) // a little smaller to force a realloc
 	for _, o := range bigList {
 		ok := pq.Insert(o)
 		if !ok {
@@ -237,7 +238,7 @@ func TestLargeOrderMinPriorityQueue(t *testing.T) {
 
 func TestLargeOrderMaxPriorityQueue_Orders(t *testing.T) {
 	// Max oriented queue (sell book)
-	pq := NewMaxOrderPQ(uint32(len(bigList)))
+	pq := NewMaxOrderPQ(uint32(len(bigList)), 0)
 	for _, o := range bigList {
 		ok := pq.Insert(o)
 		if !ok {
@@ -305,7 +306,7 @@ func TestLargeOrderMaxPriorityQueue_Orders(t *testing.T) {
 
 func TestLargeOrderMaxPriorityQueue_realloc(t *testing.T) {
 	// Max oriented queue (sell book)
-	pq := NewMaxOrderPQ(uint32(len(bigList))) // no realloc for initial inserts
+	pq := NewMaxOrderPQ(uint32(len(bigList)), 0) // no realloc for initial inserts
 	for _, o := range bigList {
 		ok := pq.Insert(o)
 		if !ok {
@@ -362,7 +363,7 @@ func TestLargeOrderMaxPriorityQueue_realloc(t *testing.T) {
 }
 
 func TestMinOrderPQ(t *testing.T) {
-	pq := NewMinOrderPQ(0) // zero cap to force a realloc right away
+	pq := NewMinOrderPQ(0, 0) // zero cap to force a realloc right away
 
 	for _, o := range orders {
 		ok := pq.Insert(o)
@@ -379,7 +380,7 @@ func TestMinOrderPQ(t *testing.T) {
 }
 
 func TestMaxOrderPQ(t *testing.T) {
-	pq := NewMaxOrderPQ(0)
+	pq := NewMaxOrderPQ(0, 0)
 
 	for _, o := range orders {
 		ok := pq.Insert(o)
@@ -396,7 +397,7 @@ func TestMaxOrderPQ(t *testing.T) {
 }
 
 func TestMaxOrderPQ_TieRate(t *testing.T) {
-	pq := NewMaxOrderPQ(4)
+	pq := NewMaxOrderPQ(4, 0)
 
 	for _, o := range orders[:3] {
 		ok := pq.Insert(o)
@@ -413,7 +414,7 @@ func TestMaxOrderPQ_TieRate(t *testing.T) {
 }
 
 func TestMaxOrderPQ_TieRateAndTime(t *testing.T) {
-	pq := NewMaxOrderPQ(4)
+	pq := NewMaxOrderPQ(4, 0)
 
 	// 7f9200eedcf2fa868173cdfc2101ee4d71ec024c1c052589b3371442aaa26c2d
 	ok := pq.Insert(orders[0])
@@ -435,7 +436,7 @@ func TestMaxOrderPQ_TieRateAndTime(t *testing.T) {
 }
 
 func TestOrderPQCapacity(t *testing.T) {
-	pq := NewMaxOrderPQ(2)
+	pq := NewMaxOrderPQ(2, 0)
 
 	ok := pq.Insert(orders[0])
 	if !ok {
@@ -468,7 +469,7 @@ func TestOrderPQCapacity(t *testing.T) {
 }
 
 func TestOrderPQ_Insert_negative(t *testing.T) {
-	pq := NewMinOrderPQ(2)
+	pq := NewMinOrderPQ(2, 0)
 
 	ok := pq.Insert(orders[0])
 	if !ok {
@@ -487,7 +488,7 @@ func TestOrderPQ_Insert_negative(t *testing.T) {
 }
 
 func TestOrderPQ_Remove(t *testing.T) {
-	pq := NewMaxOrderPQ(2)
+	pq := NewMaxOrderPQ(2, 0)
 
 	ok := pq.Insert(orders[0])
 	if !ok {
@@ -515,7 +516,7 @@ func TestOrderPQ_Remove(t *testing.T) {
 }
 
 func TestOrderPQ_RemoveUserOrders(t *testing.T) {
-	pq := NewMaxOrderPQ(6)
+	pq := NewMaxOrderPQ(6, 0)
 
 	ok := pq.Insert(orders[0])
 	if !ok {
@@ -593,13 +594,13 @@ func TestOrderPQ_RemoveUserOrders(t *testing.T) {
 }
 
 func TestOrderPQMin_Worst(t *testing.T) {
-	pq0 := NewMinOrderPQ(4)
+	pq0 := NewMinOrderPQ(4, 0)
 	worst := pq0.Worst()
 	if worst != nil {
 		t.Errorf("Worst for an empty queue should be nil, got %v", worst)
 	}
 
-	pq1 := NewMinOrderPQ(4)
+	pq1 := NewMinOrderPQ(4, 0)
 	if !pq1.Insert(bigList[0]) {
 		t.Fatalf("Failed to insert order %v", bigList[0])
 	}
@@ -609,7 +610,7 @@ func TestOrderPQMin_Worst(t *testing.T) {
 	}
 
 	// Min oriented queue
-	pq := NewMinOrderPQ(uint32(len(bigList) - len(bigList)/16))
+	pq := NewMinOrderPQ(uint32(len(bigList)-len(bigList)/16), 0)
 	for _, o := range bigList {
 		ok := pq.Insert(o)
 		if !ok {
@@ -637,7 +638,7 @@ func TestOrderPQMin_Worst(t *testing.T) {
 
 func TestOrderPQMax_Worst(t *testing.T) {
 	// Max oriented queue
-	pq := NewMaxOrderPQ(uint32(len(bigList)))
+	pq := NewMaxOrderPQ(uint32(len(bigList)), 0)
 	for _, o := range bigList {
 		ok := pq.Insert(o)
 		if !ok {
@@ -666,7 +667,7 @@ func TestOrderPQMax_Worst(t *testing.T) {
 func TestOrderPQMax_leafNodes(t *testing.T) {
 	// Max oriented queue
 	newQ := func(list []*Order) *OrderPQ {
-		pq := NewMaxOrderPQ(uint32(len(bigList)))
+		pq := NewMaxOrderPQ(uint32(len(bigList)), 0)
 		for _, o := range list {
 			ok := pq.Insert(o)
 			if !ok {
@@ -689,5 +690,79 @@ func TestOrderPQMax_leafNodes(t *testing.T) {
 			t.Errorf("Incorrect number of leaf nodes. Got %d, expected %d",
 				len(leaves), expectedNum)
 		}
+	}
+}
+
+func TestAccountTracking(t *testing.T) {
+	// make the last order's user the same as the first.
+	lastOrd := bigList[len(bigList)-1]
+	firstOrd := bigList[0]
+	lastOrd.Address = firstOrd.Address
+	lastOrd.Coins = firstOrd.Coins
+
+	// Max oriented queue
+	pq := NewMaxOrderPQ(uint32(len(bigList)), AccountTrackingBase|AccountTrackingQuote) // a little smaller to force a realloc
+	for i, o := range bigList {
+		ok := pq.Insert(o)
+		if !ok {
+			t.Fatalf("Failed to insert order %d: %v", i, o)
+		}
+	}
+
+	if len(pq.acctTracker.base) == 0 {
+		t.Fatalf("base asset not tracked")
+	}
+
+	if len(pq.acctTracker.quote) == 0 {
+		t.Fatalf("quote asset not tracked")
+	}
+
+	// Check each order and make sure it's where we expect.
+	for _, ord := range bigList {
+		// they are all buy orders
+		baseAccount := ord.Address
+		ords, found := pq.acctTracker.base[baseAccount]
+		if !found {
+			t.Fatalf("base order account not found")
+		}
+		_, found = ords[ord.ID()]
+		if !found {
+			t.Fatalf("base order not found")
+		}
+
+		quoteAccount := string(ord.Coins[0])
+		ords, found = pq.acctTracker.quote[quoteAccount]
+		if !found {
+			t.Fatalf("quote order account not found")
+		}
+		_, found = ords[ord.ID()]
+		if !found {
+			t.Fatalf("quote order not found")
+		}
+	}
+
+	// Check that our first user has two orders.
+	if len(pq.acctTracker.base[firstOrd.BaseAccount()]) != 2 {
+		t.Fatalf("didn't track two base orders for first user")
+	}
+
+	if len(pq.acctTracker.quote[firstOrd.QuoteAccount()]) != 2 {
+		t.Fatalf("didn't track two quote orders for first user")
+	}
+
+	// Remove them all.
+	for i, o := range bigList {
+		_, ok := pq.RemoveOrder(o)
+		if !ok {
+			t.Fatalf("Failed to remove order %d: %v", i, o)
+		}
+	}
+
+	if len(pq.acctTracker.base) != 0 {
+		t.Fatalf("base asset not cleared")
+	}
+
+	if len(pq.acctTracker.quote) != 0 {
+		t.Fatalf("quote asset not cleared")
 	}
 }

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -604,7 +604,8 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	// they are all instantiated, so we are synchronous in our use of the
 	// marketTunnels map.
 	marketTunnels := make(map[string]market.MarketTunnel, len(cfg.Markets))
-	dexBalancer := market.NewDEXBalancer(marketTunnels, backedAssets, swapper)
+	pendingAccounters := make(map[string]market.PendingAccounter, len(cfg.Markets))
+	dexBalancer := market.NewDEXBalancer(pendingAccounters, backedAssets, swapper)
 
 	// Markets
 	usersWithOrders := make(map[account.AccountID]struct{})
@@ -635,6 +636,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		}
 		markets[mktInf.Name] = mkt
 		marketTunnels[mktInf.Name] = mkt
+		pendingAccounters[mktInf.Name] = mkt
 		log.Infof("Preparing historical market data API for market %v...", mktInf.Name)
 		err = dataAPI.AddMarketSource(mkt)
 		if err != nil {

--- a/server/market/balancer.go
+++ b/server/market/balancer.go
@@ -21,8 +21,11 @@ type PendingAccounter interface {
 // MatchNegotiator can view match-reserved funds for an account-based asset's
 // address. MatchNegotiator is satisfied by *Swapper.
 type MatchNegotiator interface {
-	// AccountStats returns the qty, swap count, and redeem count pending in
-	// active matches.
+	// AccountStats collects stats about pending matches for account's address
+	// on an account-based asset. qty is the total pending outgoing quantity,
+	// swaps is the number matches with oustanding swaps funded by the account,
+	// and redeem is the number of matches with outstanding redemptions that pay
+	// to the account.
 	AccountStats(acctAddr string, assetID uint32) (qty, swaps uint64, redeems int)
 }
 
@@ -95,6 +98,9 @@ func (b *DEXBalancer) CheckBalance(acctAddr string, assetID uint32, qty, lots ui
 	redeems += newRedeems
 
 	assetInfo := backedAsset.assetInfo
+	// The fee rate assigned to redemptions is at the discretion of the user.
+	// MaxFeeRate is used as a conservatively high estimate. This is then a
+	// server policy that clients must satisfy.
 	redeemCosts := uint64(redeems) * assetInfo.RedeemSize * assetInfo.MaxFeeRate
 	reqFunds := calc.RequiredOrderFunds(qty, 0, lots, assetInfo) + redeemCosts
 

--- a/server/market/balancer.go
+++ b/server/market/balancer.go
@@ -1,0 +1,88 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package market
+
+import (
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/calc"
+	"decred.org/dcrdex/server/asset"
+)
+
+// BackedBalancer is an asset manager that is capable of querying the entire DEX
+// for the balance required to fulfill new + existing orders and outstanding
+// redemptions.
+type DEXBalancer struct {
+	tunnels         map[string]MarketTunnel
+	assets          map[uint32]*backedBalancer
+	matchNegotiator MatchNegotiator
+}
+
+// NewDEXBalancer is a constructor for a BackedBalancer. Provided assets will
+// be filtered for those that are account-based. The matchNegotitator is
+// satisfied by the *Swapper.
+func NewDEXBalancer(tunnels map[string]MarketTunnel, assets map[uint32]*asset.BackedAsset, matchNegotiator MatchNegotiator) *DEXBalancer {
+	balancers := make(map[uint32]*backedBalancer)
+	for assetID, ba := range assets {
+		balancer, is := ba.Backend.(asset.AccountBalancer)
+		if !is {
+			continue
+		}
+		balancers[assetID] = &backedBalancer{
+			balancer:  balancer,
+			assetInfo: &ba.Asset,
+		}
+	}
+
+	return &DEXBalancer{
+		tunnels:         tunnels,
+		assets:          balancers,
+		matchNegotiator: matchNegotiator,
+	}
+}
+
+// CheckBalance checks if there is sufficient balance to support the specified
+// new funding and redemptions, given the existing orders throughout DEX that
+// fund from or redeem to the specified account address for the account-based
+// asset. It is an internally logged error to call CheckBalance for a
+// non-account-based asset or an asset that is was not provided to the
+// constructor.
+func (b *DEXBalancer) CheckBalance(acctAddr string, assetID uint32, qty, lots uint64, redeems int) bool {
+	backedAsset, found := b.assets[assetID]
+	if !found {
+		log.Errorf("asset ID %d not found in accountBalancer assets map", assetID)
+		return false
+	}
+	bal, err := backedAsset.balancer.AccountBalance(acctAddr)
+	if err != nil {
+		log.Error("error getting account balance for %q: %v", acctAddr, err)
+		return false
+	}
+
+	// Add quantity for unfilled orders.
+	for _, mt := range b.tunnels {
+		newQty, newLots, newRedeems := mt.AccountPending(acctAddr, assetID)
+		lots += newLots
+		qty += newQty
+		redeems += newRedeems
+	}
+
+	// Add in-process swaps.
+	newQty, newLots, newRedeems := b.matchNegotiator.AccountStats(acctAddr, assetID)
+	lots += newLots
+	qty += newQty
+	redeems += newRedeems
+
+	assetInfo := backedAsset.assetInfo
+	redeemCosts := uint64(redeems) * assetInfo.RedeemSize * assetInfo.MaxFeeRate
+	reqFunds := calc.RequiredOrderFunds(qty, 0, lots, assetInfo) + redeemCosts
+
+	return bal >= reqFunds
+}
+
+// backedBalancer is similar to a BackedAsset, but with the Backends already
+// cast to AccountBalancer.
+type backedBalancer struct {
+	balancer  asset.AccountBalancer
+	assetInfo *dex.Asset
+}

--- a/server/market/balancer.go
+++ b/server/market/balancer.go
@@ -18,7 +18,7 @@ type DEXBalancer struct {
 	matchNegotiator MatchNegotiator
 }
 
-// NewDEXBalancer is a constructor for a BackedBalancer. Provided assets will
+// NewDEXBalancer is a constructor for a DEXBalancer. Provided assets will
 // be filtered for those that are account-based. The matchNegotitator is
 // satisfied by the *Swapper.
 func NewDEXBalancer(tunnels map[string]MarketTunnel, assets map[uint32]*asset.BackedAsset, matchNegotiator MatchNegotiator) *DEXBalancer {
@@ -53,6 +53,10 @@ func (b *DEXBalancer) CheckBalance(acctAddr string, assetID uint32, qty, lots ui
 		log.Errorf("asset ID %d not found in accountBalancer assets map", assetID)
 		return false
 	}
+
+	log.Tracef("balance check for %s - %s: new qty = %d, new lots = %d, new redeems = %d",
+		backedAsset.assetInfo.Symbol, acctAddr, qty, lots, redeems)
+
 	bal, err := backedAsset.balancer.AccountBalance(acctAddr)
 	if err != nil {
 		log.Error("error getting account balance for %q: %v", acctAddr, err)
@@ -76,6 +80,10 @@ func (b *DEXBalancer) CheckBalance(acctAddr string, assetID uint32, qty, lots ui
 	assetInfo := backedAsset.assetInfo
 	redeemCosts := uint64(redeems) * assetInfo.RedeemSize * assetInfo.MaxFeeRate
 	reqFunds := calc.RequiredOrderFunds(qty, 0, lots, assetInfo) + redeemCosts
+
+	log.Tracef("balance check for %s - %s: total qty = %d, total lots = %d, "+
+		"total redeems = %d, redeemCosts = %d, required = %d, bal = %d",
+		backedAsset.assetInfo.Symbol, acctAddr, qty, lots, redeems, redeemCosts, reqFunds, bal)
 
 	return bal >= reqFunds
 }

--- a/server/market/balancer_test.go
+++ b/server/market/balancer_test.go
@@ -20,7 +20,7 @@ func TestBalancer(t *testing.T) {
 	backend := &tAccountBackend{}
 
 	balancer := &DEXBalancer{
-		tunnels: map[string]MarketTunnel{
+		tunnels: map[string]PendingAccounter{
 			"abc_xyz": tunnel,
 		},
 		assets: map[uint32]*backedBalancer{

--- a/server/market/balancer_test.go
+++ b/server/market/balancer_test.go
@@ -1,0 +1,117 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package market
+
+import (
+	"testing"
+
+	"decred.org/dcrdex/dex/calc"
+)
+
+func TestBalancer(t *testing.T) {
+	const lotSize = 1e10
+	const assetID = 123
+	assetInfo := &assetETH.Asset
+	perRedeemCost := assetInfo.RedeemSize * assetInfo.MaxFeeRate
+
+	swapper := &tMatchNegotiator{}
+	tunnel := &TMarketTunnel{}
+	backend := &tAccountBackend{}
+
+	balancer := &DEXBalancer{
+		tunnels: map[string]MarketTunnel{
+			"abc_xyz": tunnel,
+		},
+		assets: map[uint32]*backedBalancer{
+			assetID: {
+				balancer:  backend,
+				assetInfo: assetInfo,
+			},
+		},
+		matchNegotiator: swapper,
+	}
+
+	type qlr struct {
+		qty, lots uint64
+		redeems   int
+	}
+
+	type test struct {
+		name    string
+		pass    bool
+		bal     uint64
+		new     qlr
+		mkt     qlr
+		swapper qlr
+	}
+
+	tests := []*test{
+		{
+			name: "no existing - 1 new lot - pass",
+			new:  qlr{lotSize, 1, 0},
+			bal:  calc.RequiredOrderFunds(lotSize, 0, 1, assetInfo),
+			pass: true,
+		}, {
+			name: "no existing - 1 new lot - fail",
+			new:  qlr{lotSize, 1, 0},
+			bal:  calc.RequiredOrderFunds(lotSize, 0, 1, assetInfo) - 1,
+		}, {
+			name: "no existing - 1 new redeem - pass",
+			new:  qlr{0, 0, 1},
+			bal:  perRedeemCost,
+			pass: true,
+		}, {
+			name: "no existing - 1 new redeem - fail",
+			new:  qlr{0, 0, 1},
+			bal:  perRedeemCost - 1,
+		}, {
+			name:    "1 each swapper - 1 new lot - pass",
+			new:     qlr{lotSize, 1, 0},
+			swapper: qlr{lotSize, 1, 1},
+			bal:     calc.RequiredOrderFunds(lotSize*2, 0, 2, assetInfo) + perRedeemCost,
+			pass:    true,
+		}, {
+			name: "1 each market - 1 new lot - pass",
+			new:  qlr{lotSize, 1, 0},
+			mkt:  qlr{lotSize, 1, 1},
+			bal:  calc.RequiredOrderFunds(lotSize*2, 0, 2, assetInfo) + perRedeemCost,
+			pass: true,
+		},
+		{
+			name: "1 each market - 1 new lot - fail",
+			new:  qlr{lotSize, 1, 0},
+			mkt:  qlr{lotSize, 1, 1},
+			bal:  calc.RequiredOrderFunds(lotSize*2, 0, 2, assetInfo) + perRedeemCost - 1,
+		},
+		{
+			name:    "mix it up - pass",
+			new:     qlr{lotSize * 2, 2, 0},
+			mkt:     qlr{lotSize * 3, 3, 2},
+			swapper: qlr{lotSize * 4, 4, 3},
+			bal:     calc.RequiredOrderFunds(lotSize*9, 0, 9, assetInfo) + perRedeemCost*5,
+			pass:    true,
+		},
+		{
+			name:    "mix it up - fail",
+			new:     qlr{lotSize * 2, 2, 0},
+			mkt:     qlr{lotSize * 3, 3, 2},
+			swapper: qlr{lotSize * 4, 4, 3},
+			bal:     calc.RequiredOrderFunds(lotSize*9, 0, 9, assetInfo) + perRedeemCost*5 - 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tunnel.acctLots = tt.mkt.lots
+		tunnel.acctQty = tt.mkt.qty
+		tunnel.acctRedeems = tt.mkt.redeems
+		swapper.swaps = tt.swapper.lots
+		swapper.qty = tt.swapper.qty
+		swapper.redeems = tt.swapper.redeems
+		backend.bal = tt.bal
+
+		if balancer.CheckBalance("a", assetID, tt.new.qty, tt.new.lots, tt.new.redeems) != tt.pass {
+			t.Fatalf("%s: expected %t, got %t", tt.name, tt.pass, !tt.pass)
+		}
+	}
+}

--- a/server/market/integ/booker_matcher_test.go
+++ b/server/market/integ/booker_matcher_test.go
@@ -190,7 +190,7 @@ const (
 func newBook(t *testing.T) *book.Book {
 	resetMakers()
 
-	b := book.New(LotSize)
+	b := book.New(LotSize, 0)
 
 	for _, o := range bookBuyOrders {
 		if ok := b.Insert(o); !ok {
@@ -1012,7 +1012,7 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 		{
 			name: "market sell against empty book",
 			args: args{
-				book:  book.New(LotSize),
+				book:  book.New(LotSize, 0),
 				queue: []*matcher.OrderRevealed{takers[0]},
 			},
 			doesMatch:        false,

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -74,7 +74,12 @@ type FeeFetcher interface {
 	MaxFeeRate() uint64
 }
 
+// Balancer provides a method to check that an account on an account-based
+// asset has sufficient balance.
 type Balancer interface {
+	// CheckBalance checks that the address's account has sufficient balance to
+	// trade the outgoing number of lots (totaling qty) and incoming number of
+	// redeems.
 	CheckBalance(acctAddr string, assetID uint32, qty, lots uint64, redeems int) bool
 }
 

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -74,6 +74,10 @@ type FeeFetcher interface {
 	MaxFeeRate() uint64
 }
 
+type Balancer interface {
+	CheckBalance(acctAddr string, assetID uint32, qty, lots uint64, redeems int) bool
+}
+
 // Config is the Market configuration.
 type Config struct {
 	MarketInfo      *dex.MarketInfo
@@ -85,6 +89,7 @@ type Config struct {
 	FeeFetcherQuote FeeFetcher
 	CoinLockerQuote coinlock.CoinLocker
 	DataCollector   DataCollector
+	Balancer        Balancer
 }
 
 // Market is the market manager. It should not be overly involved with details
@@ -178,20 +183,39 @@ func NewMarket(cfg *Config) (*Market, error) {
 		return nil, err
 	}
 
+	log.Infof("Allowing %d lots on the book per user.", mktInfo.BookedLotLimit)
+
 	// Load existing book orders from the DB.
 	base, quote := mktInfo.Base, mktInfo.Quote
+
 	bookOrders, err := storage.BookOrders(base, quote)
 	if err != nil {
 		return nil, err
 	}
-	log.Infof("Allowing %d lots on the book per user.", mktInfo.BookedLotLimit)
-
 	log.Infof("Loaded %d stored book orders.", len(bookOrders))
+
+	baseIsAcctBased := cfg.CoinLockerBase == nil
+	quoteIsAcctBased := cfg.CoinLockerQuote == nil
+
 	// Put the book orders in a map so orders that no longer have funding coins
 	// can be removed easily.
 	bookOrdersByID := make(map[order.OrderID]*order.LimitOrder, len(bookOrders))
-	for _, ord := range bookOrders {
-		bookOrdersByID[ord.ID()] = ord
+	for _, lo := range bookOrders {
+		// Limit order amount requirements are simple unlike market buys.
+		if lo.Quantity%mktInfo.LotSize != 0 || lo.FillAmt%mktInfo.LotSize != 0 {
+			// To change market configuration, the operator should suspended the
+			// market with persist=false, but that may not have happened, or
+			// maybe a revoke failed.
+			log.Errorf("Not rebooking order %v with amount (%v/%v) incompatible with current lot size (%v)",
+				lo.ID(), lo.FillAmt, lo.Quantity, mktInfo.LotSize)
+			// Revoke the order, but do not count this against the user.
+			if _, _, err = storage.RevokeOrderUncounted(lo); err != nil {
+				log.Errorf("Failed to revoke order %v: %v", lo, err)
+				// But still not added back on the book.
+			}
+			continue
+		}
+		bookOrdersByID[lo.ID()] = lo
 	}
 
 	// "execute" any epoch orders in DB that may be left over from unclean
@@ -214,8 +238,40 @@ func NewMarket(cfg *Config) (*Market, error) {
 		}
 	}
 
-	baseCoins := make(map[order.OrderID][]order.CoinID)
-	quoteCoins := make(map[order.OrderID][]order.CoinID)
+	// Set up tracking. Which of these are actually used depend on whether the
+	// assets are account- or utxo-based.
+	// utxo-based
+	var baseCoins, quoteCoins map[order.OrderID][]order.CoinID
+	var missingCoinFails map[order.OrderID]struct{}
+	// account-based
+	var quoteAcctStats, baseAcctStats accountCounter
+	var failedBaseAccts, failedQuoteAccts map[string]bool
+	var failedAcctOrders map[order.OrderID]struct{}
+	var acctTracking book.AccountTracking
+
+	if baseIsAcctBased {
+		acctTracking |= book.AccountTrackingBase
+		baseAcctStats = make(accountCounter)
+		failedBaseAccts = make(map[string]bool)
+		failedAcctOrders = make(map[order.OrderID]struct{})
+	} else {
+		baseCoins = make(map[order.OrderID][]order.CoinID)
+		missingCoinFails = make(map[order.OrderID]struct{})
+	}
+
+	if quoteIsAcctBased {
+		acctTracking |= book.AccountTrackingQuote
+		quoteAcctStats = make(accountCounter)
+		failedQuoteAccts = make(map[string]bool)
+		if failedAcctOrders == nil {
+			failedAcctOrders = make(map[order.OrderID]struct{})
+		}
+	} else {
+		quoteCoins = make(map[order.OrderID][]order.CoinID)
+		if missingCoinFails == nil {
+			missingCoinFails = make(map[order.OrderID]struct{})
+		}
+	}
 
 ordersLoop:
 	for id, lo := range bookOrdersByID {
@@ -269,37 +325,92 @@ ordersLoop:
 			continue ordersLoop
 		}
 
-		// All coins are unspent. Lock them.
-		if lo.Sell {
+		if baseIsAcctBased {
+			var addr string
+			var qty, lots uint64
+			var redeems int
+			if lo.Sell {
+				// address is zeroth coin
+				if len(lo.Coins) != 1 {
+					log.Errorf("rejecting account-based-base-asset order %s that has no coins ¯\\_(ツ)_/¯", lo.ID())
+					continue ordersLoop
+				}
+				addr = string(lo.Coins[0])
+				qty = lo.Quantity
+				lots = qty / mktInfo.LotSize
+			} else {
+				addr = lo.Address
+				redeems = int((lo.Quantity - lo.FillAmt) / mktInfo.LotSize)
+			}
+			baseAcctStats.add(addr, qty, lots, redeems)
+		} else if lo.Sell {
 			baseCoins[id] = lo.Coins
-		} else {
+		}
+
+		if quoteIsAcctBased {
+			var addr string
+			var qty, lots uint64
+			var redeems int
+			if lo.Sell {
+				addr = lo.Address
+				redeems = int((lo.Quantity - lo.FillAmt) / mktInfo.LotSize)
+			} else {
+				// address is zeroth coin
+				if len(lo.Coins) != 1 {
+					log.Errorf("rejecting account-based-base-asset order %s that has no coins ¯\\_(ツ)_/¯", lo.ID())
+					continue ordersLoop
+				}
+				addr = string(lo.Coins[0])
+				qty = lo.Quantity
+				lots = qty / mktInfo.LotSize
+			}
+			quoteAcctStats.add(addr, qty, lots, redeems)
+		} else if !lo.Sell {
 			quoteCoins[id] = lo.Coins
 		}
 	}
 
-	log.Debugf("Locking %d base asset (%d) coins.", len(baseCoins), base)
-	if log.Level() <= dex.LevelTrace {
-		for oid, coins := range baseCoins {
-			log.Tracef(" - order %v: %v", oid, coins)
+	if baseIsAcctBased {
+		log.Debugf("Checking %d base asset (%d) balances.", len(baseAcctStats), base)
+		for acctAddr, stats := range baseAcctStats {
+			if !cfg.Balancer.CheckBalance(acctAddr, mktInfo.Base, stats.qty, stats.lots, stats.redeems) {
+				log.Errorf("%s base asset account failed the startup balance check on the %s market", acctAddr, mktInfo.Name)
+				failedBaseAccts[acctAddr] = true
+			}
+		}
+	} else {
+		log.Debugf("Locking %d base asset (%d) coins.", len(baseCoins), base)
+		if log.Level() <= dex.LevelTrace {
+			for oid, coins := range baseCoins {
+				log.Tracef(" - order %v: %v", oid, coins)
+			}
+		}
+		for oid := range cfg.CoinLockerBase.LockCoins(baseCoins) {
+			missingCoinFails[oid] = struct{}{}
 		}
 	}
 
-	log.Debugf("Locking %d quote asset (%d) coins.", len(quoteCoins), quote)
-	if log.Level() <= dex.LevelTrace {
-		for oid, coins := range quoteCoins {
-			log.Tracef(" - order %v: %v", oid, coins)
+	if quoteIsAcctBased {
+		log.Debugf("Checking %d quote asset (%d) balances.", len(quoteAcctStats), quote)
+		for acctAddr, stats := range quoteAcctStats { // quoteAcctStats is nil for utxo-based quote assets
+			if !cfg.Balancer.CheckBalance(acctAddr, mktInfo.Quote, stats.qty, stats.lots, stats.redeems) {
+				log.Errorf("%s quote asset account failed the startup balance check on the %s market", acctAddr, mktInfo.Name)
+				failedQuoteAccts[acctAddr] = true
+			}
+		}
+	} else {
+		log.Debugf("Locking %d quote asset (%d) coins.", len(quoteCoins), quote)
+		if log.Level() <= dex.LevelTrace {
+			for oid, coins := range quoteCoins {
+				log.Tracef(" - order %v: %v", oid, coins)
+			}
+		}
+		for oid := range cfg.CoinLockerQuote.LockCoins(quoteCoins) {
+			missingCoinFails[oid] = struct{}{}
 		}
 	}
 
-	// Lock the coins, catching and removing orders where coins were already
-	// locked by another market.
-	failedOrderCoins := cfg.CoinLockerBase.LockCoins(baseCoins)
-	// Merge base and quote asset coins.
-	for id, coins := range cfg.CoinLockerQuote.LockCoins(quoteCoins) {
-		failedOrderCoins[id] = coins
-	}
-
-	for oid := range failedOrderCoins {
+	for oid := range missingCoinFails {
 		log.Warnf("Revoking book order %v with already locked coins.", oid)
 		bad := bookOrdersByID[oid]
 		delete(bookOrdersByID, oid)
@@ -310,27 +421,34 @@ ordersLoop:
 		}
 	}
 
-	Book := book.New(mktInfo.LotSize)
+	Book := book.New(mktInfo.LotSize, acctTracking)
 	for _, lo := range bookOrdersByID {
-		// Limit order amount requirements are simple unlike market buys.
-		if lo.Quantity%mktInfo.LotSize != 0 || lo.FillAmt%mktInfo.LotSize != 0 {
-			// To change market configuration, the operator should suspended the
-			// market with persist=false, but that may not have happened, or
-			// maybe a revoke failed.
-			log.Errorf("Not rebooking order %v with amount (%v/%v) incompatible with current lot size (%v)",
-				lo.FillAmt, lo.Quantity, mktInfo.LotSize)
-			// Revoke the order, but do not count this against the user.
-			if _, _, err = storage.RevokeOrderUncounted(lo); err != nil {
-				log.Errorf("Failed to revoke order %v: %v", lo, err)
-				// But still not added back on the book.
-			}
+		// Catch account-based asset low-balance rejections here.
+		if baseIsAcctBased && failedBaseAccts[lo.BaseAccount()] {
+			failedAcctOrders[lo.ID()] = struct{}{}
+			log.Warnf("Skipping insert of order %s into %s book because base asset "+
+				"account failed the balance check", lo.ID(), mktInfo.Name)
 			continue
 		}
-
+		if quoteIsAcctBased && failedQuoteAccts[lo.QuoteAccount()] {
+			failedAcctOrders[lo.ID()] = struct{}{}
+			log.Warnf("Skipping insert of order %s into %s book because quote asset "+
+				"account failed the balance check", lo.ID(), mktInfo.Name)
+			continue
+		}
 		if ok := Book.Insert(lo); !ok {
 			// This can only happen if one of the loaded orders has an
-			// incompatible lot size for the current market config.
+			// incompatible lot size for the current market config, which was
+			// already checked above.
 			log.Errorf("Failed to insert order %v into %v book.", mktInfo.Name, lo)
+		}
+	}
+
+	// Revoke the low-balance rejections in the database.
+	for oid := range failedAcctOrders {
+		// Already logged in the Book.Insert loop.
+		if _, _, err = storage.RevokeOrderUncounted(bookOrdersByID[oid]); err != nil {
+			log.Errorf("Failed to revoke order with insufficient account balance %v: %v", bookOrdersByID[oid], err)
 		}
 	}
 
@@ -838,13 +956,13 @@ func (m *Market) rates() (bestBuyRate, mid, bestSellRate uint64) {
 // not assume that a CoinID for one asset cannot be made to match another
 // asset's CoinID.
 func (m *Market) CoinLocked(asset uint32, coin coinlock.CoinID) bool {
-	switch asset {
-	case m.marketInfo.Base:
+	switch {
+	case asset == m.marketInfo.Base && m.coinLockerBase != nil:
 		return m.coinLockerBase.CoinLocked(coin)
-	case m.marketInfo.Quote:
+	case asset == m.marketInfo.Quote && m.coinLockerQuote != nil:
 		return m.coinLockerQuote.CoinLocked(coin)
 	default:
-		panic(fmt.Sprintf("invalid asset %d for market %s", asset, m.marketInfo.Name))
+		panic(fmt.Sprintf("invalid utxo-based asset %d for market %s", asset, m.marketInfo.Name))
 	}
 }
 
@@ -1037,6 +1155,94 @@ func (m *Market) CheckUnfilled(assetID uint32, user account.AccountID) (unbooked
 	return m.checkUnfilledOrders(assetID, unfilled)
 }
 
+// AccountPending sums the orders quantities that pay to or from the specified
+// account address.
+func (m *Market) AccountPending(acctAddr string, assetID uint32) (qty, lots uint64, redeems int) {
+	base, quote := m.marketInfo.Base, m.marketInfo.Quote
+	if (assetID != base && assetID != quote) ||
+		(assetID == m.marketInfo.Base && m.coinLockerBase != nil) ||
+		(assetID == m.marketInfo.Quote && m.coinLockerQuote != nil) {
+
+		return
+	}
+
+	midGap := m.MidGap()
+	if midGap == 0 {
+		midGap = m.RateStep()
+	}
+
+	lotSize := m.marketInfo.LotSize
+	switch assetID {
+	case base:
+		m.iterateBaseAccount(acctAddr, func(trade *order.Trade, rate uint64) {
+			r := trade.Remaining()
+			if trade.Sell {
+				qty += r
+				lots += r / lotSize
+			} else {
+				if rate == 0 { // market buy
+					redeems += int(calc.QuoteToBase(midGap, r) / lotSize)
+				} else {
+					redeems += int(r / lotSize)
+				}
+			}
+		})
+	case quote:
+		m.iterateQuoteAccount(acctAddr, func(trade *order.Trade, rate uint64) {
+			r := trade.Remaining()
+			if trade.Sell {
+				redeems += int(r / lotSize)
+			} else {
+				if rate == 0 { // market buy
+					qty += r
+					lots += calc.QuoteToBase(midGap, r) / lotSize
+				} else {
+					qty += calc.BaseToQuote(midGap, r)
+					lots += r / lotSize
+				}
+			}
+		})
+	}
+	return
+}
+
+func (m *Market) iterateBaseAccount(acctAddr string, f func(*order.Trade, uint64)) {
+	m.epochMtx.RLock()
+	for _, epOrd := range m.epochOrders {
+		if epOrd.Type() == order.CancelOrderType || epOrd.Trade().BaseAccount() != acctAddr {
+			continue
+		}
+		var rate uint64
+		if lo, is := epOrd.(*order.LimitOrder); is {
+			rate = lo.Rate
+		}
+		f(epOrd.Trade(), rate)
+
+	}
+	m.epochMtx.RUnlock()
+	m.book.IterateBaseAccount(acctAddr, func(lo *order.LimitOrder) {
+		f(lo.Trade(), lo.Rate)
+	})
+}
+
+func (m *Market) iterateQuoteAccount(acctAddr string, f func(*order.Trade, uint64)) {
+	m.epochMtx.RLock()
+	for _, epOrd := range m.epochOrders {
+		if epOrd.Type() == order.CancelOrderType || epOrd.Trade().QuoteAccount() != acctAddr {
+			continue
+		}
+		var rate uint64
+		if lo, is := epOrd.(*order.LimitOrder); is {
+			rate = lo.Rate
+		}
+		f(epOrd.Trade(), rate)
+	}
+	m.epochMtx.RUnlock()
+	m.book.IterateQuoteAccount(acctAddr, func(lo *order.LimitOrder) {
+		f(lo.Trade(), lo.Rate)
+	})
+}
+
 // Book retrieves the market's current order book and the current epoch index.
 // If the Market is not yet running or the start epoch has not yet begun, the
 // epoch index will be zero.
@@ -1074,12 +1280,17 @@ func (m *Market) PurgeBook() {
 		// the market is still accepting new orders and processing epochs.
 
 		// Unlock base asset coins locked by sell orders.
-		for i := range sellsRemoved {
-			m.coinLockerBase.UnlockOrderCoins(sellsRemoved[i])
+		if m.coinLockerBase != nil {
+			for i := range sellsRemoved {
+				m.coinLockerBase.UnlockOrderCoins(sellsRemoved[i])
+			}
 		}
+
 		// Unlock quote asset coins locked by buy orders.
-		for i := range buysRemoved {
-			m.coinLockerQuote.UnlockOrderCoins(buysRemoved[i])
+		if m.coinLockerQuote != nil {
+			for i := range buysRemoved {
+				m.coinLockerQuote.UnlockOrderCoins(buysRemoved[i])
+			}
 		}
 	}
 }
@@ -1382,6 +1593,10 @@ func (m *Market) coinsLocked(o order.Order) []order.CoinID {
 		locker = m.coinLockerBase
 	}
 
+	if locker == nil { // Not utxo-based
+		return nil
+	}
+
 	// Check if this order is known by the locker.
 	lockedCoins := locker.OrderCoinsLocked(o.ID())
 	if len(lockedCoins) > 0 {
@@ -1403,8 +1618,11 @@ func (m *Market) lockOrderCoins(o order.Order) {
 	}
 
 	if o.Trade().Sell {
-		m.coinLockerBase.LockOrdersCoins([]order.Order{o})
-	} else {
+		if m.coinLockerBase != nil {
+			m.coinLockerBase.LockOrdersCoins([]order.Order{o})
+		}
+
+	} else if m.coinLockerQuote != nil {
 		m.coinLockerQuote.LockOrdersCoins([]order.Order{o})
 	}
 }
@@ -1415,8 +1633,10 @@ func (m *Market) unlockOrderCoins(o order.Order) {
 	}
 
 	if o.Trade().Sell {
-		m.coinLockerBase.UnlockOrderCoins(o.ID())
-	} else {
+		if m.coinLockerBase != nil {
+			m.coinLockerBase.UnlockOrderCoins(o.ID())
+		}
+	} else if m.coinLockerQuote != nil {
 		m.coinLockerQuote.UnlockOrderCoins(o.ID())
 	}
 }
@@ -1953,14 +2173,18 @@ func (m *Market) UnbookUserOrders(user account.AccountID) {
 		sellIDs = append(sellIDs, lo.ID())
 		m.unbookedOrder(lo)
 	}
-	m.coinLockerBase.UnlockOrdersCoins(sellIDs)
+	if m.coinLockerBase != nil {
+		m.coinLockerBase.UnlockOrdersCoins(sellIDs)
+	}
 
 	buyIDs := make([]order.OrderID, 0, len(removedBuys))
 	for _, lo := range removedBuys {
 		buyIDs = append(buyIDs, lo.ID())
 		m.unbookedOrder(lo)
 	}
-	m.coinLockerQuote.UnlockOrdersCoins(buyIDs)
+	if m.coinLockerQuote != nil {
+		m.coinLockerQuote.UnlockOrdersCoins(buyIDs)
+	}
 }
 
 // Unbook allows the DEX manager to remove a booked order. This does: (1) remove
@@ -2423,4 +2647,22 @@ func (m *Market) ScaleFeeRate(assetID uint32, feeRate uint64) uint64 {
 	}
 	// It started non-zero, so don't allow it to go to zero.
 	return uint64(math.Max(1.0, math.Round(float64(feeRate)*feeScale)))
+}
+
+type accountStats struct {
+	qty, lots uint64
+	redeems   int
+}
+
+type accountCounter map[string]*accountStats
+
+func (a accountCounter) add(addr string, qty, lots uint64, redeems int) {
+	stats, found := a[addr]
+	if !found {
+		stats = new(accountStats)
+		a[addr] = stats
+	}
+	stats.qty += qty
+	stats.lots += lots
+	stats.redeems += redeems
 }

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -374,7 +374,7 @@ ordersLoop:
 		log.Debugf("Checking %d base asset (%d) balances.", len(baseAcctStats), base)
 		for acctAddr, stats := range baseAcctStats {
 			if !cfg.Balancer.CheckBalance(acctAddr, mktInfo.Base, stats.qty, stats.lots, stats.redeems) {
-				log.Errorf("%s base asset account failed the startup balance check on the %s market", acctAddr, mktInfo.Name)
+				log.Info("%s base asset account failed the startup balance check on the %s market", acctAddr, mktInfo.Name)
 				failedBaseAccts[acctAddr] = true
 			}
 		}

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -97,6 +97,7 @@ type MarketTunnel interface {
 	// cancellation marked against the user, coins unlocked, and orderbook
 	// subscribers notified). See Unbook for details.
 	CheckUnfilled(assetID uint32, user account.AccountID) (unbooked []*order.LimitOrder)
+	AccountPending(acctAddr string, assetID uint32) (qty, lots uint64, redeems int)
 }
 
 // orderRecord contains the information necessary to respond to an order
@@ -135,14 +136,19 @@ type FeeSource interface {
 	LastRate(assetID uint32) (feeRate uint64)
 }
 
+type MatchNegotiator interface {
+	AccountStats(acctAddr string, assetID uint32) (qty, swaps uint64, redeems int)
+}
+
 // OrderRouter handles the 'limit', 'market', and 'cancel' DEX routes. These
 // are authenticated routes used for placing and canceling orders.
 type OrderRouter struct {
-	auth      AuthManager
-	assets    map[uint32]*asset.BackedAsset
-	tunnels   map[string]MarketTunnel
-	latencyQ  *wait.TickerQueue
-	feeSource FeeSource
+	auth        AuthManager
+	assets      map[uint32]*asset.BackedAsset
+	tunnels     map[string]MarketTunnel
+	latencyQ    *wait.TickerQueue
+	feeSource   FeeSource
+	dexBalancer *DEXBalancer
 }
 
 // OrderRouterConfig is the configuration settings for an OrderRouter.
@@ -151,16 +157,18 @@ type OrderRouterConfig struct {
 	Assets      map[uint32]*asset.BackedAsset
 	Markets     map[string]MarketTunnel
 	FeeSource   FeeSource
+	DEXBalancer *DEXBalancer
 }
 
 // NewOrderRouter is a constructor for an OrderRouter.
 func NewOrderRouter(cfg *OrderRouterConfig) *OrderRouter {
 	router := &OrderRouter{
-		auth:      cfg.AuthManager,
-		assets:    cfg.Assets,
-		tunnels:   cfg.Markets,
-		latencyQ:  wait.NewTickerQueue(2 * time.Second),
-		feeSource: cfg.FeeSource,
+		auth:        cfg.AuthManager,
+		assets:      cfg.Assets,
+		tunnels:     cfg.Markets,
+		latencyQ:    wait.NewTickerQueue(2 * time.Second),
+		feeSource:   cfg.FeeSource,
+		dexBalancer: cfg.DEXBalancer,
 	}
 	cfg.AuthManager.Route(msgjson.LimitRoute, router.handleLimit)
 	cfg.AuthManager.Route(msgjson.MarketRoute, router.handleMarket)
@@ -220,7 +228,7 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 		return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account %v may not submit trade orders", user)
 	}
 
-	tunnel, coins, sell, rpcErr := r.extractMarketDetails(&limit.Prefix, &limit.Trade)
+	tunnel, assets, sell, rpcErr := r.extractMarketDetails(&limit.Prefix, &limit.Trade)
 	if rpcErr != nil {
 		return rpcErr
 	}
@@ -245,12 +253,6 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 			limit.Rate, rateStep)
 	}
 
-	lotSize := tunnel.LotSize()
-	rpcErr = r.checkPrefixTrade(coins, lotSize, &limit.Prefix, &limit.Trade, true)
-	if rpcErr != nil {
-		return rpcErr
-	}
-
 	// Check time-in-force
 	var force order.TimeInForce
 	switch limit.TiF {
@@ -262,6 +264,12 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 		return msgjson.NewError(msgjson.OrderParameterError, "unknown time-in-force")
 	}
 
+	lotSize := tunnel.LotSize()
+	rpcErr = r.checkPrefixTrade(assets, lotSize, &limit.Prefix, &limit.Trade, limit.Rate, true)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
 	// Commitment
 	if len(limit.Commit) != order.CommitmentSize {
 		return msgjson.NewError(msgjson.OrderParameterError, "invalid commitment")
@@ -269,21 +277,9 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 	var commit order.Commitment
 	copy(commit[:], limit.Commit)
 
-	fundingAsset := coins.funding
 	coinIDs := make([]order.CoinID, 0, len(limit.Trade.Coins))
-	coinStrs := make([]string, 0, len(limit.Trade.Coins))
 	for _, coin := range limit.Trade.Coins {
-		// Check that the outpoint isn't locked.
 		coinID := order.CoinID(coin.ID)
-		if tunnel.CoinLocked(coins.funding.ID, coinID) {
-			return msgjson.NewError(msgjson.FundingError, fmt.Sprintf("coin %s is locked", fmtCoinID(coins.funding.Symbol, coinID)))
-		}
-
-		coinStr, err := fundingAsset.Backend.ValidateCoinID(coinID)
-		if err != nil {
-			return msgjson.NewError(msgjson.FundingError, fmt.Sprintf("invalid coin ID %v: %v", coinID, err))
-		}
-		coinStrs = append(coinStrs, coinStr)
 		coinIDs = append(coinIDs, coinID)
 	}
 
@@ -318,16 +314,197 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 		msgID: msg.ID,
 	}
 
-	swapVal := limit.Quantity
-	lots := swapVal / lotSize
-	if !sell {
-		swapVal = matcher.BaseToQuote(limit.Rate, limit.Quantity)
+	return r.processTrade(oRecord, tunnel, assets, limit.Coins, sell, limit.Rate, limit.RedeemSig, limit.Serialize())
+}
+
+// handleMarket is the handler for the 'market' route. This route accepts a
+// msgjson.MarketOrder payload, validates the information, constructs an
+// order.MarketOrder and submits it to the epoch queue.
+func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
+	market := new(msgjson.MarketOrder)
+	err := msg.Unmarshal(&market)
+	if err != nil || market == nil {
+		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'market' payload")
+	}
+
+	rpcErr := r.verifyAccount(user, market.AccountID, market)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	if _, suspended := r.auth.Suspended(user); suspended {
+		return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account %v may not submit trade orders", user)
+	}
+
+	tunnel, assets, sell, rpcErr := r.extractMarketDetails(&market.Prefix, &market.Trade)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	if !tunnel.Running() {
+		mktName, _ := dex.MarketName(market.Base, market.Quote)
+		return msgjson.NewError(msgjson.MarketNotRunningError, "market %s closed to new orders", mktName)
+	}
+
+	// Check that OrderType is set correctly
+	if market.OrderType != msgjson.MarketOrderNum {
+		return msgjson.NewError(msgjson.OrderParameterError, "wrong order type set for market order")
+	}
+
+	// Passing sell as the checkLot parameter causes the lot size check to be
+	// ignored for market buy orders.
+	lotSize := tunnel.LotSize()
+	rpcErr = r.checkPrefixTrade(assets, lotSize, &market.Prefix, &market.Trade, 0, sell)
+	if rpcErr != nil {
+		return rpcErr
+	}
+
+	// Commitment.
+	if len(market.Commit) != order.CommitmentSize {
+		return msgjson.NewError(msgjson.OrderParameterError, "invalid commitment")
+	}
+	var commit order.Commitment
+	copy(commit[:], market.Commit)
+
+	// fundingAsset := assets.funding
+	coinIDs := make([]order.CoinID, 0, len(market.Trade.Coins))
+	for _, coin := range market.Trade.Coins {
+		coinID := order.CoinID(coin.ID)
+		coinIDs = append(coinIDs, coinID)
+	}
+
+	// Create the market order
+	mo := &order.MarketOrder{
+		P: order.Prefix{
+			AccountID:  user,
+			BaseAsset:  market.Base,
+			QuoteAsset: market.Quote,
+			OrderType:  order.MarketOrderType,
+			ClientTime: encode.UnixTimeMilli(int64(market.ClientTime)),
+			//ServerTime set in epoch queue processing pipeline.
+			Commit: commit,
+		},
+		T: order.Trade{
+			Coins:    coinIDs,
+			Sell:     sell,
+			Quantity: market.Quantity,
+			Address:  market.Address,
+		},
+	}
+
+	// Send the order to the epoch queue.
+	oRecord := &orderRecord{
+		order: mo,
+		req:   market,
+		msgID: msg.ID,
+	}
+
+	return r.processTrade(oRecord, tunnel, assets, market.Coins, sell, 0, market.RedeemSig, market.Serialize())
+}
+
+// processTrade checks that the trade is valid and submits it to the market.
+func (r *OrderRouter) processTrade(oRecord *orderRecord, tunnel MarketTunnel, assets *assetSet,
+	coins []*msgjson.Coin, sell bool, rate uint64, redeemSig *msgjson.RedeemSig, sigMsg []byte) *msgjson.Error {
+
+	fundingAsset := assets.funding
+	user := oRecord.order.User()
+	trade := oRecord.order.Trade()
+
+	// If the receiving asset is account-based, we need to check that they can
+	// cover fees for the redemption, since they can't be subtracted from the
+	// received amount.
+	receivingBalancer, isToAccount := assets.receiving.Backend.(asset.AccountBalancer)
+	if isToAccount {
+		if redeemSig == nil {
+			log.Errorf("user %s did not include a RedeemSig for received asset %s", user, assets.receiving.Symbol)
+			return msgjson.NewError(msgjson.OrderParameterError, "no redeem address verification included for asset %s", assets.receiving.Symbol)
+		}
+
+		acctAddr := trade.ToAccount()
+		if err := receivingBalancer.ValidateSignature(acctAddr, redeemSig.PubKey, sigMsg, redeemSig.Sig); err != nil {
+			log.Errorf("user %s failed redeem signature validation for order %s: %v",
+				user, oRecord.order.ID(), err)
+			return msgjson.NewError(msgjson.SignatureError, "redeem signature validation failed")
+		}
+
+		if !r.sufficientAccountBalance(acctAddr, oRecord.order, &assets.receiving.Asset, tunnel) {
+			return msgjson.NewError(msgjson.FundingError, "insufficient balance")
+		}
+	}
+
+	// If the funding asset is account-based, we'll check balance and submit the
+	// order immediately, since we don't need to find coins.
+	fundingBalancer, isAccountFunded := assets.funding.Backend.(asset.AccountBalancer)
+	if isAccountFunded {
+		// Validate that the coins are correct for an account-based-asset-funded
+		// order. There should be 1 coin, 1 sig, 1 pubkey, and no redeem script.
+		if len(coins) != 1 {
+			log.Errorf("user %s submitted an %s-funded order with %d coin IDs", user, assets.funding.Symbol, len(coins))
+			return msgjson.NewError(msgjson.OrderParameterError, "account-type asset funding requires exactly one coin ID")
+		}
+		acctProof := coins[0]
+		if len(acctProof.PubKeys) != 1 || len(acctProof.Sigs) != 1 || len(acctProof.Redeem) > 0 {
+			log.Errorf("user %s submitted an %s-funded order with %d pubkeys, %d sigs, redeem script length %d",
+				user, assets.funding.Symbol, len(acctProof.PubKeys), len(acctProof.Sigs), len(acctProof.Redeem))
+			return msgjson.NewError(msgjson.OrderParameterError, "account-type asset funding requires exactly one coin ID")
+		}
+
+		acctAddr := trade.FromAccount()
+		pubKey := acctProof.PubKeys[0]
+		sig := acctProof.Sigs[0]
+		if err := fundingBalancer.ValidateSignature(acctAddr, pubKey, sigMsg, sig); err != nil {
+			log.Errorf("user %s failed signature validation for order %s: %v",
+				user, oRecord.order.ID(), err)
+			return msgjson.NewError(msgjson.SignatureError, "signature validation failed")
+		}
+
+		if !r.sufficientAccountBalance(acctAddr, oRecord.order, &assets.funding.Asset, tunnel) {
+			return msgjson.NewError(msgjson.FundingError, "insufficient balance")
+		}
+		return r.submitOrderToMarket(tunnel, oRecord)
+	}
+
+	// Funding coins are from a utxo-based asset. Need to find them.
+
+	// Validate coin IDs and prepare some strings for debug logging.
+	coinStrs := make([]string, 0, len(coins))
+	for _, coinID := range trade.Coins {
+		coinStr, err := fundingAsset.Backend.ValidateCoinID(coinID)
+		if err != nil {
+			return msgjson.NewError(msgjson.FundingError, fmt.Sprintf("invalid coin ID %v: %v", coinID, err))
+		}
+		// TODO: Check all markets here?
+		if tunnel.CoinLocked(assets.funding.ID, coinID) {
+			return msgjson.NewError(msgjson.FundingError, fmt.Sprintf("coin %s is locked", fmtCoinID(assets.funding.Symbol, coinID)))
+		}
+		coinStrs = append(coinStrs, coinStr)
+	}
+
+	// Use this as a chance to check user's existing market orders.
+	// TODO: check all markets?
+	for mktName, tunnel := range r.tunnels {
+		unbookedUnfunded := tunnel.CheckUnfilled(assets.funding.ID, oRecord.order.User())
+		for _, badLo := range unbookedUnfunded {
+			log.Infof("Unbooked unfunded order %v from market %s for user %v", badLo, mktName, oRecord.order.User())
+		}
+	}
+
+	lotSize := tunnel.LotSize()
+
+	midGap := tunnel.MidGap()
+	if midGap == 0 {
+		midGap = tunnel.RateStep()
+	}
+
+	lots := trade.Quantity / lotSize
+	if !sell && rate == 0 {
+		lots = matcher.QuoteToBase(midGap, trade.Quantity) / lotSize
 	}
 
 	var valSum uint64
 	var spendSize uint32
-	neededCoins := make(map[int]*msgjson.Coin, len(limit.Trade.Coins))
-	for i, coin := range limit.Trade.Coins {
+	neededCoins := make(map[int]*msgjson.Coin, len(trade.Coins))
+	for i, coin := range coins {
 		neededCoins[i] = coin
 	}
 
@@ -374,8 +551,37 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 			spendSize += dexCoin.SpendSize()
 		}
 
+		if valSum == 0 {
+			return false, msgjson.NewError(msgjson.FundingError, "zero value funding coins not permitted")
+		}
+
 		// Calculate the fees and check that the utxo sum is enough.
-		reqVal := calc.RequiredOrderFunds(swapVal, uint64(spendSize), lots, &fundingAsset.Asset)
+		var reqVal uint64
+		if sell {
+			reqVal = calc.RequiredOrderFunds(trade.Quantity, uint64(spendSize), lots, &fundingAsset.Asset)
+		} else {
+			// This is a market buy order, so the quantity gets special handling.
+			// 1. The quantity is in units of the quote asset.
+			// 2. The quantity has to satisfy the market buy buffer.
+			if rate > 0 {
+				quoteQty := calc.BaseToQuote(rate, trade.Quantity)
+				reqVal = calc.RequiredOrderFunds(quoteQty, uint64(spendSize), lots, &assets.quote.Asset)
+			} else {
+				midGap := tunnel.MidGap()
+				if midGap == 0 {
+					midGap = tunnel.RateStep()
+				}
+				buyBuffer := tunnel.MarketBuyBuffer()
+				lotWithBuffer := uint64(float64(lotSize) * buyBuffer)
+				minReq := matcher.BaseToQuote(midGap, lotWithBuffer)
+				if trade.Quantity < minReq {
+					errStr := fmt.Sprintf("order quantity does not satisfy market buy buffer. %d < %d. midGap = %d", trade.Quantity, minReq, midGap)
+					return false, msgjson.NewError(msgjson.FundingError, errStr)
+				}
+				reqVal = calc.RequiredOrderFunds(minReq, uint64(spendSize), 1, &assets.quote.Asset)
+			}
+
+		}
 		if valSum < reqVal {
 			return false, msgjson.NewError(msgjson.FundingError,
 				fmt.Sprintf("not enough funds. need at least %d, got %d", reqVal, valSum))
@@ -393,31 +599,21 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 				return wait.TryAgain
 			}
 			if msgErr != nil {
-				r.respondError(msg.ID, user, msgErr)
+				r.respondError(oRecord.msgID, user, msgErr)
 				return wait.DontTryAgain
 			}
 
 			// Send the order to the epoch queue where it will be time stamped.
 			log.Tracef("Found and validated %s coins %v for new limit order", fundingAsset.Symbol, coinStrs)
-			if err := tunnel.SubmitOrder(oRecord); err != nil {
-				code := msgjson.UnknownMarketError
-				switch {
-				case errors.Is(err, ErrInternalServer):
-					log.Errorf("Market failed to SubmitOrder: %v", err)
-				case errors.Is(err, ErrQuantityTooHigh):
-					code = msgjson.OrderQuantityTooHigh
-					fallthrough
-				default:
-					log.Debugf("Market failed to SubmitOrder: %v", err)
-				}
-				r.respondError(msg.ID, user, msgjson.NewError(code, err.Error()))
+			if msgErr := r.submitOrderToMarket(tunnel, oRecord); msgErr != nil {
+				r.respondError(oRecord.msgID, user, msgErr)
 			}
 			return wait.DontTryAgain
 		},
 		ExpireFunc: func() {
 			// Tell them to broadcast again or check their node before broadcast
 			// timeout is reached and the match is revoked.
-			r.respondError(msg.ID, user, msgjson.NewError(msgjson.TransactionUndiscovered,
+			r.respondError(oRecord.msgID, user, msgjson.NewError(msgjson.TransactionUndiscovered,
 				fmt.Sprintf("failed to find funding coins %v", coinStrs)))
 		},
 	})
@@ -425,209 +621,57 @@ func (r *OrderRouter) handleLimit(user account.AccountID, msg *msgjson.Message) 
 	return nil
 }
 
-// handleMarket is the handler for the 'market' route. This route accepts a
-// msgjson.MarketOrder payload, validates the information, constructs an
-// order.MarketOrder and submits it to the epoch queue.
-func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message) *msgjson.Error {
-	market := new(msgjson.MarketOrder)
-	err := msg.Unmarshal(&market)
-	if err != nil || market == nil {
-		return msgjson.NewError(msgjson.RPCParseError, "error decoding 'market' payload")
-	}
+// sufficientAccountBalance checks that the user's account-based asset balance
+// is sufficient to support the order, considering the user's other orders and
+// active matches across all DEX markets.
+func (r *OrderRouter) sufficientAccountBalance(accountAddr string, ord order.Order, assetInfo *dex.Asset, tunnel MarketTunnel) bool {
+	assetID := assetInfo.ID
+	trade := ord.Trade()
 
-	rpcErr := r.verifyAccount(user, market.AccountID, market)
-	if rpcErr != nil {
-		return rpcErr
-	}
-
-	if _, suspended := r.auth.Suspended(user); suspended {
-		return msgjson.NewError(msgjson.MarketNotRunningError, "suspended account %v may not submit trade orders", user)
-	}
-
-	tunnel, assets, sell, rpcErr := r.extractMarketDetails(&market.Prefix, &market.Trade)
-	if rpcErr != nil {
-		return rpcErr
-	}
-
-	if !tunnel.Running() {
-		mktName, _ := dex.MarketName(market.Base, market.Quote)
-		return msgjson.NewError(msgjson.MarketNotRunningError, "market %s closed to new orders", mktName)
-	}
-
-	// Check that OrderType is set correctly
-	if market.OrderType != msgjson.MarketOrderNum {
-		return msgjson.NewError(msgjson.OrderParameterError, "wrong order type set for market order")
-	}
-
-	// Passing sell as the checkLot parameter causes the lot size check to be
-	// ignored for market buy orders.
-	lotSize := tunnel.LotSize()
-	rpcErr = r.checkPrefixTrade(assets, lotSize, &market.Prefix, &market.Trade, sell)
-	if rpcErr != nil {
-		return rpcErr
-	}
-
-	// Commitment.
-	if len(market.Commit) != order.CommitmentSize {
-		return msgjson.NewError(msgjson.OrderParameterError, "invalid commitment")
-	}
-	var commit order.Commitment
-	copy(commit[:], market.Commit)
-
-	fundingAsset := assets.funding
-	coinIDs := make([]order.CoinID, 0, len(market.Trade.Coins))
-	coinStrs := make([]string, 0, len(market.Trade.Coins))
-	for _, coin := range market.Trade.Coins {
-		// Check that the outpoint isn't locked.
-		coinID := order.CoinID(coin.ID)
-		if tunnel.CoinLocked(fundingAsset.ID, coinID) {
-			return msgjson.NewError(msgjson.FundingError, fmt.Sprintf("coin %s is locked", fmtCoinID(fundingAsset.Symbol, coinID)))
-		}
-
-		coinStr, err := fundingAsset.Backend.ValidateCoinID(coinID)
-		if err != nil {
-			return msgjson.NewError(msgjson.FundingError, fmt.Sprintf("invalid coin ID %v: %v", coinID, err))
-		}
-		coinStrs = append(coinStrs, coinStr)
-		coinIDs = append(coinIDs, coinID)
-	}
-
-	// Create the market order
-	mo := &order.MarketOrder{
-		P: order.Prefix{
-			AccountID:  user,
-			BaseAsset:  market.Base,
-			QuoteAsset: market.Quote,
-			OrderType:  order.MarketOrderType,
-			ClientTime: encode.UnixTimeMilli(int64(market.ClientTime)),
-			//ServerTime set in epoch queue processing pipeline.
-			Commit: commit,
-		},
-		T: order.Trade{
-			Coins:    coinIDs,
-			Sell:     sell,
-			Quantity: market.Quantity,
-			Address:  market.Address,
-		},
-	}
-
-	// Send the order to the epoch queue.
-	oRecord := &orderRecord{
-		order: mo,
-		req:   market,
-		msgID: msg.ID,
-	}
-
-	var valSum uint64
-	var spendSize uint32
-	neededCoins := make(map[int]*msgjson.Coin, len(market.Trade.Coins))
-	for i, coin := range market.Trade.Coins {
-		neededCoins[i] = coin
-	}
-
-	checkCoins := func() (tryAgain bool, msgErr *msgjson.Error) {
-		for key, coin := range neededCoins {
-			// Get the coin from the backend and validate it.
-			dexCoin, err := fundingCoin(fundingAsset.Backend, coin.ID, coin.Redeem)
-			if err != nil {
-				if errors.Is(err, asset.CoinNotFoundError) {
-					return true, nil
-				}
-				if errors.Is(err, asset.ErrRequestTimeout) {
-					log.Errorf("Deadline exceeded attempting to verify funding coin %v (%s). Will try again.",
-						coin.ID, fundingAsset.Symbol)
-					return true, nil
-				}
-				log.Errorf("Error retreiving market order funding coin ID %s. user = %s: %v", coin.ID, user, err)
-				return false, msgjson.NewError(msgjson.FundingError, fmt.Sprintf("error retrieving coin ID %v", coin.ID))
-			}
-
-			// Verify that the user controls the funding coins.
-			err = dexCoin.Auth(msgBytesToBytes(coin.PubKeys), msgBytesToBytes(coin.Sigs), coin.ID)
-			if err != nil {
-				log.Debugf("Auth error for %s coin %s: %v", fundingAsset.Symbol, dexCoin, err)
-				return false, msgjson.NewError(msgjson.CoinAuthError, fmt.Sprintf("failed to authorize coin %v", dexCoin))
-			}
-
-			msgErr := r.checkZeroConfs(dexCoin, fundingAsset)
-			if msgErr != nil {
-				return false, msgErr
-			}
-
-			delete(neededCoins, key) // don't check this coin again
-			valSum += dexCoin.Value()
-			// SEE NOTE above in handleLimit regarding underestimation for BTC.
-			spendSize += dexCoin.SpendSize()
-		}
-
-		if valSum == 0 {
-			return false, msgjson.NewError(msgjson.FundingError, "zero value funding coins not permitted")
-		}
-
-		// Calculate the fees and check that the utxo sum is enough.
-		var reqVal uint64
-		if sell {
-			lots := market.Quantity / lotSize
-			reqVal = calc.RequiredOrderFunds(market.Quantity, uint64(spendSize), lots, &assets.funding.Asset)
+	var fundingQty, fundingLots uint64
+	var redeems int
+	if ord.Base() == assetID {
+		if trade.Sell {
+			fundingQty = trade.Quantity
+			fundingLots = trade.Quantity / tunnel.LotSize()
 		} else {
-			// This is a market buy order, so the quantity gets special handling.
-			// 1. The quantity is in units of the quote asset.
-			// 2. The quantity has to satisfy the market buy buffer.
-			midGap := tunnel.MidGap()
-			if midGap == 0 {
-				midGap = tunnel.RateStep()
-			}
-			buyBuffer := tunnel.MarketBuyBuffer()
-			lotWithBuffer := uint64(float64(lotSize) * buyBuffer)
-			minReq := matcher.BaseToQuote(midGap, lotWithBuffer)
-			reqVal = calc.RequiredOrderFunds(minReq, uint64(spendSize), 1, &assets.base.Asset)
-
-			if market.Quantity < minReq {
-				errStr := fmt.Sprintf("order quantity does not satisfy market buy buffer. %d < %d. midGap = %d", market.Quantity, minReq, midGap)
-				return false, msgjson.NewError(msgjson.FundingError, errStr)
+			if lo, ok := ord.(*order.LimitOrder); ok {
+				redeems = int(calc.QuoteToBase(lo.Rate, trade.Quantity) / tunnel.LotSize())
+			} else {
+				redeems = int(calc.QuoteToBase(safeMidGap(tunnel), trade.Quantity) / tunnel.LotSize())
 			}
 		}
-		if valSum < reqVal {
-			return false, msgjson.NewError(msgjson.FundingError,
-				fmt.Sprintf("not enough funds. need at least %d, got %d", reqVal, valSum))
+	} else {
+		if trade.Sell {
+			redeems = int(trade.Quantity / tunnel.LotSize())
+		} else {
+			if lo, ok := ord.(*order.LimitOrder); ok {
+				fundingQty = calc.BaseToQuote(lo.Rate, trade.Quantity)
+				fundingLots = trade.Quantity / tunnel.LotSize()
+			} else { // market buy
+				fundingQty = calc.QuoteToBase(safeMidGap(tunnel), trade.Quantity)
+				fundingLots = fundingQty / tunnel.LotSize()
+			}
 		}
-
-		return false, nil
 	}
 
-	log.Tracef("Searching for %s coins %v for new market order", fundingAsset.Symbol, coinStrs)
-	r.latencyQ.Wait(&wait.Waiter{
-		Expiration: time.Now().Add(fundingTxWait),
-		TryFunc: func() bool {
-			tryAgain, msgErr := checkCoins()
-			if tryAgain {
-				return wait.TryAgain
-			}
-			if msgErr != nil {
-				r.respondError(msg.ID, user, msgErr)
-				return wait.DontTryAgain
-			}
+	return r.dexBalancer.CheckBalance(accountAddr, assetID, fundingQty, fundingLots, redeems)
+}
 
-			// Send the order to the epoch queue where it will be time stamped.
-			log.Tracef("Found and validated %s coins %v for new market order", fundingAsset.Symbol, coinStrs)
-			if err := tunnel.SubmitOrder(oRecord); err != nil {
-				if errors.Is(err, ErrInternalServer) {
-					log.Errorf("Market failed to SubmitOrder: %v", err)
-				} else {
-					log.Debugf("Market failed to SubmitOrder: %v", err)
-				}
-				r.respondError(msg.ID, user, msgjson.NewError(msgjson.UnknownMarketError, err.Error()))
-			}
-			return wait.DontTryAgain
-		},
-		ExpireFunc: func() {
-			// Tell them to broadcast again or check their node before broadcast
-			// timeout is reached and the match is revoked.
-			r.respondError(msg.ID, user, msgjson.NewError(msgjson.TransactionUndiscovered,
-				fmt.Sprintf("failed to find funding coins %v", coinStrs)))
-		},
-	})
-
+func (r *OrderRouter) submitOrderToMarket(tunnel MarketTunnel, oRecord *orderRecord) *msgjson.Error {
+	if err := tunnel.SubmitOrder(oRecord); err != nil {
+		code := msgjson.UnknownMarketError
+		switch {
+		case errors.Is(err, ErrInternalServer):
+			log.Errorf("Market failed to SubmitOrder: %v", err)
+		case errors.Is(err, ErrQuantityTooHigh):
+			code = msgjson.OrderQuantityTooHigh
+			fallthrough
+		default:
+			log.Debugf("Market failed to SubmitOrder: %v", err)
+		}
+		return msgjson.NewError(code, err.Error())
+	}
 	return nil
 }
 
@@ -740,8 +784,6 @@ func (r *OrderRouter) verifyAccount(user account.AccountID, msgAcct msgjson.Byte
 		return msgjson.NewError(msgjson.OrderParameterError, "account ID mismatch")
 	}
 	// Check the clients signature of the order.
-	// DRAFT NOTE: These Serialize methods actually never return errors. We should
-	// just drop the error return value.
 	sigMsg := signable.Serialize()
 	err := r.auth.Auth(user, sigMsg, signable.SigBytes())
 	if err != nil {
@@ -859,7 +901,7 @@ func checkTimes(prefix *msgjson.Prefix) *msgjson.Error {
 // checkPrefixTrade validates the information in the prefix and trade portions
 // of an order.
 func (r *OrderRouter) checkPrefixTrade(assets *assetSet, lotSize uint64, prefix *msgjson.Prefix,
-	trade *msgjson.Trade, checkLot bool) *msgjson.Error {
+	trade *msgjson.Trade, rate uint64, checkLot bool) *msgjson.Error {
 	// Check that the client's timestamp is still valid.
 	rpcErr := checkTimes(prefix)
 	if rpcErr != nil {
@@ -895,17 +937,6 @@ func (r *OrderRouter) checkPrefixTrade(assets *assetSet, lotSize uint64, prefix 
 		}
 	}
 
-	// Verify all of the user's unfilled book orders have unspent funding coins,
-	// unbooking them as necessary.
-	var user account.AccountID
-	copy(user[:], prefix.AccountID)
-	for mktName, tunnel := range r.tunnels {
-		unbookedUnfunded := tunnel.CheckUnfilled(assets.funding.ID, user)
-		for _, badLo := range unbookedUnfunded {
-			log.Infof("Unbooked unfunded order %v from market %s for user %v", badLo, mktName, user)
-		}
-	}
-
 	return nil
 }
 
@@ -926,4 +957,12 @@ func fmtCoinID(symbol string, coinID []byte) string {
 		return "unparsed:" + hex.EncodeToString(coinID)
 	}
 	return strID
+}
+
+func safeMidGap(tunnel MarketTunnel) uint64 {
+	midGap := tunnel.MidGap()
+	if midGap == 0 {
+		return tunnel.RateStep()
+	}
+	return midGap
 }

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -366,7 +366,6 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 	var commit order.Commitment
 	copy(commit[:], market.Commit)
 
-	// fundingAsset := assets.funding
 	coinIDs := make([]order.CoinID, 0, len(market.Trade.Coins))
 	for _, coin := range market.Trade.Coins {
 		coinID := order.CoinID(coin.ID)
@@ -416,13 +415,13 @@ func (r *OrderRouter) processTrade(oRecord *orderRecord, tunnel MarketTunnel, as
 	receivingBalancer, isToAccount := assets.receiving.Backend.(asset.AccountBalancer)
 	if isToAccount {
 		if redeemSig == nil {
-			log.Errorf("user %s did not include a RedeemSig for received asset %s", user, assets.receiving.Symbol)
+			log.Info("user %s did not include a RedeemSig for received asset %s", user, assets.receiving.Symbol)
 			return msgjson.NewError(msgjson.OrderParameterError, "no redeem address verification included for asset %s", assets.receiving.Symbol)
 		}
 
 		acctAddr := trade.ToAccount()
 		if err := receivingBalancer.ValidateSignature(acctAddr, redeemSig.PubKey, sigMsg, redeemSig.Sig); err != nil {
-			log.Errorf("user %s failed redeem signature validation for order %s: %v",
+			log.Info("user %s failed redeem signature validation for order %s: %v",
 				user, oRecord.order.ID(), err)
 			return msgjson.NewError(msgjson.SignatureError, "redeem signature validation failed")
 		}
@@ -439,12 +438,12 @@ func (r *OrderRouter) processTrade(oRecord *orderRecord, tunnel MarketTunnel, as
 		// Validate that the coins are correct for an account-based-asset-funded
 		// order. There should be 1 coin, 1 sig, 1 pubkey, and no redeem script.
 		if len(coins) != 1 {
-			log.Errorf("user %s submitted an %s-funded order with %d coin IDs", user, assets.funding.Symbol, len(coins))
+			log.Info("user %s submitted an %s-funded order with %d coin IDs", user, assets.funding.Symbol, len(coins))
 			return msgjson.NewError(msgjson.OrderParameterError, "account-type asset funding requires exactly one coin ID")
 		}
 		acctProof := coins[0]
 		if len(acctProof.PubKeys) != 1 || len(acctProof.Sigs) != 1 || len(acctProof.Redeem) > 0 {
-			log.Errorf("user %s submitted an %s-funded order with %d pubkeys, %d sigs, redeem script length %d",
+			log.Info("user %s submitted an %s-funded order with %d pubkeys, %d sigs, redeem script length %d",
 				user, assets.funding.Symbol, len(acctProof.PubKeys), len(acctProof.Sigs), len(acctProof.Redeem))
 			return msgjson.NewError(msgjson.OrderParameterError, "account-type asset funding requires exactly one coin ID")
 		}
@@ -453,7 +452,7 @@ func (r *OrderRouter) processTrade(oRecord *orderRecord, tunnel MarketTunnel, as
 		pubKey := acctProof.PubKeys[0]
 		sig := acctProof.Sigs[0]
 		if err := fundingBalancer.ValidateSignature(acctAddr, pubKey, sigMsg, sig); err != nil {
-			log.Errorf("user %s failed signature validation for order %s: %v",
+			log.Info("user %s failed signature validation for order %s: %v",
 				user, oRecord.order.ID(), err)
 			return msgjson.NewError(msgjson.SignatureError, "signature validation failed")
 		}
@@ -649,7 +648,7 @@ func (r *OrderRouter) sufficientAccountBalance(accountAddr string, ord order.Ord
 				fundingQty = calc.BaseToQuote(lo.Rate, trade.Quantity)
 				fundingLots = trade.Quantity / tunnel.LotSize()
 			} else { // market buy
-				fundingQty = calc.QuoteToBase(safeMidGap(tunnel), trade.Quantity)
+				fundingQty = trade.Quantity
 				fundingLots = fundingQty / tunnel.LotSize()
 			}
 		}

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -97,7 +97,6 @@ type MarketTunnel interface {
 	// cancellation marked against the user, coins unlocked, and orderbook
 	// subscribers notified). See Unbook for details.
 	CheckUnfilled(assetID uint32, user account.AccountID) (unbooked []*order.LimitOrder)
-	AccountPending(acctAddr string, assetID uint32) (qty, lots uint64, redeems int)
 }
 
 // orderRecord contains the information necessary to respond to an order
@@ -134,10 +133,6 @@ func newAssetSet(base, quote *asset.BackedAsset, sell bool) *assetSet {
 // FeeSource is a source of the last reported tx fee rate estimate for an asset.
 type FeeSource interface {
 	LastRate(assetID uint32) (feeRate uint64)
-}
-
-type MatchNegotiator interface {
-	AccountStats(acctAddr string, assetID uint32) (qty, swaps uint64, redeems int)
 }
 
 // OrderRouter handles the 'limit', 'market', and 'cancel' DEX routes. These

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -658,6 +658,10 @@ func TestMain(m *testing.M) {
 		"dcr_eth":   oRig.market,
 		"eth_matic": oRig.market,
 	}
+	pendingAccounters := make(map[string]PendingAccounter)
+	for name := range tunnels {
+		pendingAccounters[name] = oRig.market
+	}
 	assets := map[uint32]*asset.BackedAsset{
 		0:   assetBTC,
 		42:  assetDCR,
@@ -669,7 +673,7 @@ func TestMain(m *testing.M) {
 		Assets:      assets,
 		Markets:     tunnels,
 		FeeSource:   &tFeeSource{},
-		DEXBalancer: NewDEXBalancer(tunnels, assets, matchNegotiator),
+		DEXBalancer: NewDEXBalancer(pendingAccounters, assets, matchNegotiator),
 	})
 	rig = newTestRig()
 	src1 := rig.source1

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1464,8 +1464,6 @@ func (s *Swapper) processInit(msg *msgjson.Message, params *msgjson.Init, stepIn
 	stepInfo.match.Status = stepInfo.nextStep
 	stepInfo.match.mtx.Unlock()
 
-	fmt.Println("-setting new status", stepInfo.nextStep)
-
 	// Only unlock match map after the statuses and txn times are stored,
 	// ensuring that checkInaction will not revoke the match as we respond and
 	// request counterparty audit.


### PR DESCRIPTION
Adds funding validation for account-based assets i.e. eth.

**dex**: Add `RedeemSize` field to `Asset`.

**msgjson**: Add `RedeemSig` field to `Trade`. `RedeemSig` should be
populated when the redemption is to an account-based asset.
This PR also indirectly proposes a protocol for specifying
the funding account. The account address should be utf-8 encoded
and passed as the coin ID of the only coin, along with the pubkey
and signature. The data signed will be the serialized `msgjson.Limit` or
`msgjson.Market`, with server stamp set to 0. Same signature input
for the `RedeemSig`.

**dex/order*: The `Trade` type has methods for accessing the account address.

**server/asset**: `AccountBalancer` gets a `ValidateSignature` method.

**general scheme**: Orders and matches involving account-based assets are
indexed by `Swapper` and `OrderPQ` in the same way they are indexed for
users (`account.AccountID`). When an order comes into the order router,
stats for existing orders, including outstanding redemptions, is
fetched from all markets and the swapper. These stats are used with
the new order info to validate the users balance. The user must have
sufficient balance to cover all outstanding orders and redemptions.

**server/book**: All `OrderPQ` are given an `AccountTracker` set up for
any account-based assets, or none. The `AccountTracker` is essentially
the same as the `userOrders` index, but indexed by account address
instead. This is important because more than one user could be
using the same account.

`AccountTracker` has methods for iterating booked orders, exposed via
`Book` and `Market` methods used by `Market` as part of the `MarketTunnel`
interface method, `PendingAccount`, described below.

**server/swap**: `Swapper` gets an account index to mirror its user index.
The new `AccountStats` method returns information about in-process matches
that aren't yet swapped/redeemed for a particular asset.

**server/market**: `OrderRouter` is refactored for improved re-use between
`handleLimit` and `handleMarket`. For account based assets, `OrderRouter`
checks the `MarketTunnels` and `MatchNegotiator` for outstanding
order and match info, and then queries the backend (via `DEXBalancer`)
to see if the account has sufficient balance.

`NewMarket` handles balance checks on startup. This is accomplished
by additional tracking through the orders loop, and then a balance
check for account-based assets immediately before adding to the
order book. utxo-based asset handling is unchanged except that the
lot size compliance check it moved earlier in the loop.

