### PR TITLE
client:{app,core}: Make order page more intuitive

### DIFF
--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -682,17 +682,11 @@ func (m *matchReader) ConfirmingTakerRedeem() bool {
 		m.Match.Status < order.MatchConfirmed && m.Match.Status >= order.MatchComplete
 }
 
-// InConfirmingRedeem returns true if the match has completed but the user's
-// redemption has not yet been confirmed.
-func (m *matchReader) InConfirmingRedeem() bool {
-	return m.ConfirmingMakerRedeem() || m.ConfirmingTakerRedeem()
-}
-
 // ConfirmRedeemString returns a string indicating the current confirmation
 // progress of the user's redemption. An empty string is returned if the
 // user has not yet submit their redemption, or if it is already confirmed.
 func (m *matchReader) ConfirmRedeemString() string {
-	if !m.InConfirmingRedeem() || m.Redeem == nil {
+	if !(m.ConfirmingMakerRedeem() || m.ConfirmingTakerRedeem()) || m.Redeem == nil {
 		return ""
 	}
 

--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -437,7 +437,7 @@ func (m *matchReader) IsMaker() bool {
 	return m.Side == order.Maker
 }
 
-// MakerSwapID reutrns the ID of the asset used in the maker's swap.
+// MakerSwapID returns the ID of the asset used in the maker's swap.
 func (m *matchReader) MakerSwapID() uint32 {
 	if m.Side == order.Maker {
 		return m.ord.FromID()
@@ -445,7 +445,7 @@ func (m *matchReader) MakerSwapID() uint32 {
 	return m.ord.ToID()
 }
 
-// TakerSwapID reutrns the ID of the asset used in the taker's swap.
+// TakerSwapID returns the ID of the asset used in the taker's swap.
 func (m *matchReader) TakerSwapID() uint32 {
 	if m.Side == order.Maker {
 		return m.ord.ToID()
@@ -453,7 +453,7 @@ func (m *matchReader) TakerSwapID() uint32 {
 	return m.ord.FromID()
 }
 
-// MakerSwapSymbol reutrns the symbol of the asset used in the maker's swap.
+// MakerSwapSymbol returns the symbol of the asset used in the maker's swap.
 func (m *matchReader) MakerSwapSymbol() string {
 	if m.Side == order.Maker {
 		return m.ord.FromSymbol()
@@ -461,7 +461,7 @@ func (m *matchReader) MakerSwapSymbol() string {
 	return m.ord.ToSymbol()
 }
 
-// TakerSwapSymbol reutrns the symbol of the asset used in the taker's swap.
+// TakerSwapSymbol returns the symbol of the asset used in the taker's swap.
 func (m *matchReader) TakerSwapSymbol() string {
 	if m.Side == order.Maker {
 		return m.ord.ToSymbol()
@@ -504,25 +504,25 @@ func (m *matchReader) TakerRedeem() *Coin {
 // ShowMakerSwap returns whether or not to display the maker swap section
 // on the match card.
 func (m *matchReader) ShowMakerSwap() bool {
-	return m.MakerSwap() != nil || !m.Revoked
+	return (m.MakerSwap() != nil || !m.Revoked) && !m.IsCancel
 }
 
 // ShowTakerSwap returns whether or not to display the taker swap section
 // on the match card.
 func (m *matchReader) ShowTakerSwap() bool {
-	return m.TakerSwap() != nil || !m.Revoked
+	return (m.TakerSwap() != nil || !m.Revoked) && !m.IsCancel
 }
 
 // ShowMakerRedeem returns whether or not to display the maker redeem section
 // on the match card.
 func (m *matchReader) ShowMakerRedeem() bool {
-	return m.MakerRedeem() != nil || !m.Revoked
+	return (m.MakerRedeem() != nil || !m.Revoked) && !m.IsCancel
 }
 
 // ShowTakerRedeem returns whether or not to display the taker redeem section
 // on the match card.
 func (m *matchReader) ShowTakerRedeem() bool {
-	return !m.IsMaker() && (m.TakerRedeem() != nil || !m.Revoked)
+	return !m.IsMaker() && (m.TakerRedeem() != nil || !m.Revoked) && !m.IsCancel
 }
 
 // ShowRefund returns whether or not to display the refund section on the match

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -271,4 +271,9 @@ var EnUS = map[string]string{
 	"transfer":                    "Transfer",
 	"invalid_address":             "Note: Provide a valid address.",
 	"max_estimated_send_tooltip":  "This is the estimated amount that will be received if you withdraw your current balance with 'Subtract fees from amount sent' checked. If there is no subtract fee checkbox, this is the maximum estimated amount you can send.",
+	"Maker Swap":                  "Maker Swap",
+	"Taker Swap":                  "Taker Swap",
+	"Maker Redemption":            "Maker Redemption",
+	"Taker Redemption":            "Taker Redemption",
+	"Pending":                     "Pending",
 }

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -149,53 +149,67 @@
         {{end}}
 
         <div class="pt-3">
-          {{$coin := $match.Swap}}
-          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="swap">
+          {{$coin := $match.MakerSwap}}
+          <div class="px-3 pb-3 {{if not $match.ShowMakerSwap}}d-hide{{end}}" data-tmpl="makerSwap">
             <div class="d-inline-block">
               <div class="d-flex align-items-center justify-content-between">
-                <span class="match-data-label">[[[Swap]]] ({{$ord.FromSymbol}}, [[[you]]])</span>
-                <span class="match-data-label{{if not $match.InSwapCast}} d-hide{{end}}" data-tmpl="swapMsg">
-                  {{$match.SwapConfirmString}}
+                <span class="match-data-label">1. [[[Maker Swap]]] ({{$match.MakerSwapSymbol}}, {{if $match.IsMaker}}[[[you]]]{{else}}[[[them]]]{{end}})</span>
+                <span class="match-data-label {{if not $match.InMakerSwapCast}}d-hide{{end}}" data-tmpl="makerSwapMsg">
+                  {{$match.MakerSwapConfirmString}}
                 </span>
               </div>
-              <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.FromID}}"
-                data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="swapCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
+              <span {{if $coin}}class="d-hide"{{end}} data-tmpl="makerSwapPending">&lt;[[[Pending]]]&gt;</span>
+              <a target="_blank" class="mono plainlink {{if not $coin}}d-hide{{end}}" data-explorer-id="{{$match.MakerSwapID}}"
+                data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="makerSwapCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
             </div>
           </div>
-          {{$coin = $match.CounterSwap}}
-          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="counterSwap">
+          {{$coin = $match.TakerSwap}}
+          <div class="px-3 pb-3 {{if not $match.ShowTakerSwap}}d-hide{{end}}" data-tmpl="takerSwap">
             <div class="d-inline-block">
               <div class="d-flex align-items-center justify-content-between">
-                <span class="match-data-label">[[[Swap]]] ({{$ord.ToSymbol}}, [[[them]]])</span>
-                <span class="match-data-label{{if not $match.InCounterSwapCast}} d-hide{{end}}" data-tmpl="counterSwapMsg">
-                  {{$match.CounterSwapConfirmString}}
+                <span class="match-data-label">2. [[[Taker Swap]]] ({{$match.TakerSwapSymbol}}, {{if $match.IsMaker}}[[[them]]]{{else}}[[[you]]]{{end}})</span>
+                <span class="match-data-label {{if not $match.InTakerSwapCast}}d-hide{{end}}" data-tmpl="takerSwapMsg">
+                  {{$match.TakerSwapConfirmString}}
                 </span>
               </div>
-              <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.ToID}}"
-                data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="counterSwapCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
+              <span {{if $coin}}class="d-hide"{{end}} data-tmpl="takerSwapPending">&lt;[[[Pending]]]&gt;</span>
+              <a target="_blank" class="mono plainlink {{if not $coin}}d-hide{{end}}" data-explorer-id="{{$match.TakerSwapID}}"
+                data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="takerSwapCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
             </div>
           </div>
-          {{$coin = $match.Redeem}}
-          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="redeem">
-            <div class="d-flex align-items-center justify-content-between">
-              <span class="match-data-label">[[[Redemption]]] ({{$ord.ToSymbol}}, [[[you]]])</span>
-              <span class="match-data-label{{if not $match.InConfirmingRedeem}} d-hide{{end}}" data-tmpl="redeemMsg">
-                {{$match.ConfirmRedeemString}}
-              </span>
+          {{$coin = $match.MakerRedeem}}
+          <div class="px-3 pb-3 {{if not $match.ShowMakerRedeem}}d-hide{{end}}" data-tmpl="makerRedeem">
+            <div class="d-inline-block">
+              <div class="d-flex align-items-center justify-content-between">
+                <span class="match-data-label">3. [[[Maker Redemption]]] ({{$match.TakerSwapSymbol}}, {{if $match.IsMaker}}[[[you]]]{{else}}[[[them]]]{{end}})</span><br>
+                <span class="match-data-label {{if not $match.ConfirmingMakerRedeem}}d-hide{{end}}" data-tmpl="makerRedeemMsg">
+                  {{$match.ConfirmRedeemString}}
+                </span>
+              </div>
+              <span {{if $coin}}class="d-hide"{{end}} data-tmpl="makerRedeemPending">&lt;[[[Pending]]]&gt;</span>
+              <a target="_blank" class="mono plainlink {{if not $coin}}d-hide{{end}}" data-explorer-id="{{$match.TakerSwapID}}"
+                data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="makerRedeemCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
             </div>
-            <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.ToID}}"
-              data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="redeemCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
           </div>
-          {{$coin = $match.CounterRedeem}}
-          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="counterRedeem">
-            <span class="match-data-label">[[[Redemption]]] ({{$ord.FromSymbol}}, [[[them]]])</span><br>
-            <a target="_blank" class="mono plainlink" data-explorer-id="{{$ord.FromID}}"
-              data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="counterRedeemCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
+          {{$coin = $match.TakerRedeem}}
+          <div class="px-3 pb-3 {{if not $match.ShowTakerRedeem}}d-hide{{end}}" data-tmpl="takerRedeem">
+            <div class="d-inline-block">
+              <div class="d-flex align-items-center justify-content-between">
+                <span class="match-data-label">4. [[[Taker Redemption]]] ({{$match.MakerSwapSymbol}}, {{if $match.IsMaker}}[[[them]]]{{else}}[[[you]]]{{end}})</span><br>
+                <span class="match-data-label {{if not $match.ConfirmingTakerRedeem}}d-hide{{end}}" data-tmpl="takerRedeemMsg">
+                  {{$match.ConfirmRedeemString}}
+                </span>
+              </div>
+              <span {{if $coin}}class="d-hide"{{end}} data-tmpl="takerRedeemPending">&lt;[[[Pending]]]&gt;</span>
+              <a target="_blank" class="mono plainlink {{if not $coin}}d-hide{{end}}" data-explorer-id="{{$match.MakerSwapID}}"
+                data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="takerRedeemCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
+            </div>
           </div>
           {{$coin = $match.Refund}}
-          <div class="px-3 pb-3{{if not $coin}} d-hide{{end}}" data-tmpl="refund">
+          <div class="px-3 pb-3 {{if not $match.ShowRefund}}d-hide{{end}}" data-tmpl="refund">
             <span class="match-data-label red">[[[Refund]]] ({{$ord.FromSymbol}}, [[[you]]])</span><br>
-            <a target="_blank" class="mono plainlink red" data-explorer-id="{{$ord.FromID}}"
+            <span {{if $coin}}class="d-hide"{{end}} data-tmpl="refundPending">&lt;[[[Pending]]]&gt;</span>
+            <a target="_blank" class="mono plainlink red {{if not $coin}}d-hide{{end}}" data-explorer-id="{{$ord.FromID}}"
               data-explorer-coin="{{if $coin}}{{$coin.StringID}}{{end}}" data-tmpl="refundCoin">{{if $coin}}{{$coin.StringID}}{{end}}</a>
           </div>
         </div>

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -263,8 +263,6 @@ export default class OrderPage extends BasePage {
     const makerRedeemSpan = Doc.tmplElement(card, 'makerRedeemMsg')
     const takerRedeemSpan = Doc.tmplElement(card, 'takerRedeemMsg')
 
-    console.log(JSON.stringify(m.redeem))
-
     if (m.status === OrderUtil.MakerSwapCast && !m.revoked && !m.refund) {
       const c = makerSwapCoin(m)
       makerSwapSpan.textContent = confirmationString(c)

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -236,41 +236,79 @@ export default class OrderPage extends BasePage {
       return
     }
 
-    const setCoin = (divName: string, linkName: string, coin: Coin) => {
+    const setCoin = (pendingName: string, linkName: string, coin: Coin) => {
       if (!card) return // Ugh
-      if (!coin) return
-      Doc.show(Doc.tmplElement(card, divName))
       const coinLink = Doc.tmplElement(card, linkName)
+      const pendingSpan = Doc.tmplElement(card, pendingName)
+      if (!coin) {
+        Doc.show(pendingSpan)
+        Doc.hide(coinLink)
+        return
+      }
       coinLink.textContent = coin.stringID
       coinLink.dataset.explorerCoin = coin.stringID
       setCoinHref(coinLink)
+      Doc.hide(pendingSpan)
+      Doc.show(coinLink)
     }
 
-    setCoin('swap', 'swapCoin', m.swap)
-    setCoin('counterSwap', 'counterSwapCoin', m.counterSwap)
-    setCoin('redeem', 'redeemCoin', m.redeem)
-    setCoin('counterRedeem', 'counterRedeemCoin', m.counterRedeem)
-    setCoin('refund', 'refundCoin', m.refund)
+    setCoin('makerSwapPending', 'makerSwapCoin', makerSwapCoin(m))
+    setCoin('takerSwapPending', 'takerSwapCoin', takerSwapCoin(m))
+    setCoin('makerRedeemPending', 'makerRedeemCoin', makerRedeemCoin(m))
+    setCoin('takerRedeemPending', 'takerRedeemCoin', takerRedeemCoin(m))
+    setCoin('refundPending', 'refundCoin', m.refund)
 
-    const swapSpan = Doc.tmplElement(card, 'swapMsg')
-    const cSwapSpan = Doc.tmplElement(card, 'counterSwapMsg')
-    const redeemSpan = Doc.tmplElement(card, 'redeemMsg')
+    const makerSwapSpan = Doc.tmplElement(card, 'makerSwapMsg')
+    const takerSwapSpan = Doc.tmplElement(card, 'takerSwapMsg')
+    const makerRedeemSpan = Doc.tmplElement(card, 'makerRedeemMsg')
+    const takerRedeemSpan = Doc.tmplElement(card, 'takerRedeemMsg')
 
-    if (inCounterSwapCast(m)) {
-      cSwapSpan.textContent = confirmationString(m.counterSwap)
-      Doc.hide(swapSpan, redeemSpan)
-      Doc.show(cSwapSpan)
-    } else if (inSwapCast(m)) {
-      swapSpan.textContent = confirmationString(m.swap)
-      Doc.hide(cSwapSpan, redeemSpan)
-      Doc.show(swapSpan)
-    } else if (inConfirmingRedeem(m)) {
-      redeemSpan.textContent = confirmationString(m.redeem)
-      Doc.hide(swapSpan, cSwapSpan)
-      Doc.show(redeemSpan)
+    console.log(JSON.stringify(m.redeem))
+
+    if (m.status === OrderUtil.MakerSwapCast && !m.revoked && !m.refund) {
+      const c = makerSwapCoin(m)
+      makerSwapSpan.textContent = confirmationString(c)
+      Doc.hide(takerSwapSpan, makerRedeemSpan, takerRedeemSpan)
+      Doc.show(makerSwapSpan)
+    } else if (m.status === OrderUtil.TakerSwapCast && !m.revoked && !m.refund) {
+      const c = takerSwapCoin(m)
+      takerSwapSpan.textContent = confirmationString(c)
+      Doc.hide(makerSwapSpan, makerRedeemSpan, takerRedeemSpan)
+      Doc.show(takerSwapSpan)
+    } else if (inConfirmingMakerRedeem(m) && !m.revoked && !m.refund) {
+      makerRedeemSpan.textContent = confirmationString(m.redeem)
+      Doc.hide(makerSwapSpan, takerSwapSpan, takerRedeemSpan)
+      Doc.show(makerRedeemSpan)
+    } else if (inConfirmingTakerRedeem(m) && !m.revoked && !m.refund) {
+      takerRedeemSpan.textContent = confirmationString(m.redeem)
+      Doc.hide(makerSwapSpan, takerSwapSpan, makerRedeemSpan)
+      Doc.show(takerRedeemSpan)
     } else {
-      Doc.hide(swapSpan, cSwapSpan, redeemSpan)
+      Doc.hide(makerSwapSpan, takerSwapSpan, makerRedeemSpan, takerRedeemSpan)
     }
+
+    const makerSwapDiv = Doc.tmplElement(card, 'makerSwap')
+    const takerSwapDiv = Doc.tmplElement(card, 'takerSwap')
+    const makerRedeemDiv = Doc.tmplElement(card, 'makerRedeem')
+    const takerRedeemDiv = Doc.tmplElement(card, 'takerRedeem')
+    const refundDiv = Doc.tmplElement(card, 'refund')
+
+    const showMakerSwap = !m.isCancel && (makerSwapCoin(m) || !m.revoked)
+    const showTakerSwap = !m.isCancel && (takerSwapCoin(m) || !m.revoked)
+    const showMakerRedeem = !m.isCancel && (makerRedeemCoin(m) || !m.revoked)
+    const showTakerRedeem = !m.isCancel && (m.side !== OrderUtil.Maker) && (takerRedeemCoin(m) || !m.revoked)
+    const showRefund = !m.isCancel && (m.refund || (m.revoked && m.active))
+
+    if (showMakerSwap) Doc.show(makerSwapDiv)
+    else Doc.hide(makerSwapDiv)
+    if (showTakerSwap) Doc.show(takerSwapDiv)
+    else Doc.hide(takerSwapDiv)
+    if (showMakerRedeem) Doc.show(makerRedeemDiv)
+    else Doc.hide(makerRedeemDiv)
+    if (showTakerRedeem) Doc.show(takerRedeemDiv)
+    else Doc.hide(takerRedeemDiv)
+    if (showRefund) Doc.show(refundDiv)
+    else Doc.hide(refundDiv)
 
     Doc.tmplElement(card, 'status').textContent = OrderUtil.matchStatusString(m)
   }
@@ -285,28 +323,40 @@ function confirmationString (coin: Coin) {
   return `${coin.confs.count} / ${coin.confs.required} confirmations`
 }
 
-/*
- * inCounterSwapCast will be true if we are waiting on confirmations for the
- * counterparty's swap.
- */
-function inCounterSwapCast (m: Match) {
-  return (m.side === OrderUtil.Taker && m.status === OrderUtil.MakerSwapCast) || (m.side === OrderUtil.Maker && m.status === OrderUtil.TakerSwapCast)
+// makerSwapCoin return's the maker's swap coin.
+function makerSwapCoin (m: Match) : Coin {
+  return (m.side === OrderUtil.Maker) ? m.swap : m.counterSwap
+}
+
+// takerSwapCoin return's the taker's swap coin.
+function takerSwapCoin (m: Match) {
+  return (m.side === OrderUtil.Maker) ? m.counterSwap : m.swap
+}
+
+// makerRedeemCoin return's the maker's redeem coin.
+function makerRedeemCoin (m: Match) {
+  return (m.side === OrderUtil.Maker) ? m.redeem : m.counterRedeem
+}
+
+// takerRedeemCoin return's the taker's redeem coin.
+function takerRedeemCoin (m: Match) {
+  return (m.side === OrderUtil.Maker) ? m.counterRedeem : m.redeem
 }
 
 /*
- * inCounterSwapCast will be true if we are waiting on confirmations for our own
- * swap.
- */
-function inSwapCast (m: Match) {
-  return (m.side === OrderUtil.Maker && m.status === OrderUtil.MakerSwapCast) || (m.side === OrderUtil.Taker && m.status === OrderUtil.TakerSwapCast)
-}
-
-/*
-* inConfirmingRedeem will be true if we are waiting on confirmations for our own
-* redeem.
+* inConfirmingMakerRedeem will be true if we are the maker, and we are waiting
+* on confirmations for our own redeem.
 */
-function inConfirmingRedeem (m: Match) {
-  return m.status < OrderUtil.MatchConfirmed && ((m.side === OrderUtil.Maker && m.status >= OrderUtil.MakerRedeemed) || (m.side === OrderUtil.Taker && m.status >= OrderUtil.MatchComplete))
+function inConfirmingMakerRedeem (m: Match) {
+  return m.status < OrderUtil.MatchConfirmed && m.side === OrderUtil.Maker && m.status >= OrderUtil.MakerRedeemed
+}
+
+/*
+* inConfirmingTakerRedeem will be true if we are the taker, and we are waiting
+* on confirmations for our own redeem.
+*/
+function inConfirmingTakerRedeem (m: Match) {
+  return m.status < OrderUtil.MatchConfirmed && m.side === OrderUtil.Taker && m.status >= OrderUtil.MatchComplete
 }
 
 /*

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -134,16 +134,16 @@ export function matchStatusString (m: Match) {
 
   switch (m.status) {
     case NewlyMatched:
-      return '(0 / 4) Newly Matched'
+      return 'Newly Matched'
     case MakerSwapCast:
-      return '(1 / 4) First Swap Sent'
+      return 'Maker Swap Sent'
     case TakerSwapCast:
-      return '(2 / 4) Second Swap Sent'
+      return 'Taker Swap Sent'
     case MakerRedeemed:
       if (m.side === Maker) {
         return 'Redemption Sent'
       }
-      return '(3 / 4) Maker Redeemed'
+      return 'Maker Redeemed'
     case MatchComplete:
       return 'Redemption Sent'
     case MatchConfirmed:


### PR DESCRIPTION
Previously, the orders page displayed the actions out of order if you were the taker, and did not display the pending future events. It is now updated to show each of the swap actions in the proper order.
<img width="503" alt="Screen Shot 2022-08-29 at 9 19 21 PM" src="https://user-images.githubusercontent.com/6186350/187223060-bf2922c0-335a-42e7-805b-dc47bdc54161.png">
<img width="503" alt="Screen Shot 2022-08-29 at 9 18 43 PM" src="https://user-images.githubusercontent.com/6186350/187223064-244b2523-8e13-443f-8013-fc2839573edc.png">

Closes #1790 