### PR TITLE
server/market: send revoke order notes on suspend with purge

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -733,11 +733,11 @@ func handleTradeSuspensionMsg(c *Core, dc *dexConnection, msg *msgjson.Message) 
 	dc.tradeMtx.RLock()
 	for _, tracker := range dc.trades {
 		if tracker.Order.Base() == mkt.Base && tracker.Order.Quote() == mkt.Quote &&
-			tracker.metaData.Host == dc.acct.host && tracker.metaData.Status == order.OrderStatusBooked {
+			tracker.metaData.Host == dc.acct.host && tracker.status() == order.OrderStatusBooked {
 			// Locally revoke the purged book order.
 			tracker.revoke()
 			subject, details := c.formatDetails(TopicOrderAutoRevoked, tracker.token(), sp.MarketID, dc.acct.host)
-			c.notify(newOrderNote(TopicOrderAutoRevoked, subject, details, db.WarningLevel, tracker.coreOrderInternal()))
+			c.notify(newOrderNote(TopicOrderAutoRevoked, subject, details, db.WarningLevel, tracker.coreOrder()))
 			updatedAssets.count(tracker.fromAssetID)
 		}
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6847,6 +6847,12 @@ func handleRevokeOrderMsg(c *Core, dc *dexConnection, msg *msgjson.Message) erro
 		return fmt.Errorf("no order found with id %s", oid.String())
 	}
 
+	if tracker.status() == order.OrderStatusRevoked {
+		// Already revoked is expected if entire book was purged in a suspend
+		// ntfn, which emits a gentler and more informative notification.
+		// However, we may not be subscribed to orderbook notifications.
+		return nil
+	}
 	tracker.revoke()
 
 	subject, details := c.formatDetails(TopicOrderRevoked, tracker.token(), tracker.mktID, dc.acct.host)

--- a/server/book/book.go
+++ b/server/book/book.go
@@ -43,13 +43,15 @@ func New(lotSize uint64, acctTracking AccountTracking) *Book {
 }
 
 // Clear reset the order book with configured capacity.
-func (b *Book) Clear() {
+func (b *Book) Clear() (removedBuys, removedSells []*order.LimitOrder) {
 	b.mtx.Lock()
+	removedBuys, removedSells = b.buys.Orders(), b.sells.Orders()
 	b.buys, b.sells = nil, nil
 	b.buys = NewMaxOrderPQ(initBookHalfCapacity)
 	b.sells = NewMinOrderPQ(initBookHalfCapacity)
 	b.acctTracker = newAccountTracker(b.acctTracking)
 	b.mtx.Unlock()
+	return
 }
 
 // LotSize returns the Book's configured lot size in atoms of the base asset.

--- a/server/book/book_test.go
+++ b/server/book/book_test.go
@@ -252,7 +252,13 @@ func TestBook(t *testing.T) {
 		t.Errorf("buy side was empty")
 	}
 
-	b.Clear()
+	buysRemoved, sellsRemoved := b.Clear()
+	if len(buysRemoved) != len(bookBuyOrders)-2 {
+		t.Errorf("removed %d buys, expected, %d", len(buysRemoved), len(bookBuyOrders)-2)
+	}
+	if len(sellsRemoved) != len(bookSellOrders)-2 {
+		t.Errorf("removed %d sells, expected, %d", len(sellsRemoved), len(bookSellOrders)-2)
+	}
 
 	if b.SellCount() != 0 {
 		t.Errorf("sell side was not empty after Clear")

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -1272,39 +1272,65 @@ func (m *Market) Book() (epoch int64, buys, sells []*order.LimitOrder) {
 // storage. In terms of storage, this means changing orders with status booked
 // to status revoked.
 func (m *Market) PurgeBook() {
+	// Clear booked orders from the DB and the in-memory book.
+	buysRemoved, sellsRemoved := m.purgeBook()
+
+	// Send individual revoke order notifications. These are not part of the
+	// orderbook subscription, so the users will receive them whether or not
+	// they are subscribed for book updates.
+	for _, lo := range append(sellsRemoved, buysRemoved...) {
+		m.sendRevokeOrderNote(lo.ID(), lo.AccountID)
+	}
+}
+
+func (m *Market) purgeBook() (buysRemoved, sellsRemoved []*order.LimitOrder) {
 	m.bookMtx.Lock()
 	defer m.bookMtx.Unlock()
 
 	// Revoke all booked orders in the DB.
-	sellsRemoved, buysRemoved, err := m.storage.FlushBook(m.marketInfo.Base, m.marketInfo.Quote)
+	sellsCleared, buysCleared, err := m.storage.FlushBook(m.marketInfo.Base, m.marketInfo.Quote)
 	if err != nil {
 		log.Errorf("Failed to flush book for market %s: %v", m.marketInfo.Name, err)
-	} else {
-		log.Infof("Flushed %d sell orders and %d buy orders from market %q book",
-			len(sellsRemoved), len(buysRemoved), m.marketInfo.Name)
-		// Clear the in-memory order book to match the DB.
-		m.book.Clear()
-		// Unlock coins for removed orders.
+		return
+	}
 
-		// TODO: only unlock previously booked order coins, do not include coins
-		// that might belong to orders still in epoch status. This won't matter
-		// if the market is suspended, but it does if PurgeBook is used while
-		// the market is still accepting new orders and processing epochs.
+	// Clear the in-memory order book to match the DB.
+	buysRemoved, sellsRemoved = m.book.Clear()
 
-		// Unlock base asset coins locked by sell orders.
-		if m.coinLockerBase != nil {
-			for i := range sellsRemoved {
-				m.coinLockerBase.UnlockOrderCoins(sellsRemoved[i])
-			}
-		}
+	log.Infof("Flushed %d sell orders and %d buy orders from market %q book",
+		len(sellsRemoved), len(buysRemoved), m.marketInfo.Name)
+	// Maybe the DB cleaned up orphaned orders. Log any discrepancies.
+	if len(sellsRemoved) != len(sellsCleared) {
+		log.Warnf("Removed %d sell orders from the book, but %d were updated in the DB.",
+			len(sellsRemoved), len(sellsCleared))
+	}
+	if len(buysRemoved) != len(buysCleared) {
+		log.Warnf("Removed %d buy orders from the book, but %d were updated in the DB.",
+			len(buysRemoved), len(buysCleared))
+	}
 
-		// Unlock quote asset coins locked by buy orders.
-		if m.coinLockerQuote != nil {
-			for i := range buysRemoved {
-				m.coinLockerQuote.UnlockOrderCoins(buysRemoved[i])
-			}
+	// Unlock coins for removed orders.
+
+	// TODO: only unlock previously booked order coins, do not include coins
+	// that might belong to orders still in epoch status. This won't matter if
+	// the market is suspended, but it does if PurgeBook is used while the
+	// market is still accepting new orders and processing epochs.
+
+	// Unlock base asset coins locked by sell orders.
+	if m.coinLockerBase != nil {
+		for i := range sellsRemoved {
+			m.coinLockerBase.UnlockOrderCoins(sellsRemoved[i].ID())
 		}
 	}
+
+	// Unlock quote asset coins locked by buy orders.
+	if m.coinLockerQuote != nil {
+		for i := range buysRemoved {
+			m.coinLockerQuote.UnlockOrderCoins(buysRemoved[i].ID())
+		}
+	}
+
+	return
 }
 
 func (m *Market) lazy(do func()) {
@@ -1368,9 +1394,7 @@ func (m *Market) Run(ctx context.Context) {
 
 		// persistBook is set under epochMtx lock.
 		m.epochMtx.Lock()
-		if !m.persistBook {
-			m.PurgeBook()
-		}
+
 		// Signal to the book router of the suspend now that the closed epoch
 		// processing pipeline is finished (wgEpochs).
 		notifyChan <- &updateSignal{
@@ -1380,6 +1404,11 @@ func (m *Market) Run(ctx context.Context) {
 				persistBook: m.persistBook,
 			},
 		}
+
+		if !m.persistBook {
+			m.PurgeBook()
+		}
+
 		m.persistBook = true // future resume default
 		m.activeEpochIdx = 0
 


### PR DESCRIPTION
The market `'suspension'` route is a somewhat mixed purpose notification in that all connected clients receive a notification of scheduled future suspension, but only `'orderbook'` subscribers get the _sequenced_ suspension notification at the time the market actually clears the book.

As such, if you have orders on the book, but do *not* have an orderbook subscription (e.g. you closed the browser window and it unsubscribed after 30 seconds or so), you will not get the final suspension notification that performs the "auto-revokes" and sends the kinder `TopicOrderAutoRevoked` notes to the frontend.  Instead, your client thinks the orders are still booked **until you reconnect with the server after market resumption** and order status reconciles from booked to revoked.  This is a bug.

To ensure that non-subscribers do not keep their orders in booked status incorrectly, this modifies `(*Market).PurgeBook` to send a `revoke_order` notification to each (user,order) that was purged.  These do not require an `orderbook` subscription.  These revokes are less friendly looking because (a) they don't explain why it was revoked other than by observing the prior suspension scheduled notification, and (b) they are sent to the frontend at error level severity instead of warn as the auto-revokes do.  However, this fixes the bug of clients without an orderbook subscription being unaware that their orders were unbooked.

Finally, this makes the revoke_order notifications come *after* the trade suspension notification so that clients that did have a subscription will get the friendlier message on the frontend, and then simply ignore the explicit redundant revoke_order notes that follow.