### PR TITLE
client/ui: Display registration tx fee estimate

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2634,6 +2634,16 @@ func (btc *baseWallet) PayFee(address string, regFee, feeRate uint64) (asset.Coi
 	return newOutput(txHash, vout, sent), nil
 }
 
+// EstimateRegistrationTxFee returns an estimate for the tx fee needed to
+// pay the registration fee using the provided feeRate.
+func (btc *baseWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
+	const inputCount = 5 // buffer so this estimate is higher than what PayFee uses
+	if feeRate == 0 || feeRate > btc.feeRateLimit {
+		feeRate = btc.fallbackFeeRate
+	}
+	return (dexbtc.MinimumTxOverhead + 2*dexbtc.P2PKHOutputSize + inputCount*dexbtc.RedeemP2PKHInputSize) * feeRate
+}
+
 // Withdraw withdraws funds to the specified address. Fees are subtracted from
 // the value. feeRate is in units of atoms/byte.
 func (btc *baseWallet) Withdraw(address string, value, feeRate uint64) (asset.Coin, error) {

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -2397,6 +2397,38 @@ func TestPayFee(t *testing.T) {
 	})
 }
 
+func TestEstimateRegistrationTxFee(t *testing.T) {
+	runRubric(t, testEstimateRegistrationTxFee)
+}
+
+func testEstimateRegistrationTxFee(t *testing.T, segwit bool, walletType string) {
+	wallet, _, shutdown, err := tNewWallet(segwit, walletType)
+	defer shutdown()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const inputCount = 5
+	const txSize = dexbtc.MinimumTxOverhead + 2*dexbtc.P2PKHOutputSize + inputCount*dexbtc.RedeemP2PKHInputSize
+	wallet.feeRateLimit = 100
+	wallet.fallbackFeeRate = 30
+
+	estimate := wallet.EstimateRegistrationTxFee(50)
+	if estimate != 50*txSize {
+		t.Fatalf("expected tx fee to be %d but got %d", 50*txSize, estimate)
+	}
+
+	estimate = wallet.EstimateRegistrationTxFee(0)
+	if estimate != wallet.fallbackFeeRate*txSize {
+		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)
+	}
+
+	estimate = wallet.EstimateRegistrationTxFee(wallet.feeRateLimit + 1)
+	if estimate != wallet.fallbackFeeRate*txSize {
+		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)
+	}
+}
+
 func TestWithdraw(t *testing.T) {
 	runRubric(t, func(t *testing.T, segwit bool, walletType string) {
 		testSender(t, tWithdrawSender, segwit, walletType)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2556,6 +2556,16 @@ func (dcr *baseWallet) PayFee(address string, regFee, feeRate uint64) (asset.Coi
 	return newOutput(msgTx.CachedTxHash(), 0, regFee, wire.TxTreeRegular), nil
 }
 
+// EstimateRegistrationTxFee returns an estimate for the tx fee needed to
+// pay the registration fee using the provided feeRate.
+func (dcr *baseWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
+	const inputCount = 5 // buffer so this estimate is higher than what PayFee uses
+	if feeRate == 0 || feeRate > dcr.feeRateLimit {
+		feeRate = dcr.fallbackFeeRate
+	}
+	return (dexdcr.MsgTxOverhead + dexdcr.P2PKHOutputSize*2 + inputCount*dexdcr.P2PKHInputSize) * feeRate
+}
+
 // Withdraw withdraws funds to the specified address. Fees are subtracted from
 // the value.
 func (dcr *baseWallet) Withdraw(address string, value, feeRate uint64) (asset.Coin, error) {

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -2496,3 +2496,28 @@ func TestPreRedeem(t *testing.T) {
 		t.Fatalf("best case > worst case")
 	}
 }
+
+func TestEstimateRegistrationTxFee(t *testing.T) {
+	wallet, _, shutdown, _ := tNewWallet()
+	defer shutdown()
+
+	const inputCount = 5
+	const txSize = dexdcr.MsgTxOverhead + dexdcr.P2PKHOutputSize*2 + inputCount*dexdcr.P2PKHInputSize
+	wallet.feeRateLimit = 100
+	wallet.fallbackFeeRate = 30
+
+	estimate := wallet.EstimateRegistrationTxFee(50)
+	if estimate != 50*txSize {
+		t.Fatalf("expected tx fee to be %d but got %d", 50*txSize, estimate)
+	}
+
+	estimate = wallet.EstimateRegistrationTxFee(0)
+	if estimate != wallet.fallbackFeeRate*txSize {
+		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)
+	}
+
+	estimate = wallet.EstimateRegistrationTxFee(wallet.feeRateLimit + 1)
+	if estimate != wallet.fallbackFeeRate*txSize {
+		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)
+	}
+}

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1188,6 +1188,12 @@ func (eth *ExchangeWallet) PayFee(address string, regFee, _ uint64) (asset.Coin,
 	return &coin{id: txHash[:], value: dexeth.WeiToGwei(tx.Value())}, nil
 }
 
+// EstimateRegistrationTxFee returns an estimate for the tx fee needed to
+// pay the registration fee using the provided feeRate.
+func (eth *ExchangeWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
+	return feeRate * defaultSendGasLimit
+}
+
 // SwapConfirmations gets the number of confirmations and the spend status
 // for the specified swap.
 func (eth *ExchangeWallet) SwapConfirmations(ctx context.Context, _ dex.Bytes, contract dex.Bytes, _ time.Time) (confs uint32, spent bool, err error) {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -299,6 +299,9 @@ type Wallet interface {
 	// payment. This method need not be supported by all assets. Those assets
 	// which do no support DEX registration fees will return an ErrUnsupported.
 	RegFeeConfirmations(ctx context.Context, coinID dex.Bytes) (confs uint32, err error)
+	// EstimateRegistrationTxFee returns an estimate for the tx fee needed to
+	// pay the registration fee using the provided feeRate.
+	EstimateRegistrationTxFee(feeRate uint64) uint64
 }
 
 // Rescanner is a wallet implementation with rescan functionality.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2707,7 +2707,7 @@ func (c *Core) EstimateRegistrationTxFee(host string, certI interface{}, assetID
 		if r, err := rater.FeeRate(); err == nil {
 			rate = r
 		} else {
-			c.log.Debugf("failed to get fee suggestion from %s FeeRater: %v", unbip(assetID), err)
+			c.log.Warnf("failed to get fee suggestion from %s FeeRater: %v", unbip(assetID), err)
 		}
 	}
 
@@ -2720,7 +2720,7 @@ func (c *Core) EstimateRegistrationTxFee(host string, certI interface{}, assetID
 		if err == nil {
 			rate = dc.fetchFeeRate(assetID)
 		} else {
-			c.log.Debugf("failed to connect to dex: %v", err)
+			c.log.Warnf("failed to connect to dex: %v", err)
 		}
 	}
 
@@ -3776,7 +3776,7 @@ func (c *Core) feeSuggestionAny(assetID uint32, preferredConns ...*dexConnection
 			if r, err := rater.FeeRate(); err == nil {
 				return r
 			} else {
-				c.log.Debugf("failed to get fee suggestion from %s FeeRater: %v", unbip(assetID), err)
+				c.log.Warnf("failed to get fee suggestion from %s FeeRater: %v", unbip(assetID), err)
 			}
 		}
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2692,6 +2692,42 @@ func (c *Core) DiscoverAccount(dexAddr string, appPW []byte, certI interface{}) 
 	return dc.exchangeInfo(), true, nil
 }
 
+// EstimateRegistrationTxFee provides an estimate for the tx fee needed to
+// pay the registration fee for a certain asset. The dex host is required
+// because the dex server is used as a fallback to determine the current
+// fee rate in case the client wallet is unable to do it.
+func (c *Core) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
+	wallet, err := c.connectedWallet(assetID)
+	if err != nil {
+		return 0, err
+	}
+
+	var rate uint64
+	if rater, is := wallet.Wallet.(asset.FeeRater); is {
+		if r, err := rater.FeeRate(); err == nil {
+			rate = r
+		} else {
+			c.log.Debugf("failed to get fee suggestion from %s FeeRater: %v", unbip(assetID), err)
+		}
+	}
+
+	if rate == 0 {
+		dc, err := c.tempDexConnection(host, certI)
+		if dc != nil {
+			// Stop (re)connect loop, which may be running even if err != nil.
+			defer dc.connMaster.Disconnect()
+		}
+		if err == nil {
+			rate = dc.fetchFeeRate(assetID)
+		} else {
+			c.log.Debugf("failed to connect to dex: %v", err)
+		}
+	}
+
+	txFee := wallet.EstimateRegistrationTxFee(rate)
+	return txFee, nil
+}
+
 // Register registers an account with a new DEX. If an error occurs while
 // fetching the DEX configuration or creating the fee transaction, it will be
 // returned immediately.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -800,6 +800,10 @@ func (w *TXCWallet) Withdraw(address string, value, feeSuggestion uint64) (asset
 	return w.payFeeCoin, w.payFeeErr
 }
 
+func (w *TXCWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
+	return 0
+}
+
 func (w *TXCWallet) ValidateSecret(secret, secretHash []byte) bool {
 	return !w.badSecret
 }

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -59,9 +59,8 @@ func (s *WebServer) apiEstimateRegistrationTxFee(w http.ResponseWriter, r *http.
 		return
 	}
 	resp := struct {
-		OK       bool           `json:"ok"`
-		Exchange *core.Exchange `json:"xc,omitempty"`
-		TxFee    uint64         `json:"txfee"`
+		OK    bool   `json:"ok"`
+		TxFee uint64 `json:"txfee"`
 	}{
 		OK:    true,
 		TxFee: txFee,

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -46,6 +46,29 @@ func (s *WebServer) apiDiscoverAccount(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp, s.indent)
 }
 
+// apiEstimateRegistrationTxFee is the handler for the '/regtxfee' API request.
+func (s *WebServer) apiEstimateRegistrationTxFee(w http.ResponseWriter, r *http.Request) {
+	form := new(registrationTxFeeForm)
+	if !readPost(w, r, form) {
+		return
+	}
+	cert := []byte(form.Cert)
+	txFee, err := s.core.EstimateRegistrationTxFee(form.Addr, cert, *form.AssetID)
+	if err != nil {
+		s.writeAPIError(w, err)
+		return
+	}
+	resp := struct {
+		OK       bool           `json:"ok"`
+		Exchange *core.Exchange `json:"xc,omitempty"`
+		TxFee    uint64         `json:"txfee"`
+	}{
+		OK:    true,
+		TxFee: txFee,
+	}
+	writeJSON(w, resp, s.indent)
+}
+
 // apiGetDEXInfo is the handler for the '/getdexinfo' API request.
 func (s *WebServer) apiGetDEXInfo(w http.ResponseWriter, r *http.Request) {
 	form := new(registrationForm)

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -524,6 +524,9 @@ func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) {
 	c.reg = r
 	return nil, nil
 }
+func (c *TCore) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
+	return 0, nil
+}
 func (c *TCore) Login([]byte) (*core.LoginResult, error) { return &core.LoginResult{}, nil }
 func (c *TCore) IsInitialized() bool                     { return true }
 func (c *TCore) Logout() error                           { return nil }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -188,6 +188,7 @@ var EnUS = map[string]string{
 	"Registration fee":            "Registration fee",
 	"Your Deposit Address":        "Your Deposit Address",
 	"Send enough for reg fee":     `Make sure you send enough to also cover network fees.`,
+	"Send enough with estimate":   `Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.`,
 	"add a different server":      "add a different server",
 	"Add a custom server":         "Add a custom server",
 	"plus tx fees":                "+ tx fees",

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=zA3PB0J"></script>
+<script src="/js/entry.js?v=qgnUuBH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">[[[Your Deposit Address]]]</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">[[[Send enough for reg fee]]]</span>
+    <span data-tmpl="sendEnoughWithEst">[[[Send enough with estimate]]]</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -658,6 +658,18 @@ export default class Application {
     return o
   }
 
+  haveAssetOrders (assetID) {
+    for (const xc of Object.values(this.user.exchanges)) {
+      for (const market of Object.values(xc.markets)) {
+        if (!market.orders) continue
+        for (const ord of market.orders) {
+          if (ord.baseID === assetID || ord.quoteID === assetID) return true
+        }
+      }
+    }
+    return false
+  }
+
   /* order attempts to locate an order by order ID. */
   order (oid) {
     for (const xc of Object.values(this.user.exchanges)) {

--- a/client/webserver/site/src/js/app.js
+++ b/client/webserver/site/src/js/app.js
@@ -658,18 +658,6 @@ export default class Application {
     return o
   }
 
-  haveAssetOrders (assetID) {
-    for (const xc of Object.values(this.user.exchanges)) {
-      for (const market of Object.values(xc.markets)) {
-        if (!market.orders) continue
-        for (const ord of market.orders) {
-          if (ord.baseID === assetID || ord.quoteID === assetID) return true
-        }
-      }
-    }
-    return false
-  }
-
   /* order attempts to locate an order by order ID. */
   order (oid) {
     for (const xc of Object.values(this.user.exchanges)) {

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -608,7 +608,7 @@ export class WalletWaitForm {
   }
 
   /* setWallet must be called before showing the form. */
-  setWallet (wallet) {
+  setWallet (wallet, txFee) {
     this.assetID = wallet.assetID
     this.progressCache = []
     this.progressed = false
@@ -623,7 +623,16 @@ export class WalletWaitForm {
     page.fee.textContent = Doc.formatCoinValue(fee.amount, asset.info.unitinfo)
 
     Doc.hide(page.syncUncheck, page.syncCheck, page.balUncheck, page.balCheck, page.syncRemainBox)
-    Doc.show(page.balanceBox, page.sendEnough)
+    Doc.show(page.balanceBox)
+
+    if (txFee > 0) {
+      page.totalFees.textContent = Doc.formatCoinValue(fee.amount + txFee, asset.info.unitinfo)
+      Doc.show(page.sendEnoughWithEst)
+      Doc.hide(page.sendEnough)
+    } else {
+      Doc.show(page.sendEnough)
+      Doc.hide(page.sendEnoughWithEst)
+    }
 
     Doc.show(wallet.synced ? page.syncCheck : wallet.syncProgress >= 1 ? page.syncSpinner : page.syncUncheck)
     Doc.show(wallet.balance.available > fee.amount ? page.balCheck : page.balUncheck)

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=zA3PB0J"></script>
+<script src="/js/entry.js?v=qgnUuBH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=zA3PB0J"></script>
+<script src="/js/entry.js?v=qgnUuBH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Twój adres do wpłaty</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Upewnij się, że wysyłasz wystarczająco dużo środków, aby pokryć również opłaty sieciowe.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=zA3PB0J"></script>
+<script src="/js/entry.js?v=qgnUuBH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Seu Endereço de Depósito</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=zA3PB0J"></script>
+<script src="/js/entry.js?v=qgnUuBH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -51,6 +51,12 @@ type registrationForm struct {
 	AssetID  *uint32          `json:"asset,omitempty"` // prevent out-of-date frontend from paying fee in BTC
 }
 
+type registrationTxFeeForm struct {
+	Addr    string  `json:"addr"`
+	Cert    string  `json:"cert"`
+	AssetID *uint32 `json:"asset,omitempty"`
+}
+
 // newWalletForm is information necessary to create a new wallet.
 type newWalletForm struct {
 	AssetID    uint32 `json:"assetID"`

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -111,6 +111,7 @@ type clientCore interface {
 	ExportSeed(pw []byte) ([]byte, error)
 	PreOrder(*core.TradeForm) (*core.OrderEstimate, error)
 	WalletLogFilePath(assetID uint32) (string, error)
+	EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -309,6 +310,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiInit.Post("/login", s.apiLogin)
 			apiInit.Post("/getdexinfo", s.apiGetDEXInfo)
 			apiInit.Post("/discoveracct", s.apiDiscoverAccount)
+			apiInit.Post("/regtxfee", s.apiEstimateRegistrationTxFee)
 		})
 
 		r.Group(func(apiAuth chi.Router) {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -81,9 +81,12 @@ func (c *TCore) DiscoverAccount(dexAddr string, pw []byte, certI interface{}) (*
 	return nil, false, nil
 }
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
-func (c *TCore) InitializeClient(pw, seed []byte) error                      { return c.initErr }
-func (c *TCore) Login(pw []byte) (*core.LoginResult, error)                  { return &core.LoginResult{}, c.loginErr }
-func (c *TCore) IsInitialized() bool                                         { return c.isInited }
+func (c *TCore) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
+	return 0, nil
+}
+func (c *TCore) InitializeClient(pw, seed []byte) error     { return c.initErr }
+func (c *TCore) Login(pw []byte) (*core.LoginResult, error) { return &core.LoginResult{}, c.loginErr }
+func (c *TCore) IsInitialized() bool                        { return c.isInited }
 func (c *TCore) SyncBook(dex string, base, quote uint32) (core.BookFeed, error) {
 	return c.syncFeed, c.syncErr
 }


### PR DESCRIPTION
- `client/core`: Add `EstimateRegistrationTxFee` function in core that determines the tx fee needed to register for the dex
- `client/asset`: Add `EstimateRegistrationTxFee` to wallet interface
- `client/webserver`: Add a new api endpoint `/regtxfee`
- `ui`: Each time the WalletWaitForm is loaded, this endpoint is called to retrieve an estimate