### PR TITLE
[release-v0.4] client/core: notify of wallet connect errors in Login

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2295,7 +2295,7 @@ func (c *Core) setWalletPassword(wallet *xcWallet, newPW []byte, crypter encrypt
 	wasConnected := wallet.connected()
 	if !wasConnected {
 		if err := c.connectAndUpdateWallet(wallet); err != nil {
-			return newError(connectionErr, "SetWalletPassword connection error: %v", err)
+			return newError(connectWalletErr, "SetWalletPassword connection error: %v", err)
 		}
 	}
 
@@ -3120,6 +3120,12 @@ func (c *Core) Login(pw []byte) (*LoginResult, error) {
 				if err != nil {
 					c.log.Errorf("Unable to connect to %s wallet (start and sync wallets BEFORE starting dex!): %v",
 						unbip(wallet.AssetID), err)
+					// NOTE: Details for this topic is in the context of fee
+					// payment, but the subject pertains to a failure to connect
+					// to the wallet. This is better than just an ERR log.
+					subject, _ := c.formatDetails(TopicWalletConnectionWarning)
+					c.notify(newWalletConfigNote(TopicWalletConnectionWarning, subject, err.Error(),
+						db.ErrorLevel, wallet.state()))
 					return
 				}
 			}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -6020,7 +6020,7 @@ func TestSetWalletPassword(t *testing.T) {
 	xyzWallet.hookedUp = false
 	tXyzWallet.connectErr = tErr
 	err = tCore.SetWalletPassword(tPW, assetID, newPW)
-	if !errorHasCode(err, connectionErr) {
+	if !errorHasCode(err, connectWalletErr) {
 		t.Fatalf("wrong error for connection error: %v", err)
 	}
 	xyzWallet.hookedUp = true


### PR DESCRIPTION
This contains a bare minimum resolution to https://github.com/decred/dcrdex/issues/1406 for the `release-v0.4` branch (for `master`, https://github.com/decred/dcrdex/pull/1413).  The "already connected" error will still be received on subsequent connect attempts, only resolvable by a `ReconfigureWallet` or dexc restart, but this will at least put the initial error, which went unseen previously except for ERR logging, in the notification menu.

![image](https://user-images.githubusercontent.com/9373513/149846168-cd92e58d-ae30-4f8b-afd0-4ab185a68c96.png)