### PR TITLE
client: missing configOpt at input

### DIFF
--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -700,7 +700,7 @@ export class WalletConfigForm {
     const inputs: Record<string, HTMLElement[]> = {}
     box.querySelectorAll('input').forEach((input: ConfigOptionInput) => {
       const k = input.dataset.configKey
-      if (!k) return // typescript
+      if (!k) return // TS2538
       const els = []
       for (const [opt, el] of this.configElements) if (opt.key === k) els.push(el)
       inputs[k] = els

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -520,7 +520,7 @@ export class WalletConfigForm {
     } else el = this.textInputTmpl.cloneNode(true) as HTMLElement
     this.configElements.push([opt, el])
     const input = el.querySelector('input') as ConfigOptionInput
-    input.configOpt = opt
+    input.dataset.configKey = opt.key
     input.id = elID
     const label = Doc.safeSelector(el, 'label')
     label.htmlFor = elID // 'for' attribute, but 'for' is a keyword
@@ -699,7 +699,8 @@ export class WalletConfigForm {
   reorder (box: HTMLElement) {
     const inputs: Record<string, HTMLElement[]> = {}
     box.querySelectorAll('input').forEach((input: ConfigOptionInput) => {
-      const k = input.configOpt.key
+      const k = input.dataset.configKey
+      if (!k) return // typescript
       const els = []
       for (const [opt, el] of this.configElements) if (opt.key === k) els.push(el)
       inputs[k] = els

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -520,6 +520,7 @@ export class WalletConfigForm {
     } else el = this.textInputTmpl.cloneNode(true) as HTMLElement
     this.configElements.push([opt, el])
     const input = el.querySelector('input') as ConfigOptionInput
+    input.configOpt = opt
     input.id = elID
     const label = Doc.safeSelector(el, 'label')
     label.htmlFor = elID // 'for' attribute, but 'for' is a keyword


### PR DESCRIPTION
This PR fixes an error when creating an external wallet.

If going to external wallet form the following error will be thrown: 

![image](https://user-images.githubusercontent.com/15069783/196998253-33d8d19a-bdaf-4c94-bc7f-c9ba8ec6f56b.png)

The reason is because the configOpt is not added into the input when the input html element `ConfigOptionInput` is created. This PR fixes it.