### PR TITLE
ui: Enter key usage on verify order view

### DIFF
--- a/client/webserver/site/src/css/forms.scss
+++ b/client/webserver/site/src/css/forms.scss
@@ -313,7 +313,7 @@ button.form-button {
 
 #changeAppPWForm,
 #dexAddrForm,
-#verifyForm,
+#verifyOrderView,
 #appPWForm,
 #deleteArchivedRecordsForm {
   width: 325px;

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -477,7 +477,7 @@ div[data-handler=markets] {
     }
   }
 
-  #verifyForm {
+  #verifyOrderView {
     .echo-data span {
       margin: 0 5px;
     }
@@ -568,7 +568,7 @@ div[data-handler=markets] {
       }
     }
 
-    #vUnlockPreorder {
+    #vUnlockPreorderForm {
       .ico-locked {
         font-size: 35px;
       }
@@ -700,7 +700,7 @@ div[data-handler=markets] {
     display: none;
   }
 
-  #vUnlockPreorder {
+  #vUnlockPreorderForm {
     .ico-locked {
       font-size: 35px;
     }

--- a/client/webserver/site/src/css/market_dark.scss
+++ b/client/webserver/site/src/css/market_dark.scss
@@ -123,7 +123,7 @@ body.dark {
       }
     }
 
-    #verifyForm {
+    #verifyOrderView {
       .header {
         &.buygreen-bg {
           background-color: #29bb7799;

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -67,11 +67,11 @@
       <label for="newWalletPass" class="form-label pt-3 ps-1 mb-1">[[[Wallet Password]]]
         <span class="ico-info" data-tooltip="[[[w_password_tooltip]]]"></span>
       </label>
-      <input type="password" class="form-control select" data-tmpl="newWalletPass" autocomplete="current-password">
+      <input type="password" class="form-control select" data-tmpl="newWalletPass" autocomplete="new-password">
     </div>
     <div class="hide-pw col-11 p-0">
       <label for="nwAppPass" class="form-label pt-3 ps-1 mb-1">[[[App Password]]]</label>
-      <input type="password" class="form-control select" id="nwAppPass" data-tmpl="appPass" autocomplete="current-password">
+      <input type="password" class="form-control select" id="nwAppPass" data-tmpl="appPass" autocomplete="new-password">
     </div>
     <span class="col-3 hide-pw"></span> {{/* flex dummy */}}
     <div class="d-grid align-items-end col-10 p-0 mt-4">

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -67,11 +67,11 @@
       <label for="newWalletPass" class="form-label pt-3 ps-1 mb-1">[[[Wallet Password]]]
         <span class="ico-info" data-tooltip="[[[w_password_tooltip]]]"></span>
       </label>
-      <input type="password" class="form-control select" data-tmpl="newWalletPass" autocomplete="off">
+      <input type="password" class="form-control select" data-tmpl="newWalletPass" autocomplete="current-password">
     </div>
     <div class="hide-pw col-11 p-0">
       <label for="nwAppPass" class="form-label pt-3 ps-1 mb-1">[[[App Password]]]</label>
-      <input type="password" class="form-control select" id="nwAppPass" data-tmpl="appPass" autocomplete="off">
+      <input type="password" class="form-control select" id="nwAppPass" data-tmpl="appPass" autocomplete="current-password">
     </div>
     <span class="col-3 hide-pw"></span> {{/* flex dummy */}}
     <div class="d-grid align-items-end col-10 p-0 mt-4">
@@ -110,7 +110,7 @@
 <div id="uwAppPassBox" class="my-3">
   <label for="uwAppPass" class="form-label ps-1">[[[App Password]]]</label>
   <div class="fs14 px-1 mb-1">[[[app_password_reminder]]]</div>
-  <input type="password" class="form-control select" id="uwAppPass" autocomplete="off">
+  <input type="password" class="form-control select" id="uwAppPass" autocomplete="current-password">
 </div>
 <div id="submitUnlockDiv" class="d-flex justify-content-end">
   <button id="submitUnlock" type="submit" class="col-8 justify-content-center fs15 bg2 selected">[[[Unlock]]]</button>
@@ -405,7 +405,7 @@
 <div class="d-flex flex-row align-items-end {{if $passwordIsCached}}justify-content-end{{end}} pb-4">
   <div class="col-12 p-0 {{if $passwordIsCached}}d-hide{{end}}">
     <label for="cancelPass" class="form-label pt-3 mb-1">[[[Password]]]</label>
-    <input type="password" class="form-control select" id="cancelPass" autocomplete="off">
+    <input type="password" class="form-control select" id="cancelPass" autocomplete="current-password">
   </div>
   <div class="col-12 py-1 {{if not $passwordIsCached}}ps-5{{end}} position-relative">
     <button id="cancelSubmit" type="button" class="w-100 fs15 bg2 selected position-relative d-inline-block">[[[Submit]]]</button>
@@ -439,7 +439,7 @@
     <div class="d-flex flex-row align-items-end {{if $passwordIsCached}}justify-content-end{{end}} pb-4">
       <div class="col-12 p-0 {{if $passwordIsCached}}d-hide{{end}}">
         <label for="acceleratePass" class="pt-3 mb-1">[[[Password]]]</label>
-        <input type="password" class="form-control select" id="acceleratePass" autocomplete="off">
+        <input type="password" class="form-control select" id="acceleratePass" autocomplete="current-password">
       </div>
       <div class="col-12 pt-2 {{if not $passwordIsCached}}px-5{{end}}">
         <button id="accelerateSubmit" type="button" class="w-100 fs15 bg2 selected">[[[Submit]]]</button>

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -472,72 +472,73 @@
     </form>
 
     {{- /* VERIFY FORM */ -}}
-      <form class="position-relative fs16 text-center d-hide" id="verifyForm" autocomplete="off">
-        <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
-        <div class="py-1 text-center fs18 position-relative header buygreen-bg" id="vHeader">
-          <span id="vBuySell"></span> <span data-unit="base"></span>
-        </div>
-        <div class="d-flex justify-content-between align-items-center py-2 fs13">
-          <span id="vOrderType" class="grey"></span>
-          <span id="vOrderHost" class="grey"></span>
-        </div>
+    <div class="position-relative fs16 text-center d-hide" id="verifyOrderView">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="py-1 text-center fs18 position-relative header buygreen-bg" id="vHeader">
+        <span id="vBuySell"></span> <span data-unit="base"></span>
+      </div>
+      <div class="d-flex justify-content-between align-items-center py-2 fs13">
+        <span id="vOrderType" class="grey"></span>
+        <span id="vOrderHost" class="grey"></span>
+      </div>
 
-        <hr class="dashed mt-0 mb-2">
+      <hr class="dashed mt-0 mb-2">
 
-        {{- /* Price, Quantity, Total Section */ -}}
-        <div id="verifyLimit">
-          <div class="d-flex align-items-center justify-content-between">
-            <span class="grey fs17 flex-grow-1 text-start">[[[:title:price]]]</span>
-            <span id="vRate" class="fs18 demi"></span>
-            <span class="grey fs14 ms-2">
-              <sup data-unit="quote"></sup>/<sub data-unit="base"></sub>
-            </span>
-          </div>
-          <div class="d-flex align-items-center mt-1">
-            <span class="grey fs17 flex-grow-1 text-start">[[[Quantity]]]</span>
-            <span id="vQty" class="fs18 demi"></span>
-            <span data-unit="base" class="grey fs14 ms-2"></span>
-          </div>
-          <div class="d-flex align-items-center mt-1">
-            <span class="grey fs17 flex-grow-1 text-start">[[[Total]]]</span>
-            <span id="vTotal" class="fs18 demi"></span>
-            <span data-unit="quote" class="grey fs14 ms-2"></span>
-          </div>
-          <span class="d-flex d-hide justify-content-end grey fs14">
-          ~<span id="vFiatTotal" class="mx-1"></span>USD
+      {{- /* Price, Quantity, Total Section */ -}}
+      <div id="verifyLimit">
+        <div class="d-flex align-items-center justify-content-between">
+          <span class="grey fs17 flex-grow-1 text-start">[[[:title:price]]]</span>
+          <span id="vRate" class="fs18 demi"></span>
+          <span class="grey fs14 ms-2">
+            <sup data-unit="quote"></sup>/<sub data-unit="base"></sub>
           </span>
         </div>
-        <div id="verifyMarket">
-          <div class="d-flex align-items-center justify-content-between">
-            <span class="grey fs17 flex-grow-1 text-start">[[[Trading]]]</span>
-            <span id="vmFromTotal" class="fs18 demi"></span>
-            <span id="vmFromAsset" class="grey fs14 ms-2"></span>
-          </div>
-          <span class="d-flex d-hide justify-content-end grey fs14">
-           ~<span id="vmFromTotalFiat" class="mx-1"></span>USD
-          </span>
-          <div id="vMarketEstimate" class="d-flex align-items-center justify-content-between">
-            <span class="grey fs17 flex-grow-1 text-start">
-              [[[Receiving Approximately]]]
-              <span class="ico-info fs12" data-tooltip="[[[verify_market]]]"></span>
-            </span>
-            <span id="vmToTotal" class="fs18 demi"></span>
-            <span id="vmToAsset" class="grey fs14 ms-2"></span>
-          </div>
-          <span class="d-flex d-hide justify-content-end grey fs14">
-           ~<span id="vmTotalFiat" class="mx-1"></span>USD
-          </span>
+        <div class="d-flex align-items-center mt-1">
+          <span class="grey fs17 flex-grow-1 text-start">[[[Quantity]]]</span>
+          <span id="vQty" class="fs18 demi"></span>
+          <span data-unit="base" class="grey fs14 ms-2"></span>
         </div>
+        <div class="d-flex align-items-center mt-1">
+          <span class="grey fs17 flex-grow-1 text-start">[[[Total]]]</span>
+          <span id="vTotal" class="fs18 demi"></span>
+          <span data-unit="quote" class="grey fs14 ms-2"></span>
+        </div>
+        <span class="d-flex d-hide justify-content-end grey fs14">
+        ~<span id="vFiatTotal" class="mx-1"></span>USD
+        </span>
+      </div>
+      <div id="verifyMarket">
+        <div class="d-flex align-items-center justify-content-between">
+          <span class="grey fs17 flex-grow-1 text-start">[[[Trading]]]</span>
+          <span id="vmFromTotal" class="fs18 demi"></span>
+          <span id="vmFromAsset" class="grey fs14 ms-2"></span>
+        </div>
+        <span class="d-flex d-hide justify-content-end grey fs14">
+         ~<span id="vmFromTotalFiat" class="mx-1"></span>USD
+        </span>
+        <div id="vMarketEstimate" class="d-flex align-items-center justify-content-between">
+          <span class="grey fs17 flex-grow-1 text-start">
+            [[[Receiving Approximately]]]
+            <span class="ico-info fs12" data-tooltip="[[[verify_market]]]"></span>
+          </span>
+          <span id="vmToTotal" class="fs18 demi"></span>
+          <span id="vmToAsset" class="grey fs14 ms-2"></span>
+        </div>
+        <span class="d-flex d-hide justify-content-end grey fs14">
+         ~<span id="vmTotalFiat" class="mx-1"></span>USD
+        </span>
+      </div>
 
-        <hr class="dashed my-2">
+      <hr class="dashed my-2">
 
-        {{- /* Auth Section */ -}}
+      {{- /* Auth Section */ -}}
+      <form id="verifyAuthForm">
         {{$passwordIsCached := .UserInfo.PasswordIsCached}}
         <div class="fs16 text-center {{if $passwordIsCached}}d-hide{{end}}">[[[auth_order_app_pw]]]</div>
         <div class="d-flex mt-3 {{if $passwordIsCached}}justify-content-end{{end}}" >
           <div class="col-12 p-0 text-start {{if $passwordIsCached}}d-hide{{end}}">
             <label for="vPass" class="form-label ps-1 mb-1">[[[Password]]]</label>
-            <input type="password" class="form-control select" id="vPass">
+            <input type="password" class="form-control select" id="vPass" autocomplete="current-password">
           </div>
           <div class="col-12 p-0 d-flex justify-content-end">
             <button id="vSubmit" type="button" class="w-75 mt-1 justify-content-center fs15 selected">
@@ -548,73 +549,75 @@
               <div class="ico-spinner spinner"></div>
             </div>
           </div>
+          <input type="submit" hidden /> <!-- To make Enter = vSubmit press -->
         </div>
-        <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="vErr"></div>{{- /* End Auth Section */ -}}
+        <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="verifyAuthFormErr"></div>{{- /* End Auth Section */ -}}
+      </form>
 
-        <div id="vPreorder">
-          <hr class="dashed mb-2 mt-3">
+      <div id="vPreorder">
+        <hr class="dashed mb-2 mt-3">
 
-          <div class="d-flex justify-content-between align-items-center">
-            <span class="grey fs18">
-              [[[Fee Projection]]]
-              <span class="ico-info fs12" data-tooltip="[[[fee_projection_tooltip]]]"></span>
-            </span>
-            <span class="grey fs14 underline pointer hoverbg" id="vFeeDetails">[[[details]]]</span>
-          </div>
+        <div class="d-flex justify-content-between align-items-center">
+          <span class="grey fs18">
+            [[[Fee Projection]]]
+            <span class="ico-info fs12" data-tooltip="[[[fee_projection_tooltip]]]"></span>
+          </span>
+          <span class="grey fs14 underline pointer hoverbg" id="vFeeDetails">[[[details]]]</span>
+        </div>
 
-          <div class="py-1 d-flex align-items-center justify-content-center fs18" id="vFeeSummary">
-            <span id="vFeeSummaryLow"></span>
-            <span class="fs15">%</span>
-            <span class="fs15 px-2">[[[to]]]</span>
-            <span id="vFeeSummaryHigh"></span>
-            <span class="fs15">%</span>
-          </div>
+        <div class="py-1 d-flex align-items-center justify-content-center fs18" id="vFeeSummary">
+          <span id="vFeeSummaryLow"></span>
+          <span class="fs15">%</span>
+          <span class="fs15 px-2">[[[to]]]</span>
+          <span id="vFeeSummaryHigh"></span>
+          <span class="fs15">%</span>
+        </div>
 
-          <hr class="dashed mb-2 mt-3">
+        <hr class="dashed mb-2 mt-3">
 
-          <div class="grey fs18 d-flex justify-content-between align-items-center">
-            [[[Options]]]
-            <span class="grey fs14 underline pointer hoverbg" id="showAdvancedOptions">
-              [[[show advanced options]]]
-            </span>
-            <span class="grey fs14 underline pointer hoverbg d-hide" id="hideAdvancedOptions">
-              [[[hide advanced options]]]
-            </span>
-          </div>
+        <div class="grey fs18 d-flex justify-content-between align-items-center">
+          [[[Options]]]
+          <span class="grey fs14 underline pointer hoverbg" id="showAdvancedOptions">
+            [[[show advanced options]]]
+          </span>
+          <span class="grey fs14 underline pointer hoverbg d-hide" id="hideAdvancedOptions">
+            [[[hide advanced options]]]
+          </span>
+        </div>
 
-          <div id="vDefaultOrderOpts">
-            {{template "orderOptionTemplates"}}
-          </div>
-          <div id="vOtherOrderOpts" class="d-hide"></div>
-        </div> {{- /* END id="vPreorder" */ -}}
+        <div id="vDefaultOrderOpts">
+          {{template "orderOptionTemplates"}}
+        </div>
+        <div id="vOtherOrderOpts" class="d-hide"></div>
+      </div> {{- /* END id="vPreorder" */ -}}
 
-        <div id="vUnlockPreorder">
-          <hr class="dashed mb-2 mt-3">
-          <div class="flex-center flex-column my-2 p-3">
-            <span class="ico-locked my-2"></span>
-            <span>[[[unlock_for_details]]]</span>
-            <div class="d-flex align-items-stretch w-100">
-              <div class="col-12 p-0 text-start">
-                <label for="vUnlockPass" class="form-label ps-1 mb-1">[[[Password]]]</label>
-                <input type="password" class="form-control select w-100" id="vUnlockPass">
-              </div>
-              <div class="col-12 p-0 d-flex align-items-end justify-content-end">
-                <button type="button" id="vUnlockSubmit" class="selected buygreen-bg">[[[Unlock]]]</button>
-              </div>
+      <form id="vUnlockPreorderForm">
+        <hr class="dashed mb-2 mt-3">
+        <div class="flex-center flex-column my-2 p-3">
+          <span class="ico-locked my-2"></span>
+          <span>[[[unlock_for_details]]]</span>
+          <div class="d-flex align-items-stretch w-100">
+            <div class="col-12 p-0 text-start">
+              <label for="vUnlockPass" class="form-label ps-1 mb-1">[[[Password]]]</label>
+              <input type="password" class="form-control select w-100" id="vUnlockPass" autocomplete="current-password">
+            </div>
+            <div class="col-12 p-0 d-flex align-items-end justify-content-end">
+              <button type="button" id="vUnlockSubmit" class="selected buygreen-bg">[[[Unlock]]]</button>
             </div>
           </div>
         </div>
-
-        <div id="vPreorderErr" class="mt-2">
-          [[[estimate_unavailable]]]
-          <span class="ico-info red fs12" id="vPreorderErrTip" data-tooltip=" "></span>
-        </div>
-
-        <hr class="dashed my-2">
-        <div class="disclaimer fs14">
-          [[[order_disclaimer]]]
-        </div>
+        <input type="submit" hidden /> <!-- To make Enter = vUnlockSubmit press -->
       </form>
+
+      <div id="vPreorderErr" class="mt-2">
+        [[[estimate_unavailable]]]
+        <span class="ico-info red fs12" id="vPreorderErrTip" data-tooltip=" "></span>
+      </div>
+
+      <hr class="dashed my-2">
+      <div class="disclaimer fs14">
+        [[[order_disclaimer]]]
+      </div>
 
       {{- /* FEE DETAIL BREAKDOWN */ -}}
       <form id="vDetailPane" class="d-hide fs16 pb-2">
@@ -678,17 +681,16 @@
 
         </div>
       </form>
-
-      {{- /* CANCEL ORDER FORM */ -}}
-      <form class="d-hide" id="cancelForm" autocomplete="off">
-        {{template "cancelOrderForm" .}}
-      </form>
-      <form class="d-hide" id="accelerateForm">
-        {{template "accelerateForm" .}}
-      </form>
     </div>
-  </div>
 
+    {{- /* CANCEL ORDER FORM */ -}}
+    <form class="d-hide" id="cancelForm" autocomplete="off">
+      {{template "cancelOrderForm" .}}
+    </form>
+    <form class="d-hide" id="accelerateForm">
+      {{template "accelerateForm" .}}
+    </form>
+  </div>
 </div>
 {{template "bottom"}}
 {{end}}

--- a/client/webserver/site/src/html/mm.tmpl
+++ b/client/webserver/site/src/html/mm.tmpl
@@ -270,7 +270,7 @@
       <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
       <div>
         <label for="pwInput" class="form-label pt-3 ps-1 mb-1">[[[App Password]]]</label>
-        <input type="password" class="form-control select" id="pwInput" autocomplete="off">
+        <input type="password" class="form-control select" id="pwInput" autocomplete="current-password">
       </div>
       <div class="text-end  mt-3">
         <button id="pwSubmit" class="selected fs16">[[[Submit]]]</button>

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -14,7 +14,7 @@
       </div>
       <div class="pb-3">
         <label for="appPWAgain" class="form-label ps-1 mb-1">[[[Password Again]]]</label>
-        <input type="password" class="form-control select" id="appPWAgain" autocomplete="current-password">
+        <input type="password" class="form-control select" id="appPWAgain" autocomplete="off">
       </div>
       <div>
         <input class="form-check-input" type="checkbox" id="rememberPass">

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -14,7 +14,7 @@
       </div>
       <div class="pb-3">
         <label for="appPWAgain" class="form-label ps-1 mb-1">[[[Password Again]]]</label>
-        <input type="password" class="form-control select" id="appPWAgain" autocomplete="off">
+        <input type="password" class="form-control select" id="appPWAgain" autocomplete="current-password">
       </div>
       <div>
         <input class="form-check-input" type="checkbox" id="rememberPass">

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -323,7 +323,7 @@
        <div class="fs16 px-4 text-center">[[[Authorize the transfer with your app password.]]]</div>
         <div class="input-group mt-2">
           <label for="vSendPw" class="form-label m-2">[[[Password]]]: </label>
-          <input type="password" class="form-control select" id="vSendPw" autocomplete="off">
+          <input type="password" class="form-control select" id="vSendPw" autocomplete="current-password">
         </div>
       <div class="d-flex justify-content-between align-items-stretch flex-wrap mt-3">
         <div class="col-12 p-0">
@@ -388,7 +388,7 @@
       <div class="d-flex mt-1 {{if $passwordIsCached}}justify-content-end{{end}}">
         <div class="col-12 p-0 {{if $passwordIsCached}}d-hide{{end}}">
           <label for="appPW" class="form-label ps-1 mb-1">[[[App Password]]]</label>
-          <input type="password" class="form-control select" id="appPW" autocomplete="off">
+          <input type="password" class="form-control select" id="appPW" autocomplete="current-password">
         </div>
         <div class="col-12 p-0 text-end">
           <div>&nbsp;</div>


### PR DESCRIPTION
When the final form for posting order (to confirm all the data) shows up after typing password and (instinctively) hitting `Enter` nothing happens, unlike with `/login` page (or when cancelling order) where it works. That's because focus doesn't change automatically to `Sell DCR` / `Buy DCR` button when `Enter` button is pressed. This PR addresses this.

Form affected:

<img width="150" alt="image" src="https://user-images.githubusercontent.com/112318969/204093034-7cbff3ae-86d0-4892-8d50-430df752d766.png">
