### PR TITLE
ui: prevent missing SupportedAsset error in setOrderBttnText

### DIFF
--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -645,8 +645,8 @@ export default class MarketsPage extends BasePage {
 
   setOrderBttnText () {
     if (this.isSell()) {
-      this.page.submitBttn.textContent = intl.prep(intl.ID_SET_BUTTON_SELL, { asset: this.market.base.symbol.toUpperCase() })
-    } else this.page.submitBttn.textContent = intl.prep(intl.ID_SET_BUTTON_BUY, { asset: this.market.base.symbol.toUpperCase() })
+      this.page.submitBttn.textContent = intl.prep(intl.ID_SET_BUTTON_SELL, { asset: this.market.baseCfg.symbol.toUpperCase() })
+    } else this.page.submitBttn.textContent = intl.prep(intl.ID_SET_BUTTON_BUY, { asset: this.market.baseCfg.symbol.toUpperCase() })
   }
 
   setCandleDurBttns () {


### PR DESCRIPTION
You would only see this if the server has a market with an asset that is not supported by the client, in which case `this.market.base` would be `null`.