### PR TITLE
client: monitor wallet peers

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -246,6 +246,10 @@ type tRawRequester struct {
 func (c *tRawRequester) RawRequest(_ context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	switch method {
 	// TODO: handle methodGetBlockHash and add actual tests to cover it.
+	case methodGetNetworkInfo:
+		return json.Marshal(&btcjson.GetNetworkInfoResult{
+			Connections: 1,
+		})
 	case methodEstimateSmartFee:
 		if c.testData.estFeeErr != nil {
 			return nil, c.testData.estFeeErr
@@ -579,6 +583,9 @@ func tNewWallet(segwit bool, walletType string) (*ExchangeWallet, *testData, fun
 			case data.tipChanged <- struct{}{}:
 			default:
 			}
+		},
+		PeersChange: func(num uint32) {
+			fmt.Println("peer count: ", num)
 		},
 	}
 	walletCtx, shutdown := context.WithCancel(tCtx)

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -58,6 +58,9 @@ func tBackend(ctx context.Context, t *testing.T, cfg *Config, node, name string,
 		TipChange: func(err error) {
 			blkFunc(reportName, err)
 		},
+		PeersChange: func(num uint32) {
+			fmt.Println("peer count: ", num)
+		},
 	}
 
 	w, err := cfg.NewWallet(walletCfg, logger, dex.Regtest)

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -47,6 +47,9 @@ const (
 	methodGetBestBlockHash   = "getbestblockhash"
 	methodGetRawMempool      = "getrawmempool"
 	methodGetRawTransaction  = "getrawtransaction"
+	methodGetBlockHeader     = "getblockheader"
+	methodGetNetworkInfo     = "getnetworkinfo"
+	methodGetBlockchainInfo  = "getblockchaininfo"
 )
 
 // RawRequester defines decred's rpcclient RawRequest func where all RPC
@@ -530,6 +533,17 @@ func (wc *rpcClient) getBlockHeight(blockHash *chainhash.Hash) (int32, error) {
 		return -1, fmt.Errorf("block is not a mainchain block")
 	}
 	return int32(hdr.Height), nil
+}
+
+func (wc *rpcClient) peerCount() (uint32, error) {
+	var r struct {
+		Connections uint32 `json:"connections"`
+	}
+	err := wc.call(methodGetNetworkInfo, nil, &r)
+	if err != nil {
+		return 0, err
+	}
+	return r.Connections, nil
 }
 
 // getBlockchainInfo sends the getblockchaininfo request and returns the result.

--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -497,6 +497,10 @@ func (w *spvWallet) getChainHeight() (int32, error) {
 	return blk.Height, err
 }
 
+func (w *spvWallet) peerCount() (uint32, error) {
+	return uint32(len(w.cl.Peers())), nil
+}
+
 // syncHeight is the best known sync height among peers.
 func (w *spvWallet) syncHeight() int32 {
 	var maxHeight int32

--- a/client/asset/btc/wallet.go
+++ b/client/asset/btc/wallet.go
@@ -36,6 +36,7 @@ type Wallet interface {
 	sendToAddress(address string, value, feeRate uint64, subtract bool) (*chainhash.Hash, error)
 	locked() bool
 	syncStatus() (*syncStatus, error)
+	peerCount() (uint32, error)
 	swapConfirmations(txHash *chainhash.Hash, vout uint32, contract []byte, startTime time.Time) (confs uint32, spent bool, err error)
 	getBlockHeader(blockHash *chainhash.Hash) (*blockHeader, error)
 	ownsAddress(addr btcutil.Address) (bool, error)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"decred.org/dcrdex/client/asset"
@@ -69,6 +70,7 @@ const (
 var (
 	// blockTicker is the delay between calls to check for new blocks.
 	blockTicker                  = time.Second
+	peerCountTicker              = 5 * time.Second
 	conventionalConversionFactor = float64(dexdcr.UnitInfo.Conventional.ConversionFactor)
 	configOpts                   = []*asset.ConfigOption{
 		{
@@ -386,6 +388,8 @@ type ExchangeWallet struct {
 	log              dex.Logger
 	acct             string
 	tipChange        func(error)
+	lastPeerCount    uint32
+	peersChange      func(uint32)
 	fallbackFeeRate  uint64
 	feeRateLimit     uint64
 	redeemConfTarget uint64
@@ -501,6 +505,7 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *Config, chainParams *cha
 		chainParams:         chainParams,
 		acct:                dcrCfg.Account,
 		tipChange:           cfg.TipChange,
+		peersChange:         cfg.PeersChange,
 		fundingCoins:        make(map[outPoint]*fundingCoin),
 		findRedemptionQueue: make(map[outPoint]*findRedemptionReq),
 		externalTxCache:     make(map[chainhash.Hash]*externalTx),
@@ -581,6 +586,11 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 			<-ctx.Done() // just wait for shutdown signal
 		}
 		dcr.shutdown()
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		dcr.monitorPeers(ctx)
 	}()
 	return &wg, nil
 }
@@ -3064,6 +3074,38 @@ func (dcr *ExchangeWallet) getKeys(addr stdaddr.Address) (*secp256k1.PrivateKey,
 
 	priv := secp256k1.PrivKeyFromBytes(wif.PrivKey())
 	return priv, priv.PubKey(), nil
+}
+
+func (dcr *ExchangeWallet) checkPeers() {
+	ctx, cancel := context.WithTimeout(dcr.ctx, 2*time.Second)
+	defer cancel()
+	numPeers, err := dcr.wallet.PeerCount(ctx)
+	if err != nil { // e.g. dcrd passthrough fail in non-SPV mode
+		prevPeer := atomic.SwapUint32(&dcr.lastPeerCount, 0)
+		if prevPeer != 0 {
+			dcr.log.Errorf("Failed to get peer count: %v", err)
+			dcr.peersChange(0)
+		}
+		return
+	}
+	prevPeer := atomic.SwapUint32(&dcr.lastPeerCount, numPeers)
+	if prevPeer != numPeers {
+		dcr.peersChange(numPeers)
+	}
+}
+
+func (dcr *ExchangeWallet) monitorPeers(ctx context.Context) {
+	ticker := time.NewTicker(peerCountTicker)
+	defer ticker.Stop()
+	for {
+		dcr.checkPeers()
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // monitorBlocks pings for new blocks and runs the tipChange callback function

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -152,7 +152,8 @@ func newTxOutResult(script []byte, value uint64, confs int64) *chainjson.GetTxOu
 func tNewWallet() (*ExchangeWallet, *tRPCClient, func(), error) {
 	client := newTRPCClient()
 	walletCfg := &asset.WalletConfig{
-		TipChange: func(error) {},
+		TipChange:   func(error) {},
+		PeersChange: func(uint32) {},
 	}
 	walletCtx, shutdown := context.WithCancel(tCtx)
 	wallet, err := unconnectedWallet(walletCfg, &Config{Account: "default"}, tChainParams, tLogger)
@@ -530,6 +531,12 @@ func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.
 	}
 
 	switch method {
+	case methodGetPeerInfo:
+		return json.Marshal([]*walletjson.GetPeerInfoResult{
+			{
+				Addr: "127.0.0.1",
+			},
+		})
 	case methodGetCFilterV2:
 		if len(params) != 1 {
 			return nil, fmt.Errorf("getcfilterv2 requires 1 param, got %d", len(params))

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -74,6 +74,9 @@ func tBackend(t *testing.T, name string, blkFunc func(string, error)) (*Exchange
 		TipChange: func(err error) {
 			blkFunc(name, err)
 		},
+		PeersChange: func(num uint32) {
+			t.Log("peer count: ", num)
+		},
 	}
 	var backend asset.Wallet
 	backend, err = NewWallet(walletCfg, tLogger, dex.Simnet)

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -135,6 +135,9 @@ type Wallet interface {
 	UnlockAccount(ctx context.Context, account, passphrase string) error
 	// SyncStatus returns the wallet's sync status.
 	SyncStatus(ctx context.Context) (bool, float32, error)
+	// PeerCount returns the number of network peers to which the wallet or its
+	// backing node are connected.
+	PeerCount(ctx context.Context) (uint32, error)
 	// AddressPrivKey fetches the privkey for the specified address.
 	AddressPrivKey(ctx context.Context, address stdaddr.Address) (*dcrutil.WIF, error)
 }

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -121,6 +121,9 @@ func (n *testNode) locked() bool {
 func (n *testNode) syncProgress() ethereum.SyncProgress {
 	return n.syncProg
 }
+func (n *testNode) peerCount() uint32 {
+	return 1
+}
 
 // initiate is not concurrent safe
 func (n *testNode) initiate(ctx context.Context, contracts []*asset.Contract, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
@@ -306,7 +309,7 @@ func TestSyncStatus(t *testing.T) {
 		wantRatio: 0.25,
 	}, {
 		name:    "ok header too old",
-		subSecs: dexeth.MaxBlockInterval,
+		subSecs: dexeth.MaxBlockInterval + 1,
 	}, {
 		name:       "best header error",
 		bestHdrErr: errors.New(""),
@@ -314,7 +317,7 @@ func TestSyncStatus(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		nowInSecs := uint64(time.Now().Unix() / 1000)
+		nowInSecs := uint64(time.Now().Unix())
 		ctx, cancel := context.WithCancel(context.Background())
 		node := &testNode{
 			syncProg:   test.syncProg,

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -162,6 +162,10 @@ func (n *nodeClient) bestBlockHash(ctx context.Context) (common.Hash, error) {
 	return header.Hash(), nil
 }
 
+func (n *nodeClient) peerCount() uint32 {
+	return uint32(n.p2pSrv.PeerCount())
+}
+
 // bestHeader gets the best header at the time of calling.
 func (n *nodeClient) bestHeader(ctx context.Context) (*types.Header, error) {
 	return n.leth.ApiBackend.HeaderByNumber(ctx, rpc.LatestBlockNumber)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -152,6 +152,10 @@ type WalletConfig struct {
 	// should not be blocking, and Wallet implementations should not rely on any
 	// specific side effect of the function call.
 	TipChange func(error)
+	// PeersChange is a function that will be called when the number of
+	// wallet/node peers changes, or the wallet fails to get the count. This
+	// should not be called prior to Connect of the constructed wallet.
+	PeersChange func(uint32)
 	// DataDir is a filesystem directory the the wallet may use for persistent
 	// storage.
 	DataDir string
@@ -277,7 +281,9 @@ type Wallet interface {
 	Withdraw(address string, value, feeSuggestion uint64) (Coin, error)
 	// ValidateSecret checks that the secret hashes to the secret hash.
 	ValidateSecret(secret, secretHash []byte) bool
-	// SyncStatus is information about the blockchain sync status.
+	// SyncStatus is information about the blockchain sync status. It should
+	// only indicate synced when there are network peers and all blocks on the
+	// network have been processed by the wallet.
 	SyncStatus() (synced bool, progress float32, err error)
 	// RegFeeConfirmations gets the confirmations for a registration fee
 	// payment. This method need not be supported by all assets. Those assets

--- a/client/core/locale_ntfn.go
+++ b/client/core/locale_ntfn.go
@@ -52,7 +52,12 @@ var enUS = map[Topic]*translation{
 	// [host, error]
 	TopicWalletUnlockError: {
 		subject:  "Wallet unlock error",
-		template: "Connected to Decred wallet to complete registration at %s, but failed to unlock: %v",
+		template: "Connected to wallet to complete registration at %s, but failed to unlock: %v",
+	},
+	// [asset name]
+	TopicWalletPeersWarning: {
+		subject:  "Wallet network issue",
+		template: "%v wallet has no network peers!",
 	},
 	// [ticker, error]
 	TopicWithdrawError: {
@@ -338,7 +343,7 @@ var ptBR = map[Topic]*translation{
 	// [host, error]
 	TopicWalletUnlockError: {
 		subject:  "Erro ao Destravar Carteira",
-		template: "Conectado com carteira decred para completar o registro em %s, mas falha ao destrancar: %v",
+		template: "Conectado com carteira para completar o registro em %s, mas falha ao destrancar: %v",
 	},
 	// [ticker, error]
 	TopicWithdrawError: {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -178,6 +178,7 @@ const (
 	TopicFeeCoinError            Topic = "FeeCoinError"
 	TopicWalletConnectionWarning Topic = "WalletConnectionWarning"
 	TopicWalletUnlockError       Topic = "WalletUnlockError"
+	TopicWalletPeersWarning      Topic = "WalletPeersWarning"
 )
 
 func newFeePaymentNote(topic Topic, subject, details string, severity db.Severity, dexAddr string) *FeePaymentNote {

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -106,6 +106,7 @@ type WalletState struct {
 	Address      string            `json:"address"`
 	Units        string            `json:"units"`
 	Encrypted    bool              `json:"encrypted"`
+	PeerCount    uint32            `json:"peerCount"`
 	Synced       bool              `json:"synced"`
 	SyncProgress float32           `json:"syncProgress"`
 }

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -50,6 +50,8 @@ type xcWallet struct {
 	balance      *WalletBalance
 	pw           encode.PassBytes
 	address      string
+	peerCount    uint32
+	monitored    uint32 // startWalletSyncMonitor goroutines monitoring sync status
 	hookedUp     bool
 	synced       bool
 	syncProgress float32
@@ -176,6 +178,7 @@ func (w *xcWallet) state() *WalletState {
 		Address:      w.address,
 		Units:        winfo.UnitInfo.AtomicUnit,
 		Encrypted:    len(w.encPass) > 0,
+		PeerCount:    w.peerCount,
 		Synced:       w.synced,
 		SyncProgress: w.syncProgress,
 		WalletType:   w.walletType,

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -118,7 +118,6 @@ func (s *WebServer) apiNewWallet(w http.ResponseWriter, r *http.Request) {
 	}
 	has := s.core.WalletState(form.AssetID) != nil
 	if has {
-
 		s.writeAPIError(w, fmt.Errorf("already have a wallet for %s", unbip(form.AssetID)))
 		return
 	}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -3,6 +3,7 @@
 <span data-state="locked" class="ico-locked grey d-hide"></span>
 <span data-state="unlocked" class="ico-unlocked d-hide"></span>
 <span data-state="syncing" class="ico-sync fs12 d-hide" data-tooltip="placeholder text"></span>
+<span data-state="nopeers" class="ico-disconnected fs12 d-hide" data-tooltip="no peers!"></span>
 <span data-state="nowallet"></span> {{/* not showing ico-cross */}}
 {{end}}
 

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -9,6 +9,7 @@
     <span data-state="syncing" 
       class="ico-sync fs12{{if or (not $w.Running) $w.Synced}} d-hide{{end}}"
       data-tooltip="wallet is {{printf "%.2f" (x100  $w.SyncProgress)}}% synced"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide" data-tooltip="no peers!"></span>
     <span data-state="status" class="txt-status">{{if $w.Open}}[[[ready]]]{{else if $w.Running}}[[[locked]]]{{else}}[[[off]]]{{end}}</span>
   {{else}}
     <span data-state="sleeping" class="ico-sleeping fs17 grey d-hide"></span>
@@ -16,6 +17,7 @@
     <span data-state="unlocked" class="ico-unlocked d-hide"></span>
     <span data-state="nowallet" class="ico-cross fs12 red"></span>
     <span data-state="syncing" class="ico-sync fs12 d-hide"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide"></span>
     <span data-state="status" class="txt-status">[[[no_wallet]]]</span>
   {{end}}
 {{end}}

--- a/client/webserver/site/src/js/doc.js
+++ b/client/webserver/site/src/js/doc.js
@@ -321,6 +321,7 @@ export class WalletIcons {
     this.icons.unlocked = stateElement('unlocked')
     this.icons.nowallet = stateElement('nowallet')
     this.icons.syncing = stateElement('syncing')
+    this.icons.nopeers = stateElement('nopeers')
     this.status = stateElement('status')
   }
 
@@ -362,15 +363,25 @@ export class WalletIcons {
   }
 
   setSyncing (wallet) {
-    const icon = this.icons.syncing
+    const syncIcon = this.icons.syncing
     if (!wallet || !wallet.running) {
-      Doc.hide(icon)
+      Doc.hide(syncIcon)
       return
     }
+
+    if (wallet.peerCount === 0) {
+      Doc.show(this.icons.nopeers)
+      Doc.hide(syncIcon) // potentially misleading with no peers
+      return
+    }
+    Doc.hide(this.icons.nopeers)
+
     if (!wallet.synced) {
-      Doc.show(icon)
-      icon.dataset.tooltip = intl.prep(intl.ID_WALLET_SYNC_PROGRESS, { syncProgress: (wallet.syncProgress * 100).toFixed(1) })
-    } else Doc.hide(icon)
+      Doc.show(syncIcon)
+      syncIcon.dataset.tooltip = intl.prep(intl.ID_WALLET_SYNC_PROGRESS, { syncProgress: (wallet.syncProgress * 100).toFixed(1) })
+      return
+    }
+    Doc.hide(syncIcon)
   }
 
   /* reads the core.Wallet state and sets the icon visibility. */

--- a/client/webserver/site/src/localized_html/en-US/markets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/markets.tmpl
@@ -3,6 +3,7 @@
 <span data-state="locked" class="ico-locked grey d-hide"></span>
 <span data-state="unlocked" class="ico-unlocked d-hide"></span>
 <span data-state="syncing" class="ico-sync fs12 d-hide" data-tooltip="placeholder text"></span>
+<span data-state="nopeers" class="ico-disconnected fs12 d-hide" data-tooltip="no peers!"></span>
 <span data-state="nowallet"></span> {{/* not showing ico-cross */}}
 {{end}}
 

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -9,6 +9,7 @@
     <span data-state="syncing" 
       class="ico-sync fs12{{if or (not $w.Running) $w.Synced}} d-hide{{end}}"
       data-tooltip="wallet is {{printf "%.2f" (x100  $w.SyncProgress)}}% synced"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide" data-tooltip="no peers!"></span>
     <span data-state="status" class="txt-status">{{if $w.Open}}ready{{else if $w.Running}}locked{{else}}off{{end}}</span>
   {{else}}
     <span data-state="sleeping" class="ico-sleeping fs17 grey d-hide"></span>
@@ -16,6 +17,7 @@
     <span data-state="unlocked" class="ico-unlocked d-hide"></span>
     <span data-state="nowallet" class="ico-cross fs12 red"></span>
     <span data-state="syncing" class="ico-sync fs12 d-hide"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide"></span>
     <span data-state="status" class="txt-status">no wallet</span>
   {{end}}
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/markets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/markets.tmpl
@@ -3,6 +3,7 @@
 <span data-state="locked" class="ico-locked grey d-hide"></span>
 <span data-state="unlocked" class="ico-unlocked d-hide"></span>
 <span data-state="syncing" class="ico-sync fs12 d-hide" data-tooltip="placeholder text"></span>
+<span data-state="nopeers" class="ico-disconnected fs12 d-hide" data-tooltip="no peers!"></span>
 <span data-state="nowallet"></span> {{/* not showing ico-cross */}}
 {{end}}
 

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -9,6 +9,7 @@
     <span data-state="syncing" 
       class="ico-sync fs12{{if or (not $w.Running) $w.Synced}} d-hide{{end}}"
       data-tooltip="wallet is {{printf "%.2f" (x100  $w.SyncProgress)}}% synced"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide" data-tooltip="no peers!"></span>
     <span data-state="status" class="txt-status">{{if $w.Open}}gotowy{{else if $w.Running}}zablokowane{{else}}wyłączony{{end}}</span>
   {{else}}
     <span data-state="sleeping" class="ico-sleeping fs17 grey d-hide"></span>
@@ -16,6 +17,7 @@
     <span data-state="unlocked" class="ico-unlocked d-hide"></span>
     <span data-state="nowallet" class="ico-cross fs12 red"></span>
     <span data-state="syncing" class="ico-sync fs12 d-hide"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide"></span>
     <span data-state="status" class="txt-status">brak portfela</span>
   {{end}}
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/markets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/markets.tmpl
@@ -3,6 +3,7 @@
 <span data-state="locked" class="ico-locked grey d-hide"></span>
 <span data-state="unlocked" class="ico-unlocked d-hide"></span>
 <span data-state="syncing" class="ico-sync fs12 d-hide" data-tooltip="placeholder text"></span>
+<span data-state="nopeers" class="ico-disconnected fs12 d-hide" data-tooltip="no peers!"></span>
 <span data-state="nowallet"></span> {{/* not showing ico-cross */}}
 {{end}}
 

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -9,6 +9,7 @@
     <span data-state="syncing" 
       class="ico-sync fs12{{if or (not $w.Running) $w.Synced}} d-hide{{end}}"
       data-tooltip="wallet is {{printf "%.2f" (x100  $w.SyncProgress)}}% synced"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide" data-tooltip="no peers!"></span>
     <span data-state="status" class="txt-status">{{if $w.Open}}destrancado{{else if $w.Running}}trancado{{else}}desligado{{end}}</span>
   {{else}}
     <span data-state="sleeping" class="ico-sleeping fs17 grey d-hide"></span>
@@ -16,6 +17,7 @@
     <span data-state="unlocked" class="ico-unlocked d-hide"></span>
     <span data-state="nowallet" class="ico-cross fs12 red"></span>
     <span data-state="syncing" class="ico-sync fs12 d-hide"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide"></span>
     <span data-state="status" class="txt-status">sem carteira</span>
   {{end}}
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/markets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/markets.tmpl
@@ -3,6 +3,7 @@
 <span data-state="locked" class="ico-locked grey d-hide"></span>
 <span data-state="unlocked" class="ico-unlocked d-hide"></span>
 <span data-state="syncing" class="ico-sync fs12 d-hide" data-tooltip="placeholder text"></span>
+<span data-state="nopeers" class="ico-disconnected fs12 d-hide" data-tooltip="no peers!"></span>
 <span data-state="nowallet"></span> {{/* not showing ico-cross */}}
 {{end}}
 

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -9,6 +9,7 @@
     <span data-state="syncing" 
       class="ico-sync fs12{{if or (not $w.Running) $w.Synced}} d-hide{{end}}"
       data-tooltip="wallet is {{printf "%.2f" (x100  $w.SyncProgress)}}% synced"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide" data-tooltip="no peers!"></span>
     <span data-state="status" class="txt-status">{{if $w.Open}}准备就绪{{else if $w.Running}}锁定{{else}}关闭{{end}}</span>
   {{else}}
     <span data-state="sleeping" class="ico-sleeping fs17 grey d-hide"></span>
@@ -16,6 +17,7 @@
     <span data-state="unlocked" class="ico-unlocked d-hide"></span>
     <span data-state="nowallet" class="ico-cross fs12 red"></span>
     <span data-state="syncing" class="ico-sync fs12 d-hide"></span>
+    <span data-state="nopeers" class="ico-disconnected fs17 d-hide"></span>
     <span data-state="status" class="txt-status">未连接钱包</span>
   {{end}}
 {{end}}


### PR DESCRIPTION
This adds a `PeersChange` callback to `client/asset.WalletConfig`, similar to `TipChange`, for backends to report changes to the network peer count. The backends now implement a `monitorPeers` goroutine similar to `monitorBlocks` but checking and reporting on peer count changes.  Any changes in peer count result in a wallet state note.  Change in peer count from 0 to >0 also start a sync status monitoring goroutine, which runs until sync is restored.

This also updates each backend's `SyncStatus` method to ensure that the `synced bool` will never be true if there are peer count is 0.

Killing the "beta" node with the **SPV** beta wallet:

![image](https://user-images.githubusercontent.com/9373513/152835283-333226fb-5657-42e5-8067-f1c9ebcbe09e.png)

![image](https://user-images.githubusercontent.com/9373513/152835068-fca1fe54-9425-4474-808a-ac734cd303ac.png)

Starting up beta dcrd makes the signal-! icon change to a syncing arrow circle icon, which then goes away when it catches up with the network.

Killing "alpha" bitcoind with native btcwallet:

![image](https://user-images.githubusercontent.com/9373513/152835739-73848610-0dab-4f61-8007-5169b55461c8.png)

![image](https://user-images.githubusercontent.com/9373513/152835517-5c711860-4525-4199-b36f-4d3d3bbfacaa.png)

That also returns to normal after restarting alpha bitcoind.

Now the **full-node** wallets (still simnet):

https://user-images.githubusercontent.com/9373513/152836640-c8977ce5-bbf5-417c-add1-336326696b1b.mp4

```
2022-02-07 11:04:07.769 [ERR] CORE[dcr]: Failed to get peer count: rawrequest error: -9: wallet.NetworkBackend: Decred network is unreachable
2022-02-07 11:04:07.769 [WRN] CORE: Wallet for asset dcr has zero network peers!
2022-02-07 11:04:07.771 [WRN] CORE: notify: |WARNING| (walletconfig) Wallet network issue - Decred wallet has no network peers!
2022-02-07 11:04:07.771 [TRC] CORE: notify: |DATA| (walletstate)
2022-02-07 11:04:16.004 [TRC] CORE: notify: |DATA| (epoch) - Index: 109616897
2022-02-07 11:04:18.586 [ERR] CORE: btc wallet is reporting a failed state: failed to get best block hash from btc node
...
2022-02-07 11:04:22.586 [ERR] CORE[btc]: Failed to get peer count: rawrequest error: Post "http://127.0.0.1:20556/wallet/": dial tcp 127.0.0.1:20556: connect: connection refused
2022-02-07 11:04:22.586 [WRN] CORE: Wallet for asset btc has zero network peers!
2022-02-07 11:04:22.587 [ERR] CORE: btc wallet is reporting a failed state: failed to get best block hash from btc node
2022-02-07 11:04:22.589 [WRN] CORE: notify: |WARNING| (walletconfig) Wallet network issue - Bitcoin wallet has no network peers!
2022-02-07 11:04:22.589 [TRC] CORE: notify: |DATA| (walletstate)
2022-02-07 11:04:23.587 [ERR] CORE: btc wallet is reporting a failed state: failed to get best block hash from btc node
...
<start back up the alpha dcrd and bitcoind>
...
2022-02-07 11:05:42.769 [TRC] CORE: New peer count for asset dcr: 2
2022-02-07 11:05:42.769 [TRC] CORE: notify: |DATA| (walletstate)
2022-02-07 11:05:45.772 [TRC] CORE: notify: |DATA| (walletstate)
2022-02-07 11:05:45.779 [TRC] CORE: notify: |DATA| (balance) balance updated
2022-02-07 11:05:45.779 [INF] CORE: Wallet synced for asset dcr
2022-02-07 11:05:46.004 [TRC] CORE: notify: |DATA| (epoch) - Index: 109616903
...
2022-02-07 11:06:22.588 [TRC] CORE: New peer count for asset btc: 1
2022-02-07 11:06:22.588 [TRC] CORE: notify: |DATA| (walletstate)
2022-02-07 11:06:25.592 [TRC] CORE: notify: |DATA| (walletstate)
2022-02-07 11:06:25.596 [TRC] CORE: notify: |DATA| (balance) balance updated
2022-02-07 11:06:25.596 [INF] CORE: Wallet synced for asset btc
```