### PR TITLE
core: remove anti-pattern in `core.connectDEX`

### DIFF
--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -1131,10 +1131,6 @@ func (c *Core) PostBond(form *PostBondForm) (*PostBondResult, error) {
 			// bond maintenance options set below.
 		})
 		if err != nil {
-			if dc != nil {
-				// Stop (re)connect loop, which may be running even if err != nil.
-				dc.connMaster.Disconnect()
-			}
 			return nil, codedError(connectionErr, err)
 		}
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2577,18 +2577,20 @@ func TestConnectDEX(t *testing.T) {
 
 	rig.queueConfig()
 	tCore.cfg.Onion = "127.0.0.1:9050"
-	_, err = tCore.connectDEX(ai)
+	dc, err := tCore.connectDEX(ai)
 	if err != nil {
 		t.Fatalf("error connecting to onion host with an onion proxy configured: %v", err)
 	}
+	dc.connMaster.Disconnect()
 
 	rig.queueConfig()
 	ai.Host = "somedex.com"
 	ai.Cert = []byte{0x1}
-	_, err = tCore.connectDEX(ai)
+	dc, err = tCore.connectDEX(ai)
 	if err != nil {
 		t.Fatalf("initial connectDEX error: %v", err)
 	}
+	dc.connMaster.Disconnect()
 
 	// Bad URL.
 	ai.Host = tUnparseableHost // Illegal ASCII control character
@@ -2611,18 +2613,11 @@ func TestConnectDEX(t *testing.T) {
 
 	// WsConn.Connect error.
 	rig.ws.connectErr = tErr
-	dc, err := tCore.connectDEX(ai)
+	_, err = tCore.connectDEX(ai)
 	if err == nil {
-		if dc != nil {
-			dc.connMaster.Disconnect()
-		}
 		t.Fatalf("no error for WsConn.Connect error")
 	}
-	if dc == nil {
-		t.Error("Expected a non-nil dexConnection that is still trying to connect.")
-	} else {
-		dc.connMaster.Disconnect()
-	}
+
 	rig.ws.connectErr = nil
 
 	// 'config' route error.
@@ -2631,25 +2626,18 @@ func TestConnectDEX(t *testing.T) {
 		f(resp)
 		return nil
 	})
-	dc, err = tCore.connectDEX(ai)
+	_, err = tCore.connectDEX(ai)
 	if err == nil {
-		if dc != nil {
-			dc.connMaster.Disconnect()
-		}
 		t.Fatalf("no error for 'config' route error")
-	}
-	if dc == nil {
-		t.Error("Expected a non-nil dexConnection that is still trying to connect.")
-	} else {
-		dc.connMaster.Disconnect()
 	}
 
 	// Success again.
 	rig.queueConfig()
-	_, err = tCore.connectDEX(ai)
+	dc, err = tCore.connectDEX(ai)
 	if err != nil {
 		t.Fatalf("final connectDEX error: %v", err)
 	}
+	dc.connMaster.Disconnect()
 
 	// TODO: test temporary, ensure listen isn't running, somehow
 }


### PR DESCRIPTION
This resolves:
>	TODO: split the above code into a dexConnection constructor, and the below into
>      a startDexConnection function so we don't have the anti-pattern of
>	returning a non-nil object with a non-nil error and requiring the caller
>	to check both!