### PR TITLE
asset: create btcwallet+neutrino log dir and file without initialization

### DIFF
--- a/client/asset/bch/spv.go
+++ b/client/asset/bch/spv.go
@@ -122,12 +122,6 @@ func createSPVWallet(privPass []byte, seed []byte, bday time.Time, dbDir string,
 		return fmt.Errorf("error initializing bchwallet+neutrino logging: %w", err)
 	}
 
-	logDir := filepath.Join(netDir, logDirName)
-	err := os.MkdirAll(logDir, 0744)
-	if err != nil {
-		return fmt.Errorf("error creating wallet directories: %w", err)
-	}
-
 	loader := wallet.NewLoader(net, walletDir, true, 250)
 
 	pubPass := []byte(wallet.InsecurePubPassphrase)

--- a/client/asset/bch/spv.go
+++ b/client/asset/bch/spv.go
@@ -961,41 +961,12 @@ func (w logWriter) Write(p []byte) (n int, err error) {
 func logRotator(netDir string) (*rotator.Rotator, error) {
 	const maxLogRolls = 8
 	logDir := filepath.Join(filepath.Dir(netDir), logDirName)
-	exist, err := fileExists(logDir)
-	if err != nil {
-		return nil, err
-	}
-	if !exist {
-		oldDir := filepath.Join(netDir, "logs")
-		exist, err := fileExists(oldDir)
-		if err != nil {
-			return nil, err
-		}
-		if !exist {
-			if err := os.MkdirAll(logDir, 0744); err != nil {
-				return nil, fmt.Errorf("error creating log directory: %w", err)
-			}
-		} else {
-			// Move old logs to new log path.
-			if err := os.Rename(oldDir, logDir); err != nil {
-				return nil, err
-			}
-		}
+	if err := os.MkdirAll(logDir, 0744); err != nil {
+		return nil, fmt.Errorf("error creating log directory: %w", err)
 	}
 
 	logFilename := filepath.Join(logDir, logFileName)
 	return rotator.New(logFilename, 32*1024, false, maxLogRolls)
-}
-
-func fileExists(filePath string) (bool, error) {
-	_, err := os.Stat(filePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 // logNeutrino initializes logging in the neutrino + wallet packages. Logging

--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -65,7 +65,7 @@ func createSPVWallet(privPass []byte, seed []byte, bday time.Time, dataDir strin
 		return fmt.Errorf("error initializing btcwallet+neutrino logging: %w", err)
 	}
 
-	logDir := filepath.Join(dir, logDirName)
+	logDir := filepath.Join(dataDir, net.Name, logDirName)
 	err := os.MkdirAll(logDir, 0744)
 	if err != nil {
 		return fmt.Errorf("error creating wallet directories: %w", err)
@@ -142,7 +142,7 @@ func (w *btcSPVWallet) updateDBBirthday(bday time.Time) error {
 	})
 }
 
-// startWallet initializes the *btcwallet.Wallet and its supporting players and
+// Start initializes the *btcwallet.Wallet and its supporting players and
 // starts syncing.
 func (w *btcSPVWallet) Start() (SPVService, error) {
 	if err := logNeutrino(w.dir); err != nil {
@@ -242,7 +242,7 @@ func (w *btcSPVWallet) Start() (SPVService, error) {
 	return &btcChainService{w.cl}, nil
 }
 
-// stop stops the wallet and database threads.
+// Stop stops the wallet and database threads.
 func (w *btcSPVWallet) Stop() {
 	w.log.Info("Unloading wallet")
 	if err := w.loader.UnloadWallet(); err != nil {
@@ -351,7 +351,7 @@ func (w *btcSPVWallet) ForceRescan() {
 	}
 }
 
-// walletTransaction pulls the transaction from the database.
+// WalletTransaction pulls the transaction from the database.
 func (w *btcSPVWallet) WalletTransaction(txHash *chainhash.Hash) (*wtxmgr.TxDetails, error) {
 	details, err := wallet.UnstableAPI(w.Wallet).TxDetails(txHash)
 	if err != nil {
@@ -383,12 +383,12 @@ func (w *btcSPVWallet) SyncedTo() waddrmgr.BlockStamp {
 // 		return err
 // 	})
 // 	if err != nil {
-// 		return nil, err // sadly, waddrmgr.ErrBirthdayBlockNotSet is expected during most of chain sync
+// 		return nil, err // sadly, waddrmgr.ErrBirthdayBlockNotSet is expected during most of the chain sync
 // 	}
 // 	return &birthdayBlock, nil
 // }
 
-// signTransaction signs the transaction inputs.
+// SignTx signs the transaction inputs.
 func (w *btcSPVWallet) SignTx(tx *wire.MsgTx) error {
 	var prevPkScripts [][]byte
 	var inputValues []btcutil.Amount
@@ -500,7 +500,7 @@ func (s *secretSource) GetScript(addr btcutil.Address) ([]byte, error) {
 // only has to be initialized once, so an atomic flag is used internally to
 // return early on subsequent invocations.
 //
-// In theory, the the rotating file logger must be Close'd at some point, but
+// In theory, the rotating file logger must be Closed at some point, but
 // there are concurrency issues with that since btcd and btcwallet have
 // unsupervised goroutines still running after shutdown. So we leave the rotator
 // running at the risk of losing some logs.

--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sync/atomic"
 	"time"
@@ -65,12 +64,6 @@ func createSPVWallet(privPass []byte, seed []byte, bday time.Time, dataDir strin
 
 	if err := logNeutrino(netDir); err != nil {
 		return fmt.Errorf("error initializing btcwallet+neutrino logging: %w", err)
-	}
-
-	logDir := filepath.Join(netDir, logDirName)
-	err := os.MkdirAll(logDir, 0744)
-	if err != nil {
-		return fmt.Errorf("error creating wallet directories: %w", err)
 	}
 
 	loader := wallet.NewLoader(net, walletDir, true, dbTimeout, 250)

--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -60,7 +60,7 @@ var _ BTCWallet = (*btcSPVWallet)(nil)
 // createSPVWallet creates a new SPV wallet.
 func createSPVWallet(privPass []byte, seed []byte, bday time.Time, dataDir string, log dex.Logger, extIdx, intIdx uint32, net *chaincfg.Params) error {
 	netDir := filepath.Join(dataDir, net.Name)
-	walletDir := filepath.Join(netDir, "spv")
+	walletDir := filepath.Join(netDir, spvDir)
 
 	if err := logNeutrino(netDir); err != nil {
 		return fmt.Errorf("error initializing btcwallet+neutrino logging: %w", err)

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -205,41 +205,12 @@ var (
 func logRotator(dir string) (*rotator.Rotator, error) {
 	const maxLogRolls = 8
 	logDir := filepath.Join(filepath.Dir(dir), logDirName)
-	exist, err := fileExists(logDir)
-	if err != nil {
-		return nil, err
-	}
-	if !exist {
-		oldDir := filepath.Join(dir, "logs")
-		exist, err := fileExists(oldDir)
-		if err != nil {
-			return nil, err
-		}
-		if !exist {
-			if err := os.MkdirAll(logDir, 0744); err != nil {
-				return nil, fmt.Errorf("error creating log directory: %w", err)
-			}
-		} else {
-			// Move old logs to new log path.
-			if err := os.Rename(oldDir, logDir); err != nil {
-				return nil, err
-			}
-		}
+	if err := os.MkdirAll(logDir, 0744); err != nil {
+		return nil, fmt.Errorf("error creating log directory: %w", err)
 	}
 
 	logFilename := filepath.Join(logDir, logFileName)
 	return rotator.New(logFilename, 32*1024, false, maxLogRolls)
-}
-
-func fileExists(filePath string) (bool, error) {
-	_, err := os.Stat(filePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 // spendingInput is added to a filterScanResult if a spending input is found.

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -204,7 +204,7 @@ var (
 // logRotator initializes a rotating file logger.
 func logRotator(dir string) (*rotator.Rotator, error) {
 	const maxLogRolls = 8
-	logDir := filepath.Join(filepath.Dir(dir), logDirName)
+	logDir := filepath.Join(dir, logDirName)
 	if err := os.MkdirAll(logDir, 0744); err != nil {
 		return nil, fmt.Errorf("error creating log directory: %w", err)
 	}

--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -939,26 +939,8 @@ var (
 func logRotator(netDir string) (*rotator.Rotator, error) {
 	const maxLogRolls = 8
 	logDir := filepath.Join(filepath.Dir(netDir), logDirName)
-	exist, err := fileExists(logDir)
-	if err != nil {
-		return nil, err
-	}
-	if !exist {
-		oldDir := filepath.Join(netDir, "logs")
-		exist, err := fileExists(oldDir)
-		if err != nil {
-			return nil, err
-		}
-		if !exist {
-			if err := os.MkdirAll(logDir, 0744); err != nil {
-				return nil, fmt.Errorf("error creating log directory: %w", err)
-			}
-		} else {
-			// Move old logs to new log path.
-			if err := os.Rename(oldDir, logDir); err != nil {
-				return nil, err
-			}
-		}
+	if err := os.MkdirAll(logDir, 0744); err != nil {
+		return nil, fmt.Errorf("error creating log directory: %w", err)
 	}
 
 	logFilename := filepath.Join(logDir, logFileName)

--- a/client/asset/ltc/spv.go
+++ b/client/asset/ltc/spv.go
@@ -993,41 +993,12 @@ var (
 func logRotator(netDir string) (*rotator.Rotator, error) {
 	const maxLogRolls = 8
 	logDir := filepath.Join(filepath.Dir(netDir), logDirName)
-	exist, err := fileExists(logDir)
-	if err != nil {
-		return nil, err
-	}
-	if !exist {
-		oldDir := filepath.Join(netDir, "logs")
-		exist, err := fileExists(oldDir)
-		if err != nil {
-			return nil, err
-		}
-		if !exist {
-			if err := os.MkdirAll(logDir, 0744); err != nil {
-				return nil, fmt.Errorf("error creating log directory: %w", err)
-			}
-		} else {
-			// Move old logs to new log path.
-			if err := os.Rename(oldDir, logDir); err != nil {
-				return nil, err
-			}
-		}
+	if err := os.MkdirAll(logDir, 0744); err != nil {
+		return nil, fmt.Errorf("error creating log directory: %w", err)
 	}
 
 	logFilename := filepath.Join(logDir, logFileName)
 	return rotator.New(logFilename, 32*1024, false, maxLogRolls)
-}
-
-func fileExists(filePath string) (bool, error) {
-	_, err := os.Stat(filePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	return true, nil
 }
 
 // logNeutrino initializes logging in the neutrino + wallet packages. Logging

--- a/client/asset/ltc/spv.go
+++ b/client/asset/ltc/spv.go
@@ -53,7 +53,7 @@ import (
 
 const (
 	DefaultM       uint64 = 784931 // From ltcutil. Used for gcs filters.
-	logDirName            = "logs"
+	logDirName            = "spvlogs"
 	neutrinoDBName        = "neutrino.db"
 	defaultAcctNum        = 0
 	dbTimeout             = 20 * time.Second
@@ -992,20 +992,49 @@ var (
 // logRotator initializes a rotating file logger.
 func logRotator(netDir string) (*rotator.Rotator, error) {
 	const maxLogRolls = 8
-	logDir := filepath.Join(netDir, logDirName)
-	if err := os.MkdirAll(logDir, 0744); err != nil {
-		return nil, fmt.Errorf("error creating log directory: %w", err)
+	logDir := filepath.Join(filepath.Dir(netDir), logDirName)
+	exist, err := fileExists(logDir)
+	if err != nil {
+		return nil, err
+	}
+	if !exist {
+		oldDir := filepath.Join(netDir, "logs")
+		exist, err := fileExists(oldDir)
+		if err != nil {
+			return nil, err
+		}
+		if !exist {
+			if err := os.MkdirAll(logDir, 0744); err != nil {
+				return nil, fmt.Errorf("error creating log directory: %w", err)
+			}
+		} else {
+			// Move old logs to new log path.
+			if err := os.Rename(oldDir, logDir); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	logFilename := filepath.Join(logDir, logFileName)
 	return rotator.New(logFilename, 32*1024, false, maxLogRolls)
 }
 
+func fileExists(filePath string) (bool, error) {
+	_, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // logNeutrino initializes logging in the neutrino + wallet packages. Logging
 // only has to be initialized once, so an atomic flag is used internally to
 // return early on subsequent invocations.
 //
-// In theory, the the rotating file logger must be Close'd at some point, but
+// In theory, the rotating file logger must be Closed at some point, but
 // there are concurrency issues with that since btcd and btcwallet have
 // unsupervised goroutines still running after shutdown. So we leave the rotator
 // running at the risk of losing some logs.

--- a/client/asset/ltc/spv.go
+++ b/client/asset/ltc/spv.go
@@ -128,12 +128,6 @@ func createSPVWallet(privPass []byte, seed []byte, bday time.Time, dbDir string,
 		return fmt.Errorf("error initializing dcrwallet+neutrino logging: %w", err)
 	}
 
-	logDir := filepath.Join(netDir, logDirName)
-	err := os.MkdirAll(logDir, 0744)
-	if err != nil {
-		return fmt.Errorf("error creating wallet directories: %w", err)
-	}
-
 	// timeout and recoverWindow arguments borrowed from btcwallet directly.
 	loader := wallet.NewLoader(net, walletDir, true, dbTimeout, 250)
 


### PR DESCRIPTION
This fixes an issue where wallet recovery deletes the existing neutrino log file but logging initialization is a one-time operation. Closes #1944.