### PR TITLE
ui: display your orders rate in header

### DIFF
--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -390,6 +390,8 @@
                     <span data-tmpl="side"></span>
                     <span data-tmpl="qty" class="ms-1"></span>
                     <span data-tmpl="baseSymbol" class="ms-1 grey"></span>
+                    <span class="ms-1">@</span>
+                    <span data-tmpl="rate" class="ms-1"></span>
                     <span class="flex-grow-1 d-flex align-items-center justify-content-end">
                       <span data-tmpl="status"></span>
                       <span data-tmpl="activeLight" class="active-indicator active"></span>

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1284,7 +1284,7 @@ export default class MarketsPage extends BasePage {
       details.side.classList.add(ord.sell ? 'sellcolor' : 'buycolor')
       header.side.classList.add(ord.sell ? 'sellcolor' : 'buycolor')
       details.qty.textContent = header.qty.textContent = fourSigFigs(ord.qty / this.market.baseUnitInfo.conventional.conversionFactor)
-      details.rate.textContent = fourSigFigs(ord.rate / this.market.rateConversionFactor)
+      details.rate.textContent = header.rate.textContent = fourSigFigs(ord.rate / this.market.rateConversionFactor)
       header.baseSymbol.textContent = ord.baseSymbol.toUpperCase()
       details.type.textContent = OrderUtil.typeString(ord)
       this.updateMetaOrder(mord)


### PR DESCRIPTION
Resolves https://github.com/decred/dcrdex/issues/2254.

Rate fits reasonably well with the longest `canceled/settling` status and max rate step we currently have = 6

<img width="300" alt="image" src="https://user-images.githubusercontent.com/112318969/229269009-771a1c16-a719-4fd3-a3a8-d83344f92c6c.png">
