### PR TITLE
core: Trim URL before parsing

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1655,6 +1655,7 @@ const defaultDEXPort = "7232"
 
 // addrHost returns the host or url:port pair for an address.
 func addrHost(addr string) (string, error) {
+	addr = strings.TrimSpace(addr)
 	const defaultHost = "localhost"
 	const missingPort = "missing port in address"
 	// Empty addresses are localhost.


### PR DESCRIPTION
Additional space at the end was causing the port to not parse properly.

Closes #2146 