### PR TITLE
ltc: switch to segwit

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -30,16 +30,15 @@ import (
 )
 
 var (
-	tLogger   dex.Logger
-	tCtx      context.Context
-	tLotSize  uint64 = 1e6 // 0.01 BTC
-	tRateStep uint64 = 10
-	tBTC             = &dex.Asset{
+	tLogger  dex.Logger
+	tCtx     context.Context
+	tLotSize uint64 = 1e6 // 0.01 BTC
+	tBTC            = &dex.Asset{
 		ID:           0,
 		Symbol:       "btc",
 		Version:      version,
-		SwapSize:     dexbtc.InitTxSize,
-		SwapSizeBase: dexbtc.InitTxSizeBase,
+		SwapSize:     dexbtc.InitTxSizeSegwit, // patched by tNewWallet, but default to segwit
+		SwapSizeBase: dexbtc.InitTxSizeBaseSegwit,
 		MaxFeeRate:   34,
 		SwapConf:     1,
 	}
@@ -2801,7 +2800,7 @@ func testTryRedemptionRequests(t *testing.T, segwit bool, walletType string) {
 	}
 
 	addBlocks := func(n int) {
-		var h int64 = 0
+		var h int64
 		// Make dummy transactions.
 		for i := 0; i < n; i++ {
 			node.addRawTx(h, otherTx())

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	version = 0
+	version = 1
 	// BipID is the BIP-0044 asset ID.
 	BipID = 2
 	// defaultFee is the default value for the fallbackfee.
@@ -165,7 +165,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		DefaultFeeRateLimit: defaultFeeRateLimit,
 		LegacyBalance:       true,
 		LegacyRawFeeLimit:   true,
-		Segwit:              false,
+		Segwit:              true,
 	}
 
 	return btc.BTCCloneWallet(cloneCFG)

--- a/client/asset/ltc/regnet_test.go
+++ b/client/asset/ltc/regnet_test.go
@@ -22,17 +22,16 @@ import (
 	dexbtc "decred.org/dcrdex/dex/networks/btc"
 )
 
-const alphaAddress = "mt9hgfXXbM3x7hewgEAovBwqoMAAnctJ4V"
+// const alphaAddress = "rltc1qjld4f85m96rr77035c5yuhkz8apxlkkla0ftmz"
 
 var (
-	tLotSize  uint64 = 1e6
-	tRateStep uint64 = 10
-	tLTC             = &dex.Asset{
+	tLotSize uint64 = 1e6
+	tLTC            = &dex.Asset{
 		ID:           2,
 		Symbol:       "ltc",
 		Version:      version,
-		SwapSize:     dexbtc.InitTxSize,
-		SwapSizeBase: dexbtc.InitTxSizeBase,
+		SwapSize:     dexbtc.InitTxSizeSegwit,
+		SwapSizeBase: dexbtc.InitTxSizeBaseSegwit,
 		MaxFeeRate:   10,
 		SwapConf:     1,
 	}

--- a/dex/networks/bch/params.go
+++ b/dex/networks/bch/params.go
@@ -19,6 +19,7 @@ var (
 	}
 	// MainNetParams are the clone parameters for mainnet.
 	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "mainnet",
 		PubKeyHashAddrID: 0x00,
 		ScriptHashAddrID: 0x05,
 		Bech32HRPSegwit:  "bitcoincash",
@@ -27,6 +28,7 @@ var (
 	})
 	// TestNet3Params are the clone parameters for testnet.
 	TestNet3Params = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "testnet3",
 		PubKeyHashAddrID: 0x6f,
 		ScriptHashAddrID: 0xc4,
 		Bech32HRPSegwit:  "bchtest",
@@ -35,6 +37,7 @@ var (
 	})
 	// RegressionNetParams are the clone parameters for simnet.
 	RegressionNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "regtest",
 		PubKeyHashAddrID: 0x6f,
 		ScriptHashAddrID: 0xc4,
 		Bech32HRPSegwit:  "bchreg",

--- a/dex/networks/btc/clone.go
+++ b/dex/networks/btc/clone.go
@@ -15,11 +15,14 @@ type AddressDecoder func(addr string, net *chaincfg.Params) (btcutil.Address, er
 // ReadCloneParams translates a CloneParams into a btcsuite chaincfg.Params.
 func ReadCloneParams(cloneParams *CloneParams) *chaincfg.Params {
 	return &chaincfg.Params{
+		Name:             cloneParams.Name,
 		PubKeyHashAddrID: cloneParams.PubKeyHashAddrID,
 		ScriptHashAddrID: cloneParams.ScriptHashAddrID,
 		Bech32HRPSegwit:  cloneParams.Bech32HRPSegwit,
 		CoinbaseMaturity: cloneParams.CoinbaseMaturity,
 		Net:              wire.BitcoinNet(cloneParams.Net),
+		HDPrivateKeyID:   cloneParams.HDPrivateKeyID,
+		HDPublicKeyID:    cloneParams.HDPublicKeyID,
 	}
 }
 
@@ -28,6 +31,9 @@ func ReadCloneParams(cloneParams *CloneParams) *chaincfg.Params {
 // create a *chaincfg.Params for server/asset/btc.NewBTCClone and
 // client/asset/btc.BTCCloneWallet.
 type CloneParams struct {
+	// Name defines a human-readable identifier for the network. e.g. "mainnet",
+	// "testnet4", or "regtest"
+	Name string
 	// PubKeyHashAddrID: Net ID byte for a pubkey-hash address
 	PubKeyHashAddrID byte
 	// ScriptHashAddrID: Net ID byte for a script-hash address
@@ -40,4 +46,11 @@ type CloneParams struct {
 	CoinbaseMaturity uint16
 	// Net is the network identifier, e.g. wire.BitcoinNet.
 	Net uint32
+	// HDPrivateKeyID and HDPublicKeyID are the BIP32 hierarchical deterministic
+	// extended key magic sequences. They are ONLY required if there is a need
+	// to derive addresses from an extended key, such as if the asset is being
+	// used by the server with the hdkeychain package to create fee addresses.
+	// These are not required by the client.
+	HDPrivateKeyID [4]byte
+	HDPublicKeyID  [4]byte
 }

--- a/dex/networks/ltc/params.go
+++ b/dex/networks/ltc/params.go
@@ -19,24 +19,31 @@ var (
 	}
 	// MainNetParams are the clone parameters for mainnet.
 	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{
-		PubKeyHashAddrID: 0x30,
-		ScriptHashAddrID: 0x32,
+		Name:             "mainnet",
+		PubKeyHashAddrID: 0x30, // starts with L
+		ScriptHashAddrID: 0x32, // starts with M
 		Bech32HRPSegwit:  "ltc",
 		CoinbaseMaturity: 100,
 		Net:              0xdbb6c0fb,
+		HDPrivateKeyID:   [4]byte{0x04, 0x88, 0xad, 0xe4}, // starts with xprv
+		HDPublicKeyID:    [4]byte{0x04, 0x88, 0xb2, 0x1e}, // starts with xpub
 	})
 	// TestNet4Params are the clone parameters for testnet.
 	TestNet4Params = btc.ReadCloneParams(&btc.CloneParams{
-		PubKeyHashAddrID: 0x6f,
-		ScriptHashAddrID: 0x3a,
+		Name:             "testnet4",
+		PubKeyHashAddrID: 0x6f, // starts with m or n
+		ScriptHashAddrID: 0x3a, // starts with Q
 		Bech32HRPSegwit:  "tltc",
 		CoinbaseMaturity: 100,
 		Net:              0xf1c8d2fd,
+		HDPrivateKeyID:   [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+		HDPublicKeyID:    [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
 	})
 	// RegressionNetParams are the clone parameters for simnet.
 	RegressionNetParams = btc.ReadCloneParams(&btc.CloneParams{
-		PubKeyHashAddrID: 0x6f,
-		ScriptHashAddrID: 0x3a,
+		Name:             "regtest",
+		PubKeyHashAddrID: 0x6f, // starts with m or n
+		ScriptHashAddrID: 0x3a, // starts with Q
 		Bech32HRPSegwit:  "rltc",
 		CoinbaseMaturity: 100,
 		// Net is not the standard for LTC simnet, since they never changed it
@@ -44,7 +51,9 @@ var (
 		// btcd/chaincfg.Register, where it is checked to prevent duplicate
 		// registration, so our only requirement is that it is unique. This one
 		// was just generated with a prng.
-		Net: 0x9acb0442,
+		Net:            0x9acb0442,
+		HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+		HDPublicKeyID:  [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
 	})
 )
 

--- a/server/asset/ltc/ltc.go
+++ b/server/asset/ltc/ltc.go
@@ -44,7 +44,7 @@ func init() {
 }
 
 const (
-	version   = 0
+	version   = 1
 	BipID     = 2
 	assetName = "ltc"
 )
@@ -78,7 +78,7 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 
 	return btc.NewBTCClone(&btc.BackendCloneConfig{
 		Name:        assetName,
-		Segwit:      false, // TODO: Change to true.
+		Segwit:      true,
 		ConfigPath:  configPath,
 		Logger:      logger,
 		Net:         network,


### PR DESCRIPTION
Rebased on https://github.com/decred/dcrdex/pull/1553 so the "livetest" simnet test can actually succeed.

```
This switches the LTC code to using and requiring segwit features.

This bumps the asset version to 1.  Note that we do not have a good
method for supporting multiple asset versions simultaneously, but
we can punt on that since LTC has not been deployed on mainnet
anywhere to my knowledge.
```

The client has asset version checks and will simply refuse an order if the server and client asset version does not match.

See discussion about possible client support for multiple asset versions here: https://github.com/decred/dcrdex/pull/1054#discussion_r616266089