### PR TITLE
server/eth: Use contract addresses in dex/eth

### DIFF
--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -244,7 +244,13 @@ func TestDecodeCoinID(t *testing.T) {
 
 func TestRun(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
-	backend := unconnectedETH(tLogger, new(config))
+	cfg := &config{
+		network: dex.Simnet,
+	}
+	backend, err := unconnectedETH(tLogger, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 	backend.node = &testNode{
 		bestHdr: &types.Header{Number: big.NewInt(1)},
 	}


### PR DESCRIPTION
Update server's eth backend to get swap contract addresses from the same place as the client.