### PR TITLE
ui: order-form responsive validation

### DIFF
--- a/client/webserver/site/src/css/main_dark.scss
+++ b/client/webserver/site/src/css/main_dark.scss
@@ -84,7 +84,6 @@ body.dark {
   input,
   input:focus {
     border: none;
-    outline: none;
     color: $font-color-dark;
   }
 

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -56,10 +56,6 @@ div[data-handler=markets] {
         font-size: 14px;
       }
 
-      input:focus {
-        outline: none;
-      }
-
       span.unitbox {
         position: absolute;
         font-size: 14px;
@@ -100,7 +96,8 @@ div[data-handler=markets] {
         color: #1e7d11;
       }
 
-      #orderPreview,
+      #orderTotalPreview,
+      #mktSellTotalPreview,
       .h21 {
         height: 21px;
       }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=XYXY183gH" rel="stylesheet">
+  <link href="/css/style.css?v=LSBFflh8d" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=jBRE183gH"></script>
+<script src="/js/entry.js?v=LSBFflh8d"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -231,59 +231,70 @@
                     <span></span>
                   </div>
 
-                  {{- /* MARKET CONFIG */ -}}
-                  <div class="d-flex justify-content-between my-2 fs14">
-                    <div>
-                      [[[:title:lot_size]]]:
-                      <span id="lotSize"></span>
-                      <span data-unit="base"></span>
+                  {{- /* LIMIT BUY & SELL ORDER */ -}}
+                  <div id="limitOrderBox">
+                    <div class="d-flex justify-content-between my-2 fs14">
+                      <div id="lotSizeBox">
+                        [[[:title:lot_size]]]:
+                        <span id="lotSize"></span>
+                        <span data-unit="base"></span>
+                      </div>
+                      <div id="rateStepBox">
+                        [[[Rate Step]]]:
+                        <span id="rateStep"></span>
+                        <span data-unit="quote"></span>
+                      </div>
                     </div>
-                    <div>
-                      [[[Rate Step]]]:
-                      <span id="rateStep"></span>
-                      <span data-unit="quote"></span>
-                    </div>
-                  </div>
-                  <div class="my-2 fs14 h21" id="maxBox">
-                    <div id="maxOrd" class="d-hide position-relative pointer">
-                      <span id="maxLotBox" class="d-hide">
+                    <div id="maxOrd" class="position-relative pointer">
+                      <span id="maxLotBox">
                         <span class="underline">[[[Max]]] <span id="maxLbl">[[[Buy]]]</span></span>:
                         <span id="maxFromLots"></span>
                         <span id="maxFromLotsLbl">[[[lot]]]</span>
                       </span>
-                      <span id="maxAboveZero" class="d-hide">
-                        ,
-                        <span id="maxFromAmt"></span>
-                        <span id="maxFromTicker"></span>
-                        <!-- &rarr;
-                        <span id="maxToAmt"></span>
-                        <span id="maxToTicker"></span> -->
+                      <span id="maxQtyBox" class="d-hide">
+                        =
+                        <span id="maxAboveZero">
+                          <span id="maxFromAmt"></span>
+                          <span id="maxFromTicker"></span>
+                          <!-- &rarr;
+                          <span id="maxToAmt"></span>
+                          <span id="maxToTicker"></span> -->
+                        </span>
                       </span>
                     </div>
+                    {{- /* RATE AND QUANTITY INPUTS */ -}}
+                    <div class="d-flex mt-3" id="priceBox">
+                      <label for="rateField" class="form-label col-6 d-flex align-items-center p-0">[[[:title:price]]]</label>
+                      <div class="col-18 p-0 position-relative">
+                        <input type="number" class="form-control select bg1" id="rateField">
+                        <span class="unitbox"><span class="unit" data-unit="quote"></span>/<span class="unit" data-unit="base"></span></span>
+                      </div>
+                    </div>
+                    <div class="d-flex mt-4" id="qtyBox">
+                      <label for="qtyField" class="form-label col-6 d-flex align-items-center p-0">[[[Quantity]]]</label>
+                      <div class="col-6 p-0 position-relative">
+                        <input type="number" class="form-control select bg1" id="lotField">
+                        <span class="unit unitbox">[[[:title:lots]]]</span>
+                      </div>
+                      <div class="col-1 p-0"></div> {{/* spacer */}}
+                      <div class="col-11 p-0 position-relative">
+                        <input type="number" class="form-control select bg1" id="qtyField">
+                        <span class="unit unitbox" data-unit="base"></span>
+                      </div>
+                    </div>
+                    {{- /* ORDER PREVIEW */ -}}
+                    <div class="mt-2 fs14 text-end" id="orderTotalPreview"></div>
+                    {{- /* TIME-IN-FORCE CHECK BOX */ -}}
+                    <div class="my-1 text-start form-check" id="tifBox">
+                      <input id="tifNow" class="form-check-input" type="checkbox" value="">
+                      <label class="form-check-label" for="tifNow">
+                        [[[Immediate or cancel]]]
+                        <span class="ico-info fs12" data-tooltip="[[[immediate_explanation]]]"></span>
+                      </label>
+                    </div>
                   </div>
 
-                  {{- /* RATE AND QUANTITY INPUTS */ -}}
-                  <div class="d-flex mt-3" id="priceBox">
-                    <label for="rateField" class="form-label col-6 d-flex align-items-center p-0">[[[:title:price]]]</label>
-                    <div class="col-18 p-0 position-relative">
-                      <input type="number" class="form-control select bg1" id="rateField">
-                      <span class="unitbox"><span class="unit" data-unit="quote"></span>/<span class="unit" data-unit="base"></span></span>
-                    </div>
-                  </div>
-                  <div class="d-flex mt-4" id="qtyBox">
-                    <label for="qtyField" class="form-label col-6 d-flex align-items-center p-0">[[[Quantity]]]</label>
-                    <div class="col-6 p-0 position-relative">
-                      <input type="number" class="form-control select bg1" id="lotField">
-                      <span class="unit unitbox">[[[:title:lots]]]</span>
-                    </div>
-                    <div class="col-1 p-0"></div> {{/* spacer */}}
-                    <div class="col-11 p-0 position-relative">
-                      <input type="number" class="form-control select bg1" id="qtyField">
-                      <span class="unit unitbox" data-unit="base"></span>
-                    </div>
-                  </div>
-
-                  {{- /* MARKET BUY ORDER QUANTITY INPUT */ -}}
+                  {{- /* MARKET BUY ORDER */ -}}
                   <div id="mktBuyBox" class="d-hide">
                     <div class="text-center mt-2 fs15">
                       [[[min trade is about]]] <span id="minMktBuy"></span> <span data-unit="quote"></span>
@@ -304,21 +315,54 @@
                     </div>
                   </div>
 
-                  {{- /* ORDER PREVIEW */ -}}
-                  <div class="mt-2 fs14 text-end" id="orderPreview"></div>
-
-                  {{- /* TIME-IN-FORCE CHECK BOX */ -}}
-                  <div class="my-1 text-start form-check" id="tifBox">
-                    <input id="tifNow" class="form-check-input" type="checkbox" value="">
-                    <label class="form-check-label" for="tifNow">
-                      [[[Immediate or cancel]]]
-                      <span class="ico-info fs12" data-tooltip="[[[immediate_explanation]]]"></span>
-                    </label>
+                  {{- /* MARKET SELL ORDER */ -}}
+                  <div id="mktSellBox" class="d-hide">
+                    <div class="d-flex justify-content-between my-2 fs14">
+                      <div id="mktSellLotSizeBox">
+                        [[[:title:lot_size]]]:
+                        <span id="mktSellLotSize"></span>
+                        <span data-unit="base"></span>
+                      </div>
+                    </div>
+                    <div id="mktSellMaxOrd" class="position-relative pointer">
+                      <span id="mktSellMaxLotBox">
+                        <span class="underline">[[[Max]]] <span id="mktSellMaxLbl">[[[Sell]]]</span></span>:
+                        <span id="mktSellMaxFromLots"></span>
+                        <span id="mktSellMaxFromLotsLbl">[[[lot]]]</span>
+                      </span>
+                      <span id="mktSellMaxQtyBox" class="d-hide">
+                        =
+                        <span id="mktSellMaxAboveZero">
+                          <span id="mktSellMaxFromAmt"></span>
+                          <span id="mktSellMaxFromTicker"></span>
+                          <!-- &rarr;
+                          <span id="mktSellMaxToAmt"></span>
+                          <span id="mktSellMaxToTicker"></span> -->
+                        </span>
+                      </span>
+                    </div>
+                    <div class="d-flex mt-4" id="mktSellQtyBox">
+                      <label for="mktSellQtyField" class="form-label col-6 d-flex align-items-center p-0">[[[Quantity]]]</label>
+                      <div class="col-6 p-0 position-relative">
+                        <input type="number" class="form-control select bg1" id="mktSellLotField">
+                        <span class="unit unitbox">[[[:title:lots]]]</span>
+                      </div>
+                      <div class="col-1 p-0"></div> {{/* spacer */}}
+                      <div class="col-11 p-0 position-relative">
+                        <input type="number" class="form-control select bg1" id="mktSellQtyField">
+                        <span class="unit unitbox" data-unit="base"></span>
+                      </div>
+                    </div>
+                    {{- /* ORDER PREVIEW */ -}}
+                    <div class="mt-2 fs14 text-end" id="mktSellTotalPreview"></div>
                   </div>
 
                   {{- /* SUBMIT ORDER BUTTON */ -}}
                   <div class="text-end">
                     <button id="submitBttn" type="button" class="my-1 fs14 submit text-center buygreen-bg"></button> {{/* textContent set by script */}}
+                    <div id="submitBttnLoader" class="loader flex-center d-hide">
+                      <div class="ico-spinner spinner"></div>
+                    </div>
                   </div>
                 </div>
                 <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="orderErr"></div>

--- a/client/webserver/site/src/js/doc.ts
+++ b/client/webserver/site/src/js/doc.ts
@@ -191,6 +191,22 @@ export default class Doc {
   }
 
   /*
+   * hidePreservingLayout hides the specified elements without affecting page layout
+   * (like Doc.hide can). Use Doc.showPreservingLayout to undo.
+   */
+  static hidePreservingLayout (...els: HTMLElement[]) {
+    for (const el of els) el.style.visibility = 'hidden'
+  }
+
+  /*
+   * showPreservingLayout shows the specified elements, undoing changes by made with
+   * Doc.hidePreservingLayout.
+   */
+  static showPreservingLayout (...els: HTMLElement[]) {
+    for (const el of els) el.style.visibility = 'visible'
+  }
+
+  /*
    * show or hide the specified elements, based on value of the truthiness of
    * vis.
    */
@@ -455,7 +471,7 @@ export class Animation {
       now = new Date().getTime()
     }
     f(1)
-    this.runCompletionFunction()
+    return this.runCompletionFunction()
   }
 
   /* wait returns a promise that will resolve when the animation completes. */

--- a/client/webserver/site/src/js/locales.ts
+++ b/client/webserver/site/src/js/locales.ts
@@ -15,11 +15,13 @@ export const ID_BUY = 'ID_BUY'
 export const ID_SELL = 'ID_SELL'
 export const ID_NOT_SUPPORTED = 'ID_NOT_SUPPORTED'
 export const ID_CONNECTION_FAILED = 'ID_CONNECTION_FAILED'
-export const ID_ORDER_PREVIEW = 'ID_ORDER_PREVIEW'
+export const ID_LIMIT_ORDER_TOTAL_PREVIEW = 'ID_LIMIT_ORDER_TOTAL_PREVIEW'
+export const ID_MARKET_ORDER_TOTAL_PREVIEW = 'ID_MARKET_ORDER_TOTAL_PREVIEW'
 export const ID_CALCULATING = 'ID_CALCULATING'
 export const ID_ESTIMATE_UNAVAILABLE = 'ID_ESTIMATE_UNAVAILABLE'
 export const ID_NO_ZERO_RATE = 'ID_NO_ZERO_RATE'
 export const ID_NO_ZERO_QUANTITY = 'ID_NO_ZERO_QUANTITY'
+export const ID_NO_QUANTITY_EXCEEDS_MAX = 'ID_NO_QUANTITY_EXCEEDS_MAX'
 export const ID_TRADE = 'ID_TRADE'
 export const ID_NO_ASSET_WALLET = 'ID_NO_ASSET_WALLET'
 export const ID_EXECUTED = 'ID_EXECUTED'
@@ -112,11 +114,13 @@ export const enUS: Locale = {
   [ID_SELL]: 'Sell',
   [ID_NOT_SUPPORTED]: '{{ asset }} is not supported',
   [ID_CONNECTION_FAILED]: 'Connection to dex server failed. You can close dexc and try again later or wait for it to reconnect.',
-  [ID_ORDER_PREVIEW]: 'Total: {{ total }} {{ asset }}',
+  [ID_LIMIT_ORDER_TOTAL_PREVIEW]: 'Total: {{ total }} {{ asset }}',
+  [ID_MARKET_ORDER_TOTAL_PREVIEW]: 'Total: ~ {{ total }} {{ asset }}',
   [ID_CALCULATING]: 'calculating...',
   [ID_ESTIMATE_UNAVAILABLE]: 'estimate unavailable',
   [ID_NO_ZERO_RATE]: 'zero rate not allowed',
   [ID_NO_ZERO_QUANTITY]: 'zero quantity not allowed',
+  [ID_NO_QUANTITY_EXCEEDS_MAX]: 'not enough funds',
   [ID_TRADE]: 'trade',
   [ID_NO_ASSET_WALLET]: 'No {{ asset }} wallet',
   [ID_EXECUTED]: 'executed',
@@ -209,7 +213,8 @@ export const ptBR: Locale = {
   [ID_SELL]: 'Vender',
   [ID_NOT_SUPPORTED]: '{{ asset }} não tem suporte',
   [ID_CONNECTION_FAILED]: 'Conexão ao server dex falhou. Pode fechar dexc e tentar novamente depois ou esperar para tentar se reconectar.',
-  [ID_ORDER_PREVIEW]: 'Total: {{ total }} {{ asset }}',
+  [ID_LIMIT_ORDER_TOTAL_PREVIEW]: 'Total: {{ total }} {{ asset }}',
+  [ID_MARKET_ORDER_TOTAL_PREVIEW]: 'Total: ~ {{ total }} {{ asset }}',
   [ID_CALCULATING]: 'calculando...',
   [ID_ESTIMATE_UNAVAILABLE]: 'estimativa indisponível',
   [ID_NO_ZERO_RATE]: 'taxa não pode ser zero',
@@ -263,7 +268,8 @@ export const zhCN: Locale = {
   [ID_SELL]: '卖出',
   [ID_NOT_SUPPORTED]: '{{ asset }}不受支持',
   [ID_CONNECTION_FAILED]: '连接到服务器 dex 失败。您可以关闭 dexc 并稍后重试或等待尝试重新连接。',
-  [ID_ORDER_PREVIEW]: '总计： {{ total }} {{ asset }}',
+  [ID_LIMIT_ORDER_TOTAL_PREVIEW]: '总计： {{ total }} {{ asset }}',
+  [ID_MARKET_ORDER_TOTAL_PREVIEW]: '总计： ~ {{ total }} {{ asset }}',
   [ID_CALCULATING]: '计算中...',
   [ID_ESTIMATE_UNAVAILABLE]: '估计不可用',
   [ID_NO_ZERO_RATE]: '汇率不能为零',
@@ -303,7 +309,8 @@ export const plPL: Locale = {
   [ID_SELL]: 'Sprzedaj',
   [ID_NOT_SUPPORTED]: '{{ asset }} nie jest wspierany',
   [ID_CONNECTION_FAILED]: 'Połączenie z serwerem dex nie powiodło się. Możesz zamknąć dexc i spróbować ponownie później, lub poczekać na wznowienie połączenia.',
-  [ID_ORDER_PREVIEW]: 'W sumie: {{ total }} {{ asset }}',
+  [ID_LIMIT_ORDER_TOTAL_PREVIEW]: 'W sumie: {{ total }} {{ asset }}',
+  [ID_MARKET_ORDER_TOTAL_PREVIEW]: 'W sumie: ~ {{ total }} {{ asset }}',
   [ID_CALCULATING]: 'obliczanie...',
   [ID_ESTIMATE_UNAVAILABLE]: 'brak szacunkowego wyliczenia',
   [ID_NO_ZERO_RATE]: 'zero nie może być ceną',
@@ -357,7 +364,8 @@ export const deDE: Locale = {
   [ID_SELL]: 'Verkaufen',
   [ID_NOT_SUPPORTED]: '{{ asset }} wird nicht unterstützt',
   [ID_CONNECTION_FAILED]: 'Die Verbindung zum Dex-Server fehlgeschlagen. Du kannst dexc schließen und es später erneut versuchen oder warten bis die Verbindung wiederhergestellt ist.',
-  [ID_ORDER_PREVIEW]: 'Insgesamt: {{ total }} {{ asset }}',
+  [ID_LIMIT_ORDER_TOTAL_PREVIEW]: 'Insgesamt: {{ total }} {{ asset }}',
+  [ID_MARKET_ORDER_TOTAL_PREVIEW]: 'Insgesamt: ~ {{ total }} {{ asset }}',
   [ID_CALCULATING]: 'kalkuliere...',
   [ID_ESTIMATE_UNAVAILABLE]: 'Schätzung nicht verfügbar',
   [ID_NO_ZERO_RATE]: 'Null-Satz nicht erlaubt',
@@ -415,7 +423,8 @@ export const ar: Locale = {
   [ID_SELL]: 'بيع',
   [ID_NOT_SUPPORTED]: '{{ asset }} غير مدعوم',
   [ID_CONNECTION_FAILED]: 'فشل الاتصال بخادم dex. يمكنك إغلاق dexc والمحاولة مرة أخرى لاحقًا أو انتظار إعادة الاتصال.',
-  [ID_ORDER_PREVIEW]: 'إجمالي: {{ total }} {{ asset }}',
+  [ID_LIMIT_ORDER_TOTAL_PREVIEW]: 'إجمالي: {{ total }} {{ asset }}',
+  [ID_MARKET_ORDER_TOTAL_PREVIEW]: 'إجمالي: ~ {{ total }} {{ asset }}',
   [ID_CALCULATING]: 'جاري الحساب ...',
   [ID_ESTIMATE_UNAVAILABLE]: 'التقديرات غير متاحة',
   [ID_NO_ZERO_RATE]: 'معدل الصفر غير مسموح به',

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -383,6 +383,8 @@ export interface PageElement extends HTMLElement {
   checked?: boolean
   href?: string
   htmlFor?: string
+  min?: string
+  step?: string
 }
 
 export interface BooleanConfig {
@@ -455,8 +457,8 @@ export interface TradeForm {
   sell: boolean
   base: number
   quote: number
-  qty: number
-  rate: number
+  qty: number // in atoms
+  rate: number // in atoms
   tifnow: boolean
   options: Record<string, any>
 }


### PR DESCRIPTION
Replaces https://github.com/decred/dcrdex/pull/1921.

To implement responsive order-form validation HTML layout and JS event handlers need to be rewritten. Since there is quite a bit of JS-code  relying on the way event handlers were written, those code-bits also needed updates/rewrites to fit in with the new event-handlers, hopefully, these changes overall make order-form handling code more explicit / thorougly documented, and less tightly coupled.

Additionally, some bugs were discovered (when testing this functionality) and fixed here.

List of most notable changes:
- validation for `Price`, `Quantity` fields should be more responsive, so that the user has a better sense of why his inputs don't make sense (this is mostly accomplished by highlighting background/border for relevant order-form element; and maybe hiding some elements like `Total` when its not possible to calculate based on current user-inputs)
- `Place order to buy ...` button press should fail right away when `Total` exceeds `Max Buy`, instead of allowing user to proceed - only to fail later on
- `Place order to ...` animates now; that 1) allows for more snappy user-feedback and more importantly 2) prevents user from clicking on it right after he's entered invalid `Rate` / `Quantity` inputs (otherwise user might not notice the rounding or will learn about his mistake in delayed manner)
- fixed a bug where the `orderTotalPreview` for market orders was not being set correctly
- added `min` and `step` attributes for various number inputs on order-form, resulting in better messaging and enabling the use of arrow keys on number inputs, and fixing a bug with Up-key not working with `Quantity` input
- fixed a bug with applying the result of `Max Buy/Sell` calculation in callback; by the time this callback displays the result, the user might have switched from Buy to Sell side, or vice versa (resulting in order-form showing him `Max Buy/Sell` for the opposite order side, not the one he switched to)
- having all 4 order types: Limit/Market+Buy/Sell managed by same view seems have resulted into tight-coupling of some code in `markets.ts`. To keep code-complexity manageable, I've split off Market-Sell order stuff into its own separate view (Limit Buy/Sell forms are almost identical, can't say same for Market orders). Market-Buy form was already handled by separate view (see `MARKET BUY ORDER` in `markets.tmpl`)
- added `Max Sell` section for "Market Sell" order type, which is probably just as useful as on limit form