### PR TITLE
client/db/bolt: ignore notes with bad IDs

### DIFF
--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -1835,7 +1835,7 @@ func (db *BoltDB) AckNotification(id []byte) error {
 // NotificationsN reads out the N most recent notifications.
 func (db *BoltDB) NotificationsN(n int) ([]*dexdb.Notification, error) {
 	notes := make([]*dexdb.Notification, 0, n)
-	return notes, db.notesView(func(master *bbolt.Bucket) error {
+	return notes, db.notesUpdate(func(master *bbolt.Bucket) error {
 		trios := newestBuckets([]*bbolt.Bucket{master}, n, stampKey, nil)
 		for _, trio := range trios {
 			note, err := dexdb.DecodeNotification(getCopy(trio.b, noteKey))
@@ -1844,6 +1844,17 @@ func (db *BoltDB) NotificationsN(n int) ([]*dexdb.Notification, error) {
 			}
 			note.Ack = bEqual(trio.b.Get(ackKey), byteTrue)
 			note.Id = note.ID()
+			if !bytes.Equal(note.Id, trio.k) {
+				// This notification was initially stored when the serialization
+				// and thus note ID did not include the TopicID. Ignore it, and
+				// flag it acknowledged so we don't have to hear about it again.
+				if !note.Ack {
+					db.log.Tracef("Ignoring stored note with bad key: %x != %x \"%s\"",
+						[]byte(note.Id), trio.k, note.String())
+					_ = trio.b.Put(ackKey, byteTrue)
+				}
+				continue
+			}
 			notes = append(notes, note)
 		}
 		return nil


### PR DESCRIPTION
The db.Notification serialization and thus ID changed in https://github.com/decred/dcrdex/commit/c994f032fe0e9a36e58a9a984dd924734c659e36#diff-592072666205a423f50bc3061a74c2cda51bfe4689d4044315ff285d29645bc3R832
The ID was used as the bucket key.
Therefore any notes prior to the upgrade will be stored in a bucket with a different key than it's new ID.  This isn't a big deal except that acknowledging such notes will fail for eternity.

In draft because I'm considering auto-acking such notes on load.