### PR TITLE
server: Do not fail redeemed makers.

### DIFF
--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -973,7 +973,11 @@ func (s *Swapper) failMatch(match *matchTracker) {
 
 	// Cancellation rate accounting
 	s.swapDone(orderAtFault, match.Match, true) // will also unbook/revoke order if needed
-	s.swapDone(otherOrder, match.Match, false)
+
+	// Accounting for the maker has already taken place if they have redeemed.
+	if match.Status != order.MakerRedeemed {
+		s.swapDone(otherOrder, match.Match, false)
+	}
 
 	// Register the failure to act violation, adjusting the user's score.
 	s.authMgr.Inaction(orderAtFault.User(), misstep, db.MatchID(match.Match), match.Quantity, refTime, orderAtFault.ID())


### PR DESCRIPTION
There is an error log that happens when maker has a booked limit order that matches with a taker (partial) who fails to redeem:

```
2022-01-24 06:41:52.704 [TRC] SWAP: checkInactionEventBased: match 966b3aa51c4a9dcdb61adc89a13f0976cc3414da343e442ee78bd18c15fa7338 (MakerRedeemed)
2022-01-24 06:41:52.714 [DBG] SWAP: failMatch: swap 966b3aa51c4a9dcdb61adc89a13f0976cc3414da343e442ee78bd18c15fa7338 failing (maker fault = false) at MakerRedeemed
2022-01-24 06:41:52.824 [ERR] MKT: Finished swap 966b3aa51c4a9dcdb61adc89a13f0976cc3414da343e442ee78bd18c15fa7338 (qty 10000000000) for order 12b8a24fff2f7a98b3bb3d132261a21af781f7b0f24e9a4f8a13a4308de11d40 larger than current settling (0) amount.
2022-01-24 06:41:52.975 [DBG] AUTH: Registering outcome "no redeem as taker" (badness 1) for user 1e2aeea64d20d45468b14c1034070e9d1616befe26826538102ba2ea81b04dda (offline), current score = -23
2022-01-24 06:41:52.978 [INF] SWAP: Sending a 'revoke_match' notification to each client for match 966b3aa51c4a9dcdb61adc89a13f0976cc3414da343e442ee78bd18c15fa7338
2022-01-24 06:41:53.013 [DBG] AUTH: Send requested for disconnected user 1e2aeea64d20d45468b14c1034070e9d1616befe26826538102ba2ea81b04dda
2022-01-24 06:41:53.015 [DBG] SWAP: Failed to send 'revoke_match' notification to user 1e2aeea64d20d45468b14c1034070e9d1616befe26826538102ba2ea81b04dda, match 966b3aa51c4a9dcdb61adc89a13f0976cc3414da343e442ee78bd18c15fa7338: user not connected: 1e2aeea64d20d45468b14c1034070e9d1616befe26826538102ba2ea81b04dda
```

This happens because the maker has zero settling with an order that is still on the books, as they already redeemed, but the swappers `failMatch` will do  `s.swapDone` for this order with zero settling anyhow.

To solve this, do not do `swapDone` for the maker when they have already redeemed, as that has already happened in `processRedeem`