### PR TITLE
multi: enforce a minimum market rate that avoids dust redemption outputs

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -166,6 +166,13 @@ func (d *Driver) Create(params *asset.CreateWalletParams) error {
 		params.Logger, recoveryCfg.NumExternalAddresses, recoveryCfg.NumInternalAddresses, chainParams)
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinLotSize(maxFeeRate, false)
+}
+
 // NewWallet is the exported constructor by which the DEX will import the
 // exchange wallet.
 func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -656,6 +656,13 @@ func (d *Driver) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinLotSize(maxFeeRate, true)
+}
+
 type CustomSPVWalletConstructor func(settings map[string]string, params *chaincfg.Params) (BTCWallet, error)
 
 // customSPVWalletConstructors are functions for setting up custom

--- a/client/asset/dash/dash.go
+++ b/client/asset/dash/dash.go
@@ -101,6 +101,13 @@ func (d *Driver) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinLotSize(maxFeeRate, false)
+}
+
 // newWallet constructs a new client wallet for Dash based on the WalletDefinition.Type
 func newWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
 	var params *chaincfg.Params

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -554,6 +554,13 @@ func (d *Driver) Create(params *asset.CreateWalletParams) error {
 		recoveryCfg.NumInternalAddresses, chainParams)
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexdcr.MinLotSize(maxFeeRate)
+}
+
 func init() {
 	asset.Register(BipID, &Driver{})
 }

--- a/client/asset/dgb/dgb.go
+++ b/client/asset/dgb/dgb.go
@@ -102,6 +102,13 @@ func (d *Driver) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinLotSize(maxFeeRate, false)
+}
+
 // NewWallet is the exported constructor by which the DEX will import the
 // exchange wallet. The wallet will shut down when the provided context is
 // canceled. The configPath can be an empty string, in which case the standard

--- a/client/asset/doge/doge.go
+++ b/client/asset/doge/doge.go
@@ -130,6 +130,13 @@ func (d *Driver) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dustLimit + dexbtc.RedeemSwapTxSize(false)*maxFeeRate
+}
+
 // NewWallet is the exported constructor by which the DEX will import the
 // exchange wallet. The wallet will shut down when the provided context is
 // canceled. The configPath can be an empty string, in which case the standard

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -296,3 +296,22 @@ func WalletDef(assetID uint32, walletType string) (*WalletDefinition, error) {
 	}
 	return wd, nil
 }
+
+// MinimumLotSize returns the minimimum lot size for a registered asset.
+func MinimumLotSize(assetID uint32, maxFeeRate uint64) (minLotSize uint64, found bool) {
+	baseChainID := assetID
+	if token, is := tokens[assetID]; is {
+		baseChainID = token.ParentID
+	}
+	drv, found := drivers[baseChainID]
+	if !found {
+		return 0, false
+	}
+	m, is := drv.(interface {
+		MinLotSize(maxFeeRate uint64) uint64
+	})
+	if !is {
+		return 1, true
+	}
+	return m.MinLotSize(maxFeeRate), true
+}

--- a/client/asset/firo/firo.go
+++ b/client/asset/firo/firo.go
@@ -115,6 +115,13 @@ func (d *Driver) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinLotSize(maxFeeRate, false)
+}
+
 // NewWallet is the exported constructor by which the DEX will import the
 // exchange wallet. The wallet will shut down when the provided context is
 // canceled. The configPath can be an empty string, in which case the standard

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -109,6 +109,13 @@ func (d *Driver) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinLotSize(maxFeeRate, true)
+}
+
 // Exists checks the existence of the wallet. Part of the Creator interface, so
 // only used for wallets with WalletDefinition.Seeded = true.
 func (d *Driver) Exists(walletType, dataDir string, settings map[string]string, net dex.Network) (bool, error) {

--- a/client/asset/zcl/zcl.go
+++ b/client/asset/zcl/zcl.go
@@ -135,6 +135,13 @@ func (d *Driver) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinLotSize(maxFeeRate, false)
+}
+
 // NewWallet is the exported constructor by which the DEX will import the
 // exchange wallet. The wallet will shut down when the provided context is
 // canceled. The configPath can be an empty string, in which case the standard

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -164,6 +164,13 @@ func (d *Driver) Info() *asset.WalletInfo {
 	return WalletInfo
 }
 
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexzec.MinLotSize(maxFeeRate)
+}
+
 // WalletConfig are wallet-level configuration settings.
 type WalletConfig struct {
 	UseSplitTx       bool   `ini:"txsplit"`

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6396,8 +6396,13 @@ func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, e
 	mktID := marketName(form.Base, form.Quote)
 
 	rate, qty := form.Rate, form.Qty
-	if form.IsLimit && rate == 0 {
-		return nil, newError(orderParamsErr, "zero-rate order not allowed")
+	if form.IsLimit {
+		if rate == 0 {
+			return nil, newError(orderParamsErr, "zero-rate order not allowed")
+		}
+		if rate < mktConf.MinimumRate {
+			return nil, newError(orderParamsErr, "order's rate is lower than market's minimum rate. %d < %d", rate, mktConf.MinimumRate)
+		}
 	}
 
 	// Get an address for the swap contract.

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -553,6 +553,9 @@ type Market struct {
 	// with a TemporaryID to match with a notification once asynchronous order
 	// submission is complete.
 	InFlightOrders []*InFlightOrder `json:"inflight"`
+	// MinimumRate is the minimum rate allowed for the market, which is the
+	// minimum rate at which 1 lot converts to something greater than dust.
+	MinimumRate uint64 `json:"minimumRate"`
 }
 
 // BaseContractLocked is the amount of base asset locked in un-redeemed

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -1509,11 +1509,19 @@ export default class MarketsPage extends BasePage {
    * true if the order appears valid.
    */
   validateOrder (order: TradeForm) {
-    const page = this.page
-    if (order.isLimit && !order.rate) {
-      Doc.show(page.orderErr)
-      page.orderErr.textContent = intl.prep(intl.ID_NO_ZERO_RATE)
-      return false
+    const { page, market: { cfg: { minimumRate }, rateConversionFactor } } = this
+    if (order.isLimit) {
+      if (!order.rate) {
+        Doc.show(page.orderErr)
+        page.orderErr.textContent = intl.prep(intl.ID_NO_ZERO_RATE)
+        return false
+      }
+      if (order.rate < minimumRate) {
+        Doc.show(page.orderErr)
+        const [r, minRate] = [order.rate / rateConversionFactor, minimumRate / rateConversionFactor]
+        page.orderErr.textContent = `rate is lower than the market's minimum rate. ${r} < ${minRate}`
+        return false
+      }
     }
     if (!order.qty) {
       Doc.show(page.orderErr)

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -96,6 +96,7 @@ export interface Market {
   spot: Spot | undefined
   atomToConv: number
   inflight: InFlightOrder[]
+  minimumRate: number
 }
 
 export interface InFlightOrder extends Order {

--- a/dex/calc/parcels.go
+++ b/dex/calc/parcels.go
@@ -3,6 +3,8 @@
 
 package calc
 
+import "math"
+
 // Parcels calculates the number of parcels associated with the given order
 // quantities, lot size and parcel size. Any quantity currently settling
 // should be summed in with the makerQty.
@@ -10,4 +12,8 @@ func Parcels(makerQty, takerQty, lotSize uint64, parcelSize uint32) float64 {
 	parcelWeight := makerQty + takerQty*2
 	parcelQty := lotSize * uint64(parcelSize)
 	return float64(parcelWeight) / float64(parcelQty)
+}
+
+func MinimumMarketRate(baseLotSize, quoteDust uint64) uint64 {
+	return uint64(math.Ceil(float64(quoteDust) * RateEncodingFactor / float64(baseLotSize)))
 }

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1265,7 +1265,6 @@ type Market struct {
 	MarketBuyBuffer float64 `json:"buybuffer"`
 	ParcelSize      uint32  `json:"parcelSize"`
 	MarketStatus    `json:"status"`
-	MinimumRate     uint64 `json:"minimumRate"`
 }
 
 // Running indicates if the market should be running given the known StartEpoch,

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1265,6 +1265,7 @@ type Market struct {
 	MarketBuyBuffer float64 `json:"buybuffer"`
 	ParcelSize      uint32  `json:"parcelSize"`
 	MarketStatus    `json:"status"`
+	MinimumRate     uint64 `json:"minimumRate"`
 }
 
 // Running indicates if the market should be running given the known StartEpoch,

--- a/server/asset/zec/zec.go
+++ b/server/asset/zec/zec.go
@@ -49,19 +49,6 @@ func (d *Driver) Name() string {
 	return "Zcash"
 }
 
-func minHTLCSize(redeemTxFees uint64) uint64 {
-	var outputSize uint64 = dexbtc.P2PKHOutputSize
-	sz := outputSize + 148                        // 148 accounts for an input on spending tx
-	const oneThirdDustThresholdRate = 100         // zats / kB
-	nFee := oneThirdDustThresholdRate * sz / 1000 // This is different from BTC
-	if nFee == 0 {
-		nFee = oneThirdDustThresholdRate
-	}
-	htlcOutputDustMin := 3 * nFee
-
-	return htlcOutputDustMin + redeemTxFees
-}
-
 // MinBondSize calculates the minimum bond size for a given fee rate that avoids
 // dust outputs on the bond and refund txs, assuming the maxFeeRate doesn't
 // change.
@@ -69,17 +56,14 @@ func (d *Driver) MinBondSize(maxFeeRate uint64) uint64 {
 	var inputsSize uint64 = dexbtc.TxInOverhead + dexbtc.RedeemBondSigScriptSize + 1
 	var outputsSize uint64 = dexbtc.P2PKHOutputSize + 1
 	refundBondTxFees := dexzec.TxFeesZIP317(inputsSize, outputsSize, 0, 0, 0, 0)
-	return minHTLCSize(refundBondTxFees)
+	return dexzec.MinHTLCSize(refundBondTxFees)
 }
 
 // MinLotSize calculates the minimum bond size for a given fee rate that avoids
 // dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
 // change.
 func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
-	var inputsSize uint64 = dexbtc.TxInOverhead + dexbtc.RefundSigScriptSize + 1
-	var outputsSize uint64 = dexbtc.P2PKHOutputSize + 1
-	refundBondTxFees := dexzec.TxFeesZIP317(inputsSize, outputsSize, 0, 0, 0, 0)
-	return minHTLCSize(refundBondTxFees)
+	return dexzec.MinLotSize(maxFeeRate)
 }
 
 func init() {

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/calc"
 	"decred.org/dcrdex/dex/candles"
 	"decred.org/dcrdex/dex/fiatrates"
 	"decred.org/dcrdex/dex/msgjson"
@@ -651,6 +652,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	// lots sizes, which will break older clients. In this case, set
 	// msgjson.Asset.LotSize 0 so older clients cannot use the market. Do the
 	// same for rate step.
+	// V0PURGE
 	lotSizes := make(map[uint32]uint64)
 	rateSteps := make(map[uint32]uint64)
 	for _, mktInfo := range cfg.Markets {
@@ -1087,12 +1089,19 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 	for _, mktInf := range cfg.Markets {
 		// nilness of the coin locker signals account-based asset.
 		var baseCoinLocker, quoteCoinLocker coinlock.CoinLocker
-		if _, ok := backedAssets[mktInf.Base].Backend.(asset.OutputTracker); ok {
+		b, q := backedAssets[mktInf.Base], backedAssets[mktInf.Quote]
+		if _, ok := b.Backend.(asset.OutputTracker); ok {
 			baseCoinLocker = dexCoinLocker.AssetLocker(mktInf.Base).Book()
 		}
-		if _, ok := backedAssets[mktInf.Quote].Backend.(asset.OutputTracker); ok {
+		if _, ok := q.Backend.(asset.OutputTracker); ok {
 			quoteCoinLocker = dexCoinLocker.AssetLocker(mktInf.Quote).Book()
 		}
+
+		// Calculate a minimum market rate that avoids dust.
+		// quote_dust = base_lot * min_rate / rate_encoding_factor
+		// => min_rate = quote_dust * rate_encoding_factor * base_lot
+		quoteMinLotSize, _, _ := asset.Minimums(mktInf.Quote, q.Asset.MaxFeeRate)
+		minRate := uint64(math.Ceil(float64(quoteMinLotSize) * calc.RateEncodingFactor / float64(mktInf.LotSize)))
 
 		mkt, err := market.NewMarket(&market.Config{
 			MarketInfo:      mktInf,
@@ -1108,6 +1117,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 			CheckParcelLimit: func(user account.AccountID, calcParcels market.MarketParcelCalculator) bool {
 				return orderRouter.CheckParcelLimit(user, mktInf.Name, calcParcels)
 			},
+			MinimumRate: minRate,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("NewMarket failed: %w", err)
@@ -1162,6 +1172,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 			MarketStatus: msgjson.MarketStatus{
 				StartEpoch: uint64(startEpochIdx),
 			},
+			MinimumRate: mkt.MinimumRate(),
 		})
 	}
 

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -1101,7 +1101,7 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 		// quote_dust = base_lot * min_rate / rate_encoding_factor
 		// => min_rate = quote_dust * rate_encoding_factor * base_lot
 		quoteMinLotSize, _, _ := asset.Minimums(mktInf.Quote, q.Asset.MaxFeeRate)
-		minRate := uint64(math.Ceil(float64(quoteMinLotSize) * calc.RateEncodingFactor / float64(mktInf.LotSize)))
+		minRate := calc.MinimumMarketRate(mktInf.LotSize, quoteMinLotSize)
 
 		mkt, err := market.NewMarket(&market.Config{
 			MarketInfo:      mktInf,
@@ -1172,7 +1172,6 @@ func NewDEX(ctx context.Context, cfg *DexConf) (*DEX, error) {
 			MarketStatus: msgjson.MarketStatus{
 				StartEpoch: uint64(startEpochIdx),
 			},
-			MinimumRate: mkt.MinimumRate(),
 		})
 	}
 

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -689,10 +689,6 @@ func (m *Market) Quote() uint32 {
 	return m.marketInfo.Quote
 }
 
-func (m *Market) MinimumRate() uint64 {
-	return m.minimumRate
-}
-
 // OrderFeed provides a new order book update channel. Channels provided before
 // the market starts and while a market is running are both valid. When the
 // market stops, channels are closed (invalidated), and new channels should be

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -1172,6 +1172,15 @@ func TestMarket_Run(t *testing.T) {
 		t.Errorf(`expected ErrInvalidOrder ("%v"), got "%v"`, ErrInvalidOrder, err)
 	}
 
+	// Rate too low
+	oRecord = newOR()
+	mkt.minimumRate = oRecord.order.(*order.LimitOrder).Rate + 1
+	storMsgPI(oRecord.msgID, pi)
+	if err = mkt.SubmitOrder(oRecord); !errors.Is(err, ErrInvalidRate) {
+		t.Errorf("An invalid rate was accepted, but it should not have been.")
+	}
+	mkt.minimumRate = 0
+
 	// Let the epoch cycle and the fake client respond with its preimage
 	// (handlePreimageResp done)..
 	<-auth.handlePreimageDone


### PR DESCRIPTION


Built on #2669. [This is the diff you're looking for.](https://github.com/buck54321/dcrdex/compare/a3e3a32...buck54321:dcrdex:minmarketrate)