### PR TITLE
client/eth: Use wallet seed as entropy for BIP-39 mnemonic

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -37,6 +37,7 @@ import (
 	ethmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/tyler-smith/go-bip39"
 )
 
 func registerToken(tokenID uint32, desc string) {
@@ -328,6 +329,20 @@ func (w *TokenWallet) Info() *asset.WalletInfo {
 	}
 }
 
+// genWalletSeed uses the wallet seed passed from core as the entropy for
+// generating a BIP-39 mnemonic. Then it returns the wallet seed generated
+// from the mnemonic which can be used to derive a private key.
+func genWalletSeed(entropy []byte) ([]byte, error) {
+	if len(entropy) != 32 {
+		return nil, fmt.Errorf("wallet entropy must be 32 bytes long")
+	}
+	mnemonic, err := bip39.NewMnemonic(entropy)
+	if err != nil {
+		return nil, fmt.Errorf("error deriving mnemonic: %w", err)
+	}
+	return bip39.NewSeed(mnemonic, ""), nil
+}
+
 // CreateWallet creates a new internal ETH wallet and stores the private key
 // derived from the wallet seed.
 func CreateWallet(createWalletParams *asset.CreateWalletParams) error {
@@ -343,7 +358,13 @@ func CreateWallet(createWalletParams *asset.CreateWalletParams) error {
 		return err
 	}
 
-	extKey, err := keygen.GenDeepChild(createWalletParams.Seed, seedDerivationPath)
+	walletSeed, err := genWalletSeed(createWalletParams.Seed)
+	if err != nil {
+		return err
+	}
+	defer encode.ClearBytes(walletSeed)
+
+	extKey, err := keygen.GenDeepChild(walletSeed, seedDerivationPath)
 	if err != nil {
 		return err
 	}
@@ -2041,7 +2062,13 @@ func (w *TokenWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
 // RestorationInfo returns information about how to restore the wallet in
 // various external wallets.
 func (w *assetWallet) RestorationInfo(seed []byte) ([]*asset.WalletRestoration, error) {
-	extKey, err := keygen.GenDeepChild(seed, seedDerivationPath)
+	walletSeed, err := genWalletSeed(seed)
+	if err != nil {
+		return nil, err
+	}
+	defer encode.ClearBytes(walletSeed)
+
+	extKey, err := keygen.GenDeepChild(walletSeed, seedDerivationPath)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/lib/pq v1.10.3
 	github.com/lightninglabs/neutrino v0.14.1
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
+	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef
 	go.etcd.io/bbolt v1.3.7-0.20220130032806-d5db64bdbfde
 	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -118,7 +119,6 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect
 	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/tklauser/numcpus v0.2.2 // indirect
-	github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef // indirect
 	github.com/urfave/cli/v2 v2.10.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect


### PR DESCRIPTION
Previously, the wallet seed from core was used as the master seed of the an HD wallet from which a private key was derived. Instead of this, the seed from core is used as an entropy for a BIP-39 mnemonic phrase, then the seed derived from the mnemonic phrase is used to derive the private key used in the wallet. The mnemonic phrase is currently not used for anything, but this will keep our options open for more features in the future.

This will come on top of #1648, d0f77dc22900b26c24226c2f347015a143581d94 is the diff for this PR.
