### PR TITLE
client: add electrum client

### DIFF
--- a/client/asset/btc/electrum/client.go
+++ b/client/asset/btc/electrum/client.go
@@ -1,0 +1,172 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package electrum
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+const defaultTimeout = 10 * time.Second
+
+// Client is an Electrum wallet JSON-RPC client.
+type Client struct {
+	reqID uint64
+	url   string
+	auth  string
+
+	// HTTPClient may be set by the user to a custom http.Client. The
+	// constructor sets a vanilla client.
+	HTTPClient *http.Client
+	// Timeout is the timeout on http requests. A 10 second default is set by
+	// the constructor.
+	Timeout time.Duration
+}
+
+// NewClient constructs a new Electrum client with the given authorization
+// information and endpoint. The endpoint should include the protocol, e.g.
+// http://127.0.0.1:4567. To specify a custom http.Client or request timeout,
+// the fields may be set after construction.
+func NewClient(user, pass, endpoint string) *Client {
+	// Prepare the HTTP Basic Authorization request header. This avoids
+	// re-encoding it for every request with (*http.Request).SetBasicAuth.
+	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+	return &Client{
+		url:        endpoint,
+		auth:       auth,
+		HTTPClient: &http.Client{},
+		Timeout:    defaultTimeout,
+	}
+}
+
+func (ec *Client) nextID() uint64 {
+	return atomic.AddUint64(&ec.reqID, 1)
+}
+
+type request struct {
+	Jsonrpc string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"` // [] for positional args or {} for named args, no bare types
+	ID      interface{}     `json:"id"`
+}
+
+// RPCError represents a JSON-RPC error object.
+type RPCError struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func (e RPCError) Error() string {
+	return fmt.Sprintf("code %d: %q", e.Code, e.Message)
+}
+
+type response struct {
+	// The "id" and "jsonrpc" fields are ignored.
+	Result json.RawMessage `json:"result"`
+	Error  *RPCError       `json:"error"`
+}
+
+type positional []interface{}
+
+// floatString is for unmarshalling a string with a float like "123.34" directly
+// into a float64 instead of a string and then converting later.
+type floatString float64
+
+func (fs *floatString) UnmarshalJSON(b []byte) error {
+	// Try to strip the string contents out of quotes.
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return err // wasn't a string
+	}
+	fl, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return err // The string didn't contain a float.
+	}
+	*fs = floatString(fl)
+	return nil
+}
+
+// Call makes a JSON-RPC request for the given method with the provided
+// arguments. args may be a struct or slice that marshalls to JSON. If it is a
+// slice, it represents positional arguments. If it is a struct or pointer to a
+// struct, it represents "named" parameters in key-value format. Any arguments
+// should have their fields appropriately tagged for JSON marshalling. The
+// result is marshaled into result if it is non-nil, otherwise the result is
+// discarded.
+func (ec *Client) Call(method string, args interface{}, result interface{}) error {
+	// nil args should marshal as [] instead of null.
+	if args == nil {
+		args = []json.RawMessage{}
+	}
+
+	switch rt := reflect.TypeOf(args); rt.Kind() {
+	case reflect.Struct, reflect.Slice:
+	case reflect.Ptr: // allow pointer to struct
+		if rt.Elem().Kind() != reflect.Struct {
+			return fmt.Errorf("invalid arg type %v, must be slice or struct", rt)
+		}
+	default:
+		return fmt.Errorf("invalid arg type %v, must be slice or struct", rt)
+	}
+
+	params, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("failed to marshal arguments: %v", err)
+	}
+	req := &request{
+		Jsonrpc: "1.0", // electrum seems to respond with 2.0 regardless
+		ID:      ec.nextID(),
+		Method:  method,
+		Params:  params,
+	}
+	reqMsg, err := json.Marshal(req)
+	if err != nil {
+		return err // likely impossible
+	}
+
+	bodyReader := bytes.NewReader(reqMsg)
+	ctx, cancel := context.WithTimeout(context.Background(), ec.Timeout)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, ec.url, bodyReader)
+	if err != nil {
+		return err
+	}
+	httpReq.Close = true
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", ec.auth) // httpReq.SetBasicAuth(ec.user, ec.pass)
+
+	resp, err := ec.HTTPClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%d: %s", resp.StatusCode, string(b))
+	}
+
+	jsonResp := &response{}
+	err = json.NewDecoder(resp.Body).Decode(jsonResp)
+	if err != nil {
+		return err
+	}
+	if jsonResp.Error != nil {
+		return jsonResp.Error
+	}
+
+	if result != nil {
+		return json.Unmarshal(jsonResp.Result, result)
+	}
+	return nil
+}

--- a/client/asset/btc/electrum/electrum_test.go
+++ b/client/asset/btc/electrum/electrum_test.go
@@ -1,0 +1,161 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+//go:build electrumlive
+
+package electrum
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	dexltc "decred.org/dcrdex/dex/networks/ltc"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestGetStuff(t *testing.T) {
+	// .electrum-ltc/testnet/config: rpcuser, rpcpass, rpcport
+	const walletPass = "walletPass" // set me
+	ec := NewClient("user", "pass", "http://127.0.0.1:5678")
+
+	res, err := ec.GetInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spew.Dump(res)
+
+	feeRate, err := ec.FeeRate(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(feeRate)
+
+	addrHist, err := ec.GetAddressHistory("Qe6bKuE2ZKxg6sCvLWb47kfgBdpjbbymtT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spew.Dump(addrHist)
+
+	addrUnspent, err := ec.GetAddressUnspent("Qe6bKuE2ZKxg6sCvLWb47kfgBdpjbbymtT")
+	if err != nil {
+		t.Fatal(err)
+	}
+	spew.Dump(addrUnspent)
+
+	tx, err := ec.GetRawTransaction("c100f9df92c90a7412e4c55ec632a2d9eb3051ac8a920d293f6e277d3b3819ca")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("%x\n", tx)
+	msgTx := &wire.MsgTx{}
+	err = msgTx.Deserialize(bytes.NewReader(tx))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spew.Dump(msgTx)
+
+	unspent, err := ec.ListUnspent()
+	if err != nil {
+		t.Fatal(err)
+	}
+	spew.Dump(unspent)
+
+	myAddr := "tltc1q74fcwvn5ydl0ssf7pvdscx2gu6aaxzavf2u7lr"
+	valid, mine, err := ec.CheckAddress(myAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("valid: %v, mine: %v", valid, mine)
+
+	notMine := "tltc1qtmjdzc3xmju803e529jv9l2860w0h47c95h37f"
+	valid, mine, err = ec.CheckAddress(notMine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("valid: %v, mine: %v", valid, mine)
+
+	invalid := "tltc1qtmjdzc3xmju803e529jv9l2860w0h47c95xxxx"
+	valid, mine, err = ec.CheckAddress(invalid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("valid: %v, mine: %v", valid, mine)
+
+	wifStr, err := ec.GetPrivateKeys(walletPass, myAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wif, err := btcutil.DecodeWIF(wifStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkh := btcutil.Hash160(wif.SerializePubKey())
+	p2wpkh, err := btcutil.NewAddressWitnessPubKeyHash(pkh, dexltc.TestNet4Params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr := p2wpkh.EncodeAddress(); addr != myAddr {
+		t.Fatalf("%v != %v", addr, myAddr)
+	}
+	// fmt.Println(wif.PrivKey.Serialize())
+
+	txRaw, err := ec.PayTo(walletPass, "tltc1qmk8uqqn37a2r5lu9jc86jnat6j0y28ydmfuadd", 1.21, 17.3454)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%x", txRaw)
+
+	txRawSigned, err := ec.SignTx(walletPass, txRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%x", txRawSigned)
+
+	// txid, err := ec.Broadcast(txRaw)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+	// t.Log(txid)
+
+	confs, err := ec.GetWalletTxConfs("f4b5fca9e2fa3abfe22ea82eece8e28cdcf3e03bb11c63c327b5c719bfa2df6f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("Confs:", confs)
+
+	_, err = ec.GetWalletTxConfs("ffca8ec6bcd44937d92c25d1c3e85cc2895419ccb66a46c986f3817cd60fa693")
+	if err == nil {
+		t.Fatal("worked for non-wallet txn???")
+	}
+
+	bal, err := ec.GetBalance()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(bal.Confirmed, bal.Unconfirmed, bal.Immature)
+
+	ok, err := ec.FreezeAddress(myAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("failed to freeze")
+	}
+	ok, err = ec.UnfreezeAddress(myAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("failed to unfreeze")
+	}
+
+	addr, err := ec.GetUnusedAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(addr)
+}

--- a/client/asset/btc/electrum/methods.go
+++ b/client/asset/btc/electrum/methods.go
@@ -1,0 +1,289 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package electrum
+
+import (
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"strings"
+)
+
+const (
+	methodGetInfo           = "getinfo"
+	methodGetFeeRate        = "getfeerate"
+	methodCreateNewAddress  = "createnewaddress" // beyond gap limit
+	methodGetUnusedAddress  = "getunusedaddress"
+	methodGetAddressHistory = "getaddresshistory"
+	methodGetAddressUnspent = "getaddressunspent"
+	methodGetTransaction    = "gettransaction"
+	methodListUnspent       = "listunspent"
+	methodGetPrivateKeys    = "getprivatekeys"
+	methodPayTo             = "payto"
+	methodBroadcast         = "broadcast"
+	methodGetTxStatus       = "get_tx_status" // only wallet txns
+	methodgetBalance        = "getbalance"
+	methodIsMine            = "ismine"
+	methodValidateAddress   = "validateaddress"
+	methodSignTransaction   = "signtransaction"
+	methodFreeze            = "freeze" // freezes all utxos for an address, freeze_utxo not avail in 4.0.9
+	methodUnfreeze          = "unfreeze"
+)
+
+// GetInfo gets basic Electrum wallet info.
+func (ec *Client) GetInfo() (*GetInfoResult, error) {
+	var res GetInfoResult
+	err := ec.Call(methodGetInfo, nil, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+type feeRateReq struct {
+	Method string  `json:"fee_method"`
+	Level  float64 `json:"fee_level"`
+}
+
+// FeeRate gets a fee rate estimate for a block confirmation target, where 1
+// indicates the next block.
+func (ec *Client) FeeRate(confTarget int64) (int64, error) {
+	if confTarget > 10 {
+		confTarget = 10
+	} else if confTarget < 1 {
+		confTarget = 1
+	}
+	target := float64(10-confTarget+1) / 20.0 // [0.5, 1.0]
+	var satPerKB int64
+	err := ec.Call(methodGetFeeRate, feeRateReq{"eta", target}, &satPerKB) // or anylist{"eta", target}
+	if err != nil {
+		return 0, err
+	}
+	return satPerKB, nil
+}
+
+// CreateNewAddress generates a new address, igoring the gap limit. NOTE: There
+// is no method to retrieve a change address.
+func (ec *Client) CreateNewAddress() (string, error) {
+	var res string
+	err := ec.Call(methodCreateNewAddress, nil, &res)
+	if err != nil {
+		return "", err
+	}
+	return res, nil
+}
+
+// GetUnusedAddress gets the next unused address from the wallet. It may have
+// already been requested.
+func (ec *Client) GetUnusedAddress() (string, error) {
+	var res string
+	err := ec.Call(methodGetUnusedAddress, nil, &res)
+	if err != nil {
+		return "", err
+	}
+	return res, nil
+}
+
+// CheckAddress validates the address and reports if it belongs to the wallet.
+func (ec *Client) CheckAddress(addr string) (valid, mine bool, err error) {
+	err = ec.Call(methodIsMine, positional{addr}, &mine)
+	if err != nil {
+		return
+	}
+	err = ec.Call(methodValidateAddress, positional{addr}, &valid)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// GetAddressHistory returns the history an address. Confirmed transactions will
+// have a nil Fee field, while unconfirmed transactions will have a Fee and a
+// value of zero for Height.
+func (ec *Client) GetAddressHistory(addr string) ([]*GetAddressHistoryResult, error) {
+	var res []*GetAddressHistoryResult
+	err := ec.Call(methodGetAddressHistory, positional{addr}, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// GetAddressUnspent returns the unspent outputs for an address. Unconfirmed
+// outputs will have a value of zero for Height.
+func (ec *Client) GetAddressUnspent(addr string) ([]*GetAddressUnspentResult, error) {
+	var res []*GetAddressUnspentResult
+	err := ec.Call(methodGetAddressUnspent, positional{addr}, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// FreezeAddress freezes/locks all UTXOs paying to the address.
+func (ec *Client) FreezeAddress(addr string) (bool, error) {
+	var res bool
+	err := ec.Call(methodFreeze, positional{addr}, &res)
+	if err != nil {
+		return false, err
+	}
+	return res, nil
+}
+
+// UnfreezeAddress unfreezes/unlocks all UTXOs paying to the address.
+func (ec *Client) UnfreezeAddress(addr string) (bool, error) {
+	var res bool
+	err := ec.Call(methodUnfreeze, positional{addr}, &res)
+	if err != nil {
+		return false, err
+	}
+	return res, nil
+}
+
+// GetRawTransaction retrieves the serialized transaction identified by txid.
+func (ec *Client) GetRawTransaction(txid string) ([]byte, error) {
+	var res string
+	err := ec.Call(methodGetTransaction, positional{txid}, &res)
+	if err != nil {
+		return nil, err
+	}
+	tx, err := hex.DecodeString(res)
+	if err != nil {
+		return nil, err
+	}
+	return tx, nil
+}
+
+// GetWalletTxConfs will get the confirmations on the wallet-related
+// transaction. This function will error if it is either not a wallet
+// transaction or not known to the wallet.
+func (ec *Client) GetWalletTxConfs(txid string) (int, error) {
+	var res struct {
+		Confs int `json:"confirmations"`
+	}
+	err := ec.Call(methodGetTxStatus, positional{txid}, &res)
+	if err != nil {
+		return 0, err
+	}
+	return res.Confs, nil
+}
+
+// ListUnspent returns details on all unspent outputs for the wallet. Note that
+// the pkScript is not included, and the user would have to retrieve it with
+// GetRawTransaction for PrevOutHash if the output is of interest.
+func (ec *Client) ListUnspent() ([]*ListUnspentResult, error) {
+	var res []*ListUnspentResult
+	err := ec.Call(methodListUnspent, nil, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (ec *Client) GetBalance() (*Balance, error) {
+	var res struct {
+		Confirmed   floatString `json:"confirmed"`
+		Unconfirmed floatString `json:"unconfirmed"`
+		Immature    floatString `json:"unmatured"` // yes, unmatured!
+	}
+	err := ec.Call(methodgetBalance, nil, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &Balance{
+		Confirmed:   float64(res.Confirmed),
+		Unconfirmed: float64(res.Unconfirmed),
+		Immature:    float64(res.Immature),
+	}, nil
+}
+
+// payto(self, destination, amount, fee=None, feerate=None, from_addr=None, from_coins=None, change_addr=None,
+// nocheck=False, unsigned=False, rbf=None, password=None, locktime=None, addtransaction=False, wallet: Abstract_Wallet = None):
+type paytoReq struct {
+	Addr   string `json:"destination"`
+	Amount string `json:"amount"` // BTC, or "!" for max
+	// Fee always omitted, only use FeeRate
+	FeeRate    *float64 `json:"feerate,omitempty"` // sat/vB, gets multiplied by 1000 for extra precision, omit for high prio
+	ChangeAddr string   `json:"change_addr,omitempty"`
+	// FromAddr omitted
+	FromUTXOs      string `json:"from_coins,omitempty"`
+	NoCheck        bool   `json:"nocheck"`
+	Unsigned       bool   `json:"unsigned"` // unsigned returns a base64 psbt thing
+	RBF            bool   `json:"rbf"`      // default to false
+	Password       string `json:"password"`
+	LockTime       *int64 `json:"locktime,omitempty"`
+	AddTransaction bool   `json:"addtransaction"`
+}
+
+func (ec *Client) PayTo(walletPass string, addr string, amtBTC float64, feeRate float64) ([]byte, error) {
+	if feeRate < 1 {
+		return nil, errors.New("fee rate in sat/vB too low")
+	}
+	amt := strconv.FormatFloat(amtBTC, 'f', 8, 64)
+	var res string
+	err := ec.Call(methodPayTo, &paytoReq{
+		Addr:     addr,
+		Amount:   amt,
+		FeeRate:  &feeRate,
+		Password: walletPass,
+	}, &res)
+	if err != nil {
+		return nil, err
+	}
+	txRaw, err := hex.DecodeString(res)
+	if err != nil {
+		return nil, err
+	}
+	return txRaw, nil
+}
+
+type signTransactionArgs struct {
+	Tx   string `json:"tx"`
+	Pass string `json:"password"`
+	// 4.0.9 has privkey in this request, but 4.2 does not since it has a
+	// signtransaction_with_privkey request.
+	// Privkey string `json:"privkey,omitempty"` // sign with wallet if empty
+}
+
+func (ec *Client) SignTx(walletPass string, tx []byte) ([]byte, error) {
+	txStr := hex.EncodeToString(tx)
+	var res string
+	err := ec.Call(methodSignTransaction, &signTransactionArgs{txStr, walletPass}, &res)
+	if err != nil {
+		return nil, err
+	}
+	txRaw, err := hex.DecodeString(res)
+	if err != nil {
+		return nil, err
+	}
+	return txRaw, nil
+}
+
+func (ec *Client) Broadcast(tx []byte) (string, error) {
+	txStr := hex.EncodeToString(tx)
+	var res string
+	err := ec.Call(methodBroadcast, positional{txStr}, &res)
+	if err != nil {
+		return "", err
+	}
+	return res, nil
+}
+
+type getPrivKeyArgs struct {
+	Addr string `json:"address"`
+	Pass string `json:"password"`
+}
+
+func (ec *Client) GetPrivateKeys(walletPass, addr string) (string, error) {
+	var res string
+	err := ec.Call(methodGetPrivateKeys, &getPrivKeyArgs{addr, walletPass}, &res)
+	if err != nil {
+		return "", err
+	}
+	privSpit := strings.Split(res, ":")
+	if len(privSpit) != 2 {
+		return "", errors.New("bad key")
+	}
+	return privSpit[1], nil
+}

--- a/client/asset/btc/electrum/types.go
+++ b/client/asset/btc/electrum/types.go
@@ -1,0 +1,61 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package electrum
+
+// GetInfoResult is the result of the getinfo RPC.
+type GetInfoResult struct {
+	AutoConnect   bool   `json:"auto_connect"`
+	SyncHeight    int64  `json:"blockchain_height"`
+	Connected     bool   `json:"connected"`
+	DefaultWallet string `json:"default_wallet"`
+	FeePerKB      int64  `json:"fee_per_kb"`
+	Path          string `json:"path"`
+	Server        string `json:"server"`
+	ServerHeight  int64  `json:"server_height"`
+	Connections   int64  `json:"spv_nodes"`
+	Version       string `json:"version"`
+}
+
+// GetAddressHistoryResult is an element of the array returned by the
+// getaddresshistory RPC.
+type GetAddressHistoryResult struct {
+	Fee    *int64 `json:"fee,omitempty"` // set when unconfirmed
+	Height int64  `json:"height"`        // 0 when unconfirmed
+	TxHash string `json:"tx_hash"`
+}
+
+// GetAddressUnspentResult is an element of the array returned by the
+// getaddressunspent RPC.
+type GetAddressUnspentResult struct { // todo: check unconfirmed fields
+	Height int64  `json:"height"`
+	TxHash string `json:"tx_hash"`
+	TxPos  int32  `json:"tx_pos"`
+	Value  int64  `json:"value"`
+}
+
+// ListUnspentResult is an element of the array returned by the listunspent RPC.
+type ListUnspentResult struct {
+	Address       string `json:"address"`
+	Value         string `json:"value"` // BTC in a string :/
+	Coinbase      bool   `json:"coinbase"`
+	Height        int64  `json:"height"`
+	Sequence      uint32 `json:"nsequence"`
+	PrevOutHash   string `json:"prevout_hash"`
+	PrevOutIdx    uint32 `json:"prevout_n"`
+	RedeemScript  string `json:"redeem_script"`
+	WitnessScript string `json:"witness_script"`
+	// PartSigs ? "part_sigs": {},
+	// BIP32Paths string    `json:"bip32_paths"`
+	// Sighash "sighash": null,
+	// "unknown_psbt_fields": {},
+	// "utxo": null,
+	// "witness_utxo": null
+}
+
+// Balance is the result of the balance RPC.
+type Balance struct {
+	Confirmed   float64 // includes spent value that is not yet confirmed
+	Unconfirmed float64 // will be negative for sends
+	Immature    float64
+}


### PR DESCRIPTION
To be the RPC client for a future `walletTypeElectrum` wallet type.

This creates a zero-dep Electrum wallet RPC client package.
An "ExchangeWalletElectrum" will be created that uses this client.  Checking foreign/counterparty transactions is possible with the `getaddresshistory`, `getaddressunspent`, and `gettransaction` RPCs, so this solves confirmation checks as well as finding redemption.  The redemption search appears to be as easy as checking `getaddresshistory` for the swap contract address, as it lists any spending txns as well.

This is meant to support external Electrum light wallets, since there are rougly 30 altcoins with their own forks of Electrum.  Namely LTC.  Maybe DOGE will get on the stick and make an Electrum fork work too.

This is designed for the RPCs available in 4.0.9 since that's where Litecoin's fork is at.  4.2.0 has some other RPCs including freeeze_utxo, so maybe in the future that will be available.