### PR TITLE
[release-v0.4] dex/keygen: use ChildBIP32Std for extended key derivation

### DIFF
--- a/dex/keygen/keygen.go
+++ b/dex/keygen/keygen.go
@@ -28,7 +28,7 @@ func GenDeepChild(seed []byte, kids []uint32) (*hdkeychain.ExtendedKey, error) {
 		err := hdkeychain.ErrInvalidChild
 		for err == hdkeychain.ErrInvalidChild {
 			var kid *hdkeychain.ExtendedKey
-			kid, err = parent.Child(childIdx)
+			kid, err = parent.ChildBIP32Std(childIdx)
 			if err == nil {
 				return kid, nil
 			}

--- a/dex/keygen/keygen_test.go
+++ b/dex/keygen/keygen_test.go
@@ -16,17 +16,17 @@ func TestGenDeepChild(t *testing.T) {
 		t.Fatalf("error getting HD keychain root: %v", err)
 	}
 
-	expectedChild, err := root.Child(1)
+	expectedChild, err := root.ChildBIP32Std(1)
 	if err != nil {
 		t.Fatalf("error deriving child: %v", err)
 	}
 
-	expectedChild, err = expectedChild.Child(2)
+	expectedChild, err = expectedChild.ChildBIP32Std(2)
 	if err != nil {
 		t.Fatalf("error deriving child: %v", err)
 	}
 
-	expectedChild, err = expectedChild.Child(3)
+	expectedChild, err = expectedChild.ChildBIP32Std(3)
 	if err != nil {
 		t.Fatalf("error deriving child: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/decred/dcrd/dcrjson/v4 v4.0.0
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0
 	github.com/decred/dcrd/gcs/v3 v3.0.0
-	github.com/decred/dcrd/hdkeychain/v3 v3.0.1
+	github.com/decred/dcrd/hdkeychain/v3 v3.1.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0
 	github.com/decred/dcrd/rpcclient/v7 v7.0.0-20211118191843-5bd1da85e135
 	github.com/decred/dcrd/txscript/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,9 @@ github.com/decred/dcrd/dcrutil/v4 v4.0.0/go.mod h1:QQpX5WVH3/ixVtiW15xZMe+neugXX
 github.com/decred/dcrd/gcs/v3 v3.0.0-20210916172859-ca03de05ecd0/go.mod h1:cfMmjV1ArvX+nemwwq1texW5pD0wrUt5TEw4IYuTmMM=
 github.com/decred/dcrd/gcs/v3 v3.0.0 h1:MjWevhoAzKENUgpaJAbZkJlKDN4HIz2nR/i3laZAT5c=
 github.com/decred/dcrd/gcs/v3 v3.0.0/go.mod h1:/OVb/rYrAz4TCtxcPneYfBs0+YI1pGIp8RA6RUNqOp4=
-github.com/decred/dcrd/hdkeychain/v3 v3.0.1 h1:wvfHa3VY8YW1sB2TzXipCehO6N0u1H6rSsNAYtEE9VY=
 github.com/decred/dcrd/hdkeychain/v3 v3.0.1/go.mod h1:rDCdqwGkcTfEyRheG1g8Wc38appT2C9+D1XTlLy21lo=
+github.com/decred/dcrd/hdkeychain/v3 v3.1.0 h1:NlUjzPMzexbk1PyJu6vrQaiilep5WsEPB0KdhLYrEcE=
+github.com/decred/dcrd/hdkeychain/v3 v3.1.0/go.mod h1:rDCdqwGkcTfEyRheG1g8Wc38appT2C9+D1XTlLy21lo=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
 github.com/decred/dcrd/lru v1.1.0 h1:QwT6v8LFKOL3xQ3qtucgRk4pdiawrxIfCbUXWpm+JL4=
 github.com/decred/dcrd/lru v1.1.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=


### PR DESCRIPTION
This is https://github.com/decred/dcrdex/pull/1341 for the `release-v0.4` branch.
Requires https://github.com/decred/dcrdex/pull/1349, which updates the go.mods first.

Updates the `github.com/decred/dcrd/hdkeychain/v3` require to v3.1.0.

**WARNING:** Keys derived from the app seed are likely to be different with the updated strict BIP32 HD key derivation.  This includes
- DEX accounts
- Any keys derived by `Wallet`s such as in `client/asset/eth` where it prepares a private key for the BIP44 path m/44'/60'/0'/0/0
As such, you should not rely on any of these accounts or keys being recoverable.

This updates the `GenDeepChild` helper, which is used in both client/core to setup DEX account keys from the app seed, and in client/asset/eth to derive the account private key from the wallet seed.

This is especially in the eth key derivation, where the intent is to follow BIP44 with the path m/44'/60'/0'/0/0, which requires generating child keys as per BIP32 strictly.

For generating DEX account keys from the app seed, it is also good from a standardness point of view to use strict BIP32 derivation.  The legacy derivation is only required for Decred wallets for compatibility.

Resolves https://github.com/decred/dcrdex/issues/1337
This eliminates the occasional error from `client/asset/eth.CreateWallet`