### PR TITLE
client/core: Always create a settings map.

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1719,6 +1719,11 @@ func (c *Core) CreateWallet(appPW, walletPW []byte, form *WalletForm) error {
 			delete(form.Config, key)
 		}
 	}
+	// Sometimes core will insert data into the Settings map to communicate
+	// information back to the wallet, so it cannot be nil.
+	if form.Config == nil {
+		form.Config = make(map[string]string)
+	}
 
 	if walletDef.Seeded {
 		if len(walletPW) > 0 {


### PR DESCRIPTION
    Core will inject some data into the settings map, so make sure it always
    exists even if not included in the create form.

Solves a bug introduced by 32721d830 that causes a panic for eth.