### PR TITLE
spec: Update README.

### DIFF
--- a/spec/README.mediawiki
+++ b/spec/README.mediawiki
@@ -23,7 +23,8 @@ While they remove the trusted third party (TTP), they insert their own products
 as a means to capture trading fees, which replaces the TTP friction with a
 new platform friction.
 
-A more robust solution is based on atomic swap technology [https://github.com/decred/atomicswap &#91;2&#93;],
+A more robust solution is based on [https://github.com/decred/atomicswap atomic swap technology]
+[[references.mediawiki|<nowiki>[2]</nowiki>]],
 which enables trustless exchange directly between wallets.
 Until recently, few blockchains supported atomic swaps, but the past few years
 have seen widespread adoption, and such an exchange is now possible.
@@ -38,10 +39,10 @@ censorship and unfair matching difficult.
 
 While trades are fully trustless, steps are taken to discourage malicious
 clients from hindering normal trade activity.
-All clients pay a non-refundable registration fee.
+All clients must lock coins in bonds to trade.
 Registered clients are then bound to the
 [[community.mediawiki|rules of community conduct]], violation of which typically
-results in loss of trading privileges up to and including a permanent ban.
+results in loss of trading privileges.
 
 In the interest of maintaining active, open-source, community-driven
 development, this specification document describes the protocols necessary for
@@ -54,84 +55,93 @@ It is intended as a first resource when implementing servers and clients.
 Continuing client-server interoperability will likely depend on subtle aspects
 of the specification laid out in this document.
 
-'''&#91;1&#93; [[comm.mediawiki|Communication Protocols]]''' describes the
+'''<nowiki>[1]</nowiki> [[comm.mediawiki|Communication Protocols]]''' describes the
 messaging protocols and communication layer technologies that are to be used
 for the DEX API.
 
-* [[comm.mediawiki#WebSockets|WebSockets]]
-* [[comm.mediawiki/#Encoding|Data Encodings]]
-** [[comm.mediawiki/#Timestamps|Timestamps]]
-** [[comm.mediawiki/#Rate_Encoding|Rate Encoding]]
-** [[comm.mediawiki/#Coin_ID|Coin ID]]
-* [[comm.mediawiki/#Message_Protocol|Message Protocol]]
-* [[comm.mediawiki/#Session_Authentication|Session Authentication]]
-* [[comm.mediawiki/#HTTP|HTTP]]
+* [[comm.mediawiki#websockets|WebSockets]]
+* [[comm.mediawiki/#encoding|Data Encodings]]
+** [[comm.mediawiki/#timestamps|Timestamps]]
+** [[comm.mediawiki/#rate-encoding|Rate Encoding]]
+** [[comm.mediawiki/#coin-id|Coin ID]]
+* [[comm.mediawiki/#message-protocol|Message Protocol]]
+* [[comm.mediawiki/#session-authentication|Session Authentication]]
+* [[comm.mediawiki/#http|HTTP]]
 
-'''&#91;2&#93; [[fundamentals.mediawiki|Distributed Exchange Design Fundamentals]]'''
+'''<nowiki>[2]</nowiki> [[fundamentals.mediawiki|Distributed Exchange Design Fundamentals]]'''
 describes the notable design aspects that facilitate an exchange service with
 the features described above.
 
-* [[fundamentals.mediawiki/#Exchange_Variables|Exchange Variables]]
-** [[fundamentals.mediawiki/#Global_Variables|Global Variables]]
-** [[fundamentals.mediawiki/#Asset_Variables|Asset Variables]]
-** [[fundamentals.mediawiki/#Market_Variables|Market Variables]]
-** [[fundamentals.mediawiki/#Configuration_Data_Request|Configuration Data Request]]
-** [[fundamentals.mediawiki/#API_Version|API Version]]
-* [[fundamentals.mediawiki/#Epochbased_Order_Matching|Epoch-based Order Matching]]
-** [[fundamentals.mediawiki/#Epoch_Time|Epoch Time]]
-** [[fundamentals.mediawiki/#Pseudorandom_Order_Matching|Pseudorandom Order Matching]]
-* [[fundamentals.mediawiki/#Identities_based_on_Public_Key_Infrastructure_PKI_Key_Pairs|Identification]]
-* [[fundamentals.mediawiki/#Blockchain_Interaction|Blockchain Interaction]]
-* [[fundamentals.mediawiki/#Adding_New_Assets|Adding New Assets]]
+* [[fundamentals.mediawiki/#exchange-variables|Exchange Variables]]
+** [[fundamentals.mediawiki/#global-variables|Global Variables]]
+** [[fundamentals.mediawiki/#asset-variables|Asset Variables]]
+** [[fundamentals.mediawiki/#market-variables|Market Variables]]
+** [[fundamentals.mediawiki/#configuration-data-request|Configuration Data Request]]
+* [[fundamentals.mediawiki/#fees|Fees]]
+* [[fundamentals.mediawiki/#transaction-fees|Transaction Fees]]
+* [[fundamentals.mediawiki/#epochbased-order-matching|Epoch-based Order Matching]]
+** [[fundamentals.mediawiki/#epoch-time|Epoch Time]]
+** [[fundamentals.mediawiki/#pseudorandom-order-matching|Pseudorandom Order Matching]]
+* [[fundamentals.mediawiki/#identities-based-on-public-key-infrastructure-pki-key-pairs|Identification]]
+* [[fundamentals.mediawiki/#blockchain-interaction|Blockchain Interaction]]
+* [[fundamentals.mediawiki/#adding-new-assets|Adding New Assets]]
+* [[fundamentals.mediawiki/#api-version|API Version]]
+** [[fundamentals.mediawiki/#v0|v0]]
 
-'''&#91;3&#93; [[admin.mediawiki|Distributed Exchange Administration]]''' describes
+'''<nowiki>[3]</nowiki> [[admin.mediawiki|Distributed Exchange Administration]]''' describes
 the tasks required to administer the exchange.
 
-* [[admin.mediawiki/#Exchange_Variables|Exchange Variables]]
-* [[admin.mediawiki/#Perasset_Variables|Per-asset Variables]]
-* [[admin.mediawiki/#Administration_API|Administration API]]
+* [[admin.mediawiki/#exchange-variables|Exchange Variables]]
+* [[admin.mediawiki/#per-asset-variables|Per-asset Variables]]
+* [[admin.mediawiki/#administration-api|Administration API]]
 
-'''&#91;4&#93; [[accounts.mediawiki|Client Accounts]]''' details account creation.
+'''<nowiki>[4]</nowiki> [[accounts.mediawiki|Client Accounts]]''' details account creation.
 
-* [[accounts.mediawiki/#Step_1_Registration|Registration]]
-* [[accounts.mediawiki/#Step_2_Fee_Notification|Fee Notification]]
+* [[accounts.mediawiki/#step-1-registration|Registration]]
+* [[accounts.mediawiki/#step-2-fee-notification|Fee Notification]]
 
-'''&#91;5&#93; [[orders.mediawiki|Client Order Management]]''' details the different
+'''<nowiki>[5]</nowiki> [[orders.mediawiki|Client Order Management]]''' details the different
 order types and the client/server workflows required to synchronize the order
 book and place orders.
 
-* [[orders.mediawiki/#Connection_Persistence|Connection Persistence]]
-* [[orders.mediawiki/#Order_Book_Subscriptions|Order Book Subscriptions]]
-* [[orders.mediawiki/#Order_Preparation|Order Preparation]]
-** [[orders.mediawiki/#Calculating_Transaction_Fees|Calculating Transaction Fees]]
-** [[orders.mediawiki/#Coin_Preparation|Coin Preparation]]
-** [[orders.mediawiki/#Order_Commitment|Order Commitment]]
-** [[orders.mediawiki/#Order_Signing|Order Signing]]
-** [[orders.mediawiki/#Order_ID|Order ID]]
-* [[orders.mediawiki/#Order_Types|Order Types]]
-** [[orders.mediawiki/#Limit_Order|Limit Order]]
-** [[orders.mediawiki/#Market_Order|Market Order]]
-*** [[orders.mediawiki/#Market_Buy_Orders|Market Buy Orders]]
-** [[orders.mediawiki/#Cancel_Order|Cancel Order]]
-* [[orders.mediawiki/#Preimage_Reveal|Preimage Handling]]
-* [[orders.mediawiki/#Unmatched_Orders|Unmatched Orders]]
-* [[orders.mediawiki/#Match_Revocation|Match Revocation]]
-* [[orders.mediawiki/#Match_negotiation|Match Negotiation]]
-* [[orders.mediawiki/#Trade_Suspension|Trade Suspension]]
+* [[orders.mediawiki/#connection-persistence|Connection Persistence]]
+* [[orders.mediawiki/#order-book-subscriptions|Order Book Subscriptions]]
+* [[orders.mediawiki/#order-preparation|Order Preparation]]
+** [[orders.mediawiki/#calculating-transaction-fees|Calculating Transaction Fees]]
+** [[orders.mediawiki/#coin-preparation|Coin Preparation]]
+** [[orders.mediawiki/#order-commitment|Order Commitment]]
+** [[orders.mediawiki/#order-signing|Order Signing]]
+** [[orders.mediawiki/#order-id|Order ID]]
+* [[orders.mediawiki/#order-types|Order Types]]
+** [[orders.mediawiki/#limit-order|Limit Order]]
+** [[orders.mediawiki/#market-order|Market Order]]
+*** [[orders.mediawiki/#market-buy-orders|Market Buy Orders]]
+** [[orders.mediawiki/#cancel-order|Cancel Order]]
+* [[orders.mediawiki/#preimage-reveal|Preimage Handling]]
+* [[orders.mediawiki/#match-negotiation|Match Negotiation]]
+* [[orders.mediawiki/#match-revocation|Match Revocation]]
+* [[orders.mediawiki/#trade-suspension|Trade Suspension]]
 
-'''&#91;6&#93; [[api.mediawiki| Data API]]''' defines http and WebSocket APIs to browse
+'''<nowiki>[6]</nowiki> [[api.mediawiki| Data API]]''' defines http and WebSocket APIs to browse
 trade history.
 
-'''&#91;7&#93; [[atomic.mediawiki|Atomic Settlement]]''' walks through the settlement
+'''<nowiki>[7]</nowiki> [[atomic.mediawiki|Atomic Settlement]]''' walks through the settlement
 process with a couple of examples to provide a high-level overview.
 
-'''&#91;8&#93; [[community.mediawiki|Community Conduct]]''' describes the system of rules
+* [[atomic.mediawiki/#case-a-perfect-match|Perfect Match]]
+* [[atomic.mediawiki/#case-b-multi-taker-with-partial-fill|Multi-Taker with Partial Fill]]
+
+'''<nowiki>[8]</nowiki> [[community.mediawiki|Community Conduct]]''' describes the system of rules
 to which clients interacting with the DEX must adhere.
 
-* [[community.mediawiki/#Rules_of_Community_Conduct|Rules of Community Conduct]]
-* [[community.mediawiki/#Penalties|Penalties]]
-** [[community.mediawiki/#Penalization_Notification|Penalization Notification]]
-*** [[community.mediawiki/#Penalty_Object|Penalty Object]]
+* [[community.mediawiki/#rules-of-community-conduct|Rules of Community Conduct]]
+** [[community.mediawiki/#rule-1-clients-must-respond-to-all-preimage-requests|Preimage Response]]
+** [[community.mediawiki/#rule-2-every-match-must-be-fully-settled|Fully Settle]]
+** [[community.mediawiki/#rule-3-an-accounts-cancellation-rate-must-not-exceed-the-threshold|Cancellation Rate Threshold]]
+** [[community.mediawiki/#rule-4-transaction-outputs-must-be-properly-sized|Transaction Output Size]]
+* [[community.mediawiki/#penalties|Penalties]]
+** [[community.mediawiki/#penalization-notification|Penalization Notification]]
+*** [[community.mediawiki/#penalty-object|Penalty Object]]
 
-'''&#91;9&#93; [[references.mediawiki|References]]''' lists references used in the development
+'''<nowiki>[9]</nowiki> [[references.mediawiki|References]]''' lists references used in the development
 of the specification.


### PR DESCRIPTION
This only updates the readme for the current spec. Some places will still need to change like registration but hopefully that is ok as incremental changes.

Unexpectedly, none of the links with spaces scrolled. I am pretty sure that these worked before, so perhaps browser handling changed at some point? I have tested on firefox and chrome and it seems that underscores do not work, they need to be hyphens. Please confirm this behavior. Here are the changes on my branch https://github.com/JoeGruffins/dcrdex/tree/updatespecadmin/spec

Part of #1641