### PR TITLE
polygon: switch to amoy

### DIFF
--- a/client/asset/eth/multirpc_test_util.go
+++ b/client/asset/eth/multirpc_test_util.go
@@ -1,4 +1,4 @@
-// //go:build rpclive
+//go:build rpclive
 
 package eth
 

--- a/client/asset/polygon/chaincfg.go
+++ b/client/asset/polygon/chaincfg.go
@@ -28,10 +28,10 @@ var (
 	}
 
 	testnetCompatibilityData = eth.CompatibilityData{
-		Addr:      common.HexToAddress("C26880A0AF2EA0c7E8130e6EC47Af756465452E8"),
-		TokenAddr: common.HexToAddress("0x734aeF51d427b2f745210Ec4BF1062ABd48Eceb6"), // weth
-		TxHash:    common.HexToHash("0xc592ac8975a58bc7ad48381f9a05c07a53a67b2a4448ad821ed7ef2dcd1a878a"),
-		BlockHash: common.HexToHash("0x5a2d26b5bd9d1995c25e211379671bce893befa31cf2a9704ff89f8682b3c6cf"),
+		Addr:      common.HexToAddress("0x248528f5A2C3731fb598E8cc1dc5dB5f997E74BC"),
+		TokenAddr: common.HexToAddress("0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"), // usdc
+		TxHash:    common.HexToHash("0x4097fc20d8566702f40323f19e351d5e2feb70dc2c99b90ababdb660351b5247"),
+		BlockHash: common.HexToHash("0x813a2898f25530a634fdaff7c3ceda786c934f476e6cd5556c32025ac103a90f"),
 	}
 )
 
@@ -90,7 +90,7 @@ func ChainConfig(net dex.Network) (c *params.ChainConfig, err error) {
 	case dex.Mainnet:
 		return dexpolygon.BorMainnetChainConfig, nil
 	case dex.Testnet:
-		return dexpolygon.MumbaiChainConfig, nil
+		return dexpolygon.AmoyChainConfig, nil
 	case dex.Simnet:
 	default:
 		return c, fmt.Errorf("unknown network %d", net)

--- a/client/asset/polygon/multirpc_live_test.go
+++ b/client/asset/polygon/multirpc_live_test.go
@@ -93,22 +93,12 @@ func TestFreeServers(t *testing.T) {
 }
 
 func TestFreeTestnetServers(t *testing.T) {
-	// https://wiki.polygon.technology/docs/pos/reference/rpc-endpoints/
-	// https://www.alchemy.com/chain-connect/chain/mumbai
-	// https://chainlist.org/chain/80001
+	// https://chainlist.org/chain/80002
+	// PASSING 24 April 2024
 	freeServers := []string{
-		// Passing
-		"https://rpc.ankr.com/polygon_mumbai",
-		"https://polygon-testnet.public.blastapi.io",
-		"https://polygon-mumbai.blockpi.network/v1/rpc/public",
-		"https://endpoints.omniatech.io/v1/matic/mumbai/public",
-		// Failing
-		"https://matic-testnet-archive-rpc.bwarelabs.com",                                         // connect error: failed to connect to even a single provider among: bwarelabs.com
-		"https://matic-mumbai.chainstacklabs.com",                                                 // connect error: failed to connect to even a single provider among: chainstacklabs.com
-		"https://g.w.lavanet.xyz:443/gateway/polygon1t/rpc-http/f7ee0000000000000000000000000000", // "TransactionReceipt" error: not found
-		"https://rpc-mumbai.maticvigil.com",                                                       // connect error: failed to connect to even a single provider among: maticvigil.com
-		"wss://polygon-mumbai-bor-rpc.publicnode.com",                                             // "TransactionReceipt" error: not found
-		"https://polygon-mumbai-pokt.nodies.app",                                                  // "TransactionReceipt" error: not found
+		"https://rpc-amoy.polygon.technology",
+		"wss://polygon-amoy-bor-rpc.publicnode.com",
+		"https://polygon-amoy.blockpi.network/v1/rpc/public",
 	}
 	mt.TestFreeServers(t, freeServers, dex.Testnet)
 }

--- a/client/asset/polygon/polygon.go
+++ b/client/asset/polygon/polygon.go
@@ -119,10 +119,9 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, net dex.Networ
 		defaultProviders = []string{filepath.Join(u.HomeDir, "dextest", "polygon", "alpha", "bor", "bor.ipc")}
 	case dex.Testnet:
 		defaultProviders = []string{
-			"https://rpc.ankr.com/polygon_mumbai",
-			"https://polygon-testnet.public.blastapi.io",
-			"https://polygon-mumbai.blockpi.network/v1/rpc/public",
-			"https://endpoints.omniatech.io/v1/matic/mumbai/public",
+			"https://rpc-amoy.polygon.technology",
+			"wss://polygon-amoy-bor-rpc.publicnode.com",
+			"https://polygon-amoy.blockpi.network/v1/rpc/public",
 		}
 	case dex.Mainnet:
 		defaultProviders = []string{

--- a/dex/networks/polygon/genesis_config.go
+++ b/dex/networks/polygon/genesis_config.go
@@ -33,10 +33,10 @@ var (
 		dex.Simnet:  SimnetChainID,
 	}
 
-	// MumbaiChainConfig contains the chain parameters to run a node on the
+	// mumbaiChainConfig contains the chain parameters to run a node on the
 	// Mumbai test network. This is a copy of
 	// https://github.com/maticnetwork/bor/blob/891ec7fef619cac0a796e3e29d5b2d4c095bdd9b/params/config.go#L336.
-	MumbaiChainConfig = &params.ChainConfig{
+	mumbaiChainConfig = &params.ChainConfig{
 		ChainID:             big.NewInt(80001),
 		HomesteadBlock:      big.NewInt(0),
 		DAOForkBlock:        nil,
@@ -70,7 +70,9 @@ var (
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
 		BerlinBlock:         big.NewInt(0),
-		LondonBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(73100),
+		// ShanghaiBlock:       big.NewInt(73100),
+		// CancunBlock:         big.NewInt(5423600),
 	}
 
 	// BorMainnetChainConfig is the genesis block of the Bor Mainnet network.
@@ -95,11 +97,26 @@ var (
 	}
 )
 
-// DefaultMumbaiGenesisBlock returns the Mumbai network genesis block. See:
-// https://github.com/maticnetwork/bor/blob/891ec7fef619cac0a796e3e29d5b2d4c095bdd9b/core/genesis.go#L495
-func DefaultMumbaiGenesisBlock() *core.Genesis {
+// DefaultAmoyGenesisBlock returns the Mumbai network genesis block. See:
+// https://github.com/maticnetwork/bor/blob/46f93b1f9415c8778d6e5ea2f3fad440f4572ba5/core/genesis.go#L616
+func DefaultAmoyGenesisBlock() *core.Genesis {
 	return &core.Genesis{
-		Config:     MumbaiChainConfig,
+		Config:     AmoyChainConfig,
+		Nonce:      0,
+		Timestamp:  1700225065,
+		GasLimit:   10000000,
+		Difficulty: big.NewInt(1),
+		Mixhash:    common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000000"),
+		Coinbase:   common.HexToAddress("0x0000000000000000000000000000000000000000"),
+		Alloc:      readPrealloc("allocs/amoy.json"),
+	}
+}
+
+// defaultMumbaiGenesisBlock returns the Mumbai network genesis block. See:
+// https://github.com/maticnetwork/bor/blob/891ec7fef619cac0a796e3e29d5b2d4c095bdd9b/core/genesis.go#L495
+func defaultMumbaiGenesisBlock() *core.Genesis {
+	return &core.Genesis{
+		Config:     mumbaiChainConfig,
 		Nonce:      0,
 		Timestamp:  1558348305,
 		GasLimit:   10000000,

--- a/dex/networks/polygon/params.go
+++ b/dex/networks/polygon/params.go
@@ -45,14 +45,14 @@ var (
 	ContractAddresses = map[uint32]map[dex.Network]common.Address{
 		0: {
 			dex.Mainnet: common.HexToAddress("0xd45e648D97Beb2ee0045E5e91d1C2C751Cd0Bc00"), // txid: 0xbb7d09fb3832b35fbbed641453a90f217a2736cf1419848887dfee2dbb14187e
-			dex.Testnet: common.HexToAddress("0xd45e648D97Beb2ee0045E5e91d1C2C751Cd0Bc00"), // txid: 0xa5f71d47998c175c9d2aba37ad2eff390ce7d20c312cee0472e3a5d606da385d
+			dex.Testnet: common.HexToAddress("0x73bc803A2604b2c58B8680c3CE1b14489842EF16"), // txid: 0x88f656a8e432fdd50f33e67bdc39a66d24f663e33792bfab16b033dd2c609a99
 			dex.Simnet:  common.HexToAddress(""),                                           // Filled in by MaybeReadSimnetAddrs
 		},
 	}
 
 	MultiBalanceAddresses = map[dex.Network]common.Address{
 		dex.Mainnet: common.HexToAddress("0x23d8203d8E3c839F359bcC85BFB71cf0d707EDF0"), // tx: 0xc593222106c700b153977fdf290f8d9656610cd2dd88522724e85b3f7fd600cf
-		dex.Testnet: common.HexToAddress("0xFbF60393F5AB800139F283cc6e090a17db6cC7a1"), // tx 0x1a0c86f80d4d66692072d7ad4246ca6f61b749030b930aad98e5309c16e8adc0
+		dex.Testnet: common.HexToAddress("0xa958d5B8a3a29E3f5f41742Fbb939A0dd93EB418"), // tx 0x692cf15b145cb45c0098bedf8a55d067b1ac994973bb62000c046b8453d8b624
 	}
 
 	usdcTokenID, _ = dex.BipSymbolID("usdc.polygon")
@@ -111,12 +111,12 @@ var (
 				},
 			},
 			dex.Testnet: {
-				Address: common.HexToAddress("0x0fa8781a83e46826621b3bc094ea2a0212e71b23"), // https://polygonscan.com/address/0x2791bca1f2de4661ed88a30c99a7a9449aa84174
+				Address: common.HexToAddress("0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582"), // https://amoy.polygonscan.com/address/0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582#readContract
 				SwapContracts: map[uint32]*dexeth.SwapContract{
 					0: {
-						// deploy tx: https://polygonscan.com/tx/0xfc27a89e5befba05df5ebe64670d5df89f635957f3fbeb2d4240cd3f0e540022
-						// swap contract: https://polygonscan.com/address/0x73bc803A2604b2c58B8680c3CE1b14489842EF16
-						Address: common.HexToAddress("0x73bc803A2604b2c58B8680c3CE1b14489842EF16"),
+						// deploy tx: https://amoy.polygonscan.com/tx/0x61315c5cf90fdf2cd4a89d04cce6496c9ee7a2ecc18dbc5f76e4baacc80bda5e
+						// swap contract: https://amoy.polygonscan.com/address/0xca70D818ffff2Cd235Ab90b4fec3e6394014D294
+						Address: common.HexToAddress("0xca70D818ffff2Cd235Ab90b4fec3e6394014D294"),
 						Gas: dexeth.Gases{
 							// First swap used 187982 gas Recommended Gases.Swap = 244376
 							// 	4 additional swaps averaged 112591 gas each. Recommended Gases.SwapAdd = 146368
@@ -130,7 +130,7 @@ var (
 							RedeemAdd: 41_117,
 							// Average of 5 refunds: 69660. Recommended Gases.Refund = 90558
 							// 	[69663 69663 69651 69663 69663]
-							Refund: 90_558,
+							Refund: 90_558, // On Amaoy recommended was actually 79067
 							// Average of 2 approvals: 58634. Recommended Gases.Approve = 76224
 							// 	[58634 58634]
 							Approve: 76_224,

--- a/server/asset/polygon/polygon.go
+++ b/server/asset/polygon/polygon.go
@@ -84,7 +84,7 @@ func (d *Driver) Setup(cfg *asset.BackendConfig) (asset.Backend, error) {
 	case dex.Mainnet:
 		chainID = dexpolygon.BorMainnetChainConfig.ChainID.Uint64()
 	case dex.Testnet:
-		chainID = dexpolygon.MumbaiChainConfig.ChainID.Uint64()
+		chainID = dexpolygon.AmoyChainConfig.ChainID.Uint64()
 	default:
 		chainID = 90001
 	}


### PR DESCRIPTION
Switch to Polygon Amoy testnet. 

https://polygon.technology/blog/introducing-the-amoy-testnet-for-polygon-pos

New contracts launched and contract data synced with polygonscan. Gas estimates verified.

Devs: Don't forget to update your **`~/dextest/credentials.json`**

Devs and testers: Please hit the MATIC faucet ([good one at Alchemy](https://www.alchemy.com/faucets/polygon-amoy)) and [Circle's testnet USDC faucet](https://faucet.circle.com/)