### PR TITLE
client/btc: fix racing test

### DIFF
--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -357,7 +357,7 @@ func (c *tNeutrinoClient) GetBlockHash(blockHeight int64) (*chainhash.Hash, erro
 func (c *tNeutrinoClient) BestBlock() (*headerfs.BlockStamp, error) {
 	c.blockchainMtx.RLock()
 	if c.getBestBlockHashErr != nil {
-		c.blockchainMtx.RUnlock()
+		defer c.blockchainMtx.RUnlock() // reading c.getBestBlockHashErr below
 		return nil, c.getBestBlockHashErr
 	}
 	c.blockchainMtx.RUnlock()


### PR DESCRIPTION
Maybe resolves https://github.com/decred/dcrdex/issues/1268.

Looks like a typo that needs fixing regardless of whether or not it resolves 1268 (but it probably does as far as I can tell).