### PR TITLE
server: notify clients with unstable websocket connection

### DIFF
--- a/client/websocket/websocket.go
+++ b/client/websocket/websocket.go
@@ -172,7 +172,7 @@ func (s *Server) connect(ctx context.Context, conn ws.Connection, addr string) {
 	s.log.Tracef("Disconnected websocket client %s", addr)
 }
 
-// Notify sends a notification to the websocket client.
+// Notify sends a notification to the websocket clients.
 func (s *Server) Notify(route string, payload interface{}) {
 	msg, err := msgjson.NewNotification(route, payload)
 	if err != nil {

--- a/server/comms/comms_test.go
+++ b/server/comms/comms_test.go
@@ -33,11 +33,12 @@ var (
 
 func newServer() *Server {
 	return &Server{
-		clients:     make(map[uint64]*wsLink),
-		wsLimiters:  make(map[dex.IPKey]*ipWsLimiter),
-		v6Prefixes:  make(map[dex.IPKey]int),
-		quarantine:  make(map[dex.IPKey]time.Time),
-		dataEnabled: 1,
+		clients:          make(map[uint64]*wsLink),
+		wsLimiters:       make(map[dex.IPKey]*ipWsLimiter),
+		v6Prefixes:       make(map[dex.IPKey]int),
+		quarantine:       make(map[dex.IPKey]time.Time),
+		wsAnomalyCounter: make(map[dex.IPKey]*anomalyCount),
+		dataEnabled:      1,
 	}
 }
 
@@ -92,6 +93,8 @@ type wsConnStub struct {
 }
 
 func (conn *wsConnStub) addChan() {
+	conn.writeMtx.Lock()
+	defer conn.writeMtx.Unlock()
 	conn.recv = make(chan []byte)
 }
 


### PR DESCRIPTION
This enables a DEX server to track and notify websocket clients with unstable connection i.e frequent disconnects/timeouts every ping interval. Closes #778 

Websocket clients with more than 3 disconnects within a one hour period since last connect will receive a message from the DEX server.