### PR TITLE
client/core: Make errors user oriented

### DIFF
--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -800,7 +800,7 @@ func (w *spvWallet) sendWithSubtract(pkScript []byte, value, feeRate uint64) (*c
 
 	sum, inputsSize, _, fundingCoins, _, _, err := fund(utxos, enough)
 	if err != nil {
-		return nil, fmt.Errorf("error funding sendWithSubtract value of %s: %v", amount(value), err)
+		return nil, fmt.Errorf("error funding sendWithSubtract value of %s: %w", amount(value), err)
 	}
 
 	fees := (unfundedTxSize + uint64(inputsSize)) * feeRate

--- a/client/core/account.go
+++ b/client/core/account.go
@@ -20,7 +20,7 @@ func (c *Core) AccountDisable(pw []byte, addr string) error {
 	// Get dex connection by host.
 	dc, _, err := c.dex(addr)
 	if err != nil {
-		return newError(unknownDEXErr, "error retrieving dex conn: %v", err)
+		return newError(unknownDEXErr, "error retrieving dex conn: %w", err)
 	}
 
 	// Check active orders.
@@ -30,7 +30,7 @@ func (c *Core) AccountDisable(pw []byte, addr string) error {
 
 	err = c.db.DisableAccount(dc.acct.host)
 	if err != nil {
-		return newError(accountDisableErr, "error disabling account: %v", err)
+		return newError(accountDisableErr, "error disabling account: %w", err)
 	}
 	// Stop dexConnection books.
 	dc.cfgMtx.RLock()
@@ -65,7 +65,7 @@ func (c *Core) AccountExport(pw []byte, host string) (*Account, error) {
 	}
 	host, err = addrHost(host)
 	if err != nil {
-		return nil, newError(addressParseErr, "error parsing address: %v", err)
+		return nil, newError(addressParseErr, "error parsing address: %w", err)
 	}
 
 	// Get the dexConnection and the dex.Asset for each asset.
@@ -121,7 +121,7 @@ func (c *Core) AccountImport(pw []byte, acct Account) error {
 
 	host, err := addrHost(acct.Host)
 	if err != nil {
-		return newError(addressParseErr, "error parsing address: %v", err)
+		return newError(addressParseErr, "error parsing address: %w", err)
 	}
 	accountInfo := db.AccountInfo{Host: host}
 
@@ -163,7 +163,7 @@ func (c *Core) AccountImport(pw []byte, acct Account) error {
 			delete(c.conns, dc.acct.host)
 			c.connMtx.Unlock()
 		}
-		return newError(accountVerificationErr, "Account not verified for host: %s err: %v", host, err)
+		return newError(accountVerificationErr, "Account not verified for host: %s err: %w", host, err)
 	}
 
 	err = c.db.CreateAccount(&accountInfo)

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -532,7 +532,7 @@ func (c *Core) SyncBook(host string, base, quote uint32) (BookFeed, error) {
 func (c *Core) Book(dex string, base, quote uint32) (*OrderBook, error) {
 	dex, err := addrHost(dex)
 	if err != nil {
-		return nil, newError(addressParseErr, "error parsing address: %v", err)
+		return nil, newError(addressParseErr, "error parsing address: %w", err)
 	}
 	c.connMtx.RLock()
 	dc, found := c.conns[dex]

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -939,7 +939,7 @@ func (c *Core) tickAsset(dc *dexConnection, assetID uint32) assetMap {
 func (c *Core) dex(addr string) (*dexConnection, bool, error) {
 	host, err := addrHost(addr)
 	if err != nil {
-		return nil, false, newError(addressParseErr, "error parsing address: %v", err)
+		return nil, false, newError(addressParseErr, "error parsing address: %w", err)
 	}
 
 	// Get the dexConnection and the dex.Asset for each asset.
@@ -1529,7 +1529,7 @@ func (c *Core) connectAndUnlock(crypter encrypt.Crypter, wallet *xcWallet) error
 		// crypter. This case could instead be handled with a refreshUnlock.
 		err := wallet.Unlock(crypter)
 		if err != nil {
-			return newError(walletAuthErr, "failed to unlock %s wallet: %v",
+			return newError(walletAuthErr, "failed to unlock %s wallet: %w",
 				unbip(wallet.AssetID), err)
 		}
 		// Notify new wallet state.
@@ -2035,7 +2035,7 @@ func (c *Core) OpenWallet(assetID uint32, appPW []byte) error {
 	}
 	err = wallet.Unlock(crypter)
 	if err != nil {
-		return newError(walletAuthErr, "failed to unlock %s wallet: %v", unbip(assetID), err)
+		return newError(walletAuthErr, "failed to unlock %s wallet: %w", unbip(assetID), err)
 	}
 
 	state := wallet.state()
@@ -2114,7 +2114,7 @@ func (c *Core) ChangeAppPass(appPW, newAppPW []byte) error {
 
 	outerCrypter, err := c.reCrypter(appPW, creds.OuterKeyParams)
 	if err != nil {
-		return newError(authErr, "old password error: %v", err)
+		return newError(authErr, "old password error: %w", err)
 	}
 	innerKey, err := outerCrypter.Decrypt(creds.EncInnerKey)
 	if err != nil {
@@ -2148,7 +2148,7 @@ func (c *Core) ChangeAppPass(appPW, newAppPW []byte) error {
 func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) error {
 	crypter, err := c.encryptionKey(appPW)
 	if err != nil {
-		return newError(authErr, "ReconfigureWallet password error: %v", err)
+		return newError(authErr, "ReconfigureWallet password error: %w", err)
 	}
 	assetID := form.AssetID
 	walletDef, err := walletDefinition(assetID, form.Type)
@@ -2196,7 +2196,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 
 		exists, err := asset.WalletExists(assetID, form.Type, c.assetDataDirectory(assetID), form.Config, c.net)
 		if err != nil {
-			return newError(existenceCheckErr, "error checking wallet pre-existence: %v", err)
+			return newError(existenceCheckErr, "error checking wallet pre-existence: %w", err)
 		}
 
 		// The password on a seeded wallet is deterministic, based on the seed
@@ -2206,12 +2206,12 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 		if exists {
 			_, pw, err = c.assetSeedAndPass(assetID, crypter)
 			if err != nil {
-				return newError(authErr, "error retrieving wallet password: %v", err)
+				return newError(authErr, "error retrieving wallet password: %w", err)
 			}
 		} else {
 			pw, err = c.createSeededWallet(assetID, crypter, form)
 			if err != nil {
-				return newError(createWalletErr, "error creating new %q-type %s wallet: %v", form.Type, unbip(assetID), err)
+				return newError(createWalletErr, "error creating new %q-type %s wallet: %w", form.Type, unbip(assetID), err)
 			}
 		}
 		dbWallet.EncryptedPW, err = crypter.Encrypt(pw)
@@ -2232,7 +2232,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 	// Reload the wallet with the new settings.
 	wallet, err := c.loadWallet(dbWallet)
 	if err != nil {
-		return newError(walletErr, "error loading wallet for %d -> %s: %v",
+		return newError(walletErr, "error loading wallet for %d -> %s: %w",
 			assetID, unbip(assetID), err)
 	}
 
@@ -2261,7 +2261,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 	}
 	if err := sameWallet(); err != nil {
 		wallet.Disconnect()
-		return newError(walletErr, "new wallet cannot be used with current active trades: %v", err)
+		return newError(walletErr, "new wallet cannot be used with current active trades: %w", err)
 	}
 
 	// If newWalletPW is non-nil, update the wallet's password.
@@ -2283,7 +2283,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 		if err != nil {
 			wallet.Disconnect()
 			return newError(walletAuthErr, "wallet successfully connected, but failed to unlock. "+
-				"reconfiguration not saved: %v", err)
+				"reconfiguration not saved: %w", err)
 		}
 	}
 
@@ -2299,7 +2299,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 	err = c.db.UpdateWallet(dbWallet)
 	if err != nil {
 		wallet.Disconnect()
-		return newError(dbErr, "error saving wallet configuration: %v", err)
+		return newError(dbErr, "error saving wallet configuration: %w", err)
 	}
 
 	// Update all relevant trackedTrades' toWallet and fromWallet.
@@ -2370,7 +2370,7 @@ func (c *Core) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) err
 	// Check the app password and get the crypter.
 	crypter, err := c.encryptionKey(appPW)
 	if err != nil {
-		return newError(authErr, "SetWalletPassword password error: %v", err)
+		return newError(authErr, "SetWalletPassword password error: %w", err)
 	}
 
 	// Check that the specified wallet exists.
@@ -2400,7 +2400,7 @@ func (c *Core) setWalletPassword(wallet *xcWallet, newPW []byte, crypter encrypt
 	wasConnected := wallet.connected()
 	if !wasConnected {
 		if err := c.connectAndUpdateWallet(wallet); err != nil {
-			return newError(connectionErr, "SetWalletPassword connection error: %v", err)
+			return newError(connectionErr, "SetWalletPassword connection error: %w", err)
 		}
 	}
 
@@ -2416,12 +2416,12 @@ func (c *Core) setWalletPassword(wallet *xcWallet, newPW []byte, crypter encrypt
 		// Encrypt password if it's not an empty string.
 		encNewPW, err := crypter.Encrypt(newPW)
 		if err != nil {
-			return newError(encryptionErr, "encryption error: %v", err)
+			return newError(encryptionErr, "encryption error: %w", err)
 		}
 		err = wallet.Wallet.Unlock(newPW)
 		if err != nil {
 			return newError(authErr,
-				"setWalletPassword unlocking wallet error, is the new password correct?: %v", err)
+				"setWalletPassword unlocking wallet error, is the new password correct?: %w", err)
 		}
 		wallet.setEncPW(encNewPW)
 	} else {
@@ -2512,11 +2512,11 @@ func (c *Core) isRegistered(host string) bool {
 func (c *Core) tempDexConnection(dexAddr string, certI interface{}) (*dexConnection, error) {
 	host, err := addrHost(dexAddr)
 	if err != nil {
-		return nil, newError(addressParseErr, "error parsing address: %v", err)
+		return nil, newError(addressParseErr, "error parsing address: %w", err)
 	}
 	cert, err := parseCert(host, certI, c.net)
 	if err != nil {
-		return nil, newError(fileReadErr, "failed to parse certificate: %v", err)
+		return nil, newError(fileReadErr, "failed to parse certificate: %w", err)
 	}
 	if c.isRegistered(host) {
 		return nil, newError(dupeDEXErr, "already registered at %s", dexAddr)
@@ -2576,7 +2576,7 @@ func (c *Core) discoverAccount(dc *dexConnection, crypter encrypt.Crypter) (bool
 	for {
 		err := dc.acct.setupCryptoV2(creds, crypter, keyIndex)
 		if err != nil {
-			return false, newError(acctKeyErr, "setupCryptoV2 error: %v", err)
+			return false, newError(acctKeyErr, "setupCryptoV2 error: %w", err)
 		}
 
 		// Discover the account by attempting a 'connect' (authorize) request.
@@ -2592,7 +2592,7 @@ func (c *Core) discoverAccount(dc *dexConnection, crypter encrypt.Crypter) (bool
 				}
 				return false, nil // all good, just go register now
 			}
-			return false, newError(authErr, "unexpected authDEX error: %v", err)
+			return false, newError(authErr, "unexpected authDEX error: %w", err)
 		}
 		if dc.acct.isSuspended {
 			c.log.Infof("HD account key for %s was reported as suspended. Deriving another account key.", dc.acct.host)
@@ -2655,7 +2655,7 @@ func (c *Core) DiscoverAccount(dexAddr string, appPW []byte, certI interface{}) 
 
 	host, err := addrHost(dexAddr)
 	if err != nil {
-		return nil, false, newError(addressParseErr, "error parsing address: %v", err)
+		return nil, false, newError(addressParseErr, "error parsing address: %w", err)
 	}
 
 	crypter, err := c.encryptionKey(appPW)
@@ -2767,7 +2767,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	}
 	host, err := addrHost(form.Addr)
 	if err != nil {
-		return nil, newError(addressParseErr, "error parsing address: %v", err)
+		return nil, newError(addressParseErr, "error parsing address: %w", err)
 	}
 	if c.isRegistered(host) {
 		return nil, newError(dupeDEXErr, "already registered at %s", form.Addr)
@@ -2790,13 +2790,13 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	if !wallet.unlocked() {
 		err = wallet.Unlock(crypter)
 		if err != nil {
-			return nil, newError(walletAuthErr, "failed to unlock %s wallet: %v", unbip(wallet.AssetID), err)
+			return nil, newError(walletAuthErr, "failed to unlock %s wallet: %w", unbip(wallet.AssetID), err)
 		}
 	}
 
 	cert, err := parseCert(host, form.Cert, c.net)
 	if err != nil {
-		return nil, newError(fileReadErr, "failed to read certificate file from %s: %v", cert, err)
+		return nil, newError(fileReadErr, "failed to read certificate file from %s: %w", cert, err)
 	}
 
 	dc, err := c.connectDEX(&db.AccountInfo{
@@ -2853,7 +2853,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	// Before we do the 'register' request, make sure we have sufficient funds.
 	balance, err := wallet.Balance()
 	if err != nil {
-		return nil, newError(walletErr, "unable to retrieve wallet balance for %v: %v",
+		return nil, newError(walletErr, "unable to retrieve wallet balance for %v: %w",
 			regFeeAssetSymbol, err)
 	}
 	// Just avail==required is not sufficient because of net fees, although that
@@ -2880,7 +2880,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	}
 
 	if err := dc.acct.unlock(crypter); err != nil { // should already be unlocked
-		return nil, newError(authErr, "failed to unlock account: %v", err)
+		return nil, newError(authErr, "failed to unlock account: %w", err)
 	}
 
 	// Check that the fee is non-zero.
@@ -2902,7 +2902,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	feeRate := c.feeSuggestionAny(feeAsset.ID, dc)
 	coin, err := wallet.PayFee(regRes.Address, regRes.Fee, feeRate)
 	if err != nil {
-		return nil, newError(feeSendErr, "error paying registration fee: %v", err)
+		return nil, newError(feeSendErr, "error paying registration fee: %w", err)
 	}
 
 	// Set the dexConnection account fields and save account info to db.
@@ -2972,7 +2972,7 @@ func (c *Core) register(dc *dexConnection, assetID uint32) (regRes *msgjson.Regi
 		msg := regRes.Serialize()
 		err = checkSigS256(msg, regRes.DEXPubKey, regRes.Sig)
 		if err != nil {
-			return nil, false, false, newError(signatureErr, "%s pubkey error: %v", dc.acct.host, err)
+			return nil, false, false, newError(signatureErr, "%s pubkey error: %w", dc.acct.host, err)
 		}
 		// Compatibility with older servers that do not include asset ID.
 		if regRes.AssetID != nil && assetID != *regRes.AssetID {
@@ -3867,7 +3867,7 @@ func (c *Core) Withdraw(pw []byte, assetID uint32, value uint64, address string)
 		return nil, fmt.Errorf("Withdraw password error: %w", err)
 	}
 	if value == 0 {
-		return nil, fmt.Errorf("%s zero withdraw", unbip(assetID))
+		return nil, fmt.Errorf("cannot withdraw zero %s", unbip(assetID))
 	}
 	wallet, found := c.wallet(assetID)
 	if !found {
@@ -4000,7 +4000,7 @@ func (c *Core) PreOrder(form *TradeForm) (*OrderEstimate, error) {
 		SelectedOptions: form.Options,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error getting swap estimate: %v", err)
+		return nil, fmt.Errorf("error getting swap estimate: %w", err)
 	}
 
 	redeemEstimate, err := wallets.toWallet.PreRedeem(&asset.PreRedeemForm{
@@ -4548,7 +4548,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	// Check the servers response signature.
 	err = dc.acct.checkSig(sigMsg, result.Sig)
 	if err != nil {
-		return newError(signatureErr, "DEX signature validation error: %v", err)
+		return newError(signatureErr, "DEX signature validation error: %w", err)
 	}
 
 	var suspended bool
@@ -5477,7 +5477,7 @@ func (c *Core) connectDEX(acctInfo *db.AccountInfo, temporary ...bool) (*dexConn
 	wsAddr := "wss://" + host + "/ws"
 	wsURL, err := url.Parse(wsAddr)
 	if err != nil {
-		return nil, newError(addressParseErr, "error parsing ws address %s: %v", wsAddr, err)
+		return nil, newError(addressParseErr, "error parsing ws address %s: %w", wsAddr, err)
 	}
 
 	listen := len(temporary) == 0 || !temporary[0]
@@ -5825,7 +5825,7 @@ func handlePenaltyMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error {
 	// Check the signature.
 	err = dc.acct.checkSig(note.Serialize(), note.Sig)
 	if err != nil {
-		return newError(signatureErr, "handlePenaltyMsg: DEX signature validation error: %v", err)
+		return newError(signatureErr, "handlePenaltyMsg: DEX signature validation error: %w", err)
 	}
 	t := encode.UnixTimeMilli(int64(note.Penalty.Time))
 	// d := time.Duration(note.Penalty.Duration) * time.Millisecond
@@ -6715,7 +6715,7 @@ func parseCert(host string, certI interface{}, net dex.Network) ([]byte, error) 
 		}
 		cert, err := os.ReadFile(c)
 		if err != nil {
-			return nil, newError(fileReadErr, "failed to read certificate file from %s: %v", c, err)
+			return nil, newError(fileReadErr, "failed to read certificate file from %s: %w", c, err)
 		}
 		return cert, nil
 	case []byte:
@@ -6732,7 +6732,7 @@ func parseCert(host string, certI interface{}, net dex.Network) ([]byte, error) 
 func walletDefinition(assetID uint32, walletType string) (*asset.WalletDefinition, error) {
 	winfo, err := asset.Info(assetID)
 	if err != nil {
-		return nil, newError(assetSupportErr, "asset.Info error: %v", err)
+		return nil, newError(assetSupportErr, "asset.Info error: %w", err)
 	}
 	if walletType == "" {
 		if len(winfo.AvailableWallets) <= winfo.LegacyWalletIndex {

--- a/client/core/errors_test.go
+++ b/client/core/errors_test.go
@@ -24,16 +24,14 @@ func TestCoreError(t *testing.T) {
 		want string
 	}{{
 		Error{
-			desc:    "wallet error",
-			code:    walletErr,
-			wrapped: err0,
+			code: walletErr,
+			err:  errors.New("wallet error"),
 		},
 		"wallet error",
 	}, {
 		Error{
-			desc:    "wallet auth error",
-			code:    walletAuthErr,
-			wrapped: err0,
+			code: walletAuthErr,
+			err:  errors.New("wallet auth error"),
 		},
 		"wallet auth error",
 	}}
@@ -46,7 +44,7 @@ func TestCoreError(t *testing.T) {
 		}
 	}
 
-	coreErr := newError(walletErr, "stuff: %v", err0)
+	coreErr := newError(walletErr, "stuff: %w", err0)
 
 	var err1 *Error
 	if !errors.As(coreErr, &err1) {
@@ -65,24 +63,24 @@ func TestCoreError(t *testing.T) {
 	}
 }
 
-func TestUnwrap(t *testing.T) {
-	err1 := errors.New("1")
+func TestUnwrapErr(t *testing.T) {
+	err1 := errors.New("Error 1")
 	err2 := fmt.Errorf("Error 2: %w", err1)
 	err3 := fmt.Errorf("Not wrapped: %v, %d", "other string", 20)
-	erra := newError(walletErr, "wrapped 1: %v", err1)
+	erra := newError(walletErr, "wraps 2: %w", err2)
 
 	testCases := []struct {
 		err  error
 		want error
 	}{
-		{newError(walletErr, "wrapped: %v", err2), err1},
 		{erra, err1},
+		{newError(walletErr, "wraps 2: %w", err2), err1},
+		{newError(walletErr, "wraps 1: %w", err1), err1},
 		{newError(walletErr, "Not wrapped: %v, %d", "other string", 20), err3},
-		{newError(walletErr, "wrap 3: %v", err1), err1},
 	}
 	for i, tc := range testCases {
-		if got := Unwrap(tc.err); got.Error() != tc.want.Error() {
-			t.Errorf("#%d: Unwrap(%v) = %v, want %v", i, tc.err, got.Error(), tc.want.Error())
+		if got := UnwrapErr(tc.err); got.Error() != tc.want.Error() {
+			t.Errorf("#%d: UnwrapErr(%v) = %v, want %v", i, tc.err, got.Error(), tc.want.Error())
 		}
 	}
 }

--- a/client/core/errors_test.go
+++ b/client/core/errors_test.go
@@ -1,0 +1,88 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type testErr string
+
+func (te testErr) Error() string {
+	return string(te)
+}
+
+const (
+	err0 = testErr("other error")
+	err2 = testErr("Test error 2")
+)
+
+// TestCoreError tests the error output for the Error type.
+func TestCoreError(t *testing.T) {
+	tests := []struct {
+		in   Error
+		want string
+	}{{
+		Error{
+			desc:    "wallet error",
+			code:    walletErr,
+			wrapped: err0,
+		},
+		"wallet error",
+	}, {
+		Error{
+			desc:    "wallet auth error",
+			code:    walletAuthErr,
+			wrapped: err0,
+		},
+		"wallet auth error",
+	}}
+
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("#%d: got: %s want: %s", i, result, test.want)
+			continue
+		}
+	}
+
+	coreErr := newError(walletErr, "stuff: %v", err0)
+
+	var err1 *Error
+	if !errors.As(coreErr, &err1) {
+		t.Errorf("it isn't a core.Error type")
+	}
+	if !errors.Is(coreErr, err0) {
+		t.Errorf("it wasn't err0")
+	}
+	if errors.Is(coreErr, err2) {
+		t.Errorf("it was err2")
+	}
+	otherErr := codedError(walletErr, err0)
+	var err3 testErr
+	if !errors.As(otherErr, &err3) {
+		t.Errorf("it wasn't an testErr")
+	}
+}
+
+func TestUnwrap(t *testing.T) {
+	err1 := errors.New("1")
+	err2 := fmt.Errorf("Error 2: %w", err1)
+	err3 := fmt.Errorf("Not wrapped: %v, %d", "other string", 20)
+	erra := newError(walletErr, "wrapped 1: %v", err1)
+
+	testCases := []struct {
+		err  error
+		want error
+	}{
+		{newError(walletErr, "wrapped: %v", err2), err1},
+		{erra, err1},
+		{newError(walletErr, "Not wrapped: %v, %d", "other string", 20), err3},
+		{newError(walletErr, "wrap 3: %v", err1), err1},
+	}
+	for i, tc := range testCases {
+		if got := Unwrap(tc.err); got.Error() != tc.want.Error() {
+			t.Errorf("#%d: Unwrap(%v) = %v, want %v", i, tc.err, got.Error(), tc.want.Error())
+		}
+	}
+}

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -854,10 +854,10 @@ func (s *WebServer) writeAPIError(w http.ResponseWriter, err error) {
 		code = cErr.Code()
 	}
 
-	rawErr := core.Unwrap(err)
+	innerErr := core.UnwrapErr(err)
 	resp := &standardResponse{
 		OK:   false,
-		Msg:  rawErr.Error(),
+		Msg:  innerErr.Error(),
 		Code: code,
 	}
 	log.Error(err.Error())

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -26,7 +26,7 @@ func (s *WebServer) apiDiscoverAccount(w http.ResponseWriter, r *http.Request) {
 	cert := []byte(form.Cert)
 	pass, err := s.resolvePass(form.Password, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	exchangeInfo, paid, err := s.core.DiscoverAccount(form.Addr, pass, cert)
@@ -108,7 +108,7 @@ func (s *WebServer) apiRegister(w http.ResponseWriter, r *http.Request) {
 	}
 	pass, err := s.resolvePass(reg.Password, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	_, err = s.core.Register(&core.RegisterForm{
@@ -145,7 +145,7 @@ func (s *WebServer) apiNewWallet(w http.ResponseWriter, r *http.Request) {
 	}
 	pass, err := s.resolvePass(form.AppPW, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	// Wallet does not exist yet. Try to create it.
@@ -203,7 +203,7 @@ func (s *WebServer) apiOpenWallet(w http.ResponseWriter, r *http.Request) {
 	}
 	pass, err := s.resolvePass(form.Pass, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	err = s.core.OpenWallet(form.AssetID, pass)
@@ -255,7 +255,7 @@ func (s *WebServer) apiConnectWallet(w http.ResponseWriter, r *http.Request) {
 	}
 	err := s.core.ConnectWallet(form.AssetID)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("error connecting to %s wallet: %v", unbip(form.AssetID), err))
+		s.writeAPIError(w, fmt.Errorf("error connecting to %s wallet: %w", unbip(form.AssetID), err))
 		return
 	}
 
@@ -272,7 +272,7 @@ func (s *WebServer) apiTrade(w http.ResponseWriter, r *http.Request) {
 	r.Close = true
 	pass, err := s.resolvePass(form.Pass, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	ord, err := s.core.Trade(pass, form.Order)
@@ -301,7 +301,7 @@ func (s *WebServer) apiAccountExport(w http.ResponseWriter, r *http.Request) {
 	r.Close = true
 	pass, err := s.resolvePass(form.Pass, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	account, err := s.core.AccountExport(pass, form.Host)
@@ -331,7 +331,7 @@ func (s *WebServer) apiExportSeed(w http.ResponseWriter, r *http.Request) {
 	r.Close = true
 	seed, err := s.core.ExportSeed(form.Pass)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("error exporting seed: %v", err))
+		s.writeAPIError(w, fmt.Errorf("error exporting seed: %w", err))
 		return
 	}
 	writeJSON(w, &struct {
@@ -353,7 +353,7 @@ func (s *WebServer) apiAccountImport(w http.ResponseWriter, r *http.Request) {
 	r.Close = true
 	pass, err := s.resolvePass(form.Pass, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	err = s.core.AccountImport(pass, form.Account)
@@ -392,7 +392,7 @@ func (s *WebServer) apiCancel(w http.ResponseWriter, r *http.Request) {
 	}
 	pass, err := s.resolvePass(form.Pass, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	err = s.core.Cancel(pass, form.OrderID)
@@ -643,7 +643,7 @@ func (s *WebServer) apiChangeAppPass(w http.ResponseWriter, r *http.Request) {
 	if passwordIsCached {
 		key, err := s.cacheAppPassword(form.NewAppPW, authToken)
 		if err != nil {
-			log.Errorf("unable to cache password: %v", err)
+			log.Errorf("unable to cache password: %w", err)
 			clearCookie(pwKeyCK, w)
 		} else {
 			setCookie(pwKeyCK, hex.EncodeToString(key), w)
@@ -672,7 +672,7 @@ func (s *WebServer) apiReconfig(w http.ResponseWriter, r *http.Request) {
 	}
 	pass, err := s.resolvePass(form.AppPW, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	// Update wallet settings.
@@ -794,7 +794,7 @@ func (s *WebServer) apiPreOrder(w http.ResponseWriter, r *http.Request) {
 func (s *WebServer) actuallyLogin(w http.ResponseWriter, r *http.Request, login *loginForm) {
 	pass, err := s.resolvePass(login.Pass, r)
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("password error: %v", err))
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
 	loginResult, err := s.core.Login(pass)
@@ -810,7 +810,7 @@ func (s *WebServer) actuallyLogin(w http.ResponseWriter, r *http.Request, login 
 		if login.RememberPass {
 			key, err := s.cacheAppPassword(pass, authToken)
 			if err != nil {
-				s.writeAPIError(w, fmt.Errorf("login error: %v", err))
+				s.writeAPIError(w, fmt.Errorf("login error: %w", err))
 				return
 			}
 			setCookie(pwKeyCK, hex.EncodeToString(key), w)
@@ -853,9 +853,11 @@ func (s *WebServer) writeAPIError(w http.ResponseWriter, err error) {
 	if errors.As(err, &cErr) {
 		code = cErr.Code()
 	}
+	
+	rawErr := core.Unwrap(err)
 	resp := &standardResponse{
 		OK:   false,
-		Msg:  err.Error(),
+		Msg:  rawErr.Error(),
 		Code: code,
 	}
 	log.Error(err.Error())

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -853,7 +853,7 @@ func (s *WebServer) writeAPIError(w http.ResponseWriter, err error) {
 	if errors.As(err, &cErr) {
 		code = cErr.Code()
 	}
-	
+
 	rawErr := core.Unwrap(err)
 	resp := &standardResponse{
 		OK:   false,

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -401,7 +401,7 @@ func TestAPILogin(t *testing.T) {
 
 	// Login error
 	tCore.loginErr = tErr
-	ensure(fmt.Sprintf(`{"ok":false,"msg":"login error: %s"}`, tErr))
+	ensure(fmt.Sprintf(`{"ok":false,"msg":"%s"}`, tErr))
 	tCore.loginErr = nil
 }
 
@@ -488,7 +488,7 @@ func TestAPIInit(t *testing.T) {
 
 	// Initialization error
 	tCore.initErr = tErr
-	ensure(s.apiInit, fmt.Sprintf(`{"ok":false,"msg":"initialization error: %s"}`, tErr))
+	ensure(s.apiInit, fmt.Sprintf(`{"ok":false,"msg":"%s"}`, tErr))
 	tCore.initErr = nil
 }
 
@@ -517,7 +517,7 @@ func TestAPINewWallet(t *testing.T) {
 	tCore.notHas = true
 
 	tCore.createWalletErr = tErr
-	ensure(fmt.Sprintf(`{"ok":false,"msg":"error creating btc wallet: %s"}`, tErr))
+	ensure(fmt.Sprintf(`{"ok":false,"msg":"%s"}`, tErr))
 	tCore.createWalletErr = nil
 
 	tCore.notHas = false
@@ -536,7 +536,7 @@ func TestAPILogout(t *testing.T) {
 
 	// Logout error
 	tCore.logoutErr = tErr
-	ensure(fmt.Sprintf(`{"ok":false,"msg":"logout error: %s"}`, tErr))
+	ensure(fmt.Sprintf(`{"ok":false,"msg":"%s"}`, tErr))
 	tCore.logoutErr = nil
 }
 
@@ -553,7 +553,7 @@ func TestApiGetBalance(t *testing.T) {
 
 	// Logout error
 	tCore.balanceErr = tErr
-	ensure(fmt.Sprintf(`{"ok":false,"msg":"balance error: %s"}`, tErr))
+	ensure(fmt.Sprintf(`{"ok":false,"msg":"%s"}`, tErr))
 	tCore.balanceErr = nil
 }
 
@@ -668,7 +668,7 @@ func TestPasswordCache(t *testing.T) {
 	body := &newWalletForm{
 		Pass: encode.PassBytes(""),
 	}
-	want := `{"ok":false,"msg":"password error: app pass cannot be empty"}`
+	want := `{"ok":false,"msg":"app pass cannot be empty"}`
 	tCore.notHas = true
 	ensureResponse(t, s.apiNewWallet, want, reader, writer, body, nil)
 


### PR DESCRIPTION
This difff makes errors more user-oriented.
1. It modifies `core.Error` type to support error wrapping and unwrapping.
2. It adds an `Unwarp()` method to `core.Error` type.
3. Adds an ` UnwrapErr(err error) error` function that unwraps until it finds a non-wrapped error.
4. Adds tests for `core.Error` type.
5. Modify error strings in `webserver_test.go`.
6. Adds `%w` directive to errors constructed with `core` `newError(...)`.

Moving forward it would be nice to wrap errors that might end up being shown to users via client, detailed errors messages are logged to the terminal while errors shown via client are unwrapped. 

**Update**: Errors created using `core` `newError(...)` should be wrapped using the `%w` directive when necessary.
 
Now:
![errorunwrap4](https://user-images.githubusercontent.com/57448127/157857463-6411b214-1973-4f92-84de-3dc852cce9e1.PNG)
![errorunwarp1](https://user-images.githubusercontent.com/57448127/157857484-287df30b-a171-46d8-af8b-76475a02ce76.PNG)
![newdexerrafter](https://user-images.githubusercontent.com/57448127/157857614-69cfe3a1-09cd-4f64-b5fb-1d3572ad6739.PNG)

Closes #1488.