### PR TITLE
client/{core,mm}: Rebalance on EpochMatchSummary instead of new epoch

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -184,13 +184,16 @@ func (b *bookie) logEpochReport(note *msgjson.EpochReportNote) error {
 
 	marketID := marketName(b.base, b.quote)
 	matchSummaries := b.AddRecentMatches(note.MatchSummary, note.EndStamp)
-	if len(note.MatchSummary) > 0 {
-		b.send(&BookUpdate{
-			Action:   EpochMatchSummary,
-			MarketID: marketID,
-			Payload:  matchSummaries,
-		})
-	}
+
+	b.send(&BookUpdate{
+		Action:   EpochMatchSummary,
+		MarketID: marketID,
+		Payload: &EpochMatchSummaryPayload{
+			MatchSummaries: matchSummaries,
+			Epoch:          note.Epoch,
+		},
+	})
+
 	for durStr, cache := range b.candleCaches {
 		c, ok := cache.addCandle(&note.Candle)
 		if !ok {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1500,6 +1500,7 @@ func TestBookFeed(t *testing.T) {
 	dc := rig.dc
 
 	checkAction := func(feed BookFeed, action string) {
+		t.Helper()
 		select {
 		case u := <-feed.Next():
 			if u.Action != action {
@@ -1728,6 +1729,8 @@ func TestBookFeed(t *testing.T) {
 		t.Fatalf("handleEpochReportMsg error: %v", err)
 	}
 
+	checkAction(feed2, EpochMatchSummary)
+
 	// We'll only receive 1 candle update, since we only synced one set of
 	// candles so far.
 	checkAction(feed2, CandleUpdateAction)
@@ -1743,6 +1746,7 @@ func TestBookFeed(t *testing.T) {
 	if err := handleEpochReportMsg(tCore, dc, epochReport); err != nil {
 		t.Fatalf("handleEpochReportMsg error: %v", err)
 	}
+	checkAction(feed2, EpochMatchSummary)
 	checkAction(feed2, CandleUpdateAction)
 	checkAction(feed2, CandleUpdateAction)
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -743,6 +743,11 @@ type CandlesPayload struct {
 	Candles      []msgjson.Candle `json:"candles"`
 }
 
+type EpochMatchSummaryPayload struct {
+	MatchSummaries []*orderbook.MatchSummary `json:"matchSummaries"`
+	Epoch          uint64                    `json:"epoch"`
+}
+
 // dexAccount is the core type to represent the client's account information for
 // a DEX.
 type dexAccount struct {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -103,7 +103,7 @@
 {{end}}
 
 {{define "bottom"}}
-<script src="/js/entry.js?v=0a518229|5c5461e5"></script>
+<script src="/js/entry.js?v=faadd923|2e83f47d"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1812,7 +1812,7 @@ export default class MarketsPage extends BasePage {
   }
 
   handleEpochMatchSummary (data: BookUpdate) {
-    this.addRecentMatches(data.payload)
+    this.addRecentMatches(data.payload.matchSummaries)
     this.refreshRecentMatchesTable()
   }
 


### PR DESCRIPTION
Updates the basic market maker to rebalance when the order book receives an `EpochMatchSummary` notification from the server instead of when an `EpochNotification` arrives. When the `EpochNotification` arrives, the OrderBook has not yet been updated with the matches of the previous epoch.