### PR TITLE
site: correct order buy/sell colors

### DIFF
--- a/client/webserver/site/src/css/market_dark.scss
+++ b/client/webserver/site/src/css/market_dark.scss
@@ -80,7 +80,7 @@ body.dark {
           }
 
           &.sell {
-            background-color: $buycolor_dark;
+            background-color: $sellcolor_dark;
           }
         }
 

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=d1040bb"></script>
+<script src="/js/entry.js?v=rgcDpVd"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=EODjPDD" rel="stylesheet">
+  <link href="/css/style.css?v=rgcDpVd" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -386,7 +386,7 @@
               <div id="userOrders" class="mb-3">
                 <div id="userOrderTmpl" class="user-order">
                   <div data-tmpl="header" class="user-order-header">
-                    <div data-tmpl="sideLight" class="side-indicator buy"></div>
+                    <div data-tmpl="sideLight" class="side-indicator"></div>
                     <span data-tmpl="side"></span>
                     <span data-tmpl="qty" class="ms-1"></span>
                     <span data-tmpl="baseSymbol" class="ms-1 grey"></span>

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1340,7 +1340,7 @@ export default class MarketsPage extends BasePage {
   */
   updateMetaOrder (mord: MetaOrder) {
     const { header, details, ord } = mord
-    if (ord.status <= OrderUtil.StatusBooked) header.activeLight.classList.add('active')
+    if (ord.status <= OrderUtil.StatusBooked || OrderUtil.hasActiveMatches(ord)) header.activeLight.classList.add('active')
     else header.activeLight.classList.remove('active')
     details.status.textContent = header.status.textContent = OrderUtil.statusString(ord)
     details.age.textContent = Doc.timeSince(ord.submitTime)


### PR DESCRIPTION
This corrects the `side-indicator`'s sell color.  It was correct on the light theme.

This also prevents both `buy` and `sell` classes on the `sideLight` div.  Both issues can be seen:

![image](https://user-images.githubusercontent.com/9373513/233121218-b38d4b3b-90e2-4e5d-8c79-dd32e1e3b5c5.png)

`.side-indicator.sell` used the buy color.  And the `sideLight` div had both `buy sell` classes.

The second issue addressed in this PR is the "active" indicator light not being shown for orders with settling matches.

Both issues visible here:

![image](https://user-images.githubusercontent.com/9373513/233121948-6d5e850d-fa73-406b-901f-b8e6115c92a8.png)
