### PR TITLE
update to Go 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,24 @@
 name: Build and Test
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   build-go:
     name: Go CI
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.16, 1.17]
+        go: [1.17, 1.18]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
 
       - name: Check out source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.0"
 
       - name: Test
         env:
@@ -30,9 +32,9 @@ jobs:
       matrix:
         node-version: [16.x, 17.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use nodejs ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm clean-install

--- a/README.md
+++ b/README.md
@@ -238,10 +238,10 @@ for more details about how atomic swaps work.
 
 ### Dependencies
 
-1. [Go >= 1.16](https://golang.org/doc/install)
-2. [Node 14+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) is used to bundle resources for the browser interface. It's important to note that the DEX client has no external javascript dependencies. The client doesn't import any Node packages. We only use Node to lint and compile our own javascript and css resources.
-3. [dcrd](https://github.com/decred/dcrd) and [dcrwallet](https://github.com/decred/dcrwallet) (non-SPV), installed from the [v1.7.x release binaries](https://github.com/decred/decred-release/releases/tag/v1.7.0), or built from the `release-v1.7` branches.
-4. [Bitcoin Core v0.21.x or v22.x](https://bitcoincore.org/en/download/) (bitcoind or bitcoin-qt) wallet, **encrypted**.
+1. [Go 1.17 or 1.18](https://golang.org/doc/install)
+2. [Node 16 or 17](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) is used to bundle resources for the browser interface. It's important to note that the DEX client has no external javascript dependencies. The client doesn't import any Node packages. We only use Node to lint and compile our own javascript and css resources.
+3. [dcrd](https://github.com/decred/dcrd) and [dcrwallet](https://github.com/decred/dcrwallet), installed from the [v1.7.x release binaries](https://github.com/decred/decred-release/releases), or built from the `release-v1.7` branches.
+4. [Bitcoin Core v0.21.x or v22.x](https://bitcoincore.org/en/download/) (bitcoind or bitcoin-qt) wallet. If you use v22, you must **not** use a "descriptor" wallet.
 5. At least 2 GB of available system memory.
 
 See the [wiki](../../wiki/Testnet-Testing) for details on preparing the wallets.
@@ -328,7 +328,7 @@ issued to **Core** for execution. **dexcctl** also requires **dexc**.
 ### Dependencies
 
 1. Linux or MacOS
-2. [Go >= 1.16](https://golang.org/doc/install)
+2. [Go >= 1.17](https://golang.org/doc/install)
 3. [PostgreSQL 11+](https://www.postgresql.org/download/), [tuned](https://pgtune.leopard.in.ua/) and running.
 4. Decred (dcrd) and Bitcoin (bitcoind) full nodes, both with `txindex` enabled.
 

--- a/client/asset/bch/regnet_test.go
+++ b/client/asset/bch/regnet_test.go
@@ -1,5 +1,4 @@
 //go:build harness
-// +build harness
 
 package bch
 

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1,5 +1,4 @@
 //go:build !spvlive
-// +build !spvlive
 
 package btc
 

--- a/client/asset/btc/livetest/regnet_test.go
+++ b/client/asset/btc/livetest/regnet_test.go
@@ -1,5 +1,4 @@
 //go:build harness
-// +build harness
 
 package livetest
 

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -1,5 +1,4 @@
 //go:build !spvlive
-// +build !spvlive
 
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1,5 +1,4 @@
 //go:build !harness
-// +build !harness
 
 package dcr
 

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -1,5 +1,4 @@
 //go:build harness
-// +build harness
 
 package dcr
 

--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/client/asset/eth/contractor_test.go
+++ b/client/asset/eth/contractor_test.go
@@ -1,5 +1,4 @@
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/client/asset/eth/doc.go
+++ b/client/asset/eth/doc.go
@@ -5,7 +5,6 @@
 // go-ethereum's GNU Lesser General Public License.
 
 //go:build lgpl
-// +build lgpl
 
 // Package eth implements methods to work with ethereum swap contracts and
 // transactions. The LGPL is a more restrictive license that may be more of a

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1,5 +1,4 @@
 //go:build !harness && lgpl
-// +build !harness,lgpl
 
 // These tests will not be run if the harness build tag is set.
 

--- a/client/asset/eth/fundingcoin.go
+++ b/client/asset/eth/fundingcoin.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/client/asset/eth/fundingcoin_test.go
+++ b/client/asset/eth/fundingcoin_test.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/client/asset/eth/node.go
+++ b/client/asset/eth/node.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -1,5 +1,4 @@
 //go:build harness && lgpl
-// +build harness,lgpl
 
 // This test requires that the testnet harness be running and the unix socket
 // be located at $HOME/dextest/eth/gamma/node/geth.ipc

--- a/client/asset/ltc/regnet_test.go
+++ b/client/asset/ltc/regnet_test.go
@@ -1,5 +1,4 @@
 //go:build harness
-// +build harness
 
 package ltc
 

--- a/client/cmd/dexc/importlgpl.go
+++ b/client/cmd/dexc/importlgpl.go
@@ -5,7 +5,6 @@
 // burden of go-ethereum's GNU Lesser General Public License.
 
 //go:build lgpl
-// +build lgpl
 
 package main
 

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -1,5 +1,4 @@
 //go:build !harness
-// +build !harness
 
 package core
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1,5 +1,4 @@
 //go:build !harness
-// +build !harness
 
 package core
 

--- a/client/core/harness_norace.go
+++ b/client/core/harness_norace.go
@@ -1,5 +1,4 @@
 //go:build !race && harness
-// +build !race,harness
 
 package core
 

--- a/client/core/harness_race.go
+++ b/client/core/harness_race.go
@@ -1,5 +1,4 @@
 //go:build race && harness
-// +build race,harness
 
 package core
 

--- a/client/core/helpers_test.go
+++ b/client/core/helpers_test.go
@@ -1,5 +1,4 @@
 //go:build !harness
-// +build !harness
 
 package core
 

--- a/client/core/trade_simnet_test.go
+++ b/client/core/trade_simnet_test.go
@@ -1,5 +1,4 @@
 //go:build harness
-// +build harness
 
 package core
 

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build !live
-// +build !live
 
 package rpcserver
 

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1,5 +1,4 @@
 //go:build live && lgpl
-// +build live,lgpl
 
 // Run a test server with
 // go test -v -tags live -run Server -timeout 60m

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -1,5 +1,4 @@
 //go:build !live
-// +build !live
 
 package webserver
 

--- a/client/websocket/websocket_test.go
+++ b/client/websocket/websocket_test.go
@@ -1,5 +1,4 @@
 //go:build !live
-// +build !live
 
 package websocket
 

--- a/dex/networks/erc20/erc20.go
+++ b/dex/networks/erc20/erc20.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package erc20
 

--- a/dex/networks/erc20/params.go
+++ b/dex/networks/erc20/params.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package erc20
 

--- a/dex/networks/erc20/txdata.go
+++ b/dex/networks/erc20/txdata.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package erc20
 

--- a/dex/networks/eth/abi.go
+++ b/dex/networks/eth/abi.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build lgpl
-// +build lgpl
 
 // This file lifted from go-ethereum/signer/fourbyte at v1.10.6 commit
 // 576681f29b895dd39e559b7ba17fcd89b42e4833 and modified to make parseCalldata take

--- a/dex/networks/eth/abi_test.go
+++ b/dex/networks/eth/abi_test.go
@@ -15,7 +15,6 @@
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
 //go:build lgpl
-// +build lgpl
 
 // This file lifted from go-ethereum/signer/fourbyte at v1.10.6 commit
 // 576681f29b895dd39e559b7ba17fcd89b42e4833 and modified to make parseCalldata take

--- a/dex/networks/eth/common.go
+++ b/dex/networks/eth/common.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/dex/networks/eth/contracts/v0/doc.go
+++ b/dex/networks/eth/contracts/v0/doc.go
@@ -5,7 +5,6 @@
 // go-ethereum's GNU Lesser General Public License.
 
 //go:build lgpl
-// +build lgpl
 
 // Package v0 contains pre-generated code that should not be directly edited.
 // See the parent package for details on how to generate.

--- a/dex/networks/eth/doc.go
+++ b/dex/networks/eth/doc.go
@@ -5,7 +5,6 @@
 // go-ethereum's GNU Lesser General Public License.
 
 //go:build lgpl
-// +build lgpl
 
 // Package eth implements methods to work with ethereum swap contracts and
 // transactions. The LGPL is a more restrictive license that may be more of a

--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/dex/networks/eth/params_test.go
+++ b/dex/networks/eth/params_test.go
@@ -1,3 +1,8 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build lgpl
+
 package eth
 
 import (

--- a/dex/networks/eth/tokens.go
+++ b/dex/networks/eth/tokens.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/dex/networks/eth/txdata.go
+++ b/dex/networks/eth/txdata.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/dex/networks/eth/txdata_test.go
+++ b/dex/networks/eth/txdata_test.go
@@ -1,5 +1,4 @@
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrdex
 
-go 1.16
+go 1.17
 
 require (
 	decred.org/dcrwallet/v2 v2.0.0-20211206163037-9537363becbb
@@ -10,7 +10,6 @@ require (
 	github.com/btcsuite/btcutil/psbt v1.0.3-0.20201208143702-a53e38424cce
 	github.com/btcsuite/btcwallet v0.12.0
 	github.com/btcsuite/btcwallet/wallet/txauthor v1.1.0
-	github.com/btcsuite/btcwallet/wallet/txsizes v1.1.0 // indirect
 	github.com/btcsuite/btcwallet/walletdb v1.4.0
 	github.com/btcsuite/btcwallet/wtxmgr v1.3.0
 	github.com/davecgh/go-spew v1.1.1
@@ -50,4 +49,61 @@ require (
 	golang.org/x/text v0.3.6
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	gopkg.in/ini.v1 v1.55.0
+)
+
+require (
+	github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 // indirect
+	github.com/VictoriaMetrics/fastcache v1.6.0 // indirect
+	github.com/aead/siphash v1.0.1 // indirect
+	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
+	github.com/btcsuite/btcwallet/wallet/txrules v1.0.0 // indirect
+	github.com/btcsuite/btcwallet/wallet/txsizes v1.1.0 // indirect
+	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd // indirect
+	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/dchest/siphash v1.2.2 // indirect
+	github.com/deckarep/golang-set v1.8.0 // indirect
+	github.com/decred/base58 v1.0.3 // indirect
+	github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0 // indirect
+	github.com/decred/dcrd/crypto/ripemd160 v1.0.1 // indirect
+	github.com/decred/dcrd/database/v3 v3.0.0 // indirect
+	github.com/decred/dcrd/lru v1.1.1 // indirect
+	github.com/edsrzf/mmap-go v1.0.0 // indirect
+	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
+	github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff // indirect
+	github.com/gcash/bchlog v0.0.0-20180913005452-b4f036f92fa6 // indirect
+	github.com/go-ole/go-ole v1.2.1 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/uuid v1.1.5 // indirect
+	github.com/hashicorp/go-bexpr v0.1.10 // indirect
+	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
+	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
+	github.com/holiman/uint256 v1.2.0 // indirect
+	github.com/huin/goupnp v1.0.2 // indirect
+	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
+	github.com/kkdai/bstream v1.0.0 // indirect
+	github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf // indirect
+	github.com/lightningnetwork/lnd/clock v1.0.1 // indirect
+	github.com/lightningnetwork/lnd/queue v1.0.1 // indirect
+	github.com/lightningnetwork/lnd/ticker v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/mitchellh/pointerstructure v1.2.0 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/tsdb v0.7.1 // indirect
+	github.com/rjeczalik/notify v0.9.1 // indirect
+	github.com/rs/cors v1.7.0 // indirect
+	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
+	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4 // indirect
+	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
+	github.com/tklauser/go-sysconf v0.3.5 // indirect
+	github.com/tklauser/numcpus v0.2.2 // indirect
+	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef // indirect
+	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
+	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
+	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
 )

--- a/server/asset/bch/live_test.go
+++ b/server/asset/bch/live_test.go
@@ -1,5 +1,4 @@
 //go:build bchlive
-// +build bchlive
 
 // go test -v -tags bchlive -run UTXOStats
 // -----------------------------------

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -1,5 +1,4 @@
 //go:build !btclive
-// +build !btclive
 
 // These tests will not be run if the btclive build tag is set. In that case,
 // the live_test.go tests will run.

--- a/server/asset/btc/live_test.go
+++ b/server/asset/btc/live_test.go
@@ -1,5 +1,4 @@
 //go:build btclive
-// +build btclive
 
 // Since at least one live test runs for an hour, you should run live tests
 // individually using the -run flag. All of these tests will only run with the

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -1,5 +1,4 @@
 //go:build !dcrlive
-// +build !dcrlive
 
 // These tests will not be run if the dcrlive build tag is set.
 

--- a/server/asset/dcr/live_test.go
+++ b/server/asset/dcr/live_test.go
@@ -1,5 +1,4 @@
 //go:build dcrlive
-// +build dcrlive
 
 // Since at least one live test runs for an hour, you should run live tests
 // individually using the -run flag. All of these tests will only run with the

--- a/server/asset/eth/coiner.go
+++ b/server/asset/eth/coiner.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/server/asset/eth/coiner_test.go
+++ b/server/asset/eth/coiner_test.go
@@ -1,5 +1,4 @@
 //go:build !harness && lgpl
-// +build !harness,lgpl
 
 // These tests will not be run if the harness build tag is set.
 

--- a/server/asset/eth/config.go
+++ b/server/asset/eth/config.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/server/asset/eth/doc.go
+++ b/server/asset/eth/doc.go
@@ -5,7 +5,6 @@
 // go-ethereum's GNU Lesser General Public License.
 
 //go:build lgpl
-// +build lgpl
 
 // Package eth implements methods to work with ethereum swap contracts and
 // transactions. The LGPL is a more restrictive license that may be more of a

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -1,5 +1,4 @@
 //go:build !harness && lgpl
-// +build !harness,lgpl
 
 // These tests will not be run if the harness build tag is set.
 

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -2,7 +2,6 @@
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
 //go:build lgpl
-// +build lgpl
 
 package eth
 

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -1,5 +1,4 @@
 //go:build harness && lgpl
-// +build harness,lgpl
 
 // This test requires that the testnet harness be running and the unix socket
 // be located at $HOME/dextest/eth/alpha/node/geth.ipc

--- a/server/asset/ltc/live_test.go
+++ b/server/asset/ltc/live_test.go
@@ -1,5 +1,4 @@
 //go:build ltclive
-// +build ltclive
 
 // go test -v -tags ltclive -run UTXOStats
 // -----------------------------------

--- a/server/cmd/dcrdex/importlgpl.go
+++ b/server/cmd/dcrdex/importlgpl.go
@@ -5,7 +5,6 @@
 // burden of go-ethereum's GNU Lesser General Public License.
 
 //go:build lgpl
-// +build lgpl
 
 package main
 

--- a/server/db/driver/pg/accounts_online_test.go
+++ b/server/db/driver/pg/accounts_online_test.go
@@ -1,5 +1,4 @@
 //go:build pgonline
-// +build pgonline
 
 package pg
 

--- a/server/db/driver/pg/matches_online_test.go
+++ b/server/db/driver/pg/matches_online_test.go
@@ -1,5 +1,4 @@
 //go:build pgonline
-// +build pgonline
 
 package pg
 

--- a/server/db/driver/pg/orders_online_test.go
+++ b/server/db/driver/pg/orders_online_test.go
@@ -1,5 +1,4 @@
 //go:build pgonline
-// +build pgonline
 
 package pg
 

--- a/server/db/driver/pg/orders_test.go
+++ b/server/db/driver/pg/orders_test.go
@@ -1,5 +1,4 @@
 //go:build !pgonline
-// +build !pgonline
 
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.

--- a/server/db/driver/pg/system_online_test.go
+++ b/server/db/driver/pg/system_online_test.go
@@ -1,5 +1,4 @@
 //go:build pgonline
-// +build pgonline
 
 package pg
 

--- a/server/db/driver/pg/tables_online_test.go
+++ b/server/db/driver/pg/tables_online_test.go
@@ -1,5 +1,4 @@
 //go:build pgonline
-// +build pgonline
 
 package pg
 

--- a/server/db/driver/pg/upgrades_test.go
+++ b/server/db/driver/pg/upgrades_test.go
@@ -1,5 +1,4 @@
 //go:build pgonline
-// +build pgonline
 
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.


### PR DESCRIPTION
This updates for Go 1.18.

The supported Go versions are now 1.17 and 1.18.

CI is updated to new action versions and uses golangci-lint v1.45.0.

All the old `//+build` lines are removed now that all supported Go versions understand the new `//go:build` lines.

The go.mod now specifies `go 1.17`, and a `go mod tidy` is applied.