### PR TITLE
ui: Fix selecting prices over 1,000

### DIFF
--- a/client/webserver/site/src/js/markets.js
+++ b/client/webserver/site/src/js/markets.js
@@ -596,7 +596,7 @@ export default class MarketsPage extends BasePage {
    * on the chart area. The rate field is set to the x-value of the click.
    */
   reportDepthClick (r) {
-    this.page.rateField.value = Doc.formatCoinValue(r)
+    this.page.rateField.value = r
     this.rateFieldChanged()
   }
 


### PR DESCRIPTION
After clicking on the graph, no need to format the value from number to localized string because the rate input field has a number type.

Closes #1494