### PR TITLE
ui: Closer button to Update bond dialog

### DIFF
--- a/client/webserver/site/src/html/dexsettings.tmpl
+++ b/client/webserver/site/src/html/dexsettings.tmpl
@@ -48,6 +48,7 @@
 
     {{- /* UPDATE BOND OPTIONS */ -}}
     <form class="d-hide" id="updateBondOptionsForm" autocomplete="off">
+      <div class="form-closer hoverbg"><span class="ico-cross"></span></div>
       <div class="py-1 text-center fs28 sans-light">[[[update_bond_options]]]</div>
       <div class="selectBondAsset mt-3">
        <label for="bondAssetSelect" class="form-label">[[[Asset]]]</label>


### PR DESCRIPTION
Added the missing closer button to the Update bond dialog.
![image](https://github.com/decred/dcrdex/assets/5878500/c5424c0d-1415-488e-bcea-89837b03bc2e)
