### PR TITLE
ui: rework app initialization

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4510,7 +4510,6 @@ func (c *Core) InitializeClient(pw, restorationSeed []byte) error {
 		subject, details := c.formatDetails(TopicSeedNeedsSaving)
 		c.notify(newSecurityNote(TopicSeedNeedsSaving, subject, details, db.Success))
 	}
-
 	return nil
 }
 

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -928,7 +928,13 @@ func (s *WebServer) apiInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, struct {
+		OK    bool     `json:"ok"`
+		Hosts []string `json:"hosts"`
+	}{
+		OK:    true,
+		Hosts: s.knownUnregisteredExchanges(map[string]*core.Exchange{}),
+	}, s.indent)
 }
 
 // apiIsInitialized is the handler for the '/isinitialized' request.

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -24,6 +24,7 @@ import (
 const (
 	homeRoute        = "/"
 	registerRoute    = "/register"
+	initRoute        = "/init"
 	loginRoute       = "/login"
 	marketsRoute     = "/markets"
 	walletsRoute     = "/wallets"
@@ -223,6 +224,11 @@ func (s *WebServer) handleGenerateQRCode(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		log.Errorf("error writing qr code image: %v", err)
 	}
+}
+
+// handleInit is the handler for the '/init' page request
+func (s *WebServer) handleInit(w http.ResponseWriter, r *http.Request) {
+	s.sendTemplate(w, "init", s.commonArgs(r, "Welcome | Decred DEX"))
 }
 
 // handleSettings is the handler for the '/settings' page request.

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -354,4 +354,18 @@ var EnUS = map[string]string{
 	"no_token_allowances":     "You have not granted allowances for any swap contracts for this token.",
 	"token_unapproval_tx_msg": `Your token approval has been removed with transaction ID:`,
 	"approval_change_pending": "Approval change pending",
+	// Init page
+	"Quick Configuration":             "Quick Configuration",
+	"quickconfig_server_header":       "We can connect to these servers.",
+	"quickconfig_wallet_header":       "We can activate these native wallets now. Configure additional wallets from the Wallets view.",
+	"quickconfig_server_error_header": "Errors encountered when connecting to the following servers. You can try again from the Settings view.",
+	"quickconfig_wallet_error_header": "Errors encountered when creating the following wallets. Wallets can be configured in the Wallets view.",
+	"Continue":                        "Continue",
+	"Backup App Seed":                 "Backup App Seed",
+	"seed_backup_implore": "It's highly recommended that you back up your application seed now. " +
+		"The application seed is critical to recovering your fidelity bonds and native wallets.",
+	"Backup Now":             "Backup Now",
+	"Skip this step for now": "Skip this step for now",
+	"save_seed_instructions": "Save the following seed somewhere safe. Do not share this with anybody.",
+	"Done":                   "Done",
 }

--- a/client/webserver/site/src/css/forms.scss
+++ b/client/webserver/site/src/css/forms.scss
@@ -331,12 +331,14 @@ button.form-button {
 #sendForm,
 #vSendForm,
 #exportSeedAuth,
-#cancelForm {
+#cancelForm,
+#quickConfigForm {
   width: 375px;
 }
 
 #reconfigForm,
-#authorizeSeedDisplay {
+#authorizeSeedDisplay,
+#seedBackupForm {
   width: 425px;
 }
 
@@ -409,5 +411,12 @@ a[data-tmpl=walletCfgGuide] {
     div.opt-check {
       background-color: #2cce9c;
     }
+  }
+}
+
+div[data-handler=init] {
+  .quickconfig-asset-logo {
+    width: 25px;
+    height: 25px;
   }
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=b364da40|18bfd169" rel="stylesheet">
+  <link href="/css/style.css?v=a179bbb8|fadb2030" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=316c3da9|8d59551e"></script>
+<script src="/js/entry.js?v=39867746|72de6251"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/init.tmpl
+++ b/client/webserver/site/src/html/init.tmpl
@@ -1,0 +1,111 @@
+{{define "init"}}
+{{template "top" .}}
+<div id="main" data-handler="init" class="main align-items-center justify-content-center flex-column stylish-overflow">
+  <div class="position-absolute" id="forms">
+
+    {{- /* App Initialization */ -}}
+    <form id="appPWForm">
+      <div class="px-2 py-1 text-center fs28 sans-light">[[[Set App Password]]]</div>
+      <div class="fs18 mt-2 sans-light">[[[reg_set_app_pw_msg]]]</div>
+      <hr class="dashed my-4">
+      <div class="pb-3">
+        <label for="appPW" class="form-label ps-1 mb-1">[[[Password]]]</label>
+        <input type="password" class="form-control select" id="appPW" autocomplete="new-password">
+      </div>
+      <div class="pb-3">
+        <label for="appPWAgain" class="form-label ps-1 mb-1">[[[Password Again]]]</label>
+        <input type="password" class="form-control select" id="appPWAgain" autocomplete="off">
+      </div>
+      <div>
+        <input class="form-check-input" type="checkbox" id="rememberPass">
+        <label for="rememberPass" class="form-check-label ps-1">[[[Remember my password]]]</label>
+      </div>
+      <div class="pb-3 d-hide mt-3" id="seedRestore">
+        <label for="seedInput" class="form-label ps-1 mb-1">[[[Restoration Seed]]]</label>
+        <input type="text" class="form-control select" id="seedInput" autocomplete="off">
+      </div>
+      <div class="d-flex justify-content-between mt-4">
+        <div class="px-1 fs13 pointer d-flex justify-content-start align-items-center" id="showSeedRestore"><span class="ico-plus fs11"></span> <div class="ps-2">[[[Restore from seed]]]</div></div>
+        <span></span>
+        <button id="appPWSubmit" type="submit" class="col-8 justify-content-center fs15 bg2 selected">[[[Submit]]]</button>
+      </div>
+      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="appPWErrMsg"></div>
+    </form>
+
+    {{- /* Quick Config Form */ -}}
+    <form id="quickConfigForm" class="d-hide">
+      <div class="px-2 py-1 text-center fs28 sans-light">[[[Quick Configuration]]]</div>
+      <div id="qcChoices">
+        <div class="fs18 mt-2">[[[quickconfig_wallet_header]]]</div>
+        <div id="qcWalletsBox">
+          <label id="qcWalletTmpl" class="p-1 my-1 d-flex justify-content-start align-items-center hoverbg pointer">
+            <input class="form-check-input" type="checkbox" data-tmpl="checkbox" checked>
+            <img class="quickconfig-asset-logo mx-2" data-tmpl="icon">
+            <span data-tmpl="name" class="fs20"></span>
+          </label>
+        </div>
+        <hr class="dashed my-3">
+        <div class="fs18 mt-2">[[[quickconfig_server_header]]]</div>
+        <div id="qcServersBox">
+          <label id="qcServerTmpl" class="d-flex justify-content-start align-items-center p-1 my-1 hoverbg pointer">
+            <input class="form-check-input" type="checkbox" data-tmpl="checkbox" checked>
+            <span data-tmpl="host" class="ms-2 fs18 lh1"></span>
+          </label>
+        </div>
+        <hr class="dashed my-4">
+        <div class="flex-center mt-4">
+          <button id="quickConfigSubmit" type="submit" class="col-8 justify-content-center fs15 bg2 selected">[[[Submit]]]</button>
+        </div>
+      </div>
+
+      <div id="qcErrors" class="d-hide">
+        <div id="qcWalletErrors">
+          <span class="my-1 fs16">
+            [[[quickconfig_wallet_error_header]]]
+          </span>
+          <div id="qcWalletErrorList" class="p-2 my-1"></div>
+        </div>
+
+        <div id="qcServerErrors">
+          <span class="my-1 fs16">
+            [[[quickconfig_server_error_header]]]
+          </span>
+          <div id="qcServerErrorList" class="p-2 my-1"></div>
+        </div>
+
+        <div class="d-flex justify-content-end my-1">
+          <button id="qcErrAck" class="selected">[[[Continue]]]</button>
+        </div>
+      </div>
+    </form>
+
+    {{- /* Seed Backup */ -}}
+    <form id="seedBackupForm" class="d-hide">
+      <div class="px-2 py-1 text-center fs28 sans-light">[[[Backup App Seed]]]</div>
+      <div id="sbWanna">
+        <div class="fs18 mt-2">
+          [[[seed_backup_implore]]]
+        </div>
+        <div class="flex-center my-2">
+          <button id="showSeed" class="fs18 selected">[[[Backup Now]]]</button>
+        </div>
+        <hr class="dashed my-4">
+        <div class="d-flex justify-content-end">
+          <a class="d-block plainlink fs15 flex-center hoverbg pointer" href="/wallets">
+            <span>[[[Skip this step for now]]]</span>
+            <span class="ico-info mx-1" data-tooltip="You can backup your seed at any time in the Settings view"></span>
+          </a>
+        </div>
+      </div>
+
+      <div id="sbSeed" class="d-hide">
+        <div class="fs18 mt-2">[[[save_seed_instructions]]]</div>
+        <div class="my-2 p-2" id="seedDiv"></div>
+        <button id="seedAck" class="selected">[[[Done]]]</button>
+      </div>
+    </form>
+
+  </div> {{/* END FORMS */}}
+</div>
+{{template "bottom"}}
+{{end}}

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -3,35 +3,6 @@
 <div id="main" data-handler="register" class="main align-items-center justify-content-center flex-column stylish-overflow">
   <div class="position-absolute" id="forms">
 
-    {{- /* Set up the initial application password. Only shown if app is not already initialized. */ -}}
-    <form class="d-hide{{if not .UserInfo.Initialized}} selected{{end}}" id="appPWForm">
-      <div class="px-2 py-1 text-center fs28 sans-light">[[[Set App Password]]]</div>
-      <div class="fs18 mt-2 sans-light">[[[reg_set_app_pw_msg]]]</div>
-      <hr class="dashed my-4">
-      <div class="pb-3">
-        <label for="appPW" class="form-label ps-1 mb-1">[[[Password]]]</label>
-        <input type="password" class="form-control select" id="appPW" autocomplete="new-password">
-      </div>
-      <div class="pb-3">
-        <label for="appPWAgain" class="form-label ps-1 mb-1">[[[Password Again]]]</label>
-        <input type="password" class="form-control select" id="appPWAgain" autocomplete="off">
-      </div>
-      <div>
-        <input class="form-check-input" type="checkbox" id="rememberPass">
-        <label for="rememberPass" class="form-check-label ps-1">[[[Remember my password]]]</label>
-      </div>
-      <div class="pb-3 d-hide mt-3" id="seedRestore">
-        <label for="seedInput" class="form-label ps-1 mb-1">[[[Restoration Seed]]]</label>
-        <input type="text" class="form-control select" id="seedInput" autocomplete="off">
-      </div>
-      <div class="d-flex justify-content-between mt-4">
-        <div class="px-1 fs13 pointer d-flex justify-content-start align-items-center" id="showSeedRestore"><span class="ico-plus fs11"></span> <div class="ps-2">[[[Restore from seed]]]</div></div>
-        <span></span>
-        <button id="appPWSubmit" type="submit" class="col-8 justify-content-center fs15 bg2 selected">[[[Submit]]]</button>
-      </div>
-      <div class="fs15 pt-3 text-center d-hide errcolor text-break" id="appPWErrMsg"></div>
-    </form>
-
     {{- /* LOGIN FORM */ -}}
     <form class="d-hide{{if and (not .UserInfo.Authed) .UserInfo.Initialized }} selected{{end}}" id="loginForm">
       {{template "loginForm"}}

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -8,6 +8,7 @@ import MarketsPage from './markets'
 import OrdersPage from './orders'
 import OrderPage from './order'
 import DexSettingsPage from './dexsettings'
+import InitPage from './init'
 import { RateEncodingFactor, StatusExecuted, hasActiveMatches } from './orderutil'
 import { getJSON, postJSON, Errors } from './http'
 import * as ntfn from './notifications'
@@ -70,7 +71,8 @@ const constructors: Record<string, PageClass> = {
   settings: SettingsPage,
   orders: OrdersPage,
   order: OrderPage,
-  dexsettings: DexSettingsPage
+  dexsettings: DexSettingsPage,
+  init: InitPage
 }
 
 // Application is the main javascript web application for the Decred DEX client.
@@ -457,12 +459,12 @@ export default class Application {
       return
     }
     const authed = user && user.authed
-    if (authed) page.profileBox.classList.add('authed')
-    else {
+    if (!authed) {
       page.profileBox.classList.remove('authed')
       Doc.hide(page.noteBell, page.walletsMenuEntry, page.marketsMenuEntry)
       return
     }
+    page.profileBox.classList.add('authed')
     Doc.show(page.noteBell, page.walletsMenuEntry)
     if (Object.keys(user.exchanges).length > 0) {
       Doc.show(page.marketsMenuEntry)

--- a/client/webserver/site/src/js/charts.ts
+++ b/client/webserver/site/src/js/charts.ts
@@ -1132,6 +1132,7 @@ export class Wave extends Chart {
     })
     if (!msg) return
     msgRegion.plot(new Extents(0, 1, 0, 1), (ctx: CanvasRenderingContext2D, t: Translator) => {
+      this.applyLabelStyle(this.fontSize)
       ctx.fillText(msg, t.x(0.5), t.y(0.5), this.msgRegion.width())
     })
   }

--- a/client/webserver/site/src/js/init.ts
+++ b/client/webserver/site/src/js/init.ts
@@ -1,0 +1,305 @@
+import Doc from './doc'
+import BasePage from './basepage'
+import { postJSON } from './http'
+import * as intl from './locales'
+import {
+  bind as bindForm,
+  slideSwap
+} from './forms'
+import { Wave } from './charts'
+import {
+  app,
+  PageElement,
+  SupportedAsset,
+  User,
+  WalletInfo,
+  WalletDefinition,
+  ConfigOption
+} from './registry'
+
+/*
+ * InitPage is the page handler for the /init view. InitPage is essentially a
+ * form handler. There are no non-form elements on /init. InitPage additionally
+ * has a role caching the initialization password. A couple of notes about
+ * InitPage.
+ *   1) There is no going backwards. Once you set a password, you can't go back
+ *      to the password form. If you refresh, you won't end up on /init, so
+ *      won't have access to the QuickConfigForm or SeedBackupForm . Once you
+ *      submit your auto-config choices, you can't change them. This has
+ *      implications for coding and UI. There are no "go back" or "close form"
+ *      elements.
+ *   2) The user can preclude auto-config and seed backup by clicking an
+ *      available header link after password init, e.g. Wallets, in the page
+ *      header. NOTE: Regardless of what the user does after setting the app
+ *      pass, they will receive a notification reminding them to back up their
+ *      seed. Perhaps it would be better to somehow delay that message until
+ *      they choose to ignore the seed backup dialog, but having more reminders
+ *      is also okay.
+ */
+export default class InitPage extends BasePage {
+  body: HTMLElement
+  page: Record<string, PageElement>
+  initForm: AppInitForm
+  quickConfigForm: QuickConfigForm
+  seedBackupForm: SeedBackupForm
+  seedProvided: boolean
+
+  constructor (body: HTMLElement) {
+    super()
+    this.body = body
+    const page = this.page = Doc.idDescendants(body)
+    this.initForm = new AppInitForm(page.appPWForm, (pw: string, hosts: string[], seedProvided: boolean) => { this.appInited(pw, hosts, seedProvided) })
+    this.quickConfigForm = new QuickConfigForm(page.quickConfigForm, () => this.quickConfigDone())
+    this.seedBackupForm = new SeedBackupForm(page.seedBackupForm, () => this.seedBackedUp())
+  }
+
+  async appInited (pw: string, hosts: string[], seedProvided: boolean) {
+    this.seedProvided = seedProvided
+    const page = this.page
+    await this.quickConfigForm.update(pw, hosts)
+    this.seedBackupForm.update(pw)
+    slideSwap(page.appPWForm, page.quickConfigForm)
+  }
+
+  quickConfigDone () {
+    if (this.seedProvided) app().loadPage('wallets')
+    else slideSwap(this.page.quickConfigForm, this.page.seedBackupForm)
+  }
+
+  seedBackedUp () {
+    app().loadPage('wallets')
+  }
+}
+
+/*
+ * The AppInitForm handles the form that sets the app password, accepts an
+ * optional seed, and initializes the app.
+ */
+class AppInitForm {
+  form: PageElement
+  page: Record<string, PageElement>
+  success: (pw: string, hosts: string[], seedProvided: boolean) => void
+
+  constructor (form: PageElement, success: (pw: string, hosts: string[], seedProvided: boolean) => void) {
+    this.form = form
+    this.success = success
+    const page = this.page = Doc.idDescendants(form)
+    bindForm(form, page.appPWSubmit, () => this.setAppPass())
+    bindForm(form, page.showSeedRestore, () => {
+      Doc.show(page.seedRestore)
+      Doc.hide(page.showSeedRestore)
+    })
+  }
+
+  /* Set the application password. Attached to form submission. */
+  async setAppPass () {
+    const page = this.page
+    Doc.hide(page.appPWErrMsg)
+    const pw = page.appPW.value || ''
+    const pwAgain = page.appPWAgain.value
+    if (pw === '') {
+      page.appPWErrMsg.textContent = intl.prep(intl.ID_NO_PASS_ERROR_MSG)
+      Doc.show(page.appPWErrMsg)
+      return
+    }
+    if (pw !== pwAgain) {
+      page.appPWErrMsg.textContent = intl.prep(intl.ID_PASSWORD_NOT_MATCH)
+      Doc.show(page.appPWErrMsg)
+      return
+    }
+
+    // Clear the notification cache. Useful for development purposes, since
+    // the Application will only clear them on login, which would leave old
+    // browser-cached notifications in place after registering even if the
+    // client db is wiped.
+    app().setNotes([])
+    page.appPW.value = ''
+    page.appPWAgain.value = ''
+    const loaded = app().loading(this.form)
+    const seed = page.seedInput.value
+    const rememberPass = page.rememberPass.checked
+    const res = await postJSON('/api/init', {
+      pass: pw,
+      seed,
+      rememberPass
+    })
+    loaded()
+    if (!app().checkResponse(res)) {
+      page.appPWErrMsg.textContent = res.msg
+      Doc.show(page.appPWErrMsg)
+      return
+    }
+    this.success(pw, res.hosts, Boolean(seed))
+  }
+}
+
+// HostConfigRow is used by the QuickConfigForm to track the user's choices.
+interface HostConfigRow {
+  host: string
+  checkbox: HTMLInputElement
+}
+
+// WalletConfigRow is used by the QuickConfigForm to track the user's choices.
+interface WalletConfigRow {
+  asset: SupportedAsset
+  type: string
+  checkbox: HTMLInputElement
+}
+
+let rowIDCounter = 0
+
+/*
+ * QuickConfigForm handles the form that allows users to quickly configure
+ * view-only servers and native wallets (that don't require any configuration).
+ */
+class QuickConfigForm {
+  page: Record<string, PageElement>
+  form: PageElement
+  servers: HostConfigRow[]
+  wallets: WalletConfigRow[]
+  pw: string
+  success: () => void
+
+  constructor (form: PageElement, success: () => void) {
+    this.form = form
+    this.success = success
+    const page = this.page = Doc.idDescendants(form)
+    Doc.cleanTemplates(page.qcServerTmpl, page.qcWalletTmpl)
+    bindForm(form, page.quickConfigSubmit, () => { this.submit() })
+    bindForm(form, page.qcErrAck, () => { this.success() })
+  }
+
+  async update (pw: string, hosts: string[]) {
+    this.pw = pw
+    const page = this.page
+
+    this.servers = []
+    for (const host of hosts) {
+      const row = page.qcServerTmpl.cloneNode(true) as PageElement
+      page.qcServersBox.appendChild(row)
+      const tmpl = Doc.parseTemplate(row)
+      rowIDCounter++
+      const rowID = `qcsrow${rowIDCounter}`
+      row.htmlFor = rowID
+      tmpl.checkbox.id = rowID
+      tmpl.host.textContent = host
+      this.servers.push({ host, checkbox: tmpl.checkbox as HTMLInputElement })
+    }
+
+    const u = await app().fetchUser() as User
+    this.wallets = []
+    for (const a of Object.values(u.assets)) {
+      if (a.token) continue
+      const winfo = a.info as WalletInfo
+      let autoConfigurable: WalletDefinition | null = null
+      for (const wDef of winfo.availablewallets) {
+        if (!wDef.seeded) continue
+        if (wDef.configopts && wDef.configopts.some((opt: ConfigOption) => opt.required)) continue
+        autoConfigurable = wDef
+        break
+      }
+      if (!autoConfigurable) continue
+      const row = page.qcWalletTmpl.cloneNode(true) as PageElement
+      page.qcWalletsBox.appendChild(row)
+      const tmpl = Doc.parseTemplate(row)
+      rowIDCounter++
+      const rowID = `qcwrow${rowIDCounter}`
+      row.htmlFor = rowID
+      tmpl.checkbox.id = rowID
+      tmpl.icon.src = Doc.logoPath(a.symbol)
+      tmpl.name.textContent = a.name
+      this.wallets.push({
+        asset: a,
+        type: autoConfigurable.type,
+        checkbox: tmpl.checkbox as HTMLInputElement
+      })
+    }
+  }
+
+  async submit () {
+    const [failedHosts, failedWallets]: [string[], string[]] = [[], []]
+    const ani = new Wave(this.form, { backgroundColor: true, message: '...' })
+    ani.opts.message = intl.prep(intl.ID_ADDING_SERVERS)
+    const connectServer = async (srvRow: HostConfigRow) => {
+      if (!srvRow.checkbox.checked) return
+      const req = {
+        addr: srvRow.host,
+        pass: this.pw
+      }
+      const res = await postJSON('/api/adddex', req) // DRAFT NOTE: ignore errors ok?
+      if (!app().checkResponse(res)) failedHosts.push(srvRow.host)
+    }
+    await Promise.all(this.servers.map(connectServer))
+
+    ani.opts.message = intl.prep(intl.ID_CREATING_WALLETS)
+    const createWallet = async (walletRow: WalletConfigRow) => {
+      const { asset: a, type, checkbox } = walletRow
+      if (!checkbox.checked) return
+      const createForm = {
+        assetID: a.id,
+        appPass: this.pw,
+        walletType: type
+      }
+      const res = await postJSON('/api/newwallet', createForm)
+      if (!app().checkResponse(res)) failedWallets.push(a.name)
+    }
+    await Promise.all(this.wallets.map(createWallet))
+
+    ani.stop()
+    await app().fetchUser() // Calls updateMenuItemsDisplay internally
+    if (failedWallets.length + failedHosts.length === 0) return this.success()
+
+    const page = this.page
+    Doc.hide(page.qcChoices)
+    Doc.show(page.qcErrors)
+
+    if (failedHosts.length) {
+      for (const host of failedHosts) {
+        page.qcServerErrorList.appendChild(document.createTextNode(host))
+        page.qcServerErrorList.appendChild(document.createElement('br'))
+      }
+    } else Doc.hide(page.qcServerErrors)
+
+    if (failedWallets.length) {
+      for (const name of failedWallets) {
+        page.qcWalletErrorList.appendChild(document.createTextNode(name))
+        page.qcWalletErrorList.appendChild(document.createElement('br'))
+      }
+    } else Doc.hide(page.qcWalletErrors)
+  }
+}
+
+/*
+ * SeedBackupForm handles the form that allows the user to back up their seed
+ * during initialization.
+ */
+class SeedBackupForm {
+  form: PageElement
+  page: Record<string, PageElement>
+  pw: string
+
+  constructor (form: PageElement, success: () => void) {
+    this.form = form
+    const page = this.page = Doc.idDescendants(form)
+    bindForm(form, page.seedAck, () => success())
+    bindForm(form, page.showSeed, () => this.showSeed())
+  }
+
+  update (pw: string) {
+    this.pw = pw
+  }
+
+  async showSeed () {
+    const loaded = app().loading(this.form)
+    const res = await postJSON('/api/exportseed', { pass: this.pw })
+    loaded()
+    if (!app().checkResponse(res)) {
+      console.error('error exporting seed:', res.msg)
+      return
+    }
+    const page = this.page
+    page.seedDiv.textContent = res.seed
+    Doc.hide(page.sbWanna)
+    Doc.show(page.sbSeed)
+  }
+}

--- a/client/webserver/site/src/js/locales.ts
+++ b/client/webserver/site/src/js/locales.ts
@@ -128,6 +128,8 @@ export const ID_SHIELDED = 'SHIELDED'
 export const ID_SHIELDED_MSG = 'SHIELDED_MSG'
 export const ID_ORDER = 'ORDER'
 export const ID_LOCKED_ORDER_BAL_MSG = 'LOCKED_ORDER_BAL_MSG'
+export const ID_CREATING_WALLETS = 'CREATING_WALLETS'
+export const ID_ADDING_SERVERS = 'ADDING_SERVER'
 
 export const enUS: Locale = {
   [ID_NO_PASS_ERROR_MSG]: 'password cannot be empty',
@@ -258,7 +260,9 @@ export const enUS: Locale = {
   [ID_SHIELDED]: 'Shielded',
   [ID_SHIELDED_MSG]: 'Total funds kept shielded',
   [ID_ORDER]: 'Order',
-  [ID_LOCKED_ORDER_BAL_MSG]: 'Funds locked in unmatched orders'
+  [ID_LOCKED_ORDER_BAL_MSG]: 'Funds locked in unmatched orders',
+  [ID_CREATING_WALLETS]: 'Creating wallets',
+  [ID_ADDING_SERVERS]: 'Connecting to servers'
 }
 
 export const ptBR: Locale = {

--- a/client/webserver/site/src/js/login.ts
+++ b/client/webserver/site/src/js/login.ts
@@ -18,6 +18,6 @@ export default class LoginPage extends BasePage {
   /* login submits the sign-in form and parses the result. */
   async loggedIn () {
     await app().fetchUser()
-    await app().loadPage('markets')
+    await app().loadPage('wallets')
   }
 }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -854,7 +854,7 @@ export default class MarketsPage extends BasePage {
     if (quote.token) {
       const quoteAsset = app().assets[quote.id]
       const quoteVersion = this.market.dex.assets[quote.id].version
-      if (quoteAsset && quoteAsset.wallet.approved && quoteAsset.wallet.approved[quoteVersion] !== undefined) {
+      if (quoteAsset?.wallet?.approved && quoteAsset.wallet.approved[quoteVersion] !== undefined) {
         quoteAssetApprovalStatus = quoteAsset.wallet.approved[quoteVersion]
       }
     }

--- a/client/webserver/site/src/js/register.ts
+++ b/client/webserver/site/src/js/register.ts
@@ -9,10 +9,8 @@ import {
   ConfirmRegistrationForm,
   FeeAssetSelectionForm,
   WalletWaitForm,
-  slideSwap,
-  bind as bindForm
+  slideSwap
 } from './forms'
-import * as intl from './locales'
 import {
   app,
   PasswordCache,
@@ -47,13 +45,6 @@ export default class RegistrationPage extends BasePage {
 
     // Hide the form closers for the registration process.
     body.querySelectorAll('.form-closer').forEach(el => Doc.hide(el))
-
-    // SET APP PASSWORD
-    bindForm(page.appPWForm, page.appPWSubmit, () => this.setAppPass())
-    Doc.bind(page.showSeedRestore, 'click', () => {
-      Doc.show(page.seedRestore)
-      Doc.hide(page.showSeedRestore)
-    })
 
     this.loginForm = new LoginForm(page.loginForm, async () => {
       await app().fetchUser()
@@ -174,52 +165,6 @@ export default class RegistrationPage extends BasePage {
       return 0
     }
     return res.feeBuffer
-  }
-
-  /* Set the application password. Attached to form submission. */
-  async setAppPass () {
-    const page = this.page
-    Doc.hide(page.appPWErrMsg)
-    const pw = page.appPW.value || ''
-    const pwAgain = page.appPWAgain.value
-    if (pw === '') {
-      page.appPWErrMsg.textContent = intl.prep(intl.ID_NO_PASS_ERROR_MSG)
-      Doc.show(page.appPWErrMsg)
-      return
-    }
-    if (pw !== pwAgain) {
-      page.appPWErrMsg.textContent = intl.prep(intl.ID_PASSWORD_NOT_MATCH)
-      Doc.show(page.appPWErrMsg)
-      return
-    }
-
-    // Clear the notification cache. Useful for development purposes, since
-    // the Application will only clear them on login, which would leave old
-    // browser-cached notifications in place after registering even if the
-    // client db is wiped.
-    app().setNotes([])
-    page.appPW.value = ''
-    page.appPWAgain.value = ''
-    const loaded = app().loading(page.appPWForm)
-    const seed = page.seedInput.value
-    const rememberPass = page.rememberPass.checked
-    const res = await postJSON('/api/init', {
-      pass: pw,
-      seed,
-      rememberPass
-    })
-    loaded()
-    if (!app().checkResponse(res)) {
-      page.appPWErrMsg.textContent = res.msg
-      Doc.show(page.appPWErrMsg)
-      return
-    }
-    this.pwCache.pw = pw
-    this.auth()
-    app().updateMenuItemsDisplay()
-    this.newWalletForm.refresh()
-    this.dexAddrForm.refresh()
-    await slideSwap(page.appPWForm, page.dexAddrForm)
   }
 
   /* gets the contents of the cert file */

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -626,7 +626,7 @@ func TestAPIInit(t *testing.T) {
 		Pass: encode.PassBytes("def"),
 	}
 	body = goodBody
-	ensure(s.apiInit, `{"ok":true}`)
+	ensure(s.apiInit, `{"ok":true,"hosts":["dex.decred.org:7232"]}`)
 
 	// Initialization error
 	tCore.initErr = tErr


### PR DESCRIPTION
This reworks app initialization to achieve a number of ux goals.

1) Adds chance for user to quickly configure native wallets and add
   known servers (view-only), https://github.com/decred/dcrdex/pull/1986#discussion_r1061747565
2) Adds seed backup dialog
3) Makes the Wallets view the landing page

![image](https://github.com/decred/dcrdex/assets/6109680/31d80d5f-b6c3-4c55-a0e7-2c8dc11879cd)
