### PR TITLE
client/btc: Fix bug in leastOverFundWithLimit

### DIFF
--- a/client/asset/btc/coin_selection.go
+++ b/client/asset/btc/coin_selection.go
@@ -123,7 +123,7 @@ func subsetWithLeastOverFund(enough func(uint64, uint64) (bool, uint64), maxFund
 					nTotal += shuffledUTXOs[i].amount
 					totalSize += uint64(shuffledUTXOs[i].input.VBytes())
 					if e, _ := enough(totalSize, nTotal); e {
-						if nTotal < best || (nTotal == best && numIncluded < bestNumIncluded) && nTotal <= maxFund {
+						if (nTotal < best || (nTotal == best && numIncluded < bestNumIncluded)) && nTotal <= maxFund {
 							best = nTotal
 							if bestIncluded == nil {
 								bestIncluded = make([]bool, len(shuffledUTXOs))


### PR DESCRIPTION
Logic was incorrect. This is not critical as it only affects MultiTrade, which is not yet in use.