### PR TITLE
client: refactor btc FeeEstimator and added DOGE external

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -5,6 +5,7 @@ package bch
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -259,8 +260,8 @@ func serializeBtcTx(msgTx *wire.MsgTx) ([]byte, error) {
 
 // estimateFee uses Bitcoin Cash's estimatefee RPC, since estimatesmartfee
 // is not implemented.
-func estimateFee(node btc.RawRequester, confTarget uint64) (uint64, error) {
-	resp, err := node.RawRequest("estimatefee", nil)
+func estimateFee(ctx context.Context, node btc.RawRequester, confTarget uint64) (uint64, error) {
+	resp, err := node.RawRequest(ctx, "estimatefee", nil)
 	if err != nil {
 		return 0, err
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -643,6 +643,7 @@ func tNewWallet(segwit bool, walletType string) (*ExchangeWalletFullNode, *testD
 		DefaultFallbackFee:  defaultFee,
 		DefaultFeeRateLimit: defaultFeeRateLimit,
 		Segwit:              segwit,
+		FeeEstimator:        rpcFeeRate,
 	}
 
 	var wallet *ExchangeWalletFullNode

--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -27,7 +27,6 @@ import (
 	"decred.org/dcrdex/dex/config"
 	dexbtc "decred.org/dcrdex/dex/networks/btc"
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/btcutil/psbt"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -157,7 +156,7 @@ func newElectrumWallet(ew electrumWalletClient, cfg *electrumWalletConfig) *elec
 
 // BEGIN unimplemented asset.Wallet methods
 
-func (ew *electrumWallet) RawRequest(string, []json.RawMessage) (json.RawMessage, error) {
+func (ew *electrumWallet) RawRequest(context.Context, string, []json.RawMessage) (json.RawMessage, error) {
 	return nil, errors.New("not available") // and not used
 }
 
@@ -376,18 +375,6 @@ func (ew *electrumWallet) reconfigure(cfg *asset.WalletConfig, currentAddress st
 
 	// Changing RPC settings is not supported without restart.
 	return parsedCfg.RPCConfig != *ew.rpcCfg, nil
-}
-
-// part of btc.Wallet interface
-func (ew *electrumWallet) estimateSmartFee(confTarget int64, _ *btcjson.EstimateSmartFeeMode) (*btcjson.EstimateSmartFeeResult, error) {
-	satPerKB, err := ew.wallet.FeeRate(ew.ctx, confTarget)
-	if err != nil {
-		return nil, err
-	}
-	feeRate := float64(satPerKB) / 1e8 // BTC/KvB
-	return &btcjson.EstimateSmartFeeResult{
-		FeeRate: &feeRate,
-	}, nil
 }
 
 // part of btc.Wallet interface

--- a/client/asset/btc/electrum_test.go
+++ b/client/asset/btc/electrum_test.go
@@ -79,6 +79,7 @@ func TestElectrumExchangeWallet(t *testing.T) {
 		DefaultFallbackFee:  defaultFee,
 		DefaultFeeRateLimit: defaultFeeRateLimit,
 		Segwit:              true,
+		// ElectrumWallet constructor overrides btc.localFeeRate = eew.walletFeeRate
 	}
 	eew, err := ElectrumWallet(cfg)
 	if err != nil {

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -378,13 +378,9 @@ func (w *spvWallet) checkpoint(txHash *chainhash.Hash, vout uint32) *filterScanR
 	return res
 }
 
-func (w *spvWallet) RawRequest(method string, params []json.RawMessage) (json.RawMessage, error) {
+func (w *spvWallet) RawRequest(ctx context.Context, method string, params []json.RawMessage) (json.RawMessage, error) {
 	// Not needed for spv wallet.
 	return nil, errors.New("RawRequest not available on spv")
-}
-
-func (w *spvWallet) estimateSmartFee(confTarget int64, mode *btcjson.EstimateSmartFeeMode) (*btcjson.EstimateSmartFeeResult, error) {
-	return nil, errors.New("EstimateSmartFee not available on spv")
 }
 
 func (w *spvWallet) ownsAddress(addr btcutil.Address) (bool, error) {

--- a/client/asset/btc/wallet.go
+++ b/client/asset/btc/wallet.go
@@ -9,7 +9,6 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
@@ -18,9 +17,8 @@ import (
 // Wallet is the interface that BTC wallet backends must implement. TODO: plumb
 // all requests with a context.Context.
 type Wallet interface {
-	RawRequester // for estimateFee calls
+	RawRequester // for localFeeRate/rpcFeeRate calls
 	connect(ctx context.Context, wg *sync.WaitGroup) error
-	estimateSmartFee(confTarget int64, mode *btcjson.EstimateSmartFeeMode) (*btcjson.EstimateSmartFeeResult, error) // TODO: ditch these btcjson types when killing the RawRequester
 	sendRawTransaction(tx *wire.MsgTx) (*chainhash.Hash, error)
 	getTxOut(txHash *chainhash.Hash, index uint32, pkScript []byte, startTime time.Time) (*wire.TxOut, uint32, error)
 	getBlockHash(blockHeight int64) (*chainhash.Hash, error)

--- a/client/asset/doge/regnet_test.go
+++ b/client/asset/doge/regnet_test.go
@@ -5,7 +5,10 @@ package doge
 // Regnet tests expect the DOGE test harness to be running.
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"decred.org/dcrdex/client/asset/btc/livetest"
 	"decred.org/dcrdex/dex"
@@ -36,4 +39,14 @@ func TestWallet(t *testing.T) {
 			Node: "beta",
 		},
 	})
+}
+
+func TestFetchExternalFee(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	rate, err := fetchExternalFee(ctx, dex.Mainnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Printf("#### External fee rate fetched: %d sat/B\n", rate)
 }

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -4,6 +4,7 @@
 package zec
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -235,9 +236,9 @@ func zecTx(tx *wire.MsgTx) *dexzec.Tx {
 // ZCash's fee estimation is pretty crappy. Full nodes can take hours to
 // get up to speed, and forget about simnet.
 // See https://github.com/zcash/zcash/issues/2552
-func estimateFee(node btc.RawRequester, confTarget uint64) (uint64, error) {
+func estimateFee(ctx context.Context, node btc.RawRequester, confTarget uint64) (uint64, error) {
 	const feeConfs = 10
-	resp, err := node.RawRequest("estimatefee", []json.RawMessage{[]byte(strconv.Itoa(feeConfs))})
+	resp, err := node.RawRequest(ctx, "estimatefee", []json.RawMessage{[]byte(strconv.Itoa(feeConfs))})
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This refactors the BTC `baseWallet` fee rate handling to abstract the internal/external estimate calls in a `feeRate` method.  The `estimateSmartFee` RPC-specific wallet method is now removed and no longer part of the `btc.Wallet` interface.

This replaces https://github.com/decred/dcrdex/pull/1888.  The commit is still authored by @vctt94, but also "co-authored" by myself and @buck54321.

Co-authored-by: Brian Stafford <buck54321@gmail.com>
Co-authored-by: Jonathan Chappelow <chappjc@gmail.com>