### PR TITLE
client/{asset,core}: wallet notifications

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -5070,12 +5070,12 @@ func (btc *intermediaryWallet) watchBlocks(ctx context.Context) {
 		case <-ticker.C:
 			newTipHdr, err := btc.node.getBestBlockHeader()
 			if err != nil {
-				btc.emit.Errorf("failed to get best block header from %s node: %w", btc.symbol, err)
+				btc.log.Errorf("failed to get best block header from %s node: %w", btc.symbol, err)
 				continue
 			}
 			newTipHash, err := chainhash.NewHashFromStr(newTipHdr.Hash)
 			if err != nil {
-				btc.emit.Errorf("invalid best block hash from %s node: %v", btc.symbol, err)
+				btc.log.Errorf("invalid best block hash from %s node: %v", btc.symbol, err)
 				continue
 			}
 

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -856,7 +856,7 @@ type baseWallet struct {
 	chainParams       *chaincfg.Params
 	log               dex.Logger
 	symbol            string
-	tipChange         func(error)
+	emit              *asset.WalletEmitter
 	lastPeerCount     uint32
 	peersChange       func(uint32, error)
 	minNetworkVersion uint64
@@ -1331,7 +1331,7 @@ func newUnconnectedWallet(cfg *BTCCloneCFG, walletCfg *WalletConfig) (*baseWalle
 		chainParams:         cfg.ChainParams,
 		cloneParams:         cfg,
 		log:                 cfg.Logger,
-		tipChange:           cfg.WalletCFG.TipChange,
+		emit:                cfg.WalletCFG.Emit,
 		peersChange:         cfg.WalletCFG.PeersChange,
 		fundingCoins:        make(map[outPoint]*utxo),
 		findRedemptionQueue: make(map[outPoint]*findRedemptionReq),
@@ -1586,6 +1586,7 @@ func (btc *baseWallet) SyncStatus() (bool, float32, error) {
 	if err != nil {
 		return false, 0, err
 	}
+
 	if ss.Target == 0 { // do not say progress = 1
 		return false, 0, nil
 	}
@@ -5069,12 +5070,12 @@ func (btc *intermediaryWallet) watchBlocks(ctx context.Context) {
 		case <-ticker.C:
 			newTipHdr, err := btc.node.getBestBlockHeader()
 			if err != nil {
-				go btc.tipChange(fmt.Errorf("failed to get best block header from %s node: %v", btc.symbol, err))
+				btc.emit.Errorf("failed to get best block header from %s node: %w", btc.symbol, err)
 				continue
 			}
 			newTipHash, err := chainhash.NewHashFromStr(newTipHdr.Hash)
 			if err != nil {
-				go btc.tipChange(fmt.Errorf("invalid best block hash from %s node: %v", btc.symbol, err))
+				btc.emit.Errorf("invalid best block hash from %s node: %v", btc.symbol, err)
 				continue
 			}
 
@@ -5172,7 +5173,7 @@ func (btc *intermediaryWallet) reportNewTip(ctx context.Context, newTip *block) 
 	prevTip := btc.currentTip
 	btc.currentTip = newTip
 	btc.log.Debugf("tip change: %d (%s) => %d (%s)", prevTip.height, prevTip.hash, newTip.height, newTip.hash)
-	go btc.tipChange(nil)
+	btc.emit.TipChange(uint64(newTip.height))
 
 	reqs := btc.prepareRedemptionRequestsForBlockCheck()
 	// Redemption search would be compromised if the starting point cannot

--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -292,7 +292,7 @@ func (btc *ExchangeWalletElectrum) watchBlocks(ctx context.Context) {
 			// unimportant because of how electrum searches for transactions.
 			stat, err := btc.node.syncStatus()
 			if err != nil {
-				go btc.tipChange(fmt.Errorf("failed to get sync status: %w", err))
+				btc.emit.Errorf("failed to get sync status: %w", err)
 				continue
 			}
 
@@ -307,8 +307,7 @@ func (btc *ExchangeWalletElectrum) watchBlocks(ctx context.Context) {
 			if err != nil {
 				// NOTE: often says "height X out of range", then succeeds on next tick
 				if !strings.Contains(err.Error(), "out of range") {
-					go btc.tipChange(fmt.Errorf("failed to get best block from %s electrum server: %w",
-						btc.symbol, err))
+					btc.emit.Errorf("failed to get best block from %s electrum server: %w", btc.symbol, err)
 				}
 				continue
 			}
@@ -316,7 +315,7 @@ func (btc *ExchangeWalletElectrum) watchBlocks(ctx context.Context) {
 			btc.log.Debugf("tip change: %d (%s) => %d (%s)", currentTip.height, currentTip.hash,
 				newTip.height, newTip.hash)
 			currentTip = newTip
-			go btc.tipChange(nil)
+			btc.emit.TipChange(uint64(newTip.height))
 			go btc.tryRedemptionRequests(ctx)
 
 		case <-ctx.Done():

--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -292,7 +292,7 @@ func (btc *ExchangeWalletElectrum) watchBlocks(ctx context.Context) {
 			// unimportant because of how electrum searches for transactions.
 			stat, err := btc.node.syncStatus()
 			if err != nil {
-				btc.emit.Errorf("failed to get sync status: %w", err)
+				btc.log.Errorf("failed to get sync status: %w", err)
 				continue
 			}
 
@@ -307,7 +307,7 @@ func (btc *ExchangeWalletElectrum) watchBlocks(ctx context.Context) {
 			if err != nil {
 				// NOTE: often says "height X out of range", then succeeds on next tick
 				if !strings.Contains(err.Error(), "out of range") {
-					btc.emit.Errorf("failed to get best block from %s electrum server: %w", btc.symbol, err)
+					btc.log.Errorf("failed to get best block from %s electrum server: %w", btc.symbol, err)
 				}
 				continue
 			}

--- a/client/asset/btc/electrum_test.go
+++ b/client/asset/btc/electrum_test.go
@@ -49,7 +49,7 @@ func TestElectrumExchangeWallet(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	tipChanged := make(chan struct{}, 1)
+	notes := make(chan asset.WalletNotification)
 	walletCfg := &asset.WalletConfig{
 		Type: walletTypeElectrum,
 		Settings: map[string]string{
@@ -57,15 +57,7 @@ func TestElectrumExchangeWallet(t *testing.T) {
 			"rpcpassword": "pass",
 			"rpcbind":     "127.0.0.1:6789",
 		},
-		TipChange: func(error) {
-			select {
-			case tipChanged <- struct{}{}:
-				t.Log("tip change, that's enough testing")
-				time.Sleep(300 * time.Millisecond)
-				cancel()
-			default:
-			}
-		},
+		Emit: asset.NewWalletEmitter(notes, BipID, tLogger),
 		PeersChange: func(num uint32, err error) {
 			t.Logf("peer count = %d, err = %v", num, err)
 		},
@@ -163,6 +155,12 @@ func TestElectrumExchangeWallet(t *testing.T) {
 	select {
 	case <-time.After(10 * time.Second): // a bit of best block polling
 		cancel()
+	case ni := <-notes:
+		cancel()
+		if n, is := ni.(*asset.AsyncWalletErrorNote); is {
+			t.Fatalf("Wallet sent an error: %v", n.Err)
+		}
+
 	case <-ctx.Done(): // or until TipChange cancels the context
 	}
 

--- a/client/asset/btc/electrum_test.go
+++ b/client/asset/btc/electrum_test.go
@@ -156,9 +156,8 @@ func TestElectrumExchangeWallet(t *testing.T) {
 	case <-time.After(10 * time.Second): // a bit of best block polling
 		cancel()
 	case ni := <-notes:
-		cancel()
-		if n, is := ni.(*asset.AsyncWalletErrorNote); is {
-			t.Fatalf("Wallet sent an error: %v", n.Err)
+		if _, is := ni.(*asset.TipChangeNote); is {
+			cancel()
 		}
 
 	case <-ctx.Done(): // or until TipChange cancels the context

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -38,7 +38,7 @@ var tLogger dex.Logger
 
 type WalletConstructor func(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error)
 
-func tBackend(ctx context.Context, t *testing.T, cfg *Config, dir string, walletName *WalletName, blkFunc func(string, error)) *connectedWallet {
+func tBackend(ctx context.Context, t *testing.T, cfg *Config, dir string, walletName *WalletName, blkFunc func(string)) *connectedWallet {
 	t.Helper()
 	user, err := user.Current()
 	if err != nil {
@@ -88,11 +88,9 @@ func tBackend(ctx context.Context, t *testing.T, cfg *Config, dir string, wallet
 		for {
 			select {
 			case ni := <-notes:
-				switch n := ni.(type) {
+				switch ni.(type) {
 				case *asset.TipChangeNote:
-					blkFunc(reportName, nil)
-				case *asset.AsyncWalletErrorNote:
-					blkFunc(reportName, n.Err)
+					blkFunc(reportName)
 				}
 			case <-ctx.Done():
 				return
@@ -190,9 +188,9 @@ func Run(t *testing.T, cfg *Config) {
 	}
 
 	var blockReported uint32
-	blkFunc := func(name string, err error) {
+	blkFunc := func(name string) {
 		atomic.StoreUint32(&blockReported, 1)
-		tLogger.Infof("%s has reported a new block, error = %v", name, err)
+		tLogger.Infof("%s has reported a new block", name)
 	}
 
 	rig := &testRig{

--- a/client/asset/btc/livetest/livetest.go
+++ b/client/asset/btc/livetest/livetest.go
@@ -62,12 +62,11 @@ func tBackend(ctx context.Context, t *testing.T, cfg *Config, dir string, wallet
 
 	reportName := fmt.Sprintf("%s:%s-%s", cfg.Asset.Symbol, walletName.Node, walletName.Name)
 
+	notes := make(chan asset.WalletNotification, 1)
 	walletCfg := &asset.WalletConfig{
 		Type:     walletName.WalletType,
 		Settings: settings,
-		TipChange: func(err error) {
-			blkFunc(reportName, err)
-		},
+		Emit:     asset.NewWalletEmitter(notes, cfg.Asset.ID, tLogger),
 		PeersChange: func(num uint32, err error) {
 			fmt.Printf("peer count = %d, err = %v", num, err)
 		},
@@ -84,6 +83,22 @@ func tBackend(ctx context.Context, t *testing.T, cfg *Config, dir string, wallet
 	if err != nil {
 		t.Fatalf("error connecting backend: %v", err)
 	}
+
+	go func() {
+		for {
+			select {
+			case ni := <-notes:
+				switch n := ni.(type) {
+				case *asset.TipChangeNote:
+					blkFunc(reportName, nil)
+				case *asset.AsyncWalletErrorNote:
+					blkFunc(reportName, n.Err)
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 
 	return &connectedWallet{w, cm}
 }
@@ -213,18 +228,18 @@ func Run(t *testing.T, cfg *Config) {
 	defer rig.close()
 
 	// Unlocks a wallet for use.
-	unlock := func(w *connectedWallet) {
+	unlock := func(w *connectedWallet, name string) {
 		a, isAuthenticator := w.Wallet.(asset.Authenticator)
 		if isAuthenticator {
 			err := a.Unlock(walletPassword)
-			if err != nil {
-				t.Fatalf("error unlocking gamma wallet: %v", err)
+			if err != nil && !strings.Contains(err.Error(), "running with an unencrypted wallet, but walletpassphrase was called") {
+				t.Fatalf("error unlocking %s wallet: %v", name, err)
 			}
 		}
 	}
 
-	unlock(rig.firstWallet)
-	unlock(rig.secondWallet)
+	unlock(rig.firstWallet, cfg.FirstWallet.Name)
+	unlock(rig.secondWallet, cfg.SecondWallet.Name)
 
 	var lots uint64 = 2
 	contractValue := lots * cfg.LotSize
@@ -362,16 +377,16 @@ func Run(t *testing.T, cfg *Config) {
 
 	confCoin := receipts[0].Coin()
 	confContract := receipts[0].Contract()
-	checkConfs := func(n uint32, expSpent bool) {
+	checkConfs := func(minN uint32, expSpent bool) {
 		t.Helper()
 		confs, spent, err := rig.secondWallet.SwapConfirmations(context.Background(), confCoin.ID(), confContract, tStart)
 		if err != nil {
-			if n > 0 || !errors.Is(err, asset.CoinNotFoundError) {
-				t.Fatalf("error getting %d confs: %v", n, err)
+			if minN > 0 || !errors.Is(err, asset.CoinNotFoundError) {
+				t.Fatalf("error getting %d confs: %v", minN, err)
 			}
 		}
-		if confs != n {
-			t.Fatalf("expected %d confs, got %d", n, confs)
+		if confs < minN {
+			t.Fatalf("expected %d confs, got %d", minN, confs)
 		}
 		if spent != expSpent {
 			t.Fatalf("checkConfs: expected spent = %t, got %t", expSpent, spent)
@@ -423,7 +438,7 @@ func Run(t *testing.T, cfg *Config) {
 		if err != nil {
 			t.Fatalf("error getting confirmations: %v", err)
 		}
-		if confs != expConfs {
+		if confs < expConfs {
 			t.Fatalf("unexpected number of confirmations. wanted %d, got %d", expConfs, confs)
 		}
 		if spent {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -5566,7 +5566,7 @@ func (dcr *ExchangeWallet) monitorBlocks(ctx context.Context) {
 
 		newTip, err := dcr.getBestBlock(ctxInternal)
 		if err != nil {
-			dcr.emit.Errorf("failed to get best block: %w", err)
+			dcr.log.Errorf("failed to get best block: %w", err)
 			return
 		}
 
@@ -5637,7 +5637,7 @@ func (dcr *ExchangeWallet) monitorBlocks(ctx context.Context) {
 
 func (dcr *ExchangeWallet) handleTipChange(ctx context.Context, newTipHash *chainhash.Hash, newTipHeight int64, err error) {
 	if err != nil {
-		dcr.emit.Error(err)
+		dcr.log.Error(err)
 		return
 	}
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -143,8 +143,9 @@ func dummyTx() *wire.MsgTx {
 // case we replace the wallet.
 func tNewWalletMonitorBlocks(monitorBlocks bool) (*ExchangeWallet, *tRPCClient, func()) {
 	client := newTRPCClient()
+	log := tLogger.SubLogger("trpc")
 	walletCfg := &asset.WalletConfig{
-		TipChange:   func(error) {},
+		Emit:        asset.NewWalletEmitter(make(chan asset.WalletNotification, 128), BipID, log),
 		PeersChange: func(uint32, error) {},
 	}
 	walletCtx, shutdown := context.WithCancel(tCtx)
@@ -156,7 +157,7 @@ func tNewWalletMonitorBlocks(monitorBlocks bool) (*ExchangeWallet, *tRPCClient, 
 	}
 	wallet.wallet = &rpcWallet{
 		rpcClient: client,
-		log:       tLogger.SubLogger("trpc"),
+		log:       log,
 	}
 	wallet.ctx = walletCtx
 
@@ -519,7 +520,7 @@ func (c *tRPCClient) Disconnected() bool {
 }
 
 func (c *tRPCClient) GetStakeInfo(ctx context.Context) (*walletjson.GetStakeInfoResult, error) {
-	return nil, nil
+	return &walletjson.GetStakeInfoResult{}, nil
 }
 
 func (c *tRPCClient) PurchaseTicket(ctx context.Context, fromAccount string, spendLimit dcrutil.Amount, minConf *int,

--- a/client/asset/dcr/spv_test.go
+++ b/client/asset/dcr/spv_test.go
@@ -194,7 +194,7 @@ func (w *tDcrWallet) GetTransactionsByHashes(ctx context.Context, txHashes []*ch
 }
 
 func (w *tDcrWallet) StakeInfo(ctx context.Context) (*wallet.StakeInfoData, error) {
-	return nil, nil
+	return &wallet.StakeInfoData{}, nil
 }
 
 func (w *tDcrWallet) PurchaseTickets(context.Context, wallet.NetworkBackend, *wallet.PurchaseTicketsRequest) (*wallet.PurchaseTicketsResponse, error) {

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -3517,7 +3517,7 @@ func (eth *ETHWallet) checkForNewBlocks(ctx context.Context) {
 	defer cancel()
 	bestHdr, err := eth.node.bestHeader(ctx)
 	if err != nil {
-		eth.emit.Errorf("failed to get best hash: %w", err)
+		eth.log.Errorf("failed to get best hash: %w", err)
 		return
 	}
 	bestHash := bestHdr.Hash()

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -405,10 +405,10 @@ func TestCheckForNewBlocks(t *testing.T) {
 	header0 := &types.Header{Number: new(big.Int)}
 	header1 := &types.Header{Number: big.NewInt(1)}
 	tests := []struct {
-		name                  string
-		hashErr, blockErr     error
-		bestHeader            *types.Header
-		wantErr, hasTipChange bool
+		name              string
+		hashErr, blockErr error
+		bestHeader        *types.Header
+		hasTipChange      bool
 	}{{
 		name:         "ok",
 		bestHeader:   header1,
@@ -416,16 +416,9 @@ func TestCheckForNewBlocks(t *testing.T) {
 	}, {
 		name:       "ok same hash",
 		bestHeader: header0,
-	}, {
-		name:         "block error",
-		bestHeader:   header1,
-		hasTipChange: true,
-		blockErr:     errors.New(""),
-		wantErr:      true,
 	}}
 
 	for _, test := range tests {
-		var err error
 		ctx, cancel := context.WithCancel(context.Background())
 		node := &testNode{}
 		notes := make(chan asset.WalletNotification, 1)
@@ -452,22 +445,27 @@ func TestCheckForNewBlocks(t *testing.T) {
 		w.checkForNewBlocks(ctx)
 
 		if test.hasTipChange {
-			ni := <-notes
-			switch n := ni.(type) {
-			case *asset.AsyncWalletErrorNote:
-				err = n.Err
+		out:
+			for {
+				select {
+				case ni := <-notes:
+					switch n := ni.(type) {
+					case *asset.TipChangeNote:
+						if n.Tip != test.bestHeader.Number.Uint64() {
+							t.Fatalf("expected tip change but didn't get it")
+						}
+						break out
+					}
+				case <-time.After(time.Second * 5):
+					t.Fatal("timed out waiting for tip change")
+				}
+			}
+		} else {
+			if w.currentTip.Number.Cmp(test.bestHeader.Number) != 0 {
+				t.Fatalf("tip was changed. wasn't supposed to be changed")
 			}
 		}
 		cancel()
-		if test.wantErr {
-			if err == nil {
-				t.Fatalf("expected error for test %v", test.name)
-			}
-			continue
-		}
-		if err != nil {
-			t.Fatalf("unexpected error for test %v: %v", test.name, err)
-		}
 
 	}
 }

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -5,7 +5,6 @@ package asset
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"decred.org/dcrdex/dex"
@@ -1329,13 +1328,6 @@ type TipChangeNote struct {
 	Data    interface{} `json:"data"`
 }
 
-// AsyncWalletErrorNote is issued when the wallet detects it is in an error
-// state.
-type AsyncWalletErrorNote struct {
-	AssetID uint32 `json:"assetID"`
-	Err     error  `json:"err"`
-}
-
 // CustomWalletNote is any other information the wallet wishes to convey to
 // the user.
 type CustomWalletNote struct {
@@ -1371,16 +1363,6 @@ func (e *WalletEmitter) emit(note WalletNotification) {
 // Data sends a CustomWalletNote with the specified data payload.
 func (e *WalletEmitter) Data(payload interface{}) {
 	e.emit(&CustomWalletNote{AssetID: e.assetID, Payload: payload})
-}
-
-// Errorf formats and sends an AsyncWalletErrorNote.
-func (e *WalletEmitter) Errorf(s string, a ...interface{}) {
-	e.emit(&AsyncWalletErrorNote{AssetID: e.assetID, Err: fmt.Errorf(s, a...)})
-}
-
-// Error sends an AsyncWalletErrorNote.
-func (e *WalletEmitter) Error(err error) {
-	e.emit(&AsyncWalletErrorNote{AssetID: e.assetID, Err: err})
 }
 
 // TipChange sends a TipChangeNote with optional extra data.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -9411,8 +9411,6 @@ func (c *Core) handleWalletNotification(ni asset.WalletNotification) {
 	switch n := ni.(type) {
 	case *asset.TipChangeNote:
 		c.tipChange(n.AssetID)
-	case *asset.AsyncWalletErrorNote:
-		c.log.Errorf("%s wallet is reporting an asynchronous error: %v", unbip(n.AssetID), n.Err)
 	}
 	c.notify(newWalletNote(ni))
 }

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1460,6 +1460,8 @@ type Core struct {
 
 	pendingWalletsMtx sync.RWMutex
 	pendingWallets    map[uint32]bool
+
+	notes chan asset.WalletNotification
 }
 
 // New is the constructor for a new Core.
@@ -1570,6 +1572,8 @@ func New(cfg *Config) (*Core, error) {
 
 		fiatRateSources: make(map[string]*commonRateSource),
 		pendingWallets:  make(map[uint32]bool),
+
+		notes: make(chan asset.WalletNotification, 128),
 	}
 
 	// Populate the initial user data. User won't include any DEX info yet, as
@@ -1641,6 +1645,20 @@ func (c *Core) Run(ctx context.Context) {
 	go func() {
 		defer c.wg.Done()
 		c.watchBonds(ctx)
+	}()
+
+	// Handle wallet notifications.
+	c.wg.Add(1)
+	go func() {
+		defer c.wg.Done()
+		for {
+			select {
+			case n := <-c.notes:
+				c.handleWalletNotification(n)
+			case <-ctx.Done():
+				return
+			}
+		}
 	}()
 
 	c.wg.Wait() // block here until all goroutines except DB complete
@@ -2771,29 +2789,15 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 		}()
 	}
 
-	tipChange := func(err error) {
-		if c.ctx.Err() != nil {
-			return
-		}
-
-		c.wg.Add(1)
-		go func() {
-			defer c.wg.Done()
-			// asset.Wallet implementations should not need wait for the
-			// callback, as they don't know what it is, and will likely launch
-			// TipChange as a goroutine. However, guard against the possibility
-			// of deadlocking a Core method that calls Wallet.Disconnect.
-			c.tipChange(assetID, err)
-		}()
-	}
-
+	log := c.log.SubLogger(unbip(assetID))
 	var w asset.Wallet
 	var err error
 	if token == nil {
+
 		walletCfg := &asset.WalletConfig{
 			Type:        dbWallet.Type,
 			Settings:    dbWallet.Settings,
-			TipChange:   tipChange,
+			Emit:        asset.NewWalletEmitter(c.notes, assetID, log),
 			PeersChange: peersChange,
 			DataDir:     c.assetDataDirectory(assetID),
 		}
@@ -2802,8 +2806,7 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 			strconv.FormatBool(c.assetHasActiveOrders(dbWallet.AssetID))
 		defer delete(walletCfg.Settings, asset.SpecialSettingActivelyUsed)
 
-		logger := c.log.SubLogger(unbip(assetID))
-		w, err = asset.OpenWallet(assetID, walletCfg, logger, c.net)
+		w, err = asset.OpenWallet(assetID, walletCfg, log, c.net)
 	} else {
 		var found bool
 		parent, found = c.wallet(token.ParentID)
@@ -2819,7 +2822,7 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 		w, err = tokenMaster.OpenTokenWallet(&asset.TokenConfig{
 			AssetID:     assetID,
 			Settings:    dbWallet.Settings,
-			TipChange:   tipChange,
+			Emit:        asset.NewWalletEmitter(c.notes, assetID, log),
 			PeersChange: peersChange,
 		})
 	}
@@ -9399,19 +9402,25 @@ func (c *Core) peerChange(w *xcWallet, numPeers uint32, err error) {
 					db.WarningLevel, w.state()))
 			}
 		}
-
 		c.notify(newWalletStateNote(w.state()))
 	}
+}
+
+// handleWalletNotification processes an asynchronous wallet notification.
+func (c *Core) handleWalletNotification(ni asset.WalletNotification) {
+	switch n := ni.(type) {
+	case *asset.TipChangeNote:
+		c.tipChange(n.AssetID)
+	case *asset.AsyncWalletErrorNote:
+		c.log.Errorf("%s wallet is reporting an asynchronous error: %v", unbip(n.AssetID), n.Err)
+	}
+	c.notify(newWalletNote(ni))
 }
 
 // tipChange is called by a wallet backend when the tip block changes, or when
 // a connection error is encountered such that tip change reporting may be
 // adversely affected.
-func (c *Core) tipChange(assetID uint32, nodeErr error) {
-	if nodeErr != nil {
-		c.log.Errorf("%s wallet is reporting a failed state: %v", unbip(assetID), nodeErr)
-		return
-	}
+func (c *Core) tipChange(assetID uint32) {
 	c.log.Tracef("Processing tip change for %s", unbip(assetID))
 	c.waiterMtx.RLock()
 	for id, waiter := range c.blockWaiters {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1303,6 +1303,7 @@ func newTestRig() *testRig {
 			localePrinter: message.NewPrinter(language.AmericanEnglish),
 
 			fiatRateSources: make(map[string]*commonRateSource),
+			notes:           make(chan asset.WalletNotification, 128),
 		},
 		db:      tdb,
 		queue:   queue,
@@ -1960,7 +1961,7 @@ func TestRegister(t *testing.T) {
 					tCore.waiterMtx.Unlock()
 					if waiterCount > 0 { // when verifyRegistrationFee adds a waiter, then we can trigger tip change
 						tWallet.setConfs(tWallet.sendCoin.id, 0, nil) // 0 ????
-						tCore.tipChange(tUTXOAssetA.ID, nil)
+						tCore.tipChange(tUTXOAssetA.ID)
 						return
 					}
 				case <-timeout.C:

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/comms"
 	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
@@ -35,6 +36,7 @@ const (
 	NoteTypeFiatRates    = "fiatrateupdate"
 	NoteTypeCreateWallet = "createwallet"
 	NoteTypeLogin        = "login"
+	NoteTypeWalletNote   = "walletnote"
 )
 
 var noteChanCounter uint64
@@ -645,5 +647,20 @@ const TopicLoginStatus Topic = "LoginStatus"
 func newLoginNote(message string) *LoginNote {
 	return &LoginNote{
 		Notification: db.NewNotification(NoteTypeLogin, TopicLoginStatus, "", message, db.Data),
+	}
+}
+
+// WalletNote is a notification originating from a wallet.
+type WalletNote struct {
+	db.Notification
+	Payload asset.WalletNotification `json:"payload"`
+}
+
+const TopicWalletNotification Topic = "WalletNotification"
+
+func newWalletNote(n asset.WalletNotification) *WalletNote {
+	return &WalletNote{
+		Notification: db.NewNotification(NoteTypeWalletNote, TopicWalletNotification, "", "", db.Data),
+		Payload:      n,
 	}
 }


### PR DESCRIPTION
Gives wallets a way to issue asynchronous notifications. Replaces the `TipChange` function. These notifications are sent to the front end, but are not used yet. This will help solve some issues that were raised in #2482, but it's also just a better pattern than the tip change function and should enable more up-to-date information on the front end.