### PR TITLE
site: Check for uninitialized market in certain note handlers

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=LcglrVTq"></script>
+<script src="/js/entry.js?v=WECSAQK"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -690,7 +690,7 @@ export default class MarketsPage extends BasePage {
 
     if (!this.assetsAreSupported().isSupported) return // assets not supported
 
-    if (this.market.dex.tier < 1) return // acct suspended or not registered
+    if (!this.market || this.market.dex.tier < 1) return // acct suspended or not registered
 
     const { base, quote } = this.market
     const hasWallets = base && app().assets[base.id].wallet && quote && app().assets[quote.id].wallet
@@ -909,8 +909,8 @@ export default class MarketsPage extends BasePage {
   }
 
   /*
-   * reportDepthMouse accepts informations about the mouse position on the
-   * chart area.
+   * reportDepthMouse accepts information about the mouse position on the chart
+   * area.
    */
   reportDepthMouse (r: MouseReport) {
     while (this.hovers.length) (this.hovers.shift() as HTMLElement).classList.remove('hover')
@@ -937,9 +937,9 @@ export default class MarketsPage extends BasePage {
   }
 
   /*
-   * reportDepthZoom accepts informations about the current depth chart zoom level.
-   * This information is saved to disk so that the zoom level can be maintained
-   * across reloads.
+   * reportDepthZoom accepts information about the current depth chart zoom
+   * level. This information is saved to disk so that the zoom level can be
+   * maintained across reloads.
    */
   reportDepthZoom (zoom: number) {
     State.storeLocal(State.depthZoomLK, zoom)
@@ -2023,6 +2023,7 @@ export default class MarketsPage extends BasePage {
    * handlePriceUpdate is the handler for the 'spots' notification.
    */
   handlePriceUpdate (note: SpotPriceNote) {
+    if (!this.market) return // This note can arrive before the market is set.
     if (note.host === this.market.dex.host && note.spots[this.market.cfg.name]) {
       this.setCurrMarketPrice()
     }
@@ -2035,6 +2036,7 @@ export default class MarketsPage extends BasePage {
    */
   async handleBondUpdate (note: BondNote) {
     const dexAddr = note.dex
+    if (!this.market) return // This note can arrive before the market is set.
     if (dexAddr !== this.market.dex.host) return
     // If we just finished legacy registration, we need to update the Exchange.
     // TODO: Use tier change notification once available.
@@ -2085,6 +2087,7 @@ export default class MarketsPage extends BasePage {
    */
   handleEpochNote (note: EpochNote) {
     app().log('book', 'handleEpochNote:', note)
+    if (!this.market) return // This note can arrive before the market is set.
     if (note.host !== this.market.dex.host || note.marketID !== this.market.sid) return
     if (this.book) {
       this.book.setEpoch(note.epoch)


### PR DESCRIPTION
This diff uses the JS optional chaining feature to prevent errors caused by attempting to access a null field. If a user losses internet connection and regains it, some js errors will be logged when notes try to access the `dex` or `market` field on `MarketPage` before those fields are initialized. But the changes here are not limited to only note handlers since it is cleaner and less code to use optional chaining to prevent runtime errors.
<img width="581" alt="Screenshot 2023-04-03 at 3 20 20 PM" src="https://user-images.githubusercontent.com/57448127/229561560-e4dbc8e0-2dd7-4864-b68c-84dc8ef68ccd.png">
