### PR TITLE
[0.6] core: fix version check on server reconnect

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -7860,7 +7860,7 @@ func (c *Core) handleReconnect(host string) {
 			auto = baseCfg == nil || !trade.wallets.baseWallet.supportsVer(baseCfg.Version)
 		}
 		if !auto {
-			quoteCfg := dc.assetConfig(trade.Base())
+			quoteCfg := dc.assetConfig(trade.Quote())
 			auto = quoteCfg == nil || !trade.wallets.quoteWallet.supportsVer(quoteCfg.Version)
 		}
 


### PR DESCRIPTION
Bug can cause orders not to proceed if they were booked through a server reconnect.