### PR TITLE
dex/testing/btc: do not create descriptor wallets

### DIFF
--- a/dex/testing/btc/base-harness.sh
+++ b/dex/testing/btc/base-harness.sh
@@ -168,10 +168,17 @@ sleep 2
 EOF
 chmod +x "./reorg"
 
+if [ "$LONG_CREATEWALLET" ] ; then
 cat > "./new-wallet" <<EOF
 #!/usr/bin/env bash
-./\$1 createwallet \$2
+./\$1 -named createwallet wallet_name=\$2 descriptors=false
 EOF
+else
+cat > "./new-wallet" <<EOF
+#!/usr/bin/env bash
+./\$1 createwallet \$
+EOF
+fi
 chmod +x "./new-wallet"
 
 cat > "${HARNESS_DIR}/quit" <<EOF
@@ -241,14 +248,22 @@ else
   # Setup the gamma wallet
   ################################################################################
   echo "Creating the gamma wallet"
-  tmux send-keys -t $SESSION:2 "./alpha createwallet gamma${DONE}" C-m\; ${WAIT}
+  if [ "$LONG_CREATEWALLET" ] ; then
+    tmux send-keys -t $SESSION:2 "./alpha -named createwallet wallet_name=gamma descriptors=false blank=true${DONE}" C-m\; ${WAIT}
+  else
+    tmux send-keys -t $SESSION:2 "./alpha createwallet gamma${DONE}" C-m\; ${WAIT}
+  fi
   tmux send-keys -t $SESSION:2 "./gamma sethdseed true ${GAMMA_WALLET_SEED}${DONE}" C-m\; ${WAIT}
 
   ################################################################################
   # Create the delta wallet
   ################################################################################
   echo "Creating the delta wallet"
-  tmux send-keys -t $SESSION:2 "./beta createwallet delta${DONE}" C-m\; ${WAIT}
+  if [ "$LONG_CREATEWALLET" ] ; then
+    tmux send-keys -t $SESSION:2 "./beta -named createwallet wallet_name=delta descriptors=false blank=true${DONE}" C-m\; ${WAIT}
+  else
+    tmux send-keys -t $SESSION:2 "./beta createwallet delta${DONE}" C-m\; ${WAIT}
+  fi
   tmux send-keys -t $SESSION:2 "./delta sethdseed true ${DELTA_WALLET_SEED}${DONE}" C-m\; ${WAIT}
 
   #################################################################################

--- a/dex/testing/btc/harness.sh
+++ b/dex/testing/btc/harness.sh
@@ -19,6 +19,7 @@ export GAMMA_ADDRESS="bcrt1qh6m8v7czylaz8tzeaxxjqjhqgs0ruu0lu44ksy"
 # Delta is a named wallet in the beta wallet directory.
 export DELTA_WALLET_SEED="cURsyTZ8icuTHwWxSfTC2Geu2F6dMRtnzt1gvSaxHdc9Zf6eviJN"
 export DELTA_ADDRESS="bcrt1q4clywna5re22qh9mexqty8u8mqvhjh8cwhp5ms"
+export LONG_CREATEWALLET="1"
 export EXTRA_ARGS="--blockfilterindex --peerblockfilters --rpcbind=0.0.0.0 --rpcallowip=0.0.0.0/0"
 # Run the harness
 ./base-harness.sh


### PR DESCRIPTION
```
The default wallet type with v23 of Bitcoin Core using the createwallet
RPC is a "descriptor" wallet, which does not work with DEX.

This updates the harness script to specify descriptors=false with the
named form of cli commands, which seem to be available since at least
0.19.  The latest litecoin is also good with this and will also switch
to named arguments with 0.21.  For now, just BTC.
```

@JoeGruffins I ran into this when messing with loadbot using bitcoind v23.
I see in https://github.com/decred/dcrdex/pull/1656 you are removing the new-wallet shell script, but I'm not sure what your plan is there yet since BTC needs `createwallet` while DCR needs `createnewaccount`, plus as we see now the args can be different between Bitcoin clones.

This PR is required until https://github.com/decred/dcrdex/pull/1659 is done