### PR TITLE
client/asset/dcr: simplify dcr.Wallet interface

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2473,7 +2473,7 @@ func (dcr *ExchangeWallet) Lock() error {
 func (dcr *ExchangeWallet) Locked() bool {
 	unlocked, err := dcr.wallet.AccountUnlocked(dcr.ctx, dcr.acctName)
 	if err != nil {
-		dcr.log.Errorf("error checking wallet lock status %v", err)
+		dcr.log.Errorf("error checking account lock status %v", err)
 		return false // assume wallet is unlocked?
 	}
 	return !unlocked

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -3188,6 +3188,7 @@ func (dcr *ExchangeWallet) mainchainAncestor(ctx context.Context, blockHash *cha
 
 // blockHeader returns the *BlockHeader for the specified block hash, and a
 // validity bool indicating true when the block has not been stake-invalidated.
+// validity will always be false if mainchain is false.
 func (dcr *ExchangeWallet) blockHeader(ctx context.Context, blockHash *chainhash.Hash) (blockHeader *BlockHeader, valid, mainchain bool, err error) {
 	blockHeader, err = dcr.wallet.GetBlockHeader(ctx, blockHash)
 	if err != nil {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2129,7 +2129,7 @@ func (dcr *ExchangeWallet) findRedemptionsInMempool(contractOutpoints []outPoint
 	}
 
 	mempooler, is := dcr.wallet.(Mempooler)
-	if !is {
+	if !is || dcr.wallet.SpvMode() {
 		return
 	}
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -140,7 +140,7 @@ func tNewWallet() (*ExchangeWallet, *tRPCClient, func(), error) {
 		PeersChange: func(uint32) {},
 	}
 	walletCtx, shutdown := context.WithCancel(tCtx)
-	wallet, err := unconnectedWallet(walletCfg, &Config{Account: "default"}, tChainParams, tLogger)
+	wallet, err := unconnectedWallet(walletCfg, &Config{Account: tAcctName}, tChainParams, tLogger)
 	if err != nil {
 		shutdown()
 		return nil, nil, nil, err
@@ -148,7 +148,6 @@ func tNewWallet() (*ExchangeWallet, *tRPCClient, func(), error) {
 	wallet.wallet = &rpcWallet{
 		rpcClient: client,
 		log:       tLogger.SubLogger("trpc"),
-		acctName:  tAcctName,
 	}
 	wallet.ctx = walletCtx
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -58,6 +58,7 @@ var (
 	tP2PKHScript   []byte
 	tChainParams          = chaincfg.MainNetParams()
 	feeSuggestion  uint64 = 10
+	tAcctName             = "tAcctName"
 )
 
 func randBytes(l int) []byte {
@@ -77,41 +78,20 @@ func makeGetTxOutRes(confs, lots int64, pkScript []byte) *chainjson.GetTxOutResu
 	}
 }
 
-func makeRawTx(blockHeight int64, txid string, inputs []chainjson.Vin, outputScripts []dex.Bytes) *chainjson.TxRawResult {
-	tx := &chainjson.TxRawResult{
-		Txid:        txid,
-		Vin:         inputs,
-		BlockHeight: blockHeight,
-	}
+func makeRawTx(inputs []*wire.TxIn, outputScripts []dex.Bytes) *wire.MsgTx {
+	tx := wire.NewMsgTx()
 	for _, pkScript := range outputScripts {
-		tx.Vout = append(tx.Vout, chainjson.Vout{
-			ScriptPubKey: chainjson.ScriptPubKeyResult{
-				Hex: hex.EncodeToString(pkScript),
-			},
+		tx.TxOut = append(tx.TxOut, &wire.TxOut{
+			PkScript: pkScript,
 		})
 	}
+	tx.TxIn = inputs
 	return tx
 }
 
-func makeTxHex(inputs []chainjson.Vin, pkScripts []dex.Bytes) (string, error) {
+func makeTxHex(inputs []*wire.TxIn, pkScripts []dex.Bytes) (string, error) {
 	msgTx := wire.NewMsgTx()
-	for _, input := range inputs {
-		prevOutHash, err := chainhash.NewHashFromStr(input.Txid)
-		if err != nil {
-			return "", err
-		}
-		prevOut := wire.NewOutPoint(prevOutHash, input.Vout, input.Tree)
-		amountIn, err := dcrutil.NewAmount(input.AmountIn)
-		if err != nil {
-			return "", err
-		}
-		sigScript, err := hex.DecodeString(input.ScriptSig.Hex)
-		if err != nil {
-			return "", err
-		}
-		txIn := wire.NewTxIn(prevOut, int64(amountIn), sigScript)
-		msgTx.AddTxIn(txIn)
-	}
+	msgTx.TxIn = inputs
 	for _, pkScript := range pkScripts {
 		txOut := wire.NewTxOut(100000000, pkScript)
 		msgTx.AddTxOut(txOut)
@@ -128,13 +108,10 @@ func makeTxHex(inputs []chainjson.Vin, pkScripts []dex.Bytes) (string, error) {
 	return hex.EncodeToString(txHex), nil
 }
 
-func makeRPCVin(txid string, vout uint32, sigScript []byte) chainjson.Vin {
-	return chainjson.Vin{
-		Txid: txid,
-		Vout: vout,
-		ScriptSig: &chainjson.ScriptSig{
-			Hex: hex.EncodeToString(sigScript),
-		},
+func makeRPCVin(txHash *chainhash.Hash, vout uint32, sigScript []byte) *wire.TxIn {
+	return &wire.TxIn{
+		PreviousOutPoint: *wire.NewOutPoint(txHash, vout, 0),
+		SignatureScript:  sigScript,
 	}
 }
 
@@ -146,6 +123,14 @@ func newTxOutResult(script []byte, value uint64, confs int64) *chainjson.GetTxOu
 			Hex: hex.EncodeToString(script),
 		},
 	}
+}
+
+func dummyInput() *wire.TxIn {
+	return wire.NewTxIn(wire.NewOutPoint(&chainhash.Hash{0x01}, 0, 0), 0, nil)
+}
+
+func dummyTx() *wire.MsgTx {
+	return makeRawTx([]*wire.TxIn{dummyInput()}, []dex.Bytes{})
 }
 
 func tNewWallet() (*ExchangeWallet, *tRPCClient, func(), error) {
@@ -163,6 +148,7 @@ func tNewWallet() (*ExchangeWallet, *tRPCClient, func(), error) {
 	wallet.wallet = &rpcWallet{
 		rpcClient: client,
 		log:       tLogger.SubLogger("trpc"),
+		acctName:  tAcctName,
 	}
 	wallet.ctx = walletCtx
 
@@ -218,83 +204,76 @@ type tRPCClient struct {
 	estFeeErr      error
 }
 
-type tBlockchain struct {
-	mtx                 sync.RWMutex
-	rawTxs              map[string]*chainjson.TxRawResult
-	mainchain           map[int64]*chainhash.Hash
-	verboseBlocks       map[string]*chainjson.GetBlockVerboseResult
-	verboseBlockHeaders map[string]*chainjson.GetBlockHeaderVerboseResult
-	v2CFilterBuilders   map[string]*tV2CFilterBuilder
+type wireTxWithHeight struct {
+	tx     *wire.MsgTx
+	height int64
 }
 
-func (blockchain *tBlockchain) addRawTx(tx *chainjson.TxRawResult) (*chainhash.Hash, *chainjson.GetBlockVerboseResult) {
+type tBlockchain struct {
+	mtx               sync.RWMutex
+	rawTxs            map[chainhash.Hash]*wireTxWithHeight
+	mainchain         map[int64]*chainhash.Hash
+	verboseBlocks     map[chainhash.Hash]*wire.MsgBlock
+	blockHeaders      map[chainhash.Hash]*wire.BlockHeader
+	v2CFilterBuilders map[chainhash.Hash]*tV2CFilterBuilder
+}
+
+func (blockchain *tBlockchain) addRawTx(blockHeight int64, tx *wire.MsgTx) (*chainhash.Hash, *wire.MsgBlock) {
 	blockchain.mtx.Lock()
 	defer blockchain.mtx.Unlock()
 
-	blockchain.rawTxs[tx.Txid] = tx
-	if tx.BlockHeight < 0 {
+	blockchain.rawTxs[tx.TxHash()] = &wireTxWithHeight{tx, blockHeight}
+
+	if blockHeight < 0 {
 		return nil, nil
 	}
 
 	// Mined tx. Add to block.
-	blkHash, block := blockchain.blockAt(tx.BlockHeight)
-	block.RawTx = append(block.RawTx, *tx)
+	block := blockchain.blockAt(blockHeight)
+	if block == nil {
+		block = &wire.MsgBlock{}
+	}
+	blockFilterBuilder := blockchain.v2CFilterBuilders[block.BlockHash()]
+	block.Transactions = append(block.Transactions, tx)
+	blockHash := block.BlockHash()
+	blockchain.mainchain[blockHeight] = &blockHash
+	blockchain.verboseBlocks[blockHash] = block
+
+	blockchain.blockHeaders[blockHash] = &wire.BlockHeader{
+		Height: uint32(blockHeight),
+		// PrevBlock: *prevBlockHash,
+	}
 
 	// Save prevout and output scripts in block cfilters.
-	blockFilterBuilder := blockchain.v2CFilterBuilders[block.Hash]
-	for i := range tx.Vin {
-		input := &tx.Vin[i]
-		prevTx, found := blockchain.rawTxs[input.Txid]
-		if !found || len(prevTx.Vout) <= int(input.Vout) {
+	if blockFilterBuilder == nil {
+		blockFilterBuilder = &tV2CFilterBuilder{}
+		copy(blockFilterBuilder.key[:], randBytes(16))
+
+	}
+	blockchain.v2CFilterBuilders[blockHash] = blockFilterBuilder
+	for _, txIn := range tx.TxIn {
+		prevOut := &txIn.PreviousOutPoint
+		prevTx, found := blockchain.rawTxs[prevOut.Hash]
+		if !found || len(prevTx.tx.TxOut) <= int(prevOut.Index) {
 			continue
 		}
-		prevOutScript, _ := hex.DecodeString(prevTx.Vout[input.Vout].ScriptPubKey.Hex)
-		if input.IsStakeBase() {
-			blockFilterBuilder.data.AddStakePkScript(prevOutScript)
-		} else {
-			blockFilterBuilder.data.AddRegularPkScript(prevOutScript)
-		}
+		blockFilterBuilder.data.AddRegularPkScript(prevTx.tx.TxOut[prevOut.Index].PkScript)
 	}
-	for o := range tx.Vout {
-		pkScript, _ := hex.DecodeString(tx.Vout[o].ScriptPubKey.Hex)
-		blockFilterBuilder.data.AddRegularPkScript(pkScript)
+	for _, txOut := range tx.TxOut {
+		blockFilterBuilder.data.AddRegularPkScript(txOut.PkScript)
 	}
 
-	return blkHash, block
+	return &blockHash, block
 }
 
 // blockchain.mtx lock should be held for writes.
-func (blockchain *tBlockchain) blockAt(height int64) (*chainhash.Hash, *chainjson.GetBlockVerboseResult) {
+func (blockchain *tBlockchain) blockAt(height int64) *wire.MsgBlock {
 	blkHash, found := blockchain.mainchain[height]
 	if found {
-		return blkHash, blockchain.verboseBlocks[blkHash.String()]
+		return blockchain.verboseBlocks[*blkHash]
 	}
 
-	prevBlockHash := blockchain.mainchain[height-1].String()
-	var newBlockHash chainhash.Hash
-	copy(newBlockHash[:], randBytes(32))
-	newBlock := &chainjson.GetBlockVerboseResult{
-		Height:       height,
-		Hash:         newBlockHash.String(),
-		PreviousHash: prevBlockHash,
-	}
-
-	blockchain.mainchain[height] = &newBlockHash
-	blockchain.verboseBlocks[newBlock.Hash] = newBlock
-	blockchain.verboseBlocks[prevBlockHash].NextHash = newBlock.Hash
-
-	blockchain.verboseBlockHeaders[newBlock.Hash] = &chainjson.GetBlockHeaderVerboseResult{
-		Height:       uint32(height),
-		Hash:         newBlock.Hash,
-		PreviousHash: prevBlockHash,
-	}
-	blockchain.verboseBlockHeaders[prevBlockHash].NextHash = newBlock.Hash
-
-	blockFilterBuilder := &tV2CFilterBuilder{}
-	copy(blockFilterBuilder.key[:], randBytes(16))
-	blockchain.v2CFilterBuilders[newBlockHash.String()] = blockFilterBuilder
-
-	return &newBlockHash, newBlock
+	return nil
 }
 
 type tV2CFilterBuilder struct {
@@ -315,17 +294,17 @@ func newTRPCClient() *tRPCClient {
 	return &tRPCClient{
 		txOutRes: make(map[outPoint]*chainjson.GetTxOutResult),
 		blockchain: &tBlockchain{
-			rawTxs: map[string]*chainjson.TxRawResult{},
+			rawTxs: map[chainhash.Hash]*wireTxWithHeight{},
 			mainchain: map[int64]*chainhash.Hash{
 				0: &newHash,
 			},
-			verboseBlocks: map[string]*chainjson.GetBlockVerboseResult{
-				newHash.String(): {},
+			verboseBlocks: map[chainhash.Hash]*wire.MsgBlock{
+				newHash: {},
 			},
-			verboseBlockHeaders: map[string]*chainjson.GetBlockHeaderVerboseResult{
-				newHash.String(): {},
+			blockHeaders: map[chainhash.Hash]*wire.BlockHeader{
+				newHash: {},
 			},
-			v2CFilterBuilders: map[string]*tV2CFilterBuilder{},
+			v2CFilterBuilders: map[chainhash.Hash]*tV2CFilterBuilder{},
 		},
 		signFunc: defaultSignFunc,
 		rawRes:   make(map[string]json.RawMessage),
@@ -391,40 +370,38 @@ func (c *tRPCClient) GetBlockHash(_ context.Context, blockHeight int64) (*chainh
 	return h, nil
 }
 
-func (c *tRPCClient) GetBlockVerbose(_ context.Context, blockHash *chainhash.Hash, verboseTx bool) (*chainjson.GetBlockVerboseResult, error) {
+func (c *tRPCClient) GetBlock(_ context.Context, blockHash *chainhash.Hash) (*wire.MsgBlock, error) {
 	c.blockchain.mtx.RLock()
 	defer c.blockchain.mtx.RUnlock()
-	blk, found := c.blockchain.verboseBlocks[blockHash.String()]
+	blk, found := c.blockchain.verboseBlocks[*blockHash]
 	if !found {
 		return nil, fmt.Errorf("no test block found for %s", blockHash)
 	}
-	blkCopy := *blk
-	if !verboseTx {
-		txIDs := make([]string, len(blkCopy.RawTx))
-		for i := range blkCopy.RawTx {
-			txIDs[i] = blkCopy.RawTx[i].Txid
-		}
-		blkCopy.Tx = txIDs
-		blkCopy.RawTx = blkCopy.RawTx[:0]
-
-		stxIDs := make([]string, len(blkCopy.RawSTx))
-		for i := range blkCopy.RawSTx {
-			stxIDs[i] = blkCopy.RawSTx[i].Txid
-		}
-		blkCopy.STx = stxIDs
-		blkCopy.RawSTx = blkCopy.RawSTx[:0]
-	}
-	return &blkCopy, nil
+	return blk, nil
 }
 
 func (c *tRPCClient) GetBlockHeaderVerbose(_ context.Context, blockHash *chainhash.Hash) (*chainjson.GetBlockHeaderVerboseResult, error) {
 	c.blockchain.mtx.RLock()
 	defer c.blockchain.mtx.RUnlock()
-	blkHeader, found := c.blockchain.verboseBlockHeaders[blockHash.String()]
+	hdr, found := c.blockchain.blockHeaders[*blockHash]
 	if !found {
 		return nil, fmt.Errorf("no test block header found for %s", blockHash)
 	}
-	return blkHeader, nil
+	return &chainjson.GetBlockHeaderVerboseResult{
+		Height:       hdr.Height,
+		Hash:         blockHash.String(),
+		PreviousHash: hdr.PrevBlock.String(),
+	}, nil
+}
+
+func (c *tRPCClient) GetBlockHeader(_ context.Context, blockHash *chainhash.Hash) (*wire.BlockHeader, error) {
+	c.blockchain.mtx.RLock()
+	defer c.blockchain.mtx.RUnlock()
+	hdr, found := c.blockchain.blockHeaders[*blockHash]
+	if !found {
+		return nil, fmt.Errorf("no test block header found for %s", blockHash)
+	}
+	return hdr, nil
 }
 
 func (c *tRPCClient) GetRawMempool(_ context.Context, txType chainjson.GetRawMempoolTxTypeCmd) ([]*chainhash.Hash, error) {
@@ -435,29 +412,23 @@ func (c *tRPCClient) GetRawMempool(_ context.Context, txType chainjson.GetRawMem
 	defer c.blockchain.mtx.RUnlock()
 	txHashes := make([]*chainhash.Hash, 0)
 	for _, tx := range c.blockchain.rawTxs {
-		if tx.BlockHeight < 0 {
-			txHash, _ := chainhash.NewHashFromStr(tx.Txid)
-			txHashes = append(txHashes, txHash)
+		if tx.height < 0 {
+			txHash := tx.tx.TxHash()
+			txHashes = append(txHashes, &txHash)
 		}
 	}
 	return txHashes, nil
 }
 
-func (c *tRPCClient) GetRawTransactionVerbose(_ context.Context, txHash *chainhash.Hash) (*chainjson.TxRawResult, error) {
+func (c *tRPCClient) GetRawTransaction(_ context.Context, txHash *chainhash.Hash) (*dcrutil.Tx, error) {
 	if c.rawTxErr != nil {
 		return nil, c.rawTxErr
 	}
-	tx, found := c.blockchain.rawTxs[txHash.String()]
+	tx, found := c.blockchain.rawTxs[*txHash]
 	if !found {
 		return nil, dcrjson.NewRPCError(dcrjson.ErrRPCNoTxInfo, "no test raw tx "+txHash.String())
 	}
-	if tx.BlockHeight < 0 {
-		tx.Confirmations = -1
-	} else {
-		_, bestBlockHeight := c.getBestBlock()
-		tx.Confirmations = bestBlockHeight - tx.BlockHeight + 1
-	}
-	return tx, nil
+	return dcrutil.NewTx(tx.tx), nil
 }
 
 func (c *tRPCClient) GetBalanceMinConf(_ context.Context, account string, minConfirms int) (*walletjson.GetBalanceResult, error) {
@@ -541,15 +512,13 @@ func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.
 			return nil, fmt.Errorf("getcfilterv2 requires 1 param, got %d", len(params))
 		}
 
-		var blkHash string
-		err := json.Unmarshal(params[0], &blkHash)
-		if err != nil {
-			return nil, err
-		}
+		var hashStr string
+		json.Unmarshal(params[0], &hashStr)
+		blkHash, _ := chainhash.NewHashFromStr(hashStr)
 
 		c.blockchain.mtx.RLock()
 		defer c.blockchain.mtx.RUnlock()
-		blockFilterBuilder := c.blockchain.v2CFilterBuilders[blkHash]
+		blockFilterBuilder := c.blockchain.v2CFilterBuilders[*blkHash]
 		if blockFilterBuilder == nil {
 			return nil, fmt.Errorf("cfilters builder not found for block %s", blkHash)
 		}
@@ -558,7 +527,7 @@ func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.
 			return nil, err
 		}
 		res := &walletjson.GetCFilterV2Result{
-			BlockHash: blkHash,
+			BlockHash: blkHash.String(),
 			Filter:    hex.EncodeToString(v2CFilter.Bytes()),
 			Key:       hex.EncodeToString(blockFilterBuilder.key[:]),
 		}
@@ -582,6 +551,7 @@ func (c *tRPCClient) RawRequest(_ context.Context, method string, params []json.
 				unspents = append(unspents, unspent)
 			}
 		}
+
 		response, _ := json.Marshal(unspents)
 		return response, nil
 
@@ -701,7 +671,7 @@ func TestAvailableFund(t *testing.T) {
 	balanceResult := &walletjson.GetBalanceResult{
 		Balances: []walletjson.GetAccountBalanceResult{
 			{
-				AccountName: wallet.acct,
+				AccountName: tAcctName,
 			},
 		},
 	}
@@ -723,7 +693,7 @@ func TestAvailableFund(t *testing.T) {
 			TxID:          tTxID,
 			Vout:          vout,
 			Address:       tPKHAddr.String(),
-			Account:       wallet.acct,
+			Account:       tAcctName,
 			Amount:        float64(atomAmt) / 1e8,
 			Confirmations: confs,
 			ScriptPubKey:  hex.EncodeToString(tP2PKHScript),
@@ -966,7 +936,7 @@ func TestAvailableFund(t *testing.T) {
 	if err == nil {
 		t.Fatalf("no error for wrong account")
 	}
-	node.unspent[0].Account = wallet.acct
+	node.unspent[0].Account = tAcctName
 
 	// Place locked utxo in different account, check locked balance.
 	node.lluCoins[0].Account = "wrong account"
@@ -1055,14 +1025,15 @@ func TestFundingCoins(t *testing.T) {
 		TxID:      tTxID,
 		Vout:      vout,
 		Address:   tPKHAddr.String(),
-		Account:   wallet.acct,
 		Spendable: true,
+		Account:   tAcctName,
 	}
 
 	node.unspent = []walletjson.ListUnspentResult{p2pkhUnspent}
 	coinIDs := []dex.Bytes{coinID}
 
 	ensureGood := func() {
+		t.Helper()
 		coins, err := wallet.FundingCoins(coinIDs)
 		if err != nil {
 			t.Fatalf("FundingCoins error: %v", err)
@@ -1175,7 +1146,7 @@ func TestFundEdges(t *testing.T) {
 	p2pkhUnspent := walletjson.ListUnspentResult{
 		TxID:          tTxID,
 		Address:       tPKHAddr.String(),
-		Account:       wallet.acct,
+		Account:       tAcctName,
 		Amount:        float64(swapVal+fees-1) / 1e8, // one atom less than needed
 		Confirmations: 5,
 		ScriptPubKey:  hex.EncodeToString(tP2PKHScript),
@@ -1771,12 +1742,9 @@ func TestFindRedemption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected GetBestBlock error: %v", err)
 	}
+
 	contractHeight := bestBlockHeight + 1
-	contractTxid := "e1b7c47df70d7d8f4c9c26f8ba9a59102c10885bd49024d32fdef08242f0c26c"
-	contractTxHash, _ := chainhash.NewHashFromStr(contractTxid)
-	otherTxid := "7a7b3b5c3638516bc8e7f19b4a3dec00f052a599fed5036c2b89829de2367bb6"
 	contractVout := uint32(1)
-	coinID := toCoinID(contractTxHash, contractVout)
 
 	secret := randBytes(32)
 	secretHash := sha256.Sum256(secret)
@@ -1792,7 +1760,6 @@ func TestFindRedemption(t *testing.T) {
 	tPKHAddrV3, _ := stdaddr.DecodeAddress(tPKHAddr.String(), tChainParams)
 	_, otherScript := tPKHAddrV3.PaymentScript()
 
-	redeemTxid := "308e9a3675fc3ea3862b7863eeead08c621dcc37ff59de597dd3cdab41450ad9"
 	redemptionScript, _ := dexdcr.RedeemP2SHContract(contract, randBytes(73), randBytes(33), secret)
 	otherSpendScript, _ := txscript.NewScriptBuilder().
 		AddData(randBytes(73)).
@@ -1800,9 +1767,12 @@ func TestFindRedemption(t *testing.T) {
 		Script()
 
 	// Prepare and add the contract transaction to the blockchain. Put the pay-to-contract script at index 1.
-	inputs := []chainjson.Vin{makeRPCVin(otherTxid, 0, otherSpendScript)}
+	inputs := []*wire.TxIn{makeRPCVin(&chainhash.Hash{}, 0, otherSpendScript)}
 	outputScripts := []dex.Bytes{otherScript, contractP2SHScript}
-	blockHash, _ := node.blockchain.addRawTx(makeRawTx(contractHeight, contractTxid, inputs, outputScripts))
+	contractTx := makeRawTx(inputs, outputScripts)
+	contractTxHash := contractTx.TxHash()
+	coinID := toCoinID(&contractTxHash, contractVout)
+	blockHash, _ := node.blockchain.addRawTx(contractHeight, contractTx)
 	txHex, err := makeTxHex(inputs, outputScripts)
 	if err != nil {
 		t.Fatalf("error generating hex for contract tx: %v", err)
@@ -1821,13 +1791,14 @@ func TestFindRedemption(t *testing.T) {
 	}
 
 	// Add an intermediate block for good measure.
-	node.blockchain.addRawTx(makeRawTx(contractHeight+1, otherTxid, inputs, []dex.Bytes{otherScript}))
+	node.blockchain.addRawTx(contractHeight+1, dummyTx())
 
 	// Prepare the redemption tx inputs including an input that spends the contract output.
-	inputs = append(inputs, makeRPCVin(contractTxid, contractVout, redemptionScript))
+	inputs = append(inputs, makeRPCVin(&contractTxHash, contractVout, redemptionScript))
 
 	// Add the redemption to mempool and check if wallet.FindRedemption finds it.
-	node.blockchain.addRawTx(makeRawTx(-1, redeemTxid, inputs, []dex.Bytes{otherScript}))
+	redeemTx := makeRawTx(inputs, []dex.Bytes{otherScript})
+	node.blockchain.addRawTx(-1, redeemTx)
 	_, checkSecret, err := wallet.FindRedemption(tCtx, coinID, nil)
 	if err != nil {
 		t.Fatalf("error finding redemption: %v", err)
@@ -1837,7 +1808,7 @@ func TestFindRedemption(t *testing.T) {
 	}
 
 	// Move the redemption to a new block and check if wallet.FindRedemption finds it.
-	_, redeemBlock := node.blockchain.addRawTx(makeRawTx(contractHeight+2, redeemTxid, inputs, []dex.Bytes{otherScript}))
+	_, redeemBlock := node.blockchain.addRawTx(contractHeight+2, makeRawTx(inputs, []dex.Bytes{otherScript}))
 	_, checkSecret, err = wallet.FindRedemption(tCtx, coinID, nil)
 	if err != nil {
 		t.Fatalf("error finding redemption: %v", err)
@@ -1863,7 +1834,7 @@ func TestFindRedemption(t *testing.T) {
 	delete(node.rawErr, methodGetCFilterV2)
 
 	// missing redemption
-	redeemBlock.RawTx[0].Vin[1].Txid = otherTxid
+	redeemBlock.Transactions[0].TxIn[1].PreviousOutPoint.Hash = chainhash.Hash{}
 	ctx, cancel := context.WithTimeout(tCtx, 2*time.Second)
 	defer cancel() // ctx should auto-cancel after 2 seconds, but this is apparently good practice to prevent leak
 	_, k, err := wallet.FindRedemption(ctx, coinID, nil)
@@ -1871,7 +1842,7 @@ func TestFindRedemption(t *testing.T) {
 		// Expected ctx to cancel after timeout and no secret should be found.
 		t.Fatalf("unexpected result for missing redemption: secret: %v, err: %v", k, err)
 	}
-	redeemBlock.RawTx[0].Vin[1].Txid = contractTxid
+	redeemBlock.Transactions[0].TxIn[1].PreviousOutPoint.Hash = contractTxHash
 
 	// Canceled context
 	deadCtx, cancelCtx := context.WithCancel(tCtx)
@@ -1882,12 +1853,12 @@ func TestFindRedemption(t *testing.T) {
 	}
 
 	// Expect FindRedemption to error because of bad input sig.
-	redeemBlock.RawTx[0].Vin[1].ScriptSig.Hex = hex.EncodeToString(randBytes(100))
+	redeemBlock.Transactions[0].TxIn[1].SignatureScript = randBytes(100)
 	_, _, err = wallet.FindRedemption(tCtx, coinID, nil)
 	if err == nil {
 		t.Fatalf("no error for wrong redemption")
 	}
-	redeemBlock.RawTx[0].Vin[1].ScriptSig.Hex = hex.EncodeToString(redemptionScript)
+	redeemBlock.Transactions[0].TxIn[1].SignatureScript = redemptionScript
 
 	// Wrong script type for output
 	node.walletTx.Hex, _ = makeTxHex(inputs, []dex.Bytes{otherScript, otherScript})
@@ -2045,7 +2016,7 @@ func testSender(t *testing.T, senderType tSenderType) {
 	node.unspent = []walletjson.ListUnspentResult{{
 		TxID:          tTxID,
 		Address:       tPKHAddr.String(),
-		Account:       wallet.acct,
+		Account:       tAcctName,
 		Amount:        float64(unspentVal) / 1e8,
 		Confirmations: 5,
 		ScriptPubKey:  hex.EncodeToString(tP2PKHScript),
@@ -2102,7 +2073,7 @@ func Test_sendMinusFees(t *testing.T) {
 	node.unspent = []walletjson.ListUnspentResult{{
 		TxID:          tTxID,
 		Address:       tPKHAddr.String(),
-		Account:       wallet.acct,
+		Account:       tAcctName,
 		Amount:        float64(unspentVal) / 1e8,
 		Confirmations: 5,
 		ScriptPubKey:  hex.EncodeToString(tP2PKHScript),
@@ -2431,7 +2402,7 @@ func TestPreSwap(t *testing.T) {
 	p2pkhUnspent := walletjson.ListUnspentResult{
 		TxID:          tTxID,
 		Address:       tPKHAddr.String(),
-		Account:       wallet.acct,
+		Account:       tAcctName,
 		Amount:        float64(swapVal+fees-1) / 1e8, // one atom less than needed
 		Confirmations: 5,
 		ScriptPubKey:  hex.EncodeToString(tP2PKHScript),

--- a/client/asset/dcr/externaltx.go
+++ b/client/asset/dcr/externaltx.go
@@ -5,16 +5,12 @@ package dcr
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"sync"
 	"time"
 
 	"decred.org/dcrdex/client/asset"
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/gcs/v3"
-	"github.com/decred/dcrd/gcs/v3/blockcf2"
-	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -127,12 +123,12 @@ func (dcr *ExchangeWallet) txBlockFromCache(ctx context.Context, tx *externalTx)
 		return nil, nil
 	}
 
-	txBlockStillValid, err := dcr.isMainchainBlock(ctx, tx.block)
+	isMainchain, err := dcr.wallet.IsValidMainchain(ctx, tx.block.hash)
 	if err != nil {
 		return nil, err
 	}
 
-	if txBlockStillValid {
+	if isMainchain {
 		dcr.log.Debugf("Cached tx %s is mined in block %d (%s).", tx.hash, tx.block.height, tx.block.hash)
 		return tx.block, nil
 	}
@@ -198,7 +194,7 @@ func (dcr *ExchangeWallet) scanFiltersForTxBlock(ctx context.Context, tx *extern
 
 	earliestTxStamp := earliestTxTime.Unix()
 	for {
-		msgTx, outputSpenders, err := dcr.findTxInBlock(ctx, tx.hash, txScripts, iHash)
+		msgTx, outputSpenders, err := dcr.findTxInBlock(ctx, *tx.hash, txScripts, iHash)
 		if err != nil {
 			return nil, err
 		}
@@ -219,79 +215,66 @@ func (dcr *ExchangeWallet) scanFiltersForTxBlock(ctx context.Context, tx *extern
 		if lastScannedBlock != nil && iHeight <= lastScannedBlock.height {
 			return scanCompletedWithoutResults()
 		}
-		iBlock, err := dcr.wallet.GetBlockHeaderVerbose(dcr.ctx, iHash)
+		iBlock, err := dcr.wallet.GetBlockHeader(dcr.ctx, iHash)
 		if err != nil {
 			return nil, fmt.Errorf("getblockheader error for block %s: %w", iHash, translateRPCCancelErr(err))
 		}
-		if iBlock.Time <= earliestTxStamp {
+		if iBlock.Timestamp.Unix() <= earliestTxStamp {
 			return scanCompletedWithoutResults()
 		}
 
 		iHeight--
-		iHash, err = chainhash.NewHashFromStr(iBlock.PreviousHash)
-		if err != nil {
-			return nil, fmt.Errorf("error decoding previous hash %s for block %s: %w",
-				iBlock.PreviousHash, iHash.String(), err)
-		}
+		iHash = &iBlock.PrevBlock
 		continue
 	}
 }
 
-func (dcr *ExchangeWallet) findTxInBlock(ctx context.Context, txHash *chainhash.Hash, txScripts [][]byte, blockHash *chainhash.Hash) (*wire.MsgTx, []*outputSpenderFinder, error) {
-	blockFilter, err := dcr.getBlockFilterV2(ctx, blockHash)
+func (dcr *ExchangeWallet) findTxInBlock(ctx context.Context, txHash chainhash.Hash, txScripts [][]byte, blockHash *chainhash.Hash) (*wire.MsgTx, []*outputSpenderFinder, error) {
+	key, filter, err := dcr.wallet.BlockFilter(ctx, blockHash)
 	if err != nil {
 		return nil, nil, err
 	}
-	if !blockFilter.MatchAny(txScripts) {
+	if !filter.MatchAny(key, txScripts) {
 		return nil, nil, nil
 	}
 
-	blk, err := dcr.wallet.GetBlockVerbose(ctx, blockHash, true)
+	blk, err := dcr.wallet.GetBlock(ctx, blockHash)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error retrieving block %s: %w", blockHash, err)
 	}
 
-	var txHex string
-	blockTxs := append(blk.RawTx, blk.RawSTx...)
-	for t := range blockTxs {
-		blkTx := &blockTxs[t]
-		if blkTx.Txid == txHash.String() {
-			dcr.log.Debugf("Found mined tx %s in block %d (%s).", txHash, blk.Height, blk.Hash)
-			txHex = blkTx.Hex
+	var msgTx *wire.MsgTx
+	for _, tx := range blk.Transactions {
+		if tx.TxHash() == txHash {
+			dcr.log.Debugf("Found mined tx %s in block %s.", txHash, blk.BlockHash())
+			msgTx = tx
 			break
 		}
 	}
 
-	if txHex == "" {
-		dcr.log.Debugf("Block %d (%s) filters matched scripts for tx %s but does NOT contain the tx.", blk.Height, blk.Hash, txHash)
+	if msgTx == nil {
+		dcr.log.Debugf("Block %s filters matched scripts for tx %s but does NOT contain the tx.", blk.BlockHash(), txHash)
 		return nil, nil, nil
 	}
 
-	msgTx, err := msgTxFromHex(txHex)
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid hex for tx %s: %v", txHash, err)
-	}
-
-	// We have the txs in this block, check if any of them spends an output from
-	// the original tx.
+	// We have the txs in this block, check if any them spends an output
+	// from the original tx.
 	outputSpenders := make([]*outputSpenderFinder, len(msgTx.TxOut))
 	for i, txOut := range msgTx.TxOut {
 		outputSpenders[i] = &outputSpenderFinder{
 			TxOut:            txOut,
-			op:               newOutPoint(txHash, uint32(i)),
+			op:               newOutPoint(&txHash, uint32(i)),
 			tree:             determineTxTree(msgTx),
 			lastScannedBlock: blockHash,
 		}
 	}
-	for t := range blockTxs {
-		blkTx := &blockTxs[t]
-		if blkTx.Txid == txHash.String() {
-			continue // original tx, ignore
+	for _, tx := range blk.Transactions {
+		if tx.TxHash() == txHash {
+			continue // oriignal tx, ignore
 		}
-		for i := range blkTx.Vin {
-			input := &blkTx.Vin[i]
-			if input.Txid == txHash.String() { // found a spender
-				outputSpenders[input.Vout].spenderBlock = &block{blk.Height, blockHash}
+		for _, txIn := range tx.TxIn {
+			if txIn.PreviousOutPoint.Hash == txHash { // found a spender
+				outputSpenders[txIn.PreviousOutPoint.Index].spenderBlock = &block{int64(blk.Header.Height), blockHash}
 			}
 		}
 	}
@@ -311,11 +294,11 @@ func (dcr *ExchangeWallet) isOutputSpent(ctx context.Context, output *outputSpen
 
 	// Check if this output is known to be spent in a mainchain block.
 	if output.spenderBlock != nil {
-		spenderBlockStillValid, err := dcr.isMainchainBlock(ctx, output.spenderBlock)
+		isMainchain, err := dcr.wallet.IsValidMainchain(ctx, output.spenderBlock.hash)
 		if err != nil {
 			return false, err
 		}
-		if spenderBlockStillValid {
+		if isMainchain {
 			dcr.log.Debugf("Found cached information for the spender of %s.", output.op)
 			return true, nil
 		}
@@ -359,7 +342,7 @@ func (dcr *ExchangeWallet) isOutputSpent(ctx context.Context, output *outputSpen
 	if err != nil {
 		return false, err
 	}
-	spenderTx, stopBlockHash, err := dcr.findTxOutSpender(ctx, output.op, output.PkScript, &block{nextScanHeight, nextScanHash})
+	spenderTx, stopBlockHash, stopBlockHeight, err := dcr.findTxOutSpender(ctx, output.op, output.PkScript, &block{nextScanHeight, nextScanHash})
 	if stopBlockHash != nil { // might be nil if the search never scanned a block
 		output.lastScannedBlock = stopBlockHash
 	}
@@ -372,12 +355,7 @@ func (dcr *ExchangeWallet) isOutputSpent(ctx context.Context, output *outputSpen
 		return false, nil
 	}
 
-	spenderBlockHash, err := chainhash.NewHashFromStr(spenderTx.BlockHash)
-	if err != nil {
-		return true, fmt.Errorf("invalid hash (%s) for tx that spends output %s: %w",
-			spenderTx.BlockHash, output.op, err)
-	}
-	output.spenderBlock = &block{hash: spenderBlockHash, height: spenderTx.BlockHeight}
+	output.spenderBlock = &block{hash: stopBlockHash, height: stopBlockHeight}
 	return true, nil
 }
 
@@ -388,32 +366,30 @@ func (dcr *ExchangeWallet) isOutputSpent(ctx context.Context, output *outputSpen
 // If no tx is found to spend the provided output, the hash of the block that
 // was last checked is returned along with any error that may have occurred
 // during the search.
-func (dcr *ExchangeWallet) findTxOutSpender(ctx context.Context, op outPoint, outputPkScript []byte, startBlock *block) (*chainjson.TxRawResult, *chainhash.Hash, error) {
+func (dcr *ExchangeWallet) findTxOutSpender(ctx context.Context, op outPoint, outputPkScript []byte, startBlock *block) (*wire.MsgTx, *chainhash.Hash, int64, error) {
 	var lastScannedHash *chainhash.Hash
 
 	iHeight := startBlock.height
 	iHash := startBlock.hash
 	bestBlock := dcr.cachedBestBlock()
 	for {
-		blockFilter, err := dcr.getBlockFilterV2(ctx, iHash)
+		key, filter, err := dcr.wallet.BlockFilter(ctx, iHash)
 		if err != nil {
-			return nil, lastScannedHash, err
+			return nil, lastScannedHash, 0, err
 		}
 
-		if blockFilter.Match(outputPkScript) {
+		if filter.Match(key, outputPkScript) {
 			dcr.log.Debugf("Output %s is likely spent in block %d (%s). Confirming.",
 				op, iHeight, iHash)
-			blk, err := dcr.wallet.GetBlockVerbose(ctx, iHash, true)
+			blk, err := dcr.wallet.GetBlock(ctx, iHash)
 			if err != nil {
-				return nil, lastScannedHash, fmt.Errorf("error retrieving block %s: %w", iHash, err)
+				return nil, lastScannedHash, 0, fmt.Errorf("error retrieving block %s: %w", iHash, err)
 			}
-			blockTxs := append(blk.RawTx, blk.RawSTx...)
-			for i := range blockTxs {
-				blkTx := &blockTxs[i]
-				if txSpendsOutput(blkTx, op) {
+			for _, tx := range blk.Transactions {
+				if txSpendsOutput(tx, op) {
 					dcr.log.Debugf("Found spender for output %s in block %d (%s), spender tx hash %s.",
-						op, iHeight, iHash, blkTx.Txid)
-					return blkTx, iHash, nil
+						op, iHeight, iHash, tx.TxHash())
+					return tx, iHash, iHeight, nil
 				}
 			}
 			dcr.log.Debugf("Output %s is NOT spent in block %d (%s).", op, iHeight, iHash)
@@ -427,7 +403,7 @@ func (dcr *ExchangeWallet) findTxOutSpender(ctx context.Context, op outPoint, ou
 		iHeight++
 		nextHash, err := dcr.wallet.GetBlockHash(ctx, iHeight)
 		if err != nil {
-			return nil, iHash, translateRPCCancelErr(err)
+			return nil, iHash, 0, translateRPCCancelErr(err)
 		}
 		lastScannedHash = iHash
 		iHash = nextHash
@@ -435,60 +411,20 @@ func (dcr *ExchangeWallet) findTxOutSpender(ctx context.Context, op outPoint, ou
 
 	dcr.log.Debugf("Output %s is NOT spent in blocks %d (%s) to %d (%s).",
 		op, startBlock.height, startBlock.hash, bestBlock.height, bestBlock.hash)
-	return nil, bestBlock.hash, nil // scanned up to best block, no spender found
+	return nil, bestBlock.hash, 0, nil // scanned up to best block, no spender found
 }
 
 // txSpendsOutput returns true if the passed tx has an input that spends the
 // specified output.
-func txSpendsOutput(tx *chainjson.TxRawResult, op outPoint) bool {
-	prevOutHash := op.txHash.String()
-	if tx.Txid == prevOutHash {
+func txSpendsOutput(tx *wire.MsgTx, op outPoint) bool {
+	if tx.TxHash() == op.txHash {
 		return false // no need to check inputs if this tx is the same tx that pays to the specified op
 	}
-	for i := range tx.Vin {
-		input := &tx.Vin[i]
-		if input.Vout == op.vout && input.Txid == prevOutHash {
+	for _, txIn := range tx.TxIn {
+		prevOut := &txIn.PreviousOutPoint
+		if prevOut.Index == op.vout && prevOut.Hash == op.txHash {
 			return true // found spender
 		}
 	}
 	return false
-}
-
-type blockFilter struct {
-	v2cfilters *gcs.FilterV2
-	key        [gcs.KeySize]byte
-}
-
-func (bf *blockFilter) Match(data []byte) bool {
-	return bf.v2cfilters.Match(bf.key, data)
-}
-
-func (bf *blockFilter) MatchAny(data [][]byte) bool {
-	return bf.v2cfilters.MatchAny(bf.key, data)
-}
-
-func (dcr *ExchangeWallet) getBlockFilterV2(ctx context.Context, blockHash *chainhash.Hash) (*blockFilter, error) {
-	bf, key, err := dcr.wallet.BlockCFilter(ctx, blockHash)
-	if err != nil {
-		return nil, err
-	}
-	filterB, err := hex.DecodeString(bf)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding block filter: %w", err)
-	}
-	keyB, err := hex.DecodeString(key)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding block filter key: %w", err)
-	}
-	filter, err := gcs.FromBytesV2(blockcf2.B, blockcf2.M, filterB)
-	if err != nil {
-		return nil, fmt.Errorf("error deserializing block filter: %w", err)
-	}
-	var bcf2Key [gcs.KeySize]byte
-	copy(bcf2Key[:], keyB)
-
-	return &blockFilter{
-		v2cfilters: filter,
-		key:        bcf2Key,
-	}, nil
 }

--- a/client/asset/dcr/externaltx.go
+++ b/client/asset/dcr/externaltx.go
@@ -123,7 +123,7 @@ func (dcr *ExchangeWallet) txBlockFromCache(ctx context.Context, tx *externalTx)
 		return nil, nil
 	}
 
-	isMainchain, err := dcr.wallet.IsValidMainchain(ctx, tx.block.hash)
+	_, isMainchain, err := dcr.blockHeader(ctx, tx.block.hash)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func (dcr *ExchangeWallet) findTxInBlock(ctx context.Context, txHash chainhash.H
 	}
 	for _, tx := range blk.Transactions {
 		if tx.TxHash() == txHash {
-			continue // oriignal tx, ignore
+			continue // orignal tx, ignore
 		}
 		for _, txIn := range tx.TxIn {
 			if txIn.PreviousOutPoint.Hash == txHash { // found a spender
@@ -294,7 +294,7 @@ func (dcr *ExchangeWallet) isOutputSpent(ctx context.Context, output *outputSpen
 
 	// Check if this output is known to be spent in a mainchain block.
 	if output.spenderBlock != nil {
-		isMainchain, err := dcr.wallet.IsValidMainchain(ctx, output.spenderBlock.hash)
+		_, isMainchain, err := dcr.blockHeader(ctx, output.spenderBlock.hash)
 		if err != nil {
 			return false, err
 		}

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -68,13 +68,13 @@ type Wallet interface {
 	// tip changes.
 	NotifyOnTipChange(ctx context.Context, cb TipChangeCallback) bool
 	// OwnsAddress checks if the provided address belongs to the Wallet.
-	OwnsAddress(ctx context.Context, addr stdaddr.Address) (bool, error)
+	OwnsAddress(ctx context.Context, addr stdaddr.Address, acctName string) (bool, error)
 	// Balance returns the balance breakdown for the Wallet.
-	Balance(ctx context.Context, confirms int32) (*walletjson.GetAccountBalanceResult, error)
+	Balance(ctx context.Context, confirms int32, acctName string) (*walletjson.GetAccountBalanceResult, error)
 	// LockedOutputs fetches locked outputs for the Wallet.
-	LockedOutputs(ctx context.Context) ([]chainjson.TransactionInput, error)
+	LockedOutputs(ctx context.Context, acctName string) ([]chainjson.TransactionInput, error)
 	// Unspents fetches unspent outputs for the Wallet.
-	Unspents(ctx context.Context) ([]*walletjson.ListUnspentResult, error)
+	Unspents(ctx context.Context, acctName string) ([]*walletjson.ListUnspentResult, error)
 	// LockUnspent locks or unlocks the specified outpoint.
 	LockUnspent(ctx context.Context, unlock bool, ops []*wire.OutPoint) error
 	// UnspentOutput returns information about an unspent tx output, if found
@@ -86,9 +86,9 @@ type Wallet interface {
 	// output cannot be located.
 	UnspentOutput(ctx context.Context, txHash *chainhash.Hash, index uint32, tree int8) (*TxOutput, error)
 	// ExternalAddress returns a new external address,
-	ExternalAddress(ctx context.Context) (stdaddr.Address, error)
+	ExternalAddress(ctx context.Context, acctName string) (stdaddr.Address, error)
 	// InternalAddress returns a change address from the Wallet.
-	InternalAddress(ctx context.Context) (stdaddr.Address, error)
+	InternalAddress(ctx context.Context, acctName string) (stdaddr.Address, error)
 	// SignRawTransaction signs the provided transaction. SignRawTransaction
 	// is not used for redemptions, so previous outpoints and scripts should
 	// be known by the wallet.
@@ -118,15 +118,15 @@ type Wallet interface {
 	// BlockFilter fetches the block filter info for the specified block.
 	BlockFilter(ctx context.Context, blockHash *chainhash.Hash) ([gcs.KeySize]byte, *gcs.FilterV2, error)
 	// Unlocked returns true if the Wallet unlocked.
-	Unlocked(ctx context.Context) (bool, error)
+	Unlocked(ctx context.Context, acctName string) (bool, error)
 	// Lock locks the Wallet. ExchangeWallet does not differentiate account
 	// locking vs wallet locking, but the underlying implementation may choose
 	// to lock only the account.
-	Lock(ctx context.Context) error
+	Lock(ctx context.Context, acctName string) error
 	// Unlock unlocks the Wallet. ExchangeWallet does not differentiate account
 	// locking vs wallet locking, but the underlying implementation may choose
 	// to unlock only the account.
-	Unlock(ctx context.Context, passphrase []byte) error
+	Unlock(ctx context.Context, passphrase []byte, acctName string) error
 	// SyncStatus returns the wallet's sync status.
 	SyncStatus(ctx context.Context) (bool, float32, error)
 	// PeerCount returns the number of network peers to which the wallet or its

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -123,9 +123,7 @@ type Wallet interface {
 	AccountUnlocked(ctx context.Context, acctName string) (bool, error)
 	// LockAccount locks the account.
 	LockAccount(ctx context.Context, acctName string) error
-	// UnlockAccount unlocks the Wallet. ExchangeWallet does not differentiate
-	// account locking vs wallet locking, but the underlying implementation may
-	// choose to unlock only the account.
+	// UnlockAccount unlocks the account.
 	UnlockAccount(ctx context.Context, passphrase []byte, acctName string) error
 	// SyncStatus returns the wallet's sync status.
 	SyncStatus(ctx context.Context) (bool, float32, error)

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 )
 
 require (
+	decred.org/cspp/v2 v2.0.0-20211122173608-ee00e4952d5f // indirect
 	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
 	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
 	github.com/aead/siphash v1.0.1 // indirect
@@ -61,6 +62,7 @@ require (
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/companyzero/sntrup4591761 v0.0.0-20200131011700-2b0d299dbd22 // indirect
 	github.com/dchest/siphash v1.2.2 // indirect
 	github.com/deckarep/golang-set v1.8.0 // indirect
 	github.com/decred/base58 v1.0.3 // indirect
@@ -82,6 +84,8 @@ require (
 	github.com/holiman/uint256 v1.2.0 // indirect
 	github.com/huin/goupnp v1.0.2 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
+	github.com/jrick/bitset v1.0.0 // indirect
+	github.com/jrick/wsrpc/v2 v2.3.4 // indirect
 	github.com/kkdai/bstream v1.0.0 // indirect
 	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
 	github.com/lightningnetwork/lnd/clock v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 collectd.org v0.3.0/go.mod h1:A/8DzQBkF6abtvrT2j/AU/4tiBgJWYyh0y/oB/4MlWE=
+decred.org/cspp/v2 v2.0.0-20211122173608-ee00e4952d5f h1:7gQImobDtPhW0BpK1h3KSb6fXelpzEhWlHqmz1gvDes=
 decred.org/cspp/v2 v2.0.0-20211122173608-ee00e4952d5f/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb h1:vio6o+nzszBrdj2Yi3/gifDa5ocfy49A9SqYPlbUjXo=
 decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb/go.mod h1:rbFJaCuXCfDhYoI5ZdeZr8TmF4A4Sb1zE7jQAwtaFMo=
@@ -124,6 +125,7 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.14.0/go.mod h1:EnwdgGMaFOruiPZRFSgn+TsQ3hQ7C/YWzIGLeu5c304=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/companyzero/sntrup4591761 v0.0.0-20200131011700-2b0d299dbd22 h1:vfqLMkB1UqwJliW0I/34oscQawInrVfL1uPjGEEt2YY=
 github.com/companyzero/sntrup4591761 v0.0.0-20200131011700-2b0d299dbd22/go.mod h1:LoZJNGDWmVPqMEHmeJzj4Weq4Stjc6FKY6FVpY3Hem0=
 github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572/go.mod h1:Bpd0/3mZuaj6Sj+PqrmIquiOKy397AKGThQPaGzNXAQ=
 github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f/go.mod h1:815PAHg3wvysy0SyIqanF8gZ0Y1wjk/hrDHD/iT88+Q=
@@ -371,9 +373,11 @@ github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7 h1:Ug59miTxVKV
 github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/jrick/bitset v1.0.0 h1:Ws0PXV3PwXqWK2n7Vz6idCdrV/9OrBXgHEJi27ZB9Dw=
 github.com/jrick/bitset v1.0.0/go.mod h1:ZOYB5Uvkla7wIEY4FEssPVi3IQXa02arznRaYaAEPe4=
 github.com/jrick/logrotate v1.0.0 h1:lQ1bL/n9mBNeIXoTUoYRlK4dHuNJVofX9oWqBtPnSzI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
+github.com/jrick/wsrpc/v2 v2.3.4 h1:+GzRtp/TyXaSB61pN92lIAVyvdVv0RSqniIEB/rPx1Q=
 github.com/jrick/wsrpc/v2 v2.3.4/go.mod h1:XPYs8BnRWl99lCvXRM5SLpZmTPqWpSOPkDIqYTwDPfU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -24,7 +24,7 @@ do
 
 	# Run `go mod tidy` and fail if the git status of go.mod and/or
 	# go.sum changes. Only do this for the latest Go version.
-	if [[ "$GV" =~ ^1.17 ]]; then
+	if [[ "$GV" =~ ^1.18 ]]; then
 		MOD_STATUS=$(git status --porcelain go.mod go.sum)
 		go mod tidy
 		UPDATED_MOD_STATUS=$(git status --porcelain go.mod go.sum)


### PR DESCRIPTION
```
Use wire types for the Wallet interface rather than rpc types. This
is a necessary step towards a built-in wallet. Previous discussion in
1278.
```