### PR TITLE
ci: test with Go 1.20 and 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.18, 1.19]
+        go: ['1.19', '1.20']
     steps:
       - name: Set up Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a #v3.2.1
@@ -18,7 +18,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1"
 
       - name: Test
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
         go: ['1.19', '1.20']
     steps:
       - name: Set up Go
-        uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a #v3.2.1
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
         with:
           go-version: ${{ matrix.go }}
 
       - name: Check out source
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
       - name: Install Linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1"
 
@@ -34,9 +34,9 @@ jobs:
       matrix:
         node-version: [16.x, 18.x]
     steps:
-    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
     - name: Use nodejs ${{ matrix.node-version }}
-      uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 #v3.5.1
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c #v3.6.0
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm clean-install
@@ -52,7 +52,7 @@ jobs:
     name: Lint Markdown
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
     - uses: DavidAnson/markdownlint-cli2-action@d57f8bd57670b9c1deedf71219dd494614ff3335 #v8
       continue-on-error: true
       with:

--- a/client/core/bot.go
+++ b/client/core/bot.go
@@ -1247,7 +1247,7 @@ func (c *Core) feeEstimates(form *TradeForm) (swapFees, redeemFees uint64, err e
 			if err2 != nil {
 				return 0, 0, fmt.Errorf("error getting swap estimate (%v) and single-lot estimate (%v)", err, err2)
 			}
-			err = nil
+			// err = nil // ineffassign
 		} else {
 			return 0, 0, fmt.Errorf("error getting swap estimate: %w", err)
 		}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -18,7 +18,7 @@ do
 
 	# Run `go mod tidy` and fail if the git status of go.mod and/or
 	# go.sum changes. Only do this for the latest Go version.
-	if [[ "$GV" =~ ^1.19 ]]; then
+	if [[ "$GV" =~ ^1.20 ]]; then
 		MOD_STATUS=$(git status --porcelain go.mod go.sum)
 		go mod tidy
 		UPDATED_MOD_STATUS=$(git status --porcelain go.mod go.sum)

--- a/server/db/driver/pg/internal/matches.go
+++ b/server/db/driver/pg/internal/matches.go
@@ -78,7 +78,7 @@ const (
 		$3, $4, $5,
 		$6, $7, $8,
 		$9, $10,
-		$11, $12, $13, $14, $15) `  // do not terminate with ;
+		$11, $12, $13, $14, $15) ` // do not terminate with ;
 
 	UpsertMatch = InsertMatch + ` ON CONFLICT (matchid) DO
 	UPDATE SET quantity = $11, status = $15;`
@@ -92,7 +92,7 @@ const (
 			$2, $3,
 			$4, $5,
 			$6, $7,
-			$8, $9, $10) `  // status should be MatchComplete although there is no swap
+			$8, $9, $10) ` // status should be MatchComplete although there is no swap
 
 	UpsertCancelMatch = InsertCancelMatch + ` ON CONFLICT (matchid) DO NOTHING;`
 

--- a/server/db/driver/pg/internal/orders.go
+++ b/server/db/driver/pg/internal/orders.go
@@ -53,7 +53,7 @@ const (
 	WHERE account_id = $1
 		AND status >= 0         -- exclude forgiven
 	ORDER BY epochCloseTime DESC
-	LIMIT $2`  // no ;
+	LIMIT $2` // no ;
 	// NOTE: we could join with the epochs table if we really want match_time instead of epoch close time
 
 	// SelectUserOrders retrieves all columns of all orders for the given
@@ -80,7 +80,7 @@ const (
 		JOIN %[2]s ON %[2]s.epoch_idx = %[1]s.epoch_idx AND %[2]s.epoch_dur = %[1]s.epoch_dur -- join on epochs table PK
 		WHERE account_id = $1 AND status = ANY($2) -- {orderStatusCanceled, orderStatusRevoked}
 		ORDER BY match_time DESC
-		LIMIT $3;`  // The matchTime is when the order was booked, not canceled!!!
+		LIMIT $3;` // The matchTime is when the order was booked, not canceled!!!
 
 	// SelectOrderByCommit retrieves the order ID for any order with the given
 	// commitment value. This applies to the cancel order tables as well.
@@ -199,7 +199,7 @@ const (
 		AND commit IS NOT NULL  -- commit NOT NULL to exclude server-generated cancels
 		AND status >= 0         -- not forgiven
 	ORDER BY epochCloseTime DESC
-	LIMIT $2`  // no ;
+	LIMIT $2` // no ;
 
 	// SelectRevokeCancels retrieves server-initiated cancels (revokes).
 	SelectRevokeCancels = `SELECT oid, target_order, server_time, epoch_idx
@@ -227,7 +227,7 @@ const (
 		JOIN %[2]s ON %[2]s.epoch_idx = %[1]s.epoch_idx AND %[2]s.epoch_dur = %[1]s.epoch_dur -- join on epochs table PK
 		WHERE account_id = $1 AND status = $2
 		ORDER BY match_time DESC
-		LIMIT $3;`  // NOTE: find revoked orders via SelectRevokeCancels
+		LIMIT $3;` // NOTE: find revoked orders via SelectRevokeCancels
 
 	// InsertCancelOrder inserts a cancel order row into the specified table.
 	InsertCancelOrder = `INSERT INTO %s (oid, account_id, client_time, server_time,


### PR DESCRIPTION
Rebased on https://github.com/decred/dcrdex/pull/2098, this switches CI to use Go 1.19 and Go 1.20, dropping 1.18.

https://github.com/decred/dcrdex/pull/2100/commits/8af52e32aed67c6d929bcce9f118d2bec88dea28

This does not however update the go.mod files.  Those still require at least 1.18, for now.