### PR TITLE
client/{core,db}: headless options

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2389,9 +2389,14 @@ func (btc *baseWallet) ReturnCoins(unspents asset.Coins) error {
 			return fmt.Errorf("error converting coin: %w", err)
 		}
 		ops = append(ops, op)
+	}
+	if err := btc.node.lockUnspent(true, ops); err != nil {
+		return err // could it have unlocked some of them? we may want to loop instead if that's the case
+	}
+	for _, op := range ops {
 		delete(btc.fundingCoins, op.pt)
 	}
-	return btc.node.lockUnspent(true, ops)
+	return nil
 }
 
 // rawWalletTx gets the raw bytes of a transaction and the number of

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1162,6 +1162,16 @@ func TestReturnCoins(t *testing.T) {
 		t.Fatalf("no error for zero coins")
 	}
 
+	// nil unlocks all
+	wallet.fundingCoins[outPoint{*tTxHash, 0}] = &utxo{}
+	err = wallet.ReturnCoins(nil)
+	if err != nil {
+		t.Fatalf("error for nil coins: %v", err)
+	}
+	if len(wallet.fundingCoins) != 0 {
+		t.Errorf("all funding coins not unlocked")
+	}
+
 	// Have the RPC return negative response.
 	node.lockUnspentErr = tErr
 	err = wallet.ReturnCoins(coins)

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -451,9 +451,9 @@ func (wc *rpcClient) listUnspent() ([]*ListUnspentResult, error) {
 
 // lockUnspent locks and unlocks outputs for spending. An output that is part of
 // an order, but not yet spent, should be locked until spent or until the order
-// is  canceled or fails.
+// is canceled or fails.
 func (wc *rpcClient) lockUnspent(unlock bool, ops []*output) error {
-	var rpcops []*RPCOutpoint // To clear all, this must be nil, not empty slice.
+	var rpcops []*RPCOutpoint // To clear all, this must be nil->null, not empty slice.
 	for _, op := range ops {
 		rpcops = append(rpcops, &RPCOutpoint{
 			TxID: op.txHash().String(),

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1910,8 +1910,24 @@ func (dcr *ExchangeWallet) lockFundingCoins(fCoins []*fundingCoin) error {
 // ReturnCoins unlocks coins. This would be necessary in the case of a canceled
 // order. Coins belonging to the tradingAcct, if configured, are transferred to
 // the unmixed account with the exception of unspent split tx outputs which are
-// kept in the tradingAcct and may later be used to fund future orders.
+// kept in the tradingAcct and may later be used to fund future orders. If
+// called with a nil slice, all coins are returned and none are moved to the
+// unmixed account.
 func (dcr *ExchangeWallet) ReturnCoins(unspents asset.Coins) error {
+	if unspents == nil { // not just empty to make this harder to do accidentally
+		dcr.log.Debugf("Returning all coins.")
+		dcr.fundingMtx.Lock()
+		defer dcr.fundingMtx.Unlock()
+		if err := dcr.wallet.LockUnspent(dcr.ctx, true, nil); err != nil {
+			return err
+		}
+		dcr.fundingCoins = make(map[outPoint]*fundingCoin)
+		return nil
+	}
+	if len(unspents) == 0 {
+		return fmt.Errorf("cannot return zero coins")
+	}
+
 	dcr.fundingMtx.Lock()
 	returnedCoins, err := dcr.returnCoins(unspents)
 	dcr.fundingMtx.Unlock()

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -999,6 +999,16 @@ func TestReturnCoins(t *testing.T) {
 		t.Fatalf("no error for zero coins")
 	}
 
+	// nil unlocks all
+	wallet.fundingCoins[outPoint{*tTxHash, 0}] = &fundingCoin{}
+	err = wallet.ReturnCoins(nil)
+	if err != nil {
+		t.Fatalf("error for nil coins: %v", err)
+	}
+	if len(wallet.fundingCoins) != 0 {
+		t.Errorf("all funding coins not unlocked")
+	}
+
 	// Have the RPC return negative response.
 	node.lockUnspentErr = tErr
 	err = wallet.ReturnCoins(coins)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -337,7 +337,11 @@ type Wallet interface {
 	// PreRedeem gets a pre-redeem estimate for the specified order size.
 	PreRedeem(*PreRedeemForm) (*PreRedeem, error)
 	// ReturnCoins unlocks coins. This would be necessary in the case of a
-	// canceled order.
+	// canceled order. A nil Coins slice indicates to unlock all coins that the
+	// wallet may have locked, a syntax that should always be followed by
+	// FundingCoins for any active orders, and is thus only appropriate at time
+	// of login. Unlocking all coins is likely only useful for external wallets
+	// whose lifetime is longer than the asset.Wallet instance.
 	ReturnCoins(Coins) error
 	// FundingCoins gets funding coins for the coin IDs. The coins are locked.
 	// This method might be called to reinitialize an order from data stored

--- a/client/cmd/dexc/config.go
+++ b/client/cmd/dexc/config.go
@@ -77,7 +77,6 @@ func defaultHostByNetwork(network dex.Network) string {
 type Config struct {
 	AppData      string `long:"appdata" description:"Path to application directory."`
 	Config       string `long:"config" description:"Path to an INI configuration file."`
-	SiteDir      string `long:"sitedir" description:"Path to the 'site' directory with packaged web files. Unspecifed = default is good in most cases."`
 	DBPath       string `long:"db" description:"Database filepath. Database will be created if it does not exist."`
 	RPCOn        bool   `long:"rpc" description:"turn on the rpc server"`
 	RPCAddr      string `long:"rpcaddr" description:"RPC server listen address"`
@@ -92,6 +91,7 @@ type Config struct {
 	Simnet       bool   `long:"simnet" description:"use simnet"`
 	ReloadHTML   bool   `long:"reload-html" description:"(DEPRECATED) Reload the webserver's page template from disk with every request. Prevents use of any embedded UI files. For development purposes. This is deprecated. Use --no-embed-site instead."`
 	NoEmbedSite  bool   `long:"no-embed-site" description:"Use on-disk UI files instead of embedded resources. This also reloads the html template with every request. For development purposes."`
+	SiteDir      string `long:"sitedir" description:"Path to the 'site' directory with packaged web files. Only used with --no-embed-site. When unspecified, search known locations relative to dexc."`
 	DebugLevel   string `long:"log" description:"Logging level {trace, debug, info, warn, error, critical}"`
 	LocalLogs    bool   `long:"loglocal" description:"Use local time zone time stamps in log entries."`
 	CPUProfile   string `long:"cpuprofile" description:"File for CPU profiling."`
@@ -103,6 +103,10 @@ type Config struct {
 	Net          dex.Network
 	CertHosts    []string
 	Experimental bool `long:"experimental" description:"Enable experimental features"`
+
+	NoAutoWalletLock   bool `long:"no-wallet-lock" description:"Disable locking of wallets on shutdown or logout. Use this if you want your external wallets to stay unlocked after closing the DEX app."`
+	NoAutoDBBackup     bool `long:"no-db-backup" description:"Disable creation of a database backup on shutdown."`
+	UnlockCoinsOnLogin bool `long:"release-wallet-coins" description:"On login or wallet creation, instruct the wallet to release any coins that it may have locked."`
 }
 
 var defaultConfig = Config{

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -93,13 +93,16 @@ func runCore() error {
 
 	// Prepare the Core.
 	clientCore, err := core.New(&core.Config{
-		DBPath:       cfg.DBPath, // global set in config.go
-		Net:          cfg.Net,
-		Logger:       logMaker.Logger("CORE"),
-		TorProxy:     cfg.TorProxy,
-		TorIsolation: cfg.TorIsolation,
-		Onion:        cfg.Onion,
-		Language:     cfg.Language,
+		DBPath:             cfg.DBPath,
+		Net:                cfg.Net,
+		Logger:             logMaker.Logger("CORE"),
+		TorProxy:           cfg.TorProxy,
+		TorIsolation:       cfg.TorIsolation,
+		Onion:              cfg.Onion,
+		Language:           cfg.Language,
+		UnlockCoinsOnLogin: cfg.UnlockCoinsOnLogin,
+		NoAutoWalletLock:   cfg.NoAutoWalletLock,
+		NoAutoDBBackup:     cfg.NoAutoDBBackup,
 	})
 	if err != nil {
 		return fmt.Errorf("error creating client core: %w", err)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1312,6 +1312,17 @@ type Config struct {
 	TorIsolation bool
 	// Language. A BCP 47 language tag. Default is en-US.
 	Language string
+
+	// NoAutoWalletLock instructs Core to skip locking the wallet on shutdown or
+	// logout. This can be helpful if the user wants the wallet to remain
+	// unlocked. e.g. They started with the wallet unlocked, or they intend to
+	// start Core again and wish to avoid the time to unlock a locked wallet on
+	// startup.
+	NoAutoWalletLock bool // zero value is legacy behavior
+	// NoAutoDBBackup instructs the DB to skip the creation of a backup DB file
+	// on shutdown. This is useful if the consumer is using the BackupDB method,
+	// or simply creating manual backups of the DB file after shutdown.
+	NoAutoDBBackup bool // zero value is legacy behavior
 }
 
 // Core is the core client application. Core manages DEX connections, wallets,
@@ -1385,7 +1396,10 @@ func New(cfg *Config) (*Core, error) {
 	if cfg.Logger == nil {
 		return nil, fmt.Errorf("Core.Config must specify a Logger")
 	}
-	boltDB, err := bolt.NewDB(cfg.DBPath, cfg.Logger.SubLogger("DB"))
+	dbOpts := bolt.Opts{
+		BackupOnShutdown: !cfg.NoAutoDBBackup,
+	}
+	boltDB, err := bolt.NewDB(cfg.DBPath, cfg.Logger.SubLogger("DB"), dbOpts)
 	if err != nil {
 		return nil, fmt.Errorf("database initialization error: %w", err)
 	}
@@ -1591,10 +1605,12 @@ func (c *Core) Run(ctx context.Context) {
 		if !wallet.connected() {
 			continue
 		}
-		symb := strings.ToUpper(unbip(assetID))
-		c.log.Infof("Locking %s wallet", symb)
-		if err := wallet.Lock(5 * time.Second); err != nil {
-			c.log.Errorf("Failed to lock %v wallet: %v", symb, err)
+		if !c.cfg.NoAutoWalletLock {
+			symb := strings.ToUpper(unbip(assetID))
+			c.log.Infof("Locking %s wallet", symb) // no-op if Logout did it
+			if err := wallet.Lock(5 * time.Second); err != nil {
+				c.log.Errorf("Failed to lock %v wallet: %v", symb, err)
+			}
 		}
 		wallet.Disconnect()
 	}
@@ -4407,12 +4423,14 @@ func (c *Core) Logout() error {
 	}
 
 	// Lock wallets
-	for _, w := range c.xcWallets() {
-		if w.connected() {
-			if err := w.Lock(5 * time.Second); err != nil {
-				// A failure to lock the wallet need not block the ability to
-				// lock the DEX accounts or shutdown Core gracefully.
-				c.log.Warnf("Unable to lock %v wallet: %v", unbip(w.AssetID), err)
+	if !c.cfg.NoAutoWalletLock {
+		for _, w := range c.xcWallets() {
+			if w.connected() {
+				if err := w.Lock(5 * time.Second); err != nil {
+					// A failure to lock the wallet need not block the ability to
+					// lock the DEX accounts or shutdown Core gracefully.
+					c.log.Warnf("Unable to lock %v wallet: %v", unbip(w.AssetID), err)
+				}
 			}
 		}
 	}

--- a/dex/testing/loadbot/mantle.go
+++ b/dex/testing/loadbot/mantle.go
@@ -151,9 +151,12 @@ func newMantle(name string) (*Mantle, error) {
 	}
 	dbPath := filepath.Join(coreDir, "core.db")
 	c, err := core.New(&core.Config{
-		DBPath: dbPath,
-		Net:    dex.Simnet,
-		Logger: loggerMaker.Logger("CORE:" + name),
+		DBPath:           dbPath,
+		Net:              dex.Simnet,
+		Logger:           loggerMaker.Logger("CORE:" + name),
+		NoAutoWalletLock: true,
+		// UnlockCoinsOnLogin: true, // true if we are certain that two bots/Core's are not using the same external wallet
+		NoAutoDBBackup: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing core: %w", err)


### PR DESCRIPTION
These options are aimed at improving startup and shutdown speed of headless clients by avoiding unneeded work.

```
client/{core,db}: options for core startup/shutdown

This adds two new core.Config options aimed at improving startup
and shutdown depending on the user's use case:
 - NoAutoWalletLock instructs Core to skip locking the wallet on
   shutdown. This can be helpful if the user wants the wallet to remain
   unlocked. e.g. They started with the wallet unlocked, or they intend
   to start Core again and wish to avoid the time to unlock a locked
   the wallet on startup.
 - NoAutoDBBackup instructs the DB to skip the creation of a backup DB
   file on shutdown. This is useful if the consumer is using the
   BackupDB method, or simply creating manual backups of the DB file
   after shutdown.

These options are intended for direct Core consumers, such as headless
applications that drive Core directly instead of via the browser UI.

These options are created so that the zero-value corresponds to legacy
behavior. That is, the defaults are the existing behavior. However, in
client/db/bolt, the BackupOnShutdown is reversed from Core's
NoAutoDBBackup flag. The NewDB constructor accepts an optional db.Opts
struct, and if it is not provided, a defaultOpts is used that has
BackupOnShutdown set to true.
```

```
client/{asset,core}: add UnlockCoinsOnLogin option

This adds the core.Config.UnlockCoinsOnLogin option that indicates that
on wallet connect during login, or on creation of a new wallet, all
coins with the wallet should be unlocked.

To support this "unlock all" with the wallets, the ReturnCoins method
of the asset.Wallet interface now interprets a nil Coins slice to mean
that all coins should be unlocked. This is similar to the lockunspent
RPC's semantics.

The individual implementations of ReturnCoins are modified to recognize
a nil unspent input slice and accordingly request the wallet backend
unlock all coins.
```