### PR TITLE
client,ui: Display tx fee for registration

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2573,6 +2573,12 @@ func (btc *ExchangeWallet) PayFee(address string, regFee, feeRateSuggestion uint
 	return newOutput(txHash, vout, sent), nil
 }
 
+// EstimateRegistrationTxFee gives a conservative enstimate for how much
+// transaction fees need to be spent to pay the registration fee.
+func (btc *ExchangeWallet) EstimateRegistrationTxFee() uint64 {
+	return (dexbtc.MinimumTxOverhead + (2 * dexbtc.P2PKHOutputSize) + dexbtc.RedeemP2PKHInputSize) * btc.feeRateLimit
+}
+
 // Withdraw withdraws funds to the specified address. Fees are subtracted from
 // the value. feeRate is in units of atoms/byte.
 func (btc *ExchangeWallet) Withdraw(address string, value, feeSuggestion uint64) (asset.Coin, error) {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2514,6 +2514,12 @@ func (dcr *ExchangeWallet) PayFee(address string, regFee, feeRateSuggestion uint
 	return newOutput(msgTx.CachedTxHash(), 0, regFee, wire.TxTreeRegular), nil
 }
 
+// EstimateRegistrationTxFee gives a conservative enstimate for how much
+// transaction fees need to be spent to pay the registration fee.
+func (dcr *ExchangeWallet) EstimateRegistrationTxFee() uint64 {
+	return (dexdcr.MsgTxOverhead + (dexdcr.P2PKHOutputSize * 2) + dexdcr.P2PKHInputSize) * dcr.feeRateLimit
+}
+
 // Withdraw withdraws funds to the specified address. Fees are subtracted from
 // the value.
 func (dcr *ExchangeWallet) Withdraw(address string, value, feeSuggestion uint64) (asset.Coin, error) {

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1052,6 +1052,12 @@ func (eth *ExchangeWallet) PayFee(address string, regFee, _ uint64) (asset.Coin,
 	return &coin{id: txHash[:], value: dexeth.WeiToGwei(tx.Value())}, nil
 }
 
+// EstimateRegistrationTxFee gives a conservative enstimate for how much
+// transaction fees need to be spent to pay the registration fee.
+func (eth *ExchangeWallet) EstimateRegistrationTxFee() uint64 {
+	return defaultSendGasLimit * eth.gasFeeLimit
+}
+
 // SwapConfirmations gets the number of confirmations and the spend status
 // for the specified swap.
 func (eth *ExchangeWallet) SwapConfirmations(ctx context.Context, _ dex.Bytes, contract dex.Bytes, _ time.Time) (confs uint32, spent bool, err error) {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -205,6 +205,9 @@ type Wallet interface {
 	// PayFee sends the dex registration fee. Transaction fees are in addition to
 	// the registration fee, and the feeRateSuggestion is gotten from the server.
 	PayFee(address string, feeAmt, feeRateSuggestion uint64) (Coin, error)
+	// EstimateRegistrationTxFee gives a conservative enstimate for how much
+	// transaction fees need to be spent to pay the registration fee.
+	EstimateRegistrationTxFee() uint64
 	// SwapConfirmations gets the number of confirmations and the spend status
 	// for the specified swap. If the swap was not funded by this wallet, and
 	// it is already spent, you may see CoinNotFoundError.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -757,6 +757,10 @@ func (w *TXCWallet) PayFee(address string, fee, feeRateSuggestion uint64) (asset
 	return w.payFeeCoin, w.payFeeErr
 }
 
+func (w *TXCWallet) EstimateRegistrationTxFee() uint64 {
+	return 0
+}
+
 func (w *TXCWallet) Withdraw(address string, value, feeSuggestion uint64) (asset.Coin, error) {
 	return w.payFeeCoin, w.payFeeErr
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -95,18 +95,19 @@ type WalletBalance struct {
 
 // WalletState is the current status of an exchange wallet.
 type WalletState struct {
-	Symbol       string         `json:"symbol"`
-	AssetID      uint32         `json:"assetID"`
-	Version      uint32         `json:"version"`
-	WalletType   string         `json:"type"`
-	Open         bool           `json:"open"`
-	Running      bool           `json:"running"`
-	Balance      *WalletBalance `json:"balance"`
-	Address      string         `json:"address"`
-	Units        string         `json:"units"`
-	Encrypted    bool           `json:"encrypted"`
-	Synced       bool           `json:"synced"`
-	SyncProgress float32        `json:"syncProgress"`
+	Symbol        string         `json:"symbol"`
+	AssetID       uint32         `json:"assetID"`
+	Version       uint32         `json:"version"`
+	WalletType    string         `json:"type"`
+	Open          bool           `json:"open"`
+	Running       bool           `json:"running"`
+	Balance       *WalletBalance `json:"balance"`
+	Address       string         `json:"address"`
+	Units         string         `json:"units"`
+	Encrypted     bool           `json:"encrypted"`
+	Synced        bool           `json:"synced"`
+	SyncProgress  float32        `json:"syncProgress"`
+	RegisterTxFee uint64         `json:"registerTxFee"`
 }
 
 // User is information about the user's wallets and DEX accounts.

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -141,18 +141,19 @@ func (w *xcWallet) state() *WalletState {
 	defer w.mtx.RUnlock()
 	winfo := w.Info()
 	return &WalletState{
-		Symbol:       unbip(w.AssetID),
-		AssetID:      w.AssetID,
-		Version:      winfo.Version,
-		Open:         len(w.encPass) == 0 || len(w.pw) > 0,
-		Running:      w.connector.On(),
-		Balance:      w.balance,
-		Address:      w.address,
-		Units:        winfo.UnitInfo.AtomicUnit,
-		Encrypted:    len(w.encPass) > 0,
-		Synced:       w.synced,
-		SyncProgress: w.syncProgress,
-		WalletType:   w.walletType,
+		Symbol:        unbip(w.AssetID),
+		AssetID:       w.AssetID,
+		Version:       winfo.Version,
+		Open:          len(w.encPass) == 0 || len(w.pw) > 0,
+		Running:       w.connector.On(),
+		Balance:       w.balance,
+		Address:       w.address,
+		Units:         winfo.UnitInfo.AtomicUnit,
+		Encrypted:     len(w.encPass) > 0,
+		Synced:        w.synced,
+		SyncProgress:  w.syncProgress,
+		WalletType:    w.walletType,
+		RegisterTxFee: w.EstimateRegistrationTxFee(),
 	}
 }
 

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -184,6 +184,7 @@ var EnUS = map[string]string{
 	"2 Fund the Registration Fee": "2: Fund the Registration Fee",
 	"Registration fee":            "Registration fee",
 	"Your Deposit Address":        "Your Deposit Address",
+	"Send enough for reg fee":     `Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.`,
 	"add a different server":      "add a different server",
 	"Add a custom server":         "Add a custom server",
 	"plus tx fees":                "+ tx fees",

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -412,6 +412,7 @@
     </div>
     <div class="fs14">[[[Your Deposit Address]]]</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
+    <span data-tmpl="sendEnough">[[[Send enough for reg fee]]]</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -616,20 +616,26 @@ export class WalletWaitForm {
     const page = this.page
     const asset = app().assets[wallet.assetID]
     const fee = this.regFee = this.xc.regFees[asset.symbol]
+    const totalFees = fee.amount + wallet.registerTxFee
 
     for (const span of this.form.querySelectorAll('.unit')) span.textContent = asset.symbol.toUpperCase()
     page.logo.src = Doc.logoPath(asset.symbol)
     page.depoAddr.textContent = wallet.address
+    page.totalFees.textContent = Doc.formatCoinValue(totalFees, asset.info.unitinfo)
     page.fee.textContent = Doc.formatCoinValue(fee.amount, asset.info.unitinfo)
 
     Doc.hide(page.syncUncheck, page.syncCheck, page.balUncheck, page.balCheck, page.syncRemainBox)
-    Doc.show(page.balanceBox)
+    Doc.show(page.balanceBox, page.sendEnough)
 
     Doc.show(wallet.synced ? page.syncCheck : wallet.syncProgress >= 1 ? page.syncSpinner : page.syncUncheck)
     Doc.show(wallet.balance.available > fee.amount ? page.balCheck : page.balUncheck)
 
     page.progress.textContent = Math.round(wallet.syncProgress * 100)
-    this.reportBalance(wallet.balance)
+
+    if (wallet.synced) {
+      this.progressed = true
+    }
+    this.reportBalance(wallet.balance, wallet.assetID)
   }
 
   /*
@@ -640,27 +646,27 @@ export class WalletWaitForm {
     if (wallet.assetID !== this.assetID) return
     if (this.progressed && this.funded) return
     this.reportProgress(wallet.synced, wallet.syncProgress)
-    this.reportBalance(wallet.balance)
+    this.reportBalance(wallet.balance, wallet.assetID)
   }
 
   /*
    * reportBalance sets the balance display and calls success if we go over the
    * threshold.
    */
-  reportBalance (bal) {
-    if (this.funded || this.assetID === -1) return
+  reportBalance (bal, assetID) {
+    if (this.funded || this.assetID === -1 || this.assetID !== assetID) return
     const page = this.page
     const asset = app().assets[this.assetID]
-    const fee = this.regFee
 
-    if (bal.available <= fee.amount) {
+    if (bal.available <= this.regFee.amount) {
       page.balance.textContent = Doc.formatCoinValue(bal.available, asset.info.unitinfo)
       return
     }
 
     Doc.show(page.balCheck)
-    Doc.hide(page.balUncheck, page.balanceBox)
+    Doc.hide(page.balUncheck, page.balanceBox, page.sendEnough)
     this.funded = true
+
     if (this.progressed) this.success()
   }
 

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -102,7 +102,7 @@ export default class RegistrationPage extends BasePage {
     if (app().user.authed) this.auth()
     this.notifiers = {
       walletstate: note => this.walletWaitForm.reportWalletState(note.wallet),
-      balance: note => this.walletWaitForm.reportBalance(note.balance)
+      balance: note => this.walletWaitForm.reportBalance(note.balance, note.assetID)
     }
   }
 

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -140,7 +140,7 @@ export default class SettingsPage extends BasePage {
 
     this.notifiers = {
       walletstate: note => this.walletWaitForm.reportWalletState(note.wallet),
-      balance: note => this.walletWaitForm.reportBalance(note.balance)
+      balance: note => this.walletWaitForm.reportBalance(note.balance, note.assetID)
     }
   }
 

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -412,6 +412,7 @@
     </div>
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
+    <span data-tmpl="sendEnough">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
@@ -412,6 +412,7 @@
     </div>
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
+    <span data-tmpl="sendEnough">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
@@ -412,6 +412,7 @@
     </div>
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
+    <span data-tmpl="sendEnough">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 


### PR DESCRIPTION
- ui: Add a line on the wallet wait form that displays
  an estimate for how much transaction fees are needed
  to register
- ui: Fix a bugs where balance updates for different assets
  were displayed on the wallet wait form, and one where
  if wallet was already synced when page loaded, but fee
  not yet paid, the confirm registration page would not load
- client/core: Add a function to the wallet interface that
  gets an estimate for the tx fee needed for registration

Closes #1396 