### PR TITLE
dexc: update go version in Docker file

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,7 +18,7 @@ RUN npm clean-install
 RUN npm run build
 
 # dexc binary build
-FROM golang:1.16 AS gobuilder
+FROM golang:1.18 AS gobuilder
 COPY --from=nodebuilder /root/dex/ /root/dex/
 WORKDIR /root/dex/client/cmd/dexc/
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build


### PR DESCRIPTION
Trying to build `dexc` with Docker I get the following error:
```
comment without // +build comment
```
I assume this started to happen after [go 1.18 update](https://github.com/decred/dcrdex/pull/1519)

with Golang 1.18 docker build works for me.