### PR TITLE
client/core: fix data race in ReconfigureWallet

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2260,7 +2260,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 		c.log.Warnf("Error getting balance for wallet %s: %v", unbip(assetID), err)
 		// Do not fail in case this requires an unlocked wallet.
 	} else {
-		wallet.balance = balances           // update xcWallet's WalletBalance
+		wallet.setBalance(balances)         // update xcWallet's WalletBalance
 		dbWallet.Balance = balances.Balance // store the db.Balance
 	}
 


### PR DESCRIPTION
This uses `(*xcWallet).setBalance` instead of directly assigning the balance. Even though the `xcWallet` is not in the `Core.wallets` map yet, this is necessary since `walletCheckAndNotify` is already running periodically in the sync status monitor goroutine, which calls `(*xcWallet).state` thus accessing the balance field.

Noticed in https://github.com/decred/dcrdex/pull/1439#issuecomment-1026199819