### PR TITLE
client/webserver/site: Use correct volume.

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=b679352"></script>
+<script src="/js/entry.js?v=CJxV8vh"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -66,7 +66,7 @@ function convertToConventional (v, unitInfo) {
   let prec = 8
   if (unitInfo) {
     const f = unitInfo.conventional.conversionFactor
-    v = v / unitInfo.conventional.conversionFactor
+    v /= f
     prec = Math.round(Math.log10(f))
   }
   return [v, prec]

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -627,7 +627,7 @@ export default class MarketsPage extends BasePage {
     }
 
     page.hoverPrice.textContent = Doc.formatCoinValue(d.rate / this.market.rateConversionFactor)
-    page.hoverVolume.textContent = Doc.formatCoinValue(d.depth, this.market.base.info.unitinfo)
+    page.hoverVolume.textContent = Doc.formatCoinValue(d.depth)
     page.hoverVolume.style.color = d.dotColor
     Doc.show(page.hoverData)
   }
@@ -652,7 +652,7 @@ export default class MarketsPage extends BasePage {
     page.candleEnd.textContent = Doc.formatCoinValue(candle.endRate / this.market.rateConversionFactor)
     page.candleHigh.textContent = Doc.formatCoinValue(candle.highRate / this.market.rateConversionFactor)
     page.candleLow.textContent = Doc.formatCoinValue(candle.lowRate / this.market.rateConversionFactor)
-    page.candleVol.textContent = Doc.formatCoinValue(candle.matchVolume, this.market.base.unitInfo)
+    page.candleVol.textContent = Doc.formatCoinValue(candle.matchVolume, this.market.base.info.unitinfo)
     Doc.show(page.hoverData)
   }
 

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=b679352"></script>
+<script src="/js/entry.js?v=CJxV8vh"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=b679352"></script>
+<script src="/js/entry.js?v=CJxV8vh"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=b679352"></script>
+<script src="/js/entry.js?v=CJxV8vh"></script>
 </body>
 </html>
 {{end}}


### PR DESCRIPTION
The legends on both the depth and candlestick charts were using incorrect units.  On the depth chart, it was applying the conversion factor a second time.  On the candlestick chart, an incorrect struct access was used to get the `unitinfo`, so no conversion was applied.

This should be cherry-picked to `release-v0.4` for RC2.

Depth legend before:

![image](https://user-images.githubusercontent.com/9373513/147293540-9c005e85-bd03-4b13-8fdf-b50f1935f6e6.png)


Depth legend after:

![image](https://user-images.githubusercontent.com/9373513/147293507-b4958a7e-e330-4455-bb45-99dd453f9519.png)

Candlestick legend before:

![image](https://user-images.githubusercontent.com/9373513/147293622-62973f98-2462-44e4-a887-1bef951f8ed8.png)


Candlestick legend after:

![image](https://user-images.githubusercontent.com/9373513/147293599-b6219ff0-d1cb-4541-a881-a65348e09391.png)
