### PR TITLE
client,testing: update minimum Firo & Dash version

### DIFF
--- a/client/asset/dash/dash.go
+++ b/client/asset/dash/dash.go
@@ -18,7 +18,7 @@ import (
 const (
 	version                 = 0
 	BipID                   = 5
-	minNetworkVersion       = 200000 // Dash v20.0.0, proto: 70230. Breaking change from 190200
+	minNetworkVersion       = 200101 // Dash v20.1.1
 	walletTypeRPC           = "dashdRPC"
 	defaultRedeemConfTarget = 2
 )

--- a/client/asset/firo/firo.go
+++ b/client/asset/firo/firo.go
@@ -28,8 +28,8 @@ const (
 	version = 0
 	// Zcoin XZC
 	BipID = 136
-	// Spark. Net proto 90031. Wallet version 130000
-	minNetworkVersion  = 141301
+	// Lelantus Spark. Net proto 90031. Wallet version 130000
+	minNetworkVersion  = 141302
 	walletTypeRPC      = "firodRPC"
 	walletTypeElectrum = "electrumRPC"
 	estimateFeeConfs   = 2 // 2 blocks should be enough

--- a/client/asset/firo/firo.go
+++ b/client/asset/firo/firo.go
@@ -29,7 +29,7 @@ const (
 	// Zcoin XZC
 	BipID = 136
 	// Lelantus Spark. Net proto 90031. Wallet version 130000
-	minNetworkVersion  = 141302
+	minNetworkVersion  = 141303
 	walletTypeRPC      = "firodRPC"
 	walletTypeElectrum = "electrumRPC"
 	estimateFeeConfs   = 2 // 2 blocks should be enough

--- a/dex/testing/dash/harness.sh
+++ b/dex/testing/dash/harness.sh
@@ -270,7 +270,7 @@ sleep 2
 ################################################################################
 echo "Creating alpha wallet - encrypted HD"
 
-tmux send-keys -t $SESSION:2 "./alpha createwallet \"\" false false \"${WALLET_PASSWORD}\" ${DONE}" C-m\; ${WAIT}
+tmux send-keys -t $SESSION:2 "./alpha createwallet \"\" false true \"${WALLET_PASSWORD}\" ${DONE}" C-m\; ${WAIT}
 sleep 2
 
 tmux send-keys -t $SESSION:2 "./alpha  upgradetohd \"${ALPHA_SEED_MNEMONIC}\" \"\" \"${WALLET_PASSWORD}\"${DONE}" C-m\; ${WAIT}
@@ -281,7 +281,7 @@ sleep 3
 ################################################################################
 echo "Creating beta wallet - encrypted HD"
 
-tmux send-keys -t $SESSION:2 "./beta  createwallet \"\" false false \"${WALLET_PASSWORD}\" ${DONE}" C-m\; ${WAIT}
+tmux send-keys -t $SESSION:2 "./beta  createwallet \"\" false true \"${WALLET_PASSWORD}\" ${DONE}" C-m\; ${WAIT}
 sleep 2
 
 tmux send-keys -t $SESSION:2 "./beta  upgradetohd \"${BETA_SEED_MNEMONIC}\" \"\" ${WALLET_PASSWORD}${DONE}" C-m\; ${WAIT}
@@ -292,7 +292,7 @@ sleep 3
 ################################################################################
 echo "Creating gamma wallet - encrypted HD"
 
-tmux send-keys -t $SESSION:2 "./alpha createwallet \"gamma\" false false \"${WALLET_PASSWORD}\" ${DONE}" C-m\; ${WAIT}
+tmux send-keys -t $SESSION:2 "./alpha createwallet \"gamma\" false true \"${WALLET_PASSWORD}\" ${DONE}" C-m\; ${WAIT}
 sleep 2
 
 tmux send-keys -t $SESSION:2 "./alpha -rpcwallet=\"gamma\" upgradetohd \"${GAMMA_SEED_MNEMONIC}\" \"\" \"${WALLET_PASSWORD}\"${DONE}" C-m\; ${WAIT}
@@ -303,7 +303,7 @@ sleep 3
 ################################################################################
 echo "Creating delta wallet - encrypted HD"
 
-tmux send-keys -t $SESSION:2 "./beta createwallet \"delta\" false false \"${WALLET_PASSWORD}\" ${DONE}" C-m\; ${WAIT}
+tmux send-keys -t $SESSION:2 "./beta createwallet \"delta\" false true \"${WALLET_PASSWORD}\" ${DONE}" C-m\; ${WAIT}
 sleep 3
 
 tmux send-keys -t $SESSION:2 "./beta -rpcwallet=\"delta\" upgradetohd \"${DELTA_SEED_MNEMONIC}\" \"\" \"${WALLET_PASSWORD}\"${DONE}" C-m\; ${WAIT}


### PR DESCRIPTION
	Firo: 0.14.13.3 - latest
	Dash: 20.1.1    - latest

    Note: This is a further bump of Firo from 0.14.13.2 -> 0.14.13.3 released today (Jun 19 2024)
    and marked as mandatory.

	For dash project this was not considered
	a breaking change but it broke our harness
	due to an RPC parameter change in 20.1.0.