### PR TITLE
site: make cancel button respond with spinner

### DIFF
--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -366,11 +366,8 @@
     <label for="cancelPass" class="form-label pt-3 mb-1">[[[Password]]]</label>
     <input type="password" class="form-control select" id="cancelPass" autocomplete="off">
   </div>
-  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
-    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">[[[Submit]]]</button>
-    <div id="cancelLoader" class="loader flex-center d-hide">
-      <div class="ico-spinner spinner"></div>
-    </div>
+  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}} position-relative">
+    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected position-relative d-inline-block">[[[Submit]]]</button>
   </div>
 </div>
 <div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -368,8 +368,12 @@
   </div>
   <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
     <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">[[[Submit]]]</button>
+    <div id="cancelLoader" class="loader flex-center d-hide">
+      <div class="ico-spinner spinner"></div>
+    </div>
   </div>
 </div>
+<div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>
 {{end}}
 
 {{define "accelerateForm"}}

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1588,8 +1588,19 @@ export default class MarketsPage extends BasePage {
       pw: page.cancelPass.value
     }
     page.cancelPass.value = ''
+    // Toggle the loader and submit button.
+    page.cancelSubmit.classList.add('d-hide')
+    page.cancelLoader.classList.remove('d-hide')
     const res = await postJSON('/api/cancel', req)
-    if (!app().checkResponse(res)) return
+    page.cancelSubmit.classList.remove('d-hide')
+    page.cancelLoader.classList.add('d-hide')
+    // Display error on confirmation modal.
+    if (!app().checkResponse(res, true)) {
+      page.cancelErr.textContent = res.msg
+      Doc.show(page.cancelErr)
+      return
+    }
+    // Hide confirmation modal only on success.
     Doc.hide(cancelData.bttn, page.forms)
     order.cancelling = true
   }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1589,11 +1589,9 @@ export default class MarketsPage extends BasePage {
     }
     page.cancelPass.value = ''
     // Toggle the loader and submit button.
-    page.cancelSubmit.classList.add('d-hide')
-    page.cancelLoader.classList.remove('d-hide')
+    const loaded = app().loading(page.cancelSubmit)
     const res = await postJSON('/api/cancel', req)
-    page.cancelSubmit.classList.remove('d-hide')
-    page.cancelLoader.classList.add('d-hide')
+    loaded()
     // Display error on confirmation modal.
     if (!app().checkResponse(res, true)) {
       page.cancelErr.textContent = res.msg

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -368,8 +368,12 @@
   </div>
   <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
     <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">Submit</button>
+    <div id="cancelLoader" class="loader flex-center d-hide">
+      <div class="ico-spinner spinner"></div>
+    </div>
   </div>
 </div>
+<div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>
 {{end}}
 
 {{define "accelerateForm"}}

--- a/client/webserver/site/src/localized_html/en-US/forms.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/forms.tmpl
@@ -366,11 +366,8 @@
     <label for="cancelPass" class="form-label pt-3 mb-1">Password</label>
     <input type="password" class="form-control select" id="cancelPass" autocomplete="off">
   </div>
-  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
-    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">Submit</button>
-    <div id="cancelLoader" class="loader flex-center d-hide">
-      <div class="ico-spinner spinner"></div>
-    </div>
+  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}} position-relative">
+    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected position-relative d-inline-block">Submit</button>
   </div>
 </div>
 <div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>

--- a/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
@@ -366,11 +366,8 @@
     <label for="cancelPass" class="form-label pt-3 mb-1">Hasło</label>
     <input type="password" class="form-control select" id="cancelPass" autocomplete="off">
   </div>
-  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
-    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">Wyślij</button>
-    <div id="cancelLoader" class="loader flex-center d-hide">
-      <div class="ico-spinner spinner"></div>
-    </div>
+  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}} position-relative">
+    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected position-relative d-inline-block">Wyślij</button>
   </div>
 </div>
 <div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>

--- a/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/forms.tmpl
@@ -368,8 +368,12 @@
   </div>
   <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
     <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">Wyślij</button>
+    <div id="cancelLoader" class="loader flex-center d-hide">
+      <div class="ico-spinner spinner"></div>
+    </div>
   </div>
 </div>
+<div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>
 {{end}}
 
 {{define "accelerateForm"}}

--- a/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
@@ -368,8 +368,12 @@
   </div>
   <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
     <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">Enviar</button>
+    <div id="cancelLoader" class="loader flex-center d-hide">
+      <div class="ico-spinner spinner"></div>
+    </div>
   </div>
 </div>
+<div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>
 {{end}}
 
 {{define "accelerateForm"}}

--- a/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/forms.tmpl
@@ -366,11 +366,8 @@
     <label for="cancelPass" class="form-label pt-3 mb-1">Senha</label>
     <input type="password" class="form-control select" id="cancelPass" autocomplete="off">
   </div>
-  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
-    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">Enviar</button>
-    <div id="cancelLoader" class="loader flex-center d-hide">
-      <div class="ico-spinner spinner"></div>
-    </div>
+  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}} position-relative">
+    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected position-relative d-inline-block">Enviar</button>
   </div>
 </div>
 <div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>

--- a/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
@@ -366,11 +366,8 @@
     <label for="cancelPass" class="form-label pt-3 mb-1">密码</label>
     <input type="password" class="form-control select" id="cancelPass" autocomplete="off">
   </div>
-  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
-    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">提交</button>
-    <div id="cancelLoader" class="loader flex-center d-hide">
-      <div class="ico-spinner spinner"></div>
-    </div>
+  <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}} position-relative">
+    <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected position-relative d-inline-block">提交</button>
   </div>
 </div>
 <div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>

--- a/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/forms.tmpl
@@ -368,8 +368,12 @@
   </div>
   <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}}">
     <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected">提交</button>
+    <div id="cancelLoader" class="loader flex-center d-hide">
+      <div class="ico-spinner spinner"></div>
+    </div>
   </div>
 </div>
+<div class="fs15 pt-3 text-center d-hide errcolor" id="cancelErr"></div>
 {{end}}
 
 {{define "accelerateForm"}}


### PR DESCRIPTION
This makes the button on the cancel form behave like the order submission button in that when clicked, the button is replaced with a spinner, and any error from the cancel request is shown on the form instead of the notification menu.