### PR TITLE
[0.6.2] asset: Implement asset.FeeRater for SPV wallets and minor refactor

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -212,15 +212,15 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		// Bitcoin Cash don't take a change_type argument in their options
 		// unlike Bitcoin Core.
 		OmitAddressType: true,
-		// Bitcoin Cash uses estimatefee instead of estimatesmartfee, and even
-		// then, they modified it from the old Bitcoin Core estimatefee by
-		// removing the confirmation target argument.
-		FeeEstimator: estimateFee,
-		AssetID:      BipID,
+		AssetID:         BipID,
 	}
 
 	switch cfg.Type {
 	case walletTypeRPC, walletTypeLegacy:
+		// Bitcoin Cash uses estimatefee instead of estimatesmartfee, and even
+		// then, they modified it from the old Bitcoin Core estimatefee by
+		// removing the confirmation target argument.
+		cloneCFG.FeeEstimator = estimateFee
 		return btc.BTCCloneWallet(cloneCFG)
 	// case walletTypeElectrum:
 	// 	logger.Warnf("\n\nUNTESTED Bitcoin Cash ELECTRUM WALLET IMPLEMENTATION! DO NOT USE ON mainnet!\n\n")

--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -26,7 +26,6 @@ type ExchangeWalletElectrum struct {
 }
 
 var _ asset.Wallet = (*ExchangeWalletElectrum)(nil)
-var _ asset.FeeRater = (*ExchangeWalletElectrum)(nil)
 
 // ElectrumWallet creates a new ExchangeWalletElectrum for the provided
 // configuration, which must contain the necessary details for accessing the
@@ -64,12 +63,10 @@ func ElectrumWallet(cfg *BTCCloneCFG) (*ExchangeWalletElectrum, error) {
 		ew:         ew,
 	}
 	// In (*baseWallet).feeRate, use ExchangeWalletElectrum's walletFeeRate
-	// override for localFeeRate. No externalFeeRate is required. Note that we
-	// could set cfg.FeeEstimator to wrap ewc.FeeRate, but we'll use the
-	// ExchangeWalletElectrum method instead.
-	btc.localFeeRate = func(ctx context.Context, _ RawRequester, confTarget uint64) (uint64, error) {
-		return eew.walletFeeRate(ctx, confTarget)
-	}
+	// override for localFeeRate. No externalFeeRate is required but will be
+	// used if eew.walletFeeRate returned an error and an externalFeeRate is
+	// enabled.
+	btc.localFeeRate = eew.walletFeeRate
 
 	return eew, nil
 }
@@ -138,23 +135,13 @@ func (btc *ExchangeWalletElectrum) Connect(ctx context.Context) (*sync.WaitGroup
 	return wg, nil
 }
 
-func (btc *ExchangeWalletElectrum) walletFeeRate(ctx context.Context, confTarget uint64) (uint64, error) {
+// walletFeeRate satisfies BTCCloneCFG.FeeEstimator.
+func (btc *ExchangeWalletElectrum) walletFeeRate(ctx context.Context, _ RawRequester, confTarget uint64) (uint64, error) {
 	satPerKB, err := btc.ew.wallet.FeeRate(ctx, int64(confTarget))
 	if err != nil {
 		return 0, err
 	}
 	return uint64(dex.IntDivUp(satPerKB, 1000)), nil
-}
-
-// FeeRate gets a fee rate estimate. Satisfies asset.FeeRater. Electrum's fee
-// rate is already externally-sourced, so we simplify for FeeRate callers.
-func (btc *ExchangeWalletElectrum) FeeRate() uint64 {
-	feeRate, err := btc.walletFeeRate(btc.ew.ctx, 1)
-	if err != nil {
-		btc.log.Errorf("Failed to retrieve fee rate: %v", err)
-		return 0
-	}
-	return feeRate
 }
 
 // findRedemption will search for the spending transaction of specified


### PR DESCRIPTION
Backport of https://github.com/decred/dcrdex/pull/2356 to v0.6.2

This is so the native SPV wallets are `FeeRaters`, providing a live estimate from any enabled external source.