### PR TITLE
multi: show recently matched orders

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -192,8 +192,9 @@ func (b *bookie) logEpochReport(note *msgjson.EpochReportNote) error {
 	}
 
 	marketID := marketName(b.base, b.quote)
-	if note.MatchesSummary != nil {
-		b.SetMatchesSummary(note.MatchesSummary, note.EndStamp)
+	b.SetMatchesSummary(note.MatchesSummarySell, note.EndStamp, true)
+	b.SetMatchesSummary(note.MatchesSummaryBuy, note.EndStamp, false)
+	if note.MatchesSummaryBuy != nil || note.MatchesSummarySell != nil {
 		b.send(&BookUpdate{
 			Action:   EpochMatchSummary,
 			MarketID: marketID,

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -192,13 +192,14 @@ func (b *bookie) logEpochReport(note *msgjson.EpochReportNote) error {
 	}
 
 	marketID := marketName(b.base, b.quote)
-	b.SetMatchesSummary(note.MatchesSummary, note.EndStamp)
-	fmt.Printf("matches summary: %+v\n\n", b.GetMatchesSummary())
-	b.send(&BookUpdate{
-		Action:   EpochMatchSummary,
-		MarketID: marketID,
-		Payload:  b.GetMatchesSummary(),
-	})
+	if note.MatchesSummary != nil {
+		b.SetMatchesSummary(note.MatchesSummary, note.EndStamp)
+		b.send(&BookUpdate{
+			Action:   EpochMatchSummary,
+			MarketID: marketID,
+			Payload:  b.GetMatchesSummary(),
+		})
+	}
 	for durStr, cache := range b.candleCaches {
 		c := cache.addCandle(&note.Candle)
 		if c == nil {

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -596,6 +596,7 @@ const (
 	UnbookOrderAction     = "unbook_order"
 	UpdateRemainingAction = "update_remaining"
 	CandleUpdateAction    = "candle_update"
+	EpochMatchSummary     = "epoch_match_summary"
 )
 
 // BookUpdate is an order book update.

--- a/client/orderbook/orderbook.go
+++ b/client/orderbook/orderbook.go
@@ -641,13 +641,32 @@ func (ob *OrderBook) SetMatchesSummary(matches map[uint64]uint64, ts uint64, sel
 		return
 	}
 	ob.matchesSummary = append(newMatchesSummary, ob.matchesSummary...)
-	maxLength := 1000
-	// if maxLength is greater than 100, slice it and left the first 100.
-	if len(ob.matchesSummary) > maxLength+100 {
-		ob.matchesSummary = ob.matchesSummary[maxLength:]
+	maxLength := 100
+	// if ob.matchesSummary length is greater than max length, we slice the array
+	// to maxLength, removing values first added.
+	if len(ob.matchesSummary) > maxLength {
+		ob.matchesSummary = ob.matchesSummary[:maxLength]
 	}
 }
 
-func (ob *OrderBook) GetMatchesSummary() []*MatchSummary {
-	return ob.matchesSummary
+// GetMatchesSummary returns a deep copy of MatchesSummary
+func (ob *OrderBook) GetMatchesSummary() []MatchSummary {
+	ob.matchSummaryMtx.Lock()
+	defer ob.matchSummaryMtx.Unlock()
+	matchesSummary := make([]MatchSummary, len(ob.matchesSummary))
+	for i := 0; i < len(ob.matchesSummary); i++ {
+		matchesSummary[i] = ob.matchesSummary[i].copy()
+	}
+	return matchesSummary
+}
+
+// makes a copy of a MatchSummary
+func (ob *MatchSummary) copy() MatchSummary {
+	matchSummary := MatchSummary{
+		Rate: ob.Rate,
+		Qty:  ob.Qty,
+		Age:  ob.Age,
+		Sell: ob.Sell,
+	}
+	return matchSummary
 }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -87,6 +87,7 @@ var EnUS = map[string]string{
 	"immature":                       "immature",
 	"Sell Orders":                    "Sell Orders",
 	"Your Orders":                    "Your Orders",
+	"Recent Matches":                 "Recent Matches",
 	"Type":                           "Type",
 	"Side":                           "Side",
 	"Age":                            "Age",

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -703,6 +703,41 @@ div.numorders {
   }
 }
 
+#recentMatchesTable {
+  th {
+    align-items: center;
+
+    &:hover {
+      opacity: 0.7;
+    }
+
+    .ico-arrowdown {
+      display: inline-block;
+      visibility: hidden;
+      vertical-align: middle;
+      font-size: 10px;
+      margin-left: 5px;
+    }
+
+    &.sorted-dsc {
+      .ico-arrowdown {
+        visibility: visible;
+      }
+    }
+
+    &.sorted-asc {
+      .ico-arrowdown {
+        visibility: visible;
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  tr {
+    cursor: pointer;
+  }
+}
+
 #vDetailPane {
   max-width: 425px;
 

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -420,6 +420,34 @@
       </div>
     </div>
 
+    {{- /* Recently Matched orders */ -}}
+    <div class="bg0 p-0 col-24 col-xxl-100 d-flex flex-column align-items-stretch">
+    {{/* <div class="bg0 p-0 col-24 col-xxl-10 d-flex flex-column align-items-stretch"> */}}
+        <div class="market-header text-center fs14 py-1 brdrleft">
+          [[[Recent Matches]]]
+        </div>
+        <div class=" brdrleft flex-grow-1 bg1 position-relative">
+          <div class="stylish-overflow">
+            <table id="recentMatchesTable" class="ordertable">
+              <thead>
+                <tr>
+                  <th data-ordercol="stamp">[[[Age]]] <span class="ico-arrowdown"></span></th>
+                  <th data-ordercol="rate">[[[Rate]]] <span class="ico-arrowdown"></span></th>
+                  <th data-ordercol="qty">[[[Quantity]]] <span class="ico-arrowdown"></span></th>
+                  <th class="last"></th>
+                </tr>
+              </thead>
+              <tbody id="recentMatchesLiveList">
+                <tr id="recentMatchesTemplate">
+                  <td data-tmpl="age" data-tooltip=" "></td>
+                  <td data-tmpl="rate"></td>
+                  <td data-tmpl="qty"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
   </div>
 
   {{- /* POP-UP FORMS */ -}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -431,7 +431,7 @@
             <table id="recentMatchesTable" class="ordertable">
               <thead>
                 <tr>
-                  <th data-ordercol="stamp">[[[Age]]] <span class="ico-arrowdown"></span></th>
+                  <th data-ordercol="stamp">[[[Time]]] <span class="ico-arrowdown"></span></th>
                   <th data-ordercol="rate">[[[Rate]]] <span class="ico-arrowdown"></span></th>
                   <th data-ordercol="qty">[[[Quantity]]] <span class="ico-arrowdown"></span></th>
                   <th class="last"></th>
@@ -439,7 +439,7 @@
               </thead>
               <tbody id="recentMatchesLiveList">
                 <tr id="recentMatchesTemplate">
-                  <td data-tmpl="age" data-tooltip=" "></td>
+                  <td data-tmpl="age"></td>
                   <td data-tmpl="rate"></td>
                   <td data-tmpl="qty"></td>
                 </tr>

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1910,8 +1910,7 @@ export default class MarketsPage extends BasePage {
       updateDataCol(row, 'rate', Doc.formatCoinValue(match.rate / this.market.rateConversionFactor))
       // change rate color based if is sell or not.
       updateDataCol(row, 'qty', Doc.formatCoinValue(match.qty, this.market.baseUnitInfo))
-      updateDataCol(row, 'age', match.age.toLocaleDateString())
-      updateToolTipCol(row, 'age', match.age.toLocaleTimeString())
+      updateDataCol(row, 'age', match.age.toLocaleTimeString())
       row.classList.add(match.sell ? 'sellcolor' : 'buycolor')
 
       page.recentMatchesLiveList.append(row)
@@ -2799,10 +2798,6 @@ function swapBttns (before: HTMLElement, now: HTMLElement) {
  */
 function updateDataCol (tr: HTMLElement, col: string, s: string) {
   Doc.tmplElement(tr, col).textContent = s
-}
-
-function updateToolTipCol (tr: HTMLElement, col: string, s: string) {
-  Doc.tmplElement(tr, col).dataset.tooltip = s
 }
 
 /*

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -50,7 +50,8 @@ import {
   ConnEventNote,
   Spot,
   OrderOption,
-  ConnectionStatus
+  ConnectionStatus,
+  RecentMatch
 } from './registry'
 
 const bind = Doc.bind
@@ -63,6 +64,7 @@ const epochOrderRoute = 'epoch_order'
 const candlesRoute = 'candles'
 const candleUpdateRoute = 'candle_update'
 const unmarketRoute = 'unmarket'
+const epochMatchSummaryRoute = 'epoch_match_summary'
 
 const lastMarketKey = 'selectedMarket'
 const chartRatioKey = 'chartRatio'
@@ -184,6 +186,9 @@ export default class MarketsPage extends BasePage {
   secondTicker: number
   candlesLoading: LoadTracker | null
   accelerateOrderForm: AccelerateOrderForm
+  recentMatches: RecentMatch[]
+  recentMatchesSortKey: string
+  recentMatchesSortDirection: 1 | -1
 
   constructor (main: HTMLElement, data: any) {
     super()
@@ -195,6 +200,7 @@ export default class MarketsPage extends BasePage {
     // that the screen is updated with the most recent one.
     this.maxOrderUpdateCounter = 0
     this.metaOrders = {}
+    this.recentMatches = []
     this.preorderCache = {}
     this.depthLines = {
       hover: [],
@@ -203,8 +209,12 @@ export default class MarketsPage extends BasePage {
     this.hovers = []
     // 'Your Orders' list sort key and direction.
     this.ordersSortKey = 'submitTime'
+    // 'Recent Matches' list sort key and direction.
+    this.recentMatchesSortKey = 'stamp'
     // 1 if sorting ascendingly, -1 if sorting descendingly.
     this.ordersSortDirection = 1
+    // same as this.ordersSortDirection.
+    this.recentMatchesSortDirection = 1
     // store original title so we can re-append it when updating market value.
     this.ogTitle = document.title
 
@@ -340,6 +350,8 @@ export default class MarketsPage extends BasePage {
     // Handle the candles update on the 'candles' route.
     ws.registerRoute(candleUpdateRoute, (data: BookUpdate) => { this.handleCandleUpdateRoute(data) })
 
+    // Handle the recent matches update on the 'epoch_report' route.
+    ws.registerRoute(epochMatchSummaryRoute, (data: BookUpdate) => { this.handleEpochMatchSummary(data) })
     // Bind the wallet unlock form.
     this.unlockForm = new UnlockWalletForm(page.unlockWalletForm, async () => { this.openFunc() })
     // Create a wallet
@@ -358,6 +370,24 @@ export default class MarketsPage extends BasePage {
     // Bind active orders list's header sort events.
     page.liveTable.querySelectorAll('[data-ordercol]')
       .forEach((th: HTMLElement) => bind(th, 'click', () => setOrdersSortCol(th.dataset.ordercol || '')))
+    // Bind active orders list's header sort events.
+    page.recentMatchesTable.querySelectorAll('[data-ordercol]')
+      .forEach((th: HTMLElement) => bind(
+        th, 'click', () => setRecentMatchesSortCol(th.dataset.ordercol || '')
+      ))
+
+    const setRecentMatchesSortCol = (key: string) => {
+      // First unset header's current sorted col classes.
+      unsetRecentMatchesSortColClasses()
+      if (this.recentMatchesSortKey === key) {
+        this.recentMatchesSortDirection *= -1
+      } else {
+        this.recentMatchesSortKey = key
+        this.recentMatchesSortDirection = 1
+      }
+      this.refreshRecentMatchesTable()
+      setRecentMatchesSortColClasses()
+    }
 
     const setOrdersSortCol = (key: string) => {
       // First unset header's current sorted col classes.
@@ -375,8 +405,9 @@ export default class MarketsPage extends BasePage {
       setOrdersSortColClasses()
     }
 
-    const sortClassByDirection = () => {
-      if (this.ordersSortDirection === 1) return 'sorted-asc'
+    // sortClassByDirection receives a sort direction and return a class based on it.
+    const sortClassByDirection = (element: 1 | -1) => {
+      if (element === 1) return 'sorted-asc'
       return 'sorted-dsc'
     }
 
@@ -385,14 +416,26 @@ export default class MarketsPage extends BasePage {
         .forEach(th => th.classList.remove('sorted-asc', 'sorted-dsc'))
     }
 
+    const unsetRecentMatchesSortColClasses = () => {
+      page.recentMatchesTable.querySelectorAll('[data-ordercol]')
+        .forEach(th => th.classList.remove('sorted-asc', 'sorted-dsc'))
+    }
+
     const setOrdersSortColClasses = () => {
       const key = this.ordersSortKey
-      const sortCls = sortClassByDirection()
+      const sortCls = sortClassByDirection(this.ordersSortDirection)
       Doc.safeSelector(page.liveTable, `[data-ordercol=${key}]`).classList.add(sortCls)
+    }
+
+    const setRecentMatchesSortColClasses = () => {
+      const key = this.recentMatchesSortKey
+      const sortCls = sortClassByDirection(this.recentMatchesSortDirection)
+      Doc.safeSelector(page.recentMatchesTable, `[data-ordercol=${key}]`).classList.add(sortCls)
     }
 
     // Set default's sorted col header classes.
     setOrdersSortColClasses()
+    setRecentMatchesSortColClasses()
 
     const closePopups = () => {
       Doc.hide(page.forms)
@@ -708,6 +751,7 @@ export default class MarketsPage extends BasePage {
       this.maxEstimateTimer = null
     }
     const mktId = marketID(baseCfg.symbol, quoteCfg.symbol)
+    this.bindToRecentMatches(dex.markets[mktId].recentmatches)
     this.market = {
       dex: dex,
       sid: mktId, // A string market identifier used by the DEX.
@@ -736,6 +780,7 @@ export default class MarketsPage extends BasePage {
       if (dex.candleDurs.indexOf(this.candleDur) === -1) this.candleDur = dex.candleDurs[0]
       this.loadCandles()
     }
+    this.refreshRecentMatchesTable()
     this.setLoaderMsgVisibility()
     this.setRegistrationStatusVisibility()
     this.resolveOrderFormVisibility()
@@ -1338,6 +1383,11 @@ export default class MarketsPage extends BasePage {
     this.candleChart.setCandles(data.payload, this.market.cfg, this.market.baseUnitInfo, this.market.quoteUnitInfo)
   }
 
+  handleEpochMatchSummary (data: BookUpdate) {
+    this.bindToRecentMatches(data.payload)
+    this.refreshRecentMatchesTable()
+  }
+
   /* handleCandleUpdateRoute is the handler for 'candle_update' notifications. */
   handleCandleUpdateRoute (data: BookUpdate) {
     if (data.host !== this.market.dex.host) return
@@ -1829,6 +1879,58 @@ export default class MarketsPage extends BasePage {
           break
       }
     }
+  }
+
+  /*
+   * ordersSortCompare returns sort compare function according to the active
+   * sort key and direction.
+   */
+  recentMatchesSortCompare () {
+    switch (this.recentMatchesSortKey) {
+      case 'rate':
+        return (a: RecentMatch, b: RecentMatch) => this.recentMatchesSortDirection * (a.Rate - b.Rate)
+      case 'qty':
+        return (a: RecentMatch, b: RecentMatch) => this.recentMatchesSortDirection * (a.Qty - b.Qty)
+      case 'age':
+        return (a: RecentMatch, b:RecentMatch) => this.recentMatchesSortDirection * (a.Age.getTime() - b.Age.getTime())
+    }
+  }
+
+  refreshRecentMatchesTable () {
+    const page = this.page
+    const recentMatches = this.recentMatches
+    Doc.empty(page.recentMatchesLiveList)
+    if (!recentMatches) return
+    const compare = this.recentMatchesSortCompare()
+    recentMatches.sort(compare)
+    for (const match of recentMatches) {
+      const row = page.recentMatchesTemplate.cloneNode(true) as HTMLElement
+
+      this.updateRecentMatchRow(row, match)
+
+      page.recentMatchesLiveList.append(row)
+    }
+  }
+
+  updateRecentMatchRow (tr: HTMLElement, match: RecentMatch) {
+    app().bindTooltips(tr)
+    updateDataCol(tr, 'rate', Doc.formatCoinValue(match.Rate / this.market.rateConversionFactor))
+    // change rate color based if is sell or not.
+    updateDataCol(tr, 'qty', Doc.formatCoinValue(match.Qty, this.market.baseUnitInfo))
+    updateDataCol(tr, 'age', match.Age.toLocaleDateString())
+    updateToolTipCol(tr, 'age', match.Age.toLocaleTimeString())
+  }
+
+  bindToRecentMatches (matches: RecentMatch[]) {
+    // if does not have new matches, just skip.
+    if (!matches) {
+      this.recentMatches = []
+      return
+    }
+    for (let i = 0; i < matches.length; i++) {
+      matches[i].Age = new Date(matches[i].Age)
+    }
+    this.recentMatches = matches
   }
 
   setBalanceVisibility () {
@@ -2703,6 +2805,10 @@ function swapBttns (before: HTMLElement, now: HTMLElement) {
  */
 function updateDataCol (tr: HTMLElement, col: string, s: string) {
   Doc.tmplElement(tr, col).textContent = s
+}
+
+function updateToolTipCol (tr: HTMLElement, col: string, s: string) {
+  Doc.tmplElement(tr, col).dataset.tooltip = s
 }
 
 /*

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -751,7 +751,7 @@ export default class MarketsPage extends BasePage {
       this.maxEstimateTimer = null
     }
     const mktId = marketID(baseCfg.symbol, quoteCfg.symbol)
-    this.bindToRecentMatches(dex.markets[mktId].recentmatches)
+    this.setToRecentMatches(dex.markets[mktId].recentmatches)
     this.market = {
       dex: dex,
       sid: mktId, // A string market identifier used by the DEX.
@@ -1384,7 +1384,7 @@ export default class MarketsPage extends BasePage {
   }
 
   handleEpochMatchSummary (data: BookUpdate) {
-    this.bindToRecentMatches(data.payload)
+    this.setToRecentMatches(data.payload)
     this.refreshRecentMatchesTable()
   }
 
@@ -1888,11 +1888,11 @@ export default class MarketsPage extends BasePage {
   recentMatchesSortCompare () {
     switch (this.recentMatchesSortKey) {
       case 'rate':
-        return (a: RecentMatch, b: RecentMatch) => this.recentMatchesSortDirection * (a.Rate - b.Rate)
+        return (a: RecentMatch, b: RecentMatch) => this.recentMatchesSortDirection * (a.rate - b.rate)
       case 'qty':
-        return (a: RecentMatch, b: RecentMatch) => this.recentMatchesSortDirection * (a.Qty - b.Qty)
+        return (a: RecentMatch, b: RecentMatch) => this.recentMatchesSortDirection * (a.qty - b.qty)
       case 'age':
-        return (a: RecentMatch, b:RecentMatch) => this.recentMatchesSortDirection * (a.Age.getTime() - b.Age.getTime())
+        return (a: RecentMatch, b:RecentMatch) => this.recentMatchesSortDirection * (a.age.getTime() - b.age.getTime())
     }
   }
 
@@ -1906,29 +1906,23 @@ export default class MarketsPage extends BasePage {
     for (const match of recentMatches) {
       const row = page.recentMatchesTemplate.cloneNode(true) as HTMLElement
 
-      this.updateRecentMatchRow(row, match)
+      app().bindTooltips(row)
+      updateDataCol(row, 'rate', Doc.formatCoinValue(match.rate / this.market.rateConversionFactor))
+      // change rate color based if is sell or not.
+      updateDataCol(row, 'qty', Doc.formatCoinValue(match.qty, this.market.baseUnitInfo))
+      updateDataCol(row, 'age', match.age.toLocaleDateString())
+      updateToolTipCol(row, 'age', match.age.toLocaleTimeString())
+      row.classList.add(match.sell ? 'sellcolor' : 'buycolor')
 
       page.recentMatchesLiveList.append(row)
     }
   }
 
-  updateRecentMatchRow (tr: HTMLElement, match: RecentMatch) {
-    app().bindTooltips(tr)
-    updateDataCol(tr, 'rate', Doc.formatCoinValue(match.Rate / this.market.rateConversionFactor))
-    // change rate color based if is sell or not.
-    updateDataCol(tr, 'qty', Doc.formatCoinValue(match.Qty, this.market.baseUnitInfo))
-    updateDataCol(tr, 'age', match.Age.toLocaleDateString())
-    updateToolTipCol(tr, 'age', match.Age.toLocaleTimeString())
-  }
-
-  bindToRecentMatches (matches: RecentMatch[]) {
+  setToRecentMatches (matches: RecentMatch[]) {
     // if does not have new matches, just skip.
-    if (!matches) {
-      this.recentMatches = []
-      return
-    }
+    if (!matches) return
     for (let i = 0; i < matches.length; i++) {
-      matches[i].Age = new Date(matches[i].Age)
+      matches[i].age = new Date(matches[i].age)
     }
     this.recentMatches = matches
   }

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -56,6 +56,7 @@ export interface Market {
   buybuffer: number
   orders: Order[]
   spot: Spot
+  recentmatches: RecentMatch[]
 }
 
 export interface Order {
@@ -315,6 +316,12 @@ export interface OrderNote extends CoreNote {
   order: Order
 }
 
+export interface RecentMatch {
+  Rate: number
+  Qty: number
+  Age: Date
+}
+
 export interface EpochNote extends CoreNote {
   host: string
   marketID: string
@@ -442,6 +449,7 @@ export interface BookUpdate {
   action: string
   host: string
   marketID: string
+  matchessummary: RecentMatch[]
   payload: any
 }
 

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -317,9 +317,10 @@ export interface OrderNote extends CoreNote {
 }
 
 export interface RecentMatch {
-  Rate: number
-  Qty: number
-  Age: Date
+  rate: number
+  qty: number
+  age: Date
+  sell: boolean
 }
 
 export interface EpochNote extends CoreNote {
@@ -449,7 +450,7 @@ export interface BookUpdate {
   action: string
   host: string
   marketID: string
-  matchessummary: RecentMatch[]
+  matchesSummary: RecentMatch[]
   payload: any
 }
 

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1178,7 +1178,8 @@ type EpochReportNote struct {
 	BaseFeeRate  uint64 `json:"baseFeeRate"`
 	QuoteFeeRate uint64 `json:"quoteFeeRate"`
 	// quantity of matches by rate: [rate]qty
-	MatchesSummary map[uint64]uint64 `json:"matchessumary"`
+	MatchesSummaryBuy  map[uint64]uint64 `json:"matchesSummaryBuy"`
+	MatchesSummarySell map[uint64]uint64 `json:"matchesSummarySell"`
 	Candle
 }
 

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1177,6 +1177,8 @@ type EpochReportNote struct {
 	Epoch        uint64 `json:"epoch"`
 	BaseFeeRate  uint64 `json:"baseFeeRate"`
 	QuoteFeeRate uint64 `json:"quoteFeeRate"`
+	// quantity of matches by rate: [rate]qty
+	MatchesSummary map[uint64]uint64 `json:"matchessumary"`
 	Candle
 }
 

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -104,12 +104,13 @@ type sigDataEpochOrder sigDataOrder
 type sigDataUpdateRemaining sigDataOrder
 
 type sigDataEpochReport struct {
-	epochIdx     int64
-	epochDur     int64
-	stats        *matcher.MatchCycleStats
-	spot         *msgjson.Spot
-	baseFeeRate  uint64
-	quoteFeeRate uint64
+	epochIdx       int64
+	epochDur       int64
+	stats          *matcher.MatchCycleStats
+	spot           *msgjson.Spot
+	baseFeeRate    uint64
+	quoteFeeRate   uint64
+	matchesSummary map[uint64]uint64
 }
 
 type sigDataNewEpoch struct {
@@ -428,6 +429,7 @@ out:
 						StartRate:   stats.StartRate,
 						EndRate:     stats.EndRate,
 					},
+					MatchesSummary: sigData.matchesSummary,
 				}
 
 			case sigDataEpochOrder:

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -104,13 +104,14 @@ type sigDataEpochOrder sigDataOrder
 type sigDataUpdateRemaining sigDataOrder
 
 type sigDataEpochReport struct {
-	epochIdx       int64
-	epochDur       int64
-	stats          *matcher.MatchCycleStats
-	spot           *msgjson.Spot
-	baseFeeRate    uint64
-	quoteFeeRate   uint64
-	matchesSummary map[uint64]uint64
+	epochIdx           int64
+	epochDur           int64
+	stats              *matcher.MatchCycleStats
+	spot               *msgjson.Spot
+	baseFeeRate        uint64
+	quoteFeeRate       uint64
+	matchesSummaryBuy  map[uint64]uint64
+	matchesSummarySell map[uint64]uint64
 }
 
 type sigDataNewEpoch struct {
@@ -429,7 +430,8 @@ out:
 						StartRate:   stats.StartRate,
 						EndRate:     stats.EndRate,
 					},
-					MatchesSummary: sigData.matchesSummary,
+					MatchesSummaryBuy:  sigData.matchesSummaryBuy,
+					MatchesSummarySell: sigData.matchesSummarySell,
 				}
 
 			case sigDataEpochOrder:

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -2589,23 +2589,29 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 		log.Errorf("Error updating API data collector: %v", err)
 	}
 
-	basicMatches := make(map[uint64]uint64)
+	basicMatchesSell := make(map[uint64]uint64)
+	basicMatchesBuy := make(map[uint64]uint64)
 	for _, matchSet := range matches {
 		for _, match := range matchSet.Matches() {
-			basicMatches[match.Rate] += match.Quantity
+			if match.Maker.Sell {
+				basicMatchesSell[match.Rate] += match.Quantity
+			} else {
+				basicMatchesBuy[match.Rate] += match.Quantity
+			}
 		}
 	}
 	// Send "epoch_report" notifications.
 	notifyChan <- &updateSignal{
 		action: epochReportAction,
 		data: sigDataEpochReport{
-			epochIdx:       epoch.Epoch,
-			epochDur:       epoch.Duration,
-			spot:           spot,
-			stats:          stats,
-			baseFeeRate:    feeRateBase,
-			quoteFeeRate:   feeRateQuote,
-			matchesSummary: basicMatches,
+			epochIdx:           epoch.Epoch,
+			epochDur:           epoch.Duration,
+			spot:               spot,
+			stats:              stats,
+			baseFeeRate:        feeRateBase,
+			quoteFeeRate:       feeRateQuote,
+			matchesSummaryBuy:  basicMatchesBuy,
+			matchesSummarySell: basicMatchesSell,
 		},
 	}
 

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -2593,7 +2593,7 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 	basicMatchesBuy := make(map[uint64]uint64)
 	for _, matchSet := range matches {
 		for _, match := range matchSet.Matches() {
-			if match.Maker.Sell {
+			if match.Taker.Trade() != nil && match.Taker.Trade().Sell {
 				basicMatchesSell[match.Rate] += match.Quantity
 			} else {
 				basicMatchesBuy[match.Rate] += match.Quantity

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -2589,16 +2589,23 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 		log.Errorf("Error updating API data collector: %v", err)
 	}
 
+	basicMatches := make(map[uint64]uint64)
+	for _, matchSet := range matches {
+		for _, match := range matchSet.Matches() {
+			basicMatches[match.Rate] += match.Quantity
+		}
+	}
 	// Send "epoch_report" notifications.
 	notifyChan <- &updateSignal{
 		action: epochReportAction,
 		data: sigDataEpochReport{
-			epochIdx:     epoch.Epoch,
-			epochDur:     epoch.Duration,
-			spot:         spot,
-			stats:        stats,
-			baseFeeRate:  feeRateBase,
-			quoteFeeRate: feeRateQuote,
+			epochIdx:       epoch.Epoch,
+			epochDur:       epoch.Duration,
+			spot:           spot,
+			stats:          stats,
+			baseFeeRate:    feeRateBase,
+			quoteFeeRate:   feeRateQuote,
+			matchesSummary: basicMatches,
 		},
 	}
 

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -2593,6 +2593,10 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 	basicMatchesBuy := make(map[uint64]uint64)
 	for _, matchSet := range matches {
 		for _, match := range matchSet.Matches() {
+			// skip cancel order types
+			if _, ok := match.Taker.(*order.CancelOrder); ok {
+				continue
+			}
 			if match.Taker.Trade() != nil && match.Taker.Trade().Sell {
 				basicMatchesSell[match.Rate] += match.Quantity
 			} else {

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -1348,7 +1348,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 				{bookAction, sigDataBookedOrder{lo, epochIdx}},
 				{unbookAction, sigDataUnbookedOrder{bestBuy, epochIdx}},
 				{unbookAction, sigDataUnbookedOrder{bestSell, epochIdx}},
-				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil}},
+				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil, nil}},
 			},
 		},
 		{
@@ -1356,7 +1356,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 			eq2,
 			[]*updateSignal{
 				{matchProofAction, sigDataMatchProof{mp2}},
-				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil}},
+				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil, nil}},
 			},
 		},
 		{
@@ -1364,7 +1364,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 			NewEpoch(epochIdx, epochDur),
 			[]*updateSignal{
 				{matchProofAction, sigDataMatchProof{mp0}},
-				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil}},
+				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil, nil}},
 			},
 		},
 	}

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -1348,7 +1348,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 				{bookAction, sigDataBookedOrder{lo, epochIdx}},
 				{unbookAction, sigDataUnbookedOrder{bestBuy, epochIdx}},
 				{unbookAction, sigDataUnbookedOrder{bestSell, epochIdx}},
-				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10}},
+				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil}},
 			},
 		},
 		{
@@ -1356,7 +1356,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 			eq2,
 			[]*updateSignal{
 				{matchProofAction, sigDataMatchProof{mp2}},
-				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10}},
+				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil}},
 			},
 		},
 		{
@@ -1364,7 +1364,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 			NewEpoch(epochIdx, epochDur),
 			[]*updateSignal{
 				{matchProofAction, sigDataMatchProof{mp0}},
-				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10}},
+				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil}},
 			},
 		},
 	}


### PR DESCRIPTION
This PR closes #1143 

I am adding a basic match struct into `MatchProofNote` so we can be notified on the client.

On the client I added a new recent matches table in our market page. Here how it looks right now:

This is how it looks right now:

![image](https://user-images.githubusercontent.com/15069783/180444318-eb734fbb-18bd-4641-8cbd-e17e2201e25e.png)

smaller screen: 

![image](https://user-images.githubusercontent.com/15069783/180444404-97eb30be-8dee-4082-b8cd-c7c43894f7b8.png)

