### PR TITLE
client/eth: Fix withdraw TODOs.

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1116,11 +1116,6 @@ func (*ExchangeWallet) ValidateSecret(secret, secretHash []byte) bool {
 	return bytes.Equal(h[:], secretHash)
 }
 
-// Confirmations gets the number of confirmations for the specified coin ID.
-func (*ExchangeWallet) Confirmations(ctx context.Context, id dex.Bytes) (confs uint32, spent bool, err error) {
-	return 0, false, asset.ErrNotImplemented
-}
-
 // SyncStatus is information about the blockchain sync status.
 func (eth *ExchangeWallet) SyncStatus() (bool, float32, error) {
 	// node.SyncProgress will return nil both before syncing has begun and

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1107,7 +1107,7 @@ func (eth *ExchangeWallet) Withdraw(addr string, value, _ uint64) (asset.Coin, e
 		return nil, err
 	}
 	txHash := tx.Hash()
-	return &coin{id: txHash[:], value: tx.Value().Uint64()}, nil
+	return &coin{id: txHash[:], value: dexeth.WeiToGwei(tx.Value())}, nil
 }
 
 // ValidateSecret checks that the secret satisfies the contract.


### PR DESCRIPTION
    Return txid bytes for printing.

    Reduce amount to withdraw by the max possible fee if value cannot
    otherwise be sent.

part of #1154 