### PR TITLE
client: Add RescanWallet for BTC SPV, with RPC and HTTP API handlers.

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -536,6 +536,23 @@ type ExchangeWallet struct {
 	findRedemptionQueue map[outPoint]*findRedemptionReq
 }
 
+// ExchangeWalletSPV embeds an ExchangeWallet, and also provides the Rescan
+// method to implement asset.Rescanner.
+type ExchangeWalletSPV struct {
+	*ExchangeWallet
+}
+
+// Rescan satisfies the asset.Rescanner interface, and issues a rescan wallet
+// command if the backend is an SPV wallet.
+func (btc *ExchangeWalletSPV) Rescan(_ context.Context) error {
+	// This will panic if not an spvWallet, which would indicate that
+	// openSPVWallet was not used to construct this instance.
+	w := btc.node.(*spvWallet)
+	atomic.StoreInt64(&btc.tipAtConnect, 0) // for progress
+	// Caller should start calling SyncStatus on a ticker.
+	return w.rescanWalletAsync()
+}
+
 type block struct {
 	height int64
 	hash   chainhash.Hash
@@ -727,8 +744,10 @@ func newUnconnectedWallet(cfg *BTCCloneCFG, walletCfg *WalletConfig) (*ExchangeW
 	return w, nil
 }
 
+var _ asset.Wallet = (*ExchangeWallet)(nil)
+
 // openSPVWallet opens the previously created native SPV wallet.
-func openSPVWallet(cfg *BTCCloneCFG) (*ExchangeWallet, error) {
+func openSPVWallet(cfg *BTCCloneCFG) (*ExchangeWalletSPV, error) {
 	walletCfg := new(WalletConfig)
 	err := config.Unmapify(cfg.WalletCFG.Settings, walletCfg)
 	if err != nil {
@@ -747,10 +766,11 @@ func openSPVWallet(cfg *BTCCloneCFG) (*ExchangeWallet, error) {
 
 	btc.node = loadSPVWallet(cfg.WalletCFG.DataDir, cfg.Logger.SubLogger("SPV"), peers, cfg.ChainParams)
 
-	return btc, nil
+	return &ExchangeWalletSPV{btc}, nil
 }
 
-var _ asset.Wallet = (*ExchangeWallet)(nil)
+var _ asset.Wallet = (*ExchangeWalletSPV)(nil)
+var _ asset.Rescanner = (*ExchangeWalletSPV)(nil)
 
 // Info returns basic information about the wallet and asset.
 func (btc *ExchangeWallet) Info() *asset.WalletInfo {

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -46,6 +46,7 @@ const (
 	suspendedAcctErr
 	existenceCheckErr
 	createWalletErr
+	activeOrdersErr
 )
 
 // Error is an error message and an error code.

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -249,6 +250,16 @@ func (w *xcWallet) Disconnect() {
 	w.mtx.Lock()
 	w.hookedUp = false
 	w.mtx.Unlock()
+}
+
+// Rescan will initiate a rescan of the wallet if the asset.Wallet
+// implementation is a Rescanner.
+func (w *xcWallet) Rescan(ctx context.Context) error {
+	rescanner, ok := w.Wallet.(asset.Rescanner)
+	if !ok {
+		return errors.New("wallet does not support rescanning")
+	}
+	return rescanner.Rescan(ctx)
 }
 
 // SwapConfirmations calls (asset.Wallet).SwapConfirmations with a timeout

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -70,6 +70,7 @@ type clientCore interface {
 	Trade(appPass []byte, form *core.TradeForm) (order *core.Order, err error)
 	Wallets() (walletsStates []*core.WalletState)
 	WalletState(assetID uint32) *core.WalletState
+	RescanWallet(assetID uint32, force bool) error
 	Withdraw(appPass []byte, assetID uint32, value uint64, addr string) (asset.Coin, error)
 	ExportSeed(pw []byte) ([]byte, error)
 }

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -39,6 +39,7 @@ type TCore struct {
 	createWalletErr     error
 	newWalletForm       *core.WalletForm
 	openWalletErr       error
+	rescanWalletErr     error
 	walletState         *core.WalletState
 	closeWalletErr      error
 	wallets             []*core.WalletState
@@ -93,6 +94,9 @@ func (c *TCore) Logout() error {
 }
 func (c *TCore) OpenWallet(assetID uint32, pw []byte) error {
 	return c.openWalletErr
+}
+func (c *TCore) RescanWallet(assetID uint32, force bool) error {
+	return c.rescanWalletErr
 }
 func (c *TCore) GetDEXConfig(dexAddr string, certI interface{}) (*core.Exchange, error) {
 	return c.dexExchange, c.getDEXConfigErr

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -441,6 +441,24 @@ func parseWithdrawArgs(params *RawParams) (*withdrawForm, error) {
 	return req, nil
 }
 
+func parseRescanWalletArgs(params *RawParams) (uint32, bool, error) {
+	if err := checkNArgs(params, []int{0}, []int{1, 2}); err != nil {
+		return 0, false, err
+	}
+	assetID, err := checkUIntArg(params.Args[0], "assetID", 32)
+	if err != nil {
+		return 0, false, err
+	}
+	var force bool // do not rescan with active orders by default
+	if len(params.Args) > 1 {
+		force, err = checkBoolArg(params.Args[1], "force")
+		if err != nil {
+			return 0, false, err
+		}
+	}
+	return uint32(assetID), force, nil
+}
+
 func parseOrderBookArgs(params *RawParams) (*orderBookForm, error) {
 	if err := checkNArgs(params, []int{0}, []int{3, 4}); err != nil {
 		return nil, err

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1291,6 +1291,10 @@ func (c *TCore) CreateWallet(appPW, walletPW []byte, form *core.WalletForm) erro
 	return nil
 }
 
+func (c *TCore) RescanWallet(assetID uint32, force bool) error {
+	return nil
+}
+
 func (c *TCore) OpenWallet(assetID uint32, pw []byte) error {
 	c.mtx.RLock()
 	defer c.mtx.RUnlock()

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=qgnUuBH"></script>
+<script src="/js/entry.js?v=zA3PB0J"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -37,6 +37,7 @@ export default class WalletsPage extends BasePage {
         withdraw: getAction(tr, 'withdraw'),
         deposit: getAction(tr, 'deposit'),
         create: getAction(tr, 'create'),
+        rescan: getAction(tr, 'rescan'),
         lock: getAction(tr, 'lock'),
         settings: getAction(tr, 'settings')
       }
@@ -105,6 +106,7 @@ export default class WalletsPage extends BasePage {
       bind(a.withdraw, 'click', e => { run(e, this.showWithdraw.bind(this)) })
       bind(a.deposit, 'click', e => { run(e, this.showDeposit.bind(this)) })
       bind(a.create, 'click', e => { run(e, this.showNewWallet.bind(this)) })
+      bind(a.rescan, 'click', e => { run(e, this.rescanWallet.bind(this)) })
       bind(a.unlock, 'click', e => { run(e, this.openWallet.bind(this)) })
       bind(a.lock, 'click', async e => { run(e, this.lock.bind(this)) })
       bind(a.settings, 'click', e => { run(e, this.showReconfig.bind(this)) })
@@ -238,6 +240,16 @@ export default class WalletsPage extends BasePage {
     await this.newWalletForm.loadDefaults()
   }
 
+  async rescanWallet (assetID) {
+    const loaded = app().loading(this.body)
+    const res = await postJSON('/api/rescanwallet', {
+      assetID: assetID,
+      force: false // TODO input arg
+    })
+    loaded()
+    app().checkResponse(res)
+  }
+
   /* Show the open wallet form if the password is not cached, and otherwise
    * attempt to open the wallet.
    */
@@ -340,7 +352,7 @@ export default class WalletsPage extends BasePage {
     const wallet = app().walletMap[assetID]
     this.depositAsset = this.lastFormAsset = assetID
     if (!wallet) {
-      app().notify(ntfn.make(`No wallet found for ${asset.info.name}`, 'Cannot retrieve deposit address.', ntfn.ERROR)) // TODO: translate
+      app().notify(ntfn.make('Cannot retrieve deposit address.', `No wallet found for ${asset.info.name}`, ntfn.ERROR)) // TODO: translate
       return
     }
     await this.hideBox()
@@ -375,7 +387,7 @@ export default class WalletsPage extends BasePage {
     const asset = this.withdrawAsset = app().assets[assetID]
     const wallet = app().walletMap[assetID]
     if (!wallet) {
-      app().notify(ntfn.make(`No wallet found for ${asset.info.name}`, 'Cannot withdraw.', ntfn.ERROR))
+      app().notify(ntfn.make('Cannot withdraw.', `No wallet found for ${asset.info.name}`, ntfn.ERROR))
     }
     await this.hideBox()
     page.withdrawAddr.value = ''

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=qgnUuBH"></script>
+<script src="/js/entry.js?v=zA3PB0J"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=qgnUuBH"></script>
+<script src="/js/entry.js?v=zA3PB0J"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=qgnUuBH"></script>
+<script src="/js/entry.js?v=zA3PB0J"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -81,6 +81,7 @@ type clientCore interface {
 	AssetBalance(assetID uint32) (*core.WalletBalance, error)
 	CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error
 	OpenWallet(assetID uint32, pw []byte) error
+	RescanWallet(assetID uint32, force bool) error
 	CloseWallet(assetID uint32) error
 	ConnectWallet(assetID uint32) error
 	Wallets() []*core.WalletState
@@ -316,6 +317,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/depositaddress", s.apiNewDepositAddress)
 			apiAuth.Post("/closewallet", s.apiCloseWallet)
 			apiAuth.Post("/connectwallet", s.apiConnectWallet)
+			apiAuth.Post("/rescanwallet", s.apiRescanWallet)
 			apiAuth.Post("/trade", s.apiTrade)
 			apiAuth.Post("/cancel", s.apiCancel)
 			apiAuth.Post("/logout", s.apiLogout)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -53,22 +53,23 @@ func (c *tCoin) Confirmations(context.Context) (uint32, error) {
 }
 
 type TCore struct {
-	balanceErr      error
-	syncFeed        core.BookFeed
-	syncErr         error
-	regErr          error
-	loginErr        error
-	logoutErr       error
-	initErr         error
-	isInited        bool
-	getDEXConfigErr error
-	createWalletErr error
-	openWalletErr   error
-	closeWalletErr  error
-	withdrawErr     error
-	notHas          bool
-	notRunning      bool
-	notOpen         bool
+	balanceErr       error
+	syncFeed         core.BookFeed
+	syncErr          error
+	regErr           error
+	loginErr         error
+	logoutErr        error
+	initErr          error
+	isInited         bool
+	getDEXConfigErr  error
+	createWalletErr  error
+	openWalletErr    error
+	closeWalletErr   error
+	rescannWalletErr error
+	withdrawErr      error
+	notHas           bool
+	notRunning       bool
+	notOpen          bool
 }
 
 func (c *TCore) Network() dex.Network                 { return dex.Mainnet }
@@ -104,6 +105,7 @@ func (c *TCore) WalletState(assetID uint32) *core.WalletState {
 func (c *TCore) CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error {
 	return c.createWalletErr
 }
+func (c *TCore) RescanWallet(assetID uint32, force bool) error    { return c.rescannWalletErr }
 func (c *TCore) OpenWallet(assetID uint32, pw []byte) error       { return c.openWalletErr }
 func (c *TCore) CloseWallet(assetID uint32) error                 { return c.closeWalletErr }
 func (c *TCore) ConnectWallet(assetID uint32) error               { return nil }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -78,6 +78,7 @@ const (
 	TooManyRequestsError              // 59
 	RPCGetDEXConfigError              // 60
 	RPCDiscoverAcctError              // 61
+	RPCWalletRescanError              // 62
 )
 
 // Routes are destinations for a "payload" of data. The type of data being


### PR DESCRIPTION
Requires https://github.com/decred/dcrdex/pull/1383 (the **first commit** in this PR).

Three other commits added in this work:

**`client/asset/btc: add (*spvWallet).rescanWallet`**

Based on btcwallet's current approach for forcing a rescan, this drops all transactions in the wallet db and restarts the wallet.


**`rescanwallet` RPC** 

Trigger wallet recsan from dexcctl.

**client/webserver: rescanwallet http api and button handler**

Add a `(*WebServer).apiRescanWallet` for calling core's rescan wallet method.  Use the `WalletTrait`s that are now in `core.WalletState`.

**IMPORTANT NOTE:**  When you click "Rescan" it is an async process, so the sync status icon will appear and start updating percent.  Due to the issue we have remaining with the wallet birthday and the chain server syncing, it shows 100% at first (although still not synced), but when it reaches the wallet birthday again it goes to sensible number and starts going up as the rescan progresses.  There is [existing commented code here](https://github.com/decred/dcrdex/blob/864f4d01daf040614c55b7b381011324f7a6af73/client/asset/btc/spv.go#L556) that was waiting on a [neutrino PR](https://github.com/lightninglabs/neutrino/pull/235), which was recently merged, so I will update that in another PR soon