### PR TITLE
client/core: do not revoke trade when the cancel is revoked

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -4333,17 +4333,45 @@ func TestHandleRevokeOrderMsg(t *testing.T) {
 		t.Fatal("[handleRevokeOrderMsg] expected a non-existent order")
 	}
 
-	// Now store the order in dc.trades.
+	// Now store the order in dc.trades, with a linked cancel order.
 	tracker := newTrackedTrade(dbOrder, preImg, dc,
 		rig.core.lockTimeTaker, rig.core.lockTimeMaker,
 		rig.db, rig.queue, walletSet, tDcrWallet.fundingCoins, rig.core.notify,
 		rig.core.formatDetails)
+	preImgC := newPreimage()
+	co := &order.CancelOrder{
+		P: order.Prefix{
+			ServerTime: time.Now(),
+			Commit:     preImgC.Commit(),
+		},
+	}
+	tracker.cancel = &trackedCancel{CancelOrder: *co}
+	coid := co.ID()
 	rig.dc.trades[oid] = tracker
 
 	orderNotes, feedDone := orderNoteFeed(tCore)
 	defer feedDone()
 
-	// Success
+	// Revoke the cancel order, not the targeted order.
+	payloadC := &msgjson.RevokeOrder{
+		OrderID: coid[:],
+	}
+	reqC, _ := msgjson.NewRequest(rig.dc.NextID(), msgjson.RevokeOrderRoute, payloadC)
+	err = handleRevokeOrderMsg(rig.core, rig.dc, reqC)
+	if err != nil {
+		t.Fatalf("handleRevokeOrderMsg error: %v", err)
+	}
+
+	verifyRevokeNotification(orderNotes, TopicFailedCancel, t)
+
+	if tracker.metaData.Status == order.OrderStatusRevoked {
+		t.Errorf("Incorrectly revoked the targeted order instead of clearing the cancel order!")
+	}
+	if tracker.cancel != nil {
+		t.Fatalf("Did not clear the cancel order")
+	}
+
+	// Now revoke the actual trade order.
 	err = handleRevokeOrderMsg(rig.core, rig.dc, req)
 	if err != nil {
 		t.Fatalf("handleRevokeOrderMsg error: %v", err)
@@ -6778,7 +6806,7 @@ func TestHandleTradeSuspensionMsg(t *testing.T) {
 }
 
 func orderNoteFeed(tCore *Core) (orderNotes chan *OrderNote, done func()) {
-	orderNotes = make(chan *OrderNote, 1)
+	orderNotes = make(chan *OrderNote, 16)
 
 	ntfnFeed := tCore.NotificationFeed()
 	feedDone := make(chan struct{})
@@ -6789,10 +6817,8 @@ func orderNoteFeed(tCore *Core) (orderNotes chan *OrderNote, done func()) {
 		for {
 			select {
 			case n := <-ntfnFeed:
-				ordNote, ok := n.(*OrderNote)
-				if ok {
+				if ordNote, ok := n.(*OrderNote); ok {
 					orderNotes <- ordNote
-					return // just one OrderNote and done
 				}
 			case <-tCtx.Done():
 				return
@@ -6810,6 +6836,7 @@ func orderNoteFeed(tCore *Core) (orderNotes chan *OrderNote, done func()) {
 }
 
 func verifyRevokeNotification(ch chan *OrderNote, expectedTopic Topic, t *testing.T) {
+	t.Helper()
 	select {
 	case actualOrderNote := <-ch:
 		if expectedTopic != actualOrderNote.TopicID {

--- a/client/core/locale_ntfn.go
+++ b/client/core/locale_ntfn.go
@@ -249,7 +249,9 @@ var originLocale = map[Topic]*translation{
 	// [token]
 	TopicFailedCancel: {
 		subject:  "Failed cancel",
-		template: "Cancel order for order %s stuck in Epoch status for 2 epochs and is now deleted.",
+		template: "Cancel order for order %s failed and is now deleted.",
+		// NOTE: "failed" means we missed the preimage request and either got
+		// the revoke_order message or it stayed in epoch status for too long.
 	},
 	// [coin ID, ticker, match]
 	TopicAuditTrouble: {
@@ -574,6 +576,7 @@ var ptBR = map[Topic]*translation{
 	TopicFailedCancel: {
 		template: "Ordem de cancelamento para pedido %s presa em estado de Epoque por 2 epoques e foi agora deletado.",
 		subject:  "Falhou Cancelamento",
+		stale:    true,
 	},
 	// [coin ID, ticker, match]
 	TopicAuditTrouble: {
@@ -878,6 +881,7 @@ var zhCN = map[Topic]*translation{
 	TopicFailedCancel: {
 		subject:  "取消失败",
 		template: "取消订单 %s 的订单 %s 处于 Epoque 状态 2 个 epoques，现在已被删除。",
+		stale:    true,
 	},
 	// [coin ID, ticker, match]
 	TopicAuditTrouble: {
@@ -1181,6 +1185,7 @@ var plPL = map[Topic]*translation{
 	TopicFailedCancel: {
 		subject:  "Niepowodzenie anulowania",
 		template: "Zlecenie anulacji dla zlecenia %s utknęło w statusie epoki przez 2 epoki i zostało usunięte.",
+		stale:    true,
 	},
 	// [coin ID, ticker, match]
 	TopicAuditTrouble: {
@@ -1503,6 +1508,7 @@ var deDE = map[Topic]*translation{
 	TopicFailedCancel: {
 		subject:  "Abbruch fehlgeschlagen",
 		template: "Der Auftrag für den Abbruch des Auftrags %s blieb 2 Epochen lang im Epoche-Status hängen und wird nun gelöscht.",
+		stale:    true,
 	},
 	// [coin ID, ticker, match]
 	TopicAuditTrouble: {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -1107,7 +1107,10 @@ func (t *trackedTrade) counterPartyConfirms(ctx context.Context, match *matchTra
 //
 // This is to be used in trade status resolution only, since normally the fate
 // of cancel orders is determined by match/nomatch and status set to executed
-// (see nomatch and negotiate)
+// (see nomatch and negotiate). A missed preimage request for the cancel order
+// that results in a revoke_order message for the cancel order should also use
+// this method to unlink and retire the failed cancel order. Similarly, cancel
+// orders detected as "stale" with the two-epochs-old heuristic use this.
 //
 // This method MUST be called with the trackedTrade mutex lock held for writes.
 func (t *trackedTrade) deleteCancelOrder() {


### PR DESCRIPTION
Related to https://github.com/decred/dcrdex/pull/1889, this fixes one such bug that can lead to retired/non-existent orders on the client that are still booked on the server.

```
client/core: do not revoke trade when the cancel is revoked

This fixes a bug where a revoke_order notification from the server that
refers to a cancel order ID would cause the client to revoke the
targeted trade order instead.

Most of the time a cancel order is declared stale and deleted after it
becomes 2 epochs old, a heuristic we use to infer when we've missed the
preimage request for the cancel order.  This was necessary since unlike
trade orders, we don't expect to get status of cancel orders.  However,
we neglected the possibility that we could miss the preimage request
but reconnect in time to receive the revoke_order notification at the
end of the epoch collection period.

When handleRevokeOrderMsg detects that the order ID is a cancel order,
we now unlink the cancel order and send a TopicFailedCancel order ntfn.
The TopicFailedCancel topic previously was only used when cancel orders
were declared "stale", meaning they were more than 2 epochs old.
```