### PR TITLE
client: add peers restored message and improve error

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -621,7 +621,7 @@ type baseWallet struct {
 	symbol            string
 	tipChange         func(error)
 	lastPeerCount     uint32
-	peersChange       func(uint32)
+	peersChange       func(uint32, error)
 	minNetworkVersion uint64
 	dustLimit         uint64
 	useLegacyBalance  bool
@@ -1809,11 +1809,11 @@ func fund(utxos []*compositeUTXO, enough func(uint64, uint64) bool) (
 // sent (true) or if the original coins were returned unmodified (false).
 //
 // A split transaction nets additional network bytes consisting of
-// - overhead from 1 transaction
-// - 1 extra signed p2wpkh-spending input. The split tx has the fundingCoins as
-//   inputs now, but we'll add the input that spends the sized coin that will go
-//   into the first swap if the split tx does not add excess baggage
-// - 2 additional p2wpkh outputs for the split tx sized output and change
+//   - overhead from 1 transaction
+//   - 1 extra signed p2wpkh-spending input. The split tx has the fundingCoins as
+//     inputs now, but we'll add the input that spends the sized coin that will go
+//     into the first swap if the split tx does not add excess baggage
+//   - 2 additional p2wpkh outputs for the split tx sized output and change
 //
 // If the fees associated with this extra baggage are more than the excess
 // amount that would be locked if a split transaction were not used, then the
@@ -3666,13 +3666,13 @@ func (btc *baseWallet) checkPeers() {
 		prevPeer := atomic.SwapUint32(&btc.lastPeerCount, 0)
 		if prevPeer != 0 {
 			btc.log.Errorf("Failed to get peer count: %v", err)
-			btc.peersChange(0)
+			btc.peersChange(0, err)
 		}
 		return
 	}
 	prevPeer := atomic.SwapUint32(&btc.lastPeerCount, numPeers)
 	if prevPeer != numPeers {
-		btc.peersChange(numPeers)
+		btc.peersChange(numPeers, nil)
 	}
 }
 

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -624,8 +624,8 @@ func tNewWallet(segwit bool, walletType string) (*ExchangeWalletFullNode, *testD
 			default:
 			}
 		},
-		PeersChange: func(num uint32) {
-			fmt.Println("peer count: ", num)
+		PeersChange: func(num uint32, err error) {
+			fmt.Printf("peer count = %d, err = %v", num, err)
 		},
 	}
 	walletCtx, shutdown := context.WithCancel(tCtx)
@@ -800,7 +800,7 @@ func testAvailableFund(t *testing.T, segwit bool, walletType string) {
 	blockHash, _ := node.addRawTx(blockHeight, msgTx)
 
 	node.getTransactionMap = map[string]*GetTransactionResult{
-		"any": &GetTransactionResult{
+		"any": {
 			BlockHash:  blockHash.String(),
 			BlockIndex: blockHeight,
 			Details: []*WalletTxDetails{
@@ -2388,7 +2388,7 @@ func testSender(t *testing.T, senderType tSenderType, segwit bool, walletType st
 
 	node.sendToAddress = txHash.String()
 	node.getTransactionMap = map[string]*GetTransactionResult{
-		"any": &GetTransactionResult{
+		"any": {
 			BlockHash:  blockHash.String(),
 			BlockIndex: blockHeight,
 			Hex:        txB,
@@ -2553,7 +2553,7 @@ func testConfirmations(t *testing.T, segwit bool, walletType string) {
 	txB, _ := serializeMsgTx(tx)
 
 	node.getTransactionMap = map[string]*GetTransactionResult{
-		"any": &GetTransactionResult{
+		"any": {
 			BlockHash: blockHash.String(),
 			Hex:       txB,
 		}}
@@ -3877,7 +3877,7 @@ func testGetTxFee(t *testing.T, segwit bool, walletType string) {
 	}
 
 	node.getTransactionMap = map[string]*GetTransactionResult{
-		"any": &GetTransactionResult{
+		"any": {
 			Hex: txBytes,
 		},
 	}

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -66,8 +66,8 @@ func tBackend(ctx context.Context, t *testing.T, cfg *Config, walletName *Wallet
 		TipChange: func(err error) {
 			blkFunc(reportName, err)
 		},
-		PeersChange: func(num uint32) {
-			fmt.Println("peer count: ", num)
+		PeersChange: func(num uint32, err error) {
+			fmt.Printf("peer count = %d, err = %v", num, err)
 		},
 	}
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -494,7 +494,7 @@ type ExchangeWallet struct {
 	tradingAccount   string
 	tipChange        func(error)
 	lastPeerCount    uint32
-	peersChange      func(uint32)
+	peersChange      func(uint32, error)
 	fallbackFeeRate  uint64
 	feeRateLimit     uint64
 	redeemConfTarget uint64
@@ -1529,11 +1529,11 @@ func (dcr *ExchangeWallet) tryFund(utxos []*compositeUTXO, enough func(sum uint6
 // sent (true) or if the original coins were returned unmodified (false).
 //
 // A split transaction nets additional network bytes consisting of
-// - overhead from 1 transaction
-// - 1 extra signed p2pkh-spending input. The split tx has the fundingCoins as
-//   inputs now, but we'll add the input that spends the sized coin that will go
-//   into the first swap
-// - 2 additional p2pkh outputs for the split tx sized output and change
+//   - overhead from 1 transaction
+//   - 1 extra signed p2pkh-spending input. The split tx has the fundingCoins as
+//     inputs now, but we'll add the input that spends the sized coin that will go
+//     into the first swap
+//   - 2 additional p2pkh outputs for the split tx sized output and change
 //
 // If the fees associated with this extra baggage are more than the excess
 // amount that would be locked if a split transaction were not used, then the
@@ -3450,13 +3450,13 @@ func (dcr *ExchangeWallet) checkPeers() {
 		prevPeer := atomic.SwapUint32(&dcr.lastPeerCount, 0)
 		if prevPeer != 0 {
 			dcr.log.Errorf("Failed to get peer count: %v", err)
-			dcr.peersChange(0)
+			dcr.peersChange(0, err)
 		}
 		return
 	}
 	prevPeer := atomic.SwapUint32(&dcr.lastPeerCount, numPeers)
 	if prevPeer != numPeers {
-		dcr.peersChange(numPeers)
+		dcr.peersChange(numPeers, nil)
 	}
 }
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -137,7 +137,7 @@ func tNewWallet() (*ExchangeWallet, *tRPCClient, func(), error) {
 	client := newTRPCClient()
 	walletCfg := &asset.WalletConfig{
 		TipChange:   func(error) {},
-		PeersChange: func(uint32) {},
+		PeersChange: func(uint32, error) {},
 	}
 	walletCtx, shutdown := context.WithCancel(tCtx)
 

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -73,8 +73,8 @@ func tBackend(t *testing.T, name string, blkFunc func(string, error)) (*Exchange
 		TipChange: func(err error) {
 			blkFunc(name, err)
 		},
-		PeersChange: func(num uint32) {
-			t.Log("peer count: ", num)
+		PeersChange: func(num uint32, err error) {
+			t.Logf("peer count = %d, err = %v", num, err)
 		},
 	}
 	var backend asset.Wallet

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -149,12 +149,12 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Ne
 
 // DecodeCoinID creates a human-readable representation of a coin ID for Ethereum.
 // In ETH there are 3 possible coin IDs:
-//   1. A transaction hash. 32 bytes
-//   2. An encoded ETH funding coin id which includes the account address and
-//      amount. 20 + 8 = 28 bytes
-//   3. An encoded token funding coin id which includes the account address, an
-//      a token value, and fees. 20 + 8 + 8 = 36 bytes
-//   4. A byte encoded string of the account address. 40 or 42 (with 0x) bytes
+//  1. A transaction hash. 32 bytes
+//  2. An encoded ETH funding coin id which includes the account address and
+//     amount. 20 + 8 = 28 bytes
+//  3. An encoded token funding coin id which includes the account address, an
+//     a token value, and fees. 20 + 8 + 8 = 36 bytes
+//  4. A byte encoded string of the account address. 40 or 42 (with 0x) bytes
 func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
 	switch len(coinID) {
 	case common.HashLength:
@@ -289,7 +289,7 @@ type ETHWallet struct {
 	*assetWallet
 
 	lastPeerCount uint32
-	peersChange   func(uint32)
+	peersChange   func(uint32, error)
 
 	tipMtx     sync.RWMutex
 	currentTip *types.Header
@@ -2221,7 +2221,7 @@ func (eth *ETHWallet) checkPeers() {
 	numPeers := eth.node.peerCount()
 	prevPeer := atomic.SwapUint32(&eth.lastPeerCount, numPeers)
 	if prevPeer != numPeers {
-		eth.peersChange(numPeers)
+		eth.peersChange(numPeers, nil)
 	}
 }
 

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -225,7 +225,7 @@ type WalletConfig struct {
 	// PeersChange is a function that will be called when the number of
 	// wallet/node peers changes, or the wallet fails to get the count. This
 	// should not be called prior to Connect of the constructed wallet.
-	PeersChange func(uint32)
+	PeersChange func(uint32, error)
 	// DataDir is a filesystem directory the the wallet may use for persistent
 	// storage.
 	DataDir string

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2713,13 +2713,13 @@ func TestTrade(t *testing.T) {
 	// dcrWallet.mtx.Lock()
 	// dcrWallet.peerCount = 0
 	// dcrWallet.mtx.Unlock()
-	tCore.peerChange(dcrWallet, 0)
+	tCore.peerChange(dcrWallet, 0, nil)
 	_, err = tCore.Trade(tPW, form)
 	if err == nil {
 		t.Fatalf("no error for no peers")
 	}
 	ch := tCore.NotificationFeed() // detect when sync goroutine completes
-	tCore.peerChange(dcrWallet, 1)
+	tCore.peerChange(dcrWallet, 1, nil)
 
 	// Wait for the balance update note when the sync status goroutine flags the
 	// wallet as synced and returns.

--- a/client/core/locale_ntfn.go
+++ b/client/core/locale_ntfn.go
@@ -55,9 +55,19 @@ var enUS = map[Topic]*translation{
 		template: "Connected to wallet to complete registration at %s, but failed to unlock: %v",
 	},
 	// [asset name]
+	TopicWalletCommsWarning: {
+		subject:  "Wallet connection issue",
+		template: "Unable to communicate with %v wallet! Reason: %q",
+	},
+	// [asset name]
 	TopicWalletPeersWarning: {
 		subject:  "Wallet network issue",
 		template: "%v wallet has no network peers!",
+	},
+	// [asset name]
+	TopicWalletPeersRestored: {
+		subject:  "Wallet connectivity restored",
+		template: "%v wallet has reestablished connectivity.",
 	},
 	// [ticker, error]
 	TopicSendError: {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -180,6 +180,8 @@ const (
 	TopicWalletConnectionWarning Topic = "WalletConnectionWarning"
 	TopicWalletUnlockError       Topic = "WalletUnlockError"
 	TopicWalletPeersWarning      Topic = "WalletPeersWarning"
+	TopicWalletCommsWarning      Topic = "WalletCommsWarning"
+	TopicWalletPeersRestored     Topic = "WalletPeersRestored"
 )
 
 func newFeePaymentNote(topic Topic, subject, details string, severity db.Severity, dexAddr string) *FeePaymentNote {


### PR DESCRIPTION
1. Add a peers restored message to match a peers lost message
 
![image](https://user-images.githubusercontent.com/9373513/177869389-ec47f2cb-2f0c-4bc6-98c8-555136132b89.png)

2. Distinguish peers lost from unable to determine peer count (e.g. rpc timeout)

![image](https://user-images.githubusercontent.com/9373513/177869501-46b8e682-020e-47dd-ba1d-47b47c8b7cf5.png)

3. Fix a bug in the DCR block monitoring goroutine.  When native SPV was added, some code that made sense in its own function (defer and return) no longer worked properly when put directly into `monitorBlocks`.  The return was killing the wallet if connectivity was lost, instead of it being a temporary issue.  This fixes those issues.

![image](https://user-images.githubusercontent.com/9373513/177869813-a7996df7-1395-4dd9-8e2d-5d0ccc3e1940.png)
