### PR TITLE
CI: fix deprecated golangci-lint install url, bump to 1.43

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0"
 
       - name: Test
         env:

--- a/server/db/driver/pg/epochs.go
+++ b/server/db/driver/pg/epochs.go
@@ -126,5 +126,5 @@ func (a *Archiver) LoadEpochStats(base, quote uint32, caches []*candles.Cache) e
 		}
 	}
 
-	return err
+	return rows.Err()
 }


### PR DESCRIPTION
The golangci-lint install script at goreleaser.com is deprecated. Docs now advise to install from a github link:

> golangci/golangci-lint err this script is deprecated, please do not
> use it anymore. check goreleaser/godownloader#207

This update caught a previously undetected missing `rows.Err` check in `LoadEpochStats`.