### PR TITLE
site: Notify users when connecting wallets fail

### DIFF
--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -335,4 +335,5 @@ var EnUS = map[string]string{
 	"connected":              "Connected",
 	"Remove":                 "Remove",
 	"unready_wallets_msg":    "Your wallets must be connected and unlocked before trades can be processed. Resolve this ASAP!",
+	"Error":                  "Error",
 }

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -535,6 +535,13 @@
       </div>
     </form>
 
+    {{- /* Error Modal */ -}}
+    <form id="errorModal" class="d-hide mw-425">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
+      <div class="fs22 text-center">[[[Error]]]</div>
+      <div id="errorModalMsg" class="fs16 errcolor my-2 text-center"></div>
+    </form>
+
   </div>
 </div>
 {{template "bottom"}}

--- a/client/webserver/site/src/js/locales.ts
+++ b/client/webserver/site/src/js/locales.ts
@@ -108,6 +108,7 @@ export const ID_EMPTY_DEX_ADDRESS_MSG = 'EMPTY_DEX_ADDRESS_MSG'
 export const ID_SELECT_WALLET_FOR_FEE_PAYMENT = 'SELECT_WALLET_FOR_FEE_PAYMENT'
 export const ID_UNAVAILABLE = 'UNAVAILABLE'
 export const ID_WALLET_SYNC_FINISHING_UP = 'WALLET_SYNC_FINISHING_UP'
+export const ID_CONNECT_WALLET_ERR_MSG = 'CONNECTING_WALLET_ERR_MSG'
 
 export const enUS: Locale = {
   [ID_NO_PASS_ERROR_MSG]: 'password cannot be empty',
@@ -217,7 +218,8 @@ export const enUS: Locale = {
   [ID_UNAVAILABLE]: 'unavailable',
   [ID_EMPTY_DEX_ADDRESS_MSG]: 'DEX address cannot be empty',
   [ID_SELECT_WALLET_FOR_FEE_PAYMENT]: 'Select a valid wallet to post a bond',
-  [ID_WALLET_SYNC_FINISHING_UP]: 'finishing up'
+  [ID_WALLET_SYNC_FINISHING_UP]: 'finishing up',
+  [ID_CONNECT_WALLET_ERR_MSG]: 'Failed to connect {{ assetName }} wallet: {{ errMsg }}'
 }
 
 export const ptBR: Locale = {

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1016,7 +1016,12 @@ export default class WalletsPage extends BasePage {
     const loaded = app().loading(this.body)
     const res = await postJSON('/api/connectwallet', { assetID })
     loaded()
-    if (!app().checkResponse(res)) return
+    if (!app().checkResponse(res)) {
+      const { symbol } = app().assets[assetID]
+      const page = this.page
+      page.errorModalMsg.textContent = intl.prep(intl.ID_CONNECT_WALLET_ERR_MSG, { assetName: symbol, errMsg: res.msg })
+      this.showForm(page.errorModal)
+    }
     this.updateDisplayedAsset(assetID)
   }
 


### PR DESCRIPTION
Closes # 2241

UI changes:
<img width="517" alt="Screenshot 2023-04-04 at 11 30 19 PM" src="https://user-images.githubusercontent.com/57448127/229938773-47a3a41f-c17c-4bda-8d29-f1aa3ba87cee.png">

> @norwnd (#2241): As a sidenote, I'm not even sure why this connect button is there in the first place , wouldn't it be better to try re-connect wallet automatically every 30s or something?

This part is not handled in this PR. @chappjc, what do you think?

IMO, using a reconnect loop for wallet connection when are not sure that we will ever connect seems to be undesirable. Wallet connection will be attempted in any part of the client code that requires a connected wallet, plus, like the note above, If a user is missing wallet files, we are going to try forever until they take action.