### PR TITLE
loadbot/zec: Avoid using the same outputs.

### DIFF
--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -149,7 +149,7 @@ if [ $ZEC_ON -eq 0 ]; then
         {
             "base": "ZEC_simnet",
             "quote": "BTC_simnet",
-            "lotSize": 100000000,
+            "lotSize": 1000000,
             "rateStep": 1000,
             "epochDuration": ${EPOCH_DURATION},
             "marketBuyBuffer": 1.2

--- a/dex/testing/zec/harness.sh
+++ b/dex/testing/zec/harness.sh
@@ -225,7 +225,7 @@ chmod +x "./start-wallet"
 
 cat > "./connect-alpha" <<EOF
 #!/usr/bin/env bash
-${CLI} -rpcport=\$1 -regtest=1 -rpcuser=user -rpcpassword=pass addnode 127.0.0.1:${ALPHA_LISTEN_PORT} add
+${CLI} -rpcport=\$1 -regtest=1 -rpcuser=user -rpcpassword=pass addnode 127.0.0.1:${ALPHA_LISTEN_PORT} onetry
 EOF
 chmod +x "./connect-alpha"
 


### PR DESCRIPTION
    zec will complain about double spends if sendtoaddress is used too soon
    after mining a block. Use a mutex to make sure we always wait a second
    after mining to send.

closes  #1683