### PR TITLE
client/core: allow changing dex host for down dex

### DIFF
--- a/client/core/account.go
+++ b/client/core/account.go
@@ -14,17 +14,19 @@ import (
 func (c *Core) disconnectDEX(dc *dexConnection) {
 	// Stop dexConnection books.
 	dc.cfgMtx.RLock()
-	for _, m := range dc.cfg.Markets {
-		// Empty bookie's feeds map, close feeds' channels & stop close timers.
-		dc.booksMtx.Lock()
-		if b, found := dc.books[m.Name]; found {
-			b.closeFeeds()
-			if b.closeTimer != nil {
-				b.closeTimer.Stop()
+	if dc.cfg != nil {
+		for _, m := range dc.cfg.Markets {
+			// Empty bookie's feeds map, close feeds' channels & stop close timers.
+			dc.booksMtx.Lock()
+			if b, found := dc.books[m.Name]; found {
+				b.closeFeeds()
+				if b.closeTimer != nil {
+					b.closeTimer.Stop()
+				}
 			}
+			dc.booksMtx.Unlock()
+			dc.stopBook(m.Base, m.Quote)
 		}
-		dc.booksMtx.Unlock()
-		dc.stopBook(m.Base, m.Quote)
 	}
 	dc.cfgMtx.RUnlock()
 	// Disconnect and delete connection from map.


### PR DESCRIPTION
When using `UpdateDEXHost`, it will panic if the DEX server has been down since startup since there is no `dc.cfg` (the config response).  Checking `dc.cfg != nil` is a practice throughout `Core`, just forgotten here.