### PR TITLE
multi: Clear private data asap.

### DIFF
--- a/client/core/account.go
+++ b/client/core/account.go
@@ -63,6 +63,7 @@ func (c *Core) AccountExport(pw []byte, host string) (*Account, error) {
 	if err != nil {
 		return nil, codedError(passwordErr, err)
 	}
+	defer crypter.Close()
 	host, err = addrHost(host)
 	if err != nil {
 		return nil, newError(addressParseErr, "error parsing address: %w", err)

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -633,6 +633,7 @@ func (a *dexAccount) setupCryptoV2(creds *db.PrimaryCredentials, crypter encrypt
 	if err != nil {
 		return fmt.Errorf("seed decryption error: %w", err)
 	}
+	defer encode.ClearBytes(seed)
 
 	dexPkB := a.dexPubKey.SerializeCompressed()
 	// And because I'm neurotic.

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -481,6 +481,7 @@ func (s *WebServer) authorize() string {
 	b := make([]byte, 32)
 	rand.Read(b)
 	token := hex.EncodeToString(b)
+	zero(b)
 	s.authMtx.Lock()
 	s.authTokens[token] = true
 	s.authMtx.Unlock()
@@ -589,6 +590,7 @@ func (s *WebServer) getCachedPasswordUsingRequest(r *http.Request) ([]byte, erro
 func (s *WebServer) cacheAppPassword(appPW []byte, authToken string) ([]byte, error) {
 	key := encode.RandomBytes(16)
 	crypter := encrypt.NewCrypter(key)
+	defer crypter.Close()
 	encryptedPass, err := crypter.Encrypt(appPW)
 	if err != nil {
 		return nil, fmt.Errorf("error encrypting password: %v", err)


### PR DESCRIPTION
    In core methods and consumers, clear passwords, private keys, and seeds
    when possible to protect against some memory scraping attacks.

lightly discussed in #1582

This pr makes it so the crypter cannot be used in goroutines. I think we're not doing so atm, but should be careful going forward.