### PR TITLE
webserver/site: fix handling of NoAuth wallets

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=LFgBaLTq"></script>
+<script src="/js/entry.js?v=LFSDCFTq"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -70,7 +70,7 @@
   </div>
   {{template "walletCfgGuideTemplate"}}
   <hr class="dashed my-2">
-  <div class="d-flex justify-content-between align-items-stretch flex-wrap" data-tmpl="auth">
+  <div class="d-flex justify-content-between align-items-stretch flex-wrap" data-tmpl=walletPassAndSubmitBttn>
     <div class="col-11 p-0" data-tmpl="newWalletPassBox">
       <label for="newWalletPass" class="form-label pt-3 ps-1 mb-1">[[[Wallet Password]]]
         <span class="ico-info" data-tooltip="[[[w_password_tooltip]]]"></span>

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -305,7 +305,7 @@ export class NewWalletForm {
     const page = this.page
     this.current.selectedDef = walletDef
     const appPwCached = State.passwordIsCached() || (this.pwCache && this.pwCache.pw)
-    Doc.hide(page.auth, page.oneBttnBox, page.newWalletPassBox)
+    Doc.hide(page.walletPassAndSubmitBttn, page.oneBttnBox, page.newWalletPassBox)
     const guideLink = walletDef.guidelink
     const configOpts = walletDef.configopts || []
     // If a config represents a wallet's birthday, we update the default
@@ -326,15 +326,15 @@ export class NewWalletForm {
         break
       }
     }
-    const noWalletPWNeeded = walletDef.seeded || Boolean(this.current.asset.token)
-    if (appPwCached && noWalletPWNeeded && !containsRequired) {
+    const displayCreateBtn = walletDef.seeded || Boolean(this.current.asset.token)
+    if (appPwCached && displayCreateBtn && !containsRequired) {
       Doc.show(page.oneBttnBox)
-    } else if (noWalletPWNeeded) {
-      Doc.show(page.auth)
+    } else if (displayCreateBtn) {
+      Doc.show(page.walletPassAndSubmitBttn)
       page.newWalletPass.value = ''
       page.submitAdd.textContent = intl.prep(intl.ID_CREATE)
     } else {
-      Doc.show(page.auth)
+      Doc.show(page.walletPassAndSubmitBttn)
       if (!walletDef.noauth) Doc.show(page.newWalletPassBox)
       page.submitAdd.textContent = intl.prep(intl.ID_ADD)
     }

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -326,7 +326,7 @@ export class NewWalletForm {
         break
       }
     }
-    const noWalletPWNeeded = walletDef.noauth || walletDef.seeded || Boolean(this.current.asset.token)
+    const noWalletPWNeeded = walletDef.seeded || Boolean(this.current.asset.token)
     if (appPwCached && noWalletPWNeeded && !containsRequired) {
       Doc.show(page.oneBttnBox)
     } else if (noWalletPWNeeded) {


### PR DESCRIPTION
Closes #2328.

Zec wallet does not require a password and uses the `NoAuth` boolean field in its wallet def. But we seem to add that as criteria to display the single `Create` btn that is used only by seeded/token wallets that do not have required config opts.

The `walletDef.noauth` field is already properly handled by the last else statement in the block of code near code change.