### PR TITLE
Properly Expand Appdata Directory

### DIFF
--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -149,7 +149,8 @@ func newRPCWallet(cfg *Config, chainParams *chaincfg.Params, logger dex.Logger) 
 		log:         log,
 	}
 
-	certs, err := os.ReadFile(cfg.RPCCert)
+	cert := dex.CleanAndExpandPath(cfg.RPCCert)
+	certs, err := os.ReadFile(cert)
 	if err != nil {
 		return nil, fmt.Errorf("TLS certificate read error: %w", err)
 	}

--- a/client/cmd/dexc/config.go
+++ b/client/cmd/dexc/config.go
@@ -151,9 +151,11 @@ func configure() (*Config, error) {
 		}
 	}
 
+	cfgPath := dex.CleanAndExpandPath(preCfg.Config)
+
 	// Load additional config from file.
 	parser := flags.NewParser(&iniCfg, flags.Default)
-	err := flags.NewIniParser(parser).ParseFile(preCfg.Config)
+	err := flags.NewIniParser(parser).ParseFile(cfgPath)
 	if err != nil {
 		if _, ok := err.(*os.PathError); !ok {
 			fmt.Fprintln(os.Stderr, err)

--- a/dex/path.go
+++ b/dex/path.go
@@ -5,62 +5,52 @@ package dex
 
 import (
 	"os"
-	"os/user"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
-// CleanAndExpandPath expands environment variables and leading ~ in the
-// passed path, cleans the result, and returns it.
+// CleanAndExpandPath expands environment variables and leading ~ in the passed
+// path, cleans the result, and returns it.
 func CleanAndExpandPath(path string) string {
 	// Nothing to do when no path is given.
 	if path == "" {
 		return path
 	}
 
-	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
-	// %VARIABLE%, but the variables can still be expanded via POSIX-style
-	// $VARIABLE.
-	path = os.ExpandEnv(path)
+	dirName := ""
+
+	// This supports Windows cmd.exe-style %VARIABLE%.
+	if strings.HasPrefix(path, "%") {
+		// Split path into %VARIABLE% and path
+		pathArray := strings.SplitAfterN(path, "/", 2)
+		dirEnv := strings.ToUpper(strings.Trim(pathArray[0], "%/"))
+		path = pathArray[1]
+		dirName = os.Getenv(dirEnv)
+		if dirName == "" {
+			// This does not support Windows XP and before as
+			// they didn't have a LOCALAPPDATA.
+			dirName = os.Getenv("LOCALAPPDATA")
+		}
+
+		return filepath.Join(dirName, path)
+	}
 
 	if !strings.HasPrefix(path, "~") {
-		return filepath.Clean(path)
+		// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
+		// %VARIABLE%, but the variables can still be expanded via POSIX-style
+		// $VARIABLE.
+		path = os.ExpandEnv(path)
+		path, _ = filepath.Abs(path)
+		return path
 	}
 
-	// Expand initial ~ to the current user's home directory, or ~otheruser
-	// to otheruser's home directory.  On Windows, both forward and backward
-	// slashes can be used.
-	path = path[1:]
-
-	var pathSeparators string
-	if runtime.GOOS == "windows" {
-		pathSeparators = string(os.PathSeparator) + "/"
-	} else {
-		pathSeparators = string(os.PathSeparator)
+	if strings.HasPrefix(path, "~") {
+		dirName, _ = os.UserHomeDir()
 	}
 
-	userName := ""
-	if i := strings.IndexAny(path, pathSeparators); i != -1 {
-		userName = path[:i]
-		path = path[i:]
+	if dirName == "" {
+		dirName = "."
 	}
 
-	homeDir := ""
-	var u *user.User
-	var err error
-	if userName == "" {
-		u, err = user.Current()
-	} else {
-		u, err = user.Lookup(userName)
-	}
-	if err == nil {
-		homeDir = u.HomeDir
-	}
-	// Fallback to CWD if user lookup fails or user has no home directory.
-	if homeDir == "" {
-		homeDir = "."
-	}
-
-	return filepath.Join(homeDir, path)
+	return filepath.Join(dirName, path[2:])
 }

--- a/dex/path.go
+++ b/dex/path.go
@@ -31,7 +31,6 @@ func CleanAndExpandPath(path string) string {
 			// they didn't have a LOCALAPPDATA.
 			dirName = os.Getenv("LOCALAPPDATA")
 		}
-
 		return filepath.Join(dirName, path)
 	}
 
@@ -40,17 +39,14 @@ func CleanAndExpandPath(path string) string {
 		// %VARIABLE%, but the variables can still be expanded via POSIX-style
 		// $VARIABLE.
 		path = os.ExpandEnv(path)
-		path, _ = filepath.Abs(path)
-		return path
+		return filepath.Clean(path)
 	}
 
-	if strings.HasPrefix(path, "~") {
-		dirName, _ = os.UserHomeDir()
-	}
-
-	if dirName == "" {
+	dirName, err := os.UserHomeDir()
+	if err != nil {
+		// Fallback to CWD if retrieving user home directory fails.
 		dirName = "."
 	}
 
-	return filepath.Join(dirName, path[2:])
+	return filepath.Join(dirName, path[1:])
 }


### PR DESCRIPTION
This diff properly expands the `~` to user home directory, provides support for windows `%VARIABLE%` style when expanding appdata dir and expands dcr rpcwallet cert path. Closes #436