### PR TITLE
server/comms,dex/ws: increase websocket read limits

### DIFF
--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -25,7 +25,7 @@ const (
 	// outBufferSize is the size of the WSLink's buffered channel for outgoing
 	// messages.
 	outBufferSize    = 128
-	defaultReadLimit = 4096
+	defaultReadLimit = 8192
 	writeWait        = 5 * time.Second
 	// ErrPeerDisconnected will be returned if Send or Request is called on a
 	// disconnected link.

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -11,7 +11,7 @@ import (
 	"decred.org/dcrdex/dex/ws"
 )
 
-const readLimitAuthorized = 65536
+const readLimitAuthorized = 262144
 
 // criticalRoutes are not subject to the rate limiter on websocket connections.
 var criticalRoutes = map[string]bool{


### PR DESCRIPTION
**Must** be included in v0.4.

This increases the server's authorized read limit by a factor of 4. We have observed the previous limit of 65 KiB is inadequate when there are a large number of orders in a single epoch, and with more funding coins than normal.  This can be extremely disruptive.

This also doubles the unauthorized/default read limit, which is still quite small at 8192 bytes.