### PR TITLE
client: resolve failure to start redemption search

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2487,7 +2487,8 @@ func (btc *baseWallet) tryRedemptionRequests(ctx context.Context, startBlock *ch
 }
 
 // Refund revokes a contract. This can only be used after the time lock has
-// expired.
+// expired. This MUST return an asset.CoinNotFoundError error if the coin is
+// spent.
 // NOTE: The contract cannot be retrieved from the unspent coin info as the
 // wallet does not store it, even though it was known when the init transaction
 // was created. The client should store this information for persistence across
@@ -2516,7 +2517,7 @@ func (btc *baseWallet) Refund(coinID, contract dex.Bytes, feeSuggestion uint64) 
 		return nil, fmt.Errorf("error finding unspent contract: %w", err)
 	}
 	if utxo == nil {
-		return nil, asset.CoinNotFoundError
+		return nil, asset.CoinNotFoundError // spent
 	}
 	msgTx, err := btc.refundTx(txHash, vout, contract, uint64(utxo.Value), nil, feeSuggestion)
 	if err != nil {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -258,11 +258,13 @@ type Wallet interface {
 	// a goroutine.
 	FindRedemption(ctx context.Context, coinID, contract dex.Bytes) (redemptionCoin, secret dex.Bytes, err error)
 	// Refund refunds a contract. This can only be used after the time lock has
-	// expired AND if the contract has not been redeemed/refunded.
-	// NOTE: The contract cannot be retrieved from the unspent coin info
-	// as the wallet does not store it, even though it was known when the init
-	// transaction was created. The client should store this information for
-	// persistence across sessions.
+	// expired AND if the contract has not been redeemed/refunded. This method
+	// MUST return an asset.CoinNotFoundError error if the swap is already
+	// spent, which is used to indicate if FindRedemption should be used and the
+	// counterparty's swap redeemed. NOTE: The contract cannot be retrieved from
+	// the unspent coin info as the wallet does not store it, even though it was
+	// known when the init transaction was created. The client should store this
+	// information for persistence across sessions.
 	Refund(coinID, contract dex.Bytes, feeSuggestion uint64) (dex.Bytes, error)
 	// Address returns an address for the exchange wallet.
 	Address() (string, error)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4500,8 +4500,8 @@ func (c *Core) authDEX(dc *dexConnection) error {
 
 		// Flag each of the missing matches as revoked.
 		for _, match := range missing {
-			c.log.Warnf("DEX %s did not report active match %s on order %s - assuming revoked.",
-				dc.acct.host, match, oid)
+			c.log.Warnf("DEX %s did not report active match %s on order %s - assuming revoked, status %v.",
+				dc.acct.host, match, oid, match.Status)
 			// Must have been revoked while we were gone. Flag to allow recovery
 			// and subsequent retirement of the match and parent trade.
 			match.MetaData.Proof.SelfRevoked = true

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -72,8 +72,8 @@ type matchTracker struct {
 	// another redeem request for this match while one is already active.
 	sendingRedeemAsync uint32 // atomic
 	// refundErr will be set to true if we attempt a refund and get a
-	// CoinNotFoundError, indicating there is nothing to refund. Prevents
-	// retries.
+	// CoinNotFoundError, indicating there is nothing to refund and the
+	// counterparty redemption search should be attempted. Prevents retries.
 	refundErr   error
 	prefix      *order.Prefix
 	trade       *order.Trade
@@ -2146,11 +2146,14 @@ func (c *Core) refundMatches(t *trackedTrade, matches []*matchTracker) (uint64, 
 		feeSuggestion := c.feeSuggestionAny(refundAsset.ID)
 		refundCoin, err := refundWallet.Refund(swapCoinID, contractToRefund, feeSuggestion)
 		if err != nil {
+			// CRITICAL - Refund must indicate if the swap is spent (i.e.
+			// redeemed already) so that as taker we will start the
+			// auto-redemption path.
 			if errors.Is(err, asset.CoinNotFoundError) && match.Side == order.Taker {
 				match.refundErr = err
-				// Could not find the contract coin, which means it has been spent.
-				// We should have already started FindRedemption for this contract,
-				// but let's do it again to ensure we find the secret.
+				// Could not find the contract coin, which means it has been
+				// spent. Unless the locktime is expired, we would have already
+				// started FindRedemption for this contract.
 				t.dc.log.Debugf("Failed to refund %s contract %s, already redeemed. Beginning find redemption.",
 					refundAsset.Symbol, swapCoinString)
 				t.findMakersRedemption(match)
@@ -2158,6 +2161,12 @@ func (c *Core) refundMatches(t *trackedTrade, matches []*matchTracker) (uint64, 
 				t.delayTicks(match, time.Minute*5)
 				errs.add("error sending refund tx for match %s, swap coin %s: %v",
 					match, swapCoinString, err)
+				if match.Status == order.TakerSwapCast && match.Side == order.Taker {
+					// Check for a redeem even though Refund did not indicate it
+					// was spent via CoinNotFoundError, but do not set refundErr
+					// so that a refund can be tried again.
+					t.findMakersRedemption(match)
+				}
 			}
 			continue
 		}


### PR DESCRIPTION
This fix resolves a regression in 0.4 with the introduction of SPV wallets.

```
client/asset: Refund must indicate when spent

It is critical that asset.Wallet Refund signal to caller that it is
spent via asset.CoinNotFoundError so that it knows to begin looking
for the counterparty's redeem and move on to redeem as well.

This fixes dcr's refundTx so that it wraps asset.CoinNotFoundError
when lookupTxOutput indicates it is spent.

This also makes explicit the requirement for the asset.Wallet.Refund
method to return asset.CoinNotFoundError when spent.

client/core: allow more Refund errors to trigger redemption search

When locktime is expired, isRefundable will be true and thus block
the shouldBeginFindRedemption case in tick.  We handle this case
by having Refund errors signal when it is spent and then trigger a
redemption search with findMakersRedemption.  This improves
the docs on this handling and the need for Refund to return
asset.CoinNotFoundError when spent. This change also starts
findMakersRedemption for any non-nil error if it is a taker match
and the status is TakerSwapCast, but it does not block refund retries.
```

Note: I considered adding a `SwapConfirmations` call in `isRefundable` when locktime is found to be expired so that `isRefundable` will not block `shouldBeginFindRedemption`, but I am concerned about bugs in `SwapConfirmations`'s `spent bool` leading to failures to refund.  I think it is more foolproof to simply attempt `Refund` and on error, trigger `findMakersRedemption` depending on the error, match side, and match status/stage.