### PR TITLE
fidelity bonds foundation: define bond tx structure, create and parse

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -3444,19 +3444,29 @@ func (btc *baseWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroad
 	}, nil
 }
 
-// LocktimeExpired returns true if the specified contract's locktime has
+// LockTimeExpired returns true if the specified locktime has expired, making it
+// possible to redeem the locked coins.
+func (btc *baseWallet) LockTimeExpired(_ context.Context, lockTime time.Time) (bool, error) {
+	medianTime, err := btc.node.medianTime() // TODO: pass ctx
+	if err != nil {
+		return false, fmt.Errorf("error getting median time: %w", err)
+	}
+	return medianTime.After(medianTime), nil
+}
+
+// ContractLockTimeExpired returns true if the specified contract's locktime has
 // expired, making it possible to issue a Refund.
-func (btc *baseWallet) LocktimeExpired(_ context.Context, contract dex.Bytes) (bool, time.Time, error) {
+func (btc *baseWallet) ContractLockTimeExpired(ctx context.Context, contract dex.Bytes) (bool, time.Time, error) {
 	_, _, locktime, _, err := dexbtc.ExtractSwapDetails(contract, btc.segwit, btc.chainParams)
 	if err != nil {
 		return false, time.Time{}, fmt.Errorf("error extracting contract locktime: %w", err)
 	}
 	contractExpiry := time.Unix(int64(locktime), 0).UTC()
-	medianTime, err := btc.node.medianTime() // TODO: pass ctx
+	expired, err := btc.LockTimeExpired(ctx, contractExpiry)
 	if err != nil {
-		return false, time.Time{}, fmt.Errorf("error getting median time: %w", err)
+		return false, time.Time{}, err
 	}
-	return medianTime.After(contractExpiry), contractExpiry, nil
+	return expired, contractExpiry, nil
 }
 
 // FindRedemption watches for the input that spends the specified contract
@@ -3894,6 +3904,19 @@ func (btc *baseWallet) Send(address string, value, feeRate uint64) (asset.Coin, 
 		return nil, err
 	}
 	return newOutput(txHash, vout, sent), nil
+}
+
+// SendTransaction broadcasts a valid fully-signed transaction.
+func (btc *baseWallet) SendTransaction(rawTx []byte) ([]byte, error) {
+	msgTx, err := btc.deserializeTx(rawTx)
+	if err != nil {
+		return nil, err
+	}
+	txHash, err := btc.node.sendRawTransaction(msgTx)
+	if err != nil {
+		return nil, err
+	}
+	return toCoinID(txHash, 0), nil
 }
 
 // ValidateSecret checks that the secret satisfies the contract.

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -28,6 +28,8 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/config"
 	dexdcr "decred.org/dcrdex/dex/networks/dcr"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/dcrutil/v4"
 )
 
 const (
@@ -147,6 +149,112 @@ func TestMain(m *testing.M) {
 		return m.Run()
 	}
 	os.Exit(doIt())
+}
+
+func TestMakeBondTx(t *testing.T) {
+	rig := newTestRig(t, func(name string, err error) {
+		tLogger.Infof("%s has reported a new block, error = %v", name, err)
+	})
+	defer rig.close(t)
+
+	// Get a private key for the bond script. This would come from the client's
+	// HD key chain.
+	priv, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubkey := priv.PubKey()
+
+	acctID := randBytes(32)
+	fee := uint64(10_2030_4050) //  ~10.2 DCR
+	const bondVer = 0
+
+	wallet := rig.beta()
+
+	// Unlock the wallet to sign the tx and get keys.
+	err = wallet.Unlock(walletPassword)
+	if err != nil {
+		t.Fatalf("error unlocking beta wallet: %v", err)
+	}
+
+	lockTime := time.Now().Add(5 * time.Minute)
+	bond, err := wallet.MakeBondTx(bondVer, fee, lockTime, priv, acctID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coinhash, _, err := decodeCoinID(bond.CoinID)
+	if err != nil {
+		t.Fatalf("decodeCoinID: %v", err)
+	}
+	t.Logf("bond txid %v\n", coinhash)
+	t.Logf("signed tx: %x\n", bond.SignedTx)
+	t.Logf("unsigned tx: %x\n", bond.UnsignedTx)
+	t.Logf("bond script: %x\n", bond.BondData)
+	t.Logf("redeem tx: %x\n", bond.RedeemTx)
+	bondMsgTx, err := msgTxFromBytes(bond.SignedTx)
+	if err != nil {
+		t.Fatalf("invalid bond tx: %v", err)
+	}
+	bondOutVersion := bondMsgTx.TxOut[0].Version
+
+	pkh := dcrutil.Hash160(pubkey.SerializeCompressed())
+
+	lockTimeUint, pkhPush, err := dexdcr.ExtractBondDetailsV0(bondOutVersion, bond.BondData)
+	if err != nil {
+		t.Fatalf("ExtractBondDetailsV0: %v", err)
+	}
+	if !bytes.Equal(pkh, pkhPush) {
+		t.Fatalf("mismatching pubkeyhash in bond script and signature (%x != %x)", pkh, pkhPush)
+	}
+
+	if lockTime.Unix() != int64(lockTimeUint) {
+		t.Fatalf("mismatching locktimes (%d != %d)", lockTime.Unix(), lockTimeUint)
+	}
+	lockTimePush := time.Unix(int64(lockTimeUint), 0)
+	t.Logf("lock time in bond script: %v", lockTimePush)
+
+	privOut := secp256k1.PrivKeyFromBytes(bond.BondPrivKey)
+	pk := privOut.PubKey()
+	if !pk.IsEqual(pubkey) {
+		t.Fatalf("privkey does not match pubkey from bond script and bond signature")
+	}
+
+	if !privOut.Key.Equals(&priv.Key) {
+		t.Fatalf("serialized private key from asset.Bond does not match private key provided private key")
+	}
+
+	sendBondTx, err := wallet.SendTransaction(bond.SignedTx)
+	if err != nil {
+		t.Fatalf("RefundBond: %v", err)
+	}
+	sendBondTxid, _, err := decodeCoinID(sendBondTx)
+	if err != nil {
+		t.Fatalf("decodeCoinID: %v", err)
+	}
+	t.Logf("sendBondTxid: %v\n", sendBondTxid)
+
+	waitNetwork() // wait for alpha to see the txn
+	mineAlpha()
+	waitNetwork() // wait for beta to see the new block (bond must be mined for RefundBond)
+
+	refundTxNew, err := wallet.RefundBond(context.Background(), bondVer, bond.CoinID,
+		bond.BondData, bond.Amount, priv)
+	if err != nil {
+		t.Fatalf("RefundBond: %v", err)
+	}
+	t.Logf("refundTxNew: %x\n", refundTxNew)
+
+	// Send it, but note that since lock time is not passed this is still
+	// non-standard and won't yet propagate on mainnet.
+	refundCoin, err := wallet.SendTransaction(refundTxNew)
+	if err != nil {
+		t.Fatalf("SendTransaction: %v", err)
+	}
+	refundCoinTxid, _, err := decodeCoinID(refundCoin)
+	if err != nil {
+		t.Fatalf("decodeCoinID: %v", err)
+	}
+	t.Log(refundCoinTxid)
 }
 
 func TestWallet(t *testing.T) {

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -2072,9 +2072,20 @@ func (w *assetWallet) AuditContract(coinID, contract, serializedTx dex.Bytes, re
 	}, nil
 }
 
-// LocktimeExpired returns true if the specified contract's locktime has
+// LockTimeExpired returns true if the specified locktime has expired, making it
+// possible to redeem the locked coins.
+func (w *assetWallet) LockTimeExpired(ctx context.Context, lockTime time.Time) (bool, error) {
+	header, err := w.node.bestHeader(ctx)
+	if err != nil {
+		return false, fmt.Errorf("unable to retrieve block header: %w", err)
+	}
+	blockTime := time.Unix(int64(header.Time), 0)
+	return lockTime.Before(blockTime), nil
+}
+
+// ContractLockTimeExpired returns true if the specified contract's locktime has
 // expired, making it possible to issue a Refund.
-func (w *assetWallet) LocktimeExpired(ctx context.Context, contract dex.Bytes) (bool, time.Time, error) {
+func (w *assetWallet) ContractLockTimeExpired(ctx context.Context, contract dex.Bytes) (bool, time.Time, error) {
 	contractVer, secretHash, err := dexeth.DecodeContractData(contract)
 	if err != nil {
 		return false, time.Time{}, err
@@ -2090,12 +2101,11 @@ func (w *assetWallet) LocktimeExpired(ctx context.Context, contract dex.Bytes) (
 		return false, time.Time{}, asset.ErrSwapNotInitiated
 	}
 
-	header, err := w.node.bestHeader(ctx)
+	expired, err := w.LockTimeExpired(ctx, swap.LockTime)
 	if err != nil {
 		return false, time.Time{}, err
 	}
-	blockTime := time.Unix(int64(header.Time), 0)
-	return swap.LockTime.Before(blockTime), swap.LockTime, nil
+	return expired, swap.LockTime, nil
 }
 
 // findRedemptionResult is used internally for queued findRedemptionRequests.
@@ -2292,6 +2302,19 @@ func (eth *TokenWallet) Lock() error {
 // Locked will be true if the wallet is currently locked.
 func (eth *baseWallet) Locked() bool {
 	return eth.node.locked()
+}
+
+// SendTransaction broadcasts a valid fully-signed transaction.
+func (eth *baseWallet) SendTransaction(rawTx []byte) ([]byte, error) {
+	tx := new(types.Transaction)
+	err := tx.UnmarshalBinary(rawTx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal transaction: %w", err)
+	}
+	if err := eth.node.sendSignedTransaction(eth.ctx, tx); err != nil {
+		return nil, err
+	}
+	return tx.Hash().Bytes(), nil
 }
 
 // EstimateRegistrationTxFee returns an estimate for the tx fee needed to

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -3099,11 +3099,11 @@ func TestLocktimeExpired(t *testing.T) {
 
 	ensureResult := func(tag string, expErr, expExpired bool) {
 		t.Helper()
-		expired, _, err := eth.LocktimeExpired(context.Background(), contract)
+		expired, _, err := eth.ContractLockTimeExpired(context.Background(), contract)
 		switch {
 		case err != nil:
 			if !expErr {
-				t.Fatalf("%s: LocktimeExpired error existing expired swap: %v", tag, err)
+				t.Fatalf("%s: ContractLockTimeExpired error existing expired swap: %v", tag, err)
 			}
 		case expErr:
 			t.Fatalf("%s: expected error, got none", tag)

--- a/client/core/addbond.txt
+++ b/client/core/addbond.txt
@@ -1,0 +1,171 @@
+// AddBond posts a new bond for an existing DEX account.
+func (c *Core) AddBond(form *PostBondForm) (*PostBondResult, error) {
+	// Make sure the app has been initialized.
+	if !c.IsInitialized() {
+		return nil, fmt.Errorf("app not initialized")
+	}
+
+	// Check the app password.
+	crypter, err := c.encryptionKey(form.AppPass)
+	if err != nil {
+		return nil, codedError(passwordErr, err)
+	}
+	if form.Addr == "" {
+		return nil, newError(emptyHostErr, "no dex address specified")
+	}
+	host, err := addrHost(form.Addr)
+	if err != nil {
+		return nil, newError(addressParseErr, "error parsing address: %v", err)
+	}
+	if !c.isRegistered(host) {
+		return nil, newError(unknownDEXErr, "not registered at %s", form.Addr)
+	}
+
+	dc, err := c.connectedDEX(host)
+	if err != nil {
+		return nil, err
+	}
+	if dc.acct.locked() { // require authDEX first to reconcile any existing bond statuses
+		return nil, newError(acctKeyErr, "acct locked %s (login first)", form.Addr)
+	}
+
+	// Get the wallet to author the transaction.
+	bondAssetID := uint32(42)
+	if form.Asset != nil {
+		bondAssetID = *form.Asset
+	}
+	bondAssetSymbol := dex.BipIDSymbol(bondAssetID)
+	wallet, err := c.connectedWallet(bondAssetID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to %s wallet to pay fee: %w", bondAssetSymbol, err)
+	}
+
+	// Ensure this DEX supports this asset for bond, and get the required
+	// confirmations and bond amount.
+	bondAsset, bondExpiry := dc.bondAsset(bondAssetID)
+	if bondAsset == nil {
+		return nil, newError(assetSupportErr, "dex server does not support fidelity bonds in asset %q", bondAssetSymbol)
+	}
+	bondValidity := time.Duration(bondExpiry) * time.Second // bond lifetime
+
+	lockTime := time.Now().Add(2 * bondValidity).Truncate(time.Second) // default lockTime is double
+	if form.LockTime > 0 {
+		lockTime = time.Unix(int64(form.LockTime), 0)
+	}
+	expireTime := time.Now().Add(bondValidity) // when the server would expire the bond
+	if lockTime.Before(expireTime) {
+		return nil, newError(bondTimeErr, "lock time of %d has already passed the server's expiry time of %d (bond expiry %d)",
+			form.LockTime, expireTime, bondExpiry)
+	}
+	if lockTime.Add(-time.Minute).Before(expireTime) {
+		return nil, newError(bondTimeErr, "lock time of %d is less than a minute from the server's expiry time of %d (bond expiry %d)",
+			form.LockTime, expireTime, bondExpiry)
+	}
+	if lockDur := time.Until(lockTime); lockDur > lockTimeLimit {
+		return nil, newError(bondTimeErr, "excessive lock time (%v>%v)", lockDur, lockTimeLimit)
+	}
+
+	if bondAssetID != bondAsset.ID { // internal consistency of config.bondassets array
+		return nil, newError(signatureErr, "config response lists asset %d, but expected %d: %v",
+			bondAsset.ID, bondAssetID, err)
+	}
+
+	// Check that the bond amount is non-zero.
+	if form.Bond == 0 {
+		return nil, newError(bondAmtErr, "zero registration fees not allowed")
+	}
+	// Check that the bond amount matches the caller's expectations.
+	if form.Bond < bondAsset.Amt {
+		return nil, newError(bondAmtErr, "specified bond amount is less than the DEX-provided amount. %d < %d",
+			form.Bond, bondAsset.Amt)
+	}
+	if rem := form.Bond % bondAsset.Amt; rem != 0 {
+		return nil, newError(bondAmtErr, "specified bond amount is not a multiple of the DEX-provided amount. %d %% %d = %d",
+			form.Bond, bondAsset.Amt, rem)
+	}
+	strength := form.Bond / bondAsset.Amt
+
+	// Get ready to generate the bond txn.
+	if !wallet.unlocked() {
+		err = wallet.Unlock(crypter)
+		if err != nil {
+			return nil, newError(walletAuthErr, "failed to unlock %s wallet: %v", unbip(wallet.AssetID), err)
+		}
+	}
+
+	// Make a bond transaction for the account ID generated from our public key.
+	privKey := dc.acct.privKey
+	pkBytes := privKey.PubKey().SerializeCompressed()
+	acctID := account.NewID(pkBytes) // dc.acct.id
+	bond, err := wallet.MakeBondTx(form.Bond, lockTime, acctID[:])
+	if err != nil {
+		return nil, codedError(registerErr, err)
+	}
+
+	// Do postbond with the *unsigned* txn.
+	pbr, err := c.postBond(dc, bond)
+	if err != nil {
+		return nil, err
+	}
+
+	reqConfs := bondAsset.Confs
+	bondCoinStr := coinIDString(bond.AssetID, bond.CoinID)
+	c.log.Infof("DEX %v has validated our bond %v (%s) with strength %d. %d confirmations required to trade.",
+		host, bondCoinStr, unbip(bond.AssetID), strength, reqConfs)
+
+	// Store the account and bond info.
+	dbBond := &db.Bond{
+		AssetID:     bond.AssetID,
+		CoinID:      bond.CoinID,
+		UnsignedTx:  bond.UnsignedTx,
+		SignedTx:    bond.SignedTx,
+		Script:      bond.BondScript,
+		Amount:      form.Bond,
+		LockTime:    uint64(lockTime.Unix()),
+		BondPrivKey: bond.BondPrivKey,
+		RefundTx:    bond.RedeemTx,
+		// Confirmed and Refunded are false (new bond tx)
+	}
+	err = c.db.AddBond(host, dbBond)
+	if err != nil {
+		return nil, fmt.Errorf("failed to store bond %v (%s) for dex %v: %v",
+			bondCoinStr, bond.AssetID, host, err)
+	}
+
+	dc.acct.authMtx.Lock()
+	dc.acct.pendingBonds = append(dc.acct.pendingBonds, dbBond)
+	dc.acct.authMtx.Unlock()
+
+	// Broadcast the bond and start waiting for confs.
+	c.log.Infof("Broadcasting bond %v (%s) with lock time %v, script = %x.\n\n"+
+		"BACKUP refund tx paying to current wallet: %x\n\n",
+		bondCoinStr, unbip(bond.AssetID), lockTime, bond.BondScript, bond.RedeemTx)
+	if bondCoinCast, err := wallet.SendTransaction(bond.SignedTx); err != nil {
+		c.log.Warnf("Failed to broadcast bond txn: %v")
+	} else if !bytes.Equal(bond.CoinID, bondCoinCast) {
+		c.log.Warnf("Broadcasted bond %v; was expecting %v!",
+			coinIDString(bond.AssetID, bondCoinCast), bondCoinStr)
+	}
+
+	c.updateAssetBalance(bond.AssetID)
+
+	if pbr.Confs < int64(reqConfs) { // pbr.Confs should be -1!
+		// Start waiting for reqConfs.
+		details := fmt.Sprintf("Waiting for %d confirmations to post bond %v (%s) to %s",
+			reqConfs, bondCoinStr, unbip(bond.AssetID), dc.acct.host)
+		c.notify(newBondPostNoteWithConfirmations(TopicBondConfirming, string(TopicBondConfirming),
+			details, db.Success, bond.AssetID, 0, dc.acct.host))
+		// Set up the coin waiter, which watches confirmations so the user knows
+		// when to expect their account to be marked paid by the server.
+		c.monitorBondConfs(dc, bond, reqConfs)
+	} else {
+		c.log.Warnf("DEX %v claims that out bond txn %v is already confirmed, but we just made it!",
+			host, bondCoinStr)
+		err = c.bondConfirmed(dc, bond.AssetID, bond.CoinID, pbr.Tier)
+		if err != nil {
+			c.log.Errorf("Unable to confirm bond: %v", err)
+		}
+	}
+
+	return &PostBondResult{BondID: bondCoinStr, ReqConfirms: uint16(reqConfs)}, err
+}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -647,6 +647,11 @@ type TXCWallet struct {
 	ownsAddressErr      error
 	pubKeys             []dex.Bytes
 	sigs                []dex.Bytes
+	feeTxMade           []byte
+	feeCoin             []byte
+	makeRegFeeTxErr     error
+	feeCoinSent         []byte
+	sendTxnErr          error
 	contractExpired     bool
 	contractLockTime    time.Time
 	accelerationParams  *struct {
@@ -824,7 +829,11 @@ func (w *TXCWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroadcas
 	return w.auditInfo, w.auditErr
 }
 
-func (w *TXCWallet) LocktimeExpired(_ context.Context, contract dex.Bytes) (bool, time.Time, error) {
+func (w *TXCWallet) LockTimeExpired(_ context.Context, lockTime time.Time) (bool, error) {
+	return w.contractExpired, nil
+}
+
+func (w *TXCWallet) ContractLockTimeExpired(_ context.Context, contract dex.Bytes) (bool, time.Time, error) {
 	return w.contractExpired, w.contractLockTime, nil
 }
 
@@ -869,6 +878,14 @@ func (w *TXCWallet) Send(address string, value, feeSuggestion uint64) (asset.Coi
 	w.sendFeeSuggestion = feeSuggestion
 	w.sendCoin.val = value
 	return w.sendCoin, w.sendErr
+}
+
+func (w *TXCWallet) MakeBondTx(ver uint64, address string, regFee uint64, acctID []byte) (*asset.Bond, error) {
+	return nil, errors.New("not used")
+}
+
+func (w *TXCWallet) SendTransaction(rawTx []byte) ([]byte, error) {
+	return w.feeCoinSent, w.sendTxnErr
 }
 
 func (w *TXCWallet) Withdraw(address string, value, feeSuggestion uint64) (asset.Coin, error) {

--- a/client/core/locale_ar_test.go
+++ b/client/core/locale_ar_test.go
@@ -1,0 +1,16 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
+)
+
+func TestArNfnt(t *testing.T) {
+	tmpl := "تمت مراجعة حالة الطلب %v من %v إلى %v"
+	localePrinter := message.NewPrinter(language.Arabic)
+	t.Log(localePrinter.Sprintf(tmpl, "4442abababa2", "booked", "revoked"))
+	fmt.Printf(tmpl+"\n", "4442abababa2", "booked", "revoked")
+}

--- a/client/core/new.txt
+++ b/client/core/new.txt
@@ -1,0 +1,107 @@
+diff --git a/client/core/locale_ntfn.go b/client/core/locale_ntfn.go
+index 4c369abc3..b917d9dcc 100644
+--- a/client/core/locale_ntfn.go
++++ b/client/core/locale_ntfn.go
+@@ -54,20 +54,30 @@ var enUS = map[Topic]*translation{
+ 		subject:  "Wallet unlock error",
+ 		template: "Connected to wallet to complete registration at %s, but failed to unlock: %v",
+ 	},
++	// [asset name, error message]
++	TopicWalletCommsWarning: {
++		subject:  "Wallet connection issue",
++		template: "Unable to communicate with %v wallet! Reason: %q",
++	},
+ 	// [asset name]
+ 	TopicWalletPeersWarning: {
+ 		subject:  "Wallet network issue",
+ 		template: "%v wallet has no network peers!",
+ 	},
++	// [asset name]
++	TopicWalletPeersRestored: {
++		subject:  "Wallet connectivity restored",
++		template: "%v wallet has reestablished connectivity.",
++	},
+ 	// [ticker, error]
+-	TopicWithdrawError: {
+-		subject:  "Withdraw error",
+-		template: "Error encountered during %s withdraw: %v",
++	TopicSendError: {
++		subject:  "Send error",
++		template: "Error encountered while sending %s: %v",
+ 	},
+ 	// [ticker, coin ID]
+-	TopicWithdrawSend: {
+-		subject:  "Withdraw sent",
+-		template: "Withdraw of %s has completed successfully. Coin ID = %s",
++	TopicSendSuccess: {
++		subject:  "Send Successful",
++		template: "Sending %s has completed successfully. Coin ID = %s",
+ 	},
+ 	// [error]
+ 	TopicOrderLoadFailure: {
+@@ -302,6 +312,11 @@ var enUS = map[Topic]*translation{
+ 		subject:  "Message from DEX",
+ 		template: "%s: %s",
+ 	},
++	// [parentSymbol, tokenSymbol, errorMsg]
++	TopicQueuedCreationFailed: {
++		subject:  "Failed to create token wallet",
++		template: "After creating %s wallet, failed to create the %s wallet",
++	},
+ }
+ 
+ var ptBR = map[Topic]*translation{
+@@ -345,13 +360,13 @@ var ptBR = map[Topic]*translation{
+ 		subject:  "Erro ao Destravar Carteira",
+ 		template: "Conectado com carteira para completar o registro em %s, mas falha ao destrancar: %v",
+ 	},
+-	// [ticker, error]
+-	TopicWithdrawError: {
++	// [ticker, error], RETRANSLATE.
++	TopicSendError: {
+ 		subject:  "Erro Retirada",
+ 		template: "Erro encontrado durante retirada de %s: %v",
+ 	},
+-	// [ticker, coin ID]
+-	TopicWithdrawSend: {
++	// [ticker, coin ID], RETRANSLATE.
++	TopicSendSuccess: {
+ 		template: "Retirada de %s foi completada com sucesso. ID da moeda = %s",
+ 		subject:  "Retirada Enviada",
+ 	},
+@@ -632,13 +647,13 @@ var zhCN = map[Topic]*translation{
+ 		subject:  "解锁钱包时出错",
+ 		template: "与 decred 钱包连接以在 %s 上完成注册，但无法解锁： %v", // alt. 已连接到 Decred 钱包以在 %s 完成注册，但无法解锁：%v
+ 	},
+-	// [ticker, error]
+-	TopicWithdrawError: {
++	// [ticker, error], RETRANSLATE.
++	TopicSendError: {
+ 		subject:  "提款错误",
+ 		template: "在 %s 提取过程中遇到错误: %v", // alt. 删除 %s 时遇到错误： %v
+ 	},
+-	// [ticker, coin ID]
+-	TopicWithdrawSend: {
++	// [ticker, coin ID], RETRANSLATE.
++	TopicSendSuccess: {
+ 		subject:  "提款已发送",
+ 		template: "%s 的提款已成功完成。硬币 ID = %s",
+ 	},
+@@ -918,13 +933,13 @@ var plPL = map[Topic]*translation{
+ 		subject:  "Błąd odblokowywania portfela",
+ 		template: "Połączono z portfelem Decred, aby dokończyć rejestrację na %s, lecz próba odblokowania portfela nie powiodła się: %v",
+ 	},
+-	// [ticker, error]
+-	TopicWithdrawError: {
++	// [ticker, error], RETRANSLATE.
++	TopicSendError: {
+ 		subject:  "Błąd wypłaty środków",
+ 		template: "Wystąpił błąd przy wypłacaniu %s: %v",
+ 	},
+-	// [ticker, coin ID]
+-	TopicWithdrawSend: {
++	// [ticker, coin ID], RETRANSLATE.
++	TopicSendSuccess: {
+ 		subject:  "Wypłata zrealizowana",
+ 		template: "Wypłata %s została zrealizowana pomyślnie. ID monety = %s",
+ 	},

--- a/client/core/regwithbond.txt
+++ b/client/core/regwithbond.txt
@@ -1,0 +1,222 @@
+// RegisterWithBond registers an account with a new DEX. If an error occurs while
+// fetching the DEX configuration or creating the bond transaction, it will be
+// returned immediately.
+//
+// A goroutine will be started to wait for the requisite confirmations on the
+// bond txn and send the postbond request to the server. Any error returned from
+// that goroutine is sent as a notification.
+func (c *Core) RegisterWithBond(form *PostBondForm) (*PostBondResult, error) {
+	// Make sure the app has been initialized. This condition would error when
+	// attempting to retrieve the encryption key below as well, but the
+	// messaging may be confusing.
+	if !c.IsInitialized() {
+		return nil, fmt.Errorf("cannot register DEX because app has not been initialized")
+	}
+
+	// Check the app password.
+	crypter, err := c.encryptionKey(form.AppPass)
+	if err != nil {
+		return nil, codedError(passwordErr, err)
+	}
+	if form.Addr == "" {
+		return nil, newError(emptyHostErr, "no dex address specified")
+	}
+	host, err := addrHost(form.Addr)
+	if err != nil {
+		return nil, newError(addressParseErr, "error parsing address: %v", err)
+	}
+	if c.isRegistered(host) {
+		return nil, newError(dupeDEXErr, "already registered at %s", form.Addr)
+	}
+
+	// Default to using DCR unless specified.
+	bondAssetID := uint32(42)
+	if form.Asset != nil {
+		bondAssetID = *form.Asset
+	}
+	bondAssetSymbol := dex.BipIDSymbol(bondAssetID)
+
+	wallet, err := c.connectedWallet(bondAssetID)
+	if err != nil {
+		// Wrap the error from connectedWallet, a core.Error coded as
+		// missingWalletErr or connectWalletErr.
+		return nil, fmt.Errorf("cannot connect to %s wallet to pay fee: %w", bondAssetSymbol, err)
+	}
+
+	// New DEX connection.
+	cert, err := parseCert(host, form.Cert, c.net)
+	if err != nil {
+		return nil, newError(fileReadErr, "failed to read certificate file from %s: %v", cert, err)
+	}
+	dc, err := c.connectDEX(&db.AccountInfo{
+		Host: host,
+		Cert: cert,
+	})
+	if err != nil {
+		if dc != nil {
+			// Stop (re)connect loop, which may be running even if err != nil.
+			dc.connMaster.Disconnect()
+		}
+		return nil, codedError(connectionErr, err)
+	}
+
+	// Close the connection to the dex server if the registration fails.
+	var registrationComplete bool
+	defer func() {
+		if !registrationComplete {
+			dc.connMaster.Disconnect()
+		}
+	}()
+
+	paid, err := c.discoverAccount(dc, crypter)
+	if err != nil {
+		return nil, err
+	}
+	if paid {
+		registrationComplete = true
+		// The listen goroutine is already running, now track the conn.
+		c.connMtx.Lock()
+		c.conns[dc.acct.host] = dc
+		c.connMtx.Unlock()
+
+		return &PostBondResult{ /* no new bond */ }, nil
+	}
+	// dc.acct is now configured with encKey, privKey, and id for a new
+	// (unregistered) account.
+
+	// Ensure this DEX supports this asset for bond, and get the required
+	// confirmations and bond amount.
+	bondAsset, bondExpiry := dc.bondAsset(bondAssetID)
+	if bondAsset == nil {
+		return nil, newError(assetSupportErr, "dex server does not support fidelity bonds in asset %q", bondAssetSymbol)
+	}
+	bondValidity := time.Duration(bondExpiry) * time.Second // bond lifetime
+
+	lockTime := time.Now().Add(2 * bondValidity).Truncate(time.Second) // default lockTime is double
+	if form.LockTime > 0 {
+		lockTime = time.Unix(int64(form.LockTime), 0)
+	}
+	expireTime := time.Now().Add(bondValidity) // when the server would expire the bond
+	if lockTime.Before(expireTime) {
+		return nil, newError(bondTimeErr, "lock time of %d has already passed the server's expiry time of %d (bond expiry %d)",
+			form.LockTime, expireTime, bondExpiry)
+	}
+	if lockTime.Add(-time.Minute).Before(expireTime) {
+		return nil, newError(bondTimeErr, "lock time of %d is less than a minute from the server's expiry time of %d (bond expiry %d)",
+			form.LockTime, expireTime, bondExpiry)
+	}
+	if lockDur := time.Until(lockTime); lockDur > lockTimeLimit {
+		return nil, newError(bondTimeErr, "excessive lock time (%v>%v)", lockDur, lockTimeLimit)
+	}
+
+	if bondAssetID != bondAsset.ID { // internal consistency of config.bondassets array
+		return nil, newError(signatureErr, "config response lists asset %d, but expected %d: %v",
+			bondAsset.ID, bondAssetID, err)
+	}
+
+	// Check that the bond amount is non-zero.
+	if form.Bond == 0 {
+		return nil, newError(bondAmtErr, "zero registration fees not allowed")
+	}
+	// Check that the bond amount matches the caller's expectations.
+	if form.Bond < bondAsset.Amt {
+		return nil, newError(bondAmtErr, "specified bond amount is less than the DEX-provided amount. %d < %d",
+			form.Bond, bondAsset.Amt)
+	}
+	if rem := form.Bond % bondAsset.Amt; rem != 0 {
+		return nil, newError(bondAmtErr, "specified bond amount is not a multiple of the DEX-provided amount. %d %% %d = %d",
+			form.Bond, bondAsset.Amt, rem)
+	}
+	strength := form.Bond / bondAsset.Amt
+
+	// Get ready to generate the bond txn.
+	if !wallet.unlocked() {
+		err = wallet.Unlock(crypter)
+		if err != nil {
+			return nil, newError(walletAuthErr, "failed to unlock %s wallet: %v", unbip(wallet.AssetID), err)
+		}
+	}
+
+	// Make a bond transaction for the account ID generated from our public key.
+	bond, err := wallet.MakeBondTx(form.Bond, lockTime, dc.acct.id[:])
+	if err != nil {
+		return nil, codedError(registerErr, err)
+	}
+
+	// Do postbond with the *unsigned* txn.
+	pbr, err := c.postBond(dc, bond)
+	if err != nil {
+		return nil, err
+	}
+
+	reqConfs := bondAsset.Confs
+	bondCoinStr := coinIDString(bond.AssetID, bond.CoinID)
+	c.log.Infof("DEX %v has validated our bond %v (%s) with strength %d.",
+		host, bondCoinStr, unbip(bond.AssetID), strength)
+
+	// Store the account and bond info.
+	dbBond := &db.Bond{
+		AssetID:     bond.AssetID,
+		CoinID:      bond.CoinID,
+		UnsignedTx:  bond.UnsignedTx,
+		SignedTx:    bond.SignedTx,
+		Script:      bond.BondScript,
+		Amount:      form.Bond,
+		LockTime:    uint64(lockTime.Unix()),
+		BondPrivKey: bond.BondPrivKey,
+		RefundTx:    bond.RedeemTx,
+		// Confirmed and Refunded are false (new bond tx)
+	}
+	ai := &db.AccountInfo{
+		Host:      host,
+		Cert:      dc.acct.cert,
+		DEXPubKey: dc.acct.dexPubKey,
+		// LegacyEncKey: nil,
+		EncKeyV2: dc.acct.encKey,
+		Bonds:    []*db.Bond{dbBond},
+		// LegacyFeeCoin
+	}
+	err = c.db.CreateAccount(ai)
+	if err != nil {
+		return nil, fmt.Errorf("failed to store account %v for dex %v: %v", dc.acct.id, host, err)
+	}
+
+	dc.acct.authMtx.Lock()
+	dc.acct.pendingBonds = append(dc.acct.pendingBonds, dbBond)
+	dc.acct.authMtx.Unlock()
+
+	// Broadcast the bond and start waiting for confs.
+	c.log.Infof("Broadcasting bond %v (%s) with lock time %v, script = %x.\n\n"+
+		"BACKUP refund tx paying to current wallet: %x\n\n",
+		bondCoinStr, unbip(bond.AssetID), lockTime, bond.BondScript, bond.RedeemTx)
+	if bondCoinCast, err := wallet.SendTransaction(bond.SignedTx); err != nil {
+		c.log.Warnf("Failed to broadcast bond txn: %v")
+	} else if !bytes.Equal(bond.CoinID, bondCoinCast) {
+		c.log.Warnf("Broadcasted bond %v; was expecting %v!",
+			coinIDString(bond.AssetID, bondCoinCast), bondCoinStr)
+	}
+
+	c.updateAssetBalance(bond.AssetID)
+
+	if pbr.Confs < int64(reqConfs) { // pbr.Confs should be -1!
+		// Start waiting for reqConfs.
+		details := fmt.Sprintf("Waiting for %d confirmations to post bond %v (%s) to %s",
+			reqConfs, bondCoinStr, unbip(bond.AssetID), dc.acct.host)
+		c.notify(newBondPostNoteWithConfirmations(TopicBondConfirming, string(TopicBondConfirming),
+			details, db.Success, bond.AssetID, 0, dc.acct.host))
+		// Set up the coin waiter, which watches confirmations so the user knows
+		// when to expect their account to be marked paid by the server.
+		c.monitorBondConfs(dc, bond, reqConfs)
+	} else {
+		c.log.Warnf("DEX %v claims that out bond txn %v is already confirmed, but we just made it!",
+			host, bondCoinStr)
+		err = c.bondConfirmed(dc, bond.AssetID, bond.CoinID, pbr.Tier)
+		if err != nil {
+			c.log.Errorf("Unable to confirm bond: %v", err)
+		}
+	}
+
+	registrationComplete = true // stay connected, with acct unlocked for auth on confirm
+
+	return &PostBondResult{BondID: bondCoinStr, ReqConfirms: uint16(reqConfs)}, err
+}

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1002,7 +1002,7 @@ func (t *trackedTrade) counterPartyConfirms(ctx context.Context, match *matchTra
 	wallet := t.wallets.toWallet
 	coin := match.counterSwap.Coin
 
-	_, lockTime, err := wallet.LocktimeExpired(ctx, match.MetaData.Proof.CounterContract)
+	_, lockTime, err := wallet.ContractLockTimeExpired(ctx, match.MetaData.Proof.CounterContract)
 	if err != nil {
 		return fail(fmt.Errorf("error checking if locktime has expired on taker's contract on order %s, "+
 			"match %s: %w", t.ID(), match, err))
@@ -1558,7 +1558,7 @@ func (t *trackedTrade) isRefundable(ctx context.Context, match *matchTracker) bo
 	}
 
 	// Issue a refund if our swap's locktime has expired.
-	swapLocktimeExpired, contractExpiry, err := wallet.LocktimeExpired(ctx, match.MetaData.Proof.ContractData)
+	swapLocktimeExpired, contractExpiry, err := wallet.ContractLockTimeExpired(ctx, match.MetaData.Proof.ContractData)
 	if err != nil {
 		if !errors.Is(err, asset.ErrSwapNotInitiated) {
 			// No need to log an error as this is expected for newly

--- a/dex/networks/dcr/script.go
+++ b/dex/networks/dcr/script.go
@@ -7,9 +7,11 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/account"
 	"decred.org/dcrwallet/v2/wallet/txsizes"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec"
@@ -21,6 +23,14 @@ import (
 )
 
 const (
+	// MaxCLTVScriptNum is the largest usable value for a CLTV lockTime. This
+	// will actually be stored in a 5-byte ScriptNum since they have a sign bit,
+	// however, it is not 2^39-1 since the spending transaction's nLocktime is
+	// an unsigned 32-bit integer and it must be at least the CLTV value. This
+	// establishes a maximum lock time of February 7, 2106. Any later requires
+	// using a block height instead of a unix epoch time stamp.
+	MaxCLTVScriptNum = 1<<32 - 1 // 0xffff_ffff a.k.a. 2^32-1
+
 	// SecretHashSize is the byte-length of the hash of the secret key used in an
 	// atomic swap.
 	SecretHashSize = 32
@@ -37,9 +47,9 @@ const (
 	// See ExtractSwapDetails for a breakdown of the bytes.
 	SwapContractSize = 97
 
-	// Overhead for a wire.TxIn with a scriptSig length < 254.
-	// prefix (41 bytes) + ValueIn (8 bytes) + BlockHeight (4 bytes)
-	// + BlockIndex (4 bytes) + sig script var int (at least 1 byte)
+	// TxInOverhead is the overhead for a wire.TxIn with a scriptSig length <
+	// 254. prefix (41 bytes) + ValueIn (8 bytes) + BlockHeight (4 bytes) +
+	// BlockIndex (4 bytes) + sig script var int (at least 1 byte)
 	TxInOverhead = 41 + 8 + 4 + 4 // 57 + at least 1 more
 
 	P2PKSigScriptSize = txsizes.RedeemP2PKSigScriptSize
@@ -59,7 +69,7 @@ const (
 	P2PKHOutputSize = TxOutOverhead + txsizes.P2PKHPkScriptSize // 36
 	P2SHOutputSize  = TxOutOverhead + txsizes.P2SHPkScriptSize  // 34
 
-	// MsgTx overhead is 4 bytes version (lower 2 bytes for the real transaction
+	// MsgTxOverhead is 4 bytes version (lower 2 bytes for the real transaction
 	// version and upper 2 bytes for the serialization type) + 4 bytes locktime
 	// + 4 bytes expiry + 3 bytes of varints for the number of transaction
 	// inputs (x2 for witness and prefix) and outputs
@@ -92,7 +102,7 @@ const (
 	//   - OP_1
 	//   - varint 97 => OP_PUSHDATA1(0x4c) + 0x61
 	//   - 97 bytes contract script
-	RedeemSwapSigScriptSize = 1 + DERSigLength + 1 + 33 + 1 + 32 + 1 + 2 + SwapContractSize // 241
+	RedeemSwapSigScriptSize = 1 + DERSigLength + 1 + pubkeyLength + 1 + 32 + 1 + 2 + SwapContractSize // 241
 
 	// RefundSigScriptSize is the worst case (largest) serialize size
 	// of a transaction input script that refunds a compressed P2PKH output.
@@ -105,7 +115,18 @@ const (
 	//   - OP_0
 	//   - varint 97 => OP_PUSHDATA1(0x4c) + 0x61
 	//   - 97 bytes contract script
-	RefundSigScriptSize = 1 + DERSigLength + 1 + 33 + 1 + 2 + SwapContractSize // 208
+	RefundSigScriptSize = 1 + DERSigLength + 1 + pubkeyLength + 1 + 2 + SwapContractSize // 208
+
+	// BondScriptSize is the maximum size of a DEX time-locked fidelity bond
+	// output script to which a bond P2SH pays:
+	//   OP_DATA_4/5 (4/5 bytes lockTime) OP_CHECKLOCKTIMEVERIFY OP_DROP OP_DUP OP_HASH160 OP_DATA_20 (20-byte pubkey hash160) OP_EQUALVERIFY OP_CHECKSIG
+	BondScriptSize = 1 + 5 + 1 + 1 + 1 + 1 + 1 + 20 + 1 + 1 // 32
+
+	// RedeemBondSigScriptSize is the worst case size of a fidelity bond
+	// signature script that spends a bond output. It includes a signature, a
+	// compressed pubkey, and the bond script. Each of said data pushes use an
+	// OP_DATA_ code.
+	RedeemBondSigScriptSize = 1 + DERSigLength + 1 + pubkeyLength + 1 + BondScriptSize // 141
 )
 
 // ScriptType is a bitmask with information about a pubkey script and
@@ -314,6 +335,201 @@ func RefundP2SHContract(contract, sig, pubkey []byte) ([]byte, error) {
 		AddInt64(0).
 		AddData(contract).
 		Script()
+}
+
+// OP_RETURN <pushData: ver[2] | account_id[32] | lockTime[4] | pkh[20]>
+func extractBondCommitDataV0(pushData []byte) (acct account.AccountID, lockTime uint32, pubkeyHash [20]byte, err error) {
+	if len(pushData) < 2 {
+		err = errors.New("invalid data")
+		return
+	}
+	ver := binary.BigEndian.Uint16(pushData)
+	if ver != 0 {
+		err = fmt.Errorf("unexpected bond commitment version %d, expected 0", ver)
+		return
+	}
+
+	const wantPushSize = 2 + account.HashSize + 4 + 20
+	if len(pushData) != wantPushSize {
+		err = fmt.Errorf("invalid bond commitment output script length: %d", len(pushData))
+		return
+	}
+
+	pushData = pushData[2:] // pop off ver
+
+	copy(acct[:], pushData)
+	pushData = pushData[account.HashSize:]
+
+	lockTime = binary.BigEndian.Uint32(pushData)
+	pushData = pushData[4:]
+
+	copy(pubkeyHash[:], pushData)
+
+	return
+}
+
+// ExtractBondCommitDataV0 parses a v0 bond commitment output script. This is
+// the OP_RETURN output, not the P2SH bond output. Use ExtractBondDetailsV0 to
+// parse the P2SH bond output's redeem script.
+//
+// If the decoded commitment data indicates a version other than 0, an error is
+// returned.
+func ExtractBondCommitDataV0(scriptVer uint16, pkScript []byte) (acct account.AccountID, lockTime uint32, pubkeyHash [20]byte, err error) {
+	tokenizer := txscript.MakeScriptTokenizer(scriptVer, pkScript)
+	if !tokenizer.Next() {
+		err = tokenizer.Err()
+		return
+	}
+
+	if tokenizer.Opcode() != txscript.OP_RETURN {
+		err = errors.New("not a null data output")
+		return
+	}
+
+	if !tokenizer.Next() {
+		err = tokenizer.Err()
+		return
+	}
+
+	pushData := tokenizer.Data()
+	acct, lockTime, pubkeyHash, err = extractBondCommitDataV0(pushData)
+	if err != nil {
+		return
+	}
+
+	if !tokenizer.Done() {
+		err = errors.New("script has extra opcodes")
+		return
+	}
+
+	return
+}
+
+// MakeBondScript constructs a versioned bond output script for the provided
+// lock time and pubkey hash. Only version 0 is supported at present. The lock
+// time must be less than 2^32-1 so that it uses at most 5 bytes. The lockTime
+// is also required to use at least 4 bytes (time stamp, not block time).
+func MakeBondScript(ver uint16, lockTime uint32, pubkeyHash []byte) ([]byte, error) {
+	if ver != 0 {
+		return nil, errors.New("only version 0 bonds supported")
+	}
+	if lockTime >= MaxCLTVScriptNum { // == should be OK, but let's not
+		return nil, errors.New("invalid lock time")
+	}
+	lockTimeBytes := txscript.ScriptNum(lockTime).Bytes()
+	if n := len(lockTimeBytes); n < 4 || n > 5 {
+		return nil, errors.New("invalid lock time")
+	}
+	if len(pubkeyHash) != 20 {
+		return nil, errors.New("invalid pubkey hash")
+	}
+	return txscript.NewScriptBuilder().
+		AddData(lockTimeBytes).
+		AddOp(txscript.OP_CHECKLOCKTIMEVERIFY).
+		AddOp(txscript.OP_DROP).
+		AddOp(txscript.OP_DUP).
+		AddOp(txscript.OP_HASH160).
+		AddData(pubkeyHash).
+		AddOp(txscript.OP_EQUALVERIFY).
+		AddOp(txscript.OP_CHECKSIG).
+		Script()
+}
+
+// RefundBondScript builds the signature script to refund a time-locked fidelity
+// bond in a P2SH output paying to the provided P2PKH bondScript.
+func RefundBondScript(bondScript, sig, pubkey []byte) ([]byte, error) {
+	return txscript.NewScriptBuilder().
+		AddData(sig).
+		AddData(pubkey).
+		AddData(bondScript).
+		Script()
+}
+
+// ExtractBondDetailsV0 validates the provided bond redeem script, extracting
+// the lock time and pubkey. The V0 format of the script must be as follows:
+//
+//	<lockTime> OP_CHECKLOCKTIMEVERIFY OP_DROP OP_DUP OP_HASH160 <pubkeyhash[20]> OP_EQUALVERIFY OP_CHECKSIG
+//
+// The script version refers to the pkScript version, not bond version, which
+// pertains to DEX's version of the bond script.
+func ExtractBondDetailsV0(scriptVersion uint16, bondScript []byte) (lockTime uint32, pkh []byte, err error) {
+	type templateMatch struct {
+		expectInt     bool
+		maxIntBytes   int
+		opcode        byte
+		extractedInt  int64
+		extractedData []byte
+	}
+	var template = [...]templateMatch{
+		{expectInt: true, maxIntBytes: txscript.CltvMaxScriptNumLen}, // extractedInt
+		{opcode: txscript.OP_CHECKLOCKTIMEVERIFY},
+		{opcode: txscript.OP_DROP},
+		{opcode: txscript.OP_DUP},
+		{opcode: txscript.OP_HASH160},
+		{opcode: txscript.OP_DATA_20}, // extractedData
+		{opcode: txscript.OP_EQUALVERIFY},
+		{opcode: txscript.OP_CHECKSIG},
+	}
+
+	var templateOffset int
+	tokenizer := txscript.MakeScriptTokenizer(scriptVersion, bondScript)
+	for tokenizer.Next() {
+		if templateOffset >= len(template) {
+			return 0, nil, errors.New("too many script elements")
+		}
+
+		op, data := tokenizer.Opcode(), tokenizer.Data()
+		tplEntry := &template[templateOffset]
+		if tplEntry.expectInt {
+			switch {
+			case data != nil:
+				val, err := txscript.MakeScriptNum(data, tplEntry.maxIntBytes)
+				if err != nil {
+					return 0, nil, err
+				}
+				tplEntry.extractedInt = int64(val)
+
+			case txscript.IsSmallInt(op): // not expected for our lockTimes, but it is an integer
+				tplEntry.extractedInt = int64(txscript.AsSmallInt(op))
+
+			default:
+				return 0, nil, errors.New("expected integer")
+			}
+		} else {
+			if op != tplEntry.opcode {
+				return 0, nil, fmt.Errorf("expected opcode %v, got %v", tplEntry.opcode, op)
+			}
+
+			tplEntry.extractedData = data
+		}
+
+		templateOffset++
+	}
+	if err := tokenizer.Err(); err != nil {
+		return 0, nil, err
+	}
+	if !tokenizer.Done() || templateOffset != len(template) {
+		return 0, nil, errors.New("incorrect script length")
+	}
+
+	// The script matches in structure. Now validate the two pushes.
+
+	lockTime64 := template[0].extractedInt
+	if lockTime64 <= 0 || lockTime64 > MaxCLTVScriptNum {
+		return 0, nil, fmt.Errorf("invalid locktime %d", lockTime64)
+	}
+	lockTime = uint32(lockTime64)
+
+	const pubkeyHashLen = 20
+	bondPubKeyHash := template[5].extractedData
+	if len(bondPubKeyHash) != pubkeyHashLen {
+		err = errors.New("missing or invalid pubkeyhash data")
+		return
+	}
+	pkh = make([]byte, pubkeyHashLen)
+	copy(pkh, bondPubKeyHash)
+
+	return
 }
 
 // ExtractSwapDetails extacts the sender and receiver addresses from a swap

--- a/dex/networks/dcr/script_test.go
+++ b/dex/networks/dcr/script_test.go
@@ -81,6 +81,22 @@ func testAddresses() *tAddrs {
 	}
 }
 
+func TestExtractBondDetailsV0(t *testing.T) {
+	bondScript, _ := hex.DecodeString("041d013663b17576a91465b064a4c6bbb1b57362b5b390c00dbd33bdb2b888ac")
+	lockTime, pkh, err := ExtractBondDetailsV0(0, bondScript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantLock := uint32(1664483613)
+	if lockTime != wantLock {
+		t.Errorf("wanted locktime %d, got %d", wantLock, lockTime)
+	}
+	wantPkh, _ := hex.DecodeString("65b064a4c6bbb1b57362b5b390c00dbd33bdb2b8")
+	if !bytes.Equal(pkh, wantPkh) {
+		t.Errorf("wanted pkh %x, got %x", wantPkh, pkh)
+	}
+}
+
 // Test ScriptType methods and pkScript identification via ParseScriptType.
 // TestInputInfo verifies combined P2SH pkScript + redeemscript identification.
 // This test also verifies ExtractScriptHashV0.

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -19,8 +19,10 @@ import (
 
 	"decred.org/dcrdex/dex"
 	dexdcr "decred.org/dcrdex/dex/networks/dcr"
+	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/asset"
 	"github.com/decred/dcrd/blockchain/stake/v4"
+	"github.com/decred/dcrd/blockchain/v4"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrjson/v4"
@@ -28,7 +30,9 @@ import (
 	"github.com/decred/dcrd/hdkeychain/v3"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v3"
 	"github.com/decred/dcrd/rpcclient/v7"
+	"github.com/decred/dcrd/txscript/v4"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
+	"github.com/decred/dcrd/txscript/v4/stdscript"
 	"github.com/decred/dcrd/wire"
 )
 
@@ -124,6 +128,7 @@ type dcrNode interface {
 	GetBestBlockHash(ctx context.Context) (*chainhash.Hash, error)
 	GetBlockChainInfo(ctx context.Context) (*chainjson.GetBlockChainInfoResult, error)
 	GetRawTransaction(ctx context.Context, txHash *chainhash.Hash) (*dcrutil.Tx, error)
+	SendRawTransaction(ctx context.Context, tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error)
 }
 
 // The rpcclient package functions will return a rpcclient.ErrRequestCanceled
@@ -133,6 +138,113 @@ func translateRPCCancelErr(err error) error {
 		err = asset.ErrRequestTimeout
 	}
 	return err
+}
+
+// ParseBondTx performs basic validation of a serialized time-locked fidelity
+// bond transaction given the bond's P2SH redeem script.
+//
+// The transaction must have at least two outputs: out 0 pays to a P2SH address
+// (the bond), and out 1 is a nulldata output that commits to an account ID.
+// There may also be a change output.
+//
+// Returned: The bond's coin ID (i.e. encoded UTXO) of the bond output. The bond
+// output's amount and P2SH address. The lockTime and pubkey hash data pushes
+// from the script. The account ID from the second output is also returned.
+//
+// Properly formed transactions:
+//
+//  1. The bond output (vout 0) must be a P2SH output.
+//  2. The bond's redeem script must be of the form:
+//     <lockTime[4]> OP_CHECKLOCKTIMEVERIFY OP_DROP OP_DUP OP_HASH160 <pubkeyhash[20]> OP_EQUALVERIFY OP_CHECKSIG
+//  3. The null data output (vout 1) must have a 58-byte data push (ver | account ID | lockTime | pubkeyHash).
+//  4. The transaction must have a zero locktime and expiry.
+//  5. All inputs must have the max sequence num set (finalized).
+//  6. The transaction must pass the checks in the
+//     blockchain.CheckTransactionSanity function.
+//
+// For DCR, and possibly all assets, the bond script is reconstructed from the
+// null data output, and it is verified that the bond output pays to this
+// script.
+func ParseBondTx(ver uint16, rawTx []byte) (bondCoinID []byte, amt int64, bondAddr string,
+	bondPubKeyHash []byte, lockTime int64, acct account.AccountID, err error) {
+	if ver != 0 {
+		err = errors.New("only version 0 bonds supported")
+		return
+	}
+	// While the dcr package uses a package-level chainParams variable, ensure
+	// that a backend has been instantiated first. Alternatively, we can add a
+	// dex.Network argument to this function, or make it a Backend method.
+	if chainParams == nil {
+		err = errors.New("dcr asset package config not yet loaded")
+		return
+	}
+	msgTx := wire.NewMsgTx()
+	if err = msgTx.Deserialize(bytes.NewReader(rawTx)); err != nil {
+		return
+	}
+
+	if msgTx.LockTime != 0 {
+		err = errors.New("transaction locktime not zero")
+		return
+	}
+	if msgTx.Expiry != wire.NoExpiryValue {
+		err = errors.New("transaction has an expiration")
+		return
+	}
+
+	if err = blockchain.CheckTransactionSanity(msgTx, chainParams); err != nil {
+		return
+	}
+
+	if len(msgTx.TxOut) < 2 {
+		err = fmt.Errorf("expected at least 2 outputs, found %d", len(msgTx.TxOut))
+		return
+	}
+
+	for _, txIn := range msgTx.TxIn {
+		if txIn.Sequence != wire.MaxTxInSequenceNum {
+			err = errors.New("input has non-max sequence number")
+			return
+		}
+	}
+
+	// Fidelity bond (output 0)
+	bondOut := msgTx.TxOut[0]
+	class, addrs := stdscript.ExtractAddrs(bondOut.Version, bondOut.PkScript, chainParams)
+	if class != stdscript.STScriptHash || len(addrs) != 1 { // addrs check is redundant for p2sh
+		err = fmt.Errorf("bad bond pkScript (class = %v)", class)
+		return
+	}
+	scriptHash := txscript.ExtractScriptHash(bondOut.PkScript)
+
+	// Bond account commitment (output 1)
+	acctCommitOut := msgTx.TxOut[1]
+	acct, lock, pkh, err := dexdcr.ExtractBondCommitDataV0(acctCommitOut.Version, acctCommitOut.PkScript)
+	if err != nil {
+		err = fmt.Errorf("invalid bond commitment output: %w", err)
+		return
+	}
+
+	// Reconstruct and check the bond redeem script.
+	bondScript, err := dexdcr.MakeBondScript(ver, lock, pkh[:])
+	if err != nil {
+		err = fmt.Errorf("failed to build bond output redeem script: %w", err)
+		return
+	}
+	if !bytes.Equal(dcrutil.Hash160(bondScript), scriptHash) {
+		err = fmt.Errorf("script hash check failed for output 0 of %s", msgTx.TxHash())
+		return
+	}
+	// lock, pkh, _ := dexdcr.ExtractBondDetailsV0(bondOut.Version, bondScript)
+
+	txid := msgTx.TxHash()
+	bondCoinID = toCoinID(&txid, 0)
+	amt = bondOut.Value
+	bondAddr = addrs[0].String() // don't convert address, must match type we specified
+	lockTime = int64(lock)
+	bondPubKeyHash = pkh[:]
+
+	return
 }
 
 // Backend is an asset backend for Decred. It has methods for fetching output
@@ -337,6 +449,22 @@ func (dcr *Backend) BlockChannel(size int) <-chan *asset.BlockUpdate {
 	return c
 }
 
+// SendRawTransaction broadcasts a raw transaction, returning a coin ID.
+func (dcr *Backend) SendRawTransaction(rawtx []byte) (coinID []byte, err error) {
+	msgTx := wire.NewMsgTx()
+	if err = msgTx.Deserialize(bytes.NewReader(rawtx)); err != nil {
+		return nil, err
+	}
+
+	var hash *chainhash.Hash
+	hash, err = dcr.node.SendRawTransaction(dcr.ctx, msgTx, false) // or allow high fees?
+	if err != nil {
+		return
+	}
+	coinID = toCoinID(hash, 0)
+	return
+}
+
 // Contract is part of the asset.Backend interface. An asset.Contract is an
 // output that has been validated as a swap contract for the passed redeem
 // script. A spendable output is one that can be spent in the next block. Every
@@ -424,7 +552,7 @@ func (dcr *Backend) FundingCoin(ctx context.Context, coinID []byte, redeemScript
 
 // ValidateXPub validates the base-58 encoded extended key, and ensures that it
 // is an extended public, not private, key.
-func (dcr *Backend) ValidateXPub(xpub string) error {
+func ValidateXPub(xpub string) error {
 	xp, err := hdkeychain.NewKeyFromString(xpub, chainParams)
 	if err != nil {
 		return err
@@ -517,13 +645,22 @@ func (dcr *Backend) FeeCoin(coinID []byte) (addr string, val uint64, confs int64
 		return
 	}
 
+	// No stake outputs, and no multisig.
 	if len(txOut.addresses) != 1 || txOut.sigsRequired != 1 ||
-		txOut.scriptType != dexdcr.ScriptP2PKH /* no schorr or edwards */ ||
 		txOut.scriptType&dexdcr.ScriptStake != 0 {
 		return "", 0, -1, dex.UnsupportedScriptError
 	}
+
+	// Needs to work for legacy fee and new bond txns.
+	switch txOut.scriptType {
+	case dexdcr.ScriptP2SH, dexdcr.ScriptP2PKH:
+	default:
+		return "", 0, -1, dex.UnsupportedScriptError
+	}
+
 	addr = txOut.addresses[0]
 	val = txOut.value
+
 	return
 }
 
@@ -553,7 +690,7 @@ func (dcr *Backend) outputSummary(txHash *chainhash.Hash, vout uint32) (txOut *t
 	}
 
 	if int(vout) > len(verboseTx.Vout)-1 {
-		err = asset.CoinNotFoundError // should be something fatal?
+		err = fmt.Errorf("invalid output index for tx with %d outputs", len(verboseTx.Vout))
 		return
 	}
 


### PR DESCRIPTION
Further breaking up https://github.com/decred/dcrdex/pull/1480 for feasible review, this piece deals with:

- Definition of the fidelity bond transaction
- Creation of the bond and refund txn (for client)
- Parsing of the bond txn (for server)

To make this transition smoother, the **client and server retain all the legacy registration fee machinery**, and the client's continues to use the legacy registration system.

### Background from https://github.com/decred/dcrdex/pull/1480:

This creates a time-locked fidelity bond, which is redeemable by the user who posted the bond after a certain time. This creates a opportunity cost to use DCRDEX instead of a simple monetary cost.  It also is a prerequisite for [mesh](https://github.com/decred/dcrdex/issues/1765).

The DEX considers a user's bond as active when the bond script's `lockTime` (when it can be redeemed by the user) is at least `bondExpiry` in the future. That is, the bond remains locked for a period even after it becomes inactive for DEX purposes.

### Bond Transaction Structure (version 0)

There must be at least two outputs: the bond output (P2SH) and an account commitment (nulldata).

See:
- `dex/networks/dcr.ExtractBondDetailsV0`
- `client/asset/dcr.(*ExchangeWallet).{MakeBondTx,RefundBond}`
- `server/assset/dcr.ParseBondTx`

#### Time-locked Bond (output 0)

Output 0 of the fidelity bond transaction must be a P2SH output paying to the bond script.

The redeem script looks similar to the refund path of an atomic swap script:

`<locktime[4]> OP_CHECKLOCKTIMEVERIFY OP_DROP <pubkey[33]> OP_CHECKSIG`

The above uses P2PK since nothing is gained from P2PKH on account of the need to reveal the script pubkey anyway for validation on the server.  (The user must demonstrate ownership of the locked funds by signing a message with the private key corresponding to the pubkey in the TL redeemscript.)

Server validates that this P2SH output actually pays to the provided redeem script.

The pubkey referenced by the script need not be controlled by the user's wallet, but in this implementation it comes from their wallet. The client could even use their account pubkey in the script, but for security reasons it is best not to reuse pubkeys in this bond outputs, which are unspent on the blockchain for long periods.  We may consider using a key pair from the client's HD keychain, but I'm leaning toward this being a wallet job.

The `lockTime` must be after a bond expiry time, the `lockTimeThreshold`. A bond becomes expired for a DEX account when duration until `lockTime` is less than a `bondExpiry` duration, which is on the order of a month. This, a user should create a bond with a `lockTime` at least `bondExpiry` in the future, but a practical `lockTime` would be more like 2x `bondExpiry` in the future so the account is active on the DEX for `bondExpiry`.

#### DEX Account commitment (output 1)

The account commitment OP_RETURN output should reference the account ID that corresponds to the account pubkey in the `postbond` request.

Having it in the raw like this allows the txn alone to identify the account, and without requiring the bond output pay to the account's private keys.

### Open Questions

Is this transaction structure and account commitment output sufficient to prevent txns from being dual purposed for other services with similar TL output structure?

In the future, how can we modify the txns or outputs to "re-commit" them in new bonds sooner than their locktime expiry, which is well past their dex expiration duration?