### PR TITLE
client: Base fraction unlocking on total lots.

### DIFF
--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -80,6 +80,9 @@ func mainCore() error {
 		log.Infof("Logging with UTC time stamps. Current local time is %v",
 			time.Now().Local().Format("15:04:05 MST"))
 	}
+	log.Infof("dexc starting for network: %s", cfg.Net)
+	log.Infof("Swap locktimes config: maker %s, taker %s",
+		dex.LockTimeMaker(cfg.Net), dex.LockTimeTaker(cfg.Net))
 
 	defer func() {
 		if pv := recover(); pv != nil {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2966,7 +2966,8 @@ func TestRefundReserves(t *testing.T) {
 	rate := dcrBtcRateStep * 100
 
 	lo, dbOrder, preImg, _ := makeLimitOrder(dc, true, qty, rate)
-	lo.BaseAsset = tACCTAsset.ID
+	lo.BaseAsset = tUTXOAssetB.ID
+	lo.QuoteAsset = tACCTAsset.ID
 	lo.Force = order.StandingTiF
 	loid := lo.ID()
 
@@ -3217,7 +3218,8 @@ func TestRedemptionReserves(t *testing.T) {
 	rate := dcrBtcRateStep * 100
 
 	lo, dbOrder, preImg, _ := makeLimitOrder(dc, true, qty, rate)
-	lo.BaseAsset = tACCTAsset.ID
+	lo.BaseAsset = tUTXOAssetB.ID
+	lo.QuoteAsset = tACCTAsset.ID
 	lo.Force = order.StandingTiF
 	loid := lo.ID()
 


### PR DESCRIPTION
closes #1544

The function wasn't a problem on the default simnet, but when used with smaller lot sizes `isDust` does not scale well. You can try out the way in master here: https://go.dev/play/p/QNqo2EDUiUX

I think using the ratio of one lot to max lots and multiplying that times the max reserved is more straightforward.

Also adding a log for client to see the net and locktimes on start up.