### PR TITLE
server/eth: RPC client priority

### DIFF
--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -219,10 +219,10 @@ ETH_CONFIG_PATH=${TEST_ROOT}/eth.conf
 ETH_IPC_FILE=${TEST_ROOT}/eth/alpha/node/geth.ipc
 
 cat > $ETH_CONFIG_PATH <<EOF
-ws://localhost:38557
+ws://localhost:38559 , 2000
 # comments are respected
-# http://localhost:38556
-${ETH_IPC_FILE}
+; http://localhost:38556
+${ETH_IPC_FILE},2
 EOF
 
 cat << EOF >> "./markets.json"

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -284,16 +284,19 @@ func NewBackend(configPath string, log dex.Logger, net dex.Network) (*ETHBackend
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
 			continue
 		}
+		ethCfgInstructions := "invalid eth config line: \"%s\". " +
+			"Each line must contain URL and optionally a priority (between 0-65535) " +
+			"separated by a comma. Example: \"https://www.infura.io/,2\""
 		parts := strings.Split(line, ",")
 		if len(parts) < 1 || len(parts) > 2 {
-			return nil, fmt.Errorf("invalid eth config line %q", line)
+			return nil, fmt.Errorf(ethCfgInstructions, line)
 		}
 		url := strings.TrimSpace(parts[0])
 		var priority uint16
 		if len(parts) == 2 {
 			priority64, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 16)
 			if err != nil {
-				return nil, fmt.Errorf("invalid eth config line %q: %v", line, err)
+				return nil, fmt.Errorf(ethCfgInstructions, line)
 			}
 			priority = uint16(priority64)
 		}

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -275,16 +276,35 @@ func NewBackend(configPath string, log dex.Logger, net dex.Network) (*ETHBackend
 	}
 	defer file.Close()
 
-	var endpoints []string
+	var endpoints []endpoint
 	endpointsMap := make(map[string]bool) // to avoid duplicates
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		line := strings.Trim(scanner.Text(), " ")
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") || endpointsMap[line] {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		parts := strings.Split(line, ",")
+		if len(parts) < 1 || len(parts) > 2 {
+			return nil, fmt.Errorf("invalid eth config line %q", line)
+		}
+		url := strings.TrimSpace(parts[0])
+		var priority uint16
+		if len(parts) == 2 {
+			priority64, err := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid eth config line %q: %v", line, err)
+			}
+			priority = uint16(priority64)
+		}
+		if endpointsMap[url] {
 			continue
 		}
 		endpointsMap[line] = true
-		endpoints = append(endpoints, line)
+		endpoints = append(endpoints, endpoint{
+			url:      url,
+			priority: priority,
+		})
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("error reading eth config file at %q. %v", configPath, err)

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -56,7 +56,7 @@ func TestMain(m *testing.M) {
 			return 1, fmt.Errorf("no contract address for eth version %d on %s", ethContractVersion, dex.Simnet)
 		}
 
-		ethClient = newRPCClient(dex.Simnet, []string{wsEndpoint, alphaIPCFile}, ethContractAddr, log)
+		ethClient = newRPCClient(dex.Simnet, []endpoint{{url: wsEndpoint}, {url: alphaIPCFile}}, ethContractAddr, log)
 		defer func() {
 			cancel()
 		}()


### PR DESCRIPTION
This change allows server operators to rank RPC entpoints by priority. The healthy connection with the highest priority will always be attempted first. If no priority is specified for an endpoint, 0 is assumed.

Closes #2161 