### PR TITLE
client/db clarify DB timeout error

### DIFF
--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -155,6 +155,9 @@ func NewDB(dbPath string, logger dex.Logger, opts ...Opts) (dexdb.DB, error) {
 
 	db, err := bbolt.Open(dbPath, 0600, &bbolt.Options{Timeout: 3 * time.Second})
 	if err != nil {
+		if errors.Is(err, bbolt.ErrTimeout) {
+			err = fmt.Errorf("%w, could happen when database is already being used by another process", err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Pretty much a nit, but could help a not-very-technical user administering `dexc`, because currently when I have 1 instance running, starting another gives me this error:
```
error creating client core: database initialization error: timeout
```
it becomes this instead:
```
error creating client core: database initialization error: timeout, could happen when database is already being used by another process
```