### PR TITLE
client: fix missing asset ID error when creating new wallet address

### DIFF
--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -65,7 +65,6 @@ export default class WalletsPage extends BasePage {
   unlockForm: UnlockWalletForm
   keyup: (e: KeyboardEvent) => void
   changeWalletPW: boolean
-  depositAsset: number
   displayed: HTMLElement
   animation: Animation
   forms: PageElement[]
@@ -662,7 +661,7 @@ export default class WalletsPage extends BasePage {
     Doc.hide(page.depositErr)
     const loaded = app().loading(page.deposit)
     const res = await postJSON('/api/depositaddress', {
-      assetID: this.depositAsset
+      assetID: this.selectedAssetID
     })
     loaded()
     if (!app().checkResponse(res, true)) {


### PR DESCRIPTION
Encountered this issue while testing the new wallets page on master. Creating a new issue wasn't necessary :)
<img width="529" alt="Screenshot 2022-08-16 at 5 10 51 PM" src="https://user-images.githubusercontent.com/57448127/184928818-182ff650-5094-41be-8592-f62344b3a29d.png">

