### PR TITLE
windows embed paths

### DIFF
--- a/client/webserver/template.go
+++ b/client/webserver/template.go
@@ -46,7 +46,8 @@ func newTemplates(folder, lang string, embedded bool) *templates {
 		t.addErr = fmt.Errorf("no translation dictionary found for lang %q", lang)
 		return t
 	}
-	if embedded {
+	if embedded { // slashes even on Windows, see embed pkg docs
+		t.folder = filepath.ToSlash(t.folder)
 		return t
 	}
 
@@ -60,6 +61,9 @@ func newTemplates(folder, lang string, embedded bool) *templates {
 
 // filepath constructs the template path from the template ID.
 func (t *templates) filepath(name string) string {
+	if t.embedded { // slashes even on Windows, see embed pkg docs
+		return t.folder + "/" + name + ".tmpl"
+	}
 	return filepath.Join(t.folder, name+".tmpl")
 }
 


### PR DESCRIPTION
v0.5.0 on Windows is broken when using embedded files because as per the `embed` pkg docs:

> The path separator is a forward slash, even on Windows systems.

So doing `filepath.Join`, which is usually "the right thing", fails on Windows.  Surprising to say the least.  https://github.com/golang/go/issues/45230 https://github.com/golang/go/issues/44305 https://pkg.go.dev/io/fs#ValidPath

For an immediate patch.