### PR TITLE
bump v0.4.1

### DIFF
--- a/client/cmd/dexc/version/version.go
+++ b/client/cmd/dexc/version/version.go
@@ -25,7 +25,7 @@ const (
 	AppName  string = "dexc"
 	AppMajor uint   = 0
 	AppMinor uint   = 4
-	AppPatch uint   = 0
+	AppPatch uint   = 1
 )
 
 // go build -v -ldflags "-X decred.org/dcrdex/client/cmd/dexc/version.appPreRelease= -X decred.org/dcrdex/client/cmd/dexc/version.appBuild=$(git rev-parse --short HEAD)"

--- a/client/cmd/dexcctl/version.go
+++ b/client/cmd/dexcctl/version.go
@@ -25,7 +25,7 @@ const (
 	appName  string = "dexcctl"
 	appMajor uint   = 0
 	appMinor uint   = 4
-	appPatch uint   = 0
+	appPatch uint   = 1
 )
 
 // go build -v -ldflags "-X decred.org/dcrdex/client/cmd/dexcctl/main.appPreRelease= -X decred.org/dcrdex/client/cmd/dexcctl/main.appBuild=$(git rev-parse --short HEAD)"

--- a/pkg.sh
+++ b/pkg.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VER="v0.4.0"
+VER="v0.4.1"
 
 rm -rf bin
 mkdir -p bin/dexc-windows-amd64-${VER}

--- a/server/cmd/dcrdex/version.go
+++ b/server/cmd/dcrdex/version.go
@@ -25,7 +25,7 @@ const (
 	AppName  string = "dcrdex"
 	AppMajor uint   = 0
 	AppMinor uint   = 4
-	AppPatch uint   = 0
+	AppPatch uint   = 1
 )
 
 // go build -v -ldflags "-X main.appPreRelease= -X main.appBuild=$(git rev-parse --short HEAD)"


### PR DESCRIPTION
That'll be a patch release.  Immediately after this we should jump `master` to v0.5

The planned diff from v0.4.0 to v0.4.1: https://github.com/decred/dcrdex/compare/v0.4.0...d2c03e9ae35961c828624cd984cb5ef2de165c2a
