### PR TITLE
spec/comm: Update connect result.

### DIFF
--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -10,24 +10,8 @@ To get started using DCRDEX, see the [Client Installation and Configuration](htt
 
 ## Contribute changes to the wiki
 
-The following instructions assume that you have already forked **dcrdex**.
+1. Fork dcrdex repo.
 
-1. Initialize your forked wiki on github by navigating to the wiki tab of your forked **dcrdex** repo and clicking the "Create the first page" button. Be sure to "Save page" as well.
+2. Edit files in the docs/wiki directory.
 
-    <img src="images/wiki-creation.png" width="700">
-
-2. In your terminal, navigate to your local **dcrdex** directory and add your remote wiki.
-
-    ```sh
-    git remote add wiki https://github.com/your-username/dcrdex.wiki.git
-    git push wiki -d master
-    git subtree push --prefix docs/wiki wiki master
-    ```
-
-3. Now after committing changes to the files in the docs/wiki folder, you can apply them to your dcrdex wiki and view them immediately. Assuming you are in the root directory:
-
-    ```sh
-    git push wiki $(git subtree split --prefix docs/wiki):master --force
-    ```
-
-4. Make a pull request with your changes to dcrdex. They will make it to the main wiki eventually.
+3. Submit a PR. Your changes will eventually flow into our wiki pages.

--- a/spec/comm.mediawiki
+++ b/spec/comm.mediawiki
@@ -191,9 +191,23 @@ of their penalization.
 |-
 | matches || &#91;object&#93; || list of [[orders.mediawiki/#Match_negotiation|Match objects]]
 |-
-| penalty || object || a [[community.mediawiki/#Penalty_Object|Penalty Object]]. omitted if in good standing
+| order statuses || <nowiki>[object]</nowiki> || list of <code>Order Status Object</code>
 |-
-| sig     || string || hex-encoded server's signature of the serialized connection data
+| score || int || The user's score. The math behind this is currently being adjusted
+|-
+| suspended || bool || true if suspended. will be deprecated in a future version
+|-
+| sig || string || hex-encoded server's signature of the serialized connection data
+|}
+
+'''Order Status Object'''
+
+{|
+! field !! type !! description
+|-
+| ID || bytes || a unique order id
+|-
+| Status || int || the order status. See [[https://github.com/decred/dcrdex/blob/master/dex/order/status.go|status.go]] for statuses.
 |}
 
 ==HTTP==


### PR DESCRIPTION
    spec/comm: Update connect result.

    wiki: Simplify contribution instructions.

part of #1641

comm page can be viewed at https://github.com/JoeGruffins/dcrdex/blob/wikihelplesshelpful/spec/comm.mediawiki