### PR TITLE
client: Add desktop Notifications

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1446,6 +1446,8 @@ type Core struct {
 	// goroutine when all rate sources have been disabled.
 	stopFiatRateFetching context.CancelFunc
 
+	noteTypePermissions map[string]bool
+
 	pendingWalletsMtx sync.RWMutex
 	pendingWallets    map[uint32]bool
 
@@ -9922,4 +9924,24 @@ func (c *Core) saveDisabledRateSources() {
 	if err != nil {
 		c.log.Errorf("Unable to save disabled fiat rate source to database: %v", err)
 	}
+}
+
+// NoteTypePermissions returns a map of note types which user permission to
+// receive notfication at OS level.
+func (c *Core) NoteTypePermissionsOpt() map[string]string {
+	opts := make(map[string]string, len(noteTypesOpt))
+	for noteTypeKey, noteType := range noteTypesOpt {
+		opts[noteTypeKey] = noteType
+	}
+	return opts
+}
+
+func (c *Core) GetNoteTypePermission(noteType string) (bool, error) {
+	return c.db.GetNotePermission(noteType)
+}
+
+// SetNotesTypePermission toggles notifications which have permission to being
+// called by the OS notifications.
+func (c *Core) SetNotesTypePermission(notesType []string) error {
+	return c.db.SetNoteTypesPermission(notesType)
 }

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -535,6 +535,14 @@ func (tdb *TDB) StoreAccountProof(proof *db.AccountProof) error {
 	return tdb.storeAccountProofErr
 }
 
+func (tdb *TDB) GetNotePermission(string) (bool, error) {
+	return true, nil
+}
+
+func (tdb *TDB) SetNoteTypesPermission([]string) error {
+	return nil
+}
+
 func (tdb *TDB) SaveNotification(*db.Notification) error            { return nil }
 func (tdb *TDB) BackupTo(dst string, overwrite, compact bool) error { return nil }
 func (tdb *TDB) NotificationsN(int) ([]*db.Notification, error)     { return nil, nil }

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -37,7 +37,32 @@ const (
 	NoteTypeLogin        = "login"
 )
 
-var noteChanCounter uint64
+var (
+	noteChanCounter uint64
+	// note types which notifications user can receive at OS level.
+	noteTypesOpt = map[string]string{
+		NoteTypeFeePayment: "Fee Payment",
+		NoteTypeBondPost:   "Bond Post",
+		NoteTypeBondRefund: "Bond Refund",
+		NoteTypeSend:       "Send",
+		NoteTypeOrder:      "Order",
+		NoteTypeMatch:      "Match",
+		NoteTypeEpoch:      "Epoch",
+		NoteTypeConnEvent:  "Conections Events",
+		NoteTypeBalance:    "Balance",
+		// NoteTypeSpots:        "Spots",
+		NoteTypeWalletConfig: "Wallet Config",
+		NoteTypeWalletState:  "Wallet State",
+		// NoteTypeServerNotify:"",
+		NoteTypeSecurity: "Security",
+		NoteTypeUpgrade:  "Upgrade",
+		// NoteTypeBot:          "Bot",
+		// NoteTypeDEXAuth:      "Auth",
+		// NoteTypeFiatRates:    "Fiat Rate Update",
+		// NoteTypeCreateWallet: "Create Wallet",
+		// NoteTypeLogin: "login",
+	}
+)
 
 func (c *Core) logNote(n Notification) {
 	// Do not log certain spammy note types that have no value in logs.

--- a/client/db/interface.go
+++ b/client/db/interface.go
@@ -128,6 +128,8 @@ type DB interface {
 	NotificationsN(int) ([]*Notification, error)
 	// AckNotification sets the acknowledgement for a notification.
 	AckNotification(id []byte) error
+
+	GetNotePermission(string) (bool, error)
 	// DeleteInactiveOrders deletes inactive orders from the database that are
 	// older than the supplied time and returns the total number of orders
 	// deleted. If no time is supplied, the current time is used. Accepts an
@@ -158,4 +160,6 @@ type DB interface {
 	RetireBotProgram(pgmID uint64) error
 	// ActiveBotPrograms loads a list of active bot program IDs.
 	ActiveBotPrograms() (map[uint64]*BotProgram, error)
+	// SetNoteTypesPermission sets permission to send notifications from the OS.
+	SetNoteTypesPermission(noteTypes []string) error
 }

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -1050,6 +1050,8 @@ type Notification struct {
 	TimeStamp   uint64    `json:"stamp"`
 	Ack         bool      `json:"acked"`
 	Id          dex.Bytes `json:"id"`
+	// OSPermission if user giver or not permission to show up on OS ntfn
+	OSPermission bool `json:"permission,omitempty"`
 }
 
 // NewNotification is a constructor for a Notification.

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1350,6 +1350,47 @@ func (s *WebServer) apiToggleRateSource(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, simpleAck(), s.indent)
 }
 
+// apiOrders responds with a filtered list of user orders.
+func (s *WebServer) apiGetNoteTypePermission(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		NoteType string `json:"noteType"`
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+	enabled, err := s.core.GetNoteTypePermission(form.NoteType)
+	if err != nil {
+		s.writeAPIError(w, fmt.Errorf("Orders error: %w", err))
+		return
+	}
+	writeJSON(w, &struct {
+		OK      bool `json:"ok"`
+		Enabled bool `json:"enabled"`
+	}{
+		OK:      true,
+		Enabled: enabled,
+	}, s.indent)
+}
+
+func (s *WebServer) apiSetNotesTypePermission(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		NotesType []string `json:"notesType"`
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+	err := s.core.SetNotesTypePermission(form.NotesType)
+	if err != nil {
+		s.writeAPIError(w, fmt.Errorf("Error: %w", err))
+		return
+	}
+	writeJSON(w, &struct {
+		OK bool `json:"ok"`
+	}{
+		OK: true,
+	}, s.indent)
+}
+
 // apiDeleteArchiveRecords handles the '/deletearchivedrecords' API request.
 func (s *WebServer) apiDeleteArchivedRecords(w http.ResponseWriter, r *http.Request) {
 	form := new(deleteRecordsForm)

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -255,14 +255,16 @@ func (s *WebServer) handleSettings(w http.ResponseWriter, r *http.Request) {
 	common := s.commonArgs(r, "Settings | Decred DEX")
 	data := &struct {
 		CommonArguments
-		KnownExchanges  []string
-		FiatRateSources map[string]bool
-		FiatCurrency    string
+		KnownExchanges      []string
+		FiatRateSources     map[string]bool
+		NoteTypePermissions map[string]string
+		FiatCurrency        string
 	}{
-		CommonArguments: *common,
-		KnownExchanges:  s.knownUnregisteredExchanges(common.UserInfo.Exchanges),
-		FiatCurrency:    core.DefaultFiatCurrency,
-		FiatRateSources: s.core.FiatRateSources(),
+		CommonArguments:     *common,
+		KnownExchanges:      s.knownUnregisteredExchanges(common.UserInfo.Exchanges),
+		FiatCurrency:        core.DefaultFiatCurrency,
+		FiatRateSources:     s.core.FiatRateSources(),
+		NoteTypePermissions: s.core.NoteTypePermissionsOpt(),
 	}
 	s.sendTemplate(w, "settings", data)
 }

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -787,6 +787,18 @@ func (c *TCore) AccountImport(pw []byte, account *core.Account, bond []*db.Bond)
 }
 func (c *TCore) AccountDisable(pw []byte, host string) error { return nil }
 
+func (c *TCore) GetNoteTypePermission(string) (bool, error) {
+	return false, nil
+}
+
+func (c *TCore) NoteTypePermissionsOpt() map[string]string {
+	return nil
+}
+
+func (c *TCore) SetNotesTypePermission([]string) error {
+	return nil
+}
+
 func coreCoin() *core.Coin {
 	b := make([]byte, 36)
 	copy(b[:], encode.RandomBytes(32))

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -151,6 +151,8 @@ var EnUS = map[string]string{
 	"Export Account":            "Export Account",
 	"simultaneous_servers_msg":  "The Decred DEX Client supports simultaneous use of any number of DEX servers.",
 	"Change App Password":       "Change App Password",
+	"Enable Notifications":      "Enable Notifications",
+	"Save Notifications":        "Save Notifications",
 	"Build ID":                  "Build ID",
 	"Connect":                   "Connect",
 	"Send":                      "Send",

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -50,6 +50,22 @@
     <div>
         <button id="changeAppPW" class="bg2 selected">[[[Change App Password]]]</button>
     </div>
+    <div id="noteTypesPermissions" {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+      <span class="mb-2" data-tooltip="[[[fiat_exchange_rate_msg]]]">
+      [[[Enable Notifications]]]:
+      <span class="ico-info"></span>
+      </span>
+      {{range $noteTypeKey, $noteType := .NoteTypePermissions}}
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" value="{{$noteTypeKey}}" id="{{$noteTypeKey}}">
+        <label class="form-check-label" for="{{$noteTypeKey}}">{{$noteType}}</label>
+      </div>
+      {{end}}
+      </div>
+      <div {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
+          <button id="allowNtfn" class="bg2 selected">[[[Save Notifications]]]</button>
+      </div>
+    </div>
     <div{{if not .UserInfo.Authed}} class="d-hide"{{end}}>
       [[[seed_implore_msg]]]<br>
       <button id="exportSeed" class="fs15 bg2 selected">[[[View Application Seed]]]</button>

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -767,6 +767,10 @@ export default class Application {
       Doc.safeSelector(el, 'div.note-indicator').classList.add(cls)
     }
 
+    // permission enables notifications to be notified by the browser api
+    if (note.permission && !note.acked) {
+      ntfn.showNotification(note)
+    }
     Doc.safeSelector(el, 'div.note-subject').textContent = note.subject
     Doc.safeSelector(el, 'div.note-details').textContent = note.details
     const np: CoreNotePlus = { el, ...note }

--- a/client/webserver/site/src/js/notifications.ts
+++ b/client/webserver/site/src/js/notifications.ts
@@ -7,23 +7,16 @@ export const SUCCESS = 3
 export const WARNING = 4
 export const ERROR = 5
 
-/*
- * make constructs a new notification. The notification structure is a mirror of
- * the structure of notifications sent from the web server.
- * NOTE: I'm hoping to make this function obsolete, since errors generated in
- * javascript should usually be displayed/cached somewhere better. For example,
- * if the error is generated during submission of a form, the error should be
- * displayed on or near the form itself, not in the notifications.
- */
-export function make (subject: string, details: string, severity: number): CoreNote {
-  return {
-    subject: subject,
-    details: details,
-    severity: severity,
-    stamp: new Date().getTime(),
-    acked: false,
-    type: 'internal',
-    topic: 'internal',
-    id: ''
+export function saveNtfnsSettings () {
+  if (Notification.permission !== 'granted') Notification.requestPermission()
+}
+
+export const showNotification = (note: CoreNote) => {
+  // xxx add dex icon?
+  //  const icon = '';
+  const notification = new Notification(note.subject, { body: note.details })
+  notification.onclick = () => {
+    notification.close()
+    window.parent.focus()
   }
 }

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -288,6 +288,7 @@ export interface CoreNote {
   stamp: number
   acked: boolean
   id: string
+  permission: boolean
 }
 
 export interface BondNote extends CoreNote {

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -154,6 +154,9 @@ type clientCore interface {
 	AddWalletPeer(assetID uint32, addr string) error
 	RemoveWalletPeer(assetID uint32, addr string) error
 	Notifications(n int) ([]*db.Notification, error)
+	NoteTypePermissionsOpt() map[string]string
+	SetNotesTypePermission([]string) error
+	GetNoteTypePermission(string) (bool, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -423,6 +426,8 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/getwalletpeers", s.apiGetWalletPeers)
 			apiAuth.Post("/addwalletpeer", s.apiAddWalletPeer)
 			apiAuth.Post("/removewalletpeer", s.apiRemoveWalletPeer)
+			apiAuth.Post("/getnotetypepermission", s.apiGetNoteTypePermission)
+			apiAuth.Post("/setnotestypepermission", s.apiSetNotesTypePermission)
 			if s.experimental {
 				apiAuth.Post("/createbot", s.apiCreateBot)
 				apiAuth.Post("/startbot", s.apiStartBot)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -296,6 +296,18 @@ func (c *TCore) MarketReport(host string, baseID, quoteID uint32) (*core.MarketR
 	return nil, nil
 }
 
+func (c *TCore) GetNoteTypePermission(string) (bool, error) {
+	return false, nil
+}
+
+func (c *TCore) NoteTypePermissionsOpt() map[string]string {
+	return nil
+}
+
+func (c *TCore) SetNotesTypePermission([]string) error {
+	return nil
+}
+
 type TWriter struct {
 	b []byte
 }


### PR DESCRIPTION
Closes #2027. This PR stills a draft.

I am adding a new bolt's db key `notesPermissionKey`  which will be used to store note types. I created a noteTypesOpts element, to populate it at our front-end, this is how it currently looks:

![image](https://user-images.githubusercontent.com/15069783/218277553-f0330dd9-b570-4a27-bb92-c16e844d695a.png)

When sending notifications to the client, we check if permission is granted and shows our notification. 

Example on firefox:

![image](https://user-images.githubusercontent.com/15069783/218277509-4fc5830e-e604-4ec0-af43-f2ff16911e97.png)
  