### PR TITLE
client/asset/eth: use currentFeeRate for preSwap, not max

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1146,18 +1146,18 @@ func (w *assetWallet) balance() (*asset.Balance, error) {
 // associated with nfo.MaxFeeRate. For quote assets, the caller will have to
 // calculate lotSize based on a rate conversion from the base asset's lot size.
 func (w *ETHWallet) MaxOrder(ord *asset.MaxOrderForm) (*asset.SwapEstimate, error) {
-	return w.maxOrder(ord.LotSize, ord.FeeSuggestion, ord.MaxFeeRate, ord.AssetVersion,
+	return w.maxOrder(ord.LotSize, ord.MaxFeeRate, ord.AssetVersion,
 		ord.RedeemVersion, ord.RedeemAssetID, nil)
 }
 
 // MaxOrder generates information about the maximum order size and associated
 // fees that the wallet can support for the given DEX configuration.
 func (w *TokenWallet) MaxOrder(ord *asset.MaxOrderForm) (*asset.SwapEstimate, error) {
-	return w.maxOrder(ord.LotSize, ord.FeeSuggestion, ord.MaxFeeRate, ord.AssetVersion,
+	return w.maxOrder(ord.LotSize, ord.MaxFeeRate, ord.AssetVersion,
 		ord.RedeemVersion, ord.RedeemAssetID, w.parent)
 }
 
-func (w *assetWallet) maxOrder(lotSize uint64, feeSuggestion, maxFeeRate uint64, ver uint32,
+func (w *assetWallet) maxOrder(lotSize uint64, maxFeeRate uint64, ver uint32,
 	redeemVer, redeemAssetID uint32, feeWallet *assetWallet) (*asset.SwapEstimate, error) {
 	balance, err := w.Balance()
 	if err != nil {
@@ -1193,7 +1193,7 @@ func (w *assetWallet) maxOrder(lotSize uint64, feeSuggestion, maxFeeRate uint64,
 	if lots < 1 {
 		return &asset.SwapEstimate{}, nil
 	}
-	return w.estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate, ver, redeemVer, redeemAssetID)
+	return w.estimateSwap(lots, lotSize, maxFeeRate, ver, redeemVer, redeemAssetID)
 }
 
 // PreSwap gets order estimates based on the available funds and the wallet
@@ -1209,17 +1209,7 @@ func (w *TokenWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, error) {
 }
 
 func (w *assetWallet) preSwap(req *asset.PreSwapForm, feeWallet *assetWallet) (*asset.PreSwap, error) {
-	// Get a realistic current effective fee rate, ignoring req.FeeSuggestion
-	// since it is generally MaxFeeRate because of dynamic txns.
-	rateNow, err := w.currentFeeRate(w.ctx)
-	if err != nil {
-		return nil, err
-	}
-	rate, err := dexeth.WeiToGweiUint64(rateNow)
-	if err != nil {
-		return nil, fmt.Errorf("invalid current fee rate: %v", err)
-	}
-	maxEst, err := w.maxOrder(req.LotSize, rate, req.MaxFeeRate, req.Version,
+	maxEst, err := w.maxOrder(req.LotSize, req.MaxFeeRate, req.Version,
 		req.RedeemVersion, req.RedeemAssetID, feeWallet)
 	if err != nil {
 		return nil, err
@@ -1229,7 +1219,7 @@ func (w *assetWallet) preSwap(req *asset.PreSwapForm, feeWallet *assetWallet) (*
 		return nil, fmt.Errorf("%d lots available for %d-lot order", maxEst.Lots, req.Lots)
 	}
 
-	est, err := w.estimateSwap(req.Lots, req.LotSize, rate, req.MaxFeeRate,
+	est, err := w.estimateSwap(req.Lots, req.LotSize, req.MaxFeeRate,
 		req.Version, req.RedeemVersion, req.RedeemAssetID)
 	if err != nil {
 		return nil, err
@@ -1253,16 +1243,41 @@ func (w *assetWallet) SingleLotSwapFees(form *asset.PreSwapForm) (fees uint64, e
 
 // estimateSwap prepares an *asset.SwapEstimate. The estimate does not include
 // funds that might be locked for refunds.
-func (w *assetWallet) estimateSwap(lots, lotSize, feeSuggestion uint64, maxFeeRate uint64, ver uint32,
+func (w *assetWallet) estimateSwap(lots, lotSize uint64, maxFeeRate uint64, ver uint32,
 	redeemVer, redeemAssetID uint32) (*asset.SwapEstimate, error) {
 	if lots == 0 {
 		return &asset.SwapEstimate{}, nil
 	}
 
-	oneSwap, nSwap, _, err := w.swapGas(int(lots), ver)
+	rateNow, err := w.currentFeeRate(w.ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error getting swap gas estimate: %w", err)
+		return nil, err
 	}
+	rate, err := dexeth.WeiToGweiUint64(rateNow)
+	if err != nil {
+		return nil, fmt.Errorf("invalid current fee rate: %v", err)
+	}
+
+	// This is an estimate, so we use the (lower) live gas estimates. If we're
+	// not approved, we can't get a live gas estimate, but we'll use higher the
+	// hard-coded gases that are heavily padded for the txOps field.
+	var oneSwap uint64
+	if approved, err := w.isApproved(); err != nil {
+		return nil, fmt.Errorf("error checking approval: %w", err)
+	} else if !approved {
+		g := w.gases(ver)
+		if g == nil {
+			return nil, fmt.Errorf("no gases known for %d version %d", w.assetID, ver)
+		}
+		oneSwap = g.Swap
+	} else {
+		oneSwap, err = w.estimateInitGas(w.ctx, 1, ver)
+		if err != nil {
+			return nil, fmt.Errorf("(%d) error estimating swap gas: %v", w.assetID, err)
+		}
+	}
+	// NOTE: nSwap is neither best nor worst case. A single match can be
+	// multiple lots. See RealisticBestCase descriptions.
 
 	value := lots * lotSize
 	allowanceGas, err := w.allowanceGasRequired(redeemVer, redeemAssetID)
@@ -1277,8 +1292,8 @@ func (w *assetWallet) estimateSwap(lots, lotSize, feeSuggestion uint64, maxFeeRa
 		Lots:               lots,
 		Value:              value,
 		MaxFees:            maxFees,
-		RealisticWorstCase: oneGasMax * feeSuggestion,
-		RealisticBestCase:  (nSwap + allowanceGas) * feeSuggestion,
+		RealisticWorstCase: oneGasMax * rate,
+		RealisticBestCase:  (oneSwap + allowanceGas) * rate, // not even batch, just perfect match
 	}, nil
 }
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1308,7 +1308,7 @@ func testFundOrderReturnCoinsFundingCoins(t *testing.T, assetID uint32) {
 
 func TestPreSwap(t *testing.T) {
 	const baseFee, tip = 42, 2
-	const feeSuggestion = 90
+	const feeSuggestion = 90 // ignored by eth's PreSwap
 	const lotSize = 10e9
 	oneFee := ethGases.Swap * tETH.MaxFeeRate
 	refund := ethGases.Refund * tETH.MaxFeeRate
@@ -1316,7 +1316,7 @@ func TestPreSwap(t *testing.T) {
 
 	oneFeeToken := tokenGases.Swap*tToken.MaxFeeRate + tokenGases.Refund*tToken.MaxFeeRate
 
-	tests := []struct {
+	type testData struct {
 		name      string
 		bal       uint64
 		balErr    error
@@ -1330,7 +1330,9 @@ func TestPreSwap(t *testing.T) {
 		wantMaxFees   uint64
 		wantWorstCase uint64
 		wantBestCase  uint64
-	}{
+	}
+
+	tests := []testData{
 		{
 			name: "no balance",
 			bal:  0,
@@ -1402,7 +1404,7 @@ func TestPreSwap(t *testing.T) {
 			wantLots:      4,
 			wantValue:     4 * lotSize,
 			wantMaxFees:   4 * tETH.MaxFeeRate * ethGases.Swap,
-			wantBestCase:  (baseFee + tip) * ethGases.SwapN(4),
+			wantBestCase:  (baseFee + tip) * ethGases.Swap,
 			wantWorstCase: 4 * (baseFee + tip) * ethGases.Swap,
 		},
 		{
@@ -1415,7 +1417,7 @@ func TestPreSwap(t *testing.T) {
 			wantLots:      4,
 			wantValue:     4 * lotSize,
 			wantMaxFees:   4 * tToken.MaxFeeRate * tokenGases.Swap,
-			wantBestCase:  (baseFee + tip) * tokenGases.SwapN(4),
+			wantBestCase:  (baseFee + tip) * tokenGases.Swap,
 			wantWorstCase: 4 * (baseFee + tip) * tokenGases.Swap,
 		},
 		{
@@ -1437,7 +1439,7 @@ func TestPreSwap(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
+	runTest := func(t *testing.T, test testData) {
 		var assetID uint32 = BipID
 		assetCfg := tETH
 		if test.token {
@@ -1450,6 +1452,8 @@ func TestPreSwap(t *testing.T) {
 		node.baseFee, node.tip = dexeth.GweiToWei(baseFee), dexeth.GweiToWei(tip)
 
 		if test.token {
+			node.tContractor.gasEstimates = &tokenGases
+			node.tokenContractor.allow = unlimitedAllowance
 			node.tokenContractor.bal = dexeth.GweiToWei(test.bal)
 			node.bal = dexeth.GweiToWei(test.parentBal)
 		} else {
@@ -1463,38 +1467,44 @@ func TestPreSwap(t *testing.T) {
 			LotSize:       lotSize,
 			Lots:          test.lots,
 			MaxFeeRate:    assetCfg.MaxFeeRate,
-			FeeSuggestion: feeSuggestion,
+			FeeSuggestion: feeSuggestion, // ignored
 			RedeemVersion: tBTC.Version,
 			RedeemAssetID: tBTC.ID,
 		})
 
 		if test.wantErr {
 			if err == nil {
-				t.Fatalf("expected error for test %q", test.name)
+				t.Fatalf("expected error")
 			}
-			continue
+			return
 		}
 		if err != nil {
-			t.Fatalf("unexpected error for test %q: %v", test.name, err)
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		est := preSwap.Estimate
 
 		if est.Lots != test.wantLots {
-			t.Fatalf("want lots %v got %v for test %q", test.wantLots, est.Lots, test.name)
+			t.Fatalf("want lots %v got %v", test.wantLots, est.Lots)
 		}
 		if est.Value != test.wantValue {
-			t.Fatalf("want value %v got %v for test %q", test.wantValue, est.Value, test.name)
+			t.Fatalf("want value %v got %v", test.wantValue, est.Value)
 		}
 		if est.MaxFees != test.wantMaxFees {
-			t.Fatalf("want maxFees %v got %v for test %q", test.wantMaxFees, est.MaxFees, test.name)
+			t.Fatalf("want maxFees %v got %v", test.wantMaxFees, est.MaxFees)
 		}
 		if est.RealisticBestCase != test.wantBestCase {
-			t.Fatalf("want best case %v got %v for test %q", test.wantBestCase, est.RealisticBestCase, test.name)
+			t.Fatalf("want best case %v got %v", test.wantBestCase, est.RealisticBestCase)
 		}
 		if est.RealisticWorstCase != test.wantWorstCase {
-			t.Fatalf("want worst case %v got %v for test %q", test.wantWorstCase, est.RealisticWorstCase, test.name)
+			t.Fatalf("want worst case %v got %v", test.wantWorstCase, est.RealisticWorstCase)
 		}
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runTest(t, test)
+		})
 	}
 }
 
@@ -2365,7 +2375,9 @@ func testRedeem(t *testing.T, assetID uint32) {
 }
 
 func TestMaxOrder(t *testing.T) {
-	tests := []struct {
+	const baseFee, tip = 42, 2
+
+	type testData struct {
 		name          string
 		bal           uint64
 		balErr        error
@@ -2381,7 +2393,8 @@ func TestMaxOrder(t *testing.T) {
 		wantWorstCase uint64
 		wantBestCase  uint64
 		wantLocked    uint64
-	}{
+	}
+	tests := []testData{
 		{
 			name:          "no balance",
 			bal:           0,
@@ -2423,8 +2436,8 @@ func TestMaxOrder(t *testing.T) {
 			wantLots:      1,
 			wantValue:     ethToGwei(10),
 			wantMaxFees:   100 * ethGases.Swap,
-			wantBestCase:  90 * ethGases.Swap,
-			wantWorstCase: 90 * ethGases.Swap,
+			wantBestCase:  (baseFee + tip) * ethGases.Swap,
+			wantWorstCase: (baseFee + tip) * ethGases.Swap,
 			wantLocked:    ethToGwei(10) + (100 * ethGases.Swap),
 		},
 		{
@@ -2438,8 +2451,8 @@ func TestMaxOrder(t *testing.T) {
 			wantLots:      1,
 			wantValue:     ethToGwei(10),
 			wantMaxFees:   100 * tokenGases.Swap,
-			wantBestCase:  90 * tokenGases.Swap,
-			wantWorstCase: 90 * tokenGases.Swap,
+			wantBestCase:  (baseFee + tip) * tokenGases.Swap,
+			wantWorstCase: (baseFee + tip) * tokenGases.Swap,
 			wantLocked:    ethToGwei(10) + (100 * tokenGases.Swap),
 		},
 		{
@@ -2451,8 +2464,8 @@ func TestMaxOrder(t *testing.T) {
 			wantLots:      5,
 			wantValue:     ethToGwei(50),
 			wantMaxFees:   5 * 100 * ethGases.Swap,
-			wantBestCase:  90 * ethGases.SwapN(5),
-			wantWorstCase: 5 * 90 * ethGases.Swap,
+			wantBestCase:  (baseFee + tip) * ethGases.Swap,
+			wantWorstCase: 5 * (baseFee + tip) * ethGases.Swap,
 			wantLocked:    ethToGwei(50) + (5 * 100 * ethGases.Swap),
 		},
 		{
@@ -2466,8 +2479,8 @@ func TestMaxOrder(t *testing.T) {
 			wantLots:      5,
 			wantValue:     ethToGwei(50),
 			wantMaxFees:   5 * 100 * tokenGases.Swap,
-			wantBestCase:  90 * tokenGases.SwapN(5),
-			wantWorstCase: 5 * 90 * tokenGases.Swap,
+			wantBestCase:  (baseFee + tip) * tokenGases.Swap,
+			wantWorstCase: 5 * (baseFee + tip) * tokenGases.Swap,
 			wantLocked:    ethToGwei(50) + (5 * 100 * tokenGases.Swap),
 		},
 		{
@@ -2480,20 +2493,22 @@ func TestMaxOrder(t *testing.T) {
 			wantErr:       true,
 		},
 	}
-	redeemerAsset := tBTC
 
-	for _, test := range tests {
+	runTest := func(t *testing.T, test testData) {
 		var assetID uint32 = BipID
-		dexAsset := tETH
+		assetCfg := tETH
 		if test.token {
 			assetID = simnetTokenID
+			assetCfg = tToken
 		}
 
 		w, _, node, shutdown := tassetWallet(assetID)
 		defer shutdown()
+		node.baseFee, node.tip = dexeth.GweiToWei(baseFee), dexeth.GweiToWei(tip)
 
 		if test.token {
-			dexAsset = tToken
+			node.tContractor.gasEstimates = &tokenGases
+			node.tokenContractor.allow = unlimitedAllowance
 			node.tokenContractor.bal = dexeth.GweiToWei(ethToGwei(test.bal))
 			node.bal = dexeth.GweiToWei(ethToGwei(test.parentBal))
 		} else {
@@ -2502,41 +2517,45 @@ func TestMaxOrder(t *testing.T) {
 
 		node.balErr = test.balErr
 
-		dexAsset.MaxFeeRate = test.maxFeeRate
-
 		maxOrder, err := w.MaxOrder(&asset.MaxOrderForm{
 			LotSize:       ethToGwei(test.lotSize),
-			FeeSuggestion: test.feeSuggestion,
-			AssetVersion:  dexAsset.Version,
-			MaxFeeRate:    dexAsset.MaxFeeRate,
-			RedeemVersion: redeemerAsset.Version,
-			RedeemAssetID: redeemerAsset.ID,
+			FeeSuggestion: test.feeSuggestion, // ignored
+			AssetVersion:  assetCfg.Version,
+			MaxFeeRate:    test.maxFeeRate,
+			RedeemVersion: tBTC.Version,
+			RedeemAssetID: tBTC.ID,
 		})
 		if test.wantErr {
 			if err == nil {
-				t.Fatalf("expected error for test %q", test.name)
+				t.Fatalf("expected error")
 			}
-			continue
+			return
 		}
 		if err != nil {
-			t.Fatalf("unexpected error for test %q: %v", test.name, err)
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		if maxOrder.Lots != test.wantLots {
-			t.Fatalf("want lots %v got %v for test %q", test.wantLots, maxOrder.Lots, test.name)
+			t.Fatalf("want lots %v got %v", test.wantLots, maxOrder.Lots)
 		}
 		if maxOrder.Value != test.wantValue {
-			t.Fatalf("want value %v got %v for test %q", test.wantValue, maxOrder.Value, test.name)
+			t.Fatalf("want value %v got %v", test.wantValue, maxOrder.Value)
 		}
 		if maxOrder.MaxFees != test.wantMaxFees {
-			t.Fatalf("want maxFees %v got %v for test %q", test.wantMaxFees, maxOrder.MaxFees, test.name)
+			t.Fatalf("want maxFees %v got %v", test.wantMaxFees, maxOrder.MaxFees)
 		}
 		if maxOrder.RealisticBestCase != test.wantBestCase {
-			t.Fatalf("want best case %v got %v for test %q", test.wantBestCase, maxOrder.RealisticBestCase, test.name)
+			t.Fatalf("want best case %v got %v", test.wantBestCase, maxOrder.RealisticBestCase)
 		}
 		if maxOrder.RealisticWorstCase != test.wantWorstCase {
-			t.Fatalf("want worst case %v got %v for test %q", test.wantWorstCase, maxOrder.RealisticWorstCase, test.name)
+			t.Fatalf("want worst case %v got %v", test.wantWorstCase, maxOrder.RealisticWorstCase)
 		}
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runTest(t, test)
+		})
 	}
 }
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1307,6 +1307,7 @@ func testFundOrderReturnCoinsFundingCoins(t *testing.T, assetID uint32) {
 }
 
 func TestPreSwap(t *testing.T) {
+	const baseFee, tip = 42, 2
 	const feeSuggestion = 90
 	const lotSize = 10e9
 	oneFee := ethGases.Swap * tETH.MaxFeeRate
@@ -1361,8 +1362,8 @@ func TestPreSwap(t *testing.T) {
 			wantLots:      1,
 			wantValue:     lotSize,
 			wantMaxFees:   tETH.MaxFeeRate * ethGases.Swap,
-			wantBestCase:  feeSuggestion * ethGases.Swap,
-			wantWorstCase: feeSuggestion * ethGases.Swap,
+			wantBestCase:  (baseFee + tip) * ethGases.Swap,
+			wantWorstCase: (baseFee + tip) * ethGases.Swap,
 		},
 		{
 			name:      "one lot enough for fees - token",
@@ -1374,8 +1375,8 @@ func TestPreSwap(t *testing.T) {
 			wantLots:      1,
 			wantValue:     lotSize,
 			wantMaxFees:   tToken.MaxFeeRate * tokenGases.Swap,
-			wantBestCase:  feeSuggestion * tokenGases.Swap,
-			wantWorstCase: feeSuggestion * tokenGases.Swap,
+			wantBestCase:  (baseFee + tip) * tokenGases.Swap,
+			wantWorstCase: (baseFee + tip) * tokenGases.Swap,
 		},
 		{
 			name: "more lots than max lots",
@@ -1401,8 +1402,8 @@ func TestPreSwap(t *testing.T) {
 			wantLots:      4,
 			wantValue:     4 * lotSize,
 			wantMaxFees:   4 * tETH.MaxFeeRate * ethGases.Swap,
-			wantBestCase:  feeSuggestion * ethGases.SwapN(4),
-			wantWorstCase: 4 * feeSuggestion * ethGases.Swap,
+			wantBestCase:  (baseFee + tip) * ethGases.SwapN(4),
+			wantWorstCase: 4 * (baseFee + tip) * ethGases.Swap,
 		},
 		{
 			name:      "fewer than max lots - token",
@@ -1414,8 +1415,8 @@ func TestPreSwap(t *testing.T) {
 			wantLots:      4,
 			wantValue:     4 * lotSize,
 			wantMaxFees:   4 * tToken.MaxFeeRate * tokenGases.Swap,
-			wantBestCase:  feeSuggestion * tokenGases.SwapN(4),
-			wantWorstCase: 4 * feeSuggestion * tokenGases.Swap,
+			wantBestCase:  (baseFee + tip) * tokenGases.SwapN(4),
+			wantWorstCase: 4 * (baseFee + tip) * tokenGases.Swap,
 		},
 		{
 			name:   "balanceError",
@@ -1446,6 +1447,7 @@ func TestPreSwap(t *testing.T) {
 
 		w, _, node, shutdown := tassetWallet(assetID)
 		defer shutdown()
+		node.baseFee, node.tip = dexeth.GweiToWei(baseFee), dexeth.GweiToWei(tip)
 
 		if test.token {
 			node.tokenContractor.bal = dexeth.GweiToWei(test.bal)


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/2136 <s>https://github.com/decred/dcrdex/issues/2137</s>

Best/worst fee rate estimates from PreSwap (to PreOrder on frontend) are now considering the current effective (likely) fee rate, not the server's MaxFeeRate or the "recommended" max fee when authoring txns that would be more than double current base fee.