### PR TITLE
dex/meter: fix flaky TestDelayedRelay test

### DIFF
--- a/dex/meter/meterer.go
+++ b/dex/meter/meterer.go
@@ -39,7 +39,7 @@ func DelayedRelay(ctx context.Context, minDelay time.Duration, n int) (out <-cha
 
 				if time.Since(last) > minDelay {
 					outC <- nil
-					last = time.Now().UTC()
+					last = time.Now()
 					continue
 				}
 
@@ -51,7 +51,7 @@ func DelayedRelay(ctx context.Context, minDelay time.Duration, n int) (out <-cha
 			case <-now:
 				outC <- nil
 				scheduled = nil
-				last = time.Now().UTC()
+				last = time.Now()
 
 			case <-ctx.Done():
 				if scheduled != nil && !scheduled.Stop() {

--- a/dex/meter/meterer_test.go
+++ b/dex/meter/meterer_test.go
@@ -10,6 +10,13 @@ import (
 func TestDelayedRelay(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	minDelay := time.Millisecond * 20
+	// While `DelayedRelay` sends signals at least `minDelay` apart, this test
+	// actually checks not the distance in time between those sends, but rather
+	// the distance in time between receives corresponding to those sends, and
+	// that distance can be less than `minDelay` (it also depends on Go scheduler),
+	// hence we lower our expectations here to account for possible Go scheduler
+	// lag.
+	minDelaySafe := minDelay - time.Millisecond*10
 	out, in := DelayedRelay(ctx, minDelay, 4)
 	defer func() { <-out }() // wait for channel close (relay shutdown)
 	defer cancel()
@@ -44,13 +51,13 @@ func TestDelayedRelay(t *testing.T) {
 	}
 
 	// Sending two signals simultaneously should end up with two signals, at
-	// least minDelay apart.
+	// least minDelaySafe apart.
 	go sendSignals(2, nil)
 	if n := countSignals(); n != 2 {
 		t.Fatalf("wrong signal count. expected 2, got %d", n)
 	}
-	if d := lastDelay(); d < minDelay {
-		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelay)
+	if d := lastDelay(); d < minDelaySafe {
+		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelaySafe)
 	}
 
 	// Should get the same exact result for 3 or more simultaneous signals.
@@ -58,8 +65,8 @@ func TestDelayedRelay(t *testing.T) {
 	if n := countSignals(); n != 2 {
 		t.Fatalf("wrong signal count. expected reduction to 2, got %d", n)
 	}
-	if d := lastDelay(); d < minDelay {
-		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelay)
+	if d := lastDelay(); d < minDelaySafe {
+		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelaySafe)
 	}
 
 	// Errors should go right through.

--- a/dex/meter/meterer_test.go
+++ b/dex/meter/meterer_test.go
@@ -10,33 +10,22 @@ import (
 func TestDelayedRelay(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	minDelay := time.Millisecond * 20
-	// While `DelayedRelay` sends signals at least `minDelay` apart, this test
-	// actually checks not the distance in time between those sends, but rather
-	// the distance in time between receives corresponding to those sends, and
-	// that distance can be less than `minDelay` (it also depends on Go scheduler),
-	// hence we lower our expectations here to account for possible Go scheduler
-	// lag.
-	minDelaySafe := minDelay - time.Millisecond*10
 	out, in := DelayedRelay(ctx, minDelay, 4)
 	defer func() { <-out }() // wait for channel close (relay shutdown)
 	defer cancel()
 
-	times := make([]time.Time, 0)
+	gotTimes := make([]time.Time, 0)
 
 	countSignals := func() (n int) {
 		for {
 			select {
 			case <-out:
-				times = append(times, time.Now())
+				gotTimes = append(gotTimes, time.Now())
 				n++
 			case <-time.After(minDelay * 2):
 				return
 			}
 		}
-	}
-
-	lastDelay := func() time.Duration {
-		return times[len(times)-1].Sub(times[len(times)-2])
 	}
 
 	sendSignals := func(n int, err error) {
@@ -50,23 +39,25 @@ func TestDelayedRelay(t *testing.T) {
 		t.Fatalf("wrong signal count. expected 1, got %d", n)
 	}
 
-	// Sending two signals simultaneously should end up with two signals, at
-	// least minDelaySafe apart.
+	// 2nd signal should be delayed at least for minDelay.
+	sentTime := time.Now()
 	go sendSignals(2, nil)
 	if n := countSignals(); n != 2 {
 		t.Fatalf("wrong signal count. expected 2, got %d", n)
 	}
-	if d := lastDelay(); d < minDelaySafe {
-		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelaySafe)
+	if d := gotTimes[len(gotTimes)-1].Sub(sentTime); d < minDelay {
+		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelay)
 	}
 
-	// Should get the same exact result for 3 or more simultaneous signals.
+	// Should get the same exact result as above (for 3 or more simultaneous signals
+	// 3rd, 4th, 5th should be skipped).
+	sentTime = time.Now()
 	go sendSignals(5, nil)
 	if n := countSignals(); n != 2 {
 		t.Fatalf("wrong signal count. expected reduction to 2, got %d", n)
 	}
-	if d := lastDelay(); d < minDelaySafe {
-		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelaySafe)
+	if d := gotTimes[len(gotTimes)-1].Sub(sentTime); d < minDelay {
+		t.Fatalf("last delay was less than minimum. %s < %s", d, minDelay)
 	}
 
 	// Errors should go right through.


### PR DESCRIPTION
Left a comment in the test describing the root cause (**edit**: see 1st commit in this PR; actually, this test can be easily re-designed to avoid having to deal with Go scheduler - which is the latest version of this PR, i.e. 2nd commit).

Closes https://github.com/decred/dcrdex/issues/1782.