### PR TITLE
server/assets/eth: refactor options for rpclient bestHeader

### DIFF
--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -133,11 +133,7 @@ func (c *rpcclient) withTokener(assetID uint32, f func(*tokener) error) error {
 
 // bestHeader gets the best header at the time of calling.
 func (c *rpcclient) bestHeader(ctx context.Context) (*types.Header, error) {
-	bn, err := c.ec.BlockNumber(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return c.ec.HeaderByNumber(ctx, big.NewInt(int64(bn)))
+	return c.ec.HeaderByNumber(ctx, nil)
 }
 
 // headerByHeight gets the best header at height.


### PR DESCRIPTION
**There are 2 options here**

The `(*rpcclient).bestHeader` method was not optimized to reduce rpc calls. I've given two options to make it better.

1) We don't need provide a block number to `HeaderByNumber`. The arg is a `*big.Int` and if we pass `nil`, it is parsed to `"latest"` which has a special meaning for **geth**. **This is the first commit.**
2) The load of getting a header is large. We could still call `BlockNumber`, but only call `HeaderByNumber` if the tip height has changed. **This is the second commit.**