### PR TITLE
dexcctl: prerelease and metadata build info

### DIFF
--- a/client/cmd/dexcctl/config.go
+++ b/client/cmd/dexcctl/config.go
@@ -83,11 +83,9 @@ func configure() (*config, []string, bool, error) {
 	}
 
 	// Show the version and exit if the version flag was specified.
-	appName := filepath.Base(os.Args[0])
-	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	if cfg.ShowVersion {
 		fmt.Printf("%s version %s (Go version %s %s/%s)\n", appName,
-			version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			version(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		return nil, nil, stop, nil
 	}
 

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -25,19 +25,6 @@ const (
 	listCmdMessage  = "Specify -l to list available commands"
 )
 
-// version is the dex server's release version.
-var version = semver{major: 0, minor: 4, patch: 0}
-
-// semver holds dexcctl's semver values.
-type semver struct {
-	major, minor, patch uint32
-}
-
-// String satisfies fmt.Stringer.
-func (s semver) String() string {
-	return fmt.Sprintf("%d.%d.%d", s.major, s.minor, s.patch)
-}
-
 func main() {
 	// Create a context that is canceled when a shutdown signal is received.
 	ctx := withShutdownCancel(context.Background())

--- a/client/cmd/dexcctl/version.go
+++ b/client/cmd/dexcctl/version.go
@@ -1,0 +1,97 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+const (
+	// semanticAlphabet defines the allowed characters for the pre-release
+	// portion of a semantic version string.
+	semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+
+	// semanticBuildAlphabet defines the allowed characters for the build
+	// portion of a semantic version string.
+	semanticBuildAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
+)
+
+// These constants define the application version and follow the semantic
+// versioning 2.0.0 spec (http://semver.org/).
+const (
+	appName  string = "dexcctl"
+	appMajor uint   = 0
+	appMinor uint   = 4
+	appPatch uint   = 0
+)
+
+// go build -v -ldflags "-X decred.org/dcrdex/client/cmd/dexc/version.appPreRelease= -X decred.org/dcrdex/client/cmd/dexc/version.appBuild=$(git rev-parse --short HEAD)"
+var (
+	// appPreRelease is defined as a variable so it can be overridden during the
+	// build process. It MUST only contain characters from semanticAlphabet per
+	// the semantic versioning spec.
+	appPreRelease = "pre"
+
+	// appBuild is defined as a variable so it can be overridden during the
+	// build process. It MUST only contain characters from semanticBuildAlphabet
+	// per the semantic versioning spec.
+	appBuild = "dev"
+)
+
+// version returns the application version as a properly formed string per the
+// semantic versioning 2.0.0 spec (http://semver.org/).
+func version() string {
+	// Start with the major, minor, and patch versions.
+	version := fmt.Sprintf("%d.%d.%d", appMajor, appMinor, appPatch)
+
+	// Append pre-release version if there is one.  The hyphen called for
+	// by the semantic versioning spec is automatically appended and should
+	// not be contained in the pre-release string.  The pre-release version
+	// is not appended if it contains invalid characters.
+	preRelease := normalizePreRelString(appPreRelease)
+	if preRelease != "" {
+		version = fmt.Sprintf("%s-%s", version, preRelease)
+	}
+
+	// Append build metadata if there is any.  The plus called for
+	// by the semantic versioning spec is automatically appended and should
+	// not be contained in the build metadata string.  The build metadata
+	// string is not appended if it contains invalid characters.
+	build := normalizeBuildString(appBuild)
+	if build != "" {
+		version = fmt.Sprintf("%s+%s", version, build)
+	}
+
+	return version
+}
+
+// normalizeSemString returns the passed string stripped of all characters
+// which are not valid according to the provided semantic versioning alphabet.
+func normalizeSemString(str, alphabet string) string {
+	var result bytes.Buffer
+	for _, r := range str {
+		if strings.ContainsRune(alphabet, r) {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+// normalizePreRelString returns the passed string stripped of all characters
+// which are not valid according to the semantic versioning guidelines for
+// pre-release strings.  In particular they MUST only contain characters in
+// semanticAlphabet.
+func normalizePreRelString(str string) string {
+	return normalizeSemString(str, semanticAlphabet)
+}
+
+// normalizeBuildString returns the passed string stripped of all characters
+// which are not valid according to the semantic versioning guidelines for build
+// metadata strings.  In particular they MUST only contain characters in
+// semanticBuildAlphabet.
+func normalizeBuildString(str string) string {
+	return normalizeSemString(str, semanticBuildAlphabet)
+}

--- a/pkg.sh
+++ b/pkg.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VER="v0.3.0"
+VER="v0.4.0"
 
 rm -rf bin
 mkdir -p bin/dexc-windows-amd64-${VER}
@@ -24,11 +24,11 @@ GOOS=darwin GOARCH=arm64 go build -trimpath -o ../../../bin/dexc-darwin-arm64-${
 popd
 
 pushd client/cmd/dexcctl
-GOOS=linux GOARCH=amd64 go build -trimpath -o ../../../bin/dexc-linux-amd64-${VER}
-GOOS=linux GOARCH=arm64 go build -trimpath -o ../../../bin/dexc-linux-arm64-${VER}
-GOOS=windows GOARCH=amd64 go build -trimpath -o ../../../bin/dexc-windows-amd64-${VER}
-GOOS=darwin GOARCH=amd64 go build -trimpath -o ../../../bin/dexc-darwin-amd64-${VER}
-GOOS=darwin GOARCH=arm64 go build -trimpath -o ../../../bin/dexc-darwin-arm64-${VER}
+GOOS=linux GOARCH=amd64 go build -trimpath -o ../../../bin/dexc-linux-amd64-${VER} -ldflags "$LDFLAGS"
+GOOS=linux GOARCH=arm64 go build -trimpath -o ../../../bin/dexc-linux-arm64-${VER} -ldflags "$LDFLAGS"
+GOOS=windows GOARCH=amd64 go build -trimpath -o ../../../bin/dexc-windows-amd64-${VER} -ldflags "$LDFLAGS"
+GOOS=darwin GOARCH=amd64 go build -trimpath -o ../../../bin/dexc-darwin-amd64-${VER} -ldflags "$LDFLAGS"
+GOOS=darwin GOARCH=arm64 go build -trimpath -o ../../../bin/dexc-darwin-arm64-${VER} -ldflags "$LDFLAGS"
 popd
 
 pushd client/webserver/site


### PR DESCRIPTION
Just copying the version stuff from dexc to resolve https://github.com/decred/dcrdex/issues/1378

I'm aware there are new approaches. i.e. https://github.com/decred/dcrd/pull/2651 Please tell me if you want both dexc and dexcctl done that way @jrick .  I really don't have a preference.