### PR TITLE
server/asset/doge: use feeConfs and reduce maxFeeBlocks

### DIFF
--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -1218,6 +1218,7 @@ func (btc *Backend) estimateFee(ctx context.Context) (satsPerB uint64, err error
 	} else if err != nil && !errors.Is(err, errNoFeeRate) {
 		btc.log.Debugf("Estimate fee failure: %v", err)
 	}
+	btc.log.Debugf("No fee estimate from node. Computing median fee rate from blocks...")
 
 	tip := btc.blockCache.tipHash()
 

--- a/server/asset/doge/doge.go
+++ b/server/asset/doge/doge.go
@@ -14,7 +14,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 )
 
-var maxFeeBlocks = 50
+var maxFeeBlocks = 16
 
 // Driver implements asset.Driver.
 type Driver struct{}
@@ -49,7 +49,7 @@ const (
 	version   = 0
 	BipID     = 3
 	assetName = "doge"
-	feeConfs  = 10
+	feeConfs  = 8
 )
 
 // NewBackend generates the network parameters and creates a ltc backend as a
@@ -92,7 +92,8 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 		Net:                  network,
 		ChainParams:          params,
 		Ports:                ports,
-		DumbFeeEstimates:     true,
+		DumbFeeEstimates:     true, // dogecoind actually has estimatesmartfee, but it is marked deprecated
+		FeeConfs:             feeConfs,
 		ManualMedianFee:      true,
 		NoCompetitionFeeRate: dexdoge.DefaultFee,
 		MaxFeeBlocks:         maxFeeBlocks,

--- a/server/asset/zec/zec.go
+++ b/server/asset/zec/zec.go
@@ -107,6 +107,7 @@ func NewBackend(configPath string, logger dex.Logger, network dex.Network) (asse
 			return zecTx.MsgTx, nil
 		},
 		DumbFeeEstimates:     true,
+		FeeConfs:             feeConfs,
 		ManualMedianFee:      true,
 		BlockFeeTransactions: blockFeeTransactions,
 		NumericGetRawRPC:     true,


### PR DESCRIPTION
This resolves a couple minor bugs introduced in https://github.com/decred/dcrdex/pull/1597

The `feeConfs` arg that was previously used for `estimatefee` was neglected when the `FeeEstimator` config item was replaced with a more sophisticated `(*Backend).estimateFee` method.  This setting was important for DOGE and BCH where a value of 1 almost always returns an estimate of -1 (failure), resulting in one of the median fee estimates.  In the case it was the "hard" way that is extremely demanding in terms of RPCs to the node, making a remote dogecoind instance virtually infeasible.

A second change is reducing the max blocks in the hard median fee estimator from 50 to 16, which is plenty because if it doesn't find 101 txns in 16 blocks it should just go with the "no competition" rate.