### PR TITLE
client/dcr,btc: Ensure balance and wallet transaction results synced

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -6075,6 +6075,7 @@ func (btc *intermediaryWallet) WalletTransaction(ctx context.Context, txID strin
 		blockHeight = uint32(height)
 	}
 
+	updated := tx == nil
 	if tx == nil {
 		tx, err = btc.idUnknownTx(&ListTransactionsResult{
 			BlockHeight: blockHeight,
@@ -6086,9 +6087,17 @@ func (btc *intermediaryWallet) WalletTransaction(ctx context.Context, txID strin
 		}
 	}
 
-	tx.BlockNumber = uint64(blockHeight)
-	tx.Timestamp = gtr.BlockTime
-	tx.Confirmed = blockHeight > 0
+	if tx.BlockNumber != uint64(blockHeight) || tx.Timestamp != gtr.BlockTime {
+		tx.BlockNumber = uint64(blockHeight)
+		tx.Timestamp = gtr.BlockTime
+		tx.Confirmed = blockHeight > 0
+		updated = true
+	}
+
+	if updated {
+		btc.addTxToHistory(tx, txHash, true, false)
+	}
+
 	return tx, nil
 }
 

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -6041,14 +6041,53 @@ func (btc *intermediaryWallet) WalletTransaction(ctx context.Context, txID strin
 	}
 
 	txs, err := btc.TxHistory(1, &txID, false)
-	if err != nil {
+	if err != nil && !errors.Is(err, asset.CoinNotFoundError) {
 		return nil, err
 	}
-	if len(txs) == 0 {
-		return nil, asset.CoinNotFoundError
+
+	var tx *asset.WalletTransaction
+	if len(txs) > 0 {
+		tx = txs[0]
+	}
+	if tx == nil {
+		txHash, err := chainhash.NewHashFromStr(txID)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding txid %s: %w", txID, err)
+		}
+
+		gtr, err := btc.node.getWalletTransaction(txHash)
+		if err != nil {
+			return nil, fmt.Errorf("error getting transaction %s: %w", txID, err)
+		}
+
+		var blockHeight uint32
+		if gtr.BlockHash != "" {
+			blockHash, err := chainhash.NewHashFromStr(gtr.BlockHash)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding block hash %s: %w", gtr.BlockHash, err)
+			}
+			height, err := btc.tipRedeemer.getBlockHeight(blockHash)
+			if err != nil {
+				return nil, fmt.Errorf("error getting block height for %s: %w", blockHash, err)
+			}
+			blockHeight = uint32(height)
+		}
+
+		tx, err = btc.idUnknownTx(&ListTransactionsResult{
+			BlockHeight: blockHeight,
+			BlockTime:   gtr.BlockTime,
+			TxID:        txID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error identifying transaction: %v", err)
+		}
+
+		tx.BlockNumber = uint64(blockHeight)
+		tx.Timestamp = gtr.BlockTime
+		tx.Confirmed = blockHeight > 0
 	}
 
-	return txs[0], nil
+	return tx, nil
 }
 
 // TxHistory returns all the transactions the wallet has made. If refID is nil,

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -5892,7 +5892,7 @@ func (dcr *ExchangeWallet) idUnknownTx(ctx context.Context, tx *ListTransactions
 	}
 	msgTx, err := dcr.wallet.GetRawTransaction(ctx, txHash)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetRawTransaction error: %v", err)
 	}
 
 	var totalIn uint64
@@ -6828,44 +6828,47 @@ func (dcr *ExchangeWallet) WalletTransaction(ctx context.Context, txID string) (
 		}
 	}
 
-	txs, err := dcr.TxHistory(1, &txID, false)
+	txHistoryDB := dcr.txDB()
+	if txHistoryDB == nil {
+		return nil, fmt.Errorf("tx database not initialized")
+	}
+
+	tx, err := txHistoryDB.GetTx(txID)
 	if err != nil && !errors.Is(err, asset.CoinNotFoundError) {
 		return nil, err
 	}
-
-	var tx *asset.WalletTransaction
-	if len(txs) > 0 {
-		tx = txs[0]
+	if tx != nil && tx.Confirmed {
+		return tx, nil
 	}
 
+	txHash, err := chainhash.NewHashFromStr(txID)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding txid %s: %w", txID, err)
+	}
+	gtr, err := dcr.wallet.GetTransaction(ctx, txHash)
+	if err != nil {
+		return nil, fmt.Errorf("error getting transaction %s: %w", txID, err)
+	}
+	if len(gtr.Details) == 0 {
+		return nil, fmt.Errorf("no details found for transaction %s", txID)
+	}
+
+	var blockHeight, blockTime uint64
+	if gtr.BlockHash != "" {
+		blockHash, err := chainhash.NewHashFromStr(gtr.BlockHash)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding block hash %s: %w", gtr.BlockHash, err)
+		}
+		blockHeader, err := dcr.wallet.GetBlockHeader(ctx, blockHash)
+		if err != nil {
+			return nil, fmt.Errorf("error getting block header for block %s: %w", blockHash, err)
+		}
+		blockHeight = uint64(blockHeader.Height)
+		blockTime = uint64(blockHeader.Timestamp.Unix())
+	}
+
+	updated := tx == nil
 	if tx == nil {
-		txHash, err := chainhash.NewHashFromStr(txID)
-		if err != nil {
-			return nil, fmt.Errorf("error decoding txid %s: %w", txID, err)
-		}
-
-		gtr, err := dcr.wallet.GetTransaction(ctx, txHash)
-		if err != nil {
-			return nil, fmt.Errorf("error getting transaction %s: %w", txID, err)
-		}
-		if len(gtr.Details) == 0 {
-			return nil, fmt.Errorf("no details found for transaction %s", txID)
-		}
-
-		var blockHeight, blockTime uint64
-		if gtr.BlockHash != "" {
-			blockHash, err := chainhash.NewHashFromStr(gtr.BlockHash)
-			if err != nil {
-				return nil, fmt.Errorf("error decoding block hash %s: %w", gtr.BlockHash, err)
-			}
-			blockHeader, err := dcr.wallet.GetBlockHeader(ctx, blockHash)
-			if err != nil {
-				return nil, fmt.Errorf("error getting block header for block %s: %w", blockHash, err)
-			}
-			blockHeight = uint64(blockHeader.Height)
-			blockTime = uint64(blockHeader.Timestamp.Unix())
-		}
-
 		blockIndex := int64(blockHeight)
 		regularTx := walletjson.LTTTRegular
 		tx, err = dcr.idUnknownTx(ctx, &ListTransactionsResult{
@@ -6876,8 +6879,18 @@ func (dcr *ExchangeWallet) WalletTransaction(ctx context.Context, txID string) (
 			TxType:     &regularTx,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error identifying transaction: %v", err)
+			return nil, fmt.Errorf("xerror identifying transaction: %v", err)
 		}
+	}
+
+	if tx.BlockNumber != blockHeight || tx.Timestamp != blockTime {
+		tx.BlockNumber = blockHeight
+		tx.Timestamp = blockTime
+		updated = true
+	}
+
+	if updated {
+		dcr.addTxToHistory(tx, txHash, true)
 	}
 
 	// If the wallet knows about the transaction, it will be part of the

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -6817,7 +6817,8 @@ func float64PtrStr(v *float64) string {
 }
 
 // WalletTransaction returns a transaction that either the wallet has made or
-// one in which the wallet has received funds.
+// one in which the wallet has received funds. The txID should be either a
+// coin ID or a transaction hash in hexadecimal form.
 func (dcr *ExchangeWallet) WalletTransaction(ctx context.Context, txID string) (*asset.WalletTransaction, error) {
 	coinID, err := hex.DecodeString(txID)
 	if err == nil {
@@ -6828,18 +6829,61 @@ func (dcr *ExchangeWallet) WalletTransaction(ctx context.Context, txID string) (
 	}
 
 	txs, err := dcr.TxHistory(1, &txID, false)
-	if err != nil {
+	if err != nil && !errors.Is(err, asset.CoinNotFoundError) {
 		return nil, err
 	}
-	if len(txs) == 0 {
-		return nil, asset.CoinNotFoundError
+
+	var tx *asset.WalletTransaction
+	if len(txs) > 0 {
+		tx = txs[0]
+	}
+
+	if tx == nil {
+		txHash, err := chainhash.NewHashFromStr(txID)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding txid %s: %w", txID, err)
+		}
+
+		gtr, err := dcr.wallet.GetTransaction(ctx, txHash)
+		if err != nil {
+			return nil, fmt.Errorf("error getting transaction %s: %w", txID, err)
+		}
+		if len(gtr.Details) == 0 {
+			return nil, fmt.Errorf("no details found for transaction %s", txID)
+		}
+
+		var blockHeight, blockTime uint64
+		if gtr.BlockHash != "" {
+			blockHash, err := chainhash.NewHashFromStr(gtr.BlockHash)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding block hash %s: %w", gtr.BlockHash, err)
+			}
+			blockHeader, err := dcr.wallet.GetBlockHeader(ctx, blockHash)
+			if err != nil {
+				return nil, fmt.Errorf("error getting block header for block %s: %w", blockHash, err)
+			}
+			blockHeight = uint64(blockHeader.Height)
+			blockTime = uint64(blockHeader.Timestamp.Unix())
+		}
+
+		blockIndex := int64(blockHeight)
+		regularTx := walletjson.LTTTRegular
+		tx, err = dcr.idUnknownTx(ctx, &ListTransactionsResult{
+			TxID:       txID,
+			BlockIndex: &blockIndex,
+			BlockTime:  int64(blockTime),
+			Send:       gtr.Details[0].Category == "send",
+			TxType:     &regularTx,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error identifying transaction: %v", err)
+		}
 	}
 
 	// If the wallet knows about the transaction, it will be part of the
 	// available balance, so we always return Confirmed = true.
-	txs[0].Confirmed = true
-
-	return txs[0], nil
+	tx.Confirmed = true
+	return tx, nil
 }
 
 // TxHistory returns all the transactions the wallet has made. If refID is nil,

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -142,6 +142,11 @@ func tBackend(t *testing.T, name string, isInternal bool, blkFunc func(string)) 
 			time.Sleep(time.Second)
 		}
 	}
+
+	if nativeWallet, is := backend.(*NativeWallet); is {
+		return nativeWallet.ExchangeWallet, cm
+	}
+
 	return backend.(*ExchangeWallet), cm
 }
 
@@ -746,4 +751,174 @@ func fetchRateWithTimeout(t *testing.T, net dex.Network) {
 		t.Fatalf("error fetching %s fees: %v", net, err)
 	}
 	fmt.Printf("##### Fee rate fetched for %s! %.8f DCR/kB \n", net, feeRate)
+}
+
+func TestWalletTxBalanceSync(t *testing.T) {
+	rig := newTestRig(t, func(name string) {
+		tLogger.Infof("%s has reported a new block", name)
+	})
+	defer rig.close(t)
+
+	beta := rig.beta()
+	gamma := rig.gamma()
+
+	err := beta.Unlock(walletPassword)
+	if err != nil {
+		t.Fatalf("error unlocking beta wallet: %v", err)
+	}
+	err = gamma.Unlock(walletPassword)
+	if err != nil {
+		t.Fatalf("error unlocking gamma wallet: %v", err)
+	}
+
+	t.Run("rpc", func(t *testing.T) {
+		testWalletTxBalanceSync(t, gamma, beta)
+	})
+	t.Run("spv", func(t *testing.T) {
+		testWalletTxBalanceSync(t, beta, gamma)
+	})
+}
+
+// This tests that redemptions becoming available in the balance and the
+// asset.WalletTransaction returned from WalletTransaction becomes confirmed
+// at the same time.
+func testWalletTxBalanceSync(t *testing.T, fromWallet, toWallet *ExchangeWallet) {
+	receivingAddr, err := toWallet.DepositAddress()
+	if err != nil {
+		t.Fatalf("error getting deposit address: %v", err)
+	}
+
+	order := &asset.Order{
+		Value:         toAtoms(1),
+		FeeSuggestion: 10,
+		MaxSwapCount:  1,
+		MaxFeeRate:    20,
+	}
+	coins, _, _, err := fromWallet.FundOrder(order)
+	if err != nil {
+		t.Fatalf("error funding order: %v", err)
+	}
+
+	secret := randBytes(32)
+	secretHash := sha256.Sum256(secret)
+	contract := &asset.Contract{
+		Address:    receivingAddr,
+		Value:      order.Value,
+		SecretHash: secretHash[:],
+		LockTime:   uint64(time.Now().Add(-1 * time.Hour).Unix()),
+	}
+	swaps := &asset.Swaps{
+		Inputs:  coins,
+		FeeRate: 10,
+		Contracts: []*asset.Contract{
+			contract,
+		},
+	}
+	receipts, _, _, err := fromWallet.Swap(swaps)
+	if err != nil {
+		t.Fatalf("error swapping: %v", err)
+	}
+	receipt := receipts[0]
+
+	var auditInfo *asset.AuditInfo
+	for i := 0; i < 10; i++ {
+		auditInfo, err = toWallet.AuditContract(receipt.Coin().ID(), receipt.Contract(), []byte{}, false)
+		if err == nil {
+			break
+		}
+
+		time.Sleep(5 * time.Second)
+	}
+	if err != nil {
+		t.Fatalf("error auditing contract: %v", err)
+	}
+
+	balance, err := toWallet.Balance()
+	if err != nil {
+		t.Fatalf("error getting balance: %v", err)
+	}
+	_, out, _, err := toWallet.Redeem(&asset.RedeemForm{
+		Redemptions: []*asset.Redemption{
+			{
+				Spends: auditInfo,
+				Secret: secret,
+			},
+		},
+		FeeSuggestion: 10,
+	})
+	if err != nil {
+		t.Fatalf("error redeeming: %v", err)
+	}
+
+	confirmSync := func(originalBalance uint64, coinID []byte) error {
+		for i := 0; i < 10; i++ {
+			balance, err := toWallet.Balance()
+			if err != nil {
+				return fmt.Errorf("error getting balance: %v", err)
+			}
+			balDiff := balance.Available - originalBalance
+
+			var confirmed bool
+			var txDiff uint64
+			if wt, err := toWallet.WalletTransaction(context.Background(), hex.EncodeToString(coinID)); err == nil {
+				confirmed = wt.Confirmed
+				txDiff = wt.Amount
+				if wt.Type != asset.Receive {
+					txDiff -= wt.Fees
+				}
+			} else {
+				fmt.Printf("error getting wallet transaction: %v\n", err)
+			}
+
+			balanceChanged := balance.Available != originalBalance
+			if confirmed != balanceChanged {
+				if balanceChanged && !confirmed {
+					for j := 0; j < 20; j++ {
+						if wt, err := toWallet.WalletTransaction(context.Background(), hex.EncodeToString(coinID)); err == nil && wt.Confirmed {
+							return fmt.Errorf("num tried: %d", j)
+						} else {
+							fmt.Printf("error getting wallet transaction: %v\n", err)
+						}
+						time.Sleep(500 * time.Millisecond)
+					}
+				}
+				return fmt.Errorf("confirmed status does not match balance change. confirmed = %v, balance changed = %d", confirmed, balDiff)
+			}
+			if confirmed {
+				if balDiff != txDiff {
+					return fmt.Errorf("balance and transaction diffs do not match. balance diff = %d, tx diff = %d", balDiff, txDiff)
+				}
+				return nil
+			}
+
+			time.Sleep(5 * time.Second)
+		}
+
+		return fmt.Errorf("timed out waiting for balance and transaction to sync")
+	}
+
+	err = confirmSync(balance.Available, out.ID())
+	if err != nil {
+		t.Fatalf("error confirming sync: %v", err)
+	}
+
+	balance, err = toWallet.Balance()
+	if err != nil {
+		t.Fatalf("error getting balance: %v", err)
+	}
+
+	receivingAddr, err = toWallet.DepositAddress()
+	if err != nil {
+		t.Fatalf("error getting deposit address: %v", err)
+	}
+
+	coin, err := fromWallet.Send(receivingAddr, toAtoms(1), 10)
+	if err != nil {
+		t.Fatalf("error sending: %v", err)
+	}
+
+	err = confirmSync(balance.Available, coin.ID())
+	if err != nil {
+		t.Fatalf("error confirming sync: %v", err)
+	}
 }


### PR DESCRIPTION
This PR ensures that a caller is able to call WalletTransaction and get a result with `Confirmed == true` if and only if the effects of the transaction can be seen in the available balance. This is important for market makers to be able to accurately track balances.