### PR TITLE
core: Fix swap/redemption fee info

### DIFF
--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -154,16 +154,6 @@ func DecodeCoinID(assetID uint32, coinID []byte) (cid string, err error) {
 		tkn.ParentID, dex.BipIDSymbol(tkn.ParentID), assetID, dex.BipIDSymbol(assetID))
 }
 
-// IsToken checks if the asset ID is for a token and returns the token's parent
-// ID.
-func IsToken(assetID uint32) (is bool, parentID uint32) {
-	token, is := tokens[assetID]
-	if !is {
-		return
-	}
-	return true, token.ParentID
-}
-
 // A registered asset is information about a supported asset.
 type RegisteredAsset struct {
 	ID     uint32

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -154,6 +154,16 @@ func DecodeCoinID(assetID uint32, coinID []byte) (cid string, err error) {
 		tkn.ParentID, dex.BipIDSymbol(tkn.ParentID), assetID, dex.BipIDSymbol(assetID))
 }
 
+// IsToken checks if the asset ID is for a token and returns the token's parent
+// ID.
+func IsToken(assetID uint32) (is bool, parentID uint32) {
+	token, is := tokens[assetID]
+	if !is {
+		return
+	}
+	return true, token.ParentID
+}
+
 // A registered asset is information about a supported asset.
 type RegisteredAsset struct {
 	ID     uint32

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -7734,12 +7734,11 @@ func (c *Core) deleteOrderFn(ordersFileStr string) (perOrderFn func(*db.MetaOrde
 
 		baseFeeAssetSymbol := unbip(cord.BaseID)
 		baseFeeUnitInfo := baseUnitInfo
-		baseIsToken, baseParent := asset.IsToken(cord.BaseID)
-		if baseIsToken {
-			baseFeeAssetSymbol = unbip(baseParent)
-			baseFeeUnitInfo, err = asset.UnitInfo(baseParent)
+		if baseToken := asset.TokenInfo(cord.BaseID); baseToken != nil {
+			baseFeeAssetSymbol = unbip(baseToken.ParentID)
+			baseFeeUnitInfo, err = asset.UnitInfo(baseToken.ParentID)
 			if err != nil {
-				return fmt.Errorf("unable to get base fee unit info for %v: %v", baseParent, err)
+				return fmt.Errorf("unable to get base fee unit info for %v: %v", baseToken.ParentID, err)
 			}
 		}
 
@@ -7750,12 +7749,11 @@ func (c *Core) deleteOrderFn(ordersFileStr string) (perOrderFn func(*db.MetaOrde
 
 		quoteFeeAssetSymbol := unbip(cord.QuoteID)
 		quoteFeeUnitInfo := quoteUnitInfo
-		quoteIsToken, quoteParent := asset.IsToken(cord.QuoteID)
-		if quoteIsToken {
-			quoteFeeAssetSymbol = unbip(quoteParent)
-			quoteFeeUnitInfo, err = asset.UnitInfo(quoteParent)
+		if quoteToken := asset.TokenInfo(cord.QuoteID); quoteToken != nil {
+			quoteFeeAssetSymbol = unbip(quoteToken.ParentID)
+			quoteFeeUnitInfo, err = asset.UnitInfo(quoteToken.ParentID)
 			if err != nil {
-				return fmt.Errorf("unable to get quote fee unit info for %v: %v", quoteParent, err)
+				return fmt.Errorf("unable to get quote fee unit info for %v: %v", quoteToken.ParentID, err)
 			}
 		}
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -7732,9 +7732,11 @@ func (c *Core) deleteOrderFn(ordersFileStr string) (perOrderFn func(*db.MetaOrde
 			return fmt.Errorf("unable to get base unit info for %v: %v", cord.BaseSymbol, err)
 		}
 
+		baseFeeAssetSymbol := unbip(cord.BaseID)
 		baseFeeUnitInfo := baseUnitInfo
 		baseIsToken, baseParent := asset.IsToken(cord.BaseID)
 		if baseIsToken {
+			baseFeeAssetSymbol = unbip(baseParent)
 			baseFeeUnitInfo, err = asset.UnitInfo(baseParent)
 			if err != nil {
 				return fmt.Errorf("unable to get base fee unit info for %v: %v", baseParent, err)
@@ -7746,9 +7748,11 @@ func (c *Core) deleteOrderFn(ordersFileStr string) (perOrderFn func(*db.MetaOrde
 			return fmt.Errorf("unable to get quote unit info for %v: %v", cord.QuoteSymbol, err)
 		}
 
+		quoteFeeAssetSymbol := unbip(cord.QuoteID)
 		quoteFeeUnitInfo := quoteUnitInfo
 		quoteIsToken, quoteParent := asset.IsToken(cord.QuoteID)
 		if quoteIsToken {
+			quoteFeeAssetSymbol = unbip(quoteParent)
 			quoteFeeUnitInfo, err = asset.UnitInfo(quoteParent)
 			if err != nil {
 				return fmt.Errorf("unable to get quote fee unit info for %v: %v", quoteParent, err)
@@ -7756,11 +7760,13 @@ func (c *Core) deleteOrderFn(ordersFileStr string) (perOrderFn func(*db.MetaOrde
 		}
 
 		ordReader := &OrderReader{
-			Order:            cord,
-			BaseUnitInfo:     baseUnitInfo,
-			BaseFeeUnitInfo:  baseFeeUnitInfo,
-			QuoteUnitInfo:    quoteUnitInfo,
-			QuoteFeeUnitInfo: quoteFeeUnitInfo,
+			Order:               cord,
+			BaseUnitInfo:        baseUnitInfo,
+			BaseFeeUnitInfo:     baseFeeUnitInfo,
+			BaseFeeAssetSymbol:  baseFeeAssetSymbol,
+			QuoteUnitInfo:       quoteUnitInfo,
+			QuoteFeeUnitInfo:    quoteFeeUnitInfo,
+			QuoteFeeAssetSymbol: quoteFeeAssetSymbol,
 		}
 
 		timestamp := time.UnixMilli(int64(cord.Stamp)).Local().Format(time.RFC3339Nano)

--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -18,8 +18,10 @@ import (
 // Whenever possible, add an OrderReader methods rather than a template func.
 type OrderReader struct {
 	*Order
-	BaseUnitInfo  dex.UnitInfo
-	QuoteUnitInfo dex.UnitInfo
+	BaseUnitInfo     dex.UnitInfo
+	BaseFeeUnitInfo  dex.UnitInfo
+	QuoteUnitInfo    dex.UnitInfo
+	QuoteFeeUnitInfo dex.UnitInfo
 }
 
 // FromSymbol is the symbol of the asset which will be sent.
@@ -36,6 +38,34 @@ func (ord *OrderReader) ToSymbol() string {
 		return ord.QuoteSymbol
 	}
 	return ord.BaseSymbol
+}
+
+// FromFeeSymbol is the symbol of the asset used to pay swap fees.
+func (ord *OrderReader) FromFeeSymbol() string {
+	if ord.Sell {
+		return ord.BaseFeeUnitInfo.Conventional.Unit
+	}
+	return ord.QuoteFeeUnitInfo.Conventional.Unit
+}
+
+// ToFeeSymbol is the symbol of the asset used to pay redeem fees.
+func (ord *OrderReader) ToFeeSymbol() string {
+	if ord.Sell {
+		return ord.QuoteFeeUnitInfo.Conventional.Unit
+	}
+	return ord.BaseFeeUnitInfo.Conventional.Unit
+}
+
+// BaseFeeSymbol is the symbol of the asset used to pay the base asset's
+// network fees.
+func (ord *OrderReader) BaseFeeSymbol() string {
+	return ord.BaseFeeUnitInfo.Conventional.Unit
+}
+
+// QuoteFeeSymbol is the symbol of the asset used to pay the quote asset's
+// network fees.
+func (ord *OrderReader) QuoteFeeSymbol() string {
+	return ord.QuoteFeeUnitInfo.Conventional.Unit
 }
 
 // FromID is the asset ID of the asset which will be sent.
@@ -303,17 +333,17 @@ func (ord *OrderReader) AverageRateString() string {
 // SwapFeesString is a formatted string of the paid swap fees.
 func (ord *OrderReader) SwapFeesString() string {
 	if ord.Sell {
-		return formatQty(ord.FeesPaid.Swap, ord.BaseUnitInfo)
+		return formatQty(ord.FeesPaid.Swap, ord.BaseFeeUnitInfo)
 	}
-	return formatQty(ord.FeesPaid.Swap, ord.QuoteUnitInfo)
+	return formatQty(ord.FeesPaid.Swap, ord.QuoteFeeUnitInfo)
 }
 
 // RedemptionFeesString is a formatted string of the paid redemption fees.
 func (ord *OrderReader) RedemptionFeesString() string {
 	if ord.Sell {
-		return formatQty(ord.FeesPaid.Swap, ord.QuoteUnitInfo)
+		return formatQty(ord.FeesPaid.Redemption, ord.QuoteFeeUnitInfo)
 	}
-	return formatQty(ord.FeesPaid.Swap, ord.BaseUnitInfo)
+	return formatQty(ord.FeesPaid.Redemption, ord.BaseFeeUnitInfo)
 }
 
 // BaseAssetFees is a formatted string of the fees paid in the base asset.

--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -18,10 +18,12 @@ import (
 // Whenever possible, add an OrderReader methods rather than a template func.
 type OrderReader struct {
 	*Order
-	BaseUnitInfo     dex.UnitInfo
-	BaseFeeUnitInfo  dex.UnitInfo
-	QuoteUnitInfo    dex.UnitInfo
-	QuoteFeeUnitInfo dex.UnitInfo
+	BaseUnitInfo        dex.UnitInfo
+	BaseFeeUnitInfo     dex.UnitInfo
+	BaseFeeAssetSymbol  string
+	QuoteUnitInfo       dex.UnitInfo
+	QuoteFeeUnitInfo    dex.UnitInfo
+	QuoteFeeAssetSymbol string
 }
 
 // FromSymbol is the symbol of the asset which will be sent.
@@ -43,29 +45,29 @@ func (ord *OrderReader) ToSymbol() string {
 // FromFeeSymbol is the symbol of the asset used to pay swap fees.
 func (ord *OrderReader) FromFeeSymbol() string {
 	if ord.Sell {
-		return ord.BaseFeeUnitInfo.Conventional.Unit
+		return ord.BaseFeeAssetSymbol
 	}
-	return ord.QuoteFeeUnitInfo.Conventional.Unit
+	return ord.QuoteFeeAssetSymbol
 }
 
 // ToFeeSymbol is the symbol of the asset used to pay redeem fees.
 func (ord *OrderReader) ToFeeSymbol() string {
 	if ord.Sell {
-		return ord.QuoteFeeUnitInfo.Conventional.Unit
+		return ord.QuoteFeeAssetSymbol
 	}
-	return ord.BaseFeeUnitInfo.Conventional.Unit
+	return ord.BaseFeeAssetSymbol
 }
 
 // BaseFeeSymbol is the symbol of the asset used to pay the base asset's
 // network fees.
 func (ord *OrderReader) BaseFeeSymbol() string {
-	return ord.BaseFeeUnitInfo.Conventional.Unit
+	return ord.BaseFeeAssetSymbol
 }
 
 // QuoteFeeSymbol is the symbol of the asset used to pay the quote asset's
 // network fees.
 func (ord *OrderReader) QuoteFeeSymbol() string {
-	return ord.QuoteFeeUnitInfo.Conventional.Unit
+	return ord.QuoteFeeAssetSymbol
 }
 
 // FromID is the asset ID of the asset which will be sent.

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -481,12 +481,11 @@ func (s *WebServer) orderReader(ord *core.Order) *core.OrderReader {
 	}
 
 	feeAssetInfo := func(assetID uint32, symbol string) (string, dex.UnitInfo) {
-		isToken, parent := asset.IsToken(assetID)
-		if !isToken {
-			return unbip(assetID), unitInfo(assetID, symbol)
+		if token := asset.TokenInfo(assetID); token != nil {
+			parentAsset := asset.Asset(token.ParentID)
+			return unbip(parentAsset.ID), parentAsset.Info.UnitInfo
 		}
-		parentAsset := asset.Asset(parent)
-		return unbip(parent), parentAsset.Info.UnitInfo
+		return unbip(assetID), unitInfo(assetID, symbol)
 	}
 
 	baseFeeAssetSymbol, baseFeeUintInfo := feeAssetInfo(ord.BaseID, ord.BaseSymbol)

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -480,20 +480,25 @@ func (s *WebServer) orderReader(ord *core.Order) *core.OrderReader {
 		return a.UnitInfo
 	}
 
-	feeUnitInfo := func(assetID uint32, symbol string) dex.UnitInfo {
+	feeAssetInfo := func(assetID uint32, symbol string) (string, dex.UnitInfo) {
 		isToken, parent := asset.IsToken(assetID)
 		if !isToken {
-			return unitInfo(assetID, symbol)
+			return unbip(assetID), unitInfo(assetID, symbol)
 		}
 		parentAsset := asset.Asset(parent)
-		return parentAsset.Info.UnitInfo
+		return unbip(parent), parentAsset.Info.UnitInfo
 	}
 
+	baseFeeAssetSymbol, baseFeeUintInfo := feeAssetInfo(ord.BaseID, ord.BaseSymbol)
+	quoteFeeAssetSymbol, quoteFeeUnitInfo := feeAssetInfo(ord.QuoteID, ord.QuoteSymbol)
+
 	return &core.OrderReader{
-		Order:            ord,
-		BaseUnitInfo:     unitInfo(ord.BaseID, ord.BaseSymbol),
-		BaseFeeUnitInfo:  feeUnitInfo(ord.BaseID, ord.BaseSymbol),
-		QuoteUnitInfo:    unitInfo(ord.QuoteID, ord.QuoteSymbol),
-		QuoteFeeUnitInfo: feeUnitInfo(ord.QuoteID, ord.QuoteSymbol),
+		Order:               ord,
+		BaseUnitInfo:        unitInfo(ord.BaseID, ord.BaseSymbol),
+		BaseFeeUnitInfo:     baseFeeUintInfo,
+		BaseFeeAssetSymbol:  baseFeeAssetSymbol,
+		QuoteUnitInfo:       unitInfo(ord.QuoteID, ord.QuoteSymbol),
+		QuoteFeeUnitInfo:    quoteFeeUnitInfo,
+		QuoteFeeAssetSymbol: quoteFeeAssetSymbol,
 	}
 }

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -76,8 +76,8 @@
       <div class="order-datum">
         <div>[[[Fees]]] <span class="ico-info fs12" data-tooltip="[[[order_fees_tooltip]]]"></span></div>
         <div>
-          {{$ord.SwapFeesString}} {{template "microIcon" $ord.FromSymbol}},
-          {{$ord.RedemptionFeesString}} {{template "microIcon" $ord.ToSymbol}}
+          {{$ord.SwapFeesString}} {{template "microIcon" $ord.FromFeeSymbol}},
+          {{$ord.RedemptionFeesString}} {{template "microIcon" $ord.ToFeeSymbol}}
         </div>
       </div>
       <div class="order-datum">


### PR DESCRIPTION
Previously, swap fees were displayed in place of redemption fees. Also, for tokens, the token asset was displayed as the fee asset instead of the parent. Both of these issues are fixed. Also, in the exported orders CSV, two new columns are added, one for the base asset's fee asset, and one for the quote asset's fee asset.

Closes #1814 