### PR TITLE
doge: enable background mining in harness

### DIFF
--- a/dex/testing/dgb/harness.sh
+++ b/dex/testing/dgb/harness.sh
@@ -20,7 +20,8 @@ export DELTA_WALLET_SEED="ehA5EC6mbNvGCJ4HqtjNc822ojnU2bGRLoc3cZipoYFFYT7tYrq4"
 export DELTA_ADDRESS="dgbrt1qdgzj8guegzuyfupcvy3vjlpfxpv8rgruqtkndf"
 # Signal that the node needs to restart after encrypting wallet
 export RESTART_AFTER_ENCRYPT="1"
-export NOMINER="1"
+# Uncomment to disable background mining
+#export NOMINER="1"
 # $1 is the node to create with. $2 is the wallet name
 export NEW_WALLET_CMD="./\$1 createwallet \$2"
 export BLOCKS_TO_MINE=120 # it chokes with high diff if you mine much more, but if you stop at 100, nothing much is mature it seems

--- a/dex/testing/dgb/harness.sh
+++ b/dex/testing/dgb/harness.sh
@@ -20,8 +20,7 @@ export DELTA_WALLET_SEED="ehA5EC6mbNvGCJ4HqtjNc822ojnU2bGRLoc3cZipoYFFYT7tYrq4"
 export DELTA_ADDRESS="dgbrt1qdgzj8guegzuyfupcvy3vjlpfxpv8rgruqtkndf"
 # Signal that the node needs to restart after encrypting wallet
 export RESTART_AFTER_ENCRYPT="1"
-# Uncomment to disable background mining
-#export NOMINER="1"
+export NOMINER="1"
 # $1 is the node to create with. $2 is the wallet name
 export NEW_WALLET_CMD="./\$1 createwallet \$2"
 export BLOCKS_TO_MINE=120 # it chokes with high diff if you mine much more, but if you stop at 100, nothing much is mature it seems

--- a/dex/testing/doge/harness.sh
+++ b/dex/testing/doge/harness.sh
@@ -276,6 +276,7 @@ tmux send-keys -t $SESSION:0 C-c
 tmux send-keys -t $SESSION:1 C-c
 tmux send-keys -t $SESSION:2 C-c
 tmux send-keys -t $SESSION:3 C-c
+tmux send-keys -t $SESSION:5 C-c
 tmux wait-for alpha${SYMBOL}
 tmux wait-for beta${SYMBOL}
 # seppuku

--- a/dex/testing/doge/harness.sh
+++ b/dex/testing/doge/harness.sh
@@ -15,6 +15,9 @@ GAMMA_RPC_PORT="23771"
 ALPHA_MINING_ADDR="mjzB71SzfAi8BwNvobPZ983d8vCdxuQD2i"
 BETA_MINING_ADDR="mwL7ypWCMEhBhGcsqWNwkvAasuXP3duXQk"
 
+# Uncomment to disable background mining
+#NOMINER="1"
+
 set -ex
 NODES_ROOT=~/dextest/${SYMBOL}
 rm -rf "${NODES_ROOT}"
@@ -315,6 +318,18 @@ done
 
 tmux send-keys -t $SESSION:4 "./mine-alpha 2${DONE}" C-m\; ${WAIT}
 
-# Reenable history and attach to the control session.
+################################################################################
+# Setup watch background miner -- if required
+################################################################################
+if [ -z "$NOMINER" ] ; then
+  tmux new-window -t $SESSION:5 -n "miner" $SHELL
+  tmux send-keys -t $SESSION:5 "cd ${HARNESS_DIR}" C-m
+  tmux send-keys -t $SESSION:5 "watch -n 15 ./mine-alpha 1" C-m
+fi
+
+######################################################################################
+# Reenable history select the harness control window & attach to the control session #
+######################################################################################
 tmux send-keys -t $SESSION:4 "set -o history" C-m
+tmux select-window -t $SESSION:4
 tmux attach-session -t $SESSION


### PR DESCRIPTION
## Harnesses:

- switch on mining for DGB
- add mining for DOGE

set/export NOMINER="1" to disable

DGB documented to have issues after mining ~100 blocks. Selectively disable as needed.
