### PR TITLE
client/core: fix intermittent TestWalletSyncing failure

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -37,6 +37,7 @@ import (
 	"decred.org/dcrdex/server/account"
 	serverdex "decred.org/dcrdex/server/dex"
 	"github.com/decred/dcrd/crypto/blake256"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 )

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -36,8 +36,8 @@ import (
 	"decred.org/dcrdex/dex/wait"
 	"decred.org/dcrdex/server/account"
 	serverdex "decred.org/dcrdex/server/dex"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/crypto/blake256"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 )

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -37,7 +37,6 @@ import (
 	"decred.org/dcrdex/server/account"
 	serverdex "decred.org/dcrdex/server/dex"
 	"github.com/decred/dcrd/crypto/blake256"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 )
@@ -9168,12 +9167,12 @@ out:
 			t.Fatalf("timed out waiting for synced wallet note. Received %d progress notes", progressNotes)
 		}
 	}
-	// Should get 9 notes, but just make sure we get at least half of them to
-	// avoid github vm false positives.
-	if progressNotes < 5 /* 9? */ {
-		t.Fatalf("expected 9 progress notes, got %d", progressNotes)
+	// We must get at least 1 progress note.
+	// By the time we've got 9th note it should signal that the wallet has been
+	// synced (due to how we've set up testDuration and syncTickerPeriod values).
+	if progressNotes < 1 || progressNotes > 9 {
+		t.Fatalf("expected at least 1 and at most 9 progress notes, got %d", progressNotes)
 	}
-	// t.Logf("got %d progress notes", progressNotes)
 }
 
 func TestParseCert(t *testing.T) {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -37,7 +37,6 @@ import (
 	"decred.org/dcrdex/server/account"
 	serverdex "decred.org/dcrdex/server/dex"
 	"github.com/decred/dcrd/crypto/blake256"
-	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 )
@@ -9160,19 +9159,18 @@ out:
 			if !ok {
 				continue
 			}
+			progressNotes++
 			if walletNote.Wallet.Synced {
 				break out
 			}
-			progressNotes++
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for synced wallet note. Received %d progress notes", progressNotes)
 		}
 	}
-	// We must get at least 1 progress note.
-	// By the time we've got 9th note it should signal that the wallet has been
+	// By the time we've got 10th note it should signal that the wallet has been
 	// synced (due to how we've set up testDuration and syncTickerPeriod values).
-	if progressNotes < 1 || progressNotes > 9 {
-		t.Fatalf("expected at least 1 and at most 9 progress notes, got %d", progressNotes)
+	if progressNotes > 10 {
+		t.Fatalf("expected 10 progress notes at most, got %d", progressNotes)
 	}
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -36,6 +36,7 @@ import (
 	"decred.org/dcrdex/dex/wait"
 	"decred.org/dcrdex/server/account"
 	serverdex "decred.org/dcrdex/server/dex"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/crypto/blake256"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"

--- a/client/core/simnet_trade.go
+++ b/client/core/simnet_trade.go
@@ -152,7 +152,7 @@ func (s *simulationTest) waitALittleBit() {
 	if sleep < feeSleep {
 		// eth based assets need to wait for txn to be mined for fees
 		// to be populated here.
-		for bipID, _ := range s.client1.wallets {
+		for bipID := range s.client1.wallets {
 			if accountBIPs[bipID] {
 				sleep = feeSleep
 				s.client1.log.Infof("Waiting for paid order fees to be populated (%s).", sleep)


### PR DESCRIPTION
How about relaxing testing conditions a little bit so that there is no chance for intermittent failure due to reasons it happens in the example from issue description ?

Closes https://github.com/decred/dcrdex/issues/1912.