### PR TITLE
client/asset/btc: recycle unused redemption and refund addresses

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -5906,18 +5906,7 @@ func TestAddressRecycling(t *testing.T) {
 		for addr := range w.recycledAddrs {
 			memList = append(memList, addr)
 		}
-		compareAddrLists(tag+":mem", expAddrs, memList)
-
-		b, _ := os.ReadFile(w.recyclePath)
-		var fileAddrs []string
-		for _, addr := range strings.Split(string(b), "\n") {
-			if addr == "" {
-				continue
-			}
-			fileAddrs = append(fileAddrs, addr)
-		}
-
-		compareAddrLists(tag+":file", expAddrs, fileAddrs)
+		compareAddrLists(tag, expAddrs, memList)
 	}
 
 	addr1, _ := btcutil.NewAddressPubKeyHash(encode.RandomBytes(20), &chaincfg.MainNetParams)
@@ -5962,8 +5951,21 @@ func TestAddressRecycling(t *testing.T) {
 
 	// Check address loading.
 	w.ReturnRefundContracts(contracts)
+
+	w.writeRecycledAddrsToFile()
+	b, _ := os.ReadFile(w.recyclePath)
+	var fileAddrs []string
+	for _, addr := range strings.Split(string(b), "\n") {
+		if addr == "" {
+			continue
+		}
+		fileAddrs = append(fileAddrs, addr)
+	}
+	compareAddrLists("filecheck", []string{addr1.String(), addr2.String()}, fileAddrs)
+
 	otherW, _ := newUnconnectedWallet(w.cloneParams, &WalletConfig{})
 	if len(otherW.recycledAddrs) != 2 {
 		t.Fatalf("newly opened wallet didn't load recycled addrs")
 	}
+
 }

--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -800,15 +800,6 @@ func (ew *electrumWallet) changeAddress() (btcutil.Address, error) {
 }
 
 // part of btc.Wallet interface
-func (ew *electrumWallet) refundAddress() (btcutil.Address, error) {
-	addr, err := ew.wallet.GetUnusedAddress(ew.ctx)
-	if err != nil {
-		return nil, err
-	}
-	return ew.decodeAddr(addr, ew.chainParams)
-}
-
-// part of btc.Wallet interface
 func (ew *electrumWallet) signTx(inTx *wire.MsgTx) (*wire.MsgTx, error) {
 	// If the wallet's signtransaction RPC ever has a problem with the PSBT, we
 	// could attempt to sign the transaction ourselves by pulling the inputs'

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -589,10 +589,6 @@ func (wc *rpcClient) externalAddress() (btcutil.Address, error) {
 	return wc.address("legacy")
 }
 
-func (wc *rpcClient) refundAddress() (btcutil.Address, error) {
-	return wc.externalAddress()
-}
-
 // address is used internally for fetching addresses of various types from the
 // wallet.
 func (wc *rpcClient) address(aType string) (btcutil.Address, error) {

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -178,7 +178,7 @@ func (c *tBtcWallet) Unlock(passphrase []byte, lock <-chan time.Time) error {
 func (c *tBtcWallet) Lock() {}
 
 func (c *tBtcWallet) Locked() bool {
-	return false
+	return c.locked
 }
 
 func (c *tBtcWallet) SendOutputs(outputs []*wire.TxOut, keyScope *waddrmgr.KeyScope,
@@ -197,7 +197,7 @@ func (c *tBtcWallet) SendOutputs(outputs []*wire.TxOut, keyScope *waddrmgr.KeySc
 }
 
 func (c *tBtcWallet) HaveAddress(a btcutil.Address) (bool, error) {
-	return false, nil
+	return c.ownsAddress, nil
 }
 
 func (c *tBtcWallet) Stop() {}

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -716,10 +716,6 @@ func (w *spvWallet) externalAddress() (btcutil.Address, error) {
 	return w.wallet.NewAddress(w.acctNum, waddrmgr.KeyScopeBIP0084)
 }
 
-func (w *spvWallet) refundAddress() (btcutil.Address, error) {
-	return w.externalAddress()
-}
-
 // signTx attempts to have the wallet sign the transaction inputs.
 func (w *spvWallet) signTx(tx *wire.MsgTx) (*wire.MsgTx, error) {
 	// Can't use btcwallet.Wallet.SignTransaction, because it doesn't work for

--- a/client/asset/btc/wallet.go
+++ b/client/asset/btc/wallet.go
@@ -31,9 +31,6 @@ type Wallet interface {
 	listLockUnspent() ([]*RPCOutpoint, error)
 	changeAddress() (btcutil.Address, error) // warning: don't just use the Stringer if there's a "recode" function for a clone e.g. BCH
 	externalAddress() (btcutil.Address, error)
-	// The refund addresses are almost never used, so we might tolerate some
-	// address reuse if the backend requires.
-	refundAddress() (btcutil.Address, error)
 	signTx(inTx *wire.MsgTx) (*wire.MsgTx, error)
 	privKeyForAddress(addr string) (*btcec.PrivateKey, error)
 	walletUnlock(pw []byte) error

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -632,7 +632,7 @@ type AddressReturner interface {
 	// ReturnRefundContracts should be called with the Receipt.Contract() data
 	// for any swaps that will not be refunded.
 	ReturnRefundContracts(contracts [][]byte)
-	// ReturnRedemptionAddress acceptsa  Wallet.RedemptionAddress() if the
+	// ReturnRedemptionAddress accepts a  Wallet.RedemptionAddress() if the
 	// address will not be used.
 	ReturnRedemptionAddress(addr string)
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -625,6 +625,13 @@ type NewAddresser interface {
 	NewAddress() (string, error)
 }
 
+// AddressReturner is a wallet that allows recycling of unused redemption
+// addresses. Asset implementations should log any errors internally. The caller
+// is responsible for only calling ReturnAddress with unused addresses.
+type AddressReturner interface {
+	ReturnAddress(addrs ...string)
+}
+
 // LogFiler is a wallet that allows for downloading of its log file.
 type LogFiler interface {
 	LogFilePath() string
@@ -984,6 +991,13 @@ type Receipt interface {
 	// SignedRefund is a signed refund script that can be used to return
 	// funds to the user in the case a contract expires.
 	SignedRefund() dex.Bytes
+}
+
+// RefundReceipt can be implemented on Receipt for assets that want refund
+// addresses returned via ReturnAddress.
+type RefundReceipt interface {
+	// RefundAddress is the change address used for the swap.
+	RefundAddress() string
 }
 
 // AuditInfo is audit information about a swap contract needed to audit the

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -625,11 +625,16 @@ type NewAddresser interface {
 	NewAddress() (string, error)
 }
 
-// AddressReturner is a wallet that allows recycling of unused redemption
+// AddressReturner is a wallet that allows recycling of unused redemption or refund
 // addresses. Asset implementations should log any errors internally. The caller
-// is responsible for only calling ReturnAddress with unused addresses.
+// is responsible for only returning unused addresses.
 type AddressReturner interface {
-	ReturnAddress(addrs ...string)
+	// ReturnRefundContracts should be called with the Receipt.Contract() data
+	// for any swaps that will not be refunded.
+	ReturnRefundContracts(contracts [][]byte)
+	// ReturnRedemptionAddress acceptsa  Wallet.RedemptionAddress() if the
+	// address will not be used.
+	ReturnRedemptionAddress(addr string)
 }
 
 // LogFiler is a wallet that allows for downloading of its log file.
@@ -991,13 +996,6 @@ type Receipt interface {
 	// SignedRefund is a signed refund script that can be used to return
 	// funds to the user in the case a contract expires.
 	SignedRefund() dex.Bytes
-}
-
-// RefundReceipt can be implemented on Receipt for assets that want refund
-// addresses returned via ReturnAddress.
-type RefundReceipt interface {
-	// RefundAddress is the change address used for the swap.
-	RefundAddress() string
 }
 
 // AuditInfo is audit information about a swap contract needed to audit the

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -2056,9 +2056,7 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 	}
 
 	if len(redemptionConfirms) > 0 {
-		for _, match := range redemptionConfirms {
-			t.confirmRedemption(match)
-		}
+		t.confirmRedemptions(redemptionConfirms)
 	}
 
 	for _, match := range dynamicSwapFeeConfirms {
@@ -2470,6 +2468,11 @@ func (c *Core) swapMatchGroup(t *trackedTrade, matches []*matchTracker, errs *er
 			proof.MakerSwap = coinID
 			match.Status = order.MakerSwapCast
 		}
+
+		if rr, is := receipt.(asset.RefundReceipt); is {
+			proof.RefundAddress = rr.RefundAddress()
+		}
+
 		if err := t.db.UpdateMatch(&match.MetaMatch); err != nil {
 			errs.add("error storing swap details in database for match %s, coin %s: %v",
 				match, coinIDString(fromWallet.AssetID, coinID), err)
@@ -2847,45 +2850,63 @@ func (t *trackedTrade) redeemFee() uint64 {
 	return feeSuggestion
 }
 
+// confirmRedemption attemps to confirm the redemptions for each match, and
+// then return any refund addresses that we won't be using.
+func (t *trackedTrade) confirmRedemptions(matches []*matchTracker) {
+	var refundAddrs []string
+	for _, m := range matches {
+		if confirmed, err := t.confirmRedemption(m); err != nil {
+			t.dc.log.Errorf("Unable to confirm redemption: %v", err)
+		} else if confirmed && m.MetaData.Proof.RefundAddress != "" {
+			refundAddrs = append(refundAddrs, m.MetaData.Proof.RefundAddress)
+		}
+	}
+	if len(refundAddrs) == 0 {
+		return
+	}
+	if ar, is := t.wallets.fromWallet.Wallet.(asset.AddressReturner); is {
+		ar.ReturnAddress(refundAddrs...)
+	}
+}
+
 // confirmRedemption checks if the user's redemption has been confirmed,
 // and if so, updates the match's status to MatchConfirmed.
 //
 // This method accesses match fields and MUST be called with the trackedTrade
 // mutex lock held for writes.
-func (t *trackedTrade) confirmRedemption(match *matchTracker) {
+func (t *trackedTrade) confirmRedemption(match *matchTracker) (bool, error) {
 	// In some cases the wallet will need to send a new redeem transaction.
 	toWallet := t.wallets.toWallet
 
 	if toWallet.peerCount < 1 {
-		t.dc.log.Errorf("Unable to confirm redemption. %s wallet has no peers.", unbip(toWallet.AssetID))
-		return
+		return false, fmt.Errorf("%s wallet has no peers", unbip(toWallet.AssetID))
 	}
 
 	if !toWallet.synchronized() {
-		t.dc.log.Errorf("Unable to confirm redemption. %s still syncing.", unbip(toWallet.AssetID))
-		return
+		return false, fmt.Errorf("%s still syncing", unbip(toWallet.AssetID))
 	}
 
 	didUnlock, err := toWallet.refreshUnlock()
 	if err != nil { // Just log it and try anyway.
-		t.dc.log.Errorf("refreshUnlock error checking redeem %s: %v", t.wallets.toWallet.Symbol, err)
+		t.dc.log.Errorf("refreshUnlock error checking redeem %s: %v", toWallet.Symbol, err)
 	}
 	if didUnlock {
-		t.dc.log.Warnf("Unexpected unlock needed for the %s wallet to check a redemption", t.wallets.toWallet.Symbol)
+		t.dc.log.Warnf("Unexpected unlock needed for the %s wallet to check a redemption", toWallet.Symbol)
 	}
 
+	proof := &match.MetaData.Proof
 	var redeemCoinID order.CoinID
 	if match.Side == order.Maker {
-		redeemCoinID = match.MetaData.Proof.MakerRedeem
+		redeemCoinID = proof.MakerRedeem
 	} else {
-		redeemCoinID = match.MetaData.Proof.TakerRedeem
+		redeemCoinID = proof.TakerRedeem
 	}
 
 	match.confirmRedemptionNumTries++
 
 	redemptionStatus, err := toWallet.Wallet.ConfirmRedemption(dex.Bytes(redeemCoinID), &asset.Redemption{
 		Spends: match.counterSwap,
-		Secret: match.MetaData.Proof.Secret,
+		Secret: proof.Secret,
 	}, t.redeemFee())
 	if errors.Is(asset.ErrSwapRefunded, err) {
 		subject, details := t.formatDetails(TopicSwapRefunded, match.token(), t.token())
@@ -2896,21 +2917,20 @@ func (t *trackedTrade) confirmRedemption(match *matchTracker) {
 		if err != nil {
 			t.dc.log.Errorf("Failed to update match in db %v", err)
 		}
-		return
+		return false, errors.New("swap was already refunded by the counterparty")
 	} else if err != nil {
-		t.dc.log.Errorf("Error confirming redemption for coin %v. Already tried %d times, will retry later: %v.",
-			redeemCoinID, match.confirmRedemptionNumTries, err)
 		match.delayTicks(time.Minute * 15)
-		return
+		return false, fmt.Errorf("error confirming redemption for coin %v. already tried %d times, will retry later: %v",
+			redeemCoinID, match.confirmRedemptionNumTries, err)
 	}
 
 	var redemptionResubmitted, redemptionConfirmed bool
 	if !bytes.Equal(redeemCoinID, redemptionStatus.CoinID) {
 		redemptionResubmitted = true
 		if match.Side == order.Maker {
-			match.MetaData.Proof.MakerRedeem = order.CoinID(redemptionStatus.CoinID)
+			proof.MakerRedeem = order.CoinID(redemptionStatus.CoinID)
 		} else {
-			match.MetaData.Proof.TakerRedeem = order.CoinID(redemptionStatus.CoinID)
+			proof.TakerRedeem = order.CoinID(redemptionStatus.CoinID)
 		}
 	}
 
@@ -2945,6 +2965,7 @@ func (t *trackedTrade) confirmRedemption(match *matchTracker) {
 		note := newMatchNote(TopicConfirms, "", "", db.Data, t, match)
 		t.notify(note)
 	}
+	return redemptionConfirmed, nil
 }
 
 // findMakersRedemption starts a goroutine to search for the redemption of
@@ -3523,6 +3544,9 @@ func (t *trackedTrade) returnCoins() {
 			t.dc.log.Warnf("Unable to return %s funding coins: %v", t.wallets.fromWallet.Symbol, err)
 		} else {
 			t.coinsLocked = false
+		}
+		if returner, is := t.wallets.toWallet.Wallet.(asset.AddressReturner); is {
+			returner.ReturnAddress(t.Trade().Address)
 		}
 	} else if t.change != nil && t.changeLocked {
 		err := t.wallets.fromWallet.ReturnCoins(asset.Coins{t.change})

--- a/client/db/types.go
+++ b/client/db/types.go
@@ -622,8 +622,6 @@ type MatchProof struct {
 	// RedemptionFeeConfirmed indicate the fees for this match have been
 	// confirmed and the value added to the trade.
 	RedemptionFeeConfirmed bool
-	// RefundAddress stores the refund address used in the swap contract.
-	RefundAddress string
 }
 
 func boolByte(b bool) []byte {
@@ -635,8 +633,8 @@ func boolByte(b bool) []byte {
 
 // MatchProofVer is the current serialization version of a MatchProof.
 const (
-	MatchProofVer    = 4
-	matchProofPushes = 25
+	MatchProofVer    = 3
+	matchProofPushes = 24
 )
 
 // Encode encodes the MatchProof to a versioned blob.
@@ -666,8 +664,7 @@ func (p *MatchProof) Encode() []byte {
 		AddData(boolByte(p.SelfRevoked)).
 		AddData(p.CounterTxData).
 		AddData(boolByte(p.SwapFeeConfirmed)).
-		AddData(boolByte(p.RedemptionFeeConfirmed)).
-		AddData([]byte(p.RefundAddress))
+		AddData(boolByte(p.RedemptionFeeConfirmed))
 }
 
 // DecodeMatchProof decodes the versioned blob to a *MatchProof.
@@ -677,9 +674,6 @@ func DecodeMatchProof(b []byte) (*MatchProof, uint8, error) {
 		return nil, 0, err
 	}
 	switch ver {
-	case 4:
-		proof, err := decodeMatchProof_v4(pushes)
-		return proof, ver, err
 	case 3: // MatchProofVer
 		proof, err := decodeMatchProof_v3(pushes)
 		return proof, ver, err
@@ -714,11 +708,6 @@ func decodeMatchProof_v2(pushes [][]byte) (*MatchProof, error) {
 }
 
 func decodeMatchProof_v3(pushes [][]byte) (*MatchProof, error) {
-	pushes = append(pushes, []byte("")) // refund address
-	return decodeMatchProof_v4(pushes)
-}
-
-func decodeMatchProof_v4(pushes [][]byte) (*MatchProof, error) {
 	if len(pushes) != matchProofPushes {
 		return nil, fmt.Errorf("DecodeMatchProof: expected %d pushes, got %d",
 			matchProofPushes, len(pushes))
@@ -750,7 +739,6 @@ func decodeMatchProof_v4(pushes [][]byte) (*MatchProof, error) {
 		SelfRevoked:            bytes.Equal(pushes[20], encode.ByteTrue),
 		SwapFeeConfirmed:       bytes.Equal(pushes[21], encode.ByteTrue),
 		RedemptionFeeConfirmed: bytes.Equal(pushes[22], encode.ByteTrue),
-		RefundAddress:          string(pushes[23]),
 	}, nil
 }
 


### PR DESCRIPTION
Concerns about overshooting the gap policy have come up. This enables a file-backed recycled address cache for unused redemption and refund addresses.