### PR TITLE
ui: do not add cancel orders to table as market order

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=EuBjPDD"></script>
+<script src="/js/entry.js?v=NYU1RvL"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -2382,6 +2382,7 @@ export default class MarketsPage extends BasePage {
     let row = tbody.firstChild as OrderRow
     // Handle market order differently.
     if (order.rate === 0) {
+      if (order.qtyAtomic === 0) return // a cancel order. TODO: maybe make an indicator on the target order, maybe gray out
       // This is a market order.
       if (row && row.manager.getRate() === 0) {
         row.manager.insertOrder(order)


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/1139

If you load the markets page while there is a cancel order in the epoch, you see a zero-quantity market buy.

![image](https://user-images.githubusercontent.com/9373513/227999560-7e68f072-6b69-4250-b633-60c39d6093af.png)

This change prevents cancels from being added to the order table.