### PR TITLE
ui: External link handling in dexc-desktop

### DIFF
--- a/client/cmd/dexc-desktop/app.go
+++ b/client/cmd/dexc-desktop/app.go
@@ -390,16 +390,11 @@ func bindJSFunctions(w webview.WebView) {
 		switch runtime.GOOS {
 		case "linux":
 			err = exec.Command("xdg-open", url).Start()
-			break
 		case "windows":
-			err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-			break
-		case "darwin":
-			err = exec.Command("open", url).Start()
-			break
+			err = exec.Command("rundll32", "url.dll", "FileProtocolHandler", url).Start()
 		}
 		if err != nil {
-			log.Errorf(err.Error())
+			log.Errorf("unable to run URL handler: %s", err.Error())
 		}
 	})
 }

--- a/client/cmd/dexc-desktop/app.go
+++ b/client/cmd/dexc-desktop/app.go
@@ -379,6 +379,31 @@ func closeAllWindows() {
 	}
 }
 
+// bindJSFunctions exports functions callable in the frontend
+func bindJSFunctions(w webview.WebView) {
+	w.Bind("isWebview", func() bool {
+		return true
+	})
+
+	w.Bind("openUrl", func(url string) {
+		var err error
+		switch runtime.GOOS {
+		case "linux":
+			err = exec.Command("xdg-open", url).Start()
+			break
+		case "windows":
+			err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+			break
+		case "darwin":
+			err = exec.Command("open", url).Start()
+			break
+		}
+		if err != nil {
+			log.Errorf(err.Error())
+		}
+	})
+}
+
 func runWebview(url string) {
 	w := webview.New(true)
 	defer w.Destroy()
@@ -389,6 +414,7 @@ func runWebview(url string) {
 
 	w.SetSize(width, height, webview.HintNone)
 	w.Navigate(url)
+	bindJSFunctions(w)
 	w.Run()
 }
 

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -40,7 +40,7 @@
       </div>
       <div class="order-datum">
         <div>[[[Offering]]]</div>
-        <div>{{$ord.OfferString}} {{$ord.FromTicker}} {{template "microIcon" $ord.FromTicker}}</div>
+        <div>{{$ord.OfferString}} {{$ord.FromTicker}} {{template "microIcon" $ord.FromSymbol}}</div>
       </div>
       <div class="order-datum">
         <div>[[[Asking]]]</div>

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -786,7 +786,7 @@
             <td data-tmpl="status"></td>
             <td data-tmpl="detailsLink" class="pointer hoverbg">
               <span class="mono">
-                <span data-tmpl="hashStart"></span>…<span data-tmpl="hashEnd"></span>
+                <a href="" data-tmpl="detailsLinkUrl" target="_blank"><span data-tmpl="hashStart"></span>…<span data-tmpl="hashEnd"></span></a>
               </span>
               <span class="ico-open ms-1"></span>
             </td>
@@ -828,7 +828,7 @@
           <div class="flex-center flex-grow-1 pe-3">
             <div data-tmpl="value" class="flex-center fs16 p-2"></div>
             <div data-tmpl="hash" class="hashwrap fs14 p-1"></div>
-            <div data-tmpl="explorerLink" class="p-2 hoverbg pointer"><span class="fs16 ico-open"></span></div>
+            <a href="" target="_blank" data-tmpl="explorerLink" class="p-2 hoverbg pointer"><span class="fs16 ico-open"></span></a>
           </div>
           <div class="d-flex align-items-stretch">
             <div class="flex-center flex-column pe-2">

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -104,6 +104,7 @@ export default class Application {
   popupNotes: HTMLElement
   popupTmpl: HTMLElement
   noteReceivers: Record<string, (n: CoreNote) => void>[]
+  isWebview: boolean
   marketMakingCfg: MarketMakingConfig
   marketMakingStatus: MarketMakingStatus | undefined
 
@@ -165,6 +166,9 @@ export default class Application {
 
     // use user current locale set by backend
     intl.setLocale()
+
+    const w = window as any
+    this.isWebview = (w.isWebview !== undefined)
   }
 
   /**
@@ -292,6 +296,11 @@ export default class Application {
 
     // Bind the tooltips.
     this.bindTooltips(this.main)
+
+    if (this.isWebview) {
+      // Bind webview URL handlers
+      this.bindUrlHandlers(this.main)
+    }
   }
 
   bindTooltips (ancestor: HTMLElement) {
@@ -311,6 +320,19 @@ export default class Application {
         this.tooltip.style.left = '-10000px'
       })
     })
+  }
+
+  bindUrlHandlers (ancestor: HTMLElement) {
+    ancestor.addEventListener('click', function (event: MouseEvent) {
+      if (event === null || event.target === null) return
+
+      const target = event.target as HTMLElement
+      if (target.matches('a[target=_blank]')) {
+        const url = target.getAttribute('href')
+        const w = window as any
+        w.openUrl(url)
+      }
+    }, false)
   }
 
   /* attachHeader attaches the header element, which unlike the main element,

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -104,7 +104,6 @@ export default class Application {
   popupNotes: HTMLElement
   popupTmpl: HTMLElement
   noteReceivers: Record<string, (n: CoreNote) => void>[]
-  isWebview: boolean
   marketMakingCfg: MarketMakingConfig
   marketMakingStatus: MarketMakingStatus | undefined
 
@@ -166,9 +165,6 @@ export default class Application {
 
     // use user current locale set by backend
     intl.setLocale()
-
-    const w = window as any
-    this.isWebview = (w.isWebview !== undefined)
   }
 
   /**
@@ -297,7 +293,7 @@ export default class Application {
     // Bind the tooltips.
     this.bindTooltips(this.main)
 
-    if (this.isWebview) {
+    if (window.isWebview) {
       // Bind webview URL handlers
       this.bindUrlHandlers(this.main)
     }
@@ -323,16 +319,12 @@ export default class Application {
   }
 
   bindUrlHandlers (ancestor: HTMLElement) {
-    ancestor.addEventListener('click', function (event: MouseEvent) {
-      if (event === null || event.target === null) return
-
-      const target = event.target as HTMLElement
-      if (target.matches('a[target=_blank]')) {
-        const url = target.getAttribute('href')
-        const w = window as any
-        w.openUrl(url)
-      }
-    }, false)
+    for (const link of Doc.applySelector(ancestor, 'a[target=_blank]')) {
+      Doc.bind(link, 'click', (e: MouseEvent) => {
+        e.preventDefault()
+        window.openUrl(link.href ?? '')
+      })
+    }
   }
 
   /* attachHeader attaches the header element, which unlike the main element,

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -406,6 +406,7 @@ export default class OrderPage extends BasePage {
   addNewMatchCard (match: Match) {
     const page = this.page
     const matchCard = page.matchCardTmpl.cloneNode(true) as HTMLElement
+    app().bindUrlHandlers(matchCard)
     matchCard.dataset.matchID = match.matchID
     this.setImmutableMatchCardElements(matchCard, match)
     this.setMutableMatchCardElements(matchCard, match)

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -8,6 +8,8 @@ declare global {
     testFormatFourSigFigs: () => void
     testFormatRateFullPrecision: () => void
     user: () => void
+    isWebview?: () => boolean
+    openUrl: (url: string) => void
   }
 }
 
@@ -808,6 +810,7 @@ export interface Application {
   loadPage (page: string, data?: any, skipPush?: boolean): Promise<boolean>
   attach (data: any): void
   bindTooltips (ancestor: HTMLElement): void
+  bindUrlHandlers (ancestor: HTMLElement): void
   attachHeader (): void
   showDropdown (icon: HTMLElement, dialog: HTMLElement): void
   ackNotes (): void

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1079,7 +1079,7 @@ export default class WalletsPage extends BasePage {
       tmpl.status.textContent = intl.prep(ticketStatusTranslationKeys[status])
       tmpl.hashStart.textContent = tx.hash.slice(0, 6)
       tmpl.hashEnd.textContent = tx.hash.slice(-6)
-      Doc.bind(tmpl.detailsLink, 'click', () => window.open(coinLink(tx.hash), '_blank'))
+      tmpl.detailsLinkUrl.setAttribute('href', coinLink(tx.hash))
     }
   }
 
@@ -1204,7 +1204,7 @@ export default class WalletsPage extends BasePage {
       if (tspend.value > 0) tmpl.value.textContent = Doc.formatFourSigFigs(tspend.value / ui.conventional.conversionFactor)
       else Doc.hide(tmpl.value)
       tmpl.hash.textContent = tspend.hash
-      Doc.bind(tmpl.explorerLink, 'click', () => window.open(coinLink(tspend.hash), '_blank'))
+      tmpl.explorerLink.setAttribute('href', coinLink(tspend.hash))
     }
 
     const setTKeyPolicy = async (key: string, policy: string) => {

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1073,6 +1073,7 @@ export default class WalletsPage extends BasePage {
     for (const { tx, status } of pageOfTickets) {
       const tr = page.ticketHistoryRowTmpl.cloneNode(true) as PageElement
       page.ticketHistoryRows.appendChild(tr)
+      app().bindUrlHandlers(tr)
       const tmpl = Doc.parseTemplate(tr)
       tmpl.age.textContent = Doc.timeSince(tx.stamp * 1000)
       tmpl.price.textContent = Doc.formatFullPrecision(tx.ticketPrice, ui)
@@ -1192,6 +1193,7 @@ export default class WalletsPage extends BasePage {
     for (const tspend of stakeStatus.stances.tspends) {
       const div = page.tspendTmpl.cloneNode(true) as PageElement
       page.votingTspends.appendChild(div)
+      app().bindUrlHandlers(div)
       const tmpl = Doc.parseTemplate(div)
       for (const opt of [tmpl.yes, tmpl.no]) {
         opt.name = tspend.hash


### PR DESCRIPTION
This PR fixes the handling/behavior of links that are to open in a new window (`target="_blank"`).  When the UI runs within a Webview window, clicks on those links are passed through to the default URL handler of the OS, instead of being handled inside the WV.

Closes #2453