### PR TITLE
client/asset: remove time from AuditContract args

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"time"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/asset/btc"
@@ -206,8 +205,8 @@ func (bch *BCHWallet) Address() (string, error) {
 // AuditContract modifies the *asset.Contract returned by the ExchangeWallet
 // AuditContract method by converting the Recipient to the Cash Address
 // encoding.
-func (bch *BCHWallet) AuditContract(coinID, contract, txData dex.Bytes, matchTime time.Time) (*asset.AuditInfo, error) { // AuditInfo has address
-	ai, err := bch.ExchangeWallet.AuditContract(coinID, contract, txData, matchTime)
+func (bch *BCHWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadcast bool) (*asset.AuditInfo, error) { // AuditInfo has address
+	ai, err := bch.ExchangeWallet.AuditContract(coinID, contract, txData, rebroadcast)
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1919,7 +1919,6 @@ func testAuditContract(t *testing.T, segwit bool, walletType string) {
 	}
 	secretHash, _ := hex.DecodeString("5124208c80d33507befa517c08ed01aa8d33adbf37ecd70fb5f9352f7a51a88d")
 	lockTime := time.Now().Add(time.Hour * 12)
-	now := time.Now()
 	addr, _ := btcutil.DecodeAddress(tP2PKHAddr, &chaincfg.MainNetParams)
 	if segwit {
 		addr, _ = btcutil.DecodeAddress(tP2WPKHAddr, &chaincfg.MainNetParams)
@@ -1947,7 +1946,7 @@ func testAuditContract(t *testing.T, segwit bool, walletType string) {
 	txHash := tx.TxHash()
 	const vout = 0
 
-	audit, err := wallet.AuditContract(toCoinID(&txHash, vout), contract, txData, now)
+	audit, err := wallet.AuditContract(toCoinID(&txHash, vout), contract, txData, false)
 	if err != nil {
 		t.Fatalf("audit error: %v", err)
 	}
@@ -1962,7 +1961,7 @@ func testAuditContract(t *testing.T, segwit bool, walletType string) {
 	}
 
 	// Invalid txid
-	_, err = wallet.AuditContract(make([]byte, 15), contract, txData, now)
+	_, err = wallet.AuditContract(make([]byte, 15), contract, txData, false)
 	if err == nil {
 		t.Fatalf("no error for bad txid")
 	}
@@ -1971,7 +1970,7 @@ func testAuditContract(t *testing.T, segwit bool, walletType string) {
 	pkh, _ := hex.DecodeString("c6a704f11af6cbee8738ff19fc28cdc70aba0b82")
 	wrongAddr, _ := btcutil.NewAddressPubKeyHash(pkh, &chaincfg.MainNetParams)
 	badContract, _ := txscript.PayToAddrScript(wrongAddr)
-	_, err = wallet.AuditContract(toCoinID(&txHash, vout), badContract, nil, now)
+	_, err = wallet.AuditContract(toCoinID(&txHash, vout), badContract, nil, false)
 	if err == nil {
 		t.Fatalf("no error for wrong contract")
 	}

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -326,7 +326,7 @@ func Run(t *testing.T, cfg *Config) {
 		t.Helper()
 
 		// Alpha should be able to redeem.
-		ci, err := rig.alpha().AuditContract(receipt.Coin().ID(), receipt.Contract(), nil, tStart)
+		ci, err := rig.alpha().AuditContract(receipt.Coin().ID(), receipt.Contract(), nil, false)
 		if err != nil {
 			t.Fatalf("error auditing contract: %v", err)
 		}

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1670,7 +1670,7 @@ func TestAuditContract(t *testing.T) {
 	contractVout := uint32(0)
 	contractCoinID := toCoinID(&contractHash, contractVout)
 
-	audit, err := wallet.AuditContract(contractCoinID, contract, contractTxData, time.Time{})
+	audit, err := wallet.AuditContract(contractCoinID, contract, contractTxData, true)
 	if err != nil {
 		t.Fatalf("audit error: %v", err)
 	}
@@ -1685,7 +1685,7 @@ func TestAuditContract(t *testing.T) {
 	}
 
 	// Invalid txid
-	_, err = wallet.AuditContract(make([]byte, 15), contract, contractTxData, time.Time{})
+	_, err = wallet.AuditContract(make([]byte, 15), contract, contractTxData, false)
 	if err == nil {
 		t.Fatalf("no error for bad txid")
 	}
@@ -1698,20 +1698,20 @@ func TestAuditContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error making wrong swap contract: %v", err)
 	}
-	_, err = wallet.AuditContract(contractCoinID, wrongContract, contractTxData, time.Time{})
+	_, err = wallet.AuditContract(contractCoinID, wrongContract, contractTxData, false)
 	if err == nil {
 		t.Fatalf("no error for wrong contract")
 	}
 
 	// Invalid contract
 	_, wrongPkScript := wrongAddr.PaymentScript()
-	_, err = wallet.AuditContract(contractCoinID, wrongPkScript, contractTxData, time.Time{}) // addrPkScript not a valid contract
+	_, err = wallet.AuditContract(contractCoinID, wrongPkScript, contractTxData, false) // addrPkScript not a valid contract
 	if err == nil {
 		t.Fatalf("no error for invalid contract")
 	}
 
 	// No txdata
-	_, err = wallet.AuditContract(contractCoinID, contract, nil, time.Time{})
+	_, err = wallet.AuditContract(contractCoinID, contract, nil, false)
 	if err == nil {
 		t.Fatalf("no error for no txdata")
 	}
@@ -1722,7 +1722,7 @@ func TestAuditContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error preparing invalid contract txdata: %v", err)
 	}
-	_, err = wallet.AuditContract(contractCoinID, contract, invalidContractTxData, time.Time{})
+	_, err = wallet.AuditContract(contractCoinID, contract, invalidContractTxData, false)
 	if err == nil {
 		t.Fatalf("no error for unknown txout")
 	}
@@ -1738,7 +1738,7 @@ func TestAuditContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error preparing wrong contract txdata: %v", err)
 	}
-	_, err = wallet.AuditContract(contractCoinID, contract, wrongContractTxData, time.Time{})
+	_, err = wallet.AuditContract(contractCoinID, contract, wrongContractTxData, false)
 	if err == nil {
 		t.Fatalf("no error for unknown txout")
 	}

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -298,7 +298,7 @@ func runTest(t *testing.T, splitTx bool) {
 	makeRedemption := func(swapVal uint64, receipt asset.Receipt, secret []byte) *asset.Redemption {
 		t.Helper()
 		swapOutput := receipt.Coin()
-		ci, err := rig.alpha().AuditContract(swapOutput.ID(), receipt.Contract(), nil, tStart)
+		ci, err := rig.alpha().AuditContract(swapOutput.ID(), receipt.Contract(), nil, false)
 		if err != nil {
 			t.Fatalf("error auditing contract: %v", err)
 		}

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -709,7 +709,7 @@ func (e *ExchangeWallet) SignMessage(coin asset.Coin, msg dex.Bytes) (pubkeys, s
 // AuditContract retrieves information about a swap contract on the
 // blockchain. This would be used to verify the counter-party's contract
 // during a swap.
-func (*ExchangeWallet) AuditContract(coinID, contract, txData dex.Bytes, _ time.Time) (*asset.AuditInfo, error) {
+func (*ExchangeWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadcast bool) (*asset.AuditInfo, error) {
 	return nil, asset.ErrNotImplemented
 }
 

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -160,7 +160,7 @@ type Wallet interface {
 	// already be broadcasted. A successful audit response does not mean
 	// the tx exists on the blockchain, use SwapConfirmations to ensure
 	// the tx is mined.
-	AuditContract(coinID, contract, txData dex.Bytes, matchTime time.Time) (*AuditInfo, error)
+	AuditContract(coinID, contract, txData dex.Bytes, rebroadcast bool) (*AuditInfo, error)
 	// LocktimeExpired returns true if the specified contract's locktime has
 	// expired, making it possible to issue a Refund. The contract expiry time
 	// is also returned, but reaching this time does not necessarily mean the

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4857,18 +4857,18 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				}
 				counterTxData := match.MetaData.Proof.CounterTxData
 
-				// Obtaining AuditInfo will fail if it's unmined AND gone from
-				// mempool, or the wallet is otherwise not ready. Note that this
-				// does not actually audit the contract's value, recipient,
-				// expiration, or secret hash (if maker), as that was already
-				// done when it was initially stored as CounterScript.
-				auditInfo, err := wallets.toWallet.AuditContract(counterSwap, counterContract, counterTxData, encode.UnixTimeMilli(int64(match.MetaData.Stamp)))
+				// Note that this does not actually audit the contract's value,
+				// recipient, expiration, or secret hash (if maker), as that was
+				// already done when it was initially stored as CounterScript.
+				auditInfo, err := wallets.toWallet.AuditContract(counterSwap, counterContract, counterTxData, true)
 				if err != nil {
 					contractStr := coinIDString(wallets.toAsset.ID, counterSwap)
 					c.log.Warnf("Starting search for counterparty contract %v (%s)", contractStr, unbip(wallets.toAsset.ID))
 					// Start the audit retry waiter. Set swapErr to block tick
 					// actions like counterSwap.Confirmations checks while it is
 					// searching since matchTracker.counterSwap is not yet set.
+					// We may consider removing this if AuditContract is an
+					// offline action for all wallet implementations.
 					match.swapErr = fmt.Errorf("audit in progress, please wait") // don't frighten the users
 					go func(tracker *trackedTrade, match *matchTracker) {
 						auditInfo, err := tracker.searchAuditInfo(match, counterSwap, counterContract, counterTxData)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -706,7 +706,7 @@ func (w *TXCWallet) SignMessage(asset.Coin, dex.Bytes) (pubkeys, sigs []dex.Byte
 	return nil, nil, w.signCoinErr
 }
 
-func (w *TXCWallet) AuditContract(coinID, contract, txData dex.Bytes, _ time.Time) (*asset.AuditInfo, error) {
+func (w *TXCWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadcast bool) (*asset.AuditInfo, error) {
 	defer func() {
 		if w.auditChan != nil {
 			w.auditChan <- struct{}{}


### PR DESCRIPTION
The `Time` argument for `AuditContract` is not used now that the method does not search for the contract on the network, that now being the job of `SwapConfirmations`.

This replaces the `Time` arg with a `rebroadcast bool`, so that the consumer may decide if a rebroadcast should be attempted.

This also logs the audited counterparty contract script since that is essential if manually redeeming the counterparty contract is required.