### PR TITLE
btc: more sensible bond fee buffer

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -534,8 +534,10 @@ type Bonder interface {
 	// transaction fees part of bond reserves when bond rotation is enabled.
 	// This should return an amount larger than the minimum required by the
 	// asset's reserves system for fees, if non-zero, so that a reserves
-	// "deficit" does not appear right after the first bond is posted.
-	BondsFeeBuffer() uint64
+	// "deficit" does not appear right after the first bond is posted. The
+	// caller may provide this value to ReserveBondFunds when actually posting
+	// the first bond to ensure it succeeds, assuming balance was checked.
+	BondsFeeBuffer(feeRate uint64) uint64
 
 	// RegisterUnspent informs the wallet of a certain amount already locked in
 	// unspent bonds that will eventually be refunded with RefundBond. This
@@ -555,7 +557,10 @@ type Bonder interface {
 	// refunding of live bonds), they will go directly into locked balance. When
 	// the reserves are decremented to zero (by the amount that they were
 	// incremented), all enforcement including any fee buffering is disabled.
-	ReserveBondFunds(future int64, respectBalance bool) bool
+	// The fee buffer amount is used only when enabling the reserves (when
+	// starting from zero). It may also be zero, in which case the wallet will
+	// attempt to obtain it's own estimate if it is needed.
+	ReserveBondFunds(future int64, feeBuffer uint64, respectBalance bool) bool
 
 	// MakeBondTx authors a DEX time-locked fidelity bond transaction for the
 	// provided amount, lock time, and dex account ID. An explicit private key

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6494,6 +6494,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 			// reserves reduction (and vice versa).
 
 			var future int64
+			var feeBuffer uint64
 			if loginAuth {
 				// If we are enabling reserves enforcement for spendable
 				// balance, we need to subtract how much we have already locked
@@ -6512,6 +6513,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 						future -= tierOffset * int64(bondAsset.Amt)
 					}
 				}
+				feeBuffer = bondWallet.BondsFeeBuffer(c.feeSuggestionAny(bondAsset.ID, dc))
 				dc.acct.totalReserved = int64(inBonds) + future // enabling starts with inBonds
 				c.log.Infof("First login at %v, with %v (x%d) in unspent bonds, "+
 					"reserving %v for future bonds with target tier of %d",
@@ -6526,7 +6528,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 
 			// TODO: limit dc.acct.totalReserved+future against maxBondedAmt
 
-			bondWallet.ReserveBondFunds(future, false)
+			bondWallet.ReserveBondFunds(future, feeBuffer, false) // may create a deficit if fees are higher now and wallet lacks funds (OK)
 			dc.log.Infof("Total reserved for %v is now %v (%v more future in bonds)", dc.acct.host,
 				bondWallet.amtStringSigned(dc.acct.totalReserved), bondWallet.amtStringSigned(future))
 			updatedAssets.count(bondAsset.ID)
@@ -7530,7 +7532,8 @@ func (c *Core) reReserveFunding(w *xcWallet) {
 			// (totalReserved minus what's locked in bonds, see the firstAuth
 			// path in authDEX, and the "enabling reserves" parts of
 			// UpdateBondOptions):
-			w.ReserveBondFunds(dc.acct.totalReserved-int64(inBonds), false)
+			feeBuffer := w.BondsFeeBuffer(c.feeSuggestionAny(w.AssetID, dc))
+			w.ReserveBondFunds(dc.acct.totalReserved-int64(inBonds), feeBuffer, false)
 		}
 		dc.acct.authMtx.RUnlock()
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -184,6 +184,10 @@ type PostBondForm struct {
 	Bond     uint64           `json:"bond"`
 	LockTime uint64           `json:"lockTime"` // 0 means go with server-derived value
 
+	// FeeBuffer is optional, to use same value from BondsFeeBuffer during
+	// wallet funding. If zero, the wallet will use an internal estimate.
+	FeeBuffer uint64 `json:"feeBuffer,omitempty"`
+
 	// These options may be set when creating an account.
 	MaintainTier *bool   `json:"maintainTier,omitempty"` // tier implied from Bond amount
 	MaxBondedAmt *uint64 `json:"maxBondedAmt,omitempty"`

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -535,12 +535,21 @@ func (w *xcWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Tim
 }
 
 // ReserveBondFunds reserves funds for future bonds given known live bonds.
-func (w *xcWallet) ReserveBondFunds(future int64, respectBalance bool) bool {
+func (w *xcWallet) ReserveBondFunds(future int64, feeBuffer uint64, respectBalance bool) bool {
 	bonder, ok := w.Wallet.(asset.Bonder)
 	if !ok {
 		return false
 	}
-	return bonder.ReserveBondFunds(future, respectBalance)
+	return bonder.ReserveBondFunds(future, feeBuffer, respectBalance)
+}
+
+// BondsFeeBuffer gets the bonds fee buffer based on the provided fee rate.
+func (w *xcWallet) BondsFeeBuffer(feeRate uint64) uint64 {
+	bonder, ok := w.Wallet.(asset.Bonder)
+	if !ok {
+		return 0
+	}
+	return bonder.BondsFeeBuffer(feeRate)
 }
 
 // RegisterUnspent informs the wallet of existing bond amounts that will be

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=nV9Bel"></script>
+<script src="/js/entry.js?v=XkMuUH"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/register.ts
+++ b/client/webserver/site/src/js/register.ts
@@ -93,11 +93,11 @@ export default class RegistrationPage extends BasePage {
       const wallet = asset.wallet
       if (wallet) {
         const bondAsset = this.currentDEX.bondAssets[asset.symbol]
-        if (wallet.synced && wallet.balance.available > bondAsset.amount) {
+        const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.regAssetForm)
+        if (wallet.synced && wallet.balance.available > 2 * bondAsset.amount + bondsFeeBuffer) {
           this.animateConfirmForm(page.regAssetForm)
           return
         }
-        const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.regAssetForm)
         this.walletWaitForm.setWallet(wallet, bondsFeeBuffer)
         slideSwap(page.regAssetForm, page.walletWait)
         return
@@ -247,12 +247,12 @@ export default class RegistrationPage extends BasePage {
     const wallet = asset.wallet
     const bondAmt = this.currentDEX.bondAssets[asset.symbol].amount
 
-    if (wallet.synced && wallet.balance.available > bondAmt) {
+    const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.newWalletForm)
+    if (wallet.synced && wallet.balance.available > 2 * bondAmt + bondsFeeBuffer) {
       await this.animateConfirmForm(page.newWalletForm)
       return
     }
 
-    const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.newWalletForm)
     this.walletWaitForm.setWallet(wallet, bondsFeeBuffer)
     await slideSwap(page.newWalletForm, page.walletWait)
   }

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -217,6 +217,11 @@ type Config struct {
 	Experimental bool
 }
 
+type valStamp struct {
+	val   uint64
+	stamp time.Time
+}
+
 // WebServer is a single-client http and websocket server enabling a browser
 // interface to the DEX client.
 type WebServer struct {
@@ -233,6 +238,9 @@ type WebServer struct {
 	authMtx         sync.RWMutex
 	authTokens      map[string]bool
 	cachedPasswords map[string]*cachedPassword // cached passwords keyed by auth token
+
+	bondBufMtx sync.Mutex
+	bondBuf    map[uint32]valStamp
 }
 
 // New is the constructor for a new WebServer. CustomSiteDir in the Config can
@@ -338,6 +346,7 @@ func New(cfg *Config) (*WebServer, error) {
 		authTokens:      make(map[string]bool),
 		cachedPasswords: make(map[string]*cachedPassword),
 		experimental:    cfg.Experimental,
+		bondBuf:         map[uint32]valStamp{},
 	}
 
 	lang := cfg.Language


### PR DESCRIPTION
```
When used for computing the bond fee buffer, the "fee rate limit" makes
an extremely high fee rate buffer, which makes BTC bonds impractical.
This change:
- switches to using a dynamic fee rate with the configured fallback rate
  for both ReserveBondFunds and BondsFeeBuffer, where the former is
  used as the requirement for the frontend to proceed with registration
- uses the exported BondsFeeBuffer method when automatically creating
  the "extra" split output in certain order funding edge cases instead
  of a buffer based on the high limit.
- tweaks the bond tx input count to be slightly less conservative, going
  from 12 -> 8 possible inputs

The motivation for these changes is that using the wallet's configured
fee rate limit creates extremely high fee buffers, whereas we have
defined the "fallback" fee rate to be a reasonable fallback where a
current estimate is not available, which also happens to be applicable
to a *future* fee rate.

Further, this is a buffer and precision is not critical, but turning
users away from on-boarding is a major issue.  The right approach
is to base reserves on a padded estimate based on current rates,
not the swap fee rate limit.

Finally, given this softening of the reserves amount, no adjustment to
the enforced bond reserves in Reconfigure is done since we are now
using current rates as a hit of future rates.

Padding of this fee buffer already comes from:
- planning for a lot of inputs
- 4 parallel bond tracks
- the exported BondsFeeBuffer method using double the provided fee rate

Even if fee rates skyrocket, and the reserves become insufficient for
bond renewal, the user will still post bond if their balance allows, and
they may deposit some nominal additional amount to cover any such
deficit.
```

**Before**

![image](https://github.com/decred/dcrdex/assets/9373513/89bf64c2-26a1-468f-bfde-80e10f977dbc)

(that's about 1500 USD, not sensible)

**After**

![image](https://github.com/decred/dcrdex/assets/9373513/39625d71-d30e-4b57-bb58-caae049eacc5)

(that's <100 USD, or 2x the bond amount plus realistic fees)