### PR TITLE
client/ws: fix panic in ws communications

### DIFF
--- a/client/websocket/websocket_test.go
+++ b/client/websocket/websocket_test.go
@@ -166,8 +166,7 @@ func TestLoadMarket(t *testing.T) {
 	// so manually stop the marketSyncer started by wsLoadMarket and the WSLink
 	// before returning from this test.
 	defer func() {
-		link.cl.feed.loop.Stop()
-		link.cl.feed.loop.WaitForShutdown()
+		link.cl.shutDownFeed()
 		link.cl.Disconnect()
 		linkWg.Wait()
 	}()

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -184,7 +184,7 @@ func (c *ConnectionMaster) On() bool {
 	}
 }
 
-// Wait waits for the the Connector to shut down. It returns immediately if
+// Wait waits for the Connector to shut down. It returns immediately if
 // Connect has not been called yet.
 func (c *ConnectionMaster) Wait() {
 	<-c.Done() // let the anon goroutine from Connect return


### PR DESCRIPTION
I've encountered this `panic` once (`dexc` doesn't crash since there is a `recover()` in place, but it did show up in logs, and I had to refresh web page to get it to working state):

```
2022-10-19 12:07:10.545 [CRT] WEB[WS][[::1]:52108]: Uh-oh! Panic while handling message from [::1]:52108.
​
Message:
​
&msgjson.Message{Type:0x1, Route:"loadcandles", ID:0x2, Payload:json.RawMessage{0x7b, 0x22, 0x68, 0x6f, 0x73, 0x74, 0x22, 0x3a, 0x22, 0x64, 0x65, 0x78, 0x2d, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x73, 0x73, 0x67, 0x65, 0x6e, 0x2e, 0x69, 0x6f, 0x3a, 0x37, 0x32, 0x33, 0x32, 0x22, 0x2c, 0x22, 0x62, 0x61, 0x73, 0x65, 0x22, 0x3a, 0x34, 0x32, 0x2c, 0x22, 0x71, 0x75, 0x6f, 0x74, 0x65, 0x22, 0x3a, 0x30, 0x2c, 0x22, 0x64, 0x75, 0x72, 0x22, 0x3a, 0x22, 0x35, 0x6d, 0x22, 0x7d}}
​
Panic:
​
runtime error: invalid memory address or nil pointer dereference
​
Stack:
​
goroutine 181 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
decred.org/dcrdex/dex/ws.(*WSLink).handleMessage.func1()
	/Users/iurii/dcrdex/dex/ws/wslink.go:228 +0x58
panic({0x1d30860, 0x2f218e0})
	/usr/local/go/src/runtime/panic.go:838 +0x207
decred.org/dcrdex/client/websocket.wsLoadCandles(0xc0005d2000, 0xc000146c00, 0xc00166ebc0)
	/Users/iurii/dcrdex/client/websocket/websocket.go:334 +0x1a0
decred.org/dcrdex/client/websocket.(*Server).handleMessage(0xc0005d2000, 0xc00166ebc0?, 0xc00166ebc0)
	/Users/iurii/dcrdex/client/websocket/websocket.go:196 +0x1bf
decred.org/dcrdex/client/websocket.(*Server).connect.func1(0xc00166ebc0?)
	/Users/iurii/dcrdex/client/websocket/websocket.go:132 +0x2a
decred.org/dcrdex/dex/ws.(*WSLink).handleMessage(0xc0005a4bd0, 0xc00166ebc0)
	/Users/iurii/dcrdex/dex/ws/wslink.go:234 +0x73
decred.org/dcrdex/dex/ws.(*WSLink).inHandler(0xc0005a4bd0, {0x27bab90, 0xc0004bba80})
	/Users/iurii/dcrdex/dex/ws/wslink.go:285 +0x1f7
created by decred.org/dcrdex/dex/ws.(*WSLink).Connect
	/Users/iurii/dcrdex/dex/ws/wslink.go:189 +0x2a5
```

Here is my full log (expires in 21 days) - https://pastebin.mozilla.org/bEXK5B56. Decoded message looks like this, if you need it: https://go.dev/play/p/ndDCmerq8HE

Here is how I see what happens (pulled out relevant log lines, added comments):
```
...
2022-10-19 12:06:40.544 [TRC] WEB[WS]: message of type 1 received for route loadmarket
# but 30s after
2022-10-19 12:07:10.545 [ERR] WEB[WS]: error getting order feed: timed out waiting for 'orderbook' response
# Because of this error ^ `cl.feed` will be nil, and when `loadcandles` msg below gets handled (UI sends it immediately after `loadmarket`, but it gets queued on the dexc side since all WS messages are sequential)  it results in nil pointer dereference
2022-10-19 12:07:10.545 [TRC] WEB[WS]: message of type 1 received for route loadcandles
# panic happens here
...
```
