### PR TITLE
eth: Versionize tx data handling

### DIFF
--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -11,7 +11,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"math/big"
-	"strings"
 	"time"
 
 	"decred.org/dcrdex/client/asset"
@@ -60,7 +59,7 @@ type contractV0 interface {
 // Redeem and Refund methods of swapv0.ETHSwap already have suitable return types.
 type contractorV0 struct {
 	contractV0   // *swapv0.ETHSwap
-	abi          abi.ABI
+	abi          *abi.ABI
 	ec           *ethclient.Client
 	contractAddr common.Address
 	acctAddr     common.Address
@@ -75,13 +74,9 @@ func newV0contractor(net dex.Network, acctAddr common.Address, ec *ethclient.Cli
 	if err != nil {
 		return nil, err
 	}
-	parsedABI, err := abi.JSON(strings.NewReader(swapv0.ETHSwapABI))
-	if err != nil {
-		return nil, err
-	}
 	return &contractorV0{
 		contractV0:   c,
-		abi:          parsedABI,
+		abi:          dexeth.ABIs[0],
 		ec:           ec,
 		contractAddr: contractAddr,
 		acctAddr:     acctAddr,

--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -239,7 +239,7 @@ func (c *contractorV0) incomingValue(ctx context.Context, tx *types.Transaction)
 	if *tx.To() != c.contractAddr {
 		return 0, nil
 	}
-	if redeems, err := dexeth.ParseRedeemData(tx.Data()); err == nil {
+	if redeems, err := dexeth.ParseRedeemData(tx.Data(), 0); err == nil {
 		var redeemed uint64
 		for _, redeem := range redeems {
 			swap, err := c.swap(ctx, redeem.SecretHash)
@@ -250,7 +250,7 @@ func (c *contractorV0) incomingValue(ctx context.Context, tx *types.Transaction)
 		}
 		return redeemed, nil
 	}
-	secretHash, err := dexeth.ParseRefundData(tx.Data())
+	secretHash, err := dexeth.ParseRefundData(tx.Data(), 0)
 	if err != nil {
 		return 0, nil
 	}

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -797,14 +797,9 @@ func (eth *ExchangeWallet) AuditContract(coinID, contract, txData dex.Bytes, reb
 	if err != nil {
 		return nil, fmt.Errorf("AuditContract: failed to parse initiate data: %w", err)
 	}
-	var initiation *dexeth.Initiation
-	for _, init := range initiations {
-		if init.SecretHash == secretHash {
-			initiation = init
-			break
-		}
-	}
-	if initiation == nil {
+
+	initiation, ok := initiations[secretHash]
+	if !ok {
 		return nil, errors.New("AuditContract: tx does not initiate secret hash")
 	}
 

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -800,7 +800,7 @@ func (eth *ExchangeWallet) AuditContract(coinID, contract, txData dex.Bytes, reb
 	var initiation *dexeth.Initiation
 	for _, init := range initiations {
 		if init.SecretHash == secretHash {
-			initiation = &init
+			initiation = init
 			break
 		}
 	}

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1553,7 +1553,7 @@ func TestAuditContract(t *testing.T) {
 	tests := []struct {
 		name           string
 		contract       dex.Bytes
-		initiations    []dexeth.Initiation
+		initiations    []*dexeth.Initiation
 		differentHash  bool
 		badTxData      bool
 		badTxBinary    bool
@@ -1564,14 +1564,14 @@ func TestAuditContract(t *testing.T) {
 		{
 			name:     "ok",
 			contract: dexeth.EncodeContractData(0, secretHashes[1]),
-			initiations: []dexeth.Initiation{
-				dexeth.Initiation{
+			initiations: []*dexeth.Initiation{
+				&dexeth.Initiation{
 					LockTime:    now,
 					SecretHash:  secretHashes[0],
 					Participant: testAddressA,
 					Value:       1,
 				},
-				dexeth.Initiation{
+				&dexeth.Initiation{
 					LockTime:    laterThanNow,
 					SecretHash:  secretHashes[1],
 					Participant: testAddressB,
@@ -1584,8 +1584,8 @@ func TestAuditContract(t *testing.T) {
 		{
 			name:     "coin id different than tx hash",
 			contract: dexeth.EncodeContractData(0, secretHashes[0]),
-			initiations: []dexeth.Initiation{
-				dexeth.Initiation{
+			initiations: []*dexeth.Initiation{
+				&dexeth.Initiation{
 					LockTime:    now,
 					SecretHash:  secretHashes[0],
 					Participant: testAddressA,
@@ -1603,14 +1603,14 @@ func TestAuditContract(t *testing.T) {
 		{
 			name:     "contract not part of transaction",
 			contract: dexeth.EncodeContractData(0, secretHashes[2]),
-			initiations: []dexeth.Initiation{
-				dexeth.Initiation{
+			initiations: []*dexeth.Initiation{
+				&dexeth.Initiation{
 					LockTime:    now,
 					SecretHash:  secretHashes[0],
 					Participant: testAddressA,
 					Value:       1,
 				},
-				dexeth.Initiation{
+				&dexeth.Initiation{
 					LockTime:    laterThanNow,
 					SecretHash:  secretHashes[1],
 					Participant: testAddressB,
@@ -1628,14 +1628,14 @@ func TestAuditContract(t *testing.T) {
 		{
 			name:     "cannot unmarshal tx binary",
 			contract: dexeth.EncodeContractData(0, secretHashes[1]),
-			initiations: []dexeth.Initiation{
-				dexeth.Initiation{
+			initiations: []*dexeth.Initiation{
+				&dexeth.Initiation{
 					LockTime:    now,
 					SecretHash:  secretHashes[0],
 					Participant: testAddressA,
 					Value:       1,
 				},
-				dexeth.Initiation{
+				&dexeth.Initiation{
 					LockTime:    laterThanNow,
 					SecretHash:  secretHashes[1],
 					Participant: testAddressB,

--- a/dex/networks/eth/abi_test.go
+++ b/dex/networks/eth/abi_test.go
@@ -17,8 +17,9 @@
 //go:build lgpl
 // +build lgpl
 
-// This file lifted verbatim from go-ethereum/signer/fourbyte at v1.10.6 commit
-// 576681f29b895dd39e559b7ba17fcd89b42e4833.
+// This file lifted from go-ethereum/signer/fourbyte at v1.10.6 commit
+// 576681f29b895dd39e559b7ba17fcd89b42e4833 and modified to make parseCalldata take
+// an abi instead of a string.
 package eth
 
 import (
@@ -133,7 +134,11 @@ func TestCalldataDecoding(t *testing.T) {
 		// contains a bool with illegal values
 		"a5643bf20000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000464617665000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003",
 	} {
-		_, err := parseCallData(common.Hex2Bytes(hexdata), jsondata)
+		abi, err := abi.JSON(strings.NewReader(jsondata))
+		if err != nil {
+			t.Errorf("test %d: failed to parse abi: %v", i, err)
+		}
+		_, err = parseCallData(common.Hex2Bytes(hexdata), &abi)
 		if err == nil {
 			t.Errorf("test %d: expected decoding to fail: %s", i, hexdata)
 		}
@@ -156,7 +161,11 @@ func TestCalldataDecoding(t *testing.T) {
 			"000000000000000000000000000000000000000000000000000000000000dead" +
 			"000000000000000000000000000000000000000000000000000000000000beef",
 	} {
-		_, err := parseCallData(common.Hex2Bytes(hexdata), jsondata)
+		abi, err := abi.JSON(strings.NewReader(jsondata))
+		if err != nil {
+			t.Errorf("test %d: failed to parse abi: %v", i, err)
+		}
+		_, err = parseCallData(common.Hex2Bytes(hexdata), &abi)
 		if err != nil {
 			t.Errorf("test %d: unexpected failure on input %s:\n %v (%d bytes) ", i, hexdata, err, len(common.Hex2Bytes(hexdata)))
 		}

--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -189,7 +189,7 @@ type Initiation struct {
 	LockTime    time.Time
 	SecretHash  [32]byte
 	Participant common.Address
-	Value       uint64
+	Value       uint64 // gwei
 }
 
 // Redemption is the data used to redeem a swap.

--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -183,3 +183,17 @@ type SwapState struct {
 	Value       uint64
 	State       SwapStep
 }
+
+// Initiation is the data used to initiate a swap.
+type Initiation struct {
+	LockTime    time.Time
+	SecretHash  [32]byte
+	Participant common.Address
+	Value       uint64
+}
+
+// Redemption is the data used to redeem a swap.
+type Redemption struct {
+	Secret     [32]byte
+	SecretHash [32]byte
+}

--- a/dex/networks/eth/txdata.go
+++ b/dex/networks/eth/txdata.go
@@ -10,40 +10,128 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	swapv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const (
-	initiateFuncName = "initiate"
-	numInputArgs     = 1
-	redeemFuncName   = "redeem"
-	numRedeemArgs    = 1
-	refundFuncName   = "refund"
-	numRefundArgs    = 1
-)
+// ParseRefundData parses the calldata used to call the initiate function of a
+// specific version of the swap contract. It returns the the list of initiations
+// done in the call and errors if the call data does not call initiate with expected
+// argument types.
+func ParseInitiateData(calldata []byte, contractVersion uint32) ([]Initiation, error) {
+	txDataHandler, ok := txDataHandlers[contractVersion]
+	if !ok {
+		return nil, fmt.Errorf("contract version %v does not exist", contractVersion)
+	}
 
-// ParseInitiateData accepts call data from a transaction that pays to a
-// contract with extra data. It will error if the call data does not call
-// initiate with expected argument types. It returns the array of initiations
-// with which initiate was called.
-func ParseInitiateData(calldata []byte) ([]swapv0.ETHSwapInitiation, error) {
+	return txDataHandler.parseInitiateData(calldata)
+}
+
+// ParseRefundData parses the calldata used to call the redem function of a
+// specific version of the swap contract. It returns the the list of redemptions
+// done in the call and errors if the call data does not call redeem with expected
+// argument types.
+func ParseRedeemData(calldata []byte, contractVersion uint32) ([]Redemption, error) {
+	txDataHandler, ok := txDataHandlers[contractVersion]
+	if !ok {
+		return nil, fmt.Errorf("contract version %v does not exist", contractVersion)
+	}
+
+	return txDataHandler.parseRedeemData(calldata)
+}
+
+// ParseRefundData parses the calldata used to call the refund function of a
+// specific version of the swap contract. It returns the secret hash and errors
+// if the call data does not call refund with expected argument types.
+func ParseRefundData(calldata []byte, contractVersion uint32) ([32]byte, error) {
+	txDataHandler, ok := txDataHandlers[contractVersion]
+	if !ok {
+		return [32]byte{}, fmt.Errorf("contract version %v does not exist", contractVersion)
+	}
+
+	return txDataHandler.parseRefundData(calldata)
+}
+
+// PackInitiateData converts a list of Initiation to the call data for the
+// initiate function for the contract specified by contractVersion.
+func PackInitiateData(initiations []Initiation, contractVersion uint32) ([]byte, error) {
+	txDataHandler, ok := txDataHandlers[contractVersion]
+	if !ok {
+		return nil, fmt.Errorf("contract version %v does not exist", contractVersion)
+	}
+
+	return txDataHandler.packInitiateData(initiations)
+}
+
+// PackRedeemData converts a list of Redemption to the call data for the
+// redeem function for the contract specified by contractVersion.
+func PackRedeemData(redemptions []Redemption, contractVersion uint32) ([]byte, error) {
+	txDataHandler, ok := txDataHandlers[contractVersion]
+	if !ok {
+		return nil, fmt.Errorf("contract version %v does not exist", contractVersion)
+	}
+
+	return txDataHandler.packRedeemData(redemptions)
+}
+
+// PackInitiateData converts a secret hash to the call data for the
+// refund function for the contract specified by contractVersion.
+func PackRefundData(secretHash [32]byte, contractVersion uint32) ([]byte, error) {
+	txDataHandler, ok := txDataHandlers[contractVersion]
+	if !ok {
+		return nil, fmt.Errorf("contract version %v does not exist", contractVersion)
+	}
+
+	return txDataHandler.packRefundData(secretHash)
+}
+
+var txDataHandlers = map[uint32]txDataHandler{
+	0: &txDataHandlerV0{
+		initiateFuncName: "initiate",
+		redeemFuncName:   "redeem",
+		refundFuncName:   "refund",
+		numInputArgs:     1,
+		numRedeemArgs:    1,
+		numRefundArgs:    1,
+	},
+}
+
+type txDataHandler interface {
+	parseInitiateData([]byte) ([]Initiation, error)
+	parseRedeemData([]byte) ([]Redemption, error)
+	parseRefundData([]byte) ([32]byte, error)
+	packInitiateData([]Initiation) ([]byte, error)
+	packRedeemData([]Redemption) ([]byte, error)
+	packRefundData([32]byte) ([]byte, error)
+}
+
+type txDataHandlerV0 struct {
+	initiateFuncName string
+	redeemFuncName   string
+	refundFuncName   string
+	numInputArgs     int
+	numRedeemArgs    int
+	numRefundArgs    int
+}
+
+func (t *txDataHandlerV0) parseInitiateData(calldata []byte) ([]Initiation, error) {
 	decoded, err := parseCallData(calldata, swapv0.ETHSwapABI)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse call data: %v", err)
 	}
-	if decoded.name != initiateFuncName {
-		return nil, fmt.Errorf("expected %v function but got %v", initiateFuncName, decoded.name)
+	if decoded.name != t.initiateFuncName {
+		return nil, fmt.Errorf("expected %v function but got %v", t.initiateFuncName, decoded.name)
 	}
 	args := decoded.inputs
 	// Any difference in number of args and types than what we expect
 	// should be caught by parseCallData, but checking again anyway.
 	//
 	// TODO: If any of the checks prove redundant, remove them.
-	if len(args) != numInputArgs {
-		return nil, fmt.Errorf("expected %v input args but got %v", numInputArgs, len(args))
+	if len(args) != t.numInputArgs {
+		return nil, fmt.Errorf("expected %v input args but got %v", t.numInputArgs, len(args))
 	}
 	initiations, ok := args[0].value.([]struct {
 		RefundTimestamp *big.Int       `json:"refundTimestamp"`
@@ -55,33 +143,45 @@ func ParseInitiateData(calldata []byte) ([]swapv0.ETHSwapInitiation, error) {
 		return nil, fmt.Errorf("expected first arg of type []swapv0.ETHSwapInitiation but got %T", args[0].value)
 	}
 
-	toReturn := make([]swapv0.ETHSwapInitiation, 0, len(initiations))
+	// This is done for the compiler to ensure that the type defined above and swapv0.ETHSwapInitiation
+	// are the same, other than the tags.
+	if len(initiations) > 0 {
+		_ = swapv0.ETHSwapInitiation(initiations[0])
+	}
+
+	toReturn := make([]Initiation, 0, len(initiations))
 	for _, init := range initiations {
-		toReturn = append(toReturn, swapv0.ETHSwapInitiation(init))
+		gweiValue, err := ToGwei(init.Value)
+		if err != nil {
+			return nil, fmt.Errorf("cannot convert wei to gwei: %w", err)
+		}
+
+		toReturn = append(toReturn, Initiation{
+			LockTime:    time.Unix(init.RefundTimestamp.Int64(), 0),
+			SecretHash:  init.SecretHash,
+			Participant: init.Participant,
+			Value:       gweiValue,
+		})
 	}
 
 	return toReturn, nil
 }
 
-// ParseRedeemData accepts call data from a transaction that pays to a
-// contract with extra data. It will error if the call data does not call
-// redeem with expected argument types. It returns the secret and secret hash
-// in that order.
-func ParseRedeemData(calldata []byte) ([]swapv0.ETHSwapRedemption, error) {
+func (t *txDataHandlerV0) parseRedeemData(calldata []byte) ([]Redemption, error) {
 	decoded, err := parseCallData(calldata, swapv0.ETHSwapABI)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse call data: %v", err)
 	}
-	if decoded.name != redeemFuncName {
-		return nil, fmt.Errorf("expected %v function but got %v", redeemFuncName, decoded.name)
+	if decoded.name != t.redeemFuncName {
+		return nil, fmt.Errorf("expected %v function but got %v", t.redeemFuncName, decoded.name)
 	}
 	args := decoded.inputs
 	// Any difference in number of args and types than what we expect
 	// should be caught by parseCallData, but checking again anyway.
 	//
 	// TODO: If any of the checks prove redundant, remove them.
-	if len(args) != numRedeemArgs {
-		return nil, fmt.Errorf("expected %v redeem args but got %v", numRedeemArgs, len(args))
+	if len(args) != t.numRedeemArgs {
+		return nil, fmt.Errorf("expected %v redeem args but got %v", t.numRedeemArgs, len(args))
 	}
 	redemptions, ok := args[0].value.([]struct {
 		Secret     [32]byte `json:"secret"`
@@ -90,35 +190,41 @@ func ParseRedeemData(calldata []byte) ([]swapv0.ETHSwapRedemption, error) {
 	if !ok {
 		return nil, fmt.Errorf("expected first arg of type []swapv0.ETHSwapRedemption but got %T", args[0].value)
 	}
-	toReturn := make([]swapv0.ETHSwapRedemption, 0, len(redemptions))
+
+	// This is done for the compiler to ensure that the type defined above and swapv0.ETHSwapInitiation
+	// are the same, other than the tags.
+	if len(redemptions) > 0 {
+		_ = swapv0.ETHSwapRedemption(redemptions[0])
+	}
+
+	toReturn := make([]Redemption, 0, len(redemptions))
 	for _, redemption := range redemptions {
-		toReturn = append(toReturn, swapv0.ETHSwapRedemption(redemption))
+		toReturn = append(toReturn, Redemption{
+			SecretHash: redemption.SecretHash,
+			Secret:     redemption.Secret,
+		})
 	}
 
 	return toReturn, nil
 }
 
-// ParseRedeemData accepts call data from a transaction that pays to a
-// contract with extra data. It will error if the call data does not call
-// redeem with expected argument types. It returns the secret and secret hash
-// in that order.
-func ParseRefundData(calldata []byte) ([32]byte, error) {
+func (t *txDataHandlerV0) parseRefundData(calldata []byte) ([32]byte, error) {
 	var secretHash [32]byte
 
 	decoded, err := parseCallData(calldata, swapv0.ETHSwapABI)
 	if err != nil {
 		return secretHash, fmt.Errorf("unable to parse call data: %v", err)
 	}
-	if decoded.name != refundFuncName {
-		return secretHash, fmt.Errorf("expected %v function but got %v", refundFuncName, decoded.name)
+	if decoded.name != t.refundFuncName {
+		return secretHash, fmt.Errorf("expected %v function but got %v", t.refundFuncName, decoded.name)
 	}
 	args := decoded.inputs
 	// Any difference in number of args and types than what we expect
 	// should be caught by parseCallData, but checking again anyway.
 	//
 	// TODO: If any of the checks prove redundant, remove them.
-	if len(args) != numRedeemArgs {
-		return secretHash, fmt.Errorf("expected %v redeem args but got %v", numRedeemArgs, len(args))
+	if len(args) != t.numRedeemArgs {
+		return secretHash, fmt.Errorf("expected %v redeem args but got %v", t.numRedeemArgs, len(args))
 	}
 	secretHash, ok := args[0].value.([32]byte)
 	if !ok {
@@ -128,31 +234,44 @@ func ParseRefundData(calldata []byte) ([32]byte, error) {
 	return secretHash, nil
 }
 
-// PackInitiateData converts a list of swapv0.ETHSwapInitiation to call data for the
-// initiate function.
-func PackInitiateData(initiations []swapv0.ETHSwapInitiation) ([]byte, error) {
+// packInitiateData converts a list of Initiate to call data for the initiate function.
+func (t *txDataHandlerV0) packInitiateData(initiations []Initiation) ([]byte, error) {
 	parsedAbi, err := abi.JSON(strings.NewReader(swapv0.ETHSwapABI))
 	if err != nil {
 		return nil, err
 	}
-	return parsedAbi.Pack(initiateFuncName, initiations)
+	abiInitiations := make([]swapv0.ETHSwapInitiation, 0, len(initiations))
+	for _, init := range initiations {
+		bigVal := new(big.Int).SetUint64(init.Value)
+		abiInitiations = append(abiInitiations, swapv0.ETHSwapInitiation{
+			RefundTimestamp: big.NewInt(init.LockTime.Unix()),
+			SecretHash:      init.SecretHash,
+			Participant:     init.Participant,
+			Value:           new(big.Int).Mul(bigVal, BigGweiFactor),
+		})
+	}
+	return parsedAbi.Pack(t.initiateFuncName, abiInitiations)
 }
 
-// PackRedeemData converts a list of swapv0.ETHSwapRedemption to call data for the
-// redeem function.
-func PackRedeemData(redemptions []swapv0.ETHSwapRedemption) ([]byte, error) {
+func (t *txDataHandlerV0) packRedeemData(redemptions []Redemption) ([]byte, error) {
 	parsedAbi, err := abi.JSON(strings.NewReader(swapv0.ETHSwapABI))
 	if err != nil {
 		return nil, err
 	}
-	return parsedAbi.Pack(redeemFuncName, redemptions)
+	abiRedemptions := make([]swapv0.ETHSwapRedemption, 0, len(redemptions))
+	for _, redeem := range redemptions {
+		abiRedemptions = append(abiRedemptions, swapv0.ETHSwapRedemption{
+			Secret:     redeem.Secret,
+			SecretHash: redeem.SecretHash,
+		})
+	}
+	return parsedAbi.Pack(t.redeemFuncName, abiRedemptions)
 }
 
-// PackRedeemData converts a secret hash to call data for the refund function.
-func PackRefundData(secretHash [32]byte) ([]byte, error) {
+func (t *txDataHandlerV0) packRefundData(secretHash [32]byte) ([]byte, error) {
 	parsedAbi, err := abi.JSON(strings.NewReader(swapv0.ETHSwapABI))
 	if err != nil {
 		return nil, err
 	}
-	return parsedAbi.Pack(refundFuncName, secretHash)
+	return parsedAbi.Pack(t.refundFuncName, secretHash)
 }

--- a/dex/networks/eth/txdata.go
+++ b/dex/networks/eth/txdata.go
@@ -126,7 +126,7 @@ func (t *txDataHandlerV0) parseInitiateData(calldata []byte) (map[[SecretHashSiz
 		_ = swapv0.ETHSwapInitiation(initiations[0])
 	}
 
-	toReturn := make(map[[SecretHashSize]byte]*Initiation)
+	toReturn := make(map[[SecretHashSize]byte]*Initiation, len(initiations))
 	for _, init := range initiations {
 		gweiValue, err := ToGwei(init.Value)
 		if err != nil {
@@ -175,7 +175,7 @@ func (t *txDataHandlerV0) parseRedeemData(calldata []byte) (map[[SecretHashSize]
 		_ = swapv0.ETHSwapRedemption(redemptions[0])
 	}
 
-	toReturn := make(map[[SecretHashSize]byte]*Redemption)
+	toReturn := make(map[[SecretHashSize]byte]*Redemption, len(redemptions))
 	for _, redemption := range redemptions {
 		toReturn[redemption.SecretHash] = &Redemption{
 			SecretHash: redemption.SecretHash,

--- a/dex/networks/eth/txdata.go
+++ b/dex/networks/eth/txdata.go
@@ -17,11 +17,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-// ParseRefundData parses the calldata used to call the initiate function of a
+// ParseInitiateData parses the calldata used to call the initiate function of a
 // specific version of the swap contract. It returns the the list of initiations
-// done in the call and errors if the call data does not call initiate with expected
-// argument types.
-func ParseInitiateData(calldata []byte, contractVersion uint32) ([]Initiation, error) {
+// done in the call and errors if the call data does not call initiate initiate
+// with expected argument types.
+func ParseInitiateData(calldata []byte, contractVersion uint32) ([]*Initiation, error) {
 	txDataHandler, ok := txDataHandlers[contractVersion]
 	if !ok {
 		return nil, fmt.Errorf("contract version %v does not exist", contractVersion)
@@ -30,11 +30,11 @@ func ParseInitiateData(calldata []byte, contractVersion uint32) ([]Initiation, e
 	return txDataHandler.parseInitiateData(calldata)
 }
 
-// ParseRefundData parses the calldata used to call the redem function of a
+// ParseRedeemData parses the calldata used to call the redeem function of a
 // specific version of the swap contract. It returns the the list of redemptions
 // done in the call and errors if the call data does not call redeem with expected
 // argument types.
-func ParseRedeemData(calldata []byte, contractVersion uint32) ([]Redemption, error) {
+func ParseRedeemData(calldata []byte, contractVersion uint32) ([]*Redemption, error) {
 	txDataHandler, ok := txDataHandlers[contractVersion]
 	if !ok {
 		return nil, fmt.Errorf("contract version %v does not exist", contractVersion)
@@ -57,7 +57,7 @@ func ParseRefundData(calldata []byte, contractVersion uint32) ([32]byte, error) 
 
 // PackInitiateData converts a list of Initiation to the call data for the
 // initiate function for the contract specified by contractVersion.
-func PackInitiateData(initiations []Initiation, contractVersion uint32) ([]byte, error) {
+func PackInitiateData(initiations []*Initiation, contractVersion uint32) ([]byte, error) {
 	txDataHandler, ok := txDataHandlers[contractVersion]
 	if !ok {
 		return nil, fmt.Errorf("contract version %v does not exist", contractVersion)
@@ -66,9 +66,9 @@ func PackInitiateData(initiations []Initiation, contractVersion uint32) ([]byte,
 	return txDataHandler.packInitiateData(initiations)
 }
 
-// PackRedeemData converts a list of Redemption to the call data for the
-// redeem function for the contract specified by contractVersion.
-func PackRedeemData(redemptions []Redemption, contractVersion uint32) ([]byte, error) {
+// PackRedeemData converts a list of Redemption to the call data for the redeem
+// function for the contract specified by contractVersion.
+func PackRedeemData(redemptions []*Redemption, contractVersion uint32) ([]byte, error) {
 	txDataHandler, ok := txDataHandlers[contractVersion]
 	if !ok {
 		return nil, fmt.Errorf("contract version %v does not exist", contractVersion)
@@ -77,8 +77,8 @@ func PackRedeemData(redemptions []Redemption, contractVersion uint32) ([]byte, e
 	return txDataHandler.packRedeemData(redemptions)
 }
 
-// PackInitiateData converts a secret hash to the call data for the
-// refund function for the contract specified by contractVersion.
+// PackRefundData converts a secret hash to the call data for the refund function
+// for the contract specified by contractVersion.
 func PackRefundData(secretHash [32]byte, contractVersion uint32) ([]byte, error) {
 	txDataHandler, ok := txDataHandlers[contractVersion]
 	if !ok {
@@ -88,36 +88,41 @@ func PackRefundData(secretHash [32]byte, contractVersion uint32) ([]byte, error)
 	return txDataHandler.packRefundData(secretHash)
 }
 
-var txDataHandlers = map[uint32]txDataHandler{
-	0: &txDataHandlerV0{
-		initiateFuncName: "initiate",
-		redeemFuncName:   "redeem",
-		refundFuncName:   "refund",
-		numInputArgs:     1,
-		numRedeemArgs:    1,
-		numRefundArgs:    1,
-	},
+type txDataHandler interface {
+	parseInitiateData([]byte) ([]*Initiation, error)
+	parseRedeemData([]byte) ([]*Redemption, error)
+	parseRefundData([]byte) ([32]byte, error)
+	packInitiateData([]*Initiation) ([]byte, error)
+	packRedeemData([]*Redemption) ([]byte, error)
+	packRefundData([32]byte) ([]byte, error)
 }
 
-type txDataHandler interface {
-	parseInitiateData([]byte) ([]Initiation, error)
-	parseRedeemData([]byte) ([]Redemption, error)
-	parseRefundData([]byte) ([32]byte, error)
-	packInitiateData([]Initiation) ([]byte, error)
-	packRedeemData([]Redemption) ([]byte, error)
-	packRefundData([32]byte) ([]byte, error)
+var txDataHandlers = map[uint32]txDataHandler{
+	0: newTxDataV0(),
 }
 
 type txDataHandlerV0 struct {
 	initiateFuncName string
 	redeemFuncName   string
 	refundFuncName   string
-	numInputArgs     int
-	numRedeemArgs    int
-	numRefundArgs    int
+	parsedAbi        abi.ABI
 }
 
-func (t *txDataHandlerV0) parseInitiateData(calldata []byte) ([]Initiation, error) {
+func newTxDataV0() *txDataHandlerV0 {
+	parsedAbi, err := abi.JSON(strings.NewReader(swapv0.ETHSwapABI))
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse abi: %v", err))
+	}
+
+	return &txDataHandlerV0{
+		initiateFuncName: "initiate",
+		redeemFuncName:   "redeem",
+		refundFuncName:   "refund",
+		parsedAbi:        parsedAbi,
+	}
+}
+
+func (t *txDataHandlerV0) parseInitiateData(calldata []byte) ([]*Initiation, error) {
 	decoded, err := parseCallData(calldata, swapv0.ETHSwapABI)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse call data: %v", err)
@@ -130,8 +135,9 @@ func (t *txDataHandlerV0) parseInitiateData(calldata []byte) ([]Initiation, erro
 	// should be caught by parseCallData, but checking again anyway.
 	//
 	// TODO: If any of the checks prove redundant, remove them.
-	if len(args) != t.numInputArgs {
-		return nil, fmt.Errorf("expected %v input args but got %v", t.numInputArgs, len(args))
+	numArgs := 1
+	if len(args) != numArgs {
+		return nil, fmt.Errorf("expected %v input args but got %v", numArgs, len(args))
 	}
 	initiations, ok := args[0].value.([]struct {
 		RefundTimestamp *big.Int       `json:"refundTimestamp"`
@@ -143,20 +149,20 @@ func (t *txDataHandlerV0) parseInitiateData(calldata []byte) ([]Initiation, erro
 		return nil, fmt.Errorf("expected first arg of type []swapv0.ETHSwapInitiation but got %T", args[0].value)
 	}
 
-	// This is done for the compiler to ensure that the type defined above and swapv0.ETHSwapInitiation
-	// are the same, other than the tags.
+	// This is done for the compiler to ensure that the type defined above and
+	// swapv0.ETHSwapInitiation are the same, other than the tags.
 	if len(initiations) > 0 {
 		_ = swapv0.ETHSwapInitiation(initiations[0])
 	}
 
-	toReturn := make([]Initiation, 0, len(initiations))
+	toReturn := make([]*Initiation, 0, len(initiations))
 	for _, init := range initiations {
 		gweiValue, err := ToGwei(init.Value)
 		if err != nil {
 			return nil, fmt.Errorf("cannot convert wei to gwei: %w", err)
 		}
 
-		toReturn = append(toReturn, Initiation{
+		toReturn = append(toReturn, &Initiation{
 			LockTime:    time.Unix(init.RefundTimestamp.Int64(), 0),
 			SecretHash:  init.SecretHash,
 			Participant: init.Participant,
@@ -167,7 +173,7 @@ func (t *txDataHandlerV0) parseInitiateData(calldata []byte) ([]Initiation, erro
 	return toReturn, nil
 }
 
-func (t *txDataHandlerV0) parseRedeemData(calldata []byte) ([]Redemption, error) {
+func (t *txDataHandlerV0) parseRedeemData(calldata []byte) ([]*Redemption, error) {
 	decoded, err := parseCallData(calldata, swapv0.ETHSwapABI)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse call data: %v", err)
@@ -180,8 +186,9 @@ func (t *txDataHandlerV0) parseRedeemData(calldata []byte) ([]Redemption, error)
 	// should be caught by parseCallData, but checking again anyway.
 	//
 	// TODO: If any of the checks prove redundant, remove them.
-	if len(args) != t.numRedeemArgs {
-		return nil, fmt.Errorf("expected %v redeem args but got %v", t.numRedeemArgs, len(args))
+	numArgs := 1
+	if len(args) != numArgs {
+		return nil, fmt.Errorf("expected %v redeem args but got %v", numArgs, len(args))
 	}
 	redemptions, ok := args[0].value.([]struct {
 		Secret     [32]byte `json:"secret"`
@@ -191,15 +198,15 @@ func (t *txDataHandlerV0) parseRedeemData(calldata []byte) ([]Redemption, error)
 		return nil, fmt.Errorf("expected first arg of type []swapv0.ETHSwapRedemption but got %T", args[0].value)
 	}
 
-	// This is done for the compiler to ensure that the type defined above and swapv0.ETHSwapInitiation
-	// are the same, other than the tags.
+	// This is done for the compiler to ensure that the type defined above and
+	// swapv0.ETHSwapRedemption are the same, other than the tags.
 	if len(redemptions) > 0 {
 		_ = swapv0.ETHSwapRedemption(redemptions[0])
 	}
 
-	toReturn := make([]Redemption, 0, len(redemptions))
+	toReturn := make([]*Redemption, 0, len(redemptions))
 	for _, redemption := range redemptions {
-		toReturn = append(toReturn, Redemption{
+		toReturn = append(toReturn, &Redemption{
 			SecretHash: redemption.SecretHash,
 			Secret:     redemption.Secret,
 		})
@@ -223,8 +230,9 @@ func (t *txDataHandlerV0) parseRefundData(calldata []byte) ([32]byte, error) {
 	// should be caught by parseCallData, but checking again anyway.
 	//
 	// TODO: If any of the checks prove redundant, remove them.
-	if len(args) != t.numRedeemArgs {
-		return secretHash, fmt.Errorf("expected %v redeem args but got %v", t.numRedeemArgs, len(args))
+	numArgs := 1
+	if len(args) != numArgs {
+		return secretHash, fmt.Errorf("expected %v redeem args but got %v", numArgs, len(args))
 	}
 	secretHash, ok := args[0].value.([32]byte)
 	if !ok {
@@ -235,11 +243,7 @@ func (t *txDataHandlerV0) parseRefundData(calldata []byte) ([32]byte, error) {
 }
 
 // packInitiateData converts a list of Initiate to call data for the initiate function.
-func (t *txDataHandlerV0) packInitiateData(initiations []Initiation) ([]byte, error) {
-	parsedAbi, err := abi.JSON(strings.NewReader(swapv0.ETHSwapABI))
-	if err != nil {
-		return nil, err
-	}
+func (t *txDataHandlerV0) packInitiateData(initiations []*Initiation) ([]byte, error) {
 	abiInitiations := make([]swapv0.ETHSwapInitiation, 0, len(initiations))
 	for _, init := range initiations {
 		bigVal := new(big.Int).SetUint64(init.Value)
@@ -250,14 +254,10 @@ func (t *txDataHandlerV0) packInitiateData(initiations []Initiation) ([]byte, er
 			Value:           new(big.Int).Mul(bigVal, BigGweiFactor),
 		})
 	}
-	return parsedAbi.Pack(t.initiateFuncName, abiInitiations)
+	return t.parsedAbi.Pack(t.initiateFuncName, abiInitiations)
 }
 
-func (t *txDataHandlerV0) packRedeemData(redemptions []Redemption) ([]byte, error) {
-	parsedAbi, err := abi.JSON(strings.NewReader(swapv0.ETHSwapABI))
-	if err != nil {
-		return nil, err
-	}
+func (t *txDataHandlerV0) packRedeemData(redemptions []*Redemption) ([]byte, error) {
 	abiRedemptions := make([]swapv0.ETHSwapRedemption, 0, len(redemptions))
 	for _, redeem := range redemptions {
 		abiRedemptions = append(abiRedemptions, swapv0.ETHSwapRedemption{
@@ -265,13 +265,9 @@ func (t *txDataHandlerV0) packRedeemData(redemptions []Redemption) ([]byte, erro
 			SecretHash: redeem.SecretHash,
 		})
 	}
-	return parsedAbi.Pack(t.redeemFuncName, abiRedemptions)
+	return t.parsedAbi.Pack(t.redeemFuncName, abiRedemptions)
 }
 
 func (t *txDataHandlerV0) packRefundData(secretHash [32]byte) ([]byte, error) {
-	parsedAbi, err := abi.JSON(strings.NewReader(swapv0.ETHSwapABI))
-	if err != nil {
-		return nil, err
-	}
-	return parsedAbi.Pack(t.refundFuncName, secretHash)
+	return t.parsedAbi.Pack(t.refundFuncName, secretHash)
 }

--- a/dex/networks/eth/txdata_test.go
+++ b/dex/networks/eth/txdata_test.go
@@ -20,7 +20,7 @@ func mustParseHex(s string) []byte {
 	return b
 }
 
-func initiationsAreEqual(a, b Initiation) bool {
+func initiationsAreEqual(a, b *Initiation) bool {
 	return a.LockTime == b.LockTime &&
 		a.SecretHash == b.SecretHash &&
 		a.Participant == b.Participant &&
@@ -36,14 +36,14 @@ func TestParseInitiateDataV0(t *testing.T) {
 
 	locktime := int64(1632112916)
 
-	initiations := []Initiation{
-		Initiation{
+	initiations := []*Initiation{
+		&Initiation{
 			LockTime:    time.Unix(locktime, 0),
 			SecretHash:  secretHashA,
 			Participant: participantAddr,
 			Value:       1,
 		},
-		Initiation{
+		&Initiation{
 			LockTime:    time.Unix(locktime, 0),
 			SecretHash:  secretHashB,
 			Participant: participantAddr,
@@ -121,7 +121,7 @@ func TestParseInitiateDataV0(t *testing.T) {
 	}
 }
 
-func redemptionsAreEqual(a, b Redemption) bool {
+func redemptionsAreEqual(a, b *Redemption) bool {
 	return a.SecretHash == b.SecretHash &&
 		a.Secret == b.Secret
 }
@@ -133,12 +133,12 @@ func TestParseRedeemDataV0(t *testing.T) {
 	copy(secretHashB[:], mustParseHex("99d971975c09331eb00f5e0dc1eaeca9bf4ee2d086d3fe1de489f920007d6546"))
 	copy(secretB[:], mustParseHex("2c0a304c9321402dc11cbb5898b9f2af3029ce1c76ec6702c4cd5bb965fd3e73"))
 
-	redemptions := []Redemption{
-		Redemption{
+	redemptions := []*Redemption{
+		&Redemption{
 			Secret:     secretA,
 			SecretHash: secretHashA,
 		},
-		Redemption{
+		&Redemption{
 			Secret:     secretB,
 			SecretHash: secretHashB,
 		},

--- a/server/asset/eth/coiner.go
+++ b/server/asset/eth/coiner.go
@@ -112,15 +112,8 @@ func (backend *Backend) newSwapCoin(coinID []byte, contractData []byte, sct swap
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse initiate call data: %v", err)
 		}
-		var initiation *dexeth.Initiation
-		for _, init := range initiations {
-			// contractData points us to the init of interest.
-			if init.SecretHash == secretHash {
-				initiation = init
-				break
-			}
-		}
-		if initiation == nil {
+		initiation, ok := initiations[secretHash]
+		if !ok {
 			return nil, fmt.Errorf("tx %v does not contain initiation with secret hash %x",
 				txHash, secretHash)
 		}
@@ -131,15 +124,8 @@ func (backend *Backend) newSwapCoin(coinID []byte, contractData []byte, sct swap
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse redemption call data: %v", err)
 		}
-		var redemption *dexeth.Redemption
-		for _, redeem := range redemptions {
-			// contractData points us to the redeem of interest.
-			if redeem.SecretHash == secretHash {
-				redemption = redeem
-				break
-			}
-		}
-		if redemption == nil {
+		redemption, ok := redemptions[secretHash]
+		if !ok {
 			return nil, fmt.Errorf("tx %v does not contain redemption with secret hash %x",
 				txHash, secretHash)
 		}

--- a/server/asset/eth/coiner.go
+++ b/server/asset/eth/coiner.go
@@ -13,7 +13,6 @@ import (
 	"math/big"
 
 	dexeth "decred.org/dcrdex/dex/networks/eth"
-	swapv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
 	"decred.org/dcrdex/server/asset"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -109,11 +108,11 @@ func (backend *Backend) newSwapCoin(coinID []byte, contractData []byte, sct swap
 
 	switch sct {
 	case sctInit:
-		initiations, err := dexeth.ParseInitiateData(txdata) // TODO: make version aware with version independent return type
+		initiations, err := dexeth.ParseInitiateData(txdata, contractVer)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse initiate call data: %v", err)
 		}
-		var initiation *swapv0.ETHSwapInitiation
+		var initiation *dexeth.Initiation
 		for _, init := range initiations {
 			// contractData points us to the init of interest.
 			if init.SecretHash == secretHash {
@@ -126,13 +125,13 @@ func (backend *Backend) newSwapCoin(coinID []byte, contractData []byte, sct swap
 				txHash, secretHash)
 		}
 		counterParty = &initiation.Participant
-		locktime = initiation.RefundTimestamp.Int64()
+		locktime = initiation.LockTime.Unix()
 	case sctRedeem:
-		redemptions, err := dexeth.ParseRedeemData(txdata)
+		redemptions, err := dexeth.ParseRedeemData(txdata, contractVer)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse redemption call data: %v", err)
 		}
-		var redemption *swapv0.ETHSwapRedemption
+		var redemption *dexeth.Redemption
 		for _, redeem := range redemptions {
 			// contractData points us to the redeem of interest.
 			if redeem.SecretHash == secretHash {

--- a/server/asset/eth/coiner.go
+++ b/server/asset/eth/coiner.go
@@ -116,7 +116,7 @@ func (backend *Backend) newSwapCoin(coinID []byte, contractData []byte, sct swap
 		for _, init := range initiations {
 			// contractData points us to the init of interest.
 			if init.SecretHash == secretHash {
-				initiation = &init
+				initiation = init
 				break
 			}
 		}
@@ -135,7 +135,7 @@ func (backend *Backend) newSwapCoin(coinID []byte, contractData []byte, sct swap
 		for _, redeem := range redemptions {
 			// contractData points us to the redeem of interest.
 			if redeem.SecretHash == secretHash {
-				redemption = &redeem
+				redemption = redeem
 				break
 			}
 		}


### PR DESCRIPTION
The functions used to parse and pack call data for the eth swap contract only supported version 0. This diff makes those functions version agnostic.