### PR TITLE
client/asset/eth: re-implement translation tests for abigen types

### DIFF
--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -157,8 +157,6 @@ func (c *contractorV0) swap(ctx context.Context, secretHash [32]byte) (*dexeth.S
 		return nil, err
 	}
 
-	fmt.Println("--swap", state.Value, dexeth.WeiToGwei(state.Value))
-
 	return &dexeth.SwapState{
 		BlockHeight: state.InitBlockNumber.Uint64(),
 		LockTime:    time.Unix(state.RefundBlockTimestamp.Int64(), 0),

--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -118,11 +118,13 @@ func (c *contractorV0) initiate(txOpts *bind.TransactOpts, contracts []*asset.Co
 			Value:           new(big.Int).Mul(bigVal, dexeth.BigGweiFactor),
 		})
 	}
+
 	return c.contractV0.Initiate(txOpts, inits)
 }
 
 func (c *contractorV0) redeem(txOpts *bind.TransactOpts, redemptions []*asset.Redemption) (*types.Transaction, error) {
 	redemps := make([]swapv0.ETHSwapRedemption, 0, len(redemptions))
+	secretHashes := make(map[[32]byte]bool, len(redemptions))
 	for _, r := range redemptions {
 		secretB, secretHashB := r.Secret, r.Spends.SecretHash
 		if len(secretB) != 32 || len(secretHashB) != 32 {
@@ -131,6 +133,11 @@ func (c *contractorV0) redeem(txOpts *bind.TransactOpts, redemptions []*asset.Re
 		var secret, secretHash [32]byte
 		copy(secret[:], secretB)
 		copy(secretHash[:], secretHashB)
+		if secretHashes[secretHash] {
+			return nil, fmt.Errorf("duplicate secret hash %x", secretHash[:])
+		}
+		secretHashes[secretHash] = true
+
 		redemps = append(redemps, swapv0.ETHSwapRedemption{
 			Secret:     secret,
 			SecretHash: secretHash,
@@ -149,6 +156,8 @@ func (c *contractorV0) swap(ctx context.Context, secretHash [32]byte) (*dexeth.S
 	if err != nil {
 		return nil, err
 	}
+
+	fmt.Println("--swap", state.Value, dexeth.WeiToGwei(state.Value))
 
 	return &dexeth.SwapState{
 		BlockHeight: state.InitBlockNumber.Uint64(),

--- a/client/asset/eth/contractor_test.go
+++ b/client/asset/eth/contractor_test.go
@@ -1,44 +1,51 @@
+//go:build lgpl
+// +build lgpl
+
 package eth
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"testing"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex/encode"
+	dexeth "decred.org/dcrdex/dex/networks/eth"
 	swapv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type tContractV0 struct {
-	initErr   error
-	redeemErr error
-	swapErr   error
+	lastInits   []swapv0.ETHSwapInitiation
+	initErr     error
+	lastRedeems []swapv0.ETHSwapRedemption
+	redeemErr   error
+	swap        swapv0.ETHSwapSwap
+	swapErr     error
 }
 
-func (c tContractV0) Initiate(opts *bind.TransactOpts, initiations []swapv0.ETHSwapInitiation) (*types.Transaction, error) {
+func (c *tContractV0) Initiate(opts *bind.TransactOpts, initiations []swapv0.ETHSwapInitiation) (*types.Transaction, error) {
+	c.lastInits = initiations
 	return nil, c.initErr
 }
 
-func (c tContractV0) Redeem(opts *bind.TransactOpts, redemptions []swapv0.ETHSwapRedemption) (*types.Transaction, error) {
+func (c *tContractV0) Redeem(opts *bind.TransactOpts, redemptions []swapv0.ETHSwapRedemption) (*types.Transaction, error) {
+	c.lastRedeems = redemptions
 	return nil, c.redeemErr
 }
 
-func (c tContractV0) Swap(opts *bind.CallOpts, secretHash [32]byte) (swapv0.ETHSwapSwap, error) {
-	return swapv0.ETHSwapSwap{
-		InitBlockNumber:      new(big.Int),
-		RefundBlockTimestamp: new(big.Int),
-		Value:                new(big.Int),
-	}, c.swapErr
+func (c *tContractV0) Swap(opts *bind.CallOpts, secretHash [32]byte) (swapv0.ETHSwapSwap, error) {
+	return c.swap, c.swapErr
 }
 
-func (c tContractV0) Refund(opts *bind.TransactOpts, secretHash [32]byte) (*types.Transaction, error) {
+func (c *tContractV0) Refund(opts *bind.TransactOpts, secretHash [32]byte) (*types.Transaction, error) {
 	return nil, nil
 }
 
-func (c tContractV0) IsRedeemable(opts *bind.CallOpts, secretHash [32]byte, secret [32]byte) (bool, error) {
+func (c *tContractV0) IsRedeemable(opts *bind.CallOpts, secretHash [32]byte, secret [32]byte) (bool, error) {
 	return false, nil
 }
 
@@ -46,9 +53,15 @@ func TestInitV0(t *testing.T) {
 	abiContract := &tContractV0{}
 	c := contractorV0{contractV0: abiContract}
 	addrStr := "0xB6De8BB5ed28E6bE6d671975cad20C03931bE981"
+	secretHashB := encode.RandomBytes(32)
+	const gweiVal = 123456
+	const lockTime = 100_000_000
+
 	contract := &asset.Contract{
-		SecretHash: encode.RandomBytes(32),
+		SecretHash: secretHashB,
 		Address:    addrStr,
+		Value:      gweiVal,
+		LockTime:   lockTime,
 	}
 
 	contracts := []*asset.Contract{contract}
@@ -62,6 +75,23 @@ func TestInitV0(t *testing.T) {
 
 	checkResult("first success", false)
 
+	if len(abiContract.lastInits) != 1 {
+		t.Fatalf("wrong number of inits translated, %d", len(abiContract.lastInits))
+	}
+	init := abiContract.lastInits[0]
+	if init.RefundTimestamp.Uint64() != lockTime {
+		t.Fatalf("wrong RefundTimestamp. expected %d, got %d", lockTime, init.RefundTimestamp.Uint64())
+	}
+	if !bytes.Equal(init.SecretHash[:], secretHashB) {
+		t.Fatalf("wrong secret hash.")
+	}
+	if init.Participant != common.HexToAddress(addrStr) {
+		t.Fatalf("wrong address. wanted %s, got %s", common.HexToAddress(addrStr), init.Participant)
+	}
+	if dexeth.WeiToGwei(init.Value) != gweiVal {
+		t.Fatalf("wrong value. wanted %d, got %d", gweiVal, dexeth.WeiToGwei(init.Value))
+	}
+
 	// wrong secret hash size
 	contract.SecretHash = encode.RandomBytes(20)
 	checkResult("bad hash", true)
@@ -70,7 +100,17 @@ func TestInitV0(t *testing.T) {
 	// dupe hash
 	contracts = []*asset.Contract{contract, contract}
 	checkResult("dupe hash", true)
+
+	// ok with two
+	contract2 := *contract
+	contract2.SecretHash = encode.RandomBytes(32)
+	contracts = []*asset.Contract{contract, &contract2}
+	checkResult("ok two", false)
 	contracts = []*asset.Contract{contract}
+
+	if len(abiContract.lastInits) != 2 {
+		t.Fatalf("two contracts weren't passed")
+	}
 
 	// bad address
 	contract.Address = "badaddress"
@@ -90,9 +130,12 @@ func TestRedeemV0(t *testing.T) {
 	abiContract := &tContractV0{}
 	c := contractorV0{contractV0: abiContract}
 
+	secretB := encode.RandomBytes(32)
+	secretHashB := encode.RandomBytes(32)
+
 	redemption := &asset.Redemption{
-		Secret: encode.RandomBytes(32),
-		Spends: &asset.AuditInfo{SecretHash: encode.RandomBytes(32)},
+		Secret: secretB,
+		Spends: &asset.AuditInfo{SecretHash: secretHashB},
 	}
 
 	redemptions := []*asset.Redemption{redemption}
@@ -100,11 +143,22 @@ func TestRedeemV0(t *testing.T) {
 	checkResult := func(tag string, wantErr bool) {
 		_, err := c.redeem(nil, redemptions)
 		if (err != nil) != wantErr {
-			t.Fatal(tag)
+			t.Fatal(tag, err)
 		}
 	}
 
 	checkResult("initial success", false)
+
+	if len(abiContract.lastRedeems) != 1 {
+		t.Fatalf("contract not passed")
+	}
+	redeem := abiContract.lastRedeems[0]
+	if !bytes.Equal(redeem.Secret[:], secretB) {
+		t.Fatalf("secret not translated")
+	}
+	if !bytes.Equal(redeem.SecretHash[:], secretHashB) {
+		t.Fatalf("secret hash not translated")
+	}
 
 	// bad secret hash length
 	redemption.Spends.SecretHash = encode.RandomBytes(20)
@@ -121,6 +175,74 @@ func TestRedeemV0(t *testing.T) {
 	checkResult("contract error", true)
 	abiContract.redeemErr = nil
 
-	// Success again
-	checkResult("success again", false)
+	// Error on dupe.
+	redemptions = []*asset.Redemption{redemption, redemption}
+	checkResult("dupe error", true)
+
+	// two OK
+	redemption2 := &asset.Redemption{
+		Secret: encode.RandomBytes(32),
+		Spends: &asset.AuditInfo{SecretHash: encode.RandomBytes(32)},
+	}
+	redemptions = []*asset.Redemption{redemption, redemption2}
+	checkResult("two ok", false)
+}
+
+func TestSwapV0(t *testing.T) {
+	abiContract := &tContractV0{}
+	c := contractorV0{contractV0: abiContract}
+
+	var secret [32]byte
+	const valGwei = 123_456
+	const blockNum = 654_321
+	const stamp = 789_654
+	var initiator, participant common.Address
+	copy(initiator[:], encode.RandomBytes(32))
+	copy(participant[:], encode.RandomBytes(32))
+	const state = 128
+
+	abiContract.swap = swapv0.ETHSwapSwap{
+		Secret:               secret,
+		Value:                dexeth.GweiToWei(valGwei),
+		InitBlockNumber:      big.NewInt(blockNum),
+		RefundBlockTimestamp: big.NewInt(stamp),
+		Initiator:            initiator,
+		Participant:          participant,
+		State:                state,
+	}
+
+	// error path
+	abiContract.swapErr = fmt.Errorf("test error")
+	_, err := c.swap(nil, [32]byte{})
+	if err == nil {
+		t.Fatalf("swap error not transmitted")
+	}
+	abiContract.swapErr = nil
+
+	swap, err := c.swap(nil, [32]byte{})
+	if err != nil {
+		t.Fatalf("swap error: %v", err)
+	}
+
+	if swap.Secret != secret {
+		t.Fatalf("wrong secret")
+	}
+	if swap.Value != valGwei {
+		t.Fatalf("wrong value")
+	}
+	if swap.BlockHeight != blockNum {
+		t.Fatalf("wrong block height")
+	}
+	if swap.LockTime.Unix() != stamp {
+		t.Fatalf("wrong lock time")
+	}
+	if swap.Initiator != initiator {
+		t.Fatalf("initiator not transmitted")
+	}
+	if swap.Participant != participant {
+		t.Fatalf("participant not transmitted")
+	}
+	if swap.State != state {
+		t.Fatalf("state not transmitted")
+	}
 }


### PR DESCRIPTION
These were ripped out with the changes in #1301 because `ExchangeWallet` no longer deals with the abigen types. Now re-implemented through contractor tests.