### PR TITLE
app: Fix token wallet creation

### DIFF
--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -912,7 +912,7 @@ export default class WalletsPage extends BasePage {
       return
     }
     const assetHasActiveOrders = app().haveAssetOrders(assetID)
-    this.reconfigForm.update(currentDef.configopts || [], { assetHasActiveOrders })
+    this.reconfigForm.update(currentDef.configopts || [], assetHasActiveOrders)
     this.reconfigForm.setConfig(res.map)
     this.updateDisplayedReconfigFields(currentDef)
   }
@@ -921,7 +921,7 @@ export default class WalletsPage extends BasePage {
     const page = this.page
     const walletType = page.changeWalletTypeSelect.value || ''
     const walletDef = app().walletDefinition(this.selectedAssetID, walletType)
-    this.reconfigForm.update(walletDef.configopts || [], {})
+    this.reconfigForm.update(walletDef.configopts || [], false)
     this.updateDisplayedReconfigFields(walletDef)
   }
 


### PR DESCRIPTION
When attempting to create a token wallet when the parent wallet has not yet been created, the configuration screen was blank. This is fixed.

Closes #2085 