### PR TITLE
multi: v2 reputation and client bond refactor

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1747,7 +1747,9 @@ func (btc *baseWallet) feeRate(confTarget uint64) (uint64, error) {
 	// may use btc.fallbackFeeRate(), as in targetFeeRateWithFallback.
 	feeRate, err = btc.externalFeeRate(btc.ctx, btc.Network) // e.g. externalFeeEstimator
 	if err != nil {
-		btc.log.Errorf("Failed to get fee rate from external API: %v", err)
+		if btc.cloneParams.Network != dex.Simnet {
+			btc.log.Errorf("Failed to get fee rate from external API: %v", err)
+		}
 		return 0, err
 	}
 	if feeRate <= 0 || feeRate > btc.feeRateLimit() { // but fetcher shouldn't return <= 0 without error

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -914,22 +914,7 @@ type baseWallet struct {
 	findRedemptionMtx   sync.RWMutex
 	findRedemptionQueue map[outPoint]*findRedemptionReq
 
-	reservesMtx sync.RWMutex // frequent reads for balance, infrequent updates
-	// bondReservesEnforced is used to reserve unspent amounts for upcoming bond
-	// transactions, including projected transaction fees, and does not include
-	// amounts that are currently locked in unspent bonds, which are in
-	// bondReservesUsed. When bonds are created, bondReservesEnforced is
-	// decremented and bondReservesUsed are incremented; when bonds are
-	// refunded, the reverse. bondReservesEnforced may become negative during
-	// the unbonding process.
-	bondReservesEnforced int64  // set by ReserveBondFunds, modified by bondSpent and bondLocked
-	bondReservesUsed     uint64 // set by RegisterUnspent, modified by bondSpent and bondLocked
-	// When bondReservesEnforced is non-zero, bondReservesNominal is the
-	// cumulative of all ReserveBondFunds and RegisterUnspent input amounts,
-	// with no fee padding. It includes the future and live (currently unspent)
-	// bond amounts. This amount only changes via ReserveBondFunds, and it is
-	// used to recognize when all reserves have been released.
-	bondReservesNominal int64 // only set by ReserveBondFunds
+	bondReserves atomic.Uint64
 
 	recycledAddrMtx sync.Mutex
 	// recycledAddrs are returned, unused redemption addresses. We track these
@@ -1669,8 +1654,10 @@ func (btc *baseWallet) Balance() (*asset.Balance, error) {
 		return nil, err
 	}
 
-	reserves := btc.reserves()
+	reserves := btc.bondReserves.Load()
 	if reserves > bal.Available {
+		// TODO: Send wallet notification.
+		// https://github.com/decred/dcrdex/pull/2492
 		btc.log.Warnf("Available balance is below configured reserves: %f < %f",
 			toBTC(bal.Available), toBTC(reserves))
 		bal.ReservesDeficit = reserves - bal.Available
@@ -2117,7 +2104,7 @@ func (btc *baseWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate uin
 	for _, utxo := range utxos {
 		avail += utxo.amount
 	}
-	reserves := btc.reserves()
+	reserves := btc.bondReserves.Load()
 
 	// If there is a fee bump, the networkFeeRate can be higher than the
 	// MaxFeeRate
@@ -2330,7 +2317,7 @@ func (btc *baseWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, ui
 		useSplit = *customCfg.Split
 	}
 
-	reserves := btc.reserves()
+	reserves := btc.bondReserves.Load()
 	minConfs := uint32(0)
 	coins, fundingCoins, spents, redeemScripts, inputsSize, sum, err := btc.fund(reserves, minConfs, true,
 		orderEnough(ord.Value, ord.MaxSwapCount, bumpedMaxRate, btc.initTxSizeBase, btc.initTxSize, btc.segwit, useSplit))
@@ -2869,7 +2856,7 @@ func (btc *baseWallet) fundMulti(maxLock uint64, values []*asset.MultiOrderValue
 	btc.fundingMtx.Lock()
 	defer btc.fundingMtx.Unlock()
 
-	reserves := btc.reserves()
+	reserves := btc.bondReserves.Load()
 
 	coins, redeemScripts, fundingCoins, spents, err := btc.fundMultiBestEffort(reserves, maxLock, values, maxFeeRate, allowSplit)
 	if err != nil {
@@ -3552,7 +3539,7 @@ func (btc *baseWallet) signedAccelerationTx(previousTxs []*GetTransactionResult,
 			return totalReq <= totalVal, totalVal - totalReq
 		}
 		minConfs := uint32(1)
-		additionalInputs, _, _, _, _, _, err = btc.fundInternal(btc.reserves(), minConfs, false, enough)
+		additionalInputs, _, _, _, _, _, err = btc.fundInternal(btc.bondReserves.Load(), minConfs, false, enough)
 		if err != nil {
 			return makeError(fmt.Errorf("failed to fund acceleration tx: %w", err))
 		}
@@ -4971,7 +4958,7 @@ func (btc *baseWallet) send(address string, val uint64, feeRate uint64, subtract
 
 	enough := sendEnough(val, feeRate, subtract, uint64(baseSize), btc.segwit, true)
 	minConfs := uint32(0)
-	coins, _, _, _, inputsSize, _, err := btc.fundInternal(btc.reserves(), minConfs, false, enough)
+	coins, _, _, _, inputsSize, _, err := btc.fundInternal(btc.bondReserves.Load(), minConfs, false, enough)
 	if err != nil {
 		return nil, 0, 0, fmt.Errorf("error funding transaction: %w", err)
 	}
@@ -5603,196 +5590,8 @@ func (btc *intermediaryWallet) EstimateSendTxFee(address string, sendAmount, fee
 	return fee, isValidAddress, nil
 }
 
-func (btc *baseWallet) reserves() uint64 {
-	btc.reservesMtx.RLock()
-	defer btc.reservesMtx.RUnlock()
-	if r := btc.bondReservesEnforced; r > 0 {
-		return uint64(r)
-	}
-	if btc.bondReservesNominal == 0 { // disabled
-		return 0
-	}
-	// When enforced is negative, we're unbonding. If nominal is still positive,
-	// we're partially unbonding and we need to report the remaining reserves
-	// after excess is unbonded, offsetting the negative enforced amount. This
-	// is the relatively small fee buffer.
-	if int64(btc.bondReservesUsed) == btc.bondReservesNominal {
-		return uint64(-btc.bondReservesEnforced)
-	}
-
-	return 0
-}
-
-// bondLocked reduces reserves, increases bonded (used) amount.
-func (btc *baseWallet) bondLocked(amt uint64) (reserved int64, unspent uint64) {
-	btc.reservesMtx.Lock()
-	defer btc.reservesMtx.Unlock()
-	e0 := btc.bondReservesEnforced
-	btc.bondReservesEnforced -= int64(amt)
-	btc.bondReservesUsed += amt
-	btc.log.Tracef("bondLocked (%v): enforced %v ==> %v (with bonded = %v / nominal = %v)",
-		toBTC(amt), toBTC(e0), toBTC(btc.bondReservesEnforced),
-		toBTC(btc.bondReservesUsed), toBTC(btc.bondReservesNominal))
-	return btc.bondReservesEnforced, btc.bondReservesUsed
-}
-
-// bondSpent increases enforce reserves, decreases bonded amount. When the
-// tracked unspent amount is reduced to zero, this clears the enforced amount
-// (just the remaining fee buffer).
-func (btc *baseWallet) bondSpent(amt uint64) (reserved int64, unspent uint64) {
-	btc.reservesMtx.Lock()
-	defer btc.reservesMtx.Unlock()
-
-	if amt <= btc.bondReservesUsed {
-		btc.bondReservesUsed -= amt
-	} else {
-		btc.log.Errorf("bondSpent: live bonds accounting error, spending bond worth %v with %v known live (zeroing!)",
-			amt, btc.bondReservesUsed)
-		btc.bondReservesUsed = 0
-	}
-
-	if btc.bondReservesNominal == 0 { // disabled
-		return btc.bondReservesEnforced, btc.bondReservesUsed // return 0, ...
-	}
-
-	e0 := btc.bondReservesEnforced
-	btc.bondReservesEnforced += int64(amt)
-
-	btc.log.Tracef("bondSpent (%v): enforced %v ==> %v (with bonded = %v / nominal = %v)",
-		toBTC(amt), toBTC(e0), toBTC(btc.bondReservesEnforced),
-		toBTC(btc.bondReservesUsed), toBTC(btc.bondReservesNominal))
-	return btc.bondReservesEnforced, btc.bondReservesUsed
-}
-
-// RegisterUnspent should be called once for every configured DEX with existing
-// unspent bond amounts, prior to login, which is when reserves for future bonds
-// are then added given the actual account tier, target tier, and this combined
-// existing bonds amount. This must be used before ReserveBondFunds, which
-// begins reserves enforcement provided a future amount that may be required
-// before the existing bonds are refunded. No reserves enforcement is enabled
-// until ReserveBondFunds is called, even with a future value of 0. A wallet
-// that is not enforcing reserves, but which has unspent bonds should use this
-// method to facilitate switching to the wallet for bonds in future.
-func (btc *baseWallet) RegisterUnspent(inBonds uint64) {
-	btc.reservesMtx.Lock()
-	defer btc.reservesMtx.Unlock()
-	btc.log.Tracef("RegisterUnspent(%v) changing unspent in bonds: %v => %v",
-		toBTC(inBonds), toBTC(btc.bondReservesUsed), toBTC(btc.bondReservesUsed+inBonds))
-	btc.bondReservesUsed += inBonds
-	// This method should be called before ReserveBondFunds, prior to login on
-	// application initialization (if there are existing for this asset bonds).
-	// The nominal counter is not modified until ReserveBondFunds is called.
-	if btc.bondReservesNominal != 0 {
-		btc.log.Warnf("BUG: RegisterUnspent called with existing nominal reserves of %v BTC",
-			toBTC(btc.bondReservesNominal))
-	}
-}
-
-// ReserveBondFunds increases the bond reserves to accommodate a certain nominal
-// amount of future bonds, or reduces the amount if a negative value is
-// provided. If indicated, updating the reserves will require sufficient
-// available balance, otherwise reserves will be adjusted regardless and the
-// funds are pre-reserved. This returns false if the available balance was
-// insufficient iff the caller requested it be respected, otherwise it always
-// returns true (success). The fee buffer is used only when enabling the
-// reserves (when starting from zero) to compute the fee buffer. It may also be
-// zero, in which case the wallet will attempt to obtain it's own estimate.
-//
-// The reserves enabled with this method are enforced when funding transactions
-// (e.g. regular withdraws/sends or funding orders), and deducted from available
-// balance. Amounts may be reserved beyond the available balance, but only the
-// amount that is offset by the available balance is reflected in the locked
-// balance category. Like funds locked in swap contracts, the caller must
-// supplement balance reporting with known bond amounts. However, via
-// RegisterUnspent, the wallet is made aware of pre-existing unspent bond
-// amounts (cumulative) that will eventually be spent with RefundBond.
-//
-// If this wallet is enforcing reserves (this method has been called, even with
-// a future value of zero), when new bonds are created the nominal bond amount
-// is deducted from the enforced reserves; when bonds are spent with RefundBond,
-// the nominal bond amount is added back into the enforced reserves. That is,
-// when there are no active bonds, the locked balance category will reflect the
-// entire amount requested with ReserveBondFunds (plus a fee buffer, see below),
-// and when bonds are created with MakeBondTx, the locked amount decreases since
-// that portion of the reserves are now held in inaccessible UTXOs, the amounts
-// of which the caller tracks independently. When spent with RefundBond, that
-// same *nominal* bond value is added back to the enforced reserves amount.
-//
-// The amounts requested for bond reserves should be the nominal amounts of the
-// bonds, but the reserved amount reflected in the locked balance category will
-// include a considerable buffer for transaction fees. Therefore when the full
-// amount of the reserves are presently locked in unspent bonds, the locked
-// balance will include this fee buffer while the wallet is enforcing reserves.
-//
-// Until this method is called, reserves enforcement is disabled, and any
-// unspent bonds registered with RegisterUnspent do not go into the enforced
-// reserves when spent. In this way, all Bonder wallets remain aware of the
-// total nominal value of unspent bonds even if the wallet is not presently
-// being used to maintain a target bonding amount that necessitates reserves
-// enforcement.
-//
-// A negative value may be provided to reduce allocated reserves. When the
-// amount is reduced by the same amount it was previously increased by both
-// ReserveBondFunds and RegisterUnspent, reserves enforcement including fee
-// padding is disabled. Consider the following example: on startup, .2 BTC of
-// existing unspent bonds are registered via RegisterUnspent, then on login and
-// auth with the relevant DEX host, .4 BTC of future bond reserves are requested
-// with ReserveBondFunds to maintain a configured target tier given the current
-// tier and amounts of the existing unspent bonds. To disable reserves, the
-// client would call ReserveBondFunds with -.6 BTC, which the wallet's internal
-// accounting recognizes as complete removal of the reserves.
-func (btc *baseWallet) ReserveBondFunds(future int64, feeBuffer uint64, respectBalance bool) bool {
-	btc.reservesMtx.Lock()
-	defer btc.reservesMtx.Unlock()
-
-	defer func(enforced0, used0, nominal0 int64) {
-		btc.log.Tracef("ReserveBondFunds(%v, %v): enforced = %v / bonded = %v / nominal = %v "+
-			" ==>  enforced = %v / bonded = %v / nominal = %v",
-			toBTC(future), respectBalance,
-			toBTC(enforced0), toBTC(used0), toBTC(nominal0),
-			toBTC(btc.bondReservesEnforced), toBTC(btc.bondReservesUsed), toBTC(uint64(btc.bondReservesNominal)))
-	}(btc.bondReservesEnforced, int64(btc.bondReservesUsed), btc.bondReservesNominal)
-
-	enforcedDelta := future
-
-	// For the reserves initialization, add the fee buffer.
-	if btc.bondReservesNominal == 0 { // enabling, add a fee buffer
-		if feeBuffer == 0 {
-			feeRate := 2 * btc.targetFeeRateWithFallback(1, 0)
-			feeBuffer = bondsFeeBuffer(btc.segwit, feeRate)
-		}
-		enforcedDelta += int64(feeBuffer)
-	}
-
-	// How much of that is covered by the available balance, when increasing
-	// reserves.
-	if respectBalance && future > 0 {
-		bal, err := btc.balance()
-		if err != nil {
-			btc.log.Errorf("Failed to retrieve balance: %v")
-			return false
-		}
-		if int64(bal.Available) < btc.bondReservesEnforced+enforcedDelta {
-			return false
-		}
-	}
-
-	if btc.bondReservesNominal == 0 { // enabling, add any previously-registered unspent
-		btc.log.Debugf("Re-enabling reserves with %v in existing unspent bonds (added to nominal).", toBTC(btc.bondReservesUsed))
-		btc.bondReservesNominal += int64(btc.bondReservesUsed)
-	}
-	btc.bondReservesNominal += future
-	btc.bondReservesEnforced += enforcedDelta
-
-	// When disabling/zeroing reserves, wipe the fee buffer too. If there are
-	// unspent bonds, this will be done in bondSpent when the last one is spent.
-	if btc.bondReservesNominal <= 0 { // nominal should not go negative though
-		btc.log.Infof("Nominal reserves depleted -- clearing enforced reserves!")
-		btc.bondReservesEnforced = 0
-		btc.bondReservesNominal = 0
-	}
-
-	return true
+func (btc *baseWallet) SetBondReserves(reserves uint64) {
+	btc.bondReserves.Store(reserves)
 }
 
 // MakeBondTx creates a time-locked fidelity bond transaction. The V0
@@ -5891,17 +5690,7 @@ func (btc *baseWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time
 		return nil, nil, fmt.Errorf("failed to fund bond tx: %w", err)
 	}
 
-	// Reduce the reserves counter now that utxos are explicitly allocated. When
-	// the bond is refunded and we pay back into our wallet, we will increase
-	// the reserves counter.
-	newReserves, unspent := btc.bondLocked(amt) // nominal, not spent amount
-	btc.log.Debugf("New bond reserves (new post) = %f BTC with %f in unspent bonds",
-		toBTC(newReserves), toBTC(unspent)) // decrement and report new
-
 	abandon := func() { // if caller does not broadcast, or we fail in this method
-		newReserves, unspent = btc.bondSpent(amt)
-		btc.log.Debugf("New bond reserves (abandoned post) = %f BTC with %f in unspent bonds",
-			toBTC(newReserves), toBTC(unspent)) // increment/restore and report new
 		err := btc.ReturnCoins(coins)
 		if err != nil {
 			btc.log.Errorf("error returning coins for unused bond tx: %v", coins)
@@ -6059,15 +5848,8 @@ func (btc *baseWallet) RefundBond(ctx context.Context, ver uint16, coinID, scrip
 		return nil, err
 	}
 
-	newReserves, unspent := btc.bondSpent(amt)
-	btc.log.Debugf("New bond reserves (new refund of %f BTC) = %f BTC with %f in unspent bonds",
-		toBTC(amt), toBTC(newReserves), toBTC(unspent))
-
 	_, err = btc.node.sendRawTransaction(msgTx)
 	if err != nil {
-		newReserves, unspent = btc.bondLocked(amt) // assume it didn't really send :/
-		btc.log.Debugf("New bond reserves (failed refund broadcast) = %f BTC with %f in unspent bonds",
-			toBTC(newReserves), toBTC(unspent)) // increment/restore and report new
 		return nil, fmt.Errorf("error sending refund bond transaction: %w", err)
 	}
 

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1656,8 +1656,6 @@ func (btc *baseWallet) Balance() (*asset.Balance, error) {
 
 	reserves := btc.bondReserves.Load()
 	if reserves > bal.Available {
-		// TODO: Send wallet notification.
-		// https://github.com/decred/dcrdex/pull/2492
 		btc.log.Warnf("Available balance is below configured reserves: %f < %f",
 			toBTC(bal.Available), toBTC(reserves))
 		bal.ReservesDeficit = reserves - bal.Available

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -617,24 +617,8 @@ type vsp struct {
 // client app communicates with the Decred blockchain and wallet. ExchangeWallet
 // satisfies the dex.Wallet interface.
 type ExchangeWallet struct {
-	reservesMtx sync.RWMutex // frequent reads for balance, infrequent updates
-	// bondReservesEnforced is used to reserve unspent amounts for upcoming bond
-	// transactions, including projected transaction fees, and does not include
-	// amounts that are currently locked in unspent bonds, which are in
-	// bondReservesUsed. When bonds are created, bondReservesEnforced is
-	// decremented and bondReservesUsed are incremented; when bonds are
-	// refunded, the reverse. bondReservesEnforced may become negative during
-	// the unbonding process.
-	bondReservesEnforced int64  // set by ReserveBondFunds, modified by bondSpent and bondLocked
-	bondReservesUsed     uint64 // set by RegisterUnspent, modified by bondSpent and bondLocked
-	// When bondReservesEnforced is non-zero, bondReservesNominal is the
-	// cumulative of all ReserveBondFunds and RegisterUnspent input amounts,
-	// with no fee padding. It includes the future and live (currently unspent)
-	// bond amounts. This amount only changes via ReserveBondFunds, and it is
-	// used to recognize when all reserves have been released.
-	bondReservesNominal int64 // only set by ReserveBondFunds
-
-	cfgV atomic.Value // *exchangeWalletConfig
+	bondReserves atomic.Uint64
+	cfgV         atomic.Value // *exchangeWalletConfig
 
 	ctx           context.Context // the asset subsystem starts with Connect(ctx)
 	wallet        Wallet
@@ -677,69 +661,6 @@ type ExchangeWallet struct {
 
 func (dcr *ExchangeWallet) config() *exchangeWalletConfig {
 	return dcr.cfgV.Load().(*exchangeWalletConfig)
-}
-
-// reserves returns the total non-negative amount reserved to inform balance
-// reporting and transaction funding.
-func (dcr *ExchangeWallet) reserves() uint64 {
-	dcr.reservesMtx.RLock()
-	defer dcr.reservesMtx.RUnlock()
-	if r := dcr.bondReservesEnforced; r > 0 {
-		return uint64(r)
-	}
-	if dcr.bondReservesNominal == 0 { // disabled
-		return 0
-	}
-	// When enforced is negative, we're unbonding. If nominal is still positive,
-	// we're partially unbonding and we need to report the remaining reserves
-	// after excess is unbonded, offsetting the negative enforced amount. This
-	// is the relatively small fee buffer.
-	if int64(dcr.bondReservesUsed) == dcr.bondReservesNominal {
-		return uint64(-dcr.bondReservesEnforced)
-	}
-
-	return 0
-}
-
-// bondLocked reduces reserves, increases bonded (used) amount.
-func (dcr *ExchangeWallet) bondLocked(amt uint64) (reserved int64, unspent uint64) {
-	dcr.reservesMtx.Lock()
-	defer dcr.reservesMtx.Unlock()
-	e0 := dcr.bondReservesEnforced
-	dcr.bondReservesEnforced -= int64(amt)
-	dcr.bondReservesUsed += amt
-	dcr.log.Tracef("bondLocked (%v): enforced %v ==> %v (with bonded = %v / nominal = %v)",
-		toDCR(amt), toDCR(e0), toDCR(dcr.bondReservesEnforced),
-		toDCR(dcr.bondReservesUsed), toDCR(dcr.bondReservesNominal))
-	return dcr.bondReservesEnforced, dcr.bondReservesUsed
-}
-
-// bondSpent increases enforce reserves, decreases bonded amount. When the
-// tracked unspent amount is reduced to zero, this clears the enforced amount
-// (just the remaining fee buffer).
-func (dcr *ExchangeWallet) bondSpent(amt uint64) (reserved int64, unspent uint64) {
-	dcr.reservesMtx.Lock()
-	defer dcr.reservesMtx.Unlock()
-
-	if amt <= dcr.bondReservesUsed {
-		dcr.bondReservesUsed -= amt
-	} else {
-		dcr.log.Errorf("bondSpent: live bonds accounting error, spending bond worth %v with %v known live (zeroing!)",
-			amt, dcr.bondReservesUsed)
-		dcr.bondReservesUsed = 0
-	}
-
-	if dcr.bondReservesNominal == 0 { // disabled
-		return dcr.bondReservesEnforced, dcr.bondReservesUsed // return 0, ...
-	}
-
-	e0 := dcr.bondReservesEnforced
-	dcr.bondReservesEnforced += int64(amt)
-
-	dcr.log.Tracef("bondSpent (%v): enforced %v ==> %v (with bonded = %v / nominal = %v)",
-		toDCR(amt), toDCR(e0), toDCR(dcr.bondReservesEnforced),
-		toDCR(dcr.bondReservesUsed), toDCR(dcr.bondReservesNominal))
-	return dcr.bondReservesEnforced, dcr.bondReservesUsed
 }
 
 // Check that ExchangeWallet satisfies the Wallet interface.
@@ -1060,17 +981,18 @@ func (dcr *ExchangeWallet) Reconfigure(ctx context.Context, cfg *asset.WalletCon
 	if err != nil {
 		return false, err
 	}
+	dcr.cfgV.Store(exchangeWalletCfg)
+	// DRAFT TODO: Caller should re-reserve after reconfig.
+	// if oldCfg.feeRateLimit != exchangeWalletCfg.feeRateLimit {
+	// 	// Adjust the bond reserves fee buffer, if enforcing.
+	// 	dcr.reservesMtx.Lock()
+	// 	if dcr.bondReservesNominal != 0 {
 
-	oldCfg := dcr.cfgV.Swap(exchangeWalletCfg).(*exchangeWalletConfig)
-	if oldCfg.feeRateLimit != exchangeWalletCfg.feeRateLimit {
-		// Adjust the bond reserves fee buffer, if enforcing.
-		dcr.reservesMtx.Lock()
-		if dcr.bondReservesNominal != 0 {
-			dcr.bondReservesEnforced += int64(bondsFeeBuffer(exchangeWalletCfg.feeRateLimit)) -
-				int64(bondsFeeBuffer(oldCfg.feeRateLimit))
-		}
-		dcr.reservesMtx.Unlock()
-	}
+	// 		dcr.bondReservesEnforced += int64(bondsFeeBuffer(exchangeWalletCfg.feeRateLimit)) -
+	// 			int64(bondsFeeBuffer(oldCfg.feeRateLimit))
+	// 	}
+	// 	dcr.reservesMtx.Unlock()
+	// }
 
 	return false, nil
 }
@@ -1170,8 +1092,10 @@ func (dcr *ExchangeWallet) Balance() (*asset.Balance, error) {
 		return nil, err
 	}
 
-	reserves := dcr.reserves()
+	reserves := dcr.bondReserves.Load()
 	if reserves > bal.Available { // unmixed (immature) probably needs to trickle in
+		// TODO: Send wallet notification.
+		// https://github.com/decred/dcrdex/pull/2492
 		dcr.log.Warnf("Available balance is below configured reserves: %f < %f",
 			toDCR(bal.Available), toDCR(reserves))
 		bal.ReservesDeficit = reserves - bal.Available
@@ -1206,134 +1130,8 @@ func (dcr *ExchangeWallet) BondsFeeBuffer(feeRate uint64) uint64 {
 	return bondsFeeBuffer(feeRate)
 }
 
-// RegisterUnspent should be called once for every configured DEX with existing
-// unspent bond amounts, prior to login, which is when reserves for future bonds
-// are then added given the actual account tier, target tier, and this combined
-// existing bonds amount. This must be used before ReserveBondFunds, which
-// begins reserves enforcement provided a future amount that may be required
-// before the existing bonds are refunded. No reserves enforcement is enabled
-// until ReserveBondFunds is called, even with a future value of 0. A wallet
-// that is not enforcing reserves, but which has unspent bonds should use this
-// method to facilitate switching to the wallet for bonds in future.
-func (dcr *ExchangeWallet) RegisterUnspent(inBonds uint64) {
-	dcr.reservesMtx.Lock()
-	defer dcr.reservesMtx.Unlock()
-	dcr.log.Tracef("RegisterUnspent(%v) changing unspent in bonds: %v => %v",
-		toDCR(inBonds), toDCR(dcr.bondReservesUsed), toDCR(dcr.bondReservesUsed+inBonds))
-	dcr.bondReservesUsed += inBonds
-	// This method should be called before ReserveBondFunds, prior to login on
-	// application initialization (if there are existing for this asset bonds).
-	// The nominal counter is not modified until ReserveBondFunds is called.
-	if dcr.bondReservesNominal != 0 {
-		dcr.log.Warnf("BUG: RegisterUnspent called with existing nominal reserves of %v DCR",
-			toDCR(dcr.bondReservesNominal))
-	}
-}
-
-// ReserveBondFunds increases the bond reserves to accommodate a certain nominal
-// amount of future bonds, or reduces the amount if a negative value is
-// provided. If indicated, updating the reserves will require sufficient
-// available balance, otherwise reserves will be adjusted regardless and the
-// funds are pre-reserved. This returns false if the available balance was
-// insufficient iff the caller requested it be respected, otherwise it always
-// returns true (success).
-//
-// The reserves enabled with this method are enforced when funding transactions
-// (e.g. regular withdraws/sends or funding orders), and deducted from available
-// balance. Amounts may be reserved beyond the available balance, but only the
-// amount that is offset by the available balance is reflected in the locked
-// balance category. Like funds locked in swap contracts, the caller must
-// supplement balance reporting with known bond amounts. However, via
-// RegisterUnspent, the wallet is made aware of pre-existing unspent bond
-// amounts (cumulative) that will eventually be spent with RefundBond.
-//
-// If this wallet is enforcing reserves (this method has been called, even with
-// a future value of zero), when new bonds are created the nominal bond amount
-// is deducted from the enforced reserves; when bonds are spent with RefundBond,
-// the nominal bond amount is added back into the enforced reserves. That is,
-// when there are no active bonds, the locked balance category will reflect the
-// entire amount requested with ReserveBondFunds (plus a fee buffer, see below),
-// and when bonds are created with MakeBondTx, the locked amount decreases since
-// that portion of the reserves are now held in inaccessible UTXOs, the amounts
-// of which the caller tracks independently. When spent with RefundBond, that
-// same *nominal* bond value is added back to the enforced reserves amount.
-//
-// The amounts requested for bond reserves should be the nominal amounts of the
-// bonds, but the reserved amount reflected in the locked balance category will
-// include a considerable buffer for transaction fees. Therefore when the full
-// amount of the reserves are presently locked in unspent bonds, the locked
-// balance will include this fee buffer while the wallet is enforcing reserves.
-//
-// Until this method is called, reserves enforcement is disabled, and any
-// unspent bonds registered with RegisterUnspent do not go into the enforced
-// reserves when spent. In this way, all Bonder wallets remain aware of the
-// total nominal value of unspent bonds even if the wallet is not presently
-// being used to maintain a target bonding amount that necessitates reserves
-// enforcement.
-//
-// A negative value may be provided to reduce allocated reserves. When the
-// amount is reduced by the same amount it was previously increased by both
-// ReserveBondFunds and RegisterUnspent, reserves enforcement including fee
-// padding is disabled. Consider the following example: on startup, 20 DCR of
-// existing unspent bonds are registered via RegisterUnspent, then on login and
-// auth with the relevant DEX host, 40 DCR of future bond reserves are requested
-// with ReserveBondFunds to maintain a configured target tier given the current
-// tier and amounts of the existing unspent bonds. To disable reserves, the
-// client would call ReserveBondFunds with -60 DCR, which the wallet's internal
-// accounting recognizes as complete removal of the reserves.
-func (dcr *ExchangeWallet) ReserveBondFunds(future int64, feeBuffer uint64, respectBalance bool) bool {
-	dcr.reservesMtx.Lock()
-	defer dcr.reservesMtx.Unlock()
-
-	defer func(enforced0, used0, nominal0 int64) {
-		dcr.log.Tracef("ReserveBondFunds(%v, %v): enforced = %v / bonded = %v / nominal = %v "+
-			" ==>  enforced = %v / bonded = %v / nominal = %v",
-			toDCR(future), respectBalance,
-			toDCR(enforced0), toDCR(used0), toDCR(nominal0),
-			toDCR(dcr.bondReservesEnforced), toDCR(dcr.bondReservesUsed), toDCR(uint64(dcr.bondReservesNominal)))
-	}(dcr.bondReservesEnforced, int64(dcr.bondReservesUsed), dcr.bondReservesNominal)
-
-	enforcedDelta := future
-
-	// For the reserves initialization, add the fee buffer.
-	if dcr.bondReservesNominal == 0 { // enabling, add a fee buffer
-		if feeBuffer == 0 {
-			feeBuffer = bondsFeeBuffer(2 * dcr.targetFeeRateWithFallback(2, 0))
-		}
-		enforcedDelta += int64(feeBuffer)
-	}
-
-	// Check how much of that is covered by the available balance.
-	if respectBalance {
-		bal, err := dcr.balance()
-		if err != nil {
-			dcr.log.Errorf("Failed to retrieve balance: %v")
-			return false
-		}
-		if int64(bal.Available) < dcr.bondReservesEnforced+enforcedDelta {
-			if future > 0 {
-				return false
-			} // always allow reducing reserves, but make noise if still in the red
-			dcr.log.Warnf("Reducing bond reserves, but available balance still low.")
-		}
-	}
-
-	if dcr.bondReservesNominal == 0 { // enabling, add any previously-registered unspent
-		dcr.log.Debugf("Re-enabling reserves with %v in existing unspent bonds (added to nominal).", toDCR(dcr.bondReservesUsed))
-		dcr.bondReservesNominal += int64(dcr.bondReservesUsed)
-	}
-	dcr.bondReservesNominal += future
-	dcr.bondReservesEnforced += enforcedDelta
-
-	// When disabling/zeroing reserves, wipe the fee buffer too. If there are
-	// unspent bonds, this will be done in bondSpent when the last one is spent.
-	if dcr.bondReservesNominal <= 0 { // nominal should not go negative though
-		dcr.log.Infof("Nominal reserves depleted -- clearing enforced reserves!")
-		dcr.bondReservesEnforced = 0
-		dcr.bondReservesNominal = 0
-	}
-
-	return true
+func (dcr *ExchangeWallet) SetBondReserves(reserves uint64) {
+	dcr.bondReserves.Store(reserves)
 }
 
 // FeeRate satisfies asset.FeeRater.
@@ -1565,7 +1363,7 @@ func (dcr *ExchangeWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate
 	}
 
 	avail := sumUTXOs(utxos)
-	reserves := dcr.reserves()
+	reserves := dcr.bondReserves.Load()
 
 	digestInputs := func(inputsSize uint32) (reqFunds, maxFees, estHighFees, estLowFees uint64) {
 		// NOTE: reqFunds = val + fees, so change (extra) will be sum-reqFunds
@@ -1961,7 +1759,7 @@ func (dcr *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes
 	}
 
 	changeForReserves := useSplit && cfg.unmixedAccount == ""
-	reserves := dcr.reserves()
+	reserves := dcr.bondReserves.Load()
 	coins, redeemScripts, sum, inputsSize, err := dcr.fund(reserves,
 		orderEnough(ord.Value, ord.MaxSwapCount, bumpedMaxRate, changeForReserves))
 	if err != nil {
@@ -2479,7 +2277,7 @@ func (dcr *ExchangeWallet) fundMulti(maxLock uint64, values []*asset.MultiOrderV
 	dcr.fundingMtx.Lock()
 	defer dcr.fundingMtx.Unlock()
 
-	reserves := dcr.reserves()
+	reserves := dcr.bondReserves.Load()
 
 	coins, redeemScripts, fundingCoins, err := dcr.fundMultiBestEffort(reserves, maxLock, values, maxFeeRate, allowSplit)
 	if err != nil {
@@ -4311,17 +4109,8 @@ func (dcr *ExchangeWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime 
 		return nil, nil, fmt.Errorf("Unable to send %s DCR with fee rate of %d atoms/byte: %w",
 			amount(amt), feeRate, err)
 	}
-	// Reduce the reserves counter now that utxos are explicitly allocated. When
-	// the bond is refunded and we pay back into our wallet, we will increase
-	// the reserves counter.
-	newReserves, unspent := dcr.bondLocked(amt) // nominal, not spent amount
-	dcr.log.Debugf("New bond reserves (new post) = %f DCR with %f in unspent bonds",
-		toDCR(newReserves), toDCR(unspent)) // decrement and report new
 
 	abandon := func() { // if caller does not broadcast, or we fail in this method
-		newReserves, unspent = dcr.bondSpent(amt)
-		dcr.log.Debugf("New bond reserves (abandoned post) = %f DCR with %f in unspent bonds",
-			toDCR(newReserves), toDCR(unspent)) // increment/restore and report new
 		_, err := dcr.returnCoins(coins)
 		if err != nil {
 			dcr.log.Errorf("error returning coins for unused bond tx: %v", coins)
@@ -4455,17 +4244,9 @@ func (dcr *ExchangeWallet) RefundBond(ctx context.Context, ver uint16, coinID, s
 	if err != nil {
 		return nil, err
 	}
-	// Increment the enforced reserves before the refunded coins make it to the
-	// spendable balance, which could be spent by another concurrent process.
-	newReserves, unspent := dcr.bondSpent(amt) // nominal, not refundAmt
-	dcr.log.Debugf("New bond reserves (new refund of %f DCR) = %f DCR with %f in unspent bonds",
-		toDCR(amt), toDCR(newReserves), toDCR(unspent))
 
 	redeemHash, err := dcr.wallet.SendRawTransaction(ctx, msgTx, false)
 	if err != nil { // TODO: we need to be much smarter about these send error types/codes
-		newReserves, unspent = dcr.bondLocked(amt) // assume it didn't really send :/
-		dcr.log.Debugf("New bond reserves (failed refund broadcast) = %f DCR with %f in unspent bonds",
-			toDCR(newReserves), toDCR(unspent)) // increment/restore and report new
 		return nil, translateRPCCancelErr(err)
 	}
 
@@ -4657,11 +4438,7 @@ func (dcr *ExchangeWallet) addInputCoins(msgTx *wire.MsgTx, coins asset.Coins) (
 }
 
 func (dcr *ExchangeWallet) shutdown() {
-	dcr.reservesMtx.Lock()
-	dcr.bondReservesEnforced = 0
-	dcr.bondReservesNominal = 0
-	dcr.bondReservesUsed = 0
-	dcr.reservesMtx.Unlock()
+	dcr.bondReserves.Store(0)
 	// or should it remember reserves in case we reconnect? There's a
 	// reReserveFunds Core method for this... unclear
 
@@ -4775,7 +4552,7 @@ func (dcr *ExchangeWallet) withdraw(addr stdaddr.Address, val, feeRate uint64) (
 	baseSize := uint32(dexdcr.MsgTxOverhead + dexdcr.P2PKHOutputSize*2)
 	reportChange := dcr.config().unmixedAccount == "" // otherwise change goes to unmixed account
 	enough := sendEnough(val, feeRate, true, baseSize, reportChange)
-	reserves := dcr.reserves()
+	reserves := dcr.bondReserves.Load()
 	coins, _, _, _, err := dcr.fund(reserves, enough)
 	if err != nil {
 		return nil, 0, fmt.Errorf("unable to withdraw %s DCR to address %s with feeRate %d atoms/byte: %w",
@@ -4799,7 +4576,7 @@ func (dcr *ExchangeWallet) sendToAddress(addr stdaddr.Address, amt, feeRate uint
 	baseSize := uint32(dexdcr.MsgTxOverhead + dexdcr.P2PKHOutputSize*2) // may be extra if change gets omitted (see signTxAndAddChange)
 	reportChange := dcr.config().unmixedAccount == ""                   // otherwise change goes to unmixed account
 	enough := sendEnough(amt, feeRate, false, baseSize, reportChange)
-	reserves := dcr.reserves()
+	reserves := dcr.bondReserves.Load()
 	coins, _, _, _, err := dcr.fund(reserves, enough)
 	if err != nil {
 		return nil, 0, fmt.Errorf("Unable to send %s DCR with fee rate of %d atoms/byte: %w",
@@ -5134,7 +4911,7 @@ func (dcr *ExchangeWallet) EstimateSendTxFee(address string, sendAmount, feeRate
 		return 0, false, err
 	}
 
-	reserves := dcr.reserves()
+	reserves := dcr.bondReserves.Load()
 	avail := sumUTXOs(utxos)
 	if avail-sum+extra /* avail-sendAmount-fees */ < reserves {
 		return 0, false, errors.New("violates reserves")

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1136,7 +1136,7 @@ func (dcr *ExchangeWallet) SetBondReserves(reserves uint64) {
 func (dcr *ExchangeWallet) FeeRate() uint64 {
 	const confTarget = 2 // 1 historically gives crazy rates
 	rate, err := dcr.feeRate(confTarget)
-	if err != nil { // log and return 0
+	if err != nil && dcr.network != dex.Simnet { // log and return 0
 		dcr.log.Errorf("feeRate error: %v", err)
 	}
 	return rate

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1094,8 +1094,6 @@ func (dcr *ExchangeWallet) Balance() (*asset.Balance, error) {
 
 	reserves := dcr.bondReserves.Load()
 	if reserves > bal.Available { // unmixed (immature) probably needs to trickle in
-		// TODO: Send wallet notification.
-		// https://github.com/decred/dcrdex/pull/2492
 		dcr.log.Warnf("Available balance is below configured reserves: %f < %f",
 			toDCR(bal.Available), toDCR(reserves))
 		bal.ReservesDeficit = reserves - bal.Available

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -982,18 +982,6 @@ func (dcr *ExchangeWallet) Reconfigure(ctx context.Context, cfg *asset.WalletCon
 		return false, err
 	}
 	dcr.cfgV.Store(exchangeWalletCfg)
-	// DRAFT TODO: Caller should re-reserve after reconfig.
-	// if oldCfg.feeRateLimit != exchangeWalletCfg.feeRateLimit {
-	// 	// Adjust the bond reserves fee buffer, if enforcing.
-	// 	dcr.reservesMtx.Lock()
-	// 	if dcr.bondReservesNominal != 0 {
-
-	// 		dcr.bondReservesEnforced += int64(bondsFeeBuffer(exchangeWalletCfg.feeRateLimit)) -
-	// 			int64(bondsFeeBuffer(oldCfg.feeRateLimit))
-	// 	}
-	// 	dcr.reservesMtx.Unlock()
-	// }
-
 	return false, nil
 }
 

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -1252,13 +1252,13 @@ func TestFundMultiOrder(t *testing.T) {
 	}
 
 	type test struct {
-		name                 string
-		multiOrder           *asset.MultiOrder
-		allOrNothing         bool
-		maxLock              uint64
-		utxos                []walletjson.ListUnspentResult
-		bondReservesEnforced int64
-		balance              uint64
+		name         string
+		multiOrder   *asset.MultiOrder
+		allOrNothing bool
+		maxLock      uint64
+		utxos        []walletjson.ListUnspentResult
+		bondReserves uint64
+		balance      uint64
 
 		// if expectedCoins is nil, all the coins are from
 		// the split output. If any of the coins are nil,
@@ -1474,8 +1474,8 @@ func TestFundMultiOrder(t *testing.T) {
 					multiSplitKey: "false",
 				},
 			},
-			maxLock:              46e5,
-			bondReservesEnforced: 12e5,
+			maxLock:      46e5,
+			bondReserves: 12e5,
 			utxos: []walletjson.ListUnspentResult{
 				{
 					Confirmations: 1,
@@ -1879,7 +1879,7 @@ func TestFundMultiOrder(t *testing.T) {
 					multiSplitKey: "true",
 				},
 			},
-			bondReservesEnforced: 2e6,
+			bondReserves: 2e6,
 			utxos: []walletjson.ListUnspentResult{
 				{
 					Confirmations: 1,
@@ -1933,7 +1933,7 @@ func TestFundMultiOrder(t *testing.T) {
 					multiSplitKey: "true",
 				},
 			},
-			bondReservesEnforced: 2e6,
+			bondReserves: 2e6,
 			utxos: []walletjson.ListUnspentResult{
 				{
 					Confirmations: 1,
@@ -2176,10 +2176,10 @@ func TestFundMultiOrder(t *testing.T) {
 					Vout:          0,
 				},
 			},
-			maxLock:              0,
-			bondReservesEnforced: 1e6,
-			balance:              144e5,
-			expectSendRawTx:      true,
+			maxLock:         0,
+			bondReserves:    1e6,
+			balance:         144e5,
+			expectSendRawTx: true,
 			expectedInputs: []*wire.TxIn{
 				{
 					PreviousOutPoint: wire.OutPoint{
@@ -2269,10 +2269,10 @@ func TestFundMultiOrder(t *testing.T) {
 					Vout:          0,
 				},
 			},
-			maxLock:              35e5,
-			bondReservesEnforced: 0,
-			balance:              42e5,
-			expectSendRawTx:      true,
+			maxLock:         35e5,
+			bondReserves:    0,
+			balance:         42e5,
+			expectSendRawTx: true,
 			expectedInputs: []*wire.TxIn{
 				{
 					PreviousOutPoint: wire.OutPoint{
@@ -2322,7 +2322,7 @@ func TestFundMultiOrder(t *testing.T) {
 			},
 		}
 		wallet.fundingCoins = make(map[outPoint]*fundingCoin)
-		wallet.bondReservesEnforced = test.bondReservesEnforced
+		wallet.bondReserves.Store(test.bondReserves)
 
 		allCoins, _, splitFee, err := wallet.FundMultiOrder(test.multiOrder, test.maxLock)
 		if test.expectErr {

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -584,28 +584,8 @@ type Bonder interface {
 	// the first bond to ensure it succeeds, assuming balance was checked.
 	BondsFeeBuffer(feeRate uint64) uint64
 
-	// RegisterUnspent informs the wallet of a certain amount already locked in
-	// unspent bonds that will eventually be refunded with RefundBond. This
-	// should be used prior to ReserveBondFunds. This alone does not enable
-	// reserves enforcement, and it should be called on bring-up when existing
-	// bonds that may refund to this wallet are known. Once ReserveBondFunds is
-	// called, these live bond amounts will become enforced reserves when they
-	// are refunded via RefundBond.
-	RegisterUnspent(live uint64)
-	// ReserveBondFunds (un)reserves funds for creation of future bonds.
-	// MakeBondTx will create transactions that decrease these reserves, while
-	// RefundBond will replenish the reserves. If the wallet's available balance
-	// should be respected when adding reserves, the boolean argument may be set
-	// to indicate this, in which case the return value indicates if it was able
-	// to reserve the funds. In this manner, funds may be pre-reserved so that
-	// when the wallet receives funds (from either external deposits or
-	// refunding of live bonds), they will go directly into locked balance. When
-	// the reserves are decremented to zero (by the amount that they were
-	// incremented), all enforcement including any fee buffering is disabled.
-	// The fee buffer amount is used only when enabling the reserves (when
-	// starting from zero). It may also be zero, in which case the wallet will
-	// attempt to obtain it's own estimate if it is needed.
-	ReserveBondFunds(future int64, feeBuffer uint64, respectBalance bool) bool
+	// SetReserves sets the bond reserve amount for the wallet.
+	SetBondReserves(reserves uint64)
 
 	// MakeBondTx authors a DEX time-locked fidelity bond transaction for the
 	// provided amount, lock time, and dex account ID. An explicit private key

--- a/client/core/account.go
+++ b/client/core/account.go
@@ -417,5 +417,5 @@ func (c *Core) UpdateDEXHost(oldHost, newHost string, appPW []byte, certI any) (
 	}
 
 	updatedHost = true
-	return newDc.exchangeInfo(), nil
+	return c.exchangeInfo(newDc), nil
 }

--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -1069,7 +1069,13 @@ func (c *Core) UpdateBondOptions(form *BondOptionsForm) error {
 		bondAssetAmt = bondAsset.Amt
 	}
 
-	maxBonded := maxBondedMult * bondAssetAmt * (targetTier + uint64(penaltyComps)) // the min if none specified
+	// If we're lowering our bond, we can't set the max bonded amount too low.
+	tierForDefaultMaxBonded := targetTier
+	if targetTier > 0 && targetTier0 > targetTier {
+		tierForDefaultMaxBonded = targetTier0
+	}
+
+	maxBonded := maxBondedMult * bondAssetAmt * (tierForDefaultMaxBonded + uint64(penaltyComps)) // the min if none specified
 	if form.MaxBondedAmt != nil {
 		requested := *form.MaxBondedAmt
 		if requested < maxBonded {

--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -757,7 +757,7 @@ func (c *Core) postBond(dc *dexConnection, bond *asset.Bond) (*msgjson.PostBondR
 	}
 
 	dc.acct.authMtx.Lock()
-	dc.updateReputation(postBondRes.Reputation, &postBondRes.Tier, nil, nil)
+	dc.updateReputation(postBondRes.Reputation, postBondRes.Tier, nil, nil)
 	dc.acct.authMtx.Unlock()
 
 	// Check the response signature.

--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -14,6 +14,7 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/keygen"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/hdkeychain/v3"
 )
@@ -196,7 +197,8 @@ func (c *Core) dexBondConfig(dc *dexConnection, now int64) *dexBondCfg {
 }
 
 type dexAcctBondState struct {
-	tierChange, tier                            int64
+	*account.TierReport
+	tierChange                                  int64
 	targetTier                                  uint64
 	pendingStrength, weakStrength, liveStrength int64
 	weak                                        []*db.Bond
@@ -238,7 +240,7 @@ func (c *Core) bondStateOfDEX(dc *dexConnection, bondCfg *dexBondCfg) *dexAcctBo
 	}
 
 	state.tierChange = dc.acct.tierChange // since last reserves update
-	state.tier, state.targetTier = dc.acct.tier, dc.acct.targetTier
+	state.TierReport, state.targetTier = dc.acct.tier, dc.acct.targetTier
 	state.bondAssetID, state.maxBondedAmt = dc.acct.bondAsset, dc.acct.maxBondedAmt
 	state.inBonds, _ = dc.bondTotalInternal(state.bondAssetID)
 	// Screen the unexpired bonds slices.
@@ -261,6 +263,7 @@ func (c *Core) bondStateOfDEX(dc *dexConnection, bondCfg *dexBondCfg) *dexAcctBo
 		}
 	}
 
+	// DRAFT TODO: Update for v2 tier data.
 	// This old way is bugged because we have no way of knowing how many bonus
 	// tiers the server has assigned us, because it is not directly reported in
 	// any comms and  to calculate it locally, we would need to know the
@@ -480,8 +483,8 @@ func (c *Core) postRequiredBonds(
 		return
 	}
 
-	c.log.Infof("Gotta post %d bond increments now. Target tier %d, current tier %d (%d weak, %d pending)",
-		state.mustPost, state.targetTier, state.tier, state.weakStrength, state.pendingStrength)
+	c.log.Infof("Gotta post %d bond increments now. Target tier %d, current bonded tier %d (%d weak, %d pending)",
+		state.mustPost, state.targetTier, state.Bonded, state.weakStrength, state.pendingStrength)
 
 	if !unlocked || dc.status() != comms.Connected {
 		c.log.Warnf("Unable to post the required bond while disconnected or account is locked.")
@@ -642,11 +645,10 @@ func (c *Core) preValidateBond(dc *dexConnection, bond *asset.Bond) error {
 	if err != nil {
 		return codedError(registerErr, err)
 	}
-
 	// Check the response signature.
 	err = dc.acct.checkSig(append(preBondRes.Serialize(), bond.UnsignedTx...), preBondRes.Sig)
 	if err != nil {
-		return fmt.Errorf("preValidateBond: DEX signature validation error: %v", err)
+		return newError(signatureErr, "preValidateBond: DEX signature validation error: %v", err)
 	}
 
 	if preBondRes.Amount != bond.Amount {
@@ -666,7 +668,6 @@ func (c *Core) postBond(dc *dexConnection, bond *asset.Bond) (*msgjson.PostBondR
 	if len(pkBytes) == 0 {
 		return nil, fmt.Errorf("account keys not decrypted")
 	}
-
 	assetID, bondCoin := bond.AssetID, bond.CoinID
 	bondCoinStr := coinIDString(assetID, bondCoin)
 
@@ -684,6 +685,10 @@ func (c *Core) postBond(dc *dexConnection, bond *asset.Bond) (*msgjson.PostBondR
 	if err != nil {
 		return nil, codedError(registerErr, err)
 	}
+
+	dc.acct.authMtx.Lock()
+	dc.updateTierReport(postBondRes.TierReportV2, &postBondRes.Tier, nil, nil)
+	dc.acct.authMtx.Unlock()
 
 	// Check the response signature.
 	err = dc.acct.checkSig(postBondRes.Serialize(), postBondRes.Sig)
@@ -973,7 +978,7 @@ func (c *Core) UpdateBondOptions(form *BondOptionsForm) error {
 			inBonds, live := dc.bondTotalInternal(bondAssetID)
 			mod := int64(bondOverlap * targetTier * bondAssetAmt)
 			// If we appear to be penalized, add increments to mod.
-			if tierOffset := int64(bondedTier()) - dc.acct.tier; tierOffset > 0 {
+			if tierOffset := int64(bondedTier()) - dc.acct.tier.Bonded; tierOffset > 0 {
 				mod += tierOffset * int64(bondAssetAmt)
 			}
 			dc.acct.totalReserved = mod
@@ -1018,7 +1023,7 @@ func (c *Core) UpdateBondOptions(form *BondOptionsForm) error {
 			mod = bondOverlap * tierDelta * int64(bondAssetAmt)
 			if oldTarget == 0 { // enabling maintenance, not just a delta
 				// If we appear to be penalized, add increments to mod.
-				if tierOffset := int64(bondedTier()) - dc.acct.tier; tierOffset > 0 {
+				if tierOffset := int64(bondedTier()) - dc.acct.tier.Bonded; tierOffset > 0 {
 					mod += tierOffset * int64(bondAssetAmt)
 				}
 				// Wallet already has live unspent bonds (inBonds) registered.
@@ -1175,7 +1180,7 @@ func (c *Core) PostBond(form *PostBondForm) (*PostBondResult, error) {
 		if bal, err := wallet.Balance(); err != nil {
 			return nil, newError(bondAssetErr, "unable to check wallet balance: %w", err)
 		} else if bal.Available < form.Bond {
-			return nil, newError(bondAssetErr, "insufficient available balance")
+			return nil, newError(walletBalanceErr, "insufficient available balance")
 		}
 
 		// New DEX connection.
@@ -1207,7 +1212,6 @@ func (c *Core) PostBond(form *PostBondForm) (*PostBondResult, error) {
 		}
 		// dc.acct is now configured with encKey, privKey, and id for a new
 		// (unregistered) account.
-
 		if paid {
 			success = true
 			// The listen goroutine is already running, now track the conn.
@@ -1409,9 +1413,8 @@ func (c *Core) updatePendingBondConfs(dc *dexConnection, assetID uint32, coinID 
 	dc.acct.pendingBondsConfs[bondIDStr] = confs
 }
 
-func (c *Core) bondConfirmed(dc *dexConnection, assetID uint32, coinID []byte, newTier int64) error {
+func (c *Core) bondConfirmed(dc *dexConnection, assetID uint32, coinID []byte, newEffectiveTier int64) error {
 	bondIDStr := coinIDString(assetID, coinID)
-
 	// Update dc.acct.{bonds,pendingBonds,tier} under authMtx lock.
 	var foundPending, foundConfirmed bool
 	dc.acct.authMtx.Lock()
@@ -1435,7 +1438,7 @@ func (c *Core) bondConfirmed(dc *dexConnection, assetID uint32, coinID []byte, n
 		}
 	}
 
-	dc.acct.tier = newTier
+	dc.acct.effectiveTier = newEffectiveTier
 	targetTier := dc.acct.targetTier
 	isAuthed := dc.acct.isAuthed
 	dc.acct.authMtx.Unlock()
@@ -1447,8 +1450,8 @@ func (c *Core) bondConfirmed(dc *dexConnection, assetID uint32, coinID []byte, n
 			return fmt.Errorf("db.ConfirmBond failure: %w", err)
 		}
 		c.log.Infof("Bond %s (%s) confirmed.", bondIDStr, unbip(assetID))
-		details := fmt.Sprintf("New tier = %d (target = %d).", newTier, targetTier) // TODO: format to subject,details
-		c.notify(newBondPostNoteWithTier(TopicBondConfirmed, string(TopicBondConfirmed), details, db.Success, dc.acct.host, newTier))
+		details := fmt.Sprintf("New tier = %d (target = %d).", newEffectiveTier, targetTier) // TODO: format to subject,details
+		c.notify(newBondPostNoteWithTier(TopicBondConfirmed, string(TopicBondConfirmed), details, db.Success, dc.acct.host, newEffectiveTier))
 	} else if !foundConfirmed {
 		c.log.Errorf("bondConfirmed: Bond %s (%s) not found", bondIDStr, unbip(assetID))
 		// just try to authenticate...
@@ -1472,9 +1475,9 @@ func (c *Core) bondConfirmed(dc *dexConnection, assetID uint32, coinID []byte, n
 		return err
 	}
 
-	details := fmt.Sprintf("New tier = %d", newTier) // TODO: format to subject,details
+	details := fmt.Sprintf("New tier = %d", newEffectiveTier) // TODO: format to subject,details
 	c.notify(newBondPostNoteWithTier(TopicAccountRegistered, string(TopicAccountRegistered),
-		details, db.Success, dc.acct.host, newTier)) // possibly redundant with SubjectBondConfirmed
+		details, db.Success, dc.acct.host, newEffectiveTier)) // possibly redundant with SubjectBondConfirmed
 
 	return nil
 }
@@ -1507,7 +1510,7 @@ func (c *Core) bondExpired(dc *dexConnection, assetID uint32, coinID []byte, new
 		}
 	}
 
-	dc.acct.tier = newTier
+	dc.acct.effectiveTier = newTier
 	targetTier := dc.acct.targetTier
 	dc.acct.authMtx.Unlock()
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -526,12 +526,13 @@ func (c *Core) exchangeInfo(dc *dexConnection) *Exchange {
 		ConnectionStatus: dc.status(),
 		CandleDurs:       cfg.BinSizes,
 		ViewOnly:         dc.acct.isViewOnly(),
-		Reputation:       acctBondState.Reputation,
+		Reputation:       acctBondState.rep,
 		BondedTier:       acctBondState.liveStrength,
 		BondOptions: &BondOptions{
 			BondAsset:    acctBondState.bondAssetID,
 			TargetTier:   acctBondState.targetTier,
 			MaxBondedAmt: acctBondState.maxBondedAmt,
+			PenaltyComps: acctBondState.penaltyComps,
 		},
 		PendingBonds: dc.pendingBonds(),
 		// TODO: Bonds

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -74,6 +74,13 @@ const (
 	// wsAnomalyDuration since last connect time, the client's websocket
 	// connection anomaly count is increased.
 	wsAnomalyDuration = 60 * time.Minute
+
+	// This is a configurable server parameter, but we're assuming servers have
+	// changed it from the default , We're using this for the v1 ConnectResult,
+	// where we don't have the necessary information to calculate our bonded
+	// tier, so we calculate our bonus/revoked tier from the score in the
+	// ConnectResult.
+	defaultBanScore = 20
 )
 
 var (
@@ -497,7 +504,7 @@ func (dc *dexConnection) exchangeInfo() *Exchange {
 
 	dc.acct.authMtx.RLock()
 	// TODO: List bonds in core.Exchange. For now, just tier.
-	tier := dc.acct.tier
+	effectiveTier := dc.acct.effectiveTier
 	bondAssetID := dc.acct.bondAsset
 	targetTier, maxBondedAmt := dc.acct.targetTier, dc.acct.maxBondedAmt
 	dc.acct.authMtx.RUnlock()
@@ -512,7 +519,7 @@ func (dc *dexConnection) exchangeInfo() *Exchange {
 		ConnectionStatus: dc.status(),
 		CandleDurs:       cfg.BinSizes,
 		ViewOnly:         dc.acct.isViewOnly(),
-		Tier:             tier,
+		Tier:             effectiveTier,
 		BondOptions: &BondOptions{
 			BondAsset:    bondAssetID,
 			TargetTier:   targetTier,
@@ -2107,7 +2114,6 @@ func (c *Core) updateWalletBalance(wallet *xcWallet) (*WalletBalance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error updating %s balance in database: %w", unbip(wallet.AssetID), err)
 	}
-
 	c.notify(newBalanceNote(wallet.AssetID, walletBal))
 	return walletBal, nil
 }
@@ -3940,11 +3946,13 @@ func (c *Core) discoverAccount(dc *dexConnection, crypter encrypt.Crypter) (bool
 		// 0 but server doesn't support bonds. If tier == 0 and server supports
 		// bonds, a bond must be posted before the account can be used to trade,
 		// but generating a new key isn't necessary.
-		cannotTrade := dc.acct.tier < 0 || (dc.acct.tier == 0 && dc.apiVersion() < serverdex.BondAPIVersion)
-		if cannotTrade {
+
+		// DRAFT NOTE: This was wrong? Isn't account suspended at tier 0?
+		// cannotTrade := dc.acct.effectiveTier < 0 || (dc.acct.effectiveTier == 0 && dc.apiVersion() < serverdex.BondAPIVersion)
+		if dc.acct.effectiveTier <= 0 {
 			dc.acct.unAuth() // acct was marked as authenticated by authDEX above.
 			c.log.Infof("HD account key for %s has tier %d (not able to trade). Deriving another account key.",
-				dc.acct.host, dc.acct.tier)
+				dc.acct.host, dc.acct.effectiveTier)
 			keyIndex++
 			time.Sleep(200 * time.Millisecond) // don't hammer
 			continue
@@ -4169,6 +4177,7 @@ func (c *Core) Register(form *RegisterForm) (*RegisterResult, error) {
 	c.connMtx.RLock()
 	dc, existingConn := c.conns[host]
 	c.connMtx.RUnlock()
+
 	if existingConn && !dc.acct.isViewOnly() {
 		// Already registered, but connection may be down and/or PostBond needed.
 		return nil, newError(dupeDEXErr, "already registered at %s", form.Addr)
@@ -6577,6 +6586,87 @@ func bondKey(assetID uint32, coinID []byte) string {
 	return string(append(encode.Uint32Bytes(assetID), coinID...))
 }
 
+// updateTierReport sets the account's tier-related fields. updateTierReport
+// must be called with the authMtx locked.
+func (dc *dexConnection) updateTierReport(
+	newTierReport *account.TierReport,
+	tier *int64,
+	legacyFee *bool,
+	scor *int32,
+) {
+
+	defer func() {
+		dc.acct.effectiveTier = dc.acct.tier.Effective()
+	}()
+
+	if newTierReport != nil {
+		dc.acct.tier = newTierReport
+		return
+	}
+	if tier == nil { // legacy server (V0PURGE)
+		// A legacy server does not set ConnectResult.LegacyFeePaid, but unpaid
+		// legacy ('register') users get an UnpaidAccountError from Connect, so
+		// we know the account is paid and not suspended.
+		// These legacy responses are unlikely to exist in the wild anymore, but
+		// there are no bonus tiers in these servers.
+		dc.acct.tier = &account.TierReport{
+			Legacy: true,
+			// Score: , // not reported in v0.
+		}
+		return
+	}
+
+	// tier != nil
+	// We have tier info, but server isn't sending a TierReportV2.
+	effectiveTier := *tier
+	legacyFeePaid := dc.acct.legacyFeePaid
+	if legacyFee != nil {
+		legacyFeePaid = *legacyFee
+	}
+	// We need to know the tier contribution from active bonds, but that
+	// depends on things like the server's ban score, which we don't have.
+	// Also, we can't add up active bonds and divide by current bond asset
+	// configuration values, beause the server doesn't do it that way. They
+	// sum the bond.Strength in the DB entries that corresponds to the bond
+	// strength at postbond, so we'd have no way of knowing if the server's
+	// bond configuration had changed. That's why TierReportV2 was added,
+	// but in the meantime, we have to make some assumptions. In this case,
+	// we'll assume that the server has the default ban score (20) and work
+	// from there.
+	var bonusTiers, revokedTiers int64
+	var score int32
+	oldTierReport := dc.acct.tier
+	// If we got here through authDEX -> ConnectResult, we won't have an
+	// oldTierReport, but we will have a score. For other paths, we will have
+	// an oldTierReport but we won't have a score.
+	if oldTierReport != nil {
+		// We don't get a score in anything but the ConnectResult, so if we got
+		// here via e.g. postBond, the best we can do is to assume these values
+		// haven't changed.
+		score = oldTierReport.Score
+		bonusTiers, revokedTiers = oldTierReport.Bonus, oldTierReport.Revoked
+	} else if scor != nil { // via authDEX -> ConnectResult
+		score = *scor
+		tierAdj := int64(score / defaultBanScore)
+		if tierAdj < 0 {
+			bonusTiers = -tierAdj
+		} else if tierAdj > 0 {
+			revokedTiers = tierAdj
+		}
+	}
+
+	// effectiveTier = bondedTier + bonusTiers - revokedTiers
+	bondedTier := effectiveTier - bonusTiers + revokedTiers
+	dc.acct.tier = &account.TierReport{
+		Bonded:  bondedTier,
+		Revoked: revokedTiers,
+		Bonus:   bonusTiers,
+		Legacy:  legacyFeePaid,
+		Score:   score,
+	}
+
+}
+
 // authDEX authenticates the connection for a DEX.
 func (c *Core) authDEX(dc *dexConnection) error {
 	bondAssets, bondExpiry := dc.bondAssets()
@@ -6587,6 +6677,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	// Copy the local bond slices since bondConfirmed will modify them.
 	dc.acct.authMtx.RLock()
 	localActiveBonds := make([]*db.Bond, len(dc.acct.bonds))
+
 	copy(localActiveBonds, dc.acct.bonds)
 	localPendingBonds := make([]*db.Bond, len(dc.acct.pendingBonds))
 	copy(localPendingBonds, dc.acct.pendingBonds)
@@ -6618,7 +6709,6 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	}, DefaultResponseTimeout, func() {
 		errChan <- fmt.Errorf("timed out waiting for '%s' response", msgjson.ConnectRoute)
 	})
-
 	// Check the request error.
 	if err != nil {
 		return err
@@ -6647,23 +6737,6 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	err = dc.acct.checkSig(sigMsg, result.Sig)
 	if err != nil {
 		return newError(signatureErr, "DEX signature validation error: %w", err)
-	}
-
-	var tier int64
-	var legacyFeePaid bool
-	if result.Tier == nil { // legacy server (V0PURGE)
-		// A legacy server does not set ConnectResult.LegacyFeePaid, but unpaid
-		// legacy ('register') users get an UnpaidAccountError from Connect, so
-		// we know the account is paid and not suspended.
-		legacyFeePaid = true
-		if result.Suspended == nil || !*result.Suspended {
-			tier = 1
-		}
-	} else {
-		tier = *result.Tier
-		if result.LegacyFeePaid != nil {
-			legacyFeePaid = *result.LegacyFeePaid
-		}
 	}
 
 	// Check active and pending bonds, comparing against result.ActiveBonds. For
@@ -6699,6 +6772,15 @@ func (c *Core) authDEX(dc *dexConnection) error {
 		key := bondKey(bond.AssetID, bond.CoinID)
 		_, found := remoteLiveBonds[key]
 		if found {
+			// TODO: This is not how the server calculates our bonded tier.
+			// On the server, they do
+			//    bondTier += int64(bond.Strength)
+			// where bond.Strength is a value stored in the database during
+			// postbond. This means if ther server doubles the bond size for an
+			// asset we're bonded in up to N tiers, by their calculation we'll
+			// still have N tiers from existing bonds, but by ours we would have
+			// floor(N / 2). If they halve the bond size, they'd say we have N,
+			// and we'd think we should have 2N.
 			bondedTiers += bond.Amount / bondAsset.Amt
 			continue // good, it's live server-side too
 		} // else needs post retry or it's expired
@@ -6748,22 +6830,19 @@ func (c *Core) authDEX(dc *dexConnection) error {
 		toPost = append(toPost, queuedBond{assetBond(bond), bondAsset.Confs})
 	}
 
-	// just a little debugging block, can remove
-	if bondAssetID, targetTier, _ := dc.bondOpts(); targetTier > 0 {
-		bondAsset := bondAssets[bondAssetID]
-		if bondAsset == nil {
-			c.log.Warnf("Selected bond asset %v is not supported by %v", unbip(bondAssetID), dc.acct.host)
-		} else { // adjust reserves given observed tier offset
-			tierOffset := tier - int64(bondedTiers) // negative means penalties, positive means bonus (trade history or legacy fee)
-			c.log.Tracef("actual (%d) - bonded (%d) tiers = %d", tier, int64(bondedTiers), tierOffset)
-			tierSurplus := tier - int64(dc.acct.targetTier) // captured by inBonds, _ := dc.bondTotalInternal(bondAsset.ID)
-			c.log.Tracef("actual (%d) - target (%d) tiers = %d", tier, int64(dc.acct.targetTier), tierSurplus)
-		}
-	}
+	// // just a little debugging block, can remove
+	// if bondAssetID, targetTier, _ := dc.bondOpts(); targetTier > 0 {
+	// 	bondAsset := bondAssets[bondAssetID]
+	// 	if bondAsset == nil {
+	// 		c.log.Warnf("Selected bond asset %v is not supported by %v", unbip(bondAssetID), dc.acct.host)
+	// 	} else { // adjust reserves given observed tier offset
+	// 		tierOffset := tier - int64(bondedTiers) // negative means penalties, positive means bonus (trade history or legacy fee)
+	// 		c.log.Tracef("actual (%d) - bonded (%d) tiers = %d", tier, int64(bondedTiers), tierOffset)
+	// 		tierSurplus := tier - int64(dc.acct.targetTier) // captured by inBonds, _ := dc.bondTotalInternal(bondAsset.ID)
+	// 		c.log.Tracef("actual (%d) - target (%d) tiers = %d", tier, int64(dc.acct.targetTier), tierSurplus)
+	// 	}
+	// }
 
-	// Set the account as authenticated.
-	c.log.Infof("Authenticated connection to %s, acct %v, %d active bonds, %d active orders, %d active matches, score %d, tier %d",
-		dc.acct.host, acctID, len(result.ActiveBonds), len(result.ActiveOrderStatuses), len(result.ActiveMatches), result.Score, tier)
 	updatedAssets := make(assetMap)
 	// Flag as authenticated before bondConfirmed and monitorBondConfs, which
 	// may call authDEX if not flagged as such.
@@ -6772,13 +6851,18 @@ func (c *Core) authDEX(dc *dexConnection) error {
 	// reconnect, (3) bondConfirmed for the initial bond for the account.
 	// totalReserved is non-zero in #3, but zero in #1. There are no reserves
 	// actions to take in #3 since PostBond reserves prior to post.
+
+	dc.updateTierReport(result.TierReportV2, result.Tier, result.LegacyFeePaid, &result.Score)
+	c.log.Infof("Authenticated connection to %s, acct %v, %d active bonds, %d active orders, %d active matches, score %d, tier %d",
+		dc.acct.host, acctID, len(result.ActiveBonds), len(result.ActiveOrderStatuses), len(result.ActiveMatches), result.Score, dc.acct.effectiveTier)
 	loginAuth := !dc.acct.isAuthed && dc.acct.totalReserved == 0
 	dc.acct.isAuthed = true
-	dc.acct.tierChange += tier - dc.acct.tier
-	dc.acct.tier = tier
-	dc.acct.legacyFeePaid = legacyFeePaid
-	c.log.Debugf("Tier/bonding with %v: tier = %v, tierChange = %v, targetTier = %v, bondedTiers = %v, legacy = %v",
-		dc.acct.host, tier, dc.acct.tierChange, dc.acct.targetTier, bondedTiers, legacyFeePaid)
+	effectiveTier := dc.acct.effectiveTier
+	dc.acct.tierChange += dc.acct.tier.Bonded - int64(bondedTiers)
+	dc.acct.legacyFeePaid = dc.acct.tier.Legacy
+
+	c.log.Debugf("Tier/bonding with %v: effectiveTier = %d, tierChange = %d, targetTier = %d, bondedTiers = %d, revokedTiers = %d, legacy = %t",
+		dc.acct.host, dc.acct.effectiveTier, dc.acct.tierChange, dc.acct.targetTier, dc.acct.tier.Bonded, dc.acct.tier.Revoked, dc.acct.legacyFeePaid)
 	// If tier maintenance is enabled AND tier changed, update reserves.
 	if dc.acct.targetTier > 0 && (dc.acct.tierChange != 0 || loginAuth) {
 		if bondAsset := bondAssets[dc.acct.bondAsset]; bondAsset == nil {
@@ -6802,10 +6886,10 @@ func (c *Core) authDEX(dc *dexConnection) error {
 				// may also be negative, which signifies unbonding.
 				inBonds, _ := dc.bondTotalInternal(bondAsset.ID)
 				future = int64(bondOverlap*dc.acct.targetTier*bondAsset.Amt - inBonds) // note: minus inBonds
-				if tierOffset := tier - int64(bondedTiers); tierOffset != 0 {
-					c.log.Warnf("Discrepancy between actual tier (%v) and expected tier from active bonds (%v). "+
+				if tierOffset := dc.acct.tier.Bonded - int64(bondedTiers); tierOffset != 0 {
+					c.log.Warnf("Discrepancy between actual bonded tier (%v) and expected tier from active bonds (%v). "+
 						"Offset: %v (negative implies penalties / positive implies bonus)", // or bug
-						tier, bondedTiers, tierOffset)
+						dc.acct.tier.Bonded, bondedTiers, tierOffset)
 					if tierOffset < 0 { // make up for penalties, but don't go the other way yet
 						future -= tierOffset * int64(bondAsset.Amt)
 					}
@@ -6841,7 +6925,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 		bond := confirmed.bond
 		bondIDStr := coinIDString(bond.AssetID, bond.CoinID)
 		c.log.Debugf("Confirming pending bond %v that is confirmed server side", bondIDStr)
-		if err = c.bondConfirmed(dc, bond.AssetID, bond.CoinID, tier /* no change */); err != nil {
+		if err = c.bondConfirmed(dc, bond.AssetID, bond.CoinID, effectiveTier /* no change */); err != nil {
 			c.log.Errorf("Unable to confirm bond %s: %v", bondIDStr, err)
 		}
 	}
@@ -8673,8 +8757,9 @@ func handleTierChangeMsg(c *Core, dc *dexConnection, msg *msgjson.Message) error
 		return newError(signatureErr, "handleTierChangeMsg: DEX signature validation error: %v", err) // warn?
 	}
 	dc.acct.authMtx.Lock()
-	dc.acct.tierChange += tierChanged.Tier - dc.acct.tier // normally negative with this ntfn
-	dc.acct.tier = tierChanged.Tier
+	dc.acct.tierChange += tierChanged.Tier - dc.acct.effectiveTier // normally negative with this ntfn
+	dc.acct.effectiveTier = tierChanged.Tier
+	dc.updateTierReport(tierChanged.TierReportV2, &tierChanged.Tier, nil, nil)
 	targetTier := dc.acct.targetTier
 	dc.acct.authMtx.Unlock()
 	c.log.Infof("Received tierchanged notification from %v for account %v. New tier = %v (target = %d)",

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -10533,9 +10533,9 @@ func TestUpdateBondOptions(t *testing.T) {
 			name: "set target tier to 1",
 			bal:  singlyBondedReserves,
 			form: BondOptionsForm{
-				Addr:       acct.host,
-				TargetTier: &targetTier,
-				BondAsset:  &bondAsset.ID,
+				Addr:        acct.host,
+				TargetTier:  &targetTier,
+				BondAssetID: &bondAsset.ID,
 			},
 			after: acctState{
 				targetTier:   1,
@@ -10547,9 +10547,9 @@ func TestUpdateBondOptions(t *testing.T) {
 			name: "low balance",
 			bal:  singlyBondedReserves - 1,
 			form: BondOptionsForm{
-				Addr:       acct.host,
-				TargetTier: &targetTier,
-				BondAsset:  &bondAsset.ID,
+				Addr:        acct.host,
+				TargetTier:  &targetTier,
+				BondAssetID: &bondAsset.ID,
 			},
 			wantErr: true,
 		},
@@ -10559,7 +10559,7 @@ func TestUpdateBondOptions(t *testing.T) {
 			form: BondOptionsForm{
 				Addr:         acct.host,
 				TargetTier:   &targetTier,
-				BondAsset:    &bondAsset.ID,
+				BondAssetID:  &bondAsset.ID,
 				MaxBondedAmt: &tooLowMaxBonded,
 			},
 			wantErr: true,
@@ -10567,9 +10567,9 @@ func TestUpdateBondOptions(t *testing.T) {
 		{
 			name: "unsupported bond asset",
 			form: BondOptionsForm{
-				Addr:       acct.host,
-				TargetTier: &targetTier,
-				BondAsset:  &wrongBondAssetID,
+				Addr:        acct.host,
+				TargetTier:  &targetTier,
+				BondAssetID: &wrongBondAssetID,
 			},
 			wantErr: true,
 		},
@@ -10577,9 +10577,9 @@ func TestUpdateBondOptions(t *testing.T) {
 			name: "lower target tier with zero balance OK",
 			bal:  0,
 			form: BondOptionsForm{
-				Addr:       acct.host,
-				TargetTier: &targetTierZero,
-				BondAsset:  &bondAsset.ID,
+				Addr:        acct.host,
+				TargetTier:  &targetTierZero,
+				BondAssetID: &bondAsset.ID,
 			},
 			before: acctState{
 				targetTier:   1,
@@ -10592,9 +10592,9 @@ func TestUpdateBondOptions(t *testing.T) {
 			name: "lower target tier to zero with other exchanges still keeps reserves",
 			bal:  0,
 			form: BondOptionsForm{
-				Addr:       acct.host,
-				TargetTier: &targetTierZero,
-				BondAsset:  &bondAsset.ID,
+				Addr:        acct.host,
+				TargetTier:  &targetTierZero,
+				BondAssetID: &bondAsset.ID,
 			},
 			before: acctState{
 				targetTier:   1,

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2161,6 +2161,7 @@ func TestPostBond(t *testing.T) {
 				}
 			case *BalanceNote:
 				balanceNotes++
+			case *ReputationNote: // ignore
 			default:
 				t.Fatalf("wrong notification (%T). Expected FeePaymentNote or BalanceNote", ntfn)
 			}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -10513,7 +10513,9 @@ func TestUpdateBondOptions(t *testing.T) {
 	var targetTierZero uint64 = 0
 	defaultMaxBondedAmt := maxBondedMult * bondAsset.Amt * targetTier
 	tooLowMaxBonded := defaultMaxBondedAmt - 1
-	singlyBondedReserves := bondAsset.Amt*targetTier + bondFeeBuffer
+	// Double because we will reserve for the bond that's about to be posted
+	// in rotateBonds too.
+	singlyBondedReserves := bondAsset.Amt*targetTier*2 + bondFeeBuffer
 
 	type acctState struct {
 		targetTier   uint64

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -679,8 +679,10 @@ type ReputationNote struct {
 
 const TopicReputationUpdate = "ReputationUpdate"
 
-func newReputationNote(host string, rep account.Reputation) *LoginNote {
-	return &LoginNote{
+func newReputationNote(host string, rep account.Reputation) *ReputationNote {
+	return &ReputationNote{
 		Notification: db.NewNotification(NoteTypeReputation, TopicReputationUpdate, "", "", db.Data),
+		Host:         host,
+		Reputation:   rep,
 	}
 }

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -270,7 +270,7 @@ type BondPostNote struct {
 	db.Notification
 	Asset         *uint32 `json:"asset,omitempty"`
 	Confirmations *int32  `json:"confirmations,omitempty"`
-	Tier          *int64  `json:"tier,omitempty"`
+	BondedTier    *int64  `json:"bondedTier,omitempty"`
 	CoinID        *string `json:"coinID,omitempty"`
 	Dex           string  `json:"dex,omitempty"`
 }
@@ -291,9 +291,9 @@ func newBondPostNoteWithConfirmations(topic Topic, subject, details string, seve
 	return bondPmtNt
 }
 
-func newBondPostNoteWithTier(topic Topic, subject, details string, severity db.Severity, dexAddr string, tier int64) *BondPostNote {
+func newBondPostNoteWithTier(topic Topic, subject, details string, severity db.Severity, dexAddr string, bondedTier int64) *BondPostNote {
 	bondPmtNt := newBondPostNote(topic, subject, details, severity, dexAddr)
-	bondPmtNt.Tier = &tier
+	bondPmtNt.BondedTier = &bondedTier
 	return bondPmtNt
 }
 

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -12,6 +12,7 @@ import (
 	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
 )
 
 // Notifications should use the following note type strings.
@@ -37,6 +38,7 @@ const (
 	NoteTypeCreateWallet = "createwallet"
 	NoteTypeLogin        = "login"
 	NoteTypeWalletNote   = "walletnote"
+	NoteTypeReputation   = "reputation"
 )
 
 var noteChanCounter uint64
@@ -666,5 +668,19 @@ func newWalletNote(n asset.WalletNotification) *WalletNote {
 	return &WalletNote{
 		Notification: db.NewNotification(NoteTypeWalletNote, TopicWalletNotification, "", "", db.Data),
 		Payload:      n,
+	}
+}
+
+type ReputationNote struct {
+	db.Notification
+	Host       string
+	Reputation account.Reputation
+}
+
+const TopicReputationUpdate = "ReputationUpdate"
+
+func newReputationNote(host string, rep account.Reputation) *LoginNote {
+	return &LoginNote{
+		Notification: db.NewNotification(NoteTypeReputation, TopicReputationUpdate, "", "", db.Data),
 	}
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -769,12 +769,11 @@ type dexAccount struct {
 	pendingBonds      []*db.Bond // not yet confirmed
 	bonds             []*db.Bond // confirmed, and not yet expired
 	expiredBonds      []*db.Bond // expired and needing refund
-	rep               *account.Reputation
+	rep               account.Reputation
 	targetTier        uint64
 	maxBondedAmt      uint64
 	bondAsset         uint32 // asset used for bond maintenance/rotation
 	legacyFeePaid     bool   // server reports a legacy fee paid
-	getOutOfJail      bool
 
 	// Legacy reg fee (V0PURGE)
 	feeAssetID uint32
@@ -946,7 +945,6 @@ func (a *dexAccount) authed() bool {
 func (a *dexAccount) unAuth() {
 	a.authMtx.Lock()
 	a.isAuthed = false
-	a.rep = nil
 	a.legacyFeePaid = false
 	a.authMtx.Unlock()
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -651,16 +651,16 @@ type BondOptions struct {
 }
 
 type ExchangeAuth struct {
-	Rep             account.Reputation           `json:"rep"`
-	BondAssetID     uint32                       `json:"bondAssetID"`
-	PendingStrength int64                        `json:"pendingStrength"`
-	WeakStrength    int64                        `json:"weakStrength"`
-	LiveStrength    int64                        `json:"liveStrength"`
-	TargetTier      uint64                       `json:"targetTier"`
-	EffectiveTier   int64                        `json:"effectiveTier"`
-	MaxBondedAmt    uint64                       `json:"maxBondedAmt"`
-	PenaltyComps    uint16                       `json:"penaltyComps"`
-	PendingBonds    map[string]*PendingBondState `json:"pendingBonds"`
+	Rep             account.Reputation  `json:"rep"`
+	BondAssetID     uint32              `json:"bondAssetID"`
+	PendingStrength int64               `json:"pendingStrength"`
+	WeakStrength    int64               `json:"weakStrength"`
+	LiveStrength    int64               `json:"liveStrength"`
+	TargetTier      uint64              `json:"targetTier"`
+	EffectiveTier   int64               `json:"effectiveTier"`
+	MaxBondedAmt    uint64              `json:"maxBondedAmt"`
+	PenaltyComps    uint16              `json:"penaltyComps"`
+	PendingBonds    []*PendingBondState `json:"pendingBonds"`
 }
 
 // Exchange represents a single DEX with any number of markets.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -661,6 +661,7 @@ type ExchangeAuth struct {
 	MaxBondedAmt    uint64              `json:"maxBondedAmt"`
 	PenaltyComps    uint16              `json:"penaltyComps"`
 	PendingBonds    []*PendingBondState `json:"pendingBonds"`
+	Compensation    int64               `json:"compensation"`
 }
 
 // Exchange represents a single DEX with any number of markets.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -192,7 +192,7 @@ type BondOptionsForm struct {
 	TargetTier   *uint64 `json:"targetTier,omitempty"`
 	MaxBondedAmt *uint64 `json:"maxBondedAmt,omitempty"`
 	PenaltyComps uint16  `json:"penaltyComps"`
-	BondAsset    *uint32 `json:"bondAsset,omitempty"`
+	BondAssetID  *uint32 `json:"bondAssetID,omitempty"`
 }
 
 // PostBondForm is information necessary to post a new bond for a new or
@@ -633,6 +633,7 @@ type FeeAsset BondAsset
 // PendingBondState conveys a pending bond's asset and current confirmation
 // count.
 type PendingBondState struct {
+	CoinID  string `json:"coinID"`
 	Symbol  string `json:"symbol"`
 	AssetID uint32 `json:"assetID"`
 	Confs   uint32 `json:"confs"`
@@ -649,22 +650,31 @@ type BondOptions struct {
 	PenaltyComps uint16 `json:"PenaltyComps"`
 }
 
+type ExchangeAuth struct {
+	Rep             account.Reputation           `json:"rep"`
+	BondAssetID     uint32                       `json:"bondAssetID"`
+	PendingStrength int64                        `json:"pendingStrength"`
+	WeakStrength    int64                        `json:"weakStrength"`
+	LiveStrength    int64                        `json:"liveStrength"`
+	TargetTier      uint64                       `json:"targetTier"`
+	EffectiveTier   int64                        `json:"effectiveTier"`
+	MaxBondedAmt    uint64                       `json:"maxBondedAmt"`
+	PenaltyComps    uint16                       `json:"penaltyComps"`
+	PendingBonds    map[string]*PendingBondState `json:"pendingBonds"`
+}
+
 // Exchange represents a single DEX with any number of markets.
 type Exchange struct {
-	Host             string                       `json:"host"`
-	AcctID           string                       `json:"acctID"`
-	Markets          map[string]*Market           `json:"markets"`
-	Assets           map[uint32]*dex.Asset        `json:"assets"`
-	BondExpiry       uint64                       `json:"bondExpiry"`
-	BondAssets       map[string]*BondAsset        `json:"bondAssets"`
-	ConnectionStatus comms.ConnectionStatus       `json:"connectionStatus"`
-	CandleDurs       []string                     `json:"candleDurs"`
-	ViewOnly         bool                         `json:"viewOnly"`
-	Reputation       account.Reputation           `json:"reputation"`
-	BondedTier       int64                        `json:"bondedTier"`
-	WeakBonds        uint32                       `json:"weakTiers"`
-	BondOptions      *BondOptions                 `json:"bondOptions"`
-	PendingBonds     map[string]*PendingBondState `json:"pendingBonds"`
+	Host             string                 `json:"host"`
+	AcctID           string                 `json:"acctID"`
+	Markets          map[string]*Market     `json:"markets"`
+	Assets           map[uint32]*dex.Asset  `json:"assets"`
+	BondExpiry       uint64                 `json:"bondExpiry"`
+	BondAssets       map[string]*BondAsset  `json:"bondAssets"`
+	ConnectionStatus comms.ConnectionStatus `json:"connectionStatus"`
+	CandleDurs       []string               `json:"candleDurs"`
+	ViewOnly         bool                   `json:"viewOnly"`
+	Auth             ExchangeAuth           `json:"auth"`
 	// TODO: Bonds slice(s) - and a LockedInBonds(assetID) method
 
 	// OLD fields for the legacy registration fee (V0PURGE):

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -650,18 +650,35 @@ type BondOptions struct {
 	PenaltyComps uint16 `json:"PenaltyComps"`
 }
 
+// ExchangeAuth is data characterizing the state of client bonding.
 type ExchangeAuth struct {
-	Rep             account.Reputation  `json:"rep"`
-	BondAssetID     uint32              `json:"bondAssetID"`
-	PendingStrength int64               `json:"pendingStrength"`
-	WeakStrength    int64               `json:"weakStrength"`
-	LiveStrength    int64               `json:"liveStrength"`
-	TargetTier      uint64              `json:"targetTier"`
-	EffectiveTier   int64               `json:"effectiveTier"`
-	MaxBondedAmt    uint64              `json:"maxBondedAmt"`
-	PenaltyComps    uint16              `json:"penaltyComps"`
-	PendingBonds    []*PendingBondState `json:"pendingBonds"`
-	Compensation    int64               `json:"compensation"`
+	// Rep is the user's Reputation as reported by the DEX server.
+	Rep account.Reputation `json:"rep"`
+	// BondAssetID is the user's currently configured bond asset.
+	BondAssetID uint32 `json:"bondAssetID"`
+	// PendingStrength counts how many tiers are in unconfirmed bonds.
+	PendingStrength int64 `json:"pendingStrength"`
+	// WeakStrength counts the number of tiers that are about to expire.
+	WeakStrength int64 `json:"weakStrength"`
+	// LiveStrength counts all active bond tiers, including weak.
+	LiveStrength int64 `json:"liveStrength"`
+	// TargetTier is the user's current configured tier level.
+	TargetTier uint64 `json:"targetTier"`
+	// EffectiveTier is the user's current tier, after considering reputation.
+	EffectiveTier int64 `json:"effectiveTier"`
+	// MaxBondedAmt is the maximum amount that can be locked in bonds at a given
+	// time. If not provided, a default is calculated based on TargetTier and
+	// PenaltyComps.
+	MaxBondedAmt uint64 `json:"maxBondedAmt"`
+	// PenaltyComps is the maximum number of penalized tiers to automatically
+	// compensate.
+	PenaltyComps uint16 `json:"penaltyComps"`
+	// PendingBonds are currently pending bonds and their confirmation count.
+	PendingBonds []*PendingBondState `json:"pendingBonds"`
+	// Compensation is the amount we have locked in bonds greater than what
+	// is needed to maintain our target tier. This could be from penalty
+	// compensation, or it could be due to the user lowering their target tier.
+	Compensation int64 `json:"compensation"`
 }
 
 // Exchange represents a single DEX with any number of markets.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -191,6 +191,7 @@ type BondOptionsForm struct {
 	Addr         string  `json:"host"`
 	TargetTier   *uint64 `json:"targetTier,omitempty"`
 	MaxBondedAmt *uint64 `json:"maxBondedAmt,omitempty"`
+	PenaltyComps uint16  `json:"penaltyComps"`
 	BondAsset    *uint32 `json:"bondAsset,omitempty"`
 }
 
@@ -645,6 +646,7 @@ type BondOptions struct {
 	BondAsset    uint32 `json:"bondAsset"`
 	TargetTier   uint64 `json:"targetTier"`
 	MaxBondedAmt uint64 `json:"maxBondedAmt"`
+	PenaltyComps uint16 `json:"PenaltyComps"`
 }
 
 // Exchange represents a single DEX with any number of markets.
@@ -772,6 +774,7 @@ type dexAccount struct {
 	rep               account.Reputation
 	targetTier        uint64
 	maxBondedAmt      uint64
+	penaltyComps      uint16 // max penalties to compensate for
 	bondAsset         uint32 // asset used for bond maintenance/rotation
 	legacyFeePaid     bool   // server reports a legacy fee paid
 

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -562,15 +562,6 @@ func (w *xcWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime time.Tim
 	return bonder.MakeBondTx(ver, amt, feeRate, lockTime, priv, acctID)
 }
 
-// ReserveBondFunds reserves funds for future bonds given known live bonds.
-func (w *xcWallet) ReserveBondFunds(future int64, feeBuffer uint64, respectBalance bool) bool {
-	bonder, ok := w.Wallet.(asset.Bonder)
-	if !ok {
-		return false
-	}
-	return bonder.ReserveBondFunds(future, feeBuffer, respectBalance)
-}
-
 // BondsFeeBuffer gets the bonds fee buffer based on the provided fee rate.
 func (w *xcWallet) BondsFeeBuffer(feeRate uint64) uint64 {
 	bonder, ok := w.Wallet.(asset.Bonder)
@@ -578,17 +569,6 @@ func (w *xcWallet) BondsFeeBuffer(feeRate uint64) uint64 {
 		return 0
 	}
 	return bonder.BondsFeeBuffer(feeRate)
-}
-
-// RegisterUnspent informs the wallet of existing bond amounts that will be
-// refunded with RefundBond. If reserves are subsequently enabled with
-// ReserveBondFunds, these amounts are combined into a "nominal" reserves.
-func (w *xcWallet) RegisterUnspent(live uint64) {
-	bonder, ok := w.Wallet.(asset.Bonder)
-	if !ok {
-		return
-	}
-	bonder.RegisterUnspent(live)
 }
 
 // RefundBond will refund the bond if the asset.Wallet implementation is a

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -1317,13 +1317,14 @@ Registration is complete after the fee transaction has been confirmed.`,
     }`,
 	},
 	bondOptionsRoute: {
-		argsShort:  `"addr" targetTier (maxBondedAmt bondAssetID)`,
+		argsShort:  `"addr" targetTier (maxBondedAmt bondAssetID penaltyComps)`,
 		cmdSummary: `Change bond options for a DEX.`,
 		argsLong: `Args:
     addr (string): The DEX address to post bond for for.
     targetTier (int): The target trading tier.
     maxBondedAmt (int): The maximum amount that may be locked in bonds.
-    bondAssetID (int): The asset ID with which to auto-post bonds.`,
+    bondAssetID (int): The asset ID with which to auto-post bonds.
+    penaltyComp (int): The maximum number of penalties to compensate`,
 		returns: `Returns: "ok"`,
 	},
 	exchangesRoute: {

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -510,7 +510,7 @@ func parseBondOptsArgs(params *RawParams) (*core.BondOptionsForm, error) {
 		Addr:         params.Args[0],
 		TargetTier:   targetTierP,
 		MaxBondedAmt: maxBondedP,
-		BondAsset:    bondAssetP,
+		BondAssetID:  bondAssetP,
 	}
 	return req, nil
 }

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -468,7 +469,7 @@ func parseBondAssetsArgs(params *RawParams) (host string, cert []byte, err error
 
 // bondopts 127.0.0.1:17273 2 2012345678 42
 func parseBondOptsArgs(params *RawParams) (*core.BondOptionsForm, error) {
-	if err := checkNArgs(params, []int{0}, []int{2, 4}); err != nil {
+	if err := checkNArgs(params, []int{0}, []int{2, 5}); err != nil {
 		return nil, err
 	}
 
@@ -506,11 +507,26 @@ func parseBondOptsArgs(params *RawParams) (*core.BondOptionsForm, error) {
 		}
 	}
 
+	var penaltyComps uint16
+	if len(params.Args) > 4 {
+		pc, err := checkIntArg(params.Args[4], "penaltyComps", 16)
+		if err != nil {
+			return nil, err
+		}
+		if pc > math.MaxUint16 {
+			return nil, fmt.Errorf("penaltyComps out of range (0, %d)", math.MaxUint16)
+		}
+		if pc > 0 {
+			penaltyComps = uint16(pc)
+		}
+	}
+
 	req := &core.BondOptionsForm{
 		Addr:         params.Args[0],
 		TargetTier:   targetTierP,
 		MaxBondedAmt: maxBondedP,
 		BondAssetID:  bondAssetP,
+		PenaltyComps: penaltyComps,
 	}
 	return req, nil
 }

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -378,19 +378,19 @@ var tExchanges = map[string]*core.Exchange{
 				Amt:   1e12,
 			},
 		},
-		CandleDurs:   []string{"1h", "24h"},
-		PendingBonds: map[string]*core.PendingBondState{},
+		CandleDurs: []string{"1h", "24h"},
+		Auth: core.ExchangeAuth{
+			PendingBonds: []*core.PendingBondState{},
+			BondAssetID:  42,
+			TargetTier:   0,
+			MaxBondedAmt: 100e8,
+		},
 		BondAssets: map[string]*core.BondAsset{
 			"dcr": {
 				ID:    42,
 				Confs: 2,
 				Amt:   1,
 			},
-		},
-		BondOptions: &core.BondOptions{
-			BondAsset:    42,
-			TargetTier:   0,
-			MaxBondedAmt: 100e8,
 		},
 		ViewOnly: true,
 	},
@@ -436,19 +436,19 @@ var tExchanges = map[string]*core.Exchange{
 				Amt:   1e10,
 			},
 		},
-		CandleDurs:   []string{"5m", "1h", "24h"},
-		PendingBonds: map[string]*core.PendingBondState{},
+		CandleDurs: []string{"5m", "1h", "24h"},
+		Auth: core.ExchangeAuth{
+			PendingBonds: []*core.PendingBondState{},
+			BondAssetID:  42,
+			TargetTier:   0,
+			MaxBondedAmt: 100e8,
+		},
 		BondAssets: map[string]*core.BondAsset{
 			"dcr": {
 				ID:    42,
 				Confs: 2,
 				Amt:   1,
 			},
-		},
-		BondOptions: &core.BondOptions{
-			BondAsset:    42,
-			TargetTier:   0,
-			MaxBondedAmt: 100e8,
 		},
 		ViewOnly: true,
 	},
@@ -645,8 +645,8 @@ func (c *TCore) PostBond(form *core.PostBondForm) (*core.PostBondResult, error) 
 	symbol := dex.BipIDSymbol(*form.Asset)
 	ba := xc.BondAssets[symbol]
 	tier := form.Bond / ba.Amt
-	xc.BondOptions.TargetTier = tier
-	xc.Reputation.BondedTier = int64(tier)
+	xc.Auth.TargetTier = tier
+	xc.Auth.Rep.BondedTier = int64(tier)
 	return &core.PostBondResult{
 		BondID:      "abc",
 		ReqConfirms: uint16(ba.Confs),

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -646,7 +646,7 @@ func (c *TCore) PostBond(form *core.PostBondForm) (*core.PostBondResult, error) 
 	ba := xc.BondAssets[symbol]
 	tier := form.Bond / ba.Amt
 	xc.BondOptions.TargetTier = tier
-	xc.Tier = int64(tier)
+	xc.Reputation.BondedTier = int64(tier)
 	return &core.PostBondResult{
 		BondID:      "abc",
 		ReqConfirms: uint16(ba.Confs),

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=98566bdc|5084a27e"></script>
+<script src="/js/entry.js?v=7ecc13d6|5084a27e"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=5548f26e|e23801a1"></script>
+<script src="/js/entry.js?v=98566bdc|5084a27e"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=7ecc13d6|5084a27e"></script>
+<script src="/js/entry.js?v=d42b3e73|6583bddc"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -487,14 +487,13 @@ export default class Application {
   /*
    * updateBondConfs updates the information for a pending bond.
    */
-  updateBondConfs (dexAddr: string, coinID: string, confs: number, assetID: number) {
+  updateBondConfs (dexAddr: string, coinID: string, confs: number) {
     const dex = this.exchanges[dexAddr]
-    const symbol = this.assets[assetID].symbol
-    dex.pendingBonds[coinID] = { confs, assetID, symbol }
+    for (const bond of dex.auth.pendingBonds) if (bond.coinID === coinID) bond.confs = confs
   }
 
-  updateTier (host: string, tier: number) {
-    this.exchanges[host].tier = tier
+  updateTier (host: string, bondedTier: number) {
+    this.exchanges[host].auth.rep.bondedTier = bondedTier
   }
 
   /*
@@ -505,7 +504,7 @@ export default class Application {
     switch (note.topic) {
       case 'RegUpdate':
         if (note.coinID !== null) { // should never be null for RegUpdate
-          this.updateBondConfs(note.dex, note.coinID, note.confirmations, note.asset)
+          this.updateBondConfs(note.dex, note.coinID, note.confirmations)
         }
         break
       case 'BondConfirmed':

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -157,6 +157,12 @@ export default class Application {
       }, 0)
     }
 
+    if (process.env.NODE_ENV === 'development') {
+      window.user = () => {
+        console.log(this.user)
+      }
+    }
+
     // use user current locale set by backend
     intl.setLocale()
   }

--- a/client/webserver/site/src/js/dexsettings.ts
+++ b/client/webserver/site/src/js/dexsettings.ts
@@ -160,13 +160,13 @@ export default class DexSettingsPage extends BasePage {
   async prepareUpdateBondOptions () {
     const page = this.page
     const xc = app().user.exchanges[this.host]
-    page.bondTargetTier.setAttribute('placeholder', xc.bondOptions.targetTier.toString())
+    page.bondTargetTier.setAttribute('placeholder', xc.auth.targetTier.toString())
     Doc.empty(page.bondAssetSelect)
     for (const [assetSymbol, bondAsset] of Object.entries(xc.bondAssets)) {
       const option = document.createElement('option') as HTMLOptionElement
       option.value = bondAsset.id.toString()
       option.textContent = assetSymbol.toUpperCase()
-      if (bondAsset.id === xc.bondOptions.bondAsset) option.selected = true
+      if (bondAsset.id === xc.auth.bondAssetID) option.selected = true
       page.bondAssetSelect.appendChild(option)
     }
     page.bondOptionsErr.textContent = ''
@@ -236,12 +236,12 @@ export default class DexSettingsPage extends BasePage {
   async updateBondOptions () {
     const page = this.page
     const targetTier = parseInt(page.bondTargetTier.value ?? '')
-    const bondAsset = parseInt(page.bondAssetSelect.value ?? '')
+    const bondAssetID = parseInt(page.bondAssetSelect.value ?? '')
 
     const bondOptions = {
       host: this.host,
       targetTier: targetTier,
-      bondAsset: bondAsset
+      bondAssetID: bondAssetID
     }
 
     const loaded = app().loading(this.body)
@@ -259,8 +259,8 @@ export default class DexSettingsPage extends BasePage {
       }, 5000)
       // update the in-memory values.
       const xc = app().user.exchanges[this.host]
-      xc.bondOptions.bondAsset = bondAsset
-      xc.bondOptions.targetTier = targetTier
+      xc.auth.bondAssetID = bondAssetID
+      xc.auth.targetTier = targetTier
     }
   }
 }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -583,7 +583,7 @@ export default class MarketsPage extends BasePage {
 
   /* hasPendingBonds is true if there are pending bonds */
   hasPendingBonds (): boolean {
-    return Object.keys(this.market.dex.pendingBonds).length > 0
+    return Object.keys(this.market.dex.auth.pendingBonds).length > 0
   }
 
   /* setCurrMarketPrice updates the current market price on the stats displays
@@ -727,7 +727,7 @@ export default class MarketsPage extends BasePage {
     const showOrderForm = async () : Promise<boolean> => {
       if (!this.assetsAreSupported().isSupported) return false // assets not supported
 
-      if (!this.market || this.market.dex.tier < 1) return false // acct suspended or not registered
+      if (!this.market || this.market.dex.auth.effectiveTier < 1) return false// acct suspended or not registered
 
       const { baseAssetApprovalStatus, quoteAssetApprovalStatus } = this.tokenAssetApprovalStatuses()
       if (baseAssetApprovalStatus !== ApprovalStatus.Approved && quoteAssetApprovalStatus !== ApprovalStatus.Approved) return false
@@ -949,12 +949,12 @@ export default class MarketsPage extends BasePage {
     page.regStatusDex.textContent = dex.host
     page.postingBondsDex.textContent = dex.host
 
-    if (dex.tier >= 1) {
+    if (dex.auth.effectiveTier >= 1) {
       this.setRegistrationStatusView(intl.prep(intl.ID_REGISTRATION_FEE_SUCCESS), '', 'completed')
       return
     }
 
-    const confStatuses = Object.values(dex.pendingBonds).map(pending => {
+    const confStatuses = Object.values(dex.auth.pendingBonds).map(pending => {
       const confirmationsRequired = dex.bondAssets[pending.symbol].confs
       return `${pending.confs} / ${confirmationsRequired}`
     })
@@ -976,7 +976,7 @@ export default class MarketsPage extends BasePage {
 
     this.updateRegistrationStatusView()
 
-    if (market.dex.tier >= 1) {
+    if (market.dex.auth.effectiveTier >= 1) {
       const toggle = async () => {
         Doc.hide(page.registrationStatus, page.bondRequired, page.bondCreationPending)
         this.resolveOrderFormVisibility()
@@ -993,10 +993,10 @@ export default class MarketsPage extends BasePage {
       Doc.show(page.notRegistered)
     } else if (this.hasPendingBonds()) {
       Doc.show(page.registrationStatus)
-    } else if (market.dex.bondOptions.targetTier > 0) {
+    } else if (market.dex.auth.targetTier > 0) {
       Doc.show(page.bondCreationPending)
     } else {
-      page.acctTier.textContent = `${market.dex.tier}`
+      page.acctTier.textContent = `${market.dex.auth.effectiveTier}`
       page.dexSettingsLink.href = `/dexsettings/${market.dex.host}`
       Doc.show(page.bondRequired)
     }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -583,7 +583,7 @@ export default class MarketsPage extends BasePage {
 
   /* hasPendingBonds is true if there are pending bonds */
   hasPendingBonds (): boolean {
-    return Object.keys(this.market.dex.auth.pendingBonds).length > 0
+    return Object.keys(this.market.dex.auth.pendingBonds || []).length > 0
   }
 
   /* setCurrMarketPrice updates the current market price on the stats displays
@@ -730,7 +730,7 @@ export default class MarketsPage extends BasePage {
       if (!this.market || this.market.dex.auth.effectiveTier < 1) return false// acct suspended or not registered
 
       const { baseAssetApprovalStatus, quoteAssetApprovalStatus } = this.tokenAssetApprovalStatuses()
-      if (baseAssetApprovalStatus !== ApprovalStatus.Approved && quoteAssetApprovalStatus !== ApprovalStatus.Approved) return false
+      if (baseAssetApprovalStatus !== ApprovalStatus.Approved || quoteAssetApprovalStatus !== ApprovalStatus.Approved) return false
 
       const { base, quote } = this.market
       const hasWallets = base && app().assets[base.id].wallet && quote && app().assets[quote.id].wallet
@@ -954,7 +954,7 @@ export default class MarketsPage extends BasePage {
       return
     }
 
-    const confStatuses = Object.values(dex.auth.pendingBonds).map(pending => {
+    const confStatuses = (dex.auth.pendingBonds || []).map(pending => {
       const confirmationsRequired = dex.bondAssets[pending.symbol].confs
       return `${pending.confs} / ${confirmationsRequired}`
     })

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -7,6 +7,7 @@ declare global {
     localeDiscrepancies: () => void
     testFormatFourSigFigs: () => void
     testFormatRateFullPrecision: () => void
+    user: () => void
   }
 }
 

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -41,6 +41,7 @@ export interface ExchangeAuth {
   maxBondedAmt: number
   penaltyComps: number
   pendingBonds: PendingBondState[]
+  compensation: number
 }
 
 export interface Exchange {

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -17,22 +17,40 @@ export enum ConnectionStatus {
 }
 
 export interface BondOptions {
-  bondAsset: number
+  bondAssetID: number
   targetTier: number
   maxBondedAmt: number
+}
+
+export interface Reputation {
+  bondedTier: number
+  penalties: number
+  legacyTier: boolean
+  score: number
+}
+
+export interface ExchangeAuth {
+  rep: Reputation
+  bondAssetID: number
+  pendingStrength: number
+  weakStrength: number
+  liveStrength: number
+  targetTier: number
+  effectiveTier: number
+  maxBondedAmt: number
+  penaltyComps: number
+  pendingBonds: PendingBondState[]
 }
 
 export interface Exchange {
   host: string
   acctID: string
+  auth: ExchangeAuth
   markets: Record<string, Market>
   assets: Record<number, Asset>
   connectionStatus: ConnectionStatus
   viewOnly: boolean
   bondAssets: Record<string, BondAsset>
-  tier: number
-  bondOptions: BondOptions
-  pendingBonds: Record<string, PendingBondState>
   candleDurs: string[]
 }
 
@@ -156,6 +174,7 @@ export interface BondAsset {
 export interface PendingBondState {
   symbol: string
   assetID: number
+  coinID: string
   confs: number
 }
 

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -946,11 +946,12 @@ func (c *Connect) Serialize() []byte {
 // Bond is information on a fidelity bond. This is part of the ConnectResult and
 // PostBondResult payloads.
 type Bond struct {
-	Version uint16 `json:"version"`
-	Amount  uint64 `json:"amount"`
-	Expiry  uint64 `json:"expiry"` // when it expires, not the lock time
-	CoinID  Bytes  `json:"coinID"` // NOTE: ID capitalization not consistent with other payloads, but internally consistent with assetID
-	AssetID uint32 `json:"assetID"`
+	Version  uint16 `json:"version"`
+	Amount   uint64 `json:"amount"`
+	Expiry   uint64 `json:"expiry"` // when it expires, not the lock time
+	CoinID   Bytes  `json:"coinID"` // NOTE: ID capitalization not consistent with other payloads, but internally consistent with assetID
+	AssetID  uint32 `json:"assetID"`
+	Strength uint32 `json:"strength"`
 }
 
 // ConnectResult is the result for the ConnectRoute request.

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -960,7 +960,7 @@ type ConnectResult struct {
 	Tier                *int64              `json:"tier"` // == v1. Deprecated in v2. means bonded and may trade, a function of active bond amounts and conduct, nil legacy
 	ActiveBonds         []*Bond             `json:"activeBonds"`
 	LegacyFeePaid       *bool               `json:"legacyFeePaid"` // == v1. Deprected in v2.
-	TierReportV2        *account.TierReport `json:"tierReportV2"`  // v2
+	Reputation          *account.Reputation `json:"reputation"`    // v2
 
 	Suspended *bool `json:"suspended,omitempty"` // DEPRECATED - implied by tier<1
 }
@@ -971,9 +971,9 @@ type ConnectResult struct {
 type TierChangedNotification struct {
 	Signature
 	// AccountID Bytes  `json:"accountID"`
-	Tier         int64               `json:"tier"`
-	TierReportV2 *account.TierReport `json:"tierReportV2"` // replaces Tier field
-	Reason       string              `json:"reason"`
+	Tier       int64               `json:"tier"`
+	Reputation *account.Reputation `json:"reputation"` // replaces Tier field
+	Reason     string              `json:"reason"`
 }
 
 // Serialize serializes the TierChangedNotification data.
@@ -1097,14 +1097,14 @@ func (pb *PostBond) Serialize() []byte {
 // true, the bond was applied to the account; if false it is not confirmed, but
 // was otherwise validated.
 type PostBondResult struct {
-	Signature                        // message is BondID | AccountID
-	AccountID    Bytes               `json:"accountID"`
-	AssetID      uint32              `json:"assetID"`
-	Amount       uint64              `json:"amount"`
-	Expiry       uint64              `json:"expiry"` // not locktime, but time when bond expires for dex
-	BondID       Bytes               `json:"bondID"`
-	Tier         int64               `json:"tier"`
-	TierReportV2 *account.TierReport `json:"tierReportV2"`
+	Signature                      // message is BondID | AccountID
+	AccountID  Bytes               `json:"accountID"`
+	AssetID    uint32              `json:"assetID"`
+	Amount     uint64              `json:"amount"`
+	Expiry     uint64              `json:"expiry"` // not locktime, but time when bond expires for dex
+	BondID     Bytes               `json:"bondID"`
+	Tier       int64               `json:"tier"`
+	Reputation *account.Reputation `json:"reputation"`
 }
 
 // Serialize serializes the PostBondResult data for the signature.
@@ -1119,10 +1119,11 @@ func (pbr *PostBondResult) Serialize() []byte {
 // expires.
 type BondExpiredNotification struct {
 	Signature
-	AccountID  Bytes  `json:"accountID"`
-	AssetID    uint32 `json:"assetid"`
-	BondCoinID Bytes  `json:"coinid"`
-	Tier       int64  `json:"tier"`
+	AccountID  Bytes               `json:"accountID"`
+	AssetID    uint32              `json:"assetid"`
+	BondCoinID Bytes               `json:"coinid"`
+	Tier       int64               `json:"tier"`
+	Reputation *account.Reputation `json:"reputation"`
 }
 
 // Serialize serializes the BondExpiredNotification data.
@@ -1310,8 +1311,8 @@ type ConfigResult struct {
 
 	RegFees map[string]*FeeAsset `json:"regFees"`
 
-	ScoreIncrement uint32 `json:"scoreIncrement"`
-	MaxScore       uint32 `json:"maxScore"`
+	PenaltyThreshold uint32 `json:"penaltyThreshold"`
+	MaxScore         uint32 `json:"maxScore"`
 }
 
 // Spot is a snapshot of a market at the end of a match cycle. A slice of Spot

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -953,13 +953,14 @@ type Bond struct {
 //
 // TODO: Include penalty data as specified in the spec.
 type ConnectResult struct {
-	Sig                 Bytes          `json:"sig"`
-	ActiveOrderStatuses []*OrderStatus `json:"activeorderstatuses"`
-	ActiveMatches       []*Match       `json:"activematches"`
-	Score               int32          `json:"score"`
-	Tier                *int64         `json:"tier"` // 1+ means bonded and may trade, a function of active bond amounts and conduct, nil legacy
-	ActiveBonds         []*Bond        `json:"activeBonds"`
-	LegacyFeePaid       *bool          `json:"legacyFeePaid"` // not set by legacy server
+	Sig                 Bytes               `json:"sig"`
+	ActiveOrderStatuses []*OrderStatus      `json:"activeorderstatuses"`
+	ActiveMatches       []*Match            `json:"activematches"`
+	Score               int32               `json:"score"`
+	Tier                *int64              `json:"tier"` // == v1. Deprecated in v2. means bonded and may trade, a function of active bond amounts and conduct, nil legacy
+	ActiveBonds         []*Bond             `json:"activeBonds"`
+	LegacyFeePaid       *bool               `json:"legacyFeePaid"` // == v1. Deprected in v2.
+	TierReportV2        *account.TierReport `json:"tierReportV2"`  // v2
 
 	Suspended *bool `json:"suspended,omitempty"` // DEPRECATED - implied by tier<1
 }
@@ -970,8 +971,9 @@ type ConnectResult struct {
 type TierChangedNotification struct {
 	Signature
 	// AccountID Bytes  `json:"accountID"`
-	Tier   int64  `json:"tier"`
-	Reason string `json:"reason"`
+	Tier         int64               `json:"tier"`
+	TierReportV2 *account.TierReport `json:"tierReportV2"` // replaces Tier field
+	Reason       string              `json:"reason"`
 }
 
 // Serialize serializes the TierChangedNotification data.
@@ -1095,13 +1097,14 @@ func (pb *PostBond) Serialize() []byte {
 // true, the bond was applied to the account; if false it is not confirmed, but
 // was otherwise validated.
 type PostBondResult struct {
-	Signature        // message is BondID | AccountID
-	AccountID Bytes  `json:"accountID"`
-	AssetID   uint32 `json:"assetID"`
-	Amount    uint64 `json:"amount"`
-	Expiry    uint64 `json:"expiry"` // not locktime, but time when bond expires for dex
-	BondID    Bytes  `json:"bondID"`
-	Tier      int64  `json:"tier"`
+	Signature                        // message is BondID | AccountID
+	AccountID    Bytes               `json:"accountID"`
+	AssetID      uint32              `json:"assetID"`
+	Amount       uint64              `json:"amount"`
+	Expiry       uint64              `json:"expiry"` // not locktime, but time when bond expires for dex
+	BondID       Bytes               `json:"bondID"`
+	Tier         int64               `json:"tier"`
+	TierReportV2 *account.TierReport `json:"tierReportV2"`
 }
 
 // Serialize serializes the PostBondResult data for the signature.
@@ -1306,6 +1309,9 @@ type ConfigResult struct {
 	BondExpiry uint64 `json:"DEV_bondExpiry"`
 
 	RegFees map[string]*FeeAsset `json:"regFees"`
+
+	ScoreIncrement uint32 `json:"scoreIncrement"`
+	MaxScore       uint32 `json:"maxScore"`
 }
 
 // Spot is a snapshot of a market at the end of a match cycle. A slice of Spot

--- a/docs/release-notes/release-notes-0.1.0.md
+++ b/docs/release-notes/release-notes-0.1.0.md
@@ -266,8 +266,8 @@ score: (1) failure to respond with a preimage for an order when the epoch for
 that order is closed (preimage miss), and (2) swap negotiation resulting in
 match revocation as described in the [previous section](#revoked-matches).
 
-The score threshold at which an account becomes suspended (ban score) is an
-operator set variable, but the default is 20.
+The score threshold at which an account becomes suspended (penalty threshold) is
+an operator set variable, but the default is 20.
 
 The adjustment to the at-fault user's score depends on the match failure:
 

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -170,10 +170,18 @@ func (r Rule) Punishable() bool {
 // Reputation is a part of a number of server-originating messages. It was
 // introduced with the v2 ConnectResult.
 type Reputation struct {
-	BondedTier int64  `json:"bondedTier"`
-	Penalties  uint16 `json:"penalties"`
-	Legacy     bool   `json:"legacyTier"`
-	Score      int32  `json:"score"`
+	// BondedTier is the tier indicated by the users active bonds. BondedTier
+	// does not account for penalties.
+	BondedTier int64 `json:"bondedTier"`
+	// Penalties are the number of tiers that are currently revoked due to low
+	// user score.
+	Penalties uint16 `json:"penalties"`
+	// Legacy is true if the server recognizes a legacy registration for this
+	// user. Legacy registration increases effective tier by 1.
+	Legacy bool `json:"legacyTier"`
+	// Score is the user's current score. Score must be evaluated against a
+	// server's configured penalty threshold to calculate penalties.
+	Score int32 `json:"score"`
 }
 
 // Effective calculates the effective tier for trading limit calculations.

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -167,19 +167,18 @@ func (r Rule) Punishable() bool {
 	return r > NoRule && r < MaxRule
 }
 
-// TierReport is a part of a number of server-originating messages. It was
+// Reputation is a part of a number of server-originating messages. It was
 // introduced with the v2 ConnectResult.
-type TierReport struct {
-	Bonded  int64 `json:"bondTier"`
-	Revoked int64 `json:"revokedTiers"`
-	Bonus   int64 `json:"bonusTiers"`
-	Legacy  bool  `json:"legacyTier"`
-	Score   int32 `json:"score"`
+type Reputation struct {
+	BondedTier int64  `json:"bondTier"`
+	Penalties  uint16 `json:"penalties"`
+	Legacy     bool   `json:"legacyTier"`
+	Score      int32  `json:"score"`
 }
 
 // Effective calculates the effective tier for trading limit calculations.
-func (r *TierReport) Effective() int64 {
-	tier := r.Bonded - r.Revoked + r.Bonus
+func (r *Reputation) EffectiveTier() int64 {
+	tier := r.BondedTier - int64(r.Penalties)
 	if r.Legacy {
 		tier++
 	}

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -170,7 +170,7 @@ func (r Rule) Punishable() bool {
 // Reputation is a part of a number of server-originating messages. It was
 // introduced with the v2 ConnectResult.
 type Reputation struct {
-	// BondedTier is the tier indicated by the users active bonds. BondedTier
+	// BondedTier is the tier indicated by the user's active bonds. BondedTier
 	// does not account for penalties.
 	BondedTier int64 `json:"bondedTier"`
 	// Penalties are the number of tiers that are currently revoked due to low

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -166,3 +166,22 @@ func (r Rule) Description() string {
 func (r Rule) Punishable() bool {
 	return r > NoRule && r < MaxRule
 }
+
+// TierReport is a part of a number of server-originating messages. It was
+// introduced with the v2 ConnectResult.
+type TierReport struct {
+	Bonded  int64 `json:"bondTier"`
+	Revoked int64 `json:"revokedTiers"`
+	Bonus   int64 `json:"bonusTiers"`
+	Legacy  bool  `json:"legacyTier"`
+	Score   int32 `json:"score"`
+}
+
+// Effective calculates the effective tier for trading limit calculations.
+func (r *TierReport) Effective() int64 {
+	tier := r.Bonded - r.Revoked + r.Bonus
+	if r.Legacy {
+		tier++
+	}
+	return tier
+}

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -170,7 +170,7 @@ func (r Rule) Punishable() bool {
 // Reputation is a part of a number of server-originating messages. It was
 // introduced with the v2 ConnectResult.
 type Reputation struct {
-	BondedTier int64  `json:"bondTier"`
+	BondedTier int64  `json:"bondedTier"`
 	Penalties  uint16 `json:"penalties"`
 	Legacy     bool   `json:"legacyTier"`
 	Score      int32  `json:"score"`

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -430,7 +430,7 @@ const (
 func NewAuthManager(cfg *Config) *AuthManager {
 	// A penalty threshold of 0 is not sensible, so have a default.
 	penaltyThreshold := int32(cfg.PenaltyThreshold)
-	if penaltyThreshold == 0 {
+	if penaltyThreshold <= 0 {
 		penaltyThreshold = DefaultPenaltyThreshold
 	}
 	// Invert sign for internal use.

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -914,7 +914,7 @@ func (auth *AuthManager) UserScore(user account.AccountID) (score int32) {
 func (auth *AuthManager) userReputation(bondTier int64, score int32, legacyFeePaid bool) *account.Reputation {
 	var penalties int32
 	if score < 0 {
-		penalties = int32(score) / int32(auth.penaltyThreshold)
+		penalties = score / auth.penaltyThreshold
 	}
 	return &account.Reputation{
 		BondedTier: bondTier,
@@ -1702,11 +1702,12 @@ func (auth *AuthManager) handleConnect(conn comms.Link, msg *msgjson.Message) *m
 		bondTier += int64(bond.Strength)
 		expireTime := lockTime.Add(-auth.bondExpiry)
 		msgBonds = append(msgBonds, &msgjson.Bond{
-			Version: bond.Version,
-			Amount:  uint64(bond.Amount),
-			Expiry:  uint64(expireTime.Unix()),
-			CoinID:  bond.CoinID,
-			AssetID: bond.AssetID,
+			Version:  bond.Version,
+			Amount:   uint64(bond.Amount),
+			Expiry:   uint64(expireTime.Unix()),
+			CoinID:   bond.CoinID,
+			AssetID:  bond.AssetID,
+			Strength: bond.Strength, // Added with v2 reputation
 		})
 		activeBonds = append(activeBonds, bond)
 	}

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -916,7 +916,9 @@ func (auth *AuthManager) tierReport(bondTier int64, score int32, legacyFeePaid b
 		Revoked: revokedTiers,
 		Bonus:   bonusTiers,
 		Legacy:  legacyFeePaid,
-		Score:   score,
+		// TODO: Reverse the signage of all violations so we get postiive scores
+		// from successes and negative score from violations.
+		Score: -score,
 	}
 }
 

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -920,9 +920,7 @@ func (auth *AuthManager) userReputation(bondTier int64, score int32, legacyFeePa
 		BondedTier: bondTier,
 		Penalties:  uint16(penalties),
 		Legacy:     legacyFeePaid,
-		// TODO: Reverse the signage of all violations so we get postiive scores
-		// from successes and negative score from violations.
-		Score: -score,
+		Score:      score,
 	}
 }
 

--- a/server/cmd/dcrdex/config.go
+++ b/server/cmd/dcrdex/config.go
@@ -50,7 +50,7 @@ const (
 	defaultHSPort              = "7252"
 	defaultAdminSrvAddr        = "127.0.0.1:6542"
 	defaultMaxUserCancels      = 2
-	defaultBanScore            = 20
+	defaultPenaltyThresh       = 20
 
 	defaultCancelThresh     = 0.95             // 19 cancels : 1 success
 	defaultBroadcastTimeout = 12 * time.Minute // accommodate certain known long block download timeouts
@@ -80,7 +80,7 @@ type dexConf struct {
 	CancelThreshold   float64
 	FreeCancels       bool
 	MaxUserCancels    uint32
-	BanScore          uint32
+	PenaltyThreshold  uint32
 	InitTakerLotLimit uint32
 	AbsTakerLotLimit  uint32
 	DEXPrivKeyPath    string
@@ -131,7 +131,7 @@ type flagsData struct {
 	CancelThreshold   float64 `long:"cancelthresh" description:"Cancellation rate threshold (cancels/all_completed)."`
 	FreeCancels       bool    `long:"freecancels" description:"No cancellation rate enforcement (unlimited cancel orders)."`
 	MaxUserCancels    uint32  `long:"maxepochcancels" description:"The maximum number of cancel orders allowed for a user in a given epoch."`
-	BanScore          uint32  `long:"banscore" description:"The accumulated penalty score at which when an account gets closed."`
+	PenaltyThreshold  uint32  `long:"penaltythreshold" description:"The accumulated penalty score at which when a bond is revoked."`
 	InitTakerLotLimit uint32  `long:"inittakerlotlimit" description:"The starting limit on the number of settling lots per-market for new users. Used to limit size of likely-taker orders."`
 	AbsTakerLotLimit  uint32  `long:"abstakerlotlimit" description:"The upper limit on the number of settling lots per-market for a user regardless of their swap history. Used to limit size of likely-taker orders."`
 
@@ -263,7 +263,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		TxWaitExpiration: defaultTxWaitExpiration,
 		CancelThreshold:  defaultCancelThresh,
 		MaxUserCancels:   defaultMaxUserCancels,
-		BanScore:         defaultBanScore,
+		PenaltyThreshold: defaultPenaltyThresh,
 	}
 
 	// Pre-parse the command line options to see if an alternative config file
@@ -541,7 +541,7 @@ func loadConfig() (*dexConf, *procOpts, error) {
 		CancelThreshold:   cfg.CancelThreshold,
 		MaxUserCancels:    cfg.MaxUserCancels,
 		FreeCancels:       cfg.FreeCancels,
-		BanScore:          cfg.BanScore,
+		PenaltyThreshold:  cfg.PenaltyThreshold,
 		InitTakerLotLimit: cfg.InitTakerLotLimit,
 		AbsTakerLotLimit:  cfg.AbsTakerLotLimit,
 		DEXPrivKeyPath:    cfg.DEXPrivKeyPath,

--- a/server/cmd/dcrdex/main.go
+++ b/server/cmd/dcrdex/main.go
@@ -138,7 +138,7 @@ func mainCore(ctx context.Context) error {
 		TxWaitExpiration:  cfg.TxWaitExpiration,
 		CancelThreshold:   cfg.CancelThreshold,
 		FreeCancels:       cfg.FreeCancels,
-		BanScore:          cfg.BanScore,
+		PenaltyThreshold:  cfg.PenaltyThreshold,
 		InitTakerLotLimit: cfg.InitTakerLotLimit,
 		AbsTakerLotLimit:  cfg.AbsTakerLotLimit,
 		DEXPrivKey:        privKey,

--- a/server/cmd/dcrdex/sample-dcrdex.conf
+++ b/server/cmd/dcrdex/sample-dcrdex.conf
@@ -154,9 +154,9 @@
 ; Default value is 2.
 ; maxepochcancels=2
 
-; The accumulated penalty score at which when an account gets closed.
+; The accumulated penalty score at which when a bond is revoked.
 ; Default value is 20.
-; banscore=20
+; penaltythreshold=20
 
 ; The starting limit on the number of settling lots per-market for new users. 
 ; Used to limit size of likely-taker orders.

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -160,6 +160,8 @@ func newConfigResponse(cfg *DexConf, regAssets map[string]*msgjson.FeeAsset, bon
 		BondExpiry:       uint64(dex.BondExpiry(cfg.Network)), // temporary while we figure it out
 		BinSizes:         candles.BinSizes,
 		RegFees:          regAssets,
+		ScoreIncrement:   cfg.BanScore,
+		MaxScore:         auth.ScoringMatchLimit,
 	}
 
 	// NOTE/TODO: To include active epoch in the market status objects, we need
@@ -672,6 +674,10 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		}
 		bondCoinID, amt, _, _, lockTime, acct, err = bc.ParseBondTx(version, rawTx)
 		return
+	}
+
+	if cfg.BanScore == 0 {
+		cfg.BanScore = auth.DefaultBanScore
 	}
 
 	authCfg := auth.Config{

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -86,7 +86,7 @@ type DexConf struct {
 	TxWaitExpiration  time.Duration
 	CancelThreshold   float64
 	FreeCancels       bool
-	BanScore          uint32
+	PenaltyThreshold  uint32
 	InitTakerLotLimit uint32
 	AbsTakerLotLimit  uint32
 	DEXPrivKey        *secp256k1.PrivateKey
@@ -160,7 +160,7 @@ func newConfigResponse(cfg *DexConf, regAssets map[string]*msgjson.FeeAsset, bon
 		BondExpiry:       uint64(dex.BondExpiry(cfg.Network)), // temporary while we figure it out
 		BinSizes:         candles.BinSizes,
 		RegFees:          regAssets,
-		ScoreIncrement:   cfg.BanScore,
+		PenaltyThreshold: cfg.PenaltyThreshold,
 		MaxScore:         auth.ScoringMatchLimit,
 	}
 
@@ -676,8 +676,8 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		return
 	}
 
-	if cfg.BanScore == 0 {
-		cfg.BanScore = auth.DefaultBanScore
+	if cfg.PenaltyThreshold == 0 {
+		cfg.PenaltyThreshold = auth.DefaultPenaltyThreshold
 	}
 
 	authCfg := auth.Config{
@@ -694,7 +694,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		MiaUserTimeout:    cfg.BroadcastTimeout,
 		CancelThreshold:   cfg.CancelThreshold,
 		FreeCancels:       cfg.FreeCancels,
-		BanScore:          cfg.BanScore,
+		PenaltyThreshold:  cfg.PenaltyThreshold,
 		InitTakerLotLimit: cfg.InitTakerLotLimit,
 		AbsTakerLotLimit:  cfg.AbsTakerLotLimit,
 		TxDataSources:     txDataSources,
@@ -707,7 +707,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	if authCfg.FreeCancels {
 		log.Infof("Cancellations are NOT COUNTED (the cancellation rate threshold is ignored).")
 	}
-	log.Infof("Ban score threshold is %v", cfg.BanScore)
+	log.Infof("Penalty threshold is %v", cfg.PenaltyThreshold)
 
 	// Create a swapDone dispatcher for the Swapper.
 	swapDone := func(ord order.Order, match *order.Match, fail bool) {

--- a/server/swap/swap_test.go
+++ b/server/swap/swap_test.go
@@ -219,7 +219,6 @@ func (m *TAuthManager) Route(string,
 func (m *TAuthManager) SwapSuccess(id account.AccountID, mmid db.MarketMatchID, value uint64, refTime time.Time) {
 }
 func (m *TAuthManager) Inaction(id account.AccountID, step auth.NoActionStep, mmid db.MarketMatchID, matchValue uint64, refTime time.Time, oid order.OrderID) {
-	// banscore of zero => immediate penalize
 	m.penalize(id, account.FailureToAct)
 }
 func (m *TAuthManager) penalize(id account.AccountID, rule account.Rule) {


### PR DESCRIPTION
### Server
1. Eliminate "bonus tiers". They weren't doing anything.
1. Server sends updates for score changes too.
1. Reverse scoring signage to match common convention.

### Client

1. Simplify `asset.Bonder`. There was a lot of tracking going on in our `Bonder` implementations that was used **exclusively** for logging. I can see an argument being made that the wallet **should** know about outstanding bond value, but the wallet didn't even know the bond IDs, so the wallets weren't really managing bonds in any way that added security. There was really nothing happening that couldn't be logged by the caller. Also swaps out the diff-based approach to reserves management, which is tedious and error-prone, to a simpler idempotent setter pattern.
1. Add `Strength` field to various `Bond` structs. That's how the server calculates tier already. Client was using a different calc. Changes to bond asset configuration could have gotten client and server out of sync.
1. Penalties are not auto-compensated by default. User will need to set a non-zero `PenaltyComps` value for the account in order for penalties to be compensated. `PenaltyComps` works in conjunction with `MaxBondedAmt`, but specifically applies to limiting penalties.
1. Parallel tracks will now merge. This is accomplished by shortening the lifetime of a new bond if there is an existing live bond with which this bond can be merged upon expiration.
1. For v1 rep servers, we will periodically re-auth since the `ConnectResult` is the only place we can get our score.

Replaces #2471 