### PR TITLE
Web: fix panic in `/markets`

### DIFF
--- a/client/websocket/websocket.go
+++ b/client/websocket/websocket.go
@@ -352,7 +352,7 @@ func wsLoadCandles(s *Server, cl *wsClient, msg *msgjson.Message) *msgjson.Error
 func wsUnmarket(_ *Server, cl *wsClient, _ *msgjson.Message) *msgjson.Error {
 	cl.feedMtx.Lock()
 	defer cl.feedMtx.Unlock()
-	if cl.feed != nil && cl.feed.loop != nil {
+	if cl.feed != nil {
 		cl.feed.loop.Stop()
 		cl.feed.loop.WaitForShutdown()
 		cl.feed = nil

--- a/client/websocket/websocket.go
+++ b/client/websocket/websocket.go
@@ -352,7 +352,7 @@ func wsLoadCandles(s *Server, cl *wsClient, msg *msgjson.Message) *msgjson.Error
 func wsUnmarket(_ *Server, cl *wsClient, _ *msgjson.Message) *msgjson.Error {
 	cl.feedMtx.Lock()
 	defer cl.feedMtx.Unlock()
-	if cl.feed.loop != nil {
+	if cl.feed != nil && cl.feed.loop != nil {
 		cl.feed.loop.Stop()
 		cl.feed.loop.WaitForShutdown()
 		cl.feed = nil


### PR DESCRIPTION
This diff fixes panic described in #1496

Reproduction steps:
1. go to `/markets` page
2. shut down server
3. after client lost ws connection to the server, leave the `/markets` page. The first `unmarket` call from frontend will be served successfully and it will delete `cl.feed`.
4. go back to `/markets` page and leave it again. The `unmarket` request will fail because `cl.feed` is deleted earlier and `cl.feed.loop.Stop()` cause panic. 

Close #1496
