### PR TITLE
client: fix typos and remove unused newDisplayID func

### DIFF
--- a/client/asset/btc/livetest/regnet_test.go
+++ b/client/asset/btc/livetest/regnet_test.go
@@ -99,7 +99,7 @@ func TestWallet(t *testing.T) {
 		}
 
 		// TODO: Randomize the address scope passed to
-		// btcwallet.Wallet.{NewAddres, NewChangeAddress} between
+		// btcwallet.Wallet.{NewAddress, NewChangeAddress} between
 		// waddrmgr.KeyScopeBIP0084 and waddrmgr.KeyScopeBIP0044 so that we
 		// know we can handle non-segwit previous outpoints too.
 		if err := loadAddress(addr); err != nil {

--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -408,7 +408,7 @@ func (c *tokenContractorV0) estimateApproveGas(ctx context.Context, amount *big.
 	return c.estimateGas(ctx, "approve", c.contractAddr, amount)
 }
 
-// estimateTransferGas esimates the gas needed for a transfer tx. The account
+// estimateTransferGas estimates the gas needed for a transfer tx. The account
 // needs to have > amount tokens to use this method.
 func (c *tokenContractorV0) estimateTransferGas(ctx context.Context, amount *big.Int) (uint64, error) {
 	return c.estimateGas(ctx, "transfer", c.acctAddr, amount)

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -530,10 +530,10 @@ func getWalletDir(dataDir string, network dex.Network) string {
 	return filepath.Join(dataDir, network.String())
 }
 
-func (eth *ETHWallet) shutdown() {
-	eth.node.shutdown()
-	if err := eth.monitoredTxDB.Close(); err != nil {
-		eth.log.Errorf("error closing tx db: %v", err)
+func (w *ETHWallet) shutdown() {
+	w.node.shutdown()
+	if err := w.monitoredTxDB.Close(); err != nil {
+		w.log.Errorf("error closing tx db: %v", err)
 	}
 }
 

--- a/client/asset/eth/fundingcoin.go
+++ b/client/asset/eth/fundingcoin.go
@@ -120,8 +120,8 @@ func decodeTokenFundingCoin(coinID []byte) (*tokenFundingCoin, error) {
 	}, nil
 }
 
-// createTokenFundingCoin constructs a new fundingtokenFundingCoinCoin for the provided account
-// address, value, and fees in gwei.
+// createTokenFundingCoin constructs a new tokenFundingCoin for the provided
+// account address, value, and fees in gwei.
 func createTokenFundingCoin(address common.Address, tokenValue, fees uint64) *tokenFundingCoin {
 	return &tokenFundingCoin{
 		addr: address,

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -582,7 +582,7 @@ type AccountLocker interface {
 	ReReserveRefund(uint64) error
 	// UnlockRefundReserves is used to return funds reserved for refunds
 	// when an order was cancelled or revoked before a swap was initiated,
-	// completed successully, or after a refund was done.
+	// completed successfully, or after a refund was done.
 	UnlockRefundReserves(uint64)
 }
 

--- a/client/cmd/dexc/log.go
+++ b/client/cmd/dexc/log.go
@@ -28,7 +28,7 @@ func (w logWriter) Write(p []byte) (n int, err error) {
 	return logRotator.Write(p)
 }
 
-// initLogging initializes the logging rotater to write logs to logFile and
+// initLogging initializes the logging rotator to write logs to logFile and
 // create roll files in the same directory. initLogging must be called before
 // the package-global log rotator variables are used.
 func initLogging(lvl string, utc bool) *dex.LoggerMaker {

--- a/client/core/errors.go
+++ b/client/core/errors.go
@@ -8,8 +8,7 @@ import (
 	"fmt"
 )
 
-// errors used on client/webserver/site/js/constants.js
-// need to be careful for not going out of sync.
+// Error codes here are used on the frontend.
 const (
 	walletErr = iota
 	walletAuthErr

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -120,7 +120,7 @@ type Notification interface {
 	// Type is a string ID unique to the concrete type.
 	Type() string
 	// Topic is a string ID unique to the message subject. Since subjects must
-	// be translated, we cannot rely on the subject to programatically identify
+	// be translated, we cannot rely on the subject to programmatically identify
 	// the message.
 	Topic() Topic
 	// Subject is a short description of the notification contents. When displayed

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -535,11 +535,6 @@ type Exchange struct {
 	CandleDurs       []string               `json:"candleDurs"`
 }
 
-// newDisplayID creates a display-friendly market ID for a base/quote ID pair.
-func newDisplayID(base, quote uint32) string {
-	return newDisplayIDFromSymbols(unbip(base), unbip(quote))
-}
-
 // newDisplayIDFromSymbols creates a display-friendly market ID for a base/quote
 // symbol pair.
 func newDisplayIDFromSymbols(base, quote string) string {
@@ -794,7 +789,7 @@ func (a *dexAccount) feePending() bool {
 	return !a.isPaid && len(a.feeCoin) > 0
 }
 
-// feePaid returns true if the account regisration fee has been accepted by the
+// feePaid returns true if the account registration fee has been accepted by the
 // DEX.
 func (a *dexAccount) feePaid() bool {
 	a.authMtx.RLock()

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -20,7 +20,7 @@ import (
 // runWithTimeout runs the provided function, returning either the error from
 // the function or errTimeout if the function fails to return within the
 // timeout. This function is for wallet methods that may not have a context or
-// timeout of their own, or we simply cannot rely on thirdparty packages to
+// timeout of their own, or we simply cannot rely on third party packages to
 // respect context cancellation or deadlines.
 func runWithTimeout(f func() error, timeout time.Duration) error {
 	errChan := make(chan error, 1)

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -1999,7 +1999,7 @@ func orderSide(tx *bbolt.Tx, oid order.OrderID) (sell bool, err error) {
 }
 
 // DeleteInactiveMatches deletes matches that are no longer needed for normal
-// operations. Optionally accepts a time to delete matchess with a later time
+// operations. Optionally accepts a time to delete matches with a later time
 // stamp. Accepts an optional function to perform on deleted matches.
 func (db *BoltDB) DeleteInactiveMatches(ctx context.Context, olderThan *time.Time,
 	perMatchFn func(mtch *dexdb.MetaMatch, isSell bool) error) error {

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -1371,7 +1371,7 @@ func TestDeleteInactiveMatches(t *testing.T) {
 	}
 	numLeft := numNewer + numActiveOrdWithMtch
 	if numArchivedMatches != numLeft {
-		t.Fatalf("expected %d acrchived matches left after deletion but got %d", numLeft, numArchivedMatches)
+		t.Fatalf("expected %d archived matches left after deletion but got %d", numLeft, numArchivedMatches)
 	}
 }
 
@@ -1519,7 +1519,7 @@ func TestDeleteInactiveOrders(t *testing.T) {
 		t.Fatalf("error getting active orders: %v", err)
 	}
 	if len(activeOrders) != numActive {
-		t.Fatalf("expected %d active orcers, got %d", numActive, len(activeOrders))
+		t.Fatalf("expected %d active orders, got %d", numActive, len(activeOrders))
 	}
 
 	// Matches occurring after stamp or part of an active match should be
@@ -1537,7 +1537,7 @@ func TestDeleteInactiveOrders(t *testing.T) {
 	}
 	numUntouched := numNewer + numActiveMtchWithOrd
 	if numArchivedOrders != numUntouched {
-		t.Fatalf("expected %d acrchived orders left after deletion but got %d", numUntouched, numArchivedOrders)
+		t.Fatalf("expected %d archived orders left after deletion but got %d", numUntouched, numArchivedOrders)
 	}
 }
 

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -346,7 +346,7 @@ func handleRegister(s *RPCServer, params *RawParams) *msgjson.ResponsePayload {
 	return createResponse(registerRoute, res, nil)
 }
 
-// handleExchanges handles requests for exchangess. It takes no arguments and
+// handleExchanges handles requests for exchanges. It takes no arguments and
 // returns a map of exchanges.
 func handleExchanges(s *RPCServer, _ *RawParams) *msgjson.ResponsePayload {
 	// Convert something to a map[string]interface{}.
@@ -363,7 +363,7 @@ func handleExchanges(s *RPCServer, _ *RawParams) *msgjson.ResponsePayload {
 	}
 	res := s.core.Exchanges()
 	exchanges := convM(res)
-	// Interate through exchanges converting structs into maps in order to
+	// Iterate through exchanges converting structs into maps in order to
 	// remove some fields. Keys are DEX addresses.
 	for k, exchange := range exchanges {
 		exchangeDetails := convM(exchange)
@@ -614,7 +614,7 @@ func parseCoreOrder(co *core.Order, b, q uint32) *myOrder {
 		TimeInForce: co.TimeInForce.String(),
 	}
 
-	// Parese matches & calculate settled value
+	// Parse matches & calculate settled value
 	o.Matches, o.Settled = parseMatches(co.Matches)
 
 	return o

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -229,7 +229,7 @@ var EnUS = map[string]string{
 	"early_acceleration_help_msg": `It will cause no harm to your order, but you might be wasting money. Acceleration is only helpful if the fee rate on an existing unconfirmed transaction has become too low to be mined in the next block, but not if blocks are just being mined slowly. You can confirm this in the block explorer by closing this popup and clicking on your previous transactions.`,
 	"recover":                     "Recover",
 	"recover_wallet":              "Recover Wallet",
-	"recover_warning":             "Recovering your wallet will move all wallet data to a backup folder. You will have to wait until the wallet resyncs with the network, which could potentially take a long time, before you can use the wallet again.",
+	"recover_warning":             "Recovering your wallet will move all wallet data to a backup folder. You will have to wait until the wallet syncs with the network, which could potentially take a long time, before you can use the wallet again.",
 	"wallet_actively_used":        "Wallet actively used!",
 	"confirm_force_message":       "This wallet is actively managing orders. After taking this action, it will take a long time to resync your wallet, potentially causing orders to fail. Only take this action if absolutely necessary!",
 	"confirm":                     "Confirm",

--- a/client/webserver/site/src/js/charts.ts
+++ b/client/webserver/site/src/js/charts.ts
@@ -218,7 +218,7 @@ class Chart {
 
   /*
    * resize updates the chart size. The parentHeight is an argument to support
-   * updating the height programatically after the caller sets a style.height
+   * updating the height programmatically after the caller sets a style.height
    * but before the clientHeight has been updated.
    */
   resize (parentHeight: number) {

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -1240,7 +1240,7 @@ export class AccelerateOrderForm {
     Doc.show(page.earlyAccelerationDiv)
   }
 
-  // sendAccelerateRequest makes an accelerateorder request to the client
+  // sendAccelerateRequest makes an accelerate order request to the client
   // backend.
   async sendAccelerateRequest () {
     const order = this.order
@@ -1306,8 +1306,8 @@ export class AccelerateOrderForm {
     this.updateAccelerationEstimate()
   }
 
-  // updateAccelerationEstimate makes an accelerateestimate request to the
-  // client backend using the curretly selected rate on the slider, and
+  // updateAccelerationEstimate makes an accelerate estimate request to the
+  // client backend using the currently selected rate on the slider, and
   // displays the results.
   async updateAccelerationEstimate () {
     const page = this.page
@@ -1601,7 +1601,7 @@ function isTruthyString (s: string) {
   return s === '1' || s.toLowerCase() === 'true'
 }
 
-// toUnixDate converts a javscript date object to a unix date, which is
+// toUnixDate converts a javascript date object to a unix date, which is
 // the number of *seconds* since the start of the epoch.
 function toUnixDate (date: Date) {
   return Math.floor(date.getTime() / 1000)

--- a/client/webserver/site/src/js/locales.ts
+++ b/client/webserver/site/src/js/locales.ts
@@ -58,8 +58,8 @@ export const ID_NEW_WALLET_SUCCESS = 'NEW_WALLET_SUCCESS'
 export const ID_WALLET_UNLOCKED = 'WALLET_UNLOCKED'
 export const ID_SELLING = 'ID_SELLING'
 export const ID_BUYING = 'ID_BUYING'
-export const ID_WALET_DISABLED_MSG = 'WALLET_DISABLED'
-export const ID_WALET_ENABLED_MSG = 'WALLET_ENABLED'
+export const ID_WALLET_DISABLED_MSG = 'WALLET_DISABLED'
+export const ID_WALLET_ENABLED_MSG = 'WALLET_ENABLED'
 export const ID_ACTIVE_ORDERS_ERR_MSG = 'ACTIVE_ORDERS_ERR_MSG'
 
 export const enUS: Locale = {
@@ -120,8 +120,8 @@ export const enUS: Locale = {
   [ID_WALLET_UNLOCKED]: 'Wallet Unlocked',
   [ID_SELLING]: 'Selling',
   [ID_BUYING]: 'Buying',
-  [ID_WALET_ENABLED_MSG]: '{{ assetName }} Wallet Enabled',
-  [ID_WALET_DISABLED_MSG]: '{{ assetName }} Wallet Disabled',
+  [ID_WALLET_ENABLED_MSG]: '{{ assetName }} Wallet Enabled',
+  [ID_WALLET_DISABLED_MSG]: '{{ assetName }} Wallet Disabled',
   [ID_DISABLED_MSG]: 'wallet is disabled',
   [ID_ACTIVE_ORDERS_ERR_MSG]: '{{ assetName }} wallet is actively managing orders'
 }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1475,7 +1475,7 @@ export default class MarketsPage extends BasePage {
         const received = order.sell ? order.qty * gap : order.qty / gap
         page.vmToTotal.textContent = Doc.formatCoinValue(received, toAsset.unitInfo)
         page.vmToAsset.textContent = toAsset.symbol.toUpperCase()
-        // Format recieved value to fiat equivalent.
+        // Format received value to fiat equivalent.
         this.showFiatValue(toAsset.id, received, page.vmTotalFiat)
       } else {
         Doc.hide(page.vMarketEstimate)

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -356,8 +356,8 @@ export default class WalletsPage extends BasePage {
       return
     }
 
-    let successMsg = intl.prep(intl.ID_WALET_DISABLED_MSG, fmtParams)
-    if (!disable) successMsg = intl.prep(intl.ID_WALET_ENABLED_MSG, fmtParams)
+    let successMsg = intl.prep(intl.ID_WALLET_DISABLED_MSG, fmtParams)
+    if (!disable) successMsg = intl.prep(intl.ID_WALLET_ENABLED_MSG, fmtParams)
     this.assetUpdated(this.selectedAssetID, page.toggleWalletStatusConfirm, successMsg)
   }
 

--- a/client/webserver/site/src/js/ws.ts
+++ b/client/webserver/site/src/js/ws.ts
@@ -1,4 +1,4 @@
-// MessageSocket is a WebSocket manager that uses the Decred DEX Mesage format
+// MessageSocket is a WebSocket manager that uses the Decred DEX Message format
 // for communications.
 //
 // Message request format:

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -80,7 +80,7 @@ type openWalletForm struct {
 	Pass    encode.PassBytes `json:"pass"` // Application password.
 }
 
-// walletStatusForm is information neccessary to change a wallet's status.
+// walletStatusForm is information necessary to change a wallet's status.
 type walletStatusForm struct {
 	AssetID uint32 `json:"assetID"`
 	Disable bool   `json:"disable"`

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -53,29 +53,29 @@ func (c *tCoin) Confirmations(context.Context) (uint32, error) {
 }
 
 type TCore struct {
-	balanceErr       error
-	syncFeed         core.BookFeed
-	syncErr          error
-	regErr           error
-	loginErr         error
-	logoutErr        error
-	initErr          error
-	isInited         bool
-	getDEXConfigErr  error
-	createWalletErr  error
-	openWalletErr    error
-	closeWalletErr   error
-	rescannWalletErr error
-	sendErr          error
-	notHas           bool
-	notRunning       bool
-	notOpen          bool
-	rateSourceErr    error
-	estFee           uint64
-	estFeeErr        error
-	validAddr        bool
-	walletDisabled   bool
-	walletStatusErr  error
+	balanceErr      error
+	syncFeed        core.BookFeed
+	syncErr         error
+	regErr          error
+	loginErr        error
+	logoutErr       error
+	initErr         error
+	isInited        bool
+	getDEXConfigErr error
+	createWalletErr error
+	openWalletErr   error
+	closeWalletErr  error
+	rescanWalletErr error
+	sendErr         error
+	notHas          bool
+	notRunning      bool
+	notOpen         bool
+	rateSourceErr   error
+	estFee          uint64
+	estFeeErr       error
+	validAddr       bool
+	walletDisabled  bool
+	walletStatusErr error
 }
 
 func (c *TCore) Network() dex.Network                         { return dex.Mainnet }
@@ -122,7 +122,7 @@ func (c *TCore) WalletState(assetID uint32) *core.WalletState {
 func (c *TCore) CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error {
 	return c.createWalletErr
 }
-func (c *TCore) RescanWallet(assetID uint32, force bool) error    { return c.rescannWalletErr }
+func (c *TCore) RescanWallet(assetID uint32, force bool) error    { return c.rescanWalletErr }
 func (c *TCore) OpenWallet(assetID uint32, pw []byte) error       { return c.openWalletErr }
 func (c *TCore) CloseWallet(assetID uint32) error                 { return c.closeWalletErr }
 func (c *TCore) ConnectWallet(assetID uint32) error               { return nil }
@@ -754,8 +754,8 @@ func TestAPI_ToggleRatesource(t *testing.T) {
 	}{{
 		name:    "Invalid rate source",
 		source:  "binance",
-		wantErr: errors.New("cannot enable unkown fiat rate source"),
-		want:    `{"ok":false,"msg":"cannot enable unkown fiat rate source"}`,
+		wantErr: errors.New("cannot enable unknown fiat rate source"),
+		want:    `{"ok":false,"msg":"cannot enable unknown fiat rate source"}`,
 	}, {
 		name:   "ok valid source",
 		source: "dcrdata",
@@ -782,8 +782,8 @@ func TestAPI_ToggleRatesource(t *testing.T) {
 	}{{
 		name:    "Invalid rate source",
 		source:  "binance",
-		wantErr: errors.New("cannot disable unkown fiat rate source"),
-		want:    `{"ok":false,"msg":"cannot disable unkown fiat rate source"}`,
+		wantErr: errors.New("cannot disable unknown fiat rate source"),
+		want:    `{"ok":false,"msg":"cannot disable unknown fiat rate source"}`,
 	}, {
 		name:   "ok valid source",
 		source: "Messari",


### PR DESCRIPTION
This diff fixes some `client` typos and removes unused newDisplayID func.