### PR TITLE
server: Market self-suspend mechanism when a chain is out of sync

### DIFF
--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -298,7 +298,8 @@ cat << EOF >> "./markets.json"
             "regXPub": "spubVWKGn9TGzyo7M4b5xubB5UV4joZ5HBMNBmMyGvYEaoZMkSxVG4opckpmQ26E85iHg8KQxrSVTdex56biddqtXBerG9xMN8Dvb3eNQVFFwpE",
             "bondAmt": 50000000,
             "bondConfs": 1,
-            "nodeRelayID": "${DCR_NODERELAY_ID}"
+            "nodeRelayID": "${DCR_NODERELAY_ID}",
+            "blockInterval": 300
         },
         "BTC_simnet": {
             "bip44symbol": "btc",
@@ -311,7 +312,8 @@ cat << EOF >> "./markets.json"
             "regXPub": "vpub5SLqN2bLY4WeZJ9SmNJHsyzqVKreTXD4ZnPC22MugDNcjhKX5xNX9QiQWcE4SSRzVWyHWUihpKRT7hckDGNzVc69wSX2JPcfGeNiT5c2XZy",
             "bondAmt": 10000,
             "bondConfs": 1,
-            "nodeRelayID": "${BTC_NODERELAY_ID}"
+            "nodeRelayID": "${BTC_NODERELAY_ID}",
+            "blockInterval": 300
 EOF
 
 if [ $LTC_ON -eq 0 ]; then
@@ -324,7 +326,8 @@ if [ $LTC_ON -eq 0 ]; then
             "swapConf": 2,
             "configPath": "${TEST_ROOT}/ltc/alpha/alpha.conf",
             "bondAmt": 1000000,
-            "bondConfs": 1
+            "bondConfs": 1,
+            "blockInterval": 300
 EOF
 fi
 

--- a/server/cmd/dcrdex/sample-markets.json
+++ b/server/cmd/dcrdex/sample-markets.json
@@ -27,7 +27,8 @@
             "swapConf": 4,
             "configPath": "/home/dcrd/.dcrd/dcrd.conf",
             "bondAmt": 10000000,
-            "bondConfs": 1
+            "bondConfs": 1,
+            "blockInterval": 3600
         },
         "DCR_testnet": {
             "bip44symbol": "dcr",
@@ -36,31 +37,36 @@
             "swapConf": 1,
             "configPath": "/home/dcrd/.dcrd/dcrd.conf",
             "bondAmt": 100000000,
-            "bondConfs": 1
+            "bondConfs": 1,
+            "blockInterval": 3600
         },
         "BTC_mainnet": {
             "bip44symbol": "btc",
             "network": "mainnet",
             "maxFeeRate": 100,
-            "swapConf": 3
+            "swapConf": 3,
+            "blockInterval": 3600
         },
         "BTC_testnet": {
             "bip44symbol": "btc",
             "network": "testnet",
             "maxFeeRate": 100,
-            "swapConf": 1
+            "swapConf": 1,
+            "blockInterval": 3600
         },
         "LTC_mainnet": {
             "bip44symbol": "ltc",
             "network": "mainnet",
             "maxFeeRate": 20,
-            "swapConf": 6
+            "swapConf": 6,
+            "blockInterval": 1200
         },
         "LTC_testnet": {
             "bip44symbol": "ltc",
             "network": "testnet",
             "maxFeeRate": 20,
-            "swapConf": 6
+            "swapConf": 6,
+            "blockInterval": 1200
         },
         "ETH_testnet": {
             "bip44symbol": "eth",

--- a/server/dex/watchdog.go
+++ b/server/dex/watchdog.go
@@ -1,0 +1,276 @@
+package dex
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/asset"
+	"decred.org/dcrdex/server/market"
+)
+
+// BlockWatchdog monitors block updates for a backed asset and sends
+// updates on chain state changes. Out of sync condition is detected
+// using a simple heuristic: when the interval between blocks exceeds
+// a (configurable) threshold, the chain is considered out of sync.
+type BlockWatchdog struct {
+	assetID       uint32
+	logger        dex.Logger
+	blockChan     <-chan *asset.BlockUpdate
+	ntfnChan      chan *WatchdogNotification
+	blockInterval uint32
+}
+
+type MonitoredAsset struct {
+	asset.Backend
+	AssetID       uint32
+	BlockInterval uint32
+}
+
+type WatchdogNotification struct {
+	AssetID uint32
+	Synced  bool
+}
+
+// NewBlockWatchdog initializes a new BlockWatchdog.
+func NewBlockWatchdog(ma *MonitoredAsset, ntfnChan chan *WatchdogNotification, logger dex.Logger) *BlockWatchdog {
+	// if blockInterval is not specified, there is no reason for our existence.
+	if ma.BlockInterval == 0 {
+		return nil
+	}
+	wd := &BlockWatchdog{
+		logger:        logger,
+		assetID:       ma.AssetID,
+		ntfnChan:      ntfnChan,
+		blockChan:     ma.Backend.BlockChannel(5),
+		blockInterval: ma.BlockInterval,
+	}
+	return wd
+}
+
+func (wd *BlockWatchdog) Run(ctx context.Context) {
+
+	log := wd.logger
+	symbol := dex.BipIDSymbol(wd.assetID)
+	log.Tracef("Starting block watchdog for [%s]", symbol)
+
+	maxBlockIntvl := time.Duration(wd.blockInterval) * time.Second
+	timer := time.NewTimer(maxBlockIntvl)
+	defer timer.Stop()
+
+	// This flag is used to detect changes in chain sync state.
+	// It defaults to true so as to avoid triggering an in-sync notification
+	// at startup.
+	lastSynced := true
+	timerStarted := time.Now().UTC()
+
+	resetTimer := func() {
+		timer.Reset(maxBlockIntvl)
+		timerStarted = time.Now().UTC()
+	}
+
+out:
+	for {
+		select {
+		// listen for block updates coming from the asset Backend
+		case update := <-wd.blockChan:
+			if update.Err != nil {
+				log.Errorf("error encountered while monitoring blocks: %v", update.Err)
+				continue
+			}
+
+			lastBlockIntvl := time.Since(timerStarted)
+			log.Tracef("Last %s block interval %.0fs", symbol, lastBlockIntvl.Seconds())
+			if !lastSynced {
+				lastSynced = true
+				wd.ntfnChan <- &WatchdogNotification{
+					AssetID: wd.assetID,
+					Synced:  true,
+				}
+			}
+			resetTimer()
+
+		case <-timer.C:
+			log.Warnf("No %s block received in %.0fs, chain out of sync", symbol, maxBlockIntvl.Seconds())
+			if lastSynced {
+				lastSynced = false
+				wd.ntfnChan <- &WatchdogNotification{
+					AssetID: wd.assetID,
+					Synced:  false,
+				}
+			}
+			resetTimer()
+
+		case <-ctx.Done():
+			break out
+		}
+	}
+	log.Tracef("Exiting block watchdog for [%s]", symbol)
+}
+
+// AssetMonitor monitors chain sync status updates emitted by BlockWatchdog.
+// When a chain is out of sync, it suspends the markets that trade that
+// asset, and resumes them when the chain is synced.
+type AssetMonitor struct {
+	dex.Runner
+	dexMgr          AMDEXInterface
+	mtx             sync.RWMutex
+	logger          dex.Logger
+	markets         map[uint32]map[string]AMMarketInterface
+	watchdogs       map[uint32]*BlockWatchdog
+	chainSyncStates map[uint32]bool
+	ntfnChan        chan *WatchdogNotification
+}
+
+type AssetMonitorConfig struct {
+	DEX     *DEX
+	Logger  dex.Logger
+	Markets map[string]*market.Market
+	Assets  map[uint32]*MonitoredAsset
+}
+
+// AMDEXInterface is defined to allow mocking the DEX interface in unit tests.
+type AMDEXInterface interface {
+	MarketRunning(string) (bool, bool)
+	ResumeMarket(string, time.Time) (int64, time.Time, error)
+	SuspendMarket(string, time.Time, bool) (*market.SuspendEpoch, error)
+}
+
+// AMMarketInterface is defined to allow mocking the Market interface in unit tests.
+type AMMarketInterface interface {
+	Base() uint32
+	Quote() uint32
+}
+
+// NewAssetMonitor initializes an AssetMonitor.
+func NewAssetMonitor(amConfig *AssetMonitorConfig) *AssetMonitor {
+
+	am := &AssetMonitor{
+		dexMgr:          AMDEXInterface(amConfig.DEX),
+		logger:          amConfig.Logger,
+		markets:         make(map[uint32]map[string]AMMarketInterface),
+		ntfnChan:        make(chan *WatchdogNotification, len(amConfig.Assets)),
+		watchdogs:       make(map[uint32]*BlockWatchdog),
+		chainSyncStates: make(map[uint32]bool),
+	}
+
+	markets := make(map[string]AMMarketInterface)
+	for name, mkt := range amConfig.Markets {
+		markets[name] = AMMarketInterface(mkt)
+	}
+
+	for assetID, ma := range amConfig.Assets {
+		// create watchdog for the asset
+		wd := NewBlockWatchdog(ma, am.ntfnChan, am.logger)
+		if wd == nil {
+			am.logger.Tracef("No block interval specified for %s chain", dex.BipIDSymbol(assetID))
+			continue
+		}
+		am.watchdogs[assetID] = wd
+		// Chain sync state cache.
+		// Initialize synced status for each monitored asset to true,
+		// assuming that the chain is synced at startup; if initial block
+		// download is in progress, the arriving blocks will keep the asset
+		// in synced state.
+		am.chainSyncStates[assetID] = true
+		// obtain the list of markets the asset is traded in
+		am.markets[assetID] = am.findMarketsByAsset(assetID, markets)
+	}
+	return am
+}
+
+// Satisfies dex.Runner
+func (am *AssetMonitor) Run(ctx context.Context) {
+
+	defer close(am.ntfnChan)
+
+	var wg sync.WaitGroup
+	for _, wd := range am.watchdogs {
+		wg.Add(1)
+		go func(wd *BlockWatchdog) {
+			defer wg.Done()
+			wd.Run(ctx)
+		}(wd)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		am.startNtfnListener(ctx)
+	}()
+	am.startNtfnListener(ctx)
+	wg.Wait()
+}
+
+func (am *AssetMonitor) startNtfnListener(ctx context.Context) {
+	log := am.logger
+	dexMgr := am.dexMgr
+out:
+	for {
+		select {
+		case ntfn := <-am.ntfnChan:
+			synced := ntfn.Synced
+			assetID := ntfn.AssetID
+			markets := am.markets[assetID]
+			am.updateChainSyncState(assetID, synced)
+			if synced {
+				for mktName, mkt := range markets {
+					if found, running := dexMgr.MarketRunning(mktName); found && !running {
+						if otherSide, synced := am.otherSideSynced(assetID, mkt); synced {
+							log.Tracef("Resuming market %s", mktName)
+							dexMgr.ResumeMarket(mktName, time.Now())
+						} else {
+							otherSymbol := dex.BipIDSymbol(otherSide)
+							log.Tracef("Not resuming market %s: the other side (%s) is out of sync", mktName, otherSymbol)
+						}
+					}
+				}
+			} else {
+				for mktName := range markets {
+					if found, running := dexMgr.MarketRunning(mktName); found && running {
+						log.Tracef("Suspending market %s", mktName)
+						dexMgr.SuspendMarket(mktName, time.Now(), true)
+					}
+				}
+			}
+		case <-ctx.Done():
+			break out
+		}
+	}
+	log.Tracef("Asset monitor stopped")
+
+}
+
+// findMarketsByAsset returns a map of markets that trade the specified asset
+func (am *AssetMonitor) findMarketsByAsset(assetID uint32, allMarkets map[string]AMMarketInterface) map[string]AMMarketInterface {
+	var markets = make(map[string]AMMarketInterface)
+	for mktName, mkt := range allMarkets {
+		if mkt.Base() == assetID || mkt.Quote() == assetID {
+			markets[mktName] = mkt
+		}
+	}
+	return markets
+}
+
+func (am *AssetMonitor) updateChainSyncState(assetID uint32, synced bool) {
+	am.mtx.Lock()
+	defer am.mtx.Unlock()
+	am.chainSyncStates[assetID] = synced
+}
+
+func (am *AssetMonitor) otherSideSynced(assetID uint32, mkt AMMarketInterface) (uint32, bool) {
+	var otherSide uint32
+	if assetID == mkt.Base() {
+		otherSide = mkt.Quote()
+	} else {
+		otherSide = mkt.Base()
+	}
+	am.mtx.RLock()
+	defer am.mtx.RUnlock()
+	// if the other side is not monitored, assume it is synced
+	if synced, found := am.chainSyncStates[otherSide]; found && synced || !found {
+		return otherSide, true
+	}
+	return otherSide, false
+}

--- a/server/dex/watchdog_test.go
+++ b/server/dex/watchdog_test.go
@@ -1,0 +1,401 @@
+package dex
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/asset"
+	"decred.org/dcrdex/server/market"
+)
+
+const (
+	// maxBlockInterval is the maximum time in seconds between blocks,
+	maxBlockInterval = uint32(10)
+	assetID          = uint32(42)
+)
+
+var logger = dex.StdOutLogger("TEST", dex.LevelTrace)
+
+func TestBlockWatchdog_NewBlockWatchdog(t *testing.T) {
+
+	blockInterval := maxBlockInterval
+	ntfnChan := make(chan *WatchdogNotification)
+
+	wd := NewBlockWatchdog(&MonitoredAsset{
+		Backend:       &TBackend{},
+		AssetID:       assetID,
+		BlockInterval: blockInterval,
+	}, ntfnChan, logger)
+
+	if wd.assetID != assetID {
+		t.Fatalf("expected AssetID %d, got %d", assetID, wd.assetID)
+	}
+
+	if wd.blockInterval != blockInterval {
+		t.Fatalf("expected BlockInterval %d, got %d", blockInterval, wd.blockInterval)
+	}
+
+	// NewBlockWatchdog returns nil if blockInterval is 0
+	wdNil := NewBlockWatchdog(&MonitoredAsset{
+		Backend:       &TBackend{},
+		AssetID:       assetID,
+		BlockInterval: 0,
+	}, ntfnChan, logger)
+	if wdNil != nil {
+		t.Fatalf("expected nil, got %v", wdNil)
+	}
+}
+
+func TestBlockWatchdog_Run(t *testing.T) {
+
+	tBlockIntervals := []uint32{5, 8, 15, 2, 29, 22, 4}
+	//
+	// Blocks/intvls |--5--*----8---*------15-------*-2-*--------------29-------------*----------22-----------*--4-*
+	// Timer resets  |     #        #          #    #   #          #          #       #          #          # #
+	// Update ntfy   |                         v    ^              v                  ^          v            ^
+	// Timestamp     |     5       13          23  28             40         50      59         69           81
+	tExpected := []*TOutput{
+		{timestamp: 23, synced: false},
+		{timestamp: 28, synced: true},
+		{timestamp: 40, synced: false},
+		{timestamp: 59, synced: true},
+		{timestamp: 69, synced: false},
+		{timestamp: 81, synced: true},
+	}
+
+	ntfnChan := make(chan *WatchdogNotification)
+
+	backend := &TBackend{
+		BackendSynced: true,
+		BlockChan:     make(chan *asset.BlockUpdate, 1),
+	}
+
+	wd := NewBlockWatchdog(&MonitoredAsset{
+		AssetID:       assetID,
+		BlockInterval: maxBlockInterval,
+		Backend:       backend,
+	}, ntfnChan, logger)
+
+	newBlock := func(blockInterval uint32) {
+		time.Sleep(time.Duration(blockInterval) * time.Second)
+		backend.BlockChan <- &asset.BlockUpdate{}
+	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	go wd.Run(ctx)
+
+	var tResults []*TOutput
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		tResults = testSyncUpdate(ctx, t, ntfnChan)
+	}()
+
+	for height, interval := range tBlockIntervals {
+		t.Logf("newBlock %d interval %d", height, interval)
+		newBlock(interval)
+	}
+
+	cancel()
+	wg.Wait()
+
+	if !reflect.DeepEqual(tResults, tExpected) {
+		t.Errorf("Test failed. Expected: %v, Got: %v", tExpected, tResults)
+	}
+}
+
+type TOutput struct {
+	timestamp int32
+	synced    bool
+}
+
+func testSyncUpdate(ctx context.Context, t *testing.T, ntfnChan <-chan *WatchdogNotification) []*TOutput {
+
+	results := []*TOutput{}
+	startedAt := time.Now().UTC()
+
+	for {
+		select {
+		case ntfn, ok := <-ntfnChan:
+			if !ok {
+				return results
+			}
+			results = append(results, &TOutput{
+				timestamp: int32(time.Since(startedAt).Seconds()),
+				synced:    ntfn.Synced,
+			})
+		case <-ctx.Done():
+			return results
+		}
+	}
+}
+
+type TBackend struct {
+	BlockChan     chan *asset.BlockUpdate
+	BackendSynced bool
+	mtx           sync.RWMutex
+}
+
+// Synced mocks the InitialBlockDownload/GetBlockChainInfo logic
+func (tb *TBackend) Synced() (bool, error) {
+	tb.mtx.RLock()
+	defer tb.mtx.RUnlock()
+	return tb.BackendSynced, nil
+}
+
+// SetSynced simulates a change in the backend's synced status
+func (tb *TBackend) SetSynced(synced bool) {
+	tb.mtx.Lock()
+	defer tb.mtx.Unlock()
+	tb.BackendSynced = synced
+}
+func (tb *TBackend) BlockChannel(size int) <-chan *asset.BlockUpdate {
+	return tb.BlockChan
+}
+
+// mock methods
+func (tb *TBackend) Connect(ctx context.Context) (*sync.WaitGroup, error) {
+	return nil, nil
+}
+
+func (tb *TBackend) Contract(coinID []byte, contractData []byte) (*asset.Contract, error) {
+	return nil, nil
+}
+func (tb *TBackend) TxData(coinID []byte) ([]byte, error) {
+	return nil, nil
+}
+func (tb *TBackend) ValidateSecret(secret, contractData []byte) bool {
+	return false
+}
+func (tb *TBackend) Redemption(redemptionID, contractID, contractData []byte) (asset.Coin, error) {
+	return nil, nil
+}
+func (tb *TBackend) InitTxSize() uint32 {
+	return 0
+}
+func (tb *TBackend) InitTxSizeBase() uint32 {
+	return 0
+}
+func (tb *TBackend) CheckSwapAddress(string) bool {
+	return false
+}
+func (tb *TBackend) ValidateCoinID(coinID []byte) (string, error) {
+	return "", nil
+}
+func (tb *TBackend) ValidateContract(contract []byte) error {
+	return nil
+}
+func (tb *TBackend) FeeRate(context.Context) (uint64, error) {
+	return 0, nil
+}
+func (tb *TBackend) Info() *asset.BackendInfo {
+	return nil
+}
+func (tb *TBackend) ValidateFeeRate(contract *asset.Contract, reqFeeRate uint64) bool {
+	return false
+}
+
+type TBackedAsset struct {
+	dex.Asset
+	Backend TBackend
+}
+
+func TestNewAssetMonitor(t *testing.T) {
+
+	amConfig := &AssetMonitorConfig{
+		DEX:    &DEX{},
+		Logger: logger,
+		Markets: map[string]*market.Market{
+			"dcr_btc": {},
+			"dcr_ltc": {},
+		},
+	}
+	am := NewAssetMonitor(amConfig)
+	if am.dexMgr == nil {
+		t.Error("dexMgr is nil")
+	}
+}
+
+type TDEX struct {
+	markets map[string]AMMarketInterface
+	mtx     sync.RWMutex
+}
+
+func (d *TDEX) MarketRunning(mktName string) (found, running bool) {
+	d.mtx.RLock()
+	defer d.mtx.RUnlock()
+	mkt, found := d.markets[mktName]
+	if !found {
+		return false, false
+	}
+	return found, mkt.(*TMarket).running
+}
+func (d *TDEX) ResumeMarket(mktName string, now time.Time) (startEpoch int64, startTime time.Time, err error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	m := d.markets[mktName]
+	m.(*TMarket).running = true
+	return 0, time.Now(), nil
+}
+func (d *TDEX) SuspendMarket(mktName string, now time.Time, persist bool) (suspEpoch *market.SuspendEpoch, err error) {
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	m := d.markets[mktName]
+	m.(*TMarket).running = false
+	return nil, nil
+}
+
+type TMarket struct {
+	AMMarketInterface
+	base, quote uint32
+	running     bool
+}
+
+func (m *TMarket) Base() uint32 {
+	return m.base
+}
+func (m *TMarket) Quote() uint32 {
+	return m.quote
+}
+func (m *TMarket) Running() bool {
+	return m.running
+}
+
+var tMarkets = map[string]AMMarketInterface{
+	"dcr_btc": &TMarket{base: 42, quote: 0, running: true},
+	"ltc_dcr": &TMarket{base: 2, quote: 42, running: true},
+}
+
+var dexMgr = &TDEX{
+	// for mocking MarketRunning/ResumeMarket/SuspendMarket
+	markets: tMarkets,
+}
+
+// func TestNewAssetMonitor_NewAssetMonitor(t *testing.T) {
+// 	am := NewAssetMonitor(&AssetMonitorConfig{
+// 		DEX:    &DEX{},
+// 		Logger: logger,
+// 		Markets: map[string]*market.Market{
+// 			// FIXME find a way to mock the market interface
+// 			"dcr_btc": {},
+// 			"ltc_dcr": {},
+// 		},
+// 		MonitoredAssets: map[uint32]*MonitoredAsset{
+// 			0: {
+// 				AssetID:       0,
+// 				BlockInterval: maxBlockInterval,
+// 				Backend:       &TBackend{},
+// 			},
+// 			2: {
+// 				AssetID:       2,
+// 				BlockInterval: maxBlockInterval,
+// 				Backend:       &TBackend{},
+// 			},
+// 			42: {
+// 				AssetID:       42,
+// 				BlockInterval: maxBlockInterval,
+// 				Backend:       &TBackend{},
+// 			},
+// 		},
+// 	})
+// 	if am == nil {
+// 		t.Error("expected AssetMonitor, got nil")
+// 	}
+// }
+
+func TestAssetMonitor_runAssetMonitor(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	ntfnChan := make(chan *WatchdogNotification)
+
+	sendNtfn := func(assetID uint32, synced bool) {
+		ntfnChan <- &WatchdogNotification{
+			AssetID: assetID,
+			Synced:  synced,
+		}
+	}
+
+	am := &AssetMonitor{
+		dexMgr: dexMgr,
+		logger: logger,
+		markets: map[uint32]map[string]AMMarketInterface{
+			0: {
+				"dcr_btc": &TMarket{base: 42, quote: 0, running: true},
+			},
+			2: {
+				"ltc_dcr": &TMarket{base: 2, quote: 42, running: true},
+			},
+			42: {
+				"dcr_btc": &TMarket{base: 42, quote: 0, running: true},
+				"ltc_dcr": &TMarket{base: 2, quote: 42, running: true},
+			},
+		},
+		ntfnChan:        ntfnChan,
+		chainSyncStates: make(map[uint32]bool),
+	}
+
+	assets := []uint32{0, 2, 42}
+
+	for _, assetID := range assets {
+		am.chainSyncStates[assetID] = true
+		am.markets[assetID] = am.findMarketsByAsset(assetID, tMarkets)
+	}
+
+	assertMarketRunning := func(mkt string, want bool) {
+		dexMgr.mtx.RLock()
+		defer dexMgr.mtx.RUnlock()
+		got := dexMgr.markets[mkt].(*TMarket).running
+		if got != want {
+			t.Errorf("expected %s market running=%v, got %v", mkt, want, got)
+		}
+	}
+
+	go am.startNtfnListener(ctx)
+
+	time.Sleep(1 * time.Second)
+
+	// btc chain out of sync
+	sendNtfn(0, false)
+	time.Sleep(1 * time.Second)
+	// dcr_btc market should be suspended
+	assertMarketRunning("dcr_btc", false)
+
+	// btc chain back in sync
+	sendNtfn(0, true)
+	time.Sleep(1 * time.Second)
+	// dcr_btc market should be running
+	assertMarketRunning("dcr_btc", true)
+
+	// dcr chain out of sync
+	sendNtfn(42, false)
+	time.Sleep(1 * time.Second)
+	assertMarketRunning("ltc_dcr", false)
+	assertMarketRunning("dcr_btc", false)
+
+	// ltc chain out of sync
+	sendNtfn(2, false)
+	time.Sleep(1 * time.Second)
+	// ltc_dcr market should still be suspended
+	assertMarketRunning("ltc_dcr", false)
+
+	// dcr chain back in sync
+	sendNtfn(42, true)
+	time.Sleep(1 * time.Second)
+	assertMarketRunning("dcr_btc", true)
+	// ltc_dcr market should be suspended (ltc still down)
+	assertMarketRunning("ltc_dcr", false)
+
+	sendNtfn(2, true)
+	time.Sleep(1 * time.Second)
+	assertMarketRunning("ltc_dcr", true)
+	assertMarketRunning("dcr_btc", true)
+
+	time.Sleep(1 * time.Second)
+	cancel()
+}


### PR DESCRIPTION
This PR adds the ability to detect out of sync chains and suspend/resume related markets.  Out of sync condition is detected
using a simple heuristic: when the interval between blocks exceeds a configurable threshold, the chain is considered out of sync.  A suspended market is resumed when a block is received.

The block interval threshold can be configured with the `blockInterval` asset parameter.

Closes #2510

I appreciate suggestions/comments on improving test coverage, and of course other aspects as well.