### PR TITLE
server: allow server operators to provide custom logo

### DIFF
--- a/client/comms/tls.go
+++ b/client/comms/tls.go
@@ -1,0 +1,35 @@
+package comms
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/url"
+)
+
+// TLSConfig prepares a *tls.Config struct using the provided cert.
+func TLSConfig(URL string, cert []byte) (*tls.Config, error) {
+	if len(cert) == 0 {
+		return nil, nil
+	}
+
+	uri, err := url.Parse(URL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing URL: %w", err)
+	}
+
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	if ok := rootCAs.AppendCertsFromPEM(cert); !ok {
+		return nil, ErrInvalidCert
+	}
+
+	return &tls.Config{
+		RootCAs:    rootCAs,
+		MinVersion: tls.VersionTLS12,
+		ServerName: uri.Hostname(),
+	}, nil
+}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"net/http"
@@ -10122,11 +10123,11 @@ func (c *Core) fetchDEXLogo(host string) []byte {
 		return nil
 	}
 
-	buf := new(bytes.Buffer)
-	if _, err = buf.ReadFrom(res.Body); err != nil {
+	logoBytes, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
 		c.log.Errorf("%s: error reading response body: %v", funcName, err)
 		return nil
 	}
 
-	return buf.Bytes()
+	return logoBytes
 }

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1918,6 +1918,9 @@ func (c *TCore) AddWalletPeer(assetID uint32, address string) error {
 func (c *TCore) RemoveWalletPeer(assetID uint32, address string) error {
 	return nil
 }
+func (c *TCore) DEXLogo(host string) []byte {
+	return nil
+}
 
 var botCounter uint64
 

--- a/client/webserver/middleware.go
+++ b/client/webserver/middleware.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/order"
@@ -187,4 +188,16 @@ func getOrderIDCtx(r *http.Request) (dex.Bytes, error) {
 		return nil, fmt.Errorf("")
 	}
 	return oidB, nil
+}
+
+// CacheControl creates a new middleware to set the HTTP response header with
+// "Cache-Control: max-age=maxAge" where maxAge is in seconds.
+func CacheControl(maxAge int64) func(http.Handler) http.Handler {
+	cacheCtrl := fmt.Sprintf("max-age=%d" + strconv.FormatInt(maxAge, 10))
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Cache-Control", cacheCtrl)
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/client/webserver/site/src/html/dexsettings.tmpl
+++ b/client/webserver/site/src/html/dexsettings.tmpl
@@ -3,7 +3,10 @@
 {{$passwordIsCached := .UserInfo.PasswordIsCached}}
 <div id="main" data-handler="dexsettings" data-host="{{.Exchange.Host}}" class="text-center py-5 overflow-y-auto">
   <span class="settings-gear ico-settings"></span>
-  <div class="flex-center fs28 text-break">{{.Exchange.Host}}</div>
+  <div class="flex-center fs28 text-break">
+     <img class="mini-icon mt-1 mx-1 mb-0" src="/dexlogo/{{.Exchange.Host}}"> 
+     {{.Exchange.Host}}
+  </div>
   <div class="flex-center fs16 mb-2">
     <span class="me-2 connection ico-connection d-hide" id="connectedIcon"></span>
     <span class="me-2 errcolor ico-disconnected d-hide" id="disconnectedIcon"></span>

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -147,7 +147,7 @@
 </div>
 <div class="d-flex flex-column align-items-stretch mt-1" data-tmpl="knownXCs">
   {{range .KnownExchanges}}
-    <div class="known-exchange" data-host="{{.}}"><img class="micro-icon me-1" src={{dummyExchangeLogo .}}> {{.}}</div>
+    <div class="known-exchange" data-host="{{.}}"><img class="micro-icon me-1" src="/dexlogo/{{.}}"> {{.}}</div>
   {{end}}
 </div>
 <div class="fs14" data-tmpl="skipRegistrationBox">

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -35,7 +35,16 @@
       <div id="exchanges" {{if eq (len .UserInfo.Exchanges) 0}} class="d-hide"{{end}}>
         <h5>[[[registered dexes]]]</h5>
         {{range $host, $xc := .UserInfo.Exchanges}}
-          <a href="/dexsettings/{{$host}}"><button class="bg2 selected"><div class=text-break>{{$host}}<span class="dex-settings-icon ico-settings"></span></div></button></a>
+          <a href="/dexsettings/{{$host}}">
+            <button class="bg2 selected">
+              <div class=text-break>
+                <img class="micro-icon m-1" src="/dexlogo/{{$host}}">
+                {{$host}}
+                <span class="dex-settings-icon ico-settings">
+                </span>
+              </div>
+            </button>
+          </a>
         {{end}}
       </div>
       <br>

--- a/client/webserver/template.go
+++ b/client/webserver/template.go
@@ -194,14 +194,15 @@ var templateFuncs = template.FuncMap{
 	"x100": func(v float32) float32 {
 		return v * 100
 	},
-	"dummyExchangeLogo": func(host string) string {
-		if len(host) == 0 {
-			return "/img/coins/z.png"
-		}
-		char := host[0]
-		if char < 97 || char > 122 {
-			return "/img/coins/z.png"
-		}
-		return "/img/coins/" + string(char) + ".png"
-	},
+}
+
+func dummyLogoURL(host string) string {
+	if len(host) == 0 {
+		return "/img/coins/z.png"
+	}
+	char := host[0]
+	if char < 97 || char > 122 {
+		return "/img/coins/z.png"
+	}
+	return "/img/coins/" + string(char) + ".png"
 }

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -155,6 +155,7 @@ type clientCore interface {
 	AddWalletPeer(assetID uint32, addr string) error
 	RemoveWalletPeer(assetID uint32, addr string) error
 	Notifications(n int) ([]*db.Notification, error)
+	DEXLogo(host string) []byte
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -357,6 +358,7 @@ func New(cfg *Config) (*WebServer, error) {
 					webAuth.Get(homeRoute, s.handleHome)
 					webAuth.Get(marketsRoute, s.handleMarkets)
 					webAuth.With(dexHostCtx).Get("/dexsettings/{host}", s.handleDexSettings)
+					webAuth.With(CacheControl(86400 /* cache for a day */), dexHostCtx).Get("/dexlogo/{host}", s.handleGetDexLogo)
 					if s.experimental {
 						webAuth.Get(marketMakerRoute, s.handleMarketMaker)
 					}

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -275,7 +275,9 @@ func (c *TCore) RemoveWalletPeer(assetID uint32, address string) error {
 func (c *TCore) Notifications(n int) ([]*db.Notification, error) {
 	return c.notes, c.notesErr
 }
-
+func (c *TCore) DEXLogo(host string) []byte {
+	return nil
+}
 func (c *TCore) CreateBot(pw []byte, botType string, pgm *core.MakerProgram) (uint64, error) {
 	return 1, nil
 }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -220,6 +220,8 @@ const (
 	// CandlesRoute is the HTTP request to get the set of candlesticks
 	// representing market activity history.
 	CandlesRoute = "candles"
+	// LogoRoute is the HTTP request to fetch server's custom logo.
+	LogoRoute = "logo"
 )
 
 const errNullRespPayload = dex.ErrorKind("null response payload")

--- a/docs/wiki/Server-Admin.md
+++ b/docs/wiki/Server-Admin.md
@@ -2,6 +2,24 @@
 
 ## Exchange Settings
 
+### Logo Image
+
+Server operators can optionally provide their preferred logo image in their DEX
+config file.
+
+#### ~/.dcrdex/dcrdex.conf
+
+```ini
+logo=path/to/logo.png
+```
+
+OR via CLI using the `--logo` flag, e.g `dcrdex --logo path/to/logo.png`.
+
+ **NOTE**: If `path/to/logo.png` is not an absolute path, It will be interpreted
+as subpath of the dex data dir. Logo image should be preferably encoded as a
+`png`, `jpg`, or `jpeg` file and path to the custom logo must indicate the file
+type (e.g `.png`,`.jpg`,`.jpeg`).
+
 ### Admin HTTP JSON API
 
 See <https://github.com/decred/dcrdex/blob/6693bc57283d4cf5b451778091aa1c1b20cb9187/server/admin/server.go#L145>

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -141,6 +141,7 @@ func mainCore(ctx context.Context) error {
 	// Create the DEX manager.
 	dexConf := &dexsrv.DexConf{
 		DataDir:    cfg.DataDir,
+		Logo:       cfg.Logo,
 		LogBackend: cfg.LogMaker,
 		Markets:    markets,
 		Assets:     assets,

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -270,7 +270,7 @@ func TestMain(m *testing.M) {
 	testCtx, shutdown = context.WithCancel(context.Background())
 	defer shutdown()
 	// Register dummy handlers for the HTTP routes.
-	for _, route := range []string{msgjson.ConfigRoute, msgjson.SpotsRoute, msgjson.CandlesRoute, msgjson.OrderBookRoute} {
+	for _, route := range []string{msgjson.ConfigRoute, msgjson.SpotsRoute, msgjson.CandlesRoute, msgjson.OrderBookRoute, msgjson.LogoRoute} {
 		RegisterHTTP(route, func(interface{}) (interface{}, error) { return nil, nil })
 	}
 	UseLogger(tLogger)


### PR DESCRIPTION
This makes it possible for server operators to specify their custom logos. Closes #1256 

-- Add new server HTTP `logo` endpoint.
-- Add server custom logo to config response.

Added logo display on the `settings` and `dexsettings` pages. Will it look better if the logos had a rounded border?
<img width="221" alt="Screenshot 2022-12-20 at 5 42 35 PM" src="https://user-images.githubusercontent.com/57448127/208725598-32954932-e935-41de-a996-d67275b7d07b.png">
<img width="217" alt="Screenshot 2022-12-20 at 5 42 00 PM" src="https://user-images.githubusercontent.com/57448127/208726468-6f237ddf-61ea-4cf7-a0de-0143a3f6ab2e.png">

<img width="337" alt="Screenshot 2022-12-20 at 5 55 30 PM" src="https://user-images.githubusercontent.com/57448127/208725610-5d4585e4-c32f-421a-a5c8-5fb01d4edd2b.png">
<img width="273" alt="Screenshot 2022-12-20 at 5 42 17 PM" src="https://user-images.githubusercontent.com/57448127/208725641-45d80a08-c265-4ceb-b362-407be6664cad.png">
