### PR TITLE
asset/eth: create node client on Connect

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -342,6 +342,7 @@ type baseWallet struct {
 	node ethFetcher
 	addr common.Address
 	log  dex.Logger
+	dir  string
 
 	gasFeeLimitV uint64 // atomic
 
@@ -476,13 +477,8 @@ func CreateWallet(createWalletParams *asset.CreateWalletParams) error {
 }
 
 // NewWallet is the exported constructor by which the DEX will import the
-// exchange wallet. It starts an internal light node.
+// exchange wallet.
 func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network) (*ETHWallet, error) {
-	cl, err := newNodeClient(getWalletDir(assetCFG.DataDir, net), net, logger.SubLogger("NODE"))
-	if err != nil {
-		return nil, err
-	}
-
 	cfg, err := parseWalletConfig(assetCFG.Settings)
 	if err != nil {
 		return nil, err
@@ -493,20 +489,13 @@ func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network)
 		gasFeeLimit = defaultGasFeeLimit
 	}
 
-	db, err := kvdb.NewFileDB(filepath.Join(assetCFG.DataDir, "tx.db"), logger.SubLogger("TXDB"))
-	if err != nil {
-		return nil, err
-	}
-
 	eth := &baseWallet{
-		log:           logger,
-		net:           net,
-		node:          cl,
-		addr:          cl.address(),
-		gasFeeLimitV:  gasFeeLimit,
-		wallets:       make(map[uint32]*assetWallet),
-		monitoredTxs:  make(map[common.Hash]*monitoredTx),
-		monitoredTxDB: db,
+		log:          logger,
+		net:          net,
+		dir:          assetCFG.DataDir,
+		gasFeeLimitV: gasFeeLimit,
+		wallets:      make(map[uint32]*assetWallet),
+		monitoredTxs: make(map[common.Hash]*monitoredTx),
 	}
 
 	w := &assetWallet{
@@ -567,8 +556,22 @@ func loadMonitoredTxs(db kvdb.KeyValueDB) (map[common.Hash]*monitoredTx, error) 
 
 // Connect connects to the node RPC server. Satisfies dex.Connector.
 func (w *ETHWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
+	cl, err := newNodeClient(getWalletDir(w.dir, w.net), w.net, w.log.SubLogger("NODE"))
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := kvdb.NewFileDB(filepath.Join(w.dir, "tx.db"), w.log.SubLogger("TXDB"))
+	if err != nil {
+		return nil, err
+	}
+
+	w.node = cl
+	w.addr = cl.address()
+	w.monitoredTxDB = db
 	w.ctx = ctx
-	err := w.node.connect(ctx)
+
+	err = w.node.connect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -479,11 +479,6 @@ func CreateWallet(createWalletParams *asset.CreateWalletParams) error {
 // NewWallet is the exported constructor by which the DEX will import the
 // exchange wallet.
 func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network) (*ETHWallet, error) {
-	cl, err := newNodeClient(getWalletDir(assetCFG.DataDir, net), net, logger.SubLogger("NODE"))
-	if err != nil {
-		return nil, err
-	}
-
 	cfg, err := parseWalletConfig(assetCFG.Settings)
 	if err != nil {
 		return nil, err
@@ -497,8 +492,6 @@ func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network)
 	eth := &baseWallet{
 		log:          logger,
 		net:          net,
-		node:         cl,
-		addr:         cl.address(),
 		dir:          assetCFG.DataDir,
 		gasFeeLimitV: gasFeeLimit,
 		wallets:      make(map[uint32]*assetWallet),
@@ -563,8 +556,15 @@ func loadMonitoredTxs(db kvdb.KeyValueDB) (map[common.Hash]*monitoredTx, error) 
 
 // Connect connects to the node RPC server. Satisfies dex.Connector.
 func (w *ETHWallet) Connect(ctx context.Context) (*sync.WaitGroup, error) {
+	cl, err := newNodeClient(getWalletDir(w.dir, w.net), w.net, w.log.SubLogger("NODE"))
+	if err != nil {
+		return nil, err
+	}
+
+	w.node = cl
+	w.addr = cl.address()
 	w.ctx = ctx
-	err := w.node.connect(ctx)
+	err = w.node.connect(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -2957,7 +2957,6 @@ func TestDriverOpen(t *testing.T) {
 	if eth.gasFeeLimit() != defaultGasFeeLimit {
 		t.Fatalf("expected gasFeeLimit to be default, but got %v", eth.gasFeeLimit())
 	}
-	eth.shutdown()
 
 	// Make sure gas fee limit is properly parsed from settings
 	cfg.Settings["gasfeelimit"] = "150"

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1861,31 +1861,15 @@ func (c *Core) ToggleWalletStatus(assetID uint32, disable bool) error {
 			return fmt.Errorf("token parent wallet is disabled")
 		}
 
-		dbWallet, err := c.db.Wallet(wallet.dbID)
-		if err != nil {
-			return fmt.Errorf("error retrieving DB wallet: %w", err)
-		}
-
-		wallet, err = c.loadWallet(dbWallet)
-		if err != nil {
-			return newError(walletErr, "error loading wallet for %d -> %s: %w",
-				assetID, unbip(assetID), err)
-		}
-
 		// Update wallet status before attempting to connect wallet because disabled
 		// wallets cannot be connected to.
 		wallet.setDisabled(false)
 
 		// Attempt to connect wallet.
-		err = c.connectAndUpdateWallet(wallet)
+		err := c.connectAndUpdateWallet(wallet)
 		if err != nil {
 			c.log.Errorf("Error connecting to %s wallet: %v", unbip(assetID), err)
 		}
-
-		// The wallet has been successfully enabled.
-		c.walletMtx.Lock()
-		c.wallets[assetID] = wallet
-		c.walletMtx.Unlock()
 	}
 
 	// Update db with wallet status.


### PR DESCRIPTION
`ETH` `NewWallet` initializes a node client and database and when initializing the node client, a lock is placed on the wallet's `datadir`. As a result, trying to enable the wallet will return `datadir already used by another process` because `loadWallet` will eventually call `NewWallet` which will try to initialize the node client and place a lock on the already locked `datadir`. Closes #1883