### PR TITLE
client/btc: Live test to provide Wallet Type

### DIFF
--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -62,6 +62,7 @@ func tBackend(ctx context.Context, t *testing.T, cfg *Config, walletName *Wallet
 	reportName := fmt.Sprintf("%s:%s-%s", cfg.Asset.Symbol, walletName.Node, walletName.Name)
 
 	walletCfg := &asset.WalletConfig{
+		Type:     walletName.WalletType,
 		Settings: settings,
 		TipChange: func(err error) {
 			blkFunc(reportName, err)
@@ -134,6 +135,8 @@ func randBytes(l int) []byte {
 type WalletName struct {
 	Node string
 	Name string
+	// WalletType is optional, default "" - non-breaking
+	WalletType string
 	// Filename is optional. If specified, it will be used instead of
 	// [node].conf.
 	Filename string

--- a/client/asset/firo/regnet_test.go
+++ b/client/asset/firo/regnet_test.go
@@ -44,12 +44,14 @@ func TestWallet(t *testing.T) {
 		LotSize:   tLotSize,
 		Asset:     tFIRO,
 		FirstWallet: &livetest.WalletName{
-			Node: "alpha",
-			Name: "alpha",
+			Node:       "alpha",
+			Name:       "alpha",
+			WalletType: walletTypeRPC,
 		},
 		SecondWallet: &livetest.WalletName{
-			Node: "beta",
-			Name: "beta",
+			Node:       "beta",
+			Name:       "beta",
+			WalletType: walletTypeRPC,
 		},
 	})
 }


### PR DESCRIPTION
Like `ltc` client `firo` client wallet `NewWallet` constructor can create different Types of wallet based on the passed in `WalletConfig.Type`. When calling this constructor from `livetest.go` the `Type` field is an empty string.
This small change adds the desired wallet type to the WalletConfig sent to the wallet constructor by `livetest.go` instead of an empty string. This should be a non-breaking change.
This is nice to have but if rejected firo `NewWallet` constructor will default to creating a full node RPC wallet if it receives the null string, which is not so clean. 