### PR TITLE
client/db/bolt: store asset versions with order

### DIFF
--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -712,6 +712,8 @@ func (db *BoltDB) UpdateOrder(m *dexdb.MetaOrder) error {
 			put(maxFeeRateKey, uint64Bytes(md.MaxFeeRate)).
 			put(redeemMaxFeeRateKey, uint64Bytes(md.RedeemMaxFeeRate)).
 			put(redemptionFeesKey, uint64Bytes(md.RedemptionFeesPaid)).
+			put(fromVersionKey, uint32Bytes(md.FromVersion)).
+			put(toVersionKey, uint32Bytes(md.ToVersion)).
 			put(optionsKey, config.Data(md.Options)).
 			put(accelerationsKey, accelerationsB).
 			err()


### PR DESCRIPTION
`UpdateOrder` must store the asset versions for both to/from assets.
Otherwise we wait for the first `UpdateOrderMetaData` data to actually store the real values.
This can be bad for LTC where we are on v1 already when we switched to segwit.

This fix was pulled from the draft https://github.com/decred/dcrdex/pull/1653#discussion_r916910330, and in that PR I also remove a bunch of stuff from `UpdateOrderMetaData` that should not be written except on order creation by `UpdateOrder`, but I'm not doing that here.