### PR TITLE
client/eth: Fix SyncStatus.

### DIFF
--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -433,7 +433,7 @@ func TestSyncStatus(t *testing.T) {
 		name: "ok header too old",
 		syncProg: ethereum.SyncProgress{
 			CurrentBlock: 25,
-			HighestBlock: 25,
+			HighestBlock: 0,
 		},
 		subSecs: dexeth.MaxBlockInterval + 1,
 	}, {
@@ -441,7 +441,7 @@ func TestSyncStatus(t *testing.T) {
 		bestHdrErr: errors.New(""),
 		syncProg: ethereum.SyncProgress{
 			CurrentBlock: 25,
-			HighestBlock: 25,
+			HighestBlock: 0,
 		},
 		wantErr: true,
 	}}

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -573,8 +573,7 @@ func syncClient(cl *nodeClient) error {
 		}
 		prog := cl.syncProgress()
 		if isTestnet {
-			syncing := prog.CurrentBlock != prog.HighestBlock || prog.HighestBlock == 0
-			if !syncing {
+			if prog.HighestBlock == 0 {
 				bh, err := cl.bestHeader(ctx)
 				if err != nil {
 					return err
@@ -584,8 +583,13 @@ func syncClient(cl *nodeClient) error {
 				if timeDiff < dexeth.MaxBlockInterval {
 					return nil
 				}
+			} else if prog.CurrentBlock >= prog.HighestBlock {
+				return nil
 			}
 		} else {
+			// If client has ever synced, assume synced with
+			// harness. This avoids checking the header time which
+			// is probably old.
 			if prog.CurrentBlock > 20 {
 				return nil
 			}


### PR DESCRIPTION
    The HighestBlock returned from syncProgress is only set if geth has been
    through a syncing state. If it is not zero we can determine if sync has
    started and finished. If zero, make a best guess based on the time in
    the best header we know of.

closes #1628

Hopefully this is the nail in the coffin of this syncing issue. Here is the code concerned in geth: https://github.com/ethereum/go-ethereum/blob/be9742721f56eb8bb7ebf4f6a03fb01b13a05408/les/fetcher.go#L327-L342

So, if that block does not happen, the HighestBlock does not change. If it's starting up and zero, it stays zero. When the syncing phase is done it also doesn't change. That block of code does not happen unless the chain is more than one block ahead or the server indicates a reorg. Our harness will mine two blocks at once, so we always get the syncing state if we mine at all. Otherwise if we shut the node off then back on without advancing the chain, we would get a hang where HighestBlock is always zero. This would also affect users on mainnet presently, if they shut dexc down and start it up rather quickly, before two blocks were mined on eth. Fortunately noone is using on mainnet.