### PR TITLE
client/asset/btc: remove incorrect error return

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1132,7 +1132,7 @@ func (btc *baseWallet) connect(ctx context.Context) (*sync.WaitGroup, error) {
 	}
 	bestBlockHash, err := chainhash.NewHashFromStr(bestBlockHdr.Hash)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get best block hash from %s node", btc.symbol)
+		return nil, fmt.Errorf("invalid best block hash from %s node: %v", btc.symbol, err)
 	}
 	// Check for method unknown error for feeRate method.
 	_, err = btc.estimateFee(btc.node, 1)
@@ -2144,7 +2144,7 @@ func (btc *baseWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 		}
 		pt := newOutPoint(txHash, rpcOP.Vout)
 		if !notFound[pt] {
-			continue
+			continue // unrelated to the order
 		}
 
 		txRaw, _, err := btc.rawWalletTx(txHash)
@@ -2192,8 +2192,6 @@ func (btc *baseWallet) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 		if len(notFound) == 0 {
 			return coins, nil
 		}
-
-		return nil, fmt.Errorf("funding coin %s:%v not found", txHash, rpcOP.Vout)
 	}
 
 	// Some funding coins still not found after checking locked outputs.
@@ -3897,12 +3895,12 @@ func (btc *intermediaryWallet) watchBlocks(ctx context.Context) {
 		case <-ticker.C:
 			newTipHdr, err := btc.node.getBestBlockHeader()
 			if err != nil {
-				go btc.tipChange(fmt.Errorf("failed to get best block header from %s node", btc.symbol))
+				go btc.tipChange(fmt.Errorf("failed to get best block header from %s node: %v", btc.symbol, err))
 				continue
 			}
 			newTipHash, err := chainhash.NewHashFromStr(newTipHdr.Hash)
 			if err != nil {
-				go btc.tipChange(fmt.Errorf("failed to get best block hash from %s node", btc.symbol))
+				go btc.tipChange(fmt.Errorf("invalid best block hash from %s node: %v", btc.symbol, err))
 				continue
 			}
 


### PR DESCRIPTION
The fixes a regression in `client/asset/btc.(*baseWallet).FundingCoins` introduced in https://github.com/decred/dcrdex/pull/1607/files#diff-1b07e494f4bdd99b2a617ac110fbadc081e5b6ae1abf23f64032bbee5ebebef1

This error return made sense before because it meant it had found the UTXO in the `listunspent` results but it did not find the vout in the `gettransaction` result `details` array.

Now if you have reached this spot, it means you have successfully found the output and added it to `btc.fundingCoins[pt] = utxo`.