### PR TITLE
client/dcr: Identify unknown txs

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1574,10 +1574,14 @@ func (btc *intermediaryWallet) Connect(ctx context.Context) (*sync.WaitGroup, er
 		btc.monitorPeers(ctx)
 	}()
 
-	btc.tipMtx.RLock()
-	tip := btc.currentTip
-	btc.tipMtx.RUnlock()
-	go btc.syncTxHistory(uint64(tip.Height))
+	wg.Add(1)
+	func() {
+		defer wg.Done()
+		btc.tipMtx.RLock()
+		tip := btc.currentTip
+		btc.tipMtx.RUnlock()
+		go btc.syncTxHistory(uint64(tip.Height))
+	}()
 
 	return wg, nil
 }

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -6031,10 +6031,6 @@ func (dcr *ExchangeWallet) idUnknownTx(ctx context.Context, tx *ListTransactions
 	allOutputsPayUs := func(msgTx *wire.MsgTx) bool {
 		for _, txOut := range msgTx.TxOut {
 			_, addrs := stdscript.ExtractAddrs(scriptVersion, txOut.PkScript, dcr.chainParams)
-			if err != nil {
-				dcr.log.Errorf("ExtractAddrs error: %w", err)
-				return false
-			}
 			if len(addrs) != 1 { // sanity check
 				return false
 			}

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -689,7 +689,8 @@ type ExchangeWallet struct {
 
 	receiveTxLastQuery atomic.Uint64
 
-	txHistoryDB atomic.Value // *btc.BadgerTxDB
+	txHistoryDB      atomic.Value // *btc.BadgerTxDB
+	syncingTxHistory atomic.Bool
 }
 
 func (dcr *ExchangeWallet) config() *exchangeWalletConfig {
@@ -705,6 +706,7 @@ var _ asset.TxFeeEstimator = (*ExchangeWallet)(nil)
 var _ asset.Bonder = (*ExchangeWallet)(nil)
 var _ asset.Authenticator = (*ExchangeWallet)(nil)
 var _ asset.TicketBuyer = (*ExchangeWallet)(nil)
+var _ asset.WalletHistorian = (*ExchangeWallet)(nil)
 
 type block struct {
 	height int64
@@ -1050,6 +1052,7 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 	// Initialize the best block.
 	dcr.tipMtx.Lock()
 	dcr.currentTip, err = dcr.getBestBlock(ctx)
+	tip := dcr.currentTip
 	dcr.tipMtx.Unlock()
 	if err != nil {
 		return nil, fmt.Errorf("error initializing best block for DCR: %w", err)
@@ -1083,6 +1086,8 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 		defer wg.Done()
 		dcr.monitorPeers(ctx)
 	}()
+
+	go dcr.syncTxHistory(ctx, uint64(tip.height))
 
 	return wg, nil
 }
@@ -2209,7 +2214,7 @@ func (dcr *ExchangeWallet) submitMultiSplitTx(fundingCoins asset.Coins, _ /* spe
 		if accts.TradingAccount != "" {
 			return dcr.wallet.ExternalAddress(dcr.ctx, accts.TradingAccount)
 		}
-		return dcr.wallet.InternalAddress(dcr.ctx, accts.PrimaryAccount)
+		return dcr.wallet.ExternalAddress(dcr.ctx, accts.PrimaryAccount)
 	}
 
 	requiredForOrders, _ := dcr.fundsRequiredForMultiOrders(orders, maxFeeRate, splitBuffer)
@@ -2252,7 +2257,11 @@ func (dcr *ExchangeWallet) submitMultiSplitTx(fundingCoins asset.Coins, _ /* spe
 	}
 
 	txHash := tx.CachedTxHash()
-	dcr.addTxToHistory(asset.Split, txHash, 0, totalIn-totalOut, nil, nil, true)
+	dcr.addTxToHistory(&asset.WalletTransaction{
+		Type: asset.Split,
+		ID:   txHash.String(),
+		Fees: totalIn - totalOut,
+	}, txHash, true)
 
 	return coins, totalIn - totalOut, nil
 }
@@ -2735,7 +2744,7 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 		if accts.TradingAccount != "" {
 			return dcr.wallet.ExternalAddress(dcr.ctx, accts.TradingAccount)
 		}
-		return dcr.wallet.InternalAddress(dcr.ctx, accts.PrimaryAccount)
+		return dcr.wallet.ExternalAddress(dcr.ctx, accts.PrimaryAccount)
 	}
 	addr, err := getAddr()
 	if err != nil {
@@ -2788,7 +2797,11 @@ func (dcr *ExchangeWallet) split(value uint64, lots uint64, coins asset.Coins, i
 	}
 
 	txHash := msgTx.CachedTxHash()
-	dcr.addTxToHistory(asset.Split, txHash, 0, coinSum-totalOut, nil, nil, true)
+	dcr.addTxToHistory(&asset.WalletTransaction{
+		Type: asset.Split,
+		ID:   txHash.String(),
+		Fees: coinSum - totalOut,
+	}, txHash, true)
 
 	dcr.log.Infof("Funding %s DCR order with split output coin %v from original coins %v", valStr, op, coins)
 	dcr.log.Infof("Sent split transaction %s to accommodate swap of size %s + fees = %s DCR",
@@ -3162,7 +3175,12 @@ func (dcr *ExchangeWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin
 		return nil, nil, 0, err
 	}
 
-	dcr.addTxToHistory(asset.Swap, txHash, totalOut, fees, nil, nil, true)
+	dcr.addTxToHistory(&asset.WalletTransaction{
+		Type:   asset.Swap,
+		ID:     txHash.String(),
+		Amount: totalOut,
+		Fees:   fees,
+	}, txHash, true)
 
 	// Return spent outputs.
 	_, err = dcr.returnCoins(swaps.Inputs)
@@ -3254,7 +3272,7 @@ func (dcr *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 	}
 
 	// Send the funds back to the exchange wallet.
-	txOut, _, err := dcr.makeChangeOut(dcr.depositAccount(), totalIn-fee)
+	txOut, _, err := dcr.makeExternalOut(dcr.depositAccount(), totalIn-fee)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -3282,7 +3300,12 @@ func (dcr *ExchangeWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Co
 		return nil, nil, 0, err
 	}
 
-	dcr.addTxToHistory(asset.Redeem, txHash, totalIn, fee, nil, nil, true)
+	dcr.addTxToHistory(&asset.WalletTransaction{
+		Type:   asset.Redeem,
+		ID:     txHash.String(),
+		Amount: totalIn,
+		Fees:   fee,
+	}, txHash, true)
 
 	coinIDs := make([]dex.Bytes, 0, len(form.Redemptions))
 	dcr.mempoolRedeemsMtx.Lock()
@@ -3967,7 +3990,12 @@ func (dcr *ExchangeWallet) Refund(coinID, contract dex.Bytes, feeRate uint64) (d
 	if err != nil {
 		return nil, err
 	}
-	dcr.addTxToHistory(asset.Refund, refundHash, refundVal, fee, nil, nil, true)
+	dcr.addTxToHistory(&asset.WalletTransaction{
+		Type:   asset.Refund,
+		ID:     refundHash.String(),
+		Amount: refundVal,
+		Fees:   fee,
+	}, refundHash, true)
 
 	return toCoinID(refundHash, 0), nil
 }
@@ -4170,6 +4198,22 @@ func (dcr *ExchangeWallet) EstimateRegistrationTxFee(feeRate uint64) uint64 {
 	return (dexdcr.MsgTxOverhead + dexdcr.P2PKHOutputSize*2 + inputCount*dexdcr.P2PKHInputSize) * feeRate
 }
 
+func bondPushDataScript(ver uint16, acctID []byte, lockTimeSec int64, pkh []byte) ([]byte, error) {
+	pushData := make([]byte, 2+len(acctID)+4+20)
+	var offset int
+	binary.BigEndian.PutUint16(pushData[offset:], ver)
+	offset += 2
+	copy(pushData[offset:], acctID[:])
+	offset += len(acctID)
+	binary.BigEndian.PutUint32(pushData[offset:], uint32(lockTimeSec))
+	offset += 4
+	copy(pushData[offset:], pkh)
+	return txscript.NewScriptBuilder().
+		AddOp(txscript.OP_RETURN).
+		AddData(pushData).
+		Script()
+}
+
 // MakeBondTx creates a time-locked fidelity bond transaction. The V0
 // transaction has two required outputs:
 //
@@ -4238,19 +4282,7 @@ func (dcr *ExchangeWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime 
 	// Acct ID commitment and bond details output, v0. The integers are encoded
 	// with big-endian byte order and a fixed number of bytes, unlike in Script,
 	// for natural visual inspection of the version and lock time.
-	pushData := make([]byte, 2+len(acctID)+4+20)
-	var offset int
-	binary.BigEndian.PutUint16(pushData[offset:], ver)
-	offset += 2
-	copy(pushData[offset:], acctID[:])
-	offset += len(acctID)
-	binary.BigEndian.PutUint32(pushData[offset:], uint32(lockTimeSec))
-	offset += 4
-	copy(pushData[offset:], pkh)
-	commitPkScript, err := txscript.NewScriptBuilder().
-		AddOp(txscript.OP_RETURN).
-		AddData(pushData).
-		Script()
+	commitPkScript, err := bondPushDataScript(ver, acctID, lockTimeSec, pkh)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build acct commit output script: %w", err)
 	}
@@ -4333,7 +4365,14 @@ func (dcr *ExchangeWallet) MakeBondTx(ver uint16, amt, feeRate uint64, lockTime 
 		LockTime:  uint64(lockTimeSec),
 		BondID:    pkh,
 	}
-	dcr.addTxToHistory(asset.CreateBond, txHash, amt, fee, bondInfo, nil, false)
+	dcr.addTxToHistory(&asset.WalletTransaction{
+		Type:     asset.CreateBond,
+		ID:       txHash.String(),
+		Amount:   amt,
+		Fees:     fee,
+		BondInfo: bondInfo,
+	}, txHash, false)
+
 	txIDToRemoveFromHistory = txHash
 
 	return bond, abandon, nil
@@ -4368,7 +4407,7 @@ func (dcr *ExchangeWallet) makeBondRefundTxV0(txid *chainhash.Hash, vout uint32,
 		return nil, fmt.Errorf("irredeemable bond at fee rate %d atoms/byte", feeRate)
 	}
 
-	redeemAddr, err := dcr.wallet.InternalAddress(dcr.ctx, dcr.wallet.Accounts().PrimaryAccount)
+	redeemAddr, err := dcr.wallet.ExternalAddress(dcr.ctx, dcr.wallet.Accounts().PrimaryAccount)
 	if err != nil {
 		return nil, fmt.Errorf("error getting new address from the wallet: %w", translateRPCCancelErr(err))
 	}
@@ -4429,7 +4468,14 @@ func (dcr *ExchangeWallet) RefundBond(ctx context.Context, ver uint16, coinID, s
 		LockTime: uint64(lockTime),
 		BondID:   pkhPush,
 	}
-	dcr.addTxToHistory(asset.RedeemBond, redeemHash, amt, amt-uint64(refundAmt), bondInfo, nil, true)
+	dcr.addTxToHistory(&asset.WalletTransaction{
+		Type:     asset.RedeemBond,
+		ID:       redeemHash.String(),
+		Amount:   amt,
+		Fees:     amt - uint64(refundAmt),
+		BondInfo: bondInfo,
+	}, redeemHash, true)
+
 	return newOutput(redeemHash, 0, uint64(refundAmt), wire.TxTreeRegular), nil
 
 	/* If we need to find the actual unspent bond transaction for any of:
@@ -4624,7 +4670,14 @@ func (dcr *ExchangeWallet) Withdraw(address string, value, feeRate uint64) (asse
 		txType = asset.SelfSend
 	}
 
-	dcr.addTxToHistory(txType, msgTx.CachedTxHash(), sentVal, value-sentVal, nil, &address, true)
+	dcr.addTxToHistory(&asset.WalletTransaction{
+		Type:      txType,
+		ID:        msgTx.CachedTxHash().String(),
+		Amount:    sentVal,
+		Fees:      value - sentVal,
+		Recipient: &address,
+	}, msgTx.CachedTxHash(), true)
+
 	return newOutput(msgTx.CachedTxHash(), 0, sentVal, wire.TxTreeRegular), nil
 }
 
@@ -4650,7 +4703,14 @@ func (dcr *ExchangeWallet) Send(address string, value, feeRate uint64) (asset.Co
 		txType = asset.SelfSend
 	}
 
-	dcr.addTxToHistory(txType, msgTx.CachedTxHash(), sentVal, fee, nil, &address, true)
+	dcr.addTxToHistory(&asset.WalletTransaction{
+		Type:      txType,
+		ID:        msgTx.CachedTxHash().String(),
+		Amount:    sentVal,
+		Fees:      fee,
+		Recipient: &address,
+	}, msgTx.CachedTxHash(), true)
+
 	return newOutput(msgTx.CachedTxHash(), 0, sentVal, wire.TxTreeRegular), nil
 }
 
@@ -5007,6 +5067,15 @@ func msgTxToHex(msgTx *wire.MsgTx) (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(b), nil
+}
+
+func (dcr *ExchangeWallet) makeExternalOut(acct string, val uint64) (*wire.TxOut, stdaddr.Address, error) {
+	addr, err := dcr.wallet.ExternalAddress(dcr.ctx, acct)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating change address: %w", err)
+	}
+	changeScriptVersion, changeScript := addr.PaymentScript()
+	return newTxOut(int64(val), changeScriptVersion, changeScript), addr, nil
 }
 
 func (dcr *ExchangeWallet) makeChangeOut(changeAcct string, val uint64) (*wire.TxOut, stdaddr.Address, error) {
@@ -5607,7 +5676,12 @@ func (dcr *ExchangeWallet) runTicketBuyer() {
 			return
 		}
 		tb.unconfirmedTickets[*txHash] = struct{}{}
-		dcr.addTxToHistory(asset.TicketPurchase, txHash, ticket.Tx.TicketPrice, ticket.Tx.Fees, nil, nil, true)
+		dcr.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.TicketPurchase,
+			ID:     txHash.String(),
+			Amount: ticket.Tx.TicketPrice,
+			Fees:   ticket.Tx.Fees,
+		}, txHash, true)
 	}
 	ok = true
 }
@@ -5762,12 +5836,390 @@ func (dcr *ExchangeWallet) txDB() *btc.BadgerTxDB {
 	return db.(*btc.BadgerTxDB)
 }
 
-// checkPendingTxs checks to see if the wallet has received any incoming
-// transactions that need to be added to the transaction history. It also
-// checks all the pending transactions to see if they have been mined into
-// a block, and if so, updates the transaction history to reflect the
-// block height.
-func (dcr *ExchangeWallet) checkPendingTxs(ctx context.Context, tip uint64) {
+func rpcTxFee(tx *ListTransactionsResult) uint64 {
+	if tx.Fee != nil {
+		if *tx.Fee < 0 {
+			return toAtoms(-*tx.Fee)
+		}
+		return toAtoms(*tx.Fee)
+	}
+	return 0
+}
+
+func (dcr *ExchangeWallet) walletOwnsAddress(addr stdaddr.Address) (bool, error) {
+	accounts := dcr.wallet.Accounts()
+	accountsToCheck := make([]string, 0, 3)
+
+	if accounts.PrimaryAccount != "" {
+		accountsToCheck = append(accountsToCheck, accounts.PrimaryAccount)
+	}
+	if accounts.TradingAccount != "" {
+		accountsToCheck = append(accountsToCheck, accounts.TradingAccount)
+	}
+	if accounts.UnmixedAccount != "" {
+		accountsToCheck = append(accountsToCheck, accounts.UnmixedAccount)
+	}
+
+	for _, acct := range accountsToCheck {
+		owns, err := dcr.wallet.AccountOwnsAddress(dcr.ctx, addr, acct)
+		if err != nil {
+			return false, err
+		}
+		if owns {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// idUnknownTx identifies the type and details of a transaction either made
+// or recieved by the wallet.
+func (dcr *ExchangeWallet) idUnknownTx(ctx context.Context, tx *ListTransactionsResult) (*asset.WalletTransaction, error) {
+	fee := rpcTxFee(tx)
+
+	txHash, err := chainhash.NewHashFromStr(tx.TxID)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding tx hash %s: %v", tx.TxID, err)
+	}
+	msgTx, err := dcr.wallet.GetRawTransaction(ctx, txHash)
+	if err != nil {
+		return nil, err
+	}
+
+	var totalOut uint64
+	for _, txOut := range msgTx.TxOut {
+		totalOut += uint64(txOut.Value)
+	}
+
+	if *tx.TxType == walletjson.LTTTVote {
+		return &asset.WalletTransaction{
+			Type:   asset.TicketVote,
+			ID:     tx.TxID,
+			Amount: totalOut,
+			Fees:   fee,
+		}, nil
+	}
+	if *tx.TxType == walletjson.LTTTRevocation {
+		return &asset.WalletTransaction{
+			Type:   asset.TicketRevocation,
+			ID:     tx.TxID,
+			Amount: totalOut,
+			Fees:   fee,
+		}, nil
+	}
+	if *tx.TxType == walletjson.LTTTTicket {
+		return &asset.WalletTransaction{
+			Type:   asset.TicketPurchase,
+			ID:     tx.TxID,
+			Amount: totalOut,
+			Fees:   fee,
+		}, nil
+	}
+
+	txIsBond := func(msgTx *wire.MsgTx) (bool, *asset.BondTxInfo) {
+		if len(msgTx.TxOut) < 2 {
+			return false, nil
+		}
+		const scriptVer = 0
+		acctID, lockTime, pkHash, err := dexdcr.ExtractBondCommitDataV0(scriptVer, msgTx.TxOut[1].PkScript)
+		if err != nil {
+			return false, nil
+		}
+		return true, &asset.BondTxInfo{
+			AccountID: acctID[:],
+			LockTime:  uint64(lockTime),
+			BondID:    pkHash[:],
+		}
+	}
+	if isBond, bondInfo := txIsBond(msgTx); isBond {
+		return &asset.WalletTransaction{
+			Type:     asset.CreateBond,
+			ID:       tx.TxID,
+			Amount:   uint64(msgTx.TxOut[0].Value),
+			Fees:     fee,
+			BondInfo: bondInfo,
+		}, nil
+	}
+
+	// Any other P2SH may be a swap or a send. We cannot determine unless we
+	// look up the transaction that spends this UTXO.
+	txPaysToScriptHash := func(msgTx *wire.MsgTx) (v uint64) {
+		for _, txOut := range msgTx.TxOut {
+			if txscript.IsPayToScriptHash(txOut.PkScript) {
+				v += uint64(txOut.Value)
+			}
+		}
+		return
+	}
+	if v := txPaysToScriptHash(msgTx); v > 0 {
+		return &asset.WalletTransaction{
+			Type:   asset.SwapOrSend,
+			ID:     tx.TxID,
+			Amount: v,
+			Fees:   fee,
+		}, nil
+	}
+
+	// Helper function will help us identify inputs that spend P2SH contracts.
+	containsContractAtPushIndex := func(msgTx *wire.MsgTx, idx int, isContract func(contract []byte) bool) bool {
+	txinloop:
+		for _, txIn := range msgTx.TxIn {
+			// not segwit
+			const scriptVer = 0
+			tokenizer := txscript.MakeScriptTokenizer(scriptVer, txIn.SignatureScript)
+			for i := 0; i <= idx; i++ { // contract is 5th item item in redemption and 4th in refund
+				if !tokenizer.Next() {
+					continue txinloop
+				}
+			}
+			if isContract(tokenizer.Data()) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Swap redemptions and refunds
+	contractIsSwap := func(contract []byte) bool {
+		_, _, _, _, err := dexdcr.ExtractSwapDetails(contract, dcr.chainParams)
+		return err == nil
+	}
+	redeemsSwap := func(msgTx *wire.MsgTx) bool {
+		return containsContractAtPushIndex(msgTx, 4, contractIsSwap)
+	}
+	if redeemsSwap(msgTx) {
+		return &asset.WalletTransaction{
+			Type:   asset.Redeem,
+			ID:     tx.TxID,
+			Amount: totalOut + fee,
+			Fees:   fee,
+		}, nil
+	}
+	refundsSwap := func(msgTx *wire.MsgTx) bool {
+		return containsContractAtPushIndex(msgTx, 3, contractIsSwap)
+	}
+	if refundsSwap(msgTx) {
+		return &asset.WalletTransaction{
+			Type:   asset.Refund,
+			ID:     tx.TxID,
+			Amount: totalOut + fee,
+			Fees:   fee,
+		}, nil
+	}
+
+	// Bond refunds
+	redeemsBond := func(msgTx *wire.MsgTx) (bool, *asset.BondTxInfo) {
+		var bondInfo *asset.BondTxInfo
+		isBond := func(contract []byte) bool {
+			const scriptVer = 0
+			lockTime, pkHash, err := dexdcr.ExtractBondDetailsV0(scriptVer, contract)
+			if err != nil {
+				return false
+			}
+			bondInfo = &asset.BondTxInfo{
+				AccountID: []byte{}, // Could look for the bond tx to get this, I guess.
+				LockTime:  uint64(lockTime),
+				BondID:    pkHash[:],
+			}
+			return true
+		}
+		return containsContractAtPushIndex(msgTx, 2, isBond), bondInfo
+	}
+	if isBondRedemption, bondInfo := redeemsBond(msgTx); isBondRedemption {
+		return &asset.WalletTransaction{
+			Type:     asset.RedeemBond,
+			ID:       tx.TxID,
+			Amount:   totalOut,
+			Fees:     fee,
+			BondInfo: bondInfo,
+		}, nil
+	}
+
+	const scriptVersion = 0
+
+	allOutputsPayUs := func(msgTx *wire.MsgTx) bool {
+		for _, txOut := range msgTx.TxOut {
+			_, addrs := stdscript.ExtractAddrs(scriptVersion, txOut.PkScript, dcr.chainParams)
+			if err != nil {
+				dcr.log.Errorf("ExtractAddrs error: %w", err)
+				return false
+			}
+			if len(addrs) != 1 { // sanity check
+				return false
+			}
+
+			addr := addrs[0]
+			owns, err := dcr.walletOwnsAddress(addr)
+			if err != nil {
+				dcr.log.Errorf("walletOwnsAddress error: %w", err)
+				return false
+			}
+			if !owns {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	if tx.Send && allOutputsPayUs(msgTx) && len(msgTx.TxIn) == 1 {
+		return &asset.WalletTransaction{
+			Type: asset.Split,
+			ID:   tx.TxID,
+			Fees: fee,
+		}, nil
+	}
+
+	txOutDirection := func(msgTx *wire.MsgTx) (in, out uint64) {
+		for _, txOut := range msgTx.TxOut {
+			_, addrs := stdscript.ExtractAddrs(scriptVersion, txOut.PkScript, dcr.chainParams)
+			if err != nil {
+				dcr.log.Errorf("ExtractAddrs error: %w", err)
+				continue
+			}
+			if len(addrs) != 1 { // sanity check
+				continue
+			}
+
+			addr := addrs[0]
+			owns, err := dcr.walletOwnsAddress(addr)
+			if err != nil {
+				dcr.log.Errorf("walletOwnsAddress error: %w", err)
+				continue
+			}
+			if owns {
+				in += uint64(txOut.Value)
+			} else {
+				out += uint64(txOut.Value)
+			}
+		}
+		return
+	}
+
+	in, out := txOutDirection(msgTx)
+
+	getRecipient := func(msgTx *wire.MsgTx, receive bool) *string {
+		for _, txOut := range msgTx.TxOut {
+			_, addrs := stdscript.ExtractAddrs(scriptVersion, txOut.PkScript, dcr.chainParams)
+			if err != nil {
+				dcr.log.Errorf("ExtractAddrs error: %w", err)
+				continue
+			}
+			if len(addrs) != 1 { // sanity check
+				continue
+			}
+
+			addr := addrs[0]
+			owns, err := dcr.walletOwnsAddress(addr)
+			if err != nil {
+				dcr.log.Errorf("walletOwnsAddress error: %w", err)
+				continue
+			}
+
+			if receive == owns {
+				str := addr.String()
+				return &str
+			}
+		}
+		return nil
+	}
+
+	if tx.Send {
+		return &asset.WalletTransaction{
+			Type:      asset.Send,
+			ID:        tx.TxID,
+			Amount:    out,
+			Fees:      fee,
+			Recipient: getRecipient(msgTx, false),
+		}, nil
+	}
+
+	return &asset.WalletTransaction{
+		Type:      asset.Receive,
+		ID:        tx.TxID,
+		Amount:    in,
+		Fees:      fee,
+		Recipient: getRecipient(msgTx, true),
+	}, nil
+}
+
+// addUnknownTransactionsToHistory checks for any transactions the wallet has
+// made or recieved that are not part of the transaction history. It scans
+// from the last point to which it had previously scanned to the current tip.
+func (dcr *ExchangeWallet) addUnknownTransactionsToHistory(tip uint64) {
+	txHistoryDB := dcr.txDB()
+
+	const blockQueryBuffer = 3
+	var blockToQuery uint64
+	lastQuery := dcr.receiveTxLastQuery.Load()
+	if lastQuery == 0 {
+		// TODO: use wallet birthday instead of block 0.
+		// blockToQuery = 0
+	} else if lastQuery < tip-blockQueryBuffer {
+		blockToQuery = lastQuery - blockQueryBuffer
+	} else {
+		blockToQuery = tip - blockQueryBuffer
+	}
+
+	txs, err := dcr.wallet.ListSinceBlock(dcr.ctx, int32(blockToQuery))
+	if err != nil {
+		dcr.log.Errorf("Error listing transactions since block %d: %v", blockToQuery, err)
+		return
+	}
+
+	for _, tx := range txs {
+		txHash, err := chainhash.NewHashFromStr(tx.TxID)
+		if err != nil {
+			dcr.log.Errorf("Error decoding tx hash %s: %v", tx.TxID, err)
+			continue
+		}
+		_, err = txHistoryDB.GetTx(txHash.String())
+		if err == nil {
+			continue
+		}
+		if !errors.Is(err, asset.CoinNotFoundError) {
+			dcr.log.Errorf("Error getting tx %s: %v", txHash.String(), err)
+			continue
+		}
+		wt, err := dcr.idUnknownTx(dcr.ctx, &tx)
+		if err != nil {
+			dcr.log.Errorf("error identifying transaction: %v", err)
+			continue
+		}
+
+		if tx.BlockIndex != nil && *tx.BlockIndex > 0 && *tx.BlockIndex < int64(tip-blockQueryBuffer) {
+			wt.BlockNumber = uint64(*tx.BlockIndex)
+			wt.Timestamp = uint64(tx.BlockTime)
+		}
+
+		// Don't send notifications for the initial sync to avoid spamming the
+		// front end. A notification is sent at the end of the initial sync.
+		dcr.addTxToHistory(wt, txHash, true, blockToQuery == 0)
+	}
+
+	dcr.receiveTxLastQuery.Store(tip)
+	err = txHistoryDB.SetLastReceiveTxQuery(tip)
+	if err != nil {
+		dcr.log.Errorf("Error setting last query to %d: %v", tip, err)
+	}
+
+	if blockToQuery == 0 {
+		dcr.emit.TransactionHistorySyncedNote()
+	}
+}
+
+// syncTxHistory checks to see if there are any transactions which the wallet
+// has made or recieved that are not part of the transaction history, then
+// identifies and adds them. It also checks all the pending transactions to see
+// if they have been mined into a block, and if so, updates the transaction
+// history to reflect the block height.
+func (dcr *ExchangeWallet) syncTxHistory(ctx context.Context, tip uint64) {
+	if !dcr.syncingTxHistory.CompareAndSwap(false, true) {
+		return
+	}
+	defer dcr.syncingTxHistory.Store(false)
+
 	txHistoryDB := dcr.txDB()
 	if txHistoryDB == nil {
 		return
@@ -5782,73 +6234,8 @@ func (dcr *ExchangeWallet) checkPendingTxs(ctx context.Context, tip uint64) {
 		return
 	}
 
-	// First, check to see if there are any recieving transactions we have not
-	// yet seen.
-	{
-		const blockQueryBuffer = 3
-		var blockToQuery uint64
-		lastQuery := dcr.receiveTxLastQuery.Load()
+	dcr.addUnknownTransactionsToHistory(tip)
 
-		if lastQuery != 0 && lastQuery < tip-blockQueryBuffer {
-			blockToQuery = lastQuery - blockQueryBuffer
-		} else {
-			blockToQuery = tip - blockQueryBuffer
-		}
-
-		recentTxs, err := dcr.wallet.ListSinceBlock(ctx, int32(blockToQuery), int32(tip), int32(tip))
-		if err != nil {
-			dcr.log.Errorf("Error listing transactions since block %d: %v", blockToQuery, err)
-			recentTxs = nil
-		} else {
-			dcr.receiveTxLastQuery.Store(tip)
-			err = txHistoryDB.SetLastReceiveTxQuery(tip)
-			if err != nil {
-				dcr.log.Errorf("Error setting last query to %d: %v", tip, err)
-			}
-		}
-
-		addToHistoryIfNew := func(tx *walletjson.ListTransactionsResult, txType asset.TransactionType) {
-			txHash, err := chainhash.NewHashFromStr(tx.TxID)
-			if err != nil {
-				dcr.log.Errorf("Error decoding txid %s: %v", tx.TxID, err)
-				return
-			}
-			_, err = txHistoryDB.GetTx(txHash.String())
-			if err == nil {
-				return
-			}
-			if !errors.Is(err, asset.CoinNotFoundError) {
-				dcr.log.Errorf("Error getting tx %s: %v", tx.TxID, err)
-				return
-			}
-
-			var fee uint64
-			if tx.Fee != nil {
-				// Fee always seems to be negative in btcwallet, but just
-				// in case.
-				if *tx.Fee < 0 {
-					fee = toAtoms(-*tx.Fee)
-				} else {
-					fee = toAtoms(*tx.Fee)
-				}
-			}
-
-			dcr.addTxToHistory(txType, txHash, toAtoms(tx.Amount), fee, nil, nil, true)
-		}
-
-		for _, tx := range recentTxs {
-			if *tx.TxType == walletjson.LTTTRegular && tx.Category == "receive" {
-				addToHistoryIfNew(&tx, asset.Receive)
-			} else if *tx.TxType == walletjson.LTTTVote {
-				addToHistoryIfNew(&tx, asset.TicketVote)
-			} else if *tx.TxType == walletjson.LTTTRevocation {
-				addToHistoryIfNew(&tx, asset.TicketRevocation)
-			}
-		}
-	}
-
-	// Not just the map must be copied here, but the ExtendedWalletTx
-	// as well.
 	pendingTxsCopy := make(map[chainhash.Hash]btc.ExtendedWalletTx, len(dcr.pendingTxs))
 	dcr.pendingTxsMtx.RLock()
 	for hash, tx := range dcr.pendingTxs {
@@ -5858,9 +6245,9 @@ func (dcr *ExchangeWallet) checkPendingTxs(ctx context.Context, tip uint64) {
 
 	handlePendingTx := func(txHash chainhash.Hash, tx *btc.ExtendedWalletTx) {
 		if !tx.Submitted {
-			dcr.log.Errorf("Pending tx %s is not submitted", txHash)
 			return
 		}
+
 		gtr, err := dcr.wallet.GetTransaction(ctx, &txHash)
 		if errors.Is(err, asset.CoinNotFoundError) {
 			err = txHistoryDB.RemoveTx(txHash.String())
@@ -5978,36 +6365,31 @@ func (dcr *ExchangeWallet) removeTxFromHistory(txHash *chainhash.Hash) {
 	}
 }
 
-func (dcr *ExchangeWallet) addTxToHistory(txType asset.TransactionType, txHash *chainhash.Hash, amount uint64, fees uint64,
-	bondInfo *asset.BondTxInfo, recipient *string, submitted bool) {
+func (dcr *ExchangeWallet) addTxToHistory(wt *asset.WalletTransaction, txHash *chainhash.Hash, submitted bool, skipNotes ...bool) {
 	txHistoryDB := dcr.txDB()
 	if txHistoryDB == nil {
 		return
 	}
 
-	wt := &btc.ExtendedWalletTx{
-		WalletTransaction: &asset.WalletTransaction{
-			Type:      txType,
-			ID:        txHash.String(),
-			Amount:    amount,
-			Fees:      fees,
-			BondInfo:  bondInfo,
-			Recipient: recipient,
-		},
-		Submitted: submitted,
+	ewt := &btc.ExtendedWalletTx{
+		WalletTransaction: wt,
+		Submitted:         submitted,
 	}
 
-	dcr.pendingTxsMtx.Lock()
-	dcr.pendingTxs[*txHash] = wt
-	dcr.pendingTxsMtx.Unlock()
+	if wt.BlockNumber == 0 {
+		dcr.pendingTxsMtx.Lock()
+		dcr.pendingTxs[*txHash] = ewt
+		dcr.pendingTxsMtx.Unlock()
+	}
 
-	err := txHistoryDB.StoreTx(wt)
+	err := txHistoryDB.StoreTx(ewt)
 	if err != nil {
 		dcr.log.Errorf("failed to store tx in tx history db: %v", err)
 	}
 
-	if submitted {
-		dcr.emit.TransactionNote(wt.WalletTransaction, true)
+	skipNote := len(skipNotes) > 0 && skipNotes[0]
+	if submitted && !skipNote {
+		dcr.emit.TransactionNote(wt, true)
 	}
 }
 
@@ -6156,6 +6538,14 @@ func (dcr *ExchangeWallet) monitorBlocks(ctx context.Context) {
 			if walletTip == nil {
 				// Mempool tx seen.
 				dcr.emitBalance()
+
+				go func() {
+					dcr.tipMtx.RLock()
+					tip := dcr.currentTip
+					dcr.tipMtx.RUnlock()
+					dcr.syncTxHistory(ctx, uint64(tip.height))
+				}()
+
 				continue
 			}
 			if queuedBlock != nil && walletTip.height >= queuedBlock.height {
@@ -6198,7 +6588,7 @@ func (dcr *ExchangeWallet) handleTipChange(ctx context.Context, newTipHash *chai
 		dcr.cycleMixer()
 	}
 
-	go dcr.checkPendingTxs(ctx, uint64(newTipHeight))
+	go dcr.syncTxHistory(ctx, uint64(newTipHeight))
 
 	// Search for contract redemption in new blocks if there
 	// are contracts pending redemption.
@@ -6254,7 +6644,6 @@ func (dcr *ExchangeWallet) handleTipChange(ctx context.Context, newTipHash *chai
 	// Run the redemption search from the startHeight determined above up
 	// till the current tip height.
 	go dcr.findRedemptionsInBlockRange(startHeight, newTipHeight, contractOutpoints)
-
 }
 
 func (dcr *ExchangeWallet) getBestBlock(ctx context.Context) (*block, error) {

--- a/client/asset/dcr/native_wallet.go
+++ b/client/asset/dcr/native_wallet.go
@@ -93,7 +93,6 @@ type NativeWallet struct {
 
 // NativeWallet must also satisfy the following interface(s).
 var _ asset.FundsMixer = (*NativeWallet)(nil)
-var _ asset.WalletHistorian = (*NativeWallet)(nil)
 
 func initNativeWallet(ew *ExchangeWallet) (*NativeWallet, error) {
 	spvWallet, ok := ew.wallet.(*spvWallet)

--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -486,14 +486,6 @@ func (w *rpcWallet) SpvMode() bool {
 	return w.spvMode
 }
 
-// NotifyOnTipChange registers a callback function that should be invoked when
-// the wallet sees new mainchain blocks. The return value indicates if this
-// notification can be provided.
-// Part of the Wallet interface.
-func (w *rpcWallet) NotifyOnTipChange(ctx context.Context, _ TipChangeCallback) bool {
-	return false
-}
-
 // AddressInfo returns information for the provided address. It is an error
 // if the address is not owned by the wallet.
 // Part of the Wallet interface.

--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -526,11 +526,6 @@ func (w *spvWallet) SpvMode() bool {
 	return true
 }
 
-// NotifyOnTipChange is not used, in favor of the tipNotifier pattern from btc.
-func (w *spvWallet) NotifyOnTipChange(ctx context.Context, cb TipChangeCallback) bool {
-	return false
-}
-
 // AddressInfo returns information for the provided address. It is an error if
 // the address is not owned by the wallet.
 func (w *spvWallet) AddressInfo(ctx context.Context, addrStr string) (*AddressInfo, error) {

--- a/client/asset/dcr/spv_test.go
+++ b/client/asset/dcr/spv_test.go
@@ -378,6 +378,10 @@ func (w *tDcrWallet) AddressAtIdx(ctx context.Context, account, branch, childIdx
 	return nil, nil
 }
 
+func (w *tDcrWallet) GetTransactions(ctx context.Context, f func(*wallet.Block) (bool, error), startBlock, endBlock *wallet.BlockIdentifier) error {
+	return nil
+}
+
 func tNewSpvWallet() (*spvWallet, *tDcrWallet) {
 	dcrw := &tDcrWallet{
 		blockHeader:    make(map[chainhash.Hash]*wire.BlockHeader),

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -69,6 +69,19 @@ type XCWalletAccounts struct {
 	TradingAccount string
 }
 
+// ListTransactionsResult is similar to the walletjson.ListTransactionsResult,
+// but most fields omitted.
+type ListTransactionsResult struct {
+	TxID       string
+	BlockIndex *int64
+	BlockTime  int64
+	// Send set to true means that the inputs of the transaction were
+	// controlled by the wallet.
+	Send   bool `json:"send"`
+	Fee    *float64
+	TxType *walletjson.ListTransactionsTxType
+}
+
 // Wallet defines methods that the ExchangeWallet uses for communicating with
 // a Decred wallet and blockchain.
 type Wallet interface {
@@ -141,7 +154,7 @@ type Wallet interface {
 	GetBlockHash(ctx context.Context, blockHeight int64) (*chainhash.Hash, error)
 	// ListSinceBlock returns all wallet transactions confirmed since the specified
 	// height.
-	ListSinceBlock(ctx context.Context, start, end, syncHeight int32) ([]walletjson.ListTransactionsResult, error)
+	ListSinceBlock(ctx context.Context, start int32) ([]ListTransactionsResult, error)
 	// MatchAnyScript looks for any of the provided scripts in the block specified.
 	MatchAnyScript(ctx context.Context, blockHash *chainhash.Hash, scripts [][]byte) (bool, error)
 	// AccountUnlocked returns true if the account is unlocked.

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -95,12 +95,6 @@ type Wallet interface {
 	// Accounts returns the names of the accounts for use by the exchange
 	// wallet.
 	Accounts() XCWalletAccounts
-	// NotifyOnTipChange registers a callback function that should be
-	// invoked when the wallet sees new mainchain blocks. The return value
-	// indicates if this notification can be provided. Where this tip change
-	// notification is unimplemented, monitorBlocks should be used to track
-	// tip changes.
-	NotifyOnTipChange(ctx context.Context, cb TipChangeCallback) bool
 	// AddressInfo returns information for the provided address. It is an error
 	// if the address is not owned by the wallet.
 	AddressInfo(ctx context.Context, address string) (*AddressInfo, error)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -1105,7 +1105,7 @@ const (
 	TicketPurchase
 	TicketVote
 	TicketRevocation
-	// SwapOrSend is used when a wallet scanned its historical transactions,
+	// SwapOrSend is used when a wallet scanned its historical transactions
 	// and was unable to determine if the transaction was a swap or a send.
 	SwapOrSend
 )
@@ -1140,8 +1140,8 @@ type WalletTransaction struct {
 	// TokenID will be non-nil if the BalanceDelta applies to the balance
 	// of a token.
 	TokenID *uint32 `json:"tokenID,omitempty"`
-	// Recipient wil be non-nil for Send transactions, and specifies the
-	// recipient of the send.
+	// Recipient will be non-nil for Send/Receive transactions, and specifies the
+	// recipient address of the transaction.
 	Recipient *string `json:"recipient,omitempty"`
 	// BondInfo will be non-nil for CreateBond and RedeemBond transactions.
 	BondInfo *BondTxInfo `json:"bondInfo,omitempty"`


### PR DESCRIPTION
This diff updates the DCR wallet to identify any unknown transaction and add it to the transaction history. Redeems, refunds, and bond refund transactions are updated to use an external address instead of an internal one. Otherwise, the RPC wallet's listsinceblock command would not return them.

Closes #2744