### PR TITLE
client/asset/eth: RegFeeConfirmations

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -152,6 +152,7 @@ type ethFetcher interface {
 	unlock(ctx context.Context, pw string) error
 	signData(addr common.Address, data []byte) ([]byte, error)
 	sendToAddr(ctx context.Context, addr common.Address, val uint64) (*types.Transaction, error)
+	transactionConfirmations(context.Context, common.Hash) (uint32, error)
 }
 
 // Check that ExchangeWallet satisfies the asset.Wallet interface.
@@ -806,8 +807,12 @@ func (eth *ExchangeWallet) SyncStatus() (bool, float32, error) {
 	return progress == 1, progress, nil
 }
 
+// RegFeeConfirmations gets the number of confirmations for the specified
+// transaction.
 func (eth *ExchangeWallet) RegFeeConfirmations(ctx context.Context, coinID dex.Bytes) (confs uint32, err error) {
-	return 0, asset.ErrNotImplemented
+	var txHash common.Hash
+	copy(txHash[:], coinID)
+	return eth.node.transactionConfirmations(ctx, txHash)
 }
 
 // monitorBlocks pings for new blocks and runs the tipChange callback function

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -164,6 +164,10 @@ func (n *testNode) sendToAddr(ctx context.Context, addr common.Address, val uint
 	return nil, nil
 }
 
+func (n *testNode) transactionConfirmations(context.Context, common.Hash) (uint32, error) {
+	return 0, nil
+}
+
 func TestLoadConfig(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Implement `RegFeeConfirmations`. Add `transactionConfirmations` method
to `nodeClient`. Check local tx pool first, since non-zero confs will
always request from peers, and the tx we're looking for is ours.