### PR TITLE
server/asset/eth: make endpoint a Stringer

### DIFF
--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -64,6 +64,13 @@ type endpoint struct {
 	priority uint16
 }
 
+func (ep endpoint) String() string {
+	return ep.url
+}
+
+var _ fmt.Stringer = endpoint{} // compile error if pointer receiver
+var _ fmt.Stringer = (*endpoint)(nil)
+
 type rpcclient struct {
 	net dex.Network
 	log dex.Logger


### PR DESCRIPTION
This makes the `endpoint` type a `fmt.Stringer` so it can be used as expected in printf-like statements (`endpoint` used to just be a `string`).  Without this change, it prints like this:

```
[WRN] ASSET[eth][RPC]: Error checking required modules at {"wss://eth-mainnet.nodereal.io/ws/v1/asdf" 'ɘ'}: needed apis not present:  txpool.
```

