### PR TITLE
ui: fix order status discrepancy on different views

### DIFF
--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -268,6 +268,9 @@ func (ord *OrderReader) hasActiveMatches() bool {
 }
 
 // StatusString is the order status.
+//
+// IMPORTANT: we have similar function in JS for UI, it must match this one exactly,
+// when updating make sure to update both!
 func (ord *OrderReader) StatusString() string {
 	isLive := ord.hasActiveMatches()
 	switch ord.Status {

--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -256,8 +256,9 @@ func (ord *OrderReader) sumTo(filter func(match *Match) bool) uint64 {
 	return v
 }
 
-// hasLiveMatches will be true if there are any matches < MakerRedeemed.
-func (ord *OrderReader) hasLiveMatches() bool {
+// hasActiveMatches will be true if order has any matches that still require some
+// actions to complete settlement.
+func (ord *OrderReader) hasActiveMatches() bool {
 	for _, match := range ord.Matches {
 		if match.Active {
 			return true
@@ -268,7 +269,7 @@ func (ord *OrderReader) hasLiveMatches() bool {
 
 // StatusString is the order status.
 func (ord *OrderReader) StatusString() string {
-	isLive := ord.hasLiveMatches()
+	isLive := ord.hasActiveMatches()
 	switch ord.Status {
 	case order.OrderStatusUnknown:
 		return "unknown"

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -9,7 +9,7 @@ import OrdersPage from './orders'
 import OrderPage from './order'
 import DexSettingsPage from './dexsettings'
 import MarketMakerPage from './mm'
-import { RateEncodingFactor, StatusExecuted, hasLiveMatches } from './orderutil'
+import { RateEncodingFactor, StatusExecuted, hasActiveMatches } from './orderutil'
 import { getJSON, postJSON, Errors } from './http'
 import * as ntfn from './notifications'
 import ws from './ws'
@@ -807,26 +807,15 @@ export default class Application {
    * haveActiveOrders returns whether or not there are active orders involving a
    * certain asset.
    */
-  haveAssetOrders (assetID: number): boolean {
+  haveActiveOrders (assetID: number): boolean {
     for (const xc of Object.values(this.user.exchanges)) {
       if (!xc.markets) continue
       for (const market of Object.values(xc.markets)) {
         if (!market.orders) continue
         for (const ord of market.orders) {
           if ((ord.baseID === assetID || ord.quoteID === assetID) &&
-            (ord.status < StatusExecuted || hasLiveMatches(ord))) return true
+            (ord.status < StatusExecuted || hasActiveMatches(ord))) return true
         }
-      }
-    }
-    return false
-  }
-
-  walletIsActive (assetID: number): boolean {
-    if (this.haveAssetOrders(assetID)) return true
-    for (const xc of Object.values(this.user.exchanges)) {
-      if (!xc) continue
-      if (xc.pendingFee && xc.pendingFee.assetID === assetID) {
-        return true
       }
     }
     return false

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -10,7 +10,7 @@ import { BooleanOption, XYRangeOption } from './opts'
 
 export const Limit = 1
 export const Market = 2
-export const CANCEL = 3
+export const Cancel = 3
 
 /* The time-in-force specifiers are a mirror of dex/order.TimeInForce. */
 export const ImmediateTiF = 0
@@ -82,7 +82,8 @@ export function statusString (order: Order): string {
       return isLive ? `${intl.prep(intl.ID_BOOKED)}/${intl.prep(intl.ID_SETTLING)}` : intl.prep(intl.ID_BOOKED)
     case StatusExecuted:
       if (isLive) return intl.prep(intl.ID_SETTLING)
-      return (order.filled === 0) ? intl.prep(intl.ID_NO_MATCH) : intl.prep(intl.ID_EXECUTED)
+      if (order.filled === 0 && order.type !== Cancel) return intl.prep(intl.ID_NO_MATCH)
+      return intl.prep(intl.ID_EXECUTED)
     case StatusCanceled:
       return isLive ? `${intl.prep(intl.ID_CANCELED)}/${intl.prep(intl.ID_SETTLING)}` : intl.prep(intl.ID_CANCELED)
     case StatusRevoked:

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -59,13 +59,13 @@ export function isMarketBuy (ord: Order) {
 }
 
 /*
- * hasLiveMatches returns true if the order has matches that have not completed
+ * hasActiveMatches returns true if the order has matches that have not completed
  * settlement yet.
  */
-export function hasLiveMatches (order: Order) {
+export function hasActiveMatches (order: Order) {
   if (!order.matches) return false
   for (const match of order.matches) {
-    if (!match.revoked && match.status < MakerRedeemed) return true
+    if (match.active) return true
   }
   return false
 }
@@ -73,7 +73,7 @@ export function hasLiveMatches (order: Order) {
 /* statusString converts the order status to a string */
 export function statusString (order: Order): string {
   if (!order.id) return intl.prep(intl.ID_ORDER_SUBMITTING) // order ID is empty.
-  const isLive = hasLiveMatches(order)
+  const isLive = hasActiveMatches(order)
   switch (order.status) {
     case StatusUnknown: return intl.prep(intl.ID_UNKNOWN)
     case StatusEpoch: return intl.prep(intl.ID_EPOCH)
@@ -88,7 +88,7 @@ export function statusString (order: Order): string {
     case StatusRevoked:
       return isLive ? `${intl.prep(intl.ID_REVOKED)}/${intl.prep(intl.ID_SETTLING)}` : intl.prep(intl.ID_REVOKED)
   }
-  return ''
+  return intl.prep(intl.ID_UNKNOWN)
 }
 
 /* filled sums the quantities of non-cancel matches available. */

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -70,7 +70,12 @@ export function hasActiveMatches (order: Order) {
   return false
 }
 
-/* statusString converts the order status to a string */
+/**
+ * statusString converts the order status to a string.
+ *
+ * IMPORTANT: we have similar function in Golang, it must match this one exactly,
+ * when updating make sure to update both!
+ */
 export function statusString (order: Order): string {
   if (!order.id) return intl.prep(intl.ID_ORDER_SUBMITTING) // order ID is empty.
   const isLive = hasActiveMatches(order)

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -596,8 +596,7 @@ export interface Application {
   prependListElement (noteList: HTMLElement, note: CoreNote, el: NoteElement): void
   loading (el: HTMLElement): () => void
   orders (host: string, mktID: string): Order[]
-  haveAssetOrders (assetID: number): boolean
-  walletIsActive (assetID: number): boolean
+  haveActiveOrders (assetID: number): boolean
   order (oid: string): Order | null
   canAccelerateOrder(order: Order): boolean
   unitInfo (assetID: number, xc?: Exchange): UnitInfo

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -655,7 +655,7 @@ export default class WalletsPage extends BasePage {
         page.syncProgress.textContent = `${(wallet.syncProgress * 100).toFixed(1)}%`
         if (wallet.open) {
           Doc.show(page.statusReady)
-          if (!app().haveAssetOrders(assetID) && wallet.encrypted) Doc.show(page.lockBttnBox)
+          if (!app().haveActiveOrders(assetID) && wallet.encrypted) Doc.show(page.lockBttnBox)
         } else Doc.show(page.statusLocked, page.unlockBttnBox) // wallet not unlocked
       } else Doc.show(page.statusOff, page.connectBttnBox) // wallet not running
     } else Doc.show(page.createWalletBox) // no wallet
@@ -911,7 +911,7 @@ export default class WalletsPage extends BasePage {
       Doc.showFormError(page.reconfigErr, res.msg)
       return
     }
-    const assetHasActiveOrders = app().haveAssetOrders(assetID)
+    const assetHasActiveOrders = app().haveActiveOrders(assetID)
     this.reconfigForm.update(currentDef.configopts || [], assetHasActiveOrders)
     this.reconfigForm.setConfig(res.map)
     this.updateDisplayedReconfigFields(currentDef)


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1945.

For the case described in the linked issue (and I haven't seen other cases) now  status is same (and correct one) for all navigated views:

[status-discrepancy.webm](https://user-images.githubusercontent.com/112318969/219619838-0382951b-f727-4ebb-837e-514555db75ca.webm)
