### PR TITLE
eth: Funding coin encoding.

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -134,9 +134,9 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Ne
 
 // DecodeCoinID creates a human-readable representation of a coin ID for Ethereum.
 func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
-	id, err := dexeth.DecodeCoinID(coinID)
+	id, err := decodeFundingCoinID(coinID)
 	if err != nil {
-		return "", nil
+		return "<invalid coin>", err
 	}
 	return id.String(), nil
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -283,6 +283,13 @@ type Coin interface {
 	Value() uint64
 }
 
+type RecoveryCoin interface {
+	// RecoveryID is an ID that can be used to re-establish funding state during
+	// startup. If a Coin implements RecoveryCoin, the RecoveryID will be used
+	// in the database record, and ultimately passed to the FundingCoin method.
+	RecoveryID() dex.Bytes
+}
+
 // Coins a collection of coins as returned by Fund.
 type Coins []Coin
 

--- a/client/cmd/dexc/importlgpl.go
+++ b/client/cmd/dexc/importlgpl.go
@@ -12,5 +12,5 @@ package main
 // import (
 // 	ETH is commented to prevent go-ethereum goroutines from launching via
 // 	it's init(). Uncomment this when ETH is ready:
-// 	_ "decred.org/dcrdex/client/asset/eth" // register eth asset
+//	_ "decred.org/dcrdex/client/asset/eth" // register eth asset
 // )

--- a/client/cmd/dexc/importlgpl.go
+++ b/client/cmd/dexc/importlgpl.go
@@ -9,8 +9,6 @@
 
 package main
 
-// import (
-// 	ETH is commented to prevent go-ethereum goroutines from launching via
-// 	it's init(). Uncomment this when ETH is ready:
-//	_ "decred.org/dcrdex/client/asset/eth" // register eth asset
-// )
+import (
+	_ "decred.org/dcrdex/client/asset/eth" // register eth asset
+)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4094,6 +4094,15 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 		}()
 	}
 
+	// A non-nil changeID indicates that this is an account based coin. The
+	// first coin is an address and the entire serialized message needs to
+	// be signed with that address's private key.
+	if changeID != nil {
+		if _, msgTrade.Coins[0].Sigs, err = fromWallet.SignMessage(nil, msgOrder.Serialize()); err != nil {
+			return nil, 0, fmt.Errorf("wallet %v failed to sign for redeem: %w", wallets.fromAsset.ID, err)
+		}
+	}
+
 	commitSig := make(chan struct{})
 	defer close(commitSig) // signals on both success and failure, unlike syncOrderPlaced/piSyncers
 	c.sentCommitsMtx.Lock()

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -2539,7 +2539,14 @@ func (t *trackedTrade) returnCoins() {
 func mapifyCoins(coins asset.Coins) map[string]asset.Coin {
 	coinMap := make(map[string]asset.Coin, len(coins))
 	for _, c := range coins {
-		cid := hex.EncodeToString(c.ID())
+		var cid string
+		if rc, is := c.(asset.RecoveryCoin); is {
+			// Account coins are keyed by a coin that includes
+			// address and value. The ID only returns address.
+			cid = hex.EncodeToString(rc.RecoveryID())
+		} else {
+			cid = hex.EncodeToString(c.ID())
+		}
 		coinMap[cid] = c
 	}
 	return coinMap

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1639,8 +1639,12 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 	if change == nil {
 		t.metaData.ChangeCoin = nil
 	} else {
-		t.coins[hex.EncodeToString(change.ID())] = change
-		t.metaData.ChangeCoin = []byte(change.ID())
+		cid := change.ID()
+		if rc, is := change.(asset.RecoveryCoin); is {
+			cid = rc.RecoveryID()
+		}
+		t.coins[cid.String()] = change
+		t.metaData.ChangeCoin = []byte(cid)
 		c.log.Debugf("Saving change coin %v (%v) to DB for order %v",
 			coinIDString(fromAsset.ID, t.metaData.ChangeCoin), fromAsset.Symbol, t.ID())
 	}

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -363,8 +363,9 @@ func (eth *Backend) AccountBalance(addrStr string) (uint64, error) {
 // ValidateSignature checks that the pubkey is correct for the address and
 // that the signature shows ownership of the associated private key.
 func (eth *Backend) ValidateSignature(addr string, pubkey, msg, sig []byte) error {
-	if len(sig) != 65 {
-		return fmt.Errorf("expected sig length of sixty five bytes but got %d", len(sig))
+	const sigLen = 64
+	if len(sig) != sigLen {
+		return fmt.Errorf("expected sig length of %d bytes but got %d", sigLen, len(sig))
 	}
 	ethPK, err := crypto.UnmarshalPubkey(pubkey)
 	if err != nil {

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -820,7 +820,7 @@ func TestValidateSignature(t *testing.T) {
 	// "ok" values used are the same as tests in client/assets/eth.
 	pkBytes := mustParseHex("04b911d1f39f7792e165767e35aa134083e2f70ac7de6945d7641a3015d09a54561b71112b8d60f63831f0e62c23c6921ec627820afedf8236155b9e9bd82b6523")
 	msg := []byte("msg")
-	sigBytes := mustParseHex("ffd26911d3fdaf11ac44801744f2df015a16539b6e688aff4cabc092b747466e7bc8036a03d1479a1570dd11bf042120301c34a65b237267720ef8a9e56f2eb101")
+	sigBytes := mustParseHex("ffd26911d3fdaf11ac44801744f2df015a16539b6e688aff4cabc092b747466e7bc8036a03d1479a1570dd11bf042120301c34a65b237267720ef8a9e56f2eb1")
 	max32Bytes := mustParseHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 	addr := "0x2b84C791b79Ee37De042AD2ffF1A253c3ce9bc27"
 	eth := new(Backend)


### PR DESCRIPTION
depends on #1314 

This is what it would look like to encode the coin as a string. However, this changes the order ID, I believe, as the funding coins are all serialized and become part of the id
https://github.com/decred/dcrdex/blob/986c765be89df6e45cae5ef538675b2700c7f7a9/dex/order/order.go#L536-L541

I think maybe another field for `msgjson.Trade` might be best and leave the coins alone? Like `FundingAddress`.