### PR TITLE
ui: funding/acceleration coins missing links regression

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=qAsSUzx7"></script>
+<script src="/js/entry.js?v=qAsIOSx7"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -203,7 +203,7 @@
       <div class="text-start">[[[Funding Coins]]]</div>
       <div class="fs14 text-start">
         {{range $ord.FundingCoins}}
-          <a target="_blank" class="plainlink mono" data-asset-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
+          <a target="_blank" class="plainlink mono" data-explorer-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
         {{end}}
       </div>
     </div>
@@ -212,7 +212,7 @@
       <div class="text-start">[[[acceleration_transactions]]]</div>
       <div class="fs14 text-start">
         {{range $ord.AccelerationCoins}}
-          <a target="_blank" class="plainlink mono" data-asset-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
+          <a target="_blank" class="plainlink mono" data-explorer-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
         {{end}}
       </div>
     </div>

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -203,7 +203,7 @@
       <div class="text-start">[[[Funding Coins]]]</div>
       <div class="fs14 text-start">
         {{range $ord.FundingCoins}}
-          <a target="_blank" class="plainlink mono" data-explorer-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
+          <a target="_blank" class="plainlink mono" data-asset-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
         {{end}}
       </div>
     </div>
@@ -212,7 +212,7 @@
       <div class="text-start">[[[acceleration_transactions]]]</div>
       <div class="fs14 text-start">
         {{range $ord.AccelerationCoins}}
-          <a target="_blank" class="plainlink mono" data-explorer-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
+          <a target="_blank" class="plainlink mono" data-asset-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
         {{end}}
       </div>
     </div>

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -62,6 +62,15 @@ export default class OrderPage extends BasePage {
       })
     })
 
+    // Some static elements on this page contain assets that can be linked
+    // to blockchain explorers (such as Etherscan) so users can easily
+    // examine funding/acceleration coins data there. We'd need to set up
+    // such hyperlinks here.
+    main.querySelectorAll('[data-asset-id]').forEach((link: PageElement) => {
+      const assetID = parseInt(link.dataset.assetId || '')
+      setCoinHref(assetID, link)
+    })
+
     if (page.cancelBttn) {
       Doc.bind(page.cancelBttn, 'click', () => {
         this.showForm(page.cancelForm)
@@ -493,8 +502,8 @@ function inConfirmingTakerRedeem (m: Match) {
 }
 
 /*
- * setCoinHref sets the hyperlink element's href attribute based on its
- * data-explorer-id and data-explorer-coin values.
+ * setCoinHref sets the hyperlink element's href attribute based on provided
+ * assetID and data-explorer-coin value present on supplied link element.
  */
 function setCoinHref (assetID: number, link: PageElement) {
   const assetExplorer = CoinExplorers[assetID]

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -66,8 +66,8 @@ export default class OrderPage extends BasePage {
     // to blockchain explorers (such as Etherscan) so users can easily
     // examine funding/acceleration coins data there. We'd need to set up
     // such hyperlinks here.
-    main.querySelectorAll('[data-asset-id]').forEach((link: PageElement) => {
-      const assetID = parseInt(link.dataset.assetId || '')
+    main.querySelectorAll('[data-explorer-id]').forEach((link: PageElement) => {
+      const assetID = parseInt(link.dataset.explorerId || '')
       setCoinHref(assetID, link)
     })
 


### PR DESCRIPTION
This is part 1 for addressing https://github.com/decred/dcrdex/issues/2175, it resolves regression with `Funding Coins` being clickable previously https://github.com/decred/dcrdex/issues/2175#issuecomment-1446343544 but no longer on the current **master**.

Seems like regression originates here: https://github.com/buck54321/dcrdex/commit/b9aaef2c280e2cb4ca1c4dbca99ac7b1fa939aee

Tested `Acceleration Coins` links too, seem to be working for BTC on **testnet**.