### PR TITLE
server/eth: Monitor RPC provider health

### DIFF
--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -217,16 +217,17 @@ EOF
 fi
 
 if [ $ETH_ON -eq 0 ]; then
-
 ETH_CONFIG_PATH=${TEST_ROOT}/eth.conf
 ETH_IPC_FILE=${TEST_ROOT}/eth/alpha/node/geth.ipc
-cat << EOF >> $ETH_CONFIG_PATH
+
+cat > $ETH_CONFIG_PATH <<EOF
 ws://localhost:38557
 # comments are respected
 # http://localhost:38556
 ${ETH_IPC_FILE}
 EOF
-    cat << EOF >> "./markets.json"
+
+cat << EOF >> "./markets.json"
          },
         "ETH_simnet": {
             "bip44symbol": "eth",

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -281,12 +281,14 @@ func NewBackend(configPath string, log dex.Logger, net dex.Network) (*ETHBackend
 	defer file.Close()
 
 	var endpoints []string
+	endpointsMap := make(map[string]bool) // to avoid duplicates
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := strings.Trim(scanner.Text(), " ")
-		if line == "" || strings.HasPrefix(line, "#") {
+		if line == "" || strings.HasPrefix(line, "#") || endpointsMap[line] {
 			continue
 		}
+		endpointsMap[line] = true
 		endpoints = append(endpoints, line)
 	}
 	if err := scanner.Err(); err != nil {

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -301,7 +301,17 @@ func NewBackend(configPath string, log dex.Logger, net dex.Network) (*ETHBackend
 	if err != nil {
 		return nil, err
 	}
-	eth.node = newRPCClient(eth.net, endpoints, log.SubLogger("RPC"))
+
+	netAddrs, found := dexeth.ContractAddresses[ethContractVersion]
+	if !found {
+		return nil, fmt.Errorf("no contract address for eth version %d", ethContractVersion)
+	}
+	ethContractAddr, found := netAddrs[eth.net]
+	if !found {
+		return nil, fmt.Errorf("no contract address for eth version %d on %s", ethContractVersion, eth.net)
+	}
+
+	eth.node = newRPCClient(eth.net, endpoints, ethContractAddr, log.SubLogger("RPC"))
 	return eth, nil
 }
 

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -46,7 +46,17 @@ func TestMain(m *testing.M) {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithCancel(context.Background())
 		log := dex.StdOutLogger("T", dex.LevelTrace)
-		ethClient = newRPCClient(dex.Simnet, []string{wsEndpoint, alphaIPCFile}, log)
+
+		netAddrs, found := dexeth.ContractAddresses[ethContractVersion]
+		if !found {
+			return 1, fmt.Errorf("no contract address for eth version %d", ethContractVersion)
+		}
+		ethContractAddr, found := netAddrs[dex.Simnet]
+		if !found {
+			return 1, fmt.Errorf("no contract address for eth version %d on %s", ethContractVersion, dex.Simnet)
+		}
+
+		ethClient = newRPCClient(dex.Simnet, []string{wsEndpoint, alphaIPCFile}, ethContractAddr, log)
 		defer func() {
 			cancel()
 			ethClient.shutdown()

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -59,7 +59,6 @@ func TestMain(m *testing.M) {
 		ethClient = newRPCClient(dex.Simnet, []string{wsEndpoint, alphaIPCFile}, ethContractAddr, log)
 		defer func() {
 			cancel()
-			ethClient.shutdown()
 		}()
 
 		dexeth.ContractAddresses[0][dex.Simnet] = getContractAddrFromFile(contractAddrFile)
@@ -199,16 +198,8 @@ func TestMonitorHealth(t *testing.T) {
 
 	updatedClients := ethClient.clientsCopy()
 
-	getEndpoints := func(clients []*ethConn) []string {
-		endpoints := make([]string, 0, len(clients))
-		for _, c := range clients {
-			endpoints = append(endpoints, c.endpoint)
-		}
-		return endpoints
-	}
-
-	fmt.Println("Original clients:", getEndpoints(originalClients))
-	fmt.Println("Updated clients:", getEndpoints(updatedClients))
+	fmt.Println("Original clients:", originalClients)
+	fmt.Println("Updated clients:", updatedClients)
 
 	if originalClients[0].endpoint != updatedClients[len(updatedClients)-1].endpoint {
 		t.Fatalf("failing client was not moved to the end. got %s, expected %s", updatedClients[len(updatedClients)-1].endpoint, originalClients[0].endpoint)


### PR DESCRIPTION
Previously, the ETH backend would not start if any of the providers could not connect or was outdated. Now, if at least one of the providers is able to connect and the header is recent, the backend will start. After connecting, a goroutine will start that will periodically check the health of the RPC providers, sort the list putting the non-outdated ones first, outdated ones after, and the ones that fail to respond last. Requests will then attempt to use the rpc providers in this order.

Closes #2122 