### PR TITLE
eth/client: Pending balance

### DIFF
--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -110,12 +110,6 @@ func (c *rpcclient) balance(ctx context.Context, addr *common.Address) (*big.Int
 	return c.ec.BalanceAt(ctx, *addr, nil)
 }
 
-// pendingBalance gets the current balance of an address, including the effects
-// of known unmined transactions.
-func (c *rpcclient) pendingBalance(ctx context.Context, addr *common.Address) (*big.Int, error) {
-	return c.ec.PendingBalanceAt(ctx, *addr)
-}
-
 // unlock uses a raw request to unlock an account indefinitely.
 func (c *rpcclient) unlock(ctx context.Context, pw string, acct *accounts.Account) error {
 	// Passing 0 as the last argument unlocks with not lock time.

--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -110,6 +110,12 @@ func (c *rpcclient) balance(ctx context.Context, addr *common.Address) (*big.Int
 	return c.ec.BalanceAt(ctx, *addr, nil)
 }
 
+// pendingBalance gets the current balance of an address, including the effects
+// of known unmined transactions.
+func (c *rpcclient) pendingBalance(ctx context.Context, addr *common.Address) (*big.Int, error) {
+	return c.ec.PendingBalanceAt(ctx, *addr)
+}
+
 // unlock uses a raw request to unlock an account indefinitely.
 func (c *rpcclient) unlock(ctx context.Context, pw string, acct *accounts.Account) error {
 	// Passing 0 as the last argument unlocks with not lock time.

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -309,6 +309,14 @@ func TestBalance(t *testing.T) {
 	spew.Dump(bal)
 }
 
+func TestPendingBalance(t *testing.T) {
+	bal, err := ethClient.pendingBalance(ctx, &simnetAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	spew.Dump(bal)
+}
+
 func TestUnlock(t *testing.T) {
 	err := ethClient.unlock(ctx, pw, simnetAcct)
 	if err != nil {

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -35,7 +35,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -48,7 +47,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -308,15 +306,6 @@ func TestBalance(t *testing.T) {
 	}
 	spew.Dump(bal)
 }
-
-func TestPendingBalance(t *testing.T) {
-	bal, err := ethClient.pendingBalance(ctx, &simnetAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	spew.Dump(bal)
-}
-
 func TestUnlock(t *testing.T) {
 	err := ethClient.unlock(ctx, pw, simnetAcct)
 	if err != nil {
@@ -425,11 +414,7 @@ func TestPeers(t *testing.T) {
 }
 
 func TestInitiateGas(t *testing.T) {
-	parsedAbi, err := abi.JSON(strings.NewReader(dexeth.ETHSwapABI))
-	if err != nil {
-		t.Fatalf("unexpected error parsing abi: %v", err)
-	}
-	err = ethClient.unlock(ctx, pw, simnetAcct)
+	err := ethClient.unlock(ctx, pw, simnetAcct)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -447,7 +432,7 @@ func TestInitiateGas(t *testing.T) {
 				Value:           big.NewInt(1),
 			})
 		}
-		data, err := parsedAbi.Pack("initiate", initiations)
+		data, err := dexeth.PackInitiateData(initiations)
 		if err != nil {
 			t.Fatalf("unexpected error packing abi: %v", err)
 		}
@@ -774,10 +759,6 @@ func TestRedeemGas(t *testing.T) {
 	}
 
 	// Test gas usage of redeem function
-	parsedAbi, err := abi.JSON(strings.NewReader(dexeth.ETHSwapABI))
-	if err != nil {
-		t.Fatalf("unexpected error parsing abi: %v", err)
-	}
 	redemptions := make([]dexeth.ETHSwapRedemption, 0, numSecrets)
 	var previous uint64
 	for i := 0; i < numSecrets; i++ {
@@ -785,7 +766,7 @@ func TestRedeemGas(t *testing.T) {
 			Secret:     secrets[i],
 			SecretHash: secretHashes[i],
 		})
-		data, err := parsedAbi.Pack("redeem", redemptions)
+		data, err := dexeth.PackRedeemData(redemptions)
 		if err != nil {
 			t.Fatalf("unexpected error packing abi: %v", err)
 		}

--- a/client/asset/eth/rpcclient_harness_test.go
+++ b/client/asset/eth/rpcclient_harness_test.go
@@ -1090,12 +1090,8 @@ func TestRefundGas(t *testing.T) {
 	if err := waitForMined(t, time.Second*8, true); err != nil {
 		t.Fatalf("unexpected error while waiting to mine: %v", err)
 	}
-	parsedAbi, err := abi.JSON(strings.NewReader(dexeth.ETHSwapABI))
-	if err != nil {
-		t.Fatalf("unexpected error parsing abi: %v", err)
-	}
 
-	data, err := parsedAbi.Pack("refund", secretHash)
+	data, err := dexeth.PackRefundData(secretHash)
 	if err != nil {
 		t.Fatalf("unexpected error packing abi: %v", err)
 	}


### PR DESCRIPTION
This PR updates the `Balance` method of the ETH client wallet by taking into account the effects of pending transactions. Pending incoming funds need to be represented by the `Immature` field in the `asset.Balance` struct, and pending outgoing funds must be subtracted from the `Available` field. When retrieving the pending balance from the eth client, the effects of incoming and outgoing funds in pending transactions are aggregated, so the pending transactions are all checked for their effects individually.

Part of #1154

 