### PR TITLE
start recognizing signatures of the hashed messages (sig fix stage 1)

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6,6 +6,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/csv"
 	"encoding/hex"
@@ -2975,6 +2976,9 @@ func (c *Core) register(dc *dexConnection, assetID uint32) (regRes *msgjson.Regi
 		if !bytes.Equal(dc.acct.dexPubKey.SerializeCompressed(), regRes.DEXPubKey) {
 			return nil, false, false, fmt.Errorf("different pubkeys reported by dex in 'config' and 'register' responses")
 		}
+		// Insert our pubkey back into the register result since it is excluded
+		// from the JSON serialization.
+		regRes.ClientPubKey = acctPubKey
 		// Check the DEX server's signature.
 		msg := regRes.Serialize()
 		err = checkSigS256(msg, regRes.DEXPubKey, regRes.Sig)
@@ -6545,17 +6549,27 @@ func checkSigS256(msg, pkBytes, sigBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("error decoding secp256k1 Signature from bytes: %w", err)
 	}
-	if !signature.Verify(msg, pubKey) {
-		return fmt.Errorf("secp256k1 signature verification failed")
+	hash := sha256.Sum256(msg)
+	if !signature.Verify(hash[:], pubKey) {
+		// Might be an older buggy server. (V0PURGE)
+		if !signature.Verify(msg, pubKey) {
+			return fmt.Errorf("secp256k1 signature verification failed")
+		}
 	}
 	return nil
+}
+
+// signMsg signs the message with provided private key.
+func signMsg(privKey *secp256k1.PrivateKey, msg []byte) []byte {
+	// NOTE: legacy servers will not accept this signature:
+	// hash := sha256.Sum256(msg)
+	return ecdsa.Sign(privKey, msg).Serialize()
 }
 
 // sign signs the msgjson.Signable with the provided private key.
 func sign(privKey *secp256k1.PrivateKey, payload msgjson.Signable) {
 	sigMsg := payload.Serialize()
-	sig := ecdsa.Sign(privKey, sigMsg) // should we be signing the *hash* of the payload?
-	payload.SetSig(sig.Serialize())
+	payload.SetSig(signMsg(privKey, sigMsg))
 }
 
 // stampAndSign time stamps the msgjson.Stampable, and signs it with the given

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -22,7 +22,6 @@ import (
 	"decred.org/dcrdex/dex/order"
 	"decred.org/dcrdex/server/account"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
 	"github.com/decred/dcrd/hdkeychain/v3"
 )
 
@@ -784,8 +783,7 @@ func (a *dexAccount) sign(msg []byte) ([]byte, error) {
 	if a.privKey == nil {
 		return nil, fmt.Errorf("account locked")
 	}
-	sig := ecdsa.Sign(a.privKey, msg)
-	return sig.Serialize(), nil
+	return signMsg(a.privKey, msg), nil
 }
 
 // checkSig checks the signature against the message and the DEX pubkey.

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -225,8 +225,6 @@ func (s *Signature) SetSig(b []byte) {
 
 // SigBytes returns the signature as a []byte.
 func (s *Signature) SigBytes() []byte {
-	// Assuming the Sig was set with SetSig, there is likely no way to error
-	// here. Ignoring error for now.
 	return s.Sig
 }
 
@@ -966,7 +964,9 @@ func (r *Register) Serialize() []byte {
 // RegisterResult is the result for the response to Register.
 type RegisterResult struct {
 	Signature
-	DEXPubKey    Bytes   `json:"pubkey"`
+	DEXPubKey Bytes `json:"pubkey"`
+	// ClientPubKey is excluded from the JSON payload to save bandwidth. The
+	// client must add it back to verify the server's signature.
 	ClientPubKey Bytes   `json:"-"`
 	AssetID      *uint32 `json:"feeAsset,omitempty"` // default to 42 if not set by server
 	Address      string  `json:"address"`

--- a/server/asset/dcr/script.go
+++ b/server/asset/dcr/script.go
@@ -6,6 +6,7 @@ package dcr
 import (
 	"fmt"
 
+	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/edwards/v2"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -37,8 +38,13 @@ func checkSigS256(msg, pkBytes, sigBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("error decoding secp256k1 Signature from bytes: %w", err)
 	}
-	if !signature.Verify(msg, pubKey) {
-		return fmt.Errorf("secp256k1 signature verification failed")
+	hash := chainhash.HashB(msg)
+	if !signature.Verify(hash, pubKey) {
+		// This might be a legacy (buggy) client that signed the truncated
+		// message itself. (V0PURGE!)
+		if !signature.Verify(msg, pubKey) {
+			return fmt.Errorf("secp256k1 signature verification failed")
+		}
 	}
 	return nil
 }
@@ -54,8 +60,13 @@ func checkSigEdwards(msg, pkBytes, sigBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("error decoding edwards Signature from bytes: %w", err)
 	}
-	if !signature.Verify(msg, pubKey) {
-		return fmt.Errorf("edwards signature verification failed")
+	hash := chainhash.HashB(msg)
+	if !signature.Verify(hash, pubKey) {
+		// This might be a legacy (buggy) client that signed the truncated
+		// message itself. (V0PURGE!)
+		if !signature.Verify(msg, pubKey) {
+			return fmt.Errorf("edwards signature verification failed")
+		}
 	}
 	return nil
 }
@@ -71,8 +82,13 @@ func checkSigSchnorr(msg, pkBytes, sigBytes []byte) error {
 	if err != nil {
 		return fmt.Errorf("error decoding schnorr Signature from bytes: %w", err)
 	}
-	if !signature.Verify(msg, pubKey) {
-		return fmt.Errorf("schnorr signature verification failed")
+	hash := chainhash.HashB(msg)
+	if !signature.Verify(hash, pubKey) {
+		// This might be a legacy (buggy) client that signed the truncated
+		// message itself. (V0PURGE!)
+		if !signature.Verify(msg, pubKey) {
+			return fmt.Errorf("schnorr signature verification failed")
+		}
 	}
 	return nil
 }

--- a/server/auth/registrar.go
+++ b/server/auth/registrar.go
@@ -61,7 +61,7 @@ func (auth *AuthManager) handleRegister(conn comms.Link, msg *msgjson.Message) *
 		// Prepare, sign, and send response.
 		regRes := &msgjson.RegisterResult{
 			DEXPubKey:    auth.signer.PubKey().SerializeCompressed(),
-			ClientPubKey: register.PubKey,
+			ClientPubKey: register.PubKey, // only for serialization and signature, not sent to client
 			AssetID:      &feeAsset,
 			Address:      feeAddr,
 			Fee:          feeAmt,


### PR DESCRIPTION
This is stage 1 of the signature message truncation fix plan outlined https://github.com/decred/dcrdex/pull/1526.

In these commits, both client and server begin recognizing signatures of both the truncated messages or the message hash.  Neither side begins signing the message hash.  After this has been deployed to servers, the next stage (https://github.com/decred/dcrdex/pull/1529) has the client begin creating signatures of the hashed messages.