### PR TITLE
multi: Add FindBond to Bonder.

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -4386,6 +4386,114 @@ func (dcr *ExchangeWallet) RefundBond(ctx context.Context, ver uint16, coinID, s
 	*/
 }
 
+// FindBond finds the bond with coinID and returns the values used to create it.
+func (dcr *ExchangeWallet) FindBond(ctx context.Context, coinID []byte, searchUntil time.Time) (bond *asset.BondDetails, err error) {
+	txHash, vout, err := decodeCoinID(coinID)
+	if err != nil {
+		return nil, err
+	}
+
+	decodeV0BondTx := func(msgTx *wire.MsgTx) (*asset.BondDetails, error) {
+		if len(msgTx.TxOut) < 2 {
+			return nil, fmt.Errorf("tx %s is not a v0 bond transaction: too few outputs", txHash)
+		}
+		_, lockTime, pkh, err := dexdcr.ExtractBondCommitDataV0(0, msgTx.TxOut[1].PkScript)
+		if err != nil {
+			return nil, fmt.Errorf("unable to extract bond commitment details from output 1 of %s: %v", txHash, err)
+		}
+		// Sanity check.
+		bondScript, err := dexdcr.MakeBondScript(0, lockTime, pkh[:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to build bond output redeem script: %w", err)
+		}
+		bondAddr, err := stdaddr.NewAddressScriptHash(0, bondScript, dcr.chainParams)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build bond output payment script: %w", err)
+		}
+		_, bondScriptWOpcodes := bondAddr.PaymentScript()
+		if !bytes.Equal(bondScriptWOpcodes, msgTx.TxOut[0].PkScript) {
+			return nil, fmt.Errorf("bond script does not match commit data for %s: %x != %x",
+				txHash, bondScript, msgTx.TxOut[0].PkScript)
+		}
+		return &asset.BondDetails{
+			Bond: &asset.Bond{
+				Version: 0,
+				AssetID: BipID,
+				Amount:  uint64(msgTx.TxOut[0].Value),
+				CoinID:  coinID,
+				Data:    bondScript,
+				//
+				// SignedTx and UnsignedTx not populated because this is
+				// an already posted bond and these fields are no longer used.
+				// SignedTx, UnsignedTx []byte
+				//
+				// RedeemTx cannot be populated because we do not have
+				// the private key that only core knows. Core will need
+				// the BondPKH to determine what the private key was.
+				// RedeemTx []byte
+			},
+			LockTime: time.Unix(int64(lockTime), 0),
+			CheckPrivKey: func(bondKey *secp256k1.PrivateKey) bool {
+				pk := bondKey.PubKey().SerializeCompressed()
+				pkhB := stdaddr.Hash160(pk)
+				return bytes.Equal(pkh[:], pkhB)
+			},
+		}, nil
+	}
+
+	// If the bond was funded by this wallet or had a change output paying
+	// to this wallet, it should be found here.
+	tx, err := dcr.wallet.GetTransaction(ctx, txHash)
+	if err == nil {
+		msgTx, err := msgTxFromHex(tx.Hex)
+		if err != nil {
+			return nil, fmt.Errorf("invalid hex for tx %s: %v", txHash, err)
+		}
+		return decodeV0BondTx(msgTx)
+	}
+	if !errors.Is(err, asset.CoinNotFoundError) {
+		dcr.log.Warnf("Unexpected error looking up bond output %v:%d", txHash, vout)
+	}
+
+	// The bond was not funded by this wallet or had no change output when
+	// restored from seed. This is not a problem. However, we are unable to
+	// use filters because we don't know any output scripts. Brute force
+	// finding the transaction.
+	blockHash, _, err := dcr.wallet.GetBestBlock(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get best hash: %v", err)
+	}
+	var (
+		blk   *wire.MsgBlock
+		msgTx *wire.MsgTx
+	)
+out:
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("bond search stopped: %w", err)
+		}
+		blk, err = dcr.wallet.GetBlock(ctx, blockHash)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving block %s: %w", blockHash, err)
+		}
+		if blk.Header.Timestamp.Before(searchUntil) {
+			return nil, fmt.Errorf("searched blocks until %v but did not find the bond tx %s", searchUntil, txHash)
+		}
+		for _, tx := range blk.Transactions {
+			if tx.TxHash() == *txHash {
+				dcr.log.Debugf("Found mined tx %s in block %s.", txHash, blk.BlockHash())
+				msgTx = tx
+				break out
+			}
+		}
+		blockHash = &blk.Header.PrevBlock
+		if blockHash == nil {
+			return nil, fmt.Errorf("did not find the bond tx %s", txHash)
+		}
+	}
+	return decodeV0BondTx(msgTx)
+}
+
 // SendTransaction broadcasts a valid fully-signed transaction.
 func (dcr *ExchangeWallet) SendTransaction(rawTx []byte) ([]byte, error) {
 	msgTx, err := msgTxFromBytes(rawTx)

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -4537,3 +4537,154 @@ func TestPurchaseTickets(t *testing.T) {
 	buyTickets(1, true)
 	checkRemains(1, 0)
 }
+
+func TestFindBond(t *testing.T) {
+	wallet, node, shutdown := tNewWallet()
+	defer shutdown()
+
+	privBytes, _ := hex.DecodeString("b07209eec1a8fb6cfe5cb6ace36567406971a75c330db7101fb21bc679bc5330")
+	bondKey := secp256k1.PrivKeyFromBytes(privBytes)
+
+	amt := uint64(50_000)
+	acctID := [32]byte{}
+	lockTime := time.Now().Add(time.Hour * 12)
+	utxo := walletjson.ListUnspentResult{
+		TxID:          tTxID,
+		Address:       tPKHAddr.String(),
+		Account:       tAcctName,
+		Amount:        1.0,
+		Confirmations: 1,
+		ScriptPubKey:  hex.EncodeToString(tP2PKHScript),
+		Spendable:     true,
+	}
+	node.unspent = []walletjson.ListUnspentResult{utxo}
+	node.changeAddr = tPKHAddr
+
+	bond, _, err := wallet.MakeBondTx(0, amt, 200, lockTime, bondKey, acctID[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txFn := func(err error, tx []byte) func() (*walletjson.GetTransactionResult, error) {
+		return func() (*walletjson.GetTransactionResult, error) {
+			if err != nil {
+				return nil, err
+			}
+			h := hex.EncodeToString(tx)
+			return &walletjson.GetTransactionResult{
+				BlockHash: hex.EncodeToString(randBytes(32)),
+				Hex:       h,
+			}, nil
+		}
+	}
+
+	newBondTx := func() *wire.MsgTx {
+		msgTx := wire.NewMsgTx()
+		if err := msgTx.FromBytes(bond.SignedTx); err != nil {
+			t.Fatal(err)
+		}
+		return msgTx
+	}
+	tooFewOutputs := newBondTx()
+	tooFewOutputs.TxOut = tooFewOutputs.TxOut[2:]
+	tooFewOutputsBytes, err := tooFewOutputs.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	badBondScript := newBondTx()
+	badBondScript.TxOut[1].PkScript = badBondScript.TxOut[1].PkScript[1:]
+	badBondScriptBytes, err := badBondScript.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noBondMatch := newBondTx()
+	noBondMatch.TxOut[0].PkScript = noBondMatch.TxOut[0].PkScript[1:]
+	noBondMatchBytes, err := noBondMatch.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	node.blockchain.addRawTx(1, newBondTx())
+	verboseBlocks := node.blockchain.verboseBlocks
+
+	tests := []struct {
+		name          string
+		coinID        []byte
+		txRes         func() (*walletjson.GetTransactionResult, error)
+		bestBlockErr  error
+		verboseBlocks map[chainhash.Hash]*wire.MsgBlock
+		searchUntil   time.Time
+		wantErr       bool
+	}{{
+		name:   "ok",
+		coinID: bond.CoinID,
+		txRes:  txFn(nil, bond.SignedTx),
+	}, {
+		name:   "ok with find blocks",
+		coinID: bond.CoinID,
+		txRes:  txFn(asset.CoinNotFoundError, nil),
+	}, {
+		name:    "bad coin id",
+		coinID:  make([]byte, 0),
+		txRes:   txFn(nil, bond.SignedTx),
+		wantErr: true,
+	}, {
+		name:    "missing an output",
+		coinID:  bond.CoinID,
+		txRes:   txFn(nil, tooFewOutputsBytes),
+		wantErr: true,
+	}, {
+		name:    "bad bond commitment script",
+		coinID:  bond.CoinID,
+		txRes:   txFn(nil, badBondScriptBytes),
+		wantErr: true,
+	}, {
+		name:    "bond script does not match commitment",
+		coinID:  bond.CoinID,
+		txRes:   txFn(nil, noBondMatchBytes),
+		wantErr: true,
+	}, {
+		name:    "bad msgtx",
+		coinID:  bond.CoinID,
+		txRes:   txFn(nil, bond.SignedTx[1:]),
+		wantErr: true,
+	}, {
+		name:         "get best block error",
+		coinID:       bond.CoinID,
+		txRes:        txFn(asset.CoinNotFoundError, nil),
+		bestBlockErr: errors.New("some error"),
+		wantErr:      true,
+	}, {
+		name:          "block not found",
+		coinID:        bond.CoinID,
+		txRes:         txFn(asset.CoinNotFoundError, nil),
+		verboseBlocks: map[chainhash.Hash]*wire.MsgBlock{},
+		wantErr:       true,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			node.walletTxFn = test.txRes
+			node.bestBlockErr = test.bestBlockErr
+			node.blockchain.verboseBlocks = verboseBlocks
+			if test.verboseBlocks != nil {
+				node.blockchain.verboseBlocks = test.verboseBlocks
+			}
+			bd, err := wallet.FindBond(tCtx, test.coinID, test.searchUntil)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !bd.CheckPrivKey(bondKey) {
+				t.Fatal("pkh not equal")
+			}
+		})
+	}
+}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -585,6 +585,13 @@ type Broadcaster interface {
 	SendTransaction(rawTx []byte) ([]byte, error)
 }
 
+// BondDetails is the return from Bonder.FindBond.
+type BondDetails struct {
+	*Bond
+	LockTime     time.Time
+	CheckPrivKey func(priv *secp256k1.PrivateKey) bool
+}
+
 // Bonder is a wallet capable of creating and redeeming time-locked fidelity
 // bond transaction outputs.
 type Bonder interface {
@@ -614,6 +621,12 @@ type Bonder interface {
 	// RefundBond will refund the bond given the full bond output details and
 	// private key to spend it. The bond is broadcasted.
 	RefundBond(ctx context.Context, ver uint16, coinID, script []byte, amt uint64, privKey *secp256k1.PrivateKey) (Coin, error)
+
+	// FindBond finds the bond with coinID and returns the values used to
+	// create it. The output should be unspent with the lockTime set to
+	// some time in the future. searchUntil is used for some wallets that
+	// are able to pull blocks.
+	FindBond(ctx context.Context, coinID []byte, searchUntil time.Time) (bondDetails *BondDetails, err error)
 
 	// A RefundBondByCoinID may be created in the future to attempt to refund a
 	// bond by locating it on chain, i.e. without providing the amount or

--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -518,7 +518,7 @@ func (c *Core) refundExpiredBonds(ctx context.Context, acct *dexAccount, cfg *de
 		var refundCoinStr string
 		var refundVal uint64
 		var bondAlreadySpent bool
-		if bond.KeyIndex == math.MaxUint32 { // invalid/unknown key index fallback (v0 db.Bond, which was never released), also will skirt reserves :/
+		if bond.KeyIndex == math.MaxUint32 { // invalid/unknown key index fallback (v0 db.Bond, which was never released, or unknown bond from server), also will skirt reserves :/
 			if len(bond.RefundTx) > 0 {
 				refundCoinID, err := wallet.SendTransaction(bond.RefundTx)
 				if err != nil {
@@ -529,7 +529,7 @@ func (c *Core) refundExpiredBonds(ctx context.Context, acct *dexAccount, cfg *de
 			} else { // else "Unknown bond reported by server", see result.ActiveBonds in authDEX
 				bondAlreadySpent = true
 			}
-		} else { // expected case -- TODO: remove the math.MaxUint32 sometime after 0.6 release
+		} else { // expected case -- TODO: remove the math.MaxUint32 sometime after bonds V1
 			priv, err := c.bondKeyIdx(bond.AssetID, bond.KeyIndex)
 			if err != nil {
 				c.log.Errorf("Failed to derive bond private key: %v", err)

--- a/client/core/locale_ntfn.go
+++ b/client/core/locale_ntfn.go
@@ -425,6 +425,13 @@ var originLocale = map[Topic]*translation{
 		subject:  "Account registered",
 		template: "New tier = %d",
 	},
+	// [bond asset, dex host]
+	TopicUnknownBondTierZero: {
+		subject: "Unknown bond found",
+		template: "Unknown %s bonds were found and added to active bonds " +
+			"but your target tier is zero for the dex at %s. Set your " +
+			"target tier in Settings to stay bonded with auto renewals.",
+	},
 }
 
 var ptBR = map[Topic]*translation{

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -20,6 +20,7 @@ const (
 	NoteTypeFeePayment   = "feepayment"
 	NoteTypeBondPost     = "bondpost"
 	NoteTypeBondRefund   = "bondrefund"
+	NoteTypeUnknownBond  = "unknownbond"
 	NoteTypeSend         = "send"
 	NoteTypeOrder        = "order"
 	NoteTypeMatch        = "match"
@@ -722,4 +723,13 @@ func newReputationNote(host string, rep account.Reputation) *ReputationNote {
 		Host:         host,
 		Reputation:   rep,
 	}
+}
+
+const TopicUnknownBondTierZero = "UnknownBondTierZero"
+
+// newUnknownBondTierZeroNote is used when unknown bonds are reported by the
+// server while at target tier zero.
+func newUnknownBondTierZeroNote(subject, details string) *db.Notification {
+	note := db.NewNotification(NoteTypeUnknownBond, TopicUnknownBondTierZero, subject, details, db.WarningLevel)
+	return &note
 }

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -582,6 +582,16 @@ func (w *xcWallet) RefundBond(ctx context.Context, ver uint16, coinID, script []
 	return bonder.RefundBond(ctx, ver, coinID, script, amt, priv)
 }
 
+// FindBond finds the bond with coinID and returns the values used to create it.
+// The output should be unspent with the lockTime set to some time in the future.
+func (w *xcWallet) FindBond(ctx context.Context, coinID []byte, searchUntil time.Time) (*asset.BondDetails, error) {
+	bonder, ok := w.Wallet.(asset.Bonder)
+	if !ok {
+		return nil, errors.New("wallet does not support making bond transactions")
+	}
+	return bonder.FindBond(ctx, coinID, searchUntil)
+}
+
 // SendTransaction broadcasts a raw transaction if the wallet is a Broadcaster.
 func (w *xcWallet) SendTransaction(tx []byte) ([]byte, error) {
 	bonder, ok := w.Wallet.(asset.Broadcaster)


### PR DESCRIPTION
When the server tells us of an unknown v0 bond attempt to find and recreate it so that it can be refunded later. Useful when restoring from seed.

closes #2371