### PR TITLE
client/core: bad log msg formatting

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -8009,7 +8009,7 @@ func handleMatchProofMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error
 		// Just warning the user for now, later on we might wanna revoke the
 		// order if this happens.
 		if err = trade.verifyCSum(note.CSum, note.Epoch); err != nil {
-			c.log.Warnf("Failed to validate commitment checksum for %s epoch %d at %s: %v"+
+			c.log.Warnf("Failed to validate commitment checksum for %s epoch %d at %s: %v",
 				note.MarketID, note.Epoch, dc.acct.host, err)
 		}
 	}

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -582,7 +582,7 @@ func (t *trackedTrade) cancelEpochIdx() uint64 {
 	return uint64(t.cancel.Prefix().ServerTime.UnixMilli()) / epochLen
 }
 
-func (t *trackedTrade) verifyCSum(csum []byte, epochIdx uint64) error {
+func (t *trackedTrade) verifyCSum(csum dex.Bytes, epochIdx uint64) error {
 	t.mtx.RLock()
 	defer t.mtx.RUnlock()
 


### PR DESCRIPTION
Noticed this in logs, fixing:

```
2023-02-28 08:16:01.156 [WRN] CORE: Failed to validate commitment checksum for %!s(uint64=239653162) epoch %!d(string=dex-test.ssgen.io:7232) at checksum #߄�
         ���ONƾ���� (I�	� != trade order preimage request checksum  for trade order 699b4ba88c8db764c84785d096c803fd012a12901fea64e25d61793c63a0c37d: %!v(MISSING)dcr_eth
```