### PR TITLE
client/mm: Arb Market Maker

### DIFF
--- a/client/mm/config.go
+++ b/client/mm/config.go
@@ -4,13 +4,6 @@ import (
 	"fmt"
 )
 
-// MarketMakingWithCEXConfig is the configuration for a market
-// maker that places orders on both sides of the order book, but
-// only if there is profitable counter-trade on the CEX
-// order book.
-type MarketMakingWithCEXConfig struct {
-}
-
 type BalanceType uint8
 
 const (
@@ -49,9 +42,9 @@ type BotConfig struct {
 	QuoteBalance     uint64      `json:"quoteBalance"`
 
 	// Only one of the following configs should be set
-	BasicMMConfig   *BasicMarketMakingConfig   `json:"basicMarketMakingConfig,omitempty"`
-	SimpleArbConfig *SimpleArbConfig           `json:"simpleArbConfig,omitempty"`
-	MMWithCEXConfig *MarketMakingWithCEXConfig `json:"marketMakingWithCEXConfig,omitempty"`
+	BasicMMConfig        *BasicMarketMakingConfig `json:"basicMarketMakingConfig,omitempty"`
+	SimpleArbConfig      *SimpleArbConfig         `json:"simpleArbConfig,omitempty"`
+	ArbMarketMakerConfig *ArbMarketMakerConfig    `json:"arbMarketMakerConfig,omitempty"`
 
 	Disabled bool `json:"disabled"`
 }

--- a/client/mm/libxc/binance.go
+++ b/client/mm/libxc/binance.go
@@ -552,7 +552,7 @@ func (bnc *binance) requestInto(req *http.Request, thing interface{}) error {
 		return nil
 	}
 	// TODO: use buffered reader
-	reader := io.LimitReader(resp.Body, 1<<20)
+	reader := io.LimitReader(resp.Body, 1<<22)
 	r, err := io.ReadAll(reader)
 	if err != nil {
 		return err

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -980,13 +980,25 @@ func (m *MarketMaker) Run(ctx context.Context, pw []byte, alternateConfigPath *s
 			wg.Add(1)
 			go func(cfg *BotConfig) {
 				defer wg.Done()
-				logger := m.log.SubLogger(fmt.Sprintf("Arbitrage-%s-%d-%d", cfg.Host, cfg.BaseAsset, cfg.QuoteAsset))
+				logger := m.log.SubLogger(fmt.Sprintf("SimpleArbitrage-%s-%d-%d", cfg.Host, cfg.BaseAsset, cfg.QuoteAsset))
 				cex, err := getConnectedCEX(cfg.SimpleArbConfig.CEXName)
 				if err != nil {
-					logger.Errorf("failed to connect to CEX: %v", err)
+					logger.Errorf("Failed to connect to CEX: %v", err)
 					return
 				}
 				RunSimpleArbBot(m.ctx, cfg, m.core, cex, logger)
+			}(cfg)
+		case cfg.ArbMarketMakerConfig != nil:
+			wg.Add(1)
+			go func(cfg *BotConfig) {
+				defer wg.Done()
+				logger := m.log.SubLogger(fmt.Sprintf("ArbMarketMaker-%s-%d-%d", cfg.Host, cfg.BaseAsset, cfg.QuoteAsset))
+				cex, err := getConnectedCEX(cfg.ArbMarketMakerConfig.CEXName)
+				if err != nil {
+					logger.Errorf("Failed to connect to CEX: %v", err)
+					return
+				}
+				RunArbMarketMaker(m.ctx, cfg, m.core, cex, logger)
 			}(cfg)
 		default:
 			m.log.Errorf("No bot config provided. Skipping %s-%d-%d", cfg.Host, cfg.BaseAsset, cfg.QuoteAsset)

--- a/client/mm/mm_arb_market_maker.go
+++ b/client/mm/mm_arb_market_maker.go
@@ -1,0 +1,651 @@
+package mm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/client/mm/libxc"
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/calc"
+	"decred.org/dcrdex/dex/order"
+)
+
+// ArbMarketMakingPlacement is the configuration for an order placement
+// on the DEX order book based on the existing orders on a CEX order book.
+type ArbMarketMakingPlacement struct {
+	Lots       uint64  `json:"lots"`
+	Multiplier float64 `json:"multiplier"`
+}
+
+// ArbMarketMakerConfig is the configuration for a market maker that places
+// orders on both sides of the DEX order book, at rates where there are
+// profitable counter trades on a CEX order book. Whenever a DEX order is
+// filled, the opposite trade will immediately be made on the CEX.
+//
+// Each placement in BuyPlacements and SellPlacements represents an order
+// that will be made on the DEX order book. The first placement will be
+// placed at a rate closest to the CEX mid-gap, and each subsequent one
+// will get farther.
+//
+// The bot calculates the extrema rate on the CEX order book where it can
+// buy or sell the quantity of lots specified in the placement multiplied
+// by the multiplier amount. This will be the rate of the expected counter
+// trade. The bot will then place an order on the DEX order book where if
+// both trades are filled, the bot will earn the profit specified in the
+// configuration.
+//
+// The multiplier is important because it ensures that even some of the
+// trades closest to the mid-gap on the CEX order book are filled before
+// the bot's orders on the DEX are matched, the bot will still be able to
+// earn the expected profit.
+//
+// Consider the following example:
+//
+//	Market:
+//		DCR/BTC, lot size = 10 DCR.
+//
+//	Sell Placements:
+//		1. { Lots: 1, Multiplier: 1.5 }
+//		2. { Lots 1, Multiplier: 1.0 }
+//
+//	 Profit:
+//	   0.01 (1%)
+//
+//	CEX Asks:
+//		1. 10 DCR @ .005 BTC/DCR
+//		2. 10 DCR @ .006 BTC/DCR
+//		3. 10 DCR @ .007 BTC/DCR
+//
+// For the first placement, the bot will find the rate at which it can
+// buy 15 DCR (1 lot * 1.5 multiplier). This rate is .006 BTC/DCR. Therefore,
+// it will place place a sell order at .00606 BTC/DCR (.006 BTC/DCR * 1.01).
+//
+// For the second placement, the bot will go deeper into the CEX order book
+// and find the rate at which it can buy 25 DCR. This is the previous 15 DCR
+// used for the first placement plus the Quantity * Multiplier of the second
+// placement. This rate is .007 BTC/DCR. Therefore it will place a sell order
+// at .00707 BTC/DCR (.007 BTC/DCR * 1.01).
+type ArbMarketMakerConfig struct {
+	CEXName            string                      `json:"cexName"`
+	BuyPlacements      []*ArbMarketMakingPlacement `json:"buyPlacements"`
+	SellPlacements     []*ArbMarketMakingPlacement `json:"sellPlacements"`
+	Profit             float64                     `json:"profit"`
+	DriftTolerance     float64                     `json:"driftTolerance"`
+	NumEpochsLeaveOpen uint64                      `json:"numEpochsLeaveOpen"`
+	BaseOptions        map[string]string           `json:"baseOptions"`
+	QuoteOptions       map[string]string           `json:"quoteOptions"`
+}
+
+type arbMarketMaker struct {
+	ctx   context.Context
+	host  string
+	base  uint32
+	quote uint32
+	cex   libxc.CEX
+	// cexTradeUpdatesID is passed to the Trade function of the cex
+	// so that the cex knows to send update notifications for the
+	// trade back to this bot.
+	cexTradeUpdatesID int
+	core              clientCore
+	log               dex.Logger
+	cfg               *ArbMarketMakerConfig
+	mkt               *core.Market
+	book              dexOrderBook
+	rebalanceRunning  atomic.Bool
+	currEpoch         atomic.Uint64
+
+	ordMtx         sync.RWMutex
+	ords           map[order.OrderID]*core.Order
+	oidToPlacement map[order.OrderID]int
+
+	matchesMtx  sync.RWMutex
+	matchesSeen map[order.MatchID]bool
+
+	cexTradesMtx sync.RWMutex
+	cexTrades    map[string]uint64
+
+	feesMtx  sync.RWMutex
+	buyFees  *orderFees
+	sellFees *orderFees
+}
+
+// groupedOrders returns the buy and sell orders grouped by placement index.
+func (m *arbMarketMaker) groupedOrders() (buys, sells map[int][]*groupedOrder) {
+	m.ordMtx.RLock()
+	defer m.ordMtx.RUnlock()
+	return groupOrders(m.ords, m.oidToPlacement, m.mkt.LotSize)
+}
+
+func (a *arbMarketMaker) handleCEXTradeUpdate(update *libxc.TradeUpdate) {
+	a.log.Debugf("CEX trade update: %+v", update)
+
+	if update.Complete {
+		a.cexTradesMtx.Lock()
+		delete(a.cexTrades, update.TradeID)
+		a.cexTradesMtx.Unlock()
+		return
+	}
+}
+
+// processDEXMatch checks to see if this is the first time the bot has seen
+// this match. If so, it sends a trade to the CEX.
+func (a *arbMarketMaker) processDEXMatch(o *core.Order, match *core.Match) {
+	var matchID order.MatchID
+	copy(matchID[:], match.MatchID)
+
+	a.matchesMtx.Lock()
+	if _, seen := a.matchesSeen[matchID]; seen {
+		a.matchesMtx.Unlock()
+		return
+	}
+	a.matchesSeen[matchID] = true
+	a.matchesMtx.Unlock()
+
+	var cexRate uint64
+	if o.Sell {
+		cexRate = uint64(float64(match.Rate) / (1 + a.cfg.Profit))
+	} else {
+		cexRate = uint64(float64(match.Rate) * (1 + a.cfg.Profit))
+	}
+	cexRate = steppedRate(cexRate, a.mkt.RateStep)
+
+	a.cexTradesMtx.Lock()
+	defer a.cexTradesMtx.Unlock()
+
+	tradeID, err := a.cex.Trade(a.ctx, dex.BipIDSymbol(a.base), dex.BipIDSymbol(a.quote), !o.Sell, cexRate, match.Qty, a.cexTradeUpdatesID)
+	if err != nil {
+		a.log.Errorf("Error sending trade to CEX: %v", err)
+		return
+	}
+
+	// Keep track of the epoch in which the trade was sent to the CEX. This way
+	// the bot can cancel the trade if it is not filled after a certain number
+	// of epochs.
+	a.cexTrades[tradeID] = a.currEpoch.Load()
+}
+
+func (a *arbMarketMaker) processDEXMatchNote(note *core.MatchNote) {
+	var oid order.OrderID
+	copy(oid[:], note.OrderID)
+
+	a.ordMtx.RLock()
+	o, found := a.ords[oid]
+	if !found {
+		a.ordMtx.RUnlock()
+		return
+	}
+	a.ordMtx.RUnlock()
+
+	a.processDEXMatch(o, note.Match)
+}
+
+func (a *arbMarketMaker) processDEXOrderNote(note *core.OrderNote) {
+	var oid order.OrderID
+	copy(oid[:], note.Order.ID)
+
+	a.ordMtx.Lock()
+	o, found := a.ords[oid]
+	if !found {
+		a.ordMtx.Unlock()
+		return
+	}
+	a.ords[oid] = note.Order
+	a.ordMtx.Unlock()
+
+	for _, match := range note.Order.Matches {
+		a.processDEXMatch(o, match)
+	}
+
+	if !note.Order.Status.IsActive() {
+		a.ordMtx.Lock()
+		delete(a.ords, oid)
+		delete(a.oidToPlacement, oid)
+		a.ordMtx.Unlock()
+	}
+}
+
+func (a *arbMarketMaker) vwap(sell bool, qty uint64) (vwap, extrema uint64, filled bool, err error) {
+	return a.cex.VWAP(dex.BipIDSymbol(a.base), dex.BipIDSymbol(a.quote), sell, qty)
+}
+
+type arbMMRebalancer interface {
+	vwap(sell bool, qty uint64) (vwap, extrema uint64, filled bool, err error)
+	groupedOrders() (buys, sells map[int][]*groupedOrder)
+}
+
+func (a *arbMarketMaker) placeMultiTrade(placements []*rateLots, sell bool) {
+	qtyRates := make([]*core.QtyRate, 0, len(placements))
+	for _, p := range placements {
+		qtyRates = append(qtyRates, &core.QtyRate{
+			Qty:  p.lots * a.mkt.LotSize,
+			Rate: p.rate,
+		})
+	}
+
+	var options map[string]string
+	if sell {
+		options = a.cfg.BaseOptions
+	} else {
+		options = a.cfg.QuoteOptions
+	}
+
+	orders, err := a.core.MultiTrade(nil, &core.MultiTradeForm{
+		Host:       a.host,
+		Sell:       sell,
+		Base:       a.base,
+		Quote:      a.quote,
+		Placements: qtyRates,
+		Options:    options,
+	})
+	if err != nil {
+		a.log.Errorf("Error placing rebalancing order: %v", err)
+		return
+	}
+
+	a.ordMtx.Lock()
+	for i, ord := range orders {
+		var oid order.OrderID
+		copy(oid[:], ord.ID)
+		a.ords[oid] = ord
+		a.oidToPlacement[oid] = placements[i].placementIndex
+	}
+	a.ordMtx.Unlock()
+}
+
+func (a *arbMarketMaker) cancelCEXTrades() {
+	currEpoch := a.currEpoch.Load()
+
+	a.cexTradesMtx.RLock()
+	defer a.cexTradesMtx.RUnlock()
+
+	for tradeID, epoch := range a.cexTrades {
+		if currEpoch-epoch >= a.cfg.NumEpochsLeaveOpen {
+			err := a.cex.CancelTrade(a.ctx, dex.BipIDSymbol(a.base), dex.BipIDSymbol(a.quote), tradeID)
+			if err != nil {
+				a.log.Errorf("Error canceling CEX trade %s: %v", tradeID, err)
+			}
+		}
+	}
+}
+
+func arbMarketMakerRebalance(newEpoch uint64, a arbMMRebalancer, c clientCore, cex libxc.CEX, cfg *ArbMarketMakerConfig, mkt *core.Market, buyFees,
+	sellFees *orderFees, log dex.Logger) (cancels []dex.Bytes, buyOrders, sellOrders []*rateLots) {
+
+	existingBuys, existingSells := a.groupedOrders()
+
+	withinTolerance := func(rate, target uint64) bool {
+		driftTolerance := uint64(float64(target) * cfg.DriftTolerance)
+		lowerBound := target - driftTolerance
+		upperBound := target + driftTolerance
+		return rate >= lowerBound && rate <= upperBound
+	}
+
+	cancels = make([]dex.Bytes, 0, 1)
+	addCancel := func(o *groupedOrder) {
+		if newEpoch-o.epoch < 2 {
+			log.Debugf("rebalance: skipping cancel not past free cancel threshold")
+			return
+		}
+		cancels = append(cancels, o.id[:])
+	}
+
+	baseDEXBalance, err := c.AssetBalance(mkt.BaseID)
+	if err != nil {
+		log.Errorf("error getting base DEX balance: %v", err)
+		return
+	}
+
+	quoteDEXBalance, err := c.AssetBalance(mkt.QuoteID)
+	if err != nil {
+		log.Errorf("error getting quote DEX balance: %v", err)
+		return
+	}
+
+	baseCEXBalance, err := cex.Balance(mkt.BaseSymbol)
+	if err != nil {
+		log.Errorf("error getting base CEX balance: %v", err)
+		return
+	}
+
+	quoteCEXBalance, err := cex.Balance(mkt.QuoteSymbol)
+	if err != nil {
+		log.Errorf("error getting quote CEX balance: %v", err)
+		return
+	}
+
+	processSide := func(sell bool) []*rateLots {
+		var cfgPlacements []*ArbMarketMakingPlacement
+		var existingOrders map[int][]*groupedOrder
+		var remainingDEXBalance, remainingCEXBalance, fundingFees uint64
+		if sell {
+			cfgPlacements = cfg.SellPlacements
+			existingOrders = existingSells
+			remainingDEXBalance = baseDEXBalance.Available
+			remainingCEXBalance = quoteCEXBalance.Available
+			fundingFees = sellFees.funding
+		} else {
+			cfgPlacements = cfg.BuyPlacements
+			existingOrders = existingBuys
+			remainingDEXBalance = quoteDEXBalance.Available
+			remainingCEXBalance = baseCEXBalance.Available
+			fundingFees = buyFees.funding
+		}
+
+		// Enough balance on the CEX needs to maintained for counter-trades
+		// for each existing trade on the DEX. Here, we reduce the available
+		// balance on the CEX by the amount required for each order on the
+		// DEX books.
+		for _, ordersForPlacement := range existingOrders {
+			for _, o := range ordersForPlacement {
+				var requiredOnCEX uint64
+				if sell {
+					rate := uint64(float64(o.rate) / (1 + cfg.Profit))
+					requiredOnCEX = calc.BaseToQuote(rate, o.lots*mkt.LotSize)
+				} else {
+					requiredOnCEX = o.lots * mkt.LotSize
+				}
+				if requiredOnCEX < remainingCEXBalance {
+					remainingCEXBalance -= requiredOnCEX
+				} else {
+					log.Warnf("rebalance: not enough CEX balance to cover existing order. cancelling.")
+					addCancel(o)
+					remainingCEXBalance = 0
+				}
+			}
+		}
+		if remainingCEXBalance == 0 {
+			log.Debug("rebalance: not enough CEX balance to place new orders")
+			return nil
+		}
+
+		if remainingDEXBalance <= fundingFees {
+			log.Debug("rebalance: not enough DEX balance to pay funding fees")
+			return nil
+		}
+		remainingDEXBalance -= fundingFees
+
+		// For each placement, we check the rate at which the counter trade can
+		// be made on the CEX for the cumulatively required lots * multipliers
+		// of the current and all previous placements. If any orders currently
+		// on the books are outside of the drift tolerance, they will be
+		// cancelled, and if there are less than the required lots on the DEX
+		// books, new orders will be added.
+		placements := make([]*rateLots, 0, len(cfgPlacements))
+		var cumulativeCEXDepth uint64
+		for i, cfgPlacement := range cfgPlacements {
+			cumulativeCEXDepth += uint64(float64(cfgPlacement.Lots*mkt.LotSize) * cfgPlacement.Multiplier)
+			_, extrema, filled, err := a.vwap(sell, cumulativeCEXDepth)
+			if err != nil {
+				log.Errorf("error calculating vwap: %v", err)
+			}
+			if !filled {
+				log.Infof("CEX %s side has < %d %s on the orderbook.", map[bool]string{true: "sell", false: "buy"}[sell], cumulativeCEXDepth, mkt.BaseSymbol)
+				break
+			}
+
+			var placementRate uint64
+			if sell {
+				placementRate = steppedRate(uint64(float64(extrema)*(1+cfg.Profit)), mkt.RateStep)
+			} else {
+				placementRate = steppedRate(uint64(float64(extrema)/(1+cfg.Profit)), mkt.RateStep)
+			}
+
+			ordersForPlacement := existingOrders[i]
+			var existingLots uint64
+			for _, o := range ordersForPlacement {
+				existingLots += o.lots
+				if !withinTolerance(o.rate, placementRate) {
+					addCancel(o)
+				}
+			}
+
+			if cfgPlacement.Lots <= existingLots {
+				continue
+			}
+			lotsToPlace := cfgPlacement.Lots - existingLots
+
+			// TODO: handle redeem/refund fees for account lockers
+			var requiredOnDEX, requiredOnCEX uint64
+			if sell {
+				requiredOnDEX = mkt.LotSize * lotsToPlace
+				requiredOnDEX += sellFees.swap * lotsToPlace
+				requiredOnCEX = calc.BaseToQuote(extrema, mkt.LotSize*lotsToPlace)
+			} else {
+				requiredOnDEX = calc.BaseToQuote(placementRate, lotsToPlace*mkt.LotSize)
+				requiredOnDEX += buyFees.swap * lotsToPlace
+				requiredOnCEX = mkt.LotSize * lotsToPlace
+			}
+			if requiredOnDEX > remainingDEXBalance {
+				log.Debugf("not enough DEX balance to place %d lots", lotsToPlace)
+				continue
+			}
+			if requiredOnCEX > remainingCEXBalance {
+				log.Debugf("not enough CEX balance to place %d lots", lotsToPlace)
+				continue
+			}
+			remainingDEXBalance -= requiredOnDEX
+			remainingCEXBalance -= requiredOnCEX
+
+			placements = append(placements, &rateLots{
+				rate:           placementRate,
+				lots:           lotsToPlace,
+				placementIndex: i,
+			})
+		}
+
+		return placements
+	}
+
+	buys := processSide(false)
+	sells := processSide(true)
+
+	return cancels, buys, sells
+}
+
+func (a *arbMarketMaker) rebalance(epoch uint64) {
+	if !a.rebalanceRunning.CompareAndSwap(false, true) {
+		return
+	}
+	defer a.rebalanceRunning.Store(false)
+
+	currEpoch := a.currEpoch.Load()
+	if epoch <= currEpoch {
+		return
+	}
+	a.currEpoch.Store(epoch)
+
+	cancels, buyOrders, sellOrders := arbMarketMakerRebalance(epoch, a, a.core, a.cex, a.cfg, a.mkt, a.buyFees, a.sellFees, a.log)
+
+	for _, cancel := range cancels {
+		err := a.core.Cancel(cancel)
+		if err != nil {
+			a.log.Errorf("Error canceling order %s: %v", cancel, err)
+			return
+		}
+	}
+	if len(buyOrders) > 0 {
+		a.placeMultiTrade(buyOrders, false)
+	}
+	if len(sellOrders) > 0 {
+		a.placeMultiTrade(sellOrders, true)
+	}
+
+	a.cancelCEXTrades()
+}
+
+func (a *arbMarketMaker) handleNotification(note core.Notification) {
+	switch n := note.(type) {
+	case *core.MatchNote:
+		a.processDEXMatchNote(n)
+	case *core.OrderNote:
+		a.processDEXOrderNote(n)
+	case *core.EpochNotification:
+		go a.rebalance(n.Epoch)
+	}
+}
+
+func (a *arbMarketMaker) cancelAllOrders() {
+	a.ordMtx.Lock()
+	defer a.ordMtx.Unlock()
+	for oid := range a.ords {
+		if err := a.core.Cancel(oid[:]); err != nil {
+			a.log.Errorf("error cancelling order: %v", err)
+		}
+	}
+	a.ords = make(map[order.OrderID]*core.Order)
+	a.oidToPlacement = make(map[order.OrderID]int)
+}
+
+func (a *arbMarketMaker) updateFeeRates() error {
+	buySwapFees, buyRedeemFees, buyRefundFees, err := a.core.SingleLotFees(&core.SingleLotFeesForm{
+		Host:          a.host,
+		Base:          a.base,
+		Quote:         a.quote,
+		UseMaxFeeRate: true,
+		UseSafeTxSize: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get fees: %v", err)
+	}
+
+	sellSwapFees, sellRedeemFees, sellRefundFees, err := a.core.SingleLotFees(&core.SingleLotFeesForm{
+		Host:          a.host,
+		Base:          a.base,
+		Quote:         a.quote,
+		UseMaxFeeRate: true,
+		UseSafeTxSize: true,
+		Sell:          true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get fees: %v", err)
+	}
+
+	buyFundingFees, err := a.core.MaxFundingFees(a.quote, a.host, uint32(len(a.cfg.BuyPlacements)), a.cfg.QuoteOptions)
+	if err != nil {
+		return fmt.Errorf("failed to get funding fees: %v", err)
+	}
+
+	sellFundingFees, err := a.core.MaxFundingFees(a.base, a.host, uint32(len(a.cfg.SellPlacements)), a.cfg.BaseOptions)
+	if err != nil {
+		return fmt.Errorf("failed to get funding fees: %v", err)
+	}
+
+	a.feesMtx.Lock()
+	defer a.feesMtx.Unlock()
+
+	a.buyFees = &orderFees{
+		swap:       buySwapFees,
+		redemption: buyRedeemFees,
+		funding:    buyFundingFees,
+		refund:     buyRefundFees,
+	}
+	a.sellFees = &orderFees{
+		swap:       sellSwapFees,
+		redemption: sellRedeemFees,
+		funding:    sellFundingFees,
+		refund:     sellRefundFees,
+	}
+
+	return nil
+}
+
+func (a *arbMarketMaker) run() {
+	book, bookFeed, err := a.core.SyncBook(a.host, a.base, a.quote)
+	if err != nil {
+		a.log.Errorf("Failed to sync book: %v", err)
+		return
+	}
+	a.book = book
+
+	a.updateFeeRates()
+
+	err = a.cex.SubscribeMarket(a.ctx, dex.BipIDSymbol(a.base), dex.BipIDSymbol(a.quote))
+	if err != nil {
+		a.log.Errorf("Failed to subscribe to cex market: %v", err)
+		return
+	}
+
+	tradeUpdates, unsubscribe, tradeUpdatesID := a.cex.SubscribeTradeUpdates()
+	defer unsubscribe()
+	a.cexTradeUpdatesID = tradeUpdatesID
+
+	wg := &sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-bookFeed.Next():
+				// Really nothing to do with the updates. We just need to keep
+				// the subscription live in order to get VWAP on dex orderbook.
+			case <-a.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case update := <-tradeUpdates:
+				a.handleCEXTradeUpdate(update)
+			case <-a.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	noteFeed := a.core.NotificationFeed()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer noteFeed.ReturnFeed()
+		for {
+			select {
+			case n := <-noteFeed.C:
+				a.handleNotification(n)
+			case <-a.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	a.cancelAllOrders()
+}
+
+func RunArbMarketMaker(ctx context.Context, cfg *BotConfig, c clientCore, cex libxc.CEX, log dex.Logger) {
+	if cfg.ArbMarketMakerConfig == nil {
+		// implies bug in caller
+		log.Errorf("No arb market maker config provided. Exiting.")
+		return
+	}
+
+	mkt, err := c.ExchangeMarket(cfg.Host, cfg.BaseAsset, cfg.QuoteAsset)
+	if err != nil {
+		log.Errorf("Failed to get market: %v", err)
+		return
+	}
+
+	(&arbMarketMaker{
+		ctx:            ctx,
+		host:           cfg.Host,
+		base:           cfg.BaseAsset,
+		quote:          cfg.QuoteAsset,
+		cex:            cex,
+		core:           c,
+		log:            log,
+		cfg:            cfg.ArbMarketMakerConfig,
+		mkt:            mkt,
+		ords:           make(map[order.OrderID]*core.Order),
+		oidToPlacement: make(map[order.OrderID]int),
+		matchesSeen:    make(map[order.MatchID]bool),
+		cexTrades:      make(map[string]uint64),
+	}).run()
+}

--- a/client/mm/mm_arb_market_maker.go
+++ b/client/mm/mm_arb_market_maker.go
@@ -206,6 +206,14 @@ func (a *arbMarketMaker) processDEXOrderNote(note *core.OrderNote) {
 		delete(a.ords, oid)
 		delete(a.oidToPlacement, oid)
 		a.ordMtx.Unlock()
+
+		a.matchesMtx.Lock()
+		for _, match := range note.Order.Matches {
+			var matchID order.MatchID
+			copy(matchID[:], match.MatchID)
+			delete(a.matchesSeen, matchID)
+		}
+		a.matchesMtx.Unlock()
 	}
 }
 

--- a/client/mm/mm_arb_market_maker_test.go
+++ b/client/mm/mm_arb_market_maker_test.go
@@ -1,0 +1,930 @@
+package mm
+
+import (
+	"context"
+	"testing"
+
+	"decred.org/dcrdex/client/core"
+	"decred.org/dcrdex/client/mm/libxc"
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/calc"
+	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/dex/order"
+)
+
+type tArbMMRebalancer struct {
+	buyVWAP      map[uint64]*vwapResult
+	sellVWAP     map[uint64]*vwapResult
+	groupedBuys  map[int][]*groupedOrder
+	groupedSells map[int][]*groupedOrder
+}
+
+var _ arbMMRebalancer = (*tArbMMRebalancer)(nil)
+
+func (r *tArbMMRebalancer) vwap(sell bool, qty uint64) (vwap, extrema uint64, filled bool, err error) {
+	if sell {
+		if res, found := r.sellVWAP[qty]; found {
+			return res.avg, res.extrema, true, nil
+		}
+		return 0, 0, false, nil
+	}
+	if res, found := r.buyVWAP[qty]; found {
+		return res.avg, res.extrema, true, nil
+	}
+	return 0, 0, false, nil
+}
+
+func (r *tArbMMRebalancer) groupedOrders() (buys, sells map[int][]*groupedOrder) {
+	return r.groupedBuys, r.groupedSells
+}
+
+func TestArbMarketMakerRebalance(t *testing.T) {
+	const rateStep uint64 = 1e3
+	const lotSize uint64 = 50e8
+	const newEpoch = 123_456_789
+	const driftTolerance = 0.001
+	const profit = 0.01
+
+	buyFees := &orderFees{
+		swap:       1e4,
+		redemption: 2e4,
+		funding:    3e4,
+	}
+	sellFees := &orderFees{
+		swap:       2e4,
+		redemption: 1e4,
+		funding:    4e4,
+	}
+
+	orderIDs := make([]order.OrderID, 5)
+	for i := range orderIDs {
+		copy(orderIDs[i][:], encode.RandomBytes(32))
+	}
+
+	mkt := &core.Market{
+		RateStep:    rateStep,
+		AtomToConv:  1,
+		LotSize:     lotSize,
+		BaseID:      42,
+		QuoteID:     0,
+		BaseSymbol:  "dcr",
+		QuoteSymbol: "btc",
+	}
+
+	cfg1 := &ArbMarketMakerConfig{
+		DriftTolerance: driftTolerance,
+		Profit:         profit,
+		BuyPlacements: []*ArbMarketMakingPlacement{{
+			Lots:       1,
+			Multiplier: 1.5,
+		}},
+		SellPlacements: []*ArbMarketMakingPlacement{{
+			Lots:       1,
+			Multiplier: 1.5,
+		}},
+	}
+
+	cfg2 := &ArbMarketMakerConfig{
+		DriftTolerance: driftTolerance,
+		Profit:         profit,
+		BuyPlacements: []*ArbMarketMakingPlacement{
+			{
+				Lots:       1,
+				Multiplier: 2,
+			},
+			{
+				Lots:       1,
+				Multiplier: 1.5,
+			},
+		},
+		SellPlacements: []*ArbMarketMakingPlacement{
+			{
+				Lots:       1,
+				Multiplier: 2,
+			},
+			{
+				Lots:       1,
+				Multiplier: 1.5,
+			},
+		},
+	}
+
+	type test struct {
+		name string
+
+		rebalancer  *tArbMMRebalancer
+		cfg         *ArbMarketMakerConfig
+		dexBalances map[uint32]uint64
+		cexBalances map[string]*libxc.ExchangeBalance
+
+		expectedCancels []dex.Bytes
+		expectedBuys    []*rateLots
+		expectedSells   []*rateLots
+	}
+
+	multiplyRate := func(u uint64, m float64) uint64 {
+		return steppedRate(uint64(float64(u)*m), mkt.RateStep)
+	}
+	divideRate := func(u uint64, d float64) uint64 {
+		return steppedRate(uint64(float64(u)/d), mkt.RateStep)
+	}
+	lotSizeMultiplier := func(m float64) uint64 {
+		return uint64(float64(mkt.LotSize) * m)
+	}
+
+	tests := []*test{
+		//  "no existing orders"
+		{
+			name: "no existing orders",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(1.5): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(1.5): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+				},
+			},
+			cfg: cfg1,
+			dexBalances: map[uint32]uint64{
+				42: lotSize * 3,
+				0:  calc.BaseToQuote(1e6, 3*lotSize),
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: 1e19},
+				"dcr": {Available: 1e19},
+			},
+			expectedBuys: []*rateLots{{
+				rate: 1.881e6,
+				lots: 1,
+			}},
+			expectedSells: []*rateLots{{
+				rate: 2.222e6,
+				lots: 1,
+			}},
+		},
+		// "existing orders within drift tolerance"
+		{
+			name: "existing orders within drift tolerance",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(1.5): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(1.5): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+				},
+				groupedBuys: map[int][]*groupedOrder{
+					0: {{
+						rate: 1.882e6,
+						lots: 1,
+					}},
+				},
+				groupedSells: map[int][]*groupedOrder{
+					0: {{
+						rate: 2.223e6,
+						lots: 1,
+					}},
+				},
+			},
+			cfg: cfg1,
+			dexBalances: map[uint32]uint64{
+				42: lotSize * 3,
+				0:  calc.BaseToQuote(1e6, 3*lotSize),
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: 1e19},
+				"dcr": {Available: 1e19},
+			},
+		},
+		// "existing orders outside drift tolerance"
+		{
+			name: "existing orders outside drift tolerance",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(1.5): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+				},
+				groupedBuys: map[int][]*groupedOrder{
+					0: {{
+						id:   orderIDs[0],
+						rate: 1.883e6,
+						lots: 1,
+					}},
+				},
+				groupedSells: map[int][]*groupedOrder{
+					0: {{
+						id:   orderIDs[1],
+						rate: 2.225e6,
+						lots: 1,
+					}},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(1.5): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+				},
+			},
+			cfg: cfg1,
+			dexBalances: map[uint32]uint64{
+				42: lotSize * 3,
+				0:  calc.BaseToQuote(1e6, 3*lotSize),
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: 1e19},
+				"dcr": {Available: 1e19},
+			},
+			expectedCancels: []dex.Bytes{
+				orderIDs[0][:],
+				orderIDs[1][:],
+			},
+		},
+		// "don't cancel before free cancel"
+		{
+			name: "don't cancel before free cancel",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(1.5): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+				},
+				groupedBuys: map[int][]*groupedOrder{
+					0: {{
+						id:    orderIDs[0],
+						rate:  1.883e6,
+						lots:  1,
+						epoch: newEpoch - 1,
+					}},
+				},
+				groupedSells: map[int][]*groupedOrder{
+					0: {{
+						id:    orderIDs[1],
+						rate:  2.225e6,
+						lots:  1,
+						epoch: newEpoch - 2,
+					}},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(1.5): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+				},
+			},
+			cfg: cfg1,
+			dexBalances: map[uint32]uint64{
+				42: lotSize * 3,
+				0:  calc.BaseToQuote(1e6, 3*lotSize),
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: 1e19},
+				"dcr": {Available: 1e19},
+			},
+			expectedCancels: []dex.Bytes{
+				orderIDs[1][:],
+			},
+		},
+		// "no existing orders, two orders each, dex balance edge, enough"
+		{
+			name: "no existing orders, two orders each, dex balance edge, enough",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     1.8e6,
+						extrema: 1.7e6,
+					},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     2.3e6,
+						extrema: 2.4e6,
+					},
+				},
+			},
+			cfg: cfg2,
+			dexBalances: map[uint32]uint64{
+				42: 2*(lotSize+sellFees.swap) + sellFees.funding,
+				0:  calc.BaseToQuote(divideRate(1.9e6, 1+profit), lotSize) + calc.BaseToQuote(divideRate(1.7e6, 1+profit), lotSize) + 2*buyFees.swap + buyFees.funding,
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: 1e19},
+				"dcr": {Available: 1e19},
+			},
+			expectedBuys: []*rateLots{
+				{
+					rate: divideRate(1.9e6, 1+profit),
+					lots: 1,
+				},
+				{
+					rate:           divideRate(1.7e6, 1+profit),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []*rateLots{
+				{
+					rate: multiplyRate(2.2e6, 1+profit),
+					lots: 1,
+				},
+				{
+					rate:           multiplyRate(2.4e6, 1+profit),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		// "no existing orders, two orders each, dex balance edge, not enough"
+		{
+			name: "no existing orders, two orders each, dex balance edge, not enough",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     1.8e6,
+						extrema: 1.7e6,
+					},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     2.3e6,
+						extrema: 2.4e6,
+					},
+				},
+			},
+			cfg: cfg2,
+			dexBalances: map[uint32]uint64{
+				42: 2*(lotSize+sellFees.swap) + sellFees.funding - 1,
+				0:  calc.BaseToQuote(divideRate(1.9e6, 1+profit), lotSize) + calc.BaseToQuote(divideRate(1.7e6, 1+profit), lotSize) + 2*buyFees.swap + buyFees.funding - 1,
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: 1e19},
+				"dcr": {Available: 1e19},
+			},
+			expectedBuys: []*rateLots{
+				{
+					rate: divideRate(1.9e6, 1+profit),
+					lots: 1,
+				},
+			},
+			expectedSells: []*rateLots{
+				{
+					rate: multiplyRate(2.2e6, 1+profit),
+					lots: 1,
+				},
+			},
+		},
+		// "no existing orders, two orders each, cex balance edge, enough"
+		{
+			name: "no existing orders, two orders each, cex balance edge, enough",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     1.8e6,
+						extrema: 1.7e6,
+					},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     2.3e6,
+						extrema: 2.4e6,
+					},
+				},
+			},
+			cfg: cfg2,
+			dexBalances: map[uint32]uint64{
+				42: 1e19,
+				0:  1e19,
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: calc.BaseToQuote(2.2e6, mkt.LotSize) + calc.BaseToQuote(2.4e6, mkt.LotSize)},
+				"dcr": {Available: 2 * mkt.LotSize},
+			},
+			expectedBuys: []*rateLots{
+				{
+					rate: divideRate(1.9e6, 1+profit),
+					lots: 1,
+				},
+				{
+					rate:           divideRate(1.7e6, 1+profit),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []*rateLots{
+				{
+					rate: multiplyRate(2.2e6, 1+profit),
+					lots: 1,
+				},
+				{
+					rate:           multiplyRate(2.4e6, 1+profit),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		// "no existing orders, two orders each, cex balance edge, not enough"
+		{
+			name: "no existing orders, two orders each, cex balance edge, not enough",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     1.8e6,
+						extrema: 1.7e6,
+					},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     2.3e6,
+						extrema: 2.4e6,
+					},
+				},
+			},
+			cfg: cfg2,
+			dexBalances: map[uint32]uint64{
+				42: 1e19,
+				0:  1e19,
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: calc.BaseToQuote(2.2e6, mkt.LotSize) + calc.BaseToQuote(2.4e6, mkt.LotSize) - 1},
+				"dcr": {Available: 2*mkt.LotSize - 1},
+			},
+			expectedBuys: []*rateLots{
+				{
+					rate: divideRate(1.9e6, 1+profit),
+					lots: 1,
+				},
+			},
+			expectedSells: []*rateLots{
+				{
+					rate: multiplyRate(2.2e6, 1+profit),
+					lots: 1,
+				},
+			},
+		},
+		// "one existing order, enough cex balance for second"
+		{
+			name: "one existing order, enough cex balance for second",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     1.8e6,
+						extrema: 1.7e6,
+					},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     2.3e6,
+						extrema: 2.4e6,
+					},
+				},
+				groupedBuys: map[int][]*groupedOrder{
+					0: {{
+						rate: divideRate(1.9e6, 1+profit),
+						lots: 1,
+					}},
+				},
+				groupedSells: map[int][]*groupedOrder{
+					0: {{
+						rate: multiplyRate(2.2e6, 1+profit),
+						lots: 1,
+					}},
+				},
+			},
+			cfg: cfg2,
+			dexBalances: map[uint32]uint64{
+				42: 1e19,
+				0:  1e19,
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: calc.BaseToQuote(2.2e6, mkt.LotSize) + calc.BaseToQuote(2.4e6, mkt.LotSize)},
+				"dcr": {Available: 2 * mkt.LotSize},
+			},
+			expectedBuys: []*rateLots{
+				{
+					rate:           divideRate(1.7e6, 1+profit),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+			expectedSells: []*rateLots{
+				{
+					rate:           multiplyRate(2.4e6, 1+profit),
+					lots:           1,
+					placementIndex: 1,
+				},
+			},
+		},
+		// "one existing order, not enough cex balance for second"
+		{
+			name: "one existing order, not enough cex balance for second",
+			rebalancer: &tArbMMRebalancer{
+				buyVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2e6,
+						extrema: 1.9e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     1.8e6,
+						extrema: 1.7e6,
+					},
+				},
+				sellVWAP: map[uint64]*vwapResult{
+					lotSizeMultiplier(2): {
+						avg:     2.1e6,
+						extrema: 2.2e6,
+					},
+					lotSizeMultiplier(3.5): {
+						avg:     2.3e6,
+						extrema: 2.4e6,
+					},
+				},
+				groupedBuys: map[int][]*groupedOrder{
+					0: {{
+						rate: divideRate(1.9e6, 1+profit),
+						lots: 1,
+					}},
+				},
+				groupedSells: map[int][]*groupedOrder{
+					0: {{
+						rate: multiplyRate(2.2e6, 1+profit),
+						lots: 1,
+					}},
+				},
+			},
+			cfg: cfg2,
+			dexBalances: map[uint32]uint64{
+				42: 1e19,
+				0:  1e19,
+			},
+			cexBalances: map[string]*libxc.ExchangeBalance{
+				"btc": {Available: calc.BaseToQuote(2.2e6, mkt.LotSize) + calc.BaseToQuote(2.4e6, mkt.LotSize) - 1},
+				"dcr": {Available: 2*mkt.LotSize - 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		tCore := newTCore()
+		tCore.setAssetBalances(test.dexBalances)
+		cex := newTCEX()
+		cex.balances = test.cexBalances
+
+		cancels, buys, sells := arbMarketMakerRebalance(newEpoch, test.rebalancer, tCore, cex, test.cfg, mkt, buyFees, sellFees, tLogger)
+
+		if len(cancels) != len(test.expectedCancels) {
+			t.Fatalf("%s: expected %d cancels, got %d", test.name, len(test.expectedCancels), len(cancels))
+		}
+		for i := range cancels {
+			if !cancels[i].Equal(test.expectedCancels[i]) {
+				t.Fatalf("%s: cancel %d expected %x, got %x", test.name, i, test.expectedCancels[i], cancels[i])
+			}
+		}
+
+		if len(buys) != len(test.expectedBuys) {
+			t.Fatalf("%s: expected %d buys, got %d", test.name, len(test.expectedBuys), len(buys))
+		}
+		for i := range buys {
+			if buys[i].rate != test.expectedBuys[i].rate {
+				t.Fatalf("%s: buy %d expected rate %d, got %d", test.name, i, test.expectedBuys[i].rate, buys[i].rate)
+			}
+			if buys[i].lots != test.expectedBuys[i].lots {
+				t.Fatalf("%s: buy %d expected lots %d, got %d", test.name, i, test.expectedBuys[i].lots, buys[i].lots)
+			}
+			if buys[i].placementIndex != test.expectedBuys[i].placementIndex {
+				t.Fatalf("%s: buy %d expected placement index %d, got %d", test.name, i, test.expectedBuys[i].placementIndex, buys[i].placementIndex)
+			}
+		}
+
+		if len(sells) != len(test.expectedSells) {
+			t.Fatalf("%s: expected %d sells, got %d", test.name, len(test.expectedSells), len(sells))
+		}
+		for i := range sells {
+			if sells[i].rate != test.expectedSells[i].rate {
+				t.Fatalf("%s: sell %d expected rate %d, got %d", test.name, i, test.expectedSells[i].rate, sells[i].rate)
+			}
+			if sells[i].lots != test.expectedSells[i].lots {
+				t.Fatalf("%s: sell %d expected lots %d, got %d", test.name, i, test.expectedSells[i].lots, sells[i].lots)
+			}
+			if sells[i].placementIndex != test.expectedSells[i].placementIndex {
+				t.Fatalf("%s: sell %d expected placement index %d, got %d", test.name, i, test.expectedSells[i].placementIndex, sells[i].placementIndex)
+			}
+		}
+	}
+}
+
+func TestArbMarketMakerDEXUpdates(t *testing.T) {
+	const lotSize uint64 = 50e8
+	const profit float64 = 0.01
+
+	orderIDs := make([]order.OrderID, 5)
+	for i := 0; i < 5; i++ {
+		copy(orderIDs[i][:], encode.RandomBytes(32))
+	}
+
+	matchIDs := make([]order.MatchID, 5)
+	for i := 0; i < 5; i++ {
+		copy(matchIDs[i][:], encode.RandomBytes(32))
+	}
+
+	mkt := &core.Market{
+		RateStep:    1e3,
+		AtomToConv:  1,
+		LotSize:     lotSize,
+		BaseID:      42,
+		QuoteID:     0,
+		BaseSymbol:  "dcr",
+		QuoteSymbol: "btc",
+	}
+
+	multiplyRate := func(u uint64, m float64) uint64 {
+		return steppedRate(uint64(float64(u)*m), mkt.RateStep)
+	}
+	divideRate := func(u uint64, d float64) uint64 {
+		return steppedRate(uint64(float64(u)/d), mkt.RateStep)
+	}
+
+	type test struct {
+		name              string
+		orders            []*core.Order
+		notes             []core.Notification
+		expectedCEXTrades []*cexOrder
+	}
+
+	tests := []*test{
+		{
+			name: "one buy and one cell match notifications",
+			orders: []*core.Order{
+				{
+					ID:   orderIDs[0][:],
+					Sell: true,
+					Qty:  lotSize,
+					Rate: 8e5,
+				},
+				{
+					ID:   orderIDs[1][:],
+					Sell: false,
+					Qty:  lotSize,
+					Rate: 6e5,
+				},
+			},
+			notes: []core.Notification{
+				&core.MatchNote{
+					OrderID: orderIDs[0][:],
+					Match: &core.Match{
+						MatchID: matchIDs[0][:],
+						Qty:     lotSize,
+						Rate:    8e5,
+					},
+				},
+				&core.MatchNote{
+					OrderID: orderIDs[1][:],
+					Match: &core.Match{
+						MatchID: matchIDs[1][:],
+						Qty:     lotSize,
+						Rate:    6e5,
+					},
+				},
+				&core.OrderNote{
+					Order: &core.Order{
+						ID:   orderIDs[0][:],
+						Sell: true,
+						Qty:  lotSize,
+						Rate: 8e5,
+						Matches: []*core.Match{
+							{
+								MatchID: matchIDs[0][:],
+								Qty:     lotSize,
+								Rate:    8e5,
+							},
+						},
+					},
+				},
+				&core.OrderNote{
+					Order: &core.Order{
+						ID:   orderIDs[1][:],
+						Sell: false,
+						Qty:  lotSize,
+						Rate: 8e5,
+						Matches: []*core.Match{
+							{
+								MatchID: matchIDs[1][:],
+								Qty:     lotSize,
+								Rate:    6e5,
+							},
+						},
+					},
+				},
+			},
+			expectedCEXTrades: []*cexOrder{
+				{
+					baseSymbol:  "dcr",
+					quoteSymbol: "btc",
+					qty:         lotSize,
+					rate:        divideRate(8e5, 1+profit),
+					sell:        false,
+				},
+				{
+					baseSymbol:  "dcr",
+					quoteSymbol: "btc",
+					qty:         lotSize,
+					rate:        multiplyRate(6e5, 1+profit),
+					sell:        true,
+				},
+				nil,
+				nil,
+			},
+		},
+		{
+			name: "place cex trades due to order note",
+			orders: []*core.Order{
+				{
+					ID:   orderIDs[0][:],
+					Sell: true,
+					Qty:  lotSize,
+					Rate: 8e5,
+				},
+				{
+					ID:   orderIDs[1][:],
+					Sell: false,
+					Qty:  lotSize,
+					Rate: 6e5,
+				},
+			},
+			notes: []core.Notification{
+				&core.OrderNote{
+					Order: &core.Order{
+						ID:   orderIDs[0][:],
+						Sell: true,
+						Qty:  lotSize,
+						Rate: 8e5,
+						Matches: []*core.Match{
+							{
+								MatchID: matchIDs[0][:],
+								Qty:     lotSize,
+								Rate:    8e5,
+							},
+						},
+					},
+				},
+				&core.OrderNote{
+					Order: &core.Order{
+						ID:   orderIDs[1][:],
+						Sell: false,
+						Qty:  lotSize,
+						Rate: 8e5,
+						Matches: []*core.Match{
+							{
+								MatchID: matchIDs[1][:],
+								Qty:     lotSize,
+								Rate:    6e5,
+							},
+						},
+					},
+				},
+				&core.MatchNote{
+					OrderID: orderIDs[0][:],
+					Match: &core.Match{
+						MatchID: matchIDs[0][:],
+						Qty:     lotSize,
+						Rate:    8e5,
+					},
+				},
+				&core.MatchNote{
+					OrderID: orderIDs[1][:],
+					Match: &core.Match{
+						MatchID: matchIDs[1][:],
+						Qty:     lotSize,
+						Rate:    6e5,
+					},
+				},
+			},
+			expectedCEXTrades: []*cexOrder{
+				{
+					baseSymbol:  "dcr",
+					quoteSymbol: "btc",
+					qty:         lotSize,
+					rate:        divideRate(8e5, 1+profit),
+					sell:        false,
+				},
+				{
+					baseSymbol:  "dcr",
+					quoteSymbol: "btc",
+					qty:         lotSize,
+					rate:        multiplyRate(6e5, 1+profit),
+					sell:        true,
+				},
+				nil,
+				nil,
+			},
+		},
+	}
+
+	runTest := func(test *test) {
+		cex := newTCEX()
+		tCore := newTCore()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ords := make(map[order.OrderID]*core.Order)
+
+		for _, o := range test.orders {
+			var oid order.OrderID
+			copy(oid[:], o.ID)
+			ords[oid] = o
+		}
+
+		arbMM := &arbMarketMaker{
+			cex:            cex,
+			core:           tCore,
+			ctx:            ctx,
+			ords:           ords,
+			base:           42,
+			quote:          0,
+			oidToPlacement: make(map[order.OrderID]int),
+			matchesSeen:    make(map[order.MatchID]bool),
+			cexTrades:      make(map[string]uint64),
+			mkt:            mkt,
+			cfg: &ArbMarketMakerConfig{
+				Profit: profit,
+			},
+		}
+		arbMM.currEpoch.Store(123)
+		go arbMM.run()
+
+		dummyNote := &core.BondRefundNote{}
+
+		for i, note := range test.notes {
+			cex.lastTrade = nil
+
+			tCore.noteFeed <- note
+			tCore.noteFeed <- dummyNote
+
+			expectedCEXTrade := test.expectedCEXTrades[i]
+			if (expectedCEXTrade == nil) != (cex.lastTrade == nil) {
+				t.Fatalf("%s: expected cex order %v but got %v", test.name, (expectedCEXTrade != nil), (cex.lastTrade != nil))
+			}
+
+			if cex.lastTrade != nil &&
+				*cex.lastTrade != *expectedCEXTrade {
+				t.Fatalf("%s: cex order %+v != expected %+v", test.name, cex.lastTrade, expectedCEXTrade)
+			}
+		}
+	}
+
+	for _, test := range tests {
+		runTest(test)
+	}
+}

--- a/client/mm/mm_arb_market_maker_test.go
+++ b/client/mm/mm_arb_market_maker_test.go
@@ -1,3 +1,6 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
 package mm
 
 import (

--- a/client/mm/mm_arb_market_maker_test.go
+++ b/client/mm/mm_arb_market_maker_test.go
@@ -708,7 +708,7 @@ func TestArbMarketMakerDEXUpdates(t *testing.T) {
 
 	tests := []*test{
 		{
-			name: "one buy and one cell match notifications",
+			name: "one buy and one sell match notifications",
 			orders: []*core.Order{
 				{
 					ID:   orderIDs[0][:],

--- a/client/mm/sample-config.json
+++ b/client/mm/sample-config.json
@@ -8,18 +8,54 @@
             "quoteBalanceType": 0,
             "baseBalance": 100,
             "quoteBalance": 100,
-            "simpleArbConfig": {
+            "arbMarketMakerConfig": {
                 "cexName": "Binance",
-                "profitTrigger": 0.01,
-                "maxActiveArbs": 5,
-                "numEpochsLeaveOpen": 5
-            },
-            "baseOptions": {
-                "multisplit": "true"
-            },
-            "quoteOptions": {
-                "multisplit": "true",
-                "multisplitbuffer": "5"
+                "buyPlacements": [
+                    {
+                        "lots": 1,
+                        "multiplier": 1.5
+                    },
+                    {
+                        "lots": 1,
+                        "multiplier": 4
+                    },
+                    {
+                        "lots": 1,
+                        "multiplier": 4
+                    },
+                    {
+                        "lots": 1,
+                        "multiplier": 4
+                    }
+                ],
+                "sellPlacements": [
+                    {
+                        "lots": 1,
+                        "multiplier": 1.5
+                    },
+                    {
+                        "lots": 1,
+                        "multiplier": 4
+                    },
+                    {
+                        "lots": 1,
+                        "multiplier": 4
+                    },
+                    {
+                        "lots": 1,
+                        "multiplier": 4
+                    }
+                ],
+                "profit": 0.01,
+                "driftTolerance" : 0.001,
+                "numEpochsLeaveOpen": 10,
+                "baseOptions": {
+                    "multisplit": "true"
+                },
+                "quoteOptions": {
+                    "multisplit": "true",
+                    "multisplitbuffer": "5"
+                }
             }
         }
     ],


### PR DESCRIPTION
This adds a market making strategy that is kind of a combination between the basic market maker and the simple arbitrage strategies. Based on a CEX order book, it places orders on the DEX order book, and when there is a match on the DEX, the opposite order on the CEX is immediately executed for a profit.

```
// ArbMarketMakerConfig is the configuration for a market maker that places
// orders on both sides of the DEX order book, at rates where there are
// profitable counter trades on a CEX order book. Whenever a DEX order is
// filled, the opposite trade will immediately be made on the CEX.
//
// Each placement in BuyPlacements and SellPlacements represents an order
// that will be made on the DEX order book. The first placement will be
// placed at a rate closest to the CEX mid-gap, and each subsequent one
// will get farther.
//
// The bot calculates the extrema rate on the CEX order book where it can
// buy or sell the quantity of lots specified in the placement multiplied
// by the multiplier amount. This will be the rate of the expected counter
// trade. The bot will then place an order on the DEX order book where if
// both trades are filled, the bot will earn the profit specified in the
// configuration.
//
// The multiplier is important because it ensures that even some of the
// trades closest to the mid-gap on the CEX order book are filled before
// the bot's orders on the DEX are matched, the bot will still be able to
// earn the expected profit.
//
// Consider the following example:
//
//	Market:
//		DCR/BTC, lot size = 10 DCR.
//
//	Sell Placements:
//		1. { Lots: 1, Multiplier: 1.5 }
//		2. { Lots 1, Multiplier: 1.0 }
//
//	 Profit:
//	   0.01 (1%)
//
//	CEX Asks:
//		1. 10 DCR @ .005 BTC/DCR
//		2. 10 DCR @ .006 BTC/DCR
//		3. 10 DCR @ .007 BTC/DCR
//
// For the first placement, the bot will find the rate at which it can
// buy 15 DCR (1 lot * 1.5 multiplier). This rate is .006 BTC/DCR. Therefore,
// it will place place a sell order at .00606 BTC/DCR (.006 BTC/DCR * 1.01).
//
// For the second placement, the bot will go deeper into the CEX order book
// and find the rate at which it can buy 25 DCR. This is the previous 15 DCR
// used for the first placement plus the Quantity * Multiplier of the second
// placement. This rate is .007 BTC/DCR. Therefore it will place a sell order
// at .00707 BTC/DCR (.007 BTC/DCR * 1.01).
```