### PR TITLE
client/asset/eth: implement FindRedemption

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1934,7 +1934,7 @@ func (btc *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time,
 //
 // This method blocks until the redemption is found, an error occurs or the
 // provided context is canceled.
-func (btc *ExchangeWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
+func (btc *ExchangeWallet) FindRedemption(ctx context.Context, coinID, _ dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
 	exitError := func(s string, a ...interface{}) (dex.Bytes, dex.Bytes, error) {
 		return nil, nil, fmt.Errorf(s, a...)
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -2059,7 +2059,7 @@ func testFindRedemption(t *testing.T, segwit bool, walletType string) {
 	})
 
 	// Check find redemption result.
-	_, checkSecret, err := wallet.FindRedemption(tCtx, coinID)
+	_, checkSecret, err := wallet.FindRedemption(tCtx, coinID, nil)
 	if err != nil {
 		t.Fatalf("error finding redemption: %v", err)
 	}
@@ -2069,7 +2069,7 @@ func testFindRedemption(t *testing.T, segwit bool, walletType string) {
 
 	// gettransaction error
 	node.getTransactionErr = tErr
-	_, _, err = wallet.FindRedemption(tCtx, coinID)
+	_, _, err = wallet.FindRedemption(tCtx, coinID, nil)
 	if err == nil {
 		t.Fatalf("no error for gettransaction rpc error")
 	}
@@ -2080,7 +2080,7 @@ func testFindRedemption(t *testing.T, segwit bool, walletType string) {
 	delete(node.getCFilterScripts, *redeemBlockHash)
 	timedCtx, cancel := context.WithTimeout(tCtx, 500*time.Millisecond) // 0.5 seconds is long enough
 	defer cancel()
-	_, k, err := wallet.FindRedemption(timedCtx, coinID)
+	_, k, err := wallet.FindRedemption(timedCtx, coinID, nil)
 	if timedCtx.Err() == nil || k != nil {
 		// Expected ctx to cancel after timeout and no secret should be found.
 		t.Fatalf("unexpected result for missing redemption: secret: %v, err: %v", k, err)
@@ -2094,7 +2094,7 @@ func testFindRedemption(t *testing.T, segwit bool, walletType string) {
 	// Canceled context
 	deadCtx, cancelCtx := context.WithCancel(tCtx)
 	cancelCtx()
-	_, _, err = wallet.FindRedemption(deadCtx, coinID)
+	_, _, err = wallet.FindRedemption(deadCtx, coinID, nil)
 	if err == nil {
 		t.Fatalf("no error for canceled context")
 	}
@@ -2105,7 +2105,7 @@ func testFindRedemption(t *testing.T, segwit bool, walletType string) {
 	redeemVin.SignatureScript = randBytes(100)
 
 	node.blockchainMtx.Unlock()
-	_, _, err = wallet.FindRedemption(tCtx, coinID)
+	_, _, err = wallet.FindRedemption(tCtx, coinID, nil)
 	if err == nil {
 		t.Fatalf("no error for wrong redemption")
 	}
@@ -2115,7 +2115,7 @@ func testFindRedemption(t *testing.T, segwit bool, walletType string) {
 	node.blockchainMtx.Unlock()
 
 	// Sanity check to make sure it passes again.
-	_, _, err = wallet.FindRedemption(tCtx, coinID)
+	_, _, err = wallet.FindRedemption(tCtx, coinID, nil)
 	if err != nil {
 		t.Fatalf("error after clearing errors: %v", err)
 	}

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -385,7 +385,7 @@ func Run(t *testing.T, cfg *Config) {
 
 	tLogger.Info("Testing FindRedemption")
 
-	_, _, err = rig.gamma().FindRedemption(ctx, swapReceipt.Coin().ID())
+	_, _, err = rig.gamma().FindRedemption(ctx, swapReceipt.Coin().ID(), nil)
 	if err != nil {
 		t.Fatalf("error finding unconfirmed redemption: %v", err)
 	}
@@ -397,7 +397,7 @@ func Run(t *testing.T, cfg *Config) {
 	}
 	// Check that there is 1 confirmation on the swap
 	checkConfs(expConfs, true)
-	_, checkKey, err := rig.gamma().FindRedemption(ctx, swapReceipt.Coin().ID())
+	_, checkKey, err := rig.gamma().FindRedemption(ctx, swapReceipt.Coin().ID(), nil)
 	if err != nil {
 		t.Fatalf("error finding confirmed redemption: %v", err)
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1680,7 +1680,7 @@ func (dcr *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time,
 //
 // This method blocks until the redemption is found, an error occurs or the
 // provided context is canceled.
-func (dcr *ExchangeWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
+func (dcr *ExchangeWallet) FindRedemption(ctx context.Context, coinID, _ dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
 	txHash, vout, err := decodeCoinID(coinID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot decode contract coin id: %w", err)

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -345,7 +345,7 @@ func runTest(t *testing.T, splitTx bool) {
 	waitNetwork()
 	ctx, cancel := context.WithDeadline(tCtx, time.Now().Add(time.Second*5))
 	defer cancel()
-	_, checkKey, err := rig.beta().FindRedemption(ctx, swapReceipt.Coin().ID())
+	_, checkKey, err := rig.beta().FindRedemption(ctx, swapReceipt.Coin().ID(), nil)
 	if err != nil {
 		t.Fatalf("error finding unconfirmed redemption: %v", err)
 	}
@@ -363,7 +363,7 @@ func runTest(t *testing.T, splitTx bool) {
 	}
 	ctx, cancel2 := context.WithDeadline(tCtx, time.Now().Add(time.Second*5))
 	defer cancel2()
-	_, _, err = rig.beta().FindRedemption(ctx, swapReceipt.Coin().ID())
+	_, _, err = rig.beta().FindRedemption(ctx, swapReceipt.Coin().ID(), nil)
 	if err != nil {
 		t.Fatalf("error finding confirmed redemption: %v", err)
 	}

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -902,12 +902,9 @@ func (eth *ExchangeWallet) findRedemptionRequests() map[[32]byte]*findRedemption
 	return reqs
 }
 
-// FindRedemption watches for the input that spends the specified contract
-// coin, and returns the spending input and the contract's secret key when it
-// finds a spender.
-//
-// This method blocks until the redemption is found, an error occurs or the
-// provided context is canceled.
+// FindRedemption checks the contract for a redemption. If the swap is initiated
+// but un-redeemed and un-refunded, FindRedemption will block until a redemption
+// is seen.
 func (eth *ExchangeWallet) FindRedemption(ctx context.Context, _, contract dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
 	contractVer, secretHash, err := dexeth.DecodeContractData(contract)
 	if err != nil {

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -89,6 +89,8 @@ var (
 	}
 
 	minGasTipCap = dexeth.GweiToWei(2)
+
+	findRedemptionCoinID = []byte("FindRedemption Coin")
 )
 
 // Check that Driver implements asset.Driver.
@@ -189,6 +191,9 @@ type ExchangeWallet struct {
 
 	lockedFunds    map[string]uint64 // gwei
 	lockedFundsMtx sync.RWMutex
+
+	findRedemptionMtx  sync.RWMutex
+	findRedemptionReqs map[[32]byte]*findRedemptionRequest
 }
 
 // Info returns basic information about the wallet and asset.
@@ -246,12 +251,13 @@ func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network)
 	}
 
 	return &ExchangeWallet{
-		log:         logger,
-		net:         net,
-		node:        cl,
-		addr:        cl.address(),
-		tipChange:   assetCFG.TipChange,
-		lockedFunds: make(map[string]uint64),
+		log:                logger,
+		net:                net,
+		node:               cl,
+		addr:               cl.address(),
+		tipChange:          assetCFG.TipChange,
+		lockedFunds:        make(map[string]uint64),
+		findRedemptionReqs: make(map[[32]byte]*findRedemptionRequest),
 	}, nil
 }
 
@@ -863,14 +869,117 @@ func (eth *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time,
 	return swap.LockTime.Before(blockTime), swap.LockTime, nil
 }
 
+// findRedemptionResult is used internally for queued findRedemptionRequests.
+type findRedemptionResult struct {
+	err    error
+	secret []byte
+}
+
+// findRedemptionRequest is a request that is waiting on a redemption result.
+type findRedemptionRequest struct {
+	contractVer uint32
+	res         chan *findRedemptionResult
+}
+
+// sendFindRedemptionResult sends the result or logs a message if it cannot be
+// sent.
+func (eth *ExchangeWallet) sendFindRedemptionResult(req *findRedemptionRequest, secretHash [32]byte, secret []byte, err error) {
+	select {
+	case req.res <- &findRedemptionResult{secret: secret, err: err}:
+	default:
+		eth.log.Info("findRedemptionResult channel blocking for request %s", secretHash)
+	}
+}
+
+// findRedemptionRequests creates a copy of the findRedemptionReqs map.
+func (eth *ExchangeWallet) findRedemptionRequests() map[[32]byte]*findRedemptionRequest {
+	eth.findRedemptionMtx.RLock()
+	defer eth.findRedemptionMtx.RUnlock()
+	reqs := make(map[[32]byte]*findRedemptionRequest, len(eth.findRedemptionReqs))
+	for secretHash, req := range eth.findRedemptionReqs {
+		reqs[secretHash] = req
+	}
+	return reqs
+}
+
 // FindRedemption watches for the input that spends the specified contract
 // coin, and returns the spending input and the contract's secret key when it
 // finds a spender.
 //
 // This method blocks until the redemption is found, an error occurs or the
 // provided context is canceled.
-func (*ExchangeWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
-	return nil, nil, asset.ErrNotImplemented
+func (eth *ExchangeWallet) FindRedemption(ctx context.Context, _, contract dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
+	contractVer, secretHash, err := dexeth.DecodeContractData(contract)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// See if it's ready right away.
+	secret, err = eth.findSecret(ctx, secretHash, contractVer)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(secret) > 0 {
+		return findRedemptionCoinID, secret, nil
+	}
+
+	// Not ready. Queue the request.
+	req := &findRedemptionRequest{
+		contractVer: contractVer,
+		res:         make(chan *findRedemptionResult, 1),
+	}
+
+	eth.findRedemptionMtx.Lock()
+
+	if eth.findRedemptionReqs[secretHash] != nil {
+		eth.findRedemptionMtx.Unlock()
+		return nil, nil, fmt.Errorf("duplicate find redemption request for %x", secretHash)
+	}
+
+	eth.findRedemptionReqs[secretHash] = req
+
+	eth.findRedemptionMtx.Unlock()
+
+	var res *findRedemptionResult
+	select {
+	case res = <-req.res:
+	case <-ctx.Done():
+	}
+
+	eth.findRedemptionMtx.Lock()
+	delete(eth.findRedemptionReqs, secretHash)
+	eth.findRedemptionMtx.Unlock()
+
+	if res == nil {
+		return nil, nil, fmt.Errorf("context cancelled for find redemption request %x", secretHash)
+	}
+
+	if res.err != nil {
+		return nil, nil, res.err
+	}
+
+	return findRedemptionCoinID, res.secret[:], nil
+}
+
+func (eth *ExchangeWallet) findSecret(ctx context.Context, secretHash [32]byte, contractVer uint32) ([]byte, error) {
+	// Add a reasonable timeout here.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	swap, err := eth.node.swap(ctx, secretHash, contractVer)
+	if err != nil {
+		return nil, err
+	}
+
+	if swap.State == dexeth.SSRefunded {
+		return nil, fmt.Errorf("swap %x is already refunded", secretHash)
+	}
+
+	if swap.State == dexeth.SSRedeemed {
+		return swap.Secret[:], nil
+	}
+
+	return nil, nil
 }
 
 // Refund refunds a contract. This can only be used after the time lock has
@@ -1044,4 +1153,17 @@ func (eth *ExchangeWallet) checkForNewBlocks() {
 	eth.log.Debugf("tip change: %d (%s) => %d (%s)", prevTip.NumberU64(),
 		prevTip.Hash(), newTip.NumberU64(), newTip.Hash())
 	go eth.tipChange(nil)
+	go eth.checkFindRedemptions()
+}
+
+// checkFindRedemptions checks queued findRedemptionRequests.
+func (eth *ExchangeWallet) checkFindRedemptions() {
+	for secretHash, req := range eth.findRedemptionRequests() {
+		secret, err := eth.findSecret(eth.ctx, secretHash, req.contractVer)
+		if err != nil {
+			eth.sendFindRedemptionResult(req, secretHash, nil, err)
+		} else if len(secret) > 0 {
+			eth.sendFindRedemptionResult(req, secretHash, secret, nil)
+		}
+	}
 }

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -2095,7 +2095,7 @@ func TestFindRedemption(t *testing.T) {
 	baseCtx := context.Background()
 
 	runTest := func(tag string, wantErr bool, initStep dexeth.SwapStep) {
-		// Check at the beginning. The queue should always be empty.
+		// The queue should always be empty.
 		eth.findRedemptionMtx.RLock()
 		reqsPending := len(eth.findRedemptionReqs) > 0
 		eth.findRedemptionMtx.RUnlock()
@@ -2154,6 +2154,12 @@ func TestFindRedemption(t *testing.T) {
 	runWithUpdate("redeemed after queuing", false, dexeth.SSInitiated, func() {
 		state.State = dexeth.SSRedeemed
 	})
+
+	// Doesn't exist
+	runTest("already refunded", true, dexeth.SSNone)
+
+	// Unknown swap state
+	runTest("already refunded", true, dexeth.SwapStep(^uint8(0)))
 
 	// Already refunded
 	runTest("already refunded", true, dexeth.SSRefunded)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -184,7 +184,7 @@ type Wallet interface {
 	// NOTE: This could potentially be a long and expensive operation if
 	// performed long after the swap is broadcast; might be better executed from
 	// a goroutine.
-	FindRedemption(ctx context.Context, coinID dex.Bytes) (redemptionCoin, secret dex.Bytes, err error)
+	FindRedemption(ctx context.Context, coinID, contract dex.Bytes) (redemptionCoin, secret dex.Bytes, err error)
 	// Refund refunds a contract. This can only be used after the time lock has
 	// expired AND if the contract has not been redeemed/refunded.
 	// NOTE: The contract cannot be retrieved from the unspent coin info

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -719,7 +719,7 @@ func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error)
 	return true, time.Now().Add(-time.Minute), nil
 }
 
-func (w *TXCWallet) FindRedemption(ctx context.Context, coinID dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
+func (w *TXCWallet) FindRedemption(ctx context.Context, coinID, _ dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
 	return nil, nil, fmt.Errorf("not mocked")
 }
 
@@ -4274,7 +4274,7 @@ func TestRefunds(t *testing.T) {
 	// We're the maker, so the init transaction should be broadcast.
 	checkStatus("maker swapped", match, order.MakerSwapCast)
 	proof := &match.MetaData.Proof
-	if !bytes.Equal(proof.Script, contract) {
+	if !bytes.Equal(proof.ContractData, contract) {
 		t.Fatalf("invalid contract recorded for Maker swap")
 	}
 
@@ -4362,7 +4362,7 @@ func TestRefunds(t *testing.T) {
 		t.Fatalf("wrong match status. wanted %v, got %v", order.TakerSwapCast, newMatchStatus)
 	}
 	tracker.mtx.RLock()
-	if !bytes.Equal(match.MetaData.Proof.Script, counterScript) {
+	if !bytes.Equal(match.MetaData.Proof.ContractData, counterScript) {
 		t.Fatalf("invalid contract recorded for Taker swap")
 	}
 	tracker.mtx.RUnlock()
@@ -5895,7 +5895,7 @@ func TestReconfigureWallet(t *testing.T) {
 		MetaMatch: db.MetaMatch{
 			MetaData: &db.MatchMetaData{
 				Proof: db.MatchProof{
-					Script: dex.Bytes{0},
+					ContractData: dex.Bytes{0},
 				},
 			},
 			UserMatch: &order.UserMatch{
@@ -6312,7 +6312,7 @@ func TestMatchStatusResolution(t *testing.T) {
 			proof.MakerSwap = tCoinID
 			proof.SecretHash = secretHash[:]
 			if isMaker {
-				proof.Script = tBytes
+				proof.ContractData = tBytes
 				proof.Secret = secret
 			} else {
 				proof.CounterContract = tBytes
@@ -6323,7 +6323,7 @@ func TestMatchStatusResolution(t *testing.T) {
 			if isMaker {
 				proof.CounterContract = tBytes
 			} else {
-				proof.Script = tBytes
+				proof.ContractData = tBytes
 			}
 		}
 		if status >= order.MakerRedeemed {

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1154,7 +1154,7 @@ func checkAndWaitForRefunds(ctx context.Context, client *tClient, orderID string
 	var furthestLockTime time.Time
 
 	hasRefundableSwap := func(match *matchTracker) bool {
-		sentSwap := match.MetaData.Proof.Script != nil
+		sentSwap := match.MetaData.Proof.ContractData != nil
 		noRedeems := match.Status < order.MakerRedeemed
 		return sentSwap && noRedeems
 	}

--- a/client/db/bolt/upgrades.go
+++ b/client/db/bolt/upgrades.go
@@ -400,7 +400,7 @@ func reloadMatchProofs(tx *bbolt.Tx, skipCancels bool, matchesBucket []byte) err
 			return nil
 		}
 		// No Script, and MatchComplete status means this is a cancel match.
-		if skipCancels && len(proof.Script) == 0 {
+		if skipCancels && len(proof.ContractData) == 0 {
 			statusB := mBkt.Get(statusKey)
 			if len(statusB) != 1 {
 				return fmt.Errorf("no match status")

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -353,7 +353,7 @@ type MatchAuth struct {
 // MatchProof is information related to the progression of the swap negotiation
 // process.
 type MatchProof struct {
-	Script          []byte
+	ContractData    []byte
 	CounterContract []byte
 	CounterTxData   []byte
 	SecretHash      []byte
@@ -387,7 +387,7 @@ func (p *MatchProof) Encode() []byte {
 	}
 
 	return versionedBytes(MatchProofVer).
-		AddData(p.Script).
+		AddData(p.ContractData).
 		AddData(p.CounterContract).
 		AddData(p.SecretHash).
 		AddData(p.Secret).
@@ -447,7 +447,7 @@ func decodeMatchProof_v2(pushes [][]byte) (*MatchProof, error) {
 			matchProofPushes, len(pushes))
 	}
 	return &MatchProof{
-		Script:          pushes[0],
+		ContractData:    pushes[0],
 		CounterContract: pushes[1],
 		CounterTxData:   pushes[21],
 		SecretHash:      pushes[2],


### PR DESCRIPTION
Add an argument for contract data. Rename `MatchProof.Script` field
to `ContractData`, for consistency. Implement redemption request queue,
analogous to btc and dcr.