### PR TITLE
client: Remove RefundAddress

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -217,15 +217,6 @@ func (bch *BCHWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadc
 	return ai, nil
 }
 
-// RefundAddress extracts and returns the refund address from a contract.
-func (bch *BCHWallet) RefundAddress(contract dex.Bytes) (string, error) {
-	addr, err := bch.ExchangeWallet.RefundAddress(contract)
-	if err != nil {
-		return "", err
-	}
-	return dexbch.RecodeCashAddress(addr, bch.Net())
-}
-
 // rawTxSigner signs the transaction using Bitcoin Cash's custom signature
 // hash and signing algorithm.
 func rawTxInSigner(btcTx *wire.MsgTx, idx int, subScript []byte, hashType txscript.SigHashType, btcKey *btcec.PrivateKey, val uint64) ([]byte, error) {

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1908,15 +1908,6 @@ func (btc *ExchangeWallet) AuditContract(coinID, contract, txData dex.Bytes, reb
 	}, nil
 }
 
-// RefundAddress extracts and returns the refund address from a contract.
-func (btc *ExchangeWallet) RefundAddress(contract dex.Bytes) (string, error) {
-	sender, _, _, _, err := dexbtc.ExtractSwapDetails(contract, btc.segwit, btc.chainParams)
-	if err != nil {
-		return "", fmt.Errorf("error extracting refund address: %w", err)
-	}
-	return sender.String(), nil
-}
-
 // LocktimeExpired returns true if the specified contract's locktime has
 // expired, making it possible to issue a Refund.
 func (btc *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1660,15 +1660,6 @@ func (dcr *ExchangeWallet) lookupTxOutput(ctx context.Context, txHash *chainhash
 	return txOut, confs, false, nil
 }
 
-// RefundAddress extracts and returns the refund address from a contract.
-func (dcr *ExchangeWallet) RefundAddress(contract dex.Bytes) (string, error) {
-	sender, _, _, _, err := dexdcr.ExtractSwapDetails(contract, dcr.chainParams)
-	if err != nil {
-		return "", fmt.Errorf("error extracting refund address: %w", err)
-	}
-	return sender.String(), nil
-}
-
 // LocktimeExpired returns true if the specified contract's locktime has
 // expired, making it possible to issue a Refund.
 func (dcr *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -858,11 +858,6 @@ func (eth *ExchangeWallet) SyncStatus() (bool, float32, error) {
 	return progress == 1, progress, nil
 }
 
-// RefundAddress extracts and returns the refund address from a contract.
-func (eth *ExchangeWallet) RefundAddress(contract dex.Bytes) (string, error) {
-	return "", asset.ErrNotImplemented
-}
-
 func (eth *ExchangeWallet) RegFeeConfirmations(ctx context.Context, coinID dex.Bytes) (confs uint32, err error) {
 	return 0, asset.ErrNotImplemented
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -221,8 +221,6 @@ type Wallet interface {
 	ValidateSecret(secret, secretHash []byte) bool
 	// SyncStatus is information about the blockchain sync status.
 	SyncStatus() (synced bool, progress float32, err error)
-	// RefundAddress extracts and returns the refund address from a contract.
-	RefundAddress(contract dex.Bytes) (string, error)
 	// RegFeeConfirmations gets the confirmations for a registration fee
 	// payment. This method need not be supported by all assets. Those assets
 	// which do no support DEX registration fees will return an ErrUnsupported.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -715,10 +715,6 @@ func (w *TXCWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadcas
 	return w.auditInfo, w.auditErr
 }
 
-func (w *TXCWallet) RefundAddress(contract dex.Bytes) (string, error) {
-	return "", nil
-}
-
 func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
 	return true, time.Now().Add(-time.Minute), nil
 }


### PR DESCRIPTION
The code calling `RefundAddress` was previously removed, but the function was never removed from the wallets.