### PR TITLE
webserver/site: limit config file extensions supported

### DIFF
--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -2,7 +2,7 @@
 <div class="py-2 d-flex justify-content-between align-items-center" data-tmpl="walletSettingsHeader">
   [[[Wallet Settings]]]
   <div data-tmpl="fileSelector" class="d-inline-block hoverbg pointer fs14"><span class="ico-textfile me-1"></span> [[[load from file]]]</div>
-  <input data-tmpl="fileInput" type="file" class="form-control select d-none">
+  <input data-tmpl="fileInput" type="file" class="form-control select d-none" accept=".conf, .cfg, .cnf, .ini">
 </div>
 <div data-tmpl="allSettings">
   <div data-tmpl="dynamicOpts" class="dynamicopts mb-3">

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -2,7 +2,7 @@
 <div class="py-2 d-flex justify-content-between align-items-center" data-tmpl="walletSettingsHeader">
   Wallet Settings
   <div data-tmpl="fileSelector" class="d-inline-block hoverbg pointer fs14"><span class="ico-textfile me-1"></span> load from file</div>
-  <input data-tmpl="fileInput" type="file" class="form-control select d-none">
+  <input data-tmpl="fileInput" type="file" class="form-control select d-none" accept=".conf, .cfg, .cnf, .ini">
 </div>
 <div data-tmpl="allSettings">
   <div data-tmpl="dynamicOpts" class="dynamicopts mb-3">

--- a/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
@@ -2,7 +2,7 @@
 <div class="py-2 d-flex justify-content-between align-items-center" data-tmpl="walletSettingsHeader">
   Ustawienia portfela
   <div data-tmpl="fileSelector" class="d-inline-block hoverbg pointer fs14"><span class="ico-textfile me-1"></span> wczytaj z pliku</div>
-  <input data-tmpl="fileInput" type="file" class="form-control select d-none">
+  <input data-tmpl="fileInput" type="file" class="form-control select d-none" accept=".conf, .cfg, .cnf, .ini">
 </div>
 <div data-tmpl="allSettings">
   <div data-tmpl="dynamicOpts" class="dynamicopts mb-3">

--- a/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
@@ -2,7 +2,7 @@
 <div class="py-2 d-flex justify-content-between align-items-center" data-tmpl="walletSettingsHeader">
   Configurações da Carteira
   <div data-tmpl="fileSelector" class="d-inline-block hoverbg pointer fs14"><span class="ico-textfile me-1"></span> carregar do arquivo</div>
-  <input data-tmpl="fileInput" type="file" class="form-control select d-none">
+  <input data-tmpl="fileInput" type="file" class="form-control select d-none" accept=".conf, .cfg, .cnf, .ini">
 </div>
 <div data-tmpl="allSettings">
   <div data-tmpl="dynamicOpts" class="dynamicopts mb-3">

--- a/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
@@ -2,7 +2,7 @@
 <div class="py-2 d-flex justify-content-between align-items-center" data-tmpl="walletSettingsHeader">
   钱包设置
   <div data-tmpl="fileSelector" class="d-inline-block hoverbg pointer fs14"><span class="ico-textfile me-1"></span> 从文件加载</div>
-  <input data-tmpl="fileInput" type="file" class="form-control select d-none">
+  <input data-tmpl="fileInput" type="file" class="form-control select d-none" accept=".conf, .cfg, .cnf, .ini">
 </div>
 <div data-tmpl="allSettings">
   <div data-tmpl="dynamicOpts" class="dynamicopts mb-3">


### PR DESCRIPTION
This diff limits config file extensions supported to `.conf`, `.cnf`, `.cfg`, `.ini`. closes #182 