### PR TITLE
site: redo js mouseInElement

### DIFF
--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -374,7 +374,7 @@ export default class Application {
     dialog.style.top = `${ico.top - 9}px`
 
     const hide = (e: MouseEvent) => {
-      if (!Doc.mouseInElementBounds(e, dialog)) {
+      if (!Doc.mouseInElement(e, dialog)) {
         Doc.hide(dialog)
         unbind(document, 'click', hide)
         if (dialog === this.page.noteBox && Doc.isDisplayed(this.page.noteList)) {

--- a/client/webserver/site/src/js/doc.ts
+++ b/client/webserver/site/src/js/doc.ts
@@ -110,14 +110,7 @@ export default class Doc {
    * the bounds of the specified element or any of its descendents.
    */
   static mouseInElement (e: MouseEvent, el: HTMLElement): boolean {
-    return el.contains(e.target as Node)
-  }
-
-  /*
-   * mouseInElementBounds returns true if the position of mouse event, e, is
-   * within the bounds of the specified element.
-   */
-  static mouseInElementBounds (e: MouseEvent, el: HTMLElement): boolean {
+    if (el.contains(e.target as Node)) return true
     const rect = el.getBoundingClientRect()
     return e.pageX >= rect.left && e.pageX <= rect.right &&
       e.pageY >= rect.top && e.pageY <= rect.bottom


### PR DESCRIPTION
#1811 resulted in unexpected behaviour that was addressed by #1823. This diff merges `mouseInElement` and `mouseInElementBounds` to reduce duplicate code ([comment](https://github.com/decred/dcrdex/pull/1688#issuecomment-1234331131)).