### PR TITLE
client/asset/eth: don't fail in swapGas on estimateInitGas RPC failure

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1454,11 +1454,12 @@ func (w *assetWallet) swapGas(n int, ver uint32) (oneSwap, nSwap uint64, approve
 	// If a live estimate is greater than our estimate from configured values,
 	// use the live estimate with a warning.
 	if gasEst, err := w.estimateInitGas(w.ctx, n, ver); err != nil {
-		w.log.Errorf("(%d) error estimating swap gas: %v", w.assetID, err)
+		w.log.Errorf("(%d) error estimating swap gas (using expected gas cap instead): %v", w.assetID, err)
 		// TODO: investigate "gas required exceeds allowance".
-		return 0, 0, false, err
+		// TODO: investigate "error getting gas fees: execution reverted: transfer from failed"
+		// return 0, 0, false, err
 	} else if gasEst > nSwap {
-		w.log.Warnf("Swap gas estimate %d is greater than the server's configured value %d. Using live estimate + 10%.", gasEst, nSwap)
+		w.log.Warnf("Swap gas estimate %d is greater than the server's configured value %d. Using live estimate + 10%%.", gasEst, nSwap)
 		nSwap = gasEst * 11 / 10 // 10% buffer
 		if n == 1 && nSwap > oneSwap {
 			oneSwap = nSwap


### PR DESCRIPTION
Testing a USDC swap, my maker failed (at first) to create the first swap in the sequence with the following error:

```
[DBG] CORE: Swappable match 6cdfd20fe1b2bbb168f1c0071ef625d71c1bfc04b4afb6c653a06d02de094788 for order a595439a976bbc4681297efbbbf306e33020fea9e763eec8b90d1ab0137ae2f5 (Maker)
[DBG] CORE: Using stored change coin address: ..., amount:47320000, fees:43560000 (usdc.eth) for order a595439a976bbc4681297efbbbf306e33020fea9e763eec8b90d1ab0137ae2f5 matches
[TRC] CORE[eth][ETH][RPC]: using cached header from "eth-mainnet.blastapi.io"
[ERR] CORE[eth][USDC.ETH]: (60001) error estimating swap gas: execution reverted: transfer from failed
[ERR] CORE: notify: |ERROR| (order) Swap send error - Error encountered sending a swap output(s) worth 47.320000 USDC on order a595439a - Order: a595439a976bbc4681297efbbbf306e33020fea9e763eec8b90d1ab0137ae2f5
[TRC] CORE: notify: |DATA| (balance) balance updated
[ERR] CORE: Route 'match' request handler error (DEX ...): runMatches - {tick of order a595439a976bbc4681297efbbbf306e33020fea9e763eec8b90d1ab0137ae2f5 failed: ... tick: {swapMatches order a595439a976bbc4681297efbbbf306e33020fea9e763eec8b90d1ab0137ae2f5 - {error sending swap transaction: error getting gas fees: execution reverted: transfer from failed}}}
```

This was not fatal because it retried on the next tick about a minute later, but for some reason it appears that `c.cb.EstimateGas` for the init tx payload returned `execution reverted: transfer from failed`.  May just be a provider error, but I don't think we need to fail to swap because we can use the known gas cap values (just like we do in `redeemGas`).