### PR TITLE
auth: v2 ConnectResult

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -125,6 +125,7 @@ var (
 			Type: "type",
 		}},
 	}
+	dcrBondAsset = &msgjson.BondAsset{ID: 42, Amt: tFee, Confs: 1}
 )
 
 type tMsg = *msgjson.Message
@@ -184,7 +185,9 @@ type TWebsocket struct {
 	msgs           <-chan *msgjson.Message
 	// handlers simulates a peer (server) response for request, and handles the
 	// response with the msgFunc.
-	handlers map[string][]func(*msgjson.Message, msgFunc) error
+	handlers       map[string][]func(*msgjson.Message, msgFunc) error
+	submittedBond  *msgjson.PostBond
+	liveBondExpiry uint64
 }
 
 func newTWebsocket() *TWebsocket {
@@ -209,7 +212,7 @@ func tNewAccount(crypter *tCrypter) *dexAccount {
 		feeCoin:   []byte("somecoin"),
 		// feeAssetID is 0 (btc)
 		// tier, bonds, etc. set on auth
-		tier: 1, // not suspended by default
+		effectiveTier: 1, // not suspended by default
 	}
 }
 
@@ -271,7 +274,7 @@ func testDexConnection(ctx context.Context, crypter *tCrypter) (*dexConnection, 
 			},
 			BondExpiry: 86400, // >0 make client treat as API v1
 			BondAssets: map[string]*msgjson.BondAsset{
-				"dcr": {ID: 42, Amt: tFee, Confs: 1},
+				"dcr": dcrBondAsset,
 			},
 			RegFees: map[string]*msgjson.FeeAsset{
 				"dcr": {ID: 42, Amt: tFee, Confs: 0},
@@ -396,7 +399,7 @@ func (tdb *TDB) ListAccounts() ([]string, error) {
 }
 
 func (tdb *TDB) Accounts() ([]*db.AccountInfo, error) {
-	return nil, nil
+	return []*db.AccountInfo{}, nil
 }
 
 func (tdb *TDB) Account(url string) (*db.AccountInfo, error) {
@@ -702,6 +705,8 @@ type TXCWallet struct {
 	accelerationEstimate        uint64
 	accelerateOrderErr          error
 	info                        *asset.WalletInfo
+	bondTxCoinID                []byte
+	makeBondTxErr               error
 
 	confirmRedemptionResult *asset.ConfirmRedemptionStatus
 	confirmRedemptionErr    error
@@ -731,6 +736,7 @@ func newTWallet(assetID uint32) (*xcWallet, *TXCWallet) {
 			Version:           0, // match tUTXOAssetA/tUTXOAssetB
 			SupportedVersions: []uint32{0},
 		},
+		bondTxCoinID: encode.RandomBytes(32),
 	}
 	var broadcasting uint32 = 1
 	xcWallet := &xcWallet{
@@ -921,10 +927,6 @@ func (w *TXCWallet) Send(address string, value, feeSuggestion uint64) (asset.Coi
 	return w.sendCoin, w.sendErr
 }
 
-func (w *TXCWallet) MakeBondTx(ver uint64, address string, regFee uint64, acctID []byte) (*asset.Bond, error) {
-	return nil, errors.New("not used")
-}
-
 func (w *TXCWallet) SendTransaction(rawTx []byte) ([]byte, error) {
 	return w.feeCoinSent, w.sendTxnErr
 }
@@ -1073,6 +1075,34 @@ func (w *TXCWallet) MaxFundingFees(_ uint32, _ map[string]string) uint64 {
 
 func (*TXCWallet) FundMultiOrder(ord *asset.MultiOrder, maxLock uint64) (coins []asset.Coins, redeemScripts [][]dex.Bytes, fundingFees uint64, err error) {
 	return nil, nil, 0, nil
+}
+
+var _ asset.Bonder = (*TXCWallet)(nil)
+
+func (*TXCWallet) BondsFeeBuffer(feeRate uint64) uint64 {
+	return 4 * 1000 * feeRate * 2
+}
+
+func (*TXCWallet) RegisterUnspent(live uint64) {}
+
+func (*TXCWallet) ReserveBondFunds(future int64, feeBuffer uint64, respectBalance bool) bool {
+	return true
+}
+
+func (*TXCWallet) RefundBond(ctx context.Context, ver uint16, coinID, script []byte, amt uint64, privKey *secp256k1.PrivateKey) (asset.Coin, error) {
+	return nil, nil
+}
+
+func (w *TXCWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Time, privKey *secp256k1.PrivateKey, acctID []byte) (*asset.Bond, func(), error) {
+	if w.makeBondTxErr != nil {
+		return nil, nil, w.makeBondTxErr
+	}
+	return &asset.Bond{
+		Version: ver,
+		AssetID: dcrBondAsset.ID,
+		Amount:  amt,
+		CoinID:  w.bondTxCoinID,
+	}, func() {}, nil
 }
 
 type TAccountLocker struct {
@@ -1259,7 +1289,6 @@ func newTestRig() *testRig {
 		Cert:      acct.cert,
 		DEXPubKey: acct.dexPubKey,
 		EncKeyV2:  acct.encKey,
-		// Bonds: nil,
 		// LegacyFeeCoin:    acct.feeCoin,
 		// LegacyFeeAssetID: acct.feeAssetID,
 		// LegacyFeePaid: true,
@@ -1362,6 +1391,37 @@ func (rig *testRig) queueRegister(regRes *msgjson.RegisterResult) {
 	})
 }
 
+func (rig *testRig) queuePrevalidateBond() {
+	rig.ws.queueResponse(msgjson.PreValidateBondRoute, func(msg *msgjson.Message, f msgFunc) error {
+		preEval := new(msgjson.PreValidateBond)
+		msg.Unmarshal(preEval)
+
+		preEvalResult := &msgjson.PreValidateBondResult{
+			AccountID: rig.dc.acct.id[:],
+			AssetID:   preEval.AssetID,
+			Amount:    dcrBondAsset.Amt,
+			// Expiry: ,
+		}
+		sign(tDexPriv, preEvalResult)
+		resp, _ := msgjson.NewResponse(msg.ID, preEvalResult, nil)
+		f(resp)
+		return nil
+	})
+}
+
+func (rig *testRig) queuePostBond(postBondResult *msgjson.PostBondResult) {
+	rig.ws.queueResponse(msgjson.PostBondRoute, func(msg *msgjson.Message, f msgFunc) error {
+		bond := new(msgjson.PostBond)
+		msg.Unmarshal(bond)
+		rig.ws.submittedBond = bond
+		postBondResult.BondID = bond.CoinID
+		sign(tDexPriv, postBondResult)
+		resp, _ := msgjson.NewResponse(msg.ID, postBondResult, nil)
+		f(resp)
+		return nil
+	})
+}
+
 func (rig *testRig) queueNotifyFee() {
 	rig.ws.queueResponse(msgjson.NotifyFeeRoute, func(msg *msgjson.Message, f msgFunc) error {
 		req := new(msgjson.NotifyFee)
@@ -1377,23 +1437,50 @@ func (rig *testRig) queueNotifyFee() {
 
 func (rig *testRig) queueConnect(rpcErr *msgjson.Error, matches []*msgjson.Match, orders []*msgjson.OrderStatus, suspended ...bool) {
 	rig.ws.queueResponse(msgjson.ConnectRoute, func(msg *msgjson.Message, f msgFunc) error {
+		if rpcErr != nil {
+			resp, _ := msgjson.NewResponse(msg.ID, nil, rpcErr)
+			f(resp)
+			return nil
+		}
+
 		connect := new(msgjson.Connect)
 		msg.Unmarshal(connect)
 		sign(tDexPriv, connect)
-		result := &msgjson.ConnectResult{Sig: connect.Sig, ActiveMatches: matches, ActiveOrderStatuses: orders}
+		// Default position is post-legacy but pre-v1, singly-bonded.
+		legacyFeePaid, tier := false, int64(1)
+
+		activeBonds := make([]*msgjson.Bond, 0, 1)
+		if b := rig.ws.submittedBond; b != nil {
+			activeBonds = append(activeBonds, &msgjson.Bond{
+				Version: b.Version,
+				Amount:  dcrBondAsset.Amt,
+				Expiry:  rig.ws.liveBondExpiry,
+				CoinID:  b.CoinID,
+				AssetID: b.AssetID,
+			})
+		}
+
+		result := &msgjson.ConnectResult{
+			Sig:                 connect.Sig,
+			ActiveMatches:       matches,
+			ActiveOrderStatuses: orders,
+			LegacyFeePaid:       &legacyFeePaid,
+			ActiveBonds:         activeBonds,
+			Tier:                &tier,
+			Score:               10,
+		}
 		if len(suspended) > 0 {
 			result.Suspended = &suspended[0]
 			if suspended[0] {
-				tier := int64(-1) // even <0 so keys cycle even with v1 api
+				// DRAFT NOTE: I've modified this value. There was a comment
+				// that said "even <0 so keys cycle even with v1 api", but from
+				// my read, you are suspended at tier = 0.
+				tier := int64(0)
 				result.Tier = &tier
+				result.Score = defaultBanScore
 			}
 		}
-		var resp *msgjson.Message
-		if rpcErr != nil {
-			resp, _ = msgjson.NewResponse(msg.ID, nil, rpcErr)
-		} else {
-			resp, _ = msgjson.NewResponse(msg.ID, result, nil)
-		}
+		resp, _ := msgjson.NewResponse(msg.ID, result, nil)
 		f(resp)
 		return nil
 	})
@@ -1905,7 +1992,7 @@ func TestGetFee(t *testing.T) {
 }
 */
 
-func TestRegister(t *testing.T) {
+func TestPostBond(t *testing.T) {
 	// This test takes a little longer because the key is decrypted every time
 	// Register is called.
 	rig := newTestRig()
@@ -1929,16 +2016,20 @@ func TestRegister(t *testing.T) {
 	// an error (no dupes). Initial state is to return an error.
 	rig.db.acctErr = tErr
 
+	_ = tCore.Login(tPW)
+
 	// (*Core).Register does setupCryptoV2 to make the dc.acct.privKey etc., so
 	// we don't know the ClientPubKey here. It must be set in the request
 	// handler configured by queueRegister.
-
-	regRes := &msgjson.RegisterResult{
-		DEXPubKey: rig.acct.dexPubKey.SerializeCompressed(),
-		// ClientPubKey is set in the handler, where the sig is made
-		Address: "someaddr",
-		Fee:     tFee,
-		Time:    uint64(time.Now().UnixMilli()),
+	rig.ws.liveBondExpiry = uint64(time.Now().Add(time.Duration(pendingBuffer(dex.Simnet)) * 2 * time.Second).Unix())
+	postBondResult := &msgjson.PostBondResult{
+		AccountID: rig.acct.id[:],
+		AssetID:   dcrBondAsset.ID,
+		Amount:    dcrBondAsset.Amt,
+		Expiry:    rig.ws.liveBondExpiry,
+		Tier:      1,
+		// BondID , // set in queuePostBond
+		// TierReportV2: , // DRAFT TODO: Add tests for v2
 	}
 
 	var wg sync.WaitGroup
@@ -1958,8 +2049,16 @@ func TestRegister(t *testing.T) {
 					tCore.waiterMtx.Lock()
 					waiterCount := len(tCore.blockWaiters)
 					tCore.waiterMtx.Unlock()
+
+					// Every tick, increase the bond tx confirmation count.
 					if waiterCount > 0 { // when verifyRegistrationFee adds a waiter, then we can trigger tip change
-						tWallet.setConfs(tWallet.sendCoin.id, 0, nil) // 0 ????
+						confs, found := tWallet.confs[dex.Bytes(tWallet.bondTxCoinID).String()]
+						if !found {
+							tWallet.setConfs(tWallet.bondTxCoinID, 0, nil)
+						} else {
+							tWallet.setConfs(tWallet.bondTxCoinID, confs+1, nil)
+						}
+
 						tCore.tipChange(tUTXOAssetA.ID, nil)
 						return
 					}
@@ -1974,27 +2073,40 @@ func TestRegister(t *testing.T) {
 	accountNotFoundError := msgjson.NewError(msgjson.AccountNotFoundError, "test account not found error")
 
 	queueConfigAndConnectUnknownAcct := func() {
+		rig.ws.submittedBond = nil
 		rig.queueConfig()
 		rig.queueConnect(accountNotFoundError, nil, nil) // for discoverAccount
+		rig.ws.queueResponse(msgjson.FeeRateRoute, func(msg *msgjson.Message, f msgFunc) error {
+			const feeRate = 50
+			resp, _ := msgjson.NewResponse(msg.ID, feeRate, nil)
+			f(resp)
+			return nil
+		})
 	}
 
-	queueResponses := func() {
-		queueConfigAndConnectUnknownAcct()
-		rig.queueRegister(regRes)
+	queuePostBondSequence := func() {
+		rig.queuePrevalidateBond()
+		rig.queuePostBond(postBondResult)
 		queueTipChange()
 		rig.queueNotifyFee()
 		rig.queueConnect(nil, nil, nil)
 	}
 
-	form := &RegisterForm{
+	queueResponses := func() {
+		queueConfigAndConnectUnknownAcct()
+		queuePostBondSequence()
+	}
+
+	form := &PostBondForm{
 		Addr:    tDexHost,
 		AppPass: tPW,
-		Fee:     tFee,
-		Asset:   &tFeeAsset,
+		Asset:   &dcrBondAsset.ID,
+		Bond:    dcrBondAsset.Amt,
 		Cert:    []byte{0x1}, // not empty signals TLS, otherwise no TLS allowed hidden services
 	}
 
-	tWallet.sendCoin = &tCoin{id: encode.RandomBytes(36)}
+	// Suppress warnings about SendTransaction returning a mismatching ID.
+	tWallet.feeCoinSent = tWallet.bondTxCoinID
 
 	ch := tCore.NotificationFeed()
 
@@ -2003,8 +2115,8 @@ func TestRegister(t *testing.T) {
 		// Register method will error if url is already in conns map.
 		clearConn()
 
-		tWallet.setConfs(tWallet.sendCoin.id, 0, nil)
-		_, err = tCore.Register(form)
+		tWallet.setConfs(tWallet.bondTxCoinID, 0, nil)
+		_, err = tCore.PostBond(form)
 	}
 
 	getNotification := func(tag string) interface{} {
@@ -2023,44 +2135,40 @@ func TestRegister(t *testing.T) {
 	// The feepayment note for mined fee payment txn notification to server, and
 	// the balance note from tip change are concurrent and thus come in no
 	// guaranteed order.
-	getFeeAndBalanceNote := func() *FeePaymentNote {
+	getBondAndBalanceNote := func() {
 		t.Helper()
-		var feeNote *FeePaymentNote
-		var balanceNote *BalanceNote
-		for feeNote == nil || balanceNote == nil {
-			ntfn := getNotification("feepayment or balance")
+		var bondNote *BondPostNote
+		var balanceNotes uint8
+		// For a normal PostBond, there are three balance updates.
+		// 1) makeAndPostBond, 2) monitorBondConfs.trigger, and 3) tipChange.
+		for bondNote == nil || balanceNotes < 3 {
+			ntfn := getNotification("bond posted or balance")
 			switch note := ntfn.(type) {
-			case *FeePaymentNote:
-				feeNote = note
+			case *BondPostNote:
+				if note.TopicID == TopicAccountRegistered {
+					bondNote = note
+				}
 			case *BalanceNote:
-				balanceNote = note
+				balanceNotes++
 			default:
 				t.Fatalf("wrong notification (%T). Expected FeePaymentNote or BalanceNote", ntfn)
 			}
 		}
-		return feeNote
 	}
 
 	queueResponses()
 	run()
 	if err != nil {
-		t.Fatalf("registration error: %v", err)
+		t.Fatalf("postbond error: %v", err)
 	}
 
 	// Should be two success notifications. One for fee paid on-chain, one for
 	// fee notification sent, each along with a balance note.
-	feeNote := getFeeAndBalanceNote() // payment in progress
-	if feeNote.Severity() != db.Success {
-		t.Fatalf("fee payment error notification: %s: %s", feeNote.Subject(), feeNote.Details())
-	}
-	feeNote = getFeeAndBalanceNote() // balance note concurrent with fee note (Account registered)
-	if feeNote.Severity() != db.Success {
-		t.Fatalf("fee payment error notification: %s: %s", feeNote.Subject(), feeNote.Details())
-	}
+	getBondAndBalanceNote()
 
 	// password error
 	rig.crypter.(*tCrypter).recryptErr = tErr
-	_, err = tCore.Register(form)
+	run()
 	if !errorHasCode(err, passwordErr) {
 		t.Fatalf("wrong password error: %v", err)
 	}
@@ -2068,18 +2176,11 @@ func TestRegister(t *testing.T) {
 
 	// no host error
 	form.Addr = ""
-	_, err = tCore.Register(form)
+	run()
 	if !errorHasCode(err, emptyHostErr) {
 		t.Fatalf("wrong empty host error: %v", err)
 	}
 	form.Addr = tDexHost
-
-	// account already exists
-	tCore.addDexConnection(dc)
-	_, err = tCore.Register(form)
-	if !errorHasCode(err, dupeDEXErr) {
-		t.Fatalf("wrong account exists error: %v", err)
-	}
 
 	// wallet not found
 	delete(tCore.wallets, tUTXOAssetA.ID)
@@ -2092,7 +2193,7 @@ func TestRegister(t *testing.T) {
 	// Unlock wallet error
 	tWallet.unlockErr = tErr
 	tWallet.locked = true
-	_, err = tCore.Register(form)
+	run()
 	if !errorHasCode(err, walletAuthErr) {
 		t.Fatalf("wrong wallet auth error: %v", err)
 	}
@@ -2101,29 +2202,21 @@ func TestRegister(t *testing.T) {
 
 	// connectDEX error
 	form.Addr = tUnparseableHost
-	_, err = tCore.Register(form)
+	run()
 	if !errorHasCode(err, connectionErr) {
 		t.Fatalf("wrong connectDEX error: %v", err)
 	}
 	form.Addr = tDexHost
 
 	// fee asset not found, no cfg.Fee fallback
-	mkts := dc.cfg.Markets
-	dc.cfg.RegFees = nil
-	dc.cfg.Markets = []*msgjson.Market{}
-	rig.queueConfig()
+	bondAssets := dc.cfg.BondAssets
+	dc.cfg.BondAssets = nil
+	queueConfigAndConnectUnknownAcct()
 	run()
 	if !errorHasCode(err, assetSupportErr) {
 		t.Fatalf("wrong error for missing asset: %v", err)
 	}
-	dc.cfg.RegFees = map[string]*msgjson.FeeAsset{
-		"dcr": {
-			ID:    42,
-			Confs: 0, // skip block mining and register immediately
-			Amt:   tFee,
-		},
-	}
-	dc.cfg.Markets = mkts
+	dc.cfg.BondAssets = bondAssets
 
 	// error creating signing key
 	rig.crypter.(*tCrypter).encryptErr = tErr
@@ -2136,10 +2229,9 @@ func TestRegister(t *testing.T) {
 
 	bal0 := tWallet.bal.Available
 	tWallet.bal.Available = 0
-	queueConfigAndConnectUnknownAcct()
 	run()
 	if !errorHasCode(err, walletBalanceErr) {
-		t.Fatalf("expected low balance error")
+		t.Fatalf("expected low balance error, got: %v", err)
 	}
 	tWallet.bal.Available = bal0
 
@@ -2154,89 +2246,43 @@ func TestRegister(t *testing.T) {
 	}
 
 	// signature error
-	goodSig := regRes.Sig
-	regRes.Sig = []byte("badsig")
 	queueConfigAndConnectUnknownAcct()
-	rig.ws.queueResponse(msgjson.RegisterRoute, func(msg *msgjson.Message, f msgFunc) error {
-		reg := new(msgjson.Register)
-		msg.Unmarshal(reg)
-		regRes.ClientPubKey = reg.PubKey
-		// NOT re-signing it, just keep badsig
-		resp, _ := msgjson.NewResponse(msg.ID, regRes, nil)
+	rig.ws.queueResponse(msgjson.PreValidateBondRoute, func(msg *msgjson.Message, f msgFunc) error {
+		preEval := new(msgjson.PreValidateBond)
+		msg.Unmarshal(preEval)
+
+		preEvalResult := &msgjson.PreValidateBondResult{
+			Signature: msgjson.Signature{
+				Sig: []byte{0xb, 0xa, 0xd},
+			},
+		}
+		resp, _ := msgjson.NewResponse(msg.ID, preEvalResult, nil)
 		f(resp)
 		return nil
 	})
 	run()
 	if !errorHasCode(err, signatureErr) {
-		t.Fatalf("wrong error for bad signature on register response: %v", err)
-	}
-	regRes.Sig = goodSig
-
-	// zero fee error
-	goodFee := regRes.Fee
-	regRes.Fee = 0
-	queueConfigAndConnectUnknownAcct()
-	rig.queueRegister(regRes)
-	run()
-	if !errorHasCode(err, zeroFeeErr) {
-		t.Fatalf("wrong error for zero fee: %v", err)
+		t.Fatalf("wrong error for bad signature on prevalidate response: %v", err)
 	}
 
-	// wrong fee error
-	regRes.Fee = tFee + 1
+	// Wrong bond size on form
+	goodAmt := form.Bond
+	form.Bond = goodAmt + 1
 	queueConfigAndConnectUnknownAcct()
-	rig.queueRegister(regRes)
 	run()
-	if !errorHasCode(err, feeMismatchErr) {
-		t.Fatalf("wrong error for wrong fee: %v", err)
-	}
-	regRes.Fee = goodFee
-
-	// Form fee error
-	form.Fee = tFee + 1
-	queueConfigAndConnectUnknownAcct()
-	rig.queueRegister(regRes)
-	run()
-	if !errorHasCode(err, feeMismatchErr) {
+	if !errorHasCode(err, bondAmtErr) {
 		t.Fatalf("wrong error for wrong fee in form: %v", err)
 	}
-	form.Fee = tFee
+	form.Bond = goodAmt
 
-	// Send error
+	// MakeBondTx error
 	queueConfigAndConnectUnknownAcct()
-	rig.queueRegister(regRes)
-	tWallet.sendErr = tErr
+	tWallet.makeBondTxErr = tErr
 	run()
-	if !errorHasCode(err, feeSendErr) {
-		t.Fatalf("no error for sendErr error")
+	if !errorHasCode(err, bondPostErr) {
+		t.Fatalf("wrong error for bondPostErr: %v", err)
 	}
-	tWallet.sendErr = nil
-
-	// notifyfee response error
-	queueConfigAndConnectUnknownAcct()
-	rig.queueRegister(regRes)
-	queueTipChange()
-	rig.ws.queueResponse(msgjson.NotifyFeeRoute, func(msg *msgjson.Message, f msgFunc) error {
-		m, _ := msgjson.NewResponse(msg.ID, nil, msgjson.NewError(1, "test error message"))
-		f(m)
-		return nil
-	})
-	run()
-	// This should not return a registration error, but the 2nd FeePaymentNote
-	// should indicate an error.
-	if err != nil {
-		t.Fatalf("error for notifyfee response error: %v", err)
-	}
-	// register: balance note followed by fee payment note
-	feeNote = getFeeAndBalanceNote() // Fee payment in progress
-	if feeNote.Severity() != db.Success {
-		t.Fatalf("fee payment error notification: %s: %s", feeNote.Subject(), feeNote.Details())
-	}
-	// fee error. fee and balance note from tip change in no guaranteed order.
-	feeNote = getFeeAndBalanceNote() // Fee payment error "test error message"
-	if feeNote.Severity() != db.ErrorLevel {
-		t.Fatalf("non-error fee payment notification for notifyfee response error: %s: %s", feeNote.Subject(), feeNote.Details())
-	}
+	tWallet.makeBondTxErr = nil
 
 	// Make sure it's good again.
 	queueResponses()
@@ -2244,58 +2290,24 @@ func TestRegister(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error after regaining valid state: %v", err)
 	}
-	feeNote = getFeeAndBalanceNote() // Fee payment in progress
-	if feeNote.Severity() != db.Success {
-		t.Fatalf("fee payment error notification: %s: %s", feeNote.Subject(), feeNote.Details())
-	}
-	getFeeAndBalanceNote() // account registered
-
-	// Existing but unpaid account. Server would sent previously-requested fee
-	// address and asset ID.
-	clearConn()
-	rig.queueConfig()
-	unpaidAccountError := msgjson.NewError(msgjson.UnpaidAccountError, "test account not found error")
-	rig.queueConnect(unpaidAccountError, nil, nil) // for discoverAccount
-	rig.queueRegister(regRes)
-	queueTipChange()
-	rig.queueNotifyFee()
-	rig.queueConnect(nil, nil, nil)
-
-	_, err = tCore.Register(form)
-	if err != nil {
-		t.Fatalf("Unpaid Register error: %v", err)
-	}
-
-	getFeeAndBalanceNote() // payment in progress
-	getFeeAndBalanceNote() // account registered
+	getBondAndBalanceNote()
 
 	// Test the account recovery path.
-	clearConn()
 	rig.queueConfig()
 	rig.queueConnect(nil, nil, nil) // account exists
-
-	_, err = tCore.Register(form)
+	run()
 	if err != nil {
-		t.Fatalf("Pre-paid Register error: %v", err)
+		t.Fatalf("Paid account error: %v", err)
 	}
-
-	// no fee payment notes
 
 	// Account suspended should derive new HD credentials.
-	clearConn()
 	rig.queueConnect(nil, nil, nil, true) // first try exists but suspended
 	queueResponses()
-
-	_, err = tCore.Register(form)
+	run()
 	if err != nil {
-		t.Fatalf("Suspended Register error: %v", err)
+		t.Fatalf("Suspension recovery error: %v", err)
 	}
-
-	if len(rig.db.acct.EncKeyV2) == 0 || len(rig.db.acct.LegacyEncKey) != 0 {
-		t.Fatalf("Keys not generated correctly for suspended account. %d %d", len(rig.db.acct.EncKeyV2), len(rig.db.acct.LegacyEncKey))
-	}
-	getFeeAndBalanceNote() // payment in progress
-	getFeeAndBalanceNote() // account registered
+	getBondAndBalanceNote()
 }
 
 func TestCredentialsUpgrade(t *testing.T) {
@@ -5780,10 +5792,10 @@ var (
 )
 
 // auth sets the account as authenticated at the provided tier.
-func auth(a *dexAccount, tier int64, legacyFeePaid bool) {
+func auth(a *dexAccount, effectiveTier int64, legacyFeePaid bool) {
 	a.authMtx.Lock()
 	a.isAuthed = true
-	a.tier = tier
+	a.effectiveTier = effectiveTier
 	a.legacyFeePaid = legacyFeePaid
 	a.authMtx.Unlock()
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -741,8 +741,9 @@ type dexAccount struct {
 	pendingBonds      []*db.Bond // not yet confirmed
 	bonds             []*db.Bond // confirmed, and not yet expired
 	expiredBonds      []*db.Bond // expired and needing refund
-	tier              int64      // check instead of isSuspended
-	tierChange        int64      // unactuated with bond reserves
+	tier              *account.TierReport
+	effectiveTier     int64 // before *account.TierReport, effectiveTier can be out of sync with and takes precedence over tier.Effective()
+	tierChange        int64 // unactuated with bond reserves
 	targetTier        uint64
 	maxBondedAmt      uint64
 	totalReserved     int64  // total of bondAsset reserved for bonds (future and liveunspent), set iff maintaining bonds
@@ -919,7 +920,8 @@ func (a *dexAccount) authed() bool {
 func (a *dexAccount) unAuth() {
 	a.authMtx.Lock()
 	a.isAuthed = false
-	a.tier = 0
+	a.tier = nil
+	a.effectiveTier = 0
 	a.legacyFeePaid = false
 	a.authMtx.Unlock()
 }
@@ -928,7 +930,7 @@ func (a *dexAccount) unAuth() {
 func (a *dexAccount) suspended() bool {
 	a.authMtx.RLock()
 	defer a.authMtx.RUnlock()
-	return a.tier < 1
+	return a.effectiveTier < 1
 }
 
 // feePending checks whether the fee transaction has been broadcast, but the

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -948,13 +948,14 @@ type Bond struct {
 //
 // TODO: Include penalty data as specified in the spec.
 type ConnectResult struct {
-	Sig                 Bytes          `json:"sig"`
-	ActiveOrderStatuses []*OrderStatus `json:"activeorderstatuses"`
-	ActiveMatches       []*Match       `json:"activematches"`
-	Score               int32          `json:"score"`
-	Tier                *int64         `json:"tier"` // 1+ means bonded and may trade, a function of active bond amounts and conduct, nil legacy
-	ActiveBonds         []*Bond        `json:"activeBonds"`
-	LegacyFeePaid       *bool          `json:"legacyFeePaid"` // not set by legacy server
+	Sig                 Bytes               `json:"sig"`
+	ActiveOrderStatuses []*OrderStatus      `json:"activeorderstatuses"`
+	ActiveMatches       []*Match            `json:"activematches"`
+	Score               int32               `json:"score"`
+	Tier                *int64              `json:"tier"` // == v1. Deprecated in v2. means bonded and may trade, a function of active bond amounts and conduct, nil legacy
+	ActiveBonds         []*Bond             `json:"activeBonds"`
+	LegacyFeePaid       *bool               `json:"legacyFeePaid"` // == v1. Deprected in v2.
+	TierReportV2        *account.TierReport `json:"tierReportV2"`  // v2
 
 	Suspended *bool `json:"suspended,omitempty"` // DEPRECATED - implied by tier<1
 }
@@ -965,8 +966,9 @@ type ConnectResult struct {
 type TierChangedNotification struct {
 	Signature
 	// AccountID Bytes  `json:"accountID"`
-	Tier   int64  `json:"tier"`
-	Reason string `json:"reason"`
+	Tier         int64               `json:"tier"`
+	TierReportV2 *account.TierReport `json:"tierReportV2"` // replaces Tier field
+	Reason       string              `json:"reason"`
 }
 
 // Serialize serializes the TierChangedNotification data.
@@ -1090,13 +1092,14 @@ func (pb *PostBond) Serialize() []byte {
 // true, the bond was applied to the account; if false it is not confirmed, but
 // was otherwise validated.
 type PostBondResult struct {
-	Signature        // message is BondID | AccountID
-	AccountID Bytes  `json:"accountID"`
-	AssetID   uint32 `json:"assetID"`
-	Amount    uint64 `json:"amount"`
-	Expiry    uint64 `json:"expiry"` // not locktime, but time when bond expires for dex
-	BondID    Bytes  `json:"bondID"`
-	Tier      int64  `json:"tier"`
+	Signature                        // message is BondID | AccountID
+	AccountID    Bytes               `json:"accountID"`
+	AssetID      uint32              `json:"assetID"`
+	Amount       uint64              `json:"amount"`
+	Expiry       uint64              `json:"expiry"` // not locktime, but time when bond expires for dex
+	BondID       Bytes               `json:"bondID"`
+	Tier         int64               `json:"tier"`
+	TierReportV2 *account.TierReport `json:"tierReportV2"`
 }
 
 // Serialize serializes the PostBondResult data for the signature.
@@ -1301,6 +1304,9 @@ type ConfigResult struct {
 	BondExpiry uint64 `json:"DEV_bondExpiry"`
 
 	RegFees map[string]*FeeAsset `json:"regFees"`
+
+	ScoreIncrement uint32 `json:"scoreIncrement"`
+	MaxScore       uint32 `json:"maxScore"`
 }
 
 // Spot is a snapshot of a market at the end of a match cycle. A slice of Spot

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -166,3 +166,22 @@ func (r Rule) Description() string {
 func (r Rule) Punishable() bool {
 	return r > NoRule && r < MaxRule
 }
+
+// TierReport is a part of a number of server-originating messages. It was
+// introduced with the v2 ConnectResult.
+type TierReport struct {
+	Bonded  int64 `json:"bondTier"`
+	Revoked int64 `json:"revokedTiers"`
+	Bonus   int64 `json:"bonusTiers"`
+	Legacy  bool  `json:"legacyTier"`
+	Score   int32 `json:"score"`
+}
+
+// Effective calculates the effective tier for trading limit calculations.
+func (r *TierReport) Effective() int64 {
+	tier := r.Bonded - r.Revoked + r.Bonus
+	if r.Legacy {
+		tier++
+	}
+	return tier
+}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	cancelThreshWindow = 100 // spec
-	scoringMatchLimit  = 60  // last N matches (success or at-fault fail) to be considered in swap inaction scoring
+	ScoringMatchLimit  = 60  // last N matches (success or at-fault fail) to be considered in swap inaction scoring
 	scoringOrderLimit  = 40  // last N orders to be considered in preimage miss scoring
 
 	maxIDsPerOrderStatusRequest = 10_000
@@ -285,7 +285,7 @@ const (
 
 	successScore = -1 // offsets the violations
 
-	defaultBanScore = 20
+	DefaultBanScore = 20
 )
 
 // Violation represents a specific infraction. For example, not broadcasting a
@@ -428,7 +428,7 @@ func NewAuthManager(cfg *Config) *AuthManager {
 	// A ban score of 0 is not sensible, so have a default.
 	banScore := cfg.BanScore
 	if banScore == 0 {
-		banScore = defaultBanScore
+		banScore = DefaultBanScore
 	}
 	initTakerLotLimit := int64(cfg.InitTakerLotLimit)
 	if initTakerLotLimit == 0 {
@@ -522,16 +522,17 @@ func (auth *AuthManager) GraceLimit() int {
 func (auth *AuthManager) RecordCancel(user account.AccountID, oid, target order.OrderID, epochGap int32, t time.Time) {
 	score := auth.recordOrderDone(user, oid, &target, epochGap, t.UnixMilli())
 
-	tier, bondTier, changed := auth.computeUserTier(user, score)
+	tierReport, changed := auth.computeUserTier(user, score)
+	effectiveTier := tierReport.Effective()
 	log.Debugf("RecordCancel: user %v strikes %d, bond tier %v => trading tier %v",
-		user, score, bondTier, tier)
+		user, score, tierReport.Bonded, effectiveTier)
 	// If their tier sinks below 1, unbook their orders and send a note.
-	if tier < 1 {
-		details := fmt.Sprintf("excessive cancellation rate, new tier = %d", tier)
+	if effectiveTier < 1 {
+		details := fmt.Sprintf("excessive cancellation rate, new tier = %d", effectiveTier)
 		auth.Penalize(user, account.CancellationRate, details)
 	}
 	if changed {
-		go auth.sendTierChanged(user, tier, "excessive, cancellation rate")
+		go auth.sendTierChanged(user, tierReport, "excessive, cancellation rate")
 	}
 }
 
@@ -540,11 +541,11 @@ func (auth *AuthManager) RecordCancel(user account.AccountID, oid, target order.
 // longer on the books if it ever was.
 func (auth *AuthManager) RecordCompletedOrder(user account.AccountID, oid order.OrderID, t time.Time) {
 	score := auth.recordOrderDone(user, oid, nil, db.EpochGapNA, t.UnixMilli())
-	tier, bondTier, changed := auth.computeUserTier(user, score) // may raise tier
+	tierReport, changed := auth.computeUserTier(user, score) // may raise tier
 	if changed {
 		log.Tracef("RecordCompletedOrder: tier changed for user %v strikes %d, bond tier %v => trading tier %v",
-			user, score, bondTier, tier)
-		go auth.sendTierChanged(user, tier, "successful order completion")
+			user, score, tierReport.Bonded, tierReport.Effective())
+		go auth.sendTierChanged(user, tierReport, "successful order completion")
 	}
 }
 
@@ -838,7 +839,12 @@ func (auth *AuthManager) UserSettlingLimit(user account.AccountID, mkt *dex.Mark
 	return limit
 }
 
-func (auth *AuthManager) integrateOutcomes(matchOutcomes *latestMatchOutcomes, preimgOutcomes *latestPreimageOutcomes, orderOutcomes *latestOrders) (score, successCount, piMissCount int32) {
+func (auth *AuthManager) integrateOutcomes(
+	matchOutcomes *latestMatchOutcomes,
+	preimgOutcomes *latestPreimageOutcomes,
+	orderOutcomes *latestOrders,
+) (score, successCount, piMissCount int32) {
+
 	if matchOutcomes != nil {
 		matchCounts := matchOutcomes.binViolations()
 		for v, count := range matchCounts {
@@ -892,16 +898,31 @@ func (auth *AuthManager) UserScore(user account.AccountID) (score int32) {
 	return
 }
 
+// tierReport computes the breakdown of a user's tier.
+func (auth *AuthManager) tierReport(bondTier int64, score int32, legacyFeePaid bool) *account.TierReport {
+	tierAdj := int64(score) / int64(auth.banScore)
+	var bonusTiers, revokedTiers int64
+	if tierAdj < 0 {
+		bonusTiers = -tierAdj
+	} else if tierAdj > 0 {
+		revokedTiers = tierAdj
+	}
+
+	if bonusTiers > 0 && bondTier == 0 {
+		bonusTiers = 0 // no bonus tiers unless bonded
+	}
+	return &account.TierReport{
+		Bonded:  bondTier,
+		Revoked: revokedTiers,
+		Bonus:   bonusTiers,
+		Legacy:  legacyFeePaid,
+		Score:   score,
+	}
+}
+
 // tier computes a user's tier from their conduct score and bond tier.
 func (auth *AuthManager) tier(bondTier int64, score int32, legacyFeePaid bool) int64 {
-	tierAdj := int64(score) / int64(auth.banScore)
-	if tierAdj < 0 && bondTier == 0 {
-		tierAdj = 0 // no bonus tiers unless bonded
-	}
-	if legacyFeePaid {
-		bondTier++
-	}
-	return bondTier - tierAdj
+	return auth.tierReport(bondTier, score, legacyFeePaid).Effective()
 }
 
 // computeUserTier computes the user's tier given the provided score weighed
@@ -909,26 +930,26 @@ func (auth *AuthManager) tier(bondTier int64, score int32, legacyFeePaid bool) i
 // is just for logging, and it may be removed or changed to a map by asset ID.
 // For online users, this will also indicate if the tier changed; this will
 // always return false for offline users.
-func (auth *AuthManager) computeUserTier(user account.AccountID, score int32) (tier, bondTier int64, changed bool) {
+func (auth *AuthManager) computeUserTier(user account.AccountID, score int32) (r *account.TierReport, changed bool) {
 	client := auth.user(user)
 	if client == nil {
 		// Offline. Load active bonds and legacyFeePaid flag from DB.
 		lockTimeThresh := time.Now().Add(auth.bondExpiry)
 		_, bonds, _, legacyFeePaid := auth.storage.Account(user, lockTimeThresh)
+		var bondTier int64
 		for _, bond := range bonds {
 			bondTier += int64(bond.Strength)
 		}
-		tier = auth.tier(bondTier, score, legacyFeePaid)
-		return
+		return auth.tierReport(bondTier, score, legacyFeePaid), false
 	}
 
 	client.mtx.Lock()
 	defer client.mtx.Unlock()
 	wasTier := client.tier
-	bondTier = client.bondTier()
-	client.tier = auth.tier(bondTier, score, client.legacyFeePaid)
-	tier = client.tier
-	changed = wasTier != tier
+	bondTier := client.bondTier()
+	r = auth.tierReport(bondTier, score, client.legacyFeePaid)
+	client.tier = r.Effective()
+	changed = wasTier != client.tier
 
 	return
 }
@@ -937,14 +958,14 @@ func (auth *AuthManager) computeUserTier(user account.AccountID, score int32) (t
 // score. The bondTier is also returned. The DB is always consulted for
 // computing the conduct score. Summing bond amounts may access the DB if the
 // user is not presently connected. The tier for an unknown user is -1.
-func (auth *AuthManager) ComputeUserTier(user account.AccountID) (tier, bondTier int64) {
+func (auth *AuthManager) ComputeUserTier(user account.AccountID) *account.TierReport {
 	score, err := auth.loadUserScore(user)
 	if err != nil {
 		log.Errorf("failed to load user score: %v", err)
-		return -1, -1
+		return nil
 	}
-	tier, bondTier, _ = auth.computeUserTier(user, score)
-	return
+	r, _ := auth.computeUserTier(user, score)
+	return r
 }
 
 func (auth *AuthManager) registerMatchOutcome(user account.AccountID, misstep NoActionStep, mmid db.MarketMatchID, value uint64, refTime time.Time) (score int32) {
@@ -983,13 +1004,14 @@ func (auth *AuthManager) registerMatchOutcome(user account.AccountID, misstep No
 // has no clue about lot size, and neither does DB!
 func (auth *AuthManager) SwapSuccess(user account.AccountID, mmid db.MarketMatchID, value uint64, redeemTime time.Time) {
 	score := auth.registerMatchOutcome(user, SwapSuccess, mmid, value, redeemTime)
-	tier, bondTier, changed := auth.computeUserTier(user, score) // may raise tier
+	tierReport, changed := auth.computeUserTier(user, score) // may raise tier
+	effectiveTier := tierReport.Effective()
 	log.Debugf("Match success for user %v: strikes %d, bond tier %v => tier %v",
-		user, score, bondTier, tier)
+		user, score, tierReport.Bonded, effectiveTier)
 	if changed {
 		log.Infof("SwapSuccess: tier change for user %v, strikes %d, bond tier %v => trading tier %v",
-			user, score, bondTier, tier)
-		go auth.sendTierChanged(user, tier, "successful swap completion")
+			user, score, tierReport.Bonded, effectiveTier)
+		go auth.sendTierChanged(user, tierReport, "successful swap completion")
 	}
 }
 
@@ -1010,18 +1032,19 @@ func (auth *AuthManager) Inaction(user account.AccountID, misstep NoActionStep, 
 	score := auth.registerMatchOutcome(user, misstep, mmid, matchValue, refTime)
 
 	// Recompute tier.
-	tier, bondTier, changed := auth.computeUserTier(user, score)
+	tierReport, changed := auth.computeUserTier(user, score)
+	effectiveTier := tierReport.Effective()
 	log.Infof("Match failure for user %v: %q (badness %v), strikes %d, bond tier %v => trading tier %v",
-		user, violation, violation.Score(), score, bondTier, tier)
+		user, violation, violation.Score(), score, tierReport.Bonded, effectiveTier)
 	// If their tier sinks below 1, unbook their orders and send a note.
-	if tier < 1 {
+	if effectiveTier < 1 {
 		details := fmt.Sprintf("swap %v failure (%v) for order %v, new tier = %d",
-			mmid.MatchID, misstep, oid, tier)
+			mmid.MatchID, misstep, oid, effectiveTier)
 		auth.Penalize(user, account.FailureToAct, details)
 	}
 	if changed {
 		reason := fmt.Sprintf("swap failure for match %v order %v: %v", mmid.MatchID, oid, misstep)
-		go auth.sendTierChanged(user, tier, reason)
+		go auth.sendTierChanged(user, tierReport, reason)
 	}
 }
 
@@ -1067,16 +1090,17 @@ func (auth *AuthManager) MissedPreimage(user account.AccountID, epochEnd time.Ti
 	}
 
 	// Recompute tier.
-	tier, bondTier, changed := auth.computeUserTier(user, score)
-	log.Debugf("MissedPreimage: user %v strikes %d, bond tier %v => trading tier %v", user, score, bondTier, tier)
+	tierReport, changed := auth.computeUserTier(user, score)
+	effectiveTier := tierReport.Effective()
+	log.Debugf("MissedPreimage: user %v strikes %d, bond tier %v => trading tier %v", user, score, tierReport.Bonded, effectiveTier)
 	// If their tier sinks below 1, unbook their orders and send a note.
-	if tier < 1 {
-		details := fmt.Sprintf("preimage for order %v not provided upon request: new tier = %d", oid, tier)
+	if effectiveTier < 1 {
+		details := fmt.Sprintf("preimage for order %v not provided upon request: new tier = %d", oid, effectiveTier)
 		auth.Penalize(user, account.PreimageReveal, details)
 	}
 	if changed {
 		reason := fmt.Sprintf("preimage not provided upon request for order %v", oid)
-		go auth.sendTierChanged(user, tier, reason)
+		go auth.sendTierChanged(user, tierReport, reason)
 	}
 }
 
@@ -1117,7 +1141,10 @@ func (auth *AuthManager) AcctStatus(user account.AccountID) (connected bool, tie
 	client := auth.user(user)
 	if client == nil {
 		// Load user info from DB.
-		tier, _ = auth.ComputeUserTier(user)
+		tierReport := auth.ComputeUserTier(user)
+		if tierReport != nil {
+			tier = tierReport.Effective()
+		}
 		return
 	}
 	connected = true
@@ -1154,12 +1181,12 @@ func (auth *AuthManager) ForgiveMatchFail(user account.AccountID, mid order.Matc
 	score, _, _ := auth.integrateOutcomes(latestMatches, latestPreimageResults, latestFinished)
 
 	// Recompute tier.
-	tier, _, changed := auth.computeUserTier(user, score)
+	tierReport, changed := auth.computeUserTier(user, score)
 	if changed {
-		go auth.sendTierChanged(user, tier, "swap failure forgiven")
+		go auth.sendTierChanged(user, tierReport, "swap failure forgiven")
 	}
 
-	unbanned = tier > 0
+	unbanned = tierReport.Effective() > 0
 
 	return
 }
@@ -1181,12 +1208,14 @@ func (auth *AuthManager) conn(conn comms.Link) *clientInfo {
 }
 
 // sendTierChanged sends a tierchanged notification to an account.
-func (auth *AuthManager) sendTierChanged(acctID account.AccountID, newTier int64, reason string) {
+func (auth *AuthManager) sendTierChanged(acctID account.AccountID, tierReport *account.TierReport, reason string) {
+	effectiveTier := tierReport.Effective()
 	log.Debugf("Sending tierchanged notification to %v, new tier = %d, reason = %v",
-		acctID, newTier, reason)
+		acctID, effectiveTier, reason)
 	tierChangedNtfn := &msgjson.TierChangedNotification{
-		Tier:   newTier,
-		Reason: reason,
+		Tier:         effectiveTier,
+		TierReportV2: tierReport,
+		Reason:       reason,
 	}
 	auth.Sign(tierChangedNtfn)
 	resp, err := msgjson.NewNotification(msgjson.TierChangeRoute, tierChangedNtfn)
@@ -1283,10 +1312,10 @@ func (auth *AuthManager) checkBonds() {
 // addBond registers a new active bond for an authenticated user. This only
 // updates their clientInfo.{bonds,tier} fields. It does not touch the DB. If
 // the user is not authenticated, it returns -1, -1.
-func (auth *AuthManager) addBond(user account.AccountID, bond *db.Bond) (bondTier, tier int64) {
+func (auth *AuthManager) addBond(user account.AccountID, bond *db.Bond) *account.TierReport {
 	client := auth.user(user)
 	if client == nil {
-		return -1, -1 // offline
+		return nil // offline
 	}
 
 	auth.violationMtx.Lock()
@@ -1296,11 +1325,11 @@ func (auth *AuthManager) addBond(user account.AccountID, bond *db.Bond) (bondTie
 	client.mtx.Lock()
 	defer client.mtx.Unlock()
 
-	bondTier = client.addBond(bond)
-	tier = auth.tier(bondTier, score, client.legacyFeePaid)
-	client.tier = tier
+	bondTier := client.addBond(bond)
+	tier := auth.tierReport(bondTier, score, client.legacyFeePaid)
+	client.tier = tier.Effective()
 
-	return
+	return tier
 }
 
 // addClient adds the client to the users and conns maps, and stops any unbook
@@ -1376,7 +1405,7 @@ func (auth *AuthManager) removeClient(client *clientInfo) {
 func (auth *AuthManager) loadUserOutcomes(user account.AccountID) (*latestMatchOutcomes, *latestPreimageOutcomes, *latestOrders, error) {
 	// Load the N most recent matches resulting in success or an at-fault match
 	// revocation for the user.
-	matchOutcomes, err := auth.storage.CompletedAndAtFaultMatchStats(user, scoringMatchLimit)
+	matchOutcomes, err := auth.storage.CompletedAndAtFaultMatchStats(user, ScoringMatchLimit)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("CompletedAndAtFaultMatchStats: %w", err)
 	}
@@ -1404,7 +1433,7 @@ func (auth *AuthManager) loadUserOutcomes(user account.AccountID) (*latestMatchO
 		return nil, nil, nil, fmt.Errorf("PreimageStats: %w", err)
 	}
 
-	latestMatches := newLatestMatchOutcomes(scoringMatchLimit)
+	latestMatches := newLatestMatchOutcomes(ScoringMatchLimit)
 	for _, mo := range matchOutcomes {
 		// The Fail flag qualifies MakerRedeemed, which is always success for
 		// maker, but fail for taker if revoked.
@@ -1645,7 +1674,8 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 	}
 
 	// Ensure tier and filtered bonds agree.
-	tier := auth.tier(bondTier, score, legacyPaid)
+	tierReport := auth.tierReport(bondTier, score, legacyPaid)
+	tier := tierReport.Effective()
 	client.tier = tier
 	client.bonds = activeBonds
 
@@ -1661,6 +1691,7 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 		ActiveBonds:         msgBonds,
 		Suspended:           &suspended,  // V0PURGE
 		LegacyFeePaid:       &legacyPaid, // courtesy for account discovery
+		TierReportV2:        tierReport,
 	}
 	respMsg, err := msgjson.NewResponse(msg.ID, resp, nil)
 	if err != nil {

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -155,6 +155,8 @@ func newConfigResponse(cfg *DexConf, regAssets map[string]*msgjson.FeeAsset, bon
 		BondExpiry:       uint64(dex.BondExpiry(cfg.Network)), // temporary while we figure it out
 		BinSizes:         candles.BinSizes,
 		RegFees:          regAssets,
+		ScoreIncrement:   cfg.BanScore,
+		MaxScore:         auth.ScoringMatchLimit,
 	}
 
 	// NOTE/TODO: To include active epoch in the market status objects, we need
@@ -620,6 +622,10 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		}
 		bondCoinID, amt, _, _, lockTime, acct, err = bc.ParseBondTx(version, rawTx)
 		return
+	}
+
+	if cfg.BanScore == 0 {
+		cfg.BanScore = auth.DefaultBanScore
 	}
 
 	authCfg := auth.Config{


### PR DESCRIPTION
Fully resolves #2461, though we're in a precarious state if the server is < v2 connect result (see notes here and in #2460). 

Add a `TierReportV2` field to `ConnectResult`, `TierChangedNotification`, and `PostBondResult`. The `TierReportV2 account.TierReport` field deprecates the `Tier int64` and `LegacyFeePaid bool` fields in these responses, though the fields are still populated (`V0PURGE`).

The `account.TierReport` includes information about **bonus tiers** and **revoked tiers**, allowing the client to maintain a their **bonded tier** accurately.