### PR TITLE
server/swap: metered block-triggered conf and penalty checks

### DIFF
--- a/dex/meter/meterer.go
+++ b/dex/meter/meterer.go
@@ -1,0 +1,66 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package meter
+
+import (
+	"context"
+	"time"
+)
+
+// DelayedRelay creates a simple error signal pipeline that delays and
+// aggregates the relaying of nil errors. Non-nil errors received on the in
+// channel are immediately send on the out channel without delay. If a nil error
+// arrives within minDelay of the previous one, it will be scheduled for later
+// to respect the configured delay. If multiple arrive within minDelay, they
+// will be grouped into a single delayed signal.
+func DelayedRelay(ctx context.Context, minDelay time.Duration, n int) (out <-chan error, in chan<- error) {
+	inC := make(chan error, n)
+	outC := make(chan error, n)
+
+	go func() {
+		defer close(outC) // signal shutdown to the consumer
+
+		var last time.Time
+		var scheduled *time.Timer
+		now := make(chan struct{})
+
+		for {
+			select {
+			case err := <-inC:
+				if err != nil {
+					outC <- err
+					continue
+				}
+
+				if scheduled != nil {
+					continue
+				}
+
+				if time.Since(last) > minDelay {
+					outC <- nil
+					last = time.Now().UTC()
+					continue
+				}
+
+				delay := time.Until(last.Add(minDelay))
+				scheduled = time.AfterFunc(delay, func() {
+					now <- struct{}{}
+				})
+
+			case <-now:
+				outC <- nil
+				scheduled = nil
+				last = time.Now().UTC()
+
+			case <-ctx.Done():
+				if scheduled != nil && !scheduled.Stop() {
+					<-scheduled.C
+				}
+				return
+			}
+		}
+	}()
+
+	return outC, inC
+}

--- a/dex/meter/meterer_test.go
+++ b/dex/meter/meterer_test.go
@@ -1,0 +1,70 @@
+package meter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDelayedRelay(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	minDelay := time.Millisecond * 20
+	out, in := DelayedRelay(ctx, minDelay, 4)
+	defer func() { <-out }() // wait for channel close (relay shutdown)
+	defer cancel()
+
+	times := make([]time.Time, 0)
+
+	countSignals := func() (n int) {
+		for {
+			select {
+			case <-out:
+				times = append(times, time.Now())
+				n++
+			case <-time.After(minDelay * 2):
+				return
+			}
+		}
+	}
+
+	lastDelay := func() time.Duration {
+		return times[len(times)-1].Sub(times[len(times)-2])
+	}
+
+	sendSignals := func(n int, err error) {
+		for i := 0; i < n; i++ {
+			in <- err
+		}
+	}
+
+	go sendSignals(1, nil)
+	if n := countSignals(); n != 1 {
+		t.Fatalf("wrong signal count. expected 1, got %d", n)
+	}
+
+	// Sending two signals simultaneously should end up with two signals, at
+	// least minDelay apart.
+	go sendSignals(2, nil)
+	if n := countSignals(); n != 2 {
+		t.Fatalf("wrong signal count. expected 2, got %d", n)
+	}
+	if d := lastDelay(); d < minDelay {
+		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelay)
+	}
+
+	// Should get the same exact result for 3 or more simultaneous signals.
+	go sendSignals(5, nil)
+	if n := countSignals(); n != 2 {
+		t.Fatalf("wrong signal count. expected reduction to 2, got %d", n)
+	}
+	if d := lastDelay(); d < minDelay {
+		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelay)
+	}
+
+	// Errors should go right through.
+	go sendSignals(10, errors.New(""))
+	if n := countSignals(); n != 10 {
+		t.Fatalf("wrong signal count. expected 10 errors, got %d", n)
+	}
+}

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -50,8 +50,9 @@ var (
 		0x90, 0xbc, 0xbd, 0xda, 0x5a, 0x76, 0xf9, 0x1e, 0x60, 0xa1, 0x56, 0x99,
 		0x46, 0x34, 0xe9, 0x1c, 0xaa, 0xaa, 0xaa, 0xaa,
 	}
-	acctCounter uint32
-	dexPrivKey  *secp256k1.PrivateKey
+	acctCounter   uint32
+	dexPrivKey    *secp256k1.PrivateKey
+	tBcastTimeout time.Duration
 )
 
 type tUser struct {
@@ -605,7 +606,7 @@ func tNewTestRig(matchInfo *tMatch) (*testRig, func()) {
 		},
 		Storage:          storage,
 		AuthManager:      authMgr,
-		BroadcastTimeout: txWaitExpiration * 5,
+		BroadcastTimeout: tBcastTimeout,
 		LockTimeTaker:    dex.LockTimeTaker(dex.Testnet),
 		LockTimeMaker:    dex.LockTimeMaker(dex.Testnet),
 		SwapDone:         func(ord order.Order, match *order.Match, fail bool) {},
@@ -1414,6 +1415,8 @@ func TestMain(m *testing.M) {
 	fastRecheckInterval = time.Millisecond * 40
 	taperedRecheckInterval = time.Millisecond * 40
 	txWaitExpiration = time.Millisecond * 200
+	tBcastTimeout = txWaitExpiration * 5
+	minBlockPeriod = tBcastTimeout / 3
 	logger := dex.StdOutLogger("TEST", dex.LevelTrace)
 	UseLogger(logger)
 	db.UseLogger(logger)


### PR DESCRIPTION
```
Ethereum has very short block times. And just for conservation of
resources, tightly-grouped blocks need not trigger tightly-grouped
conf and penalty checks. This adds a minimum delay window to block
notifications. If blocks comes farther than the minimum delay apart,
nothing changes from the current behavior. If 1 or more blocks
arrives within the delay window of another, they will be collected into a
single block notification that occurs once the min delay has passed.

The newly implemented SignalMeterer is only used in the swapper for
block notifications for now, but might also be useful for the client.
```