### PR TITLE
client/asset/eth: finish client wallet tokens

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1108,8 +1108,8 @@ func (btc *baseWallet) feeRateWithFallback(feeSuggestion uint64) uint64 {
 // associated with nfo.MaxFeeRate. For quote assets, the caller will have to
 // calculate lotSize based on a rate conversion from the base asset's lot size.
 // lotSize must not be zero and will cause a panic if so.
-func (btc *baseWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*asset.SwapEstimate, error) {
-	_, maxEst, err := btc.maxOrder(lotSize, feeSuggestion, nfo)
+func (btc *baseWallet) MaxOrder(ord *asset.MaxOrderForm) (*asset.SwapEstimate, error) {
+	_, maxEst, err := btc.maxOrder(ord.LotSize, ord.FeeSuggestion, ord.AssetConfig)
 	return maxEst, err
 }
 

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1223,7 +1223,11 @@ func testFundingCoins(t *testing.T, segwit bool, walletType string) {
 
 func checkMaxOrder(t *testing.T, wallet asset.Wallet, lots, swapVal, maxFees, estWorstCase, estBestCase, locked uint64) {
 	t.Helper()
-	maxOrder, err := wallet.MaxOrder(tLotSize, feeSuggestion, tBTC)
+	maxOrder, err := wallet.MaxOrder(&asset.MaxOrderForm{
+		LotSize:       tLotSize,
+		FeeSuggestion: feeSuggestion,
+		AssetConfig:   tBTC,
+	})
 	if err != nil {
 		t.Fatalf("MaxOrder error: %v", err)
 	}
@@ -2765,8 +2769,9 @@ func testPreRedeem(t *testing.T, segwit bool, walletType string) {
 	defer shutdown()
 
 	preRedeem, err := wallet.PreRedeem(&asset.PreRedeemForm{
-		LotSize: 123456, // Doesn't actually matter
-		Lots:    5,
+		LotSize:     123456, // Doesn't actually matter
+		Lots:        5,
+		AssetConfig: tBTC,
 	})
 	// Shouldn't actually be any path to error.
 	if err != nil {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -708,8 +708,8 @@ func (a amount) String() string {
 // associated with nfo.MaxFeeRate. For quote assets, the caller will have to
 // calculate lotSize based on a rate conversion from the base asset's lot size.
 // lotSize must not be zero and will cause a panic if so.
-func (dcr *ExchangeWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*asset.SwapEstimate, error) {
-	_, est, err := dcr.maxOrder(lotSize, feeSuggestion, nfo)
+func (dcr *ExchangeWallet) MaxOrder(ord *asset.MaxOrderForm) (*asset.SwapEstimate, error) {
+	_, est, err := dcr.maxOrder(ord.LotSize, ord.FeeSuggestion, ord.AssetConfig)
 	return est, err
 }
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1088,7 +1088,7 @@ func TestFundingCoins(t *testing.T) {
 
 func checkMaxOrder(t *testing.T, wallet *ExchangeWallet, lots, swapVal, maxFees, estWorstCase, estBestCase, locked uint64) {
 	t.Helper()
-	maxOrder, err := wallet.MaxOrder(tLotSize, feeSuggestion, tDCR)
+	_, maxOrder, err := wallet.maxOrder(tLotSize, feeSuggestion, tDCR)
 	if err != nil {
 		t.Fatalf("MaxOrder error: %v", err)
 	}
@@ -2459,8 +2459,9 @@ func TestPreRedeem(t *testing.T) {
 	defer shutdown()
 
 	preRedeem, err := wallet.PreRedeem(&asset.PreRedeemForm{
-		LotSize: 123456, // Doesn't actually matter
-		Lots:    5,
+		LotSize:     123456, // Doesn't actually matter
+		Lots:        5,
+		AssetConfig: tDCR,
 	})
 	// Shouldn't actually be any path to error.
 	if err != nil {

--- a/client/asset/estimation.go
+++ b/client/asset/estimation.go
@@ -45,6 +45,9 @@ type PreSwapForm struct {
 	Lots uint64
 	// AssetConfig is the dex's asset configuration info.
 	AssetConfig *dex.Asset
+	// RedeemConfig is the dex's asset configuration info for the redemption
+	// asset.
+	RedeemConfig *dex.Asset
 	// Immediate should be set to true if this is for an order that is not a
 	// standing order, likely a market order or a limit order with immediate
 	// time-in-force.
@@ -79,6 +82,8 @@ type PreRedeemForm struct {
 	FeeSuggestion uint64
 	// SelectedOptions is any options that the user has selected.
 	SelectedOptions map[string]string
+	// AssetConfig is the dex's asset configuration info.
+	AssetConfig *dex.Asset
 }
 
 // PreRedeem is an estimate of the fees for redemption. The struct will be
@@ -86,4 +91,12 @@ type PreRedeemForm struct {
 type PreRedeem struct {
 	Estimate *RedeemEstimate `json:"estimate"`
 	Options  []*OrderOption  `json:"options"`
+}
+
+// MaxOrderForm is used to get a SwapEstimate from the Wallet's MaxOrder method.
+type MaxOrderForm struct {
+	LotSize       uint64
+	FeeSuggestion uint64
+	AssetConfig   *dex.Asset
+	RedeemConfig  *dex.Asset
 }

--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -348,7 +348,6 @@ func newV0TokenContractor(net dex.Network, assetID uint32, acctAddr common.Addre
 	}
 
 	if boundAddr, err := c.TokenAddress(&bind.CallOpts{
-		Pending: true,
 		Context: context.TODO(),
 	}); err != nil {
 		return nil, fmt.Errorf("error reading bound token address: %w", err)
@@ -385,6 +384,7 @@ func (c *tokenContractorV0) balance(ctx context.Context) (*big.Int, error) {
 // allowance exposes the read-only allowance method of the erc20 token contract.
 func (c *tokenContractorV0) allowance(ctx context.Context) (*big.Int, error) {
 	callOpts := &bind.CallOpts{
+		Pending: true,
 		From:    c.acctAddr,
 		Context: ctx,
 	}

--- a/client/asset/eth/contractor_test.go
+++ b/client/asset/eth/contractor_test.go
@@ -54,7 +54,7 @@ func (c tContractV0) IsRefundable(opts *bind.CallOpts, secretHash [32]byte) (boo
 
 func TestInitV0(t *testing.T) {
 	abiContract := &tContractV0{}
-	c := contractorV0{contractV0: abiContract}
+	c := contractorV0{contractV0: abiContract, evmify: dexeth.GweiToWei}
 	addrStr := "0xB6De8BB5ed28E6bE6d671975cad20C03931bE981"
 	secretHashB := encode.RandomBytes(32)
 	const gweiVal = 123456
@@ -131,7 +131,7 @@ func TestInitV0(t *testing.T) {
 
 func TestRedeemV0(t *testing.T) {
 	abiContract := &tContractV0{}
-	c := contractorV0{contractV0: abiContract}
+	c := contractorV0{contractV0: abiContract, evmify: dexeth.GweiToWei}
 
 	secretB := encode.RandomBytes(32)
 	secretHashB := encode.RandomBytes(32)
@@ -193,7 +193,7 @@ func TestRedeemV0(t *testing.T) {
 
 func TestSwapV0(t *testing.T) {
 	abiContract := &tContractV0{}
-	c := contractorV0{contractV0: abiContract}
+	c := contractorV0{contractV0: abiContract, evmify: dexeth.GweiToWei}
 
 	var secret [32]byte
 	const valGwei = 123_456

--- a/client/asset/eth/contractor_test.go
+++ b/client/asset/eth/contractor_test.go
@@ -193,7 +193,11 @@ func TestRedeemV0(t *testing.T) {
 
 func TestSwapV0(t *testing.T) {
 	abiContract := &tContractV0{}
-	c := contractorV0{contractV0: abiContract, evmify: dexeth.GweiToWei}
+	c := contractorV0{
+		contractV0: abiContract,
+		evmify:     dexeth.GweiToWei,
+		atomize:    dexeth.WeiToGwei,
+	}
 
 	var secret [32]byte
 	const valGwei = 123_456

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"path/filepath"
 	"strconv"
@@ -23,20 +24,17 @@ import (
 	"decred.org/dcrdex/dex/config"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/keygen"
+	"decred.org/dcrdex/dex/networks/erc20"
 	dexeth "decred.org/dcrdex/dex/networks/eth"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/hdkeychain/v3"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
+	ethmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
-)
-
-var (
-	testTokenID, _ = dex.BipSymbolID("dextt.eth")
 )
 
 func registerToken(tokenID uint32, desc string) {
@@ -73,7 +71,7 @@ const (
 )
 
 var (
-	defaultAppDir = dcrutil.AppDataDir("dexethclient", false)
+	testTokenID, _ = dex.BipSymbolID("dextt.eth")
 	// blockTicker is the delay between calls to check for new blocks.
 	blockTicker     = time.Second
 	peerCountTicker = 5 * time.Second
@@ -94,12 +92,11 @@ var (
 		UnitInfo: dexeth.UnitInfo,
 		AvailableWallets: []*asset.WalletDefinition{
 			{
-				Type:              walletTypeGeth,
-				Tab:               "Internal",
-				Description:       "Use the built-in DEX wallet with snap sync",
-				ConfigOpts:        configOpts,
-				Seeded:            true,
-				DefaultConfigPath: defaultAppDir, // Incorrect if changed by user?
+				Type:        walletTypeGeth,
+				Tab:         "Internal",
+				Description: "Use the built-in DEX wallet with snap sync",
+				ConfigOpts:  configOpts,
+				Seeded:      true,
 			},
 		},
 	}
@@ -109,6 +106,11 @@ var (
 		dex.Testnet: 5,  // Görli
 		dex.Simnet:  42, // see dex/testing/eth/harness.sh
 	}
+
+	minGasTipCap = dexeth.GweiToWei(2)
+
+	unlimitedAllowance                   = ethmath.MaxBig256
+	unlimitedAllowanceReplenishThreshold = new(big.Int).Div(unlimitedAllowance, big.NewInt(2))
 
 	findRedemptionCoinID = []byte("FindRedemption Coin")
 )
@@ -157,6 +159,12 @@ func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
 			return "", err
 		}
 		return c.String(), nil
+	case tokenFundingCoinIDSize:
+		c, err := decodeTokenFundingCoin(coinID)
+		if err != nil {
+			return "", err
+		}
+		return c.String(), nil
 	case common.AddressLength * 2, common.AddressLength*2 + 2:
 		hexAddr := string(coinID)
 		if !common.IsHexAddress(hexAddr) {
@@ -193,18 +201,17 @@ type Balance struct {
 }
 
 // ethFetcher represents a blockchain information fetcher. In practice, it is
-// satisfied by rpcclient. For testing, it can be satisfied by a stub.
+// satisfied by *nodeClient. For testing, it can be satisfied by a stub.
 type ethFetcher interface {
 	address() common.Address
-	bestHeader(ctx context.Context) (*types.Header, error)
 	addressBalance(ctx context.Context, addr common.Address) (*big.Int, error)
-	connect(ctx context.Context) error
+	bestHeader(ctx context.Context) (*types.Header, error)
 	chainConfig() *params.ChainConfig
+	connect(ctx context.Context) error
 	peerCount() uint32
 	contractBackend() bind.ContractBackend
 	lock() error
 	locked() bool
-	unlock(pw string) error
 	pendingTransactions() ([]*types.Transaction, error)
 	shutdown()
 	sendSignedTransaction(ctx context.Context, tx *types.Transaction) error
@@ -214,17 +221,15 @@ type ethFetcher interface {
 	transactionConfirmations(context.Context, common.Hash) (uint32, error)
 	txOpts(ctx context.Context, val, maxGas uint64, maxFeeRate *big.Int) (*bind.TransactOpts, error)
 	currentFees(ctx context.Context) (baseFees, tipCap *big.Int, err error)
+	unlock(pw string) error
 }
 
-// Check that ExchangeWallet satisfies the asset.Wallet interface.
-var _ asset.Wallet = (*ExchangeWallet)(nil)
-var _ asset.AccountLocker = (*ExchangeWallet)(nil)
-var _ asset.FeeRater = (*ExchangeWallet)(nil)
+// Check that AssetWallet satisfies the asset.Wallet interface.
+var _ asset.Wallet = (*AssetWallet)(nil)
+var _ asset.AccountLocker = (*AssetWallet)(nil)
+var _ asset.TokenMaster = (*AssetWallet)(nil)
 
-// ExchangeWallet is a wallet backend for Ethereum. The backend is how the DEX
-// client app communicates with the Ethereum blockchain and wallet. ExchangeWallet
-// satisfies the dex.Wallet interface.
-type ExchangeWallet struct {
+type baseWallet struct {
 	// 64-bit atomic variables first. See
 	// https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 	tipAtConnect int64
@@ -234,13 +239,34 @@ type ExchangeWallet struct {
 	node          ethFetcher
 	addr          common.Address
 	log           dex.Logger
-	tipChange     func(error)
 	lastPeerCount uint32
 	peersChange   func(uint32)
 	gasFeeLimit   uint64
 
 	tipMtx     sync.RWMutex
 	currentTip *types.Header
+
+	walletsMtx sync.RWMutex
+	wallets    map[uint32]*AssetWallet
+
+	nonceSendMtx sync.Mutex
+}
+
+// tokenConfig is part of an AssetWallet that will be populated for token
+// assets.
+type tokenConfig struct {
+	*tokenWalletConfig
+	parent   *AssetWallet
+	approval atomic.Value
+}
+
+// AssetWallet is a wallet backend for Ethereum and Eth tokens. The backend is
+// how the DEX client app communicates with the Ethereum blockchain and wallet.
+// AssetWallet satisfies the dex.Wallet interface.
+type AssetWallet struct {
+	*baseWallet
+	assetID   uint32
+	tipChange func(error)
 
 	lockedFunds struct {
 		mtx                sync.RWMutex
@@ -252,13 +278,17 @@ type ExchangeWallet struct {
 	findRedemptionMtx  sync.RWMutex
 	findRedemptionReqs map[[32]byte]*findRedemptionRequest
 
-	nonceSendMtx sync.Mutex
+	// token is only used by token wallets.
+	token *tokenConfig
 
 	contractors map[uint32]contractor // version -> contractor
+
+	evmify  func(uint64) *big.Int
+	atomize func(*big.Int) uint64
 }
 
 // Info returns basic information about the wallet and asset.
-func (*ExchangeWallet) Info() *asset.WalletInfo {
+func (*baseWallet) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
@@ -305,7 +335,7 @@ func CreateWallet(createWalletParams *asset.CreateWalletParams) error {
 
 // NewWallet is the exported constructor by which the DEX will import the
 // exchange wallet. It starts an internal light node.
-func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network) (*ExchangeWallet, error) {
+func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network) (*AssetWallet, error) {
 	cl, err := newNodeClient(getWalletDir(assetCFG.DataDir, net), net, logger.SubLogger("NODE"))
 	if err != nil {
 		return nil, err
@@ -321,69 +351,186 @@ func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network)
 		gasFeeLimit = defaultGasFeeLimit
 	}
 
-	return &ExchangeWallet{
-		log:                logger,
-		net:                net,
-		node:               cl,
-		addr:               cl.address(),
+	eth := &baseWallet{
+		log:         logger,
+		net:         net,
+		node:        cl,
+		addr:        cl.address(),
+		gasFeeLimit: gasFeeLimit,
+		wallets:     make(map[uint32]*AssetWallet),
+		peersChange: assetCFG.PeersChange,
+	}
+
+	w := &AssetWallet{
+		baseWallet:         eth,
+		assetID:            BipID,
 		tipChange:          assetCFG.TipChange,
-		peersChange:        assetCFG.PeersChange,
-		gasFeeLimit:        gasFeeLimit,
 		findRedemptionReqs: make(map[[32]byte]*findRedemptionRequest),
 		contractors:        make(map[uint32]contractor),
-	}, nil
+		evmify:             dexeth.GweiToWei,
+		atomize:            dexeth.WeiToGwei,
+	}
+
+	w.wallets = map[uint32]*AssetWallet{
+		BipID: w,
+	}
+
+	return w, nil
 }
 
 func getWalletDir(dataDir string, network dex.Network) string {
 	return filepath.Join(dataDir, network.String())
 }
 
-func (eth *ExchangeWallet) shutdown() {
+func (eth *baseWallet) shutdown() {
 	eth.node.shutdown()
 }
 
 // Connect connects to the node RPC server. A dex.Connector.
-func (eth *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
-	eth.ctx = ctx
+func (w *AssetWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
+	w.ctx = ctx
 
-	err := eth.node.connect(ctx)
+	// If this is a token wallet, just wait for the provided context or the
+	// parent context to be canceled.
+	if w.token != nil {
+		if w.token.parent.ctx == nil || w.token.parent.ctx.Err() != nil {
+			return nil, fmt.Errorf("parent not connected")
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case <-ctx.Done():
+			case <-w.baseWallet.ctx.Done():
+			}
+		}()
+		return &wg, nil
+	}
+
+	err := w.node.connect(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	for ver, constructor := range contractorConstructors {
-		c, err := constructor(eth.net, eth.addr, eth.node.contractBackend())
+		c, err := constructor(w.net, w.addr, w.node.contractBackend())
 		if err != nil {
 			return nil, fmt.Errorf("error constructor version %d contractor: %v", ver, err)
 		}
-		eth.contractors[ver] = c
+		w.contractors[ver] = c
 	}
 
 	// Initialize the best block.
-	bestHdr, err := eth.node.bestHeader(ctx)
+	bestHdr, err := w.node.bestHeader(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error getting best block from geth: %w", err)
+		return nil, fmt.Errorf("error getting best block hash from geth: %w", err)
 	}
-	eth.tipMtx.Lock()
-	eth.currentTip = bestHdr
-	eth.tipMtx.Unlock()
-	height := eth.currentTip.Number
-	atomic.StoreInt64(&eth.tipAtConnect, height.Int64())
-	eth.log.Infof("Connected to geth, at height %d", height)
+	w.tipMtx.Lock()
+	w.currentTip = bestHdr
+	w.tipMtx.Unlock()
+	height := w.currentTip.Number
+	// NOTE: We should be using the tipAtConnect to set Progress in SyncStatus.
+	atomic.StoreInt64(&w.baseWallet.tipAtConnect, height.Int64())
+	w.log.Infof("Connected to geth, at height %d", height)
 
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		eth.monitorBlocks(ctx)
-		eth.shutdown()
+		w.monitorBlocks(ctx, w.tipChange)
+		w.shutdown()
 	}()
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		eth.monitorPeers(ctx)
+		w.monitorPeers(ctx)
 	}()
 	return &wg, nil
+}
+
+func (eth *baseWallet) walletList() []*AssetWallet {
+	eth.walletsMtx.RLock()
+	defer eth.walletsMtx.RUnlock()
+	m := make([]*AssetWallet, 0, len(eth.wallets))
+	for _, w := range eth.wallets {
+		m = append(m, w)
+	}
+	return m
+}
+
+func (eth *baseWallet) wallet(assetID uint32) *AssetWallet {
+	eth.walletsMtx.RLock()
+	defer eth.walletsMtx.RUnlock()
+	return eth.wallets[assetID]
+}
+
+// tokenWalletConfig is the configuration options for token wallets.
+type tokenWalletConfig struct {
+	// LimitAllowance disabled for now.
+	// See https://github.com/decred/dcrdex/pull/1394#discussion_r780479402.
+	// LimitAllowance bool `ini:"limitAllowance"`
+}
+
+// parseTokenWalletConfig parses the settings map into a *tokenWalletConfig.
+func parseTokenWalletConfig(settings map[string]string) (cfg *tokenWalletConfig, err error) {
+	cfg = new(tokenWalletConfig)
+	err = config.Unmapify(settings, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing wallet config: %w", err)
+	}
+	return cfg, nil
+}
+
+// CreateTokenWallet "creates" a wallet for a token. There is really nothing
+// to do, except check that the token exists.
+func (eth *baseWallet) CreateTokenWallet(tokenID uint32, _ map[string]string) error {
+	// Just check that the token exists for now.
+	if dexeth.Tokens[tokenID] == nil {
+		return fmt.Errorf("token not found for asset ID %d", tokenID)
+	}
+	return nil
+}
+
+// OpenTokenWallet creates a new AssetWallet for a token.
+func (w *AssetWallet) OpenTokenWallet(tokenID uint32, settings map[string]string, tipChange func(error)) (asset.Wallet, error) {
+	if w.assetID != BipID {
+		return nil, fmt.Errorf("token wallets (%d) cannot create other token wallets (%d)", w.assetID, tokenID)
+	}
+	token, found := dexeth.Tokens[w.assetID]
+	if !found {
+		return nil, fmt.Errorf("token %d not found", tokenID)
+	}
+
+	cfg, err := parseTokenWalletConfig(settings)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenWallet := &AssetWallet{
+		baseWallet: w.baseWallet,
+		assetID:    tokenID,
+		token: &tokenConfig{
+			tokenWalletConfig: cfg,
+			parent:            w,
+		},
+		tipChange:          tipChange,
+		findRedemptionReqs: make(map[[32]byte]*findRedemptionRequest),
+		contractors:        make(map[uint32]contractor),
+		evmify:             token.AtomicToEVM,
+		atomize:            token.EVMToAtomic,
+	}
+	err = tokenWallet.loadContractors(w.ctx, tokenID)
+	if err != nil {
+		return nil, err
+	}
+
+	w.baseWallet.walletsMtx.Lock()
+	w.baseWallet.wallets[tokenID] = tokenWallet
+	w.baseWallet.walletsMtx.Unlock()
+
+	return tokenWallet, nil
 }
 
 // OwnsAddress indicates if an address belongs to the wallet. The address need
@@ -391,7 +538,7 @@ func (eth *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 // prefix, and case is not important.
 //
 // In Ethereum, an address is an account.
-func (eth *ExchangeWallet) OwnsAddress(address string) (bool, error) {
+func (eth *baseWallet) OwnsAddress(address string) (bool, error) {
 	if !common.IsHexAddress(address) {
 		return false, errors.New("invalid address")
 	}
@@ -424,23 +571,23 @@ func (f fundReserveType) String() string {
 
 // fundReserveOfType returns a pointer to the funds reserved for a particular
 // use case.
-func (eth *ExchangeWallet) fundReserveOfType(t fundReserveType) *uint64 {
+func (w *AssetWallet) fundReserveOfType(t fundReserveType) *uint64 {
 	switch t {
 	case initiationReserve:
-		return &eth.lockedFunds.initiateReserves
+		return &w.lockedFunds.initiateReserves
 	case redemptionReserve:
-		return &eth.lockedFunds.redemptionReserves
+		return &w.lockedFunds.redemptionReserves
 	case refundReserve:
-		return &eth.lockedFunds.refundReserves
+		return &w.lockedFunds.refundReserves
 	default:
 		panic(fmt.Sprintf("invalid fund reserve type: %v", t))
 	}
 }
 
 // lockFunds locks funds for a use case.
-func (eth *ExchangeWallet) lockFunds(amt uint64, t fundReserveType) error {
-	reserve := eth.fundReserveOfType(t)
-	balance, err := eth.balance()
+func (w *AssetWallet) lockFunds(amt uint64, t fundReserveType) error {
+	reserve := w.fundReserveOfType(t)
+	balance, err := w.balance()
 	if err != nil {
 		return err
 	}
@@ -449,18 +596,17 @@ func (eth *ExchangeWallet) lockFunds(amt uint64, t fundReserveType) error {
 		return fmt.Errorf("attempting to lock more for %s than is currently available. %d > %d",
 			t, amt, balance.Available)
 	}
-
 	*reserve += amt
 	return nil
 }
 
 // unlockFunds unlocks funds for a use case.
-func (eth *ExchangeWallet) unlockFunds(amt uint64, t fundReserveType) {
-	reserve := eth.fundReserveOfType(t)
+func (w *AssetWallet) unlockFunds(amt uint64, t fundReserveType) {
+	reserve := w.fundReserveOfType(t)
 
 	if *reserve < amt {
 		*reserve = 0
-		eth.log.Errorf("attempting to unlock more for %s than is currently locked - %d > %d. "+
+		w.log.Errorf("attempting to unlock more for %s than is currently locked - %d > %d. "+
 			"clearing all locked funds", t, amt, *reserve)
 		return
 	}
@@ -469,32 +615,34 @@ func (eth *ExchangeWallet) unlockFunds(amt uint64, t fundReserveType) {
 }
 
 // amountLocked returns the total amount currently locked.
-func (eth *ExchangeWallet) amountLocked() uint64 {
-	return eth.lockedFunds.initiateReserves + eth.lockedFunds.redemptionReserves + eth.lockedFunds.refundReserves
+func (w *AssetWallet) amountLocked() uint64 {
+	return w.lockedFunds.initiateReserves + w.lockedFunds.redemptionReserves + w.lockedFunds.refundReserves
 }
 
 // Balance returns the total available funds in the account. The eth node
 // returns balances in wei. Those are flored and stored as gwei, or 1e9 wei.
-func (eth *ExchangeWallet) Balance() (*asset.Balance, error) {
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
+func (w *AssetWallet) Balance() (*asset.Balance, error) {
+	w.lockedFunds.mtx.Lock()
+	defer w.lockedFunds.mtx.Unlock()
 
-	return eth.balance()
+	return w.balance()
 }
 
 // balance returns the total available funds in the account.
-// This function expects eth.lockedFunds.mtx to be held.
-func (eth *ExchangeWallet) balance() (*asset.Balance, error) {
-	bal, err := eth.balanceWithTxPool()
+// This function expects eth.lockedMtx to be held.
+func (w *AssetWallet) balance() (*asset.Balance, error) {
+
+	bal, err := w.balanceWithTxPool()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("pending balance error: %w", err)
 	}
 
-	locked := eth.amountLocked()
+	locked := w.amountLocked()
+
 	return &asset.Balance{
-		Available: dexeth.WeiToGwei(bal.Current) - locked - dexeth.WeiToGwei(bal.PendingOut),
+		Available: w.atomize(bal.Current) - locked - w.atomize(bal.PendingOut),
 		Locked:    locked,
-		Immature:  dexeth.WeiToGwei(bal.PendingIn),
+		Immature:  w.atomize(bal.PendingIn),
 	}, nil
 }
 
@@ -503,27 +651,52 @@ func (eth *ExchangeWallet) balance() (*asset.Balance, error) {
 // estimate based on current network conditions, and will be <= the fees
 // associated with nfo.MaxFeeRate. For quote assets, the caller will have to
 // calculate lotSize based on a rate conversion from the base asset's lot size.
-func (eth *ExchangeWallet) MaxOrder(lotSize uint64, feeSuggestion uint64, nfo *dex.Asset) (*asset.SwapEstimate, error) {
-	balance, err := eth.Balance()
+func (w *AssetWallet) MaxOrder(ord *asset.MaxOrderForm) (*asset.SwapEstimate, error) {
+	est, err := w.maxOrder(ord.LotSize, ord.FeeSuggestion, ord.AssetConfig, ord.RedeemConfig)
+	return est, err
+}
+
+func (w *AssetWallet) maxOrder(lotSize uint64, feeSuggestion uint64, dexSwapCfg, dexRedeemCfg *dex.Asset) (*asset.SwapEstimate, error) {
+	balance, err := w.Balance()
 	if err != nil {
 		return nil, err
 	}
 	if balance.Available == 0 {
 		return &asset.SwapEstimate{}, nil
 	}
-	maxTxFee := dexeth.InitGas(1, nfo.Version) * nfo.MaxFeeRate
-	lots := balance.Available / (lotSize + maxTxFee)
+
+	g, err := w.initGasEstimate(1, dexSwapCfg, dexRedeemCfg)
+	if err != nil {
+		return nil, fmt.Errorf("gasEstimate error: %w", err)
+	}
+
+	oneFee := g.oneGas * dexSwapCfg.MaxFeeRate
+	var lots uint64
+	if w.assetID == BipID {
+		lots = balance.Available / (lotSize + oneFee)
+	} else {
+		lots = balance.Available / lotSize
+		parentBal, err := w.token.parent.Balance()
+		if err != nil {
+			return nil, fmt.Errorf("error getting base chain balance: %w", err)
+		}
+		feeLots := parentBal.Available / oneFee
+		if feeLots < lots {
+			w.log.Infof("MaxOrder reducing lots because of low fee reserves: %d -> %d", lots, feeLots)
+			lots = feeLots
+		}
+	}
+
 	if lots < 1 {
 		return &asset.SwapEstimate{}, nil
 	}
-	est := eth.estimateSwap(lots, lotSize, feeSuggestion, nfo)
-	return est, nil
+	return w.estimateSwap(lots, lotSize, feeSuggestion, dexSwapCfg, dexRedeemCfg)
 }
 
 // PreSwap gets order estimates based on the available funds and the wallet
 // configuration.
-func (eth *ExchangeWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, error) {
-	maxEst, err := eth.MaxOrder(req.LotSize, req.FeeSuggestion, req.AssetConfig)
+func (w *AssetWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, error) {
+	maxEst, err := w.maxOrder(req.LotSize, req.FeeSuggestion, req.AssetConfig, req.RedeemConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -532,42 +705,100 @@ func (eth *ExchangeWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, erro
 		return nil, fmt.Errorf("%d lots available for %d-lot order", maxEst.Lots, req.Lots)
 	}
 
-	est := eth.estimateSwap(req.Lots, req.LotSize, req.FeeSuggestion, req.AssetConfig)
+	est, err := w.estimateSwap(req.Lots, req.LotSize, req.FeeSuggestion, req.AssetConfig, req.RedeemConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return &asset.PreSwap{
 		Estimate: est,
 	}, nil
 }
 
-// estimateSwap prepares an *asset.SwapEstimate.
-func (eth *ExchangeWallet) estimateSwap(lots, lotSize, feeSuggestion uint64, nfo *dex.Asset) *asset.SwapEstimate {
+// estimateSwap prepares an *asset.SwapEstimate. The estimate does not include
+// funds that might be locked for refunds.
+func (w *AssetWallet) estimateSwap(lots, lotSize, feeSuggestion uint64, dexSwapCfg, dexRedeemCfg *dex.Asset) (*asset.SwapEstimate, error) {
 	if lots == 0 {
-		return &asset.SwapEstimate{}
+		return &asset.SwapEstimate{}, nil
 	}
+
+	oneSwap, nSwap, err := w.swapGas(int(lots), dexSwapCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error getting swap gas estimate: %w", err)
+	}
+
 	value := lots * lotSize
-	maxFees := dexeth.InitGas(1, nfo.Version) * nfo.MaxFeeRate * lots
+	allowanceGas, err := w.allowanceGasRequired(dexRedeemCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	oneGasMax := oneSwap*lots + allowanceGas
+	maxFees := oneGasMax * dexSwapCfg.MaxFeeRate
+
 	return &asset.SwapEstimate{
 		Lots:               lots,
 		Value:              value,
 		MaxFees:            maxFees,
-		RealisticWorstCase: lots * dexeth.InitGas(1, nfo.Version) * feeSuggestion,
-		RealisticBestCase:  dexeth.InitGas(int(lots), nfo.Version) * feeSuggestion,
+		RealisticWorstCase: oneGasMax * feeSuggestion,
+		RealisticBestCase:  (nSwap + allowanceGas) * feeSuggestion,
+	}, nil
+}
+
+// allowanceGasRequired estimates the gas that is required to issue an approval
+// for a token. If the dexRedeemCfg is not for a fee-family erc20 asset, no
+// error is returned and the return value will be zero.
+func (w *AssetWallet) allowanceGasRequired(dexRedeemCfg *dex.Asset) (uint64, error) {
+	if dexRedeemCfg.ID == BipID {
+		return 0, nil
 	}
+	redeemWallet := w.wallet(dexRedeemCfg.ID)
+	if redeemWallet == nil {
+		return 0, nil
+	}
+	currentAllowance, err := redeemWallet.tokenAllowance()
+	if err != nil {
+		return 0, err
+	}
+	// No reason to do anything if the allowance is > the unlimited
+	// allowance approval threshold.
+	if currentAllowance.Cmp(unlimitedAllowanceReplenishThreshold) < 0 {
+		return redeemWallet.approvalGas(unlimitedAllowance, dexRedeemCfg)
+	}
+	return 0, nil
+}
+
+// gases gets the gas table for the specified contract version.
+func (w *AssetWallet) gases(contractVer uint32) *dexeth.Gases {
+	return gases(w.assetID, contractVer, w.net)
 }
 
 // PreRedeem generates an estimate of the range of redemption fees that could
 // be assessed.
-func (*ExchangeWallet) PreRedeem(req *asset.PreRedeemForm) (*asset.PreRedeem, error) {
+func (w *AssetWallet) PreRedeem(req *asset.PreRedeemForm) (*asset.PreRedeem, error) {
+	oneRedeem, nRedeem, err := w.redeemGas(int(req.Lots), req.AssetConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Note: Any gas required for erc20 contract approval will also have been
+	// summed in the PreSwap estimate if the swap asset is a fee-family asset.
+	allowanceGas, err := w.allowanceGasRequired(req.AssetConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return &asset.PreRedeem{
 		Estimate: &asset.RedeemEstimate{
-			RealisticBestCase:  dexeth.RedeemGas(int(req.Lots), 0) * req.FeeSuggestion,
-			RealisticWorstCase: dexeth.RedeemGas(1, 0) * req.FeeSuggestion * req.Lots,
+			RealisticBestCase:  (nRedeem + allowanceGas) * req.FeeSuggestion,
+			RealisticWorstCase: (oneRedeem*req.Lots + allowanceGas) * req.FeeSuggestion,
 		},
 	}, nil
 }
 
 // coin implements the asset.Coin interface for ETH
 type coin struct {
-	id dex.Bytes
+	id common.Hash
 	// the value can be determined from the coin id, but for some
 	// coin ids a lookup would be required from the blockchain to
 	// determine its value, so this field is used as a cache.
@@ -578,7 +809,7 @@ type coin struct {
 // the ID must contain an encoded fundingCoinID, but when returned from
 // Swap, it will contain the transaction hash used to initiate the swap.
 func (c *coin) ID() dex.Bytes {
-	return c.id
+	return c.id[:]
 }
 
 // String is a string representation of the coin.
@@ -593,101 +824,284 @@ func (c *coin) Value() uint64 {
 
 var _ asset.Coin = (*coin)(nil)
 
-func (eth *ExchangeWallet) createFundingCoin(amount uint64) *fundingCoin {
+func (eth *baseWallet) createFundingCoin(amount uint64) *fundingCoin {
 	return createFundingCoin(eth.addr, amount)
 }
 
-// decodeFundingCoinID decodes a coin id into a coin object. This function ensures
-// that the id contains an encoded fundingCoinID whose address is the same as
-// the one managed by this wallet.
-func (eth *ExchangeWallet) decodeFundingCoinID(id []byte) (*fundingCoin, error) {
-	fc, err := decodeFundingCoin(id)
-	if err != nil {
-		return nil, err
-	}
-
-	if fc.addr != eth.addr {
-		return nil, fmt.Errorf("coin address %s != wallet address %s",
-			fc.addr, eth.addr)
-	}
-
-	return fc, nil
+func (eth *baseWallet) createTokenFundingCoin(amount, fees uint64) *tokenFundingCoin {
+	return createTokenFundingCoin(eth.addr, amount, fees)
 }
 
-// FundOrder selects coins for use in an order. The coins will be locked, and
-// will not be returned in subsequent calls to FundOrder or calculated in calls
-// to Available, unless they are unlocked with ReturnCoins.
-// In UTXO based coins, the returned []dex.Bytes contains the redeem scripts for the
-// selected coins, but since there are no redeem scripts in Ethereum, nil is returned.
-// Equal number of coins and redeem scripts must be returned.
-func (eth *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, error) {
-	if eth.gasFeeLimit < ord.DEXConfig.MaxFeeRate {
+func (w *AssetWallet) ethWallet() *AssetWallet {
+	if w.token != nil {
+		return w.token.parent
+	}
+	return w
+}
+
+// FundOrder locks value for use in an order.
+func (w *AssetWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, error) {
+	cfg := ord.DEXConfig
+
+	if w.gasFeeLimit < cfg.MaxFeeRate {
 		return nil, nil, fmt.Errorf(
 			"%v: server's max fee rate %v higher than configured fee rate limit %v",
 			ord.DEXConfig.Symbol,
 			ord.DEXConfig.MaxFeeRate,
-			eth.gasFeeLimit)
+			w.gasFeeLimit)
 	}
 
-	maxSwapFees := ord.DEXConfig.MaxFeeRate * ord.DEXConfig.SwapSize * ord.MaxSwapCount
-	initiationFunds := ord.Value + maxSwapFees
-	coins := asset.Coins{eth.createFundingCoin(initiationFunds)}
+	w.lockedFunds.mtx.Lock()
+	defer w.lockedFunds.mtx.Unlock()
+	// err := w.lockFunds(initiationFunds, initiationReserve)
+	// if err != nil {
+	// 	return nil, nil, fmt.Errorf("error estimating swap gas: %v", err)
+	// }
 
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
-	err := eth.lockFunds(initiationFunds, initiationReserve)
+	g, err := w.initGasEstimate(int(ord.MaxSwapCount), cfg, ord.RedeemConfig)
 	if err != nil {
+		return nil, nil, fmt.Errorf("error estimating swap gas: %v", err)
+	}
+
+	ethToLock := cfg.MaxFeeRate * g.Swap * ord.MaxSwapCount
+	// Note: In a future refactor, we could lock the redemption funds here too
+	// and signal to the user so that they don't call `RedeemN`. This has the
+	// same net effect, but avoids a lockFunds -> unlockFunds for us and likely
+	// some work for the caller as well. We can't just always do it that way and
+	// remove RedeemN, since we can't guarantee that the redemption asset is in
+	// our fee-family. though it could still be an AccountRedeemer.
+	//
+	// ethToLock += biggestUint64(g.oneRefund, g.oneRedeem) * cfg.MaxFeeRate * ord.MaxSwapCount
+
+	ethWallet := w.ethWallet()
+	var success bool
+	var coin asset.Coin
+	if w.assetID == BipID {
+		ethToLock += ord.Value
+		coin = w.createFundingCoin(ethToLock)
+	} else {
+		if err := w.lockFunds(ord.Value, initiationReserve); err != nil {
+			return nil, nil, fmt.Errorf("error locking token funds: %v", err)
+		}
+		defer func() {
+			if !success {
+				w.unlockFunds(ord.Value, initiationReserve)
+			}
+		}()
+
+		coin = w.createTokenFundingCoin(ord.Value, ethToLock)
+	}
+
+	if err := ethWallet.lockFunds(ethToLock, initiationReserve); err != nil {
 		return nil, nil, err
 	}
 
-	return coins, []dex.Bytes{nil}, nil
+	success = true
+	return asset.Coins{coin}, []dex.Bytes{nil}, nil
+}
+
+// gasEstimates are estimates of gas required for operations involving a swap
+// combination of (swap asset, redeem asset, # lots).
+type gasEstimate struct {
+	// The embedded are best calculated values for Swap gases, and redeem costs
+	// IF the redeem asset is a fee-family asset. Otherwise Redeem and RedeemAdd
+	// are zero.
+	dexeth.Gases
+	// Additional fields are based on live estimates of the swap.
+	oneGas, nGas, nSwap, nRedeem, nRefund uint64
+}
+
+// initGasEstimate gets the best available gas estimate for n initiations. A
+// live estimate is checked against the server's configured values and our own
+// known values and errors or logs generated in certain cases.
+func (w *AssetWallet) initGasEstimate(n int, dexSwapCfg, dexRedeemCfg *dex.Asset) (est *gasEstimate, err error) {
+	est = new(gasEstimate)
+
+	g := w.gases(dexSwapCfg.Version)
+	if g == nil {
+		return nil, fmt.Errorf("no gas table")
+	}
+
+	est.Refund = g.Refund
+
+	est.Swap, est.nSwap, err = w.swapGas(n, dexSwapCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error calculating swap gas: %w", err)
+	}
+
+	est.oneGas = est.Swap + est.Redeem
+	est.nGas = est.nSwap + est.nRedeem
+
+	if redeemW := w.wallet(dexRedeemCfg.ID); redeemW != nil {
+		est.Redeem, est.nRedeem, err = redeemW.redeemGas(n, dexRedeemCfg)
+		if err != nil {
+			return nil, fmt.Errorf("error calculating fee-family redeem gas: %w", err)
+		}
+	}
+
+	return
+}
+
+// swapGas estimates gas for a number of initiations. swapGas will error if we
+// cannot get a live estimate from the contractor, which will happen if the
+// wallet has no balance.
+func (w *AssetWallet) swapGas(n int, dexCfg *dex.Asset) (oneSwap, nSwap uint64, err error) {
+	oneSwap = dexCfg.SwapSize
+
+	g := w.gases(dexCfg.Version)
+	if g == nil {
+		return 0, 0, fmt.Errorf("no gases known for %d version %d", w.assetID, dexCfg.Version)
+	}
+
+	// Warn of mismatch in gas estimates.
+	if g.Swap > oneSwap {
+		w.log.Warnf("Server has a lower configured swap gas value, which is odd")
+		oneSwap = g.Swap
+	}
+
+	// Not gonna worry about accuracy for nSwap. It's never used where it
+	// matters, just for estimates.
+	nSwap = oneSwap + uint64(n-1)*g.SwapAdd
+
+	// If a live estimate is greater than our estimate from configured values,
+	// use the live estimate with a warning.
+	if gasEst, err := w.estimateInitGas(w.ctx, n, dexCfg.Version); err != nil {
+		w.log.Errorf("(%d) error estimating swap gas: %v", w.assetID, err)
+		return 0, 0, err
+	} else if gasEst > nSwap {
+		w.log.Warnf("Swap gas estimate %d is greater than the server's configured value %d. Using live estimate + 10%.")
+		nSwap = gasEst * 11 / 10
+		if n == 1 && nSwap > oneSwap {
+			oneSwap = nSwap
+		}
+	}
+	return
+}
+
+// redeemGas gets an accurate estimate for redemption gas. We allow a DEX server
+// some latitude in adjusting the redemption gas, up to 2x our local estimate.
+func (w *AssetWallet) redeemGas(n int, nfo *dex.Asset) (oneGas, nGas uint64, err error) {
+	g := w.gases(nfo.Version)
+	if g == nil {
+		return 0, 0, fmt.Errorf("no gas table for redemption asset %d", nfo.ID)
+	}
+	redeemGas := nfo.RedeemSize
+	if g.Redeem > redeemGas {
+		// This probably won't happen.
+		w.log.Debugf("Server's reported redeem gas estimate %d is less than ours %d. Using our estimate.", g.Redeem, redeemGas)
+		redeemGas = g.Redeem
+	} else if nfo.RedeemSize > 2*g.Redeem {
+		return 0, 0, fmt.Errorf("server's reported redemption costs are more than twice the expected value. %d > 2 * %d",
+			nfo.RedeemSize, g.Redeem)
+	}
+	// Not concerned with the accuracy of nGas. It's never used outside of
+	// best case estimates.
+	return redeemGas, redeemGas + (uint64(n)-1)*g.RedeemAdd, nil
+}
+
+// approvalGas gets the best available estimate for an approval tx, which is
+// the greater of the asset's registered value and a live estimate. It is an
+// error if a live estimate cannot be retrieved, which will be the case if the
+// user's eth balance is insufficient to cover tx fees for the approval.
+func (w *AssetWallet) approvalGas(newGas *big.Int, cfg *dex.Asset) (uint64, error) {
+	ourGas := w.gases(cfg.Version)
+	if ourGas == nil {
+		return 0, fmt.Errorf("no gases known for %d version %d", w.assetID, cfg.Version)
+	}
+
+	approveGas := ourGas.Approve
+
+	if approveEst, err := w.estimateApproveGas(newGas); err != nil {
+		return 0, fmt.Errorf("error estimating approve gas: %v", err)
+	} else if approveEst > approveGas {
+		w.log.Warnf("Approve gas estimate %d is greater than the expected value %d. Using live estimate + 10%.")
+		return approveEst * 11 / 10, nil
+	}
+	return approveGas, nil
 }
 
 // ReturnCoins unlocks coins. This would be necessary in the case of a
 // canceled order.
-func (eth *ExchangeWallet) ReturnCoins(coins asset.Coins) error {
-	var amt uint64
+func (w *AssetWallet) ReturnCoins(coins asset.Coins) error {
+	var amt, fees uint64
 	for _, ci := range coins {
 		amt += ci.Value()
 		var addr common.Address
 		switch c := ci.(type) {
 		case *fundingCoin:
 			addr = c.addr
+		case *tokenFundingCoin:
+			fees += c.fees
+			addr = c.addr
 		default:
 			return fmt.Errorf("unknown coin type %T", c)
 		}
-		if addr != eth.addr {
-			return fmt.Errorf("coin is not funded by this wallet. coin address %s != our address %s", addr, eth.addr)
+		if addr != w.addr {
+			return fmt.Errorf("coin is not funded by this wallet. coin address %s != our address %s", addr, w.addr)
 		}
 	}
-
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
-	eth.unlockFunds(amt, initiationReserve)
+	if fees > 0 {
+		if w.token == nil {
+			return fmt.Errorf("tokenFundingCoin returned for non-token asset")
+		}
+		w.token.parent.unlockFunds(fees, initiationReserve)
+	}
+	w.unlockFunds(amt, initiationReserve)
 	return nil
 }
 
 // FundingCoins gets funding coins for the coin IDs. The coins are locked. This
 // method might be called to reinitialize an order from data stored externally.
-func (eth *ExchangeWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
+func (w *AssetWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 	coins := make([]asset.Coin, 0, len(ids))
-	var totalValue uint64
+	var amt, fees uint64
 	for _, id := range ids {
-		coin, err := eth.decodeFundingCoinID(id)
-		if err != nil {
-			return nil, fmt.Errorf("FundingCoins: unable to decode funding coin id: %w", err)
+		var addr common.Address
+		switch len(id) {
+		case fundingCoinIDSize:
+			c, err := decodeFundingCoin(id)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding funding coin ID: %w", err)
+			}
+			amt += c.amt
+			addr = c.addr
+			coins = append(coins, c)
+		case tokenFundingCoinIDSize:
+			c, err := decodeTokenFundingCoin(id)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding funding coin ID: %w", err)
+			}
+			amt += c.amt
+			fees += c.fees
+			addr = c.addr
+			coins = append(coins, c)
+		default:
+			return nil, fmt.Errorf("%s funding coin is of unknown format", id)
 		}
-		coins = append(coins, coin)
-		totalValue += coin.Value()
+		if addr != w.addr {
+			return nil, fmt.Errorf("funding coin has wrong address. %s != %s", addr, w.addr)
+		}
 	}
 
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
-	err := eth.lockFunds(totalValue, initiationReserve)
-	if err != nil {
+	var success bool
+	if fees > 0 {
+		if w.token == nil {
+			return nil, fmt.Errorf("tokenFundingCoin returned for non-token asset")
+		}
+		if err := w.token.parent.lockFunds(fees, initiationReserve); err != nil {
+			return nil, fmt.Errorf("error unlocking parent asset fees: %w", err)
+		}
+		defer func() {
+			if !success {
+				w.token.parent.unlockFunds(fees, initiationReserve)
+			}
+		}()
+	}
+	if err := w.lockFunds(amt, initiationReserve); err != nil {
 		return nil, err
 	}
 
+	success = true
 	return coins, nil
 }
 
@@ -713,7 +1127,7 @@ func (r *swapReceipt) Expiration() time.Time {
 func (r *swapReceipt) Coin() asset.Coin {
 	return &coin{
 		value: r.value,
-		id:    r.txHash[:], // server's idea of ETH coin ID encoding
+		id:    r.txHash, // server's idea of ETH coin ID encoding
 	}
 }
 
@@ -745,59 +1159,111 @@ var _ asset.Receipt = (*swapReceipt)(nil)
 // Swap sends the swaps in a single transaction. The fees used returned are the
 // max fees that will possibly be used, since in ethereum with EIP-1559 we cannot
 // know exactly how much fees will be used.
-func (eth *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, uint64, error) {
-	fail := func(err error) ([]asset.Receipt, asset.Coin, uint64, error) {
-		return nil, nil, 0, err
+func (w *AssetWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, uint64, error) {
+	fail := func(s string, a ...interface{}) ([]asset.Receipt, asset.Coin, uint64, error) {
+		return nil, nil, 0, fmt.Errorf(s, a...)
 	}
+
+	cfg := swaps.AssetConfig
 
 	receipts := make([]asset.Receipt, 0, len(swaps.Contracts))
 
-	var totalInputValue uint64
-	for _, input := range swaps.Inputs {
-		totalInputValue += input.Value()
+	isToken := w.token != nil
+	var reservedVal, reservedParent uint64
+	for _, input := range swaps.Inputs { // Should only ever be 1 input, I think.
+		if isToken {
+			c, is := input.(*tokenFundingCoin)
+			if !is {
+				return fail("wrong coin type: %T", input)
+			}
+			reservedVal += c.amt
+			reservedParent += c.fees
+		} else {
+			c, is := input.(*fundingCoin)
+			if !is {
+				return fail("wrong coin type: %T", input)
+			}
+			reservedVal += c.amt
+		}
 	}
 
-	var totalContractValue uint64
+	var swapVal uint64
 	for _, contract := range swaps.Contracts {
-		totalContractValue += contract.Value
+		swapVal += contract.Value
 	}
 
-	fees := dexeth.InitGas(1, swaps.AssetVersion) * uint64(len(swaps.Contracts)) * swaps.FeeRate
-
-	totalSpend := fees + totalContractValue
-	if totalSpend > totalInputValue {
-		return nil, nil, 0, fmt.Errorf("unfunded contract. %d < %d", totalInputValue, totalSpend)
-	}
-
-	tx, err := eth.initiate(eth.ctx, swaps.Contracts, swaps.FeeRate, swaps.AssetVersion)
+	oneSwap, _, err := w.swapGas(1, cfg)
 	if err != nil {
-		return fail(fmt.Errorf("Swap: initiate error: %w", err))
+		return fail("error getting gas fees: %v", err)
+	}
+
+	gasLimit := oneSwap * uint64(len(swaps.Contracts))
+	fees := gasLimit * swaps.FeeRate
+
+	if isToken {
+		if swapVal > reservedVal {
+			return fail("unfunded token swap: %d < %d", reservedVal, swapVal)
+		}
+
+		if fees > reservedParent {
+			return fail("unfunded token swap fees: %d < %d", reservedParent, fees)
+		}
+	} else {
+		if swapVal+fees > reservedVal {
+			return fail("unfunded swap: %d < %d", reservedVal, swapVal+fees)
+		}
+	}
+
+	tx, err := w.initiate(w.ctx, w.assetID, swaps.Contracts, swaps.FeeRate, gasLimit, cfg.Version)
+	if err != nil {
+		return fail("Swap: initiate error: %w", err)
 	}
 
 	txHash := tx.Hash()
 	for _, swap := range swaps.Contracts {
 		var secretHash [dexeth.SecretHashSize]byte
 		copy(secretHash[:], swap.SecretHash)
-		receipts = append(receipts,
-			&swapReceipt{
-				expiration:   time.Unix(int64(swap.LockTime), 0),
-				value:        swap.Value,
-				txHash:       txHash,
-				secretHash:   secretHash,
-				ver:          swaps.AssetVersion,
-				contractAddr: dexeth.ContractAddresses[swaps.AssetVersion][eth.net].String(),
-			})
+		r := &swapReceipt{
+			expiration: time.Unix(int64(swap.LockTime), 0),
+			value:      swap.Value,
+			txHash:     txHash,
+			secretHash: secretHash,
+			ver:        cfg.Version,
+		}
+		if isToken {
+			// TODO: This can't be right
+			r.contractAddr = erc20.ContractAddresses[cfg.Version][w.net].String()
+		} else {
+			r.contractAddr = dexeth.ContractAddresses[cfg.Version][w.net].String()
+		}
+
+		receipts = append(receipts, r)
 	}
 
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
+	w.lockedFunds.mtx.Lock()
+	defer w.lockedFunds.mtx.Unlock()
 
 	var change asset.Coin
 	if swaps.LockChange {
-		eth.unlockFunds(totalSpend, initiationReserve)
-		change = eth.createFundingCoin(totalInputValue - totalSpend)
+		if isToken {
+			// For tokens, we'll unlock the swap val and the fees separately for
+			// the child and parent asset respectively.
+			w.unlockFunds(swapVal, initiationReserve)
+			w.token.parent.unlockFunds(fees, initiationReserve)
+			change = w.createTokenFundingCoin(reservedVal-swapVal, reservedParent-fees)
+		} else {
+			w.unlockFunds(swapVal+fees, initiationReserve)
+			change = w.createFundingCoin(reservedVal - swapVal - fees)
+		}
 	} else {
-		eth.unlockFunds(totalInputValue, initiationReserve)
+		if isToken {
+			// For tokens, we'll unlock the swap val and the fees separately for
+			// the child and parent asset respectively.
+			w.unlockFunds(reservedVal, initiationReserve)
+			w.token.parent.unlockFunds(reservedParent, initiationReserve)
+		} else {
+			w.unlockFunds(reservedVal, initiationReserve)
+		}
 	}
 
 	return receipts, change, fees, nil
@@ -807,17 +1273,21 @@ func (eth *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 // redemption. All redemptions must be for the same contract version because the
 // current API requires a single transaction reported (asset.Coin output), but
 // conceptually a batch of redeems could be processed for any number of
-// different contract addresses with multiple transactions.
-func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Coin, uint64, error) {
+// different contract addresses with multiple transactions. (buck: what would
+// the difference from calling Redeem repeatedly?)
+func (w *AssetWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Coin, uint64, error) {
 	fail := func(err error) ([]dex.Bytes, asset.Coin, uint64, error) {
 		return nil, nil, 0, err
 	}
 
-	if len(form.Redemptions) == 0 {
+	n := uint64(len(form.Redemptions))
+
+	if n == 0 {
 		return fail(errors.New("Redeem: must be called with at least 1 redemption"))
 	}
 
-	var contractVersion uint32 // require a consistent version since this is a single transaction
+	var contractVer uint32 // require a consistent version since this is a single transaction
+	secrets := make([][32]byte, 0, n)
 	var redeemedValue uint64
 	for i, redemption := range form.Redemptions {
 		// NOTE: redemption.Spends.SecretHash is a dup of the hash extracted
@@ -829,10 +1299,10 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 			return fail(fmt.Errorf("Redeem: invalid versioned swap contract data: %w", err))
 		}
 		if i == 0 {
-			contractVersion = ver
-		} else if contractVersion != ver {
+			contractVer = ver
+		} else if contractVer != ver {
 			return fail(fmt.Errorf("Redeem: inconsistent contract versions in RedeemForm.Redemptions: "+
-				"%d != %d", contractVersion, ver))
+				"%d != %d", contractVer, ver))
 		}
 
 		// Use the contract's free public view function to validate the secret
@@ -841,7 +1311,8 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 		// are maker (the swap initiator).
 		var secret [32]byte
 		copy(secret[:], redemption.Secret)
-		redeemable, err := eth.isRedeemable(secretHash, secret, ver)
+		secrets = append(secrets, secret)
+		redeemable, err := w.isRedeemable(secretHash, secret, ver)
 		if err != nil {
 			return fail(fmt.Errorf("Redeem: failed to check if swap is redeemable: %w", err))
 		}
@@ -850,19 +1321,54 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 				secretHash, secret))
 		}
 
-		swapData, err := eth.swap(eth.ctx, secretHash, ver)
+		swapData, err := w.swap(w.ctx, secretHash, ver)
 		if err != nil {
-			return nil, nil, 0, fmt.Errorf("Redeem: error finding swap state: %w", err)
+			return nil, nil, 0, fmt.Errorf("error finding swap state: %w", err)
 		}
 		redeemedValue += swapData.Value
 	}
 
-	outputCoin := eth.createFundingCoin(redeemedValue)
-	fundsRequired := dexeth.RedeemGas(len(form.Redemptions), contractVersion) * form.FeeSuggestion
+	g := w.gases(contractVer)
+	if g == nil {
+		return nil, nil, 0, fmt.Errorf("no gas table")
+	}
 
-	// TODO: make sure the amount we locked for redemption is enough to cover the gas
-	// fees.
-	tx, err := eth.redeem(eth.ctx, form.Redemptions, form.FeeSuggestion, contractVersion)
+	// Get a redemption gas estimate.
+	gasEst, err := w.estimateRedeemGas(w.ctx, secrets, contractVer)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("error getting redemption estimate: %v", err)
+	}
+
+	// If our estimate is higher than the calculated limit
+	gasLimit := g.Redeem * n
+	if gasEst > gasLimit {
+		// This is sticky. We only reserved so much for redemption, so accepting
+		// a gas limit higher than anticipated could potentially mess us up. On
+		// the other hand, we don't want to simply reject the redemption.
+		// Let's see if it looks like we can cover the fee. If so go ahead, up
+		// to a limit.
+		candidateLimit := gasEst * 11 / 10 // Add 10% for good measure.
+		// Cannot be more than double.
+		if candidateLimit > gasLimit*2 {
+			return nil, nil, 0, fmt.Errorf("cannot recover from excessive gas estimate %d > 2 * %d", candidateLimit, gasLimit)
+		}
+		additionalGas := candidateLimit - gasLimit
+		feeWallet := w
+		if w.token != nil {
+			feeWallet = w.token.parent
+		}
+		bal, err := feeWallet.Balance()
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("error getting balance in excessive gas fee recovery: %v", err)
+		}
+		if bal.Available < additionalGas {
+			return nil, nil, 0, fmt.Errorf("no balance available for gas overshoot recovery. %d < %d", bal.Available, additionalGas)
+		}
+		w.log.Warnf("live gas estimate %d exceeded expected max value %d. using higher limit %d for redemption", gasEst, gasLimit, candidateLimit)
+		gasLimit = candidateLimit
+	}
+
+	tx, err := w.redeem(w.ctx, w.assetID, form.Redemptions, form.FeeSuggestion, gasLimit, contractVer)
 	if err != nil {
 		return fail(fmt.Errorf("Redeem: redeem error: %w", err))
 	}
@@ -873,11 +1379,20 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 		txs[i] = txHash[:]
 	}
 
-	return txs, outputCoin, fundsRequired, nil
+	outputCoin := &coin{
+		id:    txHash,
+		value: redeemedValue,
+	}
+
+	// This is still a fee estimate. If we add a redemption confirmation method
+	// as has been discussed, then maybe the fees can be updated there.
+	fees := g.RedeemN(len(form.Redemptions)) * form.FeeSuggestion
+
+	return txs, outputCoin, fees, nil
 }
 
 // recoverPubkey recovers the uncompressed public key from the signature and the
-// message hash that wsa signed. The signature should be a compact signature
+// message hash that was signed. The signature should be a compact signature
 // generated by a geth wallet, with the format [R || S || V], with the recover
 // bit V at the end. See go-ethereum/crypto.Sign.
 func recoverPubkey(msgHash, sig []byte) ([]byte, error) {
@@ -894,70 +1409,121 @@ func recoverPubkey(msgHash, sig []byte) ([]byte, error) {
 	return pubKey.SerializeUncompressed(), nil
 }
 
+// maybeApproveTokenSwapContract checks whether a token's swap contract needs
+// to be approved for the wallet address on the erc20 contract.
+func (w *AssetWallet) maybeApproveTokenSwapContract(dexRedeemCfg *dex.Asset, redemptionReserves uint64) error {
+	if txHashI := w.token.approval.Load(); txHashI != nil {
+		return fmt.Errorf("an approval is already pending (%s). wait until it is mined "+
+			"before ordering again", txHashI.(common.Hash))
+	}
+	// Check if we need to up the allowance.
+	currentAllowance, err := w.tokenAllowance()
+	if err != nil {
+		return fmt.Errorf("error retrieving current allowance: %w", err)
+	}
+	if currentAllowance.Cmp(unlimitedAllowanceReplenishThreshold) >= 0 {
+		return nil
+	}
+	ethBal, err := w.ethWallet().balance()
+	if err != nil {
+		return fmt.Errorf("error getting eth balance: %w", err)
+	}
+	approveGas, err := w.approvalGas(unlimitedAllowance, dexRedeemCfg)
+	if err != nil {
+		return fmt.Errorf("error estimating allowance gas: %w", err)
+	}
+	if (approveGas*dexRedeemCfg.MaxFeeRate)+redemptionReserves > ethBal.Available {
+		return fmt.Errorf("parent balance %d doesn't cover contract approval (%d) and tx fees (%d)",
+			ethBal.Available, approveGas*dexRedeemCfg.MaxFeeRate, redemptionReserves)
+	}
+	tx, err := w.approveToken(unlimitedAllowance, dexRedeemCfg.MaxFeeRate, dexRedeemCfg.Version)
+	if err != nil {
+		return fmt.Errorf("token contract approval error: %w", err)
+	}
+	w.token.approval.Store(tx.Hash())
+	return nil
+}
+
 // ReserveNRedemptions locks funds for redemption. It is an error if there
 // is insufficient spendable balance. Part of the AccountLocker interface.
-func (eth *ExchangeWallet) ReserveNRedemptions(n, feeRate uint64, assetVer uint32) (uint64, error) {
-	redeemCost := dexeth.RedeemGas(1, assetVer) * feeRate
+func (w *AssetWallet) ReserveNRedemptions(n uint64, dexRedeemCfg *dex.Asset) (uint64, error) {
+	g := w.gases(dexRedeemCfg.Version)
+	if g == nil {
+		return 0, fmt.Errorf("no gas table")
+	}
+	redeemCost := g.Redeem * dexRedeemCfg.MaxFeeRate
 	reserve := redeemCost * n
+	if w.assetID != BipID {
+		if err := w.maybeApproveTokenSwapContract(dexRedeemCfg, reserve); err != nil {
+			return 0, err
+		}
+	}
 
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
-	err := eth.lockFunds(reserve, redemptionReserve)
+	w.lockedFunds.mtx.Lock()
+	defer w.lockedFunds.mtx.Unlock()
+	if err := w.ethWallet().lockFunds(reserve, redemptionReserve); err != nil {
+		return 0, err
+	}
 
-	return reserve, err
+	return reserve, nil
 }
 
 // UnlockRedemptionReserves unlocks the specified amount from redemption
 // reserves. Part of the AccountLocker interface.
-func (eth *ExchangeWallet) UnlockRedemptionReserves(reserves uint64) {
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
-	eth.unlockFunds(reserves, redemptionReserve)
+func (w *AssetWallet) UnlockRedemptionReserves(reserves uint64) {
+	w.lockedFunds.mtx.Lock()
+	defer w.lockedFunds.mtx.Unlock()
+	w.ethWallet().unlockFunds(reserves, redemptionReserve)
 }
 
 // ReReserveRedemption checks out an amount for redemptions. Use
-// ReReserveRedemption after initializing a new ExchangeWallet.
+// ReReserveRedemption after initializing a new AssetWallet.
 // Part of the AccountLocker interface.
-func (eth *ExchangeWallet) ReReserveRedemption(req uint64) error {
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
-	return eth.lockFunds(req, redemptionReserve)
+func (w *AssetWallet) ReReserveRedemption(req uint64) error {
+	w.lockedFunds.mtx.Lock()
+	defer w.lockedFunds.mtx.Unlock()
+	return w.ethWallet().lockFunds(req, redemptionReserve)
 }
 
 // ReserveNRefunds locks funds for doing refunds. It is an error if there
 // is insufficient spendable balance. Part of the AccountLocker interface.
-func (eth *ExchangeWallet) ReserveNRefunds(n, feeRate uint64, assetVer uint32) (uint64, error) {
-	refundCost := dexeth.RefundGas(assetVer) * feeRate
+func (w *AssetWallet) ReserveNRefunds(n uint64, dexSwapCfg *dex.Asset) (uint64, error) {
+	g := w.gases(dexSwapCfg.Version)
+	if g == nil {
+		return 0, errors.New("no gas table")
+	}
+	refundCost := g.Refund * dexSwapCfg.MaxFeeRate
 	reserve := refundCost * n
 
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
-	err := eth.lockFunds(reserve, refundReserve)
+	w.lockedFunds.mtx.Lock()
+	defer w.lockedFunds.mtx.Unlock()
+
+	err := w.ethWallet().lockFunds(reserve, refundReserve)
 
 	return reserve, err
 }
 
 // UnlockRefundReserves unlocks the specified amount from refund
 // reserves. Part of the AccountLocker interface.
-func (eth *ExchangeWallet) UnlockRefundReserves(reserves uint64) {
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
-	eth.unlockFunds(reserves, refundReserve)
+func (w *AssetWallet) UnlockRefundReserves(reserves uint64) {
+	w.lockedFunds.mtx.Lock()
+	defer w.lockedFunds.mtx.Unlock()
+	w.ethWallet().unlockFunds(reserves, refundReserve)
 }
 
 // ReReserveRefund checks out an amount for doing refunds. Use ReReserveRefund
-// after initializing a new ExchangeWallet. Part of the AccountLocker
+// after initializing a new AssetWallet. Part of the AccountLocker
 // interface.
-func (eth *ExchangeWallet) ReReserveRefund(req uint64) error {
-	eth.lockedFunds.mtx.Lock()
-	defer eth.lockedFunds.mtx.Unlock()
-	return eth.lockFunds(req, refundReserve)
+func (w *AssetWallet) ReReserveRefund(req uint64) error {
+	w.lockedFunds.mtx.Lock()
+	defer w.lockedFunds.mtx.Unlock()
+	return w.ethWallet().lockFunds(req, refundReserve)
 }
 
 // SignMessage signs the message with the private key associated with the
 // specified funding Coin. Only a coin that came from the address this wallet
 // is initialized with can be used to sign.
-func (eth *ExchangeWallet) SignMessage(_ asset.Coin, msg dex.Bytes) (pubkeys, sigs []dex.Bytes, err error) {
+func (eth *baseWallet) SignMessage(_ asset.Coin, msg dex.Bytes) (pubkeys, sigs []dex.Bytes, err error) {
 	sig, pubKey, err := eth.node.signData(msg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("SignMessage: error signing data: %w", err)
@@ -971,7 +1537,7 @@ func (eth *ExchangeWallet) SignMessage(_ asset.Coin, msg dex.Bytes) (pubkeys, si
 // during a swap. coinID is expected to be the transaction id, and must
 // be the same as the hash of serializedTx. contract is expected to be
 // (contractVersion|secretHash) where the secretHash uniquely keys the swap.
-func (eth *ExchangeWallet) AuditContract(coinID, contract, serializedTx dex.Bytes, rebroadcast bool) (*asset.AuditInfo, error) {
+func (eth *baseWallet) AuditContract(coinID, contract, serializedTx dex.Bytes, rebroadcast bool) (*asset.AuditInfo, error) {
 	tx := new(types.Transaction)
 	err := tx.UnmarshalBinary(serializedTx)
 	if err != nil {
@@ -999,7 +1565,7 @@ func (eth *ExchangeWallet) AuditContract(coinID, contract, serializedTx dex.Byte
 	}
 
 	coin := &coin{
-		id:    coinID,
+		id:    txHash,
 		value: initiation.Value,
 	}
 
@@ -1025,13 +1591,13 @@ func (eth *ExchangeWallet) AuditContract(coinID, contract, serializedTx dex.Byte
 
 // LocktimeExpired returns true if the specified contract's locktime has
 // expired, making it possible to issue a Refund.
-func (eth *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
+func (w *AssetWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
 	contractVer, secretHash, err := dexeth.DecodeContractData(contract)
 	if err != nil {
 		return false, time.Time{}, err
 	}
 
-	swap, err := eth.swap(eth.ctx, secretHash, contractVer)
+	swap, err := w.swap(w.ctx, secretHash, contractVer)
 	if err != nil {
 		return false, time.Time{}, err
 	}
@@ -1041,7 +1607,7 @@ func (eth *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time,
 		return false, time.Time{}, asset.ErrSwapNotInitiated
 	}
 
-	header, err := eth.node.bestHeader(eth.ctx)
+	header, err := w.node.bestHeader(w.ctx)
 	if err != nil {
 		return false, time.Time{}, err
 	}
@@ -1063,7 +1629,7 @@ type findRedemptionRequest struct {
 
 // sendFindRedemptionResult sends the result or logs a message if it cannot be
 // sent.
-func (eth *ExchangeWallet) sendFindRedemptionResult(req *findRedemptionRequest, secretHash [32]byte, secret []byte, err error) {
+func (eth *baseWallet) sendFindRedemptionResult(req *findRedemptionRequest, secretHash [32]byte, secret []byte, err error) {
 	select {
 	case req.res <- &findRedemptionResult{secret: secret, err: err}:
 	default:
@@ -1072,11 +1638,11 @@ func (eth *ExchangeWallet) sendFindRedemptionResult(req *findRedemptionRequest, 
 }
 
 // findRedemptionRequests creates a copy of the findRedemptionReqs map.
-func (eth *ExchangeWallet) findRedemptionRequests() map[[32]byte]*findRedemptionRequest {
-	eth.findRedemptionMtx.RLock()
-	defer eth.findRedemptionMtx.RUnlock()
-	reqs := make(map[[32]byte]*findRedemptionRequest, len(eth.findRedemptionReqs))
-	for secretHash, req := range eth.findRedemptionReqs {
+func (w *AssetWallet) findRedemptionRequests() map[[32]byte]*findRedemptionRequest {
+	w.findRedemptionMtx.RLock()
+	defer w.findRedemptionMtx.RUnlock()
+	reqs := make(map[[32]byte]*findRedemptionRequest, len(w.findRedemptionReqs))
+	for secretHash, req := range w.findRedemptionReqs {
 		reqs[secretHash] = req
 	}
 	return reqs
@@ -1085,14 +1651,14 @@ func (eth *ExchangeWallet) findRedemptionRequests() map[[32]byte]*findRedemption
 // FindRedemption checks the contract for a redemption. If the swap is initiated
 // but un-redeemed and un-refunded, FindRedemption will block until a redemption
 // is seen.
-func (eth *ExchangeWallet) FindRedemption(ctx context.Context, _, contract dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
+func (w *AssetWallet) FindRedemption(ctx context.Context, _, contract dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
 	contractVer, secretHash, err := dexeth.DecodeContractData(contract)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// See if it's ready right away.
-	secret, err = eth.findSecret(ctx, secretHash, contractVer)
+	secret, err = w.findSecret(secretHash, contractVer)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1107,16 +1673,16 @@ func (eth *ExchangeWallet) FindRedemption(ctx context.Context, _, contract dex.B
 		res:         make(chan *findRedemptionResult, 1),
 	}
 
-	eth.findRedemptionMtx.Lock()
+	w.findRedemptionMtx.Lock()
 
-	if eth.findRedemptionReqs[secretHash] != nil {
-		eth.findRedemptionMtx.Unlock()
+	if w.findRedemptionReqs[secretHash] != nil {
+		w.findRedemptionMtx.Unlock()
 		return nil, nil, fmt.Errorf("duplicate find redemption request for %x", secretHash)
 	}
 
-	eth.findRedemptionReqs[secretHash] = req
+	w.findRedemptionReqs[secretHash] = req
 
-	eth.findRedemptionMtx.Unlock()
+	w.findRedemptionMtx.Unlock()
 
 	var res *findRedemptionResult
 	select {
@@ -1124,9 +1690,9 @@ func (eth *ExchangeWallet) FindRedemption(ctx context.Context, _, contract dex.B
 	case <-ctx.Done():
 	}
 
-	eth.findRedemptionMtx.Lock()
-	delete(eth.findRedemptionReqs, secretHash)
-	eth.findRedemptionMtx.Unlock()
+	w.findRedemptionMtx.Lock()
+	delete(w.findRedemptionReqs, secretHash)
+	w.findRedemptionMtx.Unlock()
 
 	if res == nil {
 		return nil, nil, fmt.Errorf("context cancelled for find redemption request %x", secretHash)
@@ -1139,11 +1705,10 @@ func (eth *ExchangeWallet) FindRedemption(ctx context.Context, _, contract dex.B
 	return findRedemptionCoinID, res.secret[:], nil
 }
 
-func (eth *ExchangeWallet) findSecret(ctx context.Context, secretHash [32]byte, contractVer uint32) ([]byte, error) {
-	// Add a reasonable timeout here.
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+func (w *AssetWallet) findSecret(secretHash [32]byte, contractVer uint32) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(w.ctx, 10*time.Second)
 	defer cancel()
-	swap, err := eth.swap(ctx, secretHash, contractVer)
+	swap, err := w.swap(ctx, secretHash, contractVer)
 	if err != nil {
 		return nil, err
 	}
@@ -1163,13 +1728,13 @@ func (eth *ExchangeWallet) findSecret(ctx context.Context, secretHash [32]byte, 
 
 // Refund refunds a contract. This can only be used after the time lock has
 // expired.
-func (eth *ExchangeWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (dex.Bytes, error) {
+func (w *AssetWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (dex.Bytes, error) {
 	version, secretHash, err := dexeth.DecodeContractData(contract)
 	if err != nil {
 		return nil, fmt.Errorf("Refund: failed to decode contract: %w", err)
 	}
 
-	swap, err := eth.swap(eth.ctx, secretHash, version)
+	swap, err := w.swap(w.ctx, secretHash, version)
 	if err != nil {
 		return nil, err
 	}
@@ -1180,16 +1745,16 @@ func (eth *ExchangeWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (
 	case dexeth.SSNone:
 		return nil, asset.ErrSwapNotInitiated
 	case dexeth.SSRefunded:
-		eth.log.Infof("Swap with secret hash %x already refunded.", secretHash)
+		w.log.Infof("Swap with secret hash %x already refunded.", secretHash)
 		zeroHash := common.Hash{}
 		return zeroHash[:], nil
 	case dexeth.SSRedeemed:
-		eth.log.Infof("Swap with secret hash %x already redeemed with secret key %x.",
+		w.log.Infof("Swap with secret hash %x already redeemed with secret key %x.",
 			secretHash, swap.Secret)
 		return nil, asset.CoinNotFoundError // so caller knows to FindRedemption
 	}
 
-	refundable, err := eth.isRefundable(secretHash, version)
+	refundable, err := w.isRefundable(secretHash, version)
 	if err != nil {
 		return nil, fmt.Errorf("Refund: failed to check isRefundable: %w", err)
 	}
@@ -1197,7 +1762,7 @@ func (eth *ExchangeWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (
 		return nil, fmt.Errorf("Refund: swap with secret hash %x is not refundable", secretHash)
 	}
 
-	tx, err := eth.refund(eth.ctx, secretHash, feeSuggestion, version)
+	tx, err := w.refund(secretHash, feeSuggestion, version)
 	if err != nil {
 		return nil, fmt.Errorf("Refund: failed to call refund: %w", err)
 	}
@@ -1207,56 +1772,108 @@ func (eth *ExchangeWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (
 }
 
 // Address returns an address for the exchange wallet. This implementation is
-// idempotent, always returning the same address for a given ExchangeWallet.
-func (eth *ExchangeWallet) Address() (string, error) {
+// idempotent, always returning the same address for a given AssetWallet.
+func (eth *baseWallet) Address() (string, error) {
 	return eth.addr.String(), nil
 }
 
+// TODO: Lock, Unlock, and Locked should probably be part of an optional
+// asset.Authenticator interface that isn't implemented by token wallets.
+// This is easy to accomplish here, but would require substantial updates to
+// client/core.
+// The addition of an ETHWallet type that implements asset.Authenticator would
+// also facilitate the appropriate compartmentalization of our asset.TokenMaster
+// methods, which token wallets also won't need.
+
 // Unlock unlocks the exchange wallet.
-func (eth *ExchangeWallet) Unlock(pw []byte) error {
+func (eth *baseWallet) Unlock(pw []byte) error {
 	return eth.node.unlock(string(pw))
 }
 
 // Lock locks the exchange wallet.
-func (eth *ExchangeWallet) Lock() error {
+func (eth *baseWallet) Lock() error {
 	return eth.node.lock()
 }
 
 // Locked will be true if the wallet is currently locked.
-func (eth *ExchangeWallet) Locked() bool {
+func (eth *baseWallet) Locked() bool {
 	return eth.node.locked()
 }
 
 // PayFee sends the dex registration fee. Transaction fees are in addition to
 // the registration fee, and the fee rate is taken from the DEX configuration.
-func (eth *ExchangeWallet) PayFee(address string, regFee, _ uint64) (asset.Coin, error) {
-	bal, err := eth.Balance()
+func (w *AssetWallet) PayFee(addr string, regFee, feeSuggestion uint64) (asset.Coin, error) {
+	if !common.IsHexAddress(addr) {
+		return nil, fmt.Errorf("invalid hex address %q", addr)
+	}
+
+	bal, err := w.Balance()
 	if err != nil {
 		return nil, err
 	}
 	avail := bal.Available
-	maxFee := defaultSendGasLimit * eth.gasFeeLimit
-	need := regFee + maxFee
-	if avail < need {
-		return nil, fmt.Errorf("not enough funds to pay fee: have %d gwei need %d gwei", avail, need)
+
+	maxFeeRate := dexeth.GweiToWei(feeSuggestion)
+	if feeSuggestion == 0 {
+		maxFeeRate, err = w.recommendedMaxFeeRate(w.ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
-	tx, err := eth.sendToAddr(common.HexToAddress(address), regFee)
+
+	if w.assetID == BipID {
+		maxFee := dexeth.WeiToGwei(maxFeeRate) * defaultSendGasLimit
+		need := regFee + maxFee
+		if avail < need {
+			return nil, fmt.Errorf("not enough funds to pay fee: have %d gwei need %d gwei", avail, need)
+		}
+	} else {
+		if avail < regFee {
+			return nil, fmt.Errorf("not enough tokens: have %d gwei need %d gwei", avail, regFee)
+		}
+		ethBal, err := w.token.parent.Balance()
+		if err != nil {
+			return nil, fmt.Errorf("error getting base chain balance: %w", err)
+		}
+
+		g := w.gases(contractVersionNewest)
+		if g == nil {
+			return nil, fmt.Errorf("gas table not found")
+		}
+
+		maxFee := dexeth.WeiToGwei(maxFeeRate) * g.Transfer
+		if ethBal.Available < maxFee {
+			return nil, fmt.Errorf("insufficient balance to cover token transfer fees. %d < %d",
+				ethBal.Available, maxFee)
+		}
+	}
+
+	tx, err := w.sendToAddr(common.HexToAddress(addr), regFee, maxFeeRate)
 	if err != nil {
 		return nil, err
 	}
 	txHash := tx.Hash()
-	return &coin{id: txHash[:], value: dexeth.WeiToGwei(tx.Value())}, nil
+	return &coin{id: txHash, value: regFee}, nil
 }
 
 // EstimateRegistrationTxFee returns an estimate for the tx fee needed to
 // pay the registration fee using the provided feeRate.
-func (eth *ExchangeWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
-	return feeRate * defaultSendGasLimit
+func (w *AssetWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
+	if w.assetID == BipID {
+		return feeRate * defaultSendGasLimit
+	}
+	g := w.gases(contractVersionNewest)
+	if g == nil {
+		w.log.Errorf("no gas table")
+		return math.MaxUint64
+	}
+	return g.Transfer * feeRate
+
 }
 
 // SwapConfirmations gets the number of confirmations and the spend status
 // for the specified swap.
-func (eth *ExchangeWallet) SwapConfirmations(ctx context.Context, _ dex.Bytes, contract dex.Bytes, _ time.Time) (confs uint32, spent bool, err error) {
+func (w *AssetWallet) SwapConfirmations(ctx context.Context, _ dex.Bytes, contract dex.Bytes, _ time.Time) (confs uint32, spent bool, err error) {
 	contractVer, secretHash, err := dexeth.DecodeContractData(contract)
 	if err != nil {
 		return 0, false, err
@@ -1265,12 +1882,12 @@ func (eth *ExchangeWallet) SwapConfirmations(ctx context.Context, _ dex.Bytes, c
 	ctx, cancel := context.WithTimeout(ctx, confCheckTimeout)
 	defer cancel()
 
-	hdr, err := eth.node.bestHeader(ctx)
+	hdr, err := w.node.bestHeader(ctx)
 	if err != nil {
 		return 0, false, fmt.Errorf("error fetching best header: %w", err)
 	}
 
-	swapData, err := eth.swap(ctx, secretHash, contractVer)
+	swapData, err := w.swap(w.ctx, secretHash, contractVer)
 	if err != nil {
 		return 0, false, fmt.Errorf("error finding swap state: %w", err)
 	}
@@ -1287,8 +1904,8 @@ func (eth *ExchangeWallet) SwapConfirmations(ctx context.Context, _ dex.Bytes, c
 
 // Withdraw withdraws funds to the specified address. Value is gwei. The fee is
 // subtracted from the total balance if it cannot be sent otherwise.
-func (eth *ExchangeWallet) Withdraw(addr string, value, _ uint64) (asset.Coin, error) {
-	bal, err := eth.Balance()
+func (w *AssetWallet) Withdraw(addr string, value, _ uint64) (asset.Coin, error) {
+	bal, err := w.Balance()
 	if err != nil {
 		return nil, err
 	}
@@ -1296,29 +1913,57 @@ func (eth *ExchangeWallet) Withdraw(addr string, value, _ uint64) (asset.Coin, e
 	if avail < value {
 		return nil, fmt.Errorf("not enough funds to withdraw: have %d gwei need %d gwei", avail, value)
 	}
-	maxFee := defaultSendGasLimit * eth.gasFeeLimit
-	if avail < maxFee {
-		return nil, fmt.Errorf("not enough funds to withdraw: cannot cover max fee of %d gwei", maxFee)
+	maxFeeRate, err := w.recommendedMaxFeeRate(w.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error getting max fee rate: %v", err)
 	}
-	if avail < value+maxFee {
-		value -= maxFee
+
+	if w.assetID == BipID {
+		maxFee := defaultSendGasLimit * dexeth.WeiToGwei(maxFeeRate)
+		if avail < value+maxFee {
+			return nil, fmt.Errorf("not enough funds to withdraw: cannot cover value %d, max fee of %d gwei", value, maxFee)
+		}
+		// TODO: asset.Sweeper interface.
+		// if avail < value+maxFee {
+		// 	value -= maxFee
+		// }
+	} else {
+		if avail < value {
+			return nil, fmt.Errorf("not enough tokens: have %d gwei need %d gwei", avail, value)
+		}
+		ethBal, err := w.token.parent.Balance()
+		if err != nil {
+			return nil, fmt.Errorf("error getting base chain balance: %w", err)
+		}
+
+		g := w.gases(contractVersionNewest)
+		if g == nil {
+			return nil, fmt.Errorf("gas table not found")
+		}
+
+		maxFee := dexeth.WeiToGwei(maxFeeRate) * g.Transfer
+		if ethBal.Available < maxFee {
+			return nil, fmt.Errorf("insufficient balance to cover token transfer fees. %d < %d",
+				ethBal.Available, maxFee)
+		}
 	}
-	tx, err := eth.sendToAddr(common.HexToAddress(addr), value)
+
+	tx, err := w.sendToAddr(common.HexToAddress(addr), value, maxFeeRate)
 	if err != nil {
 		return nil, err
 	}
 	txHash := tx.Hash()
-	return &coin{id: txHash[:], value: dexeth.WeiToGwei(tx.Value())}, nil
+	return &coin{id: txHash, value: value}, nil
 }
 
 // ValidateSecret checks that the secret satisfies the contract.
-func (*ExchangeWallet) ValidateSecret(secret, secretHash []byte) bool {
+func (*baseWallet) ValidateSecret(secret, secretHash []byte) bool {
 	h := sha256.Sum256(secret)
 	return bytes.Equal(h[:], secretHash)
 }
 
 // SyncStatus is information about the blockchain sync status.
-func (eth *ExchangeWallet) SyncStatus() (bool, float32, error) {
+func (eth *baseWallet) SyncStatus() (bool, float32, error) {
 	// node.syncProgress will return a zero value both before syncing has begun
 	// and after it has finished. In order to discern when syncing has begun,
 	// check that the best header came in under dexeth.MaxBlockInterval.
@@ -1350,23 +1995,33 @@ func (eth *ExchangeWallet) SyncStatus() (bool, float32, error) {
 
 // RegFeeConfirmations gets the number of confirmations for the specified
 // transaction.
-func (eth *ExchangeWallet) RegFeeConfirmations(ctx context.Context, coinID dex.Bytes) (confs uint32, err error) {
+func (eth *baseWallet) RegFeeConfirmations(ctx context.Context, coinID dex.Bytes) (confs uint32, err error) {
 	var txHash common.Hash
 	copy(txHash[:], coinID)
 	return eth.node.transactionConfirmations(ctx, txHash)
 }
 
-// FeeRate satisfies asset.FeeRater.
-func (eth *ExchangeWallet) FeeRate() uint64 {
+// recommendedMaxFeeRate finds a recommended max fee rate using the somewhat
+// standard baseRate * 2 + tip formula.
+func (eth *baseWallet) recommendedMaxFeeRate(ctx context.Context) (*big.Int, error) {
 	base, tip, err := eth.node.currentFees(eth.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting net fee state: %v", err)
+	}
+
+	return new(big.Int).Add(
+		tip,
+		new(big.Int).Mul(base, big.NewInt(2)),
+	), nil
+}
+
+// FeeRate satisfies asset.FeeRater.
+func (eth *baseWallet) FeeRate() uint64 {
+	feeRate, err := eth.recommendedMaxFeeRate(eth.ctx)
 	if err != nil {
 		eth.log.Errorf("Error getting net fee state: %v", err)
 		return 0
 	}
-
-	feeRate := new(big.Int).Add(
-		tip,
-		new(big.Int).Mul(base, big.NewInt(2)))
 
 	feeRateGwei, err := dexeth.WeiToGweiUint64(feeRate)
 	if err != nil {
@@ -1377,7 +2032,7 @@ func (eth *ExchangeWallet) FeeRate() uint64 {
 	return feeRateGwei
 }
 
-func (eth *ExchangeWallet) checkPeers() {
+func (eth *baseWallet) checkPeers() {
 	numPeers := eth.node.peerCount()
 	prevPeer := atomic.SwapUint32(&eth.lastPeerCount, numPeers)
 	if prevPeer != numPeers {
@@ -1385,7 +2040,7 @@ func (eth *ExchangeWallet) checkPeers() {
 	}
 }
 
-func (eth *ExchangeWallet) monitorPeers(ctx context.Context) {
+func (eth *baseWallet) monitorPeers(ctx context.Context) {
 	ticker := time.NewTicker(peerCountTicker)
 	defer ticker.Stop()
 	for {
@@ -1402,13 +2057,13 @@ func (eth *ExchangeWallet) monitorPeers(ctx context.Context) {
 // monitorBlocks pings for new blocks and runs the tipChange callback function
 // when the block changes. New blocks are also scanned for potential contract
 // redeems.
-func (eth *ExchangeWallet) monitorBlocks(ctx context.Context) {
+func (eth *baseWallet) monitorBlocks(ctx context.Context, reportErr func(error)) {
 	ticker := time.NewTicker(blockTicker)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			eth.checkForNewBlocks()
+			eth.checkForNewBlocks(reportErr)
 		case <-ctx.Done():
 			return
 		}
@@ -1418,12 +2073,12 @@ func (eth *ExchangeWallet) monitorBlocks(ctx context.Context) {
 // checkForNewBlocks checks for new blocks. When a tip change is detected, the
 // tipChange callback function is invoked and a goroutine is started to check
 // if any contracts in the findRedemptionQueue are redeemed in the new blocks.
-func (eth *ExchangeWallet) checkForNewBlocks() {
+func (eth *baseWallet) checkForNewBlocks(reportErr func(error)) {
 	ctx, cancel := context.WithTimeout(eth.ctx, 2*time.Second)
 	defer cancel()
 	bestHdr, err := eth.node.bestHeader(ctx)
 	if err != nil {
-		go eth.tipChange(fmt.Errorf("failed to get best hash: %w", err))
+		go reportErr(fmt.Errorf("failed to get best hash: %w", err))
 		return
 	}
 	bestHash := bestHdr.Hash()
@@ -1441,41 +2096,48 @@ func (eth *ExchangeWallet) checkForNewBlocks() {
 
 	prevTip := eth.currentTip
 	eth.currentTip = bestHdr
-	eth.log.Debugf("tip change: %d (%s) => %d (%s)", prevTip.Number,
+
+	eth.log.Debugf("tip change: %s (%s) => %s (%s)", prevTip.Number,
 		currentTipHash, bestHdr.Number, bestHash)
-	go eth.tipChange(nil)
-	go eth.checkFindRedemptions()
+
+	go func() {
+		for _, w := range eth.walletList() {
+			w.tipChange(nil)
+		}
+	}()
+	go func() {
+		for _, w := range eth.walletList() {
+			w.checkFindRedemptions()
+		}
+	}()
 }
 
 // checkFindRedemptions checks queued findRedemptionRequests.
-func (eth *ExchangeWallet) checkFindRedemptions() {
-	for secretHash, req := range eth.findRedemptionRequests() {
-		secret, err := eth.findSecret(eth.ctx, secretHash, req.contractVer)
+func (w *AssetWallet) checkFindRedemptions() {
+	for secretHash, req := range w.findRedemptionRequests() {
+		secret, err := w.findSecret(secretHash, req.contractVer)
 		if err != nil {
-			eth.sendFindRedemptionResult(req, secretHash, nil, err)
+			w.sendFindRedemptionResult(req, secretHash, nil, err)
 		} else if len(secret) > 0 {
-			eth.sendFindRedemptionResult(req, secretHash, secret, nil)
+			w.sendFindRedemptionResult(req, secretHash, secret, nil)
 		}
 	}
 }
 
-// withContractor runs the provided function with the versioned contractor.
-func (eth *ExchangeWallet) withContractor(ver uint32, f func(contractor) error) error {
-	contractor, found := eth.contractors[ver]
-	if !found {
-		return fmt.Errorf("no version %d contractor", ver)
+func (w *AssetWallet) balanceWithTxPool() (*Balance, error) {
+	isETH := w.assetID == BipID
+	var confirmed *big.Int
+	var err error
+	if isETH {
+		confirmed, err = w.node.addressBalance(w.ctx, w.addr)
+	} else {
+		confirmed, err = w.tokenBalance()
 	}
-	return f(contractor)
-}
-
-// balanceWithTxPool gets the current and pending balances.
-func (eth *ExchangeWallet) balanceWithTxPool() (*Balance, error) {
-	confirmed, err := eth.node.addressBalance(eth.ctx, eth.addr)
 	if err != nil {
-		return nil, fmt.Errorf("balance error: %w", err)
+		return nil, fmt.Errorf("balance error: %v", err)
 	}
 
-	pendingTxs, err := eth.node.pendingTransactions()
+	pendingTxs, err := w.node.pendingTransactions()
 	if err != nil {
 		return nil, fmt.Errorf("error getting pending txs: %w", err)
 	}
@@ -1486,39 +2148,47 @@ func (eth *ExchangeWallet) balanceWithTxPool() (*Balance, error) {
 
 	addFees := func(tx *types.Transaction) {
 		gas := new(big.Int).SetUint64(tx.Gas())
+		// For legacy transactions, GasFeeCap returns gas price
 		if gasFeeCap := tx.GasFeeCap(); gasFeeCap != nil {
 			outgoing.Add(outgoing, new(big.Int).Mul(gas, gasFeeCap))
 		} else {
-			eth.log.Errorf("unable to calculate fees for tx %s", tx.Hash())
+			w.log.Errorf("unable to calculate fees for tx %s", tx.Hash())
 		}
 	}
 
-	ethSigner := types.LatestSigner(eth.node.chainConfig()) // "latest" good for pending
+	ethSigner := types.LatestSigner(w.node.chainConfig()) // "latest" good for pending
 
 	for _, tx := range pendingTxs {
-		from, _ := ethSigner.Sender(tx) // zero Address on error
-		if from != eth.addr {
+		from, _ := ethSigner.Sender(tx)
+		if from != w.addr {
 			continue
 		}
-		addFees(tx)
-		v := tx.Value()
-		if v.Cmp(zero) == 0 {
-			// If zero value, attempt to find redemptions or refunds that pay
-			// to us.
-			for ver, c := range eth.contractors {
-				in, err := c.incomingValue(eth.ctx, tx)
-				if err != nil {
-					eth.log.Errorf("version %d contractor incomingValue error: %v", ver, err)
-					continue
-				}
-				if in > 0 {
-					incoming.Add(incoming, dexeth.GweiToWei(in))
-				}
+
+		if isETH {
+			// Add tx fees
+			addFees(tx)
+		}
+
+		var contractOut uint64
+		for ver, c := range w.contractors {
+			in, out, err := c.value(w.ctx, tx)
+			if err != nil {
+				w.log.Errorf("version %d contractor incomingValue error: %v", ver, err)
+				continue
 			}
-		} else {
-			// If non-zero outgoing value, this is a swap or a send of some
-			// type.
-			outgoing.Add(outgoing, v)
+			contractOut += out
+			if in > 0 {
+				incoming.Add(incoming, w.evmify(in))
+			}
+		}
+		if contractOut > 0 {
+			outgoing.Add(outgoing, w.evmify(contractOut))
+		} else if isETH {
+			// Count withdraws and sends for ETH.
+			v := tx.Value()
+			if v.Cmp(zero) > 0 {
+				outgoing.Add(outgoing, v)
+			}
 		}
 	}
 
@@ -1530,35 +2200,49 @@ func (eth *ExchangeWallet) balanceWithTxPool() (*Balance, error) {
 }
 
 // sendToAddr sends funds to the address.
-func (eth *ExchangeWallet) sendToAddr(addr common.Address, amt uint64) (*types.Transaction, error) {
-	eth.nonceSendMtx.Lock()
-	defer eth.nonceSendMtx.Unlock()
-	txOpts, err := eth.node.txOpts(eth.ctx, amt, defaultSendGasLimit, nil)
-	if err != nil {
-		return nil, err
+func (w *AssetWallet) sendToAddr(addr common.Address, amt uint64, maxFeeRate *big.Int) (tx *types.Transaction, err error) {
+	w.baseWallet.nonceSendMtx.Lock()
+	defer w.baseWallet.nonceSendMtx.Unlock()
+	if w.assetID == BipID {
+		txOpts, err := w.node.txOpts(w.ctx, amt, defaultSendGasLimit, maxFeeRate)
+		if err != nil {
+			return nil, err
+		}
+		return w.node.sendTransaction(w.ctx, txOpts, addr, nil)
 	}
-	return eth.node.sendTransaction(eth.ctx, txOpts, addr, nil)
+	return tx, w.withTokenContractor(w.assetID, contractVersionNewest, func(c tokenContractor) error {
+		// DRAFT TODO: This shouldn't be defaultSendGasLimit
+		txOpts, err := w.node.txOpts(w.ctx, 0, defaultSendGasLimit, nil)
+		if err != nil {
+			return err
+		}
+		tx, err = c.transfer(txOpts, addr, w.evmify(amt))
+		return err
+	})
 }
 
 // swap gets a swap keyed by secretHash in the contract.
-func (eth *ExchangeWallet) swap(ctx context.Context, secretHash [32]byte, contractVer uint32) (swap *dexeth.SwapState, err error) {
-	return swap, eth.withContractor(contractVer, func(c contractor) error {
+func (w *AssetWallet) swap(ctx context.Context, secretHash [32]byte, contractVer uint32) (swap *dexeth.SwapState, err error) {
+	return swap, w.withContractor(contractVer, func(c contractor) error {
 		swap, err = c.swap(ctx, secretHash)
 		return err
 	})
 }
 
 // initiate initiates multiple swaps in the same transaction.
-func (eth *ExchangeWallet) initiate(ctx context.Context, contracts []*asset.Contract, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
-	gas := dexeth.InitGas(len(contracts), contractVer)
+func (w *AssetWallet) initiate(ctx context.Context, assetID uint32, contracts []*asset.Contract,
+	maxFeeRate, gasLimit uint64, contractVer uint32) (tx *types.Transaction, err error) {
+
 	var val uint64
-	for _, c := range contracts {
-		val += c.Value
+	if assetID == BipID {
+		for _, c := range contracts {
+			val += c.Value
+		}
 	}
-	eth.nonceSendMtx.Lock()
-	defer eth.nonceSendMtx.Unlock()
-	txOpts, _ := eth.node.txOpts(ctx, val, gas, dexeth.GweiToWei(maxFeeRate))
-	return tx, eth.withContractor(contractVer, func(c contractor) error {
+	w.nonceSendMtx.Lock()
+	defer w.nonceSendMtx.Unlock()
+	txOpts, _ := w.node.txOpts(ctx, val, gasLimit, dexeth.GweiToWei(maxFeeRate))
+	return tx, w.withContractor(contractVer, func(c contractor) error {
 		tx, err = c.initiate(txOpts, contracts)
 		return err
 	})
@@ -1566,37 +2250,122 @@ func (eth *ExchangeWallet) initiate(ctx context.Context, contracts []*asset.Cont
 
 // estimateInitGas checks the amount of gas that is used for the
 // initialization.
-func (eth *ExchangeWallet) estimateInitGas(ctx context.Context, numSwaps int, contractVer uint32) (gas uint64, err error) {
-	return gas, eth.withContractor(contractVer, func(c contractor) error {
+func (w *AssetWallet) estimateInitGas(ctx context.Context, numSwaps int, contractVer uint32) (gas uint64, err error) {
+	return gas, w.withContractor(contractVer, func(c contractor) error {
 		gas, err = c.estimateInitGas(ctx, numSwaps)
 		return err
 	})
 }
 
 // estimateRedeemGas checks the amount of gas that is used for the redemption.
-func (eth *ExchangeWallet) estimateRedeemGas(ctx context.Context, secrets [][32]byte, contractVer uint32) (gas uint64, err error) {
-	return gas, eth.withContractor(contractVer, func(c contractor) error {
+func (w *AssetWallet) estimateRedeemGas(ctx context.Context, secrets [][32]byte, contractVer uint32) (gas uint64, err error) {
+	return gas, w.withContractor(contractVer, func(c contractor) error {
 		gas, err = c.estimateRedeemGas(ctx, secrets)
 		return err
 	})
 }
 
 // estimateRefundGas checks the amount of gas that is used for a refund.
-func (eth *ExchangeWallet) estimateRefundGas(ctx context.Context, secretHash [32]byte, contractVer uint32) (gas uint64, err error) {
-	return gas, eth.withContractor(contractVer, func(c contractor) error {
+func (w *AssetWallet) estimateRefundGas(ctx context.Context, secretHash [32]byte, contractVer uint32) (gas uint64, err error) {
+	return gas, w.withContractor(contractVer, func(c contractor) error {
 		gas, err = c.estimateRefundGas(ctx, secretHash)
+		return err
+	})
+}
+
+// loadContractors prepares the token contractors and add them to the map.
+func (w *AssetWallet) loadContractors(ctx context.Context, tokenID uint32) error {
+	token, found := dexeth.Tokens[tokenID]
+	if !found {
+		return fmt.Errorf("token %d not found", tokenID)
+	}
+	netToken, found := token.NetTokens[w.net]
+	if !found {
+		return fmt.Errorf("token %d not found", tokenID)
+	}
+
+	for ver := range netToken.SwapContracts {
+		constructor, found := tokenContractorConstructors[ver]
+		if !found {
+			w.log.Errorf("contractor constructor not found for token %s, version %d", token.Name, ver)
+			continue
+		}
+		c, err := constructor(w.net, tokenID, w.addr, w.node.contractBackend())
+		if err != nil {
+			return fmt.Errorf("error constructing token %s contractor version %d: %w", token.Name, ver, err)
+		}
+
+		if tokenAddr, err := c.tokenAddress(ctx); err != nil {
+			return fmt.Errorf("error getting token address bound to contract: %w", err)
+		} else if tokenAddr != netToken.Address {
+			return fmt.Errorf("wrong %s token address. expected %s, got %s", token.Name, netToken.Address, tokenAddr)
+		}
+
+		w.contractors[ver] = c
+	}
+	return nil
+}
+
+// withContractor runs the provided function with the versioned contractor.
+func (w *AssetWallet) withContractor(contractVer uint32, f func(contractor) error) error {
+	if contractVer == contractVersionNewest {
+		var bestVer uint32
+		var bestContractor contractor
+		for ver, c := range w.contractors {
+			if ver >= bestVer {
+				bestContractor = c
+				bestVer = ver
+			}
+		}
+		return f(bestContractor)
+	}
+	contractor, found := w.contractors[contractVer]
+	if !found {
+		return fmt.Errorf("no version %d contractor for asset %d", contractVer, w.assetID)
+	}
+	return f(contractor)
+}
+
+// withTokenContractor runs the provided function with the tokenContractor.
+func (w *AssetWallet) withTokenContractor(assetID, ver uint32, f func(tokenContractor) error) error {
+	return w.withContractor(ver, func(c contractor) error {
+		tc, is := c.(tokenContractor)
+		if !is {
+			return fmt.Errorf("contractor for %d %T is not a tokenContractor", assetID, c)
+		}
+		return f(tc)
+	})
+}
+
+// estimateApproveGas estimates the gas required for a transaction approving a
+// spender for an ERC20 contract.
+func (w *AssetWallet) estimateApproveGas(newGas *big.Int) (gas uint64, err error) {
+	return gas, w.withTokenContractor(w.assetID, contractVersionNewest, func(c tokenContractor) error {
+		gas, err = c.estimateApproveGas(w.ctx, newGas)
+		return err
+	})
+}
+
+// estimateTransferGas estimates the gas needed for a token transfer call to an
+// ERC20 contract.
+func (w *AssetWallet) estimateTransferGas(val uint64) (gas uint64, err error) {
+	return gas, w.withTokenContractor(w.assetID, contractVersionNewest, func(c tokenContractor) error {
+		gas, err = c.estimateTransferGas(w.ctx, w.evmify(val))
 		return err
 	})
 }
 
 // redeem redeems a swap contract. Any on-chain failure, such as this secret not
 // matching the hash, will not cause this to error.
-func (eth *ExchangeWallet) redeem(ctx context.Context, redemptions []*asset.Redemption, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
-	eth.nonceSendMtx.Lock()
-	defer eth.nonceSendMtx.Unlock()
-	gas := dexeth.RedeemGas(len(redemptions), contractVer)
-	txOpts, _ := eth.node.txOpts(ctx, 0, gas, dexeth.GweiToWei(maxFeeRate))
-	return tx, eth.withContractor(contractVer, func(c contractor) error {
+func (w *AssetWallet) redeem(ctx context.Context, assetID uint32, redemptions []*asset.Redemption, maxFeeRate, gasLimit uint64, contractVer uint32) (tx *types.Transaction, err error) {
+	w.nonceSendMtx.Lock()
+	defer w.nonceSendMtx.Unlock()
+	txOpts, err := w.node.txOpts(ctx, 0, gasLimit, dexeth.GweiToWei(maxFeeRate))
+	if err != nil {
+		return nil, err
+	}
+
+	return tx, w.withContractor(contractVer, func(c contractor) error {
 		tx, err = c.redeem(txOpts, redemptions)
 		return err
 	})
@@ -1605,29 +2374,204 @@ func (eth *ExchangeWallet) redeem(ctx context.Context, redemptions []*asset.Rede
 // refund refunds a swap contract using the account controlled by the wallet.
 // Any on-chain failure, such as the locktime not being past, will not cause
 // this to error.
-func (eth *ExchangeWallet) refund(ctx context.Context, secretHash [32]byte, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
-	eth.nonceSendMtx.Lock()
-	defer eth.nonceSendMtx.Unlock()
-	gas := dexeth.RefundGas(contractVer)
-	txOpts, _ := eth.node.txOpts(ctx, 0, gas, dexeth.GweiToWei(maxFeeRate))
-	return tx, eth.withContractor(contractVer, func(c contractor) error {
+func (w *AssetWallet) refund(secretHash [32]byte, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
+	gas := w.gases(contractVer)
+	if gas == nil {
+		return nil, fmt.Errorf("no gas table for asset %d, version %d", w.assetID, contractVer)
+	}
+	w.nonceSendMtx.Lock()
+	defer w.nonceSendMtx.Unlock()
+	txOpts, err := w.node.txOpts(w.ctx, 0, gas.Refund, dexeth.GweiToWei(maxFeeRate))
+	if err != nil {
+		return nil, fmt.Errorf("addSignerToOpts error: %w", err)
+	}
+
+	return tx, w.withContractor(contractVer, func(c contractor) error {
 		tx, err = c.refund(txOpts, secretHash)
 		return err
 	})
 }
 
 // isRedeemable checks if the swap identified by secretHash is redeemable using secret.
-func (eth *ExchangeWallet) isRedeemable(secretHash [32]byte, secret [32]byte, contractVer uint32) (redeemable bool, err error) {
-	return redeemable, eth.withContractor(contractVer, func(c contractor) error {
+func (w *AssetWallet) isRedeemable(secretHash [32]byte, secret [32]byte, contractVer uint32) (redeemable bool, err error) {
+	return redeemable, w.withContractor(contractVer, func(c contractor) error {
 		redeemable, err = c.isRedeemable(secretHash, secret)
 		return err
 	})
 }
 
-// isRefundable checks if the swap identified by secretHash is refundable.
-func (eth *ExchangeWallet) isRefundable(secretHash [32]byte, contractVer uint32) (refundable bool, err error) {
-	return refundable, eth.withContractor(contractVer, func(c contractor) error {
+func (w *AssetWallet) isRefundable(secretHash [32]byte, contractVer uint32) (refundable bool, err error) {
+	return refundable, w.withContractor(contractVer, func(c contractor) error {
 		refundable, err = c.isRefundable(secretHash)
 		return err
 	})
+}
+
+// getGasEstimate is used to get a gas table for an asset's contract(s). The
+// provided gases, g, should be generous estimates of what the gas might be.
+// Errors are thrown if the provided estimates are too small by more than a
+// factor of 2. The account should already have a trading balance of at least
+// maxSwaps gwei (token or eth), and sufficient eth balance to cover the
+// requisite tx fees.
+func GetGasEstimates(ctx context.Context, cl *nodeClient, c contractor, maxSwaps int, g *dexeth.Gases, waitForMined func()) error {
+	tokenContractor, isToken := c.(tokenContractor)
+
+	stats := struct {
+		swaps     []uint64
+		redeems   []uint64
+		refunds   []uint64
+		approves  []uint64
+		transfers []uint64
+	}{}
+
+	avg := func(vs []uint64) uint64 {
+		var sum uint64
+		for _, v := range vs {
+			sum += v
+		}
+		return sum / uint64(len(vs))
+	}
+
+	avgDiff := func(vs []uint64) uint64 {
+		diffs := make([]uint64, 0, len(vs)-1)
+		for i := 0; i < len(vs)-1; i++ {
+			diffs = append(diffs, vs[i+1]-vs[i])
+		}
+		return avg(diffs)
+	}
+
+	defer func() {
+		if len(stats.swaps) == 0 {
+			return
+		}
+		firstSwap := stats.swaps[0]
+		fmt.Printf("  First swap used %d gas \n", firstSwap)
+		if len(stats.swaps) > 1 {
+			fmt.Printf("    %d additional swaps averaged %d gas each\n", len(stats.swaps)-1, avgDiff(stats.swaps))
+			fmt.Printf("    %+v \n", stats.swaps)
+		}
+		if len(stats.redeems) == 0 {
+			return
+		}
+		firstRedeem := stats.redeems[0]
+		fmt.Printf("  First redeem used %d gas \n", firstRedeem)
+		if len(stats.redeems) > 1 {
+			fmt.Printf("    %d additional redeems averaged %d gas each\n", len(stats.redeems)-1, avgDiff(stats.redeems))
+			fmt.Printf("    %+v \n", stats.redeems)
+		}
+		fmt.Printf("  Average of %d refunds: %d \n", len(stats.refunds), avg(stats.refunds))
+		fmt.Printf("    %+v \n", stats.refunds)
+		if !isToken {
+			return
+		}
+		fmt.Printf("  Average of %d approvals: %d \n", len(stats.approves), avg(stats.approves))
+		fmt.Printf("    %+v \n", stats.approves)
+		fmt.Printf("  Average of %d transfers: %d \n", len(stats.transfers), avg(stats.transfers))
+		fmt.Printf("    %+v \n", stats.transfers)
+	}()
+
+	for n := 1; n <= maxSwaps; n++ {
+		// Estimate approve.
+		var approveTx, transferTx *types.Transaction
+		if isToken {
+			txOpts, err := cl.txOpts(ctx, 0, g.Approve*2, nil)
+			if err != nil {
+				return fmt.Errorf("error constructing signed tx opts for approve: %v", err)
+			}
+			approveTx, err = tokenContractor.approve(txOpts, new(big.Int).SetBytes(encode.RandomBytes(8)))
+			if err != nil {
+				return fmt.Errorf("error estimating approve gas: %v", err)
+			}
+			txOpts, err = cl.txOpts(ctx, 0, g.Transfer*2, nil)
+			if err != nil {
+				return fmt.Errorf("error constructing signed tx opts for transfer: %v", err)
+			}
+			transferTx, err = tokenContractor.transfer(txOpts, cl.address(), dexeth.GweiToWei(1))
+			if err != nil {
+				return fmt.Errorf("error estimating transfer gas: %v", err)
+			}
+		}
+
+		contracts := make([]*asset.Contract, 0, n)
+		secrets := make([][32]byte, 0, n)
+		for i := 0; i < n; i++ {
+			secretB := encode.RandomBytes(32)
+			var secret [32]byte
+			copy(secret[:], secretB)
+			secretHash := sha256.Sum256(secretB)
+			contracts = append(contracts, &asset.Contract{
+				Address:    cl.address().String(),
+				Value:      1,
+				SecretHash: secretHash[:],
+				LockTime:   uint64(time.Now().Add(-time.Hour).Unix()),
+			})
+			secrets = append(secrets, secret)
+		}
+
+		var optsVal uint64
+		if !isToken {
+			optsVal = uint64(n)
+		}
+
+		// Send the inits
+		txOpts, err := cl.txOpts(ctx, optsVal, g.SwapN(n)*2, nil)
+		if err != nil {
+			return fmt.Errorf("error constructing signed tx opts for %d swaps: %v", n, err)
+		}
+		tx, err := c.initiate(txOpts, contracts)
+		if err != nil {
+			return fmt.Errorf("initiate error for %d swaps: %v", n, err)
+		}
+		waitForMined()
+		if r, err := cl.checkTxStatus(ctx, tx, txOpts); err != nil {
+			return err
+		} else {
+			stats.swaps = append(stats.swaps, r.GasUsed)
+		}
+
+		if isToken {
+			if r, err := cl.checkTxStatus(ctx, approveTx, txOpts); err != nil {
+				return err
+			} else {
+				stats.approves = append(stats.approves, r.GasUsed)
+			}
+			if r, err := cl.checkTxStatus(ctx, transferTx, txOpts); err != nil {
+				return err
+			} else {
+				stats.transfers = append(stats.transfers, r.GasUsed)
+			}
+		}
+
+		// Estimate a refund
+		var firstSecretHash [32]byte
+		copy(firstSecretHash[:], contracts[0].SecretHash)
+		refundGas, err := c.estimateRefundGas(ctx, firstSecretHash)
+		if err != nil {
+			return fmt.Errorf("error estimate refund gas: %w", err)
+		}
+		stats.refunds = append(stats.refunds, refundGas)
+
+		redemptions := make([]*asset.Redemption, 0, n)
+		for i, contract := range contracts {
+			redemptions = append(redemptions, &asset.Redemption{
+				Spends: &asset.AuditInfo{
+					SecretHash: contract.SecretHash,
+				},
+				Secret: secrets[i][:],
+			})
+		}
+
+		txOpts, _ = cl.txOpts(ctx, 0, g.RedeemN(n)*2, nil)
+		tx, err = c.redeem(txOpts, redemptions)
+		if err != nil {
+			return fmt.Errorf("redeem error for %d swaps: %v", n, err)
+		}
+		waitForMined()
+		if r, err := cl.checkTxStatus(ctx, tx, txOpts); err != nil {
+			return err
+		} else {
+			stats.redeems = append(stats.redeems, r.GasUsed)
+		}
+	}
+	return nil
 }

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -942,10 +942,9 @@ func (w *TokenWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, err
 	ethToLock := cfg.MaxFeeRate * g.Swap * ord.MaxSwapCount
 	coin := w.createTokenFundingCoin(ord.Value, ethToLock)
 
-	ethWallet := w.parent
-	ethWallet.lockedFunds.mtx.Lock()
-	err = ethWallet.lockFunds(ethToLock, initiationReserve)
-	ethWallet.lockedFunds.mtx.Unlock()
+	w.parent.lockedFunds.mtx.Lock()
+	err = w.parent.lockFunds(ethToLock, initiationReserve)
+	w.parent.lockedFunds.mtx.Unlock()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1112,10 +1111,9 @@ func (w *TokenWallet) ReturnCoins(coins asset.Coins) error {
 		fees += c.fees
 	}
 	if fees > 0 {
-		ethWallet := w.parent
-		ethWallet.lockedFunds.mtx.Lock()
+		w.parent.lockedFunds.mtx.Lock()
 		w.parent.unlockFunds(fees, initiationReserve)
-		ethWallet.lockedFunds.mtx.Unlock()
+		w.parent.lockedFunds.mtx.Unlock()
 	}
 	w.lockedFunds.mtx.Lock()
 	w.unlockFunds(amt, initiationReserve)

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -300,11 +300,20 @@ type TokenWallet struct {
 	cfg      *tokenWalletConfig
 	parent   *AssetWallet
 	approval atomic.Value
+	token    *dexeth.Token
 }
 
 // Info returns basic information about the wallet and asset.
-func (*baseWallet) Info() *asset.WalletInfo {
+func (*ETHWallet) Info() *asset.WalletInfo {
 	return WalletInfo
+}
+
+// Info returns basic information about the wallet and asset.
+func (w *TokenWallet) Info() *asset.WalletInfo {
+	return &asset.WalletInfo{
+		Name:     w.token.Name,
+		UnitInfo: w.token.UnitInfo,
+	}
 }
 
 // CreateWallet creates a new internal ETH wallet and stores the private key
@@ -545,6 +554,7 @@ func (w *ETHWallet) OpenTokenWallet(tokenID uint32, settings map[string]string, 
 		AssetWallet: aw,
 		cfg:         cfg,
 		parent:      w.AssetWallet,
+		token:       token,
 	}, nil
 }
 

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -380,38 +380,6 @@ func (n *nodeClient) sendSignedTransaction(ctx context.Context, tx *types.Transa
 	return n.leth.ApiBackend.SendTx(ctx, tx)
 }
 
-// tokenBalance checks the token balance of the account handled by the wallet.
-func (w *AssetWallet) tokenBalance() (bal *big.Int, err error) {
-	// We don't care about the version.
-	return bal, w.withTokenContractor(w.assetID, contractVersionNewest, func(c tokenContractor) error {
-		bal, err = c.balance(w.ctx)
-		return err
-	})
-}
-
-// tokenAllowance checks the amount of tokens that the swap contract is approved
-// to spend on behalf of the account handled by the wallet.
-func (w *AssetWallet) tokenAllowance() (allowance *big.Int, err error) {
-	return allowance, w.withTokenContractor(w.assetID, contractVersionNewest, func(c tokenContractor) error {
-		allowance, err = c.allowance(w.ctx)
-		return err
-	})
-}
-
-// approveToken approves the token swap contract to spend tokens on behalf of
-// account handled by the wallet.
-func (w *AssetWallet) approveToken(amount *big.Int, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
-	txOpts, err := w.node.txOpts(w.ctx, 0, approveGas, dexeth.GweiToWei(maxFeeRate))
-	if err != nil {
-		return nil, fmt.Errorf("addSignerToOpts error: %w", err)
-	}
-
-	return tx, w.withTokenContractor(w.assetID, contractVer, func(c tokenContractor) error {
-		tx, err = c.approve(txOpts, amount)
-		return err
-	})
-}
-
 func (n *nodeClient) checkTxStatus(ctx context.Context, tx *types.Transaction, txOpts *bind.TransactOpts) (*types.Receipt, error) {
 	// It appears the receipt is only accessible after the tx is mined.
 	receipt, err := n.transactionReceipt(ctx, tx.Hash())

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -246,6 +246,11 @@ func TestMain(m *testing.M) {
 			return 1, fmt.Errorf("newV0TokenContractor error: %w", err)
 		}
 
+		// I don't know why this is needed for the participant client but not
+		// the initiator. Without this, we'll get a bind.ErrNoCode from
+		// (*BoundContract).Call while calling (*ERC20Swap).TokenAddress.
+		time.Sleep(time.Second)
+
 		if participantTokenContractor, err = newV0TokenContractor(dex.Simnet, testTokenID, participantAddr, participantEthClient.contractBackend()); err != nil {
 			return 1, fmt.Errorf("participant newV0TokenContractor error: %w", err)
 		}

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -400,7 +400,6 @@ func TestTokenContract(t *testing.T) {
 	t.Run("testInitiateToken", func(t *testing.T) { testInitiate(t, testTokenID) })
 	t.Run("testRedeemToken", func(t *testing.T) { testRedeem(t, testTokenID) })
 	t.Run("testRefundToken", func(t *testing.T) { testRefund(t, testTokenID) })
-	t.Run("testGetTokenAddress", testGetTokenAddress)
 
 }
 
@@ -1509,17 +1508,6 @@ func testApproveAllowance(t *testing.T) {
 	if allowance.Cmp(new(big.Int)) == 0 {
 		t.Fatalf("expected allowance > 0")
 	}
-}
-
-func testGetTokenAddress(t *testing.T) {
-	addr, err := simnetTokenContractor.tokenAddress(ctx)
-	if err != nil {
-		t.Fatalf("Error getting token address: %v", err)
-	}
-	if addr != testTokenContractAddr {
-		t.Fatalf("Wrong contract retrieved from contract. wanted %s, got %s", testTokenContractAddr, addr)
-	}
-	fmt.Println("Token Address: ", addr)
 }
 
 func testTransferGas(t *testing.T) {

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -40,9 +40,7 @@ import (
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
-	dexerc20 "decred.org/dcrdex/dex/networks/erc20"
 	dexeth "decred.org/dcrdex/dex/networks/eth"
-	ethv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
 	swapv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
 	"decred.org/dcrdex/internal/eth/reentryattack"
 	"github.com/davecgh/go-spew/spew"
@@ -78,17 +76,20 @@ var (
 	ethClient             *nodeClient
 	participantWalletSeed = "b99fb787fc5886eb539830d103c0017eff5241ace28ee137d40f135fd02212b1a897afbdcba037c8c735cc63080558a30d72851eb5a3d05684400ec4123a2d00"
 	// participantPrivKey        = "4fc4f43c00bc6550314b8561878edbfc776884e006ad51a2fe2c054f85cfbd12"
-	participantAddr       = common.HexToAddress("1D4F2ee206474B136Af4868B887C7b166693c194")
-	participantAcct       = &accounts.Account{Address: participantAddr}
-	participantEthClient  *nodeClient
-	ethSwapContractAddr   common.Address
-	tokenSwapContractAddr common.Address
-	testTokenContractAddr common.Address
-	simnetID              int64  = 42
-	maxFeeRate            uint64 = 200 // gwei per gas
-	simnetContractor      contractor
-	participantContractor contractor
-	ethGases              = dexeth.VersionedGases[0]
+	participantAddr            = common.HexToAddress("1D4F2ee206474B136Af4868B887C7b166693c194")
+	participantAcct            = &accounts.Account{Address: participantAddr}
+	participantEthClient       *nodeClient
+	ethSwapContractAddr        common.Address
+	tokenSwapContractAddr      common.Address
+	testTokenContractAddr      common.Address
+	simnetID                   int64  = 42
+	maxFeeRate                 uint64 = 200 // gwei per gas
+	simnetContractor           contractor
+	participantContractor      contractor
+	simnetTokenContractor      tokenContractor
+	participantTokenContractor tokenContractor
+	ethGases                   = dexeth.VersionedGases[0]
+	tokenGases                 = &dexeth.Tokens[testTokenID].NetTokens[dex.Simnet].SwapContracts[0].Gas
 )
 
 func newContract(stamp uint64, secretHash [32]byte, val uint64) *asset.Contract {
@@ -174,6 +175,8 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			return 1, fmt.Errorf("error creating participant wallet dir: %v", err)
 		}
+
+		// ETH swap contract.
 		ethSwapContractAddr, err = getContractAddrFromFile(ethSwapContractAddrFile)
 		if err != nil {
 			return 1, err
@@ -184,17 +187,21 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			return 1, err
 		}
-		dexerc20.ContractAddresses[0][dex.Simnet] = tokenSwapContractAddr
 		fmt.Printf("Token swap contract addr is %v\n", tokenSwapContractAddr)
 		testTokenContractAddr, err = getContractAddrFromFile(testTokenContractAddrFile)
 		if err != nil {
 			return 1, err
 		}
 		fmt.Printf("Test token contract addr is %v\n", testTokenContractAddr)
+		token := dexeth.Tokens[testTokenID].NetTokens[dex.Simnet]
+		token.Address = testTokenContractAddr
+		token.SwapContracts[0].Address = tokenSwapContractAddr
+
 		err = setupWallet(simnetWalletDir, simnetWalletSeed, "localhost:30355")
 		if err != nil {
 			return 1, err
 		}
+
 		err = setupWallet(participantWalletDir, participantWalletSeed, "localhost:30356")
 		if err != nil {
 			return 1, err
@@ -233,6 +240,14 @@ func TestMain(m *testing.M) {
 		}
 		if participantContractor, err = newV0Contractor(dex.Simnet, participantAddr, participantEthClient.contractBackend()); err != nil {
 			return 1, fmt.Errorf("participant newV0Contractor error: %w", err)
+		}
+
+		if simnetTokenContractor, err = newV0TokenContractor(dex.Simnet, testTokenID, simnetAddr, ethClient.contractBackend()); err != nil {
+			return 1, fmt.Errorf("newV0TokenContractor error: %w", err)
+		}
+
+		if participantTokenContractor, err = newV0TokenContractor(dex.Simnet, testTokenID, participantAddr, participantEthClient.contractBackend()); err != nil {
+			return 1, fmt.Errorf("participant newV0TokenContractor error: %w", err)
 		}
 
 		accts, err := exportAccountsFromNode(ethClient.node)
@@ -296,6 +311,44 @@ func setupWallet(walletDir, seed, listenAddress string) error {
 	return CreateWallet(&createWalletParams)
 }
 
+func prepareTokenClients(t *testing.T) {
+	err := ethClient.unlock(pw)
+	if err != nil {
+		t.Fatalf("initiator unlock error; %v", err)
+	}
+	txOpts, _ := ethClient.txOpts(ctx, 0, tokenGases.Approve, nil)
+	var tx1, tx2 *types.Transaction
+	if tx1, err = simnetTokenContractor.approve(txOpts, unlimitedAllowance); err != nil {
+		t.Fatalf("initiator approveToken error: %v", err)
+	}
+	err = participantEthClient.unlock(pw)
+	if err != nil {
+		t.Fatalf("participant unlock error; %v", err)
+	}
+
+	txOpts, _ = participantEthClient.txOpts(ctx, 0, tokenGases.Approve, nil)
+	if tx2, err = participantTokenContractor.approve(txOpts, unlimitedAllowance); err != nil {
+		t.Fatalf("participant approveToken error: %v", err)
+	}
+
+	time.Sleep(1) // waitForMined only looks at alpha's tx pool. Give txs time to propagate.
+	if err := waitForMined(t, time.Second*8, true); err != nil {
+		t.Fatalf("unexpected error while waiting to mine approval block: %v", err)
+	}
+
+	receipt1, err := ethClient.transactionReceipt(ctx, tx1.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	spew.Dump(receipt1)
+
+	receipt2, err := participantEthClient.transactionReceipt(ctx, tx2.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	spew.Dump(receipt2)
+}
+
 func syncClient(cl *nodeClient) error {
 	for i := 0; ; i++ {
 		prog := cl.syncProgress()
@@ -330,17 +383,33 @@ func TestAccount(t *testing.T) {
 
 // TestContract tests methods that interact with the contract.
 func TestContract(t *testing.T) {
-	t.Run("testSwap", testSwap)
-	t.Run("testInitiate", testInitiate)
-	t.Run("testRedeem", testRedeem)
-	t.Run("testRefund", testRefund)
+	t.Run("testSwap", func(t *testing.T) { testSwap(t, BipID) })
+	t.Run("testInitiate", func(t *testing.T) { testInitiate(t, BipID) })
+	t.Run("testRedeem", func(t *testing.T) { testRedeem(t, BipID) })
+	t.Run("testRefund", func(t *testing.T) { testRefund(t, BipID) })
+}
+
+func TestGas(t *testing.T) {
+	t.Run("testInitiateGas", func(t *testing.T) { testInitiateGas(t, BipID) })
+	t.Run("testRedeemGas", func(t *testing.T) { testRedeemGas(t, BipID) })
+	t.Run("testRefundGas", func(t *testing.T) { testRefundGas(t, BipID) })
 }
 
 func TestTokenContract(t *testing.T) {
-	t.Run("testTokenSwap", testTokenSwap)
-	t.Run("testInitiateToken", testInitiateToken)
-	t.Run("testRedeemToken", testRedeemToken)
-	t.Run("testRefundToken", testRefundToken)
+	t.Run("testTokenSwap", func(t *testing.T) { testSwap(t, testTokenID) })
+	t.Run("testInitiateToken", func(t *testing.T) { testInitiate(t, testTokenID) })
+	t.Run("testRedeemToken", func(t *testing.T) { testRedeem(t, testTokenID) })
+	t.Run("testRefundToken", func(t *testing.T) { testRefund(t, testTokenID) })
+	t.Run("testGetTokenAddress", testGetTokenAddress)
+
+}
+
+func TestTokenGas(t *testing.T) {
+	t.Run("testTransferGas", testTransferGas)
+	t.Run("testApproveGas", testApproveGas)
+	t.Run("testInitiateTokenGas", func(t *testing.T) { testInitiateGas(t, testTokenID) })
+	t.Run("testRedeemTokenGas", func(t *testing.T) { testRedeemGas(t, testTokenID) })
+	t.Run("testRefundTokenGas", func(t *testing.T) { testRefundGas(t, testTokenID) })
 }
 
 func TestTokenAccess(t *testing.T) {
@@ -364,6 +433,17 @@ func testBestHeader(t *testing.T) {
 
 func testAddressBalance(t *testing.T) {
 	bal, err := ethClient.addressBalance(ctx, simnetAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bal == nil {
+		t.Fatalf("empty balance")
+	}
+	spew.Dump(bal)
+}
+
+func testTokenBalance(t *testing.T) {
+	bal, err := simnetTokenContractor.balance(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -469,7 +549,6 @@ func testSendSignedTransaction(t *testing.T) {
 
 func testTransactionReceipt(t *testing.T) {
 	txOpts, _ := ethClient.txOpts(ctx, 1, dexeth.InitGas(1, 0), nil)
-
 	tx, err := ethClient.sendTransaction(ctx, txOpts, simnetAddr, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -493,7 +572,7 @@ func testPendingTransactions(t *testing.T) {
 	spew.Dump(txs)
 }
 
-func testSwap(t *testing.T) {
+func testSwap(t *testing.T, assetID uint32) {
 	var secretHash [32]byte
 	copy(secretHash[:], encode.RandomBytes(32))
 	swap, err := simnetContractor.swap(ctx, secretHash)
@@ -508,8 +587,16 @@ func testSyncProgress(t *testing.T) {
 	spew.Dump(ethClient.syncProgress())
 }
 
-func TestInitiateGas(t *testing.T) {
+func testInitiateGas(t *testing.T, assetID uint32) {
+	prepareTokenClients(t)
+
 	c := simnetContractor
+
+	if assetID != BipID {
+		c = simnetTokenContractor
+	}
+
+	gases := gases(assetID, 0, dex.Simnet)
 
 	var previousGas uint64
 	maxSwaps := 50
@@ -522,13 +609,13 @@ func TestInitiateGas(t *testing.T) {
 		var expectedGas uint64
 		var actualGas uint64
 		if i == 1 {
-			expectedGas = ethGases.Swap
+			expectedGas = gases.Swap
 			actualGas = gas
 		} else {
-			expectedGas = ethGases.SwapAdd
+			expectedGas = gases.SwapAdd
 			actualGas = gas - previousGas
 		}
-		if actualGas > expectedGas || actualGas < expectedGas/100*95 {
+		if actualGas > expectedGas || actualGas < expectedGas*75/100 {
 			t.Fatalf("Expected incremental gas for %d initiations to be close to %d but got %d",
 				i, expectedGas, actualGas)
 		}
@@ -552,10 +639,22 @@ func feesAtBlk(ctx context.Context, n *nodeClient, blkNum int64) (fees *big.Int,
 	return tip.Add(tip, hdr.BaseFee), nil
 }
 
-func testInitiate(t *testing.T) {
+func testInitiate(t *testing.T, assetID uint32) {
+	prepareTokenClients(t)
+
+	isETH := assetID == BipID
+
 	c := simnetContractor
 	balance := func() (*big.Int, error) {
 		return ethClient.addressBalance(ctx, simnetAddr)
+	}
+	gases := ethGases
+	if !isETH {
+		c = simnetTokenContractor
+		balance = func() (*big.Int, error) {
+			return simnetTokenContractor.balance(ctx)
+		}
+		gases = tokenGases
 	}
 
 	// Create a slice of random secret hashes that can be used in the tests and
@@ -642,13 +741,15 @@ func testInitiate(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		var originalParentBal *big.Int
+
 		originalBal, err := balance()
 		if err != nil {
-			t.Fatalf("balance error for test %v: %v", test.name, err)
+			t.Fatalf("balance error for asset %d, test %s: %v", assetID, test.name, err)
 		}
 
-		originalStates := make(map[string]dexeth.SwapStep)
 		var totalVal uint64
+		originalStates := make(map[string]dexeth.SwapStep)
 		for _, tSwap := range test.swaps {
 			swap, err := c.swap(ctx, bytesToArray(tSwap.SecretHash))
 			if err != nil {
@@ -658,8 +759,17 @@ func testInitiate(t *testing.T) {
 			totalVal += tSwap.Value
 		}
 
-		expGas := ethGases.SwapN(len(test.swaps))
-		txOpts, _ := ethClient.txOpts(ctx, totalVal, expGas, dexeth.GweiToWei(maxFeeRate))
+		optsVal := totalVal
+		if !isETH {
+			optsVal = 0
+			originalParentBal, err = ethClient.addressBalance(ctx, simnetAddr)
+			if err != nil {
+				t.Fatalf("balance error for eth, test %s: %v", test.name, err)
+			}
+		}
+
+		expGas := gases.SwapN(len(test.swaps))
+		txOpts, _ := ethClient.txOpts(ctx, optsVal, expGas, dexeth.GweiToWei(maxFeeRate))
 		tx, err := c.initiate(txOpts, test.swaps)
 		if err != nil {
 			if test.swapErr {
@@ -672,7 +782,6 @@ func testInitiate(t *testing.T) {
 			t.Fatalf("%s: post-initiate mining error: %v", test.name, err)
 		}
 
-		// It appears the receipt is only accessible after the tx is mined.
 		receipt, err := ethClient.checkTxStatus(ctx, tx, txOpts)
 		if err != nil && test.success {
 			spew.Dump(tx)
@@ -691,14 +800,29 @@ func testInitiate(t *testing.T) {
 		}
 		bigGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
 		txFee := new(big.Int).Mul(bigGasUsed, gasPrice)
+
 		wantBal := new(big.Int).Set(originalBal)
-		wantBal.Sub(wantBal, txFee)
 		if test.success {
 			wantBal.Sub(wantBal, dexeth.GweiToWei(totalVal))
 		}
 		bal, err := balance()
 		if err != nil {
 			t.Fatalf("%s: balance error: %v", test.name, err)
+		}
+
+		if isETH {
+			wantBal = new(big.Int).Sub(wantBal, txFee)
+		} else {
+			parentBal, err := ethClient.addressBalance(ctx, simnetAddr)
+			if err != nil {
+				t.Fatalf("%s: eth balance error: %v", test.name, err)
+			}
+			wantParentBal := new(big.Int).Sub(originalParentBal, txFee)
+			diff := new(big.Int).Sub(wantParentBal, parentBal)
+			if diff.CmpAbs(dexeth.GweiToWei(1)) >= 0 { // Ugh. Need to get to != 0 again.
+				t.Fatalf("%s: unexpected parent chain balance change: want %d got %d, diff = %.9f",
+					test.name, dexeth.WeiToGwei(wantParentBal), dexeth.WeiToGwei(parentBal), float64(diff.Int64())/dexeth.GweiFactor)
+			}
 		}
 
 		diff := new(big.Int).Sub(wantBal, bal)
@@ -726,7 +850,9 @@ func testInitiate(t *testing.T) {
 	}
 }
 
-func TestRedeemGas(t *testing.T) {
+func testRedeemGas(t *testing.T, assetID uint32) {
+	prepareTokenClients(t)
+
 	// Create secrets and secret hashes
 	const numSwaps = 9
 	secrets := make([][32]byte, 0, numSwaps)
@@ -747,16 +873,28 @@ func TestRedeemGas(t *testing.T) {
 		swaps = append(swaps, newContract(now, secretHashes[i], 1))
 	}
 
+	gases := ethGases
 	c := simnetContractor
 	pc := participantContractor
+	optsVal := uint64(numSwaps)
+	if assetID != BipID {
+		optsVal = 0
+		gases = tokenGases
+		c = simnetTokenContractor
+		pc = participantTokenContractor
+	}
 
-	txOpts, _ := ethClient.txOpts(ctx, numSwaps, ethGases.SwapN(len(swaps)), dexeth.GweiToWei(maxFeeRate))
-	_, err := c.initiate(txOpts, swaps)
+	txOpts, _ := ethClient.txOpts(ctx, optsVal, gases.SwapN(len(swaps)), dexeth.GweiToWei(maxFeeRate))
+	tx, err := c.initiate(txOpts, swaps)
 	if err != nil {
 		t.Fatalf("Unable to initiate swap: %v ", err)
 	}
 	if err := waitForMined(t, time.Second*8, true); err != nil {
 		t.Fatalf("unexpected error while waiting to mine: %v", err)
+	}
+	_, err = ethClient.checkTxStatus(ctx, tx, txOpts)
+	if err != nil {
+		t.Fatalf("Init transaction failed: %v", err)
 	}
 
 	// Make sure swaps were properly initiated
@@ -781,22 +919,25 @@ func TestRedeemGas(t *testing.T) {
 		var expectedGas uint64
 		var actualGas uint64
 		if i == 0 {
-			expectedGas = ethGases.Redeem
+			expectedGas = gases.Redeem
 			actualGas = gas
 		} else {
-			expectedGas = ethGases.RedeemAdd
+			expectedGas = gases.RedeemAdd
 			actualGas = gas - previous
 		}
 		if actualGas > expectedGas || actualGas < (expectedGas/100*95) {
 			t.Fatalf("Expected incremental gas for %d redemptions to be close to %d but got %d",
 				i, expectedGas, actualGas)
 		}
+
 		fmt.Printf("\n\nGas used to redeem %d swaps: %d -- %d more than previous \n\n", i+1, gas, gas-previous)
 		previous = gas
 	}
 }
 
-func testRedeem(t *testing.T) {
+func testRedeem(t *testing.T, assetID uint32) {
+	prepareTokenClients(t)
+
 	lockTime := uint64(time.Now().Unix())
 	numSecrets := 10
 	secrets := make([][32]byte, 0, numSecrets)
@@ -809,7 +950,13 @@ func testRedeem(t *testing.T) {
 		secretHashes = append(secretHashes, secretHash)
 	}
 
+	isETH := assetID == BipID
+	gases := ethGases
 	c, pc := simnetContractor, participantContractor
+	if !isETH {
+		gases = tokenGases
+		c, pc = simnetTokenContractor, participantTokenContractor
+	}
 
 	tests := []struct {
 		name               string
@@ -927,14 +1074,21 @@ func testRedeem(t *testing.T) {
 			if state != dexeth.SSNone {
 				t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, dexeth.SSNone, state)
 			}
-			optsVal += contract.Value
+			if isETH {
+				optsVal += contract.Value
+			}
 		}
 
 		balance := func() (*big.Int, error) {
 			return test.redeemerClient.addressBalance(ctx, test.redeemer.Address)
 		}
+		if !isETH {
+			balance = func() (*big.Int, error) {
+				return test.redeemerContractor.(tokenContractor).balance(ctx)
+			}
+		}
 
-		txOpts, _ := test.redeemerClient.txOpts(ctx, optsVal, ethGases.SwapN(len(test.swaps)), dexeth.GweiToWei(maxFeeRate))
+		txOpts, _ := test.redeemerClient.txOpts(ctx, optsVal, gases.SwapN(len(test.swaps)), dexeth.GweiToWei(maxFeeRate))
 		tx, err := test.redeemerContractor.initiate(txOpts, test.swaps)
 		if err != nil {
 			t.Fatalf("%s: initiate error: %v ", test.name, err)
@@ -972,13 +1126,21 @@ func testRedeem(t *testing.T) {
 			}
 		}
 
+		var originalParentBal *big.Int
+		if !isETH {
+			originalParentBal, err = test.redeemerClient.addressBalance(ctx, test.redeemer.Address)
+			if err != nil {
+				t.Fatalf("%s: eth balance error: %v", test.name, err)
+			}
+		}
+
 		originalBal, err := balance()
 		if err != nil {
 			t.Fatalf("%s: balance error: %v", test.name, err)
 		}
 
-		expGas := ethGases.RedeemN(len(test.redemptions))
-		txOpts, _ = test.redeemerClient.txOpts(ctx, 0, expGas*2, dexeth.GweiToWei(maxFeeRate))
+		expGas := gases.RedeemN(len(test.redemptions))
+		txOpts, _ = test.redeemerClient.txOpts(ctx, 0, expGas, dexeth.GweiToWei(maxFeeRate))
 		tx, err = test.redeemerContractor.redeem(txOpts, test.redemptions)
 		if test.expectRedeemErr {
 			if err == nil {
@@ -1011,7 +1173,7 @@ func testRedeem(t *testing.T) {
 		}
 
 		// Check transaction parsing while we're here.
-		if in, err := test.redeemerContractor.incomingValue(ctx, tx); err != nil {
+		if in, _, err := test.redeemerContractor.value(ctx, tx); err != nil {
 			t.Fatalf("error parsing value from redemption: %v", err)
 		} else if in != uint64(len(test.swaps)) {
 			t.Fatalf("%s: unexpected pending in balance %d", test.name, in)
@@ -1027,9 +1189,25 @@ func testRedeem(t *testing.T) {
 		}
 		bigGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
 		txFee := new(big.Int).Mul(bigGasUsed, gasPrice)
-		wantBal := new(big.Int).Sub(originalBal, txFee)
+		wantBal := new(big.Int).Set(originalBal)
+
 		if test.addAmt {
 			wantBal.Add(wantBal, dexeth.GweiToWei(uint64(len(test.redemptions))))
+		}
+
+		if isETH {
+			wantBal.Sub(wantBal, txFee)
+		} else {
+			parentBal, err := test.redeemerClient.addressBalance(ctx, test.redeemer.Address)
+			if err != nil {
+				t.Fatalf("%s: post-redeem eth balance error: %v", test.name, err)
+			}
+			wantParentBal := new(big.Int).Sub(originalParentBal, txFee)
+			diff := new(big.Int).Sub(wantParentBal, parentBal)
+			if diff.CmpAbs(dexeth.GweiToWei(1)) >= 0 {
+				t.Fatalf("%s: unexpected parent chain balance change: want %d got %d, diff = %d",
+					test.name, dexeth.WeiToGwei(wantParentBal), dexeth.WeiToGwei(parentBal), dexeth.WeiToGwei(diff))
+			}
 		}
 
 		diff := new(big.Int).Sub(wantBal, bal)
@@ -1052,16 +1230,27 @@ func testRedeem(t *testing.T) {
 	}
 }
 
-func TestRefundGas(t *testing.T) {
+func testRefundGas(t *testing.T, assetID uint32) {
+	prepareTokenClients(t)
+
+	isETH := assetID == BipID
+
 	c := simnetContractor
+	gases := ethGases
 	var optsVal uint64 = 1
+	if !isETH {
+		c = simnetTokenContractor
+		gases = tokenGases
+		optsVal = 0
+	}
 
 	var secret [32]byte
 	copy(secret[:], encode.RandomBytes(32))
 	secretHash := sha256.Sum256(secret[:])
 
 	lockTime := uint64(time.Now().Unix())
-	txOpts, _ := ethClient.txOpts(ctx, optsVal, ethGases.SwapN(1), nil)
+
+	txOpts, _ := ethClient.txOpts(ctx, optsVal, gases.SwapN(1), nil)
 	_, err := c.initiate(txOpts, []*asset.Contract{newContract(lockTime, secretHash, 1)})
 	if err != nil {
 		t.Fatalf("Unable to initiate swap: %v ", err)
@@ -1083,17 +1272,30 @@ func TestRefundGas(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error estimating gas for refund function: %v", err)
 	}
-	expGas := ethGases.Refund
-	if gas > expGas || gas < expGas/100*95 {
-		t.Fatalf("expected refund gas to be near %d, but got %d",
-			expGas, gas)
+	if isETH {
+		expGas := gases.Refund
+		if gas > expGas || gas < expGas*95/100 {
+			t.Fatalf("expected refund gas to be near %d, but got %d",
+				expGas, gas)
+		}
 	}
 	fmt.Printf("Gas used for refund: %v \n", gas)
 }
 
-func testRefund(t *testing.T) {
+func testRefund(t *testing.T, assetID uint32) {
+	prepareTokenClients(t)
+
 	const amt = 1e9
+
+	isETH := assetID == BipID
+
+	gases := ethGases
 	c, pc := simnetContractor, participantContractor
+	if !isETH {
+		gases = tokenGases
+		c, pc = simnetTokenContractor, participantTokenContractor
+	}
+
 	tests := []struct {
 		name                         string
 		refunder                     *accounts.Account
@@ -1147,6 +1349,12 @@ func testRefund(t *testing.T) {
 		}
 
 		var optsVal uint64 = amt
+		if !isETH {
+			optsVal = 0
+			balance = func() (*big.Int, error) {
+				return test.refunderContractor.(tokenContractor).balance(ctx)
+			}
+		}
 
 		var secret [32]byte
 		copy(secret[:], encode.RandomBytes(32))
@@ -1162,7 +1370,7 @@ func testRefund(t *testing.T) {
 
 		inLocktime := uint64(time.Now().Add(test.addTime).Unix())
 
-		txOpts, _ := ethClient.txOpts(ctx, optsVal, ethGases.SwapN(1), nil)
+		txOpts, _ := ethClient.txOpts(ctx, optsVal, gases.SwapN(1), nil)
 		_, err = c.initiate(txOpts, []*asset.Contract{newContract(inLocktime, secretHash, amt)})
 		if err != nil {
 			t.Fatalf("%s: initiate error: %v ", test.name, err)
@@ -1172,7 +1380,8 @@ func testRefund(t *testing.T) {
 			if err := waitForMined(t, time.Second*8, false); err != nil {
 				t.Fatalf("%s: pre-redeem mining error: %v", test.name, err)
 			}
-			txOpts, _ = participantEthClient.txOpts(ctx, 0, ethGases.RedeemN(1), nil)
+
+			txOpts, _ = participantEthClient.txOpts(ctx, 0, gases.RedeemN(1), nil)
 			_, err := pc.redeem(txOpts, []*asset.Redemption{newRedeem(secret, secretHash)})
 			if err != nil {
 				t.Fatalf("%s: redeem error: %v", test.name, err)
@@ -1182,6 +1391,14 @@ func testRefund(t *testing.T) {
 		// This waitForMined will always take test.sleep to complete.
 		if err := waitForMined(t, time.Second*8, false); err != nil {
 			t.Fatalf("unexpected post-init mining error for test %v: %v", test.name, err)
+		}
+
+		var originalParentBal *big.Int
+		if !isETH {
+			originalParentBal, err = test.refunderClient.addressBalance(ctx, test.refunder.Address)
+			if err != nil {
+				t.Fatalf("%s: eth balance error: %v", test.name, err)
+			}
 		}
 
 		originalBal, err := balance()
@@ -1198,17 +1415,14 @@ func testRefund(t *testing.T) {
 				test.name, test.isRefundable, isRefundable)
 		}
 
-		txOpts, _ = test.refunderClient.txOpts(ctx, 0, ethGases.Refund, nil)
+		txOpts, _ = test.refunderClient.txOpts(ctx, 0, gases.Refund, nil)
 		tx, err := test.refunderContractor.refund(txOpts, secretHash)
 		if err != nil {
 			t.Fatalf("%s: refund error: %v", test.name, err)
 		}
 		spew.Dump(tx)
 
-		in, err := test.refunderContractor.incomingValue(ctx, tx)
-		if err != nil {
-			t.Fatalf("%s: incomingValue error: %v", test.name, err)
-		}
+		in, _, err := test.refunderContractor.value(ctx, tx)
 
 		if test.addAmt && in != amt {
 			t.Fatalf("%s: unexpected pending in balance %d", test.name, in)
@@ -1236,9 +1450,24 @@ func testRefund(t *testing.T) {
 		bigGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
 		txFee := new(big.Int).Mul(bigGasUsed, gasPrice)
 
-		wantBal := new(big.Int).Sub(originalBal, txFee)
+		wantBal := new(big.Int).Set(originalBal)
 		if test.addAmt {
 			wantBal.Add(wantBal, dexeth.GweiToWei(amt))
+		}
+
+		if isETH {
+			wantBal.Sub(wantBal, txFee)
+		} else {
+			parentBal, err := test.refunderClient.addressBalance(ctx, test.refunder.Address)
+			if err != nil {
+				t.Fatalf("%s: post-redeem eth balance error: %v", test.name, err)
+			}
+			wantParentBal := new(big.Int).Sub(originalParentBal, txFee)
+			diff := new(big.Int).Sub(wantParentBal, parentBal)
+			if diff.CmpAbs(dexeth.GweiToWei(1)) >= 0 {
+				t.Fatalf("%s: unexpected parent chain balance change: want %d got %d, diff = %d",
+					test.name, dexeth.WeiToGwei(wantParentBal), dexeth.WeiToGwei(parentBal), dexeth.WeiToGwei(diff))
+			}
 		}
 
 		bal, err := balance()
@@ -1262,22 +1491,8 @@ func testRefund(t *testing.T) {
 	}
 }
 
-func testTokenBalance(t *testing.T) {
-	bal, err := ethClient.tokenBalance(ctx, testTokenContractAddr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if bal == nil {
-		t.Fatalf("empty balance")
-	}
-	spew.Dump(bal)
-}
-
 func testApproveAllowance(t *testing.T) {
-	expectedAllowance := big.NewInt(1000)
-
-	_, err := ethClient.approveToken(ctx, testTokenContractAddr, expectedAllowance, maxFeeRate)
+	err := ethClient.unlock(pw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1286,661 +1501,61 @@ func testApproveAllowance(t *testing.T) {
 		t.Fatalf("post approve mining error: %v", err)
 	}
 
-	allowance, err := ethClient.tokenAllowance(ctx, testTokenContractAddr)
+	allowance, err := simnetTokenContractor.allowance(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if expectedAllowance.Cmp(allowance) != 0 {
-		t.Fatalf("expected allowance %v != actual %v", expectedAllowance, allowance)
+	if allowance.Cmp(new(big.Int)) == 0 {
+		t.Fatalf("expected allowance > 0")
 	}
 }
 
-func TestInitiateTokenGas(t *testing.T) {
-	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1000), maxFeeRate)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := waitForMined(t, time.Second*10, false); err != nil {
-		t.Fatalf("post approve mining error: %v", err)
-	}
-
-	var previousGas uint64
-	maxSwaps := 50
-	for i := 1; i <= maxSwaps; i++ {
-		gas, err := ethClient.estimateInitTokenGas(ctx, testTokenContractAddr, i)
-		if err != nil {
-			t.Fatalf("unexpected error from estimateInitGas(%d): %v", i, err)
-		}
-
-		fmt.Printf("Gas used for batch initiating %v swaps: %v. %v more than previous \n", i, gas, gas-previousGas)
-		previousGas = gas
-	}
-}
-
-func newTokenInitiation(stamp int64, secretHash [32]byte, val int64) ethv0.ETHSwapInitiation {
-	return ethv0.ETHSwapInitiation{
-		RefundTimestamp: big.NewInt(stamp),
-		SecretHash:      secretHash,
-		Participant:     participantAddr,
-		Value:           big.NewInt(val),
-	}
-}
-
-func newTokenRedeem(secret, secretHash [32]byte) ethv0.ETHSwapRedemption {
-	return ethv0.ETHSwapRedemption{
-		SecretHash: secretHash,
-		Secret:     secret,
-	}
-}
-
-func testTokenSwap(t *testing.T) {
-	var secretHash [32]byte
-	copy(secretHash[:], encode.RandomBytes(32))
-	swap, err := ethClient.tokenSwap(ctx, secretHash)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Should be empty.
-	spew.Dump(swap)
-}
-
-func TestGetTokenAddress(t *testing.T) {
-	addr, err := ethClient.getTokenAddress(ctx)
+func testGetTokenAddress(t *testing.T) {
+	addr, err := simnetTokenContractor.tokenAddress(ctx)
 	if err != nil {
 		t.Fatalf("Error getting token address: %v", err)
 	}
-
-	fmt.Printf("FAHK U ~~ 0x%x\n", addr)
+	if addr != testTokenContractAddr {
+		t.Fatalf("Wrong contract retrieved from contract. wanted %s, got %s", testTokenContractAddr, addr)
+	}
+	fmt.Println("Token Address: ", addr)
 }
 
-func testInitiateToken(t *testing.T) {
-	// Create a slice of random secret hashes that can be used in the tests and
-	// make sure none of them have been used yet.
-	numSecretHashes := 10
-	secretHashes := make([][32]byte, numSecretHashes)
-	for i := 0; i < numSecretHashes; i++ {
-		copy(secretHashes[i][:], encode.RandomBytes(32))
-		swap, err := ethClient.tokenSwap(ctx, secretHashes[i])
-		if err != nil {
-			t.Fatal("unable to get swap state")
-		}
-		state := dexeth.SwapStep(swap.State)
-		if state != dexeth.SSNone {
-			t.Fatalf("unexpected swap state: want %s got %s", dexeth.SSNone, state)
-		}
-	}
-
-	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1000), maxFeeRate)
+func testTransferGas(t *testing.T) {
+	err := ethClient.unlock(pw)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("unlock error: %v", err)
 	}
-	if err := waitForMined(t, time.Second*10, false); err != nil {
-		t.Fatalf("post-approve mining error: %v", err)
+	gas, err := simnetTokenContractor.estimateTransferGas(ctx, dexeth.GweiToWei(1e8))
+	if err != nil {
+		t.Fatalf("estimateTransferGas error: %v", err)
 	}
-
-	now := time.Now().Unix()
-
-	tests := []struct {
-		name    string
-		swaps   []ethv0.ETHSwapInitiation
-		success bool
-	}{
-		{
-			name:    "1 swap ok",
-			success: true,
-			swaps: []ethv0.ETHSwapInitiation{
-				newTokenInitiation(now, secretHashes[0], 2),
-			},
-		},
-		{
-			name:    "1 swap with existing hash",
-			success: false,
-			swaps: []ethv0.ETHSwapInitiation{
-				newTokenInitiation(now, secretHashes[0], 1),
-			},
-		},
-		{
-			name:    "2 swaps ok",
-			success: true,
-			swaps: []ethv0.ETHSwapInitiation{
-				newTokenInitiation(now, secretHashes[1], 1),
-				newTokenInitiation(now, secretHashes[2], 1),
-			},
-		},
-		{
-			name:    "1 swap nil refundtimestamp",
-			success: false,
-			swaps: []ethv0.ETHSwapInitiation{
-				newTokenInitiation(0, secretHashes[4], 1),
-			},
-		},
-		{
-			name:    "swap with 0 value",
-			success: false,
-			swaps: []ethv0.ETHSwapInitiation{
-				newTokenInitiation(now, secretHashes[5], 0),
-				newTokenInitiation(now, secretHashes[6], 1000),
-			},
-		},
-	}
-	for _, test := range tests {
-		originalBal, err := ethClient.tokenBalance(ctx, testTokenContractAddr)
-		if err != nil {
-			t.Fatalf("unexpected error for test %v: %v", test.name, err)
-		}
-
-		originalStates := make(map[string]dexeth.SwapStep)
-		for _, testSwap := range test.swaps {
-			swap, err := ethClient.tokenSwap(ctx, testSwap.SecretHash)
-			if err != nil {
-				t.Fatalf("%s: swap error: %v", test.name, err)
-			}
-			originalStates[hex.EncodeToString(testSwap.SecretHash[:])] = dexeth.SwapStep(swap.State)
-		}
-
-		totalValue := new(big.Int)
-		for _, swap := range test.swaps {
-			totalValue.Add(totalValue, swap.Value)
-		}
-
-		tx, err := ethClient.initiateToken(ctx, test.swaps, testTokenContractAddr, maxFeeRate)
-		if err != nil {
-			t.Fatalf("%s: initiate error: %v", test.name, err)
-		}
-		spew.Dump(tx)
-
-		if err := waitForMined(t, time.Second*10, false); err != nil {
-			t.Fatalf("%s: post-initiate mining error: %v", test.name, err)
-		}
-
-		// It appears the receipt is only accessible after the tx is mined.
-		receipt, err := ethClient.transactionReceipt(ctx, tx.Hash())
-		if err != nil {
-			t.Fatalf("%s: receipt error: %v", test.name, err)
-		}
-		spew.Dump("receipt", receipt)
-
-		wantBal := new(big.Int)
-		wantBal.Set(originalBal)
-		if test.success {
-			wantBal.Sub(wantBal, totalValue)
-		}
-
-		afterBal, err := ethClient.tokenBalance(ctx, testTokenContractAddr)
-		if err != nil {
-			t.Fatalf("unexpected error for test %v: %v", test.name, err)
-		}
-
-		if afterBal.Cmp(wantBal) != 0 {
-			t.Fatalf("%s: expected balance %v but got %v", test.name, wantBal, afterBal)
-		}
-
-		for _, testSwap := range test.swaps {
-			swap, err := ethClient.tokenSwap(ctx, testSwap.SecretHash)
-			if err != nil {
-				t.Fatalf("%s: swap error post-init: %v", test.name, err)
-			}
-
-			state := dexeth.SwapStep(swap.State)
-			if test.success && state != dexeth.SSInitiated {
-				t.Fatalf("%s: wrong success swap state: want %s got %s", test.name, dexeth.SSInitiated, state)
-			}
-
-			originalState := originalStates[hex.EncodeToString(testSwap.SecretHash[:])]
-			if !test.success && state != originalState {
-				t.Fatalf("%s: wrong error swap state: want %s got %s", test.name, originalState, state)
-			}
-		}
-	}
+	fmt.Printf("=========== gas for transfer: %d ==============\n", gas)
 }
 
-func TestRedeemTokenGas(t *testing.T) {
-	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(10000), maxFeeRate)
+func testApproveGas(t *testing.T) {
+	gas, err := simnetTokenContractor.estimateApproveGas(ctx, dexeth.GweiToWei(1e8))
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("")
 	}
-	if err := waitForMined(t, time.Second*8, true); err != nil {
-		t.Fatalf("unexpected error while waiting to mine: %v", err)
-	}
-
-	// Create secrets and secret hashes
-	numSecrets := 5
-	secrets := make([][32]byte, 0, numSecrets)
-	secretHashes := make([][32]byte, 0, numSecrets)
-	for i := 0; i < numSecrets; i++ {
-		var secret [32]byte
-		copy(secret[:], encode.RandomBytes(32))
-		secretHash := sha256.Sum256(secret[:])
-		secrets = append(secrets, secret)
-		secretHashes = append(secretHashes, secretHash)
-	}
-
-	// Initiate swaps
-	now := time.Now().Unix()
-
-	swaps := make([]ethv0.ETHSwapInitiation, 0, numSecrets)
-	for i := 0; i < numSecrets; i++ {
-		swaps = append(swaps, newTokenInitiation(now, secretHashes[i], 1))
-	}
-	_, err = ethClient.initiateToken(ctx, swaps, testTokenContractAddr, maxFeeRate)
-	if err != nil {
-		t.Fatalf("Unable to initiate swap: %v ", err)
-	}
-	if err := waitForMined(t, time.Second*8, true); err != nil {
-		t.Fatalf("unexpected error while waiting to mine: %v", err)
-	}
-
-	// Make sure swaps were properly initiated
-	for i := range swaps {
-		swap, err := ethClient.tokenSwap(ctx, swaps[i].SecretHash)
-		if err != nil {
-			t.Fatal("unable to get swap state")
-		}
-
-		state := dexeth.SwapStep(swap.State)
-		if state != dexeth.SSInitiated {
-			t.Fatalf("unexpected swap state: want %s got %s", dexeth.SSInitiated, state)
-		}
-	}
-
-	// Test gas usage of redeem function
-	var previous uint64
-	for i := 0; i < numSecrets; i++ {
-		gas, err := participantEthClient.estimateRedeemTokenGas(ctx, secrets[:i+1])
-		if err != nil {
-			t.Fatalf("Error estimating gas for redeem function: %v", err)
-		}
-
-		fmt.Printf("\n\nGas used to redeem %d swaps: %d -- %d more than previous \n\n", i+1, gas, gas-previous)
-		previous = gas
-	}
-}
-
-func testRedeemToken(t *testing.T) {
-	lockTime := time.Now().Add(time.Second * 12).Unix()
-	numSecrets := 10
-	secrets := make([][32]byte, 0, numSecrets)
-	secretHashes := make([][32]byte, 0, numSecrets)
-	for i := 0; i < numSecrets; i++ {
-		var secret [32]byte
-		copy(secret[:], encode.RandomBytes(32))
-		secretHash := sha256.Sum256(secret[:])
-		secrets = append(secrets, secret)
-		secretHashes = append(secretHashes, secretHash)
-	}
-
-	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1e6), maxFeeRate)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tests := []struct {
-		name            string
-		sleep           time.Duration
-		redeemerClient  *nodeClient
-		redeemer        *accounts.Account
-		swaps           []ethv0.ETHSwapInitiation
-		redemptions     []ethv0.ETHSwapRedemption
-		isRedeemable    []bool
-		finalStates     []dexeth.SwapStep
-		addAmt          bool
-		expectRedeemErr bool
-	}{
-		{
-			name:           "ok before locktime",
-			sleep:          time.Second * 8,
-			redeemerClient: participantEthClient,
-			redeemer:       participantAcct,
-			swaps:          []ethv0.ETHSwapInitiation{newTokenInitiation(lockTime, secretHashes[0], 1)},
-			redemptions:    []ethv0.ETHSwapRedemption{newTokenRedeem(secrets[0], secretHashes[0])},
-			isRedeemable:   []bool{true},
-			finalStates:    []dexeth.SwapStep{dexeth.SSRedeemed},
-			addAmt:         true,
-		},
-		{
-			name:           "ok two before locktime",
-			sleep:          time.Second * 8,
-			redeemerClient: participantEthClient,
-			redeemer:       participantAcct,
-			swaps: []ethv0.ETHSwapInitiation{
-				newTokenInitiation(lockTime, secretHashes[1], 1),
-				newTokenInitiation(lockTime, secretHashes[2], 1),
-			},
-			redemptions: []ethv0.ETHSwapRedemption{
-				newTokenRedeem(secrets[1], secretHashes[1]),
-				newTokenRedeem(secrets[2], secretHashes[2]),
-			},
-			isRedeemable: []bool{true, true},
-			finalStates: []dexeth.SwapStep{
-				dexeth.SSRedeemed, dexeth.SSRedeemed,
-			},
-			addAmt: true,
-		},
-		{
-			name:           "ok after locktime",
-			sleep:          time.Second * 16,
-			redeemerClient: participantEthClient,
-			redeemer:       participantAcct,
-			swaps:          []ethv0.ETHSwapInitiation{newTokenInitiation(lockTime, secretHashes[3], 1)},
-			redemptions:    []ethv0.ETHSwapRedemption{newTokenRedeem(secrets[3], secretHashes[3])},
-			isRedeemable:   []bool{true},
-			finalStates:    []dexeth.SwapStep{dexeth.SSRedeemed},
-			addAmt:         true,
-		},
-		{
-			name:           "bad redeemer",
-			sleep:          time.Second * 8,
-			redeemerClient: ethClient,
-			redeemer:       simnetAcct,
-			swaps:          []ethv0.ETHSwapInitiation{newTokenInitiation(lockTime, secretHashes[4], 1)},
-			redemptions:    []ethv0.ETHSwapRedemption{newTokenRedeem(secrets[4], secretHashes[4])},
-			isRedeemable:   []bool{false},
-			finalStates:    []dexeth.SwapStep{dexeth.SSInitiated},
-			addAmt:         false,
-		},
-		{
-			name:           "bad secret",
-			sleep:          time.Second * 8,
-			redeemerClient: ethClient,
-			redeemer:       simnetAcct,
-			swaps:          []ethv0.ETHSwapInitiation{newTokenInitiation(lockTime, secretHashes[5], 1)},
-			redemptions:    []ethv0.ETHSwapRedemption{newTokenRedeem(secrets[6], secretHashes[5])},
-			isRedeemable:   []bool{false},
-			finalStates:    []dexeth.SwapStep{dexeth.SSInitiated},
-			addAmt:         false,
-		},
-		{
-			name:           "duplicate secret hashes",
-			sleep:          time.Second * 8,
-			redeemerClient: participantEthClient,
-			redeemer:       participantAcct,
-			swaps: []ethv0.ETHSwapInitiation{
-				newTokenInitiation(lockTime, secretHashes[7], 1),
-				newTokenInitiation(lockTime, secretHashes[8], 1),
-			},
-			redemptions: []ethv0.ETHSwapRedemption{
-				newTokenRedeem(secrets[7], secretHashes[7]),
-				newTokenRedeem(secrets[7], secretHashes[7]),
-			},
-			isRedeemable: []bool{true, true},
-			finalStates: []dexeth.SwapStep{
-				dexeth.SSInitiated,
-				dexeth.SSInitiated,
-			},
-			addAmt: false,
-		},
-	}
-
-	for _, test := range tests {
-		for i := range test.swaps {
-			swap, err := ethClient.tokenSwap(ctx, test.swaps[i].SecretHash)
-			if err != nil {
-				t.Fatal("unable to get swap state")
-			}
-			state := dexeth.SwapStep(swap.State)
-			if state != dexeth.SSNone {
-				t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, dexeth.SSNone, state)
-			}
-		}
-
-		_, err := ethClient.initiateToken(ctx, test.swaps, testTokenContractAddr, maxFeeRate)
-		if err != nil {
-			t.Fatalf("%s: initiate error: %v ", test.name, err)
-		}
-
-		// This waitForMined will always take test.sleep to complete.
-		if err := waitForMined(t, test.sleep, true); err != nil {
-			t.Fatalf("%s: post-init mining error: %v", test.name, err)
-		}
-
-		for i := range test.swaps {
-			swap, err := ethClient.tokenSwap(ctx, test.swaps[i].SecretHash)
-			if err != nil {
-				t.Fatal("unable to get swap state")
-			}
-			state := dexeth.SwapStep(swap.State)
-			if state != dexeth.SSInitiated {
-				t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, dexeth.SSInitiated, state)
-			}
-		}
-
-		originalBal, err := test.redeemerClient.tokenBalance(ctx, testTokenContractAddr)
-		if err != nil {
-			t.Fatalf("%s: balance error: %v", test.name, err)
-		}
-
-		for i, redemption := range test.redemptions {
-			expected := test.isRedeemable[i]
-			isRedeemable, err := test.redeemerClient.tokenIsRedeemable(ctx, redemption.SecretHash, redemption.Secret)
-			if err != nil {
-				t.Fatalf(`test "%v": error calling isRedeemable: %v`, test.name, err)
-			}
-			if isRedeemable != expected {
-				t.Fatalf(`test "%v": expected isRedeemable to be %v, but got %v`, test.name, expected, isRedeemable)
-			}
-		}
-
-		tx, err := test.redeemerClient.redeemToken(ctx, test.redemptions, maxFeeRate)
-		if err != nil {
-			t.Fatalf("%s: redeem error: %v", test.name, err)
-		}
-		spew.Dump(tx)
-
-		if err := waitForMined(t, time.Second*10, false); err != nil {
-			t.Fatalf("%s: post-redeem mining error: %v", test.name, err)
-		}
-
-		// It appears the receipt is only accessible after the tx is mined.
-		receipt, err := test.redeemerClient.transactionReceipt(ctx, tx.Hash())
-		if err != nil {
-			t.Fatalf("%s: receipt error: %v", test.name, err)
-		}
-		spew.Dump(receipt)
-
-		wantBal := new(big.Int)
-		wantBal.Set(originalBal)
-		if test.addAmt {
-			wantBal.Add(wantBal, big.NewInt(int64(len(test.redemptions))))
-		}
-
-		afterBal, err := test.redeemerClient.tokenBalance(ctx, testTokenContractAddr)
-		if err != nil {
-			t.Fatalf("unexpected error for test %v: %v", test.name, err)
-		}
-
-		if afterBal.Cmp(wantBal) != 0 {
-			t.Fatalf("%s: expected balance %v but got %v", test.name, wantBal, afterBal)
-		}
-
-		for i, redemption := range test.redemptions {
-			swap, err := ethClient.tokenSwap(ctx, redemption.SecretHash)
-			if err != nil {
-				t.Fatalf("unexpected error for test %v: %v", test.name, err)
-			}
-			state := dexeth.SwapStep(swap.State)
-			if state != test.finalStates[i] {
-				t.Fatalf("unexpected swap state for test %v [%d]: want %s got %s",
-					test.name, i, test.finalStates[i], state)
-			}
-		}
-	}
-}
-func testRefundToken(t *testing.T) {
-	const amt = 1e5
-	locktime := time.Second * 12
-	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1e6), maxFeeRate)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tests := []struct {
-		name                 string
-		sleep                time.Duration
-		refunderClient       *nodeClient
-		finalState           dexeth.SwapStep
-		redeem, isRefundable bool
-	}{{
-		name:           "ok",
-		sleep:          time.Second * 16,
-		refunderClient: ethClient,
-		isRefundable:   true,
-		finalState:     dexeth.SSRefunded,
-	}, {
-		name:           "before locktime",
-		sleep:          time.Second * 8,
-		refunderClient: ethClient,
-		finalState:     dexeth.SSInitiated,
-	}, {
-		name:           "wrong refunder",
-		sleep:          time.Second * 16,
-		refunderClient: participantEthClient,
-		finalState:     dexeth.SSInitiated,
-	}, {
-		name:           "already redeemed",
-		sleep:          time.Second * 16,
-		refunderClient: ethClient,
-		redeem:         true,
-		finalState:     dexeth.SSRedeemed,
-	}}
-
-	for _, test := range tests {
-		var secret [32]byte
-		copy(secret[:], encode.RandomBytes(32))
-		secretHash := sha256.Sum256(secret[:])
-
-		swap, err := ethClient.tokenSwap(ctx, secretHash)
-		if err != nil {
-			t.Fatalf("%s: unable to get swap state pre-init", test.name)
-		}
-		state := dexeth.SwapStep(swap.State)
-		if state != dexeth.SSNone {
-			t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, dexeth.SSNone, state)
-		}
-
-		inLocktime := time.Now().Add(locktime).Unix()
-		_, err = ethClient.initiateToken(ctx, []ethv0.ETHSwapInitiation{newTokenInitiation(inLocktime, secretHash, amt)}, testTokenContractAddr, maxFeeRate)
-		if err != nil {
-			t.Fatalf("%s: initiate error: %v ", test.name, err)
-		}
-
-		if test.redeem {
-			if err := waitForMined(t, time.Second*8, false); err != nil {
-				t.Fatalf("%s: pre-redeem mining error: %v", test.name, err)
-			}
-			_, err := participantEthClient.redeemToken(ctx, []ethv0.ETHSwapRedemption{newTokenRedeem(secret, secretHash)}, maxFeeRate)
-			if err != nil {
-				t.Fatalf("%s: redeem error: %v", test.name, err)
-			}
-		}
-
-		// This waitForMined will always take test.sleep to complete.
-		if err := waitForMined(t, test.sleep, true); err != nil {
-			t.Fatalf("unexpected post-init mining error for test %v: %v", test.name, err)
-		}
-
-		isRefundable, err := test.refunderClient.tokenIsRefundable(ctx, secretHash)
-		if err != nil {
-			t.Fatalf("%s: isRefundable error: %v", test.name, err)
-		}
-		if isRefundable != test.isRefundable {
-			t.Fatalf("%s: expected isRefundable = %v", test.name, test.isRefundable)
-		}
-
-		originalBal, err := test.refunderClient.tokenBalance(ctx, testTokenContractAddr)
-		if err != nil {
-			t.Fatalf("%s: balance error: %v", test.name, err)
-		}
-
-		tx, err := test.refunderClient.refundToken(ctx, secretHash, maxFeeRate)
-		if err != nil {
-			t.Fatalf("%s: refund error: %v", test.name, err)
-		}
-		spew.Dump(tx)
-
-		if err := waitForMined(t, time.Second*10, false); err != nil {
-			t.Fatalf("%s: post-refund mining error: %v", test.name, err)
-		}
-
-		// It appears the receipt is only accessible after the tx is mined.
-		receipt, err := test.refunderClient.transactionReceipt(ctx, tx.Hash())
-		if err != nil {
-			t.Fatalf("%s: receipt error: %v", test.name, err)
-		}
-		spew.Dump(receipt)
-
-		// Balance should increase or decrease by a certain amount
-		// depending on whether redeem completed successfully on-chain.
-		// If unsuccessful the fee is subtracted. If successful, amt is
-		// added.
-		bal, err := test.refunderClient.tokenBalance(ctx, testTokenContractAddr)
-		if err != nil {
-			t.Fatalf("%s: balance error: %v", test.name, err)
-		}
-		wantBal := new(big.Int)
-		wantBal.Set(originalBal)
-		if test.isRefundable {
-			wantBal.Add(wantBal, big.NewInt(amt))
-		}
-
-		if bal.Cmp(wantBal) != 0 {
-			t.Fatalf("%s: expected balance %v but got %v", test.name, wantBal, bal)
-		}
-
-		swap, err = test.refunderClient.tokenSwap(ctx, secretHash)
-		if err != nil {
-			t.Fatalf("%s: post-refund swap error: %v", test.name, err)
-		}
-		state = dexeth.SwapStep(swap.State)
-		if state != test.finalState {
-			t.Fatalf("%s: wrong swap state: want %s got %s", test.name, test.finalState, state)
-		}
-	}
-}
-
-func TestRefundTokenGas(t *testing.T) {
-	var secret [32]byte
-	copy(secret[:], encode.RandomBytes(32))
-	secretHash := sha256.Sum256(secret[:])
-
-	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1e6), maxFeeRate)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := waitForMined(t, time.Second*8, true); err != nil {
-		t.Fatalf("unexpected error while waiting to mine: %v", err)
-	}
-
-	lockTime := time.Now().Unix()
-	_, err = ethClient.initiateToken(ctx, []ethv0.ETHSwapInitiation{newTokenInitiation(lockTime, secretHash, 1)}, testTokenContractAddr, maxFeeRate)
-	if err != nil {
-		t.Fatalf("Unable to initiate swap: %v ", err)
-	}
-	if err := waitForMined(t, time.Second*8, true); err != nil {
-		t.Fatalf("unexpected error while waiting to mine: %v", err)
-	}
-
-	swap, err := ethClient.tokenSwap(ctx, secretHash)
-	if err != nil {
-		t.Fatal("unable to get swap state")
-	}
-	state := dexeth.SwapStep(swap.State)
-	if state != dexeth.SSInitiated {
-		t.Fatalf("unexpected swap state: want %s got %s", dexeth.SSInitiated, state)
-	}
-
-	gas, err := ethClient.estimateRefundTokenGas(ctx, secretHash)
-	if err != nil {
-		t.Fatalf("Error estimating gas for refund function: %v", err)
-	}
-
-	fmt.Printf("Gas used for refund: %v \n", gas)
+	fmt.Printf("=========== gas for approve: %d ==============\n", gas)
 }
 
 func TestReplayAttack(t *testing.T) {
+	err := ethClient.unlock(pw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	txOpts, err := ethClient.txOpts(ctx, 1, defaultSendGasLimit*5, nil)
 	if err != nil {
 		t.Fatalf("txOpts error: %v", err)
+	}
+
+	err = ethClient.addSignerToOpts(txOpts)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	// Deploy the reentry attack contract.
@@ -2126,6 +1741,28 @@ func testSignMessage(t *testing.T) {
 	}
 	if !crypto.VerifySignature(pubKey, crypto.Keccak256(msg), sig) {
 		t.Fatalf("failed to verify signature")
+	}
+}
+
+func TestTokenGasEstimates(t *testing.T) {
+	prepareTokenClients(t)
+	if err := GetGasEstimates(ctx, ethClient, simnetTokenContractor, 5, tokenGases, func() {
+		if err := waitForMined(t, time.Second*10, false); err != nil {
+			t.Fatalf("mining error: %v", err)
+		}
+	}); err != nil {
+		t.Fatalf("getGasEstimates error: %v", err)
+	}
+}
+
+func TestTokenGasEstimatesParticipant(t *testing.T) {
+	prepareTokenClients(t)
+	if err := GetGasEstimates(ctx, participantEthClient, participantTokenContractor, 5, tokenGases, func() {
+		if err := waitForMined(t, time.Second*10, false); err != nil {
+			t.Fatalf("mining error: %v", err)
+		}
+	}); err != nil {
+		t.Fatalf("getGasEstimates error: %v", err)
 	}
 }
 

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -487,7 +487,7 @@ type Swaps struct {
 	// subsequent matches.
 	LockChange bool
 	// AssetConfig contains the asset version and fee configuration for the DEX.
-	// NOTE: Only on Config field is supported, so only orders from the same
+	// NOTE: Only one Config field is supported, so only orders from the same
 	// host can be batched. We could consider moving this field to the Contract
 	// and Wallets could batch compatible swaps internally.
 	AssetConfig *dex.Asset

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -213,7 +213,7 @@ type Wallet interface {
 	// the fees associated with the Asset.MaxFeeRate. For quote assets, lotSize
 	// will be an estimate based on current market conditions. lotSize should
 	// not be zero.
-	MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*SwapEstimate, error)
+	MaxOrder(*MaxOrderForm) (*SwapEstimate, error)
 	// PreSwap gets a pre-swap estimate for the specified order size.
 	PreSwap(*PreSwapForm) (*PreSwap, error)
 	// PreRedeem gets a pre-redeem estimate for the specified order size.
@@ -379,7 +379,7 @@ type AccountLocker interface {
 	// appropriate amount of funds so that we can redeem N swaps on the
 	// specified version of the asset, at the specified fee rate. It is an
 	// error to request funds > spendable balance.
-	ReserveNRedemptions(n, feeRate uint64, assetVer uint32) (uint64, error)
+	ReserveNRedemptions(n uint64, dexRedeemCfg *dex.Asset) (uint64, error)
 	// ReReserveRedemption is used when reconstructing existing orders on
 	// startup. It is an error to request funds > spendable balance.
 	ReReserveRedemption(amt uint64) error
@@ -391,7 +391,7 @@ type AccountLocker interface {
 	// appropriate amount of funds so that we can refund N swaps on the
 	// specified version of the asset, at the specified fee rate. It is
 	// an error to request funds > spendable balance.
-	ReserveNRefunds(n, feeRate uint64, assetVer uint32) (uint64, error)
+	ReserveNRefunds(n uint64, dexSwapCfg *dex.Asset) (uint64, error)
 	// ReReserveRefund is used when reconstructing existing orders on
 	// startup. It is an error to request funds > spendable balance.
 	ReReserveRefund(uint64) error
@@ -486,11 +486,11 @@ type Swaps struct {
 	// LockChange can be set to true if the change should be locked for
 	// subsequent matches.
 	LockChange bool
-	// AssetVersion is the swap protocol version, which may indicate a specific
+	// AssetConfig is the swap protocol version, which may indicate a specific
 	// contract or form of contract. NOTE: Depending on the asset, batch swaps
 	// may force each Contract to use the same version, but conceptually this
 	// should perhaps be in Contract with SecretHash.
-	AssetVersion uint32
+	AssetConfig *dex.Asset
 	// Options are OrderOptions set or selected by the user at order time.
 	Options map[string]string
 }
@@ -547,7 +547,8 @@ type Order struct {
 	// DEXConfig holds values specific to and provided by a particular server.
 	// Info about fee rates and swap transaction sizes is used internally to
 	// calculate the funding required to cover fees.
-	DEXConfig *dex.Asset
+	DEXConfig    *dex.Asset
+	RedeemConfig *dex.Asset
 	// Immediate should be set to true if this is for an order that is not a
 	// standing order, likely a market order or a limit order with immediate
 	// time-in-force.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -376,9 +376,9 @@ type TokenMaster interface {
 type AccountLocker interface {
 	// ReserveNRedemption is used when preparing funding for an order that
 	// redeems to an account-based asset. The wallet will set aside the
-	// appropriate amount of funds so that we can redeem N swaps on the
-	// specified version of the asset, at the specified fee rate. It is an
-	// error to request funds > spendable balance.
+	// appropriate amount of funds so that we can redeem N swaps using the fee
+	// and version configuration specified in the dex.Asset. It is an error to
+	// request funds > spendable balance.
 	ReserveNRedemptions(n uint64, dexRedeemCfg *dex.Asset) (uint64, error)
 	// ReReserveRedemption is used when reconstructing existing orders on
 	// startup. It is an error to request funds > spendable balance.
@@ -386,11 +386,11 @@ type AccountLocker interface {
 	// UnlockRedemptionReserves is used to return funds reserved for redemption
 	// when an order is canceled or otherwise completed unfilled.
 	UnlockRedemptionReserves(uint64)
-	// ReserveNRefunds is used when preparing funding for an order that
-	// refunds to an account-based asset. The wallet will set aside the
-	// appropriate amount of funds so that we can refund N swaps on the
-	// specified version of the asset, at the specified fee rate. It is
-	// an error to request funds > spendable balance.
+	// ReserveNRefunds is used when preparing funding for an order that refunds
+	// to an account-based asset. The wallet will set aside the appropriate
+	// amount of funds so that we can refund N swaps using the fee and version
+	// configuration specified in the dex.Asset. It is an error to request funds
+	// > spendable balance.
 	ReserveNRefunds(n uint64, dexSwapCfg *dex.Asset) (uint64, error)
 	// ReReserveRefund is used when reconstructing existing orders on
 	// startup. It is an error to request funds > spendable balance.
@@ -486,10 +486,10 @@ type Swaps struct {
 	// LockChange can be set to true if the change should be locked for
 	// subsequent matches.
 	LockChange bool
-	// AssetConfig is the swap protocol version, which may indicate a specific
-	// contract or form of contract. NOTE: Depending on the asset, batch swaps
-	// may force each Contract to use the same version, but conceptually this
-	// should perhaps be in Contract with SecretHash.
+	// AssetConfig contains the asset version and fee configuration for the DEX.
+	// NOTE: Only on Config field is supported, so only orders from the same
+	// host can be batched. We could consider moving this field to the Contract
+	// and Wallets could batch compatible swaps internally.
 	AssetConfig *dex.Asset
 	// Options are OrderOptions set or selected by the user at order time.
 	Options map[string]string

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -701,7 +701,7 @@ func (w *TXCWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, error
 	return w.fundingCoins, w.fundRedeemScripts, w.fundingCoinErr
 }
 
-func (w *TXCWallet) MaxOrder(lotSize, feeSuggestion uint64, nfo *dex.Asset) (*asset.SwapEstimate, error) {
+func (w *TXCWallet) MaxOrder(*asset.MaxOrderForm) (*asset.SwapEstimate, error) {
 	return nil, nil
 }
 
@@ -883,7 +883,7 @@ func newTAccountLocker(assetID uint32) (*xcWallet, *TAccountLocker) {
 	return xcWallet, accountLocker
 }
 
-func (w *TAccountLocker) ReserveNRedemptions(n, feeRate uint64, assetVer uint32) (uint64, error) {
+func (w *TAccountLocker) ReserveNRedemptions(n uint64, dexSwapCfg *dex.Asset) (uint64, error) {
 	return w.reserveNRedemptions, w.reserveNRedemptionsErr
 }
 
@@ -896,7 +896,7 @@ func (w *TAccountLocker) UnlockRedemptionReserves(v uint64) {
 	w.redemptionUnlocked += v
 }
 
-func (w *TAccountLocker) ReserveNRefunds(n, feeRate uint64, assetVer uint32) (uint64, error) {
+func (w *TAccountLocker) ReserveNRefunds(n uint64, dexRedeemCfg *dex.Asset) (uint64, error) {
 	return w.reserveNRefunds, w.reserveNRefundsErr
 }
 

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1729,12 +1729,12 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 	// A more sophisticated solution might involve tracking the error time too
 	// and trying again in certain circumstances.
 	swaps := &asset.Swaps{
-		Inputs:       inputs,
-		Contracts:    contracts,
-		FeeRate:      highestFeeRate,
-		LockChange:   lockChange,
-		AssetVersion: t.metaData.FromVersion,
-		Options:      t.options,
+		Inputs:      inputs,
+		Contracts:   contracts,
+		FeeRate:     highestFeeRate,
+		LockChange:  lockChange,
+		AssetConfig: t.wallets.fromAsset,
+		Options:     t.options,
 	}
 	receipts, change, fees, err := t.wallets.fromWallet.Swap(swaps)
 	if err != nil {

--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -226,6 +226,10 @@ type Redemption struct {
 
 var testTokenID, _ = dex.BipSymbolID("dextt.eth")
 
+// Gases lists the expected gas required for various DEX and wallet operations.
+// ★★ IMPORTANT ★★  By policy, clients should allow servers to adjust Swap and
+// Redeem gas values in their *dex.Asset up to but not over 2x the value listed
+// in VersionedGases or Tokens.
 type Gases struct {
 	// Approve is the amount of gas needed to approve the swap contract for
 	// transferring tokens.

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -125,6 +125,11 @@ function send(from, to, amt) {
 }
 EOF
 
+cat > "${NODES_ROOT}/harness-ctl/sendtoaddress" <<EOF
+"${NODES_ROOT}/harness-ctl/alpha" "attach --preload ${NODES_ROOT}/harness-ctl/send.js --exec send(\"${ALPHA_ADDRESS}\",\"\$1\",\$2*1e18)"
+EOF
+chmod +x "${NODES_ROOT}/harness-ctl/sendtoaddress"
+
 cat > "${NODES_ROOT}/harness-ctl/deploy.js" <<EOF
 function deploy(from, contract) {
   tx = personal.sendTransaction({from:"0x"+from,data:"0x"+contract,gasPrice:82000000000}, "${PASSWORD}")


### PR DESCRIPTION
I've peeled a few other PRs off of this one, but I think I'll submit the rest as one. Lots of tests written or adapted and all are passing. Ready for a look.

```
Introduce tokenContractor interface to handle operations on the token
contract and token-bound swap contract.

Separate ExchangeWallet into baseWallet and AssetWallet.

Move contractor handling to AssetWallet. This simplifies the ethFetcher
and is a better division of labor, making future implementations of
EVM-family assets easier.

Implement detailed calculations of swap and approve gas, issuing
warnings when a configuration mismatch is detected.

dex/networks/eth,dex:
Simplify dex.Token and create dexeth.Token type to add gas and address
info. Move gas info to version-specific token data.

```