### PR TITLE
client: hide advanced pre order options if not showing by default

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1826,11 +1826,12 @@ func (btc *baseWallet) splitOption(req *asset.PreSwapForm, utxos []*compositeUTX
 
 	return &asset.OrderOption{
 		ConfigOption: asset.ConfigOption{
-			Key:          splitKey,
-			DisplayName:  "Pre-size Funds",
-			Description:  desc,
-			DefaultValue: btc.useSplitTx(),
-			IsBoolean:    true,
+			Key:           splitKey,
+			DisplayName:   "Pre-size Funds",
+			Description:   desc,
+			DefaultValue:  btc.useSplitTx(),
+			IsBoolean:     true,
+			ShowByDefault: true,
 		},
 		Boolean: &asset.BooleanConfig{
 			Reason: reason,

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1325,7 +1325,6 @@ func (dcr *ExchangeWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, erro
 				Description:  desc,
 				DefaultValue: 1.0,
 			},
-			ShowByDefault: false,
 			XYRange: &asset.XYRange{
 				Start: asset.XYRangePoint{
 					Label: "1X",
@@ -1426,13 +1425,13 @@ func (dcr *ExchangeWallet) splitOption(req *asset.PreSwapForm, utxos []*composit
 	cfg := dcr.config()
 	return &asset.OrderOption{
 		ConfigOption: asset.ConfigOption{
-			Key:          splitKey,
-			DisplayName:  "Pre-size Funds",
-			Description:  desc,
-			DefaultValue: cfg.useSplitTx,
-			IsBoolean:    true,
+			Key:           splitKey,
+			DisplayName:   "Pre-size Funds",
+			Description:   desc,
+			DefaultValue:  cfg.useSplitTx,
+			IsBoolean:     true,
+			ShowByDefault: true,
 		},
-		ShowByDefault: true,
 		Boolean: &asset.BooleanConfig{
 			Reason: reason,
 		},
@@ -1481,7 +1480,6 @@ func (dcr *ExchangeWallet) PreRedeem(req *asset.PreRedeemForm) (*asset.PreRedeem
 			Description:  "Bump the redemption transaction fees up to 2x for faster confirmations on your redemption transaction.",
 			DefaultValue: 1.0,
 		},
-		ShowByDefault: false,
 		XYRange: &asset.XYRange{
 			Start: asset.XYRangePoint{
 				Label: "1X",

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1325,6 +1325,7 @@ func (dcr *ExchangeWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, erro
 				Description:  desc,
 				DefaultValue: 1.0,
 			},
+			ShowByDefault: false,
 			XYRange: &asset.XYRange{
 				Start: asset.XYRangePoint{
 					Label: "1X",
@@ -1431,6 +1432,7 @@ func (dcr *ExchangeWallet) splitOption(req *asset.PreSwapForm, utxos []*composit
 			DefaultValue: cfg.useSplitTx,
 			IsBoolean:    true,
 		},
+		ShowByDefault: true,
 		Boolean: &asset.BooleanConfig{
 			Reason: reason,
 		},
@@ -1479,6 +1481,7 @@ func (dcr *ExchangeWallet) PreRedeem(req *asset.PreRedeemForm) (*asset.PreRedeem
 			Description:  "Bump the redemption transaction fees up to 2x for faster confirmations on your redemption transaction.",
 			DefaultValue: 1.0,
 		},
+		ShowByDefault: false,
 		XYRange: &asset.XYRange{
 			Start: asset.XYRangePoint{
 				Label: "1X",

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -245,6 +245,9 @@ type ConfigOption struct {
 	// in the settings map.
 	Repeatable string `json:"repeatable"`
 	Required   bool   `json:"required"`
+
+	// ShowByDefault to show or not options on "hide advanced options".
+	ShowByDefault bool `json:"showByDefault,omitempty"`
 }
 
 const (

--- a/client/asset/options.go
+++ b/client/asset/options.go
@@ -40,6 +40,4 @@ type OrderOption struct {
 	// Range indicates a numeric input where the user can adjust the value
 	// between a pre-defined low and high.
 	XYRange *XYRange `json:"xyRange,omitempty"`
-
-	ShowByDefault bool `json:"showByDefault,omitempty"`
 }

--- a/client/asset/options.go
+++ b/client/asset/options.go
@@ -40,4 +40,6 @@ type OrderOption struct {
 	// Range indicates a numeric input where the user can adjust the value
 	// between a pre-defined low and high.
 	XYRange *XYRange `json:"xyRange,omitempty"`
+
+	ShowByDefault bool `json:"showByDefault,omitempty"`
 }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -310,4 +310,6 @@ var EnUS = map[string]string{
 	"Configure":              "Configure",
 	"Retire":                 "Retire",
 	"Lots":                   "Lots",
+	"show advanced options":  "show advanced options",
+	"hide advanced options":  "hide advanced options",
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -102,7 +102,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=GHSXZ15s"></script>
+<script src="/js/entry.js?v=MKWgJMHgU"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -572,7 +572,15 @@
 
           <hr class="dashed mb-2 mt-3">
 
-          <div class="grey fs18 text-start">[[[Options]]]</div>
+          <div class="grey fs18 d-flex justify-content-between align-items-center">
+            [[[Options]]]
+            <span class="grey fs14 underline pointer hoverbg" id="showAdvancedOptions">
+              [[[show advanced options]]]
+            </span>
+            <span class="grey fs14 underline pointer hoverbg d-hide" id="hideAdvancedOptions">
+              [[[hide advanced options]]]
+            </span>
+          </div>
 
           <div id="vOrderOpts">
             {{template "orderOptionTemplates"}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -582,9 +582,10 @@
             </span>
           </div>
 
-          <div id="vOrderOpts">
+          <div id="vDefaultOrderOpts">
             {{template "orderOptionTemplates"}}
           </div>
+          <div id="vOtherOrderOpts" class="d-hide"></div>
         </div> {{- /* END id="vPreorder" */ -}}
 
         <div id="vUnlockPreorder">

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -339,9 +339,12 @@ export default class MarketsPage extends BasePage {
     Doc.bind(page.vUnlockSubmit, 'click', async () => { this.submitEstimateUnlock() })
     // Cancel order form.
     bindForm(page.cancelForm, page.cancelSubmit, async () => { this.submitCancel() })
-    // Order detail view
+    // Order detail view.
     Doc.bind(page.vFeeDetails, 'click', () => this.showForm(page.vDetailPane))
     Doc.bind(page.closeDetailPane, 'click', () => this.showVerifyForm())
+    // bind show or hide advanced pre order options.
+    Doc.bind(page.showAdvancedOptions, 'click', () => { this.showPreOrderAdvancedOptions() })
+    Doc.bind(page.hideAdvancedOptions, 'click', () => { this.hidePreOrderAdvancedOptions() })
     // // Bind active orders list's header sort events.
     page.recentMatchesTable.querySelectorAll('[data-ordercol]')
       .forEach((th: HTMLElement) => bind(
@@ -882,6 +885,20 @@ export default class MarketsPage extends BasePage {
     page.candleHigh.textContent = Doc.formatCoinValue(candle.highRate / this.market.rateConversionFactor)
     page.candleLow.textContent = Doc.formatCoinValue(candle.lowRate / this.market.rateConversionFactor)
     page.candleVol.textContent = Doc.formatCoinValue(candle.matchVolume, this.market.baseUnitInfo)
+  }
+
+  showPreOrderAdvancedOptions () {
+    this.preOrder(this.parseOrder(), true)
+    const page = this.page
+    Doc.hide(page.showAdvancedOptions)
+    Doc.show(page.hideAdvancedOptions)
+  }
+
+  hidePreOrderAdvancedOptions () {
+    this.preOrder(this.parseOrder(), false)
+    const page = this.page
+    Doc.hide(page.hideAdvancedOptions)
+    Doc.show(page.showAdvancedOptions)
   }
 
   /*
@@ -1570,7 +1587,7 @@ export default class MarketsPage extends BasePage {
     this.showVerifyForm()
     page.vPass.focus()
 
-    if (baseAsset.wallet.open && quoteAsset.wallet.open) this.preOrder(order)
+    if (baseAsset.wallet.open && quoteAsset.wallet.open) this.preOrder(order, false)
     else {
       Doc.hide(page.vPreorder)
       if (State.passwordIsCached()) this.unlockWalletsForEstimates('')
@@ -1616,7 +1633,7 @@ export default class MarketsPage extends BasePage {
     if (err) return this.setPreorderErr(err)
     Doc.show(page.vPreorder)
     Doc.hide(page.vUnlockPreorder)
-    this.preOrder(this.parseOrder())
+    this.preOrder(this.parseOrder(), false)
   }
 
   /*
@@ -1669,7 +1686,7 @@ export default class MarketsPage extends BasePage {
   }
 
   /* preOrder loads the options and fetches pre-order estimates */
-  async preOrder (order: TradeForm) {
+  async preOrder (order: TradeForm, showAll: boolean) {
     const page = this.page
 
     // Add swap options.
@@ -1691,7 +1708,11 @@ export default class MarketsPage extends BasePage {
           page.vFeeSummary.style.backgroundColor = `rgba(128, 128, 128, ${0.5 - 0.5 * progress})`
         })
       }
-      const addOption = (opt: OrderOption, isSwap: boolean) => page.vOrderOpts.appendChild(OrderUtil.optionElement(opt, order, changed, isSwap))
+      const addOption = (opt: OrderOption, isSwap: boolean) => {
+        if (opt.showByDefault || showAll) {
+          page.vOrderOpts.appendChild(OrderUtil.optionElement(opt, order, changed, isSwap))
+        }
+      }
       for (const opt of swap.options || []) addOption(opt, true)
       for (const opt of redeem.options || []) addOption(opt, false)
       app().bindTooltips(page.vOrderOpts)

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1668,31 +1668,30 @@ export default class MarketsPage extends BasePage {
     page.vPreorderErrTip.dataset.tooltip = msg
   }
 
-  showPreOrderAdvancedOptions (order: TradeForm, swap: PreSwap, redeem: PreRedeem, changed: ()=>void) {
+  showPreOrderAdvancedOptions () {
     const page = this.page
     Doc.hide(page.showAdvancedOptions)
-    Doc.show(page.hideAdvancedOptions)
-    this.reloadOrderOpts(order, swap, redeem, true, changed)
+    Doc.show(page.hideAdvancedOptions, page.vOtherOrderOpts)
   }
 
-  hidePreOrderAdvancedOptions (order: TradeForm, swap: PreSwap, redeem: PreRedeem, changed: ()=>void) {
+  hidePreOrderAdvancedOptions () {
     const page = this.page
-    Doc.hide(page.hideAdvancedOptions)
+    Doc.hide(page.hideAdvancedOptions, page.vOtherOrderOpts)
     Doc.show(page.showAdvancedOptions)
-    this.reloadOrderOpts(order, swap, redeem, false, changed)
   }
 
-  reloadOrderOpts (order: TradeForm, swap: PreSwap, redeem: PreRedeem, showAll: boolean, changed: ()=>void) {
+  reloadOrderOpts (order: TradeForm, swap: PreSwap, redeem: PreRedeem, changed: ()=>void) {
     const page = this.page
-    Doc.empty(page.vOrderOpts)
+    Doc.empty(page.vDefaultOrderOpts, page.vOtherOrderOpts)
     const addOption = (opt: OrderOption, isSwap: boolean) => {
-      if (opt.showByDefault || showAll) {
-        page.vOrderOpts.appendChild(OrderUtil.optionElement(opt, order, changed, isSwap))
-      }
+      const el = OrderUtil.optionElement(opt, order, changed, isSwap)
+      if (opt.showByDefault) page.vDefaultOrderOpts.appendChild(el)
+      else page.vOtherOrderOpts.appendChild(el)
     }
     for (const opt of swap.options || []) addOption(opt, true)
     for (const opt of redeem.options || []) addOption(opt, false)
-    app().bindTooltips(page.vOrderOpts)
+    app().bindTooltips(page.vDefaultOrderOpts)
+    app().bindTooltips(page.vOtherOrderOpts)
   }
 
   /* preOrder loads the options and fetches pre-order estimates */
@@ -1718,9 +1717,9 @@ export default class MarketsPage extends BasePage {
         })
       }
       // bind show or hide advanced pre order options.
-      Doc.bind(page.showAdvancedOptions, 'click', () => { this.showPreOrderAdvancedOptions(order, swap, redeem, changed) })
-      Doc.bind(page.hideAdvancedOptions, 'click', () => { this.hidePreOrderAdvancedOptions(order, swap, redeem, changed) })
-      this.reloadOrderOpts(order, swap, redeem, false, changed)
+      Doc.bind(page.showAdvancedOptions, 'click', () => { this.showPreOrderAdvancedOptions() })
+      Doc.bind(page.hideAdvancedOptions, 'click', () => { this.hidePreOrderAdvancedOptions() })
+      this.reloadOrderOpts(order, swap, redeem, changed)
     }
 
     refreshPreorder()

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -404,6 +404,7 @@ export interface XYRange {
 export interface OrderOption extends ConfigOption {
   boolean?: BooleanConfig
   xyRange?: XYRange
+  showByDefault?: boolean
 }
 
 export interface SwapEstimate {


### PR DESCRIPTION
This PR closes: #1874.

I added a `ShowByDefault` config option into `OrderOption struct`, which defines value to show by default. 

I am showing the txsplit option by default and hiding the others, as chapp showed interest in keep showing it. 

How it looks right now: 

hiding:
![image](https://user-images.githubusercontent.com/15069783/193667299-b5639b6f-aa30-41d7-9cb5-0cc387b1ff08.png)

showing:
![image](https://user-images.githubusercontent.com/15069783/193667322-786ef9e4-9ebb-4ed7-9ee4-442ee6c7b9e3.png)

