### PR TITLE
server/asset/eth: token backends

### DIFF
--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -210,6 +210,20 @@ type SwapState struct {
 	State       SwapStep
 }
 
+// SwapStateFromV0 converts a version 0 contract *ETHSwapSwap to the generalized
+// *SwapState type.
+func SwapStateFromV0(state *v0.ETHSwapSwap) *SwapState {
+	return &SwapState{
+		BlockHeight: state.InitBlockNumber.Uint64(),
+		LockTime:    time.Unix(state.RefundBlockTimestamp.Int64(), 0),
+		Secret:      state.Secret,
+		Initiator:   state.Initiator,
+		Participant: state.Participant,
+		Value:       WeiToGwei(state.Value),
+		State:       SwapStep(state.State),
+	}
+}
+
 // Initiation is the data used to initiate a swap.
 type Initiation struct {
 	LockTime    time.Time
@@ -260,21 +274,4 @@ func (g *Gases) RedeemN(n int) uint64 {
 		return 0
 	}
 	return g.Redeem + g.RedeemAdd*(uint64(n)-1)
-}
-
-// SwapStateFromV0 converts a v0.ETHSwapSwap to a *SwapState.
-func SwapStateFromV0(state *v0.ETHSwapSwap) *SwapState {
-	var blockTime int64
-	if state.RefundBlockTimestamp.IsInt64() {
-		blockTime = state.RefundBlockTimestamp.Int64()
-	}
-	return &SwapState{
-		BlockHeight: state.InitBlockNumber.Uint64(),
-		LockTime:    time.Unix(blockTime, 0),
-		Secret:      state.Secret,
-		Initiator:   state.Initiator,
-		Participant: state.Participant,
-		Value:       WeiToGwei(state.Value),
-		State:       SwapStep(state.State),
-	}
 }

--- a/dex/networks/eth/tokens.go
+++ b/dex/networks/eth/tokens.go
@@ -93,9 +93,14 @@ var Tokens = map[uint32]*Token{
 				SwapContracts: map[uint32]*SwapContract{},
 			},
 			dex.Simnet: {
+				// ERC20 token contract address. The simnet harness writes this
+				// address to file. Live tests must populate this field.
 				Address: common.Address{},
 				SwapContracts: map[uint32]*SwapContract{
 					0: {
+						// Swap contract address. The simnet harness writes this
+						// address to file. Live tests must populate this field.
+						Address: common.Address{},
 						Gas: Gases{
 							Swap:      174_000,
 							SwapAdd:   115_000,

--- a/server/asset/eth/coiner_test.go
+++ b/server/asset/eth/coiner_test.go
@@ -66,11 +66,14 @@ func TestNewRedeemCoin(t *testing.T) {
 			tx:    test.tx,
 			txErr: test.txErr,
 		}
-		eth := &Backend{
-			node:         node,
-			log:          tLogger,
+		eth := &AssetBackend{
+			baseBackend: &baseBackend{
+				node: node,
+				log:  tLogger,
+			},
 			contractAddr: *contractAddr,
 			initTxSize:   uint32(dexeth.InitGas(1, 0)),
+			assetID:      BipID,
 		}
 		rc, err := eth.newRedeemCoin(txHash[:], test.contract)
 		if test.wantErr {
@@ -188,9 +191,11 @@ func TestNewSwapCoin(t *testing.T) {
 			tx:    test.tx,
 			txErr: test.txErr,
 		}
-		eth := &Backend{
-			node:         node,
-			log:          tLogger,
+		eth := &AssetBackend{
+			baseBackend: &baseBackend{
+				node: node,
+				log:  tLogger,
+			},
 			contractAddr: *contractAddr,
 			initTxSize:   uint32(dexeth.InitGas(1, 0)),
 		}
@@ -309,9 +314,11 @@ func TestConfirmations(t *testing.T) {
 			blkNum:    test.bn,
 			blkNumErr: test.bnErr,
 		}
-		eth := &Backend{
-			node:         node,
-			log:          tLogger,
+		eth := &AssetBackend{
+			baseBackend: &baseBackend{
+				node: node,
+				log:  tLogger,
+			},
 			contractAddr: *contractAddr,
 			initTxSize:   uint32(dexeth.InitGas(1, 0)),
 		}

--- a/server/asset/eth/coiner_test.go
+++ b/server/asset/eth/coiner_test.go
@@ -68,8 +68,8 @@ func TestNewRedeemCoin(t *testing.T) {
 		}
 		eth := &AssetBackend{
 			baseBackend: &baseBackend{
-				node: node,
-				log:  tLogger,
+				node:       node,
+				baseLogger: tLogger,
 			},
 			contractAddr: *contractAddr,
 			initTxSize:   uint32(dexeth.InitGas(1, 0)),
@@ -193,8 +193,8 @@ func TestNewSwapCoin(t *testing.T) {
 		}
 		eth := &AssetBackend{
 			baseBackend: &baseBackend{
-				node: node,
-				log:  tLogger,
+				node:       node,
+				baseLogger: tLogger,
 			},
 			contractAddr: *contractAddr,
 			initTxSize:   uint32(dexeth.InitGas(1, 0)),
@@ -316,8 +316,8 @@ func TestConfirmations(t *testing.T) {
 		}
 		eth := &AssetBackend{
 			baseBackend: &baseBackend{
-				node: node,
-				log:  tLogger,
+				node:       node,
+				baseLogger: tLogger,
 			},
 			contractAddr: *contractAddr,
 			initTxSize:   uint32(dexeth.InitGas(1, 0)),

--- a/server/asset/eth/config.go
+++ b/server/asset/eth/config.go
@@ -6,10 +6,8 @@
 package eth
 
 import (
-	"fmt"
 	"path/filepath"
 
-	"decred.org/dcrdex/dex"
 	"github.com/decred/dcrd/dcrutil/v4"
 )
 
@@ -18,35 +16,11 @@ var (
 	defaultIPC = filepath.Join(ethHomeDir, "geth/geth.ipc")
 )
 
-type config struct {
-	// ipc is the location of the inner process communication socket.
-	ipc string
-	// network is the network the dex is meant to be running on.
-	network dex.Network
-}
-
-// load checks the network and sets the ipc location if not supplied.
-//
-// TODO: Test this with windows.
-func load(ipc string, network dex.Network) (*config, error) {
-	switch network {
-	case dex.Simnet:
-	case dex.Testnet:
-	case dex.Mainnet:
-		// TODO: Allow.
-		return nil, fmt.Errorf("eth cannot be used on mainnet")
-	default:
-		return nil, fmt.Errorf("unknown network ID: %d", uint8(network))
-	}
-
-	cfg := &config{
-		ipc:     ipc,
-		network: network,
-	}
-
-	if cfg.ipc == "" {
-		cfg.ipc = defaultIPC
-	}
-
-	return cfg, nil
+// For tokens, the file at the config path can contain overrides for
+// token gas values. Gas used for token swaps is dependent on the token contract
+// implementation, and can change without notice. The operator can specify
+// custom gas values to be used for funding balance validation calculations.
+type configuredTokenGases struct {
+	Swap   uint64 `ini:"swap"`
+	Redeem uint64 `ini:"redeem"`
 }

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -398,12 +398,12 @@ func (eth *AssetBackend) InitTxSize() uint32 {
 	return eth.initTxSize
 }
 
-// InitTxSizeBase is the same as InitTxSize for ETH.
+// InitTxSizeBase is the same as (dex.Asset).SwapSize for asset.
 func (eth *AssetBackend) InitTxSizeBase() uint32 {
 	return eth.initTxSize
 }
 
-// InitTxSizeBase is the same as InitTxSize for ETH.
+// RedeemSize is the same as (dex.Asset).RedeemSize for the asset.
 func (eth *AssetBackend) RedeemSize() uint64 {
 	return eth.redeemSize
 }
@@ -486,7 +486,7 @@ func (eth *AssetBackend) sendBlockUpdate(u *asset.BlockUpdate) {
 }
 
 // ValidateContract ensures that contractData encodes both the expected contract
-// version targeted and the secret hash.
+// version and a secret hash.
 func (eth *ETHBackend) ValidateContract(contractData []byte) error {
 	ver, _, err := dexeth.DecodeContractData(contractData)
 	if err != nil { // ensures secretHash is proper length
@@ -499,6 +499,8 @@ func (eth *ETHBackend) ValidateContract(contractData []byte) error {
 	return nil
 }
 
+// ValidateContract ensures that contractData encodes both the expected swap
+// contract version and a secret hash.
 func (eth *TokenBackend) ValidateContract(contractData []byte) error {
 	ver, _, err := dexeth.DecodeContractData(contractData)
 	if err != nil { // ensures secretHash is proper length

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	"math/big"
 
+	"decred.org/dcrdex/dex"
 	dexeth "decred.org/dcrdex/dex/networks/eth"
 	swapv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
 	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -28,28 +28,58 @@ var (
 	bigZero = new(big.Int)
 )
 
+type ContextCaller interface {
+	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
+}
+
 type rpcclient struct {
+	net dex.Network
+	ipc string
 	// ec wraps a *rpc.Client with some useful calls.
 	ec *ethclient.Client
-	// es is a wrapper for contract calls.
-	es *swapv0.ETHSwap
 	// c is a direct client for raw calls.
-	c *rpc.Client
+	caller ContextCaller
+	// swapContract is the current ETH swapContract.
+	swapContract swapContract
+
+	// tokens are tokeners for loaded tokens. tokens is not protected by a
+	// mutex, as it is expected that the caller will connect and place calls to
+	// loadToken sequentially in the same thread during initialization.
+	tokens map[uint32]*tokener
+}
+
+func newRPCClient(net dex.Network, ipc string) *rpcclient {
+	return &rpcclient{
+		net:    net,
+		tokens: make(map[uint32]*tokener),
+		ipc:    ipc,
+	}
 }
 
 // connect connects to an ipc socket. It then wraps ethclient's client and
 // bundles commands in a form we can easil use.
-func (c *rpcclient) connect(ctx context.Context, IPC string, contractAddr *common.Address) error {
-	client, err := rpc.DialIPC(ctx, IPC)
+func (c *rpcclient) connect(ctx context.Context) error {
+	client, err := rpc.DialIPC(ctx, c.ipc)
 	if err != nil {
 		return fmt.Errorf("unable to dial rpc: %v", err)
 	}
 	c.ec = ethclient.NewClient(client)
-	c.es, err = swapv0.NewETHSwap(*contractAddr, c.ec)
+
+	netAddrs, found := dexeth.ContractAddresses[ethContractVersion]
+	if !found {
+		return fmt.Errorf("no contract address for eth version %d", ethContractVersion)
+	}
+	contractAddr, found := netAddrs[c.net]
+	if !found {
+		return fmt.Errorf("no contract address for eth version %d on %s", ethContractVersion, c.net)
+	}
+
+	es, err := swapv0.NewETHSwap(contractAddr, c.ec)
 	if err != nil {
 		return fmt.Errorf("unable to find swap contract: %v", err)
 	}
-	c.c = client
+	c.swapContract = &swapSourceV0{es}
+	c.caller = client
 	return nil
 }
 
@@ -58,6 +88,24 @@ func (c *rpcclient) shutdown() {
 	if c.ec != nil {
 		c.ec.Close()
 	}
+}
+
+func (c *rpcclient) loadToken(ctx context.Context, assetID uint32) error {
+	tkn, err := newTokener(ctx, assetID, c.net, c.ec)
+	if err != nil {
+		return fmt.Errorf("error constructing ERC20Swap: %w", err)
+	}
+
+	c.tokens[assetID] = tkn
+	return nil
+}
+
+func (c *rpcclient) withTokener(assetID uint32, f func(*tokener) error) error {
+	tkn, found := c.tokens[assetID]
+	if !found {
+		return fmt.Errorf("no swap source for asset %d", assetID)
+	}
+	return f(tkn)
 }
 
 // bestHeader gets the best header at the time of calling.
@@ -91,16 +139,14 @@ func (c *rpcclient) blockNumber(ctx context.Context) (uint64, error) {
 }
 
 // swap gets a swap keyed by secretHash in the contract.
-func (c *rpcclient) swap(ctx context.Context, secretHash [32]byte) (*dexeth.SwapState, error) {
-	callOpts := &bind.CallOpts{
-		Pending: true,
-		Context: ctx,
+func (c *rpcclient) swap(ctx context.Context, assetID uint32, secretHash [32]byte) (state *dexeth.SwapState, err error) {
+	if assetID == BipID {
+		return c.swapContract.Swap(ctx, secretHash)
 	}
-	swap, err := c.es.Swap(callOpts, secretHash)
-	if err != nil {
-		return nil, err
-	}
-	return dexeth.SwapStateFromV0(&swap), nil
+	return state, c.withTokener(assetID, func(tkn *tokener) error {
+		state, err = tkn.Swap(ctx, secretHash)
+		return err
+	})
 }
 
 // transaction gets the transaction that hashes to hash from the chain or
@@ -111,14 +157,10 @@ func (c *rpcclient) transaction(ctx context.Context, hash common.Hash) (tx *type
 
 // accountBalance gets the account balance, including the effects of known
 // unmined transactions.
-func (c *rpcclient) accountBalance(ctx context.Context, addr common.Address) (*big.Int, error) {
+func (c *rpcclient) accountBalance(ctx context.Context, assetID uint32, addr common.Address) (*big.Int, error) {
 	tip, err := c.blockNumber(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("blockNumber error: %v", err)
-	}
-	currentBal, err := c.ec.BalanceAt(ctx, addr, big.NewInt(int64(tip)))
-	if err != nil {
-		return nil, err
 	}
 
 	// We need to subtract and pending outgoing value, but ignore any pending
@@ -130,43 +172,73 @@ func (c *rpcclient) accountBalance(ctx context.Context, addr common.Address) (*b
 	// reason, so we'll have to use CallContext and copy the mimic the
 	// internal RPCTransaction type.
 	var txs map[string]map[string]*RPCTransaction
-	err = c.c.CallContext(ctx, &txs, "txpool_contentFrom", addr)
+	err = c.caller.CallContext(ctx, &txs, "txpool_contentFrom", addr)
 	if err != nil {
 		return nil, fmt.Errorf("contentFrom error: %w", err)
 	}
 
-	outgoing := new(big.Int)
-	for _, group := range txs { // 2 groups, pending and queued
-		for _, tx := range group {
-			outgoing.Add(outgoing, tx.Value.ToInt())
-			gas := new(big.Int).SetUint64(uint64(tx.Gas))
-			if tx.GasPrice != nil && tx.GasPrice.ToInt().Cmp(bigZero) > 0 {
-				outgoing.Add(outgoing, new(big.Int).Mul(gas, tx.GasPrice.ToInt()))
-			} else if tx.GasFeeCap != nil {
-				outgoing.Add(outgoing, new(big.Int).Mul(gas, tx.GasFeeCap.ToInt()))
-			} else {
-				return nil, fmt.Errorf("cannot find fees for tx %s", tx.Hash)
+	if assetID == BipID {
+		ethBalance, err := c.ec.BalanceAt(ctx, addr, big.NewInt(int64(tip)))
+		if err != nil {
+			return nil, err
+		}
+		outgoingEth := new(big.Int)
+		for _, group := range txs { // 2 groups, pending and queued
+			for _, tx := range group {
+				outgoingEth.Add(outgoingEth, tx.Value.ToInt())
+				gas := new(big.Int).SetUint64(uint64(tx.Gas))
+				if tx.GasPrice != nil && tx.GasPrice.ToInt().Cmp(bigZero) > 0 {
+					outgoingEth.Add(outgoingEth, new(big.Int).Mul(gas, tx.GasPrice.ToInt()))
+				} else if tx.GasFeeCap != nil {
+					outgoingEth.Add(outgoingEth, new(big.Int).Mul(gas, tx.GasFeeCap.ToInt()))
+				} else {
+					return nil, fmt.Errorf("cannot find fees for tx %s", tx.Hash)
+				}
 			}
 		}
+		return ethBalance.Sub(ethBalance, outgoingEth), nil
 	}
 
-	return currentBal.Sub(currentBal, outgoing), nil
+	// For tokens, we'll do something similar, but with checks for pending txs
+	// that transfer tokens or pay to the swap contract.
+	bal := new(big.Int)
+	return bal, c.withTokener(assetID, func(tkn *tokener) error {
+		bal, err = tkn.balanceOf(ctx, addr)
+		if err != nil {
+			return err
+		}
+		for _, group := range txs {
+			for _, rpcTx := range group {
+				to := *rpcTx.To
+				if to == tkn.tokenAddr {
+					if sent := tkn.transferred(rpcTx.Input); sent != nil {
+						bal.Sub(bal, sent)
+					}
+				}
+				if to == tkn.contractAddr {
+					if swapped := tkn.swapped(rpcTx.Input); swapped != nil {
+						bal.Sub(bal, swapped)
+					}
+				}
+			}
+		}
+		return nil
+	})
 }
 
 type RPCTransaction struct {
-	Value     *hexutil.Big   `json:"value"`
-	Gas       hexutil.Uint64 `json:"gas"`
-	GasPrice  *hexutil.Big   `json:"gasPrice"`
-	GasFeeCap *hexutil.Big   `json:"maxFeePerGas,omitempty"`
-	Hash      common.Hash    `json:"hash"`
+	Value     *hexutil.Big    `json:"value"`
+	Gas       hexutil.Uint64  `json:"gas"`
+	GasPrice  *hexutil.Big    `json:"gasPrice"`
+	GasFeeCap *hexutil.Big    `json:"maxFeePerGas,omitempty"`
+	Hash      common.Hash     `json:"hash"`
+	To        *common.Address `json:"to"`
+	Input     hexutil.Bytes   `json:"input"`
 	// BlockHash        *common.Hash      `json:"blockHash"`
 	// BlockNumber      *hexutil.Big      `json:"blockNumber"`
 	// From             common.Address    `json:"from"`
 	// GasTipCap        *hexutil.Big      `json:"maxPriorityFeePerGas,omitempty"`
-
-	// Input            hexutil.Bytes     `json:"input"`
 	// Nonce            hexutil.Uint64    `json:"nonce"`
-	// To               *common.Address   `json:"to"`
 	// TransactionIndex *hexutil.Uint64   `json:"transactionIndex"`
 	// Type             hexutil.Uint64    `json:"type"`
 	// Accesses         *types.AccessList `json:"accessList,omitempty"`

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -37,7 +37,7 @@ type rpcclient struct {
 	ipc string
 	// ec wraps a *rpc.Client with some useful calls.
 	ec *ethclient.Client
-	// c is a direct client for raw calls.
+	// caller is a client for raw calls not implemented by *ethclient.Client.
 	caller ContextCaller
 	// swapContract is the current ETH swapContract.
 	swapContract swapContract

--- a/server/asset/eth/tokener.go
+++ b/server/asset/eth/tokener.go
@@ -1,0 +1,150 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+// +build lgpl
+
+package eth
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/networks/erc20"
+	erc20v0 "decred.org/dcrdex/dex/networks/erc20/contracts/v0"
+	dexeth "decred.org/dcrdex/dex/networks/eth"
+	swapv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// swapContract is a generic source of swap contract data.
+type swapContract interface {
+	Swap(context.Context, [32]byte) (*dexeth.SwapState, error)
+}
+
+// tokenAddresser exposes the TokenAddress method of a token swap contract.
+type tokenAddresser interface {
+	TokenAddress(*bind.CallOpts) (common.Address, error)
+}
+
+// erc2Contract exposes methods of a token's ERC20 contract.
+type erc20Contract interface {
+	BalanceOf(*bind.CallOpts, common.Address) (*big.Int, error)
+}
+
+// tokener is a contract data manager for a token.
+type tokener struct {
+	*registeredToken
+	swapContract
+	tokenAddresser
+	erc20Contract
+	ver                     uint32
+	contractAddr, tokenAddr common.Address
+}
+
+// newTokener is a constructor for a tokener.
+func newTokener(ctx context.Context, assetID uint32, net dex.Network, be bind.ContractBackend) (*tokener, error) {
+	token, netToken, swapContract, err := networkToken(assetID, net)
+	if err != nil {
+		return nil, err
+	}
+
+	if token.ver != 0 {
+		return nil, fmt.Errorf("only version 0 contracts supported")
+	}
+
+	es, err := erc20v0.NewERC20Swap(swapContract.Address, be)
+	if err != nil {
+		return nil, err
+	}
+
+	erc20, err := erc20.NewIERC20(netToken.Address, be)
+	if err != nil {
+		return nil, err
+	}
+
+	tkn := &tokener{
+		ver:             0,
+		registeredToken: token,
+		swapContract:    &swapSourceV0{es},
+		tokenAddresser:  es,
+		erc20Contract:   erc20,
+		contractAddr:    swapContract.Address,
+		tokenAddr:       netToken.Address,
+	}
+
+	if boundAddr, err := tkn.tokenAddress(ctx); err != nil {
+		return nil, fmt.Errorf("error retrieving bound address for %s version %d contract: %w",
+			token.Name, token.ver, err)
+	} else if boundAddr != netToken.Address {
+		return nil, fmt.Errorf("wrong bound address for %s version %d contract. wanted %s, got %s",
+			token.Name, token.ver, netToken.Address, boundAddr)
+	}
+
+	return tkn, nil
+}
+
+// transferred calculates the value transferred using the token contract's
+// transfer method.
+func (t *tokener) transferred(txData []byte) *big.Int {
+	_, out, err := erc20.ParseTransferData(txData)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// swapped calculates the value sent to the swap contracts initiate method.
+func (t *tokener) swapped(txData []byte) *big.Int {
+	inits, err := dexeth.ParseInitiateData(txData, t.ver)
+	if err != nil {
+		return nil
+	}
+	var v uint64
+	for _, init := range inits {
+		v += init.Value
+	}
+	return dexeth.GweiToWei(v)
+}
+
+// tokenAddress fetches the token address bound to the swap contract.
+func (t *tokener) tokenAddress(ctx context.Context) (common.Address, error) {
+	return t.tokenAddresser.TokenAddress(readOnlyCallOpts(ctx))
+}
+
+// balanceOf checks the account's token balance.
+func (t *tokener) balanceOf(ctx context.Context, addr common.Address) (*big.Int, error) {
+	return t.BalanceOf(readOnlyCallOpts(ctx), addr)
+}
+
+// swapContractV0 represents a version 0 swap contract for ETH or a token.
+type swapContractV0 interface {
+	Swap(opts *bind.CallOpts, secretHash [32]byte) (swapv0.ETHSwapSwap, error)
+}
+
+// swapSourceV0 wraps a swapContractV0 and translates the swap data to satisfy
+// swapSource.
+type swapSourceV0 struct {
+	contract swapContractV0 // *swapv0.ETHSwap or *erc20v0.ERCSwap
+}
+
+// Swap translates the version 0 swap data to the more general SwapState to
+// satisfy the swapSource interface.
+func (s *swapSourceV0) Swap(ctx context.Context, secretHash [32]byte) (*dexeth.SwapState, error) {
+	state, err := s.contract.Swap(readOnlyCallOpts(ctx), secretHash)
+	if err != nil {
+		return nil, fmt.Errorf("Swap error: %w", err)
+	}
+	return dexeth.SwapStateFromV0(&state), nil
+}
+
+// readOnlyCallOpts is the CallOpts used for read-only contract method calls.
+func readOnlyCallOpts(ctx context.Context) *bind.CallOpts {
+	return &bind.CallOpts{
+		Pending: true,
+		Context: ctx,
+	}
+}


### PR DESCRIPTION
```
Convert Backend to AssetBackend that embed *baseBackend similarly to
the AssetWallet in PR 1399. Add interfaces to interact with token
and token swap contracts.
```