### PR TITLE
ui: price/change header/row discrepancy

### DIFF
--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -2587,8 +2587,6 @@ class MarketList {
   updateSpots (note: SpotPriceNote) {
     for (const row of this.markets) {
       if (row.mkt.xc.host !== note.host) continue
-      const spot = note.spots[row.mkt.name]
-      if (!spot) continue
       const xc = app().exchanges[row.mkt.xc.host]
       const mkt = xc.markets[row.mkt.name]
       setPriceAndChange(row.tmpl, xc, mkt)

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -2588,7 +2588,7 @@ class MarketList {
     for (const row of this.markets) {
       if (row.mkt.xc.host !== note.host) continue
       const spot = note.spots[row.mkt.name]
-      if (!spot) return
+      if (!spot) continue
       const xc = app().exchanges[row.mkt.xc.host]
       const mkt = xc.markets[row.mkt.name]
       setPriceAndChange(row.tmpl, xc, mkt)


### PR DESCRIPTION
`mkt.spot` might not be initialized when we are setting up left Market doc - we leave **Price**/**Change** values set at `-`. This is probably fine as long as these will be updated in the future, but they don't always update due to (looks like) a typo this PR fixes.

<img width="750" alt="image" src="https://user-images.githubusercontent.com/112318969/229266766-cb631938-9e22-46a5-b87f-d08fb33a7834.png">
