### PR TITLE
client/mm: Update Basic Market Maker 

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -143,19 +143,39 @@ var (
 	defaultWalletBirthdayUnix = 1622668320
 	defaultWalletBirthday     = time.Unix(int64(defaultWalletBirthdayUnix), 0)
 
+	multiFundingOpts = []*asset.ConfigOption{
+		{
+			Key:         multiSplitKey,
+			DisplayName: "External fee rate estimates",
+			Description: "Allow split funding transactions that pre-size outputs to " +
+				"prevent excessive overlock.",
+			IsBoolean:    true,
+			DefaultValue: true,
+		},
+		{
+			Key:         multiSplitBufferKey,
+			DisplayName: "External fee rate estimates",
+			Description: "Add an integer percent buffer to split output amounts to " +
+				"facilitate output reuse",
+			DefaultValue: true,
+		},
+	}
+
 	rpcWalletDefinition = &asset.WalletDefinition{
 		Type:              walletTypeRPC,
 		Tab:               "External",
 		Description:       "Connect to bitcoind",
 		DefaultConfigPath: dexbtc.SystemConfigPath("bitcoin"),
 		ConfigOpts:        append(RPCConfigOpts("Bitcoin", "8332"), CommonConfigOpts("BTC", true)...),
+		MultiFundingOpts:  multiFundingOpts,
 	}
 	spvWalletDefinition = &asset.WalletDefinition{
-		Type:        walletTypeSPV,
-		Tab:         "Native",
-		Description: "Use the built-in SPV wallet",
-		ConfigOpts:  append(SPVConfigOpts("BTC"), CommonConfigOpts("BTC", true)...),
-		Seeded:      true,
+		Type:             walletTypeSPV,
+		Tab:              "Native",
+		Description:      "Use the built-in SPV wallet",
+		ConfigOpts:       append(SPVConfigOpts("BTC"), CommonConfigOpts("BTC", true)...),
+		Seeded:           true,
+		MultiFundingOpts: multiFundingOpts,
 	}
 
 	electrumWalletDefinition = &asset.WalletDefinition{
@@ -771,7 +791,7 @@ type fundMultiOptions struct {
 	// will be created with one output per order.
 	//
 	// Use the multiSplitKey const defined above in the options map to set this option.
-	Split *bool
+	Split bool `ini:"multisplit"`
 	// SplitBuffer, if set, will instruct the wallet to add a buffer onto each
 	// output of the multi-order split transaction (if the split is needed).
 	// SplitBuffer is defined as a percentage of the output. If a .1 BTC output
@@ -788,32 +808,12 @@ type fundMultiOptions struct {
 	// is no split buffer, this may necessitate a new split transaction.
 	//
 	// Use the multiSplitBufferKey const defined above in the options map to set this.
-	SplitBuffer *uint64
+	SplitBuffer uint64 `ini:"multisplitbuffer"`
 }
 
 func decodeFundMultiOptions(options map[string]string) (*fundMultiOptions, error) {
 	opts := new(fundMultiOptions)
-	if options == nil {
-		return opts, nil
-	}
-
-	if split, ok := options[multiSplitKey]; ok {
-		b, err := strconv.ParseBool(split)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing split option: %w", err)
-		}
-		opts.Split = &b
-	}
-
-	if splitBuffer, ok := options[multiSplitBufferKey]; ok {
-		b, err := strconv.ParseUint(splitBuffer, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing split buffer option: %w", err)
-		}
-		opts.SplitBuffer = &b
-	}
-
-	return opts, nil
+	return opts, config.Unmapify(options, opts)
 }
 
 // redeemOptions are order options that apply to redemptions.
@@ -6107,30 +6107,18 @@ func (btc *baseWallet) FundMultiOrder(mo *asset.MultiOrder, maxLock uint64) ([]a
 		return nil, nil, 0, fmt.Errorf("error decoding options: %w", err)
 	}
 
-	var useSplit bool
-	var splitBuffer uint64
-	if customCfg.Split != nil {
-		useSplit = *customCfg.Split
-	}
-	if useSplit && customCfg.SplitBuffer != nil {
-		splitBuffer = *customCfg.SplitBuffer
-	}
-
-	return btc.fundMulti(maxLock, mo.Values, mo.FeeSuggestion, mo.MaxFeeRate, useSplit, splitBuffer)
+	return btc.fundMulti(maxLock, mo.Values, mo.FeeSuggestion, mo.MaxFeeRate, customCfg.Split, customCfg.SplitBuffer)
 }
 
 // MaxFundingFees returns the maximum funding fees for an order/multi-order.
-func (btc *baseWallet) MaxFundingFees(numTrades uint32, options map[string]string) uint64 {
-	useSplit := btc.useSplitTx()
-	if options != nil {
-		if split, ok := options[splitKey]; ok {
-			useSplit, _ = strconv.ParseBool(split)
-		}
-		if split, ok := options[multiSplitKey]; ok {
-			useSplit, _ = strconv.ParseBool(split)
-		}
+func (btc *baseWallet) MaxFundingFees(numTrades uint32, feeRate uint64, options map[string]string) uint64 {
+	customCfg, err := decodeFundMultiOptions(options)
+	if err != nil {
+		btc.log.Errorf("Error decoding multi-fund settings: %v", err)
+		return 0
 	}
-	if !useSplit {
+
+	if !customCfg.Split {
 		return 0
 	}
 
@@ -6146,7 +6134,7 @@ func (btc *baseWallet) MaxFundingFees(numTrades uint32, options map[string]strin
 	const numInputs = 12 // plan for lots of inputs to get a safe estimate
 
 	txSize := dexbtc.MinimumTxOverhead + numInputs*inputSize + uint64(numTrades+1)*outputSize
-	return btc.feeRateLimit() * txSize
+	return feeRate * txSize
 }
 
 type utxo struct {

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -2026,17 +2026,13 @@ func testMaxFundingFees(t *testing.T, segwit bool, walletType string) {
 	wallet, _, shutdown := tNewWallet(segwit, walletType)
 	defer shutdown()
 
-	feeRateLimit := uint64(100)
-
-	wallet.cfgV.Store(&baseWalletConfig{
-		feeRateLimit: feeRateLimit,
-	})
+	maxFeeRate := uint64(100)
 
 	useSplitOptions := map[string]string{
-		splitKey: "true",
+		multiSplitKey: "true",
 	}
 	noSplitOptions := map[string]string{
-		splitKey: "false",
+		multiSplitKey: "false",
 	}
 
 	var inputSize, outputSize uint64
@@ -2050,13 +2046,13 @@ func testMaxFundingFees(t *testing.T, segwit bool, walletType string) {
 
 	const maxSwaps = 3
 	const numInputs = 12
-	maxFundingFees := wallet.MaxFundingFees(maxSwaps, useSplitOptions)
-	expectedFees := feeRateLimit * (inputSize*numInputs + outputSize*(maxSwaps+1) + dexbtc.MinimumTxOverhead)
+	maxFundingFees := wallet.MaxFundingFees(maxSwaps, maxFeeRate, useSplitOptions)
+	expectedFees := maxFeeRate * (inputSize*numInputs + outputSize*(maxSwaps+1) + dexbtc.MinimumTxOverhead)
 	if maxFundingFees != expectedFees {
 		t.Fatalf("unexpected max funding fees. expected %d, got %d", expectedFees, maxFundingFees)
 	}
 
-	maxFundingFees = wallet.MaxFundingFees(maxSwaps, noSplitOptions)
+	maxFundingFees = wallet.MaxFundingFees(maxSwaps, maxFeeRate, noSplitOptions)
 	if maxFundingFees != 0 {
 		t.Fatalf("unexpected max funding fees. expected 0, got %d", maxFundingFees)
 	}

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -687,26 +687,22 @@ func TestMaxFundingFees(t *testing.T) {
 	wallet, _, shutdown := tNewWallet()
 	defer shutdown()
 
-	feeRateLimit := uint64(100)
-
-	wallet.cfgV.Store(&exchangeWalletConfig{
-		feeRateLimit: feeRateLimit,
-	})
+	maxFeeRate := uint64(100)
 
 	useSplitOptions := map[string]string{
-		splitKey: "true",
+		multiSplitKey: "true",
 	}
 	noSplitOptions := map[string]string{
-		splitKey: "false",
+		multiSplitKey: "false",
 	}
 
-	maxFundingFees := wallet.MaxFundingFees(3, useSplitOptions)
-	expectedFees := feeRateLimit * (dexdcr.P2PKHInputSize*12 + dexdcr.P2PKHOutputSize*4 + dexdcr.MsgTxOverhead)
+	maxFundingFees := wallet.MaxFundingFees(3, maxFeeRate, useSplitOptions)
+	expectedFees := maxFeeRate * (dexdcr.P2PKHInputSize*12 + dexdcr.P2PKHOutputSize*4 + dexdcr.MsgTxOverhead)
 	if maxFundingFees != expectedFees {
 		t.Fatalf("unexpected max funding fees. expected %d, got %d", expectedFees, maxFundingFees)
 	}
 
-	maxFundingFees = wallet.MaxFundingFees(3, noSplitOptions)
+	maxFundingFees = wallet.MaxFundingFees(3, maxFeeRate, noSplitOptions)
 	if maxFundingFees != 0 {
 		t.Fatalf("unexpected max funding fees. expected 0, got %d", maxFundingFees)
 	}

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1287,7 +1287,7 @@ func (w *assetWallet) preSwap(req *asset.PreSwapForm, feeWallet *assetWallet) (*
 }
 
 // MaxFundingFees returns 0 because ETH does not have funding fees.
-func (w *baseWallet) MaxFundingFees(_ uint32, _ map[string]string) uint64 {
+func (w *baseWallet) MaxFundingFees(_ uint32, _ uint64, _ map[string]string) uint64 {
 	return 0
 }
 

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1292,11 +1292,12 @@ func (w *baseWallet) MaxFundingFees(_ uint32, _ map[string]string) uint64 {
 }
 
 // SingleLotSwapFees returns the fees for a swap transaction for a single lot.
-func (w *assetWallet) SingleLotSwapFees(version uint32, feeSuggestion uint64, _ map[string]string) (fees uint64, err error) {
+func (w *assetWallet) SingleLotSwapFees(version uint32, feeSuggestion uint64, _ bool) (fees uint64, err error) {
 	g := w.gases(version)
 	if g == nil {
 		return 0, fmt.Errorf("no gases known for %d version %d", w.assetID, version)
 	}
+
 	return g.Swap * feeSuggestion, nil
 }
 
@@ -1361,11 +1362,12 @@ func (w *assetWallet) PreRedeem(req *asset.PreRedeemForm) (*asset.PreRedeem, err
 }
 
 // SingleLotRedeemFees returns the fees for a redeem transaction for a single lot.
-func (w *assetWallet) SingleLotRedeemFees(version uint32, feeSuggestion uint64, options map[string]string) (fees uint64, err error) {
+func (w *assetWallet) SingleLotRedeemFees(version uint32, feeSuggestion uint64) (fees uint64, err error) {
 	g := w.gases(version)
 	if g == nil {
 		return 0, fmt.Errorf("no gases known for %d version %d", w.assetID, version)
 	}
+
 	return g.Redeem * feeSuggestion, nil
 }
 

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -507,9 +507,9 @@ type Wallet interface {
 	// used to call the function.
 	ConfirmRedemption(coinID dex.Bytes, redemption *Redemption, feeSuggestion uint64) (*ConfirmRedemptionStatus, error)
 	// SingleLotSwapFees returns the fees for a swap transaction for a single lot.
-	SingleLotSwapFees(version uint32, feeRate uint64, options map[string]string) (uint64, error)
+	SingleLotSwapFees(version uint32, feeRate uint64, useSafeTxSize bool) (uint64, error)
 	// SingleLotRedeemFees returns the fees for a redeem transaction for a single lot.
-	SingleLotRedeemFees(version uint32, feeRate uint64, options map[string]string) (uint64, error)
+	SingleLotRedeemFees(version uint32, feeRate uint64) (uint64, error)
 	// FundMultiOrder funds multiple orders at once. The return values will
 	// be in the same order as the passed orders. If less values are returned
 	// than the number of orders, then the orders at the end of the list were

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -234,6 +234,8 @@ type WalletDefinition struct {
 	// description for each option. This can be used to request config info from
 	// users e.g. via dynamically generated GUI forms.
 	ConfigOpts []*ConfigOption `json:"configopts"`
+	// MultiFundingOpts are options related to funding multi-trades.
+	MultiFundingOpts []*ConfigOption `json:"multifundingopts"`
 	// NoAuth indicates that the wallet does not implement the Authenticator
 	// interface. A better way to check is to use the wallet traits but wallet
 	// construction is presently required to discern traits.
@@ -516,7 +518,7 @@ type Wallet interface {
 	// not about to be funded.
 	FundMultiOrder(ord *MultiOrder, maxLock uint64) (coins []Coins, redeemScripts [][]dex.Bytes, fundingFees uint64, err error)
 	// MaxFundingFees returns the max fees that could be paid for funding a swap.
-	MaxFundingFees(numTrades uint32, options map[string]string) uint64
+	MaxFundingFees(numTrades uint32, feeRate uint64, options map[string]string) uint64
 }
 
 // Authenticator is a wallet implementation that require authentication.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5551,13 +5551,25 @@ func (c *Core) SingleLotFees(form *SingleLotFeesForm) (uint64, uint64, error) {
 }
 
 // MaxFundingFees gives the max fees required to fund a Trade or MultiTrade.
-func (c *Core) MaxFundingFees(fromAsset uint32, numTrades uint32, options map[string]string) (uint64, error) {
+// The host is needed to get the MaxFeeRate, which is used to calculate
+// the funding fees.
+func (c *Core) MaxFundingFees(fromAsset uint32, host string, numTrades uint32, options map[string]string) (uint64, error) {
 	wallet, found := c.wallet(fromAsset)
 	if !found {
 		return 0, newError(missingWalletErr, "no wallet found for %s", unbip(fromAsset))
 	}
 
-	return wallet.MaxFundingFees(numTrades, options), nil
+	exchange, err := c.Exchange(host)
+	if err != nil {
+		return 0, err
+	}
+
+	asset, found := exchange.Assets[fromAsset]
+	if !found {
+		return 0, fmt.Errorf("asset %d not found for %s", fromAsset, host)
+	}
+
+	return wallet.MaxFundingFees(numTrades, asset.MaxFeeRate, options), nil
 }
 
 // PreOrder calculates fee estimates for a trade.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5537,12 +5537,12 @@ func (c *Core) SingleLotFees(form *SingleLotFeesForm) (uint64, uint64, error) {
 		}
 	}
 
-	swapFees, err := wallets.fromWallet.SingleLotSwapFees(assetConfigs.fromAsset.Version, swapFeeRate, form.Options)
+	swapFees, err := wallets.fromWallet.SingleLotSwapFees(assetConfigs.fromAsset.Version, swapFeeRate, form.UseSafeTxSize)
 	if err != nil {
 		return 0, 0, fmt.Errorf("error calculating swap fees: %w", err)
 	}
 
-	redeemFees, err := wallets.toWallet.SingleLotRedeemFees(assetConfigs.toAsset.Version, redeemFeeRate, form.Options)
+	redeemFees, err := wallets.toWallet.SingleLotRedeemFees(assetConfigs.toAsset.Version, redeemFeeRate)
 	if err != nil {
 		return 0, 0, fmt.Errorf("error calculating redeem fees: %w", err)
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1067,7 +1067,7 @@ func (w *TXCWallet) ReturnRedemptionAddress(addr string) {
 func (w *TXCWallet) ReturnRefundContracts(contracts [][]byte) {
 	w.returnedContracts = contracts
 }
-func (w *TXCWallet) MaxFundingFees(_ uint32, _ map[string]string) uint64 {
+func (w *TXCWallet) MaxFundingFees(_ uint32, _ uint64, _ map[string]string) uint64 {
 	return 0
 }
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1030,11 +1030,11 @@ func (w *TXCWallet) PreAccelerate(swapCoins, accelerationCoins []dex.Bytes, chan
 	return w.preAccelerateSwapRate, &w.preAccelerateSuggestedRange, nil, nil
 }
 
-func (w *TXCWallet) SingleLotSwapFees(version uint32, feeRate uint64, options map[string]string) (uint64, error) {
+func (w *TXCWallet) SingleLotSwapFees(version uint32, feeRate uint64, useSafeTxSize bool) (uint64, error) {
 	return 0, nil
 }
 
-func (w *TXCWallet) SingleLotRedeemFees(version uint32, feeRate uint64, options map[string]string) (uint64, error) {
+func (w *TXCWallet) SingleLotRedeemFees(version uint32, feeRate uint64) (uint64, error) {
 	return 0, nil
 }
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -1012,12 +1012,12 @@ type MultiTradeForm struct {
 
 // SingleLotFeesForm is used to determine the fees for a single lot trade.
 type SingleLotFeesForm struct {
-	Host          string            `json:"host"`
-	Base          uint32            `json:"base"`
-	Quote         uint32            `json:"quote"`
-	Sell          bool              `json:"sell"`
-	Options       map[string]string `json:"options"`
-	UseMaxFeeRate bool              `json:"useMaxFeeRate"`
+	Host          string `json:"host"`
+	Base          uint32 `json:"base"`
+	Quote         uint32 `json:"quote"`
+	Sell          bool   `json:"sell"`
+	UseMaxFeeRate bool   `json:"useMaxFeeRate"`
+	UseSafeTxSize bool   `json:"useSafeTxSize"`
 }
 
 // marketName is a string ID constructed from the asset IDs.

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -33,7 +33,7 @@ type clientCore interface {
 	PreOrder(form *core.TradeForm) (*core.OrderEstimate, error)
 	WalletState(assetID uint32) *core.WalletState
 	MultiTrade(pw []byte, form *core.MultiTradeForm) ([]*core.Order, error)
-	MaxFundingFees(fromAsset uint32, numTrades uint32, options map[string]string) (uint64, error)
+	MaxFundingFees(fromAsset uint32, host string, numTrades uint32, fromSettings map[string]string) (uint64, error)
 	User() *core.User
 	Login(pw []byte) error
 	OpenWallet(assetID uint32, appPW []byte) error

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -475,7 +475,7 @@ func (m *MarketMaker) handleMatchUpdate(match *core.Match, oid dex.Bytes) {
 
 	orderInfo := m.getOrderInfo(oid)
 	if orderInfo == nil {
-		m.log.Errorf("did not find order info for order %s", oid)
+		m.log.Debugf("did not find order info for order %s", oid)
 		return
 	}
 
@@ -732,6 +732,8 @@ func (m *MarketMaker) Run(ctx context.Context, cfgs []*BotConfig, pw []byte) err
 		return err
 	}
 
+	user := m.core.User()
+
 	startedMarketMaking = true
 
 	wg := new(sync.WaitGroup)
@@ -761,7 +763,12 @@ func (m *MarketMaker) Run(ctx context.Context, cfgs []*BotConfig, pw []byte) err
 			go func(cfg *BotConfig) {
 				logger := m.log.SubLogger(fmt.Sprintf("MarketMaker-%s-%d-%d", cfg.Host, cfg.BaseAsset, cfg.QuoteAsset))
 				mktID := dexMarketID(cfg.Host, cfg.BaseAsset, cfg.QuoteAsset)
-				RunBasicMarketMaker(m.ctx, cfg, m.wrappedCoreForBot(mktID), oracle, pw, logger)
+				var baseFiatRate, quoteFiatRate float64
+				if user != nil {
+					baseFiatRate = user.FiatRates[cfg.BaseAsset]
+					quoteFiatRate = user.FiatRates[cfg.QuoteAsset]
+				}
+				RunBasicMarketMaker(m.ctx, cfg, m.wrappedCoreForBot(mktID), oracle, baseFiatRate, quoteFiatRate, logger)
 				wg.Done()
 			}(cfg)
 		default:

--- a/client/mm/mm_basic.go
+++ b/client/mm/mm_basic.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"decred.org/dcrdex/client/core"
 	"decred.org/dcrdex/client/orderbook"
@@ -50,19 +50,34 @@ const (
 	GapStrategyPercentPlus GapStrategy = "percent-plus"
 )
 
-// MarketMakingConfig is the configuration for a simple market
-// maker that places orders on both sides of the order book.
-type MarketMakingConfig struct {
-	// Lots is the number of lots to allocate to each side of the market. This
-	// is an ideal allotment, but at any given time, a side could have up to
-	// 2 * Lots on order.
+// OrderPlacement represents the distance from the mid-gap and the
+// amount of lots that should be placed at this distance.
+type OrderPlacement struct {
+	// Lots is the max number of lots to place at this distance from the
+	// mid-gap rate. If there is not enough balance to place this amount
+	// of lots, the max that can be afforded will be placed.
 	Lots uint64 `json:"lots"`
-
-	// GapStrategy selects an algorithm for calculating the target spread.
-	GapStrategy GapStrategy `json:"gapStrategy"`
 
 	// GapFactor controls the gap width in a way determined by the GapStrategy.
 	GapFactor float64 `json:"gapFactor"`
+}
+
+// MarketMakingConfig is the configuration for a simple market
+// maker that places orders on both sides of the order book.
+type MarketMakingConfig struct {
+	// GapStrategy selects an algorithm for calculating the distance from
+	// the basis price to place orders.
+	GapStrategy GapStrategy `json:"gapStrategy"`
+
+	// SellPlacements is a list of order placements for sell orders.
+	// The orders are prioritized from the first in this list to the
+	// last.
+	SellPlacements []*OrderPlacement `json:"sellPlacements"`
+
+	// BuyPlacements is a list of order placements for buy orders.
+	// The orders are prioritized from the first in this list to the
+	// last.
+	BuyPlacements []*OrderPlacement `json:"buyPlacements"`
 
 	// DriftTolerance is how far away from an ideal price orders can drift
 	// before they are replaced (units: ratio of price). Default: 0.1%.
@@ -83,7 +98,32 @@ type MarketMakingConfig struct {
 
 	// EmptyMarketRate can be set if there is no market data available, and is
 	// ignored if there is market data available.
-	EmptyMarketRate float64 `json:"manualRate"`
+	EmptyMarketRate float64 `json:"emptyMarketRate"`
+
+	// SplitTxAllowed indicates whether the wallet (if it supports multi-splits)
+	// is allowed to do multi split transactions when funding orders. For UTXO
+	// based assets, it may not be possible to fund each of the orders without
+	// a split transaction which creates outputs of the size required by each
+	// order.
+	SplitTxAllowed bool `json:"splitTxAllowed"`
+
+	// SplitBuffer indicates whether the quote asset wallet (if it supports
+	// multi-splits) should add a buffer to the split amount. This is useful
+	// to prevent too many split transactions from being created. During the
+	// operation of this market maker, orders will be frequently placed and
+	// canceled as the price moves. If the price moves upward and there is
+	// no split buffer, the wallet may need to create a new split transaction
+	// to fund the new orders.
+	//
+	// The split buffer is a percentage of the total amount required for an
+	// order. For example if the order requires 0.1 BTC and the split buffer
+	// is 5, the wallet will create a split transaction with an output of
+	// 0.105 BTC.
+	SplitBuffer *uint64 `json:"splitBuffer"`
+}
+
+func needBreakEvenHalfSpread(strat GapStrategy) bool {
+	return strat == GapStrategyAbsolutePlus || strat == GapStrategyPercentPlus || strat == GapStrategyMultiplier
 }
 
 func (c *MarketMakingConfig) Validate() error {
@@ -104,20 +144,53 @@ func (c *MarketMakingConfig) Validate() error {
 		return fmt.Errorf("drift tolerance %f out of bounds", c.DriftTolerance)
 	}
 
-	var limits [2]float64
-	switch c.GapStrategy {
-	case GapStrategyMultiplier:
-		limits = [2]float64{1, 100}
-	case GapStrategyPercent, GapStrategyPercentPlus:
-		limits = [2]float64{0, 0.1}
-	case GapStrategyAbsolute, GapStrategyAbsolutePlus:
-		limits = [2]float64{0, math.MaxFloat64} // validate at < spot price at creation time
-	default:
+	if c.GapStrategy != GapStrategyMultiplier &&
+		c.GapStrategy != GapStrategyPercent &&
+		c.GapStrategy != GapStrategyPercentPlus &&
+		c.GapStrategy != GapStrategyAbsolute &&
+		c.GapStrategy != GapStrategyAbsolutePlus {
 		return fmt.Errorf("unknown gap strategy %q", c.GapStrategy)
 	}
 
-	if c.GapFactor < limits[0] || c.GapFactor > limits[1] {
-		return fmt.Errorf("%s gap factor %f is out of bounds %+v", c.GapStrategy, c.GapFactor, limits)
+	validatePlacement := func(p *OrderPlacement) error {
+		var limits [2]float64
+		switch c.GapStrategy {
+		case GapStrategyMultiplier:
+			limits = [2]float64{1, 100}
+		case GapStrategyPercent, GapStrategyPercentPlus:
+			limits = [2]float64{0, 0.1}
+		case GapStrategyAbsolute, GapStrategyAbsolutePlus:
+			limits = [2]float64{0, math.MaxFloat64} // validate at < spot price at creation time
+		default:
+			return fmt.Errorf("unknown gap strategy %q", c.GapStrategy)
+		}
+
+		if p.GapFactor < limits[0] || p.GapFactor > limits[1] {
+			return fmt.Errorf("%s gap factor %f is out of bounds %+v", c.GapStrategy, p.GapFactor, limits)
+		}
+
+		return nil
+	}
+
+	sellPlacements := make(map[float64]interface{}, len(c.SellPlacements))
+	for _, p := range c.SellPlacements {
+		if _, duplicate := sellPlacements[p.GapFactor]; duplicate {
+			return fmt.Errorf("duplicate sell placement %f", p.GapFactor)
+		}
+		sellPlacements[p.GapFactor] = true
+		if err := validatePlacement(p); err != nil {
+			return fmt.Errorf("invalid sell placement: %w", err)
+		}
+	}
+
+	buyPlacements := make(map[float64]interface{}, len(c.BuyPlacements))
+	for _, p := range c.BuyPlacements {
+		if _, duplicate := buyPlacements[p.GapFactor]; duplicate {
+			return fmt.Errorf("duplicate buy placement %f", p.GapFactor)
+		}
+		if err := validatePlacement(p); err != nil {
+			return fmt.Errorf("invalid buy placement: %w", err)
+		}
 	}
 
 	return nil
@@ -133,124 +206,164 @@ func steppedRate(r, step uint64) uint64 {
 	return uint64(math.Round(steps * float64(step)))
 }
 
+// orderFees are the fees used for calculating the half-spread.
+type orderFees struct {
+	swap       uint64
+	redemption uint64
+	funding    uint64
+}
+
 type basicMarketMaker struct {
 	ctx    context.Context
 	host   string
 	base   uint32
 	quote  uint32
 	cfg    *MarketMakingConfig
-	book   *orderbook.OrderBook
+	book   dexOrderBook
 	log    dex.Logger
 	core   clientCore
-	oracle *priceOracle
+	oracle oracle
 	mkt    *core.Market
-	pw     []byte
-
+	// the fiat rate is the rate determined by comparing the fiat rates
+	// of the two assets.
+	fiatRateV        atomic.Uint64
 	rebalanceRunning atomic.Bool
 
-	ordMtx sync.RWMutex
-	ords   map[order.OrderID]*core.Order
+	ordMtx         sync.RWMutex
+	ords           map[order.OrderID]*core.Order
+	oidToPlacement map[order.OrderID]int
+
+	feesMtx  sync.RWMutex
+	buyFees  *orderFees
+	sellFees *orderFees
 }
 
-// sortedOrder is a subset of an *core.Order used internally for sorting.
-type sortedOrder struct {
-	*core.Order
-	id   order.OrderID
-	rate uint64
-	lots uint64
+// groupedOrder is a subset of an *core.Order.
+type groupedOrder struct {
+	id    order.OrderID
+	rate  uint64
+	lots  uint64
+	epoch uint64
 }
 
-// sortedOrders returns lists of buy and sell orders, with buys sorted
-// high to low by rate, and sells low to high.
-func (m *basicMarketMaker) sortedOrders() (buys, sells []*sortedOrder) {
-	makeSortedOrder := func(o *core.Order) *sortedOrder {
+// groupedOrders returns the buy and sell orders grouped by placement index.
+func (m *basicMarketMaker) groupedOrders() (buys, sells map[int][]*groupedOrder) {
+	makeGroupedOrder := func(o *core.Order) *groupedOrder {
 		var oid order.OrderID
 		copy(oid[:], o.ID)
-		return &sortedOrder{
-			Order: o,
+		return &groupedOrder{
 			id:    oid,
 			rate:  o.Rate,
 			lots:  (o.Qty - o.Filled) / m.mkt.LotSize,
+			epoch: o.Epoch,
 		}
 	}
 
-	buys, sells = make([]*sortedOrder, 0), make([]*sortedOrder, 0)
+	buys, sells = make(map[int][]*groupedOrder), make(map[int][]*groupedOrder)
 	m.ordMtx.RLock()
 	for _, ord := range m.ords {
+		var oid order.OrderID
+		copy(oid[:], ord.ID)
+		placementIndex := m.oidToPlacement[oid]
 		if ord.Sell {
-			sells = append(sells, makeSortedOrder(ord))
+			if _, found := sells[placementIndex]; !found {
+				sells[placementIndex] = make([]*groupedOrder, 0, 1)
+			}
+			sells[placementIndex] = append(sells[placementIndex], makeGroupedOrder(ord))
 		} else {
-			buys = append(buys, makeSortedOrder(ord))
+			if _, found := buys[placementIndex]; !found {
+				buys[placementIndex] = make([]*groupedOrder, 0, 1)
+			}
+			buys[placementIndex] = append(buys[placementIndex], makeGroupedOrder(ord))
 		}
 	}
 	m.ordMtx.RUnlock()
 
-	sort.Slice(buys, func(i, j int) bool { return buys[i].rate > buys[j].rate })
-	sort.Slice(sells, func(i, j int) bool { return sells[i].rate < sells[j].rate })
-
 	return buys, sells
 }
 
-func (m *basicMarketMaker) basisPrice() uint64 {
-	midGap, err := m.book.MidGap()
+// basisPrice calculates the basis price for the market maker.
+// The mid-gap of the dex order book is used, and if oracles are
+// available, and the oracle weighting is > 0, the oracle price
+// is used to adjust the basis price.
+// If the dex market is empty, but there are oracles available and
+// oracle weighting is > 0, the oracle rate is used.
+// If the dex market is empty and there are either no oracles available
+// or oracle weighting is 0, the fiat rate is used.
+// If there is no fiat rate available, the empty market rate in the
+// configuration is used.
+func basisPrice(book dexOrderBook, oracle oracle, cfg *MarketMakingConfig, mkt *core.Market, fiatRate uint64, log dex.Logger) uint64 {
+	midGap, err := book.MidGap()
 	if err != nil && !errors.Is(err, orderbook.ErrEmptyOrderbook) {
-		m.log.Errorf("MidGap error: %v", err)
+		log.Errorf("MidGap error: %v", err)
 		return 0
 	}
 
 	basisPrice := float64(midGap) // float64 message-rate units
 
-	oraclePrice := m.oracle.getMarketPrice(m.base, m.quote)
-	var oracleWeighting float64
-	if m.cfg.OracleWeighting != nil {
-		oracleWeighting = *m.cfg.OracleWeighting
+	var oracleWeighting, oraclePrice float64
+	if cfg.OracleWeighting != nil && *cfg.OracleWeighting > 0 {
+		oracleWeighting = *cfg.OracleWeighting
+		oraclePrice = oracle.getMarketPrice(mkt.BaseID, mkt.QuoteID)
+		if oraclePrice == 0 {
+			log.Warnf("no oracle price available for %s bot", mkt.Name)
+		}
 	}
 
 	if oraclePrice > 0 {
-		msgOracleRate := float64(m.mkt.ConventionalRateToMsg(oraclePrice))
+		msgOracleRate := float64(mkt.ConventionalRateToMsg(oraclePrice))
 
 		// Apply the oracle mismatch filter.
 		if basisPrice > 0 {
 			low, high := msgOracleRate*(1-maxOracleMismatch), msgOracleRate*(1+maxOracleMismatch)
 			if basisPrice < low {
-				m.log.Debug("local mid-gap is below safe range. Using effective mid-gap of %d%% below the oracle rate.", maxOracleMismatch*100)
+				log.Debug("local mid-gap is below safe range. Using effective mid-gap of %d%% below the oracle rate.", maxOracleMismatch*100)
 				basisPrice = low
 			} else if basisPrice > high {
-				m.log.Debug("local mid-gap is above safe range. Using effective mid-gap of %d%% above the oracle rate.", maxOracleMismatch*100)
+				log.Debug("local mid-gap is above safe range. Using effective mid-gap of %d%% above the oracle rate.", maxOracleMismatch*100)
 				basisPrice = high
 			}
 		}
 
-		if m.cfg.OracleBias != 0 {
-			msgOracleRate *= 1 + m.cfg.OracleBias
+		if cfg.OracleBias != 0 {
+			msgOracleRate *= 1 + cfg.OracleBias
 		}
 
 		if basisPrice == 0 { // no mid-gap available. Use the oracle price.
 			basisPrice = msgOracleRate
-			m.log.Tracef("basisPrice: using basis price %.0f from oracle because no mid-gap was found in order book", basisPrice)
-		} else if oracleWeighting > 0 {
+			log.Tracef("basisPrice: using basis price %.0f from oracle because no mid-gap was found in order book", basisPrice)
+		} else {
 			basisPrice = msgOracleRate*oracleWeighting + basisPrice*(1-oracleWeighting)
-			m.log.Tracef("basisPrice: oracle-weighted basis price = %f", basisPrice)
+			log.Tracef("basisPrice: oracle-weighted basis price = %f", basisPrice)
 		}
-	} else {
-		m.log.Warnf("no oracle price available for %s bot", m.mkt.Name)
 	}
 
 	if basisPrice > 0 {
-		return steppedRate(uint64(basisPrice), m.mkt.RateStep)
+		return steppedRate(uint64(basisPrice), mkt.RateStep)
 	}
 
-	// TODO: infer basis price from fiat rates?
+	// TODO: add a configuration to turn off use of fiat rate?
+	if fiatRate > 0 {
+		return steppedRate(fiatRate, mkt.RateStep)
+	}
+
+	if cfg.EmptyMarketRate > 0 {
+		return mkt.ConventionalRateToMsg(cfg.EmptyMarketRate)
+	}
+
 	return 0
+}
+
+func (m *basicMarketMaker) basisPrice() uint64 {
+	return basisPrice(m.book, m.oracle, m.cfg, m.mkt, m.fiatRateV.Load(), m.log)
 }
 
 func (m *basicMarketMaker) halfSpread(basisPrice uint64) (uint64, error) {
 	form := &core.SingleLotFeesForm{
-		Host:    m.host,
-		Base:    m.base,
-		Quote:   m.quote,
-		Sell:    true,
-		Options: nil, // Probably will need to support split tx
+		Host:  m.host,
+		Base:  m.base,
+		Quote: m.quote,
+		Sell:  true,
 	}
 
 	if basisPrice == 0 { // prevent divide by zero later
@@ -272,7 +385,7 @@ func (m *basicMarketMaker) halfSpread(basisPrice uint64) (uint64, error) {
 	quoteFees += newQuoteFees
 
 	g := float64(calc.BaseToQuote(basisPrice, baseFees)+quoteFees) /
-		float64(baseFees+2*m.mkt.LotSize)
+		float64(baseFees+2*m.mkt.LotSize) * m.mkt.AtomToConv
 
 	halfGap := uint64(math.Round(g * calc.RateEncodingFactor))
 
@@ -282,21 +395,59 @@ func (m *basicMarketMaker) halfSpread(basisPrice uint64) (uint64, error) {
 	return halfGap, nil
 }
 
-func (m *basicMarketMaker) placeOrder(lots, rate uint64, sell bool) *core.Order {
-	ord, err := m.core.Trade(m.pw, &core.TradeForm{
-		Host:    m.host,
-		IsLimit: true,
-		Sell:    sell,
-		Base:    m.base,
-		Quote:   m.quote,
-		Qty:     lots * m.mkt.LotSize,
-		Rate:    rate,
+func (m *basicMarketMaker) placeMultiTrade(placements []*rateLots, sell bool) {
+	qtyRates := make([]*core.QtyRate, 0, len(placements))
+	for _, p := range placements {
+		qtyRates = append(qtyRates, &core.QtyRate{
+			Qty:  p.lots * m.mkt.LotSize,
+			Rate: p.rate,
+		})
+	}
+
+	options := map[string]string{}
+	if m.cfg.SplitTxAllowed {
+		options["multisplit"] = "true"
+	}
+	if !sell {
+		if m.cfg.SplitBuffer != nil {
+			options["multisplitbuffer"] = fmt.Sprintf("%d", *m.cfg.SplitBuffer)
+		}
+	}
+
+	orders, err := m.core.MultiTrade(nil, &core.MultiTradeForm{
+		Host:       m.host,
+		Sell:       sell,
+		Base:       m.base,
+		Quote:      m.quote,
+		Placements: qtyRates,
+		Options:    options,
 	})
 	if err != nil {
 		m.log.Errorf("Error placing rebalancing order: %v", err)
-		return nil
+		return
 	}
-	return ord
+
+	m.ordMtx.Lock()
+	for i, ord := range orders {
+		var oid order.OrderID
+		copy(oid[:], ord.ID)
+		m.ords[oid] = ord
+		placementIndex := placements[i].placementIndex
+		m.oidToPlacement[oid] = placementIndex
+	}
+	m.ordMtx.Unlock()
+}
+
+func (m *basicMarketMaker) processFiatRates(rates map[uint32]float64) {
+	var fiatRate uint64
+
+	baseRate := rates[m.base]
+	quoteRate := rates[m.quote]
+	if baseRate > 0 && quoteRate > 0 {
+		fiatRate = m.mkt.ConventionalRateToMsg(baseRate / quoteRate)
+	}
+
+	m.fiatRateV.Store(fiatRate)
 }
 
 func (m *basicMarketMaker) processTrade(o *core.Order) {
@@ -307,37 +458,238 @@ func (m *basicMarketMaker) processTrade(o *core.Order) {
 	var oid order.OrderID
 	copy(oid[:], o.ID)
 
-	m.log.Tracef("processTrade: oid = %s, status = %s", oid, o.Status)
-
 	m.ordMtx.Lock()
 	defer m.ordMtx.Unlock()
+
 	_, found := m.ords[oid]
 	if !found {
 		return
 	}
 
-	convRate := m.mkt.MsgRateToConventional(o.Rate)
-	m.log.Tracef("processTrade: oid = %s, status = %s, qty = %d, filled = %d, rate = %f", oid, o.Status, o.Qty, o.Filled, convRate)
-
 	if o.Status > order.OrderStatusBooked {
 		// We stop caring when the order is taken off the book.
 		delete(m.ords, oid)
-
-		switch {
-		case o.Filled == o.Qty:
-			m.log.Tracef("processTrade: order filled")
-		case o.Status == order.OrderStatusCanceled:
-			if len(o.Matches) == 0 {
-				m.log.Tracef("processTrade: order canceled WITHOUT matches")
-			} else {
-				m.log.Tracef("processTrade: order canceled WITH matches")
-			}
-		}
-		return
+		delete(m.oidToPlacement, oid)
 	} else {
 		// Update our reference.
 		m.ords[oid] = o
 	}
+}
+
+func orderPrice(basisPrice, breakEven uint64, strategy GapStrategy, factor float64, sell bool, mkt *core.Market) uint64 {
+	var halfSpread uint64
+
+	// Apply the base strategy.
+	switch strategy {
+	case GapStrategyMultiplier:
+		halfSpread = uint64(math.Round(float64(breakEven) * factor))
+	case GapStrategyPercent, GapStrategyPercentPlus:
+		halfSpread = uint64(math.Round(factor * float64(basisPrice)))
+	case GapStrategyAbsolute, GapStrategyAbsolutePlus:
+		halfSpread = mkt.ConventionalRateToMsg(factor)
+	}
+
+	// Add the break-even to the "-plus" strategies
+	switch strategy {
+	case GapStrategyAbsolutePlus, GapStrategyPercentPlus:
+		halfSpread += breakEven
+	}
+
+	halfSpread = steppedRate(halfSpread, mkt.RateStep)
+
+	if sell {
+		return basisPrice + halfSpread
+	}
+
+	if basisPrice < halfSpread {
+		return 0
+	}
+
+	return basisPrice - halfSpread
+}
+
+type rebalancer interface {
+	basisPrice() uint64
+	halfSpread(uint64) (uint64, error)
+	groupedOrders() (buys, sells map[int][]*groupedOrder)
+}
+
+type rateLots struct {
+	rate           uint64
+	lots           uint64
+	placementIndex int
+}
+
+func basicMMRebalance(newEpoch uint64, m rebalancer, c clientCore, cfg *MarketMakingConfig, mkt *core.Market, buyFees,
+	sellFees *orderFees, log dex.Logger) (cancels []dex.Bytes, buyOrders, sellOrders []*rateLots) {
+	basisPrice := m.basisPrice()
+	if basisPrice == 0 {
+		log.Errorf("No basis price available and no empty-market rate set")
+		return
+	}
+
+	log.Debugf("rebalance (%s): basis price = %d", mkt.Name, basisPrice)
+
+	var breakEven uint64
+	if needBreakEvenHalfSpread(cfg.GapStrategy) {
+		var err error
+		breakEven, err = m.halfSpread(basisPrice)
+		if err != nil {
+			log.Errorf("Could not calculate break-even spread: %v", err)
+			return
+		}
+	}
+
+	existingBuys, existingSells := m.groupedOrders()
+	getExistingOrders := func(index int, sell bool) []*groupedOrder {
+		if sell {
+			return existingSells[index]
+		}
+		return existingBuys[index]
+	}
+
+	// Get highest existing buy and lowest existing sell to avoid
+	// self-matches.
+	var highestExistingBuy, lowestExistingSell uint64 = 0, math.MaxUint64
+	for _, placementOrders := range existingBuys {
+		for _, o := range placementOrders {
+			if o.rate > highestExistingBuy {
+				highestExistingBuy = o.rate
+			}
+		}
+	}
+	for _, placementOrders := range existingSells {
+		for _, o := range placementOrders {
+			if o.rate < lowestExistingSell {
+				lowestExistingSell = o.rate
+			}
+		}
+	}
+	rateCausesSelfMatch := func(rate uint64, sell bool) bool {
+		if sell {
+			return rate <= highestExistingBuy
+		}
+		return rate >= lowestExistingSell
+	}
+
+	withinTolerance := func(rate, target uint64) bool {
+		driftTolerance := uint64(float64(target) * cfg.DriftTolerance)
+		lowerBound := target - driftTolerance
+		upperBound := target + driftTolerance
+		return rate >= lowerBound && rate <= upperBound
+	}
+
+	baseBalance, err := c.AssetBalance(mkt.BaseID)
+	if err != nil {
+		log.Errorf("Error getting base balance: %v", err)
+		return
+	}
+	quoteBalance, err := c.AssetBalance(mkt.QuoteID)
+	if err != nil {
+		log.Errorf("Error getting quote balance: %v", err)
+		return
+	}
+
+	cancels = make([]dex.Bytes, 0, len(cfg.SellPlacements)+len(cfg.BuyPlacements))
+	addCancel := func(o *groupedOrder) {
+		if newEpoch-o.epoch < 2 {
+			log.Debugf("rebalance: skipping cancel not past free cancel threshold")
+			return
+		}
+		cancels = append(cancels, o.id[:])
+	}
+
+	processSide := func(sell bool) []*rateLots {
+		log.Debugf("rebalance: processing %s side", map[bool]string{true: "sell", false: "buy"}[sell])
+
+		var cfgPlacements []*OrderPlacement
+		if sell {
+			cfgPlacements = cfg.SellPlacements
+		} else {
+			cfgPlacements = cfg.BuyPlacements
+		}
+		if len(cfgPlacements) == 0 {
+			return nil
+		}
+
+		var remainingBalance uint64
+		if sell {
+			remainingBalance = baseBalance.Available
+			if cfg.SplitTxAllowed {
+				remainingBalance -= sellFees.funding
+			}
+		} else {
+			remainingBalance = quoteBalance.Available
+			if cfg.SplitTxAllowed {
+				remainingBalance -= buyFees.funding
+			}
+		}
+
+		rlPlacements := make([]*rateLots, 0, len(cfgPlacements))
+
+		for i, p := range cfgPlacements {
+			placementRate := orderPrice(basisPrice, breakEven, cfg.GapStrategy, p.GapFactor, sell, mkt)
+			log.Debugf("placement %d rate: %d", i, placementRate)
+
+			if placementRate == 0 {
+				log.Warnf("skipping %s placement %d because it would result in a zero rate",
+					map[bool]string{true: "sell", false: "buy"}[sell], i)
+				continue
+			}
+			if rateCausesSelfMatch(placementRate, sell) {
+				log.Warnf("skipping %s placement %d because it would cause a self-match",
+					map[bool]string{true: "sell", false: "buy"}[sell], i)
+				continue
+			}
+
+			existingOrders := getExistingOrders(i, sell)
+			var numLotsOnBooks uint64
+			for _, o := range existingOrders {
+				numLotsOnBooks += o.lots
+				if !withinTolerance(o.rate, placementRate) {
+					addCancel(o)
+				}
+			}
+
+			var lotsToPlace uint64
+			if p.Lots > numLotsOnBooks {
+				lotsToPlace = p.Lots - numLotsOnBooks
+			}
+			if lotsToPlace == 0 {
+				continue
+			}
+
+			log.Debugf("placement %d: placing %d lots", i, lotsToPlace)
+
+			var requiredPerLot uint64
+			if sell {
+				requiredPerLot = sellFees.swap + mkt.LotSize
+			} else {
+				requiredPerLot = calc.BaseToQuote(placementRate, mkt.LotSize) + buyFees.swap
+			}
+			if remainingBalance/requiredPerLot < lotsToPlace {
+				log.Debugf("placement %d: not enough balance to place %d lots, placing %d", i, lotsToPlace, remainingBalance/requiredPerLot)
+				lotsToPlace = remainingBalance / requiredPerLot
+			}
+			if lotsToPlace == 0 {
+				continue
+			}
+
+			remainingBalance -= requiredPerLot * lotsToPlace
+			rlPlacements = append(rlPlacements, &rateLots{
+				rate:           placementRate,
+				lots:           lotsToPlace,
+				placementIndex: i,
+			})
+		}
+
+		return rlPlacements
+	}
+
+	buyOrders = processSide(false)
+	sellOrders = processSide(true)
+
+	return cancels, buyOrders, sellOrders
 }
 
 func (m *basicMarketMaker) rebalance(newEpoch uint64) {
@@ -346,230 +698,25 @@ func (m *basicMarketMaker) rebalance(newEpoch uint64) {
 	}
 	defer m.rebalanceRunning.Store(false)
 
-	basisPrice := m.basisPrice()
-	if basisPrice == 0 && m.cfg.EmptyMarketRate == 0 {
-		m.log.Errorf("No basis price available and no empty-market rate set")
-	} else if basisPrice == 0 {
-		basisPrice = m.mkt.ConventionalRateToMsg(m.cfg.EmptyMarketRate)
-	}
+	m.feesMtx.RLock()
+	buyFees, sellFees := m.buyFees, m.sellFees
+	m.feesMtx.RUnlock()
 
-	m.log.Tracef("rebalance (%s): basis price = %d", m.mkt.Name, basisPrice)
+	cancels, buyOrders, sellOrders := basicMMRebalance(newEpoch, m, m.core, m.cfg, m.mkt, buyFees, sellFees, m.log)
 
-	// Three of the strategies will use a break-even half-gap.
-	var breakEven uint64
-	switch m.cfg.GapStrategy {
-	case GapStrategyAbsolutePlus, GapStrategyPercentPlus, GapStrategyMultiplier:
-		var err error
-		breakEven, err = m.halfSpread(basisPrice)
+	for _, cancel := range cancels {
+		err := m.core.Cancel(cancel)
 		if err != nil {
-			m.log.Errorf("Could not calculate break-even spread: %v", err)
+			m.log.Errorf("Error canceling order %s: %v", cancel, err)
 			return
 		}
 	}
-
-	// Apply the base strategy.
-	var halfSpread uint64
-	switch m.cfg.GapStrategy {
-	case GapStrategyMultiplier:
-		halfSpread = uint64(math.Round(float64(breakEven) * m.cfg.GapFactor))
-	case GapStrategyPercent, GapStrategyPercentPlus:
-		halfSpread = uint64(math.Round(m.cfg.GapFactor * float64(basisPrice)))
-	case GapStrategyAbsolute, GapStrategyAbsolutePlus:
-		halfSpread = m.mkt.ConventionalRateToMsg(m.cfg.GapFactor)
+	if len(buyOrders) > 0 {
+		m.placeMultiTrade(buyOrders, false)
 	}
-
-	// Add the break-even to the "-plus" strategies.
-	switch m.cfg.GapStrategy {
-	case GapStrategyAbsolutePlus, GapStrategyPercentPlus:
-		halfSpread += breakEven
+	if len(sellOrders) > 0 {
+		m.placeMultiTrade(sellOrders, true)
 	}
-
-	m.log.Tracef("rebalance: strategized half-spread = %d, strategy = %s", halfSpread, m.cfg.GapStrategy)
-
-	halfSpread = steppedRate(halfSpread, m.mkt.RateStep)
-
-	m.log.Tracef("rebalance: stepped half-spread = %d", halfSpread)
-
-	buyPrice := basisPrice - halfSpread
-	sellPrice := basisPrice + halfSpread
-
-	m.log.Tracef("rebalance: buy price = %d, sell price = %d", buyPrice, sellPrice)
-
-	buys, sells := m.sortedOrders()
-
-	// Figure out the best existing sell and buy of existing monitored orders.
-	// These values are used to cancel order placement if there is a chance
-	// of self-matching, especially against a scheduled cancel order.
-	highestBuy, lowestSell := buyPrice, sellPrice
-	if len(sells) > 0 {
-		ord := sells[0]
-		if ord.rate < lowestSell {
-			lowestSell = ord.rate
-		}
-	}
-	if len(buys) > 0 {
-		ord := buys[0]
-		if ord.rate > highestBuy {
-			highestBuy = ord.rate
-		}
-	}
-
-	// Check if order-placement might self-match.
-	var cantBuy, cantSell bool
-	if buyPrice >= lowestSell {
-		m.log.Tracef("rebalance: can't buy because delayed cancel sell order interferes. booked rate = %d, buy price = %d",
-			lowestSell, buyPrice)
-		cantBuy = true
-	}
-	if sellPrice <= highestBuy {
-		m.log.Tracef("rebalance: can't sell because delayed cancel sell order interferes. booked rate = %d, sell price = %d",
-			highestBuy, sellPrice)
-		cantSell = true
-	}
-
-	var canceledBuyLots, canceledSellLots uint64 // for stats reporting
-	cancels := make([]*sortedOrder, 0)
-	addCancel := func(ord *sortedOrder) {
-		if newEpoch-ord.Epoch < 2 {
-			m.log.Debugf("rebalance: skipping cancel not past free cancel threshold")
-		}
-
-		if ord.Sell {
-			canceledSellLots += ord.lots
-		} else {
-			canceledBuyLots += ord.lots
-		}
-		if ord.Status <= order.OrderStatusBooked {
-			cancels = append(cancels, ord)
-		}
-	}
-
-	processSide := func(ords []*sortedOrder, price uint64, sell bool) (keptLots int) {
-		tol := uint64(math.Round(float64(price) * m.cfg.DriftTolerance))
-		low, high := price-tol, price+tol
-
-		// Limit large drift tolerances to their respective sides, i.e. mid-gap
-		// is a hard cutoff.
-		if !sell && high > basisPrice {
-			high = basisPrice - 1
-		}
-		if sell && low < basisPrice {
-			low = basisPrice + 1
-		}
-
-		for _, ord := range ords {
-			m.log.Tracef("rebalance: processSide: sell = %t, order rate = %d, low = %d, high = %d",
-				sell, ord.rate, low, high)
-			if ord.rate < low || ord.rate > high {
-				if newEpoch < ord.Epoch+2 { // https://github.com/decred/dcrdex/pull/1682
-					m.log.Tracef("rebalance: postponing cancellation for order < 2 epochs old")
-					keptLots += int(ord.lots)
-				} else {
-					m.log.Tracef("rebalance: cancelling out-of-bounds order (%d lots remaining). rate %d is not in range %d < r < %d",
-						ord.lots, ord.rate, low, high)
-					addCancel(ord)
-				}
-			} else {
-				keptLots += int(ord.lots)
-			}
-		}
-		return
-	}
-
-	newBuyLots, newSellLots := int(m.cfg.Lots), int(m.cfg.Lots)
-	keptBuys := processSide(buys, buyPrice, false)
-	keptSells := processSide(sells, sellPrice, true)
-	newBuyLots -= keptBuys
-	newSellLots -= keptSells
-
-	// Cancel out of bounds or over-stacked orders.
-	if len(cancels) > 0 {
-		// Only cancel orders that are > 1 epoch old.
-		m.log.Tracef("rebalance: cancelling %d orders", len(cancels))
-		for _, cancel := range cancels {
-			if err := m.core.Cancel(cancel.id[:]); err != nil {
-				m.log.Errorf("error cancelling order: %v", err)
-				return
-			}
-		}
-	}
-
-	if cantBuy {
-		newBuyLots = 0
-	}
-	if cantSell {
-		newSellLots = 0
-	}
-
-	m.log.Tracef("rebalance: %d buy lots and %d sell lots scheduled after existing valid %d buy and %d sell lots accounted",
-		newBuyLots, newSellLots, keptBuys, keptSells)
-
-	// Resolve requested lots against the current balance. If we come up short,
-	// we may be able to place extra orders on the other side to satisfy our
-	// lot commitment and shift our balance back.
-	var maxBuyLots int
-	if newBuyLots > 0 {
-		// TODO: MaxBuy and MaxSell shouldn't error for insufficient funds, but
-		// they do. Maybe consider a constant error asset.InsufficientBalance.
-		maxOrder, err := m.core.MaxBuy(m.host, m.base, m.quote, buyPrice)
-		if err != nil {
-			m.log.Errorf("MaxBuy error: %v", err)
-		} else {
-			maxBuyLots = int(maxOrder.Swap.Lots)
-		}
-		if maxBuyLots < newBuyLots {
-			// We don't have the balance. Add our shortcoming to the other side.
-			shortLots := newBuyLots - maxBuyLots
-			newSellLots += shortLots
-			newBuyLots = maxBuyLots
-			m.log.Tracef("rebalance: reduced buy lots to %d because of low balance", newBuyLots)
-		}
-	}
-
-	if newSellLots > 0 {
-		var maxLots int
-		maxOrder, err := m.core.MaxSell(m.host, m.base, m.quote)
-		if err != nil {
-			m.log.Errorf("MaxSell error: %v", err)
-		} else {
-			maxLots = int(maxOrder.Swap.Lots)
-		}
-		if maxLots < newSellLots {
-			shortLots := newSellLots - maxLots
-			newBuyLots += shortLots
-			if newBuyLots > maxBuyLots {
-				m.log.Tracef("rebalance: increased buy lot order to %d lots because sell balance is low", newBuyLots)
-				newBuyLots = maxBuyLots
-			}
-			newSellLots = maxLots
-			m.log.Tracef("rebalance: reduced sell lots to %d because of low balance", newSellLots)
-		}
-	}
-
-	// Place buy orders.
-	if newBuyLots > 0 {
-		ord := m.placeOrder(uint64(newBuyLots), buyPrice, false)
-		if ord != nil {
-			var oid order.OrderID
-			copy(oid[:], ord.ID)
-			m.ordMtx.Lock()
-			m.ords[oid] = ord
-			m.ordMtx.Unlock()
-		}
-	}
-
-	// Place sell orders.
-	if newSellLots > 0 {
-		ord := m.placeOrder(uint64(newSellLots), sellPrice, true)
-		if ord != nil {
-			var oid order.OrderID
-			copy(oid[:], ord.ID)
-			m.ordMtx.Lock()
-			m.ords[oid] = ord
-			m.ordMtx.Unlock()
-		}
-	}
-
 }
 
 func (m *basicMarketMaker) handleNotification(note core.Notification) {
@@ -582,6 +729,8 @@ func (m *basicMarketMaker) handleNotification(note core.Notification) {
 		m.processTrade(ord)
 	case *core.EpochNotification:
 		go m.rebalance(n.Epoch)
+	case *core.FiatRatesNote:
+		go m.processFiatRates(n.FiatRates)
 	}
 }
 
@@ -594,6 +743,57 @@ func (m *basicMarketMaker) cancelAllOrders() {
 		}
 	}
 	m.ords = make(map[order.OrderID]*core.Order)
+	m.oidToPlacement = make(map[order.OrderID]int)
+}
+
+func (m *basicMarketMaker) updateFeeRates() error {
+	buySwapFees, buyRedeemFees, err := m.core.SingleLotFees(&core.SingleLotFeesForm{
+		Host:          m.host,
+		Base:          m.base,
+		Quote:         m.quote,
+		UseMaxFeeRate: true,
+		UseSafeTxSize: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get fees: %v", err)
+	}
+
+	sellSwapFees, sellRedeemFees, err := m.core.SingleLotFees(&core.SingleLotFeesForm{
+		Host:          m.host,
+		Base:          m.base,
+		Quote:         m.quote,
+		UseMaxFeeRate: true,
+		UseSafeTxSize: true,
+		Sell:          true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get fees: %v", err)
+	}
+
+	buyFundingFees, err := m.core.MaxFundingFees(m.base, uint32(len(m.cfg.BuyPlacements)), nil)
+	if err != nil {
+		return fmt.Errorf("failed to get funding fees: %v", err)
+	}
+
+	sellFundingFees, err := m.core.MaxFundingFees(m.quote, uint32(len(m.cfg.SellPlacements)), nil)
+	if err != nil {
+		return fmt.Errorf("failed to get funding fees: %v", err)
+	}
+
+	m.feesMtx.Lock()
+	defer m.feesMtx.Unlock()
+	m.buyFees = &orderFees{
+		swap:       buySwapFees,
+		redemption: buyRedeemFees,
+		funding:    buyFundingFees,
+	}
+	m.sellFees = &orderFees{
+		swap:       sellSwapFees,
+		redemption: sellRedeemFees,
+		funding:    sellFundingFees,
+	}
+
+	return nil
 }
 
 func (m *basicMarketMaker) run() {
@@ -606,6 +806,7 @@ func (m *basicMarketMaker) run() {
 
 	wg := sync.WaitGroup{}
 
+	// Process book updates
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -622,8 +823,8 @@ func (m *basicMarketMaker) run() {
 		}
 	}()
 
+	// Process core notifications
 	noteFeed := m.core.NotificationFeed()
-
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -638,36 +839,74 @@ func (m *basicMarketMaker) run() {
 		}
 	}()
 
-	wg.Wait()
+	// Periodically update asset fee rates
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		refreshTime := time.Minute * 10
+		for {
+			select {
+			case <-time.NewTimer(refreshTime).C:
+				err := m.updateFeeRates()
+				if err != nil {
+					m.log.Error(err)
+					refreshTime = time.Minute
+				} else {
+					refreshTime = time.Minute * 10
+				}
+			case <-m.ctx.Done():
+				return
+			}
+		}
+	}()
 
+	wg.Wait()
 	m.cancelAllOrders()
 }
 
 // RunBasicMarketMaker starts a basic market maker bot.
-func RunBasicMarketMaker(ctx context.Context, cfg *BotConfig, c clientCore, oracle *priceOracle, pw []byte, log dex.Logger) {
+func RunBasicMarketMaker(ctx context.Context, cfg *BotConfig, c clientCore, oracle oracle, baseFiatRate, quoteFiatRate float64, log dex.Logger) {
 	if cfg.MMCfg == nil {
 		// implies bug in caller
 		log.Errorf("No market making config provided. Exiting.")
 		return
 	}
 
-	mkt, err := c.ExchangeMarket(cfg.Host, cfg.BaseAsset, cfg.QuoteAsset)
+	err := cfg.MMCfg.Validate()
 	if err != nil {
-		log.Errorf("Failed to get market: %v", err)
+		log.Errorf("Invalid market making config: %v. Exiting.", err)
 		return
 	}
 
-	(&basicMarketMaker{
-		ctx:    ctx,
-		core:   c,
-		log:    log,
-		cfg:    cfg.MMCfg,
-		host:   cfg.Host,
-		base:   cfg.BaseAsset,
-		quote:  cfg.QuoteAsset,
-		oracle: oracle,
-		pw:     pw,
-		mkt:    mkt,
-		ords:   make(map[order.OrderID]*core.Order),
-	}).run()
+	mkt, err := c.ExchangeMarket(cfg.Host, cfg.BaseAsset, cfg.QuoteAsset)
+	if err != nil {
+		log.Errorf("Failed to get market: %v. Not starting market maker.", err)
+		return
+	}
+
+	mm := &basicMarketMaker{
+		ctx:            ctx,
+		core:           c,
+		log:            log,
+		cfg:            cfg.MMCfg,
+		host:           cfg.Host,
+		base:           cfg.BaseAsset,
+		quote:          cfg.QuoteAsset,
+		oracle:         oracle,
+		mkt:            mkt,
+		ords:           make(map[order.OrderID]*core.Order),
+		oidToPlacement: make(map[order.OrderID]int),
+	}
+
+	err = mm.updateFeeRates()
+	if err != nil {
+		log.Errorf("Not starting market maker: %v", err)
+		return
+	}
+
+	if baseFiatRate > 0 && quoteFiatRate > 0 {
+		mm.fiatRateV.Store(mkt.ConventionalRateToMsg(baseFiatRate / quoteFiatRate))
+	}
+
+	mm.run()
 }

--- a/client/mm/mm_basic_test.go
+++ b/client/mm/mm_basic_test.go
@@ -359,8 +359,7 @@ func TestRebalance(t *testing.T) {
 		{
 			name: "test balances edge, not enough for orders",
 			cfg: &MarketMakingConfig{
-				GapStrategy:    GapStrategyMultiplier,
-				SplitTxAllowed: true,
+				GapStrategy: GapStrategyMultiplier,
 				SellPlacements: []*OrderPlacement{
 					{
 						Lots:      1,
@@ -497,8 +496,7 @@ func TestRebalance(t *testing.T) {
 		{
 			name: "test balances edge, not enough for 2 lot orders, place 1 lot",
 			cfg: &MarketMakingConfig{
-				GapStrategy:    GapStrategyMultiplier,
-				SplitTxAllowed: true,
+				GapStrategy: GapStrategyMultiplier,
 				SellPlacements: []*OrderPlacement{
 					{
 						Lots:      1,

--- a/client/mm/mm_basic_test.go
+++ b/client/mm/mm_basic_test.go
@@ -1,0 +1,1376 @@
+//go:build !harness && !botlive
+
+package mm
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	"decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/calc"
+	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/dex/order"
+)
+
+var (
+	dcrBipID uint32 = 42
+	btcBipID uint32 = 0
+)
+
+type tRebalancer struct {
+	basis        uint64
+	breakEven    uint64
+	breakEvenErr error
+	sortedBuys   map[int][]*groupedOrder
+	sortedSells  map[int][]*groupedOrder
+}
+
+var _ rebalancer = (*tRebalancer)(nil)
+
+func (r *tRebalancer) basisPrice() uint64 {
+	return r.basis
+}
+
+func (r *tRebalancer) halfSpread(basisPrice uint64) (uint64, error) {
+	return r.breakEven, r.breakEvenErr
+}
+
+func (r *tRebalancer) groupedOrders() (buys, sells map[int][]*groupedOrder) {
+	return r.sortedBuys, r.sortedSells
+}
+
+func TestRebalance(t *testing.T) {
+	const rateStep uint64 = 1e3
+	const midGap uint64 = 5e8
+	const lotSize uint64 = 50e8
+	const breakEven uint64 = 200 * rateStep
+	const newEpoch = 123_456_789
+	const driftTolerance = 0.001
+	buyFees := &orderFees{
+		swap:       1e4,
+		redemption: 2e4,
+		funding:    3e4,
+	}
+	sellFees := &orderFees{
+		swap:       2e4,
+		redemption: 1e4,
+		funding:    4e4,
+	}
+
+	tCore := newTCore()
+
+	orderIDs := make([]order.OrderID, 5)
+	for i := range orderIDs {
+		copy(orderIDs[i][:], encode.RandomBytes(32))
+	}
+
+	mkt := &core.Market{
+		RateStep:   rateStep,
+		AtomToConv: 1,
+		LotSize:    lotSize,
+		BaseID:     dcrBipID,
+		QuoteID:    btcBipID,
+	}
+
+	newBalancer := func(existingBuys, existingSells map[int][]*groupedOrder) *tRebalancer {
+		return &tRebalancer{
+			basis:       midGap,
+			breakEven:   breakEven,
+			sortedBuys:  existingBuys,
+			sortedSells: existingSells,
+		}
+	}
+
+	log := dex.StdOutLogger("T", dex.LevelTrace)
+
+	type test struct {
+		name       string
+		cfg        *MarketMakingConfig
+		epoch      uint64
+		rebalancer *tRebalancer
+
+		isAccountLocker map[uint32]bool
+		balances        map[uint32]uint64
+
+		expectedBuys    []rateLots
+		expectedSells   []rateLots
+		expectedCancels []order.OrderID
+	}
+
+	newgroupedOrder := func(id order.OrderID, lots, rate uint64, sell bool, freeCancel bool) *groupedOrder {
+		var epoch uint64 = newEpoch
+		if freeCancel {
+			epoch = newEpoch - 2
+		}
+		return &groupedOrder{
+			id:    id,
+			epoch: epoch,
+			rate:  rate,
+			lots:  lots,
+		}
+	}
+
+	driftToleranceEdge := func(rate uint64, within bool) uint64 {
+		edge := rate + uint64(float64(rate)*driftTolerance)
+		if within {
+			return edge - rateStep
+		}
+		return edge + rateStep
+	}
+
+	requiredForOrder := func(sell bool, placements []*OrderPlacement, strategy GapStrategy) (req uint64) {
+		for _, placement := range placements {
+			if sell {
+				req += placement.Lots * mkt.LotSize
+			} else {
+				rate := orderPrice(midGap, breakEven, strategy, placement.GapFactor, sell, mkt)
+				req += calc.BaseToQuote(rate, placement.Lots*mkt.LotSize)
+			}
+		}
+		return
+	}
+
+	tests := []*test{
+		// "no existing orders, one order per side"
+		{
+			name: "no existing orders, one order per side",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+			},
+			rebalancer: newBalancer(nil, nil),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+			expectedBuys: []rateLots{
+				{
+					rate: midGap - (breakEven * 3),
+					lots: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate: midGap + (breakEven * 3),
+					lots: 1,
+				},
+			},
+		},
+		// "no existing orders, no sell placements"
+		{
+			name: "no existing orders, no sell placements",
+			cfg: &MarketMakingConfig{
+				GapStrategy:    GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+			},
+			rebalancer: newBalancer(nil, nil),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+
+			expectedBuys: []rateLots{
+				{
+					rate: midGap - (breakEven * 3),
+					lots: 1,
+				},
+			},
+			expectedSells: []rateLots{},
+		},
+		// "no existing orders, no buy placements"
+		{
+			name: "no existing orders, no buy placements",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{},
+			},
+			rebalancer: newBalancer(nil, nil),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+
+			expectedBuys: []rateLots{},
+			expectedSells: []rateLots{
+				{
+					rate: midGap + (breakEven * 3),
+					lots: 1,
+				},
+			},
+		},
+		//  "no existing orders, multiple placements per side"
+		{
+			name: "no existing orders, multiple placements per side",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+			},
+			rebalancer: newBalancer(nil, nil),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+
+			expectedBuys: []rateLots{
+				{
+					rate:           midGap - (breakEven * 2),
+					lots:           1,
+					placementIndex: 0,
+				},
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate:           midGap + (breakEven * 2),
+					lots:           1,
+					placementIndex: 0,
+				},
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		// "test balances edge, enough for orders"
+		{
+			name: "test balances edge, enough for orders",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+			},
+			rebalancer: newBalancer(nil, nil),
+			balances: map[uint32]uint64{
+				dcrBipID: requiredForOrder(true, []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				}, GapStrategyMultiplier) + 2*sellFees.swap + sellFees.funding,
+				btcBipID: requiredForOrder(false, []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				}, GapStrategyMultiplier) + 2*buyFees.swap + buyFees.funding,
+			},
+			expectedBuys: []rateLots{
+				{
+					rate:           midGap - (breakEven * 2),
+					lots:           1,
+					placementIndex: 0,
+				},
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate:           midGap + (breakEven * 2),
+					lots:           1,
+					placementIndex: 0,
+				},
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		// "test balances edge, not enough for orders"
+		{
+			name: "test balances edge, not enough for orders",
+			cfg: &MarketMakingConfig{
+				GapStrategy:    GapStrategyMultiplier,
+				SplitTxAllowed: true,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+			},
+			rebalancer: newBalancer(nil, nil),
+			balances: map[uint32]uint64{
+				dcrBipID: requiredForOrder(true, []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				}, GapStrategyMultiplier) + 2*sellFees.swap + sellFees.funding - 1,
+				btcBipID: requiredForOrder(false, []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				}, GapStrategyMultiplier) + 2*buyFees.swap + buyFees.funding - 1,
+			},
+			expectedBuys: []rateLots{
+				{
+					rate: midGap - (breakEven * 2),
+					lots: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate: midGap + (breakEven * 2),
+					lots: 1,
+				},
+			},
+		},
+		// "test balances edge, enough for 2 lot orders"
+		{
+			name: "test balances edge, enough for 2 lot orders",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				},
+			},
+			rebalancer: newBalancer(nil, nil),
+			balances: map[uint32]uint64{
+				dcrBipID: requiredForOrder(true, []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				}, GapStrategyMultiplier) + 3*sellFees.swap + sellFees.funding,
+				btcBipID: requiredForOrder(false, []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				}, GapStrategyMultiplier) + 3*buyFees.swap + buyFees.funding,
+			},
+
+			expectedBuys: []rateLots{
+				{
+					rate:           midGap - (breakEven * 2),
+					lots:           1,
+					placementIndex: 0,
+				},
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           2,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate:           midGap + (breakEven * 2),
+					lots:           1,
+					placementIndex: 0,
+				},
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           2,
+					placementIndex: 1,
+				},
+			},
+		},
+		// "test balances edge, not enough for 2 lot orders, place 1 lot"
+		{
+			name: "test balances edge, not enough for 2 lot orders, place 1 lot",
+			cfg: &MarketMakingConfig{
+				GapStrategy:    GapStrategyMultiplier,
+				SplitTxAllowed: true,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				},
+			},
+			rebalancer: newBalancer(nil, nil),
+			balances: map[uint32]uint64{
+				dcrBipID: requiredForOrder(true, []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				}, GapStrategyMultiplier) + 3*sellFees.swap + sellFees.funding - 1,
+				btcBipID: requiredForOrder(false, []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				}, GapStrategyMultiplier) + 3*buyFees.swap + buyFees.funding - 1,
+			},
+			expectedBuys: []rateLots{
+				{
+					rate: midGap - (breakEven * 2),
+					lots: 1,
+				},
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate: midGap + (breakEven * 2),
+					lots: 1,
+				},
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		//  "existing orders outside edge of drift tolerance"
+		{
+			name: "existing orders outside edge of drift tolerance",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				DriftTolerance: driftTolerance,
+			},
+			rebalancer: newBalancer(
+				map[int][]*groupedOrder{
+					0: {
+						newgroupedOrder(orderIDs[0], 1, driftToleranceEdge(midGap-(breakEven*2), false), false, true),
+					},
+				},
+				map[int][]*groupedOrder{
+					1: {
+						newgroupedOrder(orderIDs[1], 1, driftToleranceEdge(midGap+(breakEven*3), false), true, true),
+					},
+				}),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+			expectedCancels: []order.OrderID{
+				orderIDs[0],
+				orderIDs[1],
+			},
+			expectedBuys: []rateLots{
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate:           midGap + (breakEven * 2),
+					lots:           1,
+					placementIndex: 0,
+				},
+			},
+		},
+		//  "existing orders within edge of drift tolerance"
+		{
+			name: "existing orders within edge of drift tolerance",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				DriftTolerance: driftTolerance,
+			},
+			rebalancer: newBalancer(
+				map[int][]*groupedOrder{
+					0: {
+						newgroupedOrder(orderIDs[0], 1, driftToleranceEdge(midGap-(breakEven*2), true), false, true),
+					},
+				},
+				map[int][]*groupedOrder{
+					1: {
+						newgroupedOrder(orderIDs[1], 1, driftToleranceEdge(midGap+(breakEven*3), true), true, true),
+					},
+				}),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+			expectedBuys: []rateLots{
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate: midGap + (breakEven * 2),
+					lots: 1,
+				},
+			},
+		},
+		//  "existing partially filled orders within drift tolerance"
+		{
+			name: "existing partially filled orders within drift tolerance",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      2,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				},
+				DriftTolerance: driftTolerance,
+			},
+			rebalancer: newBalancer(
+				map[int][]*groupedOrder{
+					0: {
+						newgroupedOrder(orderIDs[0], 1, driftToleranceEdge(midGap-(breakEven*2), true), false, true),
+					},
+				},
+				map[int][]*groupedOrder{
+					1: {
+						newgroupedOrder(orderIDs[1], 1, driftToleranceEdge(midGap+(breakEven*3), true), true, true),
+					},
+				}),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+			expectedBuys: []rateLots{
+				{
+					rate: midGap - (breakEven * 2),
+					lots: 1,
+				},
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate: midGap + (breakEven * 2),
+					lots: 1,
+				},
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		//  "existing partially filled orders outside drift tolerance"
+		{
+			name: "existing partially filled orders outside drift tolerance",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      2,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      2,
+						GapFactor: 3,
+					},
+				},
+				DriftTolerance: driftTolerance,
+			},
+			rebalancer: newBalancer(
+				map[int][]*groupedOrder{
+					0: {
+						newgroupedOrder(orderIDs[0], 1, driftToleranceEdge(midGap-(breakEven*2), false), false, true),
+					},
+				},
+				map[int][]*groupedOrder{
+					1: {
+						newgroupedOrder(orderIDs[1], 1, driftToleranceEdge(midGap+(breakEven*3), false), true, true),
+					},
+				}),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+			expectedBuys: []rateLots{
+				{
+					rate: midGap - (breakEven * 2),
+					lots: 1,
+				},
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate: midGap + (breakEven * 2),
+					lots: 1,
+				},
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedCancels: []order.OrderID{
+				orderIDs[0],
+				orderIDs[1],
+			},
+		},
+		// "cannot place buy order due to self matching"
+		{
+			name: "cannot place buy order due to self matching",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				DriftTolerance: driftTolerance,
+			},
+			rebalancer: newBalancer(
+				nil,
+				map[int][]*groupedOrder{
+					0: {
+						newgroupedOrder(orderIDs[1], 1, midGap-(breakEven*2)-1, true, true),
+					},
+				}),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+			expectedCancels: []order.OrderID{
+				orderIDs[1],
+			},
+			expectedBuys: []rateLots{
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		// "cannot place sell order due to self matching"
+		{
+			name: "cannot place sell order due to self matching",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				DriftTolerance: driftTolerance,
+			},
+			rebalancer: newBalancer(
+				map[int][]*groupedOrder{
+					0: {
+						newgroupedOrder(orderIDs[1], 1, midGap+(breakEven*2), true, true),
+					},
+				},
+				nil),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+			expectedCancels: []order.OrderID{
+				orderIDs[1],
+			},
+			expectedBuys: []rateLots{
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		// "cannot place buy order due to self matching, can't cancel because too soon"
+		{
+			name: "cannot place buy order due to self matching, can't cancel because too soon",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				DriftTolerance: driftTolerance,
+			},
+			rebalancer: newBalancer(
+				nil,
+				map[int][]*groupedOrder{
+					0: {
+						newgroupedOrder(orderIDs[1], 1, midGap-(breakEven*2)-1, true, false),
+					},
+				}),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+			expectedCancels: []order.OrderID{},
+			expectedBuys: []rateLots{
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		// "cannot place sell order due to self matching, can't cancel because too soon"
+		{
+			name: "cannot place sell order due to self matching, can't cancel because too soon",
+			cfg: &MarketMakingConfig{
+				GapStrategy: GapStrategyMultiplier,
+				SellPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				BuyPlacements: []*OrderPlacement{
+					{
+						Lots:      1,
+						GapFactor: 2,
+					},
+					{
+						Lots:      1,
+						GapFactor: 3,
+					},
+				},
+				DriftTolerance: driftTolerance,
+			},
+			rebalancer: newBalancer(
+				map[int][]*groupedOrder{
+					0: {
+						newgroupedOrder(orderIDs[1], 1, midGap+(breakEven*2), true, false),
+					},
+				},
+				nil),
+			balances: map[uint32]uint64{
+				dcrBipID: 1e13,
+				btcBipID: 1e13,
+			},
+			expectedCancels: []order.OrderID{},
+			expectedBuys: []rateLots{
+				{
+					rate:           midGap - (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []rateLots{
+				{
+					rate:           midGap + (breakEven * 3),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		if tt.isAccountLocker != nil {
+			tCore.isAccountLocker = tt.isAccountLocker
+		} else {
+			tCore.isAccountLocker = map[uint32]bool{}
+		}
+
+		tCore.setAssetBalances(tt.balances)
+
+		epoch := tt.epoch
+		if epoch == 0 {
+			epoch = newEpoch
+		}
+
+		cancels, buys, sells := basicMMRebalance(epoch, tt.rebalancer, tCore, tt.cfg, mkt, buyFees, sellFees, log)
+
+		if len(cancels) != len(tt.expectedCancels) {
+			t.Fatalf("%s: cancel count mismatch. expected %d, got %d", tt.name, len(tt.expectedCancels), len(cancels))
+		}
+
+		expectedCancels := make(map[order.OrderID]bool)
+		for _, id := range tt.expectedCancels {
+			expectedCancels[id] = true
+		}
+		for _, cancel := range cancels {
+			var id order.OrderID
+			copy(id[:], cancel)
+			if !expectedCancels[id] {
+				t.Fatalf("%s: unexpected cancel order ID %s", tt.name, id)
+			}
+		}
+
+		if len(buys) != len(tt.expectedBuys) {
+			t.Fatalf("%s: buy count mismatch. expected %d, got %d", tt.name, len(tt.expectedBuys), len(buys))
+		}
+		if len(sells) != len(tt.expectedSells) {
+			t.Fatalf("%s: sell count mismatch. expected %d, got %d", tt.name, len(tt.expectedSells), len(sells))
+		}
+
+		for i, buy := range buys {
+			if buy.rate != tt.expectedBuys[i].rate {
+				t.Fatalf("%s: buy rate mismatch. expected %d, got %d", tt.name, tt.expectedBuys[i].rate, buy.rate)
+			}
+			if buy.lots != tt.expectedBuys[i].lots {
+				t.Fatalf("%s: buy lots mismatch. expected %d, got %d", tt.name, tt.expectedBuys[i].lots, buy.lots)
+			}
+			if buy.placementIndex != tt.expectedBuys[i].placementIndex {
+				t.Fatalf("%s: buy placement index mismatch. expected %d, got %d", tt.name, tt.expectedBuys[i].placementIndex, buy.placementIndex)
+			}
+		}
+
+		for i, sell := range sells {
+			if sell.rate != tt.expectedSells[i].rate {
+				t.Fatalf("%s: sell rate mismatch. expected %d, got %d", tt.name, tt.expectedSells[i].rate, sell.rate)
+			}
+			if sell.lots != tt.expectedSells[i].lots {
+				t.Fatalf("%s: sell lots mismatch. expected %d, got %d", tt.name, tt.expectedSells[i].lots, sell.lots)
+			}
+			if sell.placementIndex != tt.expectedSells[i].placementIndex {
+				t.Fatalf("%s: sell placement index mismatch. expected %d, got %d", tt.name, tt.expectedSells[i].placementIndex, sell.placementIndex)
+			}
+		}
+	}
+}
+
+func TestBasisPrice(t *testing.T) {
+	mkt := &core.Market{
+		RateStep:   1,
+		BaseID:     42,
+		QuoteID:    0,
+		AtomToConv: 1,
+	}
+
+	log := dex.StdOutLogger("T", dex.LevelTrace)
+
+	tests := []*struct {
+		name         string
+		midGap       uint64
+		oraclePrice  uint64
+		oracleBias   float64
+		oracleWeight float64
+		conversions  map[uint32]float64
+		fiatRate     uint64
+		exp          uint64
+	}{
+		{
+			name:   "just mid-gap is enough",
+			midGap: 123e5,
+			exp:    123e5,
+		},
+		{
+			name:         "mid-gap + oracle weight",
+			midGap:       1950,
+			oraclePrice:  2000,
+			oracleWeight: 0.5,
+			exp:          1975,
+		},
+		{
+			name:         "adjusted mid-gap + oracle weight",
+			midGap:       1000, // adjusted to 1940
+			oraclePrice:  2000,
+			oracleWeight: 0.5,
+			exp:          1970,
+		},
+		{
+			name:         "no mid-gap effectively sets oracle weight to 100%",
+			midGap:       0,
+			oraclePrice:  2000,
+			oracleWeight: 0.5,
+			exp:          2000,
+		},
+		{
+			name:         "mid-gap + oracle weight + oracle bias",
+			midGap:       1950,
+			oraclePrice:  2000,
+			oracleBias:   -0.01, // minus 20
+			oracleWeight: 0.75,
+			exp:          1972, // 0.25 * 1950 + 0.75 * (2000 - 20) = 1972
+		},
+		{
+			name:         "no mid-gap and no oracle weight fails to produce result",
+			midGap:       0,
+			oraclePrice:  0,
+			oracleWeight: 0.75,
+			exp:          0,
+		},
+		{
+			name:         "no mid-gap and no oracle weight, but fiat rate is set",
+			midGap:       0,
+			oraclePrice:  0,
+			oracleWeight: 0.75,
+			fiatRate:     1200,
+			exp:          1200,
+		},
+	}
+
+	for _, tt := range tests {
+		oracle := &tOracle{
+			marketPrice: mkt.MsgRateToConventional(tt.oraclePrice),
+		}
+		ob := &tOrderBook{
+			midGap: tt.midGap,
+		}
+		cfg := &MarketMakingConfig{
+			OracleWeighting: &tt.oracleWeight,
+			OracleBias:      tt.oracleBias,
+		}
+		rate := basisPrice(ob, oracle, cfg, mkt, tt.fiatRate, log)
+		if rate != tt.exp {
+			t.Fatalf("%s: %d != %d", tt.name, rate, tt.exp)
+		}
+	}
+}
+
+func TestBreakEvenHalfSpread(t *testing.T) {
+	mkt := &core.Market{
+		LotSize:    20e8, // 20 DCR
+		BaseID:     dcrBipID,
+		QuoteID:    btcBipID,
+		AtomToConv: 1,
+	}
+
+	tCore := newTCore()
+	log := dex.StdOutLogger("T", dex.LevelTrace)
+
+	tests := []*struct {
+		name             string
+		basisPrice       uint64
+		sellSwapFees     uint64
+		sellRedeemFees   uint64
+		buySwapFees      uint64
+		buyRedeemFees    uint64
+		exp              uint64
+		singleLotFeesErr error
+		expErr           bool
+	}{
+		{
+			name:   "basis price = 0 not allowed",
+			expErr: true,
+		},
+		{
+			name:             "swap fees error propagates",
+			singleLotFeesErr: errors.New("t"),
+			expErr:           true,
+		},
+		{
+			name:           "simple",
+			basisPrice:     4e7, // 0.4 BTC/DCR, quote lot = 8 BTC
+			buySwapFees:    200, // BTC
+			buyRedeemFees:  100, // DCR
+			sellSwapFees:   300, // DCR
+			sellRedeemFees: 50,  // BTC
+			// total btc (quote) fees, Q = 250
+			// total dcr (base) fees, B = 400
+			// g = (pB + Q) / (B + 2L)
+			// g = (0.4*400 + 250) / (400 + 40e8) = 1.02e-7 // atomic units
+			// g = 10 // msg-rate units
+			exp: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		tCore.sellSwapFees = tt.sellSwapFees
+		tCore.sellRedeemFees = tt.sellRedeemFees
+		tCore.buySwapFees = tt.buySwapFees
+		tCore.buyRedeemFees = tt.buyRedeemFees
+		tCore.singleLotFeesErr = tt.singleLotFeesErr
+
+		basicMM := &basicMarketMaker{
+			core: tCore,
+			mkt:  mkt,
+			log:  log,
+		}
+
+		halfSpread, err := basicMM.halfSpread(tt.basisPrice)
+		if (err != nil) != tt.expErr {
+			t.Fatalf("expErr = %t, err = %v", tt.expErr, err)
+		}
+		if halfSpread != tt.exp {
+			t.Fatalf("%s: %d != %d", tt.name, halfSpread, tt.exp)
+		}
+	}
+}
+
+func TestGroupedOrders(t *testing.T) {
+	const rateStep uint64 = 1e3
+	const lotSize uint64 = 50e8
+	mkt := &core.Market{
+		RateStep:   rateStep,
+		AtomToConv: 1,
+		LotSize:    lotSize,
+		BaseID:     dcrBipID,
+		QuoteID:    btcBipID,
+	}
+
+	orderIDs := make([]order.OrderID, 5)
+	for i := range orderIDs {
+		copy(orderIDs[i][:], encode.RandomBytes(32))
+	}
+
+	orders := map[order.OrderID]*core.Order{
+		orderIDs[0]: {
+			ID:     orderIDs[0][:],
+			Sell:   true,
+			Rate:   100e8,
+			Qty:    2 * lotSize,
+			Filled: lotSize,
+		},
+		orderIDs[1]: {
+			ID:     orderIDs[1][:],
+			Sell:   false,
+			Rate:   200e8,
+			Qty:    2 * lotSize,
+			Filled: lotSize,
+		},
+		orderIDs[2]: {
+			ID:   orderIDs[2][:],
+			Sell: true,
+			Rate: 300e8,
+			Qty:  2 * lotSize,
+		},
+		orderIDs[3]: {
+			ID:   orderIDs[3][:],
+			Sell: false,
+			Rate: 400e8,
+			Qty:  1 * lotSize,
+		},
+		orderIDs[4]: {
+			ID:   orderIDs[4][:],
+			Sell: false,
+			Rate: 402e8,
+			Qty:  1 * lotSize,
+		},
+	}
+
+	ordToPlacementIndex := map[order.OrderID]int{
+		orderIDs[0]: 0,
+		orderIDs[1]: 0,
+		orderIDs[2]: 1,
+		orderIDs[3]: 1,
+		orderIDs[4]: 1,
+	}
+
+	mm := &basicMarketMaker{
+		mkt:            mkt,
+		ords:           orders,
+		oidToPlacement: ordToPlacementIndex,
+	}
+
+	expectedBuys := map[int][]*groupedOrder{
+		0: {{
+			id:   orderIDs[1],
+			rate: 200e8,
+			lots: 1,
+		}},
+		1: {{
+			id:   orderIDs[3],
+			rate: 400e8,
+			lots: 1,
+		}, {
+			id:   orderIDs[4],
+			rate: 402e8,
+			lots: 1,
+		}},
+	}
+
+	expectedSells := map[int][]*groupedOrder{
+		0: {{
+			id:   orderIDs[0],
+			rate: 100e8,
+			lots: 1,
+		}},
+		1: {{
+			id:   orderIDs[2],
+			rate: 300e8,
+			lots: 2,
+		}},
+	}
+
+	buys, sells := mm.groupedOrders()
+
+	for i, buy := range buys {
+		sort.Slice(buy, func(i, j int) bool {
+			return buy[i].rate < buy[j].rate
+		})
+		reflect.DeepEqual(buy, expectedBuys[i])
+	}
+
+	for i, sell := range sells {
+		sort.Slice(sell, func(i, j int) bool {
+			return sell[i].rate < sell[j].rate
+		})
+		reflect.DeepEqual(sell, expectedSells[i])
+	}
+}

--- a/client/mm/mm_test.go
+++ b/client/mm/mm_test.go
@@ -137,6 +137,7 @@ type tCore struct {
 	cancelsPlaced                []dex.Bytes
 	buysPlaced                   []*core.TradeForm
 	sellsPlaced                  []*core.TradeForm
+	multiTradesPlaced            []*core.MultiTradeForm
 	maxFundingFees               uint64
 }
 
@@ -174,13 +175,24 @@ func (*tCore) Cancel(oidB dex.Bytes) error {
 	return nil
 }
 func (c *tCore) Trade(pw []byte, form *core.TradeForm) (*core.Order, error) {
+	if form.Sell {
+		c.sellsPlaced = append(c.sellsPlaced, form)
+	} else {
+		c.buysPlaced = append(c.buysPlaced, form)
+	}
 	return c.tradeResult, nil
 }
-func (*tCore) MaxBuy(host string, base, quote uint32, rate uint64) (*core.MaxOrderEstimate, error) {
-	return nil, nil
+func (c *tCore) MaxBuy(host string, base, quote uint32, rate uint64) (*core.MaxOrderEstimate, error) {
+	if c.maxBuyErr != nil {
+		return nil, c.maxBuyErr
+	}
+	return c.maxBuyEstimate, nil
 }
-func (*tCore) MaxSell(host string, base, quote uint32) (*core.MaxOrderEstimate, error) {
-	return nil, nil
+func (c *tCore) MaxSell(host string, base, quote uint32) (*core.MaxOrderEstimate, error) {
+	if c.maxSellErr != nil {
+		return nil, c.maxSellErr
+	}
+	return c.maxSellEstimate, nil
 }
 func (c *tCore) AssetBalance(assetID uint32) (*core.WalletBalance, error) {
 	return c.assetBalances[assetID], c.assetBalanceErr
@@ -190,8 +202,10 @@ func (c *tCore) PreOrder(form *core.TradeForm) (*core.OrderEstimate, error) {
 	return c.orderEstimate, nil
 }
 func (c *tCore) MultiTrade(pw []byte, forms *core.MultiTradeForm) ([]*core.Order, error) {
+	c.multiTradesPlaced = append(c.multiTradesPlaced, forms)
 	return c.multiTradeResult, nil
 }
+
 func (c *tCore) WalletState(assetID uint32) *core.WalletState {
 	isAccountLocker := c.isAccountLocker[assetID]
 
@@ -207,9 +221,6 @@ func (c *tCore) WalletState(assetID uint32) *core.WalletState {
 func (c *tCore) MaxFundingFees(fromAsset uint32, numTrades uint32, options map[string]string) (uint64, error) {
 	return c.maxFundingFees, nil
 }
-func (c *tCore) User() *core.User {
-	return nil
-}
 func (c *tCore) Login(pw []byte) error {
 	return nil
 }
@@ -217,7 +228,23 @@ func (c *tCore) OpenWallet(assetID uint32, pw []byte) error {
 	return nil
 }
 
+func (c *tCore) User() *core.User {
+	return nil
+}
+
 var _ clientCore = (*tCore)(nil)
+
+func tMaxOrderEstimate(lots uint64, swapFees, redeemFees uint64) *core.MaxOrderEstimate {
+	return &core.MaxOrderEstimate{
+		Swap: &asset.SwapEstimate{
+			RealisticWorstCase: swapFees,
+			Lots:               lots,
+		},
+		Redeem: &asset.RedeemEstimate{
+			RealisticWorstCase: redeemFees,
+		},
+	}
+}
 
 func (c *tCore) setAssetBalances(balances map[uint32]uint64) {
 	c.assetBalances = make(map[uint32]*core.WalletBalance)
@@ -232,11 +259,21 @@ func (c *tCore) setAssetBalances(balances map[uint32]uint64) {
 	}
 }
 
+func (c *tCore) clearTradesAndCancels() {
+	c.cancelsPlaced = make([]dex.Bytes, 0)
+	c.buysPlaced = make([]*core.TradeForm, 0)
+	c.sellsPlaced = make([]*core.TradeForm, 0)
+	c.multiTradesPlaced = make([]*core.MultiTradeForm, 0)
+}
+
 func newTCore() *tCore {
 	return &tCore{
 		assetBalances:   make(map[uint32]*core.WalletBalance),
 		noteFeed:        make(chan core.Notification),
 		isAccountLocker: make(map[uint32]bool),
+		cancelsPlaced:   make([]dex.Bytes, 0),
+		buysPlaced:      make([]*core.TradeForm, 0),
+		sellsPlaced:     make([]*core.TradeForm, 0),
 	}
 }
 

--- a/client/mm/mm_test.go
+++ b/client/mm/mm_test.go
@@ -218,7 +218,7 @@ func (c *tCore) WalletState(assetID uint32) *core.WalletState {
 		Traits: traits,
 	}
 }
-func (c *tCore) MaxFundingFees(fromAsset uint32, numTrades uint32, options map[string]string) (uint64, error) {
+func (c *tCore) MaxFundingFees(fromAsset uint32, host string, numTrades uint32, options map[string]string) (uint64, error) {
 	return c.maxFundingFees, nil
 }
 func (c *tCore) Login(pw []byte) error {

--- a/client/mm/price_oracle.go
+++ b/client/mm/price_oracle.go
@@ -52,6 +52,12 @@ type priceOracle struct {
 	cachedPrices map[string]*cachedPrice
 }
 
+type oracle interface {
+	getMarketPrice(base, quote uint32) float64
+}
+
+var _ oracle = (*priceOracle)(nil)
+
 func (o *priceOracle) getMarketPrice(base, quote uint32) float64 {
 	mktStr := (&mkt{base, quote}).String()
 

--- a/client/mm/sample-config.json
+++ b/client/mm/sample-config.json
@@ -1,18 +1,32 @@
 [{
     "host": "127.0.0.1:17273",
     "baseAsset": 42,
-    "quoteAsset": 0,
+    "quoteAsset": 60,
     "baseBalanceType": 0,
     "baseBalance": 50,
     "quoteBalanceType": 0,
     "quoteBalance": 50,
     "marketMakingConfig": {
-        "lots": 2,
         "gapStrategy": "multiplier",
-        "gapFactor": 1,
+        "sellPlacements": [{
+            "gapFactor": 2,
+            "lots": 2
+        },{
+            "gapFactor": 3,
+            "lots": 1
+        }],
+        "buyPlacements": [{
+            "gapFactor": 2,
+            "lots": 2
+        },{
+            "gapFactor": 3,
+            "lots": 1
+        }],
         "driftTolerance": 0.001,
         "oracleWeighting": 0.5,
         "oracleBias": 0,
-        "manualRate": 0
+        "emptyMarketRate": 0.005,
+        "splitTxAllowed": true,
+        "splitBuffer": 10
     }
 }]

--- a/client/mm/sample-config.json
+++ b/client/mm/sample-config.json
@@ -1,7 +1,7 @@
 [{
     "host": "127.0.0.1:17273",
     "baseAsset": 42,
-    "quoteAsset": 60,
+    "quoteAsset": 0,
     "baseBalanceType": 0,
     "baseBalance": 50,
     "quoteBalanceType": 0,
@@ -26,7 +26,12 @@
         "oracleWeighting": 0.5,
         "oracleBias": 0,
         "emptyMarketRate": 0.005,
-        "splitTxAllowed": true,
-        "splitBuffer": 10
+        "baseOptions": {
+            "multisplit": "true"
+        },
+        "quoteOptions": {
+            "multisplit": "true",
+            "multisplitbuffer": "5"
+        }
     }
 }]

--- a/client/mm/wrapped_core.go
+++ b/client/mm/wrapped_core.go
@@ -37,7 +37,7 @@ func (c *wrappedCore) maxBuyQty(host string, base, quote uint32, rate uint64, op
 		return 0, err
 	}
 
-	fundingFees, err := c.MaxFundingFees(quote, 1, options)
+	fundingFees, err := c.MaxFundingFees(quote, host, 1, options)
 	if err != nil {
 		return 0, err
 	}
@@ -80,7 +80,7 @@ func (c *wrappedCore) maxSellQty(host string, base, quote, numTrades uint32, opt
 		return 0, err
 	}
 
-	fundingFees, err := c.MaxFundingFees(base, numTrades, options)
+	fundingFees, err := c.MaxFundingFees(base, host, numTrades, options)
 	if err != nil {
 		return 0, err
 	}
@@ -158,7 +158,7 @@ func (c *wrappedCore) sufficientBalanceForMultiBuy(host string, base, quote uint
 		return false, err
 	}
 
-	fundingFees, err := c.MaxFundingFees(quote, uint32(len(placements)), options)
+	fundingFees, err := c.MaxFundingFees(quote, host, uint32(len(placements)), options)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This updates the basic market maker strategy to place multiple orders at various distances from the basis price instead of just one. It uses the new MultiTrade function to do this.

The basis price calculation is also updated to use fiat rates as a fallback if there are no trades on the dex or an oracle rate.

Something still missing from this is adjusting the rates based on how many previous buys/sells have been matched. There
needs to be a skew setting that places orders from the side with more previous matches farther from the basis price.