### PR TITLE
wiki: add eth recovery section and remove archivenode

### DIFF
--- a/docs/wiki/Ethereum.md
+++ b/docs/wiki/Ethereum.md
@@ -101,3 +101,27 @@ has been under fire recently. Decide for yourself.
 Some providers allow you to sign in with a web3 wallet (e.g. MetaMask) to create
 a personal API key and access a dashboard. This may be preferable to creating an
 account with an email address.
+
+## Wallet Recovery
+
+The wallet's account and private keys are derived from the DEX "application
+seed". This means that reinitializing the DEX application from this seed will
+restore the same Ethereum wallet and any ERC20 wallets.
+
+**WARNING: You should never interact with the Ethereum account outside of the
+DEX application!**
+
+**Do NOT** simultaneously use the account from multiple wallet programs,
+including multiple installations of the DEX application with the same seed. Any
+interaction other than simply viewing the balance while the DEX app is running
+or there are active orders can interfere with trades and can lead to lost funds.
+Such interactions include sending funds, cancelling or "speeding up"
+transactions, or any other interaction that consumes gas or creates a new
+transaction.
+
+However, it is possible to export the account's private key for recovery outside
+of the DEX application. Only in emergency recovery situations should you import
+the private key into another wallet. Again, do not use the wallet outside of the
+DEX application. If you feel you need to use the backup private key, or are
+unable to reinitialize the DEX application with the same seed, please first seek
+guidance in the [Decred chat](https://matrix.to/#/#dex:decred.org).

--- a/docs/wiki/Ethereum.md
+++ b/docs/wiki/Ethereum.md
@@ -94,7 +94,6 @@ A handful that we have tested:
 - Ankr (www.ankr.com/rpc) - generic endpoint, often behind a few blocks, possibly http-only
 - Flashbots (flashbots.net) - generic endpoint
 - Publicnode (publicnode.com) - generic endpoint
-- ArchiveNode (archivenode.io) - custom API, possibly http-only, no testnet, slow access approval process
 
 Infura is also extremely reliable and common, but their data retention policy
 has been under fire recently. Decide for yourself.

--- a/docs/wiki/Ethereum.md
+++ b/docs/wiki/Ethereum.md
@@ -16,7 +16,8 @@ specified by the user. This is the wallet's gateway to the Ethereum network.
 Casual ETH users may be familiar with Infura, as an example, since this is the
 default provider for the common MetaMask wallet. When creating your Ethereum
 wallet in the DEX application, you will need to specify the full path to an
-Ethereum RPC provider, i.e. an RPC endpoint.
+Ethereum RPC provider, i.e. an RPC endpoint. See the [RPC Provider
+List](#rpc-provider-list-partial) below for suggestions.
 
 ## Wallet Setup
 
@@ -53,9 +54,9 @@ Consider the following tips when configuring your Ethereum wallet:
   provides redundancy. Often a provider will fall behind or even stall, so
   use of multiple providers adds robustness to your wallet.
 
-- Get a custom RPC endpoint, with your own **private API key**. Many providers
-  will allow you to create a custom endpoint that includes an API "key" that is
-  assigned just to you.
+- Get a personal RPC endpoint, with your own **private API key**. Many providers
+  will allow you to create a personal endpoint that includes an API "key" that
+  is assigned just to you.
   
   This is important since all providers have request rate limits, which may be
   exhausted quickly with a generic RPC endpoint (e.g.
@@ -85,18 +86,24 @@ Some common Ethereum RPC providers are listed at <https://ethereumnodes.com/>.
 
 A handful that we have tested:
 
-- NodeReal (nodereal.io) - custom API key, wss
-- Rivet (rivet.cloud) - custom API key, wss
-- Alchemy (alchemy.com) - custom API key, wss
-- LlamaNodes (llamanodes.com) - custom API key, wss, no testnet
-- Blast (blastapi.io) - custom API, wss, often behind a few blocks
-- OmniaTech (omniatech.io) - custom API, wss
-- Ankr (www.ankr.com/rpc) - generic endpoint, often behind a few blocks, possibly http-only
-- Flashbots (flashbots.net) - generic endpoint
-- Publicnode (publicnode.com) - generic endpoint
+- [NodeReal](https://dashboard.nodereal.io/) - personal API key, wss
+- [Alchemy](https://www.alchemy.com/overviews/private-rpc-endpoint) - personal API key
+- [LlamaNodes](https://llamanodes.com/) - personal API key, wss, web3 sign-in, no testnet
+- [Rivet](https://rivet.cloud/) - personal API key, wss, web3 sign-in
+- [Blast](https://blastapi.io/login?app=consumer) - personal API key, wss, web3 sign-in
+- [OmniaTech](https://app.omniatech.io/dashboard/generate-endpoints) - personal API key, wss, web3 sign-in
+- [Ankr](https://www.ankr.com/rpc/) - generic endpoint, often behind a few blocks, possibly http-only
+- [Publicnode](https://ethereum.publicnode.com/) - generic endpoint, possibly http-only
 
-Infura is also extremely reliable and common, but their data retention policy
-has been under fire recently. Decide for yourself.
+[Infura](https://docs.infura.io/infura/reference/network-endpoints) is also
+extremely reliable and common, but their data sharing and retention policy has
+been under fire recently. Decide for yourself.
+
+The Flashbots Protect RPC service is **not recommended** for the DEX wallet
+since the public mempool is only used in certain circumstances, which is not
+helpful for the DEX wallet. Further, Flashbots will abandon transactions that
+are not mined within 6 minutes, and while it is expected that transactions will
+be mined more promptly, this is not desirable.
 
 Some providers allow you to sign in with a web3 wallet (e.g. MetaMask) to create
 a personal API key and access a dashboard. This may be preferable to creating an


### PR DESCRIPTION
This adds a "Wallet Recovery" section to the Ethereum page.  I am mainly using this as a chance to sternly warn against using the wallet from multiple wallet programs simultaneously.  I am intentionally not showing screens or describing how to get the backup private key.

This also removes ArchiveNode from the RPC provider list since they have announced that [they are shutting down](https://defidude.medium.com/sunsetting-archivenode-io-c72a78fe3653).