### PR TITLE
server/asset/btc: fix panic in BTC TestReorg

### DIFF
--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -48,8 +48,8 @@ func TestMain(m *testing.M) {
 	// accommodate reorg testing.
 	blockPollInterval = time.Millisecond * 50
 	// blockPollDelay must be long enough to allow for block polling go-routine
-	// to get a single tick (must be at least as long as blockPollInterval and
-	// ideally significantly longer).
+	// to run at least a single tick (must be at least as long as blockPollInterval
+	// and ideally significantly longer).
 	blockPollDelay = blockPollInterval + time.Millisecond * 50
 	os.Exit(m.Run())
 }

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -47,7 +47,10 @@ func TestMain(m *testing.M) {
 	// Set any created Backends to poll for blocks every 50 ms to
 	// accommodate reorg testing.
 	blockPollInterval = time.Millisecond * 50
-	blockPollDelay = blockPollInterval + time.Millisecond*5
+	// blockPollDelay must be long enough to allow for block polling go-routine
+	// to get a single tick (must be at least as long as blockPollInterval and
+	// ideally significantly longer).
+	blockPollDelay = blockPollInterval + time.Millisecond * 50
 	os.Exit(m.Run())
 }
 

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -1288,7 +1288,10 @@ func TestReorg(t *testing.T) {
 	setChain(chainA)
 	tipHeight := btc.blockCache.tipHeight()
 	txHash := randomHash()
-	tip, _ := btc.blockCache.atHeight(tipHeight)
+	tip, found := btc.blockCache.atHeight(tipHeight)
+	if !found {
+		t.Fatalf("did not find newly connected block at height %d, likely cache sync issue", tipHeight)
+	}
 	msg := testMakeMsgTx(false)
 	testAddBlockVerbose(&tip.hash, nil, 1, tipHeight)
 	testAddTxOut(msg.tx, 0, txHash, &tip.hash, int64(tipHeight), 1)
@@ -1318,7 +1321,10 @@ func TestReorg(t *testing.T) {
 	// Start over, but put it in a lower block instead.
 	reset()
 	setChain(chainA)
-	tip, _ = btc.blockCache.atHeight(tipHeight)
+	tip, found := btc.blockCache.atHeight(tipHeight)
+	if !found {
+		t.Fatalf("did not find newly connected block at height %d, likely cache sync issue", tipHeight)
+	}
 	testAddBlockVerbose(&tip.hash, nil, 1, tipHeight)
 	testAddTxOut(msg.tx, 0, txHash, &tip.hash, int64(tipHeight), 1)
 	utxo, err = btc.utxo(txHash, msg.vout, nil)

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 	// blockPollDelay must be long enough to allow for block polling go-routine
 	// to run at least a single tick (must be at least as long as blockPollInterval
 	// and ideally significantly longer).
-	blockPollDelay = blockPollInterval + time.Millisecond * 50
+	blockPollDelay = blockPollInterval + time.Millisecond*50
 	os.Exit(m.Run())
 }
 

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -1321,7 +1321,7 @@ func TestReorg(t *testing.T) {
 	// Start over, but put it in a lower block instead.
 	reset()
 	setChain(chainA)
-	tip, found := btc.blockCache.atHeight(tipHeight)
+	tip, found = btc.blockCache.atHeight(tipHeight)
 	if !found {
 		t.Fatalf("did not find newly connected block at height %d, likely cache sync issue", tipHeight)
 	}


### PR DESCRIPTION
Closes https://github.com/decred/dcrdex/issues/1408.

I can reproduce this panic by making `blockPollDelay` shorter in these unit-tests (see screenshot below). So extending this interval might help with encountering this `panic`.

From what I understand, the issue happens because these tests rely on timing (go-routine managing `time.Ticker` is not synchronised with the one running this test), and so `btc.blockCache` might not have the necessary block by the time `atHeight` gets called.

I've also checked tests for other assets, they shouldn't suffer from the same issue (DCR tests [explicitly sync block-cache](https://github.com/LasTshaMAN/dcrdex/blob/master/server/asset/dcr/dcr_test.go#L1245-L1269) and other coins don't have similar tests).

![telegram-cloud-photo-size-2-5406630920015951656-y](https://user-images.githubusercontent.com/7031569/149375166-bdb73271-db35-49eb-af49-24bb7e37d552.jpg)
