### PR TITLE
client: stop accepting sigs on the truncated messages (sig fix stage 4)

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6630,10 +6630,7 @@ func checkSigS256(msg, pkBytes, sigBytes []byte) error {
 	}
 	hash := sha256.Sum256(msg)
 	if !signature.Verify(hash[:], pubKey) {
-		// Might be an older buggy server. (V0PURGE)
-		if !signature.Verify(msg, pubKey) {
-			return fmt.Errorf("secp256k1 signature verification failed")
-		}
+		return fmt.Errorf("secp256k1 signature verification failed")
 	}
 	return nil
 }


### PR DESCRIPTION
Rebased on https://github.com/decred/dcrdex/pull/1530.  This PR is just the one final commit https://github.com/decred/dcrdex/pull/1526/commits/70ec51bddbe9760cc0e882eae66f595f724cbd63

This is stage 4 of the signature message truncation fix plan outlined below.

In these commits, client **stops accepting** sigs on the truncated messages.  All servers must be sending the correct sigs i.e. have deployed the [stage 3](https://github.com/decred/dcrdex/pull/1530) of the fix.

----

## Full signature fix plan

In some places we were signing and verifying unhashed messages, resulting in truncation of the data we intend to sign and verify.  Because the truncation was performed on both sides, we didn't have errors, but the full payloads were not part of the verified message.  This included the signatures created and verified in the main comms (i.e. between `Core` and `AuthManager`), as well as in DCR and BTC's backends where coin signatures are used to verify ownership of the coins.

Note that in the asset coin sign/verify bits, it is always the client signing coins with their wallet keys, and the server verifying.  In other comms, both client and server are generating and verifying signatures.

Also note that all comms are end-to-end encrypted with TLS, and most truncated payloads included unique data anyway.  The message payloads and client signatures are also not publicly available data, so it is not straightforward to exploit this bug.

This change includes all the commits that will occur in several stages:
1. Both server and client start recognizing sigs created on both the correctly hashed message and the truncated messages. These commits should be deployed asap with 0.4.2 so that servers are ready when clients update and start sending correct signatures.  Server will continue to sign the truncated data so buggy clients will work with updated servers. https://github.com/decred/dcrdex/pull/1528
2. Client starts signing the hashed messages, making client incompatible with servers not running the fix in stage 1 (0.4.2). Client **continues accepting** sigs on the truncated messages.  Server continues sending the truncated message sigs. https://github.com/decred/dcrdex/pull/1529
3. Server starts signing the hashed messages, making server incompatible with clients not running the fix in stage 1 (0.4.2). Server **stops accepting** sigs on the truncated messages.  https://github.com/decred/dcrdex/pull/1530
4. Client **stops accepting** sigs on the truncated messages.

Note that stage 2 also fixes `client/core.(*Core).Register` failing to re-set their own pubkey in the `msgjson.RegisterResponse` from the server, where it is omitted from the JSON serialization but included in the binary serialization when the payload is signed.

In summary, the server commits should land in 0.4.2 (like **today**), while the client commits should land in master and later in 0.4.3+.
Lastly, a future commit for 0.5 and the "`V0PURGE`" should be drafted that makes server sign outgoing hashed messages _to_ the clients and stop verifying signatures on truncated data _from_ the client, breaking compatibility with older clients.

This approach is proposed to minimize disruption to older clients, delaying the breaking changes to 0.5/1.0 and the great v0 API purge.

Discuss. :older_woman:

**WARNING:** I've not tested this interactively yet.