### PR TITLE
core,eth: handle redemption funding

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -802,9 +802,8 @@ func (eth *ExchangeWallet) ReserveN(n, feeRate uint64, assetVer uint32) (uint64,
 	}
 	if reserve > bal.Available {
 		return 0, fmt.Errorf("balance too low. %d < %d", bal.Available, reserve)
-	} else {
-		eth.redemptionReserve += reserve
 	}
+	eth.redemptionReserve += reserve
 
 	return reserve, err
 }
@@ -841,12 +840,7 @@ func (eth *ExchangeWallet) ReReserve(req uint64) error {
 // SignMessage signs the message with the private key associated with the
 // specified funding Coin. Only a coin that came from the address this wallet
 // is initialized with can be used to sign.
-func (eth *ExchangeWallet) SignMessage(coin asset.Coin, msg dex.Bytes) (pubkeys, sigs []dex.Bytes, err error) {
-	_, err = eth.decodeFundingCoinID(coin.ID())
-	if err != nil {
-		return nil, nil, fmt.Errorf("SignMessage: error decoding coin: %w", err)
-	}
-
+func (eth *ExchangeWallet) SignMessage(_ asset.Coin, msg dex.Bytes) (pubkeys, sigs []dex.Bytes, err error) {
 	sig, pubKey, err := eth.node.signData(msg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("SignMessage: error signing data: %w", err)

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 var (
@@ -186,7 +185,7 @@ type ethFetcher interface {
 	lock() error
 	locked() bool
 	unlock(pw string) error
-	signData(addr common.Address, data []byte) ([]byte, error)
+	signData(data []byte) (sig, pubKey []byte, err error)
 	sendToAddr(ctx context.Context, addr common.Address, val uint64) (*types.Transaction, error)
 	transactionConfirmations(context.Context, common.Hash) (uint32, error)
 	sendSignedTransaction(ctx context.Context, tx *types.Transaction) error
@@ -194,6 +193,7 @@ type ethFetcher interface {
 
 // Check that ExchangeWallet satisfies the asset.Wallet interface.
 var _ asset.Wallet = (*ExchangeWallet)(nil)
+var _ asset.AccountRedeemer = (*ExchangeWallet)(nil)
 
 // ExchangeWallet is a wallet backend for Ethereum. The backend is how the DEX
 // client app communicates with the Ethereum blockchain and wallet. ExchangeWallet
@@ -214,8 +214,9 @@ type ExchangeWallet struct {
 	tipMtx     sync.RWMutex
 	currentTip *types.Block
 
-	locked    uint64
-	lockedMtx sync.RWMutex
+	lockedMtx         sync.RWMutex
+	locked            uint64
+	redemptionReserve uint64
 
 	findRedemptionMtx  sync.RWMutex
 	findRedemptionReqs map[[32]byte]*findRedemptionRequest
@@ -369,7 +370,7 @@ func (eth *ExchangeWallet) balance() (*asset.Balance, error) {
 		return nil, err
 	}
 
-	locked := eth.locked + dexeth.WeiToGwei(bal.PendingOut)
+	locked := eth.locked + eth.redemptionReserve + dexeth.WeiToGwei(bal.PendingOut)
 	return &asset.Balance{
 		Available: dexeth.WeiToGwei(bal.Current) - locked,
 		Locked:    locked,
@@ -713,7 +714,7 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 
 	var contractVersion uint32 // require a consistent version since this is a single transaction
 	inputs := make([]dex.Bytes, 0, len(form.Redemptions))
-	var redeemedValue uint64
+	var redeemedValue, unlocked uint64
 	for i, redemption := range form.Redemptions {
 		// NOTE: redemption.Spends.SecretHash is a dup of the hash extracted
 		// from redemption.Spends.Contract. Even for scriptable UTXO assets, the
@@ -750,6 +751,7 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 			return nil, nil, 0, fmt.Errorf("Redeem: error finding swap state: %w", err)
 		}
 		redeemedValue += swapData.Value
+		unlocked += redemption.UnlockedReserves
 		inputs = append(inputs, redemption.Spends.Coin.ID())
 	}
 
@@ -762,6 +764,8 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 	if err != nil {
 		return fail(fmt.Errorf("Redeem: redeem error: %w", err))
 	}
+
+	eth.UnlockReserves(unlocked)
 
 	return inputs, outputCoin, fundsRequired, nil
 }
@@ -784,6 +788,56 @@ func recoverPubkey(msgHash, sig []byte) ([]byte, error) {
 	return pubKey.SerializeUncompressed(), nil
 }
 
+// ReserveN locks funds for redemption. It is an error if there is insufficient
+// spendable balance. Part of the AccountRedeemer interface.
+func (eth *ExchangeWallet) ReserveN(n, feeRate uint64, assetVer uint32) (uint64, error) {
+	redeemCost := dexeth.RedeemGas(1, assetVer) * feeRate
+	reserve := redeemCost * n
+
+	eth.lockedMtx.Lock()
+	defer eth.lockedMtx.Unlock()
+	bal, err := eth.balance()
+	if err != nil {
+		return 0, fmt.Errorf("error retreiving balance: %w", err)
+	}
+	if reserve > bal.Available {
+		return 0, fmt.Errorf("balance too low. %d < %d", bal.Available, reserve)
+	} else {
+		eth.redemptionReserve += reserve
+	}
+
+	return reserve, err
+}
+
+// UnlockReserves unlocks the specified amount from redemption reserves. Part
+// of the AccountRedeemer interface.
+func (eth *ExchangeWallet) UnlockReserves(reserves uint64) {
+	eth.lockedMtx.Lock()
+	if reserves > eth.redemptionReserve {
+		eth.redemptionReserve = 0
+		eth.log.Errorf("attempting to unlock more than reserved. %d > %d", reserves, eth.redemptionReserve)
+	} else {
+		eth.redemptionReserve -= reserves
+	}
+	eth.lockedMtx.Unlock()
+}
+
+// ReReserve checks out an amount for redemptions. Use ReReserve after
+// initializing a new ExchangeWallet.
+func (eth *ExchangeWallet) ReReserve(req uint64) error {
+	eth.lockedMtx.Lock()
+	defer eth.lockedMtx.Unlock()
+	bal, err := eth.balance()
+	if err != nil {
+		return err
+	}
+	if eth.redemptionReserve+req > bal.Available {
+		return fmt.Errorf("not enough funds. %d < %d", eth.redemptionReserve+req, bal.Available)
+	}
+	eth.redemptionReserve += req
+	return nil
+}
+
 // SignMessage signs the message with the private key associated with the
 // specified funding Coin. Only a coin that came from the address this wallet
 // is initialized with can be used to sign.
@@ -793,14 +847,9 @@ func (eth *ExchangeWallet) SignMessage(coin asset.Coin, msg dex.Bytes) (pubkeys,
 		return nil, nil, fmt.Errorf("SignMessage: error decoding coin: %w", err)
 	}
 
-	sig, err := eth.node.signData(eth.addr, msg)
+	sig, pubKey, err := eth.node.signData(msg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("SignMessage: error signing data: %w", err)
-	}
-
-	pubKey, err := recoverPubkey(crypto.Keccak256(msg), sig)
-	if err != nil {
-		return nil, nil, fmt.Errorf("SignMessage: error recovering pubkey %w", err)
 	}
 
 	return []dex.Bytes{pubKey}, []dex.Bytes{sig}, nil

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1922,43 +1922,16 @@ func TestSignMessage(t *testing.T) {
 
 	msg := []byte("msg")
 
-	// Error due to coin with unparsable ID
-	var badCoin badCoin
-	_, _, err := eth.SignMessage(&badCoin, msg)
-	if err == nil {
-		t.Fatalf("expected error for signing message with bad coin")
-	}
-
-	// Error due to coin from with account than wallet
-	differentAddress := common.HexToAddress("8d83B207674bfd53B418a6E47DA148F5bFeCc652")
-	coinDifferentAddress := coin{
-		id: (&fundingCoinID{
-			Address: differentAddress,
-			Amount:  100,
-		}).Encode(),
-	}
-	_, _, err = eth.SignMessage(&coinDifferentAddress, msg)
-	if err == nil {
-		t.Fatalf("expected error for signing message with different address than wallet")
-	}
-
-	coin := coin{
-		id: (&fundingCoinID{
-			Address: account.Address,
-			Amount:  100,
-		}).Encode(),
-	}
-
 	// SignData error
 	node.signDataErr = errors.New("")
-	_, _, err = eth.SignMessage(&coin, msg)
+	_, _, err := eth.SignMessage(nil, msg)
 	if err == nil {
 		t.Fatalf("expected error due to error in rpcclient signData")
 	}
 	node.signDataErr = nil
 
 	// Test no error
-	pubKeys, sigs, err := eth.SignMessage(&coin, msg)
+	pubKeys, sigs, err := eth.SignMessage(nil, msg)
 	if err != nil {
 		t.Fatalf("unexpected error signing message: %v", err)
 	}

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -455,7 +455,7 @@ func testSendSignedTransaction(t *testing.T) {
 		Value:     dexeth.GweiToWei(1),
 		Data:      []byte{},
 	})
-	tx, err = ethClient.signTransaction(simnetAddr, tx)
+	tx, err = ethClient.signTransaction(tx)
 
 	err = ethClient.sendSignedTransaction(ctx, tx)
 	if err != nil {
@@ -2175,13 +2175,9 @@ func testSignMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error unlocking account: %v", err)
 	}
-	signature, err := ethClient.signData(simnetAddr, msg)
+	sig, pubKey, err := ethClient.signData(msg)
 	if err != nil {
 		t.Fatalf("error signing text: %v", err)
-	}
-	pubKey, err := recoverPubkey(crypto.Keccak256(msg), signature)
-	if err != nil {
-		t.Fatalf("recoverPubkey: %v", err)
 	}
 	x, y := elliptic.Unmarshal(secp256k1.S256(), pubKey)
 	recoveredAddress := crypto.PubkeyToAddress(ecdsa.PublicKey{
@@ -2192,7 +2188,7 @@ func testSignMessage(t *testing.T) {
 	if !bytes.Equal(recoveredAddress.Bytes(), simnetAcct.Address.Bytes()) {
 		t.Fatalf("recovered address: %v != simnet account address: %v", recoveredAddress, simnetAcct.Address)
 	}
-	if !crypto.VerifySignature(pubKey, crypto.Keccak256(msg), signature[:len(signature)-1]) {
+	if !crypto.VerifySignature(pubKey, crypto.Keccak256(msg), sig) {
 		t.Fatalf("failed to verify signature")
 	}
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -244,6 +244,8 @@ type TokenMaster interface {
 	OpenTokenWallet(assetID uint32, settings map[string]string, tipChange func(error)) (Wallet, error)
 }
 
+// AccountRedeemer is a wallet in which redemptions require a wallet to have
+// available balance to pay fees.
 type AccountRedeemer interface {
 	// ReserveN is used when preparing funding for an order that redeems to an
 	// account-based asset. The wallet will set aside the appropriate amount of

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -244,6 +244,20 @@ type TokenMaster interface {
 	OpenTokenWallet(assetID uint32, settings map[string]string, tipChange func(error)) (Wallet, error)
 }
 
+type AccountRedeemer interface {
+	// ReserveN is used when preparing funding for an order that redeems to an
+	// account-based asset. The wallet will set aside the appropriate amount of
+	// funds so that we can redeem. It is an error to request funds > spendable
+	// balance.
+	ReserveN(n, feeRate uint64, assetVer uint32) (uint64, error)
+	// ReReserve is used when reconstructing existing orders on startup. It is
+	// an error to request funds > spendable balance.
+	ReReserve(amt uint64) error
+	// UnlockReserves is used to return funds when an order is canceled or
+	// otherwise completed unfilled.
+	UnlockReserves(uint64)
+}
+
 // Balance is categorized information about a wallet's balance.
 type Balance struct {
 	// Available is the balance that is available for trading immediately.
@@ -349,6 +363,9 @@ type Redemption struct {
 	Spends *AuditInfo
 	// Secret is the secret key needed to satisfy the swap contract.
 	Secret dex.Bytes
+	// UnlockedReserves is the amount reserved for redemption for account-based
+	// assets.
+	UnlockedReserves uint64
 }
 
 // RedeemForm is a group of Redemptions. The struct will be

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4047,7 +4047,7 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 		}
 		redemptionReserves, err = accountRedeemer.ReserveN(redemptionLots, wallets.toAsset.MaxFeeRate, wallets.toAsset.Version)
 		if err != nil {
-			return nil, 0, codedError(walletErr, fmt.Errorf("ReserveRedemption error: %w", err))
+			return nil, 0, codedError(walletErr, fmt.Errorf("ReserveN error: %w", err))
 		}
 		msgTrade.RedeemSig = &msgjson.RedeemSig{
 			PubKey: pubKeys[0],
@@ -5063,8 +5063,7 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 			}
 		}
 
-		preCancelFilled, canceled := tracker.recalcFilled()
-		tracker.Trade().SetFill(preCancelFilled + canceled)
+		tracker.recalcFilled()
 
 		if isActive {
 			tracker.lockRedemptionFraction(trade.Remaining(), trade.Quantity)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -53,6 +53,8 @@ const (
 	// defaultTickInterval is the tick interval used before the broadcast
 	// timeout is known (e.g. startup with down server).
 	defaultTickInterval = 30 * time.Second
+
+	marketBuyRedemptionSlippageBuffer = 2
 )
 
 var (
@@ -440,7 +442,7 @@ func (c *Core) tryCancelTrade(dc *dexConnection, tracker *trackedTrade) error {
 	c.sentCommitsMtx.Unlock()
 
 	// Create and send the order message. Check the response before using it.
-	route, msgOrder := messageOrder(co, nil)
+	route, msgOrder, _ := messageOrder(co, nil)
 	var result = new(msgjson.OrderResult)
 	err = dc.signAndRequest(msgOrder, route, result, DefaultResponseTimeout)
 	if err != nil {
@@ -771,6 +773,7 @@ func (dc *dexConnection) reconcileTrades(srvOrderStatuses []*msgjson.OrderStatus
 		if trade.metaData.Status == order.OrderStatusEpoch || trade.metaData.Status == order.OrderStatusBooked {
 			knownActiveTrades[oid] = trade
 		} else if srvOrderStatus := srvActiveOrderStatuses[oid]; srvOrderStatus != nil {
+			// Lock redemption funds?
 			dc.log.Warnf("Inactive order %v, status %q reported by DEX %s as active, status %q",
 				oid, trade.metaData.Status, dc.acct.host, order.OrderStatus(srvOrderStatus.Status))
 		}
@@ -797,6 +800,16 @@ func (dc *dexConnection) reconcileTrades(srvOrderStatuses []*msgjson.OrderStatus
 			err := trade.db.UpdateOrderStatus(cid, order.OrderStatusExecuted)
 			if err != nil {
 				dc.log.Errorf("Failed to update status of executed cancel order %v: %v", cid, err)
+			}
+		}
+		// If we're updating an order from an active state to executed,
+		// canceled, or revoked, return the remaining quantity.
+		if newStatus >= order.OrderStatusExecuted && trade.Trade().Remaining() > 0 &&
+			(!trade.isMarketBuy() || len(trade.matches) == 0) {
+			if trade.isMarketBuy() {
+				trade.unlockRedemptionFraction(1, 1)
+			} else {
+				trade.unlockRedemptionFraction(trade.Trade().Remaining(), trade.Trade().Quantity)
 			}
 		}
 		// Now update the trade.
@@ -3852,6 +3865,8 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	}
 	fromWallet, toWallet := wallets.fromWallet, wallets.toWallet
 
+	accountRedeemer, isAccountRedemption := toWallet.Wallet.(asset.AccountRedeemer)
+
 	prepareWallet := func(w *xcWallet) error {
 		// NOTE: If the wallet is already internally unlocked (the decrypted
 		// password cached in xcWallet.pw), this could be done without the
@@ -3893,6 +3908,7 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	if form.IsLimit && !form.Sell {
 		fundQty = calc.BaseToQuote(rate, fundQty)
 	}
+	redemptionLots := lots
 
 	isImmediate := (!form.IsLimit || form.TifNow)
 
@@ -3915,6 +3931,7 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 			if err == nil {
 				baseQty := calc.QuoteToBase(midGap, fundQty)
 				lots = baseQty / lotSize
+				redemptionLots = lots * marketBuyRedemptionSlippageBuffer
 				if lots == 0 {
 					err = newError(orderParamsErr,
 						"order quantity is too low for current market rates. "+
@@ -3923,6 +3940,8 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 						wallets.baseAsset.Symbol, lotSize)
 					return nil, 0, err
 				}
+			} else if isAccountRedemption {
+				return nil, 0, newError(orderParamsErr, "cannot estimate redemption count")
 			}
 		}
 	}
@@ -3944,6 +3963,7 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 		return nil, 0, codedError(walletErr, fmt.Errorf("FundOrder error for %s, funding quantity %d (%d lots): %w",
 			wallets.fromAsset.Symbol, fundQty, lots, err))
 	}
+
 	coinIDs := make([]order.CoinID, 0, len(coins))
 	for i := range coins {
 		coinIDs = append(coinIDs, []byte(coins[i].ID()))
@@ -3951,12 +3971,16 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 
 	// The coins selected for this order will need to be unlocked
 	// if the order does not get to the server successfully.
-	unlockCoins := func() {
+	var success bool
+	defer func() {
+		if success {
+			return
+		}
 		err := fromWallet.ReturnCoins(coins)
 		if err != nil {
 			c.log.Warnf("Unable to return %s funding coins: %v", unbip(fromWallet.AssetID), err)
 		}
-	}
+	}()
 
 	// Construct the order.
 	preImg := newPreimage()
@@ -3999,14 +4023,41 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	}
 	err = order.ValidateOrder(ord, order.OrderStatusEpoch, lotSize)
 	if err != nil {
-		unlockCoins()
 		return nil, 0, fmt.Errorf("ValidateOrder error: %w", err)
 	}
 
 	msgCoins, err := messageCoins(wallets.fromWallet, coins, redeemScripts)
 	if err != nil {
-		unlockCoins()
 		return nil, 0, fmt.Errorf("wallet %v failed to sign coins: %w", wallets.fromAsset.ID, err)
+	}
+
+	// Everything is ready. Send the order.
+	route, msgOrder, msgTrade := messageOrder(ord, msgCoins)
+
+	// If the to asset is an AccountRedeemer, we need to lock up redemption
+	// funds.
+	var redemptionReserves uint64
+	if isAccountRedemption {
+		pubKeys, sigs, err := toWallet.SignMessage(nil, msgOrder.Serialize())
+		if err != nil {
+			return nil, 0, codedError(signatureErr, fmt.Errorf("SignMessage error: %w", err))
+		}
+		if len(pubKeys) == 0 || len(sigs) == 0 {
+			return nil, 0, newError(signatureErr, "wrong number of pubkeys or signatures, %d & %d", len(pubKeys), len(sigs))
+		}
+		redemptionReserves, err = accountRedeemer.ReserveN(redemptionLots, wallets.toAsset.MaxFeeRate, wallets.toAsset.Version)
+		if err != nil {
+			return nil, 0, codedError(walletErr, fmt.Errorf("ReserveRedemption error: %w", err))
+		}
+		msgTrade.RedeemSig = &msgjson.RedeemSig{
+			PubKey: pubKeys[0],
+			Sig:    sigs[0],
+		}
+		defer func() {
+			if !success {
+				accountRedeemer.UnlockReserves(redemptionReserves)
+			}
+		}()
 	}
 
 	commitSig := make(chan struct{})
@@ -4015,14 +4066,10 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	c.sentCommits[prefix.Commit] = commitSig
 	c.sentCommitsMtx.Unlock()
 
-	// Everything is ready. Send the order.
-	route, msgOrder := messageOrder(ord, msgCoins)
-
 	// Send and get the result.
 	result := new(msgjson.OrderResult)
 	err = dc.signAndRequest(msgOrder, route, result, fundingTxWait+DefaultResponseTimeout)
 	if err != nil {
-		unlockCoins()
 		// At this point there is a possibility that the server got the request
 		// and created the trade order, but we lost the connection before
 		// receiving the response with the trade's order ID. Any preimage
@@ -4038,7 +4085,6 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 
 	err = validateOrderResponse(dc, result, ord, msgOrder) // stamps the order, giving it a valid ID
 	if err != nil {
-		unlockCoins()
 		logAbandon(fmt.Sprintf("order response validation failure: %v", err))
 		return nil, 0, fmt.Errorf("validateOrderResponse error: %w", err)
 	}
@@ -4053,22 +4099,22 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 				DEXSig:   result.Sig,
 				Preimage: preImg[:],
 			},
-			FromVersion: wallets.fromAsset.Version,
-			ToVersion:   wallets.toAsset.Version,
-			Options:     form.Options,
+			FromVersion:        wallets.fromAsset.Version,
+			ToVersion:          wallets.toAsset.Version,
+			Options:            form.Options,
+			RedemptionReserves: redemptionReserves,
 		},
 		Order: ord,
 	}
 	err = c.db.UpdateOrder(dbOrder)
 	if err != nil {
-		unlockCoins()
 		logAbandon(fmt.Sprintf("failed to store order in database: %v", err))
 		return nil, 0, fmt.Errorf("Order abandoned due to database error: %w", err)
 	}
 
 	// Prepare and store the tracker and get the core.Order to return.
 	tracker := newTrackedTrade(dbOrder, preImg, dc, dc.marketEpochDuration(mktID), c.lockTimeTaker, c.lockTimeMaker,
-		c.db, c.latencyQ, wallets, coins, c.notify, c.formatDetails, form.Options)
+		c.db, c.latencyQ, wallets, coins, c.notify, c.formatDetails, form.Options, redemptionReserves)
 
 	dc.tradeMtx.Lock()
 	dc.trades[tracker.ID()] = tracker
@@ -4094,6 +4140,8 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 			sellString(corder.Sell), ui.ConventionalString(corder.Qty), ui.Conventional.Unit, rateString, tracker.token())
 		c.notify(newOrderNote(TopicOrderPlaced, subject, details, db.Poke, corder))
 	}
+
+	success = true
 
 	return corder, wallets.fromWallet.AssetID, nil
 }
@@ -4672,7 +4720,8 @@ func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, e
 		var preImg order.Preimage
 		copy(preImg[:], dbOrder.MetaData.Proof.Preimage)
 		tracker := newTrackedTrade(dbOrder, preImg, dc, dc.marketEpochDuration(mktID), c.lockTimeTaker,
-			c.lockTimeMaker, c.db, c.latencyQ, nil, nil, c.notify, c.formatDetails, dbOrder.MetaData.Options)
+			c.lockTimeMaker, c.db, c.latencyQ, nil, nil, c.notify, c.formatDetails,
+			dbOrder.MetaData.Options, dbOrder.MetaData.RedemptionReserves)
 		trackers[dbOrder.Order.ID()] = tracker
 
 		// Get matches.
@@ -4680,11 +4729,17 @@ func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, e
 		if err != nil {
 			return nil, fmt.Errorf("error loading matches for order %s: %w", oid, err)
 		}
+		var makerCancel *msgjson.Match
 		for _, dbMatch := range dbMatches {
 			// Only trade matches are added to the matches map. Detect and skip
 			// cancel order matches, which have an empty Address field.
 			if dbMatch.Address == "" { // only correct for maker's cancel match
 				// tracker.cancel is set from LinkedOrder with cancelTrade.
+				makerCancel = &msgjson.Match{
+					OrderID:  oid[:],
+					MatchID:  dbMatch.MatchID[:],
+					Quantity: dbMatch.Quantity,
+				}
 				continue
 			}
 			// Make sure that a taker will not prematurely send an
@@ -4721,6 +4776,7 @@ func (c *Core) dbTrackers(dc *dexConnection) (map[order.OrderID]*trackedTrade, e
 		var pimg order.Preimage
 		copy(pimg[:], metaCancel.MetaData.Proof.Preimage)
 		err = tracker.cancelTrade(co, pimg) // set tracker.cancel and link
+		tracker.cancel.matches.maker = makerCancel
 		if err != nil {
 			c.log.Errorf("Error setting cancel order info %s: %v", co.ID(), err)
 		}
@@ -4866,6 +4922,14 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 
 		tracker.wallets = wallets
 
+		lockMatchRedemption := func(match *matchTracker) {
+			if tracker.isMarketBuy() {
+				tracker.lockRedemptionFraction(1, uint64(len(tracker.matches)))
+			} else {
+				tracker.lockRedemptionFraction(match.Quantity, trade.Quantity)
+			}
+		}
+
 		// If matches haven't redeemed, but the counter-swap has been received,
 		// reload the audit info.
 		isActive := tracker.metaData.Status == order.OrderStatusBooked || tracker.metaData.Status == order.OrderStatusEpoch
@@ -4881,6 +4945,9 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 					needsAuditInfo = true // maker needs AuditInfo for takers contract
 					counterSwap = match.MetaData.Proof.TakerSwap
 				}
+				if match.Status < order.MakerRedeemed {
+					lockMatchRedemption(match)
+				}
 			} else { // Taker
 				if match.Status < order.TakerSwapCast {
 					matchesNeedingCoins = append(matchesNeedingCoins, match)
@@ -4888,6 +4955,9 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 				if match.Status < order.MatchComplete && match.Status >= order.MakerSwapCast {
 					needsAuditInfo = true // taker needs AuditInfo for maker's contract
 					counterSwap = match.MetaData.Proof.MakerSwap
+				}
+				if match.Status < order.MatchComplete {
+					lockMatchRedemption(match)
 				}
 			}
 			c.log.Tracef("Trade %v match %v needs coins = %v, needs audit info = %v",
@@ -4991,6 +5061,13 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 					tracker.coins = mapifyCoins(coins)
 				}
 			}
+		}
+
+		preCancelFilled, canceled := tracker.recalcFilled()
+		tracker.Trade().SetFill(preCancelFilled + canceled)
+
+		if isActive {
+			tracker.lockRedemptionFraction(trade.Remaining(), trade.Quantity)
 		}
 
 		// Balances should be updated for any orders with locked wallet coins,
@@ -5439,7 +5516,7 @@ func handleRevokeMatchMsg(c *Core, dc *dexConnection, msg *msgjson.Message) erro
 	copy(matchID[:], revocation.MatchID)
 
 	tracker.mtx.Lock()
-	err = tracker.revokeMatch(matchID, true)
+	err = tracker.revokeMatch(c.ctx, matchID, true)
 	tracker.mtx.Unlock()
 	if err != nil {
 		return fmt.Errorf("unable to revoke match %s for order %s: %w", matchID, tracker.ID(), err)
@@ -5584,7 +5661,16 @@ func (c *Core) listen(dc *dexConnection) {
 
 		if len(doneTrades) > 0 {
 			dc.tradeMtx.Lock()
+
 			for _, trade := range doneTrades {
+				// Log an error if redemption funds are still reserved.
+				trade.mtx.RLock()
+				reserved := trade.redemptionLocked
+				trade.mtx.RUnlock()
+				if reserved > 0 {
+					dc.log.Errorf("retiring order %s with %d > 0 redemption funds reserved", trade.ID(), reserved)
+				}
+
 				c.notify(newOrderNote(TopicOrderRetired, "", "", db.Data, trade.coreOrder()))
 				delete(dc.trades, trade.ID())
 			}
@@ -6238,7 +6324,7 @@ func messageCoins(wallet *xcWallet, coins asset.Coins, redeemScripts []dex.Bytes
 
 // messageOrder converts an order.Order of any underlying type to an appropriate
 // msgjson type used for submitting the order.
-func messageOrder(ord order.Order, coins []*msgjson.Coin) (string, msgjson.Stampable) {
+func messageOrder(ord order.Order, coins []*msgjson.Coin) (string, msgjson.Stampable, *msgjson.Trade) {
 	prefix, trade := ord.Prefix(), ord.Trade()
 	switch o := ord.(type) {
 	case *order.LimitOrder:
@@ -6246,22 +6332,24 @@ func messageOrder(ord order.Order, coins []*msgjson.Coin) (string, msgjson.Stamp
 		if o.Force == order.ImmediateTiF {
 			tifFlag = msgjson.ImmediateOrderNum
 		}
-		return msgjson.LimitRoute, &msgjson.LimitOrder{
+		msgOrd := &msgjson.LimitOrder{
 			Prefix: *messagePrefix(prefix),
 			Trade:  *messageTrade(trade, coins),
 			Rate:   o.Rate,
 			TiF:    tifFlag,
 		}
+		return msgjson.LimitRoute, msgOrd, &msgOrd.Trade
 	case *order.MarketOrder:
-		return msgjson.MarketRoute, &msgjson.MarketOrder{
+		msgOrd := &msgjson.MarketOrder{
 			Prefix: *messagePrefix(prefix),
 			Trade:  *messageTrade(trade, coins),
 		}
+		return msgjson.MarketRoute, msgOrd, &msgOrd.Trade
 	case *order.CancelOrder:
 		return msgjson.CancelRoute, &msgjson.CancelOrder{
 			Prefix:   *messagePrefix(prefix),
 			TargetID: o.TargetOrderID[:],
-		}
+		}, nil
 	default:
 		panic("unknown order type")
 	}

--- a/client/core/status.go
+++ b/client/core/status.go
@@ -71,7 +71,7 @@ func (c *Core) resolveMatchConflicts(dc *dexConnection, statusConflicts map[orde
 					statusResolutionID(dc, trade, match))
 				// revokeMatch only returns an error for a missing match ID, and
 				// we already checked in compareServerMatches.
-				_ = trade.revokeMatch(match.MatchID, false)
+				_ = trade.revokeMatch(c.ctx, match.MatchID, false)
 			}
 		}(conflict.trade, conflict.matches)
 	}

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -228,7 +228,7 @@ func (t *trackedTrade) lockRedemptionFraction(num, denom uint64) {
 	t.redemptionLocked += newReserved
 }
 
-// unlockRedemptionFraction unlocks the specified fractiOn of the redemption
+// unlockRedemptionFraction unlocks the specified fraction of the redemption
 // reserves. t.mtx should be locked if this trackedTrade is in the dc.trades
 // map. If the requested unlock would put the locked reserves < 0, an error
 // message is logged and the remaining locked reserves will be unlocked instead.

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -95,6 +95,7 @@ var (
 	fromVersionKey         = []byte("fromVersion")
 	toVersionKey           = []byte("toVersion")
 	optionsKey             = []byte("options")
+	reservesKey            = []byte("reservesKey")
 	byteTrue               = encode.ByteTrue
 	backupDir              = "backup"
 )
@@ -867,6 +868,12 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 		return nil, fmt.Errorf("error decoding order proof for %x: %w", oid, err)
 	}
 
+	var redemptionReserves uint64
+	reservesB := oBkt.Get(reservesKey)
+	if len(reservesB) == 8 {
+		redemptionReserves = intCoder.Uint64(reservesB)
+	}
+
 	var linkedID order.OrderID
 	copy(linkedID[:], oBkt.Get(linkedKey))
 
@@ -908,6 +915,7 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 			FromVersion:        fromVersion,
 			ToVersion:          toVersion,
 			Options:            options,
+			RedemptionReserves: redemptionReserves,
 		},
 		Order: ord,
 	}, nil
@@ -982,6 +990,7 @@ func (db *BoltDB) UpdateOrderMetaData(oid order.OrderID, md *db.OrderMetaData) e
 			put(fromVersionKey, uint32Bytes(md.FromVersion)).
 			put(toVersionKey, uint32Bytes(md.ToVersion)).
 			put(optionsKey, config.Data(md.Options)).
+			put(reservesKey, uint64Bytes(md.RedemptionReserves)).
 			err()
 	})
 }

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -265,6 +265,8 @@ type OrderMetaData struct {
 	ToVersion uint32
 	// Options are the options offered by the wallet and selected by the user.
 	Options map[string]string
+	// RedemptionReserve is the reserved redemption funds.
+	RedemptionReserves uint64
 }
 
 // MetaMatch is a match and its metadata.


### PR DESCRIPTION
```   
    client/asset:
    Add AccounterRedeemer interface with methods for locking and unlocking
    funds for redemption. ReserveN is used to reserve funds for an order.
    Only the amount reserved is returned. All accounting from there is
    handled by Core, who will return funds proportionally according to
    match quantities and order size. The amount reserved is persisted in
    the OrderMetaData so that accounting can be picked up exactly as it was on restarts.
    This pattern was chosen over trying to figure out how much to lock
    on restart with calculations based on order info because you would need
    to consider changes in asset configuration and therefore persist more
    data and ... it gets messy.
    
    client/core:
    Add RedeemSig to orders redeeming to and AccountRedeemer.
    Track and return reserved redemption funds. Return funds manually
    for refunds and revocations. Handle dust that can arise from rounding
    error. Log inconsistencies.
    
    client/asset/eth:
    Implement asset.AccountRedeemer. Track redemption reserves separately
    than swap reserves, but add them when calculating locked balance.
```