### PR TITLE
app/order: Link ETH coin ids to Etherscan

### DIFF
--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -265,5 +265,19 @@ const CoinExplorers: Record<number, Record<number, (cid: string) => string>> = {
   2: { // ltc
     [Mainnet]: (cid: string) => `https://ltc.bitaps.com/${cid.split(':')[0]}`,
     [Testnet]: (cid: string) => `https://tltc.bitaps.com/${cid.split(':')[0]}`
+  },
+  60: { // eth
+    [Mainnet]: (cid: string) => {
+      if (cid.length === 42) {
+        return `https://etherscan.io/address/${cid}`
+      }
+      return `https://etherscan.io/tx/${cid}`
+    },
+    [Testnet]: (cid: string) => {
+      if (cid.length === 42) {
+        return `https://goerli.etherscan.io/address/${cid}`
+      }
+      return `https://goerli.etherscan.io/tx/${cid}`
+    }
   }
 }


### PR DESCRIPTION
Make eth coin ids link to etherscan on the orders page.

Closes #1559