### PR TITLE
assets: ensure context cancellation take precedence over ticker during new block update

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -4532,6 +4532,11 @@ func (btc *intermediaryWallet) watchBlocks(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		}
+
+		// Ensure context cancellation takes priority before the next iteration.
+		if ctx.Err() != nil {
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Related fix for: #1960 