### PR TITLE
site: fix wallet page JS errors

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GHTDEG56" rel="stylesheet">
+  <link href="/css/style.css?v=GHTDFVH6" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=YKVNRn4"></script>
+<script src="/js/entry.js?v=GHTDFVH6"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -411,6 +411,7 @@ export default class WalletsPage extends BasePage {
     const page = this.page
     const markets: [string, Market][] = []
     for (const xc of Object.values(app().user.exchanges)) {
+      if (!xc.markets) continue
       for (const mkt of Object.values(xc.markets)) {
         if (mkt.baseid === assetID || mkt.quoteid === assetID) markets.push([xc.host, mkt])
       }

--- a/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/en-US/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GHTDEG56" rel="stylesheet">
+  <link href="/css/style.css?v=GHTDFVH6" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=YKVNRn4"></script>
+<script src="/js/entry.js?v=GHTDFVH6"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pl-PL/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GHTDEG56" rel="stylesheet">
+  <link href="/css/style.css?v=GHTDFVH6" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=YKVNRn4"></script>
+<script src="/js/entry.js?v=GHTDFVH6"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/pt-BR/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GHTDEG56" rel="stylesheet">
+  <link href="/css/style.css?v=GHTDFVH6" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=YKVNRn4"></script>
+<script src="/js/entry.js?v=GHTDFVH6"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
+++ b/client/webserver/site/src/localized_html/zh-CN/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GHTDEG56" rel="stylesheet">
+  <link href="/css/style.css?v=GHTDFVH6" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=YKVNRn4"></script>
+<script src="/js/entry.js?v=GHTDFVH6"></script>
 </body>
 </html>
 {{end}}


### PR DESCRIPTION
Quoting @JoeGruffins 
> There is another js error I see if I start not connected to the dex and navigate to the wallets page, since you are fixing all these. You don't have to fix in this pr though.

This resolves: 
<img width="1000" alt="Screenshot 2022-08-19 at 1 59 07 PM" src="https://user-images.githubusercontent.com/57448127/185632865-dc0a2d7c-74d7-49d0-a722-3fef6ab4fa69.png">

To reproduce: start dexc without internet connection -> login -> wallets page. While here the first auto-selected wallet will only display the wallet detail table, while the markets table and recent activity table remain blank(selecting another wallet loads the markets table and recent activity table but still produce errors).
![btcmarketserror](https://user-images.githubusercontent.com/57448127/185635345-6a87f853-4176-4659-9217-40ea4ab33854.png)

