### PR TITLE
app: correct price in depth chart legend

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=JdbTy"></script>
+<script src="/js/entry.js?v=JdbTyt"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -636,7 +636,7 @@ export default class MarketsPage extends BasePage {
       }
     }
 
-    page.hoverPrice.textContent = Doc.formatCoinValue(d.rate / this.market.rateConversionFactor)
+    page.hoverPrice.textContent = Doc.formatCoinValue(d.rate)
     page.hoverVolume.textContent = Doc.formatCoinValue(d.depth)
     page.hoverVolume.style.color = d.dotColor
     Doc.show(page.hoverData)

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=JdbTy"></script>
+<script src="/js/entry.js?v=JdbTyt"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=JdbTy"></script>
+<script src="/js/entry.js?v=JdbTyt"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=JdbTy"></script>
+<script src="/js/entry.js?v=JdbTyt"></script>
 </body>
 </html>
 {{end}}


### PR DESCRIPTION
As seen in the depth screen shots in https://github.com/decred/dcrdex/pull/1368, the price in the depth chart legend was showing as zero.  This is because the conversion factor was being applied to the `rate` field when it was already applied (`msgrate` contains the atomic "message rate").