### PR TITLE
ui: Fix darkMode flag persistence

### DIFF
--- a/client/webserver/middleware.go
+++ b/client/webserver/middleware.go
@@ -44,7 +44,6 @@ func (s *WebServer) authMiddleware(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), ctxKeyUserInfo, &userInfo{
 			Authed:           s.isAuthed(r),
 			PasswordIsCached: s.isPasswordCached(r),
-			DarkMode:         extractBooleanCookie(r, darkModeCK, true),
 		})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -26,6 +26,10 @@ body {
   justify-content: flex-start;
   background-color: $light_body_bg;
   font-family: $sans;
+
+  &.preload {
+    display: none;
+  }
 }
 
 select {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -11,7 +11,7 @@
   <title>{{.Title}}</title>
   <link href="/css/style.css?v={{commitHash}}" rel="stylesheet">
 </head>
-<body {{if .UserInfo.DarkMode}} class="dark"{{end}}>
+<body class="preload">
   <div class="popup-notes" id="popupNotes">
     <span data-tmpl="note">
       <div class="note-indicator d-inline-block" data-tmpl="indicator"></div>

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -6,7 +6,7 @@
   <span class="settings-gear ico-settings"></span><br>
   <div class="settings">
     <div class="form-check">
-      <input class="form-check-input" type="checkbox" value="" id="darkMode"{{if .UserInfo.DarkMode}} checked{{end}}>
+      <input class="form-check-input" type="checkbox" value="" id="darkMode">
       <label class="form-check-label" for="darkMode">
         [[[Dark Mode]]]
       </label>

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -118,6 +118,11 @@ export default class Application {
 
     console.log('Decred DEX Client App, Build', this.commitHash.substring(0, 7))
 
+    if (State.isDark()) {
+      document.body.classList.add('dark')
+    }
+    document.body.classList.remove('preload')
+
     // Loggers can be enabled by setting a truthy value to the loggerID using
     // enableLogger. Settings are stored across sessions. See docstring for the
     // log method for more info.

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -38,8 +38,9 @@ export default class SettingsPage extends BasePage {
     this.forms = Doc.applySelector(page.forms, ':scope > form')
     this.fiatRateSources = Doc.applySelector(page.fiatRateSources, 'input[type=checkbox]')
 
+    page.darkMode.checked = State.fetchLocal(State.darkModeLK) === '1'
     Doc.bind(page.darkMode, 'click', () => {
-      State.setCookie(State.darkModeCK, page.darkMode.checked || false ? '1' : '0')
+      State.storeLocal(State.darkModeLK, page.darkMode.checked || false ? '1' : '0')
       if (page.darkMode.checked) {
         document.body.classList.add('dark')
       } else {

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -3,7 +3,7 @@
 // to localStorage.
 export default class State {
   // Cookie keys.
-  static darkModeCK = 'darkMode'
+  static darkModeLK = 'darkMode'
   static authCK = 'dexauth'
   static pwKeyCK = 'sessionkey'
   // Local storage keys (for data that we don't need at the server).
@@ -51,8 +51,8 @@ export default class State {
   /*
    * isDark returns true if the dark-mode cookie is currently set to '1' = true.
    */
-  static isDark () {
-    return document.cookie.split(';').filter((item) => item.includes(`${State.darkModeCK}=1`)).length
+  static isDark (): boolean {
+    return State.fetchLocal(State.darkModeLK) === '1'
   }
 
   /* passwordIsCached returns whether or not there is a cached password in the cookies. */
@@ -84,6 +84,6 @@ export default class State {
 }
 
 // Setting defaults here, unless specific cookie (or local storage) value was already chosen by the user.
-if (State.getCookie(State.darkModeCK) === null) State.setCookie(State.darkModeCK, '1')
+if (State.fetchLocal(State.darkModeLK) === null) State.storeLocal(State.darkModeLK, '1')
 if (State.fetchLocal(State.popupsLK) === null) State.storeLocal(State.popupsLK, '1')
 if (State.fetchLocal(State.leftMarketDockLK) === null) State.storeLocal(State.leftMarketDockLK, '1')

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -52,8 +52,6 @@ const (
 	// reading an http request or writing the response, beyond which the http
 	// connection is terminated.
 	httpConnTimeoutSeconds = 10
-	// darkModeCK is the cookie key for dark mode.
-	darkModeCK = "darkMode"
 	// authCK is the authorization token cookie key.
 	authCK = "dexauth"
 	// pwKeyCK is the cookie used to unencrypt the user's password.
@@ -884,7 +882,6 @@ func readPost(w http.ResponseWriter, r *http.Request, thing any) bool {
 type userInfo struct {
 	Authed           bool
 	PasswordIsCached bool
-	DarkMode         bool
 }
 
 // Extract the userInfo from the request context. This should be used with


### PR DESCRIPTION
Store the `darkMode` preference in `localStorage` instead of a cookie - Webview on Linux doesn't persist the cookie jar.

Fixes #2603