### PR TITLE
ui: improve active order interactions

### DIFF
--- a/client/core/types.go
+++ b/client/core/types.go
@@ -1092,6 +1092,10 @@ type OrderFilter struct {
 	Hosts    []string            `json:"hosts"`
 	Assets   []uint32            `json:"assets"`
 	Statuses []order.OrderStatus `json:"statuses"`
+	Market   *struct {
+		Base  uint32 `json:"baseID"`
+		Quote uint32 `json:"quoteID"`
+	} `json:"market"`
 }
 
 // Account holds data returned from AccountExport.

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -1162,6 +1162,13 @@ func (db *BoltDB) Orders(orderFilter *dexdb.OrderFilter) (ords []*dexdb.MetaOrde
 		}
 	}
 
+	if orderFilter.Market != nil {
+		filters = append(filters, func(_ []byte, oBkt *bbolt.Bucket) bool {
+			baseID, quoteID := intCoder.Uint32(oBkt.Get(baseKey)), intCoder.Uint32(oBkt.Get(quoteKey))
+			return orderFilter.Market.Base == baseID && orderFilter.Market.Quote == quoteID
+		})
+	}
+
 	if !orderFilter.Offset.IsZero() {
 		offsetOID := orderFilter.Offset
 		var stampB []byte

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -1192,6 +1192,11 @@ func (n *Notification) Encode() []byte {
 		AddData([]byte(n.TopicID))
 }
 
+type OrderFilterMarket struct {
+	Base  uint32
+	Quote uint32
+}
+
 // OrderFilter is used to limit the results returned by a query to (DB).Orders.
 type OrderFilter struct {
 	// N is the number of orders to return in the set.
@@ -1206,6 +1211,8 @@ type OrderFilter struct {
 	// Assets is a list of BIP IDs for acceptable assets. A zero-length Assets
 	// means all assets are accepted.
 	Assets []uint32
+	// Market limits results to a specific market.
+	Market *OrderFilterMarket
 	// Statuses is a list of acceptable statuses. A zero-length Statuses means
 	// all statuses are accepted.
 	Statuses []order.OrderStatus

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -94,6 +94,8 @@ var EnUS = map[string]string{
 	"fee balance":                    "fee balance",
 	"Sell Orders":                    "Sell Orders",
 	"Your Orders":                    "Your Orders",
+	"sweep_orders":                   "Hide fully executed orders",
+	"sweep_order":                    "Hide this fully executed order",
 	"Recent Matches":                 "Recent Matches",
 	"Type":                           "Type",
 	"Side":                           "Side",

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -121,6 +121,15 @@ div[data-handler=markets] {
     }
   }
 
+  #sweepOrders {
+    position: absolute;
+    right: 15px;
+    top: 50%;
+    transform: translateY(-50%);
+    line-height: 1;
+    padding: 6px;
+  }
+
   #unreadyOrdersMsg {
     color: red;
   }
@@ -893,5 +902,25 @@ div[data-handler=markets] {
   #recentMatchesBox {
     overflow: visible;
     max-height: none;
+  }
+}
+
+.user-order-floaty-menu {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  z-index: 5;
+  border: 1px solid;
+  border-color: $light_border_color $light_input_border $light_input_border $light_input_border;
+  padding: 0 10px;
+  background-color: $light_body_bg;
+  cursor: pointer;
+  overflow: hidden;
+
+  & > span,
+  & > a {
+    &:hover {
+      background-color: #7775;
+    }
   }
 }

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -121,15 +121,6 @@ div[data-handler=markets] {
     }
   }
 
-  #sweepOrders {
-    position: absolute;
-    right: 15px;
-    top: 50%;
-    transform: translateY(-50%);
-    line-height: 1;
-    padding: 6px;
-  }
-
   #unreadyOrdersMsg {
     color: red;
   }
@@ -139,7 +130,6 @@ div[data-handler=markets] {
   }
 
   .user-order {
-    margin: 0 20px;
     border: 1px solid $light_border_color;
 
     &:not(:last-child) {
@@ -173,6 +163,10 @@ div[data-handler=markets] {
         &.sell {
           background-color: $sellcolor_light;
         }
+
+        &.inactive {
+          opacity: 0.5;
+        }
       }
 
       .active-indicator {
@@ -196,6 +190,7 @@ div[data-handler=markets] {
       display: grid;
       grid-template-columns: 1fr 1fr 1fr 1fr;
       row-gap: 10px;
+      column-gap: 5px;
       line-height: 1;
 
       .user-order-datum {
@@ -910,15 +905,19 @@ div[data-handler=markets] {
   display: flex;
   align-items: center;
   z-index: 5;
-  border: 1px solid;
-  border-color: $light_border_color $light_input_border $light_input_border $light_input_border;
-  padding: 0 10px;
+  border-style: none solid solid;
+  border-width: 0 2px 2px 1px;
+  border-color: $light_input_border;
   background-color: $light_body_bg;
   cursor: pointer;
   overflow: hidden;
 
   & > span,
   & > a {
+    margin: 0 5px;
+    padding-right: 10px;
+    padding-left: 10px;
+
     &:hover {
       background-color: #7775;
     }

--- a/client/webserver/site/src/css/market_dark.scss
+++ b/client/webserver/site/src/css/market_dark.scss
@@ -184,6 +184,11 @@ body.dark {
     border-color: $dark_border_color;
     background-color: $dark_body_bg;
   }
+
+  .user-order-floaty-menu {
+    border-color: $dark_border_color $dark_input_border $dark_input_border $dark_input_border;
+    background-color: $dark_body_bg;
+  }
 }
 
 @include media-breakpoint-up(lg) {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=ee884edb|b85eabd3" rel="stylesheet">
+  <link href="/css/style.css?v=db6f9378|14dcf2aa" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=d7464fea|35cd087a"></script>
+<script src="/js/entry.js?v=67f2396a|19245aa2"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=db6f9378|14dcf2aa" rel="stylesheet">
+  <link href="/css/style.css?v=2fc9aa03|01a695f9" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=b2ea5069|46b9d8f1"></script>
+<script src="/js/entry.js?v=29ba2144|89d1e8b8"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=67f2396a|19245aa2"></script>
+<script src="/js/entry.js?v=b2ea5069|46b9d8f1"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -407,12 +407,15 @@
               </div>
 
               {{- /* USER ORDERS */ -}}
-              <div class="text-center fs20 sans-light my-1">[[[Your Orders]]]</div>
+              <div class="position-relative text-center fs20 sans-light my-1">
+                [[[Your Orders]]]
+                <div id="sweepOrders" class="ico-sweep fs20 hoverbg pointer d-hide" data-tooltip="[[[sweep_orders]]]"></div>
+              </div>
               <div id="unreadyOrdersMsg" class="d-hide px-3 py-1 flex-center fs16 red">[[[unready_wallets_msg]]]</div>
               <div id="userNoOrders" class="p-3 flex-center fs16 grey">no active orders</div>
               <div id="userOrders" class="mb-3">
                 <div id="userOrderTmpl" class="user-order">
-                  <div data-tmpl="header" class="user-order-header">
+                  <div data-tmpl="header" class="user-order-header pointer">
                     <div data-tmpl="sideLight" class="side-indicator"></div>
                     <span data-tmpl="side"></span>
                     <span data-tmpl="qty" class="ms-1"></span>
@@ -428,10 +431,11 @@
                     <!-- <span class="fs11 ico-open ms-2"></span> -->
                   </div>
                   <div data-tmpl="details" class="order-details d-hide">
-                    <div class="user-order-datum full-span d-flex flex-row justify-content-start align-items-center brdrbottom fs12 p-2">
-                      <span data-tmpl="accelerateBttn" class="ico-rocket pointer hoverbg d-hide me-3" data-tooltip="[[[accelerate_order]]]"></span>
-                      <span data-tmpl="cancelBttn" class="ico-cross pointer hoverbg fs11 d-hide me-3" data-tooltip="[[[cancel_order]]]"></span>
-                      <a data-tmpl="link" class="ico-open pointer hoverbg me-3 fs13 plainlink" data-tooltip="[[[order details]]]"></a>
+                    <div class="user-order-datum full-span d-flex flex-row justify-content-start align-items-center brdrbottom fs14">
+                      <span data-tmpl="accelerateBttn" class="ico-rocket pointer hoverbg d-hide p-2" data-tooltip="[[[accelerate_order]]]"></span>
+                      <span data-tmpl="cancelBttn" class="ico-cross pointer hoverbg fs11 d-hide p-2" data-tooltip="[[[cancel_order]]]"></span>
+                      <span data-tmpl="sweepBttn" class="ico-sweep pointer hoverbg fs15 d-hide p-2" data-tooltip="[[[sweep_order]]]"></span>
+                      <a data-tmpl="link" class="ico-open pointer hoverbg me-3 fs13 plainlink p-2" data-tooltip="[[[order details]]]"></a>
                     </div>
                     <div class="user-order-datum">
                       <span>[[[Type]]]</span>

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -193,7 +193,7 @@
 
           {{- /* ORDER FORM */ -}}
           <div class="order-panel pb-3 position-relative">
-            <div class="d-flex flex-column align-items-stretch">
+            <div id="orderScroller" class="d-flex flex-column align-items-stretch">
 
               {{- /* TOKEN APPROVAL */ -}}
               <div class="fs15 pt-1 pb-3 text-center brdrbottom d-hide" id="tokenApproval">
@@ -407,13 +407,12 @@
               </div>
 
               {{- /* USER ORDERS */ -}}
-              <div class="position-relative text-center fs20 sans-light my-1">
+              <div class="text-center fs20 sans-light my-1">
                 [[[Your Orders]]]
-                <div id="sweepOrders" class="ico-sweep fs20 hoverbg pointer d-hide" data-tooltip="[[[sweep_orders]]]"></div>
               </div>
               <div id="unreadyOrdersMsg" class="d-hide px-3 py-1 flex-center fs16 red">[[[unready_wallets_msg]]]</div>
               <div id="userNoOrders" class="p-3 flex-center fs16 grey">no active orders</div>
-              <div id="userOrders" class="mb-3">
+              <div id="userOrders">
                 <div id="userOrderTmpl" class="user-order">
                   <div data-tmpl="header" class="user-order-header pointer">
                     <div data-tmpl="sideLight" class="side-indicator"></div>
@@ -432,10 +431,9 @@
                   </div>
                   <div data-tmpl="details" class="order-details d-hide">
                     <div class="user-order-datum full-span d-flex flex-row justify-content-start align-items-center brdrbottom fs14">
-                      <span data-tmpl="accelerateBttn" class="ico-rocket pointer hoverbg d-hide p-2" data-tooltip="[[[accelerate_order]]]"></span>
-                      <span data-tmpl="cancelBttn" class="ico-cross pointer hoverbg fs11 d-hide p-2" data-tooltip="[[[cancel_order]]]"></span>
-                      <span data-tmpl="sweepBttn" class="ico-sweep pointer hoverbg fs15 d-hide p-2" data-tooltip="[[[sweep_order]]]"></span>
-                      <a data-tmpl="link" class="ico-open pointer hoverbg me-3 fs13 plainlink p-2" data-tooltip="[[[order details]]]"></a>
+                      <span data-tmpl="accelerateBttn" class="ico-rocket pointer hoverbg d-hide py-2 px-3 me-1" data-tooltip="[[[accelerate_order]]]"></span>
+                      <span data-tmpl="cancelBttn" class="ico-cross pointer hoverbg fs11 d-hide py-2 px-3 mx-1" data-tooltip="[[[cancel_order]]]"></span>
+                      <a data-tmpl="link" class="ico-open pointer hoverbg fs13 plainlink py-2 px-3 ms-1" data-tooltip="[[[order details]]]"></a>
                     </div>
                     <div class="user-order-datum">
                       <span>[[[Type]]]</span>
@@ -473,10 +471,10 @@
                 </div>
               </div>{{- /* END USER ORDERS */ -}}
 
-              <a href="/orders" class="flex-center my-2 plainlink">[[[view order history]]]</a>
+              <a href="/orders" class="flex-center py-1 plainlink hoverbg">[[[view order history]]]</a>
 
               {{- /* RECENT MATCHES */ -}}
-              <div id=recentMatchesBox  class="d-flex flex-column align-items-stretch px-3 pb-4 mt-2 brdrtop">
+              <div id=recentMatchesBox  class="d-flex flex-column align-items-stretch px-3 pb-4 brdrtop">
                 <div class="text-center fs20 sans-light my-3">[[[Recent Matches]]]</div>
                 <table id="recentMatchesTable" class="ordertable">
                   <thead>

--- a/client/webserver/site/src/js/orders.ts
+++ b/client/webserver/site/src/js/orders.ts
@@ -170,7 +170,8 @@ export default class OrdersPage extends BasePage {
       set('host', `${mktID} @ ${ord.host}`)
       let from, to, fromQty
       let toQty = ''
-      const [baseUnitInfo, quoteUnitInfo] = [app().unitInfo(ord.baseID), app().unitInfo(ord.quoteID)]
+      const xc = app().exchanges[ord.host] || undefined
+      const [baseUnitInfo, quoteUnitInfo] = [app().unitInfo(ord.baseID, xc), app().unitInfo(ord.quoteID, xc)]
       if (ord.sell) {
         [from, to] = [ord.baseSymbol, ord.quoteSymbol]
         fromQty = Doc.formatCoinValue(ord.qty, baseUnitInfo)
@@ -194,7 +195,7 @@ export default class OrdersPage extends BasePage {
       Doc.tmplElement(tr, 'toLogo').src = Doc.logoPath(to)
       set('toSymbol', to)
       set('type', `${OrderUtil.typeString(ord)} ${OrderUtil.sellString(ord)}`)
-      set('rate', Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, ord.rate)))
+      set('rate', Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, ord.rate, xc)))
       set('status', OrderUtil.statusString(ord))
       set('filled', `${(OrderUtil.filled(ord) / ord.qty * 100).toFixed(1)}%`)
       set('settled', `${(OrderUtil.settled(ord) / ord.qty * 100).toFixed(1)}%`)
@@ -290,11 +291,11 @@ export default class OrdersPage extends BasePage {
    * server's filter type.
    */
   currentFilter (): OrderFilter {
-    const filterState = this.filterState
+    const filterState = this.filterState as OrderFilter
     return {
       hosts: filterState.hosts,
-      assets: filterState.assets.map((s: any) => parseInt(s)),
-      statuses: filterState.statuses.map((s: any) => parseInt(s)),
+      assets: filterState.assets?.map((s: any) => parseInt(s)),
+      statuses: filterState.statuses?.map((s: any) => parseInt(s)),
       n: orderBatchSize,
       offset: this.offset
     }

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -210,3 +210,7 @@ export function optionElement (opt: OrderOption, order: TradeForm, change: () =>
 function dexAssetSymbol (host: string, assetID: number): string {
   return app().exchanges[host].assets[assetID].symbol
 }
+
+export function isCancellable (ord: Order): boolean {
+  return ord.type === Limit && ord.tif === StandingTiF && ord.status < StatusExecuted
+}

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -543,12 +543,18 @@ export interface RemainderUpdate {
   qtyAtomic: number
 }
 
+export interface OrderFilterMarket {
+  baseID: number
+  quoteID: number
+}
+
 export interface OrderFilter {
   n?: number
   offset?: string
-  hosts: string[]
-  assets: number[]
-  statuses: number[]
+  hosts?: string[]
+  assets?: number[]
+  market?: OrderFilterMarket
+  statuses?: number[]
 }
 
 export interface MakerProgram {

--- a/dex/testing/dcr/harness.sh
+++ b/dex/testing/dcr/harness.sh
@@ -360,7 +360,6 @@ tmux send-keys -t $SESSION:0 "./alpha getmasterpubkey server_fees${WAIT}" C-m\; 
 # Prepare the wallets
 ################################################################################
 
-tmux select-window -t $SESSION:0
 for WALLET in alpha beta trading1 trading2; do
   tmux send-keys -t $SESSION:0 "./${WALLET} getnewaddress${WAIT}" C-m\; wait-for donedcr
   tmux send-keys -t $SESSION:0 "./${WALLET} getnewaddress${WAIT}" C-m\; wait-for donedcr
@@ -407,6 +406,8 @@ if [ -z "$NOMINER" ] ; then
   tmux send-keys -t $SESSION:9 "cd ${NODES_ROOT}/harness-ctl" C-m
   tmux send-keys -t $SESSION:9 "watch -n 15 ./mine-alpha 1" C-m
 fi
+
+tmux select-window -t $SESSION:0
 
 # Reenable history and attach to the control session.
 tmux send-keys -t $SESSION:0 "set -o history" C-m

--- a/dex/testing/firo/test/electrumx_network_test.go
+++ b/dex/testing/firo/test/electrumx_network_test.go
@@ -13,6 +13,8 @@
 // ElectrumX-Firo server:	dex/testing/firo/electrumx.sh
 // export REGTEST=1
 
+//go:build live
+
 package firo
 
 import (


### PR DESCRIPTION
Allow sweeping of fully-executed orders from active orders list on markets view. Shows a broom icon in the button menu to sweep a single order, and near the header to sweep all retired orders.
![image](https://user-images.githubusercontent.com/6109680/221409959-2bd72aa8-e7a2-4f10-bd23-b380b9342590.png)

Show (a copy of) the button menu on hover, allowing the user to perform actions without expanding the active order entry.
![image](https://user-images.githubusercontent.com/6109680/221409972-498d4450-e19d-48b8-afaa-b77cd73c9a75.png)


