### PR TITLE
Use zero IPv4 loopback address instead of IPv6 unspecified address for CSP connect-src directive

### DIFF
--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -261,7 +261,7 @@ func (p *provider) subscribeHeaders(ctx context.Context, sub ethereum.Subscripti
 				return sub, nil
 			}
 			if time.Since(lastWarning) > 5*time.Minute {
-				log.Warnf("can't resubscribe to %q headers: %v", err)
+				log.Warnf("can't resubscribe to %q headers: %v", p.host, err)
 			}
 			select {
 			case <-time.After(time.Second * 30):


### PR DESCRIPTION
- This fixes an issue where using the IPv6Unspecified address `[::]` for csp connect-src directive could cause issues resulting in some icons not loading properly.
<img width="951" alt="Screenshot 2023-04-03 at 8 06 02 AM" src="https://user-images.githubusercontent.com/57448127/229435889-cc8c0f1b-12e7-42f9-945c-613d65f692de.png">
- Add missing log arg.

Closes #1652 

@norwnd, please can you confirm that this PR fixes the issue on your end?
