### PR TITLE
app: Hide bond required text after no longer required

### DIFF
--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -747,7 +747,7 @@ export default class MarketsPage extends BasePage {
 
     if (market.dex.tier >= 1) {
       const toggle = () => {
-        Doc.hide(page.registrationStatus)
+        Doc.hide(page.registrationStatus, page.bondRequired)
         this.resolveOrderFormVisibility()
       }
       if (Doc.isHidden(page.orderForm)) {


### PR DESCRIPTION
The bond required text was remaining on the markets screen even after a bond had been confirmed.

Closes #2182