### PR TITLE
core: Ensure login in `core.resendPendingRequests`

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4740,10 +4740,10 @@ func (c *Core) Login(pw []byte) error {
 		// and the balance updated there.
 		c.notify(newLoginNote("Connecting wallets..."))
 		c.connectWallets() // initialize reserves
-		c.notify(newLoginNote("Resuming active trades..."))
-		c.resolveActiveTrades(crypter)
 		c.notify(newLoginNote("Connecting to DEX servers..."))
 		c.initializeDEXConnections(crypter)
+		c.notify(newLoginNote("Resuming active trades..."))
+		c.resolveActiveTrades(crypter)
 
 		c.loggedIn = true
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4740,10 +4740,10 @@ func (c *Core) Login(pw []byte) error {
 		// and the balance updated there.
 		c.notify(newLoginNote("Connecting wallets..."))
 		c.connectWallets() // initialize reserves
-		c.notify(newLoginNote("Connecting to DEX servers..."))
-		c.initializeDEXConnections(crypter)
 		c.notify(newLoginNote("Resuming active trades..."))
 		c.resolveActiveTrades(crypter)
+		c.notify(newLoginNote("Connecting to DEX servers..."))
+		c.initializeDEXConnections(crypter)
 
 		c.loggedIn = true
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -4574,6 +4574,7 @@ func TestTradeTracking(t *testing.T) {
 	defer rig.shutdown()
 	dc := rig.dc
 	tCore := rig.core
+	tCore.loggedIn = true
 	dcrWallet, tDcrWallet := newTWallet(tUTXOAssetA.ID)
 	tCore.wallets[tUTXOAssetA.ID] = dcrWallet
 	dcrWallet.address = "DsVmA7aqqWeKWy461hXjytbZbgCqbB8g2dq"

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -2086,7 +2086,7 @@ func (c *Core) tick(t *trackedTrade) (assetMap, error) {
 // This method modifies match fields and MUST be called with the trackedTrade
 // mutex lock held for reads.
 func (c *Core) resendPendingRequests(t *trackedTrade) {
-	if t.isSelfGoverned() {
+	if t.isSelfGoverned() || !c.loggedIn /* we can't send `init` or `redeem` if we are not logged in */ {
 		return
 	}
 	for _, match := range t.matches {


### PR DESCRIPTION
This PR handles an edge case that causes a match init request to be sent before connecting to the server : See: https://github.com/decred/dcrdex/issues/2617#issuecomment-1858697056
Closes: #2617 