### PR TITLE
client: check for zero fiat rates and handle fiat rates request limit

### DIFF
--- a/client/core/bot.go
+++ b/client/core/bot.go
@@ -742,7 +742,7 @@ func oracleMarketReport(ctx context.Context, b, q *SupportedAsset, log dex.Logge
 	// running on the same market.
 	var rawMarkets []*coinpapMarket
 	url := fmt.Sprintf("https://api.coinpaprika.com/v1/coins/%s/markets", baseSlug)
-	if err := getInto(ctx, url, &rawMarkets); err != nil {
+	if err := getRates(ctx, url, &rawMarkets); err != nil {
 		return nil, err
 	}
 
@@ -1657,7 +1657,7 @@ func fetchBinanceSpread(ctx context.Context, baseSymbol, quoteSymbol string) (se
 		BidPrice float64 `json:"bidPrice,string"`
 		AskPrice float64 `json:"askPrice,string"`
 	}
-	return resp.AskPrice, resp.BidPrice, getInto(ctx, url, &resp)
+	return resp.AskPrice, resp.BidPrice, getRates(ctx, url, &resp)
 }
 
 func fetchCoinbaseSpread(ctx context.Context, baseSymbol, quoteSymbol string) (sell, buy float64, err error) {
@@ -1669,7 +1669,7 @@ func fetchCoinbaseSpread(ctx context.Context, baseSymbol, quoteSymbol string) (s
 		Bid float64 `json:"bid,string"`
 	}
 
-	return resp.Ask, resp.Bid, getInto(ctx, url, &resp)
+	return resp.Ask, resp.Bid, getRates(ctx, url, &resp)
 }
 
 func fetchBittrexSpread(ctx context.Context, baseSymbol, quoteSymbol string) (sell, buy float64, err error) {
@@ -1679,7 +1679,7 @@ func fetchBittrexSpread(ctx context.Context, baseSymbol, quoteSymbol string) (se
 		AskRate float64 `json:"askRate,string"`
 		BidRate float64 `json:"bidRate,string"`
 	}
-	return resp.AskRate, resp.BidRate, getInto(ctx, url, &resp)
+	return resp.AskRate, resp.BidRate, getRates(ctx, url, &resp)
 }
 
 func fetchHitBTCSpread(ctx context.Context, baseSymbol, quoteSymbol string) (sell, buy float64, err error) {
@@ -1690,7 +1690,7 @@ func fetchHitBTCSpread(ctx context.Context, baseSymbol, quoteSymbol string) (sel
 		Ask [][2]json.Number `json:"ask"`
 		Bid [][2]json.Number `json:"bid"`
 	}
-	if err := getInto(ctx, url, &resp); err != nil {
+	if err := getRates(ctx, url, &resp); err != nil {
 		return 0, 0, err
 	}
 	if len(resp.Ask) < 1 || len(resp.Bid) < 1 {
@@ -1719,7 +1719,7 @@ func fetchEXMOSpread(ctx context.Context, baseSymbol, quoteSymbol string) (sell,
 		BidTop float64 `json:"bid_top,string"`
 	}
 
-	if err := getInto(ctx, url, &resp); err != nil {
+	if err := getRates(ctx, url, &resp); err != nil {
 		return 0, 0, err
 	}
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -9063,7 +9063,7 @@ func (c *Core) fiatConversions() map[uint32]float64 {
 		var sources int
 		for _, source := range c.fiatRateSources {
 			rateInfo := source.assetRate(assetID)
-			if rateInfo != nil && time.Since(rateInfo.lastUpdate) < fiatRateDataExpiry {
+			if rateInfo != nil && time.Since(rateInfo.lastUpdate) < fiatRateDataExpiry && rateInfo.rate > 0 {
 				sources++
 				rateSum += rateInfo.rate
 			}

--- a/client/core/exchangeratefetcher.go
+++ b/client/core/exchangeratefetcher.go
@@ -20,7 +20,7 @@ const (
 	// DefaultFiatCurrency is the currency for displaying assets fiat value.
 	DefaultFiatCurrency = "USD"
 	// fiatRateRequestInterval is the amount of time between calls to the exchange API.
-	fiatRateRequestInterval = 5 * time.Minute
+	fiatRateRequestInterval = 12 * time.Minute
 	// fiatRateDataExpiry : Any data older than fiatRateDataExpiry will be discarded.
 	fiatRateDataExpiry = 60 * time.Minute
 
@@ -226,6 +226,10 @@ func getRates(ctx context.Context, url string, thing interface{}) error {
 		return err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected response, got status code %d", resp.StatusCode)
+	}
 
 	reader := io.LimitReader(resp.Body, 1<<20)
 	return json.NewDecoder(reader).Decode(thing)


### PR DESCRIPTION
This addresses a bug where a fiat source rate returns zero rates after some time (~19hrs). This source has been removed in https://github.com/decred/dcrdex/commit/0210b57f513676daa32f071a7e67a53de2060095 and a sanity check added in  https://github.com/decred/dcrdex/commit/f7e7006c8e7e144e0946801d63ab62e1bd8a1060. Closes #1968.

PS:  I'd appreciate any suggestions of good sources to replace with.