### PR TITLE
dex,client: restore dex reconnect loop

### DIFF
--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -233,8 +233,10 @@ func (w *xcWallet) connected() bool {
 // flag to true, and validates the deposit address. Use Disconnect to cleanly
 // shutdown the wallet.
 func (w *xcWallet) Connect() error {
-	// No parent context; use Disconnect instead.
-	err := w.connector.Connect(context.Background())
+	// No parent context; use Disconnect instead. Also note that there's no
+	// reconnect loop for wallet like with the server Connectors, so we use
+	// ConnectOnce so that the ConnectionMaster's On method will report false.
+	err := w.connector.ConnectOnce(context.Background())
 	if err != nil {
 		return err
 	}

--- a/client/websocket/websocket.go
+++ b/client/websocket/websocket.go
@@ -138,10 +138,10 @@ func (s *Server) connect(ctx context.Context, conn ws.Connection, addr string) {
 	// sending before it is connected.
 	s.clientsMtx.Lock()
 	cm := dex.NewConnectionMaster(cl)
-	err := cm.Connect(ctx)
+	err := cm.ConnectOnce(ctx) // we discard the cm anyway, but good practice
 	if err != nil {
 		s.clientsMtx.Unlock()
-		s.log.Errorf("websocketHandler client Connect: %v")
+		s.log.Errorf("websocketHandler client connect: %v", err)
 		return
 	}
 

--- a/server/comms/server.go
+++ b/server/comms/server.go
@@ -713,11 +713,14 @@ func (s *Server) disconnectClients() {
 func (s *Server) addClient(ctx context.Context, client *wsLink) (*dex.ConnectionMaster, error) {
 	s.clientMtx.Lock()
 	defer s.clientMtx.Unlock()
+	cm := dex.NewConnectionMaster(client)
+	if err := cm.ConnectOnce(ctx); err != nil {
+		return nil, err
+	}
 	client.id = s.counter
 	s.counter++
 	s.clients[client.id] = client
-	cm := dex.NewConnectionMaster(client)
-	return cm, cm.Connect(ctx)
+	return cm, nil
 }
 
 // Remove the client from the map.


### PR DESCRIPTION
This reverts e8fd8acab23fbb253b649a66a95a5a63d4be6b75, which broke the
reconnect loop that the dex.Connector implemented by
client/comms.(*wsConn) starts.

This also adds a call to Disconnect when the connector for a client
wallet returns a non-nil error so that the ConnectionMaster's On method
does not say true, which is what e8fd8ac had aimed to resolve.