### PR TITLE
loadbot: Adjust doge values.

### DIFF
--- a/client/webserver/site/src/js/doc.ts
+++ b/client/webserver/site/src/js/doc.ts
@@ -293,6 +293,7 @@ export default class Doc {
     const convRate = encRate * r / RateEncodingFactor
     const rateStepDigits = log10RateEncodingFactor - Math.floor(Math.log10(rateStepEnc)) -
       Math.floor(Math.log10(bui.conventional.conversionFactor) - Math.log10(qui.conventional.conversionFactor))
+    if (rateStepDigits <= 0) return intFormatter.format(convRate)
     return fullPrecisionFormatter(rateStepDigits).format(convRate)
   }
 

--- a/dex/testing/dcrdex/genmarkets.sh
+++ b/dex/testing/dcrdex/genmarkets.sh
@@ -174,7 +174,7 @@ if [ $DOGE_ON -eq 0 ]; then
             "base": "DCR_simnet",
             "quote": "DOGE_simnet",
             "lotSize": 1000000,
-            "rateStep": 1000000,
+            "rateStep": 1000000000,
             "epochDuration": ${EPOCH_DURATION},
             "marketBuyBuffer": 1.2,
             "parcelSize": 1500

--- a/dex/testing/loadbot/loadbot.go
+++ b/dex/testing/loadbot/loadbot.go
@@ -735,8 +735,8 @@ func symmetricWalletConfig(numCoins int, midGap uint64) (
 	minBaseQty = uint64(maxOrderLots) * uint64(numCoins) * lotSize
 	minQuoteQty = calc.BaseToQuote(midGap, minBaseQty)
 	// Ensure enough for registration fees.
-	minBaseQty += 2e8
-	minQuoteQty += 2e8
+	minBaseQty += 50e8
+	minQuoteQty += 50e8
 	// eth fee estimation calls for more reserves.
 	// TODO: polygon and tokens
 	if quoteSymbol == eth {

--- a/dex/testing/loadbot/mantle.go
+++ b/dex/testing/loadbot/mantle.go
@@ -69,7 +69,6 @@ func runTrader(t Trader, name string) {
 		return
 	}
 
-	const tradingTier = 100 // ~ 50 DCR
 	maintain := true
 	_, err = m.PostBond(&core.PostBondForm{
 		Addr:         hostAddr,

--- a/dex/testing/loadbot/mantle.go
+++ b/dex/testing/loadbot/mantle.go
@@ -734,10 +734,11 @@ func newBotWallet(symbol, node, name string, port string, pass []byte, minFunds,
 			Type:    "dogecoindRPC",
 			AssetID: dogeID,
 			Config: map[string]string{
-				"walletname":  name,
-				"rpcuser":     "user",
-				"rpcpassword": "pass",
-				"rpcport":     port,
+				"walletname":   name,
+				"rpcuser":      "user",
+				"rpcpassword":  "pass",
+				"rpcport":      port,
+				"feeratelimit": "40000",
 			},
 		}
 	case dgb:

--- a/dex/testing/loadbot/sidestacker.go
+++ b/dex/testing/loadbot/sidestacker.go
@@ -309,8 +309,8 @@ func walletConfig(maxLots, maxActiveOrds int, sell bool, midGap uint64) (baseCoi
 	minBaseQty = maxOrders * lotSize
 	minQuoteQty = calc.BaseToQuote(midGap, minBaseQty)
 	// Ensure enough for registration fees.
-	minBaseQty += 2e8
-	minQuoteQty += 2e8
+	minBaseQty += 50e8
+	minQuoteQty += 50e8
 	quoteCoins, baseCoins = 1, 1
 	if sell {
 		baseCoins = numCoins


### PR DESCRIPTION
The doge loadbot does not run on master for one because the amount of dcr needed for registration is not sent to the dcr wallet. The lot size makes one lot trades impossible due to it being dust. And for some reason the default feerate for doge is not used so setting explicitly. I would think it should use the client default so can look into why it does not if needed.

Loadbot works on the default dcr_doge after these changes.