### PR TITLE
[v0.4.3] staging branch with backports

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -182,20 +182,20 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 	}
 
 	return &BCHWallet{
-		ExchangeWallet: xcWallet,
+		ExchangeWalletFullNode: xcWallet,
 	}, nil
 }
 
-// BCHWallet embeds btc.ExchangeWallet, but re-implements a couple of methods to
-// perform on-the-fly address translation.
+// BCHWallet embeds btc.ExchangeWalletFullNode, but re-implements a couple of
+// methods to perform on-the-fly address translation.
 type BCHWallet struct {
-	*btc.ExchangeWallet
+	*btc.ExchangeWalletFullNode
 }
 
 // Address converts the Bitcoin base58-encoded address returned by the embedded
 // ExchangeWallet into a Cash Address.
 func (bch *BCHWallet) Address() (string, error) {
-	btcAddrStr, err := bch.ExchangeWallet.Address()
+	btcAddrStr, err := bch.ExchangeWalletFullNode.Address()
 	if err != nil {
 		return "", err
 	}
@@ -206,7 +206,7 @@ func (bch *BCHWallet) Address() (string, error) {
 // AuditContract method by converting the Recipient to the Cash Address
 // encoding.
 func (bch *BCHWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadcast bool) (*asset.AuditInfo, error) { // AuditInfo has address
-	ai, err := bch.ExchangeWallet.AuditContract(coinID, contract, txData, rebroadcast)
+	ai, err := bch.ExchangeWalletFullNode.AuditContract(coinID, contract, txData, rebroadcast)
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2373,6 +2373,16 @@ func (btc *baseWallet) PayFee(address string, regFee, feeRate uint64) (asset.Coi
 	return newOutput(txHash, vout, sent), nil
 }
 
+// EstimateRegistrationTxFee returns an estimate for the tx fee needed to
+// pay the registration fee using the provided feeRate.
+func (btc *baseWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
+	const inputCount = 5 // buffer so this estimate is higher than what PayFee uses
+	if feeRate == 0 || feeRate > btc.feeRateLimit {
+		feeRate = btc.fallbackFeeRate
+	}
+	return (dexbtc.MinimumTxOverhead + 2*dexbtc.P2PKHOutputSize + inputCount*dexbtc.RedeemP2PKHInputSize) * feeRate
+}
+
 // Withdraw withdraws funds to the specified address. Fees are subtracted from
 // the value. feeRate is in units of atoms/byte.
 func (btc *baseWallet) Withdraw(address string, value, feeRate uint64) (asset.Coin, error) {

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -547,8 +547,13 @@ func (btc *ExchangeWalletSPV) Rescan(_ context.Context) error {
 }
 
 // FeeRate satisfies asset.FeeRater.
-func (btc *ExchangeWalletFullNode) FeeRate() (uint64, error) {
-	return btc.feeRate(nil, 1)
+func (btc *ExchangeWalletFullNode) FeeRate() uint64 {
+	rate, err := btc.feeRate(nil, 1)
+	if err != nil {
+		btc.log.Errorf("Failed to get fee rate: %v", err)
+		return 0
+	}
+	return rate
 }
 
 // LogFilePath returns the path to the neutrino log file.

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -31,16 +31,15 @@ import (
 )
 
 var (
-	tLogger   dex.Logger
-	tCtx      context.Context
-	tLotSize  uint64 = 1e6 // 0.01 BTC
-	tRateStep uint64 = 10
-	tBTC             = &dex.Asset{
+	tLogger  dex.Logger
+	tCtx     context.Context
+	tLotSize uint64 = 1e6 // 0.01 BTC
+	tBTC            = &dex.Asset{
 		ID:           0,
 		Symbol:       "btc",
 		Version:      version,
-		SwapSize:     dexbtc.InitTxSize,
-		SwapSizeBase: dexbtc.InitTxSizeBase,
+		SwapSize:     dexbtc.InitTxSizeSegwit, // patched by tNewWallet, but default to segwit
+		SwapSizeBase: dexbtc.InitTxSizeBaseSegwit,
 		MaxFeeRate:   34,
 		SwapConf:     1,
 	}
@@ -2744,7 +2743,7 @@ func testTryRedemptionRequests(t *testing.T, segwit bool, walletType string) {
 	}
 
 	addBlocks := func(n int) {
-		var h int64 = 0
+		var h int64
 		// Make dummy transactions.
 		for i := 0; i < n; i++ {
 			node.addRawTx(h, otherTx())

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -566,7 +566,7 @@ func makeSwapContract(segwit bool, lockTimeOffset time.Duration) (secret []byte,
 	return
 }
 
-func tNewWallet(segwit bool, walletType string) (*ExchangeWallet, *testData, func(), error) {
+func tNewWallet(segwit bool, walletType string) (*ExchangeWalletFullNode, *testData, func(), error) {
 	if segwit {
 		tBTC.SwapSize = dexbtc.InitTxSizeSegwit
 		tBTC.SwapSizeBase = dexbtc.InitTxSizeBaseSegwit
@@ -601,14 +601,15 @@ func tNewWallet(segwit bool, walletType string) (*ExchangeWallet, *testData, fun
 
 	// rpcClient := newRPCClient(requester, segwit, nil, false, minNetworkVersion, dex.StdOutLogger("RPCTEST", dex.LevelTrace), &chaincfg.MainNetParams)
 
-	var wallet *ExchangeWallet
+	var wallet *ExchangeWalletFullNode
 	var err error
 	switch walletType {
 	case walletTypeRPC:
 		wallet, err = newRPCWallet(&tRawRequester{data}, cfg, &WalletConfig{})
 	case walletTypeSPV:
-		wallet, err = newUnconnectedWallet(cfg, &WalletConfig{})
+		w, err := newUnconnectedWallet(cfg, &WalletConfig{})
 		if err == nil {
+			wallet = &ExchangeWalletFullNode{w}
 			neutrinoClient := &tNeutrinoClient{data}
 			wallet.node = &spvWallet{
 				chainParams: &chaincfg.MainNetParams,
@@ -1191,7 +1192,7 @@ func testFundingCoins(t *testing.T, segwit bool, walletType string) {
 	ensureGood()
 }
 
-func checkMaxOrder(t *testing.T, wallet *ExchangeWallet, lots, swapVal, maxFees, estWorstCase, estBestCase, locked uint64) {
+func checkMaxOrder(t *testing.T, wallet asset.Wallet, lots, swapVal, maxFees, estWorstCase, estBestCase, locked uint64) {
 	t.Helper()
 	maxOrder, err := wallet.MaxOrder(tLotSize, feeSuggestion, tBTC)
 	if err != nil {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2298,6 +2298,16 @@ func (dcr *ExchangeWallet) PayFee(address string, regFee, feeRate uint64) (asset
 	return newOutput(msgTx.CachedTxHash(), 0, regFee, wire.TxTreeRegular), nil
 }
 
+// EstimateRegistrationTxFee returns an estimate for the tx fee needed to
+// pay the registration fee using the provided feeRate.
+func (dcr *ExchangeWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
+	const inputCount = 5 // buffer so this estimate is higher than what PayFee uses
+	if feeRate == 0 || feeRate > dcr.feeRateLimit {
+		feeRate = dcr.fallbackFeeRate
+	}
+	return (dexdcr.MsgTxOverhead + dexdcr.P2PKHOutputSize*2 + inputCount*dexdcr.P2PKHInputSize) * feeRate
+}
+
 // Withdraw withdraws funds to the specified address. Fees are subtracted from
 // the value.
 func (dcr *ExchangeWallet) Withdraw(address string, value, feeRate uint64) (asset.Coin, error) {

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -2498,3 +2498,28 @@ func TestPreRedeem(t *testing.T) {
 		t.Fatalf("best case > worst case")
 	}
 }
+
+func TestEstimateRegistrationTxFee(t *testing.T) {
+	wallet, _, shutdown, _ := tNewWallet()
+	defer shutdown()
+
+	const inputCount = 5
+	const txSize = dexdcr.MsgTxOverhead + dexdcr.P2PKHOutputSize*2 + inputCount*dexdcr.P2PKHInputSize
+	wallet.feeRateLimit = 100
+	wallet.fallbackFeeRate = 30
+
+	estimate := wallet.EstimateRegistrationTxFee(50)
+	if estimate != 50*txSize {
+		t.Fatalf("expected tx fee to be %d but got %d", 50*txSize, estimate)
+	}
+
+	estimate = wallet.EstimateRegistrationTxFee(0)
+	if estimate != wallet.fallbackFeeRate*txSize {
+		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)
+	}
+
+	estimate = wallet.EstimateRegistrationTxFee(wallet.feeRateLimit + 1)
+	if estimate != wallet.fallbackFeeRate*txSize {
+		t.Fatalf("expected tx fee to be %d but got %d", wallet.fallbackFeeRate*txSize, estimate)
+	}
+}

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -46,9 +46,10 @@ func init() {
 
 const (
 	// BipID is the BIP-0044 asset ID.
-	BipID              = 60
-	defaultGasFee      = 82  // gwei
-	defaultGasFeeLimit = 200 // gwei
+	BipID               = 60
+	defaultGasFee       = 82  // gwei
+	defaultGasFeeLimit  = 200 // gwei
+	defaultSendGasLimit = 21_000
 )
 
 var (
@@ -788,6 +789,12 @@ func (eth *ExchangeWallet) Locked() bool {
 		return false
 	}
 	return wallet.Status != "Unlocked"
+}
+
+// EstimateRegistrationTxFee returns an estimate for the tx fee needed to
+// pay the registration fee using the provided feeRate.
+func (eth *ExchangeWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
+	return feeRate * defaultSendGasLimit
 }
 
 // PayFee sends the dex registration fee. Transaction fees are in addition to

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -318,15 +318,14 @@ type LogFiler interface {
 
 // FeeRater is capable of retrieving a non-critical fee rate estimate for an
 // asset. Some SPV wallets, for example, cannot provide a fee rate estimate, so
-// shouldn't implement FeeRater. The rates from FeeRate are used for rates that
-// are not validated by the server (Withdraw, Send, PayFee), and will/should not
-// be used to generate a fee suggestion for swap operations. Assets may also be
-// unable to retrieve an estimate temporarily, such as before the node is primed
-// for BTC. In that case, an error should be returned, but the caller can
-// proceed to get an estimate from any known server's 'fee_rate' endpoint, if
-// possible.
+// shouldn't implement FeeRater. However, since the mode of external wallets may
+// not be known on construction, only connect, a zero rate may be returned. The
+// caller should always check for zero and have a fallback rate. The rates from
+// FeeRate should be used for rates that are not validated by the server
+// (Withdraw, Send, PayFee), and will/should not be used to generate a fee
+// suggestion for swap operations.
 type FeeRater interface {
-	FeeRate() (uint64, error)
+	FeeRate() uint64
 }
 
 // Balance is categorized information about a wallet's balance.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -287,6 +287,9 @@ type Wallet interface {
 	// payment. This method need not be supported by all assets. Those assets
 	// which do no support DEX registration fees will return an ErrUnsupported.
 	RegFeeConfirmations(ctx context.Context, coinID dex.Bytes) (confs uint32, err error)
+	// EstimateRegistrationTxFee returns an estimate for the tx fee needed to
+	// pay the registration fee using the provided feeRate.
+	EstimateRegistrationTxFee(feeRate uint64) uint64
 }
 
 // Rescanner is a wallet implementation with rescan functionality.

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	version = 0
+	version = 1
 	// BipID is the BIP-0044 asset ID.
 	BipID = 2
 	// defaultFee is the default value for the fallbackfee.
@@ -165,7 +165,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		DefaultFeeRateLimit: defaultFeeRateLimit,
 		LegacyBalance:       true,
 		LegacyRawFeeLimit:   true,
-		Segwit:              false,
+		Segwit:              true,
 	}
 
 	return btc.BTCCloneWallet(cloneCFG)

--- a/client/asset/ltc/regnet_test.go
+++ b/client/asset/ltc/regnet_test.go
@@ -23,17 +23,16 @@ import (
 	dexbtc "decred.org/dcrdex/dex/networks/btc"
 )
 
-const alphaAddress = "mt9hgfXXbM3x7hewgEAovBwqoMAAnctJ4V"
+// const alphaAddress = "rltc1qjld4f85m96rr77035c5yuhkz8apxlkkla0ftmz"
 
 var (
-	tLotSize  uint64 = 1e6
-	tRateStep uint64 = 10
-	tLTC             = &dex.Asset{
+	tLotSize uint64 = 1e6
+	tLTC            = &dex.Asset{
 		ID:           2,
 		Symbol:       "ltc",
 		Version:      version,
-		SwapSize:     dexbtc.InitTxSize,
-		SwapSizeBase: dexbtc.InitTxSizeBase,
+		SwapSize:     dexbtc.InitTxSizeSegwit,
+		SwapSizeBase: dexbtc.InitTxSizeBaseSegwit,
 		MaxFeeRate:   10,
 		SwapConf:     1,
 	}

--- a/client/cmd/dexc/config.go
+++ b/client/cmd/dexc/config.go
@@ -96,6 +96,7 @@ type Config struct {
 	ShowVer      bool   `short:"V" long:"version" description:"Display version information and exit"`
 	TorProxy     string `long:"torproxy" description:"Connect via TOR (eg. 127.0.0.1:9050)."`
 	TorIsolation bool   `long:"torisolation" description:"Enable TOR circuit isolation."`
+	Onion        string `long:"onion" description:"Proxy for .onion addresses, if torproxy not set (eg. 127.0.0.1:9050)."`
 	Net          dex.Network
 	CertHosts    []string
 }

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -96,6 +96,7 @@ func mainCore() error {
 		Logger:       logMaker.Logger("CORE"),
 		TorProxy:     cfg.TorProxy,
 		TorIsolation: cfg.TorIsolation,
+		Onion:        cfg.Onion,
 		Language:     cfg.Language,
 	})
 	if err != nil {

--- a/client/cmd/dexc/version/version.go
+++ b/client/cmd/dexc/version/version.go
@@ -25,7 +25,7 @@ const (
 	AppName  string = "dexc"
 	AppMajor uint   = 0
 	AppMinor uint   = 4
-	AppPatch uint   = 2
+	AppPatch uint   = 3
 )
 
 // go build -v -ldflags "-X decred.org/dcrdex/client/cmd/dexc/version.appPreRelease= -X decred.org/dcrdex/client/cmd/dexc/version.appBuild=$(git rev-parse --short HEAD)"

--- a/client/cmd/dexcctl/version.go
+++ b/client/cmd/dexcctl/version.go
@@ -25,7 +25,7 @@ const (
 	appName  string = "dexcctl"
 	appMajor uint   = 0
 	appMinor uint   = 4
-	appPatch uint   = 2
+	appPatch uint   = 3
 )
 
 // go build -v -ldflags "-X decred.org/dcrdex/client/cmd/dexcctl/main.appPreRelease= -X decred.org/dcrdex/client/cmd/dexcctl/main.appBuild=$(git rev-parse --short HEAD)"

--- a/client/core/account.go
+++ b/client/core/account.go
@@ -163,7 +163,7 @@ func (c *Core) AccountImport(pw []byte, acct Account) error {
 			delete(c.conns, dc.acct.host)
 			c.connMtx.Unlock()
 		}
-		return newError(accountVerificationErr, "Account not verified for host: %s err: %v", host, err)
+		return newError(accountVerificationErr, "Account not verified for host: %s", host)
 	}
 
 	err = c.db.CreateAccount(&accountInfo)

--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -242,7 +242,7 @@ func buildTestAccount(host string) Account {
 		AccountID:     tDexAccountID.String(),
 		DEXPubKey:     hex.EncodeToString(tDexKey.SerializeCompressed()),
 		PrivKey:       hex.EncodeToString(tDexPriv.Serialize()),
-		Cert:          hex.EncodeToString([]byte{}),
+		Cert:          hex.EncodeToString([]byte{0x1}),
 		FeeCoin:       hex.EncodeToString([]byte("somecoin")),
 		FeeProofSig:   hex.EncodeToString(tFeeProofSig),
 		FeeProofStamp: tFeeProofStamp,

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -712,6 +712,9 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 		Seq:      sp.Seq,        // forces seq reset, but should be in seq with previous
 		Epoch:    sp.FinalEpoch, // unused?
 		// Orders is nil
+		// BaseFeeRate = QuoteFeeRate = 0 effectively disables the book's fee
+		// cache until an update is received, since bestBookFeeSuggestion
+		// ignores zeros.
 	})
 	// Return any non-nil error, but still revoke purged orders.
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1019,11 +1019,15 @@ func (dc *dexConnection) bestBookFeeSuggestion(assetID uint32) uint64 {
 	dc.booksMtx.RLock()
 	defer dc.booksMtx.RUnlock()
 	for _, book := range dc.books {
+		var feeRate uint64
 		switch assetID {
 		case book.base:
-			return book.BaseFeeRate()
+			feeRate = book.BaseFeeRate()
 		case book.quote:
-			return book.QuoteFeeRate()
+			feeRate = book.QuoteFeeRate()
+		}
+		if feeRate > 0 {
+			return feeRate
 		}
 	}
 	return 0
@@ -2838,8 +2842,8 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	c.log.Infof("Attempting registration fee payment to %s, account ID %v, of %d units of %s. "+
 		"Do NOT manually send funds to this address even if this fails.",
 		regRes.Address, dc.acct.id, regRes.Fee, regFeeAssetSymbol)
-	feeRateSuggestion := dc.fetchFeeRate(feeAsset.ID)
-	coin, err := wallet.PayFee(regRes.Address, regRes.Fee, feeRateSuggestion)
+	feeRate := c.feeSuggestionAny(feeAsset.ID, dc)
+	coin, err := wallet.PayFee(regRes.Address, regRes.Fee, feeRate)
 	if err != nil {
 		return nil, newError(feeSendErr, "error paying registration fee: %v", err)
 	}
@@ -3457,7 +3461,7 @@ func (c *Core) MaxBuy(host string, base, quote uint32, rate uint64) (*MaxOrderEs
 		return nil, fmt.Errorf("failed to get swap fee suggestion for %s at %s", unbip(quote), host)
 	}
 
-	redeemFeeSuggestion := c.feeSuggestion(dc, base)
+	redeemFeeSuggestion := c.feeSuggestionAny(base)
 	if redeemFeeSuggestion == 0 {
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(base), host)
 	}
@@ -3515,7 +3519,7 @@ func (c *Core) MaxSell(host string, base, quote uint32) (*MaxOrderEstimate, erro
 		return nil, fmt.Errorf("failed to get swap fee suggestion for %s at %s", unbip(base), host)
 	}
 
-	redeemFeeSuggestion := c.feeSuggestion(dc, quote)
+	redeemFeeSuggestion := c.feeSuggestionAny(quote)
 	if redeemFeeSuggestion == 0 {
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(quote), host)
 	}
@@ -3721,11 +3725,22 @@ func (c *Core) notifyFee(dc *dexConnection, coinID []byte) error {
 }
 
 // feeSuggestionAny gets a fee suggestion for the given asset from any source
-// with it available. It first checks all relevant books for a cached fee rate
-// obtained with an epoch_report message, and falls back to directly requesting
-// a rate from servers with a fee_rate request.
-func (c *Core) feeSuggestionAny(assetID uint32) uint64 {
-	conns := c.dexConnections()
+// with it available. It first checks for a capable wallet, then relevant books
+// for a cached fee rate obtained with an epoch_report message, and falls back
+// to directly requesting a rate from servers with a fee_rate request.
+func (c *Core) feeSuggestionAny(assetID uint32, preferredConns ...*dexConnection) uint64 {
+	conns := append(preferredConns, c.dexConnections()...)
+	// See if the wallet supports fee rates.
+	w, found := c.wallet(assetID)
+	if found && w.connected() {
+		if rater, is := w.feeRater(); is {
+			if r, err := rater.FeeRate(); err == nil {
+				return r
+			} else {
+				c.log.Debugf("failed to get fee suggestion from %s FeeRater: %v", unbip(assetID), err)
+			}
+		}
+	}
 	// Look for cached rates from epoch_report messages.
 	for _, dc := range conns {
 		feeSuggestion := dc.bestBookFeeSuggestion(assetID)
@@ -3733,8 +3748,32 @@ func (c *Core) feeSuggestionAny(assetID uint32) uint64 {
 			return feeSuggestion
 		}
 	}
+
+	// Helper function to determine if a server has an active market that pairs
+	// the requested asset.
+	hasActiveMarket := func(dc *dexConnection) bool {
+		dc.cfgMtx.RLock()
+		cfg := dc.cfg
+		dc.cfgMtx.RUnlock()
+		for _, mkt := range cfg.Markets {
+			if mkt.Base == assetID || mkt.Quote == assetID && mkt.Running() {
+				return true
+			}
+		}
+		return false
+	}
+
 	// Request a rate with fee_rate.
 	for _, dc := range conns {
+		// The server should have at least one active market with the asset,
+		// otherwise we might get an outdated rate for an asset whose backend
+		// might be supported but not in active use, e.g. down for maintenance.
+		// The fee_rate endpoint will happily return a very old rate without
+		// indication.
+		if !hasActiveMarket(dc) {
+			continue
+		}
+
 		feeSuggestion := dc.fetchFeeRate(assetID)
 		if feeSuggestion > 0 {
 			return feeSuggestion
@@ -3868,7 +3907,7 @@ func (c *Core) PreOrder(form *TradeForm) (*OrderEstimate, error) {
 		return nil, fmt.Errorf("failed to get swap fee suggestion for %s at %s", unbip(wallets.fromAsset.ID), form.Host)
 	}
 
-	redeemFeeSuggestion := c.feeSuggestion(dc, wallets.toAsset.ID)
+	redeemFeeSuggestion := c.feeSuggestionAny(wallets.toAsset.ID)
 	if redeemFeeSuggestion == 0 {
 		return nil, fmt.Errorf("failed to get redeem fee suggestion for %s at %s", unbip(wallets.toAsset.ID), form.Host)
 	}
@@ -6235,6 +6274,14 @@ func (c *Core) tipChange(assetID uint32, nodeErr error) {
 // updated. If there is no synced book, but a non-zero fee suggestion is already
 // cached, no new requests will be made.
 func (c *Core) cacheRedemptionFeeSuggestion(t *trackedTrade) {
+	if rater, is := t.wallets.toWallet.feeRater(); is {
+		feeRate, err := rater.FeeRate()
+		if err == nil {
+			atomic.StoreUint64(&t.redeemFeeSuggestion, feeRate)
+			return
+		}
+		c.log.Debugf("unable to retrieve fee rate from FeeRater. falling back to other methods: %v", err)
+	}
 	// Try to find any book that might have the fee.
 	redeemAsset := t.wallets.toAsset.ID
 	feeSuggestion := t.dc.bestBookFeeSuggestion(redeemAsset)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2686,6 +2686,38 @@ func (c *Core) DiscoverAccount(dexAddr string, appPW []byte, certI interface{}) 
 	return dc.exchangeInfo(), true, nil
 }
 
+// EstimateRegistrationTxFee provides an estimate for the tx fee needed to
+// pay the registration fee for a certain asset. The dex host is required
+// because the dex server is used as a fallback to determine the current
+// fee rate in case the client wallet is unable to do it.
+func (c *Core) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
+	wallet, err := c.connectedWallet(assetID)
+	if err != nil {
+		return 0, err
+	}
+
+	var rate uint64
+	if rater, is := wallet.Wallet.(asset.FeeRater); is {
+		rate = rater.FeeRate()
+	}
+
+	if rate == 0 {
+		dc, err := c.tempDexConnection(host, certI)
+		if dc != nil {
+			// Stop (re)connect loop, which may be running even if err != nil.
+			defer dc.connMaster.Disconnect()
+		}
+		if err == nil {
+			rate = dc.fetchFeeRate(assetID)
+		} else {
+			c.log.Warnf("failed to connect to dex: %v", err)
+		}
+	}
+
+	txFee := wallet.EstimateRegistrationTxFee(rate)
+	return txFee, nil
+}
+
 // Register registers an account with a new DEX. If an error occurs while
 // fetching the DEX configuration or creating the fee transaction, it will be
 // returned immediately.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3734,10 +3734,8 @@ func (c *Core) feeSuggestionAny(assetID uint32, preferredConns ...*dexConnection
 	w, found := c.wallet(assetID)
 	if found && w.connected() {
 		if rater, is := w.feeRater(); is {
-			if r, err := rater.FeeRate(); err == nil {
+			if r := rater.FeeRate(); r != 0 {
 				return r
-			} else {
-				c.log.Debugf("failed to get fee suggestion from %s FeeRater: %v", unbip(assetID), err)
 			}
 		}
 	}
@@ -6275,12 +6273,10 @@ func (c *Core) tipChange(assetID uint32, nodeErr error) {
 // cached, no new requests will be made.
 func (c *Core) cacheRedemptionFeeSuggestion(t *trackedTrade) {
 	if rater, is := t.wallets.toWallet.feeRater(); is {
-		feeRate, err := rater.FeeRate()
-		if err == nil {
+		if feeRate := rater.FeeRate(); feeRate != 0 {
 			atomic.StoreUint64(&t.redeemFeeSuggestion, feeRate)
 			return
 		}
-		c.log.Debugf("unable to retrieve fee rate from FeeRater. falling back to other methods: %v", err)
 	}
 	// Check any book that might have the fee recorded from an epoch_report note
 	// (requires a book subscription).

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6282,7 +6282,8 @@ func (c *Core) cacheRedemptionFeeSuggestion(t *trackedTrade) {
 		}
 		c.log.Debugf("unable to retrieve fee rate from FeeRater. falling back to other methods: %v", err)
 	}
-	// Try to find any book that might have the fee.
+	// Check any book that might have the fee recorded from an epoch_report note
+	// (requires a book subscription).
 	redeemAsset := t.wallets.toAsset.ID
 	feeSuggestion := t.dc.bestBookFeeSuggestion(redeemAsset)
 	if feeSuggestion > 0 {
@@ -6290,11 +6291,13 @@ func (c *Core) cacheRedemptionFeeSuggestion(t *trackedTrade) {
 		return
 	}
 	// Don't request it if we already have one.
+	// TODO: declare the rate stale at some point and fetch a new one.
 	if atomic.LoadUint64(&t.redeemFeeSuggestion) != 0 {
 		return
 	}
 	// Fetch it from the server.
 	go func() {
+		c.log.Tracef("Fetching fee rate for %v", unbip(redeemAsset))
 		feeSuggestion = t.dc.fetchFeeRate(redeemAsset)
 		if feeSuggestion > 0 {
 			atomic.StoreUint64(&t.redeemFeeSuggestion, feeSuggestion)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4040,8 +4040,8 @@ func (c *Core) prepareTrackedTrade(dc *dexConnection, form *TradeForm, crypter e
 				unbip(w.AssetID))
 		}
 		if !w.synced {
-			return fmt.Errorf("%s still syncing. progress = %.2f", unbip(w.AssetID),
-				w.syncProgress)
+			return fmt.Errorf("%s still syncing. progress = %.2f%%", unbip(w.AssetID),
+				w.syncProgress*100)
 		}
 		return nil
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -799,11 +799,8 @@ type TFeeRater struct {
 	feeRate uint64
 }
 
-func (w *TFeeRater) FeeRate() (uint64, error) {
-	if w.feeRate == 0 {
-		return 0, fmt.Errorf("test fee rate unavailable")
-	}
-	return w.feeRate, nil
+func (w *TFeeRater) FeeRate() uint64 {
+	return w.feeRate
 }
 
 type tCrypterSmart struct {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -762,6 +762,10 @@ func (w *TXCWallet) Withdraw(address string, value, feeSuggestion uint64) (asset
 	return w.payFeeCoin, w.payFeeErr
 }
 
+func (w *TXCWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
+	return 0
+}
+
 func (w *TXCWallet) ValidateSecret(secret, secretHash []byte) bool {
 	return !w.badSecret
 }

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1713,8 +1713,8 @@ func (c *Core) redeemMatchGroup(t *trackedTrade, matches []*matchTracker, errs *
 		})
 	}
 
-	// Don't use (*Core).feeSuggestion here, since can incur an RPC request.
-	// If we don't have a synced book, use t.redemption
+	// Don't use (*Core).feeSuggestion here, since it can incur an RPC request.
+	// If we don't have a synced book, use t.redeemFeeSuggestion.
 	feeSuggestion := t.dc.bestBookFeeSuggestion(t.wallets.toAsset.ID)
 	if feeSuggestion == 0 {
 		feeSuggestion = atomic.LoadUint64(&t.redeemFeeSuggestion)
@@ -2000,7 +2000,7 @@ func (c *Core) refundMatches(t *trackedTrade, matches []*matchTracker) (uint64, 
 		t.dc.log.Infof("Refunding %s contract %s for match %s (%s)",
 			refundAsset.Symbol, swapCoinString, match, matchFailureReason)
 
-		feeSuggestion := c.feeSuggestion(t.dc, refundAsset.ID)
+		feeSuggestion := c.feeSuggestionAny(refundAsset.ID)
 		refundCoin, err := refundWallet.Refund(swapCoinID, contractToRefund, feeSuggestion)
 		if err != nil {
 			// CRITICAL - Refund must indicate if the swap is spent (i.e.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1479,6 +1479,26 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 		errs.add("not broadcasting swap while DEX %s connection is down (could be revoked)", t.dc.acct.host)
 		return
 	}
+
+	// Use a higher swap fee rate if a local estimate is higher than the
+	// prescribed rate, but not higher than the funded (max) rate.
+	if highestFeeRate < t.metaData.MaxFeeRate {
+		var freshRate uint64
+		if r, ok := t.wallets.fromWallet.feeRater(); ok {
+			freshRate, _ = r.FeeRate()
+		}
+		if freshRate == 0 { // either not a FeeRater, or FeeRate failed
+			freshRate = t.dc.bestBookFeeSuggestion(fromAsset.ID)
+		}
+		if freshRate > t.metaData.MaxFeeRate {
+			freshRate = t.metaData.MaxFeeRate
+		}
+		if highestFeeRate < freshRate {
+			c.log.Infof("Prescribed %v fee rate %v looks low, using %v",
+				fromAsset.Symbol, highestFeeRate, freshRate)
+			highestFeeRate = freshRate
+		}
+	}
 	// swapMatches is no longer idempotent after this point.
 
 	// Send the swap. If the swap fails, set the swapErr flag for all matches.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1485,7 +1485,7 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 	if highestFeeRate < t.metaData.MaxFeeRate {
 		var freshRate uint64
 		if r, ok := t.wallets.fromWallet.feeRater(); ok {
-			freshRate, _ = r.FeeRate()
+			freshRate = r.FeeRate()
 		}
 		if freshRate == 0 { // either not a FeeRater, or FeeRate failed
 			freshRate = t.dc.bestBookFeeSuggestion(fromAsset.ID)

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -309,3 +309,9 @@ func (w *xcWallet) SwapConfirmations(ctx context.Context, coinID []byte, contrac
 	defer cancel()
 	return w.Wallet.SwapConfirmations(ctx, coinID, contract, encode.UnixTimeMilli(int64(matchTime)))
 }
+
+// feeRater is identical to calling w.Wallet.(asset.FeeRater).
+func (w *xcWallet) feeRater() (asset.FeeRater, bool) {
+	rater, is := w.Wallet.(asset.FeeRater)
+	return rater, is
+}

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -46,6 +46,28 @@ func (s *WebServer) apiDiscoverAccount(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, resp, s.indent)
 }
 
+// apiEstimateRegistrationTxFee is the handler for the '/regtxfee' API request.
+func (s *WebServer) apiEstimateRegistrationTxFee(w http.ResponseWriter, r *http.Request) {
+	form := new(registrationTxFeeForm)
+	if !readPost(w, r, form) {
+		return
+	}
+	cert := []byte(form.Cert)
+	txFee, err := s.core.EstimateRegistrationTxFee(form.Addr, cert, *form.AssetID)
+	if err != nil {
+		s.writeAPIError(w, err)
+		return
+	}
+	resp := struct {
+		OK    bool   `json:"ok"`
+		TxFee uint64 `json:"txfee"`
+	}{
+		OK:    true,
+		TxFee: txFee,
+	}
+	writeJSON(w, resp, s.indent)
+}
+
 // apiGetDEXInfo is the handler for the '/getdexinfo' API request.
 func (s *WebServer) apiGetDEXInfo(w http.ResponseWriter, r *http.Request) {
 	form := new(registrationForm)

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -523,6 +523,9 @@ func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) {
 	c.reg = r
 	return nil, nil
 }
+func (c *TCore) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
+	return 0, nil
+}
 func (c *TCore) Login([]byte) (*core.LoginResult, error) { return &core.LoginResult{}, nil }
 func (c *TCore) IsInitialized() bool                     { return true }
 func (c *TCore) Logout() error                           { return nil }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -189,6 +189,7 @@ var EnUS = map[string]string{
 	"Registration fee":            "Registration fee",
 	"Your Deposit Address":        "Your Deposit Address",
 	"Send enough for reg fee":     `Make sure you send enough to also cover network fees.`,
+	"Send enough with estimate":   `Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.`,
 	"add a different server":      "add a different server",
 	"Add a custom server":         "Add a custom server",
 	"plus tx fees":                "+ tx fees",

--- a/client/webserver/site/package-lock.json
+++ b/client/webserver/site/package-lock.json
@@ -6042,9 +6042,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/minimist-options": {
@@ -6077,9 +6077,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
+      "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -13947,9 +13947,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {
@@ -13978,9 +13978,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
+      "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
       "dev": true
     },
     "natural-compare": {

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -16,6 +16,7 @@ div.marketlist {
     text-overflow: ellipsis;
     white-space: nowrap;
     width: 100%;
+    max-width: 250px;
   }
 
   .xc:not(:first-child) .header {

--- a/client/webserver/site/src/css/orders.scss
+++ b/client/webserver/site/src/css/orders.scss
@@ -12,6 +12,10 @@
 .filter-opts {
   padding: 10px 5px 30px 5px;
   position: relative;
+  max-width: 250px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .apply-bttn {

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">[[[Your Deposit Address]]]</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">[[[Send enough for reg fee]]]</span>
+    <span data-tmpl="sendEnoughWithEst">[[[Send enough with estimate]]]</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/client/webserver/site/src/js/forms.js
+++ b/client/webserver/site/src/js/forms.js
@@ -608,7 +608,7 @@ export class WalletWaitForm {
   }
 
   /* setWallet must be called before showing the form. */
-  setWallet (wallet) {
+  setWallet (wallet, txFee) {
     this.assetID = wallet.assetID
     this.progressCache = []
     this.progressed = false
@@ -623,7 +623,16 @@ export class WalletWaitForm {
     page.fee.textContent = Doc.formatCoinValue(fee.amount, asset.info.unitinfo)
 
     Doc.hide(page.syncUncheck, page.syncCheck, page.balUncheck, page.balCheck, page.syncRemainBox)
-    Doc.show(page.balanceBox, page.sendEnough)
+    Doc.show(page.balanceBox)
+
+    if (txFee > 0) {
+      page.totalFees.textContent = Doc.formatCoinValue(fee.amount + txFee, asset.info.unitinfo)
+      Doc.show(page.sendEnoughWithEst)
+      Doc.hide(page.sendEnough)
+    } else {
+      Doc.show(page.sendEnough)
+      Doc.hide(page.sendEnoughWithEst)
+    }
 
     Doc.show(wallet.synced ? page.syncCheck : wallet.syncProgress >= 1 ? page.syncSpinner : page.syncUncheck)
     Doc.show(wallet.balance.available > fee.amount ? page.balCheck : page.balUncheck)

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Twój adres do wpłaty</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Upewnij się, że wysyłasz wystarczająco dużo środków, aby pokryć również opłaty sieciowe.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Seu Endereço de Depósito</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
@@ -413,6 +413,7 @@
     <div class="fs14">Your Deposit Address</div>
     <div class="fs14 mono bg0 p-1 select-all" data-tmpl="depoAddr"></div>
     <span data-tmpl="sendEnough">Make sure you send enough to also cover network fees.</span>
+    <span data-tmpl="sendEnoughWithEst">Send about <span data-tmpl="totalFees"></span> <span class="unit">XYZ</span> here to also cover network fees.</span>
   </div>
 </div>
 

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -91,7 +91,7 @@
   </div>
 
   {{- /* RIGHT SIDE */ -}}
-  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start overflow-auto">
+  <div id="rightBox" class="col-10 px-2 py-5 d-flex justify-content-center align-items-start text-break overflow-auto">
 
     {{- /* AVAILABLE MARKETS (for selected asset) */ -}}
     <div id="marketsBox" class="d-hide">

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -51,6 +51,12 @@ type registrationForm struct {
 	AssetID  *uint32          `json:"asset,omitempty"` // prevent out-of-date frontend from paying fee in BTC
 }
 
+type registrationTxFeeForm struct {
+	Addr    string  `json:"addr"`
+	Cert    string  `json:"cert"`
+	AssetID *uint32 `json:"asset,omitempty"`
+}
+
 // newWalletForm is information necessary to create a new wallet.
 type newWalletForm struct {
 	AssetID    uint32 `json:"assetID"`

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -110,6 +110,7 @@ type clientCore interface {
 	IsInitialized() bool
 	ExportSeed(pw []byte) ([]byte, error)
 	WalletLogFilePath(assetID uint32) (string, error)
+	EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -306,6 +307,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiInit.Post("/login", s.apiLogin)
 			apiInit.Post("/getdexinfo", s.apiGetDEXInfo)
 			apiInit.Post("/discoveracct", s.apiDiscoverAccount)
+			apiInit.Post("/regtxfee", s.apiEstimateRegistrationTxFee)
 		})
 
 		r.Group(func(apiAuth chi.Router) {

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -81,9 +81,12 @@ func (c *TCore) DiscoverAccount(dexAddr string, pw []byte, certI interface{}) (*
 	return nil, false, nil
 }
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
-func (c *TCore) InitializeClient(pw, seed []byte) error                      { return c.initErr }
-func (c *TCore) Login(pw []byte) (*core.LoginResult, error)                  { return &core.LoginResult{}, c.loginErr }
-func (c *TCore) IsInitialized() bool                                         { return c.isInited }
+func (c *TCore) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
+	return 0, nil
+}
+func (c *TCore) InitializeClient(pw, seed []byte) error     { return c.initErr }
+func (c *TCore) Login(pw []byte) (*core.LoginResult, error) { return &core.LoginResult{}, c.loginErr }
+func (c *TCore) IsInitialized() bool                        { return c.isInited }
 func (c *TCore) SyncBook(dex string, base, quote uint32) (core.BookFeed, error) {
 	return c.syncFeed, c.syncErr
 }

--- a/dex/networks/bch/params.go
+++ b/dex/networks/bch/params.go
@@ -19,6 +19,7 @@ var (
 	}
 	// MainNetParams are the clone parameters for mainnet.
 	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "mainnet",
 		PubKeyHashAddrID: 0x00,
 		ScriptHashAddrID: 0x05,
 		Bech32HRPSegwit:  "bitcoincash",
@@ -27,6 +28,7 @@ var (
 	})
 	// TestNet3Params are the clone parameters for testnet.
 	TestNet3Params = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "testnet3",
 		PubKeyHashAddrID: 0x6f,
 		ScriptHashAddrID: 0xc4,
 		Bech32HRPSegwit:  "bchtest",
@@ -35,6 +37,7 @@ var (
 	})
 	// RegressionNetParams are the clone parameters for simnet.
 	RegressionNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "regtest",
 		PubKeyHashAddrID: 0x6f,
 		ScriptHashAddrID: 0xc4,
 		Bech32HRPSegwit:  "bchreg",

--- a/dex/networks/btc/clone.go
+++ b/dex/networks/btc/clone.go
@@ -15,11 +15,14 @@ type AddressDecoder func(addr string, net *chaincfg.Params) (btcutil.Address, er
 // ReadCloneParams translates a CloneParams into a btcsuite chaincfg.Params.
 func ReadCloneParams(cloneParams *CloneParams) *chaincfg.Params {
 	return &chaincfg.Params{
+		Name:             cloneParams.Name,
 		PubKeyHashAddrID: cloneParams.PubKeyHashAddrID,
 		ScriptHashAddrID: cloneParams.ScriptHashAddrID,
 		Bech32HRPSegwit:  cloneParams.Bech32HRPSegwit,
 		CoinbaseMaturity: cloneParams.CoinbaseMaturity,
 		Net:              wire.BitcoinNet(cloneParams.Net),
+		HDPrivateKeyID:   cloneParams.HDPrivateKeyID,
+		HDPublicKeyID:    cloneParams.HDPublicKeyID,
 	}
 }
 
@@ -28,6 +31,9 @@ func ReadCloneParams(cloneParams *CloneParams) *chaincfg.Params {
 // create a *chaincfg.Params for server/asset/btc.NewBTCClone and
 // client/asset/btc.BTCCloneWallet.
 type CloneParams struct {
+	// Name defines a human-readable identifier for the network. e.g. "mainnet",
+	// "testnet4", or "regtest"
+	Name string
 	// PubKeyHashAddrID: Net ID byte for a pubkey-hash address
 	PubKeyHashAddrID byte
 	// ScriptHashAddrID: Net ID byte for a script-hash address
@@ -40,4 +46,11 @@ type CloneParams struct {
 	CoinbaseMaturity uint16
 	// Net is the network identifier, e.g. wire.BitcoinNet.
 	Net uint32
+	// HDPrivateKeyID and HDPublicKeyID are the BIP32 hierarchical deterministic
+	// extended key magic sequences. They are ONLY required if there is a need
+	// to derive addresses from an extended key, such as if the asset is being
+	// used by the server with the hdkeychain package to create fee addresses.
+	// These are not required by the client.
+	HDPrivateKeyID [4]byte
+	HDPublicKeyID  [4]byte
 }

--- a/dex/networks/ltc/params.go
+++ b/dex/networks/ltc/params.go
@@ -19,24 +19,31 @@ var (
 	}
 	// MainNetParams are the clone parameters for mainnet.
 	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{
-		PubKeyHashAddrID: 0x30,
-		ScriptHashAddrID: 0x32,
+		Name:             "mainnet",
+		PubKeyHashAddrID: 0x30, // starts with L
+		ScriptHashAddrID: 0x32, // starts with M
 		Bech32HRPSegwit:  "ltc",
 		CoinbaseMaturity: 100,
 		Net:              0xdbb6c0fb,
+		HDPrivateKeyID:   [4]byte{0x04, 0x88, 0xad, 0xe4}, // starts with xprv
+		HDPublicKeyID:    [4]byte{0x04, 0x88, 0xb2, 0x1e}, // starts with xpub
 	})
 	// TestNet4Params are the clone parameters for testnet.
 	TestNet4Params = btc.ReadCloneParams(&btc.CloneParams{
-		PubKeyHashAddrID: 0x6f,
-		ScriptHashAddrID: 0x3a,
+		Name:             "testnet4",
+		PubKeyHashAddrID: 0x6f, // starts with m or n
+		ScriptHashAddrID: 0x3a, // starts with Q
 		Bech32HRPSegwit:  "tltc",
 		CoinbaseMaturity: 100,
 		Net:              0xf1c8d2fd,
+		HDPrivateKeyID:   [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+		HDPublicKeyID:    [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
 	})
 	// RegressionNetParams are the clone parameters for simnet.
 	RegressionNetParams = btc.ReadCloneParams(&btc.CloneParams{
-		PubKeyHashAddrID: 0x6f,
-		ScriptHashAddrID: 0x3a,
+		Name:             "regtest",
+		PubKeyHashAddrID: 0x6f, // starts with m or n
+		ScriptHashAddrID: 0x3a, // starts with Q
 		Bech32HRPSegwit:  "rltc",
 		CoinbaseMaturity: 100,
 		// Net is not the standard for LTC simnet, since they never changed it
@@ -44,7 +51,9 @@ var (
 		// btcd/chaincfg.Register, where it is checked to prevent duplicate
 		// registration, so our only requirement is that it is unique. This one
 		// was just generated with a prng.
-		Net: 0x9acb0442,
+		Net:            0x9acb0442,
+		HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+		HDPublicKeyID:  [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
 	})
 )
 

--- a/pkg.sh
+++ b/pkg.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-VER="v0.4.2"
+VER="v0.4.3"
 
 rm -rf bin
 mkdir -p bin/dexc-windows-amd64-${VER}

--- a/server/asset/ltc/ltc.go
+++ b/server/asset/ltc/ltc.go
@@ -44,7 +44,7 @@ func init() {
 }
 
 const (
-	version   = 0
+	version   = 1
 	assetName = "ltc"
 )
 
@@ -77,7 +77,7 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 
 	return btc.NewBTCClone(&btc.BackendCloneConfig{
 		Name:        assetName,
-		Segwit:      false, // TODO: Change to true.
+		Segwit:      true,
 		ConfigPath:  configPath,
 		Logger:      logger,
 		Net:         network,

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -160,11 +160,12 @@ func mainCore(ctx context.Context) error {
 		AbsTakerLotLimit:  cfg.AbsTakerLotLimit,
 		DEXPrivKey:        privKey,
 		CommsCfg: &dexsrv.RPCConfig{
-			RPCCert:        cfg.RPCCert,
-			RPCKey:         cfg.RPCKey,
-			ListenAddrs:    cfg.RPCListen,
-			AltDNSNames:    cfg.AltDNSNames,
-			DisableDataAPI: cfg.DisableDataAPI,
+			RPCCert:           cfg.RPCCert,
+			RPCKey:            cfg.RPCKey,
+			ListenAddrs:       cfg.RPCListen,
+			AltDNSNames:       cfg.AltDNSNames,
+			DisableDataAPI:    cfg.DisableDataAPI,
+			HiddenServiceAddr: cfg.HiddenService,
 		},
 		NoResumeSwaps: cfg.NoResumeSwaps,
 	}

--- a/server/cmd/dcrdex/version.go
+++ b/server/cmd/dcrdex/version.go
@@ -25,7 +25,7 @@ const (
 	AppName  string = "dcrdex"
 	AppMajor uint   = 0
 	AppMinor uint   = 4
-	AppPatch uint   = 2
+	AppPatch uint   = 3
 )
 
 // go build -v -ldflags "-X main.appPreRelease= -X main.appBuild=$(git rev-parse --short HEAD)"

--- a/server/comms/middleware.go
+++ b/server/comms/middleware.go
@@ -21,6 +21,7 @@ type contextKey int
 // These are the keys for different types of values stored in a request context.
 const (
 	ctxThing contextKey = iota
+	ctxListener
 )
 
 // limitRate is rate-limiting middleware that checks whether a request can be

--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -214,7 +214,10 @@ const (
 		SET bSigAckOfARedeem = $2
 		WHERE matchid = $1;`
 
-	SetSwapDone = `UPDATE %s SET active = FALSE
+	SetSwapDone = `UPDATE %s SET active = FALSE  -- leave forgiven NULL
+		WHERE matchid = $1;`
+
+	SetSwapDoneForgiven = `UPDATE %s SET active = FALSE, forgiven = TRUE
 		WHERE matchid = $1;`
 
 	SelectMatchStatuses = `SELECT takerSell, (takerAccount = $1) AS isTaker, (makerAccount = $1) AS isMaker, matchid, status, aContract, bContract, aContractCoinID,

--- a/server/db/driver/pg/matches.go
+++ b/server/db/driver/pg/matches.go
@@ -714,6 +714,9 @@ func (a *Archiver) SaveRedeemB(mid db.MarketMatchID, coinID []byte, timestamp in
 
 // SetMatchInactive flags the match as done/inactive. This is not necessary if
 // SaveRedeemAckSigB is run for the match since it will flag the match as done.
-func (a *Archiver) SetMatchInactive(mid db.MarketMatchID) error {
+func (a *Archiver) SetMatchInactive(mid db.MarketMatchID, forgive bool) error {
+	if forgive {
+		return a.updateMatchStmt(mid, internal.SetSwapDoneForgiven, mid.MatchID)
+	} // else leave the forgiven column NULL
 	return a.updateMatchStmt(mid, internal.SetSwapDone, mid.MatchID)
 }

--- a/server/db/driver/pg/matches_online_test.go
+++ b/server/db/driver/pg/matches_online_test.go
@@ -533,7 +533,7 @@ func TestMarketMatches(t *testing.T) {
 		MatchID: match.ID(),
 		Base:    base,
 		Quote:   quote,
-	})
+	}, false)
 
 	// This one has txns.
 	mktMatchID := db.MarketMatchID{
@@ -673,7 +673,7 @@ func generateMatch(t *testing.T, matchStatus order.MatchStatus, active bool, mak
 		Active: active,
 	}
 	if !active {
-		archie.SetMatchInactive(mktMatchID)
+		archie.SetMatchInactive(mktMatchID, false)
 	}
 	for iStatus := order.NewlyMatched; iStatus <= matchStatus; iStatus++ {
 		switch iStatus {
@@ -749,7 +749,7 @@ func TestCompletedAndAtFaultMatchStats(t *testing.T) {
 		MatchID: matchLTC.ID(),
 		Base:    limitBuy.Base(),
 		Quote:   limitBuy.Quote(),
-	})
+	}, false)
 	// 7: success
 	matches = append(matches, &matchPair{
 		match: matchLTC,
@@ -758,6 +758,7 @@ func TestCompletedAndAtFaultMatchStats(t *testing.T) {
 			Status: matchLTC.Status,
 		},
 	})
+	// TODO: update with a forgiven one
 
 	epochTime := func(mp *matchPair) int64 {
 		return encode.UnixMilli(mp.match.Epoch.End())
@@ -871,7 +872,7 @@ func TestAllActiveUserMatches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InsertMatch() failed: %v", err)
 	}
-	err = archie.SetMatchInactive(db.MatchID(match)) // set inactive
+	err = archie.SetMatchInactive(db.MatchID(match), false) // set inactive, not forgiven
 	if err != nil {
 		t.Fatalf("SetMatchInactive() failed: %v", err)
 	}

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -435,8 +435,12 @@ type SwapArchiver interface {
 
 	// SetMatchInactive sets the swap as done/inactive. This can be because of a
 	// failed or successfully completed swap, but in practice this will be used
-	// for failed swaps since SaveRedeemB flags the swap as done/inactive.
-	SetMatchInactive(mid MarketMatchID) error
+	// for failed swaps since SaveRedeemB flags the swap as done/inactive. If
+	// the match is being marked as inactive prior to MatchComplete (the match
+	// was revoked) but the user is not at fault, the forgive bool may be set to
+	// true so the outcome will not count against the user who would have the
+	// next action in the swap.
+	SetMatchInactive(mid MarketMatchID, forgive bool) error
 }
 
 // ValidateOrder ensures that the order with the given status for the specified

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -210,8 +210,8 @@ func (ta *TArchivist) SaveRedeemAckSigB(mid db.MarketMatchID, sig []byte) error 
 func (ta *TArchivist) SaveRedeemB(mid db.MarketMatchID, coinID []byte, timestamp int64) error {
 	return nil
 }
-func (ta *TArchivist) SetMatchInactive(mid db.MarketMatchID) error           { return nil }
-func (ta *TArchivist) LoadEpochStats(uint32, uint32, []*candles.Cache) error { return nil }
+func (ta *TArchivist) SetMatchInactive(mid db.MarketMatchID, forgive bool) error { return nil }
+func (ta *TArchivist) LoadEpochStats(uint32, uint32, []*candles.Cache) error     { return nil }
 
 type TCollector struct{}
 

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1360,6 +1360,17 @@ func (s *Swapper) processInit(msg *msgjson.Message, params *msgjson.Init, stepIn
 		s.respondError(msg.ID, actor.user, msgjson.ContractError,
 			fmt.Sprintf("contract error. expected lock time >= %s, got %s", reqLockTime, contract.LockTime))
 		return wait.DontTryAgain
+	} else if remain := time.Until(contract.LockTime); remain < 0 {
+		s.respondError(msg.ID, actor.user, msgjson.ContractError,
+			fmt.Sprintf("contract is correct, but lock time passed %s ago", remain))
+		// Revoke the match proactively before checkInaction gets to it.
+		s.matchMtx.Lock()
+		defer s.matchMtx.Unlock()
+		if _, found := s.matches[stepInfo.match.ID()]; found {
+			s.failMatch(stepInfo.match, false) // no fault
+			s.deleteMatch(stepInfo.match)
+		} // else it's already revoked
+		return wait.DontTryAgain // and don't tell counterparty of expired contract they should not redeem
 	}
 
 	// Update the match.

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -1737,9 +1737,9 @@ func (s *Swapper) handleInit(user account.AccountID, msg *msgjson.Message) *msgj
 	// Search for the transaction for the full txWaitExpiration, even if it goes
 	// past the inaction deadline. processInit recognizes when it is revoked.
 	expireTime := time.Now().Add(txWaitExpiration).UTC()
-	log.Debugf("Allowing until %v (%v) to locate contract from %v (%v), match %v",
+	log.Debugf("Allowing until %v (%v) to locate contract from %v (%v), match %v, tx %s (%s)",
 		expireTime, time.Until(expireTime), makerTaker(stepInfo.actor.isMaker),
-		stepInfo.step, matchID)
+		stepInfo.step, matchID, coinStr, stepInfo.asset.Symbol)
 
 	// Since we have to consider broadcast latency of the asset's network, run
 	// this as a coin waiter.
@@ -1818,9 +1818,9 @@ func (s *Swapper) handleRedeem(user account.AccountID, msg *msgjson.Message) *ms
 	// Search for the transaction for the full txWaitExpiration, even if it goes
 	// past the inaction deadline. processRedeem recognizes when it is revoked.
 	expireTime := time.Now().Add(txWaitExpiration).UTC()
-	log.Debugf("Allowing until %v (%v) to locate redeem from %v (%v), match %v",
+	log.Debugf("Allowing until %v (%v) to locate redeem from %v (%v), match %v, tx %s (%s)",
 		expireTime, time.Until(expireTime), makerTaker(stepInfo.actor.isMaker),
-		stepInfo.step, matchID)
+		stepInfo.step, matchID, coinStr, stepInfo.asset.Symbol)
 
 	// Since we have to consider latency, run this as a coin waiter.
 	s.latencyQ.Wait(&wait.Waiter{

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -334,7 +334,7 @@ func (ts *TStorage) SaveRedeemAckSigB(mid db.MarketMatchID, sig []byte) error {
 func (ts *TStorage) SaveRedeemB(mid db.MarketMatchID, coinID []byte, timestamp int64) error {
 	return nil
 }
-func (ts *TStorage) SetMatchInactive(mid db.MarketMatchID) error { return nil }
+func (ts *TStorage) SetMatchInactive(mid db.MarketMatchID, forgive bool) error { return nil }
 
 type redeemKey struct {
 	redemptionCoin       string


### PR DESCRIPTION
The intent is to fast forward `release-v0.4` to this.

These are the *closed* tems in https://github.com/decred/dcrdex/milestone/19?closed=1

The dex-test server has been running this.

@martonp and @buck54321, of note are the FeeRater interface change and the **registration tx fee estimates** that it facilitates.  These changes narrowly missed the last patch releases, but the reg fee is such a big UX headache that we need it in 0.4.3.  As such, we should test some fresh registrations with BTC and DCR as the fee asset with this branch.  The rest of the commits are well tested, but please ACK regardless.

After this backport PR the remaining 0.4.3 changes are:
- p2pk fix https://github.com/decred/dcrdex/pull/1581
- DOGE https://github.com/decred/dcrdex/pull/1558
- sighash fix stage 2 https://github.com/decred/dcrdex/pull/1529

My remote/fork has 0.4 branches for the above, where the p2pk fix is included in my doge-0.4 testing branch.