### PR TITLE
client/eth: balance change trigger pending txs recheck

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -3787,7 +3787,7 @@ func (w *assetWallet) sumPendingTxs(bal *big.Int) (out, in uint64) {
 
 	w.pendingTxMtx.Lock()
 	defer w.pendingTxMtx.Unlock()
-	balanceHasChanged := bal.Cmp(w.pendingTxCheckBal) != 0
+	balanceHasChanged := w.pendingTxCheckBal == nil || bal.Cmp(w.pendingTxCheckBal) != 0
 	w.pendingTxCheckBal = bal
 	for txHash, pt := range w.pendingTxs {
 		if !isETH && pt.assetID != w.assetID {

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -615,6 +615,7 @@ func tassetWallet(assetID uint32) (asset.Wallet, *assetWallet, *tMempoolNode, co
 		atomize:            dexeth.WeiToGwei,
 		maxSwapsInTx:       40,
 		maxRedeemsInTx:     60,
+		pendingTxCheckBal:  new(big.Int),
 	}
 	aw.wallets = map[uint32]*assetWallet{
 		BipID: aw,


### PR DESCRIPTION
Resolves #2243

Since tips are cached for 10 seconds, this adds a secondary method of recognizing a new state that requires confirmation checks on pending txs. 