### PR TITLE
client/db: log database path on startup

### DIFF
--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -124,6 +124,8 @@ func NewDB(dbPath string, logger dex.Logger) (dexdb.DB, error) {
 	_, err := os.Stat(dbPath)
 	isNew := os.IsNotExist(err)
 
+	logger.Infof("opening database at: %s", dbPath)
+
 	db, err := bbolt.Open(dbPath, 0600, &bbolt.Options{Timeout: 3 * time.Second})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Would it be useful to have DB path logged on startup ? to be able to back it up somewhere of a separate device, nuke it, etc.

I couldn't easily find where `dexc` stores its data.