### PR TITLE
client/core: throttle with Ticker instead of Timer

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -7743,10 +7743,9 @@ func (c *Core) fetchFiatExchangeRates() {
 	c.wg.Add(1)
 	go func() {
 		defer c.wg.Done()
-		tick := time.NewTimer(fiatRateRequestInterval)
+		tick := time.NewTicker(fiatRateRequestInterval)
 		defer tick.Stop()
 		for {
-
 			c.refreshFiatRates(ctx)
 
 			select {


### PR DESCRIPTION
Noticed this while exploring `time.Timer` quirks [here](https://github.com/decred/dcrdex/pull/1742#discussion_r935345226).

Looks like we need a `Ticker` (not `Timer`), otherwise we'll throttle `refreshFiatRates` only once ?