### PR TITLE
electrum/wallet: Make sending RBF for payto RPC optional

### DIFF
--- a/client/asset/btc/electrum/wallet_methods.go
+++ b/client/asset/btc/electrum/wallet_methods.go
@@ -310,8 +310,8 @@ type paytoReq struct {
 	// FromAddr omitted
 	FromUTXOs      string `json:"from_coins,omitempty"`
 	NoCheck        bool   `json:"nocheck"`
-	Unsigned       bool   `json:"unsigned"` // unsigned returns a base64 psbt thing
-	RBF            bool   `json:"rbf"`      // default to false
+	Unsigned       bool   `json:"unsigned"`      // unsigned returns a base64 psbt thing
+	RBF            bool   `json:"rbf,omitempty"` // default to null
 	Password       string `json:"password,omitempty"`
 	LockTime       *int64 `json:"locktime,omitempty"`
 	AddTransaction bool   `json:"addtransaction"`


### PR DESCRIPTION
Some Electrum wallets do not have a Replace by Fee parameter for the `payto` RPC. Make sending optional.
Based on discussion [here](https://github.com/decred/dcrdex/issues/2359)
