### PR TITLE
client: handle unknown response error gracefully

### DIFF
--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1270,7 +1270,7 @@ func (t *trackedTrade) isRedeemable(ctx context.Context, match *matchTracker) (r
 		return false, false
 	}
 	if ticksGoverned, _ := match.exceptions(); ticksGoverned {
-		t.dc.log.Tracef("Match %s not redeemable: ticks metered", match, match.swapErr)
+		t.dc.log.Tracef("Match %s not redeemable: ticks metered", match)
 		return false, false
 	}
 	// NOTE: Taker must be able to redeem when revoked!  As maker, only block


### PR DESCRIPTION
Quoting @chappjc 
> I think my last comment from a year ago was a reasonable and minimal change (a response without a handler, but with Error field set -> log the error as "unhandled response with error msg: X" because there's nothing to do anyway other than wait for and handle another request that retries the previous failed one)

Closes #456 && #1770