### PR TITLE
Revert "app: conditionally set logo img src"

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=NYU1RvL"></script>
+<script src="/js/entry.js?v=LcglrVTq"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -2793,7 +2793,7 @@ class BalanceWidget {
       tmpl.newWalletRow, tmpl.expired, tmpl.unsupported, tmpl.connect, tmpl.spinner,
       tmpl.walletState, tmpl.balanceRows, tmpl.walletAddr
     )
-    tmpl.logo.src ||= Doc.logoPath(cfg.symbol)
+    tmpl.logo.src = Doc.logoPath(cfg.symbol)
     tmpl.addWalletSymbol.textContent = cfg.symbol.toUpperCase()
     Doc.empty(tmpl.symbol)
     tmpl.symbol.appendChild(Doc.symbolize(cfg.symbol))


### PR DESCRIPTION
This reverts commit 821e1768ca6a109700946e0c8ccc1710d58d358a.

The `BalanceWidgets` are reused, and we have to update the logo path, particularly when just changing between markets.

![image](https://user-images.githubusercontent.com/9373513/228354913-7e9240ae-6f78-4ab3-8f50-ff6ec39efd1f.png)

Whoops.  This goes back to always setting the log `src` attribute.  We could get fancy to only do it when called from `setWallet` (rather than every balance note as when called from `updateAsset` in response to balance or wallet state notes), but let's just make sure this works right for the release.