### PR TITLE
server: validate taker's contract hash in audit

### DIFF
--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -910,7 +910,7 @@ func (btc *Backend) auditContract(contract *Output) (*asset.Contract, error) {
 	if !bytes.Equal(hashed, scriptHash) {
 		return nil, fmt.Errorf("swap contract hash mismatch for %s:%d", tx.hash, contract.vout)
 	}
-	_, receiver, lockTime, _, err := dexbtc.ExtractSwapDetails(contract.redeemScript, contract.btc.segwit, contract.btc.chainParams)
+	_, receiver, lockTime, secretHash, err := dexbtc.ExtractSwapDetails(contract.redeemScript, contract.btc.segwit, contract.btc.chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing swap contract for %s:%d: %w", tx.hash, contract.vout, err)
 	}
@@ -918,6 +918,7 @@ func (btc *Backend) auditContract(contract *Output) (*asset.Contract, error) {
 		Coin:         contract,
 		SwapAddress:  receiver.String(),
 		ContractData: contract.redeemScript,
+		SecretHash:   secretHash,
 		LockTime:     time.Unix(int64(lockTime), 0),
 		TxData:       contract.tx.raw,
 	}, nil

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -149,6 +149,9 @@ type Contract struct {
 	// script for UTXO contracts, or a secret hash that keys swaps for account-
 	// based contracts.
 	ContractData []byte
+	// SecretHash is the secret key hash used for this swap. This should be used
+	// to validate a counterparty contract on another chain.
+	SecretHash []byte
 	// LockTime is the refund locktime.
 	LockTime time.Time
 	// TxData is raw transaction data. This data is provided for some assets

--- a/server/asset/dcr/utxo.go
+++ b/server/asset/dcr/utxo.go
@@ -389,7 +389,7 @@ func auditContract(op *Output) (*asset.Contract, error) {
 	if !bytes.Equal(stdaddr.Hash160(op.redeemScript), scriptHash) {
 		return nil, fmt.Errorf("swap contract hash mismatch for %s:%d", tx.hash, op.vout)
 	}
-	_, receiver, lockTime, _, err := dexdcr.ExtractSwapDetails(op.redeemScript, chainParams)
+	_, receiver, lockTime, secretHash, err := dexdcr.ExtractSwapDetails(op.redeemScript, chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing swap contract for %s:%d: %w", tx.hash, op.vout, err)
 	}
@@ -397,6 +397,7 @@ func auditContract(op *Output) (*asset.Contract, error) {
 		Coin:         op,
 		SwapAddress:  receiver.String(),
 		ContractData: op.redeemScript,
+		SecretHash:   secretHash,
 		LockTime:     time.Unix(int64(lockTime), 0),
 		TxData:       op.tx.raw,
 	}, nil

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1402,9 +1402,15 @@ func (s *Swapper) processInit(msg *msgjson.Message, params *msgjson.Init, stepIn
 			fmt.Sprintf("contract error. expected contract value to be %d, got %d", stepInfo.checkVal, contract.Value()))
 		return wait.DontTryAgain
 	}
+	if !actor.isMaker && !bytes.Equal(contract.SecretHash, counterParty.status.swap.SecretHash) {
+		s.respondError(msg.ID, actor.user, msgjson.ContractError,
+			fmt.Sprintf("incorrect secret hash. expected %x. got %x",
+				contract.SecretHash, counterParty.status.swap.SecretHash))
+		return wait.DontTryAgain
+	}
 
 	reqLockTime := encode.DropMilliseconds(stepInfo.match.matchTime.Add(s.lockTimeTaker))
-	if stepInfo.actor.isMaker {
+	if actor.isMaker {
 		reqLockTime = encode.DropMilliseconds(stepInfo.match.matchTime.Add(s.lockTimeMaker))
 	}
 	if contract.LockTime.Before(reqLockTime) {


### PR DESCRIPTION
The server's audit of the taker's contract must also verify that the contract hash used in their contract script matches the secret hash from the maker's contract.  This check is already performed client-side, this just updates the server's auditing to do it as well.

This was included in a recent v0.2 backport PR: https://github.com/decred/dcrdex/pull/1338