### PR TITLE
ui: consistent rate formatting

### DIFF
--- a/client/webserver/site/package.json
+++ b/client/webserver/site/package.json
@@ -8,6 +8,7 @@
     "watch": "webpack --watch --config webpack/dev.js",
     "analyze": "webpack --config webpack/analyze.js",
     "build": "npm exec tsc && webpack --config webpack/prod.js --progress --color",
+    "build_dev": "npm exec tsc && webpack --config webpack/dev.js --progress --color",
     "lint": "npm exec tsc && npm exec -- eslint src --ext .js --ext .ts",
     "check-types": "npm exec tsc"
   },

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=LVFHWeVTq"></script>
+<script src="/js/entry.js?v=LFgBaLTq"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -318,7 +318,7 @@ export default class MarketMakerPage extends BasePage {
 
     const setManualPrice = () => {
       const v = parseFloat(page.manualPriceInput.value ?? '0')
-      page.basisPrice.textContent = Doc.formatFiveSigFigs(v)
+      page.basisPrice.textContent = Doc.formatFourSigFigs(v)
       this.specifiedPrice = v
       this.setCurrentBasisPrice(v)
       Doc.show(page.basisPrice, page.manualPriceBttn)
@@ -466,10 +466,10 @@ export default class MarketMakerPage extends BasePage {
     const page = this.page
     if (r && r.basisPrice > 0) {
       this.fetchMaxBuy(Math.round(r.basisPrice / this.currentMarket.atomToConv * RateEncodingFactor))
-      page.basisPrice.textContent = Doc.formatFiveSigFigs(r.basisPrice)
+      page.basisPrice.textContent = Doc.formatFourSigFigs(r.basisPrice)
       Doc.show(page.absMaxBox, page.basisPrice)
       Doc.hide(page.manualPriceInput, page.noFiatBox)
-      this.page.gapFactorMax.textContent = Doc.formatFiveSigFigs(r.basisPrice)
+      this.page.gapFactorMax.textContent = Doc.formatFourSigFigs(r.basisPrice)
     } else {
       page.lotEstQuoteLots.textContent = '[no rate]'
       page.basisPrice.textContent = 'must set manually'
@@ -482,7 +482,7 @@ export default class MarketMakerPage extends BasePage {
 
     if (r && r.breakEvenSpread > 0) {
       Doc.show(page.breakEvenGapBox)
-      page.breakEvenGap.textContent = Doc.formatFiveSigFigs(r.breakEvenSpread)
+      page.breakEvenGap.textContent = Doc.formatFourSigFigs(r.breakEvenSpread)
     } else Doc.hide(page.breakEvenGapBox)
   }
 
@@ -687,13 +687,13 @@ export default class MarketMakerPage extends BasePage {
       const tmpl = Doc.parseTemplate(tr)
       tmpl.logo.src = 'img/' + o.host + '.png'
       tmpl.host.textContent = ExchangeNames[o.host]
-      tmpl.volume.textContent = Doc.formatThreeSigFigs(o.usdVol)
+      tmpl.volume.textContent = Doc.formatFourSigFigs(o.usdVol)
       const price = (o.bestBuy + o.bestSell) / 2
       weightedSum += o.usdVol * price
       weight += o.usdVol
-      tmpl.price.textContent = Doc.formatThreeSigFigs((o.bestBuy + o.bestSell) / 2)
+      tmpl.price.textContent = Doc.formatFourSigFigs((o.bestBuy + o.bestSell) / 2)
     }
-    page.avgPrice.textContent = Doc.formatFiveSigFigs(weightedSum / weight)
+    page.avgPrice.textContent = Doc.formatFourSigFigs(weightedSum / weight)
   }
 
   async fetchMaxBuy (rate: number): Promise<void> {

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -5,6 +5,8 @@ declare global {
     recordLogger: (loggerID: string, enable: boolean) => void
     dumpLogger: (loggerID: string) => void
     localeDiscrepancies: () => void
+    testFormatFourSigFigs: () => void
+    testFormatRateFullPrecision: () => void
   }
 }
 

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -746,10 +746,10 @@ export default class WalletsPage extends BasePage {
 
       if (spot) {
         const convRate = app().conventionalRate(baseid, quoteid, spot.rate, exchanges[host])
-        tmpl.price.textContent = fourSigFigs(convRate)
+        tmpl.price.textContent = Doc.formatFourSigFigs(convRate)
         tmpl.priceQuoteUnit.textContent = quotesymbol.toUpperCase()
         tmpl.priceBaseUnit.textContent = basesymbol.toUpperCase()
-        tmpl.volume.textContent = fourSigFigs(spotVolume(assetID, mkt))
+        tmpl.volume.textContent = Doc.formatFourSigFigs(spotVolume(assetID, mkt))
         tmpl.volumeUnit.textContent = assetID === baseid ? basesymbol.toUpperCase() : quotesymbol.toUpperCase()
       } else Doc.hide(tmpl.priceBox, tmpl.volumeBox)
       Doc.bind(row, 'click', () => app().loadPage('markets', { host, base: baseid, quote: quoteid }))
@@ -1315,18 +1315,4 @@ function assetIsConfigurable (assetID: number) {
   const defs = asset.info.availablewallets
   const zerothOpts = defs[0].configopts
   return defs.length > 1 || (zerothOpts && zerothOpts.length > 0)
-}
-
-const FourSigFigs = new Intl.NumberFormat((navigator.languages as string[]), {
-  maximumSignificantDigits: 4
-})
-
-const OneFractionalDigit = new Intl.NumberFormat((navigator.languages as string[]), {
-  minimumFractionDigits: 1,
-  maximumFractionDigits: 1
-})
-
-function fourSigFigs (v: number) {
-  if (v >= 1000 || Math.round(v) === v) return OneFractionalDigit.format(v)
-  return FourSigFigs.format(v)
 }


### PR DESCRIPTION
As a follow-up to https://github.com/decred/dcrdex/issues/2174 we still have some rates in order book (& depth/candle charts) with trailing zeros:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/112318969/229060938-66495486-3f12-43dc-8e6d-58199dac2fb7.png">

in this PR I'm basically truncating those leading 0s, which works because those rates are already complying with their respective rate steps, so it looks more like this:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/112318969/229064675-21a61aa6-af2c-4a3a-8a35-4bbea27df8f3.png">
