### PR TITLE
core: Fix nil bookie panic in `core.Book(...)`

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -548,36 +548,45 @@ func (c *Core) Book(dex string, base, quote uint32) (*OrderBook, error) {
 		return nil, fmt.Errorf("no DEX %s", dex)
 	}
 
-	mkt := marketName(base, quote)
-	dc.booksMtx.RLock()
-	defer dc.booksMtx.RUnlock() // hold it locked until any transient sub/unsub is completed
-	book, found := dc.books[mkt]
-	var ob *orderbook.OrderBook
-	// If not found, attempt to make a temporary subscription and return the
-	// initial book.
-	if !found {
-		snap, err := dc.subscribe(base, quote)
-		if err != nil {
-			return nil, fmt.Errorf("unable to subscribe to book: %w", err)
+	orderBookFn := func(book *bookie) *OrderBook {
+		buys, sells, epoch := book.OrderBook.Orders()
+		return &OrderBook{
+			Buys:  book.translateBookSide(buys),
+			Sells: book.translateBookSide(sells),
+			Epoch: book.translateBookSide(epoch),
 		}
-		err = dc.unsubscribe(base, quote)
-		if err != nil {
-			c.log.Errorf("Failed to unsubscribe to %q book: %v", mkt, err)
-		}
-		ob = orderbook.NewOrderBook(c.log.SubLogger(mkt))
-		if err = ob.Sync(snap); err != nil {
-			return nil, fmt.Errorf("unable to sync book: %w", err)
-		}
-	} else {
-		ob = book.OrderBook
 	}
 
-	buys, sells, epoch := ob.Orders()
-	return &OrderBook{
-		Buys:  book.translateBookSide(buys),
-		Sells: book.translateBookSide(sells),
-		Epoch: book.translateBookSide(epoch),
-	}, nil
+	mkt := marketName(base, quote)
+	dc.booksMtx.RLock()
+	defer dc.booksMtx.RUnlock()
+	book, found := dc.books[mkt]
+	if found {
+		return orderBookFn(book), nil
+	}
+
+	// If not found, attempt to make a temporary subscription and return the
+	// initial book.
+	snap, err := dc.subscribe(base, quote)
+	if err != nil {
+		return nil, fmt.Errorf("unable to subscribe to book: %w", err)
+	}
+	err = dc.unsubscribe(base, quote)
+	if err != nil {
+		c.log.Errorf("Failed to unsubscribe to %q book: %v", mkt, err)
+	}
+	ob := orderbook.NewOrderBook(c.log.SubLogger(mkt))
+	if err = ob.Sync(snap); err != nil {
+		return nil, fmt.Errorf("unable to sync book: %w", err)
+	}
+
+	dc.cfgMtx.RLock()
+	cfg := dc.cfg
+	dc.cfgMtx.RUnlock()
+
+	newBook := newBookie(dc, base, quote, cfg.BinSizes, dc.log.SubLogger(mkt))
+	newBook.OrderBook = ob
+	return orderBookFn(newBook), nil
 }
 
 // translateBookSide translates from []*orderbook.Order to []*MiniOrder.


### PR DESCRIPTION
To reproduce, just call the `core.Book` method for any market.

I already discarded the original log, but this is from Cryptopower:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1058897]

goroutine 3038 [running]:
decred.org/dcrdex/client/core.(*bookie).translateBookSide(0x0, {0xc009ffa160, 0x3, 0x7?})
        /home/joe/go/pkg/mod/github.com/ukane-philemon/dcrdex@v0.0.0-20240104133235-beacdac7d43d/client/core/bookie.go:589 +0x77
decred.org/dcrdex/client/core.(*Core).Book(0xc0037fe000, {0xc0051de020?, 0x1?}, 0x0?, 0x0?)
        /home/joe/go/pkg/mod/github.com/ukane-philemon/dcrdex@v0.0.0-20240104133235-beacdac7d43d/client/core/bookie.go:577 +0x891
github.com/crypto-power/cryptopower/ui/page/dcrdex.(*DEXMarketPage).setServerMarkets.func1()
        /home/joe/git/cryptopower/ui/page/dcrdex/market.go:334 +0x64
created by github.com/crypto-power/cryptopower/ui/page/dcrdex.(*DEXMarketPage).setServerMarkets in goroutine 55
        /home/joe/git/cryptopower/ui/page/dcrdex/market.go:332 +0x489

```