### PR TITLE
client/core: return from Run if db.Accounts fail in initialize

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1529,7 +1529,11 @@ func (c *Core) Run(ctx context.Context) {
 	// Store the context as a field, since we will need to spawn new DEX threads
 	// when new accounts are registered.
 	c.ctx = ctx
-	c.initialize() // connectDEX gets ctx for the wsConn
+	if err := c.initialize(); err != nil { // connectDEX gets ctx for the wsConn
+		c.log.Critical(err)
+		close(c.ready) // unblock <-Ready()
+		return
+	}
 	close(c.ready)
 
 	// The DB starts first and stops last.
@@ -6396,10 +6400,10 @@ func pluralize(n int) string {
 
 // initialize pulls the known DEXes from the database and attempts to connect
 // and retrieve the DEX configuration.
-func (c *Core) initialize() {
+func (c *Core) initialize() error {
 	accts, err := c.db.Accounts()
 	if err != nil {
-		c.log.Errorf("Error retrieving accounts from database: %v", err) // panic?
+		return fmt.Errorf("failed to retrieve accounts from database: %w", err)
 	}
 
 	// Start connecting to DEX servers.
@@ -6449,6 +6453,8 @@ func (c *Core) initialize() {
 				n, pluralize(n), host)
 		}
 	}
+
+	return nil
 }
 
 // connectAccount makes a connection to the DEX for the given account. If a

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -587,7 +587,7 @@ func (db *BoltDB) CreateAccount(ai *dexdb.AccountInfo) error {
 	return db.acctsUpdate(func(accts *bbolt.Bucket) error {
 		acct, err := accts.CreateBucket([]byte(ai.Host))
 		if err != nil {
-			return fmt.Errorf("failed to create account bucket")
+			return fmt.Errorf("failed to create account bucket: %w", err)
 		}
 
 		err = acct.Put(accountKey, ai.Encode())


### PR DESCRIPTION
After testing bonds PRs with my testnet dexc db, I went back to master or another PR, and that failed to load the Accounts because it didn't know v3 of `db.AccountInfo`.  However, i barely noticed this because it's not a fatal error.

This acts on a long standing comment to make this error fatal.  <s>I'm just using panic/recover as suggested by the comment because I didn't really want to add and `error` return to `initialize`, although that wouldn't be horrible now that I look again.</s> Now returning an error from `initialize`.