### PR TITLE
client/core: add core methods and webserver endpoints for shielded wallets

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -860,13 +860,13 @@ type ShieldedWallet interface {
 	NewShieldedAddress() (string, error)
 	// ShieldFunds moves funds from the transparent account to the shielded
 	// account.
-	ShieldFunds(ctx context.Context, amt uint64) (dex.Bytes, error)
+	ShieldFunds(ctx context.Context, amt uint64) ([]byte, error)
 	// UnshieldFunds moves funds from the shielded account to the transparent
 	// account.
-	UnshieldFunds(ctx context.Context, amt uint64) (dex.Bytes, error)
+	UnshieldFunds(ctx context.Context, amt uint64) ([]byte, error)
 	// SendShielded sends funds from the shielded account to the provided
 	// shielded or transparent address.
-	SendShielded(ctx context.Context, toAddr string, amt uint64) (dex.Bytes, error)
+	SendShielded(ctx context.Context, toAddr string, amt uint64) ([]byte, error)
 }
 
 // Balance is categorized information about a wallet's balance.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -29,6 +29,7 @@ const (
 	WalletTraitTxFeeEstimator                              // The wallet can estimate transaction fees.
 	WalletTraitPeerManager                                 // The wallet can manage its peers.
 	WalletTraitAuthenticator                               // The wallet require authentication.
+	WalletTraitShielded                                    // The wallet is ShieldedWallet (e.g. ZCash)
 )
 
 // IsRescanner tests if the WalletTrait has the WalletTraitRescanner bit set.
@@ -103,6 +104,10 @@ func (wt WalletTrait) IsAuthenticator() bool {
 	return wt&WalletTraitAuthenticator != 0
 }
 
+func (wt WalletTrait) IsShielded() bool {
+	return wt&WalletTraitShielded != 0
+}
+
 // DetermineWalletTraits returns the WalletTrait bitset for the provided Wallet.
 func DetermineWalletTraits(w Wallet) (t WalletTrait) {
 	if _, is := w.(Rescanner); is {
@@ -143,6 +148,9 @@ func DetermineWalletTraits(w Wallet) (t WalletTrait) {
 	}
 	if _, is := w.(Authenticator); is {
 		t |= WalletTraitAuthenticator
+	}
+	if _, is := w.(ShieldedWallet); is {
+		t |= WalletTraitShielded
 	}
 	return t
 }
@@ -831,6 +839,34 @@ type BotWallet interface {
 	// funds aren't available. The returned fees are the RealisticWorstCase. The
 	// Lots field of the PreSwapForm is ignored and assumed to be a single lot.
 	SingleLotRedeemFees(*PreRedeemForm) (uint64, error)
+}
+
+// ShieldedStatus is the balance and address associated with the shielded
+// account.
+type ShieldedStatus struct {
+	LastAddress string
+	Balance     uint64
+}
+
+// ShieldedWallet is implemented by ZCash, and enables working with value in
+// shielded pools.
+type ShieldedWallet interface {
+	// ShieldedStatus list the last address and the balance in the shielded
+	// account.
+	ShieldedStatus() (*ShieldedStatus, error)
+	// NewShieldedAddress creates a new shielded address. A shielded address can
+	// be be reused without sacrifice of privacy on-chain, but that doesn't stop
+	// meat-space coordination to reduce privacy.
+	NewShieldedAddress() (string, error)
+	// ShieldFunds moves funds from the transparent account to the shielded
+	// account.
+	ShieldFunds(ctx context.Context, amt uint64) (dex.Bytes, error)
+	// UnshieldFunds moves funds from the shielded account to the transparent
+	// account.
+	UnshieldFunds(ctx context.Context, amt uint64) (dex.Bytes, error)
+	// SendShielded sends funds from the shielded account to the provided
+	// shielded or transparent address.
+	SendShielded(ctx context.Context, toAddr string, amt uint64) (dex.Bytes, error)
 }
 
 // Balance is categorized information about a wallet's balance.

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -127,7 +127,15 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Ne
 // DecodeCoinID creates a human-readable representation of a coin ID for
 // Zcash.
 func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
-	// Zcash and Bitcoin have the same tx hash and output format.
+	// Zcash shielded transactions don't have transparent outputs, so the coinID
+	// will just be the tx hash.
+	if len(coinID) == chainhash.HashSize {
+		var txHash chainhash.Hash
+		copy(txHash[:], coinID)
+		return txHash.String(), nil
+	}
+	// For transparent transactions, Zcash and Bitcoin have the same tx hash
+	// and output format.
 	return (&btc.Driver{}).DecodeCoinID(coinID)
 }
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -10007,3 +10007,65 @@ func (c *Core) saveDisabledRateSources() {
 		c.log.Errorf("Unable to save disabled fiat rate source to database: %v", err)
 	}
 }
+
+func (c *Core) shieldedWallet(assetID uint32) (asset.ShieldedWallet, error) {
+	w, found := c.wallet(assetID)
+	if !found {
+		return nil, fmt.Errorf("no %s wallet", unbip(assetID))
+	}
+	sw, is := w.Wallet.(asset.ShieldedWallet)
+	if !is {
+		return nil, fmt.Errorf("%s wallet is not a shielded wallet", unbip(assetID))
+	}
+	return sw, nil
+}
+
+// ShieldedStatus is the shielded balance and last address associated with the
+// shielded wallet.
+func (c *Core) ShieldedStatus(assetID uint32) (*asset.ShieldedStatus, error) {
+	sw, err := c.shieldedWallet(assetID)
+	if err != nil {
+		return nil, err
+	}
+	return sw.ShieldedStatus()
+}
+
+// NewShieldedAddress creates a new shielded address. Visit the link below for
+// additional notes on shielded address reuse.
+// https://electriccoin.co/blog/shielded-address-contexts/
+func (c *Core) NewShieldedAddress(assetID uint32) (string, error) {
+	sw, err := c.shieldedWallet(assetID)
+	if err != nil {
+		return "", err
+	}
+	return sw.NewShieldedAddress()
+}
+
+// ShieldFunds moves funds from the transparent account to the shielded account.
+func (c *Core) ShieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+	sw, err := c.shieldedWallet(assetID)
+	if err != nil {
+		return nil, err
+	}
+	return sw.ShieldFunds(c.ctx, amt)
+}
+
+// UnshieldFunds moves funds from the shielded account to the transparent
+// account.
+func (c *Core) UnshieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+	sw, err := c.shieldedWallet(assetID)
+	if err != nil {
+		return nil, err
+	}
+	return sw.UnshieldFunds(c.ctx, amt)
+}
+
+// SendShielded sends funds from the shielded account to the provided shielded
+// or transparent address.
+func (c *Core) SendShielded(assetID uint32, toAddr string, amt uint64) (dex.Bytes, error) {
+	sw, err := c.shieldedWallet(assetID)
+	if err != nil {
+		return nil, err
+	}
+	return sw.SendShielded(c.ctx, toAddr, amt)
+}

--- a/client/core/locale_ntfn.go
+++ b/client/core/locale_ntfn.go
@@ -84,8 +84,13 @@ var originLocale = map[Topic]*translation{
 	},
 	// [value string, ticker, destination address, coin ID]
 	TopicSendSuccess: {
-		subject:  "Send Successful",
+		subject:  "Send successful",
 		template: "Sending %s %s to %s has completed successfully. Coin ID = %s",
+	},
+	// [value string, ticker, destination address, coin ID]
+	TopicShieldedSendSuccess: {
+		subject:  "Shielded send successful",
+		template: "Sent %s %s to %s: %s",
 	},
 	//[order ID, error]
 	TopicAsyncOrderFailure: {

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -279,8 +279,9 @@ type SendNote struct {
 }
 
 const (
-	TopicSendError   Topic = "SendError"
-	TopicSendSuccess Topic = "SendSuccess"
+	TopicSendError           Topic = "SendError"
+	TopicSendSuccess         Topic = "SendSuccess"
+	TopicShieldedSendSuccess Topic = "ShieldedSendSuccess"
 )
 
 func newSendNote(topic Topic, subject, details string, severity db.Severity) *SendNote {

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1595,12 +1595,18 @@ func (s *WebServer) apiUnshieldFunds(w http.ResponseWriter, r *http.Request) {
 func (s *WebServer) apiSendShielded(w http.ResponseWriter, r *http.Request) {
 	var form struct {
 		shieldUnshieldForm
-		ToAddress string `json:"toAddress"`
+		ToAddress string           `json:"toAddress"`
+		AppPW     encode.PassBytes `json:"appPW"`
 	}
 	if !readPost(w, r, &form) {
 		return
 	}
-	_, err := s.core.SendShielded(form.AssetID, form.ToAddress, form.Amount)
+	pw, err := s.resolvePass(form.AppPW, r)
+	if err != nil {
+		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
+		return
+	}
+	_, err = s.core.SendShielded(pw, form.AssetID, form.ToAddress, form.Amount)
 	if err != nil {
 		s.writeAPIError(w, fmt.Errorf("error unshielding funds: %w", err))
 		return

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -796,13 +796,13 @@ func (c *TCore) ShieldedStatus(assetID uint32) (*asset.ShieldedStatus, error) {
 func (c *TCore) NewShieldedAddress(assetID uint32) (string, error) {
 	return "", nil
 }
-func (c *TCore) ShieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+func (c *TCore) ShieldFunds(assetID uint32, amt uint64) ([]byte, error) {
 	return nil, nil
 }
-func (c *TCore) UnshieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+func (c *TCore) UnshieldFunds(assetID uint32, amt uint64) ([]byte, error) {
 	return nil, nil
 }
-func (c *TCore) SendShielded(assetID uint32, toAddr string, amt uint64) (dex.Bytes, error) {
+func (c *TCore) SendShielded(appPW []byte, assetID uint32, toAddr string, amt uint64) ([]byte, error) {
 	return nil, nil
 }
 

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -790,6 +790,22 @@ func (c *TCore) AccountImport(pw []byte, account *core.Account, bond []*db.Bond)
 }
 func (c *TCore) AccountDisable(pw []byte, host string) error { return nil }
 
+func (c *TCore) ShieldedStatus(assetID uint32) (*asset.ShieldedStatus, error) {
+	return nil, nil
+}
+func (c *TCore) NewShieldedAddress(assetID uint32) (string, error) {
+	return "", nil
+}
+func (c *TCore) ShieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+	return nil, nil
+}
+func (c *TCore) UnshieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+	return nil, nil
+}
+func (c *TCore) SendShielded(assetID uint32, toAddr string, amt uint64) (dex.Bytes, error) {
+	return nil, nil
+}
+
 func coreCoin() *core.Coin {
 	b := make([]byte, 36)
 	copy(b[:], encode.RandomBytes(32))

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -155,6 +155,11 @@ type clientCore interface {
 	AddWalletPeer(assetID uint32, addr string) error
 	RemoveWalletPeer(assetID uint32, addr string) error
 	Notifications(n int) ([]*db.Notification, error)
+	ShieldedStatus(assetID uint32) (*asset.ShieldedStatus, error)
+	NewShieldedAddress(assetID uint32) (string, error)
+	ShieldFunds(assetID uint32, amt uint64) (dex.Bytes, error)
+	UnshieldFunds(assetID uint32, amt uint64) (dex.Bytes, error)
+	SendShielded(assetID uint32, toAddr string, amt uint64) (dex.Bytes, error)
 }
 
 var _ clientCore = (*core.Core)(nil)
@@ -430,6 +435,13 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/getwalletpeers", s.apiGetWalletPeers)
 			apiAuth.Post("/addwalletpeer", s.apiAddWalletPeer)
 			apiAuth.Post("/removewalletpeer", s.apiRemoveWalletPeer)
+
+			apiAuth.Post("/shieldedstatus", s.apiShieldedStatus)
+			apiAuth.Post("/newshieldedaddress", s.apiNewShieldedAddress)
+			apiAuth.Post("/shieldfunds", s.apiShieldFunds)
+			apiAuth.Post("/unshieldfunds", s.apiUnshieldFunds)
+			apiAuth.Post("/sendshielded", s.apiSendShielded)
+
 			if s.experimental {
 				apiAuth.Post("/createbot", s.apiCreateBot)
 				apiAuth.Post("/startbot", s.apiStartBot)

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -157,9 +157,9 @@ type clientCore interface {
 	Notifications(n int) ([]*db.Notification, error)
 	ShieldedStatus(assetID uint32) (*asset.ShieldedStatus, error)
 	NewShieldedAddress(assetID uint32) (string, error)
-	ShieldFunds(assetID uint32, amt uint64) (dex.Bytes, error)
-	UnshieldFunds(assetID uint32, amt uint64) (dex.Bytes, error)
-	SendShielded(assetID uint32, toAddr string, amt uint64) (dex.Bytes, error)
+	ShieldFunds(assetID uint32, amt uint64) ([]byte, error)
+	UnshieldFunds(assetID uint32, amt uint64) ([]byte, error)
+	SendShielded(appPW []byte, assetID uint32, toAddr string, amt uint64) ([]byte, error)
 }
 
 var _ clientCore = (*core.Core)(nil)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -306,13 +306,13 @@ func (c *TCore) ShieldedStatus(assetID uint32) (*asset.ShieldedStatus, error) {
 func (c *TCore) NewShieldedAddress(assetID uint32) (string, error) {
 	return "", nil
 }
-func (c *TCore) ShieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+func (c *TCore) ShieldFunds(assetID uint32, amt uint64) ([]byte, error) {
 	return nil, nil
 }
-func (c *TCore) UnshieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+func (c *TCore) UnshieldFunds(assetID uint32, amt uint64) ([]byte, error) {
 	return nil, nil
 }
-func (c *TCore) SendShielded(assetID uint32, toAddr string, amt uint64) (dex.Bytes, error) {
+func (c *TCore) SendShielded(appPW []byte, assetID uint32, toAddr string, amt uint64) ([]byte, error) {
 	return nil, nil
 }
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -300,6 +300,22 @@ func (c *TCore) MarketReport(host string, baseID, quoteID uint32) (*core.MarketR
 	return nil, nil
 }
 
+func (c *TCore) ShieldedStatus(assetID uint32) (*asset.ShieldedStatus, error) {
+	return nil, nil
+}
+func (c *TCore) NewShieldedAddress(assetID uint32) (string, error) {
+	return "", nil
+}
+func (c *TCore) ShieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+	return nil, nil
+}
+func (c *TCore) UnshieldFunds(assetID uint32, amt uint64) (dex.Bytes, error) {
+	return nil, nil
+}
+func (c *TCore) SendShielded(assetID uint32, toAddr string, amt uint64) (dex.Bytes, error) {
+	return nil, nil
+}
+
 type TWriter struct {
 	b []byte
 }


### PR DESCRIPTION
Just copied the `ShieldedWallet` interface from #2250.