### PR TITLE
client/tests: Fix simnet tests.

### DIFF
--- a/client/cmd/simnet-trade-tests/run
+++ b/client/cmd/simnet-trade-tests/run
@@ -86,7 +86,7 @@ dcrdextt - Decred RPC wallet and Ethereum wallet with dextt.eth test token on ma
 
 ---------------------
 
-One or more of the following tests can be run by specifying one or more -t flags. Default is ['success'].
+One or more of the following tests can be run by specifying one or more -t flags. Default is ['success']. All tests for an asset pair can be run with --all. When using --all, tests can be excluded with --except=test_name.
 
 EOF
 

--- a/dex/testing/zec/harness.sh
+++ b/dex/testing/zec/harness.sh
@@ -33,10 +33,10 @@ mkdir -p "${HARNESS_DIR}"
 
 WALLET_PASSWORD="abc"
 
-ALPHA_CLI_CFG="-rpcport=${ALPHA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass"
-BETA_CLI_CFG="-rpcport=${BETA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass"
-DELTA_CLI_CFG="-rpcport=${DELTA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass"
-GAMMA_CLI_CFG="-rpcport=${GAMMA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass"
+ALPHA_CLI_CFG="-rpcport=${ALPHA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass -conf=${ALPHA_DIR}/alpha.conf"
+BETA_CLI_CFG="-rpcport=${BETA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass -conf=${BETA_DIR}/beta.conf"
+DELTA_CLI_CFG="-rpcport=${DELTA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass -conf=${DELTA_DIR}/delta.conf"
+GAMMA_CLI_CFG="-rpcport=${GAMMA_RPC_PORT} -regtest=1 -rpcuser=user -rpcpassword=pass -conf=${GAMMA_DIR}/gamma.conf"
 
 # DONE can be used in a send-keys call along with a `wait-for btc` command to
 # wait for process termination.

--- a/server/matcher/match.go
+++ b/server/matcher/match.go
@@ -434,7 +434,7 @@ func matchMarketBuyOrder(book Booker, ord *order.MarketOrder) (matchSet *order.M
 
 	lotSize := book.LotSize()
 
-	// Amount remaining for market buy is in *quoute* asset, not base asset.
+	// Amount remaining for market buy is in *quote* asset, not base asset.
 	amtRemaining := ord.Remaining() // i.e. ord.Quantity - ord.FillAmt
 	if amtRemaining == 0 {
 		return


### PR DESCRIPTION
    Fix numerous balance calculating issues. Run most tests twice,
    alternating the maker and taker between clients. Add all, except, and
    runonce commands. Cause requests to fail using communications rather
    than altering match data.

closes #1783 and fixes some other problems with them not running.