### PR TITLE
client/asset/eth: broadcast to all providers

### DIFF
--- a/client/asset/eth/multirpc_live_test.go
+++ b/client/asset/eth/multirpc_live_test.go
@@ -155,7 +155,7 @@ func TestSimnetMultiRPCClient(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// Send two in a row. They should use the same provider.
+			// Send two in a row. They should use each provider, preferred first.
 			for j := 0; j < 2; j++ {
 				if _, err := cl.sendTransaction(ctx, txOpts, alphaAddr, nil); err != nil {
 					t.Fatalf("error sending tx %d-%d: %v", i, j, err)


### PR DESCRIPTION
This adds `(*multiRPCClient).withAll`, which is used by `sendSignedTransaction` to broadcast a transaction to all providers, preferred first.