### PR TITLE
multi: Clickable tx and order links in notes/pokes

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -729,7 +729,7 @@ func (c *Core) tryCancelTrade(dc *dexConnection, tracker *trackedTrade) error {
 	c.log.Infof("Cancel order %s targeting order %s at %s has been placed",
 		co.ID(), oid, dc.acct.host)
 
-	subject, details := c.formatDetails(TopicCancellingOrder, tracker.token())
+	subject, details := c.formatDetails(TopicCancellingOrder, makeOrderToken(tracker.token()))
 	c.notify(newOrderNote(TopicCancellingOrder, subject, details, db.Poke, tracker.coreOrderInternal()))
 
 	return nil
@@ -1024,7 +1024,7 @@ func (dc *dexConnection) updateOrderStatus(trade *trackedTrade, newStatus order.
 			oid, previousStatus, newStatus, dc.acct.host)
 	}
 
-	subject, details := trade.formatDetails(TopicOrderStatusUpdate, trade.token(), previousStatus, newStatus)
+	subject, details := trade.formatDetails(TopicOrderStatusUpdate, makeOrderToken(trade.token()), previousStatus, newStatus)
 	dc.notify(newOrderNote(TopicOrderStatusUpdate, subject, details, db.WarningLevel, trade.coreOrderInternal()))
 }
 
@@ -6566,7 +6566,7 @@ func (c *Core) sendTradeRequest(tr *tradeRequest) (*Order, error) {
 	if !form.IsLimit && !form.Sell {
 		ui := wallets.quoteWallet.Info().UnitInfo
 		subject, details := c.formatDetails(TopicYoloPlaced,
-			ui.ConventionalString(corder.Qty), ui.Conventional.Unit, tracker.token())
+			ui.ConventionalString(corder.Qty), ui.Conventional.Unit, makeOrderToken(tracker.token()))
 		c.notify(newOrderNoteWithTempID(TopicYoloPlaced, subject, details, db.Poke, corder, tr.tempID))
 	} else {
 		rateString := "market"
@@ -6578,7 +6578,7 @@ func (c *Core) sendTradeRequest(tr *tradeRequest) (*Order, error) {
 		if corder.Sell {
 			topic = TopicSellOrderPlaced
 		}
-		subject, details := c.formatDetails(topic, ui.ConventionalString(corder.Qty), ui.Conventional.Unit, rateString, tracker.token())
+		subject, details := c.formatDetails(topic, ui.ConventionalString(corder.Qty), ui.Conventional.Unit, rateString, makeOrderToken(tracker.token()))
 		c.notify(newOrderNoteWithTempID(topic, subject, details, db.Poke, corder, tr.tempID))
 	}
 
@@ -7056,7 +7056,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 			}
 
 			subject, details := c.formatDetails(TopicMissingMatches,
-				len(missing), trade.token(), dc.acct.host)
+				len(missing), makeOrderToken(trade.token()), dc.acct.host)
 			c.notify(newOrderNote(TopicMissingMatches, subject, details, db.ErrorLevel, trade.coreOrderInternal()))
 		}
 
@@ -7066,7 +7066,7 @@ func (c *Core) authDEX(dc *dexConnection) error {
 			if err != nil {
 				c.log.Errorf("Error negotiating one or more previously unknown matches for order %s reported by %s on connect: %v",
 					oid, dc.acct.host, err)
-				subject, details := c.formatDetails(TopicMatchResolutionError, len(extras), dc.acct.host, trade.token())
+				subject, details := c.formatDetails(TopicMatchResolutionError, len(extras), dc.acct.host, makeOrderToken(trade.token()))
 				c.notify(newOrderNote(TopicMatchResolutionError, subject, details, db.ErrorLevel, trade.coreOrderInternal()))
 			} else {
 				// For taker matches in MakerSwapCast, queue up match status

--- a/client/core/locale_ntfn.go
+++ b/client/core/locale_ntfn.go
@@ -381,6 +381,46 @@ var originLocale = map[Topic]*translation{
 		subject:  "Resume order failure",
 		template: "Failed to resume processing of trade: %v",
 	},
+	// [reqConfs, bondCoinStr, assetID, acct.host]
+	TopicBondConfirming: {
+		subject:  "Confirming bond",
+		template: "Waiting for %d confirmations to post bond %v (%s) to %s",
+	},
+	// [effectiveTier, targetTier]
+	TopicBondConfirmed: {
+		subject:  "Bond confirmed",
+		template: "New tier = %d (target = %d).",
+	},
+	// [effectiveTier, targetTier]
+	TopicBondExpired: {
+		subject:  "Bond expired",
+		template: "New tier = %d (target = %d).",
+	},
+	// [bondIDStr, acct.host, refundCoinStr, refundVal, Amount]
+	TopicBondRefunded: {
+		subject:  "Bond refunded",
+		template: "Bond %v for %v refunded in %v, reclaiming %v of %v after tx fees",
+	},
+	// [err, err]
+	TopicBondPostError: {
+		subject:  "Bond post error",
+		template: "postbond request error (will retry): %v (%T)",
+	},
+	// []
+	TopicBondPostErrorConfirm: {
+		subject:  "Bond post error",
+		template: "Error encountered while waiting for bond confirms for %s: %v",
+	},
+	// [err]
+	TopicDexAuthErrorBond: {
+		subject:  "Authentication error",
+		template: "Bond confirmed, but failed to authenticate connection: %v",
+	},
+	// [effectiveTier]
+	TopicAccountRegTier: {
+		subject:  "Account registered",
+		template: "New tier = %d",
+	},
 }
 
 var ptBR = map[Topic]*translation{

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -157,6 +157,14 @@ func (c *Core) formatDetails(topic Topic, args ...any) (translatedSubject, detai
 	return trans.subject, c.localePrinter.Sprintf(string(topic), args...)
 }
 
+func makeCoinIDToken(txHash string, assetID uint32) string {
+	return fmt.Sprintf("{{{%d|%s}}}", assetID, txHash)
+}
+
+func makeOrderToken(orderToken string) string {
+	return fmt.Sprintf("{{{order|%s}}}", orderToken)
+}
+
 // Notification is an interface for a user notification. Notification is
 // satisfied by db.Notification, so concrete types can embed the db type.
 type Notification interface {
@@ -222,6 +230,7 @@ const (
 	TopicBondConfirming          Topic = "BondConfirming"
 	TopicBondRefunded            Topic = "BondRefunded"
 	TopicBondPostError           Topic = "BondPostError"
+	TopicBondPostErrorConfirm    Topic = "BondPostErrorConfirm"
 	TopicBondCoinError           Topic = "BondCoinError"
 	TopicAccountRegistered       Topic = "AccountRegistered"
 	TopicAccountUnlockError      Topic = "AccountUnlockError"
@@ -555,10 +564,12 @@ type DEXAuthNote struct {
 
 const (
 	TopicDexAuthError     Topic = "DexAuthError"
+	TopicDexAuthErrorBond Topic = "DexAuthErrorBond"
 	TopicUnknownOrders    Topic = "UnknownOrders"
 	TopicOrdersReconciled Topic = "OrdersReconciled"
 	TopicBondConfirmed    Topic = "BondConfirmed"
 	TopicBondExpired      Topic = "BondExpired"
+	TopicAccountRegTier   Topic = "AccountRegTier"
 )
 
 func newDEXAuthNote(topic Topic, subject, host string, authenticated bool, details string, severity db.Severity) *DEXAuthNote {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -691,10 +691,9 @@ func (t *trackedTrade) lockedAmount() (locked uint64) {
 	return
 }
 
-// token is a shortened representation of the order ID.
+// token is a string representation of the order ID.
 func (t *trackedTrade) token() string {
-	id := t.ID()
-	return hex.EncodeToString(id[:4])
+	return (t.ID().String())
 }
 
 // cancelTrade sets the cancellation data with the order and its preimage.
@@ -735,7 +734,7 @@ func (t *trackedTrade) nomatch(oid order.OrderID) (assetMap, error) {
 		t.cancel = nil
 		t.metaData.LinkedOrder = order.OrderID{}
 
-		subject, details := t.formatDetails(TopicMissedCancel, t.token())
+		subject, details := t.formatDetails(TopicMissedCancel, makeOrderToken(t.token()))
 		t.notify(newOrderNote(TopicMissedCancel, subject, details, db.WarningLevel, t.coreOrderInternal()))
 		return assets, t.db.UpdateOrderStatus(oid, order.OrderStatusExecuted)
 	}
@@ -938,7 +937,7 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		if trade.Sell {
 			topic = TopicSellOrderCanceled
 		}
-		subject, details := t.formatDetails(topic, unbip(t.Base()), unbip(t.Quote()), t.dc.acct.host, t.token())
+		subject, details := t.formatDetails(topic, unbip(t.Base()), unbip(t.Quote()), t.dc.acct.host, makeOrderToken(t.token()))
 
 		t.notify(newOrderNote(topic, subject, details, db.Poke, corder))
 		// Also send out a data notification with the cancel order information.
@@ -964,7 +963,7 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 		if trade.Sell {
 			topic = TopicSellMatchesMade
 		}
-		subject, details := t.formatDetails(topic, unbip(t.Base()), unbip(t.Quote()), fillPct, t.token())
+		subject, details := t.formatDetails(topic, unbip(t.Base()), unbip(t.Quote()), fillPct, makeOrderToken(t.token()))
 		t.notify(newOrderNote(topic, subject, details, db.Poke, corder))
 	}
 
@@ -1192,7 +1191,7 @@ func (t *trackedTrade) deleteStaleCancelOrder() {
 		t.dc.log.Errorf("DB error unlinking cancel order %s for trade %s: %v", t.cancel.ID(), t.ID(), err)
 	}
 
-	subject, details := t.formatDetails(TopicFailedCancel, t.token())
+	subject, details := t.formatDetails(TopicFailedCancel, makeOrderToken(t.token()))
 	t.notify(newOrderNote(TopicFailedCancel, subject, details, db.WarningLevel, t.coreOrderInternal()))
 }
 
@@ -2001,10 +2000,10 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 		ui := t.wallets.fromWallet.Info().UnitInfo
 		if err != nil {
 			errs.addErr(err)
-			subject, details := c.formatDetails(TopicSwapSendError, ui.ConventionalString(qty), ui.Conventional.Unit, t.token())
+			subject, details := c.formatDetails(TopicSwapSendError, ui.ConventionalString(qty), ui.Conventional.Unit, makeOrderToken(t.token()))
 			t.notify(newOrderNote(TopicSwapSendError, subject, details, db.ErrorLevel, corder))
 		} else {
-			subject, details := c.formatDetails(TopicSwapsInitiated, ui.ConventionalString(qty), ui.Conventional.Unit, t.token())
+			subject, details := c.formatDetails(TopicSwapsInitiated, ui.ConventionalString(qty), ui.Conventional.Unit, makeOrderToken(t.token()))
 			t.notify(newOrderNote(TopicSwapsInitiated, subject, details, db.Poke, corder))
 		}
 	}
@@ -2027,11 +2026,11 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 		if err != nil {
 			errs.addErr(err)
 			subject, details := c.formatDetails(TopicRedemptionError,
-				ui.ConventionalString(qty), ui.Conventional.Unit, t.token())
+				ui.ConventionalString(qty), ui.Conventional.Unit, makeOrderToken(t.token()))
 			t.notify(newOrderNote(TopicRedemptionError, subject, details, db.ErrorLevel, corder))
 		} else {
 			subject, details := c.formatDetails(TopicMatchComplete,
-				ui.ConventionalString(qty), ui.Conventional.Unit, t.token())
+				ui.ConventionalString(qty), ui.Conventional.Unit, makeOrderToken(t.token()))
 			t.notify(newOrderNote(TopicMatchComplete, subject, details, db.Poke, corder))
 		}
 	}
@@ -2050,11 +2049,11 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 		if err != nil {
 			errs.addErr(err)
 			subject, details := c.formatDetails(TopicRefundFailure,
-				ui.ConventionalString(refunded), ui.Conventional.Unit, t.token())
+				ui.ConventionalString(refunded), ui.Conventional.Unit, makeOrderToken(t.token()))
 			t.notify(newOrderNote(TopicRefundFailure, subject, details, db.ErrorLevel, corder))
 		} else {
 			subject, details := c.formatDetails(TopicMatchesRefunded,
-				ui.ConventionalString(refunded), ui.Conventional.Unit, t.token())
+				ui.ConventionalString(refunded), ui.Conventional.Unit, makeOrderToken(t.token()))
 			t.notify(newOrderNote(TopicMatchesRefunded, subject, details, db.WarningLevel, corder))
 		}
 	}
@@ -2852,7 +2851,7 @@ func (c *Core) sendRedeemAsync(t *trackedTrade, match *matchTracker, coinID, sec
 			err = fmt.Errorf("error storing redeem ack sig in database: %v", err)
 		}
 		if match.Status == order.MatchConfirmed {
-			subject, details := t.formatDetails(TopicRedemptionConfirmed, match.token(), t.token())
+			subject, details := t.formatDetails(TopicRedemptionConfirmed, match.token(), makeOrderToken(t.token()))
 			note := newMatchNote(TopicRedemptionConfirmed, subject, details, db.Success, t, match)
 			t.notify(note)
 		}
@@ -2915,7 +2914,7 @@ func (t *trackedTrade) confirmRedemption(match *matchTracker) (bool, error) {
 		if err != nil {
 			t.dc.log.Errorf("failed to update match in db: %v", err)
 		}
-		subject, details := t.formatDetails(TopicRedemptionConfirmed, match.token(), t.token())
+		subject, details := t.formatDetails(TopicRedemptionConfirmed, match.token(), makeOrderToken(t.token()))
 		note := newMatchNote(TopicRedemptionConfirmed, subject, details, db.Success, t, match)
 		t.notify(note)
 		return true, nil
@@ -2951,7 +2950,7 @@ func (t *trackedTrade) confirmRedemption(match *matchTracker) (bool, error) {
 		Secret: proof.Secret,
 	}, t.redeemFee())
 	if errors.Is(asset.ErrSwapRefunded, err) {
-		subject, details := t.formatDetails(TopicSwapRefunded, match.token(), t.token())
+		subject, details := t.formatDetails(TopicSwapRefunded, match.token(), makeOrderToken(t.token()))
 		note := newMatchNote(TopicSwapRefunded, subject, details, db.ErrorLevel, t, match)
 		t.notify(note)
 		match.Status = order.MatchConfirmed
@@ -2992,13 +2991,13 @@ func (t *trackedTrade) confirmRedemption(match *matchTracker) (bool, error) {
 	}
 
 	if redemptionResubmitted {
-		subject, details := t.formatDetails(TopicRedemptionResubmitted, match.token(), t.token())
+		subject, details := t.formatDetails(TopicRedemptionResubmitted, match.token(), makeOrderToken(t.token()))
 		note := newMatchNote(TopicRedemptionResubmitted, subject, details, db.WarningLevel, t, match)
 		t.notify(note)
 	}
 
 	if redemptionConfirmed {
-		subject, details := t.formatDetails(TopicRedemptionConfirmed, match.token(), t.token())
+		subject, details := t.formatDetails(TopicRedemptionConfirmed, match.token(), makeOrderToken(t.token()))
 		note := newMatchNote(TopicRedemptionConfirmed, subject, details, db.Success, t, match)
 		t.notify(note)
 	} else {

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -976,6 +976,21 @@ func (s *WebServer) apiLogin(w http.ResponseWriter, r *http.Request) {
 	}, s.indent)
 }
 
+func (s *WebServer) apiNotes(w http.ResponseWriter, r *http.Request) {
+	notes, err := s.core.Notifications(100)
+	if err != nil {
+		log.Errorf("failed to get notifications: %v", err)
+	}
+
+	writeJSON(w, &struct {
+		OK    bool               `json:"ok"`
+		Notes []*db.Notification `json:"notes"`
+	}{
+		OK:    true,
+		Notes: notes,
+	}, s.indent)
+}
+
 // apiLogout handles the 'logout' API request.
 func (s *WebServer) apiLogout(w http.ResponseWriter, r *http.Request) {
 	err := s.core.Logout()

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -979,7 +979,8 @@ func (s *WebServer) apiLogin(w http.ResponseWriter, r *http.Request) {
 func (s *WebServer) apiNotes(w http.ResponseWriter, r *http.Request) {
 	notes, err := s.core.Notifications(100)
 	if err != nil {
-		log.Errorf("failed to get notifications: %v", err)
+		s.writeAPIError(w, fmt.Errorf("failed to get notifications: %w", err))
+		return
 	}
 
 	writeJSON(w, &struct {

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -71,6 +71,10 @@
           <div class="fs15 px-1 flex-grow-1" data-tmpl="details"></div>
           <span class="note-time"></span>
         </div>
+        <div class="fs15 px-1">
+          <span data-tmpl="subject"></span>
+          <span data-tmpl="details"></span>
+        </div>
       </div>
     </div>
   </div>

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -68,12 +68,11 @@
     <div id="pokeList" class="d-hide flex-grow-1 stylish-overflow">
       <div id="pokeTmpl" class="note fs15 p-2">
         <div class="d-flex justify-content-center align-items-start px-1">
-          <div class="fs15 px-1 flex-grow-1" data-tmpl="details"></div>
+          <div class="fs15 px-1 flex-grow-1">
+            <span data-tmpl="subject"></span>
+            <span data-tmpl="details"></span>
+          </div>
           <span class="note-time"></span>
-        </div>
-        <div class="fs15 px-1">
-          <span data-tmpl="subject"></span>
-          <span data-tmpl="details"></span>
         </div>
       </div>
     </div>

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -211,9 +211,6 @@ export default class Application {
     this.updateMenuItemsDisplay()
     // initialize desktop notifications
     ntfn.fetchDesktopNtfnSettings()
-    // Load recent notifications from Window.localStorage.
-    const notes = State.fetchLocal(State.notificationsLK)
-    this.setNotes(notes || [])
     // Connect the websocket and register the notification route.
     ws.connect(getSocketURI(), this.reconnected)
     ws.registerRoute(notificationRoute, (note: CoreNote) => {
@@ -508,6 +505,10 @@ export default class Application {
     }
     page.profileBox.classList.add('authed')
     Doc.show(page.noteBell, page.walletsMenuEntry, page.marketsMenuEntry)
+
+    // Load recent notifications from Window.localStorage.
+    const notes = State.fetchLocal(State.notificationsLK)
+    this.setNotes(notes || [])
   }
 
   /* attachCommon scans the provided node and handles some common bindings. */
@@ -730,7 +731,7 @@ export default class Application {
     const { popupTmpl, popupNotes, showPopups } = this
     if (showPopups) {
       const span = popupTmpl.cloneNode(true) as HTMLElement
-      Doc.tmplElement(span, 'text').textContent = `${note.subject}: ${note.details}`
+      Doc.tmplElement(span, 'text').textContent = `${note.subject}: ${ntfn.plainNote(note.details)}`
       const indicator = Doc.tmplElement(span, 'indicator')
       if (note.severity === ntfn.POKE) {
         Doc.hide(indicator)
@@ -798,6 +799,7 @@ export default class Application {
     while (this.notes.length > noteCacheSize) this.notes.shift()
     const noteList = this.page.noteList
     this.prependListElement(noteList, note, el)
+    this.bindUrlHandlers(el)
     if (!skipSave) this.storeNotes()
     // Set the indicator color.
     if (this.notes.length === 0 || (Doc.isDisplayed(this.page.noteBox) && Doc.isDisplayed(noteList))) return
@@ -834,14 +836,15 @@ export default class Application {
     }
 
     Doc.safeSelector(el, 'div.note-subject').textContent = note.subject
-    Doc.safeSelector(el, 'div.note-details').textContent = note.details
+    ntfn.insertRichNote(Doc.safeSelector(el, 'div.note-details'), note.details)
     const np: CoreNotePlus = { el, ...note }
     return [el, np]
   }
 
   makePoke (note: CoreNote): [NoteElement, CoreNotePlus] {
     const el = this.page.pokeTmpl.cloneNode(true) as NoteElement
-    Doc.tmplElement(el, 'details').textContent = `${note.subject}: ${note.details}`
+    Doc.tmplElement(el, 'subject').textContent = `${note.subject}:`
+    ntfn.insertRichNote(Doc.tmplElement(el, 'details'), note.details)
     const np: CoreNotePlus = { el, ...note }
     return [el, np]
   }

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -496,6 +496,7 @@ export default class Application {
   async fetchNotes () {
     const res = await getJSON('/api/notes')
     if (!this.checkResponse(res)) return console.error('failed to fetch notes:', res?.msg || String(res))
+    res.notes.reverse()
     this.setNotes(res.notes)
   }
 

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -208,6 +208,9 @@ export default class Application {
     this.attachHeader()
     this.attachCommon(this.header)
     this.attach({})
+    // If we are authed, populate notes, otherwise get we'll them from the login
+    // response.
+    if (this.user && this.user.authed) await this.fetchNotes()
     this.updateMenuItemsDisplay()
     // initialize desktop notifications
     ntfn.fetchDesktopNtfnSettings()
@@ -369,7 +372,6 @@ export default class Application {
       }
       this.setNoteTimes(page.noteList)
       this.setNoteTimes(page.pokeList)
-      this.storeNotes()
     })
 
     bind(page.burgerIcon, 'click', () => {
@@ -470,23 +472,6 @@ export default class Application {
   }
 
   /*
-   * storeNotes stores the list of notifications in Window.localStorage. The
-   * actual stored list is stripped of information not necessary for display.
-   */
-  storeNotes () {
-    State.storeLocal(State.notificationsLK, this.notes.map(n => {
-      return {
-        subject: n.subject,
-        details: n.details,
-        severity: n.severity,
-        stamp: n.stamp,
-        id: n.id,
-        acked: n.acked
-      }
-    }))
-  }
-
-  /*
    * updateMenuItemsDisplay should be called when the user has signed in or out,
    * and when the user registers a DEX.
    */
@@ -503,12 +488,15 @@ export default class Application {
       Doc.hide(page.noteBell, page.walletsMenuEntry, page.marketsMenuEntry)
       return
     }
+
     page.profileBox.classList.add('authed')
     Doc.show(page.noteBell, page.walletsMenuEntry, page.marketsMenuEntry)
+  }
 
-    // Load recent notifications from Window.localStorage.
-    const notes = State.fetchLocal(State.notificationsLK)
-    this.setNotes(notes || [])
+  async fetchNotes () {
+    const res = await getJSON('/api/notes')
+    if (!this.checkResponse(res)) return console.error('failed to fetch notes:', res?.msg || String(res))
+    this.setNotes(res.notes)
   }
 
   /* attachCommon scans the provided node and handles some common bindings. */
@@ -580,9 +568,8 @@ export default class Application {
     this.notes = []
     Doc.empty(this.page.noteList)
     for (let i = 0; i < notes.length; i++) {
-      this.prependNoteElement(notes[i], true)
+      this.prependNoteElement(notes[i])
     }
-    this.storeNotes()
   }
 
   updateUser (note: CoreNote) {
@@ -793,14 +780,13 @@ export default class Application {
     this.prependListElement(this.page.pokeList, note, el)
   }
 
-  prependNoteElement (cn: CoreNote, skipSave?: boolean) {
+  prependNoteElement (cn: CoreNote) {
     const [el, note] = this.makeNote(cn)
     this.notes.push(note)
     while (this.notes.length > noteCacheSize) this.notes.shift()
     const noteList = this.page.noteList
     this.prependListElement(noteList, note, el)
     this.bindUrlHandlers(el)
-    if (!skipSave) this.storeNotes()
     // Set the indicator color.
     if (this.notes.length === 0 || (Doc.isDisplayed(this.page.noteBox) && Doc.isDisplayed(noteList))) return
     let unacked = 0
@@ -1021,7 +1007,7 @@ export default class Application {
     }
     State.removeCookie(State.authCK)
     State.removeCookie(State.pwKeyCK)
-    State.removeLocal(State.notificationsLK)
+    State.removeLocal(State.notificationsLK) // Notification storage was DEPRECATED pre-v1.
     window.location.href = '/login'
   }
 

--- a/client/webserver/site/src/js/coinexplorers.ts
+++ b/client/webserver/site/src/js/coinexplorers.ts
@@ -1,0 +1,154 @@
+import {
+  app,
+  PageElement
+} from './registry'
+import * as intl from './locales'
+
+export const Mainnet = 0
+export const Testnet = 1
+export const Simnet = 2
+
+const coinIDTakerFoundMakerRedemption = 'TakerFoundMakerRedemption:'
+
+/* ethBasedExplorerArg returns the explorer argument for ETH, ERC20 and EVM
+Compatible assets and whether the return value is an address. */
+function ethBasedExplorerArg (cid: string): [string, boolean] {
+  if (cid.startsWith(coinIDTakerFoundMakerRedemption)) return [cid.substring(coinIDTakerFoundMakerRedemption.length), true]
+  else if (cid.length === 42) return [cid, true]
+  else return [cid, false]
+}
+
+const ethExplorers: Record<number, (cid: string) => string> = {
+  [Mainnet]: (cid: string) => {
+    const [arg, isAddr] = ethBasedExplorerArg(cid)
+    return isAddr ? `https://etherscan.io/address/${arg}` : `https://etherscan.io/tx/${arg}`
+  },
+  [Testnet]: (cid: string) => {
+    const [arg, isAddr] = ethBasedExplorerArg(cid)
+    return isAddr ? `https://goerli.etherscan.io/address/${arg}` : `https://goerli.etherscan.io/tx/${arg}`
+  },
+  [Simnet]: (cid: string) => {
+    const [arg, isAddr] = ethBasedExplorerArg(cid)
+    return isAddr ? `https://etherscan.io/address/${arg}` : `https://etherscan.io/tx/${arg}`
+  }
+}
+
+export const CoinExplorers: Record<number, Record<number, (cid: string) => string>> = {
+  42: { // dcr
+    [Mainnet]: (cid: string) => {
+      const [txid, vout] = cid.split(':')
+      if (vout !== undefined) return `https://explorer.dcrdata.org/tx/${txid}/out/${vout}`
+      return `https://explorer.dcrdata.org/tx/${txid}`
+    },
+    [Testnet]: (cid: string) => {
+      const [txid, vout] = cid.split(':')
+      if (vout !== undefined) return `https://testnet.dcrdata.org/tx/${txid}/out/${vout}`
+      return `https://testnet.dcrdata.org/tx/${txid}`
+    },
+    [Simnet]: (cid: string) => {
+      const [txid, vout] = cid.split(':')
+      if (vout !== undefined) return `http://127.0.0.1:17779/tx/${txid}/out/${vout}`
+      return `https://127.0.0.1:17779/tx/${txid}`
+    }
+  },
+  0: { // btc
+    [Mainnet]: (cid: string) => `https://mempool.space/tx/${cid.split(':')[0]}`,
+    [Testnet]: (cid: string) => `https://mempool.space/testnet/tx/${cid.split(':')[0]}`,
+    [Simnet]: (cid: string) => `https://mempool.space/tx/${cid.split(':')[0]}`
+  },
+  2: { // ltc
+    [Mainnet]: (cid: string) => `https://ltc.bitaps.com/${cid.split(':')[0]}`,
+    [Testnet]: (cid: string) => `https://sochain.com/tx/LTCTEST/${cid.split(':')[0]}`,
+    [Simnet]: (cid: string) => `https://ltc.bitaps.com/${cid.split(':')[0]}`
+  },
+  20: {
+    [Mainnet]: (cid: string) => `https://digiexplorer.info/tx/${cid.split(':')[0]}`,
+    [Testnet]: (cid: string) => `https://testnetexplorer.digibyteservers.io/tx/${cid.split(':')[0]}`,
+    [Simnet]: (cid: string) => `https://digiexplorer.info/tx/${cid.split(':')[0]}`
+  },
+  60: ethExplorers,
+  60001: ethExplorers,
+  3: { // doge
+    [Mainnet]: (cid: string) => `https://dogeblocks.com/tx/${cid.split(':')[0]}`,
+    [Testnet]: (cid: string) => `https://blockexplorer.one/dogecoin/testnet/tx/${cid.split(':')[0]}`,
+    [Simnet]: (cid: string) => `https://dogeblocks.com/tx/${cid.split(':')[0]}`
+  },
+  5: { // dash
+    [Mainnet]: (cid: string) => `https://blockexplorer.one/dash/mainnet/tx/${cid.split(':')[0]}`,
+    [Testnet]: (cid: string) => `https://blockexplorer.one/dash/testnet/tx/${cid.split(':')[0]}`,
+    [Simnet]: (cid: string) => `https://blockexplorer.one/dash/mainnet/tx/${cid.split(':')[0]}`
+  },
+  133: { // zec
+    [Mainnet]: (cid: string) => `https://zcashblockexplorer.com/transactions/${cid.split(':')[0]}`,
+    [Testnet]: (cid: string) => `https://blockexplorer.one/zcash/testnet/tx/${cid.split(':')[0]}`,
+    [Simnet]: (cid: string) => `https://zcashblockexplorer.com/transactions/${cid.split(':')[0]}`
+  },
+  147: { // zcl
+    [Mainnet]: (cid: string) => `https://explorer.zcl.zelcore.io/tx/${cid.split(':')[0]}`,
+    [Simnet]: (cid: string) => `https://explorer.zcl.zelcore.io/tx/${cid.split(':')[0]}`
+  },
+  136: { // firo
+    [Mainnet]: (cid: string) => `https://explorer.firo.org/tx/${cid.split(':')[0]}`,
+    [Testnet]: (cid: string) => `https://testexplorer.firo.org/tx/${cid.split(':')[0]}`,
+    [Simnet]: (cid: string) => `https://explorer.firo.org/tx/${cid.split(':')[0]}`
+  },
+  145: { // bch
+    [Mainnet]: (cid: string) => `https://bch.loping.net/tx/${cid.split(':')[0]}`,
+    [Testnet]: (cid: string) => `https://tbch4.loping.net/tx/${cid.split(':')[0]}`,
+    [Simnet]: (cid: string) => `https://bch.loping.net/tx/${cid.split(':')[0]}`
+  },
+  966: { // matic
+    [Mainnet]: (cid: string) => {
+      const [arg, isAddr] = ethBasedExplorerArg(cid)
+      return isAddr ? `https://polygonscan.com/address/${arg}` : `https://polygonscan.com/tx/${arg}`
+    },
+    [Testnet]: (cid: string) => {
+      const [arg, isAddr] = ethBasedExplorerArg(cid)
+      return isAddr ? `https://mumbai.polygonscan.com/address/${arg}` : `https://mumbai.polygonscan.com/tx/${arg}`
+    },
+    [Simnet]: (cid: string) => {
+      const [arg, isAddr] = ethBasedExplorerArg(cid)
+      return isAddr ? `https://polygonscan.com/address/${arg}` : `https://polygonscan.com/tx/${arg}`
+    }
+  }
+}
+
+export function formatCoinID (cid: string) {
+  if (cid.startsWith(coinIDTakerFoundMakerRedemption)) {
+    const makerAddr = cid.substring(coinIDTakerFoundMakerRedemption.length)
+    return intl.prep(intl.ID_TAKER_FOUND_MAKER_REDEMPTION, { makerAddr: makerAddr })
+  }
+  return cid
+}
+
+/*
+ * baseChainID returns the asset ID for the asset's parent if the asset is a
+ * token, otherwise the ID for the asset itself.
+ */
+function baseChainID (assetID: number) {
+  const asset = app().user.assets[assetID]
+  return asset.token ? asset.token.parentID : assetID
+}
+
+/*
+ * setCoinHref sets the hyperlink element's href attribute based on provided
+ * assetID and data-explorer-coin value present on supplied link element.
+ */
+export function setCoinHref (assetID: number, link: PageElement) {
+  // setCoinHref may get called from `insertRichNote()` earlier than the user
+  // data is fetched, therefore we need to check if the user
+  // object is available.
+  // If it is not then we return early.  This does no harm except
+  // the coin ID in the notification will not be clickable.
+  // The order details screen is unaffected because user data
+  // is guaranteed to be available at the time of rendering.
+  if (!app().user) return
+  const net = app().user.net
+  const assetExplorer = CoinExplorers[baseChainID(assetID)]
+  if (!assetExplorer) return
+  const formatter = assetExplorer[net]
+  if (!formatter) return
+  link.classList.remove('plainlink')
+  link.classList.add('subtlelink')
+  link.href = formatter(link.dataset.explorerCoin || '')
+}

--- a/client/webserver/site/src/js/coinexplorers.ts
+++ b/client/webserver/site/src/js/coinexplorers.ts
@@ -135,14 +135,6 @@ function baseChainID (assetID: number) {
  * assetID and data-explorer-coin value present on supplied link element.
  */
 export function setCoinHref (assetID: number, link: PageElement) {
-  // setCoinHref may get called from `insertRichNote()` earlier than the user
-  // data is fetched, therefore we need to check if the user
-  // object is available.
-  // If it is not then we return early.  This does no harm except
-  // the coin ID in the notification will not be clickable.
-  // The order details screen is unaffected because user data
-  // is guaranteed to be available at the time of rendering.
-  if (!app().user) return
   const net = app().user.net
   const assetExplorer = CoinExplorers[baseChainID(assetID)]
   if (!assetExplorer) return

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -64,7 +64,7 @@ import {
   OrderFilter
 } from './registry'
 import { setOptionTemplates } from './opts'
-import { CoinExplorers } from './order'
+import { CoinExplorers } from './coinexplorers'
 
 const bind = Doc.bind
 

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -14,21 +14,14 @@ import {
   Coin
 } from './registry'
 import { setOptionTemplates } from './opts'
-
-export const Mainnet = 0
-export const Testnet = 1
-export const Simnet = 2
+import { formatCoinID, setCoinHref } from './coinexplorers'
 
 // lockTimeMakerMs must match the value returned from LockTimeMaker func in dexc.
 const lockTimeMakerMs = 20 * 60 * 60 * 1000
 // lockTimeTakerMs must match the value returned from LockTimeTaker func in dexc.
 const lockTimeTakerMs = 8 * 60 * 60 * 1000
 
-const coinIDTakerFoundMakerRedemption = 'TakerFoundMakerRedemption:'
-
 const animationLength = 500
-
-let net: number
 
 export default class OrderPage extends BasePage {
   orderID: string
@@ -44,7 +37,6 @@ export default class OrderPage extends BasePage {
     super()
     const page = this.page = Doc.idDescendants(main)
     this.stampers = Doc.applySelector(main, '[data-stamp]')
-    net = app().user.net
     // Find the order
     this.orderID = main.dataset.oid || ''
 
@@ -268,14 +260,6 @@ export default class OrderPage extends BasePage {
 
     const tmpl = Doc.parseTemplate(matchCard)
     tmpl.status.textContent = OrderUtil.matchStatusString(m)
-
-    const formatCoinID = (cid: string) => {
-      if (cid.startsWith(coinIDTakerFoundMakerRedemption)) {
-        const makerAddr = cid.substring(coinIDTakerFoundMakerRedemption.length)
-        return intl.prep(intl.ID_TAKER_FOUND_MAKER_REDEMPTION, { makerAddr: makerAddr })
-      }
-      return cid
-    }
 
     const tryShowCoin = (pendingEl: PageElement, coinLink: PageElement, coin: Coin) => {
       if (!coin) {
@@ -571,130 +555,4 @@ function inConfirmingMakerRedeem (m: Match) {
 */
 function inConfirmingTakerRedeem (m: Match) {
   return m.status < OrderUtil.MatchConfirmed && m.side === OrderUtil.Taker && m.status >= OrderUtil.MatchComplete
-}
-
-/*
- * setCoinHref sets the hyperlink element's href attribute based on provided
- * assetID and data-explorer-coin value present on supplied link element.
- */
-function setCoinHref (assetID: number, link: PageElement) {
-  const assetExplorer = CoinExplorers[baseChainID(assetID)]
-  if (!assetExplorer) return
-  const formatter = assetExplorer[net]
-  if (!formatter) return
-  link.classList.remove('plainlink')
-  link.classList.add('subtlelink')
-  link.href = formatter(link.dataset.explorerCoin || '')
-}
-
-/* ethBasedExplorerArg returns the explorer argument for ETH, ERC20 and EVM
-Compatible assets and whether the return value is an address. */
-function ethBasedExplorerArg (cid: string): [string, boolean] {
-  if (cid.startsWith(coinIDTakerFoundMakerRedemption)) return [cid.substring(coinIDTakerFoundMakerRedemption.length), true]
-  else if (cid.length === 42) return [cid, true]
-  else return [cid, false]
-}
-
-const ethExplorers: Record<number, (cid: string) => string> = {
-  [Mainnet]: (cid: string) => {
-    const [arg, isAddr] = ethBasedExplorerArg(cid)
-    return isAddr ? `https://etherscan.io/address/${arg}` : `https://etherscan.io/tx/${arg}`
-  },
-  [Testnet]: (cid: string) => {
-    const [arg, isAddr] = ethBasedExplorerArg(cid)
-    return isAddr ? `https://goerli.etherscan.io/address/${arg}` : `https://goerli.etherscan.io/tx/${arg}`
-  },
-  [Simnet]: (cid: string) => {
-    const [arg, isAddr] = ethBasedExplorerArg(cid)
-    return isAddr ? `https://etherscan.io/address/${arg}` : `https://etherscan.io/tx/${arg}`
-  }
-}
-
-export const CoinExplorers: Record<number, Record<number, (cid: string) => string>> = {
-  42: { // dcr
-    [Mainnet]: (cid: string) => {
-      const [txid, vout] = cid.split(':')
-      if (vout !== undefined) return `https://explorer.dcrdata.org/tx/${txid}/out/${vout}`
-      return `https://explorer.dcrdata.org/tx/${txid}`
-    },
-    [Testnet]: (cid: string) => {
-      const [txid, vout] = cid.split(':')
-      if (vout !== undefined) return `https://testnet.dcrdata.org/tx/${txid}/out/${vout}`
-      return `https://testnet.dcrdata.org/tx/${txid}`
-    },
-    [Simnet]: (cid: string) => {
-      const [txid, vout] = cid.split(':')
-      if (vout !== undefined) return `http://127.0.0.1:17779/tx/${txid}/out/${vout}`
-      return `https://127.0.0.1:17779/tx/${txid}`
-    }
-  },
-  0: { // btc
-    [Mainnet]: (cid: string) => `https://mempool.space/tx/${cid.split(':')[0]}`,
-    [Testnet]: (cid: string) => `https://mempool.space/testnet/tx/${cid.split(':')[0]}`,
-    [Simnet]: (cid: string) => `https://mempool.space/tx/${cid.split(':')[0]}`
-  },
-  2: { // ltc
-    [Mainnet]: (cid: string) => `https://ltc.bitaps.com/${cid.split(':')[0]}`,
-    [Testnet]: (cid: string) => `https://sochain.com/tx/LTCTEST/${cid.split(':')[0]}`,
-    [Simnet]: (cid: string) => `https://ltc.bitaps.com/${cid.split(':')[0]}`
-  },
-  20: {
-    [Mainnet]: (cid: string) => `https://digiexplorer.info/tx/${cid.split(':')[0]}`,
-    [Testnet]: (cid: string) => `https://testnetexplorer.digibyteservers.io/tx/${cid.split(':')[0]}`,
-    [Simnet]: (cid: string) => `https://digiexplorer.info/tx/${cid.split(':')[0]}`
-  },
-  60: ethExplorers,
-  60001: ethExplorers,
-  3: { // doge
-    [Mainnet]: (cid: string) => `https://dogeblocks.com/tx/${cid.split(':')[0]}`,
-    [Testnet]: (cid: string) => `https://blockexplorer.one/dogecoin/testnet/tx/${cid.split(':')[0]}`,
-    [Simnet]: (cid: string) => `https://dogeblocks.com/tx/${cid.split(':')[0]}`
-  },
-  5: { // dash
-    [Mainnet]: (cid: string) => `https://blockexplorer.one/dash/mainnet/tx/${cid.split(':')[0]}`,
-    [Testnet]: (cid: string) => `https://blockexplorer.one/dash/testnet/tx/${cid.split(':')[0]}`,
-    [Simnet]: (cid: string) => `https://blockexplorer.one/dash/mainnet/tx/${cid.split(':')[0]}`
-  },
-  133: { // zec
-    [Mainnet]: (cid: string) => `https://zcashblockexplorer.com/transactions/${cid.split(':')[0]}`,
-    [Testnet]: (cid: string) => `https://blockexplorer.one/zcash/testnet/tx/${cid.split(':')[0]}`,
-    [Simnet]: (cid: string) => `https://zcashblockexplorer.com/transactions/${cid.split(':')[0]}`
-  },
-  147: { // zcl
-    [Mainnet]: (cid: string) => `https://explorer.zcl.zelcore.io/tx/${cid.split(':')[0]}`,
-    [Simnet]: (cid: string) => `https://explorer.zcl.zelcore.io/tx/${cid.split(':')[0]}`
-  },
-  136: { // firo
-    [Mainnet]: (cid: string) => `https://explorer.firo.org/tx/${cid.split(':')[0]}`,
-    [Testnet]: (cid: string) => `https://testexplorer.firo.org/tx/${cid.split(':')[0]}`,
-    [Simnet]: (cid: string) => `https://explorer.firo.org/tx/${cid.split(':')[0]}`
-  },
-  145: { // bch
-    [Mainnet]: (cid: string) => `https://bch.loping.net/tx/${cid.split(':')[0]}`,
-    [Testnet]: (cid: string) => `https://tbch4.loping.net/tx/${cid.split(':')[0]}`,
-    [Simnet]: (cid: string) => `https://bch.loping.net/tx/${cid.split(':')[0]}`
-  },
-  966: { // matic
-    [Mainnet]: (cid: string) => {
-      const [arg, isAddr] = ethBasedExplorerArg(cid)
-      return isAddr ? `https://polygonscan.com/address/${arg}` : `https://polygonscan.com/tx/${arg}`
-    },
-    [Testnet]: (cid: string) => {
-      const [arg, isAddr] = ethBasedExplorerArg(cid)
-      return isAddr ? `https://mumbai.polygonscan.com/address/${arg}` : `https://mumbai.polygonscan.com/tx/${arg}`
-    },
-    [Simnet]: (cid: string) => {
-      const [arg, isAddr] = ethBasedExplorerArg(cid)
-      return isAddr ? `https://polygonscan.com/address/${arg}` : `https://polygonscan.com/tx/${arg}`
-    }
-  }
-}
-
-/*
- * baseChainID returns the asset ID for the asset's parent if the asset is a
- * token, otherwise the ID for the asset itself.
- */
-export function baseChainID (assetID: number) {
-  const asset = app().user.assets[assetID]
-  return asset.token ? asset.token.parentID : assetID
 }

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -877,7 +877,6 @@ export interface Application {
   ackNotes (): void
   setNoteTimes (noteList: HTMLElement): void
   bindInternalNavigation (ancestor: HTMLElement): void
-  storeNotes (): void
   updateMenuItemsDisplay (): void
   attachCommon (node: HTMLElement): void
   updateBondConfs (dexAddr: string, coinID: string, confs: number, assetID: number): void

--- a/client/webserver/site/src/js/state.ts
+++ b/client/webserver/site/src/js/state.ts
@@ -16,7 +16,7 @@ export default class State {
   static optionsExpansionLK = 'mmOptsExpand'
   static leftMarketDockLK = 'leftmarketdock'
   static selectedAssetLK = 'selectedasset'
-  static notificationsLK = 'notifications'
+  static notificationsLK = 'notifications' // DEPRECATED before v1
   static orderDisclaimerAckedLK = 'ordAck'
   static lastCandleDurationLK = 'lastCandleDuration'
 

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -44,7 +44,7 @@ import {
   WalletTransaction,
   FundsMixingStats
 } from './registry'
-import { CoinExplorers } from './order'
+import { CoinExplorers } from './coinexplorers'
 
 interface DecredTicketTipUpdate {
   ticketPrice: number

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -479,6 +479,7 @@ func New(cfg *Config) (*WebServer, error) {
 		r.Group(func(apiAuth chi.Router) {
 			apiAuth.Use(s.rejectUnauthed)
 			apiAuth.Get("/user", s.apiUser)
+			apiAuth.Get("/notes", s.apiNotes)
 			apiAuth.Post("/defaultwalletcfg", s.apiDefaultWalletCfg)
 			apiAuth.Post("/register", s.apiRegister)
 			apiAuth.Post("/postbond", s.apiPostBond)


### PR DESCRIPTION
Modified the rendering of notification and pokes:

* implemented `formatDetails` related TODO items in `bonds.go`
* bond related transaction hashes are displayed shortened and are clickable (linking to coin explorers)
* order hashes link to order details view

There are a few additional things I think would improve legibility but I wanted to solicit comments on first:

* the below 2 notifications include technical detail that may not be useful and could perhaps be trimmed:

![image](https://github.com/decred/dcrdex/assets/5878500/beef9398-b1bd-48dc-aa83-c0815d1db2b9)
(As this is not a fatal error that requires user action maybe it could be rephrased to be less scary)

![image](https://github.com/decred/dcrdex/assets/5878500/3cf0e4ac-95ea-467e-a573-c217c82bad18)
(This may well occur relatively frequently.  Maybe rephrase to something along the lines of
 > ***Trade limit exceeded*** 
 > Order quantity on <order#> exceeds trade limit. [Increase trade limit](#)

* Order # links lead to the order details screen in the same browser window, where the user would need to click the browser Back button to get back to the Markets screen (in `dexc-desktop` there's no clear way to go back).  Maybe show the order details panel in a modal?

* Pokes at present are not retained in localstorage the same way as notifications are - is this intentionally implemented this way?

* Pokes render the timestamp in 2 different formats - this seems redundant.  Given their intermittent nature maybe the relative time is enough?
![image](https://github.com/decred/dcrdex/assets/5878500/6841f791-762b-43a1-b026-d6ef9a86386e)


Closes #2591