### PR TITLE
client/asset/{btc,dcr}: maintain sync progress after losing peers

### DIFF
--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -536,8 +536,15 @@ func (w *spvWallet) syncStatus() (*syncStatus, error) {
 	if err != nil {
 		return nil, err
 	}
-	target := w.syncHeight()
+
 	currentHeight := chainBlk.Height
+
+	var target int32
+	if len(w.cl.Peers()) > 0 {
+		target = w.syncHeight()
+	} else { // use cached value if available
+		target = atomic.LoadInt32(&w.syncTarget)
+	}
 
 	var synced bool
 	var blk *block


### PR DESCRIPTION
Resolves #2006.

Sync target height becomes 0 (for btc) or the same as the wallet tip (for dcr) when the correct value cannot be inferred from connected peers when the connection to all peers is lost.

Fix: cache sync target height so the cached value is used when calculating sync progress even when there are no peers connected.