### PR TITLE
multi: support fiat conversion for assets

### DIFF
--- a/client/asset/doge/doge.go
+++ b/client/asset/doge/doge.go
@@ -78,7 +78,7 @@ var (
 	}
 	// WalletInfo defines some general information about a Dogecoin wallet.
 	WalletInfo = &asset.WalletInfo{
-		Name:     "Doge",
+		Name:     "Dogecoin",
 		Version:  version,
 		UnitInfo: dexdoge.UnitInfo,
 		AvailableWallets: []*asset.WalletDefinition{{

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1089,10 +1089,10 @@ func randomMsgMarket() (baseAsset, quoteAsset *msgjson.Asset) {
 }
 
 func tFetcher(_ context.Context, log dex.Logger, _ map[uint32]*SupportedAsset) map[uint32]float64 {
-	fiatRates := make(map[uint32]float64)
-	fiatRates[tUTXOAssetA.ID] = 45
-	fiatRates[tUTXOAssetB.ID] = 32000
-	return fiatRates
+	return map[uint32]float64{
+		tUTXOAssetA.ID: 45,
+		tUTXOAssetB.ID: 32000,
+	}
 }
 
 type testRig struct {

--- a/client/core/exchangeratefetcher.go
+++ b/client/core/exchangeratefetcher.go
@@ -1,0 +1,254 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+)
+
+const (
+	// DefaultFiatCurrency is the currency for displaying assets fiat value.
+	DefaultFiatCurrency = "USD"
+	// fiatRateRequestInterval is the amount of time between calls to the exchange API.
+	fiatRateRequestInterval = 5 * time.Minute
+	// fiatRateDataExpiry : Any data older than fiatRateDataExpiry will be discarded.
+	fiatRateDataExpiry = 60 * time.Minute
+
+	// Tokens. Used to identify fiat rate source.
+	messari       = "Messari"
+	coinpaprika   = "Coinpaprika"
+	dcrdataDotOrg = "dcrdata"
+)
+
+var (
+	dcrDataURL     = "https://explorer.dcrdata.org/api/exchangerate"
+	coinpaprikaURL = "https://api.coinpaprika.com/v1/tickers/%s"
+	messariURL     = "https://data.messari.io/api/v1/assets/%s/metrics/market-data"
+	btcBipID, _    = dex.BipSymbolID("btc")
+	dcrBipID, _    = dex.BipSymbolID("dcr")
+)
+
+// fiatRateFetchers is the list of all supported fiat rate fetchers.
+var fiatRateFetchers = map[string]rateFetcher{
+	coinpaprika:   fetchCoinpaprikaRates,
+	dcrdataDotOrg: fetchDcrdataRates,
+	messari:       fetchMessariRates,
+}
+
+// fiatRateInfo holds the fiat rate and the last update time for an
+// asset.
+type fiatRateInfo struct {
+	rate       float64
+	lastUpdate time.Time
+}
+
+// rateFetcher can fetch fiat rates for assets from an API.
+type rateFetcher func(context context.Context, logger dex.Logger, assets map[uint32]*SupportedAsset) map[uint32]float64
+
+type commonRateSource struct {
+	lastRequest time.Time
+	fetchRates  rateFetcher
+
+	mtx       sync.RWMutex
+	fiatRates map[uint32]*fiatRateInfo
+}
+
+// isExpired checks the last update time for all fiat rates against the
+// provided expiryTime.
+func (source *commonRateSource) isExpired(expiryTime time.Duration) bool {
+	source.mtx.RLock()
+	defer source.mtx.RUnlock()
+	var expiredCount int
+	for _, rateInfo := range source.fiatRates {
+		if time.Since(rateInfo.lastUpdate) > expiryTime {
+			expiredCount++
+		}
+	}
+	totalFiatRate := len(source.fiatRates)
+	return expiredCount == totalFiatRate && totalFiatRate != 0
+}
+
+// assetRate returns the fiat rate information for the assetID specified. The
+// fiatRateInfo returned should not be modified by the caller.
+func (source *commonRateSource) assetRate(assetID uint32) *fiatRateInfo {
+	source.mtx.RLock()
+	defer source.mtx.RUnlock()
+	return source.fiatRates[assetID]
+}
+
+// refreshRates updates the last update time and the rate information for assets.
+func (source *commonRateSource) refreshRates(ctx context.Context, logger dex.Logger, assets map[uint32]*SupportedAsset) {
+	fiatRates := source.fetchRates(ctx, logger, assets)
+	source.mtx.Lock()
+	defer source.mtx.Unlock()
+	for assetID, fiatRate := range fiatRates {
+		source.fiatRates[assetID] = &fiatRateInfo{
+			rate:       fiatRate,
+			lastUpdate: time.Now(),
+		}
+	}
+}
+
+// Used to initialize a fiat rate source.
+func newCommonRateSource(fetcher rateFetcher) *commonRateSource {
+	return &commonRateSource{
+		fetchRates: fetcher,
+		fiatRates:  make(map[uint32]*fiatRateInfo),
+	}
+}
+
+// fetchCoinpaprikaRates retrieves and parses fiat rate data from the
+// Coinpaprika API. See https://api.coinpaprika.com/#operation/getTickersById
+// for sample request and response information.
+func fetchCoinpaprikaRates(ctx context.Context, log dex.Logger, assets map[uint32]*SupportedAsset) map[uint32]float64 {
+	fiatRates := make(map[uint32]float64)
+	for assetID, asset := range assets {
+		if asset.Wallet == nil {
+			// we don't want to fetch rates for assets with no wallet.
+			continue
+		}
+
+		res := new(struct {
+			Quotes struct {
+				Currency struct {
+					Price float64 `json:"price"`
+				} `json:"USD"`
+			} `json:"quotes"`
+		})
+
+		slug := fmt.Sprintf("%s-%s", asset.Symbol, asset.Info.Name)
+		// Special handling for asset names with multiple space, e.g Bitcoin Cash.
+		slug = strings.ToLower(strings.ReplaceAll(slug, " ", "-"))
+		reqStr := fmt.Sprintf(coinpaprikaURL, slug)
+
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, reqStr, nil)
+		if err != nil {
+			log.Errorf("%s: NewRequestWithContext error: %v", coinpaprika, err)
+			continue
+		}
+
+		resp, err := http.DefaultClient.Do(request)
+		if err != nil {
+			log.Errorf("%s: request failed: %v", coinpaprika, err)
+			continue
+		}
+		defer resp.Body.Close()
+
+		// Read the raw bytes and close the response.
+		reader := io.LimitReader(resp.Body, 1<<20)
+		err = json.NewDecoder(reader).Decode(res)
+		if err != nil {
+			log.Errorf("%s: failed to decode json from %s: %v", coinpaprika, request.URL.String(), err)
+			continue
+		}
+
+		fiatRates[assetID] = res.Quotes.Currency.Price
+	}
+	return fiatRates
+}
+
+// fetchDcrdataRates retrieves and parses fiat rate data from dcrdata
+// exchange rate API.
+func fetchDcrdataRates(ctx context.Context, log dex.Logger, assets map[uint32]*SupportedAsset) map[uint32]float64 {
+	assetBTC := assets[btcBipID]
+	assetDCR := assets[dcrBipID]
+	noBTCAsset := assetBTC == nil || assetBTC.Wallet == nil
+	noDCRAsset := assetDCR == nil || assetDCR.Wallet == nil
+	if noBTCAsset && noDCRAsset {
+		return nil
+	}
+
+	fiatRates := make(map[uint32]float64)
+	res := new(struct {
+		DcrPrice float64 `json:"dcrPrice"`
+		BtcPrice float64 `json:"btcPrice"`
+	})
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, dcrDataURL, nil)
+	if err != nil {
+		log.Errorf("%s: NewRequestWithContext error: %v", dcrdataDotOrg, err)
+		return nil
+	}
+
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		log.Errorf("%s: request failed: %v", dcrdataDotOrg, err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	// Read the raw bytes and close the response.
+	reader := io.LimitReader(resp.Body, 1<<20)
+	err = json.NewDecoder(reader).Decode(res)
+	if err != nil {
+		log.Errorf("%s: failed to decode json from %s: %v", dcrdataDotOrg, request.URL.String(), err)
+		return nil
+	}
+
+	if !noBTCAsset {
+		fiatRates[btcBipID] = res.BtcPrice
+	}
+	if !noDCRAsset {
+		fiatRates[dcrBipID] = res.DcrPrice
+	}
+
+	return fiatRates
+}
+
+// fetchMessariRates retrieves and parses fiat rate data from the Messari API.
+// See https://messari.io/api/docs#operation/Get%20Asset%20Market%20Data for
+// sample request and response information.
+func fetchMessariRates(ctx context.Context, log dex.Logger, assets map[uint32]*SupportedAsset) map[uint32]float64 {
+	fiatRates := make(map[uint32]float64)
+	for assetID, asset := range assets {
+		if asset.Wallet == nil {
+			// we don't want to fetch rate for assets with no wallet.
+			continue
+		}
+
+		res := new(struct {
+			Data struct {
+				MarketData struct {
+					Price float64 `json:"price_usd"`
+				} `json:"market_data"`
+			} `json:"data"`
+		})
+
+		slug := strings.ToLower(asset.Symbol)
+		reqStr := fmt.Sprintf(messariURL, slug)
+
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, reqStr, nil)
+		if err != nil {
+			log.Errorf("%s: NewRequestWithContext error: %v", dcrdataDotOrg, err)
+			continue
+		}
+
+		resp, err := http.DefaultClient.Do(request)
+		if err != nil {
+			log.Errorf("%s: request error: %v", messari, err)
+			continue
+		}
+		defer resp.Body.Close()
+
+		// Read the raw bytes and close the response.
+		reader := io.LimitReader(resp.Body, 1<<20)
+		err = json.NewDecoder(reader).Decode(res)
+		if err != nil {
+			log.Errorf("%s: failed to decode json from %s: %v", messari, request.URL.String(), err)
+			continue
+		}
+
+		fiatRates[assetID] = res.Data.MarketData.Price
+	}
+	return fiatRates
+}

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -356,16 +356,16 @@ func newConnEventNote(topic Topic, subject, host string, status comms.Connection
 	}
 }
 
-// fiatRatesNote is an update of fiat rate data for assets.
-type fiatRatesNote struct {
+// FiatRatesNote is an update of fiat rate data for assets.
+type FiatRatesNote struct {
 	db.Notification
 	FiatRates map[uint32]float64 `json:"fiatRates"`
 }
 
 const TopicFiatRatesUpdate Topic = "fiatrateupdate"
 
-func newFiatRatesUpdate(rates map[uint32]float64) *fiatRatesNote {
-	return &fiatRatesNote{
+func newFiatRatesUpdate(rates map[uint32]float64) *FiatRatesNote {
+	return &FiatRatesNote{
 		Notification: db.NewNotification(NoteTypeFiatRates, TopicFiatRatesUpdate, "", "", db.Data),
 		FiatRates:    rates,
 	}

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -28,6 +28,7 @@ const (
 	NoteTypeSecurity     = "security"
 	NoteTypeUpgrade      = "upgrade"
 	NoteTypeDEXAuth      = "dex_auth"
+	NoteTypeFiatRates    = "fiatrateupdate"
 )
 
 func (c *Core) logNote(n Notification) {
@@ -352,6 +353,21 @@ func newConnEventNote(topic Topic, subject, host string, status comms.Connection
 		Notification:     db.NewNotification(NoteTypeConnEvent, topic, subject, details, severity),
 		Host:             host,
 		ConnectionStatus: status,
+	}
+}
+
+// fiatRatesNote is an update of fiat rate data for assets.
+type fiatRatesNote struct {
+	db.Notification
+	FiatRates map[uint32]float64 `json:"fiatRates"`
+}
+
+const TopicFiatRatesUpdate Topic = "fiatrateupdate"
+
+func newFiatRatesUpdate(rates map[uint32]float64) *fiatRatesNote {
+	return &fiatRatesNote{
+		Notification: db.NewNotification(NoteTypeFiatRates, TopicFiatRatesUpdate, "", "", db.Data),
+		FiatRates:    rates,
 	}
 }
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -117,6 +117,7 @@ type User struct {
 	Initialized        bool                       `json:"inited"`
 	SeedGenerationTime uint64                     `json:"seedgentime"`
 	Assets             map[uint32]*SupportedAsset `json:"assets"`
+	FiatRates          map[uint32]float64         `json:"fiatRates"`
 }
 
 // SupportedAsset is data about an asset and possibly the wallet associated

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -133,7 +133,7 @@ type DB interface {
 	// DisabledRateSources retrieves disabled fiat rate sources from the
 	// database.
 	DisabledRateSources() ([]string, error)
-	// SaveDisabledRateSources saves disabled fiat rate sources in the
-	// database.
+	// SaveDisabledRateSources saves disabled fiat rate sources in the database.
+	// A source name must not contain a comma.
 	SaveDisabledRateSources(disabledSources []string) error
 }

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -130,4 +130,10 @@ type DB interface {
 	SetSeedGenerationTime(time uint64) error
 	// SeedGenerationTime fetches the time when the app seed was generated.
 	SeedGenerationTime() (uint64, error)
+	// DisabledRateSources retrieves disabled fiat rate sources from the
+	// database.
+	DisabledRateSources() ([]string, error)
+	// SaveDisabledRateSources saves disabled fiat rate sources in the
+	// database.
+	SaveDisabledRateSources(disabledSources []string) error
 }

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1068,6 +1068,23 @@ func (s *WebServer) apiUser(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, response, s.indent)
 }
 
+// apiToggleRateSource handles the /toggleratesource API request.
+func (s *WebServer) apiToggleRateSource(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		Disable bool   `json:"disable"`
+		Source  string `json:"source"`
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+	err := s.core.ToggleRateSourceStatus(form.Source, form.Disable)
+	if err != nil {
+		s.writeAPIError(w, fmt.Errorf("error disabling/enabling rate source: %w", err))
+		return
+	}
+	writeJSON(w, simpleAck(), s.indent)
+}
+
 // writeAPIError logs the formatted error and sends a standardResponse with the
 // error message.
 func (s *WebServer) writeAPIError(w http.ResponseWriter, err error) {

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -241,10 +241,14 @@ func (s *WebServer) handleSettings(w http.ResponseWriter, r *http.Request) {
 	common := commonArgs(r, "Settings | Decred DEX")
 	data := &struct {
 		CommonArguments
-		KnownExchanges []string
+		KnownExchanges  []string
+		FiatRateSources map[string]bool
+		FiatCurrency    string
 	}{
 		CommonArguments: *common,
 		KnownExchanges:  s.knownUnregisteredExchanges(common.UserInfo.Exchanges),
+		FiatCurrency:    core.DefaultFiatCurrency,
+		FiatRateSources: s.core.FiatRateSources(),
 	}
 	s.sendTemplate(w, "settings", data)
 }

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -436,6 +436,7 @@ type TCore struct {
 	noteFeed    chan core.Notification
 	orderMtx    sync.Mutex
 	epochOrders []*core.BookUpdate
+	fiatSources map[string]bool
 }
 
 // TDriver implements the interface required of all exchange wallets.
@@ -481,6 +482,11 @@ func newTCore() *TCore {
 			145: randomBalance(145),
 		},
 		noteFeed: make(chan core.Notification, 1),
+		fiatSources: map[string]bool{
+			"dcrdata":     true,
+			"Messari":     true,
+			"Coinpaprika": true,
+		},
 	}
 }
 
@@ -1400,6 +1406,17 @@ func (c *TCore) User() *core.User {
 		Exchanges:   exchanges,
 		Initialized: c.inited,
 		Assets:      c.SupportedAssets(),
+		FiatRates: map[uint32]float64{
+			0:   21_208.61, // btc
+			2:   59.08,     // ltc
+			42:  25.46,     // dcr
+			22:  0.5117,    // mona
+			28:  0.1599,    // vtc
+			141: 0.2048,    // kmd
+			3:   0.06769,   // doge
+			145: 114.68,    // bch
+			60:  1_209.51,  // eth
+		},
 	}
 	return user
 }
@@ -1614,6 +1631,13 @@ func (c *TCore) UpdateDEXHost(string, string, []byte, interface{}) (*core.Exchan
 }
 func (c *TCore) WalletRestorationInfo(pw []byte, assetID uint32) ([]*asset.WalletRestoration, error) {
 	return nil, nil
+}
+func (c *TCore) ToggleRateSourceStatus(src string, disable bool) error {
+	c.fiatSources[src] = !disable
+	return nil
+}
+func (c *TCore) FiatRateSources() map[string]bool {
+	return c.fiatSources
 }
 
 func TestServer(t *testing.T) {

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -243,4 +243,5 @@ var EnUS = map[string]string{
 	"export_wallet_disclaimer":    `<span class="warning-text">Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS.</span> It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.`,
 	"export_wallet_msg":           "Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.",
 	"clipboard_warning":           "Copy/Pasting a wallet seed is a potential security risk. Do this at your own risk.",
+	"fiat_exchange_rate_sources":  "Fiat Exchange Rate Sources",
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
+  <link href="/css/style.css?v=GHGLDF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=8qUUO9"></script>
+<script src="/js/entry.js?v=GHTDEG"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -455,6 +455,9 @@
             <span id="vTotal" class="fs18 demi"></span>
             <span data-unit="quote" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+          ~<span id="vFiatTotal" class="mx-1"></span>USD
+          </span>
         </div>
         <div id="verifyMarket">
           <div class="d-flex align-items-center justify-content-between">
@@ -462,6 +465,9 @@
             <span id="vmFromTotal" class="fs18 demi"></span>
             <span id="vmFromAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmFromTotalFiat" class="mx-1"></span>USD
+          </span>
           <div id="vMarketEstimate" class="d-flex align-items-center justify-content-between">
             <span class="grey fs17 flex-grow-1 text-start">
               [[[Receiving Approximately]]]
@@ -470,6 +476,9 @@
             <span id="vmToTotal" class="fs18 demi"></span>
             <span id="vmToAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmTotalFiat" class="mx-1"></span>USD
+          </span>
         </div>
 
         <hr class="dashed my-2">

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -16,6 +16,24 @@
         [[[Show pop-up notifications]]]
       </label>
     </div>
+    <div {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span>Fiat Currency: </span><span id="fiatCurrency">{{.FiatCurrency}}</span>
+    </div>
+    <div id="fiatRateSources" {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span class="mb-2" data-tooltip="Sources may provide fiat exchange rates for different subsets of assets.
+     You should select all sources that are acceptable to get fiat exchange rates for the most assets. 
+     Assets with fiat rates from multiple sources will use the average from all of those sources.
+     Note: dcrdate provides fiat exchange rates for only BTC and DCR.">
+     [[[fiat_exchange_rate_sources]]]:
+    <span class="ico-info"></span>
+    </span>
+    {{range $source, $enabled := .FiatRateSources}}
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" value="{{$source}}" id="{{$source}}" {{if $enabled}} checked {{end}}>
+      <label class="form-check-label" for="{{$source}}">{{$source}}</label>
+    </div>
+    {{end}}
+    </div>
     <div>
       <div id="exchanges" {{if eq (len .UserInfo.Exchanges) 0}} class="d-hide"{{end}}>
         <h5>[[[registered dexes]]]</h5>

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -76,7 +76,7 @@
             <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
             </div>
-             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
             </div>
             {{else}}
               0.00000000

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -71,9 +71,13 @@
             <span class="fs20">{{.Info.Name}}</span>
             <span class="fs15">({{toUpper .Symbol}})</span>
           </td>
-          <td data-balance-target="{{.ID}}">
+         <td>
             {{if .Wallet}}
+            <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
+            </div>
+             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            </div>
             {{else}}
               0.00000000
             {{end}}
@@ -164,6 +168,7 @@
           <!-- <div class="d-inline">tx fees: <span id="sendFee"></span> <span id="sendUnit"></span>/byte</div> -->
         </div>
       </div>
+      <span class="mt-2 d-hide">~<span id="sendValue" class="mx-1"></span>USD</span>
       <div id="toggleSubtract" class="form-check pt-2">
            <input class="form-check-input" type="checkbox" id="subtractCheckBox">
            <label for="subtractCheckBox" class="form-label ps-1">Subtract fees from amount sent.</label>

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -572,7 +572,7 @@ export default class Application {
       case 'walletstate':
       case 'walletconfig': {
         // assets can be null if failed to connect to dex server.
-        if (!this.assets) break
+        if (!this.assets) return
         const wallet = (note as WalletConfigNote).wallet
         const asset = this.assets[wallet.assetID]
         asset.wallet = wallet
@@ -580,8 +580,8 @@ export default class Application {
         const bal = wallet.balance.available
         const balances = this.main.querySelectorAll(`[data-balance-target="${wallet.assetID}"]`)
         balances.forEach(el => { el.textContent = Doc.formatFullPrecision(bal, asset.info.unitinfo) })
-      }
         break
+      }
       case 'match': {
         const n = note as MatchNote
         const ord = this.order(n.orderID)

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -35,7 +35,8 @@ import {
   LogMessage,
   NoteElement,
   BalanceResponse,
-  APIResponse
+  APIResponse,
+  RateNote
 } from './registry'
 
 const idel = Doc.idel // = element by id
@@ -90,6 +91,7 @@ export default class Application {
   assets: Record<number, SupportedAsset>
   exchanges: Record<string, Exchange>
   walletMap: Record<number, WalletState>
+  fiatRatesMap: Record<number, number>
   tooltip: HTMLElement
   page: Record<string, HTMLElement>
   loadedPage: Page | null
@@ -101,12 +103,14 @@ export default class Application {
     this.notes = []
     this.pokes = []
     // The "user" is a large data structure that contains nearly all state
-    // information, including exchanges, markets, wallets, and orders.
+    // information, including exchanges, markets, wallets, orders and exchange
+    // rates for assets.
     this.user = {
       exchanges: {},
       inited: false,
       seedgentime: 0,
       assets: {},
+      fiatRates: {},
       authed: false,
       ok: true
     }
@@ -223,11 +227,13 @@ export default class Application {
     this.assets = user.assets
     this.exchanges = user.exchanges
     this.walletMap = {}
+    this.fiatRatesMap = user.fiatRates
     for (const [assetID, asset] of (Object.entries(user.assets) as [any, SupportedAsset][])) {
       if (asset.wallet) {
         this.walletMap[assetID] = asset.wallet
       }
     }
+
     this.updateMenuItemsDisplay()
     return user
   }
@@ -566,15 +572,16 @@ export default class Application {
       case 'walletstate':
       case 'walletconfig': {
         // assets can be null if failed to connect to dex server.
-        if (!this.assets) return
+        if (!this.assets) break
         const wallet = (note as WalletConfigNote).wallet
         const asset = this.assets[wallet.assetID]
         asset.wallet = wallet
         this.walletMap[wallet.assetID] = wallet
+        const bal = wallet.balance.available
         const balances = this.main.querySelectorAll(`[data-balance-target="${wallet.assetID}"]`)
-        balances.forEach(el => { el.textContent = Doc.formatFullPrecision(wallet.balance.available, asset.info.unitinfo) })
-        break
+        balances.forEach(el => { el.textContent = Doc.formatFullPrecision(bal, asset.info.unitinfo) })
       }
+        break
       case 'match': {
         const n = note as MatchNote
         const ord = this.order(n.orderID)
@@ -593,6 +600,10 @@ export default class Application {
         // Spots can come before the user is fetched after login.
         if (!xc) break
         for (const [mktName, spot] of Object.entries(n.spots)) xc.markets[mktName].spot = spot
+        break
+      }
+      case 'fiatrateupdate': {
+        this.fiatRatesMap = (note as RateNote).fiatRates
       }
     }
 

--- a/client/webserver/site/src/js/doc.ts
+++ b/client/webserver/site/src/js/doc.ts
@@ -236,6 +236,18 @@ export default class Doc {
   }
 
   /*
+   * formatFiatConversion formats the value in atomic units to its representation in
+   * conventional units and returns the fiat value as a string.
+   */
+  static formatFiatConversion (vAtomic: number, rate: number, unitInfo?: UnitInfo): string {
+    if (!rate || rate === 0) return 'unavailable'
+    const prec = 2
+    const [v] = convertToConventional(vAtomic, unitInfo)
+    const value = v * rate
+    return fullPrecisionFormatter(prec).format(value)
+  }
+
+  /*
    * logoPath creates a path to a png logo for the specified ticker symbol. If
    * the symbol is not a supported asset, the generic letter logo will be
    * requested instead.

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1399,7 +1399,10 @@ export default class MarketsPage extends BasePage {
       page.vOrderType.textContent = order.tifnow ? orderDesc + ' (immediate)' : orderDesc
       page.vRate.textContent = Doc.formatCoinValue(order.rate / this.market.rateConversionFactor)
       page.vQty.textContent = Doc.formatCoinValue(order.qty, baseAsset.info.unitinfo)
-      page.vTotal.textContent = Doc.formatCoinValue(order.rate / OrderUtil.RateEncodingFactor * order.qty, quoteAsset.info.unitinfo)
+      const total = order.rate / OrderUtil.RateEncodingFactor * order.qty
+      page.vTotal.textContent = Doc.formatCoinValue(total, quoteAsset.info.unitinfo)
+      // Format total fiat value.
+      this.showFiatValue(quoteAsset.id, total, page.vFiatTotal)
     } else {
       Doc.hide(page.verifyLimit)
       Doc.show(page.verifyMarket)
@@ -1407,12 +1410,16 @@ export default class MarketsPage extends BasePage {
       const ui = order.sell ? this.market.baseUnitInfo : this.market.quoteUnitInfo
       page.vmFromTotal.textContent = Doc.formatCoinValue(order.qty, ui)
       page.vmFromAsset.textContent = fromAsset.symbol.toUpperCase()
+      // Format fromAsset fiat value.
+      this.showFiatValue(fromAsset.id, order.qty, page.vmFromTotalFiat)
       const gap = this.midGap()
       if (gap) {
         Doc.show(page.vMarketEstimate)
         const received = order.sell ? order.qty * gap : order.qty / gap
         page.vmToTotal.textContent = Doc.formatCoinValue(received, toAsset.info.unitinfo)
         page.vmToAsset.textContent = toAsset.symbol.toUpperCase()
+        // Format recieved value to fiat equivalent.
+        this.showFiatValue(toAsset.id, received, page.vmTotalFiat)
       } else {
         Doc.hide(page.vMarketEstimate)
       }
@@ -1439,6 +1446,16 @@ export default class MarketsPage extends BasePage {
       Doc.hide(page.vPreorder)
       if (State.passwordIsCached()) this.unlockWalletsForEstimates('')
       else Doc.show(page.vUnlockPreorder)
+    }
+  }
+
+  // showFiatValue displays the fiat equivalent for an order quantity.
+  showFiatValue (assetID: number, qty: number, display: PageElement) {
+    if (display) {
+      const rate = app().fiatRatesMap[assetID]
+      display.textContent = Doc.formatFiatConversion(qty, rate, app().unitInfo(assetID))
+      if (rate) Doc.show(display.parentElement as Element)
+      else Doc.hide(display.parentElement as Element)
     }
   }
 

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -239,6 +239,7 @@ export interface User {
   inited: boolean
   seedgentime: number
   assets: Record<number, SupportedAsset>
+  fiatRates: Record<number, number>
   authed: boolean // added by webserver
   ok: boolean // added by webserver
 }
@@ -263,6 +264,10 @@ export interface FeePaymentNote extends CoreNote {
 export interface BalanceNote extends CoreNote {
   assetID: number
   balance: WalletBalance
+}
+
+export interface RateNote extends CoreNote {
+  fiatRates: Record<number, number>
 }
 
 export interface WalletConfigNote extends CoreNote {
@@ -465,6 +470,7 @@ export interface Application {
   header: HTMLElement
   walletMap: Record<number, WalletState>
   exchanges: Record<string, Exchange>
+  fiatRatesMap: Record<number, number>
   showPopups: boolean
   commitHash: string
   start (): Promise<void>

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
+  <link href="/css/style.css?v=GHGLDF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=8qUUO9"></script>
+<script src="/js/entry.js?v=GHTDEG"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/en-US/markets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/markets.tmpl
@@ -455,6 +455,9 @@
             <span id="vTotal" class="fs18 demi"></span>
             <span data-unit="quote" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+          ~<span id="vFiatTotal" class="mx-1"></span>USD
+          </span>
         </div>
         <div id="verifyMarket">
           <div class="d-flex align-items-center justify-content-between">
@@ -462,6 +465,9 @@
             <span id="vmFromTotal" class="fs18 demi"></span>
             <span id="vmFromAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmFromTotalFiat" class="mx-1"></span>USD
+          </span>
           <div id="vMarketEstimate" class="d-flex align-items-center justify-content-between">
             <span class="grey fs17 flex-grow-1 text-start">
               Receiving Approximately
@@ -470,6 +476,9 @@
             <span id="vmToTotal" class="fs18 demi"></span>
             <span id="vmToAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmTotalFiat" class="mx-1"></span>USD
+          </span>
         </div>
 
         <hr class="dashed my-2">

--- a/client/webserver/site/src/localized_html/en-US/settings.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/settings.tmpl
@@ -16,6 +16,24 @@
         Show pop-up notifications
       </label>
     </div>
+    <div {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span>Fiat Currency: </span><span id="fiatCurrency">{{.FiatCurrency}}</span>
+    </div>
+    <div id="fiatRateSources" {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span class="mb-2" data-tooltip="Sources may provide fiat exchange rates for different subsets of assets.
+     You should select all sources that are acceptable to get fiat exchange rates for the most assets. 
+     Assets with fiat rates from multiple sources will use the average from all of those sources.
+     Note: dcrdate provides fiat exchange rates for only BTC and DCR.">
+     Fiat Exchange Rate Sources:
+    <span class="ico-info"></span>
+    </span>
+    {{range $source, $enabled := .FiatRateSources}}
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" value="{{$source}}" id="{{$source}}" {{if $enabled}} checked {{end}}>
+      <label class="form-check-label" for="{{$source}}">{{$source}}</label>
+    </div>
+    {{end}}
+    </div>
     <div>
       <div id="exchanges" {{if eq (len .UserInfo.Exchanges) 0}} class="d-hide"{{end}}>
         <h5>Registered Dexes:</h5>

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -76,7 +76,7 @@
             <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
             </div>
-             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
             </div>
             {{else}}
               0.00000000

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -71,9 +71,13 @@
             <span class="fs20">{{.Info.Name}}</span>
             <span class="fs15">({{toUpper .Symbol}})</span>
           </td>
-          <td data-balance-target="{{.ID}}">
+         <td>
             {{if .Wallet}}
+            <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
+            </div>
+             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            </div>
             {{else}}
               0.00000000
             {{end}}
@@ -164,6 +168,7 @@
           <!-- <div class="d-inline">tx fees: <span id="sendFee"></span> <span id="sendUnit"></span>/byte</div> -->
         </div>
       </div>
+      <span class="mt-2 d-hide">~<span id="sendValue" class="mx-1"></span>USD</span>
       <div id="toggleSubtract" class="form-check pt-2">
            <input class="form-check-input" type="checkbox" id="subtractCheckBox">
            <label for="subtractCheckBox" class="form-label ps-1">Subtract fees from amount sent.</label>

--- a/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
+  <link href="/css/style.css?v=GHGLDF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=8qUUO9"></script>
+<script src="/js/entry.js?v=GHTDEG"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/markets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/markets.tmpl
@@ -455,6 +455,9 @@
             <span id="vTotal" class="fs18 demi"></span>
             <span data-unit="quote" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+          ~<span id="vFiatTotal" class="mx-1"></span>USD
+          </span>
         </div>
         <div id="verifyMarket">
           <div class="d-flex align-items-center justify-content-between">
@@ -462,6 +465,9 @@
             <span id="vmFromTotal" class="fs18 demi"></span>
             <span id="vmFromAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmFromTotalFiat" class="mx-1"></span>USD
+          </span>
           <div id="vMarketEstimate" class="d-flex align-items-center justify-content-between">
             <span class="grey fs17 flex-grow-1 text-start">
               Otrzymując około
@@ -470,6 +476,9 @@
             <span id="vmToTotal" class="fs18 demi"></span>
             <span id="vmToAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmTotalFiat" class="mx-1"></span>USD
+          </span>
         </div>
 
         <hr class="dashed my-2">

--- a/client/webserver/site/src/localized_html/pl-PL/settings.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/settings.tmpl
@@ -16,6 +16,24 @@
         Pokazuj powiadomienia w okienkach
       </label>
     </div>
+    <div {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span>Fiat Currency: </span><span id="fiatCurrency">{{.FiatCurrency}}</span>
+    </div>
+    <div id="fiatRateSources" {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span class="mb-2" data-tooltip="Sources may provide fiat exchange rates for different subsets of assets.
+     You should select all sources that are acceptable to get fiat exchange rates for the most assets. 
+     Assets with fiat rates from multiple sources will use the average from all of those sources.
+     Note: dcrdate provides fiat exchange rates for only BTC and DCR.">
+     Fiat Exchange Rate Sources:
+    <span class="ico-info"></span>
+    </span>
+    {{range $source, $enabled := .FiatRateSources}}
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" value="{{$source}}" id="{{$source}}" {{if $enabled}} checked {{end}}>
+      <label class="form-check-label" for="{{$source}}">{{$source}}</label>
+    </div>
+    {{end}}
+    </div>
     <div>
       <div id="exchanges" {{if eq (len .UserInfo.Exchanges) 0}} class="d-hide"{{end}}>
         <h5>Registered Dexes:</h5>

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -76,7 +76,7 @@
             <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
             </div>
-             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
             </div>
             {{else}}
               0.00000000

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -71,9 +71,13 @@
             <span class="fs20">{{.Info.Name}}</span>
             <span class="fs15">({{toUpper .Symbol}})</span>
           </td>
-          <td data-balance-target="{{.ID}}">
+         <td>
             {{if .Wallet}}
+            <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
+            </div>
+             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            </div>
             {{else}}
               0.00000000
             {{end}}
@@ -164,6 +168,7 @@
           <!-- <div class="d-inline">tx fees: <span id="sendFee"></span> <span id="sendUnit"></span>/byte</div> -->
         </div>
       </div>
+      <span class="mt-2 d-hide">~<span id="sendValue" class="mx-1"></span>USD</span>
       <div id="toggleSubtract" class="form-check pt-2">
            <input class="form-check-input" type="checkbox" id="subtractCheckBox">
            <label for="subtractCheckBox" class="form-label ps-1">Subtract fees from amount sent.</label>

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
+  <link href="/css/style.css?v=GHGLDF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=8qUUO9"></script>
+<script src="/js/entry.js?v=GHTDEG"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/markets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/markets.tmpl
@@ -455,6 +455,9 @@
             <span id="vTotal" class="fs18 demi"></span>
             <span data-unit="quote" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+          ~<span id="vFiatTotal" class="mx-1"></span>USD
+          </span>
         </div>
         <div id="verifyMarket">
           <div class="d-flex align-items-center justify-content-between">
@@ -462,6 +465,9 @@
             <span id="vmFromTotal" class="fs18 demi"></span>
             <span id="vmFromAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmFromTotalFiat" class="mx-1"></span>USD
+          </span>
           <div id="vMarketEstimate" class="d-flex align-items-center justify-content-between">
             <span class="grey fs17 flex-grow-1 text-start">
               Recebendo aproximadamente
@@ -470,6 +476,9 @@
             <span id="vmToTotal" class="fs18 demi"></span>
             <span id="vmToAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmTotalFiat" class="mx-1"></span>USD
+          </span>
         </div>
 
         <hr class="dashed my-2">

--- a/client/webserver/site/src/localized_html/pt-BR/settings.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/settings.tmpl
@@ -16,6 +16,24 @@
         Mostrar notificações de pop-up
       </label>
     </div>
+    <div {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span>Fiat Currency: </span><span id="fiatCurrency">{{.FiatCurrency}}</span>
+    </div>
+    <div id="fiatRateSources" {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span class="mb-2" data-tooltip="Sources may provide fiat exchange rates for different subsets of assets.
+     You should select all sources that are acceptable to get fiat exchange rates for the most assets. 
+     Assets with fiat rates from multiple sources will use the average from all of those sources.
+     Note: dcrdate provides fiat exchange rates for only BTC and DCR.">
+     Fiat Exchange Rate Sources:
+    <span class="ico-info"></span>
+    </span>
+    {{range $source, $enabled := .FiatRateSources}}
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" value="{{$source}}" id="{{$source}}" {{if $enabled}} checked {{end}}>
+      <label class="form-check-label" for="{{$source}}">{{$source}}</label>
+    </div>
+    {{end}}
+    </div>
     <div>
       <div id="exchanges" {{if eq (len .UserInfo.Exchanges) 0}} class="d-hide"{{end}}>
         <h5>Registered Dexes:</h5>

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -76,7 +76,7 @@
             <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
             </div>
-             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
             </div>
             {{else}}
               0.00000000

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -71,9 +71,13 @@
             <span class="fs20">{{.Info.Name}}</span>
             <span class="fs15">({{toUpper .Symbol}})</span>
           </td>
-          <td data-balance-target="{{.ID}}">
+         <td>
             {{if .Wallet}}
+            <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
+            </div>
+             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            </div>
             {{else}}
               0.00000000
             {{end}}
@@ -164,6 +168,7 @@
           <!-- <div class="d-inline">tx fees: <span id="sendFee"></span> <span id="sendUnit"></span>/byte</div> -->
         </div>
       </div>
+      <span class="mt-2 d-hide">~<span id="sendValue" class="mx-1"></span>USD</span>
       <div id="toggleSubtract" class="form-check pt-2">
            <input class="form-check-input" type="checkbox" id="subtractCheckBox">
            <label for="subtractCheckBox" class="form-label ps-1">Subtract fees from amount sent.</label>

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
+  <link href="/css/style.css?v=GHGLDF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=8qUUO9"></script>
+<script src="/js/entry.js?v=GHTDEG"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/markets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/markets.tmpl
@@ -455,6 +455,9 @@
             <span id="vTotal" class="fs18 demi"></span>
             <span data-unit="quote" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+          ~<span id="vFiatTotal" class="mx-1"></span>USD
+          </span>
         </div>
         <div id="verifyMarket">
           <div class="d-flex align-items-center justify-content-between">
@@ -462,6 +465,9 @@
             <span id="vmFromTotal" class="fs18 demi"></span>
             <span id="vmFromAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmFromTotalFiat" class="mx-1"></span>USD
+          </span>
           <div id="vMarketEstimate" class="d-flex align-items-center justify-content-between">
             <span class="grey fs17 flex-grow-1 text-start">
               Receiving Approximately
@@ -470,6 +476,9 @@
             <span id="vmToTotal" class="fs18 demi"></span>
             <span id="vmToAsset" class="grey fs14 ms-2"></span>
           </div>
+          <span class="d-flex d-hide justify-content-end grey fs14">
+           ~<span id="vmTotalFiat" class="mx-1"></span>USD
+          </span>
         </div>
 
         <hr class="dashed my-2">

--- a/client/webserver/site/src/localized_html/zh-CN/settings.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/settings.tmpl
@@ -16,6 +16,24 @@
         显示弹出通知
       </label>
     </div>
+    <div {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span>Fiat Currency: </span><span id="fiatCurrency">{{.FiatCurrency}}</span>
+    </div>
+    <div id="fiatRateSources" {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+    <span class="mb-2" data-tooltip="Sources may provide fiat exchange rates for different subsets of assets.
+     You should select all sources that are acceptable to get fiat exchange rates for the most assets. 
+     Assets with fiat rates from multiple sources will use the average from all of those sources.
+     Note: dcrdate provides fiat exchange rates for only BTC and DCR.">
+     Fiat Exchange Rate Sources:
+    <span class="ico-info"></span>
+    </span>
+    {{range $source, $enabled := .FiatRateSources}}
+    <div class="form-check">
+      <input class="form-check-input" type="checkbox" value="{{$source}}" id="{{$source}}" {{if $enabled}} checked {{end}}>
+      <label class="form-check-label" for="{{$source}}">{{$source}}</label>
+    </div>
+    {{end}}
+    </div>
     <div>
       <div id="exchanges" {{if eq (len .UserInfo.Exchanges) 0}} class="d-hide"{{end}}>
         <h5>Registered Dexes:</h5>

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -76,7 +76,7 @@
             <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
             </div>
-             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
             </div>
             {{else}}
               0.00000000

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -71,9 +71,13 @@
             <span class="fs20">{{.Info.Name}}</span>
             <span class="fs15">({{toUpper .Symbol}})</span>
           </td>
-          <td data-balance-target="{{.ID}}">
+         <td>
             {{if .Wallet}}
+            <div data-balance-target="{{.ID}}">
               {{.Info.UnitInfo.ConventionalString .Wallet.Balance.Available}}
+            </div>
+             <div class="d-hide d-flex"><span data-conversion-target={{.ID}}></span>USD</span>
+            </div>
             {{else}}
               0.00000000
             {{end}}
@@ -164,6 +168,7 @@
           <!-- <div class="d-inline">tx fees: <span id="sendFee"></span> <span id="sendUnit"></span>/byte</div> -->
         </div>
       </div>
+      <span class="mt-2 d-hide">~<span id="sendValue" class="mx-1"></span>USD</span>
       <div id="toggleSubtract" class="form-check pt-2">
            <input class="form-check-input" type="checkbox" id="subtractCheckBox">
            <label for="subtractCheckBox" class="form-label ps-1">Subtract fees from amount sent.</label>

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -120,6 +120,8 @@ type clientCore interface {
 	UpdateCert(host string, cert []byte) error
 	UpdateDEXHost(oldHost, newHost string, appPW []byte, certI interface{}) (*core.Exchange, error)
 	WalletRestorationInfo(pw []byte, assetID uint32) ([]*asset.WalletRestoration, error)
+	ToggleRateSourceStatus(src string, disable bool) error
+	FiatRateSources() map[string]bool
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -359,6 +361,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/updatecert", s.apiUpdateCert)
 			apiAuth.Post("/updatedexhost", s.apiUpdateDEXHost)
 			apiAuth.Post("/restorewalletinfo", s.apiRestoreWalletInfo)
+			apiAuth.Post("/toggleratesource", s.apiToggleRateSource)
 		})
 	})
 


### PR DESCRIPTION
This enables the conversion of assets value to fiat equivalent. Configuring fiat conversion is UI only. closes #1579

- [x] Modify wallets page to display fiat value for the asset if fiat price is available.
- [x] Show fiat value for send amount on the send form.
- [x] Show fiat value for order amount on the order confirmation form
- [x] Modify the settings page to display exchange rate sources and configuration options for fiat conversion.

Wallet view
![usddisplaybal](https://user-images.githubusercontent.com/57448127/176272316-45cbabf0-e4da-4d9a-9a36-6c6a11113f86.png)

Market view
![usdmk1](https://user-images.githubusercontent.com/57448127/176272348-05eefc3b-ff0c-4a5c-a6b5-05cc5e4f7855.png)
![usdmk2](https://user-images.githubusercontent.com/57448127/176272357-a6e3db69-1e7e-4961-98a2-1cb1562bf508.png)
![usdmk3](https://user-images.githubusercontent.com/57448127/176272382-965af77c-c2d9-4474-ba72-281729ef2012.png)

Withdraw/Send Form view
![usdwithdrawval](https://user-images.githubusercontent.com/57448127/176272421-06517d9f-99bb-49a6-b3d1-a81e221ec1ef.png)

Exchange rate source settings view
![Screenshot from 2022-06-28 20-07-47](https://user-images.githubusercontent.com/57448127/176272496-87fb4014-3887-45d0-bc73-1185a7f09563.png)
