### PR TITLE
multi: Bug fixes and remove/ignore unused param

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -3981,7 +3981,7 @@ func (w *assetWallet) checkPendingApprovals() {
 // sumPendingTxs sums the expected incoming and outgoing values in pending
 // transactions stored in pendingTxs. Not used if the node is a
 // txPoolFetcher.
-func (w *assetWallet) sumPendingTxs(bal *big.Int) (out, in uint64) {
+func (w *assetWallet) sumPendingTxs(_ /* bal */ *big.Int) (out, in uint64) {
 	isToken := w.assetID != w.baseChainID
 
 	sumPendingTx := func(pendingTx *extendedWalletTx) {
@@ -5486,7 +5486,7 @@ func (getGas) ReadCredentials(chain, credentialsPath string, net dex.Network) (a
 	return
 }
 
-func getGetGasClientWithEstimatesAndBalances(ctx context.Context, net dex.Network, assetID, contractVer uint32, maxSwaps int,
+func getGetGasClientWithEstimatesAndBalances(ctx context.Context, net dex.Network, _ /* assetID */, contractVer uint32, maxSwaps int,
 	walletDir string, providers []string, seed []byte, wParams *GetGasWalletParams, log dex.Logger) (cl *multiRPCClient, c contractor,
 	ethReq, swapReq, feeRate uint64, ethBal, tokenBal *big.Int, err error) {
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -474,7 +474,7 @@ func (db *tTxDB) storeTx(wt *extendedWalletTx) error {
 	db.storeTxCalled = true
 	return db.storeTxErr
 }
-func (db *tTxDB) removeTx(id string) error {
+func (db *tTxDB) removeTx(_ /* id */ string) error {
 	db.removeTxCalled = true
 	return db.removeTxErr
 }

--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -1061,8 +1061,7 @@ func (m *multiRPCClient) withAll(
 	var atLeastOne bool
 	var errs []string
 	providers := m.nonceProviderList()
-	for i := range providers {
-		p := providers[i]
+	for _, p := range providers {
 		if p.failed() {
 			continue
 		}
@@ -1101,7 +1100,7 @@ func (m *multiRPCClient) withAll(
 		return nil
 	}
 
-	if len(errs) == len(providers) {
+	if len(errs) > 0 {
 		return fmt.Errorf("all providers in a failed state: %s", strings.Join(errs, "\n"))
 	}
 

--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -1100,8 +1100,13 @@ func (m *multiRPCClient) withAll(
 		return nil
 	}
 
-	if len(errs) > 0 {
-		return fmt.Errorf("all providers in a failed state: %s", strings.Join(errs, "\n"))
+	// err will be nil if all providers were already in a failed state.
+	if errs == nil || len(errs) > 0 {
+		err := errors.New("all providers in a failed state")
+		if errs != nil {
+			err = fmt.Errorf("%w: %s", err, strings.Join(errs, "\n"))
+		}
+		return err
 	}
 
 	return nil

--- a/client/asset/eth/node.go
+++ b/client/asset/eth/node.go
@@ -189,7 +189,7 @@ func prepareNode(cfg *nodeConfig) (*node.Node, error) {
 }
 
 // startNode starts a geth node.
-func startNode(chainID int64, node *node.Node, network dex.Network) (*les.LightEthereum, error) {
+func startNode(_ /* chainID */ int64, node *node.Node, network dex.Network) (*les.LightEthereum, error) {
 	ethCfg, err := ETHConfig(network)
 	if err != nil {
 		return nil, err

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6462,7 +6462,7 @@ func (c *Core) prepareForTradeRequestPrep(pw []byte, base, quote uint32, host st
 }
 
 func (c *Core) createTradeRequest(wallets *walletSet, coins asset.Coins, redeemScripts []dex.Bytes, dc *dexConnection, redeemAddr string,
-	form *TradeForm, lots, redemptionRefundLots uint64, fundingFees uint64, assetConfigs *assetSet, mktConf *msgjson.Market, errCloser *dex.ErrorCloser) (*tradeRequest, error) {
+	form *TradeForm, redemptionRefundLots uint64, fundingFees uint64, assetConfigs *assetSet, mktConf *msgjson.Market, errCloser *dex.ErrorCloser) (*tradeRequest, error) {
 	coinIDs := make([]order.CoinID, 0, len(coins))
 	for i := range coins {
 		coinIDs = append(coinIDs, []byte(coins[i].ID()))
@@ -6752,7 +6752,7 @@ func (c *Core) prepareTradeRequest(pw []byte, form *TradeForm) (*tradeRequest, e
 	})
 
 	tradeRequest, err := c.createTradeRequest(wallets, coins, redeemScripts, dc, redeemAddr, form,
-		lots, redemptionRefundLots, fundingFees, assetConfigs, mktConf, errCloser)
+		redemptionRefundLots, fundingFees, assetConfigs, mktConf, errCloser)
 	if err != nil {
 		return nil, err
 	}
@@ -6863,7 +6863,7 @@ func (c *Core) prepareMultiTradeRequests(pw []byte, form *MultiTradeForm) ([]*tr
 			fees = fundingFees
 		}
 		req, err := c.createTradeRequest(wallets, coins, allRedeemScripts[i], dc, redeemAddresses[i], tradeForm,
-			orderValues[i].MaxSwapCount, orderValues[i].MaxSwapCount, fees, assetConfigs, mktConf, errClosers[i])
+			orderValues[i].MaxSwapCount, fees, assetConfigs, mktConf, errClosers[i])
 		if err != nil {
 			return nil, err
 		}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -995,7 +995,7 @@ func (w *TXCWallet) setConfs(coinID dex.Bytes, confs uint32, err error) {
 	w.confsMtx.Unlock()
 }
 
-func (w *TXCWallet) tConfirmations(ctx context.Context, coinID dex.Bytes) (uint32, error) {
+func (w *TXCWallet) tConfirmations(_ context.Context, coinID dex.Bytes) (uint32, error) {
 	id := coinID.String()
 	w.confsMtx.RLock()
 	defer w.confsMtx.RUnlock()
@@ -10180,7 +10180,7 @@ func TestDeleteArchivedRecords(t *testing.T) {
 	tdb := tCore.db.(*TDB)
 
 	tempFile := func(suffix string) (path string) {
-		matchesFile, err := os.CreateTemp("", "delete_archives_test_matches")
+		matchesFile, err := os.CreateTemp("", suffix+"delete_archives_test_matches")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1449,7 +1449,7 @@ func (s *WebServer) apiWithdraw(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	form.Subtract = true
-	s.send(w, r, form)
+	s.send(w, form)
 }
 
 // apiSend handles the 'send' API request.
@@ -1459,10 +1459,10 @@ func (s *WebServer) apiSend(w http.ResponseWriter, r *http.Request) {
 	if !readPost(w, r, form) {
 		return
 	}
-	s.send(w, r, form)
+	s.send(w, form)
 }
 
-func (s *WebServer) send(w http.ResponseWriter, r *http.Request, form *sendOrWithdrawForm) {
+func (s *WebServer) send(w http.ResponseWriter, form *sendOrWithdrawForm) {
 	state := s.core.WalletState(form.AssetID)
 	if state == nil {
 		s.writeAPIError(w, fmt.Errorf("no wallet found for %s", unbip(form.AssetID)))

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -41,7 +41,7 @@ func (s *WebServer) apiAddDEX(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, err)
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiDiscoverAccount is the handler for the '/discoveracct' API request.
@@ -72,7 +72,7 @@ func (s *WebServer) apiDiscoverAccount(w http.ResponseWriter, r *http.Request) {
 		Exchange: exchangeInfo,
 		Paid:     paid,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiEstimateRegistrationTxFee is the handler for the '/regtxfee' API request.
@@ -98,7 +98,7 @@ func (s *WebServer) apiEstimateRegistrationTxFee(w http.ResponseWriter, r *http.
 		OK:    true,
 		TxFee: txFee,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiValidateAddress is the handlers for the '/validateaddress' API request.
@@ -124,7 +124,7 @@ func (s *WebServer) apiValidateAddress(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK: valid,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiEstimateSendTxFee is the handler for the '/txfee' API request.
@@ -151,7 +151,7 @@ func (s *WebServer) apiEstimateSendTxFee(w http.ResponseWriter, r *http.Request)
 		TxFee:        txFee,
 		ValidAddress: validAddress,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiGetWalletPeers is the handler for the '/getwalletpeers' API request.
@@ -174,7 +174,7 @@ func (s *WebServer) apiGetWalletPeers(w http.ResponseWriter, r *http.Request) {
 		OK:    true,
 		Peers: peers,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiAddWalletPeer is the handler for the '/addwalletpeer' API request.
@@ -191,7 +191,7 @@ func (s *WebServer) apiAddWalletPeer(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, err)
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiRemoveWalletPeer is the handler for the '/removewalletpeer' API request.
@@ -208,7 +208,7 @@ func (s *WebServer) apiRemoveWalletPeer(w http.ResponseWriter, r *http.Request) 
 		s.writeAPIError(w, err)
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiApproveTokenFee(w http.ResponseWriter, r *http.Request) {
@@ -234,7 +234,7 @@ func (s *WebServer) apiApproveTokenFee(w http.ResponseWriter, r *http.Request) {
 		OK:    true,
 		TxFee: txFee,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 func (s *WebServer) apiApproveToken(w http.ResponseWriter, r *http.Request) {
@@ -265,7 +265,7 @@ func (s *WebServer) apiApproveToken(w http.ResponseWriter, r *http.Request) {
 		OK:   true,
 		TxID: txID,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 func (s *WebServer) apiUnapproveToken(w http.ResponseWriter, r *http.Request) {
@@ -296,7 +296,7 @@ func (s *WebServer) apiUnapproveToken(w http.ResponseWriter, r *http.Request) {
 		OK:   true,
 		TxID: txID,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiGetDEXInfo is the handler for the '/getdexinfo' API request.
@@ -318,7 +318,7 @@ func (s *WebServer) apiGetDEXInfo(w http.ResponseWriter, r *http.Request) {
 		OK:       true,
 		Exchange: exchangeInfo,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiRegister is the handler for the '/register' API request.
@@ -357,7 +357,7 @@ func (s *WebServer) apiRegister(w http.ResponseWriter, r *http.Request) {
 	// There was no error paying the fee, but we must wait on confirmations
 	// before informing the DEX of the fee payment. Those results will come
 	// through as a notification.
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // bondsFeeBuffer is a caching helper for the bonds fee buffer. Values for a
@@ -407,7 +407,7 @@ func (s *WebServer) apiBondsFeeBuffer(w http.ResponseWriter, r *http.Request) {
 		OK:        true,
 		FeeBuffer: feeBuffer,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiPostBond is the handler for the '/postbond' API request.
@@ -457,7 +457,7 @@ func (s *WebServer) apiPostBond(w http.ResponseWriter, r *http.Request) {
 	// There was no error paying the fee, but we must wait on confirmations
 	// before informing the DEX of the fee payment. Those results will come
 	// through as a notification.
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiUpdateBondOptions is the handler for the '/updatebondoptions' API request.
@@ -473,7 +473,7 @@ func (s *WebServer) apiUpdateBondOptions(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiRedeemPrepaidBond(w http.ResponseWriter, r *http.Request) {
@@ -504,7 +504,7 @@ func (s *WebServer) apiRedeemPrepaidBond(w http.ResponseWriter, r *http.Request)
 		OK:   true,
 		Tier: tier,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiNewWallet is the handler for the '/newwallet' API request.
@@ -546,7 +546,7 @@ func (s *WebServer) apiNewWallet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiRecoverWallet is the handler for the '/recoverwallet' API request. Commands
@@ -573,7 +573,7 @@ func (s *WebServer) apiRecoverWallet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiRescanWallet is the handler for the '/rescanwallet' API request. Commands
@@ -597,7 +597,7 @@ func (s *WebServer) apiRescanWallet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiOpenWallet is the handler for the '/openwallet' API request. Unlocks the
@@ -625,7 +625,7 @@ func (s *WebServer) apiOpenWallet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiNewDepositAddress gets a new deposit address from a wallet.
@@ -654,7 +654,7 @@ func (s *WebServer) apiNewDepositAddress(w http.ResponseWriter, r *http.Request)
 	}{
 		OK:      true,
 		Address: addr,
-	}, s.indent)
+	})
 }
 
 // apiConnectWallet is the handler for the '/connectwallet' API request.
@@ -672,7 +672,7 @@ func (s *WebServer) apiConnectWallet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiTrade is the handler for the '/trade' API request.
@@ -702,7 +702,7 @@ func (s *WebServer) apiTrade(w http.ResponseWriter, r *http.Request) {
 		Order: ord,
 	}
 	w.Header().Set("Connection", "close")
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiTradeAsync is the handler for the '/tradeasync' API request.
@@ -732,7 +732,7 @@ func (s *WebServer) apiTradeAsync(w http.ResponseWriter, r *http.Request) {
 		Order: ord,
 	}
 	w.Header().Set("Connection", "close")
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiAccountExport is the handler for the '/exportaccount' API request.
@@ -767,7 +767,7 @@ func (s *WebServer) apiAccountExport(w http.ResponseWriter, r *http.Request) {
 		Account: account,
 		Bonds:   bonds,
 	}
-	writeJSON(w, res, s.indent)
+	writeJSON(w, res)
 }
 
 // apiExportSeed is the handler for the '/exportseed' API request.
@@ -791,7 +791,7 @@ func (s *WebServer) apiExportSeed(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:   true,
 		Seed: seed,
-	}, s.indent)
+	})
 }
 
 // apiAccountImport is the handler for the '/importaccount' API request.
@@ -814,7 +814,7 @@ func (s *WebServer) apiAccountImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Connection", "close")
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiUpdateCert(w http.ResponseWriter, r *http.Request) {
@@ -832,7 +832,7 @@ func (s *WebServer) apiUpdateCert(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiUpdateDEXHost(w http.ResponseWriter, r *http.Request) {
@@ -867,7 +867,7 @@ func (s *WebServer) apiUpdateDEXHost(w http.ResponseWriter, r *http.Request) {
 		Exchange: exchange,
 	}
 
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiRestoreWalletInfo is the handler for the '/restorewalletinfo' API
@@ -895,7 +895,7 @@ func (s *WebServer) apiRestoreWalletInfo(w http.ResponseWriter, r *http.Request)
 		OK:              true,
 		RestorationInfo: info,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiAccountDisable is the handler for the '/disableaccount' API request.
@@ -913,7 +913,7 @@ func (s *WebServer) apiAccountDisable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Connection", "close")
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiCancel is the handler for the '/cancel' API request.
@@ -927,7 +927,7 @@ func (s *WebServer) apiCancel(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, fmt.Errorf("error cancelling order %s: %w", form.OrderID, err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiCloseWallet is the handler for the '/closewallet' API request.
@@ -944,7 +944,7 @@ func (s *WebServer) apiCloseWallet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiInit is the handler for the '/init' API request.
@@ -981,7 +981,7 @@ func (s *WebServer) apiInit(w http.ResponseWriter, r *http.Request) {
 		OK:           true,
 		Hosts:        s.knownUnregisteredExchanges(map[string]*core.Exchange{}),
 		MnemonicSeed: mnemonicSeed,
-	}, s.indent)
+	})
 }
 
 // apiIsInitialized is the handler for the '/isinitialized' request.
@@ -992,7 +992,7 @@ func (s *WebServer) apiIsInitialized(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:          true,
 		Initialized: s.core.IsInitialized(),
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiLocale(w http.ResponseWriter, r *http.Request) {
@@ -1014,7 +1014,7 @@ func (s *WebServer) apiLocale(w http.ResponseWriter, r *http.Request) {
 		resp[translationID] = t.T
 	}
 
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 func (s *WebServer) apiSetLocale(w http.ResponseWriter, r *http.Request) {
@@ -1033,7 +1033,7 @@ func (s *WebServer) apiSetLocale(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiLogin handles the 'login' API request.
@@ -1063,7 +1063,7 @@ func (s *WebServer) apiLogin(w http.ResponseWriter, r *http.Request) {
 		OK:    true,
 		Notes: notes,
 		Pokes: pokes,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiNotes(w http.ResponseWriter, r *http.Request) {
@@ -1081,7 +1081,7 @@ func (s *WebServer) apiNotes(w http.ResponseWriter, r *http.Request) {
 		OK:    true,
 		Notes: notes,
 		Pokes: pokes,
-	}, s.indent)
+	})
 }
 
 // apiLogout handles the 'logout' API request.
@@ -1104,7 +1104,7 @@ func (s *WebServer) apiLogout(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK: true,
 	}
-	writeJSON(w, response, s.indent)
+	writeJSON(w, response)
 }
 
 // apiGetBalance handles the 'balance' API request.
@@ -1127,7 +1127,7 @@ func (s *WebServer) apiGetBalance(w http.ResponseWriter, r *http.Request) {
 		OK:      true,
 		Balance: bal,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 
 }
 
@@ -1151,7 +1151,7 @@ func (s *WebServer) apiParseConfig(w http.ResponseWriter, r *http.Request) {
 		OK:  true,
 		Map: configMap,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiWalletSettings fetches the currently stored wallet configuration settings.
@@ -1173,7 +1173,7 @@ func (s *WebServer) apiWalletSettings(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:  true,
 		Map: settings,
-	}, s.indent)
+	})
 }
 
 // apiToggleWalletStatus updates the wallet's status.
@@ -1192,7 +1192,7 @@ func (s *WebServer) apiToggleWalletStatus(w http.ResponseWriter, r *http.Request
 	}{
 		OK: true,
 	}
-	writeJSON(w, response, s.indent)
+	writeJSON(w, response)
 }
 
 // apiDefaultWalletCfg attempts to load configuration settings from the
@@ -1216,7 +1216,7 @@ func (s *WebServer) apiDefaultWalletCfg(w http.ResponseWriter, r *http.Request) 
 	}{
 		OK:     true,
 		Config: cfg,
-	}, s.indent)
+	})
 }
 
 // apiOrders responds with a filtered list of user orders.
@@ -1237,7 +1237,7 @@ func (s *WebServer) apiOrders(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:     true,
 		Orders: ords,
-	}, s.indent)
+	})
 }
 
 // apiAccelerateOrder speeds up the mining of transactions in an order.
@@ -1269,7 +1269,7 @@ func (s *WebServer) apiAccelerateOrder(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:   true,
 		TxID: txID,
-	}, s.indent)
+	})
 }
 
 // apiPreAccelerate responds with information about accelerating the mining of
@@ -1292,7 +1292,7 @@ func (s *WebServer) apiPreAccelerate(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:            true,
 		PreAccelerate: preAccelerate,
-	}, s.indent)
+	})
 }
 
 // apiAccelerationEstimate responds with how much it would cost to accelerate
@@ -1319,7 +1319,7 @@ func (s *WebServer) apiAccelerationEstimate(w http.ResponseWriter, r *http.Reque
 	}{
 		OK:  true,
 		Fee: fee,
-	}, s.indent)
+	})
 }
 
 // apiOrder responds with data for an order.
@@ -1340,7 +1340,7 @@ func (s *WebServer) apiOrder(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:    true,
 		Order: ord,
-	}, s.indent)
+	})
 }
 
 // apiChangeAppPass updates the application password.
@@ -1380,7 +1380,7 @@ func (s *WebServer) apiChangeAppPass(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiResetAppPassword resets the application password.
@@ -1400,7 +1400,7 @@ func (s *WebServer) apiResetAppPassword(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiReconfig sets new configuration details for the wallet.
@@ -1437,7 +1437,7 @@ func (s *WebServer) apiReconfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiWithdraw handles the 'withdraw' API request. This end-point is Deprecated.
@@ -1484,7 +1484,7 @@ func (s *WebServer) send(w http.ResponseWriter, form *sendOrWithdrawForm) {
 		OK:   true,
 		Coin: coin.String(),
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiMaxBuy handles the 'maxbuy' API request.
@@ -1510,7 +1510,7 @@ func (s *WebServer) apiMaxBuy(w http.ResponseWriter, r *http.Request) {
 		OK:     true,
 		MaxBuy: maxBuy,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiMaxSell handles the 'maxsell' API request.
@@ -1535,7 +1535,7 @@ func (s *WebServer) apiMaxSell(w http.ResponseWriter, r *http.Request) {
 		OK:      true,
 		MaxSell: maxSell,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiPreOrder handles the 'preorder' API request.
@@ -1559,7 +1559,7 @@ func (s *WebServer) apiPreOrder(w http.ResponseWriter, r *http.Request) {
 		Estimate: est,
 	}
 
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // apiActuallyLogin logs the user in. login form private data is expected to be
@@ -1625,7 +1625,7 @@ func (s *WebServer) apiUser(w http.ResponseWriter, r *http.Request) {
 		Experimental: s.experimental,
 		MMStatus:     mmStatus,
 	}
-	writeJSON(w, response, s.indent)
+	writeJSON(w, response)
 }
 
 // apiToggleRateSource handles the /toggleratesource API request.
@@ -1642,7 +1642,7 @@ func (s *WebServer) apiToggleRateSource(w http.ResponseWriter, r *http.Request) 
 		s.writeAPIError(w, fmt.Errorf("error disabling/enabling rate source: %w", err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // apiDeleteArchiveRecords handles the '/deletearchivedrecords' API request.
@@ -1672,7 +1672,7 @@ func (s *WebServer) apiDeleteArchivedRecords(w http.ResponseWriter, r *http.Requ
 		ArchivedRecordsDeleted: nRecordsDeleted,
 		ArchivedRecordsPath:    archivedRecordsPath,
 	}
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 func (s *WebServer) apiMarketReport(w http.ResponseWriter, r *http.Request) {
@@ -1695,7 +1695,7 @@ func (s *WebServer) apiMarketReport(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:     true,
 		Report: report,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiCEXBalance(w http.ResponseWriter, r *http.Request) {
@@ -1717,7 +1717,7 @@ func (s *WebServer) apiCEXBalance(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:         true,
 		CEXBalance: bal,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiArchivedRuns(w http.ResponseWriter, r *http.Request) {
@@ -1733,7 +1733,7 @@ func (s *WebServer) apiArchivedRuns(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:   true,
 		Runs: runs,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiMMRunOverview(w http.ResponseWriter, r *http.Request) {
@@ -1757,7 +1757,7 @@ func (s *WebServer) apiMMRunOverview(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:       true,
 		Overview: overview,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiRunLogs(w http.ResponseWriter, r *http.Request) {
@@ -1783,7 +1783,7 @@ func (s *WebServer) apiRunLogs(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:   true,
 		Logs: logs,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiCEXBook(w http.ResponseWriter, r *http.Request) {
@@ -1810,7 +1810,7 @@ func (s *WebServer) apiCEXBook(w http.ResponseWriter, r *http.Request) {
 			Buys:  buys,
 			Sells: sells,
 		},
-	}, s.indent)
+	})
 
 }
 
@@ -1830,7 +1830,7 @@ func (s *WebServer) apiStakeStatus(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:     true,
 		Status: status,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiSetVSP(w http.ResponseWriter, r *http.Request) {
@@ -1845,7 +1845,7 @@ func (s *WebServer) apiSetVSP(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, fmt.Errorf("error settings vsp to %q for asset ID %d: %w", req.URL, req.AssetID, err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiPurchaseTickets(w http.ResponseWriter, r *http.Request) {
@@ -1867,7 +1867,7 @@ func (s *WebServer) apiPurchaseTickets(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, fmt.Errorf("error purchasing tickets for asset ID %d: %w", req.AssetID, err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiSetVotingPreferences(w http.ResponseWriter, r *http.Request) {
@@ -1884,7 +1884,7 @@ func (s *WebServer) apiSetVotingPreferences(w http.ResponseWriter, r *http.Reque
 		s.writeAPIError(w, fmt.Errorf("error setting voting preferences for asset ID %d: %w", req.AssetID, err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiListVSPs(w http.ResponseWriter, r *http.Request) {
@@ -1903,7 +1903,7 @@ func (s *WebServer) apiListVSPs(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:   true,
 		VSPs: vsps,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiTicketPage(w http.ResponseWriter, r *http.Request) {
@@ -1927,7 +1927,7 @@ func (s *WebServer) apiTicketPage(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:      true,
 		Tickets: tickets,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiMixingStats(w http.ResponseWriter, r *http.Request) {
@@ -1948,7 +1948,7 @@ func (s *WebServer) apiMixingStats(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:    true,
 		Stats: stats,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiConfigureMixer(w http.ResponseWriter, r *http.Request) {
@@ -1964,7 +1964,7 @@ func (s *WebServer) apiConfigureMixer(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, fmt.Errorf("error configuring mixing for %d: %w", req.AssetID, err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiStartMixer(w http.ResponseWriter, r *http.Request) {
@@ -1997,7 +1997,7 @@ func (s *WebServer) apiStartMixer(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, fmt.Errorf("error starting mixing for %d: %w", req.AssetID, err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiStopMixer(w http.ResponseWriter, r *http.Request) {
@@ -2011,7 +2011,7 @@ func (s *WebServer) apiStopMixer(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, fmt.Errorf("error stopping mixing for %d: %w", req.AssetID, err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiDisableMixer(w http.ResponseWriter, r *http.Request) {
@@ -2025,7 +2025,7 @@ func (s *WebServer) apiDisableMixer(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, fmt.Errorf("error disabling mixing for %d: %w", req.AssetID, err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiStartMarketMakingBot(w http.ResponseWriter, r *http.Request) {
@@ -2048,7 +2048,7 @@ func (s *WebServer) apiStartMarketMakingBot(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiStopMarketMakingBot(w http.ResponseWriter, r *http.Request) {
@@ -2063,7 +2063,7 @@ func (s *WebServer) apiStopMarketMakingBot(w http.ResponseWriter, r *http.Reques
 		s.writeAPIError(w, fmt.Errorf("error stopping mm bot %q: %v", form.Market, err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiUpdateCEXConfig(w http.ResponseWriter, r *http.Request) {
@@ -2078,7 +2078,7 @@ func (s *WebServer) apiUpdateCEXConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiUpdateBotConfig(w http.ResponseWriter, r *http.Request) {
@@ -2093,7 +2093,7 @@ func (s *WebServer) apiUpdateBotConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiRemoveBotConfig(w http.ResponseWriter, r *http.Request) {
@@ -2112,7 +2112,7 @@ func (s *WebServer) apiRemoveBotConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 func (s *WebServer) apiMarketMakingStatus(w http.ResponseWriter, r *http.Request) {
@@ -2122,7 +2122,7 @@ func (s *WebServer) apiMarketMakingStatus(w http.ResponseWriter, r *http.Request
 	}{
 		OK:     true,
 		Status: s.mm.Status(),
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiTxHistory(w http.ResponseWriter, r *http.Request) {
@@ -2152,7 +2152,7 @@ func (s *WebServer) apiTxHistory(w http.ResponseWriter, r *http.Request) {
 	}{
 		OK:  true,
 		Txs: txs,
-	}, s.indent)
+	})
 }
 
 func (s *WebServer) apiTakeAction(w http.ResponseWriter, r *http.Request) {
@@ -2168,7 +2168,7 @@ func (s *WebServer) apiTakeAction(w http.ResponseWriter, r *http.Request) {
 		s.writeAPIError(w, fmt.Errorf("error taking action: %w", err))
 		return
 	}
-	writeJSON(w, simpleAck(), s.indent)
+	writeJSON(w, simpleAck())
 }
 
 // writeAPIError logs the formatted error and sends a standardResponse with the
@@ -2187,7 +2187,7 @@ func (s *WebServer) writeAPIError(w http.ResponseWriter, err error) {
 		Code: code,
 	}
 	log.Error(err.Error())
-	writeJSON(w, resp, s.indent)
+	writeJSON(w, resp)
 }
 
 // setCookie sets the value of a cookie in the http response.

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -268,7 +268,6 @@ type WebServer struct {
 	csp          string
 	srv          *http.Server
 	html         atomic.Value // *templates
-	indent       bool
 	experimental bool
 
 	authMtx         sync.RWMutex
@@ -1073,21 +1072,15 @@ func fileServer(r chi.Router, pathPrefix, siteDir, subDir, forceContentType stri
 
 // writeJSON marshals the provided interface and writes the bytes to the
 // ResponseWriter. The response code is assumed to be StatusOK.
-func writeJSON(w http.ResponseWriter, thing any, indent bool) {
-	writeJSONWithStatus(w, thing, http.StatusOK, indent)
+func writeJSON(w http.ResponseWriter, thing any) {
+	writeJSONWithStatus(w, thing, http.StatusOK)
 }
 
 // writeJSON writes marshals the provided interface and writes the bytes to the
 // ResponseWriter with the specified response code.
-func writeJSONWithStatus(w http.ResponseWriter, thing any, code int, indent bool) {
+func writeJSONWithStatus(w http.ResponseWriter, thing any, code int) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	var b []byte
-	var err error
-	if indent {
-		b, err = json.MarshalIndent(thing, "", "	") // tab
-	} else {
-		b, err = json.Marshal(thing)
-	}
+	b, err := json.Marshal(thing)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Errorf("JSON encode error: %v", err)

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -1081,7 +1081,13 @@ func writeJSON(w http.ResponseWriter, thing any, indent bool) {
 // ResponseWriter with the specified response code.
 func writeJSONWithStatus(w http.ResponseWriter, thing any, code int, indent bool) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	b, err := json.Marshal(thing)
+	var b []byte
+	var err error
+	if indent {
+		b, err = json.MarshalIndent(thing, "", "	") // tab
+	} else {
+		b, err = json.Marshal(thing)
+	}
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		log.Errorf("JSON encode error: %v", err)


### PR DESCRIPTION
- Fixes an issue where a test case in `TestDeleteArchivedRecords` deals with the same file when it should have been two different files.
- Remove unused `lots` argument passed to `core.createTradeRequest`
- Ignore other unused variables
- Fix error check in `*multiRPCClient.withAll(...)`