### PR TITLE
client/webserver: more judicious use of authMiddleware

### DIFF
--- a/client/app/config.go
+++ b/client/app/config.go
@@ -145,12 +145,13 @@ type Config struct {
 // Web creates a configuration for the webserver. This is a Config method
 // instead of a WebConfig method because Language is an app-level setting used
 // by both core and rpcserver.
-func (cfg *Config) Web(c *core.Core, log dex.Logger) *webserver.Config {
+func (cfg *Config) Web(c *core.Core, log dex.Logger, utc bool) *webserver.Config {
 	return &webserver.Config{
 		Core:          c,
 		Addr:          cfg.WebAddr,
 		CustomSiteDir: cfg.SiteDir,
 		Logger:        log,
+		UTC:           utc,
 		NoEmbed:       cfg.NoEmbedSite,
 		HttpProf:      cfg.HTTPProfile,
 		Language:      cfg.Language,

--- a/client/cmd/dexc-desktop/main.go
+++ b/client/cmd/dexc-desktop/main.go
@@ -280,7 +280,7 @@ func mainCore() error {
 		}()
 	}
 
-	webSrv, err := webserver.New(cfg.Web(clientCore, logMaker.Logger("WEB")))
+	webSrv, err := webserver.New(cfg.Web(clientCore, logMaker.Logger("WEB"), utc))
 	if err != nil {
 		return fmt.Errorf("failed creating web server: %w", err)
 	}

--- a/client/cmd/dexc/main.go
+++ b/client/cmd/dexc/main.go
@@ -156,7 +156,7 @@ func runCore(cfg *app.Config) error {
 	}
 
 	if !cfg.NoWeb {
-		webSrv, err := webserver.New(cfg.Web(clientCore, logMaker.Logger("WEB")))
+		webSrv, err := webserver.New(cfg.Web(clientCore, logMaker.Logger("WEB"), utc))
 		if err != nil {
 			return fmt.Errorf("failed creating web server: %w", err)
 		}

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1320,8 +1320,7 @@ func (s *WebServer) actuallyLogin(w http.ResponseWriter, r *http.Request, login 
 		return fmt.Errorf("login error: %w", err)
 	}
 
-	user := extractUserInfo(r)
-	if !user.Authed {
+	if !s.isAuthed(r) {
 		authToken := s.authorize()
 		setCookie(authCK, authToken, w)
 		if login.RememberPass {
@@ -1344,14 +1343,13 @@ func (s *WebServer) actuallyLogin(w http.ResponseWriter, r *http.Request, login 
 
 // apiUser handles the 'user' API request.
 func (s *WebServer) apiUser(w http.ResponseWriter, r *http.Request) {
-	userInfo := extractUserInfo(r)
 	response := struct {
 		*core.User
 		Authed bool `json:"authed"`
 		OK     bool `json:"ok"`
 	}{
-		User:   userInfo.User,
-		Authed: userInfo.Authed,
+		User:   s.core.User(),
+		Authed: s.isAuthed(r),
 		OK:     true,
 	}
 	writeJSON(w, response, s.indent)

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -293,7 +293,6 @@ func New(cfg *Config) (*WebServer, error) {
 	}
 	mux.Use(s.securityMiddleware)
 	mux.Use(middleware.Recoverer)
-	mux.Use(s.authMiddleware)
 
 	// HTTP profiler
 	if cfg.HttpProf {
@@ -317,6 +316,11 @@ func New(cfg *Config) (*WebServer, error) {
 
 	// Webpages
 	mux.Group(func(web chi.Router) {
+		// Inject user info for handlers that use extractUserInfo, which
+		// includes most of the page handlers that use commonArgs to
+		// inject the User object for page template execution.
+		web.Use(s.authMiddleware)
+
 		// The register page and settings page are always allowed.
 		// The register page performs init if needed, along with
 		// initial setup and settings is used to register more DEXs


### PR DESCRIPTION
**client/webserver: more judicious use of authMiddleware**

```
The authMiddleware calls (*Core).User and injects the struct into the
request.  This is primarily needed for html template execution in the
web page handlers.  It is not required for any of the other redirection
middleware or the api endpoints.  And it is definitely not required
for fileServer (img/css/js resources).

This change restricts the user of authMiddleware to the web page
sub-router.  Almost every page requires it, using the commonArgs
helper to prepare the data for template rendering.

This modifies the redirection middlewares (requireInit, requireLogin,
rejectUnauthed, requireDEXConnection, etc). to only use the Core
methods that are actually required, if any.

Finally, this modifies the two api handlers that required authMiddleware
(actuallyLogin and apiUser) so that they do the requests themselves.
```

**dexc,webserver: revert to stdout http request logging, in color**

This commit restores the color and stdout-only logging of http requests with chi's `middleware.RequestLogger`.  However, it continues to use a `dex.Logger` instead of the plain `middleware.Logger` that had a different formatting and possibly mismatching time zone.