### PR TITLE
ui: uniform responsive checkbox

### DIFF
--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -507,3 +507,17 @@ span.token-aware-symbol sup {
     }
   }
 }
+
+.form-check-input[type=checkbox] {
+  background-color: #ebebeb;
+
+  &:checked {
+    background-color: #3095db;
+  }
+}
+
+.form-check-label {
+  &:hover {
+    font-weight: bold;
+  }
+}

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -510,10 +510,7 @@ span.token-aware-symbol sup {
 
 .form-check-input[type=checkbox] {
   background-color: #ebebeb;
-
-  &:hover {
-    cursor: pointer;
-  }
+  cursor: pointer;
 
   &:checked {
     background-color: #3095db;
@@ -521,8 +518,9 @@ span.token-aware-symbol sup {
 }
 
 .form-check-label {
+  cursor: pointer;
+
   &:hover {
     font-weight: bold;
-    cursor: pointer;
   }
 }

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -511,6 +511,10 @@ span.token-aware-symbol sup {
 .form-check-input[type=checkbox] {
   background-color: #ebebeb;
 
+  &:hover {
+    cursor: pointer;
+  }
+
   &:checked {
     background-color: #3095db;
   }
@@ -519,5 +523,6 @@ span.token-aware-symbol sup {
 .form-check-label {
   &:hover {
     font-weight: bold;
+    cursor: pointer;
   }
 }

--- a/client/webserver/site/src/css/main_dark.scss
+++ b/client/webserver/site/src/css/main_dark.scss
@@ -140,10 +140,4 @@ body.dark {
       background-color: #27278d;
     }
   }
-
-  .form-check-label {
-    &:hover {
-      font-weight: bold;
-    }
-  }
 }

--- a/client/webserver/site/src/css/main_dark.scss
+++ b/client/webserver/site/src/css/main_dark.scss
@@ -132,4 +132,18 @@ body.dark {
   #loader {
     background-color: #13202b77;
   }
+
+  .form-check-input[type=checkbox] {
+    background-color: black;
+
+    &:checked {
+      background-color: #27278d;
+    }
+  }
+
+  .form-check-label {
+    &:hover {
+      font-weight: bold;
+    }
+  }
 }

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -252,7 +252,7 @@
   <input type="password" class="form-control select" data-tmpl="pw" autocomplete="current-password">
   <div class="form-check pt-2">
     <input class="form-check-input" type="checkbox" data-tmpl="rememberPass" id="logRememberPass">
-    <label for="logRememberPass" class="form-label ps-1">[[[Remember my password]]]</label>
+    <label for="logRememberPass" class="form-check-label ps-1">[[[Remember my password]]]</label>
   </div>
 </div>
 <div class="d-flex justify-content-center mt-2">

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -18,7 +18,7 @@
       </div>
       <div>
         <input class="form-check-input" type="checkbox" id="rememberPass">
-        <label for="rememberPass" class="ps-1">[[[Remember my password]]]</label>
+        <label for="rememberPass" class="form-check-label ps-1">[[[Remember my password]]]</label>
       </div>
       <div class="pb-3 d-hide mt-3" id="seedRestore">
         <label for="seedInput" class="form-label ps-1 mb-1">[[[Restoration Seed]]]</label>

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -250,7 +250,7 @@
       <span class="mt-2 d-hide">~<span id="sendValue" class="mx-1"></span>USD</span>
       <div id="toggleSubtract" class="form-check pt-2">
           <input class="form-check-input" type="checkbox" id="subtractCheckBox">
-          <label for="subtractCheckBox" class="form-label ps-1">Subtract fees from amount sent.</label>
+          <label for="subtractCheckBox" class="form-check-label ps-1">Subtract fees from amount sent.</label>
       </div>
       <div id="maxSendDisplay" class="mt-3">
         <hr class="dashed mt-2">


### PR DESCRIPTION
Trying to improve checkbox UX a bit in this PR, namely:
- define common style for checkbox-type inputs so that it is consistent across different forms (if necessary, particular form can adjust/redefine it ofc)
- lower check-box brightness in dark-mode (it's way too bright/white compared to everything else, sticking out)
- highlight (currently just making font bold, maybe there is a better approach for this) **label** when hovering over ; this helps significantly with signalling to the user that he **can click on the text**, which is much easier than trying to pin the actual **box**; I think there is a room to improve checkboxes overall (redesign them somehow), can't suggest anything better at the moment though

Demo: 

https://user-images.githubusercontent.com/112318969/208713669-bc8f2b50-b4b0-4f44-99fb-ec64cdc2ae76.mp4

