### PR TITLE
client/core: Simnet fiat rates option

### DIFF
--- a/client/app/config.go
+++ b/client/app/config.go
@@ -99,6 +99,7 @@ type CoreConfig struct {
 	NoAutoWalletLock   bool `long:"no-wallet-lock" description:"Disable locking of wallets on shutdown or logout. Use this if you want your external wallets to stay unlocked after closing the DEX app."`
 	NoAutoDBBackup     bool `long:"no-db-backup" description:"Disable creation of a database backup on shutdown."`
 	UnlockCoinsOnLogin bool `long:"release-wallet-coins" description:"On login or wallet creation, instruct the wallet to release any coins that it may have locked."`
+	SimnetFiatRates    bool `long:"simnet-fiat-rates" description:"Fetch fiat rates when running in simnet mode."`
 }
 
 // WebConfig encapsulates the configuration needed for the web server.
@@ -193,6 +194,7 @@ func (cfg *Config) Core(log dex.Logger) *core.Config {
 		UnlockCoinsOnLogin: cfg.UnlockCoinsOnLogin,
 		NoAutoWalletLock:   cfg.NoAutoWalletLock,
 		NoAutoDBBackup:     cfg.NoAutoDBBackup,
+		SimnetFiatRates:    cfg.SimnetFiatRates,
 	}
 }
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1377,6 +1377,9 @@ type Config struct {
 	TorIsolation bool
 	// Language. A BCP 47 language tag. Default is en-US.
 	Language string
+	// SimnetFiatRates specifies whether to fetch fiat rates when running on
+	// simnet.
+	SimnetFiatRates bool
 
 	// NoAutoWalletLock instructs Core to skip locking the wallet on shutdown or
 	// logout. This can be helpful if the user wants the wallet to remain
@@ -1586,7 +1589,7 @@ func (c *Core) Run(ctx context.Context) {
 
 	// Skip rate fetch setup if on simnet. Rate fetching maybe enabled if
 	// desired.
-	if c.cfg.Net != dex.Simnet {
+	if c.cfg.Net != dex.Simnet || c.cfg.SimnetFiatRates {
 		c.ratesMtx.Lock()
 		// Retrieve disabled fiat rate sources from database.
 		disabledSources, err := c.db.DisabledRateSources()


### PR DESCRIPTION
Adds a command line option to fetch fiat rates when running simnet. This is helpful for testing.