### PR TITLE
client/btc: Swap / Bond redemptions to external address

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2523,7 +2523,7 @@ func (btc *baseWallet) submitMultiSplitTx(fundingCoins asset.Coins, spents []*Ou
 
 	outputAddresses := make([]btcutil.Address, len(orders))
 	for i, req := range requiredForOrders {
-		outputAddr, err := btc.node.changeAddress()
+		outputAddr, err := btc.node.externalAddress()
 		if err != nil {
 			return nil, 0, err
 		}
@@ -2775,8 +2775,7 @@ func (btc *baseWallet) split(value uint64, lots uint64, outputs []*Output, input
 		return coins, false, 0, nil // err==nil records and locks the provided fundingCoins in defer
 	}
 
-	// Use an internal address for the sized output.
-	addr, err := btc.node.changeAddress()
+	addr, err := btc.node.externalAddress()
 	if err != nil {
 		return nil, false, 0, fmt.Errorf("error creating split transaction address: %w", err)
 	}
@@ -3188,12 +3187,12 @@ func (btc *baseWallet) signedAccelerationTx(previousTxs []*GetTransactionResult,
 		return makeError(err)
 	}
 
-	changeAddr, err := btc.node.changeAddress()
+	addr, err := btc.node.externalAddress()
 	if err != nil {
 		return makeError(fmt.Errorf("error creating change address: %w", err))
 	}
 
-	tx, output, txFee, err := btc.signTxAndAddChange(baseTx, changeAddr, totalIn, additionalFeesRequired, newFeeRate)
+	tx, output, txFee, err := btc.signTxAndAddChange(baseTx, addr, totalIn, additionalFeesRequired, newFeeRate)
 	if err != nil {
 		return makeError(err)
 	}
@@ -3895,7 +3894,7 @@ func (btc *baseWallet) Redeem(form *asset.RedeemForm) ([]dex.Bytes, asset.Coin, 
 	}
 
 	// Send the funds back to the exchange wallet.
-	redeemAddr, err := btc.node.changeAddress()
+	redeemAddr, err := btc.node.externalAddress()
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("error getting new address from the wallet: %w", err)
 	}
@@ -4250,7 +4249,7 @@ func (btc *baseWallet) refundTx(txHash *chainhash.Hash, vout uint32, contract de
 		return nil, fmt.Errorf("refund tx not worth the fees")
 	}
 	if refundAddr == nil {
-		refundAddr, err = btc.node.changeAddress()
+		refundAddr, err = btc.node.externalAddress()
 		if err != nil {
 			return nil, fmt.Errorf("error getting new address from the wallet: %w", err)
 		}
@@ -5148,7 +5147,7 @@ func (btc *baseWallet) makeBondRefundTxV0(txid *chainhash.Hash, vout uint32, amt
 	}
 
 	// Add the refund output.
-	redeemAddr, err := btc.node.changeAddress()
+	redeemAddr, err := btc.node.externalAddress()
 	if err != nil {
 		return nil, fmt.Errorf("error creating change address: %w", err)
 	}
@@ -5921,11 +5920,15 @@ func (btc *intermediaryWallet) syncTxHistory(tip uint64) {
 				btc.log.Errorf("Error updating tx %s: %v", txHash, err)
 				return
 			}
+
+			btc.pendingTxsMtx.Lock()
 			if tx.Confirmed {
-				btc.pendingTxsMtx.Lock()
 				delete(btc.pendingTxs, txHash)
-				btc.pendingTxsMtx.Unlock()
+			} else {
+				btc.pendingTxs[txHash] = *tx
 			}
+			btc.pendingTxsMtx.Unlock()
+
 			btc.emit.TransactionNote(tx.WalletTransaction, false)
 		}
 	}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -855,6 +855,7 @@ func testFundMultiOrder(t *testing.T, segwit bool, walletType string) {
 	if segwit {
 		addrStr = tP2WPKHAddr
 	}
+	node.newAddress = addrStr
 	node.changeAddr = addrStr
 	node.signFunc = func(tx *wire.MsgTx) {
 		signFunc(tx, 0, wallet.segwit)
@@ -2367,8 +2368,10 @@ func testAvailableFund(t *testing.T, segwit bool, walletType string) {
 	baggageFees := tBTC.MaxFeeRate * splitTxBaggage
 	if segwit {
 		node.changeAddr = tP2WPKHAddr
+		node.newAddress = tP2WPKHAddr
 	} else {
 		node.changeAddr = tP2PKHAddr
+		node.newAddress = tP2PKHAddr
 	}
 	node.walletCfg.useSplitTx = true
 	// No error when no split performed cuz math.
@@ -2794,6 +2797,7 @@ func TestFundEdges(t *testing.T) {
 	// well.
 	node.walletCfg.useSplitTx = true
 	node.changeAddr = tP2WPKHAddr
+	node.newAddress = tP2WPKHAddr
 	node.signFunc = func(tx *wire.MsgTx) {
 		signFunc(tx, 0, wallet.segwit)
 	}
@@ -3017,6 +3021,7 @@ func TestFundEdgesSegwit(t *testing.T) {
 	// well.
 	node.walletCfg.useSplitTx = true
 	node.changeAddr = tP2WPKHAddr
+	node.newAddress = tP2WPKHAddr
 	node.signFunc = func(tx *wire.MsgTx) {
 		signFunc(tx, 0, wallet.segwit)
 	}
@@ -3220,6 +3225,7 @@ func testRedeem(t *testing.T, segwit bool, walletType string) {
 	}
 
 	node.changeAddr = addrStr
+	node.newAddress = addrStr
 	node.privKeyForAddr = wif
 
 	redemptions := &asset.RedeemForm{
@@ -3269,13 +3275,13 @@ func testRedeem(t *testing.T, segwit bool, walletType string) {
 	}
 	coin.Val = swapVal
 
-	// Change address error
-	node.changeAddrErr = tErr
+	// New address error
+	node.newAddressErr = tErr
 	_, _, _, err = wallet.Redeem(redemptions)
 	if err == nil {
-		t.Fatalf("no error for change address error")
+		t.Fatalf("no error for new address error")
 	}
-	node.changeAddrErr = nil
+	node.newAddressErr = nil
 
 	// Missing priv key error
 	node.privKeyForAddrErr = tErr
@@ -3611,6 +3617,7 @@ func testRefund(t *testing.T, segwit bool, walletType string) {
 	bigTxOut := newTxOutResult(nil, 1e8, 2)
 	node.txOutRes = bigTxOut // rpc
 	node.changeAddr = addr.String()
+	node.newAddress = addr.String()
 	const feeSuggestion = 100
 
 	privBytes, _ := hex.DecodeString("b07209eec1a8fb6cfe5cb6ace36567406971a75c330db7101fb21bc679bc5330")
@@ -3676,9 +3683,9 @@ func testRefund(t *testing.T, segwit bool, walletType string) {
 	tx.TxOut[0].Value = 1e8
 
 	// getrawchangeaddress error
-	node.changeAddrErr = tErr
-	ensureErr("getchangeaddress error")
-	node.changeAddrErr = nil
+	node.newAddressErr = tErr
+	ensureErr("new address error")
+	node.newAddressErr = nil
 
 	// signature error
 	node.privKeyForAddrErr = tErr
@@ -4763,8 +4770,10 @@ func testAccelerateOrder(t *testing.T, segwit bool, walletType string) {
 
 	if segwit {
 		node.changeAddr = tP2WPKHAddr
+		node.newAddress = tP2WPKHAddr
 	} else {
 		node.changeAddr = tP2PKHAddr
+		node.newAddress = tP2PKHAddr
 	}
 
 	node.signFunc = func(tx *wire.MsgTx) {
@@ -5856,7 +5865,7 @@ func TestConfirmRedemption(t *testing.T) {
 		t.Fatalf("error encoding wif: %v", err)
 	}
 
-	node.changeAddr = tP2WPKHAddr
+	node.newAddress = tP2WPKHAddr
 	node.privKeyForAddr = wif
 
 	tests := []struct {
@@ -6054,6 +6063,7 @@ func TestFindBond(t *testing.T) {
 	}
 	node.listUnspent = []*ListUnspentResult{utxo}
 	node.changeAddr = tP2PKHAddr
+	node.newAddress = tP2PKHAddr
 
 	bond, _, err := wallet.MakeBondTx(0, amt, 200, lockTime, bondKey, acctID[:])
 	if err != nil {


### PR DESCRIPTION
Updates swap redemption/refunds and bond redemptions to be sent to external addresses.