### PR TITLE
client/dcr: Incorrect excess return from sendEnough

### DIFF
--- a/client/asset/dcr/coin_selection.go
+++ b/client/asset/dcr/coin_selection.go
@@ -30,9 +30,6 @@ func sendEnough(amt, feeRate uint64, subtract bool, baseTxSize uint32, reportCha
 			return false, 0
 		}
 		excess := total - req
-		if subtract && excess > txFee {
-			excess -= txFee // total - (req + txFee), without underflow
-		}
 		if !reportChange || dexdcr.IsDustVal(dexdcr.P2PKHOutputSize, excess, feeRate) {
 			excess = 0
 		}


### PR DESCRIPTION
The txFee was being incorrectly subtracted from the excess value when `subtract == true`. This does not need to be subtracted from the `excess`, as it is subtracted from the actual value being sent.