### PR TITLE
client/asset/btc: redemption search refactor

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -4395,9 +4395,7 @@ func (btc *intermediaryWallet) fatalFindRedemptionsError(err error, reqs []*find
 	btc.findRedemptionMtx.Lock()
 	btc.log.Debugf("stopping redemption search for %d contracts in queue: %v", len(reqs), err)
 	for _, req := range reqs {
-		req.resultChan <- &findRedemptionResult{
-			err: err,
-		}
+		req.fail("searching for redemption, fatal error %w", err)
 		delete(btc.findRedemptionQueue, req.outPt)
 	}
 	btc.findRedemptionMtx.Unlock()

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -4352,7 +4352,6 @@ func (btc *intermediaryWallet) reportNewTip(ctx context.Context, newTip *block) 
 	startHash := &newTip.hash
 
 	// Check if the previous tip is still part of the mainchain (prevTip confs >= 0).
-	// Redemption search would typically resume from prevTipHeight + 1 unless the
 	// Redemption search would typically resume from prevTip.height + 1 unless the
 	// previous tip was re-orged out of the mainchain, in which case redemption
 	// search will resume from the mainchain ancestor of the previous tip.


### PR DESCRIPTION
Rebased on https://github.com/decred/dcrdex/pull/2225, 

This PR contains those refactoring bits (related to redemption search) mentioned in #2225. The overall refactor idea is to mimic pretty much exactly what DCR SPV wallet does.