### PR TITLE
client: start adding asset config at core

### DIFF
--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1068,7 +1068,15 @@ func (t *trackedTrade) counterPartyConfirms(ctx context.Context, match *matchTra
 	fail := func(err error) (uint32, uint32, bool, bool, bool, error) {
 		return 0, 0, false, false, false, err
 	}
-
+	// If makerSwapConfOverride is defined and it is the taker's wallet,
+	// override the swapconf with its value.
+	if t.wallets.quoteWallet.makerSwapConfOverride > 0 && match.Status == order.MakerSwapCast && match.Side == order.Taker {
+		t.metaData.ToSwapConf = uint32(t.wallets.quoteWallet.makerSwapConfOverride)
+	}
+	// as maker, override the swap conf with the takerSwapConfOverride if defined.
+	if t.wallets.baseWallet.takerSwapConfOverride > 0 && match.Status == order.TakerSwapCast && match.Side == order.Maker {
+		t.metaData.ToSwapConf = uint32(t.wallets.baseWallet.takerSwapConfOverride)
+	}
 	// Counter-party's swap is the "to" asset.
 	needed = t.metaData.ToSwapConf
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -111,21 +111,23 @@ type WalletBalance struct {
 
 // WalletState is the current status of an exchange wallet.
 type WalletState struct {
-	Symbol       string            `json:"symbol"`
-	AssetID      uint32            `json:"assetID"`
-	Version      uint32            `json:"version"`
-	WalletType   string            `json:"type"`
-	Traits       asset.WalletTrait `json:"traits"`
-	Open         bool              `json:"open"`
-	Running      bool              `json:"running"`
-	Balance      *WalletBalance    `json:"balance"`
-	Address      string            `json:"address"`
-	Units        string            `json:"units"`
-	Encrypted    bool              `json:"encrypted"`
-	PeerCount    uint32            `json:"peerCount"`
-	Synced       bool              `json:"synced"`
-	SyncProgress float32           `json:"syncProgress"`
-	Disabled     bool              `json:"disabled"`
+	Symbol                string            `json:"symbol"`
+	AssetID               uint32            `json:"assetID"`
+	Version               uint32            `json:"version"`
+	WalletType            string            `json:"type"`
+	Traits                asset.WalletTrait `json:"traits"`
+	Open                  bool              `json:"open"`
+	Running               bool              `json:"running"`
+	Balance               *WalletBalance    `json:"balance"`
+	Address               string            `json:"address"`
+	Units                 string            `json:"units"`
+	Encrypted             bool              `json:"encrypted"`
+	PeerCount             uint32            `json:"peerCount"`
+	Synced                bool              `json:"synced"`
+	SyncProgress          float32           `json:"syncProgress"`
+	Disabled              bool              `json:"disabled"`
+	MakerSwapConfOverride int64             `json:"makerswapconfoverride"`
+	TakerSwapConfOverride int64             `json:"takerswapconfoverride"`
 }
 
 // User is information about the user's wallets and DEX accounts.
@@ -153,7 +155,8 @@ type SupportedAsset struct {
 	UnitInfo dex.UnitInfo `json:"unitInfo"`
 	// WalletCreationPending will be true if this wallet's parent wallet is
 	// being synced before this wallet is created.
-	WalletCreationPending bool `json:"walletCreationPending"`
+	WalletCreationPending bool                  `json:"walletCreationPending"`
+	TradingOpts           []*asset.ConfigOption `json:"tradingOpts"`
 }
 
 // BondOptionsForm is used from the settings page to change the auto-bond

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -321,4 +321,5 @@ var EnUS = map[string]string{
 	"connected":              "Connected",
 	"Remove":                 "Remove",
 	"unready_wallets_msg":    "Your wallets must be connected and unlocked before trades can be processed. Resolve this ASAP!",
+	"Trading Options":        "Trading Options",
 }

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -302,11 +302,12 @@ export class NewWalletForm {
     this.current.selectedDef = walletDef
     const appPwCached = State.passwordIsCached() || (this.pwCache && this.pwCache.pw)
     Doc.hide(page.auth, page.oneBttnBox, page.newWalletPassBox)
-    const configOpts = walletDef.configopts || []
+    const { asset, parentAsset, winfo } = this.current
+    const configOpts = [...walletDef.configopts, ...asset.tradingOpts] || []
     // If a config represents a wallet's birthday, we update the default
     // selection to the current date if this installation of the client
     // generated a seed.
-    configOpts.map((opt) => {
+    configOpts.forEach((opt) => {
       if (opt.isBirthdayConfig && app().seedGenTime > 0) {
         opt.default = toUnixDate(new Date())
       }
@@ -334,7 +335,6 @@ export class NewWalletForm {
       page.submitAdd.textContent = intl.prep(intl.ID_ADD)
     }
 
-    const { asset, parentAsset, winfo } = this.current
     if (parentAsset) {
       this.subform.update(configOpts, { assetID: parentAsset.id })
       this.subform.update((winfo as Token).definition.configopts, {
@@ -414,6 +414,7 @@ export class WalletConfigForm {
   sectionize: boolean
   allSettings: PageElement
   dynamicOpts: PageElement
+  tradingOpts: ConfigOption[]
   textInputTmpl: PageElement
   dateInputTmpl: PageElement
   checkboxTmpl: PageElement
@@ -438,6 +439,7 @@ export class WalletConfigForm {
     this.configElements = []
     // configOpts is the wallet options provided by core.
     this.configOpts = []
+    this.tradingOpts = []
     this.sectionize = sectionize
 
     // Get template elements

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -160,6 +160,7 @@ export interface SupportedAsset {
   token?: Token
   unitInfo: UnitInfo
   walletCreationPending: boolean
+  tradingOpts: ConfigOption[]
 }
 
 export interface Token {


### PR DESCRIPTION
Closes #1900.

I am using @chappjc 's commit https://github.com/decred/dcrdex/commit/bdb379f6ca343ce5768b7d374920272795a2da57 as reference.

I am adding `makerSwapConfOverride` and `takerSwapConfOverride` params at core, as I am using chapp's commit as base, but I believe we might want to add a trading asset config opt, which can have more fields, so we can use it to fix https://github.com/decred/dcrdex/issues/1932 as well, without the need to add each param individually. 




 