### PR TITLE
client/asset/dcr: ensure rpcclient is fresh before Connect

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -525,8 +525,7 @@ func (dcr *ExchangeWallet) Info() *asset.WalletInfo {
 // }
 
 // Connect connects the wallet to the RPC server. Satisfies the dex.Connector
-// interface. WARNING: Once stopped, it cannot reconnect, requiring NewWallet to
-// construct a new ExchangeWallet to Connect again.
+// interface.
 func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	// rpclog(dcr.log)
 	dcr.ctx = ctx

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3191,6 +3191,12 @@ func (c *Core) Login(pw []byte) (*LoginResult, error) {
 				if err != nil {
 					c.log.Errorf("Unable to connect to %s wallet (start and sync wallets BEFORE starting dex!): %v",
 						unbip(wallet.AssetID), err)
+					// NOTE: Details for this topic is in the context of fee
+					// payment, but the subject pertains to a failure to connect
+					// to the wallet.
+					subject, _ := c.formatDetails(TopicWalletConnectionWarning)
+					c.notify(newWalletConfigNote(TopicWalletConnectionWarning, subject, err.Error(),
+						db.ErrorLevel, wallet.state()))
 					return
 				}
 			}

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -105,6 +105,9 @@ func (c *ConnectionMaster) Connect(ctx context.Context) (err error) {
 	c.mtx.Lock()
 	c.wg, err = c.connector.Connect(c.ctx)
 	c.mtx.Unlock()
+	if err != nil {
+		c.cancel() // otherwise On() says true
+	}
 	return err
 }
 


### PR DESCRIPTION
Another alternative to https://github.com/decred/dcrdex/pull/1471, and the polar opposite approach to https://github.com/decred/dcrdex/pull/1413.  Unlike those, this just addresses the real issue, which is that dcrd's `rpcclient.Client` becomes unusable after `Shutdown`.  I had drafted this commit almost a month ago, but rejected it because I disliked the extra mutex, but given the state in an `xcWallet` or an `asset.Wallet` implementation like the `ExchangeWallet`s such as locked amounts, it's probably best just to solve it at the level of the `rpcWallet`.  If other assets have a similar constraint, they will have to adopt a similar solution.  e.g. BTC's wallet client does HTTP POST, and there's no issue there, but maybe eth would need special handling.

This allows the rpcclient to be reconstructed as needed before Connect, as is the case if it had been Disconnected previously. This is needed because dcrd's rpcclient.Client is not able to start up again after having shutdown.