### PR TITLE
client: update Dash minimum version to 200000 v20.0.0 breaking changes

### DIFF
--- a/client/asset/dash/dash.go
+++ b/client/asset/dash/dash.go
@@ -18,7 +18,7 @@ import (
 const (
 	version                 = 0
 	BipID                   = 5
-	minNetworkVersion       = 190200 // Dash v19.2.0, proto: 70228. Breaking change
+	minNetworkVersion       = 200000 // Dash v20.0.0, proto: 70230. Breaking change from 190200
 	walletTypeRPC           = "dashdRPC"
 	defaultRedeemConfTarget = 2
 )


### PR DESCRIPTION
Dash upgraded to a hard fork version.https://github.com/dashpay/dash/blob/v20.0.0/doc/release-notes.md

I have tested
 - basic regtest harness: works
 - client/asset/dash_test.go: works
 