### PR TITLE
client: fix split option handling

### DIFF
--- a/client/core/bot.go
+++ b/client/core/bot.go
@@ -1229,7 +1229,7 @@ func (c *Core) feeEstimates(form *TradeForm) (swapFees, redeemFees uint64, err e
 		LotSize:         swapLotSize,
 		Lots:            lots,
 		MaxFeeRate:      fromAsset.MaxFeeRate,
-		Immediate:       (form.IsLimit && form.TifNow),
+		Immediate:       (form.IsLimit && form.TifNow) || !form.IsLimit,
 		FeeSuggestion:   swapFeeSuggestion,
 		SelectedOptions: form.Options,
 		RedeemVersion:   toWallet.version,

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5107,7 +5107,7 @@ func (c *Core) PreOrder(form *TradeForm) (*OrderEstimate, error) {
 		LotSize:         swapLotSize,
 		Lots:            lots,
 		MaxFeeRate:      assetConfigs.fromAsset.MaxFeeRate,
-		Immediate:       form.IsLimit && form.TifNow,
+		Immediate:       (form.IsLimit && form.TifNow) || !form.IsLimit,
 		FeeSuggestion:   swapFeeSuggestion,
 		SelectedOptions: form.Options,
 		RedeemVersion:   assetConfigs.toAsset.Version,


### PR DESCRIPTION
This fixes a bug in the asset backends' `estimateSwap` handling when trying a split transaction.

It was possible for the estimates to permit/allow a split even when it would consume more than without a split transaction. The symptom of this was that the "locked" amount estimates obtained when requesting a split could be higher than if not using a split, resulting in an integer underflow in the caller when comparing the two amounts.

Resolves https://github.com/decred/dcrdex/issues/1959

[client/asset: fix estimateSwap split rejection](https://github.com/decred/dcrdex/commit/dac81568edf388767266f0bb71de745f6c06115f)

```
The enough func in estimateSwap does not account for a split transaction
at the start, so it is possible that funding for trySplit would actually
choose more UTXOs. Actual order funding accounts for this. For this
estimate, we will just not use a split tx if the split-adjusted required
funds exceeds the total value of the UTXO selected with this enough
closure.

The fix is to reject a spit transaction if the output amount plus split tx
fees is less than the sum of the amounts of the utxos selected by fund,
rather than the total of the available utxos provided to fund initially.
There is no point to calling fund again with a different enough func
that accounts for the cost split tx because this indicates it would
reqiure an additional UTXO, thus making the spit txn wasteful.
```

--- 

This also changes how the split order option is emitted from `PreSwap` so that it is never omitted, instead given a default of false and a reason explaining why it is not effective (wasteful) for the proposed order.  This is better than the option not appearing since the UI should be consistent for a given form and wallet. (What happened to the Pre-size option?  Sometimes it's just not there.)

[client/asset: show split option when ineffectual with reason](https://github.com/decred/dcrdex/commit/c209a419269384e004d51f73de610551567823d6)

![image](https://user-images.githubusercontent.com/9373513/206342470-3faba3a1-1501-4a61-9b42-215d75c06404.png)

![image](https://user-images.githubusercontent.com/9373513/206342477-0f6f9e43-bf75-44f7-8a36-604718b89867.png)

---

Finally, this also fixes a bug in how core was obtaining `PreOrder` results for market orders with the spit option enabled.  Split transactions are supposed to be disabled/skipped for any order that is immediate (_not_ standing), which includes both market orders and limit orders with immediate time-in-force, as described by the `PreSwapForm` docs.  This fixes how `PreSwapForm.Immediate` is set by Core so that it is true for market orders as well as immediate limit orders.

[client/core: market orders are immediate (PreOrder)](https://github.com/decred/dcrdex/commit/ef0f1c57e1b42e4aa7be7e7ae0ac2b08ec3cfa79)