### PR TITLE
ui: fix sort direction and cursor on recent matches table

### DIFF
--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -757,10 +757,6 @@ div[data-handler=markets] {
       }
     }
   }
-
-  tr {
-    cursor: pointer;
-  }
 }
 
 @include media-breakpoint-up(xl) {

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -435,7 +435,7 @@
                 <div class="text-center fs20 sans-light my-3">[[[Recent Matches]]]</div>
                 <table id="recentMatchesTable" class="ordertable">
                   <thead>
-                    <tr>
+                    <tr class="pointer">
                       <th data-ordercol="age" class="text-nowrap">[[[Age]]] <span class="ico-arrowdown"></span></th>
                       <th data-ordercol="rate" class="text-end pe-2 text-nowrap"><span class="ico-arrowdown"></span> [[[Rate]]]</th>
                       <th data-ordercol="qty" class="text-end text-nowrap"><span class="ico-arrowdown"></span> [[[Quantity]]]</th>

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -198,7 +198,7 @@ export default class MarketsPage extends BasePage {
     this.hovers = []
     // 'Recent Matches' list sort key and direction.
     this.recentMatchesSortKey = 'age'
-    this.recentMatchesSortDirection = 1
+    this.recentMatchesSortDirection = -1
     // store original title so we can re-append it when updating market value.
     this.ogTitle = document.title
 


### PR DESCRIPTION
Cursor was set to pointer for the entire table, but only the headers are interactive. 

Sort direction showed oldest first. Changed to newest first.