### PR TITLE
mesh: implement toy mesh network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ client/asset/eth/cmd/getgas/getgas
 client/asset/eth/cmd/deploy/deploy
 client/cmd/dexc-desktop/pkg/installers
 server/noderelay/cmd/sourcenode/sourcenode
+tatanka/cmd/demo/demo

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -3898,7 +3898,8 @@ func (dcr *ExchangeWallet) refundTx(coinID, contract dex.Bytes, val uint64, refu
 // DepositAddress returns an address for depositing funds into the exchange
 // wallet.
 func (dcr *ExchangeWallet) DepositAddress() (string, error) {
-	addr, err := dcr.wallet.ExternalAddress(dcr.ctx, dcr.depositAccount())
+	acct := dcr.depositAccount()
+	addr, err := dcr.wallet.ExternalAddress(dcr.ctx, acct)
 	if err != nil {
 		return "", err
 	}

--- a/client/asset/eth/txdb.go
+++ b/client/asset/eth/txdb.go
@@ -408,6 +408,7 @@ func (s *badgerTxDB) getTxs(n int, refID *dex.Bytes, past bool) ([]*asset.Wallet
 				return err
 			}
 			err = item.Value(func(nonceB []byte) error {
+				// Does this need to be copied?
 				startNonceKey = nonceB
 				return nil
 			})

--- a/client/asset/eth/txdb.go
+++ b/client/asset/eth/txdb.go
@@ -407,12 +407,7 @@ func (s *badgerTxDB) getTxs(n int, refID *dex.Bytes, past bool) ([]*asset.Wallet
 			if err != nil {
 				return err
 			}
-			err = item.Value(func(nonceB []byte) error {
-				// Does this need to be copied?
-				startNonceKey = nonceB
-				return nil
-			})
-			if err != nil {
+			if startNonceKey, err = item.ValueCopy(nil); err != nil {
 				return err
 			}
 		} else {

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -331,6 +331,9 @@ func (conn *TWebsocket) SendRaw([]byte) error {
 func (conn *TWebsocket) Request(msg *msgjson.Message, f msgFunc) error {
 	return conn.RequestWithTimeout(msg, f, 0, func() {})
 }
+func (conn *TWebsocket) RequestRaw(msgID uint64, rawMsg []byte, respHandler func(*msgjson.Message)) error {
+	return nil
+}
 func (conn *TWebsocket) RequestWithTimeout(msg *msgjson.Message, f func(*msgjson.Message), _ time.Duration, _ func()) error {
 	if conn.reqErr != nil {
 		return conn.reqErr

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -395,7 +395,7 @@ func (w *xcWallet) Connect() error {
 	// ConnectOnce so that the ConnectionMaster's On method will report false.
 	err := w.connector.ConnectOnce(context.Background())
 	if err != nil {
-		return err
+		return fmt.Errorf("ConnectOnce error: %w", err)
 	}
 
 	var ready bool
@@ -409,7 +409,7 @@ func (w *xcWallet) Connect() error {
 
 	synced, progress, err := w.SyncStatus()
 	if err != nil {
-		return err
+		return fmt.Errorf("SyncStatus error: %w", err)
 	}
 
 	w.mtx.Lock()
@@ -417,12 +417,12 @@ func (w *xcWallet) Connect() error {
 	haveAddress := w.address != ""
 	if haveAddress {
 		if haveAddress, err = w.OwnsDepositAddress(w.address); err != nil {
-			return err
+			return fmt.Errorf("OwnsDepositAddress error: %w", err)
 		}
 	}
 	if !haveAddress {
 		if w.address, err = w.DepositAddress(); err != nil {
-			return err
+			return fmt.Errorf("DepositAddress error: %w", err)
 		}
 	}
 	w.hookedUp = true

--- a/dex/marshal.go
+++ b/dex/marshal.go
@@ -59,6 +59,10 @@ func (b *Bytes) UnmarshalJSON(encHex []byte) (err error) {
 	return err
 }
 
+func (b Bytes) MarshalBinary() (data []byte, err error) {
+	return b, nil
+}
+
 // Equal is true if otherB has identical []byte contents to the Bytes.
 func (b Bytes) Equal(otherB []byte) bool {
 	return bytes.Equal(b, otherB)

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -348,13 +348,16 @@ type Message struct {
 	// Payload is any data attached to the message. How Payload is decoded
 	// depends on the Route.
 	Payload json.RawMessage `json:"payload,omitempty"`
+	// Sig is a signature of the message. This is the new-style signature
+	// scheme. The old way was to sign individual payloads. Which is used
+	// depends on the route.
+	Sig dex.Bytes `json:"sig"`
 }
 
 // DecodeMessage decodes a *Message from JSON-formatted bytes. Note that
 // *Message may be nil even if error is nil, when the message is JSON null,
 // []byte("null").
-func DecodeMessage(b []byte) (*Message, error) {
-	msg := new(Message)
+func DecodeMessage(b []byte) (msg *Message, _ error) {
 	err := json.Unmarshal(b, &msg)
 	if err != nil {
 		return nil, err

--- a/dex/runner.go
+++ b/dex/runner.go
@@ -120,7 +120,7 @@ func (c *ConnectionMaster) Connect(ctx context.Context) (err error) {
 	// Attempt to start the Connector.
 	ctx, cancel := context.WithCancel(ctx)
 	wg, err := c.connector.Connect(ctx)
-	if wg == nil {
+	if err != nil {
 		cancel() // no context leak
 		return fmt.Errorf("connect failure: %w", err)
 	}

--- a/dex/utils/generics.go
+++ b/dex/utils/generics.go
@@ -8,3 +8,11 @@ func ReverseSlice[T any](s []T) {
 		s[i], s[j] = s[j], s[i]
 	}
 }
+
+func CopyMap[K comparable, V any](m map[K]V) map[K]V {
+	r := make(map[K]V, len(m))
+	for k, v := range m {
+		r[k] = v
+	}
+	return r
+}

--- a/server/apidata/apidata.go
+++ b/server/apidata/apidata.go
@@ -64,7 +64,7 @@ type DataAPI struct {
 }
 
 // NewDataAPI is the constructor for a new DataAPI.
-func NewDataAPI(dbSrc DBSource) *DataAPI {
+func NewDataAPI(dbSrc DBSource, registerHTTP func(route string, handler comms.HTTPHandler)) *DataAPI {
 	s := &DataAPI{
 		db:             dbSrc,
 		epochDurations: make(map[string]uint64),
@@ -73,9 +73,9 @@ func NewDataAPI(dbSrc DBSource) *DataAPI {
 	}
 
 	if atomic.CompareAndSwapUint32(&started, 0, 1) {
-		comms.RegisterHTTP(msgjson.SpotsRoute, s.handleSpots)
-		comms.RegisterHTTP(msgjson.CandlesRoute, s.handleCandles)
-		comms.RegisterHTTP(msgjson.OrderBookRoute, s.handleOrderBook)
+		registerHTTP(msgjson.SpotsRoute, s.handleSpots)
+		registerHTTP(msgjson.CandlesRoute, s.handleCandles)
+		registerHTTP(msgjson.OrderBookRoute, s.handleOrderBook)
 	}
 	return s
 }

--- a/server/apidata/apidata_test.go
+++ b/server/apidata/apidata_test.go
@@ -11,6 +11,7 @@ import (
 
 	"decred.org/dcrdex/dex/candles"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/comms"
 	"decred.org/dcrdex/server/matcher"
 )
 
@@ -57,7 +58,7 @@ func newTestRig() *testRig {
 	db := new(TDBSource)
 	return &testRig{
 		db:  db,
-		api: NewDataAPI(db),
+		api: NewDataAPI(db, func(route string, handler comms.HTTPHandler) {}),
 	}
 }
 

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -4,7 +4,9 @@
 package comms
 
 import (
+	"encoding/json"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"decred.org/dcrdex/dex/msgjson"
@@ -40,6 +42,7 @@ type Link interface {
 	// Request sends the Request-type msgjson.Message to the client and registers
 	// a handler for the response.
 	Request(msg *msgjson.Message, f func(Link, *msgjson.Message), expireTime time.Duration, expire func()) error
+	RequestRaw(msgID uint64, rawMsg []byte, f func(Link, *msgjson.Message), expireTime time.Duration, expire func()) error
 	// Banish closes the link and quarantines the client.
 	Banish()
 	// Disconnect closes the link.
@@ -48,6 +51,10 @@ type Link interface {
 	// becomes authorized. Request handlers must be run synchronous with other
 	// reads or it will be a data race with the link's input loop.
 	Authorized()
+	// SetCustomID
+	SetCustomID(string)
+	// CustomID
+	CustomID() string
 }
 
 // When the DEX sends a request to the client, a responseHandler is created
@@ -61,7 +68,8 @@ type responseHandler struct {
 type wsLink struct {
 	*ws.WSLink
 	// The id is the unique identifier assigned to this client.
-	id uint64
+	id       uint64
+	customID atomic.Value
 	// For DEX-originating requests, the response handler is mapped to the
 	// resquest ID.
 	reqMtx       sync.Mutex
@@ -78,11 +86,11 @@ type wsLink struct {
 }
 
 // newWSLink is a constructor for a new wsLink.
-func newWSLink(addr string, conn ws.Connection, wsLimiter *routeLimiter, limitData func() (int, error)) *wsLink {
+func (s *Server) newWSLink(addr string, conn ws.Connection, wsLimiter *routeLimiter, limitData func() (int, error)) *wsLink {
 	var c *wsLink
 	c = &wsLink{
 		WSLink: ws.NewWSLink(addr, conn, pingPeriod, func(msg *msgjson.Message) *msgjson.Error {
-			return handleMessage(c, msg)
+			return s.handleMessage(c, msg)
 		}, log.SubLogger("WS")),
 		respHandlers: make(map[uint64]*responseHandler),
 		dataMeter:    limitData,
@@ -102,6 +110,17 @@ func (c *wsLink) ID() uint64 {
 	return c.id
 }
 
+func (c *wsLink) SetCustomID(id string) {
+	c.customID.Store(id)
+}
+
+func (c *wsLink) CustomID() string {
+	if s := c.customID.Load(); s != nil {
+		return s.(string)
+	}
+	return ""
+}
+
 // Addr returns the string-encoded IP address.
 func (c *wsLink) Addr() string {
 	return c.WSLink.Addr()
@@ -117,7 +136,7 @@ func (c *wsLink) Authorized() {
 }
 
 // The WSLink.handler for WSLink.inHandler
-func handleMessage(c *wsLink, msg *msgjson.Message) *msgjson.Error {
+func (s *Server) handleMessage(c *wsLink, msg *msgjson.Message) *msgjson.Error {
 	switch msg.Type {
 	case msgjson.Request:
 		if msg.ID == 0 {
@@ -125,7 +144,7 @@ func handleMessage(c *wsLink, msg *msgjson.Message) *msgjson.Error {
 		}
 		// Look for a registered WebSocket route handler. This excludes the data
 		// API routes, which are part of the httpHandler map.
-		handler := RouteHandler(msg.Route)
+		handler := s.rpcRoutes[msg.Route]
 		if handler != nil {
 			if !c.wsLimiter.allow(msg.Route) {
 				return msgjson.NewError(msgjson.TooManyRequestsError, "too many requests to "+msg.Route)
@@ -135,7 +154,7 @@ func handleMessage(c *wsLink, msg *msgjson.Message) *msgjson.Error {
 		}
 
 		// Look for an HTTP handler.
-		httpHandler := httpRoutes[msg.Route]
+		httpHandler := s.httpRoutes[msg.Route]
 		if httpHandler == nil {
 			return msgjson.NewError(msgjson.RPCUnknownRoute, "unknown route")
 		}
@@ -181,6 +200,17 @@ func handleMessage(c *wsLink, msg *msgjson.Message) *msgjson.Error {
 		}
 		return nil
 
+	case msgjson.Notification:
+		// Look for a registered WebSocket route handler. This excludes the data
+		// API routes, which are part of the httpHandler map.
+		handler := s.rpcRoutes[msg.Route]
+		if handler != nil {
+			if !c.wsLimiter.allow(msg.Route) {
+				return msgjson.NewError(msgjson.TooManyRequestsError, "too many requests to "+msg.Route)
+			}
+			// Handle the request.
+			return handler(c, msg)
+		}
 	case msgjson.Response:
 		// NOTE: In the event of an error, we respond to a response, which makes
 		// no sense. A new mechanism is needed with appropriate client handling.
@@ -231,22 +261,55 @@ func (c *wsLink) logReq(id uint64, respHandler func(Link, *msgjson.Message), exp
 // is equal to the response Message.ID passed to the handler (see the
 // msgjson.Response case in handleMessage).
 func (c *wsLink) Request(msg *msgjson.Message, f func(conn Link, msg *msgjson.Message), expireTime time.Duration, expire func()) error {
+	// // log.Tracef("Registering '%s' request ID %d (wsLink)", msg.Route, msg.ID)
+	// c.logReq(msg.ID, f, expireTime, expire)
+	// // Send errors are (1) connection is already down or (2) json marshal
+	// // failure. Any connection write errors just cause the link to quit as the
+	// // goroutine that actually does the write does not relay any errors back to
+	// // the caller. The request will eventually expire when no response comes.
+	// // This is not ideal - we may consider an error callback, or different
+	// // Send/SendNow/QueueSend functions.
+	// err := c.Send(msg)
+	// if err != nil {
+	// 	// Neither expire nor the handler should run. Stop the expire timer
+	// 	// created by logReq and delete the response handler it added. The
+	// 	// caller receives a non-nil error to deal with it.
+	// 	log.Debugf("(*wsLink).Request(route '%s') Send error, unregistering msg ID %d handler: %v",
+	// 		msg.Route, msg.ID, err)
+	// 	c.respHandler(msg.ID) // drop the removed responseHandler
+	// }
+	// return err
+
+	rawMsg, err := json.Marshal(msg)
+	if err != nil {
+		log.Errorf("Failed to marshal message: %v", err)
+		return err
+	}
+
+	err = c.RequestRaw(msg.ID, rawMsg, f, expireTime, expire)
+	if err != nil {
+		log.Debugf("(*wsLink).Request(route '%s') Send error, unregistering msg ID %d handler: %v",
+			msg.Route, msg.ID, err)
+	}
+	return err
+}
+
+func (c *wsLink) RequestRaw(msgID uint64, rawMsg []byte, f func(conn Link, msg *msgjson.Message), expireTime time.Duration, expire func()) error {
 	// log.Tracef("Registering '%s' request ID %d (wsLink)", msg.Route, msg.ID)
-	c.logReq(msg.ID, f, expireTime, expire)
+	c.logReq(msgID, f, expireTime, expire)
 	// Send errors are (1) connection is already down or (2) json marshal
 	// failure. Any connection write errors just cause the link to quit as the
 	// goroutine that actually does the write does not relay any errors back to
 	// the caller. The request will eventually expire when no response comes.
 	// This is not ideal - we may consider an error callback, or different
 	// Send/SendNow/QueueSend functions.
-	err := c.Send(msg)
+	err := c.SendRaw(rawMsg)
 	if err != nil {
 		// Neither expire nor the handler should run. Stop the expire timer
 		// created by logReq and delete the response handler it added. The
 		// caller receives a non-nil error to deal with it.
-		log.Debugf("(*wsLink).Request(route '%s') Send error, unregistering msg ID %d handler: %v",
-			msg.Route, msg.ID, err)
-		c.respHandler(msg.ID) // drop the removed responseHandler
+
+		c.respHandler(msgID) // drop the removed responseHandler
 	}
 	return err
 }

--- a/server/comms/link.go
+++ b/server/comms/link.go
@@ -261,25 +261,6 @@ func (c *wsLink) logReq(id uint64, respHandler func(Link, *msgjson.Message), exp
 // is equal to the response Message.ID passed to the handler (see the
 // msgjson.Response case in handleMessage).
 func (c *wsLink) Request(msg *msgjson.Message, f func(conn Link, msg *msgjson.Message), expireTime time.Duration, expire func()) error {
-	// // log.Tracef("Registering '%s' request ID %d (wsLink)", msg.Route, msg.ID)
-	// c.logReq(msg.ID, f, expireTime, expire)
-	// // Send errors are (1) connection is already down or (2) json marshal
-	// // failure. Any connection write errors just cause the link to quit as the
-	// // goroutine that actually does the write does not relay any errors back to
-	// // the caller. The request will eventually expire when no response comes.
-	// // This is not ideal - we may consider an error callback, or different
-	// // Send/SendNow/QueueSend functions.
-	// err := c.Send(msg)
-	// if err != nil {
-	// 	// Neither expire nor the handler should run. Stop the expire timer
-	// 	// created by logReq and delete the response handler it added. The
-	// 	// caller receives a non-nil error to deal with it.
-	// 	log.Debugf("(*wsLink).Request(route '%s') Send error, unregistering msg ID %d handler: %v",
-	// 		msg.Route, msg.ID, err)
-	// 	c.respHandler(msg.ID) // drop the removed responseHandler
-	// }
-	// return err
-
 	rawMsg, err := json.Marshal(msg)
 	if err != nil {
 		log.Errorf("Failed to marshal message: %v", err)

--- a/server/comms/middleware.go
+++ b/server/comms/middleware.go
@@ -4,29 +4,24 @@
 package comms
 
 import (
-	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"sync/atomic"
-	"time"
 
 	"decred.org/dcrdex/dex"
-	"decred.org/dcrdex/dex/msgjson"
-	"github.com/go-chi/chi/v5"
 )
 
 type contextKey int
 
 // These are the keys for different types of values stored in a request context.
 const (
-	ctxThing contextKey = iota
+	CtxThing contextKey = iota
 	ctxListener
 )
 
-// limitRate is rate-limiting middleware that checks whether a request can be
+// LimitRate is rate-limiting middleware that checks whether a request can be
 // fulfilled. This is intended for the /api HTTP endpoints.
-func (s *Server) limitRate(next http.Handler) http.Handler {
+func (s *Server) LimitRate(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		code, err := s.meterIP(dex.NewIPKey(r.RemoteAddr))
 		if err != nil {
@@ -53,72 +48,4 @@ func (s *Server) meterIP(ip dex.IPKey) (int, error) {
 		return http.StatusTooManyRequests, fmt.Errorf(http.StatusText(http.StatusTooManyRequests))
 	}
 	return 0, nil
-}
-
-// candlesParamsParser is middleware for the /candles routes. Parses the
-// *msgjson.CandlesRequest from the URL parameters.
-func candleParamsParser(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		baseID, quoteID, errMsg := parseBaseQuoteIDs(r)
-		if errMsg != "" {
-			http.Error(w, errMsg, http.StatusBadRequest)
-			return
-		}
-
-		// Ensure the bin size is a valid duration string.
-		binSize := chi.URLParam(r, "binSize")
-		_, err := time.ParseDuration(binSize)
-		if err != nil {
-			http.Error(w, "bin size unparseable", http.StatusBadRequest)
-			return
-		}
-
-		countStr := chi.URLParam(r, "count")
-		count := 0
-		if countStr != "" {
-			count, err = strconv.Atoi(countStr)
-			if err != nil {
-				http.Error(w, "count unparseable", http.StatusBadRequest)
-				return
-			}
-		}
-		ctx := context.WithValue(r.Context(), ctxThing, &msgjson.CandlesRequest{
-			BaseID:     baseID,
-			QuoteID:    quoteID,
-			BinSize:    binSize,
-			NumCandles: count,
-		})
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
-
-// orderBookParamsParser is middleware for the /orderbook route. Parses the
-// *msgjson.OrderBookSubscription from the URL parameters.
-func orderBookParamsParser(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		baseID, quoteID, errMsg := parseBaseQuoteIDs(r)
-		if errMsg != "" {
-			http.Error(w, errMsg, http.StatusBadRequest)
-			return
-		}
-		ctx := context.WithValue(r.Context(), ctxThing, &msgjson.OrderBookSubscription{
-			Base:  baseID,
-			Quote: quoteID,
-		})
-		next.ServeHTTP(w, r.WithContext(ctx))
-	})
-}
-
-// parseBaseQuoteIDs parses the "baseSymbol" and "quoteSymbol" URL parameters
-// from the request.
-func parseBaseQuoteIDs(r *http.Request) (baseID, quoteID uint32, errMsg string) {
-	baseID, found := dex.BipSymbolID(chi.URLParam(r, "baseSymbol"))
-	if !found {
-		return 0, 0, "unknown base"
-	}
-	quoteID, found = dex.BipSymbolID(chi.URLParam(r, "quoteSymbol"))
-	if !found {
-		return 0, 0, "unknown quote"
-	}
-	return
 }

--- a/server/market/bookrouter.go
+++ b/server/market/bookrouter.go
@@ -295,7 +295,7 @@ type BookRouter struct {
 // comms and a monitoring goroutine is started for each BookSource specified.
 // The input sources is a mapping of market names to sources for order and epoch
 // queue information.
-func NewBookRouter(sources map[string]BookSource, feeSource FeeSource) *BookRouter {
+func NewBookRouter(sources map[string]BookSource, feeSource FeeSource, route func(route string, handler comms.MsgHandler)) *BookRouter {
 	router := &BookRouter{
 		books:     make(map[string]*msgBook),
 		feeSource: feeSource,
@@ -318,10 +318,10 @@ func NewBookRouter(sources map[string]BookSource, feeSource FeeSource) *BookRout
 		}
 		router.books[mkt] = book
 	}
-	comms.Route(msgjson.OrderBookRoute, router.handleOrderBook)
-	comms.Route(msgjson.UnsubOrderBookRoute, router.handleUnsubOrderBook)
-	comms.Route(msgjson.FeeRateRoute, router.handleFeeRate)
-	comms.Route(msgjson.PriceFeedRoute, router.handlePriceFeeder)
+	route(msgjson.OrderBookRoute, router.handleOrderBook)
+	route(msgjson.UnsubOrderBookRoute, router.handleUnsubOrderBook)
+	route(msgjson.FeeRateRoute, router.handleFeeRate)
+	route(msgjson.PriceFeedRoute, router.handlePriceFeeder)
 
 	return router
 }

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -790,7 +790,7 @@ func TestMain(m *testing.M) {
 		// Not counted as coverage, must test Archiver constructor explicitly.
 		var shutdown context.CancelFunc
 		testCtx, shutdown = context.WithCancel(context.Background())
-		rig.router = NewBookRouter(rig.sources(), &tFeeSource{})
+		rig.router = NewBookRouter(rig.sources(), &tFeeSource{}, func(route string, handler comms.MsgHandler) {})
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
@@ -1608,6 +1608,9 @@ func (conn *TLink) getSend() *msgjson.Message {
 func (conn *TLink) Request(msg *msgjson.Message, f func(comms.Link, *msgjson.Message), expDur time.Duration, exp func()) error {
 	return nil
 }
+func (conn *TLink) RequestRaw(msgID uint64, rawMsg []byte, f func(comms.Link, *msgjson.Message), expireTime time.Duration, expire func()) error {
+	return nil
+}
 func (conn *TLink) Banish() {
 	conn.banished = true
 }
@@ -1619,6 +1622,9 @@ func (conn *TLink) Disconnect() {
 		close(conn.closed)
 	}
 }
+
+func (conn *TLink) SetCustomID(string) {}
+func (conn *TLink) CustomID() string   { return "" }
 
 type testRig struct {
 	router  *BookRouter

--- a/tatanka/chain/chain.go
+++ b/tatanka/chain/chain.go
@@ -1,0 +1,67 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package chain
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/tatanka/tanka"
+)
+
+/*
+	The chain package describes the interfaces that must be implemented for
+	Tatatanka node blockchain backends.
+*/
+
+type BadQueryError error
+
+type ChainConfig struct {
+	ConfigPath string
+}
+
+// type Query json.RawMessage
+type Result json.RawMessage
+
+// Chain is an interface that must be implemented by every blockchain backend.
+type Chain interface {
+	Connect(context.Context) (*sync.WaitGroup, error)
+	// Query may be needed if clients are the auditors, since some clients might
+	// not have e.g. txindex enabled for utxo-based assets.
+	// Query(context.Context, Query) (Result, error)
+	Connected() bool
+	CheckBond(*tanka.Bond) error
+	// AuditHTLC will be needed if Tatanka nodes are the auditors.
+	// AuditHTLC(*tanka.HTLCAudit) (bool, error)
+}
+
+// FeeRater is an optional interface that should be implemented by backends for
+// which the network transaction fee rates are variable. The Tatanka Mesh
+// provides a oracle service for these chains.
+type FeeRater interface {
+	FeeChannel() <-chan uint64
+}
+
+// ChainConstructor is a constructor for a Chain.
+type ChainConstructor func(config json.RawMessage, log dex.Logger, net dex.Network) (Chain, error)
+
+var chains = make(map[uint32]ChainConstructor)
+
+// RegisterChainConstructor is called by chain backends to register their
+// ChainConstructors.
+func RegisterChainConstructor(chainID uint32, c ChainConstructor) {
+	chains[chainID] = c
+}
+
+// New is used by the caller to construct a new Chain.
+func New(chainID uint32, cfg json.RawMessage, log dex.Logger, net dex.Network) (Chain, error) {
+	c, found := chains[chainID]
+	if !found {
+		return nil, fmt.Errorf("chain %d not known", chainID)
+	}
+	return c(cfg, log, net)
+}

--- a/tatanka/chain/utxo/btc.go
+++ b/tatanka/chain/utxo/btc.go
@@ -1,0 +1,337 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package utxo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	dexbtc "decred.org/dcrdex/dex/networks/btc"
+	"decred.org/dcrdex/tatanka/chain"
+	"decred.org/dcrdex/tatanka/tanka"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrjson/v4"
+	"github.com/decred/dcrd/dcrutil/v4"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v4"
+	"github.com/decred/dcrd/rpcclient/v8"
+	"github.com/gcash/bchd/btcjson"
+)
+
+const (
+	BitcoinID      = 0
+	feeMonitorTick = time.Second * 10
+)
+
+func init() {
+	chain.RegisterChainConstructor(0, NewBitcoin)
+}
+
+type BitcoinConfigFile struct {
+	dexbtc.RPCConfig
+	NodeRelay string `json:"nodeRelay"`
+}
+
+type bitcoinChain struct {
+	cfg  *BitcoinConfigFile
+	net  dex.Network
+	log  dex.Logger
+	fees chan uint64
+	name string
+
+	cl        *rpcclient.Client
+	connected atomic.Bool
+}
+
+func NewBitcoin(rawConfig json.RawMessage, log dex.Logger, net dex.Network) (chain.Chain, error) {
+	var cfg BitcoinConfigFile
+	if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+		return nil, fmt.Errorf("error parsing configuration: %w", err)
+	}
+	if cfg.NodeRelay != "" {
+		cfg.RPCBind = cfg.NodeRelay
+	}
+
+	if err := dexbtc.CheckRPCConfig(&cfg.RPCConfig, "Bitcoin", net, dexbtc.RPCPorts); err != nil {
+		return nil, fmt.Errorf("error validating RPC configuration: %v", err)
+	}
+
+	return &bitcoinChain{
+		cfg:  &cfg,
+		net:  net,
+		log:  log,
+		name: "Bitcoin",
+		fees: make(chan uint64, 1),
+	}, nil
+}
+
+func (c *bitcoinChain) Connect(ctx context.Context) (_ *sync.WaitGroup, err error) {
+	cfg := c.cfg
+	host := cfg.RPCBind
+	if cfg.NodeRelay != "" {
+		host = cfg.NodeRelay
+	}
+	c.cl, err = connectLocalHTTP(host, cfg.RPCUser, cfg.RPCPass)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting RPC client: %w", err)
+	}
+
+	if err = c.initialize(ctx); err != nil {
+		return nil, err
+	}
+
+	c.connected.Store(true)
+	defer c.connected.Store(false)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.monitorFees(ctx)
+	}()
+
+	return &wg, nil
+}
+
+func (c *bitcoinChain) initialize(ctx context.Context) error {
+	// TODO: Check min version
+
+	tip, err := c.getBestBlockHash(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting best block from rpc: %w", err)
+	}
+	if tip == nil {
+		return fmt.Errorf("nil best block hash?")
+	}
+
+	txindex, err := c.checkTxIndex(ctx)
+	if err != nil {
+		c.log.Warnf(`Please ensure txindex is enabled in the node config and you might need to re-index if txindex was not previously enabled for %s`, c.name)
+		return fmt.Errorf("error checking txindex for %s: %w", c.name, err)
+	}
+	if !txindex {
+		return fmt.Errorf("%s transaction index is not enabled. Please enable txindex in the node config and you might need to re-index when you enable txindex", c.name)
+	}
+
+	return nil
+}
+
+// func (c *bitcoinChain) Query(ctx context.Context, rawQuery chain.Query) (chain.Result, error) {
+// 	var q query
+// 	if err := json.Unmarshal(rawQuery, &q); err != nil {
+// 		return nil, chain.BadQueryError(fmt.Errorf("error parsing raw query: %w", err))
+// 	}
+
+// 	if q.Method == "" {
+// 		return nil, chain.BadQueryError(errors.New("invalid query parameters. no method"))
+// 	}
+
+// 	res, err := c.cl.RawRequest(ctx, q.Method, q.Args)
+// 	if err != nil {
+// 		// Could potentially try to parse certain errors here
+
+// 		return nil, fmt.Errorf("error performing query: %w", err)
+// 	}
+
+// 	return chain.Result(res), nil
+// }
+
+func (c *bitcoinChain) Connected() bool {
+	return c.connected.Load()
+}
+
+func (c *bitcoinChain) FeeChannel() <-chan uint64 {
+	return c.fees
+}
+
+func (c *bitcoinChain) monitorFees(ctx context.Context) {
+	tick := time.NewTicker(feeMonitorTick)
+	var tip *chainhash.Hash
+	for {
+		select {
+		case <-tick.C:
+		case <-ctx.Done():
+			return
+		}
+
+		newTip, err := c.getBestBlockHash(ctx)
+		if err != nil {
+			c.connected.Store(false)
+			c.log.Errorf("Decred is not connected: %w", err)
+			continue
+		}
+		if newTip == nil { // sanity check
+			c.log.Error("nil tip hash?")
+			continue
+		}
+		if tip != nil && *tip == *newTip {
+			continue
+		}
+		c.connected.Store(true)
+		// estimatesmartfee 1 returns extremely high rates on DCR.
+		estimateFeeResult, err := c.cl.EstimateSmartFee(ctx, 2, chainjson.EstimateSmartFeeConservative)
+		if err != nil {
+			c.log.Errorf("estimatesmartfee error: %w", err)
+			continue
+		}
+		atomsPerKB, err := dcrutil.NewAmount(estimateFeeResult.FeeRate)
+		if err != nil {
+			c.log.Errorf("NewAmount error: %w", err)
+			continue
+		}
+		atomsPerB := uint64(math.Round(float64(atomsPerKB) / 1000))
+		if atomsPerB == 0 {
+			atomsPerB = 1
+		}
+		select {
+		case c.fees <- atomsPerB:
+		case <-time.After(time.Second * 5):
+			c.log.Errorf("fee channel is blocking")
+		}
+
+	}
+
+}
+
+func (c *bitcoinChain) callHashGetter(ctx context.Context, method string, args []any) (*chainhash.Hash, error) {
+	var txid string
+	err := c.call(ctx, method, args, &txid)
+	if err != nil {
+		return nil, err
+	}
+	return chainhash.NewHashFromStr(txid)
+}
+
+// GetBestBlockHash returns the hash of the best block in the longest block
+// chain.
+func (c *bitcoinChain) getBestBlockHash(ctx context.Context) (*chainhash.Hash, error) {
+	return c.callHashGetter(ctx, "getbestblockhash", nil)
+}
+
+// checkTxIndex checks if bitcoind transaction index is enabled.
+func (c *bitcoinChain) checkTxIndex(ctx context.Context) (bool, error) {
+	var res struct {
+		TxIndex *struct{} `json:"txindex"`
+	}
+	err := c.call(ctx, "getindexinfo", []any{"txindex"}, &res)
+	if err == nil {
+		// Return early if there is no error. bitcoind returns an empty json
+		// object if txindex is not enabled. It is safe to conclude txindex is
+		// enabled if res.Txindex is not nil.
+		return res.TxIndex != nil, nil
+	}
+
+	if !isMethodNotFoundErr(err) {
+		return false, err
+	}
+
+	// Using block at index 5 to retrieve a coinbase transaction and ensure
+	// txindex is enabled for pre 0.21 versions of bitcoind.
+	const blockIndex = 5
+	blockHash, err := c.getBlockHash(ctx, blockIndex)
+	if err != nil {
+		return false, err
+	}
+
+	blockInfo, err := c.getBlockVerbose(ctx, blockHash)
+	if err != nil {
+		return false, err
+	}
+
+	if len(blockInfo.Tx) == 0 {
+		return false, fmt.Errorf("block %d does not have a coinbase transaction", blockIndex)
+	}
+
+	txHash, err := chainhash.NewHashFromStr(blockInfo.Tx[0])
+	if err != nil {
+		return false, err
+	}
+
+	// Retrieve coinbase transaction information.
+	txBytes, err := c.getRawTransaction(ctx, txHash)
+	if err != nil {
+		return false, err
+	}
+
+	return len(txBytes) != 0, nil
+}
+
+func (c *bitcoinChain) getBlockHash(ctx context.Context, index int64) (*chainhash.Hash, error) {
+	var blockHashStr string
+	if err := c.call(ctx, "getblockhash", []any{index}, &blockHashStr); err != nil {
+		return nil, err
+	}
+	return chainhash.NewHashFromStr(blockHashStr)
+}
+
+type getBlockVerboseResult struct {
+	Hash          string   `json:"hash"`
+	Confirmations int64    `json:"confirmations"`
+	Height        int64    `json:"height"`
+	Tx            []string `json:"tx,omitempty"`
+	PreviousHash  string   `json:"previousblockhash"`
+}
+
+func (c *bitcoinChain) getBlockVerbose(ctx context.Context, blockHash *chainhash.Hash) (*getBlockVerboseResult, error) {
+	var res getBlockVerboseResult
+	return &res, c.call(ctx, "getblock", []any{blockHash.String(), []any{1}}, res)
+}
+
+func (c *bitcoinChain) getRawTransaction(ctx context.Context, txHash *chainhash.Hash) ([]byte, error) {
+	var txB dex.Bytes
+	return txB, c.call(ctx, "getrawtransaction", []any{txHash.String(), false}, &txB)
+}
+
+func (c *bitcoinChain) call(ctx context.Context, method string, args []any, thing any) error {
+	params := make([]json.RawMessage, 0, len(args))
+	for i := range args {
+		p, err := json.Marshal(args[i])
+		if err != nil {
+			return err
+		}
+		params = append(params, p)
+	}
+	b, err := c.cl.RawRequest(ctx, method, params)
+	if err != nil {
+		return fmt.Errorf("rawrequest error: %w", err)
+	}
+
+	if thing != nil {
+		return json.Unmarshal(b, thing)
+	}
+	return nil
+}
+
+func (c *bitcoinChain) CheckBond(b *tanka.Bond) error {
+
+	// TODO: Validate bond
+
+	return nil
+}
+
+func (c *bitcoinChain) AuditHTLC(*tanka.HTLCAudit) (bool, error) {
+
+	// TODO: Perform the audit
+
+	return true, nil
+}
+
+// isMethodNotFoundErr will return true if the error indicates that the RPC
+// method was not found by the RPC server. The error must be dcrjson.RPCError
+// with a numeric code equal to btcjson.ErrRPCMethodNotFound.Code or a message
+// containing "method not found".
+func isMethodNotFoundErr(err error) bool {
+	var errRPCMethodNotFound = int(btcjson.ErrRPCMethodNotFound.Code)
+	var rpcErr *dcrjson.RPCError
+	return errors.As(err, &rpcErr) &&
+		(int(rpcErr.Code) == errRPCMethodNotFound ||
+			strings.Contains(strings.ToLower(rpcErr.Message), "method not found"))
+}

--- a/tatanka/chain/utxo/btc.go
+++ b/tatanka/chain/utxo/btc.go
@@ -18,12 +18,11 @@ import (
 	dexbtc "decred.org/dcrdex/dex/networks/btc"
 	"decred.org/dcrdex/tatanka/chain"
 	"decred.org/dcrdex/tatanka/tanka"
-	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/dcrjson/v4"
-	"github.com/decred/dcrd/dcrutil/v4"
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v4"
 	"github.com/decred/dcrd/rpcclient/v8"
-	"github.com/gcash/bchd/btcjson"
 )
 
 const (
@@ -182,7 +181,7 @@ func (c *bitcoinChain) monitorFees(ctx context.Context) {
 			c.log.Errorf("estimatesmartfee error: %w", err)
 			continue
 		}
-		atomsPerKB, err := dcrutil.NewAmount(estimateFeeResult.FeeRate)
+		atomsPerKB, err := btcutil.NewAmount(estimateFeeResult.FeeRate)
 		if err != nil {
 			c.log.Errorf("NewAmount error: %w", err)
 			continue
@@ -330,7 +329,7 @@ func (c *bitcoinChain) AuditHTLC(*tanka.HTLCAudit) (bool, error) {
 // containing "method not found".
 func isMethodNotFoundErr(err error) bool {
 	var errRPCMethodNotFound = int(btcjson.ErrRPCMethodNotFound.Code)
-	var rpcErr *dcrjson.RPCError
+	var rpcErr *btcjson.RPCError
 	return errors.As(err, &rpcErr) &&
 		(int(rpcErr.Code) == errRPCMethodNotFound ||
 			strings.Contains(strings.ToLower(rpcErr.Message), "method not found"))

--- a/tatanka/chain/utxo/btc_live_test.go
+++ b/tatanka/chain/utxo/btc_live_test.go
@@ -1,0 +1,115 @@
+//go:build harness
+
+package utxo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/user"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	dexbtc "decred.org/dcrdex/dex/networks/btc"
+	"decred.org/dcrdex/tatanka/chain"
+)
+
+func TestSimnetBTC(t *testing.T) {
+	simnetAlphaHarnessConfig := &BitcoinConfigFile{
+		RPCConfig: dexbtc.RPCConfig{
+			RPCUser: "user",
+			RPCPass: "pass",
+			RPCBind: "127.0.0.1",
+			RPCPort: 20556,
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rawCfg, _ := json.Marshal(simnetAlphaHarnessConfig)
+	c := prepareSimnetChain(t, ctx, NewBitcoin, rawCfg)
+
+	q := &query{
+		Method: "getchaintxstats",
+		Args:   []json.RawMessage{[]byte("5")},
+	}
+	rawQuery, _ := json.Marshal(q)
+	rawRes, err := c.Query(ctx, chain.Query(rawQuery))
+	if err != nil {
+		t.Fatalf("Query error: %v", err)
+	}
+
+	var res struct {
+		Blocks uint `json:"window_block_count"`
+	}
+	if err := json.Unmarshal(rawRes, &res); err != nil {
+		t.Fatalf("Query unmarshal error: %v", err)
+	}
+
+	if res.Blocks != 5 {
+		t.Fatalf("Unexpected query results")
+	}
+}
+func TestSimnetDCR(t *testing.T) {
+	usr, _ := user.Current()
+	dextestDir := filepath.Join(usr.HomeDir, "dextest")
+	rpcPath := filepath.Join(dextestDir, "dcr", "alpha", "rpc.cert")
+	simnetAlphaHarnessConfig := &DecredConfigFile{
+		RPCUser:   "user",
+		RPCPass:   "pass",
+		RPCListen: "127.0.0.1:19561",
+		RPCCert:   rpcPath,
+	}
+	rawCfg, _ := json.Marshal(simnetAlphaHarnessConfig)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := prepareSimnetChain(t, ctx, NewDecred, rawCfg)
+
+	q := &query{
+		Method: "getvoteinfo",
+		Args:   []json.RawMessage{[]byte("4")},
+	}
+	rawQuery, _ := json.Marshal(q)
+	rawRes, err := c.Query(ctx, chain.Query(rawQuery))
+	if err != nil {
+		t.Fatalf("Query error: %v", err)
+	}
+
+	var res struct {
+		Agendas []struct {
+			ID string `json:"id"`
+		} `json:"agendas"`
+	}
+	if err := json.Unmarshal(rawRes, &res); err != nil {
+		t.Fatalf("Query unmarshal error: %v", err)
+	}
+
+	if len(res.Agendas) != 1 || res.Agendas[0].ID != "maxblocksize" {
+		t.Fatalf("Unexpected query results")
+	}
+}
+
+func prepareSimnetChain(t *testing.T, ctx context.Context, newChain chain.ChainConstructor, rawCfg json.RawMessage) chain.Chain {
+	feeMonitorTick = time.Second
+
+	c, err := newChain(rawCfg, dex.StdOutLogger("T", dex.LevelTrace), dex.Simnet)
+	if err != nil {
+		t.Fatalf("NewBTC error: %v", err)
+	}
+
+	cm := dex.NewConnectionMaster(c)
+	if err := cm.ConnectOnce(ctx); err != nil {
+		t.Fatalf("Connect error: %v", err)
+	}
+
+	fmt.Println("Waiting for fee update")
+	select {
+	case fees := <-c.FeeChannel():
+		fmt.Println("Fees received over fee channel =", fees)
+	case <-time.After(time.Second * 30):
+		t.Fatalf("No fee update seen. Is the miner running?")
+	}
+
+	return c
+}

--- a/tatanka/chain/utxo/dcr.go
+++ b/tatanka/chain/utxo/dcr.go
@@ -1,0 +1,300 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package utxo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/tatanka/chain"
+	"decred.org/dcrdex/tatanka/tanka"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil/v4"
+	chainjson "github.com/decred/dcrd/rpc/jsonrpc/types/v4"
+	"github.com/decred/dcrd/rpcclient/v8"
+	"github.com/decred/dcrd/wire"
+)
+
+const (
+	ChainID = 42
+)
+
+var (
+	compatibleNodeRPCVersions = []dex.Semver{
+		{Major: 8, Minor: 0, Patch: 0}, // 1.8-pre, just dropped unused ticket RPCs
+		{Major: 7, Minor: 0, Patch: 0}, // 1.7 release, new gettxout args
+	}
+)
+
+func init() {
+	chain.RegisterChainConstructor(42, NewDecred)
+}
+
+type DecredConfigFile struct {
+	RPCUser   string `json:"rpcuser"`
+	RPCPass   string `json:"rpcpass"`
+	RPCListen string `json:"rpclisten"`
+	RPCCert   string `json:"rpccert"`
+	NodeRelay string `json:"nodeRelay"`
+}
+
+type decredChain struct {
+	cfg  *DecredConfigFile
+	net  dex.Network
+	log  dex.Logger
+	fees chan uint64
+
+	cl        *rpcclient.Client
+	connected atomic.Bool
+}
+
+func NewDecred(rawConfig json.RawMessage, log dex.Logger, net dex.Network) (chain.Chain, error) {
+	var cfg DecredConfigFile
+	if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+		return nil, fmt.Errorf("error parsing configuration: %w", err)
+	}
+	return &decredChain{
+		cfg:  &cfg,
+		net:  net,
+		log:  log,
+		fees: make(chan uint64, 1),
+	}, nil
+}
+
+func (c *decredChain) Connect(ctx context.Context) (_ *sync.WaitGroup, err error) {
+	cfg := c.cfg
+	if cfg.NodeRelay == "" {
+		c.cl, err = connectNodeRPC(cfg.RPCListen, cfg.RPCUser, cfg.RPCPass, cfg.RPCCert)
+	} else {
+		c.cl, err = connectLocalHTTP(cfg.NodeRelay, cfg.RPCUser, cfg.RPCPass)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error connecting RPC client: %w", err)
+	}
+
+	if err = c.initialize(ctx); err != nil {
+		return nil, err
+	}
+
+	c.connected.Store(true)
+	defer c.connected.Store(false)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.monitorFees(ctx)
+	}()
+
+	return &wg, nil
+}
+
+func (c *decredChain) initialize(ctx context.Context) error {
+	net, err := c.cl.GetCurrentNet(ctx)
+	if err != nil {
+		return fmt.Errorf("getcurrentnet failure: %w", err)
+	}
+	var wantCurrencyNet wire.CurrencyNet
+	switch c.net {
+	case dex.Testnet:
+		wantCurrencyNet = wire.TestNet3
+	case dex.Mainnet:
+		wantCurrencyNet = wire.MainNet
+	case dex.Regtest: // dex.Simnet
+		wantCurrencyNet = wire.SimNet
+	}
+	if net != wantCurrencyNet {
+		return fmt.Errorf("wrong net %v", net.String())
+	}
+
+	// Check the required API versions.
+	versions, err := c.cl.Version(ctx)
+	if err != nil {
+		return fmt.Errorf("DCR node version fetch error: %w", err)
+	}
+
+	ver, exists := versions["dcrdjsonrpcapi"]
+	if !exists {
+		return fmt.Errorf("dcrd.Version response missing 'dcrdjsonrpcapi'")
+	}
+	nodeSemver := dex.NewSemver(ver.Major, ver.Minor, ver.Patch)
+	if !dex.SemverCompatibleAny(compatibleNodeRPCVersions, nodeSemver) {
+		return fmt.Errorf("dcrd has an incompatible JSON-RPC version %s, require one of %s",
+			nodeSemver, compatibleNodeRPCVersions)
+	}
+
+	// Verify dcrd has tx index enabled (required for getrawtransaction).
+	info, err := c.cl.GetInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("dcrd getinfo check failed: %w", err)
+	}
+	if !info.TxIndex {
+		return errors.New("dcrd does not have transaction index enabled (specify --txindex)")
+	}
+
+	// Prime the cache with the best block.
+	tip, err := c.cl.GetBestBlockHash(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting best block from dcrd: %w", err)
+	}
+	if tip == nil {
+		return fmt.Errorf("nil best block hash?")
+	}
+	// if bestHash != nil {
+	// 	_, err := dcr.getDcrBlock(ctx, bestHash)
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf("error priming the cache: %w", err)
+	// 	}
+	// }
+
+	// if _, err = c.cl.FeeRate(ctx); err != nil {
+	// 	c.log.Warnf("Decred backend started without fee estimation available: %v", err)
+	// }
+	return nil
+}
+
+type query struct {
+	Method string            `json:"method"`
+	Args   []json.RawMessage `json:"args"`
+}
+
+// func (c *decredChain) Query(ctx context.Context, rawQuery chain.Query) (chain.Result, error) {
+// 	var q query
+// 	if err := json.Unmarshal(rawQuery, &q); err != nil {
+// 		return nil, chain.BadQueryError(fmt.Errorf("error parsing raw query: %w", err))
+// 	}
+
+// 	if q.Method == "" {
+// 		return nil, chain.BadQueryError(errors.New("invalid query parameters. no method"))
+// 	}
+
+// 	res, err := c.cl.RawRequest(ctx, q.Method, q.Args)
+// 	if err != nil {
+// 		// Could potentially try to parse certain errors here
+
+// 		return nil, fmt.Errorf("error performing query: %w", err)
+// 	}
+
+// 	return chain.Result(res), nil
+// }
+
+func (c *decredChain) Connected() bool {
+	return c.connected.Load()
+}
+
+func (c *decredChain) FeeChannel() <-chan uint64 {
+	return c.fees
+}
+
+func (c *decredChain) monitorFees(ctx context.Context) {
+	tick := time.NewTicker(feeMonitorTick)
+	var tip *chainhash.Hash
+	for {
+		select {
+		case <-tick.C:
+		case <-ctx.Done():
+			return
+		}
+
+		newTip, err := c.cl.GetBestBlockHash(ctx)
+		if err != nil {
+			c.connected.Store(false)
+			c.log.Errorf("Decred is not connected: %w", err)
+			continue
+		}
+		if newTip == nil { // sanity check
+			c.log.Error("nil tip hash?")
+			continue
+		}
+		if tip != nil && *tip == *newTip {
+			continue
+		}
+		c.connected.Store(true)
+		// estimatesmartfee 1 returns extremely high rates on DCR.
+		estimateFeeResult, err := c.cl.EstimateSmartFee(ctx, 2, chainjson.EstimateSmartFeeConservative)
+		if err != nil {
+			c.log.Errorf("estimatesmartfee error: %w", err)
+			continue
+		}
+		atomsPerKB, err := dcrutil.NewAmount(estimateFeeResult.FeeRate)
+		if err != nil {
+			c.log.Errorf("NewAmount error: %w", err)
+			continue
+		}
+		atomsPerB := uint64(math.Round(float64(atomsPerKB) / 1000))
+		if atomsPerB == 0 {
+			atomsPerB = 1
+		}
+		select {
+		case c.fees <- atomsPerB:
+		case <-time.After(time.Second * 5):
+			c.log.Errorf("fee channel is blocking")
+		}
+
+	}
+
+}
+
+func (c *decredChain) CheckBond(b *tanka.Bond) error {
+
+	// TODO: Validate bond
+
+	return nil
+}
+
+func (c *decredChain) AuditHTLC(*tanka.HTLCAudit) (bool, error) {
+
+	// TODO: Perform the audit
+
+	return true, nil
+}
+
+// connectNodeRPC attempts to create a new websocket connection to a dcrd node
+// with the given credentials and notification handlers.
+func connectNodeRPC(host, user, pass, cert string) (*rpcclient.Client, error) {
+	dcrdCerts, err := os.ReadFile(cert)
+	if err != nil {
+		return nil, fmt.Errorf("TLS certificate read error: %w", err)
+	}
+
+	config := &rpcclient.ConnConfig{
+		Host:         host,
+		Endpoint:     "ws", // websocket
+		User:         user,
+		Pass:         pass,
+		Certificates: dcrdCerts,
+	}
+
+	dcrdClient, err := rpcclient.New(config, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start dcrd RPC client: %w", err)
+	}
+
+	return dcrdClient, nil
+}
+
+func connectLocalHTTP(host, user, pass string) (*rpcclient.Client, error) {
+	config := &rpcclient.ConnConfig{
+		Host:         host,
+		HTTPPostMode: true,
+		DisableTLS:   true,
+		User:         user,
+		Pass:         pass,
+	}
+
+	dcrdClient, err := rpcclient.New(config, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start dcrd RPC client: %w", err)
+	}
+
+	return dcrdClient, nil
+}

--- a/tatanka/client/client.go
+++ b/tatanka/client/client.go
@@ -1,0 +1,846 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/tatanka/mj"
+	"decred.org/dcrdex/tatanka/tanka"
+	tcpclient "decred.org/dcrdex/tatanka/tcp/client"
+	"github.com/decred/dcrd/crypto/blake256"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+const rsaPrivateKeyLength = 2048
+
+// NetworkBackend represents a peer's communication protocol.
+type NetworkBackend interface {
+	Send(*msgjson.Message) error
+	Request(msg *msgjson.Message, respHandler func(*msgjson.Message)) error
+}
+
+// tatanka is a Tatanka mesh server node.
+type tatanka struct {
+	NetworkBackend
+	cm     *dex.ConnectionMaster
+	peerID tanka.PeerID
+	pub    *secp256k1.PublicKey
+	config atomic.Value // *mj.TatankaConfig
+}
+
+type order struct {
+	*tanka.Order
+	oid      tanka.ID32
+	proposed map[tanka.ID32]*tanka.Match
+	accepted map[tanka.ID32]*tanka.Match
+}
+
+type market struct {
+	log dex.Logger
+
+	ordsMtx sync.RWMutex
+	ords    map[tanka.ID32]*order
+}
+
+func (m *market) addOrder(ord *tanka.Order) {
+	m.ordsMtx.Lock()
+	defer m.ordsMtx.Unlock()
+	oid := ord.ID()
+	if _, exists := m.ords[oid]; exists {
+		// ignore it then
+		return
+	}
+	m.ords[oid] = &order{
+		Order:    ord,
+		oid:      oid,
+		proposed: make(map[tanka.ID32]*tanka.Match),
+		accepted: make(map[tanka.ID32]*tanka.Match),
+	}
+}
+
+func (m *market) addMatchProposal(match *tanka.Match) {
+	m.ordsMtx.Lock()
+	defer m.ordsMtx.Unlock()
+	ord, found := m.ords[match.OrderID]
+	if !found {
+		m.log.Debugf("ignoring match proposal for unknown order %s", match.OrderID)
+	}
+	// Make sure it's not already known or accepted
+	mid := match.ID()
+	if ord.proposed[mid] != nil {
+		// Already known
+		return
+	}
+	if ord.accepted[mid] != nil {
+		// Already accepted
+		return
+	}
+	ord.proposed[mid] = match
+}
+
+func (m *market) addMatchAcceptance(match *tanka.Match) {
+	m.ordsMtx.Lock()
+	defer m.ordsMtx.Unlock()
+	ord, found := m.ords[match.OrderID]
+	if !found {
+		m.log.Debugf("ignoring match proposal for unknown order %s", match.OrderID)
+	}
+	// Make sure it's not already known or accepted
+	mid := match.ID()
+	if ord.proposed[mid] != nil {
+		delete(ord.proposed, mid)
+	}
+	if ord.accepted[mid] != nil {
+		// Already accepted
+		return
+	}
+	ord.accepted[mid] = match
+}
+
+// peer is a network peer with which we have established encrypted
+// communication.
+type peer struct {
+	id            tanka.PeerID
+	pub           *secp256k1.PublicKey
+	decryptionKey *rsa.PrivateKey // ours
+	encryptionKey *rsa.PublicKey
+}
+
+// wireKey encrypts our RSA public key for transmission.
+func (p *peer) wireKey() []byte {
+	modulusB := p.decryptionKey.PublicKey.N.Bytes()
+	encryptionKey := make([]byte, 8+len(modulusB))
+	binary.BigEndian.PutUint64(encryptionKey[:8], uint64(p.decryptionKey.PublicKey.E))
+	copy(encryptionKey[8:], modulusB)
+	return encryptionKey
+}
+
+// https://stackoverflow.com/a/67035019
+func (p *peer) decryptRSA(enc []byte) ([]byte, error) {
+	msgLen := len(enc)
+	hasher := blake256.New()
+	step := p.decryptionKey.PublicKey.Size()
+	var b []byte
+	for start := 0; start < msgLen; start += step {
+		finish := start + step
+		if finish > msgLen {
+			finish = msgLen
+		}
+		block, err := rsa.DecryptOAEP(hasher, rand.Reader, p.decryptionKey, enc[start:finish], []byte{})
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, block...)
+	}
+	return b, nil
+}
+
+func (p *peer) encryptRSA(b []byte) ([]byte, error) {
+	msgLen := len(b)
+	hasher := blake256.New()
+	step := p.encryptionKey.Size() - 2*hasher.Size() - 2
+	var enc []byte
+	for start := 0; start < msgLen; start += step {
+		finish := start + step
+		if finish > msgLen {
+			finish = msgLen
+		}
+		block, err := rsa.EncryptOAEP(hasher, rand.Reader, p.encryptionKey, b[start:finish], []byte{})
+		if err != nil {
+			return nil, err
+		}
+		enc = append(enc, block...)
+	}
+	return enc, nil
+}
+
+// IncomingPeerConnect will be emitted when a peer requests a connection for
+// the transmission of tankagrams.
+type IncomingPeerConnect struct {
+	PeerID tanka.PeerID
+	Reject func()
+}
+
+// IncomingTankagram will be emitted when we receive a tankagram from a
+// connected peer.
+type IncomingTankagram struct {
+	Msg     *msgjson.Message
+	Respond func(thing interface{}) error
+}
+
+// NewMarketSubscriber will be emitted when a new client subscribes to a market.
+type NewMarketSubscriber struct {
+	MarketName string
+	PeerID     tanka.PeerID
+}
+
+// Config is the configuration for the TankaClient.
+type Config struct {
+	Logger     dex.Logger
+	PrivateKey *secp256k1.PrivateKey
+}
+
+type TankaClient struct {
+	ctx                  context.Context
+	wg                   *sync.WaitGroup
+	peerID               tanka.PeerID
+	priv                 *secp256k1.PrivateKey
+	log                  dex.Logger
+	requestHandlers      map[string]func(*tatanka, *msgjson.Message) *msgjson.Error
+	notificationHandlers map[string]func(*tatanka, *msgjson.Message)
+	payloads             chan interface{}
+
+	tankaMtx sync.RWMutex
+	tankas   map[tanka.PeerID]*tatanka
+
+	peersMtx sync.RWMutex
+	peers    map[tanka.PeerID]*peer
+
+	marketsMtx sync.RWMutex
+	markets    map[string]*market
+}
+
+func New(cfg *Config) *TankaClient {
+	var peerID tanka.PeerID
+	copy(peerID[:], cfg.PrivateKey.PubKey().SerializeCompressed())
+
+	c := &TankaClient{
+		log:      cfg.Logger,
+		peerID:   peerID,
+		priv:     cfg.PrivateKey,
+		tankas:   make(map[tanka.PeerID]*tatanka),
+		peers:    make(map[tanka.PeerID]*peer),
+		markets:  make(map[string]*market),
+		payloads: make(chan interface{}, 128),
+	}
+	c.prepareHandlers()
+	return c
+}
+
+func (c *TankaClient) ID() tanka.PeerID {
+	return c.peerID
+}
+
+func (c *TankaClient) prepareHandlers() {
+	c.requestHandlers = map[string]func(*tatanka, *msgjson.Message) *msgjson.Error{
+		mj.RouteTankagram: c.handleTankagram,
+	}
+
+	c.notificationHandlers = map[string]func(*tatanka, *msgjson.Message){
+		mj.RouteBroadcast: c.handleBroadcast,
+	}
+}
+
+func (c *TankaClient) Next() <-chan interface{} {
+	return c.payloads
+}
+
+func (c *TankaClient) handleTankagram(tt *tatanka, tankagram *msgjson.Message) *msgjson.Error {
+	var gram mj.Tankagram
+	if err := tankagram.Unmarshal(&gram); err != nil {
+		return msgjson.NewError(mj.ErrBadRequest, "unmarshal error")
+	}
+
+	c.peersMtx.Lock()
+	defer c.peersMtx.Unlock()
+	p, peerExisted := c.peers[gram.From]
+	if !peerExisted {
+		// TODO: We should do a little message verification before accepting
+		// new peers.
+		if gram.Message == nil || gram.Message.Route != mj.RouteEncryptionKey {
+			return msgjson.NewError(mj.ErrBadRequest, "where's your key?")
+		}
+		pub, err := secp256k1.ParsePubKey(gram.From[:])
+		if err != nil {
+			c.log.Errorf("could not parse pubkey for tankagram from %s: %w", gram.From, err)
+			return msgjson.NewError(mj.ErrBadRequest, "bad pubkey")
+		}
+		priv, err := rsa.GenerateKey(rand.Reader, rsaPrivateKeyLength)
+		if err != nil {
+			return msgjson.NewError(mj.ErrInternal, "error generating rsa key: %v", err)
+		}
+		p = &peer{
+			id:            gram.From,
+			pub:           pub,
+			decryptionKey: priv,
+		}
+	}
+
+	// The only unencrypted tankagram we'll look for is the encryption key.
+	if !peerExisted {
+		msg := gram.Message
+		if msg.Route != mj.RouteEncryptionKey {
+			// if err := c.handlePeerMessage(p, msg); err != nil {
+			// 	return msgjson.NewError(mj.ErrBadRequest, "bad raw message")
+			// }
+			return msgjson.NewError(mj.ErrBadRequest, "where's your key?")
+		}
+		if err := mj.CheckSig(msg, p.pub); err != nil {
+			c.log.Errorf("%s sent a unencrypted message with a bad signature: %w", p.id, err)
+			return msgjson.NewError(mj.ErrBadRequest, "bad gram sig")
+		}
+
+		var b dex.Bytes
+		if err := msg.Unmarshal(&b); err != nil {
+			c.log.Errorf("%s tankagram unmarshal error: %w", err)
+			return msgjson.NewError(mj.ErrBadRequest, "unmarshal key error")
+		}
+
+		var err error
+		p.encryptionKey, err = decodePubkeyRSA(b)
+		if err != nil {
+			c.log.Errorf("error decoding RSA pub key from %s: %v", p.id, err)
+			return msgjson.NewError(mj.ErrBadRequest, "bad key encoding")
+		}
+
+		if err := c.sendResult(tt, tankagram.ID, dex.Bytes(p.wireKey())); err != nil {
+			c.log.Errorf("error responding to encryption key message from peer %s", p.id)
+		} else {
+			c.peers[p.id] = p
+			c.emit(&IncomingPeerConnect{
+				PeerID: p.id,
+				Reject: func() {
+					c.peersMtx.Lock()
+					delete(c.peers, p.id)
+					c.peersMtx.Unlock()
+				},
+			})
+		}
+		return nil
+	}
+
+	// If this isn't the encryption key, this gram.Message is ignored and this
+	// is assumed to be encrypted.
+	if len(gram.EncryptedMsg) == 0 {
+		c.log.Errorf("%s sent a tankagram with no message or data", p.id)
+		return msgjson.NewError(mj.ErrBadRequest, "bad gram")
+	}
+
+	b, err := p.decryptRSA(gram.EncryptedMsg)
+	if err != nil {
+		c.log.Errorf("%s sent an enrypted message that didn't decrypt: %v", p.id, err)
+		return msgjson.NewError(mj.ErrBadRequest, "bad encryption")
+	}
+	msg, err := msgjson.DecodeMessage(b)
+	if err != nil {
+		c.log.Errorf("%s sent a tankagram that didn't encode a message: %v", p.id, err)
+		return msgjson.NewError(mj.ErrBadRequest, "where's the message?")
+	}
+
+	c.emit(&IncomingTankagram{
+		Msg: msg,
+		Respond: func(thing interface{}) error {
+			b, err := json.Marshal(thing)
+			if err != nil {
+				return err
+			}
+			enc, err := p.encryptRSA(b)
+			if err != nil {
+				return err
+			}
+			return c.sendResult(tt, tankagram.ID, dex.Bytes(enc))
+		},
+	})
+
+	return nil
+}
+
+func (c *TankaClient) handleBroadcast(tt *tatanka, msg *msgjson.Message) {
+	var bcast mj.Broadcast
+	if err := msg.Unmarshal(&bcast); err != nil {
+		c.log.Errorf("%s broadcast unmarshal error: %w", err)
+		return // msgjson.NewError(mj.ErrBadRequest, "bad payload")
+	}
+	switch bcast.Topic {
+	case mj.TopicMarket:
+		c.handleMarketBroadcast(tt, &bcast)
+	}
+	c.emit(bcast)
+}
+
+func (c *TankaClient) emit(thing interface{}) {
+	select {
+	case c.payloads <- thing:
+	default:
+		c.log.Errorf("payload channel is blocking")
+	}
+}
+
+func (c *TankaClient) handleMarketBroadcast(tt *tatanka, bcast *mj.Broadcast) {
+	mktName := string(bcast.Subject)
+	c.marketsMtx.RLock()
+	mkt, found := c.markets[mktName]
+	c.marketsMtx.RUnlock()
+	if !found {
+		c.log.Debugf("received order notification for unknown market %q", mktName)
+		return
+	}
+	switch bcast.MessageType {
+	case mj.MessageTypeTrollBox:
+		var troll mj.Troll
+		if err := json.Unmarshal(bcast.Payload, &troll); err != nil {
+			c.log.Errorf("error unmarshaling trollbox message: %v", err)
+			return
+		}
+		fmt.Printf("trollbox message for market %s: %s\n", mktName, troll.Msg)
+	case mj.MessageTypeNewOrder:
+		var ord tanka.Order
+		if err := json.Unmarshal(bcast.Payload, &ord); err != nil {
+			c.log.Errorf("error unmarshaling new order: %v", err)
+			return
+		}
+		mkt.addOrder(&ord)
+	case mj.MessageTypeProposeMatch:
+		var match tanka.Match
+		if err := json.Unmarshal(bcast.Payload, &match); err != nil {
+			c.log.Errorf("error unmarshaling match proposal: %v", err)
+			return
+		}
+		mkt.addMatchProposal(&match)
+	case mj.MessageTypeAcceptMatch:
+		var match tanka.Match
+		if err := json.Unmarshal(bcast.Payload, &match); err != nil {
+			c.log.Errorf("error unmarshaling match proposal: %v", err)
+			return
+		}
+		mkt.addMatchAcceptance(&match)
+	case mj.MessageTypeNewSubscriber:
+		var ns mj.NewSubscriber
+		if err := json.Unmarshal(bcast.Payload, &ns); err != nil {
+			c.log.Errorf("error decoding new_subscriber payload: %v", err)
+		}
+		// c.emit(&NewMarketSubscriber{
+		// 	MarketName: mktName,
+		// 	PeerID:     bcast.PeerID,
+		// })
+	default:
+		c.log.Errorf("received broadcast on %s -> %s with unknown message type %s", bcast.Topic, bcast.Subject)
+	}
+}
+
+func (c *TankaClient) Broadcast(topic tanka.Topic, subject tanka.Subject, msgType mj.BroadcastMessageType, thing interface{}) error {
+	payload, err := json.Marshal(thing)
+	if err != nil {
+		return fmt.Errorf("error marshaling broadcast payload: %v", err)
+	}
+	note := mj.MustRequest(mj.RouteBroadcast, &mj.Broadcast{
+		PeerID:      c.peerID,
+		Topic:       topic,
+		Subject:     subject,
+		MessageType: msgType,
+		Payload:     payload,
+		Stamp:       time.Now(),
+	})
+	var oks int
+	for _, tt := range c.tankas {
+		var ok bool
+		if err := c.request(tt, note, &ok); err != nil || !ok {
+			c.log.Errorf("error sending to %s: ok = %t, err = %v", tt.peerID, ok, err)
+		} else {
+			oks++
+		}
+	}
+	if oks == 0 {
+		return errors.New("broadcast failed for all servers")
+	}
+	return nil
+}
+
+func (c *TankaClient) Connect(ctx context.Context) (*sync.WaitGroup, error) {
+	c.ctx = ctx
+	var wg sync.WaitGroup
+	c.wg = &wg
+
+	c.log.Infof("Starting TankaClient with peer ID %s", c.peerID)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+		c.tankaMtx.Lock()
+		for _, tt := range c.tankas {
+			tt.cm.Disconnect()
+		}
+		c.tankas = make(map[tanka.PeerID]*tatanka)
+		c.tankaMtx.Unlock()
+	}()
+
+	return c.wg, nil
+}
+
+func (c *TankaClient) AddTatankaNode(peerID tanka.PeerID, uri string, cert []byte) error {
+	pub, err := secp256k1.ParsePubKey(peerID[:])
+	if err != nil {
+		return fmt.Errorf("error parsing pubkey from peer ID: %w", err)
+	}
+
+	log := c.log.SubLogger("TCP")
+	cl, err := tcpclient.New(&tcpclient.Config{
+		Logger: log,
+		URL:    uri + "/ws",
+		Cert:   cert,
+		HandleMessage: func(msg *msgjson.Message) *msgjson.Error {
+			return c.handleTatankaMessage(peerID, msg)
+		},
+	})
+
+	if err != nil {
+		return fmt.Errorf("error creating connection: %w", err)
+	}
+
+	cm := dex.NewConnectionMaster(cl)
+	if err := cm.ConnectOnce(c.ctx); err != nil {
+		return fmt.Errorf("error connecting: %w", err)
+	}
+
+	c.tankaMtx.Lock()
+	defer c.tankaMtx.Unlock()
+
+	if oldTanka, exists := c.tankas[peerID]; exists {
+		oldTanka.cm.Disconnect()
+		log.Infof("replacing existing connection")
+	}
+
+	c.tankas[peerID] = &tatanka{
+		NetworkBackend: cl,
+		cm:             cm,
+		peerID:         peerID,
+		pub:            pub,
+	}
+
+	return nil
+}
+
+func (c *TankaClient) handleTatankaMessage(peerID tanka.PeerID, msg *msgjson.Message) *msgjson.Error {
+	if c.log.Level() == dex.LevelTrace {
+		c.log.Tracef("Client handling message from tatanka node: route = %s, payload = %s", msg.Route, mj.Truncate(msg.Payload))
+	}
+
+	c.tankaMtx.RLock()
+	tt, exists := c.tankas[peerID]
+	c.tankaMtx.RUnlock()
+	if !exists {
+		c.log.Errorf("%q message received from unknown peer %s", msg.Route, peerID)
+		return msgjson.NewError(mj.ErrAuth, "who the heck are you?")
+	}
+
+	if err := mj.CheckSig(msg, tt.pub); err != nil {
+		// DRAFT TODO: Record for reputation somehow, no?
+		c.log.Errorf("tatanka node %s sent a bad signature. disconnecting", tt.peerID)
+		return msgjson.NewError(mj.ErrAuth, "bad sig")
+	}
+
+	switch msg.Type {
+	case msgjson.Request:
+		handle, found := c.requestHandlers[msg.Route]
+		if !found {
+			// DRAFT NOTE: We should pontentially be more permissive of unknown
+			// routes in order to support minor network upgrades that add new
+			// routes.
+			c.log.Errorf("tatanka node %s sent a request to an unknown route %q", peerID, msg.Route)
+			return msgjson.NewError(mj.ErrBadRequest, "what is route %q?", msg.Route)
+		}
+		c.handleRequest(tt, msg, handle)
+	case msgjson.Notification:
+		handle, found := c.notificationHandlers[msg.Route]
+		if !found {
+			// DRAFT NOTE: We should pontentially be more permissive of unknown
+			// routes in order to support minor network upgrades that add new
+			// routes.
+			c.log.Errorf("tatanka node %s sent a notification to an unknown route %q", peerID, msg.Route)
+			return msgjson.NewError(mj.ErrBadRequest, "what is route %q?", msg.Route)
+		}
+		handle(tt, msg)
+	default:
+		c.log.Errorf("tatanka node %s send a message with an unhandleable type %d", msg.Type)
+		return msgjson.NewError(mj.ErrBadRequest, "message type %d doesn't work for me", msg.Type)
+	}
+
+	return nil
+}
+
+func (c *TankaClient) sendResult(tt *tatanka, msgID uint64, result interface{}) error {
+	resp, err := msgjson.NewResponse(msgID, result, nil)
+	if err != nil {
+		return err
+	}
+	if err := c.send(tt, resp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *TankaClient) handleRequest(tt *tatanka, msg *msgjson.Message, handle func(*tatanka, *msgjson.Message) *msgjson.Error) {
+	if msgErr := handle(tt, msg); msgErr != nil {
+		respMsg := mj.MustResponse(msg.ID, nil, msgErr)
+		if err := c.send(tt, respMsg); err != nil {
+			c.log.Errorf("Send error: %v", err)
+		}
+	}
+}
+
+func (c *TankaClient) Auth(peerID tanka.PeerID) error {
+	c.tankaMtx.RLock()
+	tt, found := c.tankas[peerID]
+	c.tankaMtx.RUnlock()
+	if !found {
+		return fmt.Errorf("cannot auth with unknown server %s", peerID)
+	}
+	return c.auth(tt)
+}
+
+func (c *TankaClient) auth(tt *tatanka) error {
+	connectMsg := mj.MustRequest(mj.RouteConnect, &mj.Connect{ID: c.peerID})
+	var cfg *mj.TatankaConfig
+	if err := c.request(tt, connectMsg, &cfg); err != nil {
+		return err
+	}
+	tt.config.Store(cfg)
+	return nil
+}
+
+func (c *TankaClient) tankaNodes() []*tatanka {
+	c.tankaMtx.RLock()
+	defer c.tankaMtx.RUnlock()
+	tankas := make([]*tatanka, 0, len(c.tankas))
+	for _, tanka := range c.tankas {
+		tankas = append(tankas, tanka)
+	}
+	return tankas
+}
+
+func (c *TankaClient) PostBond(bond *tanka.Bond) error {
+	msg := mj.MustRequest(mj.RoutePostBond, []*tanka.Bond{bond})
+	for _, tt := range c.tankaNodes() {
+		var res bool
+		if err := c.request(tt, msg, &res); err != nil {
+			c.log.Errorf("error sending bond to tatanka node %s", tt.peerID)
+			continue
+		}
+		return nil
+	}
+	return errors.New("failed to report bond to any tatanka nodes")
+}
+
+func (c *TankaClient) SubscribeMarket(baseID, quoteID uint32) error {
+	// params := &tanka.MarketParameters{
+	// 	BaseID:  baseID,
+	// 	QuoteID: quoteID,
+	// }
+	// paramsB, err := json.Marshal(params)
+	// if err != nil {
+	// 	return fmt.Errorf("marshal error: %w", err)
+	// }
+
+	mktName, err := dex.MarketName(baseID, quoteID)
+	if err != nil {
+		return fmt.Errorf("error constructing market name: %w", err)
+	}
+
+	msg := mj.MustRequest(mj.RouteSubscribe, &mj.Subscription{
+		Topic:   mj.TopicMarket,
+		Subject: tanka.Subject(mktName),
+		// ChannelParameters: paramsB,
+	})
+
+	c.marketsMtx.Lock()
+	defer c.marketsMtx.Unlock()
+
+	ttNodes := c.tankaNodes()
+	subscribed := make([]*tatanka, 0, len(ttNodes))
+	for _, tt := range ttNodes {
+		var ok bool // true is only possible non-error payload.
+		if err := c.request(tt, msg, &ok); err != nil {
+			c.log.Errorf("Error subscribing to %s market with %s: %w", mktName, tt.peerID, err)
+			continue
+		}
+		subscribed = append(subscribed, tt)
+	}
+
+	if len(subscribed) == 0 {
+		return fmt.Errorf("failed to subscribe to market %s on any servers", mktName)
+	} else {
+		c.markets[mktName] = &market{
+			log:  c.log.SubLogger(mktName),
+			ords: make(map[tanka.ID32]*order),
+		}
+	}
+
+	return nil
+}
+
+func (c *TankaClient) send(tt *tatanka, msg *msgjson.Message) error {
+	mj.SignMessage(c.priv, msg)
+	return tt.Send(msg)
+}
+
+func (c *TankaClient) request(tt *tatanka, msg *msgjson.Message, resp interface{}) error {
+	mj.SignMessage(c.priv, msg)
+	errChan := make(chan error)
+	if err := tt.Request(msg, func(msg *msgjson.Message) {
+		errChan <- msg.UnmarshalResult(&resp)
+	}); err != nil {
+		errChan <- fmt.Errorf("request error: %w", err)
+	}
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			return fmt.Errorf("tankagram error: %w", err)
+		}
+	case <-time.After(time.Second * 30):
+		return errors.New("timed out waiting for tankagram result")
+	}
+	return nil
+}
+
+func (c *TankaClient) ConnectPeer(peerID tanka.PeerID, hosts ...tanka.PeerID) (*mj.TankagramResult, error) {
+	c.peersMtx.Lock()
+	defer c.peersMtx.Unlock()
+	p, exists := c.peers[peerID]
+	if !exists {
+		priv, err := rsa.GenerateKey(rand.Reader, rsaPrivateKeyLength)
+		if err != nil {
+			return nil, fmt.Errorf("error generating rsa key: %v", err)
+		}
+		remotePub, err := secp256k1.ParsePubKey(peerID[:])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing remote pubkey: %v", err)
+		}
+		p = &peer{
+			id:            peerID,    //            tanka.PeerID
+			pub:           remotePub, //           *secp256k1.PublicKey
+			decryptionKey: priv,      // *rsa.PrivateKey // ours
+			// encryptionKey: , // atomic.Value    // *rsa.PublicKey, from remote peer
+		}
+	}
+
+	msg := mj.MustNotification(mj.RouteEncryptionKey, dex.Bytes(p.wireKey()))
+	mj.SignMessage(c.priv, msg) // We sign the embedded message separately.
+
+	req := mj.MustRequest(mj.RouteTankagram, &mj.Tankagram{
+		To:      peerID,
+		From:    c.peerID,
+		Message: msg,
+	})
+
+	var tts []*tatanka
+	if len(hosts) == 0 {
+		tts = c.tankaNodes()
+	} else {
+		tts = make([]*tatanka, 0, len(hosts))
+		c.tankaMtx.RLock()
+		for _, host := range hosts {
+			tt, exists := c.tankas[host]
+			if !exists {
+				c.log.Warnf("Requested host %q is not known", host)
+				continue
+			}
+			tts = append(tts, tt)
+		}
+		c.tankaMtx.RUnlock()
+	}
+	if len(tts) == 0 {
+		return nil, errors.New("no hosts")
+	}
+
+	for _, tt := range tts {
+		var r mj.TankagramResult
+		if err := c.request(tt, req, &r); err != nil {
+			c.log.Errorf("error sending rsa key to %s: %v", peerID, err)
+			continue
+		}
+		if r.Result == mj.TRTTransmitted {
+			// We need to get this to the caller, as a Tankagram result can
+			// be used as part of an audit request for reporting penalties.
+			pub, err := decodePubkeyRSA(r.Response)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding RSA pub key from %s: %v", p.id, err)
+			}
+			p.encryptionKey = pub
+			c.peers[peerID] = p
+			return &r, nil
+		}
+		return &r, nil
+	}
+	return nil, errors.New("no path")
+}
+
+func (c *TankaClient) SendTankagram(peerID tanka.PeerID, msg *msgjson.Message) (_ *mj.TankagramResult, _ json.RawMessage, err error) {
+	c.peersMtx.RLock()
+	p, known := c.peers[peerID]
+	c.peersMtx.RUnlock()
+
+	if !known {
+		return nil, nil, fmt.Errorf("not connected to peer %s", peerID)
+	}
+
+	mj.SignMessage(c.priv, msg)
+	tankaGram := &mj.Tankagram{
+		From: c.peerID,
+		To:   peerID,
+	}
+	tankaGram.EncryptedMsg, err = c.signAndEncryptTankagram(p, msg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error signing and encrypting tankagram for %s: %w", p.id, err)
+	}
+	wrappedMsg := mj.MustRequest(mj.RouteTankagram, tankaGram)
+	for _, tt := range c.tankaNodes() {
+		var r mj.TankagramResult
+		if err := c.request(tt, wrappedMsg, &r); err != nil {
+			c.log.Errorf("error sending tankagram to %s via %s: %v", p.id, tt.peerID, err)
+			continue
+		}
+		switch r.Result {
+		case mj.TRTTransmitted:
+			resB, err := p.decryptRSA(r.Response)
+			return &r, resB, err
+		case mj.TRTErrFromPeer, mj.TRTErrBadClient:
+			return &r, nil, nil
+		case mj.TRTNoPath, mj.TRTErrFromTanka:
+			continue
+		default:
+			return nil, nil, fmt.Errorf("unknown result %q", r.Result)
+		}
+
+	}
+	return nil, nil, fmt.Errorf("no path")
+	// var res bool // only possible non-error result is `true`
+	// return c.request(tt, wrappedMsg, res)
+}
+
+func (c *TankaClient) signAndEncryptTankagram(p *peer, msg *msgjson.Message) ([]byte, error) {
+	mj.SignMessage(c.priv, msg)
+	b, err := json.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling tankagram: %w", err)
+	}
+	return p.encryptRSA(b)
+}
+
+func decodePubkeyRSA(b []byte) (*rsa.PublicKey, error) {
+	if len(b) < 9 {
+		return nil, fmt.Errorf("invalid payload length of %d", len(b))
+	}
+	exponentB, modulusB := b[:8], b[8:]
+	exponent := int(binary.BigEndian.Uint64(exponentB))
+	modulus := new(big.Int).SetBytes(modulusB)
+	return &rsa.PublicKey{
+		E: exponent,
+		N: modulus,
+	}, nil
+}

--- a/tatanka/client/client_test.go
+++ b/tatanka/client/client_test.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+)
+
+func TestEncryption(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, rsaPrivateKeyLength)
+	if err != nil {
+		t.Fatalf("error generating rsa key: %v", err)
+	}
+	p := &peer{
+		encryptionKey: &priv.PublicKey,
+		decryptionKey: priv,
+	}
+
+	msg := []byte(
+		"this is an unencrypted message. " +
+			"For a size 2048 private key -> 256 byte public key, it needs to be longer than 190 bytes, " +
+			"so that we can test out our chunking loop." +
+			"So to make it that long, we'll just continue jabbering about nothing. " +
+			"Nothing, nothing, nothing, nothing, nothing.",
+	)
+
+	enc, err := p.encryptRSA(msg)
+	if err != nil {
+		t.Fatalf("encryptRSA error: %v", err)
+	}
+
+	reMsg, err := p.decryptRSA(enc)
+	if err != nil {
+		t.Fatalf("decryptRSA error: %v", err)
+	}
+
+	if !bytes.Equal(reMsg, msg) {
+		t.Fatalf("wrong message. %q != %q", string(reMsg), string(msg))
+	}
+}

--- a/tatanka/client_messages.go
+++ b/tatanka/client_messages.go
@@ -1,0 +1,728 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package tatanka
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/dex/utils"
+	"decred.org/dcrdex/tatanka/mj"
+	"decred.org/dcrdex/tatanka/tanka"
+)
+
+// clientJob is a job for the remote clients loop.
+type clientJob struct {
+	task interface{}
+	res  chan interface{}
+}
+
+// clientJobNewRemote is a clientJob task that adds a remote client to the
+// remoteClients map.
+type clientJobNewRemote struct {
+	tankaID  tanka.PeerID
+	clientID tanka.PeerID
+}
+
+// clientJobRemoteDisconnect is a clientJob task that removes a remote client
+// from the remoteClients map.
+type clientJobRemoteDisconnect clientJobNewRemote
+
+// clientJobFindRemotes is a clientJob that produces a list of remote tatanka
+// nodes to which the client it thought to be connected.
+type clientJobFindRemotes struct {
+	clientID tanka.PeerID
+}
+
+// runRemoteClientsLoop is a loop for reading and writing to the remoteClients
+// map. I don't know if it's more performant, I'm just tired of mutex patterns.
+func (t *Tatanka) runRemoteClientsLoop(ctx context.Context) {
+	for {
+		select {
+		case job := <-t.clientJobs:
+			switch task := job.task.(type) {
+			case *clientJobNewRemote:
+				srvs, found := t.remoteClients[task.clientID]
+				if !found {
+					srvs = make(map[tanka.PeerID]struct{})
+					t.remoteClients[task.clientID] = srvs
+				}
+				if _, found = srvs[task.tankaID]; !found {
+					srvs[task.tankaID] = struct{}{}
+					if t.log.Level() <= dex.LevelTrace {
+						t.log.Tracef("Indexing new remote client %s from %s", task.clientID, task.tankaID)
+					}
+				}
+				job.res <- true
+			case *clientJobRemoteDisconnect:
+				srvs, found := t.remoteClients[task.clientID]
+				if !found {
+					return
+				}
+				delete(srvs, task.tankaID)
+				if len(srvs) == 0 {
+					delete(t.remoteClients, task.clientID)
+				}
+				job.res <- true
+			case *clientJobFindRemotes:
+				job.res <- utils.CopyMap(t.remoteClients[task.clientID])
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// registerRemoteClient ensures the remote client is in the remoteClients map.
+func (t *Tatanka) registerRemoteClient(tankaID, clientID tanka.PeerID) {
+	job := &clientJob{
+		task: &clientJobNewRemote{
+			clientID: clientID,
+			tankaID:  tankaID,
+		},
+		res: make(chan interface{}, 1),
+	}
+	t.clientJobs <- job
+	select {
+	case <-job.res:
+	case <-t.ctx.Done():
+	}
+}
+
+// handleClientConnect handles a new locally-connected client. checking
+// reputation before adding the client to the map.
+func (t *Tatanka) handleClientConnect(cl tanka.Sender, msg *msgjson.Message) *msgjson.Error {
+	var conn *mj.Connect
+	if err := msg.Unmarshal(&conn); err != nil {
+		return msgjson.NewError(mj.ErrBadRequest, "error unmarshaling client connection configuration from %q: %v", cl.PeerID(), err)
+	}
+
+	p, rrs, err := t.loadPeer(conn.ID)
+	if err != nil {
+		return msgjson.NewError(mj.ErrInternal, "error getting peer info for peer %q: %v", conn.ID, err)
+	}
+
+	if err := mj.CheckSig(msg, p.PubKey); err != nil {
+		return msgjson.NewError(mj.ErrAuth, "signature error: %v", err)
+	}
+
+	cl.SetPeerID(p.ID)
+
+	pp := &peer{Peer: p, Sender: cl, rrs: rrs}
+	if pp.banned() {
+		return msgjson.NewError(mj.ErrBannned, "your tier is <= 0. post some bonds")
+	}
+
+	bondTier := p.BondTier()
+
+	t.clientMtx.Lock()
+	oldClient := t.clients[conn.ID]
+	t.clients[conn.ID] = &client{peer: pp}
+	t.clientMtx.Unlock()
+
+	if oldClient != nil {
+		t.log.Debugf("new connection for already connected client %q", conn.ID)
+		oldClient.Disconnect()
+	}
+
+	t.sendResult(cl, msg.ID, t.generateConfig(bondTier))
+
+	note := mj.MustNotification(mj.RouteNewClient, conn)
+	for _, s := range t.tatankaNodes() {
+		if err := t.send(s, note); err != nil {
+			t.log.Errorf("error sharing new client info with tatanka node %q", s.ID)
+		}
+	}
+
+	return nil
+}
+
+// handleClientMessage handles incoming message from locally-connected clients.
+// All messages except for handleClientConnect and handlePostBond are handled
+// here, with some common pre-processing and validation done before the
+// subsequent route handler is called.
+func (t *Tatanka) handleClientMessage(cl tanka.Sender, msg *msgjson.Message) *msgjson.Error {
+	peerID := cl.PeerID()
+	c := t.clientNode(peerID)
+	if c == nil {
+		t.log.Errorf("Ignoring message from unknown client %s", peerID)
+		cl.Disconnect()
+		return nil
+	}
+
+	if err := mj.CheckSig(msg, c.PubKey); err != nil {
+		t.log.Errorf("Signature error for %q message from %q: %v", msg.Route, c.ID, err)
+		return msgjson.NewError(mj.ErrSig, "signature doesn't check")
+	}
+
+	t.clientMtx.RLock()
+	c, found := t.clients[peerID]
+	t.clientMtx.RUnlock()
+	if !found {
+		t.log.Errorf("client %s sent a message requiring tier before connecting", peerID)
+		return msgjson.NewError(mj.ErrAuth, "not connected")
+	}
+
+	switch msg.Type {
+	case msgjson.Request:
+		switch msg.Route {
+		case mj.RouteSubscribe:
+			return t.handleSubscription(c, msg)
+		// case mj.RouteUnsubscribe:
+		// 	return t.handleUnsubscribe(c, msg)
+		case mj.RouteBroadcast:
+			return t.handleBroadcast(c.peer, msg, true)
+		case mj.RouteTankagram:
+			return t.handleTankagram(c, msg)
+		default:
+			return msgjson.NewError(mj.ErrBadRequest, "unknown request route %q", msg.Route)
+		}
+	case msgjson.Notification:
+		switch msg.Route {
+		default:
+			// TODO: What? Can't let this happen too much.
+			return msgjson.NewError(mj.ErrBadRequest, "unknown notification route %q", msg.Route)
+		}
+	default:
+		return msgjson.NewError(mj.ErrBadRequest, "unknown message type %d", msg.Type)
+	}
+}
+
+// handlePostBond handles a new bond sent from a locally connected client.
+// handlePostBond is the only client route than can be invoked before the user
+// is bonded.
+func (t *Tatanka) handlePostBond(cl tanka.Sender, msg *msgjson.Message) *msgjson.Error {
+	var bonds []*tanka.Bond
+	if err := msg.Unmarshal(&bonds); err != nil {
+		t.log.Errorf("Bond-posting client sent a bad bond message: %v", err)
+		return msgjson.NewError(mj.ErrBadRequest, "bad request")
+	}
+
+	if len(bonds) == 0 {
+		t.log.Errorf("Bond-posting client sent zero bondsl")
+		return msgjson.NewError(mj.ErrBadRequest, "no bonds sent")
+	}
+
+	peerID := bonds[0].PeerID
+	if peerID == (tanka.PeerID{}) {
+		t.log.Errorf("Bond-posting client didn't provide a peer ID")
+		return msgjson.NewError(mj.ErrBadRequest, "no peer ID")
+	}
+	for i := 1; i < len(bonds); i++ {
+		if bonds[i].PeerID != bonds[0].PeerID {
+			t.log.Errorf("Bond-posting client provided non uniform peer IDs")
+			return msgjson.NewError(mj.ErrBadRequest, "mismatched peer IDs")
+		}
+	}
+
+	var allBonds []*tanka.Bond
+	for _, b := range bonds {
+		if b == nil {
+			t.log.Errorf("Bond-posting client %s sent a nil bond", peerID)
+			return msgjson.NewError(mj.ErrBadRequest, "nil bond")
+		}
+		if b.Expiration.Before(time.Now()) {
+			t.log.Errorf("Bond-posting client %q sent an expired bond", peerID)
+			return msgjson.NewError(mj.ErrBadRequest, "bond already expired")
+		}
+
+		t.chainMtx.RLock()
+		ch := t.chains[b.AssetID]
+		t.chainMtx.RUnlock()
+		if ch == nil {
+			t.log.Errorf("Bond-posting client %q sent a bond for an unknown chain %d", peerID, b.AssetID)
+			return msgjson.NewError(mj.ErrBadRequest, "unsupported asset")
+		}
+
+		if err := ch.CheckBond(b); err != nil {
+			t.log.Errorf("Bond-posting client %q with bond %s didn't pass validation for chain %d: %v", peerID, b.CoinID, b.AssetID, err)
+			return msgjson.NewError(mj.ErrBadRequest, "failed validation")
+		}
+
+		var err error
+		allBonds, err = t.db.StoreBond(b)
+		if err != nil {
+			t.log.Errorf("Error storing bond for client %s in db: %v", peerID, err)
+			return msgjson.NewError(mj.ErrInternal, "internal error")
+		}
+
+	}
+
+	if len(allBonds) > 0 { // Probably no way to get here with empty allBonds, but checking anyway.
+		if c := t.clientNode(peerID); c != nil {
+			c.updateBonds(allBonds)
+		}
+	}
+
+	t.sendResult(cl, msg.ID, true)
+
+	return nil
+}
+
+// handleSubscription handles a new subscription, adding the subject to the
+// map if it doesn't exist. It then distributes a NewSubscriber broadcast
+// to all current subscribers and remote tatankas.
+func (t *Tatanka) handleSubscription(c *client, msg *msgjson.Message) *msgjson.Error {
+	if t.skipRelay(msg) {
+		return nil
+	}
+
+	var sub *mj.Subscription
+	if err := msg.Unmarshal(&sub); err != nil || sub == nil || sub.Topic == "" {
+		t.log.Errorf("error unmarshaling subscription from %s: %w", c.ID, err)
+		return msgjson.NewError(mj.ErrBadRequest, "is this payload a subscription?")
+	}
+
+	bcast := &mj.Broadcast{
+		Topic:       sub.Topic,
+		Subject:     sub.Subject,
+		MessageType: mj.MessageTypeNewSubscriber,
+		PeerID:      c.ID,
+		Stamp:       time.Now(),
+	}
+
+	// Do a helper function here to keep things tidy below.
+	relay := func(subs map[tanka.PeerID]struct{}) {
+		clientMsg := mj.MustNotification(mj.RouteBroadcast, bcast)
+		mj.SignMessage(t.priv, clientMsg)
+		clientMsgB, _ := json.Marshal(clientMsg)
+		for peerID := range subs {
+			subscriber, found := t.clients[peerID]
+			if !found {
+				t.log.Errorf("client not found for subscriber %s on topic %q, subject %q", peerID, sub.Topic, sub.Subject)
+				continue
+			}
+
+			if err := subscriber.Sender.SendRaw(clientMsgB); err != nil {
+				// DRAFT TODO: Remove subscriber and client and disconnect?
+				// Or do that in (*Tatanka).send?
+				t.log.Errorf("Error relaying broadcast: %v", err)
+				continue
+			}
+		}
+	}
+
+	// Send it to all other remote tatankas.
+	t.relayBroadcast(bcast, c.ID)
+
+	// Find it and broadcaast to locally-connected clients, or add the subject
+	// if it doesn't exist.
+	t.clientMtx.Lock()
+	defer t.clientMtx.Unlock()
+	topic, exists := t.topics[sub.Topic]
+	if exists {
+		// We have the topic. Do we have the subject?
+		topic.subscribers[c.ID] = struct{}{}
+		subs, exists := topic.subjects[sub.Subject]
+		if exists {
+			// We already have the subject, distribute the broadcast to existing
+			// subscribers.
+			relay(subs)
+			subs[c.ID] = struct{}{}
+		} else {
+			// Add the subject. Nothing to broadcast.
+			topic.subjects[sub.Subject] = map[tanka.PeerID]struct{}{
+				c.ID: {},
+			}
+		}
+	} else {
+		// New topic and subject.
+		t.log.Tracef("Adding new subscription topic and subject %s -> %s", sub.Topic, sub.Subject)
+		t.topics[sub.Topic] = &Topic{
+			subjects: map[tanka.Subject]map[tanka.PeerID]struct{}{
+				sub.Subject: {
+					c.ID: {},
+				},
+			},
+			subscribers: map[tanka.PeerID]struct{}{
+				c.ID: {},
+			},
+		}
+	}
+
+	t.sendResult(c, msg.ID, true)
+	return nil
+}
+
+func (t *Tatanka) unsub(peerID tanka.PeerID, topicID tanka.Topic, subjectID tanka.Subject) *msgjson.Error {
+	t.clientMtx.Lock()
+	defer t.clientMtx.Unlock()
+	topic, exists := t.topics[topicID]
+	if !exists {
+		t.log.Errorf("client %q unsubscribed from an unknown topic %q", peerID, topicID)
+		return msgjson.NewError(mj.ErrBadRequest, "unknown topic")
+	}
+	if _, found := topic.subscribers[peerID]; !found {
+		t.log.Errorf("client %q unsubscribed from topic %q, to which they were not suscribed", peerID, topicID)
+		return msgjson.NewError(mj.ErrBadRequest, "unknown topic")
+	}
+	if subjectID == "" {
+		// Unsubbing all subjects.
+		for subID, subs := range topic.subjects {
+			delete(subs, peerID)
+			if len(subs) == 0 {
+				delete(topic.subjects, subID)
+			}
+		}
+	} else {
+		subs, exists := topic.subjects[subjectID]
+		if !exists {
+			t.log.Errorf("client %q unsubscribed subject %q, topic %q, to which they were not suscribed", peerID, subjectID, topicID)
+			return msgjson.NewError(mj.ErrBadRequest, "unknown subject")
+		}
+		delete(subs, peerID)
+		if len(subs) == 0 {
+			delete(topic.subjects, subjectID)
+		}
+	}
+
+	if len(topic.subscribers) == 0 {
+		delete(t.topics, topicID)
+	}
+	return nil
+}
+
+// skipRelay checks whether the message has already been handled. This function
+// may not be necessary with the version 0 whitelisted mesh net, since
+// it is expected to be highly connected and relays only go one hop.
+func (t *Tatanka) skipRelay(msg *msgjson.Message) bool {
+	bcastID := mj.MessageDigest(msg)
+	t.relayMtx.Lock()
+	defer t.relayMtx.Unlock()
+	_, exists := t.recentRelays[bcastID]
+	if !exists {
+		t.recentRelays[bcastID] = time.Now()
+	}
+	return exists
+}
+
+// distributeBroadcastedMessage distributes the broadcast to any
+// locally-connected subscribers.
+func (t *Tatanka) distributeBroadcastedMessage(bcast *mj.Broadcast, mustExist bool) *msgjson.Error {
+	relayedMsg := mj.MustNotification(mj.RouteBroadcast, bcast)
+	mj.SignMessage(t.priv, relayedMsg)
+	relayedMsgB, _ := json.Marshal(relayedMsg)
+
+	t.clientMtx.RLock()
+	defer t.clientMtx.RUnlock()
+	topic, found := t.topics[bcast.Topic]
+	if !found {
+		if mustExist {
+			t.log.Errorf("client %q broadcasted to an unknown topic %q", bcast.PeerID, bcast.Topic)
+			return msgjson.NewError(mj.ErrBadRequest, "unknown topic")
+		}
+		return nil
+	}
+
+	relay := func(subs map[tanka.PeerID]struct{}) {
+		for peerID := range subs {
+			subscriber, found := t.clients[peerID]
+			if !found {
+				t.log.Errorf("client not found for subscriber %s on topic %q, subject %q", peerID, bcast.Topic, bcast.Subject)
+				continue
+			}
+
+			if err := subscriber.Sender.SendRaw(relayedMsgB); err != nil {
+				// DRAFT TODO: Remove subscriber and client and disconnect?
+				// Or do that in (*Tatanka).send?
+				t.log.Errorf("Error relaying broadcast: %v", err)
+				continue
+			}
+		}
+	}
+
+	if bcast.Subject == "" {
+		relay(topic.subscribers)
+	} else {
+		subs, found := topic.subjects[bcast.Subject]
+		if !found {
+			if mustExist {
+				t.log.Errorf("client %s broadcasted to an unknown subject %q on topic %s", bcast.PeerID, bcast.Subject, bcast.Topic)
+			}
+			return msgjson.NewError(mj.ErrBadRequest, "unknown subject")
+		}
+		relay(subs)
+	}
+	return nil
+}
+
+// handleBroadcast handles a broadcast from a locally connected client,
+// forwarding the message to all remote tatankas and local subscribers.
+func (t *Tatanka) handleBroadcast(p *peer, msg *msgjson.Message, mustExist bool) *msgjson.Error {
+	if t.skipRelay(msg) {
+		return nil
+	}
+
+	var bcast *mj.Broadcast
+	if err := msg.Unmarshal(&bcast); err != nil || bcast == nil || bcast.Topic == "" {
+		t.log.Errorf("error unmarshaling broadcast from %s: %w", p.ID, err)
+		return msgjson.NewError(mj.ErrBadRequest, "is this payload a broadcast?")
+	}
+
+	if bcast.PeerID != p.ID {
+		t.log.Errorf("broadcast peer ID does not match connected client: %s != %s", bcast.PeerID, p.ID)
+		return msgjson.NewError(mj.ErrBadRequest, "who's broadcast is this?")
+	}
+
+	if time.Since(bcast.Stamp) > tanka.EpochLength || time.Until(bcast.Stamp) > tanka.EpochLength {
+		t.log.Errorf("Ignoring broadcast with old stamp received from %s", p.ID)
+		return msgjson.NewError(mj.ErrBadRequest, "too old")
+	}
+
+	// Relay to remote tatankas first.
+	t.relayBroadcast(bcast, p.ID)
+
+	// Send to local subscribers.
+	if msgErr := t.distributeBroadcastedMessage(bcast, mustExist); msgErr != nil {
+		return msgErr
+	}
+
+	t.sendResult(p, msg.ID, true)
+
+	// Handle unsubs.
+	switch bcast.MessageType {
+	case mj.MessageTypeUnsubTopic:
+		t.unsub(p.ID, bcast.Topic, "")
+	case mj.MessageTypeUnsubSubject:
+		t.unsub(p.ID, bcast.Topic, bcast.Subject)
+	}
+
+	return nil
+}
+
+// relayBroadcast sends a relay_broadcast message to all remote tatankas.
+func (t *Tatanka) relayBroadcast(bcast *mj.Broadcast, from tanka.PeerID) {
+	relayedMsg := mj.MustNotification(mj.RouteRelayBroadcast, bcast)
+	mj.SignMessage(t.priv, relayedMsg)
+	relayedMsgB, _ := json.Marshal(relayedMsg)
+
+	for _, tt := range t.tatankaNodes() {
+		if tt.ID == from {
+			// don't send back to sender
+			continue
+		}
+		if err := tt.Sender.SendRaw(relayedMsgB); err != nil {
+			t.log.Errorf("Error relaying broadcast to %s: %v", tt.ID, err)
+		}
+	}
+}
+
+// findPath finds an remote tatankas that are hosting the specified peer.
+func (t *Tatanka) findPath(peerID tanka.PeerID) []*remoteTatanka {
+	job := &clientJob{
+		task: &clientJobFindRemotes{
+			clientID: peerID,
+		},
+		res: make(chan interface{}),
+	}
+	t.clientJobs <- job
+	ttIDs := (<-job.res).(map[tanka.PeerID]struct{})
+
+	nodes := make([]*remoteTatanka, 0, len(ttIDs))
+	t.tatankasMtx.RLock()
+	for ttID := range ttIDs {
+		if tt, found := t.tatankas[ttID]; found {
+			nodes = append(nodes, tt)
+		}
+	}
+	t.tatankasMtx.RUnlock()
+	return nodes
+	// 	// Attempt to locate the remote client.
+	// 	req := mj.MustRequest(mj.RoutePathInquiry, &mj.PathInquiry{ID: peerID})
+	// 	mj.SignMessage(t.priv, req)
+	// 	peers := t.tatankaNodes()
+	// 	n := len(peers)
+	// 	type result struct {
+	// 		tt    *remoteTatanka
+	// 		err   error
+	// 		found bool
+	// 	}
+	// 	resC := make(chan *result)
+	// 	sendReq := func(tt *remoteTatanka) {
+	// 		var found bool
+	// 		if err := tt.Request(req, func(msg *msgjson.Message) {
+	// 			if err := msg.UnmarshalResult(&found); err != nil {
+	// 				resC <- &result{err: err, tt: tt}
+	// 			} else {
+	// 				resC <- &result{found: found, tt: tt}
+	// 			}
+	// 		}); err != nil {
+	// 			resC <- &result{err: err, tt: tt}
+	// 		}
+	// 	}
+	// 	for _, tt := range peers {
+	// 		sendReq(tt)
+	// 	}
+	// 	timeout := time.After(time.Second * 5)
+	// 	rcvd := make([]*result, 0, n)
+	// 	var nFound int
+	// out:
+	// 	for {
+	// 		select {
+	// 		case r := <-resC:
+	// 			rcvd = append(rcvd, r)
+	// 			if r.found {
+	// 				nFound++
+	// 			}
+	// 			if len(rcvd) == n {
+	// 				break out
+	// 			}
+	// 		case <-timeout:
+	// 			t.log.Error("timed out waiting for results for path inquiry")
+	// 			break out
+	// 		case <-t.ctx.Done():
+	// 			return nil
+	// 		}
+	// 	}
+
+	// 	nodes := make([]*remoteTatanka, 0, nFound)
+	// 	t.remoteClientMtx.Lock()
+	// 	for _, r := range rcvd {
+	// 		if r.err != nil {
+	// 			t.log.Errorf("Path inquiry error from %s: %v", r.tt.ID, r.err)
+	// 			continue
+	// 		}
+	// 		if !r.found {
+	// 			continue
+	// 		}
+	// 		nodes = append(nodes, r.tt)
+	// 		srvs := t.remoteClients[peerID]
+	// 		if srvs == nil {
+	// 			srvs = make(map[tanka.PeerID]struct{})
+	// 			t.remoteClients[peerID] = srvs
+	// 		}
+	// 		srvs[r.tt.ID] = struct{}{}
+	// 	}
+	// 	t.remoteClientMtx.Unlock()
+
+	// return nodes
+}
+
+// handleTankagram forwards a tankagram from a locally connected client, sending
+// it to the recipient if the recipient is also locally connected, or else
+// bouncing it off of a remote tatanka if one is known.
+func (t *Tatanka) handleTankagram(c *client, msg *msgjson.Message) *msgjson.Error {
+	var gram mj.Tankagram
+	if err := msg.Unmarshal(&gram); err != nil {
+		t.log.Errorf("Error unmarshaling tankagram from %s: %w", c.ID, err)
+		return msgjson.NewError(mj.ErrBadRequest, "bad tankagram")
+	}
+
+	if gram.From != c.ID {
+		t.log.Errorf("Tankagram from %s has wrong sender %s", c.ID, gram.From)
+		return msgjson.NewError(mj.ErrBadRequest, "wrong sender")
+	}
+
+	// The TankagramResult is signed separately.
+	sendTankagramResult := func(r *mj.TankagramResult) {
+		r.Sign(t.priv)
+		t.sendResult(c, msg.ID, r)
+	}
+
+	t.clientMtx.RLock()
+	recip, foundLocally := t.clients[gram.To]
+	t.clientMtx.RUnlock()
+	if foundLocally {
+		var resB dex.Bytes
+		relayedMsg := mj.MustRequest(mj.RouteTankagram, gram)
+		sent, clientErr, err := t.requestAnyOne([]tanka.Sender{recip}, relayedMsg, &resB)
+		if sent {
+			sendTankagramResult(&mj.TankagramResult{Result: mj.TRTTransmitted, Response: resB})
+			return nil
+		}
+		if clientErr != nil {
+			sendTankagramResult(&mj.TankagramResult{Result: mj.TRTErrBadClient})
+			return nil
+		}
+		if err != nil {
+			t.log.Errorf("Error sending to local client %s: %v", recip.ID, err)
+		}
+	}
+
+	// Either it's not a locally-connected client, or the send attempt failed.
+	// See if we have any other routes.
+
+	tts := t.findPath(gram.To)
+	if len(tts) == 0 {
+		// TODO: Disconnect client?
+		t.log.Errorf("No local or remote client %s for tankagram from %s", gram.To, c.ID)
+		sendTankagramResult(&mj.TankagramResult{Result: mj.TRTNoPath})
+		return nil
+	}
+
+	relayedMsg := mj.MustRequest(mj.RouteRelayTankagram, gram)
+	var r mj.TankagramResult
+	sent, clientErr, err := t.requestAnyOne(tankasToSenders(tts), relayedMsg, &r)
+	if sent {
+		sendTankagramResult(&r)
+		return nil
+	}
+	if clientErr != nil {
+		// TODO: This means weren't able to communicate with the server
+		// node. We should probably disconnect this server.
+		sendTankagramResult(&mj.TankagramResult{Result: mj.TRTErrFromTanka})
+		return nil
+	}
+	if err != nil {
+		if errors.Is(err, ErrNoPath) {
+			sendTankagramResult(&mj.TankagramResult{Result: mj.TRTNoPath})
+		} else {
+			sendTankagramResult(&mj.TankagramResult{Result: mj.TRTErrFromTanka})
+		}
+	}
+	return nil
+}
+
+const ErrNoPath = dex.ErrorKind("no path")
+
+// requestAnyOne tries to request from the senders in order until one succeeds.
+func (t *Tatanka) requestAnyOne(senders []tanka.Sender, msg *msgjson.Message, resp interface{}) (sent bool, clientErr, err error) {
+	mj.SignMessage(t.priv, msg)
+	rawMsg, err := json.Marshal(msg)
+	if err != nil {
+		return false, nil, err
+	}
+	return t.requestAnyOneRaw(senders, msg.ID, rawMsg, resp)
+}
+
+func (t *Tatanka) requestAnyOneRaw(senders []tanka.Sender, msgID uint64, rawMsg []byte, resp interface{}) (sent bool, clientErr, err error) {
+	for _, sender := range senders {
+		var errChan = make(chan error)
+		if err := sender.RequestRaw(msgID, rawMsg, func(msg *msgjson.Message) {
+			if err := msg.UnmarshalResult(&resp); err != nil {
+				errChan <- err
+				return
+			}
+			errChan <- nil
+		}); err != nil {
+			peerID := sender.PeerID()
+			t.log.Errorf("error sending message to %s. msg = %s, err = %v", dex.Bytes(peerID[:]), mj.Truncate(rawMsg), err)
+			continue
+		}
+		select {
+		case err := <-errChan:
+			if err == nil {
+				return true, nil, nil
+			}
+			// If we get here, that means we got a result from the client, but
+			// it didn't parse. This is a client error.
+			return false, err, nil
+		case <-t.ctx.Done():
+			return false, nil, nil
+		}
+	}
+	return false, nil, ErrNoPath
+}
+
+func tankasToSenders(tts []*remoteTatanka) []tanka.Sender {
+	senders := make([]tanka.Sender, len(tts))
+	for i, tt := range tts {
+		senders[i] = tt
+	}
+	return senders
+}

--- a/tatanka/cmd/demo/main.go
+++ b/tatanka/cmd/demo/main.go
@@ -64,7 +64,6 @@ func mainErr() (err error) {
 		return fmt.Errorf("failed to create custom logger: %w", err)
 	}
 
-	// log := logMaker.NewLogger("MAIN", dex.LevelTrace)
 	comms.UseLogger(logMaker.NewLogger("COMMS", dex.LevelTrace))
 
 	addrs, err := findOpenAddrs(2)
@@ -366,7 +365,7 @@ func newClient(ctx context.Context, addr string, peerID tanka.PeerID, i int) (*c
 		return nil, fmt.Errorf("ConnectOnce error: %w", err)
 	}
 
-	if err := tc.AddTatankaNode(peerID, "ws://"+addr, nil); err != nil {
+	if err := tc.AddTatankaNode(ctx, peerID, "ws://"+addr, nil); err != nil {
 		cm.Disconnect()
 		return nil, fmt.Errorf("error adding server %q", addr)
 	}

--- a/tatanka/cmd/demo/main.go
+++ b/tatanka/cmd/demo/main.go
@@ -1,0 +1,402 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"os/user"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	dexbtc "decred.org/dcrdex/dex/networks/btc"
+	"decred.org/dcrdex/server/comms"
+	"decred.org/dcrdex/tatanka"
+	"decred.org/dcrdex/tatanka/chain/utxo"
+	tankaclient "decred.org/dcrdex/tatanka/client"
+	"decred.org/dcrdex/tatanka/mj"
+	"decred.org/dcrdex/tatanka/tanka"
+	"decred.org/dcrdex/tatanka/tcp"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+var (
+	logMaker      *dex.LoggerMaker
+	usr, _        = user.Current()
+	dextestDir    = filepath.Join(usr.HomeDir, "dextest")
+	decredRPCPath = filepath.Join(dextestDir, "dcr", "alpha", "rpc.cert")
+)
+
+func main() {
+	if err := mainErr(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+}
+
+func mainErr() (err error) {
+	var wg sync.WaitGroup
+	defer func() {
+		wg.Wait()
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	killChan := make(chan os.Signal, 1)
+	signal.Notify(killChan, os.Interrupt)
+	go func() {
+		<-killChan
+		fmt.Println("Shutting down...")
+		cancel()
+	}()
+
+	tmpDir, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(tmpDir)
+
+	logMaker, err = dex.NewLoggerMaker(os.Stdout, dex.LevelTrace.String())
+	if err != nil {
+		return fmt.Errorf("failed to create custom logger: %w", err)
+	}
+
+	// log := logMaker.NewLogger("MAIN", dex.LevelTrace)
+	comms.UseLogger(logMaker.NewLogger("COMMS", dex.LevelTrace))
+
+	addrs, err := findOpenAddrs(2)
+	if err != nil {
+		return fmt.Errorf("findOpenAddrs error: %w", err)
+	}
+
+	genKey := func(dir string) (*secp256k1.PrivateKey, tanka.PeerID) {
+		priv, _ := secp256k1.GeneratePrivateKey()
+		var peerID tanka.PeerID
+		copy(peerID[:], priv.PubKey().SerializeCompressed())
+		os.MkdirAll(dir, 0755)
+		os.WriteFile(filepath.Join(dir, "priv.key"), priv.Serialize(), 0644)
+		return priv, peerID
+	}
+	dir0 := filepath.Join(tmpDir, "tatanka1")
+	priv0, pid0 := genKey(dir0)
+	dir1 := filepath.Join(tmpDir, "tatanka2")
+	priv1, pid1 := genKey(dir1)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+
+		runServer(ctx, dir0, addrs[0], addrs[1], priv1.PubKey().SerializeCompressed())
+	}()
+
+	time.Sleep(time.Second)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancel()
+
+		runServer(ctx, dir1, addrs[1], addrs[0], priv0.PubKey().SerializeCompressed())
+	}()
+
+	time.Sleep(time.Second)
+
+	cl1, err := newClient(ctx, addrs[0].String(), pid0, 0)
+	if err != nil {
+		return fmt.Errorf("error making first connected client: %v", err)
+	}
+
+	cl2, err := newClient(ctx, addrs[1].String(), pid1, 1)
+	if err != nil {
+		return fmt.Errorf("error making second connected client: %v", err)
+	}
+
+	// cm.Disconnect()
+
+	if err := cl1.SubscribeMarket(42, 0); err != nil {
+		return fmt.Errorf("SubscribeMarket error: %v", err)
+	}
+
+	// Miss the relayed new subscription broadcast.
+	time.Sleep(time.Second)
+
+	if err := cl2.SubscribeMarket(42, 0); err != nil {
+		return fmt.Errorf("SubscribeMarket error: %v", err)
+	}
+
+	// Client 1 should receive a notification.
+	select {
+	case bcastI := <-cl1.Next():
+		bcast, is := bcastI.(mj.Broadcast)
+		if !is {
+			return fmt.Errorf("expected new subscription Broadcast, got %T", bcastI)
+		}
+		if bcast.MessageType != mj.MessageTypeNewSubscriber {
+			return fmt.Errorf("expected new subscription message type, got %s", bcast.MessageType)
+		}
+		fmt.Printf("Client 1's bounced broadcast received: %+v \n", bcastI)
+	case <-time.After(time.Second):
+		return errors.New("timed out waiting for client 1 to receive new subscriber notification")
+	}
+
+	mktName, err := dex.MarketName(42, 0)
+	if err != nil {
+		return fmt.Errorf("error constructing market name: %w", err)
+	}
+
+	if err := cl1.Broadcast(mj.TopicMarket, tanka.Subject(mktName), mj.MessageTypeTrollBox, &mj.Troll{Msg: "trollin'"}); err != nil {
+		return fmt.Errorf("broadcast error: %w", err)
+	}
+
+	select {
+	case bcastI := <-cl1.Next():
+		bcast, is := bcastI.(mj.Broadcast)
+		if !is {
+			return fmt.Errorf("client 1 expected trollbox Broadcast bounceback, got %T", bcastI)
+		}
+		if bcast.MessageType != mj.MessageTypeTrollBox {
+			return fmt.Errorf("client 1 expected trollbox message type for bounced message, got %s", bcast.MessageType)
+		}
+		fmt.Printf("Client 1's bounced broadcast received: %+v \n", bcastI)
+	case <-time.After(time.Second):
+		return errors.New("timed out waiting for client 1 broadcast to bounce back")
+	}
+
+	select {
+	case bcastI := <-cl2.Next():
+		bcast, is := bcastI.(mj.Broadcast)
+		if !is {
+			return fmt.Errorf("client 2 expected trollbox Broadcast, got %T", bcastI)
+		}
+		if bcast.MessageType != mj.MessageTypeTrollBox {
+			return fmt.Errorf("client 2 expected trollbox message type, got %s", bcast.MessageType)
+		}
+		fmt.Printf("Client 2's received the broadcast: %+v \n", bcastI)
+	case <-time.After(time.Second):
+		return errors.New("timed out waiting for client 2 to receive broadcast from client 1")
+	}
+
+	// Connect clients
+	if _, err := cl1.ConnectPeer(cl2.ID()); err != nil {
+		return fmt.Errorf("error connecting peers: %w", err)
+	}
+
+	select {
+	case newPeerI := <-cl2.Next():
+		if _, is := newPeerI.(*tankaclient.IncomingPeerConnect); !is {
+			return fmt.Errorf("expected IncomingPeerConnect, got %T", newPeerI)
+		}
+		fmt.Printf("Client 2's received the new peer notification: %+v \n", newPeerI)
+	case <-time.After(time.Second):
+		return errors.New("timed out waiting for client 2 to receive broadcast from client 1")
+	}
+
+	// Send a tankagram
+	const testRoute = "test_route"
+	respC := make(chan interface{})
+	go func() {
+		msg := mj.MustRequest(testRoute, true)
+		r, resB, err := cl1.SendTankagram(cl2.ID(), msg)
+		if r.Result != mj.TRTTransmitted {
+			respC <- fmt.Errorf("not transmitted. %q", r.Result)
+			return
+		}
+		if err != nil {
+			respC <- err
+			return
+		}
+		respC <- resB
+	}()
+
+	select {
+	case gramI := <-cl2.Next():
+		gram, is := gramI.(*tankaclient.IncomingTankagram)
+		if !is {
+			return fmt.Errorf("expected IncomingTankagram, got a %T", gramI)
+		}
+		if gram.Msg.Route != testRoute || !bytes.Equal(gram.Msg.Payload, []byte("true")) {
+			return fmt.Errorf("tankagram ain't right %s, %s", gram.Msg.Route, string(gram.Msg.Payload))
+		}
+		gram.Respond("ok")
+	case <-time.After(time.Second):
+		return errors.New("timed out waiting for tankagram from client 1")
+	}
+
+	select {
+	case respI := <-respC:
+		switch resp := respI.(type) {
+		case error:
+			return fmt.Errorf("error sending tankagram: %v", resp)
+		case json.RawMessage:
+			var s string
+			if err := json.Unmarshal(resp, &s); err != nil {
+				return fmt.Errorf("tankagram response didn't unmarshal: %w", err)
+			}
+			if s != "ok" {
+				return fmt.Errorf("wrong tankagram response %q", s)
+			}
+		}
+	case <-time.After(time.Second):
+		return errors.New("timed out waiting for SendTankagram to return")
+	}
+
+	fmt.Println("!!!!!!!! Test Success !!!!!!!!")
+
+	wg.Wait()
+
+	cl1.cm.Wait()
+	cl2.cm.Wait()
+
+	return nil
+}
+
+type connectedClient struct {
+	*tankaclient.TankaClient
+	cm *dex.ConnectionMaster
+}
+
+func findOpenAddrs(n int) ([]net.Addr, error) {
+	addrs := make([]net.Addr, 0, n)
+	for i := 0; i < n; i++ {
+		addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+		if err != nil {
+			return nil, err
+		}
+
+		l, err := net.ListenTCP("tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		defer l.Close()
+		addrs = append(addrs, l.Addr())
+	}
+
+	return addrs, nil
+}
+
+func runServer(ctx context.Context, dir string, addr, peerAddr net.Addr, peerID []byte) {
+	n := newBootNode(peerAddr.String(), peerID)
+
+	log := logMaker.Logger(fmt.Sprintf("SRV[%s]", addr))
+
+	os.MkdirAll(dir, 0755)
+
+	ttCfg := &tatanka.ConfigFile{Chains: []tatanka.ChainConfig{
+		{
+			Symbol: "dcr",
+			Config: mustEncode(&utxo.DecredConfigFile{
+				RPCUser:   "user",
+				RPCPass:   "pass",
+				RPCListen: "127.0.0.1:19561",
+				RPCCert:   decredRPCPath,
+			}),
+		},
+		{
+			Symbol: "btc",
+			Config: mustEncode(&utxo.BitcoinConfigFile{
+				RPCConfig: dexbtc.RPCConfig{
+					RPCUser: "user",
+					RPCPass: "pass",
+					RPCBind: "127.0.0.1",
+					RPCPort: 20556,
+				},
+			}),
+		},
+	}}
+	rawCfg, _ := json.Marshal(ttCfg)
+	cfgPath := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(cfgPath, rawCfg, 0644); err != nil {
+		log.Errorf("WriteFile error: %v", err)
+		return
+	}
+
+	cfg := &tatanka.Config{
+		Net:     dex.Simnet,
+		DataDir: dir,
+		Logger:  log,
+		RPC: comms.RPCConfig{
+			ListenAddrs: []string{addr.String()},
+			NoTLS:       true,
+		},
+		ConfigPath: cfgPath,
+		WhiteList:  []tatanka.BootNode{n},
+	}
+	t, err := tatanka.New(cfg)
+	if err != nil {
+		log.Errorf("error creating Tatanka node: %v", err)
+		return
+	}
+
+	cm := dex.NewConnectionMaster(t)
+	if err := cm.ConnectOnce(ctx); err != nil {
+		log.Errorf("ConnectOnce error: %v", err)
+		return
+	}
+
+	cm.Wait()
+}
+
+func newBootNode(addr string, peerID []byte) tatanka.BootNode {
+	tcpCfg, _ := json.Marshal(&tcp.RemoteNodeConfig{
+		URL: "ws://" + addr,
+		// Cert: ,
+	})
+	return tatanka.BootNode{
+		Protocol: "ws",
+		Config:   tcpCfg,
+		PeerID:   peerID,
+	}
+}
+
+func newClient(ctx context.Context, addr string, peerID tanka.PeerID, i int) (*connectedClient, error) {
+	log := logMaker.NewLogger(fmt.Sprintf("tCL[%d:%s]", i, addr), dex.LevelTrace)
+	priv, _ := secp256k1.GeneratePrivateKey()
+
+	tc := tankaclient.New(&tankaclient.Config{
+		Logger:     log.SubLogger("tTC"),
+		PrivateKey: priv,
+	})
+
+	cm := dex.NewConnectionMaster(tc)
+	if err := cm.ConnectOnce(ctx); err != nil {
+		return nil, fmt.Errorf("ConnectOnce error: %w", err)
+	}
+
+	if err := tc.AddTatankaNode(peerID, "ws://"+addr, nil); err != nil {
+		cm.Disconnect()
+		return nil, fmt.Errorf("error adding server %q", addr)
+	}
+
+	if err := tc.PostBond(&tanka.Bond{
+		PeerID:     tc.ID(),
+		AssetID:    42,
+		CoinID:     nil,
+		Strength:   1,
+		Expiration: time.Now().Add(time.Hour * 24 * 365),
+	}); err != nil {
+		cm.Disconnect()
+		return nil, fmt.Errorf("PostBond error: %v", err)
+	}
+
+	if err := tc.Auth(peerID); err != nil {
+		cm.Disconnect()
+		return nil, fmt.Errorf("auth error: %v", err)
+	}
+
+	return &connectedClient{
+		TankaClient: tc,
+		cm:          cm,
+	}, nil
+}
+
+func mustEncode(thing interface{}) json.RawMessage {
+	b, err := json.Marshal(thing)
+	if err != nil {
+		panic("mustEncode: " + err.Error())
+	}
+	return b
+}

--- a/tatanka/cmd/tatanka/main.go
+++ b/tatanka/cmd/tatanka/main.go
@@ -1,0 +1,315 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/comms"
+	"decred.org/dcrdex/tatanka"
+	"github.com/jessevdk/go-flags"
+	"github.com/jrick/logrotate/rotator"
+)
+
+const (
+	Version               = 0
+	defaultConfigFilename = "tatanka.conf"
+	defaultHost           = "127.0.0.1"
+	defaultPort           = "7232"
+	missingPort           = "missing port in address"
+	defaultHSHost         = defaultHost // should be a loopback address
+	defaultHSPort         = "7252"
+)
+
+var (
+	log              = dex.Disabled
+	subsystemLoggers = map[string]dex.Logger{
+		"MAIN": dex.Disabled,
+	}
+)
+
+func main() {
+	if err := mainErr(); err != nil {
+		fmt.Fprint(os.Stderr, err, "\n")
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func mainErr() (err error) {
+	logMaker, cfg := config()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	killChan := make(chan os.Signal, 1)
+	signal.Notify(killChan, os.Interrupt)
+	go func() {
+		<-killChan
+		fmt.Println("Shutting down...")
+		cancel()
+	}()
+
+	net := dex.Mainnet
+	switch {
+	case cfg.Simnet:
+		net = dex.Simnet
+	case cfg.Testnet:
+		net = dex.Testnet
+	}
+
+	t, err := tatanka.New(&tatanka.Config{
+		Net:        net,
+		DataDir:    cfg.AppDataDir,
+		Logger:     logMaker.Logger("🦬"),
+		ConfigPath: cfg.ConfigFile,
+		RPC: comms.RPCConfig{
+			HiddenServiceAddr: cfg.HiddenService,
+			ListenAddrs:       cfg.Listeners,
+			RPCKey:            cfg.KeyPath,
+			RPCCert:           cfg.CertPath,
+			NoTLS:             cfg.NoTLS,
+			AltDNSNames:       cfg.AltDNSNames,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("tatanka.New error: %w", err)
+	}
+
+	tc := dex.NewConnectionMaster(t)
+	if err = tc.ConnectOnce(ctx); err != nil {
+		return fmt.Errorf("ConnectOnce error: %w", err)
+	}
+
+	tc.Wait()
+	return nil
+}
+
+type Config struct {
+	AppDataDir  string `short:"A" long:"appdata" description:"Path to application home directory."`
+	ConfigFile  string `short:"C" long:"configfile" description:"Path to configuration file."`
+	DebugLevel  string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}."`
+	LocalLogs   bool   `long:"loglocal" description:"Use local time zone time stamps in log entries."`
+	ShowVersion bool   `short:"v" long:"version" description:"Display version information and exit."`
+
+	Testnet bool `long:"testnet" description:"Use the test network (default mainnet)."`
+	Simnet  bool `long:"simnet" description:"Use the simulation test network (default mainnet)."`
+
+	CertPath      string   `long:"tlscert" description:"TLS certificate file."`
+	KeyPath       string   `long:"tlskey" description:"TLS private key file."`
+	Listeners     []string `long:"listen" description:"IP addresses on which the RPC server should listen for incoming connections."`
+	NoTLS         bool     `long:"notls" description:"Run without TLS encryption."`
+	AltDNSNames   []string `long:"altdnsnames" description:"A list of hostnames to include in the RPC certificate (X509v3 Subject Alternative Name)."`
+	HiddenService string   `long:"hiddenservice" description:"A host:port on which the RPC server should listen for incoming hidden service connections. No TLS is used for these connections."`
+
+	WebAddr string `long:"webaddr" description:"The public facing address by which peers should connect."`
+}
+
+func config() (*dex.LoggerMaker, *Config) {
+	emitConfigError := func(s string, a ...interface{}) {
+		fmt.Fprintln(os.Stderr, fmt.Errorf(s, a...))
+		os.Exit(0)
+	}
+
+	cfg := Config{}
+	var preCfg Config // zero values as defaults
+	preParser := flags.NewParser(&preCfg, flags.HelpFlag)
+	_, err := preParser.Parse()
+	if err != nil {
+		if e, ok := err.(*flags.Error); ok && e.Type != flags.ErrHelp {
+			emitConfigError("flag pre-parse error: %v", err)
+		} else if ok && e.Type == flags.ErrHelp {
+			fmt.Fprintln(os.Stdout, err)
+			os.Exit(0)
+		}
+	}
+
+	// Show the version and exit if the version flag was specified.
+	if preCfg.ShowVersion {
+		fmt.Printf("Tatanka version %d (Go version %s %s/%s)\n",
+			Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		os.Exit(0)
+	}
+
+	// If a non-default appdata folder is specified on the command line, it may
+	// be necessary adjust the config file location. If the the config file
+	// location was not specified on the command line, the default location
+	// should be under the non-default appdata directory. However, if the config
+	// file was specified on the command line, it should be used regardless of
+	// the appdata directory.
+	if preCfg.AppDataDir != "" {
+		// appdata was set on the command line. If it is not absolute, make it
+		// relative to cwd.
+		cfg.AppDataDir, err = filepath.Abs(preCfg.AppDataDir)
+		if err != nil {
+			emitConfigError("Unable to determine working directory: %v", err)
+		}
+	}
+	isDefaultConfigFile := preCfg.ConfigFile == ""
+	if isDefaultConfigFile {
+		preCfg.ConfigFile = filepath.Join(cfg.AppDataDir, defaultConfigFilename)
+	} else if !filepath.IsAbs(preCfg.ConfigFile) {
+		preCfg.ConfigFile = filepath.Join(cfg.AppDataDir, preCfg.ConfigFile)
+	}
+
+	// Config file name for logging.
+	configFile := "NONE (defaults)"
+
+	// Load additional config from file.
+	parser := flags.NewParser(&cfg, flags.Default)
+	// Do not error default config file is missing.
+	if _, err := os.Stat(preCfg.ConfigFile); os.IsNotExist(err) {
+		// Non-default config file must exist.
+		if !isDefaultConfigFile {
+			emitConfigError("error characterizing file %q: %v", preCfg.ConfigFile, err)
+		}
+		// Warn about missing default config file, but continue.
+		fmt.Printf("Config file (%s) does not exist. Using defaults.\n",
+			preCfg.ConfigFile)
+	} else {
+		// The config file exists, so attempt to parse it.
+		err = flags.NewIniParser(parser).ParseFile(preCfg.ConfigFile)
+		if err != nil {
+			if _, ok := err.(*os.PathError); !ok {
+				emitConfigError("INI file parsing error: %v", err)
+			}
+		}
+		configFile = preCfg.ConfigFile
+	}
+
+	// Parse command line options again to ensure they take precedence.
+	_, err = parser.Parse()
+	if err != nil {
+		if e, ok := err.(*flags.Error); !ok || e.Type != flags.ErrHelp {
+			parser.WriteHelp(os.Stderr)
+		}
+		emitConfigError("CLI re-parsing error: %v", err)
+	}
+
+	if len(cfg.Listeners) == 0 {
+		cfg.Listeners = []string{defaultHost + ":" + defaultPort}
+	}
+	for i := range cfg.Listeners {
+		listen, err := normalizeNetworkAddress(cfg.Listeners[i], defaultHost, defaultPort)
+		if err != nil {
+			emitConfigError(err.Error())
+		}
+		cfg.Listeners[i] = listen
+	}
+	if cfg.HiddenService != "" {
+		cfg.HiddenService, err = normalizeNetworkAddress(cfg.HiddenService, defaultHSHost, defaultHSPort)
+		if err != nil {
+			emitConfigError(err.Error())
+		}
+	}
+
+	// Create the loggers: Parse and validate the debug level string, create the
+	// subsystem loggers, and set package level loggers. The generated
+	// LoggerMaker is used by other subsystems to create new loggers with the
+	// same backend.
+	logMaker, err := parseAndSetDebugLevels(cfg.DebugLevel, !cfg.LocalLogs)
+	if err != nil {
+		emitConfigError("parseAndSetDebugLevels error: %v", err)
+	}
+
+	initLogRotator(filepath.Join(cfg.AppDataDir, "logs"))
+
+	log.Infof("App data folder: %s", cfg.AppDataDir)
+	log.Infof("Config file:     %s", configFile)
+
+	return logMaker, &cfg
+}
+
+// parseAndSetDebugLevels attempts to parse the specified debug level and set
+// the levels accordingly. An appropriate error is returned if anything is
+// invalid.
+func parseAndSetDebugLevels(debugLevel string, UTC bool) (*dex.LoggerMaker, error) {
+	// Create a LoggerMaker with the level string.
+	lm, err := dex.NewLoggerMaker(logWriter{}, debugLevel, UTC)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create subsystem loggers.
+	for subsysID := range subsystemLoggers {
+		subsystemLoggers[subsysID] = lm.Logger(subsysID)
+	}
+
+	// Set main's Logger.
+	log = subsystemLoggers["MAIN"]
+
+	// db.UseLogger(subsystemLoggers["DB"])
+
+	return lm, nil
+}
+
+// logWriter implements an io.Writer that outputs to both standard output and
+// the write-end pipe of an initialized log rotator.
+type logWriter struct {
+	logRotator *rotator.Rotator
+}
+
+// Write writes the data in p to standard out and the log rotator.
+func (w logWriter) Write(p []byte) (n int, err error) {
+	if w.logRotator == nil {
+		return os.Stdout.Write(p)
+	}
+	os.Stdout.Write(p)
+	return w.logRotator.Write(p) // not safe concurrent writes, so only one logWriter{} allowed!
+}
+
+// initLogRotator initializes the logging rotater to write logs to logFile and
+// create roll files in the same directory.  It must be called before the
+// package-global log rotater variables are used.
+func initLogRotator(dir string) (*rotator.Rotator, error) {
+	logFile := filepath.Join(dir, "tatanka.log")
+	err := os.MkdirAll(dir, 0700)
+	if err != nil {
+		return nil, err
+	}
+	const maxLogRolls = 5
+	return rotator.New(logFile, 32*1024, false, maxLogRolls)
+}
+
+// normalizeNetworkAddress checks for a valid local network address format and
+// adds default host and port if not present. Invalidates addresses that include
+// a protocol identifier.
+func normalizeNetworkAddress(a, defaultHost, defaultPort string) (string, error) {
+	if strings.Contains(a, "://") {
+		return a, fmt.Errorf("address %s contains a protocol identifier, which is not allowed", a)
+	}
+	if a == "" {
+		return net.JoinHostPort(defaultHost, defaultPort), nil
+	}
+	host, port, err := net.SplitHostPort(a)
+	if err != nil {
+		var addrErr *net.AddrError
+		if errors.As(err, &addrErr) && addrErr.Err == missingPort {
+			host = strings.Trim(addrErr.Addr, "[]") // JoinHostPort expects no brackets for ipv6 hosts
+			normalized := net.JoinHostPort(host, defaultPort)
+			host, port, err = net.SplitHostPort(normalized)
+			if err != nil {
+				return a, fmt.Errorf("unable to address %s after port resolution: %w", normalized, err)
+			}
+		} else {
+			return a, fmt.Errorf("unable to normalize address %s: %w", a, err)
+		}
+	}
+	if host == "" {
+		host = defaultHost
+	}
+	if port == "" {
+		port = defaultPort
+	}
+	return net.JoinHostPort(host, port), nil
+}

--- a/tatanka/cmd/tatanka/main.go
+++ b/tatanka/cmd/tatanka/main.go
@@ -248,8 +248,6 @@ func parseAndSetDebugLevels(debugLevel string, UTC bool) (*dex.LoggerMaker, erro
 	// Set main's Logger.
 	log = subsystemLoggers["MAIN"]
 
-	// db.UseLogger(subsystemLoggers["DB"])
-
 	return lm, nil
 }
 

--- a/tatanka/db/bonds.go
+++ b/tatanka/db/bonds.go
@@ -1,0 +1,68 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"decred.org/dcrdex/tatanka/tanka"
+)
+
+type jsonCoder struct {
+	thing interface{}
+}
+
+func newJSON(thing interface{}) *jsonCoder {
+	return &jsonCoder{thing}
+}
+
+func (p *jsonCoder) MarshalBinary() ([]byte, error) {
+	return json.Marshal(p.thing)
+}
+
+func (p *jsonCoder) UnmarshalBinary(b []byte) error {
+	return json.Unmarshal(b, p.thing)
+}
+
+func (d *DB) StoreBond(newBond *tanka.Bond) (goodBonds []*tanka.Bond, err error) {
+	var existingBonds []*tanka.Bond
+	if _, err = d.bondsDB.Get(newBond.PeerID[:], newJSON(existingBonds)); err != nil {
+		return nil, fmt.Errorf("error reading bonds db: %w", err)
+	}
+
+	for _, b := range existingBonds {
+		if time.Now().After(b.Expiration) {
+			continue
+		}
+		goodBonds = append(goodBonds, b)
+	}
+
+	goodBonds = append(goodBonds, newBond)
+	return goodBonds, d.bondsDB.Store(newBond.PeerID[:], newJSON(goodBonds))
+}
+
+func (d *DB) GetBonds(peerID tanka.PeerID) ([]*tanka.Bond, error) {
+	var existingBonds []*tanka.Bond
+	if _, err := d.bondsDB.Get(peerID[:], newJSON(&existingBonds)); err != nil {
+		return nil, fmt.Errorf("error reading bonds db: %w", err)
+	}
+
+	var goodBonds []*tanka.Bond
+	for _, b := range existingBonds {
+		if time.Now().After(b.Expiration) {
+			continue
+		}
+		goodBonds = append(goodBonds, b)
+	}
+
+	if len(goodBonds) != len(existingBonds) {
+		if err := d.bondsDB.Store(peerID[:], newJSON(goodBonds)); err != nil {
+			return nil, fmt.Errorf("error storing bonds after pruning: %v", err)
+		}
+	}
+
+	return goodBonds, nil
+}

--- a/tatanka/db/db.go
+++ b/tatanka/db/db.go
@@ -1,0 +1,43 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package db
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"decred.org/dcrdex/dex"
+)
+
+type DB struct {
+	log dex.Logger
+	// peerDB       KeyValueDB
+	reputationDB KeyValueDB
+	bondsDB      KeyValueDB
+}
+
+func New(dir string, log dex.Logger) (*DB, error) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("error creating db dir: %w", err)
+	}
+	// peerDB, err := NewFileDB(filepath.Join(dir, "peers.db"), log.SubLogger("PEER.DB"))
+	// if err != nil {
+	// 	return nil, fmt.Errorf("error opening peer DB: %w", err)
+	// }
+	reputationDB, err := NewFileDB(filepath.Join(dir, "reputation.db"), log.SubLogger("REP.DB"))
+	if err != nil {
+		return nil, fmt.Errorf("error opening reputation DB: %w", err)
+	}
+	bondsDB, err := NewFileDB(filepath.Join(dir, "bonds.db"), log.SubLogger("BONDS.DB"))
+	if err != nil {
+		return nil, fmt.Errorf("error opening bonds db: %w", err)
+	}
+	return &DB{
+		log: log,
+		// peerDB:       peerDB,
+		reputationDB: reputationDB,
+		bondsDB:      bondsDB,
+	}, nil
+}

--- a/tatanka/db/db_test.go
+++ b/tatanka/db/db_test.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"encoding/binary"
+	"os"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/tatanka/tanka"
+)
+
+func TestReputation(t *testing.T) {
+	dir, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(dir)
+
+	log := dex.StdOutLogger("T", dex.LevelTrace)
+
+	d, err := New(dir, log)
+	if err != nil {
+		t.Fatalf("New error: %v", err)
+	}
+
+	var peerID tanka.PeerID
+	peerID[0] = 0x1
+	peerID[tanka.PeerIDLength-1] = 0x1
+
+	rep, err := d.Reputation(peerID)
+	if err != nil {
+		t.Fatalf("Error getting first reputation: %v", err)
+	}
+	if rep.Score != 0 {
+		t.Fatalf("non-zero initial score %d", rep.Score)
+	}
+
+	var n, penalties, decrement uint16
+	success := func() {
+		var refID [32]byte
+		copy(refID[:], encode.RandomBytes(32))
+		if err := d.RegisterSuccess(peerID, time.Now(), refID); err != nil {
+			t.Fatalf("RegisterSuccess error: %v", err)
+		}
+		n++
+	}
+	penalize := func(dec uint8) {
+		penalties++
+		decrement += uint16(dec)
+		penaltiesB := make([]byte, 2)
+		binary.BigEndian.PutUint16(penaltiesB, penalties)
+		var penaltyID [32]byte
+		copy(penaltyID[:], penaltiesB)
+		penaltyProof := make(dex.Bytes, 2)
+		if err := d.RegisterPenalty(peerID, time.Now(), penaltyID, dec, penaltyProof); err != nil {
+			t.Fatalf("RegisterPenalty error: %v", err)
+		}
+	}
+	checkScore := func(expScore int16) {
+		rep, err := d.Reputation(peerID)
+		if err != nil {
+			t.Fatalf("Reputation error: %v", err)
+		}
+		if rep.Score != expScore {
+			t.Fatalf("wanted score %d, got %d", expScore, rep.Score)
+		}
+	}
+
+	success()
+	checkScore(1)
+
+	var someoneElse tanka.PeerID
+	us := peerID
+	peerID = someoneElse
+	success()
+	peerID = us
+	checkScore(1)
+
+	for n < tanka.MaxReputationEntries*2 {
+		success()
+	}
+	checkScore(tanka.MaxReputationEntries)
+
+	penalize(10)
+	checkScore((tanka.MaxReputationEntries - 1) - 10)
+}

--- a/tatanka/db/kvdb.go
+++ b/tatanka/db/kvdb.go
@@ -1,0 +1,263 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package db
+
+import (
+	"context"
+	"encoding"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"github.com/dgraph-io/badger"
+)
+
+var (
+	seekEnd = []byte{
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+	}
+)
+
+type KeyValueDB interface {
+	Get(k []byte, thing encoding.BinaryUnmarshaler) (bool, error)
+	Store(k []byte, thing encoding.BinaryMarshaler) error
+	Close() error
+	ForEach(f func(k, v []byte) error, opts ...*IterationOption) error
+	Run(context.Context)
+	Delete(k []byte) error
+}
+
+type IterationOption struct {
+	reverse       bool
+	prefix        []byte
+	maxEntries    uint64
+	deleteOverMax bool
+}
+
+func WithReverse() *IterationOption {
+	return &IterationOption{
+		reverse: true,
+	}
+}
+
+func WithPrefix(b []byte) *IterationOption {
+	return &IterationOption{
+		prefix: b,
+	}
+}
+
+func WithMaxEntries(max uint64, deleteExcess bool) *IterationOption {
+	return &IterationOption{
+		maxEntries:    max,
+		deleteOverMax: deleteExcess,
+	}
+}
+
+type kvDB struct {
+	*badger.DB
+	log dex.Logger
+}
+
+func NewFileDB(filePath string, log dex.Logger) (KeyValueDB, error) {
+	// If memory use is a concern, could try
+	//   .WithValueLogLoadingMode(options.FileIO) // default options.MemoryMap
+	//   .WithMaxTableSize(sz int64); // bytes, default 6MB
+	//   .WithValueLogFileSize(sz int64), bytes, default 1 GB, must be 1MB <= sz <= 1GB
+	opts := badger.DefaultOptions(filePath).WithLogger(&badgerLoggerWrapper{log})
+	db, err := badger.Open(opts)
+	if err == badger.ErrTruncateNeeded {
+		// Probably a Windows thing.
+		// https://github.com/dgraph-io/badger/issues/744
+		log.Warnf("NewFileDB badger db: %v", err)
+		// Try again with value log truncation enabled.
+		opts.Truncate = true
+		log.Warnf("Attempting to reopen badger DB with the Truncate option set...")
+		db, err = badger.Open(opts)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &kvDB{db, log}, nil
+}
+
+// Run starts the garbage collection loop.
+func (d *kvDB) Run(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			err := d.RunValueLogGC(0.5)
+			if err != nil && !errors.Is(err, badger.ErrNoRewrite) {
+				d.log.Errorf("garbage collection error: %v", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Close the database.
+func (d *kvDB) Close() error {
+	return d.DB.Close()
+}
+
+func (d *kvDB) ForEach(f func(k, v []byte) error, iterOpts ...*IterationOption) error {
+	var deletes [][]byte
+	err := d.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchSize = 10
+		var maxEntries uint64 = math.MaxUint64
+		var deleteExcess bool
+		for _, iterOpt := range iterOpts {
+			switch {
+			case iterOpt.reverse:
+				opts.Reverse = true
+			case iterOpt.maxEntries > 0:
+				maxEntries = iterOpt.maxEntries
+				deleteExcess = iterOpt.deleteOverMax
+			case len(iterOpt.prefix) > 0:
+				opts.Prefix = iterOpt.prefix
+			}
+		}
+
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		if opts.Reverse {
+			it.Seek(append(opts.Prefix, seekEnd...))
+		} else {
+			it.Rewind()
+		}
+		var n uint64
+		for ; it.Valid(); it.Next() {
+			n++
+			item := it.Item()
+			k := item.Key()
+			if maxEntries > 0 && n > maxEntries {
+				deletes = append(deletes, k)
+				continue
+			}
+			err := item.Value(func(v []byte) error {
+				return f(k, v)
+			})
+			if err != nil {
+				return err
+			}
+			if !deleteExcess && n == maxEntries {
+				break
+			}
+		}
+		return nil
+	})
+
+	if len(deletes) > 0 {
+		d.log.Tracef("deleting %d entries from db", len(deletes))
+		if err := d.Update(func(txn *badger.Txn) error {
+			for _, k := range deletes {
+				if err := txn.Delete(k); err != nil {
+					d.log.Errorf("Error deleting db entry: %v", err)
+				}
+			}
+			return nil
+		}); err != nil {
+			d.log.Errorf("Error while deleting keys: %v", err)
+		}
+	}
+
+	return err
+}
+
+func (d *kvDB) Delete(k []byte) error {
+	return d.Update(func(tx *badger.Txn) error {
+		return tx.Delete(k)
+	})
+}
+
+func (d *kvDB) Store(k []byte, thing encoding.BinaryMarshaler) error {
+	b, err := thing.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	return d.Update(func(tx *badger.Txn) error {
+		return tx.Set(k, b)
+	})
+}
+
+func (d *kvDB) Get(k []byte, thing encoding.BinaryUnmarshaler) (found bool, err error) {
+	return found, d.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(k)
+		if err != nil {
+			if errors.Is(err, badger.ErrKeyNotFound) {
+				return nil
+			}
+			return fmt.Errorf("error reading database: %w", err)
+		}
+		found = true
+		return item.Value(func(b []byte) error {
+			return thing.UnmarshalBinary(b)
+		})
+	})
+}
+
+// badgerLoggerWrapper wraps dex.Logger and translates Warnf to Warningf to
+// satisfy badger.Logger.
+type badgerLoggerWrapper struct {
+	dex.Logger
+}
+
+var _ badger.Logger = (*badgerLoggerWrapper)(nil)
+
+// Warningf -> dex.Logger.Warnf
+func (log *badgerLoggerWrapper) Warningf(s string, a ...any) {
+	log.Warnf(s, a...)
+}
+
+type memoryDB map[string][]byte
+
+func NewMemoryDB() KeyValueDB {
+	return make(memoryDB)
+}
+
+func (m memoryDB) Store(k []byte, v encoding.BinaryMarshaler) error {
+	b, err := v.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	m[string(k)] = b
+	return nil
+}
+
+func (m memoryDB) Get(k []byte, thing encoding.BinaryUnmarshaler) (found bool, err error) {
+	b, found := m[string(k)]
+	if !found {
+		return
+	}
+	return true, thing.UnmarshalBinary(b)
+}
+
+func (m memoryDB) Close() error {
+	return nil
+}
+
+func (m memoryDB) ForEach(f func(k, v []byte) error, iterOpts ...*IterationOption) error {
+	for k, v := range m {
+		if err := f([]byte(k), v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m memoryDB) Run(context.Context) {}
+
+func (m memoryDB) Delete(k []byte) error {
+	delete(m, string(k))
+	return nil
+}

--- a/tatanka/db/peers.go
+++ b/tatanka/db/peers.go
@@ -1,0 +1,47 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package db
+
+import (
+	"fmt"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/tatanka/tanka"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+const (
+	ErrNotFound = dex.ErrorKind("not found")
+)
+
+// func (d *DB) StorePeer(p *tanka.Peer) error {
+// 	k := p.PubKey.SerializeCompressed()
+// 	return d.peerDB.Store(k, newJSON(p))
+// }
+
+func (d *DB) GetPeer(peerID tanka.PeerID) (_ *tanka.Peer, err error) {
+	p := &tanka.Peer{
+		ID: peerID,
+	}
+	// if found, err := d.peerDB.Get(peerID[:], newJSON(p)); err != nil {
+	// 	return nil, fmt.Errorf("Get error: %w", err)
+	// } else if !found {
+	// 	return nil, ErrNotFound
+	// }
+
+	p.ID = peerID
+	if p.PubKey, err = secp256k1.ParsePubKey(peerID[:]); err != nil {
+		return nil, fmt.Errorf("ParsePubKey error: %w", err)
+	}
+
+	if p.Bonds, err = d.GetBonds(peerID); err != nil {
+		return nil, fmt.Errorf("GetBonds error: %w", err)
+	}
+
+	if p.Reputation, err = d.Reputation(peerID); err != nil {
+		return nil, fmt.Errorf("error getting Reputation: %w", err)
+	}
+
+	return p, nil
+}

--- a/tatanka/db/reputation.go
+++ b/tatanka/db/reputation.go
@@ -1,0 +1,78 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package db
+
+import (
+	"encoding"
+	"encoding/binary"
+	"fmt"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/tatanka/tanka"
+)
+
+// Reputation entries with key encoded as
+//    peer_id | 6_bytes_millisecond_timestamp | 32_byte_penalty_id
+// Value is empty if it's a success. For penalties, the value is
+//   1_byte_score_decrement | encoded_penalty_proof.
+
+func (d *DB) Reputation(peerID tanka.PeerID) (rep *tanka.Reputation, err error) {
+	rep = &tanka.Reputation{
+		Points: make([]int8, 0, tanka.MaxReputationEntries),
+	}
+	return rep, d.reputationDB.ForEach(func(k, v []byte) error {
+		if len(v) == 0 {
+			// Success
+			rep.Score++
+			rep.Points = append(rep.Points, 1)
+			return nil
+		}
+		rep.Score -= int16(v[0])
+		rep.Points = append(rep.Points, -int8(v[0]))
+		return nil
+	}, WithPrefix(peerID[:]), WithReverse(), WithMaxEntries(tanka.MaxReputationEntries, true))
+}
+
+func (d *DB) RegisterSuccess(peerID tanka.PeerID, stamp time.Time, refID [32]byte) error {
+	const keyLength = tanka.PeerIDLength + 6 + 32
+	k := make([]byte, keyLength)
+	copy(k[:tanka.PeerIDLength], peerID[:])
+	stampB := make([]byte, 8)
+	binary.BigEndian.PutUint64(stampB, uint64(stamp.UnixMilli()))
+	copy(k[tanka.PeerIDLength:tanka.PeerIDLength+6], stampB[2:])
+	copy(k[tanka.PeerIDLength+6:], refID[:])
+
+	if err := d.reputationDB.Store(k, dex.Bytes{}); err != nil {
+		return fmt.Errorf("error storing success for user %q: %v", peerID, err)
+	}
+
+	// TODO: Periodically run a nanny function to clear extra entries. Otherwise
+	// entries are only deleted during the score scan. So theoretically, someone
+	// could fill the db with a billion successes. Same in RegisterPenalty.
+
+	return nil
+}
+
+func (d *DB) RegisterPenalty(peerID tanka.PeerID, stamp time.Time, penaltyID [32]byte, scoreDecrement uint8, penaltyInfo encoding.BinaryMarshaler) error {
+	const keyLength = tanka.PeerIDLength + 6 + 32
+	k := make([]byte, keyLength)
+	copy(k[:tanka.PeerIDLength], peerID[:])
+	stampB := make([]byte, 8)
+	binary.BigEndian.PutUint64(stampB, uint64(stamp.UnixMilli()))
+	copy(k[tanka.PeerIDLength:tanka.PeerIDLength+6], stampB[2:])
+	copy(k[tanka.PeerIDLength+6:], penaltyID[:])
+
+	b, err := penaltyInfo.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("error marshaling penalty info: %w", err)
+	}
+	v := make(dex.Bytes, 1+len(b))
+	v[0] = scoreDecrement
+	copy(v[1:], b)
+	if err := d.reputationDB.Store(k, v); err != nil {
+		return fmt.Errorf("error storing penalty: %w", err)
+	}
+	return nil
+}

--- a/tatanka/mj/auth.go
+++ b/tatanka/mj/auth.go
@@ -1,0 +1,44 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mj
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+
+	"decred.org/dcrdex/dex/msgjson"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+func MessageDigest(msg *msgjson.Message) [32]byte {
+	b := make([]byte, 0, 1+len(msg.Route)+8+len(msg.Payload))
+	b = append(b, byte(msg.Type))
+	b = append(b, []byte(msg.Route)...)
+	var idB [8]byte
+	binary.BigEndian.PutUint64(idB[:], msg.ID)
+	b = append(b, idB[:]...)
+	b = append(b, msg.Payload...)
+	return sha256.Sum256(b)
+}
+
+func SignMessage(priv *secp256k1.PrivateKey, msg *msgjson.Message) {
+	h := MessageDigest(msg)
+	msg.Sig = ecdsa.Sign(priv, h[:]).Serialize()
+}
+
+// CheckSig checks that the message's signature was created with the private
+// key for the provided secp256k1 public key on the sha256 hash of the message.
+func CheckSig(msg *msgjson.Message, pubKey *secp256k1.PublicKey) error {
+	signature, err := ecdsa.ParseDERSignature(msg.Sig)
+	if err != nil {
+		return fmt.Errorf("error decoding secp256k1 Signature from bytes: %w", err)
+	}
+	h := MessageDigest(msg)
+	if !signature.Verify(h[:], pubKey) {
+		return fmt.Errorf("secp256k1 signature verification failed")
+	}
+	return nil
+}

--- a/tatanka/mj/types.go
+++ b/tatanka/mj/types.go
@@ -80,7 +80,7 @@ type TatankaConfig struct {
 	ID      tanka.PeerID `json:"id"`
 	Version uint32       `json:"version"`
 	Chains  []uint32     `json:"chains"`
-	// BondTier is be the senders current view of the receivers tier.
+	// BondTier is the senders current view of the receiver's tier.
 	BondTier uint64 `json:"bondTier"`
 }
 
@@ -205,7 +205,7 @@ func MustNotification(route string, payload any) *msgjson.Message {
 func MustResponse(id uint64, payload any, rpcErr *msgjson.Error) *msgjson.Message {
 	msg, err := msgjson.NewResponse(id, payload, rpcErr)
 	if err != nil {
-		panic("MustNotification error: " + err.Error())
+		panic("MustResponse error: " + err.Error())
 	}
 	return msg
 }

--- a/tatanka/mj/types.go
+++ b/tatanka/mj/types.go
@@ -1,0 +1,211 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mj
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"sync/atomic"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/tatanka/tanka"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+const (
+	ErrNone = iota
+	ErrTimeout
+	ErrInternal
+	ErrBadRequest
+	ErrAuth
+	ErrSig
+	ErrNoConfig
+	ErrBannned
+	ErrFailedRelay
+)
+
+const (
+	// tatanka <=> tatanka
+	RouteTatankaConfig    = "tatanka_config"
+	RouteTatankaConnect   = "tatanka_connect"
+	RouteNewClient        = "new_client"
+	RouteClientDisconnect = "client_disconnect"
+	RouteGetReputation    = "get_reputation"
+	RouteRelayBroadcast   = "relay_broadcast"
+	RouteRelayTankagram   = "relay_tankagram"
+	RoutePathInquiry      = "path_inquiry"
+
+	// tatanka <=> client
+	RouteConnect     = "connect"
+	RouteConfig      = "config"
+	RoutePostBond    = "post_bond"
+	RouteSubscribe   = "subscribe"
+	RouteUnsubscribe = "unsubscribe"
+
+	// client1 <=> tatankanode <=> client2
+	RouteTankagram     = "tankagram"
+	RouteEncryptionKey = "encryption_key"
+	RouteBroadcast     = "broadcast"
+	RouteNewSubscriber = "new_subscriber"
+)
+
+const (
+	TopicMarket = "market"
+)
+
+type BroadcastMessageType string
+
+const (
+	MessageTypeTrollBox      BroadcastMessageType = "troll_box"
+	MessageTypeNewOrder      BroadcastMessageType = "new_order"
+	MessageTypeProposeMatch  BroadcastMessageType = "propose_match"
+	MessageTypeAcceptMatch   BroadcastMessageType = "accept_match"
+	MessageTypeNewSubscriber BroadcastMessageType = "new_subscriber"
+	MessageTypeUnsubTopic    BroadcastMessageType = "unsub_topic"
+	MessageTypeUnsubSubject  BroadcastMessageType = "unsub_subject"
+)
+
+var msgIDCounter atomic.Uint64
+
+func NewMessageID() uint64 {
+	return msgIDCounter.Add(1)
+}
+
+type TatankaConfig struct {
+	ID      tanka.PeerID `json:"id"`
+	Version uint32       `json:"version"`
+	Chains  []uint32     `json:"chains"`
+	// BondTier is be the senders current view of the receivers tier.
+	BondTier uint64 `json:"bondTier"`
+}
+
+type Connect struct {
+	ID tanka.PeerID `json:"id"`
+}
+
+type Disconnect = Connect
+
+type RemoteReputation struct {
+	Score  int16
+	NumPts uint8
+}
+
+type Tankagram struct {
+	To           tanka.PeerID     `json:"to"`
+	From         tanka.PeerID     `json:"from"`
+	Message      *msgjson.Message `json:"message,omitempty"`
+	EncryptedMsg dex.Bytes        `json:"encryptedMessage,omitempty"`
+}
+
+// TankagramResultType is a critical component of the mesh network's reputation
+// system. The outcome of self-reported audits of counterparty failures will
+// depend heavily on what signed TankagramResult.Result is submitted.
+type TankagramResultType string
+
+const (
+	TRTTransmitted  TankagramResultType = "transmitted"
+	TRTNoPath       TankagramResultType = "nopath"
+	TRTErrFromPeer  TankagramResultType = "errorfrompeer"
+	TRTErrFromTanka TankagramResultType = "errorfromtanka"
+	TRTErrBadClient TankagramResultType = "badclient"
+)
+
+type TankagramResult struct {
+	Result   TankagramResultType `json:"result"`
+	Response dex.Bytes           `json:"response"`
+	// If the tankagram is not transmitted, the server will stamp and sign the
+	// tankagram separately.
+	Stamp uint64    `json:"stamp"`
+	Sig   dex.Bytes `json:"sig"`
+}
+
+func (r *TankagramResult) Sign(priv *secp256k1.PrivateKey) {
+	r.Stamp = uint64(time.Now().UnixMilli())
+	resultB := []byte(r.Result)
+	preimage := make([]byte, len(resultB)+len(r.Response)+4)
+	copy(preimage[:len(resultB)], resultB)
+	copy(preimage[len(resultB):len(resultB)+len(r.Response)], r.Response)
+	copy(preimage[len(resultB)+len(r.Response):], encode.Uint64Bytes(r.Stamp))
+	digest := sha256.Sum256(preimage)
+	r.Sig = ecdsa.Sign(priv, digest[:]).Serialize()
+}
+
+type Broadcast struct {
+	PeerID      tanka.PeerID         `json:"peerID"`
+	Topic       tanka.Topic          `json:"topic"`
+	Subject     tanka.Subject        `json:"subject"`
+	MessageType BroadcastMessageType `json:"messageType"`
+	Payload     dex.Bytes            `json:"payload,omitempty"`
+	Stamp       time.Time            `json:"stamp"`
+}
+
+type Subscription struct {
+	Topic   tanka.Topic   `json:"topic"`
+	Subject tanka.Subject `json:"subject"`
+	// ChannelParameters json.RawMessage `json:"channelParameters,omitempty"`
+}
+
+type Unsubscription struct {
+	Topic  tanka.Topic  `json:"topic"`
+	PeerID tanka.PeerID `json:"peerID"`
+}
+
+type FundedMessage struct {
+	AssetID uint32          `json:"assetID"`
+	Funding json.RawMessage `json:"funding"`
+	Msg     msgjson.Message `json:"msg"`
+}
+
+type Troll struct {
+	Msg string `json:"msg"`
+}
+
+var ellipsis = []byte("...")
+
+func Truncate(b []byte) string {
+	const truncationLength = 300
+	if len(b) <= truncationLength {
+		return string(b)
+	}
+	truncated := make([]byte, truncationLength+len(ellipsis))
+	copy(truncated[:truncationLength], b[:truncationLength])
+	copy(truncated[truncationLength:], ellipsis)
+	return string(truncated)
+}
+
+type PathInquiry = Connect
+
+type NewSubscriber struct {
+	PeerID  tanka.PeerID  `json:"peerID"`
+	Topic   tanka.Topic   `json:"topic"`
+	Subject tanka.Subject `json:"subject"`
+}
+
+func MustRequest(route string, payload any) *msgjson.Message {
+	msg, err := msgjson.NewRequest(NewMessageID(), route, payload)
+	if err != nil {
+		panic("MustRequest error: " + err.Error())
+	}
+	return msg
+}
+
+func MustNotification(route string, payload any) *msgjson.Message {
+	msg, err := msgjson.NewNotification(route, payload)
+	if err != nil {
+		panic("MustNotification error: " + err.Error())
+	}
+	return msg
+}
+
+func MustResponse(id uint64, payload any, rpcErr *msgjson.Error) *msgjson.Message {
+	msg, err := msgjson.NewResponse(id, payload, rpcErr)
+	if err != nil {
+		panic("MustNotification error: " + err.Error())
+	}
+	return msg
+}

--- a/tatanka/peer.go
+++ b/tatanka/peer.go
@@ -1,0 +1,83 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package tatanka
+
+import (
+	"math"
+	"sync"
+
+	"decred.org/dcrdex/tatanka/mj"
+	"decred.org/dcrdex/tatanka/tanka"
+)
+
+// peer represents a locally connected client.
+type peer struct {
+	tanka.Sender
+
+	mtx         sync.RWMutex
+	*tanka.Peer // Bonds and Reputation protected by mtx
+	rrs         map[tanka.PeerID]*mj.RemoteReputation
+}
+
+// score calculates the peer's reputation score.
+func (p *peer) score() int16 {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+	// If we have registered enough points ourselves, just use our score.
+	if len(p.Reputation.Points) == tanka.MaxReputationEntries {
+		return p.Reputation.Score
+	}
+	// Create a composite score. This is not an average. If we have 90 or the
+	// max 100 sepearate point entries, our score is weighted as 90%. The other
+	// 10% is taken from a poll of peers, weighted according to the number of
+	// points that they report.
+	myScoreRatio := float64(len(p.Reputation.Points)) / tanka.MaxReputationEntries
+	remainingScoreRatio := (tanka.MaxReputationEntries - float64(len(p.Reputation.Points))) / tanka.MaxReputationEntries
+	var weight int64
+	var ptCount uint32
+	for _, r := range p.rrs {
+		if r == nil {
+			continue
+		}
+		weight += int64(r.Score) * int64(r.NumPts)
+		ptCount += uint32(r.NumPts)
+	}
+
+	remoteScore := float64(weight) / float64(ptCount)
+	score := int64(math.Round(float64(p.Reputation.Score)*myScoreRatio + remoteScore*remainingScoreRatio))
+	if score > math.MaxUint16 {
+		score = math.MaxInt64
+	}
+	if score < -int64(math.MaxInt16) {
+		score = -int64(math.MaxInt16)
+	}
+	return int16(score)
+}
+
+// banned checks whether the peer is banned.
+func (p *peer) banned() bool {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+	// NEED TO CONSIDER *RemoteReputations....
+	tier := calcTier(p.Reputation, p.BondTier())
+	return tier <= 0
+}
+
+// bondTier is the peer's current bonded tier.
+func (p *peer) bondTier() uint64 {
+	p.mtx.RLock()
+	defer p.mtx.RUnlock()
+	return p.BondTier()
+}
+
+// updateBonds updates the peers bond set.
+func (p *peer) updateBonds(bonds []*tanka.Bond) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.Bonds = bonds
+}
+
+type client struct {
+	*peer
+}

--- a/tatanka/spec/intro.md
+++ b/tatanka/spec/intro.md
@@ -1,0 +1,93 @@
+# Introduction to Tatanka Mesh
+
+Tatanka Mesh (TM, or just "the mesh") is a multi-blockchain mesh network offering a suite
+of services for clients. This initial specification version may reference the
+"toy mesh", which is a proof-of-concept implementation of Tatanka Mesh. 
+
+### Services
+
+1) Reputation services. The mesh will handle client bonds and reputation in
+a fashion similar to a dcrdex server. Bonds provide network access, increased
+network usage limits, and can offset penalties for high-volume users. Clients
+self-report successes and failures, which are used to build a reputation score.
+If a clients reputation score drops too low, they can have their usage limited
+or outright suspended.
+
+1) Subscription channels, or "apps", perform a function similar to a chat room.
+Clients subscribe to "topics", which can also have more narrow "subjects" to
+which the client might subscribe. Subscription channels can be used to construct
+various applications, such as a peer-to-peer decentralized exchange. The mesh
+does not prescribe protocols for communications on a topic or subject. Such
+protocols are defined by the client software.
+
+1) Client message routing. The mesh can route messages from client to client,
+even when those clients are connected to different mesh nodes. Client messaging
+is end-to-end encrypted, so the mesh network itself cannot read the contents.
+The encrypted messaging primitive is called a "tankagram". Clients connected
+to the same subscription channel might send one another tankagrams to, for
+instance, communicate detaila about an ongoing atomic swap.
+
+1) Oracle services. The mesh will coordinate distribution of network transaction
+fee rates that might be used as part of validation for app actions. The mesh
+could potentially distribute fiat exchange rates as well, although such
+functionality is not implemented in the toy mesh. See also the
+[Outstanding Questions](#oustanding_questions) section.
+
+### Other Important Features
+
+- Although the toy mesh uses WebSockets for communications, there is no
+prescribed transport protocol, and other communication backends are planned,
+especially BisonRelay. If clients are using compatible protocols with the
+requisite features (e.g. BisonRelay), client communications (tankagrams) can be
+taken out-of-band.
+
+- Version 0 of Tatanka Mesh will be whitelist-only. This means that the mesh
+network itself is a network of trusted nodes. By using a whitelist, we can
+initially forego implementation of what will inevitably be a complicated mesh
+node reputation system.
+
+- Tatanka Mesh does not maintain a global state. Mesh nodes need not agree on
+client reputation, and the ability to synchronize reputation is extremely
+limited. See the [Outstanding Questions](#oustanding_questions) section for more
+discussion.
+
+### Why?
+
+The mesh architecture is designed in this way specifically to move all DEX
+operations to the clients. In the litany of proposed U.S. legislation aimed at
+regulating cryptocurrencies, even the most favorable bills indicate that
+operating an order book would compel the server operator to collect
+know-your-customer (KYC) and anti-money-laundering (AML) information from users.
+This is going to be the case regardless of the (non-custodial, trustless) nature
+of the underlying exchange protocol. While we believe that the trustless nature
+of atomic swaps should preclude an order book operator from these regulations,
+that is simply not going to be the case. As such, we're moving towards a fully
+P2P model. Tatanka Mesh does not even know what a market is.
+
+### Outstanding Questions<a name="oustanding_questions">
+
+- Client will self-report successes and counter-party failures, but who is in charge of
+auditing these reports before inclusion into reputation? For example, the mesh
+does not know what an atomic swap is, so how can a mesh node validate a reported
+swap failure? Two possiblities are...
+    1) The server could audit the reports, but do so in terms of blockchain
+    primitives that exist outside of the context of particular applications. For
+    example, the server could audit reports in terms of "HTLC pairs". The
+    important thing is that the server does not even appear to participate in
+    any way in the maintenance of an exchange market.
+    1) The server could outsource auditing to clients, and accept the majority
+    result. This might require the server to expose some blockchain functionality
+    to clients who may not have e.g. txindex enabled on their UTXO-based
+    blockchain. This also creates perhaps more questions than it answers. What
+    if there aren't enough clients connected? How do we account for the report
+    while we are still waiting for client audits?
+
+- Since the mesh network does not maintain a global state, what happens if a
+client is suspended on one node but not another? For the toy mesh, reputation
+is only checked by the node(s) to which the client is directly connected. This
+simple system might work for a whitelisted network, but is not a long-term
+solution.
+
+### More Info
+
+[Introduction to Mesh DEX](meshdex.md)

--- a/tatanka/spec/intro.md
+++ b/tatanka/spec/intro.md
@@ -25,7 +25,7 @@ even when those clients are connected to different mesh nodes. Client messaging
 is end-to-end encrypted, so the mesh network itself cannot read the contents.
 The encrypted messaging primitive is called a "tankagram". Clients connected
 to the same subscription channel might send one another tankagrams to, for
-instance, communicate detaila about an ongoing atomic swap.
+instance, communicate details about an ongoing atomic swap.
 
 1) Oracle services. The mesh will coordinate distribution of network transaction
 fee rates that might be used as part of validation for app actions. The mesh
@@ -66,10 +66,10 @@ P2P model. Tatanka Mesh does not even know what a market is.
 
 ### Outstanding Questions<a name="oustanding_questions">
 
-- Client will self-report successes and counter-party failures, but who is in charge of
-auditing these reports before inclusion into reputation? For example, the mesh
-does not know what an atomic swap is, so how can a mesh node validate a reported
-swap failure? Two possiblities are...
+- Clients will self-report successes and counter-party failures, but who is in
+charge of auditing these reports before inclusion into reputation? For example,
+the mesh does not know what an atomic swap is, so how can a mesh node validate a
+reported swap failure? Two possiblities are...
     1) The server could audit the reports, but do so in terms of blockchain
     primitives that exist outside of the context of particular applications. For
     example, the server could audit reports in terms of "HTLC pairs". The

--- a/tatanka/spec/meshdex.md
+++ b/tatanka/spec/meshdex.md
@@ -1,0 +1,62 @@
+# DEX on Tatanka Mesh
+
+Implementing a peer-to-peer decentralized exchange on Tatanka Mesh will require
+substantial re-thinking of many existing DCRDEX protocol features. The primary
+difference between DCRDEX and DEX on Tatanka Mesh is that Tatanka Mesh clients
+take over the roll of maintaining order books.
+
+### Protocol Basics
+
+1) There are no pre-defined markets. A market is simply a broadcast channel,
+which is a topic-subject pair, e.g. topic = "market", subject = "dcr_btc". Any
+user can create a new market by simply subscribing to a non-existent channel.
+This means we need to eliminate most market configuration.
+    - Lot size will not be a constant. Instead, it will be chosen by the user
+    based on their preferences for limiting fee exposure. For example, the user
+    may set their fee exposure limit to 1%. This will hide any order (in their
+    local view of the order book) which have a lot size that might result in fee
+    losses > 1%. Only orders with compatible lot sizes can match. To ensure
+    orders fill completely, I propose that lot sizes must be a power of 2,
+    though other schemes are possibly conceivable.
+    - Max fee rates are similarly set by the user as part of the order, and
+    orders whose max fee rate falls below the fee rates provided by the mesh
+    oracle feed will be ignored or unbooked.
+    - If the mesh provides a fiat exchange rate feed, we can define the rate
+    step and parcel size as a exchange-wide constant in terms of USD, and these
+    values will be dynamically re-calculated for each market as rates change.
+    - We could potentially do away with epoch-based matching, but we may want to
+    keep it around, albeit in a different form. Our goal should be that clients
+    are reacting appropriately by creating matches for valid offers. Clients
+    can't just ignore offers based on their own arbitrary criteria. Ideally
+    they would accept the first offers that are sent to them, though this would
+    be very hard to enforce.
+    - I've considered doing away with order funding validation. The only purpose
+    of funding validation is to prevent empty wallets from spamming the market
+    with orders they have no intention to fulfill. This would of course result
+    in an account suspension, so such spamming cannot go on indefinitely. The
+    bonding system also requires users to lock up funds before using the
+    network, so there is still a barrier to such malicious behavior, though this
+    is not as strong a filter as funding validation would provide. It's
+    important to remember that the global worst-case scenario for
+    atomic-swap-based exchange is a refund, not lost funds, so a malicious
+    actor's only incentive to spam would be to grief the network. On the other
+    hand, the server could still provide funding validation services without
+    participating in the market. Either way, we're going to do away with the
+    necessity of split funding transactions. More on this later.
+
+
+1) Markets are user-policed. Successes and counterparty failures are
+self-reported.
+
+1) Match proposals could be either public or private. Public match proposals
+could be monitored by all market participants to potentially root out bad
+actors, but private match proposals have obvious benefits as well. Either way
+matches are self-reported as public broadcasts, so that clients can maintain
+their order books.
+
+1) Swap communications take place in encrypted tankagrams. Unless a swap failure
+occurs which requires an audit, the server never knows any swap details.
+
+1) Orders will have an expiration time that can be only so far in the future.
+Clients can extend their expiration time as needed, but still only within a
+relatively short window into the future. Expired orders are pruned.

--- a/tatanka/spec/meshdex.md
+++ b/tatanka/spec/meshdex.md
@@ -38,11 +38,11 @@ This means we need to eliminate most market configuration.
     network, so there is still a barrier to such malicious behavior, though this
     is not as strong a filter as funding validation would provide. It's
     important to remember that the global worst-case scenario for
-    atomic-swap-based exchange is a refund, not lost funds, so a malicious
-    actor's only incentive to spam would be to grief the network. On the other
-    hand, the server could still provide funding validation services without
-    participating in the market. Either way, we're going to do away with the
-    necessity of split funding transactions. More on this later.
+    atomic-swap-based exchange is a refund and fees, not lost funds, so a
+    malicious actor's only incentive to spam would be to grief the network. On
+    the other hand, the server could still provide funding validation services
+    without participating in the market. Either way, we're going to do away with
+    the necessity of split funding transactions. More on this later.
 
 
 1) Markets are user-policed. Successes and counterparty failures are

--- a/tatanka/tanka/peer.go
+++ b/tatanka/tanka/peer.go
@@ -1,0 +1,74 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package tanka
+
+import (
+	"encoding/hex"
+
+	"decred.org/dcrdex/dex/msgjson"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+const PeerIDLength = secp256k1.PubKeyBytesLenCompressed
+
+// PeerID is the primary identifier for both clients and servers on Tatanka
+// Mesh. The PeerID is the compressed-format serialized secp256k1.PublicKey.
+type PeerID [PeerIDLength]byte
+
+func (p PeerID) String() string {
+	return hex.EncodeToString(p[:])
+}
+
+// func (p *PeerID) MarshalJSON() ([]byte, error) {
+// 	return json.Marshal(hex.EncodeToString((*p)[:]))
+// }
+
+// func (p *PeerID) UnmarshalJSON(encHex []byte) (err error) {
+// 	if len(encHex) < 2 {
+// 		return fmt.Errorf("unmarshalled bytes, %q, not valid", string(encHex))
+// 	}
+// 	if encHex[0] != '"' || encHex[len(encHex)-1] != '"' {
+// 		return fmt.Errorf("unmarshalled bytes, %q, not quoted", string(encHex))
+// 	}
+// 	// DecodeString over-allocates by at least double, and it makes a copy.
+// 	src := encHex[1 : len(encHex)-1]
+// 	if len(src) != PeerIDLength*2 {
+// 		return fmt.Errorf("unmarshalled bytes of wrong length %d", len(src))
+// 	}
+// 	dst := make([]byte, len(src)/2)
+// 	_, err = hex.Decode(dst, src)
+// 	if err == nil {
+// 		var id PeerID
+// 		copy(id[:], dst)
+// 		*p = id
+// 	}
+// 	return err
+// }
+
+// Peer is a network peer, which could be a client or a server node.
+type Peer struct {
+	ID         PeerID               `json:"-"`
+	PubKey     *secp256k1.PublicKey `json:"-"`
+	Bonds      []*Bond              `json:"-"`
+	Reputation *Reputation          `json:"reputation"`
+}
+
+// BondTier sums the tier of the current bond set.
+func (p *Peer) BondTier() (tier uint64) {
+	for _, b := range p.Bonds {
+		tier += b.Strength
+	}
+	return
+}
+
+// Sender is an interface that is implemented by all network connections.
+type Sender interface {
+	Send(*msgjson.Message) error
+	SendRaw([]byte) error
+	Request(msg *msgjson.Message, respHandler func(*msgjson.Message)) error
+	RequestRaw(msgID uint64, rawMsg []byte, respHandler func(*msgjson.Message)) error
+	SetPeerID(PeerID)
+	PeerID() PeerID
+	Disconnect()
+}

--- a/tatanka/tanka/peer_test.go
+++ b/tatanka/tanka/peer_test.go
@@ -1,0 +1,1 @@
+package tanka

--- a/tatanka/tanka/reputation.go
+++ b/tatanka/tanka/reputation.go
@@ -1,0 +1,32 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package tanka
+
+import (
+	"time"
+
+	"decred.org/dcrdex/dex"
+)
+
+const (
+	MaxReputationEntries = 100
+	TierIncrement        = 20
+	MaxScore             = MaxReputationEntries
+	EpochLength          = time.Second * 15
+)
+
+type Reputation struct {
+	Score  int16
+	Points []int8
+}
+
+type Bond struct {
+	PeerID     PeerID    `json:"peerID"`
+	AssetID    uint32    `json:"assetID"`
+	CoinID     dex.Bytes `json:"coinID"`
+	Strength   uint64    `json:"strength"`
+	Expiration time.Time `json:"expiration"`
+}
+
+type HTLCAudit struct{}

--- a/tatanka/tanka/subscriptions.go
+++ b/tatanka/tanka/subscriptions.go
@@ -1,0 +1,7 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package tanka
+
+type Subject string
+type Topic string

--- a/tatanka/tanka/swaps.go
+++ b/tatanka/tanka/swaps.go
@@ -1,0 +1,86 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package tanka
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"time"
+
+	"github.com/decred/dcrd/crypto/blake256"
+)
+
+type Order struct {
+	From    PeerID `json:"from"`
+	BaseID  uint32 `json:"baseID"`
+	QuoteID uint32 `json:"quoteID"`
+	Sell    bool   `json:"sell"`
+	Qty     uint64 `json:"qty"`
+	Rate    uint64 `json:"rate"`
+	// LotSize: Tatankanet does not prescribe a lot size. Instead, users must
+	// select their own minimum minimum lot size. The user's UI should ignore
+	// orderbook orders that don't have the requisite lot size. The UI should
+	// show lot size selection in terms of a sliding scale of fee exposure.
+	// Lot sizes can only be powers of 2.
+	LotSize uint64 `json:"lotSize"`
+	// MinFeeRate: Tatankanet does not prescribe a fee rate on an order, but it
+	// does supply a suggested fee rate that is updated periodically. The user's
+	// UI should ignore an order from the order book if its MinFeeRate falls
+	// below the Tatnkanet suggested rate.
+	MinFeeRate uint64    `json:"minFeeRate"`
+	Stamp      time.Time `json:"stamp"`
+	Expiration time.Time `json:"expiration"`
+}
+
+func (ord *Order) ID() [32]byte {
+	const msgLen = 32 + 4 + 4 + 1 + 8 + 8 + 8 + 8 + 8 + 8
+	b := make([]byte, msgLen)
+	copy(b[:32], ord.From[:])
+	binary.BigEndian.PutUint32(b[32:36], ord.BaseID)
+	binary.BigEndian.PutUint32(b[36:40], ord.QuoteID)
+	if ord.Sell {
+		b[41] = 1
+	}
+	binary.BigEndian.PutUint64(b[41:49], ord.Qty)
+	binary.BigEndian.PutUint64(b[49:57], ord.Rate)
+	binary.BigEndian.PutUint64(b[57:65], ord.LotSize)
+	binary.BigEndian.PutUint64(b[65:73], ord.MinFeeRate)
+	binary.BigEndian.PutUint64(b[73:81], uint64(ord.Stamp.UnixMilli()))
+	binary.BigEndian.PutUint64(b[81:89], uint64(ord.Expiration.UnixMilli()))
+	return blake256.Sum256(b)
+
+}
+
+type ID32 [32]byte
+
+func (i ID32) String() string {
+	return hex.EncodeToString(i[:])
+}
+
+type Match struct {
+	From    PeerID    `json:"from"`
+	OrderID ID32      `json:"orderID"`
+	Qty     uint64    `json:"qty"`
+	Stamp   time.Time `json:"stamp"`
+}
+
+func (m *Match) ID() ID32 {
+	const msgLen = 32 + 32 + 8 + 8
+	b := make([]byte, msgLen)
+	copy(b[:32], m.From[:])
+	copy(b[32:64], m.OrderID[:])
+	binary.BigEndian.PutUint64(b[64:72], m.Qty)
+	binary.BigEndian.PutUint64(b[72:80], uint64(m.Stamp.UnixMilli()))
+	return blake256.Sum256(b)
+}
+
+type MatchAcceptance struct {
+	OrderID ID32 `json:"orderID"`
+	MatchID ID32 `json:"matchID"`
+}
+
+type MarketParameters struct {
+	BaseID  uint32 `json:"baseID"`
+	QuoteID uint32 `json:"quoteID"`
+}

--- a/tatanka/tatanka.go
+++ b/tatanka/tatanka.go
@@ -1,0 +1,680 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package tatanka
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/comms"
+	"decred.org/dcrdex/tatanka/chain"
+	"decred.org/dcrdex/tatanka/db"
+	"decred.org/dcrdex/tatanka/mj"
+	"decred.org/dcrdex/tatanka/tanka"
+	"decred.org/dcrdex/tatanka/tcp"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+const version = 0
+
+// remoteTatanka is a remote tatanka node. A remote tatanka node can either
+// be outgoing (whitelist loop) or incoming via handleInboundTatankaConnect.
+type remoteTatanka struct {
+	*peer
+	cfg atomic.Value // mj.TatankaConfig
+}
+
+type Topic struct {
+	subjects    map[tanka.Subject]map[tanka.PeerID]struct{}
+	subscribers map[tanka.PeerID]struct{}
+}
+
+func (topic *Topic) unsubUser(peerID tanka.PeerID) {
+	if _, found := topic.subscribers[peerID]; !found {
+		return
+	}
+	for subID, subs := range topic.subjects {
+		delete(subs, peerID)
+		if len(subs) == 0 {
+			delete(topic.subjects, subID)
+		}
+	}
+	delete(topic.subscribers, peerID)
+}
+
+// BootNode represents a configured boot node. Tatanka is whitelist only, and
+// node operators are responsible for keeping their whitelist up to date.
+type BootNode struct {
+	// Protocol is one of ("ws", "wss"), though other tatanka comms protocols
+	// may be implemented later. Or we may end up using e.g. go-libp2p.
+	Protocol string
+	PeerID   dex.Bytes
+	// Config can take different forms depending on the comms protocol, but is
+	// probably a tcp.RemoteNodeConfig.
+	Config json.RawMessage
+}
+
+// parsedBootNode is the unexported version of BootNode, but with a PeerID
+// instead of []byte.
+type parsedBootNode struct {
+	peerID   tanka.PeerID
+	cfg      json.RawMessage
+	protocol string
+}
+
+// Tatanka is a server node on Tatanka Mesh. Tatanka implements two APIs, one
+// for fellow tatanka nodes, and one for clients. The primary roles of a
+// tatanka node are
+//  1. Maintain reputation information about client nodes.
+//  2. Distribute broadcasts and relay tankagrams.
+//  3. Provide some basic oracle services.
+type Tatanka struct {
+	net       dex.Network
+	log       dex.Logger
+	tcpSrv    *tcp.Server
+	dataDir   string
+	ctx       context.Context
+	wg        *sync.WaitGroup
+	whitelist map[tanka.PeerID]*parsedBootNode
+	db        *db.DB
+	nets      atomic.Value // []uint32
+	handlers  map[string]func(tanka.Sender, *msgjson.Message) *msgjson.Error
+	routes    []string
+	// bondTier  atomic.Uint64
+
+	priv *secp256k1.PrivateKey
+	id   tanka.PeerID
+
+	chainMtx sync.RWMutex
+	chains   map[uint32]chain.Chain
+
+	relayMtx     sync.Mutex
+	recentRelays map[[32]byte]time.Time
+
+	clientMtx sync.RWMutex
+	clients   map[tanka.PeerID]*client
+	topics    map[tanka.Topic]*Topic
+
+	clientJobs    chan *clientJob
+	remoteClients map[tanka.PeerID]map[tanka.PeerID]struct{}
+
+	tatankasMtx sync.RWMutex
+	tatankas    map[tanka.PeerID]*remoteTatanka
+}
+
+// Config is the configuration of the Tatanka.
+type Config struct {
+	Net        dex.Network
+	DataDir    string
+	Logger     dex.Logger
+	RPC        comms.RPCConfig
+	ConfigPath string
+
+	// TODO: Change to whitelist
+	WhiteList []BootNode
+}
+
+func New(cfg *Config) (*Tatanka, error) {
+	chainCfg, err := loadConfig(cfg.ConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("error loading config %w", err)
+	}
+
+	chains := make(map[uint32]chain.Chain)
+	nets := make([]uint32, 0, len(chainCfg.Chains))
+	for _, c := range chainCfg.Chains {
+		chainID, found := dex.BipSymbolID(c.Symbol)
+		if !found {
+			return nil, fmt.Errorf("no chain ID found for symbol %s", c.Symbol)
+		}
+		chains[chainID], err = chain.New(chainID, c.Config, cfg.Logger.SubLogger(c.Symbol), cfg.Net)
+		if err != nil {
+			return nil, fmt.Errorf("error creating chain backend: %w", err)
+		}
+		nets = append(nets, chainID)
+	}
+
+	db, err := db.New(filepath.Join(cfg.DataDir, "db"), cfg.Logger.SubLogger("DB"))
+	if err != nil {
+		return nil, fmt.Errorf("db.New error: %w", err)
+	}
+
+	keyPath := filepath.Join(cfg.DataDir, "priv.key")
+	keyB, err := os.ReadFile(keyPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("error reading key file")
+		}
+		cfg.Logger.Infof("No key file found. Generating new identity.")
+		priv, err := secp256k1.GeneratePrivateKey()
+		if err != nil {
+			return nil, fmt.Errorf("GeneratePrivateKey error: %w", err)
+		}
+		keyB = priv.Serialize()
+	}
+	priv := secp256k1.PrivKeyFromBytes(keyB)
+	var peerID tanka.PeerID
+	copy(peerID[:], priv.PubKey().SerializeCompressed())
+
+	whitelist := make(map[tanka.PeerID]*parsedBootNode, len(cfg.WhiteList))
+	for _, n := range cfg.WhiteList {
+		if len(n.PeerID) != tanka.PeerIDLength {
+			return nil, fmt.Errorf("invalid peer ID length %d for %s boot node with configuration %q", len(n.PeerID), n.Protocol, n.Config)
+		}
+		var peerID tanka.PeerID
+		copy(peerID[:], n.PeerID)
+		whitelist[peerID] = &parsedBootNode{
+			peerID:   peerID,
+			cfg:      n.Config,
+			protocol: n.Protocol,
+		}
+	}
+
+	t := &Tatanka{
+		net:           cfg.Net,
+		dataDir:       cfg.DataDir,
+		log:           cfg.Logger,
+		whitelist:     whitelist,
+		db:            db,
+		priv:          priv,
+		id:            peerID,
+		chains:        chains,
+		tatankas:      make(map[tanka.PeerID]*remoteTatanka),
+		clients:       make(map[tanka.PeerID]*client),
+		remoteClients: make(map[tanka.PeerID]map[tanka.PeerID]struct{}),
+		topics:        make(map[tanka.Topic]*Topic),
+		recentRelays:  make(map[[32]byte]time.Time),
+		clientJobs:    make(chan *clientJob, 128),
+	}
+	t.nets.Store(nets)
+	t.prepareHandlers()
+	t.tcpSrv, err = tcp.NewServer(&cfg.RPC, &tcpCore{t}, cfg.Logger.SubLogger("TCP"))
+	if err != nil {
+		return nil, fmt.Errorf("error starting TPC server:: %v", err)
+	}
+
+	return t, nil
+}
+
+func (t *Tatanka) prepareHandlers() {
+	t.handlers = map[string]func(tanka.Sender, *msgjson.Message) *msgjson.Error{
+		// tatanka messages
+		mj.RouteTatankaConnect:   t.handleInboundTatankaConnect,
+		mj.RouteTatankaConfig:    t.handleTatankaMessage,
+		mj.RouteRelayBroadcast:   t.handleTatankaMessage,
+		mj.RouteNewClient:        t.handleTatankaMessage,
+		mj.RouteClientDisconnect: t.handleTatankaMessage,
+		mj.RouteRelayTankagram:   t.handleTatankaMessage,
+		mj.RoutePathInquiry:      t.handleTatankaMessage,
+		// client messages
+		mj.RouteConnect:     t.handleClientConnect,
+		mj.RoutePostBond:    t.handlePostBond,
+		mj.RouteSubscribe:   t.handleClientMessage,
+		mj.RouteUnsubscribe: t.handleClientMessage,
+		mj.RouteBroadcast:   t.handleClientMessage,
+		mj.RouteTankagram:   t.handleClientMessage,
+	}
+	for route := range t.handlers {
+		t.routes = append(t.routes, route)
+	}
+}
+
+func (t *Tatanka) assets() []uint32 {
+	return t.nets.Load().([]uint32)
+}
+
+func (t *Tatanka) tatankaNodes() []*remoteTatanka {
+	t.tatankasMtx.RLock()
+	defer t.tatankasMtx.RUnlock()
+	nodes := make([]*remoteTatanka, 0, len(t.tatankas))
+	for _, n := range t.tatankas {
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
+func (t *Tatanka) tatankaNode(peerID tanka.PeerID) *remoteTatanka {
+	t.tatankasMtx.RLock()
+	defer t.tatankasMtx.RUnlock()
+	return t.tatankas[peerID]
+}
+
+func (t *Tatanka) clientNode(peerID tanka.PeerID) *client {
+	t.clientMtx.RLock()
+	defer t.clientMtx.RUnlock()
+	return t.clients[peerID]
+}
+
+func (t *Tatanka) Connect(ctx context.Context) (_ *sync.WaitGroup, err error) {
+	t.ctx = ctx
+	var wg sync.WaitGroup
+	t.wg = &wg
+
+	t.log.Infof("Starting Tatanka node with peer ID %s", t.id)
+
+	// Start WebSocket server
+	cm := dex.NewConnectionMaster(t.tcpSrv)
+	if err := cm.ConnectOnce(ctx); err != nil {
+		return nil, fmt.Errorf("error connecting TCP server: %v", err)
+	}
+
+	wg.Add(1)
+	go func() {
+		cm.Wait()
+		wg.Done()
+	}()
+
+	// Start a ticker to clean up the recent relays map.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tick := time.NewTicker(tanka.EpochLength * 4) // 1 minute
+		for {
+			select {
+			case <-tick.C:
+				t.relayMtx.Lock()
+				for bid, stamp := range t.recentRelays {
+					if time.Since(stamp) > time.Minute {
+						delete(t.recentRelays, bid)
+					}
+				}
+				t.relayMtx.Unlock()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		t.runRemoteClientsLoop(ctx)
+	}()
+
+	var success bool
+	defer func() {
+		if !success {
+			cm.Disconnect()
+			cm.Wait()
+		}
+	}()
+
+	t.chainMtx.RLock()
+	for assetID, c := range t.chains {
+		feeRater, is := c.(chain.FeeRater)
+		if !is {
+			continue
+		}
+		wg.Add(1)
+		go func(assetID uint32, feeRater chain.FeeRater) {
+			defer wg.Done()
+			t.monitorChainFees(ctx, assetID, feeRater)
+		}(assetID, feeRater)
+	}
+	t.chainMtx.RUnlock()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		t.runWhitelistLoop(ctx)
+	}()
+
+	success = true
+	return &wg, nil
+}
+
+// runWhitelistLoop attempts to connect to the whitelist, and then periodically
+// tries again.
+func (t *Tatanka) runWhitelistLoop(ctx context.Context) {
+	connectWhitelist := func() {
+		for proto, n := range t.whitelist {
+			t.tatankasMtx.RLock()
+			_, exists := t.tatankas[n.peerID]
+			t.tatankasMtx.RUnlock()
+			if exists {
+				continue
+			}
+
+			p, rrs, err := t.loadPeer(n.peerID)
+			if err != nil {
+				t.log.Errorf("error getting peer info for boot node at %q (proto %q): %v", string(n.cfg), proto, err)
+				continue
+			}
+
+			bondTier := p.BondTier()
+			// TODO: Check Tatanka Node reputation too
+			// if calcTier(rep, bondTier) <= 0 {
+			// 	t.log.Errorf("not attempting to contact banned boot node at %q (proto %q)", string(n.cfg), proto)
+			// }
+
+			handleDisconnect := func() {
+				// TODO: schedule a reconnect?
+				t.tatankasMtx.Lock()
+				delete(t.tatankas, p.ID)
+				t.tatankasMtx.Unlock()
+			}
+
+			handleMessage := func(cl tanka.Sender, msg *msgjson.Message) {
+				t.handleTatankaMessage(cl, msg)
+			}
+
+			var cl tanka.Sender
+			switch n.protocol {
+			case "ws", "wss":
+				cl, err = t.tcpSrv.ConnectBootNode(ctx, n.cfg, handleMessage, handleDisconnect)
+			default:
+				t.log.Errorf("unknown boot node network protocol: %s", proto)
+				continue
+			}
+			if err != nil {
+				t.log.Errorf("error connecting boot node with proto = %s, config = %s", proto, string(n.cfg))
+				continue
+			}
+
+			t.log.Infof("Connected to boot node with peer ID %s, config %s", n.peerID, string(n.cfg))
+
+			cl.SetPeerID(p.ID)
+			pp := &peer{Peer: p, Sender: cl, rrs: rrs}
+			tt := &remoteTatanka{peer: pp}
+			t.tatankasMtx.Lock()
+			t.tatankas[p.ID] = tt
+			t.tatankasMtx.Unlock()
+
+			cfgMsg := mj.MustRequest(mj.RouteTatankaConnect, t.generateConfig(bondTier))
+			if err := t.request(cl, cfgMsg, func(msg *msgjson.Message) {
+				// Nothing to do. The only non-error result is payload = true.
+			}); err != nil {
+				t.log.Errorf("Error sending connect message: %w", err)
+				cl.Disconnect()
+			}
+		}
+	}
+
+	for {
+		connectWhitelist()
+
+		select {
+		case <-time.After(time.Minute * 5):
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// monitorChainFees monitors chains for new fee rates, and will distribute them
+// as part of the not-yet-implemented oracle services the mesh provides.
+func (t *Tatanka) monitorChainFees(ctx context.Context, assetID uint32, c chain.FeeRater) {
+	feeC := c.FeeChannel()
+	for {
+		select {
+		case feeRate := <-feeC:
+			// TODO: Distribute the fee rate to other Tatanka nodes, then to
+			// clients. Should fee rates be averaged across tatankas somehow?
+			fmt.Printf("new fee rate from %s: %d\n", dex.BipIDSymbol(assetID), feeRate)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// sendResult sends the response to a request and logs errors.
+func (t *Tatanka) sendResult(cl tanka.Sender, msgID uint64, result interface{}) {
+	resp := mj.MustResponse(msgID, result, nil)
+	if err := t.send(cl, resp); err != nil {
+		peerID := cl.PeerID()
+		t.log.Errorf("error sending result to %q: %v", dex.Bytes(peerID[:]), err)
+	}
+}
+
+// batchSend must be called with the clientMtx >= RLocked.
+func (t *Tatanka) batchSend(peers map[tanka.PeerID]struct{}, msg *msgjson.Message) {
+	mj.SignMessage(t.priv, msg)
+	msgB, err := json.Marshal(msg)
+	if err != nil {
+		t.log.Errorf("error marshaling batch send message: %v", err)
+		return
+	}
+	disconnects := make(map[tanka.PeerID]struct{})
+	t.clientMtx.RLock()
+	for peerID := range peers {
+		if c, found := t.clients[peerID]; found {
+			if err := c.SendRaw(msgB); err != nil {
+				t.log.Tracef("Disconnecting client %s after SendRaw error: %v", peerID, err)
+				disconnects[peerID] = struct{}{}
+			}
+		} else {
+			t.log.Error("found a subscriber ID without a client")
+		}
+	}
+	t.clientMtx.RUnlock()
+	if len(disconnects) > 0 {
+		for peerID := range disconnects {
+			t.clientDisconnected(peerID)
+		}
+	}
+}
+
+// send signs and sends the message, returning any errors.
+func (t *Tatanka) send(s tanka.Sender, msg *msgjson.Message) error {
+	mj.SignMessage(t.priv, msg)
+	err := s.Send(msg)
+	if err != nil {
+		t.clientDisconnected(s.PeerID())
+	}
+	return err
+}
+
+// request signs and sends the request, returning any errors.
+func (t *Tatanka) request(s tanka.Sender, msg *msgjson.Message, respHandler func(*msgjson.Message)) error {
+	mj.SignMessage(t.priv, msg)
+	err := s.Request(msg, respHandler)
+	if err != nil {
+		t.clientDisconnected(s.PeerID())
+	}
+	return err
+}
+
+// loadPeer loads and resolves peer reputation data from the database.
+func (t *Tatanka) loadPeer(peerID tanka.PeerID) (*tanka.Peer, map[tanka.PeerID]*mj.RemoteReputation, error) {
+	p, err := t.db.GetPeer(peerID)
+	if err == nil {
+		return p, nil, nil
+	}
+
+	if !errors.Is(err, db.ErrNotFound) {
+		return nil, nil, err
+	}
+	pubKey, err := secp256k1.ParsePubKey(peerID[:])
+	if err != nil {
+		return nil, nil, fmt.Errorf("ParsePubKey error: %w", err)
+	}
+	rep, rrs, err := t.resolveReputation(peerID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error fetching reputation: %w", err)
+	}
+
+	return &tanka.Peer{
+		ID:         peerID,
+		PubKey:     pubKey,
+		Reputation: rep,
+	}, rrs, nil
+}
+
+// resolveReputation constructs a user reputation, doing a "soft sync" with
+// the mesh if our data is scant.
+func (t *Tatanka) resolveReputation(peerID tanka.PeerID) (*tanka.Reputation, map[tanka.PeerID]*mj.RemoteReputation, error) {
+	rep, err := t.db.Reputation(peerID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error fetching reputation: %w", err)
+	}
+	// If we have a fully-established reputation, we don't care what our peers
+	// think of this guy.
+	if len(rep.Points) == tanka.MaxReputationEntries {
+		return rep, nil, nil
+	}
+
+	if true {
+		fmt.Println("!!!! Skipping reputation resolution")
+		return rep, nil, nil
+	}
+
+	// We don't have enough info. We'll reach out to others to see what we can
+	// figure out.
+	tankas := t.tatankaNodes()
+	n := len(tankas)
+	type res struct {
+		rr *mj.RemoteReputation
+		id tanka.PeerID
+	}
+	resC := make(chan *res)
+
+	report := func(rr *res) {
+		select {
+		case resC <- rr:
+		case <-time.After(time.Second):
+			t.log.Errorf("blocking remote reputation result channel")
+		}
+	}
+
+	requestReputation := func(tt *remoteTatanka) {
+		req := mj.MustRequest(mj.RouteGetReputation, nil)
+		t.request(tt, req, func(respMsg *msgjson.Message) {
+			var rr mj.RemoteReputation
+			if err := respMsg.UnmarshalResult(&rr); err == nil {
+				report(&res{
+					id: tt.ID,
+					rr: &rr,
+				})
+			} else {
+				t.log.Errorf("error requesting remote reputation from %q: %v", tt.ID, err)
+				report(nil)
+			}
+		})
+	}
+	for _, tt := range tankas {
+		requestReputation(tt)
+	}
+
+	received := make(map[tanka.PeerID]*mj.RemoteReputation, n)
+	timedOut := time.After(time.Second * 10)
+
+out:
+	for {
+		select {
+		case res := <-resC:
+			received[res.id] = res.rr
+			if len(received) == n {
+				break out
+			}
+		case <-timedOut:
+			t.log.Errorf("timed out waiting for remote reputations. %d received out of %d requested", len(received), len(tankas))
+			break out
+		}
+	}
+	return rep, received, nil
+}
+
+func (t *Tatanka) generateConfig(bondTier uint64) *mj.TatankaConfig {
+	return &mj.TatankaConfig{
+		ID:       t.id,
+		Version:  version,
+		Chains:   t.assets(),
+		BondTier: bondTier,
+	}
+}
+
+func calcTier(r *tanka.Reputation, bondTier uint64) int64 {
+	return int64(bondTier) + int64(r.Score)/tanka.TierIncrement
+}
+
+// ChainConfig is how the chain configuration is specified in the Tatanka
+// configuration file.
+type ChainConfig struct {
+	Symbol string          `json:"symbol"`
+	Config json.RawMessage `json:"config"`
+}
+
+// ConfigFile represents the JSON Tatanka configuration file.
+type ConfigFile struct {
+	Chains []ChainConfig `json:"chains"`
+}
+
+func loadConfig(configPath string) (*ConfigFile, error) {
+	var cfg ConfigFile
+	b, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("OpenFile error: %w", err)
+	}
+	return &cfg, json.Unmarshal(b, &cfg)
+}
+
+// tcpCore implements tcp.TankaCore.
+type tcpCore struct {
+	*Tatanka
+}
+
+func (t *tcpCore) Routes() []string {
+	return t.routes
+}
+
+func (t *tcpCore) HandleMessage(cl tanka.Sender, msg *msgjson.Message) *msgjson.Error {
+	if t.log.Level() == dex.LevelTrace {
+		t.log.Tracef("Tatanka node handling message. route = %s, payload = %s", msg.Route, mj.Truncate(msg.Payload))
+	}
+
+	handle, found := t.handlers[msg.Route]
+	if !found {
+		return msgjson.NewError(mj.ErrBadRequest, "route %q not known", msg.Route)
+	}
+	return handle(cl, msg)
+}
+
+// clientDisconnected handle a client disconnect, removing the client from the
+// clients map and unsubscribing from all topics.
+func (t *Tatanka) clientDisconnected(peerID tanka.PeerID) {
+	unsubs := make(map[tanka.Topic]*Topic)
+
+	t.clientMtx.Lock()
+	delete(t.clients, peerID)
+	for n, topic := range t.topics {
+		if _, found := topic.subscribers[peerID]; found {
+			unsubs[n] = topic
+			delete(topic.subscribers, peerID)
+			for _, subs := range topic.subjects {
+				delete(subs, peerID)
+			}
+		}
+	}
+	t.clientMtx.Unlock()
+
+	if len(unsubs) == 0 {
+		return
+	}
+
+	stamp := time.Now()
+	for n, topic := range unsubs {
+		note := mj.MustNotification(mj.RouteBroadcast, &mj.Broadcast{
+			Topic:       n,
+			PeerID:      peerID,
+			MessageType: mj.MessageTypeUnsubTopic,
+			Stamp:       stamp,
+		})
+		t.batchSend(topic.subscribers, note)
+	}
+
+	note := mj.MustNotification(mj.RouteClientDisconnect, &mj.Disconnect{ID: peerID})
+	mj.SignMessage(t.priv, note)
+	for _, tt := range t.tatankaNodes() {
+		tt.Send(note)
+	}
+}

--- a/tatanka/tatanka.go
+++ b/tatanka/tatanka.go
@@ -161,6 +161,9 @@ func New(cfg *Config) (*Tatanka, error) {
 			return nil, fmt.Errorf("GeneratePrivateKey error: %w", err)
 		}
 		keyB = priv.Serialize()
+		if os.WriteFile(keyPath, keyB, 0600); err != nil {
+			return nil, fmt.Errorf("error writing newly-generated key to %q: %v", keyPath, err)
+		}
 	}
 	priv := secp256k1.PrivKeyFromBytes(keyB)
 	var peerID tanka.PeerID

--- a/tatanka/tatanka_messages.go
+++ b/tatanka/tatanka_messages.go
@@ -1,0 +1,283 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package tatanka
+
+import (
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/tatanka/mj"
+	"decred.org/dcrdex/tatanka/tanka"
+)
+
+// handleInboundTatankaConnect handles an inbound tatanka connection.
+func (t *Tatanka) handleInboundTatankaConnect(cl tanka.Sender, msg *msgjson.Message) *msgjson.Error {
+	var cfg mj.TatankaConfig
+	if err := msg.Unmarshal(&cfg); err != nil {
+		return msgjson.NewError(mj.ErrBadRequest, "unmarshal error: %v", err)
+	}
+
+	p, rrs, err := t.loadPeer(cfg.ID)
+	if err != nil {
+		return msgjson.NewError(mj.ErrInternal, "error finding peer: %v", err)
+	}
+
+	if err := mj.CheckSig(msg, p.PubKey); err != nil {
+		return msgjson.NewError(mj.ErrAuth, "bad sig")
+	}
+
+	// if calcTier(rep, p.BondTier()) <= 0 {
+	// 	return msgjson.NewError(mj.ErrAuth, "denying inbound banned tatanka node %q", p.ID)
+	// }
+
+	cfgMsg := mj.MustNotification(mj.RouteTatankaConfig, t.generateConfig(p.BondTier()))
+	if err := t.send(cl, cfgMsg); err != nil {
+		peerID := cl.PeerID()
+		t.log.Errorf("error sending configuration to connecting tatanka %q", dex.Bytes(peerID[:]))
+		cl.Disconnect()
+		return nil // don't bother
+	}
+
+	// TODO: Resolve our own bond tier with the tatanka node.
+	// myTier := t.bondTier.Load()
+	// if conn.BondTier != myTier {
+	// 	bonds, err := t.db.GetBonds(t.id)
+	// 	if err != nil {
+	// 		t.log.Errorf("Error getting bonds from DB: %v", err)
+	// 		return msgjson.NewError(mj.ErrInternal, "internal error")
+	// 	}
+	// 	var bondTier uint64
+	// 	for _, b := range bonds {
+	// 		bondTier += b.Strength
+	// 	}
+	// 	if conn.BondTier != myTier {
+	// 		bondsUpdate := mj.MustNotification(mj.RouteBonds, bonds)
+	// 		if err := cl.Send(bondsUpdate); err != nil {
+	// 			t.log.Errorf("Error sending bonds update to %s during connect: %w", p.ID, err)
+	// 			cl.Disconnect()
+	// 			return nil
+	// 		}
+	// 	}
+
+	// }
+
+	cl.SetPeerID(cfg.ID)
+
+	t.tatankasMtx.Lock()
+	// TODO: Track peer reconnections and ban peer if on a runaway.
+	if _, exists := t.tatankas[p.ID]; exists {
+		t.log.Debugf("Connecting Tatanka node %s replaces already connected node", cl.PeerID())
+	}
+
+	pp := &peer{Peer: p, Sender: cl, rrs: rrs}
+
+	// TODO: Check Tatanka Node reputation too
+	// if pp.banned() {
+	// 	t.tatankasMtx.Unlock()
+	// 	return msgjson.NewError(mj.ErrAuth, "inbound peer %q is banned", p.ID)
+	// }
+
+	tt := &remoteTatanka{peer: pp}
+	tt.cfg.Store(&cfg)
+	t.tatankas[cfg.ID] = tt
+	t.tatankasMtx.Unlock()
+
+	t.sendResult(cl, msg.ID, true)
+
+	return nil
+}
+
+// handleTatankaMessage handles all messages from remote tatanka nodes except
+// for mj.RouteTatankaConnect. The node is expected to already be connected.
+// handleTatankaMessage perfoms some initial  handling of the message, like
+// fetching the *remoteTatanka and checking signatures, before finding calling
+// the appropriate handler.
+func (t *Tatanka) handleTatankaMessage(cl tanka.Sender, msg *msgjson.Message) *msgjson.Error {
+	if t.log.Level() == dex.LevelTrace {
+		t.log.Tracef("Tatanka node handling message from remote tatanka. route = %s, payload = %s", msg.Route, mj.Truncate(msg.Payload))
+	}
+
+	peerID := cl.PeerID()
+	tt := t.tatankaNode(peerID)
+	if tt == nil {
+		t.log.Errorf("%q (%d) message received from unknown outbound tatanka peer %q", msg.Route, msg.ID, peerID)
+		return msgjson.NewError(mj.ErrAuth, "who even is this?")
+	}
+
+	if err := mj.CheckSig(msg, tt.PubKey); err != nil {
+		t.log.Errorf("Signature error for %q message from %q: %v", msg.Route, tt.ID, err)
+		return msgjson.NewError(mj.ErrSig, "signature doesn't check")
+	}
+
+	// The first message received after mj.RouteTatankaConnect must be the
+	// config.
+	if msg.Route != mj.RouteTatankaConfig && tt.cfg.Load() == nil {
+		t.log.Errorf("message received from tatanka peer %q before configuration", peerID)
+		tt.Disconnect()
+		return msgjson.NewError(mj.ErrNoConfig, "send your configuration first")
+	}
+
+	switch msg.Type {
+	case msgjson.Request:
+		switch msg.Route {
+		case mj.RouteRelayTankagram:
+			return t.handleRelayedTankagram(tt, msg)
+		case mj.RoutePathInquiry:
+			return t.handlePathInquiry(tt, msg)
+		default:
+			return msgjson.NewError(mj.ErrBadRequest, "unknown request route %q", msg.Route)
+		}
+	case msgjson.Notification:
+		switch msg.Route {
+		case mj.RouteNewClient:
+			t.handleNewRemoteClientNotification(tt.ID, msg)
+		case mj.RouteClientDisconnect:
+			t.handleRemoteClientDisconnect(tt.ID, msg)
+		case mj.RouteTatankaConfig:
+			t.handleTatankaConfig(tt, msg)
+		case mj.RouteRelayBroadcast:
+			t.handleRelayBroadcast(tt, msg)
+		default:
+			// TODO: What? Can't let this happen too much.
+			return msgjson.NewError(mj.ErrBadRequest, "unknown notification route %q", msg.Route)
+		}
+	default:
+		return msgjson.NewError(mj.ErrBadRequest, "unknown message type %d", msg.Type)
+	}
+	return nil
+}
+
+// handleRelayedTankagram handles a tankagram relayed from another node. The
+// mesh is currently only capable of single-hop relays.
+func (t *Tatanka) handleRelayedTankagram(tt *remoteTatanka, msg *msgjson.Message) *msgjson.Error {
+	var gram *mj.Tankagram
+	if err := msg.Unmarshal(&gram); err != nil {
+		t.log.Errorf("Error unmarshaling tankagram from %s: %w", tt.ID, err)
+		return msgjson.NewError(mj.ErrBadRequest, "unmarshal error")
+	}
+
+	t.clientMtx.RLock()
+	c, found := t.clients[gram.To]
+	t.clientMtx.RUnlock()
+	if !found {
+		t.sendResult(tt, msg.ID, &mj.TankagramResult{Result: mj.TRTNoPath})
+		t.log.Warnf("Tankagram relay from %s to unknown client %s", tt.ID, gram.To)
+		return nil
+	}
+
+	relayedMsg := mj.MustRequest(mj.RouteTankagram, gram)
+	var resB dex.Bytes
+	sent, clientErr, err := t.requestAnyOne([]tanka.Sender{c}, relayedMsg, &resB)
+	if sent {
+		t.sendResult(tt, msg.ID, &mj.TankagramResult{Result: mj.TRTTransmitted, Response: resB})
+		return nil
+	}
+	if clientErr != nil {
+		t.sendResult(tt, msg.ID, &mj.TankagramResult{Result: mj.TRTErrBadClient})
+		return nil
+	}
+	if err != nil {
+		t.log.Errorf("Error sending to local client %s: %v", gram.To, err)
+		t.sendResult(tt, msg.ID, &mj.TankagramResult{Result: mj.TRTErrFromTanka})
+		return nil
+	}
+	// We might get here if the context expires during the call to requestOne.
+	return nil
+}
+
+// handlePathInquire returns whether a particular client is connected to this
+// node.
+func (t *Tatanka) handlePathInquiry(tt *remoteTatanka, msg *msgjson.Message) *msgjson.Error {
+	var inq mj.PathInquiry
+	if err := msg.Unmarshal(&inq); err != nil {
+		t.log.Errorf("Failed to unmarshal path inquiry from %s: %v", tt.ID, err)
+	}
+
+	t.clientMtx.RLock()
+	_, found := t.clients[inq.ID]
+	t.clientMtx.RUnlock()
+	t.sendResult(tt, msg.ID, found)
+	return nil
+}
+
+// handleNewRemoteClientNotification handles an mj.RouteNewClient notification,
+// updating the t.remoteClients map.
+func (t *Tatanka) handleNewRemoteClientNotification(ttID tanka.PeerID, msg *msgjson.Message) {
+	if t.skipRelay(msg) {
+		return
+	}
+
+	var conn mj.Connect
+	if err := msg.Unmarshal(&conn); err != nil {
+		t.log.Errorf("error unmarshaling %s notification payload: %q", msg.Route, err)
+		return
+	}
+	t.registerRemoteClient(ttID, conn.ID)
+}
+
+// handleRemoteClientDisconnect handles an mj.RouteClientDisconnect
+// notification, updating the t.remoteClients map.
+func (t *Tatanka) handleRemoteClientDisconnect(ttID tanka.PeerID, msg *msgjson.Message) {
+	if t.skipRelay(msg) {
+		return
+	}
+
+	var dconn mj.Disconnect
+	if err := msg.Unmarshal(&dconn); err != nil {
+		t.log.Errorf("error unmarshaling %s notification payload: %q", msg.Route, err)
+		return
+	}
+
+	job := &clientJob{
+		task: &clientJobRemoteDisconnect{
+			clientID: dconn.ID,
+			tankaID:  ttID,
+		},
+		res: make(chan interface{}, 1),
+	}
+	t.clientJobs <- job
+	<-job.res
+}
+
+// handleTatankaConfig handles the mj.RouteTatankaConfig notification,
+// storing a remote tatanka node's updated configuration info.
+func (t *Tatanka) handleTatankaConfig(tt *remoteTatanka, msg *msgjson.Message) {
+	peerID := tt.PeerID()
+
+	var cfg mj.TatankaConfig
+	if err := msg.Unmarshal(&cfg); err != nil {
+		tt.Disconnect()
+		t.log.Errorf("failed to parse tatanka config from %q: %w", peerID, err)
+		return
+	}
+
+	tt.cfg.Store(&cfg)
+}
+
+// handleRelayBroadcast distributes the broadcast to any locally connected
+// subscribers.
+func (t *Tatanka) handleRelayBroadcast(tt *remoteTatanka, msg *msgjson.Message) {
+	if t.skipRelay(msg) {
+		return
+	}
+
+	var bcast *mj.Broadcast
+	if err := msg.Unmarshal(&bcast); err != nil || bcast == nil || bcast.Topic == "" {
+		t.log.Errorf("error unmarshaling broadcast from %s: %w", tt.ID, err)
+		return
+	}
+
+	if time.Since(bcast.Stamp) > tanka.EpochLength || time.Until(bcast.Stamp) > tanka.EpochLength {
+		t.log.Errorf("Ignoring relayed broadcast with old stamp received from %s", tt.ID)
+		return
+	}
+
+	t.registerRemoteClient(tt.ID, tt.ID)
+
+	if msgErr := t.distributeBroadcastedMessage(bcast, false); msgErr != nil {
+		t.log.Errorf("error distributing broadcast: %v", msgErr)
+		return
+	}
+}

--- a/tatanka/tatanka_messages.go
+++ b/tatanka/tatanka_messages.go
@@ -19,6 +19,10 @@ func (t *Tatanka) handleInboundTatankaConnect(cl tanka.Sender, msg *msgjson.Mess
 		return msgjson.NewError(mj.ErrBadRequest, "unmarshal error: %v", err)
 	}
 
+	if _, found := t.whitelist[cfg.ID]; !found {
+		return msgjson.NewError(mj.ErrAuth, "not whitelisted")
+	}
+
 	p, rrs, err := t.loadPeer(cfg.ID)
 	if err != nil {
 		return msgjson.NewError(mj.ErrInternal, "error finding peer: %v", err)

--- a/tatanka/tatanka_test.go
+++ b/tatanka/tatanka_test.go
@@ -1,0 +1,213 @@
+package tatanka
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/encode"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/tatanka/mj"
+	"decred.org/dcrdex/tatanka/tanka"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+type tSender struct {
+	id           tanka.PeerID
+	disconnected bool
+	responseErr  error
+	responses    []*msgjson.Message
+	recvd        []*msgjson.Message
+	sendErr      error
+}
+
+func tNewSender(peerID tanka.PeerID) *tSender {
+	return &tSender{id: peerID}
+}
+
+func (s *tSender) queueResponse(resp *msgjson.Message) {
+	s.responses = append(s.responses, resp)
+}
+
+func (s *tSender) received() *msgjson.Message {
+	if len(s.recvd) == 0 {
+		return nil
+	}
+	msg := s.recvd[0]
+	s.recvd = s.recvd[1:]
+	return msg
+}
+
+func (s *tSender) Send(msg *msgjson.Message) error {
+	s.recvd = append(s.recvd, msg)
+	return s.sendErr
+}
+func (s *tSender) SendRaw(rawMsg []byte) error {
+	msg, err := msgjson.DecodeMessage(rawMsg)
+	if err != nil {
+		return fmt.Errorf("tSender DecodeMessage error: %w", err)
+	}
+	s.recvd = append(s.recvd, msg)
+	return s.sendErr
+}
+func (s *tSender) Request(msg *msgjson.Message, respHandler func(*msgjson.Message)) error {
+	return s.RequestRaw(0, nil, respHandler)
+}
+func (s *tSender) RequestRaw(msgID uint64, rawMsg []byte, respHandler func(*msgjson.Message)) error {
+	if s.responseErr != nil {
+		return s.responseErr
+	}
+	if len(s.responses) == 0 {
+		return errors.New("not test responses queued")
+	}
+	resp := s.responses[0]
+	s.responses = s.responses[1:]
+	go respHandler(resp) // goroutine to simulate Sender impls
+	return nil
+}
+func (s *tSender) SetPeerID(tanka.PeerID) {}
+
+func (s *tSender) PeerID() tanka.PeerID {
+	return s.id
+}
+func (s *tSender) Disconnect() {
+	s.disconnected = true
+}
+
+func tNewTatanka(id byte) (*Tatanka, func()) {
+	priv, _ := secp256k1.GeneratePrivateKey()
+	var peerID tanka.PeerID
+	peerID[tanka.PeerIDLength-1] = id
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	srv := &Tatanka{
+		ctx: ctx,
+		net: dex.Simnet,
+		log: dex.StdOutLogger("T", dex.LevelTrace),
+		// db:            db,
+		priv: priv,
+		id:   peerID,
+		// chains:        chains,
+		tatankas:      make(map[tanka.PeerID]*remoteTatanka),
+		clients:       make(map[tanka.PeerID]*client),
+		remoteClients: make(map[tanka.PeerID]map[tanka.PeerID]struct{}),
+		topics:        make(map[tanka.Topic]*Topic),
+		recentRelays:  make(map[[32]byte]time.Time),
+		clientJobs:    make(chan *clientJob, 128),
+	}
+
+	go srv.runRemoteClientsLoop(ctx)
+
+	return srv, cancel
+}
+
+func tNewPeer(id byte) (*peer, *tSender) {
+	var peerID tanka.PeerID
+	peerID[tanka.PeerIDLength-1] = id
+	p := &tanka.Peer{ID: peerID}
+	s := tNewSender(peerID)
+	return &peer{Peer: p, Sender: s, rrs: make(map[tanka.PeerID]*mj.RemoteReputation)}, s
+}
+
+func tNewRemoteTatanka(id byte) (*remoteTatanka, *tSender) {
+	p, s := tNewPeer(id)
+	return &remoteTatanka{peer: p}, s
+}
+
+func tNewClient(id byte) (*client, *tSender) {
+	p, s := tNewPeer(id)
+	return &client{peer: p}, s
+}
+
+func TestTankagrams(t *testing.T) {
+	srv, shutdown := tNewTatanka(0)
+	defer shutdown()
+
+	tt, tts := tNewRemoteTatanka(1)
+	srv.tatankas[tt.ID] = tt
+
+	c0, c0s := tNewClient(2)
+	srv.clients[c0.ID] = c0
+
+	c1, c1s := tNewClient(3)
+	srv.clients[c1.ID] = c1
+
+	gram := &mj.Tankagram{
+		From: c0.ID,
+		To:   c1.ID,
+	}
+	msg := mj.MustRequest(mj.RouteTankagram, gram)
+	var r mj.TankagramResult
+	checkResponse := func(expResult mj.TankagramResultType) {
+		t.Helper()
+		if msgErr := srv.handleTankagram(c0, msg); msgErr != nil {
+			t.Fatalf("Initial handleTankagram error: %v", msgErr)
+		}
+		respMsg := c0s.received()
+		if respMsg == nil {
+			t.Fatalf("No response received")
+		}
+
+		respMsg.UnmarshalResult(&r)
+		if r.Result != expResult {
+			t.Fatalf("Expected result %q, got %q", expResult, r.Result)
+		}
+	}
+
+	// tankagram to locally connected client success
+	responseB := dex.Bytes(encode.RandomBytes(10))
+	resp := mj.MustResponse(msg.ID, responseB, nil)
+	c1s.queueResponse(resp)
+	checkResponse(mj.TRTTransmitted)
+	if !bytes.Equal(r.Response, responseB) {
+		t.Fatalf("wrong response")
+	}
+
+	// Bad response from client.
+	resp, _ = msgjson.NewResponse(msg.ID, "zz", nil)
+	c1s.queueResponse(resp)
+	checkResponse(mj.TRTErrBadClient)
+
+	// Client not responsive locally, but is remotely.
+	c1s.responseErr = errors.New("test error")
+	resp, _ = msgjson.NewResponse(msg.ID, &mj.TankagramResult{Result: mj.TRTTransmitted, Response: responseB}, nil)
+	tts.queueResponse(resp)
+	srv.remoteClients[c1.ID] = map[tanka.PeerID]struct{}{tt.ID: {}}
+	checkResponse(mj.TRTTransmitted)
+	if !bytes.Equal(r.Response, responseB) {
+		t.Fatalf("wrong response")
+	}
+	c1s.responseErr = nil
+
+	// Client not known locally, and is erroneous remotely.
+	delete(srv.clients, c1.ID)
+	resp, _ = msgjson.NewResponse(msg.ID, &mj.TankagramResult{Result: mj.TRTErrBadClient}, nil)
+	tts.queueResponse(resp)
+	checkResponse(mj.TRTErrBadClient)
+
+	// Client not known locally or remotely
+	delete(srv.remoteClients, c1.ID)
+	checkResponse(mj.TRTNoPath)
+
+	// Now we're the remote.
+
+	// We know the client and transmit the relayed tankagram successfully.
+	srv.clients[c1.ID] = c1
+	resp, _ = msgjson.NewResponse(msg.ID, responseB, nil)
+	c1s.queueResponse(resp)
+	msg, _ = msgjson.NewRequest(mj.NewMessageID(), mj.RouteRelayTankagram, gram)
+	srv.handleRelayedTankagram(tt, msg)
+	respMsg := tts.received()
+	if respMsg == nil {
+		t.Fatalf("No response received")
+	}
+	respMsg.UnmarshalResult(&r)
+	if r.Result != mj.TRTTransmitted {
+		t.Fatalf("Expected result %q, got %q", mj.TRTTransmitted, r.Result)
+	}
+}

--- a/tatanka/tcp/client/client.go
+++ b/tatanka/tcp/client/client.go
@@ -1,0 +1,106 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/client/comms"
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+type Client struct {
+	ctx    context.Context
+	log    dex.Logger
+	url    *url.URL
+	cert   []byte
+	cl     comms.WsConn
+	cm     *dex.ConnectionMaster
+	handle func(*msgjson.Message) *msgjson.Error
+}
+
+type Config struct {
+	Logger        dex.Logger
+	URL           string
+	Cert          []byte
+	PrivateKey    *secp256k1.PrivateKey
+	HandleMessage func(*msgjson.Message) *msgjson.Error
+}
+
+func New(cfg *Config) (*Client, error) {
+	u, err := url.Parse(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing URL: %w", err)
+	}
+	switch u.Scheme {
+	case "ws", "wss":
+	default:
+		return nil, fmt.Errorf("protocol should be 'ws' or 'wss', not %q", u.Scheme)
+	}
+	return &Client{
+		log:    cfg.Logger,
+		url:    u,
+		cert:   cfg.Cert,
+		handle: cfg.HandleMessage,
+	}, nil
+}
+
+func (c *Client) Connect(ctx context.Context) (_ *sync.WaitGroup, err error) {
+	c.ctx = ctx
+	if c.cl, err = comms.NewWsConn(&comms.WsCfg{
+		URL:      c.url.String(),
+		PingWait: 20 * time.Second,
+		Cert:     c.cert,
+		ReconnectSync: func() {
+			fmt.Println("--RECONNECTED RECONNECTED RECONNECTED RECONNECTED ")
+		},
+		ConnectEventFunc: func(status comms.ConnectionStatus) {
+			if status == comms.Disconnected {
+				// Remove it from the map.
+				c.log.Infof("WebSockets client for %s has disconnected", c.url)
+			}
+		},
+		Logger: c.log.SubLogger("TC"),
+	}); err != nil {
+		return nil, fmt.Errorf("error creating websockets connection: %w", err)
+	}
+
+	var wg sync.WaitGroup
+
+	msgs := c.cl.MessageSource()
+
+	c.cm = dex.NewConnectionMaster(c.cl)
+	if err := c.cm.ConnectOnce(ctx); err != nil {
+		return nil, fmt.Errorf("error connecting to %q: %w", c.url, err)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case msg := <-msgs:
+				c.handle(msg)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return &wg, nil
+}
+
+func (c *Client) Send(msg *msgjson.Message) error {
+	return c.cl.Send(msg)
+}
+
+func (c *Client) Request(msg *msgjson.Message, respHandler func(*msgjson.Message)) error {
+	return c.cl.Request(msg, respHandler)
+}

--- a/tatanka/tcp/server.go
+++ b/tatanka/tcp/server.go
@@ -85,7 +85,6 @@ func (cl *wsConnWrapper) PeerID() tanka.PeerID {
 // Server handles HTTP, HTTPS, WebSockets, and Tor communications protocols.
 type Server struct {
 	t   TankaCore
-	ctx context.Context
 	wg  *sync.WaitGroup
 	srv *comms.Server
 	log dex.Logger
@@ -119,7 +118,6 @@ func NewServer(cfg *comms.RPCConfig, t TankaCore, log dex.Logger) (*Server, erro
 }
 
 func (s *Server) Connect(ctx context.Context) (*sync.WaitGroup, error) {
-	s.ctx = ctx
 	var wg sync.WaitGroup
 	s.wg = &wg
 

--- a/tatanka/tcp/server.go
+++ b/tatanka/tcp/server.go
@@ -1,0 +1,210 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package tcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	clientcomms "decred.org/dcrdex/client/comms"
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/comms"
+	"decred.org/dcrdex/tatanka/mj"
+	"decred.org/dcrdex/tatanka/tanka"
+)
+
+// linkWrapper wraps a comms.Link to create a tanka.Sender.
+type linkWrapper struct {
+	comms.Link
+}
+
+func (l *linkWrapper) Request(msg *msgjson.Message, respHandler func(*msgjson.Message)) error {
+	const requestTimeout = time.Second * 30
+	return l.Link.Request(msg, func(_ comms.Link, respMsg *msgjson.Message) {
+		respHandler(respMsg)
+	}, requestTimeout, func() { // expire
+		errMsg := mj.MustResponse(msg.ID, nil, msgjson.NewError(mj.ErrTimeout, "request timed out"))
+		respHandler(errMsg)
+	})
+}
+
+func (l *linkWrapper) RequestRaw(msgID uint64, rawMsg []byte, respHandler func(*msgjson.Message)) error {
+	const requestTimeout = time.Second * 30
+	return l.Link.RequestRaw(msgID, rawMsg, func(_ comms.Link, respMsg *msgjson.Message) {
+		respHandler(respMsg)
+	}, requestTimeout, func() { // expire
+		errMsg := mj.MustResponse(msgID, nil, msgjson.NewError(mj.ErrTimeout, "request timed out"))
+		respHandler(errMsg)
+	})
+}
+
+func (l *linkWrapper) PeerID() (peerID tanka.PeerID) {
+	copy(peerID[:], []byte(l.CustomID()))
+	return
+}
+
+func (l *linkWrapper) SetPeerID(peerID tanka.PeerID) {
+	l.SetCustomID(string(peerID[:]))
+}
+
+type wsConnWrapper struct {
+	clientcomms.WsConn
+	cm *dex.ConnectionMaster
+	id atomic.Value
+}
+
+func newWsConnWrapper(cl clientcomms.WsConn, cm *dex.ConnectionMaster) *wsConnWrapper {
+	w := &wsConnWrapper{
+		WsConn: cl,
+		cm:     cm,
+	}
+	w.id.Store(tanka.PeerID{})
+	return w
+}
+
+func (cl *wsConnWrapper) Disconnect() {
+	cl.cm.Disconnect()
+	cl.cm.Wait()
+}
+
+func (cl *wsConnWrapper) SetPeerID(id tanka.PeerID) {
+	cl.id.Store(id)
+}
+
+func (cl *wsConnWrapper) PeerID() tanka.PeerID {
+	return cl.id.Load().(tanka.PeerID)
+}
+
+// Server handles HTTP, HTTPS, WebSockets, and Tor communications protocols.
+type Server struct {
+	t   TankaCore
+	ctx context.Context
+	wg  *sync.WaitGroup
+	srv *comms.Server
+	log dex.Logger
+}
+
+type TankaCore interface {
+	// Config() *mj.TatankaConfig
+	Routes() []string
+	HandleMessage(tanka.Sender, *msgjson.Message) *msgjson.Error
+}
+
+func NewServer(cfg *comms.RPCConfig, t TankaCore, log dex.Logger) (*Server, error) {
+	srv, err := comms.NewServer(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("NewServer error: %w", err)
+	}
+
+	s := &Server{
+		t:   t,
+		srv: srv,
+		log: log,
+	}
+
+	for _, r := range t.Routes() {
+		srv.Route(r, func(l comms.Link, msg *msgjson.Message) *msgjson.Error {
+			return t.HandleMessage(&linkWrapper{l}, msg)
+		})
+	}
+
+	return s, nil
+}
+
+func (s *Server) Connect(ctx context.Context) (*sync.WaitGroup, error) {
+	s.ctx = ctx
+	var wg sync.WaitGroup
+	s.wg = &wg
+
+	// Start WebSocket server
+	runner := dex.NewStartStopWaiter(s.srv)
+	runner.Start(ctx) // stopped with Stop
+
+	wg.Add(1)
+	go func() {
+		<-ctx.Done()
+		runner.Stop()
+		wg.Done()
+	}()
+
+	return &wg, nil
+}
+
+type RemoteNodeConfig struct {
+	URL  string `json:"url"`
+	Cert []byte `json:"cert"`
+}
+
+func (s *Server) ConnectBootNode(
+	ctx context.Context,
+	rawCfg json.RawMessage,
+	handleMessage func(cl tanka.Sender, msg *msgjson.Message),
+	disconnect func(),
+) (tanka.Sender, error) {
+
+	var n RemoteNodeConfig
+	if err := json.Unmarshal(rawCfg, &n); err != nil {
+		return nil, fmt.Errorf("error reading boot node configuration: %w", err)
+	}
+
+	uri, err := url.Parse(n.URL)
+	if err != nil {
+		return nil, fmt.Errorf("url parse error: %w", err)
+	}
+
+	if uri.Path != "/ws" {
+		uri.Path = "/ws"
+	}
+
+	cl, err := clientcomms.NewWsConn(&clientcomms.WsCfg{
+		URL:      uri.String(),
+		PingWait: 20 * time.Second,
+		Cert:     n.Cert,
+		ConnectEventFunc: func(status clientcomms.ConnectionStatus) {
+			if status == clientcomms.Disconnected {
+				disconnect()
+			}
+		},
+		Logger:               dex.StdOutLogger(fmt.Sprintf("CL[%s]", n.URL), dex.LevelDebug),
+		DisableAutoReconnect: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to bootnode %q: %v", n.URL, err)
+	}
+
+	cm := dex.NewConnectionMaster(cl)
+	if err := cm.ConnectOnce(ctx); err != nil {
+		return nil, fmt.Errorf("failed to connect to boot node %q. error: %w", n.URL, err)
+	}
+
+	sender := newWsConnWrapper(cl, cm)
+	go s.handleOutboudTatankaConnection(ctx, sender, handleMessage)
+
+	return sender, nil
+}
+
+func (s *Server) handleOutboudTatankaConnection(ctx context.Context, cl *wsConnWrapper, handleMessage func(cl tanka.Sender, msg *msgjson.Message)) {
+	msgs := cl.MessageSource()
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		select {
+		case msg, ok := <-msgs:
+			if !ok {
+				// Connection has been closed.
+				return
+			}
+			handleMessage(cl, msg)
+		case <-ctx.Done():
+			return
+		}
+	}
+}


### PR DESCRIPTION
Required viewing: https://youtu.be/uZRTLpXXlds (up to 2:41)

### Tatanka Mesh

This is the first PR for the mesh network as proposed in https://proposals.decred.org/record/4d2324b. Due to dynamic circumstances, there are a couple of notable deviations from the proposal, the most important of which is that the server itself no longer has any active role in maintaining an order book. The high-level description provided in **tatanka/spec** provides the justification for any deviations.

The Tatanka Mesh (the mesh) has 3 primary roles. The mesh 1) maintains reputation data for clients, 2) handles messaging between clients and other server nodes, and 3) provides some oracle services.

The Tatanka Mesh does not participate in the maintenance of any exchange markets. Those functions are relegated to the clients.

See the high-level descriptions provided in **tatanka/spec** for more information about the network and the migration of DCRDEX to the mesh.