### PR TITLE
client/asset: Firo should manually unlock unspents

### DIFF
--- a/client/asset/firo/firo.go
+++ b/client/asset/firo/firo.go
@@ -154,7 +154,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		NumericGetRawRPC:         false, // getrawtransaction uses either 0/1 Or true/false
 		LegacyValidateAddressRPC: true,  // use validateaddress to read 'ismine' bool
 		SingularWallet:           true,  // one wallet/node
-		UnlockSpends:             false, // checked after sendtoaddress
+		UnlockSpends:             true,  // checked after sendtoaddress and listlockunspent
 		AssetID:                  BipID,
 		FeeEstimator:             estimateFee,
 		ExternalFeeEstimator:     fetchExternalFee,


### PR DESCRIPTION
After checking `listlockunspent` after `lockunspent true` & `sendtoaddress` Firo should use the code path to check and 'manually' check and unlock outputs.

Discovered while compare/contrast while testing Dash so dash may be similar.