### PR TITLE
client/db,dex/order: patch archived match status based on enc version

### DIFF
--- a/client/db/bolt/upgrades.go
+++ b/client/db/bolt/upgrades.go
@@ -329,7 +329,7 @@ func v6Upgrade(dbtx *bbolt.Tx) error {
 		if matchB == nil {
 			return fmt.Errorf("nil match bytes for %x", k)
 		}
-		match, err := order.DecodeMatch(matchB)
+		match, _, err := order.DecodeMatch(matchB)
 		if err != nil {
 			return fmt.Errorf("error decoding match %x: %w", k, err)
 		}

--- a/dex/order/test/serialize_test.go
+++ b/dex/order/test/serialize_test.go
@@ -84,7 +84,7 @@ func testUserMatch(t *testing.T) {
 	match := RandomUserMatch()
 	matchB := order.EncodeMatch(match)
 
-	reMatch, err := order.DecodeMatch(matchB)
+	reMatch, _, err := order.DecodeMatch(matchB)
 	if err != nil {
 		t.Fatalf("error decoding UserMatch: %v", err)
 	}


### PR DESCRIPTION
Option 2 of 2 that resolves https://github.com/decred/dcrdex/issues/2164
See other option at https://github.com/decred/dcrdex/pull/2165

I **have** confirmed that this PR works yet.