### PR TITLE
client/testing: Make simnet tests modular.

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -2219,8 +2219,8 @@ func (eth *baseWallet) SyncStatus() (bool, float32, error) {
 	// and after it has finished. In order to discern when syncing has begun,
 	// check that the best header came in under dexeth.MaxBlockInterval.
 	prog := eth.node.syncProgress()
-	syncing := prog.CurrentBlock >= prog.HighestBlock
-	if !syncing {
+	syncing := prog.CurrentBlock < prog.HighestBlock || prog.HighestBlock == 0
+	if syncing {
 		var ratio float32
 		if prog.HighestBlock != 0 {
 			ratio = float32(prog.CurrentBlock) / float32(prog.HighestBlock)

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -407,10 +407,6 @@ func TestCheckForNewBlocks(t *testing.T) {
 }
 
 func TestSyncStatus(t *testing.T) {
-	fourthSyncProg := &ethereum.SyncProgress{
-		CurrentBlock: 25,
-		HighestBlock: 100,
-	}
 	tests := []struct {
 		name                string
 		syncProg            ethereum.SyncProgress
@@ -419,20 +415,35 @@ func TestSyncStatus(t *testing.T) {
 		wantErr, wantSynced bool
 		wantRatio           float32
 	}{{
-		name:       "ok synced",
+		name: "ok synced",
+		syncProg: ethereum.SyncProgress{
+			CurrentBlock: 25,
+			HighestBlock: 25,
+		},
 		wantRatio:  1,
 		wantSynced: true,
 	}, {
-		name:      "ok syncing",
-		syncProg:  *fourthSyncProg,
+		name: "ok syncing",
+		syncProg: ethereum.SyncProgress{
+			CurrentBlock: 25,
+			HighestBlock: 100,
+		},
 		wantRatio: 0.25,
 	}, {
-		name:    "ok header too old",
+		name: "ok header too old",
+		syncProg: ethereum.SyncProgress{
+			CurrentBlock: 25,
+			HighestBlock: 25,
+		},
 		subSecs: dexeth.MaxBlockInterval + 1,
 	}, {
 		name:       "best header error",
 		bestHdrErr: errors.New(""),
-		wantErr:    true,
+		syncProg: ethereum.SyncProgress{
+			CurrentBlock: 25,
+			HighestBlock: 25,
+		},
+		wantErr: true,
 	}}
 
 	for _, test := range tests {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -52,7 +52,7 @@ go test "${dumptags[@]}" harness ./client/asset/btc/livetest
 go test "${dumptags[@]}" harness ./client/asset/ltc
 go test "${dumptags[@]}" harness ./client/asset/bch
 go test "${dumptags[@]}" harness,lgpl ./client/asset/eth
-go test "${dumptags[@]}" harness ./client/core
+go test "${dumptags[@]}" harness,lgpl ./client/core
 go test "${dumptags[@]}" dcrlive ./server/asset/dcr
 go test "${dumptags[@]}" btclive ./server/asset/btc
 go test "${dumptags[@]}" ltclive ./server/asset/ltc


### PR DESCRIPTION
    client/testing: Make simnet tests modular.
    
    Change the simnet harness tests to work with all currently supported
    assets.

    testing/doge: Add delta and gamma nodes.
    
    Because doge does not distinguish between different wallets, it is
    difficult to test balance changes when testing, especially if the node
    is mining. Add two wallets that don't do anything special to use in
    tests.

part of #1565

edit: Not sure if it closes the issue because it also mentions loadbot. Removed the closing phrase.