### PR TITLE
client: fix error before spot price

### DIFF
--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -141,13 +141,13 @@
                       </span>
                     </td>
                     <td class="d-none d-md-table-cell d-lg-none d-xxl-table-cell"><div data-tmpl="host" class="short-host"></div></td>
-                    <td>
+                    <td data-tmpl="priceBox">
                       <span data-tmpl="price"></span>
                       <span class="fs13 grey">
                         <sup data-tmpl="priceQuoteUnit" class></sup>/<sub data-tmpl="priceBaseUnit"></sub>
                       </span>
                     </td>
-                    <td data-tmpl="volume">
+                    <td data-tmpl="volumeBox">
                       <span data-tmpl="volume"></span>
                       <span data-tmpl="volumeUnit" class="fs15 grey"></span>
                     </td>


### PR DESCRIPTION
If going to the wallet page before the spot price being calculated, an error will be thrown:

![image](https://user-images.githubusercontent.com/15069783/186169457-18456c61-3c54-4dc6-aee4-2913bd87d42f.png)

This PR fixes it.