### PR TITLE
reload wallets page when new wallets are created

### DIFF
--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -615,13 +615,8 @@ export default class WalletsPage extends BasePage {
   async createWalletSuccess () {
     const rowInfo = this.rowInfos[this.walletAsset]
     this.showMarkets(rowInfo.assetID)
-    const a = rowInfo.actions
-    Doc.hide(a.create)
-    Doc.show(a.send, a.deposit, a.settings)
     await app().fetchUser()
-    if (app().walletMap[rowInfo.assetID].encrypted) {
-      Doc.show(a.lock)
-    }
+    await app().loadPage('wallets')
   }
 
   /* openWalletSuccess is the success callback for wallet unlocking. */


### PR DESCRIPTION
This diff modifies `createWalletSuccess` to reload `wallets` page as part of the success callback for wallet creation. Closes #1754 and maybe #1763.