### PR TITLE
prevent concurrent login in Core

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1147,11 +1147,12 @@ func newTestRig() *testRig {
 	rig := &testRig{
 		shutdown: shutdown,
 		core: &Core{
-			ctx:      ctx,
-			cfg:      &Config{},
-			db:       tdb,
-			log:      tLogger,
-			latencyQ: queue,
+			ctx:       ctx,
+			cfg:       &Config{},
+			db:        tdb,
+			log:       tLogger,
+			loginSlot: make(chan struct{}, 1),
+			latencyQ:  queue,
 			conns: map[string]*dexConnection{
 				tDexHost: dc,
 			},


### PR DESCRIPTION
Concurrent attempts take a short path when the existing one unblocks.
Subsequent attempts do full Login, as before.