### PR TITLE
client: bond reserves

### DIFF
--- a/client/asset/dcr/coin_selection.go
+++ b/client/asset/dcr/coin_selection.go
@@ -1,0 +1,210 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package dcr
+
+import (
+	"sort"
+
+	"decred.org/dcrdex/dex/calc"
+	dexdcr "decred.org/dcrdex/dex/networks/dcr"
+)
+
+// sendEnough generates a function that can be used as the enough argument to
+// the fund method when creating transactions to send funds. If fees are to be
+// subtracted from the inputs, set subtract so that the required amount excludes
+// the transaction fee. If change from the transaction should be considered
+// immediately available (not mixing), set reportChange to indicate this and the
+// returned enough func will return a non-zero excess value. Otherwise, the
+// enough func will always return 0, leaving only unselected UTXOs to cover any
+// required reserves.
+func sendEnough(amt, feeRate uint64, subtract bool, baseTxSize uint32, reportChange bool) func(sum uint64, inputSize uint32, unspent *compositeUTXO) (bool, uint64) {
+	return func(sum uint64, inputSize uint32, unspent *compositeUTXO) (bool, uint64) {
+		total := sum + toAtoms(unspent.rpc.Amount)
+		txFee := uint64(baseTxSize+inputSize+unspent.input.Size()) * feeRate
+		req := amt
+		if !subtract { // add the fee to required
+			req += txFee
+		}
+		if total < req {
+			return false, 0
+		}
+		excess := total - req
+		if subtract && excess > txFee {
+			excess -= txFee // total - (req + txFee), without underflow
+		}
+		if !reportChange || dexdcr.IsDustVal(dexdcr.P2PKHOutputSize, excess, feeRate) {
+			excess = 0
+		}
+		return true, excess
+	}
+}
+
+// orderEnough generates a function that can be used as the enough argument to
+// the fund method. If change from a split transaction will be created AND
+// immediately available (not mixing), set reportChange to indicate this and the
+// returned enough func will return a non-zero excess value reflecting this
+// potential spit tx change. Otherwise, the enough func will always return 0,
+// leaving only unselected UTXOs to cover any required reserves.
+func orderEnough(val, lots, feeRate uint64, reportChange bool) func(sum uint64, size uint32, unspent *compositeUTXO) (bool, uint64) {
+	return func(sum uint64, size uint32, unspent *compositeUTXO) (bool, uint64) {
+		reqFunds := calc.RequiredOrderFundsAlt(val, uint64(size+unspent.input.Size()), lots,
+			dexdcr.InitTxSizeBase, dexdcr.InitTxSize, feeRate)
+		total := sum + toAtoms(unspent.rpc.Amount) // all selected utxos
+
+		if total >= reqFunds { // that'll do it
+			// change = total - (val + swapTxnsFee)
+			excess := total - reqFunds // reqFunds = val + swapTxnsFee
+			if !reportChange || dexdcr.IsDustVal(dexdcr.P2PKHOutputSize, excess, feeRate) {
+				excess = 0
+			}
+			return true, excess
+		}
+		return false, 0
+	}
+}
+
+func sumUTXOs(set []*compositeUTXO) (tot uint64) {
+	for _, utxo := range set {
+		tot += toAtoms(utxo.rpc.Amount)
+	}
+	return tot
+}
+
+// In the following utxo selection functions, the compositeUTXO slice MUST be
+// sorted in ascending order (smallest first, largest last).
+
+// subsetLargeBias begins by summing from the largest UTXO down until the sum is
+// just below the requested amount. Then it picks the (one) final UTXO that
+// reaches the amount with the least excess. Each utxo in the input must be
+// smaller than amt - use via leastOverFund only!
+func subsetLargeBias(amt uint64, utxos []*compositeUTXO) []*compositeUTXO {
+	// Add from largest down until sum is *just under*. Resulting sum will be
+	// less, and index will be the next (smaller) element that would hit amt.
+	var sum uint64
+	var i int
+	for i = len(utxos) - 1; i >= 0; i-- {
+		this := toAtoms(utxos[i].rpc.Amount) // must not be >= amt
+		if sum+this >= amt {
+			break
+		}
+		sum += this
+	}
+
+	if i == -1 { // full set used
+		// if sum >= amt { return utxos } // would have been i>=0 after break above
+		return nil
+	}
+	// if i == len(utxos)-1 { return utxos[i:] } // shouldn't happen if each in set are < amt
+
+	// Find the last one to meet amt, as small as possible.
+	rem, set := utxos[:i+1], utxos[i+1:]
+	idx := sort.Search(len(rem), func(i int) bool {
+		return sum+toAtoms(rem[i].rpc.Amount) >= amt
+	})
+
+	return append([]*compositeUTXO{rem[idx]}, set...)
+}
+
+// subsetSmallBias begins by summing from the smallest UTXO up until the sum is
+// at least the requested amount. Then it drops the smallest ones it had
+// selected if they are not required to reach the amount.
+func subsetSmallBias(amt uint64, utxos []*compositeUTXO) []*compositeUTXO {
+	// Add from smallest up until sum is enough.
+	var sum uint64
+	var idx int
+	for i, utxo := range utxos {
+		sum += toAtoms(utxo.rpc.Amount)
+		if sum >= amt {
+			idx = i
+			break
+		}
+	}
+	if sum < amt {
+		return nil
+	}
+	set := utxos[:idx+1]
+
+	// Now drop excess small ones.
+	for i, utxo := range set {
+		sum -= toAtoms(utxo.rpc.Amount)
+		if sum < amt {
+			idx = i // needed this one
+			break
+		}
+	}
+	return set[idx:]
+}
+
+// leastOverFund attempts to pick a subset of the provided UTXOs to reach the
+// required amount with the objective of minimizing the total amount of the
+// selected UTXOs. This is different from the objective used when funding
+// orders, which is to minimize the number of UTXOs (to minimize fees).
+//
+// The UTXOs MUST be sorted in ascending order (smallest first, largest last)!
+//
+// This begins by partitioning the slice before the smallest single UTXO that is
+// large enough to fully fund the requested amount, if it exists. If the smaller
+// set is insufficient, the single largest UTXO is returned. If instead the set
+// of smaller UTXOs has enough total value, it will search for a subset that
+// reaches the amount with least over-funding (see subsetSmallBias and
+// subsetLargeBias). If that subset has less combined value than the single
+// sufficiently-large UTXO (if it exists), the subset will be returned,
+// otherwise the single UTXO will be returned.
+//
+// If the provided UTXO set has less combined value than the requested amount a
+// nil slice is returned.
+func leastOverFund(amt uint64, utxos []*compositeUTXO) []*compositeUTXO {
+	if amt == 0 || sumUTXOs(utxos) < amt {
+		return nil
+	}
+
+	// Partition - smallest UTXO that is large enough to fully fund, and the set
+	// of smaller ones.
+	idx := sort.Search(len(utxos), func(i int) bool {
+		return toAtoms(utxos[i].rpc.Amount) >= amt
+	})
+	var small []*compositeUTXO
+	var single *compositeUTXO // only return this if smaller ones would use more
+	if idx == len(utxos) {    // no one is enough
+		small = utxos
+	} else {
+		small = utxos[:idx]
+		single = utxos[idx]
+	}
+
+	// Find a subset of the small UTXO set with smallest combined amount.
+	var set []*compositeUTXO
+	if sumUTXOs(small) >= amt {
+		set = subsetLargeBias(amt, small)
+		setX := subsetSmallBias(amt, small)
+		if sumUTXOs(setX) < sumUTXOs(set) {
+			set = setX
+		}
+	} else if single != nil {
+		return []*compositeUTXO{single}
+	}
+
+	// Return the small UTXO subset if it is less than the single big UTXO.
+	if single != nil && toAtoms(single.rpc.Amount) < sumUTXOs(set) {
+		return []*compositeUTXO{single}
+	}
+	return set
+}
+
+// utxoSetDiff performs the setdiff(set,sub) of two UTXO sets. That is, any
+// UTXOs that are both sets are removed from the first. The comparison is done
+// *by pointer*, with no regard to the values of the compositeUTXO elements.
+func utxoSetDiff(set, sub []*compositeUTXO) []*compositeUTXO {
+	var availUTXOs []*compositeUTXO
+avail:
+	for _, utxo := range set {
+		for _, kept := range sub {
+			if utxo == kept { // by pointer
+				continue avail
+			}
+		}
+		availUTXOs = append(availUTXOs, utxo)
+	}
+	return availUTXOs
+}

--- a/client/asset/dcr/coin_selection_test.go
+++ b/client/asset/dcr/coin_selection_test.go
@@ -1,0 +1,333 @@
+package dcr
+
+import (
+	"math/rand"
+	"reflect"
+	"testing"
+
+	walletjson "decred.org/dcrwallet/v2/rpc/jsonrpc/types"
+)
+
+func Test_subsetLargeBias(t *testing.T) {
+	amt := uint64(10e8)
+	newU := func(amt float64) *compositeUTXO {
+		return &compositeUTXO{
+			rpc: &walletjson.ListUnspentResult{Amount: amt},
+		}
+	}
+	tests := []struct {
+		name  string
+		utxos []*compositeUTXO
+		want  []*compositeUTXO
+	}{
+		{
+			"1,3 exact",
+			[]*compositeUTXO{newU(1), newU(8), newU(9)},
+			[]*compositeUTXO{newU(1), newU(9)},
+		},
+		{
+			"subset large bias",
+			[]*compositeUTXO{newU(1), newU(3), newU(6), newU(7)},
+			[]*compositeUTXO{newU(3), newU(7)},
+		},
+		{
+			"subset large bias",
+			[]*compositeUTXO{newU(1), newU(3), newU(5), newU(7), newU(8)},
+			[]*compositeUTXO{newU(3), newU(8)},
+		},
+		{
+			"insufficient",
+			[]*compositeUTXO{newU(1), newU(8)},
+			nil,
+		},
+		{
+			"all exact",
+			[]*compositeUTXO{newU(1), newU(9)},
+			[]*compositeUTXO{newU(1), newU(9)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := subsetLargeBias(amt, tt.utxos); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("subset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_subsetSmallBias(t *testing.T) {
+	amt := uint64(10e8)
+	newU := func(amt float64) *compositeUTXO {
+		return &compositeUTXO{
+			rpc: &walletjson.ListUnspentResult{Amount: amt},
+		}
+	}
+	tests := []struct {
+		name  string
+		utxos []*compositeUTXO
+		want  []*compositeUTXO
+	}{
+		{
+			"1,3",
+			[]*compositeUTXO{newU(1), newU(8), newU(9)},
+			[]*compositeUTXO{newU(8), newU(9)},
+		},
+		{
+			"subset",
+			[]*compositeUTXO{newU(1), newU(9), newU(11)},
+			[]*compositeUTXO{newU(1), newU(9)},
+		},
+		{
+			"subset small bias",
+			[]*compositeUTXO{newU(1), newU(3), newU(6), newU(7)},
+			[]*compositeUTXO{newU(1), newU(3), newU(6)},
+		},
+		{
+			"subset small bias",
+			[]*compositeUTXO{newU(1), newU(3), newU(5), newU(7), newU(8)},
+			[]*compositeUTXO{newU(5), newU(7)},
+		},
+		{
+			"ok nil",
+			[]*compositeUTXO{newU(1), newU(8)},
+			nil,
+		},
+		{
+			"two, over",
+			[]*compositeUTXO{newU(5), newU(7), newU(11)},
+			[]*compositeUTXO{newU(5), newU(7)},
+		},
+		{
+			"insufficient",
+			[]*compositeUTXO{newU(1), newU(8)},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := subsetSmallBias(amt, tt.utxos); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("subset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_leastOverFund(t *testing.T) {
+	amt := uint64(10e8)
+	newU := func(amt float64) *compositeUTXO {
+		return &compositeUTXO{
+			rpc: &walletjson.ListUnspentResult{Amount: amt},
+		}
+	}
+	tests := []struct {
+		name  string
+		utxos []*compositeUTXO
+		want  []*compositeUTXO
+	}{
+		{
+			"1,3",
+			[]*compositeUTXO{newU(1), newU(8), newU(9)},
+			[]*compositeUTXO{newU(1), newU(9)},
+		},
+		{
+			"1,2",
+			[]*compositeUTXO{newU(1), newU(9)},
+			[]*compositeUTXO{newU(1), newU(9)},
+		},
+		{
+			"1,2++",
+			[]*compositeUTXO{newU(2), newU(9)},
+			[]*compositeUTXO{newU(2), newU(9)},
+		},
+		{
+			"2,3++",
+			[]*compositeUTXO{newU(0), newU(2), newU(9)},
+			[]*compositeUTXO{newU(2), newU(9)},
+		},
+		{
+			"3",
+			[]*compositeUTXO{newU(0), newU(2), newU(10)},
+			[]*compositeUTXO{newU(10)},
+		},
+		{
+			"subset",
+			[]*compositeUTXO{newU(1), newU(9), newU(11)},
+			[]*compositeUTXO{newU(1), newU(9)},
+		},
+		{
+			"subset small bias",
+			[]*compositeUTXO{newU(1), newU(3), newU(6), newU(7)},
+			[]*compositeUTXO{newU(3), newU(7)},
+		},
+		{
+			"single exception",
+			[]*compositeUTXO{newU(5), newU(7), newU(11)},
+			[]*compositeUTXO{newU(11)},
+		},
+		{
+			"1 of 1",
+			[]*compositeUTXO{newU(10)},
+			[]*compositeUTXO{newU(10)},
+		},
+		{
+			"ok nil",
+			[]*compositeUTXO{newU(1), newU(8)},
+			nil,
+		},
+		{
+			"ok",
+			[]*compositeUTXO{newU(1)},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := leastOverFund(amt, tt.utxos); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("subset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Fuzz_leastOverFund(f *testing.F) {
+	seeds := []struct {
+		amt uint64
+		n   int
+	}{{
+		amt: 200,
+		n:   2,
+	}, {
+		amt: 20,
+		n:   1,
+	}, {
+		amt: 20,
+		n:   20,
+	}, {
+		amt: 2,
+		n:   40,
+	}}
+
+	for _, seed := range seeds {
+		f.Add(seed.amt, seed.n)
+	}
+
+	newU := func(amt float64) *compositeUTXO {
+		return &compositeUTXO{
+			rpc: &walletjson.ListUnspentResult{Amount: amt},
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, amt uint64, n int) {
+		if n < 1 || n > 65535 || amt == 0 || amt > 21e6 {
+			t.Skip()
+		}
+		m := 2 * amt / uint64(n)
+		utxos := make([]*compositeUTXO, n)
+		for i := range utxos {
+			var v float64
+			if rand.Intn(2) > 0 {
+				v = rand.Float64()
+			}
+			if m != 0 {
+				v += float64(rand.Int63n(int64(m)))
+			}
+			if v > 40000 {
+				t.Skip()
+			}
+			utxos[i] = newU(v)
+		}
+		leastOverFund(amt*1e8, utxos)
+	})
+}
+
+func Test_utxoSetDiff(t *testing.T) {
+	newU := func(amt float64) *compositeUTXO {
+		return &compositeUTXO{
+			rpc: &walletjson.ListUnspentResult{Amount: amt},
+		}
+	}
+
+	all := []*compositeUTXO{newU(1), newU(3), newU(6), newU(7), newU(12)}
+
+	sub := func(inds []int) []*compositeUTXO {
+		out := make([]*compositeUTXO, len(inds))
+		for i, ind := range inds {
+			out[i] = all[ind]
+		}
+		return out
+	}
+
+	checkPtrs := func(a, b []*compositeUTXO) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	tests := []struct {
+		name string
+		set  []*compositeUTXO
+		sub  []*compositeUTXO
+		want []*compositeUTXO
+	}{
+		{
+			"one",
+			sub([]int{0, 1}),
+			sub([]int{1}),
+			sub([]int{0}),
+		}, {
+			"none",
+			sub([]int{0, 1}),
+			sub([]int{2}),
+			sub([]int{0, 1}),
+		}, {
+			"some",
+			sub([]int{0, 1}),
+			sub([]int{1, 2}),
+			sub([]int{0}),
+		}, {
+			"both all / nil",
+			sub([]int{0, 1}),
+			sub([]int{0, 1}),
+			nil,
+		}, {
+			"one all / nil",
+			sub([]int{0}),
+			sub([]int{0}),
+			nil,
+		}, {
+			"bigger sub, all",
+			sub([]int{0, 1}),
+			sub([]int{0, 1, 2}),
+			nil,
+		}, {
+			"nil set",
+			nil,
+			sub([]int{0, 1, 2}),
+			nil,
+		}, {
+			"nil sub",
+			sub([]int{0, 1, 2}),
+			nil,
+			sub([]int{0, 1, 2}),
+		}, {
+			"nil both",
+			nil,
+			nil,
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := utxoSetDiff(tt.set, tt.sub)
+			if !checkPtrs(got, tt.want) {
+				t.Errorf("utxoSetDiff() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -227,24 +227,12 @@ func TestMakeBondTx(t *testing.T) {
 	mineAlpha()
 	waitNetwork() // wait for beta to see the new block (bond must be mined for RefundBond)
 
-	refundTxNew, err := wallet.RefundBond(context.Background(), bondVer, bond.CoinID,
+	refundCoin, err := wallet.RefundBond(context.Background(), bondVer, bond.CoinID,
 		bond.Data, bond.Amount, priv)
 	if err != nil {
 		t.Fatalf("RefundBond: %v", err)
 	}
-	t.Logf("refundTxNew: %x\n", refundTxNew)
-
-	// Send it, but note that since lock time is not passed this is still
-	// non-standard and won't yet propagate on mainnet.
-	refundCoin, err := wallet.SendTransaction(refundTxNew)
-	if err != nil {
-		t.Fatalf("SendTransaction: %v", err)
-	}
-	refundCoinTxid, _, err := decodeCoinID(refundCoin)
-	if err != nil {
-		t.Fatalf("decodeCoinID: %v", err)
-	}
-	t.Log(refundCoinTxid)
+	t.Logf("refundCoin: %v\n", refundCoin)
 }
 
 func TestWallet(t *testing.T) {

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -178,7 +178,7 @@ func TestMakeBondTx(t *testing.T) {
 	}
 
 	lockTime := time.Now().Add(5 * time.Minute)
-	bond, err := wallet.MakeBondTx(bondVer, fee, 10, lockTime, priv, acctID)
+	bond, _, err := wallet.MakeBondTx(bondVer, fee, 10, lockTime, priv, acctID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -476,6 +476,26 @@ type Broadcaster interface {
 type Bonder interface {
 	Broadcaster
 
+	// RegisterUnspent informs the wallet of a certain amount already locked in
+	// unspent bonds that will eventually be refunded with RefundBond. This
+	// should be used prior to ReserveBondFunds. This alone does not enable
+	// reserves enforcement, and it should be called on bring-up when existing
+	// bonds that may refund to this wallet are known. Once ReserveBondFunds is
+	// called, these live bond amounts will become enforced reserves when they
+	// are refunded via RefundBond.
+	RegisterUnspent(live uint64)
+	// ReserveBondFunds (un)reserves funds for creation of future bonds.
+	// MakeBondTx will create transactions that decrease these reserves, while
+	// RefundBond will replenish the reserves. If the wallet's available balance
+	// should be respected when adding reserves, the boolean argument may be set
+	// to indicate this, in which case the return value indicates if it was able
+	// to reserve the funds. In this manner, funds may be pre-reserved so that
+	// when the wallet receives funds (from either external deposits or
+	// refunding of live bonds), they will go directly into locked balance. When
+	// the reserves are decremented to zero (by the amount that they were
+	// incremented), all enforcement including any fee buffering is disabled.
+	ReserveBondFunds(future int64, respectBalance bool) bool
+
 	// MakeBondTx authors a DEX time-locked fidelity bond transaction for the
 	// provided amount, lock time, and dex account ID. An explicit private key
 	// type is used to guarantee it's not bytes from something else like a

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -479,8 +479,12 @@ type Bonder interface {
 	// MakeBondTx authors a DEX time-locked fidelity bond transaction for the
 	// provided amount, lock time, and dex account ID. An explicit private key
 	// type is used to guarantee it's not bytes from something else like a
-	// public key.
-	MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Time, privKey *secp256k1.PrivateKey, acctID []byte) (*Bond, error)
+	// public key. If there are insufficient bond reserves, the returned error
+	// should be of kind asset.ErrInsufficientBalance. The returned function may
+	// be used to abandon the bond iff it has not yet been broadcast. Generally
+	// this means unlocking the funds that are used by the transaction and
+	// restoring consumed reserves amounts.
+	MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Time, privKey *secp256k1.PrivateKey, acctID []byte) (*Bond, func(), error)
 	// RefundBond will refund the bond given the full bond output details and
 	// private key to spend it. The bond is broadcasted.
 	RefundBond(ctx context.Context, ver uint16, coinID, script []byte, amt uint64, privKey *secp256k1.PrivateKey) (Coin, error)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -479,8 +479,8 @@ type Bonder interface {
 	// public key.
 	MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Time, privKey *secp256k1.PrivateKey, acctID []byte) (*Bond, error)
 	// RefundBond will refund the bond given the full bond output details and
-	// private key to spend it.
-	RefundBond(ctx context.Context, ver uint16, coinID, script []byte, amt uint64, privKey *secp256k1.PrivateKey) ([]byte, error)
+	// private key to spend it. The bond is broadcasted.
+	RefundBond(ctx context.Context, ver uint16, coinID, script []byte, amt uint64, privKey *secp256k1.PrivateKey) (Coin, error)
 
 	// A RefundBondByCoinID may be created in the future to attempt to refund a
 	// bond by locating it on chain, i.e. without providing the amount or

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -160,6 +160,9 @@ const (
 	// ErrWalletTypeDisabled inidicates that a wallet type is no longer
 	// available.
 	ErrWalletTypeDisabled = dex.ErrorKind("wallet type has been disabled")
+	// ErrInsufficientBalance is returned when there is insufficient available
+	// balance for an operation, such as reserving funds for future bonds.
+	ErrInsufficientBalance = dex.ErrorKind("insufficient available balance")
 
 	// InternalNodeLoggerName is the name for a logger that is used to fine
 	// tune log levels for only loggers using this name.

--- a/client/core/account.go
+++ b/client/core/account.go
@@ -54,9 +54,12 @@ func (c *Core) AccountDisable(pw []byte, addr string) error {
 		return newError(unknownDEXErr, "error retrieving dex conn: %w", err)
 	}
 
-	// Check active orders.
+	// Check active orders or bonds.
 	if dc.hasActiveOrders() {
 		return fmt.Errorf("cannot disable account with active orders")
+	}
+	if dc.hasUnspentBond() {
+		return fmt.Errorf("cannot disable account with unspent bonds")
 	}
 
 	err = c.db.DisableAccount(dc.acct.host)

--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -1359,9 +1359,11 @@ func (c *Core) bondExpired(dc *dexConnection, assetID uint32, coinID []byte, new
 			bondIDStr, unbip(assetID))
 	}
 
-	details := fmt.Sprintf("New tier = %d (target = %d).", newTier, targetTier)
-	c.notify(newBondPostNoteWithTier(TopicBondExpired, string(TopicBondExpired),
-		details, db.Success, dc.acct.host, newTier))
+	if targetTier > uint64(newTier) {
+		details := fmt.Sprintf("New tier = %d (target = %d).", newTier, targetTier)
+		c.notify(newBondPostNoteWithTier(TopicBondExpired, string(TopicBondExpired),
+			details, db.WarningLevel, dc.acct.host, newTier))
+	}
 
 	return nil
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2775,9 +2775,15 @@ func (dc *dexConnection) bondTotal(assetID uint32) (total, active uint64) {
 	return dc.bondTotalInternal(assetID)
 }
 
-func (dc *dexConnection) hasUnspentBond(assetID uint32) bool {
+func (dc *dexConnection) hasUnspentAssetBond(assetID uint32) bool {
 	total, _ := dc.bondTotal(assetID)
 	return total > 0
+}
+
+func (dc *dexConnection) hasUnspentBond() bool {
+	dc.acct.authMtx.RLock()
+	defer dc.acct.authMtx.RUnlock()
+	return len(dc.acct.bonds) > 0 || len(dc.acct.pendingBonds) > 0 || len(dc.acct.expiredBonds) > 0
 }
 
 // isActiveBondAsset indicates if a wallet (or it's parent if the asset is a
@@ -2808,7 +2814,7 @@ func (c *Core) isActiveBondAsset(assetID uint32, includeLive bool) bool {
 		}
 		if includeLive {
 			for id := range assetIDs {
-				if dc.hasUnspentBond(id) {
+				if dc.hasUnspentAssetBond(id) {
 					return true
 				}
 			}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -5772,12 +5772,21 @@ var (
 	}
 )
 
+// auth sets the account as authenticated at the provided tier.
+func auth(a *dexAccount, tier int64, legacyFeePaid bool) {
+	a.authMtx.Lock()
+	a.isAuthed = true
+	a.tier = tier
+	a.legacyFeePaid = legacyFeePaid
+	a.authMtx.Unlock()
+}
+
 func TestResolveActiveTrades(t *testing.T) {
 	rig := newTestRig()
 	defer rig.shutdown()
 	tCore := rig.core
 
-	rig.acct.auth(1, false) // Short path through initializeDEXConnections
+	auth(rig.acct, 1, false) // Short path through initializeDEXConnections
 
 	utxoAsset /* base */, acctAsset /* quote */ := tUTXOAssetB, tACCTAsset
 
@@ -5943,7 +5952,7 @@ func TestReReserveFunding(t *testing.T) {
 	defer rig.shutdown()
 	tCore := rig.core
 
-	rig.acct.auth(1, false) // Short path through initializeDEXConnections
+	auth(rig.acct, 1, false) // Short path through initializeDEXConnections
 
 	utxoAsset /* base */, acctAsset /* quote */ := tUTXOAssetB, tACCTAsset
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -96,17 +96,26 @@ type WalletForm struct {
 	ParentForm *WalletForm
 }
 
-// WalletBalance is an exchange wallet's balance which includes contractlocked
-// amounts in addition to other balance details stored in db.
+// WalletBalance is an exchange wallet's balance which includes various locked
+// amounts in addition to other balance details stored in db. Both the
+// ContractLocked and BondLocked amounts are not included in the Locked field of
+// the embedded asset.Balance since they correspond to outputs that are foreign
+// to the wallet i.e. only spendable by externally-crafted transactions. On the
+// other hand, OrderLocked is part of Locked since these are regular UTXOs that
+// have been locked by the wallet to fund an order's swap transaction.
 type WalletBalance struct {
 	*db.Balance
 	// OrderLocked is the total amount of funds that is currently locked
 	// for swap, but not actually swapped yet. This amount is also included
 	// in the `Locked` balance value.
 	OrderLocked uint64 `json:"orderlocked"`
-	// ContractLocked is the total amount of funds locked in unspent
-	// (i.e. unredeemed / unrefunded) swap contracts.
+	// ContractLocked is the total amount of funds locked in unspent (i.e.
+	// unredeemed / unrefunded) swap contracts. This amount is NOT included in
+	// the db.Balance.
 	ContractLocked uint64 `json:"contractlocked"`
+	// BondLocked is the total amount of funds locked in unspent fidelity bonds.
+	// This amount is NOT included in the db.Balance.
+	BondLocked uint64 `json:"bondlocked"`
 }
 
 // WalletState is the current status of an exchange wallet.

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -508,6 +508,26 @@ func (w *xcWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Tim
 	return bonder.MakeBondTx(ver, amt, feeRate, lockTime, priv, acctID)
 }
 
+// ReserveBondFunds reserves funds for future bonds given known live bonds.
+func (w *xcWallet) ReserveBondFunds(future int64, respectBalance bool) bool {
+	bonder, ok := w.Wallet.(asset.Bonder)
+	if !ok {
+		return false
+	}
+	return bonder.ReserveBondFunds(future, respectBalance)
+}
+
+// RegisterUnspent informs the wallet of existing bond amounts that will be
+// refunded with RefundBond. If reserves are subsequently enabled with
+// ReserveBondFunds, these amounts are combined into a "nominal" reserves.
+func (w *xcWallet) RegisterUnspent(live uint64) {
+	bonder, ok := w.Wallet.(asset.Bonder)
+	if !ok {
+		return
+	}
+	bonder.RegisterUnspent(live)
+}
+
 // RefundBond will refund the bond if the asset.Wallet implementation is a
 // Bonder. The lock time must be passed to spend the bond. LockTimeExpired
 // should be used to check first.

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -500,10 +500,10 @@ func (w *xcWallet) swapConfirmations(ctx context.Context, coinID []byte, contrac
 
 // MakeBondTx authors a DEX time-locked fidelity bond transaction if the
 // asset.Wallet implementation is a Bonder.
-func (w *xcWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Time, priv *secp256k1.PrivateKey, acctID []byte) (*asset.Bond, error) {
+func (w *xcWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Time, priv *secp256k1.PrivateKey, acctID []byte) (*asset.Bond, func(), error) {
 	bonder, ok := w.Wallet.(asset.Bonder)
 	if !ok {
-		return nil, errors.New("wallet does not support making bond transactions")
+		return nil, nil, errors.New("wallet does not support making bond transactions")
 	}
 	return bonder.MakeBondTx(ver, amt, feeRate, lockTime, priv, acctID)
 }

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -241,6 +241,13 @@ func (w *xcWallet) amtString(amt uint64) string {
 	return fmt.Sprintf("%s %s", ui.ConventionalString(amt), ui.Conventional.Unit)
 }
 
+func (w *xcWallet) amtStringSigned(amt int64) string {
+	if amt >= 0 {
+		return w.amtString(uint64(amt))
+	}
+	return "-" + w.amtString(uint64(-amt))
+}
+
 // state returns the current WalletState.
 func (w *xcWallet) state() *WalletState {
 	winfo := w.Info()
@@ -504,7 +511,7 @@ func (w *xcWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Tim
 // RefundBond will refund the bond if the asset.Wallet implementation is a
 // Bonder. The lock time must be passed to spend the bond. LockTimeExpired
 // should be used to check first.
-func (w *xcWallet) RefundBond(ctx context.Context, ver uint16, coinID, script []byte, amt uint64, priv *secp256k1.PrivateKey) ([]byte, error) {
+func (w *xcWallet) RefundBond(ctx context.Context, ver uint16, coinID, script []byte, amt uint64, priv *secp256k1.PrivateKey) (asset.Coin, error) {
 	bonder, ok := w.Wallet.(asset.Bonder)
 	if !ok {
 		return nil, errors.New("wallet does not support refunding bond transactions")

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1230,6 +1230,7 @@ func randomBalance(assetID uint32) *core.WalletBalance {
 			Stamp: time.Now().Add(-time.Duration(int64(2 * float64(time.Hour) * rand.Float64()))),
 		},
 		ContractLocked: randVal(),
+		BondLocked:     randVal(),
 	}
 }
 

--- a/client/webserver/site/src/css/wallets.scss
+++ b/client/webserver/site/src/css/wallets.scss
@@ -89,6 +89,10 @@
     td:last-child {
       text-align: right;
     }
+
+    tr.first-other {
+      border-top: 1px solid $light_border_color;
+    }
   }
 
   #balanceBreakdownBox {

--- a/client/webserver/site/src/css/wallets_dark.scss
+++ b/client/webserver/site/src/css/wallets_dark.scss
@@ -12,5 +12,11 @@ body.dark {
     .peers-table {
       @extend .table-dark;
     }
+
+    table#balanceTable {
+      tr.first-other {
+        border-top: 1px solid $dark_border_color;
+      }
+    }
   }
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=N2HhoiFV"></script>
+<script src="/js/entry.js?v=Om9tNpJl"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=Om9tNpJl"></script>
+<script src="/js/entry.js?v=eGfPLtv5"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -562,36 +562,38 @@
         <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="vErr"></div>{{- /* End Auth Section */ -}}
 
         <div id="vPreorder">
-          <hr class="dashed mb-2 mt-3">
+          <div id="vPreorderEstimates">
+            <hr class="dashed mb-2 mt-3">
 
-          <div class="d-flex justify-content-between align-items-center">
-            <span class="grey fs18">
-              [[[Fee Projection]]]
-              <span class="ico-info fs12" data-tooltip="[[[fee_projection_tooltip]]]"></span>
-            </span>
-            <span class="grey fs14 underline pointer hoverbg" id="vFeeDetails">[[[details]]]</span>
-          </div>
-
-          <div class="py-1 d-flex align-items-center justify-content-center fs18" id="vFeeSummaryPct">
-            <span id="vFeeSummaryLow"></span>
-            <span class="fs15">%</span>
-            <span class="fs15 px-2">[[[to]]]</span>
-            <span id="vFeeSummaryHigh"></span>
-            <span class="fs15">%</span>
-          </div>
-
-          <div class="py-1 flex-column align-items-center justify-content-center fs18" id="vFeeSummary">
-            <div class="d-flex flex-row align-items-center justify-content-center">
-              <img class="micro-icon mx-1" data-icon="from">
-              <span id="summarySwapFeesLow"></span>
-              <span class="px-1">&ndash;</span>
-              <span id="summarySwapFeesHigh"></span>
+            <div class="d-flex justify-content-between align-items-center">
+              <span class="grey fs18">
+                [[[Fee Projection]]]
+                <span class="ico-info fs12" data-tooltip="[[[fee_projection_tooltip]]]"></span>
+              </span>
+              <span class="grey fs14 underline pointer hoverbg" id="vFeeDetails">[[[details]]]</span>
             </div>
-            <div class="d-flex flex-row align-items-center justify-content-center">
-              <img class="micro-icon mx-1" data-icon="to">
-              <span id="summaryRedeemFeesLow"></span>
-              <span class="px-1">&ndash;</span>
-              <span id="summaryRedeemFeesHigh"></span>
+
+            <div class="py-1 d-flex align-items-center justify-content-center fs18" id="vFeeSummaryPct">
+              <span id="vFeeSummaryLow"></span>
+              <span class="fs15">%</span>
+              <span class="fs15 px-2">[[[to]]]</span>
+              <span id="vFeeSummaryHigh"></span>
+              <span class="fs15">%</span>
+            </div>
+
+            <div class="py-1 flex-column align-items-center justify-content-center fs18" id="vFeeSummary">
+              <div class="d-flex flex-row align-items-center justify-content-center">
+                <img class="micro-icon mx-1" data-icon="from">
+                <span id="summarySwapFeesLow"></span>
+                <span class="px-1">&ndash;</span>
+                <span id="summarySwapFeesHigh"></span>
+              </div>
+              <div class="d-flex flex-row align-items-center justify-content-center">
+                <img class="micro-icon mx-1" data-icon="to">
+                <span id="summaryRedeemFeesLow"></span>
+                <span class="px-1">&ndash;</span>
+                <span id="summaryRedeemFeesHigh"></span>
+              </div>
             </div>
           </div>
 

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -2810,7 +2810,7 @@ class BalanceWidget {
     }
 
     addRow(intl.prep(intl.ID_AVAILABLE), bal.available, asset.unitInfo)
-    addRow(intl.prep(intl.ID_LOCKED), bal.locked + bal.contractlocked, asset.unitInfo)
+    addRow(intl.prep(intl.ID_LOCKED), bal.locked + bal.contractlocked + bal.bondlocked, asset.unitInfo)
     addRow(intl.prep(intl.ID_IMMATURE), bal.immature, asset.unitInfo)
     if (asset.token) {
       const { wallet: { balance }, unitInfo, symbol } = app().assets[asset.token.parentID]

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1803,6 +1803,11 @@ export default class MarketsPage extends BasePage {
   /* setFeeEstimates sets all of the pre-order estimate fields */
   setFeeEstimates (swap: PreSwap, redeem: PreRedeem, order: TradeForm) {
     const { page, market } = this
+    if (!swap.estimate || !redeem.estimate) {
+      Doc.hide(page.vPreorderEstimates)
+      return // preOrder may return just options, no fee estimates
+    }
+    Doc.show(page.vPreorderEstimates)
     const { baseUnitInfo, quoteUnitInfo, rateConversionFactor } = market
     const fmtPct = (value: number) => {
       if (value < 0.05) return '< 0.1'
@@ -2124,6 +2129,7 @@ export default class MarketsPage extends BasePage {
   /* handleBalanceNote handles notifications updating a wallet's balance. */
   handleBalanceNote (note: BalanceNote) {
     this.setBalanceVisibility()
+    this.preorderCache = {} // invalidate previous preorder results
     // if connection to dex server fails, it is not possible to retrieve
     // markets.
     const mkt = this.market

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -205,6 +205,7 @@ export interface WalletBalance {
   stamp: string // time.Time
   orderlocked: number
   contractlocked: number
+  bondlocked: number
   other: Record<string, number>
 }
 

--- a/dex/networks/dcr/script.go
+++ b/dex/networks/dcr/script.go
@@ -127,6 +127,10 @@ const (
 	// compressed pubkey, and the bond script. Each of said data pushes use an
 	// OP_DATA_ code.
 	RedeemBondSigScriptSize = 1 + DERSigLength + 1 + pubkeyLength + 1 + BondScriptSize // 141
+
+	// BondPushDataSize is the size of the nulldata in a bond commitment output:
+	//  OP_RETURN <pushData: ver[2] | account_id[32] | lockTime[4] | pkh[20]>
+	BondPushDataSize = 2 + account.HashSize + 4 + 20
 )
 
 // ScriptType is a bitmask with information about a pubkey script and
@@ -349,8 +353,7 @@ func extractBondCommitDataV0(pushData []byte) (acct account.AccountID, lockTime 
 		return
 	}
 
-	const wantPushSize = 2 + account.HashSize + 4 + 20
-	if len(pushData) != wantPushSize {
+	if len(pushData) != BondPushDataSize {
 		err = fmt.Errorf("invalid bond commitment output script length: %d", len(pushData))
 		return
 	}


### PR DESCRIPTION
<s>Requires https://github.com/decred/dcrdex/pull/2036. In draft until that's settled.</s>

This PR is the commits starting with `client/{asset,core}: RefundBond broadcasts too`.

Commit messages (but there are a ton of "fixup" commits already pushed that will be squashed before this is merged):

[client/{asset,core}: RefundBond broadcasts too](https://github.com/decred/dcrdex/commit/c759d01b4bb6e45a82c5f22bba779dd89d7b44b8) 

```
The asset.Bonder.RefundBond method now broadcasts, as it was supposed
to from the beginning. Only MakeBondTx required broadcasting in the
consumer.
```

[client/{asset,core,webserver}: BondLocked balance category](https://github.com/decred/dcrdex/commit/df1d6d4c06cba7a1b72dd056de7ed88225b2a963) 

```
This adds the client.WalletBalance.BondLocked field, which parallels
the ContractLocked field. These are used for core to supplement the
wallet's reported balance with values that the wallet does not
include in the balance itself because they are not spendable by the
wallet alone (core authors the spending tx).

This also updates the web UI's TypeScript to include bondLocked
when appropriate.  This also fixes a bug where contractLocked was
not included on the wallets page's "Locked" balance category.

This also adds to DCR's implementation fields for reserves tracking.
The values are included in the reported asset.Balance. Subsequent
commits will add the ability modify the reserves, and for funding
methods to respect the reserves.
```

[client/asset/dcr: respect reserves in funding](https://github.com/decred/dcrdex/commit/f9e6d9dc03755d4e79ba346ac49dd5f3268a809b) 

```
This updates the DCR wallet's transaction funding method and helpers to
respect the reserves added in the previous commit.

To do so without creating sizing transactions to actively isolate the
reserved value, we add new coin selection functions that we use exclude
UTXOs from transaction funding. The objective of these coin selection
functions is different from order funding coin selection.

The main helper, leastOverFund, attempts to pick a subset of the provided
UTXOs to reach the required amount with the objective of minimizing the
total amount of the selected UTXOs. This is different from the objective
used when funding orders, which is to minimize the number of UTXOs (to
minimize fees).

NOTE: The provided UTXO set MUST be sorted in ascending order (smallest
first, largest last)!

leastOverFund begins by partitioning the UTXO slice before the smallest
single UTXO that is large enough to fully fund the requested amount, if
it exists. If the smaller set is insufficient, the single largest UTXO
is returned. If instead the set of smaller UTXOs has enough total
value, it will search for a subset that reaches the amount with least
over-funding (see subsetSmallBias and subsetLargeBias). If that subset
has less combined value than the single sufficiently-large UTXO (if it
exists), the subset will be returned, otherwise the single UTXO will be
returned.

We also modify the "enough" functions and their constructors with
excess (change) reporting in a new return from the enough function.
The constructor also accepts a flag indicating if this returned value
should be set to zero. The tryFund helper now returns the final excess
value when it completes UTXO selection. This is used in the
(*ExchangeWallet).fund method, and in other callers, to discern if
there would be sufficient remaining in the wallet (including this
change) to satisfy a reserved amount. This amount is an input to fund
called "keep". If change should not be considered "kept" (e.g. no
preceding split txn, or mixing sends change to umixed account where it
is unusable for reserves), caller should return 0 extra from the enough
func (via the enough func's constructor flag).
```

[client/{asset,core}: reserves track as bonds are spend/refunded](https://github.com/decred/dcrdex/commit/4883a033d25454820f3d0506e25eee5eb9a976f5) 

```
This updates DCR's backend to begin modifying the reserves fields
as bonds are created (locked UTXOs) and spend (unlock UTXOs into
balance). Subsequent commits add the new exported wallet
interface methods for a consumer (core) to prepare and adjust the
reserves for the client's needs.

This also modifies the wallet's MakeBondTx method signature with
an additional return, an "abandon" function" to be used if the
consumer decides not to broadcast the generated bond transaction.
This function both unlocks the bond's funding utxos, and reverts
the reserves updates that were made when the transaction was
created.
```

[client/{asset,core}: ReserveBondFunds and dexAccount.tierChange](https://github.com/decred/dcrdex/commit/5c4029c396d10174d234d946c731fbe6b6c37d39) 

```
This adds the new Bonder methods, RegisterUnspent and ReserveBondFunds:

RegisterUnspent informs the wallet of a certain amount already locked in
unspent bonds that will eventually be refunded with RefundBond. This
should be used prior to ReserveBondFunds. This alone does not enable
reserves enforcement, and it should be called on bring-up when existing
bonds that may refund to this wallet are known. Once ReserveBondFunds is
called, even with 0 for future bonds, these live bond amounts will
become enforced reserves when they are refunded via RefundBond.

ReserveBondFunds (un)reserves funds for creation of future bonds.
MakeBondTx will create transactions that decrement these reserves, while
RefundBond will replenish the reserves. If the wallet's available
balance should be respected when adding reserves, the boolean argument
may be set to indicate this, in which case the return value indicates if
it was able to reserve the funds. In this manner, funds may be
pre-reserved so that when the wallet receives funds (from either
external deposits or refunding of live bonds), they will go directly
into locked balance. When the reserves are decremented to zero (by the
amount that they were incremented), all enforcement including any fee
buffering is disabled. Previously registered unspent/active bonds are
not forgotten however; they total amount of these are tracked in case
the wallet is used for reserves again in the future.

In core.Core, the new wallet reserves methods are used to maintain
adequate reserves based on the account's target tier and observed tier
change. The dexAccount type has new fields to support this:
- tierChange int64, is the total tier change that needs to be actuated
  with wallet reserves. Facilitates maintenance with changing tier.
- totalReserved int64, helps track and debug the total amount reserved
  with the wallet's ReserveBondFunds method *only* for this dexAccount.

Use of ReserveBondFunds and RegisterUnspent, facilitated by the new
dexAccount fields, happens in:
- connectWallets() via initialize(), after connectDEX(). Here it
  calls RegisterUnspent for all known bonds across all dexConnections.
- authDEX. On reconnect, any observed tier change is acctuated with
  wallet reserves. Initial auth on login is handled slightly
  differently, (re)reserving the full required amount given the known
  unspent bonds.
- handleTier change, which is called on penalization only, updates
  the tierChange field of the dexAccount.
- rotateBonds. Any tierChange value is actuated with reserves.
- PostBond. When making the initial bond for a new account, with
  maintenance enabled, ReserveBondFunds is used to pre-reseve. Here
  the boolean input is true, and the return is checked to ensure the
  wallet is sufficiently funded to increase reserves by the requested
  amount for the new bonds.
- UpdateBondOptions. When modifying target tier or changing the bond
  asset. The boolean input and output are also used here.
```