### PR TITLE
site: persist fee asset icon on markets page

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=EODkFSD"></script>
+<script src="/js/entry.js?v=d1040bb"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -2869,7 +2869,8 @@ class BalanceWidget {
   /* updateParent updates the side's parent asset balance. */
   updateParent (side: BalanceWidgetElement) {
     const { wallet: { balance }, unitInfo } = app().assets[side.parentID]
-    if (side.parentBal) side.parentBal.textContent = Doc.formatCoinValue(balance.available, unitInfo)
+    // firstChild is the text node set before the img child node in addRow.
+    if (side.parentBal?.firstChild) side.parentBal.firstChild.textContent = Doc.formatCoinValue(balance.available, unitInfo)
   }
 
   /*


### PR DESCRIPTION
Given `<div data-tmpl="bal">48<img src="/img/coins/eth.png" class="micro-icon"></div>`, if we do `balTmpl.textContent = "48"` that nukes the child `img` class.  To only update the text and persist the `img` child node set before, we have to target only the text node via `balTmpl.firstChild`.