### PR TITLE
Github docker build workflow adjustments

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -2,7 +2,8 @@ name: Build and Push Docker Image
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 
 env:
   DOCKER_CLI_EXPERIMENTAL: enabled


### PR DESCRIPTION
- Trigger docker build workflow on release published (instead of `created` which does not trigger reliably when creating releases via the GH web interface)
- Allow the manual triggering of the build