### PR TITLE
client/asset/btc: RPC connect and reconfig fixes

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1449,6 +1449,7 @@ func (btc *baseWallet) IsDust(txOut *wire.TxOut, minRelayTxFee uint64) bool {
 // getBlockchainInfoResult models the data returned from the getblockchaininfo
 // command.
 type getBlockchainInfoResult struct {
+	Chain         string `json:"chain"`
 	Blocks        int64  `json:"blocks"`
 	Headers       int64  `json:"headers"`
 	BestBlockHash string `json:"bestblockhash"`

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1172,13 +1172,24 @@ func newRPCWallet(requester RawRequester, cfg *BTCCloneCFG, parsedCfg *RPCWallet
 	}, nil
 }
 
+func decodeAddress(addr string, params *chaincfg.Params) (btcutil.Address, error) {
+	a, err := btcutil.DecodeAddress(addr, params)
+	if err != nil {
+		return nil, err
+	}
+	if !a.IsForNet(params) {
+		return nil, errors.New("wrong network")
+	}
+	return a, nil
+}
+
 func newUnconnectedWallet(cfg *BTCCloneCFG, walletCfg *WalletConfig) (*baseWallet, error) {
 	baseCfg, err := readBaseWalletConfig(walletCfg)
 	if err != nil {
 		return nil, err
 	}
 
-	addrDecoder := btcutil.DecodeAddress
+	addrDecoder := decodeAddress
 	if cfg.AddressDecoder != nil {
 		addrDecoder = cfg.AddressDecoder
 	}

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -208,6 +208,9 @@ func (wc *rpcClient) reconfigure(cfg *asset.WalletConfig, currentAddress string)
 		restartRequired = true
 		return
 	}
+	if wc.ctx == nil || wc.ctx.Err() != nil {
+		return true, nil // not connected, ok to reconfigure, but restart required
+	}
 
 	parsedCfg := new(RPCWalletConfig)
 	if err = config.Unmapify(cfg.Settings, parsedCfg); err != nil {

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -203,8 +203,7 @@ func (wc *rpcClient) connect(ctx context.Context, _ *sync.WaitGroup) error {
 // the special_activelyUsed flag is set, reconfigure will fail if we can't
 // validate ownership of the current deposit address.
 func (wc *rpcClient) reconfigure(cfg *asset.WalletConfig, currentAddress string) (restartRequired bool, err error) {
-	// rpcClient only handles walletTypeRPC.
-	if cfg.Type != walletTypeRPC {
+	if cfg.Type != wc.cloneParams.WalletCFG.Type {
 		restartRequired = true
 		return
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -3312,7 +3312,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 	}
 
 	// See if the wallet offers a quick path.
-	if configurer, is := oldWallet.Wallet.(asset.LiveReconfigurer); is {
+	if configurer, is := oldWallet.Wallet.(asset.LiveReconfigurer); is && oldWallet.walletType == walletDef.Type {
 		form.Config[asset.SpecialSettingActivelyUsed] = strconv.FormatBool(c.assetHasActiveOrders(dbWallet.AssetID))
 		defer delete(form.Config, asset.SpecialSettingActivelyUsed)
 
@@ -3331,7 +3331,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 					return newError(newAddrErr, "error refreshing deposit address after live config update: %w", err)
 				}
 			}
-			if !walletDef.Seeded && newWalletPW != nil {
+			if !oldDef.Seeded && newWalletPW != nil {
 				if err = c.setWalletPassword(oldWallet, newWalletPW, crypter); err != nil {
 					return newError(walletAuthErr, "failed to update password: %v", err)
 				}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -7232,6 +7232,7 @@ func TestReconfigureWallet(t *testing.T) {
 		Config:  newSettings,
 		Type:    "type",
 	}
+	xyzWallet.walletType = "type"
 
 	// App Password error
 	rig.crypter.(*tCrypter).recryptErr = tErr

--- a/dex/networks/bch/params_test.go
+++ b/dex/networks/bch/params_test.go
@@ -17,15 +17,23 @@ func TestCompatibility(t *testing.T) {
 	}
 
 	// 2b381efec176b72da70e894a6dbba1fc1ba18a1d573af898e6f92915c0ca8209:1
-	p2pkhAddr, err := DecodeCashAddress("bitcoincash:qznf2drgsapgsejd95yp9nw0qzhw9mrcxsez7d78uv", MainNetParams)
+	cashAddrP2PKH := "bitcoincash:qznf2drgsapgsejd95yp9nw0qzhw9mrcxsez7d78uv"
+	p2pkhAddr, err := DecodeCashAddress(cashAddrP2PKH, MainNetParams)
 	if err != nil {
 		t.Fatalf("error p2pkh decoding CashAddr address: %v", err)
 	}
+	if !p2pkhAddr.IsForNet(MainNetParams) {
+		t.Fatalf("IsForNet rejected address %v (%v) for net %v", p2pkhAddr, cashAddrP2PKH, MainNetParams.Name)
+	}
 
 	// b63e8090fe7140328d5d6ecdd6045b123e3f05742d9a749f2550fba7d0a6879f:1
-	p2shAddr, err := DecodeCashAddress("bitcoincash:pqugctqhj096cufywe32rktfu5dpmnnrjgsznuudl2", MainNetParams)
+	cashAddrP2SH := "bitcoincash:pqugctqhj096cufywe32rktfu5dpmnnrjgsznuudl2"
+	p2shAddr, err := DecodeCashAddress(cashAddrP2SH, MainNetParams)
 	if err != nil {
 		t.Fatalf("error decoding p2sh CashAddr address: %v", err)
+	}
+	if !p2shAddr.IsForNet(MainNetParams) {
+		t.Fatalf("IsForNet rejected address %v (%v) for net %v", p2shAddr, cashAddrP2SH, MainNetParams.Name)
 	}
 
 	// These scripts and addresses are just copy-pasted from random

--- a/dex/networks/btc/test/compat.go
+++ b/dex/networks/btc/test/compat.go
@@ -42,6 +42,9 @@ func CompatibilityCheck(t *testing.T, items *CompatibilityItems, chainParams *ch
 		if addrs[0].String() != addr {
 			t.Fatalf("address mismatch %s != %s", addrs[0].String(), addr)
 		}
+		if !addrs[0].IsForNet(chainParams) {
+			t.Fatalf("IsForNet rejected address %v for net %v", addrs[0], chainParams.Name)
+		}
 	}
 
 	// P2PKH

--- a/dex/networks/dgb/params.go
+++ b/dex/networks/dgb/params.go
@@ -45,6 +45,7 @@ var (
 
 	// MainNetParams are the clone parameters for mainnet.
 	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "mainnet",
 		PubKeyHashAddrID: 0x1e, // 30 - start with D
 		ScriptHashAddrID: 0x3f, // 63 - start with S, "old" was 5
 		Bech32HRPSegwit:  "dgb",
@@ -54,6 +55,7 @@ var (
 	})
 	// TestNetParams are the clone parameters for testnet.
 	TestNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "testnet4",
 		PubKeyHashAddrID: 0x7e, // 126 - start with t
 		ScriptHashAddrID: 0x8c, // 140 - start with s
 		Bech32HRPSegwit:  "dgbt",
@@ -63,6 +65,7 @@ var (
 	})
 	// RegressionNetParams are the clone parameters for simnet.
 	RegressionNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "regtest",
 		PubKeyHashAddrID: 0x7e, // 126
 		ScriptHashAddrID: 0x8c, // 140
 		Bech32HRPSegwit:  "dgbrt",

--- a/dex/networks/doge/params.go
+++ b/dex/networks/doge/params.go
@@ -42,6 +42,7 @@ var (
 
 	// MainNetParams are the clone parameters for mainnet.
 	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "mainnet",
 		PubKeyHashAddrID: 0x1e,
 		ScriptHashAddrID: 0x16,
 		CoinbaseMaturity: 30,
@@ -50,6 +51,7 @@ var (
 	})
 	// TestNet4Params are the clone parameters for testnet.
 	TestNet4Params = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "testnet4",
 		PubKeyHashAddrID: 0x71,
 		ScriptHashAddrID: 0xc4,
 		CoinbaseMaturity: 30,
@@ -58,6 +60,7 @@ var (
 	})
 	// RegressionNetParams are the clone parameters for simnet.
 	RegressionNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "regtest",
 		PubKeyHashAddrID: 0x6f,
 		ScriptHashAddrID: 0xc4,
 		CoinbaseMaturity: 60,

--- a/dex/networks/zec/params.go
+++ b/dex/networks/zec/params.go
@@ -34,6 +34,7 @@ var (
 	// between address types on the fly and use these spoof parameters
 	// internally.
 	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "mainnet",
 		ScriptHashAddrID: 0xBD,
 		PubKeyHashAddrID: 0xB8,
 		CoinbaseMaturity: 100,
@@ -41,6 +42,7 @@ var (
 	})
 	// TestNet4Params are the clone parameters for testnet.
 	TestNet4Params = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "testnet4",
 		PubKeyHashAddrID: 0x25,
 		ScriptHashAddrID: 0xBA,
 		CoinbaseMaturity: 100,
@@ -48,6 +50,7 @@ var (
 	})
 	// RegressionNetParams are the clone parameters for simnet.
 	RegressionNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "regtest",
 		PubKeyHashAddrID: 0x25,
 		ScriptHashAddrID: 0xBA,
 		CoinbaseMaturity: 100,

--- a/dex/networks/zec/params_test.go
+++ b/dex/networks/zec/params_test.go
@@ -21,11 +21,17 @@ func TestCompatibility(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error decoding p2pkh address: %v", err)
 	}
+	if !btcPkhAddr.IsForNet(MainNetParams) {
+		t.Fatalf("IsForNet rejected address %v (%v) for net %v", btcPkhAddr, pkhAddr, MainNetParams.Name)
+	}
 
 	shAddr := "t3ZJCdehVh9MTm6BaKWZmWy5Hsw7PhJxmTc"
 	btcShAddr, err := DecodeAddress(shAddr, MainNetAddressParams, MainNetParams)
 	if err != nil {
 		t.Fatalf("error decoding p2sh address: %v", err)
+	}
+	if !btcShAddr.IsForNet(MainNetParams) {
+		t.Fatalf("IsForNet rejected address %v (%v) for net %v", btcShAddr, shAddr, MainNetParams.Name)
 	}
 
 	items := &btctest.CompatibilityItems{


### PR DESCRIPTION
A few issues related to BTC/clone RPC connection and reconfiguration popped out:

- Running dexc on simnet, you can create a wallet that connects to bitciond/clone on mainnet (or reverse)
- You cannot switch to the correct one because if errors trying to validate the previous deposit address from the other network
- "Clone" asset always return `restartRequired = true` when attempting to reconfigure because a condition for live-reconfigurability compares the new wallet type against `"bitcoindRPC"` when clones have strings like `"dogecoindRPC"`.
- Reconfiguring a disconnected wallet could fail in certain circumstances because the context could already be canceled, blocking some of the reconfigure checks that involve an RPC with the new client.