### PR TITLE
client/asset/eth: less provider check spam

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -672,7 +672,7 @@ func NewWallet(assetCFG *asset.WalletConfig, logger dex.Logger, net dex.Network)
 
 	aw := &assetWallet{
 		baseWallet:         eth,
-		log:                logger.SubLogger("ETH"),
+		log:                logger,
 		assetID:            BipID,
 		tipChange:          assetCFG.TipChange,
 		findRedemptionReqs: make(map[[32]byte]*findRedemptionRequest),

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"os"
 	"os/user"
 	"path/filepath"
 	"sort"
@@ -589,6 +590,11 @@ func createWallet(createWalletParams *asset.CreateWalletParams, skipConnect bool
 	// 	defer node.Close()
 	// 	return importKeyToNode(node, privateKey, createWalletParams.Pass)
 	case walletTypeRPC:
+		// Make the wallet dir if it does not exist, otherwise we may fail to
+		// write the compliant_providers.json file.
+		if err := os.MkdirAll(walletDir, 0700); err != nil {
+			return err
+		}
 
 		// Check that we can connect to all endpoints.
 		providerDef := createWalletParams.Settings[providersKey]

--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -26,7 +26,6 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/networks/erc20"
 	dexeth "decred.org/dcrdex/dex/networks/eth"
-	"github.com/decred/slog"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -697,7 +696,7 @@ func createAndCheckProviders(ctx context.Context, walletDir string, endpoints []
 		if len(providers) != len(unknownEndpoints) {
 			return providersErr(providers)
 		}
-		if err := checkProvidersCompliance(ctx, providers, net, log); err != nil {
+		if err := checkProvidersCompliance(ctx, providers, net, dex.Disabled /* logger is for testing only */); err != nil {
 			return err
 		}
 	}
@@ -1400,7 +1399,9 @@ type rpcTest struct {
 
 // newCompatibilityTests returns a list of RPC tests to run to determine API
 // compatibility.
-func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log slog.Logger) []*rpcTest {
+func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log dex.Logger) []*rpcTest {
+	// NOTE: The logger is intended for use the execution of the compatibility
+	// tests, and it will generally be dex.Disabled in production.
 	var (
 		// Vitalik's address from https://twitter.com/VitalikButerin/status/1050126908589887488
 		mainnetAddr      = common.HexToAddress("0xab5801a7d398351b8be11c439e05c5b3259aec9b")
@@ -1440,15 +1441,15 @@ func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log slog.Lo
 		readIt := func(path string) string {
 			b, err := os.ReadFile(path)
 			if err != nil {
-				log.Errorf("Problem reading simnet testing file: %v", err)
+				panic(fmt.Sprintf("Problem reading simnet testing file %q: %v", path, err))
 			}
-			return strings.TrimRight(string(b), "\r\n")
+			return strings.TrimSpace(string(b)) // mainly the trailing "\r\n"
 		}
 		usdc = common.HexToAddress(readIt(tContractFile))
 		txHash = common.HexToHash(readIt(tTxHashFile))
 		blockHash = common.HexToHash(readIt(tBlockHashFile))
-	default:
-		log.Errorf("Unknown net %v in compatibility tests. Testing data not initiated.", net)
+	default: // caller should have checked though
+		panic(fmt.Sprintf("Unknown net %v in compatibility tests. Testing data not initiated.", net))
 	}
 
 	return []*rpcTest{
@@ -1487,7 +1488,7 @@ func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log slog.Lo
 				if err != nil {
 					return err
 				}
-				log.Info("#### Retreived tip cap:", tipCap)
+				log.Debugf("#### Retrieved tip cap: %d gwei", dexeth.WeiToGwei(tipCap))
 				return nil
 			},
 		},
@@ -1498,7 +1499,7 @@ func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log slog.Lo
 				if err != nil {
 					return err
 				}
-				log.Infof("#### Balance retrieved: %.9f", float64(dexeth.WeiToGwei(bal))/1e9)
+				log.Debugf("#### Balance retrieved: %.9f", float64(dexeth.WeiToGwei(bal))/1e9)
 				return nil
 			},
 		},
@@ -1509,7 +1510,7 @@ func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log slog.Lo
 				if err != nil {
 					return err
 				}
-				log.Infof("#### %d bytes of USDC contract retrieved", len(code))
+				log.Debugf("#### %d bytes of USDC contract retrieved", len(code))
 				return nil
 			},
 		},
@@ -1530,7 +1531,7 @@ func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log slog.Lo
 				// I guess we would need to unpack the results. I don't really
 				// know how to interpret these, but I'm really just looking for
 				// a request error.
-				log.Info("#### USDC balanceOf result:", bal, "wei")
+				log.Debug("#### USDC balanceOf result:", dexeth.WeiToGwei(bal), "gwei")
 				return nil
 			},
 		},
@@ -1541,18 +1542,7 @@ func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log slog.Lo
 				if err != nil {
 					return err
 				}
-				log.Infof("#### Chain ID: %d", chainID)
-				return nil
-			},
-		},
-		{
-			name: "PendingNonceAt",
-			f: func(ctx context.Context, p *provider) error {
-				n, err := p.ec.PendingNonceAt(ctx, addr)
-				if err != nil {
-					return err
-				}
-				log.Infof("#### Pending nonce: %d", n)
+				log.Debugf("#### Chain ID: %d", chainID)
 				return nil
 			},
 		},
@@ -1567,7 +1557,7 @@ func newCompatibilityTests(cb bind.ContractBackend, net dex.Network, log slog.Lo
 				if rpcTx.BlockNumber != nil {
 					h = *rpcTx.BlockNumber
 				}
-				log.Infof("#### RPC Tx is nil? %t, block number: %q", rpcTx.tx == nil, h)
+				log.Debugf("#### RPC Tx is nil? %t, block number: %q", rpcTx.tx == nil, h)
 				return nil
 			},
 		},
@@ -1587,7 +1577,7 @@ func domain(host string) string {
 // requires by sending a series of requests and verifying the responses. If a
 // provider is found to be compliant, their domain name is added to a list and
 // stored in a file on disk so that future checks can be short-circuited.
-func checkProvidersCompliance(ctx context.Context, providers []*provider, net dex.Network, log slog.Logger) error {
+func checkProvidersCompliance(ctx context.Context, providers []*provider, net dex.Network, log dex.Logger) error {
 	for _, p := range providers {
 		// Need to run API tests on this endpoint.
 		for _, t := range newCompatibilityTests(p.ec, net, log) {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2534,7 +2534,7 @@ func (c *Core) createSeededWallet(assetID uint32, crypter encrypt.Crypter, form 
 		Settings: form.Config,
 		DataDir:  c.assetDataDirectory(assetID),
 		Net:      c.net,
-		Logger:   c.log.SubLogger("CREATE"),
+		Logger:   c.log.SubLogger(unbip(assetID)),
 	}); err != nil {
 		return nil, fmt.Errorf("Error creating wallet: %w", err)
 	}
@@ -2959,7 +2959,7 @@ func (c *Core) RecoverWallet(assetID uint32, appPW []byte, force bool) error {
 		Settings: dbWallet.Settings,
 		DataDir:  c.assetDataDirectory(assetID),
 		Net:      c.net,
-		Logger:   c.log.SubLogger("CREATE"),
+		Logger:   c.log.SubLogger(unbip(assetID)),
 	}); err != nil {
 		return fmt.Errorf("error creating wallet: %w", err)
 	}

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -332,7 +332,7 @@ func (eth *ETHBackend) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	bn, err := eth.node.blockNumber(ctx)
 	if err != nil {
 		cancelNodeContext()
-		return nil, fmt.Errorf("error getting best block header from geth: %w", err)
+		return nil, fmt.Errorf("error getting best block header: %w", err)
 	}
 	eth.baseBackend.bestHeight = bn
 
@@ -715,7 +715,7 @@ func (eth *ETHBackend) poll(ctx context.Context) {
 	}
 	bn, err := eth.node.blockNumber(ctx)
 	if err != nil {
-		send(fmt.Errorf("error getting best block header from geth: %w", err))
+		send(fmt.Errorf("error getting best block header: %w", err))
 		return
 	}
 	if bn == eth.bestHeight {

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -250,7 +250,7 @@ func unconnectedETH(logger dex.Logger, net dex.Network) (*ETHBackend, error) {
 			baseLogger: logger,
 			tokens:     make(map[uint32]*TokenBackend),
 		},
-		log:          logger.SubLogger("ETH"),
+		log:          logger,
 		contractAddr: contractAddr,
 		blockChans:   make(map[chan *asset.BlockUpdate]struct{}),
 		initTxSize:   uint32(dexeth.InitGas(1, ethContractVersion)),


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/2158

```
This quiets down the logs from the RPC provider compatibility tests,
which was only supposed to be enable for testing and debugging.

This also removes a duplicate check for PendingNonceAt.

This also removes the redundant sublogger so that
CORE[eth][ETH] becomes just CORE[eth].  Same on server.

Finally, the changes the subloger used by CreateWallet not be
CORE[CREATE], and instead just show the asset symbol.
```

This also resolves the missing parent path for the compliant providers json file on initial wallet creation.