### PR TITLE
dexc-desktop: Use macdrive for Darwin

### DIFF
--- a/client/cmd/dexc-desktop/app.go
+++ b/client/cmd/dexc-desktop/app.go
@@ -341,7 +341,7 @@ func runWebview(url string) {
 	w.SetTitle(appTitle)
 	w.SetSize(600, 600, webview.HintMin)
 
-	width, height := defaultWindowWidthAndHeight()
+	width, height := limitedWindowWidthAndHeight(int(C.display_width()), int(C.display_height()))
 
 	w.SetSize(width, height, webview.HintNone)
 	w.Navigate(url)

--- a/client/cmd/dexc-desktop/app.go
+++ b/client/cmd/dexc-desktop/app.go
@@ -2,6 +2,50 @@
 
 package main
 
+// Full screen cgo solution. Seems to work on Debian.
+// TODO: Check multi-screen.
+// https://github.com/webview/webview/issues/458#issuecomment-738034846
+
+/*
+#cgo darwin LDFLAGS: -framework CoreGraphics
+#cgo linux pkg-config: x11
+#if defined(__APPLE__)
+#include <CoreGraphics/CGDisplayConfiguration.h>
+int display_width() {
+	return CGDisplayPixelsWide(CGMainDisplayID());
+}
+int display_height() {
+	return CGDisplayPixelsHigh(CGMainDisplayID());
+}
+#elif defined(_WIN32)
+#include <wtypes.h>
+int display_width() {
+	RECT desktop;
+	const HWND hDesktop = GetDesktopWindow();
+	GetWindowRect(hDesktop, &desktop);
+	return desktop.right;
+}
+int display_height() {
+	RECT desktop;
+	const HWND hDesktop = GetDesktopWindow();
+	GetWindowRect(hDesktop, &desktop);
+	return desktop.bottom;
+}
+#else
+#include <X11/Xlib.h>
+int display_width() {
+	Display* d = XOpenDisplay(NULL);
+	Screen*  s = DefaultScreenOfDisplay(d);
+	return s->width;
+}
+int display_height() {
+	Display* d = XOpenDisplay(NULL);
+	Screen*  s = DefaultScreenOfDisplay(d);
+	return s->height;
+}
+#endif
+*/
+import "C"
 import (
 	"context"
 	"errors"

--- a/client/cmd/dexc-desktop/app.go
+++ b/client/cmd/dexc-desktop/app.go
@@ -1,0 +1,457 @@
+//go:build !darwin
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"sync"
+	"syscall"
+	"time"
+
+	"decred.org/dcrdex/client/app"
+	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/client/mm"
+	"decred.org/dcrdex/client/rpcserver"
+	"decred.org/dcrdex/client/webserver"
+	"decred.org/dcrdex/dex"
+	"fyne.io/systray"
+	"github.com/webview/webview"
+)
+
+func mainCore() error {
+	appCtx, cancel := context.WithCancel(context.Background())
+	defer cancel() // don't leak on the earliest returns
+
+	// Parse configuration.
+	cfg, err := configure()
+	if err != nil {
+		return fmt.Errorf("configuration error: %w", err)
+	}
+
+	// Filter registered assets.
+	asset.SetNetwork(cfg.Net)
+
+	// A single process cannot run multiple webview windows, so we run webview
+	// as a subprocess. We could create a simpler webview binary to call that
+	// would be substantially smaller than the dexc binary, but when done that
+	// way, the opened window does not have the icon that the system associates
+	// with dexc and taskbar icons won't be stacked. Instead, we'll create a
+	// short path here and execute ourself with the --webview flag.
+	if cfg.Webview != "" {
+		runWebview(cfg.Webview)
+		return nil
+	}
+
+	// Initialize logging.
+	utc := !cfg.LocalLogs
+	logMaker, closeLogger := app.InitLogging(cfg.LogPath, cfg.DebugLevel, cfg.LogStdout, utc)
+	defer closeLogger()
+	log = logMaker.Logger("APP")
+	log.Infof("%s version %s (Go version %s)", appName, app.Version, runtime.Version())
+	if utc {
+		log.Infof("Logging with UTC time stamps. Current local time is %v",
+			time.Now().Local().Format("15:04:05 MST"))
+	}
+
+	syncDir := filepath.Join(cfg.AppData, cfg.Net.String())
+
+	// The --kill flag is a backup measure to end a background process (that
+	// presumably has active orders).
+	if cfg.Kill {
+		sendKillSignal(syncDir)
+		return nil
+	}
+
+	startServer, err := synchronize(syncDir)
+	if err != nil || !startServer {
+		// If we didn't start the server but there is no error, and it means
+		// that we've successfully sent an open window request to an already
+		// running instance.
+		return err
+	}
+
+	if cfg.CPUProfile != "" {
+		f, err := os.Create(cfg.CPUProfile)
+		if err != nil {
+			return fmt.Errorf("error starting CPU profiler: %w", err)
+		}
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			return fmt.Errorf("error starting CPU profiler: %w", err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	defer func() {
+		if pv := recover(); pv != nil {
+			log.Criticalf("Uh-oh! \n\nPanic:\n\n%v\n\nStack:\n\n%v\n\n",
+				pv, string(debug.Stack()))
+		}
+	}()
+
+	// Prepare the Core.
+	clientCore, err := core.New(cfg.Core(logMaker.Logger("CORE")))
+	if err != nil {
+		return fmt.Errorf("error creating client core: %w", err)
+	}
+
+	// Handle shutdown by user (if running via terminal), or on system shutdown.
+	// TODO: SIGTERM is apparently spoofed by Go for Windows. Nice feature, but
+	// not well documented. Test to verify. Could also catch SIGKILL, which is
+	// sent after a configured timeout if the program doesn't exit on SIGTERM.
+	killChan := make(chan os.Signal, 1)
+	signal.Notify(killChan, os.Interrupt /* ctrl-c */, syscall.SIGTERM /* system shutdown */)
+	go func() {
+		for range killChan {
+			log.Infof("Shutting down...")
+			cancel()
+			return
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		clientCore.Run(appCtx)
+		cancel() // in the event that Run returns prematurely prior to context cancellation
+	}()
+
+	<-clientCore.Ready()
+
+	defer func() {
+		log.Info("Exiting dexc main.")
+		cancel()  // no-op with clean rpc/web server setup
+		wg.Wait() // no-op with clean setup and shutdown
+	}()
+
+	var marketMaker *mm.MarketMaker
+	if cfg.Experimental {
+		// TODO: on shutdown, stop market making and wait for trades to be
+		// canceled.
+		marketMaker, err = mm.NewMarketMaker(clientCore, logMaker.Logger("MM"))
+		if err != nil {
+			return fmt.Errorf("error creating market maker: %w", err)
+		}
+	}
+
+	if cfg.RPCOn {
+		rpcSrv, err := rpcserver.New(cfg.RPC(clientCore, marketMaker, logMaker.Logger("RPC")))
+		if err != nil {
+			return fmt.Errorf("failed to create rpc server: %w", err)
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cm := dex.NewConnectionMaster(rpcSrv)
+			err := cm.Connect(appCtx)
+			if err != nil {
+				log.Errorf("Error starting rpc server: %v", err)
+				cancel()
+				return
+			}
+			cm.Wait()
+		}()
+	}
+
+	webSrv, err := webserver.New(cfg.Web(clientCore, logMaker.Logger("WEB"), utc))
+	if err != nil {
+		return fmt.Errorf("failed creating web server: %w", err)
+	}
+
+	webStart := make(chan error)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cm := dex.NewConnectionMaster(webSrv)
+		webStart <- cm.Connect(appCtx)
+		cm.Wait()
+	}()
+
+	if err := <-webStart; err != nil {
+		return err
+	}
+
+	// No errors running webserver, so we can be certain we won any race between
+	// starting instances. Start the sync server now.
+	openC := make(chan struct{}) // no buffer. Is ignored if window is currently open
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runServer(appCtx, syncDir, openC, killChan, cfg.Net)
+	}()
+
+	openWindow := func() {
+		wg.Add(1)
+		go func() {
+			runWebviewSubprocess(appCtx, "http://"+webSrv.Addr())
+			wg.Done()
+		}()
+	}
+
+	openWindow()
+
+	wg.Add(1)
+	go func() {
+		defer func() {
+			systray.SetTooltip("Shutting down. Please wait...")
+			systray.Quit()
+			wg.Done()
+			defer cancel()
+		}()
+	windowloop:
+		for {
+			var backgroundNoteSent bool
+			select {
+			case <-windowManager.zeroLeft:
+				if windowManager.persist.Load() {
+					continue // ignore
+				}
+			logout:
+				for {
+					err := clientCore.Logout()
+					if err == nil {
+						// Okay to quit.
+						break windowloop
+					}
+					if !errors.Is(err, core.ActiveOrdersLogoutErr) {
+						// Unknown error. Force shutdown.
+						log.Errorf("Core logout error: %v", err)
+						break windowloop
+					}
+					if !backgroundNoteSent {
+						sendDesktopNotification("DEX client still running", "DEX client is still resolving active DEX orders")
+						backgroundNoteSent = true
+					}
+					// Can't log out. Keep checking until either
+					//   1. We can log out. Exit the program.
+					//   2. The user reopens the window (via syncserver).
+					select {
+					case <-time.After(time.Minute):
+						// Try to log out again.
+						continue logout
+					case <-openC:
+						// re-open the window
+						openWindow()
+						continue windowloop
+					case <-appCtx.Done():
+						break windowloop
+					}
+				}
+			case <-appCtx.Done():
+				break windowloop
+			case <-openC:
+				openWindow()
+			}
+		}
+	}()
+
+	activeState := make(chan bool, 8)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		active := true // starting with "Force Quit"
+		for {
+			select {
+			case <-time.After(time.Second):
+				// inelegant polling? Even Core doesn't know until it checks, so
+				// can't feasibly rig a signal from Core without changes there.
+				coreActive := clientCore.Active()
+				if coreActive != active {
+					active = coreActive
+					activeState <- coreActive
+				}
+			case <-appCtx.Done():
+				return
+			}
+		}
+	}()
+
+	systray.Run(func() {
+		systrayOnReady(appCtx, filepath.Dir(cfg.LogPath), openC, killChan, activeState)
+	}, nil)
+
+	closeAllWindows()
+
+	log.Infof("Shutting down...")
+	cancel()
+	wg.Wait()
+
+	return nil
+}
+
+var windowManager = &struct {
+	sync.Mutex
+	counter  uint32
+	windows  map[uint32]*exec.Cmd
+	zeroLeft chan struct{}
+	persist  atomic.Bool
+}{
+	windows:  make(map[uint32]*exec.Cmd),
+	zeroLeft: make(chan struct{}, 1),
+}
+
+func closeWindow(windowID uint32) {
+	m := windowManager
+	m.Lock()
+	cmd, found := m.windows[windowID]
+	if !found {
+		m.Unlock()
+		// Probably killed by caller via closeAllWindows.
+		return
+	}
+	delete(m.windows, windowID)
+	remain := len(m.windows)
+	m.Unlock()
+	if remain == 0 {
+		select {
+		case m.zeroLeft <- struct{}{}:
+		default:
+		}
+	}
+	log.Infof("Closing window. %d windows remain open.", remain)
+	cmd.Process.Kill()
+}
+
+func closeAllWindows() {
+	m := windowManager
+	m.Lock()
+	defer m.Unlock()
+	for windowID, cmd := range m.windows {
+		cmd.Process.Kill()
+		delete(m.windows, windowID)
+	}
+}
+
+func runWebview(url string) {
+	w := webview.New(true)
+	defer w.Destroy()
+	w.SetTitle(appTitle)
+	w.SetSize(600, 600, webview.HintMin)
+
+	width, height := defaultWindowWidthAndHeight()
+
+	w.SetSize(width, height, webview.HintNone)
+	w.Navigate(url)
+	w.Run()
+}
+
+func runWebviewSubprocess(ctx context.Context, url string) {
+	cmd := exec.CommandContext(ctx, exePath, "--webview", url)
+	if err := cmd.Start(); err != nil {
+		log.Errorf("webview start error: %v", err)
+		return
+	}
+	m := windowManager
+	m.Lock()
+	m.counter++
+	windowID := windowManager.counter
+	m.windows[windowID] = cmd
+	windowCount := len(m.windows)
+	m.Unlock()
+	defer closeWindow(windowID)
+	log.Infof("Opening new window. %d windows open now", windowCount)
+	if err := cmd.Wait(); err != nil {
+		log.Errorf("webview error: %v", err)
+	}
+}
+
+func systrayOnReady(ctx context.Context, logDirectory string, openC chan<- struct{},
+	killC chan<- os.Signal, activeState <-chan bool) {
+	systray.SetIcon(FavIcon)
+	systray.SetTitle("DEX client")
+	systray.SetTooltip("Self-custodial multi-wallet")
+
+	// TODO: Consider reworking main so we can show the icon earlier?
+	// mStarting := systray.AddMenuItem("Starting...", "Starting up. Please wait...")
+	// var addr string
+	// var ok bool
+	// select {
+	// case addr, ok = <-webserverReady:
+	// 	if !ok { // no webserver started
+	// 		fmt.Fprintln(os.Stderr, "Web server required!")
+	// 		cancel()
+	// 		return
+	// 	}
+	// case <-mainDone:
+	// 	return
+	// }
+
+	// mStarting.Hide()
+
+	mOpen := systray.AddMenuItem("Open", "Open DEX client window")
+	mOpen.SetIcon(SymbolBWIcon)
+	go func() {
+		for range mOpen.ClickedCh {
+			select {
+			case openC <- struct{}{}:
+				log.Debug("Received window reopen request from system tray")
+			default:
+				log.Infof("Ignored a window open request from the system tray")
+			}
+		}
+	}()
+
+	systray.AddSeparator()
+
+	if logDirURL, err := app.FilePathToURL(logDirectory); err != nil {
+		log.Errorf("error constructing log directory URL: %v", err)
+	} else {
+		mLogs := systray.AddMenuItem("Open logs folder", "Open the folder with your DEX logs.")
+		go func() {
+			for range mLogs.ClickedCh {
+				log.Debug("Opening browser to log directory at", logDirURL)
+				runWebviewSubprocess(ctx, logDirURL)
+			}
+		}()
+	}
+
+	systray.AddSeparator()
+
+	mPersist := systray.AddMenuItemCheckbox("Persist after windows closed.",
+		"Keep the process running after all windows are closed. "+
+			"Shutdown is initiated through the Quit item in the system tray menu.", false)
+	go func() {
+		for range mPersist.ClickedCh {
+			var persisting = !mPersist.Checked() // toggle
+			if persisting {
+				mPersist.Check()
+			} else {
+				mPersist.Uncheck()
+			}
+			windowManager.persist.Store(persisting)
+		}
+	}()
+
+	mQuit := systray.AddMenuItem("Force Quit", "Force DEX client to close with active orders.")
+	go func() {
+		for {
+			select {
+			case active := <-activeState:
+				if active {
+					mQuit.SetTitle("Force Quit")
+					mQuit.SetTooltip("Force DEX client to close with active orders.")
+				} else {
+					mQuit.SetTitle("Quit")
+					mQuit.SetTooltip("Shutdown the DEX client. You have no active orders.")
+				}
+			case <-mQuit.ClickedCh:
+				mOpen.Disable()
+				mQuit.Disable()
+				killC <- os.Interrupt
+				return
+			}
+		}
+	}()
+}

--- a/client/cmd/dexc-desktop/app.go
+++ b/client/cmd/dexc-desktop/app.go
@@ -14,6 +14,7 @@ import (
 	"runtime/debug"
 	"runtime/pprof"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 

--- a/client/cmd/dexc-desktop/app_darwin.go
+++ b/client/cmd/dexc-desktop/app_darwin.go
@@ -379,6 +379,7 @@ func createNewWebView() {
 	webView := webkit.WKWebView_Init(mdCore.Rect(0, 0, float64(width), float64(height)), webviewConfig)
 	webView.Object.Class().AddMethod(selIsNewWebview, func(_ objc.Object) objc.Object { return mdCore.True })
 	webView.LoadRequest(req)
+	webView.SetAllowsBackForwardNavigationGestures_(true)
 	webView.SetUIDelegate_(cocoa.DefaultDelegate)
 	webView.SetNavigationDelegate_(cocoa.DefaultDelegate)
 }

--- a/client/cmd/dexc-desktop/app_darwin.go
+++ b/client/cmd/dexc-desktop/app_darwin.go
@@ -478,7 +478,7 @@ func createMainMenuItems() []cocoa.NSMenu {
 
 	appMenu.AddItem(cocoa.NSMenuItem_Separator())
 
-	quitMenuItem := cocoa.NSMenuItem_Init("Quit Decred DEX", objc.Sel("terminate:"), "q")
+	quitMenuItem := cocoa.NSMenuItem_Init("Quit "+macOSAppTitle, objc.Sel("terminate:"), "q")
 	quitMenuItem.SetToolTip("Force DEX client to close")
 	appMenu.AddItem(quitMenuItem)
 
@@ -540,17 +540,17 @@ func lockDexcDesktopStateFile(path string) (io.Closer, error) {
 		}
 
 		if err := os.Remove(path); err != nil {
-			return nil, fmt.Errorf("lockDexcDesktopStateFile: failed to remove lock file %s %v", path, err)
+			return nil, fmt.Errorf("lockDexcDesktopStateFile: failed to remove lock file %s: %w", path, err)
 		}
 	}
 
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_EXCL, 0666)
 	if err != nil {
-		return nil, fmt.Errorf("lockDexcDesktopStateFile: failed to create lock file %s %v", path, err)
+		return nil, fmt.Errorf("lockDexcDesktopStateFile: failed to create lock file %s: %w", path, err)
 	}
 
 	if _, err := f.WriteString(fmt.Sprintf("%d", os.Getpid())); err != nil {
-		return nil, fmt.Errorf("lockDexcDesktopStateFile: cannot write owner pid: %v", err)
+		return nil, fmt.Errorf("lockDexcDesktopStateFile: cannot write owner pid: %w", err)
 	}
 
 	return f, nil

--- a/client/cmd/dexc-desktop/app_darwin.go
+++ b/client/cmd/dexc-desktop/app_darwin.go
@@ -1,0 +1,380 @@
+//go:build darwin
+
+package main
+
+/*
+dexc-desktop is the Desktop version of the DEX Client. There are a number of
+differences that make this version more suitable for less tech-savvy users.
+
+| CLI version                       | Desktop version                          |
+|-----------------------------------|------------------------------------------|
+| Installed by building from source | Installed with an installer program.     |
+| or downloading a binary. Or with  | (e.g a .dmg MacOS installer)             |
+| dcrinstall from a terminal.       |                                          |
+|-----------------------------------|------------------------------------------|
+| Started by command-line.          | Started by selecting from the start/main |
+|                                   | menu, or by selecting a desktop icon or  |
+|                                   | pinned taskbar icon. CLI is fine too.    |
+|                                   |                                          |
+|-----------------------------------|------------------------------------------|
+| Accessed by going to localhost    | Opens in WebView, a simple window        |
+| address in the browser.           | backed by a web engine.                  |
+|-----------------------------------|------------------------------------------|
+| Shutdown via ctrl-c signal.       | When user closes window, continues       |
+| Prompt user to force shutdown if  | running in the background if there are   |
+| there are active orders.          | active orders. Run a little server that  |
+|                                   | synchronizes at start-up, enabling the   |
+|                                   | window to be reopened when the user      |
+|                                   | tries to start another instance. A       |
+|                                   | desktop notification is sent and the     |
+|                                   | system tray icon remains in the tray.    |
+|-----------------------------------|------------------------------------------|
+
+Both versions use the same default client configuration file locations at
+AppDataDir("dexc").
+
+The program will continue to run in the background even if all windows are
+closed. This is the default behavior for MacOS apps but new windows can be
+created by clicking on the icon in the dock.
+*/
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"runtime/pprof"
+	"sync"
+	"syscall"
+	"time"
+
+	"decred.org/dcrdex/client/app"
+	"decred.org/dcrdex/client/asset"
+	_ "decred.org/dcrdex/client/asset/bch"  // register bch asset
+	_ "decred.org/dcrdex/client/asset/btc"  // register btc asset
+	_ "decred.org/dcrdex/client/asset/dcr"  // register dcr asset
+	_ "decred.org/dcrdex/client/asset/dgb"  // register dgb asset
+	_ "decred.org/dcrdex/client/asset/doge" // register doge asset
+	_ "decred.org/dcrdex/client/asset/firo" // register firo asset
+	_ "decred.org/dcrdex/client/asset/ltc"  // register ltc asset
+	_ "decred.org/dcrdex/client/asset/zec"  // register zec asset
+	dexCore "decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/client/mm"
+	"decred.org/dcrdex/client/rpcserver"
+	"decred.org/dcrdex/client/webserver"
+	"decred.org/dcrdex/dex"
+	"github.com/pkg/browser"
+	"github.com/progrium/macdriver/cocoa"
+	"github.com/progrium/macdriver/core"
+	"github.com/progrium/macdriver/objc"
+	"github.com/progrium/macdriver/webkit"
+	// Ethereum loaded in client/app/importlgpl.go
+)
+
+func init() {
+	runtime.LockOSThread()
+}
+
+var nOpenWindows int
+
+// createNewAppWindow creates a new window with the specified URL. Only one
+// window can be open at a time to portray the feel of a native app. We can
+// allow multiple windows in the future if needed.
+func createNewAppWindow(url string) {
+	if nOpenWindows > 0 {
+		return
+	}
+	nOpenWindows++
+
+	// Prepare webview config.
+	config := webkit.WKWebViewConfiguration_New()
+	config.Preferences().SetValueForKey(core.True, core.String("developerExtrasEnabled"))
+	width, height := defaultWindowWidthAndHeight()
+
+	// Create a new webview and load the provided url.
+	webView := webkit.WKWebView_Init(core.Rect(0, 0, float64(width), float64(height)), config)
+	req := core.NSURLRequest_Init(core.URL(url))
+	webView.LoadRequest(req)
+
+	// Create a new window and set the webview as its content view.
+	win := cocoa.NSWindow_Init(core.NSMakeRect(0, 0, 1440, 900), cocoa.NSClosableWindowMask|cocoa.NSTitledWindowMask|cocoa.NSResizableWindowMask|cocoa.NSFullSizeContentViewWindowMask|cocoa.NSMiniaturizableWindowMask, cocoa.NSBackingStoreBuffered, false)
+	win.SetTitle("Decred DEX Client")
+	win.Center()
+	win.SetMovable_(true)
+	win.MakeKeyAndOrderFront(nil)
+	win.SetContentView(webView)
+	win.SetMinSize_(core.NSSize{Width: 600, Height: 600})
+	win.SetDelegate_(cocoa.DefaultDelegate)
+}
+
+// mainCore is the darwin entry point for the DEX Desktop client.
+func mainCore() error {
+	appCtx, cancel := context.WithCancel(context.Background())
+	defer cancel() // don't leak on the earliest returns
+
+	// Parse configuration.
+	cfg, err := configure()
+	if err != nil {
+		return fmt.Errorf("configuration error: %w", err)
+	}
+
+	// Filter registered assets.
+	asset.SetNetwork(cfg.Net)
+
+	if cfg.Webview != "" { // Ignore, other OS use this for a specific reason (to support multiple windows).
+		return nil
+	}
+
+	// Initialize logging.
+	utc := !cfg.LocalLogs
+	logMaker, closeLogger := app.InitLogging(cfg.LogPath, cfg.DebugLevel, cfg.LogStdout, utc)
+	defer closeLogger()
+	log = logMaker.Logger("APP")
+	log.Infof("%s version %s (Go version %s)", appName, app.Version, runtime.Version())
+	if utc {
+		log.Infof("Logging with UTC time stamps. Current local time is %v",
+			time.Now().Local().Format("15:04:05 MST"))
+	}
+
+	syncDir := filepath.Join(cfg.AppData, cfg.Net.String())
+
+	// The --kill flag is a backup measure to end a background process (that
+	// presumably has active orders).
+	if cfg.Kill {
+		sendKillSignal(syncDir)
+		return nil
+	}
+
+	startServer, err := synchronize(syncDir)
+	if err != nil || !startServer {
+		// If we didn't start the server but there is no error, and it means
+		// that we've successfully sent an open window request to an already
+		// running instance.
+		return err
+	}
+
+	if cfg.CPUProfile != "" {
+		f, err := os.Create(cfg.CPUProfile)
+		if err != nil {
+			return fmt.Errorf("error starting CPU profiler: %w", err)
+		}
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			return fmt.Errorf("error starting CPU profiler: %w", err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	defer func() {
+		if pv := recover(); pv != nil {
+			log.Criticalf("Uh-oh! \n\nPanic:\n\n%v\n\nStack:\n\n%v\n\n",
+				pv, string(debug.Stack()))
+		}
+	}()
+
+	// Prepare the Core.
+	clientCore, err := dexCore.New(cfg.Core(logMaker.Logger("CORE")))
+	if err != nil {
+		return fmt.Errorf("error creating client core: %w", err)
+	}
+
+	// Handle shutdown by user (if running via terminal), or on system shutdown.
+	// TODO: SIGTERM is apparently spoofed by Go for Windows. Nice feature, but
+	// not well documented. Test to verify. Could also catch SIGKILL, which is
+	// sent after a configured timeout if the program doesn't exit on SIGTERM.
+	killChan := make(chan os.Signal, 1)
+	signal.Notify(killChan, os.Interrupt /* ctrl-c */, syscall.SIGTERM /* system shutdown */, syscall.SIGQUIT /* ctrl-\ */)
+	go func() {
+		for range killChan {
+			log.Infof("Shutting down...")
+			cancel()
+			return
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		clientCore.Run(appCtx)
+		cancel() // in the event that Run returns prematurely prior to context cancellation
+	}()
+
+	<-clientCore.Ready()
+
+	defer func() {
+		log.Info("Exiting dexc main.")
+		cancel()  // no-op with clean rpc/web server setup
+		wg.Wait() // no-op with clean setup and shutdown
+	}()
+
+	var marketMaker *mm.MarketMaker
+	if cfg.Experimental {
+		// TODO: on shutdown, stop market making and wait for trades to be
+		// canceled.
+		marketMaker, err = mm.NewMarketMaker(clientCore, logMaker.Logger("MM"))
+		if err != nil {
+			return fmt.Errorf("error creating market maker: %w", err)
+		}
+	}
+
+	if cfg.RPCOn {
+		rpcSrv, err := rpcserver.New(cfg.RPC(clientCore, marketMaker, logMaker.Logger("RPC")))
+		if err != nil {
+			return fmt.Errorf("failed to create rpc server: %w", err)
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cm := dex.NewConnectionMaster(rpcSrv)
+			err := cm.Connect(appCtx)
+			if err != nil {
+				log.Errorf("Error starting rpc server: %v", err)
+				cancel()
+				return
+			}
+			cm.Wait()
+		}()
+	}
+
+	webSrv, err := webserver.New(cfg.Web(clientCore, logMaker.Logger("WEB"), utc))
+	if err != nil {
+		return fmt.Errorf("failed creating web server: %w", err)
+	}
+
+	webStart := make(chan error)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cm := dex.NewConnectionMaster(webSrv)
+		webStart <- cm.Connect(appCtx)
+		cm.Wait()
+	}()
+
+	if err := <-webStart; err != nil {
+		return err
+	}
+
+	// No errors running webserver, so we can be certain we won any race between
+	// starting instances. Start the sync server now.
+	openC := make(chan struct{}) // no buffer. Is ignored if window is currently open
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runServer(appCtx, syncDir, openC, killChan, cfg.Net)
+	}()
+
+	url := "http://" + webSrv.Addr()
+	logDir := filepath.Dir(cfg.LogPath)
+
+	// Set to false so that the app doesn't exit when the last window is closed.
+	cocoa.TerminateAfterWindowsClose = false
+
+	addMethodToDelegate("applicationDockMenu:", func(_ objc.Object) objc.Object {
+		newWindowItem := cocoa.NSMenuItem_New()
+		newWindowItem.SetTitle("New Window")
+		newWindowItem.SetAction(objc.Sel("newWindow:"))
+		addMethodToDelegate("newWindow:", func(_ objc.Object) {
+			createNewAppWindow(url)
+		})
+
+		openLogsItem := cocoa.NSMenuItem_New()
+		openLogsItem.SetTitle("Open Logs")
+		openLogsItem.SetAction(objc.Sel("openLogs:"))
+		addMethodToDelegate("openLogs:", func(_ objc.Object) {
+			logDirURL, err := app.FilePathToURL(logDir)
+			if err != nil {
+				log.Errorf("error constructing log directory URL: %v", err)
+			} else {
+				browser.OpenURL(logDirURL)
+			}
+		})
+
+		menu := cocoa.NSMenu_New()
+		menu.AddItem(newWindowItem)
+		menu.AddItem(openLogsItem)
+		return menu
+	})
+
+	// MacOS will always send the "windowWillClose" event when an application
+	// window is closing.
+	var noteSent bool
+	addMethodToDelegate("windowWillClose:", func(s objc.Object) {
+		nOpenWindows--
+
+		err := clientCore.Logout()
+		if err == nil {
+			return // nothing to do
+		}
+
+		if !errors.Is(err, dexCore.ActiveOrdersLogoutErr) {
+			log.Errorf("Core logout error: %v", err)
+			return
+		}
+
+		if nOpenWindows == 0 && !noteSent && cocoa.NSApp().IsRunning() { // last window has been closed but app is still running
+			noteSent = true
+			sendDesktopNotification("DEX client still running", "DEX client is still resolving active DEX orders")
+		}
+	})
+
+	// MacOS will always send this event when an application icon on the dock is
+	// clicked or a new process is about to start, so we hijack the action and
+	// create new windows if all windows have been closed.
+	addMethodToDelegate("applicationShouldHandleReopen:hasVisibleWindows:", func(_ objc.Object) bool {
+		if nOpenWindows < 1 {
+			// dexc-desktop is already running but there are no windows open so
+			// we should create a new window.
+			createNewAppWindow(url)
+		}
+
+		// dexc-desktop is already running and there's a window open so we can
+		// go ahead with the default action which is to bring the open window to
+		// the front.
+		return true
+	})
+
+	app := cocoa.NSApp_WithDidLaunch(func(notification objc.Object) {
+		createNewAppWindow(url)
+	})
+	app.SetActivationPolicy(cocoa.NSApplicationActivationPolicyRegular)
+	app.ActivateIgnoringOtherApps(false)
+	app.SetDelegate(cocoa.DefaultDelegate)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-appCtx.Done():
+				cocoa.NSApp().Terminate()
+				return
+			case <-killChan:
+				cocoa.NSApp().Terminate()
+				return
+			case <-openC:
+				// Execute on main thread.
+				core.Dispatch(func() {
+					createNewAppWindow(url)
+				})
+			}
+		}
+	}()
+
+	app.Run() // blocks until app.Terminate() is called
+	log.Infof("Shutting down...")
+	cancel()
+	wg.Wait()
+
+	return nil
+}
+
+// addMethodToDelegate adds a method to the default Cocoa delegate.
+func addMethodToDelegate(method string, fn interface{}) {
+	cocoa.DefaultDelegateClass.AddMethod(method, fn)
+}

--- a/client/cmd/dexc-desktop/config.go
+++ b/client/cmd/dexc-desktop/config.go
@@ -14,9 +14,9 @@ import (
 // Config is the configuration for the DEX client application.
 type Config struct {
 	app.Config
-	Kill      bool   `long:"kill" description:"Send a kill signal to a running instance and exit"`
+	Kill      bool   `long:"kill" description:"Send a kill signal to a running instance and exit. This is not be supported on darwin"`
 	LogStdout bool   `long:"stdout" description:"Log to stdout (in addition to the log file)"`
-	Webview   string `long:"webview" description:"Opens a webview window pointing to the provided URL. Does nothing else. Precludes applicability of any other settings."`
+	Webview   string `long:"webview" description:"Opens a webview window pointing to the provided URL but not supported on darwin. Does nothing else. Precludes applicability of any other settings."`
 }
 
 func configure() (*Config, error) {

--- a/client/cmd/dexc-desktop/go.mod
+++ b/client/cmd/dexc-desktop/go.mod
@@ -8,7 +8,7 @@ require (
 	decred.org/dcrdex v0.6.1
 	fyne.io/systray v1.10.1-0.20230403195833-7dc3c09283d6
 	github.com/gen2brain/beeep v0.0.0-20220909211152-5a9ec94374f6
-	github.com/progrium/macdriver v0.2.0
+	github.com/progrium/macdriver v0.4.0
 	github.com/webview/webview v0.0.0-20230415172654-8387ff8945fc
 )
 
@@ -173,7 +173,7 @@ require (
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.7.0 // indirect
+	golang.org/x/sys v0.9.0 // indirect
 	golang.org/x/term v0.6.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/client/cmd/dexc-desktop/go.mod
+++ b/client/cmd/dexc-desktop/go.mod
@@ -8,6 +8,7 @@ require (
 	decred.org/dcrdex v0.6.1
 	fyne.io/systray v1.10.1-0.20230403195833-7dc3c09283d6
 	github.com/gen2brain/beeep v0.0.0-20220909211152-5a9ec94374f6
+	github.com/progrium/macdriver v0.2.0
 	github.com/webview/webview v0.0.0-20230415172654-8387ff8945fc
 )
 
@@ -146,6 +147,7 @@ require (
 	github.com/mitchellh/pointerstructure v1.2.0 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/client/cmd/dexc-desktop/go.mod
+++ b/client/cmd/dexc-desktop/go.mod
@@ -147,7 +147,6 @@ require (
 	github.com/mitchellh/pointerstructure v1.2.0 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/client/cmd/dexc-desktop/go.sum
+++ b/client/cmd/dexc-desktop/go.sum
@@ -191,6 +191,9 @@ github.com/charithe/durationcheck v0.0.6/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6pr
 github.com/charithe/durationcheck v0.0.7/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6prSM8ap1UCpNKtgg=
 github.com/chavacava/garif v0.0.0-20210405163807-87a70f3d418b/go.mod h1:Qjyv4H3//PWVzTeCezG2b9IRn6myJxJSr4TD/xo6ojU=
 github.com/chavacava/garif v0.0.0-20210405164556-e8a0a408d6af/go.mod h1:Qjyv4H3//PWVzTeCezG2b9IRn6myJxJSr4TD/xo6ojU=
+github.com/chromedp/cdproto v0.0.0-20210323015217-0942afbea50e/go.mod h1:At5TxYYdxkbQL0TSefRjhLE3Q0lgvqKKMSFUglJ7i1U=
+github.com/chromedp/chromedp v0.6.10/go.mod h1:Q8L2uDLH9YFYbThK5fqPpyWa3CT4y9dqHLxaQr+Yhl8=
+github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -443,6 +446,7 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1 h1:ntEHSVwIt7PNXNpgPmVfMrNhLtgjlmnZha2kOpuRiDw=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
+github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
 github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4 h1:qZNfIGkIANxGv/OqtnntR4DfOY2+BgwR60cAcu/i3SE=
 github.com/go-toast/toast v0.0.0-20190211030409-01e6764cf0a4/go.mod h1:kW3HQ4UdaAyrUCSSDR4xUzBKW6O2iA4uHhk7AtyYp10=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
@@ -462,8 +466,11 @@ github.com/go-toolsmith/typep v1.0.2/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2
 github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
+github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
+github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/gobwas/ws v1.0.4/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -695,6 +702,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jrick/bitset v1.0.0 h1:Ws0PXV3PwXqWK2n7Vz6idCdrV/9OrBXgHEJi27ZB9Dw=
 github.com/jrick/bitset v1.0.0/go.mod h1:ZOYB5Uvkla7wIEY4FEssPVi3IQXa02arznRaYaAEPe4=
@@ -830,6 +838,7 @@ github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0Q
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
 github.com/matoous/godox v0.0.0-20210227103229-6504466cf951/go.mod h1:1BELzlh859Sh1c6+90blK8lbYy0kwQf1bYlBhBysy1s=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -976,6 +985,8 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -990,6 +1001,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/polyfloyd/go-errorlint v0.0.0-20210418123303-74da32850375/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
 github.com/polyfloyd/go-errorlint v0.0.0-20210510181950-ab96adb96fea/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
+github.com/progrium/macdriver v0.2.0 h1:+b90k/lyX0K0sV/aYs9EzWSgVhOFMGytKsnCsa1Uh7M=
+github.com/progrium/macdriver v0.2.0/go.mod h1:QkZLlOeMkYF92euEWqUBpry7/tXrZuM575xZRwnuiig=
+github.com/progrium/macschema v0.1.0/go.mod h1:XzxlqYAo4vKozoZd837LBMjPcfJNlvwB5yBn5Nu+RDE=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -1175,6 +1189,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
+github.com/ukane-philemon/webview v0.0.0-20230524200242-b3c1c693168d h1:gYjuQ1WaCs/7Pfm8hODyAv+r8GaqUuNd86KBrNpCQ8w=
+github.com/ukane-philemon/webview v0.0.0-20230524200242-b3c1c693168d/go.mod h1:MqUO4jptb337qa/AqX+puM8EAOEKC6S4dztGognyvK4=
 github.com/ultraware/funlen v0.0.3/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
@@ -1484,6 +1500,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/client/cmd/dexc-desktop/go.sum
+++ b/client/cmd/dexc-desktop/go.sum
@@ -191,8 +191,9 @@ github.com/charithe/durationcheck v0.0.6/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6pr
 github.com/charithe/durationcheck v0.0.7/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6prSM8ap1UCpNKtgg=
 github.com/chavacava/garif v0.0.0-20210405163807-87a70f3d418b/go.mod h1:Qjyv4H3//PWVzTeCezG2b9IRn6myJxJSr4TD/xo6ojU=
 github.com/chavacava/garif v0.0.0-20210405164556-e8a0a408d6af/go.mod h1:Qjyv4H3//PWVzTeCezG2b9IRn6myJxJSr4TD/xo6ojU=
-github.com/chromedp/cdproto v0.0.0-20210323015217-0942afbea50e/go.mod h1:At5TxYYdxkbQL0TSefRjhLE3Q0lgvqKKMSFUglJ7i1U=
-github.com/chromedp/chromedp v0.6.10/go.mod h1:Q8L2uDLH9YFYbThK5fqPpyWa3CT4y9dqHLxaQr+Yhl8=
+github.com/chromedp/cdproto v0.0.0-20230220211738-2b1ec77315c9/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
+github.com/chromedp/cdproto v0.0.0-20230625224106-7fafe342e117/go.mod h1:GKljq0VrfU4D5yc+2qA6OVr8pmO/MBbPEWqWQ/oqGEs=
+github.com/chromedp/chromedp v0.9.1/go.mod h1:DUgZWRvYoEfgi66CgZ/9Yv+psgi+Sksy5DTScENWjaQ=
 github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -470,7 +471,8 @@ github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u1
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
-github.com/gobwas/ws v1.0.4/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
+github.com/gobwas/ws v1.1.0/go.mod h1:nzvNcVha5eUziGrbxFCo6qFIojQHjJV5cLYIbezhfL0=
+github.com/gobwas/ws v1.2.1/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/KY=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -779,6 +781,7 @@ github.com/labstack/echo/v4 v4.5.0/go.mod h1:czIriw4a0C1dFun+ObrXp7ok03xON0N1awS
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/ldez/gomoddirectives v0.2.1/go.mod h1:sGicqkRgBOg//JfpXwkB9Hj0X5RyJ7mlACM5B9f6Me4=
 github.com/ldez/tagliatelle v0.2.0/go.mod h1:8s6WJQwEYHbKZDsp/LjArytKOG8qaMrKQQ3mFukHs88=
+github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/letsencrypt/pkcs11key/v4 v4.0.0/go.mod h1:EFUvBDay26dErnNb70Nd0/VW3tJiIbETBPTl9ATXQag=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -968,6 +971,7 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
@@ -999,9 +1003,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/polyfloyd/go-errorlint v0.0.0-20210418123303-74da32850375/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
 github.com/polyfloyd/go-errorlint v0.0.0-20210510181950-ab96adb96fea/go.mod h1:wi9BfjxjF/bwiZ701TzmfKu6UKC357IOAtNr0Td0Lvw=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/progrium/macdriver v0.2.0 h1:+b90k/lyX0K0sV/aYs9EzWSgVhOFMGytKsnCsa1Uh7M=
-github.com/progrium/macdriver v0.2.0/go.mod h1:QkZLlOeMkYF92euEWqUBpry7/tXrZuM575xZRwnuiig=
-github.com/progrium/macschema v0.1.0/go.mod h1:XzxlqYAo4vKozoZd837LBMjPcfJNlvwB5yBn5Nu+RDE=
+github.com/progrium/macdriver v0.4.0 h1:aQ4KCBRG1XlMWxA8fM7ABvRJrOVs8p8jeb9wEz1SZX0=
+github.com/progrium/macdriver v0.4.0/go.mod h1:eOkZeUZKoYeBp7kXdZXTPqtn+c67fVxBYO6NyHIoDac=
+github.com/progrium/macschema v0.1.1-0.20230703163849-29f3d05de640/go.mod h1:4Xfn2JjWUS9ZFQwyRsrU8hbOHVAuvDj+7PX29p1uhts=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -1477,6 +1481,7 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201024232916-9f70ab9862d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1508,8 +1513,9 @@ golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
-golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
+golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=

--- a/client/cmd/dexc-desktop/go.sum
+++ b/client/cmd/dexc-desktop/go.sum
@@ -1189,8 +1189,6 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
-github.com/ukane-philemon/webview v0.0.0-20230524200242-b3c1c693168d h1:gYjuQ1WaCs/7Pfm8hODyAv+r8GaqUuNd86KBrNpCQ8w=
-github.com/ukane-philemon/webview v0.0.0-20230524200242-b3c1c693168d/go.mod h1:MqUO4jptb337qa/AqX+puM8EAOEKC6S4dztGognyvK4=
 github.com/ultraware/funlen v0.0.3/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/whitespace v0.0.4/go.mod h1:aVMh/gQve5Maj9hQ/hg+F75lr/X5A89uZnzAmWSineA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/client/cmd/dexc-desktop/go.sum
+++ b/client/cmd/dexc-desktop/go.sum
@@ -985,8 +985,6 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
-github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1498,7 +1496,6 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210521203332-0cec03c779c1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/client/cmd/dexc-desktop/main.go
+++ b/client/cmd/dexc-desktop/main.go
@@ -151,8 +151,7 @@ func findExePath() string {
 	return s
 }
 
-func defaultWindowWidthAndHeight() (int, int) {
-	width, height := int(C.display_width()), int(C.display_height())
+func limitedWindowWidthAndHeight(width int, height int) (int, int) {
 	if width <= 0 || width > 1920 {
 		width = 1920
 	}

--- a/client/cmd/dexc-desktop/main.go
+++ b/client/cmd/dexc-desktop/main.go
@@ -47,50 +47,6 @@ when the user simply shuts off their computer.
 
 package main
 
-// Full screen cgo solution. Seems to work on Debian.
-// TODO: Check multi-screen.
-// https://github.com/webview/webview/issues/458#issuecomment-738034846
-
-/*
-#cgo darwin LDFLAGS: -framework CoreGraphics
-#cgo linux pkg-config: x11
-#if defined(__APPLE__)
-#include <CoreGraphics/CGDisplayConfiguration.h>
-int display_width() {
-	return CGDisplayPixelsWide(CGMainDisplayID());
-}
-int display_height() {
-	return CGDisplayPixelsHigh(CGMainDisplayID());
-}
-#elif defined(_WIN32)
-#include <wtypes.h>
-int display_width() {
-	RECT desktop;
-	const HWND hDesktop = GetDesktopWindow();
-	GetWindowRect(hDesktop, &desktop);
-	return desktop.right;
-}
-int display_height() {
-	RECT desktop;
-	const HWND hDesktop = GetDesktopWindow();
-	GetWindowRect(hDesktop, &desktop);
-	return desktop.bottom;
-}
-#else
-#include <X11/Xlib.h>
-int display_width() {
-	Display* d = XOpenDisplay(NULL);
-	Screen*  s = DefaultScreenOfDisplay(d);
-	return s->width;
-}
-int display_height() {
-	Display* d = XOpenDisplay(NULL);
-	Screen*  s = DefaultScreenOfDisplay(d);
-	return s->height;
-}
-#endif
-*/
-import "C"
 import (
 	_ "embed"
 	"fmt"

--- a/client/cmd/dexc-desktop/main.go
+++ b/client/cmd/dexc-desktop/main.go
@@ -92,24 +92,11 @@ int display_height() {
 */
 import "C"
 import (
-	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
-	"os/signal"
 	"path/filepath"
-	"runtime"
-	"runtime/debug"
-	"runtime/pprof"
-	"sync"
-	"sync/atomic"
-	"syscall"
-	"time"
 
-	"decred.org/dcrdex/client/app"
-	"decred.org/dcrdex/client/asset"
 	_ "decred.org/dcrdex/client/asset/bch"  // register bch asset
 	_ "decred.org/dcrdex/client/asset/btc"  // register btc asset
 	_ "decred.org/dcrdex/client/asset/dcr"  // register dcr asset
@@ -118,25 +105,28 @@ import (
 	_ "decred.org/dcrdex/client/asset/firo" // register firo asset
 	_ "decred.org/dcrdex/client/asset/ltc"  // register ltc asset
 	_ "decred.org/dcrdex/client/asset/zec"  // register zec asset
-	"decred.org/dcrdex/client/mm"
 
 	// Ethereum loaded in client/app/importlgpl.go
 
-	"decred.org/dcrdex/client/core"
-	"decred.org/dcrdex/client/rpcserver"
-	"decred.org/dcrdex/client/webserver"
 	"decred.org/dcrdex/dex"
-	"fyne.io/systray"
 	"github.com/gen2brain/beeep"
-	"github.com/webview/webview"
 )
 
-const appName = "dexc-desktop"
+const (
+	appName  = "dexc-desktop"
+	appTitle = "Decred DEX Client"
+)
 
 var (
 	log     dex.Logger
 	exePath = findExePath()
 	srcDir  = filepath.Join(filepath.Dir(exePath), "src")
+
+	//go:embed src/dexc.png
+	FavIcon []byte
+
+	//go:embed src/symbol-bw-round.png
+	SymbolBWIcon []byte
 )
 
 func main() {
@@ -147,351 +137,6 @@ func main() {
 		os.Exit(1)
 	}
 	os.Exit(0)
-}
-
-func mainCore() error {
-	appCtx, cancel := context.WithCancel(context.Background())
-	defer cancel() // don't leak on the earliest returns
-
-	// Parse configuration.
-	cfg, err := configure()
-	if err != nil {
-		return fmt.Errorf("configuration error: %w", err)
-	}
-
-	// Filter registered assets.
-	asset.SetNetwork(cfg.Net)
-
-	// A single process cannot run multiple webview windows, so we run webview
-	// as a subprocess. We could create a simpler webview binary to call that
-	// would be substantially smaller than the dexc binary, but when done that
-	// way, the opened window does not have the icon that the system associates
-	// with dexc and taskbar icons won't be stacked. Instead, we'll create a
-	// short path here and execute ourself with the --webview flag.
-	if cfg.Webview != "" {
-		runWebview(cfg.Webview)
-		return nil
-	}
-
-	// Initialize logging.
-	utc := !cfg.LocalLogs
-	logMaker, closeLogger := app.InitLogging(cfg.LogPath, cfg.DebugLevel, cfg.LogStdout, utc)
-	defer closeLogger()
-	log = logMaker.Logger("APP")
-	log.Infof("%s version %s (Go version %s)", appName, app.Version, runtime.Version())
-	if utc {
-		log.Infof("Logging with UTC time stamps. Current local time is %v",
-			time.Now().Local().Format("15:04:05 MST"))
-	}
-
-	syncDir := filepath.Join(cfg.AppData, cfg.Net.String())
-
-	// The --kill flag is a backup measure to end a background process (that
-	// presumably has active orders).
-	if cfg.Kill {
-		sendKillSignal(syncDir)
-		return nil
-	}
-
-	startServer, err := synchronize(syncDir)
-	if err != nil || !startServer {
-		// If we didn't start the server but there is no error, and it means
-		// that we've successfully sent an open window request to an already
-		// running instance.
-		return err
-	}
-
-	if cfg.CPUProfile != "" {
-		f, err := os.Create(cfg.CPUProfile)
-		if err != nil {
-			return fmt.Errorf("error starting CPU profiler: %w", err)
-		}
-		err = pprof.StartCPUProfile(f)
-		if err != nil {
-			return fmt.Errorf("error starting CPU profiler: %w", err)
-		}
-		defer pprof.StopCPUProfile()
-	}
-
-	defer func() {
-		if pv := recover(); pv != nil {
-			log.Criticalf("Uh-oh! \n\nPanic:\n\n%v\n\nStack:\n\n%v\n\n",
-				pv, string(debug.Stack()))
-		}
-	}()
-
-	// Prepare the Core.
-	clientCore, err := core.New(cfg.Core(logMaker.Logger("CORE")))
-	if err != nil {
-		return fmt.Errorf("error creating client core: %w", err)
-	}
-
-	// Handle shutdown by user (if running via terminal), or on system shutdown.
-	// TODO: SIGTERM is apparently spoofed by Go for Windows. Nice feature, but
-	// not well documented. Test to verify. Could also catch SIGKILL, which is
-	// sent after a configured timeout if the program doesn't exit on SIGTERM.
-	killChan := make(chan os.Signal, 1)
-	signal.Notify(killChan, os.Interrupt /* ctrl-c */, syscall.SIGTERM /* system shutdown */)
-	go func() {
-		for range killChan {
-			log.Infof("Shutting down...")
-			cancel()
-			return
-		}
-	}()
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		clientCore.Run(appCtx)
-		cancel() // in the event that Run returns prematurely prior to context cancellation
-	}()
-
-	<-clientCore.Ready()
-
-	defer func() {
-		log.Info("Exiting dexc main.")
-		cancel()  // no-op with clean rpc/web server setup
-		wg.Wait() // no-op with clean setup and shutdown
-	}()
-
-	var marketMaker *mm.MarketMaker
-	if cfg.Experimental {
-		// TODO: on shutdown, stop market making and wait for trades to be
-		// canceled.
-		marketMaker, err = mm.NewMarketMaker(clientCore, logMaker.Logger("MM"))
-		if err != nil {
-			return fmt.Errorf("error creating market maker: %w", err)
-		}
-	}
-
-	if cfg.RPCOn {
-		rpcSrv, err := rpcserver.New(cfg.RPC(clientCore, marketMaker, logMaker.Logger("RPC")))
-		if err != nil {
-			return fmt.Errorf("failed to create rpc server: %w", err)
-		}
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			cm := dex.NewConnectionMaster(rpcSrv)
-			err := cm.Connect(appCtx)
-			if err != nil {
-				log.Errorf("Error starting rpc server: %v", err)
-				cancel()
-				return
-			}
-			cm.Wait()
-		}()
-	}
-
-	webSrv, err := webserver.New(cfg.Web(clientCore, logMaker.Logger("WEB"), utc))
-	if err != nil {
-		return fmt.Errorf("failed creating web server: %w", err)
-	}
-
-	webStart := make(chan error)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		cm := dex.NewConnectionMaster(webSrv)
-		webStart <- cm.Connect(appCtx)
-		cm.Wait()
-	}()
-
-	if err := <-webStart; err != nil {
-		return err
-	}
-
-	// No errors running webserver, so we can be certain we won any race between
-	// starting instances. Start the sync server now.
-	openC := make(chan struct{}) // no buffer. Is ignored if window is currently open
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		runServer(appCtx, syncDir, openC, killChan, cfg.Net)
-	}()
-
-	openWindow := func() {
-		wg.Add(1)
-		go func() {
-			runWebviewSubprocess(appCtx, "http://"+webSrv.Addr())
-			wg.Done()
-		}()
-	}
-
-	openWindow()
-
-	wg.Add(1)
-	go func() {
-		defer func() {
-			systray.SetTooltip("Shutting down. Please wait...")
-			systray.Quit()
-			wg.Done()
-			defer cancel()
-		}()
-	windowloop:
-		for {
-			var backgroundNoteSent bool
-			select {
-			case <-windowManager.zeroLeft:
-				if windowManager.persist.Load() {
-					continue // ignore
-				}
-			logout:
-				for {
-					err := clientCore.Logout()
-					if err == nil {
-						// Okay to quit.
-						break windowloop
-					}
-					if !errors.Is(err, core.ActiveOrdersLogoutErr) {
-						// Unknown error. Force shutdown.
-						log.Errorf("Core logout error: %v", err)
-						break windowloop
-					}
-					if !backgroundNoteSent {
-						sendDesktopNotification("DEX client still running", "DEX client is still resolving active DEX orders")
-						backgroundNoteSent = true
-					}
-					// Can't log out. Keep checking until either
-					//   1. We can log out. Exit the program.
-					//   2. The user reopens the window (via syncserver).
-					select {
-					case <-time.After(time.Minute):
-						// Try to log out again.
-						continue logout
-					case <-openC:
-						// re-open the window
-						openWindow()
-						continue windowloop
-					case <-appCtx.Done():
-						break windowloop
-					}
-				}
-			case <-appCtx.Done():
-				break windowloop
-			case <-openC:
-				openWindow()
-			}
-		}
-	}()
-
-	activeState := make(chan bool, 8)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		active := true // starting with "Force Quit"
-		for {
-			select {
-			case <-time.After(time.Second):
-				// inelegant polling? Even Core doesn't know until it checks, so
-				// can't feasibly rig a signal from Core without changes there.
-				coreActive := clientCore.Active()
-				if coreActive != active {
-					active = coreActive
-					activeState <- coreActive
-				}
-			case <-appCtx.Done():
-				return
-			}
-		}
-	}()
-
-	systray.Run(func() {
-		systrayOnReady(appCtx, filepath.Dir(cfg.LogPath), openC, killChan, activeState)
-	}, nil)
-
-	closeAllWindows()
-
-	log.Infof("Shutting down...")
-	cancel()
-	wg.Wait()
-
-	return nil
-}
-
-var windowManager = &struct {
-	sync.Mutex
-	counter  uint32
-	windows  map[uint32]*exec.Cmd
-	zeroLeft chan struct{}
-	persist  atomic.Bool
-}{
-	windows:  make(map[uint32]*exec.Cmd),
-	zeroLeft: make(chan struct{}, 1),
-}
-
-func closeWindow(windowID uint32) {
-	m := windowManager
-	m.Lock()
-	cmd, found := m.windows[windowID]
-	if !found {
-		m.Unlock()
-		// Probably killed by caller via closeAllWindows.
-		return
-	}
-	delete(m.windows, windowID)
-	remain := len(m.windows)
-	m.Unlock()
-	if remain == 0 {
-		select {
-		case m.zeroLeft <- struct{}{}:
-		default:
-		}
-	}
-	log.Infof("Closing window. %d windows remain open.", remain)
-	cmd.Process.Kill()
-}
-
-func closeAllWindows() {
-	m := windowManager
-	m.Lock()
-	defer m.Unlock()
-	for windowID, cmd := range m.windows {
-		cmd.Process.Kill()
-		delete(m.windows, windowID)
-	}
-}
-
-func runWebview(url string) {
-	w := webview.New(true)
-	defer w.Destroy()
-	w.SetTitle("Decred DEX Client")
-	w.SetSize(600, 600, webview.HintMin)
-
-	width, height := int(C.display_width()), int(C.display_height())
-	if width <= 0 || width > 1920 {
-		width = 1920
-	}
-	if height <= 0 || height > 1080 {
-		height = 1080
-	}
-
-	w.SetSize(width, height, webview.HintNone)
-	w.Navigate(url)
-	w.Run()
-}
-
-func runWebviewSubprocess(ctx context.Context, url string) {
-	cmd := exec.CommandContext(ctx, exePath, "--webview", url)
-	if err := cmd.Start(); err != nil {
-		log.Errorf("webview start error: %v", err)
-		return
-	}
-	m := windowManager
-	m.Lock()
-	m.counter++
-	windowID := windowManager.counter
-	m.windows[windowID] = cmd
-	windowCount := len(m.windows)
-	m.Unlock()
-	defer closeWindow(windowID)
-	log.Infof("Opening new window. %d windows open now", windowCount)
-	if err := cmd.Wait(); err != nil {
-		log.Errorf("webview error: %v", err)
-	}
 }
 
 func findExePath() string {
@@ -506,99 +151,15 @@ func findExePath() string {
 	return s
 }
 
-//go:embed src/dexc.png
-var FavIcon []byte
-
-//go:embed src/symbol-bw-round.png
-var SymbolBWIcon []byte
-
-func systrayOnReady(ctx context.Context, logDirectory string, openC chan<- struct{},
-	killC chan<- os.Signal, activeState <-chan bool) {
-	systray.SetIcon(FavIcon)
-	systray.SetTitle("DEX client")
-	systray.SetTooltip("Self-custodial multi-wallet")
-
-	// TODO: Consider reworking main so we can show the icon earlier?
-	// mStarting := systray.AddMenuItem("Starting...", "Starting up. Please wait...")
-	// var addr string
-	// var ok bool
-	// select {
-	// case addr, ok = <-webserverReady:
-	// 	if !ok { // no webserver started
-	// 		fmt.Fprintln(os.Stderr, "Web server required!")
-	// 		cancel()
-	// 		return
-	// 	}
-	// case <-mainDone:
-	// 	return
-	// }
-
-	// mStarting.Hide()
-
-	mOpen := systray.AddMenuItem("Open", "Open DEX client window")
-	mOpen.SetIcon(SymbolBWIcon)
-	go func() {
-		for range mOpen.ClickedCh {
-			select {
-			case openC <- struct{}{}:
-				log.Debug("Received window reopen request from system tray")
-			default:
-				log.Infof("Ignored a window open request from the system tray")
-			}
-		}
-	}()
-
-	systray.AddSeparator()
-
-	if logDirURL, err := app.FilePathToURL(logDirectory); err != nil {
-		log.Errorf("error constructing log directory URL: %v", err)
-	} else {
-		mLogs := systray.AddMenuItem("Open logs folder", "Open the folder with your DEX logs.")
-		go func() {
-			for range mLogs.ClickedCh {
-				log.Debug("Opening browser to log directory at", logDirURL)
-				runWebviewSubprocess(ctx, logDirURL)
-			}
-		}()
+func defaultWindowWidthAndHeight() (int, int) {
+	width, height := int(C.display_width()), int(C.display_height())
+	if width <= 0 || width > 1920 {
+		width = 1920
 	}
-
-	systray.AddSeparator()
-
-	mPersist := systray.AddMenuItemCheckbox("Persist after windows closed.",
-		"Keep the process running after all windows are closed. "+
-			"Shutdown is initiated through the Quit item in the system tray menu.", false)
-	go func() {
-		for range mPersist.ClickedCh {
-			var persisting = !mPersist.Checked() // toggle
-			if persisting {
-				mPersist.Check()
-			} else {
-				mPersist.Uncheck()
-			}
-			windowManager.persist.Store(persisting)
-		}
-	}()
-
-	mQuit := systray.AddMenuItem("Force Quit", "Force DEX client to close with active orders.")
-	go func() {
-		for {
-			select {
-			case active := <-activeState:
-				if active {
-					mQuit.SetTitle("Force Quit")
-					mQuit.SetTooltip("Force DEX client to close with active orders.")
-				} else {
-					mQuit.SetTitle("Quit")
-					mQuit.SetTooltip("Shutdown the DEX client. You have no active orders.")
-				}
-			case <-mQuit.ClickedCh:
-				mOpen.Disable()
-				mQuit.Disable()
-				killC <- os.Interrupt
-				return
-			}
-		}
-	}()
+	if height <= 0 || height > 1080 {
+		height = 1080
+	}
+	return width, height
 }
 
 func sendDesktopNotification(title, msg string) {

--- a/client/cmd/dexc-desktop/pkg/pkg-darwin.sh
+++ b/client/cmd/dexc-desktop/pkg/pkg-darwin.sh
@@ -71,7 +71,6 @@ function prepare() {
 		  <key>CFBundleSignature</key><string>dexc</string>
 		  <key>CFBundleSupportedPlatforms</key><array><string>MacOSX</string></array>
 		  <key>LSMinimumSystemVersion</key><string>10.11.0</string>
-		  <key>LSUIElement</key><true/>
 		  <key>NSHighResolutionCapable</key><true/>
 		  <key>NSRequiresAquaSystemAppearance</key><false/>
 		  <key>NSSupportsAutomaticGraphicsSwitching</key><true/>

--- a/client/cmd/dexc-desktop/syncserver.go
+++ b/client/cmd/dexc-desktop/syncserver.go
@@ -1,6 +1,8 @@
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
 
+//go:build !darwin
+
 /*
 The sync server is a tiny HTTP server that handles synchronization of multiple
 instances of dexc-desktop. Any dexc-desktop instance that manages to get a


### PR DESCRIPTION
Builds on #2333.

I researched other options and [MacDrive](https://github.com/progrium/macdriver) seem to be a reasonable option. It allows using supported native Mac APIs, which covers our use case.

I was able to implement some "native" macOS app behaviour and features; keeping the app running without windows, creating new windows, and having a dock icon menu.

<img width="170" alt="Screenshot 2023-05-25 at 8 35 26 PM" src="https://github.com/decred/dcrdex/assets/57448127/0faabc33-be2a-4f26-b298-c5268b866152">

I'm putting this up so we can have discussions around it and clarify what feature is missing (menu items etc)

EDIT: If we want to keep the New Window menu as @martonp mentioned here https://github.com/decred/dcrdex/pull/2333#issuecomment-1562681245, we'd have to allow more than one window on macOS.