### PR TITLE
client/asset/dcr: workaround TxDetails unconfirmed bug

### DIFF
--- a/client/asset/dcr/spv_test.go
+++ b/client/asset/dcr/spv_test.go
@@ -174,6 +174,16 @@ func (w *tDcrWallet) TxDetails(ctx context.Context, txHash *chainhash.Hash) (*ud
 	return w.txDetails, w.txDetailsErr
 }
 
+func (w *tDcrWallet) TransactionSummary(ctx context.Context, txHash *chainhash.Hash) (txSummary *wallet.TransactionSummary, confs int32, blockHash *chainhash.Hash, err error) {
+	return nil, 0, nil, errors.New("blah")
+}
+func (w *tDcrWallet) TxConfirms(ctx context.Context, hash *chainhash.Hash) (int32, error) {
+	return 0, errors.New("blah")
+}
+func (w *tDcrWallet) TxBlock(ctx context.Context, hash *chainhash.Hash) (chainhash.Hash, int32, error) {
+	return chainhash.Hash{}, 0, errors.New("blah")
+}
+
 func (w *tDcrWallet) Synced() bool {
 	return true
 }


### PR DESCRIPTION
Pertains to https://github.com/decred/dcrdex/issues/2442.

There is an issue given:
- taker's swap tx is DCR
- you shutdown dexc after the (taker) DCR swap transaction is broadcast, but before it is mined
- start dexc, login
- wait for DCR block(s), transaction always appears unconfirmed, swap never proceeds (except refund)

I believe you must be both maker and taker (self trade) for it to halt the swap because if you are not also the taker who authored the DCR swap transaction, then for maker, the `SwapConfirmations` method will fallback to cfilters scan when `lookupTxOutput` fails to find the transaction.  Or so I would expect since the counterparty contract transaction would not be a wallet transaction.

The above is not always reproducible, but I managed to get it to happen twice with the native SPV wallet.

I tracked the culprit down to `dcrwallet/wallet/udb.(*Store).TxDetails`.  It will find and return an **unmined** transaction that it finds with `existsRawUnmined` and `unminedTxDetails` (but it's really mined, several confs even).

https://github.com/decred/dcrwallet/blob/master/wallet/udb/txquery.go#L180-L194

I do not know if it would find a **mined** transaction *also* if it could get down to `latestTxRecord` and `minedTxDetails`, but it seems the transaction is left in `bucketUnmined`.  i.e. `deleteRawUnmined` is not called as expected.  There are only two call sites for `deleteRawUnmined`:
- `wallet/udb.(*Store).moveMinedTx`
- `wallet/udb.(*Store).RemoveUnconfirmed`

I don't know which isn't getting called.

Perhaps one detail worth noting is that I generally use a split tx in the order, meaning the resulting DCR swap contract transaction will have no change, so it's just the input/debit that belongs to the authoring wallet, and the one swap output technically belongs to neither wallet.