### PR TITLE
client/asset/dcr: refund method recognizes spends in refunds

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -3073,15 +3073,11 @@ func (dcr *ExchangeWallet) refundTx(coinID, contract dex.Bytes, val uint64, refu
 
 		switch spent {
 		case 0: // unspent, proceed to create refund tx
-		case 1: // spent!
-			// Refund MUST signal to caller that it is spent via
-			// asset.CoinNotFoundError so that it knows to begin looking for the
-			// counterparty's redeem and move on to redeem too. TODO: attempt to
-			// identify if it was manually refunded with the backup transaction,
-			// in which case we can skip broadcast and record the spending
-			// transaction we may locate as below.
-			return nil, fmt.Errorf("contract %s:%d is spent (%w)", txHash, vout, asset.CoinNotFoundError)
-		case -1: // unknown, we must scan for spending tx
+		case 1, -1: // spent or unknown
+			// Attempt to identify if it was manually refunded with the backup
+			// transaction, in which case we can skip broadcast and record the
+			// spending transaction we may locate as below.
+
 			// First find the block containing the output itself.
 			scriptAddr, err := stdaddr.NewAddressScriptHashV0(contract, dcr.chainParams)
 			if err != nil {
@@ -3093,12 +3089,19 @@ func (dcr *ExchangeWallet) refundTx(coinID, contract dex.Bytes, val uint64, refu
 			if err != nil {
 				return nil, err // possibly the contract is still in mempool
 			}
+			// Try to find a transaction that spends it.
 			spent, err := dcr.isOutputSpent(dcr.ctx, outFound) // => findTxOutSpender
 			if err != nil {
 				return nil, fmt.Errorf("error checking if contract %v:%d is spent: %w", txHash, vout, err)
 			}
 			if spent {
-				return nil, fmt.Errorf("contract %s:%d is spent (%w)", txHash, vout, asset.CoinNotFoundError)
+				spendTx := outFound.spenderTx
+				// Refunds are not batched, so input 0 is always the spender.
+				if dexdcr.IsRefundScript(utxo.Version, spendTx.TxIn[0].SignatureScript, contract) {
+					return spendTx, nil
+				} // otherwise it must be a redeem
+				return nil, fmt.Errorf("contract %s:%d is spent in %v (%w)",
+					txHash, vout, spendTx.TxHash(), asset.CoinNotFoundError)
 			}
 		}
 	}

--- a/dex/networks/dcr/script_test.go
+++ b/dex/networks/dcr/script_test.go
@@ -627,3 +627,43 @@ func TestDataPrefixSize(t *testing.T) {
 		})
 	}
 }
+
+func hexBytes(h string) []byte {
+	b, err := hex.DecodeString(h)
+	if err != nil {
+		panic(err.Error())
+	}
+	return b
+}
+
+func TestIsRefundScript(t *testing.T) {
+	tests := []struct {
+		name          string
+		scriptVersion uint16
+		sigScript     []byte
+		contract      []byte
+		want          bool
+	}{
+		{
+			"redeem",
+			0,
+			hexBytes("47304402203cf1e969830a6255d02e40a9333b502d802f0c17331e54dc5d8028fb6a3bd54c02202cfc3673c8013416e38dd27d3c96082a4f069cf296ca2bbba7d039308df1bdc401210227b951b91a01e11600cdd1d3e9f2894e2e38567b6883b9b3e7a4f99946a3d445209a5a58c653c2c384825bc4217443a2b3e3dead04db5e0586570c774706d97a0d514c616382012088c020c66b3b91cffadc613689cf9c391c7792307e5d5390407ad3e33b6ff0bf4a95218876a91425e5d9b138e16fa526bc765a721193da79fc5c32670420489d63b17576a9147f1686f0a6f1b0afd5b9efaee37d234b417ca2ee6888ac"),
+			hexBytes("6382012088c020c66b3b91cffadc613689cf9c391c7792307e5d5390407ad3e33b6ff0bf4a95218876a91425e5d9b138e16fa526bc765a721193da79fc5c32670420489d63b17576a9147f1686f0a6f1b0afd5b9efaee37d234b417ca2ee6888ac"),
+			false,
+		},
+		{
+			"refund",
+			0,
+			hexBytes("473044022063793a405b3c60a37180d009f191bf68a8ce0560093718612220b019596ebd9602201f9028644d45744279f5676db18ba3621760eb33d18d6ba74909a2e98393e40c012102bc03f292e7ec067c10cdcbc22eb9dc49b2693a1b7dd7c3b4c4d9a0bf054f3f2d004c616382012088c020eec3b3ffb1bf921701653437600eba8a8fc95dd5bbefa65e977b3d91db9ca6248876a9145ca2a115488f1b264591a014734d33443bbfa379670410bf3563b17576a914462748b29df61bd1fedd7dc1a953392aa2c05d996888ac"),
+			hexBytes("6382012088c020eec3b3ffb1bf921701653437600eba8a8fc95dd5bbefa65e977b3d91db9ca6248876a9145ca2a115488f1b264591a014734d33443bbfa379670410bf3563b17576a914462748b29df61bd1fedd7dc1a953392aa2c05d996888ac"),
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if is := IsRefundScript(tt.scriptVersion, tt.sigScript, tt.contract); is != tt.want {
+				t.Errorf("want %v, got %v", tt.want, is)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/2009

The first commit fixes a bug whereby "unknown" spend status causes the DCR backend to attempt to refund even if it was already spent in certain undetectable situations.  Normally not an issue since for taker the maker redemption search would have been running prior to locktime expiry that triggers the refund attempt.

The second commit adds the ability to recognize when a located spending transaction is a refund, in which case that transaction is returned without authoring a new one.

In draft because it may be necessary to skip the broadcast step if the refund transaction was locate in this manner.