### PR TITLE
core: Make wallet connection synchronous

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -2856,6 +2856,7 @@ func trade(t *testing.T, async bool) {
 	defer rig.shutdown()
 	tCore := rig.core
 	dcrWallet, tDcrWallet := newTWallet(tUTXOAssetA.ID)
+	dcrWallet.hookedUp = false
 	tCore.wallets[tUTXOAssetA.ID] = dcrWallet
 	dcrWallet.address = "DsVmA7aqqWeKWy461hXjytbZbgCqbB8g2dq"
 	dcrWallet.Unlock(rig.crypter)
@@ -9548,6 +9549,7 @@ func TestWalletSyncing(t *testing.T) {
 	dcrWallet, tDcrWallet := newTWallet(tUTXOAssetA.ID)
 	dcrWallet.synced = false
 	dcrWallet.syncProgress = 0
+	dcrWallet.hookedUp = false
 	// Connect with tCore.connectWallet below.
 
 	tStart := time.Now()

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -54,6 +54,7 @@ type xcWallet struct {
 	traits            asset.WalletTrait
 	parent            *xcWallet
 	feeState          atomic.Value // *FeeState
+	connectMtx        sync.Mutex
 
 	mtx          sync.RWMutex
 	encPass      []byte // empty means wallet not password protected
@@ -393,9 +394,16 @@ func (w *xcWallet) checkPeersAndSyncStatus() error {
 // flag to true, and validates the deposit address. Use Disconnect to cleanly
 // shutdown the wallet.
 func (w *xcWallet) Connect() error {
+	w.connectMtx.Lock()
+	defer w.connectMtx.Unlock()
+
 	// Disabled wallet cannot be connected to unless it is enabled.
 	if w.isDisabled() {
 		return fmt.Errorf(walletDisabledErrStr, strings.ToUpper(unbip(w.AssetID)))
+	}
+
+	if w.connected() {
+		return nil
 	}
 
 	// No parent context; use Disconnect instead. Also note that there's no


### PR DESCRIPTION
Two wallet connections running in parallel was causing a panic.

There were parallel calls to `xcWallet.Connect` happening in `core.refundExpiredBonds` and `core.connectWallets`. The second connect was timing out, causing the panic in #2793.

Resolves: #2793 