### PR TITLE
client/asset,webserver: wallet traits and hide eth new address button

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2553,13 +2553,19 @@ func (btc *ExchangeWallet) refundTx(txHash *chainhash.Hash, vout uint32, contrac
 	return msgTx, nil
 }
 
-// Address returns a new external address from the wallet.
+// Address returns an external address from the wallet.
 func (btc *ExchangeWallet) Address() (string, error) {
 	addr, err := btc.externalAddress()
 	if err != nil {
 		return "", err
 	}
 	return addr.String(), nil
+}
+
+// NewAddress returns a new address from the wallet. This satisfies the
+// NewAddresser interface.
+func (btc *ExchangeWallet) NewAddress() (string, error) {
+	return btc.Address()
 }
 
 // PayFee sends the dex registration fee. Transaction fees are in addition to

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2420,6 +2420,12 @@ func (dcr *ExchangeWallet) Address() (string, error) {
 	return addr.String(), nil
 }
 
+// NewAddress returns a new address from the wallet. This satisfies the
+// NewAddresser interface.
+func (dcr *ExchangeWallet) NewAddress() (string, error) {
+	return dcr.Address()
+}
+
 func (dcr *ExchangeWallet) accountUnlocked(ctx context.Context, acct string) (encrypted, unlocked bool, err error) {
 	var res *walletjson.AccountUnlockedResult
 	res, err = dcr.wallet.AccountUnlocked(ctx, acct)

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1066,7 +1066,8 @@ func (eth *ExchangeWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (
 	return txHash[:], nil
 }
 
-// Address returns an address for the exchange wallet.
+// Address returns an address for the exchange wallet. This implementation is
+// idempotent, always returning the same address for a given ExchangeWallet.
 func (eth *ExchangeWallet) Address() (string, error) {
 	return eth.addr.String(), nil
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1907,6 +1907,7 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 		address:    dbWallet.Address,
 		dbID:       dbWallet.ID(),
 		walletType: dbWallet.Type,
+		traits:     asset.DetermineWalletTraits(w),
 	}, nil
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -760,6 +760,10 @@ func (w *TXCWallet) Address() (string, error) {
 	return "", w.addrErr
 }
 
+func (w *TXCWallet) NewAddress() (string, error) {
+	return "", w.addrErr
+}
+
 func (w *TXCWallet) Unlock(pw []byte) error {
 	return w.unlockErr
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -95,18 +95,19 @@ type WalletBalance struct {
 
 // WalletState is the current status of an exchange wallet.
 type WalletState struct {
-	Symbol       string         `json:"symbol"`
-	AssetID      uint32         `json:"assetID"`
-	Version      uint32         `json:"version"`
-	WalletType   string         `json:"type"`
-	Open         bool           `json:"open"`
-	Running      bool           `json:"running"`
-	Balance      *WalletBalance `json:"balance"`
-	Address      string         `json:"address"`
-	Units        string         `json:"units"`
-	Encrypted    bool           `json:"encrypted"`
-	Synced       bool           `json:"synced"`
-	SyncProgress float32        `json:"syncProgress"`
+	Symbol       string            `json:"symbol"`
+	AssetID      uint32            `json:"assetID"`
+	Version      uint32            `json:"version"`
+	WalletType   string            `json:"type"`
+	Traits       asset.WalletTrait `json:"traits"`
+	Open         bool              `json:"open"`
+	Running      bool              `json:"running"`
+	Balance      *WalletBalance    `json:"balance"`
+	Address      string            `json:"address"`
+	Units        string            `json:"units"`
+	Encrypted    bool              `json:"encrypted"`
+	Synced       bool              `json:"synced"`
+	SyncProgress float32           `json:"syncProgress"`
 }
 
 // User is information about the user's wallets and DEX accounts.

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -21,6 +21,7 @@ type xcWallet struct {
 	AssetID    uint32
 	dbID       []byte
 	walletType string
+	traits     asset.WalletTrait
 
 	mtx          sync.RWMutex
 	encPass      []byte // empty means wallet not password protected
@@ -153,6 +154,7 @@ func (w *xcWallet) state() *WalletState {
 		Synced:       w.synced,
 		SyncProgress: w.syncProgress,
 		WalletType:   w.walletType,
+		Traits:       w.traits,
 	}
 }
 
@@ -177,7 +179,12 @@ func (w *xcWallet) refreshDepositAddress() (string, error) {
 			unbip(w.AssetID))
 	}
 
-	addr, err := w.Address()
+	na, is := w.Wallet.(asset.NewAddresser)
+	if !is {
+		return "", fmt.Errorf("wallet does not generate new addresses")
+	}
+
+	addr, err := na.NewAddress()
 	if err != nil {
 		return "", fmt.Errorf("%s Wallet.Address error: %w", unbip(w.AssetID), err)
 	}

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -18,6 +18,7 @@ var EnUS = map[string]string{
 	"app_password_helper":            "Your app password is always required when performing sensitive wallet operations.",
 	"Add":                            "Add",
 	"Unlock":                         "Unlock",
+	"Rescan":                         "Rescan",
 	"Wallet":                         "Wallet",
 	"app_password_reminder":          "Your app password is always required when performing sensitive wallet operations.",
 	"DEX Address":                    "DEX Address",

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=JdbTyt"></script>
+<script src="/js/entry.js?v=qgnUuBH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -23,20 +23,22 @@
 {{define "actionButtons"}}
   {{$w := .Wallet}}
   {{if $w}}
-  {{$ready := and $w.Running $w.Open}}
-  <button data-action="connect"{{if $w.Running}} class="d-hide"{{end}}>[[[Connect]]]</button>
-  <button data-action="unlock"{{if $w.Open}} class="d-hide"{{end}}>[[[Unlock]]]</button>
-  <button data-action="withdraw"{{if not $ready}} class="d-hide"{{end}}>[[[Withdraw]]]</button>
-  <button data-action="deposit"{{if not $ready}} class="d-hide"{{end}}>[[[Deposit]]]</button>
-  <button data-action="lock"{{if or (not $ready) (not $w.Encrypted)}} class="d-hide"{{end}}>[[[Lock]]]</button>
-  <button data-action="create" class="d-hide">[[[create_a_x_wallet]]]</button>
+    {{$ready := and $w.Running $w.Open}}
+    <button data-action="connect"{{if $w.Running}} class="d-hide"{{end}}>[[[Connect]]]</button>
+    <button data-action="unlock"{{if $w.Open}} class="d-hide"{{end}}>[[[Unlock]]]</button>
+    <button data-action="withdraw"{{if not $ready}} class="d-hide"{{end}}>[[[Withdraw]]]</button>
+    <button data-action="deposit"{{if not $ready}} class="d-hide"{{end}}>[[[Deposit]]]</button>
+    <button data-action="lock"{{if or (not $ready) (not $w.Encrypted)}} class="d-hide"{{end}}>[[[Lock]]]</button>
+    <button data-action="rescan"{{if not $w.Traits.IsRescanner}} class="d-hide"{{end}}>[[[Rescan]]]</button>
+    <button data-action="create" class="d-hide">[[[create_a_x_wallet]]]</button>
     <span data-action="settings" class="ico-settings fs20 pointer"></span>
-    {{else}}
+  {{else}}
     <button data-action="connect" class="d-hide">[[[Connect]]]</button>
     <button data-action="unlock" class="d-hide">[[[Unlock]]]</button>
     <button data-action="withdraw" class="d-hide">[[[Withdraw]]]</button>
     <button data-action="deposit" class="d-hide">[[[Deposit]]]</button>
     <button data-action="lock" class="d-hide">[[[Lock]]]</button>
+    <button data-action="rescan" class="d-hide">[[[Rescan]]]</button>
     <button data-action="create">[[[create_a_x_wallet]]]</button>
     <span data-action="settings" class="ico-settings fs20 pointer d-hide"></span>
   {{end}}

--- a/client/webserver/site/src/js/wallets.js
+++ b/client/webserver/site/src/js/wallets.js
@@ -9,6 +9,7 @@ import * as intl from './locales'
 
 const bind = Doc.bind
 const animationLength = 300
+const traitNewAddresser = 1 << 1
 
 export default class WalletsPage extends BasePage {
   constructor (body) {
@@ -345,6 +346,8 @@ export default class WalletsPage extends BasePage {
     await this.hideBox()
     page.depositName.textContent = asset.info.name
     page.depositAddress.textContent = wallet.address
+    if ((wallet.traits & traitNewAddresser) !== 0) Doc.show(page.newDepAddrBttn)
+    else Doc.hide(page.newDepAddrBttn)
     this.animation = this.showBox(box)
   }
 

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=JdbTyt"></script>
+<script src="/js/entry.js?v=qgnUuBH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -23,20 +23,22 @@
 {{define "actionButtons"}}
   {{$w := .Wallet}}
   {{if $w}}
-  {{$ready := and $w.Running $w.Open}}
-  <button data-action="connect"{{if $w.Running}} class="d-hide"{{end}}>Connect</button>
-  <button data-action="unlock"{{if $w.Open}} class="d-hide"{{end}}>Unlock</button>
-  <button data-action="withdraw"{{if not $ready}} class="d-hide"{{end}}>Withdraw</button>
-  <button data-action="deposit"{{if not $ready}} class="d-hide"{{end}}>Deposit</button>
-  <button data-action="lock"{{if or (not $ready) (not $w.Encrypted)}} class="d-hide"{{end}}>Lock</button>
-  <button data-action="create" class="d-hide">Create a {{.Info.Name}} Wallet</button>
+    {{$ready := and $w.Running $w.Open}}
+    <button data-action="connect"{{if $w.Running}} class="d-hide"{{end}}>Connect</button>
+    <button data-action="unlock"{{if $w.Open}} class="d-hide"{{end}}>Unlock</button>
+    <button data-action="withdraw"{{if not $ready}} class="d-hide"{{end}}>Withdraw</button>
+    <button data-action="deposit"{{if not $ready}} class="d-hide"{{end}}>Deposit</button>
+    <button data-action="lock"{{if or (not $ready) (not $w.Encrypted)}} class="d-hide"{{end}}>Lock</button>
+    <button data-action="rescan"{{if not $w.Traits.IsRescanner}} class="d-hide"{{end}}>Rescan</button>
+    <button data-action="create" class="d-hide">Create a {{.Info.Name}} Wallet</button>
     <span data-action="settings" class="ico-settings fs20 pointer"></span>
-    {{else}}
+  {{else}}
     <button data-action="connect" class="d-hide">Connect</button>
     <button data-action="unlock" class="d-hide">Unlock</button>
     <button data-action="withdraw" class="d-hide">Withdraw</button>
     <button data-action="deposit" class="d-hide">Deposit</button>
     <button data-action="lock" class="d-hide">Lock</button>
+    <button data-action="rescan" class="d-hide">Rescan</button>
     <button data-action="create">Create a {{.Info.Name}} Wallet</button>
     <span data-action="settings" class="ico-settings fs20 pointer d-hide"></span>
   {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=JdbTyt"></script>
+<script src="/js/entry.js?v=qgnUuBH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -23,20 +23,22 @@
 {{define "actionButtons"}}
   {{$w := .Wallet}}
   {{if $w}}
-  {{$ready := and $w.Running $w.Open}}
-  <button data-action="connect"{{if $w.Running}} class="d-hide"{{end}}>Conectar</button>
-  <button data-action="unlock"{{if $w.Open}} class="d-hide"{{end}}>Destrancar</button>
-  <button data-action="withdraw"{{if not $ready}} class="d-hide"{{end}}>Retirar</button>
-  <button data-action="deposit"{{if not $ready}} class="d-hide"{{end}}>Depositar</button>
-  <button data-action="lock"{{if or (not $ready) (not $w.Encrypted)}} class="d-hide"{{end}}>Trancar</button>
-  <button data-action="create" class="d-hide">Criar uma Carteira {{.Info.Name}}</button>
+    {{$ready := and $w.Running $w.Open}}
+    <button data-action="connect"{{if $w.Running}} class="d-hide"{{end}}>Conectar</button>
+    <button data-action="unlock"{{if $w.Open}} class="d-hide"{{end}}>Destrancar</button>
+    <button data-action="withdraw"{{if not $ready}} class="d-hide"{{end}}>Retirar</button>
+    <button data-action="deposit"{{if not $ready}} class="d-hide"{{end}}>Depositar</button>
+    <button data-action="lock"{{if or (not $ready) (not $w.Encrypted)}} class="d-hide"{{end}}>Trancar</button>
+    <button data-action="rescan"{{if not $w.Traits.IsRescanner}} class="d-hide"{{end}}>Rescan</button>
+    <button data-action="create" class="d-hide">Criar uma Carteira {{.Info.Name}}</button>
     <span data-action="settings" class="ico-settings fs20 pointer"></span>
-    {{else}}
+  {{else}}
     <button data-action="connect" class="d-hide">Conectar</button>
     <button data-action="unlock" class="d-hide">Destrancar</button>
     <button data-action="withdraw" class="d-hide">Retirar</button>
     <button data-action="deposit" class="d-hide">Depositar</button>
     <button data-action="lock" class="d-hide">Trancar</button>
+    <button data-action="rescan" class="d-hide">Rescan</button>
     <button data-action="create">Criar uma Carteira {{.Info.Name}}</button>
     <span data-action="settings" class="ico-settings fs20 pointer d-hide"></span>
   {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=JdbTyt"></script>
+<script src="/js/entry.js?v=qgnUuBH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -23,20 +23,22 @@
 {{define "actionButtons"}}
   {{$w := .Wallet}}
   {{if $w}}
-  {{$ready := and $w.Running $w.Open}}
-  <button data-action="connect"{{if $w.Running}} class="d-hide"{{end}}>连接</button>
-  <button data-action="unlock"{{if $w.Open}} class="d-hide"{{end}}>解锁</button>
-  <button data-action="withdraw"{{if not $ready}} class="d-hide"{{end}}>提款</button>
-  <button data-action="deposit"{{if not $ready}} class="d-hide"{{end}}>存款</button>
-  <button data-action="lock"{{if or (not $ready) (not $w.Encrypted)}} class="d-hide"{{end}}>锁定</button>
-  <button data-action="create" class="d-hide">创建{{.Info.Name}}钱包</button>
+    {{$ready := and $w.Running $w.Open}}
+    <button data-action="connect"{{if $w.Running}} class="d-hide"{{end}}>连接</button>
+    <button data-action="unlock"{{if $w.Open}} class="d-hide"{{end}}>解锁</button>
+    <button data-action="withdraw"{{if not $ready}} class="d-hide"{{end}}>提款</button>
+    <button data-action="deposit"{{if not $ready}} class="d-hide"{{end}}>存款</button>
+    <button data-action="lock"{{if or (not $ready) (not $w.Encrypted)}} class="d-hide"{{end}}>锁定</button>
+    <button data-action="rescan"{{if not $w.Traits.IsRescanner}} class="d-hide"{{end}}>Rescan</button>
+    <button data-action="create" class="d-hide">创建{{.Info.Name}}钱包</button>
     <span data-action="settings" class="ico-settings fs20 pointer"></span>
-    {{else}}
+  {{else}}
     <button data-action="connect" class="d-hide">连接</button>
     <button data-action="unlock" class="d-hide">解锁</button>
     <button data-action="withdraw" class="d-hide">提款</button>
     <button data-action="deposit" class="d-hide">存款</button>
     <button data-action="lock" class="d-hide">锁定</button>
+    <button data-action="rescan" class="d-hide">Rescan</button>
     <button data-action="create">创建{{.Info.Name}}钱包</button>
     <span data-action="settings" class="ico-settings fs20 pointer d-hide"></span>
   {{end}}


### PR DESCRIPTION
Required for https://github.com/decred/dcrdex/pull/1374 and a future solution to the Send vs. Withdraw (or Sweep) issue in https://github.com/decred/dcrdex/pull/1355#discussion_r775917934

This PR adds a `client/core.WalletTrait` type that is a bitset communicating various optional functionality of a `client/asset.Wallet` in an `xcWallet` (via a new `core.WalletState` field).

As an initial application of the traits, this hides the ETH wallet's "New deposit address" button.