### PR TITLE
dexc/core: remove redundant validation

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2311,26 +2311,28 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 		return newError(authErr, "ReconfigureWallet password error: %w", err)
 	}
 	defer crypter.Close()
+
 	assetID := form.AssetID
+
 	walletDef, err := walletDefinition(assetID, form.Type)
 	if err != nil {
 		return err
 	}
+	if walletDef.Seeded && newWalletPW != nil {
+		return newError(passwordErr, "cannot set a password on a built-in(seeded) wallet")
+	}
+
 	oldWallet, found := c.wallet(assetID)
 	if !found {
 		return newError(missingWalletErr, "%d -> %s wallet not found",
 			assetID, unbip(assetID))
 	}
-
 	oldDef, err := walletDefinition(assetID, oldWallet.walletType)
 	if err != nil {
 		return fmt.Errorf("failed to locate old wallet definition: %v", err)
 	}
-
-	if walletDef.Seeded && newWalletPW != nil {
-		return newError(passwordErr, "cannot set a password on a built-in wallet")
-	}
 	oldDepositAddr := oldWallet.currentDepositAddress()
+
 	dbWallet := &db.Wallet{
 		Type:        form.Type,
 		AssetID:     oldWallet.AssetID,
@@ -2351,10 +2353,6 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 	}()
 
 	if walletDef.Seeded {
-		if newWalletPW != nil {
-			return newError(passwordErr, "cannot set a password on a seeded wallet")
-		}
-
 		exists, err := asset.WalletExists(assetID, form.Type, c.assetDataDirectory(assetID), form.Config, c.net)
 		if err != nil {
 			return newError(existenceCheckErr, "error checking wallet pre-existence: %w", err)


### PR DESCRIPTION
While reading this part of code I've noticed a duplicate check (same check is done several lines of codes above, I've moved it slightly higher because it can be done earlier)

looks like it can be removed ?