### PR TITLE
app: Fix profile and notification dropdowns

### DIFF
--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -380,7 +380,7 @@ export default class Application {
     dialog.style.top = `${ico.top - 9}px`
 
     const hide = (e: MouseEvent) => {
-      if (!Doc.mouseInElement(e, dialog)) {
+      if (!Doc.mouseInElementBounds(e, dialog)) {
         Doc.hide(dialog)
         unbind(document, 'click', hide)
         if (dialog === this.page.noteBox && Doc.isDisplayed(this.page.noteList)) {

--- a/client/webserver/site/src/js/doc.ts
+++ b/client/webserver/site/src/js/doc.ts
@@ -107,10 +107,20 @@ export default class Doc {
 
   /*
    * mouseInElement returns true if the position of mouse event, e, is within
-   * the bounds of the specified element.
+   * the bounds of the specified element or any of its descendents.
    */
   static mouseInElement (e: MouseEvent, el: HTMLElement): boolean {
     return el.contains(e.target as Node)
+  }
+
+  /*
+   * mouseInElementBounds returns true if the position of mouse event, e, is
+   * within the bounds of the specified element.
+   */
+  static mouseInElementBounds (e: MouseEvent, el: HTMLElement): boolean {
+    const rect = el.getBoundingClientRect()
+    return e.pageX >= rect.left && e.pageX <= rect.right &&
+      e.pageY >= rect.top && e.pageY <= rect.bottom
   }
 
   /*


### PR DESCRIPTION
The previous update to `Doc.mouseInElement` broke the profile and notification dropdowns. Using the new `Doc.mouseInElementBounds` function, which is the original implementation of `Doc.mouseInElement`, fixes them.