### PR TITLE
client/asset/btc: provide Electrum wallet path in RPCs if specified

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -112,15 +112,21 @@ var (
 			NoEcho:      true,
 		},
 		{
+			Key:         "rpcport",
+			DisplayName: "JSON-RPC Port",
+			Description: "Electrum's 'rpcport' (if not set with rpcbind)",
+		},
+		{
 			Key:          "rpcbind", // match RPCConfig struct field tags
 			DisplayName:  "JSON-RPC Address",
 			Description:  "Electrum's 'rpchost' <addr> or <addr>:<port>",
 			DefaultValue: "127.0.0.1",
 		},
 		{
-			Key:         "rpcport",
-			DisplayName: "JSON-RPC Port",
-			Description: "Electrum's 'rpcport' (if not set with rpcbind)",
+			Key:          "walletname", // match RPCConfig struct field tags
+			DisplayName:  "Wallet File",
+			Description:  "Full path to the wallet file (empty is default_wallet)",
+			DefaultValue: "", // empty string, not a nil interface
 		},
 	}
 
@@ -148,7 +154,7 @@ var (
 		Tab:         "Electrum (external)",
 		Description: "Use an external Electrum Wallet",
 		// json: DefaultConfigPath: filepath.Join(btcutil.AppDataDir("electrum", false), "config"), // e.g. ~/.electrum/config
-		ConfigOpts: append(append(ElectrumConfigOpts, apiFallbackOpt(false)), CommonConfigOpts("BTC", false)...),
+		ConfigOpts: append(append(ElectrumConfigOpts, CommonConfigOpts("BTC", false)...), apiFallbackOpt(false)),
 	}
 
 	// WalletInfo defines some general information about a Bitcoin wallet.

--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -45,7 +45,8 @@ func ElectrumWallet(cfg *BTCCloneCFG) (*ExchangeWalletElectrum, error) {
 	}
 
 	rpcCfg := &clientCfg.RPCConfig
-	ewc := electrum.NewWalletClient(rpcCfg.RPCUser, rpcCfg.RPCPass, "http://"+rpcCfg.RPCBind)
+	ewc := electrum.NewWalletClient(rpcCfg.RPCUser, rpcCfg.RPCPass,
+		"http://"+rpcCfg.RPCBind, rpcCfg.WalletName)
 	ew := newElectrumWallet(ewc, &electrumWalletConfig{
 		params:         cfg.ChainParams,
 		log:            cfg.Logger.SubLogger("ELECTRUM"),

--- a/client/asset/btc/electrum/example/wallet/main.go
+++ b/client/asset/btc/electrum/example/wallet/main.go
@@ -31,8 +31,9 @@ func run() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 	// .electrum-ltc/testnet/config: rpcuser, rpcpass, rpcport
-	const walletPass = "walletpass" // set me
-	ec := electrum.NewWalletClient("user", "pass", "http://127.0.0.1:5678")
+	const walletPass = "walletpass"                                     // set me
+	const walletName = "~/.electrum-ltc/testnet/wallets/default_wallet" // passed directly to Electrum, not resolved
+	ec := electrum.NewWalletClient("user", "pass", "http://127.0.0.1:5678", walletName)
 
 	commands, err := ec.Commands(ctx)
 	if err != nil {

--- a/client/asset/btc/electrum/jsonrpc.go
+++ b/client/asset/btc/electrum/jsonrpc.go
@@ -48,6 +48,15 @@ func prepareRequest(id uint64, method string, args interface{}) ([]byte, error) 
 	if args == nil {
 		args = []json.RawMessage{}
 	}
+	// else {
+	// 	switch reflect.TypeOf(args).Kind() {
+	// 	case reflect.Interface, reflect.Pointer, reflect.Slice, reflect.Map:
+	// 		if reflect.ValueOf(args).IsNil() {
+	// 			args = []json.RawMessage{}
+	// 		}
+	// 	default:
+	// 	}
+	// }
 
 	switch rt := reflect.TypeOf(args); rt.Kind() {
 	case reflect.Struct, reflect.Slice:

--- a/client/asset/btc/electrum/wallet.go
+++ b/client/asset/btc/electrum/wallet.go
@@ -19,9 +19,10 @@ const defaultWalletTimeout = 10 * time.Second
 
 // WalletClient is an Electrum wallet HTTP JSON-RPC client.
 type WalletClient struct {
-	reqID uint64
-	url   string
-	auth  string
+	reqID      uint64
+	url        string
+	auth       string
+	walletFile string
 
 	// HTTPClient may be set by the user to a custom http.Client. The
 	// constructor sets a vanilla client.
@@ -34,14 +35,17 @@ type WalletClient struct {
 // NewWalletClient constructs a new Electrum wallet RPC client with the given
 // authorization information and endpoint. The endpoint should include the
 // protocol, e.g. http://127.0.0.1:4567. To specify a custom http.Client or
-// request timeout, the fields may be set after construction.
-func NewWalletClient(user, pass, endpoint string) *WalletClient {
+// request timeout, the fields may be set after construction. The full path to
+// the wallet file, if provided, will be passed directly to Electrum in RPCs
+// that have an optional "wallet" field.
+func NewWalletClient(user, pass, endpoint, walletFile string) *WalletClient {
 	// Prepare the HTTP Basic Authorization request header. This avoids
 	// re-encoding it for every request with (*http.Request).SetBasicAuth.
 	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
 	return &WalletClient{
 		url:        endpoint,
 		auth:       auth,
+		walletFile: walletFile,
 		HTTPClient: &http.Client{},
 		Timeout:    defaultWalletTimeout,
 	}

--- a/client/asset/btc/electrum/wallet_methods.go
+++ b/client/asset/btc/electrum/wallet_methods.go
@@ -28,14 +28,14 @@ const (
 	methodGetUnusedAddress = "getunusedaddress"
 	methodGetTransaction   = "gettransaction"
 	methodListUnspent      = "listunspent"
-	methodGetPrivateKeys   = "getprivatekeys"
-	methodPayTo            = "payto"
+	methodGetPrivateKeys   = "getprivatekeys" // requires password for protected wallets
+	methodPayTo            = "payto"          // requires password for protected wallets
 	methodAddLocalTx       = "addtransaction"
 	methodRemoveLocalTx    = "removelocaltx"
 	methodGetTxStatus      = "get_tx_status" // only wallet txns
 	methodGetBalance       = "getbalance"
 	methodIsMine           = "ismine"
-	methodSignTransaction  = "signtransaction"
+	methodSignTransaction  = "signtransaction" // requires password for protected wallets
 	methodFreezeUTXO       = "freeze_utxo"
 	methodUnfreezeUTXO     = "unfreeze_utxo"
 )
@@ -312,7 +312,7 @@ type paytoReq struct {
 	NoCheck        bool   `json:"nocheck"`
 	Unsigned       bool   `json:"unsigned"` // unsigned returns a base64 psbt thing
 	RBF            bool   `json:"rbf"`      // default to false
-	Password       string `json:"password"`
+	Password       string `json:"password,omitempty"`
 	LockTime       *int64 `json:"locktime,omitempty"`
 	AddTransaction bool   `json:"addtransaction"`
 	Wallet         string `json:"wallet,omitempty"`
@@ -409,7 +409,7 @@ func (wc *WalletClient) Sweep(ctx context.Context, walletPass string, addr strin
 
 type signTransactionArgs struct {
 	Tx   string `json:"tx"`
-	Pass string `json:"password"`
+	Pass string `json:"password,omitempty"`
 	// 4.0.9 has privkey in this request, but 4.2 does not since it has a
 	// signtransaction_with_privkey request. (this RPC should not use positional
 	// arguments)
@@ -476,7 +476,7 @@ func (wc *WalletClient) RemoveLocalTx(ctx context.Context, txid string) error {
 
 type getPrivKeyArgs struct {
 	Addr   string `json:"address"`
-	Pass   string `json:"password"`
+	Pass   string `json:"password,omitempty"`
 	Wallet string `json:"wallet,omitempty"`
 }
 

--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -372,6 +372,7 @@ func (ew *electrumWallet) reconfigure(cfg *asset.WalletConfig, currentAddress st
 	if err != nil {
 		return false, fmt.Errorf("error parsing rpc wallet config: %w", err)
 	}
+	dexbtc.StandardizeRPCConf(&parsedCfg.RPCConfig.RPCConfig, "")
 
 	// Changing RPC settings is not supported without restart.
 	return parsedCfg.RPCConfig != *ew.rpcCfg, nil

--- a/client/asset/btc/electrum_client_test.go
+++ b/client/asset/btc/electrum_client_test.go
@@ -30,7 +30,7 @@ func Test_electrumWallet(t *testing.T) {
 	// (and the bitcoin network) and there are historical transactions that can
 	// be inspected in public block explorers.
 	const walletPass = "walletpass" // set me
-	ewc := electrum.NewWalletClient("user", "pass", "http://127.0.0.1:6789")
+	ewc := electrum.NewWalletClient("user", "pass", "http://127.0.0.1:5678", "~/.electrum/testnet/wallets/default_wallet")
 	ew := newElectrumWallet(ewc, &electrumWalletConfig{
 		params: &chaincfg.TestNet3Params,
 		log:    dex.StdOutLogger("ELECTRUM-TEST", dex.LevelTrace),

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -322,21 +322,6 @@ func (wc *rpcClient) getTxOutput(txHash *chainhash.Hash, index uint32) (*btcjson
 		&res)
 }
 
-// locked returns the wallet's lock state.
-func (wc *rpcClient) locked() bool {
-	walletInfo, err := wc.GetWalletInfo()
-	if err != nil {
-		wc.log.Errorf("GetWalletInfo error: %w", err)
-		return false
-	}
-	if walletInfo.UnlockedUntil == nil {
-		// This wallet is not encrypted.
-		return false
-	}
-
-	return time.Unix(*walletInfo.UnlockedUntil, 0).Before(time.Now())
-}
-
 func (wc *rpcClient) callHashGetter(method string, args anylist) (*chainhash.Hash, error) {
 	var txid string
 	err := wc.call(method, args, &txid)
@@ -768,6 +753,21 @@ func (wc *rpcClient) walletUnlock(pw []byte) error {
 // walletLock locks the wallet.
 func (wc *rpcClient) walletLock() error {
 	return wc.call(methodLock, nil, nil)
+}
+
+// locked returns the wallet's lock state.
+func (wc *rpcClient) locked() bool {
+	walletInfo, err := wc.GetWalletInfo()
+	if err != nil {
+		wc.log.Errorf("GetWalletInfo error: %w", err)
+		return false
+	}
+	if walletInfo.UnlockedUntil == nil {
+		// This wallet is not encrypted.
+		return false
+	}
+
+	return time.Unix(*walletInfo.UnlockedUntil, 0).Before(time.Now())
 }
 
 // sendToAddress sends the amount to the address. feeRate is in units of

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -40,7 +40,7 @@ var (
 	testParams     = &chaincfg.MainNetParams
 	mainnetPort    = 8332
 	blockPollDelay time.Duration
-	defaultHost    = "localhost"
+	defaultHost    = "127.0.0.1"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1867

To use a non-default wallet, it is necessary to:
- Include the full path to the wallet file loaded in Electrum in all RPCs that pertain to a specific wallet. This string is passed in the RPCs without interpreting the path.  See https://github.com/spesmilo/electrum/issues/7391
- Use named/dict `params` because positional arguments do not work for the wallet argument.  See https://github.com/spesmilo/electrum/issues/6221

Tested with: (1) the `electrumlive` BTC wallet "test", (2) the example/wallet/main.go app for LTC, and (3) interactive BTC testing with dexc and the UI with both an empty wallet arg for the default and a path to the wallet file `~/.electrum/testnet/wallets/wallet_1`. Tested on [a 0.5 branch](https://github.com/chappjc/dcrdex/tree/electrum-wallet-args-0.5), but almost identical.

![image](https://user-images.githubusercontent.com/9373513/192338768-a13fef3f-faa9-45fc-a7d7-52bb6969e48c.png)
