### PR TITLE
ui: Move sign out menu item to bottom of hamburger menu

### DIFF
--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -93,7 +93,6 @@
       <span class="ico-settings fs16 me-2"></span>
       [[[Settings]]]
     </a>
-    <hr>
     <div class="demi hoverbright pointer d-flex align-items-center py-1 authed-only" id="profileSignout">
       <span class="ico-profile fs16 me-2"></span>
       [[[Sign Out]]]

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -78,10 +78,6 @@
 
   <div id="profileBox" class="d-hide">
     <div class="icon fs20 ico-hamburger p-1" id="innerBurgerIcon"></div>
-    <div class="demi hoverbright pointer d-flex align-items-center py-1 authed-only" id="profileSignout">
-      <span class="ico-profile fs16 me-2"></span>
-      [[[Sign Out]]]
-    </div>
     <span class="errcolor" id="logoutErr"></span>
     <a href="/orders" class="demi hoverbright plainlink d-flex align-items-center py-1 authed-only">
       <span class="ico-settings fs16 me-2"></span>
@@ -97,6 +93,11 @@
       <span class="ico-settings fs16 me-2"></span>
       [[[Settings]]]
     </a>
+    <hr>
+    <div class="demi hoverbright pointer d-flex align-items-center py-1 authed-only" id="profileSignout">
+      <span class="ico-profile fs16 me-2"></span>
+      [[[Sign Out]]]
+    </div>
   </div>
 
 </header>


### PR DESCRIPTION
Sign out is usually at the bottom of profile menus.

![image](https://github.com/decred/dcrdex/assets/5878500/ff449316-5ad9-4357-99b9-050cd3c88cb4)
