### PR TITLE
server/market: startup balance checks must convert base to quote

### DIFF
--- a/server/market/market.go
+++ b/server/market/market.go
@@ -358,18 +358,18 @@ ordersLoop:
 			var addr string
 			var qty, lots uint64
 			var redeems int
-			if lo.Sell {
+			if lo.Sell { // sell base => redeem acct-based quote
 				addr = lo.Address
 				redeems = int((lo.Quantity - lo.FillAmt) / mktInfo.LotSize)
-			} else {
+			} else { // buy base => offer acct-based quote
 				// address is zeroth coin
 				if len(lo.Coins) != 1 {
 					log.Errorf("rejecting account-based-base-asset order %s that has no coins ¯\\_(ツ)_/¯", lo.ID())
 					continue ordersLoop
 				}
 				addr = string(lo.Coins[0])
-				qty = lo.Quantity
-				lots = qty / mktInfo.LotSize
+				lots = lo.Quantity / mktInfo.LotSize
+				qty = calc.BaseToQuote(lo.Rate, lo.Quantity)
 			}
 			quoteAcctStats.add(addr, qty, lots, redeems)
 		} else if !lo.Sell {


### PR DESCRIPTION
When an account-based asset is the quote asset in a market, and there is a booked buy order, the quantity to check must be in units of the quote asset (the account-based asset).

Test/repro: On the simnet harness fund your wallet with something like `0.39` ETH.  On the DCR-ETH market, book a **buy** order at 0.01 ETH/DCR for 1 lot, which should say "Total: 0.10 ETH".
Stop the server process and start again with `./run`.  It would unbook the order because it was comparing the base asset (10 DCR or 1000000000 atoms) with the eth balance of 0.039 ETH (390000000 gwei).

With this change, it will compare quote units (plus fees) against balance.