### PR TITLE
client: upgrade btc min version required

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -53,8 +53,10 @@ const (
 	// redeem transaction.
 	defaultRedeemConfTarget = 2
 
-	minNetworkVersion  = 190000
+	minNetworkVersion  = 210000
 	minProtocolVersion = 70015
+	// version which descriptor wallets have been introduced.
+	minDescriptorVersion = 220000
 
 	// splitTxBaggage is the total number of additional bytes associated with
 	// using a split transaction to fund a swap.

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -165,6 +165,10 @@ func (wc *rpcClient) connect(ctx context.Context, _ *sync.WaitGroup) error {
 	}
 	wc.descriptors = wiRes.Descriptors
 	if wc.descriptors {
+		if netVer < minDescriptorVersion {
+			return fmt.Errorf("reported node version %d is less than minimum %d"+
+				" for descriptor wallets", netVer, minDescriptorVersion)
+		}
 		wc.log.Debug("Using a descriptor wallet.")
 	}
 	return nil


### PR DESCRIPTION
This PR upgrades bitcoin min version required from v0.19 to v0.21. It also adds a min descriptor version, if using descriptor wallets.

This was discussed at matrix.