### PR TITLE
server/swap: reduce lock contention and fix memory leak

### DIFF
--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -80,6 +80,7 @@ const (
 	RPCDiscoverAcctError                 // 61
 	RPCWalletRescanError                 // 62
 	RPCDeleteArchivedRecordsError        // 63
+	DuplicateRequestError                // 64
 )
 
 // Routes are destinations for a "payload" of data. The type of data being


### PR DESCRIPTION
Not super polished, but OK to review.

There is a lot of lock contention in the swapper, with mutexes locked during expensive operations that can time out like confirmations checks.  This starts fixing that.

There also appeared to be a memory leak with the coinlocker map with "premature" init requests from clients/