### PR TITLE
server: fail fast if txindex is not enabled for btc clones

### DIFF
--- a/dex/networks/btc/script_test.go
+++ b/dex/networks/btc/script_test.go
@@ -257,7 +257,6 @@ func TestIsDust(t *testing.T) {
 		if res != test.isDust {
 			t.Fatalf("Dust test '%s' failed: want %v got %v",
 				test.name, test.isDust, res)
-			continue
 		}
 	}
 }

--- a/dex/networks/dcr/script_test.go
+++ b/dex/networks/dcr/script_test.go
@@ -298,7 +298,6 @@ func TestIsDust(t *testing.T) {
 		if res != test.isDust {
 			t.Fatalf("Dust test '%s' failed: want %v got %v",
 				test.name, test.isDust, res)
-			continue
 		}
 	}
 }

--- a/server/asset/btc/rpcclient.go
+++ b/server/asset/btc/rpcclient.go
@@ -29,6 +29,7 @@ const (
 	methodGetIndexInfo      = "getindexinfo"
 	methodGetBlockHeader    = "getblockheader"
 	methodGetBlockStats     = "getblockstats"
+	methodGetBlockHash      = "getblockhash"
 
 	errNoCompetition = dex.ErrorKind("no competition")
 	errNoFeeRate     = dex.ErrorKind("fee rate could not be estimated")
@@ -96,8 +97,8 @@ func (rc *RPCClient) GetBlockChainInfo() (*GetBlockchainInfoResult, error) {
 	return chainInfo, nil
 }
 
-// txIndexResult models the data returned from the getindexinfo command
-// for txindex.
+// txIndexResult models the data returned from the getindexinfo command for
+// txindex.
 // txIndexResult.Txindex is nil if the returned data is an empty json object.
 type txIndexResult struct {
 	TxIndex *struct{} `json:"txindex"`
@@ -107,12 +108,46 @@ type txIndexResult struct {
 func (rc *RPCClient) checkTxIndex() (bool, error) {
 	res := new(txIndexResult)
 	err := rc.call(methodGetIndexInfo, anylist{"txindex"}, res)
-	if err != nil {
-		return false, err
+	if err == nil {
+		// Return early if there is no error. bitcoind returns an empty json
+		// object if txindex is not enabled. It is safe to conclude txindex is
+		// enabled if res.Txindex is not nil.
+		return res.TxIndex != nil, nil
 	}
-	// bitcoind returns an empty json object if txindex is not enabled.
-	// It is safe to conclude txindex is enabled if res.Txindex is not nil.
-	return res.TxIndex != nil, nil
+
+	if isMethodNotFoundErr(err) {
+		// Using block at index 5 to retrieve a coinbase transaction and ensure
+		// txindex is enabled for pre 0.21 versions of bitcoind.
+		const blockIndex = 5
+		blockHash, err := rc.GetBlockHash(blockIndex)
+		if err != nil {
+			return false, err
+		}
+
+		blockInfo, err := rc.GetBlockVerbose(blockHash)
+		if err != nil {
+			return false, err
+		}
+
+		if len(blockInfo.Tx) == 0 {
+			return false, fmt.Errorf("block %d does not have a coinbase transaction", blockIndex)
+		}
+
+		txHash, err := chainhash.NewHashFromStr(blockInfo.Tx[0])
+		if err != nil {
+			return false, err
+		}
+
+		// Retrieve coinbase transaction information.
+		txBytes, err := rc.GetRawTransaction(txHash)
+		if err != nil {
+			return false, err
+		}
+
+		return len(txBytes) != 0, nil
+	}
+
+	return false, err
 }
 
 // EstimateSmartFee requests the server to estimate a fee level.
@@ -247,6 +282,22 @@ func (rc *RPCClient) GetBlockVerbose(blockHash *chainhash.Hash) (*GetBlockVerbos
 	}
 	res := new(GetBlockVerboseResult)
 	return res, rc.call(methodGetBlock, anylist{blockHash.String(), arg}, res)
+}
+
+// GetBlockHash fetches the block hash for the block at the given index.
+func (rc *RPCClient) GetBlockHash(index int64) (*chainhash.Hash, error) {
+	var blockHashStr string
+	err := rc.Call(methodGetBlockHash, []interface{}{index}, &blockHashStr)
+	if err != nil {
+		return nil, err
+	}
+
+	blockHash, err := chainhash.NewHashFromStr(blockHashStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return blockHash, nil
 }
 
 // MedianFeeRate returns the median rate from the specified block.

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -695,7 +695,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	// Because the dexBalancer relies on the marketTunnels map, and NewMarket
 	// checks necessary balances for account-based assets using the dexBalancer,
 	// that means that each market can only query orders for the markets that
-	// were intitialized before it was, which is fine, but notable. The
+	// were initialized before it was, which is fine, but notable. The
 	// resulting behavior is that a user could have orders involving an
 	// account-based asset approved for re-booking on one market, but have
 	// orders rejected on a market involving the same asset created afterwards,


### PR DESCRIPTION
This ensures `txindex` is enabled by fetching information for a `coinbase` transaction of a given block which is essential for dex activities as it could be fatal for `btc` clone markets if this is not enabled. Closes #1778 

Litecoin Core version v0.21.2.1 has `getindexinfo` rpc command. Tested with bitcoin cash, dogecoin, litecoin and should work for zcash(my zec refuses to sync).
PS: @JoeGruffins, I'd be glad if you can find time to test this with zcash.
