### PR TITLE
multi: use average rate for market order rate display

### DIFF
--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -344,7 +344,8 @@ func (ord *OrderReader) RateString() string {
 // AverageRateString returns a formatting string containing the average rate of
 // the matches that have been filled in an order.
 func (ord *OrderReader) AverageRateString() string {
-	if len(ord.Matches) == 0 {
+	nMatch := len(ord.Matches)
+	if nMatch == 0 {
 		return "0"
 	}
 	var baseQty, rateProduct uint64
@@ -352,7 +353,11 @@ func (ord *OrderReader) AverageRateString() string {
 		baseQty += match.Qty
 		rateProduct += match.Rate * match.Qty // order ~ 1e16
 	}
-	return "~ " + ord.formatRate(rateProduct/baseQty)
+	rateStr := ord.formatRate(rateProduct / baseQty)
+	if nMatch > 1 {
+		rateStr = "~ " + rateStr // "~" only makes sense if the order has more than one match.
+	}
+	return rateStr
 }
 
 // SwapFeesString is a formatted string of the paid swap fees.

--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -337,6 +337,11 @@ func (ord *OrderReader) RateString() string {
 	rateStr := ord.formatRate(ord.Rate)
 	if ord.Type == order.MarketOrderType {
 		rateStr = ord.AverageRateString()
+		if len(ord.Matches) > 1 {
+			rateStr = "~ " + rateStr // "~" only makes sense if the order has more than one match.
+		} else {
+			return "market" // "market" is better than 0 BTC/ETH ?
+		}
 	}
 	return fmt.Sprintf("%s %s/%s", rateStr, ord.QuoteUnitInfo.Conventional.Unit, ord.BaseUnitInfo.Conventional.Unit)
 }
@@ -354,9 +359,6 @@ func (ord *OrderReader) AverageRateString() string {
 		rateProduct += match.Rate * match.Qty // order ~ 1e16
 	}
 	rateStr := ord.formatRate(rateProduct / baseQty)
-	if nMatch > 1 {
-		rateStr = "~ " + rateStr // "~" only makes sense if the order has more than one match.
-	}
 	return rateStr
 }
 

--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -336,11 +336,13 @@ func (ord *OrderReader) SimpleRateString() string {
 func (ord *OrderReader) RateString() string {
 	rateStr := ord.formatRate(ord.Rate)
 	if ord.Type == order.MarketOrderType {
+		nMatches := len(ord.Matches) 
+		if nMatches == 0 {
+			return "market" // "market" is better than 0 BTC/ETH ?
+		}
 		rateStr = ord.AverageRateString()
 		if len(ord.Matches) > 1 {
 			rateStr = "~ " + rateStr // "~" only makes sense if the order has more than one match.
-		} else {
-			return "market" // "market" is better than 0 BTC/ETH ?
 		}
 	}
 	return fmt.Sprintf("%s %s/%s", rateStr, ord.QuoteUnitInfo.Conventional.Unit, ord.BaseUnitInfo.Conventional.Unit)
@@ -349,8 +351,7 @@ func (ord *OrderReader) RateString() string {
 // AverageRateString returns a formatting string containing the average rate of
 // the matches that have been filled in an order.
 func (ord *OrderReader) AverageRateString() string {
-	nMatch := len(ord.Matches)
-	if nMatch == 0 {
+	if len(ord.Matches) == 0 {
 		return "0"
 	}
 	var baseQty, rateProduct uint64
@@ -358,8 +359,7 @@ func (ord *OrderReader) AverageRateString() string {
 		baseQty += match.Qty
 		rateProduct += match.Rate * match.Qty // order ~ 1e16
 	}
-	rateStr := ord.formatRate(rateProduct / baseQty)
-	return rateStr
+	return ord.formatRate(rateProduct / baseQty)
 }
 
 // SwapFeesString is a formatted string of the paid swap fees.

--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -336,7 +336,7 @@ func (ord *OrderReader) SimpleRateString() string {
 func (ord *OrderReader) RateString() string {
 	rateStr := ord.formatRate(ord.Rate)
 	if ord.Type == order.MarketOrderType {
-		nMatches := len(ord.Matches) 
+		nMatches := len(ord.Matches)
 		if nMatches == 0 {
 			return "market" // "market" is better than 0 BTC/ETH ?
 		}

--- a/client/core/helpers.go
+++ b/client/core/helpers.go
@@ -326,15 +326,19 @@ func (ord *OrderReader) StatusString() string {
 
 // SimpleRateString is the formatted match rate.
 func (ord *OrderReader) SimpleRateString() string {
+	if ord.Type == order.MarketOrderType {
+		return ord.AverageRateString()
+	}
 	return ord.formatRate(ord.Rate)
 }
 
 // RateString is a formatted rate with units.
 func (ord *OrderReader) RateString() string {
+	rateStr := ord.formatRate(ord.Rate)
 	if ord.Type == order.MarketOrderType {
-		return "market"
+		rateStr = ord.AverageRateString()
 	}
-	return fmt.Sprintf("%s %s/%s", ord.formatRate(ord.Rate), ord.QuoteUnitInfo.Conventional.Unit, ord.BaseUnitInfo.Conventional.Unit)
+	return fmt.Sprintf("%s %s/%s", rateStr, ord.QuoteUnitInfo.Conventional.Unit, ord.BaseUnitInfo.Conventional.Unit)
 }
 
 // AverageRateString returns a formatting string containing the average rate of
@@ -348,7 +352,7 @@ func (ord *OrderReader) AverageRateString() string {
 		baseQty += match.Qty
 		rateProduct += match.Rate * match.Qty // order ~ 1e16
 	}
-	return ord.formatRate(rateProduct / baseQty)
+	return "~ " + ord.formatRate(rateProduct/baseQty)
 }
 
 // SwapFeesString is a formatted string of the paid swap fees.

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=c7319724|cdeaccf3"></script>
+<script src="/js/entry.js?v=dedee09b|9193c67a"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=c8e99f90|57d459a0"></script>
+<script src="/js/entry.js?v=a72e5d84|9d363229"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=e9f3d67b|cfdf763f"></script>
+<script src="/js/entry.js?v=c7319724|cdeaccf3"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=a72e5d84|9d363229"></script>
+<script src="/js/entry.js?v=0a518229|5c5461e5"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=dedee09b|9193c67a"></script>
+<script src="/js/entry.js?v=c8e99f90|57d459a0"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=e3c6714c|0bc54d99"></script>
+<script src="/js/entry.js?v=e9f3d67b|cfdf763f"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -846,7 +846,7 @@ export default class Application {
     const wallet = this.walletMap[fromAssetID]
     if (!wallet || !(wallet.traits & walletTraitAccelerator)) return false
     if (order.matches) {
-      for (let i = 0; i < order.matches.length; i++) {
+      for (let i = 0; i < order.matches?.length; i++) {
         const match = order.matches[i]
         if (match.swap && match.swap.confs && match.swap.confs.count === 0 && !match.revoked) {
           return true

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1555,9 +1555,10 @@ export default class MarketsPage extends BasePage {
       details.rate.textContent = mord.header.rate.textContent = Doc.formatRateFullPrecision(ord.rate, market.baseUnitInfo, market.quoteUnitInfo, cfg.ratestep)
       let rate = ord.rate
       let ratePrefix = ''
-      if (ord.type === OrderUtil.Market && ord.matches?.length > 0) {
-        ratePrefix = '~ '
+      const nMatch = ord.matches?.length
+      if (ord.type === OrderUtil.Market && nMatch > 0) {
         rate = OrderUtil.averageRate(ord)
+        if (nMatch > 1) ratePrefix = '~ ' // ~ only makes sense if the order has more than one match
       }
       details.rate.textContent = mord.header.rate.textContent = ratePrefix + Doc.formatRateFullPrecision(rate, market.baseUnitInfo, market.quoteUnitInfo, cfg.ratestep)
       header.baseSymbol.textContent = market.baseUnitInfo.conventional.unit
@@ -2367,7 +2368,7 @@ export default class MarketsPage extends BasePage {
 
   handleMatchNote (note: MatchNote) {
     const mord = this.metaOrders[note.orderID]
-    if (!mord) return this.refreshActiveOrders()
+    if (!mord || note.match.status === OrderUtil.NewlyMatched) return this.refreshActiveOrders()
     if (app().canAccelerateOrder(mord.ord)) Doc.show(mord.details.accelerateBttn)
     else Doc.hide(mord.details.accelerateBttn)
   }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1666,10 +1666,9 @@ export default class MarketsPage extends BasePage {
    market order rate.
   */
   marketOrderRateString (ord: Order, mkt: CurrentMarket) :string {
-    const nMatch = ord.matches?.length
-    if (nMatch === 0) return intl.prep(intl.ID_MARKET_ORDER)
+    if (!ord.matches) return intl.prep(intl.ID_MARKET_ORDER)
     let rateStr = Doc.formatRateFullPrecision(OrderUtil.averageRate(ord), mkt.baseUnitInfo, mkt.quoteUnitInfo, mkt.cfg.ratestep)
-    if (nMatch > 1) rateStr = '~ ' + rateStr // ~ only makes sense if the order has more than one match
+    if (ord.matches.length > 1) rateStr = '~ ' + rateStr // ~ only makes sense if the order has more than one match
     return rateStr
   }
 
@@ -2379,10 +2378,7 @@ export default class MarketsPage extends BasePage {
     else if (mord.ord.type === OrderUtil.Market && note.match.status === OrderUtil.NewlyMatched) { // Update the average market rate display.
       // Fetch and use the updated order.
       const ord = app().order(note.orderID)
-      if (ord) {
-        const rateStr = this.marketOrderRateString(ord, this.market)
-        mord.details.rate.textContent = mord.details.header.textContent = rateStr
-      }
+      if (ord) mord.details.rate.textContent = mord.header.rate.textContent = this.marketOrderRateString(ord, this.market)
     }
     if (app().canAccelerateOrder(mord.ord)) Doc.show(mord.details.accelerateBttn)
     else Doc.hide(mord.details.accelerateBttn)

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1666,7 +1666,7 @@ export default class MarketsPage extends BasePage {
    market order rate.
   */
   marketOrderRateString (ord: Order, mkt: CurrentMarket) :string {
-    if (!ord.matches) return intl.prep(intl.ID_MARKET_ORDER)
+    if (!ord.matches?.length) return intl.prep(intl.ID_MARKET_ORDER)
     let rateStr = Doc.formatRateFullPrecision(OrderUtil.averageRate(ord), mkt.baseUnitInfo, mkt.quoteUnitInfo, mkt.cfg.ratestep)
     if (ord.matches.length > 1) rateStr = '~ ' + rateStr // ~ only makes sense if the order has more than one match
     return rateStr

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1553,6 +1553,13 @@ export default class MarketsPage extends BasePage {
       header.side.classList.add(ord.sell ? 'sellcolor' : 'buycolor')
       details.qty.textContent = mord.header.qty.textContent = Doc.formatCoinValue(ord.qty, market.baseUnitInfo)
       details.rate.textContent = mord.header.rate.textContent = Doc.formatRateFullPrecision(ord.rate, market.baseUnitInfo, market.quoteUnitInfo, cfg.ratestep)
+      let rate = ord.rate
+      let ratePrefix = ''
+      if (ord.type === OrderUtil.Market && ord.matches?.length > 0) {
+        ratePrefix = '~ '
+        rate = OrderUtil.averageRate(ord)
+      }
+      details.rate.textContent = mord.header.rate.textContent = ratePrefix + Doc.formatRateFullPrecision(rate, market.baseUnitInfo, market.quoteUnitInfo, cfg.ratestep)
       header.baseSymbol.textContent = market.baseUnitInfo.conventional.unit
       details.type.textContent = market.quoteUnitInfo.conventional.unit
       this.updateMetaOrder(mord)

--- a/client/webserver/site/src/js/orders.ts
+++ b/client/webserver/site/src/js/orders.ts
@@ -199,7 +199,7 @@ export default class OrdersPage extends BasePage {
       tmpl.toSymbol.textContent = toUnit
       tmpl.type.textContent = `${OrderUtil.typeString(ord)} ${OrderUtil.sellString(ord)}`
       let rate = Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, ord.rate, xc))
-      if (ord.type === OrderUtil.Market) rate = OrderUtil.averageRateString(ord)
+      if (ord.type === OrderUtil.Market) rate = OrderUtil.averageMarketOrderRateString(ord)
       tmpl.rate.textContent = rate
       tmpl.status.textContent = OrderUtil.statusString(ord)
       tmpl.filled.textContent = `${(OrderUtil.filled(ord) / ord.qty * 100).toFixed(1)}%`

--- a/client/webserver/site/src/js/orders.ts
+++ b/client/webserver/site/src/js/orders.ts
@@ -198,7 +198,9 @@ export default class OrdersPage extends BasePage {
       tmpl.toLogo.src = Doc.logoPath(toSymbol)
       tmpl.toSymbol.textContent = toUnit
       tmpl.type.textContent = `${OrderUtil.typeString(ord)} ${OrderUtil.sellString(ord)}`
-      tmpl.rate.textContent = Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, ord.rate, xc))
+      let rate = Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, ord.rate, xc))
+      if (ord.type === OrderUtil.Market) rate = OrderUtil.averageRateString(ord)
+      tmpl.rate.textContent = rate
       tmpl.status.textContent = OrderUtil.statusString(ord)
       tmpl.filled.textContent = `${(OrderUtil.filled(ord) / ord.qty * 100).toFixed(1)}%`
       tmpl.settled.textContent = `${(OrderUtil.settled(ord) / ord.qty * 100).toFixed(1)}%`

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -121,10 +121,10 @@ export function settled (order: Order) {
 }
 
 /* averageRateString returns a formatting string containing the average rate of
-the matches that have been filled in an order. */
-export function averageRateString (ord: Order): string {
+the matches that have been filled for a market order. */
+export function averageMarketOrderRateString (ord: Order): string {
   const nMatch = ord.matches?.length
-  if (nMatch === 0) return '0'
+  if (nMatch === 0) return intl.prep(intl.ID_MARKET_ORDER)
   let rateStr = Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, averageRate(ord)))
   if (nMatch > 1) rateStr = '~ ' + rateStr // "~" only makes sense if the order has more than one match.
   return rateStr

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -7,6 +7,7 @@ import {
   Match
 } from './registry'
 import { BooleanOption, XYRangeOption } from './opts'
+import Doc from './doc'
 
 export const Limit = 1
 export const Market = 2
@@ -117,6 +118,26 @@ export function settled (order: Order) {
       (match.side === Taker && match.status >= MatchComplete)
     return redeemed ? settled + qty(match) : settled
   }, 0)
+}
+
+/* averageRateString returns a formatting string containing the average rate of
+the matches that have been filled in an order. */
+export function averageRateString (ord: Order): string {
+  if (ord.matches?.length === 0) return '0'
+  return '~ ' + Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, averageRate(ord)))
+}
+
+/* averageRate returns a the average rate of the matches that have been filled
+in an order. */
+export function averageRate (ord: Order): number {
+  if (ord.matches?.length === 0) return 0
+  let rateProduct = 0
+  let baseQty = 0
+  ord.matches.forEach((m) => {
+    baseQty += m.qty
+    rateProduct += (m.rate * m.qty) // order ~ 1e16
+  })
+  return rateProduct / baseQty
 }
 
 /* baseToQuote returns the quantity of the quote asset. */

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -123,23 +123,22 @@ export function settled (order: Order) {
 /* averageRateString returns a formatting string containing the average rate of
 the matches that have been filled for a market order. */
 export function averageMarketOrderRateString (ord: Order): string {
-  const nMatch = ord.matches?.length
-  if (nMatch === 0) return intl.prep(intl.ID_MARKET_ORDER)
+  if (!ord.matches) return intl.prep(intl.ID_MARKET_ORDER)
   let rateStr = Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, averageRate(ord)))
-  if (nMatch > 1) rateStr = '~ ' + rateStr // "~" only makes sense if the order has more than one match.
+  if (ord.matches.length > 1) rateStr = '~ ' + rateStr // "~" only makes sense if the order has more than one match.
   return rateStr
 }
 
 /* averageRate returns a the average rate of the matches that have been filled
 in an order. */
 export function averageRate (ord: Order): number {
-  if (ord.matches?.length === 0) return 0
+  if (!ord.matches) return 0
   let rateProduct = 0
   let baseQty = 0
-  ord.matches.forEach((m) => {
+  for (const m of ord.matches) {
     baseQty += m.qty
     rateProduct += (m.rate * m.qty) // order ~ 1e16
-  })
+  }
   return rateProduct / baseQty
 }
 

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -123,7 +123,7 @@ export function settled (order: Order) {
 /* averageRateString returns a formatting string containing the average rate of
 the matches that have been filled for a market order. */
 export function averageMarketOrderRateString (ord: Order): string {
-  if (!ord.matches) return intl.prep(intl.ID_MARKET_ORDER)
+  if (!ord.matches?.length) return intl.prep(intl.ID_MARKET_ORDER)
   let rateStr = Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, averageRate(ord)))
   if (ord.matches.length > 1) rateStr = '~ ' + rateStr // "~" only makes sense if the order has more than one match.
   return rateStr
@@ -132,7 +132,7 @@ export function averageMarketOrderRateString (ord: Order): string {
 /* averageRate returns a the average rate of the matches that have been filled
 in an order. */
 export function averageRate (ord: Order): number {
-  if (!ord.matches) return 0
+  if (!ord.matches?.length) return 0
   let rateProduct = 0
   let baseQty = 0
   for (const m of ord.matches) {

--- a/client/webserver/site/src/js/orderutil.ts
+++ b/client/webserver/site/src/js/orderutil.ts
@@ -123,8 +123,11 @@ export function settled (order: Order) {
 /* averageRateString returns a formatting string containing the average rate of
 the matches that have been filled in an order. */
 export function averageRateString (ord: Order): string {
-  if (ord.matches?.length === 0) return '0'
-  return '~ ' + Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, averageRate(ord)))
+  const nMatch = ord.matches?.length
+  if (nMatch === 0) return '0'
+  let rateStr = Doc.formatCoinValue(app().conventionalRate(ord.baseID, ord.quoteID, averageRate(ord)))
+  if (nMatch > 1) rateStr = '~ ' + rateStr // "~" only makes sense if the order has more than one match.
+  return rateStr
 }
 
 /* averageRate returns a the average rate of the matches that have been filled


### PR DESCRIPTION
The rate display for market orders on the `orders`, `order` and 'market'(on the "user-order card") page, including the `Actual Rate` field when exporting a market order, will use the average order rate instead of just zero or `market`. Closes #1969.