### PR TITLE
ui: normalize input borders

### DIFF
--- a/client/webserver/site/src/css/application.scss
+++ b/client/webserver/site/src/css/application.scss
@@ -10,6 +10,8 @@ $light_body_bg: white;
 $dark_body_bg: #091a28;
 $light_border_color: #ddd;
 $dark_border_color: #383f4b;
+$light_input_border: #999;
+$dark_input_border: #555;
 $sans: "source-sans", sans-serif;
 $demi-sans: "demi-sans", sans-serif;
 $mono: "mono", monospace;

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -184,6 +184,13 @@ input[type=number] {
   -moz-appearance: textfield;
 }
 
+select,
+select:focus,
+input:not([type=checkbox]),
+input:focus:not([type=checkbox]) {
+  border: 1px solid $light_input_border;
+}
+
 .flex-center {
   display: flex;
   justify-content: center;
@@ -510,6 +517,7 @@ span.token-aware-symbol sup {
 
 .form-check-input[type=checkbox] {
   background-color: #ebebeb;
+  border: 1px solid $light_input_border;
   cursor: pointer;
 
   &:checked {

--- a/client/webserver/site/src/css/main_dark.scss
+++ b/client/webserver/site/src/css/main_dark.scss
@@ -93,6 +93,7 @@ body.dark {
   input:not([type=checkbox]),
   input:focus:not([type=checkbox]) {
     background-color: black;
+    border: 1px solid $dark_input_border;
   }
 
   input:disabled {
@@ -135,6 +136,7 @@ body.dark {
 
   .form-check-input[type=checkbox] {
     background-color: black;
+    border: 1px solid $dark_input_border;
 
     &:checked {
       background-color: #27278d;

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -51,7 +51,6 @@ div[data-handler=markets] {
     #orderForm {
       input[type=number] {
         height: 30px;
-        border: 1px solid #6a6a6a;
         border-radius: 0;
         font-size: 14px;
       }

--- a/client/webserver/site/src/css/market_dark.scss
+++ b/client/webserver/site/src/css/market_dark.scss
@@ -1,9 +1,5 @@
 body.dark {
   div[data-handler=markets] {
-    input[type=number] {
-      border-color: #444;
-    }
-
     table.ordertable {
       color: #a1a1a1;
 


### PR DESCRIPTION
I noticed after #2002 that the checkbox is hard to see in dark mode. 
![image](https://user-images.githubusercontent.com/6109680/214292438-05453690-f80b-4f5d-9883-13469b9433f8.png)
Also, we didn't have consistent input borders site-wide. 
Now all inputs, selects, and checkboxes have a light border in both dark and light mode.
![image](https://user-images.githubusercontent.com/6109680/214292905-ccdb3738-7351-4d50-abdc-f7669e61bc0d.png)
