### PR TITLE
client/asset/eth: fix failedProviders string misusing domain helper

### DIFF
--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -705,17 +705,17 @@ func createAndCheckProviders(ctx context.Context, walletDir string, endpoints []
 	return nil
 }
 
-// failedProviders builds string message that describes providers we tried to connect
-// to but didn't succeed.
+// failedProviders builds string message that describes provider endpoints we
+// tried to connect to but didn't succeed.
 func failedProviders(succeeded []*provider, tried []string) string {
 	ok := make(map[string]bool)
 	for _, p := range succeeded {
 		ok[p.endpointAddr] = true
 	}
 	notOK := make([]string, 0, len(tried)-len(succeeded))
-	for _, addr := range tried {
-		if !ok[addr] {
-			notOK = append(notOK, domain(addr))
+	for _, endpoint := range tried {
+		if !ok[endpoint] {
+			notOK = append(notOK, endpoint)
 		}
 	}
 	return strings.Join(notOK, " ")


### PR DESCRIPTION
Related to https://github.com/decred/dcrdex/issues/2271

The stops using `domain` to shorten the failed providers string, which is purely informational, since `domain` only works for a hostname, not a full endpoint address, and there are IP address issues to resolve.