### PR TITLE
client/eth/ui: Export ETH wallet to Metamask

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -2053,7 +2053,7 @@ func (w *assetWallet) RestorationInfo(seed []byte) ([]*asset.WalletRestoration, 
 	}
 
 	return []*asset.WalletRestoration{
-		&asset.WalletRestoration{
+		{
 			Target:   "MetaMask",
 			Seed:     hex.EncodeToString(privateKey),
 			SeedName: "Private Key",

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -2054,14 +2054,15 @@ func (w *assetWallet) RestorationInfo(seed []byte) ([]*asset.WalletRestoration, 
 
 	return []*asset.WalletRestoration{
 		&asset.WalletRestoration{
-			Target: "MetaMask",
-			Seed:   hex.EncodeToString(privateKey),
+			Target:   "MetaMask",
+			Seed:     hex.EncodeToString(privateKey),
+			SeedName: "Private Key",
 			Instructions: "Accounts can be imported by private key only if MetaMask has already be initialized. " +
 				"If this is your first time installing MetaMask, create a new wallet and secret recovery phrase. " +
 				"Then, to import your DEX account into MetaMask, follow the steps below:\n" +
 				`1. Open the settings menu
 				 2. Select "Import Account"
-				 3. Make sure "Private Key" is selected, and paste the private key above into the box`,
+				 3. Make sure "Private Key" is selected, and enter the private key above into the box`,
 		},
 	}, nil
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -429,8 +429,11 @@ type FeeRater interface {
 // WalletRestoration contains all the information needed for a user to restore
 // their wallet in an external wallet.
 type WalletRestoration struct {
-	Target       string `json:"target"`
-	Seed         string `json:"seed"`
+	Target string `json:"target"`
+	Seed   string `json:"seed"`
+	// SeedName is the name of the seed used for this particular wallet, i.e
+	// Private Key.
+	SeedName     string `json:"seedName"`
 	Instructions string `json:"instructions"`
 }
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -7072,7 +7072,7 @@ func (c *Core) WalletRestorationInfo(pw []byte, assetID uint32) ([]*asset.Wallet
 
 	restorer, ok := wallet.Wallet.(asset.WalletRestorer)
 	if !ok {
-		return nil, fmt.Errorf("wallet for asset %d cannot be restored", assetID)
+		return nil, fmt.Errorf("wallet for asset %d doesn't support exporting functionality", assetID)
 	}
 
 	restorationInfo, err := restorer.RestorationInfo(seed)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -7057,11 +7057,13 @@ func (c *Core) WalletRestorationInfo(pw []byte, assetID uint32) ([]*asset.Wallet
 	if err != nil {
 		return nil, fmt.Errorf("WalletRestorationInfo password error: %w", err)
 	}
+	defer crypter.Close()
 
 	seed, _, err := c.assetSeedAndPass(assetID, crypter)
 	if err != nil {
 		return nil, fmt.Errorf("assetSeedAndPass error: %w", err)
 	}
+	defer encode.ClearBytes(seed)
 
 	wallet, found := c.wallet(assetID)
 	if !found {

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/core"
 	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
@@ -448,6 +449,34 @@ func (s *WebServer) apiUpdateDEXHost(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:       true,
 		Exchange: exchange,
+	}
+
+	writeJSON(w, resp, s.indent)
+}
+
+// apiRestoreWalletInfo is the handler for the '/restorewalletinfo' API
+// request.
+func (s *WebServer) apiRestoreWalletInfo(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		AssetID uint32
+		Pass    encode.PassBytes
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+
+	info, err := s.core.WalletRestorationInfo(form.Pass, form.AssetID)
+	if err != nil {
+		s.writeAPIError(w, fmt.Errorf("error updating cert: %w", err))
+		return
+	}
+
+	resp := struct {
+		OK              bool                       `json:"ok"`
+		RestorationInfo []*asset.WalletRestoration `json:"restorationinfo,omitempty"`
+	}{
+		OK:              true,
+		RestorationInfo: info,
 	}
 	writeJSON(w, resp, s.indent)
 }

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -461,6 +461,7 @@ func (s *WebServer) apiRestoreWalletInfo(w http.ResponseWriter, r *http.Request)
 		AssetID uint32
 		Pass    encode.PassBytes
 	}{}
+	defer form.Pass.Clear()
 	if !readPost(w, r, form) {
 		return
 	}
@@ -491,7 +492,6 @@ func (s *WebServer) apiAccountDisable(w http.ResponseWriter, r *http.Request) {
 
 	// Disable account.
 	err := s.core.AccountDisable(form.Pass, form.Host)
-	zero(form.Pass)
 	if err != nil {
 		s.writeAPIError(w, fmt.Errorf("error disabling account: %w", err))
 		return

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1612,6 +1612,9 @@ func (c *TCore) UpdateCert(string, []byte) error {
 func (c *TCore) UpdateDEXHost(string, string, []byte, interface{}) (*core.Exchange, error) {
 	return nil, nil
 }
+func (c *TCore) WalletRestorationInfo(pw []byte, assetID uint32) ([]*asset.WalletRestoration, error) {
+	return nil, nil
+}
 
 func TestServer(t *testing.T) {
 	// Register dummy drivers for unimplemented assets.

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -238,4 +238,9 @@ var EnUS = map[string]string{
 	"successful_cert_update":      "Successfully updated certificate!",
 	"update dex host":             "Update DEX Host",
 	"copied":                      "Copied!",
+	"export_wallet":               "Export Wallet",
+	"pw_for_wallet_seed":          "Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.",
+	"export_wallet_disclaimer":    "You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.",
+	"retype_instructions":         `Please type the following to confirm that you understand the risks of exporting the wallet:`,
+	"export_wallet_msg":           "Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.",
 }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -239,8 +239,9 @@ var EnUS = map[string]string{
 	"update dex host":             "Update DEX Host",
 	"copied":                      "Copied!",
 	"export_wallet":               "Export Wallet",
-	"pw_for_wallet_seed":          "Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.",
-	"export_wallet_disclaimer":    "You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.",
+	"pw_for_wallet_seed":          "Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.",
+	"export_wallet_disclaimer":    "Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.",
 	"retype_instructions":         `Please type the following to confirm that you understand the risks of exporting the wallet:`,
 	"export_wallet_msg":           "Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.",
+	"restore_wallet_retype_text":  "I will not use any external wallet while I have active trades in the DEX",
 }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -240,8 +240,7 @@ var EnUS = map[string]string{
 	"copied":                      "Copied!",
 	"export_wallet":               "Export Wallet",
 	"pw_for_wallet_seed":          "Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.",
-	"export_wallet_disclaimer":    "Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.",
-	"retype_instructions":         `Please type the following to confirm that you understand the risks of exporting the wallet:`,
+	"export_wallet_disclaimer":    `<span class="warning-text">Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS.</span> It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.`,
 	"export_wallet_msg":           "Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.",
-	"restore_wallet_retype_text":  "I will not use any external wallet while I have active trades in the DEX",
+	"clipboard_warning":           "Copy/Pasting a wallet seed is a potential security risk. Do this at your own risk.",
 }

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -466,3 +466,7 @@ div.border1 {
 #loader {
   background-color: #e0e0e077;
 }
+
+.preline {
+  white-space: pre-line;
+}

--- a/client/webserver/site/src/css/typography.scss
+++ b/client/webserver/site/src/css/typography.scss
@@ -124,3 +124,7 @@
 .sans-light {
   font-family: $sans-light;
 }
+
+.bold {
+  font-weight: bold;
+}

--- a/client/webserver/site/src/css/wallets.scss
+++ b/client/webserver/site/src/css/wallets.scss
@@ -99,7 +99,13 @@ table.wallets {
 }
 
 #restoreWalletInfo,
-#exportWalletDisclaimer,
 #exportWalletAuth {
   width: 450px;
+}
+
+.warning-text {
+  text-decoration: underline;
+  text-decoration-color: #d11414;
+  color: #d11414;
+  font-size: bold;
 }

--- a/client/webserver/site/src/css/wallets.scss
+++ b/client/webserver/site/src/css/wallets.scss
@@ -97,3 +97,9 @@ table.wallets {
   margin-left: 12px;
   position: absolute;
 }
+
+#restoreWalletInfo,
+#exportWalletDisclaimer,
+#exportWalletAuth {
+  width: 450px;
+}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
+  <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
+  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GTHMDHF"></script>
+<script src="/js/entry.js?v=8qUUO9"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -238,6 +238,7 @@
       <hr class="dashed my-2">
       <div class="d-flex flex-row">
         <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">[[[wallet_logs]]]</button>
+        <button id="exportWallet" type="button" class="w-25 mx-1 mt-1 justify-content-center fs15 bg2">[[[export_wallet]]]</button>
         <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">[[[recover]]]</button>
       </div>
     </form>
@@ -280,6 +281,72 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
+
+    {{- /* EXPORT WALLET DISCLAIMER */ -}}
+    <form class="d-hide" id="exportWalletDisclaimer">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        [[[export_wallet]]]
+      </div>
+      <div class="fs15 text-start mt-2">
+        [[[export_wallet_disclaimer]]]
+      </div>
+      <div class="fs15 text-start mt-2">
+        [[[retype_instructions]]]
+      </div>
+      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <input class="form-control mt-2" id="disclaimerInput" >
+      <div class="d-flex justify-content-end mt-4">
+        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">[[[Submit]]]</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
+    </form>
+
+    {{- /* EXPORT WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="exportWalletAuth">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        [[[export_wallet]]]
+      </div>
+      <div class="fs15 text-start mt-2">
+        [[[pw_for_wallet_seed]]]
+      </div>
+      <div class="text-start mt-2">
+        <label for="exportWalletPW" class="ps-1 mb-1">[[[Password]]]</label>
+        <input type="password" class="form-control select" id="exportWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="exportWalletAuthSubmit" type="button" class="justify-content-center fs15 bg2 selected">[[[Show Me]]]</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="exportWalletErr"></div>
+    </form>
+
+    {{- /* RESTORE WALLET INFO */ -}}
+    <form class="d-hide" id="restoreWalletInfo">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        [[[export_wallet]]]
+      </div>
+      <div class="fs15 text-start mt-2">
+        [[[export_wallet_msg]]]
+      </div>
+      <hr />
+      <div id="restoreInfoCardsList">
+        <div id="restoreInfoCard">
+          <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
+          <br />
+          <span>Seed:</span>
+          <br />
+          <span data-tmpl="seed" class="sans-light text-break"></span>
+          <br />
+          <span>Instructions:</span>
+          <br />
+          <span data-tmpl="instructions" class="sans-light text-break preline"></span>
+          <hr />
+        </div>
+      </div>
+    </form>
+
   </div>
 </div>
 {{template "bottom"}}

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -294,7 +294,7 @@
       <div class="fs15 text-start mt-2">
         [[[retype_instructions]]]
       </div>
-      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <span id="retypeText" class="fs15 text-start bold underline">[[[restore_wallet_retype_text]]]</span>
       <input class="form-control mt-2" id="disclaimerInput" >
       <div class="d-flex justify-content-end mt-4">
         <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">[[[Submit]]]</button>

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -282,26 +282,6 @@
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
 
-    {{- /* EXPORT WALLET DISCLAIMER */ -}}
-    <form class="d-hide" id="exportWalletDisclaimer">
-      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-      <div class="py-1 text-center position-relative fs22 sans-light">
-        [[[export_wallet]]]
-      </div>
-      <div class="fs15 text-start mt-2">
-        [[[export_wallet_disclaimer]]]
-      </div>
-      <div class="fs15 text-start mt-2">
-        [[[retype_instructions]]]
-      </div>
-      <span id="retypeText" class="fs15 text-start bold underline">[[[restore_wallet_retype_text]]]</span>
-      <input class="form-control mt-2" id="disclaimerInput" >
-      <div class="d-flex justify-content-end mt-4">
-        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">[[[Submit]]]</button>
-      </div>
-      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
-    </form>
-
     {{- /* EXPORT WALLET AUTHORIZATION */ -}}
     <form class="d-hide" id="exportWalletAuth">
       <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
@@ -310,6 +290,9 @@
       </div>
       <div class="fs15 text-start mt-2">
         [[[pw_for_wallet_seed]]]
+      </div>
+      <div id="exportDisclaimer" class="fs15 text-start mt-2">
+        [[[export_wallet_disclaimer]]]
       </div>
       <div class="text-start mt-2">
         <label for="exportWalletPW" class="ps-1 mb-1">[[[Password]]]</label>
@@ -330,15 +313,19 @@
       <div class="fs15 text-start mt-2">
         [[[export_wallet_msg]]]
       </div>
+      <div class="fs15 text-start mt-2 warning-text">
+        [[[clipboard_warning]]]
+      </div>
       <hr />
       <div id="restoreInfoCardsList">
         <div id="restoreInfoCard">
           <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
           <br />
-          <span>Seed:</span>
+          <span data-tmpl="seedName"></span>
           <br />
-          <span data-tmpl="seed" class="sans-light text-break"></span>
-          <br />
+          <div>
+            <span data-tmpl="seed" class="mono fs14"></span>
+          </div>
           <span>Instructions:</span>
           <br />
           <span data-tmpl="instructions" class="sans-light text-break preline"></span>

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
+  <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
+  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GTHMDHF"></script>
+<script src="/js/entry.js?v=8qUUO9"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -289,12 +289,12 @@
         Export Wallet
       </div>
       <div class="fs15 text-start mt-2">
-        You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
+        Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
       </div>
       <div class="fs15 text-start mt-2">
         Please type the following to confirm that you understand the risks of exporting the wallet:
       </div>
-      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <span id="retypeText" class="fs15 text-start bold underline">I will not use any external wallet while I have active trades in the DEX</span>
       <input class="form-control mt-2" id="disclaimerInput" >
       <div class="d-flex justify-content-end mt-4">
         <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">Submit</button>
@@ -309,7 +309,7 @@
         Export Wallet
       </div>
       <div class="fs15 text-start mt-2">
-        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.
+        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.
       </div>
       <div class="text-start mt-2">
         <label for="exportWalletPW" class="ps-1 mb-1">Password</label>

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -238,6 +238,7 @@
       <hr class="dashed my-2">
       <div class="d-flex flex-row">
         <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">Wallet Logs</button>
+        <button id="exportWallet" type="button" class="w-25 mx-1 mt-1 justify-content-center fs15 bg2">Export Wallet</button>
         <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">Recover</button>
       </div>
     </form>
@@ -280,6 +281,72 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
+
+    {{- /* EXPORT WALLET DISCLAIMER */ -}}
+    <form class="d-hide" id="exportWalletDisclaimer">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
+      </div>
+      <div class="fs15 text-start mt-2">
+        Please type the following to confirm that you understand the risks of exporting the wallet:
+      </div>
+      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <input class="form-control mt-2" id="disclaimerInput" >
+      <div class="d-flex justify-content-end mt-4">
+        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">Submit</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
+    </form>
+
+    {{- /* EXPORT WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="exportWalletAuth">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.
+      </div>
+      <div class="text-start mt-2">
+        <label for="exportWalletPW" class="ps-1 mb-1">Password</label>
+        <input type="password" class="form-control select" id="exportWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="exportWalletAuthSubmit" type="button" class="justify-content-center fs15 bg2 selected">Show Me</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="exportWalletErr"></div>
+    </form>
+
+    {{- /* RESTORE WALLET INFO */ -}}
+    <form class="d-hide" id="restoreWalletInfo">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.
+      </div>
+      <hr />
+      <div id="restoreInfoCardsList">
+        <div id="restoreInfoCard">
+          <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
+          <br />
+          <span>Seed:</span>
+          <br />
+          <span data-tmpl="seed" class="sans-light text-break"></span>
+          <br />
+          <span>Instructions:</span>
+          <br />
+          <span data-tmpl="instructions" class="sans-light text-break preline"></span>
+          <hr />
+        </div>
+      </div>
+    </form>
+
   </div>
 </div>
 {{template "bottom"}}

--- a/client/webserver/site/src/localized_html/en-US/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/wallets.tmpl
@@ -282,26 +282,6 @@
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
 
-    {{- /* EXPORT WALLET DISCLAIMER */ -}}
-    <form class="d-hide" id="exportWalletDisclaimer">
-      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-      <div class="py-1 text-center position-relative fs22 sans-light">
-        Export Wallet
-      </div>
-      <div class="fs15 text-start mt-2">
-        Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
-      </div>
-      <div class="fs15 text-start mt-2">
-        Please type the following to confirm that you understand the risks of exporting the wallet:
-      </div>
-      <span id="retypeText" class="fs15 text-start bold underline">I will not use any external wallet while I have active trades in the DEX</span>
-      <input class="form-control mt-2" id="disclaimerInput" >
-      <div class="d-flex justify-content-end mt-4">
-        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">Submit</button>
-      </div>
-      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
-    </form>
-
     {{- /* EXPORT WALLET AUTHORIZATION */ -}}
     <form class="d-hide" id="exportWalletAuth">
       <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
@@ -310,6 +290,9 @@
       </div>
       <div class="fs15 text-start mt-2">
         Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.
+      </div>
+      <div id="exportDisclaimer" class="fs15 text-start mt-2">
+        <span class="warning-text">Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS.</span> It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
       </div>
       <div class="text-start mt-2">
         <label for="exportWalletPW" class="ps-1 mb-1">Password</label>
@@ -330,15 +313,19 @@
       <div class="fs15 text-start mt-2">
         Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.
       </div>
+      <div class="fs15 text-start mt-2 warning-text">
+        Copy/Pasting a wallet seed is a potential security risk. Do this at your own risk.
+      </div>
       <hr />
       <div id="restoreInfoCardsList">
         <div id="restoreInfoCard">
           <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
           <br />
-          <span>Seed:</span>
+          <span data-tmpl="seedName"></span>
           <br />
-          <span data-tmpl="seed" class="sans-light text-break"></span>
-          <br />
+          <div>
+            <span data-tmpl="seed" class="mono fs14"></span>
+          </div>
           <span>Instructions:</span>
           <br />
           <span data-tmpl="instructions" class="sans-light text-break preline"></span>

--- a/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
+  <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
+  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GTHMDHF"></script>
+<script src="/js/entry.js?v=8qUUO9"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -289,12 +289,12 @@
         Export Wallet
       </div>
       <div class="fs15 text-start mt-2">
-        You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
+        Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
       </div>
       <div class="fs15 text-start mt-2">
         Please type the following to confirm that you understand the risks of exporting the wallet:
       </div>
-      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <span id="retypeText" class="fs15 text-start bold underline">I will not use any external wallet while I have active trades in the DEX</span>
       <input class="form-control mt-2" id="disclaimerInput" >
       <div class="d-flex justify-content-end mt-4">
         <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">Wyślij</button>
@@ -309,7 +309,7 @@
         Export Wallet
       </div>
       <div class="fs15 text-start mt-2">
-        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.
+        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.
       </div>
       <div class="text-start mt-2">
         <label for="exportWalletPW" class="ps-1 mb-1">Hasło</label>

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -238,6 +238,7 @@
       <hr class="dashed my-2">
       <div class="d-flex flex-row">
         <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">Wallet Logs</button>
+        <button id="exportWallet" type="button" class="w-25 mx-1 mt-1 justify-content-center fs15 bg2">Export Wallet</button>
         <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">Recover</button>
       </div>
     </form>
@@ -280,6 +281,72 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
+
+    {{- /* EXPORT WALLET DISCLAIMER */ -}}
+    <form class="d-hide" id="exportWalletDisclaimer">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
+      </div>
+      <div class="fs15 text-start mt-2">
+        Please type the following to confirm that you understand the risks of exporting the wallet:
+      </div>
+      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <input class="form-control mt-2" id="disclaimerInput" >
+      <div class="d-flex justify-content-end mt-4">
+        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">Wyślij</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
+    </form>
+
+    {{- /* EXPORT WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="exportWalletAuth">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.
+      </div>
+      <div class="text-start mt-2">
+        <label for="exportWalletPW" class="ps-1 mb-1">Hasło</label>
+        <input type="password" class="form-control select" id="exportWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="exportWalletAuthSubmit" type="button" class="justify-content-center fs15 bg2 selected">Pokaż</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="exportWalletErr"></div>
+    </form>
+
+    {{- /* RESTORE WALLET INFO */ -}}
+    <form class="d-hide" id="restoreWalletInfo">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.
+      </div>
+      <hr />
+      <div id="restoreInfoCardsList">
+        <div id="restoreInfoCard">
+          <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
+          <br />
+          <span>Seed:</span>
+          <br />
+          <span data-tmpl="seed" class="sans-light text-break"></span>
+          <br />
+          <span>Instructions:</span>
+          <br />
+          <span data-tmpl="instructions" class="sans-light text-break preline"></span>
+          <hr />
+        </div>
+      </div>
+    </form>
+
   </div>
 </div>
 {{template "bottom"}}

--- a/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/wallets.tmpl
@@ -282,26 +282,6 @@
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
 
-    {{- /* EXPORT WALLET DISCLAIMER */ -}}
-    <form class="d-hide" id="exportWalletDisclaimer">
-      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-      <div class="py-1 text-center position-relative fs22 sans-light">
-        Export Wallet
-      </div>
-      <div class="fs15 text-start mt-2">
-        Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
-      </div>
-      <div class="fs15 text-start mt-2">
-        Please type the following to confirm that you understand the risks of exporting the wallet:
-      </div>
-      <span id="retypeText" class="fs15 text-start bold underline">I will not use any external wallet while I have active trades in the DEX</span>
-      <input class="form-control mt-2" id="disclaimerInput" >
-      <div class="d-flex justify-content-end mt-4">
-        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">Wyślij</button>
-      </div>
-      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
-    </form>
-
     {{- /* EXPORT WALLET AUTHORIZATION */ -}}
     <form class="d-hide" id="exportWalletAuth">
       <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
@@ -310,6 +290,9 @@
       </div>
       <div class="fs15 text-start mt-2">
         Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.
+      </div>
+      <div id="exportDisclaimer" class="fs15 text-start mt-2">
+        <span class="warning-text">Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS.</span> It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
       </div>
       <div class="text-start mt-2">
         <label for="exportWalletPW" class="ps-1 mb-1">Hasło</label>
@@ -330,15 +313,19 @@
       <div class="fs15 text-start mt-2">
         Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.
       </div>
+      <div class="fs15 text-start mt-2 warning-text">
+        Copy/Pasting a wallet seed is a potential security risk. Do this at your own risk.
+      </div>
       <hr />
       <div id="restoreInfoCardsList">
         <div id="restoreInfoCard">
           <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
           <br />
-          <span>Seed:</span>
+          <span data-tmpl="seedName"></span>
           <br />
-          <span data-tmpl="seed" class="sans-light text-break"></span>
-          <br />
+          <div>
+            <span data-tmpl="seed" class="mono fs14"></span>
+          </div>
           <span>Instructions:</span>
           <br />
           <span data-tmpl="instructions" class="sans-light text-break preline"></span>

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
+  <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
+  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GTHMDHF"></script>
+<script src="/js/entry.js?v=8qUUO9"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -238,6 +238,7 @@
       <hr class="dashed my-2">
       <div class="d-flex flex-row">
         <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">Wallet Logs</button>
+        <button id="exportWallet" type="button" class="w-25 mx-1 mt-1 justify-content-center fs15 bg2">Export Wallet</button>
         <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">Recover</button>
       </div>
     </form>
@@ -280,6 +281,72 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
+
+    {{- /* EXPORT WALLET DISCLAIMER */ -}}
+    <form class="d-hide" id="exportWalletDisclaimer">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
+      </div>
+      <div class="fs15 text-start mt-2">
+        Please type the following to confirm that you understand the risks of exporting the wallet:
+      </div>
+      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <input class="form-control mt-2" id="disclaimerInput" >
+      <div class="d-flex justify-content-end mt-4">
+        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">Enviar</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
+    </form>
+
+    {{- /* EXPORT WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="exportWalletAuth">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.
+      </div>
+      <div class="text-start mt-2">
+        <label for="exportWalletPW" class="ps-1 mb-1">Senha</label>
+        <input type="password" class="form-control select" id="exportWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="exportWalletAuthSubmit" type="button" class="justify-content-center fs15 bg2 selected">Mostre me</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="exportWalletErr"></div>
+    </form>
+
+    {{- /* RESTORE WALLET INFO */ -}}
+    <form class="d-hide" id="restoreWalletInfo">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.
+      </div>
+      <hr />
+      <div id="restoreInfoCardsList">
+        <div id="restoreInfoCard">
+          <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
+          <br />
+          <span>Seed:</span>
+          <br />
+          <span data-tmpl="seed" class="sans-light text-break"></span>
+          <br />
+          <span>Instructions:</span>
+          <br />
+          <span data-tmpl="instructions" class="sans-light text-break preline"></span>
+          <hr />
+        </div>
+      </div>
+    </form>
+
   </div>
 </div>
 {{template "bottom"}}

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -289,12 +289,12 @@
         Export Wallet
       </div>
       <div class="fs15 text-start mt-2">
-        You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
+        Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
       </div>
       <div class="fs15 text-start mt-2">
         Please type the following to confirm that you understand the risks of exporting the wallet:
       </div>
-      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <span id="retypeText" class="fs15 text-start bold underline">I will not use any external wallet while I have active trades in the DEX</span>
       <input class="form-control mt-2" id="disclaimerInput" >
       <div class="d-flex justify-content-end mt-4">
         <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">Enviar</button>
@@ -309,7 +309,7 @@
         Export Wallet
       </div>
       <div class="fs15 text-start mt-2">
-        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.
+        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.
       </div>
       <div class="text-start mt-2">
         <label for="exportWalletPW" class="ps-1 mb-1">Senha</label>

--- a/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/wallets.tmpl
@@ -282,26 +282,6 @@
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
 
-    {{- /* EXPORT WALLET DISCLAIMER */ -}}
-    <form class="d-hide" id="exportWalletDisclaimer">
-      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-      <div class="py-1 text-center position-relative fs22 sans-light">
-        Export Wallet
-      </div>
-      <div class="fs15 text-start mt-2">
-        Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
-      </div>
-      <div class="fs15 text-start mt-2">
-        Please type the following to confirm that you understand the risks of exporting the wallet:
-      </div>
-      <span id="retypeText" class="fs15 text-start bold underline">I will not use any external wallet while I have active trades in the DEX</span>
-      <input class="form-control mt-2" id="disclaimerInput" >
-      <div class="d-flex justify-content-end mt-4">
-        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">Enviar</button>
-      </div>
-      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
-    </form>
-
     {{- /* EXPORT WALLET AUTHORIZATION */ -}}
     <form class="d-hide" id="exportWalletAuth">
       <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
@@ -310,6 +290,9 @@
       </div>
       <div class="fs15 text-start mt-2">
         Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.
+      </div>
+      <div id="exportDisclaimer" class="fs15 text-start mt-2">
+        <span class="warning-text">Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS.</span> It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
       </div>
       <div class="text-start mt-2">
         <label for="exportWalletPW" class="ps-1 mb-1">Senha</label>
@@ -330,15 +313,19 @@
       <div class="fs15 text-start mt-2">
         Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.
       </div>
+      <div class="fs15 text-start mt-2 warning-text">
+        Copy/Pasting a wallet seed is a potential security risk. Do this at your own risk.
+      </div>
       <hr />
       <div id="restoreInfoCardsList">
         <div id="restoreInfoCard">
           <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
           <br />
-          <span>Seed:</span>
+          <span data-tmpl="seedName"></span>
           <br />
-          <span data-tmpl="seed" class="sans-light text-break"></span>
-          <br />
+          <div>
+            <span data-tmpl="seed" class="mono fs14"></span>
+          </div>
           <span>Instructions:</span>
           <br />
           <span data-tmpl="instructions" class="sans-light text-break preline"></span>

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -5,10 +5,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {{- /* The above 2 meta tags *must* come first in the head; any other head content must come *after* these tags */ -}}
-  <link rel="icon" href="/img/favicon.png?v=z8A71BD">
+  <link rel="icon" href="/img/favicon.png?v=8qUUO9">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
+  <link href="/css/style.css?v=8qUUO9" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GTHMDHF"></script>
+<script src="/js/entry.js?v=8qUUO9"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -282,26 +282,6 @@
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
 
-    {{- /* EXPORT WALLET DISCLAIMER */ -}}
-    <form class="d-hide" id="exportWalletDisclaimer">
-      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-      <div class="py-1 text-center position-relative fs22 sans-light">
-        Export Wallet
-      </div>
-      <div class="fs15 text-start mt-2">
-        Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
-      </div>
-      <div class="fs15 text-start mt-2">
-        Please type the following to confirm that you understand the risks of exporting the wallet:
-      </div>
-      <span id="retypeText" class="fs15 text-start bold underline">I will not use any external wallet while I have active trades in the DEX</span>
-      <input class="form-control mt-2" id="disclaimerInput" >
-      <div class="d-flex justify-content-end mt-4">
-        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">提交</button>
-      </div>
-      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
-    </form>
-
     {{- /* EXPORT WALLET AUTHORIZATION */ -}}
     <form class="d-hide" id="exportWalletAuth">
       <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
@@ -310,6 +290,9 @@
       </div>
       <div class="fs15 text-start mt-2">
         Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.
+      </div>
+      <div id="exportDisclaimer" class="fs15 text-start mt-2">
+        <span class="warning-text">Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS.</span> It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
       </div>
       <div class="text-start mt-2">
         <label for="exportWalletPW" class="ps-1 mb-1">密码</label>
@@ -330,15 +313,19 @@
       <div class="fs15 text-start mt-2">
         Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.
       </div>
+      <div class="fs15 text-start mt-2 warning-text">
+        Copy/Pasting a wallet seed is a potential security risk. Do this at your own risk.
+      </div>
       <hr />
       <div id="restoreInfoCardsList">
         <div id="restoreInfoCard">
           <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
           <br />
-          <span>Seed:</span>
+          <span data-tmpl="seedName"></span>
           <br />
-          <span data-tmpl="seed" class="sans-light text-break"></span>
-          <br />
+          <div>
+            <span data-tmpl="seed" class="mono fs14"></span>
+          </div>
           <span>Instructions:</span>
           <br />
           <span data-tmpl="instructions" class="sans-light text-break preline"></span>

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -238,6 +238,7 @@
       <hr class="dashed my-2">
       <div class="d-flex flex-row">
         <button id="downloadLogs" type="button" class="w-25 mt-1 mx-1 justify-content-center fs15 bg2">Wallet Logs</button>
+        <button id="exportWallet" type="button" class="w-25 mx-1 mt-1 justify-content-center fs15 bg2">Export Wallet</button>
         <button id="recoverWallet" type="button" class="danger w-25 mx-1 mt-1 justify-content-center fs15 bg2">Recover</button>
       </div>
     </form>
@@ -280,6 +281,72 @@
       </div>
       <div class="fs15 pt-3 text-center d-hide errcolor" id="recoverWalletErr"></div>
     </form>
+
+    {{- /* EXPORT WALLET DISCLAIMER */ -}}
+    <form class="d-hide" id="exportWalletDisclaimer">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
+      </div>
+      <div class="fs15 text-start mt-2">
+        Please type the following to confirm that you understand the risks of exporting the wallet:
+      </div>
+      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <input class="form-control mt-2" id="disclaimerInput" >
+      <div class="d-flex justify-content-end mt-4">
+        <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">提交</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="disclaimerErr"></div>
+    </form>
+
+    {{- /* EXPORT WALLET AUTHORIZATION */ -}}
+    <form class="d-hide" id="exportWalletAuth">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.
+      </div>
+      <div class="text-start mt-2">
+        <label for="exportWalletPW" class="ps-1 mb-1">密码</label>
+        <input type="password" class="form-control select" id="exportWalletPW" autocomplete="current-password">
+      </div>
+      <div class="d-flex justify-content-end mt-4">
+        <button id="exportWalletAuthSubmit" type="button" class="justify-content-center fs15 bg2 selected">展示</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="exportWalletErr"></div>
+    </form>
+
+    {{- /* RESTORE WALLET INFO */ -}}
+    <form class="d-hide" id="restoreWalletInfo">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="px-2 py-1 text-center position-relative fs22 sans-light">
+        Export Wallet
+      </div>
+      <div class="fs15 text-start mt-2">
+        Below are the seeds needed to restore your wallet in some popular external wallets. DO NOT make transactions with your external wallet while you have active trades running on the DEX.
+      </div>
+      <hr />
+      <div id="restoreInfoCardsList">
+        <div id="restoreInfoCard">
+          <span data-tmpl="name" class="text-left position-relative fs20 sans-light bold underline"></span>
+          <br />
+          <span>Seed:</span>
+          <br />
+          <span data-tmpl="seed" class="sans-light text-break"></span>
+          <br />
+          <span>Instructions:</span>
+          <br />
+          <span data-tmpl="instructions" class="sans-light text-break preline"></span>
+          <hr />
+        </div>
+      </div>
+    </form>
+
   </div>
 </div>
 {{template "bottom"}}

--- a/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/wallets.tmpl
@@ -289,12 +289,12 @@
         Export Wallet
       </div>
       <div class="fs15 text-start mt-2">
-        You WILL LOSE FUNDS if export your wallet and use the external wallet while you have active trades running in the DEX. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
+        Using an externally restored wallet while you have active trades running in the DEX could result in failed trades and LOST FUNDS. It is recommended that you do not export your wallet unless you are an experienced user and you know what are doing.
       </div>
       <div class="fs15 text-start mt-2">
         Please type the following to confirm that you understand the risks of exporting the wallet:
       </div>
-      <span id="retypeText" class="fs15 text-start bold underline"></span>
+      <span id="retypeText" class="fs15 text-start bold underline">I will not use any external wallet while I have active trades in the DEX</span>
       <input class="form-control mt-2" id="disclaimerInput" >
       <div class="d-flex justify-content-end mt-4">
         <button id="disclaimerSubmit" type="button" class="justify-content-center fs15 bg2 selected">提交</button>
@@ -309,7 +309,7 @@
         Export Wallet
       </div>
       <div class="fs15 text-start mt-2">
-        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets accecss to the wallet seed, they will be able to steal all of your funds.
+        Enter your app password to show the wallet seed. Make sure nobody else can see your screen. If anyone gets access to the wallet seed, they will be able to steal all of your funds.
       </div>
       <div class="text-start mt-2">
         <label for="exportWalletPW" class="ps-1 mb-1">密码</label>

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -119,6 +119,7 @@ type clientCore interface {
 	AccelerationEstimate(oidB dex.Bytes, newFeeRate uint64) (uint64, error)
 	UpdateCert(host string, cert []byte) error
 	UpdateDEXHost(oldHost, newHost string, appPW []byte, certI interface{}) (*core.Exchange, error)
+	WalletRestorationInfo(pw []byte, assetID uint32) ([]*asset.WalletRestoration, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -357,6 +358,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/accelerationestimate", s.apiAccelerationEstimate)
 			apiAuth.Post("/updatecert", s.apiUpdateCert)
 			apiAuth.Post("/updatedexhost", s.apiUpdateDEXHost)
+			apiAuth.Post("/restorewalletinfo", s.apiRestoreWalletInfo)
 		})
 	})
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -195,6 +195,9 @@ func (c *TCore) UpdateCert(string, []byte) error {
 func (c *TCore) UpdateDEXHost(string, string, []byte, interface{}) (*core.Exchange, error) {
 	return nil, nil
 }
+func (c *TCore) WalletRestorationInfo(pw []byte, assetID uint32) ([]*asset.WalletRestoration, error) {
+	return nil, nil
+}
 
 type TWriter struct {
 	b []byte

--- a/dex/keygen/keygen.go
+++ b/dex/keygen/keygen.go
@@ -20,10 +20,10 @@ func (*RootKeyParams) HDPubKeyVersion() [4]byte {
 // GenDeepChild derives the leaf of a path of children from a root extended key.
 func GenDeepChild(seed []byte, kids []uint32) (*hdkeychain.ExtendedKey, error) {
 	root, err := hdkeychain.NewMaster(seed, &RootKeyParams{})
-	defer root.Zero()
 	if err != nil {
 		return nil, err
 	}
+	defer root.Zero()
 	genChild := func(parent *hdkeychain.ExtendedKey, childIdx uint32) (*hdkeychain.ExtendedKey, error) {
 		err := hdkeychain.ErrInvalidChild
 		for err == hdkeychain.ErrInvalidChild {


### PR DESCRIPTION
- `client/asset`: Adds a `WalletRestorer` interface which requires
  the `RestorationInfo` method to be implemented. `RestorationInfo`
  returns the wallet seed and instructions for the user to restore
  the wallet in various external wallets.
- client/eth: Implements the `WalletRestorer` interface. Returns
  information about how to restore the wallet in MetaMask.
- ui: Displays a new button on the wallet settings page if the wallet
  implements `WalletRestorer`. The user is promped to copy a disclaimer
  confirming that they understand the risks of restoring their wallet
  in an external wallet software. After doing so, they are able to see
  the information returned from the wallet's `RestorationInfo` function.

<img width="568" alt="Screen Shot 2022-07-06 at 10 37 40 PM" src="https://user-images.githubusercontent.com/6186350/177589495-b0d90fab-fb2b-4790-bbd3-1202a64519cd.png">
<img width="586" alt="Screen Shot 2022-07-06 at 10 37 54 PM" src="https://user-images.githubusercontent.com/6186350/177589479-bb289daf-b534-4bd2-9822-20b501b06652.png">

