### PR TITLE
client: Let core handle redeem and refund locking.

### DIFF
--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -724,11 +724,6 @@ func TestRefund(t *testing.T) {
 					test.name, dexeth.GweiToWei(feeSuggestion), node.contractor.lastRefund.maxFeeRate)
 			}
 		}
-
-		if test.wantLocked > 0 && eth.lockedFunds.refundReserves != test.wantLocked {
-			t.Fatalf("%v: refund reserves %v != expected %v",
-				test.name, eth.lockedFunds.refundReserves, test.wantLocked)
-		}
 	}
 }
 
@@ -2517,7 +2512,6 @@ func TestRedemptionReserves(t *testing.T) {
 
 	var secretHash [32]byte
 	node.contractor.swapMap[secretHash] = &dexeth.SwapState{}
-	spentCoin := &coin{id: encode.RandomBytes(32)}
 
 	var maxFeeRateV0 uint64 = 45
 	gasesV0 := dexeth.VersionedGases[0]
@@ -2555,31 +2549,6 @@ func TestRedemptionReserves(t *testing.T) {
 	expLock += v1Lock
 	if eth.lockedFunds.redemptionReserves != expLock {
 		t.Fatalf("wrong v1 locked. wanted %d, got %d", expLock, eth.lockedFunds.redemptionReserves)
-	}
-
-	// Redeem two v0.
-	node.contractor.redeemTx = types.NewTx(&types.DynamicFeeTx{})
-	if _, _, _, err = eth.Redeem(&asset.RedeemForm{
-		Redemptions: []*asset.Redemption{{
-			Spends: &asset.AuditInfo{
-				Coin:     spentCoin,
-				Contract: dexeth.EncodeContractData(0, secretHash),
-			},
-			UnlockedReserves: lockPerV0,
-		}, {
-			Spends: &asset.AuditInfo{
-				Coin:     spentCoin,
-				Contract: dexeth.EncodeContractData(0, secretHash),
-			},
-			UnlockedReserves: lockPerV0,
-		}},
-	}); err != nil {
-		t.Fatalf("Redeem error: %v", err)
-	}
-
-	expLock -= lockPerV0 * 2
-	if eth.lockedFunds.redemptionReserves != expLock {
-		t.Fatalf("wrong unreserved. wanted %d, got %d", expLock, eth.lockedFunds.redemptionReserves)
 	}
 }
 

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -514,9 +514,6 @@ type Redemption struct {
 	Spends *AuditInfo
 	// Secret is the secret key needed to satisfy the swap contract.
 	Secret dex.Bytes
-	// UnlockedReserves is the amount reserved for redemption for account-based
-	// assets.
-	UnlockedReserves uint64
 }
 
 // RedeemForm is a group of Redemptions. The struct will be

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5948,10 +5948,14 @@ func (c *Core) listen(dc *dexConnection) {
 			for _, trade := range doneTrades {
 				// Log an error if redemption funds are still reserved.
 				trade.mtx.RLock()
-				reserved := trade.redemptionLocked
+				redeemLocked := trade.redemptionLocked
+				refundLocked := trade.refundLocked
 				trade.mtx.RUnlock()
-				if reserved > 0 {
-					dc.log.Errorf("retiring order %s with %d > 0 redemption funds reserved", trade.ID(), reserved)
+				if redeemLocked > 0 {
+					dc.log.Errorf("retiring order %s with %d > 0 redemption funds locked", trade.ID(), redeemLocked)
+				}
+				if refundLocked > 0 {
+					dc.log.Errorf("retiring order %s with %d > 0 refund funds locked", trade.ID(), refundLocked)
 				}
 
 				c.notify(newOrderNote(TopicOrderRetired, "", "", db.Data, trade.coreOrder()))

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5309,6 +5309,13 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 			}
 		}
 
+		if refundNum != 0 {
+			tracker.lockRefundFraction(refundNum, denom)
+		}
+		if redeemNum != 0 {
+			tracker.lockRedemptionFraction(redeemNum, denom)
+		}
+
 		// Active orders and orders with matches with unsent swaps need funding
 		// coin(s). If they are not found, block new matches and swap attempts.
 		needsCoins := len(matchesNeedingCoins) > 0
@@ -5354,12 +5361,8 @@ func (c *Core) resumeTrades(dc *dexConnection, trackers []*trackedTrade) assetMa
 		tracker.recalcFilled()
 
 		if isActive {
-			if refundNum != 0 {
-				tracker.lockRefundFraction(refundNum, denom)
-			}
-			if redeemNum != 0 {
-				tracker.lockRedemptionFraction(redeemNum, denom)
-			}
+			tracker.lockRedemptionFraction(trade.Remaining(), trade.Quantity)
+			tracker.lockRefundFraction(trade.Remaining(), trade.Quantity)
 		}
 
 		// Balances should be updated for any orders with locked wallet coins,

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -5241,12 +5241,10 @@ func TestResolveActiveTrades(t *testing.T) {
 			t.Fatalf("%s: expected %d coin loaded, got %d", description, expCoinsLoaded, len(trade.coins))
 		}
 
-		isActive := dbOrder.MetaData.Status == order.OrderStatusBooked || dbOrder.MetaData.Status == order.OrderStatusEpoch
-
 		if lo.T.Sell && ((match.Side == order.Taker && match.Status < order.MatchComplete) ||
 			(match.Side == order.Taker && match.Status < order.MakerRedeemed)) {
-			var reReserveQty uint64
-			if isActive {
+			var reReserveQty uint64 = redemptionReserves
+			if dbOrder.MetaData.Status > order.OrderStatusBooked {
 				reReserveQty = applyFraction(matchQty, qty, redemptionReserves)
 			}
 
@@ -5256,8 +5254,8 @@ func TestResolveActiveTrades(t *testing.T) {
 		}
 
 		if !lo.T.Sell && match.Status < order.MakerRedeemed {
-			var reRefundQty uint64
-			if isActive {
+			var reRefundQty uint64 = refundReserves
+			if dbOrder.MetaData.Status > order.OrderStatusBooked {
 				reRefundQty = applyFraction(matchQty, qty, refundReserves)
 			}
 


### PR DESCRIPTION
    For account based coins, let core use the Reserve and Unlock methods to
    handle redemption and refund reserves for assets that use them. This
    solves a minor bug where redemption funds are not unlocked for a tracked
    trade that is redeemed normally.

closes #1539