### PR TITLE
app: Tx History UI Fixes

### DIFF
--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -1021,23 +1021,23 @@
         </tr>
         <tr>
           <td class="grey">[[[tx_id]]]</td>
-          <td><span id="txDetailsID" class="ease-color"></span><span id="copyTxIDBtn" class="ico-copy pt-0"></span></td>
+          <td><span id="txDetailsID" class="ease-color"></span><span id="copyTxIDBtn" class="ease-color ico-copy pt-0"></span></td>
         </tr>
         <tr id="txDetailsRecipientSection" class="border-top">
           <td class="grey">[[[recipient]]]</td>
-          <td><span id="txDetailsRecipient" class="ease-color"></span><span id="copyRecipientBtn" class="ico-copy pt-0"></span></td>
+          <td><span id="txDetailsRecipient" class="ease-color"></span><span id="copyRecipientBtn" class="ease-color ico-copy pt-0"></span></td>
         </tr>
-        <tr id="txDetailsBondSection" class="border-top">
+        <tr id="txDetailsBondIDSection" class="border-top">
           <td class="grey">[[[bond_id]]]</td>
-          <td><span id="txDetailsBondID" class="ease-color"></span><span id="copyBondIDBtn" class="ico-copy pt-0"></span></td>
+          <td><span id="txDetailsBondID" class="ease-color"></span><span id="copyBondIDBtn" class="ease-color ico-copy pt-0"></span></td>
         </tr>
-        <tr>
+        <tr id="txDetailsBondLocktimeSection">
           <td class="grey">[[[locktime]]]</td>
           <td><span id="txDetailsBondLocktime" class="ease-color"></span></td>
         </tr>
         <tr id="txDetailsBondAccountIDSection">
           <td class="grey">[[[Account ID]]]</td>
-          <td><span id="txDetailsBondAccountID" class="ease-color"></span><span id="copyBondAccountIDBtn" class="ico-copy pt-0"></span></td>
+          <td><span id="txDetailsBondAccountID" class="ease-color"></span><span id="copyBondAccountIDBtn" class="ease-color ico-copy pt-0"></span></td>
         </tr>
         <tr id="txDetailsNonceSection" class="border-top">
           <td class="grey">[[[nonce]]]</td>


### PR DESCRIPTION
Bond related rows were being displayed for non-bond transactions, age of txs was not being updated, and copy buttons didn't match the color transitions of the text they were copying.