### PR TITLE
client/asset/{btc,dcr}: reset redeemScripts when changing min confs

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1442,7 +1442,7 @@ func fund(utxos []*compositeUTXO, enough func(uint64, uint64) bool) (
 
 	tryUTXOs := func(minconf uint32) bool {
 		sum, size = 0, 0
-		coins, spents = nil, nil
+		coins, spents, redeemScripts = nil, nil, nil
 		fundingCoins = make(map[outPoint]*utxo)
 
 		okUTXOs := make([]*compositeUTXO, 0, len(utxos)) // over-allocate
@@ -1475,7 +1475,8 @@ func fund(utxos []*compositeUTXO, enough func(uint64, uint64) bool) (
 	// First try with confs>0, falling back to allowing 0-conf outputs.
 	if !tryUTXOs(1) {
 		if !tryUTXOs(0) {
-			return 0, 0, nil, nil, nil, nil, fmt.Errorf("not enough to cover requested funds %s available", amount(sum))
+			return 0, 0, nil, nil, nil, nil, fmt.Errorf("not enough to cover requested funds. "+
+				"%s BTC available in %d UTXOs", amount(sum), len(coins))
 		}
 	}
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1180,7 +1180,7 @@ func (dcr *ExchangeWallet) tryFund(utxos []*compositeUTXO, enough func(sum uint6
 
 	tryUTXOs := func(minconf int64) (ok bool, err error) {
 		sum, size = 0, 0
-		coins, spents = nil, nil
+		coins, spents, redeemScripts = nil, nil, nil
 
 		okUTXOs := make([]*compositeUTXO, 0, len(utxos)) // over-allocate
 		for _, cu := range utxos {
@@ -1225,7 +1225,8 @@ func (dcr *ExchangeWallet) tryFund(utxos []*compositeUTXO, enough func(sum uint6
 			return 0, 0, nil, nil, nil, err
 		}
 		if !ok {
-			return 0, 0, nil, nil, nil, fmt.Errorf("not enough to cover requested funds. %s DCR available", amount(sum))
+			return 0, 0, nil, nil, nil, fmt.Errorf("not enough to cover requested funds. "+
+				"%s DCR available in %d UTXOs", amount(sum), len(coins))
 		}
 	}
 


### PR DESCRIPTION
In the UTXO selection methods for DCR and BTC, initially only UTXOs with >0 confs are tried, and if there are insufficient funds, it
attempts it again with unconfirmed utxos included (minus "untrusted" for BTC). However, on the second run, both methods neglect to reset the `redeemScripts` slices.  This fixes the issue.