### PR TITLE
tests: repo-wide bandaid for rand.Seed badness

### DIFF
--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -21,10 +21,6 @@ import (
 	"go.etcd.io/bbolt"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 var (
 	tLogger = dex.StdOutLogger("db_TEST", dex.LevelTrace)
 )

--- a/dex/order/match_test.go
+++ b/dex/order/match_test.go
@@ -8,14 +8,13 @@ import (
 	"time"
 )
 
-// randomCommitment creates a random order commitment. If you require a matching
-// commitment, generate a Preimage, then Preimage.Commit().
-func randomCommitment() (com Commitment) {
-	rand.Read(com[:])
-	return
-}
-
 func TestMatchID(t *testing.T) {
+	rnd := rand.New(rand.NewSource(1))
+	randomCommitment := func() (com Commitment) {
+		rnd.Read(com[:])
+		return
+	}
+
 	// taker
 	marketID0, _ := hex.DecodeString("f1f4fb29235f5eeef55b27d909aac860828f6cf45f0b0fab92c6265844c50e54")
 	var marketID OrderID

--- a/server/auth/cancel_test.go
+++ b/server/auth/cancel_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	crand "crypto/rand"
 	"math/rand"
 	"sort"
 	"testing"
@@ -10,7 +11,7 @@ import (
 )
 
 func randomOrderID() (oid order.OrderID) {
-	rand.Read(oid[:])
+	crand.Read(oid[:])
 	return
 }
 
@@ -79,8 +80,6 @@ func Test_latestOrders(t *testing.T) {
 	if cancels != 1 {
 		t.Errorf("expected 1 cancels, got %d", total)
 	}
-
-	rand.Seed(1324)
 
 	for i := total; i < int(cap); i++ {
 		ts++

--- a/server/coinlock/coinlocker_test.go
+++ b/server/coinlock/coinlocker_test.go
@@ -1,6 +1,7 @@
 package coinlock
 
 import (
+	crand "crypto/rand"
 	"math/rand"
 	"testing"
 
@@ -10,7 +11,7 @@ import (
 
 func randomBytes(len int) []byte {
 	bytes := make([]byte, len)
-	rand.Read(bytes)
+	crand.Read(bytes)
 	return bytes
 }
 
@@ -50,8 +51,6 @@ func verifyLocked(cl CoinLockChecker, coins []CoinID, wantLocked bool, t *testin
 }
 
 func Test_swapLocker_LockOrderCoins(t *testing.T) {
-	rand.Seed(0)
-
 	w := &test.Writer{
 		Addr: "asdf",
 		Acct: test.NextAccount(),
@@ -145,8 +144,6 @@ func Test_swapLocker_LockOrderCoins(t *testing.T) {
 func Test_bookLocker_LockCoins(t *testing.T) {
 	masterLock := NewMasterCoinLocker()
 	bookLock := masterLock.Book()
-
-	rand.Seed(0)
 
 	coinMap := make(map[order.OrderID][]CoinID)
 	var allCoins []CoinID

--- a/server/market/integ/booker_matcher_test.go
+++ b/server/market/integ/booker_matcher_test.go
@@ -23,6 +23,8 @@ var acct0 = account.AccountID{
 	0x46, 0x34, 0xe9, 0x1c, 0xec, 0x25, 0xd5, 0x40, // 32 bytes
 }
 
+var rnd = rand.New(rand.NewSource(1))
+
 const (
 	AssetDCR uint32 = iota
 	AssetBTC
@@ -39,7 +41,7 @@ func startLogger() {
 }
 
 func randomPreimage() (pe order.Preimage) {
-	rand.Read(pe[:])
+	rnd.Read(pe[:])
 	return
 }
 
@@ -243,7 +245,7 @@ func TestMatchWithBook_limitsOnly(t *testing.T) {
 	// New matching engine.
 	me := matcher.New()
 
-	rand.Seed(0)
+	rnd.Seed(0)
 
 	badLotsizeOrder := newLimit(false, 05000000, 1, order.ImmediateTiF, 0)
 	badLotsizeOrder.Order.(*order.LimitOrder).Quantity /= 2
@@ -497,7 +499,7 @@ func TestMatchWithBook_limitsOnly_multipleQueued(t *testing.T) {
 	// New matching engine.
 	me := matcher.New()
 
-	rand.Seed(0)
+	rnd.Seed(0)
 
 	// epochQueue is heterogenous w.r.t. type
 	epochQueue := []*matcher.OrderRevealed{
@@ -733,7 +735,7 @@ func TestMatch_cancelOnly(t *testing.T) {
 	// New matching engine.
 	me := matcher.New()
 
-	rand.Seed(0)
+	rnd.Seed(0)
 
 	fakeOrder := newLimitOrder(false, 4550000, 1, order.ImmediateTiF, 0)
 	fakeOrder.ServerTime = time.Unix(1566497654, 0)
@@ -863,7 +865,7 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 	// New matching engine.
 	me := matcher.New()
 
-	rand.Seed(0)
+	rnd.Seed(0)
 
 	badLotsizeOrder := newMarketSell(1, 0)
 	badLotsizeOrder.Order.(*order.MarketOrder).Quantity /= 2
@@ -1118,7 +1120,7 @@ func TestMatch_marketBuysOnly(t *testing.T) {
 	// New matching engine.
 	me := matcher.New()
 
-	rand.Seed(0)
+	rnd.Seed(0)
 
 	nSell := len(bookSellOrders)
 	//nBuy := len(bookBuyOrders)
@@ -1293,7 +1295,7 @@ func TestMatchWithBook_everything_multipleQueued(t *testing.T) {
 	// New matching engine.
 	me := matcher.New()
 
-	rand.Seed(12)
+	rnd.Seed(12)
 
 	nSell := len(bookSellOrders)
 	nBuy := len(bookBuyOrders)

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -380,11 +380,11 @@ func TestMarket_NewMarket_BookOrders(t *testing.T) {
 	}
 	cleanup()
 
-	rand.Seed(12)
+	rnd.Seed(12)
 
 	randCoinDCR := func() []byte {
 		coinID := make([]byte, 36)
-		rand.Read(coinID[:])
+		rnd.Read(coinID[:])
 		return coinID
 	}
 
@@ -442,7 +442,7 @@ func TestMarket_Book(t *testing.T) {
 	}
 	defer cleanup()
 
-	rand.Seed(0)
+	rnd.Seed(0)
 
 	// Fill the book.
 	for i := 0; i < 8; i++ {
@@ -1218,7 +1218,7 @@ func TestMarket_enqueueEpoch(t *testing.T) {
 	}
 	defer cleanup()
 
-	rand.Seed(0) // deterministic random data
+	rnd.Seed(0) // deterministic random data
 
 	// Fill the book. Preimages not needed for these.
 	for i := 0; i < 8; i++ {
@@ -1605,7 +1605,7 @@ func TestMarket_Cancelable(t *testing.T) {
 
 func TestMarket_handlePreimageResp(t *testing.T) {
 	randomCommit := func() (com order.Commitment) {
-		rand.Read(com[:])
+		rnd.Read(com[:])
 		return
 	}
 

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -114,6 +114,8 @@ var (
 	}
 )
 
+var rnd = rand.New(rand.NewSource(1))
+
 func nowMs() time.Time {
 	return time.Now().Truncate(time.Millisecond).UTC()
 }
@@ -627,7 +629,7 @@ var assetUnknown = &asset.BackedAsset{
 
 func randomBytes(len int) []byte {
 	bytes := make([]byte, len)
-	rand.Read(bytes)
+	rnd.Read(bytes)
 	return bytes
 }
 
@@ -661,6 +663,8 @@ func TestMain(m *testing.M) {
 	book.UseLogger(logger)
 	matcher.UseLogger(logger)
 	swap.UseLogger(logger)
+
+	ordertest.UseRand(rnd) // yuk, but we have old tests with deterministic sequences from math/rand that I'm not rewriting now
 
 	privKey, _ := secp256k1.GeneratePrivateKey()
 	auth := &TAuth{
@@ -1417,11 +1421,11 @@ func testPrefixTrade(prefix *msgjson.Prefix, trade *msgjson.Trade, fundingAsset,
 
 // nolint:unparam
 func randLots(max int) uint64 {
-	return uint64(rand.Intn(max) + 1)
+	return uint64(rnd.Intn(max) + 1)
 }
 
 func randRate(baseRate, lotSize uint64, min, max float64) uint64 {
-	multiplier := rand.Float64()*(max-min) + min
+	multiplier := rnd.Float64()*(max-min) + min
 	rate := uint64(multiplier * float64(baseRate))
 	return rate - rate%lotSize
 }

--- a/server/matcher/match_test.go
+++ b/server/matcher/match_test.go
@@ -29,8 +29,10 @@ const (
 	LotSize = uint64(10 * 1e8)
 )
 
+var rnd = rand.New(rand.NewSource(1))
+
 func randomPreimage() (pe order.Preimage) {
-	rand.Read(pe[:])
+	rnd.Read(pe[:])
 	return
 }
 
@@ -537,7 +539,7 @@ func TestMatch_cancelOnly(t *testing.T) {
 	// New matching engine.
 	me := New()
 
-	rand.Seed(1212121)
+	rnd.Seed(1212121)
 
 	fakeOrder := newLimitOrder(false, 4550000, 1, order.ImmediateTiF, 0)
 	fakeOrder.ServerTime = time.Now()
@@ -692,7 +694,7 @@ func TestMatch_limitsOnly(t *testing.T) {
 	// New matching engine.
 	me := New()
 
-	rand.Seed(1212121)
+	rnd.Seed(1212121)
 
 	badLotsizeOrder := newLimit(false, 05000000, 1, order.ImmediateTiF, 0)
 	badLotsizeOrder.Order.(*order.LimitOrder).Quantity /= 2
@@ -1004,7 +1006,7 @@ func TestMatch_marketSellsOnly(t *testing.T) {
 	// New matching engine.
 	me := New()
 
-	rand.Seed(1212121)
+	rnd.Seed(1212121)
 
 	badLotsizeOrder := newMarketSellOrder(1, 0)
 	badLotsizeOrder.Order.(*order.MarketOrder).Quantity /= 2
@@ -1315,7 +1317,7 @@ func TestMatch_marketBuysOnly(t *testing.T) {
 	// New matching engine.
 	me := New()
 
-	rand.Seed(1212121)
+	rnd.Seed(1212121)
 
 	nSell := len(bookSellOrders)
 


### PR DESCRIPTION
Early on we got in the habit of building tests on data with reproducible random sequences using the `math/rand` package's global `*math.Rand` instance, seeding it with some arbitrary hard coded numbers to get certain sequence.  That proved quite problematic for test maintenance, concurrency, and now the standard library rightly has deprecated the use of `rand.Seed` and they have made the default initialization actually random instead of with "1" as the seed.

> The [math/rand](https://go.dev/pkg/math/rand/) package now automatically seeds the global random number generator (used by top-level functions like Float64 and Int) with a random value, and the top-level [Seed](https://go.dev/pkg/math/rand/#Seed) function has been deprecated. Programs that need a reproducible sequence of random numbers should prefer to allocate their own random source, using rand.New(rand.NewSource(seed)).
> 
> Programs that need the earlier consistent global seeding behavior can set GODEBUG=randautoseed=0 in their environment.
> 
> The top-level [Read](https://go.dev/pkg/math/rand/#Read) function has been deprecated. In almost all cases, [crypto/rand.Read](https://go.dev/pkg/crypto/rand/#Read) is more appropriate.

This PR is a bandaid to get the test passing given the new random seeding of the package level `math/rand.Rand`.
We should look at rewriting some of these tests to not have unrecorded but expected magic values to produce certain test data set.

<s>We cannot support Go 1.20 yet, at least not in CI, because golangci-lint is getting patched up for a bug `ERRO [runner] Panic: buildir: package "netip" (isInitialPkg: false, needAnalyzeSource: true): in net/netip.AddrFromSlice: cannot convert Load <[]byte> t0 ([]byte) to [4]byte: goroutine 9489 [running]:`.  There's a PR up with a fix so we might be good to go soon.</s>  Go 1.20 PR in https://github.com/decred/dcrdex/pull/2100