### PR TITLE
client: Update server host

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -362,7 +362,7 @@ type TDB struct {
 	verifyCreateAccount      bool
 	verifyUpdateAccountInfo  bool
 	accountProofPersisted    *db.AccountProof
-	disabledAcct             *db.AccountInfo
+	disabledHost             *string
 	disableAccountErr        error
 	creds                    *db.PrimaryCredentials
 	setCredsErr              error
@@ -394,8 +394,7 @@ func (tdb *TDB) CreateAccount(ai *db.AccountInfo) error {
 }
 
 func (tdb *TDB) DisableAccount(url string) error {
-	acct, _ := tdb.Account(url)
-	tdb.disabledAcct = acct
+	tdb.disabledHost = &url
 	return tdb.disableAccountErr
 }
 

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1609,6 +1609,9 @@ func (c *TCore) RecoverWallet(uint32, []byte, bool) error {
 func (c *TCore) UpdateCert(string, []byte) error {
 	return nil
 }
+func (c *TCore) UpdateDEXHost(string, string, []byte, interface{}) (*core.Exchange, error) {
+	return nil, nil
+}
 
 func TestServer(t *testing.T) {
 	// Register dummy drivers for unimplemented assets.

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -236,4 +236,5 @@ var EnUS = map[string]string{
 	"Update TLS Certificate":      "Update TLS Certificate",
 	"registered dexes":            "Registered Dexes:",
 	"successful_cert_update":      "Successfully updated certificate!",
+	"update dex host":             "Update DEX Host",
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=tVlMrZC" rel="stylesheet">
+  <link href="/css/style.css?v=h877Tgq" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=tVlMrZC"></script>
+<script src="/js/entry.js?v=h877Tgq"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/dexsettings.tmpl
+++ b/client/webserver/site/src/html/dexsettings.tmpl
@@ -6,8 +6,8 @@
   <div class="flex-center fs28 text-break">{{.Exchange.Host}}</div>
   <div class="flex-center fs16 mb-2">
     <span class="me-2 connection ico-connection d-hide" id="connectedIcon"></span>
-    <span class="disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
-    <h4 id="connectionStatus"></h4>
+    <span class="me-2 disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
+    <span id="connectionStatus"></span>
   </div>
   <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="errMsg"></div>
   <div class="settings">
@@ -22,6 +22,9 @@
       <button id="updateCertBtn" class="bg2 selected">[[[Update TLS Certificate]]]</button>
       <span class="update-cert-msg mx-2 d-hide" id="updateCertMsg">[[[successful_cert_update]]]</span>
     </div>
+    <div>
+      <button id="updateHostBtn" class="bg2 selected">[[[update dex host]]]</button>
+    </div>
   </div>
 
   <div id="forms" class="d-hide">
@@ -33,6 +36,11 @@
     {{- /* AUTHORIZE EXPORT ACCOUNT */ -}}
     <form class="d-hide" id="authorizeAccountExportForm">
       {{template "authorizeAccountExportForm"}}
+    </form>
+
+    {{- /* DEX ADDRESS */ -}}
+    <form class="d-hide" id="dexAddrForm" autocomplete="off">
+      {{template "dexAddrForm" .}}
     </form>
   </div>
 

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -101,21 +101,23 @@
 
 {{define "dexAddrForm"}}
 <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-<div class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> [[[Add a DEX]]]</div>
-<div class="fs20 sans-light">[[[Pick a server]]]</div>
+<div data-tmpl="addDexHdr" class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> [[[Add a DEX]]]</div>
+<div data-tmpl="updateDexHdr" class="flex-center fs24 sans-light d-hide"></span> [[[update dex host]]]</div>
+<div class="fs20 sans-light" data-tmpl="pickServerMsg">[[[Pick a server]]]</div>
 <div class="d-flex flex-column align-items-stretch mt-1" data-tmpl="knownXCs">
   {{range .KnownExchanges}}
     <div class="known-exchange" data-host="{{.}}"><img class="micro-icon me-1" src={{dummyExchangeLogo .}}> {{.}}</div>
   {{end}}
 </div>
-<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center" data-tmpl="showCustom">
+<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center {{if eq (len .KnownExchanges) 0}}d-hide{{end}}"
+  data-tmpl="showCustom">
   <span class="ico-plus fs11"></span>
   <div class="ps-2">[[[add a different server]]]</div>
 </div>
 
-<div data-tmpl="customBox" class="d-hide">
+<div data-tmpl="customBox">
   <hr class="dashed my-2">
-  <div class="fs20 sans-light">[[[Add a custom server]]]</div>
+  <div class="fs20 sans-light" data-tmpl="addCustomMsg">[[[Add a custom server]]]</div>
   <div>
     <label for="dexAddr" class="form-label ps-1 mt-2">[[[DEX Address]]]</label>
     <input type="text" class="form-control select" data-tmpl="addr" id="dexAddr">

--- a/client/webserver/site/src/js/dexsettings.ts
+++ b/client/webserver/site/src/js/dexsettings.ts
@@ -7,7 +7,8 @@ import * as forms from './forms'
 import {
   app,
   PageElement,
-  ConnectionStatus
+  ConnectionStatus,
+  Exchange
 } from './registry'
 
 const animationLength = 300
@@ -19,6 +20,7 @@ export default class DexSettingsPage extends BasePage {
   page: Record<string, PageElement>
   host: string
   keyup: (e: KeyboardEvent) => void
+  dexAddrForm: forms.DEXAddressForm
 
   constructor (body: HTMLElement) {
     super()
@@ -30,7 +32,12 @@ export default class DexSettingsPage extends BasePage {
     Doc.bind(page.exportDexBtn, 'click', () => this.prepareAccountExport(page.authorizeAccountExportForm))
     Doc.bind(page.disableAcctBtn, 'click', () => this.prepareAccountDisable(page.disableAccountForm))
     Doc.bind(page.updateCertBtn, 'click', () => page.certFileInput.click())
+    Doc.bind(page.updateHostBtn, 'click', () => this.prepareUpdateHost())
     Doc.bind(page.certFileInput, 'change', () => this.onCertFileChange())
+
+    this.dexAddrForm = new forms.DEXAddressForm(page.dexAddrForm, async (xc: Exchange) => {
+      window.location.assign(`/dexsettings/${xc.host}`)
+    }, undefined, this.host)
 
     forms.bind(page.authorizeAccountExportForm, page.authorizeExportAccountConfirm, () => this.exportAccount())
     forms.bind(page.disableAccountForm, page.disableAccountConfirm, () => this.disableAccount())
@@ -139,6 +146,12 @@ export default class DexSettingsPage extends BasePage {
     page.disableAccountHost.textContent = this.host
     page.disableAccountErr.textContent = ''
     this.showForm(disableAccountForm)
+  }
+
+  async prepareUpdateHost () {
+    const page = this.page
+    this.dexAddrForm.refresh()
+    this.showForm(page.dexAddrForm)
   }
 
   async onCertFileChange () {

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=tVlMrZC" rel="stylesheet">
+  <link href="/css/style.css?v=h877Tgq" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=tVlMrZC"></script>
+<script src="/js/entry.js?v=h877Tgq"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/en-US/dexsettings.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/dexsettings.tmpl
@@ -6,8 +6,8 @@
   <div class="flex-center fs28 text-break">{{.Exchange.Host}}</div>
   <div class="flex-center fs16 mb-2">
     <span class="me-2 connection ico-connection d-hide" id="connectedIcon"></span>
-    <span class="disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
-    <h4 id="connectionStatus"></h4>
+    <span class="me-2 disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
+    <span id="connectionStatus"></span>
   </div>
   <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="errMsg"></div>
   <div class="settings">
@@ -22,6 +22,9 @@
       <button id="updateCertBtn" class="bg2 selected">Update TLS Certificate</button>
       <span class="update-cert-msg mx-2 d-hide" id="updateCertMsg">Successfully updated certificate!</span>
     </div>
+    <div>
+      <button id="updateHostBtn" class="bg2 selected">Update DEX Host</button>
+    </div>
   </div>
 
   <div id="forms" class="d-hide">
@@ -33,6 +36,11 @@
     {{- /* AUTHORIZE EXPORT ACCOUNT */ -}}
     <form class="d-hide" id="authorizeAccountExportForm">
       {{template "authorizeAccountExportForm"}}
+    </form>
+
+    {{- /* DEX ADDRESS */ -}}
+    <form class="d-hide" id="dexAddrForm" autocomplete="off">
+      {{template "dexAddrForm" .}}
     </form>
   </div>
 

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -101,21 +101,23 @@
 
 {{define "dexAddrForm"}}
 <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-<div class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> Add a DEX</div>
-<div class="fs20 sans-light">Pick a server</div>
+<div data-tmpl="addDexHdr" class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> Add a DEX</div>
+<div data-tmpl="updateDexHdr" class="flex-center fs24 sans-light d-hide"></span> Update DEX Host</div>
+<div class="fs20 sans-light" data-tmpl="pickServerMsg">Pick a server</div>
 <div class="d-flex flex-column align-items-stretch mt-1" data-tmpl="knownXCs">
   {{range .KnownExchanges}}
     <div class="known-exchange" data-host="{{.}}"><img class="micro-icon me-1" src={{dummyExchangeLogo .}}> {{.}}</div>
   {{end}}
 </div>
-<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center" data-tmpl="showCustom">
+<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center {{if eq (len .KnownExchanges) 0}}d-hide{{end}}"
+  data-tmpl="showCustom">
   <span class="ico-plus fs11"></span>
   <div class="ps-2">add a different server</div>
 </div>
 
-<div data-tmpl="customBox" class="d-hide">
+<div data-tmpl="customBox">
   <hr class="dashed my-2">
-  <div class="fs20 sans-light">Add a custom server</div>
+  <div class="fs20 sans-light" data-tmpl="addCustomMsg">Add a custom server</div>
   <div>
     <label for="dexAddr" class="form-label ps-1 mt-2">DEX Address</label>
     <input type="text" class="form-control select" data-tmpl="addr" id="dexAddr">

--- a/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=tVlMrZC" rel="stylesheet">
+  <link href="/css/style.css?v=h877Tgq" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=tVlMrZC"></script>
+<script src="/js/entry.js?v=h877Tgq"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/dexsettings.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/dexsettings.tmpl
@@ -6,8 +6,8 @@
   <div class="flex-center fs28 text-break">{{.Exchange.Host}}</div>
   <div class="flex-center fs16 mb-2">
     <span class="me-2 connection ico-connection d-hide" id="connectedIcon"></span>
-    <span class="disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
-    <h4 id="connectionStatus"></h4>
+    <span class="me-2 disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
+    <span id="connectionStatus"></span>
   </div>
   <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="errMsg"></div>
   <div class="settings">
@@ -22,6 +22,9 @@
       <button id="updateCertBtn" class="bg2 selected">Update TLS Certificate</button>
       <span class="update-cert-msg mx-2 d-hide" id="updateCertMsg">Successfully updated certificate!</span>
     </div>
+    <div>
+      <button id="updateHostBtn" class="bg2 selected">Update DEX Host</button>
+    </div>
   </div>
 
   <div id="forms" class="d-hide">
@@ -33,6 +36,11 @@
     {{- /* AUTHORIZE EXPORT ACCOUNT */ -}}
     <form class="d-hide" id="authorizeAccountExportForm">
       {{template "authorizeAccountExportForm"}}
+    </form>
+
+    {{- /* DEX ADDRESS */ -}}
+    <form class="d-hide" id="dexAddrForm" autocomplete="off">
+      {{template "dexAddrForm" .}}
     </form>
   </div>
 

--- a/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
@@ -101,21 +101,23 @@
 
 {{define "dexAddrForm"}}
 <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-<div class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> Dodaj DEX</div>
-<div class="fs20 sans-light">Pick a server</div>
+<div data-tmpl="addDexHdr" class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> Dodaj DEX</div>
+<div data-tmpl="updateDexHdr" class="flex-center fs24 sans-light d-hide"></span> Update DEX Host</div>
+<div class="fs20 sans-light" data-tmpl="pickServerMsg">Pick a server</div>
 <div class="d-flex flex-column align-items-stretch mt-1" data-tmpl="knownXCs">
   {{range .KnownExchanges}}
     <div class="known-exchange" data-host="{{.}}"><img class="micro-icon me-1" src={{dummyExchangeLogo .}}> {{.}}</div>
   {{end}}
 </div>
-<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center" data-tmpl="showCustom">
+<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center {{if eq (len .KnownExchanges) 0}}d-hide{{end}}"
+  data-tmpl="showCustom">
   <span class="ico-plus fs11"></span>
   <div class="ps-2">dodaj inny serwer</div>
 </div>
 
-<div data-tmpl="customBox" class="d-hide">
+<div data-tmpl="customBox">
   <hr class="dashed my-2">
-  <div class="fs20 sans-light">Dodaj niestandardowy serwer</div>
+  <div class="fs20 sans-light" data-tmpl="addCustomMsg">Dodaj niestandardowy serwer</div>
   <div>
     <label for="dexAddr" class="form-label ps-1 mt-2">Adres DEX</label>
     <input type="text" class="form-control select" data-tmpl="addr" id="dexAddr">

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=tVlMrZC" rel="stylesheet">
+  <link href="/css/style.css?v=h877Tgq" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=tVlMrZC"></script>
+<script src="/js/entry.js?v=h877Tgq"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/dexsettings.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/dexsettings.tmpl
@@ -6,8 +6,8 @@
   <div class="flex-center fs28 text-break">{{.Exchange.Host}}</div>
   <div class="flex-center fs16 mb-2">
     <span class="me-2 connection ico-connection d-hide" id="connectedIcon"></span>
-    <span class="disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
-    <h4 id="connectionStatus"></h4>
+    <span class="me-2 disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
+    <span id="connectionStatus"></span>
   </div>
   <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="errMsg"></div>
   <div class="settings">
@@ -22,6 +22,9 @@
       <button id="updateCertBtn" class="bg2 selected">Update TLS Certificate</button>
       <span class="update-cert-msg mx-2 d-hide" id="updateCertMsg">Successfully updated certificate!</span>
     </div>
+    <div>
+      <button id="updateHostBtn" class="bg2 selected">Update DEX Host</button>
+    </div>
   </div>
 
   <div id="forms" class="d-hide">
@@ -33,6 +36,11 @@
     {{- /* AUTHORIZE EXPORT ACCOUNT */ -}}
     <form class="d-hide" id="authorizeAccountExportForm">
       {{template "authorizeAccountExportForm"}}
+    </form>
+
+    {{- /* DEX ADDRESS */ -}}
+    <form class="d-hide" id="dexAddrForm" autocomplete="off">
+      {{template "dexAddrForm" .}}
     </form>
   </div>
 

--- a/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
@@ -101,21 +101,23 @@
 
 {{define "dexAddrForm"}}
 <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-<div class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> Adicionar uma DEX</div>
-<div class="fs20 sans-light">Pick a server</div>
+<div data-tmpl="addDexHdr" class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> Adicionar uma DEX</div>
+<div data-tmpl="updateDexHdr" class="flex-center fs24 sans-light d-hide"></span> Update DEX Host</div>
+<div class="fs20 sans-light" data-tmpl="pickServerMsg">Pick a server</div>
 <div class="d-flex flex-column align-items-stretch mt-1" data-tmpl="knownXCs">
   {{range .KnownExchanges}}
     <div class="known-exchange" data-host="{{.}}"><img class="micro-icon me-1" src={{dummyExchangeLogo .}}> {{.}}</div>
   {{end}}
 </div>
-<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center" data-tmpl="showCustom">
+<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center {{if eq (len .KnownExchanges) 0}}d-hide{{end}}"
+  data-tmpl="showCustom">
   <span class="ico-plus fs11"></span>
   <div class="ps-2">Adicionar um servidor diferente</div>
 </div>
 
-<div data-tmpl="customBox" class="d-hide">
+<div data-tmpl="customBox">
   <hr class="dashed my-2">
-  <div class="fs20 sans-light">Adicionar um servidor personalizado</div>
+  <div class="fs20 sans-light" data-tmpl="addCustomMsg">Adicionar um servidor personalizado</div>
   <div>
     <label for="dexAddr" class="form-label ps-1 mt-2">Endereço DEX</label>
     <input type="text" class="form-control select" data-tmpl="addr" id="dexAddr">

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=tVlMrZC" rel="stylesheet">
+  <link href="/css/style.css?v=h877Tgq" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=tVlMrZC"></script>
+<script src="/js/entry.js?v=h877Tgq"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/dexsettings.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/dexsettings.tmpl
@@ -6,8 +6,8 @@
   <div class="flex-center fs28 text-break">{{.Exchange.Host}}</div>
   <div class="flex-center fs16 mb-2">
     <span class="me-2 connection ico-connection d-hide" id="connectedIcon"></span>
-    <span class="disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
-    <h4 id="connectionStatus"></h4>
+    <span class="me-2 disconnected ico-disconnected d-hide" id="disconnectedIcon"></span>
+    <span id="connectionStatus"></span>
   </div>
   <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="errMsg"></div>
   <div class="settings">
@@ -22,6 +22,9 @@
       <button id="updateCertBtn" class="bg2 selected">Update TLS Certificate</button>
       <span class="update-cert-msg mx-2 d-hide" id="updateCertMsg">Successfully updated certificate!</span>
     </div>
+    <div>
+      <button id="updateHostBtn" class="bg2 selected">Update DEX Host</button>
+    </div>
   </div>
 
   <div id="forms" class="d-hide">
@@ -33,6 +36,11 @@
     {{- /* AUTHORIZE EXPORT ACCOUNT */ -}}
     <form class="d-hide" id="authorizeAccountExportForm">
       {{template "authorizeAccountExportForm"}}
+    </form>
+
+    {{- /* DEX ADDRESS */ -}}
+    <form class="d-hide" id="dexAddrForm" autocomplete="off">
+      {{template "dexAddrForm" .}}
     </form>
   </div>
 

--- a/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
@@ -101,21 +101,23 @@
 
 {{define "dexAddrForm"}}
 <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-<div class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> 添加一个 DEX</div>
-<div class="fs20 sans-light">Pick a server</div>
+<div data-tmpl="addDexHdr" class="flex-center fs24 sans-light"><span class="ico-plus fs12 me-2"></span> 添加一个 DEX</div>
+<div data-tmpl="updateDexHdr" class="flex-center fs24 sans-light d-hide"></span> Update DEX Host</div>
+<div class="fs20 sans-light" data-tmpl="pickServerMsg">Pick a server</div>
 <div class="d-flex flex-column align-items-stretch mt-1" data-tmpl="knownXCs">
   {{range .KnownExchanges}}
     <div class="known-exchange" data-host="{{.}}"><img class="micro-icon me-1" src={{dummyExchangeLogo .}}> {{.}}</div>
   {{end}}
 </div>
-<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center" data-tmpl="showCustom">
+<div class="px-1 mt-3 fs14 pointer d-flex justify-content-start align-items-center {{if eq (len .KnownExchanges) 0}}d-hide{{end}}"
+  data-tmpl="showCustom">
   <span class="ico-plus fs11"></span>
   <div class="ps-2">add a different server</div>
 </div>
 
-<div data-tmpl="customBox" class="d-hide">
+<div data-tmpl="customBox">
   <hr class="dashed my-2">
-  <div class="fs20 sans-light">Add a custom server</div>
+  <div class="fs20 sans-light" data-tmpl="addCustomMsg">Add a custom server</div>
   <div>
     <label for="dexAddr" class="form-label ps-1 mt-2">DEX 地址</label>
     <input type="text" class="form-control select" data-tmpl="addr" id="dexAddr">

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -118,6 +118,7 @@ type clientCore interface {
 	AccelerateOrder(pw []byte, oidB dex.Bytes, newFeeRate uint64) (string, error)
 	AccelerationEstimate(oidB dex.Bytes, newFeeRate uint64) (uint64, error)
 	UpdateCert(host string, cert []byte) error
+	UpdateDEXHost(oldHost, newHost string, appPW []byte, certI interface{}) (*core.Exchange, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -354,6 +355,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/preaccelerate", s.apiPreAccelerate)
 			apiAuth.Post("/accelerationestimate", s.apiAccelerationEstimate)
 			apiAuth.Post("/updatecert", s.apiUpdateCert)
+			apiAuth.Post("/updatedexhost", s.apiUpdateDEXHost)
 		})
 	})
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -192,6 +192,9 @@ func (c *TCore) RecoverWallet(uint32, []byte, bool) error {
 func (c *TCore) UpdateCert(string, []byte) error {
 	return nil
 }
+func (c *TCore) UpdateDEXHost(string, string, []byte, interface{}) (*core.Exchange, error) {
+	return nil, nil
+}
 
 type TWriter struct {
 	b []byte

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -32,7 +32,7 @@ func mainCore(ctx context.Context) error {
 	// Parse the configuration file, and setup logger.
 	cfg, opts, err := loadConfig()
 	if err != nil {
-		fmt.Printf("Failed to load dcrdata config: %s\n", err.Error())
+		fmt.Printf("Failed to load dcrdex config: %s\n", err.Error())
 		return err
 	}
 	defer func() {


### PR DESCRIPTION
DEX servers are able to advertise on multiple host names. This update gives users of the dex client the ability to switch between the different host names of the same dex.

- client/core: Add `UpdateDexHost` method which takes
  a current dex host and a new host name, and if the dex
  at both host names use the same dex pub key, the host
  name is updated. Also, adding a dex with the same pub
  key as a dex which is already registered is now blocked.

- ui: Adds a button on the dex settings page to allow updating
  the dex host. The DEXAddressForm is reused for this purpose.
  The DEXAddressPopup is also updated to not show known
  exchanges that the user is already registered for.