### PR TITLE
core: refactor tick and matchTracker access model

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -70,8 +70,8 @@ const (
 	walletTypeSPV     = "SPV"
 
 	// confCheckTimeout is the amount of time allowed to check for
-	// confirmations.
-	confCheckTimeout = 2 * time.Second
+	// confirmations. If SPV, this might involve pulling a full block.
+	confCheckTimeout = 4 * time.Second
 
 	// acctInternalBranch is the child number used when performing BIP0044 style
 	// hierarchical deterministic key derivation for the internal branch of an
@@ -2539,7 +2539,8 @@ func (dcr *ExchangeWallet) FindRedemption(ctx context.Context, coinID, _ dex.Byt
 	if result != nil {
 		return result.RedemptionCoinID, result.Secret, result.Err
 	}
-	return nil, nil, fmt.Errorf("aborted search for redemption of contract %s", contractOutpoint.String())
+	return nil, nil, fmt.Errorf("aborted search for redemption of contract %s: %w",
+		contractOutpoint, ctx.Err())
 }
 
 // queueFindRedemptionRequest extracts the contract hash and tx block (if mined)

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -3163,7 +3163,7 @@ func TestRefundReserves(t *testing.T) {
 		matchID := addMatch(side, status, matchQty)
 		desc := fmt.Sprintf("match revoke - %s in %s", side, status)
 		test(desc, expReserves, func() {
-			tracker.revokeMatch(tCtx, matchID, true)
+			tracker.revokeMatch(matchID, true)
 		})
 	}
 
@@ -3211,7 +3211,7 @@ func TestRefundReserves(t *testing.T) {
 	tEthWallet.refundUnlocked = 0
 	for _, mid := range mids {
 		// Third match should catch the market buy order dust filter.
-		if err := tracker.revokeMatch(tCtx, mid, true); err != nil {
+		if err := tracker.revokeMatch(mid, true); err != nil {
 			t.Fatalf("revokeMatch error: %v", err)
 		}
 	}
@@ -3391,7 +3391,7 @@ func TestRedemptionReserves(t *testing.T) {
 		matchID := addMatch(side, status, matchQty)
 		desc := fmt.Sprintf("match revoke - %s in %s", side, status)
 		test(desc, expReserves, func() {
-			tracker.revokeMatch(tCtx, matchID, true)
+			tracker.revokeMatch(matchID, true)
 		})
 	}
 
@@ -3425,7 +3425,7 @@ func TestRedemptionReserves(t *testing.T) {
 	tEthWallet.redemptionUnlocked = 0
 	for _, mid := range mids {
 		// Third match should catch the market buy order dust filter.
-		if err := tracker.revokeMatch(tCtx, mid, true); err != nil {
+		if err := tracker.revokeMatch(mid, true); err != nil {
 			t.Fatalf("revokeMatch error: %v", err)
 		}
 	}

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -289,11 +289,11 @@ const (
 )
 
 func newMatchNote(topic Topic, subject, details string, severity db.Severity, t *trackedTrade, match *matchTracker) *MatchNote {
-	var counterConfs int64
-	if match.counterConfirms > 0 {
+	_, counterConfs := match.confirms()
+	if counterConfs < 0 {
 		// This can be -1 before it is actually checked, but for purposes of the
 		// match note, it should be non-negative.
-		counterConfs = match.counterConfirms
+		counterConfs = 0
 	}
 	return &MatchNote{
 		Notification: db.NewNotification(NoteTypeMatch, topic, subject, details, severity),

--- a/client/core/status.go
+++ b/client/core/status.go
@@ -71,7 +71,7 @@ func (c *Core) resolveMatchConflicts(dc *dexConnection, statusConflicts map[orde
 					statusResolutionID(dc, trade, match))
 				// revokeMatch only returns an error for a missing match ID, and
 				// we already checked in compareServerMatches.
-				_ = trade.revokeMatch(c.ctx, match.MatchID, false)
+				_ = trade.revokeMatch(match.MatchID, false)
 			}
 		}(conflict.trade, conflict.matches)
 	}


### PR DESCRIPTION
Builds on https://github.com/decred/dcrdex/pull/1732.
This PR is https://github.com/decred/dcrdex/pull/1739/commits/7a76dc3066627d07f8f171664363324aba1ded8c
I don't think this should be for 0.5, but I wanted to put it up so we can start considering some refactoring that will alleviate some of the deadlock and lock contention issues we've been grappling with in `Core`.

This is a bigger change to core to deal with the deadlocks and lock contention with `trackedTrades`.  The main changes are:
- Only _read_ locking the `trackedTrade` mutex for the portion of `tick` where the checks are going on (with lots of wallet requests), and only write locking when actions are taken subsequently that may need to modify trade and/or match status and metadata.  This is the section of code that was causing delays and outright hangs in many places, namely anywhere that was using `(*trackedTrade).isActive`, which is all over the place.
- More fine grained concurrency controls for some `matchTracker` fields to allow certain mutations while the parent `trackedTrade`'s mutex is _not_ write locked, such as during the checking stage of `tick` and other places that don't modify any of the actual `trackedTrade` fields.  The parent's mutex is still the main guard for most of the matches fields, just now with some exceptions.
- Preventing concurrent runs of `tick` for the same `trackedTrade` using a `ticking` semaphore and CAS at the start of `tick`.  This would have been good to have even without the above changes, but it's necessary now that the entirety of `tick` is not done with the `trackedTrade`'s mutex *write* locked.  The possibility for concurrent ticks arises because tick can be called from at least three different spots, in response to different events, and thus all on different goroutines.