### PR TITLE
client/asset/dcr: Unlock must unlock unmixed account

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -800,10 +800,8 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 		}
 	}()
 
-	cfg := dcr.config()
-
 	// Validate accounts early on to prevent errors later.
-	for _, acct := range []string{cfg.primaryAcct, cfg.unmixedAccount, cfg.tradingAccount} {
+	for _, acct := range dcr.allAccounts() {
 		if acct == "" {
 			continue
 		}
@@ -3154,7 +3152,7 @@ func (dcr *ExchangeWallet) Lock() error {
 // Locked will be true if the wallet is currently locked.
 // Q: why are we ignoring RPC errors in this?
 func (dcr *ExchangeWallet) Locked() bool {
-	for _, acct := range dcr.fundingAccounts() {
+	for _, acct := range dcr.allAccounts() {
 		unlocked, err := dcr.wallet.AccountUnlocked(dcr.ctx, acct)
 		if err != nil {
 			dcr.log.Errorf("error checking account lock status %v", err)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -899,6 +899,15 @@ func (dcr *ExchangeWallet) fundingAccounts() []string {
 	return []string{cfg.primaryAcct, cfg.tradingAccount}
 }
 
+func (dcr *ExchangeWallet) allAccounts() []string {
+	cfg := dcr.config()
+
+	if cfg.unmixedAccount == "" {
+		return []string{cfg.primaryAcct}
+	}
+	return []string{cfg.primaryAcct, cfg.tradingAccount, cfg.unmixedAccount}
+}
+
 // OwnsDepositAddress indicates if the provided address can be used to deposit
 // funds into the wallet.
 func (dcr *ExchangeWallet) OwnsDepositAddress(address string) (bool, error) {
@@ -3115,7 +3124,9 @@ func (dcr *ExchangeWallet) NewAddress() (string, error) {
 
 // Unlock unlocks the exchange wallet.
 func (dcr *ExchangeWallet) Unlock(pw []byte) error {
-	for _, acct := range dcr.fundingAccounts() {
+	// We must unlock all accounts, including any unmixed account, which is used
+	// to supply keys to the refund path of the swap contract script.
+	for _, acct := range dcr.allAccounts() {
 		unlocked, err := dcr.wallet.AccountUnlocked(dcr.ctx, acct)
 		if err != nil {
 			return err

--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -760,7 +760,6 @@ func (w *rpcWallet) unlockWallet(ctx context.Context, passphrase string, timeout
 func (w *rpcWallet) AccountUnlocked(ctx context.Context, acctName string) (bool, error) {
 	// First return locked status of the account, falling back to walletinfo if
 	// the account is not individually password protected.
-	var res *walletjson.AccountUnlockedResult
 	res, err := w.rpcClient.AccountUnlocked(ctx, acctName)
 	if err != nil {
 		return false, err
@@ -811,7 +810,6 @@ func (w *rpcWallet) LockAccount(ctx context.Context, acctName string) error {
 // UnlockAccount unlocks the specified account or the wallet if account is not
 // encrypted. Part of the Wallet interface.
 func (w *rpcWallet) UnlockAccount(ctx context.Context, pw []byte, acctName string) error {
-	var res *walletjson.AccountUnlockedResult
 	res, err := w.rpcClient.AccountUnlocked(ctx, acctName)
 	if err != nil {
 		return err


### PR DESCRIPTION
All accounts must be unlocked, including any unmixed account, which is used to supply keys to the refund path of the swap contract script. If using a mixed account configuration with individually-encrypted accounts, AND the unmixed account is not unlocked, preparing the backup refund tx in Swap will fail (good and early!).