### PR TITLE
remove core.User from auth middleware user info

### DIFF
--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -236,6 +236,7 @@ func (s *WebServer) handleInit(w http.ResponseWriter, r *http.Request) {
 // handleSettings is the handler for the '/settings' page request.
 func (s *WebServer) handleSettings(w http.ResponseWriter, r *http.Request) {
 	common := s.commonArgs(r, "Settings | Decred DEX")
+	xcs := s.core.Exchanges()
 	data := &struct {
 		CommonArguments
 		KnownExchanges  []string
@@ -244,10 +245,10 @@ func (s *WebServer) handleSettings(w http.ResponseWriter, r *http.Request) {
 		Exchanges       map[string]*core.Exchange
 	}{
 		CommonArguments: *common,
-		KnownExchanges:  s.knownUnregisteredExchanges(s.core.Exchanges()),
+		KnownExchanges:  s.knownUnregisteredExchanges(xcs),
 		FiatCurrency:    core.DefaultFiatCurrency,
 		FiatRateSources: s.core.FiatRateSources(),
-		Exchanges:       s.core.Exchanges(),
+		Exchanges:       xcs,
 	}
 	s.sendTemplate(w, "settings", data)
 }

--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -87,7 +87,8 @@ type registerTmplData struct {
 	KnownExchanges []string
 	// Host is optional. If provided, the register page will not display the add
 	// dex form, instead this host will be pre-selected for registration.
-	Host string
+	Host        string
+	Initialized bool
 }
 
 // handleRegister is the handler for the '/register' page request.
@@ -97,7 +98,8 @@ func (s *WebServer) handleRegister(w http.ResponseWriter, r *http.Request) {
 	s.sendTemplate(w, "register", &registerTmplData{
 		CommonArguments: *common,
 		Host:            host,
-		KnownExchanges:  s.knownUnregisteredExchanges(common.UserInfo.Exchanges),
+		KnownExchanges:  s.knownUnregisteredExchanges(s.core.Exchanges()),
+		Initialized:     s.core.IsInitialized(),
 	})
 }
 
@@ -239,11 +241,13 @@ func (s *WebServer) handleSettings(w http.ResponseWriter, r *http.Request) {
 		KnownExchanges  []string
 		FiatRateSources map[string]bool
 		FiatCurrency    string
+		Exchanges       map[string]*core.Exchange
 	}{
 		CommonArguments: *common,
-		KnownExchanges:  s.knownUnregisteredExchanges(common.UserInfo.Exchanges),
+		KnownExchanges:  s.knownUnregisteredExchanges(s.core.Exchanges()),
 		FiatCurrency:    core.DefaultFiatCurrency,
 		FiatRateSources: s.core.FiatRateSources(),
+		Exchanges:       s.core.Exchanges(),
 	}
 	s.sendTemplate(w, "settings", data)
 }
@@ -272,7 +276,7 @@ func (s *WebServer) handleDexSettings(w http.ResponseWriter, r *http.Request) {
 	}{
 		CommonArguments: common,
 		Exchange:        exchange,
-		KnownExchanges:  s.knownUnregisteredExchanges(common.UserInfo.Exchanges),
+		KnownExchanges:  s.knownUnregisteredExchanges(s.core.Exchanges()),
 	}
 
 	s.sendTemplate(w, "dexsettings", data)
@@ -295,15 +299,15 @@ var allStatuses = map[uint8]string{
 
 // handleOrders is the handler for the /orders page request.
 func (s *WebServer) handleOrders(w http.ResponseWriter, r *http.Request) {
-	user := extractUserInfo(r).User
-	hosts := make([]string, 0, len(user.Exchanges))
-	for _, xc := range user.Exchanges {
+	xcs := s.core.Exchanges()
+	hosts := make([]string, 0, len(xcs))
+	for _, xc := range xcs {
 		hosts = append(hosts, xc.Host)
 	}
 
 	s.sendTemplate(w, "orders", &ordersTmplData{
 		CommonArguments: *s.commonArgs(r, "Orders | Decred DEX"),
-		Assets:          user.Assets,
+		Assets:          s.core.SupportedAssets(),
 		Hosts:           hosts,
 		Statuses:        allStatuses,
 	})

--- a/client/webserver/locales/parse_test.go
+++ b/client/webserver/locales/parse_test.go
@@ -25,12 +25,6 @@ func TestTokens(t *testing.T) {
     <span class="ico-info"></span>
     </span>
     <div>
-      <div id="exchanges" {{if eq (len .UserInfo.Exchanges) 0}} class="d-hide"{{end}}>
-        <h5>[[[registered dexes]]]</h5>
-        {{range $host, $xc := .UserInfo.Exchanges}}
-          <a href="/dexsettings/{{$host}}"><button class="bg2 selected"><div class=text-break>{{$host}}<span class="dex-settings-icon ico-settings"></span></div></button></a>
-        {{end}}
-      </div>
       <br>
       <div {{if not .UserInfo.Authed}} class="d-hide"{{end}}>
         <p>
@@ -50,7 +44,6 @@ func TestTokens(t *testing.T) {
 		"[[[Show pop-up notifications]]]",
 		"[[[fiat_exchange_rate_msg]]]",
 		"[[[fiat_exchange_rate_sources]]]",
-		"[[[registered dexes]]]",
 		"[[[simultaneous_servers_msg]]]",
 		"[[[Add a DEX]]]",
 		"[[[Import Account]]]",
@@ -63,7 +56,6 @@ func TestTokens(t *testing.T) {
 		"Show pop-up notifications",
 		"fiat_exchange_rate_msg",
 		"fiat_exchange_rate_sources",
-		"registered dexes",
 		"simultaneous_servers_msg",
 		"Add a DEX",
 		"Import Account",

--- a/client/webserver/middleware.go
+++ b/client/webserver/middleware.go
@@ -42,7 +42,6 @@ func (s *WebServer) securityMiddleware(next http.Handler) http.Handler {
 func (s *WebServer) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := context.WithValue(r.Context(), ctxKeyUserInfo, &userInfo{
-			User:             s.core.User(),
 			Authed:           s.isAuthed(r),
 			PasswordIsCached: s.isPasswordCached(r),
 			DarkMode:         extractBooleanCookie(r, darkModeCK, true),

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -25,13 +25,12 @@
 {{define "header"}}
 <header id=header class="maintop">
   {{$authed := .UserInfo.Authed}}
-  {{$marketsReady := and $authed (gt (len .UserInfo.Exchanges) 0)}}
   <a href="/" class="logo-icon d-none d-md-block"></a>
   <a href="/" class="logo-icon d-block d-md-none"></a>
   <div id="headerSpace"></div>
   <div class="mainlinks fs18 offwhite pe-2">
 
-    <a href="/markets" class="demi hoverbg{{if not $marketsReady}} d-hide{{end}}" id="marketsMenuEntry">[[[Markets]]]</a>
+    <a href="/markets" class="demi hoverbg d-hide" id="marketsMenuEntry">[[[Markets]]]</a>
 
     <a href="/wallets" class="demi hoverbg{{if not $authed}} d-hide{{end}}" id="walletsMenuEntry">[[[Wallets]]]</a>
 
@@ -104,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=8d78a43c|6fec6c4d"></script>
+<script src="/js/entry.js?v=e399004c|4c138427"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -4,7 +4,7 @@
   <div class="position-absolute" id="forms">
 
     {{- /* LOGIN FORM */ -}}
-    <form class="d-hide{{if and (not .UserInfo.Authed) .UserInfo.Initialized }} selected{{end}}" id="loginForm">
+    <form class="d-hide{{if and (not .UserInfo.Authed) .Initialized }} selected{{end}}" id="loginForm">
       {{template "loginForm"}}
     </form>
 
@@ -14,12 +14,12 @@
     </form>
 
     {{- /* DEX ADDRESS FORM */ -}}
-    <form class="d-hide{{if and .UserInfo.Initialized .UserInfo.Authed (not .Host)}} selected{{end}}" id="dexAddrForm">
+    <form class="d-hide{{if and .Initialized .UserInfo.Authed (not .Host)}} selected{{end}}" id="dexAddrForm">
       {{template "dexAddrForm" .}}
     </form>
 
     {{- /* DISCOVER ACCOUNT FORM */ -}}
-    <form class="d-hide{{if and .UserInfo.Initialized .UserInfo.Authed .Host}} selected{{end}}" id="discoverAcctForm" data-host="{{.Host}}">
+    <form class="d-hide{{if and .Initialized .UserInfo.Authed .Host}} selected{{end}}" id="discoverAcctForm" data-host="{{.Host}}">
       {{template "discoverAcctForm" .}}
     </form>
 

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -32,9 +32,9 @@
     {{end}}
     </div>
     <div>
-      <div id="exchanges" {{if eq (len .UserInfo.Exchanges) 0}} class="d-hide"{{end}}>
+      <div id="exchanges" {{if eq (len .Exchanges) 0}} class="d-hide"{{end}}>
         <h5>[[[registered dexes]]]</h5>
-        {{range $host, $xc := .UserInfo.Exchanges}}
+        {{range $host, $xc := .Exchanges}}
           <a href="/dexsettings/{{$host}}"><button class="bg2 selected"><div class=text-break>{{$host}}<span class="dex-settings-icon ico-settings"></span></div></button></a>
         {{end}}
       </div>

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -466,11 +466,7 @@ export default class Application {
     }
     page.profileBox.classList.add('authed')
     Doc.show(page.noteBell, page.walletsMenuEntry)
-    if (Object.keys(user.exchanges).length > 0) {
-      Doc.show(page.marketsMenuEntry)
-    } else {
-      Doc.hide(page.marketsMenuEntry)
-    }
+    Doc.setVis(Object.keys(user.exchanges).length > 0, page.marketsMenuEntry)
   }
 
   /* attachCommon scans the provided node and handles some common bindings. */

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -843,7 +843,6 @@ func readPost(w http.ResponseWriter, r *http.Request, thing interface{}) bool {
 // core.User type, adding fields specific to the users server authentication
 // and cookies.
 type userInfo struct {
-	*core.User
 	Authed           bool
 	PasswordIsCached bool
 	DarkMode         bool


### PR DESCRIPTION
We use almost none of the `*core.User` data that was embedded in the `webserver.CommonArguments`. In continuation of #2350, I've completely removed the `User` and made adjustments to template data where necessary.