### PR TITLE
server/asset/eth: forget reorg handling

### DIFF
--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -179,7 +179,7 @@ type Contract struct {
 // BlockUpdate is sent over the update channel when a tip change is detected.
 type BlockUpdate struct {
 	Err   error
-	Reorg bool
+	Reorg bool // TODO: Not used. Remove and update through btc and dcr. Don't really need the BlockUpdate struct at all.
 }
 
 // ConnectionError error should be sent over the block update channel if a

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -684,7 +684,7 @@ func (eth *ETHBackend) poll(ctx context.Context) {
 		return
 	}
 	if bn == eth.bestHeight {
-		// Same hash, nothing to do.
+		// Same height, nothing to do.
 		return
 	}
 	eth.log.Debugf("Tip change from %d to %d.", eth.bestHeight, bn)


### PR DESCRIPTION
re: https://github.com/decred/dcrdex/pull/2104#discussion_r1096819950

We don't use reorg. No need for complex tip change handling.