### PR TITLE
client/core: prevent concurrent login requests

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -5493,6 +5493,7 @@ func TestResolveActiveTrades(t *testing.T) {
 		tEthWallet.reservedRedemption = 0
 		tEthWallet.reservedRefund = 0
 		rig.dc.trades = make(map[order.OrderID]*trackedTrade)
+		tCore.loginWg = nil
 	}
 
 	// Ensure the order is good, and reset the state.


### PR DESCRIPTION
This addresses a concern in #1690. It is a minor fix to prevent concurrent login requests.

> @chappjc, One thing I'm noticing from your dexc logs is a second call to /api/login that seemed to trigger unloading of the wallet before trying to load it again. I've noted before (cannot find my comments) that logging in twice is a little wonky and we should reexamine (*Core).Login from the perspective of an already logged in Core.

> I think we can try to catch the explicit panics from SynchronizeRPC, but the root cause seems to have to do with repeat logins or possibly abrupt shutdown of the wallet.