### PR TITLE
app: Fee summary touch-ups

### DIFF
--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -563,6 +563,14 @@
             <span class="grey fs14 underline pointer hoverbg" id="vFeeDetails">[[[details]]]</span>
           </div>
 
+          <div class="py-1 d-flex align-items-center justify-content-center fs18" id="vFeeSummaryPct">
+            <span id="vFeeSummaryLow"></span>
+            <span class="fs15">%</span>
+            <span class="fs15 px-2">[[[to]]]</span>
+            <span id="vFeeSummaryHigh"></span>
+            <span class="fs15">%</span>
+          </div>
+
           <div class="py-1 flex-column align-items-center justify-content-center fs18" id="vFeeSummary">
             <div class="d-flex flex-row align-items-center justify-content-center">
               <img class="micro-icon mx-1" data-icon="from">

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1852,8 +1852,8 @@ export default class MarketsPage extends BasePage {
     if (baseExchangeRate && quoteExchangeRate) {
       Doc.show(page.vFeeSummaryPct)
       Doc.hide(page.vFeeSummary)
-      page.vFeeSummaryLow.textContent = fmtPct((bestSwapPct + bestRedeemPct) / 2)
-      page.vFeeSummaryHigh.textContent = fmtPct((worstSwapPct + worstRedeemPct) / 2)
+      page.vFeeSummaryLow.textContent = fmtPct(bestSwapPct + bestRedeemPct)
+      page.vFeeSummaryHigh.textContent = fmtPct(worstSwapPct + worstRedeemPct)
     } else {
       Doc.hide(page.vFeeSummaryPct)
       Doc.show(page.vFeeSummary)


### PR DESCRIPTION
The fee summary panel now shows the fees as a percentage of the order for token assets, if the fiat rate is available for both the token and the parent. Also, if the percentage is less than 0.05%, "< 0.1" is displayed.

Closes #2095 