### PR TITLE
client/eth: Fix test gas calculations.

### DIFF
--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -543,7 +543,8 @@ func (n *nodeClient) transactionConfirmations(ctx context.Context, txHash common
 	// tx pool, and when our peers are ready to supply the info. I saw a
 	// CoinNotFoundError in TestAccount/testSendTransaction, but haven't
 	// reproduced.
-	return 0, fmt.Errorf("cannot find %v: %w", txHash, asset.CoinNotFoundError)
+	n.log.Warnf("transactionConfirmations: cannot find %v", txHash)
+	return 0, asset.CoinNotFoundError
 }
 
 // sendSignedTransaction injects a signed transaction into the pending pool for execution.

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -226,8 +226,6 @@ func (n *nodeClient) balance(ctx context.Context) (*Balance, error) {
 
 	for _, tx := range pendingTxs {
 		from, _ := ethSigner.Sender(tx) // zero Address on error
-		// Intentionally ignoring receives from addresses that do not
-		// belong to us.
 		if from != n.creds.addr {
 			continue
 		}

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -74,20 +74,20 @@ var (
 	ctx                       context.Context
 	tLogger                   = dex.StdOutLogger("ETHTEST", dex.LevelCritical)
 	simnetWalletSeed          = "5c52e2ef5f5298ec41107e4e9573df4488577fb3504959cbc26c88437205dd2c0812f5244004217452059e2fd11603a511b5d0870ead753df76c966ce3c71531"
-	simnetPrivKey             = "8b19650a41e740f3b7ebb7ad112a91f63df9f005320489147cdf6f8d8f585500"
-	simnetAddr                = common.HexToAddress("dd93b447f7eBCA361805eBe056259853F3912E04")
-	simnetAcct                = &accounts.Account{Address: simnetAddr}
-	ethClient                 *nodeClient
-	participantWalletSeed     = "b99fb787fc5886eb539830d103c0017eff5241ace28ee137d40f135fd02212b1a897afbdcba037c8c735cc63080558a30d72851eb5a3d05684400ec4123a2d00"
-	participantPrivKey        = "4fc4f43c00bc6550314b8561878edbfc776884e006ad51a2fe2c054f85cfbd12"
-	participantAddr           = common.HexToAddress("1D4F2ee206474B136Af4868B887C7b166693c194")
-	participantAcct           = &accounts.Account{Address: participantAddr}
-	participantEthClient      *nodeClient
-	ethSwapContractAddr       common.Address
-	tokenSwapContractAddr     common.Address
-	testTokenContractAddr     common.Address
-	simnetID                  int64  = 42
-	maxFeeRate                uint64 = 1000 // gwei per gas
+	// simnetPrivKey             = "8b19650a41e740f3b7ebb7ad112a91f63df9f005320489147cdf6f8d8f585500"
+	simnetAddr            = common.HexToAddress("dd93b447f7eBCA361805eBe056259853F3912E04")
+	simnetAcct            = &accounts.Account{Address: simnetAddr}
+	ethClient             *nodeClient
+	participantWalletSeed = "b99fb787fc5886eb539830d103c0017eff5241ace28ee137d40f135fd02212b1a897afbdcba037c8c735cc63080558a30d72851eb5a3d05684400ec4123a2d00"
+	// participantPrivKey        = "4fc4f43c00bc6550314b8561878edbfc776884e006ad51a2fe2c054f85cfbd12"
+	participantAddr       = common.HexToAddress("1D4F2ee206474B136Af4868B887C7b166693c194")
+	participantAcct       = &accounts.Account{Address: participantAddr}
+	participantEthClient  *nodeClient
+	ethSwapContractAddr   common.Address
+	tokenSwapContractAddr common.Address
+	testTokenContractAddr common.Address
+	simnetID              int64  = 42
+	maxFeeRate            uint64 = 1000 // gwei per gas
 )
 
 func newContract(stamp uint64, secretHash [32]byte, val uint64) *asset.Contract {

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -475,11 +475,6 @@ func testSendSignedTransaction(t *testing.T) {
 
 	bal, _ := ethClient.balance(ctx)
 
-	// Removed pending issue #1342 resolution.
-	//if bal.PendingIn.Cmp(dexeth.GweiToWei(1)) != 0 { // We sent it to ourselves.
-	//	t.Fatalf("pending in not showing")
-	//}
-
 	fee := uint64(21000 * 300) // gwei
 	if bal.PendingOut.Cmp(dexeth.GweiToWei(1+fee)) != 0 {
 		t.Fatalf("pending out not showing")
@@ -580,6 +575,9 @@ func TestInitiateGas(t *testing.T) {
 	}
 }
 
+// feesAtBlk calculates the gas fee at blkNum. Txs that have already been mined
+// should pass the block number before being mined. This adds the base fee as
+// calculated at blkNum to a minimum gas tip cap.
 func feesAtBlk(ctx context.Context, n *nodeClient, blkNum int64) (fees *big.Int, err error) {
 	hdr, err := n.leth.ApiBackend.HeaderByNumber(ctx, rpc.BlockNumber(blkNum))
 	if err != nil {

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -89,6 +89,7 @@ cat > "${NODES_ROOT}/genesis.json" <<EOF
     "muirGlacierBlock": 0,
     "berlinBlock": 0,
     "londonBlock": 0,
+    "arrowGlacierBlock": 0,
     "clique": {
       "period": 1,
       "epoch": 30000


### PR DESCRIPTION
    Use the base gas fee for the block before a tx was mined to caculate
    exact gas used and test using that expected amount.

closes #1342 