### PR TITLE
client/asset/dcr: fix side chain and approval checks

### DIFF
--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -392,9 +392,11 @@ func (c *tRPCClient) GetBlockHeaderVerbose(_ context.Context, blockHash *chainha
 		return nil, fmt.Errorf("no test block header found for %s", blockHash)
 	}
 	return &chainjson.GetBlockHeaderVerboseResult{
-		Height:       hdr.Height,
-		Hash:         blockHash.String(),
-		PreviousHash: hdr.PrevBlock.String(),
+		Height:        hdr.Height,
+		Hash:          blockHash.String(),
+		PreviousHash:  hdr.PrevBlock.String(),
+		Confirmations: 1,  // just not -1, which indicates side chain
+		NextHash:      "", // empty string signals that it is tip
 	}, nil
 }
 

--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -534,9 +534,19 @@ func (w *rpcWallet) GetBlockHeader(ctx context.Context, blockHash *chainhash.Has
 	if err != nil {
 		return nil, err
 	}
+	var nextHash *chainhash.Hash
+	if verboseHdr.NextHash != "" {
+		nextHash, err = chainhash.NewHashFromStr(verboseHdr.NextHash)
+		if err != nil {
+			return nil, fmt.Errorf("invalid next block hash %v: %w",
+				verboseHdr.NextHash, err)
+		}
+	}
 	return &BlockHeader{
-		BlockHeader: hdr,
-		MedianTime:  verboseHdr.MedianTime,
+		BlockHeader:   hdr,
+		MedianTime:    verboseHdr.MedianTime,
+		Confirmations: verboseHdr.Confirmations,
+		NextHash:      nextHash,
 	}, nil
 }
 

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -50,7 +50,9 @@ type TipChangeCallback func(*chainhash.Hash, int64, error)
 // BlockHeader.
 type BlockHeader struct {
 	*wire.BlockHeader
-	MedianTime int64
+	MedianTime    int64
+	Confirmations int64
+	NextHash      *chainhash.Hash
 }
 
 // Wallet defines methods that the ExchangeWallet uses for communicating with


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1587

```
The mainchain and valid returns from (*ExchangeWallet).blockHeader were
switched.  This flips them correctly.

This also changes the way a block is detected as side chain by checking
the Confirmations field of the getblockverbose result instead of
requesting the hash of the block at the same height and comparing
the hashes.  A side chain block will have -1 for Confirmations.

This also changes the way the next block is retrieved for stakeholder
approval checking.  Instead of requesting the hash of the block at the
next height, use the NextHash field returned by getblockverbose.
This saves an RPC, but it is also more robust since there is no need
to use strings.Contains on the error returned from getblockhash
to detect if there is no next block (we are at tip).  If we are at tip,
the NextHash field is empty.  With getblockhash, the wallet says
"-1: Block number out of range: N" while the node says
"-4: wallet.BlockInfo: item does not exist: no block at height N in main
chain".  Although client only ever checks with wallet, these strings are
fairly arbitrary  human readable messages that are likely to change
without warning.
```