### PR TITLE
eth: LoadGenesisFile helper

### DIFF
--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -8,13 +8,17 @@ package eth
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
+	"os"
 	"time"
 
 	"decred.org/dcrdex/dex"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 )
 
 const (
@@ -68,6 +72,22 @@ var v0Gases = &Gases{
 	AdditionalRedeemGas: 32000,
 	// RefundGas is the amount of gas it costs to refund a swap.
 	RefundGas: 43000,
+}
+
+// LoadGenesisFile loads a Genesis config from a json file.
+func LoadGenesisFile(genesisFile string) (*core.Genesis, error) {
+	fid, err := os.Open(genesisFile)
+	if err != nil {
+		return nil, err
+	}
+	defer fid.Close()
+
+	var genesis core.Genesis
+	err = json.NewDecoder(fid).Decode(&genesis)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal simnet genesis: %v", err)
+	}
+	return &genesis, nil
 }
 
 // EncodeContractData packs the contract version and the secret hash into a byte


### PR DESCRIPTION
dex/networks/eth: add LoadGenesisFile helper

client/asset/eth: use dexeth.LoadGenesisFile in startNode

I started this in experimenting with getting the `params.ChainConfig` for server-side use with a modified `FeeRate` estimate that uses separate tip and base fee rates rather than the [legacy transaction fee estimation method `suggestGasPrice`](https://github.com/ethereum/go-ethereum/blob/bc6bf1e1937829b5d5b0d431a9333d47c3e08082/internal/ethapi/api.go#L63-L64).  Draft: https://github.com/decred/dcrdex/commit/64a72b48fe3b05fcf8d5f4a7d9296496092967ac Although in that draft, I think the server would be just as well off using the base fee from the current best header rather than bothering to check with `consensus/misc.CalcBaseFee` using the `ChainConfig`, especially since just need an estimate, and a high one at that to be used as the gas **cap** for new transactions.