### PR TITLE
remove deprecated linter: structcheck

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -75,7 +75,6 @@ golangci-lint run --disable-all --deadline=10m \
   --enable=govet \
   --enable=gosimple \
   --enable=unconvert \
-  --enable=structcheck \
   --enable=ineffassign \
   --enable=asciicheck \
   --enable=rowserrcheck \

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -93,7 +93,7 @@ func (us updateSignal) String() string {
 	return us.action.String()
 }
 
-// nolint:structcheck,unused
+// nolint:unused
 type sigDataOrder struct {
 	order    order.Order
 	epochIdx int64


### PR DESCRIPTION
Removes linter warning:

```
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
```