### PR TITLE
client/asset/dcr: determine sync status with SpvSyncer.Synced() method

### DIFF
--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -774,7 +774,12 @@ func (w *spvWallet) SyncStatus(ctx context.Context) (bool, float32, error) {
 		return false, 0, nil
 	}
 
-	return w.spv.Synced(), float32(height) / float32(bestHeight), nil
+	synced, progress := w.spv.Synced(), float32(height)/float32(bestHeight)
+	if progress > 0.999 && !synced {
+		progress = 0.999
+	}
+
+	return synced, progress, nil
 }
 
 // bestPeerInitialHeight is the highest InitialHeight recorded from our peers.

--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -88,6 +88,7 @@ type dcrWallet interface {
 // Interface for *spv.Syncer so that we can test with a stub.
 type spvSyncer interface {
 	wallet.NetworkBackend
+	Synced() bool
 	GetRemotePeers() map[string]*p2p.RemotePeer
 }
 
@@ -773,7 +774,7 @@ func (w *spvWallet) SyncStatus(ctx context.Context) (bool, float32, error) {
 		return false, 0, nil
 	}
 
-	return bestHeight == height, float32(height) / float32(bestHeight), nil
+	return w.spv.Synced(), float32(height) / float32(bestHeight), nil
 }
 
 // bestPeerInitialHeight is the highest InitialHeight recorded from our peers.

--- a/client/asset/dcr/spv_test.go
+++ b/client/asset/dcr/spv_test.go
@@ -174,6 +174,10 @@ func (w *tDcrWallet) TxDetails(ctx context.Context, txHash *chainhash.Hash) (*ud
 	return w.txDetails, w.txDetailsErr
 }
 
+func (w *tDcrWallet) Synced() bool {
+	return true
+}
+
 func (w *tDcrWallet) GetRemotePeers() map[string]*p2p.RemotePeer {
 	return w.remotePeers
 }


### PR DESCRIPTION
Resolves #1816.

After headers are fetched, other processes occur before the wallet is considered
synced and balance is updated. Use `SpvSyncer.Synced()` to accurately report
sync completion.

Reporting sync completed only after block headers are fetched results in dexc
reporting an outdated balance, which will only be corrected when a block is mined
_after_ wallet synchronisation (including account discovery and blocks rescan)
fully completes. Thus, new blocks won't necessarily update the balance unless
the new block notification is reported after the sync actually completes.