### PR TITLE
client/asset/eth: SwapConfirmations

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2361,7 +2361,9 @@ func (btc *ExchangeWallet) send(address string, val uint64, feeRate uint64, subt
 // SwapConfirmations gets the number of confirmations for the specified swap
 // by first checking for a unspent output, and if not found, searching indexed
 // wallet transactions.
-func (btc *ExchangeWallet) SwapConfirmations(_ context.Context, id dex.Bytes, contract dex.Bytes, startTime time.Time) (uint32, bool, error) {
+func (btc *ExchangeWallet) SwapConfirmations(_ context.Context, id dex.Bytes, contract dex.Bytes,
+	startTime time.Time, _ uint32) (uint32, bool, error) {
+
 	txHash, vout, err := decodeCoinID(id)
 	if err != nil {
 		return 0, false, err

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -2408,7 +2408,7 @@ func testConfirmations(t *testing.T, segwit bool, walletType string) {
 	matchTime := swapBlock.Header.Timestamp
 
 	// Bad coin id
-	_, _, err = wallet.SwapConfirmations(context.Background(), randBytes(35), contract, matchTime)
+	_, _, err = wallet.SwapConfirmations(context.Background(), randBytes(35), contract, matchTime, 0)
 	if err == nil {
 		t.Fatalf("no error for bad coin ID")
 	}
@@ -2420,7 +2420,7 @@ func testConfirmations(t *testing.T, segwit bool, walletType string) {
 	}
 	node.txOutRes = txOutRes
 	node.getCFilterScripts[*blockHash] = [][]byte{pkScript}
-	confs, _, err := wallet.SwapConfirmations(context.Background(), coinID, contract, matchTime)
+	confs, _, err := wallet.SwapConfirmations(context.Background(), coinID, contract, matchTime, 0)
 	if err != nil {
 		t.Fatalf("error for gettransaction path: %v", err)
 	}
@@ -2432,7 +2432,7 @@ func testConfirmations(t *testing.T, segwit bool, walletType string) {
 	node.txOutRes = nil
 	node.getCFilterScripts[*blockHash] = nil
 	node.getTransactionErr = tErr
-	_, _, err = wallet.SwapConfirmations(context.Background(), coinID, contract, matchTime)
+	_, _, err = wallet.SwapConfirmations(context.Background(), coinID, contract, matchTime, 0)
 	if err == nil {
 		t.Fatalf("no error for gettransaction error")
 	}
@@ -2446,7 +2446,7 @@ func testConfirmations(t *testing.T, segwit bool, walletType string) {
 
 	node.getCFilterScripts[*spendingBlockHash] = [][]byte{pkScript}
 	node.walletTxSpent = true
-	_, spent, err := wallet.SwapConfirmations(context.Background(), coinID, contract, matchTime)
+	_, spent, err := wallet.SwapConfirmations(context.Background(), coinID, contract, matchTime, 0)
 	if err != nil {
 		t.Fatalf("error for spent swap: %v", err)
 	}

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -306,7 +306,7 @@ func Run(t *testing.T, cfg *Config) {
 	confContract := receipts[0].Contract()
 	checkConfs := func(n uint32, expSpent bool) {
 		t.Helper()
-		confs, spent, err := rig.gamma().SwapConfirmations(context.Background(), confCoin.ID(), confContract, tStart)
+		confs, spent, err := rig.gamma().SwapConfirmations(context.Background(), confCoin.ID(), confContract, tStart, 0)
 		if err != nil {
 			if n > 0 || !errors.Is(err, asset.CoinNotFoundError) {
 				t.Fatalf("error getting %d confs: %v", n, err)
@@ -337,7 +337,7 @@ func Run(t *testing.T, cfg *Config) {
 		if auditCoin.Value() != swapVal {
 			t.Fatalf("wrong contract value. wanted %d, got %d", swapVal, auditCoin.Value())
 		}
-		confs, spent, err := rig.alpha().SwapConfirmations(context.TODO(), receipt.Coin().ID(), receipt.Contract(), tStart)
+		confs, spent, err := rig.alpha().SwapConfirmations(context.TODO(), receipt.Coin().ID(), receipt.Contract(), tStart, 0)
 		if err != nil {
 			t.Fatalf("error getting confirmations: %v", err)
 		}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2281,7 +2281,9 @@ func (dcr *ExchangeWallet) ValidateSecret(secret, secretHash []byte) bool {
 // method may return asset.CoinNotFoundError. Compare dcr.externalTxOut.
 //
 // If the coin is located, but recognized as spent, no error is returned.
-func (dcr *ExchangeWallet) SwapConfirmations(ctx context.Context, coinID, contract dex.Bytes, matchTime time.Time) (confs uint32, spent bool, err error) {
+func (dcr *ExchangeWallet) SwapConfirmations(ctx context.Context, coinID, contract dex.Bytes,
+	matchTime time.Time, _ uint32) (confs uint32, spent bool, err error) {
+
 	txHash, vout, err := decodeCoinID(coinID)
 	if err != nil {
 		return 0, false, err

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -272,7 +272,7 @@ func runTest(t *testing.T, splitTx bool) {
 	confContract := receipts[0].Contract()
 	checkConfs := func(n uint32, expSpent bool) {
 		t.Helper()
-		confs, spent, err := rig.beta().SwapConfirmations(tCtx, confCoin.ID(), confContract, tStart)
+		confs, spent, err := rig.beta().SwapConfirmations(tCtx, confCoin.ID(), confContract, tStart, 0)
 		if err != nil {
 			t.Fatalf("error getting %d confs: %v", n, err)
 		}
@@ -309,7 +309,7 @@ func runTest(t *testing.T, splitTx bool) {
 		if swapOutput.Value() != swapVal {
 			t.Fatalf("wrong contract value. wanted %d, got %d", swapVal, swapOutput.Value())
 		}
-		confs, spent, err := rig.alpha().SwapConfirmations(context.TODO(), swapOutput.ID(), receipt.Contract(), tStart)
+		confs, spent, err := rig.alpha().SwapConfirmations(context.TODO(), swapOutput.ID(), receipt.Contract(), tStart, 0)
 		if err != nil {
 			t.Fatalf("error getting confirmations: %v", err)
 		}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -213,7 +213,8 @@ type Wallet interface {
 	// be accurate.
 	// The contract and matchTime are provided so that wallets may search for
 	// the coin using light filters.
-	SwapConfirmations(ctx context.Context, coinID dex.Bytes, contract dex.Bytes, matchTime time.Time) (confs uint32, spent bool, err error)
+	SwapConfirmations(ctx context.Context, coinID dex.Bytes, contract dex.Bytes,
+		matchTime time.Time, assetVersion uint32) (confs uint32, spent bool, err error)
 	// Withdraw withdraws funds to the specified address. Fees are subtracted
 	// from the value.
 	Withdraw(address string, value, feeSuggestion uint64) (Coin, error)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -784,7 +784,7 @@ func (w *TXCWallet) tConfirmations(ctx context.Context, coinID dex.Bytes) (uint3
 	return w.confs[id], w.confsErr[id]
 }
 
-func (w *TXCWallet) SwapConfirmations(ctx context.Context, coinID dex.Bytes, contract dex.Bytes, matchTime time.Time) (uint32, bool, error) {
+func (w *TXCWallet) SwapConfirmations(ctx context.Context, coinID dex.Bytes, contract dex.Bytes, matchTime time.Time, _ uint32) (uint32, bool, error) {
 	confs, err := w.tConfirmations(ctx, coinID)
 	return confs, false, err
 }

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -670,7 +670,7 @@ func (t *trackedTrade) counterPartyConfirms(ctx context.Context, match *matchTra
 
 	var err error
 	have, spent, err = t.wallets.toWallet.SwapConfirmations(ctx, coin.ID(),
-		match.MetaData.Proof.CounterContract, match.MetaData.Stamp)
+		match.MetaData.Proof.CounterContract, match.MetaData.Stamp, t.metaData.FromVersion)
 	if err != nil {
 		t.dc.log.Errorf("Failed to get confirmations of the counter-party's swap %s (%s) for match %s, order %v: %v",
 			coin, t.wallets.toAsset.Symbol, match, t.UID(), err)
@@ -885,7 +885,7 @@ func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) boo
 		t.dc.log.Tracef("Checking confirmations on our OWN swap txn %v (%s)...",
 			coinIDString(wallet.AssetID, match.MetaData.Proof.MakerSwap), unbip(wallet.AssetID))
 		confs, spent, err := wallet.SwapConfirmations(ctx, match.MetaData.Proof.MakerSwap,
-			match.MetaData.Proof.Script, match.MetaData.Stamp)
+			match.MetaData.Proof.Script, match.MetaData.Stamp, t.metaData.FromVersion)
 		if err != nil {
 			t.dc.log.Errorf("error getting confirmation for our own swap transaction: %v", err)
 		}
@@ -943,7 +943,7 @@ func (t *trackedTrade) isRedeemable(ctx context.Context, match *matchTracker) bo
 		}
 		// If we're the taker, check the confirmations anyway so we can notify.
 		confs, spent, err := t.wallets.fromWallet.SwapConfirmations(ctx, match.MetaData.Proof.TakerSwap,
-			match.MetaData.Proof.Script, match.MetaData.Stamp)
+			match.MetaData.Proof.Script, match.MetaData.Stamp, t.metaData.FromVersion)
 		if err != nil {
 			t.dc.log.Errorf("error getting confirmation for our own swap transaction: %v", err)
 		}
@@ -1064,7 +1064,7 @@ func (t *trackedTrade) shouldBeginFindRedemption(ctx context.Context, match *mat
 		return false
 	}
 
-	confs, spent, err := t.wallets.fromWallet.SwapConfirmations(ctx, swapCoinID, proof.Script, match.MetaData.Stamp)
+	confs, spent, err := t.wallets.fromWallet.SwapConfirmations(ctx, swapCoinID, proof.Script, match.MetaData.Stamp, t.metaData.FromVersion)
 	if err != nil {
 		t.dc.log.Errorf("Failed to get confirmations of the taker's swap %s (%s) for match %s, order %v: %v",
 			coinIDString(t.wallets.fromAsset.ID, swapCoinID), t.wallets.fromAsset.Symbol, match, t.UID(), err)

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -248,8 +248,10 @@ func (w *xcWallet) Disconnect() {
 // Context. If the coin cannot be located, an asset.CoinNotFoundError is
 // returned. If the coin is located, but recognized as spent, no error is
 // returned.
-func (w *xcWallet) SwapConfirmations(ctx context.Context, coinID []byte, contract []byte, matchTime uint64) (uint32, bool, error) {
+func (w *xcWallet) SwapConfirmations(ctx context.Context, coinID []byte, contract []byte,
+	matchTime uint64, assetVer uint32) (uint32, bool, error) {
+
 	ctx, cancel := context.WithTimeout(ctx, confCheckTimeout)
 	defer cancel()
-	return w.Wallet.SwapConfirmations(ctx, coinID, contract, encode.UnixTimeMilli(int64(matchTime)))
+	return w.Wallet.SwapConfirmations(ctx, coinID, contract, encode.UnixTimeMilli(int64(matchTime)), assetVer)
 }


### PR DESCRIPTION
Add an asset version argument to `(Wallet).SwapConfirmations` and implement the method for eth.