### PR TITLE
client/asset/{btc,dcr}: support p2pk and fix unsupported btc utxos

### DIFF
--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -690,7 +690,7 @@ func (wc *rpcClient) call(method string, args anylist, thing interface{}) error 
 
 	b, err := wc.requester.RawRequest(wc.ctx, method, params)
 	if err != nil {
-		return fmt.Errorf("rawrequest error: %w", err)
+		return fmt.Errorf("rawrequest (%v) error: %w", method, err)
 	}
 	if thing != nil {
 		return json.Unmarshal(b, thing)

--- a/dex/networks/btc/script.go
+++ b/dex/networks/btc/script.go
@@ -229,6 +229,7 @@ type BTCScriptType uint8
 
 const (
 	ScriptP2PKH = 1 << iota
+	ScriptP2PK
 	ScriptP2SH
 	ScriptTypeSegwit
 	ScriptMultiSig
@@ -248,6 +249,11 @@ func (s BTCScriptType) IsP2WSH() bool {
 // IsP2PKH will return boolean true if the script is a P2PKH script.
 func (s BTCScriptType) IsP2PKH() bool {
 	return s&ScriptP2PKH != 0 && s&ScriptTypeSegwit == 0
+}
+
+// IsP2PK will return boolean true if the script is a P2PK script.
+func (s BTCScriptType) IsP2PK() bool {
+	return s&ScriptP2PK != 0 && s&ScriptTypeSegwit == 0
 }
 
 // IsP2WPKH will return boolean true if the script is a P2WPKH script.
@@ -274,6 +280,8 @@ func ParseScriptType(pkScript, redeemScript []byte) BTCScriptType {
 	class := txscript.GetScriptClass(pkScript)
 
 	switch class {
+	case txscript.PubKeyTy:
+		scriptType |= ScriptP2PK
 	case txscript.PubKeyHashTy:
 		scriptType |= ScriptP2PKH
 	case txscript.WitnessV0PubKeyHashTy:
@@ -649,6 +657,9 @@ func InputInfo(pkScript, redeemScript []byte, chainParams *chaincfg.Params) (*Sp
 	// Start with standard P2PKH.
 	var sigScriptSize, witnessWeight int
 	switch {
+	case scriptType.IsP2PK():
+		sigScriptSize = RedeemP2PKSigScriptSize
+		witnessWeight = 0
 	case scriptType.IsP2PKH():
 		sigScriptSize = RedeemP2PKHSigScriptSize
 		witnessWeight = 0

--- a/dex/networks/btc/script_test.go
+++ b/dex/networks/btc/script_test.go
@@ -96,7 +96,17 @@ func TestParseScriptType(t *testing.T) {
 		}
 	}
 
+	parse(addrs.pk1, nil)
+	check("p2pk-IsP2PK", scriptType.IsP2PK(), true)
+	check("p2pk-IsP2PKH", scriptType.IsP2PKH(), false)
+	check("p2pk-IsP2SH", scriptType.IsP2SH(), false)
+	check("p2pk-IsP2WPKH", scriptType.IsP2WPKH(), false)
+	check("p2pk-IsP2WSH", scriptType.IsP2WSH(), false)
+	check("p2pk-IsMultiSig", scriptType.IsMultiSig(), false)
+	check("p2pk-IsSegwit", scriptType.IsSegwit(), false)
+
 	parse(addrs.pkh, nil)
+	check("p2pkh-IsP2PK", scriptType.IsP2PK(), false)
 	check("p2pkh-IsP2PKH", scriptType.IsP2PKH(), true)
 	check("p2pkh-IsP2SH", scriptType.IsP2SH(), false)
 	check("p2pkh-IsP2WPKH", scriptType.IsP2WPKH(), false)
@@ -105,6 +115,7 @@ func TestParseScriptType(t *testing.T) {
 	check("p2pkh-IsSegwit", scriptType.IsSegwit(), false)
 
 	parse(addrs.wpkh, nil)
+	check("p2wpkh-IsP2PK", scriptType.IsP2PK(), false)
 	check("p2wpkh-IsP2PKH", scriptType.IsP2PKH(), false)
 	check("p2wpkh-IsP2SH", scriptType.IsP2SH(), false)
 	check("p2wpkh-IsP2WPKH", scriptType.IsP2WPKH(), true)
@@ -113,6 +124,7 @@ func TestParseScriptType(t *testing.T) {
 	check("p2wpkh-IsSegwit", scriptType.IsSegwit(), true)
 
 	parse(addrs.sh, addrs.multiSig)
+	check("p2sh-IsP2PK", scriptType.IsP2PK(), false)
 	check("p2sh-IsP2PKH", scriptType.IsP2PKH(), false)
 	check("p2sh-IsP2SH", scriptType.IsP2SH(), true)
 	check("p2sh-IsP2WPKH", scriptType.IsP2WPKH(), false)
@@ -121,6 +133,7 @@ func TestParseScriptType(t *testing.T) {
 	check("p2sh-IsSegwit", scriptType.IsSegwit(), false)
 
 	parse(addrs.wsh, nil)
+	check("p2wsh-IsP2PK", scriptType.IsP2PK(), false)
 	check("p2wsh-IsP2PKH", scriptType.IsP2PKH(), false)
 	check("p2wsh-IsP2SH", scriptType.IsP2SH(), false)
 	check("p2wsh-IsP2WPKH", scriptType.IsP2WPKH(), false)

--- a/dex/networks/dcr/script_test.go
+++ b/dex/networks/dcr/script_test.go
@@ -105,31 +105,43 @@ func TestScriptType(t *testing.T) {
 		}
 	}
 
+	parse(addrs.pk1, 0)
+	check("p2pk-IsP2PK", scriptType.IsP2PK(), true)
+	check("p2pk-IsP2PKH", scriptType.IsP2PKH(), false)
+	check("p2pk-IsP2SH", scriptType.IsP2SH(), false)
+	check("p2pk-IsStake", scriptType.IsStake(), false)
+	check("p2pk-IsMultiSig", scriptType.IsMultiSig(), false)
+
 	parse(addrs.pkh, 0)
+	check("p2pkh-IsP2PK", scriptType.IsP2PK(), false)
 	check("p2pkh-IsP2PKH", scriptType.IsP2PKH(), true)
 	check("p2pkh-IsP2SH", scriptType.IsP2SH(), false)
 	check("p2pkh-IsStake", scriptType.IsStake(), false)
 	check("p2pkh-IsMultiSig", scriptType.IsMultiSig(), false)
 
 	parse(addrs.pkh, txscript.OP_SSGEN)
+	check("stakePKH-IsP2PK", scriptType.IsP2PK(), false)
 	check("stakePKH-IsP2PKH", scriptType.IsP2PKH(), true)
 	check("stakePKH-IsP2SH", scriptType.IsP2SH(), false)
 	check("stakePKH-IsStake", scriptType.IsStake(), true)
 	check("stakePKH-IsMultiSig", scriptType.IsMultiSig(), false)
 
 	parse(addrs.edwards, 0)
+	check("edwards-IsP2PK", scriptType.IsP2PK(), false)
 	check("edwards-IsP2PKH", scriptType.IsP2PKH(), true)
 	check("edwards-IsP2SH", scriptType.IsP2SH(), false)
 	check("edwards-IsStake", scriptType.IsStake(), false)
 	check("edwards-IsMultiSig", scriptType.IsMultiSig(), false)
 
 	parse(addrs.schnorrPK, 0)
+	check("schnorrPK-IsP2PK", scriptType.IsP2PK(), true)
 	check("schnorrPK-IsP2PKH", scriptType.IsP2PKH(), false)
 	check("schnorrPK-IsP2SH", scriptType.IsP2SH(), false)
 	check("schnorrPK-IsStake", scriptType.IsStake(), false)
 	check("schnorrPK-IsMultiSig", scriptType.IsMultiSig(), false)
 
 	pkScript, scriptType := parse(addrs.sh, 0)
+	check("p2sh-IsP2PK", scriptType.IsP2PK(), false)
 	check("p2sh-IsP2PKH", scriptType.IsP2PKH(), false)
 	check("p2sh-IsP2SH", scriptType.IsP2SH(), true)
 	check("p2pkh-IsStake", scriptType.IsStake(), false)
@@ -149,6 +161,7 @@ func TestScriptType(t *testing.T) {
 	check("p2pkh-IsStake", scriptType.IsStake(), false)
 
 	pkScript, scriptType = parse(addrs.sh, txscript.OP_SSGEN)
+	check("stake-p2sh-IsP2PK", scriptType.IsP2PK(), false)
 	check("stake-p2sh-IsP2PKH", scriptType.IsP2PKH(), false)
 	check("stake-p2sh-IsP2SH", scriptType.IsP2SH(), true)
 	check("stake-p2pkh-IsStake", scriptType.IsStake(), true)

--- a/server/asset/btc/utxo.go
+++ b/server/asset/btc/utxo.go
@@ -287,7 +287,7 @@ func (utxo *UTXO) Confirmations(context.Context) (int64, error) {
 		// See if we can find the utxo in another block.
 		newUtxo, err := utxo.btc.utxo(&utxo.tx.hash, utxo.vout, utxo.redeemScript)
 		if err != nil {
-			return -1, fmt.Errorf("utxo block is not mainchain")
+			return -1, fmt.Errorf("utxo error: %w", err)
 		}
 		*utxo = *newUtxo
 		return utxo.Confirmations(context.Background())

--- a/server/asset/doge/doge.go
+++ b/server/asset/doge/doge.go
@@ -109,5 +109,7 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 
 			return uint64(math.Round(r * 1e5)), nil
 		},
+		BooleanGetBlockRPC: true,
+		BlockDeserializer:  dexdoge.DeserializeBlock,
 	})
 }


### PR DESCRIPTION
Addressing issues revealed in https://github.com/decred/dcrdex/pull/1558#issuecomment-1095680799

This updates the DCR and BTC packages to understand P2PK outputs.

This also fixes the BTC client packages UTXO conversion code so that
unsupported output scripts in the listunspent result are merely skipped
instead of breaking the ability to select UTXOs at all.