### PR TITLE
client/comms: check for non-standard compliant error

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -213,7 +213,7 @@ func (conn *wsConn) connect(ctx context.Context) error {
 	ws, _, err := dialer.DialContext(ctx, conn.cfg.URL, nil)
 	if err != nil {
 		var e x509.UnknownAuthorityError
-		if errors.As(err, &e) {
+		if errors.As(err, &e) || strings.Contains(err.Error(), "certificate is not standards compliant") {
 			conn.setConnectionStatus(InvalidCert)
 			if conn.tlsCfg == nil {
 				return ErrCertRequired

--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -70,13 +70,12 @@ func (cs ConnectionStatus) String() string {
 var invalidCertRegexp = regexp.MustCompile(".*(unknown authority|not standards compliant|not trusted)")
 
 // isErrorInvalidCert checks if the provided error is one of the different
-// variant of an invalid cert error returned from the x509 package or is
-// ErrInvalidCert.
+// variant of an invalid cert error returned from the x509 package.
 func isErrorInvalidCert(err error) bool {
 	var invalidCertErr x509.CertificateInvalidError
 	var unknownCertAuthErr x509.UnknownAuthorityError
 	var hostNameErr x509.HostnameError
-	return errors.Is(err, ErrInvalidCert) || errors.As(err, &invalidCertErr) || errors.As(err, &hostNameErr) ||
+	return errors.As(err, &invalidCertErr) || errors.As(err, &hostNameErr) ||
 		errors.As(err, &unknownCertAuthErr) || invalidCertRegexp.MatchString(err.Error())
 }
 
@@ -231,9 +230,9 @@ func (conn *wsConn) connect(ctx context.Context) error {
 		if isErrorInvalidCert(err) {
 			conn.setConnectionStatus(InvalidCert)
 			if conn.tlsCfg == nil {
-				return ErrCertRequired
+				return dex.NewError(ErrCertRequired, err.Error())
 			}
-			return ErrInvalidCert
+			return dex.NewError(ErrInvalidCert, err.Error())
 		}
 		conn.setConnectionStatus(Disconnected)
 		return err

--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -263,13 +263,13 @@ func TestWsConn(t *testing.T) {
 	err = noCertConnMaster.Connect(ctx)
 	noCertConnMaster.Disconnect()
 	if err == nil || !errors.Is(err, ErrCertRequired) {
-		t.Fatalf("failed to get ErrCertRequired for no cert connection")
+		t.Fatalf("failed to get ErrCertRequired for no cert connection, got %v", err)
 	}
 
 	// test invalid cert error
 	_, err = setupWsConn([]byte("invalid cert"))
 	if err == nil || !errors.Is(err, ErrInvalidCert) {
-		t.Fatalf("failed to get ErrInvalidCert for invalid cert connection")
+		t.Fatalf("failed to get ErrInvalidCert for invalid cert connection, got %v", err)
 	}
 
 	// connect with cert


### PR DESCRIPTION
This seems to be a known issue on some versions of `MacOS` or `OS X` where an error: `x509: “invalid-cert-name” certificate is not standards compliant` is returned. Since we cannot check the error type using `errors.Is` or `errors.As`, this PR checks if the returned error contains the known error message `certificate is not standards compliant`.

Users could run varying versions of `macOS` and could be affected by this issue. This PR will ensure that a retry loop is not started because the cert is considered `Invalid`.

Issue: https://github.com/golang/go/issues/51991

For more context, I use `macOS` and was a bit flustered that `TestWsConn` kept failing, so I had to investigate. 