### PR TITLE
client: No hide header when having additional settings

### DIFF
--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -87,8 +87,6 @@ export class NewWalletForm {
     // WalletConfigForm will set the global app variable.
     this.subform = new WalletConfigForm(page.walletSettings, true)
 
-    Doc.bind(this.subform.showOther, 'click', () => Doc.show(page.walletSettingsHeader))
-
     bind(form, page.submitAdd, () => this.submit())
     bind(form, page.oneBttn, () => this.submit())
 
@@ -316,6 +314,8 @@ export class NewWalletForm {
     const noWalletPWNeeded = walletDef.seeded || Boolean(this.current.asset.token)
     if (appPwCached && noWalletPWNeeded) {
       Doc.show(page.oneBttnBox)
+      // no required configuration for wallet.
+      Doc.hide(page.walletSettingsHeader)
     } else if (noWalletPWNeeded) {
       Doc.show(page.auth)
       page.newWalletPass.value = ''
@@ -335,7 +335,7 @@ export class NewWalletForm {
       })
     } else this.subform.update(configOpts, {})
 
-    if (this.subform.dynamicOpts.children.length) Doc.show(page.walletSettingsHeader)
+    if (this.subform.dynamicOpts.attributes.length) Doc.show(page.walletSettingsHeader)
     else Doc.hide(page.walletSettingsHeader)
     // A seeded or token wallet is internal to the dex client and as such does
     // not have an external config file to select.

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -335,7 +335,9 @@ export class NewWalletForm {
       })
     } else this.subform.update(configOpts, {})
 
-    if (this.subform.dynamicOpts.attributes.length) Doc.show(page.walletSettingsHeader)
+    if (this.subform.dynamicOpts.children.length || this.subform.defaultSettings.children.length) {
+        Doc.show(page.walletSettingsHeader)
+    }
     else Doc.hide(page.walletSettingsHeader)
     // A seeded or token wallet is internal to the dex client and as such does
     // not have an external config file to select.

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -314,8 +314,6 @@ export class NewWalletForm {
     const noWalletPWNeeded = walletDef.seeded || Boolean(this.current.asset.token)
     if (appPwCached && noWalletPWNeeded) {
       Doc.show(page.oneBttnBox)
-      // no required configuration for wallet.
-      Doc.hide(page.walletSettingsHeader)
     } else if (noWalletPWNeeded) {
       Doc.show(page.auth)
       page.newWalletPass.value = ''

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -336,9 +336,8 @@ export class NewWalletForm {
     } else this.subform.update(configOpts, {})
 
     if (this.subform.dynamicOpts.children.length || this.subform.defaultSettings.children.length) {
-        Doc.show(page.walletSettingsHeader)
-    }
-    else Doc.hide(page.walletSettingsHeader)
+      Doc.show(page.walletSettingsHeader)
+    } else Doc.hide(page.walletSettingsHeader)
     // A seeded or token wallet is internal to the dex client and as such does
     // not have an external config file to select.
     if (walletDef.seeded || Boolean(this.current.asset.token)) Doc.hide(this.subform.fileSelector)


### PR DESCRIPTION
This PR is build on top of #1841

This PR is based in this matrix chat: https://matrix.to/#/!SFRQQFIHUUNXARfvew:decred.org/$Yy4D-nIYqum6RkurYGH6RDPz3WnvbzRBh85xZjow06o?via=decred.org&via=matrix.org&via=planetdecred.org

Where @chappjc mentioned the `Wallet Settings` header appearing and not disappearing was a small bug, but later said he feels like it should always show, when availble. 

I think that's reasonable, so this PR removes hiding the wallet settings header. The wallet setting header starts as hided. It will always show, if available. 

New behavior: 

![Peek 14-09-2022 16-42](https://user-images.githubusercontent.com/15069783/190247580-be738c51-7468-4d62-a915-5ae4e0dce8fe.gif)