### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/client/asset/btc/livetest/regnet_test.go
+++ b/client/asset/btc/livetest/regnet_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
@@ -61,18 +60,14 @@ func TestWallet(t *testing.T) {
 		SplitTx:   true,
 	})
 
-	spvDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("MkdirTemp error: %v", err)
-	}
-	defer os.RemoveAll(spvDir) // clean up
+	spvDir := t.TempDir()
 
 	createWallet := func(cfg *asset.WalletConfig, name string, logger dex.Logger) error {
 		// var seed [32]byte
 		// copy(seed[:], []byte(name))
 		seed := encode.RandomBytes(32)
 
-		err = (&btc.Driver{}).Create(&asset.CreateWalletParams{
+		err := (&btc.Driver{}).Create(&asset.CreateWalletParams{
 			Type:    walletTypeSPV,
 			Seed:    seed[:],
 			Pass:    tPW, // match walletPassword in livetest.go -> Run

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -2092,8 +2091,7 @@ func TestSwapConfirmation(t *testing.T) {
 func TestDriverOpen(t *testing.T) {
 	drv := &Driver{}
 	logger := dex.StdOutLogger("ETHTEST", dex.LevelOff)
-	tmpDir, _ := os.MkdirTemp("", "")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	err := CreateWallet(&asset.CreateWalletParams{
 		Type:     walletTypeGeth,
@@ -2144,8 +2142,7 @@ func TestDriverOpen(t *testing.T) {
 
 func TestDriverExists(t *testing.T) {
 	drv := &Driver{}
-	tmpDir, _ := os.MkdirTemp("", "")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	settings := map[string]string{}
 

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -26,15 +26,12 @@ func init() {
 }
 
 var (
-	tDir     string
-	tCounter int
-	tLogger  = dex.StdOutLogger("db_TEST", dex.LevelTrace)
+	tLogger = dex.StdOutLogger("db_TEST", dex.LevelTrace)
 )
 
 func newTestDB(t *testing.T) (*BoltDB, func()) {
 	t.Helper()
-	tCounter++
-	dbPath := filepath.Join(tDir, fmt.Sprintf("db%d.db", tCounter))
+	dbPath := filepath.Join(t.TempDir(), "db.db")
 	dbi, err := NewDB(dbPath, tLogger)
 	if err != nil {
 		t.Fatalf("error creating dB: %v", err)
@@ -59,17 +56,7 @@ func newTestDB(t *testing.T) (*BoltDB, func()) {
 
 func TestMain(m *testing.M) {
 	defer os.Stdout.Sync()
-	doIt := func() int {
-		var err error
-		tDir, err = os.MkdirTemp("", "dbtest")
-		if err != nil {
-			fmt.Printf("error creating temporary directory: %v\n", err)
-			return -1
-		}
-		defer os.RemoveAll(tDir)
-		return m.Run()
-	}
-	os.Exit(doIt())
+	os.Exit(m.Run())
 }
 
 func TestBackup(t *testing.T) {

--- a/client/db/bolt/upgrades_test.go
+++ b/client/db/bolt/upgrades_test.go
@@ -44,8 +44,7 @@ func TestUpgrades(t *testing.T) {
 			tc := tc // capture range variable
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-				dbPath, cleanup := unpack(t, tc.filename)
-				defer cleanup()
+				dbPath := unpack(t, tc.filename)
 				db, err := bbolt.Open(dbPath, 0600,
 					&bbolt.Options{Timeout: 1 * time.Second})
 				if err != nil {
@@ -66,8 +65,7 @@ func TestUpgrades(t *testing.T) {
 
 func TestUpgradeDB(t *testing.T) {
 	runUpgrade := func(archiveName string) error {
-		dbPath, cleanup := unpack(t, archiveName)
-		defer cleanup()
+		dbPath := unpack(t, archiveName)
 		// NewDB runs upgradeDB.
 		dbi, err := NewDB(dbPath, tLogger)
 		if err != nil {
@@ -326,12 +324,9 @@ func checkVersion(dbtx *bbolt.Tx, expectedVersion uint32) error {
 	return nil
 }
 
-func unpack(t *testing.T, db string) (string, func()) {
+func unpack(t *testing.T, db string) string {
 	t.Helper()
-	d, err := os.MkdirTemp("", "dcrdex_test_upgrades")
-	if err != nil {
-		t.Fatal(err)
-	}
+	d := t.TempDir()
 
 	t.Helper()
 	archive, err := os.Open(filepath.Join("testdata", db))
@@ -352,10 +347,7 @@ func unpack(t *testing.T, db string) (string, func()) {
 	archive.Close()
 	dbFile.Close()
 	if err != nil {
-		os.RemoveAll(d)
 		t.Fatal(err)
 	}
-	return dbPath, func() {
-		os.RemoveAll(d)
-	}
+	return dbPath
 }

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -155,12 +155,7 @@ func newTServerWErr(t *testing.T, start bool, user, pass string) (*RPCServer, fu
 
 	var shutdown func()
 	ctx, killCtx := context.WithCancel(tCtx)
-	tempDir, err := os.MkdirTemp("", "rpcservertest")
-	if err != nil {
-		killCtx()
-		return nil, nil, fmt.Errorf("error creating temporary directory: %w", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	cert, key := tempDir+"/cert.cert", tempDir+"/key.key"
 	cfg := &Config{
@@ -207,11 +202,7 @@ func TestConnectBindError(t *testing.T) {
 	s0, shutdown := newTServer(t, true, "", "abc")
 	defer shutdown()
 
-	tempDir, err := os.MkdirTemp("", "rpcservertest")
-	if err != nil {
-		t.Fatalf("error creating temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	cert, key := tempDir+"/cert.cert", tempDir+"/key.key"
 	cfg := &Config{

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -295,8 +295,7 @@ func TestNew_siteError(t *testing.T) {
 	}
 
 	// Change to a directory with no "site" or "../../webserver/site" folder.
-	dir, _ := os.MkdirTemp("", "test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	defer os.Chdir(cwd) // leave the temp dir before trying to delete it
 
 	if err = os.Chdir(dir); err != nil {

--- a/dex/config/config_test.go
+++ b/dex/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -38,14 +37,10 @@ func makeConfigPtr() *config {
 func TestConfigParsing(t *testing.T) {
 	var testConfig = defaultConfig()
 
-	tempDir, err := os.MkdirTemp("", "configtest")
-	if err != nil {
-		t.Fatalf("error creating temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	cfgFilePath := filepath.Join(tempDir, "test.conf")
 	cfgFile := ini.Empty()
-	err = cfgFile.ReflectFrom(&testConfig)
+	err := cfgFile.ReflectFrom(&testConfig)
 	if err != nil {
 		t.Fatalf("error creating temporary config file: %v", err)
 	}

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -244,14 +244,10 @@ var tPort = 5555
 // If start is true, the Server's Run goroutine is started, and the shutdown
 // func must be called when finished with the Server.
 func newTServer(t *testing.T, start bool, authSHA [32]byte) (*Server, func()) {
-	tmp, err := os.MkdirTemp("", "admin")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	cert, key := filepath.Join(tmp, "tls.cert"), filepath.Join(tmp, "tls.key")
-	err = genCertPair(cert, key)
+	err := genCertPair(cert, key)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -58,11 +58,7 @@ func TestConfig(t *testing.T) {
 	cfg := &dexbtc.RPCConfig{}
 	parsedCfg := &dexbtc.RPCConfig{}
 
-	tempDir, err := os.MkdirTemp("", "btctest")
-	if err != nil {
-		t.Fatalf("error creating temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "test.conf")
 
 	runCfg := func(inCfg *dexbtc.RPCConfig) error {
@@ -85,7 +81,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	// Check that there is an error from an unpopulated configuration.
-	err = runCfg(cfg)
+	err := runCfg(cfg)
 	if err == nil {
 		t.Fatalf("no error for empty config")
 	}

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -49,11 +49,7 @@ func TestLoadConfig(t *testing.T) {
 	cfg := &config{}
 	parsedCfg := &config{}
 
-	tempDir, err := os.MkdirTemp("", "btctest")
-	if err != nil {
-		t.Fatalf("error creating temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 	filePath := filepath.Join(tempDir, "test.conf")
 	rootParser := flags.NewParser(cfg, flags.None)
 	iniParser := flags.NewIniParser(rootParser)
@@ -69,7 +65,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	// Try with just the name. Error expected.
-	err = runCfg(&config{
+	err := runCfg(&config{
 		RPCUser: "somename",
 	})
 	if err == nil {

--- a/server/cmd/dcrdex/key_test.go
+++ b/server/cmd/dcrdex/key_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,9 +12,7 @@ import (
 )
 
 func Test_createAndStoreKey(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "test")
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	file := "newkey"
 
 	tests := []struct {
@@ -61,8 +58,7 @@ func Test_createAndStoreKey(t *testing.T) {
 }
 
 func Test_loadKeyFile(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	fullFile := filepath.Join(dir, "newkey")
 	pass := []byte("pass1234")
@@ -119,8 +115,7 @@ func Test_loadKeyFile(t *testing.T) {
 }
 
 func Test_dexKey(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "test")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := "newkey"
 	fullFile := filepath.Join(dir, file)

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -679,11 +679,7 @@ func TestClientResponses(t *testing.T) {
 func TestOnline(t *testing.T) {
 	defer resetRPCRoutes()
 
-	tempDir, err := os.MkdirTemp("", "example")
-	if err != nil {
-		t.Fatalf("TempDir error: %v", err)
-	}
-	defer os.RemoveAll(tempDir) // clean up
+	tempDir := t.TempDir()
 
 	keyPath := filepath.Join(tempDir, "rpc.key")
 	certPath := filepath.Join(tempDir, "rpc.cert")

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -305,10 +304,6 @@ func newTestMarket(opts ...interface{}) (*Market, *TArchivist, *TAuth, func(), e
 		preimagesByOrdID: make(map[string]order.Preimage),
 	}
 
-	swapDataDir, err := os.MkdirTemp("", "swapstates")
-	if err != nil {
-		panic(err.Error())
-	}
 	var swapDone func(ord order.Order, match *order.Match, fail bool)
 	swapperCfg := &swap.Config{
 		Assets: map[uint32]*swap.SwapperAsset{
@@ -361,7 +356,6 @@ func newTestMarket(opts ...interface{}) (*Market, *TArchivist, *TAuth, func(), e
 	cleanup := func() {
 		ssw.Stop()
 		ssw.WaitForShutdown()
-		os.RemoveAll(swapDataDir)
 	}
 
 	return mkt, storage, authMgr, cleanup, nil


### PR DESCRIPTION
A testing cleanup.

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir