### PR TITLE
client/ui/btc: Recover BTC SPV wallet

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -6218,7 +6218,7 @@ func TestAssetBalance(t *testing.T) {
 	tWallet.bal = bal
 	walletBal, err := tCore.AssetBalance(tUTXOAssetA.ID)
 	if err != nil {
-		t.Fatalf("error retreiving asset balance: %v", err)
+		t.Fatalf("error retrieving asset balance: %v", err)
 	}
 	dbtest.MustCompareAssetBalances(t, "zero-conf", bal, &walletBal.Balance.Balance)
 	if walletBal.ContractLocked != 0 {

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1594,6 +1594,9 @@ func (c *TCore) ExportSeed(pw []byte) ([]byte, error) {
 func (c *TCore) WalletLogFilePath(uint32) (string, error) {
 	return "", nil
 }
+func (c *TCore) RecoverWallet(uint32, []byte, bool) error {
+	return nil
+}
 
 func TestServer(t *testing.T) {
 	// Register dummy drivers for unimplemented assets.

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -226,4 +226,11 @@ var EnUS = map[string]string{
 	"recent_acceleration_msg":     `Your latest acceleration was only <span id="recentAccelerationTime"></span> minutes ago! Are you sure you want to accelerate?`,
 	"recent_swap_msg":             `Your oldest unconfirmed swap transaction was submitted only <span id="recentSwapTime"></span> minutes ago! Are you sure you want to accelerate?`,
 	"early_acceleration_help_msg": `It will cause no harm to your order, but you might be wasting money. Acceleration is only helpful if the fee rate on an existing unconfirmed transaction has become too low to be mined in the next block, but not if blocks are just being mined slowly. You can confirm this in the block explorer by closing this popup and clicking on your previous transactions.`,
+	"recover":                     "Recover",
+	"recover_wallet":              "Recover Wallet",
+	"recover_warning":             "Recovering your wallet will move all wallet data to a backup folder. You will have to wait until the wallet resyncs with the network, which could potentially take a long time, before you can use the wallet again.",
+	"wallet_actively_used":        "Wallet actively used!",
+	"confirm_force_message":       "This wallet is actively managing orders. After taking this action, it will take a long time to resync your wallet, potentially causing orders to fail. Only take this action if absolutely necessary!",
+	"confirm":                     "Confirm",
+	"cancel":                      "Cancel",
 }

--- a/client/webserver/site/src/css/main_dark.scss
+++ b/client/webserver/site/src/css/main_dark.scss
@@ -67,6 +67,10 @@ body.dark {
     &.selected {
       background-color: #0b5831;
     }
+
+    &.danger {
+      background-color: #c91e1e;
+    }
   }
 
   select,

--- a/client/webserver/site/src/css/wallets.scss
+++ b/client/webserver/site/src/css/wallets.scss
@@ -82,3 +82,8 @@ table.wallets {
 #depositAddress {
   user-select: all;
 }
+
+#recoverWalletConfirm,
+#confirmForce {
+  width: 400px;
+}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=MQq4VWee">
+  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=Jj1lP4" rel="stylesheet">
+  <link href="/css/style.css?v=z8A71BD" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=z8A71BD"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -225,7 +225,49 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="reconfigErr"></div>
       <hr class="dashed my-2">
-      <button id="downloadLogs" type="button" class="w-25 mt-1 justify-content-center fs15 bg2">[[[wallet_logs]]]</button>
+      <div class="d-flex flex-row">
+        <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">[[[wallet_logs]]]</button>
+        <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">[[[recover]]]</button>
+      </div>
+    </form>
+  </div>
+
+  {{- /* POP-UP FORMS */ -}}
+  <div id="forms" class="d-hide">
+
+    {{- /* CONFIRM FORCE FORM */ -}}
+    <form class="d-hide" id="confirmForce">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        [[[wallet_actively_used]]]
+      </div>
+      <div class="fs15 text-left mt-2">
+        [[[confirm_force_message]]]
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="cancelForce" type="button" class="justify-content-center fs15 bg2 danger mx-1">[[[cancel]]]</button>
+        <button id="confirmForceSubmit" type="button" class="justify-content-center fs15 bg2 selected mx-2">[[[confirm]]]</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="confirmForceErr"></div>
+    </form>
+
+    {{- /* RECOVER WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="recoverWalletConfirm">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        [[[recover_wallet]]]
+      </div>
+      <div class="fs15 text-left mt-2">
+        [[[recover_warning]]]
+      </div>
+      <div class="text-left mt-2">
+        <label for="recoverWalletPW" class="form-label pl-1 mb-1">Password</label>
+        <input type="password" class="form-control select" id="recoverWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="recoverWalletSubmit" type="button" class="justify-content-center fs15 bg2 selected">[[[Submit]]]</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
   </div>
 </div>

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=MQq4VWee">
+  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=Jj1lP4" rel="stylesheet">
+  <link href="/css/style.css?v=z8A71BD" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=z8A71BD"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -225,7 +225,49 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="reconfigErr"></div>
       <hr class="dashed my-2">
-      <button id="downloadLogs" type="button" class="w-25 mt-1 justify-content-center fs15 bg2">Wallet Logs</button>
+      <div class="d-flex flex-row">
+        <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">Wallet Logs</button>
+        <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">Recover</button>
+      </div>
+    </form>
+  </div>
+
+  {{- /* POP-UP FORMS */ -}}
+  <div id="forms" class="d-hide">
+
+    {{- /* CONFIRM FORCE FORM */ -}}
+    <form class="d-hide" id="confirmForce">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Wallet actively used!
+      </div>
+      <div class="fs15 text-left mt-2">
+        This wallet is actively managing orders. After taking this action, it will take a long time to resync your wallet, potentially causing orders to fail. Only take this action if absolutely necessary!
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="cancelForce" type="button" class="justify-content-center fs15 bg2 danger mx-1">Cancel</button>
+        <button id="confirmForceSubmit" type="button" class="justify-content-center fs15 bg2 selected mx-2">Confirm</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="confirmForceErr"></div>
+    </form>
+
+    {{- /* RECOVER WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="recoverWalletConfirm">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Recover Wallet
+      </div>
+      <div class="fs15 text-left mt-2">
+        Recovering your wallet will move all wallet data to a backup folder. You will have to wait until the wallet resyncs with the network, which could potentially take a long time, before you can use the wallet again.
+      </div>
+      <div class="text-left mt-2">
+        <label for="recoverWalletPW" class="form-label pl-1 mb-1">Password</label>
+        <input type="password" class="form-control select" id="recoverWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="recoverWalletSubmit" type="button" class="justify-content-center fs15 bg2 selected">Submit</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
   </div>
 </div>

--- a/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=MQq4VWee">
+  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=Jj1lP4" rel="stylesheet">
+  <link href="/css/style.css?v=z8A71BD" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=z8A71BD"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -225,7 +225,49 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="reconfigErr"></div>
       <hr class="dashed my-2">
-      <button id="downloadLogs" type="button" class="w-25 mt-1 justify-content-center fs15 bg2">Wallet Logs</button>
+      <div class="d-flex flex-row">
+        <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">Wallet Logs</button>
+        <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">Recover</button>
+      </div>
+    </form>
+  </div>
+
+  {{- /* POP-UP FORMS */ -}}
+  <div id="forms" class="d-hide">
+
+    {{- /* CONFIRM FORCE FORM */ -}}
+    <form class="d-hide" id="confirmForce">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Wallet actively used!
+      </div>
+      <div class="fs15 text-left mt-2">
+        This wallet is actively managing orders. After taking this action, it will take a long time to resync your wallet, potentially causing orders to fail. Only take this action if absolutely necessary!
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="cancelForce" type="button" class="justify-content-center fs15 bg2 danger mx-1">Cancel</button>
+        <button id="confirmForceSubmit" type="button" class="justify-content-center fs15 bg2 selected mx-2">Confirm</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="confirmForceErr"></div>
+    </form>
+
+    {{- /* RECOVER WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="recoverWalletConfirm">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Recover Wallet
+      </div>
+      <div class="fs15 text-left mt-2">
+        Recovering your wallet will move all wallet data to a backup folder. You will have to wait until the wallet resyncs with the network, which could potentially take a long time, before you can use the wallet again.
+      </div>
+      <div class="text-left mt-2">
+        <label for="recoverWalletPW" class="form-label pl-1 mb-1">Password</label>
+        <input type="password" class="form-control select" id="recoverWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="recoverWalletSubmit" type="button" class="justify-content-center fs15 bg2 selected">Wyślij</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
   </div>
 </div>

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=MQq4VWee">
+  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=Jj1lP4" rel="stylesheet">
+  <link href="/css/style.css?v=z8A71BD" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=z8A71BD"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -225,7 +225,49 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="reconfigErr"></div>
       <hr class="dashed my-2">
-      <button id="downloadLogs" type="button" class="w-25 mt-1 justify-content-center fs15 bg2">Wallet Logs</button>
+      <div class="d-flex flex-row">
+        <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">Wallet Logs</button>
+        <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">Recover</button>
+      </div>
+    </form>
+  </div>
+
+  {{- /* POP-UP FORMS */ -}}
+  <div id="forms" class="d-hide">
+
+    {{- /* CONFIRM FORCE FORM */ -}}
+    <form class="d-hide" id="confirmForce">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Wallet actively used!
+      </div>
+      <div class="fs15 text-left mt-2">
+        This wallet is actively managing orders. After taking this action, it will take a long time to resync your wallet, potentially causing orders to fail. Only take this action if absolutely necessary!
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="cancelForce" type="button" class="justify-content-center fs15 bg2 danger mx-1">Cancel</button>
+        <button id="confirmForceSubmit" type="button" class="justify-content-center fs15 bg2 selected mx-2">Confirm</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="confirmForceErr"></div>
+    </form>
+
+    {{- /* RECOVER WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="recoverWalletConfirm">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Recover Wallet
+      </div>
+      <div class="fs15 text-left mt-2">
+        Recovering your wallet will move all wallet data to a backup folder. You will have to wait until the wallet resyncs with the network, which could potentially take a long time, before you can use the wallet again.
+      </div>
+      <div class="text-left mt-2">
+        <label for="recoverWalletPW" class="form-label pl-1 mb-1">Password</label>
+        <input type="password" class="form-control select" id="recoverWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="recoverWalletSubmit" type="button" class="justify-content-center fs15 bg2 selected">Enviar</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
   </div>
 </div>

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=MQq4VWee">
+  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=Jj1lP4" rel="stylesheet">
+  <link href="/css/style.css?v=z8A71BD" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=z8A71BD"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -225,7 +225,49 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="reconfigErr"></div>
       <hr class="dashed my-2">
-      <button id="downloadLogs" type="button" class="w-25 mt-1 justify-content-center fs15 bg2">Wallet Logs</button>
+      <div class="d-flex flex-row">
+        <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">Wallet Logs</button>
+        <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">Recover</button>
+      </div>
+    </form>
+  </div>
+
+  {{- /* POP-UP FORMS */ -}}
+  <div id="forms" class="d-hide">
+
+    {{- /* CONFIRM FORCE FORM */ -}}
+    <form class="d-hide" id="confirmForce">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Wallet actively used!
+      </div>
+      <div class="fs15 text-left mt-2">
+        This wallet is actively managing orders. After taking this action, it will take a long time to resync your wallet, potentially causing orders to fail. Only take this action if absolutely necessary!
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="cancelForce" type="button" class="justify-content-center fs15 bg2 danger mx-1">Cancel</button>
+        <button id="confirmForceSubmit" type="button" class="justify-content-center fs15 bg2 selected mx-2">Confirm</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="confirmForceErr"></div>
+    </form>
+
+    {{- /* RECOVER WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="recoverWalletConfirm">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Recover Wallet
+      </div>
+      <div class="fs15 text-left mt-2">
+        Recovering your wallet will move all wallet data to a backup folder. You will have to wait until the wallet resyncs with the network, which could potentially take a long time, before you can use the wallet again.
+      </div>
+      <div class="text-left mt-2">
+        <label for="recoverWalletPW" class="form-label pl-1 mb-1">Password</label>
+        <input type="password" class="form-control select" id="recoverWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="recoverWalletSubmit" type="button" class="justify-content-center fs15 bg2 selected">提交</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
   </div>
 </div>

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -82,6 +82,7 @@ type clientCore interface {
 	CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error
 	OpenWallet(assetID uint32, pw []byte) error
 	RescanWallet(assetID uint32, force bool) error
+	RecoverWallet(assetID uint32, appPW []byte, force bool) error
 	CloseWallet(assetID uint32) error
 	ConnectWallet(assetID uint32) error
 	Wallets() []*core.WalletState
@@ -327,6 +328,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/closewallet", s.apiCloseWallet)
 			apiAuth.Post("/connectwallet", s.apiConnectWallet)
 			apiAuth.Post("/rescanwallet", s.apiRescanWallet)
+			apiAuth.Post("/recoverwallet", s.apiRecoverWallet)
 			apiAuth.Post("/trade", s.apiTrade)
 			apiAuth.Post("/cancel", s.apiCancel)
 			apiAuth.Post("/logout", s.apiLogout)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -185,6 +185,9 @@ func (c *TCore) AccelerationEstimate(oidB dex.Bytes, newFeeRate uint64) (uint64,
 func (c *TCore) PreAccelerateOrder(oidB dex.Bytes) (*core.PreAccelerate, error) {
 	return nil, nil
 }
+func (c *TCore) RecoverWallet(uint32, []byte, bool) error {
+	return nil
+}
 
 type TWriter struct {
 	b []byte

--- a/dex/config/config.go
+++ b/dex/config/config.go
@@ -62,3 +62,20 @@ func Unmapify(settings map[string]string, obj interface{}) error {
 	cfgData := Data(settings)
 	return ParseInto(cfgData, obj)
 }
+
+// Mapify takes an interface with ini tags, and parses it into
+// a settings map. obj must be a pointer to a struct.
+func Mapify(obj interface{}) (map[string]string, error) {
+	cfg := ini.Empty()
+	err := ini.ReflectFrom(cfg, obj)
+	if err != nil {
+		return nil, err
+	}
+	cfgKeyValues := make(map[string]string)
+	for _, section := range cfg.Sections() {
+		for _, key := range section.Keys() {
+			cfgKeyValues[key.Name()] = key.String()
+		}
+	}
+	return cfgKeyValues, nil
+}

--- a/dex/config/config_test.go
+++ b/dex/config/config_test.go
@@ -212,6 +212,15 @@ func TestConfigParsing(t *testing.T) {
 			t.Fatalf("%s: expected parsed cfg key5 to have '%v', got '%v'", tt.name, tt.expect.parsedCfg.Key5,
 				parsedCfg.Key3)
 		}
+
+		mapifiedCfg, err := Mapify(tt.parsedCfg)
+		if err != nil {
+			t.Fatalf("%s: unexpected error from Mapify: %v", tt.name, err)
+		}
+
+		if len(mapifiedCfg) != 4 {
+			t.Fatalf("%s: expected all keys except ignored to be in map, but got %v", tt.name, len(mapifiedCfg))
+		}
 	}
 }
 

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -515,7 +515,7 @@ func (r *OrderRouter) processTrade(oRecord *orderRecord, tunnel MarketTunnel, as
 						coin.ID, fundingAsset.Symbol)
 					return true, nil
 				}
-				log.Errorf("Error retreiving limit order funding coin ID %s. user = %s: %v", coin.ID, user, err)
+				log.Errorf("Error retrieving limit order funding coin ID %s. user = %s: %v", coin.ID, user, err)
 				return false, msgjson.NewError(msgjson.FundingError, fmt.Sprintf("error retrieving coin ID %v", coin.ID))
 			}
 


### PR DESCRIPTION
Adds the ability to delete all the files from the BTC SPV wallet and recreate it from scratch.

- `client/asset/interface`: A `Recoverer` trait is added that includes three functions
  - `GetRecoveryCfg`: Attempts to retrieve a `map[string]string` from the existing wallet that would help in putting the
     wallet back to the state is was in before all the wallet files were deleted.
  - `Destroy`: deletes all the wallet files
  - `ApplyRecoveryCfg`: passes the settings that were retrieved using `GetRecoveryCfg` to a newly created wallet.
- `client/asset/btc`: Implements the `Recoverer` interface. The recovery configuration includes the number of internal and number of external addresses that the wallet generated. This amount of addresses are regenerated in the new instance of the wallet. If this was not done and there were active orders being managed when the user recovered the wallet, the new wallet would not be able to redeem and swaps because it wouldn't have access to the required private keys.
- `client/core`: A `Recover` function is added that destroys the old wallet and creates a new one. It contains a force parameter similar to `Rescan` which unless is set to true, will not allow the user to recover a wallet if there are currently active deals requiring the wallet.  An `activeOrdersErr` is returned from the wallet if `force=false` and there are currently active deals.
- `app`: A button is added on the wallet's page to allow users to recover a wallet if the wallet has the `Recoverer` trait. The "force" workflow is implemented for both rescan and recover. If either of these requests return the `activeOrdersErr`, another popup will show up prompting the user to confirm that they would like to take this action even though there are active orders. If the user confirms, the same request will be resubmitted with `force=true`.

Closes #1438.