### PR TITLE
site: bond asset choice wording tweaks

### DIFF
--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -185,7 +185,7 @@ var EnUS = map[string]string{
 	"Export Trades":               "Export Trades",
 	"change the wallet type":      "change the wallet type",
 	"confirmations":               "confirmations",
-	"how_reg":                     "How will you post bond?",
+	"how_reg":                     "How will you create your bond?",
 	"All markets at":              "All markets at",
 	"pick a different asset":      "pick a different asset",
 	"Create":                      "Create",

--- a/client/webserver/site/src/css/forms.scss
+++ b/client/webserver/site/src/css/forms.scss
@@ -1,5 +1,5 @@
 #regAssetForm {
-  position: relative;
+  max-width: 425px;
 
   div.reg-asset-allmkts {
     min-width: 210px;

--- a/client/webserver/site/src/css/forms.scss
+++ b/client/webserver/site/src/css/forms.scss
@@ -1,5 +1,7 @@
 #regAssetForm {
-  max-width: 425px;
+  #whatsabond {
+    max-width: 425px;
+  }
 
   div.reg-asset-allmkts {
     min-width: 210px;

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=f63dbec4" rel="stylesheet">
+  <link href="/css/style.css?v=nTZAqUp" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=XkMuUH"></script>
+<script src="/js/entry.js?v=nTZAqUp"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -218,6 +218,10 @@
 
 {{define "regAssetForm"}}
 <div class="text-center sans-light fs24 mb-3" data-tmpl="how">[[[how_reg]]]</div>
+<div class="mt-1">
+  <span class="ico-info"></span>
+  <span class="fs14">[[[whatsabond]]]</span>
+</div>
 <div data-tmpl="assets">
   <div data-tmpl="assetTmpl" class="reg-asset pointer d-flex align-items-stretch">
     <div class="reg-asset-logo-wrapper d-flex align-items-center justify-content-center">

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -218,9 +218,9 @@
 
 {{define "regAssetForm"}}
 <div class="text-center sans-light fs24 mb-3" data-tmpl="how">[[[how_reg]]]</div>
-<div class="mt-1">
+<div class="mt-1 fs14">
   <span class="ico-info"></span>
-  <span class="fs14">[[[whatsabond]]]</span>
+  <span class="ms-1">[[[whatsabond]]]</span>
 </div>
 <div data-tmpl="assets">
   <div data-tmpl="assetTmpl" class="reg-asset pointer d-flex align-items-stretch">

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -218,7 +218,7 @@
 
 {{define "regAssetForm"}}
 <div class="text-center sans-light fs24 mb-3" data-tmpl="how">[[[how_reg]]]</div>
-<div class="mt-1 fs14">
+<div id="whatsabond" class="mt-1 fs14">
   <span class="ico-info"></span>
   <span class="ms-1">[[[whatsabond]]]</span>
 </div>

--- a/client/webserver/site/src/js/register.ts
+++ b/client/webserver/site/src/js/register.ts
@@ -94,7 +94,7 @@ export default class RegistrationPage extends BasePage {
       if (wallet) {
         const bondAsset = this.currentDEX.bondAssets[asset.symbol]
         const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.regAssetForm)
-        if (wallet.synced && wallet.balance.available > 2 * bondAsset.amount + bondsFeeBuffer) {
+        if (wallet.synced && wallet.balance.available >= 2 * bondAsset.amount + bondsFeeBuffer) {
           this.animateConfirmForm(page.regAssetForm)
           return
         }
@@ -165,7 +165,7 @@ export default class RegistrationPage extends BasePage {
     Doc.show(this.page.confirmRegForm)
   }
 
-  // Retrieve an estimate for the tx fee needed to pay the registration fee.
+  // Retrieve an estimate for the tx fee needed to create new bond reserves.
   async getBondsFeeBuffer (assetID: number, form: HTMLElement) {
     const loaded = app().loading(form)
     const res = await postJSON('/api/bondsfeebuffer', { assetID })
@@ -248,7 +248,7 @@ export default class RegistrationPage extends BasePage {
     const bondAmt = this.currentDEX.bondAssets[asset.symbol].amount
 
     const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.newWalletForm)
-    if (wallet.synced && wallet.balance.available > 2 * bondAmt + bondsFeeBuffer) {
+    if (wallet.synced && wallet.balance.available >= 2 * bondAmt + bondsFeeBuffer) {
       await this.animateConfirmForm(page.newWalletForm)
       return
     }

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -80,12 +80,12 @@ export default class SettingsPage extends BasePage {
       const wallet = asset.wallet
       if (wallet) {
         const bondAsset = this.currentDEX.bondAssets[asset.symbol]
-        if (wallet.synced && wallet.balance.available > bondAsset.amount) {
+        const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.regAssetForm)
+        if (wallet.synced && wallet.balance.available >= 2 * bondAsset.amount + bondsFeeBuffer) {
           this.animateConfirmForm(page.regAssetForm)
           return
         }
-        const txFee = await this.getRegistrationTxFeeEstimate(assetID, page.regAssetForm)
-        this.walletWaitForm.setWallet(wallet, txFee)
+        this.walletWaitForm.setWallet(wallet, bondsFeeBuffer)
         forms.slideSwap(page.regAssetForm, page.walletWait)
         return
       }
@@ -158,20 +158,15 @@ export default class SettingsPage extends BasePage {
     })
   }
 
-  // Retrieve an estimate for the tx fee needed to pay the registration fee.
-  async getRegistrationTxFeeEstimate (assetID: number, form: HTMLElement) {
-    const cert = await this.getCertFile()
+  // Retrieve an estimate for the tx fee needed to create new bond reserves.
+  async getBondsFeeBuffer (assetID: number, form: HTMLElement) {
     const loaded = app().loading(form)
-    const res = await postJSON('/api/regtxfee', {
-      addr: this.currentDEX.host,
-      cert: cert,
-      asset: assetID
-    })
+    const res = await postJSON('/api/bondsfeebuffer', { assetID })
     loaded()
     if (!app().checkResponse(res)) {
       return 0
     }
-    return res.txfee
+    return res.feeBuffer
   }
 
   async newWalletCreated (assetID: number) {
@@ -182,13 +177,13 @@ export default class SettingsPage extends BasePage {
     const wallet = asset.wallet
     const bondAmt = this.currentDEX.bondAssets[asset.symbol].amount
 
-    if (wallet.synced && wallet.balance.available > bondAmt) {
+    const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.newWalletForm)
+    if (wallet.synced && wallet.balance.available >= 2 * bondAmt + bondsFeeBuffer) {
       await this.animateConfirmForm(page.newWalletForm)
       return
     }
 
-    const txFee = await this.getRegistrationTxFeeEstimate(assetID, page.newWalletForm)
-    this.walletWaitForm.setWallet(wallet, txFee)
+    this.walletWaitForm.setWallet(wallet, bondsFeeBuffer)
     this.currentForm = page.walletWait
     await forms.slideSwap(page.newWalletForm, page.walletWait)
   }

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -86,6 +86,7 @@ export default class SettingsPage extends BasePage {
           return
         }
         this.walletWaitForm.setWallet(wallet, bondsFeeBuffer)
+        this.currentForm = page.walletWait
         forms.slideSwap(page.regAssetForm, page.walletWait)
         return
       }


### PR DESCRIPTION
Based on feedback from the community and other users new to Decred, this tweaks some of the bond messaging during registration:

- "How will you post bond?" ==> "How will you create your bond?" on the form where you choose the bond asset
- Includes the `whatsabond` info text on the same form, just below the previous question/title

![image](https://github.com/decred/dcrdex/assets/9373513/105a1b3a-efdb-4742-a0aa-19b2ad763b35)
