### PR TITLE
server/asset: trade address validation consistency

### DIFF
--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -623,13 +623,28 @@ func (*Backend) ValidateFeeRate(contract *asset.Contract, reqFeeRate uint64) boo
 	return contract.FeeRate() >= reqFeeRate
 }
 
-// CheckAddress checks that the given address is parseable.
-func (btc *Backend) CheckAddress(addr string) bool {
-	_, err := btc.decodeAddr(addr, btc.chainParams)
+// CheckSwapAddress checks that the given address is parseable, and suitable as
+// a redeem address in a swap contract script.
+func (btc *Backend) CheckSwapAddress(addr string) bool {
+	btcAddr, err := btc.decodeAddr(addr, btc.chainParams)
 	if err != nil {
-		btc.log.Errorf("CheckAddress for %s failed: %v", addr, err)
+		btc.log.Errorf("CheckSwapAddress for %s failed: %v", addr, err)
+		return false
 	}
-	return err == nil
+	if btc.segwit {
+		if _, ok := btcAddr.(*btcutil.AddressWitnessPubKeyHash); !ok {
+			btc.log.Errorf("CheckSwapAddress for %s failed: not a witness-pubkey-hash address (%T)",
+				btcAddr.String(), btcAddr)
+			return false
+		}
+	} else {
+		if _, ok := btcAddr.(*btcutil.AddressPubKeyHash); !ok {
+			btc.log.Errorf("CheckSwapAddress for %s failed: not a pubkey-hash address (%T)",
+				btcAddr.String(), btcAddr)
+			return false
+		}
+	}
+	return true
 }
 
 // TxData is the raw transaction bytes. SPV clients rebroadcast the transaction

--- a/server/asset/common.go
+++ b/server/asset/common.go
@@ -64,8 +64,9 @@ type Backend interface {
 	InitTxSize() uint32
 	// InitTxSizeBase is InitTxSize not including an input.
 	InitTxSizeBase() uint32
-	// CheckAddress checks that the given address is parseable.
-	CheckAddress(string) bool
+	// CheckSwapAddress checks that the given address is parseable, and suitable
+	// as a redeem address in a swap contract script or initiation.
+	CheckSwapAddress(string) bool
 	// ValidateCoinID checks the coinID to ensure it can be decoded, returning a
 	// human-readable string if it is valid.
 	// Note: ValidateCoinID is NOT used for funding coin IDs for account-based

--- a/server/asset/dcr/dcr.go
+++ b/server/asset/dcr/dcr.go
@@ -583,14 +583,20 @@ func (dcr *Backend) ValidateContract(contract []byte) error {
 	return err
 }
 
-// CheckAddress checks that the given address is parseable.
-func (dcr *Backend) CheckAddress(addr string) bool {
-	_, err := stdaddr.DecodeAddress(addr, chainParams)
+// CheckSwapAddress checks that the given address is parseable and of the
+// required type for a swap contract script (p2pkh).
+func (dcr *Backend) CheckSwapAddress(addr string) bool {
+	dcrAddr, err := stdaddr.DecodeAddress(addr, chainParams)
 	if err != nil {
 		dcr.log.Errorf("DecodeAddress error for %s: %v", addr, err)
+		return false
 	}
-
-	return err == nil
+	if _, ok := dcrAddr.(*stdaddr.AddressPubKeyHashEcdsaSecp256k1V0); !ok {
+		dcr.log.Errorf("CheckSwapAddress for %s failed: not a pubkey-hash-ecdsa-secp256k1 address (%T)",
+			dcrAddr.String(), dcrAddr)
+		return false
+	}
+	return true
 }
 
 // TxData is the raw transaction bytes. SPV clients rebroadcast the transaction

--- a/server/asset/dcr/dcr_test.go
+++ b/server/asset/dcr/dcr_test.go
@@ -1503,9 +1503,9 @@ func TestAuxiliary(t *testing.T) {
 	}
 }
 
-// TestCheckAddress checks that addresses are parsing or not parsing as
+// TestCheckSwapAddress checks that addresses are parsing or not parsing as
 // expected.
-func TestCheckAddress(t *testing.T) {
+func TestCheckSwapAddress(t *testing.T) {
 	dcr, shutdown := testBackend()
 	defer shutdown()
 
@@ -1516,16 +1516,16 @@ func TestCheckAddress(t *testing.T) {
 	tests := []test{
 		{"", true},
 		{"DsYXjAK3UiTVN9js8v9G21iRbr2wPty7f12", false},
-		{"DeZcGyCtPq7sTvACZupjT3BC1tsSEsKaYL4", false},
-		{"DSo9Qw4FZLTwFL6fg2T9XPoJA8sFoZ4idZ7", false},
-		{"DkM3W1518RharMSnqSiJCCGQ7RikMKCATeRvRwEW8vy1B2fjTd4Xi", false},
-		{"Dce4vLzzENaZT7D2Wq5crRZ4VwfYMDMWkD9", false},
-		{"TsYXjAK3UiTVN9js8v9G21iRbr2wPty7f12", true},
-		{"Dce4vLzzENaZT7D2Wq5crRZ4VwfYMDMWkD0", true}, // capital letter O not base 58
+		{"DeZcGyCtPq7sTvACZupjT3BC1tsSEsKaYL4", true},                   // valid, but AddressPubKeyHashEd25519V0
+		{"DSo9Qw4FZLTwFL6fg2T9XPoJA8sFoZ4idZ7", true},                   // valid, but AddressPubKeyHashSchnorrSecp256k1V0
+		{"DkM3W1518RharMSnqSiJCCGQ7RikMKCATeRvRwEW8vy1B2fjTd4Xi", true}, // valid, but AddressPubKeyEcdsaSecp256k1V0
+		{"Dce4vLzzENaZT7D2Wq5crRZ4VwfYMDMWkD9", true},                   // valid, but AddressScriptHashV0
+		{"TsYXjAK3UiTVN9js8v9G21iRbr2wPty7f12", true},                   // wrong network
+		{"Dce4vLzzENaZT7D2Wq5crRZ4VwfYMDMWkD0", true},                   // capital letter O not base 58
 		{"Dce4vLzzE", true},
 	}
 	for _, test := range tests {
-		if dcr.CheckAddress(test.addr) != !test.wantErr {
+		if dcr.CheckSwapAddress(test.addr) != !test.wantErr {
 			t.Fatalf("wantErr = %t, address = %s", test.wantErr, test.addr)
 		}
 	}

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -649,8 +649,8 @@ func (eth *baseBackend) ValidateCoinID(coinID []byte) (string, error) {
 	return txHash.String(), nil
 }
 
-// CheckAddress checks that the given address is parseable.
-func (eth *baseBackend) CheckAddress(addr string) bool {
+// CheckSwapAddress checks that the given address is parseable.
+func (eth *baseBackend) CheckSwapAddress(addr string) bool {
 	return common.IsHexAddress(addr)
 }
 

--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -911,7 +911,7 @@ func (r *OrderRouter) checkPrefixTrade(assets *assetSet, lotSize uint64, prefix 
 		return rpcErr
 	}
 	// Check that the address is valid.
-	if !assets.receiving.Backend.CheckAddress(trade.Address) {
+	if !assets.receiving.Backend.CheckSwapAddress(trade.Address) {
 		return msgjson.NewError(msgjson.OrderParameterError, "address doesn't check")
 	}
 	// Quantity cannot be zero, and must be an integral multiple of the lot size.

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -416,7 +416,7 @@ func (b *TBackend) Redemption(redemptionID, contractID, contractData []byte) (as
 func (b *TBackend) BlockChannel(size int) <-chan *asset.BlockUpdate { return nil }
 func (b *TBackend) InitTxSize() uint32                              { return dummySize }
 func (b *TBackend) InitTxSizeBase() uint32                          { return dummySize / 2 }
-func (b *TBackend) CheckAddress(string) bool                        { return b.addrChecks }
+func (b *TBackend) CheckSwapAddress(string) bool                    { return b.addrChecks }
 func (b *TBackend) addUTXO(coin *msgjson.Coin, val uint64) {
 	b.utxos[hex.EncodeToString(coin.ID)] = val
 }

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -429,7 +429,7 @@ func (a *TBackend) BlockChannel(size int) <-chan *asset.BlockUpdate  { return a.
 func (a *TBackend) InitTxSize() uint32                               { return 100 }
 func (a *TBackend) InitTxSizeBase() uint32                           { return 66 }
 func (a *TBackend) FeeRate(context.Context) (uint64, error)          { return 10, nil }
-func (a *TBackend) CheckAddress(string) bool                         { return true }
+func (a *TBackend) CheckSwapAddress(string) bool                     { return true }
 func (a *TBackend) Connect(context.Context) (*sync.WaitGroup, error) { return nil, nil }
 func (a *TBackend) ValidateSecret(secret, contract []byte) bool      { return true }
 func (a *TBackend) Synced() (bool, error)                            { return true, nil }


### PR DESCRIPTION
The trade address provided with an order is checked for validity, but it also must be checked that it is the proper type for inclusion in a swap contract.  This renames `server.asset.CheckAddress` to `CheckSwapAddress`, and updates it with the same type checks used client-side in `dex/networks/{dcr,btc}.MakeContract` as well as in `ExtractSwapDetails`.