### PR TITLE
server/asset: move CompatibilityCheck to dex/networks

### DIFF
--- a/dex/networks/bch/params_test.go
+++ b/dex/networks/bch/params_test.go
@@ -4,8 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	dexbch "decred.org/dcrdex/dex/networks/bch"
-	"decred.org/dcrdex/server/asset/btc"
+	btctest "decred.org/dcrdex/dex/networks/btc/test"
 )
 
 func TestCompatibility(t *testing.T) {
@@ -18,24 +17,24 @@ func TestCompatibility(t *testing.T) {
 	}
 
 	// 2b381efec176b72da70e894a6dbba1fc1ba18a1d573af898e6f92915c0ca8209:1
-	p2pkhAddr, err := dexbch.DecodeCashAddress("bitcoincash:qznf2drgsapgsejd95yp9nw0qzhw9mrcxsez7d78uv", dexbch.MainNetParams)
+	p2pkhAddr, err := DecodeCashAddress("bitcoincash:qznf2drgsapgsejd95yp9nw0qzhw9mrcxsez7d78uv", MainNetParams)
 	if err != nil {
 		t.Fatalf("error p2pkh decoding CashAddr address: %v", err)
 	}
 
 	// b63e8090fe7140328d5d6ecdd6045b123e3f05742d9a749f2550fba7d0a6879f:1
-	p2shAddr, err := dexbch.DecodeCashAddress("bitcoincash:pqugctqhj096cufywe32rktfu5dpmnnrjgsznuudl2", dexbch.MainNetParams)
+	p2shAddr, err := DecodeCashAddress("bitcoincash:pqugctqhj096cufywe32rktfu5dpmnnrjgsznuudl2", MainNetParams)
 	if err != nil {
 		t.Fatalf("error decoding p2sh CashAddr address: %v", err)
 	}
 
 	// These scripts and addresses are just copy-pasted from random
 	// getrawtransaction output.
-	items := &btc.CompatibilityItems{
+	items := &btctest.CompatibilityItems{
 		P2PKHScript: fromHex("76a914a6953468874288664d2d0812cdcf00aee2ec783488ac"),
 		PKHAddr:     p2pkhAddr.String(),
 		P2SHScript:  fromHex("a914388c2c1793cbac71247662a1d969e51a1dce639287"),
 		SHAddr:      p2shAddr.String(),
 	}
-	btc.CompatibilityCheck(items, dexbch.MainNetParams, t)
+	btctest.CompatibilityCheck(t, items, MainNetParams)
 }

--- a/dex/networks/btc/test/compat.go
+++ b/dex/networks/btc/test/compat.go
@@ -1,0 +1,84 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package test
+
+import (
+	"testing"
+
+	"decred.org/dcrdex/dex/networks/btc"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/txscript"
+)
+
+// CompatibilityItems are a set of pubkey scripts and corresponding
+// string-encoded addresses checked in CompatibilityTest. They should be taken
+// from existing on-chain data.
+type CompatibilityItems struct {
+	P2PKHScript  []byte
+	PKHAddr      string
+	P2WPKHScript []byte
+	WPKHAddr     string
+	P2SHScript   []byte
+	SHAddr       string
+	P2WSHScript  []byte
+	WSHAddr      string
+}
+
+// CompatibilityCheck checks various scripts' compatibility with the Backend.
+// If a fork's CompatibilityItems can pass the CompatibilityCheck, the node
+// can likely use NewBTCClone to create a DEX-compatible backend.
+func CompatibilityCheck(t *testing.T, items *CompatibilityItems, chainParams *chaincfg.Params) {
+	t.Helper()
+	checkAddr := func(pkScript []byte, addr string) {
+		_, addrs, _, err := txscript.ExtractPkScriptAddrs(pkScript, chainParams)
+		if err != nil {
+			t.Fatalf("ExtractPkScriptAddrs error: %v", err)
+		}
+		if len(addrs) == 0 {
+			t.Fatalf("no addresses extracted from script %x", pkScript)
+		}
+		if addrs[0].String() != addr {
+			t.Fatalf("address mismatch %s != %s", addrs[0].String(), addr)
+		}
+	}
+
+	// P2PKH
+	pkh := btc.ExtractPubKeyHash(items.P2PKHScript)
+	if pkh == nil {
+		t.Fatalf("incompatible P2PKH script")
+	}
+	checkAddr(items.P2PKHScript, items.PKHAddr)
+
+	// P2WPKH
+	// A clone doesn't necessarily need segwit, so a nil value here will skip
+	// the test.
+	if items.P2WPKHScript != nil {
+		scriptClass := txscript.GetScriptClass(items.P2WPKHScript)
+		if scriptClass != txscript.WitnessV0PubKeyHashTy {
+			t.Fatalf("incompatible P2WPKH script")
+		}
+		checkAddr(items.P2WPKHScript, items.WPKHAddr)
+	}
+
+	// P2SH
+	sh := btc.ExtractScriptHash(items.P2SHScript)
+	if sh == nil {
+		t.Fatalf("incompatible P2SH script")
+	}
+	checkAddr(items.P2SHScript, items.SHAddr)
+
+	// P2WSH
+	if items.P2WSHScript != nil {
+		scriptClass := txscript.GetScriptClass(items.P2WSHScript)
+		if scriptClass != txscript.WitnessV0ScriptHashTy {
+			t.Fatalf("incompatible P2WPKH script")
+		}
+		wsh := btc.ExtractScriptHash(items.P2WSHScript)
+		if wsh == nil {
+			t.Fatalf("incompatible P2WSH script")
+		}
+		checkAddr(items.P2WSHScript, items.WSHAddr)
+	}
+}

--- a/dex/networks/doge/params_test.go
+++ b/dex/networks/doge/params_test.go
@@ -4,8 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	dexdoge "decred.org/dcrdex/dex/networks/doge"
-	"decred.org/dcrdex/server/asset/btc"
+	btctest "decred.org/dcrdex/dex/networks/btc/test"
 )
 
 func TestCompatibility(t *testing.T) {
@@ -18,11 +17,11 @@ func TestCompatibility(t *testing.T) {
 	}
 	// These scripts and addresses are just copy-pasted from random
 	// getrawtransaction output.
-	items := &btc.CompatibilityItems{
+	items := &btctest.CompatibilityItems{
 		P2PKHScript: fromHex("76a914f8f0813eb71c0c5c0a8677b6e8f1e4bb870935fc88ac"),
 		PKHAddr:     "DTqNEQLjhn2hf8vK46py9nDohkci2BeAt1",
 		P2SHScript:  fromHex("a9140aa26a002d22f88c1f83d35298dc64769fe6e81a87"),
 		SHAddr:      "9sQVz2zRbhCAMdXb4NtoLRYzi84qAkGD5r",
 	}
-	btc.CompatibilityCheck(items, dexdoge.MainNetParams, t)
+	btctest.CompatibilityCheck(t, items, MainNetParams)
 }

--- a/dex/networks/ltc/params_test.go
+++ b/dex/networks/ltc/params_test.go
@@ -4,8 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	dexltc "decred.org/dcrdex/dex/networks/ltc"
-	"decred.org/dcrdex/server/asset/btc"
+	btctest "decred.org/dcrdex/dex/networks/btc/test"
 )
 
 func TestCompatibility(t *testing.T) {
@@ -18,7 +17,7 @@ func TestCompatibility(t *testing.T) {
 	}
 	// These scripts and addresses are just copy-pasted from random
 	// getrawtransaction output.
-	items := &btc.CompatibilityItems{
+	items := &btctest.CompatibilityItems{
 		P2PKHScript:  fromHex("76a9146e137cab355e7a35d7546470dc6db403b7bd47ea88ac"),
 		PKHAddr:      "LVFywJ1DHYbN2uYjWNCJGcLJJhL3boaiSy",
 		P2WPKHScript: fromHex("00144820955c5ecf2fd7a0864d8ae7572f17b1e8fb91"),
@@ -28,5 +27,5 @@ func TestCompatibility(t *testing.T) {
 		P2WSHScript:  fromHex("0020adb044cf4da15506e73c6d3928737229e64227f29cd86dcc34b7353c1f5560eb"),
 		WSHAddr:      "ltc1q4kcyfn6d592sdeeud5ujsumj98nyyfljnnvxmnp5ku6nc864vr4sawj2gw",
 	}
-	btc.CompatibilityCheck(items, dexltc.MainNetParams, t)
+	btctest.CompatibilityCheck(t, items, MainNetParams)
 }

--- a/dex/networks/zec/params_test.go
+++ b/dex/networks/zec/params_test.go
@@ -1,13 +1,10 @@
-//go:build !zeclive
-
 package zec
 
 import (
 	"encoding/hex"
 	"testing"
 
-	dexzec "decred.org/dcrdex/dex/networks/zec"
-	"decred.org/dcrdex/server/asset/btc"
+	btctest "decred.org/dcrdex/dex/networks/btc/test"
 )
 
 func TestCompatibility(t *testing.T) {
@@ -20,22 +17,22 @@ func TestCompatibility(t *testing.T) {
 	}
 
 	pkhAddr := "t1SqYLhzHyGoWwatRNGrTt4ueqivKdJpFY4"
-	btcPkhAddr, err := dexzec.DecodeAddress(pkhAddr, dexzec.MainNetAddressParams, dexzec.MainNetParams)
+	btcPkhAddr, err := DecodeAddress(pkhAddr, MainNetAddressParams, MainNetParams)
 	if err != nil {
 		t.Fatalf("error decoding p2pkh address: %v", err)
 	}
 
 	shAddr := "t3ZJCdehVh9MTm6BaKWZmWy5Hsw7PhJxmTc"
-	btcShAddr, err := dexzec.DecodeAddress(shAddr, dexzec.MainNetAddressParams, dexzec.MainNetParams)
+	btcShAddr, err := DecodeAddress(shAddr, MainNetAddressParams, MainNetParams)
 	if err != nil {
 		t.Fatalf("error decoding p2sh address: %v", err)
 	}
 
-	items := &btc.CompatibilityItems{
+	items := &btctest.CompatibilityItems{
 		P2PKHScript: fromHex("76a91462553d6a85afe7753cbe8dc57c7f34f6a8efd79f88ac"),
 		PKHAddr:     btcPkhAddr.String(),
 		P2SHScript:  fromHex("a914a19f5d7d23bbbff0695363f932c8d67c0169963f87"),
 		SHAddr:      btcShAddr.String(),
 	}
-	btc.CompatibilityCheck(items, dexzec.MainNetParams, t)
+	btctest.CompatibilityCheck(t, items, MainNetParams)
 }

--- a/server/asset/btc/testing.go
+++ b/server/asset/btc/testing.go
@@ -11,9 +11,7 @@ import (
 	"testing"
 
 	dexbtc "decred.org/dcrdex/dex/networks/btc"
-	btctest "decred.org/dcrdex/dex/networks/btc/test"
 	"decred.org/dcrdex/server/asset"
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 )
@@ -378,16 +376,6 @@ func isEscrowScript(script []byte) bool {
 		return true
 	}
 	return false
-}
-
-// CompatibilityItems is an alias for the type in dex/networks/btc/test, which
-// should be used instead of this type to test a clone's chain parameters.
-type CompatibilityItems = btctest.CompatibilityItems
-
-// CompatibilityCheck is an alias for the type in dex/networks/btc/test, which
-// should be used instead of this type to test a clone's chain parameters.
-func CompatibilityCheck(items *CompatibilityItems, chainParams *chaincfg.Params, t *testing.T) {
-	btctest.CompatibilityCheck(t, items, chainParams)
 }
 
 func TestMedianFees(btc *Backend, t *testing.T) {


### PR DESCRIPTION
Extracting this change from https://github.com/decred/dcrdex/pull/1993, so that the DGB PR can be a model.

The idea of this change is that `CompatibilityCheck` is testing the parameters defined in `dex/networks`, so it should be in `dex/networks`.  This also makes a special test package (`dex/networks/btc/test`) so that this code, which is not used in production, does not find it's way into the exported product code.