### PR TITLE
client/asset: Add WalletHistorian interface and RPC method 

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -188,7 +188,7 @@ func DetermineWalletTraits(w Wallet) (t WalletTrait) {
 	if _, is := w.(TicketBuyer); is {
 		t |= WalletTraitTicketBuyer
 	}
-	if _, is := w.(TicketBuyer); is {
+	if _, is := w.(WalletHistorian); is {
 		t |= WalletTraitHistorian
 	}
 	return t
@@ -1027,15 +1027,17 @@ type TicketBuyer interface {
 	TicketPage(scanStart int32, n, skipN int) ([]*Ticket, error)
 }
 
-// TransactionType is type type of transaction made by a wallet.
+// TransactionType is the type of transaction made by a wallet.
 type TransactionType uint16
 
 const (
-	Send TransactionType = iota
+	Unknown TransactionType = iota
+	Send
 	Receive
 	Swap
 	Redeem
 	Refund
+	Split
 	CreateBond
 	RedeemBond
 	ApproveToken
@@ -1044,13 +1046,14 @@ const (
 
 // WalletTransaction represents a transaction that was made by a wallet.
 type WalletTransaction struct {
-	Type           TransactionType `json:"type"`
-	ID             dex.Bytes       `json:"id"`
-	AmtIn          uint64          `json:"amtIn"`
-	AmtOut         uint64          `json:"amtOut"`
-	Fees           uint64          `json:"fees"`
-	BlockNumber    uint64          `json:"blockNumber"`
-	UpdatedBalance uint64          `json:"updatedBalance"`
+	Type TransactionType `json:"type"`
+	ID   dex.Bytes       `json:"id"`
+	// BalanceDelta is the amount the wallet balance changed as a result of
+	// the transaction, excluding fees.
+	BalanceDelta int64  `json:"balanceDelta"`
+	Fees         uint64 `json:"fees"`
+	// BlockNumber is 0 for txs in the mempool.
+	BlockNumber uint64 `json:"blockNumber"`
 	// AdditionalData contains asset specific information, i.e. nonce
 	// for ETH.
 	AdditionalData map[string]string `json:"additionalData"`

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -33,6 +33,7 @@ const (
 	WalletTraitTokenApprover                          // The wallet is a TokenApprover
 	WalletTraitAccountLocker                          // The wallet must have enough balance for redemptions before a trade.
 	WalletTraitTicketBuyer                            // The wallet can participate in decred staking.
+	WalletTraitHistorian                              // This wallet can return its transaction history
 )
 
 // IsRescanner tests if the WalletTrait has the WalletTraitRescanner bit set.
@@ -131,6 +132,12 @@ func (wt WalletTrait) IsTicketBuyer() bool {
 	return wt&WalletTraitTicketBuyer != 0
 }
 
+// IsHistorian tests if the WalletTrait has the WalletTraitHistorian bit set,
+// which indicates the wallet implements the WalletHistorian interface.
+func (wt WalletTrait) IsHistorian() bool {
+	return wt&WalletTraitHistorian != 0
+}
+
 // DetermineWalletTraits returns the WalletTrait bitset for the provided Wallet.
 func DetermineWalletTraits(w Wallet) (t WalletTrait) {
 	if _, is := w.(Rescanner); is {
@@ -180,6 +187,9 @@ func DetermineWalletTraits(w Wallet) (t WalletTrait) {
 	}
 	if _, is := w.(TicketBuyer); is {
 		t |= WalletTraitTicketBuyer
+	}
+	if _, is := w.(TicketBuyer); is {
+		t |= WalletTraitHistorian
 	}
 	return t
 }
@@ -1015,6 +1025,47 @@ type TicketBuyer interface {
 	// starting at scanStart and going to progressively lower blocks. scanStart
 	// can be set to -1 to indicate the current chain tip.
 	TicketPage(scanStart int32, n, skipN int) ([]*Ticket, error)
+}
+
+// TransactionType is type type of transaction made by a wallet.
+type TransactionType uint16
+
+const (
+	Send TransactionType = iota
+	Receive
+	Swap
+	Redeem
+	Refund
+	CreateBond
+	RedeemBond
+	ApproveToken
+	Acceleration
+)
+
+// WalletTransaction represents a transaction that was made by a wallet.
+type WalletTransaction struct {
+	Type           TransactionType `json:"type"`
+	ID             dex.Bytes       `json:"id"`
+	AmtIn          uint64          `json:"amtIn"`
+	AmtOut         uint64          `json:"amtOut"`
+	Fees           uint64          `json:"fees"`
+	BlockNumber    uint64          `json:"blockNumber"`
+	UpdatedBalance uint64          `json:"updatedBalance"`
+	// AdditionalData contains asset specific information, i.e. nonce
+	// for ETH.
+	AdditionalData map[string]string `json:"additionalData"`
+}
+
+// WalletHistorian is a wallet that is able to retrieve the history of all
+// transactions it has made.
+type WalletHistorian interface {
+	// TxHistory returns all the transactions a wallet has made. If refID
+	// is nil, then transactions starting from the most recent are returned
+	// (past is ignored). If past is true, the transactions prior to the
+	// refID are returned, otherwise the transactions after the refID are
+	// returned. n is the number of transactions to return. If n is <= 0,
+	// all the transactions will be returned.
+	TxHistory(n int, refID *dex.Bytes, past bool) ([]*WalletTransaction, error)
 }
 
 // Bond is the fidelity bond info generated for a certain account ID, amount,

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -5769,6 +5769,21 @@ func (c *Core) MultiTrade(pw []byte, form *MultiTradeForm) ([]*Order, error) {
 	return orders, nil
 }
 
+// TxHistory returns all the transactions a wallet has made. If refID
+// is nil, then transactions starting from the most recent are returned
+// (past is ignored). If past is true, the transactions prior to the
+// refID are returned, otherwise the transactions after the refID are
+// returned. n is the number of transactions to return. If n is <= 0,
+// all the transactions will be returned
+func (c *Core) TxHistory(assetID uint32, n int, refID *dex.Bytes, past bool) ([]*asset.WalletTransaction, error) {
+	wallet, found := c.wallet(assetID)
+	if !found {
+		return nil, newError(missingWalletErr, "no wallet found for %s", unbip(assetID))
+	}
+
+	return wallet.TxHistory(n, refID, past)
+}
+
 // Trade is used to place a market or limit order.
 func (c *Core) Trade(pw []byte, form *TradeForm) (*Order, error) {
 	req, err := c.prepareTradeRequest(pw, form)

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -533,6 +533,25 @@ func (w *xcWallet) swapConfirmations(ctx context.Context, coinID []byte, contrac
 	return w.Wallet.SwapConfirmations(ctx, coinID, contract, time.UnixMilli(int64(matchTime)))
 }
 
+// TxHistory returns all the transactions a wallet has made. If refID
+// is nil, then transactions starting from the most recent are returned
+// (past is ignored). If past is true, the transactions prior to the
+// refID are returned, otherwise the transactions after the refID are
+// returned. n is the number of transactions to return. If n is <= 0,
+// all the transactions will be returned.
+func (w *xcWallet) TxHistory(n int, refID *dex.Bytes, past bool) ([]*asset.WalletTransaction, error) {
+	if !w.connected() {
+		return nil, errWalletNotConnected
+	}
+
+	historian, ok := w.Wallet.(asset.WalletHistorian)
+	if !ok {
+		return nil, fmt.Errorf("wallet does not support transaction history")
+	}
+
+	return historian.TxHistory(n, refID, past)
+}
+
 // MakeBondTx authors a DEX time-locked fidelity bond transaction if the
 // asset.Wallet implementation is a Bonder.
 func (w *xcWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Time, priv *secp256k1.PrivateKey, acctID []byte) (*asset.Bond, func(), error) {

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -85,6 +85,7 @@ type clientCore interface {
 	RemoveWalletPeer(assetID uint32, host string) error
 	Notifications(int) ([]*db.Notification, error)
 	MultiTrade(pw []byte, form *core.MultiTradeForm) ([]*core.Order, error)
+	TxHistory(assetID uint32, n int, refID *dex.Bytes, past bool) ([]*asset.WalletTransaction, error)
 
 	// These are core's ticket buying interface.
 	StakeStatus(assetID uint32) (*asset.TicketStakingStatus, error)

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -201,6 +201,9 @@ func (c *TCore) StakeStatus(assetID uint32) (*asset.TicketStakingStatus, error) 
 func (c *TCore) SetVotingPreferences(assetID uint32, choices, tSpendPolicy, treasuryPolicy map[string]string) error {
 	return c.setVotingPrefErr
 }
+func (c *TCore) TxHistory(assetID uint32, n int, refID *dex.Bytes, past bool) ([]*asset.WalletTransaction, error) {
+	return nil, nil
+}
 
 type tBookFeed struct{}
 

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -93,6 +93,7 @@ const (
 	RPCPurchaseTicketsError              // 75
 	RPCStakeStatusError                  // 76
 	RPCSetVotingPreferencesError         // 77
+	RPCTxHistoryError                    // 78
 )
 
 // Routes are destinations for a "payload" of data. The type of data being


### PR DESCRIPTION
This adds a `WalletHistorian` interface which exposes a `TxHistory`
function. This will allow wallets to display the history of their
transactions. Also adds a method to the RPC server to retrieve the
wallet history.
