### PR TITLE
 multi: implement asset.Authtenticator for assets that require authentication

### DIFF
--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -22,11 +22,13 @@ import (
 // ExchangeWalletElectrum is the asset.Wallet for an external Electrum wallet.
 type ExchangeWalletElectrum struct {
 	*baseWallet
+	*authAddOn
 	ew *electrumWallet
 }
 
 var _ asset.Wallet = (*ExchangeWalletElectrum)(nil)
 var _ asset.FeeRater = (*ExchangeWalletElectrum)(nil)
+var _ asset.Authenticator = (*ExchangeWalletElectrum)(nil)
 
 // ElectrumWallet creates a new ExchangeWalletElectrum for the provided
 // configuration, which must contain the necessary details for accessing the
@@ -61,6 +63,7 @@ func ElectrumWallet(cfg *BTCCloneCFG) (*ExchangeWalletElectrum, error) {
 
 	eew := &ExchangeWalletElectrum{
 		baseWallet: btc,
+		authAddOn:  &authAddOn{btc.node},
 		ew:         ew,
 	}
 	// In (*baseWallet).feeRate, use ExchangeWalletElectrum's walletFeeRate

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -661,6 +661,7 @@ var _ asset.Withdrawer = (*ExchangeWallet)(nil)
 var _ asset.LiveReconfigurer = (*ExchangeWallet)(nil)
 var _ asset.TxFeeEstimator = (*ExchangeWallet)(nil)
 var _ asset.Bonder = (*ExchangeWallet)(nil)
+var _ asset.Authenticator = (*ExchangeWallet)(nil)
 
 type block struct {
 	height int64

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -154,7 +154,6 @@ var (
 				Description: "Infrastructure providers (e.g. Infura) or local nodes",
 				ConfigOpts:  append(RPCOpts, WalletOpts...),
 				Seeded:      true,
-				NoAuth:      true,
 				GuideLink:   "https://github.com/decred/dcrdex/blob/master/docs/wiki/Ethereum.md",
 			},
 			// MaxSwapsInTx and MaxRedeemsInTx are set in (Wallet).Info, since
@@ -447,6 +446,7 @@ var _ asset.TxFeeEstimator = (*TokenWallet)(nil)
 var _ asset.DynamicSwapOrRedemptionFeeChecker = (*ETHWallet)(nil)
 var _ asset.DynamicSwapOrRedemptionFeeChecker = (*TokenWallet)(nil)
 var _ asset.BotWallet = (*assetWallet)(nil)
+var _ asset.Authenticator = (*ETHWallet)(nil)
 
 type baseWallet struct {
 	// The asset subsystem starts with Connect(ctx). This ctx will be initialized
@@ -2709,16 +2709,8 @@ func (eth *baseWallet) RedemptionAddress() (string, error) {
 	return eth.addr.String(), nil
 }
 
-// TODO: Lock, Unlock, and Locked should probably be part of an optional
-// asset.Authenticator interface that isn't implemented by token wallets.
-// This is easy to accomplish here, but would require substantial updates to
-// client/core.
-// The addition of an ETHWallet type that implements asset.Authenticator would
-// also facilitate the appropriate compartmentalization of our asset.TokenMaster
-// methods, which token wallets also won't need.
-
 // Unlock unlocks the exchange wallet.
-func (eth *baseWallet) Unlock(pw []byte) error {
+func (eth *ETHWallet) Unlock(pw []byte) error {
 	return eth.node.unlock(string(pw))
 }
 
@@ -2727,13 +2719,8 @@ func (eth *ETHWallet) Lock() error {
 	return eth.node.lock()
 }
 
-// Lock does nothing for tokens. See above TODO.
-func (eth *TokenWallet) Lock() error {
-	return nil
-}
-
 // Locked will be true if the wallet is currently locked.
-func (eth *baseWallet) Locked() bool {
+func (eth *ETHWallet) Locked() bool {
 	return eth.node.locked()
 }
 

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -164,7 +164,8 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (ass
 		Testnet: "18232",
 		Simnet:  "18232",
 	}
-	var w *btc.ExchangeWalletFullNode
+
+	var w *btc.ExchangeWalletNoAuth
 	cloneCFG := &btc.BTCCloneCFG{
 		WalletCFG:                cfg,
 		MinNetworkVersion:        minNetworkVersion,
@@ -233,7 +234,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (ass
 	}
 
 	var err error
-	w, err = btc.BTCCloneWallet(cloneCFG)
+	w, err = btc.BTCCloneWalletNoAuth(cloneCFG)
 	return w, err
 }
 

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=rgcDpVd"></script>
+<script src="/js/entry.js?v=LVFHWeVTq"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -326,8 +326,8 @@ export class NewWalletForm {
         break
       }
     }
-    const noWalletPWNeeded = !containsRequired && (walletDef.seeded || Boolean(this.current.asset.token))
-    if (appPwCached && noWalletPWNeeded) {
+    const noWalletPWNeeded = walletDef.noauth || walletDef.seeded || Boolean(this.current.asset.token)
+    if (appPwCached && noWalletPWNeeded && !containsRequired) {
       Doc.show(page.oneBttnBox)
     } else if (noWalletPWNeeded) {
       Doc.show(page.auth)

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -1002,8 +1002,7 @@ function createOption (opt: BaseOption): OrderOption {
     isboolean: false,
     isdate: false,
     disablewhenactive: false,
-    isBirthdayConfig: false,
-    noauth: false
+    isBirthdayConfig: false
   }
 }
 

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -241,7 +241,6 @@ export interface ConfigOption {
   isBirthdayConfig: boolean
   repeatable?: string
   repeatN?: number
-  noauth: boolean
   regAsset?: number
   required?: boolean
 }


### PR DESCRIPTION
This resolves an existing TODO:

>   TODO: Use an asset.Authenticator interface and WalletTraits to do this instead.

- Implements an `asset.Authenticator` for wallets that require auth.
- Added a `btc.ExchangeWalletAuthenticator` the implements the `asset.Authenticator` interface.