### PR TITLE
bug fix: use prepared webserver adress in csp

### DIFF
--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -526,7 +526,7 @@ func (s *WebServer) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		// Safari. When this is removed, the allowInCSP variable can be removed
 		// but prepareAddr should still return 127.0.0.1 for unspecified
 		// addresses.
-		s.csp = fmt.Sprintf("%s ws://%s", baseCSP, s.addr)
+		s.csp = fmt.Sprintf("%s ws://%s", baseCSP, addr)
 	}
 	s.addr = addr
 


### PR DESCRIPTION
#2283 was supposed to use `addr` and not `s.addr` which is passed to the CSP.