### PR TITLE
dex: use spec defined epoch duration if provided value is not valid

### DIFF
--- a/dex/market.go
+++ b/dex/market.go
@@ -9,6 +9,12 @@ import (
 	"strings"
 )
 
+const (
+	// defaultEpochDuration is the spec defined default markets epoch duration
+	// in milliseconds.
+	defaultEpochDuration uint64 = 60000
+)
+
 // MarketInfo specifies a market that the Archiver must support.
 type MarketInfo struct {
 	Name                   string
@@ -53,6 +59,12 @@ func NewMarketInfo(base, quote uint32, lotSize, rateStep, epochDuration uint64, 
 	if err != nil {
 		return nil, err
 	}
+
+	// Check for sensible epoch duration.
+	if epochDuration <= 0 {
+		epochDuration = defaultEpochDuration
+	}
+
 	return &MarketInfo{
 		Name:                   name,
 		Base:                   base,
@@ -80,6 +92,11 @@ func NewMarketInfoFromSymbols(base, quote string, lotSize, rateStep, epochDurati
 	quoteID, found := BipSymbolID(quote)
 	if !found {
 		return nil, fmt.Errorf(`quote asset symbol "%s" unrecognized`, quote)
+	}
+
+	// Check for sensible epoch duration.
+	if epochDuration <= 0 {
+		epochDuration = defaultEpochDuration
 	}
 
 	return &MarketInfo{

--- a/dex/market.go
+++ b/dex/market.go
@@ -12,7 +12,7 @@ import (
 const (
 	// defaultEpochDuration is the spec defined default markets epoch duration
 	// in milliseconds.
-	defaultEpochDuration uint64 = 60000
+	defaultEpochDuration uint64 = 20000
 )
 
 // MarketInfo specifies a market that the Archiver must support.
@@ -61,7 +61,7 @@ func NewMarketInfo(base, quote uint32, lotSize, rateStep, epochDuration uint64, 
 	}
 
 	// Check for sensible epoch duration.
-	if epochDuration <= 0 {
+	if epochDuration == 0 {
 		epochDuration = defaultEpochDuration
 	}
 
@@ -95,7 +95,7 @@ func NewMarketInfoFromSymbols(base, quote string, lotSize, rateStep, epochDurati
 	}
 
 	// Check for sensible epoch duration.
-	if epochDuration <= 0 {
+	if epochDuration == 0 {
 		epochDuration = defaultEpochDuration
 	}
 

--- a/spec/admin.mediawiki
+++ b/spec/admin.mediawiki
@@ -16,7 +16,7 @@ possible.
 {|
 ! variable !! relevant section !! units || default
 |-
-| epoch&nbsp;duration || [[fundamentals.mediawiki/#Epochbased_Order_Matching|Epoch-based Order Matching]] || milliseconds || 60,000
+| epoch&nbsp;duration || [[fundamentals.mediawiki/#Epochbased_Order_Matching|Epoch-based Order Matching]] || milliseconds || 20,000
 |-
 | market&nbsp;buy&nbsp;buffer || [[orders.mediawiki/#Market_Buy_Orders|Market Buy Orders]] || unitless ratio || 1.25
 |-


### PR DESCRIPTION
This diff ensures a market's epoch duration is set to the [spec-defined epoch duration](https://github.com/decred/dcrdex/blob/master/spec/admin.mediawiki#exchange-variables) if the config epoch duration is invalid. Closes #300.