### PR TITLE
multi: Ensure redeemed matches are confirmed.

### DIFF
--- a/client/core/simnet_trade.go
+++ b/client/core/simnet_trade.go
@@ -519,10 +519,7 @@ func testMakerGhostingAfterTakerRedeem(s *simulationTest) error {
 	defer s.client1.filteredConn.requestFilter.Store(func(string) error { return nil })
 	defer s.client2.filteredConn.requestFilter.Store(func(string) error { return nil })
 
-	// TODO: Currently taker redeemer will not have its redeem confirmed
-	// when match is server revoked. That should be changed and this
-	// changed to order.MatchConfirmed.
-	return s.simpleTradeTest(qty, rate, order.MatchComplete)
+	return s.simpleTradeTest(qty, rate, order.MatchConfirmed)
 }
 
 // TestOrderStatusReconciliation simulates a few conditions that could cause a
@@ -1144,11 +1141,6 @@ func (s *simulationTest) monitorTrackedTrade(client *simulationClient, tracker *
 	maxTradeDuration := 4 * time.Minute
 	var waitedForOtherSideMakerInit, waitedForOtherSideTakerInit bool
 
-	// TODO: Remove this when the makerghost todo is fixed.
-	if finalStatus == order.MatchComplete {
-		finalStatus = order.MakerRedeemed
-	}
-
 	tryUntil(s.ctx, maxTradeDuration, func() bool {
 		var completedTrades int
 		mineAssets := make(map[uint32]uint32)
@@ -1227,14 +1219,6 @@ func (s *simulationTest) monitorTrackedTrade(client *simulationClient, tracker *
 					nBlocks = 8
 				}
 				assetID := tracker.wallets.toWallet.AssetID
-				mineAssets[assetID] = nBlocks
-				logIt("redeem", assetID, nBlocks)
-			}
-			// TODO: Remove this when the makerghost todo is fixed.
-			if accountBIPs[tracker.wallets.toWallet.AssetID] && finalStatus == order.MakerRedeemed &&
-				side == order.Taker && status >= order.MakerRedeemed {
-				assetID := tracker.wallets.toWallet.AssetID
-				nBlocks := uint32(14)
 				mineAssets[assetID] = nBlocks
 				logIt("redeem", assetID, nBlocks)
 			}

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -354,13 +354,12 @@ func MatchIsActive(match *order.UserMatch, proof *MatchProof) bool {
 		// - NewlyMatched requires no further action from either side
 		// - MakerSwapCast requires no further action from the taker
 		// - (TakerSwapCast requires action on both sides)
-		// - MakerRedeemed requires no further action from the maker
-		// - MatchComplete requires no further action. This happens if taker
-		//   does not have server's ack of their redeem request (RedeemSig).
+		// Matches that make it to MakerRedeemed or MatchComplete must
+		// stay active until the redeem is confirmed. When the redeem
+		// is confirmed is up to the asset and differs between assets.
 		status, side := match.Status, match.Side
-		if status == order.NewlyMatched || status >= order.MatchComplete ||
-			(status == order.MakerSwapCast && side == order.Taker) ||
-			(status == order.MakerRedeemed && side == order.Maker) {
+		if status == order.NewlyMatched ||
+			(status == order.MakerSwapCast && side == order.Taker) {
 			return false
 		}
 	}


### PR DESCRIPTION
    multi: Ensure redeemed matches are confirmed.

    Remove conditional checks for revoked matches that allow some to skip
    redemption confirms. All matches that are redeemed now must make it to
    status order.MatchConfirmed to be considered inactive.

closes #1924