### PR TITLE
zec: implement FeeRate to short-circuit fee checks - release-v0.6

### DIFF
--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -5,10 +5,7 @@ package zec
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"math"
-	"strconv"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/asset/btc"
@@ -231,26 +228,9 @@ func zecTx(tx *wire.MsgTx) *dexzec.Tx {
 	return dexzec.NewTxFromMsgTx(tx, dexzec.MaxExpiryHeight)
 }
 
-// estimateFee uses ZCash's estimatefee RPC, since estimatesmartfee
-// is not implemented.
-// ZCash's fee estimation is pretty crappy. Full nodes can take hours to
-// get up to speed, and forget about simnet.
-// See https://github.com/zcash/zcash/issues/2552
-func estimateFee(ctx context.Context, node btc.RawRequester, confTarget uint64) (uint64, error) {
-	const feeConfs = 10
-	resp, err := node.RawRequest(ctx, "estimatefee", []json.RawMessage{[]byte(strconv.Itoa(feeConfs))})
-	if err != nil {
-		return 0, err
-	}
-	var feeRate float64
-	err = json.Unmarshal(resp, &feeRate)
-	if err != nil {
-		return 0, err
-	}
-	if feeRate <= 0 {
-		return 0, fmt.Errorf("fee could not be estimated")
-	}
-	return uint64(math.Round(feeRate * 1e5)), nil
+// estimateFee returns the asset standard legacy fee rate.
+func estimateFee(context.Context, btc.RawRequester, uint64) (uint64, error) {
+	return dexzec.LegacyFeeRate, nil
 }
 
 // signTx signs the transaction input with ZCash's BLAKE-2B sighash digest.

--- a/dex/networks/zec/params.go
+++ b/dex/networks/zec/params.go
@@ -18,6 +18,14 @@ const (
 
 	InitTxSizeBase = MinimumTxOverhead + btc.P2PKHOutputSize + btc.P2SHOutputSize // 29 + 34 + 32 = 95
 	InitTxSize     = InitTxSizeBase + btc.RedeemP2PKHInputSize                    // 95 + 149 = 244
+
+	// LegacyFeeRate returns a standard 10 zats / byte. Prior to ZIP-0317, Zcash
+	// used a standard tx fee of 1000 zats, regardless of tx size. We don't
+	// handle fees correctly yet though, so just use a fee / byte that
+	// guarantees a tx fee of > 1000 zats. A single input spending a p2pkh
+	// output is 149 bytes, so 10 zats / byte should be sufficient for any
+	// tx.
+	LegacyFeeRate = 10
 )
 
 var (

--- a/server/asset/zec/zec.go
+++ b/server/asset/zec/zec.go
@@ -4,6 +4,7 @@
 package zec
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -146,6 +147,12 @@ func (be *ZECBackend) Contract(coinID []byte, redeemScript []byte) (*asset.Contr
 		return nil, err
 	}
 	return contract, nil
+}
+
+// For Zcash, return a constant fee rate of 10 zats / byte. We just need to
+// guarantee the tx gets over the legacy 0.00001 standard tx fee.
+func (be *ZECBackend) FeeRate(context.Context) (uint64, error) {
+	return dexzec.LegacyFeeRate, nil
 }
 
 func blockFeeTransactions(rc *btc.RPCClient, blockHash *chainhash.Hash) (feeTxs []btc.FeeTx, prevBlock chainhash.Hash, err error) {


### PR DESCRIPTION
Counterpart of #2336 for release-v0.6 branch. We don't have a `zecWallet` type yet, so I'm not adding the `FeeRate` to the zec wallet yet, but setting the `FeeEstimator` is effectively the same thing.