### PR TITLE
client/rpcserver: Always add a new wallet config.

### DIFF
--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -312,6 +312,7 @@ func parseNewWalletArgs(params *RawParams) (*newWalletForm, error) {
 		walletType: params.Args[1],
 		walletPass: params.PWArgs[1],
 		assetID:    uint32(assetID),
+		config:     make(map[string]string),
 	}
 	if len(params.Args) > 2 {
 		req.config, err = config.Parse([]byte(params.Args[2]))


### PR DESCRIPTION
closes #2084

An oversight. There should always be a config. We check for keys later. 