### PR TITLE
client/UI: Add pending bond message.

### DIFF
--- a/client/cmd/dexcctl/simnet-setup.sh
+++ b/client/cmd/dexcctl/simnet-setup.sh
@@ -89,7 +89,8 @@ if [ $RESTORING == "true" ]; then
 else
 
   echo registering with DEX
-  ./dexcctl -p abc --simnet register 127.0.0.1:17273 100000000 42 ~/dextest/dcrdex/rpc.cert
+  ./dexcctl -p abc --simnet login
+  ./dexcctl -p abc --simnet postbond 127.0.0.1:17273 1000000000 42 true ~/dextest/dcrdex/rpc.cert
 
   echo mining fee confirmation blocks
   tmux send-keys -t dcr-harness:0 "./mine-alpha 1" C-m

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -8138,20 +8138,20 @@ func (c *Core) startDexConnection(acctInfo *db.AccountInfo, dc *dexConnection) e
 			bondIDStr := coinIDString(dbBond.AssetID, dbBond.CoinID)
 
 			if int64(dbBond.LockTime) <= lockTimeThresh {
-				c.log.Infof("Loaded expired bond %v. Refund tx: %x", bondIDStr, dbBond.RefundTx)
+				c.log.Infof("Loaded expired bond %v. Refund tx: %v", bondIDStr, dbBond.RefundTx)
 				dc.acct.expiredBonds = append(dc.acct.expiredBonds, dbBond)
 				continue
 			}
 
 			if dbBond.Confirmed {
 				// This bond has already been confirmed by the server.
-				c.log.Infof("Loaded active bond %v. BACKUP refund tx: %x", bondIDStr, dbBond.RefundTx)
+				c.log.Infof("Loaded active bond %v. BACKUP refund tx: %v", bondIDStr, dbBond.RefundTx)
 				dc.acct.bonds = append(dc.acct.bonds, dbBond)
 				continue
 			}
 
 			// Server has not yet confirmed this bond.
-			c.log.Infof("Loaded pending bond %v. Refund tx: %x", bondIDStr, dbBond.RefundTx)
+			c.log.Infof("Loaded pending bond %v. Refund tx: %v", bondIDStr, dbBond.RefundTx)
 			dc.acct.pendingBonds = append(dc.acct.pendingBonds, dbBond)
 
 			// We need to start monitorBondConfs on login since postbond

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -1216,7 +1216,7 @@ Registration is complete after the fee transaction has been confirmed.`,
 	},
 	postBondRoute: {
 		pwArgsShort: `"appPass"`,
-		argsShort:   `"addr" bond assetID (lockTime "cert" maintain)`,
+		argsShort:   `"addr" bond assetID (maintain "cert")`,
 		cmdSummary: `Post new bond for DEX. An ok response does not mean that the bond is active.
 		Bond is active after the bond transaction has been confirmed and the server notified.`,
 		pwArgsLong: `Password Args:
@@ -1225,8 +1225,8 @@ Registration is complete after the fee transaction has been confirmed.`,
     addr (string): The DEX address to post bond for for.
     bond (int): The bond amount (in DCR presently).
     assetID (int): The asset ID with which to pay the fee.
-    cert (string): Optional. The TLS certificate path. Only applicable when registering.
-    maintain (bool): Optional. Whether to maintain the trading tier established by this bond. Only applicable when registering. (default is true)`,
+    maintain (bool): Optional. Whether to maintain the trading tier established by this bond. Only applicable when registering. (default is true)
+    cert (string): Optional. The TLS certificate path. Only applicable when registering.`,
 		returns: `Returns:
     {
       "bondID" (string): The bond transactions's txid and output index.

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -70,6 +70,8 @@ var EnUS = map[string]string{
 	"need_to_register_msg":           `You need to create an account on <span id="unregisteredDex"></span> to trade.`,
 	"Create Account":                 "Create Account",
 	"reg_status_msg":                 `In order to trade at <span id="regStatusDex" class="text-break"></span>, your pending bond(s) need to be confirmed.`,
+	"posting_bonds_shortly":          "Creating bonds...",
+	"bond_creation_pending_msg":      `In order to trade at <span id="postingBondsDex" class="text-break"></span> bond(s) will be created shortly.`,
 	"action_required_to_trade":       "ACTION REQUIRED TO TRADE",
 	"acct_tier_post_bond":            `You account tier is <span id="acctTier"></span>. You need to post new bonds to trade.`,
 	"enable_bond_maintenance":        "Enable bond maintenance from DEX Settings page.",

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -457,6 +457,14 @@ div[data-handler=markets] {
     color: #777;
   }
 
+  #bondCreationPending {
+    .title {
+      font-weight: bold;
+      margin-bottom: 5px;
+      color: #9b8c09;
+    }
+  }
+
   #registrationStatus {
     .title {
       font-weight: bold;

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=84c0e9b2|a81bed06" rel="stylesheet">
+  <link href="/css/style.css?v=b364da40|18bfd169" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=6bafbf4d|06009820"></script>
+<script src="/js/entry.js?v=316c3da9|8d59551e"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -227,6 +227,18 @@
                 </div>
               </div>
 
+              {{- /* BOND CREATION PENDING */ -}}
+              <div class="d-hide p-2 mt-2" id="bondCreationPending">
+                <div class="p-0 w-100">
+                  <div class="d-flex flex-column justify-content-center align-items-center">
+                    <p id="postingBondsShortlyTitle" class="title">[[[posting_bonds_shortly]]]
+                    </p>
+                    <p id="bondCreationPendingMessage">[[[bond_creation_pending_msg]]]
+                    </p>
+                  </div>
+                </div>
+              </div>
+
               {{- /* REGISTRATION STATUS */ -}}
               <div class="d-hide p-2 mt-2" id="registrationStatus">
                 <div class="p-0 w-100">

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -930,6 +930,7 @@ export default class MarketsPage extends BasePage {
   updateRegistrationStatusView () {
     const { page, market: { dex } } = this
     page.regStatusDex.textContent = dex.host
+    page.postingBondsDex.textContent = dex.host
 
     if (dex.tier >= 1) {
       this.setRegistrationStatusView(intl.prep(intl.ID_REGISTRATION_FEE_SUCCESS), '', 'completed')
@@ -960,7 +961,7 @@ export default class MarketsPage extends BasePage {
 
     if (market.dex.tier >= 1) {
       const toggle = () => {
-        Doc.hide(page.registrationStatus, page.bondRequired)
+        Doc.hide(page.registrationStatus, page.bondRequired, page.bondCreationPending)
         this.resolveOrderFormVisibility()
       }
       if (Doc.isHidden(page.orderForm)) {
@@ -975,6 +976,8 @@ export default class MarketsPage extends BasePage {
       Doc.show(page.notRegistered)
     } else if (this.hasPendingBonds()) {
       Doc.show(page.registrationStatus)
+    } else if (market.dex.bondOptions.targetTier > 0) {
+      Doc.show(page.bondCreationPending)
     } else {
       page.acctTier.textContent = `${market.dex.tier}`
       page.dexSettingsLink.href = `/dexsettings/${market.dex.host}`


### PR DESCRIPTION
If target bond tier is more than zero but bonds have not been sent yet, inform the user of the state rather than incorrect message that they must change their bond settings.

Also updating the simnet setup script to use bonds and attempting to fix a couple bugs.

![image](https://github.com/decred/dcrdex/assets/34998433/c8823a44-1f01-4e5f-ab26-05db06da2aee)

closes #2408