### PR TITLE
client/{core,asset,btc,dcr}: Add FeeRater interface and WalletTraitFeeRater

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -182,20 +182,20 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 	}
 
 	return &BCHWallet{
-		ExchangeWallet: xcWallet,
+		ExchangeWalletFullNode: xcWallet,
 	}, nil
 }
 
-// BCHWallet embeds btc.ExchangeWallet, but re-implements a couple of methods to
-// perform on-the-fly address translation.
+// BCHWallet embeds btc.ExchangeWalletFullNode, but re-implements a couple of
+// methods to perform on-the-fly address translation.
 type BCHWallet struct {
-	*btc.ExchangeWallet
+	*btc.ExchangeWalletFullNode
 }
 
 // Address converts the Bitcoin base58-encoded address returned by the embedded
 // ExchangeWallet into a Cash Address.
 func (bch *BCHWallet) Address() (string, error) {
-	btcAddrStr, err := bch.ExchangeWallet.Address()
+	btcAddrStr, err := bch.ExchangeWalletFullNode.Address()
 	if err != nil {
 		return "", err
 	}
@@ -206,7 +206,7 @@ func (bch *BCHWallet) Address() (string, error) {
 // AuditContract method by converting the Recipient to the Cash Address
 // encoding.
 func (bch *BCHWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadcast bool) (*asset.AuditInfo, error) { // AuditInfo has address
-	ai, err := bch.ExchangeWallet.AuditContract(coinID, contract, txData, rebroadcast)
+	ai, err := bch.ExchangeWalletFullNode.AuditContract(coinID, contract, txData, rebroadcast)
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -567,7 +567,7 @@ func makeSwapContract(segwit bool, lockTimeOffset time.Duration) (secret []byte,
 	return
 }
 
-func tNewWallet(segwit bool, walletType string) (*ExchangeWallet, *testData, func(), error) {
+func tNewWallet(segwit bool, walletType string) (*ExchangeWalletFullNode, *testData, func(), error) {
 	if segwit {
 		tBTC.SwapSize = dexbtc.InitTxSizeSegwit
 		tBTC.SwapSizeBase = dexbtc.InitTxSizeBaseSegwit
@@ -602,14 +602,15 @@ func tNewWallet(segwit bool, walletType string) (*ExchangeWallet, *testData, fun
 
 	// rpcClient := newRPCClient(requester, segwit, nil, false, minNetworkVersion, dex.StdOutLogger("RPCTEST", dex.LevelTrace), &chaincfg.MainNetParams)
 
-	var wallet *ExchangeWallet
+	var wallet *ExchangeWalletFullNode
 	var err error
 	switch walletType {
 	case walletTypeRPC:
 		wallet, err = newRPCWallet(&tRawRequester{data}, cfg, &WalletConfig{})
 	case walletTypeSPV:
-		wallet, err = newUnconnectedWallet(cfg, &WalletConfig{})
+		w, err := newUnconnectedWallet(cfg, &WalletConfig{})
 		if err == nil {
+			wallet = &ExchangeWalletFullNode{w}
 			neutrinoClient := &tNeutrinoClient{data}
 			wallet.node = &spvWallet{
 				chainParams: &chaincfg.MainNetParams,
@@ -1220,7 +1221,7 @@ func testFundingCoins(t *testing.T, segwit bool, walletType string) {
 	ensureGood()
 }
 
-func checkMaxOrder(t *testing.T, wallet *ExchangeWallet, lots, swapVal, maxFees, estWorstCase, estBestCase, locked uint64) {
+func checkMaxOrder(t *testing.T, wallet asset.Wallet, lots, swapVal, maxFees, estWorstCase, estBestCase, locked uint64) {
 	t.Helper()
 	maxOrder, err := wallet.MaxOrder(tLotSize, feeSuggestion, tBTC)
 	if err != nil {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -409,6 +409,10 @@ type ExchangeWallet struct {
 	externalTxCache map[chainhash.Hash]*externalTx
 }
 
+// Check that ExchangeWallet satisfies the Wallet interface.
+var _ asset.Wallet = (*ExchangeWallet)(nil)
+var _ asset.FeeRater = (*ExchangeWallet)(nil)
+
 type block struct {
 	height int64
 	hash   *chainhash.Hash
@@ -434,9 +438,6 @@ type findRedemptionResult struct {
 	Secret           dex.Bytes
 	Err              error
 }
-
-// Check that ExchangeWallet satisfies the Wallet interface.
-var _ asset.Wallet = (*ExchangeWallet)(nil)
 
 // NewWallet is the exported constructor by which the DEX will import the
 // exchange wallet.
@@ -622,6 +623,12 @@ func (dcr *ExchangeWallet) Balance() (*asset.Balance, error) {
 	}, nil
 }
 
+// FeeRate satisfies asset.FeeRater.
+func (dcr *ExchangeWallet) FeeRate() (uint64, error) {
+	// Requesting a rate for 1 confirmation can return unreasonably high rates.
+	return dcr.feeRate(2)
+}
+
 // FeeRate returns the current optimal fee rate in atoms / byte.
 func (dcr *ExchangeWallet) feeRate(confTarget uint64) (uint64, error) {
 	// estimatesmartfee 1 returns extremely high rates on DCR.
@@ -641,21 +648,29 @@ func (dcr *ExchangeWallet) feeRate(confTarget uint64) (uint64, error) {
 	return 1 + uint64(atomsPerKB)/1000, nil // dcrPerKB * 1e8 / 1e3
 }
 
-// feeRateWithFallback attempts to get the optimal fee rate in atoms / byte via
-// FeeRate. If that fails, it will return the configured fallback fee rate.
-func (dcr *ExchangeWallet) feeRateWithFallback(confTarget, feeSuggestion uint64) uint64 {
+// targetFeeRateWithFallback attempts to get a fresh fee rate for the target
+// number of confirmations, but falls back to the suggestion or fallbackFeeRate
+// via feeRateWithFallback.
+func (dcr *ExchangeWallet) targetFeeRateWithFallback(confTarget, feeSuggestion uint64) uint64 {
 	feeRate, err := dcr.feeRate(confTarget)
 	if err == nil {
 		dcr.log.Tracef("Obtained local estimate for %d-conf fee rate, %d", confTarget, feeRate)
 		return feeRate
 	}
-	if feeSuggestion > 0 && feeSuggestion < dcr.fallbackFeeRate && feeSuggestion < dcr.feeRateLimit {
-		dcr.log.Tracef("feeRateWithFallback using caller's suggestion for %d-conf fee rate, %d. Local estimate unavailable (%q)",
-			confTarget, feeSuggestion, err)
+	dcr.log.Tracef("no %d-conf feeRate available: %v", confTarget, err)
+	return dcr.feeRateWithFallback(feeSuggestion)
+}
+
+// feeRateWithFallback filters the suggested fee rate by ensuring it is within
+// limits. If not, the configured fallbackFeeRate is returned and a warning
+// logged.
+func (dcr *ExchangeWallet) feeRateWithFallback(feeSuggestion uint64) uint64 {
+	if feeSuggestion > 0 && feeSuggestion < dcr.feeRateLimit {
+		dcr.log.Tracef("feeRateWithFallback using caller's suggestion for fee rate, %d. Local estimate unavailable",
+			feeSuggestion)
 		return feeSuggestion
 	}
-	dcr.log.Warnf("Unable to get optimal fee rate, using fallback of %d: %v",
-		dcr.fallbackFeeRate, err)
+	dcr.log.Warnf("Unable to get optimal fee rate, using fallback of %d", dcr.fallbackFeeRate)
 	return dcr.fallbackFeeRate
 }
 
@@ -940,7 +955,7 @@ func (dcr *ExchangeWallet) splitOption(req *asset.PreSwapForm, utxos []*composit
 // PreRedeem generates an estimate of the range of redemption fees that could
 // be assessed.
 func (dcr *ExchangeWallet) PreRedeem(req *asset.PreRedeemForm) (*asset.PreRedeem, error) {
-	feeRate := dcr.feeRateWithFallback(dcr.redeemConfTarget, req.FeeSuggestion)
+	feeRate := dcr.targetFeeRateWithFallback(dcr.redeemConfTarget, req.FeeSuggestion)
 	// Best is one transaction with req.Lots inputs and 1 output.
 	var best uint64 = dexdcr.MsgTxOverhead
 	// Worst is req.Lots transactions, each with one input and one output.
@@ -1076,7 +1091,7 @@ func (dcr *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes
 			// TODO
 			// 1.0: Error when no suggestion.
 			// return nil, false, fmt.Errorf("cannot do a split transaction without a fee rate suggestion from the server")
-			rawFeeRate = dcr.feeRateWithFallback(dcr.redeemConfTarget, 0)
+			rawFeeRate = dcr.targetFeeRateWithFallback(dcr.redeemConfTarget, 0)
 			// We PreOrder checked this as <= MaxFeeRate, so use that as an
 			// upper limit.
 			if rawFeeRate > ord.DEXConfig.MaxFeeRate {
@@ -1648,7 +1663,7 @@ func (dcr *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 		return nil, nil, 0, fmt.Errorf("error parsing selected swap options: %w", err)
 	}
 
-	rawFeeRate := dcr.feeRateWithFallback(dcr.redeemConfTarget, form.FeeSuggestion)
+	rawFeeRate := dcr.targetFeeRateWithFallback(dcr.redeemConfTarget, form.FeeSuggestion)
 	feeRate, err := calcBumpedRate(rawFeeRate, customCfg.FeeBump)
 	if err != nil {
 		dcr.log.Errorf("calcBumpRate error: %v", err)
@@ -2377,7 +2392,7 @@ func (dcr *ExchangeWallet) refundTx(coinID, contract dex.Bytes, val uint64, refu
 	}
 
 	// Create the transaction that spends the contract.
-	feeRate := dcr.feeRateWithFallback(2, feeSuggestion)
+	feeRate := dcr.targetFeeRateWithFallback(2, feeSuggestion)
 	msgTx := wire.NewMsgTx()
 	msgTx.LockTime = uint32(lockTime)
 	prevOut := wire.NewOutPoint(txHash, vout, wire.TxTreeRegular)
@@ -2511,14 +2526,14 @@ func (dcr *ExchangeWallet) Locked() bool {
 
 // PayFee sends the dex registration fee. Transaction fees are in addition to
 // the registration fee, and the fee rate is taken from the DEX configuration.
-func (dcr *ExchangeWallet) PayFee(address string, regFee, feeRateSuggestion uint64) (asset.Coin, error) {
+func (dcr *ExchangeWallet) PayFee(address string, regFee, feeRate uint64) (asset.Coin, error) {
 	addr, err := stdaddr.DecodeAddress(address, dcr.chainParams)
 	if err != nil {
 		return nil, err
 	}
 	// TODO: Evaluate SendToAddress and how it deals with the change output
 	// address index to see if it can be used here instead.
-	msgTx, sent, err := dcr.sendRegFee(addr, regFee, dcr.feeRateWithFallback(1, feeRateSuggestion))
+	msgTx, sent, err := dcr.sendRegFee(addr, regFee, dcr.feeRateWithFallback(feeRate))
 	if err != nil {
 		return nil, err
 	}
@@ -2531,12 +2546,12 @@ func (dcr *ExchangeWallet) PayFee(address string, regFee, feeRateSuggestion uint
 
 // Withdraw withdraws funds to the specified address. Fees are subtracted from
 // the value.
-func (dcr *ExchangeWallet) Withdraw(address string, value, feeSuggestion uint64) (asset.Coin, error) {
+func (dcr *ExchangeWallet) Withdraw(address string, value, feeRate uint64) (asset.Coin, error) {
 	addr, err := stdaddr.DecodeAddress(address, dcr.chainParams)
 	if err != nil {
 		return nil, err
 	}
-	msgTx, net, err := dcr.sendMinusFees(addr, value, dcr.feeRateWithFallback(2, feeSuggestion))
+	msgTx, net, err := dcr.sendMinusFees(addr, value, dcr.feeRateWithFallback(feeRate))
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/dcr/externaltx.go
+++ b/client/asset/dcr/externaltx.go
@@ -47,7 +47,7 @@ type outputSpenderFinder struct {
 // block between the current best block and the block just before the provided
 // earliestTxTime. Returns asset.CoinNotFoundError if the block containing the
 // output is not found.
-func (dcr *ExchangeWallet) lookupTxOutWithBlockFilters(ctx context.Context, op outPoint, pkScript []byte, earliestTxTime time.Time) (uint32, bool, error) {
+func (dcr *baseWallet) lookupTxOutWithBlockFilters(ctx context.Context, op outPoint, pkScript []byte, earliestTxTime time.Time) (uint32, bool, error) {
 	if len(pkScript) == 0 {
 		return 0, false, fmt.Errorf("cannot perform block filters lookup without a script")
 	}
@@ -77,7 +77,7 @@ func (dcr *ExchangeWallet) lookupTxOutWithBlockFilters(ctx context.Context, op o
 
 // externalTxOutput attempts to locate the requested tx output in a mainchain
 // block and if found, returns the output details along with the block details.
-func (dcr *ExchangeWallet) externalTxOutput(ctx context.Context, op outPoint, pkScript []byte, earliestTxTime time.Time) (*outputSpenderFinder, *block, error) {
+func (dcr *baseWallet) externalTxOutput(ctx context.Context, op outPoint, pkScript []byte, earliestTxTime time.Time) (*outputSpenderFinder, *block, error) {
 	dcr.externalTxMtx.Lock()
 	tx := dcr.externalTxCache[op.txHash]
 	if tx == nil {
@@ -122,7 +122,7 @@ func (dcr *ExchangeWallet) externalTxOutput(ctx context.Context, op outPoint, pk
 // still part of the mainchain. It is not an error if the block is unknown
 // or invalidated.
 // The tx.blockMtx MUST be locked for writing.
-func (dcr *ExchangeWallet) txBlockFromCache(ctx context.Context, tx *externalTx) (*block, error) {
+func (dcr *baseWallet) txBlockFromCache(ctx context.Context, tx *externalTx) (*block, error) {
 	if tx.block == nil {
 		return nil, nil
 	}
@@ -153,7 +153,7 @@ func (dcr *ExchangeWallet) txBlockFromCache(ctx context.Context, tx *externalTx)
 // previous scan. If the tx block is found, the block hash, height and the tx
 // outputs details are cached; and the block is returned.
 // The tx.blockMtx MUST be locked for writing.
-func (dcr *ExchangeWallet) scanFiltersForTxBlock(ctx context.Context, tx *externalTx, txScripts [][]byte, earliestTxTime time.Time) (*block, error) {
+func (dcr *baseWallet) scanFiltersForTxBlock(ctx context.Context, tx *externalTx, txScripts [][]byte, earliestTxTime time.Time) (*block, error) {
 	// Scan block filters in reverse from the current best block to the last
 	// scanned block. If the last scanned block has been re-orged out of the
 	// mainchain, scan back to the mainchain ancestor of the lastScannedBlock.
@@ -237,7 +237,7 @@ func (dcr *ExchangeWallet) scanFiltersForTxBlock(ctx context.Context, tx *extern
 	}
 }
 
-func (dcr *ExchangeWallet) findTxInBlock(ctx context.Context, txHash *chainhash.Hash, txScripts [][]byte, blockHash *chainhash.Hash) (*wire.MsgTx, []*outputSpenderFinder, error) {
+func (dcr *baseWallet) findTxInBlock(ctx context.Context, txHash *chainhash.Hash, txScripts [][]byte, blockHash *chainhash.Hash) (*wire.MsgTx, []*outputSpenderFinder, error) {
 	blockFilter, err := dcr.getBlockFilterV2(ctx, blockHash)
 	if err != nil {
 		return nil, nil, err
@@ -299,7 +299,7 @@ func (dcr *ExchangeWallet) findTxInBlock(ctx context.Context, txHash *chainhash.
 	return msgTx, outputSpenders, nil
 }
 
-func (dcr *ExchangeWallet) isOutputSpent(ctx context.Context, output *outputSpenderFinder) (bool, error) {
+func (dcr *baseWallet) isOutputSpent(ctx context.Context, output *outputSpenderFinder) (bool, error) {
 	// Hold the output.spenderMtx lock for 2 reasons:
 	// 1) To read (and set) the spenderBlock field.
 	// 2) To prevent duplicate spender block scans if the spenderBlock is not
@@ -388,7 +388,7 @@ func (dcr *ExchangeWallet) isOutputSpent(ctx context.Context, output *outputSpen
 // If no tx is found to spend the provided output, the hash of the block that
 // was last checked is returned along with any error that may have occurred
 // during the search.
-func (dcr *ExchangeWallet) findTxOutSpender(ctx context.Context, op outPoint, outputPkScript []byte, startBlock *block) (*chainjson.TxRawResult, *chainhash.Hash, error) {
+func (dcr *baseWallet) findTxOutSpender(ctx context.Context, op outPoint, outputPkScript []byte, startBlock *block) (*chainjson.TxRawResult, *chainhash.Hash, error) {
 	var lastScannedHash *chainhash.Hash
 
 	iHeight := startBlock.height
@@ -467,7 +467,7 @@ func (bf *blockFilter) MatchAny(data [][]byte) bool {
 	return bf.v2cfilters.MatchAny(bf.key, data)
 }
 
-func (dcr *ExchangeWallet) getBlockFilterV2(ctx context.Context, blockHash *chainhash.Hash) (*blockFilter, error) {
+func (dcr *baseWallet) getBlockFilterV2(ctx context.Context, blockHash *chainhash.Hash) (*blockFilter, error) {
 	bf, key, err := dcr.wallet.BlockCFilter(ctx, blockHash)
 	if err != nil {
 		return nil, err

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -57,7 +57,7 @@ func mineAlpha() error {
 	return exec.Command("tmux", "send-keys", "-t", "dcr-harness:0", "./mine-alpha 1", "C-m").Run()
 }
 
-func tBackend(t *testing.T, name string, blkFunc func(string, error)) (*ExchangeWallet, *dex.ConnectionMaster) {
+func tBackend(t *testing.T, name string, blkFunc func(string, error)) (*ExchangeWalletFullNode, *dex.ConnectionMaster) {
 	t.Helper()
 	user, err := user.Current()
 	if err != nil {
@@ -88,18 +88,18 @@ func tBackend(t *testing.T, name string, blkFunc func(string, error)) (*Exchange
 	if err != nil {
 		t.Fatalf("error connecting backend: %v", err)
 	}
-	return backend.(*ExchangeWallet), cm
+	return backend.(*ExchangeWalletFullNode), cm
 }
 
 type testRig struct {
-	backends          map[string]*ExchangeWallet
+	backends          map[string]*ExchangeWalletFullNode
 	connectionMasters map[string]*dex.ConnectionMaster
 }
 
 func newTestRig(t *testing.T, blkFunc func(string, error)) *testRig {
 	t.Helper()
 	rig := &testRig{
-		backends:          make(map[string]*ExchangeWallet),
+		backends:          make(map[string]*ExchangeWalletFullNode),
 		connectionMasters: make(map[string]*dex.ConnectionMaster, 3),
 	}
 	rig.backends["alpha"], rig.connectionMasters["alpha"] = tBackend(t, "alpha", blkFunc)
@@ -107,10 +107,10 @@ func newTestRig(t *testing.T, blkFunc func(string, error)) *testRig {
 	return rig
 }
 
-func (rig *testRig) alpha() *ExchangeWallet {
+func (rig *testRig) alpha() *ExchangeWalletFullNode {
 	return rig.backends["alpha"]
 }
-func (rig *testRig) beta() *ExchangeWallet {
+func (rig *testRig) beta() *ExchangeWalletFullNode {
 	return rig.backends["beta"]
 }
 func (rig *testRig) close(t *testing.T) {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -329,14 +329,14 @@ type LogFiler interface {
 }
 
 // FeeRater is capable of retrieving a non-critical fee rate estimate for an
-// asset. SPV wallets, for example, cannot provide a fee rate estimate, so
-// shouldn't implement FeeRater. The rates from FeeRate are used for rates
-// that are not validated by the server (Withdraw, Send, PayFee), and
-// will/should not be used to generate a fee suggestion for swap operations.
-// Assets may also be unable to retrieve an estimate temporarily, such as before
-// the node is primed for BTC. In that case, an error should be returned, but
-// the caller can proceed to get an estimate from any known server's
-// 'fee_rate' endpoint, if possible.
+// asset. Some SPV wallets, for example, cannot provide a fee rate estimate, so
+// shouldn't implement FeeRater. The rates from FeeRate are used for rates that
+// are not validated by the server (Withdraw, Send, PayFee), and will/should not
+// be used to generate a fee suggestion for swap operations. Assets may also be
+// unable to retrieve an estimate temporarily, such as before the node is primed
+// for BTC. In that case, an error should be returned, but the caller can
+// proceed to get an estimate from any known server's 'fee_rate' endpoint, if
+// possible.
 type FeeRater interface {
 	FeeRate() (uint64, error)
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -276,7 +276,7 @@ type Wallet interface {
 	Locked() bool
 	// PayFee sends the dex registration fee. Transaction fees are in addition to
 	// the registration fee, and the feeSuggestion is gotten from the server.
-	PayFee(address string, feeAmt, feeSuggestion uint64) (Coin, error)
+	PayFee(address string, feeAmt, feeRate uint64) (Coin, error)
 	// SwapConfirmations gets the number of confirmations and the spend status
 	// for the specified swap. If the swap was not funded by this wallet, and
 	// it is already spent, you may see CoinNotFoundError.
@@ -288,7 +288,7 @@ type Wallet interface {
 	SwapConfirmations(ctx context.Context, coinID dex.Bytes, contract dex.Bytes, matchTime time.Time) (confs uint32, spent bool, err error)
 	// Withdraw withdraws funds to the specified address. Fees are subtracted
 	// from the value.
-	Withdraw(address string, value, feeSuggestion uint64) (Coin, error)
+	Withdraw(address string, value, feeRate uint64) (Coin, error)
 	// ValidateSecret checks that the secret hashes to the secret hash.
 	ValidateSecret(secret, secretHash []byte) bool
 	// SyncStatus is information about the blockchain sync status. It should

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -18,6 +18,7 @@ const (
 	WalletTraitRescanner    WalletTrait = 1 << iota // The Wallet is an asset.Rescanner.
 	WalletTraitNewAddresser                         // The Wallet can generate new addresses on demand with NewAddress.
 	WalletTraitLogFiler                             // The Wallet allows for downloading of a log file.
+	WalletTraitFeeRater                             // Wallet can provide a fee rate for non-critical transactions
 )
 
 // IsRescanner tests if the WalletTrait has the WalletTraitRescanner bit set.
@@ -38,6 +39,12 @@ func (wt WalletTrait) IsLogFiler() bool {
 	return wt&WalletTraitLogFiler != 0
 }
 
+// IsFeeRater tests if the WalletTrait has the WalletTraitFeeRater bit set,
+// which indicates the presence of a FeeRate method.
+func (wt WalletTrait) IsFeeRater() bool {
+	return wt&WalletTraitFeeRater != 0
+}
+
 // DetermineWalletTraits returns the WalletTrait bitset for the provided Wallet.
 func DetermineWalletTraits(w Wallet) (t WalletTrait) {
 	if _, is := w.(Rescanner); is {
@@ -48,6 +55,9 @@ func DetermineWalletTraits(w Wallet) (t WalletTrait) {
 	}
 	if _, is := w.(LogFiler); is {
 		t |= WalletTraitLogFiler
+	}
+	if _, is := w.(FeeRater); is {
+		t |= WalletTraitFeeRater
 	}
 	return t
 }
@@ -265,8 +275,8 @@ type Wallet interface {
 	// Locked will be true if the wallet is currently locked.
 	Locked() bool
 	// PayFee sends the dex registration fee. Transaction fees are in addition to
-	// the registration fee, and the feeRateSuggestion is gotten from the server.
-	PayFee(address string, feeAmt, feeRateSuggestion uint64) (Coin, error)
+	// the registration fee, and the feeSuggestion is gotten from the server.
+	PayFee(address string, feeAmt, feeSuggestion uint64) (Coin, error)
 	// SwapConfirmations gets the number of confirmations and the spend status
 	// for the specified swap. If the swap was not funded by this wallet, and
 	// it is already spent, you may see CoinNotFoundError.
@@ -316,6 +326,19 @@ type NewAddresser interface {
 // LogFiler is a wallet that allows for downloading of its log file.
 type LogFiler interface {
 	LogFilePath() string
+}
+
+// FeeRater is capable of retrieving a non-critical fee rate estimate for an
+// asset. SPV wallets, for example, cannot provide a fee rate estimate, so
+// shouldn't implement FeeRater. The rates from FeeRate are used for rates
+// that are not validated by the server (Withdraw, Send, PayFee), and
+// will/should not be used to generate a fee suggestion for swap operations.
+// Assets may also be unable to retrieve an estimate temporarily, such as before
+// the node is primed for BTC. In that case, an error should be returned, but
+// the caller can proceed to get an estimate from any known server's
+// 'fee_rate' endpoint, if possible.
+type FeeRater interface {
+	FeeRate() (uint64, error)
 }
 
 // TokenMaster is implemented by assets which support degenerate tokens.

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -712,6 +712,9 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 		Seq:      sp.Seq,        // forces seq reset, but should be in seq with previous
 		Epoch:    sp.FinalEpoch, // unused?
 		// Orders is nil
+		// BaseFeeRate = QuoteFeeRate = 0 effectively disables the book's fee
+		// cache until an update is received, since bestBookFeeSuggestion
+		// ignores zeros.
 	})
 	// Return any non-nil error, but still revoke purged orders.
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6391,14 +6391,15 @@ func (c *Core) tipChange(assetID uint32, nodeErr error) {
 // updated. If there is no synced book, but a non-zero fee suggestion is already
 // cached, no new requests will be made.
 func (c *Core) cacheRedemptionFeeSuggestion(t *trackedTrade) {
-	// Try to find any book that might have the fee.
 	if rater, is := t.wallets.toWallet.feeRater(); is {
-		if feeRate, err := rater.FeeRate(); err == nil {
+		feeRate, err := rater.FeeRate()
+		if err == nil {
 			atomic.StoreUint64(&t.redeemFeeSuggestion, feeRate)
-		} else {
-			c.log.Debugf("unable to retrieve fee rate from FeeRater. falling back to other methods: %v", err)
+			return
 		}
+		c.log.Debugf("unable to retrieve fee rate from FeeRater. falling back to other methods: %v", err)
 	}
+	// Try to find any book that might have the fee.
 	redeemAsset := t.wallets.toAsset.ID
 	feeSuggestion := t.dc.bestBookFeeSuggestion(redeemAsset)
 	if feeSuggestion > 0 {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2848,7 +2848,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	c.log.Infof("Attempting registration fee payment to %s, account ID %v, of %d units of %s. "+
 		"Do NOT manually send funds to this address even if this fails.",
 		regRes.Address, dc.acct.id, regRes.Fee, regFeeAssetSymbol)
-	feeRate := c.feeSuggestionAny(feeAsset.ID)
+	feeRate := c.feeSuggestionAny(feeAsset.ID, dc)
 	coin, err := wallet.PayFee(regRes.Address, regRes.Fee, feeRate)
 	if err != nil {
 		return nil, newError(feeSendErr, "error paying registration fee: %v", err)
@@ -3731,8 +3731,8 @@ func (c *Core) notifyFee(dc *dexConnection, coinID []byte) error {
 // with it available. It first checks for a capable wallet, then relevant books
 // for a cached fee rate obtained with an epoch_report message, and falls back
 // to directly requesting a rate from servers with a fee_rate request.
-func (c *Core) feeSuggestionAny(assetID uint32) uint64 {
-	conns := c.dexConnections()
+func (c *Core) feeSuggestionAny(assetID uint32, preferredConns ...*dexConnection) uint64 {
+	conns := append(preferredConns, c.dexConnections()...)
 	// See if the wallet supports fee rates.
 	w, found := c.wallet(assetID)
 	if found && w.connected() {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1031,11 +1031,15 @@ func (dc *dexConnection) bestBookFeeSuggestion(assetID uint32) uint64 {
 	dc.booksMtx.RLock()
 	defer dc.booksMtx.RUnlock()
 	for _, book := range dc.books {
+		var feeRate uint64
 		switch assetID {
 		case book.base:
-			return book.BaseFeeRate()
+			feeRate = book.BaseFeeRate()
 		case book.quote:
-			return book.QuoteFeeRate()
+			feeRate = book.QuoteFeeRate()
+		}
+		if feeRate > 0 {
+			return feeRate
 		}
 	}
 	return 0
@@ -2844,8 +2848,8 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	c.log.Infof("Attempting registration fee payment to %s, account ID %v, of %d units of %s. "+
 		"Do NOT manually send funds to this address even if this fails.",
 		regRes.Address, dc.acct.id, regRes.Fee, regFeeAssetSymbol)
-	feeRateSuggestion := dc.fetchFeeRate(feeAsset.ID)
-	coin, err := wallet.PayFee(regRes.Address, regRes.Fee, feeRateSuggestion)
+	feeRate := c.feeSuggestionAny(feeAsset.ID)
+	coin, err := wallet.PayFee(regRes.Address, regRes.Fee, feeRate)
 	if err != nil {
 		return nil, newError(feeSendErr, "error paying registration fee: %v", err)
 	}
@@ -3460,7 +3464,7 @@ func (c *Core) MaxBuy(host string, base, quote uint32, rate uint64) (*MaxOrderEs
 		return nil, fmt.Errorf("failed to get swap fee suggestion for %s at %s", unbip(quote), host)
 	}
 
-	redeemFeeSuggestion := c.feeSuggestion(dc, base)
+	redeemFeeSuggestion := c.feeSuggestionAny(base)
 	if redeemFeeSuggestion == 0 {
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(base), host)
 	}
@@ -3518,7 +3522,7 @@ func (c *Core) MaxSell(host string, base, quote uint32) (*MaxOrderEstimate, erro
 		return nil, fmt.Errorf("failed to get swap fee suggestion for %s at %s", unbip(base), host)
 	}
 
-	redeemFeeSuggestion := c.feeSuggestion(dc, quote)
+	redeemFeeSuggestion := c.feeSuggestionAny(quote)
 	if redeemFeeSuggestion == 0 {
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(quote), host)
 	}
@@ -3724,11 +3728,22 @@ func (c *Core) notifyFee(dc *dexConnection, coinID []byte) error {
 }
 
 // feeSuggestionAny gets a fee suggestion for the given asset from any source
-// with it available. It first checks all relevant books for a cached fee rate
-// obtained with an epoch_report message, and falls back to directly requesting
-// a rate from servers with a fee_rate request.
+// with it available. It first checks for a capable wallet, then relevant books
+// for a cached fee rate obtained with an epoch_report message, and falls back
+// to directly requesting a rate from servers with a fee_rate request.
 func (c *Core) feeSuggestionAny(assetID uint32) uint64 {
 	conns := c.dexConnections()
+	// See if the wallet supports fee rates.
+	w, found := c.wallet(assetID)
+	if found && w.connected() {
+		if rater, is := w.feeRater(); is {
+			if r, err := rater.FeeRate(); err == nil {
+				return r
+			} else {
+				c.log.Debugf("failed to get fee suggestion from %s FeeRater: %v", unbip(assetID), err)
+			}
+		}
+	}
 	// Look for cached rates from epoch_report messages.
 	for _, dc := range conns {
 		feeSuggestion := dc.bestBookFeeSuggestion(assetID)
@@ -3736,8 +3751,32 @@ func (c *Core) feeSuggestionAny(assetID uint32) uint64 {
 			return feeSuggestion
 		}
 	}
+
+	// Helper function to determine if a server has an active market that pairs
+	// the requested asset.
+	hasActiveMarket := func(dc *dexConnection) bool {
+		dc.cfgMtx.RLock()
+		cfg := dc.cfg
+		dc.cfgMtx.RUnlock()
+		for _, mkt := range cfg.Markets {
+			if mkt.Base == assetID || mkt.Quote == assetID && mkt.Running() {
+				return true
+			}
+		}
+		return false
+	}
+
 	// Request a rate with fee_rate.
 	for _, dc := range conns {
+		// The server should have at least one active market with the asset,
+		// otherwise we might get an outdated rate for an asset whose backend
+		// might be supported but not in active use, e.g. down for maintenance.
+		// The fee_rate endpoint will happily return a very old rate without
+		// indication.
+		if !hasActiveMarket(dc) {
+			continue
+		}
+
 		feeSuggestion := dc.fetchFeeRate(assetID)
 		if feeSuggestion > 0 {
 			return feeSuggestion
@@ -3880,7 +3919,7 @@ func (c *Core) PreOrder(form *TradeForm) (*OrderEstimate, error) {
 		return nil, fmt.Errorf("failed to get swap fee suggestion for %s at %s", unbip(wallets.fromAsset.ID), form.Host)
 	}
 
-	redeemFeeSuggestion := c.feeSuggestion(dc, wallets.toAsset.ID)
+	redeemFeeSuggestion := c.feeSuggestionAny(wallets.toAsset.ID)
 	if redeemFeeSuggestion == 0 {
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(wallets.toAsset.ID), form.Host)
 	}
@@ -6353,6 +6392,13 @@ func (c *Core) tipChange(assetID uint32, nodeErr error) {
 // cached, no new requests will be made.
 func (c *Core) cacheRedemptionFeeSuggestion(t *trackedTrade) {
 	// Try to find any book that might have the fee.
+	if rater, is := t.wallets.toWallet.feeRater(); is {
+		if feeRate, err := rater.FeeRate(); err == nil {
+			atomic.StoreUint64(&t.redeemFeeSuggestion, feeRate)
+		} else {
+			c.log.Debugf("unable to retrieve fee rate from FeeRater. falling back to other methods: %v", err)
+		}
+	}
 	redeemAsset := t.wallets.toAsset.ID
 	feeSuggestion := t.dc.bestBookFeeSuggestion(redeemAsset)
 	if feeSuggestion > 0 {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -561,7 +561,7 @@ func (r *tReceipt) SignedRefund() dex.Bytes {
 }
 
 type TXCWallet struct {
-	mtx               sync.RWMutex
+	payFeeSuggestion  uint64
 	payFeeCoin        *tCoin
 	payFeeErr         error
 	addrErr           error
@@ -659,10 +659,6 @@ func (w *TXCWallet) Balance() (*asset.Balance, error) {
 		w.bal = new(asset.Balance)
 	}
 	return w.bal, nil
-}
-
-func (w *TXCWallet) FeeRate() (uint64, error) {
-	return 24, nil
 }
 
 func (w *TXCWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, error) {
@@ -777,21 +773,17 @@ func (w *TXCWallet) Locked() bool {
 	return w.locked
 }
 
-func (w *TXCWallet) Send(address string, fee uint64, _ *dex.Asset) (asset.Coin, error) {
-	w.mtx.RLock()
-	defer w.mtx.RUnlock()
-	return w.payFeeCoin, w.payFeeErr
-}
-
 func (w *TXCWallet) ConfirmTime(id dex.Bytes, nConfs uint32) (time.Time, error) {
 	return time.Time{}, nil
 }
 
-func (w *TXCWallet) PayFee(address string, fee, feeRateSuggestion uint64) (asset.Coin, error) {
+func (w *TXCWallet) PayFee(address string, fee, feeSuggestion uint64) (asset.Coin, error) {
+	w.payFeeSuggestion = feeSuggestion
 	return w.payFeeCoin, w.payFeeErr
 }
 
 func (w *TXCWallet) Withdraw(address string, value, feeSuggestion uint64) (asset.Coin, error) {
+	w.payFeeSuggestion = feeSuggestion
 	return w.payFeeCoin, w.payFeeErr
 }
 
@@ -856,6 +848,18 @@ func (w *TAccountRedeemer) ReReserve(v uint64) error {
 
 func (w *TAccountRedeemer) UnlockReserves(v uint64) {
 	w.redemptionUnlocked += v
+}
+
+type TFeeRater struct {
+	*TXCWallet
+	feeRate uint64
+}
+
+func (w *TFeeRater) FeeRate() (uint64, error) {
+	if w.feeRate == 0 {
+		return 0, fmt.Errorf("test fee rate unavailable")
+	}
+	return w.feeRate, nil
 }
 
 type tCrypterSmart struct {
@@ -2358,6 +2362,29 @@ func TestWithdraw(t *testing.T) {
 	coinID := coin.ID()
 	if len(coinID) != 1 || coinID[0] != 'a' {
 		t.Fatalf("coin ID not propagated")
+	}
+
+	// So far, the fee suggestion should have always been zero.
+	if tWallet.payFeeSuggestion != 0 {
+		t.Fatalf("unexpected non-zero fee rate when no books or responses prepared")
+	}
+
+	const feeRate = 54321
+
+	feeRater := &TFeeRater{
+		TXCWallet: tWallet,
+		feeRate:   feeRate,
+	}
+
+	wallet.Wallet = feeRater
+
+	_, err = tCore.Withdraw(tPW, tDCR.ID, 1e8, address)
+	if err != nil {
+		t.Fatalf("FeeRater Withdraw error: %v", err)
+	}
+
+	if tWallet.payFeeSuggestion != feeRate {
+		t.Fatalf("unexpected fee rate from FeeRater. wanted %d, got %d", feeRate, tWallet.payFeeSuggestion)
 	}
 }
 

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1860,7 +1860,6 @@ func (c *Core) redeemMatchGroup(t *trackedTrade, matches []*matchTracker, errs *
 	// one cached.
 	feeSuggestion := atomic.LoadUint64(&t.redeemFeeSuggestion)
 	if feeSuggestion == 0 {
-		// No new RPC requests.
 		feeSuggestion = t.dc.bestBookFeeSuggestion(t.wallets.toAsset.ID)
 	}
 

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -309,3 +309,9 @@ func (w *xcWallet) SwapConfirmations(ctx context.Context, coinID []byte, contrac
 	defer cancel()
 	return w.Wallet.SwapConfirmations(ctx, coinID, contract, encode.UnixTimeMilli(int64(matchTime)))
 }
+
+// feeRater is identical to calling w.Wallet.(asset.FeeRater).
+func (w *xcWallet) feeRater() (asset.FeeRater, bool) {
+	rater, is := w.Wallet.(asset.FeeRater)
+	return rater, is
+}


### PR DESCRIPTION
```
A FeeRater can generate fee suggestions when they are not validated by the
server, specifically for inputs to Withdraw, PayFee, Send, and
possibly Refund. This corresponds to places where
(*Core).feeSuggestionAny would be used.
```