### PR TITLE
client: fix missing settings button for erc20 tokens

### DIFF
--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -385,7 +385,7 @@
         </div>
         <select id="changeWalletTypeSelect"></select>
       </div>
-      <div class="d-flex mt-1 {{if $passwordIsCached}}justify-content-end{{end}}">
+      <div id="passwordWrapper" class="d-flex mt-1 {{if $passwordIsCached}}justify-content-end{{end}}">
         <div class="col-12 p-0 {{if $passwordIsCached}}d-hide{{end}}">
           <label for="appPW" class="form-label ps-1 mb-1">[[[App Password]]]</label>
           <input type="password" class="form-control select" id="appPW" autocomplete="off">

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -629,18 +629,15 @@ export default class WalletsPage extends BasePage {
       page.balanceBox, page.fiatBalanceBox, page.createWalletBox, page.walletDetails,
       page.sendReceive, page.connectBttnBox, page.statusLocked, page.statusReady,
       page.statusOff, page.unlockBttnBox, page.lockBttnBox, page.connectBttnBox,
-      page.reconfigureBox, page.peerCountBox, page.syncProgressBox, page.statusDisabled
+      page.peerCountBox, page.syncProgressBox, page.statusDisabled
     )
     if (wallet) {
       this.updateDisplayedAssetBalance()
 
       const walletDef = app().walletDefinition(assetID, wallet.type)
       page.walletType.textContent = walletDef.tab
-      Doc.show(page.reconfigureBox)
       const configurable = assetIsConfigurable(assetID)
-      // if it is not configurable, we do not show the password form.
-      if (configurable) Doc.show(page.passwordWrapper)
-      else Doc.hide(page.passwordWrapper)
+      Doc.setVis(configurable, page.passwordWrapper)
 
       if (wallet.disabled) Doc.show(page.statusDisabled) // wallet is disabled
       else if (wallet.running) {

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -636,8 +636,11 @@ export default class WalletsPage extends BasePage {
 
       const walletDef = app().walletDefinition(assetID, wallet.type)
       page.walletType.textContent = walletDef.tab
+      Doc.show(page.reconfigureBox)
       const configurable = assetIsConfigurable(assetID)
-      if (configurable) Doc.show(page.reconfigureBox)
+      // if it is not configurable, we do not show the password form.
+      if (configurable) Doc.show(page.passwordWrapper)
+      else Doc.hide(page.passwordWrapper)
 
       if (wallet.disabled) Doc.show(page.statusDisabled) // wallet is disabled
       else if (wallet.running) {
@@ -1270,9 +1273,10 @@ export default class WalletsPage extends BasePage {
  */
 function assetIsConfigurable (assetID: number) {
   const asset = app().assets[assetID]
-  // alaways return if it is a token, so we can enable or disable the wallet
-  // and export it.
-  if (asset.token) return true
+  if (asset.token) {
+    const opts = asset.token.definition.configopts
+    return opts && opts.length > 0
+  }
   if (!asset.info) throw Error('this asset isn\'t an asset, I guess')
   const defs = asset.info.availablewallets
   const zerothOpts = defs[0].configopts

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1270,10 +1270,9 @@ export default class WalletsPage extends BasePage {
  */
 function assetIsConfigurable (assetID: number) {
   const asset = app().assets[assetID]
-  if (asset.token) {
-    const opts = asset.token.definition.configopts
-    return opts && opts.length > 0
-  }
+  // alaways return if it is a token, so we can enable or disable the wallet
+  // and export it.
+  if (asset.token) return true
   if (!asset.info) throw Error('this asset isn\'t an asset, I guess')
   const defs = asset.info.availablewallets
   const zerothOpts = defs[0].configopts


### PR DESCRIPTION
closes #2040.

I am always showing the settings button for tokens now, even though they don't have configopts defined. This way it is possible to enable or disable and export them.