### PR TITLE
client/eth: implement Exists

### DIFF
--- a/client/asset/eth/config.go
+++ b/client/asset/eth/config.go
@@ -15,7 +15,6 @@ import (
 
 // Config holds the parameters needed to initialize an ETH wallet.
 type Config struct {
-	AppDir         string  `ini:"appdir"`
 	NodeListenAddr string  `ini:"nodelistenaddr"`
 	GasFee         float64 `ini:"gasfee"`
 }

--- a/client/asset/eth/node.go
+++ b/client/asset/eth/node.go
@@ -140,7 +140,12 @@ func SetSimnetGenesis(sng string) {
 
 // prepareNode sets up a geth node, but does not start it.
 func prepareNode(cfg *nodeConfig) (*node.Node, error) {
-	stackConf := &node.Config{DataDir: cfg.appDir}
+	stackConf := &node.Config{
+		DataDir: cfg.appDir,
+		// KeyStoreDir is set the same as the geth default, but we rely on this
+		// location for Exists, so protect against future geth changes.
+		KeyStoreDir: filepath.Join(cfg.appDir, "keystore"),
+	}
 
 	stackConf.Logger = &ethLogger{dl: cfg.logger}
 

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -217,12 +217,12 @@ func TestMain(m *testing.M) {
 
 func setupWallet(walletDir, seed, listenAddress string) error {
 	settings := map[string]string{
-		"appdir":         walletDir,
 		"nodelistenaddr": listenAddress,
 	}
 	seedB, _ := hex.DecodeString(seed)
 	walletPass, _ := hex.DecodeString(pw)
 	createWalletParams := asset.CreateWalletParams{
+		Type:     walletTypeGeth,
 		Seed:     seedB,
 		Pass:     walletPass,
 		Settings: settings,


### PR DESCRIPTION
`Exists` works by trying to load the keystore and checking for > 1
wallets. Remove unused `"appdir"` setting from custom config. We already
have `CreateWalletParams.DataDir`.