### PR TITLE
client/eth: Only call tipChange and peersChange for connected wallets

### DIFF
--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -441,6 +441,7 @@ func TestCheckForNewBlocks(t *testing.T) {
 			currentTip: header0,
 		}
 		w.wallets = map[uint32]*assetWallet{BipID: w.assetWallet}
+		w.assetWallet.connected.Store(true)
 		w.checkForNewBlocks(tipChange)
 
 		if test.hasTipChange {


### PR DESCRIPTION
`TipChange` was being called for token wallets that were not yet connected. This caused core to call the token wallet to retrieve its balance, but because it was not yet connected, it would return an error.

Closes #2137. 