### PR TITLE
client/eth: Sign redeems.

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -227,6 +227,14 @@ type Wallet interface {
 	RegFeeConfirmations(ctx context.Context, coinID dex.Bytes) (confs uint32, err error)
 }
 
+// AccountRedeemer is implemented by account based assets and has methods that
+// support their redemption needs.
+type AccountRedeemer interface {
+	// SignRedeem signs a message that allows a server to verify that this
+	// account owns a redemption address.
+	SignRedeem(dex.Bytes) (pubkey, sig dex.Bytes, err error)
+}
+
 // Balance is categorized information about a wallet's balance.
 type Balance struct {
 	// Available is the balance that is available for trading immediately.


### PR DESCRIPTION
    Add an AccountRedeemer interface that enables signing redeems for
    account based wallets when they will be a redeemer in a trade.

Preemptively adds the Account Redeemer interface in #1314 This does not attempt to solve the balance reserving problem, but allows signing redemptions so that we can use the eth wallet to redeem trades.