### PR TITLE
asset: display asset symbol in failed connect message

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1853,12 +1853,12 @@ func (c *Core) connectedWallet(assetID uint32) (*xcWallet, error) {
 // startup will be made.
 func (c *Core) connectWalletResumeTrades(w *xcWallet, resumeTrades bool) (depositAddr string, err error) {
 	if w.isDisabled() {
-		return "", fmt.Errorf(walletDisabledErrStr, strings.ToUpper(unbip(w.AssetID)))
+		return "", fmt.Errorf(walletDisabledErrStr, w.Symbol)
 	}
 
 	err = w.Connect() // ensures valid deposit address
 	if err != nil {
-		return "", codedError(connectWalletErr, err)
+		return "", newError(connectWalletErr, "failed to connect %s wallet: %w", w.Symbol, err)
 	}
 
 	// This may be a wallet that does not require a password, so we can attempt

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -340,7 +340,7 @@ func (w *xcWallet) Connect() error {
 	// ConnectOnce so that the ConnectionMaster's On method will report false.
 	err := w.connector.ConnectOnce(context.Background())
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: %w", unbip(w.AssetID), err)
 	}
 	// Now that we are connected, we must Disconnect if any calls fail below
 	// since we are considering this wallet not "hookedUp".
@@ -348,7 +348,7 @@ func (w *xcWallet) Connect() error {
 	synced, progress, err := w.SyncStatus()
 	if err != nil {
 		w.connector.Disconnect()
-		return err
+		return fmt.Errorf("%s: %w", unbip(w.AssetID), err)
 	}
 
 	w.mtx.Lock()
@@ -358,7 +358,7 @@ func (w *xcWallet) Connect() error {
 		haveAddress, err = w.OwnsDepositAddress(w.address)
 		if err != nil {
 			w.connector.Disconnect()
-			return err
+			return fmt.Errorf("%s: %w", unbip(w.AssetID), err)
 		}
 	}
 	if !haveAddress {


### PR DESCRIPTION
Resolves #2066.

<img width="414" alt="Wallet connection warning" src="https://user-images.githubusercontent.com/57448127/214295067-2fde09ff-0c55-4d52-8ef3-d4b231d0c870.png">
