### PR TITLE
client/multi: Consider refunds in market making

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2018,9 +2018,10 @@ func (btc *baseWallet) SingleLotSwapRefundFees(_ uint32, feeSuggestion uint64, u
 	var refundTxSize uint64
 	if btc.segwit {
 		witnessVBytes := uint64((dexbtc.RefundSigScriptSize + 2 + 3) / 4)
-		refundTxSize = dexbtc.MinimumTxOverhead + witnessVBytes + dexbtc.P2WPKHOutputSize
+		refundTxSize = dexbtc.MinimumTxOverhead + dexbtc.TxInOverhead + witnessVBytes + dexbtc.P2WPKHOutputSize
 	} else {
-		refundTxSize = dexbtc.MinimumTxOverhead + dexbtc.RefundSigScriptSize + dexbtc.P2PKHOutputSize
+		inputSize := uint64(dexbtc.TxInOverhead + dexbtc.RefundSigScriptSize)
+		refundTxSize = dexbtc.MinimumTxOverhead + inputSize + dexbtc.P2PKHOutputSize
 	}
 
 	return swapTxSize * feeSuggestion, refundTxSize * feeSuggestion, nil

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1995,8 +1995,9 @@ func (btc *baseWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, error) {
 	}, nil
 }
 
-// SingleLotSwapFees returns the fees for a swap transaction for a single lot.
-func (btc *baseWallet) SingleLotSwapFees(_ uint32, feeSuggestion uint64, useSafeTxSize bool) (fees uint64, err error) {
+// SingleLotSwapRefundFees returns the fees for a swap and refund transaction
+// for a single lot.
+func (btc *baseWallet) SingleLotSwapRefundFees(_ uint32, feeSuggestion uint64, useSafeTxSize bool) (swapFees uint64, redeemFees uint64, err error) {
 	var numInputs uint64
 	if useSafeTxSize {
 		numInputs = 12
@@ -2007,14 +2008,22 @@ func (btc *baseWallet) SingleLotSwapFees(_ uint32, feeSuggestion uint64, useSafe
 	// TODO: The following is not correct for all BTC clones. e.g. Zcash has
 	// a different MinimumTxOverhead (29).
 
-	var txSize uint64
+	var swapTxSize uint64
 	if btc.segwit {
-		txSize = dexbtc.MinimumTxOverhead + (numInputs * dexbtc.RedeemP2WPKHInputSize) + dexbtc.P2WSHOutputSize + dexbtc.P2WPKHOutputSize
+		swapTxSize = dexbtc.MinimumTxOverhead + (numInputs * dexbtc.RedeemP2WPKHInputSize) + dexbtc.P2WSHOutputSize + dexbtc.P2WPKHOutputSize
 	} else {
-		txSize = dexbtc.MinimumTxOverhead + (numInputs * dexbtc.RedeemP2PKHInputSize) + dexbtc.P2SHOutputSize + dexbtc.P2PKHOutputSize
+		swapTxSize = dexbtc.MinimumTxOverhead + (numInputs * dexbtc.RedeemP2PKHInputSize) + dexbtc.P2SHOutputSize + dexbtc.P2PKHOutputSize
 	}
 
-	return txSize * feeSuggestion, nil
+	var refundTxSize uint64
+	if btc.segwit {
+		witnessVBytes := uint64((dexbtc.RefundSigScriptSize + 2 + 3) / 4)
+		refundTxSize = dexbtc.MinimumTxOverhead + witnessVBytes + dexbtc.P2WPKHOutputSize
+	} else {
+		refundTxSize = dexbtc.MinimumTxOverhead + dexbtc.RefundSigScriptSize + dexbtc.P2PKHOutputSize
+	}
+
+	return swapTxSize * feeSuggestion, refundTxSize * feeSuggestion, nil
 }
 
 // splitOption constructs an *asset.OrderOption with customized text based on the

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1717,20 +1717,18 @@ func (dcr *ExchangeWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, erro
 	}, nil
 }
 
-// SingleLotSwapFees returns the fees for a swap transaction for a single lot.
-func (dcr *ExchangeWallet) SingleLotSwapFees(_ uint32, feeSuggestion uint64, useSafeTxSize bool) (fees uint64, err error) {
+// SingleLotSwapRefundFees returns the fees for a swap and refund transaction
+// for a single lot.
+func (dcr *ExchangeWallet) SingleLotSwapRefundFees(_ uint32, feeSuggestion uint64, useSafeTxSize bool) (swapFees uint64, refundFees uint64, err error) {
 	var numInputs uint64
 	if useSafeTxSize {
 		numInputs = 12
 	} else {
 		numInputs = 2
 	}
-
-	var txSize uint64 = dexdcr.InitTxSizeBase + (numInputs * dexdcr.P2PKHInputSize)
-
-	dcr.log.Infof("SingleLotSwapFees: txSize = %d, feeSuggestion = %d", txSize, feeSuggestion)
-
-	return txSize * feeSuggestion, nil
+	swapTxSize := dexdcr.InitTxSizeBase + (numInputs * dexdcr.P2PKHInputSize)
+	refundTxSize := dexdcr.MsgTxOverhead + dexdcr.TxInOverhead + dexdcr.RefundSigScriptSize + dexdcr.P2PKHOutputSize
+	return swapTxSize * feeSuggestion, uint64(refundTxSize) * feeSuggestion, nil
 }
 
 // MaxFundingFees returns the maximum funding fees for an order/multi-order.

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1291,14 +1291,13 @@ func (w *baseWallet) MaxFundingFees(_ uint32, _ uint64, _ map[string]string) uin
 	return 0
 }
 
-// SingleLotSwapFees returns the fees for a swap transaction for a single lot.
-func (w *assetWallet) SingleLotSwapFees(version uint32, feeSuggestion uint64, _ bool) (fees uint64, err error) {
+// SingleLotSwapRefundFees returns the fees for a swap transaction for a single lot.
+func (w *assetWallet) SingleLotSwapRefundFees(version uint32, feeSuggestion uint64, _ bool) (swapFees uint64, refundFees uint64, err error) {
 	g := w.gases(version)
 	if g == nil {
-		return 0, fmt.Errorf("no gases known for %d version %d", w.assetID, version)
+		return 0, 0, fmt.Errorf("no gases known for %d version %d", w.assetID, version)
 	}
-
-	return g.Swap * feeSuggestion, nil
+	return g.Swap * feeSuggestion, g.Refund * feeSuggestion, nil
 }
 
 // estimateSwap prepares an *asset.SwapEstimate. The estimate does not include

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -518,8 +518,8 @@ type Wallet interface {
 	// different CoinID in the returned asset.ConfirmRedemptionStatus as was
 	// used to call the function.
 	ConfirmRedemption(coinID dex.Bytes, redemption *Redemption, feeSuggestion uint64) (*ConfirmRedemptionStatus, error)
-	// SingleLotSwapFees returns the fees for a swap transaction for a single lot.
-	SingleLotSwapFees(version uint32, feeRate uint64, useSafeTxSize bool) (uint64, error)
+	// SingleLotSwapRefundFees returns the fees for a swap and refund transaction for a single lot.
+	SingleLotSwapRefundFees(version uint32, feeRate uint64, useSafeTxSize bool) (uint64, uint64, error)
 	// SingleLotRedeemFees returns the fees for a redeem transaction for a single lot.
 	SingleLotRedeemFees(version uint32, feeRate uint64) (uint64, error)
 	// FundMultiOrder funds multiple orders at once. The return values will

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1030,8 +1030,8 @@ func (w *TXCWallet) PreAccelerate(swapCoins, accelerationCoins []dex.Bytes, chan
 	return w.preAccelerateSwapRate, &w.preAccelerateSuggestedRange, nil, nil
 }
 
-func (w *TXCWallet) SingleLotSwapFees(version uint32, feeRate uint64, useSafeTxSize bool) (uint64, error) {
-	return 0, nil
+func (w *TXCWallet) SingleLotSwapRefundFees(version uint32, feeRate uint64, useSafeTxSize bool) (uint64, uint64, error) {
+	return 0, 0, nil
 }
 
 func (w *TXCWallet) SingleLotRedeemFees(version uint32, feeRate uint64) (uint64, error) {

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -419,6 +419,8 @@ type FeeBreakdown struct {
 	Swap       uint64 `json:"swap"`
 	Redemption uint64 `json:"redemption"`
 	Funding    uint64 `json:"funding"` // split fees
+	// TODO: Refund is not yet being populated.
+	Refund uint64 `json:"refund"`
 }
 
 // coreOrderFromTrade constructs an *Order from the supplied limit or market

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -560,21 +560,21 @@ func (m *MarketMaker) handleMatchUpdate(match *core.Match, oid dex.Bytes) {
 	orderInfo.matchesSettled[matchID] = struct{}{}
 
 	if match.Refund != nil {
-		var maxRefundFees uint64
+		var singleLotRefundFees uint64
 		if orderInfo.initialRefundFeesLocked == 0 {
-			maxRefundFees = orderInfo.singleLotRefundFees
+			singleLotRefundFees = orderInfo.singleLotRefundFees
 		}
 
 		var balanceMods []*balanceMod
 		if orderInfo.order.Sell {
 			balanceMods = []*balanceMod{
-				{balanceModDecrease, orderInfo.order.BaseID, balTypePendingRefund, match.Qty - maxRefundFees},
-				{balanceModIncrease, orderInfo.order.BaseID, balTypeAvailable, match.Qty - maxRefundFees},
+				{balanceModDecrease, orderInfo.order.BaseID, balTypePendingRefund, match.Qty - singleLotRefundFees},
+				{balanceModIncrease, orderInfo.order.BaseID, balTypeAvailable, match.Qty - singleLotRefundFees},
 			}
 		} else {
 			balanceMods = []*balanceMod{
-				{balanceModDecrease, orderInfo.order.QuoteID, balTypePendingRefund, calc.BaseToQuote(match.Rate, match.Qty) - maxRefundFees},
-				{balanceModIncrease, orderInfo.order.QuoteID, balTypeAvailable, calc.BaseToQuote(match.Rate, match.Qty) - maxRefundFees},
+				{balanceModDecrease, orderInfo.order.QuoteID, balTypePendingRefund, calc.BaseToQuote(match.Rate, match.Qty) - singleLotRefundFees},
+				{balanceModIncrease, orderInfo.order.QuoteID, balTypeAvailable, calc.BaseToQuote(match.Rate, match.Qty) - singleLotRefundFees},
 			}
 		}
 		m.log.Tracef("oid: %s, increasing balance due to refund")

--- a/client/mm/mm_basic.go
+++ b/client/mm/mm_basic.go
@@ -357,13 +357,13 @@ func (m *basicMarketMaker) halfSpread(basisPrice uint64) (uint64, error) {
 		return 0, fmt.Errorf("basis price cannot be zero")
 	}
 
-	baseFees, quoteFees, err := m.core.SingleLotFees(form)
+	baseFees, quoteFees, _, err := m.core.SingleLotFees(form)
 	if err != nil {
 		return 0, fmt.Errorf("SingleLotFees error: %v", err)
 	}
 
 	form.Sell = false
-	newQuoteFees, newBaseFees, err := m.core.SingleLotFees(form)
+	newQuoteFees, newBaseFees, _, err := m.core.SingleLotFees(form)
 	if err != nil {
 		return 0, fmt.Errorf("SingleLotFees error: %v", err)
 	}

--- a/client/mm/mm_test.go
+++ b/client/mm/mm_test.go
@@ -1198,19 +1198,21 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    true,
-							Filled:  1e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      true,
+							Filled:    1e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
 									Qty:     1e6,
 									Rate:    5e7,
 									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
 								},
 							},
 						},
@@ -1234,6 +1236,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							MatchID: matchIDs[0][:],
 							Qty:     1e6,
 							Rate:    5e7,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
 							Status:  order.MatchComplete,
 						},
 					},
@@ -1257,6 +1261,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Status:  order.MatchConfirmed,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -1292,6 +1297,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 								},
 							},
 						},
@@ -1355,18 +1362,20 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    false,
-							Filled:  1e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      false,
+							Filled:    1e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
 									Qty:     1e6,
 									Rate:    5e7,
+									Swap:    &core.Coin{},
 									Status:  order.MakerSwapCast,
 								},
 							},
@@ -1390,6 +1399,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							MatchID: matchIDs[0][:],
 							Qty:     1e6,
 							Rate:    5e7,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
 							Status:  order.MatchComplete,
 						},
 					},
@@ -1412,6 +1423,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Status:  order.MatchConfirmed,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -1514,19 +1526,21 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    true,
-							Filled:  1e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      true,
+							Filled:    1e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
 									Qty:     1e6,
 									Rate:    5e7,
 									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
 								},
 							},
 						},
@@ -1550,6 +1564,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							MatchID: matchIDs[0][:],
 							Qty:     1e6,
 							Rate:    5e7,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
 							Status:  order.MatchComplete,
 						},
 					},
@@ -1573,6 +1589,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Status:  order.MatchConfirmed,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -1607,12 +1624,15 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Status:  order.MatchConfirmed,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 								},
 								{
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    55e6,
 									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
 								},
 							},
 						},
@@ -1637,6 +1657,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    55e6,
 							Status:  order.MatchComplete,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -1660,6 +1681,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    55e6,
 							Status:  order.MatchConfirmed,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -1694,12 +1716,16 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									MatchID: matchIDs[0][:],
 									Qty:     1e6,
 									Rate:    5e7,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 									Status:  order.MatchConfirmed,
 								},
 								{
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    55e6,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 									Status:  order.MatchConfirmed,
 								},
 							},
@@ -1764,18 +1790,20 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    false,
-							Filled:  1e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      false,
+							Filled:    1e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
 									Qty:     1e6,
 									Rate:    5e7,
+									Swap:    &core.Coin{},
 									Status:  order.MakerSwapCast,
 								},
 							},
@@ -1799,6 +1827,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							MatchID: matchIDs[0][:],
 							Qty:     1e6,
 							Rate:    5e7,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
 							Status:  order.MatchComplete,
 						},
 					},
@@ -1821,6 +1851,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Status:  order.MatchConfirmed,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -1854,12 +1885,15 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									MatchID: matchIDs[0][:],
 									Qty:     1e6,
 									Rate:    5e7,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 									Status:  order.MatchConfirmed,
 								},
 								{
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    45e6,
+									Swap:    &core.Coin{},
 									Status:  order.MakerSwapCast,
 								},
 							},
@@ -1973,18 +2007,20 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    true,
-							Filled:  1e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      true,
+							Filled:    1e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
 									Qty:     1e6,
 									Rate:    5e7,
+									Swap:    &core.Coin{},
 									Status:  order.MakerSwapCast,
 								},
 							},
@@ -2010,6 +2046,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Status:  order.MatchComplete,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
 						},
 					},
 					balance: map[uint32]*botBalance{
@@ -2032,6 +2070,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Status:  order.MatchConfirmed,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -2066,12 +2105,15 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Status:  order.MatchConfirmed,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 								},
 								{
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    55e6,
 									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
 								},
 							},
 						},
@@ -2097,6 +2139,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Rate:    55e6,
 							Status:  order.MatchComplete,
 							Redeem:  &core.Coin{},
+							Swap:    &core.Coin{},
 						},
 					},
 					balance: map[uint32]*botBalance{
@@ -2120,6 +2163,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Rate:    55e6,
 							Status:  order.MatchConfirmed,
 							Redeem:  &core.Coin{},
+							Swap:    &core.Coin{},
 						},
 					},
 					balance: map[uint32]*botBalance{
@@ -2154,12 +2198,16 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Status:  order.MatchConfirmed,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 								},
 								{
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    55e6,
 									Status:  order.MatchConfirmed,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 								},
 							},
 						},
@@ -2177,7 +2225,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 		},
 		// "fully filled order, buy, accountLocker"
 		{
-			name: "fully filled order, buy, account locker",
+			name: "fully filled order, buy, accountLocker",
 			cfg: &BotConfig{
 				Host:             "host1",
 				BaseAsset:        42,
@@ -2225,19 +2273,21 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    false,
-							Filled:  1e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      false,
+							Filled:    1e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
 									Qty:     1e6,
 									Rate:    5e7,
 									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
 								},
 							},
 						},
@@ -2261,6 +2311,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Status:  order.MatchComplete,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
 						},
 					},
 					balance: map[uint32]*botBalance{
@@ -2282,6 +2334,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Status:  order.MatchConfirmed,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -2316,12 +2369,15 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Status:  order.MatchConfirmed,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 								},
 								{
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    45e6,
 									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
 								},
 							},
 						},
@@ -2345,6 +2401,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    45e6,
 							Status:  order.MatchComplete,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -2367,6 +2424,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    45e6,
 							Status:  order.MatchConfirmed,
+							Swap:    &core.Coin{},
 							Redeem:  &core.Coin{},
 						},
 					},
@@ -2431,13 +2489,14 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    false,
-							Filled:  2e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      false,
+							Filled:    2e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
@@ -2450,7 +2509,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    5e7,
-									Status:  order.MakerSwapCast,
+									Status:  order.NewlyMatched,
 								},
 								{
 									MatchID: matchIDs[2][:],
@@ -2470,30 +2529,6 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 						42: {
 							Available:     (1e7 / 2),
 							PendingRedeem: 3e6 - 3000,
-						},
-					},
-				},
-				{
-					note: &core.MatchNote{
-						OrderID: id,
-						Match: &core.Match{
-							MatchID: matchIDs[0][:],
-							Qty:     1e6,
-							Rate:    5e7,
-							Revoked: true,
-							Swap:    &core.Coin{},
-							Status:  order.MakerSwapCast,
-						},
-					},
-					balance: map[uint32]*botBalance{
-						0: {
-							Available:     (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 3e6),
-							PendingRefund: calc.BaseToQuote(5e7, 1e6) - 800,
-							FundingOrder:  3000,
-						},
-						42: {
-							Available:     (1e7 / 2),
-							PendingRedeem: 2e6 - 2000,
 						},
 					},
 				},
@@ -2529,13 +2564,13 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Revoked: true,
-							Status:  order.MatchConfirmed,
+							Status:  order.NewlyMatched,
 						},
 					},
 					balance: map[uint32]*botBalance{
 						0: {
-							Available:    (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 1e6) - 800,
-							FundingOrder: 3000,
+							Available:    (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 2e6) - 800,
+							FundingOrder: 3000 + calc.BaseToQuote(5e7, 1e6),
 						},
 						42: {
 							Available:     (1e7 / 2),
@@ -2557,8 +2592,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 					},
 					balance: map[uint32]*botBalance{
 						0: {
-							Available:    (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 1e6) - 800,
-							FundingOrder: 3000,
+							Available:    (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 2e6) - 800,
+							FundingOrder: 3000 + calc.BaseToQuote(5e7, 1e6),
 						},
 						42: {
 							Available: (1e7 / 2) + 1e6 - 1000,
@@ -2596,7 +2631,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Revoked: true,
-									Status:  order.MatchComplete,
+									Status:  order.NewlyMatched,
 								},
 								{
 									MatchID: matchIDs[2][:],
@@ -2669,13 +2704,14 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    true,
-							Filled:  2e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      true,
+							Filled:    2e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
@@ -2688,7 +2724,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    5e7,
-									Status:  order.MakerSwapCast,
+									Status:  order.NewlyMatched,
 								},
 								{
 									MatchID: matchIDs[2][:],
@@ -2708,30 +2744,6 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 						42: {
 							Available:    (1e7 / 2) - 3e6 - 3000,
 							FundingOrder: 3000,
-						},
-					},
-				},
-				{
-					note: &core.MatchNote{
-						OrderID: id,
-						Match: &core.Match{
-							MatchID: matchIDs[0][:],
-							Qty:     1e6,
-							Rate:    5e7,
-							Revoked: true,
-							Swap:    &core.Coin{},
-							Status:  order.MakerSwapCast,
-						},
-					},
-					balance: map[uint32]*botBalance{
-						0: {
-							Available:     (1e7 / 2),
-							PendingRedeem: calc.BaseToQuote(5e7, 2e6) - 2000,
-						},
-						42: {
-							Available:     (1e7 / 2) - 3e6 - 3000,
-							PendingRefund: 1e6 - 800,
-							FundingOrder:  3000,
 						},
 					},
 				},
@@ -2767,7 +2779,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Revoked: true,
-							Status:  order.MatchConfirmed,
+							Status:  order.NewlyMatched,
 						},
 					},
 					balance: map[uint32]*botBalance{
@@ -2776,8 +2788,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							PendingRedeem: calc.BaseToQuote(5e7, 1e6) - 1000,
 						},
 						42: {
-							Available:    (1e7 / 2) - 1e6 - 3000 - 800,
-							FundingOrder: 3000,
+							Available:    (1e7 / 2) - 2e6 - 3000 - 800,
+							FundingOrder: 3000 + 1e6,
 						},
 					},
 				},
@@ -2798,8 +2810,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Available: (1e7 / 2) + calc.BaseToQuote(5e7, 1e6) - 1000,
 						},
 						42: {
-							Available:    (1e7 / 2) - 1e6 - 3000 - 800,
-							FundingOrder: 3000,
+							Available:    (1e7 / 2) - 2e6 - 3000 - 800,
+							FundingOrder: 3000 + 1e6,
 						},
 					},
 				},
@@ -2834,7 +2846,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Revoked: true,
-									Status:  order.MatchComplete,
+									Status:  order.NewlyMatched,
 								},
 								{
 									MatchID: matchIDs[2][:],
@@ -2908,13 +2920,14 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    false,
-							Filled:  2e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      false,
+							Filled:    2e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
@@ -2927,7 +2940,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    5e7,
-									Status:  order.MakerSwapCast,
+									Status:  order.NewlyMatched,
 								},
 								{
 									MatchID: matchIDs[2][:],
@@ -2947,30 +2960,6 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 						42: {
 							Available:     (1e7 / 2),
 							PendingRedeem: 3e6 - 3000,
-						},
-					},
-				},
-				{
-					note: &core.MatchNote{
-						OrderID: id,
-						Match: &core.Match{
-							MatchID: matchIDs[0][:],
-							Qty:     1e6,
-							Rate:    5e7,
-							Revoked: true,
-							Swap:    &core.Coin{},
-							Status:  order.MakerSwapCast,
-						},
-					},
-					balance: map[uint32]*botBalance{
-						0: {
-							Available:     (1e7 / 2) - calc.BaseToQuote(5e7, 3e6) - 3000 - 2400,
-							PendingRefund: calc.BaseToQuote(5e7, 1e6),
-							FundingOrder:  3000 + 2400,
-						},
-						42: {
-							Available:     (1e7 / 2),
-							PendingRedeem: 2e6 - 2000,
 						},
 					},
 				},
@@ -3006,13 +2995,13 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Revoked: true,
-							Status:  order.MatchConfirmed,
+							Status:  order.NewlyMatched,
 						},
 					},
 					balance: map[uint32]*botBalance{
 						0: {
-							Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 1e6) - 3000 - 2400,
-							FundingOrder: 3000 + 2400,
+							Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 2e6) - 3000 - 2400,
+							FundingOrder: 3000 + 2400 + calc.BaseToQuote(5e7, 1e6),
 						},
 						42: {
 							Available:     (1e7 / 2),
@@ -3034,8 +3023,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 					},
 					balance: map[uint32]*botBalance{
 						0: {
-							Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 1e6) - 3000 - 2400,
-							FundingOrder: 3000 + 2400,
+							Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 2e6) - 3000 - 2400,
+							FundingOrder: 3000 + 2400 + calc.BaseToQuote(5e7, 1e6),
 						},
 						42: {
 							Available: (1e7 / 2) + 1e6 - 1000,
@@ -3073,7 +3062,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Revoked: true,
-									Status:  order.MatchComplete,
+									Status:  order.NewlyMatched,
 								},
 								{
 									MatchID: matchIDs[2][:],
@@ -3147,13 +3136,14 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 				{
 					note: &core.OrderNote{
 						Order: &core.Order{
-							ID:      id,
-							Status:  order.OrderStatusBooked,
-							BaseID:  42,
-							QuoteID: 0,
-							Qty:     2e6,
-							Sell:    true,
-							Filled:  2e6,
+							ID:        id,
+							Status:    order.OrderStatusBooked,
+							BaseID:    42,
+							QuoteID:   0,
+							Qty:       2e6,
+							Sell:      true,
+							Filled:    2e6,
+							LockedAmt: 1e6,
 							Matches: []*core.Match{
 								{
 									MatchID: matchIDs[0][:],
@@ -3166,7 +3156,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									MatchID: matchIDs[1][:],
 									Qty:     1e6,
 									Rate:    5e7,
-									Status:  order.MakerSwapCast,
+									Status:  order.NewlyMatched,
 								},
 								{
 									MatchID: matchIDs[2][:],
@@ -3186,30 +3176,6 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 						42: {
 							Available:    (1e7 / 2) - 3e6 - 3000 - 2400,
 							FundingOrder: 3000 + 2400,
-						},
-					},
-				},
-				{
-					note: &core.MatchNote{
-						OrderID: id,
-						Match: &core.Match{
-							MatchID: matchIDs[0][:],
-							Qty:     1e6,
-							Rate:    5e7,
-							Revoked: true,
-							Swap:    &core.Coin{},
-							Status:  order.MakerSwapCast,
-						},
-					},
-					balance: map[uint32]*botBalance{
-						0: {
-							Available:     (1e7 / 2),
-							PendingRedeem: calc.BaseToQuote(5e7, 2e6) - 2000,
-						},
-						42: {
-							Available:     (1e7 / 2) - 3e6 - 3000 - 2400,
-							PendingRefund: 1e6,
-							FundingOrder:  3000 + 2400,
 						},
 					},
 				},
@@ -3245,7 +3211,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Qty:     1e6,
 							Rate:    5e7,
 							Revoked: true,
-							Status:  order.MatchConfirmed,
+							Status:  order.NewlyMatched,
 						},
 					},
 					balance: map[uint32]*botBalance{
@@ -3254,8 +3220,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							PendingRedeem: calc.BaseToQuote(5e7, 1e6) - 1000,
 						},
 						42: {
-							Available:    (1e7 / 2) - 1e6 - 3000 - 2400,
-							FundingOrder: 3000 + 2400,
+							Available:    (1e7 / 2) - 2e6 - 3000 - 2400,
+							FundingOrder: 3000 + 2400 + 1e6,
 						},
 					},
 				},
@@ -3276,8 +3242,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 							Available: (1e7 / 2) + calc.BaseToQuote(5e7, 1e6) - 1000,
 						},
 						42: {
-							Available:    (1e7 / 2) - 1e6 - 3000 - 2400,
-							FundingOrder: 3000 + 2400,
+							Available:    (1e7 / 2) - 2e6 - 3000 - 2400,
+							FundingOrder: 3000 + 2400 + 1e6,
 						},
 					},
 				},
@@ -3312,7 +3278,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Revoked: true,
-									Status:  order.MatchComplete,
+									Status:  order.NewlyMatched,
 								},
 								{
 									MatchID: matchIDs[2][:],

--- a/client/mm/mm_test.go
+++ b/client/mm/mm_test.go
@@ -118,27 +118,31 @@ func (drv *tDriver) Info() *asset.WalletInfo {
 }
 
 type tCore struct {
-	assetBalances                map[uint32]*core.WalletBalance
-	assetBalanceErr              error
-	market                       *core.Market
-	orderEstimate                *core.OrderEstimate
-	sellSwapFees, sellRedeemFees uint64
-	buySwapFees, buyRedeemFees   uint64
-	singleLotFeesErr             error
-	preOrderParam                *core.TradeForm
-	tradeResult                  *core.Order
-	multiTradeResult             []*core.Order
-	noteFeed                     chan core.Notification
-	isAccountLocker              map[uint32]bool
-	maxBuyEstimate               *core.MaxOrderEstimate
-	maxBuyErr                    error
-	maxSellEstimate              *core.MaxOrderEstimate
-	maxSellErr                   error
-	cancelsPlaced                []dex.Bytes
-	buysPlaced                   []*core.TradeForm
-	sellsPlaced                  []*core.TradeForm
-	multiTradesPlaced            []*core.MultiTradeForm
-	maxFundingFees               uint64
+	assetBalances     map[uint32]*core.WalletBalance
+	assetBalanceErr   error
+	market            *core.Market
+	orderEstimate     *core.OrderEstimate
+	sellSwapFees      uint64
+	sellRedeemFees    uint64
+	sellRefundFees    uint64
+	buySwapFees       uint64
+	buyRedeemFees     uint64
+	buyRefundFees     uint64
+	singleLotFeesErr  error
+	preOrderParam     *core.TradeForm
+	tradeResult       *core.Order
+	multiTradeResult  []*core.Order
+	noteFeed          chan core.Notification
+	isAccountLocker   map[uint32]bool
+	maxBuyEstimate    *core.MaxOrderEstimate
+	maxBuyErr         error
+	maxSellEstimate   *core.MaxOrderEstimate
+	maxSellErr        error
+	cancelsPlaced     []dex.Bytes
+	buysPlaced        []*core.TradeForm
+	sellsPlaced       []*core.TradeForm
+	multiTradesPlaced []*core.MultiTradeForm
+	maxFundingFees    uint64
 }
 
 func (c *tCore) NotificationFeed() *core.NoteFeed {
@@ -162,14 +166,14 @@ func (*tCore) SyncBook(host string, base, quote uint32) (*orderbook.OrderBook, c
 func (*tCore) SupportedAssets() map[uint32]*core.SupportedAsset {
 	return nil
 }
-func (c *tCore) SingleLotFees(form *core.SingleLotFeesForm) (uint64, uint64, error) {
+func (c *tCore) SingleLotFees(form *core.SingleLotFeesForm) (uint64, uint64, uint64, error) {
 	if c.singleLotFeesErr != nil {
-		return 0, 0, c.singleLotFeesErr
+		return 0, 0, 0, c.singleLotFeesErr
 	}
 	if form.Sell {
-		return c.sellSwapFees, c.sellRedeemFees, nil
+		return c.sellSwapFees, c.sellRedeemFees, c.sellRefundFees, nil
 	}
-	return c.buySwapFees, c.buyRedeemFees, nil
+	return c.buySwapFees, c.buyRedeemFees, c.buyRefundFees, nil
 }
 func (*tCore) Cancel(oidB dex.Bytes) error {
 	return nil
@@ -539,6 +543,7 @@ func TestSegregatedCoreMaxSell(t *testing.T) {
 		market        *core.Market
 		swapFees      uint64
 		redeemFees    uint64
+		refundFees    uint64
 
 		expectPreOrderParam *core.TradeForm
 		wantErr             bool
@@ -674,6 +679,66 @@ func TestSegregatedCoreMaxSell(t *testing.T) {
 				Qty:     1e6,
 			},
 		},
+		{
+			name: "2 lots with refund fees, not account locker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        42,
+				QuoteAsset:       0,
+				BaseBalanceType:  Amount,
+				BaseBalance:      2e6 + 2000,
+				QuoteBalanceType: Amount,
+				QuoteBalance:     1000,
+			},
+			assetBalances: map[uint32]uint64{
+				0:  1e7,
+				42: 1e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			expectPreOrderParam: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    42,
+				Quote:   0,
+				Sell:    true,
+				Qty:     2e6,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 1000,
+		},
+		{
+			name: "1 lot with refund fees, account locker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        42,
+				QuoteAsset:       60,
+				BaseBalanceType:  Amount,
+				BaseBalance:      2e6 + 2000,
+				QuoteBalanceType: Amount,
+				QuoteBalance:     1000,
+			},
+			assetBalances: map[uint32]uint64{
+				60: 1e7,
+				42: 1e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			expectPreOrderParam: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    42,
+				Quote:   60,
+				Sell:    true,
+				Qty:     1e6,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 1000,
+		},
 	}
 
 	for _, test := range tests {
@@ -681,6 +746,7 @@ func TestSegregatedCoreMaxSell(t *testing.T) {
 		tCore.market = test.market
 		tCore.sellSwapFees = test.swapFees
 		tCore.sellRedeemFees = test.redeemFees
+		tCore.sellRefundFees = test.refundFees
 
 		mm, err := NewMarketMaker(tCore, tLogger)
 		if err != nil {
@@ -769,6 +835,7 @@ func TestSegregatedCoreMaxBuy(t *testing.T) {
 		rate          uint64
 		swapFees      uint64
 		redeemFees    uint64
+		refundFees    uint64
 
 		expectPreOrderParam *core.TradeForm
 		wantErr             bool
@@ -912,9 +979,76 @@ func TestSegregatedCoreMaxBuy(t *testing.T) {
 				Rate:    5e7,
 			},
 		},
+		{
+			name: "2 lots with refund fees, not account locker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        42,
+				QuoteAsset:       0,
+				BaseBalanceType:  Amount,
+				BaseBalance:      1000,
+				QuoteBalanceType: Amount,
+				QuoteBalance:     (2e6 * 5e7 / 1e8) + 2000,
+			},
+			rate: 5e7,
+			assetBalances: map[uint32]uint64{
+				0:  1e7,
+				42: 1e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			expectPreOrderParam: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    42,
+				Quote:   0,
+				Sell:    false,
+				Qty:     2e6,
+				Rate:    5e7,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 1000,
+		},
+		{
+			name: "1 lot with refund fees, account locker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        60,
+				QuoteAsset:       0,
+				BaseBalanceType:  Amount,
+				BaseBalance:      1000,
+				QuoteBalanceType: Amount,
+				QuoteBalance:     (2e6 * 5e7 / 1e8) + 2000,
+			},
+			rate: 5e7,
+			assetBalances: map[uint32]uint64{
+				60: 1e7,
+				0:  1e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			expectPreOrderParam: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    60,
+				Quote:   0,
+				Sell:    false,
+				Qty:     1e6,
+				Rate:    5e7,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 1000,
+		},
 	}
 
 	for _, test := range tests {
+		if test.name != "1 lot with refund fees, account locker" {
+			continue
+		}
 		tCore.setAssetBalances(test.assetBalances)
 		tCore.market = test.market
 		tCore.buySwapFees = test.swapFees
@@ -976,8 +1110,6 @@ func TestSegregatedCoreTrade(t *testing.T) {
 }
 
 func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
-	dcrBtcID := fmt.Sprintf("%s-%d-%d", "host1", 42, 0)
-
 	id := encode.RandomBytes(order.OrderIDSize)
 	id2 := encode.RandomBytes(order.OrderIDSize)
 
@@ -1005,6 +1137,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 		market            *core.Market
 		swapFees          uint64
 		redeemFees        uint64
+		refundFees        uint64
 		tradeRes          *core.Order
 		multiTradeRes     []*core.Order
 		notifications     []*noteAndBalances
@@ -1314,6 +1447,8 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 									Qty:     1e6,
 									Rate:    5e7,
 									Status:  order.MatchConfirmed,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
 								},
 							},
 						},
@@ -1781,6 +1916,1421 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 						},
 						42: {
 							Available: (1e7 / 2) + 2e6 - 2000,
+						},
+					},
+				},
+			},
+		},
+		// "fully filled order, sell, accountLocker"
+		{
+			name: "fully filled order, sell, accountLocker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        42,
+				QuoteAsset:       0,
+				BaseBalanceType:  Percentage,
+				BaseBalance:      50,
+				QuoteBalanceType: Percentage,
+				QuoteBalance:     50,
+			},
+			assetBalances: map[uint32]uint64{
+				0:  1e7,
+				42: 1e7,
+			},
+			trade: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    42,
+				Quote:   0,
+				Sell:    true,
+				Qty:     2e6,
+				Rate:    5e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 800,
+			tradeRes: &core.Order{
+				ID:              id,
+				LockedAmt:       2e6 + 2000,
+				RedeemLockedAmt: 2000,
+				RefundLockedAmt: 1600,
+				Sell:            true,
+			},
+			postTradeBalances: map[uint32]*botBalance{
+				0: {
+					Available:    (1e7 / 2) - 2000,
+					FundingOrder: 2000,
+				},
+				42: {
+					Available:    (1e7 / 2) - 2e6 - 2000 - 1600,
+					FundingOrder: 2e6 + 2000 + 1600,
+				},
+			},
+			notifications: []*noteAndBalances{
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:      id,
+							Status:  order.OrderStatusBooked,
+							BaseID:  42,
+							QuoteID: 0,
+							Qty:     2e6,
+							Sell:    true,
+							Filled:  1e6,
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2) - 2000,
+							FundingOrder:  2000,
+							PendingRedeem: calc.BaseToQuote(5e7, 1e6),
+						},
+						42: {
+							Available:    (1e7 / 2) - 2e6 - 2000 - 1600,
+							FundingOrder: 1e6 + 2000 + 1600,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Status:  order.MatchComplete,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2) - 2000,
+							FundingOrder:  2000,
+							PendingRedeem: calc.BaseToQuote(5e7, 1e6),
+						},
+						42: {
+							Available:    (1e7 / 2) - 2e6 - 2000 - 1600,
+							FundingOrder: 1e6 + 2000 + 1600,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Status:  order.MatchConfirmed,
+							Redeem:  &core.Coin{},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 2000 + calc.BaseToQuote(5e7, 1e6),
+							FundingOrder: 2000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 2e6 - 2000 - 1600,
+							FundingOrder: 1e6 + 2000 + 1600,
+						},
+					},
+				},
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:      id,
+							Status:  order.OrderStatusExecuted,
+							BaseID:  42,
+							QuoteID: 0,
+							Qty:     2e6,
+							Sell:    true,
+							Filled:  2e6,
+							FeesPaid: &core.FeeBreakdown{
+								Swap:       1600,
+								Redemption: 1600,
+							},
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchConfirmed,
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    55e6,
+									Status:  order.MakerSwapCast,
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2) - 2000 + calc.BaseToQuote(5e7, 1e6),
+							FundingOrder:  2000,
+							PendingRedeem: calc.BaseToQuote(55e6, 1e6),
+						},
+						42: {
+							Available:    (1e7 / 2) - 2e6 - 2000 - 1600,
+							FundingOrder: 2000 + 1600,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[1][:],
+							Qty:     1e6,
+							Rate:    55e6,
+							Status:  order.MatchComplete,
+							Redeem:  &core.Coin{},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2) - 2000 + calc.BaseToQuote(5e7, 1e6),
+							FundingOrder:  2000,
+							PendingRedeem: calc.BaseToQuote(55e6, 1e6),
+						},
+						42: {
+							Available:    (1e7 / 2) - 2e6 - 2000 - 1600,
+							FundingOrder: 2000 + 1600,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[1][:],
+							Qty:     1e6,
+							Rate:    55e6,
+							Status:  order.MatchConfirmed,
+							Redeem:  &core.Coin{},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 2000 + calc.BaseToQuote(5e7, 1e6) + calc.BaseToQuote(55e6, 1e6),
+							FundingOrder: 2000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 2e6 - 2000 - 1600,
+							FundingOrder: 2000 + 1600,
+						},
+					},
+				},
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:               id,
+							Status:           order.OrderStatusExecuted,
+							BaseID:           42,
+							QuoteID:          0,
+							Qty:              2e6,
+							Sell:             true,
+							Filled:           2e6,
+							AllFeesConfirmed: true,
+							FeesPaid: &core.FeeBreakdown{
+								Swap:       1600,
+								Redemption: 1600,
+							},
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchConfirmed,
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    55e6,
+									Status:  order.MatchConfirmed,
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available: (1e7 / 2) - 1600 + calc.BaseToQuote(5e7, 1e6) + calc.BaseToQuote(55e6, 1e6),
+						},
+						42: {
+							Available: (1e7 / 2) - 2e6 - 1600,
+						},
+					},
+				},
+			},
+		},
+		// "fully filled order, buy, accountLocker"
+		{
+			name: "fully filled order, buy, account locker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        42,
+				QuoteAsset:       0,
+				BaseBalanceType:  Percentage,
+				BaseBalance:      50,
+				QuoteBalanceType: Percentage,
+				QuoteBalance:     50,
+			},
+			assetBalances: map[uint32]uint64{
+				0:  1e7,
+				42: 1e7,
+			},
+			trade: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    42,
+				Quote:   0,
+				Sell:    false,
+				Qty:     2e6,
+				Rate:    5e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 800,
+			tradeRes: &core.Order{
+				ID:              id,
+				LockedAmt:       calc.BaseToQuote(5e7, 2e6) + 2000,
+				RefundLockedAmt: 1600,
+				Sell:            true,
+			},
+			postTradeBalances: map[uint32]*botBalance{
+				0: {
+					Available:    (1e7 / 2) - 2000 - calc.BaseToQuote(5e7, 2e6) - 1600,
+					FundingOrder: calc.BaseToQuote(5e7, 2e6) + 2000 + 1600,
+				},
+				42: {
+					Available: (1e7 / 2),
+				},
+			},
+			notifications: []*noteAndBalances{
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:      id,
+							Status:  order.OrderStatusBooked,
+							BaseID:  42,
+							QuoteID: 0,
+							Qty:     2e6,
+							Sell:    false,
+							Filled:  1e6,
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 2000 - calc.BaseToQuote(5e7, 2e6) - 1600,
+							FundingOrder: calc.BaseToQuote(5e7, 1e6) + 2000 + 1600,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 1e6 - 1000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Status:  order.MatchComplete,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 2000 - calc.BaseToQuote(5e7, 2e6) - 1600,
+							FundingOrder: calc.BaseToQuote(5e7, 1e6) + 2000 + 1600,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 1e6 - 1000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Status:  order.MatchConfirmed,
+							Redeem:  &core.Coin{},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 2000 - calc.BaseToQuote(5e7, 2e6) - 1600,
+							FundingOrder: calc.BaseToQuote(5e7, 1e6) + 2000 + 1600,
+						},
+						42: {
+							Available: (1e7 / 2) - 1000 + 1e6,
+						},
+					},
+				},
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:      id,
+							Status:  order.OrderStatusExecuted,
+							BaseID:  42,
+							QuoteID: 0,
+							Qty:     2e6,
+							Rate:    5e7,
+							Sell:    false,
+							Filled:  2e6,
+							FeesPaid: &core.FeeBreakdown{
+								Swap:       1600,
+								Redemption: 1600,
+							},
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchConfirmed,
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    45e6,
+									Status:  order.MakerSwapCast,
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 2000 - calc.BaseToQuote(5e7, 1e6) - calc.BaseToQuote(45e6, 1e6) - 1600,
+							FundingOrder: 2000 + 1600,
+						},
+						42: {
+							Available:     (1e7 / 2) + 1e6 - 1000,
+							PendingRedeem: 1e6 - 1000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[1][:],
+							Qty:     1e6,
+							Rate:    45e6,
+							Status:  order.MatchComplete,
+							Redeem:  &core.Coin{},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 2000 - calc.BaseToQuote(5e7, 1e6) - calc.BaseToQuote(45e6, 1e6) - 1600,
+							FundingOrder: 2000 + 1600,
+						},
+						42: {
+							Available:     (1e7 / 2) + 1e6 - 1000,
+							PendingRedeem: 1e6 - 1000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[1][:],
+							Qty:     1e6,
+							Rate:    45e6,
+							Status:  order.MatchConfirmed,
+							Redeem:  &core.Coin{},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 2000 - calc.BaseToQuote(5e7, 1e6) - calc.BaseToQuote(45e6, 1e6) - 1600,
+							FundingOrder: 2000 + 1600,
+						},
+						42: {
+							Available: (1e7 / 2) + 2e6 - 2000,
+						},
+					},
+				},
+			},
+		},
+		// "buy, 1 match refunded, 1 revoked before swap, 1 redeemed match, not accountLocker"
+		{
+			name: "buy, 1 refunded, 1 revoked before swap, 1 redeemed match, not accountLocker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        42,
+				QuoteAsset:       0,
+				BaseBalanceType:  Percentage,
+				BaseBalance:      50,
+				QuoteBalanceType: Percentage,
+				QuoteBalance:     50,
+			},
+			assetBalances: map[uint32]uint64{
+				0:  1e7,
+				42: 1e7,
+			},
+			trade: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    42,
+				Quote:   0,
+				Sell:    false,
+				Qty:     3e6,
+				Rate:    5e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 800,
+			tradeRes: &core.Order{
+				ID:        id,
+				LockedAmt: calc.BaseToQuote(5e7, 3e6) + 3000,
+				Sell:      false,
+			},
+			postTradeBalances: map[uint32]*botBalance{
+				0: {
+					Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 3e6) - 3000,
+					FundingOrder: calc.BaseToQuote(5e7, 3e6) + 3000,
+				},
+				42: {
+					Available: (1e7 / 2),
+				},
+			},
+			notifications: []*noteAndBalances{
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:      id,
+							Status:  order.OrderStatusBooked,
+							BaseID:  42,
+							QuoteID: 0,
+							Qty:     2e6,
+							Sell:    false,
+							Filled:  2e6,
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+								},
+								{
+									MatchID: matchIDs[2][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 3e6),
+							FundingOrder: 3000,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 3e6 - 3000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Swap:    &core.Coin{},
+							Status:  order.MakerSwapCast,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 3e6),
+							PendingRefund: calc.BaseToQuote(5e7, 1e6) - 800,
+							FundingOrder:  3000,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 2e6 - 2000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Swap:    &core.Coin{},
+							Refund:  &core.Coin{},
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 2e6) - 800,
+							FundingOrder: 3000,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 2e6 - 2000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[1][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 1e6) - 800,
+							FundingOrder: 3000,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 1e6 - 1000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[2][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - 3000 - calc.BaseToQuote(5e7, 1e6) - 800,
+							FundingOrder: 3000,
+						},
+						42: {
+							Available: (1e7 / 2) + 1e6 - 1000,
+						},
+					},
+				},
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:               id,
+							Status:           order.OrderStatusRevoked,
+							BaseID:           42,
+							QuoteID:          0,
+							Qty:              2e6,
+							Sell:             false,
+							Filled:           2e6,
+							AllFeesConfirmed: true,
+							FeesPaid: &core.FeeBreakdown{
+								Swap:       1600,
+								Refund:     400,
+								Redemption: 500,
+							},
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchComplete,
+									Swap:    &core.Coin{},
+									Revoked: true,
+									Refund:  &core.Coin{},
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Revoked: true,
+									Status:  order.MatchComplete,
+								},
+								{
+									MatchID: matchIDs[2][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchComplete,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available: (1e7 / 2) - calc.BaseToQuote(5e7, 1e6) - 1600 - 400,
+						},
+						42: {
+							Available: (1e7 / 2) + 1e6 - 500,
+						},
+					},
+				},
+			},
+		},
+		// "sell, 1 match refunded, 1 revoked before swap, 1 redeemed match, not accountLocker"
+		{
+			name: "sell, 1 refunded, 1 revoked before swap, 1 redeemed match, not accountLocker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        42,
+				QuoteAsset:       0,
+				BaseBalanceType:  Percentage,
+				BaseBalance:      50,
+				QuoteBalanceType: Percentage,
+				QuoteBalance:     50,
+			},
+			assetBalances: map[uint32]uint64{
+				0:  1e7,
+				42: 1e7,
+			},
+			trade: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    42,
+				Quote:   0,
+				Sell:    true,
+				Qty:     3e6,
+				Rate:    5e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 800,
+			tradeRes: &core.Order{
+				ID:        id,
+				LockedAmt: 3e6 + 3000,
+				Sell:      false,
+			},
+			postTradeBalances: map[uint32]*botBalance{
+				0: {
+					Available: (1e7 / 2),
+				},
+				42: {
+					Available:    (1e7 / 2) - 3e6 - 3000,
+					FundingOrder: 3e6 + 3000,
+				},
+			},
+			notifications: []*noteAndBalances{
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:      id,
+							Status:  order.OrderStatusBooked,
+							BaseID:  42,
+							QuoteID: 0,
+							Qty:     2e6,
+							Sell:    true,
+							Filled:  2e6,
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+								},
+								{
+									MatchID: matchIDs[2][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2),
+							PendingRedeem: calc.BaseToQuote(5e7, 3e6) - 3000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 3e6 - 3000,
+							FundingOrder: 3000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Swap:    &core.Coin{},
+							Status:  order.MakerSwapCast,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2),
+							PendingRedeem: calc.BaseToQuote(5e7, 2e6) - 2000,
+						},
+						42: {
+							Available:     (1e7 / 2) - 3e6 - 3000,
+							PendingRefund: 1e6 - 800,
+							FundingOrder:  3000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Swap:    &core.Coin{},
+							Refund:  &core.Coin{},
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2),
+							PendingRedeem: calc.BaseToQuote(5e7, 2e6) - 2000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 2e6 - 3000 - 800,
+							FundingOrder: 3000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[1][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2),
+							PendingRedeem: calc.BaseToQuote(5e7, 1e6) - 1000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 1e6 - 3000 - 800,
+							FundingOrder: 3000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[2][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available: (1e7 / 2) + calc.BaseToQuote(5e7, 1e6) - 1000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 1e6 - 3000 - 800,
+							FundingOrder: 3000,
+						},
+					},
+				},
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:               id,
+							Status:           order.OrderStatusRevoked,
+							BaseID:           42,
+							QuoteID:          0,
+							Qty:              3e6,
+							Sell:             true,
+							Filled:           3e6,
+							AllFeesConfirmed: true,
+							FeesPaid: &core.FeeBreakdown{
+								Swap:       1600,
+								Refund:     400,
+								Redemption: 500,
+							},
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchComplete,
+									Swap:    &core.Coin{},
+									Revoked: true,
+									Refund:  &core.Coin{},
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Revoked: true,
+									Status:  order.MatchComplete,
+								},
+								{
+									MatchID: matchIDs[2][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchComplete,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available: (1e7 / 2) + calc.BaseToQuote(5e7, 1e6) - 500,
+						},
+						42: {
+							Available: (1e7 / 2) - 1e6 - 1600 - 400,
+						},
+					},
+				},
+			},
+		},
+		// "buy, 1 match refunded, 1 revoked before swap, 1 redeemed match, accountLocker"
+		{
+			name: "buy, 1 refunded, 1 revoked before swap, 1 redeemed match, accountLocker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        42,
+				QuoteAsset:       0,
+				BaseBalanceType:  Percentage,
+				BaseBalance:      50,
+				QuoteBalanceType: Percentage,
+				QuoteBalance:     50,
+			},
+			assetBalances: map[uint32]uint64{
+				0:  1e7,
+				42: 1e7,
+			},
+			trade: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    42,
+				Quote:   0,
+				Sell:    false,
+				Qty:     3e6,
+				Rate:    5e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 800,
+			tradeRes: &core.Order{
+				ID:              id,
+				LockedAmt:       calc.BaseToQuote(5e7, 3e6) + 3000,
+				RefundLockedAmt: 2400,
+				Sell:            false,
+			},
+			postTradeBalances: map[uint32]*botBalance{
+				0: {
+					Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 3e6) - 3000 - 2400,
+					FundingOrder: calc.BaseToQuote(5e7, 3e6) + 3000 + 2400,
+				},
+				42: {
+					Available: (1e7 / 2),
+				},
+			},
+			notifications: []*noteAndBalances{
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:      id,
+							Status:  order.OrderStatusBooked,
+							BaseID:  42,
+							QuoteID: 0,
+							Qty:     2e6,
+							Sell:    false,
+							Filled:  2e6,
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+								},
+								{
+									MatchID: matchIDs[2][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 3e6) - 3000 - 2400,
+							FundingOrder: 3000 + 2400,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 3e6 - 3000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Swap:    &core.Coin{},
+							Status:  order.MakerSwapCast,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2) - calc.BaseToQuote(5e7, 3e6) - 3000 - 2400,
+							PendingRefund: calc.BaseToQuote(5e7, 1e6),
+							FundingOrder:  3000 + 2400,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 2e6 - 2000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Swap:    &core.Coin{},
+							Refund:  &core.Coin{},
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 2e6) - 3000 - 2400,
+							FundingOrder: 3000 + 2400,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 2e6 - 2000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[1][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 1e6) - 3000 - 2400,
+							FundingOrder: 3000 + 2400,
+						},
+						42: {
+							Available:     (1e7 / 2),
+							PendingRedeem: 1e6 - 1000,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[2][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:    (1e7 / 2) - calc.BaseToQuote(5e7, 1e6) - 3000 - 2400,
+							FundingOrder: 3000 + 2400,
+						},
+						42: {
+							Available: (1e7 / 2) + 1e6 - 1000,
+						},
+					},
+				},
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:               id,
+							Status:           order.OrderStatusRevoked,
+							BaseID:           42,
+							QuoteID:          0,
+							Qty:              3e6,
+							Sell:             false,
+							Filled:           3e6,
+							AllFeesConfirmed: true,
+							FeesPaid: &core.FeeBreakdown{
+								Swap:       1600,
+								Refund:     400,
+								Redemption: 500,
+							},
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchComplete,
+									Swap:    &core.Coin{},
+									Revoked: true,
+									Refund:  &core.Coin{},
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Revoked: true,
+									Status:  order.MatchComplete,
+								},
+								{
+									MatchID: matchIDs[2][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchComplete,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available: (1e7 / 2) - calc.BaseToQuote(5e7, 1e6) - 1600 - 400,
+						},
+						42: {
+							Available: (1e7 / 2) + 1e6 - 500,
+						},
+					},
+				},
+			},
+		},
+		// "sell, 1 match refunded, 1 revoked before swap, 1 redeemed match, accountLocker"
+		{
+			name: "sell, 1 refunded, 1 revoked before swap, 1 redeemed match, accountLocker",
+			cfg: &BotConfig{
+				Host:             "host1",
+				BaseAsset:        42,
+				QuoteAsset:       0,
+				BaseBalanceType:  Percentage,
+				BaseBalance:      50,
+				QuoteBalanceType: Percentage,
+				QuoteBalance:     50,
+			},
+			assetBalances: map[uint32]uint64{
+				0:  1e7,
+				42: 1e7,
+			},
+			trade: &core.TradeForm{
+				Host:    "host1",
+				IsLimit: true,
+				Base:    42,
+				Quote:   0,
+				Sell:    true,
+				Qty:     3e6,
+				Rate:    5e7,
+			},
+			market: &core.Market{
+				LotSize: 1e6,
+			},
+			swapFees:   1000,
+			redeemFees: 1000,
+			refundFees: 800,
+			tradeRes: &core.Order{
+				ID:              id,
+				LockedAmt:       3e6 + 3000,
+				RefundLockedAmt: 2400,
+				Sell:            false,
+			},
+			postTradeBalances: map[uint32]*botBalance{
+				0: {
+					Available: (1e7 / 2),
+				},
+				42: {
+					Available:    (1e7 / 2) - 3e6 - 3000 - 2400,
+					FundingOrder: 3e6 + 3000 + 2400,
+				},
+			},
+			notifications: []*noteAndBalances{
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:      id,
+							Status:  order.OrderStatusBooked,
+							BaseID:  42,
+							QuoteID: 0,
+							Qty:     2e6,
+							Sell:    true,
+							Filled:  2e6,
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+								},
+								{
+									MatchID: matchIDs[2][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MakerSwapCast,
+									Swap:    &core.Coin{},
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2),
+							PendingRedeem: calc.BaseToQuote(5e7, 3e6) - 3000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 3e6 - 3000 - 2400,
+							FundingOrder: 3000 + 2400,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Swap:    &core.Coin{},
+							Status:  order.MakerSwapCast,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2),
+							PendingRedeem: calc.BaseToQuote(5e7, 2e6) - 2000,
+						},
+						42: {
+							Available:     (1e7 / 2) - 3e6 - 3000 - 2400,
+							PendingRefund: 1e6,
+							FundingOrder:  3000 + 2400,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[0][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Swap:    &core.Coin{},
+							Refund:  &core.Coin{},
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2),
+							PendingRedeem: calc.BaseToQuote(5e7, 2e6) - 2000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 2e6 - 3000 - 2400,
+							FundingOrder: 3000 + 2400,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[1][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Revoked: true,
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available:     (1e7 / 2),
+							PendingRedeem: calc.BaseToQuote(5e7, 1e6) - 1000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 1e6 - 3000 - 2400,
+							FundingOrder: 3000 + 2400,
+						},
+					},
+				},
+				{
+					note: &core.MatchNote{
+						OrderID: id,
+						Match: &core.Match{
+							MatchID: matchIDs[2][:],
+							Qty:     1e6,
+							Rate:    5e7,
+							Swap:    &core.Coin{},
+							Redeem:  &core.Coin{},
+							Status:  order.MatchConfirmed,
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available: (1e7 / 2) + calc.BaseToQuote(5e7, 1e6) - 1000,
+						},
+						42: {
+							Available:    (1e7 / 2) - 1e6 - 3000 - 2400,
+							FundingOrder: 3000 + 2400,
+						},
+					},
+				},
+				{
+					note: &core.OrderNote{
+						Order: &core.Order{
+							ID:               id,
+							Status:           order.OrderStatusRevoked,
+							BaseID:           42,
+							QuoteID:          0,
+							Qty:              3e6,
+							Sell:             true,
+							Filled:           3e6,
+							AllFeesConfirmed: true,
+							FeesPaid: &core.FeeBreakdown{
+								Swap:       1600,
+								Refund:     400,
+								Redemption: 500,
+							},
+							Matches: []*core.Match{
+								{
+									MatchID: matchIDs[0][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchComplete,
+									Swap:    &core.Coin{},
+									Revoked: true,
+									Refund:  &core.Coin{},
+								},
+								{
+									MatchID: matchIDs[1][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Revoked: true,
+									Status:  order.MatchComplete,
+								},
+								{
+									MatchID: matchIDs[2][:],
+									Qty:     1e6,
+									Rate:    5e7,
+									Status:  order.MatchComplete,
+									Swap:    &core.Coin{},
+									Redeem:  &core.Coin{},
+								},
+							},
+						},
+					},
+					balance: map[uint32]*botBalance{
+						0: {
+							Available: (1e7 / 2) + calc.BaseToQuote(5e7, 1e6) - 500,
+						},
+						42: {
+							Available: (1e7 / 2) - 1e6 - 1600 - 400,
 						},
 					},
 				},
@@ -2529,26 +4079,28 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 			return
 		}
 
+		mktID := dexMarketID(test.cfg.Host, test.cfg.BaseAsset, test.cfg.QuoteAsset)
+
 		tCore := newTCore()
 		tCore.setAssetBalances(test.assetBalances)
 		tCore.market = test.market
-		if !test.multiTradeOnly {
-			if test.trade.Sell {
-				tCore.sellSwapFees = test.swapFees
-				tCore.sellRedeemFees = test.redeemFees
-			} else {
-				tCore.buySwapFees = test.swapFees
-				tCore.buyRedeemFees = test.redeemFees
-			}
+		var sell bool
+		if test.multiTradeOnly {
+			sell = test.multiTrade.Sell
 		} else {
-			if test.multiTrade.Sell {
-				tCore.sellSwapFees = test.swapFees
-				tCore.sellRedeemFees = test.redeemFees
-			} else {
-				tCore.buySwapFees = test.swapFees
-				tCore.buyRedeemFees = test.redeemFees
-			}
+			sell = test.trade.Sell
 		}
+
+		if sell {
+			tCore.sellSwapFees = test.swapFees
+			tCore.sellRedeemFees = test.redeemFees
+			tCore.sellRefundFees = test.refundFees
+		} else {
+			tCore.buySwapFees = test.swapFees
+			tCore.buyRedeemFees = test.redeemFees
+			tCore.buyRefundFees = test.refundFees
+		}
+
 		if test.isAccountLocker == nil {
 			tCore.isAccountLocker = make(map[uint32]bool)
 		} else {
@@ -2579,7 +4131,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 			t.Fatalf("%s: unexpected error: %v", test.name, err)
 		}
 
-		segregatedCore := mm.wrappedCoreForBot(dcrBtcID)
+		segregatedCore := mm.wrappedCoreForBot(mktID)
 
 		if testMultiTrade {
 
@@ -2613,7 +4165,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 			t.Fatalf("%s: unexpected error: %v", test.name, err)
 		}
 
-		if err := assetBalancesMatch(test.postTradeBalances, dcrBtcID, mm); err != nil {
+		if err := assetBalancesMatch(test.postTradeBalances, mktID, mm); err != nil {
 			t.Fatalf("%s: unexpected post trade balance: %v", test.name, err)
 		}
 
@@ -2622,7 +4174,7 @@ func testSegregatedCoreTrade(t *testing.T, testMultiTrade bool) {
 			tCore.noteFeed <- noteAndBalances.note
 			tCore.noteFeed <- dummyNote
 
-			if err := assetBalancesMatch(noteAndBalances.balance, dcrBtcID, mm); err != nil {
+			if err := assetBalancesMatch(noteAndBalances.balance, mktID, mm); err != nil {
 				t.Fatalf("%s: unexpected balances after note %d: %v", test.name, i, err)
 			}
 		}

--- a/client/mm/wrapped_core.go
+++ b/client/mm/wrapped_core.go
@@ -267,7 +267,6 @@ func (c *wrappedCore) Trade(pw []byte, form *core.TradeForm) (*core.Order, error
 		lotSize:                 mkt.LotSize,
 		matchesSettled:          make(map[order.MatchID]struct{}),
 		matchesSeen:             make(map[order.MatchID]struct{}),
-		revokedMatchesSeen:      make(map[order.MatchID]struct{}),
 	}
 	c.mm.ordersMtx.Unlock()
 
@@ -351,7 +350,6 @@ func (c *wrappedCore) MultiTrade(pw []byte, form *core.MultiTradeForm) ([]*core.
 			lotSize:                 mkt.LotSize,
 			matchesSettled:          make(map[order.MatchID]struct{}),
 			matchesSeen:             make(map[order.MatchID]struct{}),
-			revokedMatchesSeen:      make(map[order.MatchID]struct{}),
 		}
 		c.mm.ordersMtx.Unlock()
 


### PR DESCRIPTION
The possibility of refunds was previously ignored in the market making balance handling code.

- `core.SingleLotFees` now returns refund fees in addition to swap and redeem. This is needed because ETH reserves refund fees when funding a swap, so the market maker `MaxSell`/`MaxBuy` implementations need to know about this.
- `asset.SingleLotSwapFees` is now `asset.SingleLotSwapRefundFees`
- `core.FeeBreakdown` now includes Refund fees.
- `PendingRefund` is removed from the `botBalance` struct. Matches are assumed to eventually be redeemed
   until we actually see a refund.
- Revoked matches where a swap has not been sent are handled.

The Refund field of `core.FeeBreakdown` is not yet populated. This will be implemented in a future diff.