### PR TITLE
orderbook: Move atomic fields to top of struct.

### DIFF
--- a/client/orderbook/orderbook.go
+++ b/client/orderbook/orderbook.go
@@ -69,6 +69,13 @@ type MatchSummary struct {
 
 // OrderBook represents a client tracked order book.
 type OrderBook struct {
+	// feeRates is at the top to account for atomic field alignment in
+	// 32-bit systems. See also https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	feeRates struct {
+		base  uint64
+		quote uint64
+	}
+
 	log      dex.Logger
 	seqMtx   sync.Mutex
 	seq      uint64
@@ -94,13 +101,6 @@ type OrderBook struct {
 
 	matchSummaryMtx sync.Mutex
 	matchesSummary  []*MatchSummary
-
-	// feeRates is a separate struct to account for atomic field alignment in
-	// 32-bit systems. See also https://golang.org/pkg/sync/atomic/#pkg-note-BUG
-	feeRates struct {
-		base  uint64
-		quote uint64
-	}
 }
 
 // NewOrderBook creates a new order book.


### PR DESCRIPTION
closes #2029

Tested on a 32bit arm OS.