### PR TITLE
ci: node v18/v20 in actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Check out source
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2"
 
       - name: Test
         env:
@@ -32,9 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
     - name: Use nodejs ${{ matrix.node-version }}
       uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c #v3.6.0
       with:
@@ -52,8 +52,8 @@ jobs:
     name: Lint Markdown
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
-    - uses: DavidAnson/markdownlint-cli2-action@d57f8bd57670b9c1deedf71219dd494614ff3335 #v8
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
+    - uses: DavidAnson/markdownlint-cli2-action@bb4bb94c73936643d73d345b48fead3e96f90a5e #v10.0.1
       continue-on-error: true
       with:
         globs: |

--- a/client/webserver/site/package.json
+++ b/client/webserver/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexclient",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "dexc browser frontend",
   "private": true,
   "scripts": {


### PR DESCRIPTION
As of 2023-04-18, Node.js 18 and 20 are now the "active/current" LTC releases.  v16 will be EOL on 2023-09-11.

As a reminder, Node.js has an "even number" LTC release convention, similar to Ubuntu.

![image](https://user-images.githubusercontent.com/9373513/236334817-3e182679-9b53-474e-b22c-fd29008420d1.png)

https://nodejs.dev/en/about/releases/ (the image is updated but not the table).

