### PR TITLE
charts: Make sure regions are defined in render.

### DIFF
--- a/client/webserver/site/src/js/charts.js
+++ b/client/webserver/site/src/js/charts.js
@@ -53,6 +53,7 @@ class Chart {
     this.ctx = this.canvas.getContext('2d')
     this.ctx.textAlign = 'center'
     this.ctx.textBaseline = 'middle'
+    this.setZoomBttns()
     // Mouse handling
     this.mousePos = null
     bind(this.canvas, 'mousemove', e => {
@@ -87,6 +88,10 @@ class Chart {
   draw () {
     this.render()
   }
+
+  // setZoomBttns is run before drawing and should be used for setup of zoom
+  // buttons.
+  setZoomBttns () {}
 
   /* click is the handler for a click event on the canvas. */
   click (e) {
@@ -277,11 +282,17 @@ export class DepthChart extends Chart {
     this.resize(parent.clientHeight)
   }
 
+  // setZoomBttns creates new regions for zoom in and zoom out buttons. It is
+  // used in initiation of the buttons and resizing.
+  setZoomBttns () {
+    this.zoomInBttn = new Region(this.ctx, new Extents(0, 0, 0, 0))
+    this.zoomOutBttn = new Region(this.ctx, new Extents(0, 0, 0, 0))
+  }
+
   /* resized is called when the window or parent element are resized. */
   resized () {
     // The button region extents are set during drawing.
-    this.zoomInBttn = new Region(this.ctx, new Extents(0, 0, 0, 0))
-    this.zoomOutBttn = new Region(this.ctx, new Extents(0, 0, 0, 0))
+    this.setZoomBttns()
     if (this.book) this.draw()
   }
 

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -106,7 +106,7 @@ if [ $ETH_ON -eq 0 ]; then
             "base": "DCR_simnet",
             "quote": "ETH_simnet",
             "lotSize": 1000000000,
-            "rateStep": 1000000000,
+            "rateStep": 1000,
             "epochDuration": ${EPOCH_DURATION},
             "marketBuyBuffer": 1.2
 EOF


### PR DESCRIPTION
    testing/dcrdex: Reduce dcr/eth rate step. 

    charts: Make sure regions are defined in render.

    There was an apparent race between the resized method and render. If
    render would happen first some elements that are initiated in resized
    were not yet available, causing a js error and hang. Set those fields in
    the constructor to avoid errors.


closes #1450,  closes #1357

I think this solves it.

I have not seen an error with the candle graph, so those changes may not be necessary. I think we se it with the normal graph because that is what we open the page to.

Also reduce the rate step in the simnet harness so the rates show.