### PR TITLE
client: sign and verify hashed messages (sig fix stage 2)

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2184,12 +2184,13 @@ func (btc *baseWallet) SignMessage(coin asset.Coin, msg dex.Bytes) (pubkeys, sig
 		return nil, nil, err
 	}
 	pk := privKey.PubKey()
-	sig, err := privKey.Sign(msg)
+	hash := chainhash.HashB(msg) // legacy servers will not accept this signature!
+	sig, err := privKey.Sign(hash)
 	if err != nil {
 		return nil, nil, err
 	}
 	pubkeys = append(pubkeys, pk.SerializeCompressed())
-	sigs = append(sigs, sig.Serialize())
+	sigs = append(sigs, sig.Serialize()) // DER format serialization
 	return
 }
 

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1862,8 +1862,9 @@ func testSignMessage(t *testing.T, segwit bool, walletType string) {
 	}
 
 	msg := randBytes(36)
+	msgHash := chainhash.HashB(msg)
 	pk := pubKey.SerializeCompressed()
-	signature, err := privKey.Sign(msg)
+	signature, err := privKey.Sign(msgHash)
 	if err != nil {
 		t.Fatalf("signature error: %v", err)
 	}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1788,9 +1788,10 @@ func (dcr *ExchangeWallet) SignMessage(coin asset.Coin, msg dex.Bytes) (pubkeys,
 		return nil, nil, err
 	}
 	defer priv.Zero()
-	signature := ecdsa.Sign(priv, msg)
+	hash := chainhash.HashB(msg) // legacy servers will not accept this signature!
+	signature := ecdsa.Sign(priv, hash)
 	pubkeys = append(pubkeys, priv.PubKey().SerializeCompressed())
-	sigs = append(sigs, signature.Serialize())
+	sigs = append(sigs, signature.Serialize()) // DER format
 	return pubkeys, sigs, nil
 }
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1557,7 +1557,8 @@ func TestSignMessage(t *testing.T) {
 
 	msg := randBytes(36)
 	pk := pubKey.SerializeCompressed()
-	signature := ecdsa.Sign(privKey, msg)
+	msgHash := chainhash.HashB(msg)
+	signature := ecdsa.Sign(privKey, msgHash)
 	sig := signature.Serialize()
 
 	node.privWIF, err = dcrutil.NewWIF(privBytes, tChainParams.PrivateKeyID, dcrec.STEcdsaSecp256k1)

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -10,6 +10,8 @@ import (
 
 	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex/order"
+	"decred.org/dcrdex/server/account"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
 func TestAccountExport(t *testing.T) {
@@ -236,11 +238,12 @@ func TestAccountExportAccountProofError(t *testing.T) {
 }
 
 func buildTestAccount(host string) Account {
+	privKey, _ := secp256k1.GeneratePrivateKey()
 	return Account{
 		Host:          host,
-		AccountID:     tDexAccountID.String(),
+		AccountID:     account.NewID(privKey.PubKey().SerializeCompressed()).String(), // can be anything though
+		PrivKey:       hex.EncodeToString(privKey.Serialize()),
 		DEXPubKey:     hex.EncodeToString(tDexKey.SerializeCompressed()),
-		PrivKey:       hex.EncodeToString(tDexPriv.Serialize()),
 		Cert:          hex.EncodeToString([]byte{0x1}),
 		FeeCoin:       hex.EncodeToString([]byte("somecoin")),
 		FeeProofSig:   hex.EncodeToString(tFeeProofSig),

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6590,8 +6590,8 @@ func convertAssetInfo(ai *msgjson.Asset) *dex.Asset {
 	}
 }
 
-// checkSigS256 checks that the message's signature was created with the
-// private key for the provided secp256k1 public key.
+// checkSigS256 checks that the message's signature was created with the private
+// key for the provided secp256k1 public key on the sha256 hash of the message.
 func checkSigS256(msg, pkBytes, sigBytes []byte) error {
 	pubKey, err := secp256k1.ParsePubKey(pkBytes)
 	if err != nil {
@@ -6611,11 +6611,12 @@ func checkSigS256(msg, pkBytes, sigBytes []byte) error {
 	return nil
 }
 
-// signMsg signs the message with provided private key.
+// signMsg hashes and signs the message with the sha256 hash function and the
+// provided private key.
 func signMsg(privKey *secp256k1.PrivateKey, msg []byte) []byte {
-	// NOTE: legacy servers will not accept this signature:
-	// hash := sha256.Sum256(msg)
-	return ecdsa.Sign(privKey, msg).Serialize()
+	// NOTE: legacy servers will not accept this signature.
+	hash := sha256.Sum256(msg)
+	return ecdsa.Sign(privKey, hash[:]).Serialize()
 }
 
 // sign signs the msgjson.Signable with the provided private key.


### PR DESCRIPTION
<s>Rebased on https://github.com/decred/dcrdex/pull/1528</s>

This is stage 2 of the signature message truncation fix plan outlined in https://github.com/decred/dcrdex/pull/1526.

In these commits, client begins signing the hashed messages, but **continues to recognize the buggy signatures** from the server.  This is because the while the server understands the correct hashed message signatures [as of stage 1](https://github.com/decred/dcrdex/pull/1528), it is still sending the old signatures with its messages.

This work can be backported to a 0.4.3+ release if https://github.com/decred/dcrdex/pull/1528 has been deployed with 0.4.2.

In the next stage, the server begins sending the correct signatures.