### PR TITLE
[release-v0.2] correct the dex pubkey tag in the config response

### DIFF
--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1032,7 +1032,7 @@ type Asset struct {
 
 // ConfigResult is the successful result for the ConfigRoute.
 type ConfigResult struct {
-	DEXPubKey        Bytes     `json:"dexpubkey,omitempty"` // empty prior to 0.2.2
+	DEXPubKey        Bytes     `json:"pubkey,omitempty"` // empty prior to 0.2.2
 	CancelMax        float64   `json:"cancelmax"`
 	BroadcastTimeout uint64    `json:"btimeout"`
 	RegFeeConfirms   uint16    `json:"regfeeconfirms"`


### PR DESCRIPTION
The backport in https://github.com/decred/dcrdex/pull/1155 was bad. 
:cry: 