### PR TITLE
server: Health API endpoint

### DIFF
--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -196,6 +196,9 @@ const (
 	// ConfigRoute is the client-originating request-type message requesting the
 	// DEX configuration information.
 	ConfigRoute = "config"
+	// HealthRoute is the client-originating request-type message requesting the
+	// DEX's health status.
+	HealthRoute = "healthy"
 	// MatchProofRoute is the DEX-originating notification-type message
 	// delivering match cycle results to the client.
 	MatchProofRoute = "match_proof"

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -1476,7 +1476,7 @@ func (dm *DEX) Healthy() bool {
 		return false
 	}
 	if assetID, found := dex.BipSymbolID("btc"); found {
-		if synced, err := dm.assets[assetID].Backend.Synced(); err != nil || !synced {
+		if synced, _ := dm.assets[assetID].Backend.Synced(); !synced {
 			return false
 		}
 	}


### PR DESCRIPTION
This PR adds a `/healthy` endpoint to the API, to be consumed by a status page monitoring the health of the platform.  The status returns `false` if `storage.LastErr()` is non-nil, or the BTC asset backend reports the chain being out of sync (via `Synced()`).

The necessity of the latter is debatable but it feels like that, BTC being one of the main assets, it indicates that the DEX as a service does not function as intended when that chain is not synced.

Also, `storage.fatalErr` is not being reset after a (transient) DB error.

Thoughts, suggestions?