### PR TITLE
site: wipe orders on OrderRetired topic order note

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=qAsSUzx7"></script>
+<script src="/js/entry.js?v=NhPu0J3"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -2050,6 +2050,10 @@ export default class MarketsPage extends BasePage {
     mord.ord = order
     if (note.topic === 'MissedCancel') Doc.show(mord.details.cancelBttn)
     if (order.filled === order.qty) Doc.hide(mord.details.cancelBttn)
+    if (note.topic === 'OrderRetired') {
+      delete this.metaOrders[order.id]
+      mord.div.remove()
+    }
     if (app().canAccelerateOrder(order)) Doc.show(mord.details.accelerateBttn)
     else Doc.hide(mord.details.accelerateBttn)
     this.updateMetaOrder(mord)


### PR DESCRIPTION
Pertaining to https://github.com/decred/dcrdex/pull/2171, the `OrderRetired` order notification topic is sent when the backend "retires" the order, meaning it deletes it from the `trackedTrades` map.  This is when an order ceases to be listed in the "Your Orders" table of the markets page, and is only accessible via the historical orders methods.

As such, this change recognizes the `OrderRetired` topic on the frontend and removes it from the "Your Orders" table automatically (since a page refresh would remove it too).

We could use `setTimeout` to remove it after another minute or so, which would be helpful for simnet where ticks are every 7.5 by default, and even mainnet if the timing of order completion is such that the tick that retires it is not long after.