### PR TITLE
app: Fix registration flow forms

### DIFF
--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -887,7 +887,7 @@ export class ConfirmRegistrationForm {
     let form: any
     let url: string
 
-    if (xc.viewOnly || !app().exchanges[xc.host]) {
+    if (!app().exchanges[xc.host] || app().exchanges[xc.host].viewOnly) {
       form = {
         addr: dexAddr,
         cert: certFile,
@@ -1264,7 +1264,7 @@ export class WalletWaitForm {
   page: Record<string, PageElement>
   assetID: number
   parentID?: number
-  host: string
+  xc: Exchange
   bondAsset: BondAsset
   progressCache: ProgressPoint[]
   progressed: boolean
@@ -1295,7 +1295,7 @@ export class WalletWaitForm {
 
   /* setExchange sets the exchange for which the fee is being paid. */
   setExchange (xc: Exchange) {
-    this.host = xc.host
+    this.xc = xc
   }
 
   /* setWallet must be called before showing the WalletWaitForm. */
@@ -1308,10 +1308,9 @@ export class WalletWaitForm {
     this.parentAssetSynced = false
     const page = this.page
     const asset = app().assets[assetID]
-    const xc = app().exchanges[this.host]
     const { symbol, unitInfo: ui, wallet: { balance: bal, address, synced, syncProgress }, token } = asset
     this.parentID = token?.parentID
-    const bondAsset = this.bondAsset = xc.bondAssets[symbol]
+    const bondAsset = this.bondAsset = this.xc.bondAssets[symbol]
 
     const symbolize = (el: PageElement, asset: SupportedAsset) => {
       Doc.empty(el)

--- a/client/webserver/site/src/js/register.ts
+++ b/client/webserver/site/src/js/register.ts
@@ -30,7 +30,7 @@ export default class RegistrationPage extends BasePage {
   body: HTMLElement
   data: RegistrationPageData
   pwCache: PasswordCache
-  host: string
+  xc: Exchange
   page: Record<string, PageElement>
   loginForm: LoginForm
   appPassResetForm: AppPassResetForm
@@ -110,7 +110,7 @@ export default class RegistrationPage extends BasePage {
       const asset = app().assets[assetID]
       const wallet = asset.wallet
       if (wallet) {
-        const bondAsset = this.regAssetForm.xc.bondAssets[asset.symbol]
+        const bondAsset = this.xc.bondAssets[asset.symbol]
         const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.regAssetForm)
         this.confirmRegisterForm.setAsset(assetID, tier, bondsFeeBuffer)
         if (wallet.synced && wallet.balance.available >= 2 * bondAsset.amount + bondsFeeBuffer) {
@@ -171,7 +171,7 @@ export default class RegistrationPage extends BasePage {
   }
 
   async requestFeepayment (oldForm: HTMLElement, xc: Exchange, certFile: string) {
-    this.host = xc.host
+    this.xc = xc
     this.confirmRegisterForm.setExchange(xc, certFile)
     this.walletWaitForm.setExchange(xc)
     this.regAssetForm.setExchange(xc, certFile)
@@ -225,9 +225,8 @@ export default class RegistrationPage extends BasePage {
     if (!user) return
     const page = this.page
     const asset = user.assets[assetID]
-    const xc = app().exchanges[this.host]
     const wallet = asset.wallet
-    const bondAmt = xc.bondAssets[asset.symbol].amount
+    const bondAmt = this.xc.bondAssets[asset.symbol].amount
 
     const bondsFeeBuffer = await this.getBondsFeeBuffer(assetID, page.newWalletForm)
     this.walletWaitForm.setWallet(assetID, bondsFeeBuffer, tier)


### PR DESCRIPTION
The registration flow didn't take into account the case where an exchange had not yet been added to user.Exchanges. It assumed the exchange would already be view only.

Closes #2749 