### PR TITLE
client: fix markets page

### DIFF
--- a/client/webserver/site/src/js/charts.ts
+++ b/client/webserver/site/src/js/charts.ts
@@ -1207,6 +1207,7 @@ function makeLabels (
   valFmt = valFmt || formatLabelValue
   const n = screenW / spacingGuess
   const diff = max - min
+  if (n < 1 || diff <= 0) return { lbls: [] }
   const tickGuess = diff / n
   // make the tick spacing a multiple of the step
   const tick = tickGuess + step - (tickGuess % step)

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -1466,7 +1466,7 @@ export class DEXAddressForm {
     }
     if (!this.dexToUpdate && res.paid) {
       await app().fetchUser()
-      app().loadPage('markets')
+      await app().loadPage('markets')
       return
     }
     if (this.pwCache) this.pwCache.pw = pw

--- a/client/webserver/site/src/js/login.ts
+++ b/client/webserver/site/src/js/login.ts
@@ -18,6 +18,6 @@ export default class LoginPage extends BasePage {
   /* login submits the sign-in form and parses the result. */
   async loggedIn () {
     await app().fetchUser()
-    app().loadPage('markets')
+    await app().loadPage('markets')
   }
 }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -2125,7 +2125,7 @@ export default class MarketsPage extends BasePage {
       // or this may be the first opportunity to get the server's config, so
       // fetch it all before reloading the markets page.
       await app().fetchUser()
-      app().loadPage('markets')
+      await app().loadPage('markets')
     }
   }
 

--- a/client/webserver/site/src/js/register.ts
+++ b/client/webserver/site/src/js/register.ts
@@ -214,7 +214,7 @@ export default class RegistrationPage extends BasePage {
   /* Called after successful registration to a DEX. */
   async registerDEXSuccess () {
     await app().fetchUser()
-    app().loadPage('markets')
+    await app().loadPage('markets')
   }
 
   async newWalletCreated (assetID: number) {


### PR DESCRIPTION
Each time the markets page is loaded I see these errors. Some elements might not be made available if we run `app().loadPage('markets')` without `await` which will result in `notes` and other methods trying to access elements that are not available. Don't know if there is more to these errors.

<img width="1368" alt="Screenshot 2022-08-03 at 11 28 17 PM" src="https://user-images.githubusercontent.com/57448127/182725018-d3dab8b2-318a-4f71-9244-4275532a4320.png">
<img width="1353" alt="Screenshot 2022-08-03 at 11 29 42 PM" src="https://user-images.githubusercontent.com/57448127/182725027-afc6507e-04a9-4061-9f38-11a15bf7655a.png">

EDIT:  Also this.
<img width="1511" alt="Screenshot 2022-08-05 at 12 34 36 AM" src="https://user-images.githubusercontent.com/57448127/182972904-b91b1565-89f5-4049-b9e8-30d62a0093aa.png">

EDIT 2: Looks like noteFeeder is trying to access a property on an object that is not yet available. Just like in #1754. It goes away after a refresh. I think these errors are all related to not waiting for `app().loadPage('markets')`.

<img width="1511" alt="Screenshot 2022-08-05 at 12 59 32 AM" src="https://user-images.githubusercontent.com/57448127/182974819-cc523dba-7dfe-448c-80bc-d68cfde7ec1a.png">

