### PR TITLE
core/eth: Handle block gas limit

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/tyler-smith/go-bip39"
 )
@@ -384,6 +385,9 @@ type assetWallet struct {
 
 	evmify  func(uint64) *big.Int
 	atomize func(*big.Int) uint64
+
+	maxSwapsInTx   uint64
+	maxRedeemsInTx uint64
 }
 
 // ETHWallet implements some Ethereum-specific methods.
@@ -408,16 +412,22 @@ type TokenWallet struct {
 	token    *dexeth.Token
 }
 
+const maxProportionOfBlockGasLimitToUse = 4
+
 // Info returns basic information about the wallet and asset.
-func (*ETHWallet) Info() *asset.WalletInfo {
+func (w *ETHWallet) Info() *asset.WalletInfo {
+	WalletInfo.MaxSwapsInTx = w.maxSwapsInTx
+	WalletInfo.MaxRedeemsInTx = w.maxRedeemsInTx
 	return WalletInfo
 }
 
 // Info returns basic information about the wallet and asset.
 func (w *TokenWallet) Info() *asset.WalletInfo {
 	return &asset.WalletInfo{
-		Name:     w.token.Name,
-		UnitInfo: w.token.UnitInfo,
+		Name:           w.token.Name,
+		UnitInfo:       w.token.UnitInfo,
+		MaxSwapsInTx:   w.maxSwapsInTx,
+		MaxRedeemsInTx: w.maxRedeemsInTx,
 	}
 }
 
@@ -509,6 +519,17 @@ func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network)
 		monitoredTxDB: db,
 	}
 
+	gasCeil := ethconfig.Defaults.Miner.GasCeil
+	var maxSwapGas, maxRedeemGas uint64
+	for _, gases := range dexeth.VersionedGases {
+		if gases.Swap > maxSwapGas {
+			maxSwapGas = gases.Swap
+		}
+		if gases.Redeem > maxRedeemGas {
+			maxRedeemGas = gases.Redeem
+		}
+	}
+
 	w := &assetWallet{
 		baseWallet:         eth,
 		log:                logger.SubLogger("ETH"),
@@ -520,6 +541,8 @@ func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network)
 		evmify:             dexeth.GweiToWei,
 		atomize:            dexeth.WeiToGwei,
 		atomicUnit:         dexeth.UnitInfo.AtomicUnit,
+		maxSwapsInTx:       gasCeil / maxProportionOfBlockGasLimitToUse / maxSwapGas,
+		maxRedeemsInTx:     gasCeil / maxProportionOfBlockGasLimitToUse / maxRedeemGas,
 	}
 
 	w.wallets = map[uint32]*assetWallet{
@@ -722,6 +745,22 @@ func (w *ETHWallet) OpenTokenWallet(tokenCfg *asset.TokenConfig) (asset.Wallet, 
 		return nil, err
 	}
 
+	netToken := token.NetTokens[w.net]
+	if netToken == nil || len(netToken.SwapContracts) == 0 {
+		return nil, fmt.Errorf("could not find token with ID %d on network %s", w.assetID, w.net)
+	}
+
+	gasCeil := ethconfig.Defaults.Miner.GasCeil
+	var maxSwapGas, maxRedeemGas uint64
+	for _, contract := range netToken.SwapContracts {
+		if contract.Gas.Swap > maxSwapGas {
+			maxSwapGas = contract.Gas.Swap
+		}
+		if contract.Gas.Redeem > maxRedeemGas {
+			maxRedeemGas = contract.Gas.Redeem
+		}
+	}
+
 	aw := &assetWallet{
 		baseWallet:         w.baseWallet,
 		log:                w.baseWallet.log.SubLogger(strings.ToUpper(dex.BipIDSymbol(tokenCfg.AssetID))),
@@ -733,6 +772,8 @@ func (w *ETHWallet) OpenTokenWallet(tokenCfg *asset.TokenConfig) (asset.Wallet, 
 		evmify:             token.AtomicToEVM,
 		atomize:            token.EVMToAtomic,
 		atomicUnit:         token.UnitInfo.AtomicUnit,
+		maxSwapsInTx:       gasCeil / maxProportionOfBlockGasLimitToUse / maxSwapGas,
+		maxRedeemsInTx:     gasCeil / maxProportionOfBlockGasLimitToUse / maxRedeemGas,
 	}
 
 	w.baseWallet.walletsMtx.Lock()

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -412,6 +412,9 @@ type TokenWallet struct {
 	token    *dexeth.Token
 }
 
+// maxProportionOfBlockGasLimitToUse sets the maximum proportion of a block's
+// gas limit that a swap and redeem transaction will use. Since it is set to
+// 4, the max that will be used is 25% (1/4) of the block's gas limit.
 const maxProportionOfBlockGasLimitToUse = 4
 
 // Info returns basic information about the wallet and asset.

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -628,10 +628,15 @@ func tassetWallet(assetID uint32) (asset.Wallet, *assetWallet, *testNode, contex
 			assetID:     BipID,
 			atomize:     dexeth.WeiToGwei,
 		}
+		testTokenID, found := dex.BipSymbolID("dextt.eth")
+		if !found {
+			panic("could not find test token ID")
+		}
 		w = &TokenWallet{
 			assetWallet: aw,
 			cfg:         &tokenWalletConfig{},
 			parent:      node.tokenParent,
+			token:       dexeth.Tokens[testTokenID],
 		}
 		aw.wallets = map[uint32]*assetWallet{
 			testTokenID: aw,
@@ -4529,6 +4534,69 @@ func testEstimateSendTxFee(t *testing.T, assetID uint32) {
 		}
 		if err != nil {
 			t.Fatalf("%s: unexpected error: %v", test.name, err)
+		}
+	}
+}
+
+// This test will fail if new versions of the eth or the test token
+// contract (that require more gas) are added.
+func TestMaxSwapRedeemLots(t *testing.T) {
+	t.Run("eth", func(t *testing.T) { testMaxSwapRedeemLots(t, BipID) })
+	t.Run("token", func(t *testing.T) { testMaxSwapRedeemLots(t, testTokenID) })
+}
+
+func testMaxSwapRedeemLots(t *testing.T, assetID uint32) {
+	drv := &Driver{}
+	logger := dex.StdOutLogger("ETHTEST", dex.LevelOff)
+	tmpDir := t.TempDir()
+
+	err := CreateWallet(&asset.CreateWalletParams{
+		Type:     walletTypeGeth,
+		Seed:     encode.RandomBytes(32),
+		Pass:     encode.RandomBytes(32),
+		Settings: make(map[string]string),
+		DataDir:  tmpDir,
+		Net:      dex.Testnet,
+		Logger:   logger,
+	})
+	if err != nil {
+		t.Fatalf("CreateWallet error: %v", err)
+	}
+
+	wallet, err := drv.Open(&asset.WalletConfig{
+		Type:     walletTypeGeth,
+		Settings: make(map[string]string),
+		DataDir:  tmpDir,
+	}, logger, dex.Testnet)
+	if err != nil {
+		t.Fatalf("driver open error: %v", err)
+	}
+
+	if assetID != BipID {
+		eth, _ := wallet.(*ETHWallet)
+		eth.net = dex.Simnet
+		wallet, err = eth.OpenTokenWallet(&asset.TokenConfig{
+			AssetID: assetID,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	info := wallet.Info()
+	if assetID == BipID {
+		if info.MaxSwapsInTx != 55 {
+			t.Fatalf("expected 55 for max swaps but got %d", info.MaxSwapsInTx)
+		}
+		if info.MaxRedeemsInTx != 119 {
+			t.Fatalf("expected 119 for max redemptions but got %d", info.MaxRedeemsInTx)
+		}
+	} else {
+		if info.MaxSwapsInTx != 43 {
+			t.Fatalf("expected 43 for max swaps but got %d", info.MaxSwapsInTx)
+		}
+		if info.MaxRedeemsInTx != 107 {
+			t.Fatalf("expected 107 for max redemptions but got %d", info.MaxRedeemsInTx)
 		}
 	}
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -207,6 +207,12 @@ type WalletInfo struct {
 	// UnitInfo is the information about unit names and conversion factors for
 	// the asset.
 	UnitInfo dex.UnitInfo `json:"unitinfo"`
+	// MaxSwapsInTx is the max amount of swaps that this wallet can do in a
+	// single transaction.
+	MaxSwapsInTx uint64
+	// MaxRedeemsInTx is the max amount of redemptions that this wallet can do
+	// in a single transaction.
+	MaxRedeemsInTx uint64
 }
 
 // ConfigOption is a wallet configuration option.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -2090,7 +2090,18 @@ func (c *Core) swapMatches(t *trackedTrade, matches []*matchTracker) error {
 		}
 	}
 	if len(groupables) > 0 {
-		c.swapMatchGroup(t, groupables, errs)
+		maxSwapsInTx := int(t.wallets.fromWallet.Info().MaxSwapsInTx)
+		if maxSwapsInTx <= 0 || len(groupables) < maxSwapsInTx {
+			c.swapMatchGroup(t, groupables, errs)
+		} else {
+			for i := 0; i < len(groupables); i += maxSwapsInTx {
+				if i+maxSwapsInTx < len(groupables) {
+					c.swapMatchGroup(t, groupables[i:i+maxSwapsInTx], errs)
+				} else {
+					c.swapMatchGroup(t, groupables[i:], errs)
+				}
+			}
+		}
 	}
 	for _, m := range suspects {
 		c.swapMatchGroup(t, []*matchTracker{m}, errs)
@@ -2431,7 +2442,18 @@ func (c *Core) redeemMatches(t *trackedTrade, matches []*matchTracker) error {
 		}
 	}
 	if len(groupables) > 0 {
-		c.redeemMatchGroup(t, groupables, errs)
+		maxRedeemsInTx := int(t.wallets.toWallet.Info().MaxRedeemsInTx)
+		if maxRedeemsInTx <= 0 || len(groupables) < maxRedeemsInTx {
+			c.redeemMatchGroup(t, groupables, errs)
+		} else {
+			for i := 0; i < len(groupables); i += maxRedeemsInTx {
+				if i+maxRedeemsInTx < len(groupables) {
+					c.redeemMatchGroup(t, groupables[i:i+maxRedeemsInTx], errs)
+				} else {
+					c.redeemMatchGroup(t, groupables[i:], errs)
+				}
+			}
+		}
 	}
 	for _, m := range suspects {
 		c.redeemMatchGroup(t, []*matchTracker{m}, errs)


### PR DESCRIPTION
Two new fields are added to `asset.WalletInfo`: `MaxSwapsInTx` and `MaxRedeemsInTx`. `Core` uses these fields to call `Swap` and `Redeem` in batches if needed. These fields are currently only populated by ETH and ETH token wallets. They check each of the versions of the contract, and the fields are populated so that at most 1/4 of the gas limit of a block can be filled up by a swap or redeem transaction.

Closes #1771