### PR TITLE
asset/btc/electrum: make floatString work for `float` and string float

### DIFF
--- a/client/asset/btc/electrum/jsonrpc.go
+++ b/client/asset/btc/electrum/jsonrpc.go
@@ -38,7 +38,6 @@ type response struct {
 	Error  *RPCError       `json:"error"`
 }
 
-type ntfn = request // weird but true
 type ntfnData struct {
 	Params json.RawMessage `json:"params"`
 }

--- a/client/asset/btc/electrum/jsonrpc.go
+++ b/client/asset/btc/electrum/jsonrpc.go
@@ -4,10 +4,10 @@
 package electrum
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strconv"
 )
 
 type positional []any
@@ -87,13 +87,12 @@ type floatString float64
 
 func (fs *floatString) UnmarshalJSON(b []byte) error {
 	// Try to strip the string contents out of quotes.
-	var str string
-	if err := json.Unmarshal(b, &str); err != nil {
-		return err // wasn't a string
+	if bytes.HasPrefix(b, []byte(`"`)) && bytes.HasSuffix(b, []byte(`"`)) {
+		b = bytes.Trim(b, `"`)
 	}
-	fl, err := strconv.ParseFloat(str, 64)
-	if err != nil {
-		return err // The string didn't contain a float.
+	var fl float64
+	if err := json.Unmarshal(b, &fl); err != nil {
+		return err
 	}
 	*fs = floatString(fl)
 	return nil

--- a/client/asset/btc/electrum/jsonrpc_test.go
+++ b/client/asset/btc/electrum/jsonrpc_test.go
@@ -4,6 +4,7 @@
 package electrum
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -11,23 +12,28 @@ import (
 func Test_floatString_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string
-		arg     []byte
+		arg     any
 		wantErr bool
 	}{
 		{
-			name: "float64",
-			arg:  []byte{49, 50, 46, 50, 51}, // 12.23
+			name: "float",
+			arg:  12.23,
 		},
 		{
-			name: "string float64",
-			arg:  []byte{34, 49, 50, 46, 50, 51, 34}, // "12.23"
+			name: "string float",
+			arg:  "12.23",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			argByte, err := json.Marshal(tt.arg)
+			if err != nil {
+				t.Errorf("%s: json.Marshal error: %v", tt.name, err)
+			}
+
 			var fs floatString
-			if err := fs.UnmarshalJSON(tt.arg); (err != nil) != tt.wantErr {
+			if err := fs.UnmarshalJSON(argByte); (err != nil) != tt.wantErr {
 				t.Errorf("%s: error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			}
 

--- a/client/asset/btc/electrum/jsonrpc_test.go
+++ b/client/asset/btc/electrum/jsonrpc_test.go
@@ -1,0 +1,41 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package electrum
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_floatString_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     []byte
+		wantErr bool
+	}{
+		{
+			name: "float64",
+			arg:  []byte{49, 50, 46, 50, 51}, // 12.23
+		},
+		{
+			name: "string float64",
+			arg:  []byte{34, 49, 50, 46, 50, 51, 34}, // "12.23"
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fs floatString
+			if err := fs.UnmarshalJSON(tt.arg); (err != nil) != tt.wantErr {
+				t.Errorf("%s: error = %v, wantErr %v", tt.name, err, tt.wantErr)
+			}
+
+			fsStr := fmt.Sprint(fs)
+			fsByte := []byte(fsStr)
+			if string(fsByte) != fsStr {
+				t.Errorf("%s: expected %v got %v", tt.name, string(fsByte), fsStr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR improves the `UnmarshalJSON` method of type `floatString`.