### PR TITLE
fix misshappen search box on markets page

### DIFF
--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -3,7 +3,7 @@ div.marketlist {
   border-right: 1px solid #626262;
   z-index: 99;
   background-color: #dbdbdb;
-  min-width: 175px;
+  min-width: 190px;
 
   .selected {
     border-style: solid none;
@@ -78,7 +78,7 @@ label.market-search {
 
   input {
     border: none;
-    max-width: 75px;
+    width: 100%;
   }
 
   span {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=EDTWQGB" rel="stylesheet">
+  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=EDTWQGM"></script>
+<script src="/js/entry.js?v=GTHMDHF"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -18,7 +18,7 @@
     <label class="market-search">
       <div><span class="ico-search px-2"></span></div>
       <div class="flex-grow-1 position-relative">
-        <div class="fill-abs"><input type="text" id="marketSearch" class="px-1 fill-abs"></div>
+        <input type="text" id="marketSearch" class="px-1">
       </div>
     </label>
 

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=EDTWQGB" rel="stylesheet">
+  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=EDTWQGM"></script>
+<script src="/js/entry.js?v=GTHMDHF"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/en-US/markets.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/markets.tmpl
@@ -18,7 +18,7 @@
     <label class="market-search">
       <div><span class="ico-search px-2"></span></div>
       <div class="flex-grow-1 position-relative">
-        <div class="fill-abs"><input type="text" id="marketSearch" class="px-1 fill-abs"></div>
+        <input type="text" id="marketSearch" class="px-1">
       </div>
     </label>
 

--- a/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=EDTWQGB" rel="stylesheet">
+  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=EDTWQGM"></script>
+<script src="/js/entry.js?v=GTHMDHF"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/markets.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/markets.tmpl
@@ -18,7 +18,7 @@
     <label class="market-search">
       <div><span class="ico-search px-2"></span></div>
       <div class="flex-grow-1 position-relative">
-        <div class="fill-abs"><input type="text" id="marketSearch" class="px-1 fill-abs"></div>
+        <input type="text" id="marketSearch" class="px-1">
       </div>
     </label>
 

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=EDTWQGB" rel="stylesheet">
+  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=EDTWQGM"></script>
+<script src="/js/entry.js?v=GTHMDHF"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/markets.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/markets.tmpl
@@ -18,7 +18,7 @@
     <label class="market-search">
       <div><span class="ico-search px-2"></span></div>
       <div class="flex-grow-1 position-relative">
-        <div class="fill-abs"><input type="text" id="marketSearch" class="px-1 fill-abs"></div>
+        <input type="text" id="marketSearch" class="px-1">
       </div>
     </label>
 

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=z8A71BD">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=EDTWQGB" rel="stylesheet">
+  <link href="/css/style.css?v=GTHMDHF" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -85,7 +85,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=EDTWQGM"></script>
+<script src="/js/entry.js?v=GTHMDHF"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/markets.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/markets.tmpl
@@ -18,7 +18,7 @@
     <label class="market-search">
       <div><span class="ico-search px-2"></span></div>
       <div class="flex-grow-1 position-relative">
-        <div class="fill-abs"><input type="text" id="marketSearch" class="px-1 fill-abs"></div>
+        <input type="text" id="marketSearch" class="px-1">
       </div>
     </label>
 


### PR DESCRIPTION
Fix search box mishappen on markets page. Closes #1527.
FireFox and chrome are now the same.
<img width="209" alt="Screenshot 2022-07-09 at 12 20 54 AM" src="https://user-images.githubusercontent.com/57448127/178081611-076b9fe0-7406-43ca-98c3-76d0b739857a.png">

Search box width fixed.
<img width="197" alt="Screenshot 2022-07-09 at 12 27 00 AM" src="https://user-images.githubusercontent.com/57448127/178081781-997f9041-9e9a-483c-a4cd-3675a7dbe4fc.png">

