### PR TITLE
client/asset/eth: Fix eth receipt locktime.

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -780,7 +780,7 @@ func (eth *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 		copy(secretHash[:], swap.SecretHash)
 		receipts = append(receipts,
 			&swapReceipt{
-				expiration:   encode.UnixTimeMilli(int64(swap.LockTime)),
+				expiration:   time.Unix(int64(swap.LockTime), 0),
 				value:        swap.Value,
 				txHash:       txHash,
 				secretHash:   secretHash,

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1152,9 +1152,9 @@ func TestSwap(t *testing.T) {
 		for i, contract := range swaps.Contracts {
 			// Check that receipts match the contract inputs
 			receipt := receipts[i]
-			if encode.UnixMilliU(receipt.Expiration()) != contract.LockTime {
+			if uint64(receipt.Expiration().Unix()) != contract.LockTime {
 				t.Fatalf("%v: expected expiration %v != expiration %v",
-					testName, encode.UnixTimeMilli(int64(contract.LockTime)), receipts[0].Expiration())
+					testName, time.Unix(int64(contract.LockTime), 0), receipts[0].Expiration())
 			}
 			if receipt.Coin().Value() != contract.Value {
 				t.Fatalf("%v: receipt coin value: %v != expected: %v",
@@ -1225,7 +1225,7 @@ func TestSwap(t *testing.T) {
 	secretHash := sha256.Sum256(secret)
 	secret2 := encode.RandomBytes(32)
 	secretHash2 := sha256.Sum256(secret2)
-	expiration := encode.UnixMilliU(time.Now().Add(time.Hour * 8))
+	expiration := uint64(time.Now().Add(time.Hour * 8).Unix())
 
 	// Ensure error when initializing swap errors
 	node.contractor.initErr = errors.New("")

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -503,7 +503,7 @@ type Contract struct {
 	Value uint64
 	// SecretHash is the hash of the secret key.
 	SecretHash dex.Bytes
-	// LockTime is the contract lock time.
+	// LockTime is the contract lock time in UNIX seconds.
 	LockTime uint64
 }
 

--- a/client/cmd/dexcctl/simnet-setup.sh
+++ b/client/cmd/dexcctl/simnet-setup.sh
@@ -2,6 +2,9 @@
 # Set up DCR and BTC wallets and register with the DEX.
 # dcrdex, dexc, and the wallet simnet harnesses should all be running before
 # calling this script.
+#
+# dexc can be built with -ldflags "-X 'decred.org/dcrdex/dex.testLockTimeTaker=30s' -X 'decred.org/dcrdex/dex.testLockTimeMaker=1m'"
+# in order to set simnet locktimes.
 
 set +e
 


### PR DESCRIPTION
    Parse locktime as seconds because it is seconds and not milliseconds.

closes #1592