### PR TITLE
client/asset: add methods for ZCash shielded pools

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -74,36 +74,38 @@ func (wt WalletTrait) IsWithdrawer() bool {
 	return wt&WalletTraitWithdrawer != 0
 }
 
-// IsSweeper test if the WalletTrait has the WalletTraitSweeper bit set, which
+// IsSweeper tests if the WalletTrait has the WalletTraitSweeper bit set, which
 // indicates the presence of a Sweep method.
 func (wt WalletTrait) IsSweeper() bool {
 	return wt&WalletTraitSweeper != 0
 }
 
-// IsRestorer test if the WalletTrait has the WalletTraitRestorer bit set, which
+// IsRestorer tests if the WalletTrait has the WalletTraitRestorer bit set, which
 // indicates the wallet implements the WalletRestorer interface.
 func (wt WalletTrait) IsRestorer() bool {
 	return wt&WalletTraitRestorer != 0
 }
 
-// IsTxFeeEstimator test if the WalletTrait has the WalletTraitTxFeeEstimator
+// IsTxFeeEstimator tests if the WalletTrait has the WalletTraitTxFeeEstimator
 // bit set, which indicates the wallet implements the TxFeeEstimator interface.
 func (wt WalletTrait) IsTxFeeEstimator() bool {
 	return wt&WalletTraitTxFeeEstimator != 0
 }
 
-// IsPeerManager test if the WalletTrait has the WalletTraitPeerManager bit
+// IsPeerManager tests if the WalletTrait has the WalletTraitPeerManager bit
 // set, which indicates the wallet implements the PeerManager interface.
 func (wt WalletTrait) IsPeerManager() bool {
 	return wt&WalletTraitPeerManager != 0
 }
 
-// IsAuthenticator test if WalletTrait has WalletTraitAuthenticator bit set,
+// IsAuthenticator tests if WalletTrait has WalletTraitAuthenticator bit set,
 // which indicates authentication is required by wallet.
 func (wt WalletTrait) IsAuthenticator() bool {
 	return wt&WalletTraitAuthenticator != 0
 }
 
+// IsShielded tests if the WalletTrait has the WalletTraitShielded bit
+// set, which indicates the wallet implements the ShieldedWallet interface.
 func (wt WalletTrait) IsShielded() bool {
 	return wt&WalletTraitShielded != 0
 }
@@ -855,7 +857,7 @@ type ShieldedWallet interface {
 	// account.
 	ShieldedStatus() (*ShieldedStatus, error)
 	// NewShieldedAddress creates a new shielded address. A shielded address can
-	// be be reused without sacrifice of privacy on-chain, but that doesn't stop
+	// be reused without sacrifice of privacy on-chain, but that doesn't stop
 	// meat-space coordination to reduce privacy.
 	NewShieldedAddress() (string, error)
 	// ShieldFunds moves funds from the transparent account to the shielded

--- a/client/asset/zec/regnet_test.go
+++ b/client/asset/zec/regnet_test.go
@@ -19,6 +19,13 @@ import (
 	"github.com/decred/dcrd/rpcclient/v7"
 )
 
+const (
+	mainnetNU5ActivationHeight        = 1687104
+	testnetNU5ActivationHeight        = 1842420
+	testnetSaplingActivationHeight    = 280000
+	testnetOverwinterActivationHeight = 207500
+)
+
 var (
 	tLotSize uint64 = 1e6
 	tZEC            = &dex.Asset{
@@ -44,7 +51,6 @@ func TestWallet(t *testing.T) {
 			Node:     "beta",
 			Filename: "beta.conf",
 		},
-		Unencrypted: true,
 	})
 }
 

--- a/client/asset/zec/shielded_rpc.go
+++ b/client/asset/zec/shielded_rpc.go
@@ -3,11 +3,20 @@
 
 package zec
 
+import (
+	"decred.org/dcrdex/dex"
+	"github.com/btcsuite/btcd/btcutil"
+)
+
 const (
 	methodZGetAddressForAccount = "z_getaddressforaccount"
 	methodZListUnifiedReceivers = "z_listunifiedreceivers"
 	methodZListAccounts         = "z_listaccounts"
 	methodZGetNewAccount        = "z_getnewaccount"
+	methodZGetBalanceForAccount = "z_getbalanceforaccount"
+	methodZSendMany             = "z_sendmany"
+	methodZValidateAddress      = "z_validateaddress"
+	methodZGetOperationResult   = "z_getoperationresult"
 )
 
 type zListAccountsResult struct {
@@ -55,4 +64,106 @@ type unifiedReceivers struct {
 // z_listunifiedreceivers unified_address
 func zGetUnifiedReceivers(c rpcCaller, unifiedAddr string) (receivers *unifiedReceivers, err error) {
 	return receivers, c.CallRPC(methodZListUnifiedReceivers, []interface{}{unifiedAddr}, &receivers)
+}
+
+func zGetBalanceForAccount(c rpcCaller, acct uint32) (uint64, error) {
+	const minConf = 1
+
+	var res struct {
+		Pools struct {
+			Orchard struct { // Ignoring similar fields for Sapling, Transparent...
+				ValueZat uint64 `json:"valueZat"`
+			} `json:"orchard"`
+		} `json:"pools"`
+	}
+	return res.Pools.Orchard.ValueZat, c.CallRPC(methodZGetBalanceForAccount, []interface{}{acct, minConf}, &res)
+}
+
+type zValidateAddressResult struct {
+	IsValid     bool   `json:"isvalid"`
+	Address     string `json:"address"`
+	AddressType string `json:"address_type"`
+	IsMine      bool   `json:"ismine"`
+	// PayingKey string `json:"payingkey"`
+	// TransmissionKey string `json:"transmissionkey"`
+	Diversifier                string `json:"diversifier"`                // sapling
+	DiversifiedTransmissionkey string `json:"diversifiedtransmissionkey"` // sapling
+}
+
+// z_validateaddress "address"
+func zValidateAddress(c rpcCaller, addr string) (res *zValidateAddressResult, err error) {
+	return res, c.CallRPC(methodZValidateAddress, []interface{}{addr}, &res)
+}
+
+type zSendManyRecipient struct {
+	Address string  `json:"address"`
+	Amount  float64 `json:"amount"`
+	Memo    string  `json:"memo,omitempty"`
+}
+
+func singleSendManyRecipient(addr string, amt uint64) []*zSendManyRecipient {
+	return []*zSendManyRecipient{
+		{
+			Address: addr,
+			Amount:  btcutil.Amount(amt).ToBTC(),
+		},
+	}
+}
+
+// When sending using z_sendmany and you're not sending a shielded tx to the
+// same pool, you must specify a lower privacy policy.
+type privacyPolicy string
+
+const (
+	FullPrivacy             privacyPolicy = "FullPrivacy"
+	AllowRevealedRecipients privacyPolicy = "AllowRevealedRecipients"
+	AllowRevealedAmounts    privacyPolicy = "AllowRevealedAmounts"
+	AllowRevealedSenders    privacyPolicy = "AllowRevealedSenders"
+)
+
+// z_sendmany "fromaddress" [{"address":... ,"amount":...},...] ( minconf ) ( fee ) ( privacyPolicy )
+func zSendMany(c rpcCaller, fromAddress string, recips []*zSendManyRecipient, priv privacyPolicy) (operationID string, err error) {
+	const minConf, fee = 1, 0.00001
+	return operationID, c.CallRPC(methodZSendMany, []interface{}{fromAddress, recips, minConf, fee, priv}, &operationID)
+}
+
+type operationStatus struct {
+	ID           string    `json:"id"`
+	Status       string    `json:"status"` // "success", "failed", others?
+	CreationTime int64     `json:"creation_time"`
+	Error        *struct { // nil for success
+		Code    int32  `json:"code"`
+		Message string `json:"message"`
+	} `json:"error" `
+	Result *struct {
+		TxID string `json:"txid"`
+	} `json:"result"`
+	ExecutionSeconds float64 `json:"execution_secs"`
+	Method           string  `json:"method"`
+	Params           struct {
+		FromAddress string `json:"fromaddress"`
+		Amounts     []struct {
+			Address string  `json:"address"`
+			Amount  float64 `json:"amount"`
+		} `json:"amounts"`
+		MinConf uint32  `json:"minconf"`
+		Fee     float64 `json:"fee"`
+	} `json:"params"`
+}
+
+// ErrEmptyOpResults is returned when z_getoperationresult returns an empty
+// array for the specified operation ID. This appears to be normal in some or
+// all cases when the result is not yet ready.
+const ErrEmptyOpResults = dex.ErrorKind("no z_getoperationstatus results")
+
+// z_getoperationresult (["operationid", ... ])
+func zGetOperationResult(c rpcCaller, operationID string) (s *operationStatus, err error) {
+	var res []*operationStatus
+	if err := c.CallRPC(methodZGetOperationResult, []interface{}{[]string{operationID}}, &res); err != nil {
+		return nil, err
+	}
+	if len(res) == 0 {
+		return nil, ErrEmptyOpResults
+	}
+	return res[0], nil
 }

--- a/client/asset/zec/shielded_test.go
+++ b/client/asset/zec/shielded_test.go
@@ -1,0 +1,134 @@
+//go:build harness
+
+package zec
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/dex"
+	dexzec "decred.org/dcrdex/dex/networks/zec"
+)
+
+var (
+	dextestDir  = filepath.Join(os.Getenv("HOME"), "dextest")
+	harnessDir  = filepath.Join(dextestDir, "zec", "harness-ctl")
+	ctx         = context.Background()
+	log         = dex.StdOutLogger("ZT", dex.LevelTrace)
+	tBtcParams  = dexzec.RegressionNetParams
+	tAddrParams = dexzec.RegressionNetAddressParams
+)
+
+func harnessCmd(ctx context.Context, exe string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, exe, args...)
+	cmd.Dir = harnessDir
+	op, err := cmd.CombinedOutput()
+	return string(op), err
+}
+
+func getDeltaWallet(t *testing.T) (*zecWallet, func()) {
+	wi, err := NewWallet(&asset.WalletConfig{
+		Type: walletTypeRPC,
+		Settings: map[string]string{
+			"rpcuser":     "user",
+			"rpcpassword": "pass",
+			"rpcport":     "33770",
+		},
+		PeersChange: func(uint32, error) {},
+		TipChange:   func(err error) {},
+	}, log, dex.Simnet)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := wi.(*zecWallet)
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	_, err = w.Connect(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return w, cancel
+}
+
+func TestTransparentAddress(t *testing.T) {
+	w, cancel := getDeltaWallet(t)
+	defer cancel()
+	_, err := transparentAddress(w, tAddrParams, tBtcParams)
+	if err != nil {
+		t.Fatalf("Error getting transparent address: %v", err)
+	}
+}
+
+func TestShieldUnshield(t *testing.T) {
+	w, cancel := getDeltaWallet(t)
+	defer cancel()
+
+	_, err := w.ShieldFunds(ctx, 1e8)
+	if err != nil {
+		t.Fatalf("ShieldFunds error: %v", err)
+	}
+
+	time.Sleep(time.Second)
+	harnessCmd(ctx, "./mine-alpha 1")
+	time.Sleep(4 * time.Second)
+
+	status, err := w.ShieldedStatus()
+	if err != nil {
+		t.Fatalf("Error getting shielded balance: %v", err)
+	}
+
+	bal, err := w.Balance()
+	if err != nil {
+		t.Fatalf("Balance error: %v", err)
+	}
+
+	if bal.Other["shielded"] != status.Balance {
+		t.Fatalf("Account balance does not match sum of Orchard address balances. %d != %d", bal.Other["shielded"], status.Balance)
+	}
+
+	_, err = w.UnshieldFunds(ctx, 5e7)
+	if err != nil {
+		t.Fatalf("UnshieldFunds error: %v", err)
+	}
+}
+
+func TestSendShielded(t *testing.T) {
+	w, cancel := getDeltaWallet(t)
+	defer cancel()
+
+	_, err := w.ShieldFunds(ctx, 1e8)
+	if err != nil {
+		t.Fatalf("ShieldFunds error: %v", err)
+	}
+
+	harnessCmd(ctx, "./mine-alpha 1")
+	time.Sleep(4 * time.Second)
+
+	orchardAddr, err := w.NewShieldedAddress()
+	if err != nil {
+		t.Fatalf("NewShieldedAddress error: %v", err)
+	}
+
+	_, err = w.SendShielded(ctx, orchardAddr, 5e7)
+	if err != nil {
+		t.Fatalf("SendShielded error: %v", err)
+	}
+
+	tAddr, err := w.NewAddress()
+	if err != nil {
+		t.Fatalf("NewAddress error: %v", err)
+	}
+
+	_, err = w.SendShielded(ctx, tAddr, 1e7)
+	if err != nil {
+		t.Fatalf("SendShielded error: %v", err)
+	}
+}

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -357,18 +357,18 @@ func (w *zecWallet) ShieldedStatus() (status *asset.ShieldedStatus, err error) {
 
 // Balance adds a sum of shielded pool balances to the transparent balance info.
 //
-// Since v4.5.0, the getnewaddress RPC is deprecated if favor of using unified
+// Since v5.4.0, the getnewaddress RPC is deprecated if favor of using unified
 // addresses from accounts generated wtih z_getnewaccount. Addresses are
-// generated from account 0. Any addresses generated using getnewaddress belong
-// to a legacy account that is not listed with z_listaccount, nor addressable
-// with e.g. z_getbalanceforaccount. For transparent addresses, we still use the
-// getbalance RPC, which combines transparent balance from both legacy and
-// generated accounts. This matches the behavior of the listunspent RPC, and
-// conveniently makes upgrading simple. So even though we ONLY use account 0 to
-// generate t-addresses, any account's transparent outputs are eligible for
-// trading. To minimize confusion, we don't add transparent receivers to
-// addresses generated from the shielded account. This doesn't preclude a user
-// doing something silly with zcash-cli.
+// generated from account 0. Any addresses previously generated using
+// getnewaddress belong to a legacy account that is not listed with
+// z_listaccount, nor addressable with e.g. z_getbalanceforaccount. For
+// transparent addresses, we still use the getbalance RPC, which combines
+// transparent balance from both legacy and generated accounts. This matches the
+// behavior of the listunspent RPC, and conveniently makes upgrading simple. So
+// even though we ONLY use account 0 to generate t-addresses, any account's
+// transparent outputs are eligible for trading. To minimize confusion, we don't
+// add transparent receivers to addresses generated from the shielded account.
+// This doesn't preclude a user doing something silly with zcash-cli.
 func (w *zecWallet) Balance() (*asset.Balance, error) {
 	bal, err := w.ExchangeWalletNoAuth.Balance()
 	if err != nil {
@@ -409,7 +409,7 @@ func (w *zecWallet) ShieldFunds(ctx context.Context, transparentVal uint64) ([]b
 	if err != nil {
 		return nil, err
 	}
-	const fees = 1000 // TODO: Update after v4.5.0 which includes ZIP137
+	const fees = 1000 // TODO: Update after v5.5.0 which includes ZIP137
 	if bal.Available < fees || bal.Available-fees < transparentVal {
 		return nil, asset.ErrInsufficientBalance
 	}
@@ -432,7 +432,7 @@ func (w *zecWallet) UnshieldFunds(ctx context.Context, amt uint64) ([]byte, erro
 	if err != nil {
 		return nil, fmt.Errorf("z_getbalance error: %w", err)
 	}
-	const fees = 1000 // TODO: Update after v4.5.0 which includes ZIP137
+	const fees = 1000 // TODO: Update after v5.5.0 which includes ZIP137
 	if bal < fees || bal-fees < amt {
 		return nil, asset.ErrInsufficientBalance
 	}
@@ -514,7 +514,7 @@ func (w *zecWallet) SendShielded(ctx context.Context, toAddr string, amt uint64)
 	if err != nil {
 		return nil, err
 	}
-	const fees = 1000 // TODO: Update after v4.5.0 which includes ZIP137
+	const fees = 1000 // TODO: Update after v5.5.0 which includes ZIP137
 	if bal < fees || bal-fees < amt {
 		return nil, asset.ErrInsufficientBalance
 	}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -52,6 +52,7 @@ go test -c -o /dev/null -tags harness ./client/asset/ltc
 go test -c -o /dev/null -tags harness ./client/asset/bch
 go test -c -o /dev/null -tags harness ./client/asset/eth
 go test -c -o /dev/null -tags rpclive ./client/asset/eth
+go test -c -o /dev/null -tags harness ./client/asset/zec
 go test -c -o /dev/null -tags dcrlive ./server/asset/dcr
 go test -c -o /dev/null -tags btclive ./server/asset/btc
 go test -c -o /dev/null -tags ltclive ./server/asset/ltc


### PR DESCRIPTION
Add methods for working with shielded pools. Only the client/asset parts are implemented. **client/core** and UI will follow in separate efforts. As such, this API may change.