### PR TITLE
client/asset/btc: get locked balance for ZEC

### DIFF
--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -179,6 +179,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (ass
 		NumericGetRawRPC:         true,
 		LegacyValidateAddressRPC: true,
 		SingularWallet:           true,
+		UnlockSpends:             true,
 		FeeEstimator:             estimateFee,
 		AddressDecoder: func(addr string, net *chaincfg.Params) (btcutil.Address, error) {
 			return dexzec.DecodeAddress(addr, addrParams, btcParams)


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1768

Requires https://github.com/decred/dcrdex/pull/1909.

This root cause is essentially a simple omission from the `asset.Balance` for ZEC.  However, testing also revealed that zcashd does not unlock locked outpoints when they are spent, like dogecoind.  As such, this PR also sets the `UnlockSpends` config flag, and adds a spent utxo check to the `(*rpcClient).listLockUnspent` method.