### PR TITLE
client/asset/{btc,dcr}: best swap estimate is perfect match

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1936,12 +1936,7 @@ func (btc *baseWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate uin
 	estHighFees := estHighFunds - val
 
 	estLowFunds := calc.RequiredOrderFundsAlt(val, uint64(inputsSize), 1,
-		btc.initTxSizeBase, btc.initTxSize, bumpedNetRate)
-	if btc.segwit {
-		estLowFunds += dexbtc.P2WSHOutputSize * (lots - 1) * bumpedNetRate
-	} else {
-		estLowFunds += dexbtc.P2SHOutputSize * (lots - 1) * bumpedNetRate
-	}
+		btc.initTxSizeBase, btc.initTxSize, bumpedNetRate) // best means single multi-lot match, even better than batch
 	estLowFees := estLowFunds - val
 
 	// Math for split transactions is a little different.

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -1367,12 +1367,11 @@ func TestFundEdges(t *testing.T) {
 	// total_bytes  = base_tx_bytes + backing_bytes = 2101 + 149 = 2250
 	// total_fees: base_fees + backing_fees = 71434 + 5066 = 76500 atoms
 	//          OR total_bytes * fee_rate = 2250 * 34 = 76500
-	// base_best_case_bytes = swap_size_base + (lots - 1) * swap_output_size (P2SHOutputSize) + backing_bytes
-	//                      = 76 + 9*32 + 149 = 513
+	// base_best_case_bytes = swap_size_base + backing_bytes
+	//                      = 76 + 149 = 225
 	const swapSize = 225
 	const totalBytes = 2250
-	const bestCaseBytes = 513
-	const swapOutputSize = 32                           // (P2SHOutputSize)
+	const bestCaseBytes = 225
 	backingFees := uint64(totalBytes) * tBTC.MaxFeeRate // total_bytes * fee_rate
 	p2pkhUnspent := &ListUnspentResult{
 		TxID:          tTxID,
@@ -1398,7 +1397,7 @@ func TestFundEdges(t *testing.T) {
 	estFeeReduction := swapSize * feeSuggestion
 	checkMaxOrder(t, wallet, lots-1, swapVal-tLotSize, backingFees-feeReduction,
 		totalBytes*feeSuggestion-estFeeReduction,
-		(bestCaseBytes-swapOutputSize)*feeSuggestion)
+		bestCaseBytes*feeSuggestion)
 
 	_, _, err := wallet.FundOrder(ord)
 	if err == nil {
@@ -1590,12 +1589,11 @@ func TestFundEdgesSegwit(t *testing.T) {
 	// total_bytes  = base_tx_bytes + backing_bytes = 1461 + 69 = 1530
 	// total_fees: base_fees + backing_fees = 49674 + 2346 = 52020 atoms
 	//          OR total_bytes * fee_rate = 1530 * 34 = 52020
-	// base_best_case_bytes = swap_size_base + (lots - 1) * swap_output_size (P2SHOutputSize) + backing_bytes
-	//                      = 84 + 9*43 + 69 = 540
+	// base_best_case_bytes = swap_size_base + backing_bytes
+	//                      = 84 + 69 = 153
 	const swapSize = 153
 	const totalBytes = 1530
-	const bestCaseBytes = 540
-	const swapOutputSize = 43                           // (P2WSHOutputSize)
+	const bestCaseBytes = 153
 	backingFees := uint64(totalBytes) * tBTC.MaxFeeRate // total_bytes * fee_rate
 	p2wpkhUnspent := &ListUnspentResult{
 		TxID:          tTxID,
@@ -1621,7 +1619,7 @@ func TestFundEdgesSegwit(t *testing.T) {
 	estFeeReduction := swapSize * feeSuggestion
 	checkMaxOrder(t, wallet, lots-1, swapVal-tLotSize, backingFees-feeReduction,
 		totalBytes*feeSuggestion-estFeeReduction,
-		(bestCaseBytes-swapOutputSize)*feeSuggestion)
+		bestCaseBytes*feeSuggestion)
 
 	_, _, err := wallet.FundOrder(ord)
 	if err == nil {
@@ -2852,12 +2850,12 @@ func testPreSwap(t *testing.T, segwit bool, walletType string) {
 
 	// var swapSize = 225
 	var totalBytes uint64 = 2250
-	var bestCaseBytes uint64 = 513
+	var bestCaseBytes uint64 = 225
 	pkScript := tP2PKH
 	if segwit {
 		// swapSize = 153
 		totalBytes = 1530
-		bestCaseBytes = 540
+		bestCaseBytes = 153
 		pkScript = tP2WPKH
 	}
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1209,8 +1209,7 @@ func (dcr *ExchangeWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate
 	estHighFees := estHighFunds - val
 
 	estLowFunds := calc.RequiredOrderFundsAlt(val, uint64(inputsSize), 1,
-		dexdcr.InitTxSizeBase, dexdcr.InitTxSize, bumpedNetRate)
-	estLowFunds += dexdcr.P2SHOutputSize * (lots - 1) * bumpedNetRate
+		dexdcr.InitTxSizeBase, dexdcr.InitTxSize, bumpedNetRate) // best means single multi-lot match, even better than batch
 	estLowFees := estLowFunds - val
 
 	// Math for split transactions is a little different.

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1155,7 +1155,7 @@ func TestFundEdges(t *testing.T) {
 	//                      = 85 + 9*34 + 166 = 557
 	const swapSize = 251
 	const totalBytes = 2510
-	const bestCaseBytes = 557
+	const bestCaseBytes = swapSize
 	const swapOutputSize = 34
 	fees := uint64(totalBytes) * tDCR.MaxFeeRate
 	p2pkhUnspent := walletjson.ListUnspentResult{
@@ -1180,9 +1180,9 @@ func TestFundEdges(t *testing.T) {
 	var feeReduction uint64 = swapSize * tDCR.MaxFeeRate
 	estFeeReduction := swapSize * feeSuggestion
 	checkMaxOrder(t, wallet, lots-1, swapVal-tLotSize,
-		fees-feeReduction,                            // max fees
-		totalBytes*feeSuggestion-estFeeReduction,     // worst case
-		(bestCaseBytes-swapOutputSize)*feeSuggestion) // best case
+		fees-feeReduction,                        // max fees
+		totalBytes*feeSuggestion-estFeeReduction, // worst case
+		bestCaseBytes*feeSuggestion)              // best case
 
 	_, _, err := wallet.FundOrder(ord)
 	if err == nil {
@@ -2396,7 +2396,9 @@ func TestPreSwap(t *testing.T) {
 	lots := swapVal / tLotSize // 10 lots
 
 	const totalBytes = 2510
-	const bestCaseBytes = 557
+	// base_best_case_bytes = swap_size_base + backing_bytes
+	//                      = 85 + 166 = 251
+	const bestCaseBytes = 251 // i.e. swapSize
 
 	backingFees := uint64(totalBytes) * tDCR.MaxFeeRate // total_bytes * fee_rate
 


### PR DESCRIPTION
Revising the "best" swap estimates for dcr and btc as per the discussion on https://github.com/decred/dcrdex/pull/2139#discussion_r1110502885

Previously we considered the "best" swap fee estimate to be when there was a single transaction that batched several matches, but the true best is when there is a perfect match with another multi-lot order.

The UI and Go interface docs describe this as well.  This makes the estimates reflect this interpretation.