### PR TITLE
client/asset/btc: avoid a bbolt deadlock with nested View

### DIFF
--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -1997,9 +1997,7 @@ func (w *walletExtender) signTransaction(tx *wire.MsgTx) error {
 		txIn.SignatureScript = nil
 		txIn.Witness = nil
 	}
-	return walletdb.View(w.Database(), func(dbtx walletdb.ReadTx) error { // what is the db tx for?
-		return txauthor.AddAllInputScripts(tx, prevPkScripts, inputValues, &secretSource{w, w.chainParams})
-	})
+	return txauthor.AddAllInputScripts(tx, prevPkScripts, inputValues, &secretSource{w, w.chainParams})
 }
 
 // txNotifications gives access to the NotificationServer's tx notifications.


### PR DESCRIPTION
This resolves a useless nested `walletdb.View` that causes a reproducible deadlock with a concurrent  `Update`.

**Repro**: Get three DCR buy orders funded by BTC on the book, match a 3 lot DCR sell with those three orders.  When matched, this triggers `swapMatchGroup` to run all three BTC `Swap` calls concurrently (which by design).  I used a `-race` build with Go 1.19.

![image](https://user-images.githubusercontent.com/9373513/182722343-1a797869-5cb7-4fcd-8666-f99fda3ee5d5.png)

**Cause:**  In my tests, two of them are doing `Updates` like from `refundAddress` > `(*Wallet).NewAddress` (or similar for `changeAddress`), and another that does a `View` for `signTxAndAddChange`.  This is where the problem is since `(*walletExtender).signTransaction` does the nested `View`, where the inner `View` deadlocks with one of the other `Updates`.

This is [called out in the bbolt docs](https://github.com/etcd-io/bbolt/blob/master/README.md#transactions) as a no-no:

> Transactions should not depend on one another and generally shouldn't be opened simultaneously in the same goroutine. This can cause a deadlock as the read-write transaction needs to periodically re-map the data file but it cannot do so while any read-only transaction is open. **Even a nested read-only transaction can cause a deadlock, as the child transaction can block the parent transaction from releasing its resources.**

https://github.com/etcd-io/bbolt/pull/59

The deadlock was exactly as described.  The inner `View` was hung on `db.mmaplock.RLock()` because the `Update` was waiting on `db.mmaplock.Lock()` (in `(*Tx).Commit` > `(*DB).mmap`) and the outer view already had it read-locked.

**Resolution:**  I recently added a comment that the outer `View` seemed to have no purpose, and indeed it did not.  We can just remove the outer `View`.

----


`refundAddress` goroutine hung getting `db.mmaplock.Lock()` in `Update` > `Commit` > `mmap`

![image](https://user-images.githubusercontent.com/9373513/182722396-4950ae4c-16ad-47c3-8959-35be27ef72b8.png)

`signTransaction` goroutine hung in nested `View`, outer `View` already read-locked `mmaplock` and inner view trying to `RLock` again in `beginTx` (but cannot because the `refundAddress` goroutine is waiting for write lock):

![image](https://user-images.githubusercontent.com/9373513/182722384-165392ca-6a3d-4227-bdfe-1b46728a85fb.png)

`changeAddress` goroutine hung getting `db.rwlock.Lock()` in `Update` > `beginRWTx`:

![image](https://user-images.githubusercontent.com/9373513/182722374-6e078fcf-48fb-42bb-bc75-180cb67d3fec.png)
