### PR TITLE
site: do not get icon repeatedly

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=eGfPLtv5"></script>
+<script src="/js/entry.js?v=qAsSUzx7"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -603,7 +603,7 @@ export default class WalletsPage extends BasePage {
     const { bttn, tmpl } = this.assetButtons[assetID]
     Doc.hide(tmpl.fiat, tmpl.noWallet)
     bttn.classList.add('nowallet')
-    tmpl.img.src = Doc.logoPath(a.symbol)
+    tmpl.img.src ||= Doc.logoPath(a.symbol) // don't initiate GET if already set (e.g. update on some notification)
     tmpl.name.textContent = a.name
     if (a.wallet) {
       bttn.classList.remove('nowallet')


### PR DESCRIPTION
A variety of notifications from the client backend cause the frontend to update an asset's "button" on the wallet's page.  In part, this involves setting `tmpl.img.src`, which unfortunately initiates a GET request for the resource, whether the path has changed or not.

For instance, my testnet bch wallet was spewing wallet state notes, causing repeated fetches of the bch.png icon each time:

![image](https://user-images.githubusercontent.com/9373513/221037727-da571827-8d7c-46e5-af77-aea746307f7f.png)

If the browser isn't sharp about caching these resources, it hits the backend repeatedly:

```
2023/02/23 13:54:17 "GET http://127.0.0.2:5758/img/coins/bch.png HTTP/1.1" from 127.0.0.1:54706 - 200 4103B in 12.844756ms
2023/02/23 13:54:20 "GET http://127.0.0.2:5758/img/coins/bch.png HTTP/1.1" from 127.0.0.1:54706 - 200 4103B in 12.682972ms
2023/02/23 13:54:23 "GET http://127.0.0.2:5758/img/coins/bch.png HTTP/1.1" from 127.0.0.1:54706 - 200 4103B in 13.716873ms
2023/02/23 13:54:26 "GET http://127.0.0.2:5758/img/coins/bch.png HTTP/1.1" from 127.0.0.1:54706 - 200 4103B in 12.674457ms
2023/02/23 13:54:29 "GET http://127.0.0.2:5758/img/coins/bch.png HTTP/1.1" from 127.0.0.1:54706 - 200 4103B in 11.653743ms
2023/02/23 13:54:32 "GET http://127.0.0.2:5758/img/coins/bch.png HTTP/1.1" from 127.0.0.1:54706 - 200 4103B in 8.95034ms
2023/02/23 13:54:35 "GET http://127.0.0.2:5758/img/coins/bch.png HTTP/1.1" from 127.0.0.1:54706 - 200 4103B in 9.302125ms
2023/02/23 13:54:38 "GET http://127.0.0.2:5758/img/coins/bch.png HTTP/1.1" from 127.0.0.1:54706 - 200 4103B in 14.660306ms
```

This PR updates the `updateAssetButton` method of `WalletsPage` so that it does not re-assign the `img.src` field if it has already been set.  This method is called by at least 4 notification handlers, so it is the main offender.