### PR TITLE
client/core,eth: Lock funds for refund

### DIFF
--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -741,6 +741,7 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 	}
 
 	checkBalance := func(wallet *ExchangeWallet, expectedAvailable, expectedLocked uint64, testName string) {
+		t.Helper()
 		balance, err := wallet.Balance()
 		if err != nil {
 			t.Fatalf("%v: unexpected error %v", testName, err)
@@ -836,7 +837,7 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	checkBalance(eth, walletBalanceGwei, 0, "after redeem too much")
+	checkBalance(eth, walletBalanceGwei, 0, "after return too much")
 
 	// Fund order with funds equal to available
 	order.Value = walletBalanceGwei - expectedOrderFees
@@ -1143,7 +1144,10 @@ func TestSwap(t *testing.T) {
 
 	refreshWalletAndFundCoins := func(ethBalance uint64, coinAmounts []uint64) asset.Coins {
 		node.bal.Current = ethToWei(ethBalance)
-		eth.lockedFunds = fundReserves{}
+		eth.lockedFunds.initiateReserves = 0
+		eth.lockedFunds.redemptionReserves = 0
+		eth.lockedFunds.refundReserves = 0
+
 		coins, err := eth.FundingCoins(coinIDsForAmounts(coinAmounts))
 		if err != nil {
 			t.Fatalf("FundingCoins error: %v", err)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -352,25 +352,27 @@ type TokenMaster interface {
 	OpenTokenWallet(assetID uint32, settings map[string]string, tipChange func(error)) (Wallet, error)
 }
 
-// AccountLocker is a wallet in which redemptions require a wallet to have
-// available balance to pay fees.
+// AccountLocker is a wallet in which redemptions and refunds require a wallet
+// to have available balance to pay fees.
 type AccountLocker interface {
 	// ReserveNRedemption is used when preparing funding for an order that
 	// redeems to an account-based asset. The wallet will set aside the
-	// appropriate amount of funds so that we can redeem. It is an error
-	// to request funds > spendable balance.
-	ReserveNRedemption(n, feeRate uint64, assetVer uint32) (uint64, error)
+	// appropriate amount of funds so that we can redeem N swaps on the
+	// specified version of the asset, at the specified fee rate. It is an
+	// error to request funds > spendable balance.
+	ReserveNRedemptions(n, feeRate uint64, assetVer uint32) (uint64, error)
 	// ReReserveRedemption is used when reconstructing existing orders on
 	// startup. It is an error to request funds > spendable balance.
 	ReReserveRedemption(amt uint64) error
 	// UnlockRedemptionReserves is used to return funds reserved for redemption
 	// when an order is canceled or otherwise completed unfilled.
 	UnlockRedemptionReserves(uint64)
-	// ReserveNRefund is used when preparing funding for an order that
+	// ReserveNRefunds is used when preparing funding for an order that
 	// refunds to an account-based asset. The wallet will set aside the
-	// appropriate amount of funds so that we can refund. It is an error
-	// to request funds > spendable balance.
-	ReserveNRefund(n uint64, assetVer uint32) (uint64, error)
+	// appropriate amount of funds so that we can refund N swaps on the
+	// specified version of the asset, at the specified fee rate. It is
+	// an error to request funds > spendable balance.
+	ReserveNRefunds(n, feeRate uint64, assetVer uint32) (uint64, error)
 	// ReReserveRefund is used when reconstructing existing orders on
 	// startup. It is an error to request funds > spendable balance.
 	ReReserveRefund(uint64) error

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -352,20 +352,32 @@ type TokenMaster interface {
 	OpenTokenWallet(assetID uint32, settings map[string]string, tipChange func(error)) (Wallet, error)
 }
 
-// AccountRedeemer is a wallet in which redemptions require a wallet to have
+// AccountLocker is a wallet in which redemptions require a wallet to have
 // available balance to pay fees.
-type AccountRedeemer interface {
-	// ReserveN is used when preparing funding for an order that redeems to an
-	// account-based asset. The wallet will set aside the appropriate amount of
-	// funds so that we can redeem. It is an error to request funds > spendable
-	// balance.
-	ReserveN(n, feeRate uint64, assetVer uint32) (uint64, error)
-	// ReReserve is used when reconstructing existing orders on startup. It is
-	// an error to request funds > spendable balance.
-	ReReserve(amt uint64) error
-	// UnlockReserves is used to return funds when an order is canceled or
-	// otherwise completed unfilled.
-	UnlockReserves(uint64)
+type AccountLocker interface {
+	// ReserveNRedemption is used when preparing funding for an order that
+	// redeems to an account-based asset. The wallet will set aside the
+	// appropriate amount of funds so that we can redeem. It is an error
+	// to request funds > spendable balance.
+	ReserveNRedemption(n, feeRate uint64, assetVer uint32) (uint64, error)
+	// ReReserveRedemption is used when reconstructing existing orders on
+	// startup. It is an error to request funds > spendable balance.
+	ReReserveRedemption(amt uint64) error
+	// UnlockRedemptionReserves is used to return funds reserved for redemption
+	// when an order is canceled or otherwise completed unfilled.
+	UnlockRedemptionReserves(uint64)
+	// ReserveNRefund is used when preparing funding for an order that
+	// refunds to an account-based asset. The wallet will set aside the
+	// appropriate amount of funds so that we can refund. It is an error
+	// to request funds > spendable balance.
+	ReserveNRefund(n uint64, assetVer uint32) (uint64, error)
+	// ReReserveRefund is used when reconstructing existing orders on
+	// startup. It is an error to request funds > spendable balance.
+	ReReserveRefund(uint64) error
+	// UnlockRefundReserves is used to return funds reserved for refunds
+	// when an order was cancelled or revoked before a swap was initiated,
+	// completed successully, or after a refund was done.
+	UnlockRefundReserves(uint64)
 }
 
 // Balance is categorized information about a wallet's balance.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4305,8 +4305,6 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 	tracker.redemptionLocked = tracker.redemptionReserves
 	tracker.refundLocked = tracker.refundReserves
 
-	tracker.redemptionLocked = tracker.redemptionReserves
-
 	if recoveryCoin != nil {
 		tracker.change = recoveryCoin
 		tracker.coinsLocked = false

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2894,6 +2894,21 @@ func TestRefundReserves(t *testing.T) {
 
 	tracker.cancel = nil
 
+	lo.Force = order.ImmediateTiF
+	loid = lo.ID()
+	msgMatch.OrderID = loid[:]
+
+	test("partial immediate TiF limit order", reserves/3, func() {
+		matchReq, _ := msgjson.NewRequest(1, msgjson.MatchRoute, []*msgjson.Match{msgMatch})
+		if err := handleMatchRoute(tCore, rig.dc, matchReq); err != nil {
+			t.Fatalf("handleMatchRoute error: %v", err)
+		}
+	})
+
+	lo.Force = order.StandingTiF
+	loid = lo.ID()
+	msgMatch.OrderID = loid[:]
+
 	addMatch := func(side order.MatchSide, status order.MatchStatus, qty uint64) order.MatchID {
 		msgMatch.Side = uint8(side)
 		m := *msgMatch
@@ -3124,6 +3139,17 @@ func TestRedemptionReserves(t *testing.T) {
 	})
 
 	tracker.cancel = nil
+
+	lo.Force = order.ImmediateTiF
+	loid = lo.ID()
+	msgMatch.OrderID = loid[:]
+
+	test("partially filled immediate TiF limit order", reserves/3, func() {
+		matchReq, _ := msgjson.NewRequest(1, msgjson.MatchRoute, []*msgjson.Match{msgMatch})
+		if err := handleMatchRoute(tCore, rig.dc, matchReq); err != nil {
+			t.Fatalf("handleMatchRoute error: %v", err)
+		}
+	})
 
 	mo := &order.MarketOrder{
 		P: lo.P,

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -159,13 +159,15 @@ type trackedTrade struct {
 	options            map[string]string
 	redemptionReserves uint64
 	redemptionLocked   uint64
+	refundReserves     uint64
+	refundLocked       uint64
 }
 
 // newTrackedTrade is a constructor for a trackedTrade.
 func newTrackedTrade(dbOrder *db.MetaOrder, preImg order.Preimage, dc *dexConnection, epochLen uint64,
 	lockTimeTaker, lockTimeMaker time.Duration, db db.DB, latencyQ *wait.TickerQueue, wallets *walletSet,
 	coins asset.Coins, notify func(Notification), formatDetails func(Topic, ...interface{}) (string, string),
-	options map[string]string, redemptionReserves uint64) *trackedTrade {
+	options map[string]string, redemptionReserves uint64, refundReserves uint64) *trackedTrade {
 
 	fromID := dbOrder.Order.Quote()
 	if dbOrder.Order.Trade().Sell {
@@ -193,15 +195,43 @@ func newTrackedTrade(dbOrder *db.MetaOrder, preImg order.Preimage, dc *dexConnec
 		formatDetails:      formatDetails,
 		options:            options,
 		redemptionReserves: redemptionReserves,
+		refundReserves:     refundReserves,
 	}
 	return t
 }
 
 // accountRedeemer is equivalent to calling
-// xcWallet.Wallet.(asset.AccountRedeemer) on the to-wallet.
-func (t *trackedTrade) accountRedeemer() (asset.AccountRedeemer, bool) {
-	ar, is := t.wallets.toWallet.Wallet.(asset.AccountRedeemer)
+// xcWallet.Wallet.(asset.AccountLocker) on the to-wallet.
+func (t *trackedTrade) accountRedeemer() (asset.AccountLocker, bool) {
+	ar, is := t.wallets.toWallet.Wallet.(asset.AccountLocker)
 	return ar, is
+}
+
+// accountRefunder is equivalent to calling
+// xcWallet.Wallet.(asset.AccountLocker) on the from-wallet.
+func (t *trackedTrade) accountRefunder() (asset.AccountLocker, bool) {
+	ar, is := t.wallets.fromWallet.Wallet.(asset.AccountLocker)
+	return ar, is
+}
+
+// lockRedemptionFraction locks the specified fraction of the available
+// refund reserves. Subsequent calls are additive. If a call to
+// lockRedemptionFraction would put the locked reserves > available reserves,
+// nothing will be reserved, and an error message is logged.
+func (t *trackedTrade) lockRefundFraction(num, denom uint64) {
+	redeemer, is := t.accountRefunder()
+	if !is {
+		return
+	}
+
+	newReserved := t.reservesToLock(num, denom, t.refundReserves, t.refundLocked)
+
+	if err := redeemer.ReReserveRefund(newReserved); err != nil {
+		t.dc.log.Errorf("error re-reserving refund %d %s for order %s: %v",
+			newReserved, t.wallets.fromAsset.UnitInfo.AtomicUnit, t.ID(), err)
+		return
+	}
+	t.refundLocked += newReserved
 }
 
 // lockRedemptionFraction locks the specified fraction of the available
@@ -213,19 +243,43 @@ func (t *trackedTrade) lockRedemptionFraction(num, denom uint64) {
 	if !is {
 		return
 	}
-	newReserved := applyFraction(num, denom, t.redemptionReserves)
-	if t.redemptionLocked+newReserved > t.redemptionReserves {
-		t.dc.log.Errorf("attempting to mark as active more reserves than available for order %s:"+
-			"%d available, %d already reserved, %d requested", t.ID(), t.redemptionReserves, t.redemptionLocked, newReserved)
-		return
-	}
 
-	if err := redeemer.ReReserve(newReserved); err != nil {
-		t.dc.log.Errorf("error re-reserving %d %s for order %s: %v",
+	newReserved := t.reservesToLock(num, denom, t.redemptionReserves, t.redemptionLocked)
+
+	if err := redeemer.ReReserveRedemption(newReserved); err != nil {
+		t.dc.log.Errorf("error re-reserving redemption %d %s for order %s: %v",
 			newReserved, t.wallets.toAsset.UnitInfo.AtomicUnit, t.ID(), err)
 		return
 	}
 	t.redemptionLocked += newReserved
+}
+
+// reservesToLock is a helper function used by lockRedemptionFraction and
+// lockRefundFraction to determine the amount of funds to lock.
+func (t *trackedTrade) reservesToLock(num, denom, reserves, reservesLocked uint64) uint64 {
+	newReserved := applyFraction(num, denom, reserves)
+	if reservesLocked+newReserved > reserves {
+		t.dc.log.Errorf("attempting to mark as active more reserves than available for order %s:"+
+			"%d available, %d already reserved, %d requested", t.ID(), t.redemptionReserves, t.redemptionLocked, newReserved)
+		return 0
+	}
+	return newReserved
+}
+
+// unlockRefundFraction unlocks the specified fraction of the refund
+// reserves. t.mtx should be locked if this trackedTrade is in the dc.trades
+// map. If the requested unlock would put the locked reserves < 0, an error
+// message is logged and the remaining locked reserves will be unlocked instead.
+// If the remaining locked reserves after this unlock is determined to be
+// "dust", it will be unlocked too.
+func (t *trackedTrade) unlockRefundFraction(num, denom uint64) {
+	refunder, is := t.accountRefunder()
+	if !is {
+		return
+	}
+	unlock := t.reservesToUnlock(num, denom, t.refundReserves, t.refundLocked)
+	t.refundLocked -= unlock
+	refunder.UnlockRefundReserves(unlock)
 }
 
 // unlockRedemptionFraction unlocks the specified fraction of the redemption
@@ -239,20 +293,27 @@ func (t *trackedTrade) unlockRedemptionFraction(num, denom uint64) {
 	if !is {
 		return
 	}
-	unlock := applyFraction(num, denom, t.redemptionReserves)
-	if unlock > t.redemptionLocked {
+	unlock := t.reservesToUnlock(num, denom, t.redemptionReserves, t.redemptionLocked)
+	t.redemptionLocked -= unlock
+	redeemer.UnlockRedemptionReserves(unlock)
+}
+
+// reservesToUnlock is a helper function used by unlockRedemptionFraction and
+// unlockRefundFraction to determine the amount of funds to unlock.
+func (t *trackedTrade) reservesToUnlock(num, denom, reserves, reservesLocked uint64) uint64 {
+	unlock := applyFraction(num, denom, reserves)
+	if unlock > reservesLocked {
 		t.dc.log.Errorf("attempting to unlock more than is reserved for order %s. unlocking reserved amount instead: "+
-			"%d reserved, unlocking %d", t.ID(), t.redemptionLocked, unlock)
-		unlock = t.redemptionLocked
-		t.redemptionLocked = 0
+			"%d reserved, unlocking %d", t.ID(), reservesLocked, unlock)
+		unlock = reservesLocked
 	}
 
-	t.redemptionLocked -= unlock
+	reservesLocked -= unlock
 
 	// Can be dust. Clean it up.
 	var isDust bool
 	if t.isMarketBuy() {
-		isDust = t.redemptionLocked < applyFraction(1, uint64(2*len(t.matches)), t.redemptionReserves)
+		isDust = reservesLocked < applyFraction(1, uint64(2*len(t.matches)), reserves)
 	} else if t.metaData.Status > order.OrderStatusBooked && len(t.matches) > 0 {
 		// Order is executed, so no changes should be expected. If there were
 		// zero matches, the return is expected to be fraction 1 / 1, so no
@@ -261,7 +322,7 @@ func (t *trackedTrade) unlockRedemptionFraction(num, denom uint64) {
 		// divide it by 2. Any remainder less than that is dust.
 		smallestShare := ^uint64(0)
 		shrink := func(num, denom uint64) {
-			v := applyFraction(num, denom, t.redemptionReserves)
+			v := applyFraction(num, denom, reserves)
 			if v < smallestShare {
 				smallestShare = v
 			}
@@ -274,16 +335,12 @@ func (t *trackedTrade) unlockRedemptionFraction(num, denom uint64) {
 		for _, m := range t.matches {
 			shrink(m.Quantity, qty)
 		}
-		isDust = t.redemptionLocked < applyFraction(smallestShare, qty*2, t.redemptionReserves)
+		isDust = reservesLocked < applyFraction(smallestShare, qty*2, reserves)
 	}
 	if isDust {
-		unlock += t.redemptionLocked
-		t.redemptionLocked = 0
+		unlock += reservesLocked
 	}
-
-	if unlock > 0 {
-		redeemer.UnlockReserves(unlock)
-	}
+	return unlock
 }
 
 func (t *trackedTrade) isMarketBuy() bool {
@@ -473,6 +530,7 @@ func (t *trackedTrade) nomatch(oid order.OrderID) (assetMap, error) {
 	} else {
 		t.returnCoins()
 		t.unlockRedemptionFraction(1, 1)
+		t.unlockRefundFraction(1, 1)
 		assets.count(t.wallets.fromAsset.ID)
 		t.dc.log.Infof("Non-standing order %s did not match.", t.token())
 		t.metaData.Status = order.OrderStatusExecuted
@@ -640,6 +698,7 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 	// reserves.
 	if remain := trade.Quantity - preCancelFilled; remain > 0 && (completedMarketSell || cancelMatch != nil) {
 		t.unlockRedemptionFraction(remain, trade.Quantity)
+		t.unlockRefundFraction(remain, trade.Quantity)
 	}
 
 	// Send notifications.
@@ -1423,8 +1482,10 @@ func (t *trackedTrade) revoke() {
 
 	if t.isMarketBuy() { // Is this even possible?
 		t.unlockRedemptionFraction(1, 1)
+		t.unlockRefundFraction(1, 1)
 	} else {
 		t.unlockRedemptionFraction(t.Trade().Remaining(), t.Trade().Quantity)
+		t.unlockRefundFraction(t.Trade().Remaining(), t.Trade().Quantity)
 	}
 }
 
@@ -1469,8 +1530,10 @@ func (t *trackedTrade) revokeMatch(ctx context.Context, matchID order.MatchID, f
 
 		if t.isMarketBuy() {
 			t.unlockRedemptionFraction(1, uint64(len(t.matches)))
+			t.unlockRefundFraction(1, uint64(len(t.matches)))
 		} else {
 			t.unlockRedemptionFraction(revokedMatch.Quantity, t.Trade().Quantity)
+			t.unlockRefundFraction(revokedMatch.Quantity, t.Trade().Quantity)
 		}
 	}
 
@@ -1939,6 +2002,11 @@ func (c *Core) redeemMatchGroup(t *trackedTrade, matches []*matchTracker, errs *
 			match.Status = order.MatchComplete // could this cause the match to be retired before the `redeem` request succeeds?
 			proof.TakerRedeem = coinID
 		} else {
+			if t.isMarketBuy() {
+				t.unlockRefundFraction(1, uint64(len(t.matches)))
+			} else {
+				t.unlockRefundFraction(match.Quantity, t.Trade().Quantity)
+			}
 			match.Status = order.MakerRedeemed
 			proof.MakerRedeem = coinID
 		}
@@ -2087,6 +2155,12 @@ func (t *trackedTrade) findMakersRedemption(match *matchTracker) {
 			return
 		}
 
+		if t.isMarketBuy() {
+			t.unlockRefundFraction(1, uint64(len(t.matches)))
+		} else {
+			t.unlockRefundFraction(match.Quantity, t.Trade().Quantity)
+		}
+
 		// Update the match status and set the secret so that Maker's swap
 		// will be redeemed in the next call to trade.tick().
 		match.Status = order.MakerRedeemed
@@ -2164,8 +2238,10 @@ func (c *Core) refundMatches(t *trackedTrade, matches []*matchTracker) (uint64, 
 
 		if t.isMarketBuy() {
 			t.unlockRedemptionFraction(1, uint64(len(t.matches)))
+			t.unlockRefundFraction(1, uint64(len(t.matches)))
 		} else {
 			t.unlockRedemptionFraction(match.Quantity, t.Trade().Quantity)
+			t.unlockRefundFraction(match.Quantity, t.Trade().Quantity)
 		}
 
 		// Refund successful, cancel any previously started attempt to find
@@ -2486,6 +2562,14 @@ func (t *trackedTrade) processMakersRedemption(match *matchTracker, coinID, secr
 	redeemAsset := t.wallets.fromAsset
 	t.dc.log.Infof("Notified of maker's redemption (%s: %v) and validated secret for order %v...",
 		redeemAsset.Symbol, coinIDString(redeemAsset.ID, coinID), t.ID())
+
+	if match.Status < order.MakerRedeemed {
+		if t.isMarketBuy() {
+			t.unlockRefundFraction(1, uint64(len(t.matches)))
+		} else {
+			t.unlockRefundFraction(match.Quantity, t.Trade().Quantity)
+		}
+	}
 
 	match.Status = order.MakerRedeemed
 	proof.MakerRedeem = coinID

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -84,6 +84,7 @@ var (
 	ackKey                 = []byte("ack")
 	swapFeesKey            = []byte("swapFees")
 	maxFeeRateKey          = []byte("maxFeeRate")
+	redeemMaxFeeRateKey    = []byte("redeemMaxFeeRate")
 	redemptionFeesKey      = []byte("redeemFees")
 	typeKey                = []byte("type")
 	credentialsBucket      = []byte("credentials")
@@ -600,6 +601,7 @@ func (db *BoltDB) UpdateOrder(m *dexdb.MetaOrder) error {
 			put(orderKey, order.EncodeOrder(ord)).
 			put(swapFeesKey, uint64Bytes(md.SwapFeesPaid)).
 			put(maxFeeRateKey, uint64Bytes(md.MaxFeeRate)).
+			put(redeemMaxFeeRateKey, uint64Bytes(md.RedeemMaxFeeRate)).
 			put(redemptionFeesKey, uint64Bytes(md.RedemptionFeesPaid)).
 			put(optionsKey, config.Data(md.Options)).
 			err()
@@ -894,6 +896,11 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 		maxFeeRate = ^uint64(0) // should not happen for trade orders after v2 upgrade
 	}
 
+	var redeemMaxFeeRate uint64
+	if redeemMaxFeeRateB := oBkt.Get(redeemMaxFeeRateKey); len(redeemMaxFeeRateB) == 8 {
+		redeemMaxFeeRate = intCoder.Uint64(redeemMaxFeeRateB)
+	}
+
 	var fromVersion, toVersion uint32
 	fromVersionB, toVersionB := oBkt.Get(fromVersionKey), oBkt.Get(toVersionKey)
 	if len(fromVersionB) == 4 {
@@ -918,6 +925,7 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 			LinkedOrder:        linkedID,
 			SwapFeesPaid:       intCoder.Uint64(oBkt.Get(swapFeesKey)),
 			MaxFeeRate:         maxFeeRate,
+			RedeemMaxFeeRate:   redeemMaxFeeRate,
 			RedemptionFeesPaid: intCoder.Uint64(oBkt.Get(redemptionFeesKey)),
 			FromVersion:        fromVersion,
 			ToVersion:          toVersion,

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -95,7 +95,8 @@ var (
 	fromVersionKey         = []byte("fromVersion")
 	toVersionKey           = []byte("toVersion")
 	optionsKey             = []byte("options")
-	reservesKey            = []byte("reservesKey")
+	redemptionReservesKey  = []byte("redemptionReservesKey")
+	refundReservesKey      = []byte("refundReservesKey")
 	byteTrue               = encode.ByteTrue
 	backupDir              = "backup"
 )
@@ -869,9 +870,15 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 	}
 
 	var redemptionReserves uint64
-	reservesB := oBkt.Get(reservesKey)
-	if len(reservesB) == 8 {
-		redemptionReserves = intCoder.Uint64(reservesB)
+	redemptionReservesB := oBkt.Get(redemptionReservesKey)
+	if len(redemptionReservesB) == 8 {
+		redemptionReserves = intCoder.Uint64(redemptionReservesB)
+	}
+
+	var refundReserves uint64
+	refundReservesB := oBkt.Get(refundReservesKey)
+	if len(refundReservesB) == 8 {
+		refundReserves = intCoder.Uint64(refundReservesB)
 	}
 
 	var linkedID order.OrderID
@@ -916,6 +923,7 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 			ToVersion:          toVersion,
 			Options:            options,
 			RedemptionReserves: redemptionReserves,
+			RefundReserves:     refundReserves,
 		},
 		Order: ord,
 	}, nil
@@ -990,7 +998,8 @@ func (db *BoltDB) UpdateOrderMetaData(oid order.OrderID, md *db.OrderMetaData) e
 			put(fromVersionKey, uint32Bytes(md.FromVersion)).
 			put(toVersionKey, uint32Bytes(md.ToVersion)).
 			put(optionsKey, config.Data(md.Options)).
-			put(reservesKey, uint64Bytes(md.RedemptionReserves)).
+			put(redemptionReservesKey, uint64Bytes(md.RedemptionReserves)).
+			put(refundReservesKey, uint64Bytes(md.RefundReserves)).
 			err()
 	})
 }

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -267,6 +267,7 @@ type OrderMetaData struct {
 	Options map[string]string
 	// RedemptionReserve is the reserved redemption funds.
 	RedemptionReserves uint64
+	RefundReserves     uint64
 }
 
 // MetaMatch is a match and its metadata.

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -259,15 +259,31 @@ type OrderMetaData struct {
 	// MaxFeeRate is the dex.Asset.MaxFeeRate at the time of ordering. The rates
 	// assigned to matches will be validated against this value.
 	MaxFeeRate uint64
+	// RedeemMaxFeeRate is the dex.Asset.MaxFeeRate for the redemption asset at
+	// the time of ordering. This rate is used to reserve funds for redemption,
+	// and therefore this rate can be used when actually submitting a redemption
+	// transaction.
+	RedeemMaxFeeRate uint64
 	// FromVersion is the version of the from asset.
 	FromVersion uint32
 	// ToVersion is the version of the to asset.
 	ToVersion uint32
 	// Options are the options offered by the wallet and selected by the user.
 	Options map[string]string
-	// RedemptionReserve is the reserved redemption funds.
+	// RedemptionReserves is the amount of funds reserved by the wallet to pay
+	// the transaction fees for all the possible redemptions in this order.
+	// The amount that should be locked at any point can be determined by
+	// checking the status of the order and the status of all matches related
+	// to this order, and determining how many more possible redemptions there
+	// could be.
 	RedemptionReserves uint64
-	RefundReserves     uint64
+	// RedemptionRefunds is the amount of funds reserved by the wallet to pay
+	// the transaction fees for all the possible refunds in this order.
+	// The amount that should be locked at any point can be determined by
+	// checking the status of the order and the status of all matches related
+	// to this order, and determining how many more possible refunds there
+	// could be.
+	RefundReserves uint64
 }
 
 // MetaMatch is a match and its metadata.


### PR DESCRIPTION
Previously, the funds needed for refunds were locked in `FundOrder` together with the funds needed for initiations, but they were unlocked when `Swap` was called with `LockChange = false`.  This diff applies the same logic we use to reserve funds for redemptions to refunds.

Prior to this PR, redemptions were being reserved using the server's max fee rate, but the redemption transaction was being submitted with the current fee rate estimate. This PR updates this to use the server's max fee rate when submitting the transaction as well. There is no reason to use a lower rate when submitting the transaction, as ETH uses dynamic transaction fees, and the entire fee will not be used anyways. The server's max fee rate is also used for refunds.

- `client/asset`: Rename `AssetRedeemer` interface to `AssetLocker`, and add functions for refunds with the same functionality as already exist for redemptions.
- `client/eth`: Refactor fund locking to keep track of funds locked for initiation, refunds, and redemptions separately. Also, make ETH a `FeeRater`.
- `client/core`: Keep track of refund reserves the same way as they are tracked for redemptions. In addition to unlocking when the deal is revoked or cancelled, funds reserved for refunds are also unlocked when either the counterparty or the current user does a redemption.

Closes #1466