### PR TITLE
site: reject invalid address for send or withdraw tx

### DIFF
--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -281,4 +281,5 @@ var EnUS = map[string]string{
 	"disable_wallet_warning":      "Note: This wallet will not be connected to when you start the DEX client software and cannot be used until it is enabled.",
 	"enable_wallet_message":       "This wallet will resume operation and might take some time to sync.",
 	"Disabled":                    "Disabled",
+	"txfee_not_available":         "Transaction fee currently unavailable",
 }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -270,7 +270,6 @@ var EnUS = map[string]string{
 	"max_estimated_send_fee":      "Max Estimated Send Fee",
 	"sending":                     "Sending",
 	"transfer":                    "Transfer",
-	"invalid_address":             "Note: Provide a valid address.",
 	"max_estimated_send_tooltip":  "This is the estimated amount that will be received if you withdraw your current balance with 'Subtract fees from amount sent' checked. If there is no subtract fee checkbox, this is the maximum estimated amount you can send.",
 	"Maker Swap":                  "Maker Swap",
 	"Taker Swap":                  "Taker Swap",

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=GHTDFVH710" rel="stylesheet">
+  <link href="/css/style.css?v=GHDH71x" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -87,7 +87,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GHTDFVH710"></script>
+<script src="/js/entry.js?v=GHDH71x"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -311,7 +311,6 @@
       <span class="d-flex d-hide justify-content-end grey fs14">
        ~<span id="balanceAfterSendFiat" class="mx-1"></span>USD
       </span>
-      <div class="fs14  errcolor mt-3" id="vSendAddrMsg">[[[invalid_address]]]</div>
       <hr class="dashed my-4">
        <div class="fs16 px-4 text-center">[[[Authorize the transfer with your app password.]]]</div>
         <div class="input-group mt-2">

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -231,7 +231,7 @@
       <div class="mt-3">
         <label for="sendAddr" class="form-label ps-1 mb-1">[[[Address]]]</label>
         <div class="d-flex">
-         <input type="text" class="form-control col-1 select" id="sendAddr">
+         <input type="text" class="form-control col-1 select" id="sendAddr" spellcheck="false">
          <span id="validAddr" class="ico-check mx-2 pt-2 d-hide"></span>
         </div>
       </div>
@@ -292,25 +292,30 @@
       <div class="text-center">[[[to]]]</div>
       <div id="vSendAddr" class="text-center font-weight-bold"></div>
       <hr class="dashed mt-2">
-      <div class="d-flex align-items-center justify-content-between">[[[estimated_fee]]]: 
-       <span id="vSendFee"></span>
+      <div id="vSendEstimates" class="d-hide">
+        <div class="d-flex align-items-center justify-content-between">[[[estimated_fee]]]: 
+         <span id="vSendFee"></span>
+        </div>
+        <span class="d-flex d-hide justify-content-end grey fs14">
+         ~<span id="vSendFeeFiat" class="mx-1"></span>USD
+        </span>
+        <hr class="dashed mt-2">
+        <div class="d-flex align-items-center justify-content-between">[[[estimated_total_spend]]]: 
+         <span id="vTotalSend"></span>
+        </div>
+        <span class="d-flex d-hide justify-content-end grey fs14">
+         ~<span id="vTotalSendFiat" class="mx-1"></span>USD
+        </span>
+        <div class="d-flex align-items-center justify-content-between">[[[estimated_balance]]]: 
+         <span id="balanceAfterSend"></span>
+        </div>
+        <span class="d-flex d-hide justify-content-end grey fs14">
+         ~<span id="balanceAfterSendFiat" class="mx-1"></span>USD
+        </span>
       </div>
-      <span class="d-flex d-hide justify-content-end grey fs14">
-       ~<span id="vSendFeeFiat" class="mx-1"></span>USD
-      </span>
-      <hr class="dashed mt-2">
-      <div class="d-flex align-items-center justify-content-between">[[[estimated_total_spend]]]: 
-       <span id="vTotalSend"></span>
+      <div id="txFeeNotAvailable" class="d-hide" data-tooltip="Fee unavailable">[[[txfee_not_available]]]
+        <span class="ico-info errcolor"></span>
       </div>
-      <span class="d-flex d-hide justify-content-end grey fs14">
-       ~<span id="vTotalSendFiat" class="mx-1"></span>USD
-      </span>
-      <div class="d-flex align-items-center justify-content-between">[[[estimated_balance]]]: 
-       <span id="balanceAfterSend"></span>
-      </div>
-      <span class="d-flex d-hide justify-content-end grey fs14">
-       ~<span id="balanceAfterSendFiat" class="mx-1"></span>USD
-      </span>
       <hr class="dashed my-4">
        <div class="fs16 px-4 text-center">[[[Authorize the transfer with your app password.]]]</div>
         <div class="input-group mt-2">

--- a/client/webserver/site/src/js/locales.ts
+++ b/client/webserver/site/src/js/locales.ts
@@ -67,6 +67,8 @@ export const ID_FEE_BALANCE = 'FEE_BALANCE'
 export const ID_CANDLES_LOADING = 'CANDLES_LOADING'
 export const ID_DEPTH_LOADING = 'DEPTH_LOADING'
 export const ID_INVALID_ADDRESS_MSG = 'INVALID_ADDRESS_MSG'
+export const ID_TXFEE_UNSUPPORTED = 'TXFEE_UNSUPPORTED'
+export const ID_TXFEE_ERR_MSG = 'TXFEE_ERR_MSG'
 
 export const enUS: Locale = {
   [ID_NO_PASS_ERROR_MSG]: 'password cannot be empty',
@@ -135,7 +137,9 @@ export const enUS: Locale = {
   [ID_FEE_BALANCE]: 'fee balance',
   [ID_CANDLES_LOADING]: 'waiting for candlesticks',
   [ID_DEPTH_LOADING]: 'retrieving depth data',
-  [ID_INVALID_ADDRESS_MSG]: 'Invalid address: {{ address }}'
+  [ID_INVALID_ADDRESS_MSG]: 'invalid address: {{ address }}',
+  [ID_TXFEE_UNSUPPORTED]: 'fee estimation is not supported for this wallet type',
+  [ID_TXFEE_ERR_MSG]: 'fee estimation failed: {{ err }}'
 }
 
 export const ptBR: Locale = {

--- a/client/webserver/site/src/js/locales.ts
+++ b/client/webserver/site/src/js/locales.ts
@@ -66,6 +66,7 @@ export const ID_IMMATURE = 'IMMATURE'
 export const ID_FEE_BALANCE = 'FEE_BALANCE'
 export const ID_CANDLES_LOADING = 'CANDLES_LOADING'
 export const ID_DEPTH_LOADING = 'DEPTH_LOADING'
+export const ID_INVALID_ADDRESS_MSG = 'INVALID_ADDRESS_MSG'
 
 export const enUS: Locale = {
   [ID_NO_PASS_ERROR_MSG]: 'password cannot be empty',
@@ -133,7 +134,8 @@ export const enUS: Locale = {
   [ID_IMMATURE]: 'immature',
   [ID_FEE_BALANCE]: 'fee balance',
   [ID_CANDLES_LOADING]: 'waiting for candlesticks',
-  [ID_DEPTH_LOADING]: 'retrieving depth data'
+  [ID_DEPTH_LOADING]: 'retrieving depth data',
+  [ID_INVALID_ADDRESS_MSG]: 'Invalid address: {{ address }}'
 }
 
 export const ptBR: Locale = {


### PR DESCRIPTION
Quoting @chappjc.
>At least something. You could argue fully validated address, but really it should not go to confirm for an empty address because that's obviously crazy
Sorry, I know we've been over this, but in testing all the assets' Send functionality, this really stuck out as bad UX.  (Says "Provide a valid address" on the "Confirm" form where it's too late to provide a valid address, so you have to cancel and go back.  So why does not just just stop you from getting to "Confirm"?)

This address a UI concern and the issue on the image below.
I was trying to simulate ZEC's edge case with BCH and noticed send amount was not displayed properly.
<img width="397" alt="Screenshot 2022-09-07 at 3 48 42 PM" src="https://user-images.githubusercontent.com/57448127/188915431-4c10556c-734c-41bf-ace7-a364ff6e955a.png">
