### PR TITLE
dex/encode: allow data longer than 65535 bytes

### DIFF
--- a/dex/encode/encode_test.go
+++ b/dex/encode/encode_test.go
@@ -46,7 +46,17 @@ func TestBuildyBytes(t *testing.T) {
 }
 
 func TestDecodeBlob(t *testing.T) {
+	almostLongBlob := RandomBytes(254)
 	longBlob := RandomBytes(255)
+	longBlob2 := RandomBytes(555)
+	longestUint16Blob := RandomBytes(65535)
+	longerBlob := RandomBytes(65536)
+	longerBlob2 := RandomBytes(65599)
+	megaBlob := RandomBytes(12_345_678)
+	almostLargestBlob := RandomBytes(maxDataLen - 1)
+	largestBlob := RandomBytes(maxDataLen)
+	// tooLargeBlob tested after the loop, recovering the expected panic
+
 	type test struct {
 		v       byte
 		b       []byte
@@ -65,9 +75,49 @@ func TestDecodeBlob(t *testing.T) {
 			exp: [][]byte{tB, tC},
 		},
 		{
+			v:   250,
+			b:   BuildyBytes{250}.AddData(tA).AddData(almostLongBlob),
+			exp: [][]byte{tA, almostLongBlob},
+		},
+		{
 			v:   255,
 			b:   BuildyBytes{255}.AddData(tA).AddData(longBlob),
 			exp: [][]byte{tA, longBlob},
+		},
+		{
+			v:   255,
+			b:   BuildyBytes{255}.AddData(tA).AddData(longBlob2),
+			exp: [][]byte{tA, longBlob2},
+		},
+		{
+			v:   255,
+			b:   BuildyBytes{255}.AddData(tA).AddData(longestUint16Blob),
+			exp: [][]byte{tA, longestUint16Blob},
+		},
+		{
+			v:   255,
+			b:   BuildyBytes{255}.AddData(tA).AddData(longerBlob),
+			exp: [][]byte{tA, longerBlob},
+		},
+		{
+			v:   255,
+			b:   BuildyBytes{255}.AddData(tA).AddData(longerBlob2),
+			exp: [][]byte{tA, longerBlob2},
+		},
+		{
+			v:   255,
+			b:   BuildyBytes{255}.AddData(tA).AddData(megaBlob),
+			exp: [][]byte{tA, megaBlob},
+		},
+		{
+			v:   255,
+			b:   BuildyBytes{255}.AddData(tA).AddData(almostLargestBlob),
+			exp: [][]byte{tA, almostLargestBlob},
+		},
+		{
+			v:   255,
+			b:   BuildyBytes{255}.AddData(tA).AddData(largestBlob),
+			exp: [][]byte{tA, largestBlob},
 		},
 		{
 			b:       []byte{0x01, 0x02}, // missing two bytes
@@ -95,4 +145,14 @@ func TestDecodeBlob(t *testing.T) {
 			}
 		}
 	}
+
+	tooLargeBlob := RandomBytes(maxDataLen + 1)
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("no panic encoding data that's too large")
+			}
+		}()
+		BuildyBytes{255}.AddData(tA).AddData(tooLargeBlob)
+	}()
 }

--- a/dex/encode/encode_test.go
+++ b/dex/encode/encode_test.go
@@ -1,10 +1,12 @@
 package encode
 
 import (
+	"bytes"
 	"testing"
 )
 
 var (
+	bEqual = bytes.Equal
 	tEmpty = []byte{}
 	tA     = []byte{0xaa}
 	tB     = []byte{0xbb, 0xbb}
@@ -53,8 +55,8 @@ func TestDecodeBlob(t *testing.T) {
 	longerBlob := RandomBytes(65536)
 	longerBlob2 := RandomBytes(65599)
 	megaBlob := RandomBytes(12_345_678)
-	almostLargestBlob := RandomBytes(maxDataLen - 1)
-	largestBlob := RandomBytes(maxDataLen)
+	almostLargestBlob := RandomBytes(MaxDataLen - 1)
+	largestBlob := RandomBytes(MaxDataLen)
 	// tooLargeBlob tested after the loop, recovering the expected panic
 
 	type test struct {
@@ -146,7 +148,7 @@ func TestDecodeBlob(t *testing.T) {
 		}
 	}
 
-	tooLargeBlob := RandomBytes(maxDataLen + 1)
+	tooLargeBlob := RandomBytes(MaxDataLen + 1)
 	func() {
 		defer func() {
 			if r := recover(); r == nil {


### PR DESCRIPTION
Relating to the issue hit in https://github.com/decred/dcrdex/issues/1105#issuecomment-1128595137, where the counter tx data was too large on account of the tx having many funding coins.

```
Retrofit the blob encoding and decoding to allow byte slices up to
0x00fe_ffff (16711679) long.  The decoding scheme detects a uint32
length when the top two bytes decoded as big endian uint16 indicate a
value less than 255.
```

This is a bit of a cludge, but it seems to be working, so I figure we could discuss it.