### PR TITLE
client/core: don't spam bond refund countdown

### DIFF
--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -24,8 +24,9 @@ const (
 
 	defaultBondAsset = 42 // DCR
 
-	maxBondedMult = 4
-	bondOverlap   = 2
+	maxBondedMult    = 4
+	bondOverlap      = 2
+	bondTickInterval = 20 * time.Second
 )
 
 func cutBond(bonds []*db.Bond, i int) []*db.Bond { // input slice modified
@@ -36,7 +37,7 @@ func cutBond(bonds []*db.Bond, i int) []*db.Bond { // input slice modified
 }
 
 func (c *Core) watchBonds(ctx context.Context) {
-	t := time.NewTicker(20 * time.Second)
+	t := time.NewTicker(bondTickInterval)
 	defer t.Stop()
 
 	for {
@@ -282,8 +283,10 @@ func (c *Core) refundExpiredBonds(ctx context.Context, acct *dexAccount, cfg *de
 	for _, bond := range state.expiredBonds {
 		bondIDStr := fmt.Sprintf("%v (%s)", coinIDString(bond.AssetID, bond.CoinID), unbip(bond.AssetID))
 		if now < int64(bond.LockTime) {
-			c.log.Debugf("Expired bond %v refundable in about %v.",
-				bondIDStr, time.Duration(int64(bond.LockTime)-now)*time.Second)
+			ttr := time.Duration(int64(bond.LockTime)-now) * time.Second
+			if ttr < 15*time.Minute || ((ttr/time.Minute)%30 == 0 && (ttr%time.Minute <= bondTickInterval)) {
+				c.log.Debugf("Expired bond %v refundable in about %v.", bondIDStr, ttr)
+			}
 			continue
 		}
 


### PR DESCRIPTION
The time-to-bond-refund logging is really spammy on mainnet.  For roughly 4 weeks you see a countdown logged every 20 seconds.  This throttles that logging so it only happens once every 30 minutes, until the refund is just 15 minutes away.  The 15 minute threshold is partly for sim/testnet so we can see more feedback in testing, but also so a mainnet user sees the countdown as the time gets closer.