### PR TITLE
multi: check for used addresses

### DIFF
--- a/client/asset/bch/spv.go
+++ b/client/asset/bch/spv.go
@@ -792,6 +792,18 @@ func (w *bchSPVWallet) RemovePeer(addr string) error {
 	return w.peerManager.RemovePeer(addr)
 }
 
+func (w *bchSPVWallet) TotalReceivedForAddr(btcAddr btcutil.Address, minConf int32) (btcutil.Amount, error) {
+	bchAddr, err := dexbch.BTCAddrToBCHAddr(btcAddr, w.btcParams)
+	if err != nil {
+		return 0, err
+	}
+	amt, err := w.Wallet.TotalReceivedForAddr(bchAddr, 0)
+	if err != nil {
+		return 0, err
+	}
+	return btcutil.Amount(amt), nil
+}
+
 // secretSource is used to locate keys and redemption scripts while signing a
 // transaction. secretSource satisfies the txauthor.SecretsSource interface.
 type secretSource struct {

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -4497,7 +4497,7 @@ func (btc *baseWallet) NewAddress() (string, error) {
 
 // AddressUsed checks if a wallet address has been used.
 func (btc *baseWallet) AddressUsed(addrStr string) (bool, error) {
-	return btc.node.addressUsed(addrStr)
+	return btc.node.AddressUsed(addrStr)
 }
 
 // Withdraw withdraws funds to the specified address. Fees are subtracted from

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -931,6 +931,7 @@ var _ asset.Authenticator = (*ExchangeWalletAccelerator)(nil)
 var _ asset.Authenticator = (*ExchangeWalletCustom)(nil)
 var _ asset.AddressReturner = (*baseWallet)(nil)
 var _ asset.WalletHistorian = (*ExchangeWalletSPV)(nil)
+var _ asset.NewAddresser = (*baseWallet)(nil)
 
 // RecoveryCfg is the information that is transferred from the old wallet
 // to the new one when the wallet is recovered.
@@ -4492,6 +4493,11 @@ func (btc *baseWallet) ReturnRedemptionAddress(addr string) {
 // NewAddresser interface.
 func (btc *baseWallet) NewAddress() (string, error) {
 	return btc.DepositAddress()
+}
+
+// AddressUsed checks if a wallet address has been used.
+func (btc *baseWallet) AddressUsed(addrStr string) (bool, error) {
+	return btc.node.addressUsed(addrStr)
 }
 
 // Withdraw withdraws funds to the specified address. Fees are subtracted from

--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -1211,3 +1211,11 @@ func (ew *electrumWallet) findOutputSpender(ctx context.Context, txHash *chainha
 
 	return nil, 0, nil // caller should check msgTx (internal method)
 }
+
+func (ew *electrumWallet) addressUsed(addrStr string) (bool, error) {
+	txs, err := ew.wallet.GetAddressHistory(ew.ctx, addrStr)
+	if err != nil {
+		return false, fmt.Errorf("error getting address history: %w", err)
+	}
+	return len(txs) > 0, nil
+}

--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -1212,7 +1212,7 @@ func (ew *electrumWallet) findOutputSpender(ctx context.Context, txHash *chainha
 	return nil, 0, nil // caller should check msgTx (internal method)
 }
 
-func (ew *electrumWallet) addressUsed(addrStr string) (bool, error) {
+func (ew *electrumWallet) AddressUsed(addrStr string) (bool, error) {
 	txs, err := ew.wallet.GetAddressHistory(ew.ctx, addrStr)
 	if err != nil {
 		return false, fmt.Errorf("error getting address history: %w", err)

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -1181,7 +1181,7 @@ func SearchBlockForRedemptions(
 	return
 }
 
-func (wc *rpcClient) addressUsed(addr string) (bool, error) {
+func (wc *rpcClient) AddressUsed(addr string) (bool, error) {
 	var recv float64
 	const minConf = 0
 	if err := wc.call(methodGetReceivedByAddress, []any{addr, minConf}, &recv); err != nil {

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -29,38 +29,39 @@ import (
 )
 
 const (
-	methodGetBalances        = "getbalances"
-	methodGetBalance         = "getbalance"
-	methodListUnspent        = "listunspent"
-	methodLockUnspent        = "lockunspent"
-	methodListLockUnspent    = "listlockunspent"
-	methodChangeAddress      = "getrawchangeaddress"
-	methodNewAddress         = "getnewaddress"
-	methodSignTx             = "signrawtransactionwithwallet"
-	methodSignTxLegacy       = "signrawtransaction"
-	methodUnlock             = "walletpassphrase"
-	methodLock               = "walletlock"
-	methodPrivKeyForAddress  = "dumpprivkey"
-	methodGetTransaction     = "gettransaction"
-	methodSendToAddress      = "sendtoaddress"
-	methodSetTxFee           = "settxfee"
-	methodGetWalletInfo      = "getwalletinfo"
-	methodGetAddressInfo     = "getaddressinfo"
-	methodListDescriptors    = "listdescriptors"
-	methodValidateAddress    = "validateaddress"
-	methodEstimateSmartFee   = "estimatesmartfee"
-	methodSendRawTransaction = "sendrawtransaction"
-	methodGetTxOut           = "gettxout"
-	methodGetBlock           = "getblock"
-	methodGetBlockHash       = "getblockhash"
-	methodGetBestBlockHash   = "getbestblockhash"
-	methodGetRawMempool      = "getrawmempool"
-	methodGetRawTransaction  = "getrawtransaction"
-	methodGetBlockHeader     = "getblockheader"
-	methodGetNetworkInfo     = "getnetworkinfo"
-	methodGetBlockchainInfo  = "getblockchaininfo"
-	methodFundRawTransaction = "fundrawtransaction"
-	methodListSinceBlock     = "listsinceblock"
+	methodGetBalances          = "getbalances"
+	methodGetBalance           = "getbalance"
+	methodListUnspent          = "listunspent"
+	methodLockUnspent          = "lockunspent"
+	methodListLockUnspent      = "listlockunspent"
+	methodChangeAddress        = "getrawchangeaddress"
+	methodNewAddress           = "getnewaddress"
+	methodSignTx               = "signrawtransactionwithwallet"
+	methodSignTxLegacy         = "signrawtransaction"
+	methodUnlock               = "walletpassphrase"
+	methodLock                 = "walletlock"
+	methodPrivKeyForAddress    = "dumpprivkey"
+	methodGetTransaction       = "gettransaction"
+	methodSendToAddress        = "sendtoaddress"
+	methodSetTxFee             = "settxfee"
+	methodGetWalletInfo        = "getwalletinfo"
+	methodGetAddressInfo       = "getaddressinfo"
+	methodListDescriptors      = "listdescriptors"
+	methodValidateAddress      = "validateaddress"
+	methodEstimateSmartFee     = "estimatesmartfee"
+	methodSendRawTransaction   = "sendrawtransaction"
+	methodGetTxOut             = "gettxout"
+	methodGetBlock             = "getblock"
+	methodGetBlockHash         = "getblockhash"
+	methodGetBestBlockHash     = "getbestblockhash"
+	methodGetRawMempool        = "getrawmempool"
+	methodGetRawTransaction    = "getrawtransaction"
+	methodGetBlockHeader       = "getblockheader"
+	methodGetNetworkInfo       = "getnetworkinfo"
+	methodGetBlockchainInfo    = "getblockchaininfo"
+	methodFundRawTransaction   = "fundrawtransaction"
+	methodListSinceBlock       = "listsinceblock"
+	methodGetReceivedByAddress = "getreceivedbyaddress"
 )
 
 // IsTxNotFoundErr will return true if the error indicates that the requested
@@ -1178,6 +1179,15 @@ func SearchBlockForRedemptions(
 		}
 	}
 	return
+}
+
+func (wc *rpcClient) addressUsed(addr string) (bool, error) {
+	var recv float64
+	const minConf = 0
+	if err := wc.call(methodGetReceivedByAddress, []any{addr, minConf}, &recv); err != nil {
+		return false, err
+	}
+	return recv != 0, nil
 }
 
 // call is used internally to marshal parameters and send requests to the RPC

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -342,6 +342,10 @@ func (c *tBtcWallet) RemovePeer(string) error {
 	return nil
 }
 
+func (c *tBtcWallet) TotalReceivedForAddr(addr btcutil.Address, minConf int32) (btcutil.Amount, error) {
+	return 0, nil
+}
+
 type tNeutrinoClient struct {
 	*testData
 }

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -1316,7 +1316,7 @@ func (w *spvWallet) GetWalletTransaction(txHash *chainhash.Hash) (*GetTransactio
 	*/
 }
 
-func (w *spvWallet) addressUsed(addrStr string) (bool, error) {
+func (w *spvWallet) AddressUsed(addrStr string) (bool, error) {
 	addr, err := w.decodeAddr(addrStr, w.chainParams)
 	if err != nil {
 		return false, fmt.Errorf("error decoding address: %w", err)

--- a/client/asset/btc/wallet.go
+++ b/client/asset/btc/wallet.go
@@ -45,6 +45,7 @@ type Wallet interface {
 	Reconfigure(walletCfg *asset.WalletConfig, currentAddress string) (restartRequired bool, err error)
 	Fingerprint() (string, error)
 	ListTransactionsSinceBlock(blockHeight int32) ([]*ListTransactionsResult, error)
+	AddressUsed(addr string) (bool, error)
 }
 
 type TipRedemptionWallet interface {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -707,6 +707,7 @@ var _ asset.Bonder = (*ExchangeWallet)(nil)
 var _ asset.Authenticator = (*ExchangeWallet)(nil)
 var _ asset.TicketBuyer = (*ExchangeWallet)(nil)
 var _ asset.WalletHistorian = (*ExchangeWallet)(nil)
+var _ asset.NewAddresser = (*ExchangeWallet)(nil)
 
 type block struct {
 	height int64
@@ -4125,6 +4126,11 @@ func (dcr *ExchangeWallet) RedemptionAddress() (string, error) {
 // NewAddresser interface.
 func (dcr *ExchangeWallet) NewAddress() (string, error) {
 	return dcr.DepositAddress()
+}
+
+// AddressUsed checks if a wallet address has been used.
+func (dcr *ExchangeWallet) AddressUsed(addrStr string) (bool, error) {
+	return dcr.wallet.AddressUsed(dcr.ctx, addrStr)
 }
 
 // Unlock unlocks the exchange wallet.

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -721,6 +721,10 @@ func (c *tRPCClient) SetTxFee(ctx context.Context, fee dcrutil.Amount) error {
 	return nil
 }
 
+func (c *tRPCClient) GetReceivedByAddressMinConf(ctx context.Context, address stdaddr.Address, minConfs int) (dcrutil.Amount, error) {
+	return 0, nil
+}
+
 func (c *tRPCClient) ListSinceBlock(ctx context.Context, hash *chainhash.Hash) (*walletjson.ListSinceBlockResult, error) {
 	return nil, nil
 }

--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -156,6 +156,7 @@ type rpcClient interface {
 	SetVoteChoice(ctx context.Context, agendaID, choiceID string) error
 	SetTxFee(ctx context.Context, fee dcrutil.Amount) error
 	ListSinceBlock(ctx context.Context, hash *chainhash.Hash) (*walletjson.ListSinceBlockResult, error)
+	GetReceivedByAddressMinConf(ctx context.Context, address stdaddr.Address, minConfs int) (dcrutil.Amount, error)
 }
 
 // newRPCWallet creates an rpcClient and uses it to construct a new instance
@@ -1215,6 +1216,19 @@ func (w *rpcWallet) SetVotingPreferences(ctx context.Context, choices, tSpendPol
 
 func (w *rpcWallet) SetTxFee(ctx context.Context, feePerKB dcrutil.Amount) error {
 	return w.rpcClient.SetTxFee(ctx, feePerKB)
+}
+
+func (w *rpcWallet) AddressUsed(ctx context.Context, addrStr string) (bool, error) {
+	addr, err := stdaddr.DecodeAddress(addrStr, w.chainParams)
+	if err != nil {
+		return false, err
+	}
+	const minConf = 0
+	recv, err := w.rpcClient.GetReceivedByAddressMinConf(ctx, addr, minConf)
+	if err != nil {
+		return false, err
+	}
+	return recv != 0, nil
 }
 
 // anylist is a list of RPC parameters to be converted to []json.RawMessage and

--- a/client/asset/dcr/spv_test.go
+++ b/client/asset/dcr/spv_test.go
@@ -430,6 +430,10 @@ func (w *tDcrWallet) RescanPoint(ctx context.Context) (*chainhash.Hash, error) {
 	return nil, nil
 }
 
+func (w *tDcrWallet) TotalReceivedForAddr(ctx context.Context, addr stdaddr.Address, minConf int32) (dcrutil.Amount, error) {
+	return 0, nil
+}
+
 func tNewSpvWallet() (*spvWallet, *tDcrWallet) {
 	dcrw := &tDcrWallet{
 		blockInfo:      make(map[int32]*wallet.BlockInfo),

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -176,6 +176,7 @@ type Wallet interface {
 	StakeInfo(ctx context.Context) (*wallet.StakeInfoData, error)
 	Reconfigure(ctx context.Context, cfg *asset.WalletConfig, net dex.Network, currentAddress string) (restart bool, err error)
 	WalletOwnsAddress(ctx context.Context, addr stdaddr.Address) (bool, error)
+	AddressUsed(ctx context.Context, addrStr string) (bool, error)
 }
 
 // WalletTransaction is a pared down version of walletjson.GetTransactionResult.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -703,6 +703,7 @@ type Sweeper interface {
 // NewAddresser is a wallet that can generate new deposit addresses.
 type NewAddresser interface {
 	NewAddress() (string, error)
+	AddressUsed(string) (bool, error)
 }
 
 // AddressReturner is a wallet that allows recycling of unused redemption or refund

--- a/client/asset/ltc/spv.go
+++ b/client/asset/ltc/spv.go
@@ -829,6 +829,18 @@ func (w *ltcSPVWallet) RemovePeer(addr string) error {
 	return w.peerManager.RemovePeer(addr)
 }
 
+func (w *ltcSPVWallet) TotalReceivedForAddr(btcAddr btcutil.Address, minConf int32) (btcutil.Amount, error) {
+	ltcAddr, err := w.addrBTC2LTC(btcAddr)
+	if err != nil {
+		return 0, err
+	}
+	amt, err := w.Wallet.TotalReceivedForAddr(ltcAddr, 0)
+	if err != nil {
+		return 0, err
+	}
+	return btcutil.Amount(amt), nil
+}
+
 // secretSource is used to locate keys and redemption scripts while signing a
 // transaction. secretSource satisfies the txauthor.SecretsSource interface.
 type secretSource struct {

--- a/client/asset/zec/transparent_rpc.go
+++ b/client/asset/zec/transparent_rpc.go
@@ -410,3 +410,9 @@ func walletInfo(c rpcCaller) (*walletInfoRes, error) {
 	}
 	return &res, nil
 }
+
+func getReceivedByAddress(c rpcCaller, addrStr string) (recv uint64, _ error) {
+	const minConf = 0
+	const inZats = true
+	return recv, c.CallRPC("getreceivedbyaddress", []any{addrStr, minConf, inZats}, &recv)
+}

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -336,6 +336,7 @@ type zecWallet struct {
 var _ asset.FeeRater = (*zecWallet)(nil)
 var _ asset.Wallet = (*zecWallet)(nil)
 var _ asset.WalletHistorian = (*zecWallet)(nil)
+var _ asset.NewAddresser = (*zecWallet)(nil)
 
 // TODO: Implement LiveReconfigurer
 // var _ asset.LiveReconfigurer = (*zecWallet)(nil)
@@ -1678,6 +1679,13 @@ func (w *zecWallet) DepositAddress() (string, error) {
 
 func (w *zecWallet) NewAddress() (string, error) {
 	return w.DepositAddress()
+}
+
+// AddressUsed checks if a wallet address has been used.
+func (w *zecWallet) AddressUsed(addrStr string) (bool, error) {
+	// TODO: Resolve with new unified address encoding in https://github.com/decred/dcrdex/pull/2675
+	recv, err := getReceivedByAddress(w, addrStr)
+	return recv != 0, err
 }
 
 func (w *zecWallet) FindRedemption(ctx context.Context, coinID, contract dex.Bytes) (redemptionCoin, secret dex.Bytes, err error) {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4012,6 +4012,21 @@ func (c *Core) NewDepositAddress(assetID uint32) (string, error) {
 	return addr, nil
 }
 
+// AddressUsed checks whether an address for a NewAddresser has been used.
+func (c *Core) AddressUsed(assetID uint32, addr string) (bool, error) {
+	w, exists := c.wallet(assetID)
+	if !exists {
+		return false, newError(missingWalletErr, "no wallet found for %s", unbip(assetID))
+	}
+
+	na, ok := w.Wallet.(asset.NewAddresser)
+	if !ok {
+		return false, errors.New("wallet is not a NewAddresser")
+	}
+
+	return na.AddressUsed(addr)
+}
+
 // AutoWalletConfig attempts to load setting from a wallet package's
 // asset.WalletInfo.DefaultConfigPath. If settings are not found, an empty map
 // is returned.

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -914,6 +914,10 @@ func (w *TXCWallet) NewAddress() (string, error) {
 	return "", w.addrErr
 }
 
+func (w *TXCWallet) AddressUsed(addr string) (bool, error) {
+	return false, nil
+}
+
 func (w *TXCWallet) Unlock(pw []byte) error {
 	return w.unlockErr
 }

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -627,7 +627,7 @@ func (s *WebServer) apiAddressUsed(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:   true,
 		Used: used,
-	}, s.indent)
+	})
 }
 
 // apiConnectWallet is the handler for the '/connectwallet' API request.

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -600,6 +600,36 @@ func (s *WebServer) apiNewDepositAddress(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+// apiAddressUsed gets a new deposit address from a wallet.
+func (s *WebServer) apiAddressUsed(w http.ResponseWriter, r *http.Request) {
+	form := &struct {
+		AssetID *uint32 `json:"assetID"`
+		Addr    string  `json:"addr"`
+	}{}
+	if !readPost(w, r, form) {
+		return
+	}
+	if form.AssetID == nil {
+		s.writeAPIError(w, errors.New("missing asset ID"))
+		return
+	}
+	assetID := *form.AssetID
+
+	used, err := s.core.AddressUsed(assetID, form.Addr)
+	if err != nil {
+		s.writeAPIError(w, err)
+		return
+	}
+
+	writeJSON(w, &struct {
+		OK   bool `json:"ok"`
+		Used bool `json:"used"`
+	}{
+		OK:   true,
+		Used: used,
+	}, s.indent)
+}
+
 // apiConnectWallet is the handler for the '/connectwallet' API request.
 // Connects to a specified wallet, but does not unlock it.
 func (s *WebServer) apiConnectWallet(w http.ResponseWriter, r *http.Request) {

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -600,7 +600,7 @@ func (s *WebServer) apiNewDepositAddress(w http.ResponseWriter, r *http.Request)
 	})
 }
 
-// apiAddressUsed gets a new deposit address from a wallet.
+// apiAddressUsed checks whether an address has been used.
 func (s *WebServer) apiAddressUsed(w http.ResponseWriter, r *http.Request) {
 	form := &struct {
 		AssetID *uint32 `json:"assetID"`

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1657,6 +1657,10 @@ func (c *TCore) NewDepositAddress(assetID uint32) (string, error) {
 	return ordertest.RandomAddress(), nil
 }
 
+func (c *TCore) AddressUsed(assetID uint32, addr string) (bool, error) {
+	return rand.Float32() > 0.5, nil
+}
+
 func (c *TCore) SetWalletPassword(appPW []byte, assetID uint32, newPW []byte) error { return nil }
 
 func (c *TCore) User() *core.User {

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -688,4 +688,5 @@ var EnUS = map[string]*intl.Translation{
 	"Placements":                  {T: "Placements"},
 	"delete_bot":                  {T: "Delete Bot"},
 	"export_logs":                 {T: "Export Logs"},
+	"address has been used":       {T: "address has been used"},
 }

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -135,14 +135,11 @@
 <div id="unifiedReceivers" class="d-flex align-items-stretch">
   <div id="unifiedReceiverTmpl" class="p-1 me-2 hoverbg lh1 fs15 pointer brdr selectable"></div>
 </div>
-<div id="newDepAddrBttnBox" class="flex-stretch-column">
-  <button id="newDepAddrBttn" type="button" class="feature">[[[New Address]]]</button>
-</div>
-<div id="addrUsed" class="mt-3 fs15 grey">
+<div id="addrUsed" class="my-1 text-center fs15 grey lh1 text-warning">
   [[[address has been used]]]
 </div>
-<div class="my-3">
-  <button id="newDepAddrBttn" type="button" class=" px-2 justify-content-center fs15 bg2 selected">[[[New Deposit Address]]]</button>
+<div id="newDepAddrBttnBox" class="flex-stretch-column">
+  <button id="newDepAddrBttn" type="button" class="feature">[[[New Address]]]</button>
 </div>
 <div class="fs15 text-center d-hide text-danger text-break" id="depositErr"></div>
 {{end}}

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -138,6 +138,12 @@
 <div id="newDepAddrBttnBox" class="flex-stretch-column">
   <button id="newDepAddrBttn" type="button" class="feature">[[[New Address]]]</button>
 </div>
+<div id="addrUsed" class="mt-3 fs15 grey">
+  [[[address has been used]]]
+</div>
+<div class="my-3">
+  <button id="newDepAddrBttn" type="button" class=" px-2 justify-content-center fs15 bg2 selected">[[[New Deposit Address]]]</button>
+</div>
 <div class="fs15 text-center d-hide text-danger text-break" id="depositErr"></div>
 {{end}}
 

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -1953,6 +1953,8 @@ export class DepositAddress {
 
   handleTx (assetID: number, tx: WalletTransaction) {
     if (assetID !== this.assetID) return
+    const wallet = app().walletMap[assetID]
+    if ((wallet.traits & traitNewAddresser) === 0) return
     const { page, addr } = this
     if (tx.amount > 0 && tx.recipient === addr) Doc.show(page.addrUsed)
   }

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -28,7 +28,8 @@ import {
   Token,
   WalletCreationNote,
   CoreNote,
-  PrepaidBondID
+  PrepaidBondID,
+  WalletTransaction
 } from './registry'
 import { XYRangeHandler } from './opts'
 import { CoinExplorers } from './coinexplorers'
@@ -1864,6 +1865,7 @@ export class DepositAddress {
   form: PageElement
   page: Record<string, PageElement>
   assetID: number
+  addr: string
 
   constructor (form: PageElement) {
     this.form = form
@@ -1877,11 +1879,17 @@ export class DepositAddress {
   async setAsset (assetID: number) {
     this.assetID = assetID
     const page = this.page
-    Doc.hide(page.depositErr, page.depositTokenMsgBox)
+    Doc.hide(page.depositErr, page.depositTokenMsgBox, page.addrUsed)
     const asset = app().assets[assetID]
     page.depositLogo.src = Doc.logoPath(asset.symbol)
     const wallet = app().walletMap[assetID]
     page.depositName.textContent = asset.unitInfo.conventional.unit
+    const addr = this.addr = wallet.address
+    if ((wallet.traits & traitNewAddresser) !== 0) {
+      const res = await postJSON('/api/addressused', { assetID, addr })
+      const used = app().checkResponse(res) && res.used
+      Doc.setVis(used, page.addrUsed)
+    }
     if (asset.token) {
       const parentAsset = app().assets[asset.token.parentID]
       page.depositTokenParentLogo.src = Doc.logoPath(parentAsset.symbol)
@@ -1889,7 +1897,7 @@ export class DepositAddress {
       Doc.show(page.depositTokenMsgBox)
     }
     Doc.setVis((wallet.traits & traitNewAddresser) !== 0, page.newDepAddrBttnBox)
-    this.setAddress(wallet.address)
+    this.setAddress(addr)
   }
 
   setAddress (addr: string) {
@@ -1940,11 +1948,18 @@ export class DepositAddress {
     }
     app().walletMap[assetID].address = res.address
     this.setAddress(res.address)
+    Doc.hide(page.addrUsed)
+  }
+
+  handleTx (assetID: number, tx: WalletTransaction) {
+    if (assetID !== this.assetID) return
+    const { page, addr } = this
+    if (tx.amount > 0 && tx.recipient === addr) Doc.show(page.addrUsed)
   }
 
   async copyAddress () {
-    const page = this.page
-    navigator.clipboard.writeText(page.depositAddress.textContent || '')
+    const { page, addr } = this
+    navigator.clipboard.writeText(addr)
       .then(() => {
         Doc.show(page.copyAlert)
         setTimeout(() => {

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1848,6 +1848,8 @@ export default class WalletsPage extends BasePage {
   }
 
   handleTxNote (tx: WalletTransaction, newTx: boolean) {
+    const { selectedAssetID: assetID } = this
+    this.depositAddrForm.handleTx(assetID, tx)
     const w = app().assets[this.selectedAssetID].wallet
     const hideMixing = (w.traits & traitFundsMixer) !== 0 && !!this.page.hideMixTxs.checked
     if (hideMixing && tx.type === txTypeMixing) return
@@ -1856,20 +1858,20 @@ export default class WalletsPage extends BasePage {
         Doc.show(this.page.txHistoryTable)
         Doc.hide(this.page.noTxHistory)
         this.page.txHistoryTableBody.appendChild(this.txHistoryDateRow(this.txDate(tx)))
-        this.page.txHistoryTableBody.appendChild(this.txHistoryRow(tx, this.selectedAssetID))
+        this.page.txHistoryTableBody.appendChild(this.txHistoryRow(tx, assetID))
         this.oldestTx = tx
       } else if (this.txDate(tx) !== this.txHistoryTableNewestDate()) {
-        this.page.txHistoryTableBody.insertBefore(this.txHistoryRow(tx, this.selectedAssetID), this.page.txHistoryTableBody.children[0])
+        this.page.txHistoryTableBody.insertBefore(this.txHistoryRow(tx, assetID), this.page.txHistoryTableBody.children[0])
         this.page.txHistoryTableBody.insertBefore(this.txHistoryDateRow(this.txDate(tx)), this.page.txHistoryTableBody.children[0])
       } else {
-        this.page.txHistoryTableBody.insertBefore(this.txHistoryRow(tx, this.selectedAssetID), this.page.txHistoryTableBody.children[1])
+        this.page.txHistoryTableBody.insertBefore(this.txHistoryRow(tx, assetID), this.page.txHistoryTableBody.children[1])
       }
       return
     }
     for (const row of this.page.txHistoryTableBody.children) {
       const peRow = row as PageElement
       if (peRow.dataset.txid === tx.id) {
-        this.updateTxHistoryRow(peRow, tx, this.selectedAssetID)
+        this.updateTxHistoryRow(peRow, tx, assetID)
         break
       }
     }

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -116,6 +116,7 @@ type clientCore interface {
 	ChangeAppPass([]byte, []byte) error
 	ResetAppPass(newPass []byte, seed string) error
 	NewDepositAddress(assetID uint32) (string, error)
+	AddressUsed(assetID uint32, addr string) (bool, error)
 	AutoWalletConfig(assetID uint32, walletType string) (map[string]string, error)
 	User() *core.User
 	GetDEXConfig(dexAddr string, certI any) (*core.Exchange, error)
@@ -538,6 +539,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/newwallet", s.apiNewWallet)
 			apiAuth.Post("/openwallet", s.apiOpenWallet)
 			apiAuth.Post("/depositaddress", s.apiNewDepositAddress)
+			apiAuth.Post("/addressused", s.apiAddressUsed)
 			apiAuth.Post("/closewallet", s.apiCloseWallet)
 			apiAuth.Post("/connectwallet", s.apiConnectWallet)
 			apiAuth.Post("/rescanwallet", s.apiRescanWallet)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -62,6 +62,7 @@ func (c *tCoin) Confirmations(context.Context) (uint32, error) {
 }
 
 type TCore struct {
+	clientCore       // This is here so we don't have to implement core methods we're not testing
 	balanceErr       error
 	syncFeed         core.BookFeed
 	syncErr          error


### PR DESCRIPTION
Closes #2662
Alternative to #2685

Marks used addresses. Doesn't show tx info on the deposit form, but does show the used address indicator when the tx is seen.

![image](https://github.com/decred/dcrdex/assets/6109680/a130627b-457b-4f89-862d-7f3ac9e44376)
