### PR TITLE
client/core: add reporter for missing ntfn translations

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1194,7 +1194,7 @@ func newTestRig() *testRig {
 			newCrypter: func([]byte) encrypt.Crypter { return crypter },
 			reCrypter:  func([]byte, []byte) (encrypt.Crypter, error) { return crypter, crypter.recryptErr },
 
-			locale:        enUS,
+			locale:        originLocale,
 			localePrinter: message.NewPrinter(language.AmericanEnglish),
 
 			fiatRateSources: make(map[string]*commonRateSource),

--- a/client/core/localetest/main.go
+++ b/client/core/localetest/main.go
@@ -2,32 +2,28 @@ package main
 
 import (
 	"fmt"
+	"os"
 
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
+	"decred.org/dcrdex/client/core"
 )
 
-const key = "key"
-
 func main() {
-	icelandicTmpl := "%.2f gígavött"
-	englishTmpl := "%.2f gigawatts"
-
-	err := message.SetString(language.Icelandic, key, icelandicTmpl)
-	if err != nil {
-		panic(err.Error())
+	missing, stale := core.CheckTopicLangs()
+	if len(missing) == 0 && len(stale) == 0 {
+		fmt.Println("No missing or stale notification translations!")
+		os.Exit(0)
 	}
-	err = message.SetString(language.AmericanEnglish, key, englishTmpl)
-	if err != nil {
-		panic(err.Error())
+	for lang, topics := range missing {
+		fmt.Printf("%d missing notification translations for %v\n", len(topics), lang)
+		for i := range topics {
+			fmt.Printf("[%v] Translation missing for topic %v\n", lang, topics[i])
+		}
 	}
-
-	icelandicPrinter := message.NewPrinter(language.Icelandic)
-	englishPrinter := message.NewPrinter(language.AmericanEnglish)
-
-	fmt.Println("Icelandic (using key):", icelandicPrinter.Sprintf(key, 1.21))
-	fmt.Println("Icelandic (direct):   ", icelandicPrinter.Sprintf(icelandicTmpl, 1.21))
-
-	fmt.Println("English (using key):  ", englishPrinter.Sprintf(key, 1.21))
-	fmt.Println("English (direct):     ", englishPrinter.Sprintf(englishTmpl, 1.21))
+	for lang, topics := range stale {
+		fmt.Printf("%d stale notification translations for %v\n", len(topics), lang)
+		for i := range topics {
+			fmt.Printf("[%v] Translation stale for topic %v\n", lang, topics[i])
+		}
+	}
+	// os.Exit(1) // if we want this to be fatal
 }

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -104,8 +104,12 @@ func (c *Core) AckNotes(ids []dex.Bytes) {
 func (c *Core) formatDetails(topic Topic, args ...interface{}) (translatedSubject, details string) {
 	trans, found := c.locale[topic]
 	if !found {
-		c.log.Errorf("no translation found for topic %q", topic)
-		return string(topic), "translation error"
+		c.log.Errorf("No translation found for topic %q", topic)
+		originTrans := originLocale[topic]
+		if originTrans == nil {
+			return string(topic), "translation error"
+		}
+		return originTrans.subject, fmt.Sprintf(originTrans.template, args...)
 	}
 	return trans.subject, c.localePrinter.Sprintf(string(topic), args...)
 }

--- a/docs/wiki/Localization-and-Translation.md
+++ b/docs/wiki/Localization-and-Translation.md
@@ -18,7 +18,7 @@ The new HTML strings map must then be listed in <https://github.com/decred/dcrde
 
 ## Step 2 - Notifications
 
-The notification strings involved editing [client/core/locale_ntfn.go](https://github.com/decred/dcrdex/blob/master/client/core/locale_ntfn.go) with a new `var zhCN map[Topic]*translation`. These translations correspond to the English strings in the `enUS` map in the same file.
+The notification strings involved editing [client/core/locale_ntfn.go](https://github.com/decred/dcrdex/blob/master/client/core/locale_ntfn.go) with a new `var zhCN map[Topic]*translation`. These translations correspond to the English strings in the `originLocale` map in the same file.
 
 Note how in **client/core/locale_ntfn.go** there are "printf" specifiers like `%s` and `%d`.  These define the formatting for various runtime data, such as integer numbers, identifier strings, etc.  Because sentence structure varies between languages the order of those specifiers can be explicitly defined like `%[3]s` (the third argument given to printf in the code) instead of relying on the position of those specifiers in the formatting string.  This is necessary because the code that executes the printing always provides the values in a particular order, which may not be the same order in a translated string.
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -35,6 +35,9 @@ done
 
 cd "$dir"
 
+# Print missing Core notification translations.
+go run ./client/core/localetest/main.go
+
 # -race in go tests above requires cgo, but disable it for the compile tests below
 export CGO_ENABLED=0
 go build ./...


### PR DESCRIPTION
This adds a tool to check for missing notification translations.

This also modifies `(*Core).formatDetails` to use the origin/english text when a translation does not exist instead of just `"translation error"`.

The current missing ones:

```
4 missing notification translations for pl-PL
[pl-PL] Translation missing for topic WalletPeersWarning
[pl-PL] Translation missing for topic QueuedCreationFailed
[pl-PL] Translation missing for topic WalletPeersRestored
[pl-PL] Translation missing for topic WalletCommsWarning
4 missing notification translations for pt-BR
[pt-BR] Translation missing for topic WalletCommsWarning
[pt-BR] Translation missing for topic WalletPeersWarning
[pt-BR] Translation missing for topic QueuedCreationFailed
[pt-BR] Translation missing for topic WalletPeersRestored
4 missing notification translations for zh-CN
[zh-CN] Translation missing for topic WalletPeersWarning
[zh-CN] Translation missing for topic QueuedCreationFailed
[zh-CN] Translation missing for topic WalletPeersRestored
[zh-CN] Translation missing for topic WalletCommsWarning
2 stale notification translations for pt-BR
[pt-BR] Translation stale for topic SendError
[pt-BR] Translation stale for topic SendSuccess
2 stale notification translations for zh-CN
[zh-CN] Translation stale for topic SendError
[zh-CN] Translation stale for topic SendSuccess
2 stale notification translations for pl-PL
[pl-PL] Translation stale for topic SendError
[pl-PL] Translation stale for topic SendSuccess
```