### PR TITLE
server/asset/{btc,doge,ltc,bch}: median-fee based fee rate estimation backup

### DIFF
--- a/server/asset/bch/bch.go
+++ b/server/asset/bch/bch.go
@@ -14,6 +14,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 )
 
+var maxFeeBlocks = 3
+
 // Driver implements asset.Driver.
 type Driver struct{}
 
@@ -91,6 +93,7 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 		// in units of BCH/byte.
 		ManualMedianFee:      true,
 		NoCompetitionFeeRate: 2,
+		MaxFeeBlocks:         maxFeeBlocks,
 		ArglessFeeEstimates:  true,
 	})
 	if err != nil {

--- a/server/asset/bch/live_test.go
+++ b/server/asset/bch/live_test.go
@@ -49,6 +49,8 @@ func TestMain(m *testing.M) {
 		homeDir := btcutil.AppDataDir("bch", false)
 		configPath := filepath.Join(homeDir, "bitcoin.conf")
 
+		maxFeeBlocks = 1000
+
 		dexAsset, err := NewBackend(configPath, logger, dex.Mainnet)
 		if err != nil {
 			fmt.Printf("NewBackend error: %v\n", err)

--- a/server/asset/bch/live_test.go
+++ b/server/asset/bch/live_test.go
@@ -15,6 +15,10 @@
 // ------------------------------------------
 // Test that fees rates are parsed without error and that a few historical fee
 // rates are correct
+//
+// go test -v -tags bchlive -run TestMedianFeeRates
+// ------------------------------------------
+// Test that a median fee rate can be calculated.
 
 package bch
 
@@ -93,4 +97,8 @@ func TestLiveFees(t *testing.T) {
 		"dc3962fc4d2d7d99646cacc16a23cc49143ea9cfc43128ec986b61e9132b2726": 444,
 		"0de586d0c74780605c36c0f51dcd850d1772f41a92c549e3aa36f9e78e905284": 2604,
 	})
+}
+
+func TestMedianFeeRates(t *testing.T) {
+	btc.TestMedianFeesTheHardWay(bch.Backend, t)
 }

--- a/server/asset/btc/rpcclient.go
+++ b/server/asset/btc/rpcclient.go
@@ -9,6 +9,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
+	"math/rand"
+	"sort"
 	"strings"
 
 	"decred.org/dcrdex/dex"
@@ -22,11 +25,15 @@ const (
 	methodGetBestBlockHash  = "getbestblockhash"
 	methodGetBlockchainInfo = "getblockchaininfo"
 	methodEstimateSmartFee  = "estimatesmartfee"
+	methodEstimateFee       = "estimatefee"
 	methodGetTxOut          = "gettxout"
 	methodGetRawTransaction = "getrawtransaction"
 	methodGetBlock          = "getblock"
 	methodGetIndexInfo      = "getindexinfo"
 	methodGetBlockHeader    = "getblockheader"
+	methodGetBlockStats     = "getblockstats"
+
+	ErrNoCompetition = dex.ErrorKind("no competition")
 )
 
 // RawRequester is for sending context-aware RPC requests, and has methods for
@@ -41,10 +48,12 @@ type RawRequester interface {
 // RPCClient is a bitcoind wallet RPC client that uses rpcclient.Client's
 // RawRequest for wallet-related calls.
 type RPCClient struct {
-	ctx                    context.Context
-	requester              RawRequester
-	booleanVerboseGetBlock bool
-	blockDeserializer      func([]byte) (*wire.MsgBlock, error)
+	ctx                 context.Context
+	requester           RawRequester
+	booleanGetBlockRPC  bool
+	maxFeeBlocks        int
+	arglessFeeEstimates bool
+	blockDeserializer   func([]byte) (*wire.MsgBlock, error)
 }
 
 func (rc *RPCClient) callHashGetter(method string, args anylist) (*chainhash.Hash, error) {
@@ -102,9 +111,31 @@ func (rc *RPCClient) checkTxIndex() (bool, error) {
 }
 
 // EstimateSmartFee requests the server to estimate a fee level.
-func (rc *RPCClient) EstimateSmartFee(confTarget int64, mode *btcjson.EstimateSmartFeeMode) (*btcjson.EstimateSmartFeeResult, error) {
+func (rc *RPCClient) EstimateSmartFee(confTarget int64, mode *btcjson.EstimateSmartFeeMode) (uint64, error) {
 	res := new(btcjson.EstimateSmartFeeResult)
-	return res, rc.call(methodEstimateSmartFee, anylist{confTarget, mode}, res)
+	if err := rc.call(methodEstimateSmartFee, anylist{confTarget, mode}, res); err != nil {
+		return 0, err
+	}
+	if res.FeeRate == nil || *res.FeeRate <= 0 {
+		return 0, fmt.Errorf("fee rate couldn't be estimated")
+	}
+	return uint64(math.Round(*res.FeeRate * 1e5)), nil
+}
+
+// EstimateFee requests the server to estimate a fee level.
+func (rc *RPCClient) EstimateFee(confTarget int64) (uint64, error) {
+	var feeRate float64
+	var args anylist
+	if !rc.arglessFeeEstimates {
+		args = anylist{confTarget}
+	}
+	if err := rc.call(methodEstimateFee, args, &feeRate); err != nil {
+		return 0, err
+	}
+	if feeRate <= 0 {
+		return 0, fmt.Errorf("fee could not be estimated")
+	}
+	return uint64(math.Round(feeRate * 1e5)), nil
 }
 
 // GetTxOut returns the transaction output info if it's unspent and
@@ -140,7 +171,7 @@ func (rc *RPCClient) GetRawTransactionVerbose(txHash *chainhash.Hash) (*btcjson.
 // the wire type does not contain.
 func (rc *RPCClient) getBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, *btcjson.GetBlockHeaderVerboseResult, error) {
 	arg := interface{}(0)
-	if rc.booleanVerboseGetBlock {
+	if rc.booleanGetBlockRPC {
 		arg = false
 	}
 	var blockB dex.Bytes // UnmarshalJSON hex -> bytes
@@ -174,11 +205,194 @@ func (rc *RPCClient) getBlock(blockHash *chainhash.Hash) (*wire.MsgBlock, *btcjs
 // GetBlockVerbose fetches verbose block data for the block with the given hash.
 func (rc *RPCClient) GetBlockVerbose(blockHash *chainhash.Hash) (*btcjson.GetBlockVerboseResult, error) {
 	arg := interface{}(1)
-	if rc.booleanVerboseGetBlock {
+	if rc.booleanGetBlockRPC {
 		arg = true
 	}
 	res := new(btcjson.GetBlockVerboseResult)
 	return res, rc.call(methodGetBlock, anylist{blockHash.String(), arg}, res)
+}
+
+// MedianFeeRate returns the median rate from the specified block.
+func (rc *RPCClient) medianFeeRate() (uint64, error) {
+	blockHash, err := rc.GetBestBlockHash()
+	if err != nil {
+		return 0, err
+	}
+
+	res := struct {
+		FeeRatePercentiles []uint64 `json:"feerate_percentiles"` // 10th, 25th, 50th, 75th, and 90th percentiles
+		TxCount            int      `json:"txs"`
+	}{}
+
+	categories := []string{"feerate_percentiles", "txs"}
+
+	// We need at least a few transactions, but there's nothing stopping a miner
+	// from publishing empty blocks, regardless of the current mempool state,
+	// and we would want to reduce the impact of a particularly choosy node as
+	// well, I think. So we'll check > 100 transaction in up to 10 blocks,
+	// taking a weighted average of the fees. Consider two cases.
+	//
+	// 1) When the first block has > 100 transactions, it probably indicates the
+	// the miner is operating as expected and the blockchain is busy. In this
+	// case, the most recent block is the best estimate, since fees from older
+	// blocks could become quickly outdated on a busy chain.
+	//
+	// 2) If the first block has fewer transactions, it may be safe to say that
+	// either a) the miner is not stuffing blocks as expected or b) the
+	// blockchain does not have 100 txs/block worth of traffic. Because we have
+	// no historical view of mempool, it's impossible to say which one it is,
+	// though. In this case, taking a weighted average over a few recent blocks
+	// would provide a better estimate.
+
+	var blocksChecked, txCount int
+	var weight uint64
+	for txCount < 101 {
+		if blocksChecked >= rc.maxFeeBlocks {
+			return 0, ErrNoCompetition
+		}
+
+		if err := rc.call(methodGetBlockStats, anylist{blockHash.String(), categories}, &res); err != nil {
+			return 0, err
+		}
+		if len(res.FeeRatePercentiles) != 5 {
+			return 0, fmt.Errorf("unexpected feerate_percentiles response. %d entries", len(res.FeeRatePercentiles))
+		}
+
+		feeRate := res.FeeRatePercentiles[2]
+
+		weight += uint64(res.TxCount) * feeRate
+
+		txCount += res.TxCount
+		blocksChecked++
+
+		if txCount >= 101 {
+			break
+		}
+
+		// Not enough transactions to count yet.
+		verboseBlock, err := rc.GetBlockVerbose(blockHash)
+		if err != nil {
+			return 0, err
+		}
+
+		blockHash, err = chainhash.NewHashFromStr(verboseBlock.PreviousHash)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	// rounded average
+	return uint64(math.Round(float64(weight) / float64(txCount))), nil
+}
+
+// medianFeesTheHardWay calculates the median fees from the previous block(s).
+// medianFeesTheHardWay is used for assets that don't have a getblockstats RPC,
+// and is only useful for non-segwit assets.
+func (rc *RPCClient) medianFeesTheHardWay() (uint64, error) {
+	const numTxs = 101
+
+	iHash, err := rc.GetBestBlockHash()
+	if err != nil {
+		return 0, err
+	}
+
+	txs := make([]*wire.MsgTx, 0, numTxs)
+	prevOuts := make(map[chainhash.Hash]map[int]int64, numTxs)
+
+	var blocksChecked int
+
+out:
+	for len(txs) < numTxs {
+		blocksChecked++
+		if blocksChecked > rc.maxFeeBlocks {
+			return 0, ErrNoCompetition
+		}
+
+		blk, err := rc.GetBlockVerbose(iHash)
+		if err != nil {
+			return 0, err
+		}
+
+		if len(blk.Tx) == 0 {
+			return 0, fmt.Errorf("no transactions?")
+		}
+
+		rawTxs := blk.Tx[1:] // skip coinbase
+		rand.Shuffle(len(rawTxs), func(i, j int) { rawTxs[i], rawTxs[j] = rawTxs[j], rawTxs[i] })
+
+		for _, txid := range rawTxs {
+			txHash, err := chainhash.NewHashFromStr(txid)
+			if err != nil {
+				return 0, err
+			}
+
+			utilTx, err := rc.GetRawTransaction(txHash)
+			if err != nil {
+				return 0, err
+			}
+
+			tx := utilTx.MsgTx()
+
+			for _, vin := range tx.TxIn {
+				prevOut := vin.PreviousOutPoint
+				prevs := prevOuts[prevOut.Hash]
+				if len(prevs) == 0 {
+					prevs = make(map[int]int64, 1)
+					prevOuts[prevOut.Hash] = prevs
+				}
+				prevs[int(prevOut.Index)] = 0 // placeholder
+			}
+			txs = append(txs, tx)
+
+			if len(txs) >= numTxs {
+				break out
+			}
+		}
+
+		iHash, err = chainhash.NewHashFromStr(blk.PreviousHash)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	// Fetch all the previous outpoints and log the values.
+	for txHash, prevs := range prevOuts {
+		utilTx, err := rc.GetRawTransaction(&txHash)
+		if err != nil {
+			return 0, fmt.Errorf("GetRawTransaction error: %v", err)
+		}
+		tx := utilTx.MsgTx()
+		for vout := range prevs {
+			if len(tx.TxOut) < vout+1 {
+				return 0, fmt.Errorf("too few outputs")
+			}
+			prevs[vout] = tx.TxOut[vout].Value
+		}
+	}
+
+	// Do math.
+	rates := make([]uint64, 0, numTxs)
+	for _, tx := range txs {
+		var in, out int64
+		for _, vin := range tx.TxIn {
+			prevOut := vin.PreviousOutPoint
+			in += prevOuts[prevOut.Hash][int(prevOut.Index)]
+		}
+		for _, vout := range tx.TxOut {
+			out += vout.Value
+		}
+		fees := in - out
+		if fees < 0 {
+			return 0, fmt.Errorf("fees < 0 for tx %s", tx.TxHash())
+		}
+		sz := tx.SerializeSize()
+		if sz == 0 {
+			return 0, fmt.Errorf("size 0 tx %s", tx.TxHash())
+		}
+		rates = append(rates, uint64(fees)/uint64(sz))
+	}
+	sort.Slice(rates, func(i, j int) bool { return rates[i] < rates[j] })
+	return rates[len(rates)/2], nil
 }
 
 // RawRequest is a wrapper func for callers that are not context-enabled.

--- a/server/asset/btc/testing.go
+++ b/server/asset/btc/testing.go
@@ -428,11 +428,6 @@ func CompatibilityCheck(items *CompatibilityItems, chainParams *chaincfg.Params,
 	}
 
 	// P2SH
-	scriptClass := txscript.GetScriptClass(items.P2SHScript)
-	if scriptClass != txscript.ScriptHashTy {
-		t.Fatalf("wrong script class for p2sh script. wanted %s, got %s", txscript.ScriptHashTy, scriptClass)
-	}
-
 	sh := dexbtc.ExtractScriptHash(items.P2SHScript)
 	if sh == nil {
 		t.Fatalf("incompatible P2SH script")
@@ -451,4 +446,23 @@ func CompatibilityCheck(items *CompatibilityItems, chainParams *chaincfg.Params,
 		}
 		checkAddr(items.P2WSHScript, items.WSHAddr)
 	}
+}
+
+func TestMedianFees(btc *Backend, t *testing.T) {
+	// The easy way.
+	medianFees, err := btc.node.medianFeeRate()
+	if err != nil {
+		t.Fatalf("medianFeeRate error: %v", err)
+	}
+	fmt.Printf("medianFeeRate: %v \n", medianFees)
+}
+
+func TestMedianFeesTheHardWay(btc *Backend, t *testing.T) {
+	// The hard way.
+	medianFees, err := btc.node.medianFeesTheHardWay()
+	if err != nil {
+		t.Fatalf("medianFeesTheHardWay error: %v", err)
+	}
+
+	fmt.Printf("medianFeesTheHardWay: %v \n", medianFees)
 }

--- a/server/asset/btc/testing.go
+++ b/server/asset/btc/testing.go
@@ -4,6 +4,7 @@
 package btc
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -214,7 +215,7 @@ func LiveUTXOStats(btc *Backend, t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting best block hash: %v", err)
 	}
-	block, verboseHeader, err := btc.node.getBlock(hash)
+	block, verboseHeader, err := btc.node.getBlockWithVerboseHeader(hash)
 	if err != nil {
 		t.Fatalf("error getting best block verbose: %v", err)
 	}
@@ -290,7 +291,7 @@ out:
 			}
 		}
 		prevHash := block.Header.PrevBlock
-		block, verboseHeader, err = btc.node.getBlock(&prevHash)
+		block, verboseHeader, err = btc.node.getBlockWithVerboseHeader(&prevHash)
 		if err != nil {
 			t.Fatalf("error getting previous block verbose: %v", err)
 		}
@@ -459,7 +460,7 @@ func TestMedianFees(btc *Backend, t *testing.T) {
 
 func TestMedianFeesTheHardWay(btc *Backend, t *testing.T) {
 	// The hard way.
-	medianFees, err := btc.node.medianFeesTheHardWay()
+	medianFees, err := btc.node.medianFeesTheHardWay(context.Background())
 	if err != nil {
 		t.Fatalf("medianFeesTheHardWay error: %v", err)
 	}

--- a/server/asset/doge/doge.go
+++ b/server/asset/doge/doge.go
@@ -5,7 +5,6 @@ package doge
 
 import (
 	"fmt"
-	"math"
 
 	"decred.org/dcrdex/dex"
 	dexbtc "decred.org/dcrdex/dex/networks/btc"
@@ -85,31 +84,17 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 		// https://github.com/dogecoin/dogecoin/discussions/2264
 		// Looks like Segwit will be false for a little while longer. Should
 		// think about how to transition once activated.
-		Segwit:      false,
-		ConfigPath:  configPath,
-		Logger:      logger,
-		Net:         network,
-		ChainParams: params,
-		Ports:       ports,
-		FeeEstimator: func(cl *btc.RPCClient) (uint64, error) {
-
-			var r float64
-			if err := cl.Call("estimatefee", []interface{}{feeConfs}, &r); err != nil {
-				return 0, err
-			}
-			if r <= 0 {
-				return 0, nil
-			}
-
-			// estimatefee is f#$%ed
-			// https://github.com/decred/dcrdex/pull/1558#discussion_r850061882
-			if r > dexdoge.DefaultFeeRateLimit/1e5 {
-				return dexdoge.DefaultFee, nil
-			}
-
-			return uint64(math.Round(r * 1e5)), nil
-		},
-		BooleanGetBlockRPC: true,
-		BlockDeserializer:  dexdoge.DeserializeBlock,
+		Segwit:               false,
+		ConfigPath:           configPath,
+		Logger:               logger,
+		Net:                  network,
+		ChainParams:          params,
+		Ports:                ports,
+		DumbFeeEstimates:     true,
+		ManualMedianFee:      true,
+		NoCompetitionFeeRate: dexdoge.DefaultFee,
+		MaxFeeBlocks:         50,
+		BooleanGetBlockRPC:   true,
+		BlockDeserializer:    dexdoge.DeserializeBlock,
 	})
 }

--- a/server/asset/doge/doge.go
+++ b/server/asset/doge/doge.go
@@ -14,6 +14,8 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 )
 
+var maxFeeBlocks = 50
+
 // Driver implements asset.Driver.
 type Driver struct{}
 
@@ -93,7 +95,7 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 		DumbFeeEstimates:     true,
 		ManualMedianFee:      true,
 		NoCompetitionFeeRate: dexdoge.DefaultFee,
-		MaxFeeBlocks:         50,
+		MaxFeeBlocks:         maxFeeBlocks,
 		BooleanGetBlockRPC:   true,
 		BlockDeserializer:    dexdoge.DeserializeBlock,
 	})

--- a/server/asset/doge/live_test.go
+++ b/server/asset/doge/live_test.go
@@ -81,3 +81,7 @@ func TestLiveFees(t *testing.T) {
 		// "9387d8b2097ee23cc3da36daf90262dda9a98eb25063ddddb630cf15513fa9b8": 1,
 	})
 }
+
+func TestMedianFeeRates(t *testing.T) {
+	btc.TestMedianFeesTheHardWay(doge, t)
+}

--- a/server/asset/doge/live_test.go
+++ b/server/asset/doge/live_test.go
@@ -15,6 +15,10 @@
 // ------------------------------------------
 // Test that fees rates are parsed without error and that a few historical fee
 // rates are correct
+//
+// go test -v -tags dogelive -run TestMedianFeeRates
+// ------------------------------------------
+// Test the median fee rate calculation.
 
 package doge
 
@@ -36,6 +40,7 @@ var (
 func TestMain(m *testing.M) {
 	// Wrap everything for defers.
 	doIt := func() int {
+		maxFeeBlocks = 1000
 		logger := dex.StdOutLogger("DOGETEST", dex.LevelTrace)
 		dexAsset, err := NewBackend("", logger, dex.Mainnet)
 		if err != nil {
@@ -51,7 +56,7 @@ func TestMain(m *testing.M) {
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-		wg, err := dexAsset.Connect(ctx)
+		wg, err := doge.Connect(ctx)
 		if err != nil {
 			fmt.Printf("Connect failed: %v", err)
 			return 1

--- a/server/asset/ltc/live_test.go
+++ b/server/asset/ltc/live_test.go
@@ -15,6 +15,10 @@
 // ------------------------------------------
 // Test that fees rates are parsed without error and that a few historical fee
 // rates are correct
+//
+// go test -v -tags ltclive -run TestMedianFeeRates
+// ------------------------------------------
+// Test that a median fee rate can be calculated.
 
 package ltc
 
@@ -86,4 +90,8 @@ func TestLiveFees(t *testing.T) {
 		"6e7bfce6aee69312629b1f60afe6dcef02f367207642f2dc380a554c21181eb2": 888,
 		"9387d8b2097ee23cc3da36daf90262dda9a98eb25063ddddb630cf15513fa9b8": 1,
 	})
+}
+
+func TestMedianFeeRates(t *testing.T) {
+	btc.TestMedianFees(ltc, t)
 }

--- a/server/asset/ltc/ltc.go
+++ b/server/asset/ltc/ltc.go
@@ -77,12 +77,17 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 	}
 
 	return btc.NewBTCClone(&btc.BackendCloneConfig{
-		Name:        assetName,
-		Segwit:      true,
-		ConfigPath:  configPath,
-		Logger:      logger,
-		Net:         network,
-		ChainParams: params,
-		Ports:       ports,
+		Name:                 assetName,
+		Segwit:               true,
+		ConfigPath:           configPath,
+		Logger:               logger,
+		Net:                  network,
+		ChainParams:          params,
+		Ports:                ports,
+		NoCompetitionFeeRate: 10,
+		// It looks like if you set it to 1, litecoind just returns data for 2
+		// anyway.
+		FeeConfs:     2,
+		MaxFeeBlocks: 20,
 	})
 }


### PR DESCRIPTION
```
Add methods for calculating the median fee of the most recent block(s).
Ensure that there is sufficient data by requiring M transactions in the
last N blocks. If not enough data, fallback to a "no-competition" fee
rate. Implement a cache to prevent repeated scans between blocks.
Some chains provide the getblockstats RPC. Others require manual
scanning.
```