### PR TITLE
client/asset/dash: Update minNetworkVersion to v19.2.0.

### DIFF
--- a/client/asset/dash/dash.go
+++ b/client/asset/dash/dash.go
@@ -18,7 +18,7 @@ import (
 const (
 	version                 = 0
 	BipID                   = 5
-	minNetworkVersion       = 190100 // Dash v19.1.0, proto: 70227
+	minNetworkVersion       = 190200 // Dash v19.2.0, proto: 70228. Breaking change
 	walletTypeRPC           = "dashdRPC"
 	defaultRedeemConfTarget = 2
 )


### PR DESCRIPTION
[Dash v19.2.0](https://github.com/dashpay/dash/releases/tag/v19.2.0)

Dash Core 19.2.0 is a **mandatory** minor version that does include breaking changes. You can find detailed release notes at <https://github.com/dashpay/dash/blob/v19.2.0/doc/release-notes.md>.

When upgrading from a version < 19.2, a migration process will occur. Although expected to complete quite quickly, this migration process can take up to thirty minutes to complete on some systems.

This release is **mandatory** for all nodes. Versions < 19.2 are expected to fork off from the rest of the network on July 6th.
