### PR TITLE
CI: specify golangci config file

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -68,4 +68,4 @@ cd "$dir"
 # static checker.
 
 # check linters
-golangci-lint run
+golangci-lint -c ./.golangci.yml run


### PR DESCRIPTION
My workspace has a .golangci.json file (not .golangci.yml) that golangci-lint seems to prefer.  I use this to configure my IDE, where I use more strict linters, which I can ignore.  When I ran run_tests.sh, it used the default linters instead of the ones in the new .golangci.yml file.  This fixes the issue by having run_tests.sh do `golangci-lint -c ./.golangci.yml run`.

Here's my .golangci.json file for reference.  I use this because I like the revive linter in my IDE, but we don't want it in CI.  Also I occasionally turn on the shadowing checks for go vet, but most of the time it makes too much noise about shadowed `err` variables.

```json
{
    "linters-settings": {
        "govet": {
            "check-shadowing": false
        },
        "revive": {
            "enableAllRules": true,
            "rules": [
                {
                    "name": "var-naming",
                    "disabled": true
                }
            ]
        }
    }
}
```
