### PR TITLE
client/webserver: standardize log output

### DIFF
--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -284,7 +284,11 @@ func New(cfg *Config) (*WebServer, error) {
 
 	// Middleware
 	if log.Level() == dex.LevelTrace {
-		mux.Use(middleware.Logger)
+		mux.Use(
+			middleware.RequestLogger(
+				&middleware.DefaultLogFormatter{Logger: &chiLogger{logger: log}},
+			),
+		)
 	}
 	mux.Use(s.securityMiddleware)
 	mux.Use(middleware.Recoverer)
@@ -903,4 +907,14 @@ func writeJSONWithStatus(w http.ResponseWriter, thing interface{}, code int, ind
 func folderExists(fp string) bool {
 	stat, err := os.Stat(fp)
 	return err == nil && stat.IsDir()
+}
+
+// chiLogger is an adaptor around dex.Logger so that it can be used seamlessly
+// with chi library.
+type chiLogger struct {
+	logger dex.Logger
+}
+
+func (l *chiLogger) Print(v ...interface{}) {
+	l.logger.Trace(v...)
 }


### PR DESCRIPTION
Fixes (at least for my setup) timezone discrepancy in logs on some systems (I'm running Mac) originally [spotted here](https://github.com/decred/dcrdex/pull/2195#issuecomment-1451244023) by @JoeGruffins, as well as standardizes log output a bit.

Answering https://github.com/decred/dcrdex/pull/2195#issuecomment-1451264781:

> Do you have a flag set? I think I am on default settings and don't see a difference.

I'm running **dexc** with `--log=trace` if that's what you mean. However that shouldn't affect anything related to timezone, at least I wouldn't expect it to.

> Does browser time zone come into play here?

Since wrapping logger solves the issue I'd say no, and looking at how `chi` logger is currently initialized on **master** it seems that it is setting `log.LstdFlags` for std logger that tell it to use local time zone. Does this mean you have your local timezone set to UTC @JoeGruffins ? If not, that's curious.

