### PR TITLE
client/asset/eth: implement LocktimeExpired

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -702,8 +702,23 @@ func (*ExchangeWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroad
 
 // LocktimeExpired returns true if the specified contract's locktime has
 // expired, making it possible to issue a Refund.
-func (*ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
-	return false, time.Time{}, asset.ErrNotImplemented
+func (eth *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
+	contractVer, secretHash, err := decodeVersionedSecretHash(contract)
+	if err != nil {
+		return false, time.Time{}, err
+	}
+
+	header, err := eth.node.bestHeader(eth.ctx)
+	if err != nil {
+		return false, time.Time{}, err
+	}
+	blockTime := time.Unix(int64(header.Time), 0)
+
+	swap, err := eth.node.swap(eth.ctx, secretHash, contractVer)
+	if err != nil {
+		return false, time.Time{}, err
+	}
+	return swap.LockTime.Before(blockTime), swap.LockTime, nil
 }
 
 // FindRedemption watches for the input that spends the specified contract
@@ -753,15 +768,10 @@ func (*ExchangeWallet) PayFee(address string, regFee, feeRateSuggestion uint64) 
 // SwapConfirmations gets the number of confirmations and the spend status
 // for the specified swap.
 func (eth *ExchangeWallet) SwapConfirmations(ctx context.Context, _ dex.Bytes, contract dex.Bytes, _ time.Time) (confs uint32, spent bool, err error) {
-	if len(contract) != 36 {
-		return 0, false, fmt.Errorf("wrong contract length. expected 36, got %d", len(contract))
+	contractVer, secretHash, err := decodeVersionedSecretHash(contract)
+	if err != nil {
+		return 0, false, err
 	}
-
-	// contract fully specifies this swap in terms of which contract version
-	// is used and the secret hash that keys the unique swap.
-	contractVer := binary.BigEndian.Uint32(contract[:4])
-	var secretHash [32]byte
-	copy(secretHash[:], contract[4:])
 
 	hdr, err := eth.node.bestHeader(ctx)
 	if err != nil {
@@ -905,4 +915,15 @@ func versionedBytes(ver uint32, h []byte) []byte {
 	binary.BigEndian.PutUint32(b[:4], ver)
 	copy(b[4:], h)
 	return b
+}
+
+// decodeVersionedSecretHash unpacks the contract version and secret hash.
+func decodeVersionedSecretHash(data []byte) (contractVersion uint32, swapKey [dexeth.SecretHashSize]byte, err error) {
+	if len(data) != dexeth.SecretHashSize+4 {
+		err = errors.New("invalid swap data")
+		return
+	}
+	contractVersion = binary.BigEndian.Uint32(data[:4])
+	copy(swapKey[:], data[4:])
+	return
 }

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1492,7 +1492,70 @@ func TestSwapConfirmation(t *testing.T) {
 	state.BlockHeight = 6
 	state.State = dexeth.SSRedeemed
 	checkResult(false, 1, true)
+}
 
+func TestLocktimeExpired(t *testing.T) {
+	var secretHash [32]byte
+	copy(secretHash[:], encode.RandomBytes(32))
+
+	state := &dexeth.SwapState{
+		LockTime: time.Now(),
+	}
+
+	header := &types.Header{
+		Time: uint64(time.Now().Add(time.Second).Unix()),
+	}
+
+	node := &testNode{
+		swapMap:  map[[32]byte]*dexeth.SwapState{secretHash: state},
+		swapVers: map[uint32]struct{}{0: {}},
+		bestHdr:  header,
+	}
+
+	eth := &ExchangeWallet{node: node}
+
+	contract := make([]byte, 36)
+	copy(contract[4:], secretHash[:])
+
+	ensureResult := func(tag string, expErr, expExpired bool) {
+		expired, _, err := eth.LocktimeExpired(contract)
+		switch {
+		case err != nil:
+			if !expErr {
+				t.Fatalf("%s: LocktimeExpired error existing expired swap: %v", tag, err)
+			}
+		case expErr:
+			t.Fatalf("%s: expected error, got none", tag)
+		case expExpired != expired:
+			t.Fatalf("%s: expired wrong. %t != %t", tag, expired, expExpired)
+		}
+	}
+
+	// locktime expired
+	ensureResult("locktime expired", false, true)
+
+	// header error
+	node.bestHdrErr = errors.New("test error")
+	ensureResult("header error", true, false)
+	node.bestHdrErr = nil
+
+	// missing swap
+	delete(node.swapMap, secretHash)
+	ensureResult("missing swap", true, false)
+	node.swapMap[secretHash] = state
+
+	// lock time not expired
+	state.LockTime = time.Now().Add(time.Minute)
+	ensureResult("lock time not expired", false, false)
+
+	// wrong contract version
+	contract[3] = 1
+	ensureResult("wrong contract version", true, false)
+	contract[3] = 0
+
+	// bad contract
+	contract = append(contract, 0)
+	ensureResult("bad contract", true, false)
 }
 
 func ethToGwei(v uint64) uint64 {


### PR DESCRIPTION
Pull the swap data from the contract and compare the lock time against the best header's timestamp.