### PR TITLE
eth: Update TxCoinID and Contract

### DIFF
--- a/dex/networks/eth/cointypes.go
+++ b/dex/networks/eth/cointypes.go
@@ -48,8 +48,8 @@ type CoinID interface {
 }
 
 const (
-	// coin type id (2) + tx id (32) + index (4) = 38
-	txCoinIDSize = 38
+	// coin type id (2) + tx id (32) = 34
+	txCoinIDSize = 34
 	// coin type id (2) + address (20) + secret has (32) = 54
 	swapCoinIDSize = 54
 	// coin type id (2) + address (20) + amount (8) + nonce (8) = 38
@@ -62,13 +62,12 @@ const (
 // function. This type of ID is useful to identify coins that
 // were sent in transactions that have not yet been mined.
 type TxCoinID struct {
-	TxID  common.Hash
-	Index uint32
+	TxID common.Hash
 }
 
 // String creates a human readable string.
 func (c *TxCoinID) String() string {
-	return fmt.Sprintf("tx: %x, index: %d", c.TxID, c.Index)
+	return fmt.Sprintf("tx: %x", c.TxID)
 }
 
 // Encode creates a byte slice that can be decoded with DecodeCoinID.
@@ -76,7 +75,6 @@ func (c *TxCoinID) Encode() []byte {
 	b := make([]byte, txCoinIDSize)
 	binary.BigEndian.PutUint16(b[:2], uint16(CIDTxID))
 	copy(b[2:], c.TxID[:])
-	binary.BigEndian.PutUint32(b[34:], c.Index)
 	return b
 }
 
@@ -98,11 +96,8 @@ func decodeTxCoinID(coinID []byte) (*TxCoinID, error) {
 	var txID [32]byte
 	copy(txID[:], coinID[2:])
 
-	index := binary.BigEndian.Uint32(coinID[34:])
-
 	return &TxCoinID{
-		TxID:  txID,
-		Index: index,
+		TxID: txID,
 	}, nil
 }
 

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -259,8 +259,8 @@ func (eth *Backend) BlockChannel(size int) <-chan *asset.BlockUpdate {
 }
 
 // Contract is part of the asset.Backend interface.
-func (eth *Backend) Contract(coinID, _ []byte) (*asset.Contract, error) {
-	sc, err := eth.newSwapCoin(coinID, sctInit)
+func (eth *Backend) Contract(coinID, contract []byte) (*asset.Contract, error) {
+	sc, err := eth.newSwapCoin(coinID, contract, sctInit)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create coiner: %w", err)
 	}
@@ -310,7 +310,7 @@ func (eth *Backend) Synced() (bool, error) {
 // should be the transaction that sent a redemption, while contractCoinID is the
 // swap contract this redemption redeems.
 func (eth *Backend) Redemption(redeemCoinID, contractCoinID []byte) (asset.Coin, error) {
-	cnr, err := eth.newSwapCoin(redeemCoinID, sctRedeem)
+	cnr, err := eth.newSwapCoin(redeemCoinID, contractCoinID, sctRedeem)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create coiner: %w", err)
 	}


### PR DESCRIPTION
TxCoinID contained an Index field which is now removed, and in many places the code assumed that a contract is a SwapCoinID when in fact it should be just a secret hash.