### PR TITLE
client/asset/btc: disallow descriptor wallets

### DIFF
--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -34,7 +34,6 @@ const (
 	methodUnlock             = "walletpassphrase"
 	methodLock               = "walletlock"
 	methodPrivKeyForAddress  = "dumpprivkey"
-	methodSignMessage        = "signmessagewithprivkey"
 	methodGetTransaction     = "gettransaction"
 	methodSendToAddress      = "sendtoaddress"
 	methodSetTxFee           = "settxfee"
@@ -109,10 +108,18 @@ func (wc *rpcClient) connect(ctx context.Context, _ *sync.WaitGroup) error {
 	if codeVer < minProtocolVersion {
 		return fmt.Errorf("node software out of date. version %d is less than minimum %d", codeVer, minProtocolVersion)
 	}
+	wiRes, err := wc.GetWalletInfo()
+	if err != nil {
+		return fmt.Errorf("getwalletinfo failure: %w", err)
+	}
+	if wiRes.Descriptors {
+		return fmt.Errorf("descriptor wallets are not supported, see " +
+			"https://bitcoincore.org/en/releases/0.21.0/#experimental-descriptor-wallets")
+	}
 	return nil
 }
 
-// RawRequest passes the reqeuest to the wallet's RawRequester.
+// RawRequest passes the request to the wallet's RawRequester.
 func (wc *rpcClient) RawRequest(method string, params []json.RawMessage) (json.RawMessage, error) {
 	return wc.requester.RawRequest(wc.ctx, method, params)
 }

--- a/client/asset/btc/wallettypes.go
+++ b/client/asset/btc/wallettypes.go
@@ -99,6 +99,7 @@ type RPCOutpoint struct {
 type GetWalletInfoResult struct {
 	WalletName            string  `json:"walletname"`
 	WalletVersion         uint32  `json:"walletversion"`
+	Format                string  `json:"format"`
 	Balance               float64 `json:"balance"`
 	UnconfirmedBalance    float64 `json:"unconfirmed_balance"`
 	ImmatureBalance       float64 `json:"immature_balance"`
@@ -123,6 +124,7 @@ type GetWalletInfoResult struct {
 	// 	Duration uint32  `json:"duration"`
 	// 	Progress float32 `json:"progress"`
 	// } `json:"scanning"`
+	Descriptors bool `json:"descriptors"` // Descriptor wallets that do not support dumpprivkey
 }
 
 // GetAddressInfoResult models the data from the getaddressinfo command.


### PR DESCRIPTION
Bitcoin Core v22 creates Descriptor wallets instead of Legacy wallets by default if the DB backend in the build is sqlite instead of bdb.  v0.21 still used Legacy wallets by default as descriptor wallets were experimental in v0.21.

This is a problem because descriptor wallets do not support the `dumpprivkey` RPC, which we need for several reasons, but most importantly for signing the redemption tx input with the private key for the address referenced by the contract script.

https://bitcoincore.org/en/releases/0.21.0/#experimental-descriptor-wallets
"New export RPCs for Descriptor Wallets have not yet been added"

This change adds a `getwalletinfo` check in `(*rpcClient).connect` to ensure that the `Descriptors bool` is false.

This should be cherry-picked to `release-v0.4` for RC2.