### PR TITLE
core: Add `ExpiredBonds` field to `ExchangeAuth`

### DIFF
--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -415,7 +415,6 @@ func (c *Core) bondStateOfDEX(dc *dexConnection, bondCfg *dexBondCfg) *dexAcctBo
 	state.WeakStrength = sumBondStrengths(weakBonds, bondCfg.bondAssets)
 	state.LiveStrength = sumBondStrengths(dc.acct.bonds, bondCfg.bondAssets) // for max bonded check
 	state.PendingBonds = dc.pendingBonds()
-	state.ExpiredBondsPendingRefund = int64(len(dc.acct.expiredBonds))
 	// Extract the expired bonds.
 	state.ExpiredBonds = make([]*db.Bond, len(dc.acct.expiredBonds))
 	copy(state.ExpiredBonds, dc.acct.expiredBonds)

--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -268,7 +268,7 @@ func (c *Core) minBondReserves(dc *dexConnection, bondAsset *BondAsset) uint64 {
 	}
 	// Keep a list of tuples of [weakTime, bondStrength]. Later, we'll check
 	// these against expired bonds, to see how many tiers we can expect to have
-	// refunded funds avilable for.
+	// refunded funds available for.
 	activeTiers := make([][2]uint64, 0)
 	dexCfg := dc.config()
 	bondExpiry := dexCfg.BondExpiry
@@ -1688,4 +1688,16 @@ func (c *Core) bondExpired(dc *dexConnection, assetID uint32, coinID []byte, not
 	}
 
 	return nil
+}
+
+// ExpiredBonds returns a map of dex server host to a slice of expired bonds for
+// each dex server.
+func (c *Core) ExpiredBonds() map[string][]*db.Bond {
+	expiredBonds := make(map[string][]*db.Bond)
+	for _, dc := range c.dexConnections() {
+		bondCfg := c.dexBondConfig(dc, time.Now().Unix())
+		bondState := c.bondStateOfDEX(dc, bondCfg)
+		expiredBonds[dc.acct.host] = append(expiredBonds[dc.acct.host], bondState.expiredBonds...)
+	}
+	return expiredBonds
 }

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -682,6 +682,9 @@ type ExchangeAuth struct {
 	PenaltyComps uint16 `json:"penaltyComps"`
 	// PendingBonds are currently pending bonds and their confirmation count.
 	PendingBonds []*PendingBondState `json:"pendingBonds"`
+	// ExpiredBonds are bonds that have expired but have not yet reached their
+	// lock time for refunding.
+	ExpiredBonds []*db.Bond `json:"expiredBonds"`
 	// ExpiredBondsPendingRefund is the number of expired but unrefunded bonds.
 	ExpiredBondsPendingRefund int64 `json:"expiredBondsPendingRefund"`
 	// Compensation is the amount we have locked in bonds greater than what

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -685,8 +685,6 @@ type ExchangeAuth struct {
 	// ExpiredBonds are bonds that have expired but have not yet reached their
 	// lock time for refunding.
 	ExpiredBonds []*db.Bond `json:"expiredBonds"`
-	// ExpiredBondsPendingRefund is the number of expired but unrefunded bonds.
-	ExpiredBondsPendingRefund int64 `json:"expiredBondsPendingRefund"`
 	// Compensation is the amount we have locked in bonds greater than what
 	// is needed to maintain our target tier. This could be from penalty
 	// compensation, or it could be due to the user lowering their target tier.

--- a/client/webserver/site/src/js/dexsettings.ts
+++ b/client/webserver/site/src/js/dexsettings.ts
@@ -264,12 +264,12 @@ export default class DexSettingsPage extends BasePage {
   updateReputation () {
     const page = this.page
     const auth = app().exchanges[this.host].auth
-    const { rep: { penalties }, targetTier, expiredBondsPendingRefund } = auth
+    const { rep: { penalties }, targetTier, expiredBonds } = auth
     const displayTier = strongTier(auth)
     page.targetTier.textContent = String(targetTier)
     page.effectiveTier.textContent = String(displayTier)
     page.penalties.textContent = String(penalties)
-    page.bondsPendingRefund.textContent = `${expiredBondsPendingRefund}`
+    page.bondsPendingRefund.textContent = `${expiredBonds?.length || 0}`
     this.reputationMeter.update()
   }
 

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -45,7 +45,7 @@ export interface ExchangeAuth {
   maxBondedAmt: number
   penaltyComps: number
   pendingBonds: PendingBondState[]
-  expiredBondsPendingRefund: number
+  expiredBonds: any[]
   compensation: number
 }
 


### PR DESCRIPTION
This PR adds a core method that exposes expired bonds for all connected dex servers.