### PR TITLE
client/{core,ui}: Fix unit info and asset config usage on markets page

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6215,15 +6215,16 @@ func (c *Core) cacheRedemptionFeeSuggestion(t *trackedTrade) {
 
 // convertAssetInfo converts from a *msgjson.Asset to the nearly identical
 // *dex.Asset.
-func convertAssetInfo(asset *msgjson.Asset) *dex.Asset {
+func convertAssetInfo(ai *msgjson.Asset) *dex.Asset {
 	return &dex.Asset{
-		ID:           asset.ID,
-		Symbol:       asset.Symbol,
-		Version:      asset.Version,
-		MaxFeeRate:   asset.MaxFeeRate,
-		SwapSize:     asset.SwapSize,
-		SwapSizeBase: asset.SwapSizeBase,
-		SwapConf:     uint32(asset.SwapConf),
+		ID:           ai.ID,
+		Symbol:       ai.Symbol,
+		Version:      ai.Version,
+		MaxFeeRate:   ai.MaxFeeRate,
+		SwapSize:     ai.SwapSize,
+		SwapSizeBase: ai.SwapSizeBase,
+		SwapConf:     uint32(ai.SwapConf),
+		UnitInfo:     ai.UnitInfo,
 	}
 }
 

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -218,6 +218,7 @@ func mkDexAsset(symbol string) *dex.Asset {
 		SwapSize:     uint64(rand.Intn(150) + 150),
 		SwapSizeBase: uint64(rand.Intn(150) + 15),
 		SwapConf:     uint32(rand.Intn(5) + 2),
+		UnitInfo:     dex.UnitInfo{Conventional: dex.Denomination{ConversionFactor: 1e8}},
 	}
 	return a
 }

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -670,8 +670,16 @@ export default class Application {
     }
   }
 
-  /* unitInfo fetches unit info [dex.UnitInfo] for the asset */
-  unitInfo (assetID) { return this.assets[assetID].info.unitinfo }
+  /*
+   * unitInfo fetches unit info [dex.UnitInfo] for the asset. If xc
+   * [core.Exchange] is provided, and this is not a SupportedAsset, the UnitInfo
+   * sent from the exchange's assets map [dex.Asset] will be used.
+   */
+  unitInfo (assetID, xc) {
+    const supportedAsset = this.assets[assetID]
+    if (supportedAsset) return supportedAsset.info.unitinfo
+    return xc.assets[assetID].unitInfo
+  }
 
   /* conventionalRate converts the encoded atomic rate to a conventional rate */
   conventionalRate (baseID, quoteID, encRate) {

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -480,9 +480,9 @@ export class FeeAssetSelectionForm {
       const marketTmpl = Doc.parseTemplate(marketNode)
 
       const baseAsset = xc.assets[mkt.baseid]
-      const baseUnitInfo = unitInfo(xc, mkt.baseid)
+      const baseUnitInfo = app().unitInfo(mkt.baseid, xc)
       const quoteAsset = xc.assets[mkt.quoteid]
-      const quoteUnitInfo = unitInfo(xc, mkt.quoteid)
+      const quoteUnitInfo = app().unitInfo(mkt.quoteid, xc)
 
       if (cFactor(baseUnitInfo) === 0 || cFactor(quoteUnitInfo) === 0) return null
 
@@ -1002,12 +1002,4 @@ export function bind (form, submitBttn, handler) {
 // value representing true.
 function isTruthyString (s) {
   return s === '1' || s.toLowerCase() === 'true'
-}
-
-function unitInfo (xc, assetID) {
-  const dexAsset = xc.assets[assetID]
-  if (dexAsset && dexAsset.unitInfo.conventional.conversionFactor > 0) return dexAsset.unitInfo
-  const supportedAsset = app().assets[assetID]
-  if (!supportedAsset) return null
-  return supportedAsset.info.unitinfo
 }

--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -699,6 +699,7 @@ export default class MarketsPage extends BasePage {
    */
   previewQuoteAmt (show) {
     const page = this.page
+    if (!this.market.base || !this.market.quote) return // Not a supported asset
     const order = this.parseOrder()
     const adjusted = this.adjustedRate()
     page.orderErr.textContent = ''


### PR DESCRIPTION
```
We were expecting a SupportedAsset in some places where it wasn't guaranteed.
Update Application.unitInfo method to accept optional xc [core.Exchange] argument
from which to look for UnitInfo. Pass the arg in relevant contexts.
Use MarketsPage.market.{baseCfg,quoteCfg} [dex.Asset] instead of
{base,quote} [core.SupportedAsset] in book-related code. Fix omission in
(*Core).convertAssetInfo.
```

Resolves #1428