### PR TITLE
[release-v0.4] server: validate taker's contract hash in audit

### DIFF
--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -910,7 +910,7 @@ func (btc *Backend) auditContract(contract *Output) (*asset.Contract, error) {
 	if !bytes.Equal(hashed, scriptHash) {
 		return nil, fmt.Errorf("swap contract hash mismatch for %s:%d", tx.hash, contract.vout)
 	}
-	_, receiver, lockTime, _, err := dexbtc.ExtractSwapDetails(contract.redeemScript, contract.btc.segwit, contract.btc.chainParams)
+	_, receiver, lockTime, secretHash, err := dexbtc.ExtractSwapDetails(contract.redeemScript, contract.btc.segwit, contract.btc.chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing swap contract for %s:%d: %w", tx.hash, contract.vout, err)
 	}
@@ -918,6 +918,7 @@ func (btc *Backend) auditContract(contract *Output) (*asset.Contract, error) {
 		Coin:         contract,
 		SwapAddress:  receiver.String(),
 		RedeemScript: contract.redeemScript,
+		SecretHash:   secretHash,
 		LockTime:     time.Unix(int64(lockTime), 0),
 		TxData:       contract.tx.raw,
 	}, nil

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -124,6 +124,9 @@ type Contract struct {
 	SwapAddress string
 	// RedeemScript is the contract redeem script.
 	RedeemScript []byte
+	// SecretHash is the secret key hash used for this swap. This should be used
+	// to validate a counterparty contract on another chain.
+	SecretHash []byte
 	// LockTime is the refund locktime.
 	LockTime time.Time
 	// TxData is raw transaction data. This data is provided for some assets

--- a/server/asset/dcr/utxo.go
+++ b/server/asset/dcr/utxo.go
@@ -388,7 +388,7 @@ func auditContract(op *Output) (*asset.Contract, error) {
 	if !bytes.Equal(stdaddr.Hash160(op.redeemScript), scriptHash) {
 		return nil, fmt.Errorf("swap contract hash mismatch for %s:%d", tx.hash, op.vout)
 	}
-	_, receiver, lockTime, _, err := dexdcr.ExtractSwapDetails(op.redeemScript, chainParams)
+	_, receiver, lockTime, secretHash, err := dexdcr.ExtractSwapDetails(op.redeemScript, chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing swap contract for %s:%d: %w", tx.hash, op.vout, err)
 	}
@@ -396,6 +396,7 @@ func auditContract(op *Output) (*asset.Contract, error) {
 		Coin:         op,
 		SwapAddress:  receiver.String(),
 		RedeemScript: op.redeemScript,
+		SecretHash:   secretHash,
 		LockTime:     time.Unix(int64(lockTime), 0),
 		TxData:       op.tx.raw,
 	}, nil

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1288,9 +1288,15 @@ func (s *Swapper) processInit(msg *msgjson.Message, params *msgjson.Init, stepIn
 			fmt.Sprintf("contract error. expected contract value to be %d, got %d", stepInfo.checkVal, contract.Value()))
 		return wait.DontTryAgain
 	}
+	if !actor.isMaker && !bytes.Equal(contract.SecretHash, counterParty.status.swap.SecretHash) {
+		s.respondError(msg.ID, actor.user, msgjson.ContractError,
+			fmt.Sprintf("incorrect secret hash. expected %x. got %x",
+				contract.SecretHash, counterParty.status.swap.SecretHash))
+		return wait.DontTryAgain
+	}
 
 	reqLockTime := encode.DropMilliseconds(stepInfo.match.matchTime.Add(s.lockTimeTaker))
-	if stepInfo.actor.isMaker {
+	if actor.isMaker {
 		reqLockTime = encode.DropMilliseconds(stepInfo.match.matchTime.Add(s.lockTimeMaker))
 	}
 	if contract.LockTime.Before(reqLockTime) {


### PR DESCRIPTION
This is https://github.com/decred/dcrdex/pull/1351 for the `release-v0.4` branch.

The server's audit of the taker's contract must also verify that the contract hash used in their contract script matches the secret hash from the maker's contract.  This check is already performed client-side, this just updates the server's auditing to do it as well.