### PR TITLE
client/asset/btc: remove mainnet cfilters btc spv node default

### DIFF
--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -191,8 +191,6 @@ func (w *btcSPVWallet) Start() (SPVService, error) {
 
 	var defaultPeers []string
 	switch w.chainParams.Net {
-	case wire.MainNet:
-		defaultPeers = []string{"cfilters.ssgen.io:8333"}
 	case wire.TestNet3:
 		defaultPeers = []string{"dex-test.ssgen.io:18333"}
 	case wire.TestNet, wire.SimNet: // plain "wire.TestNet" is regnet!


### PR DESCRIPTION
There are now plenty of public full **Bitcoin** nodes supporting compact block filters.  This default peer was added when the node landscape was quite different.  In addition, it's generally overloaded and constantly at it's max incoming peer limit.  Further, with the peer manager you can always add it back manually, but you cannot remove it when it's a "Default" peer.