### PR TITLE
meterer: Do not wait for stopped timer.

### DIFF
--- a/dex/meter/meterer.go
+++ b/dex/meter/meterer.go
@@ -10,7 +10,7 @@ import (
 
 // DelayedRelay creates a simple error signal pipeline that delays and
 // aggregates the relaying of nil errors. Non-nil errors received on the in
-// channel are immediately send on the out channel without delay. If a nil error
+// channel are immediately sent on the out channel without delay. If a nil error
 // arrives within minDelay of the previous one, it will be scheduled for later
 // to respect the configured delay. If multiple arrive within minDelay, they
 // will be grouped into a single delayed signal.
@@ -54,8 +54,8 @@ func DelayedRelay(ctx context.Context, minDelay time.Duration, n int) (out <-cha
 				last = time.Now()
 
 			case <-ctx.Done():
-				if scheduled != nil && !scheduled.Stop() {
-					<-scheduled.C
+				if scheduled != nil {
+					scheduled.Stop()
 				}
 				return
 			}

--- a/server/swap/swap.go
+++ b/server/swap/swap.go
@@ -799,7 +799,7 @@ func (s *Swapper) Run(ctx context.Context) {
 						return
 					}
 					select {
-					case <-mainLoop:
+					case <-ctxHelpers.Done():
 						return
 					case blockNotes <- &blockNotification{
 						time:    time.Now().UTC(),


### PR DESCRIPTION
closes #1984

please see https://go.dev/play/p/U9d_pvnMBu6

As called out in the docs https://pkg.go.dev/time#Timer.Stop It does not close the channel. If the timer has already fired, nothing happens. The example says "assuming the program has not received from t.C already"

So anyway, we are not reusing the timer, so I don't think we need to worry about it.