### PR TITLE
core: Fix deadlock in `c.connectWalletResumeTrades`

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1994,13 +1994,14 @@ func (c *Core) connectWalletResumeTrades(w *xcWallet, resumeTrades bool) (deposi
 	}
 
 	w.mtx.RLock()
-	defer w.mtx.RUnlock()
 	depositAddr = w.address
+	synced := w.synced
+	w.mtx.RUnlock()
 
 	// If the wallet is synced, update the bond reserves, logging any balance
 	// insufficiencies, otherwise start a loop to check the sync status until it
 	// is.
-	if w.synced {
+	if synced {
 		c.updateBondReserves(w.AssetID)
 	} else {
 		c.startWalletSyncMonitor(w)


### PR DESCRIPTION
This PR resolves a deadlock when `c.connectWalletResumeTrades` defers a `RUnlock`, and another goroutine (`c.handleWalletNotification` or `c.peerChange`) tries to hold a write lock (blocks as expected) and code path in `updateBondReserves` tries to hold another `RLock` (this will block waiting for the write lock in `c.handleWalletNotification` or `c.peerChange`, which in turn is waiting for the deferred `RUnlock`).

