### PR TITLE
app: Fix displayed market volume

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GHTDFVH6" rel="stylesheet">
+  <link href="/css/style.css?v=RQIW8192" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GHTDFVH6"></script>
+<script src="/js/entry.js?v=RQIW8192"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -420,7 +420,9 @@ export default class WalletsPage extends BasePage {
     const spotVolume = (assetID: number, mkt: Market): number => {
       const spot = mkt.spot
       if (!spot) return 0
-      return assetID === mkt.baseid ? spot.vol24 : spot.vol24 * spot.rate / OrderUtil.RateEncodingFactor
+      const conversionFactor = app().unitInfo(assetID).conventional.conversionFactor
+      const volume = assetID === mkt.baseid ? spot.vol24 : spot.vol24 * spot.rate / OrderUtil.RateEncodingFactor
+      return volume / conversionFactor
     }
 
     markets.sort((a: [string, Market], b: [string, Market]): number => {


### PR DESCRIPTION
The market volume displayed on the wallets page was not adjusted by the asset's conventional unit's conversion factor.

Closes #1834 