### PR TITLE
multi: show fee rate on withdrawal form

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -603,13 +603,13 @@ func (btc *ExchangeWalletSPV) Rescan(_ context.Context) error {
 }
 
 // FeeRate satisfies asset.FeeRater.
-func (btc *ExchangeWalletFullNode) FeeRate() (uint64, string) {
+func (btc *ExchangeWalletFullNode) FeeRate() uint64 {
 	rate, err := btc.feeRate(nil, 1)
 	if err != nil {
 		btc.log.Errorf("Failed to get fee rate: %v", err)
-		return 0, ""
+		return 0
 	}
-	return rate, btc.sizeUnit()
+	return rate
 }
 
 // LogFilePath returns the path to the neutrino log file.
@@ -2698,6 +2698,11 @@ func (btc *baseWallet) PayFee(address string, regFee, feeRate uint64) (asset.Coi
 		return nil, err
 	}
 	return newOutput(txHash, vout, sent), nil
+}
+
+// FallbackFeeRate returns the fallback fee rate.
+func (btc *baseWallet) FallbackFeeRate() uint64 {
+	return btc.fallbackFeeRate
 }
 
 // EstimateRegistrationTxFee returns an estimate for the tx fee needed to

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -603,13 +603,13 @@ func (btc *ExchangeWalletSPV) Rescan(_ context.Context) error {
 }
 
 // FeeRate satisfies asset.FeeRater.
-func (btc *ExchangeWalletFullNode) FeeRate() uint64 {
+func (btc *ExchangeWalletFullNode) FeeRate() (uint64, string) {
 	rate, err := btc.feeRate(nil, 1)
 	if err != nil {
 		btc.log.Errorf("Failed to get fee rate: %v", err)
-		return 0
+		return 0, ""
 	}
-	return rate
+	return rate, btc.sizeUnit()
 }
 
 // LogFilePath returns the path to the neutrino log file.

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -622,17 +622,17 @@ func (dcr *ExchangeWallet) Balance() (*asset.Balance, error) {
 }
 
 // FeeRate satisfies asset.FeeRater.
-func (dcr *ExchangeWallet) FeeRate() uint64 {
+func (dcr *ExchangeWallet) FeeRate() (uint64, string) {
 	if dcr.wallet.SpvMode() {
-		return 0 // EstimateSmartFeeRate needs dcrd passthrough
+		return 0, "" // EstimateSmartFeeRate needs dcrd passthrough
 	}
 	// Requesting a rate for 1 confirmation can return unreasonably high rates.
 	rate, err := dcr.feeRate(2)
 	if err != nil {
 		dcr.log.Errorf("Failed to get fee rate: %v", err)
-		return 0
+		return 0, ""
 	}
-	return rate
+	return rate, "B" 
 }
 
 // FeeRate returns the current optimal fee rate in atoms / byte.

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -622,17 +622,17 @@ func (dcr *ExchangeWallet) Balance() (*asset.Balance, error) {
 }
 
 // FeeRate satisfies asset.FeeRater.
-func (dcr *ExchangeWallet) FeeRate() (uint64, string) {
+func (dcr *ExchangeWallet) FeeRate() uint64 {
 	if dcr.wallet.SpvMode() {
-		return 0, "" // EstimateSmartFeeRate needs dcrd passthrough
+		return 0 // EstimateSmartFeeRate needs dcrd passthrough
 	}
 	// Requesting a rate for 1 confirmation can return unreasonably high rates.
 	rate, err := dcr.feeRate(2)
 	if err != nil {
 		dcr.log.Errorf("Failed to get fee rate: %v", err)
-		return 0, ""
+		return 0
 	}
-	return rate, "B" 
+	return rate
 }
 
 // FeeRate returns the current optimal fee rate in atoms / byte.
@@ -2501,6 +2501,11 @@ func (dcr *ExchangeWallet) PayFee(address string, regFee, feeRate uint64) (asset
 			"expected %.8f, but %.8f was reported", msgTx.CachedTxHash(), toDCR(regFee), toDCR(sent))
 	}
 	return newOutput(msgTx.CachedTxHash(), 0, regFee, wire.TxTreeRegular), nil
+}
+
+// FallbackFeeRate returns the fallback fee rate.
+func (dcr *ExchangeWallet) FallbackFeeRate() uint64 {
+	return dcr.fallbackFeeRate
 }
 
 // EstimateRegistrationTxFee returns an estimate for the tx fee needed to

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -520,6 +520,11 @@ func (eth *ExchangeWallet) MaxOrder(lotSize uint64, feeSuggestion uint64, nfo *d
 	return est, nil
 }
 
+// FallbackFeeRate returns the fallback fee rate.
+func (eth *ExchangeWallet) FallbackFeeRate() uint64 {
+	return defaultGasFee
+}
+
 // PreSwap gets order estimates based on the available funds and the wallet
 // configuration.
 func (eth *ExchangeWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, error) {
@@ -1357,11 +1362,12 @@ func (eth *ExchangeWallet) RegFeeConfirmations(ctx context.Context, coinID dex.B
 }
 
 // FeeRate satisfies asset.FeeRater.
-func (eth *ExchangeWallet) FeeRate() (uint64, string) {
+// FeeRate returns the current optimal fee rate in gwei / gas.
+func (eth *ExchangeWallet) FeeRate() uint64 {
 	base, tip, err := eth.node.currentFees(eth.ctx)
 	if err != nil {
 		eth.log.Errorf("Error getting net fee state: %v", err)
-		return 0, ""
+		return 0
 	}
 
 	feeRate := new(big.Int).Add(
@@ -1371,10 +1377,10 @@ func (eth *ExchangeWallet) FeeRate() (uint64, string) {
 	feeRateGwei, err := dexeth.WeiToGweiUint64(feeRate)
 	if err != nil {
 		eth.log.Errorf("Failed to convert wei to gwei: %v", err)
-		return 0, ""
+		return 0
 	}
 
-	return feeRateGwei, "gwei"
+	return feeRateGwei
 }
 
 func (eth *ExchangeWallet) checkPeers() {

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1357,11 +1357,11 @@ func (eth *ExchangeWallet) RegFeeConfirmations(ctx context.Context, coinID dex.B
 }
 
 // FeeRate satisfies asset.FeeRater.
-func (eth *ExchangeWallet) FeeRate() uint64 {
+func (eth *ExchangeWallet) FeeRate() (uint64, string) {
 	base, tip, err := eth.node.currentFees(eth.ctx)
 	if err != nil {
 		eth.log.Errorf("Error getting net fee state: %v", err)
-		return 0
+		return 0, ""
 	}
 
 	feeRate := new(big.Int).Add(
@@ -1371,10 +1371,10 @@ func (eth *ExchangeWallet) FeeRate() uint64 {
 	feeRateGwei, err := dexeth.WeiToGweiUint64(feeRate)
 	if err != nil {
 		eth.log.Errorf("Failed to convert wei to gwei: %v", err)
-		return 0
+		return 0, ""
 	}
 
-	return feeRateGwei
+	return feeRateGwei, "gwei"
 }
 
 func (eth *ExchangeWallet) checkPeers() {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -348,16 +348,17 @@ type LogFiler interface {
 	LogFilePath() string
 }
 
-// FeeRater is capable of retrieving a non-critical fee rate estimate for an
-// asset. Some SPV wallets, for example, cannot provide a fee rate estimate, so
-// shouldn't implement FeeRater. However, since the mode of external wallets may
-// not be known on construction, only connect, a zero rate may be returned. The
+// FeeRater is capable of retrieving a non-critical fee rate estimate and
+// unit for an asset. Some SPV wallets, for example, cannot provide a fee rate
+// estimate, so shouldn't implement FeeRater.
+// However, since the mode of external wallets may not be known on
+// construction, only connect, a zero rate may be returned. The
 // caller should always check for zero and have a fallback rate. The rates from
 // FeeRate should be used for rates that are not validated by the server
 // (Withdraw, Send, PayFee), and will/should not be used to generate a fee
 // suggestion for swap operations.
 type FeeRater interface {
-	FeeRate() uint64
+	FeeRate() (uint64, string)
 }
 
 // TokenMaster is implemented by assets which support degenerate tokens.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -319,6 +319,8 @@ type Wallet interface {
 	// EstimateRegistrationTxFee returns an estimate for the tx fee needed to
 	// pay the registration fee using the provided feeRate.
 	EstimateRegistrationTxFee(feeRate uint64) uint64
+	// FallbackFeeRate returns the fallback fee rate.
+	FallbackFeeRate() uint64
 }
 
 // Rescanner is a wallet implementation with rescan functionality.
@@ -348,8 +350,8 @@ type LogFiler interface {
 	LogFilePath() string
 }
 
-// FeeRater is capable of retrieving a non-critical fee rate estimate and
-// unit for an asset. Some SPV wallets, for example, cannot provide a fee rate
+// FeeRater is capable of retrieving a non-critical fee rate estimate for an
+// asset. Some SPV wallets, for example, cannot provide a fee rate
 // estimate, so shouldn't implement FeeRater.
 // However, since the mode of external wallets may not be known on
 // construction, only connect, a zero rate may be returned. The
@@ -357,8 +359,9 @@ type LogFiler interface {
 // FeeRate should be used for rates that are not validated by the server
 // (Withdraw, Send, PayFee), and will/should not be used to generate a fee
 // suggestion for swap operations.
+// FeeRate returns the fee rate, in atoms/byte equivalent.
 type FeeRater interface {
-	FeeRate() (uint64, string)
+	FeeRate() uint64
 }
 
 // TokenMaster is implemented by assets which support degenerate tokens.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2731,22 +2731,18 @@ func (c *Core) DiscoverAccount(dexAddr string, appPW []byte, certI interface{}) 
 }
 
 // EstimateFeeRate provides an estimate fee rate for assetID.
-func (c *Core) EstimateFeeRate(assetID uint32) (uint64, string, error) {
+func (c *Core) EstimateFeeRate(assetID uint32) (uint64, error) {
 	wallet, err := c.connectedWallet(assetID)
 	if err != nil {
-		return 0, "", err
+		return 0, err
 	}
 
 	var rate uint64
-	var unit string
 	if rater, is := wallet.Wallet.(asset.FeeRater); is {
-		rate, unit = rater.FeeRate()
+		rate = rater.FeeRate()
 	}
-	if rate > 0 {
-		
-	}
-	
-	return rate, unit, nil
+
+	return rate, nil
 }
 
 // EstimateRegistrationTxFee provides an estimate for the tx fee needed to
@@ -2761,8 +2757,7 @@ func (c *Core) EstimateRegistrationTxFee(host string, certI interface{}, assetID
 
 	var rate uint64
 	if rater, is := wallet.Wallet.(asset.FeeRater); is {
-		// Ignore unit.
-		rate, _ = rater.FeeRate()
+		rate = rater.FeeRate()
 	}
 
 	if rate == 0 {
@@ -3841,8 +3836,7 @@ func (c *Core) feeSuggestionAny(assetID uint32, preferredConns ...*dexConnection
 	w, found := c.wallet(assetID)
 	if found && w.connected() {
 		if rater, is := w.feeRater(); is {
-			// Ignore unit.
-			if r, _ := rater.FeeRate(); r != 0 {
+			if r := rater.FeeRate(); r != 0 {
 				return r
 			}
 		}
@@ -6568,7 +6562,7 @@ func (c *Core) tipChange(assetID uint32, nodeErr error) {
 // cached, no new requests will be made.
 func (c *Core) cacheRedemptionFeeSuggestion(t *trackedTrade) {
 	if rater, is := t.wallets.toWallet.feeRater(); is {
-		if feeRate, _ := rater.FeeRate(); feeRate != 0 {
+		if feeRate := rater.FeeRate(); feeRate != 0 {
 			atomic.StoreUint64(&t.redeemFeeSuggestion, feeRate)
 			return
 		}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -825,6 +825,10 @@ func (w *TXCWallet) Withdraw(address string, value, feeSuggestion uint64) (asset
 	return w.payFeeCoin, w.payFeeErr
 }
 
+func (w *TXCWallet) FallbackFeeRate() uint64 {
+	return w.payFeeSuggestion
+}
+
 func (w *TXCWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
 	return 0
 }

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1709,8 +1709,7 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 	if highestFeeRate < t.metaData.MaxFeeRate {
 		var freshRate uint64
 		if r, ok := t.wallets.fromWallet.feeRater(); ok {
-			// Ignore unit.
-			freshRate, _ = r.FeeRate()
+			freshRate = r.FeeRate()
 		}
 		if freshRate == 0 { // either not a FeeRater, or FeeRate failed
 			freshRate = t.dc.bestBookFeeSuggestion(fromAsset.ID)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1709,7 +1709,8 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 	if highestFeeRate < t.metaData.MaxFeeRate {
 		var freshRate uint64
 		if r, ok := t.wallets.fromWallet.feeRater(); ok {
-			freshRate = r.FeeRate()
+			// Ignore unit.
+			freshRate, _ = r.FeeRate()
 		}
 		if freshRate == 0 { // either not a FeeRater, or FeeRate failed
 			freshRate = t.dc.bestBookFeeSuggestion(fromAsset.ID)

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -94,20 +94,22 @@ type WalletBalance struct {
 
 // WalletState is the current status of an exchange wallet.
 type WalletState struct {
-	Symbol       string            `json:"symbol"`
-	AssetID      uint32            `json:"assetID"`
-	Version      uint32            `json:"version"`
-	WalletType   string            `json:"type"`
-	Traits       asset.WalletTrait `json:"traits"`
-	Open         bool              `json:"open"`
-	Running      bool              `json:"running"`
-	Balance      *WalletBalance    `json:"balance"`
-	Address      string            `json:"address"`
-	Units        string            `json:"units"`
-	Encrypted    bool              `json:"encrypted"`
-	PeerCount    uint32            `json:"peerCount"`
-	Synced       bool              `json:"synced"`
-	SyncProgress float32           `json:"syncProgress"`
+	Symbol          string            `json:"symbol"`
+	AssetID         uint32            `json:"assetID"`
+	Version         uint32            `json:"version"`
+	WalletType      string            `json:"type"`
+	Traits          asset.WalletTrait `json:"traits"`
+	Open            bool              `json:"open"`
+	Running         bool              `json:"running"`
+	Balance         *WalletBalance    `json:"balance"`
+	Address         string            `json:"address"`
+	Units           string            `json:"units"`
+	FallbackFeeRate uint64            `json:"fallbackFeeRate"`
+	FeeRateUnits    string            `json:"feeRateUnits"`
+	Encrypted       bool              `json:"encrypted"`
+	PeerCount       uint32            `json:"peerCount"`
+	Synced          bool              `json:"synced"`
+	SyncProgress    float32           `json:"syncProgress"`
 }
 
 // User is information about the user's wallets and DEX accounts.

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -169,20 +169,22 @@ func (w *xcWallet) state() *WalletState {
 	defer w.mtx.RUnlock()
 	winfo := w.Info()
 	return &WalletState{
-		Symbol:       unbip(w.AssetID),
-		AssetID:      w.AssetID,
-		Version:      winfo.Version,
-		Open:         len(w.encPass) == 0 || len(w.pw) > 0,
-		Running:      w.connector.On(),
-		Balance:      w.balance,
-		Address:      w.address,
-		Units:        winfo.UnitInfo.AtomicUnit,
-		Encrypted:    len(w.encPass) > 0,
-		PeerCount:    w.peerCount,
-		Synced:       w.synced,
-		SyncProgress: w.syncProgress,
-		WalletType:   w.walletType,
-		Traits:       w.traits,
+		Symbol:          unbip(w.AssetID),
+		AssetID:         w.AssetID,
+		Version:         winfo.Version,
+		Open:            len(w.encPass) == 0 || len(w.pw) > 0,
+		Running:         w.connector.On(),
+		Balance:         w.balance,
+		Address:         w.address,
+		Units:           winfo.UnitInfo.AtomicUnit,
+		FallbackFeeRate: w.FallbackFeeRate(),
+		FeeRateUnits:    winfo.UnitInfo.FeeRateUnit,
+		Encrypted:       len(w.encPass) > 0,
+		PeerCount:       w.peerCount,
+		Synced:          w.synced,
+		SyncProgress:    w.syncProgress,
+		WalletType:      w.walletType,
+		Traits:          w.traits,
 	}
 }
 

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -68,6 +68,29 @@ func (s *WebServer) apiEstimateRegistrationTxFee(w http.ResponseWriter, r *http.
 	writeJSON(w, resp, s.indent)
 }
 
+// apiEstimateFeeRate is the handler for the '/getfeerate' API request.
+func (s *WebServer) apiEstimateFeeRate(w http.ResponseWriter, r *http.Request) {
+	form := new(feeRateForm)
+	if !readPost(w, r, form) {
+		return
+	}
+	feeRate, unit, err := s.core.EstimateFeeRate(*form.AssetID)
+	if err != nil {
+		s.writeAPIError(w, err)
+		return
+	}
+	resp := struct {
+		OK      bool   `json:"ok"`
+		Unit    string `json:"unit"`
+		FeeRate uint64 `json:"feeRate"`
+	}{
+		OK:      true,
+		Unit:    unit,
+		FeeRate: feeRate,
+	}
+	writeJSON(w, resp, s.indent)
+}
+
 // apiGetDEXInfo is the handler for the '/getdexinfo' API request.
 func (s *WebServer) apiGetDEXInfo(w http.ResponseWriter, r *http.Request) {
 	form := new(registrationForm)

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -74,18 +74,16 @@ func (s *WebServer) apiEstimateFeeRate(w http.ResponseWriter, r *http.Request) {
 	if !readPost(w, r, form) {
 		return
 	}
-	feeRate, unit, err := s.core.EstimateFeeRate(*form.AssetID)
+	feeRate, err := s.core.EstimateFeeRate(*form.AssetID)
 	if err != nil {
 		s.writeAPIError(w, err)
 		return
 	}
 	resp := struct {
 		OK      bool   `json:"ok"`
-		Unit    string `json:"unit"`
 		FeeRate uint64 `json:"feeRate"`
 	}{
 		OK:      true,
-		Unit:    unit,
 		FeeRate: feeRate,
 	}
 	writeJSON(w, resp, s.indent)

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -523,6 +523,9 @@ func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) {
 	c.reg = r
 	return nil, nil
 }
+func (c *TCore) EstimateFeeRate(assetID uint32) (uint64, error) {
+	return 0, nil
+}
 func (c *TCore) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
 	return 0, nil
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=rGTvdHw"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -157,7 +157,7 @@
         </div>
         <div class="col-14 px-0 py-1 flex-center flex-column fs15 justify-content-between">
           <div class="d-inline pt-3"><span class="pointer" id="withdrawAvail"></span> [[[available]]]</div>
-          <!-- <div class="d-inline">tx fees: <span id="withdrawFee"></span> <span id="withdrawUnit"></span>/byte</div> -->
+          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>
         </div>
       </div>
       <hr class="dashed my-4">

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -770,7 +770,8 @@ export default class Application {
           unit: '',
           conversionFactor: 1e8
         },
-        denominations: []
+        denominations: [],
+        feeRateUnit: ''
       }
     }
     return xc.assets[assetID].unitInfo

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -154,6 +154,8 @@ export interface WalletState {
   balance: WalletBalance
   address: string
   units: string
+  feeRateUnits: string
+  fallbackFeeRate: number
   encrypted: boolean
   peerCount: number
   synced: boolean
@@ -217,6 +219,7 @@ export interface UnitInfo {
   atomicUnit: string
   conventional: Denomination
   denominations: Denomination[]
+  feeRateUnit: string
 }
 
 export interface Denomination {

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -456,17 +456,19 @@ export default class WalletsPage extends BasePage {
     page.withdrawName.textContent = asset.info.name
     box.dataset.assetID = String(assetID)
     this.animation = this.showBox(box, page.walletPass)
+    page.withdrawUnit.textContent = ''
+    page.withdrawFeeRate.textContent = ''
 
     Doc.hide(page.FeeRate)
     const res = await postJSON('/api/getfeerate', {
       assetID: assetID
     })
-    console.log(res)
     if (!app().checkResponse(res) || res.feeRate === 0) {
-      page.withdrawFeeRate.textContent = 'unavailable'
+      page.withdrawFeeRate.textContent = wallet.fallbackFeeRate.toString()
+      page.withdrawUnit.textContent = wallet.feeRateUnits
     } else if (res.feeRate > 0) {
       page.withdrawFeeRate.textContent = res.feeRate
-      page.withdrawUnit.textContent = wallet.units + '/' + res.unit
+      page.withdrawUnit.textContent = wallet.feeRateUnits
     }
     Doc.show(page.FeeRate)
   }

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -454,10 +454,21 @@ export default class WalletsPage extends BasePage {
     page.withdrawAvail.textContent = Doc.formatFullPrecision(wallet.balance.available, asset.info.unitinfo)
     page.withdrawLogo.src = Doc.logoPath(asset.symbol)
     page.withdrawName.textContent = asset.info.name
-    // page.withdrawFee.textContent = wallet.feerate
-    // page.withdrawUnit.textContent = wallet.units
     box.dataset.assetID = String(assetID)
     this.animation = this.showBox(box, page.walletPass)
+
+    Doc.hide(page.FeeRate)
+    const res = await postJSON('/api/getfeerate', {
+      assetID: assetID
+    })
+    console.log(res)
+    if (!app().checkResponse(res) || res.feeRate === 0) {
+      page.withdrawFeeRate.textContent = 'unavailable'
+    } else if (res.feeRate > 0) {
+      page.withdrawFeeRate.textContent = res.feeRate
+      page.withdrawUnit.textContent = wallet.units + '/' + res.unit
+    }
+    Doc.show(page.FeeRate)
   }
 
   /* doConnect connects to a wallet via the connectwallet API route. */

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=rGTvdHw"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -157,7 +157,7 @@
         </div>
         <div class="col-14 px-0 py-1 flex-center flex-column fs15 justify-content-between">
           <div class="d-inline pt-3"><span class="pointer" id="withdrawAvail"></span> available</div>
-          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>        
+          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>
         </div>
       </div>
       <hr class="dashed my-4">

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -157,7 +157,7 @@
         </div>
         <div class="col-14 px-0 py-1 flex-center flex-column fs15 justify-content-between">
           <div class="d-inline pt-3"><span class="pointer" id="withdrawAvail"></span> available</div>
-          <!-- <div class="d-inline">tx fees: <span id="withdrawFee"></span> <span id="withdrawUnit"></span>/byte</div> -->
+          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>        
         </div>
       </div>
       <hr class="dashed my-4">

--- a/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=rGTvdHw"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -157,7 +157,7 @@
         </div>
         <div class="col-14 px-0 py-1 flex-center flex-column fs15 justify-content-between">
           <div class="d-inline pt-3"><span class="pointer" id="withdrawAvail"></span> dostępne</div>
-          <!-- <div class="d-inline">tx fees: <span id="withdrawFee"></span> <span id="withdrawUnit"></span>/byte</div> -->
+          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>        
         </div>
       </div>
       <hr class="dashed my-4">

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -157,7 +157,7 @@
         </div>
         <div class="col-14 px-0 py-1 flex-center flex-column fs15 justify-content-between">
           <div class="d-inline pt-3"><span class="pointer" id="withdrawAvail"></span> dostępne</div>
-          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>        
+          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>
         </div>
       </div>
       <hr class="dashed my-4">

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=rGTvdHw"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -157,7 +157,7 @@
         </div>
         <div class="col-14 px-0 py-1 flex-center flex-column fs15 justify-content-between">
           <div class="d-inline pt-3"><span class="pointer" id="withdrawAvail"></span> disponível</div>
-          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>        
+          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>
         </div>
       </div>
       <hr class="dashed my-4">

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -157,7 +157,7 @@
         </div>
         <div class="col-14 px-0 py-1 flex-center flex-column fs15 justify-content-between">
           <div class="d-inline pt-3"><span class="pointer" id="withdrawAvail"></span> disponível</div>
-          <!-- <div class="d-inline">tx fees: <span id="withdrawFee"></span> <span id="withdrawUnit"></span>/byte</div> -->
+          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>        
         </div>
       </div>
       <hr class="dashed my-4">

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=K9sWAHG"></script>
+<script src="/js/entry.js?v=rGTvdHw"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -157,7 +157,7 @@
         </div>
         <div class="col-14 px-0 py-1 flex-center flex-column fs15 justify-content-between">
           <div class="d-inline pt-3"><span class="pointer" id="withdrawAvail"></span> 可用</div>
-          <!-- <div class="d-inline">tx fees: <span id="withdrawFee"></span> <span id="withdrawUnit"></span>/byte</div> -->
+          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>        
         </div>
       </div>
       <hr class="dashed my-4">

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -157,7 +157,7 @@
         </div>
         <div class="col-14 px-0 py-1 flex-center flex-column fs15 justify-content-between">
           <div class="d-inline pt-3"><span class="pointer" id="withdrawAvail"></span> 可用</div>
-          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>        
+          <div class="d-inline" id="FeeRate">Fee rate: <span id="withdrawFeeRate"></span> <span id="withdrawUnit"></span></div>
         </div>
       </div>
       <hr class="dashed my-4">

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -51,6 +51,9 @@ type registrationTxFeeForm struct {
 	AssetID *uint32 `json:"asset,omitempty"`
 }
 
+type feeRateForm struct {
+	AssetID *uint32 `json:"assetID"`
+}
 // newWalletForm is information necessary to create a new wallet.
 type newWalletForm struct {
 	AssetID    uint32 `json:"assetID"`

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -54,6 +54,7 @@ type registrationTxFeeForm struct {
 type feeRateForm struct {
 	AssetID *uint32 `json:"assetID"`
 }
+
 // newWalletForm is information necessary to create a new wallet.
 type newWalletForm struct {
 	AssetID    uint32 `json:"assetID"`

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -111,7 +111,7 @@ type clientCore interface {
 	ExportSeed(pw []byte) ([]byte, error)
 	PreOrder(*core.TradeForm) (*core.OrderEstimate, error)
 	WalletLogFilePath(assetID uint32) (string, error)
-	EstimateFeeRate(assetID uint32) (uint64, string, error)
+	EstimateFeeRate(assetID uint32) (uint64, error)
 	EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error)
 }
 

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -111,6 +111,7 @@ type clientCore interface {
 	ExportSeed(pw []byte) ([]byte, error)
 	PreOrder(*core.TradeForm) (*core.OrderEstimate, error)
 	WalletLogFilePath(assetID uint32) (string, error)
+	EstimateFeeRate(assetID uint32) (uint64, string, error)
 	EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error)
 }
 
@@ -342,6 +343,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/exportseed", s.apiExportSeed)
 			apiAuth.Post("/importaccount", s.apiAccountImport)
 			apiAuth.Post("/disableaccount", s.apiAccountDisable)
+			apiAuth.Post("/getfeerate", s.apiEstimateFeeRate)
 		})
 	})
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -83,8 +83,8 @@ func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { r
 func (c *TCore) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
 	return 0, nil
 }
-func (c *TCore) EstimateFeeRate(assetID uint32) (uint64, string, error) {
-	return 0, "", nil
+func (c *TCore) EstimateFeeRate(assetID uint32) (uint64, error) {
+	return 0, nil
 }
 func (c *TCore) InitializeClient(pw, seed []byte) error     { return c.initErr }
 func (c *TCore) Login(pw []byte) (*core.LoginResult, error) { return &core.LoginResult{}, c.loginErr }

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -83,6 +83,9 @@ func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { r
 func (c *TCore) EstimateRegistrationTxFee(host string, certI interface{}, assetID uint32) (uint64, error) {
 	return 0, nil
 }
+func (c *TCore) EstimateFeeRate(assetID uint32) (uint64, string, error) {
+	return 0, "", nil
+}
 func (c *TCore) InitializeClient(pw, seed []byte) error     { return c.initErr }
 func (c *TCore) Login(pw []byte) (*core.LoginResult, error) { return &core.LoginResult{}, c.loginErr }
 func (c *TCore) IsInitialized() bool                        { return c.isInited }

--- a/dex/asset.go
+++ b/dex/asset.go
@@ -141,6 +141,9 @@ type UnitInfo struct {
 	// Alternatives lists additionally available Denominations, and can be
 	// empty.
 	Alternatives []Denomination `json:"denominations"`
+	// FeeRateUnit is the name associated with the unit used for fee rates.
+	// E.g. satoshis/bytes, atoms/bytes, gwei/gas
+	FeeRateUnit string `json:"feeRateUnit"`
 }
 
 // ConventionalString converts the quantity to conventional units, and returns

--- a/dex/networks/bch/params.go
+++ b/dex/networks/bch/params.go
@@ -16,6 +16,7 @@ var (
 			Unit:             "BCH",
 			ConversionFactor: 1e8,
 		},
+		FeeRateUnit: "Sats/B",
 	}
 	// MainNetParams are the clone parameters for mainnet.
 	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{

--- a/dex/networks/btc/params.go
+++ b/dex/networks/btc/params.go
@@ -21,4 +21,5 @@ var UnitInfo = dex.UnitInfo{
 			ConversionFactor: 1e2,
 		},
 	},
+	FeeRateUnit: "Sats/B",
 }

--- a/dex/networks/dcr/params.go
+++ b/dex/networks/dcr/params.go
@@ -11,4 +11,5 @@ var UnitInfo = dex.UnitInfo{
 		Unit:             "DCR",
 		ConversionFactor: 1e8,
 	},
+	FeeRateUnit: "atoms/B",
 }

--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -38,6 +38,7 @@ var (
 			Unit:             "ETH",
 			ConversionFactor: 1e9,
 		},
+		FeeRateUnit: "gwei/gas",
 	}
 
 	VersionedGases = map[uint32]*Gases{

--- a/dex/networks/ltc/params.go
+++ b/dex/networks/ltc/params.go
@@ -16,6 +16,7 @@ var (
 			Unit:             "LTC",
 			ConversionFactor: 1e8,
 		},
+		FeeRateUnit: "litoshi/B",
 	}
 	// MainNetParams are the clone parameters for mainnet.
 	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{


### PR DESCRIPTION
This diff displays the estimated fee rate on the withdrawal form and adds a `FallbackFeeRate() uint64` method to default if the fee rate is unavailable.
![feeratedcr](https://user-images.githubusercontent.com/57448127/164253531-0f732a9b-bcbb-40ae-afba-3697e9b51de0.png)
![btcfeerate](https://user-images.githubusercontent.com/57448127/164254057-d2b60ef3-47f6-4464-9e11-d47fdb2880b2.png)

Closes #970 
