### PR TITLE
server/swap: better contract expiry edge case handling

### DIFF
--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -214,7 +214,10 @@ const (
 		SET bSigAckOfARedeem = $2
 		WHERE matchid = $1;`
 
-	SetSwapDone = `UPDATE %s SET active = FALSE
+	SetSwapDone = `UPDATE %s SET active = FALSE  -- leave forgiven NULL
+		WHERE matchid = $1;`
+
+	SetSwapDoneForgiven = `UPDATE %s SET active = FALSE, forgiven = TRUE
 		WHERE matchid = $1;`
 
 	SelectMatchStatuses = `SELECT takerSell, (takerAccount = $1) AS isTaker, (makerAccount = $1) AS isMaker, matchid, status, aContract, bContract, aContractCoinID,

--- a/server/db/driver/pg/matches.go
+++ b/server/db/driver/pg/matches.go
@@ -714,6 +714,9 @@ func (a *Archiver) SaveRedeemB(mid db.MarketMatchID, coinID []byte, timestamp in
 
 // SetMatchInactive flags the match as done/inactive. This is not necessary if
 // SaveRedeemAckSigB is run for the match since it will flag the match as done.
-func (a *Archiver) SetMatchInactive(mid db.MarketMatchID) error {
+func (a *Archiver) SetMatchInactive(mid db.MarketMatchID, forgive bool) error {
+	if forgive {
+		return a.updateMatchStmt(mid, internal.SetSwapDoneForgiven, mid.MatchID)
+	} // else leave the forgiven column NULL
 	return a.updateMatchStmt(mid, internal.SetSwapDone, mid.MatchID)
 }

--- a/server/db/driver/pg/matches_online_test.go
+++ b/server/db/driver/pg/matches_online_test.go
@@ -532,7 +532,7 @@ func TestMarketMatches(t *testing.T) {
 		MatchID: match.ID(),
 		Base:    base,
 		Quote:   quote,
-	})
+	}, false)
 
 	// This one has txns.
 	mktMatchID := db.MarketMatchID{
@@ -672,7 +672,7 @@ func generateMatch(t *testing.T, matchStatus order.MatchStatus, active bool, mak
 		Active: active,
 	}
 	if !active {
-		archie.SetMatchInactive(mktMatchID)
+		archie.SetMatchInactive(mktMatchID, false)
 	}
 	for iStatus := order.NewlyMatched; iStatus <= matchStatus; iStatus++ {
 		switch iStatus {
@@ -748,7 +748,7 @@ func TestCompletedAndAtFaultMatchStats(t *testing.T) {
 		MatchID: matchLTC.ID(),
 		Base:    limitBuy.Base(),
 		Quote:   limitBuy.Quote(),
-	})
+	}, false)
 	// 7: success
 	matches = append(matches, &matchPair{
 		match: matchLTC,
@@ -757,6 +757,7 @@ func TestCompletedAndAtFaultMatchStats(t *testing.T) {
 			Status: matchLTC.Status,
 		},
 	})
+	// TODO: update with a forgiven one
 
 	epochTime := func(mp *matchPair) int64 {
 		return encode.UnixMilli(mp.match.Epoch.End())
@@ -870,7 +871,7 @@ func TestAllActiveUserMatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InsertMatch() failed: %v", err)
 	}
-	err = archie.SetMatchInactive(db.MatchID(match)) // set inactive
+	err = archie.SetMatchInactive(db.MatchID(match), false) // set inactive, not forgiven
 	if err != nil {
 		t.Fatalf("SetMatchInactive() failed: %v", err)
 	}

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -435,8 +435,12 @@ type SwapArchiver interface {
 
 	// SetMatchInactive sets the swap as done/inactive. This can be because of a
 	// failed or successfully completed swap, but in practice this will be used
-	// for failed swaps since SaveRedeemB flags the swap as done/inactive.
-	SetMatchInactive(mid MarketMatchID) error
+	// for failed swaps since SaveRedeemB flags the swap as done/inactive. If
+	// the match is being marked as inactive prior to MatchComplete (the match
+	// was revoked) but the user is not at fault, the forgive bool may be set to
+	// true so the outcome will not count against the user who would have the
+	// next action in the swap.
+	SetMatchInactive(mid MarketMatchID, forgive bool) error
 }
 
 // ValidateOrder ensures that the order with the given status for the specified

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -212,8 +212,8 @@ func (ta *TArchivist) SaveRedeemAckSigB(mid db.MarketMatchID, sig []byte) error 
 func (ta *TArchivist) SaveRedeemB(mid db.MarketMatchID, coinID []byte, timestamp int64) error {
 	return nil
 }
-func (ta *TArchivist) SetMatchInactive(mid db.MarketMatchID) error           { return nil }
-func (ta *TArchivist) LoadEpochStats(uint32, uint32, []*candles.Cache) error { return nil }
+func (ta *TArchivist) SetMatchInactive(mid db.MarketMatchID, forgive bool) error { return nil }
+func (ta *TArchivist) LoadEpochStats(uint32, uint32, []*candles.Cache) error     { return nil }
 
 type TCollector struct{}
 

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1802,20 +1802,9 @@ func (s *Swapper) handleInit(user account.AccountID, msg *msgjson.Message) *msgj
 	// checked in processInit. Note that value cannot be checked as transaction
 	// details, which includes the coin/output value, are not yet retrieved.
 
-	// Do not search for the transaction past the inaction deadline. For maker,
-	// this is bTimeout after match request. For taker, this is bTimeout after
-	// maker's swap reached swapConfs.
-	lastEvent := stepInfo.match.time // NewlyMatched - the match request time, not matchTime
-	if stepInfo.step == order.MakerSwapCast {
-		lastEvent = stepInfo.match.makerStatus.swapConfTime()
-	}
+	// Search for the transaction for the full txWaitExpiration, even if it goes
+	// past the inaction deadline. processInit recognizes when it is revoked.
 	expireTime := time.Now().Add(txWaitExpiration).UTC()
-	if lastEvent.IsZero() {
-		log.Warnf("Prematurely received 'init' from %v at step %v. acct = %s, match = %s",
-			makerTaker(stepInfo.actor.isMaker), stepInfo.step, stepInfo.actor.user, stepInfo.match.ID())
-	} else if deadline := lastEvent.Add(s.bTimeout); expireTime.After(deadline) {
-		expireTime = deadline
-	}
 	log.Debugf("Allowing until %v (%v) to locate contract from %v (%v), match %v",
 		expireTime, time.Until(expireTime), makerTaker(stepInfo.actor.isMaker),
 		stepInfo.step, matchID)
@@ -1894,19 +1883,9 @@ func (s *Swapper) handleRedeem(user account.AccountID, msg *msgjson.Message) *ms
 		}
 	}
 
-	// Do not search for the transaction past the inaction deadline. For maker,
-	// this is bTimeout after taker's swap reached swapConfs. For taker, this is
-	// bTimeout after maker's redeem cast (and redemption request time).
-	lastEvent := stepInfo.match.takerStatus.swapConfTime() // TakerSwapCast
-	if stepInfo.step == order.MakerRedeemed {
-		lastEvent = stepInfo.match.makerStatus.redeemSeenTime()
-	}
+	// Search for the transaction for the full txWaitExpiration, even if it goes
+	// past the inaction deadline. processRedeem recognizes when it is revoked.
 	expireTime := time.Now().Add(txWaitExpiration).UTC()
-	if lastEvent.IsZero() {
-		log.Warnf("Prematurely received 'redeem' from %v at step %v", makerTaker(stepInfo.actor.isMaker), stepInfo.step)
-	} else if deadline := lastEvent.Add(s.bTimeout); expireTime.After(deadline) {
-		expireTime = deadline
-	}
 	log.Debugf("Allowing until %v (%v) to locate redeem from %v (%v), match %v",
 		expireTime, time.Until(expireTime), makerTaker(stepInfo.actor.isMaker),
 		stepInfo.step, matchID)

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -119,6 +119,14 @@ type matchTracker struct {
 	takerStatus *swapStatus
 }
 
+// expiredBy returns true if the lock time of either party's *known* swap is
+// before the reference time e.g. time.Now().
+func (mt *matchTracker) expiredBy(ref time.Time) bool {
+	mSwap, tSwap := mt.makerStatus.swap, mt.takerStatus.swap
+	return (tSwap != nil && tSwap.LockTime.Before(ref)) ||
+		(mSwap != nil && mSwap.LockTime.Before(ref))
+}
+
 // A blockNotification is used internally when an asset.Backend reports a new
 // block.
 type blockNotification struct {
@@ -871,7 +879,7 @@ func (s *Swapper) tryConfirmSwap(ctx context.Context, status *swapStatus, confTi
 	}
 	confs, err := status.swap.Confirmations(ctx)
 	if err != nil {
-		// The transaction has become invalid. No reason to do anything.
+		log.Warnf("Unable to get confirmations for swap tx %v: %v", status.swap.TxID(), err)
 		return
 	}
 	// If a swapStatus was created, the asset.Asset is already known to be in
@@ -935,7 +943,11 @@ func (s *Swapper) processBlock(ctx context.Context, block *blockNotification) {
 	}
 }
 
-func (s *Swapper) failMatch(match *matchTracker) {
+// failMatch revokes the match and marks the swap as done for accounting
+// purposes. If userFault is false, there will be no penalty, such as if the
+// failure is because a swap tx lock time expired before required confirmations
+// were reached.
+func (s *Swapper) failMatch(match *matchTracker, userFault bool) {
 	// From the match status, determine maker/taker fault and the corresponding
 	// auth.NoActionStep.
 	var makerFault bool
@@ -965,14 +977,14 @@ func (s *Swapper) failMatch(match *matchTracker) {
 	if makerFault {
 		orderAtFault, otherOrder = match.Maker, match.Taker
 	}
-	log.Debugf("failMatch: swap %v failing (maker fault = %v) at %v",
-		match.ID(), makerFault, match.Status)
+	log.Debugf("failMatch: swap %v failing at %v (%v), user fault = %v",
+		match.ID(), match.Status, misstep, userFault)
 
 	// Record the end of this match's processing.
-	s.storage.SetMatchInactive(db.MatchID(match.Match))
+	s.storage.SetMatchInactive(db.MatchID(match.Match), !userFault)
 
 	// Cancellation rate accounting
-	s.swapDone(orderAtFault, match.Match, true) // will also unbook/revoke order if needed
+	s.swapDone(orderAtFault, match.Match, userFault) // will also unbook/revoke order if needed
 
 	// Accounting for the maker has already taken place if they have redeemed.
 	if match.Status != order.MakerRedeemed {
@@ -980,7 +992,10 @@ func (s *Swapper) failMatch(match *matchTracker) {
 	}
 
 	// Register the failure to act violation, adjusting the user's score.
-	s.authMgr.Inaction(orderAtFault.User(), misstep, db.MatchID(match.Match), match.Quantity, refTime, orderAtFault.ID())
+	if userFault {
+		s.authMgr.Inaction(orderAtFault.User(), misstep, db.MatchID(match.Match),
+			match.Quantity, refTime, orderAtFault.ID())
+	}
 
 	// Send the revoke_match messages, and solicit acks.
 	s.revoke(match)
@@ -1016,8 +1031,8 @@ func (s *Swapper) checkInactionEventBased() {
 
 		log.Tracef("checkInactionEventBased: match %v (%v)", match.ID(), match.Status)
 
-		failMatch := func() {
-			s.failMatch(match)
+		failMatch := func(fault bool) {
+			s.failMatch(match, fault)
 			deletions = append(deletions, match)
 		}
 
@@ -1026,14 +1041,34 @@ func (s *Swapper) checkInactionEventBased() {
 			// Maker has not broadcast their swap. They have until match time
 			// plus bTimeout.
 			if tooOld(match.time) {
-				failMatch()
+				failMatch(true)
+			}
+		case order.MakerSwapCast:
+			// If the taker contract's expected lock time would be in the past,
+			// revoke this match with no penalty.
+			expectedTakerLockTime := match.matchTime.Add(s.lockTimeTaker)
+			if expectedTakerLockTime.Before(now) {
+				log.Infof("Revoking match %v at %v because the expected taker swap locktime would be in the past (%v).",
+					match.ID(), match.Status, expectedTakerLockTime)
+				failMatch(false)
+			}
+			// The taker's contract should expire first, but also check the lock
+			// time of the maker's known swap.
+			fallthrough
+		case order.TakerSwapCast:
+			// If either published contract's lock time is already passed,
+			// revoke with no penalty because the swap cannot complete safely.
+			if match.expiredBy(now) {
+				log.Infof("Revoking match %v at %v because at least one published contract has expired.",
+					match.ID(), match.Status)
+				failMatch(false)
 			}
 		case order.MakerRedeemed:
 			// If the maker has redeemed, the taker can redeem immediately, so
 			// check the timeout against the time the Swapper received the
 			// maker's `redeem` request (and sent the taker's 'redemption').
 			if tooOld(match.makerStatus.redeemSeenTime()) {
-				failMatch()
+				failMatch(true)
 			}
 		}
 	}
@@ -1086,7 +1121,8 @@ func (s *Swapper) checkInactionBlockBased(assetID uint32) {
 			assetID, match.ID(), match.Status)
 
 		failMatch := func() {
-			s.failMatch(match)
+			// Fail the match, and assign fault if lock times are not passed.
+			s.failMatch(match, !match.expiredBy(now))
 			deletions = append(deletions, match)
 		}
 

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -336,7 +336,7 @@ func (ts *TStorage) SaveRedeemAckSigB(mid db.MarketMatchID, sig []byte) error {
 func (ts *TStorage) SaveRedeemB(mid db.MarketMatchID, coinID []byte, timestamp int64) error {
 	return nil
 }
-func (ts *TStorage) SetMatchInactive(mid db.MarketMatchID) error { return nil }
+func (ts *TStorage) SetMatchInactive(mid db.MarketMatchID, forgive bool) error { return nil }
 
 type redeemKey struct {
 	redemptionCoin       string

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -1172,6 +1172,10 @@ func tMatchInfo(maker, taker *tUser, matchQty, matchRate uint64, makerOrder *ord
 		Rate:         matchRate,
 		FeeRateBase:  42,
 		FeeRateQuote: 62,
+		Epoch: order.EpochID{ // make Epoch.End() be now, Idx and Dur not important per se
+			Idx: encode.UnixMilliU(unixMsNow()),
+			Dur: 1,
+		}, // Need Epoch set for lock time
 	}
 	mid := match.ID()
 	maker.matchIDs = append(maker.matchIDs, mid)
@@ -1204,6 +1208,7 @@ func (set *tMatchSet) add(matchInfo *tMatch) *tMatchSet {
 		fmt.Println("!!!tMatchSet taker mismatch!!!")
 	}
 	ms := set.matchSet
+	ms.Epoch = matchInfo.match.Epoch
 	ms.Makers = append(ms.Makers, match.Maker)
 	ms.Amounts = append(ms.Amounts, matchInfo.qty)
 	ms.Rates = append(ms.Rates, matchInfo.rate)
@@ -1231,11 +1236,14 @@ func tMultiMatchSet(matchQtys, rates []uint64, makerSell bool, isMarket bool) *t
 		takerOrder = makeLimitOrder(sum*5/4, rates[0], taker, !makerSell)
 	}
 	set := new(tMatchSet)
+	now := encode.UnixMilliU(unixMsNow())
 	for i, v := range matchQtys {
 		maker := tNewUser("maker" + strconv.Itoa(i))
 		// Alternate market and limit orders
 		makerOrder := makeLimitOrder(v, rates[i], maker, makerSell)
 		matchInfo := tMatchInfo(maker, taker, v, rates[i], makerOrder, takerOrder)
+		matchInfo.match.Epoch.Idx = now
+		matchInfo.match.Epoch.Dur = 1
 		set.add(matchInfo)
 	}
 	return set


### PR DESCRIPTION
This PR contains three closely related updates to `Swapper` to improve the handling of matches around broadcast timeout and contract expiration.

**server/swap: wait for init/redeem for full wait expiration** https://github.com/decred/dcrdex/pull/1541/commits/bf2001c857cd4de4796256b939ece8151d50b6b8

```
In handleInit and handleRedeem, do not bother to limit the expiration
time of the processInit/processRedeem waiters by the broadcast timeout.
Both of the TryFuncs (processInit and processRedeem) will respond in
error if the match is revoked, so there is no need to tweak the waiter's
expire time.

This will prevent a client request timeout when the init or redeem is
submitted just before the Swapper revokes the match, when the waiter's
expire time could be set to the past despite the inaction checks having
not yet revoked the match.
```

**server/swap: revoke when contracts are/would be expired** https://github.com/decred/dcrdex/pull/1541/commits/1be939f37faa724a468b53d2fa2d7e5f908f3e03

```
This updates Swapper to proactively revoke matches where any known swap
contracts are expired, or in the case of MakerSwapCast where the
expected taker contract would be created with a lock time in the past.
These scenarios are possible if a transaction takes an extremely long
time to reach the required number of confirmations.

The new checks are done in checkInactionEventBased, which is called
on a ticker.

The (*Swapper).failMatch method is given a userFault bool input
argument to indicate if the actor should be penalized.

matchTracker is given an expiredBy method that returns true if the lock
time of either party's *known* swap is before the reference time.
Normally this will be called with the present time.

checkInactionBlockBased now consults expiredBy when calling failMatch
to determine if either of the swap contracts are expired, justifying
the inaction.

NOTE: client should be updated with similar logic to prevent attempting
to make expired contracts or contracts that are about to expire.

server/db: option to store forgiven revoked matches

When a match is revoked due to no fault of the user, it should be saved
in the DB with the forgiven flag set.
```

**server/swap: do not accept expired contracts in processInit** https://github.com/decred/dcrdex/pull/1541/commits/bbce25cd3a882bad24325b4c5436625da359af3d

```
If the located contract transaction in processInit is found to have a
lock time that is in the past (already expired) revoke the match
immediately and respond to the user with an error.  No penalties are
assesed since processInit first verifies that the proper lock time has
been used.  This would be the case if the maker's swap took a very
long time to reach the required number of confirmations, and when
the taker's turn to publish their swap came around it was already
passed the expected lock time for their swap (matchTime + 8 hrs).

NOTE: client should be updated with similar logic to prevent attempting
to make expired contracts or contracts that are about to expire.
```