### PR TITLE
client/asset: use compatible wallet dir and rework moveWalletData

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -127,9 +127,9 @@ func (d *Driver) Exists(walletType, dataDir string, settings map[string]string, 
 	if err != nil {
 		return false, err
 	}
-	netDir := filepath.Join(dataDir, chainParams.Name, "spv")
+	walletDir := filepath.Join(dataDir, chainParams.Name)
 	// recoverWindow argument borrowed from bchwallet directly.
-	loader := wallet.NewLoader(chainParams, netDir, true, 250)
+	loader := wallet.NewLoader(chainParams, walletDir, true, 250)
 	return loader.WalletExists()
 }
 
@@ -161,7 +161,8 @@ func (d *Driver) Create(params *asset.CreateWalletParams) error {
 		return err
 	}
 
-	return createSPVWallet(params.Pass, params.Seed, walletCfg.AdjustedBirthday(), params.DataDir,
+	walletDir := filepath.Join(params.DataDir, chainParams.Name)
+	return createSPVWallet(params.Pass, params.Seed, walletCfg.AdjustedBirthday(), walletDir,
 		params.Logger, recoveryCfg.NumExternalAddresses, recoveryCfg.NumInternalAddresses, chainParams)
 }
 

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -660,7 +660,7 @@ func (d *Driver) Exists(walletType, dataDir string, settings map[string]string, 
 	if err != nil {
 		return false, err
 	}
-	dir := filepath.Join(dataDir, chainParams.Name, "spv")
+	dir := filepath.Join(dataDir, chainParams.Name)
 	// timeout and recoverWindow arguments borrowed from btcwallet directly.
 	loader := wallet.NewLoader(chainParams, dir, true, dbTimeout, 250)
 	return loader.WalletExists()
@@ -699,7 +699,8 @@ func (d *Driver) Create(params *asset.CreateWalletParams) error {
 		return err
 	}
 
-	return createSPVWallet(params.Pass, params.Seed, cfg.AdjustedBirthday(), params.DataDir,
+	dir := filepath.Join(params.DataDir, chainParams.Name)
+	return createSPVWallet(params.Pass, params.Seed, cfg.AdjustedBirthday(), dir,
 		params.Logger, cfg.NumExternalAddresses, cfg.NumInternalAddresses, chainParams)
 }
 
@@ -1243,7 +1244,7 @@ func OpenSPVWallet(cfg *BTCCloneCFG, walletConstructor BTCWalletConstructor) (*E
 		cfg:         walletCfg,
 		acctNum:     defaultAcctNum,
 		acctName:    defaultAcctName,
-		dir:         filepath.Join(cfg.WalletCFG.DataDir, cfg.ChainParams.Name, "spv"),
+		dir:         filepath.Join(cfg.WalletCFG.DataDir, cfg.ChainParams.Name),
 		txBlocks:    make(map[chainhash.Hash]*hashEntry),
 		checkpoints: make(map[outPoint]*scanCheckpoint),
 		log:         cfg.Logger.SubLogger("SPV"),

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -50,7 +51,6 @@ import (
 	"github.com/btcsuite/btcwallet/walletdb"
 	_ "github.com/btcsuite/btcwallet/walletdb/bdb" // bdb init() registers a driver
 	"github.com/btcsuite/btcwallet/wtxmgr"
-	"github.com/jrick/logrotate/rotator"
 	"github.com/lightninglabs/neutrino"
 	"github.com/lightninglabs/neutrino/headerfs"
 )
@@ -72,8 +72,7 @@ const (
 
 	maxFutureBlockTime = 2 * time.Hour // see MaxTimeOffsetSeconds in btcd/blockchain/validate.go
 	neutrinoDBName     = "neutrino.db"
-	spvDir             = "spv"
-	logDirName         = "spvlogs"
+	logDirName         = "logs"
 	logFileName        = "neutrino.log"
 	defaultAcctNum     = 0
 	defaultAcctName    = "default"
@@ -198,23 +197,6 @@ func extendAddresses(extIdx, intIdx uint32, btcw *wallet.Wallet) error {
 	})
 }
 
-var (
-	// loggingInited will be set when the log rotator has been initialized.
-	loggingInited uint32
-)
-
-// logRotator initializes a rotating file logger.
-func logRotator(dir string) (*rotator.Rotator, error) {
-	const maxLogRolls = 8
-	logDir := filepath.Join(dir, logDirName)
-	if err := os.MkdirAll(logDir, 0744); err != nil {
-		return nil, fmt.Errorf("error creating log directory: %w", err)
-	}
-
-	logFilename := filepath.Join(logDir, logFileName)
-	return rotator.New(logFilename, 32*1024, false, maxLogRolls)
-}
-
 // spendingInput is added to a filterScanResult if a spending input is found.
 type spendingInput struct {
 	txHash      chainhash.Hash
@@ -251,16 +233,6 @@ type hashEntry struct {
 type scanCheckpoint struct {
 	res        *filterScanResult
 	lastAccess time.Time
-}
-
-// logWriter implements an io.Writer that outputs to a rotating log file.
-type logWriter struct {
-	*rotator.Rotator
-}
-
-// Write writes the data in p to the log file.
-func (w logWriter) Write(p []byte) (n int, err error) {
-	return w.Rotator.Write(p)
 }
 
 // spvWallet is an in-process btcwallet.Wallet + neutrino light-filter-based
@@ -1084,7 +1056,7 @@ func (w *spvWallet) getBestBlockHeader() (*blockHeader, error) {
 }
 
 func (w *spvWallet) logFilePath() string {
-	return filepath.Join(filepath.Dir(w.dir), logDirName, logFileName)
+	return filepath.Join(w.dir, logDirName, logFileName)
 }
 
 // connect will start the wallet and begin syncing.
@@ -1148,28 +1120,47 @@ func (w *spvWallet) connect(ctx context.Context, wg *sync.WaitGroup) (err error)
 	return nil
 }
 
-// moveWalletData will move all wallet files to a backup directory.
+// moveWalletData will move all wallet files to a backup directory, but leaving
+// the logs folder.
 func (w *spvWallet) moveWalletData(backupDir string) error {
 	timeString := time.Now().Format("2006-01-02T15:04:05")
-	err := os.MkdirAll(backupDir, 0744)
+	backupFolder := filepath.Join(backupDir, w.chainParams.Name, timeString)
+	err := os.MkdirAll(backupFolder, 0744)
 	if err != nil {
 		return err
 	}
 
-	backupFolder := filepath.Join(backupDir, w.chainParams.Name, timeString)
-	// Copy wallet logs first. Even if there is an error, wallet files are
-	// still intact.
+	// Copy wallet logs folder since we do not move it.
 	backupLogDir := filepath.Join(backupFolder, logDirName)
-	walletLogDir := filepath.Dir(w.logFilePath())
+	walletLogDir := filepath.Join(w.dir, logDirName)
 	if err := copyDir(walletLogDir, backupLogDir); err != nil {
 		return err
 	}
 
-	walletBackupDir := filepath.Join(backupFolder, spvDir)
-	if err := os.Rename(w.dir, walletBackupDir); err != nil {
-		return err
-	}
-	return nil
+	// Move contents of the wallet dir, except the logs folder.
+	return filepath.WalkDir(w.dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == w.dir { // top
+			return nil
+		}
+		if d.IsDir() && d.Name() == logDirName {
+			return filepath.SkipDir
+		}
+		rel, err := filepath.Rel(w.dir, path)
+		if err != nil {
+			return err
+		}
+		err = os.Rename(path, filepath.Join(backupFolder, rel))
+		if err != nil {
+			return err
+		}
+		if d.IsDir() { // we just moved a folder, including the contents
+			return filepath.SkipDir
+		}
+		return nil
+	})
 }
 
 // copyFile copies a file from src to dst.

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -120,8 +120,8 @@ func (d *Driver) Exists(walletType, dataDir string, settings map[string]string, 
 	if err != nil {
 		return false, err
 	}
-	netDir := filepath.Join(dataDir, chainParams.Name, "spv")
-	loader := wallet.NewLoader(chainParams, netDir, true, dbTimeout, 250)
+	walletDir := filepath.Join(dataDir, chainParams.Name)
+	loader := wallet.NewLoader(chainParams, walletDir, true, dbTimeout, 250)
 	return loader.WalletExists()
 }
 
@@ -153,7 +153,8 @@ func (d *Driver) Create(params *asset.CreateWalletParams) error {
 		return err
 	}
 
-	return createSPVWallet(params.Pass, params.Seed, walletCfg.AdjustedBirthday(), params.DataDir,
+	walletDir := filepath.Join(params.DataDir, chainParams.Name)
+	return createSPVWallet(params.Pass, params.Seed, walletCfg.AdjustedBirthday(), walletDir,
 		params.Logger, recoveryCfg.NumExternalAddresses, recoveryCfg.NumInternalAddresses, chainParams)
 }
 

--- a/client/asset/ltc/spv.go
+++ b/client/asset/ltc/spv.go
@@ -53,7 +53,7 @@ import (
 
 const (
 	DefaultM       uint64 = 784931 // From ltcutil. Used for gcs filters.
-	logDirName            = "spvlogs"
+	logDirName            = "logs"
 	neutrinoDBName        = "neutrino.db"
 	defaultAcctNum        = 0
 	dbTimeout             = 20 * time.Second
@@ -120,11 +120,8 @@ func openSPVWallet(dir string, cfg *btc.WalletConfig, btcParams *chaincfg.Params
 }
 
 // createSPVWallet creates a new SPV wallet.
-func createSPVWallet(privPass []byte, seed []byte, bday time.Time, dbDir string, log dex.Logger, extIdx, intIdx uint32, net *ltcchaincfg.Params) error {
-	netDir := filepath.Join(dbDir, net.Name)
-	walletDir := filepath.Join(netDir, "spv")
-
-	if err := logNeutrino(netDir, log); err != nil {
+func createSPVWallet(privPass []byte, seed []byte, bday time.Time, walletDir string, log dex.Logger, extIdx, intIdx uint32, net *ltcchaincfg.Params) error {
+	if err := logNeutrino(walletDir, log); err != nil {
 		return fmt.Errorf("error initializing dcrwallet+neutrino logging: %w", err)
 	}
 
@@ -183,8 +180,7 @@ func (w *ltcSPVWallet) walletParams() *ltcchaincfg.Params {
 // Start initializes the *ltcwallet.Wallet and its supporting players and starts
 // syncing.
 func (w *ltcSPVWallet) Start() (btc.SPVService, error) {
-	netDir := filepath.Dir(w.dir)
-	if err := logNeutrino(netDir, w.log); err != nil {
+	if err := logNeutrino(w.dir, w.log); err != nil {
 		return nil, fmt.Errorf("error initializing dcrwallet+neutrino logging: %v", err)
 	}
 	// recoverWindow arguments borrowed from ltcwallet directly.
@@ -986,9 +982,9 @@ var (
 )
 
 // logRotator initializes a rotating file logger.
-func logRotator(netDir string) (*rotator.Rotator, error) {
+func logRotator(walletDir string) (*rotator.Rotator, error) {
 	const maxLogRolls = 8
-	logDir := filepath.Join(netDir, logDirName)
+	logDir := filepath.Join(walletDir, logDirName)
 	if err := os.MkdirAll(logDir, 0744); err != nil {
 		return nil, fmt.Errorf("error creating log directory: %w", err)
 	}
@@ -1005,12 +1001,12 @@ func logRotator(netDir string) (*rotator.Rotator, error) {
 // there are concurrency issues with that since btcd and btcwallet have
 // unsupervised goroutines still running after shutdown. So we leave the rotator
 // running at the risk of losing some logs.
-func logNeutrino(netDir string, errorLogger dex.Logger) error {
+func logNeutrino(walletDir string, errorLogger dex.Logger) error {
 	if !atomic.CompareAndSwapUint32(&loggingInited, 0, 1) {
 		return nil
 	}
 
-	logSpinner, err := logRotator(netDir)
+	logSpinner, err := logRotator(walletDir)
 	if err != nil {
 		return fmt.Errorf("error initializing log rotator: %w", err)
 	}


### PR DESCRIPTION
This reverts the BTC SPV wallet data directory so that there is no trailing `"spv"` folder.  This allows existing native BTC wallets created with 0.5 to be usable with 0.6, otherwise 0.6/master does not find them.

This also reworks how the wallet backups are done so that all files in the native wallet directory are moved one at a time, skipping the "logs" folder so that the log rotator used by the package-level loggers is not interrupted.  There is no longer an `"spvlogs"` folder; it is back to the `"logs"` folder adjacent to the other neutrino and wallet db files.