### PR TITLE
harness: Disable geth light nodes.

### DIFF
--- a/dex/testing/eth/README.md
+++ b/dex/testing/eth/README.md
@@ -6,7 +6,7 @@ sandboxed environment for testing dex swap transactions.
 ## Dependencies
 
 The harness depends on [geth](https://github.com/ethereum/go-ethereum/tree/master/cmd/geth)
-to run. geth v1.10.21+ is recommended.
+to run. geth v1.13.4+ is recommended.
 
 It also requires tmux and bc.
 

--- a/dex/testing/eth/create-node.sh
+++ b/dex/testing/eth/create-node.sh
@@ -72,9 +72,6 @@ cat > "${NODE_DIR}/eth.conf" <<EOF
 NetworkId = 42
 SyncMode = "${SYNC_MODE}"
 
-[Eth.Ethash]
-DatasetDir = "${NODE_DIR}/.ethash"
-
 [Node]
 DataDir = "${NODE_DIR}"
 AuthPort = ${AUTHRPC_PORT}
@@ -132,7 +129,7 @@ echo "Starting simnet ${NAME} node"
 if [ "${SYNC_MODE}" = "snap" ]; then
   # Start the eth node with the chain account unlocked, listening restricted to
   # localhost, and our custom configuration file.
-  tmux send-keys -t "$TMUX_WIN_ID" "${NODES_ROOT}/harness-ctl/${NAME} --nodiscover " \
+  tmux send-keys -t "$TMUX_WIN_ID" "${NODES_ROOT}/harness-ctl/${NAME} " \
 	  "--config ${NODE_DIR}/eth.conf --unlock ${CHAIN_ADDRESS} " \
 	  "--password ${GROUP_DIR}/password --light.serve 25 --datadir.ancient " \
 	  "${NODE_DIR}/geth-ancient --verbosity 5 --vmdebug --http --http.port " \
@@ -143,7 +140,7 @@ if [ "${SYNC_MODE}" = "snap" ]; then
 else
   # Start the eth node listening restricted to localhost and our custom
   # configuration file.
-  tmux send-keys -t "$TMUX_WIN_ID" "${NODES_ROOT}/harness-ctl/${NAME} --nodiscover --allow-insecure-unlock --rpc.enabledeprecatedpersonal " \
+  tmux send-keys -t "$TMUX_WIN_ID" "${NODES_ROOT}/harness-ctl/${NAME} --allow-insecure-unlock --rpc.enabledeprecatedpersonal " \
 	  "--config ${NODE_DIR}/eth.conf --verbosity 5 ${HTTP_OPT} 2>&1 | tee " \
 	  "${NODE_DIR}/${NAME}.log" C-m
 fi


### PR DESCRIPTION
I recently updated geth to `1.13.4-stable` and the harness did not work. It seems some config variables were removed, and that the light nodes also do not work, unless I am missing something. This removes the config vars and disables the light nodes for now.