### PR TITLE
dex/networks,server/eth: decode swap data message blob

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -259,7 +259,9 @@ type Receipt interface {
 	Expiration() time.Time
 	// Coin is the contract's coin.
 	Coin() Coin
-	// Contract is the contract script.
+	// Contract is the unique swap contract data. This may be a redeem script
+	// for UTXO assets, or other information that uniquely identifies the swap
+	// for account-based assets e.g. a contract version and secret hash for ETH.
 	Contract() dex.Bytes
 	// String provides a human-readable representation of the contract's Coin.
 	String() string
@@ -277,9 +279,13 @@ type AuditInfo struct {
 	Expiration time.Time
 	// Coin is the coin that contains the contract.
 	Coin Coin
-	// Contract is the contract script.
+	// Contract is the unique swap contract data. This may be a redeem script
+	// for UTXO assets, or other information that uniquely identifies the swap
+	// for account-based assets e.g. a contract version and secret hash for ETH.
 	Contract dex.Bytes
-	// SecretHash is the contract's secret hash.
+	// SecretHash is the contract's secret hash. This is likely to be encoded in
+	// the Contract field, which is often the redeem script or an asset-specific
+	// encoding of the unique swap data.
 	SecretHash dex.Bytes
 }
 
@@ -299,7 +305,9 @@ type Swaps struct {
 	// subsequent matches.
 	LockChange bool
 	// AssetVersion is the swap protocol version, which may indicate a specific
-	// contract or form of contract.
+	// contract or form of contract. NOTE: Depending on the asset, batch swaps
+	// may force each Contract to use the same version, but conceptually this
+	// should perhaps be in Contract with SecretHash.
 	AssetVersion uint32
 }
 
@@ -335,9 +343,6 @@ type RedeemForm struct {
 	// suggestion in any way, but obviously fees that are too low may result in
 	// the redemption getting stuck in mempool.
 	FeeSuggestion uint64
-	// AssetVersion is the swap protocol version, which may indicate a specific
-	// contract or form of contract.
-	AssetVersion uint32
 }
 
 // Order is order details needed for FundOrder.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1529,7 +1529,11 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 		// to notify the server of the swap.
 		proof := &match.MetaData.Proof
 		contract, coinID := receipt.Contract(), []byte(coin.ID())
-		proof.Script = contract
+		// NOTE: receipt.Contract() uniquely identifies this swap. Only the
+		// asset backend can decode this information, which may be a redeem
+		// script with UTXO assets, or a secret hash + contract version for
+		// contracts on account-based assets.
+		proof.Script = contract // expected conflict: buck is renaming this
 		if match.Side == order.Taker {
 			proof.TakerSwap = coinID
 			match.Status = order.TakerSwapCast
@@ -1677,7 +1681,6 @@ func (c *Core) redeemMatchGroup(t *trackedTrade, matches []*matchTracker, errs *
 	coinIDs, outCoin, fees, err := redeemWallet.Redeem(&asset.RedeemForm{
 		Redemptions:   redemptions,
 		FeeSuggestion: feeSuggestion,
-		AssetVersion:  t.metaData.ToVersion,
 	})
 	// If an error was encountered, fail all of the matches. A failed match will
 	// not run again on during ticks.

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1,5 +1,5 @@
-//go:build live
-// +build live
+//go:build live && lgpl
+// +build live,lgpl
 
 // Run a test server with
 // go test -v -tags live -run Server -timeout 60m
@@ -305,37 +305,37 @@ var tExchanges = map[string]*core.Exchange{
 		},
 		Connected: true,
 		RegFees: map[string]*core.FeeAsset{
-			"dcr": &core.FeeAsset{
+			"dcr": {
 				ID:    42,
 				Confs: 1,
 				Amt:   1e8,
 			},
-			"btc": &core.FeeAsset{
+			"btc": {
 				ID:    0,
 				Confs: 2,
 				Amt:   1e5,
 			},
-			"eth": &core.FeeAsset{
+			"eth": {
 				ID:    60,
 				Confs: 5,
 				Amt:   1e7,
 			},
-			"bch": &core.FeeAsset{
+			"bch": {
 				ID:    145,
 				Confs: 2,
 				Amt:   1e10,
 			},
-			"ltc": &core.FeeAsset{
+			"ltc": {
 				ID:    2,
 				Confs: 5,
 				Amt:   1e10,
 			},
-			"doge": &core.FeeAsset{
+			"doge": {
 				ID:    3,
 				Confs: 10,
 				Amt:   1e12,
 			},
-			"kmd": &core.FeeAsset{ // Not-supported
+			"kmd": { // Not-supported
 				ID:    141,
 				Confs: 10,
 				Amt:   1e12,
@@ -354,12 +354,12 @@ var tExchanges = map[string]*core.Exchange{
 		},
 		Connected: true,
 		RegFees: map[string]*core.FeeAsset{
-			"dcr": &core.FeeAsset{
+			"dcr": {
 				ID:    42,
 				Confs: 1,
 				Amt:   1e8,
 			},
-			"btc": &core.FeeAsset{
+			"btc": {
 				ID:    0,
 				Confs: 2,
 				Amt:   1e6,
@@ -1412,7 +1412,7 @@ out:
 			c.noteFeed <- &core.SpotPriceNote{
 				Host:         dexAddr,
 				Notification: db.NewNotification(core.NoteTypeSpots, core.TopicSpotsUpdate, "", "", db.Data),
-				Spots: map[string]*msgjson.Spot{mktID: &msgjson.Spot{
+				Spots: map[string]*msgjson.Spot{mktID: {
 					Stamp:   encode.UnixMilliU(time.Now()),
 					BaseID:  baseID,
 					QuoteID: quoteID,

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -42,7 +42,7 @@ done
 
 cd "$dir"
 dumptags=(-c -o /dev/null -tags)
-go test "${dumptags[@]}" live ./client/webserver
+go test "${dumptags[@]}" live,lgpl ./client/webserver
 go test "${dumptags[@]}" harness ./client/asset/dcr
 go test "${dumptags[@]}" harness ./client/asset/btc/livetest
 go test "${dumptags[@]}" harness ./client/asset/ltc


### PR DESCRIPTION
The `msgjson.Init.Contract` and `server/asset.Contract.RedeemScript` fields
contain an encoding of the ETH contract version concatenated with the
swap's secret hash that is the unique key for the swap.

This updates server/asset/eth's `ValidateContract` and `Contract` methods
to decode and check this data.

This also adds the `dexeth.EncodeContractData` and `DecodeContractData` functions.