### PR TITLE
client/core: simplify view-only backend machinery, remove connectAccount helper

### DIFF
--- a/client/db/types.go
+++ b/client/db/types.go
@@ -240,7 +240,7 @@ func (ai *AccountInfo) Encode() []byte {
 		AddData(ai.LegacyFeeCoin)
 }
 
-// ViewOnly is true if account keys are not saved.
+// ViewOnly is true if account keys (identity) do not exist.
 func (ai *AccountInfo) ViewOnly() bool {
 	return len(ai.EncKey()) == 0
 }


### PR DESCRIPTION
The one place a view-only flag needs to exist is `core.Exchange.ViewOnly` so that when marshaled to JSON for the frontend, it is possible to recognize when a DEX is view-only.

Within core (`dexAccount`, `db.AccountInfo`, etc.) a view-only account is characterized by the lack of account keys, which are the user's identity.  These values are set in `discoverAccount` > `setupCryptoV2`, and implicitly convert a view-only dex connection.  There seems to be no need in `Register` to distinguish a dex account that is *intended* to be for trading (not view-only) for the brief period between `connectDEX` and `addDexConnection`, so this commit simplifies everything.