### PR TITLE
[release-v0.4] client/asset/dcr: coin not found not an error for spv

### DIFF
--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -957,6 +957,8 @@ func (w *spvWallet) swapConfirmations(txHash *chainhash.Hash, vout uint32, pkScr
 		if assumedMempool {
 			w.log.Tracef("swapConfirmations - scanFilters did not find %v:%d, assuming in mempool.",
 				txHash, vout)
+			// NOT asset.CoinNotFoundError since this is normal for mempool
+			// transactions with an SPV wallet.
 			return 0, false, nil
 		}
 		return 0, false, fmt.Errorf("output %s:%v not found with search parameters startTime = %s, pkScript = %x",

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1599,14 +1599,14 @@ func (dcr *ExchangeWallet) lookupTxOutput(ctx context.Context, txHash *chainhash
 	output, err := dcr.wallet.UnspentOutput(ctx, txHash, vout, wire.TxTreeUnknown)
 	if err == nil {
 		return output.TxOut, output.Confirmations, false, nil
-	} else if err != asset.CoinNotFoundError {
+	} else if !errors.Is(err, asset.CoinNotFoundError) {
 		return nil, 0, false, err
 	}
 
 	// Check wallet transactions.
 	tx, err := dcr.wallet.GetTransaction(ctx, txHash)
 	if err != nil {
-		return nil, 0, false, err
+		return nil, 0, false, err // asset.CoinNotFoundError if not found
 	}
 	msgTx, err := msgTxFromHex(tx.Hex)
 	if err != nil {
@@ -2275,8 +2275,10 @@ func (dcr *ExchangeWallet) ValidateSecret(secret, secretHash []byte) bool {
 // the specified swap. The contract and matchTime are provided so that wallets
 // may search for the coin using light filters.
 //
-// If the swap was not funded by this wallet, and it is already spent, this
-// method may return asset.CoinNotFoundError. Compare dcr.externalTxOut.
+// For a non-SPV wallet, if the swap appears spent but it cannot be located in a
+// block with a cfilters scan, this will return asset.CoinNotFoundError. For SPV
+// wallets, it is not an error if the transaction cannot be located SPV wallets
+// cannot see non-wallet transactions until they are mined.
 //
 // If the coin is located, but recognized as spent, no error is returned.
 func (dcr *ExchangeWallet) SwapConfirmations(ctx context.Context, coinID, contract dex.Bytes, matchTime time.Time) (confs uint32, spent bool, err error) {
@@ -2289,7 +2291,7 @@ func (dcr *ExchangeWallet) SwapConfirmations(ctx context.Context, coinID, contra
 	_, confs, spent, err = dcr.lookupTxOutput(ctx, txHash, vout)
 	if err == nil {
 		return confs, spent, nil
-	} else if err != asset.CoinNotFoundError {
+	} else if !errors.Is(err, asset.CoinNotFoundError) {
 		return 0, false, err
 	}
 
@@ -2300,9 +2302,17 @@ func (dcr *ExchangeWallet) SwapConfirmations(ctx context.Context, coinID, contra
 	}
 	_, p2shScript := scriptAddr.PaymentScript()
 
-	// Find the contract and it's spend status using block filters.
+	// Find the contract and its spend status using block filters.
 	dcr.log.Debugf("Contract output %s:%d NOT yet found, will attempt finding it with block filters.", txHash, vout)
-	return dcr.lookupTxOutWithBlockFilters(ctx, newOutPoint(txHash, vout), p2shScript, matchTime)
+	confs, spent, err = dcr.lookupTxOutWithBlockFilters(ctx, newOutPoint(txHash, vout), p2shScript, matchTime)
+	// Don't trouble the caller if we're using an SPV wallet and the transaction
+	// cannot be located.
+	if errors.Is(err, asset.CoinNotFoundError) && dcr.wallet.SpvMode() {
+		dcr.log.Debugf("SwapConfirmations - cfilters scan did not find %v:%d. "+
+			"Assuming in mempool.", txHash, vout)
+		err = nil
+	}
+	return confs, spent, err
 }
 
 // RegFeeConfirmations gets the number of confirmations for the specified
@@ -2962,7 +2972,7 @@ func (dcr *ExchangeWallet) isMainchainBlock(ctx context.Context, block *block) (
 	}
 	nextBlockHash, err := chainhash.NewHashFromStr(blockHeader.NextHash)
 	if err != nil {
-		return false, fmt.Errorf("block %s has invalid nexthash value %s: %v",
+		return false, fmt.Errorf("block %s has invalid nexthash value %s: %w",
 			block.hash, blockHeader.NextHash, err)
 	}
 	nextBlockHeader, err := dcr.wallet.GetBlockHeaderVerbose(ctx, nextBlockHash)


### PR DESCRIPTION
Cherry-pick of https://github.com/decred/dcrdex/pull/1403 for `release-v0.4`

Do not return asset.CoinNotFoundError from SwapConfirmations with an
SPV wallet since this is normal for mempool transactions in SPV.

For a non-SPV wallet, if the swap appears spent but it cannot be
located in a block with a cfilters scan, this will return
asset.CoinNotFoundError. For SPV wallets, it is not an error if the
transaction cannot be located SPV wallets cannot see non-wallet
transactions until they are mined.

Fix a few logs where arguments were orderd strangely.

Also silence a warning that happens each time a transaction is
found in a block while looking for a spending transaction immediately
afterward.