### PR TITLE
ui: add expected refund time to match-card

### DIFF
--- a/client/db/types.go
+++ b/client/db/types.go
@@ -491,12 +491,12 @@ func (m *MetaMatch) MatchOrderUniqueID() []byte {
 
 // MatchIsActive returns false (i.e. the match is inactive) if any: (1) status
 // is MatchConfirmed OR InitSig unset, signaling a cancel order match, which is
-// never active), (2) the match is refunded, or (3) it is revoked and this side
+// never active, (2) the match is refunded, or (3) it is revoked and this side
 // of the match requires no further action like refund or auto-redeem.
 func MatchIsActive(match *order.UserMatch, proof *MatchProof) bool {
 	// MatchComplete only means inactive if: (a) cancel order match or (b) the
 	// redeem request was accepted for trade orders. A cancel order match starts
-	// complete and has no InitSig as their is no swap negotiation.
+	// complete and has no InitSig as there is no swap negotiation.
 	// Unfortunately, an empty Address is not sufficient since taker cancel
 	// matches included the makers Address.
 	if match.Status == order.MatchConfirmed {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=LESXCTh9e" rel="stylesheet">
+  <link href="/css/style.css?v=JDSD183gH" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=HXDiJys"></script>
+<script src="/js/entry.js?v=JDSD183gH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -148,7 +148,7 @@
           </div>
 
           <div class="pt-3">
-            <div class="px-3 pb-3" data-tmpl="makerSwap">
+            <div class="px-3 pb-3 d-hide" data-tmpl="makerSwap">
               <div class="d-inline-block">
                 <div class="d-flex align-items-center justify-content-between">
                   <span class="match-data-label">1. [[[Maker Swap]]] (<span data-tmpl="makerSwapAsset"></span>, <span data-tmpl="makerSwapYou">[[[you]]]</span><span data-tmpl="makerSwapThem">[[[them]]]</span>)</span>
@@ -158,7 +158,7 @@
                 <a target="_blank" class="mono plainlink" data-tmpl="makerSwapCoin"></a>
               </div>
             </div>
-            <div class="px-3 pb-3" data-tmpl="takerSwap">
+            <div class="px-3 pb-3 d-hide" data-tmpl="takerSwap">
               <div class="d-inline-block">
                 <div class="d-flex align-items-center justify-content-between">
                   <span class="match-data-label">2. [[[Taker Swap]]] (<span data-tmpl="takerSwapAsset"></span>, <span data-tmpl="takerSwapYou">[[[you]]]</span><span data-tmpl="takerSwapThem">[[[them]]]</span>)</span>
@@ -168,7 +168,7 @@
                 <a target="_blank" class="mono plainlink" data-tmpl="takerSwapCoin"></a>
               </div>
             </div>
-            <div class="px-3 pb-3" data-tmpl="makerRedeem">
+            <div class="px-3 pb-3 d-hide" data-tmpl="makerRedeem">
               <div class="d-inline-block">
                 <div class="d-flex align-items-center justify-content-between">
                   <span class="match-data-label">3. [[[Maker Redemption]]] (<span data-tmpl="makerRedeemAsset"></span>, <span data-tmpl="makerRedeemYou">[[[you]]]</span><span data-tmpl="makerRedeemThem">[[[them]]]</span>)</span>
@@ -178,7 +178,7 @@
                 <a target="_blank" class="mono plainlink" data-tmpl="makerRedeemCoin"></a>
               </div>
             </div>
-            <div class="px-3 pb-3" data-tmpl="takerRedeem">
+            <div class="px-3 pb-3 d-hide" data-tmpl="takerRedeem">
               <div class="d-inline-block">
                 <div class="d-flex align-items-center justify-content-between">
                   <span class="match-data-label">4. [[[Taker Redemption]]] (<span data-tmpl="takerRedeemAsset"></span>, <span data-tmpl="takerRedeemYou">[[[you]]]</span><span data-tmpl="takerRedeemThem">[[[them]]]</span>)</span>
@@ -188,14 +188,14 @@
                 <a target="_blank" class="mono plainlink" data-tmpl="takerRedeemCoin"></a>
               </div>
             </div>
-            <div class="px-3 pb-3" data-tmpl="refund">
+            <div class="px-3 pb-3 d-hide" data-tmpl="refund">
               <span class="match-data-label red">[[[Refund]]] (<span data-tmpl="refundAsset"></span>, [[[you]]])</span><br>
-              <span data-tmpl="refundPending">&lt;[[[Pending]]]&gt;</span>
-                <a target="_blank" class="mono plainlink" data-tmpl="refundCoin"></a>
+              <span data-tmpl="refundPending"></span>
+              <a target="_blank" class="mono plainlink" data-tmpl="refundCoin"></a>
             </div>
           </div>
         </div>
-      </div>    
+      </div>
     </div>
 
     {{- /* FUNDING COINS */ -}}

--- a/client/webserver/site/src/js/locales.ts
+++ b/client/webserver/site/src/js/locales.ts
@@ -109,6 +109,8 @@ export const ID_SELECT_WALLET_FOR_FEE_PAYMENT = 'SELECT_WALLET_FOR_FEE_PAYMENT'
 export const ID_UNAVAILABLE = 'UNAVAILABLE'
 export const ID_WALLET_SYNC_FINISHING_UP = 'WALLET_SYNC_FINISHING_UP'
 export const ID_CONNECT_WALLET_ERR_MSG = 'CONNECTING_WALLET_ERR_MSG'
+export const ID_REFUND_IMMINENT = 'REFUND_IMMINENT'
+export const ID_REFUND_WILL_HAPPEN_AFTER = 'REFUND_WILL_HAPPEN_AFTER'
 
 export const enUS: Locale = {
   [ID_NO_PASS_ERROR_MSG]: 'password cannot be empty',
@@ -219,7 +221,10 @@ export const enUS: Locale = {
   [ID_EMPTY_DEX_ADDRESS_MSG]: 'DEX address cannot be empty',
   [ID_SELECT_WALLET_FOR_FEE_PAYMENT]: 'Select a valid wallet to post a bond',
   [ID_WALLET_SYNC_FINISHING_UP]: 'finishing up',
-  [ID_CONNECT_WALLET_ERR_MSG]: 'Failed to connect {{ assetName }} wallet: {{ errMsg }}'
+  [ID_CONNECT_WALLET_ERR_MSG]: 'Failed to connect {{ assetName }} wallet: {{ errMsg }}',
+  [ID_TAKER_FOUND_MAKER_REDEMPTION]: 'Redeemed by {{ makerAddr }}',
+  [ID_REFUND_IMMINENT]: 'Will happen in the next few blocks',
+  [ID_REFUND_WILL_HAPPEN_AFTER]: 'Refund will happen after {{ refundAfterTime }}'
 }
 
 export const ptBR: Locale = {

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -19,6 +19,11 @@ const Mainnet = 0
 const Testnet = 1
 // const Regtest = 3
 
+// lockTimeMakerMs must match the value returned from LockTimeMaker func in dexc.
+const lockTimeMakerMs = 20 * 60 * 60 * 1000
+// lockTimeTakerMs must match the value returned from LockTimeTaker func in dexc.
+const lockTimeTakerMs = 8 * 60 * 60 * 1000
+
 const coinIDTakerFoundMakerRedemption = 'TakerFoundMakerRedemption:'
 
 const animationLength = 500
@@ -155,7 +160,7 @@ export default class OrderPage extends BasePage {
     tmpl.matchID.textContent = match.matchID
 
     const time = new Date(match.stamp)
-    tmpl.matchTime.textContent = time.toLocaleTimeString('en-GB', {
+    tmpl.matchTime.textContent = time.toLocaleTimeString(navigator.languages as string[], {
       year: 'numeric',
       month: 'short',
       day: 'numeric'
@@ -260,40 +265,59 @@ export default class OrderPage extends BasePage {
    * updated on each update to the match.
    */
   setMutableMatchCardElements (matchCard: HTMLElement, m: Match) {
-    if (m.isCancel) {
-      return
-    }
+    if (m.isCancel) return
 
     const tmpl = Doc.parseTemplate(matchCard)
     tmpl.status.textContent = OrderUtil.matchStatusString(m)
 
-    const setCoin = (pendingName: string, linkName: string, coin: Coin) => {
-      const formatCoinID = (cid: string) => {
-        if (cid.startsWith(coinIDTakerFoundMakerRedemption)) {
-          const makerAddr = cid.substring(coinIDTakerFoundMakerRedemption.length)
-          return intl.prep(intl.ID_TAKER_FOUND_MAKER_REDEMPTION, { makerAddr: makerAddr })
-        }
-        return cid
+    const formatCoinID = (cid: string) => {
+      if (cid.startsWith(coinIDTakerFoundMakerRedemption)) {
+        const makerAddr = cid.substring(coinIDTakerFoundMakerRedemption.length)
+        return intl.prep(intl.ID_TAKER_FOUND_MAKER_REDEMPTION, { makerAddr: makerAddr })
       }
-      const coinLink = tmpl[linkName]
-      const pendingSpan = tmpl[pendingName]
+      return cid
+    }
+
+    const tryShowCoin = (pendingEl: PageElement, coinLink: PageElement, coin: Coin) => {
       if (!coin) {
-        Doc.show(tmpl[pendingName])
-        Doc.hide(tmpl[linkName])
+        Doc.hide(coinLink)
+        Doc.show(pendingEl)
         return
       }
       coinLink.textContent = formatCoinID(coin.stringID)
       coinLink.dataset.explorerCoin = coin.stringID
       setCoinHref(coin.assetID, coinLink)
-      Doc.hide(pendingSpan)
       Doc.show(coinLink)
+      Doc.hide(pendingEl)
     }
 
-    setCoin('makerSwapPending', 'makerSwapCoin', makerSwapCoin(m))
-    setCoin('takerSwapPending', 'takerSwapCoin', takerSwapCoin(m))
-    setCoin('makerRedeemPending', 'makerRedeemCoin', makerRedeemCoin(m))
-    setCoin('takerRedeemPending', 'takerRedeemCoin', takerRedeemCoin(m))
-    setCoin('refundPending', 'refundCoin', m.refund)
+    tryShowCoin(tmpl.makerSwapPending, tmpl.makerSwapCoin, makerSwapCoin(m))
+    tryShowCoin(tmpl.takerSwapPending, tmpl.takerSwapCoin, takerSwapCoin(m))
+    tryShowCoin(tmpl.makerRedeemPending, tmpl.makerRedeemCoin, makerRedeemCoin(m))
+    tryShowCoin(tmpl.takerRedeemPending, tmpl.takerRedeemCoin, takerRedeemCoin(m))
+    if (!m.refund) {
+      // Special messaging for pending refunds.
+      let lockTime = lockTimeMakerMs
+      if (m.side === OrderUtil.Taker) lockTime = lockTimeTakerMs
+      const refundAfter = new Date(m.stamp + lockTime)
+      if (Date.now() > refundAfter.getTime()) tmpl.refundPending.textContent = intl.prep(intl.ID_REFUND_IMMINENT)
+      else {
+        const refundAfterStr = refundAfter.toLocaleTimeString(navigator.languages as string[], {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric'
+        })
+        tmpl.refundPending.textContent = intl.prep(intl.ID_REFUND_WILL_HAPPEN_AFTER, { refundAfterTime: refundAfterStr })
+      }
+      Doc.hide(tmpl.refundCoin)
+      Doc.show(tmpl.refundPending)
+    } else {
+      tmpl.refundCoin.textContent = formatCoinID(m.refund.stringID)
+      tmpl.refundCoin.dataset.explorerCoin = m.refund.stringID
+      setCoinHref(m.refund.assetID, tmpl.refundCoin)
+      Doc.show(tmpl.refundCoin)
+      Doc.hide(tmpl.refundPending)
+    }
 
     if (m.status === OrderUtil.MakerSwapCast && !m.revoked && !m.refund) {
       const c = makerSwapCoin(m)
@@ -317,14 +341,64 @@ export default class OrderPage extends BasePage {
       Doc.hide(tmpl.makerSwapMsg, tmpl.takerSwapMsg, tmpl.makerRedeemMsg, tmpl.takerRedeemMsg)
     }
 
-    Doc.setVis(!m.isCancel && (makerSwapCoin(m) || !m.revoked), tmpl.makerSwap)
-    Doc.setVis(!m.isCancel && (takerSwapCoin(m) || !m.revoked), tmpl.takerSwap)
-    Doc.setVis(!m.isCancel && (makerRedeemCoin(m) || !m.revoked), tmpl.makerRedeem)
-    // When revoked, there is uncertainty about the taker redeem coin. The taker
-    // redeem may be needed if maker redeems while taker is waiting to refund.
-    Doc.setVis(!m.isCancel && (takerRedeemCoin(m) || (!m.revoked && m.active) || ((m.side === OrderUtil.Taker) && m.active && (m.counterRedeem || !m.refund))), tmpl.takerRedeem)
-    // The refund placeholder should not be shown if there is a counter redeem.
-    Doc.setVis(!m.isCancel && (m.refund || (m.revoked && m.active && !m.counterRedeem)), tmpl.refund)
+    if (!m.revoked) {
+      // Match is still following the usual success-path, it is desirable for the
+      // user to see it in full (even if to learn how atomic swap is supposed to
+      // work).
+
+      Doc.setVis(makerSwapCoin(m) || m.active, tmpl.makerSwap)
+      Doc.setVis(takerSwapCoin(m) || m.active, tmpl.takerSwap)
+      Doc.setVis(makerRedeemCoin(m) || m.active, tmpl.makerRedeem)
+      // When maker isn't aware of taker redeem coin, once the match becomes inactive
+      // (nothing else maker is expected to do in this match) just hide taker redeem.
+      Doc.setVis(takerRedeemCoin(m) || m.active, tmpl.takerRedeem)
+      // Refunding isn't a usual part of success-path, but don't rule it out.
+      Doc.setVis(m.refund, tmpl.refund)
+    } else {
+      // Match diverged from the usual success-path, since this could have happened
+      // at any step it is hard (maybe impossible) to predict the final state this
+      // match will end up in, so show only steps that already happened plus all
+      // the possibilities on the next step ahead.
+
+      // If we don't have swap coins after revocation, we won't show the pending message.
+      Doc.setVis(makerSwapCoin(m), tmpl.makerSwap)
+      Doc.setVis(takerSwapCoin(m), tmpl.takerSwap)
+      const takerRefundsAfter = new Date(m.stamp + lockTimeTakerMs)
+      const takerLockTimeExpired = Date.now() > takerRefundsAfter.getTime()
+      // When match is revoked and both swaps are present, maker redeem might still show up:
+      // - as maker, we'll try to redeem until taker locktime expires (if taker refunds
+      //   we won't be able to redeem; even if taker hasn't refunded just yet - it
+      //   becomes too dangerous to redeem after taker locktime expired because maker
+      //   reveals his secret when redeeming, and taker might be able to submit both
+      //   redeem and refund transactions before maker's redeem gets mined), so we'll
+      //   have to show redeem pending element until maker redeem shows up, or until
+      //   we give up on redeeming due to taker locktime expiry.
+      // - as taker, we should expect maker redeeming any time, so we'll have to show
+      //   redeem pending element until maker redeem shows up, or until we refund.
+      Doc.setVis(makerRedeemCoin(m) || (takerSwapCoin(m) && m.active && !m.refund && !takerLockTimeExpired), tmpl.makerRedeem)
+      // When maker isn't aware of taker redeem coin, once the match becomes inactive
+      // (nothing else maker is expected to do in this match) just hide taker redeem.
+      Doc.setVis(takerRedeemCoin(m) || (makerRedeemCoin(m) && m.active && !m.refund), tmpl.takerRedeem)
+      // As taker, show refund placeholder only if we have outstanding swap to refund.
+      // There is no need to wait for anything else, we can show refund placeholder
+      // (to inform the user that it is likely to happen) right after match revocation.
+      let expectingRefund = Boolean(takerSwapCoin(m)) // as taker
+      if (m.side === OrderUtil.Maker) {
+        // As maker, show refund placeholder only if we have outstanding swap to refund.
+        // If we don't have taker swap there is no need to wait for anything else, we
+        // can show refund placeholder (to inform the user that it is likely to happen)
+        // right after match revocation.
+        expectingRefund = Boolean(makerSwapCoin(m))
+        // If we discover taker swap we'll be trying to redeem it (instead of trying
+        // to refund our own swap) until taker refunds, so start showing refund
+        // placeholder only after taker is expected to start his refund process in
+        // this case.
+        if (takerSwapCoin(m)) {
+          expectingRefund = expectingRefund && takerLockTimeExpired
+        }
+      }
+      Doc.setVis(m.refund || (m.active && !m.redeem && !m.counterRedeem && expectingRefund), tmpl.refund)
+    }
   }
 
   /*
@@ -458,7 +532,7 @@ export default class OrderPage extends BasePage {
 
 /*
  * confirmationString is a string describing the state of confirmations for a
- * coin
+ * coin.
  * */
 function confirmationString (coin: Coin) {
   if (!coin.confs || coin.confs.required === 0) return ''


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1947.

With changes in this PR (note, these screenshots were indeed made in November 2022, just waited for https://github.com/decred/dcrdex/pull/1978 to go in first; I didn't re-test it myself after rebase, but you'll probably be doing your own testing and I'm optimistic that it still works fine):

<img width="150" alt="image" src="https://user-images.githubusercontent.com/112318969/211986434-2851bb90-a0cb-4354-bf92-4125ec6c780e.png"><img width="150" alt="image" src="https://user-images.githubusercontent.com/112318969/211986490-d7f323ee-da29-4264-9a94-928e2909750b.png"><img width="150" alt="image" src="https://user-images.githubusercontent.com/112318969/211986527-99e4204a-0cdd-4526-b9c8-bf1f5758275c.png">
