### PR TITLE
server/wslink: Add SendRaw.

### DIFF
--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -145,6 +145,7 @@ type TRPCClient struct {
 	ip         dex.IPKey
 	addr       string
 	sendErr    error
+	sendRawErr error
 	requestErr error
 	banished   bool
 	sends      []*msgjson.Message
@@ -160,6 +161,17 @@ func (c *TRPCClient) Authorized()   {}
 func (c *TRPCClient) Send(msg *msgjson.Message) error {
 	c.sends = append(c.sends, msg)
 	return c.sendErr
+}
+func (c *TRPCClient) SendRaw(b []byte) error {
+	if c.sendRawErr != nil {
+		return c.sendRawErr
+	}
+	msg, err := msgjson.DecodeMessage(b)
+	if err != nil {
+		return err
+	}
+	c.sends = append(c.sends, msg)
+	return nil
 }
 func (c *TRPCClient) SendError(id uint64, msg *msgjson.Error) {
 }

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -30,6 +30,10 @@ type Link interface {
 	Addr() string
 	// Send sends the msgjson.Message to the peer.
 	Send(msg *msgjson.Message) error
+	// SendRaw sends the raw bytes which is assumed to be a marshalled
+	// msgjson.Message to the peer. Can be used to avoid marshalling the
+	// same message multiple times.
+	SendRaw(b []byte) error
 	// SendError sends the msgjson.Error to the peer, with reference to a
 	// request message ID.
 	SendError(id uint64, rpcErr *msgjson.Error)


### PR DESCRIPTION
    In order to avoid marshalling the same message multiple times when
    sending to multiple clients, marshal once and send the raw bytes.

closes #1478 