### PR TITLE
dex: redesign ConnectionMaster

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -8342,8 +8342,7 @@ func TestWalletSyncing(t *testing.T) {
 	dcrWallet, tDcrWallet := newTWallet(tUTXOAssetA.ID)
 	dcrWallet.synced = false
 	dcrWallet.syncProgress = 0
-	_ = dcrWallet.Connect()
-	defer dcrWallet.Disconnect()
+	// Connect with tCore.connectWallet below.
 
 	tStart := time.Now()
 	testDuration := 100 * time.Millisecond


### PR DESCRIPTION
See the discussion at https://github.com/decred/dcrdex/pull/1445#discussion_r803100088 for the motivation.

This redesigns `dex.ConnectionMaster`, adding a `Done() <-chan struct{}` method upon which the `On` and `Wait` methods are now based.

This also uses the new `Done` method in `(*Core).startWalletSyncMonitor` to quit if the wallet shuts down without an extra goroutine sitting on `Wait`.