### PR TITLE
dexc-desktop: Filter registered assets for those available on the specified network

### DIFF
--- a/client/cmd/dexc-desktop/main.go
+++ b/client/cmd/dexc-desktop/main.go
@@ -108,6 +108,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/app"
+	"decred.org/dcrdex/client/asset"
 	_ "decred.org/dcrdex/client/asset/bch"  // register bch asset
 	_ "decred.org/dcrdex/client/asset/btc"  // register btc asset
 	_ "decred.org/dcrdex/client/asset/dcr"  // register dcr asset
@@ -155,6 +156,9 @@ func mainCore() error {
 	if err != nil {
 		return fmt.Errorf("configuration error: %w", err)
 	}
+
+	// Filter registered assets.
+	asset.SetNetwork(cfg.Net)
 
 	// A single process cannot run multiple webview windows, so we run webview
 	// as a subprocess. We could create a simpler webview binary to call that

--- a/dex/networks/eth/tokens.go
+++ b/dex/networks/eth/tokens.go
@@ -292,6 +292,7 @@ func getContractAddrFromFile(fileName string) (addr common.Address) {
 	addrLen := len(addrBytes)
 	if addrLen == 0 {
 		fmt.Printf("no contract address found at %v \n", fileName)
+		return
 	}
 	addrStr := string(addrBytes[:addrLen-1])
 	return common.HexToAddress(addrStr)


### PR DESCRIPTION
This diff resolves two non-critical bugs:
- Registered assets were not filtered in the `dexc-desktop` pkg
- `getContractAddrFromFile` did not return early if no address was found.