### PR TITLE
CI: enforce fmt simplification

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -800,7 +800,7 @@ func testAvailableFund(t *testing.T, segwit bool, walletType string) {
 	blockHash, _ := node.addRawTx(blockHeight, msgTx)
 
 	node.getTransactionMap = map[string]*GetTransactionResult{
-		"any": &GetTransactionResult{
+		"any": {
 			BlockHash:  blockHash.String(),
 			BlockIndex: blockHeight,
 			Details: []*WalletTxDetails{
@@ -2388,7 +2388,7 @@ func testSender(t *testing.T, senderType tSenderType, segwit bool, walletType st
 
 	node.sendToAddress = txHash.String()
 	node.getTransactionMap = map[string]*GetTransactionResult{
-		"any": &GetTransactionResult{
+		"any": {
 			BlockHash:  blockHash.String(),
 			BlockIndex: blockHeight,
 			Hex:        txB,
@@ -2553,7 +2553,7 @@ func testConfirmations(t *testing.T, segwit bool, walletType string) {
 	txB, _ := serializeMsgTx(tx)
 
 	node.getTransactionMap = map[string]*GetTransactionResult{
-		"any": &GetTransactionResult{
+		"any": {
 			BlockHash: blockHash.String(),
 			Hex:       txB,
 		}}
@@ -3877,7 +3877,7 @@ func testGetTxFee(t *testing.T, segwit bool, walletType string) {
 	}
 
 	node.getTransactionMap = map[string]*GetTransactionResult{
-		"any": &GetTransactionResult{
+		"any": {
 			Hex: txBytes,
 		},
 	}

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -457,7 +457,7 @@ func TestSwapConfirmations(t *testing.T) {
 	node.confsSpent = true
 	txB, _ := serializeMsgTx(swapTx)
 	node.getTransactionMap = map[string]*GetTransactionResult{
-		"any": &GetTransactionResult{
+		"any": {
 			BlockHash:  swapBlockHash.String(),
 			BlockIndex: swapHeight,
 			Hex:        txB,
@@ -593,7 +593,7 @@ func TestGetTxOut(t *testing.T) {
 
 	// Wallet transaction found
 	node.getTransactionErr = nil
-	node.getTransactionMap = map[string]*GetTransactionResult{"any": &GetTransactionResult{
+	node.getTransactionMap = map[string]*GetTransactionResult{"any": {
 		BlockHash: blockHash.String(),
 		Hex:       txB,
 	}}

--- a/dex/networks/erc20/contracts/updatecontract.sh
+++ b/dex/networks/erc20/contracts/updatecontract.sh
@@ -73,4 +73,7 @@ if [ "$VERSION" -eq "0" ]; then
 
   perl -0pi -e 's/\/\/ ERC20SwapSwap[^}]*}\n\n//' $CONTRACT_FILE
   perl -0pi -e 's/ERC20SwapSwap/ethv0.ETHSwapSwap/g' $CONTRACT_FILE
+
+  # Reorder the imports since we rewrote go-ethereum/event to a dcrdex package.
+  gofmt -s -w "$CONTRACT_FILE"
 fi

--- a/dex/networks/erc20/contracts/v0/contract.go
+++ b/dex/networks/erc20/contracts/v0/contract.go
@@ -8,13 +8,13 @@ import (
 	"math/big"
 	"strings"
 
+	ethv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	ethv0 "decred.org/dcrdex/dex/networks/eth/contracts/v0"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/dex/networks/eth/txdata_test.go
+++ b/dex/networks/eth/txdata_test.go
@@ -67,13 +67,13 @@ func TestParseInitiateDataV0(t *testing.T) {
 	locktime := int64(1632112916)
 
 	initiations := []*Initiation{
-		&Initiation{
+		{
 			LockTime:    time.Unix(locktime, 0),
 			SecretHash:  secretHashA,
 			Participant: participantAddr,
 			Value:       1,
 		},
-		&Initiation{
+		{
 			LockTime:    time.Unix(locktime, 0),
 			SecretHash:  secretHashB,
 			Participant: participantAddr,
@@ -164,11 +164,11 @@ func TestParseRedeemDataV0(t *testing.T) {
 	copy(secretB[:], mustParseHex("2c0a304c9321402dc11cbb5898b9f2af3029ce1c76ec6702c4cd5bb965fd3e73"))
 
 	redemptions := []*Redemption{
-		&Redemption{
+		{
 			Secret:     secretA,
 			SecretHash: secretHashA,
 		},
-		&Redemption{
+		{
 			Secret:     secretB,
 			SecretHash: secretHashB,
 		},

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -71,6 +71,7 @@ cd "$dir"
 # check linters
 golangci-lint run --disable-all --deadline=10m \
   --out-format=github-actions,colored-line-number \
+  --enable=gofmt \
   --enable=goimports \
   --enable=govet \
   --enable=gosimple \


### PR DESCRIPTION
In catching up with recent PRs I noticed some churn because `gofmt` has a "simplify" option that removes some superfluous identifiers, but CI does not enforce its use and only some developers have it set.  I don't see a way to enforce "not simple" so this PR enforces simple for consistency.  This is done by enabling the `gofmt` linter in golangci-lint:

`gofmt: Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification [fast: true, auto-fix: true]`

Developers may choose to add that as well, or just add `-s` to their gofmt flags.

This also modifies the the erc20 updatecontract.sh script so that it reorders the imports after rewriting the import lines with perl.  Recent PRs have tried to modify contract.go, but since it is generated it should not be touched (except by the script that generates it).