### PR TITLE
multi: encode recent matches to preserve order

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -193,7 +193,7 @@ func (b *bookie) logEpochReport(note *msgjson.EpochReportNote) error {
 
 	marketID := marketName(b.base, b.quote)
 	matchSummaries := b.AddRecentMatches(note.MatchSummary, note.EndStamp)
-	if note.MatchSummary != nil && len(note.MatchSummary) > 0 {
+	if len(note.MatchSummary) > 0 {
 		b.send(&BookUpdate{
 			Action:   EpochMatchSummary,
 			MarketID: marketID,

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -192,13 +192,12 @@ func (b *bookie) logEpochReport(note *msgjson.EpochReportNote) error {
 	}
 
 	marketID := marketName(b.base, b.quote)
-	b.SetMatchesSummary(note.MatchesSummarySell, note.EndStamp, true)
-	b.SetMatchesSummary(note.MatchesSummaryBuy, note.EndStamp, false)
-	if note.MatchesSummaryBuy != nil || note.MatchesSummarySell != nil {
+	matchSummaries := b.AddRecentMatches(note.MatchSummary, note.EndStamp)
+	if note.MatchSummary != nil && len(note.MatchSummary) > 0 {
 		b.send(&BookUpdate{
 			Action:   EpochMatchSummary,
 			MarketID: marketID,
-			Payload:  b.GetMatchesSummary(),
+			Payload:  matchSummaries,
 		})
 	}
 	for durStr, cache := range b.candleCaches {
@@ -365,9 +364,10 @@ func (b *bookie) send(u *BookUpdate) {
 func (b *bookie) book() *OrderBook {
 	buys, sells, epoch := b.Orders()
 	return &OrderBook{
-		Buys:  b.translateBookSide(buys),
-		Sells: b.translateBookSide(sells),
-		Epoch: b.translateBookSide(epoch),
+		Buys:          b.translateBookSide(buys),
+		Sells:         b.translateBookSide(sells),
+		Epoch:         b.translateBookSide(epoch),
+		RecentMatches: b.RecentMatches(),
 	}
 }
 
@@ -911,7 +911,7 @@ func (dc *dexConnection) refreshServerConfig() error {
 
 	assets, epochs, err := generateDEXMaps(dc.acct.host, cfg)
 	if err != nil {
-		return fmt.Errorf("Inconsistent 'config' response: %w", err)
+		return fmt.Errorf("inconsistent 'config' response: %w", err)
 	}
 
 	// Update dc.{marketMap,epoch,assets}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -13,6 +13,7 @@ import (
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/comms"
 	"decred.org/dcrdex/client/db"
+	"decred.org/dcrdex/client/orderbook"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
 	"decred.org/dcrdex/dex/candles"
@@ -572,6 +573,8 @@ type OrderBook struct {
 	Sells []*MiniOrder `json:"sells"`
 	Buys  []*MiniOrder `json:"buys"`
 	Epoch []*MiniOrder `json:"epoch"`
+	// RecentMatches is a cache of up to 100 recent matches for a market.
+	RecentMatches []*orderbook.MatchSummary `json:"recentMatches"`
 }
 
 // MarketOrderBook is used as the BookUpdate's Payload with the FreshBookAction.

--- a/client/orderbook/orderbook.go
+++ b/client/orderbook/orderbook.go
@@ -54,6 +54,9 @@ type rateSell struct {
 	sell bool
 }
 
+// MatchSummary summarizes one or more consecutive matches at a given rate and
+// buy/sell direction. Consecutive matches of the same rate and direction are
+// binned by the server.
 type MatchSummary struct {
 	Rate  uint64 `json:"rate"`
 	Qty   uint64 `json:"qty"`
@@ -655,7 +658,7 @@ func (ob *OrderBook) AddRecentMatches(matches [][2]int64, ts uint64) []*MatchSum
 	return newMatches
 }
 
-// RecentMatches returns a deep copy of MatchesSummary
+// RecentMatches returns up to 100 recent matches, newest first.
 func (ob *OrderBook) RecentMatches() []*MatchSummary {
 	ob.matchSummaryMtx.Lock()
 	defer ob.matchSummaryMtx.Unlock()

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -8,7 +8,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=RQIW8192" rel="stylesheet">
+  <link href="/css/style.css?v=RQIW8193" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=RQIW8192"></script>
+<script src="/js/entry.js?v=RQIW8193"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -56,7 +56,6 @@ export interface Market {
   buybuffer: number
   orders: Order[]
   spot: Spot
-  recentmatches: RecentMatch[]
 }
 
 export interface Order {
@@ -319,7 +318,7 @@ export interface OrderNote extends CoreNote {
 export interface RecentMatch {
   rate: number
   qty: number
-  age: Date
+  stamp: number
   sell: boolean
 }
 
@@ -468,6 +467,7 @@ export interface CoreOrderBook {
   sells: MiniOrder[]
   buys: MiniOrder[]
   epoch: MiniOrder[]
+  recentMatches: RecentMatch[]
 }
 
 export interface MarketOrderBook {

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1177,9 +1177,9 @@ type EpochReportNote struct {
 	Epoch        uint64 `json:"epoch"`
 	BaseFeeRate  uint64 `json:"baseFeeRate"`
 	QuoteFeeRate uint64 `json:"quoteFeeRate"`
-	// quantity of matches by rate: [rate]qty
-	MatchesSummaryBuy  map[uint64]uint64 `json:"matchesSummaryBuy"`
-	MatchesSummarySell map[uint64]uint64 `json:"matchesSummarySell"`
+	// MatchSummary: [rate, quantity]. Quantity is signed. Negative means that
+	// the maker was a sell order.
+	MatchSummary [][2]int64 `json:"matchSummary"`
 	Candle
 }
 

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -104,14 +104,13 @@ type sigDataEpochOrder sigDataOrder
 type sigDataUpdateRemaining sigDataOrder
 
 type sigDataEpochReport struct {
-	epochIdx           int64
-	epochDur           int64
-	stats              *matcher.MatchCycleStats
-	spot               *msgjson.Spot
-	baseFeeRate        uint64
-	quoteFeeRate       uint64
-	matchesSummaryBuy  map[uint64]uint64
-	matchesSummarySell map[uint64]uint64
+	epochIdx     int64
+	epochDur     int64
+	stats        *matcher.MatchCycleStats
+	spot         *msgjson.Spot
+	baseFeeRate  uint64
+	quoteFeeRate uint64
+	matches      [][2]int64
 }
 
 type sigDataNewEpoch struct {
@@ -430,8 +429,7 @@ out:
 						StartRate:   stats.StartRate,
 						EndRate:     stats.EndRate,
 					},
-					MatchesSummaryBuy:  sigData.matchesSummaryBuy,
-					MatchesSummarySell: sigData.matchesSummarySell,
+					MatchSummary: sigData.matches,
 				}
 
 			case sigDataEpochOrder:

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -2589,18 +2589,23 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 		log.Errorf("Error updating API data collector: %v", err)
 	}
 
-	basicMatchesSell := make(map[uint64]uint64)
-	basicMatchesBuy := make(map[uint64]uint64)
+	matchReport := make([][2]int64, 0, len(matches)) // allocation almost certainly too low, but a good starting point.
+	var lastRate uint64
+	var lastSide bool
 	for _, matchSet := range matches {
 		for _, match := range matchSet.Matches() {
-			// skip cancel order types
-			if _, ok := match.Taker.(*order.CancelOrder); ok {
+			t := match.Taker.Trade()
+			if t == nil {
 				continue
 			}
-			if match.Taker.Trade() != nil && match.Taker.Trade().Sell {
-				basicMatchesSell[match.Rate] += match.Quantity
+			if match.Rate != lastRate || t.Sell != lastSide {
+				matchReport = append(matchReport, [2]int64{int64(match.Rate), 0})
+				lastRate, lastSide = match.Rate, t.Sell
+			}
+			if t.Sell {
+				matchReport[len(matchReport)-1][1] += int64(match.Quantity)
 			} else {
-				basicMatchesBuy[match.Rate] += match.Quantity
+				matchReport[len(matchReport)-1][1] -= int64(match.Quantity)
 			}
 		}
 	}
@@ -2608,14 +2613,13 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 	notifyChan <- &updateSignal{
 		action: epochReportAction,
 		data: sigDataEpochReport{
-			epochIdx:           epoch.Epoch,
-			epochDur:           epoch.Duration,
-			spot:               spot,
-			stats:              stats,
-			baseFeeRate:        feeRateBase,
-			quoteFeeRate:       feeRateQuote,
-			matchesSummaryBuy:  basicMatchesBuy,
-			matchesSummarySell: basicMatchesSell,
+			epochIdx:     epoch.Epoch,
+			epochDur:     epoch.Duration,
+			spot:         spot,
+			stats:        stats,
+			baseFeeRate:  feeRateBase,
+			quoteFeeRate: feeRateQuote,
+			matches:      matchReport,
 		},
 	}
 

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -2589,7 +2589,7 @@ func (m *Market) processReadyEpoch(epoch *readyEpoch, notifyChan chan<- *updateS
 		log.Errorf("Error updating API data collector: %v", err)
 	}
 
-	matchReport := make([][2]int64, 0, len(matches)) // allocation almost certainly too low, but a good starting point.
+	matchReport := make([][2]int64, 0, len(matches))
 	var lastRate uint64
 	var lastSide bool
 	for _, matchSet := range matches {

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -1348,7 +1348,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 				{bookAction, sigDataBookedOrder{lo, epochIdx}},
 				{unbookAction, sigDataUnbookedOrder{bestBuy, epochIdx}},
 				{unbookAction, sigDataUnbookedOrder{bestSell, epochIdx}},
-				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil, nil}},
+				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil}},
 			},
 		},
 		{
@@ -1356,7 +1356,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 			eq2,
 			[]*updateSignal{
 				{matchProofAction, sigDataMatchProof{mp2}},
-				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil, nil}},
+				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil}},
 			},
 		},
 		{
@@ -1364,7 +1364,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 			NewEpoch(epochIdx, epochDur),
 			[]*updateSignal{
 				{matchProofAction, sigDataMatchProof{mp0}},
-				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil, nil}},
+				{epochReportAction, sigDataEpochReport{epochIdx, epochDur, nil, nil, 10, 10, nil}},
 			},
 		},
 	}


### PR DESCRIPTION
This encoding preserves order. Matches are only binned if they occur sequentially.