### PR TITLE
client/asset/btc: attempt audit with empty txdata

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -73,6 +73,11 @@ const (
 )
 
 var (
+	// ContractSearchLimit is how far back in time AuditContract in SPV mode
+	// will search for a contract if no txData is provided. This should be a
+	// positive duration.
+	ContractSearchLimit = 48 * time.Hour
+
 	// blockTicker is the delay between calls to check for new blocks.
 	blockTicker                  = time.Second
 	peerCountTicker              = 5 * time.Second
@@ -2190,7 +2195,13 @@ func (btc *baseWallet) SignMessage(coin asset.Coin, msg dex.Bytes) (pubkeys, sig
 
 // AuditContract retrieves information about a swap contract from the provided
 // txData. The extracted information would be used to audit the counter-party's
-// contract during a swap.
+// contract during a swap. The txData may be empty to attempt retrieval of the
+// transaction output from the network, but it is only ensured to succeed for a
+// full node or, if the tx is confirmed, an SPV wallet. Normally the server
+// should communicate this txData, and the caller can decide to require it. The
+// ability to work with an empty txData is a convenience for recovery tools and
+// testing, and it may change in the future if a GetTxData method is added for
+// this purpose.
 func (btc *baseWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadcast bool) (*asset.AuditInfo, error) {
 	txHash, vout, err := decodeCoinID(coinID)
 	if err != nil {
@@ -2202,19 +2213,34 @@ func (btc *baseWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroad
 		return nil, fmt.Errorf("error extracting swap addresses: %w", err)
 	}
 
-	// Perform basic validation using the txData.
-	// It may be worth separating data validation from coin
-	// retrieval at the asset.Wallet interface level.
-	tx, err := msgTxFromBytes(txData)
-	if err != nil {
-		return nil, fmt.Errorf("coin not found, and error encountered decoding tx data: %v", err)
+	// If no tx data is provided, attempt to get the required data (the txOut)
+	// from the wallet. If this is a full node wallet, a simple gettxout RPC is
+	// sufficient with no pkScript or "since" time. If this is an SPV wallet,
+	// only a confirmed counterparty contract can be located, and only one
+	// within ContractSearchLimit. As such, this mode of operation is not
+	// intended for normal server-coordinated operation.
+	var tx *wire.MsgTx
+	var txOut *wire.TxOut
+	if len(txData) == 0 {
+		// Fall back to gettxout, but we won't have the tx to rebroadcast.
+		pkScript, _ := btc.scriptHashScript(contract) // pkScript and since time are unused if full node
+		txOut, _, err = btc.node.getTxOut(txHash, vout, pkScript, time.Now().Add(-ContractSearchLimit))
+		if err != nil || txOut == nil {
+			return nil, fmt.Errorf("error finding unspent contract: %s:%d : %w", txHash, vout, err)
+		}
+	} else {
+		tx, err = msgTxFromBytes(txData)
+		if err != nil {
+			return nil, fmt.Errorf("coin not found, and error encountered decoding tx data: %v", err)
+		}
+		if len(tx.TxOut) <= int(vout) {
+			return nil, fmt.Errorf("specified output %d not found in decoded tx %s", vout, txHash)
+		}
+		txOut = tx.TxOut[vout]
 	}
-	if len(tx.TxOut) <= int(vout) {
-		return nil, fmt.Errorf("specified output %d not found in decoded tx %s", vout, txHash)
-	}
-	txOut := tx.TxOut[vout]
 
-	// Check for standard P2SH.
+	// Check for standard P2SH. NOTE: btc.scriptHashScript(contract) should
+	// equal txOut.PkScript. All we really get from the TxOut is the *value*.
 	scriptClass, addrs, numReq, err := txscript.ExtractPkScriptAddrs(txOut.PkScript, btc.chainParams)
 	if err != nil {
 		return nil, fmt.Errorf("error extracting script addresses from '%x': %w", txOut.PkScript, err)
@@ -2251,7 +2277,7 @@ func (btc *baseWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroad
 
 	// Broadcast the transaction, but do not block because this is not required
 	// and does not affect the audit result.
-	if rebroadcast {
+	if rebroadcast && tx != nil {
 		go func() {
 			if hashSent, err := btc.node.sendRawTransaction(tx); err != nil {
 				btc.log.Debugf("Rebroadcasting counterparty contract %v (THIS MAY BE NORMAL): %v", txHash, err)
@@ -2464,7 +2490,7 @@ func (btc *baseWallet) tryRedemptionRequests(ctx context.Context, startBlock *ch
 		btc.findRedemptionMtx.RUnlock()
 
 		if len(validReqs) == 0 {
-			iHeight += 1
+			iHeight++
 			continue
 		}
 
@@ -2483,7 +2509,7 @@ func (btc *baseWallet) tryRedemptionRequests(ctx context.Context, startBlock *ch
 			break
 		}
 
-		iHeight += 1
+		iHeight++
 		if iHeight <= tipHeight {
 			if iHash, err = btc.node.getBlockHash(int64(iHeight)); err != nil {
 				// This might be due to a reorg. Don't abandon yet, since


### PR DESCRIPTION
This fixes the client btc (and clone) "livetest" simnet tests, and makes the `asset.Wallet` API usable without a server or oracle providing the txData of the counterparty contract.  `Core` should still always provide txData, but in general this is a needless limitation that I have had to confront in several contexts recently.

```
When AuditContract was switched to a hard requirement of txData
(the raw tx bytes), it broke certain simnet tests where no server was
available to provide the data, and made the asset.Wallet API somewhat
incomplete with no way to retrieve this txData in either full node or
SPV mode because there is no method to do so.  This makes a redeem
cli tool or other use case with no server or txdata oracle extremely
cumbersome because the raw bytes are required as an input instead of
just the coinid/txid.

Normally the server should communicate this txData, and the caller can
decide to require it. This adds (back) the ability to work with an
empty txData as a convenience for recovery tools and testing.  This MAY
change in the future if a GetTxData method is added for this purpose.

The baseWallet AuditContract now attempts retrieval of the transaction
output from the network, but it is only ensured to succeed for a full
node or, if the tx is confirmed, and SPV wallet.  If this is a full node
wallet, a simple gettxout RPC is sufficient with no pkScript or "since"
time. If this is an SPV wallet, only a confirmed counterparty contract
can be located, and only one within the last 48 hours. As such, this
mode of operation is not intended for normal server-coordinate
operation.

The above change fixes the "livetest" package, which is also used by
all btc "clone" assets. The test code is also updated with some extra
sleeps for SPV wallets.  A comment at the call site of AuditContract
is made noting that a nil txData must be provided because in normal
operation that data comes from the server coordinating the swap, and
that the Wallet API has no ability to get this data.
```

For reference, the commit that dropped support for empty txData: https://github.com/decred/dcrdex/commit/fe1995a42289f29e18bcccd9e537a2ba707a8ad1
That was fine if server or oracle is always providing it, but the `asset.Wallet` API is quite lacking without this capability.

I will similarly revitalize DCR's `AuditContract` after this.  It also appears to be a non-issue for eth to do this.