### PR TITLE
add network field to core.User

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2358,6 +2358,7 @@ func (c *Core) User() *User {
 		Initialized:        c.IsInitialized(),
 		SeedGenerationTime: c.seedGenerationTime,
 		FiatRates:          c.fiatConversions(),
+		Net:                c.net,
 	}
 }
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -145,6 +145,7 @@ type User struct {
 	SeedGenerationTime uint64                     `json:"seedgentime"`
 	Assets             map[uint32]*SupportedAsset `json:"assets"`
 	FiatRates          map[uint32]float64         `json:"fiatRates"`
+	Net                dex.Network                `json:"net"`
 }
 
 // SupportedAsset is data about an asset and possibly the wallet associated

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -113,26 +113,9 @@ func (s *WebServer) knownUnregisteredExchanges(registeredExchanges map[string]*c
 	return exchanges
 }
 
-// marketResult is the template data for the `/markets` page request.
-type marketTmplData struct {
-	CommonArguments
-	Exchanges map[string]*core.Exchange
-	Net       uint8
-}
-
 // handleMarkets is the handler for the '/markets' page request.
 func (s *WebServer) handleMarkets(w http.ResponseWriter, r *http.Request) {
-	cArgs := s.commonArgs(r, "Markets | Decred DEX")
-	s.sendTemplate(w, "markets", &marketTmplData{
-		CommonArguments: *cArgs,
-		Net:             uint8(s.core.Network()),
-	})
-}
-
-type walletsTmplData struct {
-	CommonArguments
-	Assets []*core.SupportedAsset
-	Net    uint8
+	s.sendTemplate(w, "markets", s.commonArgs(r, "Markets | Decred DEX"))
 }
 
 // handleWallets is the handler for the '/wallets' page request.
@@ -156,12 +139,7 @@ func (s *WebServer) handleWallets(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(nowallets, func(i, j int) bool {
 		return nowallets[i].Name < nowallets[j].Name
 	})
-	data := &walletsTmplData{
-		CommonArguments: *s.commonArgs(r, "Wallets | Decred DEX"),
-		Assets:          append(assets, nowallets...),
-		Net:             uint8(s.core.Network()),
-	}
-	s.sendTemplate(w, "wallets", data)
+	s.sendTemplate(w, "wallets", s.commonArgs(r, "Wallets | Decred DEX"))
 }
 
 // handleWalletLogFile is the handler for the '/wallets/logfile' page request.
@@ -441,8 +419,6 @@ func (s *WebServer) handleExportOrders(w http.ResponseWriter, r *http.Request) {
 type orderTmplData struct {
 	CommonArguments
 	Order *core.OrderReader
-	// Don't use dex.Network because the template parser will use the Stringer.
-	Net uint8
 }
 
 // handleOrder is the handler for the /order/{oid} page request.
@@ -462,7 +438,6 @@ func (s *WebServer) handleOrder(w http.ResponseWriter, r *http.Request) {
 	s.sendTemplate(w, "order", &orderTmplData{
 		CommonArguments: *s.commonArgs(r, "Order | Decred DEX"),
 		Order:           s.orderReader(ord),
-		Net:             uint8(s.core.Network()),
 	})
 }
 

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=JDSD183gH"></script>
+<script src="/js/entry.js?v=nV9Bel"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -10,7 +10,7 @@
 
 {{define "markets"}}
 {{template "top" .}}
-<div id="main" data-handler="markets" data-net="{{.Net}}" class="main m-0 flex-nowrap v1">
+<div id="main" data-handler="markets" class="main m-0 flex-nowrap v1">
   {{- /* MARKET LIST */ -}}
   <div id="leftMarketDock" class="flex-column align-items-end v1 default">
     <div class="h-100 d-flex flex-column align-items-stretch">

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -5,7 +5,7 @@
 {{define "order"}}
 {{template "top" .}}
 {{$ord := .Order}}
-<div id="main" data-handler="order" class="main w-100 overflow-y-auto" data-net="{{.Net}}" data-oid="{{$ord.ID}}">
+<div id="main" data-handler="order" class="main w-100 overflow-y-auto" data-oid="{{$ord.ID}}">
   <div class="px-5">
     <div class="px-1 py-2">
       <span class="fs22 demi me-2">[[[Order]]]</span>

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -1,7 +1,7 @@
 {{define "wallets"}}
 {{$passwordIsCached := .UserInfo.PasswordIsCached}}
 {{template "top" .}}
-<div id="main" data-handler="wallets" data-net="{{.Net}}" class="walletspage flex-grow-1 position-relative">
+<div id="main" data-handler="wallets" class="walletspage flex-grow-1 position-relative">
   <span class="me-2 connection ico-connection d-hide peers-table-icon" id="connectedIconTmpl"></span>
   <span class="me-2 errcolor ico-disconnected d-hide peers-table-icon" id="disconnectedIconTmpl"></span>
   <span class="me-2 errcolor ico-cross d-hide pointer peers-table-icon" id="removeIconTmpl"></span>

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -189,7 +189,7 @@ export default class MarketsPage extends BasePage {
   constructor (main: HTMLElement, data: any) {
     super()
 
-    net = parseInt(main.dataset.net || '')
+    net = app().user.net
     const page = this.page = Doc.idDescendants(main)
     this.main = main
     if (!this.main.parentElement) return // Not gonna happen, but TypeScript cares.

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -44,7 +44,7 @@ export default class OrderPage extends BasePage {
     super()
     const page = this.page = Doc.idDescendants(main)
     this.stampers = Doc.applySelector(main, '[data-stamp]')
-    net = parseInt(main.dataset.net || '')
+    net = app().user.net
     // Find the order
     this.orderID = main.dataset.oid || ''
 

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -289,6 +289,7 @@ export interface User {
   authed: boolean // added by webserver
   ok: boolean // added by webserver
   bots: BotReport[]
+  net: number
 }
 
 export interface CoreNote {

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -95,7 +95,7 @@ export default class WalletsPage extends BasePage {
     super()
     this.body = body
     const page = this.page = Doc.idDescendants(body)
-    net = parseInt(body.dataset.net || '')
+    net = app().user.net
 
     Doc.cleanTemplates(page.restoreInfoCard, page.connectedIconTmpl, page.disconnectedIconTmpl, page.removeIconTmpl)
     this.restoreInfoCard = page.restoreInfoCard.cloneNode(true) as HTMLElement


### PR DESCRIPTION
Noticed while looking over #2349 that we were passing the network via a data attribute for a few pages, requiring some custom page templates structs that are otherwise unneeded. It's cleaner to report it in the `core.User` instead.