### PR TITLE
dex/testing/firo: remove duplicate build tag

### DIFF
--- a/dex/testing/firo/test/electrumx_network_test.go
+++ b/dex/testing/firo/test/electrumx_network_test.go
@@ -15,8 +15,6 @@
 // ElectrumX-Firo server:	dex/testing/firo/electrumx.sh
 // export REGTEST=1
 
-//go:build live
-
 package firo
 
 import (


### PR DESCRIPTION
Came out of the squash merge, apparently.