### PR TITLE
client/core: remove the immutable trackedTrade.dc field

### DIFF
--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -91,11 +91,13 @@ func runCore() error {
 		closeFileLogger()
 	}()
 
+	coreLogger := logMaker.Logger("CORE")
+	core.UseLogger(coreLogger)
+
 	// Prepare the Core.
 	clientCore, err := core.New(&core.Config{
 		DBPath:             cfg.DBPath,
 		Net:                cfg.Net,
-		Logger:             logMaker.Logger("CORE"),
 		TorProxy:           cfg.TorProxy,
 		TorIsolation:       cfg.TorIsolation,
 		Onion:              cfg.Onion,

--- a/client/cmd/mmbot/main.go
+++ b/client/cmd/mmbot/main.go
@@ -110,10 +110,13 @@ func mainErr() error {
 		net = dex.Testnet
 	}
 
+	coreLogger := loggerMaker.Logger("CORE")
+	core.UseLogger(coreLogger)
+
 	c, err = core.New(&core.Config{
 		DBPath:   filepath.Join(coreDir, net.String(), "dexc.db"),
 		Net:      net,
-		Logger:   loggerMaker.NewLogger("CORE"),
+		Logger:   coreLogger,
 		Language: lang,
 	})
 	if err != nil {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -387,8 +387,8 @@ func newMatchNote(topic Topic, subject, details string, severity db.Severity, t 
 		Match: matchFromMetaMatchWithConfs(t.Order, &match.MetaMatch, swapConfs,
 			int64(t.metaData.FromSwapConf), counterConfs, int64(t.metaData.ToSwapConf),
 			int64(match.redemptionConfs), int64(match.redemptionConfsReq)),
-		Host:     t.dc.acct.host,
-		MarketID: marketName(t.Base(), t.Quote()),
+		Host:     t.host,
+		MarketID: t.mktID, // marketName(t.Base(), t.Quote())
 	}
 }
 

--- a/client/core/status.go
+++ b/client/core/status.go
@@ -202,7 +202,7 @@ func resolveMissedMakerAudit(dc *dexConnection, trade *trackedTrade, match *matc
 			match.MetaData.Proof.SelfRevoked = true
 			err = trade.db.UpdateMatch(&match.MetaMatch)
 			if err != nil {
-				trade.dc.log.Errorf("Error updating database for match %s: %v", match, err)
+				dc.log.Errorf("Error updating database for match %s: %v", match, err)
 			}
 		}
 	}()
@@ -245,7 +245,7 @@ func resolveMissedTakerAudit(dc *dexConnection, trade *trackedTrade, match *matc
 			match.MetaData.Proof.SelfRevoked = true
 			err = trade.db.UpdateMatch(&match.MetaMatch)
 			if err != nil {
-				trade.dc.log.Errorf("Error updating database for match %s: %v", match, err)
+				dc.log.Errorf("Error updating database for match %s: %v", match, err)
 			}
 		}
 	}()

--- a/dex/testing/loadbot/loadbot.go
+++ b/dex/testing/loadbot/loadbot.go
@@ -39,6 +39,7 @@ import (
 	_ "decred.org/dcrdex/client/asset/eth"
 	_ "decred.org/dcrdex/client/asset/ltc"
 	_ "decred.org/dcrdex/client/asset/zec"
+	"decred.org/dcrdex/client/core"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
 	"decred.org/dcrdex/dex/config"
@@ -631,6 +632,10 @@ func run() error {
 			defer proxy.Delete()
 		}
 	}
+
+	// Set core's package-level (default) logger
+	commonCoreLogger := loggerMaker.Logger("CORE[common]")
+	core.UseLogger(commonCoreLogger)
 
 	tStart := time.Now()
 


### PR DESCRIPTION
We have had difficulty with smaller/child types (like `trackedTrade`) carrying references to the larger/parent types (like `dexConnection`, `xcWallet`, etc.).  In addition, having these higher level types available to lower level types encourages some bad patterns that are difficult to break out of.

This removes the `*dexConnection` field from the `trackedTrade` type.

In doing this, I've also _provisionally_ created a default package-level logger for `core` since having logger fields has soured on me. The many `t.dc.log(...` occurrences is also a sign of the first issue this PR is addressing.  If we really have a problem with the package-level logger, we can make a logger field for `trackedTrade`.  However, I feel we have been bending over backwards to accommodate load testing utilities, while there are virtually no conceivable uses for an application with multiple instances of `Core` other than load testing utilities.  Even a production bot should have a single `Core` instances.  If it needs two, there should be two standalone apps.

@ukane-philemon re https://github.com/decred/dcrdex/pull/2019#discussion_r1086041439