### PR TITLE
ui: Markets menu item visibility

### DIFF
--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -501,8 +501,7 @@ export default class Application {
       return
     }
     page.profileBox.classList.add('authed')
-    Doc.show(page.noteBell, page.walletsMenuEntry)
-    Doc.setVis(Object.keys(user.exchanges).length > 0, page.marketsMenuEntry)
+    Doc.show(page.noteBell, page.walletsMenuEntry, page.marketsMenuEntry)
   }
 
   /* attachCommon scans the provided node and handles some common bindings. */


### PR DESCRIPTION
Do not hide the markets menu item when a DEX connection is not configured.  Clicking the item in that case will redirect to /register.