### PR TITLE
dcrdex/dex/wait: intermittent test failure

### DIFF
--- a/dex/wait/queue.go
+++ b/dex/wait/queue.go
@@ -185,8 +185,6 @@ func (q *TaperingTickerQueue) Wait(waiter *Waiter) {
 
 // Run runs the primary wait loop until the context is canceled.
 func (q *TaperingTickerQueue) Run(ctx context.Context) {
-	taper := float64(q.slowestInterval - q.fastestInterval)
-
 	waiters := make([]*taperingWaiter, 0, 100)
 
 	var wg sync.WaitGroup
@@ -194,6 +192,7 @@ func (q *TaperingTickerQueue) Run(ctx context.Context) {
 
 	runWaiter := func(w *taperingWaiter) {
 		defer wg.Done()
+
 		if w.TryFunc() == DontTryAgain {
 			return
 		}
@@ -204,31 +203,27 @@ func (q *TaperingTickerQueue) Run(ctx context.Context) {
 			return
 		}
 
-		var nextTick time.Time
-		switch {
-		case w.tick <= fullSpeedTicks:
-			nextTick = time.Now().Add(q.fastestInterval)
-		case w.tick < fullyTapered: // ramp up the interval
-			prog := float64(w.tick-fullSpeedTicks) / (fullyTapered - fullSpeedTicks)
-			interval := q.fastestInterval + time.Duration(math.Round(prog*taper))
-			nextTick = time.Now().Add(interval)
-		default:
-			nextTick = time.Now().Add(q.slowestInterval)
-		}
-		if nextTick.After(w.Expiration) {
-			nextTick = w.Expiration
-		}
-
-		w.nextTick = nextTick
 		w.tick++
+		w.nextTick = nextTick(w.tick, q.slowestInterval, q.fastestInterval,
+			time.Now(), w.Expiration)
 
 		q.queueWaiter <- w // send it back to the queue
 	}
+	maybeStop := func(timer *time.Timer) {
+		if timer != nil {
+			timer.Stop()
+		}
+	}
 
+	var (
+		tick  <-chan time.Time
+		timer *time.Timer
+	)
 	for {
-		var tick <-chan time.Time
 		if len(waiters) > 0 {
-			tick = time.After(time.Until(waiters[0].nextTick))
+			maybeStop(timer)
+			timer = time.NewTimer(time.Until(waiters[0].nextTick))
+			tick = timer.C
 		}
 
 		select {
@@ -253,14 +248,37 @@ func (q *TaperingTickerQueue) Run(ctx context.Context) {
 			sort.Slice(waiters, func(i, j int) bool {
 				return waiters[i].nextTick.Before(waiters[j].nextTick) // ascending, next tick first
 			})
-			// NOTE: timer leaked until it fires - consider NewTimer and Stop here
 
 		case <-ctx.Done():
+			maybeStop(timer)
 			for _, w := range waiters {
 				w.ExpireFunc() // early, but still ending prior to DontTryAgain
 			}
 			return
 		}
 	}
+}
 
+func nextTick(
+	nextTick int,
+	slowestInterval, fastestInterval time.Duration,
+	now, expiration time.Time,
+) time.Time {
+	var nextTickTime time.Time
+	switch {
+	case nextTick < fullSpeedTicks:
+		nextTickTime = now.Add(fastestInterval)
+	case nextTick < fullyTapered: // ramp up the interval
+		prog := float64(nextTick+1-fullSpeedTicks) / (fullyTapered - fullSpeedTicks)
+		taper := float64(slowestInterval - fastestInterval)
+		interval := fastestInterval + time.Duration(math.Round(prog*taper))
+		nextTickTime = now.Add(interval)
+	default:
+		nextTickTime = now.Add(slowestInterval)
+	}
+
+	if nextTickTime.After(expiration) {
+		return expiration
+	}
+	return nextTickTime
 }

--- a/dex/wait/queue_test.go
+++ b/dex/wait/queue_test.go
@@ -207,25 +207,16 @@ func expTickSchedule(startTime time.Time, fastestInterval, slowestInterval time.
 	expectedTicks[1] = expectedTicks[0].Add(fastestInterval)
 	expectedTicks[2] = expectedTicks[1].Add(fastestInterval)
 
-	const linearCnt = float64(fullyTapered - fullSpeedTicks)
-	expectedTicks[3] = expectedTicks[2].Add(fastestInterval + time.Duration(math.Round((float64(1)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[4] = expectedTicks[3].Add(fastestInterval + time.Duration(math.Round((float64(2)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[5] = expectedTicks[4].Add(fastestInterval + time.Duration(math.Round((float64(3)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[6] = expectedTicks[5].Add(fastestInterval + time.Duration(math.Round((float64(4)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[7] = expectedTicks[6].Add(fastestInterval + time.Duration(math.Round((float64(5)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[8] = expectedTicks[7].Add(fastestInterval + time.Duration(math.Round((float64(6)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[9] = expectedTicks[8].Add(fastestInterval + time.Duration(math.Round((float64(7)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[10] = expectedTicks[9].Add(fastestInterval + time.Duration(math.Round((float64(8)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[11] = expectedTicks[10].Add(fastestInterval + time.Duration(math.Round((float64(9)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[12] = expectedTicks[11].Add(fastestInterval + time.Duration(math.Round((float64(10)/linearCnt)*float64(slowestInterval-fastestInterval))))
-	expectedTicks[13] = expectedTicks[12].Add(fastestInterval + time.Duration(math.Round((float64(11)/linearCnt)*float64(slowestInterval-fastestInterval))))
-
-	expectedTicks[14] = expectedTicks[13].Add(slowestInterval)
-	expectedTicks[15] = expectedTicks[14].Add(slowestInterval)
-	expectedTicks[16] = expectedTicks[15].Add(slowestInterval)
-	expectedTicks[17] = expectedTicks[16].Add(slowestInterval)
-	expectedTicks[18] = expectedTicks[17].Add(slowestInterval)
-	expectedTicks[19] = expectedTicks[18].Add(slowestInterval)
-	expectedTicks[20] = expectedTicks[19].Add(slowestInterval)
+	taper := func(i int) time.Duration {
+		const linearCnt = fullyTapered - fullSpeedTicks
+		ramp := float64(slowestInterval - fastestInterval)
+		return time.Duration(math.Round(float64(i) / linearCnt * ramp))
+	}
+	for i := fullSpeedTicks; i < fullyTapered-1; i++ {
+		expectedTicks[i] = expectedTicks[i-1].Add(fastestInterval + taper(i-2))
+	}
+	for i := fullyTapered - 1; i < len(expectedTicks); i++ {
+		expectedTicks[i] = expectedTicks[i-1].Add(slowestInterval)
+	}
 	return expectedTicks[:]
 }

--- a/dex/wait/queue_test.go
+++ b/dex/wait/queue_test.go
@@ -2,6 +2,7 @@ package wait
 
 import (
 	"context"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -16,11 +17,13 @@ func TestTaper(t *testing.T) {
 
 	var last time.Time
 	intervals := make([]time.Duration, 0, 10)
+	var expirationTime time.Time
 	var expiration sync.WaitGroup
 	expiration.Add(1)
 
+	wantExpirationTime := time.Now().Add(time.Millisecond * 30)
 	q.Wait(&Waiter{
-		Expiration: time.Now().Add(time.Millisecond * 30),
+		Expiration: wantExpirationTime,
 		TryFunc: func() TryDirective {
 			if last.IsZero() {
 				last = time.Now()
@@ -31,6 +34,7 @@ func TestTaper(t *testing.T) {
 			return TryAgain
 		},
 		ExpireFunc: func() {
+			expirationTime = time.Now()
 			expiration.Done()
 		},
 	})
@@ -60,44 +64,51 @@ func TestTaper(t *testing.T) {
 	if lastInterval < time.Millisecond*2 {
 		t.Fatalf("last interval wasn't ~5 ms: %s", lastInterval)
 	}
+	if expirationTime.Before(wantExpirationTime) {
+		t.Fatalf("expired at: %v - sooner than expected: %v", expirationTime, wantExpirationTime)
+	}
 }
 
 func TestTaperingQueue(t *testing.T) {
-	q := NewTaperingTickerQueue(time.Millisecond, time.Millisecond*5)
+	const fastestInterval, slowestInterval = 1 * time.Millisecond, 2 * time.Millisecond
+	expiration := time.Now().Add(time.Minute)
 
-	var waiterNumber int
-	var resultMtx sync.Mutex
-	var resultOrder []int
-	var wg sync.WaitGroup
-	addWaiter := func(numTryAgains int) {
+	q := NewTaperingTickerQueue(fastestInterval, slowestInterval)
+
+	// waiterTriesTimedMtx protects waiterTriesTimed from concurrent access.
+	var waiterTriesTimedMtx sync.Mutex
+	// waiterTriesTimed maps waiter to a list of tries, each try is represented
+	// by timestamp (that reflects when waiter try starts executing).
+	waiterTriesTimed := make(map[int][]time.Time, 5)
+	var wgWaiters sync.WaitGroup
+	addWaiter := func(waiterNumber, numTryAgains int) {
 		var numTrys int
-		num := waiterNumber
-		waiterNumber++
 		q.Wait(&Waiter{
-			Expiration: time.Now().Add(time.Hour),
+			Expiration: expiration,
 			TryFunc: func() TryDirective {
+				waiterTriesTimedMtx.Lock()
+				// Record when try func was called to check it later.
+				waiterTriesTimed[waiterNumber] = append(waiterTriesTimed[waiterNumber], time.Now())
+				waiterTriesTimedMtx.Unlock()
 				numTrys++
 				if numTrys > numTryAgains {
-					resultMtx.Lock()
-					resultOrder = append(resultOrder, num)
-					resultMtx.Unlock()
-					wg.Done()
+					wgWaiters.Done()
 					return DontTryAgain
 				}
 				return TryAgain
 			},
-			ExpireFunc: func() {},
+			// We don't expect expire func being called in this test, leaving it
+			// undefined so that we'll get a panic in case it gets called.
+			//ExpireFunc: func() {},
 		})
 	}
 
-	wg.Add(5)
-	addWaiter(4)
-	addWaiter(0)
-	addWaiter(3)
-	addWaiter(1)
-	addWaiter(2)
-
-	expOrder := []int{1, 3, 4, 2, 0}
+	wgWaiters.Add(5)
+	addWaiter(0, 20)
+	addWaiter(1, 0)
+	addWaiter(2, 10)
+	addWaiter(3, 3)
+	addWaiter(4, 1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -110,17 +121,111 @@ func TestTaperingQueue(t *testing.T) {
 
 	// Wait for each waiter to get done, then stop the ticker queue itself and
 	// wait for it.
-	wg.Wait()
+	wgWaiters.Wait()
 	cancel()
 	wgQ.Wait()
 
-	if len(resultOrder) != len(expOrder) {
-		t.Fatalf("only %d of %d results received", len(resultOrder), len(expOrder))
+	calcExpectedTicks := func(totalTicks int) []time.Time {
+		return expTickSchedule(time.Now(), fastestInterval, slowestInterval)[:totalTicks]
 	}
-
-	for i := range resultOrder {
-		if resultOrder[i] != expOrder[i] {
-			t.Fatalf("wrong result order expected %+x, got %+x", expOrder, resultOrder)
+	// There is always at least one tick per waiter we expect (hence +1).
+	expWaiterTriesTimes := map[int][]time.Time{
+		0: calcExpectedTicks(20 + 1),
+		1: calcExpectedTicks(0 + 1),
+		2: calcExpectedTicks(10 + 1),
+		3: calcExpectedTicks(3 + 1),
+		4: calcExpectedTicks(1 + 1),
+	}
+	for waiterNumber, wantTriesTimes := range expWaiterTriesTimes {
+		gotTriesTimed := waiterTriesTimed[waiterNumber]
+		if len(gotTriesTimed) != len(wantTriesTimes) {
+			t.Fatalf("expected waiter %d to execute %d tries, got %d instead",
+				waiterNumber, len(wantTriesTimes), len(gotTriesTimed))
+		}
+		var (
+			prevWantTryTime time.Time
+			prevGotTryTimed time.Time
+		)
+		for i, wantTryTime := range wantTriesTimes {
+			gotTryTimed := gotTriesTimed[i]
+			if i == 0 {
+				// Can't compare try difference for first try since there is nothing
+				// to compare against.
+				prevWantTryTime = wantTryTime
+				prevGotTryTimed = gotTryTimed
+				continue
+			}
+			// Check that waiter tapering works, in other words each waiter try attempt
+			// doesn't execute sooner than we expect.
+			// We compare the actual observed time difference between two adjacent waiter
+			// try-attempts with synthetically calculated one (in wantTryDiff var), the
+			// actual observed should be higher-or-equal because there is additional
+			// code executing (scheduling/executing retry-attempts and such).
+			wantTryDiff := wantTryTime.Sub(prevWantTryTime)
+			gotTryDiff := gotTryTimed.Sub(prevGotTryTimed)
+			if gotTryDiff < wantTryDiff {
+				t.Fatalf("expected waiter %d to have time difference between tries %d-%d be > %v, "+
+					"got time difference: %v", waiterNumber, i, i-1, wantTryDiff, gotTryDiff)
+			}
+			prevWantTryTime = wantTryTime
+			prevGotTryTimed = gotTryTimed
 		}
 	}
+}
+
+func Test_nextTick(t *testing.T) {
+	const fastestInterval, slowestInterval = 100 * time.Millisecond, 500 * time.Millisecond
+	var gotTicks []time.Time
+	now := time.Now()
+	expiration := now.Add(time.Hour)
+
+	// First tick happens right away.
+	gotTicks = append(gotTicks, now)
+	for tick := 1; tick <= 19; tick++ {
+		gotTicks = append(gotTicks, nextTick(tick, slowestInterval, fastestInterval,
+			gotTicks[tick-1], expiration))
+	}
+	wantTicks := expTickSchedule(now, fastestInterval, slowestInterval)
+
+	// To check expiration on the last tick.
+	gotTicks = append(gotTicks, nextTick(20, slowestInterval, fastestInterval,
+		expiration, expiration))
+	wantTicks[len(wantTicks)-1] = expiration
+
+	for i, want := range wantTicks {
+		got := gotTicks[i]
+		if want != got {
+			t.Fatalf("expected tick %d to be: %v, got: %v", i, want, got)
+		}
+	}
+}
+
+// expTickSchedule returns expected tick schedule with a certain startTime.
+func expTickSchedule(startTime time.Time, fastestInterval, slowestInterval time.Duration) []time.Time {
+	expectedTicks := [21]time.Time{} // 21 element should be enough for all our needs in these tests.
+	expectedTicks[0] = startTime
+	expectedTicks[1] = expectedTicks[0].Add(fastestInterval)
+	expectedTicks[2] = expectedTicks[1].Add(fastestInterval)
+
+	const linearCnt = float64(fullyTapered - fullSpeedTicks)
+	expectedTicks[3] = expectedTicks[2].Add(fastestInterval + time.Duration(math.Round((float64(1)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[4] = expectedTicks[3].Add(fastestInterval + time.Duration(math.Round((float64(2)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[5] = expectedTicks[4].Add(fastestInterval + time.Duration(math.Round((float64(3)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[6] = expectedTicks[5].Add(fastestInterval + time.Duration(math.Round((float64(4)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[7] = expectedTicks[6].Add(fastestInterval + time.Duration(math.Round((float64(5)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[8] = expectedTicks[7].Add(fastestInterval + time.Duration(math.Round((float64(6)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[9] = expectedTicks[8].Add(fastestInterval + time.Duration(math.Round((float64(7)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[10] = expectedTicks[9].Add(fastestInterval + time.Duration(math.Round((float64(8)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[11] = expectedTicks[10].Add(fastestInterval + time.Duration(math.Round((float64(9)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[12] = expectedTicks[11].Add(fastestInterval + time.Duration(math.Round((float64(10)/linearCnt)*float64(slowestInterval-fastestInterval))))
+	expectedTicks[13] = expectedTicks[12].Add(fastestInterval + time.Duration(math.Round((float64(11)/linearCnt)*float64(slowestInterval-fastestInterval))))
+
+	expectedTicks[14] = expectedTicks[13].Add(slowestInterval)
+	expectedTicks[15] = expectedTicks[14].Add(slowestInterval)
+	expectedTicks[16] = expectedTicks[15].Add(slowestInterval)
+	expectedTicks[17] = expectedTicks[16].Add(slowestInterval)
+	expectedTicks[18] = expectedTicks[17].Add(slowestInterval)
+	expectedTicks[19] = expectedTicks[18].Add(slowestInterval)
+	expectedTicks[20] = expectedTicks[19].Add(slowestInterval)
+	return expectedTicks[:]
 }


### PR DESCRIPTION
Stumbled upon this test failure on master, looks like `TestTaperingQueue` should be somewhat more resilient to go-scheduler.
```
--- FAIL: TestTaperingQueue (0.01s)
    queue_test.go:123: wrong result order expected [+1 +3 +4 +2 +0], got [+1 +3 +4 +0 +2]
FAIL
FAIL	decred.org/dcrdex/dex/wait	0.824s
```
With the changes from in this PR, problematic test still runs in under 2.5 seconds on CI, which I think is ok for flakiness trade-off (although it could be tweaked of course).

Closes https://github.com/decred/dcrdex/issues/1671.