### PR TITLE
eth/coiner: Save value of one initiation.

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -508,7 +507,7 @@ func (c *fundingCoin) RecoveryID() dex.Bytes {
 }
 
 func (c *fundingCoin) String() string {
-	return "{" + c.id.String() + ":" + hex.EncodeToString(c.recoveryID) + "}"
+	return fmt.Sprintf("{%s:%x}", []byte(c.id), c.recoveryID)
 }
 
 var _ asset.Coin = (*coin)(nil)

--- a/server/asset/eth/coiner.go
+++ b/server/asset/eth/coiner.go
@@ -298,3 +298,8 @@ func (c *baseCoin) Value() uint64 {
 func (c *baseCoin) FeeRate() uint64 {
 	return c.gasFeeCap
 }
+
+// Value returns the value of one swap in order to validate during processing.
+func (c *swapCoin) Value() uint64 {
+	return c.init.Value
+}


### PR DESCRIPTION
    Save and return the value of a specific initiation rather than the
    entire transaction value for validation later. This allows coins that
    share a transaction to be matched separately.

closes #1469