### PR TITLE
app: fix wallet birthday is UTC date

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -550,7 +550,7 @@ type WalletConfig struct {
 }
 
 // AdjustedBirthday converts WalletConfig.Birthday to a time.Time, and adjusts
-// it so that defaultWalletBirthday <= WalletConfig.Bithday <= now.
+// it so that defaultWalletBirthday <= WalletConfig.Birthday <= now.
 func (cfg *WalletConfig) AdjustedBirthday() time.Time {
 	bday := time.Unix(int64(cfg.Birthday), 0)
 	now := time.Now()

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=YYNQOy1"></script>
+<script src="/js/entry.js?v=EuBjPDD"></script>
 </body>
 </html>
 {{end}}


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/2192

When using a `<input type='date'>` element, it is tricky to get the time zone correct when using the `value`, `valueAsNumber`, and `valueAsDate` fields.  This is because the browser will always display the date as UTC, regardless of how you have set `valueAsDate`.  Also, when getting the date out with `new Date(input.value)`, where the value is `yyyy-mm-dd`, the `Date` parses as in UTC (12am UTC instead of local).

When the user is interacting with the input element, they are thinking in local time.  However, unless we offset the time that we set, it can show an incorrect date.  This change sets the `value` date string manually to the local date. We could also offset the `Date` that we assign to `valueAsDate` so that it will show a local date, or similarly with `valueAsNumber`, but this is harder to follow and we do not benefit from finer precision than simply 12am of the current day.

When reading the selected date back into javascript, we also have to interpret it as a local date string.  We do this by forcing the `Date` constructor to interpret the date as local by appending `"T00:00"` to the date string from `input.value`.  We also must use this trick when reading the `min` and `max` date strings.  We could instead use `valueAsDate` and manually shift in the opposite direction as when we set it, but this seems better.

See https://dev.to/mendyberger/input-and-js-dates-2lhc for a better explanation