### PR TITLE
core: reestablish old dex connection if new one is unsuccessful

### DIFF
--- a/client/core/account_test.go
+++ b/client/core/account_test.go
@@ -307,9 +307,7 @@ func TestUpdateDEXHost(t *testing.T) {
 		rig.db.acct.LegacyFeeCoin = encode.RandomBytes(32)
 		rig.db.acct.Host = tDexHost
 
-		tCore.connMtx.Lock()
-		tCore.conns[rig.acct.host] = rig.dc
-		tCore.connMtx.Unlock()
+		tCore.addDexConnection(rig.dc)
 
 		rig.dc.pendingFee = nil
 		if test.feePending {

--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -860,9 +860,7 @@ func (c *Core) PostBond(form *PostBondForm) (*PostBondResult, error) {
 		if paid {
 			success = true
 			// The listen goroutine is already running, now track the conn.
-			c.connMtx.Lock()
-			c.conns[dc.acct.host] = dc
-			c.connMtx.Unlock()
+			c.addDexConnection(dc)
 			return &PostBondResult{ /* no new bond */ }, nil
 		}
 	}
@@ -997,9 +995,7 @@ func (c *Core) makeAndPostBond(dc *dexConnection, acctExists bool, wallet *xcWal
 	dc.acct.authMtx.Unlock()
 
 	if !acctExists { // *after* setting pendingBonds for rotateBonds accounting if targetTier>0
-		c.connMtx.Lock()
-		c.conns[dc.acct.host] = dc
-		c.connMtx.Unlock()
+		c.addDexConnection(dc)
 		// NOTE: it's still not authed if this was the first bond
 	}
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2066,9 +2066,7 @@ func TestRegister(t *testing.T) {
 	form.Addr = tDexHost
 
 	// account already exists
-	tCore.connMtx.Lock()
-	tCore.conns[tDexHost] = dc
-	tCore.connMtx.Unlock()
+	tCore.addDexConnection(dc)
 	_, err = tCore.Register(form)
 	if !errorHasCode(err, dupeDEXErr) {
 		t.Fatalf("wrong account exists error: %v", err)


### PR DESCRIPTION
Issue:
Updating a dex cert to an invalid causes `core` to run a continuous retry using the bad cert (until dex is restarted). The old connection was disconnected and replaced even though the new connection failed.

Fix:
 This fix allows `core.UpdateCert` to specify that failed connection(while updating a dex's cert) should not replace the previous connection.

-- Modified `core.connectAccount` to accept an `addFailedConn bool` value which is used to control behaviour concerning saving a failed connection to the conns map. 

I should have opened an issue first but I think it was better to deal with it. 