### PR TITLE
dex/networks/ltc: witness limits fixes and decoder simplifications

### DIFF
--- a/dex/networks/ltc/tx.go
+++ b/dex/networks/ltc/tx.go
@@ -20,8 +20,8 @@ const (
 	maxTxInPerMessage         = wire.MaxMessagePayload/41 + 1 // wire.maxTxInPerMessage
 	maxTxOutPerMessage        = wire.MaxMessagePayload/       // wire.maxTxOutPerMessage
 		wire.MinTxOutPayload + 1
-	maxWitnessItemsPerInput = 500000 // from wire
-	maxWitnessItemSize      = 11000  // from wire
+	maxWitnessItemsPerInput = 4_000_000 // from wire
+	maxWitnessItemSize      = 4_000_000 // from wire
 )
 
 type decoder struct {


### PR DESCRIPTION
ltcsuite is adopting our MW tx deserialization code, and it [revealed](https://github.com/ltcsuite/ltcd/issues/17#issuecomment-1507856230) a small usability issue with the `decoder` API, which this fixes.

This also updates the `maxWitnessItemsPerInput` and `maxWitnessItemSize` to match the current values following the btcsuite backports in https://github.com/ltcsuite/ltcd/pull/25