### PR TITLE
client/core: swap completion without server coordination

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -75,8 +75,9 @@ var (
 
 	// WalletInfo defines some general information about a Bitcoin Cash wallet.
 	WalletInfo = &asset.WalletInfo{
-		Name:    "Bitcoin Cash",
-		Version: version,
+		Name:              "Bitcoin Cash",
+		Version:           version,
+		SupportedVersions: []uint32{version},
 		// Same as bitcoin. That's dumb.
 		UnitInfo: dexbch.UnitInfo,
 		AvailableWallets: []*asset.WalletDefinition{
@@ -192,6 +193,8 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		Ports:              netPorts,
 		DefaultFallbackFee: defaultFee,
 		Segwit:             false,
+		InitTxSizeBase:     dexbtc.InitTxSizeBase,
+		InitTxSize:         dexbtc.InitTxSize,
 		LegacyBalance:      cfg.Type != walletTypeSPV,
 		LegacySendToAddr:   true,
 		// Bitcoin Cash uses the Cash Address encoding, which is Bech32, but not

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1764,6 +1764,8 @@ func (btc *baseWallet) SingleLotSwapFees(form *asset.PreSwapForm) (fees uint64, 
 	}
 
 	if split {
+		// TODO: The following is not correct for all BTC clones. e.g. zcash has
+		// a different MinimumTxOverhead (29).
 		if btc.segwit {
 			fees += (dexbtc.MinimumTxOverhead + dexbtc.RedeemP2WPKHInputSize + dexbtc.P2WPKHOutputSize) * bumpedNetRate
 		} else {
@@ -1778,9 +1780,9 @@ func (btc *baseWallet) SingleLotSwapFees(form *asset.PreSwapForm) (fees uint64, 
 		inputSize = dexbtc.RedeemP2PKHInputSize
 	}
 
-	nfo := form.AssetConfig
 	const maxSwaps = 1 // Assumed single lot order
-	swapFunds := calc.RequiredOrderFundsAlt(form.LotSize, inputSize, maxSwaps, nfo.SwapSizeBase, nfo.SwapSize, bumpedNetRate)
+	swapFunds := calc.RequiredOrderFundsAlt(form.LotSize, inputSize, maxSwaps,
+		btc.initTxSizeBase, btc.initTxSize, bumpedNetRate)
 	fees += swapFunds - form.LotSize
 
 	return fees, nil

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1438,9 +1438,8 @@ func (btc *baseWallet) legacyBalance() (*asset.Balance, error) {
 func (btc *baseWallet) feeRate(_ RawRequester, confTarget uint64) (uint64, error) {
 	feeResult, err := btc.node.estimateSmartFee(int64(confTarget), &btcjson.EstimateModeConservative)
 	if err != nil {
-		btc.log.Errorf("Failed to get fee rate with estimate smart fee rate: %v", err)
-
 		if !btc.apiFeeFallback() {
+			btc.log.Warnf("Failed to get local fee rate estimate: %v", err)
 			return 0, err
 		}
 		btc.log.Debug("Retrieving fee rate from external API: ", externalApiUrl)

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -863,9 +863,10 @@ func testAvailableFund(t *testing.T, segwit bool, walletType string) {
 	}
 
 	ord := &asset.Order{
+		Version:       version,
 		Value:         0,
 		MaxSwapCount:  1,
-		DEXConfig:     tBTC,
+		MaxFeeRate:    tBTC.MaxFeeRate,
 		FeeSuggestion: feeSuggestion,
 	}
 
@@ -1298,7 +1299,8 @@ func checkMaxOrder(t *testing.T, wallet asset.Wallet, lots, swapVal, maxFees, es
 	maxOrder, err := wallet.MaxOrder(&asset.MaxOrderForm{
 		LotSize:       tLotSize,
 		FeeSuggestion: feeSuggestion,
-		AssetConfig:   tBTC,
+		AssetVersion:  version,
+		MaxFeeRate:    tBTC.MaxFeeRate,
 	})
 	if err != nil {
 		t.Fatalf("MaxOrder error: %v", err)
@@ -1379,9 +1381,10 @@ func TestFundEdges(t *testing.T) {
 	unspents := []*ListUnspentResult{p2pkhUnspent}
 	node.listUnspent = unspents
 	ord := &asset.Order{
+		Version:       version,
 		Value:         swapVal,
 		MaxSwapCount:  lots,
-		DEXConfig:     tBTC,
+		MaxFeeRate:    tBTC.MaxFeeRate,
 		FeeSuggestion: feeSuggestion,
 	}
 
@@ -1602,9 +1605,10 @@ func TestFundEdgesSegwit(t *testing.T) {
 	unspents := []*ListUnspentResult{p2wpkhUnspent}
 	node.listUnspent = unspents
 	ord := &asset.Order{
+		Version:       version,
 		Value:         swapVal,
 		MaxSwapCount:  lots,
-		DEXConfig:     tBTC,
+		MaxFeeRate:    tBTC.MaxFeeRate,
 		FeeSuggestion: feeSuggestion,
 	}
 
@@ -2869,11 +2873,13 @@ func testPreSwap(t *testing.T, segwit bool, walletType string) {
 	}
 
 	form := &asset.PreSwapForm{
+		Version:       version,
 		LotSize:       tLotSize,
 		Lots:          lots,
-		AssetConfig:   tBTC,
+		MaxFeeRate:    tBTC.MaxFeeRate,
 		Immediate:     false,
 		FeeSuggestion: feeSuggestion,
+		// Redeem fields unneeded
 	}
 
 	setFunds(minReq)
@@ -2913,8 +2919,8 @@ func testPreRedeem(t *testing.T, segwit bool, walletType string) {
 	defer shutdown()
 
 	preRedeem, err := wallet.PreRedeem(&asset.PreRedeemForm{
-		Lots:        5,
-		AssetConfig: tBTC,
+		Version: version,
+		Lots:    5,
 	})
 	// Shouldn't actually be any path to error.
 	if err != nil {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1373,9 +1373,9 @@ func (dcr *ExchangeWallet) SingleLotSwapFees(form *asset.PreSwapForm) (fees uint
 		fees += (dexdcr.MsgTxOverhead + dexdcr.P2PKHInputSize + dexdcr.P2PKHOutputSize) * bumpedNetRate
 	}
 
-	nfo := form.AssetConfig
 	const maxSwaps = 1 // Assumed single lot order
-	swapFunds := calc.RequiredOrderFundsAlt(form.LotSize, dexdcr.P2PKHInputSize, maxSwaps, nfo.SwapSizeBase, nfo.SwapSize, bumpedNetRate)
+	swapFunds := calc.RequiredOrderFundsAlt(form.LotSize, dexdcr.P2PKHInputSize,
+		maxSwaps, dexdcr.InitTxSizeBase, dexdcr.InitTxSize, bumpedNetRate)
 	fees += swapFunds - form.LotSize
 
 	return fees, nil

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -785,9 +785,10 @@ func TestAvailableFund(t *testing.T) {
 	}
 
 	ord := &asset.Order{
+		Version:       version,
 		Value:         0,
 		MaxSwapCount:  1,
-		DEXConfig:     tDCR,
+		MaxFeeRate:    tDCR.MaxFeeRate,
 		FeeSuggestion: feeSuggestion,
 	}
 
@@ -1092,7 +1093,7 @@ func TestFundingCoins(t *testing.T) {
 
 func checkMaxOrder(t *testing.T, wallet *ExchangeWallet, lots, swapVal, maxFees, estWorstCase, estBestCase, locked uint64) {
 	t.Helper()
-	_, maxOrder, err := wallet.maxOrder(tLotSize, feeSuggestion, tDCR)
+	_, maxOrder, err := wallet.maxOrder(tLotSize, feeSuggestion, tDCR.MaxFeeRate)
 	if err != nil {
 		t.Fatalf("MaxOrder error: %v", err)
 	}
@@ -1163,9 +1164,10 @@ func TestFundEdges(t *testing.T) {
 
 	node.unspent = []walletjson.ListUnspentResult{p2pkhUnspent}
 	ord := &asset.Order{
+		Version:       version,
 		Value:         swapVal,
 		MaxSwapCount:  lots,
-		DEXConfig:     tDCR,
+		MaxFeeRate:    tDCR.MaxFeeRate,
 		FeeSuggestion: feeSuggestion,
 	}
 
@@ -2419,7 +2421,6 @@ func TestPreSwap(t *testing.T) {
 	swapVal := uint64(1e8)
 	lots := swapVal / tLotSize // 10 lots
 
-	const swapSize = 251
 	const totalBytes = 2510
 	const bestCaseBytes = 557
 
@@ -2441,11 +2442,13 @@ func TestPreSwap(t *testing.T) {
 	node.unspent = []walletjson.ListUnspentResult{p2pkhUnspent}
 
 	form := &asset.PreSwapForm{
+		Version:       version,
 		LotSize:       tLotSize,
 		Lots:          lots,
-		AssetConfig:   tDCR,
+		MaxFeeRate:    tDCR.MaxFeeRate,
 		Immediate:     false,
 		FeeSuggestion: feeSuggestion,
+		// Redeem fields unneeded
 	}
 
 	node.unspent[0].Amount = float64(minReq) / 1e8
@@ -2481,8 +2484,8 @@ func TestPreRedeem(t *testing.T) {
 	defer shutdown()
 
 	preRedeem, err := wallet.PreRedeem(&asset.PreRedeemForm{
-		Lots:        5,
-		AssetConfig: tDCR,
+		Version: version,
+		Lots:    5,
 	})
 	// Shouldn't actually be any path to error.
 	if err != nil {

--- a/client/asset/dcr/externaltx.go
+++ b/client/asset/dcr/externaltx.go
@@ -99,6 +99,7 @@ func (dcr *ExchangeWallet) externalTxOutput(ctx context.Context, op outPoint, pk
 
 	// Scan block filters to find the tx block if it is yet unknown.
 	if txBlock == nil {
+		dcr.log.Infof("Contract output %s:%d NOT yet found; now searching with block filters.", op.txHash, op.vout)
 		txBlock, err = dcr.scanFiltersForTxBlock(ctx, tx, [][]byte{pkScript}, earliestTxTime)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error checking if tx %s is mined: %w", tx.hash, err)
@@ -129,7 +130,7 @@ func (dcr *ExchangeWallet) txBlockFromCache(ctx context.Context, tx *externalTx)
 	}
 
 	if txBlockStillValid { // both mainchain and not disapproved
-		dcr.log.Debugf("Cached tx %s is mined in block %d (%s).", tx.hash, tx.block.height, tx.block.hash)
+		// dcr.log.Tracef("Cached tx %s is mined in block %d (%s).", tx.hash, tx.block.height, tx.block.hash)
 		return tx.block, nil
 	}
 
@@ -300,7 +301,7 @@ func (dcr *ExchangeWallet) isOutputSpent(ctx context.Context, output *outputSpen
 			return false, err
 		}
 		if spenderBlockStillValid { // both mainchain and not disapproved
-			dcr.log.Debugf("Found cached information for the spender of %s.", output.op)
+			// dcr.log.Debugf("Found cached information for the spender of %s.", output.op)
 			return true, nil
 		}
 		// Output was previously found to have been spent but the block

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -302,9 +302,10 @@ func runTest(t *testing.T, splitTx bool) {
 	}
 
 	ord := &asset.Order{
+		Version:      tDCR.Version,
 		Value:        contractValue * 3,
 		MaxSwapCount: lots * 3,
-		DEXConfig:    tDCR,
+		MaxFeeRate:   tDCR.MaxFeeRate,
 	}
 	setOrderValue := func(v uint64) {
 		ord.Value = v

--- a/client/asset/doge/doge.go
+++ b/client/asset/doge/doge.go
@@ -78,9 +78,10 @@ var (
 	}
 	// WalletInfo defines some general information about a Dogecoin wallet.
 	WalletInfo = &asset.WalletInfo{
-		Name:     "Dogecoin",
-		Version:  version,
-		UnitInfo: dexdoge.UnitInfo,
+		Name:              "Dogecoin",
+		Version:           version,
+		SupportedVersions: []uint32{version},
+		UnitInfo:          dexdoge.UnitInfo,
 		AvailableWallets: []*asset.WalletDefinition{{
 			Type:              walletTypeRPC,
 			Tab:               "External",
@@ -152,6 +153,8 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		DefaultFeeRateLimit:      dexdoge.DefaultFeeRateLimit,
 		LegacyBalance:            true,
 		Segwit:                   false,
+		InitTxSize:               dexbtc.InitTxSize,
+		InitTxSizeBase:           dexbtc.InitTxSizeBase,
 		OmitAddressType:          true,
 		LegacySignTxRPC:          true,
 		LegacySendToAddr:         true,

--- a/client/asset/estimation.go
+++ b/client/asset/estimation.go
@@ -42,7 +42,9 @@ type PreSwapForm struct {
 	// of the current market rate.
 	LotSize uint64
 	// Lots is the number of lots in the order.
-	Lots       uint64
+	Lots uint64
+	// MaxFeeRate is the highest possible fee rate that may be required for the
+	// swap initialization transaction.
 	MaxFeeRate uint64
 	// Immediate should be set to true if this is for an order that is not a
 	// standing order, likely a market order or a limit order with immediate

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -70,9 +70,10 @@ var (
 	}
 	// WalletInfo defines some general information about a Litecoin wallet.
 	WalletInfo = &asset.WalletInfo{
-		Name:     "Litecoin",
-		Version:  version,
-		UnitInfo: dexltc.UnitInfo,
+		Name:              "Litecoin",
+		Version:           version,
+		SupportedVersions: []uint32{version},
+		UnitInfo:          dexltc.UnitInfo,
 		AvailableWallets: []*asset.WalletDefinition{
 			spvWalletDefinition,
 			rpcWalletDefinition,
@@ -187,6 +188,8 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		LegacyBalance:       false,
 		LegacyRawFeeLimit:   false,
 		Segwit:              true,
+		InitTxSize:          dexbtc.InitTxSizeSegwit,
+		InitTxSizeBase:      dexbtc.InitTxSizeBaseSegwit,
 		BlockDeserializer:   dexltc.DeserializeBlockBytes,
 	}
 

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -92,9 +92,10 @@ var (
 	}
 	// WalletInfo defines some general information about a ZCash wallet.
 	WalletInfo = &asset.WalletInfo{
-		Name:     "ZCash",
-		Version:  version,
-		UnitInfo: dexzec.UnitInfo,
+		Name:              "ZCash",
+		Version:           version,
+		SupportedVersions: []uint32{version},
+		UnitInfo:          dexzec.UnitInfo,
 		AvailableWallets: []*asset.WalletDefinition{{
 			Type:              walletTypeRPC,
 			Tab:               "External",
@@ -173,6 +174,8 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (ass
 		LegacyRawFeeLimit:        true,
 		ZECStyleBalance:          true,
 		Segwit:                   false,
+		InitTxSize:               dexzec.InitTxSize,
+		InitTxSizeBase:           dexzec.InitTxSizeBase,
 		OmitAddressType:          true,
 		LegacySignTxRPC:          true,
 		LegacySendToAddr:         true,

--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -50,6 +50,20 @@ const (
 	InvalidCert
 )
 
+// String gives a human readable string for each connection status.
+func (cs ConnectionStatus) String() string {
+	switch cs {
+	case Disconnected:
+		return "disconnected"
+	case Connected:
+		return "connected"
+	case InvalidCert:
+		return "invalid certificate"
+	default:
+		return "unknown status"
+	}
+}
+
 // ErrInvalidCert is the error returned when attempting to use an invalid cert
 // to set up a ws connection.
 var ErrInvalidCert = fmt.Errorf("invalid certificate")

--- a/client/core/bot.go
+++ b/client/core/bot.go
@@ -1247,6 +1247,7 @@ func (c *Core) feeEstimates(form *TradeForm) (swapFees, redeemFees uint64, err e
 			if err2 != nil {
 				return 0, 0, fmt.Errorf("error getting swap estimate (%v) and single-lot estimate (%v)", err, err2)
 			}
+			err = nil
 		} else {
 			return 0, 0, fmt.Errorf("error getting swap estimate: %w", err)
 		}
@@ -1262,12 +1263,13 @@ func (c *Core) feeEstimates(form *TradeForm) (swapFees, redeemFees uint64, err e
 	if err == nil {
 		redeemFees = redeemEstimate.Estimate.RealisticWorstCase
 	} else {
-		if bw, is := fromWallet.Wallet.(asset.BotWallet); is {
+		if bw, is := toWallet.Wallet.(asset.BotWallet); is {
 			var err2 error
 			redeemFees, err2 = bw.SingleLotRedeemFees(preRedeemForm)
 			if err2 != nil {
 				return 0, 0, fmt.Errorf("error getting redemption estimate (%v) and single-lot estimate (%v)", err, err2)
 			}
+			err = nil
 		} else {
 			return 0, 0, fmt.Errorf("error getting redemption estimate: %v", err)
 		}

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -325,7 +325,7 @@ func newMatchNote(topic Topic, subject, details string, severity db.Severity, t 
 		Notification: db.NewNotification(NoteTypeMatch, topic, subject, details, severity),
 		OrderID:      t.ID().Bytes(),
 		Match: matchFromMetaMatchWithConfs(t.Order, &match.MetaMatch, match.swapConfirms,
-			int64(t.wallets.fromAsset.SwapConf), counterConfs, int64(t.wallets.toAsset.SwapConf),
+			int64(t.metaData.FromSwapConf), counterConfs, int64(t.metaData.ToSwapConf),
 			int64(match.redemptionConfs), int64(match.redemptionConfsReq)),
 		Host:     t.dc.acct.host,
 		MarketID: marketName(t.Base(), t.Quote()),

--- a/client/core/simnet_trade.go
+++ b/client/core/simnet_trade.go
@@ -665,7 +665,7 @@ func testOrderStatusReconciliation(s *simulationTest) error {
 		}
 		oid := tracker.ID()
 		// Wait a max of 2 epochs for preimage to be sent for this order.
-		twoEpochs := 2 * time.Duration(tracker.epochLen) * time.Millisecond
+		twoEpochs := 2 * time.Duration(tracker.epochLen()) * time.Millisecond
 		s.client2.log.Infof("Waiting %v for preimage reveal, order %s", twoEpochs, tracker.token())
 		preimageRevealed := notes.find(ctx, twoEpochs, func(n Notification) bool {
 			orderNote, isOrderNote := n.(*OrderNote)
@@ -700,7 +700,7 @@ func testOrderStatusReconciliation(s *simulationTest) error {
 			return fmt.Errorf("client 2 place order error: %v", err)
 		}
 		// Wait a max of 2 epochs for preimage to be sent for this order.
-		twoEpochs := 2 * time.Duration(tracker.epochLen) * time.Millisecond
+		twoEpochs := 2 * time.Duration(tracker.epochLen()) * time.Millisecond
 		s.client2.log.Infof("Waiting %v for preimage reveal, order %s", twoEpochs, tracker.token())
 		preimageRevealed := notes.find(ctx, twoEpochs, func(n Notification) bool {
 			orderNote, isOrderNote := n.(*OrderNote)
@@ -1091,7 +1091,7 @@ func (s *simulationTest) monitorOrderMatchingAndTradeNeg(ctx context.Context, cl
 	}
 
 	// Wait up to 2 times the epoch duration for this order to get matched.
-	maxMatchDuration := 2 * time.Duration(tracker.epochLen) * time.Millisecond
+	maxMatchDuration := 2 * time.Duration(tracker.epochLen()) * time.Millisecond
 	client.log.Infof("Waiting up to %v for matches on order %s", maxMatchDuration, tracker.token())
 	matched := client.notes.find(ctx, maxMatchDuration, func(n Notification) bool {
 		orderNote, isOrderNote := n.(*OrderNote)

--- a/client/core/simnet_trade.go
+++ b/client/core/simnet_trade.go
@@ -1066,7 +1066,7 @@ func (s *simulationTest) placeTestOrders(qty, rate uint64) (string, string, erro
 		return "", "", err
 	}
 	// Wait the epoch duration for this order to get booked.
-	epochDur := time.Duration(tracker.epochLen) * time.Millisecond
+	epochDur := time.Duration(tracker.epochLen()) * time.Millisecond
 	time.Sleep(epochDur)
 
 	if s.client1IsMaker {
@@ -1209,7 +1209,7 @@ func (s *simulationTest) monitorTrackedTrade(client *simulationClient, tracker *
 					waitForOtherSideTakerInit = true
 				}
 				// Progress from asset.
-				nBlocks := tracker.wallets.fromAsset.SwapConf
+				nBlocks := tracker.metaData.FromSwapConf
 				if accountBIPs[tracker.wallets.fromWallet.AssetID] {
 					nBlocks = 8
 				}
@@ -1229,7 +1229,7 @@ func (s *simulationTest) monitorTrackedTrade(client *simulationClient, tracker *
 					waitForOtherSideTakerInit = true
 				}
 				// Progress to asset.
-				nBlocks := tracker.wallets.toAsset.SwapConf
+				nBlocks := tracker.metaData.ToSwapConf
 				if accountBIPs[tracker.wallets.toWallet.AssetID] {
 					nBlocks = 8
 				}
@@ -1350,7 +1350,7 @@ func (s *simulationTest) checkAndWaitForRefunds(ctx context.Context, client *sim
 		if !client.isSeller {
 			swapAmt = calc.BaseToQuote(match.Rate, match.Quantity)
 		}
-		refundAmts[tracker.wallets.fromAsset.ID] += int64(swapAmt)
+		refundAmts[tracker.wallets.fromWallet.AssetID] += int64(swapAmt)
 
 		matchTime := match.matchTime()
 		swapLockTime := matchTime.Add(tracker.lockTimeTaker)

--- a/client/core/status.go
+++ b/client/core/status.go
@@ -315,7 +315,7 @@ func resolveMissedMakerRedemption(dc *dexConnection, trade *trackedTrade, match 
 	// If we're the maker, this state is nonsense. Just revoke the match for
 	// good measure.
 	if match.Side == order.Maker {
-		coinStr, _ := asset.DecodeCoinID(trade.wallets.toAsset.ID, srvData.MakerRedeem)
+		coinStr, _ := asset.DecodeCoinID(trade.wallets.toWallet.AssetID, srvData.MakerRedeem)
 		err = fmt.Errorf("server reported match status MakerRedeemed, but we're the maker and we don't have redemption data."+
 			" self-revoking. %s, reported coin = %s", logID, coinStr)
 		return
@@ -347,7 +347,7 @@ func resolveMatchComplete(dc *dexConnection, trade *trackedTrade, match *matchTr
 	// good measure.
 	if match.Side == order.Taker {
 		match.MetaData.Proof.SelfRevoked = true
-		coinStr, _ := asset.DecodeCoinID(trade.wallets.toAsset.ID, srvData.TakerRedeem)
+		coinStr, _ := asset.DecodeCoinID(trade.wallets.toWallet.AssetID, srvData.TakerRedeem)
 		dc.log.Error("server reported match status MatchComplete, but we're the taker and we don't have redemption data."+
 			" self-revoking. %s, reported coin = %s", logID, coinStr)
 		return

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1535,7 +1535,7 @@ func (t *trackedTrade) isRedeemable(ctx context.Context, match *matchTracker) (r
 	// Just a quick check here. We'll perform a more thorough check if there are
 	// actually redeemables.
 	if !wallet.locallyUnlocked() {
-		t.dc.log.Errorf("not checking if order %s, match %s is redeemable because %s wallet is not unlocked",
+		t.dc.log.Errorf("not checking if order %s, match %s is redeemable because %s wallet is locked or disabled",
 			t.ID(), match, unbip(wallet.AssetID))
 		return false, false
 	}
@@ -1630,7 +1630,7 @@ func (t *trackedTrade) isRefundable(ctx context.Context, match *matchTracker) bo
 	// Just a quick check here. We'll perform a more thorough check if there are
 	// actually refundables.
 	if !wallet.locallyUnlocked() {
-		t.dc.log.Errorf("not checking if order %s, match %s is refundable because %s wallet is not unlocked",
+		t.dc.log.Errorf("not checking if order %s, match %s is refundable because %s wallet is locked or disabled",
 			t.ID(), match, unbip(wallet.AssetID))
 		return false
 	}

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1357,10 +1357,8 @@ func (t *trackedTrade) isSwappable(ctx context.Context, match *matchTracker) (re
 			// is expected for newly made swaps involving contracts.
 			t.dc.log.Errorf("isSwappable: error getting confirmation for our own swap transaction: %v", err)
 		}
-		if spent {
-			t.dc.log.Debugf("Our (maker) swap for match %s is being reported as spent, "+
-				"but we have not seen the counter-party's redemption yet. This could just"+
-				" be network latency.", match)
+		if spent { // This should NEVER happen for maker in MakerSwapCast unless revoked and refunded!
+			t.dc.log.Errorf("Our (maker) swap for match %s is being reported as spent before taker's swap was broadcast!", match)
 		}
 		match.setSwapConfirms(int64(confs))
 		t.notify(newMatchNote(TopicConfirms, "", "", db.Data, t, match))

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -56,7 +56,7 @@ type DB interface {
 	// filtered by supplying a non-zero since value, corresponding to a UNIX
 	// timestamp, in milliseconds. n = 0 applies no limit on number of orders
 	// returned. since = 0 is equivalent to disabling the time filter, since
-	// no orders were created before before 1970.
+	// no orders were created before 1970.
 	AccountOrders(dex string, n int, since uint64) ([]*MetaOrder, error)
 	// Order fetches a MetaOrder by order ID.
 	Order(order.OrderID) (*MetaOrder, error)
@@ -72,7 +72,7 @@ type DB interface {
 	// filtered by supplying a non-zero since value, corresponding to a UNIX
 	// timestamp, in milliseconds. n = 0 applies no limit on number of orders
 	// returned. since = 0 is equivalent to disabling the time filter, since
-	// no orders were created before before 1970.
+	// no orders were created before 1970.
 	MarketOrders(dex string, base, quote uint32, n int, since uint64) ([]*MetaOrder, error)
 	// UpdateOrderMetaData updates the order metadata, not including the Host.
 	UpdateOrderMetaData(order.OrderID, *OrderMetaData) error

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -500,6 +500,8 @@ func (*TDriver) DecodeCoinID(coinID []byte) (string, error) {
 
 func (*TDriver) Info() *asset.WalletInfo {
 	return &asset.WalletInfo{
+		Version:           0,
+		SupportedVersions: []uint32{0},
 		UnitInfo: dex.UnitInfo{
 			Conventional: dex.Denomination{
 				ConversionFactor: 1e8,
@@ -1234,6 +1236,8 @@ var winfos = map[uint32]*asset.WalletInfo{
 	2:  ltc.WalletInfo,
 	42: dcr.WalletInfo,
 	22: {
+		Version:           0,
+		SupportedVersions: []uint32{0},
 		UnitInfo: dex.UnitInfo{
 			AtomicUnit: "atoms",
 			Conventional: dex.Denomination{
@@ -1256,6 +1260,8 @@ var winfos = map[uint32]*asset.WalletInfo{
 		},
 	},
 	3: {
+		Version:           0,
+		SupportedVersions: []uint32{0},
 		UnitInfo: dex.UnitInfo{
 			AtomicUnit: "atoms",
 			Conventional: dex.Denomination{
@@ -1269,6 +1275,8 @@ var winfos = map[uint32]*asset.WalletInfo{
 		}},
 	},
 	28: {
+		Version:           0,
+		SupportedVersions: []uint32{0},
 		UnitInfo: dex.UnitInfo{
 			AtomicUnit: "Sats",
 			Conventional: dex.Denomination{
@@ -1283,8 +1291,10 @@ var winfos = map[uint32]*asset.WalletInfo{
 	},
 	60: eth.WalletInfo,
 	145: {
-		Name:     "Bitcoin Cash",
-		UnitInfo: dexbch.UnitInfo,
+		Version:           0,
+		SupportedVersions: []uint32{0},
+		Name:              "Bitcoin Cash",
+		UnitInfo:          dexbch.UnitInfo,
 		AvailableWallets: []*asset.WalletDefinition{{
 			ConfigOpts: configOpts,
 		}},

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -102,7 +102,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=LESXCTh9d"></script>
+<script src="/js/entry.js?v=odfVl8g"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -102,7 +102,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=odfVl8g"></script>
+<script src="/js/entry.js?v=cYXx7p"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -802,6 +802,7 @@ export default class Application {
   walletIsActive (assetID: number): boolean {
     if (this.haveAssetOrders(assetID)) return true
     for (const xc of Object.values(this.user.exchanges)) {
+      if (!xc) continue
       if (xc.pendingFee && xc.pendingFee.assetID === assetID) {
         return true
       }
@@ -812,6 +813,7 @@ export default class Application {
   /* order attempts to locate an order by order ID. */
   order (oid: string): Order | null {
     for (const xc of Object.values(this.user.exchanges)) {
+      if (!xc || !xc.markets) continue
       for (const market of Object.values(xc.markets)) {
         if (!market.orders) continue
         for (const ord of market.orders) {
@@ -853,7 +855,7 @@ export default class Application {
   unitInfo (assetID: number, xc?: Exchange): UnitInfo {
     const supportedAsset = this.assets[assetID]
     if (supportedAsset) return supportedAsset.unitInfo
-    if (!xc) {
+    if (!xc || !xc.assets) {
       throw Error(`no supported asset info for id = ${assetID}, and no exchange info provided`)
     }
     return xc.assets[assetID].unitInfo

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -302,8 +302,11 @@ export default class OrderPage extends BasePage {
     Doc.setVis(!m.isCancel && (makerSwapCoin(m) || !m.revoked), tmpl.makerSwap)
     Doc.setVis(!m.isCancel && (takerSwapCoin(m) || !m.revoked), tmpl.takerSwap)
     Doc.setVis(!m.isCancel && (makerRedeemCoin(m) || !m.revoked), tmpl.makerRedeem)
-    Doc.setVis(!m.isCancel && (m.side !== OrderUtil.Maker) && (takerRedeemCoin(m) || !m.revoked), tmpl.takerRedeem)
-    Doc.setVis(!m.isCancel && (m.refund || (m.revoked && m.active)), tmpl.refund)
+    // When revoked, there is uncertainty about the taker redeem coin. The taker
+    // redeem may be needed if maker redeems while taker is waiting to refund.
+    Doc.setVis(!m.isCancel && (takerRedeemCoin(m) || (!m.revoked && m.active) || ((m.side === OrderUtil.Taker) && m.active && (m.counterRedeem || !m.refund))), tmpl.takerRedeem)
+    // The refund placeholder should not be shown if there is a counter redeem.
+    Doc.setVis(!m.isCancel && (m.refund || (m.revoked && m.active && !m.counterRedeem)), tmpl.refund)
   }
 
   /*

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -134,15 +134,21 @@ export function matchStatusString (m: Match) {
     // When revoked, match status is less important than pending action if still
     // active, or the outcome if inactive.
     if (m.active) {
-      return 'Revoked - Refund PENDING' // auto-redeem also possible, but action is pending
+      if (m.redeem) return 'Revoked - Redemption Sent' // must require confirmation if active
+      // If maker and we have not redeemed, waiting to refund, assuming it's not
+      // revoked while waiting for confs on an unspent/unexpired taker swap.
+      if (m.side === Maker) return 'Revoked - Refund PENDING'
+      // As taker, resolution depends on maker's actions while waiting to refund.
+      if (m.counterRedeem) return 'Revoked - Redeem PENDING' // this should be very brief if we see the maker's redeem
+      return 'Revoked - Refund PENDING' // may switch to redeem if maker redeems on the sly
     }
     if (m.refund) {
       return 'Revoked - Refunded'
     }
     if (m.redeem) {
-      return 'Revoked - Redeemed'
+      return 'Revoked - Redemption Confirmed'
     }
-    return 'Revoked - Complete'
+    return 'Revoked - Complete' // i.e. we sent no swap
   }
 
   switch (m.status) {

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1056,17 +1056,21 @@ func (m *Market) Running() bool {
 // Asset describes an asset and its variables, and is returned as part of a
 // ConfigResult.
 type Asset struct {
-	Symbol       string       `json:"symbol"`
-	ID           uint32       `json:"id"`
-	Version      uint32       `json:"version"`
-	LotSize      uint64       `json:"lotsize,omitempty"`
-	RateStep     uint64       `json:"ratestep,omitempty"`
-	MaxFeeRate   uint64       `json:"maxfeerate"`
-	SwapSize     uint64       `json:"swapsize"`
-	SwapSizeBase uint64       `json:"swapsizebase"`
-	RedeemSize   uint64       `json:"redeemsize"`
-	SwapConf     uint16       `json:"swapconf"`
-	UnitInfo     dex.UnitInfo `json:"unitinfo"`
+	Symbol     string       `json:"symbol"`
+	ID         uint32       `json:"id"`
+	Version    uint32       `json:"version"`
+	LotSize    uint64       `json:"lotsize,omitempty"`
+	RateStep   uint64       `json:"ratestep,omitempty"`
+	MaxFeeRate uint64       `json:"maxfeerate"`
+	SwapConf   uint16       `json:"swapconf"`
+	UnitInfo   dex.UnitInfo `json:"unitinfo"`
+
+	// The swap/redeem size fields are DEPRECATED. They are implied by version.
+	// The values provided by the server in these fields should not be used by
+	// client wallets, which know the structure of their own transactions.
+	SwapSize     uint64 `json:"swapsize"`
+	SwapSizeBase uint64 `json:"swapsizebase"`
+	RedeemSize   uint64 `json:"redeemsize"`
 }
 
 // FeeAsset describes an asset for which registration fees are supported.


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/952 (part 1 anyway, because the wallet locked issue is fairly different and partially resolved by the backup refund paths)

```
client/core: self-governed trades when server is down

When the client has active swaps on a server that is either down or
mysteriously looses the market on which the trades was started, it is
still necessary to complete these orders if a swap has been broadcast.
In particular, the refund and auto-redeem/find-redemption paths need
to work as expected.

This change allows such trades to be loaded on startup even when
the asset configurations are unavailable from the server for any
reason. The lack of a market configuration or a DEX connection are also
conditions for special handling. Trades in this state are flagged as
"self-governed".

In addition to flagging self-governed trades on startup and login
(resumeTrades), the DEX connect and reconnect handlers now toggle the
flag. The reconnect handler only removes the self-governed flag if the
fresh market config includes the trade's market.

To support safely redeeming a counter-party swap and other actions
that depend on the asset configs (e.g. SwapConf, MaxFeeRate, etc).,
this supplements the db.OrderMetaData struct with both to/from SwapConf
values as they were when the order was placed. This also adds EpochDur
to the struct to help with existing logic for handling stale cancels
and other epoch orders, as well as epoch index computations when
considered with the order's ServerTime stamp.

While it is generally ill-advised to perform a client upgrade with
active orders, this also tries during order loading to get these
values if they were not stored (load as zero).
```