### PR TITLE
app: ignore zero-quantity book_order updates

### DIFF
--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1258,7 +1258,7 @@ export default class MarketsPage extends BasePage {
   handleBookOrderRoute (data: BookUpdate) {
     app().log('book', 'handleBookOrderRoute:', data)
     if (data.host !== this.market.dex.host || data.marketID !== this.market.sid) return
-    const order = data.payload
+    const order = data.payload as MiniOrder
     if (order.rate > 0) this.book.add(order)
     this.addTableOrder(order)
     this.updateTitle()

--- a/client/webserver/site/src/js/orderbook.ts
+++ b/client/webserver/site/src/js/orderbook.ts
@@ -23,7 +23,10 @@ export default class OrderBook {
 
   /* add adds an order to the order book. */
   add (ord: MiniOrder) {
-    if (ord.qtyAtomic === 0) return
+    if (ord.qtyAtomic === 0) {
+      window.log('zeroqty', 'zero quantity order encountered', ord)
+      return
+    }
     const side = ord.sell ? this.sells : this.buys
     side.splice(findIdx(side, ord.rate, !ord.sell), 0, ord)
   }

--- a/client/webserver/site/src/js/orderbook.ts
+++ b/client/webserver/site/src/js/orderbook.ts
@@ -24,6 +24,17 @@ export default class OrderBook {
   /* add adds an order to the order book. */
   add (ord: MiniOrder) {
     if (ord.qtyAtomic === 0) {
+      // TODO: Somebody, for the love of god, figure out why the hell this helps
+      // with the ghost orders problem. As far as I know, this order is a booked
+      // order that had more than one match in an epoch and completely filled.
+      // Because the first match didn't exhaust the order, there would be a
+      // 'update_remaining' notification scheduled for the order. But by the
+      // time OrderRouter generates the notification long after matching, the
+      // order has zero qty left to fill. It's all good though, kinda, because
+      // the notification is quickly followed with an 'unbook_order'
+      // notification. I have tried my damnedest to catch an update_remaining
+      // note without an accompanying unbook_order note, and have thus failed.
+      // Yet, this fix somehow seems to work. It's infuriating, tbh.
       window.log('zeroqty', 'zero quantity order encountered', ord)
       return
     }

--- a/client/webserver/site/src/js/orderbook.ts
+++ b/client/webserver/site/src/js/orderbook.ts
@@ -23,6 +23,7 @@ export default class OrderBook {
 
   /* add adds an order to the order book. */
   add (ord: MiniOrder) {
+    if (ord.qtyAtomic === 0) return
     const side = ord.sell ? this.sells : this.buys
     side.splice(findIdx(side, ord.rate, !ord.sell), 0, ord)
   }


### PR DESCRIPTION
I've been chasing down the residual orders in the front-end order book and depth chart. The orders that we see are zero-quantity orders that appear to be related to orders that are booked and unbooked on the same match cycle. In that case, we receive a `book_order` update followed by an `unbook_order` update. The `book_order` update contains a `BookOrderNote` with a zero-quantity order, because by the time the `order.LimitOrder` gets translated by `BookRouter`, the `Remaining` is already zero.

I still haven't figured this out. I've put feelers around to try to catch a zero-quantity `book_order` update with no subsequent `unbook_order` update, but I haven't seen one yet, even though I still see residual orders. 

Oddly, these leftover orders only appear on the buy side. 

This PR is here just to display a crude fix and for discussion. I've been banging my head against the wall on this one, and I need to switch gears.

The crude fix is to simply ignore zero-quantity orders in `OrderBook.add`. We already ignore unmatched `unbook_order` updates. 