### PR TITLE
trade: Update dynamic fees after they are mined.

### DIFF
--- a/dex/networks/eth/txdata.go
+++ b/dex/networks/eth/txdata.go
@@ -45,7 +45,7 @@ func ParseRedeemData(calldata []byte, contractVersion uint32) (map[[SecretHashSi
 // ParseRefundData parses the calldata used to call the refund function of a
 // specific version of the swap contract. It returns the secret hash and errors
 // if the call data does not call refund with expected argument types.
-func ParseRefundData(calldata []byte, contractVersion uint32) ([32]byte, error) {
+func ParseRefundData(calldata []byte, contractVersion uint32) ([SecretHashSize]byte, error) {
 	txDataHandler, ok := txDataHandlers[contractVersion]
 	if !ok {
 		return [32]byte{}, fmt.Errorf("contract version %v does not exist", contractVersion)


### PR DESCRIPTION
    Fees for some trades cannot be accurately calculated until after the tx
    is mined. For those assets, start a go routine to check on the txn until
    it can be found and the actual gas used be added to the swap and
    redemption fees paid.

~depends on #1739~