### PR TITLE
client/asset/eth: Fix decode coin id

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -468,7 +468,7 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Ne
 func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
 	txid, vout, err := decodeCoinID(coinID)
 	if err != nil {
-		return "", err
+		return "<invalid>", err
 	}
 	return fmt.Sprintf("%v:%d", txid, vout), err
 }

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -350,7 +350,7 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Ne
 func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
 	txid, vout, err := decodeCoinID(coinID)
 	if err != nil {
-		return "", err
+		return "<invalid>", err
 	}
 	return fmt.Sprintf("%v:%d", txid, vout), err
 }

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -133,20 +133,27 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Ne
 }
 
 // DecodeCoinID creates a human-readable representation of a coin ID for Ethereum.
+// In ETH there are 3 possible coin IDs:
+//   1. A transaction hash
+//   2. An encoded funding coin id which includes the account address and amount.
+//   3. A byte encoded string of the account address.
 func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
-	const invalid = "<invalid coin>"
-	if len(coinID) == common.HashLength {
-		id, err := dexeth.DecodeCoinID(coinID)
-		if err != nil {
-			return invalid, err
-		}
-		return id.String(), nil
+	txHashID, err := dexeth.DecodeCoinID(coinID)
+	if err == nil {
+		return txHashID.String(), nil
 	}
-	id, err := decodeFundingCoinID(coinID)
-	if err != nil {
-		return invalid, err
+
+	fundingCoinID, err := decodeFundingCoinID(coinID)
+	if err == nil {
+		return fundingCoinID.String(), nil
 	}
-	return id.String(), nil
+
+	addressID := string(coinID)
+	if len(addressID) == 42 && addressID[0:2] == "0x" {
+		return addressID, nil
+	}
+
+	return "", fmt.Errorf("%x is not a valid ETH coin id", coinID)
 }
 
 // Info returns basic information about the wallet and asset.

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -2114,6 +2114,49 @@ func TestDriverExists(t *testing.T) {
 	}
 }
 
+func TestDriverDecodeCoinID(t *testing.T) {
+	drv := &Driver{}
+	addressStr := "0xB6De8BB5ed28E6bE6d671975cad20C03931bE981"
+	address := common.HexToAddress(addressStr)
+
+	// Test tx hash
+	txHash := encode.RandomBytes(common.HashLength)
+	coinID, err := drv.DecodeCoinID(txHash)
+	if err != nil {
+		t.Fatalf("error decoding coin id: %v", err)
+	}
+	var hash common.Hash
+	hash.SetBytes(txHash)
+	if coinID != hash.String() {
+		t.Fatalf("expected coin id to be %s but got %s", hash.String(), coinID)
+	}
+
+	// Test funding coin id
+	fundingCoinID := createFundingCoinID(address, 1000)
+	coinID, err = drv.DecodeCoinID(fundingCoinID.Encode())
+	if err != nil {
+		t.Fatalf("error decoding coin id: %v", err)
+	}
+	if coinID != fundingCoinID.String() {
+		t.Fatalf("expected coin id to be %s but got %s", fundingCoinID.String(), coinID)
+	}
+
+	// Test byte encoded address string
+	coinID, err = drv.DecodeCoinID([]byte(addressStr))
+	if err != nil {
+		t.Fatalf("error decoding coin id: %v", err)
+	}
+	if coinID != addressStr {
+		t.Fatalf("expected coin id to be %s but got %s", addressStr, coinID)
+	}
+
+	// Test invalid coin id
+	_, err = drv.DecodeCoinID(encode.RandomBytes(20))
+	if err == nil {
+		t.Fatal("expected error but did not get")
+	}
+}
+
 func TestLocktimeExpired(t *testing.T) {
 	var secretHash [32]byte
 	copy(secretHash[:], encode.RandomBytes(32))

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -346,7 +346,7 @@ func (eth *Backend) Redemption(redeemCoinID, _, contractData []byte) (asset.Coin
 func (eth *Backend) ValidateCoinID(coinID []byte) (string, error) {
 	txHash, err := dexeth.DecodeCoinID(coinID)
 	if err != nil {
-		return "", err
+		return "<invalid>", err
 	}
 	return txHash.String(), nil
 }


### PR DESCRIPTION
The driver's DecodeCoinID function was attempting to parse the eth
coin's recovery address instead of the byte encoded address string.

Closes #1459.