### PR TITLE
client/asset/eth: Remove nonce from funding coin id

### DIFF
--- a/client/asset/eth/fundingcoin.go
+++ b/client/asset/eth/fundingcoin.go
@@ -10,24 +10,21 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"decred.org/dcrdex/dex/encode"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const fundingCoinIDSize = 36 // address (20) + amount (8) + nonce (8) = 36
+const fundingCoinIDSize = 28 // address (20) + amount (8) = 28
 
 // fundingCoinID is an identifier for a coin which has not yet been sent to the
 // swap contract.
 type fundingCoinID struct {
 	Address common.Address
 	Amount  uint64
-	Nonce   [8]byte
 }
 
 // String creates a human readable string.
 func (c *fundingCoinID) String() string {
-	return fmt.Sprintf("address: %v, amount:%x, nonce:%x",
-		c.Address, c.Amount, c.Nonce)
+	return fmt.Sprintf("address: %v, amount:%x", c.Address, c.Amount)
 }
 
 // Encode creates a byte slice that can be decoded with DecodeCoinID.
@@ -35,7 +32,6 @@ func (c *fundingCoinID) Encode() []byte {
 	b := make([]byte, fundingCoinIDSize)
 	copy(b[:20], c.Address[:])
 	binary.BigEndian.PutUint64(b[20:28], c.Amount)
-	copy(b[28:], c.Nonce[:])
 	return b
 }
 
@@ -47,24 +43,18 @@ func decodeFundingCoinID(coinID []byte) (*fundingCoinID, error) {
 	}
 
 	var address [20]byte
-	var nonce [8]byte
 	copy(address[:], coinID[:20])
-	copy(nonce[:], coinID[28:])
 	return &fundingCoinID{
 		Address: address,
 		Amount:  binary.BigEndian.Uint64(coinID[20:28]),
-		Nonce:   nonce,
 	}, nil
 }
 
 // createFundingCoinID constructs a new fundingCoinID for the provided account
-// address and amount in Gwei. A random nonce is assigned.
+// address and amount in Gwei.
 func createFundingCoinID(address common.Address, amount uint64) *fundingCoinID {
-	var nonce [8]byte
-	copy(nonce[:], encode.RandomBytes(8))
 	return &fundingCoinID{
 		Address: address,
 		Amount:  amount,
-		Nonce:   nonce,
 	}
 }

--- a/client/asset/eth/fundingcoin_test.go
+++ b/client/asset/eth/fundingcoin_test.go
@@ -16,13 +16,10 @@ import (
 func TestFundingCoinID(t *testing.T) {
 	// Decode and encode fundingCoinID
 	var address [20]byte
-	var nonce [8]byte
 	copy(address[:], encode.RandomBytes(20))
-	copy(nonce[:], encode.RandomBytes(8))
 	originalFundingCoin := fundingCoinID{
 		Address: address,
 		Amount:  100,
-		Nonce:   nonce,
 	}
 	encodedFundingCoin := originalFundingCoin.Encode()
 	decodedFundingCoin, err := decodeFundingCoinID(encodedFundingCoin)
@@ -31,9 +28,6 @@ func TestFundingCoinID(t *testing.T) {
 	}
 	if !bytes.Equal(originalFundingCoin.Address[:], decodedFundingCoin.Address[:]) {
 		t.Fatalf("expected address to be equal before and after decoding")
-	}
-	if !bytes.Equal(originalFundingCoin.Nonce[:], decodedFundingCoin.Nonce[:]) {
-		t.Fatalf("expected nonce to be equal before and after decoding")
 	}
 	if originalFundingCoin.Amount != decodedFundingCoin.Amount {
 		t.Fatalf("expected amount to be equal before and after decoding")


### PR DESCRIPTION
The nonce in `FundingCoinID` is no longer needed because we only use the address in communication with the server, and the client wallet no longer uses a map to keep track of unique coin ids.