### PR TITLE
client/core: allow maker match status MatchConfirmed when redeem can't be reported

### DIFF
--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -2891,7 +2891,7 @@ func (t *trackedTrade) confirmRedemptions(matches []*matchTracker) {
 // mutex lock held for writes.
 func (t *trackedTrade) confirmRedemption(match *matchTracker) (bool, error) {
 	if confs := match.redemptionConfs; confs > 0 && confs >= match.redemptionConfsReq { // already there, stop checking
-		if len(match.MetaData.Proof.Auth.RedeemSig) == 0 && !t.isSelfGoverned() {
+		if len(match.MetaData.Proof.Auth.RedeemSig) == 0 && (!t.isSelfGoverned() && !match.MetaData.Proof.IsRevoked()) {
 			return false, nil // waiting on redeem request to succeed
 		}
 		// Redeem request just succeeded or we gave up on the server.


### PR DESCRIPTION
I had to do this in order for the **simnet-trade-tests** `makerghost` test to pass, e.g. `./run dcrbtrc -t makerghost`.

When we, for the purposes of testing, intentionally block the maker from sending their `redeem` \o the server, the maker is stuck in the status `MakerSwapCast`. The server will eventually revoke the match, and the maker seems to be stuck in `MakerSwapCast` indefinitely, never satisfying the test, but more importantly blocking the order from being retired.

In practice, this would be like the maker losing contact with the server before redeeming and not establishing contact again until after the server revokes the match. So unless I'm missing something, this scenario is possible, could be caused by user intervention, and we're just not handling it.

closes https://github.com/decred/dcrdex/issues/2465