### PR TITLE
multi: Send recent matches in orderbook sync

### DIFF
--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -869,6 +869,9 @@ type OrderBook struct {
 	Orders       []*BookOrderNote `json:"orders"`
 	BaseFeeRate  uint64           `json:"baseFeeRate"`
 	QuoteFeeRate uint64           `json:"quoteFeeRate"`
+	// RecentMatches is [rate, qty, timestamp]. Quantity is signed.
+	// Negative means that the maker was a sell order.
+	RecentMatches [][3]int64 `json:"recentMatches"`
 }
 
 // MatchProofNote is the match_proof notification payload.


### PR DESCRIPTION
Server orderbook is updated to cache the 100 most recent matches in memory, and they are returned whenever a client syncs the orderbook.

Closes #2296