### PR TITLE
go.mod/workflow/Dockerfile: version update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.19', '1.20']
+        go: ['1.20', '1.21']
     steps:
       - uses: awalsh128/cache-apt-pkgs-action@1850ee53f6e706525805321a3f2f863dcf73c962 #v1.3.0
         with:
@@ -16,21 +16,21 @@ jobs:
           version: 1.0
 
       - name: Set up Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #v4.1.0
         with:
           go-version: ${{ matrix.go }}
 
       - name: Check out source
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
         with:
           fetch-depth: 0
       # Restore original file modification times for test cache reasons
       - name: restore timestamps
         run: git restore-mtime
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.53.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2"
       - name: Use test and module cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 #v3.3.1
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
           path: |
             ~/.cache/go-build
@@ -52,9 +52,9 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
     - name: Use nodejs ${{ matrix.node-version }}
-      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c #v3.6.0
+      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d #v3.8.1
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm clean-install
@@ -71,8 +71,8 @@ jobs:
     name: Lint Markdown
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
-    - uses: DavidAnson/markdownlint-cli2-action@bb4bb94c73936643d73d345b48fead3e96f90a5e #v10.0.1
+    - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
+    - uses: DavidAnson/markdownlint-cli2-action@3aaa38e446fbd2c288af4291aa0f55d64651050f #v12.0.0
       continue-on-error: true
       with:
         globs: |

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -10,7 +10,14 @@
 #
 
 # frontend build
-FROM node:19-buster-slim AS nodebuilder
+
+# The image below is node:current-alpine3.18 (linux/amd64)
+# It's pulled by the digest (immutable id) to avoid supply-chain attacks.
+# Maintainer Note:
+#    To update to a new digest, you must first manually pull the new image:
+#    `docker pull node:<new version>`
+#    Docker will print the digest of the new image after the pull has finished.
+FROM node@sha256:d75175d449921d06250afd87d51f39a74fc174789fa3c50eba0d3b18369cc749 AS nodebuilder
 WORKDIR /root/dex
 COPY . .
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y git
@@ -19,7 +26,14 @@ RUN npm clean-install
 RUN npm run build
 
 # dexc binary build
-FROM golang:1.19-alpine AS gobuilder
+
+# The image below is golang:1.21.0-alpine3.18 (linux/amd64)
+# It's pulled by the digest (immutable id) to avoid supply-chain attacks.
+# Maintainer Note:
+#    To update to a new digest, you must first manually pull the new image:
+#    `docker pull golang:<new version>`
+#    Docker will print the digest of the new image after the pull has finished.
+FROM golang@sha256:445f34008a77b0b98bf1821bf7ef5e37bb63cc42d22ee7c21cc17041070d134f AS gobuilder
 COPY --from=nodebuilder /root/dex/ /root/dex/
 WORKDIR /root/dex/client/cmd/dexc/
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build

--- a/client/cmd/dexc-desktop/go.mod
+++ b/client/cmd/dexc-desktop/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrdex/client/cmd/dexc-desktop
 
-go 1.18
+go 1.19
 
 replace decred.org/dcrdex => ../../..
 

--- a/dex/testing/loadbot/go.mod
+++ b/dex/testing/loadbot/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrdex/dex/testing/loadbot
 
-go 1.18
+go 1.19
 
 replace decred.org/dcrdex => ../../../
 

--- a/docs/wiki/Server-Installation.md
+++ b/docs/wiki/Server-Installation.md
@@ -3,7 +3,7 @@
 ## Server Dependencies
 
 1. Linux or MacOS
-2. [Go >= 1.18](https://golang.org/doc/install)
+2. [Go >= 1.19](https://golang.org/doc/install)
 3. [PostgreSQL 11+](https://www.postgresql.org/download/), [tuned](https://pgtune.leopard.in.ua/) and running.
 4. Decred (dcrd) and Bitcoin (bitcoind) full nodes, and any other assets' full nodes, both with `txindex` enabled.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrdex
 
-go 1.18
+go 1.19
 
 require (
 	decred.org/dcrwallet/v3 v3.0.1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -32,7 +32,7 @@ do
 
 	# Run `go mod tidy` and fail if the git status of go.mod and/or
 	# go.sum changes. Only do this for the latest Go version.
-	if [[ "$GV" =~ ^1.20 ]]; then
+	if [[ "$GV" =~ ^1.21 ]]; then
 		MOD_STATUS=$(git status --porcelain go.mod go.sum)
 		go mod tidy
 		UPDATED_MOD_STATUS=$(git status --porcelain go.mod go.sum)


### PR DESCRIPTION
- Bump go.mod versions from 1.18 to 1.19
- Bump CI build.yml versions to 1.20 and 1.21
- Bump CI action versions
- Update Go and Node Dockfile images to 1.21.0 and 20.6.1 respectively.

I don't know when we should update our required Go versions but with the recent release of Go 1.21 I think it's time to bump to at least 1.19.

 To verify the docker images:
 $ docker pull golang:1.21.0-alpine3.18 for Go
 $ docker pull node:current-alpine3.18 for Node