### PR TITLE
webserver: fix live testing wallet issues

### DIFF
--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -767,14 +767,16 @@ export default class MarketsPage extends BasePage {
       this.maxEstimateTimer = null
     }
     const mktId = marketID(baseCfg.symbol, quoteCfg.symbol)
+    const baseAsset = app().assets[base]
+    const quoteAsset = app().assets[quote]
     this.market = {
       dex: dex,
       sid: mktId, // A string market identifier used by the DEX.
       cfg: dex.markets[mktId],
       // app().assets is a map of core.SupportedAsset type, which can be found at
       // client/core/types.go.
-      base: app().assets[base],
-      quote: app().assets[quote],
+      base: baseAsset,
+      quote: quoteAsset,
       baseUnitInfo: bui,
       quoteUnitInfo: qui,
       maxSell: null,
@@ -788,7 +790,7 @@ export default class MarketsPage extends BasePage {
       buyBalance: 0
     }
 
-    Doc.setVis(!(this.market.base.wallet && this.market.quote.wallet), page.noWallet)
+    Doc.setVis(!(baseAsset && quoteAsset) || !(baseAsset.wallet && quoteAsset.wallet), page.noWallet)
     this.setStats()
     this.refreshRecentMatchesTable()
 

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -551,8 +551,9 @@ export default class WalletsPage extends BasePage {
 
   showAvailableMarkets (assetID: number) {
     const page = this.page
+    const exchanges = app().user.exchanges
     const markets: [string, Market][] = []
-    for (const xc of Object.values(app().user.exchanges)) {
+    for (const xc of Object.values(exchanges)) {
       if (!xc.markets) continue
       for (const mkt of Object.values(xc.markets)) {
         if (mkt.baseid === assetID || mkt.quoteid === assetID) markets.push([xc.host, mkt])
@@ -588,7 +589,7 @@ export default class WalletsPage extends BasePage {
       tmpl.quoteSymbol.appendChild(Doc.symbolize(quotesymbol))
 
       if (spot) {
-        const convRate = app().conventionalRate(baseid, quoteid, spot.rate)
+        const convRate = app().conventionalRate(baseid, quoteid, spot.rate, exchanges[host])
         tmpl.price.textContent = fourSigFigs(convRate)
         tmpl.priceQuoteUnit.textContent = quotesymbol.toUpperCase()
         tmpl.priceBaseUnit.textContent = basesymbol.toUpperCase()


### PR DESCRIPTION
- This fixes an error on the markets page for an unsupported wallet.
- Also fixes panic when trying to create specific test wallets(`mona`,...).
- Minor refactoring of the live tests. 
Closes #1949 