### PR TITLE
site: fix firefox bug

### DIFF
--- a/client/webserver/site/src/js/doc.ts
+++ b/client/webserver/site/src/js/doc.ts
@@ -110,9 +110,7 @@ export default class Doc {
    * the bounds of the specified element.
    */
   static mouseInElement (e: MouseEvent, el: HTMLElement): boolean {
-    const rect = el.getBoundingClientRect()
-    return e.pageX >= rect.left && e.pageX <= rect.right &&
-      e.pageY >= rect.top && e.pageY <= rect.bottom
+    return el.contains(e.target as Node)
   }
 
   /*


### PR DESCRIPTION
I investigated the issue resulting in #1808 and found out firefox and chrome behave differently on `mousedown` events.
I think the issue lies in the fact that Firefox triggers 3 events (onmousedown, onmousedown, onchange) instead of 2 (onmousedown, onchange) like Chrome does. The last `onmousedown` will have the screen coordination value of the event set to zero(cause the last mouse `event`  is actually right in the `Element`?). Closes #1808.

Reference 1: [w3c uievents #201](https://github.com/w3c/uievents/issues/201)