### PR TITLE
dexc-desktop: Register firo for dexc-desktop

### DIFF
--- a/client/cmd/dexc-desktop/main.go
+++ b/client/cmd/dexc-desktop/main.go
@@ -113,6 +113,7 @@ import (
 	_ "decred.org/dcrdex/client/asset/dcr"  // register dcr asset
 	_ "decred.org/dcrdex/client/asset/dgb"  // register dgb asset
 	_ "decred.org/dcrdex/client/asset/doge" // register doge asset
+	_ "decred.org/dcrdex/client/asset/firo" // register firo asset
 	_ "decred.org/dcrdex/client/asset/ltc"  // register ltc asset
 	_ "decred.org/dcrdex/client/asset/zec"  // register zec asset
 	"decred.org/dcrdex/client/mm"


### PR DESCRIPTION
I noticed dexc-desktop was missing firo.