### PR TITLE
client/core: check balance before register

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1567,6 +1567,9 @@ func TestRegister(t *testing.T) {
 
 	wallet, tWallet := newTWallet(tDCR.ID)
 	tCore.wallets[tDCR.ID] = wallet
+	tWallet.bal = &asset.Balance{
+		Available: 4e9,
+	}
 
 	// When registering, successfully retrieving *db.AccountInfo from the DB is
 	// an error (no dupes). Initial state is to return an error.
@@ -1684,6 +1687,7 @@ func TestRegister(t *testing.T) {
 	if err != nil {
 		t.Fatalf("registration error: %v", err)
 	}
+
 	// Should be two success notifications. One for fee paid on-chain, one for
 	// fee notification sent, each along with a balance note.
 	feeNote := getFeeAndBalanceNote() // payment in progress
@@ -1767,6 +1771,15 @@ func TestRegister(t *testing.T) {
 		t.Fatalf("wrong account key error: %v", err)
 	}
 	rig.crypter.(*tCrypter).encryptErr = nil
+
+	bal0 := tWallet.bal.Available
+	tWallet.bal.Available = 0
+	queueConfigAndConnectUnknownAcct()
+	run()
+	if !errorHasCode(err, walletBalanceErr) {
+		t.Fatalf("expected low balance error")
+	}
+	tWallet.bal.Available = bal0
 
 	// register request error
 	queueConfigAndConnectUnknownAcct()

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -13,6 +13,7 @@ import (
 const (
 	walletErr = iota
 	walletAuthErr
+	walletBalanceErr
 	dupeDEXErr
 	assetSupportErr
 	registerErr


### PR DESCRIPTION
This complements the frontend work in https://github.com/decred/dcrdex/pull/1401

Other consumers should be able to rely on `(*Core).Register` to ensure balance is sufficient before initiating a `'register'` request.

```
$  ./dexcctl -p abc --simnet wallets
[
  {
    "symbol": "dcr",
    "assetID": 42,
    "version": 0,
    "type": "dcrwalletRPC",
    "open": true,
    "running": true,
    "balance": {
      "available": 0,
...

$  ./dexcctl -p abc --simnet register 127.0.0.1:17273 100000000 42 ~/dextest/dcrdex/rpc.cert
insufficient balance for fee 100000000, have 0, but need fee amount plus network fees
```