### PR TITLE
ui: Fix Add new DEX form

### DIFF
--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -1607,7 +1607,7 @@ export class DEXAddressForm {
       }
       return
     }
-    if (!this.dexToUpdate && (skipRegistration || res.paid || Object.keys(res.xc.pendingBonds).length > 0)) {
+    if (!this.dexToUpdate && (skipRegistration || res.paid || Object.keys(res.xc.auth.pendingBonds).length > 0)) {
       await app().fetchUser()
       await app().loadPage('markets')
       return


### PR DESCRIPTION
This fixes the `checkDEX()` function called from the Add new DEX server form.  It was looking for `pendingBonds` in the wrong spot.

Closes #2561