### PR TITLE
ui: wallet sync progress improvements (register page)

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=1yeumsqty"></script>
+<script src="/js/entry.js?v=N2HhoiFV"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -508,7 +508,8 @@
     <span class="fs16 grey">%</span>
   </div>
   <div class="mt-1 flex-center flex-row fs14 d-hide" data-tmpl="syncRemainBox">
-    <span data-tmpl="syncRemain" class="me-1"></span> [[[remaining]]]
+    <span data-tmpl="syncRemaining"><span data-tmpl="syncRemain" class="me-1"></span> [[[remaining]]]</span>
+    <span data-tmpl="syncFinishingUp" class="me-1"></span>
   </div>
 </div>
 

--- a/client/webserver/site/src/js/locales.ts
+++ b/client/webserver/site/src/js/locales.ts
@@ -107,6 +107,7 @@ export const ID_MAKER = 'MAKER'
 export const ID_EMPTY_DEX_ADDRESS_MSG = 'EMPTY_DEX_ADDRESS_MSG'
 export const ID_SELECT_WALLET_FOR_FEE_PAYMENT = 'SELECT_WALLET_FOR_FEE_PAYMENT'
 export const ID_UNAVAILABLE = 'UNAVAILABLE'
+export const ID_WALLET_SYNC_FINISHING_UP = 'WALLET_SYNC_FINISHING_UP'
 
 export const enUS: Locale = {
   [ID_NO_PASS_ERROR_MSG]: 'password cannot be empty',
@@ -215,7 +216,8 @@ export const enUS: Locale = {
   [ID_MAKER]: 'Maker',
   [ID_UNAVAILABLE]: 'unavailable',
   [ID_EMPTY_DEX_ADDRESS_MSG]: 'DEX address cannot be empty',
-  [ID_SELECT_WALLET_FOR_FEE_PAYMENT]: 'You must select a valid wallet for fee payment'
+  [ID_SELECT_WALLET_FOR_FEE_PAYMENT]: 'You must select a valid wallet for fee payment',
+  [ID_WALLET_SYNC_FINISHING_UP]: 'finishing up'
 }
 
 export const ptBR: Locale = {


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/2080.

This should address boths parts of https://github.com/decred/dcrdex/issues/2080:
- progress stuck at 100% for more than one would expect (while wallet is still undergoing some final stages of syncing; this also makes sync progress behavior  consistent with 99.9% shown on `/wallets` page)

current behavior seems to result from rounding 99.9% to 100% (currently on **master**), while `.toFixed(1)` will not round and just trim all the extra digits instead, which is probably what we want here too,

- `> 1 day remaining` message isn't very accurate

I've reimplemented some edge-case handling to address that.