### PR TITLE
eth: supplement eth swap receipt

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -362,13 +362,14 @@ type Coins []Coin
 type Receipt interface {
 	// Expiration is the time lock expiration.
 	Expiration() time.Time
-	// Coin is the contract's coin.
+	// Coin is the swap initiation transaction's Coin.
 	Coin() Coin
 	// Contract is the unique swap contract data. This may be a redeem script
 	// for UTXO assets, or other information that uniquely identifies the swap
 	// for account-based assets e.g. a contract version and secret hash for ETH.
 	Contract() dex.Bytes
-	// String provides a human-readable representation of the contract's Coin.
+	// String provides a human-readable representation of the swap that may
+	// provide supplementary data to locate the swap.
 	String() string
 	// SignedRefund is a signed refund script that can be used to return
 	// funds to the user in the case a contract expires.


### PR DESCRIPTION
Further work on https://github.com/decred/dcrdex/issues/1311

This supplements the `swapRecipt` `String` method with the contract address, which in addition to the secret hash makes performing a manual refund more straightforward.

This also omits the raw refund transaction logging in `(*Core).swapMatchGroup` when the `Receipt.SignedRefund` provides no such data, as is the case with ETH.  The swap `Receipt`'s `Stringer` is still used here to log the secret hash and contract address for ETH `swapReceipts`.