### PR TITLE
server/eth: websocket header subscriptions and less frequent http polling

### DIFF
--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -249,7 +249,7 @@ func TestRun(t *testing.T) {
 		select {
 		case <-ch:
 			cancel()
-		case <-time.After(blockPollInterval * 2):
+		case <-time.After(time.Second * 2):
 		}
 	}()
 	backend.run(ctx)

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"math/big"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -877,6 +878,28 @@ func TestValidateSignature(t *testing.T) {
 		}
 		if err != nil {
 			t.Fatalf("unexpected error for test %q: %v", test.name, err)
+		}
+	}
+}
+
+func TestIsRemoteURL(t *testing.T) {
+	for _, tt := range []struct {
+		url        string
+		wantRemote bool
+	}{
+		{"http://localhost:1234", false},
+		{"http://127.0.0.1", false},
+		{"http://127.0.0.1:1234", false},
+		{"https://127.0.0.1:1234", false},
+		{"https://decred.org", true},
+		{"https://241.45.173.171", true},
+		{"http://[::1]:8080", false},
+		{"https://[2001:db8::1]:8080", true},
+		{"https://241.45.173.171:1234", true},
+	} {
+		uri, _ := url.Parse(tt.url)
+		if is := isRemoteURL(uri); is != tt.wantRemote {
+			t.Fatalf("%s: wanted %t, got %t", tt.url, tt.wantRemote, is)
 		}
 	}
 }

--- a/server/asset/eth/rpcclient.go
+++ b/server/asset/eth/rpcclient.go
@@ -103,8 +103,8 @@ func (ec *ethConn) monitorBlocks(ctx context.Context, log dex.Logger) {
 			if ctx.Err() != nil || err == nil { // Both conditions indicate normal close
 				return
 			}
-			log.Errorf("Header subscription to %s failed with error: %v", err)
-			log.Info("Falling back to manual header requests")
+			log.Errorf("Header subscription to %s failed with error: %v", ec.endpoint, err)
+			log.Infof("Falling back to manual header requests for %s", ec.endpoint)
 			return
 		case <-ctx.Done():
 			return

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -203,7 +203,7 @@ func TestHeaderSubscription(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, headerExpirationTime)
 	defer cancel()
 	ept := endpoint{url: wsEndpoint}
-	cl := newRPCClient(dex.Simnet, []endpoint{ept}, ethClient.ethContractAddr, ethClient.log)
+	cl := newRPCClient(BipID, dex.Simnet, []endpoint{ept}, ethClient.ethContractAddr, ethClient.log)
 	ec, err := cl.connectToEndpoint(ctx, ept)
 	if err != nil {
 		t.Fatalf("connectToEndpoint error: %v", err)

--- a/server/asset/eth/rpcclient_harness_test.go
+++ b/server/asset/eth/rpcclient_harness_test.go
@@ -199,6 +199,35 @@ func TestMonitorHealth(t *testing.T) {
 	}
 }
 
+func TestHeaderSubscription(t *testing.T) {
+	ctx, cancel := context.WithTimeout(ctx, headerExpirationTime)
+	defer cancel()
+	ept := endpoint{url: wsEndpoint}
+	cl := newRPCClient(dex.Simnet, []endpoint{ept}, ethClient.ethContractAddr, ethClient.log)
+	ec, err := cl.connectToEndpoint(ctx, ept)
+	if err != nil {
+		t.Fatalf("connectToEndpoint error: %v", err)
+	}
+	hdr, err := ec.tip(ctx)
+	if err != nil {
+		t.Fatalf("Error getting initial tip: %v", err)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+		ec.tipCache.Lock()
+		bestHdr := ec.tipCache.hdr
+		ec.tipCache.Unlock()
+		if bestHdr.Number.Cmp(hdr.Number) > 0 {
+			hdr = bestHdr
+			fmt.Println("New header seen at height", bestHdr.Number)
+		}
+	}
+}
+
 func tmuxRun(cmd string) error {
 	cmd += "; tmux wait-for -S harnessdone"
 	err := exec.Command("tmux", "send-keys", "-t", "eth-harness:0", cmd, "C-m").Run() // ; wait-for harnessdone


### PR DESCRIPTION
We weren't using header subscriptions with WebSocket provider connections, so were polling every second by default. 

1) Add WebSocket header subscriptions to minimize requests.

1) Automatically increase the poll interval for HTTP connections if the IP is not a loopback address. Previously, the poll interval could be modified by setting the `blockPollIntervalStr` with `ldflags` at compile-time, but this is a little more user friendly, I think, and captures the intent just the same.