### PR TITLE
client/core: reload wallet on connect fail

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1875,6 +1875,9 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 		Wallet:    w,
 		connector: dex.NewConnectionMaster(w),
 		AssetID:   assetID,
+		cfg:       walletCfg,
+		logger:    logger,
+		net:       c.net,
 		balance: &WalletBalance{
 			Balance:        dbWallet.Balance,
 			OrderLocked:    orderLockedAmt,

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -619,6 +619,8 @@ func newTWallet(assetID uint32) (*xcWallet, *TXCWallet) {
 		Wallet:       w,
 		connector:    dex.NewConnectionMaster(w),
 		AssetID:      assetID,
+		cfg:          &asset.WalletConfig{},
+		logger:       dex.Disabled,
 		hookedUp:     true,
 		dbID:         encode.Uint32Bytes(assetID),
 		encPass:      []byte{0x01},
@@ -6317,7 +6319,7 @@ func TestSetWalletPassword(t *testing.T) {
 		EncryptedPW: []byte("abc"),
 	}
 	newPW := []byte("def")
-	var assetID uint32 = 54321
+	var assetID uint32 = 42
 
 	// Nil password error
 	err := tCore.SetWalletPassword(tPW, assetID, nil)


### PR DESCRIPTION
DRAFT  A starting point for a different solution to https://github.com/decred/dcrdex/pull/1413.  This was the inital solution, which is still in need of concurrency controls for the `xcWallet.Wallet` field. 