### PR TITLE
client/core: Popuplate AssetConfig on PreRedeem call

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3875,6 +3875,7 @@ func (c *Core) MaxSell(host string, base, quote uint32) (*MaxOrderEstimate, erro
 	preRedeem, err := quoteWallet.PreRedeem(&asset.PreRedeemForm{
 		Lots:          maxSell.Lots,
 		FeeSuggestion: redeemFeeSuggestion,
+		AssetConfig:   quoteAsset,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%s PreRedeem error: %v", unbip(quote), err)


### PR DESCRIPTION
The asset config was not populated when calling `PreRedeem` in `MaxSell`. This was causing a panic.