### PR TITLE
client/core: Refactor Login

### DIFF
--- a/client/cmd/mmbot/main.go
+++ b/client/cmd/mmbot/main.go
@@ -167,7 +167,7 @@ func mainErr() error {
 		return fmt.Errorf("no market %q", mktName)
 	}
 
-	if _, err := c.Login(appPW); err != nil {
+	if err := c.Login(appPW); err != nil {
 		return fmt.Errorf("login error: %w", err)
 	}
 

--- a/client/core/account.go
+++ b/client/core/account.go
@@ -197,6 +197,7 @@ func (c *Core) AccountImport(pw []byte, acct Account) error {
 		}
 	}
 
+	c.initializeDEXConnections(crypter)
 	return nil
 }
 

--- a/client/core/locale_ntfn.go
+++ b/client/core/locale_ntfn.go
@@ -362,6 +362,10 @@ var originLocale = map[Topic]*translation{
 		subject:  "Wallet Disabled",
 		template: "Your %s wallet type is no longer supported. Create a new wallet.",
 	},
+	TopicOrderResumeFailure: {
+		subject:  "Resume order failure",
+		template: "Failed to resume processing of trade: %v",
+	},
 }
 
 var ptBR = map[Topic]*translation{

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -248,6 +248,7 @@ type OrderNote struct {
 
 const (
 	TopicOrderLoadFailure     Topic = "OrderLoadFailure"
+	TopicOrderResumeFailure   Topic = "OrderResumeFailure"
 	TopicBuyOrderPlaced       Topic = "BuyOrderPlaced"
 	TopicSellOrderPlaced      Topic = "SellOrderPlaced"
 	TopicYoloPlaced           Topic = "YoloPlaced"

--- a/client/core/simnet_trade.go
+++ b/client/core/simnet_trade.go
@@ -814,7 +814,7 @@ func testOrderStatusReconciliation(s *simulationTest) error {
 	// to trigger dex authentication.
 	// TODO: cannot do this anymore with built-in wallets
 	s.client2.core.initialize()
-	_, err = s.client2.core.Login(s.client2.appPass)
+	err = s.client2.core.Login(s.client2.appPass)
 	if err != nil {
 		return fmt.Errorf("client 2 login error: %w", err)
 	}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -333,6 +333,7 @@ type Order struct {
 	Rate              uint64            `json:"rate"`          // limit only
 	TimeInForce       order.TimeInForce `json:"tif"`           // limit only
 	TargetOrderID     dex.Bytes         `json:"targetOrderID"` // cancel only
+	ReadyToTick       bool              `json:"readyToTick"`
 }
 
 // InFlightOrder is an Order that is not stamped yet, but has a temporary ID
@@ -927,21 +928,6 @@ func coinIDString(assetID uint32, coinID []byte) string {
 		return "<invalid coin>:" + hex.EncodeToString(coinID)
 	}
 	return coinStr
-}
-
-// DEXBrief holds data returned from initializeDEXConnections.
-type DEXBrief struct {
-	Host     string   `json:"host"`
-	AcctID   string   `json:"acctID"`
-	Authed   bool     `json:"authed"`
-	AuthErr  string   `json:"autherr,omitempty"`
-	TradeIDs []string `json:"tradeIDs"`
-}
-
-// LoginResult holds data returned from Login.
-type LoginResult struct {
-	Notifications []*db.Notification `json:"notifications"`
-	DEXes         []*DEXBrief        `json:"dexes"`
 }
 
 // RegisterResult holds data returned from Register.

--- a/client/rpcserver/handlers_test.go
+++ b/client/rpcserver/handlers_test.go
@@ -676,13 +676,12 @@ func TestHandleLogin(t *testing.T) {
 	}}
 	for _, test := range tests {
 		tc := &TCore{
-			loginResult: &core.LoginResult{},
-			loginErr:    test.loginErr,
+			loginErr: test.loginErr,
 		}
 		r := &RPCServer{core: tc}
 		payload := handleLogin(r, test.params)
-		var res *core.LoginResult
-		if err := verifyResponse(payload, &res, test.wantErrCode); err != nil {
+		successString := "successfully logged in"
+		if err := verifyResponse(payload, &successString, test.wantErrCode); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -22,6 +22,7 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/client/websocket"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
@@ -63,7 +64,7 @@ type clientCore interface {
 	DiscoverAccount(dexAddr string, pass []byte, certI interface{}) (*core.Exchange, bool, error)
 	Exchanges() (exchanges map[string]*core.Exchange)
 	InitializeClient(appPass, seed []byte) error
-	Login(appPass []byte) (*core.LoginResult, error)
+	Login(appPass []byte) error
 	Logout() error
 	OpenWallet(assetID uint32, appPass []byte) error
 	ToggleWalletStatus(assetID uint32, disable bool) error
@@ -79,6 +80,7 @@ type clientCore interface {
 	WalletPeers(assetID uint32) ([]*asset.WalletPeer, error)
 	AddWalletPeer(assetID uint32, host string) error
 	RemoveWalletPeer(assetID uint32, host string) error
+	Notifications(int) ([]*db.Notification, error)
 }
 
 // RPCServer is a single-client http and websocket server enabling a JSON

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -19,6 +19,7 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
 )
@@ -49,7 +50,6 @@ type TCore struct {
 	registerErr              error
 	exchanges                map[string]*core.Exchange
 	loginErr                 error
-	loginResult              *core.LoginResult
 	order                    *core.Order
 	tradeErr                 error
 	cancelErr                error
@@ -96,8 +96,8 @@ func (c *TCore) Exchange(host string) (*core.Exchange, error) {
 func (c *TCore) InitializeClient(pw, seed []byte) error {
 	return c.initializeClientErr
 }
-func (c *TCore) Login(appPass []byte) (*core.LoginResult, error) {
-	return c.loginResult, c.loginErr
+func (c *TCore) Login(appPass []byte) error {
+	return c.loginErr
 }
 func (c *TCore) Logout() error {
 	return c.logoutErr
@@ -158,6 +158,9 @@ func (c *TCore) AddWalletPeer(assetID uint32, address string) error {
 }
 func (c *TCore) RemoveWalletPeer(assetID uint32, address string) error {
 	return nil
+}
+func (c *TCore) Notifications(n int) ([]*db.Notification, error) {
+	return nil, nil
 }
 
 type tBookFeed struct{}

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -630,3 +630,14 @@ func parseAddRemoveWalletPeerArgs(params *RawParams) (form *addRemovePeerForm, e
 	form.address = params.Args[1]
 	return form, nil
 }
+
+func parseNotificationsArgs(params *RawParams) (int, error) {
+	if err := checkNArgs(params, []int{0}, []int{1}); err != nil {
+		return 0, err
+	}
+	num, err := checkUIntArg(params.Args[0], "num", 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid num: %v", err)
+	}
+	return int(num), nil
+}

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -622,9 +622,12 @@ func (c *TCore) ValidateAddress(address string, assetID uint32) (bool, error) {
 func (c *TCore) EstimateSendTxFee(addr string, assetID uint32, value uint64, subtract bool) (fee uint64, isValidAddress bool, err error) {
 	return uint64(float64(value) * 0.01), len(addr) > 10, nil
 }
-func (c *TCore) Login([]byte) (*core.LoginResult, error) { return &core.LoginResult{}, nil }
-func (c *TCore) IsInitialized() bool                     { return true }
-func (c *TCore) Logout() error                           { return nil }
+func (c *TCore) Login([]byte) error  { return nil }
+func (c *TCore) IsInitialized() bool { return true }
+func (c *TCore) Logout() error       { return nil }
+func (c *TCore) Notifications(n int) ([]*db.Notification, error) {
+	return nil, nil
+}
 
 var orderAssets = []string{"dcr", "btc", "ltc", "doge", "mona", "vtc", "dextt.eth"}
 

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -318,4 +318,5 @@ var EnUS = map[string]string{
 	"source":                 "Source",
 	"connected":              "Connected",
 	"Remove":                 "Remove",
+	"unready_wallets_msg":    "Your wallets must be connected and unlocked before trades can be processed. Resolve this ASAP!",
 }

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -122,6 +122,14 @@ div[data-handler=markets] {
     }
   }
 
+  #unreadyOrdersMsg {
+    color: red;
+  }
+
+  .unready-user-order {
+    background-color: #6e0909;
+  }
+
   .user-order {
     margin: 0 20px;
     border: 1px solid $light_border_color;

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -360,6 +360,7 @@
 
               {{- /* USER ORDERS */ -}}
               <div class="text-center fs20 sans-light my-1">[[[Your Orders]]]</div>
+              <div id="unreadyOrdersMsg" class="d-hide px-3 py-1 flex-center fs16 red">[[[unready_wallets_msg]]]</div>
               <div id="userNoOrders" class="p-3 flex-center fs16 grey">no active orders</div>
               <div id="userOrders" class="mb-3">
                 <div id="userOrderTmpl" class="user-order">

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -1600,8 +1600,8 @@ export class LoginForm {
     }
     if (res.notes) {
       res.notes.reverse()
+      app().setNotes(res.notes)
     }
-    app().setNotes(res.notes || [])
     if (this.pwCache) this.pwCache.pw = pw
     this.success()
   }

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -91,6 +91,7 @@ export interface Order {
   rate: number // limit only
   tif: number // limit only
   targetOrderID: string // cancel only
+  readyToTick: boolean
 }
 
 export interface Match {

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -257,12 +257,6 @@ export default class SettingsPage extends BasePage {
       Doc.show(page.importAccountErr)
       return
     }
-    const loginResponse = await postJSON('/api/login', { pass: pw })
-    if (!app().checkResponse(loginResponse)) {
-      page.importAccountErr.textContent = loginResponse.msg
-      Doc.show(page.importAccountErr)
-      return
-    }
     await app().fetchUser()
     Doc.hide(page.forms)
     // Initial method of displaying imported account.

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -26,6 +26,7 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/client/webserver/locales"
 	"decred.org/dcrdex/client/websocket"
 	"decred.org/dcrdex/dex"
@@ -92,7 +93,7 @@ type clientCore interface {
 	Exchanges() map[string]*core.Exchange
 	Exchange(host string) (*core.Exchange, error)
 	Register(*core.RegisterForm) (*core.RegisterResult, error)
-	Login(pw []byte) (*core.LoginResult, error)
+	Login(pw []byte) error
 	InitializeClient(pw, seed []byte) error
 	AssetBalance(assetID uint32) (*core.WalletBalance, error)
 	CreateWallet(appPW, walletPW []byte, form *core.WalletForm) error
@@ -151,6 +152,7 @@ type clientCore interface {
 	WalletPeers(assetID uint32) ([]*asset.WalletPeer, error)
 	AddWalletPeer(assetID uint32, addr string) error
 	RemoveWalletPeer(assetID uint32, addr string) error
+	Notifications(n int) ([]*db.Notification, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -414,7 +416,6 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/getwalletpeers", s.apiGetWalletPeers)
 			apiAuth.Post("/addwalletpeer", s.apiAddWalletPeer)
 			apiAuth.Post("/removewalletpeer", s.apiRemoveWalletPeer)
-
 			if s.experimental {
 				apiAuth.Post("/createbot", s.apiCreateBot)
 				apiAuth.Post("/startbot", s.apiStartBot)

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -84,6 +84,7 @@ const (
 	BondError                            // 66
 	BondAlreadyConfirmingError           // 67
 	RPCWalletPeersError                  // 68
+	RPCNotificationsError                // 69
 )
 
 // Routes are destinations for a "payload" of data. The type of data being


### PR DESCRIPTION
`client/core`: 
- Login is updated not return a `LoginResult`. It only returns an error if the password is incorrect. On the first login after startup or after a logout, the wallets are connected, active trades are resolved, and the dex connections are authed. On subsequent logins, only the password is checked.
- Two new functions, `GetNotifications` and `AuthDEXConnections` are added.
- `loadDBTrades` now adds all trades for which a `walletSet` is able to be generated to the `dexConnection`'s trades map. A field `readyToTick` is added to `trackedTrade`, and `tick` returns early for trades where it is set to false. `resumeTrades` will set `readyToTick` to true for all trades where both wallets can be unlocked. `resumeTrades` is also called whenever a wallet is unlocked or connected in order to possibly resume trades that were previously unable to have both wallets unlocked.
 
`client/webserver`:
- `/api/getnotes` and `/api/authdexconns` are added.

`app`:
- `/api/getnotes` is called after login to retrieve existing notifications since this is now removed from login.
- `/api/authdexconns` is called instead of `/api/login` after a dex account is imported.
- Active trades that have `readyToTick` will have their header displayed in red on the market's page. Also a message asking the user to unlock their wallets is displayed.

![Screen Shot 2022-11-22 at 9 28 04 AM](https://user-images.githubusercontent.com/6186350/203339507-2ad17b79-6251-437f-b1cf-18e1445188a9.png)

Closes #1762 