### PR TITLE
eth: refactor tx montoring, handle tx resubmissions better, general refactoring

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1944,7 +1944,9 @@ func (btc *baseWallet) maxOrder(lotSize, feeSuggestion, maxFeeRate uint64) (utxo
 		return utxos, est, err
 	}
 
-	return utxos, &asset.SwapEstimate{}, nil
+	return utxos, &asset.SwapEstimate{
+		FeeReservesPerLot: basicFee,
+	}, nil
 }
 
 // sizeUnit returns the short form of the unit used to measure size, either
@@ -2170,6 +2172,8 @@ func (btc *baseWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate uin
 		bumpedNetRate = uint64(math.Ceil(float64(bumpedNetRate) * feeBump))
 	}
 
+	feeReservesPerLot := bumpedMaxRate * btc.initTxSize
+
 	val := lots * lotSize
 	// The orderEnough func does not account for a split transaction at the start,
 	// so it is possible that funding for trySplit would actually choose more
@@ -2211,6 +2215,7 @@ func (btc *baseWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate uin
 				MaxFees:            maxFees + splitMaxFees,
 				RealisticBestCase:  estLowFees + splitFees,
 				RealisticWorstCase: estHighFees + splitFees,
+				FeeReservesPerLot:  feeReservesPerLot,
 			}, true, reqFunds, nil // requires reqTotal, but locks reqFunds in the split output
 		}
 	}
@@ -2234,6 +2239,7 @@ func (btc *baseWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate uin
 		MaxFees:            maxFees,
 		RealisticBestCase:  estLowFees,
 		RealisticWorstCase: estHighFees,
+		FeeReservesPerLot:  feeReservesPerLot,
 	}, false, sum, nil
 }
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1454,7 +1454,9 @@ func (dcr *ExchangeWallet) maxOrder(lotSize, feeSuggestion, maxFeeRate uint64) (
 		return utxos, est, err
 	}
 
-	return nil, &asset.SwapEstimate{}, nil
+	return nil, &asset.SwapEstimate{
+		FeeReservesPerLot: basicFee,
+	}, nil
 }
 
 // estimateSwap prepares an *asset.SwapEstimate.
@@ -1468,6 +1470,8 @@ func (dcr *ExchangeWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate
 		bumpedMaxRate = uint64(math.Ceil(float64(bumpedMaxRate) * feeBump))
 		bumpedNetRate = uint64(math.Ceil(float64(bumpedNetRate) * feeBump))
 	}
+
+	feeReservesPerLot := bumpedMaxRate * dexdcr.InitTxSize
 
 	val := lots * lotSize
 	// The orderEnough func does not account for a split transaction at the
@@ -1515,6 +1519,7 @@ func (dcr *ExchangeWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate
 				MaxFees:            maxFees + splitMaxFees,
 				RealisticBestCase:  estLowFees + splitFees,
 				RealisticWorstCase: estHighFees + splitFees,
+				FeeReservesPerLot:  feeReservesPerLot,
 			}, true, reqFunds, nil // requires reqTotal, but locks reqFunds in the split output
 		}
 	}
@@ -1541,6 +1546,7 @@ func (dcr *ExchangeWallet) estimateSwap(lots, lotSize, feeSuggestion, maxFeeRate
 		MaxFees:            maxFees,
 		RealisticBestCase:  estLowFees,
 		RealisticWorstCase: estHighFees,
+		FeeReservesPerLot:  feeReservesPerLot,
 	}, false, sum, nil
 }
 

--- a/client/asset/dcr/externaltx.go
+++ b/client/asset/dcr/externaltx.go
@@ -100,7 +100,7 @@ func (dcr *ExchangeWallet) externalTxOutput(ctx context.Context, op outPoint, pk
 
 	// Scan block filters to find the tx block if it is yet unknown.
 	if txBlock == nil {
-		dcr.log.Infof("Output %s:%d NOT yet found; now searching with block filters.", op.txHash, op.vout)
+		dcr.log.Tracef("Output %s:%d NOT yet found; now searching with block filters.", op.txHash, op.vout)
 		txBlock, err = dcr.scanFiltersForTxBlock(ctx, tx, [][]byte{pkScript}, earliestTxTime)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error checking if tx %s is mined: %w", tx.hash, err)

--- a/client/asset/estimation.go
+++ b/client/asset/estimation.go
@@ -20,6 +20,9 @@ type SwapEstimate struct {
 	// RealisticBestCase is an estimation of the fees that might be assessed in
 	// a best-case scenario of 1 tx and 1 output for the entire order.
 	RealisticBestCase uint64 `json:"realisticBestCase"`
+	// FeeReservesPerLot is the amount that must be reserved per lot to cover
+	// fees for swap transactions.
+	FeeReservesPerLot uint64 `json:"feeReservesPerLot"`
 }
 
 // RedeemEstimate is an estimate of the range of fees that might realistically

--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -41,7 +41,7 @@ type contractor interface {
 	// case will always be zero.
 	value(context.Context, *types.Transaction) (incoming, outgoing uint64, err error)
 	isRefundable(secretHash [32]byte) (bool, error)
-	voidUnusedNonce()
+	// voidUnusedNonce()
 }
 
 // tokenContractor interacts with an ERC20 token contract and a token swap
@@ -305,15 +305,6 @@ func (c *contractorV0) outgoingValue(tx *types.Transaction) (swapped uint64) {
 		}
 	}
 	return
-}
-
-// voidUnusedNonce allows the next nonce received from a provider to be the same
-// as a recent nonce. Use when we fetch a nonce but error before or while
-// sending a transaction.
-func (c *contractorV0) voidUnusedNonce() {
-	if mRPC, is := c.cb.(*multiRPCClient); is {
-		mRPC.voidUnusedNonce()
-	}
 }
 
 // tokenContractorV0 is a contractor that implements the tokenContractor

--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -41,7 +41,6 @@ type contractor interface {
 	// case will always be zero.
 	value(context.Context, *types.Transaction) (incoming, outgoing uint64, err error)
 	isRefundable(secretHash [32]byte) (bool, error)
-	// voidUnusedNonce()
 }
 
 // tokenContractor interacts with an ERC20 token contract and a token swap

--- a/client/asset/eth/deploy.go
+++ b/client/asset/eth/deploy.go
@@ -368,7 +368,7 @@ func (contractDeployer) nodeAndRate(
 		return nil, 0, fmt.Errorf("Error estimating fee rate: %v", err)
 	}
 
-	feeRate := dexeth.WeiToGwei(new(big.Int).Add(tip, new(big.Int).Mul(base, big.NewInt(2))))
+	feeRate := dexeth.WeiToGweiCeil(new(big.Int).Add(tip, new(big.Int).Mul(base, big.NewInt(2))))
 	return cl, feeRate, nil
 }
 

--- a/client/asset/eth/deploy.go
+++ b/client/asset/eth/deploy.go
@@ -72,7 +72,7 @@ func (contractDeployer) estimateDeployFunding(
 	}
 	defer os.RemoveAll(walletDir)
 
-	cl, feeRate, err := ContractDeployer.nodeAndRate(ctx, chain, walletDir, credentialsPath, chainCfg, log, net)
+	cl, maxFeeRate, _, err := ContractDeployer.nodeAndRate(ctx, chain, walletDir, credentialsPath, chainCfg, log, net)
 	if err != nil {
 		return err
 	}
@@ -102,6 +102,7 @@ func (contractDeployer) estimateDeployFunding(
 		}
 	}
 
+	feeRate := dexeth.WeiToGweiCeil(maxFeeRate)
 	if gas == 0 {
 		gas = deploymentGas
 	}
@@ -237,7 +238,7 @@ func (contractDeployer) deployContract(
 	}
 	defer os.RemoveAll(walletDir)
 
-	cl, feeRate, err := ContractDeployer.nodeAndRate(ctx, chain, walletDir, credentialsPath, chainCfg, log, net)
+	cl, maxFeeRate, tipRate, err := ContractDeployer.nodeAndRate(ctx, chain, walletDir, credentialsPath, chainCfg, log, net)
 	if err != nil {
 		return err
 	}
@@ -262,7 +263,8 @@ func (contractDeployer) deployContract(
 		return fmt.Errorf("EstimateGas error: %v", err)
 	}
 
-	log.Infof("Estimated fees: %s", ui.ConventionalString(feeRate*gas))
+	feeRate := dexeth.WeiToGweiCeil(maxFeeRate)
+	log.Infof("Estimated fees: %s gwei / gas", ui.ConventionalString(feeRate*gas))
 
 	gas *= 5 / 4 // Add 20% buffer
 	feesWithBuffer := feeRate * gas
@@ -275,7 +277,7 @@ func (contractDeployer) deployContract(
 			ui.ConventionalString(shortage), cl.address())
 	}
 
-	txOpts, err := cl.txOpts(ctx, 0, gas, dexeth.GweiToWei(feeRate), nil)
+	txOpts, err := cl.txOpts(ctx, 0, gas, dexeth.GweiToWei(feeRate), tipRate, nil)
 	if err != nil {
 		return err
 	}
@@ -309,13 +311,13 @@ func (contractDeployer) ReturnETH(
 	}
 	defer os.RemoveAll(walletDir)
 
-	cl, feeRate, err := ContractDeployer.nodeAndRate(ctx, chain, walletDir, credentialsPath, chainCfg, log, net)
+	cl, maxFeeRate, tipRate, err := ContractDeployer.nodeAndRate(ctx, chain, walletDir, credentialsPath, chainCfg, log, net)
 	if err != nil {
 		return err
 	}
 	defer cl.shutdown()
 
-	return GetGas.returnFunds(ctx, cl, dexeth.GweiToWei(feeRate), returnAddr, nil, ui, log, net)
+	return GetGas.returnFunds(ctx, cl, maxFeeRate, tipRate, returnAddr, nil, ui, log, net)
 }
 
 func (contractDeployer) nodeAndRate(
@@ -327,11 +329,11 @@ func (contractDeployer) nodeAndRate(
 	chainCfg *params.ChainConfig,
 	log dex.Logger,
 	net dex.Network,
-) (*multiRPCClient, uint64, error) {
+) (*multiRPCClient, *big.Int, *big.Int, error) {
 
 	seed, providers, err := getFileCredentials(chain, credentialsPath, net)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, nil, err
 	}
 
 	pw := []byte("abc")
@@ -346,30 +348,30 @@ func (contractDeployer) nodeAndRate(
 		Net:      net,
 		Logger:   log,
 	}, nil /* we don't need the full api, skipConnect = true allows for nil compat */, true); err != nil {
-		return nil, 0, fmt.Errorf("error creating wallet: %w", err)
+		return nil, nil, nil, fmt.Errorf("error creating wallet: %w", err)
 	}
 
 	cl, err := newMultiRPCClient(walletDir, providers, log, chainCfg, net)
 	if err != nil {
-		return nil, 0, fmt.Errorf("error creating rpc client: %w", err)
+		return nil, nil, nil, fmt.Errorf("error creating rpc client: %w", err)
 	}
 
 	if err := cl.unlock(string(pw)); err != nil {
-		return nil, 0, fmt.Errorf("error unlocking rpc client: %w", err)
+		return nil, nil, nil, fmt.Errorf("error unlocking rpc client: %w", err)
 	}
 
 	if err = cl.connect(ctx); err != nil {
-		return nil, 0, fmt.Errorf("error connecting: %w", err)
+		return nil, nil, nil, fmt.Errorf("error connecting: %w", err)
 	}
 
-	base, tip, err := cl.currentFees(ctx)
+	baseRate, tipRate, err := cl.currentFees(ctx)
 	if err != nil {
 		cl.shutdown()
-		return nil, 0, fmt.Errorf("Error estimating fee rate: %v", err)
+		return nil, nil, nil, fmt.Errorf("Error estimating fee rate: %v", err)
 	}
 
-	feeRate := dexeth.WeiToGweiCeil(new(big.Int).Add(tip, new(big.Int).Mul(base, big.NewInt(2))))
-	return cl, feeRate, nil
+	maxFeeRate := new(big.Int).Add(tipRate, new(big.Int).Mul(baseRate, big.NewInt(2)))
+	return cl, maxFeeRate, tipRate, nil
 }
 
 // DeployMultiBalance deployes a contract with a function for reading all

--- a/client/asset/eth/deploy.go
+++ b/client/asset/eth/deploy.go
@@ -351,7 +351,7 @@ func (contractDeployer) nodeAndRate(
 		return nil, nil, nil, fmt.Errorf("error creating wallet: %w", err)
 	}
 
-	cl, err := newMultiRPCClient(walletDir, providers, log, chainCfg, net)
+	cl, err := newMultiRPCClient(walletDir, providers, log, chainCfg, 3, net)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating rpc client: %w", err)
 	}

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -893,8 +893,7 @@ func (w *ETHWallet) Connect(ctx context.Context) (_ *sync.WaitGroup, err error) 
 		}
 	}
 
-	w.txDB = newBadgerTxDB(filepath.Join(w.dir, "txhistorydb"), w.log.SubLogger("TXDB"))
-	wg, err := w.txDB.connect(ctx)
+	w.txDB, err = newBadgerTxDB(filepath.Join(w.dir, "txhistorydb"), w.log.SubLogger("TXDB"))
 	if err != nil {
 		return nil, err
 	}
@@ -947,7 +946,13 @@ func (w *ETHWallet) Connect(ctx context.Context) (_ *sync.WaitGroup, err error) 
 	atomic.StoreInt64(&w.tipAtConnect, height.Int64())
 	w.log.Infof("Connected to eth (%s), at height %d", w.walletType, height)
 
-	w.connected.Store(true)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		w.txDB.run(ctx)
+	}()
 
 	wg.Add(1)
 	go func() {
@@ -962,12 +967,13 @@ func (w *ETHWallet) Connect(ctx context.Context) (_ *sync.WaitGroup, err error) 
 		w.monitorPeers(ctx)
 	}()
 
+	w.connected.Store(true)
 	go func() {
 		<-ctx.Done()
 		w.connected.Store(false)
 	}()
 
-	return wg, nil
+	return &wg, nil
 }
 
 // Connect waits for context cancellation and closes the WaitGroup. Satisfies

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -796,7 +796,7 @@ func TestCheckPendingTxs(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			eth.confirmedNonceAt = new(big.Int).Add(tt.pendingTxs[0].Nonce, big.NewInt(1))
+			eth.confirmedNonceAt = tt.pendingTxs[0].Nonce
 			eth.pendingNonceAt = new(big.Int).Add(tt.pendingTxs[len(tt.pendingTxs)-1].Nonce, big.NewInt(1))
 
 			node.lastSignedTx = nil

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -198,7 +198,7 @@ func (n *testNode) getTransaction(ctx context.Context, hash common.Hash) (*types
 	return n.getTxRes, n.getTxHeight, n.getTxErr
 }
 
-func (n *testNode) txOpts(ctx context.Context, val, maxGas uint64, maxFeeRate, nonce *big.Int) (*bind.TransactOpts, error) {
+func (n *testNode) txOpts(ctx context.Context, val, maxGas uint64, maxFeeRate, tipRate, nonce *big.Int) (*bind.TransactOpts, error) {
 	if maxFeeRate == nil {
 		maxFeeRate = n.maxFeeRate
 	}
@@ -684,7 +684,7 @@ func TestCheckPendingTxs(t *testing.T) {
 	const finalized = tip - txConfsNeededToConfirm + 1
 	now := uint64(time.Now().Unix())
 	finalizedStamp := now - txConfsNeededToConfirm*10
-	mature := now - 300 // able to send actions
+	mature := now - 600 // able to send actions
 	agedOut := now - uint64(txAgeOut.Seconds()) - 1
 
 	val := dexeth.GweiToWei(1)
@@ -695,6 +695,7 @@ func TestCheckPendingTxs(t *testing.T) {
 		pendingTx.Timestamp = blockStamp
 		pendingTx.SubmissionTime = submissionStamp
 		pendingTx.lastBroadcast = time.Unix(int64(submissionStamp), 0)
+		pendingTx.lastFeeCheck = time.Unix(int64(submissionStamp), 0)
 		return pendingTx
 	}
 
@@ -772,13 +773,14 @@ func TestCheckPendingTxs(t *testing.T) {
 			actionID:    actionTypeLostTx,
 		},
 		{
-			name: "old and indexed, low fees",
+			name: "mature and indexed, low fees",
 			pendingTxs: []*extendedWalletTx{
-				extendedTx(6, 0, 0, agedOut),
+				extendedTx(6, 0, 0, mature),
 			},
 			noncesAfter: []uint64{6},
 			receipts:    []*types.Receipt{newReceipt(0)},
 			actionID:    actionTypeTooCheap,
+			recast:      true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1490,6 +1492,7 @@ func TestFeeRate(t *testing.T) {
 		ctx:           ctx,
 		log:           tLogger,
 		finalizeConfs: txConfsNeededToConfirm,
+		currentTip:    &types.Header{Number: big.NewInt(100)},
 	}
 
 	maxInt := ^int64(0)
@@ -1518,6 +1521,7 @@ func TestFeeRate(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		eth.currentFees.blockNum = 0
 		node.baseFee = test.baseFee
 		node.tip = test.tip
 		node.netFeeStateErr = test.netFeeStateErr
@@ -3843,7 +3847,7 @@ func TestSwapConfirmation(t *testing.T) {
 	state.BlockHeight = 5
 	state.State = dexeth.SSInitiated
 	hdr.Number = big.NewInt(6)
-	node.bestHdr = hdr
+	eth.currentTip = hdr
 
 	ver := uint32(0)
 
@@ -3851,6 +3855,7 @@ func TestSwapConfirmation(t *testing.T) {
 	defer cancel()
 
 	checkResult := func(expErr bool, expConfs uint32, expSpent bool) {
+		t.Helper()
 		confs, spent, err := eth.SwapConfirmations(ctx, nil, dexeth.EncodeContractData(ver, secretHash), time.Time{})
 		if err != nil {
 			if expErr {
@@ -3877,11 +3882,6 @@ func TestSwapConfirmation(t *testing.T) {
 	node.tContractor.swapErr = fmt.Errorf("test error")
 	checkResult(true, 0, false)
 	node.tContractor.swapErr = nil
-
-	// header error
-	node.bestHdrErr = fmt.Errorf("test error")
-	checkResult(true, 0, false)
-	node.bestHdrErr = nil
 
 	// ErrSwapNotInitiated
 	state.State = dexeth.SSNone
@@ -4494,7 +4494,7 @@ func testSend(t *testing.T, assetID uint32) {
 	node.sendTxTx = tx
 	node.tokenContractor.transferTx = tx
 
-	maxFeeRate, _ := eth.recommendedMaxFeeRate(eth.ctx)
+	maxFeeRate, _, _ := eth.recommendedMaxFeeRate(eth.ctx)
 	ethFees := dexeth.WeiToGwei(maxFeeRate) * defaultSendGasLimit
 	tokenFees := dexeth.WeiToGwei(maxFeeRate) * tokenGases.Transfer
 
@@ -4792,7 +4792,7 @@ func testEstimateSendTxFee(t *testing.T, assetID uint32) {
 	w, eth, node, shutdown := tassetWallet(assetID)
 	defer shutdown()
 
-	maxFeeRate, _ := eth.recommendedMaxFeeRate(eth.ctx)
+	maxFeeRate, _, _ := eth.recommendedMaxFeeRate(eth.ctx)
 	ethFees := dexeth.WeiToGwei(maxFeeRate) * defaultSendGasLimit
 	tokenFees := dexeth.WeiToGwei(maxFeeRate) * tokenGases.Transfer
 

--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -1077,8 +1076,6 @@ func (m *multiRPCClient) withAll(
 		if discarded {
 			atLeastOne = true
 		} else {
-			errs = append(errs, err)
-			debug.PrintStack()
 			m.log.Warnf("Failed request from %q: %v", p, err)
 		}
 	}
@@ -1561,7 +1558,7 @@ func newCompatibilityTests(cb bind.ContractBackend, compat *CompatibilityData, l
 				if err != nil {
 					return err
 				}
-				log.Debugf("#### Retrieved tip cap: %d gwei", dexeth.WeiToGwei(tipCap))
+				log.Debugf("#### Retrieved tip cap: %d gwei", dexeth.WeiToGweiCeil(tipCap))
 				return nil
 			},
 		},
@@ -1572,7 +1569,7 @@ func newCompatibilityTests(cb bind.ContractBackend, compat *CompatibilityData, l
 				if err != nil {
 					return err
 				}
-				log.Debugf("#### Balance retrieved: %.9f", float64(dexeth.WeiToGwei(bal))/1e9)
+				log.Debugf("#### Balance retrieved: %.9f", float64(dexeth.WeiToGweiCeil(bal))/1e9)
 				return nil
 			},
 		},

--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -388,7 +388,15 @@ type multiRPCClient struct {
 
 var _ ethFetcher = (*multiRPCClient)(nil)
 
-func newMultiRPCClient(dir string, endpoints []string, log dex.Logger, cfg *params.ChainConfig, net dex.Network) (*multiRPCClient, error) {
+func newMultiRPCClient(
+	dir string,
+	endpoints []string,
+	log dex.Logger,
+	cfg *params.ChainConfig,
+	finalizeConfs uint64,
+	net dex.Network,
+) (*multiRPCClient, error) {
+
 	walletDir := getWalletDir(dir, net)
 	creds, err := pathCredentials(filepath.Join(walletDir, "keystore"))
 	if err != nil {
@@ -396,14 +404,13 @@ func newMultiRPCClient(dir string, endpoints []string, log dex.Logger, cfg *para
 	}
 
 	m := &multiRPCClient{
-		net:       net,
-		cfg:       cfg,
-		log:       log,
-		creds:     creds,
-		chainID:   cfg.ChainID,
-		endpoints: endpoints,
-		// Set this low. If the user needs higher, they can update it.
-		finalizeConfs: 3,
+		net:           net,
+		cfg:           cfg,
+		log:           log,
+		creds:         creds,
+		chainID:       cfg.ChainID,
+		endpoints:     endpoints,
+		finalizeConfs: finalizeConfs,
 	}
 	m.receipts.cache = make(map[common.Hash]*receiptRecord)
 	m.receipts.lastClean = time.Now()

--- a/client/asset/eth/multirpc_live_test.go
+++ b/client/asset/eth/multirpc_live_test.go
@@ -115,3 +115,7 @@ func TestFreeTestnetServers(t *testing.T) {
 func TestMainnetCompliance(t *testing.T) {
 	mt.TestMainnetCompliance(t)
 }
+
+func TestReceiptsHaveEffectiveGasPrice(t *testing.T) {
+	mt.TestReceiptsHaveEffectiveGasPrice(t)
+}

--- a/client/asset/eth/multirpc_test_util.go
+++ b/client/asset/eth/multirpc_test_util.go
@@ -95,7 +95,7 @@ func (m *MRPCTest) rpcClient(dir string, seed []byte, endpoints []string, net de
 		return nil, fmt.Errorf("error creating wallet: %v", err)
 	}
 
-	return newMultiRPCClient(dir, endpoints, log, cfg, net)
+	return newMultiRPCClient(dir, endpoints, log, cfg, 3, net)
 }
 
 func (m *MRPCTest) TestHTTP(t *testing.T, port string) {

--- a/client/asset/eth/multirpc_test_util.go
+++ b/client/asset/eth/multirpc_test_util.go
@@ -153,7 +153,7 @@ func (m *MRPCTest) TestSimnetMultiRPCClient(t *testing.T, wsPort, httpPort strin
 		for i := 0; i < 10; i++ {
 			// Send two in a row. They should use each provider, preferred first.
 			for j := 0; j < 2; j++ {
-				txOpts, err := cl.txOpts(ctx, amt, defaultSendGasLimit, nil, nil)
+				txOpts, err := cl.txOpts(ctx, amt, defaultSendGasLimit, nil, nil, nil)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/client/asset/eth/multirpc_test_util.go
+++ b/client/asset/eth/multirpc_test_util.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math/big"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -17,7 +18,9 @@ import (
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
+	dexeth "decred.org/dcrdex/dex/networks/eth"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -176,6 +179,7 @@ func (m *MRPCTest) TestSimnetMultiRPCClient(t *testing.T, wsPort, httpPort strin
 func (m *MRPCTest) TestMonitorNet(t *testing.T, net dex.Network) {
 	seed, providers := m.readProviderFile(t, net)
 	dir, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(dir)
 
 	cl, err := m.rpcClient(dir, seed, providers, net, true)
 	if err != nil {
@@ -289,6 +293,98 @@ func (m *MRPCTest) TestMainnetCompliance(t *testing.T) {
 	}
 }
 
+func (m *MRPCTest) withClient(t *testing.T, net dex.Network, f func(context.Context, *multiRPCClient)) {
+	seed, providers := m.readProviderFile(t, net)
+	dir, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(dir)
+
+	cl, err := m.rpcClient(dir, seed, providers, net, false)
+	if err != nil {
+		t.Fatalf("Error creating rpc client: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(m.ctx, time.Hour)
+	defer cancel()
+
+	if err := cl.connect(ctx); err != nil {
+		t.Fatalf("Connection error: %v", err)
+	}
+
+	f(ctx, cl)
+}
+
+// FeeHistory prints the base fees sampled once per week going back the
+// specified number of days.
+func (m *MRPCTest) FeeHistory(t *testing.T, net dex.Network, blockTimeSecs, days uint64) {
+	m.withClient(t, net, func(ctx context.Context, cl *multiRPCClient) {
+		tip, err := cl.bestHeader(ctx)
+		if err != nil {
+			t.Fatalf("bestHeader error: %v", err)
+		}
+
+		tipHeight := tip.Number.Uint64()
+
+		baseFees := misc.CalcBaseFee(cl.cfg, tip)
+
+		fmt.Printf("##### Tip = %d \n", tipHeight)
+		fmt.Printf("##### Current base fees: %s \n", fmtFee(baseFees))
+
+		const secondsPerDay = 86_400
+		var samplingDuration uint64 = 7 * secondsPerDay // Check every 7 days
+		totalDuration := secondsPerDay * days
+		n := totalDuration / samplingDuration
+		samplingDistance := samplingDuration / blockTimeSecs
+		fees := make([]uint64, n)
+		for i := range fees {
+			height := tipHeight - (uint64(i+1) * samplingDistance)
+			hdr, err := cl.HeaderByNumber(ctx, big.NewInt(int64(height)))
+			if err != nil {
+				t.Fatalf("HeaderByNumber(%d) error: %v", height, err)
+			}
+			if hdr.BaseFee == nil {
+				fmt.Println("nil base fees for height", height)
+				continue
+			}
+			baseFees = misc.CalcBaseFee(cl.cfg, hdr)
+			fmt.Printf("##### Base fees height %d @ %s: %s \n", height, time.Unix(int64(hdr.Time), 0), fmtFee(baseFees))
+		}
+	})
+}
+
+func (m *MRPCTest) TipCaps(t *testing.T, net dex.Network) {
+	m.withClient(t, net, func(ctx context.Context, cl *multiRPCClient) {
+		if err := cl.withAny(ctx, func(ctx context.Context, p *provider) error {
+			blk, err := p.ec.BlockByNumber(ctx, nil)
+			if err != nil {
+				return err
+			}
+			h := blk.Number()
+			const m = 20 // how many txs
+			var n int
+			for {
+				txs := blk.Transactions()
+				fmt.Printf("##### Block %d has %d transactions \n", h, len(txs))
+				for _, tx := range txs {
+					n++
+					fmt.Println("##### Tx tip cap =", fmtFee(tx.GasTipCap()))
+				}
+				if n >= m {
+					break
+				}
+				h.Add(h, big.NewInt(-1))
+				blk, err = p.ec.BlockByNumber(ctx, h)
+				if err != nil {
+					return fmt.Errorf("error getting block %d: %w", h, err)
+				}
+			}
+
+			return nil
+		}); err != nil {
+			t.Fatalf("Error getting block: %v", err)
+		}
+	})
+}
+
 func (m *MRPCTest) testSimnetEndpoint(endpoints []string, syncBlocks uint64, tFunc func(context.Context, *multiRPCClient)) error {
 	dir, _ := os.MkdirTemp("", "")
 	defer os.RemoveAll(dir)
@@ -360,4 +456,11 @@ func (m *MRPCTest) readProviderFile(t *testing.T, net dex.Network) (seed []byte,
 		t.Fatalf("Error retreiving credentials from file at %q: %v", m.credentialsFile, err)
 	}
 	return
+}
+
+func fmtFee(v *big.Int) string {
+	if v.Cmp(dexeth.GweiToWei(1)) < 0 {
+		return fmt.Sprintf("%s wei / gas", v)
+	}
+	return fmt.Sprintf("%d gwei / gas", dexeth.WeiToGwei(v))
 }

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -393,8 +393,16 @@ func (n *nodeClient) sendSignedTransaction(ctx context.Context, tx *types.Transa
 
 // newTxOpts is a constructor for a TransactOpts.
 func newTxOpts(ctx context.Context, from common.Address, val, maxGas uint64, maxFeeRate, gasTipCap *big.Int) *bind.TransactOpts {
+	// We'll enforce dexeth.MinGasTipCap since the server does, but this isn't
+	// necessarily a constant for all networks or under all conditions.
+	minGasWei := dexeth.GweiToWei(dexeth.MinGasTipCap)
+	if gasTipCap.Cmp(minGasWei) < 0 {
+		gasTipCap.Set(minGasWei)
+	}
+	// This is enforced by concensus. We shouldn't be able to get here with a
+	// swap tx.
 	if gasTipCap.Cmp(maxFeeRate) > 0 {
-		gasTipCap = maxFeeRate
+		gasTipCap.Set(maxFeeRate)
 	}
 	return &bind.TransactOpts{
 		Context:   ctx,

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -201,8 +201,8 @@ func (n *nodeClient) transactionAndReceipt(ctx context.Context, txHash common.Ha
 	return receipt, tx, nil
 }
 
-func (n *nodeClient) nextNonce(ctx context.Context) (*big.Int, error) {
-	return nil, errors.New("unimplemented")
+func (n *nodeClient) nonce(ctx context.Context) (*big.Int, *big.Int, error) {
+	return nil, nil, errors.New("unimplemented")
 }
 
 // pendingTransactions returns pending transactions.
@@ -232,7 +232,7 @@ func (n *nodeClient) getConfirmedNonce(ctx context.Context) (uint64, error) {
 
 // sendTransaction sends a tx. The nonce should be set in txOpts.
 func (n *nodeClient) sendTransaction(ctx context.Context, txOpts *bind.TransactOpts,
-	to common.Address, data []byte) (*types.Transaction, error) {
+	to common.Address, data []byte, filts ...acceptabilityFilter) (*types.Transaction, error) {
 
 	tx, err := n.creds.ks.SignTx(*n.creds.acct, types.NewTx(&types.DynamicFeeTx{
 		To:        &to,
@@ -395,7 +395,7 @@ func (n *nodeClient) transactionConfirmations(ctx context.Context, txHash common
 }
 
 // sendSignedTransaction injects a signed transaction into the pending pool for execution.
-func (n *nodeClient) sendSignedTransaction(ctx context.Context, tx *types.Transaction) error {
+func (n *nodeClient) sendSignedTransaction(ctx context.Context, tx *types.Transaction, filts ...acceptabilityFilter) error {
 	return n.leth.ApiBackend.SendTx(ctx, tx)
 }
 

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -317,7 +317,7 @@ func (n *nodeClient) getCodeAt(ctx context.Context, contractAddr common.Address)
 //
 // NOTE: The nonce included in the txOpts must be sent before txOpts is used
 // again. The caller should ensure that txOpts -> send sequence is synchronized.
-func (n *nodeClient) txOpts(ctx context.Context, val, maxGas uint64, maxFeeRate, nonce *big.Int) (*bind.TransactOpts, error) {
+func (n *nodeClient) txOpts(ctx context.Context, val, maxGas uint64, maxFeeRate, tipRate, nonce *big.Int) (*bind.TransactOpts, error) {
 	baseFee, gasTipCap, err := n.currentFees(ctx)
 	if err != nil {
 		return nil, err

--- a/client/asset/eth/nodeclient.go
+++ b/client/asset/eth/nodeclient.go
@@ -171,8 +171,12 @@ func (n *nodeClient) locked() bool {
 	return status != "Unlocked"
 }
 
+func (n *nodeClient) transactionReceipt(ctx context.Context, txHash common.Hash) (r *types.Receipt, err error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
 // transactionReceipt retrieves the transaction's receipt.
-func (n *nodeClient) transactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, *types.Transaction, error) {
+func (n *nodeClient) transactionAndReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, *types.Transaction, error) {
 	tx, blockHash, _, index, err := n.leth.ApiBackend.GetTransaction(ctx, txHash)
 	if err != nil {
 		if errors.Is(err, ethereum.NotFound) {
@@ -195,6 +199,10 @@ func (n *nodeClient) transactionReceipt(ctx context.Context, txHash common.Hash)
 		return nil, nil, fmt.Errorf("nil receipt at index %d in block %s for tx %s", index, blockHash, txHash)
 	}
 	return receipt, tx, nil
+}
+
+func (n *nodeClient) nextNonce(ctx context.Context) (*big.Int, error) {
+	return nil, errors.New("unimplemented")
 }
 
 // pendingTransactions returns pending transactions.

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -153,7 +153,7 @@ func waitForReceipt(nc ethFetcher, tx *types.Transaction) (*types.Receipt, error
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-time.After(time.Second):
-			receipt, _, err := nc.transactionReceipt(ctx, hash)
+			receipt, err := nc.transactionReceipt(ctx, hash)
 			if err != nil {
 				if errors.Is(err, asset.CoinNotFoundError) {
 					continue
@@ -1014,10 +1014,11 @@ func testSendSignedTransaction(t *testing.T) {
 		ks = c.creds.ks
 		chainID = c.chainID
 	case *multiRPCClient:
-		nonce, err = c.nextNonce(ctx)
+		n, err := c.nextNonce(ctx)
 		if err != nil {
 			t.Fatalf("error getting nonce: %v", err)
 		}
+		nonce = n.Uint64()
 		ks = c.creds.ks
 		chainID = c.chainID
 	}
@@ -1382,7 +1383,6 @@ func testInitiate(t *testing.T, assetID uint32) {
 		}
 		if err != nil {
 			if test.swapErr {
-				sc.voidUnusedNonce()
 				continue
 			}
 			t.Fatalf("%s: initiate error: %v", test.name, err)
@@ -1764,7 +1764,6 @@ func testRedeem(t *testing.T, assetID uint32) {
 		}
 		tx, err = test.redeemerContractor.redeem(txOpts, test.redemptions)
 		if test.expectRedeemErr {
-			test.redeemerContractor.voidUnusedNonce()
 			if err == nil {
 				t.Fatalf("%s: expected error but did not get", test.name)
 			}

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -255,7 +255,7 @@ func prepareRPCClient(name, dataDir string, providers []string, net dex.Network)
 		return nil, nil, err
 	}
 
-	c, err := newMultiRPCClient(dataDir, providers, tLogger.SubLogger(name), cfg, net)
+	c, err := newMultiRPCClient(dataDir, providers, tLogger.SubLogger(name), cfg, 3, net)
 	if err != nil {
 		return nil, nil, fmt.Errorf("(%s) newNodeClient error: %v", name, err)
 	}

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -695,7 +695,7 @@ func prepareTokenClients(t *testing.T) {
 	if err != nil {
 		t.Fatalf("initiator unlock error; %v", err)
 	}
-	txOpts, err := ethClient.txOpts(ctx, 0, tokenGases.Approve, nil, nil)
+	txOpts, err := ethClient.txOpts(ctx, 0, tokenGases.Approve, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("txOpts error: %v", err)
 	}
@@ -708,7 +708,7 @@ func prepareTokenClients(t *testing.T) {
 		t.Fatalf("participant unlock error; %v", err)
 	}
 
-	txOpts, err = participantEthClient.txOpts(ctx, 0, tokenGases.Approve, nil, nil)
+	txOpts, err = participantEthClient.txOpts(ctx, 0, tokenGases.Approve, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("txOpts error: %v", err)
 	}
@@ -932,7 +932,7 @@ func testSendTransaction(t *testing.T) {
 		t.Fatalf("no CoinNotFoundError")
 	}
 
-	txOpts, err := ethClient.txOpts(ctx, 1, defaultSendGasLimit, nil, nil)
+	txOpts, err := ethClient.txOpts(ctx, 1, defaultSendGasLimit, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("txOpts error: %v", err)
 	}
@@ -1069,7 +1069,7 @@ func testSendSignedTransaction(t *testing.T) {
 }
 
 func testTransactionReceipt(t *testing.T) {
-	txOpts, err := ethClient.txOpts(ctx, 1, defaultSendGasLimit, nil, nil)
+	txOpts, err := ethClient.txOpts(ctx, 1, defaultSendGasLimit, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("txOpts error: %v", err)
 	}
@@ -1366,7 +1366,7 @@ func testInitiate(t *testing.T, assetID uint32) {
 		}
 
 		expGas := gases.SwapN(len(test.swaps))
-		txOpts, err := ethClient.txOpts(ctx, optsVal, expGas, dexeth.GweiToWei(maxFeeRate), nil)
+		txOpts, err := ethClient.txOpts(ctx, optsVal, expGas, dexeth.GweiToWei(maxFeeRate), nil, nil)
 		if err != nil {
 			t.Fatalf("%s: txOpts error: %v", test.name, err)
 		}
@@ -1498,7 +1498,7 @@ func testRedeemGas(t *testing.T, assetID uint32) {
 		pc = participantTokenContractor
 	}
 
-	txOpts, err := ethClient.txOpts(ctx, optsVal, gases.SwapN(len(swaps)), dexeth.GweiToWei(maxFeeRate), nil)
+	txOpts, err := ethClient.txOpts(ctx, optsVal, gases.SwapN(len(swaps)), dexeth.GweiToWei(maxFeeRate), nil, nil)
 	if err != nil {
 		t.Fatalf("txOpts error: %v", err)
 	}
@@ -1708,7 +1708,7 @@ func testRedeem(t *testing.T, assetID uint32) {
 			}
 		}
 
-		txOpts, err := test.redeemerClient.txOpts(ctx, optsVal, gases.SwapN(len(test.swaps)), dexeth.GweiToWei(maxFeeRate), nil)
+		txOpts, err := test.redeemerClient.txOpts(ctx, optsVal, gases.SwapN(len(test.swaps)), dexeth.GweiToWei(maxFeeRate), nil, nil)
 		if err != nil {
 			t.Fatalf("%s: txOpts error: %v", test.name, err)
 		}
@@ -1758,7 +1758,7 @@ func testRedeem(t *testing.T, assetID uint32) {
 		}
 
 		expGas := gases.RedeemN(len(test.redemptions))
-		txOpts, err = test.redeemerClient.txOpts(ctx, 0, expGas, dexeth.GweiToWei(maxFeeRate), nil)
+		txOpts, err = test.redeemerClient.txOpts(ctx, 0, expGas, dexeth.GweiToWei(maxFeeRate), nil, nil)
 		if err != nil {
 			t.Fatalf("%s: txOpts error: %v", test.name, err)
 		}
@@ -1876,7 +1876,7 @@ func testRefundGas(t *testing.T, assetID uint32) {
 
 	lockTime := uint64(time.Now().Unix())
 
-	txOpts, err := ethClient.txOpts(ctx, optsVal, gases.SwapN(1), nil, nil)
+	txOpts, err := ethClient.txOpts(ctx, optsVal, gases.SwapN(1), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("txOpts error: %v", err)
 	}
@@ -2005,7 +2005,7 @@ func testRefund(t *testing.T, assetID uint32) {
 
 		inLocktime := uint64(time.Now().Add(test.addTime).Unix())
 
-		txOpts, err := ethClient.txOpts(ctx, optsVal, gases.SwapN(1), nil, nil)
+		txOpts, err := ethClient.txOpts(ctx, optsVal, gases.SwapN(1), nil, nil, nil)
 		if err != nil {
 			t.Fatalf("%s: txOpts error: %v", test.name, err)
 		}
@@ -2019,7 +2019,7 @@ func testRefund(t *testing.T, assetID uint32) {
 				t.Fatalf("%s: pre-redeem mining error: %v", test.name, err)
 			}
 
-			txOpts, err = participantEthClient.txOpts(ctx, 0, gases.RedeemN(1), nil, nil)
+			txOpts, err = participantEthClient.txOpts(ctx, 0, gases.RedeemN(1), nil, nil, nil)
 			if err != nil {
 				t.Fatalf("%s: txOpts error: %v", test.name, err)
 			}
@@ -2056,7 +2056,7 @@ func testRefund(t *testing.T, assetID uint32) {
 				test.name, test.isRefundable, isRefundable)
 		}
 
-		txOpts, err = test.refunderClient.txOpts(ctx, 0, gases.Refund, dexeth.GweiToWei(maxFeeRate), nil)
+		txOpts, err = test.refunderClient.txOpts(ctx, 0, gases.Refund, dexeth.GweiToWei(maxFeeRate), nil, nil)
 		if err != nil {
 			t.Fatalf("%s: txOpts error: %v", test.name, err)
 		}
@@ -2151,7 +2151,7 @@ func testApproveAllowance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txOpts, err := ethClient.txOpts(ctx, 0, tokenGases.Approve, nil, nil)
+	txOpts, err := ethClient.txOpts(ctx, 0, tokenGases.Approve, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("txOpts error: %v", err)
 	}

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -1014,7 +1014,7 @@ func testSendSignedTransaction(t *testing.T) {
 		ks = c.creds.ks
 		chainID = c.chainID
 	case *multiRPCClient:
-		n, err := c.nextNonce(ctx)
+		n, _, err := c.nonce(ctx)
 		if err != nil {
 			t.Fatalf("error getting nonce: %v", err)
 		}

--- a/client/asset/eth/txdb.go
+++ b/client/asset/eth/txdb.go
@@ -48,11 +48,8 @@ type extendedWalletTx struct {
 	lastCheck       uint64
 	savedToDB       bool
 	lastBroadcast   time.Time
+	lastFeeCheck    time.Time
 	actionRequested bool
-	// indexed will be true if the network seems to know about the tx one way
-	// or another, even if we can't get a receipt. which might be the case for
-	// providers that return information about mempool transactions.
-	indexed bool
 }
 
 func (t *extendedWalletTx) age() time.Duration {

--- a/client/asset/eth/txdb.go
+++ b/client/asset/eth/txdb.go
@@ -26,20 +26,33 @@ import (
 // fields used for tracking transactions.
 type extendedWalletTx struct {
 	*asset.WalletTransaction
-	BlockSubmitted   uint64         `json:"blockSubmitted"`
-	SubmissionTime   uint64         `json:"timeStamp"` // seconds
-	RawTx            dex.Bytes      `json:"rawTx"`
-	NonceReplacement string         `json:"feeReplacement,omitempty"`
-	AssumedLost      bool           `json:"assumedLost,omitempty"`
-	Nonce            *big.Int       `json:"nonce"`
-	Receipt          *types.Receipt `json:"receipt,omitempty"`
+	BlockSubmitted uint64         `json:"blockSubmitted"`
+	SubmissionTime uint64         `json:"timeStamp"` // seconds
+	Nonce          *big.Int       `json:"nonce"`
+	Receipt        *types.Receipt `json:"receipt,omitempty"`
+	RawTx          dex.Bytes      `json:"rawTx"`
+	// NonceReplacement is a transaction with the same nonce that was accepted
+	// by the network, meaning this tx was not applied.
+	NonceReplacement string `json:"nonceReplacement,omitempty"`
+	// FeeReplacement is a transaction that replaced this transaction but with
+	// higher fees. The FeeReplacement is always the NonceReplacement too,
+	// but the FeeReplacement can be assumed to otherwise be the same tx as
+	// the one replaced, just with higher fees.
+	FeeReplacement string `json:"feeReplacement,omitempty"`
+	// AssumedLost will be set to true if a transaction is assumed to be lost.
+	// This typically requires feedback from the user in response to an
+	// ActionRequiredNote.
+	AssumedLost bool `json:"assumedLost,omitempty"`
 
 	txHash          common.Hash
 	lastCheck       uint64
 	savedToDB       bool
-	indexed         bool // The network seems to know about it.
 	lastBroadcast   time.Time
 	actionRequested bool
+	// indexed will be true if the network seems to know about the tx one way
+	// or another, even if we can't get a receipt. which might be the case for
+	// providers that return information about mempool transactions.
+	indexed bool
 }
 
 func (t *extendedWalletTx) age() time.Duration {
@@ -107,18 +120,18 @@ func (db *badgerTxDB) Update(f func(txn *badger.Txn) error) (err error) {
 var maxNonceKey = nonceKey(math.MaxUint64)
 
 // initialDBVersion only contained mappings from txHash -> monitoredTx.
-const initialDBVersion = 0
+// const initialDBVersion = 0
 
 // prefixDBVersion contains two mappings each marked with a prefix:
 //
 //	nonceKey -> extendedWalletTx (noncePrefix)
 //	txHash -> nonceKey (txHashPrefix)
-const prefixDBVersion = 1
+// const prefixDBVersion = 1
 
 // txMappingVersion reverses the semantics so that all txs are accessible
 // by txHash.
 //
-// nonceKey -> accepted tx hash
+// nonceKey -> best-known txHash
 // txHash -> extendedWalletTx, which contains a nonce
 const txMappingVersion = 2
 
@@ -312,16 +325,16 @@ func (db *badgerTxDB) storeTx(wt *extendedWalletTx) error {
 		if err != nil && !errors.Is(err, badger.ErrKeyNotFound) {
 			return fmt.Errorf("error reading nonce tx: %w", err)
 		}
-		if nonceTx == nil || !nonceTx.Confirmed {
+		// If we don't have a tx stored at the nonce or the tx stored at the
+		// nonce is not confirmed, put this one there instead, unless this one
+		// has been marked as nonce-replaced.
+		if (nonceTx == nil || !nonceTx.Confirmed) && wt.NonceReplacement == "" {
 			if err := txn.Set(nonceKey(nonce), wt.txHash[:]); err != nil {
 				return fmt.Errorf("error mapping nonce to tx hash: %w", err)
 			}
 		}
-		// Store the at it's hash.
-		if err = txn.Set(txKey(wt.txHash), wtB); err != nil {
-			return err
-		}
-		return nil
+		// Store the tx at its hash.
+		return txn.Set(txKey(wt.txHash), wtB)
 	})
 }
 

--- a/client/asset/eth/txdb.go
+++ b/client/asset/eth/txdb.go
@@ -346,11 +346,11 @@ func unmarshalTx(wtB []byte) (wt *extendedWalletTx, err error) {
 
 // getTxs fetches n transactions. If no refID is provided, getTxs returns the
 // n most recent txs in reverse-nonce order. If no refID is provided, the past
-// argument is ignored. If a refID is provided, getTxs will return 10 txs
+// argument is ignored. If a refID is provided, getTxs will return n txs
 // starting with the nonce of the tx referenced. When refID is provided, and
 // past is false, the results will be in increasing order starting at and
 // including the nonce of the referenced tx. If refID is provided and past
-// is false, the results will be in decreasing nonce order starting at and
+// is true, the results will be in decreasing nonce order starting at and
 // including the referenced tx. No orphans will be included in the results.
 // If a non-nil refID is not found, asset.CoinNotFoundError is returned.
 func (db *badgerTxDB) getTxs(n int, refID *common.Hash, past bool, tokenID *uint32) ([]*asset.WalletTransaction, error) {

--- a/client/asset/eth/txdb.go
+++ b/client/asset/eth/txdb.go
@@ -34,11 +34,9 @@ type extendedWalletTx struct {
 	// NonceReplacement is a transaction with the same nonce that was accepted
 	// by the network, meaning this tx was not applied.
 	NonceReplacement string `json:"nonceReplacement,omitempty"`
-	// FeeReplacement is a transaction that replaced this transaction but with
-	// higher fees. The FeeReplacement is always the NonceReplacement too,
-	// but the FeeReplacement can be assumed to otherwise be the same tx as
-	// the one replaced, just with higher fees.
-	FeeReplacement string `json:"feeReplacement,omitempty"`
+	// FeeReplacement is true if the NonceReplacement is the same tx as this
+	// one, just with higher fees.
+	FeeReplacement bool `json:"feeReplacement,omitempty"`
 	// AssumedLost will be set to true if a transaction is assumed to be lost.
 	// This typically requires feedback from the user in response to an
 	// ActionRequiredNote.

--- a/client/asset/eth/txdb_test.go
+++ b/client/asset/eth/txdb_test.go
@@ -1,22 +1,24 @@
+//go:build !harness && !rpclive
+
 package eth
 
 import (
 	"context"
-	"encoding/hex"
+	"math/big"
 	"reflect"
 	"testing"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
-	"decred.org/dcrdex/dex/encode"
-	"github.com/dgraph-io/badger"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 func TestTxDB(t *testing.T) {
 	tempDir := t.TempDir()
 	tLogger := dex.StdOutLogger("TXDB", dex.LevelTrace)
+
+	// Grab these for the tx generation utilities
+	_, eth, node, shutdown := tassetWallet(BipID)
+	defer shutdown()
 
 	txHistoryStore := newBadgerTxDB(tempDir, tLogger)
 
@@ -34,64 +36,22 @@ func TestTxDB(t *testing.T) {
 		t.Fatalf("expected 0 txs but got %d", len(txs))
 	}
 
-	wt1 := &extendedWalletTx{
-		WalletTransaction: &asset.WalletTransaction{
-			Type:        asset.Send,
-			ID:          hex.EncodeToString(encode.RandomBytes(32)),
-			Amount:      100,
-			Fees:        300,
-			BlockNumber: 123,
-			AdditionalData: map[string]string{
-				"Nonce": "1",
-			},
-			TokenID:   &usdcTokenID,
-			Confirmed: true,
-		},
+	newTx := func(nonce uint64) *extendedWalletTx {
+		return eth.extendedTx(node.newTransaction(nonce, big.NewInt(1)), asset.Send, 1)
 	}
 
-	wt2 := &extendedWalletTx{
-		WalletTransaction: &asset.WalletTransaction{
-			Type:        asset.Swap,
-			ID:          hex.EncodeToString(encode.RandomBytes(32)),
-			Amount:      200,
-			Fees:        100,
-			BlockNumber: 124,
-			AdditionalData: map[string]string{
-				"Nonce": "2",
-			},
-		},
-	}
+	wt1 := newTx(1)
+	wt1.Confirmed = true
+	wt1.TokenID = &usdcTokenID
+	wt2 := newTx(2)
+	wt3 := newTx(3)
+	wt4 := newTx(4)
 
-	wt3 := &extendedWalletTx{
-		WalletTransaction: &asset.WalletTransaction{
-			Type:        asset.Redeem,
-			ID:          hex.EncodeToString(encode.RandomBytes(32)),
-			Amount:      200,
-			Fees:        200,
-			BlockNumber: 125,
-			AdditionalData: map[string]string{
-				"Nonce": "3",
-			},
-		},
-	}
-
-	wt4 := &extendedWalletTx{
-		WalletTransaction: &asset.WalletTransaction{
-			Type:        asset.Redeem,
-			ID:          hex.EncodeToString(encode.RandomBytes(32)),
-			Amount:      200,
-			Fees:        300,
-			BlockNumber: 125,
-			AdditionalData: map[string]string{
-				"Nonce": "3",
-			},
-		},
-	}
-
-	err = txHistoryStore.storeTx(1, wt1)
+	err = txHistoryStore.storeTx(wt1)
 	if err != nil {
 		t.Fatalf("error storing tx: %v", err)
 	}
+
 	txs, err = txHistoryStore.getTxs(0, nil, true, nil)
 	if err != nil {
 		t.Fatalf("error retrieving txs: %v", err)
@@ -101,7 +61,7 @@ func TestTxDB(t *testing.T) {
 		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
 	}
 
-	err = txHistoryStore.storeTx(2, wt2)
+	err = txHistoryStore.storeTx(wt2)
 	if err != nil {
 		t.Fatalf("error storing tx: %v", err)
 	}
@@ -114,7 +74,7 @@ func TestTxDB(t *testing.T) {
 		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
 	}
 
-	err = txHistoryStore.storeTx(3, wt3)
+	err = txHistoryStore.storeTx(wt3)
 	if err != nil {
 		t.Fatalf("error storing tx: %v", err)
 	}
@@ -127,7 +87,7 @@ func TestTxDB(t *testing.T) {
 		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
 	}
 
-	txs, err = txHistoryStore.getTxs(0, &wt2.ID, true, nil)
+	txs, err = txHistoryStore.getTxs(0, &wt2.txHash, true, nil)
 	if err != nil {
 		t.Fatalf("error retrieving txs: %v", err)
 	}
@@ -136,35 +96,20 @@ func TestTxDB(t *testing.T) {
 		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
 	}
 
-	txs, err = txHistoryStore.getTxs(0, &wt2.ID, false, nil)
+	txs, err = txHistoryStore.getTxs(0, &wt2.txHash, false, nil)
 	if err != nil {
 		t.Fatalf("error retrieving txs: %v", err)
 	}
-	expectedTxs = []*asset.WalletTransaction{wt3.WalletTransaction, wt2.WalletTransaction}
+	expectedTxs = []*asset.WalletTransaction{wt2.WalletTransaction, wt3.WalletTransaction}
 	if !reflect.DeepEqual(expectedTxs, txs) {
 		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
 	}
 
-	// Update nonce with different tx
-	err = txHistoryStore.storeTx(3, wt4)
-	if err != nil {
-		t.Fatalf("error storing tx: %v", err)
-	}
-	txs, err = txHistoryStore.getTxs(0, nil, false, nil)
-	if err != nil {
-		t.Fatalf("error retrieving txs: %v", err)
-	}
-	if len(txs) != 3 {
-		t.Fatalf("expected 3 txs but got %d", len(txs))
-	}
-	expectedTxs = []*asset.WalletTransaction{wt4.WalletTransaction, wt2.WalletTransaction, wt1.WalletTransaction}
-	if !reflect.DeepEqual(expectedTxs, txs) {
-		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
-	}
+	allTxs := []*asset.WalletTransaction{wt4.WalletTransaction, wt3.WalletTransaction, wt2.WalletTransaction, wt1.WalletTransaction}
 
 	// Update same tx with new fee
 	wt4.Fees = 300
-	err = txHistoryStore.storeTx(3, wt4)
+	err = txHistoryStore.storeTx(wt4)
 	if err != nil {
 		t.Fatalf("error storing tx: %v", err)
 	}
@@ -172,8 +117,7 @@ func TestTxDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error retrieving txs: %v", err)
 	}
-	expectedTxs = []*asset.WalletTransaction{wt4.WalletTransaction, wt2.WalletTransaction, wt1.WalletTransaction}
-	if !reflect.DeepEqual(expectedTxs, txs) {
+	if !reflect.DeepEqual(allTxs, txs) {
 		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
 	}
 
@@ -181,8 +125,9 @@ func TestTxDB(t *testing.T) {
 	wg.Wait()
 
 	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
 	txHistoryStore = newBadgerTxDB(tempDir, dex.StdOutLogger("TXDB", dex.LevelTrace))
-	wg, err = txHistoryStore.connect(ctx)
+	_, err = txHistoryStore.connect(ctx)
 	if err != nil {
 		t.Fatalf("error connecting to tx history store: %v", err)
 	}
@@ -191,8 +136,7 @@ func TestTxDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error retrieving txs: %v", err)
 	}
-	expectedTxs = []*asset.WalletTransaction{wt4.WalletTransaction, wt2.WalletTransaction, wt1.WalletTransaction}
-	if !reflect.DeepEqual(expectedTxs, txs) {
+	if !reflect.DeepEqual(allTxs, txs) {
 		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
 	}
 
@@ -200,25 +144,32 @@ func TestTxDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error retrieving txs: %v", err)
 	}
-	expectedUnconfirmedTxs := map[uint64]*extendedWalletTx{
-		3: wt4,
-		2: wt2,
+	expectedUnconfirmedTxs := []*extendedWalletTx{wt2, wt3, wt4}
+	compareTxs := func(txs0, txs1 []*extendedWalletTx) bool {
+		if len(txs0) != len(txs1) {
+			return false
+		}
+		for i, tx0 := range txs0 {
+			tx1 := txs1[i]
+			n0, n1 := tx0.Nonce, tx1.Nonce
+			tx0.Nonce, tx1.Nonce = nil, nil
+			eq := reflect.DeepEqual(tx0.WalletTransaction, tx1.WalletTransaction)
+			tx0.Nonce, tx1.Nonce = n0, n1
+			if !eq {
+				return false
+			}
+		}
+		return true
 	}
-	if !reflect.DeepEqual(expectedUnconfirmedTxs, unconfirmedTxs) {
+	if !compareTxs(expectedUnconfirmedTxs, unconfirmedTxs) {
 		t.Fatalf("expected txs %+v but got %+v", expectedUnconfirmedTxs, unconfirmedTxs)
-	}
-
-	err = txHistoryStore.removeTx(wt2.ID)
-	if err != nil {
-		t.Fatalf("error removing tx: %v", err)
 	}
 
 	txs, err = txHistoryStore.getTxs(0, nil, false, nil)
 	if err != nil {
 		t.Fatalf("error retrieving txs: %v", err)
 	}
-	expectedTxs = []*asset.WalletTransaction{wt4.WalletTransaction, wt1.WalletTransaction}
-	if !reflect.DeepEqual(expectedTxs, txs) {
+	if !reflect.DeepEqual(allTxs, txs) {
 		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
 	}
 
@@ -229,218 +180,5 @@ func TestTxDB(t *testing.T) {
 	expectedTxs = []*asset.WalletTransaction{wt1.WalletTransaction}
 	if !reflect.DeepEqual(expectedTxs, txs) {
 		t.Fatalf("expected txs %+v but got %+v", expectedTxs, txs)
-	}
-
-	txHashes := make([]common.Hash, 3)
-	for i := range txHashes {
-		txHashes[i] = common.BytesToHash(encode.RandomBytes(32))
-	}
-	monitoredTx1 := &monitoredTx{
-		tx:             types.NewTx(&types.LegacyTx{Data: []byte{1}}),
-		replacementTx:  &txHashes[1],
-		blockSubmitted: 1,
-	}
-	monitoredTx2 := &monitoredTx{
-		tx:             types.NewTx(&types.LegacyTx{Data: []byte{2}}),
-		replacementTx:  &txHashes[2],
-		replacedTx:     &txHashes[0],
-		blockSubmitted: 2,
-	}
-	monitoredTx3 := &monitoredTx{
-		tx:             types.NewTx(&types.LegacyTx{Data: []byte{3}}),
-		replacedTx:     &txHashes[1],
-		blockSubmitted: 3,
-	}
-
-	txHistoryStore.storeMonitoredTx(txHashes[0], monitoredTx1)
-	txHistoryStore.storeMonitoredTx(txHashes[1], monitoredTx2)
-	txHistoryStore.storeMonitoredTx(txHashes[2], monitoredTx3)
-	monitoredTxs, err := txHistoryStore.getMonitoredTxs()
-	if err != nil {
-		t.Fatalf("error retrieving monitored txs: %v", err)
-	}
-
-	expectedMonitoredTxs := map[common.Hash]*monitoredTx{
-		txHashes[0]: monitoredTx1,
-		txHashes[1]: monitoredTx2,
-		txHashes[2]: monitoredTx3,
-	}
-
-	if len(monitoredTxs) != len(expectedMonitoredTxs) {
-		t.Fatalf("expected %d monitored txs but got %d", len(expectedMonitoredTxs), len(monitoredTxs))
-	}
-
-	monitoredTxsEqual := func(a, b *monitoredTx) bool {
-		if a.tx.Hash() != b.tx.Hash() {
-			return false
-		}
-		if a.replacementTx != nil && b.replacementTx != nil && *a.replacementTx != *b.replacementTx {
-			return false
-		}
-		if a.replacedTx != nil && b.replacedTx != nil && *a.replacedTx != *b.replacedTx {
-			return false
-		}
-		if a.blockSubmitted != b.blockSubmitted {
-			return false
-		}
-		return true
-	}
-
-	for txHash, monitoredTx := range monitoredTxs {
-		expectedMonitoredTx := expectedMonitoredTxs[txHash]
-		if !monitoredTxsEqual(monitoredTx, expectedMonitoredTxs[txHash]) {
-			t.Fatalf("expected monitored tx %+v but got %+v", expectedMonitoredTx, monitoredTx)
-		}
-	}
-
-	err = txHistoryStore.removeMonitoredTxs([]common.Hash{txHashes[0]})
-	if err != nil {
-		t.Fatalf("error removing monitored tx: %v", err)
-	}
-
-	monitoredTxs, err = txHistoryStore.getMonitoredTxs()
-	if err != nil {
-		t.Fatalf("error retrieving monitored txs: %v", err)
-	}
-
-	expectedMonitoredTxs = map[common.Hash]*monitoredTx{
-		txHashes[1]: monitoredTx2,
-		txHashes[2]: monitoredTx3,
-	}
-
-	if len(monitoredTxs) != len(expectedMonitoredTxs) {
-		t.Fatalf("expected %d monitored txs but got %d", len(expectedMonitoredTxs), len(monitoredTxs))
-	}
-
-	for txHash, monitoredTx := range monitoredTxs {
-		expectedMonitoredTx := expectedMonitoredTxs[txHash]
-		if !monitoredTxsEqual(monitoredTx, expectedMonitoredTxs[txHash]) {
-			t.Fatalf("expected monitored tx %+v but got %+v", expectedMonitoredTx, monitoredTx)
-		}
-	}
-
-	err = txHistoryStore.removeMonitoredTxs([]common.Hash{txHashes[1], txHashes[2]})
-	if err != nil {
-		t.Fatalf("error removing monitored tx: %v", err)
-	}
-
-	monitoredTxs, err = txHistoryStore.getMonitoredTxs()
-	if err != nil {
-		t.Fatalf("error retrieving monitored txs: %v", err)
-	}
-
-	if len(monitoredTxs) != 0 {
-		t.Fatalf("expected 0 monitored txs but got %d", len(monitoredTxs))
-	}
-
-	cancel()
-	wg.Wait()
-}
-
-func TestTxDBUpgrade(t *testing.T) {
-	dir := t.TempDir()
-	tLogger := dex.StdOutLogger("TXDB", dex.LevelTrace)
-
-	opts := badger.DefaultOptions(dir).WithLogger(&badgerLoggerWrapper{tLogger})
-	db, err := badger.Open(opts)
-	if err == badger.ErrTruncateNeeded {
-		// Probably a Windows thing.
-		// https://github.com/dgraph-io/badger/issues/744
-		tLogger.Warnf("newTxHistoryStore badger db: %v", err)
-		// Try again with value log truncation enabled.
-		opts.Truncate = true
-		tLogger.Warnf("Attempting to reopen badger DB with the Truncate option set...")
-		db, err = badger.Open(opts)
-	}
-	if err != nil {
-		t.Fatalf("error opening badger db: %v", err)
-	}
-
-	txHashes := make([]common.Hash, 3)
-	for i := range txHashes {
-		txHashes[i] = common.BytesToHash(encode.RandomBytes(32))
-	}
-
-	monitoredTxs := map[common.Hash]*monitoredTx{
-		txHashes[0]: {
-			tx:             types.NewTx(&types.LegacyTx{Data: []byte{1}}),
-			replacementTx:  &txHashes[1],
-			blockSubmitted: 1,
-		},
-		txHashes[1]: {
-			tx:             types.NewTx(&types.LegacyTx{Data: []byte{2}}),
-			replacementTx:  &txHashes[2],
-			replacedTx:     &txHashes[0],
-			blockSubmitted: 2,
-		},
-		txHashes[2]: {
-			tx:             types.NewTx(&types.LegacyTx{Data: []byte{3}}),
-			replacedTx:     &txHashes[1],
-			blockSubmitted: 3,
-		},
-	}
-
-	err = db.Update(func(txn *badger.Txn) error {
-		for txHash, monitoredTx := range monitoredTxs {
-			monitoredTxB, err := monitoredTx.MarshalBinary()
-			if err != nil {
-				return err
-			}
-
-			th := txHash
-			err = txn.Set(th[:], monitoredTxB)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("error storing monitored txs: %v", err)
-	}
-
-	db.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	txHistoryStore := newBadgerTxDB(dir, tLogger)
-	wg, err := txHistoryStore.connect(ctx)
-	if err != nil {
-		t.Fatalf("error connecting to tx history store: %v", err)
-	}
-	defer func() {
-		cancel()
-		wg.Wait()
-	}()
-
-	retrievedMonitoredTxs, err := txHistoryStore.getMonitoredTxs()
-	if err != nil {
-		t.Fatalf("error retrieving monitored txs: %v", err)
-	}
-
-	if len(retrievedMonitoredTxs) != len(monitoredTxs) {
-		t.Fatalf("expected %d monitored txs but got %d", len(monitoredTxs), len(retrievedMonitoredTxs))
-	}
-
-	monitoredTxsEqual := func(a, b *monitoredTx) bool {
-		if a.tx.Hash() != b.tx.Hash() {
-			return false
-		}
-		if a.replacementTx != nil && b.replacementTx != nil && *a.replacementTx != *b.replacementTx {
-			return false
-		}
-		if a.replacedTx != nil && b.replacedTx != nil && *a.replacedTx != *b.replacedTx {
-			return false
-		}
-		if a.blockSubmitted != b.blockSubmitted {
-			return false
-		}
-		return true
-	}
-
-	for txHash, monitoredTx := range retrievedMonitoredTxs {
-		expectedMonitoredTx := monitoredTxs[txHash]
-		if !monitoredTxsEqual(monitoredTx, expectedMonitoredTx) {
-			t.Fatalf("expected monitored tx %+v but got %+v", expectedMonitoredTx, monitoredTx)
-		}
 	}
 }

--- a/client/asset/eth/txdb_test.go
+++ b/client/asset/eth/txdb_test.go
@@ -18,7 +18,7 @@ func TestTxDB(t *testing.T) {
 
 	// Grab these for the tx generation utilities
 	_, eth, node, shutdown := tassetWallet(BipID)
-	defer shutdown()
+	shutdown()
 
 	txHistoryStore := newBadgerTxDB(tempDir, tLogger)
 

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -1163,6 +1163,9 @@ type WalletTransaction struct {
 	// Confirmed transactions are no longer updated and will be considered
 	// finalized forever.
 	Confirmed bool `json:"confirmed"`
+	// Rejected will be true the transaction was rejected and did not have any
+	// effect, though fees were incurred.
+	Rejected bool `json:"rejected,omitempty"`
 }
 
 // WalletHistorian is a wallet that is able to retrieve the history of all

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -226,11 +226,23 @@ const (
 	// not yet been mined. There is no guarantee that the swap will be mined
 	// in the future.
 	ErrSwapNotInitiated = dex.ErrorKind("swap not yet initiated")
-	CoinNotFoundError   = dex.ErrorKind("coin not found")
-	ErrRequestTimeout   = dex.ErrorKind("request timeout")
-	ErrConnectionDown   = dex.ErrorKind("wallet not connected")
-	ErrNotImplemented   = dex.ErrorKind("not implemented")
-	ErrUnsupported      = dex.ErrorKind("unsupported")
+
+	CoinNotFoundError = dex.ErrorKind("coin not found")
+	// ErrTxRejected is returned when a transaction was rejected. This
+	// generally would indicate either an internal wallet error, or potentially
+	// a user using multiple instances of the wallet simultaneously. As such
+	// it may or may not be advisable to try the tx again without seeking
+	// further investigation.
+	ErrTxRejected = dex.ErrorKind("transaction was rejected")
+	// ErrTxLost is returned when the tx is irreparably lost, as would be the
+	// case if it's inputs were spent by another tx first or if it is not the
+	// accepted tx for a given nonce. These txs have incurred no fee losses, so
+	// the caller should feel free to re-issue the tx.
+	ErrTxLost         = dex.ErrorKind("tx lost")
+	ErrRequestTimeout = dex.ErrorKind("request timeout")
+	ErrConnectionDown = dex.ErrorKind("wallet not connected")
+	ErrNotImplemented = dex.ErrorKind("not implemented")
+	ErrUnsupported    = dex.ErrorKind("unsupported")
 	// ErrSwapRefunded is returned from ConfirmRedemption when the swap has
 	// been refunded before the user could redeem.
 	ErrSwapRefunded = dex.ErrorKind("swap refunded")
@@ -249,8 +261,6 @@ const (
 	// ErrUnapprovedToken is returned when trying to fund an order using a token
 	// that has not been approved.
 	ErrUnapprovedToken = dex.ErrorKind("token not approved")
-	// ErrTxRejected is returned when a transaction was rejected.
-	ErrTxRejected = dex.ErrorKind("transaction was rejected")
 
 	// InternalNodeLoggerName is the name for a logger that is used to fine
 	// tune log levels for only loggers using this name.

--- a/client/asset/polygon/multirpc_live_test.go
+++ b/client/asset/polygon/multirpc_live_test.go
@@ -114,3 +114,7 @@ func TestTestnetFees(t *testing.T) {
 func TestTestnetTipCaps(t *testing.T) {
 	mt.TipCaps(t, dex.Testnet)
 }
+
+func TestReceiptsHaveEffectiveGasPrice(t *testing.T) {
+	mt.TestReceiptsHaveEffectiveGasPrice(t)
+}

--- a/client/asset/polygon/multirpc_live_test.go
+++ b/client/asset/polygon/multirpc_live_test.go
@@ -106,3 +106,11 @@ func TestFreeTestnetServers(t *testing.T) {
 func TestMainnetCompliance(t *testing.T) {
 	mt.TestMainnetCompliance(t)
 }
+
+func TestTestnetFees(t *testing.T) {
+	mt.FeeHistory(t, dex.Testnet, 3, 90)
+}
+
+func TestTestnetTipCaps(t *testing.T) {
+	mt.TipCaps(t, dex.Testnet)
+}

--- a/client/asset/polygon/polygon.go
+++ b/client/asset/polygon/polygon.go
@@ -147,6 +147,7 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, net dex.Networ
 		CompatData:         &compat,
 		VersionedGases:     dexpolygon.VersionedGases,
 		Tokens:             dexpolygon.Tokens,
+		FinalizeConfs:      64,
 		Logger:             logger,
 		BaseChainContracts: contracts,
 		MultiBalAddress:    dexpolygon.MultiBalanceAddresses[net],

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -130,6 +130,8 @@ var (
 			NoAuth:            true,
 		}},
 	}
+
+	feeReservesPerLot = dexzec.TxFeesZIP317(dexbtc.RedeemP2PKHInputSize+1, 2*dexbtc.P2PKHOutputSize+1, 0, 0, 0, 0)
 )
 
 func init() {
@@ -970,7 +972,7 @@ func (w *zecWallet) maxOrder(lotSize, feeSuggestion, maxFeeRate uint64) (utxos [
 		return utxos, bals, est, err
 	}
 
-	return utxos, bals, &asset.SwapEstimate{}, nil
+	return utxos, bals, &asset.SwapEstimate{FeeReservesPerLot: feeReservesPerLot}, nil
 }
 
 // estimateSwap prepares an *asset.SwapEstimate.
@@ -1000,6 +1002,7 @@ func (w *zecWallet) estimateSwap(
 			MaxFees:            shieldedSplitFees,
 			RealisticBestCase:  shieldedSplitFees,
 			RealisticWorstCase: shieldedSplitFees,
+			FeeReservesPerLot:  feeReservesPerLot,
 		}, true, splitLocked, nil
 	}
 
@@ -1037,6 +1040,7 @@ func (w *zecWallet) estimateSwap(
 				MaxFees:            maxFees,
 				RealisticBestCase:  estLowFees,
 				RealisticWorstCase: estHighFees,
+				FeeReservesPerLot:  feeReservesPerLot,
 			}, true, reqFunds, nil
 		}
 	}
@@ -1048,6 +1052,7 @@ func (w *zecWallet) estimateSwap(
 		MaxFees:            maxFees,
 		RealisticBestCase:  estLowFees,
 		RealisticWorstCase: estHighFees,
+		FeeReservesPerLot:  feeReservesPerLot,
 	}, false, sum, nil
 }
 

--- a/client/cmd/bisonw-desktop/app_darwin.go
+++ b/client/cmd/bisonw-desktop/app_darwin.go
@@ -152,7 +152,7 @@ func mainCore() error {
 
 	// Return early if unsupported flags are provided.
 	if cfg.Webview != "" {
-		return errors.New("--webview flag is not supported. Other OS use it for a specific reason (to support multiple windows)")
+		return errors.New("the --webview flag is not supported. Other OS use it for a specific reason (to support multiple windows)")
 	}
 
 	// The --kill flag is a backup measure to end a background process (that

--- a/client/cmd/simnet-trade-tests/run
+++ b/client/cmd/simnet-trade-tests/run
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
 
-go build -tags harness
+go build -tags harness -ldflags \
+    "-X 'decred.org/dcrdex/dex.testLockTimeTaker=1m' \
+    -X 'decred.org/dcrdex/dex.testLockTimeMaker=2m'"
 
 case $1 in
 

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -1363,9 +1363,10 @@ func newTestRig() *testRig {
 			reCrypter:  func([]byte, []byte) (encrypt.Crypter, error) { return crypter, crypter.recryptErr },
 			noteChans:  make(map[uint64]chan Notification),
 
-			fiatRateSources: make(map[string]*commonRateSource),
-			notes:           make(chan asset.WalletNotification, 128),
-			pokesCache:      newPokesCache(pokesCapacity),
+			fiatRateSources:  make(map[string]*commonRateSource),
+			notes:            make(chan asset.WalletNotification, 128),
+			pokesCache:       newPokesCache(pokesCapacity),
+			requestedActions: make(map[string]*asset.ActionRequiredNote),
 		},
 		db:      tdb,
 		queue:   queue,

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -12,34 +12,36 @@ import (
 	"decred.org/dcrdex/client/db"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/dex/order"
 	"decred.org/dcrdex/server/account"
 )
 
 // Notifications should use the following note type strings.
 const (
-	NoteTypeFeePayment   = "feepayment"
-	NoteTypeBondPost     = "bondpost"
-	NoteTypeBondRefund   = "bondrefund"
-	NoteTypeUnknownBond  = "unknownbond"
-	NoteTypeSend         = "send"
-	NoteTypeOrder        = "order"
-	NoteTypeMatch        = "match"
-	NoteTypeEpoch        = "epoch"
-	NoteTypeConnEvent    = "conn"
-	NoteTypeBalance      = "balance"
-	NoteTypeSpots        = "spots"
-	NoteTypeWalletConfig = "walletconfig"
-	NoteTypeWalletState  = "walletstate"
-	NoteTypeServerNotify = "notify"
-	NoteTypeSecurity     = "security"
-	NoteTypeUpgrade      = "upgrade"
-	NoteTypeBot          = "bot"
-	NoteTypeDEXAuth      = "dex_auth"
-	NoteTypeFiatRates    = "fiatrateupdate"
-	NoteTypeCreateWallet = "createwallet"
-	NoteTypeLogin        = "login"
-	NoteTypeWalletNote   = "walletnote"
-	NoteTypeReputation   = "reputation"
+	NoteTypeFeePayment     = "feepayment"
+	NoteTypeBondPost       = "bondpost"
+	NoteTypeBondRefund     = "bondrefund"
+	NoteTypeUnknownBond    = "unknownbond"
+	NoteTypeSend           = "send"
+	NoteTypeOrder          = "order"
+	NoteTypeMatch          = "match"
+	NoteTypeEpoch          = "epoch"
+	NoteTypeConnEvent      = "conn"
+	NoteTypeBalance        = "balance"
+	NoteTypeSpots          = "spots"
+	NoteTypeWalletConfig   = "walletconfig"
+	NoteTypeWalletState    = "walletstate"
+	NoteTypeServerNotify   = "notify"
+	NoteTypeSecurity       = "security"
+	NoteTypeUpgrade        = "upgrade"
+	NoteTypeBot            = "bot"
+	NoteTypeDEXAuth        = "dex_auth"
+	NoteTypeFiatRates      = "fiatrateupdate"
+	NoteTypeCreateWallet   = "createwallet"
+	NoteTypeLogin          = "login"
+	NoteTypeWalletNote     = "walletnote"
+	NoteTypeReputation     = "reputation"
+	NoteTypeActionRequired = "actionrequired"
 )
 
 var noteChanCounter uint64
@@ -735,4 +737,47 @@ const TopicUnknownBondTierZero = "UnknownBondTierZero"
 func newUnknownBondTierZeroNote(subject, details string) *db.Notification {
 	note := db.NewNotification(NoteTypeUnknownBond, TopicUnknownBondTierZero, subject, details, db.WarningLevel)
 	return &note
+}
+
+const (
+	ActionIDRedeemRejected = "redeemRejected"
+	TopicRedeemRejected    = "RedeemRejected"
+)
+
+func newActionRequiredNote(actionID, uniqueID string, payload any) *asset.ActionRequiredNote {
+	n := &asset.ActionRequiredNote{
+		UniqueID: uniqueID,
+		ActionID: actionID,
+		Payload:  payload,
+	}
+	const routeNotNeededCuzCoreHasNoteType = ""
+	n.Route = routeNotNeededCuzCoreHasNoteType
+	return n
+}
+
+type RejectedRedemptionData struct {
+	OrderID dex.Bytes `json:"orderID"`
+	CoinID  dex.Bytes `json:"coinID"`
+	AssetID uint32    `json:"assetID"`
+	CoinFmt string    `json:"coinFmt"`
+}
+
+// ActionRequiredNote is structured like a WalletNote. The payload will be
+// an *asset.ActionRequiredNote. This is done for compatiblility reasons.
+type ActionRequiredNote WalletNote
+
+func newRejectedRedemptionNote(assetID uint32, oid order.OrderID, coinID []byte) (*asset.ActionRequiredNote, *ActionRequiredNote) {
+	data := &RejectedRedemptionData{
+		AssetID: assetID,
+		OrderID: oid[:],
+		CoinID:  coinID,
+		CoinFmt: coinIDString(assetID, coinID),
+	}
+	uniqueID := dex.Bytes(coinID).String()
+	actionNote := newActionRequiredNote(ActionIDRedeemRejected, uniqueID, data)
+	coreNote := &ActionRequiredNote{
+		Notification: db.NewNotification(NoteTypeActionRequired, TopicRedeemRejected, "", "", db.Data),
+		Payload:      actionNote,
+	}
+	return actionNote, coreNote
 }

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -763,7 +763,7 @@ type RejectedRedemptionData struct {
 }
 
 // ActionRequiredNote is structured like a WalletNote. The payload will be
-// an *asset.ActionRequiredNote. This is done for compatiblility reasons.
+// an *asset.ActionRequiredNote. This is done for compatibility reasons.
 type ActionRequiredNote WalletNote
 
 func newRejectedRedemptionNote(assetID uint32, oid order.OrderID, coinID []byte) (*asset.ActionRequiredNote, *ActionRequiredNote) {

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -3015,8 +3015,7 @@ func (c *Core) confirmRedemption(t *trackedTrade, match *matchTracker) (bool, er
 			unbip(toWallet.AssetID), coinIDString(toWallet.AssetID, redeemCoinID))
 	case errors.Is(err, asset.ErrTxLost):
 		// The transaction was nonce-replaced or otherwise lost without
-		// rejection or with user acknowlegement. Try again if we're the taker.
-		// If we're the maker we'll give up and try to refund.
+		// rejection or with user acknowlegement. Try again.
 		var coinID order.CoinID
 		if match.Side == order.Taker {
 			coinID = match.MetaData.Proof.TakerRedeem

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -164,13 +164,14 @@ type ExtensionModeConfig struct {
 
 // User is information about the user's wallets and DEX accounts.
 type User struct {
-	Exchanges          map[string]*Exchange       `json:"exchanges"`
-	Initialized        bool                       `json:"inited"`
-	SeedGenerationTime uint64                     `json:"seedgentime"`
-	Assets             map[uint32]*SupportedAsset `json:"assets"`
-	FiatRates          map[uint32]float64         `json:"fiatRates"`
-	Net                dex.Network                `json:"net"`
-	ExtensionConfig    *ExtensionModeConfig       `json:"extensionModeConfig,omitempty"`
+	Exchanges          map[string]*Exchange        `json:"exchanges"`
+	Initialized        bool                        `json:"inited"`
+	SeedGenerationTime uint64                      `json:"seedgentime"`
+	Assets             map[uint32]*SupportedAsset  `json:"assets"`
+	FiatRates          map[uint32]float64          `json:"fiatRates"`
+	Net                dex.Network                 `json:"net"`
+	ExtensionConfig    *ExtensionModeConfig        `json:"extensionModeConfig,omitempty"`
+	Actions            []*asset.ActionRequiredNote `json:"actions,omitempty"`
 }
 
 // SupportedAsset is data about an asset and possibly the wallet associated

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -5,6 +5,7 @@ package webserver
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -2266,6 +2267,22 @@ func (s *WebServer) apiTxHistory(w http.ResponseWriter, r *http.Request) {
 		OK:  true,
 		Txs: txs,
 	}, s.indent)
+}
+
+func (s *WebServer) apiTakeAction(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		AssetID  uint32          `json:"assetID"`
+		ActionID string          `json:"actionID"`
+		Action   json.RawMessage `json:"action"`
+	}
+	if !readPost(w, r, &req) {
+		return
+	}
+	if err := s.core.TakeAction(req.AssetID, req.ActionID, req.Action); err != nil {
+		s.writeAPIError(w, fmt.Errorf("error taking action: %w", err))
+		return
+	}
+	writeJSON(w, simpleAck(), s.indent)
 }
 
 // writeAPIError logs the formatted error and sends a standardResponse with the

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1936,7 +1936,7 @@ out:
 			if enableActions && rand.Float32() < 0.05 {
 				c.noteFeed <- &core.WalletNote{
 					Notification: db.NewNotification(core.NoteTypeWalletNote, core.TopicWalletNotification, "", "", db.Data),
-					Payload:      makeRequiredAction(baseID, "lostTx"),
+					Payload:      makeRequiredAction(baseID, "missingNonces"),
 				}
 			}
 		case <-tCtx.Done():
@@ -2679,7 +2679,7 @@ func TestServer(t *testing.T) {
 
 	if enableActions {
 		actions = []*asset.ActionRequiredNote{
-			makeRequiredAction(0, "lostTx"),
+			makeRequiredAction(0, "missingNonces"),
 			makeRequiredAction(42, "lostNonce"),
 			makeRequiredAction(60, "tooCheap"),
 			makeRequiredAction(60, "redeemRejected"),

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -631,4 +631,6 @@ var EnUS = map[string]*intl.Translation{
 	"Round_trip fees":             {T: "Round-trip fees"},
 	"feegap_tooltip":              {T: "The rate adjustment necessary to account for on-chain tx fees"},
 	"remotegap_tooltip":           {T: "The buy-sell spread on the linked cex market"},
+	"max_zero_no_fees":            {T: `<span id="maxZeroNoFeesTicker"></span> balance < min fees ~<span id="maxZeroMinFees"></span>`},
+	"max_zero_no_bal":             {T: `low <span id="maxZeroNoBalTicker"></span> balance`},
 }

--- a/client/webserver/site/src/css/bootstrap.scss
+++ b/client/webserver/site/src/css/bootstrap.scss
@@ -216,6 +216,7 @@ $utilities: (
       start: left,
       end: right,
       center: center,
+      justify: justify,
     )
   ),
 );

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -208,6 +208,18 @@ z-index: 1000;
   background-color: var(--loader-bg);
 }
 
+#requiredActions {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  z-index: 98;
+
+  & > div {
+    background-color: var(--body-bg);
+    border: 3px solid var(--border-color);
+  }
+}
+
 @include media-breakpoint-up(sm) {
   section {
     margin: 0.5rem;

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -420,10 +420,6 @@ div[data-handler=markets] {
       margin: 0 5px;
     }
 
-    .red {
-      color: $danger;
-    }
-
     .disclaimer {
       text-align: justify;
     }

--- a/client/webserver/site/src/css/market.scss
+++ b/client/webserver/site/src/css/market.scss
@@ -434,7 +434,7 @@ div[data-handler=markets] {
       }
     }
 
-    button.selected {
+    button {
       &.buygreen-bg {
         background-color: var(--market-buygreen-bg);
       }

--- a/client/webserver/site/src/css/mixins.scss
+++ b/client/webserver/site/src/css/mixins.scss
@@ -21,6 +21,15 @@
   }
 }
 
+@mixin hidden-overflow {
+  overflow: auto;
+  scrollbar-width: none;  /* Firefox */
+
+  &::-webkit-scrollbar {
+    display: none;  /* Safari and Chrome */
+  }
+}
+
 @mixin fill-abs {
   position: absolute;
   top: 0;

--- a/client/webserver/site/src/css/order.scss
+++ b/client/webserver/site/src/css/order.scss
@@ -21,10 +21,6 @@ div.match-card {
   flex-direction: column;
   align-items: stretch;
   font-size: 14px;
-  
-  .red {
-    color: $danger;
-  }
 }
 
 .match-data-label {

--- a/client/webserver/site/src/css/utilities.scss
+++ b/client/webserver/site/src/css/utilities.scss
@@ -38,6 +38,10 @@
   background-color: var(--tertiary-bg);
 }
 
+.invisible {
+  visibility: hidden;
+}
+
 .stylish-overflow {
   @include stylish-overflow;
 
@@ -75,6 +79,10 @@
 
 .ease-color {
   transition: color 1s ease;
+}
+
+.mw-375 {
+  max-width: 375px;
 }
 
 .mw-425 {
@@ -165,10 +173,9 @@ sup.token-parent {
 }
 
 
-// .hashwrap {
-//   word-break: break-all;
-//   user-select: all;
-// }
+.break-all {
+  word-break: break-all;
+}
 
 .lh1 {
   line-height: 1;

--- a/client/webserver/site/src/css/utilities.scss
+++ b/client/webserver/site/src/css/utilities.scss
@@ -59,6 +59,10 @@
   }
 }
 
+.hidden-overflow {
+  @include hidden-overflow;
+}
+
 @keyframes spin {
   0% {
     transform: rotate(0deg);

--- a/client/webserver/site/src/css/wallets.scss
+++ b/client/webserver/site/src/css/wallets.scss
@@ -53,7 +53,7 @@
       &.selected,
       &:hover {
         background-color: var(--body-bg);
-        border: 1px solid var(--border-color);
+        // border: 1px solid var(--border-color);
         opacity: 1;
 
         img[data-tmpl=parentImg] {
@@ -196,7 +196,7 @@
   }
 
   .column {
-    @include stylish-overflow;
+    @include hidden-overflow;
     @include fill-abs;
   }
 }

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -172,16 +172,14 @@
         </tbody>
       </table>
 
-      <div id="lostTxTmpl" class="flex-stretch-column mt-2">
+      <div id="missingNoncesTmpl" class="flex-stretch-column mt-2">
         <div class="text-justify">
-          A <span data-tmpl="assetName"></span>
-          transaction appears to be lost, and all attempts to re-broadcast it
-          have failed. Do you want to abandon it?
+          <span data-tmpl="assetName"></span> nonces are missing. Would you like
+           to attempt recovery?
         </div>
-        <div data-tmpl="txTable"></div>
         <div class="d-flex align-items-stretch mt-3">
-          <button data-tmpl="lostAbandonBttn" class="flex-grow-1 me-2 danger">Abandon</button>
-          <button data-tmpl="lostWaitBttn" class="flex-grow-1 ms-2">Keep Trying</button>
+          <button data-tmpl="doNothingBttn" class="flex-grow-1 me-2 danger">Do Nothing</button>
+          <button data-tmpl="recoverBttn" class="flex-grow-1 ms-2">Attempt Recovery</button>
         </div>
         <div data-tmpl="errMsg" class="p-2 errcolor d-hide"></div>
       </div>

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -201,8 +201,8 @@
       <div id="lostNonceTmpl" class="flex-stretch-column mt-2">
         <div class="text-justify">
           A <span data-tmpl="assetName"></span>
-          transaction might be lost. A transaction with a higher nonce was
-          confirmed first. You can abandon the transaction
+          transaction might be lost. A different transaction with the same
+          nonce was confirmed first. You can abandon the transaction
         </div>
         <div data-tmpl="txTable"></div>
         <div class="d-flex mt-2">

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -118,6 +118,119 @@
 {{end}}
 
 {{define "bottom"}}
+<div id="requiredActions">
+  <div id="actionDialogCollapsed" class="d-inline-block text-center p-2 m-1 pointer hoverbg d-hide">
+    <span class="text-warning fs20">
+      <span class="ico-info ms-0 me-1"></span>
+      <span id="actionDialogCount">4</span>
+    </span>
+  </div>
+  <div id="actionDialog" class="mw-375 rounded3 m-3 p-3 d-hide">
+    <div class="d-flex justify-content-between">
+      <div class="fs22">
+        <span class="ico-info text-warning me-2"></span>
+        Action Required
+      </div>
+      <div id="actionsCollapse" class="fs16 p-2 ico-arrowdown hoverbg pointer"></div>
+    </div>
+    <div id="actionDialogContent">
+
+      <table id="actionTxTableTmpl" class="compact border cell-border mt-2">
+        <thead>
+          <tr>
+            <th colspan="2">
+              <a data-tmpl="lostTxID" class="break-all"></a>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>[[[Amount]]]</td>
+            <td>
+              <span data-tmpl="txAmt"></span>
+              <span data-tmpl="amtUnit" class="fs15 grey"></span>
+            </td>
+          </tr>
+          <tr>
+            <td>[[[Fees]]]</td>
+            <td>
+              <span data-tmpl="feeAmount"></span>
+              <span data-tmpl="feeUnit" class="fs15 grey"></span>
+            </td>
+          </tr>
+          <tr data-tmpl="newFeesRow" class="d-hide">
+            <td>New Fees</td>
+            <td>
+              <span data-tmpl="newFees"></span>
+              <span data-tmpl="newFeesUnit" class="fs15 grey"></span>
+            </td>
+          </tr>
+          <tr>
+            <td>Tx Type</td>
+            <td data-tmpl="type"></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div id="lostTxTmpl" class="flex-stretch-column mt-2">
+        <div class="text-justify">
+          A <span data-tmpl="assetName"></span>
+          transaction appears to be lost, and all attempts to re-broadcast it
+          have failed. Do you want to abandon it?
+        </div>
+        <div data-tmpl="txTable"></div>
+        <div class="d-flex align-items-stretch mt-3">
+          <button data-tmpl="lostAbandonBttn" class="flex-grow-1 me-2 danger">Abandon</button>
+          <button data-tmpl="lostWaitBttn" class="flex-grow-1 ms-2">Keep Trying</button>
+        </div>
+        <div data-tmpl="errMsg" class="p-2 errcolor d-hide"></div>
+      </div>
+
+      <div id="tooCheapTmpl" class="flex-stretch-column mt-2">
+        <div class="text-justify">
+          A <span data-tmpl="assetName"></span>
+          transaction is stuck and has low fees. Should we replace it with a new
+          transaction?
+        </div>
+        <div data-tmpl="txTable"></div>
+        <div class="d-flex align-items-stretch mt-3">
+          <button data-tmpl="keepWaitingBttn" class="flex-grow-1 me-2">Keep Waiting</button>
+          <button data-tmpl="addFeesBttn" class="flex-grow-1 ms-2">Add Fees</button>
+        </div>
+        <div data-tmpl="errMsg" class="p-2 errcolor d-hide"></div>
+      </div>
+
+      <div id="lostNonceTmpl" class="flex-stretch-column mt-2">
+        <div class="text-justify">
+          A <span data-tmpl="assetName"></span>
+          transaction might be lost. A transaction with a higher nonce was
+          confirmed first. You can abandon the transaction
+        </div>
+        <div data-tmpl="txTable"></div>
+        <div class="d-flex mt-2">
+          <button data-tmpl="keepWaitingBttn" class="flex-grow-1 me-1">Keep Waiting</button>
+          <button data-tmpl="abandonBttn" class="danger flex-grow-1 ms-1">Abandon</button>
+        </div>
+        <hr>
+        <div class="mt-2">
+          or you can tell us which transaction has nonce <span data-tmpl="nonce"></span>
+        </div>
+        <div class="d-flex align-items-stretch mt-2">
+          <input type="text" data-tmpl="idInput" class="flex-grow-1">
+          <button data-tmpl="replaceBttn" class="ms-2">Submit</button>
+        </div>
+        <div data-tmpl="errMsg" class="p-2 errcolor d-hide"></div>
+      </div>
+
+    </div>
+    <div id="actionsNavigator" class="flex-center mt-2 lh1 fs16 user-select-none">
+      <span id="prevAction" class="p-1 ico-arrowback pointer hoverbg"></span>
+      <span id="currentAction" class="mx-1"></span>
+      <span id="nextAction" class="p-1 ico-arrowright pointer hoverbg"></span>
+    </div>
+  </div>
+</div>
+
 <script src="/js/entry.js?v={{commitHash}}"></script>
 </body>
 </html>

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -222,10 +222,32 @@
         <div data-tmpl="errMsg" class="p-2 errcolor d-hide"></div>
       </div>
 
+      <div id="rejectedRedemptionTmpl" class="flex-stretch-column mt-2">
+        <div class="text-justify">
+          A <span data-tmpl="assetName"></span> trade redemption was rejected
+          by the network. Network transaction fees were incurred. You
+          can try to redeem again, but it will likely incur more fees and
+          it may be rejected again.
+        </div>
+        <a data-tmpl="txid" class="d-block fs12 mono break-all border p-2 mt-2"></a>
+        <div class="d-flex align-items-stretch mt-3">
+          <button data-tmpl="doNothingBttn" class="flex-grow-1 me-2">Do Nothing</button>
+          <button data-tmpl="tryAgainBttn" class="flex-grow-1 ms-2">Try Again</button>
+        </div>
+        <div class="flex-center fs14 mt-2">
+          <a href="https://docs.decred.org/getting-started/joining-matrix-channels/" target="_blank">
+            Find technical support
+          </a>
+        </div>
+        <div data-tmpl="errMsg" class="p-2 errcolor mt-2 d-hide"></div>
+      </div>
+
     </div>
     <div id="actionsNavigator" class="flex-center mt-2 lh1 fs16 user-select-none">
       <span id="prevAction" class="p-1 ico-arrowback pointer hoverbg"></span>
       <span id="currentAction" class="mx-1"></span>
+      <span>/</span>
+      <span id="actionCount" class="mx-1"></span>
       <span id="nextAction" class="p-1 ico-arrowright pointer hoverbg"></span>
     </div>
   </div>

--- a/client/webserver/site/src/html/markets.tmpl
+++ b/client/webserver/site/src/html/markets.tmpl
@@ -463,6 +463,12 @@
                         <span id="maxToAmt"></span>
                         <span id="maxToTicker"></span> -->
                       </span>
+                      <span id="maxZeroNoFees">
+                        , [[[max_zero_no_fees]]]
+                      </span>
+                      <span id="maxZeroNoBal">
+                        , [[[max_zero_no_bal]]]
+                      </span>
                     </div>
                   </div>
 
@@ -626,7 +632,7 @@
               <div class="text-center fs20 mb-2">
                 [[[Your Orders]]]
               </div>
-              <div id="unreadyOrdersMsg" class="d-hide px-3 py-1 flex-center fs16 red">[[[unready_wallets_msg]]]</div>
+              <div id="unreadyOrdersMsg" class="d-hide px-3 py-1 flex-center fs16 text-danger">[[[unready_wallets_msg]]]</div>
               <div id="userNoOrders" class="p-3 flex-center fs16 grey">no active orders</div>
               <div id="userOrders" class="border-bottom">
                 <div id="userOrderTmpl" class="user-order border-top">
@@ -893,7 +899,7 @@
 
         <div id="vPreorderErr" class="mt-2">
           [[[estimate_unavailable]]]
-          <span class="ico-info red fs12" id="vPreorderErrTip" data-tooltip=" "></span>
+          <span class="ico-info text-danger fs12" id="vPreorderErrTip" data-tooltip=" "></span>
         </div>
 
         <hr class="dashed mt-2 mb-0">

--- a/client/webserver/site/src/html/order.tmpl
+++ b/client/webserver/site/src/html/order.tmpl
@@ -117,7 +117,7 @@
         </div>
 
         <div data-tmpl="cancelInfoDiv">
-          <div class="text-center fs20 red">[[[Cancellation]]]</div>
+          <div class="text-center fs20 text-danger">[[[Cancellation]]]</div>
           <div class="text-center fs16" data-tmpl="cancelInfo">
             <span data-tmpl="cancelAmount"></span> <img src="" class="micro-icon" data-tmpl="cancelIcon"> (<span data-tmpl="cancelOrderPortion"></span>)
           </div>
@@ -189,7 +189,7 @@
               </div>
             </div>
             <div class="px-3 pb-3 d-hide" data-tmpl="refund">
-              <span class="match-data-label red">[[[Refund]]] (<span data-tmpl="refundAsset"></span>, [[[you]]])</span><br>
+              <span class="match-data-label text-danger">[[[Refund]]] (<span data-tmpl="refundAsset"></span>, [[[you]]])</span><br>
               <span data-tmpl="refundPending"></span>
               <a target="_blank" class="mono plainlink" data-tmpl="refundCoin"></a>
             </div>

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -7,17 +7,25 @@
   <span class="me-2 text-danger ico-cross d-hide pointer peers-table-icon" id="removeIconTmpl"></span>
   <div id="content" class="fill-abs d-flex">
     {{- /* ASSET SELECT */ -}}
-    <section id="assetSelect" class="w-auto d-flex align-items-stretch overflow-y-hidden stylish-overflow hoveronly invisible">
-      <div id="iconSelectTmpl" class="icon-select d-flex align-items-stretch p-2">
-        <div class="position-relative overflow-visible">
-          <img data-tmpl="img">
-          <img data-tmpl="parentImg" class="d-hide">
+    <section id="assetSelect" class="w-auto d-flex align-items-stretch overflow-y-hidden hidden-overflow invisible">
+      <div id="iconSelectTmpl" class="icon-select d-flex align-items-stretch p-2 border-bottom">
+        <div class="flex-center">
+          <div class="position-relative overflow-visible">
+            <img data-tmpl="img">
+            <img data-tmpl="parentImg" class="d-hide">
+          </div>
         </div>
-        <div class="d-none d-md-flex flex-column justify-content-around ps-3">
-          <span class="fs15 lh1 text-nowrap" data-tmpl="name"></span>
-          <span class="fs15 lh1" data-tmpl="balance"></span>
-          <span class="fs13 lh1" data-tmpl="fiat" class="d-hide"></span>
-          <span class="fs13 lh1" data-tmpl="noWallet">[[[Create a Wallet]]]</span>
+        <div class="d-none d-md-flex flex-column justify-content-around ps-3 lh1">
+          <span class="fs17 demi lh1 text-nowrap" data-tmpl="name"></span>
+          <span data-tmpl="balanceBox" class="d-hide">
+            <span class="fs14 lh1" data-tmpl="balance"></span>
+            <span class="fs14 grey" data-tmpl="unit"></span>
+          </span>
+          <span data-tmpl="fiatBox" class="d-hide">
+            <span class="fs14 lh1" data-tmpl="fiat"></span>
+            <span class="fs14 grey">USD</span>
+          </span>
+          <span class="fs15 lh1" data-tmpl="noWallet">[[[Create a Wallet]]]</span>
         </div>
       </div>
     </section>
@@ -138,10 +146,13 @@
                     [[[Settings]]]
                   </button>
                 </div>
-                <button id="needsProviderBttn" class="flex-center mt-2 lh1 fs17" data-tooltip="[[[add_provider_tooltip]]]">
-                  <span class="ico-disconnected text-warning demi me-2"></span>
-                  <span>Add a custom API provider</span>
-                </button>
+                <div id="needsProviderBox" class="flex-stretch-column border-top mt-2">
+                  <div class="mt-2 text-justify">[[[add_provider_tooltip]]]</div>
+                  <button id="needsProviderBttn" class="flex-center mt-2 lh1 fs17">
+                    <span class="ico-disconnected text-warning demi me-2"></span>
+                    <span>Add a custom API provider</span>
+                  </button>
+                </div>
               </div>
             </div>
           </section>

--- a/client/webserver/site/src/js/coinexplorers.ts
+++ b/client/webserver/site/src/js/coinexplorers.ts
@@ -104,7 +104,7 @@ export const CoinExplorers: Record<number, Record<number, (cid: string) => strin
     },
     [Testnet]: (cid: string) => {
       const [arg, isAddr] = ethBasedExplorerArg(cid)
-      return isAddr ? `https://mumbai.polygonscan.com/address/${arg}` : `https://mumbai.polygonscan.com/tx/${arg}`
+      return isAddr ? `https://amoy.polygonscan.com/address/${arg}` : `https://amoy.polygonscan.com/tx/${arg}`
     },
     [Simnet]: (cid: string) => {
       const [arg, isAddr] = ethBasedExplorerArg(cid)

--- a/client/webserver/site/src/js/doc.ts
+++ b/client/webserver/site/src/js/doc.ts
@@ -5,6 +5,7 @@ import {
   WalletState,
   PageElement
 } from './registry'
+import State from './state'
 import { RateEncodingFactor } from './orderutil'
 
 // Symbolizer is satisfied by both dex.Asset and core.SupportedAsset. Used by
@@ -240,6 +241,14 @@ export default class Doc {
    */
   static async animate (duration: number, f: (progress: number) => void, easingAlgo?: string) {
     await new Animation(duration, f, easingAlgo).wait()
+  }
+
+  static async blink (el: PageElement) {
+    const [r, g, b] = State.isDark() ? [255, 255, 255] : [0, 0, 0]
+    const cycles = 2
+    Doc.animate(1000, (p: number) => {
+      el.style.outline = `2px solid rgba(${r}, ${g}, ${b}, ${(cycles - p * cycles) % 1})`
+    })
   }
 
   static applySelector (ancestor: HTMLElement, k: string): PageElement[] {

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -1986,13 +1986,10 @@ export class LoginForm {
       return
     }
     await app().fetchUser()
-    if (res.notes) {
-      res.notes.reverse()
-      app().setNotes(res.notes)
-    }
-    if (res.pokes) {
-      app().setPokes(res.pokes)
-    }
+    res.notes = res.notes || []
+    res.notes.reverse()
+    res.pokes = res.pokes || []
+    app().loggedIn(res.notes, res.pokes)
     if (this.pwCache) this.pwCache.pw = pw
     this.success()
   }

--- a/client/webserver/site/src/js/init.ts
+++ b/client/webserver/site/src/js/init.ts
@@ -125,7 +125,7 @@ class AppInitForm {
     // the Application will only clear them on login, which would leave old
     // browser-cached notifications in place after registering even if the
     // client db is wiped.
-    app().setNotes([])
+    app().loggedIn([], [])
     page.appPW.value = ''
     page.appPWAgain.value = ''
     const loaded = app().loading(this.form)

--- a/client/webserver/site/src/js/init.ts
+++ b/client/webserver/site/src/js/init.ts
@@ -121,11 +121,6 @@ class AppInitForm {
       return
     }
 
-    // Clear the notification cache. Useful for development purposes, since
-    // the Application will only clear them on login, which would leave old
-    // browser-cached notifications in place after registering even if the
-    // client db is wiped.
-    app().loggedIn([], [])
     page.appPW.value = ''
     page.appPWAgain.value = ''
     const loaded = app().loading(this.form)

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -429,6 +429,17 @@ export interface WalletNote extends CoreNote {
   payload: BaseWalletNote
 }
 
+export interface CoreActionRequiredNote extends CoreNote {
+  payload: ActionRequiredNote
+}
+
+export interface RejectedRedemptionData {
+  assetID: number
+  orderID: string
+  coinID: string
+  coinFmt: string
+}
+
 export interface SpotPriceNote extends CoreNote {
   host: string
   spots: Record<string, Spot>

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -343,6 +343,7 @@ export interface User {
   bots: BotReport[]
   net: number
   extensionModeConfig: ExtensionModeConfig
+  actions: ActionRequiredNote[]
 }
 
 export interface CoreNote {
@@ -406,6 +407,22 @@ export interface CustomWalletNote extends BaseWalletNote {
 export interface TransactionNote extends BaseWalletNote {
   transaction: WalletTransaction
   new: boolean
+}
+
+export interface ActionRequiredNote extends BaseWalletNote {
+  uniqueID: string
+  actionID: string
+  payload: any
+}
+
+export interface ActionResolvedNote extends BaseWalletNote {
+  uniqueID: string
+}
+
+export interface TransactionActionNote {
+  tx: WalletTransaction
+  nonce: number
+  newFees: number
 }
 
 export interface WalletNote extends CoreNote {
@@ -1035,7 +1052,7 @@ export interface Application {
   attachCommon (node: HTMLElement): void
   updateBondConfs (dexAddr: string, coinID: string, confs: number, assetID: number): void
   handleBondNote (note: BondNote): void
-  setNotes (notes: CoreNote[]): void
+  loggedIn (notes: CoreNote[], pokes: CoreNote[]): void
   setPokes(pokes: CoreNote[]): void
   notify (note: CoreNote): void
   log (loggerID: string, ...msg: any): void

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -585,6 +585,7 @@ export interface SwapEstimate {
   maxFees: number
   realisticWorstCase: number
   realisticBestCase: number
+  feeReservesPerLot: number
 }
 
 export interface RedeemEstimate {

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1045,11 +1045,7 @@ export default class WalletsPage extends BasePage {
     const { page: { needsProviderBox: box, needsProviderBttn: bttn } } = this
     Doc.setVis(needs, box)
     if (!needs) return
-    const [r, g, b] = State.isDark() ? [255, 255, 255] : [0, 0, 0]
-    const cycles = 2
-    Doc.animate(1000, (p: number) => {
-      bttn.style.outline = `2px solid rgba(${r}, ${g}, ${b}, ${(cycles - p * cycles) % 1})`
-    })
+    Doc.blink(bttn)
   }
 
   async updateTicketBuyer (assetID: number) {

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -935,6 +935,7 @@ export default class WalletsPage extends BasePage {
       const bttn = page.iconSelectTmpl.cloneNode(true) as HTMLElement
       page.assetSelect.appendChild(bttn)
       const tmpl = Doc.parseTemplate(bttn)
+      tmpl.unit.textContent = a.unitInfo.conventional.unit
       this.assetButtons[a.id] = { tmpl, bttn }
       this.updateAssetButton(a.id)
       Doc.bind(bttn, 'click', () => {
@@ -949,7 +950,7 @@ export default class WalletsPage extends BasePage {
   updateAssetButton (assetID: number) {
     const a = app().assets[assetID]
     const { bttn, tmpl } = this.assetButtons[assetID]
-    Doc.hide(tmpl.fiat, tmpl.noWallet)
+    Doc.hide(tmpl.fiatBox, tmpl.noWallet)
     bttn.classList.add('nowallet')
     tmpl.img.src ||= Doc.logoPath(a.symbol) // don't initiate GET if already set (e.g. update on some notification)
     const symbolParts = a.symbol.split('.')
@@ -965,9 +966,10 @@ export default class WalletsPage extends BasePage {
       const { wallet: { balance: b }, unitInfo: ui } = a
       const totalBalance = b.available + b.locked + b.immature
       tmpl.balance.textContent = Doc.formatCoinValue(totalBalance, ui)
+      Doc.show(tmpl.balanceBox)
       const rate = app().fiatRatesMap[a.id]
       if (rate) {
-        Doc.show(tmpl.fiat)
+        Doc.show(tmpl.fiatBox)
         tmpl.fiat.textContent = Doc.formatFiatConversion(totalBalance, rate, ui)
       }
     } else Doc.show(tmpl.noWallet)
@@ -1005,7 +1007,7 @@ export default class WalletsPage extends BasePage {
       page.sendReceive, page.connectBttnBox, page.statusLocked, page.statusReady,
       page.statusOff, page.unlockBttnBox, page.lockBttnBox, page.connectBttnBox,
       page.peerCountBox, page.syncProgressBox, page.statusDisabled, page.tokenInfoBox,
-      page.needsProviderBttn
+      page.needsProviderBox
     )
     this.checkNeedsProvider(assetID)
     if (token) {
@@ -1040,8 +1042,8 @@ export default class WalletsPage extends BasePage {
 
   async checkNeedsProvider (assetID: number) {
     const needs = await app().needsCustomProvider(assetID)
-    const bttn = this.page.needsProviderBttn
-    Doc.setVis(needs, bttn)
+    const { page: { needsProviderBox: box, needsProviderBttn: bttn } } = this
+    Doc.setVis(needs, box)
     if (!needs) return
     const [r, g, b] = State.isDark() ? [255, 255, 255] : [0, 0, 0]
     const cycles = 2

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -178,6 +178,7 @@ type clientCore interface {
 	DisableFundsMixer(assetID uint32) error
 	SetLanguage(string) error
 	Language() string
+	TakeAction(assetID uint32, actionID string, actionB json.RawMessage) error
 }
 
 type mmCore interface {
@@ -565,6 +566,7 @@ func New(cfg *Config) (*WebServer, error) {
 			apiAuth.Post("/unapprovetoken", s.apiUnapproveToken)
 			apiAuth.Post("/approvetokenfee", s.apiApproveTokenFee)
 			apiAuth.Post("/txhistory", s.apiTxHistory)
+			apiAuth.Post("/takeaction", s.apiTakeAction)
 
 			apiAuth.Post("/shieldedstatus", s.apiShieldedStatus)
 			apiAuth.Post("/newshieldedaddress", s.apiNewShieldedAddress)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -371,6 +371,8 @@ func (c *TCore) DisableFundsMixer(assetID uint32) error {
 func (*TCore) SetLanguage(string) error { return nil }
 func (*TCore) Language() string         { return "en-US" }
 
+func (*TCore) TakeAction(assetID uint32, actionID string, actionB json.RawMessage) error { return nil }
+
 type TWriter struct {
 	b []byte
 }

--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -147,13 +147,16 @@ func RefundGas(contractVer uint32) uint64 {
 	return g.Refund
 }
 
+var gweiFactorBig = big.NewInt(GweiFactor)
+
 // GweiToWei converts uint64 Gwei to *big.Int Wei.
 func GweiToWei(v uint64) *big.Int {
-	return new(big.Int).Mul(big.NewInt(int64(v)), big.NewInt(GweiFactor))
+	return new(big.Int).Mul(big.NewInt(int64(v)), gweiFactorBig)
 }
 
-// WeiToGwei converts *big.Int Wei to uint64 Gwei. If v is determined to be
-// unsuitable for a uint64, zero is returned.
+// WeiToGweiFloor converts *big.Int Wei to uint64 Gwei. If v is determined to be
+// unsuitable for a uint64, zero is returned. For values that are not even
+// multiples of 1 gwei, this function returns the floor.
 func WeiToGwei(v *big.Int) uint64 {
 	vGwei := new(big.Int).Div(v, big.NewInt(GweiFactor))
 	if vGwei.IsUint64() {
@@ -162,14 +165,29 @@ func WeiToGwei(v *big.Int) uint64 {
 	return 0
 }
 
-// WeiToGweiUint64 converts a *big.Int in wei (1e18 unit) to gwei (1e9 unit) as
+// add before diving by gweiFactorBig to take the ceiling.
+var gweiCeilAddend = big.NewInt(GweiFactor - 1)
+
+// WeiToGweiCeil converts *big.Int Wei to uint64 Gwei. If v is determined to be
+// unsuitable for a uint64, zero is returned. For values that are not even
+// multiples of 1 gwei, this function returns the ceiling.
+func WeiToGweiCeil(v *big.Int) uint64 {
+	vGwei := new(big.Int).Div(v.Add(v, gweiCeilAddend), big.NewInt(GweiFactor))
+	if vGwei.IsUint64() {
+		return vGwei.Uint64()
+	}
+	return 0
+}
+
+// WeiToGweiSafe converts a *big.Int in wei (1e18 unit) to gwei (1e9 unit) as
 // a uint64. Errors if the amount of gwei is too big to fit fully into a uint64.
-func WeiToGweiUint64(wei *big.Int) (uint64, error) {
+// For values that are not even multiples of 1 gwei, this function returns the
+// ceiling.
+func WeiToGweiSafe(wei *big.Int) (uint64, error) {
 	if wei.Cmp(new(big.Int)) == -1 {
 		return 0, fmt.Errorf("wei must be non-negative")
 	}
-	gweiFactorBig := big.NewInt(GweiFactor)
-	gwei := new(big.Int).Div(wei, gweiFactorBig)
+	gwei := new(big.Int).Div(wei.Add(wei, gweiCeilAddend), gweiFactorBig)
 	if !gwei.IsUint64() {
 		return 0, fmt.Errorf("suggest gas price %v gwei is too big for a uint64", wei)
 	}

--- a/dex/networks/eth/params.go
+++ b/dex/networks/eth/params.go
@@ -172,7 +172,7 @@ var gweiCeilAddend = big.NewInt(GweiFactor - 1)
 // unsuitable for a uint64, zero is returned. For values that are not even
 // multiples of 1 gwei, this function returns the ceiling.
 func WeiToGweiCeil(v *big.Int) uint64 {
-	vGwei := new(big.Int).Div(v.Add(v, gweiCeilAddend), big.NewInt(GweiFactor))
+	vGwei := new(big.Int).Div(new(big.Int).Add(v, gweiCeilAddend), big.NewInt(GweiFactor))
 	if vGwei.IsUint64() {
 		return vGwei.Uint64()
 	}
@@ -187,7 +187,7 @@ func WeiToGweiSafe(wei *big.Int) (uint64, error) {
 	if wei.Cmp(new(big.Int)) == -1 {
 		return 0, fmt.Errorf("wei must be non-negative")
 	}
-	gwei := new(big.Int).Div(wei.Add(wei, gweiCeilAddend), gweiFactorBig)
+	gwei := new(big.Int).Div(new(big.Int).Add(wei, gweiCeilAddend), gweiFactorBig)
 	if !gwei.IsUint64() {
 		return 0, fmt.Errorf("suggest gas price %v gwei is too big for a uint64", wei)
 	}

--- a/dex/testing/dcrdex/harness.sh
+++ b/dex/testing/dcrdex/harness.sh
@@ -20,8 +20,8 @@ cat > "${DCRDEX_DATA_DIR}/build" <<EOF
 #!/usr/bin/env bash
 cd ${HARNESS_DIR}/../../../server/cmd/dcrdex/
 go build -o ${DCRDEX_DATA_DIR}/dcrdex -ldflags \
-    "-X 'decred.org/dcrdex/dex.testLockTimeTaker=30s' \
-    -X 'decred.org/dcrdex/dex.testLockTimeMaker=1m'"
+    "-X 'decred.org/dcrdex/dex.testLockTimeTaker=1m' \
+    -X 'decred.org/dcrdex/dex.testLockTimeMaker=2m'"
 EOF
 chmod +x "${DCRDEX_DATA_DIR}/build"
 

--- a/server/asset/eth/coiner.go
+++ b/server/asset/eth/coiner.go
@@ -21,8 +21,8 @@ var _ asset.Coin = (*redeemCoin)(nil)
 type baseCoin struct {
 	backend      *AssetBackend
 	secretHash   [32]byte
-	gasFeeCap    uint64
-	gasTipCap    uint64
+	gasFeeCap    *big.Int
+	gasTipCap    *big.Int
 	txHash       common.Hash
 	value        *big.Int
 	txData       []byte
@@ -182,25 +182,17 @@ func (be *AssetBackend) baseCoin(coinID []byte, contractData []byte) (*baseCoin,
 	if gasFeeCap == nil || gasFeeCap.Cmp(zero) <= 0 {
 		return nil, fmt.Errorf("Failed to parse gas fee cap from tx %s", txHash)
 	}
-	gasFeeCapGwei, err := dexeth.WeiToGweiUint64(gasFeeCap)
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert gas fee cap: %v", err)
-	}
 
 	gasTipCap := tx.GasTipCap()
 	if gasTipCap == nil || gasTipCap.Cmp(zero) <= 0 {
 		return nil, fmt.Errorf("Failed to parse gas tip cap from tx %s", txHash)
 	}
-	gasTipCapGwei, err := dexeth.WeiToGweiUint64(gasTipCap)
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert gas tip cap: %v", err)
-	}
 
 	return &baseCoin{
 		backend:      be,
 		secretHash:   secretHash,
-		gasFeeCap:    gasFeeCapGwei,
-		gasTipCap:    gasTipCapGwei,
+		gasFeeCap:    gasFeeCap,
+		gasTipCap:    gasTipCap,
 		txHash:       txHash,
 		value:        tx.Value(),
 		txData:       tx.Data(),
@@ -313,7 +305,7 @@ func (c *baseCoin) String() string {
 // FeeRate returns the gas rate, in gwei/gas. It is set in initialization of
 // the swapCoin.
 func (c *baseCoin) FeeRate() uint64 {
-	return c.gasFeeCap
+	return dexeth.WeiToGwei(c.gasFeeCap)
 }
 
 // Value returns the value of one swap in order to validate during processing.

--- a/server/asset/eth/coiner.go
+++ b/server/asset/eth/coiner.go
@@ -305,7 +305,7 @@ func (c *baseCoin) String() string {
 // FeeRate returns the gas rate, in gwei/gas. It is set in initialization of
 // the swapCoin.
 func (c *baseCoin) FeeRate() uint64 {
-	return dexeth.WeiToGwei(c.gasFeeCap)
+	return dexeth.WeiToGweiCeil(c.gasFeeCap)
 }
 
 // Value returns the value of one swap in order to validate during processing.

--- a/server/asset/eth/coiner_test.go
+++ b/server/asset/eth/coiner_test.go
@@ -110,8 +110,8 @@ func TestNewRedeemCoin(t *testing.T) {
 		if test.txErr == nil && (rc.secretHash != secretHash ||
 			rc.secret != secret ||
 			rc.value.Uint64() != 0 ||
-			rc.gasFeeCap != wantGas ||
-			rc.gasTipCap != wantGasTipCap) {
+			dexeth.WeiToGwei(rc.gasFeeCap) != wantGas ||
+			dexeth.WeiToGwei(rc.gasTipCap) != wantGasTipCap) {
 			t.Fatalf("returns do not match expected for test %q / %v", test.name, rc)
 		}
 	}
@@ -236,8 +236,8 @@ func TestNewSwapCoin(t *testing.T) {
 		if sc.init.Participant != initParticipantAddr ||
 			sc.secretHash != secretHash ||
 			dexeth.WeiToGwei(sc.value) != wantVal ||
-			sc.gasFeeCap != wantGas ||
-			sc.gasTipCap != wantGasTipCap ||
+			dexeth.WeiToGwei(sc.gasFeeCap) != wantGas ||
+			dexeth.WeiToGwei(sc.gasTipCap) != wantGasTipCap ||
 			sc.init.LockTime.Unix() != initLocktime {
 			t.Fatalf("returns do not match expected for test %q / %v", test.name, sc)
 		}

--- a/server/asset/eth/coiner_test.go
+++ b/server/asset/eth/coiner_test.go
@@ -128,15 +128,15 @@ func TestNewSwapCoin(t *testing.T) {
 	const gasPrice = 30
 	const value = 5e9
 	const gasTipCap = 2
-	wantGas, err := dexeth.WeiToGweiUint64(big.NewInt(3e10))
+	wantGas, err := dexeth.WeiToGweiSafe(big.NewInt(3e10))
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantVal, err := dexeth.WeiToGweiUint64(big.NewInt(5e18))
+	wantVal, err := dexeth.WeiToGweiSafe(big.NewInt(5e18))
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantGasTipCap, err := dexeth.WeiToGweiUint64(big.NewInt(2e9))
+	wantGasTipCap, err := dexeth.WeiToGweiSafe(big.NewInt(2e9))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/asset/eth/eth.go
+++ b/server/asset/eth/eth.go
@@ -520,7 +520,7 @@ func (eth *baseBackend) FeeRate(ctx context.Context) (uint64, error) {
 		suggestedGasTipCap,
 		new(big.Int).Mul(hdr.BaseFee, big.NewInt(2)))
 
-	feeRateGwei, err := dexeth.WeiToGweiUint64(feeRate)
+	feeRateGwei, err := dexeth.WeiToGweiSafe(feeRate)
 	if err != nil {
 		return 0, fmt.Errorf("failed to convert wei to gwei: %w", err)
 	}

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -285,10 +285,10 @@ func TestFeeRate(t *testing.T) {
 		suggGasTipCap: new(big.Int),
 		wantFee:       0,
 	}, {
-		name:          "ok rounded down",
+		name:          "ok rounded up",
 		hdrBaseFee:    big.NewInt(dexeth.GweiFactor - 1),
 		suggGasTipCap: new(big.Int),
-		wantFee:       1,
+		wantFee:       2,
 	}, {
 		name:          "ok 100, 2",
 		hdrBaseFee:    big.NewInt(dexeth.GweiFactor * 100),

--- a/server/asset/eth/eth_test.go
+++ b/server/asset/eth/eth_test.go
@@ -495,8 +495,9 @@ func TestContract(t *testing.T) {
 func TestValidateFeeRate(t *testing.T) {
 	swapCoin := swapCoin{
 		baseCoin: &baseCoin{
-			gasFeeCap: 100,
-			gasTipCap: 2,
+			backend:   &AssetBackend{log: tLogger},
+			gasFeeCap: dexeth.GweiToWei(100),
+			gasTipCap: dexeth.GweiToWei(2),
 		},
 	}
 
@@ -514,7 +515,7 @@ func TestValidateFeeRate(t *testing.T) {
 		t.Fatalf("expected invalid fee rate, but was valid")
 	}
 
-	swapCoin.gasTipCap = dexeth.MinGasTipCap - 1
+	swapCoin.gasTipCap = dexeth.GweiToWei(dexeth.MinGasTipCap - 1)
 	if eth.ValidateFeeRate(contract.Coin, 100) {
 		t.Fatalf("expected invalid fee rate, but was valid")
 	}

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -108,7 +108,7 @@ func loadMarketConf(net dex.Network, src io.Reader) ([]*dex.MarketInfo, []*Asset
 		return nil, nil, err
 	}
 
-	log.Debug("-------------------- BEGIN parsed markets.json --------------------")
+	log.Debug("|-------------------- BEGIN parsed markets.json --------------------")
 	log.Debug("MARKETS")
 	log.Debug("                  Base         Quote    LotSize     EpochDur")
 	for i, mktConf := range conf.Markets {
@@ -138,7 +138,7 @@ func loadMarketConf(net dex.Network, src io.Reader) ([]*dex.MarketInfo, []*Asset
 		}
 		log.Debugf("%-12s % 10d  % 9d % 9s", asset, assetConf.MaxFeeRate, assetConf.SwapConf, assetConf.Network)
 	}
-	log.Debug("--------------------- END parsed markets.json ---------------------")
+	log.Debug("|--------------------- END parsed markets.json ---------------------|")
 
 	// Normalize the asset names to lower case.
 	var assets []*Asset

--- a/tatanka/tcp/client/client.go
+++ b/tatanka/tcp/client/client.go
@@ -59,7 +59,7 @@ func (c *Client) Connect(ctx context.Context) (_ *sync.WaitGroup, err error) {
 		PingWait: 20 * time.Second,
 		Cert:     c.cert,
 		ReconnectSync: func() {
-			fmt.Println("--RECONNECTED RECONNECTED RECONNECTED RECONNECTED ")
+			fmt.Println("## RECONNECTED RECONNECTED RECONNECTED RECONNECTED ")
 		},
 		ConnectEventFunc: func(status comms.ConnectionStatus) {
 			if status == comms.Disconnected {


### PR DESCRIPTION
This work accomplishes a number of goals required for putting eth and polygon into production.

- Fix nonce tracking and pending tx monitoring. Some bugs came out in testnet testing and one of them put us in a state where we were rebroadcasing txs with a nonce too low and they weren't being accepted.
- Implement for eth/polygon new rule that we will not automatically generate replacement txs if the tx being replaced incurred tx fees. New system to getting user authorization in these hopefully exceedingly rare edge cases.
- Add some caches and fix some spots where we were hitting the rpc way too much. Use our DB and tx monitoring for rpc-free info.
- A bunch of general refactoring.
- One unrelated UI fix snuck in regarding 0-lot max fee result messaging. Sorry.

Hand-tested. Will do some self-review asap.