### PR TITLE
client/core: try a fresh fee rate for the init

### DIFF
--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1584,6 +1584,21 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 		errs.add("not broadcasting swap while DEX %s connection is down (could be revoked)", t.dc.acct.host)
 		return
 	}
+
+	// Use a higher swap fee rate if a local estimate is higher than the
+	// prescribed rate, but not higher than the funded (max) rate.
+	var freshRate uint64
+	if r, ok := t.wallets.fromWallet.feeRater(); ok {
+		freshRate, _ = r.FeeRate()
+	}
+	if freshRate == 0 { // either not a FeeRater, or FeeRate failed
+		freshRate = t.dc.bestBookFeeSuggestion(fromAsset.ID)
+	}
+	if highestFeeRate < freshRate && freshRate <= t.metaData.MaxFeeRate {
+		c.log.Infof("Prescribed %v fee rate %v looks low, using %v",
+			fromAsset.Symbol, highestFeeRate, freshRate)
+		highestFeeRate = freshRate
+	}
 	// swapMatches is no longer idempotent after this point.
 
 	// Send the swap. If the swap fails, set the swapErr flag for all matches.


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1489

```
When creating the swap transaction, see if a more current fee rate
should be used instead of the prescribed swap rate. This can be
particularly helpful for the taker because their swap may be a
long time after the match is made because the maker's swap must
be fully confirmed first.

If the current rate is swapRate < currentRate <= MaxFeeRate, then
use the current rate for the swap transaction.
```

We can also consider protocol changes where taker must get a new rate from server, and that will be enforced separately.
This current change is helpful even with that because it guards against server giving rates that are too low for whatever reason.