### PR TITLE
client/eth: multiRPCClient.lastProvider race

### DIFF
--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -296,7 +296,7 @@ type multiRPCClient struct {
 	log     dex.Logger
 	chainID *big.Int
 
-	providerMtx sync.Mutex
+	providerMtx sync.RWMutex
 	endpoints   []string
 	providers   []*provider
 
@@ -735,8 +735,8 @@ func (m *multiRPCClient) getConfirmedNonce(ctx context.Context, blockNumber int6
 }
 
 func (m *multiRPCClient) providerList() []*provider {
-	m.providerMtx.Lock()
-	defer m.providerMtx.Unlock()
+	m.providerMtx.RLock()
+	defer m.providerMtx.RUnlock()
 
 	providers := make([]*provider, len(m.providers))
 	copy(providers, m.providers)
@@ -847,7 +847,7 @@ func (m *multiRPCClient) nonceProviderList() []*provider {
 	}
 	m.lastProvider.Unlock()
 
-	m.providerMtx.Lock()
+	m.providerMtx.RLock()
 	providers := make([]*provider, 0, len(m.providers))
 	for _, p := range m.providers {
 		if lastProvider != nil && lastProvider.host == p.host {
@@ -855,7 +855,7 @@ func (m *multiRPCClient) nonceProviderList() []*provider {
 		}
 		providers = append(providers, p)
 	}
-	m.providerMtx.Unlock()
+	m.providerMtx.RUnlock()
 
 	shuffleProviders(providers)
 
@@ -954,8 +954,8 @@ func (m *multiRPCClient) chainConfig() *params.ChainConfig {
 }
 
 func (m *multiRPCClient) peerCount() (c uint32) {
-	m.providerMtx.Lock()
-	defer m.providerMtx.Unlock()
+	m.providerMtx.RLock()
+	defer m.providerMtx.RUnlock()
 	for _, p := range m.providers {
 		if !p.failed() {
 			c++


### PR DESCRIPTION
Found another race:

```
WARNING: DATA RACE
Read at 0x00c000e82270 by goroutine 3921:
  decred.org/dcrdex/client/asset/eth.(*multiRPCClient).nonceProviderList()
      /Users/norwnd/dcrdex/client/asset/eth/multirpc.go:850 +0x178
  decred.org/dcrdex/client/asset/eth.(*multiRPCClient).withPreferred()
      /Users/norwnd/dcrdex/client/asset/eth/multirpc.go:837 +0x4e
  decred.org/dcrdex/client/asset/eth.(*multiRPCClient).CallContract()
      /Users/norwnd/dcrdex/client/asset/eth/multirpc.go:1149 +0x132
  github.com/ethereum/go-ethereum/accounts/abi/bind.(*BoundContract).Call()
      /Users/norwnd/go/pkg/mod/github.com/ethereum/go-ethereum@v1.10.25/accounts/abi/bind/base.go:186 +0x62c
  decred.org/dcrdex/dex/networks/eth/contracts/v0.(*ETHSwapCaller).Swap()
      /Users/norwnd/dcrdex/dex/networks/eth/contracts/v0/contract.go:296 +0x124
  decred.org/dcrdex/dex/networks/eth/contracts/v0.(*ETHSwap).Swap()
      <autogenerated>:1 +0xe4
  decred.org/dcrdex/client/asset/eth.(*contractorV0).swap()
      /Users/norwnd/dcrdex/client/asset/eth/contractor.go:181 +0x1fa
  decred.org/dcrdex/client/asset/eth.(*assetWallet).swap.func1()
      /Users/norwnd/dcrdex/client/asset/eth/eth.go:3680 +0xc4
  decred.org/dcrdex/client/asset/eth.(*assetWallet).withContractor()
      /Users/norwnd/dcrdex/client/asset/eth/eth.go:3784 +0x126
  decred.org/dcrdex/client/asset/eth.(*assetWallet).swap()
      /Users/norwnd/dcrdex/client/asset/eth/eth.go:3679 +0xe8
  decred.org/dcrdex/client/asset/eth.(*assetWallet).ContractLockTimeExpired()
      /Users/norwnd/dcrdex/client/asset/eth/eth.go:2296 +0x1dd
  decred.org/dcrdex/client/asset/eth.(*ETHWallet).ContractLockTimeExpired()
      <autogenerated>:1 +0xa4
  decred.org/dcrdex/client/core.(*trackedTrade).counterPartyConfirms()
      /Users/norwnd/dcrdex/client/core/trade.go:1088 +0x24c
  decred.org/dcrdex/client/core.(*trackedTrade).isSwappable()
      /Users/norwnd/dcrdex/client/core/trade.go:1325 +0x364
  decred.org/dcrdex/client/core.(*Core).tick.func2()
      /Users/norwnd/dcrdex/client/core/trade.go:1813 +0x2e4
  decred.org/dcrdex/client/core.(*Core).tick()
      /Users/norwnd/dcrdex/client/core/trade.go:1909 +0x5c1
  decred.org/dcrdex/client/core.(*Core).tickAsset.func1()
      /Users/norwnd/dcrdex/client/core/core.go:1159 +0x71

Previous write at 0x00c000e82270 by goroutine 3891:
  decred.org/dcrdex/client/asset/eth.(*multiRPCClient).sendSignedTransaction()
      /Users/norwnd/dcrdex/client/asset/eth/multirpc.go:1005 +0x14c
  decred.org/dcrdex/client/asset/eth.(*assetWallet).AuditContract.func1()
      /Users/norwnd/dcrdex/client/asset/eth/eth.go:2262 +0xe5
```

Added/updated mutex usage so that it shouldn't happen anymore.