### PR TITLE
bch: disable Bitcoin Cash SPV wallet

### DIFF
--- a/client/asset/bch/bch.go
+++ b/client/asset/bch/bch.go
@@ -82,7 +82,7 @@ var (
 		// Same as bitcoin. That's dumb.
 		UnitInfo: dexbch.UnitInfo,
 		AvailableWallets: []*asset.WalletDefinition{
-			spvWalletDefinition,
+			// spvWalletDefinition,
 			rpcWalletDefinition,
 			// electrumWalletDefinition, // getinfo RPC needs backport: https://github.com/Electron-Cash/Electron-Cash/pull/2399
 		},
@@ -93,6 +93,7 @@ var (
 
 func init() {
 	asset.Register(BipID, &Driver{})
+	asset.RegisterSPVWithdrawFunc(BipID, WithdrawSPVFunds)
 }
 
 // Driver implements asset.Driver.
@@ -103,6 +104,9 @@ var _ asset.Driver = (*Driver)(nil)
 
 // Open creates the BCH exchange wallet. Start the wallet with its Run method.
 func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
+	if cfg.Type == walletTypeSPV {
+		return nil, asset.ErrWalletTypeDisabled
+	}
 	return NewWallet(cfg, logger, network)
 }
 
@@ -178,15 +182,8 @@ func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
 // NewWallet is the exported constructor by which the DEX will import the
 // exchange wallet.
 func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
-	var cloneParams *chaincfg.Params
-	switch network {
-	case dex.Mainnet:
-		cloneParams = dexbch.MainNetParams
-	case dex.Testnet:
-		cloneParams = dexbch.TestNet4Params
-	case dex.Regtest:
-		cloneParams = dexbch.RegressionNetParams
-	default:
+	cloneParams := parseCloneParams(network)
+	if cloneParams == nil {
 		return nil, fmt.Errorf("unknown network ID %v", network)
 	}
 
@@ -303,6 +300,18 @@ func translateTx(btcTx *wire.MsgTx) (*bchwire.MsgTx, error) {
 	return bchTx, nil
 }
 
+func parseCloneParams(net dex.Network) *chaincfg.Params {
+	switch net {
+	case dex.Mainnet:
+		return dexbch.MainNetParams
+	case dex.Testnet:
+		return dexbch.TestNet4Params
+	case dex.Regtest:
+		return dexbch.RegressionNetParams
+	}
+	return nil
+}
+
 func parseChainParams(net dex.Network) (*bchchaincfg.Params, error) {
 	switch net {
 	case dex.Mainnet:
@@ -313,4 +322,49 @@ func parseChainParams(net dex.Network) (*bchchaincfg.Params, error) {
 		return &bchchaincfg.RegressionNetParams, nil
 	}
 	return nil, fmt.Errorf("unknown network ID %v", net)
+}
+
+// WithdrawSPVFunds is a function to generate a tx that spends all funds from a
+// deprecated SPV wallet.
+func WithdrawSPVFunds(ctx context.Context, walletPW []byte, recipient, dataDir string, net dex.Network, log dex.Logger) ([]byte, error) {
+	cloneParams := parseCloneParams(net)
+	if cloneParams == nil {
+		return nil, fmt.Errorf("unknown net %v", net)
+	}
+	addr, err := dexbch.DecodeCashAddress(recipient, cloneParams)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding address %q: %w", recipient, err)
+	}
+	c := make(chan asset.WalletNotification, 16)
+	cfg := &asset.WalletConfig{
+		Type:        walletTypeSPV,
+		Emit:        asset.NewWalletEmitter(c, BipID, log),
+		PeersChange: func(u uint32, err error) {},
+		DataDir:     dataDir,
+		Settings: map[string]string{
+			"apifeefallback": "true",
+			"fallbackfee":    "0.001", // = defaultFee in BCH/kB
+		},
+	}
+	wi, err := NewWallet(cfg, log, net)
+	if err != nil {
+		return nil, fmt.Errorf("error constructing wallet: %w", err)
+	}
+	w := wi.(*btc.ExchangeWalletSPV)
+
+	btcTx, err := w.WithdrawTx(ctx, walletPW, addr)
+	if err != nil {
+		return nil, fmt.Errorf("error generating withdraw tx: %w", err)
+	}
+
+	bchTx, err := translateTx(btcTx)
+	if err != nil {
+		return nil, fmt.Errorf("btc->bch wire.MsgTx translation error: %v", err)
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, bchTx.SerializeSize()))
+	if err = bchTx.Serialize(buf); err != nil {
+		return nil, fmt.Errorf("error serializing tx: %w", err)
+	}
+	return buf.Bytes(), nil
 }

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -4,6 +4,8 @@
 package asset
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -314,4 +316,24 @@ func MinimumLotSize(assetID uint32, maxFeeRate uint64) (minLotSize uint64, found
 		return 1, true
 	}
 	return m.MinLotSize(maxFeeRate), true
+}
+
+type spvWithdrawFunc func(ctx context.Context, walletPW []byte, recipient, dataDir string, net dex.Network, log dex.Logger) ([]byte, error)
+
+var spvRecovererFuncs = make(map[uint32]spvWithdrawFunc)
+
+// RegisterSPVWithdrawFunc registers the function to genreate a withdraw
+// transaction that spends funds from a deprecated SPV wallet.
+func RegisterSPVWithdrawFunc(assetID uint32, f spvWithdrawFunc) {
+	spvRecovererFuncs[assetID] = f
+}
+
+// SPVWithdrawTx generates a transaction that spends all funds from a deprecated
+// spv wallet.
+func SPVWithdrawTx(ctx context.Context, assetID uint32, walletPW []byte, recipient, dataDir string, net dex.Network, log dex.Logger) ([]byte, error) {
+	f, found := spvRecovererFuncs[assetID]
+	if !found {
+		return nil, errors.New("no withdraw function")
+	}
+	return f(ctx, walletPW, recipient, dataDir, net, log)
 }

--- a/client/cmd/bwctl/main.go
+++ b/client/cmd/bwctl/main.go
@@ -62,6 +62,7 @@ var promptPasswords = map[string][]string{
 	"multitrade":        {"App password:"},
 	"purchasetickets":   {"App password:"},
 	"startmmbot":        {"App password:"},
+	"withdrawbchspv":    {"App password"},
 }
 
 // optionalTextFiles is a map of routes to arg index for routes that should read

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -11471,3 +11471,18 @@ func (c *Core) TakeAction(assetID uint32, actionID string, actionB json.RawMessa
 	}
 	return goGetter.TakeAction(actionID, actionB)
 }
+
+// GenerateBCHRecoveryTransaction generates a tx that spends all inputs from the
+// deprecated BCH wallet to the given recipient.
+func (c *Core) GenerateBCHRecoveryTransaction(appPW []byte, recipient string) ([]byte, error) {
+	const bipID = 145
+	crypter, err := c.encryptionKey(appPW)
+	if err != nil {
+		return nil, err
+	}
+	_, walletPW, err := c.assetSeedAndPass(bipID, crypter)
+	if err != nil {
+		return nil, err
+	}
+	return asset.SPVWithdrawTx(c.ctx, bipID, walletPW, recipient, c.assetDataDirectory(bipID), c.net, c.log.SubLogger("BCH"))
+}

--- a/client/rpcserver/rpcserver.go
+++ b/client/rpcserver/rpcserver.go
@@ -93,6 +93,7 @@ type clientCore interface {
 	SetVSP(assetID uint32, addr string) error
 	PurchaseTickets(assetID uint32, pw []byte, n int) error
 	SetVotingPreferences(assetID uint32, choices, tSpendPolicy, treasuryPolicy map[string]string) error
+	GenerateBCHRecoveryTransaction(appPW []byte, recipient string) ([]byte, error)
 }
 
 // RPCServer is a single-client http and websocket server enabling a JSON

--- a/client/rpcserver/rpcserver_test.go
+++ b/client/rpcserver/rpcserver_test.go
@@ -203,6 +203,9 @@ func (c *TCore) TxHistory(assetID uint32, n int, refID *string, past bool) ([]*a
 func (c *TCore) WalletTransaction(assetID uint32, txID string) (*asset.WalletTransaction, error) {
 	return nil, nil
 }
+func (c *TCore) GenerateBCHRecoveryTransaction(appPW []byte, recipient string) ([]byte, error) {
+	return nil, nil
+}
 
 type tBookFeed struct{}
 

--- a/client/rpcserver/types.go
+++ b/client/rpcserver/types.go
@@ -249,7 +249,7 @@ func checkNArgs(params *RawParams, nPWArgs, nArgs []int) error {
 			}
 		} else {
 			if have < want[0] || have > want[1] {
-				return fmt.Errorf("%w: wanted between %d and %d argument but got %d argument", errArgs, want[0], want[1], have)
+				return fmt.Errorf("%w: wanted between %d and %d argument but got %d arguments", errArgs, want[0], want[1], have)
 			}
 		}
 		return nil
@@ -731,6 +731,13 @@ func parseSendOrWithdrawArgs(params *RawParams) (*sendOrWithdrawForm, error) {
 		address: params.Args[2],
 	}
 	return req, nil
+}
+
+func parseBchWithdrawArgs(params *RawParams) (appPW encode.PassBytes, recipient string, _ error) {
+	if err := checkNArgs(params, []int{1}, []int{1}); err != nil {
+		return nil, "", err
+	}
+	return params.PWArgs[0], params.Args[0], nil
 }
 
 func parseRescanWalletArgs(params *RawParams) (uint32, bool, error) {

--- a/dex/testing/bch/harness.sh
+++ b/dex/testing/bch/harness.sh
@@ -27,5 +27,6 @@ export GODAEMON="go run github.com/gcash/bchd@v0.19.0"
 export GOCLIENT="go run github.com/gcash/bchd/cmd/bchctl@v0.19.0"
 export OMEGA_LISTEN_PORT=21577
 export OMEGA_RPC_PORT=21558
+export EXTRA_ARGS="--expire=0"
 # Run the harness
 ../btc/base-harness.sh


### PR DESCRIPTION
[bchd](https://github.com/gcash/bchd) was the only node implementation that served filters, it's been [busted for some time](https://github.com/gcash/bchd/issues/531), and [efforts to upgrade are stalled](https://github.com/gcash/bchd/pull/528). Similarly, [efforts at gitlab.com/bitcoin-cash-node](https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node/-/issues/261) have been stalled for years.

The fact that the spv wallet hasn't worked for so long and nobody has sought support leads me to believe that nobody is using this wallet. That said, we need to provide a way for those users to move funds should they appear, so I've added an rpcserver endpoint to generate a transaction that spends all funds to another address. The transaction will need to be pasted into e.g. https://blockchair.com/broadcast/ to be broadcast. Going forward, we should work on a GUI way to handle deprecated wallets.