### PR TITLE
client/core: Do not disconnect token wallets on shutdown

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1674,7 +1674,7 @@ func (c *Core) Run(ctx context.Context) {
 	defer c.walletMtx.Unlock()
 	for assetID, wallet := range c.wallets {
 		delete(c.wallets, assetID)
-		if !wallet.connected() {
+		if !wallet.connected() || wallet.parent != nil {
 			continue
 		}
 		if !c.cfg.NoAutoWalletLock {


### PR DESCRIPTION
This was causing an unnecessary error message, and there is no need for this as disconnecting the parent wallet is sufficient.

Closes #2058 