### PR TITLE
core: Fix OrderReader percentage helper for market buys

### DIFF
--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -179,7 +179,7 @@ func (ord *OrderReader) SideString() string {
 
 func (ord *OrderReader) percent(filter func(match *Match) bool) string {
 	var sum uint64
-	if ord.Sell {
+	if ord.Sell || ord.IsMarketBuy() {
 		sum = ord.sumFrom(filter)
 	} else {
 		sum = ord.sumTo(filter)


### PR DESCRIPTION
The percent filled/settled calculation for market buys was incorrectly using the "to" asset as the numerator. It is now updated to use the "from asset".

Closes #775 