### PR TITLE
hidden service / .onion dex support

### DIFF
--- a/client/cmd/dexc/config.go
+++ b/client/cmd/dexc/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	ShowVer      bool   `short:"V" long:"version" description:"Display version information and exit"`
 	TorProxy     string `long:"torproxy" description:"Connect via TOR (eg. 127.0.0.1:9050)."`
 	TorIsolation bool   `long:"torisolation" description:"Enable TOR circuit isolation."`
+	Onion        string `long:"onion" description:"Proxy for .onion addresses, if torproxy not set (eg. 127.0.0.1:9050)."`
 	Net          dex.Network
 	CertHosts    []string
 }

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -96,6 +96,7 @@ func mainCore() error {
 		Logger:       logMaker.Logger("CORE"),
 		TorProxy:     cfg.TorProxy,
 		TorIsolation: cfg.TorIsolation,
+		Onion:        cfg.Onion,
 		Language:     cfg.Language,
 	})
 	if err != nil {

--- a/client/core/account.go
+++ b/client/core/account.go
@@ -163,7 +163,7 @@ func (c *Core) AccountImport(pw []byte, acct Account) error {
 			delete(c.conns, dc.acct.host)
 			c.connMtx.Unlock()
 		}
-		return newError(accountVerificationErr, "Account not verified for host: %s err: %w", host, err)
+		return newError(accountVerificationErr, "Account not verified for host: %s", host)
 	}
 
 	err = c.db.CreateAccount(&accountInfo)

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -241,7 +241,7 @@ func buildTestAccount(host string) Account {
 		AccountID:     tDexAccountID.String(),
 		DEXPubKey:     hex.EncodeToString(tDexKey.SerializeCompressed()),
 		PrivKey:       hex.EncodeToString(tDexPriv.Serialize()),
-		Cert:          hex.EncodeToString([]byte{}),
+		Cert:          hex.EncodeToString([]byte{0x1}),
 		FeeCoin:       hex.EncodeToString([]byte("somecoin")),
 		FeeProofSig:   hex.EncodeToString(tFeeProofSig),
 		FeeProofStamp: tFeeProofStamp,

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1070,6 +1070,10 @@ type Config struct {
 	// Logger is the Core's logger and is also used to create the sub-loggers
 	// for the asset backends.
 	Logger dex.Logger
+	// Onion is the address (host:port) of a Tor proxy for use with DEX hosts
+	// with a .onion address. To use Tor with regular DEX addresses as well, set
+	// TorProxy.
+	Onion string
 	// TorProxy specifies the address of a Tor proxy server.
 	TorProxy string
 	// TorIsolation specifies whether to enable Tor circuit isolation.
@@ -1139,6 +1143,13 @@ func New(cfg *Config) (*Core, error) {
 		if _, _, err = net.SplitHostPort(cfg.TorProxy); err != nil {
 			return nil, err
 		}
+	}
+	if cfg.Onion != "" {
+		if _, _, err = net.SplitHostPort(cfg.Onion); err != nil {
+			return nil, err
+		}
+	} else { // default to torproxy if onion not set explicitly
+		cfg.Onion = cfg.TorProxy
 	}
 	lang := language.AmericanEnglish
 	if cfg.Language != "" {
@@ -5471,6 +5482,14 @@ func sendOutdatedClientNotification(c *Core, dc *dexConnection) {
 	c.notify(newUpgradeNote(TopicUpgradeNeeded, subject, details, db.WarningLevel))
 }
 
+func isOnionHost(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	return strings.HasSuffix(host, ".onion")
+}
+
 // connectDEX establishes a ws connection to a DEX server using the provided
 // account info, but does not authenticate the connection through the 'connect'
 // route. If temporary is provided and true, the c.listen(dc) goroutine is not
@@ -5483,7 +5502,12 @@ func (c *Core) connectDEX(acctInfo *db.AccountInfo, temporary ...bool) (*dexConn
 	if err != nil {
 		return nil, newError(addressParseErr, "error parsing address: %v", err)
 	}
-	wsAddr := "wss://" + host + "/ws"
+	// The scheme switches gorilla/websocket to use the tls.Config or not.
+	scheme := "wss"
+	if len(acctInfo.Cert) == 0 {
+		scheme = "ws" // only supported for .onion hosts, but could allow private IP too
+	}
+	wsAddr := scheme + "://" + host + "/ws"
 	wsURL, err := url.Parse(wsAddr)
 	if err != nil {
 		return nil, newError(addressParseErr, "error parsing ws address %s: %w", wsAddr, err)
@@ -5515,12 +5539,24 @@ func (c *Core) connectDEX(acctInfo *db.AccountInfo, temporary ...bool) (*dexConn
 		Cert:     acctInfo.Cert,
 		Logger:   c.log.SubLogger(wsURL.String()),
 	}
-	if c.cfg.TorProxy != "" {
+
+	isOnionHost := isOnionHost(wsURL.Host)
+	if isOnionHost || c.cfg.TorProxy != "" {
+		proxyAddr := c.cfg.TorProxy
+		if isOnionHost {
+			if c.cfg.Onion == "" {
+				return nil, errors.New("tor must be configured for .onion addresses")
+			}
+			proxyAddr = c.cfg.Onion
+		}
 		proxy := &socks.Proxy{
-			Addr:         c.cfg.TorProxy,
-			TorIsolation: c.cfg.TorIsolation,
+			Addr:         proxyAddr,
+			TorIsolation: c.cfg.TorIsolation, // need socks.NewPool with isolation???
 		}
 		wsCfg.NetDialContext = proxy.DialContext
+	}
+	if scheme == "ws" && !isOnionHost {
+		return nil, errors.New("a TLS connection is required when not using a hidden service")
 	}
 
 	wsCfg.ConnectEventFunc = func(connected bool) {
@@ -6731,7 +6767,7 @@ func parseCert(host string, certI interface{}, net dex.Network) ([]byte, error) 
 	switch c := certI.(type) {
 	case string:
 		if len(c) == 0 {
-			return CertStore[net][host], nil
+			return CertStore[net][host], nil // not found is ok (try without TLS)
 		}
 		cert, err := os.ReadFile(c)
 		if err != nil {
@@ -6740,9 +6776,11 @@ func parseCert(host string, certI interface{}, net dex.Network) ([]byte, error) 
 		return cert, nil
 	case []byte:
 		if len(c) == 0 {
-			return CertStore[net][host], nil
+			return CertStore[net][host], nil // not found is ok (try without TLS)
 		}
 		return c, nil
+	case nil:
+		return CertStore[net][host], nil // not found is ok (try without TLS)
 	}
 	return nil, fmt.Errorf("not a valid certificate type %T", certI)
 }

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1695,7 +1695,7 @@ func TestRegister(t *testing.T) {
 		AppPass: tPW,
 		Fee:     tFee,
 		Asset:   &tFeeAsset,
-		Cert:    []byte{},
+		Cert:    []byte{0x1}, // not empty signals TLS, otherwise no TLS allowed hidden services
 	}
 
 	tWallet.payFeeCoin = &tCoin{id: encode.RandomBytes(36)}
@@ -2252,8 +2252,29 @@ func TestConnectDEX(t *testing.T) {
 		Host: "somedex.com",
 	}
 
-	rig.queueConfig()
 	_, err := tCore.connectDEX(ai)
+	if err == nil {
+		t.Fatalf("expected error for no TLS plain internet DEX host")
+	}
+
+	ai.Host = "somedex13254214214.onion" // not a valid onion host in case we decide to validate them
+	// No onion proxy set => error
+	_, err = tCore.connectDEX(ai)
+	if err == nil {
+		t.Fatalf("expected error with no onion proxy set")
+	}
+
+	rig.queueConfig()
+	tCore.cfg.Onion = "127.0.0.1:9050"
+	_, err = tCore.connectDEX(ai)
+	if err != nil {
+		t.Fatalf("error connecting to onion host with an onion proxy configured: %v", err)
+	}
+
+	rig.queueConfig()
+	ai.Host = "somedex.com"
+	ai.Cert = []byte{0x1}
+	_, err = tCore.connectDEX(ai)
 	if err != nil {
 		t.Fatalf("initial connectDEX error: %v", err)
 	}

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -16,6 +16,7 @@ div.marketlist {
     text-overflow: ellipsis;
     white-space: nowrap;
     width: 100%;
+    max-width: 250px;
   }
 
   .xc:not(:first-child) .header {

--- a/client/webserver/site/src/css/orders.scss
+++ b/client/webserver/site/src/css/orders.scss
@@ -12,6 +12,10 @@
 .filter-opts {
   padding: 10px 5px 30px;
   position: relative;
+  max-width: 250px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .apply-bttn {

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -46,6 +46,8 @@ const (
 	defaultDEXPrivKeyFilename  = "sigkey"
 	defaultRPCHost             = "127.0.0.1"
 	defaultRPCPort             = "7232"
+	defaultHSHost              = defaultRPCHost // should be a loopback address
+	defaultHSPort              = "7252"
 	defaultAdminSrvAddr        = "127.0.0.1:6542"
 	defaultMaxUserCancels      = 2
 	defaultBanScore            = 20
@@ -88,6 +90,7 @@ type dexConf struct {
 	RPCCert           string
 	RPCKey            string
 	RPCListen         []string
+	HiddenService     string
 	BroadcastTimeout  time.Duration
 	AltDNSNames       []string
 	LogMaker          *dex.LoggerMaker
@@ -113,10 +116,11 @@ type flagsData struct {
 	Testnet bool `long:"testnet" description:"Use the test network (default mainnet)."`
 	Simnet  bool `long:"simnet" description:"Use the simulation test network (default mainnet)."`
 
-	RPCCert     string   `long:"rpccert" description:"RPC server TLS certificate file."`
-	RPCKey      string   `long:"rpckey" description:"RPC server TLS private key file."`
-	RPCListen   []string `long:"rpclisten" description:"IP addresses on which the RPC server should listen for incoming connections."`
-	AltDNSNames []string `long:"altdnsnames" description:"A list of hostnames to include in the RPC certificate (X509v3 Subject Alternative Name)."`
+	RPCCert       string   `long:"rpccert" description:"RPC server TLS certificate file."`
+	RPCKey        string   `long:"rpckey" description:"RPC server TLS private key file."`
+	RPCListen     []string `long:"rpclisten" description:"IP addresses on which the RPC server should listen for incoming connections."`
+	AltDNSNames   []string `long:"altdnsnames" description:"A list of hostnames to include in the RPC certificate (X509v3 Subject Alternative Name)."`
+	HiddenService string   `long:"hiddenservice" description:"A host:port on which the RPC server should listen for incoming hidden service connections. No TLS is used for these connections."`
 
 	MarketsConfPath  string        `long:"marketsconfpath" description:"Path to the markets configuration JSON file."`
 	BroadcastTimeout time.Duration `long:"bcasttimeout" description:"The broadcast timeout specifies how long clients have to broadcast an expected transaction when it is their turn to act. Matches without the expected action by this time are revoked and the actor is penalized."`
@@ -459,6 +463,13 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		}
 		RPCListen = append(RPCListen, listen)
 	}
+	var HiddenService string
+	if cfg.HiddenService != "" {
+		HiddenService, err = normalizeNetworkAddress(cfg.HiddenService, defaultHSHost, defaultHSPort)
+		if err != nil {
+			return loadConfigError(err)
+		}
+	}
 
 	// Initialize log rotation. This creates the LogDir if needed.
 	if cfg.MaxLogZips < 0 {
@@ -543,6 +554,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		RPCCert:           cfg.RPCCert,
 		RPCKey:            cfg.RPCKey,
 		RPCListen:         RPCListen,
+		HiddenService:     HiddenService,
 		BroadcastTimeout:  cfg.BroadcastTimeout,
 		AltDNSNames:       cfg.AltDNSNames,
 		LogMaker:          logMaker,

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -160,11 +160,12 @@ func mainCore(ctx context.Context) error {
 		AbsTakerLotLimit:  cfg.AbsTakerLotLimit,
 		DEXPrivKey:        privKey,
 		CommsCfg: &dexsrv.RPCConfig{
-			RPCCert:        cfg.RPCCert,
-			RPCKey:         cfg.RPCKey,
-			ListenAddrs:    cfg.RPCListen,
-			AltDNSNames:    cfg.AltDNSNames,
-			DisableDataAPI: cfg.DisableDataAPI,
+			RPCCert:           cfg.RPCCert,
+			RPCKey:            cfg.RPCKey,
+			ListenAddrs:       cfg.RPCListen,
+			AltDNSNames:       cfg.AltDNSNames,
+			DisableDataAPI:    cfg.DisableDataAPI,
+			HiddenServiceAddr: cfg.HiddenService,
 		},
 		NoResumeSwaps: cfg.NoResumeSwaps,
 	}

--- a/server/comms/middleware.go
+++ b/server/comms/middleware.go
@@ -21,6 +21,7 @@ type contextKey int
 // These are the keys for different types of values stored in a request context.
 const (
 	ctxThing contextKey = iota
+	ctxListener
 )
 
 // limitRate is rate-limiting middleware that checks whether a request can be

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -164,6 +164,14 @@ func RegisterHTTP(route string, handler HTTPHandler) {
 // The RPCConfig is the server configuration settings and the only argument
 // to the server's constructor.
 type RPCConfig struct {
+	// HiddenServiceAddr is the local address to which connections from the
+	// local hidden service will connect, e.g. 127.0.0.1:7252. This is not the
+	// .onion address of the hidden service. The TLS key pairs do not apply to
+	// these connections since TLS is not used on the hidden service's listener.
+	// This corresponds to the last component of a HiddenServicePort line in a
+	// torrc config file. e.g. HiddenServicePort 7232 127.0.0.1:7252. Clients
+	// would specify the port preceding this address in the above statement.
+	HiddenServiceAddr string
 	// ListenAddrs are the addresses on which the server will listen.
 	ListenAddrs []string
 	// The location of the TLS keypair files. If they are not already at the
@@ -297,9 +305,35 @@ func NewServer(cfg *RPCConfig) (*Server, error) {
 		return nil, err
 	}
 
+	// Start with the hidden service listener, if specified.
+	var listeners []net.Listener
+	if cfg.HiddenServiceAddr == "" {
+		listeners = make([]net.Listener, 0, len(cfg.ListenAddrs))
+	} else {
+		listeners = make([]net.Listener, 0, 1+len(cfg.ListenAddrs))
+		ipv4ListenAddrs, ipv6ListenAddrs, _, err := parseListeners([]string{cfg.HiddenServiceAddr})
+		if err != nil {
+			return nil, err
+		}
+		for _, addr := range ipv4ListenAddrs {
+			listener, err := net.Listen("tcp4", addr)
+			if err != nil {
+				return nil, fmt.Errorf("cannot listen on %s: %w", addr, err)
+			}
+			listeners = append(listeners, onionListener{listener})
+		}
+		for _, addr := range ipv6ListenAddrs {
+			listener, err := net.Listen("tcp6", addr)
+			if err != nil {
+				return nil, fmt.Errorf("cannot listen on %s: %w", addr, err)
+			}
+			listeners = append(listeners, onionListener{listener})
+		}
+	}
+
 	// Prepare the TLS configuration.
 	tlsConfig := tls.Config{
-		Certificates: []tls.Certificate{keypair},
+		Certificates: []tls.Certificate{keypair}, // TODO: multiple key pairs for virtual hosting
 		MinVersion:   tls.VersionTLS12,
 	}
 	// Parse the specified listen addresses and create the []net.Listener.
@@ -307,18 +341,17 @@ func NewServer(cfg *RPCConfig) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	listeners := make([]net.Listener, 0, len(ipv6ListenAddrs)+len(ipv4ListenAddrs))
 	for _, addr := range ipv4ListenAddrs {
 		listener, err := tls.Listen("tcp4", addr, &tlsConfig)
 		if err != nil {
-			return nil, fmt.Errorf("Can't listen on %s: %w", addr, err)
+			return nil, fmt.Errorf("cannot listen on %s: %w", addr, err)
 		}
 		listeners = append(listeners, listener)
 	}
 	for _, addr := range ipv6ListenAddrs {
 		listener, err := tls.Listen("tcp6", addr, &tlsConfig)
 		if err != nil {
-			return nil, fmt.Errorf("Can't listen on %s: %w", addr, err)
+			return nil, fmt.Errorf("cannot listen on %s: %w", addr, err)
 		}
 		listeners = append(listeners, listener)
 	}
@@ -340,6 +373,8 @@ func NewServer(cfg *RPCConfig) (*Server, error) {
 	}, nil
 }
 
+type onionListener struct{ net.Listener }
+
 // Run starts the server. Run should be called only after all routes are
 // registered.
 func (s *Server) Run(ctx context.Context) {
@@ -353,7 +388,9 @@ func (s *Server) Run(ctx context.Context) {
 		Handler:      mux,
 		ReadTimeout:  rpcTimeoutSeconds * time.Second, // slow requests should not hold connections opened
 		WriteTimeout: rpcTimeoutSeconds * time.Second, // hung responses must die
-		//BaseContext:  func(net.Listener) context.Context { return ctx },
+		BaseContext: func(l net.Listener) context.Context {
+			return context.WithValue(ctx, ctxListener, l) // the actual listener is not really useful, maybe drop it
+		},
 	}
 
 	var wg sync.WaitGroup
@@ -370,6 +407,7 @@ func (s *Server) Run(ctx context.Context) {
 			http.Error(w, "server at maximum capacity", http.StatusServiceUnavailable)
 			return
 		}
+
 		// Check websocket connection count for this IP before upgrading the
 		// conn so we can send an HTTP error code, but check again after
 		// upgrade/hijack so they cannot initiate many simultaneously.
@@ -382,6 +420,13 @@ func (s *Server) Run(ctx context.Context) {
 			log.Errorf("ws connection error: %v", err)
 			return
 		}
+
+		_, isHiddenService := r.Context().Value(ctxListener).(onionListener)
+		if isHiddenService {
+			log.Infof("Hidden service websocket connection starting from %v", r.RemoteAddr) // should be 127.0.0.1
+		}
+		// TODO: give isHiddenService to websocketHandler, possibly with a
+		// special dex.IPKey rather than the one from r.RemoteAddr
 
 		// http.Server.Shutdown waits for connections to complete (such as this
 		// http.HandlerFunc), but not the long running upgraded websocket


### PR DESCRIPTION
This introduces special handling for dex hosts with .onion host names.

Deployed to the dex-test.ssgen.io (**testnet**) server under the host name **dextesttaggpdj27s26wklczemovhqdzyvgokyumey33uemlw4imawqd.onion**.

No TLS is used with the dedicated .onion listener, and as such the client should not specify a TLS certificate.  The onion protocol provides end-to-end encryption and identification via the ed25512 key pair.  The hostname itself is all the certification that is needed AFAICT.

You can either make a new account or disable any existing dex-test.ssgen.io account and add the .onion host in its place.  If you had an account already, account discovery works as expected despite the changed host name (server is identified by it's signing key pair, not the TLS junk used for plain internet connections).

Bad thinks are likely to happen if you have an active dex-test.ssgen.io account and you try to add it again under the .onion host without first disabling the dex-test.ssgen.io version.  Related issue: https://github.com/decred/dcrdex/issues/1574

This PR is mainly the backend bits, but it all works fine via the browser, albeit with some ugly display:

![image](https://user-images.githubusercontent.com/9373513/162641656-bedd2946-7c8c-41e8-aff0-a1d26cf75746.png)

![image](https://user-images.githubusercontent.com/9373513/162641662-599ce3c0-e536-4c10-8ac3-69540e0f22a3.png)


A related change to server that I am planning is a keypair *slice* so that the TLS listener can server **virtual hosts**.