### PR TITLE
client/core: dexAccount race

### DIFF
--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -165,7 +165,7 @@ func (c *Core) rotateBonds(ctx context.Context) {
 	}
 
 	for _, dc := range c.dexConnections() {
-		initialized, unlocked, _ := dc.acct.status()
+		initialized, unlocked := dc.acct.status()
 		if !initialized {
 			continue // view-only or temporary connection
 		}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -841,10 +841,10 @@ func (a *dexAccount) lock() {
 	a.keyMtx.Unlock()
 }
 
-func (a *dexAccount) status() (initialized, unlocked, authed bool) {
+func (a *dexAccount) status() (initialized, unlocked bool) {
 	a.keyMtx.RLock()
 	defer a.keyMtx.RUnlock()
-	return len(a.encKey) > 0, a.privKey != nil, a.isAuthed
+	return len(a.encKey) > 0, a.privKey != nil
 }
 
 // locked will be true if the account private key is currently decrypted, or


### PR DESCRIPTION
Observed another race:

```
WARNING: DATA RACE
Read at 0x00c0006a80a0 by goroutine 47:
  decred.org/dcrdex/client/core.(*dexAccount).status()
      /Users/norwnd/dcrdex/client/core/types.go:847 +0xed
  decred.org/dcrdex/client/core.(*Core).rotateBonds()
      /Users/norwnd/dcrdex/client/core/bond.go:168 +0x1e4
  decred.org/dcrdex/client/core.(*Core).watchBonds()
      /Users/norwnd/dcrdex/client/core/bond.go:44 +0xd6
  decred.org/dcrdex/client/core.(*Core).Run.func3()
      /Users/norwnd/dcrdex/client/core/core.go:1579 +0x9e

Previous write at 0x00c0006a80a0 by goroutine 1617:
  decred.org/dcrdex/client/core.(*dexAccount).auth()
      /Users/norwnd/dcrdex/client/core/types.go:878 +0x5e
  decred.org/dcrdex/client/core.(*Core).authDEX()
      /Users/norwnd/dcrdex/client/core/core.go:6000 +0x15e6
  decred.org/dcrdex/client/core.(*Core).handleReconnect()
      /Users/norwnd/dcrdex/client/core/core.go:7543 +0xf24
  decred.org/dcrdex/client/core.(*Core).connectDEX.func2.1()
      /Users/norwnd/dcrdex/client/core/core.go:7377 +0x58
```

Not sure whether `authed bool` returned intentionally maybe for future usage, but right now it seems to be the reason for this race. In case it needs to stay, I can simply sketch out another similar fix too.