### PR TITLE
client/asset/eth: token prefactor

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -28,9 +28,11 @@ import (
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/hdkeychain/v3"
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 var (
@@ -139,22 +141,21 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Ne
 //   2. An encoded funding coin id which includes the account address and amount.
 //   3. A byte encoded string of the account address.
 func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
-	txHashID, err := dexeth.DecodeCoinID(coinID)
-	if err == nil {
-		return txHashID.String(), nil
+	switch len(coinID) {
+	case common.HashLength:
+		var txHash common.Hash
+		copy(txHash[:], coinID)
+		return txHash.String(), nil
+	case fundingCoinIDSize:
+		c, err := decodeFundingCoin(coinID)
+		if err != nil {
+			return "", err
+		}
+		return c.String(), nil
+	case common.AddressLength*2 + 2:
+		return common.HexToAddress(string(coinID)).String(), nil
 	}
-
-	fundingCoinID, err := decodeFundingCoinID(coinID)
-	if err == nil {
-		return fundingCoinID.String(), nil
-	}
-
-	addressID := string(coinID)
-	if len(addressID) == 42 && addressID[0:2] == "0x" {
-		return addressID, nil
-	}
-
-	return "", fmt.Errorf("%x is not a valid ETH coin id", coinID)
+	return "", fmt.Errorf("unknown coin ID format: %x", coinID)
 }
 
 // Info returns basic information about the wallet and asset.
@@ -186,28 +187,24 @@ type Balance struct {
 // satisfied by rpcclient. For testing, it can be satisfied by a stub.
 type ethFetcher interface {
 	address() common.Address
-	balance(ctx context.Context) (*Balance, error)
-	bestBlockHash(ctx context.Context) (common.Hash, error)
 	bestHeader(ctx context.Context) (*types.Header, error)
-	block(ctx context.Context, hash common.Hash) (*types.Block, error)
+	addressBalance(ctx context.Context, addr common.Address) (*big.Int, error)
 	connect(ctx context.Context) error
-	initiate(ctx context.Context, contracts []*asset.Contract, maxFeeRate uint64, contractVer uint32) (*types.Transaction, error)
-	shutdown()
-	syncProgress() ethereum.SyncProgress
+	chainConfig() *params.ChainConfig
 	peerCount() uint32
-	isRedeemable(secretHash, secret [32]byte, contractVer uint32) (bool, error)
-	redeem(ctx context.Context, redemptions []*asset.Redemption, maxFeeRate uint64, contractVer uint32) (*types.Transaction, error)
-	isRefundable(secretHash [32]byte, contractVer uint32) (bool, error)
-	refund(ctx context.Context, secretHash [32]byte, maxFeeRate uint64, contractVer uint32) (*types.Transaction, error)
-	swap(ctx context.Context, secretHash [32]byte, contractVer uint32) (*dexeth.SwapState, error)
+	contractBackend() bind.ContractBackend
 	lock() error
 	locked() bool
 	unlock(pw string) error
-	signData(data []byte) (sig, pubKey []byte, err error)
-	sendToAddr(ctx context.Context, addr common.Address, val uint64) (*types.Transaction, error)
-	transactionConfirmations(context.Context, common.Hash) (uint32, error)
+	pendingTransactions() ([]*types.Transaction, error)
+	shutdown()
 	sendSignedTransaction(ctx context.Context, tx *types.Transaction) error
-	netFeeState(ctx context.Context) (baseFees, tipCap *big.Int, err error)
+	sendTransaction(ctx context.Context, txOpts *bind.TransactOpts, to common.Address, data []byte) (*types.Transaction, error)
+	signData(data []byte) (sig, pubKey []byte, err error)
+	syncProgress() ethereum.SyncProgress
+	transactionConfirmations(context.Context, common.Hash) (uint32, error)
+	txOpts(ctx context.Context, val, maxGas uint64, maxFeeRate *big.Int) (*bind.TransactOpts, error)
+	currentFees(ctx context.Context) (baseFees, tipCap *big.Int, err error)
 }
 
 // Check that ExchangeWallet satisfies the asset.Wallet interface.
@@ -234,7 +231,7 @@ type ExchangeWallet struct {
 	gasFeeLimit   uint64
 
 	tipMtx     sync.RWMutex
-	currentTip *types.Block
+	currentTip *types.Header
 
 	lockedFunds struct {
 		mtx                sync.RWMutex
@@ -245,6 +242,10 @@ type ExchangeWallet struct {
 
 	findRedemptionMtx  sync.RWMutex
 	findRedemptionReqs map[[32]byte]*findRedemptionRequest
+
+	nonceSendMtx sync.Mutex
+
+	contractors map[uint32]contractor // version -> contractor
 }
 
 // Info returns basic information about the wallet and asset.
@@ -320,6 +321,7 @@ func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network)
 		peersChange:        assetCFG.PeersChange,
 		gasFeeLimit:        gasFeeLimit,
 		findRedemptionReqs: make(map[[32]byte]*findRedemptionRequest),
+		contractors:        make(map[uint32]contractor),
 	}, nil
 }
 
@@ -340,20 +342,22 @@ func (eth *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 		return nil, err
 	}
 
-	// Initialize the best block.
-	bestHash, err := eth.node.bestBlockHash(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error getting best block hash from geth: %w", err)
+	for ver, constructor := range contractorConstructors {
+		if eth.contractors[ver], err = constructor(eth.net, eth.addr, eth.node.contractBackend()); err != nil {
+			return nil, fmt.Errorf("error constructor version %d contractor: %v", ver, err)
+		}
 	}
-	block, err := eth.node.block(ctx, bestHash)
+
+	// Initialize the best block.
+	bestHdr, err := eth.node.bestHeader(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting best block from geth: %w", err)
 	}
 	eth.tipMtx.Lock()
-	eth.currentTip = block
+	eth.currentTip = bestHdr
 	eth.tipMtx.Unlock()
-	height := eth.currentTip.NumberU64()
-	atomic.StoreInt64(&eth.tipAtConnect, int64(height))
+	height := eth.currentTip.Number
+	atomic.StoreInt64(&eth.tipAtConnect, height.Int64())
 	eth.log.Infof("Connected to geth, at height %d", height)
 
 	var wg sync.WaitGroup
@@ -470,7 +474,7 @@ func (eth *ExchangeWallet) Balance() (*asset.Balance, error) {
 // balance returns the total available funds in the account.
 // This function expects eth.lockedFunds.mtx to be held.
 func (eth *ExchangeWallet) balance() (*asset.Balance, error) {
-	bal, err := eth.node.balance(eth.ctx)
+	bal, err := eth.balanceWithTxPool()
 	if err != nil {
 		return nil, err
 	}
@@ -576,53 +580,27 @@ func (c *coin) Value() uint64 {
 	return c.value
 }
 
-// fundingCoin is a coin that also implements asset.RecoveryCoin, enabling
-// a custom database record and special handling of the recovery ID for use in
-// later calls to FundingCoin.
-type fundingCoin struct {
-	*coin
-	recoveryID []byte
-}
-
-func (c *fundingCoin) RecoveryID() dex.Bytes {
-	return c.recoveryID[:]
-}
-
-func (c *fundingCoin) String() string {
-	return fmt.Sprintf("{%s:%x}", []byte(c.id), c.recoveryID)
-}
-
 var _ asset.Coin = (*coin)(nil)
+
+func (eth *ExchangeWallet) createFundingCoin(amount uint64) *fundingCoin {
+	return createFundingCoin(eth.addr, amount)
+}
 
 // decodeFundingCoinID decodes a coin id into a coin object. This function ensures
 // that the id contains an encoded fundingCoinID whose address is the same as
 // the one managed by this wallet.
-func (eth *ExchangeWallet) decodeFundingCoinID(id []byte) (*coin, error) {
-	fundingCoinID, err := decodeFundingCoinID(id)
+func (eth *ExchangeWallet) decodeFundingCoinID(id []byte) (*fundingCoin, error) {
+	fc, err := decodeFundingCoin(id)
 	if err != nil {
 		return nil, err
 	}
 
-	if fundingCoinID.Address != eth.addr {
+	if fc.addr != eth.addr {
 		return nil, fmt.Errorf("coin address %x != wallet address %x",
-			fundingCoinID.Address, eth.addr)
+			fc.addr, eth.addr)
 	}
 
-	return &coin{
-		id:    fundingCoinID.Encode(),
-		value: fundingCoinID.Amount,
-	}, nil
-}
-
-func (eth *ExchangeWallet) createFundingCoin(amount uint64) *fundingCoin {
-	id := createFundingCoinID(eth.addr, amount)
-	return &fundingCoin{
-		coin: &coin{
-			id:    []byte(eth.addr.String()),
-			value: amount,
-		},
-		recoveryID: id.Encode(),
-	}
+	return fc, nil
 }
 
 // FundOrder selects coins for use in an order. The coins will be locked, and
@@ -658,19 +636,23 @@ func (eth *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes
 // canceled order.
 func (eth *ExchangeWallet) ReturnCoins(coins asset.Coins) error {
 	var amt uint64
-	for i := range coins {
-		switch c := coins[i].(type) {
+	for _, ci := range coins {
+		amt += ci.Value()
+		var addr common.Address
+		switch c := ci.(type) {
 		case *fundingCoin:
-			amt += c.value
+			addr = c.addr
 		default:
-			return fmt.Errorf("unsupported funding coin type for coin %[1]s: %[1]T", coins[i])
+			return fmt.Errorf("unknown coin type %T", c)
+		}
+		if addr != eth.addr {
+			return fmt.Errorf("coin is not funded by this wallet. coin address %s != our address %s", addr, eth.addr)
 		}
 	}
 
 	eth.lockedFunds.mtx.Lock()
 	defer eth.lockedFunds.mtx.Unlock()
 	eth.unlockFunds(amt, initiationReserve)
-
 	return nil
 }
 
@@ -776,7 +758,7 @@ func (eth *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 		return nil, nil, 0, fmt.Errorf("unfunded contract. %d < %d", totalInputValue, totalSpend)
 	}
 
-	tx, err := eth.node.initiate(eth.ctx, swaps.Contracts, swaps.FeeRate, swaps.AssetVersion)
+	tx, err := eth.initiate(eth.ctx, swaps.Contracts, swaps.FeeRate, swaps.AssetVersion)
 	if err != nil {
 		return fail(fmt.Errorf("Swap: initiate error: %w", err))
 	}
@@ -848,7 +830,7 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 		// are maker (the swap initiator).
 		var secret [32]byte
 		copy(secret[:], redemption.Secret)
-		redeemable, err := eth.node.isRedeemable(secretHash, secret, ver)
+		redeemable, err := eth.isRedeemable(secretHash, secret, ver)
 		if err != nil {
 			return fail(fmt.Errorf("Redeem: failed to check if swap is redeemable: %w", err))
 		}
@@ -857,7 +839,7 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 				secretHash, secret))
 		}
 
-		swapData, err := eth.node.swap(eth.ctx, secretHash, ver)
+		swapData, err := eth.swap(eth.ctx, secretHash, ver)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("Redeem: error finding swap state: %w", err)
 		}
@@ -870,7 +852,7 @@ func (eth *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 
 	// TODO: make sure the amount we locked for redemption is enough to cover the gas
 	// fees.
-	tx, err := eth.node.redeem(eth.ctx, form.Redemptions, form.FeeSuggestion, contractVersion)
+	tx, err := eth.redeem(eth.ctx, form.Redemptions, form.FeeSuggestion, contractVersion)
 	if err != nil {
 		return fail(fmt.Errorf("Redeem: redeem error: %w", err))
 	}
@@ -1041,7 +1023,7 @@ func (eth *ExchangeWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time,
 		return false, time.Time{}, err
 	}
 
-	swap, err := eth.node.swap(eth.ctx, secretHash, contractVer)
+	swap, err := eth.swap(eth.ctx, secretHash, contractVer)
 	if err != nil {
 		return false, time.Time{}, err
 	}
@@ -1153,7 +1135,7 @@ func (eth *ExchangeWallet) findSecret(ctx context.Context, secretHash [32]byte, 
 	// Add a reasonable timeout here.
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	swap, err := eth.node.swap(ctx, secretHash, contractVer)
+	swap, err := eth.swap(ctx, secretHash, contractVer)
 	if err != nil {
 		return nil, err
 	}
@@ -1185,7 +1167,7 @@ func (eth *ExchangeWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (
 		eth.unlockFunds(feeSuggestion*dexeth.RefundGas(version), refundReserve)
 	}
 
-	swap, err := eth.node.swap(eth.ctx, secretHash, version)
+	swap, err := eth.swap(eth.ctx, secretHash, version)
 	if err != nil {
 		return nil, err
 	}
@@ -1206,7 +1188,7 @@ func (eth *ExchangeWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (
 		return nil, asset.CoinNotFoundError // so caller knows to FindRedemption
 	}
 
-	refundable, err := eth.node.isRefundable(secretHash, version)
+	refundable, err := eth.isRefundable(secretHash, version)
 	if err != nil {
 		return nil, fmt.Errorf("Refund: failed to check isRefundable: %w", err)
 	}
@@ -1214,7 +1196,7 @@ func (eth *ExchangeWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (
 		return nil, fmt.Errorf("Refund: swap with secret hash %x is not refundable", secretHash)
 	}
 
-	tx, err := eth.node.refund(eth.ctx, secretHash, feeSuggestion, version)
+	tx, err := eth.refund(eth.ctx, secretHash, feeSuggestion, version)
 	if err != nil {
 		return nil, fmt.Errorf("Refund: failed to call refund: %w", err)
 	}
@@ -1259,7 +1241,7 @@ func (eth *ExchangeWallet) PayFee(address string, regFee, _ uint64) (asset.Coin,
 	if avail < need {
 		return nil, fmt.Errorf("not enough funds to pay fee: have %d gwei need %d gwei", avail, need)
 	}
-	tx, err := eth.node.sendToAddr(eth.ctx, common.HexToAddress(address), regFee)
+	tx, err := eth.sendToAddr(common.HexToAddress(address), regFee)
 	if err != nil {
 		return nil, err
 	}
@@ -1286,7 +1268,7 @@ func (eth *ExchangeWallet) SwapConfirmations(ctx context.Context, _ dex.Bytes, c
 		return 0, false, fmt.Errorf("error fetching best header: %w", err)
 	}
 
-	swapData, err := eth.node.swap(ctx, secretHash, contractVer)
+	swapData, err := eth.swap(ctx, secretHash, contractVer)
 	if err != nil {
 		return 0, false, fmt.Errorf("error finding swap state: %w", err)
 	}
@@ -1319,7 +1301,7 @@ func (eth *ExchangeWallet) Withdraw(addr string, value, _ uint64) (asset.Coin, e
 	if avail < value+maxFee {
 		value -= maxFee
 	}
-	tx, err := eth.node.sendToAddr(eth.ctx, common.HexToAddress(addr), value)
+	tx, err := eth.sendToAddr(common.HexToAddress(addr), value)
 	if err != nil {
 		return nil, err
 	}
@@ -1374,7 +1356,7 @@ func (eth *ExchangeWallet) RegFeeConfirmations(ctx context.Context, coinID dex.B
 
 // FeeRate satisfies asset.FeeRater.
 func (eth *ExchangeWallet) FeeRate() uint64 {
-	base, tip, err := eth.node.netFeeState(eth.ctx)
+	base, tip, err := eth.node.currentFees(eth.ctx)
 	if err != nil {
 		eth.log.Errorf("Error getting net fee state: %v", err)
 		return 0
@@ -1437,11 +1419,12 @@ func (eth *ExchangeWallet) monitorBlocks(ctx context.Context) {
 func (eth *ExchangeWallet) checkForNewBlocks() {
 	ctx, cancel := context.WithTimeout(eth.ctx, 2*time.Second)
 	defer cancel()
-	bestHash, err := eth.node.bestBlockHash(ctx)
+	bestHdr, err := eth.node.bestHeader(ctx)
 	if err != nil {
 		go eth.tipChange(fmt.Errorf("failed to get best hash: %w", err))
 		return
 	}
+	bestHash := bestHdr.Hash()
 	// This method is called frequently. Don't hold write lock
 	// unless tip has changed.
 	eth.tipMtx.RLock()
@@ -1451,19 +1434,13 @@ func (eth *ExchangeWallet) checkForNewBlocks() {
 		return
 	}
 
-	newTip, err := eth.node.block(ctx, bestHash)
-	if err != nil {
-		go eth.tipChange(fmt.Errorf("failed to get best block: %w", err))
-		return
-	}
-
 	eth.tipMtx.Lock()
 	defer eth.tipMtx.Unlock()
 
 	prevTip := eth.currentTip
-	eth.currentTip = newTip
-	eth.log.Debugf("tip change: %d (%s) => %d (%s)", prevTip.NumberU64(),
-		prevTip.Hash(), newTip.NumberU64(), newTip.Hash())
+	eth.currentTip = bestHdr
+	eth.log.Debugf("tip change: %d (%s) => %d (%s)", prevTip.Number,
+		currentTipHash, bestHdr.Number, bestHash)
 	go eth.tipChange(nil)
 	go eth.checkFindRedemptions()
 }
@@ -1478,4 +1455,185 @@ func (eth *ExchangeWallet) checkFindRedemptions() {
 			eth.sendFindRedemptionResult(req, secretHash, secret, nil)
 		}
 	}
+}
+
+// withContractor runs the provided function with the versioned contractor.
+func (eth *ExchangeWallet) withContractor(ver uint32, f func(contractor) error) error {
+	contractor, found := eth.contractors[ver]
+	if !found {
+		return fmt.Errorf("no version %d contractor", ver)
+	}
+	return f(contractor)
+}
+
+func (eth *ExchangeWallet) estimateSwapGas(num int, contractVer uint32) (gas uint64, err error) {
+	return gas, eth.withContractor(contractVer, func(c contractor) error {
+		gas, err = c.estimateInitGas(eth.ctx, num)
+		return err
+	})
+}
+
+// balanceWithTxPool gets the current and pending balances.
+func (eth *ExchangeWallet) balanceWithTxPool() (*Balance, error) {
+	confirmed, err := eth.node.addressBalance(eth.ctx, eth.addr)
+	if err != nil {
+		return nil, fmt.Errorf("balance error: %w", err)
+	}
+
+	pendingTxs, err := eth.node.pendingTransactions()
+	if err != nil {
+		return nil, fmt.Errorf("error getting pending txs: %w", err)
+	}
+
+	outgoing := new(big.Int)
+	incoming := new(big.Int)
+	zero := new(big.Int)
+
+	addFees := func(tx *types.Transaction) {
+		gas := new(big.Int).SetUint64(tx.Gas())
+		// For legacy transactions, GasFeeCap returns gas price
+		if gasFeeCap := tx.GasFeeCap(); gasFeeCap != nil {
+			outgoing.Add(outgoing, new(big.Int).Mul(gas, gasFeeCap))
+		} else {
+			eth.log.Errorf("unable to calculate fees for tx %s", tx.Hash())
+		}
+	}
+
+	ethSigner := types.LatestSigner(eth.node.chainConfig()) // "latest" good for pending
+
+	for _, tx := range pendingTxs {
+		from, _ := ethSigner.Sender(tx) // zero Address on error
+		if from != eth.addr {
+			continue
+		}
+		addFees(tx)
+		v := tx.Value()
+		if v.Cmp(zero) == 0 {
+			// If zero value, attempt to find redemptions or refunds that pay
+			// to us.
+			for ver, c := range eth.contractors {
+				in, err := c.incomingValue(eth.ctx, tx)
+				if err != nil {
+					eth.log.Errorf("version %d contractor incomingValue error: %v", ver, err)
+					continue
+				}
+				if in > 0 {
+					incoming.Add(incoming, dexeth.GweiToWei(in))
+				}
+			}
+		} else {
+			// If non-zero outgoing value, this is a swap or a send of some
+			// type.
+			outgoing.Add(outgoing, v)
+		}
+	}
+
+	return &Balance{
+		Current:    confirmed,
+		PendingOut: outgoing,
+		PendingIn:  incoming,
+	}, nil
+}
+
+// sendToAddr sends funds to the address.
+func (eth *ExchangeWallet) sendToAddr(addr common.Address, amt uint64) (*types.Transaction, error) {
+	eth.nonceSendMtx.Lock()
+	defer eth.nonceSendMtx.Unlock()
+	txOpts, err := eth.node.txOpts(eth.ctx, amt, defaultSendGasLimit, nil)
+	if err != nil {
+		return nil, err
+	}
+	return eth.node.sendTransaction(eth.ctx, txOpts, addr, nil)
+}
+
+// swap gets a swap keyed by secretHash in the contract.
+func (eth *ExchangeWallet) swap(ctx context.Context, secretHash [32]byte, contractVer uint32) (swap *dexeth.SwapState, err error) {
+	return swap, eth.withContractor(contractVer, func(c contractor) error {
+		swap, err = c.swap(ctx, secretHash)
+		return err
+	})
+}
+
+// initiate initiates multiple swaps in the same transaction.
+func (eth *ExchangeWallet) initiate(ctx context.Context, contracts []*asset.Contract, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
+	gas := dexeth.InitGas(len(contracts), contractVer)
+	var val uint64
+	for _, c := range contracts {
+		val += c.Value
+	}
+	eth.nonceSendMtx.Lock()
+	defer eth.nonceSendMtx.Unlock()
+	txOpts, _ := eth.node.txOpts(ctx, val, gas, dexeth.GweiToWei(maxFeeRate))
+	return tx, eth.withContractor(contractVer, func(c contractor) error {
+		tx, err = c.initiate(txOpts, contracts)
+		return err
+	})
+}
+
+// estimateInitGas checks the amount of gas that is used for the
+// initialization.
+func (eth *ExchangeWallet) estimateInitGas(ctx context.Context, numSwaps int, contractVer uint32) (gas uint64, err error) {
+	return gas, eth.withContractor(contractVer, func(c contractor) error {
+		gas, err = c.estimateInitGas(ctx, numSwaps)
+		return err
+	})
+}
+
+// estimateRedeemGas checks the amount of gas that is used for the redemption.
+func (eth *ExchangeWallet) estimateRedeemGas(ctx context.Context, secrets [][32]byte, contractVer uint32) (gas uint64, err error) {
+	return gas, eth.withContractor(contractVer, func(c contractor) error {
+		gas, err = c.estimateRedeemGas(ctx, secrets)
+		return err
+	})
+}
+
+// estimateRefundGas checks the amount of gas that is used for a refund.
+func (eth *ExchangeWallet) estimateRefundGas(ctx context.Context, secretHash [32]byte, contractVer uint32) (gas uint64, err error) {
+	return gas, eth.withContractor(contractVer, func(c contractor) error {
+		gas, err = c.estimateRefundGas(ctx, secretHash)
+		return err
+	})
+}
+
+// redeem redeems a swap contract. Any on-chain failure, such as this secret not
+// matching the hash, will not cause this to error.
+func (eth *ExchangeWallet) redeem(ctx context.Context, redemptions []*asset.Redemption, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
+	eth.nonceSendMtx.Lock()
+	defer eth.nonceSendMtx.Unlock()
+	gas := dexeth.RedeemGas(len(redemptions), contractVer)
+	txOpts, _ := eth.node.txOpts(ctx, 0, gas, dexeth.GweiToWei(maxFeeRate))
+	return tx, eth.withContractor(contractVer, func(c contractor) error {
+		tx, err = c.redeem(txOpts, redemptions)
+		return err
+	})
+}
+
+// refund refunds a swap contract using the account controlled by the wallet.
+// Any on-chain failure, such as the locktime not being past, will not cause
+// this to error.
+func (eth *ExchangeWallet) refund(ctx context.Context, secretHash [32]byte, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
+	eth.nonceSendMtx.Lock()
+	defer eth.nonceSendMtx.Unlock()
+	gas := dexeth.RefundGas(contractVer)
+	txOpts, _ := eth.node.txOpts(ctx, 0, gas, dexeth.GweiToWei(maxFeeRate))
+	return tx, eth.withContractor(contractVer, func(c contractor) error {
+		tx, err = c.refund(txOpts, secretHash)
+		return err
+	})
+}
+
+// isRedeemable checks if the swap identified by secretHash is redeemable using secret.
+func (eth *ExchangeWallet) isRedeemable(secretHash [32]byte, secret [32]byte, contractVer uint32) (redeemable bool, err error) {
+	return redeemable, eth.withContractor(contractVer, func(c contractor) error {
+		redeemable, err = c.isRedeemable(secretHash, secret)
+		return err
+	})
+}
+
+// isRefundable checks if the swap identified by secretHash is refundable.
+func (eth *ExchangeWallet) isRefundable(secretHash [32]byte, contractVer uint32) (refundable bool, err error) {
+	return refundable, eth.withContractor(contractVer, func(c contractor) error {
+		refundable, err = c.isRefundable(secretHash)
+		return err
+	})
 }

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1491,7 +1491,6 @@ func (eth *ExchangeWallet) balanceWithTxPool() (*Balance, error) {
 
 	addFees := func(tx *types.Transaction) {
 		gas := new(big.Int).SetUint64(tx.Gas())
-		// For legacy transactions, GasFeeCap returns gas price
 		if gasFeeCap := tx.GasFeeCap(); gasFeeCap != nil {
 			outgoing.Add(outgoing, new(big.Int).Mul(gas, gasFeeCap))
 		} else {

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -27,9 +27,11 @@ import (
 	swapv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 var (
@@ -39,45 +41,44 @@ var (
 	testAddressA = common.HexToAddress("dd93b447f7eBCA361805eBe056259853F3912E04")
 	testAddressB = common.HexToAddress("8d83B207674bfd53B418a6E47DA148F5bFeCc652")
 	testAddressC = common.HexToAddress("2b84C791b79Ee37De042AD2ffF1A253c3ce9bc27")
+
+	ethGases = dexeth.VersionedGases[0]
+
+	tETH = &dex.Asset{
+		ID:           60,
+		Symbol:       "ETH",
+		MaxFeeRate:   100,
+		SwapSize:     ethGases.Swap,
+		SwapSizeBase: ethGases.Swap,
+		RedeemSize:   ethGases.Redeem,
+		SwapConf:     1,
+	}
 )
 
 type testNode struct {
-	acct              *accounts.Account
-	addr              common.Address
-	connectErr        error
-	bestHdr           *types.Header
-	bestHdrErr        error
-	bestBlkHash       common.Hash
-	bestBlkHashErr    error
-	blk               *types.Block
-	blkErr            error
-	syncProg          ethereum.SyncProgress
-	bal               *Balance
-	balErr            error
-	signDataErr       error
-	privKeyForSigning *ecdsa.PrivateKey
-	swapVers          map[uint32]struct{} // For SwapConfirmations -> swap. TODO for other contractor methods
-	swapMap           map[[32]byte]*dexeth.SwapState
-	swapErr           error
-	initErr           error
-	redeemErr         error
-	redeemable        bool
-	isRedeemableErr   error
-	refundErr         error
-	refundable        bool
-	lastRefund        struct {
-		tx          *types.Transaction
-		secretHash  [32]byte
-		fee         uint64
-		contractVer uint32
-	}
-	isRefundableErr error
-	nonce           uint64
-	sendToAddrTx    *types.Transaction
-	sendToAddrErr   error
-	baseFee         *big.Int
-	tip             *big.Int
-	netFeeStateErr  error
+	acct           *accounts.Account
+	addr           common.Address
+	connectErr     error
+	bestHdr        *types.Header
+	bestHdrErr     error
+	syncProg       ethereum.SyncProgress
+	bal            *big.Int
+	balErr         error
+	signDataErr    error
+	privKey        *ecdsa.PrivateKey
+	swapVers       map[uint32]struct{} // For SwapConfirmations -> swap. TODO for other contractor methods
+	swapMap        map[[32]byte]*dexeth.SwapState
+	refundable     bool
+	baseFee        *big.Int
+	tip            *big.Int
+	netFeeStateErr error
+
+	sendTxTx   *types.Transaction
+	sendTxErr  error
+	simBackend bind.ContractBackend
+	maxFeeRate *big.Int
+	pendingTxs []*types.Transaction
+	contractor *tContractor
 }
 
 func newBalance(current, in, out uint64) *Balance {
@@ -91,24 +92,40 @@ func newBalance(current, in, out uint64) *Balance {
 func (n *testNode) address() common.Address {
 	return n.addr
 }
+
 func (n *testNode) connect(ctx context.Context) error {
 	return n.connectErr
 }
+
+func (n *testNode) contractBackend() bind.ContractBackend {
+	return n.simBackend
+}
+
+func (n *testNode) chainConfig() *params.ChainConfig {
+	return params.AllEthashProtocolChanges
+}
+
+func (n *testNode) pendingTransactions() ([]*types.Transaction, error) {
+	return n.pendingTxs, nil
+}
+
+func (n *testNode) txOpts(ctx context.Context, val, maxGas uint64, maxFeeRate *big.Int) (*bind.TransactOpts, error) {
+	if maxFeeRate == nil {
+		maxFeeRate = n.maxFeeRate
+	}
+	return newTxOpts(ctx, n.addr, val, maxGas, maxFeeRate, dexeth.GweiToWei(2)), nil
+}
+
+func (n *testNode) currentFees(ctx context.Context) (baseFees, tipCap *big.Int, err error) {
+	return n.baseFee, n.tip, n.netFeeStateErr
+}
+
 func (n *testNode) shutdown() {}
 func (n *testNode) bestHeader(ctx context.Context) (*types.Header, error) {
 	return n.bestHdr, n.bestHdrErr
 }
-func (n *testNode) bestBlockHash(ctx context.Context) (common.Hash, error) {
-	return n.bestBlkHash, n.bestBlkHashErr
-}
-func (n *testNode) block(ctx context.Context, hash common.Hash) (*types.Block, error) {
-	return n.blk, n.blkErr
-}
-func (n *testNode) balance(ctx context.Context) (*Balance, error) {
+func (n *testNode) addressBalance(ctx context.Context, addr common.Address) (*big.Int, error) {
 	return n.bal, n.balErr
-}
-func (n *testNode) syncStatus(ctx context.Context) (bool, float32, error) {
-	return false, 0, nil
 }
 func (n *testNode) unlock(pw string) error {
 	return nil
@@ -125,79 +142,25 @@ func (n *testNode) syncProgress() ethereum.SyncProgress {
 func (n *testNode) peerCount() uint32 {
 	return 1
 }
-func (n *testNode) netFeeState(ctx context.Context) (baseFees, tipCap *big.Int, err error) {
-	return n.baseFee, n.tip, n.netFeeStateErr
-}
-
-// initiate is not concurrent safe
-func (n *testNode) initiate(ctx context.Context, contracts []*asset.Contract, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
-	if n.initErr != nil {
-		return nil, n.initErr
-	}
-	tx = types.NewTx(&types.DynamicFeeTx{})
-	n.nonce++
-	return types.NewTx(&types.DynamicFeeTx{
-		Nonce: n.nonce,
-	}), nil
-}
-func (n *testNode) isRedeemable(secretHash [32]byte, secret [32]byte, contractVer uint32) (redeemable bool, err error) {
-	return n.redeemable, n.isRedeemableErr
-}
-func (n *testNode) redeem(ctx context.Context, redemptions []*asset.Redemption, maxFeeRate uint64, contractVer uint32) (*types.Transaction, error) {
-	if n.redeemErr != nil {
-		return nil, n.redeemErr
-	}
-	n.nonce++
-	return types.NewTx(&types.DynamicFeeTx{
-		Nonce: n.nonce,
-	}), nil
-}
-func (n *testNode) refund(ctx context.Context, secretHash [32]byte, maxFeeRate uint64, contractVer uint32) (tx *types.Transaction, err error) {
-	if n.refundErr != nil {
-		return nil, n.refundErr
-	}
-	n.nonce++
-	n.lastRefund.secretHash = secretHash
-	n.lastRefund.fee = maxFeeRate
-	n.lastRefund.contractVer = contractVer
-	n.lastRefund.tx = types.NewTx(&types.DynamicFeeTx{
-		Nonce: n.nonce,
-	})
-	return n.lastRefund.tx, nil
-}
-func (n *testNode) isRefundable(secretHash [32]byte, contractVer uint32) (isRefundable bool, err error) {
-	return n.refundable, n.isRefundableErr
-}
-func (n *testNode) swap(ctx context.Context, secretHash [32]byte, contractVer uint32) (*dexeth.SwapState, error) {
-	if n.swapErr != nil {
-		return nil, n.swapErr
-	}
-	swap, ok := n.swapMap[secretHash]
-	if !ok {
-		return nil, errors.New("swap not in map")
-	}
-	_, found := n.swapVers[contractVer]
-	if !found {
-		return nil, errors.New("unknown contract version")
-	}
-	return swap, nil
-}
 
 func (n *testNode) signData(data []byte) (sig, pubKey []byte, err error) {
 	if n.signDataErr != nil {
 		return nil, nil, n.signDataErr
 	}
 
-	if n.privKeyForSigning == nil {
+	if n.privKey == nil {
 		return nil, nil, nil
 	}
 
-	sig, err = crypto.Sign(crypto.Keccak256(data), n.privKeyForSigning)
+	sig, err = crypto.Sign(crypto.Keccak256(data), n.privKey)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return sig, crypto.FromECDSAPub(&n.privKeyForSigning.PublicKey), nil
+	return sig, crypto.FromECDSAPub(&n.privKey.PublicKey), nil
+}
+func (n *testNode) sendTransaction(ctx context.Context, txOpts *bind.TransactOpts, to common.Address, data []byte) (*types.Transaction, error) {
+	return n.sendTxTx, n.sendTxErr
 }
 func (n *testNode) sendSignedTransaction(ctx context.Context, tx *types.Transaction) error {
 	return nil
@@ -213,39 +176,113 @@ func tTx(gasFeeCap, gasTipCap, value uint64, to *common.Address, data []byte) *t
 	})
 }
 
-func (n *testNode) sendToAddr(ctx context.Context, addr common.Address, val uint64) (*types.Transaction, error) {
-	return n.sendToAddrTx, n.sendToAddrErr
-}
-
 func (n *testNode) transactionConfirmations(context.Context, common.Hash) (uint32, error) {
 	return 0, nil
 }
 
+type tContractor struct {
+	gasEstimates  *dexeth.Gases
+	swapMap       map[[32]byte]*dexeth.SwapState
+	swapErr       error
+	initTx        *types.Transaction
+	initErr       error
+	redeemTx      *types.Transaction
+	redeemErr     error
+	refundTx      *types.Transaction
+	refundErr     error
+	initGasErr    error
+	redeemGasErr  error
+	refundGasErr  error
+	redeemable    bool
+	redeemableErr error
+	valueIn       map[common.Hash]uint64
+	// valueOut      uint64
+	valueErr      error
+	refundable    bool
+	refundableErr error
+	lastRefund    struct {
+		// tx          *types.Transaction
+		secretHash [32]byte
+		maxFeeRate *big.Int
+		// contractVer uint32
+	}
+}
+
+func tNewContractor(g *dexeth.Gases) *tContractor {
+	return &tContractor{
+		gasEstimates: g,
+		swapMap:      make(map[[32]byte]*dexeth.SwapState),
+		valueIn:      make(map[common.Hash]uint64),
+	}
+}
+
+func (c *tContractor) swap(ctx context.Context, secretHash [32]byte) (*dexeth.SwapState, error) {
+	if c.swapErr != nil {
+		return nil, c.swapErr
+	}
+	swap, ok := c.swapMap[secretHash]
+	if !ok {
+		return nil, errors.New("swap not in map")
+	}
+	return swap, nil
+}
+
+func (c *tContractor) initiate(*bind.TransactOpts, []*asset.Contract) (*types.Transaction, error) {
+	return c.initTx, c.initErr
+}
+
+func (c *tContractor) redeem(txOpts *bind.TransactOpts, redeems []*asset.Redemption) (*types.Transaction, error) {
+	return c.redeemTx, c.redeemErr
+}
+
+func (c *tContractor) refund(opts *bind.TransactOpts, secretHash [32]byte) (*types.Transaction, error) {
+	c.lastRefund.secretHash = secretHash
+	c.lastRefund.maxFeeRate = opts.GasFeeCap
+	return c.refundTx, c.refundErr
+}
+
+func (c *tContractor) estimateInitGas(ctx context.Context, n int) (uint64, error) {
+	return c.gasEstimates.SwapN(n), c.initGasErr
+}
+
+func (c *tContractor) estimateRedeemGas(ctx context.Context, secrets [][32]byte) (uint64, error) {
+	return c.gasEstimates.RedeemN(len(secrets)), c.redeemGasErr
+}
+
+func (c *tContractor) estimateRefundGas(ctx context.Context, secretHash [32]byte) (uint64, error) {
+	return c.gasEstimates.Refund, c.refundGasErr
+}
+
+func (c *tContractor) isRedeemable(secretHash, secret [32]byte) (bool, error) {
+	return c.redeemable, c.redeemableErr
+}
+
+func (c *tContractor) incomingValue(_ context.Context, tx *types.Transaction) (incoming uint64, err error) {
+	return c.valueIn[tx.Hash()], c.valueErr
+}
+
+func (c *tContractor) isRefundable(secretHash [32]byte) (bool, error) {
+	return c.refundable, c.refundableErr
+}
+
 func TestCheckForNewBlocks(t *testing.T) {
 	header0 := &types.Header{Number: new(big.Int)}
-	block0 := types.NewBlockWithHeader(header0)
 	header1 := &types.Header{Number: big.NewInt(1)}
-	block1 := types.NewBlockWithHeader(header1)
 	tests := []struct {
 		name                  string
 		hashErr, blockErr     error
-		bestHash              common.Hash
+		bestHeader            *types.Header
 		wantErr, hasTipChange bool
 	}{{
 		name:         "ok",
-		bestHash:     block1.Hash(),
+		bestHeader:   header1,
 		hasTipChange: true,
 	}, {
-		name:     "ok same hash",
-		bestHash: block0.Hash(),
-	}, {
-		name:         "best hash error",
-		hasTipChange: true,
-		hashErr:      errors.New(""),
-		wantErr:      true,
+		name:       "ok same hash",
+		bestHeader: header0,
 	}, {
 		name:         "block error",
-		bestHash:     block1.Hash(),
+		bestHeader:   header1,
 		hasTipChange: true,
 		blockErr:     errors.New(""),
 		wantErr:      true,
@@ -260,19 +297,18 @@ func TestCheckForNewBlocks(t *testing.T) {
 			close(blocker)
 		}
 		node := &testNode{}
-		node.bestBlkHash = test.bestHash
-		node.blk = block1
-		node.bestBlkHashErr = test.hashErr
-		node.blkErr = test.blockErr
-		eth := &ExchangeWallet{
+
+		node.bestHdr = test.bestHeader
+		node.bestHdrErr = test.blockErr
+		w := &ExchangeWallet{
 			node:       node,
 			addr:       node.address(),
-			tipChange:  tipChange,
 			ctx:        ctx,
-			currentTip: block0,
 			log:        tLogger,
+			currentTip: header0,
+			tipChange:  tipChange,
 		}
-		eth.checkForNewBlocks()
+		w.checkForNewBlocks()
 
 		if test.hasTipChange {
 			<-blocker
@@ -354,37 +390,42 @@ func TestSyncStatus(t *testing.T) {
 	}
 }
 
-func newTestNode(acct *accounts.Account) *testNode {
-	if acct == nil {
-		acct = new(accounts.Account)
+func newTestNode() *testNode {
+	privKey, _ := crypto.HexToECDSA("9447129055a25c8496fca9e5ee1b9463e47e6043ff0c288d07169e8284860e34")
+	addr := common.HexToAddress("2b84C791b79Ee37De042AD2ffF1A253c3ce9bc27")
+	acct := &accounts.Account{
+		Address: addr,
 	}
 	return &testNode{
-		acct: acct,
-		addr: acct.Address,
+		acct:       acct,
+		addr:       acct.Address,
+		maxFeeRate: dexeth.GweiToWei(100),
+		baseFee:    dexeth.GweiToWei(100),
+		tip:        dexeth.GweiToWei(2),
+		privKey:    privKey,
+		contractor: tNewContractor(ethGases),
 	}
 }
 
-func TestBalance(t *testing.T) {
-	// maxInt := ^uint64(0)
-	// maxWei := new(big.Int).SetUint64(maxInt)
-	// gweiFactorBig := big.NewInt(dexeth.GweiFactor)
-	// maxWei.Mul(maxWei, gweiFactorBig)
-	// overMaxWei := new(big.Int).Set(maxWei)
-	// overMaxWei.Add(overMaxWei, gweiFactorBig)
+func tAssetWallet() (*ExchangeWallet, *testNode, context.CancelFunc) {
+	node := newTestNode()
+	ctx, cancel := context.WithCancel(context.Background())
+	w := &ExchangeWallet{
+		addr:               node.addr,
+		node:               node,
+		ctx:                ctx,
+		log:                tLogger,
+		gasFeeLimit:        defaultGasFeeLimit,
+		contractors:        map[uint32]contractor{0: node.contractor},
+		findRedemptionReqs: make(map[[32]byte]*findRedemptionRequest),
+	}
 
+	return w, node, cancel
+}
+
+func TestBalance(t *testing.T) {
 	tinyBal := newBalance(0, 0, 0)
 	tinyBal.Current = big.NewInt(dexeth.GweiFactor - 1)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	node := &testNode{}
-	node.swapMap = make(map[[32]byte]*dexeth.SwapState)
-	eth := &ExchangeWallet{
-		node: node,
-		ctx:  ctx,
-		log:  tLogger,
-		addr: testAddressA,
-	}
 
 	tests := []struct {
 		name         string
@@ -424,10 +465,6 @@ func TestBalance(t *testing.T) {
 		wantLocked:   0,
 		wantImmature: 2e8,
 	}, {
-		// 	name: "swap error",
-		// 	swapErr: errors.New("swap error"),
-		// 	wantErr: true,
-		// }, {
 		// 	name:         "ok max int",
 		// 	bal:          maxWei,
 		// 	pendingTxs:   []*types.Transaction{},
@@ -440,14 +477,40 @@ func TestBalance(t *testing.T) {
 		// 	wantErr:    true,
 		// }, {
 		name:    "node balance error",
+		bal:     newBalance(0, 0, 0),
 		balErr:  errors.New(""),
 		wantErr: true,
 	}}
 
 	for _, test := range tests {
+		eth, node, shutdown := tAssetWallet()
+		defer shutdown()
 
-		node.bal = test.bal
+		node.bal = test.bal.Current
 		node.balErr = test.balErr
+
+		var nonce uint64
+		newTx := func(value *big.Int) *types.Transaction {
+			nonce++
+			signer := types.LatestSignerForChainID(node.chainConfig().ChainID)
+			tx, err := types.SignTx(types.NewTx(&types.DynamicFeeTx{
+				Nonce: nonce,
+				Value: value,
+			}), signer, node.privKey)
+			if err != nil {
+				t.Fatalf("SignTx error: %v", err)
+			}
+			return tx
+		}
+
+		if test.bal.PendingIn.Cmp(new(big.Int)) > 0 {
+			tx := newTx(new(big.Int))
+			node.pendingTxs = append(node.pendingTxs, tx)
+			node.contractor.valueIn[tx.Hash()] = dexeth.WeiToGwei(test.bal.PendingIn)
+		}
+		if test.bal.PendingOut.Cmp(new(big.Int)) > 0 {
+			node.pendingTxs = append(node.pendingTxs, newTx(test.bal.PendingOut))
+		}
 
 		bal, err := eth.Balance()
 		if test.wantErr {
@@ -518,133 +581,118 @@ func TestFeeRate(t *testing.T) {
 }
 
 func TestRefund(t *testing.T) {
-	node := &testNode{
-		swapVers: map[uint32]struct{}{
-			0: {},
-			1: {},
-		},
-		swapMap: make(map[[32]byte]*dexeth.SwapState),
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	eth := &ExchangeWallet{
-		node: node,
-		ctx:  ctx,
-		addr: testAddressA,
-		log:  tLogger,
-	}
+	eth, node, shutdown := tAssetWallet()
+	defer shutdown()
 
-	gasesV0 := dexeth.VersionedGases[0]
+	const feeSuggestion = 100
+	const gweiBal = 1e9
+	const ogRefundReserves = 1e8
+
 	gasesV1 := &dexeth.Gases{Refund: 1e5}
 	dexeth.VersionedGases[1] = gasesV1
+	v1Contractor := tNewContractor(gasesV1)
 
-	var randomSecretHash [32]byte
-	copy(randomSecretHash[:], encode.RandomBytes(32))
-	randomContractDataV0 := dexeth.EncodeContractData(0, randomSecretHash)
-	randomContractDataV1 := dexeth.EncodeContractData(1, randomSecretHash)
-
+	var secretHash [32]byte
+	copy(secretHash[:], encode.RandomBytes(32))
+	v0Contract := dexeth.EncodeContractData(0, secretHash)
 	ss := new(dexeth.SwapState)
-	node.swapMap[randomSecretHash] = ss
+	v0Contractor := node.contractor
+	v0Contractor.swapMap[secretHash] = ss
+	v1Contractor.swapMap[secretHash] = ss
 
 	tests := []struct {
-		name                   string
-		contract               dex.Bytes
-		swapStep               dexeth.SwapStep
-		feeSuggestion          uint64
-		originalRefundReserves uint64
-		wantRefundReserves     uint64
-		isRefundable           bool
-		isRefundableErr        error
-		refundErr              error
-		swapErr                error
-		originalBalance        *Balance
-		wantZeroHash           bool
-		wantErr                bool
+		name            string
+		badContract     bool
+		isRefundable    bool
+		isRefundableErr error
+		refundErr       error
+		wantLocked      uint64
+		wantErr         bool
+		wantZeroHash    bool
+		swapStep        dexeth.SwapStep
+		swapErr         error
+		useV1Gases      bool
 	}{
 		{
-			name:                   "ok v0",
-			contract:               randomContractDataV0,
-			swapStep:               dexeth.SSInitiated,
-			isRefundable:           true,
-			feeSuggestion:          100,
-			originalBalance:        newBalance(1e9, 0, 0),
-			originalRefundReserves: 1e8,
-			wantRefundReserves:     1e8 - 100*gasesV0.Refund,
+			name:         "ok",
+			swapStep:     dexeth.SSInitiated,
+			isRefundable: true,
+			wantLocked:   ogRefundReserves - feeSuggestion*dexeth.RefundGas(0),
 		},
 		{
-			name:                   "ok v1",
-			contract:               randomContractDataV1,
-			swapStep:               dexeth.SSInitiated,
-			isRefundable:           true,
-			feeSuggestion:          100,
-			originalBalance:        newBalance(1e9, 0, 0),
-			originalRefundReserves: 1e8,
-			wantRefundReserves:     1e8 - 100*gasesV1.Refund,
+			name:         "ok v1",
+			swapStep:     dexeth.SSInitiated,
+			isRefundable: true,
+			wantLocked:   ogRefundReserves - feeSuggestion*dexeth.RefundGas(1),
+			useV1Gases:   true,
 		},
 		{
-			name:                   "ok refunded",
-			contract:               randomContractDataV0,
-			swapStep:               dexeth.SSRefunded,
-			isRefundable:           true,
-			feeSuggestion:          100,
-			originalBalance:        newBalance(1e9, 0, 0),
-			originalRefundReserves: 1e8,
-			wantRefundReserves:     1e8 - 100*gasesV0.Refund,
-			wantZeroHash:           true,
+			name:         "ok refunded",
+			swapStep:     dexeth.SSRefunded,
+			isRefundable: true,
+			wantLocked:   ogRefundReserves - feeSuggestion*dexeth.RefundGas(0),
+			wantZeroHash: true,
 		},
 		{
 			name:     "swap error",
-			contract: randomContractDataV0,
 			swapStep: dexeth.SSInitiated,
 			swapErr:  errors.New(""),
 			wantErr:  true,
 		},
 		{
 			name:            "is refundable error",
-			contract:        randomContractDataV0,
 			isRefundable:    true,
 			isRefundableErr: errors.New(""),
-			feeSuggestion:   100,
-			originalBalance: newBalance(1e9, 0, 0),
 			wantErr:         true,
 		},
 		{
-			name:            "is refundable false",
-			contract:        randomContractDataV0,
-			isRefundable:    false,
-			feeSuggestion:   100,
-			originalBalance: newBalance(1e9, 0, 0),
-			wantErr:         true,
+			name:         "is refundable false",
+			isRefundable: false,
+			wantErr:      true,
 		},
 		{
-			name:            "refund error",
-			contract:        randomContractDataV0,
-			isRefundable:    true,
-			refundErr:       errors.New(""),
-			feeSuggestion:   100,
-			originalBalance: newBalance(1e9, 0, 0),
-			wantErr:         true,
+			name:         "refund error",
+			isRefundable: true,
+			refundErr:    errors.New(""),
+			wantErr:      true,
 		},
 		{
-			name:            "cannot decode contract",
-			contract:        []byte{},
-			isRefundable:    true,
-			feeSuggestion:   100,
-			originalBalance: newBalance(1e9, 0, 0),
-			wantErr:         true,
+			name:         "cannot decode contract",
+			badContract:  true,
+			isRefundable: true,
+			wantErr:      true,
 		},
 	}
 
 	for _, test := range tests {
-		node.refundable = test.isRefundable
-		node.isRefundableErr = test.isRefundableErr
-		node.refundErr = test.refundErr
-		node.bal = test.originalBalance
-		node.swapErr = test.swapErr
-		ss.State = test.swapStep
-		eth.lockedFunds.refundReserves = test.originalRefundReserves
+		contract := v0Contract
+		node.contractor = v0Contractor
+		if test.useV1Gases {
+			contract = dexeth.EncodeContractData(1, secretHash)
+			node.contractor = v1Contractor
+			eth.contractors[1] = node.contractor
+			defer delete(eth.contractors, 1)
+		} else if test.badContract {
+			contract = []byte{}
+		}
 
-		id, err := eth.Refund(nil, test.contract, test.feeSuggestion)
+		node.contractor.refundable = test.isRefundable
+		node.contractor.refundableErr = test.isRefundableErr
+		node.contractor.refundErr = test.refundErr
+		node.bal = dexeth.GweiToWei(gweiBal)
+		node.contractor.swapErr = test.swapErr
+		ss.State = test.swapStep
+		eth.lockedFunds.refundReserves = ogRefundReserves
+
+		var txHash common.Hash
+		if test.isRefundable {
+			tx := types.NewTx(&types.DynamicFeeTx{})
+			txHash = tx.Hash()
+			node.contractor.refundTx = tx
+		}
+
+		refundID, err := eth.Refund(nil, contract, feeSuggestion)
+
 		if test.wantErr {
 			if err == nil {
 				t.Fatalf(`%v: expected error but did not get: %v`, test.name, err)
@@ -658,39 +706,28 @@ func TestRefund(t *testing.T) {
 		if test.wantZeroHash {
 			// No on chain refund expected if status was already refunded.
 			zeroHash := common.Hash{}
-			if !bytes.Equal(id, zeroHash[:]) {
-				t.Fatalf(`%v: expected refund tx hash: %x = returned id: %x`, test.name, zeroHash, id)
+			if !bytes.Equal(refundID, zeroHash[:]) {
+				t.Fatalf(`%v: expected refund tx hash: %x = returned id: %s`, test.name, zeroHash, refundID)
 			}
 		} else {
-			lastTxHash := node.lastRefund.tx.Hash()
-			if !bytes.Equal(id, lastTxHash[:]) {
-				t.Fatalf(`%v: expected refund tx hash: %x = returned id: %x`, test.name, lastTxHash, id)
+			if !bytes.Equal(refundID, txHash[:]) {
+				t.Fatalf(`%v: expected refund tx hash: %x = returned id: %s`, test.name, txHash, refundID)
 			}
 
-			contractVer, secretHash, err := dexeth.DecodeContractData(test.contract)
-			if err != nil {
-				t.Fatalf(`%v: error decoding versioned secret hash: %v`, test.name, err)
-			}
-
-			if secretHash != node.lastRefund.secretHash {
+			if secretHash != node.contractor.lastRefund.secretHash {
 				t.Fatalf(`%v: secret hash in contract %x != used to call refund %x`,
-					test.name, secretHash, node.lastRefund.secretHash)
+					test.name, secretHash, node.contractor.lastRefund.secretHash)
 			}
 
-			if contractVer != node.lastRefund.contractVer {
-				t.Fatalf(`%v: contract version %v != used to call refund %v`,
-					test.name, contractVer, node.lastRefund.contractVer)
-			}
-
-			if test.feeSuggestion != node.lastRefund.fee {
+			if dexeth.GweiToWei(feeSuggestion).Cmp(node.contractor.lastRefund.maxFeeRate) != 0 {
 				t.Fatalf(`%v: fee suggestion %v != used to call refund %v`,
-					test.name, test.feeSuggestion, node.lastRefund.fee)
+					test.name, dexeth.GweiToWei(feeSuggestion), node.contractor.lastRefund.maxFeeRate)
 			}
 		}
 
-		if test.wantRefundReserves != eth.lockedFunds.refundReserves {
+		if test.wantLocked > 0 && eth.lockedFunds.refundReserves != test.wantLocked {
 			t.Fatalf("%v: refund reserves %v != expected %v",
-				test.name, eth.lockedFunds.refundReserves, test.wantRefundReserves)
+				test.name, eth.lockedFunds.refundReserves, test.wantLocked)
 		}
 	}
 }
@@ -710,22 +747,10 @@ func (b *badCoin) Value() uint64 {
 }
 
 func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	eth, node, shutdown := tAssetWallet()
+	defer shutdown()
 	walletBalanceGwei := uint64(dexeth.GweiFactor)
-	address := "0xB6De8BB5ed28E6bE6d671975cad20C03931bE981"
-	account := accounts.Account{
-		Address: common.HexToAddress(address),
-	}
-	node := newTestNode(&account)
-	node.bal = newBalance(walletBalanceGwei, 0, 0)
-	eth := &ExchangeWallet{
-		node:        node,
-		addr:        node.address(),
-		ctx:         ctx,
-		log:         tLogger,
-		gasFeeLimit: 200,
-	}
+	node.bal = dexeth.GweiToWei(walletBalanceGwei)
 
 	checkBalance := func(wallet *ExchangeWallet, expectedAvailable, expectedLocked uint64, testName string) {
 		t.Helper()
@@ -773,30 +798,26 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 			t.Fatalf("%s: unexpected error: %v", test.testName, err)
 		}
 		if coins[0].Value() != test.coinValue {
-			t.Fatalf("%s: expected %v but got %v", test.testName, test.coinValue, coins[0].Value())
+			t.Fatalf("%s: wrong value. expected %v but got %v", test.testName, test.coinValue, coins[0].Value())
 		}
 	}
 
 	order := asset.Order{
 		Value:        500000000,
 		MaxSwapCount: 2,
-		DEXConfig: &dex.Asset{
-			ID:         60,
-			Symbol:     "ETH",
-			Version:    0,
-			MaxFeeRate: 150,
-			SwapSize:   180000,
-		},
+		DEXConfig:    tETH,
 	}
 
 	// Test fund order with less than available funds
 	coins1, redeemScripts1, err := eth.FundOrder(&order)
 	expectedOrderFees := order.DEXConfig.SwapSize * order.DEXConfig.MaxFeeRate * order.MaxSwapCount
+	expectedFees := expectedOrderFees
 	expectedCoinValue := order.Value + expectedOrderFees
+
 	checkFundOrderResult(coins1, redeemScripts1, err, fundOrderTest{
 		testName:    "more than enough",
 		coinValue:   expectedCoinValue,
-		coinAddress: address,
+		coinAddress: node.addr.String(),
 	})
 	checkBalance(eth, walletBalanceGwei-expectedCoinValue, expectedCoinValue, "more than enough")
 
@@ -814,8 +835,8 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 	coins2, redeemScripts2, err := eth.FundOrder(&order)
 	checkFundOrderResult(coins2, redeemScripts2, err, fundOrderTest{
 		testName:    "just enough",
-		coinValue:   order.Value + expectedOrderFees,
-		coinAddress: address,
+		coinValue:   order.Value + expectedFees,
+		coinAddress: node.addr.String(),
 	})
 	checkBalance(eth, 0, walletBalanceGwei, "just enough")
 
@@ -864,12 +885,9 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 	}
 	eth.gasFeeLimit = tmpGasFeeLimit
 
-	eth2 := &ExchangeWallet{
-		node: node,
-		addr: node.address(),
-		ctx:  ctx,
-		log:  tLogger,
-	}
+	eth2, _, shutdown2 := tAssetWallet()
+	defer shutdown2()
+	eth2.node = node
 
 	// Test reloading coins from first order
 	coins, err = eth2.FundingCoins([]dex.Bytes{parseRecoveryID(coins1[0])})
@@ -910,7 +928,13 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 	})
 	_, err = eth2.FundingCoins([]dex.Bytes{differentKindaCoin.ID()})
 	if err == nil {
-		t.Fatalf("expected error but did not get")
+		t.Fatalf("expected error for unknown coin id format, but did not get")
+	}
+
+	differentAddressCoin := createFundingCoin(differentAddress, 100000)
+	_, err = eth2.FundingCoins([]dex.Bytes{differentAddressCoin.ID()})
+	if err == nil {
+		t.Fatalf("expected error for wrong address, but did not get")
 	}
 	checkBalance(eth2, walletBalanceGwei-coins1[0].Value(), coins1[0].Value(), "after funding error 4")
 
@@ -936,10 +960,15 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 	}
 	checkBalance(eth2, 0, walletBalanceGwei, "funding2")
 
-	// return coin with incorrect address
+	// return coin with wrong kind and incorrect address
 	err = eth2.ReturnCoins([]asset.Coin{differentKindaCoin})
 	if err == nil {
-		t.Fatalf("expected error but did not get")
+		t.Fatalf("expected error for unknown coin ID format, but did not get")
+	}
+
+	err = eth2.ReturnCoins([]asset.Coin{differentAddressCoin})
+	if err == nil {
+		t.Fatalf("expected error for wrong address, but did not get")
 	}
 
 	// return all coins
@@ -958,16 +987,16 @@ func TestFundOrderReturnCoinsFundingCoins(t *testing.T) {
 }
 
 func TestPreSwap(t *testing.T) {
-	gases := dexeth.VersionedGases[0]
+	const feeSuggestion = 90
+	const lotSize = 10e9
+	oneFee := ethGases.Swap * tETH.MaxFeeRate
+	oneLock := lotSize + oneFee
 
 	tests := []struct {
-		name          string
-		bal           uint64
-		balErr        error
-		lotSize       uint64
-		maxFeeRate    uint64
-		feeSuggestion uint64
-		lots          uint64
+		name   string
+		bal    uint64
+		balErr error
+		lots   uint64
 
 		wantErr       bool
 		wantLots      uint64
@@ -977,105 +1006,70 @@ func TestPreSwap(t *testing.T) {
 		wantBestCase  uint64
 	}{
 		{
-			name:          "no balance",
-			bal:           0,
-			lotSize:       ethToGwei(10),
-			feeSuggestion: 90,
-			maxFeeRate:    100,
-			lots:          1,
+			name: "no balance",
+			bal:  0,
+			lots: 1,
 
 			wantErr: true,
 		},
 		{
-			name:          "not enough for fees",
-			bal:           10,
-			lotSize:       ethToGwei(10),
-			feeSuggestion: 90,
-			maxFeeRate:    100,
-			lots:          1,
+			name: "not enough for fees",
+			bal:  lotSize,
+			lots: 1,
 
 			wantErr: true,
 		},
 		{
-			name:          "one lot enough for fees",
-			bal:           11,
-			lotSize:       ethToGwei(10),
-			feeSuggestion: 90,
-			maxFeeRate:    100,
-			lots:          1,
+			name: "one lot enough for fees",
+			bal:  oneLock,
+			lots: 1,
 
 			wantLots:      1,
-			wantValue:     ethToGwei(10),
-			wantMaxFees:   100 * gases.Swap,
-			wantBestCase:  90 * gases.Swap,
-			wantWorstCase: 90 * gases.Swap,
+			wantValue:     lotSize,
+			wantMaxFees:   tETH.MaxFeeRate * ethGases.Swap,
+			wantBestCase:  feeSuggestion * ethGases.Swap,
+			wantWorstCase: feeSuggestion * ethGases.Swap,
 		},
 		{
-			name:          "more lots than max lots",
-			bal:           11,
-			lotSize:       ethToGwei(10),
-			feeSuggestion: 90,
-			maxFeeRate:    100,
-			lots:          2,
+			name: "more lots than max lots",
+			bal:  oneLock*2 - 1,
+			lots: 2,
 
 			wantErr: true,
 		},
 		{
-			name:          "less than max lots",
-			bal:           51,
-			lotSize:       ethToGwei(10),
-			feeSuggestion: 90,
-			maxFeeRate:    100,
-			lots:          4,
+			name: "fewer than max lots",
+			bal:  10 * oneLock,
+			lots: 4,
 
 			wantLots:      4,
-			wantValue:     ethToGwei(40),
-			wantMaxFees:   4 * 100 * gases.Swap,
-			wantBestCase:  90 * gases.SwapN(4),
-			wantWorstCase: 4 * 90 * gases.Swap,
+			wantValue:     4 * lotSize,
+			wantMaxFees:   4 * tETH.MaxFeeRate * ethGases.Swap,
+			wantBestCase:  feeSuggestion * ethGases.SwapN(4),
+			wantWorstCase: 4 * feeSuggestion * ethGases.Swap,
 		},
 		{
-			name:          "balanceError",
-			bal:           51,
-			lotSize:       ethToGwei(10),
-			feeSuggestion: 90,
-			maxFeeRate:    100,
-			balErr:        errors.New(""),
-			lots:          1,
+			name:   "balanceError",
+			bal:    5 * lotSize,
+			balErr: errors.New(""),
+			lots:   1,
 
 			wantErr: true,
 		},
-	}
-
-	dexAsset := dex.Asset{
-		ID:           60,
-		Symbol:       "ETH",
-		MaxFeeRate:   100,
-		SwapSize:     gases.Swap,
-		SwapSizeBase: 0,
-		SwapConf:     1,
 	}
 
 	for _, test := range tests {
-		ctx, cancel := context.WithCancel(context.Background())
-		preSwapForm := asset.PreSwapForm{
-			LotSize:       test.lotSize,
-			Lots:          test.lots,
-			AssetConfig:   &dexAsset,
-			FeeSuggestion: test.feeSuggestion,
-		}
-		node := newTestNode(nil)
-		node.bal = newBalance(test.bal*1e9, 0, 0)
+		eth, node, shutdown := tAssetWallet()
+		defer shutdown()
+		node.bal = dexeth.GweiToWei(test.bal)
 		node.balErr = test.balErr
-		eth := &ExchangeWallet{
-			node: node,
-			addr: node.address(),
-			ctx:  ctx,
-			log:  tLogger,
-		}
-		dexAsset.MaxFeeRate = test.maxFeeRate
-		preSwap, err := eth.PreSwap(&preSwapForm)
-		cancel()
+
+		preSwap, err := eth.PreSwap(&asset.PreSwapForm{
+			LotSize:       lotSize,
+			Lots:          test.lots,
+			AssetConfig:   tETH,
+			FeeSuggestion: feeSuggestion,
+		})
 
 		if test.wantErr {
 			if err == nil {
@@ -1106,31 +1100,22 @@ func TestPreSwap(t *testing.T) {
 }
 
 func TestSwap(t *testing.T) {
-	node := &testNode{
-		bal: newBalance(0, 0, 0),
-	}
-	address := "0xB6De8BB5ed28E6bE6d671975cad20C03931bE981"
+	eth, node, shutdown := tAssetWallet()
+	defer shutdown()
 	receivingAddress := "0x2b84C791b79Ee37De042AD2ffF1A253c3ce9bc27"
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	eth := &ExchangeWallet{
-		node: node,
-		addr: common.HexToAddress(address),
-		ctx:  ctx,
-		log:  tLogger,
-	}
+	node.contractor.initTx = types.NewTx(&types.DynamicFeeTx{})
 
 	coinIDsForAmounts := func(coinAmounts []uint64) []dex.Bytes {
 		coinIDs := make([]dex.Bytes, 0, len(coinAmounts))
 		for _, amt := range coinAmounts {
-			fundingCoinID := createFundingCoinID(eth.addr, amt)
-			coinIDs = append(coinIDs, fundingCoinID.Encode())
+			fundingCoinID := createFundingCoin(eth.addr, amt)
+			coinIDs = append(coinIDs, fundingCoinID.ID())
 		}
 		return coinIDs
 	}
 
 	refreshWalletAndFundCoins := func(ethBalance uint64, coinAmounts []uint64) asset.Coins {
-		node.bal.Current = ethToWei(ethBalance)
+		node.bal = ethToWei(ethBalance)
 		eth.lockedFunds.initiateReserves = 0
 		eth.lockedFunds.redemptionReserves = 0
 		eth.lockedFunds.refundReserves = 0
@@ -1147,6 +1132,7 @@ func TestSwap(t *testing.T) {
 	}
 
 	testSwap := func(testName string, swaps asset.Swaps, expectError bool) {
+		t.Helper()
 		originalBalance, err := eth.Balance()
 		if err != nil {
 			t.Fatalf("%v: error getting balance: %v", testName, err)
@@ -1248,7 +1234,7 @@ func TestSwap(t *testing.T) {
 	expiration := encode.UnixMilliU(time.Now().Add(time.Hour * 8))
 
 	// Ensure error when initializing swap errors
-	node.initErr = errors.New("")
+	node.contractor.initErr = errors.New("")
 	contracts := []*asset.Contract{
 		{
 			Address:    receivingAddress,
@@ -1265,7 +1251,7 @@ func TestSwap(t *testing.T) {
 		LockChange: false,
 	}
 	testSwap("error initialize but no send", swaps, true)
-	node.initErr = nil
+	node.contractor.initErr = nil
 
 	// Tests one contract without locking change
 	contracts = []*asset.Contract{
@@ -1341,7 +1327,7 @@ func TestSwap(t *testing.T) {
 }
 
 func TestPreRedeem(t *testing.T) {
-	node := newTestNode(nil)
+	node := newTestNode()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	eth := &ExchangeWallet{
@@ -1365,24 +1351,23 @@ func TestPreRedeem(t *testing.T) {
 }
 
 func TestRedeem(t *testing.T) {
+	eth, node, shutdown := tAssetWallet()
+	defer shutdown()
+
 	// Test with a non-zero contract version to ensure it makes it into the receipt
 	contractVer := uint32(1)
-	dexeth.VersionedGases[1] = dexeth.VersionedGases[0] // for dexeth.RedeemGas(..., 1)
+	dexeth.VersionedGases[1] = ethGases // for dexeth.RedeemGas(..., 1)
 	defer delete(dexeth.VersionedGases, 1)
-	node := &testNode{
-		swapVers: map[uint32]struct{}{
-			contractVer: {},
-		},
-		swapMap: make(map[[32]byte]*dexeth.SwapState),
+
+	node.bal = dexeth.GweiToWei(10e9)
+
+	contractorV1 := &tContractor{
+		swapMap:      make(map[[32]byte]*dexeth.SwapState, 1),
+		gasEstimates: ethGases,
+		redeemTx:     types.NewTx(&types.DynamicFeeTx{}),
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	eth := &ExchangeWallet{
-		node: node,
-		ctx:  ctx,
-		log:  tLogger,
-		addr: testAddressA,
-	}
+	eth.contractors[1] = contractorV1
+
 	addSwapToSwapMap := func(secretHash [32]byte, value uint64, step dexeth.SwapStep) {
 		swap := dexeth.SwapState{
 			BlockHeight: 1,
@@ -1392,7 +1377,7 @@ func TestRedeem(t *testing.T) {
 			Value:       value,
 			State:       step,
 		}
-		node.swapMap[secretHash] = &swap
+		contractorV1.swapMap[secretHash] = &swap
 	}
 
 	numSecrets := 3
@@ -1561,9 +1546,9 @@ func TestRedeem(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		node.redeemErr = test.redeemErr
-		node.redeemable = test.isRedeemable
-		node.isRedeemableErr = test.isRedeemableErr
+		contractorV1.redeemErr = test.redeemErr
+		contractorV1.redeemable = test.isRedeemable
+		contractorV1.redeemableErr = test.isRedeemableErr
 
 		txs, out, fees, err := eth.Redeem(&test.form)
 		if test.expectError {
@@ -1573,7 +1558,7 @@ func TestRedeem(t *testing.T) {
 			continue
 		}
 		if err != nil {
-			t.Fatalf("%v: unexpected error: %v", test.name, err)
+			t.Fatalf("%v: unexpected Redeem error: %v", test.name, err)
 		}
 
 		if len(txs) != len(test.form.Redemptions) {
@@ -1596,7 +1581,7 @@ func TestRedeem(t *testing.T) {
 			}
 			// secretHash should equal redemption.Spends.SecretHash, but it's
 			// not part of the Redeem code, just the test input consistency.
-			swap := node.swapMap[secretHash]
+			swap := contractorV1.swapMap[secretHash]
 			totalSwapValue += swap.Value
 		}
 
@@ -1676,30 +1661,25 @@ func TestMaxOrder(t *testing.T) {
 		},
 	}
 
-	dexAsset := dex.Asset{
+	dexAsset := &dex.Asset{
 		ID:           60,
 		Symbol:       "ETH",
 		MaxFeeRate:   100,
 		SwapSize:     gases.Swap,
-		SwapSizeBase: 0,
+		SwapSizeBase: gases.Swap,
 		SwapConf:     1,
 	}
 
 	for _, test := range tests {
-		ctx, cancel := context.WithCancel(context.Background())
-		node := newTestNode(nil)
-		node.bal = newBalance(test.bal*1e9, 0, 0)
-		node.balErr = test.balErr
-		eth := &ExchangeWallet{
-			node: node,
-			addr: node.address(),
-			ctx:  ctx,
-			log:  tLogger,
-		}
-		dexAsset.MaxFeeRate = test.maxFeeRate
-		maxOrder, err := eth.MaxOrder(test.lotSize, test.feeSuggestion, &dexAsset)
-		cancel()
+		eth, node, shutdown := tAssetWallet()
+		defer shutdown()
 
+		node.bal = dexeth.GweiToWei(test.bal * 1e9)
+		node.balErr = test.balErr
+
+		dexAsset.MaxFeeRate = test.maxFeeRate
+
+		maxOrder, err := eth.MaxOrder(test.lotSize, test.feeSuggestion, dexAsset)
 		if test.wantErr {
 			if err == nil {
 				t.Fatalf("expected error for test %q", test.name)
@@ -2011,14 +1991,7 @@ func TestOwnsAddress(t *testing.T) {
 func TestSignMessage(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	privKey, _ := crypto.HexToECDSA("9447129055a25c8496fca9e5ee1b9463e47e6043ff0c288d07169e8284860e34")
-
-	address := "2b84C791b79Ee37De042AD2ffF1A253c3ce9bc27"
-	account := accounts.Account{
-		Address: common.HexToAddress(address),
-	}
-	node := newTestNode(&account)
-	node.privKeyForSigning = privKey
+	node := newTestNode()
 	eth := &ExchangeWallet{
 		node: node,
 		addr: node.address(),
@@ -2053,30 +2026,20 @@ func TestSignMessage(t *testing.T) {
 }
 
 func TestSwapConfirmation(t *testing.T) {
+	eth, node, shutdown := tAssetWallet()
+	defer shutdown()
+
 	var secretHash [32]byte
 	copy(secretHash[:], encode.RandomBytes(32))
 	state := &dexeth.SwapState{}
 	hdr := &types.Header{}
 
-	node := &testNode{
-		bal:     newBalance(0, 0, 0),
-		bestHdr: hdr,
-		swapMap: map[[32]byte]*dexeth.SwapState{
-			secretHash: state,
-		},
-		swapVers: map[uint32]struct{}{
-			0: {},
-		},
-	}
-
-	eth := &ExchangeWallet{
-		node: node,
-		addr: testAddressA,
-	}
+	node.contractor.swapMap[secretHash] = state
 
 	state.BlockHeight = 5
 	state.State = dexeth.SSInitiated
 	hdr.Number = big.NewInt(6)
+	node.bestHdr = hdr
 
 	ver := uint32(0)
 
@@ -2104,9 +2067,9 @@ func TestSwapConfirmation(t *testing.T) {
 	ver = 0
 
 	// swap error
-	node.swapErr = fmt.Errorf("test error")
+	node.contractor.swapErr = fmt.Errorf("test error")
 	checkResult(true, 0, false)
-	node.swapErr = nil
+	node.contractor.swapErr = nil
 
 	// header error
 	node.bestHdrErr = fmt.Errorf("test error")
@@ -2242,13 +2205,13 @@ func TestDriverDecodeCoinID(t *testing.T) {
 	}
 
 	// Test funding coin id
-	fundingCoinID := createFundingCoinID(address, 1000)
-	coinID, err = drv.DecodeCoinID(fundingCoinID.Encode())
+	fundingCoin := createFundingCoin(address, 1000)
+	coinID, err = drv.DecodeCoinID(fundingCoin.ID())
 	if err != nil {
 		t.Fatalf("error decoding coin id: %v", err)
 	}
-	if coinID != fundingCoinID.String() {
-		t.Fatalf("expected coin id to be %s but got %s", fundingCoinID.String(), coinID)
+	if coinID != fundingCoin.String() {
+		t.Fatalf("expected coin id to be %s but got %s", fundingCoin.String(), coinID)
 	}
 
 	// Test byte encoded address string
@@ -2268,6 +2231,9 @@ func TestDriverDecodeCoinID(t *testing.T) {
 }
 
 func TestLocktimeExpired(t *testing.T) {
+	eth, node, shutdown := tAssetWallet()
+	defer shutdown()
+
 	var secretHash [32]byte
 	copy(secretHash[:], encode.RandomBytes(32))
 
@@ -2280,18 +2246,14 @@ func TestLocktimeExpired(t *testing.T) {
 		Time: uint64(time.Now().Add(time.Second).Unix()),
 	}
 
-	node := &testNode{
-		swapMap:  map[[32]byte]*dexeth.SwapState{secretHash: state},
-		swapVers: map[uint32]struct{}{0: {}},
-		bestHdr:  header,
-	}
-
-	eth := &ExchangeWallet{node: node}
+	node.contractor.swapMap[secretHash] = state
+	node.bestHdr = header
 
 	contract := make([]byte, 36)
 	copy(contract[4:], secretHash[:])
 
 	ensureResult := func(tag string, expErr, expExpired bool) {
+		t.Helper()
 		expired, _, err := eth.LocktimeExpired(contract)
 		switch {
 		case err != nil:
@@ -2320,9 +2282,9 @@ func TestLocktimeExpired(t *testing.T) {
 	state.State = saveState
 
 	// missing swap
-	delete(node.swapMap, secretHash)
+	delete(node.contractor.swapMap, secretHash)
 	ensureResult("missing swap", true, false)
-	node.swapMap[secretHash] = state
+	node.contractor.swapMap[secretHash] = state
 
 	// lock time not expired
 	state.LockTime = time.Now().Add(time.Minute)
@@ -2339,6 +2301,9 @@ func TestLocktimeExpired(t *testing.T) {
 }
 
 func TestFindRedemption(t *testing.T) {
+	eth, node, shutdown := tAssetWallet()
+	defer shutdown()
+
 	var secret [32]byte
 	copy(secret[:], encode.RandomBytes(32))
 	secretHash := sha256.Sum256(secret[:])
@@ -2349,19 +2314,7 @@ func TestFindRedemption(t *testing.T) {
 		State:  dexeth.SSInitiated,
 	}
 
-	node := &testNode{
-		swapMap: map[[32]byte]*dexeth.SwapState{
-			secretHash: state,
-		},
-		swapVers: map[uint32]struct{}{0: {}},
-	}
-
-	eth := &ExchangeWallet{
-		ctx:                context.Background(),
-		node:               node,
-		findRedemptionReqs: make(map[[32]byte]*findRedemptionRequest),
-		log:                tLogger,
-	}
+	node.contractor.swapMap[secretHash] = state
 
 	baseCtx := context.Background()
 
@@ -2441,15 +2394,15 @@ func TestFindRedemption(t *testing.T) {
 	})
 
 	// swap error
-	node.swapErr = errors.New("test error")
+	node.contractor.swapErr = errors.New("test error")
 	runTest("swap error", true, 0)
-	node.swapErr = nil
+	node.contractor.swapErr = nil
 
 	// swap error after queuing
 	runWithUpdate("swap error after queuing", true, dexeth.SSInitiated, func() {
-		node.swapErr = errors.New("test error")
+		node.contractor.swapErr = errors.New("test error")
 	})
-	node.swapErr = nil
+	node.contractor.swapErr = nil
 
 	// cancelled context error
 	var cancel context.CancelFunc
@@ -2485,8 +2438,8 @@ func TestFindRedemption(t *testing.T) {
 }
 
 func TestRefundReserves(t *testing.T) {
-	node := newTestNode(nil)
-	node.bal = newBalance(1e9, 0, 0)
+	node := newTestNode()
+	node.bal = dexeth.GweiToWei(1e9)
 	node.refundable = true
 	node.swapVers = map[uint32]struct{}{0: {}}
 
@@ -2556,18 +2509,15 @@ func TestRefundReserves(t *testing.T) {
 }
 
 func TestRedemptionReserves(t *testing.T) {
-	node := newTestNode(nil)
-	node.bal = newBalance(1e9, 0, 0)
-	node.redeemable = true
-	node.swapVers = map[uint32]struct{}{0: {}}
+	eth, node, shutdown := tAssetWallet()
+	defer shutdown()
+
+	node.bal = dexeth.GweiToWei(1e9)
+	node.contractor.redeemable = true
 
 	var secretHash [32]byte
-	node.swapMap = map[[32]byte]*dexeth.SwapState{secretHash: {}}
+	node.contractor.swapMap[secretHash] = &dexeth.SwapState{}
 	spentCoin := &coin{id: encode.RandomBytes(32)}
-
-	eth := &ExchangeWallet{
-		node: node,
-	}
 
 	var maxFeeRateV0 uint64 = 45
 	gasesV0 := dexeth.VersionedGases[0]
@@ -2608,6 +2558,7 @@ func TestRedemptionReserves(t *testing.T) {
 	}
 
 	// Redeem two v0.
+	node.contractor.redeemTx = types.NewTx(&types.DynamicFeeTx{})
 	if _, _, _, err = eth.Redeem(&asset.RedeemForm{
 		Redemptions: []*asset.Redemption{{
 			Spends: &asset.AuditInfo{
@@ -2646,15 +2597,15 @@ func TestPayFee(t *testing.T) {
 	txHash := tx.Hash()
 	maxFee := uint64(defaultSendGasLimit * defaultGasFeeLimit)
 	tests := []struct {
-		name                  string
-		regFee                uint64
-		bal                   *Balance
-		balErr, sendToAddrErr error
-		wantErr               bool
+		name              string
+		regFee            uint64
+		bal               uint64
+		balErr, sendTxErr error
+		wantErr           bool
 	}{{
 		name:   "ok",
 		regFee: 10e9,
-		bal:    newBalance(10e9+maxFee, 0, 0),
+		bal:    10e9 + maxFee,
 	}, {
 		name:    "balance error",
 		balErr:  errors.New(""),
@@ -2662,23 +2613,23 @@ func TestPayFee(t *testing.T) {
 	}, {
 		name:    "not enough",
 		regFee:  10e9,
-		bal:     newBalance(10e9, 0, 0),
+		bal:     10e9,
 		wantErr: true,
 	}, {
-		name:          "sendToAddr error",
-		regFee:        5e9,
-		bal:           newBalance(10e9, 0, 0),
-		sendToAddrErr: errors.New(""),
-		wantErr:       true,
+		name:      "sendToAddr error",
+		regFee:    5e9,
+		bal:       10e9,
+		sendTxErr: errors.New(""),
+		wantErr:   true,
 	}}
 
 	for _, test := range tests {
-		node := &testNode{
-			bal:           test.bal,
-			balErr:        test.balErr,
-			sendToAddrTx:  tx,
-			sendToAddrErr: test.sendToAddrErr,
-		}
+		node := newTestNode()
+
+		node.bal = dexeth.GweiToWei(test.bal)
+		node.balErr = test.balErr
+		node.sendTxTx = tx
+		node.sendTxErr = test.sendTxErr
 		eth := &ExchangeWallet{
 			node:        node,
 			gasFeeLimit: defaultGasFeeLimit,
@@ -2704,15 +2655,15 @@ func TestWithdraw(t *testing.T) {
 	txHash := tx.Hash()
 	maxFee := uint64(defaultSendGasLimit * defaultGasFeeLimit)
 	tests := []struct {
-		name                  string
-		value                 uint64
-		bal                   *Balance
-		balErr, sendToAddrErr error
-		wantErr               bool
+		name              string
+		value             uint64
+		bal               uint64
+		balErr, sendTxErr error
+		wantErr           bool
 	}{{
 		name:  "ok",
 		value: 10e9,
-		bal:   newBalance(10e9, 0, 0),
+		bal:   10e9,
 	}, {
 		name:    "balance error",
 		balErr:  errors.New(""),
@@ -2720,27 +2671,26 @@ func TestWithdraw(t *testing.T) {
 	}, {
 		name:    "not enough",
 		value:   10e9 + 1,
-		bal:     newBalance(10e9, 0, 0),
+		bal:     10e9,
 		wantErr: true,
 	}, {
 		name:    "cannot cover fee",
-		bal:     newBalance(maxFee-1, 0, 0),
+		bal:     maxFee - 1,
 		wantErr: true,
 	}, {
-		name:          "sendToAddr error",
-		value:         5e9,
-		bal:           newBalance(10e9, 0, 0),
-		sendToAddrErr: errors.New(""),
-		wantErr:       true,
+		name:      "sendToAddr error",
+		value:     5e9,
+		bal:       10e9,
+		sendTxErr: errors.New(""),
+		wantErr:   true,
 	}}
 
 	for _, test := range tests {
-		node := &testNode{
-			bal:           test.bal,
-			balErr:        test.balErr,
-			sendToAddrTx:  tx,
-			sendToAddrErr: test.sendToAddrErr,
-		}
+		node := newTestNode()
+		node.bal = dexeth.GweiToWei(test.bal)
+		node.balErr = test.balErr
+		node.sendTxTx = tx
+		node.sendTxErr = test.sendTxErr
 		eth := &ExchangeWallet{
 			node:        node,
 			gasFeeLimit: defaultGasFeeLimit,
@@ -2762,5 +2712,5 @@ func TestWithdraw(t *testing.T) {
 }
 
 func parseRecoveryID(c asset.Coin) []byte {
-	return c.(*fundingCoin).recoveryID
+	return c.(*fundingCoin).RecoveryID()
 }

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1109,7 +1109,7 @@ func TestSwap(t *testing.T) {
 		coinIDs := make([]dex.Bytes, 0, len(coinAmounts))
 		for _, amt := range coinAmounts {
 			fundingCoinID := createFundingCoin(eth.addr, amt)
-			coinIDs = append(coinIDs, fundingCoinID.ID())
+			coinIDs = append(coinIDs, fundingCoinID.RecoveryID())
 		}
 		return coinIDs
 	}
@@ -2206,7 +2206,7 @@ func TestDriverDecodeCoinID(t *testing.T) {
 
 	// Test funding coin id
 	fundingCoin := createFundingCoin(address, 1000)
-	coinID, err = drv.DecodeCoinID(fundingCoin.ID())
+	coinID, err = drv.DecodeCoinID(fundingCoin.RecoveryID())
 	if err != nil {
 		t.Fatalf("error decoding coin id: %v", err)
 	}

--- a/client/asset/eth/fundingcoin.go
+++ b/client/asset/eth/fundingcoin.go
@@ -13,8 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const fundingCoinIDSize = 28      // address (20) + amount (8) = 28
-const tokenFundingCoinIDSize = 36 // address (20) + amount (8) + amount (8) = 36
+const fundingCoinIDSize = 28 // address (20) + amount (8) = 28
 
 // fundingCoin is an identifier for a coin which has not yet been sent to the
 // swap contract.
@@ -28,15 +27,20 @@ func (c *fundingCoin) String() string {
 	return fmt.Sprintf("address: %v, amount:%x", c.addr, c.amt)
 }
 
-// ID creates a byte slice that can be decoded with decodeFundingCoin.
+// ID utf-8 encodes the account address. This ID will be sent to the server as
+// part of the an order.
 func (c *fundingCoin) ID() dex.Bytes {
 	return []byte(c.addr.String())
 }
 
+// Value returns the value reserved in the funding coin.
 func (c *fundingCoin) Value() uint64 {
 	return c.amt
 }
 
+// RecoveryID is a byte-encoded address and value of a funding coin. RecoveryID
+// satisfies the asset.RecoveryCoin interface, so this ID will be used as input
+// for (asset.Wallet).FundingCoins.
 func (c *fundingCoin) RecoveryID() dex.Bytes {
 	b := make([]byte, fundingCoinIDSize)
 	copy(b[:20], c.addr[:])

--- a/client/asset/eth/fundingcoin.go
+++ b/client/asset/eth/fundingcoin.go
@@ -9,51 +9,64 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"decred.org/dcrdex/dex"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const fundingCoinIDSize = 28 // address (20) + amount (8) = 28
+const fundingCoinIDSize = 28      // address (20) + amount (8) = 28
+const tokenFundingCoinIDSize = 36 // address (20) + amount (8) + amount (8) = 36
 
-// fundingCoinID is an identifier for a coin which has not yet been sent to the
+// fundingCoin is an identifier for a coin which has not yet been sent to the
 // swap contract.
-type fundingCoinID struct {
-	Address common.Address
-	Amount  uint64
+type fundingCoin struct {
+	addr common.Address
+	amt  uint64
 }
 
 // String creates a human readable string.
-func (c *fundingCoinID) String() string {
-	return fmt.Sprintf("address: %v, amount:%x", c.Address, c.Amount)
+func (c *fundingCoin) String() string {
+	return fmt.Sprintf("address: %v, amount:%x", c.addr, c.amt)
 }
 
-// Encode creates a byte slice that can be decoded with DecodeCoinID.
-func (c *fundingCoinID) Encode() []byte {
+// ID creates a byte slice that can be decoded with decodeFundingCoin.
+func (c *fundingCoin) ID() dex.Bytes {
 	b := make([]byte, fundingCoinIDSize)
-	copy(b[:20], c.Address[:])
-	binary.BigEndian.PutUint64(b[20:28], c.Amount)
+	copy(b[:20], c.addr[:])
+	binary.BigEndian.PutUint64(b[20:28], c.amt)
 	return b
 }
 
-// decodeFundingCoinID decodes a byte slice into an fundingCoinID struct.
-func decodeFundingCoinID(coinID []byte) (*fundingCoinID, error) {
+func (c *fundingCoin) Value() uint64 {
+	return c.amt
+}
+
+func (c *fundingCoin) RecoveryID() dex.Bytes {
+	b := make([]byte, fundingCoinIDSize)
+	copy(b[:20], c.addr[:])
+	binary.BigEndian.PutUint64(b[20:28], c.amt)
+	return b
+}
+
+// decodeFundingCoin decodes a byte slice into an fundingCoinID struct.
+func decodeFundingCoin(coinID []byte) (*fundingCoin, error) {
 	if len(coinID) != fundingCoinIDSize {
-		return nil, fmt.Errorf("decodeFundingCoinID: length expected %v, got %v",
+		return nil, fmt.Errorf("decodeFundingCoin: length expected %v, got %v",
 			fundingCoinIDSize, len(coinID))
 	}
 
 	var address [20]byte
 	copy(address[:], coinID[:20])
-	return &fundingCoinID{
-		Address: address,
-		Amount:  binary.BigEndian.Uint64(coinID[20:28]),
+	return &fundingCoin{
+		addr: address,
+		amt:  binary.BigEndian.Uint64(coinID[20:28]),
 	}, nil
 }
 
-// createFundingCoinID constructs a new fundingCoinID for the provided account
+// createFundingCoin constructs a new fundingCoinID for the provided account
 // address and amount in Gwei.
-func createFundingCoinID(address common.Address, amount uint64) *fundingCoinID {
-	return &fundingCoinID{
-		Address: address,
-		Amount:  amount,
+func createFundingCoin(address common.Address, amount uint64) *fundingCoin {
+	return &fundingCoin{
+		addr: address,
+		amt:  amount,
 	}
 }

--- a/client/asset/eth/fundingcoin.go
+++ b/client/asset/eth/fundingcoin.go
@@ -30,10 +30,7 @@ func (c *fundingCoin) String() string {
 
 // ID creates a byte slice that can be decoded with decodeFundingCoin.
 func (c *fundingCoin) ID() dex.Bytes {
-	b := make([]byte, fundingCoinIDSize)
-	copy(b[:20], c.addr[:])
-	binary.BigEndian.PutUint64(b[20:28], c.amt)
-	return b
+	return []byte(c.addr.String())
 }
 
 func (c *fundingCoin) Value() uint64 {

--- a/client/asset/eth/fundingcoin_test.go
+++ b/client/asset/eth/fundingcoin_test.go
@@ -16,26 +16,26 @@ func TestFundingCoinID(t *testing.T) {
 	// Decode and encode fundingCoinID
 	var address [20]byte
 	copy(address[:], encode.RandomBytes(20))
-	originalFundingCoin := fundingCoinID{
-		Address: address,
-		Amount:  100,
+	originalFundingCoin := &fundingCoin{
+		addr: address,
+		amt:  100,
 	}
-	encodedFundingCoin := originalFundingCoin.Encode()
-	decodedFundingCoin, err := decodeFundingCoinID(encodedFundingCoin)
+	encodedFundingCoin := originalFundingCoin.ID()
+	decodedFundingCoin, err := decodeFundingCoin(encodedFundingCoin)
 	if err != nil {
 		t.Fatalf("unexpected error decoding swap coin: %v", err)
 	}
-	if !bytes.Equal(originalFundingCoin.Address[:], decodedFundingCoin.Address[:]) {
+	if !bytes.Equal(originalFundingCoin.addr[:], decodedFundingCoin.addr[:]) {
 		t.Fatalf("expected address to be equal before and after decoding")
 	}
-	if originalFundingCoin.Amount != decodedFundingCoin.Amount {
+	if originalFundingCoin.amt != decodedFundingCoin.amt {
 		t.Fatalf("expected amount to be equal before and after decoding")
 	}
 
 	// Decode amount coin id with incorrect length
 	fundingCoinID := make([]byte, 35)
 	copy(fundingCoinID, encode.RandomBytes(35))
-	if _, err := decodeFundingCoinID(fundingCoinID); err == nil {
+	if _, err := decodeFundingCoin(fundingCoinID); err == nil {
 		t.Fatalf("expected error decoding amount coin ID with incorrect length")
 	}
 }

--- a/client/asset/eth/fundingcoin_test.go
+++ b/client/asset/eth/fundingcoin_test.go
@@ -20,7 +20,7 @@ func TestFundingCoinID(t *testing.T) {
 		addr: address,
 		amt:  100,
 	}
-	encodedFundingCoin := originalFundingCoin.ID()
+	encodedFundingCoin := originalFundingCoin.RecoveryID()
 	decodedFundingCoin, err := decodeFundingCoin(encodedFundingCoin)
 	if err != nil {
 		t.Fatalf("unexpected error decoding swap coin: %v", err)

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -86,6 +86,9 @@ var (
 	testTokenContractAddr common.Address
 	simnetID              int64  = 42
 	maxFeeRate            uint64 = 200 // gwei per gas
+	simnetContractor      contractor
+	participantContractor contractor
+	ethGases              = dexeth.VersionedGases[0]
 )
 
 func newContract(stamp uint64, secretHash [32]byte, val uint64) *asset.Contract {
@@ -122,11 +125,15 @@ out:
 		case <-timesUp:
 			return errors.New("timed out")
 		case <-time.After(time.Second):
-			txs, err := ethClient.pendingTransactions()
+			txsa, err := ethClient.pendingTransactions()
 			if err != nil {
-				return err
+				return fmt.Errorf("initiator pendingTransactions error: %v", err)
 			}
-			if len(txs) == 0 {
+			txsb, err := participantEthClient.pendingTransactions()
+			if err != nil {
+				return fmt.Errorf("participant pendingTransactions error: %v", err)
+			}
+			if len(txsa)+len(txsb) == 0 {
 				break out
 			}
 		}
@@ -201,6 +208,8 @@ func TestMain(m *testing.M) {
 		}
 		defer ethClient.shutdown()
 
+		fmt.Println("initiator address is", ethClient.address())
+
 		participantEthClient, err = newNodeClient(getWalletDir(participantWalletDir, dex.Simnet), dex.Simnet, tLogger.SubLogger("participant"))
 		if err != nil {
 			return 1, fmt.Errorf("newNodeClient participant error: %v", err)
@@ -210,11 +219,20 @@ func TestMain(m *testing.M) {
 		}
 		defer participantEthClient.shutdown()
 
+		fmt.Println("participant address is", participantEthClient.address())
+
 		if err := syncClient(ethClient); err != nil {
 			return 1, fmt.Errorf("error initializing initiator client: %v", err)
 		}
 		if err := syncClient(participantEthClient); err != nil {
 			return 1, fmt.Errorf("error initializing participant client: %v", err)
+		}
+
+		if simnetContractor, err = newV0Contractor(dex.Simnet, simnetAddr, ethClient.contractBackend()); err != nil {
+			return 1, fmt.Errorf("newV0Contractor error: %w", err)
+		}
+		if participantContractor, err = newV0Contractor(dex.Simnet, participantAddr, participantEthClient.contractBackend()); err != nil {
+			return 1, fmt.Errorf("participant newV0Contractor error: %w", err)
 		}
 
 		accts, err := exportAccountsFromNode(ethClient.node)
@@ -231,7 +249,29 @@ func TestMain(m *testing.M) {
 		if len(accts) != 1 {
 			return 1, fmt.Errorf("expected 1 account to be exported but got %v", len(accts))
 		}
-		return m.Run(), nil
+
+		if err := ethClient.unlock(pw); err != nil {
+			return 1, fmt.Errorf("error unlocking initiator client: %w", err)
+		}
+		if err := participantEthClient.unlock(pw); err != nil {
+			return 1, fmt.Errorf("error unlocking initiator client: %w", err)
+		}
+
+		code := m.Run()
+
+		if code != 0 {
+			return code, nil
+		}
+
+		if err := ethClient.lock(); err != nil {
+			return 1, fmt.Errorf("error locking initiator client: %w", err)
+		}
+		if err := participantEthClient.lock(); err != nil {
+			return 1, fmt.Errorf("error locking initiator client: %w", err)
+		}
+
+		return code, nil
+
 	}
 	exitCode, err := run()
 	if err != nil {
@@ -270,9 +310,7 @@ func syncClient(cl *nodeClient) error {
 }
 
 func TestBasicRetrieval(t *testing.T) {
-	t.Run("testBestBlockHash", testBestBlockHash)
 	t.Run("testBestHeader", testBestHeader)
-	t.Run("testBlock", testBlock)
 	t.Run("testPendingTransactions", testPendingTransactions)
 }
 
@@ -283,9 +321,7 @@ func TestPeering(t *testing.T) {
 }
 
 func TestAccount(t *testing.T) {
-	t.Run("testBalance", testBalance)
-	t.Run("testUnlock", testUnlock)
-	t.Run("testLock", testLock)
+	t.Run("testAddressBalance", testAddressBalance)
 	t.Run("testSendTransaction", testSendTransaction)
 	t.Run("testSendSignedTransaction", testSendSignedTransaction)
 	t.Run("testTransactionReceipt", testTransactionReceipt)
@@ -318,14 +354,6 @@ func testAddPeer(t *testing.T) {
 	}
 }
 
-func testBestBlockHash(t *testing.T) {
-	bbh, err := ethClient.bestBlockHash(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	spew.Dump(bbh)
-}
-
 func testBestHeader(t *testing.T) {
 	bh, err := ethClient.bestHeader(ctx)
 	if err != nil {
@@ -334,20 +362,8 @@ func testBestHeader(t *testing.T) {
 	spew.Dump(bh)
 }
 
-func testBlock(t *testing.T) {
-	bh, err := ethClient.bestBlockHash(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	b, err := ethClient.block(ctx, bh)
-	if err != nil {
-		t.Fatal(err)
-	}
-	spew.Dump(b)
-}
-
-func testBalance(t *testing.T) {
-	bal, err := ethClient.balance(ctx)
+func testAddressBalance(t *testing.T) {
+	bal, err := ethClient.addressBalance(ctx, simnetAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,30 +373,11 @@ func testBalance(t *testing.T) {
 	spew.Dump(bal)
 }
 
-func testUnlock(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func testLock(t *testing.T) {
-	err := ethClient.lock()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func testSendTransaction(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Checking confirmations for a random hash should result in not found error.
 	var txHash common.Hash
 	copy(txHash[:], encode.RandomBytes(32))
-	_, err = ethClient.transactionConfirmations(ctx, txHash)
+	_, err := ethClient.transactionConfirmations(ctx, txHash)
 	if !errors.Is(err, asset.CoinNotFoundError) {
 		t.Fatalf("no CoinNotFoundError")
 	}
@@ -402,14 +399,6 @@ func testSendTransaction(t *testing.T) {
 		t.Fatalf("%d confs reported for unmined transaction", confs)
 	}
 
-	fees := new(big.Int).Mul(txOpts.GasFeeCap, new(big.Int).SetUint64(txOpts.GasLimit))
-
-	bal, _ := ethClient.balance(ctx)
-
-	if bal.PendingOut.Cmp(new(big.Int).Add(dexeth.GweiToWei(1), fees)) != 0 {
-		t.Fatalf("pending out not showing")
-	}
-
 	spew.Dump(tx)
 	if err := waitForMined(t, time.Second*10, false); err != nil {
 		t.Fatal(err)
@@ -425,21 +414,14 @@ func testSendTransaction(t *testing.T) {
 }
 
 func testSendSignedTransaction(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Checking confirmations for a random hash should result in not found error.
 	var txHash common.Hash
 	copy(txHash[:], encode.RandomBytes(32))
-	_, err = ethClient.transactionConfirmations(ctx, txHash)
+	_, err := ethClient.transactionConfirmations(ctx, txHash)
 	if !errors.Is(err, asset.CoinNotFoundError) {
 		t.Fatalf("no CoinNotFoundError")
 	}
 
-	ethClient.nonceSendMtx.Lock()
-	defer ethClient.nonceSendMtx.Unlock()
 	nonce, err := ethClient.leth.ApiBackend.GetPoolNonce(ctx, ethClient.creds.addr)
 	if err != nil {
 		t.Fatalf("error getting nonce: %v", err)
@@ -454,7 +436,7 @@ func testSendSignedTransaction(t *testing.T) {
 		Value:     dexeth.GweiToWei(1),
 		Data:      []byte{},
 	})
-	tx, err = ethClient.signTransaction(tx)
+	tx, err = ethClient.creds.ks.SignTx(*simnetAcct, tx, ethClient.chainID)
 
 	err = ethClient.sendSignedTransaction(ctx, tx)
 	if err != nil {
@@ -469,13 +451,6 @@ func testSendSignedTransaction(t *testing.T) {
 	}
 	if confs != 0 {
 		t.Fatalf("%d confs reported for unmined transaction", confs)
-	}
-
-	bal, _ := ethClient.balance(ctx)
-
-	fee := uint64(21000 * 300) // gwei
-	if bal.PendingOut.Cmp(dexeth.GweiToWei(1+fee)) != 0 {
-		t.Fatalf("pending out not showing")
 	}
 
 	spew.Dump(tx)
@@ -493,11 +468,6 @@ func testSendSignedTransaction(t *testing.T) {
 }
 
 func testTransactionReceipt(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	txOpts, _ := ethClient.txOpts(ctx, 1, dexeth.InitGas(1, 0), nil)
 
 	tx, err := ethClient.sendTransaction(ctx, txOpts, simnetAddr, nil)
@@ -526,7 +496,7 @@ func testPendingTransactions(t *testing.T) {
 func testSwap(t *testing.T) {
 	var secretHash [32]byte
 	copy(secretHash[:], encode.RandomBytes(32))
-	swap, err := ethClient.swap(ctx, secretHash, 0)
+	swap, err := simnetContractor.swap(ctx, secretHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -539,28 +509,23 @@ func testSyncProgress(t *testing.T) {
 }
 
 func TestInitiateGas(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := simnetContractor
 
 	var previousGas uint64
 	maxSwaps := 50
 	for i := 1; i <= maxSwaps; i++ {
-		gas, err := ethClient.estimateInitGas(ctx, i, 0)
+		gas, err := c.estimateInitGas(ctx, i)
 		if err != nil {
 			t.Fatalf("unexpected error from estimateInitGas(%d): %v", i, err)
 		}
 
-		gases := dexeth.VersionedGases[0]
-
 		var expectedGas uint64
 		var actualGas uint64
 		if i == 1 {
-			expectedGas = gases.Swap
+			expectedGas = ethGases.Swap
 			actualGas = gas
 		} else {
-			expectedGas = gases.SwapAdd
+			expectedGas = ethGases.SwapAdd
 			actualGas = gas - previousGas
 		}
 		if actualGas > expectedGas || actualGas < expectedGas/100*95 {
@@ -588,9 +553,9 @@ func feesAtBlk(ctx context.Context, n *nodeClient, blkNum int64) (fees *big.Int,
 }
 
 func testInitiate(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
+	c := simnetContractor
+	balance := func() (*big.Int, error) {
+		return ethClient.addressBalance(ctx, simnetAddr)
 	}
 
 	// Create a slice of random secret hashes that can be used in the tests and
@@ -599,7 +564,7 @@ func testInitiate(t *testing.T) {
 	secretHashes := make([][32]byte, numSecretHashes)
 	for i := 0; i < numSecretHashes; i++ {
 		copy(secretHashes[i][:], encode.RandomBytes(32))
-		swap, err := ethClient.swap(ctx, secretHashes[i], 0)
+		swap, err := c.swap(ctx, secretHashes[i])
 		if err != nil {
 			t.Fatal("unable to get swap state")
 		}
@@ -677,48 +642,47 @@ func testInitiate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		originalBal, err := ethClient.balance(ctx)
+		originalBal, err := balance()
 		if err != nil {
-			t.Fatalf("unexpected error for test %v: %v", test.name, err)
+			t.Fatalf("balance error for test %v: %v", test.name, err)
 		}
 
 		originalStates := make(map[string]dexeth.SwapStep)
-		for _, testSwap := range test.swaps {
-			swap, err := ethClient.swap(ctx, bytesToArray(testSwap.SecretHash), 0)
+		var totalVal uint64
+		for _, tSwap := range test.swaps {
+			swap, err := c.swap(ctx, bytesToArray(tSwap.SecretHash))
 			if err != nil {
 				t.Fatalf("%s: swap error: %v", test.name, err)
 			}
-			originalStates[testSwap.SecretHash.String()] = dexeth.SwapStep(swap.State)
+			originalStates[tSwap.SecretHash.String()] = dexeth.SwapStep(swap.State)
+			totalVal += tSwap.Value
 		}
 
-		tx, err := ethClient.initiate(ctx, test.swaps, maxFeeRate, 0)
+		expGas := ethGases.SwapN(len(test.swaps))
+		txOpts, _ := ethClient.txOpts(ctx, totalVal, expGas*2, nil)
+		tx, err := c.initiate(txOpts, test.swaps)
 		if err != nil {
 			if test.swapErr {
 				continue
 			}
 			t.Fatalf("%s: initiate error: %v", test.name, err)
 		}
-		spew.Dump(tx)
 
 		if err := waitForMined(t, time.Second*10, false); err != nil {
 			t.Fatalf("%s: post-initiate mining error: %v", test.name, err)
 		}
 
 		// It appears the receipt is only accessible after the tx is mined.
-		receipt, err := ethClient.transactionReceipt(ctx, tx.Hash())
-		if err != nil {
-			t.Fatalf("%s: receipt error: %v", test.name, err)
+		receipt, err := ethClient.checkTxStatus(ctx, tx, txOpts)
+		if err != nil && test.success {
+			spew.Dump(tx)
+			spew.Dump(receipt)
+			t.Fatalf("%s: failed transaction status: %v", test.name, err)
+		} else if receipt.GasUsed > expGas {
+			t.Fatalf("%s: gas used %d exceeds expected max %d", test.name, receipt.GasUsed, expGas)
 		}
-		spew.Dump("receipt", receipt)
 
-		// Balance should be reduced by a certain amount depending on
-		// whether initiate completed successfully on-chain. If
-		// unsuccessful the fee is subtracted. If successful, amt is
-		// also subtracted.
-		bal, err := ethClient.balance(ctx)
-		if err != nil {
-			t.Fatalf("%s: balance error: %v", test.name, err)
-		}
+		fmt.Printf("Gas used for %d initiations, success = %t: %d \n", len(test.swaps), test.success, receipt.GasUsed)
 
 		gasPrice, err := feesAtBlk(ctx, ethClient, receipt.BlockNumber.Int64())
 		if err != nil {
@@ -726,21 +690,26 @@ func testInitiate(t *testing.T) {
 		}
 		bigGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
 		txFee := new(big.Int).Mul(bigGasUsed, gasPrice)
-		wantBal := new(big.Int).Sub(originalBal.Current, txFee)
+		wantBal := new(big.Int).Set(originalBal)
+		wantBal.Sub(wantBal, txFee)
 		if test.success {
 			for _, swap := range test.swaps {
 				wantBal.Sub(wantBal, dexeth.GweiToWei(swap.Value))
 			}
 		}
-
-		diff := new(big.Int).Abs(new(big.Int).Sub(wantBal, bal.Current))
-		if diff.Cmp(new(big.Int)) != 0 {
-			t.Fatalf("%s: unexpected balance change: want %d got %d, diff = %d",
-				test.name, wantBal, bal.Current, diff)
+		bal, err := balance()
+		if err != nil {
+			t.Fatalf("%s: balance error: %v", test.name, err)
 		}
 
-		for _, testSwap := range test.swaps {
-			swap, err := ethClient.swap(ctx, bytesToArray(testSwap.SecretHash), 0)
+		diff := new(big.Int).Sub(wantBal, bal)
+		if diff.CmpAbs(dexeth.GweiToWei(1)) >= 0 {
+			t.Fatalf("%s: unexpected balance change: want %d got %d gwei, diff = %.9f gwei",
+				test.name, dexeth.WeiToGwei(wantBal), dexeth.WeiToGwei(bal), float64(diff.Int64())/dexeth.GweiFactor)
+		}
+
+		for _, tSwap := range test.swaps {
+			swap, err := c.swap(ctx, bytesToArray(tSwap.SecretHash))
 			if err != nil {
 				t.Fatalf("%s: swap error post-init: %v", test.name, err)
 			}
@@ -750,7 +719,7 @@ func testInitiate(t *testing.T) {
 				t.Fatalf("%s: wrong success swap state: want %s got %s", test.name, dexeth.SSInitiated, state)
 			}
 
-			originalState := originalStates[hex.EncodeToString(testSwap.SecretHash[:])]
+			originalState := originalStates[hex.EncodeToString(tSwap.SecretHash[:])]
 			if !test.success && state != originalState {
 				t.Fatalf("%s: wrong error swap state: want %s got %s", test.name, originalState, state)
 			}
@@ -759,11 +728,6 @@ func testInitiate(t *testing.T) {
 }
 
 func TestRedeemGas(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Create secrets and secret hashes
 	numSecrets := 9
 	secrets := make([][32]byte, 0, numSecrets)
@@ -783,7 +747,12 @@ func TestRedeemGas(t *testing.T) {
 	for i := 0; i < numSecrets; i++ {
 		swaps = append(swaps, newContract(now, secretHashes[i], 1))
 	}
-	_, err = ethClient.initiate(ctx, swaps, maxFeeRate, 0)
+
+	c := simnetContractor
+	pc := participantContractor
+
+	txOpts, _ := ethClient.txOpts(ctx, 0, ethGases.SwapN(len(swaps)), nil)
+	_, err := c.initiate(txOpts, swaps)
 	if err != nil {
 		t.Fatalf("Unable to initiate swap: %v ", err)
 	}
@@ -793,7 +762,7 @@ func TestRedeemGas(t *testing.T) {
 
 	// Make sure swaps were properly initiated
 	for i := range swaps {
-		swap, err := ethClient.swap(ctx, bytesToArray(swaps[i].SecretHash), 0)
+		swap, err := c.swap(ctx, bytesToArray(swaps[i].SecretHash))
 		if err != nil {
 			t.Fatal("unable to get swap state")
 		}
@@ -805,20 +774,18 @@ func TestRedeemGas(t *testing.T) {
 	// Test gas usage of redeem function
 	var previous uint64
 	for i := 0; i < numSecrets; i++ {
-		gas, err := participantEthClient.estimateRedeemGas(ctx, secrets[:i+1], 0)
+		gas, err := pc.estimateRedeemGas(ctx, secrets[:i+1])
 		if err != nil {
 			t.Fatalf("Error estimating gas for redeem function: %v", err)
 		}
 
-		gases := dexeth.VersionedGases[0]
-
 		var expectedGas uint64
 		var actualGas uint64
 		if i == 0 {
-			expectedGas = gases.Redeem
+			expectedGas = ethGases.Redeem
 			actualGas = gas
 		} else {
-			expectedGas = gases.RedeemAdd
+			expectedGas = ethGases.RedeemAdd
 			actualGas = gas - previous
 		}
 		if actualGas > expectedGas || actualGas < (expectedGas/100*95) {
@@ -831,7 +798,7 @@ func TestRedeemGas(t *testing.T) {
 }
 
 func testRedeem(t *testing.T) {
-	lockTime := uint64(time.Now().Add(time.Second * 12).Unix())
+	lockTime := uint64(time.Now().Unix())
 	numSecrets := 10
 	secrets := make([][32]byte, 0, numSecrets)
 	secretHashes := make([][32]byte, 0, numSecrets)
@@ -843,43 +810,39 @@ func testRedeem(t *testing.T) {
 		secretHashes = append(secretHashes, secretHash)
 	}
 
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = participantEthClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c, pc := simnetContractor, participantContractor
 
 	tests := []struct {
-		name            string
-		sleep           time.Duration
-		redeemerClient  *nodeClient
-		redeemer        *accounts.Account
-		swaps           []*asset.Contract
-		redemptions     []*asset.Redemption
-		isRedeemable    []bool
-		finalStates     []dexeth.SwapStep
-		addAmt          bool
-		expectRedeemErr bool
+		name               string
+		sleep              time.Duration
+		redeemerClient     *nodeClient
+		redeemer           *accounts.Account
+		redeemerContractor contractor
+		swaps              []*asset.Contract
+		redemptions        []*asset.Redemption
+		isRedeemable       []bool
+		finalStates        []dexeth.SwapStep
+		addAmt             bool
+		expectRedeemErr    bool
 	}{
 		{
-			name:           "ok before locktime",
-			sleep:          time.Second * 8,
-			redeemerClient: participantEthClient,
-			redeemer:       participantAcct,
-			swaps:          []*asset.Contract{newContract(lockTime, secretHashes[0], 1)},
-			redemptions:    []*asset.Redemption{newRedeem(secrets[0], secretHashes[0])},
-			isRedeemable:   []bool{true},
-			finalStates:    []dexeth.SwapStep{dexeth.SSRedeemed},
-			addAmt:         true,
+			name:               "ok before locktime",
+			sleep:              time.Second * 8,
+			redeemerClient:     participantEthClient,
+			redeemer:           participantAcct,
+			redeemerContractor: pc,
+			swaps:              []*asset.Contract{newContract(lockTime, secretHashes[0], 1)},
+			redemptions:        []*asset.Redemption{newRedeem(secrets[0], secretHashes[0])},
+			isRedeemable:       []bool{true},
+			finalStates:        []dexeth.SwapStep{dexeth.SSRedeemed},
+			addAmt:             true,
 		},
 		{
-			name:           "ok two before locktime",
-			sleep:          time.Second * 8,
-			redeemerClient: participantEthClient,
-			redeemer:       participantAcct,
+			name:               "ok two before locktime",
+			sleep:              time.Second * 8,
+			redeemerClient:     participantEthClient,
+			redeemer:           participantAcct,
+			redeemerContractor: pc,
 			swaps: []*asset.Contract{
 				newContract(lockTime, secretHashes[1], 1),
 				newContract(lockTime, secretHashes[2], 1),
@@ -895,44 +858,48 @@ func testRedeem(t *testing.T) {
 			addAmt: true,
 		},
 		{
-			name:           "ok after locktime",
-			sleep:          time.Second * 16,
-			redeemerClient: participantEthClient,
-			redeemer:       participantAcct,
-			swaps:          []*asset.Contract{newContract(lockTime, secretHashes[3], 1)},
-			redemptions:    []*asset.Redemption{newRedeem(secrets[3], secretHashes[3])},
-			isRedeemable:   []bool{true},
-			finalStates:    []dexeth.SwapStep{dexeth.SSRedeemed},
-			addAmt:         true,
+			name:               "ok after locktime",
+			sleep:              time.Second * 16,
+			redeemerClient:     participantEthClient,
+			redeemer:           participantAcct,
+			redeemerContractor: pc,
+			swaps:              []*asset.Contract{newContract(lockTime, secretHashes[3], 1)},
+			redemptions:        []*asset.Redemption{newRedeem(secrets[3], secretHashes[3])},
+			isRedeemable:       []bool{true},
+			finalStates:        []dexeth.SwapStep{dexeth.SSRedeemed},
+			addAmt:             true,
 		},
 		{
-			name:           "bad redeemer",
-			sleep:          time.Second * 8,
-			redeemerClient: ethClient,
-			redeemer:       simnetAcct,
-			swaps:          []*asset.Contract{newContract(lockTime, secretHashes[4], 1)},
-			redemptions:    []*asset.Redemption{newRedeem(secrets[4], secretHashes[4])},
-			isRedeemable:   []bool{false},
-			finalStates:    []dexeth.SwapStep{dexeth.SSInitiated},
-			addAmt:         false,
+			name:               "bad redeemer",
+			sleep:              time.Second * 8,
+			redeemerClient:     ethClient,
+			redeemer:           simnetAcct,
+			redeemerContractor: c,
+			swaps:              []*asset.Contract{newContract(lockTime, secretHashes[4], 1)},
+			redemptions:        []*asset.Redemption{newRedeem(secrets[4], secretHashes[4])},
+			isRedeemable:       []bool{false},
+			finalStates:        []dexeth.SwapStep{dexeth.SSInitiated},
+			addAmt:             false,
 		},
 		{
-			name:           "bad secret",
-			sleep:          time.Second * 8,
-			redeemerClient: ethClient,
-			redeemer:       simnetAcct,
-			swaps:          []*asset.Contract{newContract(lockTime, secretHashes[5], 1)},
-			redemptions:    []*asset.Redemption{newRedeem(secrets[6], secretHashes[5])},
-			isRedeemable:   []bool{false},
-			finalStates:    []dexeth.SwapStep{dexeth.SSInitiated},
-			addAmt:         false,
+			name:               "bad secret",
+			sleep:              time.Second * 8,
+			redeemerClient:     participantEthClient,
+			redeemer:           participantAcct,
+			redeemerContractor: pc,
+			swaps:              []*asset.Contract{newContract(lockTime, secretHashes[5], 1)},
+			redemptions:        []*asset.Redemption{newRedeem(secrets[6], secretHashes[5])},
+			isRedeemable:       []bool{false},
+			finalStates:        []dexeth.SwapStep{dexeth.SSInitiated},
+			addAmt:             false,
 		},
 		{
-			name:            "duplicate secret hashes",
-			expectRedeemErr: true,
-			sleep:           time.Second * 8,
-			redeemerClient:  participantEthClient,
-			redeemer:        participantAcct,
+			name:               "duplicate secret hashes",
+			expectRedeemErr:    true,
+			sleep:              time.Second * 8,
+			redeemerClient:     participantEthClient,
+			redeemer:           participantAcct,
+			redeemerContractor: pc,
 			swaps: []*asset.Contract{
 				newContract(lockTime, secretHashes[7], 1),
 				newContract(lockTime, secretHashes[8], 1),
@@ -951,8 +918,9 @@ func testRedeem(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		for i := range test.swaps {
-			swap, err := ethClient.swap(ctx, bytesToArray(test.swaps[i].SecretHash), 0)
+		var optsVal uint64
+		for i, contract := range test.swaps {
+			swap, err := c.swap(ctx, bytesToArray(test.swaps[i].SecretHash))
 			if err != nil {
 				t.Fatal("unable to get swap state")
 			}
@@ -960,9 +928,15 @@ func testRedeem(t *testing.T) {
 			if state != dexeth.SSNone {
 				t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, dexeth.SSNone, state)
 			}
+			optsVal += contract.Value
 		}
 
-		_, err = ethClient.initiate(ctx, test.swaps, maxFeeRate, 0)
+		balance := func() (*big.Int, error) {
+			return test.redeemerClient.addressBalance(ctx, test.redeemer.Address)
+		}
+
+		txOpts, _ := test.redeemerClient.txOpts(ctx, optsVal, ethGases.SwapN(len(test.swaps)), nil)
+		tx, err := test.redeemerContractor.initiate(txOpts, test.swaps)
 		if err != nil {
 			t.Fatalf("%s: initiate error: %v ", test.name, err)
 		}
@@ -972,33 +946,41 @@ func testRedeem(t *testing.T) {
 			t.Fatalf("%s: post-init mining error: %v", test.name, err)
 		}
 
+		receipt, err := test.redeemerClient.checkTxStatus(ctx, tx, txOpts)
+		if err != nil {
+			t.Fatalf("%s: failed init transaction status: %v", test.name, err)
+		}
+		spew.Dump(receipt)
+		fmt.Printf("Gas used for %d inits: %d \n", len(test.swaps), receipt.GasUsed)
+
 		for i := range test.swaps {
-			swap, err := ethClient.swap(ctx, bytesToArray(test.swaps[i].SecretHash), 0)
+			swap, err := test.redeemerContractor.swap(ctx, bytesToArray(test.swaps[i].SecretHash))
 			if err != nil {
 				t.Fatal("unable to get swap state")
 			}
-			state := dexeth.SwapStep(swap.State)
-			if state != dexeth.SSInitiated {
-				t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, dexeth.SSInitiated, state)
+			if swap.State != dexeth.SSInitiated {
+				t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, dexeth.SSInitiated, swap.State)
+			}
+
+			expected := test.isRedeemable[i]
+			redemption := test.redemptions[i]
+
+			isRedeemable, err := test.redeemerContractor.isRedeemable(bytesToArray(redemption.Spends.SecretHash), bytesToArray(redemption.Secret))
+			if err != nil {
+				t.Fatalf(`test "%v": error calling isRedeemable: %v`, test.name, err)
+			} else if isRedeemable != expected {
+				t.Fatalf(`test "%v": expected isRedeemable to be %v, but got %v. swap = %+v`, test.name, expected, isRedeemable, swap)
 			}
 		}
 
-		originalBal, err := test.redeemerClient.balance(ctx)
+		originalBal, err := balance()
 		if err != nil {
 			t.Fatalf("%s: balance error: %v", test.name, err)
 		}
-		for i, redemption := range test.redemptions {
-			expected := test.isRedeemable[i]
-			isRedeemable, err := test.redeemerClient.isRedeemable(bytesToArray(redemption.Spends.SecretHash), bytesToArray(redemption.Secret), 0)
-			if err != nil {
-				t.Fatalf(`test "%v": error calling isRedeemable: %v`, test.name, err)
-			}
-			if isRedeemable != expected {
-				t.Fatalf(`test "%v": expected isRedeemable to be %v, but got %v`, test.name, expected, isRedeemable)
-			}
-		}
 
-		tx, err := test.redeemerClient.redeem(ctx, test.redemptions, maxFeeRate, 0)
+		expGas := ethGases.RedeemN(len(test.redemptions))
+		txOpts, _ = test.redeemerClient.txOpts(ctx, 0, expGas*2, nil)
+		tx, err = test.redeemerContractor.redeem(txOpts, test.redemptions)
 		if test.expectRedeemErr {
 			if err == nil {
 				t.Fatalf("%s: expected error but did not get", test.name)
@@ -1010,54 +992,55 @@ func testRedeem(t *testing.T) {
 		}
 		spew.Dump(tx)
 
-		bal, err := test.redeemerClient.balance(ctx)
-		if err != nil {
-			t.Fatalf("%s: redeemer pending in balance error: %v", test.name, err)
-		}
-
-		if test.addAmt && dexeth.WeiToGwei(bal.PendingIn) != uint64(len(test.swaps)) {
-			t.Fatalf("%s: unexpected pending in balance %s", test.name, bal.PendingIn)
-		}
-
 		if err := waitForMined(t, time.Second*10, false); err != nil {
 			t.Fatalf("%s: post-redeem mining error: %v", test.name, err)
 		}
 
-		// It appears the receipt is only accessible after the tx is mined.
-		receipt, err := test.redeemerClient.transactionReceipt(ctx, tx.Hash())
-		if err != nil {
-			t.Fatalf("%s: receipt error: %v", test.name, err)
+		expSuccess := !test.expectRedeemErr && test.addAmt
+		receipt, err = test.redeemerClient.checkTxStatus(ctx, tx, txOpts)
+		if err != nil && expSuccess {
+			t.Fatalf("%s: failed redeem transaction status: %v", test.name, err)
+		} else if receipt.GasUsed > expGas {
+			t.Fatalf("%s: gas used %d is > expected max %d", test.name, receipt.GasUsed, expGas)
 		}
 		spew.Dump(receipt)
+		fmt.Printf("Gas used for %d redeems, success = %t: %d \n", len(test.swaps), expSuccess, receipt.GasUsed)
+
+		bal, err := balance()
+		if err != nil {
+			t.Fatalf("%s: redeemer balance error: %v", test.name, err)
+		}
+
+		// Check transaction parsing while we're here.
+		if in, err := test.redeemerContractor.incomingValue(ctx, tx); err != nil {
+			t.Fatalf("error parsing value from redemption: %v", err)
+		} else if in != uint64(len(test.swaps)) {
+			t.Fatalf("%s: unexpected pending in balance %d", test.name, in)
+		}
 
 		// Balance should increase or decrease by a certain amount
 		// depending on whether redeem completed successfully on-chain.
 		// If unsuccessful the fee is subtracted. If successful, amt is
 		// added.
-		bal, err = test.redeemerClient.balance(ctx)
-		if err != nil {
-			t.Fatalf("%s: redeemer balance error: %v", test.name, err)
-		}
-
 		gasPrice, err := feesAtBlk(ctx, ethClient, receipt.BlockNumber.Int64())
 		if err != nil {
 			t.Fatalf("%s: feesAtBlk error: %v", test.name, err)
 		}
 		bigGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
 		txFee := new(big.Int).Mul(bigGasUsed, gasPrice)
-		wantBal := new(big.Int).Sub(originalBal.Current, txFee)
+		wantBal := new(big.Int).Sub(originalBal, txFee)
 		if test.addAmt {
 			wantBal.Add(wantBal, dexeth.GweiToWei(uint64(len(test.redemptions))))
 		}
 
-		diff := new(big.Int).Abs(new(big.Int).Sub(wantBal, bal.Current))
-		if diff.Cmp(new(big.Int)) != 0 {
-			t.Fatalf("%s: unexpected balance change: want %d got %d, diff = %d",
-				test.name, wantBal, bal.Current, diff)
+		diff := new(big.Int).Sub(wantBal, bal)
+		if diff.CmpAbs(dexeth.GweiToWei(1)) >= 0 {
+			t.Fatalf("%s: unexpected balance change: want %d got %d, diff = %.9f",
+				test.name, dexeth.WeiToGwei(wantBal), dexeth.WeiToGwei(bal), float64(diff.Int64())/dexeth.GweiFactor)
 		}
 
 		for i, redemption := range test.redemptions {
-			swap, err := ethClient.swap(ctx, bytesToArray(redemption.Spends.SecretHash), 0)
+			swap, err := c.swap(ctx, bytesToArray(redemption.Spends.SecretHash))
 			if err != nil {
 				t.Fatalf("unexpected error for test %v: %v", test.name, err)
 			}
@@ -1071,17 +1054,16 @@ func testRedeem(t *testing.T) {
 }
 
 func TestRefundGas(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := simnetContractor
+	var optsVal uint64 = 1
 
 	var secret [32]byte
 	copy(secret[:], encode.RandomBytes(32))
 	secretHash := sha256.Sum256(secret[:])
 
 	lockTime := uint64(time.Now().Unix())
-	_, err = ethClient.initiate(ctx, []*asset.Contract{newContract(lockTime, secretHash, 1)}, maxFeeRate, 0)
+	txOpts, _ := ethClient.txOpts(ctx, optsVal, ethGases.SwapN(1), nil)
+	_, err := c.initiate(txOpts, []*asset.Contract{newContract(lockTime, secretHash, 1)})
 	if err != nil {
 		t.Fatalf("Unable to initiate swap: %v ", err)
 	}
@@ -1089,7 +1071,7 @@ func TestRefundGas(t *testing.T) {
 		t.Fatalf("unexpected error while waiting to mine: %v", err)
 	}
 
-	swap, err := ethClient.swap(ctx, secretHash, 0)
+	swap, err := c.swap(ctx, secretHash)
 	if err != nil {
 		t.Fatal("unable to get swap state")
 	}
@@ -1098,11 +1080,11 @@ func TestRefundGas(t *testing.T) {
 		t.Fatalf("unexpected swap state: want %s got %s", dexeth.SSInitiated, state)
 	}
 
-	gas, err := ethClient.estimateRefundGas(ctx, secretHash, 0)
+	gas, err := c.estimateRefundGas(ctx, secretHash)
 	if err != nil {
 		t.Fatalf("Error estimating gas for refund function: %v", err)
 	}
-	expGas := dexeth.RefundGas(0)
+	expGas := ethGases.Refund
 	if gas > expGas || gas < expGas/100*95 {
 		t.Fatalf("expected refund gas to be near %d, but got %d",
 			expGas, gas)
@@ -1112,31 +1094,31 @@ func TestRefundGas(t *testing.T) {
 
 func testRefund(t *testing.T) {
 	const amt = 1e9
-	locktime := time.Second * 12
+	c, pc := simnetContractor, participantContractor
 	tests := []struct {
-		name                                 string
-		sleep                                time.Duration
-		refunder                             *accounts.Account
-		refunderClient                       *nodeClient
-		finalState                           dexeth.SwapStep
-		addAmt, addFee, redeem, isRefundable bool
+		name                         string
+		refunder                     *accounts.Account
+		refunderClient               *nodeClient
+		refunderContractor           contractor
+		finalState                   dexeth.SwapStep
+		addAmt, redeem, isRefundable bool
+		addTime                      time.Duration
 	}{{
-		name:           "ok",
-		sleep:          time.Second * 16,
-		isRefundable:   true,
-		refunderClient: ethClient,
-		refunder:       simnetAcct,
-		addAmt:         true,
-		addFee:         true,
-		finalState:     dexeth.SSRefunded,
+		name:               "ok",
+		isRefundable:       true,
+		refunderClient:     ethClient,
+		refunder:           simnetAcct,
+		refunderContractor: c,
+		addAmt:             true,
+		finalState:         dexeth.SSRefunded,
 	}, {
-		name:           "before locktime",
-		sleep:          time.Second * 8,
-		isRefundable:   false,
-		refunderClient: ethClient,
-		refunder:       simnetAcct,
-		addFee:         true,
-		finalState:     dexeth.SSInitiated,
+		name:               "before locktime",
+		isRefundable:       false,
+		refunderClient:     ethClient,
+		refunder:           simnetAcct,
+		refunderContractor: c,
+		finalState:         dexeth.SSInitiated,
+		addTime:            time.Hour,
 
 		// NOTE: Refunding to an account other than the sender takes more
 		// gas. At present redeem gas must be set to around 46000 although
@@ -1151,41 +1133,38 @@ func testRefund(t *testing.T) {
 		// 	addAmt:         true,
 		// 	finalState:     dexeth.SSRefunded,
 	}, {
-		name:           "already redeemed",
-		sleep:          time.Second * 16,
-		isRefundable:   false,
-		refunderClient: ethClient,
-		refunder:       simnetAcct,
-		addFee:         true,
-		redeem:         true,
-		finalState:     dexeth.SSRedeemed,
+		name:               "already redeemed",
+		isRefundable:       false,
+		refunderClient:     ethClient,
+		refunder:           simnetAcct,
+		refunderContractor: c,
+		redeem:             true,
+		finalState:         dexeth.SSRedeemed,
 	}}
 
 	for _, test := range tests {
-		err := ethClient.unlock(pw)
-		if err != nil {
-			t.Fatal(err)
+		balance := func() (*big.Int, error) {
+			return test.refunderClient.addressBalance(ctx, test.refunder.Address)
 		}
-		err = participantEthClient.unlock(pw)
-		if err != nil {
-			t.Fatal(err)
-		}
+
+		var optsVal uint64 = amt
+
 		var secret [32]byte
 		copy(secret[:], encode.RandomBytes(32))
 		secretHash := sha256.Sum256(secret[:])
 
-		swap, err := ethClient.swap(ctx, secretHash, 0)
+		swap, err := test.refunderContractor.swap(ctx, secretHash)
 		if err != nil {
 			t.Fatalf("%s: unable to get swap state pre-init", test.name)
 		}
-		state := dexeth.SwapStep(swap.State)
-		if state != dexeth.SSNone {
-			t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, dexeth.SSNone, state)
+		if swap.State != dexeth.SSNone {
+			t.Fatalf("unexpected swap state for test %v: want %s got %s", test.name, dexeth.SSNone, swap.State)
 		}
 
-		inLocktime := uint64(time.Now().Add(locktime).Unix())
+		inLocktime := uint64(time.Now().Add(test.addTime).Unix())
 
-		_, err = ethClient.initiate(ctx, []*asset.Contract{newContract(inLocktime, secretHash, amt)}, maxFeeRate, 0)
+		txOpts, _ := ethClient.txOpts(ctx, optsVal, ethGases.SwapN(1), nil)
+		_, err = c.initiate(txOpts, []*asset.Contract{newContract(inLocktime, secretHash, amt)})
 		if err != nil {
 			t.Fatalf("%s: initiate error: %v ", test.name, err)
 		}
@@ -1194,23 +1173,24 @@ func testRefund(t *testing.T) {
 			if err := waitForMined(t, time.Second*8, false); err != nil {
 				t.Fatalf("%s: pre-redeem mining error: %v", test.name, err)
 			}
-			_, err := participantEthClient.redeem(ctx, []*asset.Redemption{newRedeem(secret, secretHash)}, maxFeeRate, 0)
+			txOpts, _ = participantEthClient.txOpts(ctx, 0, ethGases.RedeemN(1), nil)
+			_, err := pc.redeem(txOpts, []*asset.Redemption{newRedeem(secret, secretHash)})
 			if err != nil {
 				t.Fatalf("%s: redeem error: %v", test.name, err)
 			}
 		}
 
 		// This waitForMined will always take test.sleep to complete.
-		if err := waitForMined(t, test.sleep, true); err != nil {
+		if err := waitForMined(t, time.Second*8, false); err != nil {
 			t.Fatalf("unexpected post-init mining error for test %v: %v", test.name, err)
 		}
 
-		originalBal, err := ethClient.balance(ctx)
+		originalBal, err := balance()
 		if err != nil {
 			t.Fatalf("%s: balance error: %v", test.name, err)
 		}
 
-		isRefundable, err := test.refunderClient.isRefundable(secretHash, 0)
+		isRefundable, err := test.refunderContractor.isRefundable(secretHash)
 		if err != nil {
 			t.Fatalf("%s: isRefundable error %v", test.name, err)
 		}
@@ -1219,81 +1199,71 @@ func testRefund(t *testing.T) {
 				test.name, test.isRefundable, isRefundable)
 		}
 
-		tx, err := test.refunderClient.refund(ctx, secretHash, maxFeeRate, 0)
+		txOpts, _ = test.refunderClient.txOpts(ctx, 0, ethGases.Refund, nil)
+		tx, err := test.refunderContractor.refund(txOpts, secretHash)
 		if err != nil {
 			t.Fatalf("%s: refund error: %v", test.name, err)
 		}
 		spew.Dump(tx)
 
-		bal, err := ethClient.balance(ctx)
+		in, err := test.refunderContractor.incomingValue(ctx, tx)
 		if err != nil {
-			t.Fatalf("%s: balance error: %v", test.name, err)
+			t.Fatalf("%s: incomingValue error: %v", test.name, err)
 		}
 
-		if test.addFee && dexeth.WeiToGwei(bal.PendingIn) != amt {
-			t.Fatalf("%s: unexpected pending in balance %s", test.name, bal.PendingIn)
+		if test.addAmt && in != amt {
+			t.Fatalf("%s: unexpected pending in balance %d", test.name, in)
 		}
 
 		if err := waitForMined(t, time.Second*10, false); err != nil {
 			t.Fatalf("%s: post-refund mining error: %v", test.name, err)
 		}
 
-		// It appears the receipt is only accessible after the tx is mined.
-		receipt, err := ethClient.transactionReceipt(ctx, tx.Hash())
-		if err != nil {
-			t.Fatalf("%s: receipt error: %v", test.name, err)
+		receipt, err := test.refunderClient.checkTxStatus(ctx, tx, txOpts)
+		if err != nil && test.addAmt {
+			t.Fatalf("%s: failed redeem transaction status: %v", test.name, err)
 		}
 		spew.Dump(receipt)
+		fmt.Printf("Gas used for refund, success = %t: %d \n", test.addAmt, receipt.GasUsed)
 
 		// Balance should increase or decrease by a certain amount
 		// depending on whether redeem completed successfully on-chain.
 		// If unsuccessful the fee is subtracted. If successful, amt is
 		// added.
-		bal, err = ethClient.balance(ctx)
-		if err != nil {
-			t.Fatalf("%s: balance error: %v", test.name, err)
-		}
-		swap, err = ethClient.swap(ctx, secretHash, 0)
-		if err != nil {
-			t.Fatalf("%s: post-refund swap error: %v", test.name, err)
-		}
 		gasPrice, err := feesAtBlk(ctx, ethClient, receipt.BlockNumber.Int64())
 		if err != nil {
 			t.Fatalf("%s: feesAtBlk error: %v", test.name, err)
 		}
-		txFee := big.NewInt(0)
-		if test.addFee {
-			bigGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
-			txFee = new(big.Int).Mul(bigGasUsed, gasPrice)
-		}
-		wantBal := new(big.Int).Sub(originalBal.Current, txFee)
+		bigGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
+		txFee := new(big.Int).Mul(bigGasUsed, gasPrice)
+
+		wantBal := new(big.Int).Sub(originalBal, txFee)
 		if test.addAmt {
 			wantBal.Add(wantBal, dexeth.GweiToWei(amt))
 		}
 
-		diff := new(big.Int).Abs(new(big.Int).Sub(wantBal, bal.Current))
-		if diff.Cmp(new(big.Int)) != 0 {
-			t.Fatalf("%s: unexpected balance change: want %d got %d, diff = %d",
-				test.name, wantBal, bal.Current, diff)
+		bal, err := balance()
+		if err != nil {
+			t.Fatalf("%s: balance error: %v", test.name, err)
 		}
 
-		swap, err = ethClient.swap(ctx, secretHash, 0)
+		diff := new(big.Int).Sub(wantBal, bal)
+		if diff.CmpAbs(dexeth.GweiToWei(1)) >= 0 {
+			t.Fatalf("%s: unexpected balance change: want %d got %d, diff = %d",
+				test.name, dexeth.WeiToGwei(wantBal), dexeth.WeiToGwei(bal), dexeth.WeiToGwei(diff))
+		}
+
+		swap, err = test.refunderContractor.swap(ctx, secretHash)
 		if err != nil {
 			t.Fatalf("%s: post-refund swap error: %v", test.name, err)
 		}
-		state = dexeth.SwapStep(swap.State)
-		if state != test.finalState {
-			t.Fatalf("%s: wrong swap state: want %s got %s", test.name, test.finalState, state)
+		if swap.State != test.finalState {
+			t.Fatalf("%s: wrong swap state: want %s got %s", test.name, test.finalState, swap.State)
 		}
 	}
 }
 
 func testTokenBalance(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	bal, err := ethClient.tokenBalance(ctx, testTokenContractAddr)
 	if err != nil {
 		t.Fatal(err)
@@ -1306,14 +1276,9 @@ func testTokenBalance(t *testing.T) {
 }
 
 func testApproveAllowance(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	expectedAllowance := big.NewInt(1000)
 
-	_, err = ethClient.approveToken(ctx, testTokenContractAddr, expectedAllowance, maxFeeRate)
+	_, err := ethClient.approveToken(ctx, testTokenContractAddr, expectedAllowance, maxFeeRate)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1333,12 +1298,7 @@ func testApproveAllowance(t *testing.T) {
 }
 
 func TestInitiateTokenGas(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1000), maxFeeRate)
+	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1000), maxFeeRate)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1397,11 +1357,6 @@ func TestGetTokenAddress(t *testing.T) {
 }
 
 func testInitiateToken(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Create a slice of random secret hashes that can be used in the tests and
 	// make sure none of them have been used yet.
 	numSecretHashes := 10
@@ -1418,7 +1373,7 @@ func testInitiateToken(t *testing.T) {
 		}
 	}
 
-	_, err = ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1000), maxFeeRate)
+	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1000), maxFeeRate)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1543,11 +1498,7 @@ func testInitiateToken(t *testing.T) {
 }
 
 func TestRedeemTokenGas(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(10000), maxFeeRate)
+	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(10000), maxFeeRate)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1621,16 +1572,7 @@ func testRedeemToken(t *testing.T) {
 		secretHashes = append(secretHashes, secretHash)
 	}
 
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = participantEthClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1e6), maxFeeRate)
+	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1e6), maxFeeRate)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1744,7 +1686,7 @@ func testRedeemToken(t *testing.T) {
 			}
 		}
 
-		_, err = ethClient.initiateToken(ctx, test.swaps, testTokenContractAddr, maxFeeRate)
+		_, err := ethClient.initiateToken(ctx, test.swaps, testTokenContractAddr, maxFeeRate)
 		if err != nil {
 			t.Fatalf("%s: initiate error: %v ", test.name, err)
 		}
@@ -1829,15 +1771,7 @@ func testRedeemToken(t *testing.T) {
 func testRefundToken(t *testing.T) {
 	const amt = 1e5
 	locktime := time.Second * 12
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = participantEthClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1e6), maxFeeRate)
+	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1e6), maxFeeRate)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1966,16 +1900,11 @@ func testRefundToken(t *testing.T) {
 }
 
 func TestRefundTokenGas(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var secret [32]byte
 	copy(secret[:], encode.RandomBytes(32))
 	secretHash := sha256.Sum256(secret[:])
 
-	_, err = ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1e6), maxFeeRate)
+	_, err := ethClient.approveToken(ctx, testTokenContractAddr, big.NewInt(1e6), maxFeeRate)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2010,11 +1939,6 @@ func TestRefundTokenGas(t *testing.T) {
 }
 
 func TestReplayAttack(t *testing.T) {
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	txOpts, err := ethClient.txOpts(ctx, 1, defaultSendGasLimit*5, nil)
 	if err != nil {
 		t.Fatalf("txOpts error: %v", err)
@@ -2049,7 +1973,9 @@ func TestReplayAttack(t *testing.T) {
 
 		if i != 4 {
 			inLocktime := uint64(time.Now().Add(time.Hour).Unix())
-			_, err = ethClient.initiate(ctx, []*asset.Contract{newContract(inLocktime, secretHash, 1)}, maxFeeRate, 0)
+
+			txOpts, _ := ethClient.txOpts(ctx, 1, ethGases.SwapN(1), nil)
+			_, err = simnetContractor.initiate(txOpts, []*asset.Contract{newContract(inLocktime, secretHash, 1)})
 			if err != nil {
 				t.Fatalf("unable to initiate swap: %v ", err)
 			}
@@ -2096,7 +2022,7 @@ func TestReplayAttack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	originalAcctBal, err := ethClient.balance(ctx)
+	originalAcctBal, err := ethClient.addressBalance(ctx, simnetAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2120,31 +2046,31 @@ func TestReplayAttack(t *testing.T) {
 	}
 	bigGasUsed := new(big.Int).SetUint64(receipt.GasUsed)
 	txFee := new(big.Int).Mul(bigGasUsed, gasPrice)
-	wantBal := new(big.Int).Sub(originalAcctBal.Current, txFee)
+	wantBal := new(big.Int).Sub(originalAcctBal, txFee)
 
-	acctBal, err := ethClient.balance(ctx)
+	acctBal, err := ethClient.addressBalance(ctx, simnetAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// If the exploit worked, the test will fail here, with 4 ether we
 	// shouldn't be drained from the contract.
-	delta := new(big.Int).Sub(originalAcctBal.Current, acctBal.Current)
-	wantDelta := new(big.Int).Sub(originalAcctBal.Current, wantBal)
+	delta := new(big.Int).Sub(originalAcctBal, acctBal)
+	wantDelta := new(big.Int).Sub(originalAcctBal, wantBal)
 	diff := new(big.Int).Abs(new(big.Int).Sub(wantDelta, delta))
 	if dexeth.WeiToGwei(diff) > receipt.GasUsed { // See TestContract notes.
-		delta := new(big.Int).Sub(originalAcctBal.Current, acctBal.Current)
-		wantDelta := new(big.Int).Sub(originalAcctBal.Current, wantBal)
+		delta := new(big.Int).Sub(originalAcctBal, acctBal)
+		wantDelta := new(big.Int).Sub(originalAcctBal, wantBal)
 		diff := new(big.Int).Sub(wantDelta, delta)
 		t.Logf("unexpected balance change of account. original = %d, final = %d, expected %d",
-			dexeth.WeiToGwei(originalAcctBal.Current), dexeth.WeiToGwei(acctBal.Current), dexeth.WeiToGwei(wantBal))
+			dexeth.WeiToGwei(originalAcctBal), dexeth.WeiToGwei(acctBal), dexeth.WeiToGwei(wantBal))
 		t.Fatalf("actual change = %d, expected change = %d, a difference of %d",
 			dexeth.WeiToGwei(delta), dexeth.WeiToGwei(wantDelta), dexeth.WeiToGwei(diff))
 	}
 
 	// The exploit failed and status should be SSNone because initiation also
 	// failed.
-	swap, err := ethClient.swap(ctx, secretHash, 0)
+	swap, err := simnetContractor.swap(ctx, secretHash)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2188,10 +2114,6 @@ func testGetCodeAt(t *testing.T) {
 
 func testSignMessage(t *testing.T) {
 	msg := []byte("test message")
-	err := ethClient.unlock(pw)
-	if err != nil {
-		t.Fatalf("error unlocking account: %v", err)
-	}
 	sig, pubKey, err := ethClient.signData(msg)
 	if err != nil {
 		t.Fatalf("error signing text: %v", err)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -427,7 +427,7 @@ type Coin interface {
 type RecoveryCoin interface {
 	// RecoveryID is an ID that can be used to re-establish funding state during
 	// startup. If a Coin implements RecoveryCoin, the RecoveryID will be used
-	// in the database record, and ultimately passed to the FundingCoin method.
+	// in the database record, and ultimately passed to the FundingCoins method.
 	RecoveryID() dex.Bytes
 }
 


### PR DESCRIPTION
Preparing for tokens. Peeled off of #1399.

```
Moves contractor from nodeClient to ExchangeWallet. The changes the
ethFetcher API quite a bit, but is overall a simplification. To accomplish
this, I moved the nonceSendMtx to from nodeClient to ExchangeWallet too.
Nonce generation and signing is moved into nodeClient.txOpts to dedupe.

Use block headers instead of full blocks for tip monitoring.

Simplify fundingCoin and eliminate fundingCoinID.

Simplify tests using more consts and simpler structs.
```