### PR TITLE
dexc-desktop: Snap package

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,9 @@
+
+# Build and Publish Snap Package workflow
+
+This workflow builds a `snap` package and uploads it to the [Snap Store](https://snapcraft.io/store).  It has a `workflow_dispatch` trigger so it can be triggered manually only, it is not hooked up to any other GH event.
+
+The store upload requires the `SNAPCRAFT_STORE_CREDENTIALS` variable to be set in [Github Secrets](https://github.com/decred/dcrdex/settings/secrets/actions).  
+See https://github.com/snapcore/action-publish for details.
+
+More information on Snapcraft authentication: [https://snapcraft.io/docs/snapcraft-authentication]

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -1,0 +1,48 @@
+name: Build and Publish Snap Package
+
+on:
+# manually trigger the workflow from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-snap:
+    runs-on: ubuntu-latest
+
+    steps:
+        - name: Checkout code
+          uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+          with:
+            fetch-depth: 0
+
+        - name: Compile frontend
+          working-directory: client/webserver/site
+          run: |
+            npm install
+            npm run build
+
+        - name: Install deb deps
+          run: |
+            sudo apt-get update
+            sudo apt-get -y install libgtk-3-dev libwebkit2gtk-4.1-dev build-essential
+
+        - name: Build deb package
+          working-directory: client/cmd/bisonw-desktop
+          run: pkg/pkg-debian.sh
+
+        - name: Prepare snapcraft.yml
+          working-directory: client/cmd/bisonw-desktop
+          run: pkg/prepare-snap.sh
+
+        - name: Build snap package
+          uses: snapcore/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
+          id: build
+          with:
+            path: client/cmd/bisonw-desktop
+
+        - name: Publish snap to Snap Store
+          uses: snapcore/action-publish@214b86e5ca036ead1668c79afb81e550e6c54d40 # v1.2.0
+          env:
+            SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+          with:
+            snap: ${{ steps.build.outputs.snap }}
+            release: stable

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ client/cmd/bisonw-desktop/pkg/installers
 client/cmd/testbinance/testbinance
 client/cmd/mmbaltracker/mmbaltracker
 server/noderelay/cmd/sourcenode/sourcenode
+client/cmd/bisonw-desktop/snap/snapcraft.yaml
 tatanka/cmd/demo/demo
 server/cmd/validatemarkets
 client/cmd/translationsreport/translationsreport

--- a/client/cmd/bisonw-desktop/README.md
+++ b/client/cmd/bisonw-desktop/README.md
@@ -5,14 +5,46 @@ bison-desktop is a cross-platform desktop application for Bison Wallet. The inst
 **Note**: The instructions below are to be run in your CLI from the `bisonw-desktop` directory.
 
 ## Debian
-Build with `./pkg/pkg-debian.sh`. The deb archive is located in **./build**.
 
-For development, you'll need to install the WebKit Development Libraries.
-`apt install libgtk-3-dev libwebkit2gtk-4.0-dev`
-For production, they are specified as DEPENDS in the control file and the
-package manager will install them.
+### Install build dependencies
 
-## MacOS (darwin)
-Build with `./pkg/pkg-darwin.sh` for `amd64` MacOS machines. If running on an
-`arm64` machine, you'll need to build with `TARGETS=darwin/arm64 ./pkg/pkg-darwin.sh` instead.
-The `.dmg` click installer can be located in **./pkg/installers** after a successful build.
+```bash
+sudo apt-get install libgtk-3-dev libwebkit2gtk-4.1-dev build-essential
+```
+
+### Run build
+
+```bash
+./pkg/pkg-debian.sh
+```
+
+The deb archive will be located in **./build**.
+
+## Snap
+
+Snap is a package standard that can be installed on many Linux distributions from the Snap Store, and via software centers in e.g. Fedora, Ubuntu.
+
+### Preparing the build environment
+
+```bash
+sudo apt-get install snapd
+sudo snap install --classic snapcraft
+sudo adduser $USER lxd
+newgrp lxd
+lxd init --auto
+sudo ufw disable # if ufw is installed on the host, this is neccessary for lxd to have network access
+
+```
+
+### Running the build
+
+ 1. Build the Debian package
+ 2. `./pkg/pkg-snap.sh`
+
+### Publishing the snap
+
+The snap can be uploaded to the Snap Store using `./pkg/publish-snap.sh`.  This requires [Snapcraft developer account credentials](https://snapcraft.io/docs/releasing-your-app).  After this is completed, the package can be installed on any system running `snap` by running `snap install bisonw`.  The app will be available on the [Snap Store](https://snapcraft.io/store/bisonw).
+
+## macOS (darwin)
+
+Build with `./pkg/pkg-darwin.sh` for `amd64` MacOS machines. If running on an `arm64` machine, you'll need to build with `TARGETS=darwin/arm64 ./pkg/pkg-darwin.sh` instead. The `.dmg` click installer can be located in **./pkg/installers** after a successful build.

--- a/client/cmd/bisonw-desktop/pkg/common.sh
+++ b/client/cmd/bisonw-desktop/pkg/common.sh
@@ -1,0 +1,19 @@
+
+# This file defines common variables to be source'd by the various build scripts
+# in this directory.
+
+# pick up the release tag from git
+VER=$(git describe --tags --abbrev=0 --always | sed -e 's/^v//')
+META= # "release"
+REV="0"
+
+APP="bisonw"
+ARCH="amd64"
+
+# The build directory will be deleted at the beginning of every build. The
+# directory is .gitignore'd.
+BUILD_DIR="./build"
+
+# DEB_NAME follows the prescribed format for debian packaging.
+DEB_NAME="${APP}_${VER}-${REV}_${ARCH}"
+

--- a/client/cmd/bisonw-desktop/pkg/pkg-debian.sh
+++ b/client/cmd/bisonw-desktop/pkg/pkg-debian.sh
@@ -3,22 +3,12 @@
 # A good getting-started guide for Debian packaging can be found at
 # https://www.internalpointers.com/post/build-binary-deb-package-practical-guide
 
-set -ex
+# turn this on for debugging, keep noise low for prod builds
+# set -ex
 
-APP="bisonw"
-VER="0.7.0-pre"
-META= # "release"
-REV="0"
-ARCH="amd64"
+source $(dirname "$0")/common.sh
 
-# DEB_NAME follows the prescribed format for debian packaging.
-DEB_NAME="${APP}_${VER}-${REV}_${ARCH}"
-
-# The build directory will be deleted at the beginning of every build. The
-# directory is .gitignore'd.
-BUILD_DIR="./build"
-
-# A directory for binary source files e.g. image files.
+# A directory containing metadata files
 SRC_DIR="./src"
 
 # The DEB_DIR represents the root directory in our target system. The directory
@@ -35,16 +25,11 @@ CONTROL_DIR="${DEB_DIR}/DEBIAN"
 POSTINST_PATH="${CONTROL_DIR}/postinst"
 POSTRM_PATH="${CONTROL_DIR}/postrm"
 
-# The bisonw binary.
-BIN_TARGETDIR="/usr/lib/bisonw"
+# The dexc binary.
+BIN_TARGETDIR="/usr/bin"
 BIN_BUILDDIR="${DEB_DIR}${BIN_TARGETDIR}"
 BIN_FILENAME="${APP}"
 BIN_BUILDPATH="${BIN_BUILDDIR}/${BIN_FILENAME}"
-
-ICON_FILENAME="bisonw.png"
-SRC_TARGETDIR="${BIN_TARGETDIR}/src"
-SRC_BUILDDIR="${DEB_DIR}${SRC_TARGETDIR}"
-LIBICON_BUILDPATH="${SRC_BUILDDIR}/${ICON_FILENAME}"
 
 # The Desktop Entry is a format for "installing" programs on Linux, creating
 # an entry in the main menu.
@@ -54,18 +39,17 @@ DOT_DESKTOP_BUILDDIR="${DEB_DIR}${DOT_DESKTOP_TARGETDIR}"
 DOT_DESKTOP_FILENAME="bisonw.desktop"
 DOT_DESKTOP_BUILDPATH="${DOT_DESKTOP_BUILDDIR}/${DOT_DESKTOP_FILENAME}"
 
-# This will be the icon shown for the program in the taskbar. I know that both
-# PNG and SVG will work. If it's a bitmap, should probably be >= 128 x 128 px.
-ICON_TARGETDIR="/usr/share/pixmaps"
-ICON_BUILDDIR="${DEB_DIR}${ICON_TARGETDIR}"
-DESKTOPICON_BUILDPATH="${ICON_BUILDDIR}/${ICON_FILENAME}"
-
 # Prepare the directory structure.
 rm -fr "${BUILD_DIR}"
 mkdir -p -m 0755 "${CONTROL_DIR}"
-mkdir -p "${SRC_BUILDDIR}" # subdir of BIN_BUILDDIR
 mkdir -p "${DOT_DESKTOP_BUILDDIR}"
-mkdir -p "${ICON_BUILDDIR}"
+
+# Build site bundle
+CWD=$(pwd)
+cd ../../webserver/site
+npm clean-install
+npm run build
+cd $CWD
 
 # Build bisonw
 LDFLAGS="-s -w -X main.Version=${VER}${META:++${META}}"
@@ -83,40 +67,38 @@ Depends: libgtk-3-0, libwebkit2gtk-4.0-37
 Description: A multi-wallet backed by Decred DEX
 EOF
 
-# Symlink the binary and update the desktop icons, refresh the "start" menu.
+# Copy icons
+# This will be the icon shown for the program in the taskbar. I know that both
+# PNG and SVG will work. If it's a bitmap, should probably be >= 128 x 128 px.
+ICON_TARGETDIR="/usr/share/icons/hicolor"
+ICON_BUILDDIR="${DEB_DIR}${ICON_TARGETDIR}"
+install -Dm644 -t "${ICON_BUILDDIR}/scalable/apps" "${SRC_DIR}/bisonw.svg"
+install -Dm644 -t "${ICON_BUILDDIR}/128x128/apps" "${SRC_DIR}/bisonw.png"
+
+# AppStream metadata
+# https://wiki.debian.org/AppStream
+install -Dm644 -t "${DEB_DIR}/usr/share/metainfo" "${SRC_DIR}/org.decred.dcrdex.metainfo.xml"
+
+# Update the desktop icons, refresh the "start" menu.
 cat > "${POSTINST_PATH}" <<EOF
-ln -s "${BIN_TARGETDIR}/${BIN_FILENAME}" "/usr/bin/${BIN_FILENAME}"
 update-desktop-database
 EOF
 chmod 775 "${POSTINST_PATH}"
-
-# Remove symlink from postinst.
-cat > "${POSTRM_PATH}" <<EOF
-rm "/usr/bin/${BIN_FILENAME}"
-EOF
-chmod 775 "${POSTRM_PATH}"
 
 # Example file:
 # https://specifications.freedesktop.org/desktop-entry-spec/latest/apa.html
 cat > "${DOT_DESKTOP_BUILDPATH}" <<EOF
 [Desktop Entry]
-Version=${VER}
+Version=1.5
 Name=Bison Wallet
 Comment=Multi-wallet backed by Decred DEX
-Exec=${BIN_TARGETDIR}/${BIN_FILENAME}
-Icon=${ICON_TARGETDIR}/${ICON_FILENAME}
+Exec=${BIN_FILENAME}
+Icon=${APP}
 Terminal=false
 Type=Application
-Categories=Office;Development;
+Categories=Office;Finance;
 EOF
 chmod 644 "${DOT_DESKTOP_BUILDPATH}"
-
-# Icon
-cp "${SRC_DIR}/${ICON_FILENAME}" "${DESKTOPICON_BUILDPATH}"
-chmod 644 "${DESKTOPICON_BUILDPATH}"
-
-cp "${SRC_DIR}/${ICON_FILENAME}" "${LIBICON_BUILDPATH}"
-chmod 644 "${LIBICON_BUILDPATH}"
 
 # Build the installation archive (.deb file).
 dpkg-deb --build --root-owner-group "${DEB_DIR}"

--- a/client/cmd/bisonw-desktop/pkg/pkg-snap.sh
+++ b/client/cmd/bisonw-desktop/pkg/pkg-snap.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -ex
+
+SCRIPT_DIR=$(dirname "$0")
+
+source $SCRIPT_DIR/common.sh
+
+pkg/prepare-snap.sh
+snapcraft --verbose --output $BUILD_DIR/

--- a/client/cmd/bisonw-desktop/pkg/prepare-snap.sh
+++ b/client/cmd/bisonw-desktop/pkg/prepare-snap.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -ex
+
+SCRIPT_DIR=$(dirname "$0")
+
+source $SCRIPT_DIR/common.sh
+
+SNAPCRAFT_YML_IN=snap/local/snapcraft.yaml.in
+SNAPCRAFT_YML=snap/snapcraft.yaml
+sed -e "s/\$VERSION/$VER/g" \
+    -e "s/\$DEB_NAME/$DEB_NAME/g" "$SNAPCRAFT_YML_IN" > "$SNAPCRAFT_YML"
+

--- a/client/cmd/bisonw-desktop/pkg/publish-snap.sh
+++ b/client/cmd/bisonw-desktop/pkg/publish-snap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+source $(dirname "$0")/common.sh
+
+snapcraft login
+
+snapcraft upload --release=stable $BUILD_DIR/${APP}_${VER}_${ARCH}.snap

--- a/client/cmd/bisonw-desktop/snap/local/snapcraft.yaml.in
+++ b/client/cmd/bisonw-desktop/snap/local/snapcraft.yaml.in
@@ -1,0 +1,103 @@
+name: bisonw
+adopt-info: metainfo
+version: '$VERSION'
+license: BlueOak-1.0.0
+
+base: core22 
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: amd64
+compression: lzo
+
+plugs:
+  dbus-svc:
+    bus: system
+    interface: dbus
+    name: org.freedesktop.portal
+  dbus-statusnotifier:
+    bus: session
+    interface: dbus
+    name: org.kde.StatusNotifierWatcher
+  dbus-dbusmenu:
+    bus: session
+    interface: dbus
+    name: com.canonical.dbusmenu
+
+apps:
+  bisonw:
+    common-id: org.decred.dcrdex
+    command: usr/bin/bisonw
+    desktop: usr/share/applications/bisonw.desktop
+    extensions: [gnome]
+    environment:
+      GTK_USE_PORTAL: "1"
+
+    # required snap interfaces:
+    # https://snapcraft.io/docs/interface-management
+    plugs: 
+      - home
+      - opengl
+      - x11
+      - desktop
+      - desktop-legacy
+      - network
+      - network-status
+      - browser-support
+      - screen-inhibit-control
+      - dbus-svc
+      - dbus-dbusmenu
+      - dbus-statusnotifier
+
+parts:
+  metainfo:
+    plugin: nil
+    source: .
+    parse-info: [./src/org.decred.dcrdex.metainfo.xml]
+
+  bisonw-desktop:
+    plugin: dump
+    source: ./build/$DEB_NAME.deb
+    source-type: deb
+    override-build: |
+      craftctl default
+      # Point icon to the correct location
+      sed -i -e 's|Icon=.*$|Icon=usr/share/icons/hicolor/scalable/apps/bisonw.svg|' $SNAPCRAFT_PART_INSTALL/usr/share/applications/bisonw.desktop
+  
+    # prune unused libs added by .deb dependencies from the .snap
+    prime:
+      - -usr/lib/x86_64-linux-gnu/libEGL_mesa*
+      - -usr/lib/x86_64-linux-gnu/libGLX_mesa*
+      - -usr/lib/x86_64-linux-gnu/libGLESv2*
+      - -usr/lib/x86_64-linux-gnu/libcaca++*
+      - -usr/lib/x86_64-linux-gnu/libcolordprivate*
+      - -usr/lib/x86_64-linux-gnu/libdconf*
+      - -usr/lib/x86_64-linux-gnu/libexslt*
+      - -usr/lib/x86_64-linux-gnu/libgstcheck-1.0*
+      - -usr/lib/x86_64-linux-gnu/libgstcontroller-1.0*
+      - -usr/lib/x86_64-linux-gnu/libicuio*
+      - -usr/lib/x86_64-linux-gnu/libicutest*
+      - -usr/lib/x86_64-linux-gnu/libjacknet*
+      - -usr/lib/x86_64-linux-gnu/libjackserver*
+      - -usr/lib/x86_64-linux-gnu/liborc-test-0.4*
+      - -usr/lib/x86_64-linux-gnu/libpulse-simple*
+      - -usr/lib/x86_64-linux-gnu/libunwind-coredump*
+      - -usr/lib/x86_64-linux-gnu/libunwind-ptrace*
+      - -usr/lib/x86_64-linux-gnu/libunwind-x86_64*
+      - -usr/lib/x86_64-linux-gnu/libwoff2enc*
+      - -usr/lib/x86_64-linux-gnu/libicutu*
+      - -usr/lib/x86_64-linux-gnu/libsamplerate*
+      - -usr/lib/x86_64-linux-gnu/libxcb-dri2*
+      - -usr/lib/x86_64-linux-gnu/libxcb-glx*
+      - -usr/lib/x86_64-linux-gnu/libxcb-present*
+      - -usr/lib/x86_64-linux-gnu/libxcb-randr*
+      - -usr/lib/x86_64-linux-gnu/libxcb-sync*
+      - -usr/lib/x86_64-linux-gnu/libxcb-xfixes*
+      - -usr/lib/x86_64-linux-gnu/libxshmfence*
+
+    stage-packages:
+      - desktop-file-utils
+      - libwebkit2gtk-4.1-0
+      - libgtk-3-0
+

--- a/client/cmd/bisonw-desktop/src/bisonw.svg
+++ b/client/cmd/bisonw-desktop/src/bisonw.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg height="128px" viewBox="0 0 128 128" width="128px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <linearGradient id="a" gradientTransform="matrix(0.690851 0 0 -0.690851 -33.81841 -125.264472)" gradientUnits="userSpaceOnUse" x1="96.658699" x2="186.539993" y1="-258.971191" y2="-169.089905">
+        <stop offset="0" stop-color="#2c2fa9"/>
+        <stop offset="1" stop-color="#504cff"/>
+    </linearGradient>
+    <linearGradient id="b" gradientTransform="matrix(0.690851 0 0 -0.690851 -33.81841 -125.264472)" gradientUnits="userSpaceOnUse" x1="96.658699" x2="186.539993" y1="-378.812012" y2="-288.930695">
+        <stop offset="0" stop-color="#101866"/>
+        <stop offset="1" stop-color="#3133b4"/>
+    </linearGradient>
+    <linearGradient id="c" gradientTransform="matrix(0.690851 0 0 -0.690851 -33.81841 -125.264472)" gradientUnits="userSpaceOnUse" x1="166.317398" x2="209.758896" y1="-295.671387" y2="-252.229904">
+        <stop offset="0" stop-color="#3133b4"/>
+        <stop offset="1" stop-color="#4342e0"/>
+    </linearGradient>
+    <linearGradient id="d" gradientTransform="matrix(0.690851 0 0 -0.690851 -33.81841 -125.264472)" gradientUnits="userSpaceOnUse" x1="73.4375" x2="116.884201" y1="-295.67041" y2="-252.229996">
+        <stop offset="0" stop-color="#1d2285"/>
+        <stop offset="1" stop-color="#2f31b0"/>
+    </linearGradient>
+    <path d="m 115.75 12.25 v 20.699219 h -10.347656 c -13.519532 0 -24.714844 8.636719 -28.976563 20.695312 h -24.839843 c -4.261719 -12.058593 -15.457032 -20.695312 -28.976563 -20.695312 h -10.347656 v -20.699219 h 10.347656 c 16.289063 -0.011719 31.632813 7.660156 41.394531 20.699219 c 9.765625 -13.039063 25.109375 -20.710938 41.398438 -20.699219 z m 0 0" fill="url(#a)"/>
+    <path d="m 105.402344 95.042969 h 10.347656 v 20.699219 h -10.347656 c -16.289063 0.011718 -31.632813 -7.660157 -41.398438 -20.699219 c -9.761718 13.039062 -25.105468 20.710937 -41.394531 20.699219 h -10.347656 v -20.699219 h 10.347656 c 13.519531 0 24.714844 -8.640625 28.976563 -20.699219 h 24.839843 c 4.261719 12.058594 15.457031 20.699219 28.976563 20.699219 z m 0 0" fill="url(#b)"/>
+    <path d="m 76.425781 53.644531 h 39.324219 v 20.699219 h -39.324219 z m 0 0" fill="url(#c)"/>
+    <path d="m 12.257812 53.644531 h 39.328126 v 20.699219 h -39.328126 z m 0 0" fill="url(#d)"/>
+</svg>

--- a/client/cmd/bisonw-desktop/src/org.decred.dcrdex.desktop
+++ b/client/cmd/bisonw-desktop/src/org.decred.dcrdex.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Bison Wallet
+Comment=Multi-wallet backed by Decred DEX
+Categories=Office;Finance;
+Icon=org.decred.dcrdex
+Exec=dexc
+Terminal=false
+StartupWMClass=BisonWallet

--- a/client/cmd/bisonw-desktop/src/org.decred.dcrdex.metainfo.xml
+++ b/client/cmd/bisonw-desktop/src/org.decred.dcrdex.metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.decred.dcrdex</id>
+  <launchable type="desktop-id">org.decred.dcrdex.desktop</launchable>
+  <name>Decred DEX Client</name>
+  <summary>Multi-wallet backed by Decred DEX</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>BlueOak-1.0.0</project_license>
+  <url type="homepage">https://dex.decred.org</url>
+  <url type="help">https://chat.decred.org/#/room/#dex:decred.org</url>
+  <developer_name>The Decred Developers</developer_name>
+  <description>
+    <p>
+      Self-custodial multi-wallet with built-in peer-to-peer exchange.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/decred/umbrel-app-store/master/decred-dcrdex/images/screenshot_1.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/decred/umbrel-app-store/master/decred-dcrdex/images/screenshot_2.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/decred/umbrel-app-store/master/decred-dcrdex/images/screenshot_3.png</image>
+    </screenshot>
+  </screenshots>
+</component>


### PR DESCRIPTION
This PR adds configuration, build scripts and Github workflow to build the Snap package and publishing it in the [Snap Store](https://snapcraft.io/store).

The snap build uses the .deb package.  The PR also contains a few fixes/improvements in the deb build:

 *   Icons: added SVG icon for hicolor and symbolic variations, fixed 128px PNG to match official version
 *   icon install location changed to /usr/share/icons which is the XDG standard
 *  binary installs in /usr/bin directly (this is standard practice, simplifies deb scripts)
 *   added AppStream metainfo file (for GNOME/KDE/Ubuntu software centers and the snap)

