### PR TITLE
server/{market,swap,db}: free cancels

### DIFF
--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -433,7 +433,7 @@ func (auth *AuthManager) ExpectUsers(users map[account.AccountID]struct{}, withi
 
 // RecordCancel records a user's executed cancel order, including the canceled
 // order ID, and the time when the cancel was executed.
-func (auth *AuthManager) RecordCancel(user account.AccountID, oid, target order.OrderID, epochGap int, t time.Time) {
+func (auth *AuthManager) RecordCancel(user account.AccountID, oid, target order.OrderID, epochGap int32, t time.Time) {
 	auth.recordOrderDone(user, oid, &target, epochGap, t.UnixMilli())
 }
 
@@ -449,7 +449,7 @@ func (auth *AuthManager) RecordCompletedOrder(user account.AccountID, oid order.
 // completed the swap negotiation. Note that in the case of a cancel, oid refers
 // to the ID of the cancel order itself, while target is non-nil for cancel
 // orders.
-func (auth *AuthManager) recordOrderDone(user account.AccountID, oid order.OrderID, target *order.OrderID, epochGap int, tMS int64) {
+func (auth *AuthManager) recordOrderDone(user account.AccountID, oid order.OrderID, target *order.OrderID, epochGap int32, tMS int64) {
 	client := auth.user(user)
 	if client == nil {
 		// It is likely that the user is gone if this is a revoked order.
@@ -1361,10 +1361,11 @@ func (auth *AuthManager) loadRecentFinishedOrders(aid account.AccountID, N int) 
 	// Insert the executed cancels, popping off older orders that do not fit in
 	// the list.
 	for _, c := range cancels {
+		tid := c.TargetID
 		latestFinished.add(&oidStamped{
 			OrderID:  c.ID,
 			time:     c.MatchTime,
-			target:   &c.TargetID,
+			target:   &tid,
 			epochGap: c.EpochGap,
 		})
 	}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -54,7 +54,7 @@ type Storage interface {
 	UserOrderStatuses(aid account.AccountID, base, quote uint32, oids []order.OrderID) ([]*db.OrderStatus, error)
 	ActiveUserOrderStatuses(aid account.AccountID) ([]*db.OrderStatus, error)
 	CompletedUserOrders(aid account.AccountID, N int) (oids []order.OrderID, compTimes []int64, err error)
-	ExecutedCancelsForUser(aid account.AccountID, N int) (oids, targets []order.OrderID, execTimes []int64, err error)
+	ExecutedCancelsForUser(aid account.AccountID, N int) ([]*db.CancelRecord, error)
 	CompletedAndAtFaultMatchStats(aid account.AccountID, lastN int) ([]*db.MatchOutcome, error)
 	PreimageStats(user account.AccountID, lastN int) ([]*db.PreimageResult, error)
 	AllActiveUserMatches(aid account.AccountID) ([]*db.MatchData, error)
@@ -433,15 +433,15 @@ func (auth *AuthManager) ExpectUsers(users map[account.AccountID]struct{}, withi
 
 // RecordCancel records a user's executed cancel order, including the canceled
 // order ID, and the time when the cancel was executed.
-func (auth *AuthManager) RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time) {
-	auth.recordOrderDone(user, oid, &target, t.UnixMilli())
+func (auth *AuthManager) RecordCancel(user account.AccountID, oid, target order.OrderID, epochGap int, t time.Time) {
+	auth.recordOrderDone(user, oid, &target, epochGap, t.UnixMilli())
 }
 
 // RecordCompletedOrder records a user's completed order, where completed means
 // a swap involving the order was successfully completed and the order is no
 // longer on the books if it ever was.
 func (auth *AuthManager) RecordCompletedOrder(user account.AccountID, oid order.OrderID, t time.Time) {
-	auth.recordOrderDone(user, oid, nil, t.UnixMilli())
+	auth.recordOrderDone(user, oid, nil, db.EpochGapNA, t.UnixMilli())
 }
 
 // recordOrderDone an order that has finished processing. This can be a cancel
@@ -449,7 +449,7 @@ func (auth *AuthManager) RecordCompletedOrder(user account.AccountID, oid order.
 // completed the swap negotiation. Note that in the case of a cancel, oid refers
 // to the ID of the cancel order itself, while target is non-nil for cancel
 // orders.
-func (auth *AuthManager) recordOrderDone(user account.AccountID, oid order.OrderID, target *order.OrderID, tMS int64) {
+func (auth *AuthManager) recordOrderDone(user account.AccountID, oid order.OrderID, target *order.OrderID, epochGap int, tMS int64) {
 	client := auth.user(user)
 	if client == nil {
 		// It is likely that the user is gone if this is a revoked order.
@@ -460,9 +460,10 @@ func (auth *AuthManager) recordOrderDone(user account.AccountID, oid order.Order
 	// Update recent orders and check/set suspended status atomically.
 	client.mtx.Lock()
 	client.recentOrders.add(&oidStamped{
-		OrderID: oid,
-		time:    tMS,
-		target:  target,
+		OrderID:  oid,
+		time:     tMS,
+		target:   target,
+		epochGap: epochGap,
 	})
 
 	log.Debugf("Recorded order %v that has finished processing: user=%v, time=%v, target=%v",
@@ -1342,7 +1343,7 @@ func (auth *AuthManager) loadRecentFinishedOrders(aid account.AccountID, N int) 
 	}
 
 	// Load the N latest executed cancel orders for the user.
-	cancelOids, targetOids, cancelTimes, err := auth.storage.ExecutedCancelsForUser(aid, N)
+	cancels, err := auth.storage.ExecutedCancelsForUser(aid, N)
 	if err != nil {
 		return nil, err
 	}
@@ -1359,11 +1360,12 @@ func (auth *AuthManager) loadRecentFinishedOrders(aid account.AccountID, N int) 
 	}
 	// Insert the executed cancels, popping off older orders that do not fit in
 	// the list.
-	for i := range cancelOids {
+	for _, c := range cancels {
 		latestFinished.add(&oidStamped{
-			OrderID: cancelOids[i],
-			time:    cancelTimes[i],
-			target:  &targetOids[i],
+			OrderID:  c.ID,
+			time:     c.MatchTime,
+			target:   &c.TargetID,
+			epochGap: c.EpochGap,
 		})
 	}
 

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -44,7 +44,7 @@ type ratioData struct {
 	oidsCancels    []order.OrderID
 	oidsCanceled   []order.OrderID
 	timesCanceled  []int64
-	epochGaps      []int
+	epochGaps      []int32
 }
 
 // TStorage satisfies the Storage interface
@@ -709,7 +709,7 @@ func TestConnect(t *testing.T) {
 	rig.storage.matches = []*db.MatchData{matchData}
 	defer func() { rig.storage.matches = nil }()
 
-	epochGaps := []int{1} // penalized
+	epochGaps := []int32{1} // penalized
 
 	rig.storage.setRatioData(&ratioData{
 		oidsCompleted:  []order.OrderID{{0x1}},

--- a/server/auth/cancel.go
+++ b/server/auth/cancel.go
@@ -12,12 +12,20 @@ import (
 	"decred.org/dcrdex/dex/order"
 )
 
+// freeCancelThreshold is the minimum number of epochs a user should wait before
+// placing a cancel order, if they want to avoid penalization. It is set to 2,
+// which means if a user places a cancel order in the same epoch as its limit
+// order, or the next epoch, the user will be penalized. This ensures that the
+// order remains booked for at least one full epoch and one full match cycle.
+const freeCancelThreshold = 2
+
 // oidStamped is a time-stamped order ID, with a field for target order ID if
 // the order is a cancel order.
 type oidStamped struct {
 	order.OrderID
-	time   int64
-	target *order.OrderID
+	time     int64
+	target   *order.OrderID
+	epochGap int
 }
 
 // ordsByTimeThenID is used to sort an ord slice in ascending order by time and
@@ -116,7 +124,7 @@ func (lo *latestOrders) counts() (total, cancels int) {
 
 	total = len(lo.orders)
 	for _, o := range lo.orders {
-		if o.target != nil {
+		if o.target != nil && o.epochGap >= 0 && o.epochGap < freeCancelThreshold {
 			cancels++
 		}
 	}

--- a/server/auth/cancel.go
+++ b/server/auth/cancel.go
@@ -15,8 +15,9 @@ import (
 // freeCancelThreshold is the minimum number of epochs a user should wait before
 // placing a cancel order, if they want to avoid penalization. It is set to 2,
 // which means if a user places a cancel order in the same epoch as its limit
-// order, or the next epoch, the user will be penalized. This ensures that the
-// order remains booked for at least one full epoch and one full match cycle.
+// order, or the next epoch, the user will be penalized. This value is chosen
+// because it is the minimum value such that the order remains booked for at
+// least one full epoch and one full match cycle.
 const freeCancelThreshold = 2
 
 // oidStamped is a time-stamped order ID, with a field for target order ID if
@@ -25,7 +26,7 @@ type oidStamped struct {
 	order.OrderID
 	time     int64
 	target   *order.OrderID
-	epochGap int
+	epochGap int32
 }
 
 // ordsByTimeThenID is used to sort an ord slice in ascending order by time and

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -183,7 +183,7 @@ func (status pgOrderStatus) active() bool {
 
 // NewEpochOrder stores the given order with epoch status. This is equivalent to
 // StoreOrder with OrderStatusEpoch.
-func (a *Archiver) NewEpochOrder(ord order.Order, epochIdx, epochDur int64, epochGap int) error {
+func (a *Archiver) NewEpochOrder(ord order.Order, epochIdx, epochDur int64, epochGap int32) error {
 	return a.storeOrder(ord, epochIdx, epochDur, epochGap, orderStatusEpoch)
 }
 
@@ -538,7 +538,7 @@ func (a *Archiver) StoreOrder(ord order.Order, epochIdx, epochDur int64, status 
 	return a.storeOrder(ord, epochIdx, epochDur, db.EpochGapNA, marketToPgStatus(status))
 }
 
-func (a *Archiver) storeOrder(ord order.Order, epochIdx, epochDur int64, epochGap int, status pgOrderStatus) error {
+func (a *Archiver) storeOrder(ord order.Order, epochIdx, epochDur int64, epochGap int32, status pgOrderStatus) error {
 	marketSchema, err := a.marketSchema(ord.Base(), ord.Quote())
 	if err != nil {
 		return err
@@ -1278,7 +1278,7 @@ func (a *Archiver) executedCancelsForUser(ctx context.Context, dbe *sql.DB, stmt
 	for rows.Next() {
 		var oid, target order.OrderID
 		var execTime int64
-		var epochGap int
+		var epochGap int32
 		err = rows.Scan(&oid, &target, &epochGap, &execTime)
 		if err != nil {
 			return
@@ -1711,7 +1711,7 @@ func moveOrder(dbe sqlExecutor, oldTableName, newTableName string, oid order.Ord
 
 // BEGIN cancel order functions
 
-func storeCancelOrder(dbe sqlExecutor, tableName string, co *order.CancelOrder, status pgOrderStatus, epochIdx, epochDur int64, epochGap int) (int64, error) {
+func storeCancelOrder(dbe sqlExecutor, tableName string, co *order.CancelOrder, status pgOrderStatus, epochIdx, epochDur int64, epochGap int32) (int64, error) {
 	stmt := fmt.Sprintf(internal.InsertCancelOrder, tableName)
 	return sqlExec(dbe, stmt, co.ID(), co.AccountID, co.ClientTime,
 		co.ServerTime, co.Commit, co.TargetOrderID, status, epochIdx, epochDur, epochGap)

--- a/server/db/driver/pg/orders.go
+++ b/server/db/driver/pg/orders.go
@@ -183,8 +183,8 @@ func (status pgOrderStatus) active() bool {
 
 // NewEpochOrder stores the given order with epoch status. This is equivalent to
 // StoreOrder with OrderStatusEpoch.
-func (a *Archiver) NewEpochOrder(ord order.Order, epochIdx, epochDur int64) error {
-	return a.storeOrder(ord, epochIdx, epochDur, orderStatusEpoch)
+func (a *Archiver) NewEpochOrder(ord order.Order, epochIdx, epochDur int64, epochGap int) error {
+	return a.storeOrder(ord, epochIdx, epochDur, epochGap, orderStatusEpoch)
 }
 
 // NewArchivedCancel stores a cancel order directly in the executed state. This
@@ -197,7 +197,7 @@ func (a *Archiver) NewArchivedCancel(ord *order.CancelOrder, epochID, epochDur i
 	}
 	status := orderStatusExecuted
 	tableName := fullCancelOrderTableName(a.dbName, marketSchema, status.active())
-	N, err := storeCancelOrder(a.db, tableName, ord, status, epochID, epochDur)
+	N, err := storeCancelOrder(a.db, tableName, ord, status, epochID, epochDur, db.EpochGapNA)
 	if err != nil {
 		a.fatalBackendErr(err)
 		return fmt.Errorf("storeCancelOrder failed: %w", err)
@@ -298,7 +298,7 @@ func (a *Archiver) FlushBook(base, quote uint32) (sellsRemoved, buysRemoved []or
 		//  - Set epoch idx to exemptEpochIdx (-1) and dur to dummyEpochDur (1),
 		//    consistent with revokeOrder(..., exempt=true).
 		_, err = dbTx.Exec(stmt, co.ID(), co.AccountID, co.ClientTime,
-			co.ServerTime, nil, co.TargetOrderID, orderStatusRevoked, exemptEpochIdx, dummyEpochDur)
+			co.ServerTime, nil, co.TargetOrderID, orderStatusRevoked, exemptEpochIdx, dummyEpochDur, db.EpochGapNA)
 		if err != nil {
 			fail()
 			err = fmt.Errorf("failed to store pseudo-cancel order: %w", err)
@@ -511,7 +511,7 @@ func (a *Archiver) revokeOrder(ord order.Order, exempt bool) (cancelID order.Ord
 	if exempt {
 		epochIdx = exemptEpochIdx
 	}
-	err = a.storeOrder(co, epochIdx, dummyEpochDur, orderStatusRevoked)
+	err = a.storeOrder(co, epochIdx, dummyEpochDur, db.EpochGapNA, orderStatusRevoked)
 	return
 }
 
@@ -535,10 +535,10 @@ func validateOrder(ord order.Order, status pgOrderStatus, mkt *dex.MarketInfo) b
 // storage. Updating orders should be done via one of the update functions such
 // as UpdateOrderStatus.
 func (a *Archiver) StoreOrder(ord order.Order, epochIdx, epochDur int64, status order.OrderStatus) error {
-	return a.storeOrder(ord, epochIdx, epochDur, marketToPgStatus(status))
+	return a.storeOrder(ord, epochIdx, epochDur, db.EpochGapNA, marketToPgStatus(status))
 }
 
-func (a *Archiver) storeOrder(ord order.Order, epochIdx, epochDur int64, status pgOrderStatus) error {
+func (a *Archiver) storeOrder(ord order.Order, epochIdx, epochDur int64, epochGap int, status pgOrderStatus) error {
 	marketSchema, err := a.marketSchema(ord.Base(), ord.Quote())
 	if err != nil {
 		return err
@@ -601,7 +601,7 @@ func (a *Archiver) storeOrder(ord order.Order, epochIdx, epochDur int64, status 
 	switch ot := ord.(type) {
 	case *order.CancelOrder:
 		tableName := fullCancelOrderTableName(a.dbName, marketSchema, status.active())
-		N, err = storeCancelOrder(a.db, tableName, ot, status, epochIdx, epochDur)
+		N, err = storeCancelOrder(a.db, tableName, ot, status, epochIdx, epochDur, epochGap)
 		if err != nil {
 			a.fatalBackendErr(err)
 			return fmt.Errorf("storeCancelOrder failed: %w", err)
@@ -1228,16 +1228,10 @@ func (a *Archiver) OrderWithCommit(ctx context.Context, commit order.Commitment)
 	return // false, zero, nil
 }
 
-type cancelExecStamped struct {
-	oid, target order.OrderID
-	t           int64
-}
-
 // ExecutedCancelsForUser retrieves up to N executed cancel orders for a given
 // user. These may be user-initiated cancels, or cancels created by the server
 // (revokes). Executed cancel orders from all markets are returned.
-func (a *Archiver) ExecutedCancelsForUser(aid account.AccountID, N int) (oids, targets []order.OrderID, execTimes []int64, err error) {
-	var ords []cancelExecStamped
+func (a *Archiver) ExecutedCancelsForUser(aid account.AccountID, N int) (ords []*db.CancelRecord, err error) {
 
 	// Check all markets.
 	for marketSchema := range a.markets {
@@ -1246,42 +1240,34 @@ func (a *Archiver) ExecutedCancelsForUser(aid account.AccountID, N int) (oids, t
 		epochsTableName := fullEpochsTableName(a.dbName, marketSchema)
 		stmt := fmt.Sprintf(internal.RetrieveCancelTimesForUserByStatus, cancelTableName, epochsTableName)
 		ctx, cancel := context.WithTimeout(a.ctx, a.queryTimeout)
-		mktOids, err := a.executedCancelsForUser(ctx, a.db, stmt, aid, N)
+		mktOrds, err := a.executedCancelsForUser(ctx, a.db, stmt, aid, N)
 		cancel()
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
-		ords = append(ords, mktOids...)
+		ords = append(ords, mktOrds...)
 
 		// Query for revoked orders (server-initiated cancels).
 		stmt = fmt.Sprintf(internal.SelectRevokeCancels, cancelTableName)
 		ctx, cancel = context.WithTimeout(a.ctx, a.queryTimeout)
-		mktOids, err = a.revokeGeneratedCancelsForUser(ctx, a.db, stmt, aid, N)
+		mktOrds, err = a.revokeGeneratedCancelsForUser(ctx, a.db, stmt, aid, N)
 		cancel()
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
-		ords = append(ords, mktOids...)
+		ords = append(ords, mktOrds...)
 	}
 
 	sort.Slice(ords, func(i, j int) bool {
-		return ords[i].t > ords[j].t // descending, latest completed order first
+		return ords[i].MatchTime > ords[j].MatchTime // descending, latest completed order first
 	})
-
-	if N > len(ords) {
-		N = len(ords)
-	}
-
-	for i := range ords[:N] {
-		oids = append(oids, ords[i].oid)
-		targets = append(targets, ords[i].target)
-		execTimes = append(execTimes, ords[i].t)
-	}
 
 	return
 }
 
-func (a *Archiver) executedCancelsForUser(ctx context.Context, dbe *sql.DB, stmt string, aid account.AccountID, N int) (ords []cancelExecStamped, err error) {
+func (a *Archiver) executedCancelsForUser(ctx context.Context, dbe *sql.DB, stmt string,
+	aid account.AccountID, N int) (ords []*db.CancelRecord, err error) {
+
 	var rows *sql.Rows
 	rows, err = dbe.QueryContext(ctx, stmt, aid, orderStatusExecuted, N) // excludes orderStatusFailed
 	if err != nil {
@@ -1292,12 +1278,18 @@ func (a *Archiver) executedCancelsForUser(ctx context.Context, dbe *sql.DB, stmt
 	for rows.Next() {
 		var oid, target order.OrderID
 		var execTime int64
-		err = rows.Scan(&oid, &target, &execTime)
+		var epochGap int
+		err = rows.Scan(&oid, &target, &epochGap, &execTime)
 		if err != nil {
 			return
 		}
 
-		ords = append(ords, cancelExecStamped{oid, target, execTime})
+		ords = append(ords, &db.CancelRecord{
+			ID:        oid,
+			TargetID:  target,
+			MatchTime: execTime,
+			EpochGap:  epochGap,
+		})
 	}
 
 	if err = rows.Err(); err != nil {
@@ -1308,7 +1300,9 @@ func (a *Archiver) executedCancelsForUser(ctx context.Context, dbe *sql.DB, stmt
 
 // revokeGeneratedCancelsForUser excludes exempt/uncounted cancels created with
 // RevokeOrderUncounted or revokeOrder(..., exempt=true).
-func (a *Archiver) revokeGeneratedCancelsForUser(ctx context.Context, dbe *sql.DB, stmt string, aid account.AccountID, N int) (ords []cancelExecStamped, err error) {
+func (a *Archiver) revokeGeneratedCancelsForUser(ctx context.Context, dbe *sql.DB, stmt string,
+	aid account.AccountID, N int) (ords []*db.CancelRecord, err error) {
+
 	var rows *sql.Rows
 	rows, err = dbe.QueryContext(ctx, stmt, aid, orderStatusRevoked, N)
 	if err != nil {
@@ -1330,7 +1324,12 @@ func (a *Archiver) revokeGeneratedCancelsForUser(ctx context.Context, dbe *sql.D
 			continue
 		}
 
-		ords = append(ords, cancelExecStamped{oid, target, revokeTime.UnixMilli()})
+		ords = append(ords, &db.CancelRecord{
+			ID:        oid,
+			TargetID:  target,
+			MatchTime: revokeTime.UnixMilli(),
+			EpochGap:  db.EpochGapNA,
+		})
 	}
 
 	if err = rows.Err(); err != nil {
@@ -1712,10 +1711,10 @@ func moveOrder(dbe sqlExecutor, oldTableName, newTableName string, oid order.Ord
 
 // BEGIN cancel order functions
 
-func storeCancelOrder(dbe sqlExecutor, tableName string, co *order.CancelOrder, status pgOrderStatus, epochIdx, epochDur int64) (int64, error) {
+func storeCancelOrder(dbe sqlExecutor, tableName string, co *order.CancelOrder, status pgOrderStatus, epochIdx, epochDur int64, epochGap int) (int64, error) {
 	stmt := fmt.Sprintf(internal.InsertCancelOrder, tableName)
 	return sqlExec(dbe, stmt, co.ID(), co.AccountID, co.ClientTime,
-		co.ServerTime, co.Commit, co.TargetOrderID, status, epochIdx, epochDur)
+		co.ServerTime, co.Commit, co.TargetOrderID, status, epochIdx, epochDur, epochGap)
 }
 
 // loadCancelOrderFromTable does NOT set BaseAsset and QuoteAsset!

--- a/server/db/driver/pg/upgrades.go
+++ b/server/db/driver/pg/upgrades.go
@@ -40,8 +40,8 @@ var upgrades = []func(db *sql.Tx) error{
 	// accommodate a 32-bit unsigned integer.
 	v4Upgrade,
 
-	// v5 upgrade adds an epoch_gap column to the cancel order tables in order
-	// to facilitate free cancels.
+	// v5 upgrade adds an epoch_gap column to the cancel order tables to
+	// facilitate free cancels.
 	v5Upgrade,
 }
 
@@ -306,7 +306,7 @@ func v5Upgrade(tx *sql.Tx) (err error) {
 		return err
 	}
 
-	log.Info("Adding epoch_gap column to %d market tables", len(mkts)*2)
+	log.Infof("Adding epoch_gap column to cancel tables for %d markets", len(mkts))
 
 	for _, mkt := range mkts {
 		if err := doTable(mkt.Name + "." + cancelsArchivedTableName); err != nil {

--- a/server/db/driver/pg/upgrades.go
+++ b/server/db/driver/pg/upgrades.go
@@ -17,7 +17,7 @@ import (
 	"decred.org/dcrdex/server/db/driver/pg/internal"
 )
 
-const dbVersion = 4
+const dbVersion = 5
 
 // The number of upgrades defined MUST be equal to dbVersion.
 var upgrades = []func(db *sql.Tx) error{
@@ -39,6 +39,10 @@ var upgrades = []func(db *sql.Tx) error{
 	// v4 upgrade updates the markets tables to use a integer type that can
 	// accommodate a 32-bit unsigned integer.
 	v4Upgrade,
+
+	// v5 upgrade adds an epoch_gap column to the cancel order tables in order
+	// to facilitate free cancels.
+	v5Upgrade,
 }
 
 // v1Upgrade adds the schema_version column and removes the state_hash column
@@ -289,6 +293,30 @@ func v4Upgrade(tx *sql.Tx) (err error) {
 	}
 	_, err = tx.Exec("ALTER TABLE markets ALTER COLUMN quote TYPE INT8;")
 	return err
+}
+
+func v5Upgrade(tx *sql.Tx) (err error) {
+	mkts, err := loadMarkets(tx, marketsTableName)
+	if err != nil {
+		return fmt.Errorf("failed to read markets table: %w", err)
+	}
+
+	doTable := func(tableName string) error {
+		_, err = tx.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN epoch_gap INT4 DEFAULT -1;", tableName))
+		return err
+	}
+
+	log.Info("Adding epoch_gap column to %d market tables", len(mkts)*2)
+
+	for _, mkt := range mkts {
+		if err := doTable(mkt.Name + "." + cancelsArchivedTableName); err != nil {
+			return err
+		}
+		if err := doTable(mkt.Name + "." + cancelsActiveTableName); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // DBVersion retrieves the database version from the meta table.

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1799,7 +1799,7 @@ func (m *Market) processOrder(rec *orderRecord, epoch *EpochQueue, notifyChan ch
 			return nil
 		}
 
-		epochGap = int(epoch.Epoch - loTime.UnixMilli()/epoch.Duration)
+		epochGap = int32(epoch.Epoch - loTime.UnixMilli()/epoch.Duration)
 
 	} else if likelyTaker(ord) { // Likely-taker trade order. Check the quantity against user's limit.
 		// NOTE: We can entirely change this so that the taker limit is not
@@ -2352,7 +2352,7 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 		// Update order settling amounts.
 		for _, match := range ms.Matches() {
 			if co, ok := match.Taker.(*order.CancelOrder); ok {
-				epochGap := int((co.ServerTime.UnixMilli() / epochDur) - (match.Maker.ServerTime.UnixMilli() / epochDur))
+				epochGap := int32((co.ServerTime.UnixMilli() / epochDur) - (match.Maker.ServerTime.UnixMilli() / epochDur))
 				m.auth.RecordCancel(co.User(), co.ID(), co.TargetOrderID, epochGap, matchTime)
 				canceled = append(canceled, co.TargetOrderID)
 				continue

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -758,7 +758,7 @@ func (m *Market) processCancelOrderWhileSuspended(rec *orderRecord, errChan chan
 		return
 	}
 
-	if cancelable, err := m.CancelableBy(co.TargetOrderID, co.AccountID); !cancelable {
+	if cancelable, _, err := m.CancelableBy(co.TargetOrderID, co.AccountID); !cancelable {
 		errChan <- err
 		return
 	}
@@ -1002,13 +1002,13 @@ func (m *Market) Cancelable(oid order.OrderID) bool {
 // means: (1) an order in the book or epoch queue, (2) type limit with
 // time-in-force standing (implied for book orders), and (3) AccountID field
 // matching the provided account ID.
-func (m *Market) CancelableBy(oid order.OrderID, aid account.AccountID) (bool, error) {
+func (m *Market) CancelableBy(oid order.OrderID, aid account.AccountID) (bool, time.Time, error) {
 	// All book orders are standing limit orders.
 	if lo := m.book.Order(oid); lo != nil {
 		if lo.AccountID == aid {
-			return true, nil
+			return true, lo.ServerTime, nil
 		}
-		return false, ErrCancelNotPermitted
+		return false, time.Time{}, ErrCancelNotPermitted
 	}
 
 	// Check the active epochs (includes current and next).
@@ -1017,20 +1017,20 @@ func (m *Market) CancelableBy(oid order.OrderID, aid account.AccountID) (bool, e
 	m.epochMtx.RUnlock()
 
 	if ord == nil {
-		return false, ErrTargetNotActive
+		return false, time.Time{}, ErrTargetNotActive
 	}
 
 	lo, ok := ord.(*order.LimitOrder)
 	if !ok {
-		return false, ErrTargetNotCancelable
+		return false, time.Time{}, ErrTargetNotCancelable
 	}
 	if lo.Force != order.StandingTiF {
-		return false, ErrTargetNotCancelable
+		return false, time.Time{}, ErrTargetNotCancelable
 	}
 	if lo.AccountID != aid {
-		return false, ErrCancelNotPermitted
+		return false, time.Time{}, ErrCancelNotPermitted
 	}
-	return true, nil
+	return true, lo.ServerTime, nil
 }
 
 func (m *Market) checkUnfilledOrders(assetID uint32, unfilled []*order.LimitOrder) (unbooked []*order.LimitOrder) {
@@ -1772,6 +1772,7 @@ func (m *Market) processOrder(rec *orderRecord, epoch *EpochQueue, notifyChan ch
 	// Verify that another cancel order targeting the same order is not already
 	// in the epoch queue. Market and limit orders using the same coin IDs as
 	// other orders is prevented by the coinlocker.
+	epochGap := db.EpochGapNA
 	if co, ok := ord.(*order.CancelOrder); ok {
 		if eco := epoch.CancelTargets[co.TargetOrderID]; eco != nil {
 			log.Debugf("Received cancel order %v targeting %v, but already have %v.",
@@ -1790,13 +1791,16 @@ func (m *Market) processOrder(rec *orderRecord, epoch *EpochQueue, notifyChan ch
 		// Verify that the target order is on the books or in the epoch queue,
 		// and that the account of the CancelOrder is the same as the account of
 		// the target order.
-		cancelable, err := m.CancelableBy(co.TargetOrderID, co.AccountID)
+		cancelable, loTime, err := m.CancelableBy(co.TargetOrderID, co.AccountID)
 		if !cancelable {
 			log.Debugf("Cancel order %v (account=%v) target order %v: %v",
 				co, co.AccountID, co.TargetOrderID, err)
 			errChan <- err
 			return nil
 		}
+
+		epochGap = int(epoch.Epoch - loTime.UnixMilli()/epoch.Duration)
+
 	} else if likelyTaker(ord) { // Likely-taker trade order. Check the quantity against user's limit.
 		// NOTE: We can entirely change this so that the taker limit is not
 		// based on just this market. Also so that it's based on lots rather
@@ -1879,7 +1883,7 @@ func (m *Market) processOrder(rec *orderRecord, epoch *EpochQueue, notifyChan ch
 
 	// Store the new epoch order BEFORE inserting it into the epoch queue,
 	// initiating the swap, and notifying book subscribers.
-	if err := m.storage.NewEpochOrder(ord, epoch.Epoch, epoch.Duration); err != nil {
+	if err := m.storage.NewEpochOrder(ord, epoch.Epoch, epoch.Duration, epochGap); err != nil {
 		errChan <- ErrInternalServer
 		return fmt.Errorf("processOrder: Failed to store new epoch order %v: %w",
 			ord, err)
@@ -2145,7 +2149,7 @@ func (m *Market) prepEpoch(orders []order.Order, epochEnd time.Time) (cSum []byt
 		// Change the order status from orderStatusEpoch to orderStatusRevoked.
 		coid, revTime, err := m.storage.RevokeOrder(ord)
 		if err == nil {
-			m.auth.RecordCancel(ord.User(), coid, ord.ID(), revTime)
+			m.auth.RecordCancel(ord.User(), coid, ord.ID(), db.EpochGapNA, revTime)
 		} else {
 			log.Errorf("Failed to revoke order %v with a new cancel order: %v",
 				ord.UID(), err)
@@ -2236,7 +2240,7 @@ func (m *Market) unbookedOrder(lo *order.LimitOrder) {
 	oid, user := lo.ID(), lo.User()
 	coid, revTime, err := m.storage.RevokeOrder(lo)
 	if err == nil {
-		m.auth.RecordCancel(user, coid, oid, revTime)
+		m.auth.RecordCancel(user, coid, oid, db.EpochGapNA, revTime)
 	} else {
 		log.Errorf("Failed to revoke order %v with a new cancel order: %v",
 			lo.UID(), err)
@@ -2336,6 +2340,7 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 	matchTime := time.Now() // considered as the time at which matched cancel orders are executed
 	seed, matches, _, failed, doneOK, partial, booked, nomatched, unbooked, updates, stats := m.matcher.Match(m.book, ordersRevealed)
 	m.bookEpochIdx = epoch.Epoch + 1
+	epochDur := int64(m.EpochDuration())
 	var canceled []order.OrderID
 	for _, ms := range matches {
 		// Set the epoch ID.
@@ -2347,7 +2352,8 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 		// Update order settling amounts.
 		for _, match := range ms.Matches() {
 			if co, ok := match.Taker.(*order.CancelOrder); ok {
-				m.auth.RecordCancel(co.User(), co.ID(), co.TargetOrderID, matchTime)
+				epochGap := int((co.ServerTime.UnixMilli() / epochDur) - (match.Maker.ServerTime.UnixMilli() / epochDur))
+				m.auth.RecordCancel(co.User(), co.ID(), co.TargetOrderID, epochGap, matchTime)
 				canceled = append(canceled, co.TargetOrderID)
 				continue
 			}

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -109,13 +109,13 @@ func (ta *TArchivist) failOnCommitWithOrder(ord order.Order) {
 func (ta *TArchivist) CompletedUserOrders(aid account.AccountID, N int) (oids []order.OrderID, compTimes []int64, err error) {
 	return nil, nil, nil
 }
-func (ta *TArchivist) ExecutedCancelsForUser(aid account.AccountID, N int) (oids, targets []order.OrderID, execTimes []int64, err error) {
-	return nil, nil, nil, nil
+func (ta *TArchivist) ExecutedCancelsForUser(aid account.AccountID, N int) ([]*db.CancelRecord, error) {
+	return nil, nil
 }
 func (ta *TArchivist) OrderStatus(order.Order) (order.OrderStatus, order.OrderType, int64, error) {
 	return order.OrderStatusUnknown, order.UnknownOrderType, -1, errors.New("boom")
 }
-func (ta *TArchivist) NewEpochOrder(ord order.Order, epochIdx, epochDur int64) error {
+func (ta *TArchivist) NewEpochOrder(ord order.Order, epochIdx, epochDur int64, epochGap int) error {
 	ta.mtx.Lock()
 	defer ta.mtx.Unlock()
 	if ta.poisonEpochOrder != nil && ord.ID() == ta.poisonEpochOrder.ID() {

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -115,7 +115,7 @@ func (ta *TArchivist) ExecutedCancelsForUser(aid account.AccountID, N int) ([]*d
 func (ta *TArchivist) OrderStatus(order.Order) (order.OrderStatus, order.OrderType, int64, error) {
 	return order.OrderStatusUnknown, order.UnknownOrderType, -1, errors.New("boom")
 }
-func (ta *TArchivist) NewEpochOrder(ord order.Order, epochIdx, epochDur int64, epochGap int) error {
+func (ta *TArchivist) NewEpochOrder(ord order.Order, epochIdx, epochDur int64, epochGap int32) error {
 	ta.mtx.Lock()
 	defer ta.mtx.Unlock()
 	if ta.poisonEpochOrder != nil && ord.ID() == ta.poisonEpochOrder.ID() {

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -35,7 +35,7 @@ type AuthManager interface {
 	RequestWithTimeout(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message), time.Duration, func()) error
 	PreimageSuccess(user account.AccountID, refTime time.Time, oid order.OrderID)
 	MissedPreimage(user account.AccountID, refTime time.Time, oid order.OrderID)
-	RecordCancel(user account.AccountID, oid, target order.OrderID, epochGap int, t time.Time)
+	RecordCancel(user account.AccountID, oid, target order.OrderID, epochGap int32, t time.Time)
 	RecordCompletedOrder(user account.AccountID, oid order.OrderID, t time.Time)
 	UserSettlingLimit(user account.AccountID, mkt *dex.MarketInfo) int64
 }

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -35,7 +35,7 @@ type AuthManager interface {
 	RequestWithTimeout(account.AccountID, *msgjson.Message, func(comms.Link, *msgjson.Message), time.Duration, func()) error
 	PreimageSuccess(user account.AccountID, refTime time.Time, oid order.OrderID)
 	MissedPreimage(user account.AccountID, refTime time.Time, oid order.OrderID)
-	RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time)
+	RecordCancel(user account.AccountID, oid, target order.OrderID, epochGap int, t time.Time)
 	RecordCompletedOrder(user account.AccountID, oid order.OrderID, t time.Time)
 	UserSettlingLimit(user account.AccountID, mkt *dex.MarketInfo) int64
 }

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -249,7 +249,7 @@ func (a *TAuth) UserSettlingLimit(user account.AccountID, mkt *dex.MarketInfo) i
 }
 
 func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time) {}
-func (a *TAuth) RecordCancel(aid account.AccountID, coid, oid order.OrderID, epochGap int, t time.Time) {
+func (a *TAuth) RecordCancel(aid account.AccountID, coid, oid order.OrderID, epochGap int32, t time.Time) {
 	a.cancelOrder = coid
 	a.canceledOrder = oid
 }

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -249,7 +249,7 @@ func (a *TAuth) UserSettlingLimit(user account.AccountID, mkt *dex.MarketInfo) i
 }
 
 func (a *TAuth) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time) {}
-func (a *TAuth) RecordCancel(aid account.AccountID, coid, oid order.OrderID, t time.Time) {
+func (a *TAuth) RecordCancel(aid account.AccountID, coid, oid order.OrderID, epochGap int, t time.Time) {
 	a.cancelOrder = coid
 	a.canceledOrder = oid
 }

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -230,9 +230,6 @@ func (m *TAuthManager) penalize(id account.AccountID, rule account.Rule) {
 	}
 }
 
-func (m *TAuthManager) RecordCancel(user account.AccountID, oid, target order.OrderID, t time.Time) {}
-func (m *TAuthManager) RecordCompletedOrder(account.AccountID, order.OrderID, time.Time)            {}
-
 func (m *TAuthManager) flushPenalty(user account.AccountID) (found bool, rule account.Rule) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()


### PR DESCRIPTION
```
server/db:
Add epoch_gap column to cancel order table. When set (not EpochGapNA),
the epoch_gap is the number of epochs between the limit order placement
and the cancel order placement. Update InsertEpoch method to accept an
epoch gap argument (or EpochGapNA).

server/auth:
RecordCancel now accepts an epoch gap argument. Epoch gap is loaded from
the db via ExecutedCancelsForUser with a modified return value.
(*latestOrders).counts now only counts cancel orders if 0 <= epochGap < 2.

server/market:
processOrder now reports the epoch gap to the AuthManager for matched
cancel orders.
```