### PR TITLE
client/asset/eth: break immediately on shutdown when timing out

### DIFF
--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -444,7 +444,7 @@ func TestCheckForNewBlocks(t *testing.T) {
 		}
 		w.wallets = map[uint32]*assetWallet{BipID: w.assetWallet}
 		w.assetWallet.connected.Store(true)
-		w.checkForNewBlocks(tipChange)
+		w.checkForNewBlocks(ctx, tipChange)
 
 		if test.hasTipChange {
 			<-blocker


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/2045

Turns out the timeouts there before shutdown were (wait for it)... DNS.  The only actual issue there was that shutting down when `eth.checkForNewBlocks` was timing out would involve a random chance of receiving from the canceled context instead of the ticker.

This change checks for a shutdown that may have occurred while `eth.checkForNewBlocks` timed out.  I've decided to keep the ticker because with health providers, it is desirable to keep a regular check interval in terms of wall time rather than relative to the previous check.  Tickers don't backup indefinitely, but they will buffer a single tick, so a single tick may be delayed when there is a timeout.