### PR TITLE
multi: check rpc semver compatibility

### DIFF
--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -27,6 +27,7 @@ import (
 	"decred.org/dcrdex/client/rpcserver"
 	"decred.org/dcrdex/client/webserver"
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/version"
 )
 
 func main() {
@@ -134,15 +135,37 @@ func mainCore() error {
 	}()
 
 	if cfg.RPCOn {
+		// Prepare dexc version for use with rpc server.
+		dexcMajor, dexcMinor, dexcPatch, dexcPreRel, dexcBuildMeta, err := version.ParseSemVer(Version)
+		if err != nil {
+			return fmt.Errorf("failed to parse %s version: %w", appName, err)
+		}
+
+		runtimeVer := strings.Replace(runtime.Version(), ".", "-", -1)
+		runBuildMeta := version.NormalizeString(runtimeVer)
+		build := version.NormalizeString(dexcBuildMeta)
+		if build != "" {
+			dexcBuildMeta = fmt.Sprintf("%s.%s", build, runBuildMeta)
+		}
+		dexcVersion := &rpcserver.SemVersion{
+			VersionString: Version,
+			Major:         dexcMajor,
+			Minor:         dexcMinor,
+			Patch:         dexcPatch,
+			Prerelease:    dexcPreRel,
+			BuildMetadata: dexcBuildMeta,
+		}
+
 		rpcserver.SetLogger(logMaker.Logger("RPC"))
 		rpcCfg := &rpcserver.Config{
-			Core:      clientCore,
-			Addr:      cfg.RPCAddr,
-			User:      cfg.RPCUser,
-			Pass:      cfg.RPCPass,
-			Cert:      cfg.RPCCert,
-			Key:       cfg.RPCKey,
-			CertHosts: cfg.CertHosts,
+			Core:        clientCore,
+			Addr:        cfg.RPCAddr,
+			User:        cfg.RPCUser,
+			Pass:        cfg.RPCPass,
+			Cert:        cfg.RPCCert,
+			Key:         cfg.RPCKey,
+			DexcVersion: dexcVersion,
+			CertHosts:   cfg.CertHosts,
 		}
 		rpcSrv, err := rpcserver.New(rpcCfg)
 		if err != nil {

--- a/client/cmd/dexcctl/config.go
+++ b/client/cmd/dexcctl/config.go
@@ -85,6 +85,7 @@ func configure() (*config, []string, bool, error) {
 	if cfg.ShowVersion {
 		fmt.Printf("%s version %s (Go version %s %s/%s)\n", appName,
 			Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("%s required RPC server version: %s\n", appName, requiredRPCServerVersion.String())
 		return nil, nil, stop, nil
 	}
 

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -230,12 +230,11 @@ func run(ctx context.Context) error {
 		var verResp rpcserver.VersionResponse
 		err = json.Unmarshal(resp.Result, &verResp)
 		if err != nil {
-			fmt.Printf("Unable to check RPC server compatibility: failed to unmarshal result: %v\n", err)
-			return nil
+			return fmt.Errorf("Unable to check RPC server compatibility: failed to unmarshal result: %v\n", err)
 		}
 
 		if !dex.SemverCompatible(requiredRPCServerVersion, *verResp.RPCServerVer) {
-			fmt.Printf("%s is not compatible with dexc RPC server: required RPC server version - %s, dexc RPC server version - %s\n",
+			return fmt.Errorf("%s is not compatible with dexc RPC server: required RPC server version - %s, dexc RPC server version - %s\n",
 				appName, requiredRPCServerVersion.String(), verResp.RPCServerVer.String())
 		}
 	}

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -26,6 +26,13 @@ const (
 	listCmdMessage  = "Specify -l to list available commands"
 )
 
+var (
+	// requiredRPCServerVersion is the least version of the dexc RPC server that
+	// this dexcctl package can work with. It should be updated whenever a
+	// dexcctl change requires an updated RPC server.
+	requiredRPCServerVersion = dex.Semver{Major: 0, Minor: 2, Patch: 0}
+)
+
 func main() {
 	// Create a context that is canceled when a shutdown signal is received.
 	ctx := withShutdownCancel(context.Background())
@@ -215,6 +222,22 @@ func run(ctx context.Context) error {
 		fmt.Println(str)
 	} else if strResult != "null" {
 		fmt.Println(strResult)
+	}
+
+	// If this is a version check command, go the extra mile and check for
+	// compatibility.
+	if args[0] == "version" {
+		var verResp rpcserver.VersionResponse
+		err = json.Unmarshal(resp.Result, &verResp)
+		if err != nil {
+			fmt.Printf("Unable to check RPC server compatibility: failed to unmarshal result: %v\n", err)
+			return nil
+		}
+
+		if !dex.SemverCompatible(requiredRPCServerVersion, *verResp.RPCServerVer) {
+			fmt.Printf("%s is not compatible with dexc RPC server: required RPC server version - %s, dexc RPC server version - %s\n",
+				appName, requiredRPCServerVersion.String(), verResp.RPCServerVer.String())
+		}
 	}
 	return nil
 }

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -138,15 +138,19 @@ func handleInit(s *RPCServer, params *RawParams) *msgjson.ResponsePayload {
 	return createResponse(initRoute, &res, nil)
 }
 
-// handleVersion handles requests for version. It takes no arguments and returns
-// the semver.
-func handleVersion(_ *RPCServer, _ *RawParams) *msgjson.ResponsePayload {
-	res := &versionResponse{
-		Major: rpcSemverMajor,
-		Minor: rpcSemverMinor,
-		Patch: rpcSemverPatch,
+// handleVersion handles requests for version. It returns the rpc server version
+// and dexc version.
+func handleVersion(s *RPCServer, _ *RawParams) *msgjson.ResponsePayload {
+	result := &VersionResponse{
+		RPCServerVer: &dex.Semver{
+			Major: rpcSemverMajor,
+			Minor: rpcSemverMinor,
+			Patch: rpcSemverPatch,
+		},
+		DexcVersion: s.dexcVersion,
 	}
-	return createResponse(versionRoute, res.String(), nil)
+
+	return createResponse(versionRoute, result, nil)
 }
 
 // handleNewWallet handles requests for newwallet.

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -183,8 +183,10 @@ func TestHandleHelp(t *testing.T) {
 }
 
 func TestHandleVersion(t *testing.T) {
-	payload := handleVersion(nil, nil)
-	res := ""
+	tc := &TCore{}
+	r := &RPCServer{core: tc, dexcVersion: &SemVersion{}}
+	payload := handleVersion(r, nil)
+	res := &VersionResponse{}
 	if err := verifyResponse(payload, &res, -1); err != nil {
 		t.Fatal(err)
 	}

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -31,16 +31,16 @@ import (
 )
 
 const (
-	// rpcSemver is the RPC server's semantic API version.
-	// Move major up one for breaking changes. Move minor for
-	// backwards compatible features. Move patch for bug fixes.
-	// Dexcctl requiredRPCSemVer should be kept up to date with this version.
+	// rpcSemver is the RPC server's semantic API version. Move major up one for
+	// breaking changes. Move minor for backwards compatible features. Move
+	// patch for bug fixes. Dexcctl requiredRPCSemVer should be kept up to date
+	// with this version.
 	rpcSemverMajor uint32 = 0
 	rpcSemverMinor uint32 = 2
 	rpcSemverPatch uint32 = 0
-	// rpcTimeoutSeconds is the number of seconds a connection to the
-	// RPC server is allowed to stay open without authenticating before it
-	// is closed.
+
+	// rpcTimeoutSeconds is the number of seconds a connection to the RPC server
+	// is allowed to stay open without authenticating before it is closed.
 	rpcTimeoutSeconds = 10
 )
 
@@ -122,8 +122,8 @@ func writeJSON(w http.ResponseWriter, thing interface{}) {
 	writeJSONWithStatus(w, thing, http.StatusOK)
 }
 
-// writeJSONWithStatus marshals the provided interface and writes the bytes to the
-// ResponseWriter with the specified response code.
+// writeJSONWithStatus marshals the provided interface and writes the bytes to
+// the ResponseWriter with the specified response code.
 func writeJSONWithStatus(w http.ResponseWriter, thing interface{}, code int) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	b, err := json.Marshal(thing)

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -32,16 +32,20 @@ type RawParams struct {
 	Args   []string           `json:"args"`
 }
 
-// versionResponse holds a semver version JSON object.
-type versionResponse struct {
-	Major uint32 `json:"major"`
-	Minor uint32 `json:"minor"`
-	Patch uint32 `json:"patch"`
+// VersionResponse holds dexc and dexc rpc server version.
+type VersionResponse struct {
+	RPCServerVer *dex.Semver `json:"rpcServerVersion"`
+	DexcVersion  *SemVersion `json:"dexcVersion"`
 }
 
-// String satisfies the Stringer interface.
-func (vr versionResponse) String() string {
-	return fmt.Sprintf("%d.%d.%d", vr.Major, vr.Minor, vr.Patch)
+// SemVersion holds a semver version JSON object.
+type SemVersion struct {
+	VersionString string `json:"versionString"`
+	Major         uint32 `json:"major"`
+	Minor         uint32 `json:"minor"`
+	Patch         uint32 `json:"patch"`
+	Prerelease    string `json:"prerelease,omitempty"`
+	BuildMetadata string `json:"buildMetadata,omitempty"`
 }
 
 // tradeResponse is used when responding to the trade route.

--- a/dex/version/version.go
+++ b/dex/version/version.go
@@ -5,6 +5,7 @@
 package version
 
 import (
+	"bytes"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -44,8 +45,8 @@ func checkSemString(s, alphabet, fieldName string) error {
 	return nil
 }
 
-// parseSemVer parses various semver components from the provided string.
-func parseSemVer(s string) (uint32, uint32, uint32, string, string, error) {
+// ParseSemVer parses various semver components from the provided string.
+func ParseSemVer(s string) (major, minor, patch uint32, preRel, build string, err error) {
 	// Parse the various semver component from the version string via a regular
 	// expression.
 	m := semverRE.FindStringSubmatch(s)
@@ -55,28 +56,28 @@ func parseSemVer(s string) (uint32, uint32, uint32, string, string, error) {
 		return 0, 0, 0, "", "", err
 	}
 
-	major, err := parseUint32(m[1], "major")
+	major, err = parseUint32(m[1], "major")
 	if err != nil {
 		return 0, 0, 0, "", "", err
 	}
 
-	minor, err := parseUint32(m[2], "minor")
+	minor, err = parseUint32(m[2], "minor")
 	if err != nil {
 		return 0, 0, 0, "", "", err
 	}
 
-	patch, err := parseUint32(m[3], "patch")
+	patch, err = parseUint32(m[3], "patch")
 	if err != nil {
 		return 0, 0, 0, "", "", err
 	}
 
-	preRel := m[4]
+	preRel = m[4]
 	err = checkSemString(preRel, semanticAlphabet, "pre-release")
 	if err != nil {
 		return 0, 0, 0, s, s, err
 	}
 
-	build := m[5]
+	build = m[5]
 	err = checkSemString(build, semanticAlphabet, "buildmetadata")
 	if err != nil {
 		return 0, 0, 0, s, s, err
@@ -89,7 +90,7 @@ func parseSemVer(s string) (uint32, uint32, uint32, string, string, error) {
 // semantic versioning 2.0.0 spec (https://semver.org/).
 func Parse(version string) string {
 	var err error
-	Major, Minor, Patch, PreRelease, BuildMetadata, err := parseSemVer(version)
+	Major, Minor, Patch, PreRelease, BuildMetadata, err := ParseSemVer(version)
 	if err != nil {
 		panic(err)
 	}
@@ -105,4 +106,18 @@ func Parse(version string) string {
 	}
 
 	return version
+}
+
+// NormalizeString returns the passed string stripped of all characters which
+// are not valid according to the semantic versioning guidelines for pre-release
+// and build metadata strings.  In particular they MUST only contain characters
+// in semanticAlphabet.
+func NormalizeString(str string) string {
+	var result bytes.Buffer
+	for _, r := range str {
+		if strings.ContainsRune(semanticAlphabet, r) {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
 }

--- a/dex/version/version.go
+++ b/dex/version/version.go
@@ -5,7 +5,6 @@
 package version
 
 import (
-	"bytes"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -110,10 +109,10 @@ func Parse(version string) string {
 
 // NormalizeString returns the passed string stripped of all characters which
 // are not valid according to the semantic versioning guidelines for pre-release
-// and build metadata strings.  In particular they MUST only contain characters
+// and build metadata strings. In particular they MUST only contain characters
 // in semanticAlphabet.
 func NormalizeString(str string) string {
-	var result bytes.Buffer
+	var result strings.Builder
 	for _, r := range str {
 		if strings.ContainsRune(semanticAlphabet, r) {
 			result.WriteRune(r)

--- a/dex/version/version_test.go
+++ b/dex/version/version_test.go
@@ -326,7 +326,7 @@ func TestSemVerParsing(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		major, minor, patch, pre, build, err := parseSemVer(test.ver)
+		major, minor, patch, pre, build, err := ParseSemVer(test.ver)
 		if test.invalid && err == nil {
 			t.Errorf("%q: did not receive expected error", test.ver)
 			continue


### PR DESCRIPTION
This adds new values to RPC server version return. Closes #1151 
- add dexc version to rpc server version return value
- add supported RPC version to dexcctl.
- change dexc RPC server version return to a json object
- Edit: update rpc version handler test
```
$ ./dexcctl version
{
  "rpcServerVersion": {
    "Major": 0,
    "Minor": 2,
    "Patch": 0
  },
  "dexcVersion": {
    "versionString": "0.5.0-pre+9763b71bb",
    "major": 0,
    "minor": 5,
    "patch": 0,
    "prerelease": "pre",
    "buildMetadata": "9763b71bb.go1-18"
  }
}
```

```
$ ./dexcctl -V
dexcctl version 0.5.0-pre+9763b71bb (Go version go1.18 linux/amd64)
dexcctl required RPC server version: 0.2.0
```