### PR TITLE
ui: Fix wallet wait form issues

### DIFF
--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -184,6 +184,7 @@ var EnUS = map[string]string{
 	"2 Fund the Registration Fee": "2: Fund the Registration Fee",
 	"Registration fee":            "Registration fee",
 	"Your Deposit Address":        "Your Deposit Address",
+	"Send enough for reg fee":     `Make sure you send enough to also cover network fees.`,
 	"add a different server":      "add a different server",
 	"Add a custom server":         "Add a custom server",
 	"plus tx fees":                "+ tx fees",

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -412,6 +412,7 @@
     </div>
     <div class="fs14">[[[Your Deposit Address]]]</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
+    <span data-tmpl="sendEnough">[[[Send enough for reg fee]]]</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -623,13 +623,17 @@ export class WalletWaitForm {
     page.fee.textContent = Doc.formatCoinValue(fee.amount, asset.info.unitinfo)
 
     Doc.hide(page.syncUncheck, page.syncCheck, page.balUncheck, page.balCheck, page.syncRemainBox)
-    Doc.show(page.balanceBox)
+    Doc.show(page.balanceBox, page.sendEnough)
 
     Doc.show(wallet.synced ? page.syncCheck : wallet.syncProgress >= 1 ? page.syncSpinner : page.syncUncheck)
     Doc.show(wallet.balance.available > fee.amount ? page.balCheck : page.balUncheck)
 
     page.progress.textContent = Math.round(wallet.syncProgress * 100)
-    this.reportBalance(wallet.balance)
+
+    if (wallet.synced) {
+      this.progressed = true
+    }
+    this.reportBalance(wallet.balance, wallet.assetID)
   }
 
   /*
@@ -640,27 +644,27 @@ export class WalletWaitForm {
     if (wallet.assetID !== this.assetID) return
     if (this.progressed && this.funded) return
     this.reportProgress(wallet.synced, wallet.syncProgress)
-    this.reportBalance(wallet.balance)
+    this.reportBalance(wallet.balance, wallet.assetID)
   }
 
   /*
    * reportBalance sets the balance display and calls success if we go over the
    * threshold.
    */
-  reportBalance (bal) {
-    if (this.funded || this.assetID === -1) return
+  reportBalance (bal, assetID) {
+    if (this.funded || this.assetID === -1 || this.assetID !== assetID) return
     const page = this.page
     const asset = app().assets[this.assetID]
-    const fee = this.regFee
 
-    if (bal.available <= fee.amount) {
+    if (bal.available <= this.regFee.amount) {
       page.balance.textContent = Doc.formatCoinValue(bal.available, asset.info.unitinfo)
       return
     }
 
     Doc.show(page.balCheck)
-    Doc.hide(page.balUncheck, page.balanceBox)
+    Doc.hide(page.balUncheck, page.balanceBox, page.sendEnough)
     this.funded = true
+
     if (this.progressed) this.success()
   }
 

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -102,7 +102,7 @@ export default class RegistrationPage extends BasePage {
     if (app().user.authed) this.auth()
     this.notifiers = {
       walletstate: note => this.walletWaitForm.reportWalletState(note.wallet),
-      balance: note => this.walletWaitForm.reportBalance(note.balance)
+      balance: note => this.walletWaitForm.reportBalance(note.balance, note.assetID)
     }
   }
 

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -140,7 +140,7 @@ export default class SettingsPage extends BasePage {
 
     this.notifiers = {
       walletstate: note => this.walletWaitForm.reportWalletState(note.wallet),
-      balance: note => this.walletWaitForm.reportBalance(note.balance)
+      balance: note => this.walletWaitForm.reportBalance(note.balance, note.assetID)
     }
   }
 

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -412,6 +412,7 @@
     </div>
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
+    <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
@@ -412,6 +412,7 @@
     </div>
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
+    <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
@@ -412,6 +412,7 @@
     </div>
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
+    <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
   </div>
 </div>
 


### PR DESCRIPTION
- ui: Add a line on the wallet wait form that displays
  tells the user to send enough funds to cover tx fee in
  addition to the registration fee
- ui: Fix a bugs where balance updates for different assets
  were displayed on the wallet wait form, and one where
  if wallet was already synced when page loaded, but fee
  not yet paid, the confirm registration page would not load

This contains the same bug fixes as #1401, but adds a generic instruction to send enough to cover tx fees instead of trying to estimate how much they will be. 