### PR TITLE
client/{core,asset}: fee rate caching and expiry

### DIFF
--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -422,6 +422,10 @@ func (w *rpcWallet) LockedOutputs(ctx context.Context, acctName string) ([]chain
 // estimatesmartfee rpc.
 // Part of the Wallet interface.
 func (w *rpcWallet) EstimateSmartFeeRate(ctx context.Context, confTarget int64, mode chainjson.EstimateSmartFeeMode) (float64, error) {
+	// estimatesmartfee 1 returns extremely high rates (e.g. 0.00817644).
+	if confTarget < 2 {
+		confTarget = 2
+	}
 	estimateFeeResult, err := w.client().EstimateSmartFee(ctx, confTarget, mode)
 	if err != nil {
 		return 0, translateRPCCancelErr(err)

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1943,7 +1943,7 @@ func (w *assetWallet) findSecret(secretHash [32]byte, contractVer uint32) ([]byt
 
 // Refund refunds a contract. This can only be used after the time lock has
 // expired.
-func (w *assetWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (dex.Bytes, error) {
+func (w *assetWallet) Refund(_, contract dex.Bytes, feeRate uint64) (dex.Bytes, error) {
 	version, secretHash, err := dexeth.DecodeContractData(contract)
 	if err != nil {
 		return nil, fmt.Errorf("Refund: failed to decode contract: %w", err)
@@ -1977,7 +1977,7 @@ func (w *assetWallet) Refund(_, contract dex.Bytes, feeSuggestion uint64) (dex.B
 		return nil, fmt.Errorf("Refund: swap with secret hash %x is not refundable", secretHash)
 	}
 
-	tx, err := w.refund(secretHash, feeSuggestion, version)
+	tx, err := w.refund(secretHash, feeRate, version)
 	if err != nil {
 		return nil, fmt.Errorf("Refund: failed to call refund: %w", err)
 	}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -335,7 +335,7 @@ type Wallet interface {
 	// the unspent coin info as the wallet does not store it, even though it was
 	// known when the init transaction was created. The client should store this
 	// information for persistence across sessions.
-	Refund(coinID, contract dex.Bytes, feeSuggestion uint64) (dex.Bytes, error)
+	Refund(coinID, contract dex.Bytes, feeRate uint64) (dex.Bytes, error)
 	// DepositAddress returns an address for depositing funds into the exchange
 	// wallet.
 	DepositAddress() (string, error)
@@ -667,12 +667,12 @@ type Redemption struct {
 // expanded in in-progress work to accommodate order-time options.
 type RedeemForm struct {
 	Redemptions []*Redemption
-	// FeeSuggestion is a suggested fee from the server. For redemptions, the
-	// suggestion is provided as a convenience for wallets without full
-	// chain backing which cannot get an estimate otherwise. Since this is the
-	// redemption, there is no obligation on the client to use the fee
-	// suggestion in any way, but obviously fees that are too low may result in
-	// the redemption getting stuck in mempool.
+	// FeeSuggestion is a suggested fee rate. For redemptions, the suggestion is
+	// just a fallback if an internal estimate using the wallet's redeem confirm
+	// block target setting is not available. Since this is the redemption,
+	// there is no obligation on the client to use the fee suggestion in any
+	// way, but obviously fees that are too low may result in the redemption
+	// getting stuck in mempool.
 	FeeSuggestion uint64
 	Options       map[string]string
 }


### PR DESCRIPTION
This resolves https://github.com/decred/dcrdex/issues/1717, https://github.com/decred/dcrdex/issues/1515, and https://github.com/decred/dcrdex/issues/1718

```
In client/core, this updates trackedTrade's redeemFeeSuggestion field
as a new type, feeStamped, with a time stamp paired with the fee rate.

cacheRedemptionFeeSuggestion is made into a trackedTrade method (always
should have been), and now checks the time stamp on the
redeemFeeSuggestion before retrieving an updated rate from any of the
sources: wallet (may include external oracle request), best book fee
suggestion, and on demand fee_rate server RPC. This expiry check
resolves a long standing stale fee rate issue, and it throttles the
frequency with which we request fee rates from any source.

In client/asset/dcr, fee rates from an external API / oracle are now
cached and time stamped. The feeRate method is in charge of checking
and saving these cached rates.

PreRedeem now uses any non-zero FeeSuggestion directly, only making a
feeRate request if the provided rate is zero.  Callers in Core,
including MaxSell, MaxBuy, and Preorder, already obtain a rate.

Redeem remains a method that internally gets a fee rate because some
wallets have a redeem confirm target blocks setting to respect. It is
now documented on dcr's Redeem method that FeeSuggestion is a fallback.

Also, the Refund method now treats the fee rate argument as the rate to
use rather than a fallback, which matches the methods updated in
e41ecdfe57045cd3bf6b22aa7a6054740f0dca05.
dcr's Refund now only requests a rate if the provided rate is zero,
where previously the feeSuggestion input was a fallback.

btc's Refund and PreRedeem methods are similarly updated to use the
provided fee rate directly rather than as a fallback.

eth's Refund and PreRedeem methods already used the fee rates directly.
```