### PR TITLE
client/core: resolve xcWallet.peerCount race

### DIFF
--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -238,11 +238,6 @@ func (w *xcWallet) unitInfo() dex.UnitInfo {
 
 // state returns the current WalletState.
 func (w *xcWallet) state() *WalletState {
-	var peerCount uint32
-	if w.peerCount > 0 { // -1 initially
-		peerCount = uint32(w.peerCount)
-	}
-
 	winfo := w.Info()
 	lockable := w
 	if w.parent != nil {
@@ -251,6 +246,12 @@ func (w *xcWallet) state() *WalletState {
 
 	w.mtx.RLock()
 	defer w.mtx.RUnlock()
+
+	var peerCount uint32
+	if w.peerCount > 0 { // initialized to -1 initially, means no count yet
+		peerCount = uint32(w.peerCount)
+	}
+
 	return &WalletState{
 		Symbol:       unbip(w.AssetID),
 		AssetID:      w.AssetID,


### PR DESCRIPTION
Caught another race:

```
WARNING: DATA RACE
Read at 0x00c000a17888 by goroutine 1530:
  decred.org/dcrdex/client/core.(*xcWallet).state()
      /Users/norwnd/dcrdex/client/core/wallet.go:242 +0x67
  decred.org/dcrdex/client/core.(*Core).walletCheckAndNotify()
      /Users/norwnd/dcrdex/client/core/core.go:2704 +0x2ea
  decred.org/dcrdex/client/core.(*Core).startWalletSyncMonitor.func1()
      /Users/norwnd/dcrdex/client/core/core.go:2731 +0x2d2

Previous write at 0x00c000a17888 by goroutine 13933269:
  decred.org/dcrdex/client/core.(*Core).peerChange()
      /Users/norwnd/dcrdex/client/core/core.go:8418 +0x525
  decred.org/dcrdex/client/core.(*Core).loadWallet.func1.1()
      /Users/norwnd/dcrdex/client/core/core.go:2583 +0x6e
```

Here is the full log (I killed `dexc` with `kill -QUIT` to check for deadlocks also, because I had DCR wallet sync stuck at 99.9% for ~1h which resolved to 100% only after restarting `dexc`; could be because binary was built with `-race` that slowed it down or just some network lags on my side, I don't see obvious deadlocks in the printout, attaching just in case for future reference): [race-xcWallet-peerCount.txt](https://github.com/decred/dcrdex/files/10535116/race-xcWallet-peerCount.txt)

Seems like a pretty simple fix, no longer saw this race with changes in this PR.