### PR TITLE
[release-v0.2] maintenance backports

### DIFF
--- a/client/asset/bch/regnet_test.go
+++ b/client/asset/bch/regnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package bch

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1,3 +1,4 @@
+//go:build !harness
 // +build !harness
 
 package btc

--- a/client/asset/btc/livetest/regnet_test.go
+++ b/client/asset/btc/livetest/regnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package livetest

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1,3 +1,4 @@
+//go:build !harness
 // +build !harness
 
 package dcr

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package dcr

--- a/client/asset/ltc/regnet_test.go
+++ b/client/asset/ltc/regnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package ltc

--- a/client/cmd/dexc/version/version.go
+++ b/client/cmd/dexc/version/version.go
@@ -25,7 +25,7 @@ const (
 	AppName  string = "dexc"
 	AppMajor uint   = 0
 	AppMinor uint   = 2
-	AppPatch uint   = 2
+	AppPatch uint   = 3
 )
 
 // go build -v -ldflags "-X decred.org/dcrdex/client/cmd/dexc/version.appPreRelease= -X decred.org/dcrdex/client/cmd/dexc/version.appBuild=$(git rev-parse --short HEAD)"

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -27,7 +27,7 @@ const (
 )
 
 // The product release version.
-var version = semver{major: 0, minor: 2, patch: 2}
+var version = semver{major: 0, minor: 2, patch: 3}
 
 // semver holds dexcctl's semver values.
 type semver struct {

--- a/client/core/account.go
+++ b/client/core/account.go
@@ -55,7 +55,9 @@ func (c *Core) AccountDisable(pw []byte, addr string) error {
 	dc.cfgMtx.RUnlock()
 	// Disconnect and delete connection from map.
 	dc.connMaster.Disconnect()
+	c.connMtx.Lock()
 	delete(c.conns, dc.acct.host)
+	c.connMtx.Unlock()
 
 	return nil
 }

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -1,3 +1,4 @@
+//go:build !harness
 // +build !harness
 
 package core

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1239,8 +1239,9 @@ func (c *Core) dexConnections() []*dexConnection {
 // exchangeMap creates a map of *Exchange keyed by host, including markets and
 // orders.
 func (c *Core) exchangeMap() map[string]*Exchange {
-	infos := make(map[string]*Exchange, len(c.conns))
-	for _, dc := range c.dexConnections() {
+	dcs := c.dexConnections()
+	infos := make(map[string]*Exchange, len(dcs))
+	for _, dc := range dcs {
 		infos[dc.acct.host] = dc.exchangeInfo()
 	}
 	return infos

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1,3 +1,4 @@
+//go:build !harness
 // +build !harness
 
 package core

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1957,7 +1957,7 @@ func (t *trackedTrade) processAuditMsg(msgID uint64, audit *msgjson.Audit) error
 		err := t.auditContract(match, audit.CoinID, audit.Contract, audit.TxData)
 		if err != nil {
 			contractID := coinIDString(t.wallets.toAsset.ID, audit.CoinID)
-			t.dc.log.Error("Failed to audit contract coin %v (%s) for match %s: %v",
+			t.dc.log.Errorf("Failed to audit contract coin %v (%s) for match %s: %v",
 				contractID, t.wallets.toAsset.Symbol, match, err)
 			// Don't revoke in case server sends a revised audit request before
 			// the match is revoked.

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1,3 +1,4 @@
+//go:build harness
 // +build harness
 
 package core

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -1,6 +1,7 @@
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
+//go:build !live
 // +build !live
 
 package rpcserver

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1,4 +1,6 @@
+//go:build live
 // +build live
+
 // Run a test server with
 // go test -v -tags live -run Server -timeout 60m
 // test server will run for 1 hour and serve randomness.

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -147,6 +147,9 @@ func New(core clientCore, addr, customSiteDir string, logger dex.Logger, reloadH
 		absDir,
 		filepath.Clean(filepath.Join(execPath, "../../webserver/site")),
 	} {
+		if dir == "" {
+			continue
+		}
 		log.Debugf("Looking for site in %s", dir)
 		if folderExists(dir) {
 			siteDir = dir

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -1,3 +1,4 @@
+//go:build !live
 // +build !live
 
 package webserver

--- a/client/websocket/websocket_test.go
+++ b/client/websocket/websocket_test.go
@@ -1,3 +1,4 @@
+//go:build !live
 // +build !live
 
 package websocket

--- a/dex/testing/dcr/create-wallet.sh
+++ b/dex/testing/dcr/create-wallet.sh
@@ -13,6 +13,8 @@ HTTPPROF_PORT=$6
 WALLET_DIR="${NODES_ROOT}/${NAME}"
 mkdir -p ${WALLET_DIR}
 
+DCRWALLET=${DCRWALLET:-dcrwallet-1.6}
+
 export SHELL=$(which bash)
 
 # Connect to alpha or beta node
@@ -63,7 +65,7 @@ EOF
 # wallet ctl script
 cat > "${NODES_ROOT}/harness-ctl/${NAME}" <<EOF
 #!/usr/bin/env bash
-dcrctl -C "${WALLET_DIR}/${NAME}-ctl.conf" --wallet \$*
+${DCRCTL} -C "${WALLET_DIR}/${NAME}-ctl.conf" --wallet \$*
 EOF
 chmod +x "${NODES_ROOT}/harness-ctl/${NAME}"
 
@@ -81,8 +83,8 @@ tmux send-keys -t $TMUX_WIN_ID "set +o history" C-m
 tmux send-keys -t $TMUX_WIN_ID "cd ${WALLET_DIR}" C-m
 
 echo "Creating simnet ${NAME} wallet"
-tmux send-keys -t $TMUX_WIN_ID "dcrwallet -C ${NAME}.conf --create < wallet.answers; tmux wait-for -S ${NAME}" C-m
+tmux send-keys -t $TMUX_WIN_ID "${DCRWALLET} -C ${NAME}.conf --create < wallet.answers; tmux wait-for -S ${NAME}" C-m
 tmux wait-for ${NAME}
 
 echo "Starting simnet ${NAME} wallet"
-tmux send-keys -t $TMUX_WIN_ID "dcrwallet -C ${NAME}.conf" C-m
+tmux send-keys -t $TMUX_WIN_ID "${DCRWALLET} -C ${NAME}.conf" C-m

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -29,6 +29,10 @@ TRADING_WALLET2_PORT="19582"
 # wait for process termination.
 WAIT="; tmux wait-for -S donedcr"
 
+DCRD=${DCRD:-dcrd-1.6}
+DCRCTL=${DCRCTL:-dcrctl-1.6}
+export DCRCTL
+
 NODES_ROOT=~/dextest/dcr
 export NODES_ROOT
 
@@ -83,9 +87,9 @@ NUM=1
       *) NUM=\$1 ;;
   esac
   for i in \$(seq \$NUM) ; do
-    dcrctl -C ${NODES_ROOT}/alpha/alpha-ctl.conf regentemplate
+    ${DCRCTL} -C ${NODES_ROOT}/alpha/alpha-ctl.conf regentemplate
     sleep 0.05
-    dcrctl -C ${NODES_ROOT}/alpha/alpha-ctl.conf generate 1
+    ${DCRCTL} -C ${NODES_ROOT}/alpha/alpha-ctl.conf generate 1
     if [ $i != $NUM ]; then
       sleep ${MINE_SLEEP}
     fi
@@ -102,9 +106,9 @@ NUM=1
       *) NUM=\$1 ;;
   esac
   for i in \$(seq \$NUM) ; do
-    dcrctl -C ${NODES_ROOT}/beta/beta-ctl.conf regentemplate
+    ${DCRCTL} -C ${NODES_ROOT}/beta/beta-ctl.conf regentemplate
     sleep 0.05
-    dcrctl -C ${NODES_ROOT}/beta/beta-ctl.conf generate 1
+    ${DCRCTL} -C ${NODES_ROOT}/beta/beta-ctl.conf generate 1
     if [ $i != $NUM ]; then
       sleep ${MINE_SLEEP}
     fi
@@ -186,7 +190,7 @@ tmux send-keys -t $SESSION:1 "set +o history" C-m
 tmux send-keys -t $SESSION:1 "cd ${NODES_ROOT}/alpha" C-m
 
 echo "Starting simnet alpha node (txindex for server)"
-tmux send-keys -t $SESSION:1 "dcrd --appdata=${NODES_ROOT}/alpha \
+tmux send-keys -t $SESSION:1 "${DCRD} --appdata=${NODES_ROOT}/alpha \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --miningaddr=${ALPHA_MINING_ADDR} --rpclisten=:${ALPHA_RPC_PORT} \
 --txindex --listen=:${ALPHA_NODE_PORT} \
@@ -199,7 +203,7 @@ tmux send-keys -t $SESSION:2 "set +o history" C-m
 tmux send-keys -t $SESSION:2 "cd ${NODES_ROOT}/beta" C-m
 
 echo "Starting simnet beta node (no txindex for a typical client)"
-tmux send-keys -t $SESSION:2 "dcrd --appdata=${NODES_ROOT}/beta \
+tmux send-keys -t $SESSION:2 "${DCRD} --appdata=${NODES_ROOT}/beta \
 --rpcuser=${RPC_USER} --rpcpass=${RPC_PASS} \
 --listen=:${BETA_NODE_PORT} --rpclisten=:${BETA_RPC_PORT} \
 --miningaddr=${BETA_MINING_ADDR} \

--- a/pkg.sh
+++ b/pkg.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VER="v0.2.2"
+VER="v0.2.3"
 
 rm -rf bin
 mkdir -p bin/dexc-windows-amd64-${VER}

--- a/server/asset/bch/live_test.go
+++ b/server/asset/bch/live_test.go
@@ -1,4 +1,6 @@
+//go:build bchlive
 // +build bchlive
+
 //
 // go test -v -tags bchlive -run UTXOStats
 // -----------------------------------

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -867,7 +867,7 @@ func (btc *Backend) auditContract(contract *Output) (*asset.Contract, error) {
 	if !bytes.Equal(hashed, scriptHash) {
 		return nil, fmt.Errorf("swap contract hash mismatch for %s:%d", tx.hash, contract.vout)
 	}
-	_, receiver, lockTime, _, err := dexbtc.ExtractSwapDetails(contract.redeemScript, contract.btc.segwit, contract.btc.chainParams)
+	_, receiver, lockTime, secretHash, err := dexbtc.ExtractSwapDetails(contract.redeemScript, contract.btc.segwit, contract.btc.chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing swap contract for %s:%d: %w", tx.hash, contract.vout, err)
 	}
@@ -875,6 +875,7 @@ func (btc *Backend) auditContract(contract *Output) (*asset.Contract, error) {
 		Coin:         contract,
 		SwapAddress:  receiver.String(),
 		RedeemScript: contract.redeemScript,
+		SecretHash:   secretHash,
 		LockTime:     time.Unix(int64(lockTime), 0),
 		TxData:       contract.tx.raw,
 	}, nil

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -1,4 +1,6 @@
+//go:build !btclive
 // +build !btclive
+
 //
 // These tests will not be run if the btclive build tag is set. In that case,
 // the live_test.go tests will run.

--- a/server/asset/btc/live_test.go
+++ b/server/asset/btc/live_test.go
@@ -1,4 +1,6 @@
+//go:build btclive
 // +build btclive
+
 //
 // Since at least one live test runs for an hour, you should run live tests
 // individually using the -run flag. All of these tests will only run with the

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -108,6 +108,9 @@ type Contract struct {
 	SwapAddress string
 	// RedeemScript is the contract redeem script.
 	RedeemScript []byte
+	// SecretHash is the secret key hash used for this swap. This is extracted
+	// from the RedeemScript and is provided here for convenience.
+	SecretHash []byte
 	// LockTime is the refund locktime.
 	LockTime time.Time
 	// TxData is raw transaction data. This data is provided for some assets

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -1,4 +1,6 @@
+//go:build !dcrlive
 // +build !dcrlive
+
 //
 // These tests will not be run if the dcrlive build tag is set.
 

--- a/server/asset/dcr/live_test.go
+++ b/server/asset/dcr/live_test.go
@@ -1,4 +1,6 @@
+//go:build dcrlive
 // +build dcrlive
+
 //
 // Since at least one live test runs for an hour, you should run live tests
 // individually using the -run flag. All of these tests will only run with the

--- a/server/asset/dcr/utxo.go
+++ b/server/asset/dcr/utxo.go
@@ -390,7 +390,7 @@ func auditContract(op *Output) (*asset.Contract, error) {
 	if !bytes.Equal(dcrutil.Hash160(op.redeemScript), scriptHash) {
 		return nil, fmt.Errorf("swap contract hash mismatch for %s:%d", tx.hash, op.vout)
 	}
-	_, receiver, lockTime, _, err := dexdcr.ExtractSwapDetails(op.redeemScript, chainParams)
+	_, receiver, lockTime, secretHash, err := dexdcr.ExtractSwapDetails(op.redeemScript, chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing swap contract for %s:%d: %w", tx.hash, op.vout, err)
 	}
@@ -398,6 +398,7 @@ func auditContract(op *Output) (*asset.Contract, error) {
 		Coin:         op,
 		SwapAddress:  receiver.String(),
 		RedeemScript: op.redeemScript,
+		SecretHash:   secretHash,
 		LockTime:     time.Unix(int64(lockTime), 0),
 		TxData:       op.tx.raw,
 	}, nil

--- a/server/asset/ltc/live_test.go
+++ b/server/asset/ltc/live_test.go
@@ -1,4 +1,6 @@
+//go:build ltclive
 // +build ltclive
+
 //
 // go test -v -tags ltclive -run UTXOStats
 // -----------------------------------

--- a/server/cmd/dcrdex/version.go
+++ b/server/cmd/dcrdex/version.go
@@ -25,7 +25,7 @@ const (
 	AppName  string = "dcrdex"
 	AppMajor uint   = 0
 	AppMinor uint   = 2
-	AppPatch uint   = 2
+	AppPatch uint   = 3
 )
 
 // go build -v -ldflags "-X main.appPreRelease= -X main.appBuild=$(git rev-parse --short HEAD)"

--- a/server/db/driver/pg/accounts_online_test.go
+++ b/server/db/driver/pg/accounts_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -62,9 +62,6 @@ const (
 	RetrieveMatchStatsByEpoch = `SELECT quantity, rate, takerSell FROM %s
 		WHERE takerSell IS NOT NULL AND epochIdx = $1 AND epochDur = $2;`
 
-	AddMatchesForgivenColumn = `ALTER TABLE %s
-		ADD COLUMN IF NOT EXISTS forgiven BOOL;`
-
 	RetrieveSwapData = `SELECT status, sigMatchAckMaker, sigMatchAckTaker,
 		aContractCoinID, aContract, aContractTime, bSigAckOfAContract,
 		bContractCoinID, bContract, bContractTime, aSigAckOfBContract,

--- a/server/db/driver/pg/markets.go
+++ b/server/db/driver/pg/markets.go
@@ -59,19 +59,12 @@ func newMarket(db *sql.DB, marketsTableName string, mkt *dex.MarketInfo) error {
 	return nil
 }
 
-// Basic idempotent table alteration queries for existing markets tables with a
-// printf specifier for full name of the targeted table. Remove this when scheme
-// versioning and upgrades are implemented (and v1 has the changes already).
-var marketTablesUpdates = map[string]string{
-	matchesTableName: internal.AddMatchesForgivenColumn,
-}
-
 func createMarketTables(db *sql.DB, marketUID string) error {
-	created, err := createSchema(db, marketUID)
+	newMarket, err := createSchema(db, marketUID)
 	if err != nil {
 		return err
 	}
-	if created {
+	if newMarket {
 		log.Debugf("Created new market schema %q", marketUID)
 	} else {
 		log.Tracef("Market schema %q already exists.", marketUID)
@@ -82,17 +75,9 @@ func createMarketTables(db *sql.DB, marketUID string) error {
 		if err != nil {
 			return err
 		}
-		if newTable {
-			if !created {
-				log.Warnf(`Created missing table "%s" for existing market %s.`,
-					c.name, marketUID)
-			}
-		} else if update, found := marketTablesUpdates[c.name]; found {
-			// Remove this with actual upgrades.
-			nameSpacedTable := marketUID + "." + c.name
-			if _, err = db.Exec(fmt.Sprintf(update, nameSpacedTable)); err != nil {
-				return fmt.Errorf("failed to update table %v: %w", nameSpacedTable, err)
-			}
+		if newTable && !newMarket {
+			log.Warnf(`Created missing table "%s" for existing market %s.`,
+				c.name, marketUID)
 		}
 	}
 

--- a/server/db/driver/pg/matches_online_test.go
+++ b/server/db/driver/pg/matches_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/orders_online_test.go
+++ b/server/db/driver/pg/orders_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/orders_test.go
+++ b/server/db/driver/pg/orders_test.go
@@ -1,3 +1,4 @@
+//go:build !pgonline
 // +build !pgonline
 
 // This code is available on the terms of the project LICENSE.md file,

--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/tables_online_test.go
+++ b/server/db/driver/pg/tables_online_test.go
@@ -1,3 +1,4 @@
+//go:build pgonline
 // +build pgonline
 
 package pg

--- a/server/db/driver/pg/upgrades_test.go
+++ b/server/db/driver/pg/upgrades_test.go
@@ -1,4 +1,6 @@
+//go:build pgonline
 // +build pgonline
+
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -192,6 +192,26 @@ func NewMarket(cfg *Config) (*Market, error) {
 		bookOrdersByID[ord.ID()] = ord
 	}
 
+	// "execute" any epoch orders in DB that may be left over from unclean
+	// shutdown. Whatever epoch they were in will not be seen again.
+	epochOrders, err := storage.EpochOrders(base, quote)
+	if err != nil {
+		return nil, err
+	}
+	for _, ord := range epochOrders {
+		oid := ord.ID()
+		log.Infof("Dropping old epoch order %v", oid)
+		if co, ok := ord.(*order.CancelOrder); ok {
+			if err := storage.FailCancelOrder(co); err != nil {
+				log.Errorf("Failed to set orphaned epoch cancel order %v as executed: %v", oid, err)
+			}
+			continue
+		}
+		if err := storage.ExecuteOrder(ord); err != nil {
+			log.Errorf("Failed to set orphaned epoch trade order %v as executed: %v", oid, err)
+		}
+	}
+
 	baseCoins := make(map[order.OrderID][]order.CoinID)
 	quoteCoins := make(map[order.OrderID][]order.CoinID)
 

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -570,7 +570,7 @@ func (r *OrderRouter) handleMarket(user account.AccountID, msg *msgjson.Message)
 			buyBuffer := tunnel.MarketBuyBuffer()
 			lotWithBuffer := uint64(float64(assets.base.LotSize) * buyBuffer)
 			minReq := matcher.BaseToQuote(midGap, lotWithBuffer)
-			reqVal = calc.RequiredOrderFunds(minReq, uint64(spendSize), 1, &assets.base.Asset)
+			reqVal = calc.RequiredOrderFunds(minReq, uint64(spendSize), 1, &assets.funding.Asset)
 
 			if market.Quantity < minReq {
 				errStr := fmt.Sprintf("order quantity does not satisfy market buy buffer. %d < %d. midGap = %d", market.Quantity, minReq, midGap)

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1272,9 +1272,15 @@ func (s *Swapper) processInit(msg *msgjson.Message, params *msgjson.Init, stepIn
 			fmt.Sprintf("contract error. expected contract value to be %d, got %d", stepInfo.checkVal, contract.Value()))
 		return wait.DontTryAgain
 	}
+	if !actor.isMaker && !bytes.Equal(contract.SecretHash, counterParty.status.swap.SecretHash) {
+		s.respondError(msg.ID, actor.user, msgjson.ContractError,
+			fmt.Sprintf("incorrect secret hash. expected %x. got %x",
+				contract.SecretHash, counterParty.status.swap.SecretHash))
+		return wait.DontTryAgain
+	}
 
 	reqLockTime := encode.DropMilliseconds(stepInfo.match.matchTime.Add(s.lockTimeTaker))
-	if stepInfo.actor.isMaker {
+	if actor.isMaker {
 		reqLockTime = encode.DropMilliseconds(stepInfo.match.matchTime.Add(s.lockTimeMaker))
 	}
 	if contract.LockTime.Before(reqLockTime) {


### PR DESCRIPTION
Since both the v0.3 and v0.4 stable branches of dcrdex are targeting the unreleased Decred 1.7 (dcrd/dcrwallet), this cherry-picks a handful of minor bug fixes for the 0.2 release branch.

- pg: remove old pseudo-upgrade (https://github.com/decred/dcrdex/pull/1226)
- client/webserver: do not check empty CustomSiteDir (https://github.com/decred/dcrdex/pull/1253)
- Update go:build tags and log more init data (https://github.com/decred/dcrdex/pull/1161)
- fix conns data races (https://github.com/decred/dcrdex/pull/1280)
- server/market: fix wrong asset for RequiredOrderFunds on market-buy (https://github.com/decred/dcrdex/pull/1323)

This also adds two new commits to facilitate this backporting:
- dcr harness: allow specifying binary paths (e.g. `DCRD=dcrd-1.6 DCRWALLET=dcrwallet-1.6 ./harness.sh`)
- bump versions to v0.2.3 in the applications and in the packaging script