### PR TITLE
eth: Always check header time.

### DIFF
--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -577,7 +577,7 @@ func (eth *baseBackend) Synced() (bool, error) {
 		return false, err
 	}
 	// Time in the header is in seconds.
-	nowInSecs := time.Now().Unix() / 1000
+	nowInSecs := time.Now().Unix()
 	timeDiff := nowInSecs - int64(bh.Time)
 	return timeDiff < dexeth.MaxBlockInterval, nil
 }

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -368,7 +368,7 @@ func TestSynced(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		nowInSecs := uint64(time.Now().Unix() / 1000)
+		nowInSecs := uint64(time.Now().Unix())
 		eth, node := tNewBackend(BipID)
 		node.syncProg = test.syncProg
 		node.syncProgErr = test.syncProgErr


### PR DESCRIPTION
Post merge geth will report both the current and highest block as the same number. Check the header time even when we would have been synced before the merge.

closes #2017