### PR TITLE
client/asset/dcr: suppress harmless coin-not-found errors with SPV

### DIFF
--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -957,6 +957,8 @@ func (w *spvWallet) swapConfirmations(txHash *chainhash.Hash, vout uint32, pkScr
 		if assumedMempool {
 			w.log.Tracef("swapConfirmations - scanFilters did not find %v:%d, assuming in mempool.",
 				txHash, vout)
+			// NOT asset.CoinNotFoundError since this is normal for mempool
+			// transactions with an SPV wallet.
 			return 0, false, nil
 		}
 		return 0, false, fmt.Errorf("output %s:%v not found with search parameters startTime = %s, pkScript = %x",

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1862,14 +1862,14 @@ func (dcr *ExchangeWallet) lookupTxOutput(ctx context.Context, txHash *chainhash
 	output, err := dcr.wallet.UnspentOutput(ctx, txHash, vout, wire.TxTreeUnknown)
 	if err == nil {
 		return output.TxOut, output.Confirmations, false, nil
-	} else if err != asset.CoinNotFoundError {
+	} else if !errors.Is(err, asset.CoinNotFoundError) {
 		return nil, 0, false, err
 	}
 
 	// Check wallet transactions.
 	tx, err := dcr.wallet.GetTransaction(ctx, txHash)
 	if err != nil {
-		return nil, 0, false, err
+		return nil, 0, false, err // asset.CoinNotFoundError if not found
 	}
 	msgTx, err := msgTxFromHex(tx.Hex)
 	if err != nil {
@@ -2538,8 +2538,10 @@ func (dcr *ExchangeWallet) ValidateSecret(secret, secretHash []byte) bool {
 // the specified swap. The contract and matchTime are provided so that wallets
 // may search for the coin using light filters.
 //
-// If the swap was not funded by this wallet, and it is already spent, this
-// method may return asset.CoinNotFoundError. Compare dcr.externalTxOut.
+// For a non-SPV wallet, if the swap appears spent but it cannot be located in a
+// block with a cfilters scan, this will return asset.CoinNotFoundError. For SPV
+// wallets, it is not an error if the transaction cannot be located SPV wallets
+// cannot see non-wallet transactions until they are mined.
 //
 // If the coin is located, but recognized as spent, no error is returned.
 func (dcr *ExchangeWallet) SwapConfirmations(ctx context.Context, coinID, contract dex.Bytes, matchTime time.Time) (confs uint32, spent bool, err error) {
@@ -2552,7 +2554,7 @@ func (dcr *ExchangeWallet) SwapConfirmations(ctx context.Context, coinID, contra
 	_, confs, spent, err = dcr.lookupTxOutput(ctx, txHash, vout)
 	if err == nil {
 		return confs, spent, nil
-	} else if err != asset.CoinNotFoundError {
+	} else if !errors.Is(err, asset.CoinNotFoundError) {
 		return 0, false, err
 	}
 
@@ -2563,9 +2565,17 @@ func (dcr *ExchangeWallet) SwapConfirmations(ctx context.Context, coinID, contra
 	}
 	_, p2shScript := scriptAddr.PaymentScript()
 
-	// Find the contract and it's spend status using block filters.
+	// Find the contract and its spend status using block filters.
 	dcr.log.Debugf("Contract output %s:%d NOT yet found, will attempt finding it with block filters.", txHash, vout)
-	return dcr.lookupTxOutWithBlockFilters(ctx, newOutPoint(txHash, vout), p2shScript, matchTime)
+	confs, spent, err = dcr.lookupTxOutWithBlockFilters(ctx, newOutPoint(txHash, vout), p2shScript, matchTime)
+	// Don't trouble the caller if we're using an SPV wallet and the transaction
+	// cannot be located.
+	if errors.Is(err, asset.CoinNotFoundError) && dcr.wallet.SpvMode() {
+		dcr.log.Debugf("SwapConfirmations - cfilters scan did not find %v:%d. "+
+			"Assuming in mempool.", txHash, vout)
+		err = nil
+	}
+	return confs, spent, err
 }
 
 // RegFeeConfirmations gets the number of confirmations for the specified
@@ -3225,7 +3235,7 @@ func (dcr *ExchangeWallet) isMainchainBlock(ctx context.Context, block *block) (
 	}
 	nextBlockHash, err := chainhash.NewHashFromStr(blockHeader.NextHash)
 	if err != nil {
-		return false, fmt.Errorf("block %s has invalid nexthash value %s: %v",
+		return false, fmt.Errorf("block %s has invalid nexthash value %s: %w",
 			block.hash, blockHeader.NextHash, err)
 	}
 	nextBlockHeader, err := dcr.wallet.GetBlockHeaderVerbose(ctx, nextBlockHash)


### PR DESCRIPTION
When using dcrwallet in SPV mode and trading with another party (not yourself), there are certain errors and warnings logged that are not of cause for concern.

Consider the following logs of a Buy DCR order where the counterparty is another wallet and thus the dcr ExchangeWallet takes a different path to getting confirmations and spend status of their swap transaction:

> 2022-01-11 15:11:15.432 [DBG] CORE[dcr]: Contract output c4aeefdaa9dae7ab66e909d7107480287d638501bca8550fc1d53f1107f055bd:0 NOT yet found, will attempt finding it with block filters.
> 2022-01-11 15:11:15.432 [DBG] CORE[dcr]: Searching for tx c4aeefdaa9dae7ab66e909d7107480287d638501bca8550fc1d53f1107f055bd in blocks between block 852084 (000000004e22a09d0970a087ac07865d1ddd3f696940585e1039b6dc5a823dc7) to the block just before 2022-01-11 15:11:00 +0000 UTC.
> 2022-01-11 15:11:15.432 [DBG] CORE[dcr]: Tx c4aeefdaa9dae7ab66e909d7107480287d638501bca8550fc1d53f1107f055bd NOT found in blocks 852084 (000000004e22a09d0970a087ac07865d1ddd3f696940585e1039b6dc5a823dc7) to 852083 (00000000df11307a13f705c69368fa170f7fd90c6f5b0f4f4f6c363d044788b5).
> 2022-01-11 15:11:15.432 [ERR] CORE: Failed to get confirmations of the counter-party's swap c4aeefdaa9dae7ab66e909d7107480287d638501bca8550fc1d53f1107f055bd:0 (dcr) for match b620b29c634a491766dfb30d4d8b94d5b3e72cedfffe9d6f4c2f9f120c2f3562, order bf036c088a79c864fd397e0b63f9b24d2003005f828e7b112d1c8f634a49f214: coin not found

In the above, the ERR is logged because `asset.CoinNotFoundError` is returned from `SwapConfirmations` even though it is expected not to find the counterparty swap with an SPV wallet.  The BTC spvWallet does not return this error for this reason.
Also, the blocks scanned are reversed from a logical <low> to <high> order.

After repeating the error above until the counterparty contract is mined, it then finds it with a cfilter scan:

> 2022-01-11 15:13:30.431 [DBG] CORE[dcr]: tip change: 852084 (000000004e22a09d0970a087ac07865d1ddd3f696940585e1039b6dc5a823dc7) => 852085 (00000000509750fa562844e724b86af4e14f3880bbf804fbb7db7df3d01cf254)
> 2022-01-11 15:13:30.431 [TRC] CORE: processing tip change for dcr
> 2022-01-11 15:13:30.431 [TRC] CORE: Checking confirmations on COUNTERPARTY swap txn c4aeefdaa9dae7ab66e909d7107480287d638501bca8550fc1d53f1107f055bd:0 (dcr)...
> 2022-01-11 15:13:30.431 [DBG] CORE[dcr]: Contract output c4aeefdaa9dae7ab66e909d7107480287d638501bca8550fc1d53f1107f055bd:0 NOT yet found, will attempt finding it with block filters.
> 2022-01-11 15:13:30.432 [DBG] CORE[dcr]: Searching for tx c4aeefdaa9dae7ab66e909d7107480287d638501bca8550fc1d53f1107f055bd in blocks 852085 (00000000509750fa562844e724b86af4e14f3880bbf804fbb7db7df3d01cf254) to 852084 (000000004e22a09d0970a087ac07865d1ddd3f696940585e1039b6dc5a823dc7).
> 2022-01-11 15:13:30.439 [DBG] CORE[dcr]: Found mined tx c4aeefdaa9dae7ab66e909d7107480287d638501bca8550fc1d53f1107f055bd in block 852085 (00000000509750fa562844e724b86af4e14f3880bbf804fbb7db7df3d01cf254).
> 2022-01-11 15:13:30.439 [WRN] CORE[dcr]: Attempted to look for output spender in block 852086 but current tip is 852085

Here the WRN is unnecessary since it is expected to have already scanned the best block due to an optimization in `findTxInBlock` because it has the full block handy.

This addresses these cases with the following changes.

Do not return `asset.CoinNotFoundError` from `SwapConfirmations` with an SPV wallet since this is normal for mempool transactions in SPV.

For a non-SPV wallet, if the swap appears spent but it cannot be located in a block with a cfilters scan, this will return `asset.CoinNotFoundError`. For SPV wallets, it is not an error if the transaction cannot be located SPV wallets cannot see non-wallet transactions until they are mined.

Fix a few logs where arguments were ordered strangely.

Also silence a warning that happens each time a transaction is found in a block while looking for a spending transaction immediately afterward.