### PR TITLE
eth: compare parsed address in OwnsAddress

### DIFF
--- a/client/asset/eth/rpcclient.go
+++ b/client/asset/eth/rpcclient.go
@@ -216,7 +216,7 @@ func (c *rpcclient) swap(ctx context.Context, from *accounts.Account, secretHash
 func (c *rpcclient) wallet(acct accounts.Account) (accounts.Wallet, error) {
 	wallet, err := c.n.AccountManager().Find(acct)
 	if err != nil {
-		return nil, fmt.Errorf("error finding wallet for account %s: %v \n", acct.Address, err)
+		return nil, fmt.Errorf("error finding wallet for account %s: %w", acct.Address, err)
 	}
 	return wallet, nil
 }


### PR DESCRIPTION
The string address can have different formattings, so parse the input string into a `common.Address` and compare that to the account address.  For example, it can be formatted with mixed case and with or without "0x", among other things.

Also use direct array comparison for address equality instead of `bytes.Equal`.

Also address some missing error checks.