### PR TITLE
multi: add pre-paid bonds

### DIFF
--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -15,6 +15,7 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/keygen"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/hdkeychain/v3"
 )
@@ -807,19 +808,20 @@ func (c *Core) postBond(dc *dexConnection, bond *asset.Bond) (*msgjson.PostBondR
 		return nil, codedError(registerErr, err)
 	}
 
-	dc.acct.authMtx.Lock()
-	dc.updateReputation(postBondRes.Reputation, postBondRes.Tier, nil, nil)
-	dc.acct.authMtx.Unlock()
-
 	// Check the response signature.
 	err = dc.acct.checkSig(postBondRes.Serialize(), postBondRes.Sig)
 	if err != nil {
 		c.log.Warnf("postbond: DEX signature validation error: %v", err)
 	}
+
 	if !bytes.Equal(postBondRes.BondID, bondCoin) {
 		return nil, fmt.Errorf("server reported bond coin ID %v, expected %v", coinIDString(assetID, postBondRes.BondID),
 			bondCoinStr)
 	}
+
+	dc.acct.authMtx.Lock()
+	dc.updateReputation(postBondRes.Reputation, postBondRes.Tier, nil, nil)
+	dc.acct.authMtx.Unlock()
 
 	return postBondRes, nil
 }
@@ -924,6 +926,135 @@ func (c *Core) monitorBondConfs(dc *dexConnection, bond *asset.Bond, reqConfs ui
 
 		c.postAndConfirmBond(dc, bond) // if it fails (e.g. timeout), retry in rotateBonds
 	})
+}
+
+// RedeemPrepaidBond redeems a pre-paid bond for a dcrdex host server.
+func (c *Core) RedeemPrepaidBond(appPW []byte, code []byte, host string, certI any) (tier uint64, err error) {
+	// Make sure the app has been initialized.
+	if !c.IsInitialized() {
+		return 0, fmt.Errorf("app not initialized")
+	}
+
+	// Check the app password.
+	crypter, err := c.encryptionKey(appPW)
+	if err != nil {
+		return 0, codedError(passwordErr, err)
+	}
+	defer crypter.Close()
+
+	var success, acctExists bool
+
+	c.connMtx.RLock()
+	dc, found := c.conns[host]
+	c.connMtx.RUnlock()
+	if found {
+		acctExists = !dc.acct.isViewOnly()
+		if acctExists {
+			if dc.acct.locked() { // require authDEX first to reconcile any existing bond statuses
+				return 0, newError(acctKeyErr, "acct locked %s (login first)", host)
+			}
+		}
+	} else {
+		// New DEX connection.
+		cert, err := parseCert(host, certI, c.net)
+		if err != nil {
+			return 0, newError(fileReadErr, "failed to read certificate file from %s: %v", cert, err)
+		}
+		dc, err = c.connectDEX(&db.AccountInfo{
+			Host: host,
+			Cert: cert,
+			// bond maintenance options set below.
+		})
+		if err != nil {
+			return 0, codedError(connectionErr, err)
+		}
+
+		// Close the connection to the dex server if the registration fails.
+		defer func() {
+			if !success {
+				dc.connMaster.Disconnect()
+			}
+		}()
+	}
+
+	if !acctExists { // new dex connection or pre-existing view-only connection
+		_, err := c.discoverAccount(dc, crypter)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	pkBytes := dc.acct.pubKey()
+	if len(pkBytes) == 0 {
+		return 0, fmt.Errorf("account keys not decrypted")
+	}
+
+	// Do a postbond request with the raw bytes of the unsigned tx, the bond
+	// script, and our account pubkey.
+	postBond := &msgjson.PostBond{
+		AcctPubKey: pkBytes,
+		AssetID:    account.PrepaidBondID,
+		// Version:    0,
+		CoinID: code,
+	}
+	postBondRes := new(msgjson.PostBondResult)
+	if err = dc.signAndRequest(postBond, msgjson.PostBondRoute, postBondRes, DefaultResponseTimeout); err != nil {
+		return 0, codedError(registerErr, err)
+	}
+
+	// Check the response signature.
+	err = dc.acct.checkSig(postBondRes.Serialize(), postBondRes.Sig)
+	if err != nil {
+		c.log.Warnf("postbond: DEX signature validation error: %v", err)
+	}
+
+	lockTime := postBondRes.Expiry + dc.config().BondExpiry
+
+	dbBond := &db.Bond{
+		// Version:    0,
+		AssetID:   account.PrepaidBondID,
+		CoinID:    code,
+		LockTime:  lockTime,
+		Strength:  postBondRes.Strength,
+		Confirmed: true,
+	}
+
+	dc.acct.authMtx.Lock()
+	dc.updateReputation(postBondRes.Reputation, postBondRes.Tier, nil, nil)
+	dc.acct.bonds = append(dc.acct.bonds, dbBond)
+	dc.acct.authMtx.Unlock()
+
+	defer func() {
+		if success {
+			c.notify(newBondAuthUpdate(dc.acct.host, c.exchangeAuth(dc)))
+		}
+	}()
+
+	if acctExists {
+		err = c.db.AddBond(dc.acct.host, dbBond)
+		if err != nil {
+			return 0, fmt.Errorf("failed to store pre-paid bond for dex %s: %w", host, err)
+		}
+	} else {
+		dc.acct.keyMtx.RLock()
+		ai := &db.AccountInfo{
+			Host:      dc.acct.host,
+			Cert:      dc.acct.cert,
+			DEXPubKey: dc.acct.dexPubKey,
+			EncKeyV2:  dc.acct.encKey,
+			Bonds:     []*db.Bond{dbBond},
+		}
+		dc.acct.keyMtx.RUnlock()
+		err = c.dbCreateOrUpdateAccount(dc, ai)
+		if err != nil {
+			return 0, fmt.Errorf("failed to store pre-paid account for dex %s: %w", host, err)
+		}
+	}
+
+	c.updateBondReserves()
+
+	success = true
+	return uint64(postBondRes.Strength), nil
 }
 
 func deriveBondKey(bondXPriv *hdkeychain.ExtendedKey, assetID, bondIndex uint32) (*secp256k1.PrivateKey, error) {

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -1116,6 +1116,9 @@ func token(id []byte) string {
 // coinIDString converts a coin ID to a human-readable string. If an error is
 // encountered the value starting with "<invalid coin>:" prefix is returned.
 func coinIDString(assetID uint32, coinID []byte) string {
+	if assetID == account.PrepaidBondID {
+		return "prepaid-bond:" + hex.EncodeToString(coinID)
+	}
 	coinStr, err := asset.DecodeCoinID(assetID, coinID)
 	if err != nil {
 		// Logging error here with fmt.Printf is better than dropping it. It's not

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -638,7 +638,7 @@ func (c *TCore) GetDEXConfig(host string, certI any) (*core.Exchange, error) {
 	return tExchanges[firstDEX], nil
 }
 
-func (c *TCore) AddDEX(dexAddr string, certI any) error {
+func (c *TCore) AddDEX(appPW []byte, dexAddr string, certI any) error {
 	randomDelay()
 	if initErrors {
 		return fmt.Errorf("forced init error")
@@ -680,6 +680,9 @@ func (c *TCore) PostBond(form *core.PostBondForm) (*core.PostBondResult, error) 
 		BondID:      "abc",
 		ReqConfirms: uint16(ba.Confs),
 	}, nil
+}
+func (c *TCore) RedeemPrepaidBond(appPW []byte, code []byte, host string, certI any) (tier uint64, err error) {
+	return 1, nil
 }
 func (c *TCore) UpdateBondOptions(form *core.BondOptionsForm) error {
 	xc := tExchanges[form.Host]

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -13,7 +13,7 @@
 </head>
 <body >
   <div class="popup-notes d-hide" id="popupNotes">
-    <span data-tmpl="note fs15">
+    <span data-tmpl="note" class="fs15">
       <div class="note-indicator d-inline-block" data-tmpl="indicator"></div>
       <span data-tmpl="text"></span>
     </span>

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -263,7 +263,7 @@
 <div data-tmpl="assetForm">
   <h3 class="text-center">[[[Select your bond asset]]]</h3>
   <div data-tmpl="regAssetErr" class="fs14 text-danger flex-center"></div>
-  <div data-tmpl="bondAssets" class="mt-2">
+  <div data-tmpl="bondAssets">
 
     <div data-tmpl="bondAssetTmpl" class="border rounded3 d-flex align-items-stretch p-2 hoverbg pointer mt-3">
       <div class="flex-center pe-4">
@@ -287,6 +287,10 @@
     </div>
 
   </div>
+  <button type="button" data-tmpl="usePrepaidBond" class="w-100 mt-3">
+    <span class="ico-ticket fs22 me-2"></span>
+    <span class="fs22">Use a pre-paid bond</span>
+  </button>
   <div data-tmpl="whatsABond" class="flex-center fs18 hoverbg pointer underline pt-2 pb-1 mt-1">[[[what_s_a_bond]]]</div>
 </div>
 
@@ -430,6 +434,22 @@
 
     </tbody>
   </table>
+</div>
+<div data-tmpl="prepaidBonds" class="d-hide">
+  <div class="py-2 fs14 grey">
+    <span class="hoverbg pointer" data-tmpl="ppbGoBack"><span class="ico-arrowback fs12 me-1"></span> go back</span>
+  </div>
+  <h3>Redeem Pre-paid Bond</h3>
+  <label for="prepaidBondCode">Code</label>
+  <input type="text" data-tmpl="prepaidBondCode" autocomplete="off">
+  <div data-tmpl="prepaidBondPWBox">
+    <label for="ppbAppPW">[[[Password]]]</label>
+    <input type="password" data-tmpl="prepaidBondPW" autocomplete="off">
+  </div>
+  <div data-tmpl="prepaidBondErr" class="pt-2 px-2 text-danger d-hide"></div>
+  <div class="text-left mt-2">
+    <button data-tmpl="submitPrepaidBond" type="button" class="go">[[[Submit]]]</button>
+  </div>
 </div>
 {{end}}
 

--- a/client/webserver/site/src/html/register.tmpl
+++ b/client/webserver/site/src/html/register.tmpl
@@ -42,7 +42,6 @@
     <form class="d-hide" id="walletWait">
       {{template "waitingForWalletForm"}}
     </form>
-
   </div>
 </div>
 {{template "bottom"}}

--- a/client/webserver/site/src/js/dexsettings.ts
+++ b/client/webserver/site/src/js/dexsettings.ts
@@ -11,7 +11,8 @@ import {
   ConnectionStatus,
   Exchange,
   PasswordCache,
-  WalletState
+  WalletState,
+  PrepaidBondID
 } from './registry'
 
 interface Animator {
@@ -82,6 +83,12 @@ export default class DexSettingsPage extends BasePage {
     }, this.pwCache)
 
     this.regAssetForm = new forms.FeeAssetSelectionForm(page.regAssetForm, async (assetID: number, tier: number) => {
+      if (assetID === PrepaidBondID) {
+        await app().fetchUser()
+        this.updateReputation()
+        this.showSuccess(intl.prep(intl.ID_TRADING_TIER_UPDATED))
+        return
+      }
       const asset = app().assets[assetID]
       const wallet = asset.wallet
       if (wallet) {
@@ -95,8 +102,8 @@ export default class DexSettingsPage extends BasePage {
       this.confirmRegisterForm.setAsset(assetID, tier, 0)
       this.newWalletForm.setAsset(assetID)
       this.showForm(page.newWalletForm)
-    })
-    this.regAssetForm.setExchange(xc)
+    }, this.pwCache)
+    this.regAssetForm.setExchange(xc, '')
 
     this.reputationMeter = new ReputationMeter(page.repMeter)
     this.reputationMeter.setHost(host)
@@ -109,7 +116,7 @@ export default class DexSettingsPage extends BasePage {
     Doc.bind(page.goBackToSettings, 'click', () => app().loadPage('settings'))
 
     const showTierForm = () => {
-      this.regAssetForm.setExchange(app().exchanges[host]) // reset form
+      this.regAssetForm.setExchange(app().exchanges[host], '') // reset form
       this.showForm(page.regAssetForm)
     }
     Doc.bind(page.changeTier, 'click', () => { showTierForm() })

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -27,7 +27,8 @@ import {
   WalletInfo,
   Token,
   WalletCreationNote,
-  CoreNote
+  CoreNote,
+  PrepaidBondID
 } from './registry'
 import { XYRangeHandler } from './opts'
 import { CoinExplorers } from './coinexplorers'
@@ -883,7 +884,6 @@ export class ConfirmRegistrationForm {
     Doc.hide(page.regErr)
     const xc = app().exchanges[host]
     const bondAsset = xc.bondAssets[asset.wallet.symbol]
-    const cert = await certFile
     const dexAddr = xc.host
     const pw = page.appPass.value || (pwCache ? pwCache.pw : '')
     let form: any
@@ -892,7 +892,7 @@ export class ConfirmRegistrationForm {
     if (xc.viewOnly || !app().exchanges[xc.host]) {
       form = {
         addr: dexAddr,
-        cert: cert,
+        cert: certFile,
         pass: pw,
         bond: bondAsset.amount * tier,
         asset: bondAsset.id
@@ -937,12 +937,16 @@ export class FeeAssetSelectionForm {
   success: (assetID: number, tier: number) => Promise<void>
   host: string
   selectedAssetID: number
+  certFile: string
   page: Record<string, PageElement>
   assetRows: Record<string, RegAssetRow>
   marketRows: MarketLimitsRow[]
+  pwCache: PasswordCache
 
-  constructor (form: HTMLElement, success: (assetID: number, tier: number) => Promise<void>) {
+  constructor (form: HTMLElement, success: (assetID: number, tier: number) => Promise<void>, pwCache: PasswordCache) {
     this.form = form
+    this.pwCache = pwCache
+    this.certFile = ''
     this.success = success
     const page = this.page = Doc.parseTemplate(form)
     Doc.cleanTemplates(page.currentBondTmpl, page.bondAssetTmpl, page.marketTmpl)
@@ -973,6 +977,10 @@ export class FeeAssetSelectionForm {
 
     Doc.bind(page.whatsABondBack, 'click', () => { hideWhatsABond() })
 
+    Doc.bind(page.usePrepaidBond, 'click', () => { this.showPrepaidBondForm() })
+    Doc.bind(page.ppbGoBack, 'click', () => { this.hidePrepaidBondForm() })
+    Doc.bind(page.submitPrepaidBond, 'click', () => { this.submitPrepaidBond() })
+
     app().registerNoteFeeder({
       createwallet: (note: WalletCreationNote) => {
         if (note.topic === 'QueuedCreationSuccess') this.walletCreated(note.assetID)
@@ -994,12 +1002,13 @@ export class FeeAssetSelectionForm {
     Doc.hide(this.page.regAssetErr, this.page.tradingTierErr)
   }
 
-  setExchange (xc: Exchange) {
+  setExchange (xc: Exchange, certFile: string) {
     this.host = xc.host
+    this.certFile = certFile
     this.assetRows = {}
     this.marketRows = []
     const page = this.page
-    Doc.hide(page.assetForm, page.tradingTierForm, page.whatsABondPanel)
+    Doc.hide(page.assetForm, page.tradingTierForm, page.whatsABondPanel, page.prepaidBonds)
     Doc.empty(page.bondAssets, page.markets)
     this.clearErrors()
 
@@ -1092,15 +1101,16 @@ export class FeeAssetSelectionForm {
   }
 
   refresh () {
-    this.setExchange(app().exchanges[this.host])
+    this.setExchange(app().exchanges[this.host], this.certFile)
   }
 
   assetSelected (assetID: number) {
     this.selectedAssetID = assetID
     this.setTier()
-    Doc.hide(this.page.assetForm)
-    Doc.show(this.page.tradingTierForm)
-    this.page.tradingTierInput.focus()
+    const { page: { assetForm, tradingTierForm, tradingTierInput } } = this
+    Doc.hide(assetForm)
+    Doc.show(tradingTierForm)
+    tradingTierInput.focus()
   }
 
   setTier () {
@@ -1195,6 +1205,42 @@ export class FeeAssetSelectionForm {
       form.style.opacity = Math.pow(prog, 4).toFixed(1)
       form.style.top = `${(1 - prog) * extraTop}px`
     }, 'easeOut')
+  }
+
+  showPrepaidBondForm () {
+    const { page, pwCache } = this
+    Doc.hide(page.assetForm, page.prepaidBondErr)
+    page.prepaidBondCode.value = ''
+    page.prepaidBondPW.value = ''
+    const hidePWBox = State.passwordIsCached() || (pwCache && pwCache.pw)
+    Doc.setVis(!hidePWBox, page.prepaidBondPWBox)
+    Doc.show(page.prepaidBonds)
+  }
+
+  hidePrepaidBondForm () {
+    const { page } = this
+    Doc.hide(page.prepaidBonds)
+    Doc.show(page.assetForm)
+  }
+
+  async submitPrepaidBond () {
+    const { page, host } = this
+    Doc.hide(page.prepaidBondErr)
+    const code = page.prepaidBondCode.value
+    if (!code) {
+      page.prepaidBondErr.textContent = intl.prep(intl.ID_INVALID_VALUE)
+      Doc.show(page.prepaidBondErr)
+      return
+    }
+    const appPW = page.prepaidBondPW.value || ''
+    const res = await postJSON('/api/redeemprepaidbond', { appPW, host, code, cert: this.certFile })
+    if (!app().checkResponse(res)) {
+      page.prepaidBondErr.textContent = res.msg
+      Doc.show(page.prepaidBondErr)
+      return
+    }
+    if (appPW && this.pwCache) this.pwCache.pw = appPW
+    this.success(PrepaidBondID, res.tier)
   }
 }
 

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -1224,7 +1224,7 @@ export class FeeAssetSelectionForm {
   }
 
   async submitPrepaidBond () {
-    const { page, host } = this
+    const { page, host, pwCache } = this
     Doc.hide(page.prepaidBondErr)
     const code = page.prepaidBondCode.value
     if (!code) {
@@ -1232,7 +1232,7 @@ export class FeeAssetSelectionForm {
       Doc.show(page.prepaidBondErr)
       return
     }
-    const appPW = page.prepaidBondPW.value || ''
+    const appPW = page.prepaidBondPW.value || (pwCache ? pwCache.pw : '')
     const res = await postJSON('/api/redeemprepaidbond', { appPW, host, code, cert: this.certFile })
     if (!app().checkResponse(res)) {
       page.prepaidBondErr.textContent = res.msg

--- a/client/webserver/site/src/js/init.ts
+++ b/client/webserver/site/src/js/init.ts
@@ -238,7 +238,7 @@ class QuickConfigForm {
       if (!srvRow.checkbox.checked) return
       const req = {
         addr: srvRow.host,
-        pass: this.pw
+        appPW: this.pw
       }
       const res = await postJSON('/api/adddex', req) // DRAFT NOTE: ignore errors ok?
       if (!app().checkResponse(res)) failedHosts.push(srvRow.host)

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -775,7 +775,7 @@ export default class MarketsPage extends BasePage {
     }
 
     Doc.setVis(this.mmRunning, page.mmRunning)
-    Doc.setVis(!this.mmRunning, page.orderForm, page.orderTypeBttns)
+    if (this.mmRunning) Doc.hide(page.orderForm, page.orderTypeBttns)
   }
 
   /* setLoaderMsgVisibility displays a message in case a dex asset is not

--- a/client/webserver/site/src/js/register.ts
+++ b/client/webserver/site/src/js/register.ts
@@ -16,7 +16,8 @@ import {
   app,
   PasswordCache,
   Exchange,
-  PageElement
+  PageElement,
+  PrepaidBondID
 } from './registry'
 import State from './state'
 
@@ -102,6 +103,10 @@ export default class RegistrationPage extends BasePage {
 
     // SELECT REG ASSET
     this.regAssetForm = new FeeAssetSelectionForm(page.regAssetForm, async (assetID: number, tier: number) => {
+      if (assetID === PrepaidBondID) {
+        this.registerDEXSuccess()
+        return
+      }
       const asset = app().assets[assetID]
       const xc = app().exchanges[this.host]
       const wallet = asset.wallet
@@ -120,7 +125,7 @@ export default class RegistrationPage extends BasePage {
       this.confirmRegisterForm.tier = tier
       this.newWalletForm.setAsset(assetID)
       slideSwap(page.regAssetForm, page.newWalletForm)
-    })
+    }, this.pwCache)
 
     this.walletWaitForm = new WalletWaitForm(page.walletWait, () => {
       this.animateConfirmForm(page.walletWait)
@@ -170,7 +175,7 @@ export default class RegistrationPage extends BasePage {
     this.host = xc.host
     this.confirmRegisterForm.setExchange(xc, certFile)
     this.walletWaitForm.setExchange(xc)
-    this.regAssetForm.setExchange(xc)
+    this.regAssetForm.setExchange(xc, certFile)
     this.animateRegAsset(oldForm)
   }
 

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -1012,6 +1012,8 @@ export interface TxHistoryResult {
   lastTx: boolean
 }
 
+export const PrepaidBondID = 2147483647
+
 export interface Application {
   assets: Record<number, SupportedAsset>
   seedGenTime: number

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -15,7 +15,8 @@ import {
   app,
   Exchange,
   PageElement,
-  PasswordCache
+  PasswordCache,
+  PrepaidBondID
 } from './registry'
 
 const animationLength = 300
@@ -83,6 +84,11 @@ export default class SettingsPage extends BasePage {
 
     // Asset selection
     this.regAssetForm = new forms.FeeAssetSelectionForm(page.regAssetForm, async (assetID: number, tier: number) => {
+      if (assetID === PrepaidBondID) {
+        await app().fetchUser()
+        window.location.reload()
+        return
+      }
       const asset = app().assets[assetID]
       const wallet = asset.wallet
       if (wallet) {
@@ -101,7 +107,7 @@ export default class SettingsPage extends BasePage {
       this.confirmRegisterForm.setAsset(assetID, tier, 0)
       this.newWalletForm.setAsset(assetID)
       this.slideSwap(page.newWalletForm)
-    })
+    }, this.pwCache)
 
     // Approve fee payment
     this.confirmRegisterForm = new forms.ConfirmRegistrationForm(page.confirmRegForm, () => {
@@ -127,7 +133,7 @@ export default class SettingsPage extends BasePage {
       this.currentDEX = xc
       this.confirmRegisterForm.setExchange(xc, certFile)
       this.walletWaitForm.setExchange(xc)
-      this.regAssetForm.setExchange(xc)
+      this.regAssetForm.setExchange(xc, certFile)
       this.animateRegAsset(page.dexAddrForm)
     })
 

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -32,8 +32,9 @@ type loginForm struct {
 
 // addDexForm is used to connect a DEX without creating an account.
 type addDexForm struct {
-	Addr string `json:"addr"`
-	Cert string `json:"cert"`
+	Addr  string           `json:"addr"`
+	Cert  string           `json:"cert"`
+	AppPW encode.PassBytes `json:"appPW"`
 }
 
 // registrationForm is used to register a new DEX account.

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -99,7 +99,7 @@ func (c *TCore) Exchange(host string) (*core.Exchange, error) { return nil, nil 
 func (c *TCore) GetDEXConfig(dexAddr string, certI any) (*core.Exchange, error) {
 	return nil, c.getDEXConfigErr // TODO along with test for apiUser / Exchanges() / User()
 }
-func (c *TCore) AddDEX(dexAddr string, certI any) error {
+func (c *TCore) AddDEX(appPW []byte, dexAddr string, certI any) error {
 	return nil
 }
 func (c *TCore) DiscoverAccount(dexAddr string, pw []byte, certI any) (*core.Exchange, bool, error) {
@@ -108,6 +108,9 @@ func (c *TCore) DiscoverAccount(dexAddr string, pw []byte, certI any) (*core.Exc
 func (c *TCore) Register(r *core.RegisterForm) (*core.RegisterResult, error) { return nil, c.regErr }
 func (c *TCore) PostBond(r *core.PostBondForm) (*core.PostBondResult, error) {
 	return nil, c.postBondErr
+}
+func (c *TCore) RedeemPrepaidBond(appPW []byte, code []byte, host string, certI any) (tier uint64, err error) {
+	return 1, nil
 }
 func (c *TCore) UpdateBondOptions(form *core.BondOptionsForm) error {
 	return c.postBondErr

--- a/dex/bip-id.go
+++ b/dex/bip-id.go
@@ -637,6 +637,10 @@ var bipIDs = map[uint32]string{
 	91927009: "kusd",
 	99999998: "fluid",
 	99999999: "qkc",
+	// math.MaxInt32 is the highest ID we should gol for v1 non-mesh dcrdex cuz
+	// of db type used for asset ID.
+	// Reserved for pre-paid bonds.
+	2147483647: "reservedforprepaidbonds", // math.MaxInt32
 }
 
 // TokenChains is a map of token symbol to a list of [2]uint32, where the first

--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -1134,6 +1134,7 @@ type PostBondResult struct {
 	AssetID    uint32              `json:"assetID"`
 	Amount     uint64              `json:"amount"`
 	Expiry     uint64              `json:"expiry"` // not locktime, but time when bond expires for dex
+	Strength   uint32              `json:"strength"`
 	BondID     Bytes               `json:"bondID"`
 	Tier       int64               `json:"tier"`
 	Reputation *account.Reputation `json:"reputation"`

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 
 	"github.com/decred/dcrd/crypto/blake256"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -17,9 +18,10 @@ import (
 type PrivateKey = secp256k1.PrivateKey
 
 const (
-	PrivKeySize = secp256k1.PrivKeyBytesLen
-	PubKeySize  = secp256k1.PubKeyBytesLenCompressed
-	HashSize    = blake256.Size
+	PrivKeySize   = secp256k1.PrivKeyBytesLen
+	PubKeySize    = secp256k1.PubKeyBytesLenCompressed
+	HashSize      = blake256.Size
+	PrepaidBondID = math.MaxInt32
 )
 
 // HashFunc is the hash function used to generate account IDs from pubkeys.

--- a/server/admin/server.go
+++ b/server/admin/server.go
@@ -45,6 +45,8 @@ const (
 	scaleKey           = "scale"
 	includeInactiveKey = "includeinactive"
 	nKey               = "n"
+	daysKey            = "days"
+	strengthKey        = "strength"
 )
 
 var (
@@ -71,6 +73,7 @@ type SvrCore interface {
 	EpochOrders(base, quote uint32) (orders []order.Order, err error)
 	MarketMatchesStreaming(base, quote uint32, includeInactive bool, N int64, f func(*dexsrv.MatchData) error) (int, error)
 	EnableDataAPI(yes bool)
+	CreatePrepaidBonds(n int, strength uint32, durSecs int64) ([][]byte, error)
 }
 
 // Server is a multi-client https server.
@@ -161,6 +164,7 @@ func NewServer(cfg *SrvConfig) (*Server, error) {
 			rm.Get("/suspend", s.apiSuspend)
 			rm.Get("/resume", s.apiResume)
 		})
+		r.Get("/prepaybonds", s.prepayBonds)
 	})
 
 	return s, nil

--- a/server/admin/server_test.go
+++ b/server/admin/server_test.go
@@ -210,6 +210,9 @@ func (c *TCore) Unban(_ account.AccountID) error {
 func (c *TCore) ForgiveMatchFail(_ account.AccountID, _ order.MatchID) (bool, bool, error) {
 	return false, false, nil // TODO: tests
 }
+func (c *TCore) CreatePrepaidBonds(n int, strength uint32, durSecs int64) ([][]byte, error) {
+	return nil, nil
+}
 func (c *TCore) Notify(_ account.AccountID, _ *msgjson.Message) {}
 func (c *TCore) NotifyAll(_ *msgjson.Message)                   {}
 

--- a/server/auth/auth_test.go
+++ b/server/auth/auth_test.go
@@ -77,6 +77,13 @@ func (s *TStorage) Account(acct account.AccountID, lockTimeThresh time.Time) (*a
 func (s *TStorage) CreateAccountWithBond(acct *account.Account, bond *db.Bond) error { return nil }
 func (s *TStorage) AddBond(acct account.AccountID, bond *db.Bond) error              { return nil }
 func (s *TStorage) DeleteBond(assetID uint32, coinID []byte) error                   { return nil }
+func (s *TStorage) FetchPrepaidBond([]byte) (uint32, int64, error) {
+	return 1, time.Now().Add(time.Hour * 48).Unix(), nil
+}
+func (s *TStorage) DeletePrepaidBond(coinID []byte) (err error) { return nil }
+func (s *TStorage) StorePrepaidBonds(coinIDs [][]byte, strength uint32, lockTime int64) error {
+	return nil
+}
 func (s *TStorage) CompletedAndAtFaultMatchStats(aid account.AccountID, lastN int) ([]*db.MatchOutcome, error) {
 	return s.userMatchOutcomes, nil
 }

--- a/server/db/driver/pg/accounts.go
+++ b/server/db/driver/pg/accounts.go
@@ -155,6 +155,28 @@ func (a *Archiver) DeleteBond(assetID uint32, coinID []byte) error {
 	return deleteBond(a.db, a.tables.bonds, assetID, coinID)
 }
 
+func (a *Archiver) FetchPrepaidBond(coinID []byte) (strength uint32, lockTime int64, err error) {
+	stmt := fmt.Sprintf(internal.SelectPrepaidBond, prepaidBondsTableName)
+	err = a.db.QueryRow(stmt, coinID).Scan(&strength, &lockTime)
+	return
+}
+
+func (a *Archiver) DeletePrepaidBond(coinID []byte) (err error) {
+	stmt := fmt.Sprintf(internal.DeletePrepaidBond, prepaidBondsTableName)
+	_, err = a.db.ExecContext(a.ctx, stmt, coinID)
+	return
+}
+
+func (a *Archiver) StorePrepaidBonds(coinIDs [][]byte, strength uint32, lockTime int64) error {
+	stmt := fmt.Sprintf(internal.InsertPrepaidBond, prepaidBondsTableName)
+	for i := range coinIDs {
+		if _, err := a.db.ExecContext(a.ctx, stmt, coinIDs[i], strength, lockTime); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // AccountRegAddr retrieves the registration fee address and the corresponding
 // asset ID created for the the specified account.
 func (a *Archiver) AccountRegAddr(aid account.AccountID) (string, uint32, error) {

--- a/server/db/driver/pg/internal/accounts.go
+++ b/server/db/driver/pg/internal/accounts.go
@@ -95,4 +95,17 @@ const (
 	SetRegOutput = `UPDATE %s SET
 		fee_coin = $1
 		WHERE account_id = $2;`
+
+	CreatePrepaidBondsTable = `CREATE TABLE IF NOT EXISTS %s (
+		coin_id BYTEA PRIMARY KEY,
+		version INT2 DEFAULT 0,
+		strength int4,
+		lock_time INT8
+	);`
+
+	SelectPrepaidBond = `SELECT strength, lock_time FROM %s WHERE coin_id = $1;`
+
+	DeletePrepaidBond = `DELETE FROM %s WHERE coin_id = $1;`
+
+	InsertPrepaidBond = `INSERT INTO %s (coin_id, strength, lock_time) VALUES ($1, $2, $3);`
 )

--- a/server/db/driver/pg/pg.go
+++ b/server/db/driver/pg/pg.go
@@ -54,9 +54,10 @@ type Config struct {
 
 // Some frequently used long-form table names.
 type archiverTables struct {
-	feeKeys  string
-	accounts string
-	bonds    string
+	feeKeys      string
+	accounts     string
+	bonds        string
+	prepaidBonds string
 }
 
 // Archiver must implement server/db.DEXArchivist.
@@ -150,9 +151,10 @@ func NewArchiverForRead(ctx context.Context, cfg *Config) (*Archiver, error) {
 		queryTimeout: queryTimeout,
 		markets:      mktMap,
 		tables: archiverTables{
-			feeKeys:  fullTableName(cfg.DBName, publicSchema, feeKeysTableName),
-			accounts: fullTableName(cfg.DBName, publicSchema, accountsTableName),
-			bonds:    fullTableName(cfg.DBName, publicSchema, bondsTableName),
+			feeKeys:      fullTableName(cfg.DBName, publicSchema, feeKeysTableName),
+			accounts:     fullTableName(cfg.DBName, publicSchema, accountsTableName),
+			bonds:        fullTableName(cfg.DBName, publicSchema, bondsTableName),
+			prepaidBonds: fullTableName(cfg.DBName, publicSchema, prepaidBondsTableName),
 		},
 		fatal: make(chan struct{}),
 	}, nil

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -272,6 +272,10 @@ type AccountArchiver interface {
 	// DeleteBond deletes a bond which should generally be expired.
 	DeleteBond(assetID uint32, coinID []byte) error
 
+	FetchPrepaidBond(bondCoinID []byte) (strength uint32, lockTime int64, err error)
+	DeletePrepaidBond(coinID []byte) error
+	StorePrepaidBonds(coinIDs [][]byte, strength uint32, lockTime int64) error
+
 	// AccountRegAddr gets any legacy registration fee address and the
 	// corresponding asset ID for the account. (V0PURGE)
 	AccountRegAddr(account.AccountID) (string, uint32, error)

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -1459,6 +1459,10 @@ func (dm *DEX) ForgiveMatchFail(aid account.AccountID, mid order.MatchID) (forgi
 	return dm.authMgr.ForgiveMatchFail(aid, mid)
 }
 
+func (dm *DEX) CreatePrepaidBonds(n int, strength uint32, durSecs int64) ([][]byte, error) {
+	return dm.authMgr.CreatePrepaidBonds(n, strength, durSecs)
+}
+
 // Notify sends a text notification to a connected client.
 func (dm *DEX) Notify(acctID account.AccountID, msg *msgjson.Message) {
 	dm.authMgr.Notify(acctID, msg)


### PR DESCRIPTION
This adds "pre-paid bonds", invite codes generated by the server that the client uses to generate a cost-free, time-limited fidelity bond.

Access the pre-paid bond dialog with the button at the bottom of the bond tier dialog.

<img src="https://github.com/decred/dcrdex/assets/6109680/683a66d1-dd9c-4d13-895e-ce066ef24438" width="561">

Test on simnet with the `dextest/dcrdex/dexadm` script using `./dexadm "prepaybonds?days=365&n=2&strength=2"`

Closes #2728