### PR TITLE
client/db: compact DB on shutdown

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1304,6 +1304,12 @@ func (c *Core) Ready() <-chan struct{} {
 	return c.ready
 }
 
+// BackupDB makes a backup of the database at the specified location, optionally
+// overwriting any existing file and compacting the database.
+func (c *Core) BackupDB(dst string, overwrite, compact bool) error {
+	return c.db.BackupTo(dst, overwrite, compact)
+}
+
 const defaultDEXPort = "7232"
 
 // addrHost returns the host or url:port pair for an address.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -502,8 +502,9 @@ func (tdb *TDB) AccountPaid(proof *db.AccountProof) error {
 	return tdb.accountPaidErr
 }
 
-func (tdb *TDB) SaveNotification(*db.Notification) error        { return nil }
-func (tdb *TDB) NotificationsN(int) ([]*db.Notification, error) { return nil, nil }
+func (tdb *TDB) SaveNotification(*db.Notification) error            { return nil }
+func (tdb *TDB) BackupTo(dst string, overwrite, compact bool) error { return nil }
+func (tdb *TDB) NotificationsN(int) ([]*db.Notification, error)     { return nil, nil }
 
 func (tdb *TDB) SetPrimaryCredentials(creds *db.PrimaryCredentials) error {
 	if tdb.setCredsErr != nil {

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -118,7 +119,7 @@ func NewDB(dbPath string, logger dex.Logger) (dexdb.DB, error) {
 	_, err := os.Stat(dbPath)
 	isNew := os.IsNotExist(err)
 
-	db, err := bbolt.Open(dbPath, 0600, &bbolt.Options{Timeout: 1 * time.Second})
+	db, err := bbolt.Open(dbPath, 0600, &bbolt.Options{Timeout: 3 * time.Second})
 	if err != nil {
 		return nil, err
 	}
@@ -166,14 +167,61 @@ func NewDB(dbPath string, logger dex.Logger) (dexdb.DB, error) {
 	return bdb, bdb.upgradeDB()
 }
 
+func (db *BoltDB) fileSize(path string) int64 {
+	stat, err := os.Stat(path)
+	if err != nil {
+		db.log.Errorf("Failed to stat %v: %v", path, err)
+		return 0
+	}
+	return stat.Size()
+}
+
 // Run waits for context cancellation and closes the database.
 func (db *BoltDB) Run(ctx context.Context) {
-	<-ctx.Done()
+	<-ctx.Done() // wait for shutdown to backup and compact
+
+	// Create a backup in the backups folder.
+	db.log.Infof("Backing up database...")
 	err := db.Backup()
 	if err != nil {
-		db.log.Errorf("unable to backup database: %v", err)
+		db.Close()
+		db.log.Errorf("Unable to backup database: %v", err)
 	}
-	db.Close()
+
+	// Only compact the current DB file if there are excessive free pages.
+	if db.Stats().FreePageN < 32 { // 128 KiB for 4096 page size
+		db.Close()
+		return
+	}
+
+	// TODO: If we never see trouble with the compacted DB files when dexc
+	// starts up, we can just compact to the backups folder and copy that backup
+	// file back on top of the main DB file after it is closed.  For now, the
+	// backup above is a direct (not compacted) copy.
+
+	// Compact the database by writing into a temporary file, closing the source
+	// DB, and overwriting the original with the compacted temporary file.
+	db.log.Infof("Compacting database...")
+	srcPath := db.Path()                    // before db.Close
+	compFile := srcPath + ".tmp"            // deterministic on *same fs*
+	err = db.BackupTo(compFile, true, true) // overwrite and compact
+	if err != nil {
+		db.Close()
+		db.log.Errorf("Unable to compact database: %v", err)
+		return
+	}
+
+	db.Close() // close db file at srcPath
+
+	initSize, compSize := db.fileSize(srcPath), db.fileSize(compFile)
+	db.log.Infof("Compacted database from %v => %v bytes (%.2f%% reduction)",
+		initSize, compSize, 100*float64(compSize)/float64(initSize))
+
+	err = os.Rename(compFile, srcPath) // compFile => srcPath
+	if err != nil {
+		db.log.Errorf("Unable to switch to compacted database: %v", err)
+		return
+	}
 }
 
 // Recrypt re-encrypts the wallet passwords and account private keys. As a
@@ -1569,31 +1617,93 @@ func (db *BoltDB) withBucket(bkt []byte, viewer txFunc, f bucketFunc) error {
 	})
 }
 
-// Backup makes a copy of the database.
-func (db *BoltDB) Backup() error {
-	return db.backup("")
+func ovrFlag(overwrite bool) int {
+	if overwrite {
+		return os.O_TRUNC
+	}
+	return os.O_EXCL
 }
 
-// backup makes a copy of the database to the specified file name in the backup
-// subfolder of the current DB file's folder. If fileName is empty, the current
-// DB's file name is used.
-func (db *BoltDB) backup(fileName string) error {
-	dir := filepath.Join(filepath.Dir(db.Path()), backupDir)
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		err := os.Mkdir(dir, 0700)
+// compact writes a compacted copy of the DB into the specified destination
+// file. This function should be called from BackupTo to validate the
+// destination file and create any needed parent folders.
+func (db *BoltDB) compact(dst string, overwrite bool) error {
+	opts := bbolt.Options{
+		OpenFile: func(path string, _ int, mode os.FileMode) (*os.File, error) {
+			return os.OpenFile(path, os.O_RDWR|os.O_CREATE|ovrFlag(overwrite), mode)
+		},
+	}
+	newDB, err := bbolt.Open(dst, 0600, &opts)
+	if err != nil {
+		return fmt.Errorf("unable to compact database: %w", err)
+	}
+
+	const txMaxSize = 1 << 19 // 512 KiB
+	err = bbolt.Compact(newDB, db.DB, txMaxSize)
+	if err != nil {
+		_ = newDB.Close()
+		return fmt.Errorf("unable to compact database: %w", err)
+	}
+	return newDB.Close()
+}
+
+// backup writes a direct copy of the DB into the specified destination file.
+// This function should be called from BackupTo to validate the destination file
+// and create any needed parent folders.
+func (db *BoltDB) backup(dst string, overwrite bool) error {
+	// Just copy. This is like tx.CopyFile but with the overwrite flag set
+	// as specified.
+	f, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|ovrFlag(overwrite), 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	err = db.View(func(tx *bbolt.Tx) error {
+		_, err = tx.WriteTo(f)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+// BackupTo makes a copy of the database to the specified file, optionally
+// overwriting and compacting the DB.
+func (db *BoltDB) BackupTo(dst string, overwrite, compact bool) error {
+	// If relative path, use current db path.
+	var dir string
+	if !filepath.IsAbs(dst) {
+		dir = filepath.Dir(db.Path())
+		dst = filepath.Join(dir, dst)
+	}
+	dst = filepath.Clean(dst)
+	dir = filepath.Dir(dst)
+	if dst == filepath.Clean(db.Path()) {
+		return errors.New("destination is the active DB")
+	}
+
+	// Make the parent folder if it does not exists.
+	if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
+		err = os.MkdirAll(dir, 0700)
 		if err != nil {
 			return fmt.Errorf("unable to create backup directory: %w", err)
 		}
 	}
 
-	if fileName == "" {
-		fileName = filepath.Base(db.Path())
+	if compact {
+		return db.compact(dst, overwrite)
 	}
-	path := filepath.Join(dir, fileName)
-	err := db.View(func(tx *bbolt.Tx) error {
-		return tx.CopyFile(path, 0600)
-	})
-	return err
+
+	return db.backup(dst, overwrite)
+}
+
+// Backup makes a copy of the database in the "backup" folder, overwriting any
+// existing backup.
+func (db *BoltDB) Backup() error {
+	dir, file := filepath.Split(db.Path())
+	return db.BackupTo(filepath.Join(dir, backupDir, file), true, false)
 }
 
 // bucketPutter enables chained calls to (*bbolt.Bucket).Put with error

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -95,6 +95,44 @@ func TestBackup(t *testing.T) {
 	}
 }
 
+func TestBackupTo(t *testing.T) {
+	db, shutdown := newTestDB(t)
+	defer shutdown()
+
+	// Backup the database.
+	testBackup := "asdf.db"
+	err := db.BackupTo(testBackup, false, false)
+	if err != nil {
+		t.Fatalf("unable to backup database: %v", err)
+	}
+
+	// Ensure the backup exists.
+	path := filepath.Join(filepath.Dir(db.Path()), testBackup)
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatalf("backup file does not exist: %v", err)
+	}
+
+	// Don't overwrite existing.
+	same := db.Path()
+	err = db.BackupTo(same, false, false)
+	if err == nil {
+		t.Fatalf("overwrote file!")
+	}
+	err = db.BackupTo(testBackup, false, false)
+	if err == nil {
+		t.Fatalf("overwrote file!")
+	}
+	// Allow overwrite
+	err = db.BackupTo(testBackup, true, false) // no compact
+	if err != nil {
+		t.Fatalf("unable to backup database: %v", err)
+	}
+	err = db.BackupTo(testBackup, true, true) // compact
+	if err != nil {
+		t.Fatalf("unable to backup database: %v", err)
+	}
+}
+
 func TestStorePrimaryCredentials(t *testing.T) {
 	boltdb, shutdown := newTestDB(t)
 	defer shutdown()

--- a/client/db/bolt/upgrades.go
+++ b/client/db/bolt/upgrades.go
@@ -86,7 +86,7 @@ func (db *BoltDB) upgradeDB() error {
 	// DBVersion. Note that any intermediate versions are not stored.
 	currentFile := filepath.Base(db.Path())
 	backupPath := fmt.Sprintf("%s.v%d.bak", currentFile, version) // e.g. dexc.db.v1.bak
-	if err = db.backup(backupPath); err != nil {
+	if err = db.backup(backupPath, true); err != nil {
 		return fmt.Errorf("failed to backup DB prior to upgrade: %w", err)
 	}
 

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -101,8 +101,11 @@ type DB interface {
 	Wallets() ([]*Wallet, error)
 	// Wallet fetches the wallet for the specified asset by wallet ID.
 	Wallet(wid []byte) (*Wallet, error)
-	// Backup makes a copy of the database.
+	// Backup makes a copy of the database to the default "backups" folder.
 	Backup() error
+	// BackupTo makes a backup of the database at the specified location,
+	// optionally overwriting any existing file and compacting the database.
+	BackupTo(dst string, overwrite, compact bool) error
 	// SaveNotification saves the notification.
 	SaveNotification(*Notification) error
 	// NotificationsN reads out the N most recent notifications.

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/lib/pq v1.10.3
 	github.com/lightninglabs/neutrino v0.13.1-0.20211214231330-53b628ce1756
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
-	go.etcd.io/bbolt v1.3.5
+	go.etcd.io/bbolt v1.3.7-0.20220130032806-d5db64bdbfde
 	golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d

--- a/go.sum
+++ b/go.sum
@@ -553,8 +553,9 @@ github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6Ut
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zquestz/grab v0.0.0-20190224022517-abcee96e61b1/go.mod h1:bslhAiUxakrA6z6CHmVyvkfpnxx18RJBwVyx2TluJWw=
 go.etcd.io/bbolt v1.3.5-0.20200615073812-232d8fc87f50/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
-go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
+go.etcd.io/bbolt v1.3.7-0.20220130032806-d5db64bdbfde h1:jqAsjG/dU6OSvhzkskltTptEQ+xeolIxgK2jh5qKqGo=
+go.etcd.io/bbolt v1.3.7-0.20220130032806-d5db64bdbfde/go.mod h1:sh/Yp01MYDakY7RVfzKZn+T1WOMTTFJrWjl7+M73RXA=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -687,6 +688,7 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
The latest revisions of bbolt expose DB compaction methods, which is necessary to reclaim any storage space from purged orders and matches from https://github.com/decred/dcrdex/pull/1475

https://github.com/etcd-io/bbolt/pull/248

This adds a compaction and custom backup file support to `client/db/boltdb.BoltDB`.

This also adds a `client/core.(*Core).BackupDB` method so Go consumers of `Core` may issue backup requests at any time.

```
2022-02-25 16:28:05.971 [INF] CORE[DB]: Backing up database...
2022-02-25 16:28:06.982 [INF] CORE[DB]: Compacting database...
2022-02-25 16:28:13.938 [INF] CORE[DB]: Compacted database from 1073156096 => 507797504 bytes (47.32% reduction)
```