### PR TITLE
ui: token wallet is missing type

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -50,7 +50,8 @@ func registerToken(tokenID uint32, desc string, nets ...dex.Network) {
 		panic("token " + strconv.Itoa(int(tokenID)) + " not known")
 	}
 	asset.RegisterToken(tokenID, token.Token, &asset.WalletDefinition{
-		Type:        "token",
+		Type:        walletTypeToken,
+		Tab:         "Token",
 		Description: desc,
 	}, nets...)
 }
@@ -69,8 +70,9 @@ const (
 	defaultGasFeeLimit  = 200 // gwei
 	defaultSendGasLimit = 21_000
 
-	walletTypeGeth = "geth"
-	walletTypeRPC  = "rpc"
+	walletTypeGeth  = "geth"
+	walletTypeRPC   = "rpc"
+	walletTypeToken = "token"
 
 	providersKey = "providers"
 

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -51,7 +51,7 @@ func registerToken(tokenID uint32, desc string, nets ...dex.Network) {
 	}
 	asset.RegisterToken(tokenID, token.Token, &asset.WalletDefinition{
 		Type:        walletTypeToken,
-		Tab:         "Token",
+		Tab:         "Ethereum token",
 		Description: desc,
 	}, nets...)
 }
@@ -147,7 +147,7 @@ var (
 			// },
 			{
 				Type:        walletTypeRPC,
-				Tab:         "External",
+				Tab:         "RPC",
 				Description: "Infrastructure providers (e.g. Infura) or local nodes",
 				ConfigOpts:  append(RPCOpts, WalletOpts...),
 				Seeded:      true,

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2568,7 +2568,7 @@ func (c *Core) createTokenWallet(tokenID uint32, token *asset.Token, form *Walle
 	}
 
 	return &db.Wallet{
-		Type:     "token",
+		Type:     form.Type,
 		AssetID:  tokenID,
 		Settings: form.Config,
 		// EncryptedPW ignored because we assume throughout that token wallet

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -155,11 +155,7 @@ export class NewWalletForm {
     let parentForm
     let walletType = selectedDef.type
     if (parentAsset) {
-      if (!asset.token) {
-        this.setError('token is absent from asset with parent, should never happen!')
-        return
-      }
-      walletType = asset.token.definition.type
+      walletType = (asset.token as Token).definition.type
       parentForm = {
         assetID: parentAsset.id,
         config: this.subform.map(parentAsset.id),

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -153,7 +153,13 @@ export class NewWalletForm {
     const { asset, parentAsset } = this.current
     const selectedDef = this.current.selectedDef
     let parentForm
+    let walletType = selectedDef.type
     if (parentAsset) {
+      if (!asset.token) {
+        this.setError('token is absent from asset with parent, should never happen!')
+        return
+      }
+      walletType = asset.token.definition.type
       parentForm = {
         assetID: parentAsset.id,
         config: this.subform.map(parentAsset.id),
@@ -161,7 +167,7 @@ export class NewWalletForm {
       }
     }
     // Register the selected asset.
-    const res = await this.createWallet(asset.id, selectedDef.type, pw, parentForm)
+    const res = await this.createWallet(asset.id, walletType, pw, parentForm)
     if (!app().checkResponse(res)) {
       this.setError(res.msg)
       return


### PR DESCRIPTION
I'm reaching into "unknown" area here a bit, hope this doesn't rub you in wrong way (don't want to step on someone's toes if it's already being worked on, still, I would like to figure out how it works for myself anyway).

Currently **Token** wallet displays its `Wallet Type` as empty. This is either unnecessary to see for the user, or it could be a bug (and this PR treats it this way),

before / after:

<img width="250" alt="image" src="https://user-images.githubusercontent.com/112318969/222900703-2b2658c4-60cb-4b6d-a8f5-e59a63bf615f.png"><img width="250" alt="image" src="https://user-images.githubusercontent.com/112318969/222900709-9938070f-26bc-4d82-9da8-ad7b6d35a28b.png">

Also tested that ETH/USDC wallet creation isn't broken with this change, however affected code is a bit hairy and I might have missed something. 
