### PR TITLE
site: set zoom buttons in DepthChart ctor

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GHTDEG56"></script>
+<script src="/js/entry.js?v=YKVNRn4"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/charts.ts
+++ b/client/webserver/site/src/js/charts.ts
@@ -169,7 +169,6 @@ class Chart {
     this.ctx = ctx
     this.ctx.textAlign = 'center'
     this.ctx.textBaseline = 'middle'
-    this.setZoomBttns()
     // Mouse handling
     this.mousePos = null
     bind(this.canvas, 'mousemove', (e: MouseEvent) => {
@@ -204,12 +203,6 @@ class Chart {
   /* draw calls the child class's render method. */
   draw () {
     this.render()
-  }
-
-  // setZoomBttns is run before drawing and should be used for setup of zoom
-  // buttons.
-  setZoomBttns () {
-    // should be implemented by inheriting class.
   }
 
   /* click is the handler for a click event on the canvas. */
@@ -410,6 +403,7 @@ export class DepthChart extends Chart {
       buys: [],
       sells: []
     }
+    this.setZoomBttns() // can't wait for requestAnimationFrame -> resized
     this.resize(parent.clientHeight)
   }
 

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -330,10 +330,11 @@ export default class MarketsPage extends BasePage {
     ws.registerRoute(updateRemainingRoute, (data: BookUpdate) => { this.handleUpdateRemainingRoute(data) })
     // Handle the new order for the order book on the 'epoch_order' route.
     ws.registerRoute(epochOrderRoute, (data: BookUpdate) => { this.handleEpochOrderRoute(data) })
-    // Handle the intial candlestick data on the 'candles' route.
-    ws.registerRoute(candleUpdateRoute, (data: BookUpdate) => { this.handleCandleUpdateRoute(data) })
-    // Handle the candles update on the 'candles' route.
+    // Handle the initial candlestick data on the 'candles' route.
     ws.registerRoute(candlesRoute, (data: BookUpdate) => { this.handleCandlesRoute(data) })
+    // Handle the candles update on the 'candles' route.
+    ws.registerRoute(candleUpdateRoute, (data: BookUpdate) => { this.handleCandleUpdateRoute(data) })
+
     // Bind the wallet unlock form.
     this.unlockForm = new UnlockWalletForm(page.unlockWalletForm, async () => { this.openFunc() })
     // Create a wallet
@@ -2221,9 +2222,10 @@ export default class MarketsPage extends BasePage {
   unload () {
     ws.request(unmarketRoute, {})
     ws.deregisterRoute(bookRoute)
-    ws.deregisterRoute(epochOrderRoute)
     ws.deregisterRoute(bookOrderRoute)
     ws.deregisterRoute(unbookOrderRoute)
+    ws.deregisterRoute(updateRemainingRoute)
+    ws.deregisterRoute(epochOrderRoute)
     ws.deregisterRoute(candlesRoute)
     ws.deregisterRoute(candleUpdateRoute)
     this.depthChart.unattach()

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GHTDEG56"></script>
+<script src="/js/entry.js?v=YKVNRn4"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GHTDEG56"></script>
+<script src="/js/entry.js?v=YKVNRn4"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GHTDEG56"></script>
+<script src="/js/entry.js?v=YKVNRn4"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GHTDEG56"></script>
+<script src="/js/entry.js?v=YKVNRn4"></script>
 </body>
 </html>
 {{end}}


### PR DESCRIPTION
This resolves the error `Uncaught TypeError: can't access property "setExtents", e.zoomOutBttn is undefined`, which happens often on DEX server reconnect events.  Probably more so if you have more than one server configured.
The best way to reproduce is:
- get the dex window opened to the markets page
- switch to another tab in the same window, effectively hiding the tab
- minimize the window for good measure, but neither of these steps are really required
- wait for a reconnect, or wait a minute or two and force a reconnect (e.g. restart tor, toggle vpn, etc).

The root of the issue seems to be that the parent constructor was not setting the zoom buttons as intended.  And the `requestAnimation` callback that actually was setting them via the `resized` reporter is not called until the browser decides to actually draw on the canvas.  This is asynchronous, and the steps above try to make it a longer delay.

```
The zoom buttons were not being initialized in the constructor as
indended. This calls setZoomBttns directly from the constructor of the
inheriting class, DepthChart.

This also fixes a missing ws.deregisterRoute for updateRemainingRoute.
```