### PR TITLE
ui: improve app seed display

### DIFF
--- a/client/webserver/site/src/css/main_dark.scss
+++ b/client/webserver/site/src/css/main_dark.scss
@@ -82,7 +82,9 @@ body.dark {
   select,
   select:focus,
   input,
-  input:focus {
+  input:focus,
+  textarea,
+  textarea:focus {
     border: none;
     outline: none;
     color: $font-color-dark;
@@ -91,7 +93,9 @@ body.dark {
   select,
   select:focus,
   input:not([type=checkbox]),
-  input:focus:not([type=checkbox]) {
+  input:focus:not([type=checkbox]),
+  textarea,
+  textarea:focus {
     background-color: black;
     border: 1px solid $dark_input_border;
   }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AK4XS4">
   <meta name="description" content="Decred DEX Client Web Portal">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v=a179bbb8|fadb2030" rel="stylesheet">
+  <link href="/css/style.css?v=2df17a50|6907cdb7" rel="stylesheet">
 </head>
 <body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
   <div class="popup-notes" id="popupNotes">
@@ -104,7 +104,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=028e1498|b813f78d"></script>
+<script src="/js/entry.js?v=fd4f6cab|6e85ed8b"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/init.tmpl
+++ b/client/webserver/site/src/html/init.tmpl
@@ -22,7 +22,7 @@
       </div>
       <div class="pb-3 d-hide mt-3" id="seedRestore">
         <label for="seedInput" class="form-label ps-1 mb-1">[[[Restoration Seed]]]</label>
-        <input type="text" class="form-control select" id="seedInput" autocomplete="off">
+        <textarea class="form-control select mono" id="seedInput" rows="4" autocomplete="off" spellcheck="false"></textarea>
       </div>
       <div class="d-flex justify-content-between mt-4">
         <div class="px-1 fs13 pointer d-flex justify-content-start align-items-center" id="showSeedRestore"><span class="ico-plus fs11"></span> <div class="ps-2">[[[Restore from seed]]]</div></div>
@@ -100,7 +100,9 @@
 
       <div id="sbSeed" class="d-hide">
         <div class="fs18 mt-2">[[[save_seed_instructions]]]</div>
-        <div class="my-2 p-2" id="seedDiv"></div>
+        <div class="my-2 p-2 flex-center">
+          <pre class="fs18 mono mx-auto select-all" id="seedDiv"></pre>
+        </div>
         <button id="seedAck" class="selected">[[[Done]]]</button>
       </div>
     </form>

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -112,7 +112,9 @@
     <form class="d-hide" id="authorizeSeedDisplay">
       <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
       <div class="fs18 sans-light text-center mb-2">[[[dont_share]]]</div>
-      <div id="seedDiv"></div>
+      <div class="my-2 p-2 flex-center">
+        <pre class="fs18 mono mx-auto select-all" id="seedDiv"></pre>
+      </div>
     </form>
 
     {{- /* SYNC AND BALANCE FORM */ -}}

--- a/client/webserver/site/src/js/init.ts
+++ b/client/webserver/site/src/js/init.ts
@@ -116,7 +116,7 @@ class AppInitForm {
     page.appPW.value = ''
     page.appPWAgain.value = ''
     const loaded = app().loading(this.form)
-    const seed = page.seedInput.value
+    const seed = page.seedInput.value?.replace(/\s+/g, '') // strip whitespace
     const rememberPass = page.rememberPass.checked
     const res = await postJSON('/api/init', {
       pass: pw,
@@ -298,7 +298,8 @@ class SeedBackupForm {
       return
     }
     const page = this.page
-    page.seedDiv.textContent = res.seed
+    // 64 bytes, 128 hex characters. Format nicely.
+    page.seedDiv.textContent = res.seed.match(/.{1,32}/g).map((chunk: string) => chunk.match(/.{1,8}/g)?.join(' ')).join('\n')
     Doc.hide(page.sbWanna)
     Doc.show(page.sbSeed)
   }

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -278,7 +278,7 @@ export default class SettingsPage extends BasePage {
       return
     }
     page.exportSeedPW.value = ''
-    page.seedDiv.textContent = res.seed
+    page.seedDiv.textContent = res.seed.match(/.{1,32}/g).map((chunk: string) => chunk.match(/.{1,8}/g)?.join(' ')).join('\n')
     this.showForm(page.authorizeSeedDisplay)
   }
 


### PR DESCRIPTION
Format app seed in chunks of 8. Change seed input to a `<textarea>`. Remove input whitespace.

![image](https://github.com/decred/dcrdex/assets/6109680/84f0d508-8e95-4664-a288-80a5299d06f7)
![image](https://github.com/decred/dcrdex/assets/6109680/b914aac3-ad60-4efd-aeb9-9af19e2deab2)
