### PR TITLE
ui: make order detailsDiv slightly easier to drop down

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=ZZS892G"></script>
+<script src="/js/entry.js?v=3KW3Tiwr"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1281,7 +1281,7 @@ export default class MarketsPage extends BasePage {
         app().bindInternalNavigation(div)
       }
 
-      Doc.bind(header.expander, 'click', () => {
+      Doc.bind(headerEl, 'click', () => {
         if (Doc.isDisplayed(detailsDiv)) {
           Doc.hide(detailsDiv)
           header.expander.classList.add('ico-arrowdown')


### PR DESCRIPTION
This makes the order `status` text as well as any "active" light indicator expand the order details div, in addition to clicking the `expander`. This is just to make it a bit easier to get the order details to expand, without having the entire header element under user-order trigger expanding it, although that might be ok too.

To clarify, you can click the status text in addition to the expander icon to the order `detailsDiv` to expand down.

![image](https://user-images.githubusercontent.com/9373513/217345217-b8acc47f-bf7b-4163-b91d-0e1dbe0dd0a3.png)
(click) =>
![image](https://user-images.githubusercontent.com/9373513/217345373-555a782b-e553-4b70-98f9-118124d8afb2.png)
