### PR TITLE
ui: store markets/wallets user preferences

### DIFF
--- a/client/webserver/locales/parse_test.go
+++ b/client/webserver/locales/parse_test.go
@@ -14,7 +14,7 @@ func TestTokens(t *testing.T) {
 <div id="main" data-handler="settings" class="text-center py-5 overflow-y-auto">
   <div class="settings">
     <div class="form-check">
-      <input class="form-check-input" type="checkbox" value="" id="showPokes"{{if .UserInfo.ShowPopups}} checked{{end}}>
+      <input class="form-check-input" type="checkbox" value="" id="showPokes" checked>
       <label class="form-check-label" for="showPokes">
         [[[Show pop-up notifications]]]
       </label>

--- a/client/webserver/middleware.go
+++ b/client/webserver/middleware.go
@@ -44,7 +44,6 @@ func (s *WebServer) authMiddleware(next http.Handler) http.Handler {
 			Authed:           s.isAuthed(r),
 			PasswordIsCached: s.isPasswordCached(r),
 			DarkMode:         extractBooleanCookie(r, darkModeCK, true),
-			ShowPopups:       extractBooleanCookie(r, popupsCK, true),
 		})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -263,7 +263,7 @@ div[data-handler=markets] {
     font-size: 0.9em;
   }
 
-  #leftColumnV1 {
+  #leftMarketDock {
     height: 100%;
     position: absolute;
     display: flex;
@@ -773,7 +773,7 @@ div[data-handler=markets] {
     display: flex;
   }
 
-  div[data-handler=markets] #leftColumnV1 {
+  div[data-handler=markets] #leftMarketDock {
     position: relative;
 
     &.default {
@@ -871,7 +871,7 @@ div[data-handler=markets] {
       }
     }
 
-    #leftColumnV1.stashed + #marketReopener {
+    #leftMarketDock.stashed + #marketReopener {
       display: block;
     }
   }

--- a/client/webserver/site/src/css/market_dark.scss
+++ b/client/webserver/site/src/css/market_dark.scss
@@ -145,7 +145,7 @@ body.dark {
       }
     }
 
-    #leftColumnV1 {
+    #leftMarketDock {
       border-color: $dark_border_color;
       background-color: $dark_body_bg;
 

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=XYXY183gH" rel="stylesheet">
+  <link href="/css/style.css?v=XBHD888gH" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=jBRE183gH"></script>
+<script src="/js/entry.js?v=XBHD888gH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -12,7 +12,7 @@
 {{template "top" .}}
 <div id="main" data-handler="markets" class="main m-0 flex-nowrap v1">
   {{- /* MARKET LIST */ -}}
-  <div id="leftColumnV1" class="flex-column align-items-end v1 default">
+  <div id="leftMarketDock" class="flex-column align-items-end v1 default">
     <div class="h-100 d-flex flex-column align-items-stretch">
 
       <div class="d-flex align-items-stretch" id="searchBoxV1">

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -11,7 +11,7 @@
       </label>
     </div>
     <div class="form-check">
-      <input class="form-check-input" type="checkbox" value="" id="showPokes"{{if .UserInfo.ShowPopups}} checked{{end}}>
+      <input class="form-check-input" type="checkbox" value="" id="showPokes" checked>
       <label class="form-check-label" for="showPokes">
         [[[Show pop-up notifications]]]
       </label>

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -108,7 +108,7 @@ export default class Application {
     this.commitHash = process.env.COMMITHASH || ''
     this.noteReceivers = []
     this.fiatRatesMap = {}
-    this.showPopups = State.getCookie('popups') === '1'
+    this.showPopups = State.getCookie(State.PopupsCK) === '1'
     console.log('Decred DEX Client App, Build', this.commitHash.substring(0, 7))
 
     // Loggers can be enabled by setting a truthy value to the loggerID using

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -48,8 +48,6 @@ const bind = Doc.bind
 const unbind = Doc.unbind
 
 const notificationRoute = 'notify'
-const loggersKey = 'loggers'
-const recordersKey = 'recorders'
 const noteCacheSize = 100
 
 interface Page {
@@ -114,18 +112,18 @@ export default class Application {
     // Loggers can be enabled by setting a truthy value to the loggerID using
     // enableLogger. Settings are stored across sessions. See docstring for the
     // log method for more info.
-    this.loggers = State.fetch(loggersKey) || {}
+    this.loggers = State.fetch(State.LoggersLK) || {}
     window.enableLogger = (loggerID, state) => {
       if (state) this.loggers[loggerID] = true
       else delete this.loggers[loggerID]
-      State.store(loggersKey, this.loggers)
+      State.store(State.LoggersLK, this.loggers)
       return `${loggerID} logger ${state ? 'enabled' : 'disabled'}`
     }
     // Enable logging from anywhere.
     window.log = (loggerID, ...a) => { this.log(loggerID, ...a) }
 
     // Recorders can record log messages, and then save them to file on request.
-    const recorderKeys = State.fetch(recordersKey) || []
+    const recorderKeys = State.fetch(State.RecordersLK) || []
     this.recorders = {}
     for (const loggerID of recorderKeys) {
       console.log('recording', loggerID)
@@ -134,7 +132,7 @@ export default class Application {
     window.recordLogger = (loggerID, on) => {
       if (on) this.recorders[loggerID] = []
       else delete this.recorders[loggerID]
-      State.store(recordersKey, Object.keys(this.recorders))
+      State.store(State.RecordersLK, Object.keys(this.recorders))
       return `${loggerID} recorder ${on ? 'enabled' : 'disabled'}`
     }
     window.dumpLogger = loggerID => {

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -931,9 +931,8 @@ export default class Application {
   }
 
   /**
-   * signOut call to /api/logout, if response with no errors occurred clear all
-   * store, remove auth, darkMode cookies and reload the page, otherwise will
-   * show a notification
+   * signOut call to /api/logout, if response with no errors occurred remove
+   * auth cookie and reload the page, otherwise show a notification.
    */
   async signOut () {
     const res = await postJSON('/api/logout')
@@ -946,7 +945,6 @@ export default class Application {
       Doc.show(this.page.logoutErr)
       return
     }
-    State.clearAllStore()
     State.removeAuthCK()
     window.location.href = '/login'
   }

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -106,7 +106,7 @@ export default class Application {
     this.commitHash = process.env.COMMITHASH || ''
     this.noteReceivers = []
     this.fiatRatesMap = {}
-    this.showPopups = State.fetchLocal(State.popupsCK) === '1'
+    this.showPopups = State.fetchLocal(State.popupsLK) === '1'
 
     console.log('Decred DEX Client App, Build', this.commitHash.substring(0, 7))
 

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -112,18 +112,18 @@ export default class Application {
     // Loggers can be enabled by setting a truthy value to the loggerID using
     // enableLogger. Settings are stored across sessions. See docstring for the
     // log method for more info.
-    this.loggers = State.fetch(State.LoggersLK) || {}
+    this.loggers = State.fetchLocal(State.LoggersLK) || {}
     window.enableLogger = (loggerID, state) => {
       if (state) this.loggers[loggerID] = true
       else delete this.loggers[loggerID]
-      State.store(State.LoggersLK, this.loggers)
+      State.storeLocal(State.LoggersLK, this.loggers)
       return `${loggerID} logger ${state ? 'enabled' : 'disabled'}`
     }
     // Enable logging from anywhere.
     window.log = (loggerID, ...a) => { this.log(loggerID, ...a) }
 
     // Recorders can record log messages, and then save them to file on request.
-    const recorderKeys = State.fetch(State.RecordersLK) || []
+    const recorderKeys = State.fetchLocal(State.RecordersLK) || []
     this.recorders = {}
     for (const loggerID of recorderKeys) {
       console.log('recording', loggerID)
@@ -132,7 +132,7 @@ export default class Application {
     window.recordLogger = (loggerID, on) => {
       if (on) this.recorders[loggerID] = []
       else delete this.recorders[loggerID]
-      State.store(State.RecordersLK, Object.keys(this.recorders))
+      State.storeLocal(State.RecordersLK, Object.keys(this.recorders))
       return `${loggerID} recorder ${on ? 'enabled' : 'disabled'}`
     }
     window.dumpLogger = loggerID => {
@@ -184,7 +184,7 @@ export default class Application {
     this.attachCommon(this.header)
     this.attach({})
     // Load recent notifications from Window.localStorage.
-    const notes = State.fetch(State.NotificationsLK)
+    const notes = State.fetchLocal(State.NotificationsLK)
     this.setNotes(notes || [])
     // Connect the websocket and register the notification route.
     ws.connect(getSocketURI(), this.reconnected)
@@ -434,7 +434,7 @@ export default class Application {
    * actual stored list is stripped of information not necessary for display.
    */
   storeNotes () {
-    State.store(State.NotificationsLK, this.notes.map(n => {
+    State.storeLocal(State.NotificationsLK, this.notes.map(n => {
       return {
         subject: n.subject,
         details: n.details,
@@ -944,11 +944,11 @@ export default class Application {
       Doc.show(this.page.logoutErr)
       return
     }
-    State.removeAuthCK()
-    State.removePwKeyCK()
-    State.remove(State.LastMarketLK)
-    State.remove(State.LastMMMarketLK)
-    State.remove(State.NotificationsLK)
+    State.removeCookie(State.AuthCK)
+    State.removeCookie(State.PwKeyCK)
+    State.removeLocal(State.LastMarketLK)
+    State.removeLocal(State.LastMMMarketLK)
+    State.removeLocal(State.NotificationsLK)
     window.location.href = '/login'
   }
 }

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -184,7 +184,7 @@ export default class Application {
     this.attachCommon(this.header)
     this.attach({})
     // Load recent notifications from Window.localStorage.
-    const notes = State.fetch('notifications')
+    const notes = State.fetch(State.NotificationsLK)
     this.setNotes(notes || [])
     // Connect the websocket and register the notification route.
     ws.connect(getSocketURI(), this.reconnected)
@@ -434,7 +434,7 @@ export default class Application {
    * actual stored list is stripped of information not necessary for display.
    */
   storeNotes () {
-    State.store('notifications', this.notes.map(n => {
+    State.store(State.NotificationsLK, this.notes.map(n => {
       return {
         subject: n.subject,
         details: n.details,
@@ -929,8 +929,9 @@ export default class Application {
   }
 
   /**
-   * signOut call to /api/logout, if response with no errors occurred remove
-   * auth cookie and reload the page, otherwise show a notification.
+   * signOut call to /api/logout, if response with no errors occurred remove auth
+   * and other privacy-critical cookies/locals and reload the page, otherwise
+   * show a notification.
    */
   async signOut () {
     const res = await postJSON('/api/logout')
@@ -944,6 +945,10 @@ export default class Application {
       return
     }
     State.removeAuthCK()
+    State.removePwKeyCK()
+    State.remove(State.LastMarketLK)
+    State.remove(State.LastMMMarketLK)
+    State.remove(State.NotificationsLK)
     window.location.href = '/login'
   }
 }

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -106,24 +106,24 @@ export default class Application {
     this.commitHash = process.env.COMMITHASH || ''
     this.noteReceivers = []
     this.fiatRatesMap = {}
-    this.showPopups = State.getCookie(State.PopupsCK) === '1'
+    this.showPopups = State.getCookie(State.popupsCK) === '1'
     console.log('Decred DEX Client App, Build', this.commitHash.substring(0, 7))
 
     // Loggers can be enabled by setting a truthy value to the loggerID using
     // enableLogger. Settings are stored across sessions. See docstring for the
     // log method for more info.
-    this.loggers = State.fetchLocal(State.LoggersLK) || {}
+    this.loggers = State.fetchLocal(State.loggersLK) || {}
     window.enableLogger = (loggerID, state) => {
       if (state) this.loggers[loggerID] = true
       else delete this.loggers[loggerID]
-      State.storeLocal(State.LoggersLK, this.loggers)
+      State.storeLocal(State.loggersLK, this.loggers)
       return `${loggerID} logger ${state ? 'enabled' : 'disabled'}`
     }
     // Enable logging from anywhere.
     window.log = (loggerID, ...a) => { this.log(loggerID, ...a) }
 
     // Recorders can record log messages, and then save them to file on request.
-    const recorderKeys = State.fetchLocal(State.RecordersLK) || []
+    const recorderKeys = State.fetchLocal(State.recordersLK) || []
     this.recorders = {}
     for (const loggerID of recorderKeys) {
       console.log('recording', loggerID)
@@ -132,7 +132,7 @@ export default class Application {
     window.recordLogger = (loggerID, on) => {
       if (on) this.recorders[loggerID] = []
       else delete this.recorders[loggerID]
-      State.storeLocal(State.RecordersLK, Object.keys(this.recorders))
+      State.storeLocal(State.recordersLK, Object.keys(this.recorders))
       return `${loggerID} recorder ${on ? 'enabled' : 'disabled'}`
     }
     window.dumpLogger = loggerID => {
@@ -184,7 +184,7 @@ export default class Application {
     this.attachCommon(this.header)
     this.attach({})
     // Load recent notifications from Window.localStorage.
-    const notes = State.fetchLocal(State.NotificationsLK)
+    const notes = State.fetchLocal(State.notificationsLK)
     this.setNotes(notes || [])
     // Connect the websocket and register the notification route.
     ws.connect(getSocketURI(), this.reconnected)
@@ -434,7 +434,7 @@ export default class Application {
    * actual stored list is stripped of information not necessary for display.
    */
   storeNotes () {
-    State.storeLocal(State.NotificationsLK, this.notes.map(n => {
+    State.storeLocal(State.notificationsLK, this.notes.map(n => {
       return {
         subject: n.subject,
         details: n.details,
@@ -944,11 +944,11 @@ export default class Application {
       Doc.show(this.page.logoutErr)
       return
     }
-    State.removeCookie(State.AuthCK)
-    State.removeCookie(State.PwKeyCK)
-    State.removeLocal(State.LastMarketLK)
-    State.removeLocal(State.LastMMMarketLK)
-    State.removeLocal(State.NotificationsLK)
+    State.removeCookie(State.authCK)
+    State.removeCookie(State.pwKeyCK)
+    State.removeLocal(State.lastMarketLK)
+    State.removeLocal(State.lastMMMarketLK)
+    State.removeLocal(State.notificationsLK)
     window.location.href = '/login'
   }
 }

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -664,11 +664,6 @@ export default class Application {
     if (note.severity < ntfn.POKE) return
     // Poke notifications have their own display.
     const { popupTmpl, popupNotes, showPopups } = this
-
-    // TODO
-    console.log(showPopups)
-    console.log(this.showPopups)
-
     if (showPopups) {
       const span = popupTmpl.cloneNode(true) as HTMLElement
       Doc.tmplElement(span, 'text').textContent = `${note.subject}: ${note.details}`

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -106,7 +106,8 @@ export default class Application {
     this.commitHash = process.env.COMMITHASH || ''
     this.noteReceivers = []
     this.fiatRatesMap = {}
-    this.showPopups = State.getCookie(State.popupsCK) === '1'
+    this.showPopups = State.fetchLocal(State.popupsCK) === '1'
+
     console.log('Decred DEX Client App, Build', this.commitHash.substring(0, 7))
 
     // Loggers can be enabled by setting a truthy value to the loggerID using
@@ -663,6 +664,11 @@ export default class Application {
     if (note.severity < ntfn.POKE) return
     // Poke notifications have their own display.
     const { popupTmpl, popupNotes, showPopups } = this
+
+    // TODO
+    console.log(showPopups)
+    console.log(this.showPopups)
+
     if (showPopups) {
       const span = popupTmpl.cloneNode(true) as HTMLElement
       Doc.tmplElement(span, 'text').textContent = `${note.subject}: ${note.details}`
@@ -946,8 +952,6 @@ export default class Application {
     }
     State.removeCookie(State.authCK)
     State.removeCookie(State.pwKeyCK)
-    State.removeLocal(State.lastMarketLK)
-    State.removeLocal(State.lastMMMarketLK)
     State.removeLocal(State.notificationsLK)
     window.location.href = '/login'
   }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -455,27 +455,24 @@ export default class MarketsPage extends BasePage {
     this.stats = [{ row: stats0, tmpl: Doc.parseTemplate(stats0) }, { row: stats1, tmpl: Doc.parseTemplate(stats1) }]
 
     const closeMarketsList = () => {
-      page.leftColumnV1.classList.remove('default')
-      page.leftColumnV1.classList.add('stashed')
+      State.setCookie(State.LeftMarketDockCK, '0')
+      page.leftMarketDock.classList.remove('default')
+      page.leftMarketDock.classList.add('stashed')
       for (const s of this.stats) s.row.classList.remove('listopen')
     }
-
     const openMarketsList = () => {
-      page.leftColumnV1.classList.remove('default', 'stashed')
+      State.setCookie(State.LeftMarketDockCK, '1')
+      page.leftMarketDock.classList.remove('default', 'stashed')
       for (const s of this.stats) s.row.classList.add('listopen')
     }
-
     Doc.bind(page.leftHider, 'click', () => closeMarketsList())
-
     Doc.bind(page.marketReopener, 'click', () => openMarketsList())
-
     for (const s of this.stats) {
       Doc.bind(s.tmpl.marketSelect, 'click', () => {
-        if (page.leftColumnV1.clientWidth === 0) openMarketsList()
+        if (page.leftMarketDock.clientWidth === 0) openMarketsList()
         else closeMarketsList()
       })
     }
-
     this.marketList = new MarketList(page.marketListV1)
     // Prepare the list of markets.
     for (const row of this.marketList.markets) {
@@ -483,6 +480,9 @@ export default class MarketsPage extends BasePage {
         this.startLoadingAnimations()
         this.setMarket(row.mkt.xc.host, row.mkt.baseid, row.mkt.quoteid)
       })
+    }
+    if (!State.showLeftMarketDock()) { // It is shown by default, hiding if necessary.
+      closeMarketsList()
     }
 
     // Notification filters.

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -455,13 +455,13 @@ export default class MarketsPage extends BasePage {
     this.stats = [{ row: stats0, tmpl: Doc.parseTemplate(stats0) }, { row: stats1, tmpl: Doc.parseTemplate(stats1) }]
 
     const closeMarketsList = () => {
-      State.setCookie(State.LeftMarketDockCK, '0')
+      State.store(State.LeftMarketDockLK, '0')
       page.leftMarketDock.classList.remove('default')
       page.leftMarketDock.classList.add('stashed')
       for (const s of this.stats) s.row.classList.remove('listopen')
     }
     const openMarketsList = () => {
-      State.setCookie(State.LeftMarketDockCK, '1')
+      State.store(State.LeftMarketDockLK, '1')
       page.leftMarketDock.classList.remove('default', 'stashed')
       for (const s of this.stats) s.row.classList.add('listopen')
     }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -208,7 +208,7 @@ export default class MarketsPage extends BasePage {
       mouse: (r: MouseReport) => { this.reportDepthMouse(r) },
       zoom: (z: number) => { this.reportDepthZoom(z) }
     }
-    this.depthChart = new DepthChart(page.depthChart, depthReporters, State.fetchLocal(State.DepthZoomLK))
+    this.depthChart = new DepthChart(page.depthChart, depthReporters, State.fetchLocal(State.depthZoomLK))
 
     const candleReporters: CandleReporters = {
       mouse: c => { this.reportMouseCandle(c) }
@@ -452,13 +452,13 @@ export default class MarketsPage extends BasePage {
     this.stats = [{ row: stats0, tmpl: Doc.parseTemplate(stats0) }, { row: stats1, tmpl: Doc.parseTemplate(stats1) }]
 
     const closeMarketsList = () => {
-      State.storeLocal(State.LeftMarketDockLK, '0')
+      State.storeLocal(State.leftMarketDockLK, '0')
       page.leftMarketDock.classList.remove('default')
       page.leftMarketDock.classList.add('stashed')
       for (const s of this.stats) s.row.classList.remove('listopen')
     }
     const openMarketsList = () => {
-      State.storeLocal(State.LeftMarketDockLK, '1')
+      State.storeLocal(State.leftMarketDockLK, '1')
       page.leftMarketDock.classList.remove('default', 'stashed')
       for (const s of this.stats) s.row.classList.add('listopen')
     }
@@ -478,7 +478,7 @@ export default class MarketsPage extends BasePage {
         this.setMarket(row.mkt.xc.host, row.mkt.baseid, row.mkt.quoteid)
       })
     }
-    if (!State.showLeftMarketDock()) { // It is shown by default, hiding if necessary.
+    if (State.fetchLocal(State.leftMarketDockLK) !== '1') { // It is shown by default, hiding if necessary.
       closeMarketsList()
     }
 
@@ -516,7 +516,7 @@ export default class MarketsPage extends BasePage {
     if (data && data.host && typeof data.base !== 'undefined' && typeof data.quote !== 'undefined') {
       selected = makeMarket(data.host, parseInt(data.base), parseInt(data.quote))
     } else {
-      selected = State.fetchLocal(State.LastMarketLK)
+      selected = State.fetchLocal(State.lastMarketLK)
     }
     if (!selected || !this.marketList.exists(selected.host, selected.base, selected.quote)) {
       const first = this.marketList.first()
@@ -881,7 +881,7 @@ export default class MarketsPage extends BasePage {
    * across reloads.
    */
   reportDepthZoom (zoom: number) {
-    State.storeLocal(State.DepthZoomLK, zoom)
+    State.storeLocal(State.depthZoomLK, zoom)
   }
 
   reportMouseCandle (candle: Candle | null) {
@@ -1346,7 +1346,7 @@ export default class MarketsPage extends BasePage {
     this.updateTitle()
     this.marketList.select(host, b.id, q.id)
 
-    State.storeLocal(State.LastMarketLK, {
+    State.storeLocal(State.lastMarketLK, {
       host: note.host,
       base: mktBook.base,
       quote: mktBook.quote

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -423,14 +423,14 @@ export default class MarketsPage extends BasePage {
       Doc.setVis(acked, page.showDisclaimer)
     }
     bind(page.disclaimerAck, 'click', () => {
-      State.store(State.orderDisclaimerAckedLK, true)
+      State.storeLocal(State.orderDisclaimerAckedLK, true)
       setDisclaimerAckViz(true)
     })
     bind(page.showDisclaimer, 'click', () => {
-      State.store(State.orderDisclaimerAckedLK, false)
+      State.storeLocal(State.orderDisclaimerAckedLK, false)
       setDisclaimerAckViz(false)
     })
-    setDisclaimerAckViz(State.fetch(State.orderDisclaimerAckedLK))
+    setDisclaimerAckViz(State.fetchLocal(State.orderDisclaimerAckedLK))
 
     const clearChartLines = () => {
       this.depthLines.hover = []

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -74,9 +74,6 @@ const candleUpdateRoute = 'candle_update'
 const unmarketRoute = 'unmarket'
 const epochMatchSummaryRoute = 'epoch_match_summary'
 
-const lastMarketKey = 'selectedMarket'
-const depthZoomKey = 'depthZoom'
-
 const animationLength = 500
 
 const anHour = 60 * 60 * 1000 // milliseconds
@@ -211,7 +208,7 @@ export default class MarketsPage extends BasePage {
       mouse: (r: MouseReport) => { this.reportDepthMouse(r) },
       zoom: (z: number) => { this.reportDepthZoom(z) }
     }
-    this.depthChart = new DepthChart(page.depthChart, depthReporters, State.fetch(depthZoomKey))
+    this.depthChart = new DepthChart(page.depthChart, depthReporters, State.fetch(State.DepthZoomLK))
 
     const candleReporters: CandleReporters = {
       mouse: c => { this.reportMouseCandle(c) }
@@ -519,7 +516,7 @@ export default class MarketsPage extends BasePage {
     if (data && data.host && typeof data.base !== 'undefined' && typeof data.quote !== 'undefined') {
       selected = makeMarket(data.host, parseInt(data.base), parseInt(data.quote))
     } else {
-      selected = State.fetch(lastMarketKey)
+      selected = State.fetch(State.LastMarketLK)
     }
     if (!selected || !this.marketList.exists(selected.host, selected.base, selected.quote)) {
       const first = this.marketList.first()
@@ -884,7 +881,7 @@ export default class MarketsPage extends BasePage {
    * across reloads.
    */
   reportDepthZoom (zoom: number) {
-    State.store(depthZoomKey, zoom)
+    State.store(State.DepthZoomLK, zoom)
   }
 
   reportMouseCandle (candle: Candle | null) {
@@ -1349,7 +1346,7 @@ export default class MarketsPage extends BasePage {
     this.updateTitle()
     this.marketList.select(host, b.id, q.id)
 
-    State.store(lastMarketKey, {
+    State.store(State.LastMarketLK, {
       host: note.host,
       base: mktBook.base,
       quote: mktBook.quote

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -208,7 +208,7 @@ export default class MarketsPage extends BasePage {
       mouse: (r: MouseReport) => { this.reportDepthMouse(r) },
       zoom: (z: number) => { this.reportDepthZoom(z) }
     }
-    this.depthChart = new DepthChart(page.depthChart, depthReporters, State.fetch(State.DepthZoomLK))
+    this.depthChart = new DepthChart(page.depthChart, depthReporters, State.fetchLocal(State.DepthZoomLK))
 
     const candleReporters: CandleReporters = {
       mouse: c => { this.reportMouseCandle(c) }
@@ -452,13 +452,13 @@ export default class MarketsPage extends BasePage {
     this.stats = [{ row: stats0, tmpl: Doc.parseTemplate(stats0) }, { row: stats1, tmpl: Doc.parseTemplate(stats1) }]
 
     const closeMarketsList = () => {
-      State.store(State.LeftMarketDockLK, '0')
+      State.storeLocal(State.LeftMarketDockLK, '0')
       page.leftMarketDock.classList.remove('default')
       page.leftMarketDock.classList.add('stashed')
       for (const s of this.stats) s.row.classList.remove('listopen')
     }
     const openMarketsList = () => {
-      State.store(State.LeftMarketDockLK, '1')
+      State.storeLocal(State.LeftMarketDockLK, '1')
       page.leftMarketDock.classList.remove('default', 'stashed')
       for (const s of this.stats) s.row.classList.add('listopen')
     }
@@ -516,7 +516,7 @@ export default class MarketsPage extends BasePage {
     if (data && data.host && typeof data.base !== 'undefined' && typeof data.quote !== 'undefined') {
       selected = makeMarket(data.host, parseInt(data.base), parseInt(data.quote))
     } else {
-      selected = State.fetch(State.LastMarketLK)
+      selected = State.fetchLocal(State.LastMarketLK)
     }
     if (!selected || !this.marketList.exists(selected.host, selected.base, selected.quote)) {
       const first = this.marketList.first()
@@ -881,7 +881,7 @@ export default class MarketsPage extends BasePage {
    * across reloads.
    */
   reportDepthZoom (zoom: number) {
-    State.store(State.DepthZoomLK, zoom)
+    State.storeLocal(State.DepthZoomLK, zoom)
   }
 
   reportMouseCandle (candle: Candle | null) {
@@ -1346,7 +1346,7 @@ export default class MarketsPage extends BasePage {
     this.updateTitle()
     this.marketList.select(host, b.id, q.id)
 
-    State.store(State.LastMarketLK, {
+    State.storeLocal(State.LastMarketLK, {
       host: note.host,
       base: mktBook.base,
       quote: mktBook.quote

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -20,9 +20,6 @@ import State from './state'
 import { bind as bindForm, NewWalletForm } from './forms'
 import { RateEncodingFactor } from './orderutil'
 
-const lastMarketKey = 'mmMarket'
-const optionsExpansionKey = 'mmOptsExpand'
-
 const GapStrategyMultiplier = 'multiplier'
 const GapStrategyAbsolute = 'absolute'
 const GapStrategyAbsolutePlus = 'absolute-plus'
@@ -294,13 +291,13 @@ export default class MarketMakerPage extends BasePage {
     page.options.appendChild(this.biasOpt.node)
 
     Doc.bind(page.showAdvanced, 'click', () => {
-      State.store(optionsExpansionKey, true)
+      State.store(State.OptionsExpansionLK, true)
       Doc.hide(page.showAdvanced)
       Doc.show(page.hideAdvanced, page.options)
     })
 
     Doc.bind(page.hideAdvanced, 'click', () => {
-      State.store(optionsExpansionKey, false)
+      State.store(State.OptionsExpansionLK, false)
       Doc.hide(page.hideAdvanced, page.options)
       Doc.show(page.showAdvanced)
     })
@@ -395,7 +392,7 @@ export default class MarketMakerPage extends BasePage {
       }
     }
 
-    const lastMkt = State.fetch(lastMarketKey) as HostedMarket
+    const lastMkt = State.fetch(State.LastMMMarketLK) as HostedMarket
     let mkt: HostedMarket | null = null
     if (lastMkt && lastMkt.host) {
       const xc = app().exchanges[lastMkt.host]
@@ -406,7 +403,7 @@ export default class MarketMakerPage extends BasePage {
       }
     }
 
-    if (State.fetch(optionsExpansionKey)) {
+    if (State.fetch(State.OptionsExpansionLK)) {
       Doc.show(page.hideAdvanced, page.options)
       Doc.hide(page.showAdvanced)
     }
@@ -575,7 +572,7 @@ export default class MarketMakerPage extends BasePage {
     this.setCurrentReport(null)
     page.manualPriceInput.value = ''
 
-    State.store(lastMarketKey, mkt)
+    State.store(State.LastMMMarketLK, mkt)
 
     Doc.empty(page.baseSelect, page.quoteSelect)
     page.baseSelect.appendChild(this.assetRow(mkt.basesymbol))
@@ -630,7 +627,7 @@ export default class MarketMakerPage extends BasePage {
         page.lotEstQuoteBox, page.lotEstBaseBox, page.availHeader, page.fetchingMarkets,
         page.lotsBox, page.advancedBox
       )
-      if (State.fetch(optionsExpansionKey)) Doc.show(page.options)
+      if (State.fetch(State.OptionsExpansionLK)) Doc.show(page.options)
       const loaded = app().loading(page.options)
       const buy = this.fetchOracleAndMaxBuy()
       const sell = this.fetchMaxSell()

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -291,13 +291,13 @@ export default class MarketMakerPage extends BasePage {
     page.options.appendChild(this.biasOpt.node)
 
     Doc.bind(page.showAdvanced, 'click', () => {
-      State.store(State.OptionsExpansionLK, true)
+      State.storeLocal(State.OptionsExpansionLK, true)
       Doc.hide(page.showAdvanced)
       Doc.show(page.hideAdvanced, page.options)
     })
 
     Doc.bind(page.hideAdvanced, 'click', () => {
-      State.store(State.OptionsExpansionLK, false)
+      State.storeLocal(State.OptionsExpansionLK, false)
       Doc.hide(page.hideAdvanced, page.options)
       Doc.show(page.showAdvanced)
     })
@@ -392,7 +392,7 @@ export default class MarketMakerPage extends BasePage {
       }
     }
 
-    const lastMkt = State.fetch(State.LastMMMarketLK) as HostedMarket
+    const lastMkt = State.fetchLocal(State.LastMMMarketLK) as HostedMarket
     let mkt: HostedMarket | null = null
     if (lastMkt && lastMkt.host) {
       const xc = app().exchanges[lastMkt.host]
@@ -403,7 +403,7 @@ export default class MarketMakerPage extends BasePage {
       }
     }
 
-    if (State.fetch(State.OptionsExpansionLK)) {
+    if (State.fetchLocal(State.OptionsExpansionLK)) {
       Doc.show(page.hideAdvanced, page.options)
       Doc.hide(page.showAdvanced)
     }
@@ -572,7 +572,7 @@ export default class MarketMakerPage extends BasePage {
     this.setCurrentReport(null)
     page.manualPriceInput.value = ''
 
-    State.store(State.LastMMMarketLK, mkt)
+    State.storeLocal(State.LastMMMarketLK, mkt)
 
     Doc.empty(page.baseSelect, page.quoteSelect)
     page.baseSelect.appendChild(this.assetRow(mkt.basesymbol))
@@ -627,7 +627,7 @@ export default class MarketMakerPage extends BasePage {
         page.lotEstQuoteBox, page.lotEstBaseBox, page.availHeader, page.fetchingMarkets,
         page.lotsBox, page.advancedBox
       )
-      if (State.fetch(State.OptionsExpansionLK)) Doc.show(page.options)
+      if (State.fetchLocal(State.OptionsExpansionLK)) Doc.show(page.options)
       const loaded = app().loading(page.options)
       const buy = this.fetchOracleAndMaxBuy()
       const sell = this.fetchMaxSell()

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -291,13 +291,13 @@ export default class MarketMakerPage extends BasePage {
     page.options.appendChild(this.biasOpt.node)
 
     Doc.bind(page.showAdvanced, 'click', () => {
-      State.storeLocal(State.OptionsExpansionLK, true)
+      State.storeLocal(State.optionsExpansionLK, true)
       Doc.hide(page.showAdvanced)
       Doc.show(page.hideAdvanced, page.options)
     })
 
     Doc.bind(page.hideAdvanced, 'click', () => {
-      State.storeLocal(State.OptionsExpansionLK, false)
+      State.storeLocal(State.optionsExpansionLK, false)
       Doc.hide(page.hideAdvanced, page.options)
       Doc.show(page.showAdvanced)
     })
@@ -392,7 +392,7 @@ export default class MarketMakerPage extends BasePage {
       }
     }
 
-    const lastMkt = State.fetchLocal(State.LastMMMarketLK) as HostedMarket
+    const lastMkt = State.fetchLocal(State.lastMMMarketLK) as HostedMarket
     let mkt: HostedMarket | null = null
     if (lastMkt && lastMkt.host) {
       const xc = app().exchanges[lastMkt.host]
@@ -403,7 +403,7 @@ export default class MarketMakerPage extends BasePage {
       }
     }
 
-    if (State.fetchLocal(State.OptionsExpansionLK)) {
+    if (State.fetchLocal(State.optionsExpansionLK)) {
       Doc.show(page.hideAdvanced, page.options)
       Doc.hide(page.showAdvanced)
     }
@@ -572,7 +572,7 @@ export default class MarketMakerPage extends BasePage {
     this.setCurrentReport(null)
     page.manualPriceInput.value = ''
 
-    State.storeLocal(State.LastMMMarketLK, mkt)
+    State.storeLocal(State.lastMMMarketLK, mkt)
 
     Doc.empty(page.baseSelect, page.quoteSelect)
     page.baseSelect.appendChild(this.assetRow(mkt.basesymbol))
@@ -627,7 +627,7 @@ export default class MarketMakerPage extends BasePage {
         page.lotEstQuoteBox, page.lotEstBaseBox, page.availHeader, page.fetchingMarkets,
         page.lotsBox, page.advancedBox
       )
-      if (State.fetchLocal(State.OptionsExpansionLK)) Doc.show(page.options)
+      if (State.fetchLocal(State.optionsExpansionLK)) Doc.show(page.options)
       const loaded = app().loading(page.options)
       const buy = this.fetchOracleAndMaxBuy()
       const sell = this.fetchMaxSell()

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -568,7 +568,6 @@ export interface Application {
   walletMap: Record<number, WalletState>
   exchanges: Record<string, Exchange>
   fiatRatesMap: Record<number, number>
-  showPopups: boolean
   commitHash: string
   authed(): boolean
   start (): Promise<void>

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -568,6 +568,7 @@ export interface Application {
   walletMap: Record<number, WalletState>
   exchanges: Record<string, Exchange>
   fiatRatesMap: Record<number, number>
+  showPopups: boolean
   commitHash: string
   authed(): boolean
   start (): Promise<void>

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -48,7 +48,9 @@ export default class SettingsPage extends BasePage {
     })
 
     Doc.bind(page.showPokes, 'click', () => {
-      State.setCookie(State.PopupsCK, page.showPokes.checked || false ? '1' : '0')
+      const show = page.showPokes.checked || false
+      State.setCookie(State.PopupsCK, show ? '1' : '0')
+      app().showPopups = show
     })
 
     page.commitHash.textContent = app().commitHash.substring(0, 7)

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -39,7 +39,7 @@ export default class SettingsPage extends BasePage {
     this.fiatRateSources = Doc.applySelector(page.fiatRateSources, 'input[type=checkbox]')
 
     Doc.bind(page.darkMode, 'click', () => {
-      State.dark(page.darkMode.checked || false)
+      State.setCookie(State.DarkModeCK, page.darkMode.checked || false ? '1' : '0')
       if (page.darkMode.checked) {
         document.body.classList.add('dark')
       } else {
@@ -48,9 +48,7 @@ export default class SettingsPage extends BasePage {
     })
 
     Doc.bind(page.showPokes, 'click', () => {
-      const show = page.showPokes.checked || false
-      State.setCookie('popups', show ? '1' : '0')
-      app().showPopups = show
+      State.setCookie(State.PopupsCK, page.showPokes.checked || false ? '1' : '0')
     })
 
     page.commitHash.textContent = app().commitHash.substring(0, 7)

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -47,10 +47,25 @@ export default class SettingsPage extends BasePage {
       }
     })
 
+    page.showPokes.checked = State.fetchLocal(State.popupsCK) === '1'
     Doc.bind(page.showPokes, 'click', () => {
       const show = page.showPokes.checked || false
-      State.setCookie(State.popupsCK, show ? '1' : '0')
+
+      // TODO
+      console.log('Show')
+      console.log(show)
+
+      State.storeLocal(State.popupsCK, show ? '1' : '0')
+
+      // TODO
+      console.log('Before')
+      console.log(app().showPopups)
+
       app().showPopups = show
+
+      // TODO
+      console.log('After')
+      console.log(app().showPopups)
     })
 
     page.commitHash.textContent = app().commitHash.substring(0, 7)

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -39,7 +39,7 @@ export default class SettingsPage extends BasePage {
     this.fiatRateSources = Doc.applySelector(page.fiatRateSources, 'input[type=checkbox]')
 
     Doc.bind(page.darkMode, 'click', () => {
-      State.setCookie(State.DarkModeCK, page.darkMode.checked || false ? '1' : '0')
+      State.setCookie(State.darkModeCK, page.darkMode.checked || false ? '1' : '0')
       if (page.darkMode.checked) {
         document.body.classList.add('dark')
       } else {
@@ -49,7 +49,7 @@ export default class SettingsPage extends BasePage {
 
     Doc.bind(page.showPokes, 'click', () => {
       const show = page.showPokes.checked || false
-      State.setCookie(State.PopupsCK, show ? '1' : '0')
+      State.setCookie(State.popupsCK, show ? '1' : '0')
       app().showPopups = show
     })
 

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -47,10 +47,10 @@ export default class SettingsPage extends BasePage {
       }
     })
 
-    page.showPokes.checked = State.fetchLocal(State.popupsCK) === '1'
+    page.showPokes.checked = State.fetchLocal(State.popupsLK) === '1'
     Doc.bind(page.showPokes, 'click', () => {
       const show = page.showPokes.checked || false
-      State.storeLocal(State.popupsCK, show ? '1' : '0')
+      State.storeLocal(State.popupsLK, show ? '1' : '0')
       app().showPopups = show
     })
 

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -50,22 +50,8 @@ export default class SettingsPage extends BasePage {
     page.showPokes.checked = State.fetchLocal(State.popupsCK) === '1'
     Doc.bind(page.showPokes, 'click', () => {
       const show = page.showPokes.checked || false
-
-      // TODO
-      console.log('Show')
-      console.log(show)
-
       State.storeLocal(State.popupsCK, show ? '1' : '0')
-
-      // TODO
-      console.log('Before')
-      console.log(app().showPopups)
-
       app().showPopups = show
-
-      // TODO
-      console.log('After')
-      console.log(app().showPopups)
     })
 
     page.commitHash.textContent = app().commitHash.substring(0, 7)

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -8,6 +8,12 @@ export default class State {
   static PopupsCK = 'popups'
   static PwKeyCK = 'sessionkey'
   // Local storage keys (for data that we don't need at the server).
+  static LoggersLK = 'loggers'
+  static RecordersLK = 'recorders'
+  static LastMarketLK = 'selectedMarket'
+  static DepthZoomLK = 'depthZoom'
+  static LastMMMarketLK = 'mmMarket'
+  static OptionsExpansionLK = 'mmOptsExpand'
   static LeftMarketDockLK = 'leftmarketdock'
   static SelectedAssetLK = 'selectedasset'
 

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -40,6 +40,15 @@ export default class State {
   }
 
   /*
+   * removeCookie tells the browser to stop using cookie. It's not enough to simply
+   * erase cookie value because browser will still send it to the server (with empty
+   * value), and that's not what server expects.
+   */
+  static removeCookie (cKey: string) {
+    document.cookie = `${cKey}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`
+  }
+
+  /*
    * isDark returns true if the dark-mode cookie is currently set to '1' = true.
    */
   static isDark () {
@@ -51,17 +60,9 @@ export default class State {
     return !!this.getCookie(State.PwKeyCK)
   }
 
-  static removeAuthCK () {
-    document.cookie = `${State.AuthCK}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`
-  }
-
-  static removePwKeyCK () {
-    document.cookie = `${State.PwKeyCK}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`
-  }
-
   /* showLeftMarketDock returns whether or not user wants left market doc shown. */
   static showLeftMarketDock () {
-    return this.fetch(State.LeftMarketDockLK) === '1'
+    return this.fetchLocal(State.LeftMarketDockLK) === '1'
   }
 
   /*
@@ -69,23 +70,23 @@ export default class State {
    * yet.
    */
   static selectedAsset (): number | null {
-    const assetIDStr = State.fetch(State.SelectedAssetLK)
+    const assetIDStr = State.fetchLocal(State.SelectedAssetLK)
     if (!assetIDStr) {
       return null
     }
     return Number(assetIDStr)
   }
 
-  /* store puts the key-value pair into Window.localStorage. */
-  static store (k: string, v: any) {
+  /* storeLocal puts the key-value pair into Window.localStorage. */
+  static storeLocal (k: string, v: any) {
     window.localStorage.setItem(k, JSON.stringify(v))
   }
 
   /*
-  * fetch the value associated with the key in Window.localStorage, or
+  * fetchLocal the value associated with the key in Window.localStorage, or
   * null if the no value exists for the key.
   */
-  static fetch (k: string) {
+  static fetchLocal (k: string) {
     const v = window.localStorage.getItem(k)
     if (v !== null) {
       return JSON.parse(v)
@@ -93,8 +94,8 @@ export default class State {
     return null
   }
 
-  /* store removes the key-value pair from Window.localStorage. */
-  static remove (k: string) {
+  /* removeLocal removes the key-value pair from Window.localStorage. */
+  static removeLocal (k: string) {
     window.localStorage.removeItem(k)
   }
 }
@@ -102,4 +103,4 @@ export default class State {
 // Setting defaults here, unless specific cookie (or local storage) value was already chosen by the user.
 if (State.getCookie(State.DarkModeCK) === null) State.setCookie(State.DarkModeCK, '1')
 if (State.getCookie(State.PopupsCK) === null) State.setCookie(State.PopupsCK, '1')
-if (State.fetch(State.LeftMarketDockLK) === null) State.store(State.LeftMarketDockLK, '1')
+if (State.fetchLocal(State.LeftMarketDockLK) === null) State.storeLocal(State.LeftMarketDockLK, '1')

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -2,12 +2,14 @@
 // utilities for setting and retrieving cookies and storing user configuration
 // to localStorage.
 export default class State {
+  // Cookie keys.
   static DarkModeCK = 'darkMode'
   static AuthCK = 'dexauth'
   static PopupsCK = 'popups'
   static PwKeyCK = 'sessionkey'
-  static LeftMarketDockCK = 'leftmarketdock'
-  static SelectedAssetCK = 'selectedAsset'
+  // Local storage keys (for data that we don't need at the server).
+  static LeftMarketDockLK = 'leftmarketdock'
+  static SelectedAssetLK = 'selectedasset'
 
   static orderDisclaimerAckedLK = 'ordAck'
 
@@ -42,13 +44,13 @@ export default class State {
     return !!this.getCookie(State.PwKeyCK)
   }
 
-  /* showLeftMarketDock returns whether or not user wants left market doc shown. */
-  static showLeftMarketDock () {
-    return this.getCookie(State.LeftMarketDockCK) === '1'
-  }
-
   static removeAuthCK () {
     document.cookie = `${State.AuthCK}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`
+  }
+
+  /* showLeftMarketDock returns whether or not user wants left market doc shown. */
+  static showLeftMarketDock () {
+    return this.fetch(State.LeftMarketDockLK) === '1'
   }
 
   /*
@@ -56,7 +58,7 @@ export default class State {
    * yet.
    */
   static selectedAsset (): number | null {
-    const assetIDStr = State.getCookie(State.SelectedAssetCK)
+    const assetIDStr = State.fetch(State.SelectedAssetLK)
     if (!assetIDStr) {
       return null
     }
@@ -74,7 +76,7 @@ export default class State {
   }
 
   /*
-  * fetch fetches the value associated with the key in Window.localStorage, or
+  * fetch the value associated with the key in Window.localStorage, or
   * null if the no value exists for the key.
   */
   static fetch (k: string) {
@@ -86,7 +88,7 @@ export default class State {
   }
 }
 
-// Setting defaults here, unless specific cookie value was already chosen by the user.
+// Setting defaults here, unless specific cookie (or local storage) value was already chosen by the user.
 if (State.getCookie(State.DarkModeCK) === null) State.setCookie(State.DarkModeCK, '1')
 if (State.getCookie(State.PopupsCK) === null) State.setCookie(State.PopupsCK, '1')
-if (State.getCookie(State.LeftMarketDockCK) === null) State.setCookie(State.LeftMarketDockCK, '1')
+if (State.fetch(State.LeftMarketDockLK) === null) State.store(State.LeftMarketDockLK, '1')

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -3,20 +3,20 @@
 // to localStorage.
 export default class State {
   // Cookie keys.
-  static DarkModeCK = 'darkMode'
-  static AuthCK = 'dexauth'
-  static PopupsCK = 'popups'
-  static PwKeyCK = 'sessionkey'
+  static darkModeCK = 'darkMode'
+  static authCK = 'dexauth'
+  static popupsCK = 'popups'
+  static pwKeyCK = 'sessionkey'
   // Local storage keys (for data that we don't need at the server).
-  static LoggersLK = 'loggers'
-  static RecordersLK = 'recorders'
-  static LastMarketLK = 'selectedMarket'
-  static DepthZoomLK = 'depthZoom'
-  static LastMMMarketLK = 'mmMarket'
-  static OptionsExpansionLK = 'mmOptsExpand'
-  static LeftMarketDockLK = 'leftmarketdock'
-  static SelectedAssetLK = 'selectedasset'
-  static NotificationsLK = 'notifications'
+  static loggersLK = 'loggers'
+  static recordersLK = 'recorders'
+  static lastMarketLK = 'selectedMarket'
+  static depthZoomLK = 'depthZoom'
+  static lastMMMarketLK = 'mmMarket'
+  static optionsExpansionLK = 'mmOptsExpand'
+  static leftMarketDockLK = 'leftmarketdock'
+  static selectedAssetLK = 'selectedasset'
+  static notificationsLK = 'notifications'
 
   static orderDisclaimerAckedLK = 'ordAck'
 
@@ -52,29 +52,12 @@ export default class State {
    * isDark returns true if the dark-mode cookie is currently set to '1' = true.
    */
   static isDark () {
-    return document.cookie.split(';').filter((item) => item.includes(`${State.DarkModeCK}=1`)).length
+    return document.cookie.split(';').filter((item) => item.includes(`${State.darkModeCK}=1`)).length
   }
 
   /* passwordIsCached returns whether or not there is a cached password in the cookies. */
   static passwordIsCached () {
-    return !!this.getCookie(State.PwKeyCK)
-  }
-
-  /* showLeftMarketDock returns whether or not user wants left market doc shown. */
-  static showLeftMarketDock () {
-    return this.fetchLocal(State.LeftMarketDockLK) === '1'
-  }
-
-  /*
-   * selectedAsset returns selected asset ID or null if none user hasn't selected one
-   * yet.
-   */
-  static selectedAsset (): number | null {
-    const assetIDStr = State.fetchLocal(State.SelectedAssetLK)
-    if (!assetIDStr) {
-      return null
-    }
-    return Number(assetIDStr)
+    return !!this.getCookie(State.pwKeyCK)
   }
 
   /* storeLocal puts the key-value pair into Window.localStorage. */
@@ -101,6 +84,6 @@ export default class State {
 }
 
 // Setting defaults here, unless specific cookie (or local storage) value was already chosen by the user.
-if (State.getCookie(State.DarkModeCK) === null) State.setCookie(State.DarkModeCK, '1')
-if (State.getCookie(State.PopupsCK) === null) State.setCookie(State.PopupsCK, '1')
-if (State.fetchLocal(State.LeftMarketDockLK) === null) State.storeLocal(State.LeftMarketDockLK, '1')
+if (State.getCookie(State.darkModeCK) === null) State.setCookie(State.darkModeCK, '1')
+if (State.getCookie(State.popupsCK) === null) State.setCookie(State.popupsCK, '1')
+if (State.fetchLocal(State.leftMarketDockLK) === null) State.storeLocal(State.leftMarketDockLK, '1')

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -5,9 +5,9 @@ export default class State {
   // Cookie keys.
   static darkModeCK = 'darkMode'
   static authCK = 'dexauth'
-  static popupsCK = 'popups'
   static pwKeyCK = 'sessionkey'
   // Local storage keys (for data that we don't need at the server).
+  static popupsCK = 'popups'
   static loggersLK = 'loggers'
   static recordersLK = 'recorders'
   static lastMarketLK = 'selectedMarket'
@@ -85,5 +85,5 @@ export default class State {
 
 // Setting defaults here, unless specific cookie (or local storage) value was already chosen by the user.
 if (State.getCookie(State.darkModeCK) === null) State.setCookie(State.darkModeCK, '1')
-if (State.getCookie(State.popupsCK) === null) State.setCookie(State.popupsCK, '1')
+if (State.fetchLocal(State.popupsCK) === null) State.storeLocal(State.popupsCK, '1')
 if (State.fetchLocal(State.leftMarketDockLK) === null) State.storeLocal(State.leftMarketDockLK, '1')

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -7,7 +7,7 @@ export default class State {
   static authCK = 'dexauth'
   static pwKeyCK = 'sessionkey'
   // Local storage keys (for data that we don't need at the server).
-  static popupsCK = 'popups'
+  static popupsLK = 'popups'
   static loggersLK = 'loggers'
   static recordersLK = 'recorders'
   static lastMarketLK = 'selectedMarket'
@@ -85,5 +85,5 @@ export default class State {
 
 // Setting defaults here, unless specific cookie (or local storage) value was already chosen by the user.
 if (State.getCookie(State.darkModeCK) === null) State.setCookie(State.darkModeCK, '1')
-if (State.fetchLocal(State.popupsCK) === null) State.storeLocal(State.popupsCK, '1')
+if (State.fetchLocal(State.popupsLK) === null) State.storeLocal(State.popupsLK, '1')
 if (State.fetchLocal(State.leftMarketDockLK) === null) State.storeLocal(State.leftMarketDockLK, '1')

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -17,7 +17,6 @@ export default class State {
   static leftMarketDockLK = 'leftmarketdock'
   static selectedAssetLK = 'selectedasset'
   static notificationsLK = 'notifications'
-
   static orderDisclaimerAckedLK = 'ordAck'
 
   static setCookie (cname: string, cvalue: string) {

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -16,6 +16,7 @@ export default class State {
   static OptionsExpansionLK = 'mmOptsExpand'
   static LeftMarketDockLK = 'leftmarketdock'
   static SelectedAssetLK = 'selectedasset'
+  static NotificationsLK = 'notifications'
 
   static orderDisclaimerAckedLK = 'ordAck'
 
@@ -54,6 +55,10 @@ export default class State {
     document.cookie = `${State.AuthCK}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`
   }
 
+  static removePwKeyCK () {
+    document.cookie = `${State.PwKeyCK}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`
+  }
+
   /* showLeftMarketDock returns whether or not user wants left market doc shown. */
   static showLeftMarketDock () {
     return this.fetch(State.LeftMarketDockLK) === '1'
@@ -86,6 +91,11 @@ export default class State {
       return JSON.parse(v)
     }
     return null
+  }
+
+  /* store removes the key-value pair from Window.localStorage. */
+  static remove (k: string) {
+    window.localStorage.removeItem(k)
   }
 }
 

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -1,12 +1,14 @@
-const darkModeCK = 'darkMode'
-const authCK = 'dexauth'
-const popupsCK = 'popups'
-const pwKeyCK = 'sessionkey'
-
 // State is a set of static methods for working with the user state. It has
 // utilities for setting and retrieving cookies and storing user configuration
 // to localStorage.
 export default class State {
+  static DarkModeCK = 'darkMode'
+  static AuthCK = 'dexauth'
+  static PopupsCK = 'popups'
+  static PwKeyCK = 'sessionkey'
+  static LeftMarketDockCK = 'leftmarketdock'
+  static SelectedAssetCK = 'selectedAsset'
+
   static orderDisclaimerAckedLK = 'ordAck'
 
   static setCookie (cname: string, cvalue: string) {
@@ -28,26 +30,37 @@ export default class State {
     return null
   }
 
-  /* dark sets the dark-mode cookie. */
-  static dark (dark: boolean) {
-    this.setCookie(darkModeCK, dark ? '1' : '0')
-    if (dark) {
-      document.body.classList.add('dark')
-    } else {
-      document.body.classList.remove('dark')
-    }
-  }
-
   /*
    * isDark returns true if the dark-mode cookie is currently set to '1' = true.
    */
   static isDark () {
-    return document.cookie.split(';').filter((item) => item.includes(`${darkModeCK}=1`)).length
+    return document.cookie.split(';').filter((item) => item.includes(`${State.DarkModeCK}=1`)).length
   }
 
   /* passwordIsCached returns whether or not there is a cached password in the cookies. */
   static passwordIsCached () {
-    return !!this.getCookie(pwKeyCK)
+    return !!this.getCookie(State.PwKeyCK)
+  }
+
+  /* showLeftMarketDock returns whether or not user wants left market doc shown. */
+  static showLeftMarketDock () {
+    return this.getCookie(State.LeftMarketDockCK) === '1'
+  }
+
+  static removeAuthCK () {
+    document.cookie = `${State.AuthCK}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`
+  }
+
+  /*
+   * selectedAsset returns selected asset ID or null if none user hasn't selected one
+   * yet.
+   */
+  static selectedAsset (): number | null {
+    const assetIDStr = State.getCookie(State.SelectedAssetCK)
+    if (!assetIDStr) {
+      return null
+    }
+    return Number(assetIDStr)
   }
 
   /* store puts the key-value pair into Window.localStorage. */
@@ -58,10 +71,6 @@ export default class State {
   /* clearAllStore remove all the key-value pair in Window.localStorage. */
   static clearAllStore () {
     window.localStorage.clear()
-  }
-
-  static removeAuthCK () {
-    document.cookie = `${authCK}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`
   }
 
   /*
@@ -77,6 +86,7 @@ export default class State {
   }
 }
 
-// If the dark-mode cookie is not set, set it to dark mode on.
-if (State.getCookie(darkModeCK) === null) State.setCookie(darkModeCK, '1')
-if (State.getCookie(popupsCK) === null) State.setCookie(popupsCK, '1')
+// Setting defaults here, unless specific cookie value was already chosen by the user.
+if (State.getCookie(State.DarkModeCK) === null) State.setCookie(State.DarkModeCK, '1')
+if (State.getCookie(State.PopupsCK) === null) State.setCookie(State.PopupsCK, '1')
+if (State.getCookie(State.LeftMarketDockCK) === null) State.setCookie(State.LeftMarketDockCK, '1')

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -70,11 +70,6 @@ export default class State {
     window.localStorage.setItem(k, JSON.stringify(v))
   }
 
-  /* clearAllStore remove all the key-value pair in Window.localStorage. */
-  static clearAllStore () {
-    window.localStorage.clear()
-  }
-
   /*
   * fetch the value associated with the key in Window.localStorage, or
   * null if the no value exists for the key.

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -592,7 +592,7 @@ export default class WalletsPage extends BasePage {
       this.updateAssetButton(a.id)
       Doc.bind(bttn, 'click', () => {
         this.setSelectedAsset(a.id)
-        State.setCookie(State.SelectedAssetCK, String(a.id))
+        State.store(State.SelectedAssetLK, String(a.id))
       })
     }
     page.assetSelect.classList.remove('invisible')

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -220,9 +220,7 @@ export default class WalletsPage extends BasePage {
     const firstAsset = this.sortAssetButtons()
     let selectedAsset = firstAsset.id
     const assetIDStr = State.fetchLocal(State.selectedAssetLK)
-    if (assetIDStr) {
-      selectedAsset = Number(assetIDStr)
-    }
+    if (assetIDStr) selectedAsset = Number(assetIDStr)
     this.setSelectedAsset(selectedAsset)
   }
 

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -218,9 +218,10 @@ export default class WalletsPage extends BasePage {
     })
 
     const firstAsset = this.sortAssetButtons()
-    let selectedAsset = State.selectedAsset()
-    if (!selectedAsset) {
-      selectedAsset = firstAsset.id
+    let selectedAsset = firstAsset.id
+    const assetIDStr = State.fetchLocal(State.selectedAssetLK)
+    if (assetIDStr) {
+      selectedAsset = Number(assetIDStr)
     }
     this.setSelectedAsset(selectedAsset)
   }
@@ -592,7 +593,7 @@ export default class WalletsPage extends BasePage {
       this.updateAssetButton(a.id)
       Doc.bind(bttn, 'click', () => {
         this.setSelectedAsset(a.id)
-        State.storeLocal(State.SelectedAssetLK, String(a.id))
+        State.storeLocal(State.selectedAssetLK, String(a.id))
       })
     }
     page.assetSelect.classList.remove('invisible')

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -592,7 +592,7 @@ export default class WalletsPage extends BasePage {
       this.updateAssetButton(a.id)
       Doc.bind(bttn, 'click', () => {
         this.setSelectedAsset(a.id)
-        State.store(State.SelectedAssetLK, String(a.id))
+        State.storeLocal(State.SelectedAssetLK, String(a.id))
       })
     }
     page.assetSelect.classList.remove('invisible')

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -102,7 +102,7 @@ export default class WalletsPage extends BasePage {
     Doc.cleanTemplates(
       page.iconSelectTmpl, page.balanceDetailRow, page.recentOrderTmpl
     )
-    const firstAsset = this.sortAssetButtons()
+
     Doc.bind(page.createWallet, 'click', () => this.showNewWallet(this.selectedAssetID))
     Doc.bind(page.connectBttn, 'click', () => this.doConnect(this.selectedAssetID))
     Doc.bind(page.send, 'click', () => this.showSendForm(this.selectedAssetID))
@@ -217,7 +217,12 @@ export default class WalletsPage extends BasePage {
       createwallet: (note: WalletCreationNote) => { this.handleCreateWalletNote(note) }
     })
 
-    this.setSelectedAsset(firstAsset.id)
+    const firstAsset = this.sortAssetButtons()
+    let selectedAsset = State.selectedAsset()
+    if (!selectedAsset) {
+      selectedAsset = firstAsset.id
+    }
+    this.setSelectedAsset(selectedAsset)
   }
 
   closePopups () {
@@ -567,6 +572,8 @@ export default class WalletsPage extends BasePage {
     await defaultsLoaded
   }
 
+  // sortAssetButtons displays supported assets, sorted. Returns first asset in the
+  // list.
   sortAssetButtons (): SupportedAsset {
     const page = this.page
     this.assetButtons = {}
@@ -583,7 +590,10 @@ export default class WalletsPage extends BasePage {
       const tmpl = Doc.parseTemplate(bttn)
       this.assetButtons[a.id] = { tmpl, bttn }
       this.updateAssetButton(a.id)
-      Doc.bind(bttn, 'click', () => this.setSelectedAsset(a.id))
+      Doc.bind(bttn, 'click', () => {
+        this.setSelectedAsset(a.id)
+        State.setCookie(State.SelectedAssetCK, String(a.id))
+      })
     }
     page.assetSelect.classList.remove('invisible')
     return sortedAssets[0]

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -51,8 +51,6 @@ const (
 	darkModeCK = "darkMode"
 	// authCK is the authorization token cookie key.
 	authCK = "dexauth"
-	// popupsCK is the cookie key for the user's preference for showing popups.
-	popupsCK = "popups"
 	// pwKeyCK is the cookie used to unencrypt the user's password.
 	pwKeyCK = "sessionkey"
 	// ctxKeyUserInfo is used in the authorization middleware for saving user
@@ -729,7 +727,6 @@ type userInfo struct {
 	Authed           bool
 	PasswordIsCached bool
 	DarkMode         bool
-	ShowPopups       bool
 }
 
 // Extract the userInfo from the request context. This should be used with


### PR DESCRIPTION
This PR implements saving (between page switch/refresh or `dexc` restarts) the following UI preferences a user can set:
- hide/show left market dock on `/markets` page
- select chosen wallet on `/wallets` page

Relevant UI views affected:

<img width="150" alt="image" src="https://user-images.githubusercontent.com/112318969/203921981-4d19e8e6-f6f7-4ebc-bac1-901214238c66.png"> <img width="150" alt="image" src="https://user-images.githubusercontent.com/112318969/203922123-b06362a5-fc60-40db-9f2b-b0f69e8d77ea.png">

