### PR TITLE
server/{market,asset}: token registration and balance checks

### DIFF
--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1063,6 +1063,7 @@ type Asset struct {
 	MaxFeeRate   uint64       `json:"maxfeerate"`
 	SwapSize     uint64       `json:"swapsize"`
 	SwapSizeBase uint64       `json:"swapsizebase"`
+	RedeemSize   uint64       `json:"redeemsize"`
 	SwapConf     uint16       `json:"swapconf"`
 	UnitInfo     dex.UnitInfo `json:"unitinfo"`
 }

--- a/server/asset/bch/bch.go
+++ b/server/asset/bch/bch.go
@@ -42,11 +42,12 @@ func (d *Driver) UnitInfo() dex.UnitInfo {
 }
 
 func init() {
-	asset.Register(assetName, &Driver{})
+	asset.Register(BipID, &Driver{})
 }
 
 const (
 	version   = 0
+	BipID     = 145
 	assetName = "bch"
 )
 

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -71,7 +71,7 @@ func (d *Driver) NewAddresser(xPub string, keyIndexer asset.KeyIndexer, network 
 }
 
 func init() {
-	asset.Register(assetName, &Driver{})
+	asset.Register(BipID, &Driver{})
 }
 
 var (
@@ -84,6 +84,7 @@ var (
 
 const (
 	version                  = 0
+	BipID                    = 0
 	assetName                = "btc"
 	immatureTransactionError = dex.ErrorKind("immature output")
 )

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -113,6 +113,13 @@ type AccountBalancer interface {
 	// etc. must be exactly the same order-to-order, since the address string
 	// is used as a key for various accounting operations throughout DEX.
 	ValidateSignature(addr string, pubkey, msg, sig []byte) error
+	// RedeemSize is the gas used for a single redemption.
+	RedeemSize() uint64
+}
+
+// TokenBacker is implemented by Backends that support degenerate tokens.
+type TokenBacker interface {
+	TokenBackend(assetID uint32, configPath string) (Backend, error)
 }
 
 // Coin represents a transaction input or output.

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -88,7 +88,7 @@ func (d *Driver) NewAddresser(xPub string, keyIndexer asset.KeyIndexer, network 
 }
 
 func init() {
-	asset.Register(assetName, &Driver{})
+	asset.Register(BipID, &Driver{})
 }
 
 var (
@@ -104,6 +104,7 @@ var (
 
 const (
 	version                  = 0
+	BipID                    = 42
 	assetName                = "dcr"
 	immatureTransactionError = dex.ErrorKind("immature output")
 )

--- a/server/asset/driver.go
+++ b/server/asset/driver.go
@@ -128,6 +128,9 @@ func RegisterToken(assetID uint32, drv TokenDriver) {
 	if _, exists := drivers[token.ParentID]; !exists {
 		panic(fmt.Sprintf("no parent (%d) registered for %s", token.ParentID, token.Name))
 	}
+	if drv.UnitInfo().Conventional.ConversionFactor == 0 {
+		panic(fmt.Sprintf("asset: TokenDriver registered with unit conversion factor = 0: %q", assetID))
+	}
 	children := childTokens[token.ParentID]
 	if children == nil {
 		children = make(map[uint32]*dex.Token, 1)

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -28,11 +28,12 @@ import (
 )
 
 func init() {
-	asset.Register(assetName, &Driver{})
+	asset.Register(BipID, &Driver{})
 }
 
 const (
 	version   = 0
+	BipID     = 60
 	assetName = "eth"
 	// The blockPollInterval is the delay between calls to bestBlockHash to
 	// check for new blocks.
@@ -412,6 +413,10 @@ func (eth *Backend) AccountBalance(addrStr string) (uint64, error) {
 		return 0, fmt.Errorf("accountBalance error: %w", err)
 	}
 	return dexeth.WeiToGweiUint64(bigBal)
+}
+
+func (eth *Backend) RedeemSize() uint64 {
+	return dexeth.VersionedGases[0].Redeem
 }
 
 // ValidateSignature checks that the pubkey is correct for the address and

--- a/server/asset/ltc/ltc.go
+++ b/server/asset/ltc/ltc.go
@@ -40,11 +40,12 @@ func (d *Driver) Version() uint32 {
 }
 
 func init() {
-	asset.Register(assetName, &Driver{})
+	asset.Register(BipID, &Driver{})
 }
 
 const (
 	version   = 0
+	BipID     = 2
 	assetName = "ltc"
 )
 

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -1640,7 +1640,7 @@ func checkSigS256(msg, sig []byte, pubKey *secp256k1.PublicKey) error {
 }
 
 func coinIDString(assetID uint32, coinID []byte) string {
-	s, err := asset.DecodeCoinID(dex.BipIDSymbol(assetID), coinID)
+	s, err := asset.DecodeCoinID(assetID, coinID)
 	if err != nil {
 		return "unparsed:" + hex.EncodeToString(coinID)
 	}

--- a/server/cmd/dexcoin/main.go
+++ b/server/cmd/dexcoin/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/server/asset"
 	_ "decred.org/dcrdex/server/asset/bch"
 	_ "decred.org/dcrdex/server/asset/btc"
@@ -28,12 +29,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	assetID, ok := dex.BipSymbolID(symbol)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "asset %s not known \n", symbol)
+		os.Exit(1)
+	}
+
 	coinID, err := hex.DecodeString(flag.Arg(0))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-	coinIDStr, err := asset.DecodeCoinID(symbol, coinID)
+	coinIDStr, err := asset.DecodeCoinID(assetID, coinID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/server/db/driver/pg/upgrades.go
+++ b/server/db/driver/pg/upgrades.go
@@ -104,10 +104,9 @@ func v2Upgrade(tx *sql.Tx) error {
 	}
 
 	unitInfo := func(assetID uint32) dex.UnitInfo {
-		symbol := dex.BipIDSymbol(assetID)
-		ui, err := asset.UnitInfo(symbol)
+		ui, err := asset.UnitInfo(assetID)
 		if err != nil {
-			log.Errorf("no unit info found for %q", symbol)
+			log.Errorf("no unit info found for %d (%q)", assetID, dex.BipIDSymbol(assetID))
 			ui.Conventional.ConversionFactor = 1e8
 		}
 		return ui

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -299,7 +299,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		symbol := strings.ToLower(assetConf.Symbol)
 
 		// Ensure the symbol is a recognized BIP44 symbol, and retrieve its ID.
-		ID, found := dex.BipSymbolID(symbol)
+		assetID, found := dex.BipSymbolID(symbol)
 		if !found {
 			return nil, fmt.Errorf("asset symbol %q unrecognized", assetConf.Symbol)
 		}
@@ -319,7 +319,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 			return nil, fmt.Errorf("max fee rate of 0 is invalid for asset %q", symbol)
 		}
 
-		assetIDs[i] = ID
+		assetIDs[i] = assetID
 	}
 
 	// Check each market's base lot size to see if any asset has different base

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -396,42 +396,59 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	assetLogger := cfg.LogBackend.Logger("ASSET")
 	txDataSources := make(map[uint32]auth.TxDataSource)
 	feeMgr := NewFeeManager()
-	for i, assetConf := range cfg.Assets {
+	addAsset := func(assetID uint32, assetConf *AssetConf) error {
 		symbol := strings.ToLower(assetConf.Symbol)
-		assetID := assetIDs[i]
 
-		assetVer, err := asset.Version(symbol)
+		assetVer, err := asset.Version(assetID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve asset %q version: %w", symbol, err)
+			return fmt.Errorf("failed to retrieve asset %q version: %w", symbol, err)
 		}
 
 		// Create a new asset backend. An asset driver with a name matching the
 		// asset symbol must be available.
 		log.Infof("Starting asset backend %q...", symbol)
 		logger := assetLogger.SubLogger(symbol)
-		be, err := asset.Setup(symbol, assetConf.ConfigPath, logger, cfg.Network)
-		if err != nil {
-			return nil, fmt.Errorf("failed to setup asset %q: %w", symbol, err)
+
+		isToken, parentID := asset.IsToken(assetID)
+		var be asset.Backend
+		if isToken {
+			parent, found := backedAssets[parentID]
+			if !found {
+				return fmt.Errorf("attempting to load token asset %d before parent %d", assetID, parentID)
+			}
+			backer, is := parent.Backend.(asset.TokenBacker)
+			if !is {
+				return fmt.Errorf("token %d parent %d is not a TokenBacker", assetID, parentID)
+			}
+			be, err = backer.TokenBackend(assetID, assetConf.ConfigPath)
+			if err != nil {
+				return fmt.Errorf("failed to setup token %q: %w", symbol, err)
+			}
+		} else {
+			be, err = asset.Setup(assetID, assetConf.ConfigPath, logger, cfg.Network)
+			if err != nil {
+				return fmt.Errorf("failed to setup asset %q: %w", symbol, err)
+			}
 		}
 
 		err = startSubSys(fmt.Sprintf("Asset[%s]", symbol), be)
 		if err != nil {
-			return nil, fmt.Errorf("failed to start asset %q: %w", symbol, err)
+			return fmt.Errorf("failed to start asset %q: %w", symbol, err)
 		}
 
 		if assetConf.RegFee > 0 {
 			// Make sure we can check on fee transactions.
 			fc, ok := be.(FeeCoiner)
 			if !ok {
-				return nil, fmt.Errorf("asset %v is not a FeeCoiner", symbol)
+				return fmt.Errorf("asset %v is not a FeeCoiner", symbol)
 			}
 			// Make sure we can derive addresses from an extended public key.
-			addresser, startChild, err := asset.NewAddresser(symbol, assetConf.RegXPub, storage, cfg.Network)
+			addresser, startChild, err := asset.NewAddresser(assetID, assetConf.RegXPub, storage, cfg.Network)
 			if err != nil {
-				return nil, fmt.Errorf("failed to create fee addresser for asset %v: %w", symbol, err)
+				return fmt.Errorf("failed to create fee addresser for asset %v: %w", symbol, err)
 			}
 			if other := xpubs[assetConf.RegXPub]; other != "" {
-				return nil, fmt.Errorf("reused xpub for assets %v and %v forbidden", other, symbol)
+				return fmt.Errorf("reused xpub for assets %v and %v forbidden", other, symbol)
 			}
 			xpubs[assetConf.RegXPub] = symbol
 			feeAssets[symbol] = &msgjson.FeeAsset{
@@ -445,9 +462,19 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 				symbol, assetConf.RegFee, assetConf.RegConfs, startChild)
 		}
 
-		unitInfo, err := asset.UnitInfo(symbol)
+		unitInfo, err := asset.UnitInfo(assetID)
 		if err != nil {
-			return nil, err
+			return err
+		}
+
+		var redeemSize uint64
+		var coinLocker coinlock.CoinLocker
+
+		accountBalancer, isAccountRedeemer := be.(asset.AccountBalancer)
+		if isAccountRedeemer {
+			redeemSize = accountBalancer.RedeemSize()
+		} else {
+			coinLocker = dexCoinLocker.AssetLocker(assetID).Swap()
 		}
 
 		initTxSize := uint64(be.InitTxSize())
@@ -460,6 +487,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 				MaxFeeRate:   assetConf.MaxFeeRate,
 				SwapSize:     initTxSize,
 				SwapSizeBase: initTxSizeBase,
+				RedeemSize:   redeemSize,
 				SwapConf:     assetConf.SwapConf,
 				UnitInfo:     unitInfo,
 			},
@@ -469,7 +497,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		backedAssets[assetID] = ba
 		lockableAssets[assetID] = &swap.SwapperAsset{
 			BackedAsset: ba,
-			Locker:      dexCoinLocker.AssetLocker(assetID).Swap(),
+			Locker:      coinLocker,
 		}
 		feeMgr.AddFetcher(ba)
 
@@ -483,11 +511,33 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 			MaxFeeRate:   assetConf.MaxFeeRate,
 			SwapSize:     initTxSize,
 			SwapSizeBase: initTxSizeBase,
+			RedeemSize:   redeemSize,
 			SwapConf:     uint16(assetConf.SwapConf),
 			UnitInfo:     unitInfo,
 		})
 
 		txDataSources[assetID] = be.TxData
+		return nil
+	}
+
+	// Add base chain assets before tokens.
+	tokens := make(map[uint32]*AssetConf)
+
+	for i, assetConf := range cfg.Assets {
+		assetID := assetIDs[i]
+		if isToken, _ := asset.IsToken(assetID); isToken {
+			tokens[assetID] = assetConf
+			continue
+		}
+		if err := addAsset(assetID, assetConf); err != nil {
+			return nil, err
+		}
+	}
+
+	for assetID, assetConf := range tokens {
+		if err := addAsset(assetID, assetConf); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, mkt := range cfg.Markets {
@@ -605,7 +655,11 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	// marketTunnels map.
 	marketTunnels := make(map[string]market.MarketTunnel, len(cfg.Markets))
 	pendingAccounters := make(map[string]market.PendingAccounter, len(cfg.Markets))
-	dexBalancer := market.NewDEXBalancer(pendingAccounters, backedAssets, swapper)
+
+	dexBalancer, err := market.NewDEXBalancer(pendingAccounters, backedAssets, swapper)
+	if err != nil {
+		return nil, fmt.Errorf("NewDEXBalancer error: %w", err)
+	}
 
 	// Markets
 	usersWithOrders := make(map[account.AccountID]struct{})

--- a/server/market/balancer.go
+++ b/server/market/balancer.go
@@ -4,6 +4,8 @@
 package market
 
 import (
+	"fmt"
+
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
 	"decred.org/dcrdex/server/asset"
@@ -16,6 +18,10 @@ type PendingAccounter interface {
 	// the asset, as well as the number of possible pending redemptions
 	// (a.k.a. ordered lots).
 	AccountPending(acctAddr string, assetID uint32) (qty, lots uint64, redeems int)
+	// Base is the base asset ID.
+	Base() uint32
+	// Quote is the quote asset ID.
+	Quote() uint32
 }
 
 // MatchNegotiator can view match-reserved funds for an account-based asset's
@@ -33,7 +39,6 @@ type MatchNegotiator interface {
 // for the balance required to fulfill new + existing orders and outstanding
 // redemptions.
 type DEXBalancer struct {
-	tunnels         map[string]PendingAccounter
 	assets          map[uint32]*backedBalancer
 	matchNegotiator MatchNegotiator
 }
@@ -41,24 +46,81 @@ type DEXBalancer struct {
 // NewDEXBalancer is a constructor for a DEXBalancer. Provided assets will
 // be filtered for those that are account-based. The matchNegotiator is
 // satisfied by the *Swapper.
-func NewDEXBalancer(tunnels map[string]PendingAccounter, assets map[uint32]*asset.BackedAsset, matchNegotiator MatchNegotiator) *DEXBalancer {
+func NewDEXBalancer(tunnels map[string]PendingAccounter, assets map[uint32]*asset.BackedAsset, matchNegotiator MatchNegotiator) (*DEXBalancer, error) {
 	balancers := make(map[uint32]*backedBalancer)
-	for assetID, ba := range assets {
+
+	addAsset := func(ba *asset.BackedAsset) error {
+		assetID := ba.ID
 		balancer, is := ba.Backend.(asset.AccountBalancer)
 		if !is {
-			continue
+			return nil
 		}
-		balancers[assetID] = &backedBalancer{
+
+		var markets []PendingAccounter
+		for _, mkt := range tunnels {
+			if mkt.Base() == assetID || mkt.Quote() == assetID {
+				markets = append(markets, mkt)
+			}
+		}
+
+		bb := &backedBalancer{
 			balancer:  balancer,
 			assetInfo: &ba.Asset,
+			feeFamily: make(map[uint32]*dex.Asset),
+			markets:   markets,
+		}
+		balancers[assetID] = bb
+
+		isToken, parentID := asset.IsToken(assetID)
+		if isToken {
+			parent, found := balancers[parentID]
+			if !found {
+				return fmt.Errorf("%s parent asset %d(%s)", ba.Symbol, parentID, dex.BipIDSymbol(parentID))
+			}
+			bb.feeFamily[parentID] = parent.assetInfo
+			for tokenID := range asset.Tokens(parentID) {
+				if tokenID == assetID { // Don't double count
+					continue
+				}
+				bb.feeFamily[tokenID] = &assets[tokenID].Asset
+			}
+			bb.feeBalancer = parent
+		} else {
+			for tokenID := range asset.Tokens(assetID) {
+				if familyAsset, found := assets[tokenID]; found {
+					if _, is := familyAsset.Backend.(asset.AccountBalancer); !is {
+						return fmt.Errorf("fee-family asset %s is not an AccountBalancer", familyAsset.Symbol)
+					}
+					bb.feeFamily[tokenID] = &familyAsset.Asset
+				}
+			}
+		}
+		return nil
+	}
+
+	// Add base chain assets first, then tokens.
+	tokens := make([]*asset.BackedAsset, 0)
+
+	for assetID, ba := range assets {
+		if isToken, _ := asset.IsToken(assetID); isToken {
+			tokens = append(tokens, ba)
+			continue
+		}
+		if err := addAsset(ba); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, ba := range tokens {
+		if err := addAsset(ba); err != nil {
+			return nil, err
 		}
 	}
 
 	return &DEXBalancer{
-		tunnels:         tunnels,
 		assets:          balancers,
 		matchNegotiator: matchNegotiator,
-	}
+	}, nil
 }
 
 // CheckBalance checks if there is sufficient balance to support the specified
@@ -67,7 +129,7 @@ func NewDEXBalancer(tunnels map[string]PendingAccounter, assets map[uint32]*asse
 // asset. It is an internally logged error to call CheckBalance for a
 // non-account-based asset or an asset that is was not provided to the
 // constructor.
-func (b *DEXBalancer) CheckBalance(acctAddr string, assetID uint32, qty, lots uint64, redeems int) bool {
+func (b *DEXBalancer) CheckBalance(acctAddr string, assetID, redeemAssetID uint32, qty, lots uint64, redeems int) bool {
 	backedAsset, found := b.assets[assetID]
 	if !found {
 		log.Errorf("(*DEXBalancer).CheckBalance: asset ID %d not a configured backedBalancer", assetID)
@@ -77,36 +139,113 @@ func (b *DEXBalancer) CheckBalance(acctAddr string, assetID uint32, qty, lots ui
 	log.Tracef("balance check for %s - %s: new qty = %d, new lots = %d, new redeems = %d",
 		backedAsset.assetInfo.Symbol, acctAddr, qty, lots, redeems)
 
+	// Make sure we can get the primary balance first.
 	bal, err := backedAsset.balancer.AccountBalance(acctAddr)
 	if err != nil {
 		log.Error("(*DEXBalancer).CheckBalance: error getting account balance for %q: %v", acctAddr, err)
 		return false
 	}
-
-	// Add quantity for unfilled orders.
-	for _, mt := range b.tunnels {
-		newQty, newLots, newRedeems := mt.AccountPending(acctAddr, assetID)
-		lots += newLots
-		qty += newQty
-		redeems += newRedeems
+	if bal == 0 {
+		log.Tracef("(*DEXBalancer).CheckBalance(%q, %d, %d, %d, %d) false for zero balance",
+			acctAddr, assetID, qty, lots, redeems)
+		return false
 	}
 
-	// Add in-process swaps.
-	newQty, newLots, newRedeems := b.matchNegotiator.AccountStats(acctAddr, assetID)
-	lots += newLots
-	qty += newQty
-	redeems += newRedeems
+	// Set up fee tracking for tokens.
+	var feeID uint32 // Asset ID of the base chain asset.
+	// feeQty will track the fee asset order-locked quantity, but is only used
+	// for tokens. When not a token (when assetID = base chain), the
+	// order-locked quantity is summed in reqFunds as for any other asset. We'll
+	// fetch feeBal to catch any zero bals or other errors early before
+	// iterating markets and querying the Swapper.
+	var feeQty, feeBal uint64 // Current balance.
+	feeBalancer := backedAsset.feeBalancer
+	isToken := feeBalancer != nil
+	if isToken {
+		feeID = feeBalancer.assetInfo.ID
+		feeBal, err = feeBalancer.balancer.AccountBalance(acctAddr)
+		if err != nil {
+			log.Error("(*DEXBalancer).CheckBalance: error getting fee asset balance for %q: %v", acctAddr, err)
+			return false
+		}
+		if feeBal == 0 {
+			log.Tracef("(*DEXBalancer).CheckBalance(%q, %d, %d, %d, %d) false for zero fee asset (%s) balance",
+				acctAddr, assetID, qty, lots, redeems, feeBalancer.assetInfo.Symbol)
+			return false
+		}
+	}
 
-	assetInfo := backedAsset.assetInfo
-	// The fee rate assigned to redemptions is at the discretion of the user.
-	// MaxFeeRate is used as a conservatively high estimate. This is then a
-	// server policy that clients must satisfy.
-	redeemCosts := uint64(redeems) * assetInfo.RedeemSize * assetInfo.MaxFeeRate
-	reqFunds := calc.RequiredOrderFunds(qty, 0, lots, assetInfo) + redeemCosts
+	var swapFees, redeemFees uint64
+	addFees := func(assetInfo *dex.Asset, l uint64, r int) {
+		// The fee rate assigned to redemptions is at the discretion of the
+		// user. MaxFeeRate is used as a conservatively high estimate. This is
+		// then a server policy that clients must satisfy.
+		redeemFees += uint64(r) * assetInfo.RedeemSize * assetInfo.MaxFeeRate
+		swapFees += calc.RequiredOrderFunds(0, 0, l, assetInfo) // Alt: assetInfo.SwapSize * l
+	}
+
+	// Add the fees for the requested lots.
+	addFees(backedAsset.assetInfo, lots, redeems)
+
+	// Prepare a function to add fees pending orders for the asset and each
+	// asset in the fee-family.
+	addPending := func(assetID uint32) (q uint64) {
+		ba, found := b.assets[assetID]
+		if !found {
+			log.Errorf("(*DEXBalancer).CheckBalance: asset ID %d not a configured backedBalancer", assetID)
+			return 0
+		}
+
+		var l uint64
+		var r int
+		for _, mt := range ba.markets {
+			newQty, newLots, newRedeems := mt.AccountPending(acctAddr, assetID)
+			l += newLots
+			q += newQty
+			r += newRedeems
+		}
+
+		// Add in-process swaps.
+		newQty, newLots, newRedeems := b.matchNegotiator.AccountStats(acctAddr, assetID)
+		l += newLots
+		q += newQty
+		r += newRedeems
+
+		addFees(ba.assetInfo, l, r)
+		return
+	}
+
+	qty += addPending(assetID)
+
+	// Add fee-family asset pending fees.
+	for famID := range backedAsset.feeFamily {
+		if q := addPending(famID); isToken && famID == feeID {
+			// Add the quantity of the base chain order reserves to our fee
+			// asset balance check.
+			feeQty = q
+		}
+	}
+
+	// Add redeems if we're redeeming this to a fee-family asset.
+	if redeemAsset, found := backedAsset.feeFamily[redeemAssetID]; found {
+		redeemFees += redeemAsset.RedeemSize * redeemAsset.MaxFeeRate * lots
+	}
+
+	reqFunds := qty
+	if isToken { // Check sufficient fee asset balance for tokens.
+		reqFeeAssetQty := swapFees + redeemFees + feeQty
+		if feeBal < reqFeeAssetQty {
+			log.Tracef("(*DEXBalancer).CheckBalance(%q, %d, %d, %d, %d) false for low fee asset balance. %d < %d",
+				acctAddr, assetID, qty, lots, redeems, feeBal, reqFeeAssetQty)
+			return false
+		}
+	} else { // Add fees to main qty for base chain assets.
+		reqFunds += redeemFees + swapFees
+	}
 
 	log.Tracef("(*DEXBalancer).CheckBalance: balance check for %s - %s: total qty = %d, "+
 		"total lots = %d, total redeems = %d, redeemCosts = %d, required = %d, bal = %d",
-		backedAsset.assetInfo.Symbol, acctAddr, qty, lots, redeems, redeemCosts, reqFunds, bal)
+		backedAsset.assetInfo.Symbol, acctAddr, qty, lots, redeems, redeemFees, reqFunds, bal)
 
 	return bal >= reqFunds
 }
@@ -114,6 +253,9 @@ func (b *DEXBalancer) CheckBalance(acctAddr string, assetID uint32, qty, lots ui
 // backedBalancer is similar to a BackedAsset, but with the Backends already
 // cast to AccountBalancer.
 type backedBalancer struct {
-	balancer  asset.AccountBalancer
-	assetInfo *dex.Asset
+	balancer    asset.AccountBalancer
+	assetInfo   *dex.Asset
+	feeBalancer *backedBalancer       // feeBalancer != nil implies that this is a token
+	feeFamily   map[uint32]*dex.Asset // Excluding self
+	markets     []PendingAccounter
 }

--- a/server/market/balancer_test.go
+++ b/server/market/balancer_test.go
@@ -6,111 +6,293 @@ package market
 import (
 	"testing"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
 )
 
 func TestBalancer(t *testing.T) {
 	const lotSize = 1e10
-	const assetID = 123
-	assetInfo := &assetETH.Asset
-	perRedeemCost := assetInfo.RedeemSize * assetInfo.MaxFeeRate
 
-	swapper := &tMatchNegotiator{}
-	tunnel := &TMarketTunnel{}
-	backend := &tAccountBackend{}
+	swapper := tNewMatchNegotiator()
+
+	ethTunnel := &TMarketTunnel{base: assetETH.ID}
+	ethBackend := &tAccountBackend{}
+	ethRedeemCost := assetETH.RedeemSize * assetETH.MaxFeeRate
+
+	tokenTunnel := &TMarketTunnel{quote: assetToken.ID}
+	tokenBackend := &tAccountBackend{}
+	// tokenRedeemCost := assetToken.RedeemSize * assetToken.MaxFeeRate
+
+	ethBalancer := &backedBalancer{
+		balancer:  ethBackend,
+		assetInfo: &assetETH.Asset,
+		markets: []PendingAccounter{
+			ethTunnel,
+		},
+		feeFamily: map[uint32]*dex.Asset{
+			assetToken.ID: &assetToken.Asset,
+		},
+	}
 
 	balancer := &DEXBalancer{
-		tunnels: map[string]PendingAccounter{
-			"abc_xyz": tunnel,
-		},
 		assets: map[uint32]*backedBalancer{
-			assetID: {
-				balancer:  backend,
-				assetInfo: assetInfo,
+			assetETH.ID: ethBalancer,
+			assetToken.ID: {
+				balancer:  tokenBackend,
+				assetInfo: &assetToken.Asset,
+				markets: []PendingAccounter{
+					tokenTunnel,
+				},
+				feeBalancer: ethBalancer,
+				feeFamily: map[uint32]*dex.Asset{
+					assetETH.ID: &assetETH.Asset,
+				},
 			},
 		},
 		matchNegotiator: swapper,
 	}
+
+	ethNineFive := calc.RequiredOrderFunds(lotSize*9, 0, 9, &assetETH.Asset) + ethRedeemCost*5
 
 	type qlr struct {
 		qty, lots uint64
 		redeems   int
 	}
 
-	type test struct {
-		name    string
-		pass    bool
+	type assetParams struct {
 		bal     uint64
 		new     qlr
 		mkt     qlr
 		swapper qlr
 	}
 
+	type test struct {
+		name     string
+		pass     bool
+		eth      assetParams
+		token    assetParams
+		useToken bool
+		redeemID uint32
+	}
+
 	tests := []*test{
 		{
 			name: "no existing - 1 new lot - pass",
-			new:  qlr{lotSize, 1, 0},
-			bal:  calc.RequiredOrderFunds(lotSize, 0, 1, assetInfo),
+			eth: assetParams{
+				new: qlr{lotSize, 1, 0},
+				bal: calc.RequiredOrderFunds(lotSize, 0, 1, &assetETH.Asset),
+			},
 			pass: true,
 		}, {
 			name: "no existing - 1 new lot - fail",
-			new:  qlr{lotSize, 1, 0},
-			bal:  calc.RequiredOrderFunds(lotSize, 0, 1, assetInfo) - 1,
+			eth: assetParams{
+				new: qlr{lotSize, 1, 0},
+				bal: calc.RequiredOrderFunds(lotSize, 0, 1, &assetETH.Asset) - 1,
+			},
 		}, {
 			name: "no existing - 1 new redeem - pass",
-			new:  qlr{0, 0, 1},
-			bal:  perRedeemCost,
+			eth: assetParams{
+				new: qlr{0, 0, 1},
+				bal: ethRedeemCost,
+			},
 			pass: true,
 		}, {
 			name: "no existing - 1 new redeem - fail",
-			new:  qlr{0, 0, 1},
-			bal:  perRedeemCost - 1,
+			eth: assetParams{
+				new: qlr{0, 0, 1},
+				bal: ethRedeemCost - 1,
+			},
 		}, {
-			name:    "1 each swapper - 1 new lot - pass",
-			new:     qlr{lotSize, 1, 0},
-			swapper: qlr{lotSize, 1, 1},
-			bal:     calc.RequiredOrderFunds(lotSize*2, 0, 2, assetInfo) + perRedeemCost,
-			pass:    true,
+			name: "1 each swapper - 1 new lot - pass",
+			eth: assetParams{
+				new:     qlr{lotSize, 1, 0},
+				swapper: qlr{lotSize, 1, 1},
+				bal:     calc.RequiredOrderFunds(lotSize*2, 0, 2, &assetETH.Asset) + ethRedeemCost,
+			},
+			pass: true,
 		}, {
 			name: "1 each market - 1 new lot - pass",
-			new:  qlr{lotSize, 1, 0},
-			mkt:  qlr{lotSize, 1, 1},
-			bal:  calc.RequiredOrderFunds(lotSize*2, 0, 2, assetInfo) + perRedeemCost,
+			eth: assetParams{
+				new: qlr{lotSize, 1, 0},
+				mkt: qlr{lotSize, 1, 1},
+				bal: calc.RequiredOrderFunds(lotSize*2, 0, 2, &assetETH.Asset) + ethRedeemCost,
+			},
 			pass: true,
 		},
 		{
 			name: "1 each market - 1 new lot - fail",
-			new:  qlr{lotSize, 1, 0},
-			mkt:  qlr{lotSize, 1, 1},
-			bal:  calc.RequiredOrderFunds(lotSize*2, 0, 2, assetInfo) + perRedeemCost - 1,
+			eth: assetParams{
+				new: qlr{lotSize, 1, 0},
+				mkt: qlr{lotSize, 1, 1},
+				bal: calc.RequiredOrderFunds(lotSize*2, 0, 2, &assetETH.Asset) + ethRedeemCost - 1,
+			},
 		},
 		{
-			name:    "mix it up - pass",
-			new:     qlr{lotSize * 2, 2, 0},
-			mkt:     qlr{lotSize * 3, 3, 2},
-			swapper: qlr{lotSize * 4, 4, 3},
-			bal:     calc.RequiredOrderFunds(lotSize*9, 0, 9, assetInfo) + perRedeemCost*5,
-			pass:    true,
+			name: "mix it up - pass",
+			eth: assetParams{
+				new:     qlr{lotSize * 2, 2, 0},
+				mkt:     qlr{lotSize * 3, 3, 2},
+				swapper: qlr{lotSize * 4, 4, 3},
+				bal:     ethNineFive,
+			},
+			pass: true,
 		},
 		{
-			name:    "mix it up - fail",
-			new:     qlr{lotSize * 2, 2, 0},
-			mkt:     qlr{lotSize * 3, 3, 2},
-			swapper: qlr{lotSize * 4, 4, 3},
-			bal:     calc.RequiredOrderFunds(lotSize*9, 0, 9, assetInfo) + perRedeemCost*5 - 1,
+			name: "mix it up - fail",
+			eth: assetParams{
+				new:     qlr{lotSize * 2, 2, 0},
+				mkt:     qlr{lotSize * 3, 3, 2},
+				swapper: qlr{lotSize * 4, 4, 3},
+				bal:     ethNineFive - 1,
+			},
+		},
+		{
+			name: "mix it up - with tokens - pass",
+			eth: assetParams{
+				new:     qlr{lotSize * 2, 2, 0},
+				mkt:     qlr{lotSize * 3, 3, 2},
+				swapper: qlr{lotSize * 4, 4, 3},
+				bal:     ethNineFive + assetToken.MaxFeeRate*(assetToken.SwapSize+assetToken.RedeemSize),
+			},
+			token: assetParams{
+				mkt: qlr{lotSize * 5000, 1, 1}, // qty doesn't shouldn't matter.
+			},
+			pass: true,
+		},
+		{
+			name: "mix it up - with tokens - fail",
+			eth: assetParams{
+				new:     qlr{lotSize * 2, 2, 0},
+				mkt:     qlr{lotSize * 3, 3, 2},
+				swapper: qlr{lotSize * 4, 4, 3},
+				bal:     ethNineFive + assetToken.MaxFeeRate*(assetToken.SwapSize+assetToken.RedeemSize) - 1,
+			},
+			token: assetParams{
+				mkt: qlr{lotSize * 5000, 1, 1},
+			},
+		}, {
+			name:     "1 new lot token - pass",
+			useToken: true,
+			token: assetParams{
+				new: qlr{lotSize, 1, 0},
+				bal: lotSize,
+			},
+			eth: assetParams{
+				bal: assetToken.SwapSize * assetToken.MaxFeeRate,
+			},
+			pass: true,
+		}, {
+			name:     "1 new lot token - fail insufficient fees",
+			useToken: true,
+			token: assetParams{
+				new: qlr{lotSize, 1, 0},
+				bal: lotSize,
+			},
+			eth: assetParams{
+				bal: assetToken.SwapSize*assetToken.MaxFeeRate - 1,
+			},
+		}, {
+			name:     "1 new lot token - fail insufficient balance",
+			useToken: true,
+			token: assetParams{
+				new: qlr{lotSize, 1, 0},
+				bal: lotSize - 1,
+			},
+			eth: assetParams{
+				bal: assetToken.SwapSize * assetToken.MaxFeeRate,
+			},
+		}, {
+			name:     "1 new lot token - family redeem - pass",
+			useToken: true,
+			token: assetParams{
+				new: qlr{lotSize, 1, 0},
+				bal: lotSize,
+			},
+			eth: assetParams{
+				bal: assetToken.SwapSize*assetToken.MaxFeeRate + assetETH.RedeemSize*assetETH.MaxFeeRate,
+			},
+			redeemID: assetETH.ID,
+			pass:     true,
+		}, {
+			name:     "1 new lot token - family redeem - fail insufficient fees",
+			useToken: true,
+			token: assetParams{
+				new: qlr{2 * lotSize, 1, 0},
+				bal: lotSize,
+			},
+			eth: assetParams{
+				bal: assetToken.SwapSize*assetToken.MaxFeeRate + assetETH.RedeemSize*assetETH.MaxFeeRate - 1,
+			},
+			redeemID: assetETH.ID,
+		}, {
+			name:     "2 new lot token - family redeem + 2 pending token redeems - pass",
+			useToken: true,
+			token: assetParams{
+				new: qlr{2 * lotSize, 2, 0},
+				mkt: qlr{0, 0, 2},
+				bal: 2 * lotSize,
+			},
+			eth: assetParams{
+				bal: 2*(assetToken.SwapSize*assetToken.MaxFeeRate+assetETH.RedeemSize*assetETH.MaxFeeRate) +
+					2*assetToken.RedeemSize*assetToken.MaxFeeRate,
+			},
+			redeemID: assetETH.ID,
+			pass:     true,
+		}, {
+			name:     "2 new lot token - family redeem + 2 pending token redeems - fail insufficient fees",
+			useToken: true,
+			token: assetParams{
+				new: qlr{2 * lotSize, 2, 0},
+				mkt: qlr{0, 0, 2},
+				bal: 2 * lotSize,
+			},
+			eth: assetParams{
+				bal: 2*(assetToken.SwapSize*assetToken.MaxFeeRate+assetETH.RedeemSize*assetETH.MaxFeeRate) +
+					2*assetToken.RedeemSize*assetToken.MaxFeeRate - 1,
+			},
+			redeemID: assetETH.ID,
+		},
+		{
+			name:     "2 new lot token - family redeem + 2 pending token redeems - fail insufficient balance",
+			useToken: true,
+			token: assetParams{
+				new: qlr{2 * lotSize, 2, 0},
+				mkt: qlr{0, 0, 2},
+				bal: 2*lotSize - 1,
+			},
+			eth: assetParams{
+				bal: 2*(assetToken.SwapSize*assetToken.MaxFeeRate+assetETH.RedeemSize*assetETH.MaxFeeRate) +
+					2*assetToken.RedeemSize*assetToken.MaxFeeRate,
+			},
+			redeemID: assetETH.ID,
 		},
 	}
 
 	for _, tt := range tests {
-		tunnel.acctLots = tt.mkt.lots
-		tunnel.acctQty = tt.mkt.qty
-		tunnel.acctRedeems = tt.mkt.redeems
-		swapper.swaps = tt.swapper.lots
-		swapper.qty = tt.swapper.qty
-		swapper.redeems = tt.swapper.redeems
-		backend.bal = tt.bal
+		ethTunnel.acctLots = tt.eth.mkt.lots
+		ethTunnel.acctQty = tt.eth.mkt.qty
+		ethTunnel.acctRedeems = tt.eth.mkt.redeems
+		swapper.swaps[assetETH.ID] = tt.eth.swapper.lots
+		swapper.qty[assetETH.ID] = tt.eth.swapper.qty
+		swapper.redeems[assetETH.ID] = tt.eth.swapper.redeems
+		ethBackend.bal = tt.eth.bal
 
-		if balancer.CheckBalance("a", assetID, tt.new.qty, tt.new.lots, tt.new.redeems) != tt.pass {
+		tokenTunnel.acctLots = tt.token.mkt.lots
+		tokenTunnel.acctQty = tt.token.mkt.qty
+		tokenTunnel.acctRedeems = tt.token.mkt.redeems
+		swapper.swaps[assetToken.ID] = tt.token.swapper.lots
+		swapper.qty[assetToken.ID] = tt.token.swapper.qty
+		swapper.redeems[assetToken.ID] = tt.token.swapper.redeems
+		tokenBackend.bal = tt.token.bal
+
+		assetID := assetETH.ID
+		newQLR := tt.eth.new
+		if tt.useToken {
+			assetID = assetToken.ID
+			newQLR = tt.token.new
+		}
+
+		if balancer.CheckBalance("a", assetID, tt.redeemID, newQLR.qty, newQLR.lots, newQLR.redeems) != tt.pass {
 			t.Fatalf("%s: expected %t, got %t", tt.name, tt.pass, !tt.pass)
 		}
 	}

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -253,7 +253,7 @@ func newTBalancer() *tBalancer {
 	return &tBalancer{make(map[string]int)}
 }
 
-func (b *tBalancer) CheckBalance(acctAddr string, assetID uint32, qty, lots uint64, redeems int) bool {
+func (b *tBalancer) CheckBalance(acctAddr string, assetID, redeemAssetID uint32, qty, lots uint64, redeems int) bool {
 	b.reqs[acctAddr]++
 	return true
 }

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -421,7 +421,7 @@ func (r *OrderRouter) processTrade(oRecord *orderRecord, tunnel MarketTunnel, as
 			return msgjson.NewError(msgjson.SignatureError, "redeem signature validation failed")
 		}
 
-		if !r.sufficientAccountBalance(acctAddr, oRecord.order, &assets.receiving.Asset, assets.funding.ID, tunnel) {
+		if !r.sufficientAccountBalance(acctAddr, oRecord.order, &assets.receiving.Asset, assets.receiving.ID, tunnel) {
 			return msgjson.NewError(msgjson.FundingError, "insufficient balance")
 		}
 	}

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -468,12 +468,18 @@ type TAccountBackend struct {
 	TBackend
 }
 
+var _ asset.AccountBalancer = (*TAccountBackend)(nil)
+
 func (b *TAccountBackend) AccountBalance(addr string) (uint64, error) {
 	return 0, nil
 }
 
 func (b *TAccountBackend) ValidateSignature(addr string, pubkey, msg, sig []byte) error {
 	return nil
+}
+
+func (b *TAccountBackend) RedeemSize() uint64 {
+	return 21_000
 }
 
 // This stub satisfies asset.Transaction, used by asset.Backend.


### PR DESCRIPTION
```
Add RegisterToken method for token registration. The asset package
keeps a map of tokens as well as the token "fee families", e.g. all
tokens of a base chain asset.

DEXBalancer.CheckBalance reworked to account for fee-family assets.
```