### PR TITLE
client: Wait for server revoke status of init.

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5284,7 +5284,7 @@ func (c *Core) handleConnectEvent(dc *dexConnection, connected bool) {
 		v = 1
 		topic = TopicDEXConnected
 	} else {
-		dc.tradeMtx.RLock()
+		dc.tradeMtx.Lock()
 		for _, tracker := range dc.trades {
 			for _, match := range tracker.matches {
 				// Make sure that a taker will not prematurely send an
@@ -5295,7 +5295,7 @@ func (c *Core) handleConnectEvent(dc *dexConnection, connected bool) {
 				}
 			}
 		}
-		dc.tradeMtx.RUnlock()
+		dc.tradeMtx.Unlock()
 	}
 	atomic.StoreUint32(&dc.connected, v)
 	if dc.broadcastingConnect() {

--- a/client/core/status.go
+++ b/client/core/status.go
@@ -119,6 +119,7 @@ func conflictResolver(ours, servers order.MatchStatus) matchConflictResolver {
 // resolution. If the conflict cannot be resolved, the match will be
 // self-revoked.
 func (c *Core) resolveConflictWithServerData(dc *dexConnection, trade *trackedTrade, match *matchTracker, srvData *msgjson.MatchStatusResult) {
+	match.checkServerRevoke = false
 	srvStatus := order.MatchStatus(srvData.Status)
 	if srvStatus != order.MatchComplete && !srvData.Active {
 		// Server has revoked the match. We'll still go through

--- a/client/core/status.go
+++ b/client/core/status.go
@@ -119,7 +119,6 @@ func conflictResolver(ours, servers order.MatchStatus) matchConflictResolver {
 // resolution. If the conflict cannot be resolved, the match will be
 // self-revoked.
 func (c *Core) resolveConflictWithServerData(dc *dexConnection, trade *trackedTrade, match *matchTracker, srvData *msgjson.MatchStatusResult) {
-	match.checkServerRevoke = false
 	srvStatus := order.MatchStatus(srvData.Status)
 	if srvStatus != order.MatchComplete && !srvData.Active {
 		// Server has revoked the match. We'll still go through

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -97,7 +97,7 @@ type matchTracker struct {
 	// will be logged on the first check or when 0.
 	lastExpireDur time.Duration
 	// checkServerRevoke is set to make sure that a taker will not prematurely
-	// send an initialization until it is confimed with the server that the
+	// send an initialization until it is confirmed with the server that the
 	// match is not revoked.
 	checkServerRevoke bool
 }


### PR DESCRIPTION
    When taker, it is possible to miss a revoke and have the initiation swap
    happen automatically on start up. Add checkServerRevoke to the match
    tracker in order to force false for isSwappable until at least one
    order status message has been received for the order.

closes #1246

This change plus setting `-timeout=20` solves the simnet test issues for me.