### PR TITLE
ui: prevent negative amt on send form

### DIFF
--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -986,6 +986,9 @@ export default class WalletsPage extends BasePage {
         let canSend = wallet.balance.available
         if (!token) {
           canSend -= res.txfee
+          if (canSend < 0) {
+            canSend = 0
+          }
         }
         this.maxSend = canSend
         page.maxSend.textContent = Doc.formatFullPrecision(canSend, ui)

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -986,9 +986,7 @@ export default class WalletsPage extends BasePage {
         let canSend = wallet.balance.available
         if (!token) {
           canSend -= res.txfee
-          if (canSend < 0) {
-            canSend = 0
-          }
+          if (canSend < 0) canSend = 0
         }
         this.maxSend = canSend
         page.maxSend.textContent = Doc.formatFullPrecision(canSend, ui)


### PR DESCRIPTION
When transaction fee is comparable to amount left in user wallet we might get into negative territory calculating max send value.

[send-negative-amt-ui.webm](https://user-images.githubusercontent.com/112318969/227706401-7bdb39db-46ef-4b50-b8df-9366643f31be.webm)