### PR TITLE
multi: exclude cancel matches for filled amount and percent on UI display

### DIFF
--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -140,29 +140,31 @@ func (ord *OrderReader) SettledPercent() string {
 	return ord.percent(settledFilter)
 }
 
-// FilledFrom is the sum filled in units of the outgoing asset.
+// FilledFrom is the sum filled in units of the outgoing asset. Excludes cancel
+// matches.
 func (ord *OrderReader) FilledFrom() string {
 	if ord.Sell {
-		return formatQty(ord.sumFrom(filledFilter), ord.BaseUnitInfo)
+		return formatQty(ord.sumFrom(filledNonCancelFilter), ord.BaseUnitInfo)
 	}
-	return formatQty(ord.sumFrom(filledFilter), ord.QuoteUnitInfo)
+	return formatQty(ord.sumFrom(filledNonCancelFilter), ord.QuoteUnitInfo)
 }
 
-// FilledTo is the sum filled in units of the incoming asset.
+// FilledTo is the sum filled in units of the incoming asset. Excludes cancel
+// matches.
 func (ord *OrderReader) FilledTo() string {
 	if ord.Sell {
-		return formatQty(ord.sumTo(filledFilter), ord.QuoteUnitInfo)
+		return formatQty(ord.sumTo(filledNonCancelFilter), ord.QuoteUnitInfo)
 	}
-	return formatQty(ord.sumTo(filledFilter), ord.BaseUnitInfo)
+	return formatQty(ord.sumTo(filledNonCancelFilter), ord.BaseUnitInfo)
 }
 
 // FilledPercent is the percent of the order that has filled, without percent
-// sign.
+// sign. Excludes cancel matches.
 func (ord *OrderReader) FilledPercent() string {
 	if ord.Type == order.CancelOrderType {
 		return ""
 	}
-	return ord.percent(filledFilter)
+	return ord.percent(filledNonCancelFilter)
 }
 
 // SideString is "sell" for sell orders, "buy" for buy orders, and "" for
@@ -370,8 +372,6 @@ func settlingFilter(match *Match) bool {
 	return (match.Side == order.Taker && match.Status < order.MatchComplete) ||
 		(match.Side == order.Maker && match.Status < order.MakerRedeemed)
 }
-
-func filledFilter(match *Match) bool { return true }
 
 func filledNonCancelFilter(match *Match) bool {
 	return !match.IsCancel

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1105,7 +1105,7 @@ export default class MarketsPage extends BasePage {
           ((OrderUtil.settled(a) * 100 / a.qty) - (OrderUtil.settled(b) * 100 / b.qty))
       case 'filled':
         return (a: Order, b: Order) => this.ordersSortDirection *
-          ((a.filled * 100 / a.qty) - (b.filled * 100 / b.qty))
+          ((OrderUtil.filled(a) * 100 / a.qty) - (OrderUtil.filled(b) * 100 / b.qty))
     }
   }
 
@@ -1170,7 +1170,7 @@ export default class MarketsPage extends BasePage {
     updateDataCol(tr, 'age', Doc.timeSince(ord.submitTime))
     updateDataCol(tr, 'rate', Doc.formatCoinValue(ord.rate / this.market.rateConversionFactor))
     updateDataCol(tr, 'qty', Doc.formatCoinValue(ord.qty, this.market.baseUnitInfo))
-    updateDataCol(tr, 'filled', `${(ord.filled / ord.qty * 100).toFixed(1)}%`)
+    updateDataCol(tr, 'filled', `${(OrderUtil.filled(ord) / ord.qty * 100).toFixed(1)}%`)
     updateDataCol(tr, 'settled', `${(OrderUtil.settled(ord) / ord.qty * 100).toFixed(1)}%`)
     updateDataCol(tr, 'status', OrderUtil.statusString(ord))
   }

--- a/client/webserver/site/src/js/orders.ts
+++ b/client/webserver/site/src/js/orders.ts
@@ -136,7 +136,7 @@ export default class OrdersPage extends BasePage {
       set('type', `${OrderUtil.typeString(ord)} ${OrderUtil.sellString(ord)}`)
       set('rate', Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, ord.rate)))
       set('status', OrderUtil.statusString(ord))
-      set('filled', `${(ord.filled / ord.qty * 100).toFixed(1)}%`)
+      set('filled', `${(OrderUtil.filled(ord) / ord.qty * 100).toFixed(1)}%`)
       set('settled', `${(OrderUtil.settled(ord) / ord.qty * 100).toFixed(1)}%`)
       const dateTime = new Date(ord.submitTime).toLocaleString()
       set('time', `${Doc.timeSince(ord.submitTime)} ago, ${dateTime}`)

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -84,6 +84,16 @@ export function statusString (order: Order): string {
   return ''
 }
 
+/* filled sums the quantities of non-cancel matches available. */
+export function filled (order: Order) {
+  if (!order.matches) return 0
+  const qty = isMarketBuy(order) ? (m: Match) => m.qty * m.rate / RateEncodingFactor : (m: Match) => m.qty
+  return order.matches.reduce((filled, match) => {
+    if (match.isCancel) return filled
+    return filled + qty(match)
+  }, 0)
+}
+
 /* settled sums the quantities of the matches that have completed. */
 export function settled (order: Order) {
   if (!order.matches) return 0


### PR DESCRIPTION
Exclude canceled matches when displaying filled amount and percent on the order page and orders table. Closes #1608
<img width="304" alt="Screenshot 2022-07-30 at 6 31 02 PM" src="https://user-images.githubusercontent.com/57448127/181935964-379aa860-8b35-4328-8547-a632fc528421.png">
<img width="1013" alt="Screenshot 2022-07-30 at 6 30 24 PM" src="https://user-images.githubusercontent.com/57448127/181935965-2163f103-6960-4f72-8d7b-79b822d57bd2.png">
 