### PR TITLE
client/core: allow wallet Lock to timeout

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -4811,8 +4811,8 @@ func TestResolveActiveTrades(t *testing.T) {
 	// reset
 	reset := func() {
 		rig.acct.lock()
-		btcWallet.Lock()
-		ethWallet.Lock()
+		btcWallet.Lock(time.Second)
+		ethWallet.Lock(time.Second)
 		tEthWallet.reserved = 0
 		rig.dc.trades = make(map[order.OrderID]*trackedTrade)
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -5407,7 +5407,7 @@ func TestLogout(t *testing.T) {
 	defer rig.shutdown()
 	tCore := rig.core
 
-	dcrWallet, tDcrWallet := newTWallet(tDCR.ID)
+	dcrWallet, _ := newTWallet(tDCR.ID)
 	tCore.wallets[tDCR.ID] = dcrWallet
 
 	btcWallet, _ := newTWallet(tBTC.ID)
@@ -5457,10 +5457,6 @@ func TestLogout(t *testing.T) {
 	// Active orders with matches error.
 	ensureErr("active orders matches")
 	rig.dc.trades = nil
-
-	// Lock wallet error.
-	tDcrWallet.lockErr = tErr
-	ensureErr("lock wallet")
 }
 
 func TestSetEpoch(t *testing.T) {


### PR DESCRIPTION
For various reasons, some unknown, it is apparently quite common for wallet lock to hang either client shutdown or just logout.
This is particularly problematic because it leaves the user no choice but to hard kill the process, which may have undesirable consequences.   Even when it is just slow to lock, most users decide it's hung forever much sooner.  I'm estimating this threshold at around 5-10 seconds.

This PR wraps the `wallet.Lock` calls with a timeout contraption.  The individual implementations could also be modified with say a `context.Context` or a `time.Duration` argument, but in cases where the backend is not context enabled it ends up like this anyway, just with the backend worrying about this and the caller (core) being ultimately at the mercy of the backends actually doing it, back to possible hangs.

Also of note is that this PR makes `wallet.Lock` errors no longer prevent full `Logout` (and thus clean shutdown) possible.  This was only encouraging dangerous killing of the process.

Related TODO: rework the **btc** backend so that the `call` method accepts a `context.Context`.