### PR TITLE
client/{core, btc}: MultiTrade

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2223,9 +2223,6 @@ func (btc *baseWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, ui
 	if ord.FeeSuggestion > ord.MaxFeeRate {
 		return nil, nil, 0, fmt.Errorf("fee suggestion %d > max fee rate %d", ord.FeeSuggestion, ord.MaxFeeRate)
 	}
-	if ord.FeeSuggestion > btc.feeRateLimit() {
-		return nil, nil, 0, fmt.Errorf("suggested fee > configured limit. %d > %d", ord.FeeSuggestion, btc.feeRateLimit())
-	}
 	// Check wallets fee rate limit against server's max fee rate
 	if btc.feeRateLimit() < ord.MaxFeeRate {
 		return nil, nil, 0, fmt.Errorf(
@@ -5735,9 +5732,6 @@ func (btc *baseWallet) FundMultiOrder(mo *asset.MultiOrder, keep uint64) ([]asse
 
 	if mo.FeeSuggestion > mo.MaxFeeRate {
 		return nil, nil, 0, fmt.Errorf("fee suggestion %d > max fee rate %d", mo.FeeSuggestion, mo.MaxFeeRate)
-	}
-	if mo.FeeSuggestion > btc.feeRateLimit() {
-		return nil, nil, 0, fmt.Errorf("fee suggestion %d > configured limit %d", mo.FeeSuggestion, btc.feeRateLimit())
 	}
 	// Check wallets fee rate limit against server's max fee rate
 	if btc.feeRateLimit() < mo.MaxFeeRate {

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -860,6 +860,9 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 		bondReservesEnforced int64
 		balance              uint64
 
+		// if expectedCoins is nil, all the coins are from
+		// the split output. If any of the coins are nil,
+		// than that output is from the split output.
 		expectedCoins         []asset.Coins
 		expectedRedeemScripts [][]dex.Bytes
 		expectSendRawTx       bool
@@ -870,9 +873,6 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 		expectedLockedCoins   []*RPCOutpoint
 		expectErr             bool
 	}
-
-	fmt.Printf("amount of balance: %v\n", (2*uint64(requiredForOrder(15e5, 2)) + (expectedSplitFee(2, 2))))
-	fmt.Printf("expected split fee %v\n", expectedSplitFee(1, 2))
 
 	tests := []*test{
 		{ // "split not allowed, utxos like split previously done"
@@ -902,7 +902,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 					RedeemScript:  nil,
 					ScriptPubKey:  scriptPubKeys(0),
 					Address:       addresses(0),
-					Amount:        12e5 / 1e8,
+					Amount:        19e5 / 1e8,
 					Vout:          0,
 				},
 				{
@@ -912,22 +912,18 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 					RedeemScript:  nil,
 					ScriptPubKey:  scriptPubKeys(1),
 					Address:       addresses(1),
-					Amount:        23e5 / 1e8,
+					Amount:        35e5 / 1e8,
 					Vout:          0,
 				},
 			},
 			balance: 35e5,
 			expectedCoins: []asset.Coins{
-				{newOutput(txHashes[0], 0, 12e5)},
-				{newOutput(txHashes[1], 0, 23e5)},
+				{newOutput(txHashes[0], 0, 19e5)},
+				{newOutput(txHashes[1], 0, 35e5)},
 			},
 			expectedRedeemScripts: [][]dex.Bytes{
 				{nil},
 				{nil},
-			},
-			expectedLockedCoins: []*RPCOutpoint{
-				{txHashes[0].String(), 0},
-				{txHashes[1].String(), 0},
 			},
 		},
 		{ // "split not allowed, require multiple utxos per order"
@@ -1076,7 +1072,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit": "false",
+					multiSplitKey: "false",
 				},
 			},
 			maxLock:              46e5,
@@ -1144,7 +1140,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit": "false",
+					multiSplitKey: "false",
 				},
 			},
 			maxLock: 50e5,
@@ -1213,7 +1209,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit": "true",
+					multiSplitKey: "true",
 				},
 			},
 			allOrNothing: false,
@@ -1280,7 +1276,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit": "true",
+					multiSplitKey: "true",
 				},
 			},
 			utxos: []*ListUnspentResult{
@@ -1348,7 +1344,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit": "true",
+					multiSplitKey: "true",
 				},
 			},
 			utxos: []*ListUnspentResult{
@@ -1393,7 +1389,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit": "true",
+					multiSplitKey: "true",
 				},
 			},
 			utxos: []*ListUnspentResult{
@@ -1446,7 +1442,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit": "true",
+					multiSplitKey: "true",
 				},
 			},
 			utxos: []*ListUnspentResult{
@@ -1481,7 +1477,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit": "true",
+					multiSplitKey: "true",
 				},
 			},
 			bondReservesEnforced: 2e6,
@@ -1535,7 +1531,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit": "true",
+					multiSplitKey: "true",
 				},
 			},
 			bondReservesEnforced: 2e6,
@@ -1571,8 +1567,8 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit":   "true",
-					"splitbuffer": "10",
+					multiSplitKey:       "true",
+					multiSplitBufferKey: "10",
 				},
 			},
 			utxos: []*ListUnspentResult{
@@ -1624,8 +1620,8 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				MaxFeeRate:    maxFeeRate,
 				FeeSuggestion: feeSuggestion,
 				Options: map[string]string{
-					"swapsplit":   "true",
-					"splitbuffer": "10",
+					multiSplitKey:       "true",
+					multiSplitBufferKey: "10",
 				},
 			},
 			utxos: []*ListUnspentResult{
@@ -1643,6 +1639,171 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 			balance:   2*uint64(requiredForOrder(15e5, 2)*110/100) + expectedSplitFee(1, 2),
 			maxLock:   2*uint64(requiredForOrder(15e5, 2)*110/100) + expectedSplitFee(1, 2) - 1,
 			expectErr: true,
+		},
+		{ // "only one order needs a split, rest can be funded without"
+			name: "only one order needs a split, rest can be funded without",
+			multiOrder: &asset.MultiOrder{
+				Values: []*asset.MultiOrderValue{
+					{
+						Value:        1e6,
+						MaxSwapCount: 2,
+					},
+					{
+						Value:        1e6,
+						MaxSwapCount: 2,
+					},
+					{
+						Value:        1e6,
+						MaxSwapCount: 2,
+					},
+				},
+				MaxFeeRate:    maxFeeRate,
+				FeeSuggestion: feeSuggestion,
+				Options: map[string]string{
+					multiSplitKey: "true",
+				},
+			},
+			utxos: []*ListUnspentResult{
+				{
+					Confirmations: 1,
+					Spendable:     true,
+					TxID:          txIDs[0],
+					RedeemScript:  nil,
+					ScriptPubKey:  scriptPubKeys(0),
+					Address:       addresses(0),
+					Amount:        12e5 / 1e8,
+					Vout:          0,
+				},
+				{
+					Confirmations: 1,
+					Spendable:     true,
+					TxID:          txIDs[1],
+					RedeemScript:  nil,
+					ScriptPubKey:  scriptPubKeys(1),
+					Address:       addresses(1),
+					Amount:        12e5 / 1e8,
+					Vout:          0,
+				},
+				{
+					Confirmations: 1,
+					Spendable:     true,
+					TxID:          txIDs[2],
+					RedeemScript:  nil,
+					ScriptPubKey:  scriptPubKeys(2),
+					Address:       addresses(2),
+					Amount:        120e5 / 1e8,
+					Vout:          0,
+				},
+			},
+			maxLock:         50e5,
+			balance:         144e5,
+			expectSendRawTx: true,
+			expectedInputs: []*wire.TxIn{
+				{
+					PreviousOutPoint: wire.OutPoint{
+						Hash:  *txHashes[2],
+						Index: 0,
+					},
+				},
+			},
+			expectedOutputs: []*wire.TxOut{
+				wire.NewTxOut(requiredForOrder(1e6, 2), []byte{}),
+				wire.NewTxOut(120e5-requiredForOrder(1e6, 2)-int64(expectedSplitFee(1, 2)), []byte{}),
+			},
+			expectedSplitFee: expectedSplitFee(1, 2),
+			expectedRedeemScripts: [][]dex.Bytes{
+				{nil},
+				{nil},
+				{nil},
+			},
+			expectedCoins: []asset.Coins{
+				{newOutput(txHashes[0], 0, 12e5)},
+				{newOutput(txHashes[1], 0, 12e5)},
+				nil,
+			},
+		},
+		{ // "only one order needs a split due to bond reserves, rest funded without"
+			name: "only one order needs a split, rest can be funded without",
+			multiOrder: &asset.MultiOrder{
+				Values: []*asset.MultiOrderValue{
+					{
+						Value:        1e6,
+						MaxSwapCount: 2,
+					},
+					{
+						Value:        1e6,
+						MaxSwapCount: 2,
+					},
+					{
+						Value:        1e6,
+						MaxSwapCount: 2,
+					},
+				},
+				MaxFeeRate:    maxFeeRate,
+				FeeSuggestion: feeSuggestion,
+				Options: map[string]string{
+					multiSplitKey: "true",
+				},
+			},
+			utxos: []*ListUnspentResult{
+				{
+					Confirmations: 1,
+					Spendable:     true,
+					TxID:          txIDs[0],
+					RedeemScript:  nil,
+					ScriptPubKey:  scriptPubKeys(0),
+					Address:       addresses(0),
+					Amount:        12e5 / 1e8,
+					Vout:          0,
+				},
+				{
+					Confirmations: 1,
+					Spendable:     true,
+					TxID:          txIDs[1],
+					RedeemScript:  nil,
+					ScriptPubKey:  scriptPubKeys(1),
+					Address:       addresses(1),
+					Amount:        12e5 / 1e8,
+					Vout:          0,
+				},
+				{
+					Confirmations: 1,
+					Spendable:     true,
+					TxID:          txIDs[2],
+					RedeemScript:  nil,
+					ScriptPubKey:  scriptPubKeys(2),
+					Address:       addresses(2),
+					Amount:        120e5 / 1e8,
+					Vout:          0,
+				},
+			},
+			maxLock:              0,
+			bondReservesEnforced: 1e6,
+			balance:              144e5,
+			expectSendRawTx:      true,
+			expectedInputs: []*wire.TxIn{
+				{
+					PreviousOutPoint: wire.OutPoint{
+						Hash:  *txHashes[2],
+						Index: 0,
+					},
+				},
+			},
+			expectedOutputs: []*wire.TxOut{
+				wire.NewTxOut(requiredForOrder(1e6, 2), []byte{}),
+				wire.NewTxOut(120e5-requiredForOrder(1e6, 2)-int64(expectedSplitFee(1, 2)), []byte{}),
+			},
+			expectedSplitFee: expectedSplitFee(1, 2),
+			expectedRedeemScripts: [][]dex.Bytes{
+				{nil},
+				{nil},
+				{nil},
+			},
+			expectedCoins: []asset.Coins{
+				{newOutput(txHashes[0], 0, 12e5)},
+				{newOutput(txHashes[1], 0, 12e5)},
+				nil,
+			},
 		},
 	}
 
@@ -1700,18 +1861,6 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 					}
 				}
 			}
-			if len(test.expectedLockedCoins) != len(node.lockedCoins) {
-				t.Fatalf("%s: expected %d locked coins, got %d", test.name, len(test.expectedLockedCoins), len(node.lockedCoins))
-			}
-			lockedCoins := make(map[RPCOutpoint]interface{})
-			for _, coin := range node.lockedCoins {
-				lockedCoins[*coin] = true
-			}
-			for _, expectedCoin := range test.expectedLockedCoins {
-				if _, ok := lockedCoins[*expectedCoin]; !ok {
-					t.Fatalf("%s: expected locked coin %+v not found", test.name, *expectedCoin)
-				}
-			}
 		} else { // expectSplit
 			if node.sentRawTx == nil {
 				t.Fatalf("%s: SendRawTransaction not called", test.name)
@@ -1735,6 +1884,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 			if len(node.sentRawTx.TxOut) != expectedNumOutputs {
 				t.Fatalf("%s: expected %d outputs, got %d", test.name, expectedNumOutputs, len(node.sentRawTx.TxOut))
 			}
+
 			for i, expectedOut := range test.expectedOutputs {
 				actualOut := node.sentRawTx.TxOut[i]
 				if actualOut.Value != expectedOut.Value {
@@ -1752,14 +1902,56 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 				t.Fatalf("%s: expected %d coins, got %d", test.name, len(test.multiOrder.Values), len(allCoins))
 			}
 			splitTxID := node.sentRawTx.TxHash()
-			for i, actualCoin := range allCoins {
-				actualOut := actualCoin[0].(*output)
-				expectedOut := node.sentRawTx.TxOut[i]
-				if uint64(expectedOut.Value) != actualOut.value {
-					t.Fatalf("%s: unexpected output %d value. expected %d, got %d", test.name, i, expectedOut.Value, actualOut.value)
+
+			// This means all coins are split outputs
+			if test.expectedCoins == nil {
+				for i, actualCoin := range allCoins {
+					actualOut := actualCoin[0].(*output)
+					expectedOut := node.sentRawTx.TxOut[i]
+					if uint64(expectedOut.Value) != actualOut.value {
+						t.Fatalf("%s: unexpected output %d value. expected %d, got %d", test.name, i, expectedOut.Value, actualOut.value)
+					}
+					if !bytes.Equal(actualOut.pt.txHash[:], splitTxID[:]) {
+						t.Fatalf("%s: unexpected output %d txid. expected %s, got %s", test.name, i, splitTxID, actualOut.pt.txHash)
+					}
 				}
-				if !bytes.Equal(actualOut.pt.txHash[:], splitTxID[:]) {
-					t.Fatalf("%s: unexpected output %d txid. expected %s, got %s", test.name, i, splitTxID, actualOut.pt.txHash)
+			} else {
+				var splitTxOutputIndex int
+				for i := range allCoins {
+					actual := allCoins[i]
+					expected := test.expectedCoins[i]
+
+					// This means the coins are the split outputs
+					if expected == nil {
+						actualOut := actual[0].(*output)
+						expectedOut := node.sentRawTx.TxOut[splitTxOutputIndex]
+						if uint64(expectedOut.Value) != actualOut.value {
+							t.Fatalf("%s: unexpected output %d value. expected %d, got %d", test.name, i, expectedOut.Value, actualOut.value)
+						}
+						if !bytes.Equal(actualOut.pt.txHash[:], splitTxID[:]) {
+							t.Fatalf("%s: unexpected output %d txid. expected %s, got %s", test.name, i, splitTxID, actualOut.pt.txHash)
+						}
+						splitTxOutputIndex++
+						continue
+					}
+
+					if len(actual) != len(expected) {
+						t.Fatalf("%s: expected %d coins in set %d, got %d", test.name, len(test.expectedCoins[i]), i, len(allCoins[i]))
+					}
+					sort.Slice(actual, func(i, j int) bool {
+						return bytes.Compare(actual[i].ID(), actual[j].ID()) < 0
+					})
+					sort.Slice(expected, func(i, j int) bool {
+						return bytes.Compare(expected[i].ID(), expected[j].ID()) < 0
+					})
+					for j := range actual {
+						if !bytes.Equal(actual[j].ID(), expected[j].ID()) {
+							t.Fatalf("%s: unexpected coin in set %d. expected %s, got %s", test.name, i, expected[j].ID(), actual[j].ID())
+						}
+						if actual[j].Value() != expected[j].Value() {
+							t.Fatalf("%s: unexpected coin value in set %d. expected %d, got %d", test.name, i, expected[j].Value(), actual[j].Value())
+						}
+					}
 				}
 			}
 
@@ -1767,7 +1959,47 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 			if len(node.lockedCoins) != len(allCoins)+len(test.expectedInputs) {
 				t.Fatalf("%s: expected %d locked coins, got %d", test.name, len(allCoins)+len(test.expectedInputs), len(node.lockedCoins))
 			}
+
 		}
+
+		// Check that the right coins are locked and in the fundingCoins map
+		var totalNumCoins int
+		for _, coins := range allCoins {
+			totalNumCoins += len(coins)
+		}
+		if totalNumCoins != len(wallet.fundingCoins) {
+			t.Fatalf("%s: expected %d funding coins in wallet, got %d", test.name, totalNumCoins, len(wallet.fundingCoins))
+		}
+		totalNumCoins += len(test.expectedInputs)
+		if totalNumCoins != len(node.lockedCoins) {
+			t.Fatalf("%s: expected %d locked coins, got %d", test.name, totalNumCoins, len(node.lockedCoins))
+		}
+		lockedCoins := make(map[RPCOutpoint]interface{})
+		for _, coin := range node.lockedCoins {
+			lockedCoins[*coin] = true
+		}
+		checkLockedCoin := func(txHash chainhash.Hash, vout uint32) {
+			if _, ok := lockedCoins[RPCOutpoint{TxID: txHash.String(), Vout: vout}]; !ok {
+				t.Fatalf("%s: expected locked coin %s:%d not found", test.name, txHash, vout)
+			}
+		}
+		checkFundingCoin := func(txHash chainhash.Hash, vout uint32) {
+			if _, ok := wallet.fundingCoins[outPoint{txHash: txHash, vout: vout}]; !ok {
+				t.Fatalf("%s: expected locked coin %s:%d not found in wallet", test.name, txHash, vout)
+			}
+		}
+		for _, coins := range allCoins {
+			for _, coin := range coins {
+				// decode coin to output
+				out := coin.(*output)
+				checkLockedCoin(out.pt.txHash, out.pt.vout)
+				checkFundingCoin(out.pt.txHash, out.pt.vout)
+			}
+		}
+		for _, expectedIn := range test.expectedInputs {
+			checkLockedCoin(expectedIn.PreviousOutPoint.Hash, expectedIn.PreviousOutPoint.Index)
+		}
+
 		if test.expectedSplitFee != splitFee {
 			t.Fatalf("%s: unexpected split fee. expected %d, got %d", test.name, test.expectedSplitFee, splitFee)
 		}

--- a/client/asset/btc/coin_selection.go
+++ b/client/asset/btc/coin_selection.go
@@ -180,6 +180,9 @@ func leastOverFund(enough func(inputsSize, sum uint64) (bool, uint64), utxos []*
 	return leastOverFundWithLimit(enough, math.MaxUint64, utxos)
 }
 
+// leastOverFundWithLimit is the same as leastOverFund, but with an additional
+// maxFund parameter. The total value of the returned UTXOs will not exceed
+// maxFund.
 func leastOverFundWithLimit(enough func(inputsSize, sum uint64) (bool, uint64), maxFund uint64, utxos []*compositeUTXO) []*compositeUTXO {
 	// Remove the UTXOs that are larger than maxFund
 	var smallEnoughUTXOs []*compositeUTXO

--- a/client/asset/btc/coin_selection.go
+++ b/client/asset/btc/coin_selection.go
@@ -216,7 +216,7 @@ func leastOverFundWithLimit(enough func(inputsSize, sum uint64) (bool, uint64), 
 		if single != nil {
 			return []*compositeUTXO{single}
 		} else {
-			return set
+			return nil
 		}
 	} else {
 		set = subsetWithLeastOverFund(enough, maxFund, small)

--- a/client/asset/btc/coin_selection.go
+++ b/client/asset/btc/coin_selection.go
@@ -59,6 +59,15 @@ func orderEnough(val, lots, feeRate, initTxSizeBase, initTxSize uint64, segwit, 
 	}
 }
 
+// reserveEnough generates a function that can be used as the enough argument
+// to the fund method. The function returns true if sum is greater than equal
+// to amt.
+func reserveEnough(amt uint64) func(_, sum uint64) (bool, uint64) {
+	return func(_, sum uint64) (bool, uint64) {
+		return sum >= amt, 0
+	}
+}
+
 func sumUTXOSize(set []*compositeUTXO) (tot uint64) {
 	for _, utxo := range set {
 		tot += uint64(utxo.input.VBytes())

--- a/client/asset/btc/coin_selection_test.go
+++ b/client/asset/btc/coin_selection_test.go
@@ -1,0 +1,182 @@
+package btc
+
+import (
+	"math/rand"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	dexbtc "decred.org/dcrdex/dex/networks/btc"
+)
+
+func Test_leastOverFund(t *testing.T) {
+	enough := func(_, sum uint64) (bool, uint64) {
+		return sum >= 10e8, 0
+	}
+	newU := func(amt float64) *compositeUTXO {
+		return &compositeUTXO{
+			utxo: &utxo{
+				amount: uint64(amt) * 1e8,
+			},
+			input: &dexbtc.SpendInfo{},
+		}
+	}
+	tests := []struct {
+		name  string
+		utxos []*compositeUTXO
+		want  []*compositeUTXO
+	}{
+		{
+			"1,3",
+			[]*compositeUTXO{newU(1), newU(8), newU(9)},
+			[]*compositeUTXO{newU(1), newU(9)},
+		},
+		{
+			"1,2",
+			[]*compositeUTXO{newU(1), newU(9)},
+			[]*compositeUTXO{newU(1), newU(9)},
+		},
+		{
+			"1,2++",
+			[]*compositeUTXO{newU(2), newU(9)},
+			[]*compositeUTXO{newU(2), newU(9)},
+		},
+		{
+			"2,3++",
+			[]*compositeUTXO{newU(0), newU(2), newU(9)},
+			[]*compositeUTXO{newU(2), newU(9)},
+		},
+		{
+			"3",
+			[]*compositeUTXO{newU(0), newU(2), newU(10)},
+			[]*compositeUTXO{newU(10)},
+		},
+		{
+			"subset",
+			[]*compositeUTXO{newU(1), newU(9), newU(11)},
+			[]*compositeUTXO{newU(1), newU(9)},
+		},
+		{
+			"subset small bias",
+			[]*compositeUTXO{newU(3), newU(6), newU(7)},
+			[]*compositeUTXO{newU(3), newU(7)},
+		},
+		{
+			"single exception",
+			[]*compositeUTXO{newU(5), newU(7), newU(11)},
+			[]*compositeUTXO{newU(11)},
+		},
+		{
+			"1 of 1",
+			[]*compositeUTXO{newU(10)},
+			[]*compositeUTXO{newU(10)},
+		},
+		{
+			"ok nil",
+			[]*compositeUTXO{newU(1), newU(8)},
+			nil,
+		},
+		{
+			"ok",
+			[]*compositeUTXO{newU(1)},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := leastOverFund(enough, tt.utxos)
+			sort.Slice(got, func(i int, j int) bool {
+				return got[i].amount < got[j].amount
+			})
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("subset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Fuzz_leastOverFund(f *testing.F) {
+	type seed struct {
+		amt uint64
+		n   int
+	}
+
+	rnd := rand.New(rand.NewSource(1))
+
+	seeds := make([]seed, 0, 40)
+	for i := 0; i < 10; i++ {
+		seeds = append(seeds, seed{
+			amt: uint64(rnd.Intn(40)),
+			n:   rnd.Intn(20000),
+		})
+	}
+
+	for _, seed := range seeds {
+		f.Add(seed.amt, seed.n)
+	}
+
+	newU := func(amt float64) *compositeUTXO {
+		return &compositeUTXO{
+			utxo: &utxo{
+				amount: uint64(amt * 1e8),
+			},
+			input: &dexbtc.SpendInfo{},
+		}
+	}
+
+	var totalDuration time.Duration
+	var totalUTXO int64
+
+	f.Fuzz(func(t *testing.T, amt uint64, n int) {
+		if n < 1 || n > 65535 || amt == 0 || amt > 21e6 {
+			t.Skip()
+		}
+		m := 2 * amt / uint64(n)
+		utxos := make([]*compositeUTXO, n)
+		for i := range utxos {
+			var v float64
+			if rand.Intn(2) > 0 {
+				v = rand.Float64()
+			}
+			if m != 0 {
+				v += float64(rand.Int63n(int64(m)))
+			}
+			if v > 40000 {
+				t.Skip()
+			}
+			utxos[i] = newU(v)
+		}
+		startTime := time.Now()
+		enough := func(_, sum uint64) (bool, uint64) {
+			return sum >= amt*1e8, 0
+		}
+		leastOverFund(enough, utxos)
+		totalDuration += time.Since(startTime)
+		totalUTXO += int64(n)
+	})
+
+	f.Logf("leastOverFund: average duration: %v, with average number of UTXOs: %v\n", totalDuration/100, totalUTXO/100)
+}
+
+func BenchmarkLeastOverFund(b *testing.B) {
+	// Same amounts every time.
+	rnd := rand.New(rand.NewSource(1))
+	utxos := make([]*compositeUTXO, 2_000)
+	for i := range utxos {
+		utxo := &compositeUTXO{
+			utxo: &utxo{
+				amount: uint64(rnd.Int31n(100) * 1e8),
+			},
+			input: &dexbtc.SpendInfo{},
+		}
+		utxos[i] = utxo
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		enough := func(_, sum uint64) (bool, uint64) {
+			return sum >= 10_000*1e8, 0
+		}
+		leastOverFund(enough, utxos)
+	}
+}

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -255,21 +255,21 @@ func Run(t *testing.T, cfg *Config) {
 
 	// Gamma should only have 10 BTC utxos, so calling fund for less should only
 	// return 1 utxo.
-	utxos, _, err := rig.secondWallet.FundOrder(ord)
+	utxos, _, _, err := rig.secondWallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("Funding error: %v", err)
 	}
 	utxo := utxos[0]
 
 	// UTXOs should be locked
-	utxos, _, _ = rig.secondWallet.FundOrder(ord)
+	utxos, _, _, _ = rig.secondWallet.FundOrder(ord)
 	if inUTXOs(utxo, utxos) {
 		t.Fatalf("received locked output")
 	}
 	rig.secondWallet.ReturnCoins([]asset.Coin{utxo})
 	rig.secondWallet.ReturnCoins(utxos)
 	// Make sure we get the first utxo back with Fund.
-	utxos, _, _ = rig.secondWallet.FundOrder(ord)
+	utxos, _, _, _ = rig.secondWallet.FundOrder(ord)
 	if !cfg.SplitTx && !inUTXOs(utxo, utxos) {
 		t.Fatalf("unlocked output not returned")
 	}
@@ -277,13 +277,13 @@ func Run(t *testing.T, cfg *Config) {
 
 	// Get a separate set of UTXOs for each contract.
 	setOrderValue(contractValue)
-	utxos1, _, err := rig.secondWallet.FundOrder(ord)
+	utxos1, _, _, err := rig.secondWallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding first contract: %v", err)
 	}
 	// Get a separate set of UTXOs for each contract.
 	setOrderValue(contractValue * 2)
-	utxos2, _, err := rig.secondWallet.FundOrder(ord)
+	utxos2, _, _, err := rig.secondWallet.FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding second contract: %v", err)
 	}
@@ -493,7 +493,7 @@ func Run(t *testing.T, cfg *Config) {
 
 	// Have gamma send a swap contract to the alpha address.
 	setOrderValue(contractValue)
-	utxos, _, _ = rig.secondWallet.FundOrder(ord)
+	utxos, _, _, _ = rig.secondWallet.FundOrder(ord)
 	contract := &asset.Contract{
 		Address:    address,
 		Value:      contractValue,

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -98,6 +98,22 @@ func (c *tBtcWallet) FetchInputInfo(prevOut *wire.OutPoint) (*wire.MsgTx, *wire.
 func (c *tBtcWallet) ResetLockedOutpoints() {}
 
 func (c *tBtcWallet) LockOutpoint(op wire.OutPoint) {
+	if c.lockedCoins != nil {
+		// check if already locked
+		for _, l := range c.lockedCoins {
+			// print the
+			if l.TxID == op.Hash.String() && l.Vout == op.Index {
+				return
+			}
+		}
+
+		c.lockedCoins = append(c.lockedCoins, &RPCOutpoint{
+			TxID: op.Hash.String(),
+			Vout: op.Index,
+		})
+		return
+	}
+
 	c.lockedCoins = []*RPCOutpoint{{
 		TxID: op.Hash.String(),
 		Vout: op.Index,

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -101,7 +101,6 @@ func (c *tBtcWallet) LockOutpoint(op wire.OutPoint) {
 	if c.lockedCoins != nil {
 		// check if already locked
 		for _, l := range c.lockedCoins {
-			// print the
 			if l.TxID == op.Hash.String() && l.Vout == op.Index {
 				return
 			}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -2224,7 +2224,6 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 	dcr.fundingMtx.Lock()         // before generating the new output in sendCoins
 	defer dcr.fundingMtx.Unlock() // after locking it (wallet and map)
 
-	fmt.Printf("split fee rate %d\n", splitFeeRate)
 	msgTx, sentVal, err := dcr.sendCoins(coins, addr, addr2, reqFunds, extraOutput, splitFeeRate, false)
 	if err != nil {
 		return nil, false, 0, fmt.Errorf("error sending split transaction: %w", err)
@@ -2251,12 +2250,8 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 		dcr.log.Errorf("error returning coins spent in split transaction %v", coins)
 	}
 
-	fmt.Printf("split tx size %d\n", msgTx.SerializeSize())
-
 	totalOut := uint64(0)
-	fmt.Printf("bumpedMaxRate: %d\n", bumpedMaxRate)
 	for i := 0; i < len(msgTx.TxOut); i++ {
-		fmt.Printf("output amount %d\n", msgTx.TxOut[i].Value)
 		totalOut += uint64(msgTx.TxOut[i].Value)
 	}
 
@@ -4238,7 +4233,6 @@ func (dcr *ExchangeWallet) sendCoins(coins asset.Coins, addr, addr2 stdaddr.Addr
 	if !subtract {
 		feeSource = -1 // subtract from change
 	}
-	fmt.Printf("sendCoins: feeSource = %d\n", feeSource)
 
 	tx, err := dcr.sendWithReturn(baseTx, feeRate, feeSource)
 	if err != nil {
@@ -4361,7 +4355,6 @@ func (dcr *ExchangeWallet) signTxAndAddChange(baseTx *wire.MsgTx, feeRate uint64
 	var changeAddress stdaddr.Address
 	var changeOutput *wire.TxOut
 	minFeeWithChange := (size + dexdcr.P2PKHOutputSize) * feeRate
-	fmt.Printf("size=%d, minFeeWithChange = %d\n", size, minFeeWithChange)
 	if remaining > minFeeWithChange {
 		changeValue := remaining - minFeeWithChange
 		if subtractFrom >= 0 {

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -291,21 +291,21 @@ func runTest(t *testing.T, splitTx bool) {
 	}
 
 	// Grab some coins.
-	utxos, _, err := rig.beta().FundOrder(ord)
+	utxos, _, _, err := rig.beta().FundOrder(ord)
 	if err != nil {
 		t.Fatalf("Funding error: %v", err)
 	}
 	utxo := utxos[0]
 
 	// Coins should be locked
-	utxos, _, _ = rig.beta().FundOrder(ord)
+	utxos, _, _, _ = rig.beta().FundOrder(ord)
 	if !splitTx && inUTXOs(utxo, utxos) {
 		t.Fatalf("received locked output")
 	}
 	rig.beta().ReturnCoins([]asset.Coin{utxo})
 	rig.beta().ReturnCoins(utxos)
 	// Make sure we get the first utxo back with Fund.
-	utxos, _, _ = rig.beta().FundOrder(ord)
+	utxos, _, _, _ = rig.beta().FundOrder(ord)
 	if !splitTx && !inUTXOs(utxo, utxos) {
 		t.Fatalf("unlocked output not returned")
 	}
@@ -313,13 +313,13 @@ func runTest(t *testing.T, splitTx bool) {
 
 	// Get a separate set of UTXOs for each contract.
 	setOrderValue(contractValue)
-	utxos1, _, err := rig.beta().FundOrder(ord)
+	utxos1, _, _, err := rig.beta().FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding first contract: %v", err)
 	}
 	// Get a separate set of UTXOs for each contract.
 	setOrderValue(contractValue * 2)
-	utxos2, _, err := rig.beta().FundOrder(ord)
+	utxos2, _, _, err := rig.beta().FundOrder(ord)
 	if err != nil {
 		t.Fatalf("error funding second contract: %v", err)
 	}
@@ -482,7 +482,7 @@ func runTest(t *testing.T, splitTx bool) {
 
 	// Have beta send a swap contract to the alpha address.
 	setOrderValue(contractValue)
-	utxos, _, _ = rig.beta().FundOrder(ord)
+	utxos, _, _, _ = rig.beta().FundOrder(ord)
 	contract := &asset.Contract{
 		Address:    alphaAddress,
 		Value:      contractValue,

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1338,7 +1338,7 @@ func testFundOrderReturnCoinsFundingCoins(t *testing.T, assetID uint32) {
 	if assetID != BipID {
 		eth.approvalCache = make(map[uint32]bool)
 		node.tokenContractor.allow = big.NewInt(0)
-		_, _, err = w.FundOrder(&order)
+		_, _, _, err = w.FundOrder(&order)
 		if err == nil {
 			t.Fatalf("no allowance should cause error but did not")
 		}

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1253,7 +1253,7 @@ func testFundOrderReturnCoinsFundingCoins(t *testing.T, assetID uint32) {
 	}
 
 	// Test fund order with less than available funds
-	coins1, redeemScripts1, err := w.FundOrder(&order)
+	coins1, redeemScripts1, _, err := w.FundOrder(&order)
 	// NOTE: the following should NOT use dex.Asset.SwapSize, instead w.gases(ver) and the swap count and fee rate
 	expectedOrderFees := fromAsset.SwapSize * order.MaxFeeRate * order.MaxSwapCount
 	expectedFees := expectedOrderFees
@@ -1274,7 +1274,7 @@ func testFundOrderReturnCoinsFundingCoins(t *testing.T, assetID uint32) {
 	if assetID == BipID {
 		order.Value -= expectedOrderFees
 	}
-	coins, redeemScripts, err := w.FundOrder(&order)
+	coins, redeemScripts, _, err := w.FundOrder(&order)
 	checkFundOrderResult(coins, redeemScripts, err, fundOrderTest{
 		testName: "not enough",
 		wantErr:  true,
@@ -1287,7 +1287,7 @@ func testFundOrderReturnCoinsFundingCoins(t *testing.T, assetID uint32) {
 	if assetID == BipID {
 		expVal += expectedFees
 	}
-	coins2, redeemScripts2, err := w.FundOrder(&order)
+	coins2, redeemScripts2, _, err := w.FundOrder(&order)
 	checkFundOrderResult(coins2, redeemScripts2, err, fundOrderTest{
 		testName:    "just enough",
 		coinValue:   expVal,
@@ -1307,7 +1307,7 @@ func testFundOrderReturnCoinsFundingCoins(t *testing.T, assetID uint32) {
 	if assetID == BipID {
 		order.Value -= expectedOrderFees
 	}
-	_, _, err = w.FundOrder(&order)
+	_, _, _, err = w.FundOrder(&order)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1328,7 +1328,7 @@ func testFundOrderReturnCoinsFundingCoins(t *testing.T, assetID uint32) {
 	checkBalance(eth, walletBalanceGwei, 0, "returned correct amount")
 
 	node.balErr = errors.New("")
-	_, _, err = w.FundOrder(&order)
+	_, _, _, err = w.FundOrder(&order)
 	if err == nil {
 		t.Fatalf("balance error should cause error but did not")
 	}
@@ -1348,7 +1348,7 @@ func testFundOrderReturnCoinsFundingCoins(t *testing.T, assetID uint32) {
 	// Test eth wallet gas fee limit > server MaxFeeRate causes error
 	tmpGasFeeLimit := eth.gasFeeLimit()
 	eth.gasFeeLimitV = order.MaxFeeRate - 1
-	_, _, err = w.FundOrder(&order)
+	_, _, _, err = w.FundOrder(&order)
 	if err == nil {
 		t.Fatalf("eth wallet gas fee limit > server MaxFeeRate should cause error")
 	}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -504,7 +504,7 @@ type Wallet interface {
 // MultiOrderFunder is a wallet that can fund multiple orders at once.
 // This will be part of the Wallet interface once all wallets support it.
 type MultiOrderFunder interface {
-	FundMultiOrder(ord *MultiOrder, maxLock uint64) (coins []Coins, redeemScripts [][]dex.Bytes, fundingFees uint64, err error)
+	FundMultiOrder(ord *MultiOrder, keep uint64) (coins []Coins, redeemScripts [][]dex.Bytes, fundingFees uint64, err error)
 }
 
 // Authenticator is a wallet implementation that require authentication.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -504,7 +504,7 @@ type Wallet interface {
 // MultiOrderFunder is a wallet that can fund multiple orders at once.
 // This will be part of the Wallet interface once all wallets support it.
 type MultiOrderFunder interface {
-	FundMultiOrder(ord *MultiOrder, keep uint64) (coins []Coins, redeemScripts [][]dex.Bytes, fundingFees uint64, err error)
+	FundMultiOrder(ord *MultiOrder, maxLock uint64) (coins []Coins, redeemScripts [][]dex.Bytes, fundingFees uint64, err error)
 }
 
 // Authenticator is a wallet implementation that require authentication.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -363,8 +363,9 @@ type Wallet interface {
 	// returned []dex.Bytes contains the redeem scripts for the selected coins.
 	// Equal number of coins and redeemed scripts must be returned. A nil or
 	// empty dex.Bytes should be appended to the redeem scripts collection for
-	// coins with no redeem script.
-	FundOrder(*Order) (coins Coins, redeemScripts []dex.Bytes, err error)
+	// coins with no redeem script. The fees returned are any fees paid in the
+	// process of funding the order, such as transaction fees for a split tx.
+	FundOrder(*Order) (coins Coins, redeemScripts []dex.Bytes, fees uint64, err error)
 	// MaxOrder generates information about the maximum order size and
 	// associated fees that the wallet can support for the specified DEX. The
 	// fees are an estimate based on current network conditions, and will be <=
@@ -498,6 +499,12 @@ type Wallet interface {
 	SingleLotSwapFees(version uint32, feeRate uint64, options map[string]string) (uint64, error)
 	// SingleLotRedeemFees returns the fees for a redeem transaction for a single lot.
 	SingleLotRedeemFees(version uint32, feeRate uint64, options map[string]string) (uint64, error)
+}
+
+// MultiOrderFunder is a wallet that can fund multiple orders at once.
+// This will be part of the Wallet interface once all wallets support it.
+type MultiOrderFunder interface {
+	FundMultiOrder(ord *MultiOrder, maxLock uint64) (coins []Coins, redeemScripts [][]dex.Bytes, fundingFees uint64, err error)
 }
 
 // Authenticator is a wallet implementation that require authentication.
@@ -1040,6 +1047,51 @@ type Order struct {
 	// standing order, likely a market order or a limit order with immediate
 	// time-in-force.
 	Immediate bool
+	// FeeSuggestion is a suggested fee from the server. If a split transaction
+	// is used, the fee rate used should be at least the suggested fee, else
+	// zero-conf coins might be rejected.
+	FeeSuggestion uint64
+	// Options are options that corresponds to PreSwap.Options, as well as
+	// their values.
+	Options map[string]string
+
+	// The following fields are only used for some assets where the redeemed/to
+	// asset may require funds in this "from" asset. For example, buying ERC20
+	// tokens with ETH.
+
+	// RedeemVersion is the asset version of the "to" asset with the redeem
+	// transaction. Most backends only support one version.
+	RedeemVersion uint32
+	// RedeemAssetID is the asset ID of the "to" asset.
+	RedeemAssetID uint32
+}
+
+// MultiOrderValue is one of the placements in a multi-order.
+type MultiOrderValue struct {
+	// Value is the amount required to satisfy the order. The Value does not
+	// include fees. Fees will be calculated internally based on the number of
+	// possible swaps (MaxSwapCount) and the exchange's configuration
+	// (DEXConfig).
+	Value uint64
+	// MaxSwapCount is the number of lots in the order, which is also the
+	// maximum number of transaction that an order could potentially generate
+	// in a worst-case scenario of all 1-lot matches. Note that if requesting
+	// funding for the quote asset's wallet, the number of lots will not be
+	// Value / DEXConfig.LotSize, because an order is quantified in the base
+	// asset, so lots is always (order quantity) / (base asset lot size).
+	MaxSwapCount uint64 // uint64 for compatibility with quantity and lot size.
+}
+
+// MultiOrder is order details needed for FundMultiOrder.
+type MultiOrder struct {
+	// Version is the asset version of the "from" asset with the init
+	// transaction (this wallet). Most backends only support one version.
+	Version uint32
+	Values  []*MultiOrderValue
+	// MaxFeeRate is the largest possible fee rate for the init transaction (of
+	// this "from" asset) specific to and provided by a particular server, and
+	// is used to calculate the funding required to cover fees.
+	MaxFeeRate uint64
 	// FeeSuggestion is a suggested fee from the server. If a split transaction
 	// is used, the fee rate used should be at least the suggested fee, else
 	// zero-conf coins might be rejected.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -972,7 +972,7 @@ type AuditInfo struct {
 
 // Swaps is the details needed to broadcast a swap contract(s).
 type Swaps struct {
-	// Version is the asset version. Most backends only support one version.
+	// Version is the asset version.
 	Version uint32
 	// Inputs are the Coins being spent.
 	Inputs Coins
@@ -1025,7 +1025,7 @@ type RedeemForm struct {
 // Order is order details needed for FundOrder.
 type Order struct {
 	// Version is the asset version of the "from" asset with the init
-	// transaction (this wallet). Most backends only support one version.
+	// transaction.
 	Version uint32
 	// Value is the amount required to satisfy the order. The Value does not
 	// include fees. Fees will be calculated internally based on the number of
@@ -1033,11 +1033,8 @@ type Order struct {
 	// (DEXConfig).
 	Value uint64
 	// MaxSwapCount is the number of lots in the order, which is also the
-	// maximum number of transaction that an order could potentially generate
-	// in a worst-case scenario of all 1-lot matches. Note that if requesting
-	// funding for the quote asset's wallet, the number of lots will not be
-	// Value / DEXConfig.LotSize, because an order is quantified in the base
-	// asset, so lots is always (order quantity) / (base asset lot size).
+	// maximum number of transactions that an order could potentially generate
+	// in a worst-case scenario of all 1-lot matches.
 	MaxSwapCount uint64 // uint64 for compatibility with quantity and lot size.
 	// MaxFeeRate is the largest possible fee rate for the init transaction (of
 	// this "from" asset) specific to and provided by a particular server, and
@@ -1060,7 +1057,7 @@ type Order struct {
 	// tokens with ETH.
 
 	// RedeemVersion is the asset version of the "to" asset with the redeem
-	// transaction. Most backends only support one version.
+	// transaction.
 	RedeemVersion uint32
 	// RedeemAssetID is the asset ID of the "to" asset.
 	RedeemAssetID uint32
@@ -1074,18 +1071,15 @@ type MultiOrderValue struct {
 	// (DEXConfig).
 	Value uint64
 	// MaxSwapCount is the number of lots in the order, which is also the
-	// maximum number of transaction that an order could potentially generate
-	// in a worst-case scenario of all 1-lot matches. Note that if requesting
-	// funding for the quote asset's wallet, the number of lots will not be
-	// Value / DEXConfig.LotSize, because an order is quantified in the base
-	// asset, so lots is always (order quantity) / (base asset lot size).
+	// maximum number of transactions that an order could potentially generate
+	// in a worst-case scenario of all 1-lot matches.
 	MaxSwapCount uint64 // uint64 for compatibility with quantity and lot size.
 }
 
 // MultiOrder is order details needed for FundMultiOrder.
 type MultiOrder struct {
 	// Version is the asset version of the "from" asset with the init
-	// transaction (this wallet). Most backends only support one version.
+	// transaction.
 	Version uint32
 	Values  []*MultiOrderValue
 	// MaxFeeRate is the largest possible fee rate for the init transaction (of
@@ -1105,7 +1099,7 @@ type MultiOrder struct {
 	// tokens with ETH.
 
 	// RedeemVersion is the asset version of the "to" asset with the redeem
-	// transaction. Most backends only support one version.
+	// transaction.
 	RedeemVersion uint32
 	// RedeemAssetID is the asset ID of the "to" asset.
 	RedeemAssetID uint32

--- a/client/cmd/dexcctl/main.go
+++ b/client/cmd/dexcctl/main.go
@@ -60,6 +60,7 @@ var promptPasswords = map[string][]string{
 	"send":              {"App password:"},
 	"appseed":           {"App password:"},
 	"startmarketmaking": {"App password:"},
+	"multitrade":        {"App password:"},
 }
 
 // optionalTextFiles is a map of routes to arg index for routes that should read

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6172,6 +6172,7 @@ func (c *Core) prepareMultiTradeRequests(pw []byte, form *MultiTradeForm) ([]*tr
 	if err != nil {
 		return nil, codedError(walletErr, fmt.Errorf("FundMultiOrder error for %s: %v", assetConfigs.fromAsset.Symbol, err))
 	}
+
 	if len(allCoins) != len(form.Placements) {
 		c.log.Infof("FundMultiOrder only funded %d orders out of %d", len(allCoins), len(form.Placements))
 	}
@@ -6186,10 +6187,11 @@ func (c *Core) prepareMultiTradeRequests(pw []byte, form *MultiTradeForm) ([]*tr
 
 	errClosers := make([]*dex.ErrorCloser, 0, len(allCoins))
 	for _, coins := range allCoins {
+		theseCoins := coins
 		errCloser := dex.NewErrorCloser()
 		defer errCloser.Done(c.log)
 		errCloser.Add(func() error {
-			err := fromWallet.ReturnCoins(coins)
+			err := fromWallet.ReturnCoins(theseCoins)
 			if err != nil {
 				return fmt.Errorf("unable to return %s funding coins: %v", unbip(fromWallet.AssetID), err)
 			}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5630,6 +5630,27 @@ func (c *Core) PreOrder(form *TradeForm) (*OrderEstimate, error) {
 	}, nil
 }
 
+// MultiTrade is used to place multiple standing limit orders on the same
+// side of the same market simultaneously.
+func (c *Core) MultiTrade(pw []byte, form *MultiTradeForm) ([]*Order, error) {
+	reqs, err := c.prepareMultiTradeRequests(pw, form)
+	if err != nil {
+		return nil, err
+	}
+
+	orders := make([]*Order, 0, len(reqs))
+
+	for _, req := range reqs {
+		corder, err := c.sendTradeRequest(req)
+		if err != nil {
+			return nil, err
+		}
+		orders = append(orders, corder)
+	}
+
+	return orders, nil
+}
+
 // Trade is used to place a market or limit order.
 func (c *Core) Trade(pw []byte, form *TradeForm) (*Order, error) {
 	req, err := c.prepareTradeRequest(pw, form)
@@ -5703,8 +5724,11 @@ type tradeRequest struct {
 	tempID       uint64
 }
 
-// prepareTradeRequest prepares a trade request.
-func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, error) {
+func (c *Core) prepareForTradeRequestPrep(pw []byte, base, quote uint32, host string, sell bool) (wallets *walletSet, assetConfig *assetSet, dc *dexConnection, mktConf *msgjson.Market, err error) {
+	fail := func(err error) (*walletSet, *assetSet, *dexConnection, *msgjson.Market, error) {
+		return nil, nil, nil, nil, err
+	}
+
 	// Check the user password. A Trade can be attempted with an empty password,
 	// which should work if both wallets are unlocked. We use this feature for
 	// bots.
@@ -5713,48 +5737,40 @@ func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, e
 		var err error
 		crypter, err = c.encryptionKey(pw)
 		if err != nil {
-			return nil, fmt.Errorf("Trade password error: %w", err)
+			return fail(fmt.Errorf("Trade password error: %w", err))
 		}
 		defer crypter.Close()
 	}
 
-	dc, err := c.registeredDEX(form.Host)
+	dc, err = c.registeredDEX(host)
 	if err != nil {
-		return nil, err
+		return fail(err)
 	}
 	if dc.acct.suspended() {
-		return nil, newError(suspendedAcctErr, "may not trade while account is suspended")
+		return fail(newError(suspendedAcctErr, "may not trade while account is suspended"))
 	}
 
-	mktID := marketName(form.Base, form.Quote)
-	mktConf := dc.marketConfig(mktID)
+	mktID := marketName(base, quote)
+	mktConf = dc.marketConfig(mktID)
 	if mktConf == nil {
-		return nil, newError(marketErr, "order placed for unknown market %q", mktID)
+		return fail(newError(marketErr, "order placed for unknown market %q", mktID))
 	}
 
 	// Proceed with the order if there is no trade suspension
 	// scheduled for the market.
 	if !dc.running(mktID) {
-		return nil, newError(marketErr, "%s market trading is suspended", mktID)
+		return fail(newError(marketErr, "%s market trading is suspended", mktID))
 	}
 
-	rate, qty := form.Rate, form.Qty
-	if form.IsLimit && rate == 0 {
-		return nil, newError(orderParamsErr, "zero-rate order not allowed")
-	}
-
-	wallets, assetConfigs, versCompat, err := c.walletSet(dc, form.Base, form.Quote, form.Sell)
+	wallets, assetConfigs, versCompat, err := c.walletSet(dc, base, quote, sell)
 	if err != nil {
-		return nil, err
+		return fail(err)
 	}
 	if !versCompat { // also covers missing asset config, but that's unlikely since there is a market config
-		return nil, fmt.Errorf("client and server asset versions are incompatible for %v", dc.acct.host)
+		return fail(fmt.Errorf("client and server asset versions are incompatible for %v", dc.acct.host))
 	}
 
 	fromWallet, toWallet := wallets.fromWallet, wallets.toWallet
-
-	accountRedeemer, isAccountRedemption := toWallet.Wallet.(asset.AccountLocker)
-	accountRefunder, isAccountRefund := fromWallet.Wallet.(asset.AccountLocker)
 
 	prepareWallet := func(w *xcWallet) error {
 		// NOTE: If the wallet is already internally unlocked (the decrypted
@@ -5780,99 +5796,27 @@ func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, e
 
 	err = prepareWallet(fromWallet)
 	if err != nil {
-		return nil, err
+		return fail(err)
 	}
 
 	err = prepareWallet(toWallet)
 	if err != nil {
-		return nil, err
+		return fail(err)
 	}
 
-	// Get an address for the swap contract.
-	redeemAddr, err := toWallet.RedemptionAddress()
-	if err != nil {
-		return nil, codedError(walletErr, fmt.Errorf("%s RedemptionAddress error: %w",
-			assetConfigs.toAsset.Symbol, err))
-	}
+	return wallets, assetConfigs, dc, mktConf, nil
+}
 
-	// Fund the order and prepare the coins.
-	lotSize := mktConf.LotSize
-	fundQty := qty
-	lots := qty / lotSize
-	if form.IsLimit && !form.Sell {
-		fundQty = calc.BaseToQuote(rate, fundQty)
-	}
-	redemptionRefundLots := lots
-
-	isImmediate := (!form.IsLimit || form.TifNow)
-
-	// Market buy order
-	if !form.IsLimit && !form.Sell {
-		// There is some ambiguity here about whether the specified quantity for
-		// a market buy order should include projected fees, or whether fees
-		// should be in addition to the quantity. If the fees should be
-		// additional to the order quantity (the approach taken here), we should
-		// try to estimate the number of lots based on the current market. If
-		// the market is not synced, fall back to a single-lot estimate, with
-		// the knowledge that such an estimate means that the specified amount
-		// might not all be available for matching once fees are considered.
-		lots = 1
-		book := dc.bookie(mktID)
-		if book != nil {
-			midGap, err := book.MidGap()
-			// An error is only returned when there are no orders on the book.
-			// In that case, fall back to the 1 lot estimate for now.
-			if err == nil {
-				baseQty := calc.QuoteToBase(midGap, fundQty)
-				lots = baseQty / lotSize
-				redemptionRefundLots = lots * marketBuyRedemptionSlippageBuffer
-				if lots == 0 {
-					err = newError(orderParamsErr,
-						"order quantity is too low for current market rates. "+
-							"qty = %d %s, mid-gap = %d, base-qty = %d %s, lot size = %d",
-						qty, assetConfigs.quoteAsset.Symbol, midGap, baseQty,
-						assetConfigs.baseAsset.Symbol, lotSize)
-					return nil, err
-				}
-			} else if isAccountRedemption {
-				return nil, newError(orderParamsErr, "cannot estimate redemption count")
-			}
-		}
-	}
-
-	if lots == 0 {
-		return nil, newError(orderParamsErr, "order quantity < 1 lot. qty = %d %s, rate = %d, lot size = %d",
-			qty, assetConfigs.baseAsset.Symbol, rate, lotSize)
-	}
-
-	coins, redeemScripts, err := fromWallet.FundOrder(&asset.Order{
-		Version:       assetConfigs.fromAsset.Version,
-		Value:         fundQty,
-		MaxSwapCount:  lots,
-		MaxFeeRate:    assetConfigs.fromAsset.MaxFeeRate,
-		Immediate:     isImmediate,
-		FeeSuggestion: c.feeSuggestion(dc, assetConfigs.fromAsset.ID),
-		Options:       form.Options,
-		RedeemVersion: assetConfigs.toAsset.Version,
-		RedeemAssetID: assetConfigs.toAsset.ID,
-	})
-	if err != nil {
-		return nil, codedError(walletErr, fmt.Errorf("FundOrder error for %s, funding quantity %d (%d lots): %w",
-			assetConfigs.fromAsset.Symbol, fundQty, lots, err))
-	}
-	defer func() {
-		if _, err := c.updateWalletBalance(fromWallet); err != nil {
-			c.log.Errorf("updateWalletBalance error: %v", err)
-		}
-		if fromToken := asset.TokenInfo(assetConfigs.fromAsset.ID); fromToken != nil {
-			c.updateAssetBalance(fromToken.ParentID)
-		}
-	}()
-
+func (c *Core) createTradeRequest(wallets *walletSet, coins asset.Coins, redeemScripts []dex.Bytes, dc *dexConnection, redeemAddr string,
+	form *TradeForm, lots, redemptionRefundLots uint64, fundingFees uint64, assetConfigs *assetSet, mktConf *msgjson.Market, errCloser *dex.ErrorCloser) (*tradeRequest, error) {
 	coinIDs := make([]order.CoinID, 0, len(coins))
 	for i := range coins {
 		coinIDs = append(coinIDs, []byte(coins[i].ID()))
 	}
+
+	fromWallet, toWallet := wallets.fromWallet, wallets.toWallet
+	accountRedeemer, isAccountRedemption := toWallet.Wallet.(asset.AccountLocker)
+	accountRefunder, isAccountRefund := fromWallet.Wallet.(asset.AccountLocker)
 
 	// In the special case that there is a single coin that implements
 	// RecoveryCoin, set that as the change coin.
@@ -5886,19 +5830,6 @@ func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, e
 		}
 	}
 
-	// The coins selected for this order will need to be unlocked
-	// if the order does not get to the server successfully.
-	errCloser := dex.NewErrorCloser()
-	defer errCloser.Done(c.log)
-	errCloser.Add(func() error {
-		err := fromWallet.ReturnCoins(coins)
-		if err != nil {
-			return fmt.Errorf("Unable to return %s funding coins: %v", unbip(fromWallet.AssetID), err)
-		}
-		return nil
-	})
-
-	// Construct the order.
 	preImg := newPreimage()
 	prefix := &order.Prefix{
 		AccountID:  dc.acct.ID(),
@@ -5937,12 +5868,13 @@ func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, e
 			},
 		}
 	}
-	err = order.ValidateOrder(ord, order.OrderStatusEpoch, lotSize)
+
+	err := order.ValidateOrder(ord, order.OrderStatusEpoch, mktConf.LotSize)
 	if err != nil {
 		return nil, fmt.Errorf("ValidateOrder error: %w", err)
 	}
 
-	msgCoins, err := messageCoins(wallets.fromWallet, coins, redeemScripts)
+	msgCoins, err := messageCoins(fromWallet, coins, redeemScripts)
 	if err != nil {
 		return nil, fmt.Errorf("%v wallet failed to sign coins: %w", assetConfigs.fromAsset.Symbol, err)
 	}
@@ -6030,12 +5962,13 @@ func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, e
 			RedemptionReserves: redemptionReserves,
 			RefundReserves:     refundReserves,
 			ChangeCoin:         changeID,
+			FundingFeesPaid:    fundingFees,
 		},
 		Order: ord,
 	}
 
-	tradeRequest := &tradeRequest{
-		mktID:        mktID,
+	return &tradeRequest{
+		mktID:        marketName(form.Base, form.Quote),
 		route:        route,
 		dc:           dc,
 		form:         form,
@@ -6046,11 +5979,243 @@ func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, e
 		wallets:      wallets,
 		errCloser:    errCloser.Copy(),
 		preImg:       preImg,
+	}, nil
+}
+
+// prepareTradeRequest prepares a trade request.
+func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, error) {
+	wallets, assetConfigs, dc, mktConf, err := c.prepareForTradeRequestPrep(pw, form.Base, form.Quote, form.Host, form.Sell)
+	if err != nil {
+		return nil, err
+	}
+
+	fromWallet, toWallet := wallets.fromWallet, wallets.toWallet
+	mktID := marketName(form.Base, form.Quote)
+
+	rate, qty := form.Rate, form.Qty
+	if form.IsLimit && rate == 0 {
+		return nil, newError(orderParamsErr, "zero-rate order not allowed")
+	}
+
+	// Get an address for the swap contract.
+	redeemAddr, err := toWallet.RedemptionAddress()
+	if err != nil {
+		return nil, codedError(walletErr, fmt.Errorf("%s RedemptionAddress error: %w",
+			assetConfigs.toAsset.Symbol, err))
+	}
+
+	// Fund the order and prepare the coins.
+	lotSize := mktConf.LotSize
+	fundQty := qty
+	lots := qty / lotSize
+	if form.IsLimit && !form.Sell {
+		fundQty = calc.BaseToQuote(rate, fundQty)
+	}
+	redemptionRefundLots := lots
+
+	isImmediate := (!form.IsLimit || form.TifNow)
+
+	// Market buy order
+	if !form.IsLimit && !form.Sell {
+		_, isAccountRedemption := toWallet.Wallet.(asset.AccountLocker)
+
+		// There is some ambiguity here about whether the specified quantity for
+		// a market buy order should include projected fees, or whether fees
+		// should be in addition to the quantity. If the fees should be
+		// additional to the order quantity (the approach taken here), we should
+		// try to estimate the number of lots based on the current market. If
+		// the market is not synced, fall back to a single-lot estimate, with
+		// the knowledge that such an estimate means that the specified amount
+		// might not all be available for matching once fees are considered.
+		lots = 1
+		book := dc.bookie(mktID)
+		if book != nil {
+			midGap, err := book.MidGap()
+			// An error is only returned when there are no orders on the book.
+			// In that case, fall back to the 1 lot estimate for now.
+			if err == nil {
+				baseQty := calc.QuoteToBase(midGap, fundQty)
+				lots = baseQty / lotSize
+				redemptionRefundLots = lots * marketBuyRedemptionSlippageBuffer
+				if lots == 0 {
+					err = newError(orderParamsErr,
+						"order quantity is too low for current market rates. "+
+							"qty = %d %s, mid-gap = %d, base-qty = %d %s, lot size = %d",
+						qty, assetConfigs.quoteAsset.Symbol, midGap, baseQty,
+						assetConfigs.baseAsset.Symbol, lotSize)
+					return nil, err
+				}
+			} else if isAccountRedemption {
+				return nil, newError(orderParamsErr, "cannot estimate redemption count")
+			}
+		}
+	}
+
+	if lots == 0 {
+		return nil, newError(orderParamsErr, "order quantity < 1 lot. qty = %d %s, rate = %d, lot size = %d",
+			qty, assetConfigs.baseAsset.Symbol, rate, mktConf.LotSize)
+	}
+
+	coins, redeemScripts, fundingFees, err := fromWallet.FundOrder(&asset.Order{
+		Version:       assetConfigs.fromAsset.Version,
+		Value:         fundQty,
+		MaxSwapCount:  lots,
+		MaxFeeRate:    assetConfigs.fromAsset.MaxFeeRate,
+		Immediate:     isImmediate,
+		FeeSuggestion: c.feeSuggestion(dc, assetConfigs.fromAsset.ID),
+		Options:       form.Options,
+		RedeemVersion: assetConfigs.toAsset.Version,
+		RedeemAssetID: assetConfigs.toAsset.ID,
+	})
+	if err != nil {
+		return nil, codedError(walletErr, fmt.Errorf("FundOrder error for %s, funding quantity %d (%d lots): %w",
+			assetConfigs.fromAsset.Symbol, fundQty, lots, err))
+	}
+	defer func() {
+		if _, err := c.updateWalletBalance(fromWallet); err != nil {
+			c.log.Errorf("updateWalletBalance error: %v", err)
+		}
+		if fromToken := asset.TokenInfo(assetConfigs.fromAsset.ID); fromToken != nil {
+			c.updateAssetBalance(fromToken.ParentID)
+		}
+	}()
+
+	// The coins selected for this order will need to be unlocked
+	// if the order does not get to the server successfully.
+	errCloser := dex.NewErrorCloser()
+	defer errCloser.Done(c.log)
+	errCloser.Add(func() error {
+		err := fromWallet.ReturnCoins(coins)
+		if err != nil {
+			return fmt.Errorf("Unable to return %s funding coins: %v", unbip(fromWallet.AssetID), err)
+		}
+		return nil
+	})
+
+	tradeRequest, err := c.createTradeRequest(wallets, coins, redeemScripts, dc, redeemAddr, form,
+		lots, redemptionRefundLots, fundingFees, assetConfigs, mktConf, errCloser)
+	if err != nil {
+		return nil, err
 	}
 
 	errCloser.Success()
 
 	return tradeRequest, nil
+}
+
+func (c *Core) prepareMultiTradeRequests(pw []byte, form *MultiTradeForm) ([]*tradeRequest, error) {
+	wallets, assetConfigs, dc, mktConf, err := c.prepareForTradeRequestPrep(pw, form.Base, form.Quote, form.Host, form.Sell)
+	if err != nil {
+		return nil, err
+	}
+	fromWallet, toWallet := wallets.fromWallet, wallets.toWallet
+
+	multiFunder, is := fromWallet.Wallet.(asset.MultiOrderFunder)
+	if !is {
+		return nil, newError(orderParamsErr, "fromWallet is not a MultiOrderFunder")
+	}
+
+	for _, trade := range form.Placements {
+		if trade.Rate == 0 {
+			return nil, newError(orderParamsErr, "zero rate is invalid")
+		}
+		if trade.Qty == 0 {
+			return nil, newError(orderParamsErr, "zero quantity is invalid")
+		}
+	}
+
+	redeemAddresses := make([]string, 0, len(form.Placements))
+	for range form.Placements {
+		redeemAddr, err := toWallet.RedemptionAddress()
+		if err != nil {
+			return nil, codedError(walletErr, fmt.Errorf("%s RedemptionAddress error: %w",
+				assetConfigs.toAsset.Symbol, err))
+		}
+		redeemAddresses = append(redeemAddresses, redeemAddr)
+	}
+
+	orderValues := make([]*asset.MultiOrderValue, 0, len(form.Placements))
+	for _, trade := range form.Placements {
+		fundQty := trade.Qty
+		lots := fundQty / mktConf.LotSize
+		if lots == 0 {
+			return nil, newError(orderParamsErr, "order quantity < 1 lot")
+		}
+
+		if !form.Sell {
+			fundQty = calc.BaseToQuote(trade.Rate, fundQty)
+		}
+		orderValues = append(orderValues, &asset.MultiOrderValue{
+			MaxSwapCount: lots,
+			Value:        fundQty,
+		})
+	}
+
+	allCoins, allRedeemScripts, fundingFees, err := multiFunder.FundMultiOrder(&asset.MultiOrder{
+		Version:       assetConfigs.fromAsset.Version,
+		Values:        orderValues,
+		MaxFeeRate:    assetConfigs.fromAsset.MaxFeeRate,
+		FeeSuggestion: c.feeSuggestion(dc, assetConfigs.fromAsset.ID),
+		Options:       form.Options,
+		RedeemVersion: assetConfigs.toAsset.Version,
+		RedeemAssetID: assetConfigs.toAsset.ID,
+	}, 0)
+	if err != nil {
+		return nil, codedError(walletErr, fmt.Errorf("FundMultiOrder error for %s: %v", assetConfigs.fromAsset.Symbol, err))
+	}
+	defer func() {
+		if _, err := c.updateWalletBalance(fromWallet); err != nil {
+			c.log.Errorf("updateWalletBalance error: %v", err)
+		}
+		if fromToken := asset.TokenInfo(assetConfigs.fromAsset.ID); fromToken != nil {
+			c.updateAssetBalance(fromToken.ParentID)
+		}
+	}()
+
+	errClosers := make([]*dex.ErrorCloser, 0, len(allCoins))
+	for _, coins := range allCoins {
+		errCloser := dex.NewErrorCloser()
+		defer errCloser.Done(c.log)
+		errCloser.Add(func() error {
+			err := fromWallet.ReturnCoins(coins)
+			if err != nil {
+				return fmt.Errorf("unable to return %s funding coins: %v", unbip(fromWallet.AssetID), err)
+			}
+			return nil
+		})
+		errClosers = append(errClosers, errCloser)
+	}
+
+	tradeRequests := make([]*tradeRequest, 0, len(allCoins))
+	for i, coins := range allCoins {
+		tradeForm := &TradeForm{
+			Host:    form.Host,
+			IsLimit: true,
+			Sell:    form.Sell,
+			Base:    form.Base,
+			Quote:   form.Quote,
+			Qty:     form.Placements[i].Qty,
+			Rate:    form.Placements[i].Rate,
+			Options: form.Options,
+		}
+		// Only count the funding fees once.
+		var fees uint64
+		if i == 0 {
+			fees = fundingFees
+		}
+		req, err := c.createTradeRequest(wallets, coins, allRedeemScripts[i], dc, redeemAddresses[i], tradeForm,
+			orderValues[i].MaxSwapCount, orderValues[i].MaxSwapCount, fees, assetConfigs, mktConf, errClosers[i])
+		if err != nil {
+			return nil, err
+		}
+		tradeRequests = append(tradeRequests, req)
+	}
+
+	for _, errCloser := range errClosers {
+		errCloser.Success()
+	}
+
+	return tradeRequests, nil
 }
 
 // sendTradeRequest sends an order, processes the result, then prepares and

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6161,9 +6161,12 @@ func (c *Core) prepareMultiTradeRequests(pw []byte, form *MultiTradeForm) ([]*tr
 		Options:       form.Options,
 		RedeemVersion: assetConfigs.toAsset.Version,
 		RedeemAssetID: assetConfigs.toAsset.ID,
-	}, form.Keep)
+	}, form.MaxLock)
 	if err != nil {
 		return nil, codedError(walletErr, fmt.Errorf("FundMultiOrder error for %s: %v", assetConfigs.fromAsset.Symbol, err))
+	}
+	if len(allCoins) != len(form.Placements) {
+		c.log.Infof("FundMultiOrder only funded %d orders out of %d", len(allCoins), len(form.Placements))
 	}
 	defer func() {
 		if _, err := c.updateWalletBalance(fromWallet); err != nil {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6161,7 +6161,7 @@ func (c *Core) prepareMultiTradeRequests(pw []byte, form *MultiTradeForm) ([]*tr
 		Options:       form.Options,
 		RedeemVersion: assetConfigs.toAsset.Version,
 		RedeemAssetID: assetConfigs.toAsset.ID,
-	}, 0)
+	}, form.Keep)
 	if err != nil {
 		return nil, codedError(walletErr, fmt.Errorf("FundMultiOrder error for %s: %v", assetConfigs.fromAsset.Symbol, err))
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5640,11 +5640,13 @@ func (c *Core) MultiTrade(pw []byte, form *MultiTradeForm) ([]*Order, error) {
 
 	orders := make([]*Order, 0, len(reqs))
 
+	var numSuccessful uint64
 	for _, req := range reqs {
 		corder, err := c.sendTradeRequest(req)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error sending trade request after %d successful sends: %v", numSuccessful, err)
 		}
+		numSuccessful++
 		orders = append(orders, corder)
 	}
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -784,10 +784,10 @@ func (w *TXCWallet) ConfirmRedemption(coinID dex.Bytes, redemption *asset.Redemp
 	return w.confirmRedemptionResult, w.confirmRedemptionErr
 }
 
-func (w *TXCWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, error) {
+func (w *TXCWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, uint64, error) {
 	w.fundedVal = ord.Value
 	w.fundedSwaps = ord.MaxSwapCount
-	return w.fundingCoins, w.fundRedeemScripts, w.fundingCoinErr
+	return w.fundingCoins, w.fundRedeemScripts, 0, w.fundingCoinErr
 }
 
 func (w *TXCWallet) MaxOrder(*asset.MaxOrderForm) (*asset.SwapEstimate, error) {

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -392,6 +392,7 @@ type InFlightOrder struct {
 type FeeBreakdown struct {
 	Swap       uint64 `json:"swap"`
 	Redemption uint64 `json:"redemption"`
+	Funding    uint64 `json:"funding"` // split fees
 }
 
 // coreOrderFromTrade constructs an *Order from the supplied limit or market
@@ -478,6 +479,7 @@ func coreOrderFromTrade(ord order.Order, metaData *db.OrderMetaData) *Order {
 		FeesPaid: &FeeBreakdown{
 			Swap:       metaData.SwapFeesPaid,
 			Redemption: metaData.RedemptionFeesPaid,
+			Funding:    metaData.FundingFeesPaid,
 		},
 		FundingCoins:      fundingCoins,
 		AccelerationCoins: accelerationCoins,
@@ -978,6 +980,24 @@ type TradeForm struct {
 	Rate    uint64            `json:"rate"`
 	TifNow  bool              `json:"tifnow"`
 	Options map[string]string `json:"options"`
+}
+
+// QtyRate specifies the quantity and rate of an order placement.
+type QtyRate struct {
+	Qty  uint64 `json:"qty"`
+	Rate uint64 `json:"rate"`
+}
+
+// MultiTradeForm is used to place multiple orders in one go.
+// All orders must be on the same side of the same market, and only standing
+// limit orders are supported.
+type MultiTradeForm struct {
+	Host       string            `json:"host"`
+	Sell       bool              `json:"sell"`
+	Base       uint32            `json:"base"`
+	Quote      uint32            `json:"quote"`
+	Placements []*QtyRate        `json:"placement"`
+	Options    map[string]string `json:"options"`
 }
 
 // SingleLotFeesForm is used to determine the fees for a single lot trade.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -998,6 +998,9 @@ type MultiTradeForm struct {
 	Quote      uint32            `json:"quote"`
 	Placements []*QtyRate        `json:"placement"`
 	Options    map[string]string `json:"options"`
+	// Keep is the amount of the "from" asset that is required to still be
+	// available in the wallet after all of the trades are funded.
+	Keep uint64 `json:"keep"`
 }
 
 // SingleLotFeesForm is used to determine the fees for a single lot trade.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -998,9 +998,9 @@ type MultiTradeForm struct {
 	Quote      uint32            `json:"quote"`
 	Placements []*QtyRate        `json:"placement"`
 	Options    map[string]string `json:"options"`
-	// Keep is the amount of the "from" asset that is required to still be
-	// available in the wallet after all of the trades are funded.
-	Keep uint64 `json:"keep"`
+	// MaxLock is the maximum amount of the "from" asset that the wallet
+	// should lock for the trade.
+	MaxLock uint64 `json:"maxLock"`
 }
 
 // SingleLotFeesForm is used to determine the fees for a single lot trade.

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -99,6 +99,7 @@ var (
 	maxFeeRateKey         = []byte("maxFeeRate")
 	redeemMaxFeeRateKey   = []byte("redeemMaxFeeRate")
 	redemptionFeesKey     = []byte("redeemFees")
+	fundingFeesKey        = []byte("fundingFees")
 	accelerationsKey      = []byte("accelerations")
 	typeKey               = []byte("type")
 	seedGenTimeKey        = []byte("seedGenTime")
@@ -1280,6 +1281,11 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 		}
 	}
 
+	var fundingFeesPaid uint64
+	if fundingFeesB := oBkt.Get(fundingFeesKey); len(fundingFeesB) == 8 {
+		fundingFeesPaid = intCoder.Uint64(fundingFeesB)
+	}
+
 	return &dexdb.MetaOrder{
 		MetaData: &dexdb.OrderMetaData{
 			Proof:              *proof,
@@ -1300,6 +1306,7 @@ func decodeOrderBucket(oid []byte, oBkt *bbolt.Bucket) (*dexdb.MetaOrder, error)
 			RedemptionReserves: redemptionReserves,
 			RefundReserves:     refundReserves,
 			AccelerationCoins:  accelerationCoinIDs,
+			FundingFeesPaid:    fundingFeesPaid,
 		},
 		Order: ord,
 	}, nil
@@ -1387,6 +1394,7 @@ func updateOrderMetaData(bkt *bbolt.Bucket, md *dexdb.OrderMetaData) error {
 		put(redemptionReservesKey, uint64Bytes(md.RedemptionReserves)).
 		put(refundReservesKey, uint64Bytes(md.RefundReserves)).
 		put(accelerationsKey, accelerationsB).
+		put(fundingFeesKey, uint64Bytes(md.FundingFeesPaid)).
 		err()
 }
 

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -424,6 +424,9 @@ type OrderMetaData struct {
 	// RedemptionFeesPaid is the sum of the actual fees paid for all
 	// redemptions.
 	RedemptionFeesPaid uint64
+	// FundingFeesPaid is the fees paid when funding the order. This is > 0
+	// when funding the order required a split tx.
+	FundingFeesPaid uint64
 
 	// EpochDur is the epoch duration for the market at the time the order was
 	// submitted. When considered with the order's ServerTime, we also know the

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -1347,7 +1347,7 @@ Registration is complete after the fee transaction has been confirmed.`,
 	},
 	multiTradeRoute: {
 		pwArgsShort: `"appPass"`,
-		argsShort:   `"host" sell base quote numPlacements [qty,rate] options`,
+		argsShort:   `"host" sell base quote keep numPlacements [qty,rate] options`,
 		cmdSummary:  `Place multiple orders in one go.`,
 		pwArgsLong: `Password Args:
     appPass (string): The DEX client password.`,
@@ -1356,6 +1356,7 @@ Registration is complete after the fee transaction has been confirmed.`,
     sell (bool): Whether the order is selling.
     base (int): The BIP-44 coin index for the market's base asset.
     quote (int): The BIP-44 coin index for the market's quote asset.
+    keep (int): The amount of the fund asset that must be available after all of the trades are funded.
     numPlacements (int): The number of orders to place.
     placements ([int,int]): The quantities and rates of the orders. Quantity must be
 	 a multiple of the lot size. Rate must be in atomic units of the quote asset.

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -54,6 +54,7 @@ const (
 	notificationsRoute         = "notifications"
 	startMarketMakingRoute     = "startmarketmaking"
 	stopMarketMakingRoute      = "stopmarketmaking"
+	multiTradeRoute            = "multitrade"
 )
 
 const (
@@ -118,6 +119,7 @@ var routes = map[string]func(s *RPCServer, params *RawParams) *msgjson.ResponseP
 	notificationsRoute:         handleNotificationsRoute,
 	startMarketMakingRoute:     handleStartMarketMakingRoute,
 	stopMarketMakingRoute:      handleStopMarketMakingRoute,
+	multiTradeRoute:            handleMultiTrade,
 }
 
 // handleHelp handles requests for help. Returns general help for all commands
@@ -555,6 +557,29 @@ func handleTrade(s *RPCServer, params *RawParams) *msgjson.ResponsePayload {
 		Stamp:   res.Stamp,
 	}
 	return createResponse(tradeRoute, &tradeRes, nil)
+}
+
+func handleMultiTrade(s *RPCServer, params *RawParams) *msgjson.ResponsePayload {
+	form, err := parseMultiTradeArgs(params)
+	if err != nil {
+		return usage(multiTradeRoute, err)
+	}
+	defer form.appPass.Clear()
+	res, err := s.core.MultiTrade(form.appPass, form.srvForm)
+	if err != nil {
+		errMsg := fmt.Sprintf("unable to multi trade: %v", err)
+		resErr := msgjson.NewError(msgjson.RPCTradeError, errMsg)
+		return createResponse(multiTradeRoute, nil, resErr)
+	}
+	trades := make([]*tradeResponse, 0, len(res))
+	for _, trade := range res {
+		trades = append(trades, &tradeResponse{
+			OrderID: trade.ID.String(),
+			Sig:     trade.Sig.String(),
+			Stamp:   trade.Stamp,
+		})
+	}
+	return createResponse(multiTradeRoute, &trades, nil)
 }
 
 // handleCancel handles requests for cancel. *msgjson.ResponsePayload.Error is
@@ -1319,6 +1344,32 @@ Registration is complete after the fee transaction has been confirmed.`,
       "stamp" (int): The time the order was signed in milliseconds since 00:00:00
         Jan 1 1970.
     }`,
+	},
+	multiTradeRoute: {
+		pwArgsShort: `"appPass"`,
+		argsShort:   `"host" sell base quote numPlacements [qty,rate] options`,
+		cmdSummary:  `Place multiple orders in one go.`,
+		pwArgsLong: `Password Args:
+    appPass (string): The DEX client password.`,
+		argsLong: `Args:
+    host (string): The DEX to trade on.
+    sell (bool): Whether the order is selling.
+    base (int): The BIP-44 coin index for the market's base asset.
+    quote (int): The BIP-44 coin index for the market's quote asset.
+    numPlacements (int): The number of orders to place.
+    placements ([int,int]): The quantities and rates of the orders. Quantity must be
+	 a multiple of the lot size. Rate must be in atomic units of the quote asset.
+    immediate (bool): Require immediate match. Do not book the order.
+    options (string): A JSON-encoded string->string mapping of additional
+       trade options.`,
+		returns: `Returns:
+    obj: The details of each order.
+    [{
+      "orderid" (string): The order's unique hex identifier.
+      "sig" (string): The DEX's signature of the order information.
+      "stamp" (int): The time the order was signed in milliseconds since 00:00:00
+        Jan 1 1970.
+    }]`,
 	},
 	cancelRoute: {
 		pwArgsShort: `"appPass"`,

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -1347,7 +1347,7 @@ Registration is complete after the fee transaction has been confirmed.`,
 	},
 	multiTradeRoute: {
 		pwArgsShort: `"appPass"`,
-		argsShort:   `"host" sell base quote keep numPlacements [qty,rate] options`,
+		argsShort:   `"host" sell base quote maxLock numPlacements [qty,rate] options`,
 		cmdSummary:  `Place multiple orders in one go.`,
 		pwArgsLong: `Password Args:
     appPass (string): The DEX client password.`,
@@ -1356,7 +1356,7 @@ Registration is complete after the fee transaction has been confirmed.`,
     sell (bool): Whether the order is selling.
     base (int): The BIP-44 coin index for the market's base asset.
     quote (int): The BIP-44 coin index for the market's quote asset.
-    keep (int): The amount of the fund asset that must be available after all of the trades are funded.
+    maxLock (int): The maximum amount the wallet can lock for this order. 0 means no limit.
     numPlacements (int): The number of orders to place.
     placements ([int,int]): The quantities and rates of the orders. Quantity must be
 	 a multiple of the lot size. Rate must be in atomic units of the quote asset.

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -1347,7 +1347,7 @@ Registration is complete after the fee transaction has been confirmed.`,
 	},
 	multiTradeRoute: {
 		pwArgsShort: `"appPass"`,
-		argsShort:   `"host" sell base quote maxLock numPlacements [qty,rate] options`,
+		argsShort:   `"host" sell base quote maxLock [[qty,rate]] options`,
 		cmdSummary:  `Place multiple orders in one go.`,
 		pwArgsLong: `Password Args:
     appPass (string): The DEX client password.`,
@@ -1357,10 +1357,8 @@ Registration is complete after the fee transaction has been confirmed.`,
     base (int): The BIP-44 coin index for the market's base asset.
     quote (int): The BIP-44 coin index for the market's quote asset.
     maxLock (int): The maximum amount the wallet can lock for this order. 0 means no limit.
-    numPlacements (int): The number of orders to place.
-    placements ([int,int]): The quantities and rates of the orders. Quantity must be
+    placements ([[int,int]]):  An array of [qty,rate] placements. Quantity must be
 	 a multiple of the lot size. Rate must be in atomic units of the quote asset.
-    immediate (bool): Require immediate match. Do not book the order.
     options (string): A JSON-encoded string->string mapping of additional
        trade options.`,
 		returns: `Returns:

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -84,6 +84,7 @@ type clientCore interface {
 	AddWalletPeer(assetID uint32, host string) error
 	RemoveWalletPeer(assetID uint32, host string) error
 	Notifications(int) ([]*db.Notification, error)
+	MultiTrade(pw []byte, form *core.MultiTradeForm) ([]*core.Order, error)
 }
 
 // RPCServer is a single-client http and websocket server enabling a JSON

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -172,6 +172,9 @@ func (c *TCore) RemoveWalletPeer(assetID uint32, address string) error {
 func (c *TCore) Notifications(n int) ([]*db.Notification, error) {
 	return nil, nil
 }
+func (c *TCore) MultiTrade(appPass []byte, form *core.MultiTradeForm) ([]*core.Order, error) {
+	return nil, nil
+}
 
 type tBookFeed struct{}
 

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -605,7 +605,7 @@ func parseMultiTradeArgs(params *RawParams) (*multiTradeForm, error) {
 		return nil, err
 	}
 
-	keep, err := checkUIntArg(params.Args[4], "keep", 64)
+	maxLock, err := checkUIntArg(params.Args[4], "maxLock", 64)
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +647,7 @@ func parseMultiTradeArgs(params *RawParams) (*multiTradeForm, error) {
 			Quote:      uint32(quote),
 			Placements: placements,
 			Options:    options,
-			Keep:       keep,
+			MaxLock:    maxLock,
 		},
 	}, nil
 }

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -605,7 +605,12 @@ func parseMultiTradeArgs(params *RawParams) (*multiTradeForm, error) {
 		return nil, err
 	}
 
-	numPlacements, err := checkIntArg(params.Args[4], "numPlacements", 32)
+	keep, err := checkUIntArg(params.Args[4], "keep", 64)
+	if err != nil {
+		return nil, err
+	}
+
+	numPlacements, err := checkIntArg(params.Args[5], "numPlacements", 32)
 	if err != nil {
 		return nil, err
 	}
@@ -616,7 +621,7 @@ func parseMultiTradeArgs(params *RawParams) (*multiTradeForm, error) {
 		// placements are in the format of [qty, rate]. parse them
 		// and add them to the placements array
 		placement := make([]uint64, 0, 2)
-		if err := json.Unmarshal([]byte(params.Args[5+i]), &placement); err != nil {
+		if err := json.Unmarshal([]byte(params.Args[6+i]), &placement); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal placement %d: %v", i, err)
 		}
 		if len(placement) != 2 {
@@ -628,7 +633,7 @@ func parseMultiTradeArgs(params *RawParams) (*multiTradeForm, error) {
 		})
 	}
 
-	options, err := checkMapArg(params.Args[5+numPlacements], "options")
+	options, err := checkMapArg(params.Args[6+numPlacements], "options")
 	if err != nil {
 		return nil, err
 	}
@@ -642,6 +647,7 @@ func parseMultiTradeArgs(params *RawParams) (*multiTradeForm, error) {
 			Quote:      uint32(quote),
 			Placements: placements,
 			Options:    options,
+			Keep:       keep,
 		},
 	}, nil
 }


### PR DESCRIPTION
This adds a `core.MultiTrade` function. It allows callers to fund multiple trades in one go. It is only implemented for BTC currently, but will be implemented for other assets later, after this is reviewed. In order to fund multiple orders in one go, the BTC wallet first attempts to fund each of the orders with the existing UTXOs. If this was not possible and splitting is not allowed, the orders that are able to be funded are returned. If splitting is allowed, a split transaction with one output per order will be created.

This also updates `FundOrder` to return the fees spent on any split transactions, and this is stored in the database.