### PR TITLE
client/core: reload wallet on connect fail

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1478,8 +1478,8 @@ func (c *Core) reloadWallet(wallet *xcWallet) (*xcWallet, error) {
 // already connected. If the wallet gets connected, this also emits WalletState
 // and WalletBalance notification.
 func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
-	c.walletMtx.RLock()
-	defer c.walletMtx.RUnlock()
+	c.walletMtx.Lock() // may replace the xcWallet in the map if connect fails
+	defer c.walletMtx.Unlock()
 	wallet, exists := c.wallets[assetID]
 	if !exists {
 		return nil, newError(missingWalletErr, "no configured wallet found for %s (%d)",

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -19,6 +19,7 @@ type xcWallet struct {
 	asset.Wallet
 	connector  *dex.ConnectionMaster
 	AssetID    uint32
+	cfg        *asset.WalletConfig // for recreating the xcWallet
 	dbID       []byte
 	walletType string
 


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1406

You cannot do `wallet.Disconnect` and later `wallet.Connect`, at least not with dcr's `ExchangeWallet` using `rpcclient`.  I think that we should assume that once you do `asset.Wallet.Disconnect` you cannot do `asset.Wallet.Connect` although that would depend on the implementation.

This PR solves the issue by creating a new `xcWallet` to replace the one the `Core.conns` map if the connection fails.  This is obviously only required if the `xcWallet` was in the map in the first place.

A simple way to test this is with an counted error in `(*rpcWallet).checkRPCConnection`:

```diff
diff --git a/client/asset/dcr/rpcwallet.go b/client/asset/dcr/rpcwallet.go
index 314ebe08..df4b51aa 100644
--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -239,9 +239,15 @@ func (w *rpcWallet) checkRPCConnection(ctx context.Context) error {
                w.log.Infof("Connected to dcrwallet (JSON-RPC API v%s) in SPV mode", walletSemver)
        }
 
+       if fail < 3 {
+               fail++
+               return errors.New("asdf")
+       }
        return nil
 }
 
+var fail int
+
```