### PR TITLE
server: sign and verify hashed messages (sig fix stage 3)

### DIFF
--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -524,7 +524,8 @@ func s256Auth(msg []byte) *testAuth {
 	if msg == nil {
 		msg = randomBytes(32)
 	}
-	sig, err := priv.Sign(msg)
+	hash := sha256.Sum256(msg)
+	sig, err := priv.Sign(hash[:])
 	if err != nil {
 		fmt.Printf("s256Auth sign error: %v\n", err)
 	}

--- a/server/asset/btc/script.go
+++ b/server/asset/btc/script.go
@@ -23,11 +23,7 @@ func checkSig(msg, pkBytes, sigBytes []byte) error {
 	}
 	hash := sha256.Sum256(msg)
 	if !signature.Verify(hash[:], pubKey) {
-		// This might be a legacy (buggy) client that signed the truncated
-		// message itself. (V0PURGE!)
-		if !signature.Verify(msg, pubKey) {
-			return fmt.Errorf("signature verification failed")
-		}
+		return fmt.Errorf("signature verification failed")
 	}
 	return nil
 }

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -408,7 +408,8 @@ func s256Auth(msg []byte) *testAuth {
 	if msg == nil {
 		msg = randomBytes(32)
 	}
-	sig := ecdsa.Sign(priv, msg)
+	hash := chainhash.HashB(msg)
+	sig := ecdsa.Sign(priv, hash)
 	return &testAuth{
 		pubkey: pubkey,
 		pkHash: dcrutil.Hash160(pubkey),
@@ -426,7 +427,8 @@ func edwardsAuth(msg []byte) *testAuth {
 	if msg == nil {
 		msg = randomBytes(32)
 	}
-	sig, err := priv.Sign(msg)
+	hash := chainhash.HashB(msg)
+	sig, err := priv.Sign(hash)
 	if err != nil {
 		fmt.Printf("edwardsAuth sign error: %v\n", err)
 	}
@@ -447,7 +449,8 @@ func schnorrAuth(msg []byte) *testAuth {
 	if msg == nil {
 		msg = randomBytes(32)
 	}
-	sig, err := schnorr.Sign(priv, msg)
+	hash := chainhash.HashB(msg)
+	sig, err := schnorr.Sign(priv, hash)
 	if err != nil {
 		fmt.Printf("schnorrAuth sign error: %v\n", err)
 	}

--- a/server/asset/dcr/script.go
+++ b/server/asset/dcr/script.go
@@ -40,11 +40,7 @@ func checkSigS256(msg, pkBytes, sigBytes []byte) error {
 	}
 	hash := chainhash.HashB(msg)
 	if !signature.Verify(hash, pubKey) {
-		// This might be a legacy (buggy) client that signed the truncated
-		// message itself. (V0PURGE!)
-		if !signature.Verify(msg, pubKey) {
-			return fmt.Errorf("secp256k1 signature verification failed")
-		}
+		return fmt.Errorf("secp256k1 signature verification failed")
 	}
 	return nil
 }
@@ -62,11 +58,7 @@ func checkSigEdwards(msg, pkBytes, sigBytes []byte) error {
 	}
 	hash := chainhash.HashB(msg)
 	if !signature.Verify(hash, pubKey) {
-		// This might be a legacy (buggy) client that signed the truncated
-		// message itself. (V0PURGE!)
-		if !signature.Verify(msg, pubKey) {
-			return fmt.Errorf("edwards signature verification failed")
-		}
+		return fmt.Errorf("edwards signature verification failed")
 	}
 	return nil
 }
@@ -84,11 +76,7 @@ func checkSigSchnorr(msg, pkBytes, sigBytes []byte) error {
 	}
 	hash := chainhash.HashB(msg)
 	if !signature.Verify(hash, pubKey) {
-		// This might be a legacy (buggy) client that signed the truncated
-		// message itself. (V0PURGE!)
-		if !signature.Verify(msg, pubKey) {
-			return fmt.Errorf("schnorr signature verification failed")
-		}
+		return fmt.Errorf("schnorr signature verification failed")
 	}
 	return nil
 }

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -532,11 +532,7 @@ func checkSigS256(msg, sig []byte, pubKey *secp256k1.PublicKey) error {
 	}
 	hash := sha256.Sum256(msg)
 	if !signature.Verify(hash[:], pubKey) {
-		// This might be a legacy (buggy) client that signed the truncated
-		// message itself. (V0PURGE!)
-		if !signature.Verify(msg, pubKey) {
-			return fmt.Errorf("secp256k1 signature verification failed")
-		}
+		return fmt.Errorf("secp256k1 signature verification failed")
 	}
 	return nil
 }
@@ -551,11 +547,10 @@ func (auth *AuthManager) Auth(user account.AccountID, msg, sig []byte) error {
 }
 
 // SignMsg signs the message with the DEX private key, returning the DER encoded
-// signature. VOPURGE: This must switch to hashing the msg with sha256 first!
+// signature. SHA256 is used to hash the message before signing it.
 func (auth *AuthManager) SignMsg(msg []byte) []byte {
-	// VOPURGE: Switch to the msg hash, not the message itself that gets
-	// truncated. i.e. hash := sha256.Sum256(msg); Sign(hash[:])
-	return auth.signer.Sign(msg).Serialize()
+	hash := sha256.Sum256(msg)
+	return auth.signer.Sign(hash[:]).Serialize()
 }
 
 // Sign signs the msgjson.Signables with the DEX private key.


### PR DESCRIPTION
This is stage 3 of the signature message truncation fix plan outlined in https://github.com/decred/dcrdex/pull/1526.

In these commits, server:
1. Begins signing the hashed messages
2. **Stops recognizing** the buggy signatures.

All clients must be running with the [stage 2 fix](https://github.com/decred/dcrdex/pull/1529) in v0.4.3 before this change can be deployed.

In the [next and final stage](https://github.com/decred/dcrdex/pull/1526), the client drops support for truncated message signatures from the server running at this point.