### PR TITLE
[0.6.2] client/webserver: avoid authMiddleware for file server

### DIFF
--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -289,7 +289,6 @@ func New(cfg *Config) (*WebServer, error) {
 	}
 	mux.Use(s.securityMiddleware)
 	mux.Use(middleware.Recoverer)
-	mux.Use(s.authMiddleware)
 
 	// HTTP profiler
 	if cfg.HttpProf {
@@ -313,6 +312,7 @@ func New(cfg *Config) (*WebServer, error) {
 
 	// Webpages
 	mux.Group(func(web chi.Router) {
+		web.Use(s.authMiddleware)
 		// The register page and settings page are always allowed.
 		// The register page performs init if needed, along with
 		// initial setup and settings is used to register more DEXs
@@ -363,6 +363,7 @@ func New(cfg *Config) (*WebServer, error) {
 
 	// api endpoints
 	mux.Route("/api", func(r chi.Router) {
+		r.Use(s.authMiddleware)
 		r.Use(middleware.AllowContentType("application/json"))
 		r.Post("/init", s.apiInit)
 		r.Get("/isinitialized", s.apiIsInitialized)


### PR DESCRIPTION
Absolutely minimal version of https://github.com/decred/dcrdex/pull/2350
This just stops calling `(*Core).User` in the file server.  The effect is that static asset retrieval is on the order of microseconds instead of milliseconds.
This version does not change any of the middleware used in either the web or api routers.