### PR TITLE
client/asset/eth: fix client balance calcs

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -902,7 +902,7 @@ func (eth *ExchangeWallet) checkForNewBlocks() {
 // Balance is the current balance, including information about the pending
 // balance.
 type Balance struct {
-	Current, Pending, PendingIn, PendingOut *big.Int
+	Current, PendingIn, PendingOut *big.Int
 }
 
 func versionedBytes(ver uint32, h []byte) []byte {

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -148,9 +148,9 @@ type ethFetcher interface {
 	redeem(txOpts *bind.TransactOpts, redemptions []*asset.Redemption, contractVer uint32) (*types.Transaction, error)
 	refund(txOpts *bind.TransactOpts, secretHash [32]byte, contractVer uint32) (*types.Transaction, error)
 	swap(ctx context.Context, secretHash [32]byte, contractVer uint32) (*dexeth.SwapState, error)
-	lock(ctx context.Context) error
+	lock() error
 	locked() bool
-	unlock(ctx context.Context, pw string) error
+	unlock(pw string) error
 	signData(addr common.Address, data []byte) ([]byte, error)
 	sendToAddr(ctx context.Context, addr common.Address, val uint64) (*types.Transaction, error)
 	transactionConfirmations(context.Context, common.Hash) (uint32, error)
@@ -734,12 +734,12 @@ func (eth *ExchangeWallet) Address() (string, error) {
 
 // Unlock unlocks the exchange wallet.
 func (eth *ExchangeWallet) Unlock(pw []byte) error {
-	return eth.node.unlock(eth.ctx, string(pw))
+	return eth.node.unlock(string(pw))
 }
 
 // Lock locks the exchange wallet.
 func (eth *ExchangeWallet) Lock() error {
-	return eth.node.lock(eth.ctx)
+	return eth.node.lock()
 }
 
 // Locked will be true if the wallet is currently locked.

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -64,10 +64,9 @@ type testNode struct {
 	nonce             uint64
 }
 
-func newBalance(current, pending, in, out uint64) *Balance {
+func newBalance(current, in, out uint64) *Balance {
 	return &Balance{
 		Current:    dexeth.GweiToWei(current),
-		Pending:    dexeth.GweiToWei(pending),
 		PendingIn:  dexeth.GweiToWei(in),
 		PendingOut: dexeth.GweiToWei(out),
 	}
@@ -354,7 +353,7 @@ func TestBalance(t *testing.T) {
 	// overMaxWei := new(big.Int).Set(maxWei)
 	// overMaxWei.Add(overMaxWei, gweiFactorBig)
 
-	tinyBal := newBalance(0, 0, 0, 0)
+	tinyBal := newBalance(0, 0, 0)
 	tinyBal.Current = big.NewInt(dexeth.GweiFactor - 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -377,7 +376,7 @@ func TestBalance(t *testing.T) {
 		wantLocked   uint64
 	}{{
 		name:         "ok zero",
-		bal:          newBalance(0, 0, 0, 0),
+		bal:          newBalance(0, 0, 0),
 		wantBal:      0,
 		wantImmature: 0,
 	}, {
@@ -386,21 +385,21 @@ func TestBalance(t *testing.T) {
 		wantBal: 0,
 	}, {
 		name:    "ok one",
-		bal:     newBalance(1, 0, 0, 0),
+		bal:     newBalance(1, 0, 0),
 		wantBal: 1,
 	}, {
 		name:       "ok pending out",
-		bal:        newBalance(4e8, (4-1.4)*1e8, 0, 1.4e8),
+		bal:        newBalance(4e8, 0, 1.4e8),
 		wantBal:    2.6e8,
 		wantLocked: 1.4e8,
 	}, {
 		name:         "ok pending in",
-		bal:          newBalance(1e8, 4e8, 3e8, 0),
+		bal:          newBalance(1e8, 3e8, 0),
 		wantBal:      1e8,
 		wantImmature: 3e8,
 	}, {
 		name:         "ok pending out and in",
-		bal:          newBalance(4e8, 5e8, 2e8, 1e8),
+		bal:          newBalance(4e8, 2e8, 1e8),
 		wantBal:      3e8,
 		wantLocked:   1e8,
 		wantImmature: 2e8,
@@ -475,7 +474,7 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 		Address: common.HexToAddress(address),
 	}
 	node := newTestNode(&account)
-	node.bal = newBalance(walletBalanceGwei, 0, 0, 0)
+	node.bal = newBalance(walletBalanceGwei, 0, 0)
 	eth := &ExchangeWallet{
 		node:        node,
 		addr:        node.address(),
@@ -822,7 +821,7 @@ func TestPreSwap(t *testing.T) {
 			FeeSuggestion: test.feeSuggestion,
 		}
 		node := newTestNode(nil)
-		node.bal = newBalance(test.bal*1e9, 0, 0, 0)
+		node.bal = newBalance(test.bal*1e9, 0, 0)
 		node.balErr = test.balErr
 		eth := &ExchangeWallet{
 			node: node,
@@ -867,7 +866,7 @@ func TestPreSwap(t *testing.T) {
 
 func TestSwap(t *testing.T) {
 	node := &testNode{
-		bal: newBalance(0, 0, 0, 0),
+		bal: newBalance(0, 0, 0),
 	}
 	address := "0xB6De8BB5ed28E6bE6d671975cad20C03931bE981"
 	receivingAddress := "0x2b84C791b79Ee37De042AD2ffF1A253c3ce9bc27"
@@ -1219,7 +1218,7 @@ func TestMaxOrder(t *testing.T) {
 	for _, test := range tests {
 		ctx, cancel := context.WithCancel(context.Background())
 		node := newTestNode(nil)
-		node.bal = newBalance(test.bal*1e9, 0, 0, 0)
+		node.bal = newBalance(test.bal*1e9, 0, 0)
 		node.balErr = test.balErr
 		eth := &ExchangeWallet{
 			node: node,
@@ -1428,7 +1427,7 @@ func TestSwapConfirmation(t *testing.T) {
 	hdr := &types.Header{}
 
 	node := &testNode{
-		bal:     newBalance(0, 0, 0, 0),
+		bal:     newBalance(0, 0, 0),
 		bestHdr: hdr,
 		swapMap: map[[32]byte]*dexeth.SwapState{
 			secretHash: state,

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -94,10 +94,10 @@ func (n *testNode) balance(ctx context.Context) (*Balance, error) {
 func (n *testNode) syncStatus(ctx context.Context) (bool, float32, error) {
 	return false, 0, nil
 }
-func (n *testNode) unlock(ctx context.Context, pw string) error {
+func (n *testNode) unlock(pw string) error {
 	return nil
 }
-func (n *testNode) lock(ctx context.Context) error {
+func (n *testNode) lock() error {
 	return nil
 }
 func (n *testNode) locked() bool {

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -155,17 +155,6 @@ func (n *nodeClient) block(ctx context.Context, hash common.Hash) (*types.Block,
 	return n.leth.ApiBackend.BlockByHash(ctx, hash)
 }
 
-// accounts returns all accounts from the internal node.
-func (n *nodeClient) accounts() []*accounts.Account {
-	var accts []*accounts.Account
-	for _, wallet := range n.node.AccountManager().Wallets() {
-		for _, acct := range wallet.Accounts() {
-			accts = append(accts, &acct)
-		}
-	}
-	return accts
-}
-
 func (n *nodeClient) stateAt(ctx context.Context, bn rpc.BlockNumber) (*state.StateDB, error) {
 	state, _, err := n.leth.ApiBackend.StateAndHeaderByNumberOrHash(ctx, rpc.BlockNumberOrHashWithNumber(bn))
 	if err != nil {
@@ -312,19 +301,6 @@ func (n *nodeClient) addPeer(peerURL string) error {
 	return nil
 }
 
-// nodeInfo retrieves useful information about a node.
-// Not used in production. TODO: remove?
-func (n *nodeClient) nodeInfo() *p2p.NodeInfo {
-	return n.p2pSrv.NodeInfo()
-}
-
-// listWallets list all of the wallet's wallets? and accounts along with details
-// such as locked status.
-// Not used in production. TODO: remove?
-func (n *nodeClient) listWallets() []accounts.Wallet {
-	return n.creds.ks.Wallets()
-}
-
 // sendTransaction sends a tx.
 func (n *nodeClient) sendTransaction(ctx context.Context, txOpts *bind.TransactOpts,
 	to common.Address, data []byte) (*types.Transaction, error) {
@@ -358,12 +334,6 @@ func (n *nodeClient) sendTransaction(ctx context.Context, txOpts *bind.TransactO
 // syncProgress return the current sync progress. Returns no error and nil when not syncing.
 func (n *nodeClient) syncProgress() ethereum.SyncProgress {
 	return n.leth.ApiBackend.SyncProgress()
-}
-
-// peers returns connected peers.
-// Not used in production. TODO: remove?
-func (n *nodeClient) peers() []*p2p.Peer {
-	return n.p2pSrv.Peers()
 }
 
 // swap gets a swap keyed by secretHash in the contract.

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -247,7 +247,6 @@ func syncClient(cl *nodeClient) error {
 
 func TestBasicRetrieval(t *testing.T) {
 	syncClient(ethClient)
-	t.Run("testNodeInfo", testNodeInfo)
 	t.Run("testBestBlockHash", testBestBlockHash)
 	t.Run("testBestHeader", testBestHeader)
 	t.Run("testBlock", testBlock)
@@ -257,16 +256,13 @@ func TestBasicRetrieval(t *testing.T) {
 func TestPeering(t *testing.T) {
 	t.Run("testAddPeer", testAddPeer)
 	t.Run("testSyncProgress", testSyncProgress)
-	t.Run("testPeers", testPeers)
 	t.Run("testGetCodeAt", testGetCodeAt)
 }
 
 func TestAccount(t *testing.T) {
-	t.Run("testAccounts", testAccounts)
 	t.Run("testBalance", testBalance)
 	t.Run("testUnlock", testUnlock)
 	t.Run("testLock", testLock)
-	t.Run("testListWallets", testListWallets)
 	t.Run("testSendTransaction", testSendTransaction)
 	t.Run("testTransactionReceipt", testTransactionReceipt)
 	t.Run("testSignMessage", testSignMessage)
@@ -282,11 +278,6 @@ func TestContract(t *testing.T) {
 	t.Run("testInitiate", testInitiate)
 	t.Run("testRedeem", testRedeem)
 	// t.Run("testRefund", testRefund)
-}
-
-func testNodeInfo(t *testing.T) {
-	ni := ethClient.nodeInfo()
-	spew.Dump(ni)
 }
 
 func testAddPeer(t *testing.T) {
@@ -323,14 +314,6 @@ func testBlock(t *testing.T) {
 	spew.Dump(b)
 }
 
-func testAccounts(t *testing.T) {
-	accts := ethClient.accounts()
-	if len(accts) == 0 {
-		t.Errorf("Found no accounts")
-	}
-	spew.Dump(accts)
-}
-
 func testBalance(t *testing.T) {
 	bal, err := ethClient.balance(ctx)
 	if err != nil {
@@ -354,14 +337,6 @@ func testLock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-func testListWallets(t *testing.T) {
-	wallets := ethClient.listWallets()
-	if len(wallets) == 0 {
-		t.Fatalf("no wallets")
-	}
-	spew.Dump(wallets)
 }
 
 func testSendTransaction(t *testing.T) {
@@ -461,11 +436,6 @@ func testSwap(t *testing.T) {
 
 func testSyncProgress(t *testing.T) {
 	spew.Dump(ethClient.syncProgress())
-}
-
-func testPeers(t *testing.T) {
-	peers := ethClient.peers()
-	spew.Dump(peers)
 }
 
 func TestInitiateGas(t *testing.T) {

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -115,7 +115,7 @@ out:
 		case <-timesUp:
 			return errors.New("timed out")
 		case <-time.After(time.Second):
-			txs, err := ethClient.pendingTransactions(ctx)
+			txs, err := ethClient.pendingTransactions()
 			if err != nil {
 				return err
 			}
@@ -285,12 +285,12 @@ func TestContract(t *testing.T) {
 }
 
 func testNodeInfo(t *testing.T) {
-	ni := ethClient.nodeInfo(ctx)
+	ni := ethClient.nodeInfo()
 	spew.Dump(ni)
 }
 
 func testAddPeer(t *testing.T) {
-	if err := ethClient.addPeer(ctx, alphaNode); err != nil {
+	if err := ethClient.addPeer(alphaNode); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -343,21 +343,21 @@ func testBalance(t *testing.T) {
 }
 
 func testUnlock(t *testing.T) {
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testLock(t *testing.T) {
-	err := ethClient.lock(ctx)
+	err := ethClient.lock()
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testListWallets(t *testing.T) {
-	wallets := ethClient.listWallets(ctx)
+	wallets := ethClient.listWallets()
 	if len(wallets) == 0 {
 		t.Fatalf("no wallets")
 	}
@@ -365,7 +365,7 @@ func testListWallets(t *testing.T) {
 }
 
 func testSendTransaction(t *testing.T) {
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +418,7 @@ func testSendTransaction(t *testing.T) {
 }
 
 func testTransactionReceipt(t *testing.T) {
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -440,7 +440,7 @@ func testTransactionReceipt(t *testing.T) {
 }
 
 func testPendingTransactions(t *testing.T) {
-	txs, err := ethClient.pendingTransactions(ctx)
+	txs, err := ethClient.pendingTransactions()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,12 +464,12 @@ func testSyncProgress(t *testing.T) {
 }
 
 func testPeers(t *testing.T) {
-	peers := ethClient.peers(ctx)
+	peers := ethClient.peers()
 	spew.Dump(peers)
 }
 
 func TestInitiateGas(t *testing.T) {
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -504,7 +504,7 @@ func TestInitiateGas(t *testing.T) {
 }
 
 func testInitiate(t *testing.T) {
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -676,7 +676,7 @@ func testInitiate(t *testing.T) {
 }
 
 func TestRedeemGas(t *testing.T) {
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -760,11 +760,11 @@ func testRedeem(t *testing.T) {
 		secretHashes = append(secretHashes, secretHash)
 	}
 
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = participantEthClient.unlock(ctx, pw)
+	err = participantEthClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -982,7 +982,7 @@ func testRedeem(t *testing.T) {
 }
 
 func TestRefundGas(t *testing.T) {
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1060,11 +1060,11 @@ func TestRefund(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		err := ethClient.unlock(ctx, pw)
+		err := ethClient.unlock(pw)
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = participantEthClient.unlock(ctx, pw)
+		err = participantEthClient.unlock(pw)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1170,7 +1170,7 @@ func TestRefund(t *testing.T) {
 }
 
 func TestReplayAttack(t *testing.T) {
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1349,7 +1349,7 @@ func testGetCodeAt(t *testing.T) {
 
 func testSignMessage(t *testing.T) {
 	msg := []byte("test message")
-	err := ethClient.unlock(ctx, pw)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatalf("error unlocking account: %v", err)
 	}

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -277,7 +277,7 @@ func TestContract(t *testing.T) {
 	t.Run("testSwap", testSwap)
 	t.Run("testInitiate", testInitiate)
 	t.Run("testRedeem", testRedeem)
-	// t.Run("testRefund", testRefund)
+	t.Run("testRefund", testRefund)
 }
 
 func testAddPeer(t *testing.T) {
@@ -991,7 +991,7 @@ func TestRefundGas(t *testing.T) {
 	fmt.Printf("Gas used for refund: %v \n", gas)
 }
 
-func TestRefund(t *testing.T) {
+func testRefund(t *testing.T) {
 	const amt = 1e9
 	locktime := time.Second * 12
 	tests := []struct {

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/p2p"
 )
 
 func init() {
@@ -89,12 +88,11 @@ type ethFetcher interface {
 	bestBlockHash(ctx context.Context) (common.Hash, error)
 	bestHeader(ctx context.Context) (*types.Header, error)
 	block(ctx context.Context, hash common.Hash) (*types.Block, error)
+	blockNumber(ctx context.Context) (uint64, error)
 	connect(ctx context.Context, ipc string, contractAddr *common.Address) error
 	shutdown()
 	suggestGasPrice(ctx context.Context) (*big.Int, error)
 	syncProgress(ctx context.Context) (*ethereum.SyncProgress, error)
-	blockNumber(ctx context.Context) (uint64, error)
-	peers(ctx context.Context) ([]*p2p.PeerInfo, error)
 	swap(ctx context.Context, secretHash [32]byte) (*swapv0.ETHSwapSwap, error)
 	transaction(ctx context.Context, hash common.Hash) (tx *types.Transaction, isMempool bool, err error)
 	accountBalance(ctx context.Context, addr common.Address) (*big.Int, error)

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/p2p"
 )
 
 var (
@@ -73,8 +72,6 @@ type testNode struct {
 	syncProgErr    error
 	sugGasPrice    *big.Int
 	sugGasPriceErr error
-	peerInfo       []*p2p.PeerInfo
-	peersErr       error
 	swp            *swapv0.ETHSwapSwap
 	swpErr         error
 	tx             *types.Transaction

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -110,10 +110,6 @@ func (n *testNode) syncProgress(ctx context.Context) (*ethereum.SyncProgress, er
 	return n.syncProg, n.syncProgErr
 }
 
-func (n *testNode) peers(ctx context.Context) ([]*p2p.PeerInfo, error) {
-	return n.peerInfo, n.peersErr
-}
-
 func (n *testNode) suggestGasPrice(ctx context.Context) (*big.Int, error) {
 	return n.sugGasPrice, n.sugGasPriceErr
 }


### PR DESCRIPTION
The client apparently doesn't maintain a pending state, so the
way I had calculated balance client-side didn't work. Go back
to @martonp's initial implementation which parses redeem
and refund data from transactions.

Remove the `Pending` field from `Balance`. It wasn't used.