### PR TITLE
client/asset/btc: TestTryBlocksWithNotifier is flaky

### DIFF
--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -755,8 +755,8 @@ func TestTryBlocksWithNotifier(t *testing.T) {
 	defaultWalletBlockAllowance := walletBlockAllowance
 	defaultBlockTicker := blockTicker
 
-	walletBlockAllowance = 300 * time.Millisecond
-	blockTicker = 50 * time.Millisecond
+	walletBlockAllowance = 50 * time.Millisecond
+	blockTicker = 20 * time.Millisecond
 
 	defer func() {
 		walletBlockAllowance = defaultWalletBlockAllowance

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -755,8 +755,8 @@ func TestTryBlocksWithNotifier(t *testing.T) {
 	defaultWalletBlockAllowance := walletBlockAllowance
 	defaultBlockTicker := blockTicker
 
-	walletBlockAllowance = 30 * time.Millisecond
-	blockTicker = 5 * time.Millisecond
+	walletBlockAllowance = 300 * time.Millisecond
+	blockTicker = 50 * time.Millisecond
 
 	defer func() {
 		walletBlockAllowance = defaultWalletBlockAllowance


### PR DESCRIPTION
Couldn't see any issues with the code being tested, however I think test waiting-intervals need to be tweaked (in master, `blockTicker / 2` is `2.5ms` in this test, which doesn't seem too generous for go-runtime to finish its business with handling go-routines / channels),

for tests relying on go-scheduler to "work in time" (like this one), I think, it's better to over-allocate waiting times (than under-allocate these), even at the cost of long-running tests (cause flakieness will distract devs); although, it's a trade-off ...

Maybe worth closing https://github.com/decred/dcrdex/issues/1330 and re-open it if  the issue reproduces with higher waiting-intervals.
