### PR TITLE
git: ignore dirs created when code run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ client/asset/btc/electrum/example/wallet/wallet
 **/testdata/fuzz
 client/asset/eth/cmd/getgas/getgas
 client/cmd/dexc-desktop/pkg/installers
+mainnet/
+testnet/
+regtest/


### PR DESCRIPTION
Sometimes a dir `regtest` is created when dex-tests/dex-code is run inside the repo tree. This pr adds
```
mainnet/
testnet/
regtest/
```
 to `.gitignore` 