### PR TITLE
fix inconsistent wallet sync status

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4088,8 +4088,8 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 				unbip(w.AssetID))
 		}
 		if !w.synced {
-			return fmt.Errorf("%s still syncing. progress = %.2f", unbip(w.AssetID),
-				w.syncProgress)
+			return fmt.Errorf("%s still syncing. progress = %.2f%%", unbip(w.AssetID),
+				w.syncProgress*100)
 		}
 		return nil
 	}


### PR DESCRIPTION
This diff properly formats wallet sync status.
![dexsync](https://user-images.githubusercontent.com/57448127/159069332-0cd62ca7-2b25-4ffc-8000-0f060a56106b.PNG)
Closes #1514 