### PR TITLE
nit: don't send connection anomaly notification for first disconnect

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -7984,14 +7984,16 @@ func (c *Core) handleConnectEvent(dc *dexConnection, status comms.ConnectionStat
 		dc.lastConnectMtx.RLock()
 		lastConnect := dc.lastConnect
 		dc.lastConnectMtx.RUnlock()
-		anomalies := atomic.LoadUint32(&dc.anomaliesCount)
-		if anomalies != 0 && anomalies%wsMaxAnomalyCount == 0 {
-			// Send notification to check connectivity.
-			subject, details := c.formatDetails(TopicDexConnectivity, dc.acct.host)
-			c.notify(newConnEventNote(TopicDexConnectivity, subject, dc.acct.host, dc.status(), details, db.Poke))
-		} else if time.Since(lastConnect) < wsAnomalyDuration {
+		if time.Since(lastConnect) < wsAnomalyDuration {
 			// Increase anomalies count for this connection.
-			atomic.AddUint32(&dc.anomaliesCount, 1)
+			count := atomic.AddUint32(&dc.anomaliesCount, 1)
+			if count%wsMaxAnomalyCount == 0 {
+				// Send notification to check connectivity.
+				subject, details := c.formatDetails(TopicDexConnectivity, dc.acct.host)
+				c.notify(newConnEventNote(TopicDexConnectivity, subject, dc.acct.host, dc.status(), details, db.Poke))
+			}
+		} else {
+			atomic.StoreUint32(&dc.anomaliesCount, 0)
 		}
 
 		for _, tracker := range dc.trackedTrades() {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -7984,7 +7984,8 @@ func (c *Core) handleConnectEvent(dc *dexConnection, status comms.ConnectionStat
 		dc.lastConnectMtx.RLock()
 		lastConnect := dc.lastConnect
 		dc.lastConnectMtx.RUnlock()
-		if atomic.LoadUint32(&dc.anomaliesCount)%wsMaxAnomalyCount == 0 {
+		anomalies := atomic.LoadUint32(&dc.anomaliesCount)
+		if anomalies != 0 && anomalies%wsMaxAnomalyCount == 0 {
 			// Send notification to check connectivity.
 			subject, details := c.formatDetails(TopicDexConnectivity, dc.acct.host)
 			c.notify(newConnEventNote(TopicDexConnectivity, subject, dc.acct.host, dc.status(), details, db.Poke))


### PR DESCRIPTION
I think we should not send notes for the first disconnect. follow up for #2028

EDIT: Changes in the PR are suggestions offered by @buck54321. This will allow resetting a connection's total anomaly count when the time since the `lastConnect` is > `wsAnomalyDuration`.