### PR TITLE
ui: funding coins hidden by default under offering section

### DIFF
--- a/client/webserver/locales/ar.go
+++ b/client/webserver/locales/ar.go
@@ -124,7 +124,6 @@ var Ar = map[string]string{
 	"them":                      "هم",
 	"Redemption":                "اِستِردَاد",
 	"Refund":                    "المبالغ المردودة",
-	"Funding Coins":             "عملات التمويل",
 	"Exchanges":                 "منصات التداول",
 	"apply":                     "طبق",
 	"Assets":                    "الأصول",

--- a/client/webserver/locales/de-de.go
+++ b/client/webserver/locales/de-de.go
@@ -118,7 +118,6 @@ var DeDE = map[string]string{
 	"them":                      "Gegenseite",
 	"Redemption":                "Rücknahme",
 	"Refund":                    "Erstattung",
-	"Funding Coins":             "Funding-Coins",
 	"Exchanges":                 "Exchanges",
 	"apply":                     "Anwenden",
 	"Assets":                    "Assets",

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -134,7 +134,6 @@ var EnUS = map[string]string{
 	"them":                      "them",
 	"Redemption":                "Redemption",
 	"Refund":                    "Refund",
-	"Funding Coins":             "Funding Coins",
 	"Exchanges":                 "Exchanges",
 	"apply":                     "apply",
 	"Assets":                    "Assets",

--- a/client/webserver/locales/pl-pl.go
+++ b/client/webserver/locales/pl-pl.go
@@ -116,7 +116,6 @@ var PlPL = map[string]string{
 	"them":                        "oni",
 	"Redemption":                  "Wykupienie środków",
 	"Refund":                      "Zwrot środków",
-	"Funding Coins":               "Środki fundujące zlecenie",
 	"Exchanges":                   "Giełdy",
 	"apply":                       "zastosuj",
 	"Assets":                      "Aktywa",

--- a/client/webserver/locales/pt-br.go
+++ b/client/webserver/locales/pt-br.go
@@ -117,7 +117,6 @@ var PtBr = map[string]string{
 	"them":                        "Eles",
 	"Redemption":                  "Rendenção",
 	"Refund":                      "Reembolso",
-	"Funding Coins":               "Moedas de Financiamento",
 	"Exchanges":                   "Casa de câmbios", //revisar
 	"apply":                       "aplicar",
 	"Assets":                      "Ativos",

--- a/client/webserver/locales/zh-cn.go
+++ b/client/webserver/locales/zh-cn.go
@@ -118,7 +118,6 @@ var ZhCN = map[string]string{
 	"them":                      "他们",
 	"Redemption":                "赎回",
 	"Refund":                    "退款",
-	"Funding Coins":             "资金硬币",
 	"Exchanges":                 "交易",
 	"apply":                     "申请",
 	"Assets":                    "资产",

--- a/client/webserver/site/src/css/order.scss
+++ b/client/webserver/site/src/css/order.scss
@@ -8,7 +8,7 @@ div.order-datum {
   font-size: 15px;
   margin: 5px 10px 5px 0;
 
-  div:first-child {
+  .order-datum-hdr {
     padding: 2px 15px;
     border-bottom: 1px solid #777a;
     font-family: $demi-sans;

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=qAsIOSx7"></script>
+<script src="/js/entry.js?v=qAKDOSx7"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -15,22 +15,22 @@
     {{- /* DATA CARDS */ -}}
     <div class="d-flex flex-wrap">
       <div class="order-datum">
-        <div>[[[Exchange]]]</div>
+        <div class="order-datum-hdr">[[[Exchange]]]</div>
         <div>{{$ord.Host}}</div>
       </div>
       <div class="order-datum">
-        <div>[[[Market]]]</div>
+        <div class="order-datum-hdr">[[[Market]]]</div>
         <a href="/markets?host={{$ord.Host}}&base={{$ord.BaseID}}&quote={{$ord.QuoteID}}" class="plainlink hoverbg">
           {{template "microIcon" $ord.BaseSymbol}} {{template "microIcon" $ord.QuoteSymbol}}
           <span id="mktBaseSymbol">{{toUpper $ord.BaseSymbol}}</span>-<span id="mktQuoteSymbol">{{toUpper $ord.QuoteSymbol}}</span>
         </a>
       </div>
       <div class="order-datum">
-        <div>[[[Type]]]</div>
+        <div class="order-datum-hdr">[[[Type]]]</div>
         <div>{{ $ord.TypeString }}</div>
       </div>
       <div class="order-datum">
-        <div>[[[Status]]]</div>
+        <div class="order-datum-hdr">[[[Status]]]</div>
         <div>
           <span id="status">{{$ord.StatusString}}</span>
           {{if $ord.Cancelable}}
@@ -39,11 +39,20 @@
         </div>
       </div>
       <div class="order-datum">
-        <div>[[[Offering]]]</div>
-        <div>{{$ord.OfferString}} {{$ord.FromSymbol}} {{template "microIcon" $ord.FromSymbol}}</div>
+        <div class="order-datum-hdr">[[[Offering]]]</div>
+        <div id="offering" class="pointer hoverbg">
+          <div id="offerAmt">
+            {{$ord.OfferString}} {{$ord.FromSymbol}} {{template "microIcon" $ord.FromSymbol}}
+          </div>
+          <div id="fundingCoinsList" class="fs14 text-start d-hide">
+            {{range $ord.FundingCoins}}
+              <a target="_blank" class="plainlink mono" data-explorer-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
+            {{end}}
+          </div>
+        </div>
       </div>
       <div class="order-datum">
-        <div>[[[Asking]]]</div>
+        <div class="order-datum-hdr">[[[Asking]]]</div>
         <div>
           {{if (not $ord.IsMarketOrder)}}
             {{$ord.AskString}}
@@ -52,11 +61,11 @@
         </div>
       </div>
       <div class="order-datum">
-        <div>[[[Rate]]]</div>
+        <div class="order-datum-hdr">[[[Rate]]]</div>
         <div>{{$ord.RateString}}</div>
       </div>
       <div class="order-datum">
-        <div>[[[Filled]]]</div>
+        <div class="order-datum-hdr">[[[Filled]]]</div>
         <div>
           {{$ord.FilledPercent}}%
           ({{$ord.FilledFrom}} {{template "microIcon" $ord.FromSymbol}}
@@ -65,7 +74,7 @@
         </div>
       </div>
       <div class="order-datum">
-        <div>[[[Settled]]]</div>
+        <div class="order-datum-hdr">[[[Settled]]]</div>
         <div>
           {{$ord.SettledPercent}}%
           ({{$ord.SettledFrom}} {{template "microIcon" $ord.FromSymbol}}
@@ -74,14 +83,14 @@
         </div>
       </div>
       <div class="order-datum">
-        <div>[[[Fees]]] <span class="ico-info fs12" data-tooltip="[[[order_fees_tooltip]]]"></span></div>
+        <div class="order-datum-hdr">[[[Fees]]] <span class="ico-info fs12" data-tooltip="[[[order_fees_tooltip]]]"></span></div>
         <div>
           {{$ord.SwapFeesString}} {{template "microIcon" $ord.FromFeeSymbol}},
           {{$ord.RedemptionFeesString}} {{template "microIcon" $ord.ToFeeSymbol}}
         </div>
       </div>
       <div class="order-datum">
-        <div>[[[Age]]]</div>
+        <div class="order-datum-hdr">[[[Age]]]</div>
         <div data-stamp="{{$ord.SubmitTime}}"></div>
       </div>
     </div> {{- /* END DATA CARDS */ -}}
@@ -196,16 +205,6 @@
           </div>
         </div>
       </div>    
-    </div>
-
-    {{- /* FUNDING COINS */ -}}
-    <div class="order-datum d-inline-block my-3">
-      <div class="text-start">[[[Funding Coins]]]</div>
-      <div class="fs14 text-start">
-        {{range $ord.FundingCoins}}
-          <a target="_blank" class="plainlink mono" data-explorer-id="{{$ord.FromID}}" data-explorer-coin="{{.StringID}}">{{.StringID}}</a><br>
-        {{end}}
-      </div>
     </div>
 
     <div id="accelerationCoins" class="order-datum d-inline-block my-3 {{if not $ord.AccelerationCoins}}d-hide{{end}}">

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -76,7 +76,9 @@ export default class OrderPage extends BasePage {
         this.showForm(page.cancelForm)
       })
     }
-
+    Doc.bind(page.offerAmt, 'click', () => {
+      this.showFundingCoinsList()
+    })
     Doc.bind(page.accelerateBttn, 'click', () => {
       this.showAccelerateForm()
     })
@@ -392,6 +394,17 @@ export default class OrderPage extends BasePage {
     page.status.textContent = intl.prep(intl.ID_CANCELING)
     Doc.hide(page.forms)
     order.cancelling = true
+  }
+
+  /*
+   * showFundingCoinsList shows funding coins list instead of amount being offered.
+   */
+  showFundingCoinsList () {
+    if (!this.order) return
+    const page = this.page
+    Doc.hide(page.offerAmt)
+    page.offering.classList.remove('hoverbg', 'pointer')
+    Doc.show(page.fundingCoinsList)
   }
 
   /*


### PR DESCRIPTION
Completes 2nd part and resolves https://github.com/decred/dcrdex/issues/2175.

We can get the best of both: still having info about funding coins, not overwhelming users with that

[funding-coins-under-offering.webm](https://user-images.githubusercontent.com/112318969/224531320-cf6030b6-5ca9-440e-ad75-5cffccf58c5f.webm)

-----
I don't think we need to implement a switch-back **funding coins** -> **offering amount** since page refresh does that.

Regarding that tool tip for **funding coins** I suggested in #2175, since it's an advanced and hidden feature now (with the changes in this PR) I no longer think it's something we want/need to add there.