### PR TITLE
build: use docker/login-action and make apt-get non-interactive

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,7 +14,10 @@ jobs:
 
     steps:
       - name: Login to Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Checkout project
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -13,7 +13,7 @@
 FROM node:19-buster-slim AS nodebuilder
 WORKDIR /root/dex
 COPY . .
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git
 WORKDIR /root/dex/client/webserver/site/
 RUN npm clean-install
 RUN npm run build
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
 
 # Final image
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates
 WORKDIR /dex
 ENV HOME /dex
 RUN mkdir -p /dex/.dexc && chown 1000 /dex/.dexc

--- a/client/Dockerfile.release
+++ b/client/Dockerfile.release
@@ -23,7 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
 
 # Final image
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates
 WORKDIR /dex
 ENV HOME /dex
 RUN mkdir -p /dex/.dexc && chown 1000 /dex/.dexc


### PR DESCRIPTION
- SIlence apt terminal warning
- Use `docker/login-action` for docker hub login 