### PR TITLE
dcr: work with range of JSON-RPC versions

### DIFF
--- a/dex/semver.go
+++ b/dex/semver.go
@@ -31,6 +31,17 @@ func SemverCompatible(required, actual Semver) bool {
 	}
 }
 
+// SemverCompatibleAny checks if the version is compatible with any versions in
+// a slice of versions.
+func SemverCompatibleAny(compatible []Semver, actual Semver) bool {
+	for _, v := range compatible {
+		if SemverCompatible(v, actual) {
+			return true
+		}
+	}
+	return false
+}
+
 // Semver formats the Semver as major.minor.patch (e.g. 1.2.3).
 func (s Semver) String() string {
 	return fmt.Sprintf("%d.%d.%d", s.Major, s.Minor, s.Patch)


### PR DESCRIPTION
This allows dex to work with both the 1.7 release versions of dcrd+dcrwallet and the 1.8 prerelease version on master presently.

dcrd was bumped from 7.0.0 to 8.0.0 on account of [removed expired/missed ticket RPCs](https://github.com/decred/dcrd/pull/2911), but we don't use them.

dcrwallet bumped from [8.8.0](https://github.com/decred/dcrwallet/commit/305bed7bace07539de610cc4d2f340b4fb0d699d) to 9.0.0:
- 8.9.0: Removed ticket revoking RPCs we didn't use. https://github.com/decred/dcrwallet/commit/081e25d7c85e5f5b5d0125dc7527406e68c4390b
- 9.0.0: Updated for the dcrd 8.0.0 change and small modification to `getstakeinfo`, which we didn't use. https://github.com/decred/dcrwallet/commit/4c162c4f0db5550d1951a6db8a053b3482d2c3e9