### PR TITLE
client/asset/btc: fix SPV reorg handling

### DIFF
--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -980,7 +980,7 @@ func TestGetBlockHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid tip height not noticed")
 	}
-	if mainchain {
+	if !mainchain {
 		t.Fatalf("expected block %s to be classified as oprhan", blockHash)
 	}
 	if hdr.Confirmations != 0 {

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -980,10 +980,10 @@ func TestGetBlockHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("invalid tip height not noticed")
 	}
-	if !mainchain {
-		t.Fatalf("expected block %s to be classified as oprhan", blockHash)
+	if mainchain {
+		t.Fatalf("expected block %s to be classified as orphan", blockHash)
 	}
-	if hdr.Confirmations != 0 {
+	if hdr.Confirmations != -1 {
 		t.Fatalf("confirmations not zero for lower mainchain tip height, got: %d", hdr.Confirmations)
 	}
 	node.mainchain = prevMainchain // clean up

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -1726,7 +1726,7 @@ func (w *spvWallet) getWalletTransaction(txHash *chainhash.Hash) (*GetTransactio
 		TimeReceived: uint64(details.Received.Unix()),
 	}
 
-	if details.Block.Height > 0 {
+	if details.Block.Height >= 0 {
 		ret.BlockHash = details.Block.Hash.String()
 		ret.BlockTime = uint64(details.Block.Time.Unix())
 		// ret.BlockHeight = uint64(details.Block.Height)

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -1055,8 +1055,10 @@ func (w *spvWallet) getBlockHeader(blockHash *chainhash.Hash) (header *blockHead
 	mainchain = w.blockIsMainchain(blockHash, blockHeight)
 	if mainchain {
 		confirmations = int64(confirms(blockHeight, tip.Height))
-	}
-	if tip.Height < blockHeight { // if tip is less, may be rolling back, so just mock dcrd/dcrwallet
+	} else if tip.Height < blockHeight {
+		// Gotta treat this block as mainchain, until mainchain tip catches up.
+		mainchain = true
+		// If tip is less, may be rolling back, so just mock dcrd/dcrwallet.
 		confirmations = 0
 	}
 

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -1051,17 +1051,21 @@ func (w *spvWallet) getBlockHeader(blockHash *chainhash.Hash) (header *blockHead
 		return nil, false, err
 	}
 
-	mainchain = w.blockIsMainchain(blockHash, blockHeight)
 	confirmations := int64(-1)
+	mainchain = w.blockIsMainchain(blockHash, blockHeight)
 	if mainchain {
 		confirmations = int64(confirms(blockHeight, tip.Height))
 	}
+	if tip.Height < blockHeight { // if tip is less, may be rolling back, so just mock dcrd/dcrwallet
+		confirmations = 0
+	}
 
 	return &blockHeader{
-		Hash:          hdr.BlockHash().String(),
-		Confirmations: confirmations,
-		Height:        int64(blockHeight),
-		Time:          hdr.Timestamp.Unix(),
+		Hash:              hdr.BlockHash().String(),
+		Confirmations:     confirmations,
+		Height:            int64(blockHeight),
+		Time:              hdr.Timestamp.Unix(),
+		PreviousBlockHash: hdr.PrevBlock.String(),
 	}, mainchain, nil
 }
 

--- a/client/asset/btc/wallet.go
+++ b/client/asset/btc/wallet.go
@@ -52,7 +52,7 @@ type Wallet interface {
 type tipRedemptionWallet interface {
 	Wallet
 	getBlockHeight(*chainhash.Hash) (int32, error)
-	getBlockHeader(blockHash *chainhash.Hash) (*blockHeader, error)
+	getBlockHeader(blockHash *chainhash.Hash) (hdr *blockHeader, mainchain bool, err error)
 	getBlock(h chainhash.Hash) (*wire.MsgBlock, error)
 	searchBlockForRedemptions(ctx context.Context, reqs map[outPoint]*findRedemptionReq, blockHash chainhash.Hash) (discovered map[outPoint]*findRedemptionResult)
 	findRedemptionsInMempool(ctx context.Context, reqs map[outPoint]*findRedemptionReq) (discovered map[outPoint]*findRedemptionResult)


### PR DESCRIPTION
This PR targeting BTC SPV wallet being able to spot reorgs, as per https://github.com/decred/dcrdex/pull/2219#pullrequestreview-1340616893 (functionally mirroring https://github.com/decred/dcrdex/pull/2219).

While it is possible to just fix the issue and move on I think some [code clean up is warranted here](https://github.com/decred/dcrdex/pull/2227).