### PR TITLE
client/asset/btc: init asset.Balance.Other in legacyBalance

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1548,6 +1548,7 @@ func (btc *baseWallet) legacyBalance() (*asset.Balance, error) {
 		return &asset.Balance{
 			Available: bal - locked,
 			Locked:    locked,
+			Other:     make(map[string]uint64),
 		}, nil
 	}
 
@@ -1560,6 +1561,7 @@ func (btc *baseWallet) legacyBalance() (*asset.Balance, error) {
 		Available: toSatoshi(walletInfo.Balance+walletInfo.UnconfirmedBalance) - locked,
 		Immature:  toSatoshi(walletInfo.ImmatureBalance),
 		Locked:    locked,
+		Other:     make(map[string]uint64),
 	}, nil
 }
 


### PR DESCRIPTION
"legacy" balance needed to construct the `asset.Balance` with an initialized `Other` map too.  We missed this because BTC uses the new `getbalances`.

```
panic({0x18d7a20, 0x25835b0})
	/home/jon/go120/src/runtime/panic.go:884 +0x213
decred.org/dcrdex/client/asset/btc.(*baseWallet).Balance(0xc0003ec680)
	/home/jon/github/decred/dcrdex/client/asset/btc/btc.go:1504 +0x197
decred.org/dcrdex/client/core.(*Core).walletBalance(0xc0001e2000?, 0xc0012a2240)
	/home/jon/github/decred/dcrdex/client/core/core.go:2054 +0x32
decred.org/dcrdex/client/core.(*Core).createWalletOrToken(0xc0001e2000, {0x25900d0, 0xc000134140}, {0xc000b4208a, 0x3, 0x3}, 0xc0019f0030)
	/home/jon/github/decred/dcrdex/client/core/core.go:2497 +0x4d1
decred.org/dcrdex/client/core.(*Core).CreateWallet(0xc0001e2000, {0xc00130c020, 0x1, 0x1}, {0xc000b4208a, 0x3, 0x3}, 0xc0019f0030)
	/home/jon/github/decred/dcrdex/client/core/core.go:2373 +0x7a6
decred.org/dcrdex/client/webserver.(*WebServer).apiNewWallet(0xc0001b8200, {0x7fe6d64e9060, 0xc001a2c600}, 0xc001370030?)
	/home/jon/github/decred/dcrdex/client/webserver/api.go:375 +0x3da
```