### PR TITLE
client/core: consider contract expiry before acting

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -109,7 +109,7 @@ var (
 	tUnparseableHost           = string([]byte{0x7f})
 	tSwapFeesPaid       uint64 = 500
 	tRedemptionFeesPaid uint64 = 350
-	tLogger                    = dex.StdOutLogger("TCORE", dex.LevelInfo)
+	tLogger                    = dex.StdOutLogger("TCORE", dex.LevelDebug)
 	tMaxFeeRate         uint64 = 10
 	tWalletInfo                = &asset.WalletInfo{
 		UnitInfo: dex.UnitInfo{
@@ -638,15 +638,18 @@ type TXCWallet struct {
 	ownsAddressErr      error
 	pubKeys             []dex.Bytes
 	sigs                []dex.Bytes
+	contractExpired     bool
+	contractLockTime    time.Time
 }
 
 func newTWallet(assetID uint32) (*xcWallet, *TXCWallet) {
 	w := &TXCWallet{
-		changeCoin:  &tCoin{id: encode.RandomBytes(36)},
-		syncStatus:  func() (synced bool, progress float32, err error) { return true, 1, nil },
-		confs:       make(map[string]uint32),
-		confsErr:    make(map[string]error),
-		ownsAddress: true,
+		changeCoin:       &tCoin{id: encode.RandomBytes(36)},
+		syncStatus:       func() (synced bool, progress float32, err error) { return true, 1, nil },
+		confs:            make(map[string]uint32),
+		confsErr:         make(map[string]error),
+		ownsAddress:      true,
+		contractLockTime: time.Now().Add(time.Minute),
 	}
 	xcWallet := &xcWallet{
 		Wallet:       w,
@@ -776,7 +779,7 @@ func (w *TXCWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadcas
 }
 
 func (w *TXCWallet) LocktimeExpired(contract dex.Bytes) (bool, time.Time, error) {
-	return true, time.Now().Add(-time.Minute), nil
+	return w.contractExpired, w.contractLockTime, nil
 }
 
 func (w *TXCWallet) FindRedemption(ctx context.Context, coinID, _ dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {
@@ -4942,7 +4945,7 @@ func TestRefunds(t *testing.T) {
 	// MAKER REFUND, INVALID TAKER COUNTERSWAP
 	//
 
-	matchTime := time.Now()
+	matchTime := time.Now().Truncate(time.Millisecond).UTC()
 	msgMatch := &msgjson.Match{
 		OrderID:    loid[:],
 		MatchID:    mid[:],
@@ -4977,7 +4980,7 @@ func TestRefunds(t *testing.T) {
 	// Send the counter-party's init info.
 	audit, auditInfo := tMsgAudit(loid, mid, addr, matchSize, proof.SecretHash)
 	tBtcWallet.auditInfo = auditInfo
-	auditInfo.Expiration = encode.DropMilliseconds(matchTime.Add(tracker.lockTimeMaker))
+	auditInfo.Expiration = encode.DropMilliseconds(matchTime.Add(tracker.lockTimeMaker).UTC())
 
 	// Check audit errors.
 	tBtcWallet.auditErr = tErr
@@ -4992,11 +4995,17 @@ func TestRefunds(t *testing.T) {
 	tBtcWallet.refundCoin = nil
 	tBtcWallet.refundErr = fmt.Errorf("unexpected call to btcWallet.Refund")
 	matchSizeQuoteUnits := calc.BaseToQuote(rate, matchSize)
+	// Make the contract appear expired
+	tEthWallet.contractExpired = true
+	tEthWallet.contractLockTime = time.Now()
 	checkRefund(tracker, match, matchSizeQuoteUnits)
+	tEthWallet.contractExpired = false
+	tEthWallet.contractLockTime = time.Now().Add(time.Minute)
 
 	// TAKER REFUND, NO MAKER REDEEM
 	//
 	// Reset funding coins in the trackedTrade, wipe change coin.
+	matchTime = time.Now().Truncate(time.Millisecond).UTC()
 	tracker.mtx.Lock()
 	tracker.coins = mapifyCoins(fundCoinsETH)
 	tracker.coinsLocked = true
@@ -5006,12 +5015,13 @@ func TestRefunds(t *testing.T) {
 	tracker.mtx.Unlock()
 	mid = ordertest.RandomMatchID()
 	msgMatch = &msgjson.Match{
-		OrderID:  loid[:],
-		MatchID:  mid[:],
-		Quantity: matchSize,
-		Rate:     rate,
-		Address:  "counterparty-address",
-		Side:     uint8(order.Taker),
+		OrderID:    loid[:],
+		MatchID:    mid[:],
+		Quantity:   matchSize,
+		Rate:       rate,
+		Address:    "counterparty-address",
+		Side:       uint8(order.Taker),
+		ServerTime: encode.UnixMilliU(matchTime),
 	}
 	sign(tDexPriv, msgMatch)
 	msg, _ = msgjson.NewRequest(1, msgjson.MatchRoute, []*msgjson.Match{msgMatch})
@@ -5076,7 +5086,11 @@ func TestRefunds(t *testing.T) {
 
 	// Attempt refund.
 	rig.db.updateMatchChan = nil
+	tEthWallet.contractExpired = true
+	tEthWallet.contractLockTime = time.Now()
 	checkRefund(tracker, match, matchSizeQuoteUnits)
+	tEthWallet.contractExpired = false
+	tEthWallet.contractLockTime = time.Now().Add(time.Minute)
 }
 
 func TestNotifications(t *testing.T) {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -844,7 +844,7 @@ func (t *trackedTrade) processCancelMatch(msgMatch *msgjson.Match) error {
 //
 // This method accesses match fields and MUST be called with the trackedTrade
 // mutex lock held for reads.
-func (t *trackedTrade) counterPartyConfirms(ctx context.Context, match *matchTracker) (have, needed uint32, changed, spent bool) {
+func (t *trackedTrade) counterPartyConfirms(ctx context.Context, match *matchTracker) (have, needed uint32, changed, spent, expired bool) {
 	// Counter-party's swap is the "to" asset.
 	needed = t.wallets.toAsset.SwapConf
 
@@ -854,16 +854,25 @@ func (t *trackedTrade) counterPartyConfirms(ctx context.Context, match *matchTra
 		t.dc.log.Warnf("counterPartyConfirms: No AuditInfo available to check!")
 		return
 	}
+
+	wallet := t.wallets.toWallet
 	coin := match.counterSwap.Coin
 
-	var err error
-	have, spent, err = t.wallets.toWallet.SwapConfirmations(ctx, coin.ID(),
+	_, lockTime, err := wallet.LocktimeExpired(match.MetaData.Proof.CounterContract)
+	if err != nil {
+		t.dc.log.Errorf("Error checking if locktime has expired on taker's contract on order %s, "+
+			"match %s: %v", t.ID(), match, err)
+	}
+	expired = time.Until(lockTime) < 0 // not necessarily refundable, but can be at any moment
+
+	have, spent, err = wallet.SwapConfirmations(ctx, coin.ID(),
 		match.MetaData.Proof.CounterContract, match.MetaData.Stamp)
 	if err != nil {
 		if !errors.Is(err, asset.ErrSwapNotInitiated) {
 			// No need to log an error if swap not initiated as this
 			// is expected for newly made swaps involving contracts.
-			t.dc.log.Errorf("Failed to get confirmations of the counter-party's swap %s (%s) for match %s, order %v: %v",
+			t.dc.log.Errorf("Failed to get confirmations of the counter-party's swap %s (%s) "+
+				"for match %s, order %v: %v",
 				coin, t.wallets.toAsset.Symbol, match, t.UID(), err)
 		}
 		return
@@ -1037,6 +1046,12 @@ func (t *trackedTrade) unspentContractAmounts() (amount uint64) {
 // This method accesses match fields and MUST be called with the trackedTrade
 // mutex lock held for writes.
 func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) bool {
+	// Quick status check before we bother with the wallet.
+	switch match.Status {
+	case order.TakerSwapCast, order.MakerRedeemed, order.MatchComplete:
+		return false // all swaps already sent
+	}
+
 	if match.swapErr != nil || match.MetaData.Proof.IsRevoked() || match.tickGovernor != nil || match.checkServerRevoke {
 		t.dc.log.Tracef("Match %s not swappable: swapErr = %v, revoked = %v, metered = %t, checkServerRevoke = %v",
 			match, match.swapErr, match.MetaData.Proof.IsRevoked(), match.tickGovernor != nil, match.checkServerRevoke)
@@ -1047,12 +1062,15 @@ func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) boo
 	// Just a quick check here. We'll perform a more thorough check if there are
 	// actually swappables.
 	if !wallet.locallyUnlocked() {
-		t.dc.log.Errorf("not checking if order %s, match %s is swappable because %s wallet is not unlocked",
+		t.dc.log.Errorf("Order %s, match %s is not swappable because %s wallet is not unlocked",
 			t.ID(), match, unbip(wallet.AssetID))
 		return false
 	}
 
-	if match.Status == order.MakerSwapCast {
+	switch match.Status {
+	case order.NewlyMatched:
+		return match.Side == order.Maker
+	case order.MakerSwapCast:
 		// Get the confirmation count on the maker's coin.
 		if match.Side == order.Taker {
 			toAssetID := t.wallets.toAsset.ID
@@ -1060,19 +1078,31 @@ func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) boo
 				coinIDString(toAssetID, match.MetaData.Proof.MakerSwap), unbip(toAssetID))
 			// If the maker is the counterparty, we can determine swappability
 			// based on the confirmations.
-			confs, req, changed, spent := t.counterPartyConfirms(ctx, match)
-			ready := confs >= req
-			if changed && !ready {
-				t.dc.log.Debugf("Match %s not yet swappable: current confs = %d, required confs = %d",
-					match, confs, req)
-			}
+			confs, req, changed, spent, expired := t.counterPartyConfirms(ctx, match)
 			if spent {
 				t.dc.log.Errorf("Counter-party's swap is spent before we could broadcast our own")
 				match.MetaData.Proof.SelfRevoked = true
 				return false
 			}
+			if expired {
+				t.dc.log.Errorf("Counter-party's swap expired before we could broadcast our own")
+				match.MetaData.Proof.SelfRevoked = true
+				return false
+			}
+			matchTime := match.matchTime()
+			if lockTime := matchTime.Add(t.lockTimeTaker); time.Until(lockTime) < 0 {
+				t.dc.log.Errorf("Our contract would expire in the past (%v). Revoking.", lockTime)
+				match.MetaData.Proof.SelfRevoked = true
+				return false
+			}
+			ready := confs >= req
+			if changed && !ready {
+				t.dc.log.Infof("Match %s not yet swappable: current confs = %d, required confs = %d",
+					match, confs, req)
+			}
 			return ready
 		}
+
 		// If we're the maker, check the confirmations anyway so we can notify.
 		t.dc.log.Tracef("Checking confirmations on our OWN swap txn %v (%s)...",
 			coinIDString(wallet.AssetID, match.MetaData.Proof.MakerSwap), unbip(wallet.AssetID))
@@ -1084,7 +1114,7 @@ func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) boo
 			t.dc.log.Errorf("isSwappable: error getting confirmation for our own swap transaction: %v", err)
 		}
 		if spent {
-			t.dc.log.Debugf("our (maker) swap for match %s is being reported as spent, "+
+			t.dc.log.Debugf("Our (maker) swap for match %s is being reported as spent, "+
 				"but we have not seen the counter-party's redemption yet. This could just"+
 				" be network latency.", match)
 		}
@@ -1092,9 +1122,7 @@ func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) boo
 		t.notify(newMatchNote(TopicConfirms, "", "", db.Data, t, match))
 		return false
 	}
-	if match.Side == order.Maker && match.Status == order.NewlyMatched {
-		return true
-	}
+
 	return false
 }
 
@@ -1104,11 +1132,25 @@ func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) boo
 // This method accesses match fields and MUST be called with the trackedTrade
 // mutex lock held for reads.
 func (t *trackedTrade) isRedeemable(ctx context.Context, match *matchTracker) bool {
+	// Quick status check before we bother with the wallet.
+	switch match.Status {
+	case order.NewlyMatched, order.MakerSwapCast:
+		return false // all swaps not yet sent
+	}
+
 	if match.swapErr != nil || len(match.MetaData.Proof.RefundCoin) != 0 || match.tickGovernor != nil {
 		t.dc.log.Tracef("Match %s not redeemable: swapErr = %v, RefundCoin = %v, metered = %t",
 			match, match.swapErr, match.MetaData.Proof.RefundCoin, match.tickGovernor != nil)
 		return false
 	}
+	// NOTE: taker must be able to redeem when revoked! Arguably, maker should
+	// not, and we could check here, but as long as taker contract's is not
+	// expired (locktime passed), the swap may be completed.
+	//
+	// if match.Side == order.Maker && match.MetaData.Proof.IsRevoked() {
+	// 	t.dc.log.Warnf("Revoked match %s not redeemable as maker")
+	// 	return false
+	// }
 
 	wallet := t.wallets.toWallet
 	// Just a quick check here. We'll perform a more thorough check if there are
@@ -1119,22 +1161,29 @@ func (t *trackedTrade) isRedeemable(ctx context.Context, match *matchTracker) bo
 		return false
 	}
 
-	if match.Status == order.TakerSwapCast {
+	switch match.Status {
+	case order.TakerSwapCast:
 		if match.Side == order.Maker {
 			// Check the confirmations on the taker's swap.
-			confs, req, changed, spent := t.counterPartyConfirms(ctx, match)
-			ready := confs >= req
-			if changed && !ready {
-				t.dc.log.Debugf("Match %s not yet redeemable: current confs = %d, required confs = %d",
-					match, confs, req)
-			}
+			confs, req, changed, spent, expired := t.counterPartyConfirms(ctx, match)
 			if spent {
 				t.dc.log.Errorf("Order %s, match %s counter-party's swap is spent before we could redeem", t.ID(), match)
 				match.MetaData.Proof.SelfRevoked = true
 				return false
 			}
+			if expired {
+				t.dc.log.Errorf("Order %s, match %s counter-party's swap expired before we could redeem", t.ID(), match)
+				match.MetaData.Proof.SelfRevoked = true
+				return false
+			}
+			ready := confs >= req
+			if changed && !ready {
+				t.dc.log.Infof("Match %s not yet redeemable: current confs = %d, required confs = %d",
+					match, confs, req)
+			}
 			return ready
 		}
+
 		// If we're the taker, check the confirmations anyway so we can notify.
 		confs, spent, err := t.wallets.fromWallet.SwapConfirmations(ctx, match.MetaData.Proof.TakerSwap,
 			match.MetaData.Proof.ContractData, match.MetaData.Stamp)
@@ -1151,10 +1200,11 @@ func (t *trackedTrade) isRedeemable(ctx context.Context, match *matchTracker) bo
 		match.swapConfirms = int64(confs)
 		t.notify(newMatchNote(TopicConfirms, "", "", db.Data, t, match))
 		return false
+
+	case order.MakerRedeemed:
+		return match.Side == order.Taker
 	}
-	if match.Side == order.Taker && match.Status == order.MakerRedeemed {
-		return true
-	}
+
 	return false
 }
 
@@ -1824,9 +1874,9 @@ func (c *Core) sendInitAsync(t *trackedTrade, match *matchTracker, coinID, contr
 	// Send the init request asynchronously.
 	c.wg.Add(1) // So Core does not shut down until we're done with this request.
 	go func() {
+		defer c.wg.Done() // bottom of the stack
 		var err error
 		defer func() {
-			c.wg.Done()
 			atomic.StoreUint32(&match.sendingInitAsync, 0)
 			if err != nil {
 				corder := t.coreOrder()
@@ -2032,7 +2082,9 @@ func (c *Core) redeemMatchGroup(t *trackedTrade, matches []*matchTracker, errs *
 		proof := &match.MetaData.Proof
 		coinID := []byte(coinIDs[i])
 		if match.Side == order.Taker {
-			match.Status = order.MatchComplete // could this cause the match to be retired before the `redeem` request succeeds?
+			// The match won't be retired before the redeem request succeeds
+			// because RedeemSig is required unless the match is revoked.
+			match.Status = order.MatchComplete
 			proof.TakerRedeem = coinID
 		} else {
 			if t.isMarketBuy() {
@@ -2066,9 +2118,9 @@ func (c *Core) sendRedeemAsync(t *trackedTrade, match *matchTracker, coinID, sec
 	// Send the redeem request asynchronously.
 	c.wg.Add(1) // So Core does not shut down until we're done with this request.
 	go func() {
+		defer c.wg.Done() // bottom of the stack
 		var err error
 		defer func() {
-			c.wg.Done()
 			atomic.StoreUint32(&match.sendingRedeemAsync, 0)
 			if err != nil {
 				corder := t.coreOrder()


### PR DESCRIPTION
Complementary to https://github.com/decred/dcrdex/pull/1541, this includes client-side checks.

In particular, `(*trackedTrade).counterPartyConfirms` checks if the contract is expired and returns an `expired bool`.  The callers (`isSwappable` and `isRedeemable`) consider the expired status in the same way they already consider spent status -- self-revoke and return false to the spendable/redeemable check.  Specifically, this happens _only_ in the `order.TakerSwapCast` && `order.Maker` condition of `isRedeemable`, and in the `order.MakerSwapCast` && `order.Taker` condition of `isSwappable`.

Note that in the first scenario above of the maker deciding if the taker's contract is redeemable, it is quite important not to redeem an expired contract.  This is true for either actor since the contract could also be refunded at any time, but it's absolutely critical for maker since they are revealing the secret key to the taker.  That must not happen if the taker's contract is expired.

Another check added is for taker at `MakerSwapCast` when checking swappability, where it now also ensures that the taker's own contract that it _would publish_ would not have a lock time that is already in the past.

To ease readability, some order status `if` statements are converted to `switch` statements.  Also, an initial order status filter is added to `isSwappable` and `isRedeemable` for efficiency.

Finally, an minor bug with `wg.Done()` being called not at the end of a defer stack is fixed.