### PR TITLE
client/asset/eth: avoid confirmations overflow

### DIFF
--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -1251,6 +1251,9 @@ func (m *multiRPCClient) transactionConfirmations(ctx context.Context, txHash co
 	}
 	if r.BlockNumber != nil && tip.Number != nil {
 		bigConfs := new(big.Int).Sub(tip.Number, r.BlockNumber)
+		if bigConfs.Sign() < 0 { // avoid potential overflow
+			return 0, nil
+		}
 		bigConfs.Add(bigConfs, big.NewInt(1))
 		if bigConfs.IsInt64() {
 			return uint32(bigConfs.Int64()), nil

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -379,6 +379,10 @@ func (n *nodeClient) transactionConfirmations(ctx context.Context, txHash common
 		return 0, err
 	}
 
+	if hdr.Number.Int64() < blockHeight { // avoid potential overflow
+		return 0, nil
+	}
+
 	return uint32(hdr.Number.Int64() - blockHeight + 1), nil
 }
 


### PR DESCRIPTION
I think I observed this overflow recently on match card, consider additional protection when `uints` are used.