### PR TITLE
markdownlint-cli2 action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,13 @@ jobs:
     - name: npm run build
       working-directory: ./client/webserver/site
       run: npm run build
+  lint-docs:
+    name: Lint Markdown
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DavidAnson/markdownlint-cli2-action@v7
+      continue-on-error: true
+      with:
+        globs: '**/*.md'
+      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,5 +56,7 @@ jobs:
     - uses: DavidAnson/markdownlint-cli2-action@v7
       continue-on-error: true
       with:
-        globs: '**/*.md'
+        globs: |
+          *.md
+          docs/**/*.md
       

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,5 +3,6 @@
     "MD007": false,
     "MD010": { "code_blocks": false },
     "MD013": false,
-    "MD014": false
+    "MD014": false,
+    "MD033": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+    "default": true,
+    "MD007": false,
+    "MD010": { "code_blocks": false },
+    "MD013": false,
+    "MD014": false
+}


### PR DESCRIPTION
This sets up a [markdownlint-cli2 GitHub action](https://github.com/marketplace/actions/markdownlint-cli2-action) in a mode that only prints violations but **does not fail** the workflow.  It takes about 6 seconds to run in CI and is purely informative. See [this workflow run](https://github.com/decred/dcrdex/runs/7903558863?check_suite_focus=true#step:3:10), for example.

I chose this particular action because David Anson is the author of markdownlint (https://github.com/DavidAnson/markdownlint), although there are many other [similar Github Actions](https://github.com/marketplace?type=actions&query=markdown+lint+sort%3Apopularity-desc+).

Devs should either configure their editor (e.g. https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) or use a standalone/CLI markdownlint-cli/markdownlint-cli2 while preparing.

We can use this as a basis to settle on a `.markdownlint.json` (the rules config) that we like.

