### PR TITLE
client/ui: Display registration tx fee estimate

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2582,7 +2582,7 @@ func (btc *ExchangeWallet) feeRateWithOracleFallback(confTarget uint64, oracle f
 		return feeRate
 	}
 	feeSuggestion := oracle()
-	if feeSuggestion > 0 && feeSuggestion < btc.fallbackFeeRate && feeSuggestion < btc.feeRateLimit {
+	if feeSuggestion > 0 && feeSuggestion < btc.feeRateLimit {
 		btc.log.Tracef("feeRateWithFallback using caller's suggestion for %d-conf fee rate, %d. Local estimate unavailable (%q)",
 			confTarget, feeSuggestion, err)
 		return feeSuggestion

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -2407,7 +2407,7 @@ func testEstimateRegistrationTxFee(t *testing.T, segwit bool, walletType string)
 	}
 	const inputCount = 5
 	const txSize = dexbtc.MinimumTxOverhead + 2*dexbtc.P2PKHOutputSize + inputCount*dexbtc.RedeemP2PKHInputSize
-	wallet.fallbackFeeRate = 30
+	wallet.feeRateLimit = 100
 
 	estimate := wallet.EstimateRegistrationTxFee(rateOracleFallback)
 	// estimateSmartFee is not supported in the spv wallet
@@ -2429,8 +2429,8 @@ func testEstimateRegistrationTxFee(t *testing.T, segwit bool, walletType string)
 		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)
 	}
 
-	// if value from oracle > fallback fee rate, use fallback fee rate
-	oracleEstimate = 31
+	// if value from oracle > fee rate limit, use fallback fee rate
+	oracleEstimate = wallet.feeRateLimit + 1
 	estimate = wallet.EstimateRegistrationTxFee(rateOracleFallback)
 	if estimate != wallet.fallbackFeeRate*txSize {
 		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2523,7 +2523,7 @@ func (dcr *ExchangeWallet) feeRateWithOracleFallback(confTarget uint64, oracle f
 		return feeRate
 	}
 	feeSuggestion := oracle()
-	if feeSuggestion > 0 && feeSuggestion < dcr.fallbackFeeRate && feeSuggestion < dcr.feeRateLimit {
+	if feeSuggestion > 0 && feeSuggestion < dcr.feeRateLimit {
 		dcr.log.Tracef("feeRateWithFallback using caller's suggestion for %d-conf fee rate, %d. Local estimate unavailable (%q)",
 			confTarget, feeSuggestion, err)
 		return feeSuggestion

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -2500,7 +2500,7 @@ func TestEstimateRegistrationTxFee(t *testing.T) {
 	}
 	const inputCount = 5
 	const txSize = dexdcr.MsgTxOverhead + dexdcr.P2PKHOutputSize*2 + inputCount*dexdcr.P2PKHInputSize
-	wallet.fallbackFeeRate = 30
+	wallet.feeRateLimit = 100
 
 	estimate := wallet.EstimateRegistrationTxFee(rateOracleFallback)
 	if estimate != (optimalFeeRate+1)*txSize {
@@ -2521,8 +2521,8 @@ func TestEstimateRegistrationTxFee(t *testing.T) {
 		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)
 	}
 
-	// if value from oracle > fallback fee rate, use fallback fee rate
-	oracleEstimate = 31
+	// if value from oracle > fee rate limit, use fallback fee rate
+	oracleEstimate = wallet.feeRateLimit + 1
 	estimate = wallet.EstimateRegistrationTxFee(rateOracleFallback)
 	if estimate != wallet.fallbackFeeRate*txSize {
 		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1110,6 +1110,14 @@ func (eth *ExchangeWallet) PayFee(address string, regFee, _ uint64) (asset.Coin,
 	return &coin{id: txHash[:], value: dexeth.WeiToGwei(tx.Value())}, nil
 }
 
+// EstimateRegistrationTxFee provides an estimate for the tx fee needed to
+// pay the registration fee. rateOracleFallback is used in the case where
+// the wallet fails to determine the current fee rate on its own.
+func (eth *ExchangeWallet) EstimateRegistrationTxFee(oracle func() uint64) uint64 {
+	// TODO: implement this
+	return 0
+}
+
 // SwapConfirmations gets the number of confirmations and the spend status
 // for the specified swap.
 func (eth *ExchangeWallet) SwapConfirmations(ctx context.Context, _ dex.Bytes, contract dex.Bytes, _ time.Time) (confs uint32, spent bool, err error) {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -231,6 +231,10 @@ type Wallet interface {
 	// payment. This method need not be supported by all assets. Those assets
 	// which do no support DEX registration fees will return an ErrUnsupported.
 	RegFeeConfirmations(ctx context.Context, coinID dex.Bytes) (confs uint32, err error)
+	// EstimateRegistrationTxFee provides an estimate for the tx fee needed to
+	// pay the registration fee. rateOracleFallback is used in the case where
+	// the wallet fails to determine the current fee rate on its own.
+	EstimateRegistrationTxFee(rateOracleFallback func() uint64) uint64
 }
 
 // TokenMaster is implemented by assets which support degenerate tokens.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -790,6 +790,10 @@ func (w *TXCWallet) Withdraw(address string, value, feeSuggestion uint64) (asset
 	return w.payFeeCoin, w.payFeeErr
 }
 
+func (w *TXCWallet) EstimateRegistrationTxFee(rateOracleFallback func() uint64) uint64 {
+	return 0
+}
+
 func (w *TXCWallet) ValidateSecret(secret, secretHash []byte) bool {
 	return !w.badSecret
 }

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -46,6 +46,29 @@ func (s *WebServer) apiDiscoverAccount(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp, s.indent)
 }
 
+// apiEstimateRegistrationTxFee is the handler for the '/regtxfee' API request.
+func (s *WebServer) apiEstimateRegistrationTxFee(w http.ResponseWriter, r *http.Request) {
+	form := new(registrationTxFeeForm)
+	if !readPost(w, r, form) {
+		return
+	}
+	cert := []byte(form.Cert)
+	txFee, err := s.core.EstimateRegistrationTxFee(form.Addr, cert, *form.AssetID)
+	if err != nil {
+		s.writeAPIError(w, err)
+		return
+	}
+	resp := struct {
+		OK       bool           `json:"ok"`
+		Exchange *core.Exchange `json:"xc,omitempty"`
+		TxFee    uint64         `json:"txfee"`
+	}{
+		OK:    true,
+		TxFee: txFee,
+	}
+	writeJSON(w, resp, s.indent)
+}
+
 // apiGetDEXInfo is the handler for the '/getdexinfo' API request.
 func (s *WebServer) apiGetDEXInfo(w http.ResponseWriter, r *http.Request) {
 	form := new(registrationForm)

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -523,6 +523,9 @@ func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) {
 	c.reg = r
 	return nil, nil
 }
+func (c *TCore) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
+	return 0, nil
+}
 func (c *TCore) Login([]byte) (*core.LoginResult, error) { return &core.LoginResult{}, nil }
 func (c *TCore) IsInitialized() bool                     { return true }
 func (c *TCore) Logout() error                           { return nil }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -185,6 +185,7 @@ var EnUS = map[string]string{
 	"Registration fee":            "Registration fee",
 	"Your Deposit Address":        "Your Deposit Address",
 	"Send enough for reg fee":     `Make sure you send enough to also cover network fees.`,
+	"Send enough with estimate":   `Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.`,
 	"add a different server":      "add a different server",
 	"Add a custom server":         "Add a custom server",
 	"plus tx fees":                "+ tx fees",

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">[[[Your Deposit Address]]]</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">[[[Send enough for reg fee]]]</span>
+    <span data-tmpl="sendEnoughWithEst">[[[Send enough with estimate]]]</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -608,7 +608,7 @@ export class WalletWaitForm {
   }
 
   /* setWallet must be called before showing the form. */
-  setWallet (wallet) {
+  setWallet (wallet, txFee) {
     this.assetID = wallet.assetID
     this.progressCache = []
     this.progressed = false
@@ -623,7 +623,16 @@ export class WalletWaitForm {
     page.fee.textContent = Doc.formatCoinValue(fee.amount, asset.info.unitinfo)
 
     Doc.hide(page.syncUncheck, page.syncCheck, page.balUncheck, page.balCheck, page.syncRemainBox)
-    Doc.show(page.balanceBox, page.sendEnough)
+    Doc.show(page.balanceBox)
+
+    if (txFee > 0) {
+      page.totalFees.textContent = Doc.formatCoinValue(fee.amount + txFee, asset.info.unitinfo)
+      Doc.show(page.sendEnoughWithEst)
+      Doc.hide(page.sendEnough)
+    } else {
+      Doc.show(page.sendEnough)
+      Doc.hide(page.sendEnoughWithEst)
+    }
 
     Doc.show(wallet.synced ? page.syncCheck : wallet.syncProgress >= 1 ? page.syncSpinner : page.syncUncheck)
     Doc.show(wallet.balance.available > fee.amount ? page.balCheck : page.balUncheck)

--- a/client/webserver/site/src/js/register.js
+++ b/client/webserver/site/src/js/register.js
@@ -55,7 +55,7 @@ export default class RegistrationPage extends BasePage {
     }, this.pwCache)
 
     // SELECT REG ASSET
-    this.regAssetForm = new FeeAssetSelectionForm(page.regAssetForm, assetID => {
+    this.regAssetForm = new FeeAssetSelectionForm(page.regAssetForm, async assetID => {
       this.confirmRegisterForm.setAsset(assetID)
 
       const asset = app().assets[assetID]
@@ -66,7 +66,8 @@ export default class RegistrationPage extends BasePage {
           this.animateConfirmForm(page.regAssetForm)
           return
         }
-        this.walletWaitForm.setWallet(wallet)
+        const txFee = await this.getRegistrationTxFeeEstimate(assetID, page.regAssetForm)
+        this.walletWaitForm.setWallet(wallet, txFee)
         slideSwap(page.regAssetForm, page.walletWait)
         return
       }
@@ -127,6 +128,23 @@ export default class RegistrationPage extends BasePage {
     this.confirmRegisterForm.animate()
     Doc.hide(oldForm)
     Doc.show(this.page.confirmRegForm)
+  }
+
+  // Retrieve an estimate for the tx fee needed to pay the registration fee.
+  async getRegistrationTxFeeEstimate (assetID, form) {
+    const cert = await this.getCertFile()
+    const loaded = app().loading(form)
+    const res = await postJSON('/api/regtxfee', {
+      addr: this.currentDEX.host,
+      cert: cert,
+      asset: assetID
+    })
+    loaded()
+    if (!app().checkResponse(res, true)) {
+      return 0
+    }
+
+    return res.txfee
   }
 
   /* Set the application password. Attached to form submission. */
@@ -208,7 +226,8 @@ export default class RegistrationPage extends BasePage {
       return
     }
 
-    this.walletWaitForm.setWallet(wallet)
+    const txFee = await this.getRegistrationTxFeeEstimate(assetID, page.newWalletForm)
+    this.walletWaitForm.setWallet(wallet, txFee)
     await slideSwap(page.newWalletForm, page.walletWait)
   }
 }

--- a/client/webserver/site/src/js/settings.js
+++ b/client/webserver/site/src/js/settings.js
@@ -39,7 +39,7 @@ export default class SettingsPage extends BasePage {
     })
 
     // Asset selection
-    this.regAssetForm = new forms.FeeAssetSelectionForm(page.regAssetForm, assetID => {
+    this.regAssetForm = new forms.FeeAssetSelectionForm(page.regAssetForm, async assetID => {
       this.confirmRegisterForm.setAsset(assetID)
 
       const asset = app().assets[assetID]
@@ -50,7 +50,8 @@ export default class SettingsPage extends BasePage {
           this.animateConfirmForm(page.regAssetForm)
           return
         }
-        this.walletWaitForm.setWallet(wallet)
+        const txFee = await this.getRegistrationTxFeeEstimate(assetID, page.regAssetForm)
+        this.walletWaitForm.setWallet(wallet, txFee)
         forms.slideSwap(page.regAssetForm, page.walletWait)
         return
       }
@@ -144,6 +145,23 @@ export default class SettingsPage extends BasePage {
     }
   }
 
+  // Retrieve an estimate for the tx fee needed to pay the registration fee.
+  async getRegistrationTxFeeEstimate (assetID, form) {
+    const cert = await this.getCertFile()
+    const loaded = app().loading(form)
+    const res = await postJSON('/api/regtxfee', {
+      addr: this.currentDEX.host,
+      cert: cert,
+      asset: assetID
+    })
+    loaded()
+    if (!app().checkResponse(res, true)) {
+      return 0
+    }
+
+    return res.txfee
+  }
+
   async newWalletCreated (assetID) {
     const user = await app().fetchUser()
     const page = this.page
@@ -156,7 +174,8 @@ export default class SettingsPage extends BasePage {
       return
     }
 
-    this.walletWaitForm.setWallet(wallet)
+    const txFee = await this.getRegistrationTxFeeEstimate(assetID, page.newWalletForm)
+    this.walletWaitForm.setWallet(wallet, txFee)
     this.currentForm = page.walletWait
     await forms.slideSwap(page.newWalletForm, page.walletWait)
   }

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Seu Endereço de Depósito</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -51,6 +51,12 @@ type registrationForm struct {
 	AssetID  *uint32          `json:"asset,omitempty"` // prevent out-of-date frontend from paying fee in BTC
 }
 
+type registrationTxFeeForm struct {
+	Addr    string  `json:"addr"`
+	Cert    string  `json:"cert"`
+	AssetID *uint32 `json:"asset,omitempty"`
+}
+
 // newWalletForm is information necessary to create a new wallet.
 type newWalletForm struct {
 	AssetID    uint32 `json:"assetID"`

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -109,6 +109,7 @@ type clientCore interface {
 	IsInitialized() bool
 	ExportSeed(pw []byte) ([]byte, error)
 	PreOrder(*core.TradeForm) (*core.OrderEstimate, error)
+	EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -304,6 +305,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiInit.Post("/login", s.apiLogin)
 			apiInit.Post("/getdexinfo", s.apiGetDEXInfo)
 			apiInit.Post("/discoveracct", s.apiDiscoverAccount)
+			apiInit.Post("/regtxfee", s.apiEstimateRegistrationTxFee)
 		})
 
 		r.Group(func(apiAuth chi.Router) {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -80,9 +80,12 @@ func (c *TCore) DiscoverAccount(dexAddr string, pw []byte, certI interface{}) (*
 	return nil, false, nil
 }
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
-func (c *TCore) InitializeClient(pw, seed []byte) error                      { return c.initErr }
-func (c *TCore) Login(pw []byte) (*core.LoginResult, error)                  { return &core.LoginResult{}, c.loginErr }
-func (c *TCore) IsInitialized() bool                                         { return c.isInited }
+func (c *TCore) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
+	return 0, nil
+}
+func (c *TCore) InitializeClient(pw, seed []byte) error     { return c.initErr }
+func (c *TCore) Login(pw []byte) (*core.LoginResult, error) { return &core.LoginResult{}, c.loginErr }
+func (c *TCore) IsInitialized() bool                        { return c.isInited }
 func (c *TCore) SyncBook(dex string, base, quote uint32) (core.BookFeed, error) {
 	return c.syncFeed, c.syncErr
 }


### PR DESCRIPTION
- `client/core`: Add `EstimateRegistrationTxFee` function in core that determines the tx fee needed to register for the dex
- `client/asset`: Add `EstimateRegistrationTxFee` to wallet interface
- `client/webserver`: Add a new api endpoint `/regtxfee`
- `ui`: Each time the WalletWaitForm is loaded, this endpoint is called to retrieve an estimate
