### PR TITLE
multi: allow no dcr reg fee config on server, remove dcr-specific fields

### DIFF
--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -531,7 +531,9 @@ func (c *Core) rotateBonds(ctx context.Context) {
 
 		wallet, err := c.connectedWallet(acctBondState.bondAssetID)
 		if err != nil {
-			c.log.Errorf("%v wallet not available for bonds: %v", unbip(acctBondState.bondAssetID), err)
+			if acctBondState.targetTier > 0 {
+				c.log.Errorf("%v wallet not available for bonds: %v", unbip(acctBondState.bondAssetID), err)
+			}
 			continue
 		}
 

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -883,32 +883,6 @@ func (dc *dexConnection) refreshServerConfig() (*msgjson.ConfigResult, error) {
 		}
 	}
 
-	// Patch ConfigResponse.RegFees if no entry for DCR is there, meaning it is
-	// likely an older server using cfg.Fee and cfg.RegFeeConfirms.
-	if dcrAsset := cfg.RegFees["dcr"]; dcrAsset == nil {
-		dc.log.Warnf("Legacy server %v does not provide a regFees map.", dc.acct.host)
-		if cfg.RegFees == nil {
-			cfg.RegFees = make(map[string]*msgjson.FeeAsset)
-		}
-		if cfg.Fee > 0 {
-			cfg.RegFees["dcr"] = &msgjson.FeeAsset{ // v0 is only DCR
-				ID:    42,
-				Confs: uint32(cfg.RegFeeConfirms),
-				Amt:   cfg.Fee,
-			}
-		} else {
-			dc.log.Warnf("Server %v does not support DCR for registration", dc.acct.host)
-		}
-	} else {
-		if cfg.Fee > 0 && dcrAsset.Amt != cfg.Fee {
-			dc.log.Warnf("Inconsistent DCR fee amount: %d != %d", dcrAsset.Amt, cfg.Fee)
-		}
-		if dcrAsset.Confs != uint32(cfg.RegFeeConfirms) {
-			dc.log.Warnf("Inconsistent DCR fee confirmation requirement: %d != %d",
-				dcrAsset.Confs, cfg.RegFeeConfirms)
-		}
-	}
-
 	// Update the dex connection with the new config details, including
 	// StartEpoch and FinalEpoch, and rebuild the market data maps.
 	dc.cfgMtx.Lock()

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -493,16 +493,6 @@ func (dc *dexConnection) exchangeInfo() *Exchange {
 			Amt:   asset.Amt,
 		}
 	}
-	dcrAsset := feeAssets["dcr"]
-	if dcrAsset == nil { // should have happened in refreshServerConfig
-		// V0PURGE
-		dcrAsset = &FeeAsset{
-			ID:    42,
-			Amt:   cfg.Fee,
-			Confs: uint32(cfg.RegFeeConfirms),
-		}
-		feeAssets["dcr"] = dcrAsset
-	}
 
 	dc.acct.authMtx.RLock()
 	// TODO: List bonds in core.Exchange. For now, just tier.
@@ -531,7 +521,6 @@ func (dc *dexConnection) exchangeInfo() *Exchange {
 		// TODO: Bonds
 
 		// Legacy reg fee (V0PURGE)
-		Fee:        dcrAsset,
 		RegFees:    feeAssets,
 		PendingFee: dc.getPendingFee(),
 	}

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -633,7 +633,6 @@ type Exchange struct {
 	// TODO: Bonds slice(s) - and a LockedInBonds(assetID) method
 
 	// OLD fields for the legacy registration fee (V0PURGE):
-	Fee        *FeeAsset            `json:"feeAsset"` // DCR. DEPRECATED by RegFees.
 	RegFees    map[string]*FeeAsset `json:"regFees"`
 	PendingFee *PendingFeeState     `json:"pendingFee,omitempty"`
 }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1295,9 +1295,7 @@ type ConfigResult struct {
 	// by bond version.
 	BondExpiry uint64 `json:"DEV_bondExpiry"`
 
-	RegFees        map[string]*FeeAsset `json:"regFees"`
-	Fee            uint64               `json:"fee"`            // DEPRECATED
-	RegFeeConfirms uint16               `json:"regfeeconfirms"` // DEPRECATED
+	RegFees map[string]*FeeAsset `json:"regFees"`
 }
 
 // Spot is a snapshot of a market at the end of a match cycle. A slice of Spot

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -310,8 +310,6 @@ EOF
 
 # Write dcrdex.conf. The regfeexpub comes from the alpha>server_fees account.
 cat << EOF >> ./dcrdex.conf
-regfeexpub=spubVWKGn9TGzyo7M4b5xubB5UV4joZ5HBMNBmMyGvYEaoZMkSxVG4opckpmQ26E85iHg8KQxrSVTdex56biddqtXBerG9xMN8Dvb3eNQVFFwpE
-regfeeconfirms=1
 pgdbname=${TEST_DB}
 simnet=1
 rpclisten=127.0.0.1:17273

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -77,9 +77,6 @@ type dexConf struct {
 	DBPort            uint16
 	ShowPGConfig      bool
 	MarketsConfPath   string
-	RegFeeXPub        string
-	RegFeeConfirms    int64
-	RegFeeAmount      uint64
 	CancelThreshold   float64
 	FreeCancels       bool
 	MaxUserCancels    uint32
@@ -127,11 +124,6 @@ type flagsData struct {
 	BroadcastTimeout time.Duration `long:"bcasttimeout" description:"The broadcast timeout specifies how long clients have to broadcast an expected transaction when it is their turn to act. Matches without the expected action by this time are revoked and the actor is penalized (default: 12 minutes)."`
 	TxWaitExpiration time.Duration `long:"txwaitexpiration" description:"How long the server will search for a client-reported transaction before responding to the client with an error indicating that it was not found. This should ideally be less than half of swaps BroadcastTimeout to allow for more than one retry of the client's request (default: 2 minutes)."`
 	DEXPrivKeyPath   string        `long:"dexprivkeypath" description:"The path to a file containing the DEX private key for message signing."`
-	// Deprecated fields that specify the Decred-specific registration fee
-	// config. This information is now specified per-asset in markets.json.
-	RegFeeXPub     string `long:"regfeexpub" description:"DEPRECATED - use markets.json instead. The extended public key for deriving Decred addresses to which DEX registration fees should be paid."`
-	RegFeeConfirms int64  `long:"regfeeconfirms" description:"DEPRECATED - use markets.json instead. The number of confirmations required to consider a registration fee paid."`
-	RegFeeAmount   uint64 `long:"regfeeamount" description:"DEPRECATED - use markets.json instead. The registration fee amount in atoms."`
 
 	CancelThreshold   float64 `long:"cancelthresh" description:"Cancellation rate threshold (cancels/all_completed)."`
 	FreeCancels       bool    `long:"freecancels" description:"No cancellation rate enforcement (unlimited cancel orders)."`
@@ -541,9 +533,6 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		DBPass:            cfg.PGPass,
 		ShowPGConfig:      cfg.ShowPGConfig,
 		MarketsConfPath:   cfg.MarketsConfPath,
-		RegFeeAmount:      cfg.RegFeeAmount,
-		RegFeeConfirms:    cfg.RegFeeConfirms,
-		RegFeeXPub:        cfg.RegFeeXPub,
 		CancelThreshold:   cfg.CancelThreshold,
 		MaxUserCancels:    cfg.MaxUserCancels,
 		FreeCancels:       cfg.FreeCancels,

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -117,28 +117,6 @@ func mainCore(ctx context.Context) error {
 		return err
 	}
 
-	// Validate any deprecated fields that are still set in the .conf file.
-	var dcrValidated bool
-	for _, asset := range assets {
-		if strings.ToLower(asset.Symbol) != "dcr" {
-			continue // the config fields applied to DCR
-		}
-		if cfg.RegFeeXPub != "" && cfg.RegFeeXPub != asset.RegXPub {
-			return fmt.Errorf("Decred fee xpub in config file does not match xpub in markets.json")
-		}
-		if cfg.RegFeeAmount > 0 && cfg.RegFeeAmount != asset.RegFee {
-			return fmt.Errorf("Decred fee amount in config file does not match amount in markets.json")
-		}
-		if cfg.RegFeeConfirms != 0 && cfg.RegFeeConfirms != int64(asset.RegConfs) {
-			return fmt.Errorf("Decred fee confirms in config file does not match confirms in markets.json")
-		}
-		dcrValidated = true
-		break
-	}
-	if !dcrValidated {
-		return fmt.Errorf("Decred asset not specified")
-	}
-
 	// Create the DEX manager.
 	dexConf := &dexsrv.DexConf{
 		DataDir:    cfg.DataDir,

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -143,10 +143,6 @@ type configResponse struct {
 
 func newConfigResponse(cfg *DexConf, regAssets map[string]*msgjson.FeeAsset, bondAssets map[string]*msgjson.BondAsset,
 	cfgAssets []*msgjson.Asset, cfgMarkets []*msgjson.Market) (*configResponse, error) {
-	dcrAsset := regAssets["dcr"]
-	if dcrAsset == nil {
-		return nil, fmt.Errorf("DCR is required as a fee asset for backward compatibility")
-	}
 
 	configMsg := &msgjson.ConfigResult{
 		APIVersion:       uint16(APIVersion),
@@ -159,9 +155,6 @@ func newConfigResponse(cfg *DexConf, regAssets map[string]*msgjson.FeeAsset, bon
 		BondExpiry:       uint64(dex.BondExpiry(cfg.Network)), // temporary while we figure it out
 		BinSizes:         candles.BinSizes,
 		RegFees:          regAssets,
-
-		RegFeeConfirms: uint16(dcrAsset.Confs), // DEPRECATED - DCR only (V0PURGE)
-		Fee:            dcrAsset.Amt,           // DEPRECATED - DCR only
 	}
 
 	// NOTE/TODO: To include active epoch in the market status objects, we need


### PR DESCRIPTION
The first commit removes the server's startup requirement of having DCR reg fee info specified.  This was a hold-over from before we even had multi-asset reg fee support.  There is still the RegFees map (which may also be empty in a bonds-only config).

The second commit removes the warning about a server that does not support DCR for registration. This also removes the handling of ancient servers that even lacked the RegFees map (only had the dcr-specific fields).