### PR TITLE
docs: download link for standalone app

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ few simple *options* for obtaining the software. The standalone DEX client is
 strongly recommended as it is the easiest to setup and generally has the most
 up-to-date downloads. Pick **just one** method:
 
-1. Download the the standalone DEX client for your operating system for the
-   [latest release on GitHub](https://github.com/decred/dcrdex/releases).
-2. Use your operating system's package manager. See [OS Packages](#os-packages)
+1. Download [standalone DEX client for your operating system](https://dex.decred.org/#downloads).
+2. Download [the latest standalone DEX client release from GitHub](https://github.com/decred/dcrdex/releases)
+   for your operating system.
+3. Use your operating system's package manager. See [OS Packages](#os-packages)
    for more info.
-3. [Use Decrediton](https://docs.decred.org/wallets/decrediton/decrediton-setup/),
+4. [Use Decrediton](https://docs.decred.org/wallets/decrediton/decrediton-setup/),
    the official graphical Decred wallet, which integrates the DEX client, and go
    to the DEX tab.
-4. Use the Decred command line application installer, [**dcrinstall**](https://docs.decred.org/wallets/cli/cli-installation/). Not recommended unless you already have this in your workflow.
-5. Build the standalone client [from source](https://github.com/decred/dcrdex/wiki/Client-Installation-and-Configuration#advanced-client-installation).
+5. Use the Decred command line application installer, [**dcrinstall**](https://docs.decred.org/wallets/cli/cli-installation/). Not recommended unless you already have this in your workflow.
+6. Build the standalone client [from source](https://github.com/decred/dcrdex/wiki/Client-Installation-and-Configuration#advanced-client-installation).
 
 See the [Client Installation and Configuration](https://github.com/decred/dcrdex/wiki/Client-Installation-and-Configuration)
 page on the wiki for more information and a detailed walk-through of the initial setup.

--- a/docs/wiki/Client-Installation-and-Configuration.md
+++ b/docs/wiki/Client-Installation-and-Configuration.md
@@ -5,11 +5,11 @@
 The DEX client can be installed in one of the following ways. Download the
 application from *just one* of the following locations:
 
-* Download the standalone DEX client for your operating system for the [latest
-  release on GitHub](https://github.com/decred/dcrdex/releases). Extract the
-  "dexc" executable from the archive and run it. Open any web browser to the
-  link shown by the application. You may also put the **dexc** executable's
-  folder on your `PATH`.
+* Download [standalone DEX client for your operating system](https://dex.decred.org/#downloads).
+* Download [the latest standalone DEX client release from GitHub](https://github.com/decred/dcrdex/releases)
+  for your operating system. Extract the "dexc" executable from the archive and run it.
+  Open any web browser to the link shown by the application. You may also put the **dexc**
+  executable's folder on your `PATH`.
 * [Use Decrediton](https://docs.decred.org/wallets/decrediton/decrediton-setup/),
   the official graphical Decred wallet, which integrates the DEX client, and go
   to the DEX tab.


### PR DESCRIPTION
Based on https://github.com/decred/dcrdex/pull/2456, blocked by https://github.com/decred/dexweb/issues/41 (hence PR is a draft).

See [rendered version](https://github.com/norwnd/dcrdex/tree/docs-download-link-for-standalone-app).

It will probably be useful to have the https://dex.decred.org/#downloads link in setup section(s), once it's ready to distribute standalone apps: https://github.com/decred/dexweb/issues/41.