### PR TITLE
[0.6] server/btc: use external fee rates

### DIFF
--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -1,4 +1,4 @@
-//go:build !btclive
+//go:build !btclive && !btcfees
 
 // These tests will not be run if the btclive build tag is set. In that case,
 // the live_test.go tests will run.

--- a/server/asset/btc/btcfees_test.go
+++ b/server/asset/btc/btcfees_test.go
@@ -1,0 +1,34 @@
+//go:build btcfees
+
+package btc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+)
+
+func TestExternalBTCFeeRates(t *testing.T) {
+	log := dex.StdOutLogger("T", dex.LevelTrace)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	feeRate := getMempoolDotSpaceFeeRate(ctx, log)
+	if feeRate == 0 {
+		t.Fatalf("mempool.space fee rate failed")
+	}
+
+	feeRate = getBtcDotComFeeRate(ctx, log)
+	if feeRate == 0 {
+		t.Fatalf("btc.com fee rate failed")
+	}
+
+	time.Sleep(time.Second)
+
+	feeRate = (&Backend{log: log}).fetchExternalBitcoinFeeRate(ctx)
+	if feeRate == 0 {
+		t.Fatalf("fetchExternalBitcoinFeeRate failed")
+	}
+}


### PR DESCRIPTION
The `estimatesmartfee` RPC is not very responsive to changing conditions and often gives fee rates that are too high. Try to use fee rates from mempool.space or btc.com before falling back `estimatesmartfee`. Retrieve rates every five minutes, preferring mempool.space. Fall back if rates are stale by 10 minutes.

Some profiling of fee rate sources was done separately. Ask on Element for results if interested.