### PR TITLE
mm: Handle market params update

### DIFF
--- a/client/core/core.go
+++ b/client/core/core.go
@@ -8324,6 +8324,7 @@ func (c *Core) handleReconnect(host string) {
 		c.log.Errorf("handleReconnect: Unable to apply new configuration for DEX at %s: %v", host, err)
 		return
 	}
+	c.notify(newServerConfigUpdateNote(host))
 
 	type market struct { // for book re-subscribe
 		name  string

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -686,6 +686,21 @@ func newUpgradeNote(topic Topic, subject, details string, severity db.Severity) 
 	}
 }
 
+// ServerConfigUpdateNote is sent when a server's configuration is updated.
+type ServerConfigUpdateNote struct {
+	db.Notification
+	Host string `json:"host"`
+}
+
+const TopicServerConfigUpdate Topic = "ServerConfigUpdate"
+
+func newServerConfigUpdateNote(host string) *ServerConfigUpdateNote {
+	return &ServerConfigUpdateNote{
+		Notification: db.NewNotification(NoteTypeServerNotify, TopicServerConfigUpdate, "", "", db.Data),
+		Host:         host,
+	}
+}
+
 // WalletCreationNote is a notification regarding asynchronous wallet creation.
 type WalletCreationNote struct {
 	db.Notification

--- a/client/mm/config.go
+++ b/client/mm/config.go
@@ -195,13 +195,11 @@ func (c *BotConfig) updateLotSize(oldLotSize, newLotSize uint64) {
 
 func (c *BotConfig) validate() error {
 	if c.BasicMMConfig != nil {
-		return c.BasicMMConfig.Validate()
+		return c.BasicMMConfig.validate()
 	} else if c.SimpleArbConfig != nil {
-		return c.SimpleArbConfig.Validate()
+		return c.SimpleArbConfig.validate()
 	} else if c.ArbMarketMakerConfig != nil {
-		// TODO:
-		// c.ArbMarketMakerConfig.Validate()
-		return nil
+		return c.ArbMarketMakerConfig.validate()
 	}
 
 	return fmt.Errorf("no bot config set")

--- a/client/mm/exchange_adaptor_test.go
+++ b/client/mm/exchange_adaptor_test.go
@@ -507,7 +507,9 @@ func testDistribution(t *testing.T, baseID, quoteID uint32) {
 	u.clientCore = tCore
 	u.autoRebalanceCfg = &AutoRebalanceConfig{}
 	a := &arbMarketMaker{unifiedExchangeAdaptor: u}
-	a.cfgV.Store(&ArbMarketMakerConfig{Profit: profit})
+	u.botCfgV.Store(&BotConfig{
+		ArbMarketMakerConfig: &ArbMarketMakerConfig{Profit: profit},
+	})
 	fiatRates := map[uint32]float64{baseID: 1, quoteID: 1}
 	u.fiatRates.Store(fiatRates)
 
@@ -579,9 +581,16 @@ func testDistribution(t *testing.T, baseID, quoteID uint32) {
 
 	setLots := func(b, s uint64) {
 		buyLots, sellLots = b, s
-		a.placementLotsV.Store(&placementLots{
-			baseLots:  sellLots,
-			quoteLots: buyLots,
+		u.botCfgV.Store(&BotConfig{
+			ArbMarketMakerConfig: &ArbMarketMakerConfig{
+				Profit: profit,
+				BuyPlacements: []*ArbMarketMakingPlacement{
+					{Lots: buyLots, Multiplier: 1},
+				},
+				SellPlacements: []*ArbMarketMakingPlacement{
+					{Lots: sellLots, Multiplier: 1},
+				},
+			},
 		})
 		addBaseFees, addQuoteFees = sellFundingFees, buyFundingFees
 		cex.asksVWAP[lotSize*buyLots] = vwapResult{avg: buyVWAP}

--- a/client/mm/mm_arb_market_maker.go
+++ b/client/mm/mm_arb_market_maker.go
@@ -82,6 +82,57 @@ type ArbMarketMakerConfig struct {
 	NumEpochsLeaveOpen uint64                      `json:"orderPersistence"`
 }
 
+func (a *ArbMarketMakerConfig) copy() *ArbMarketMakerConfig {
+	c := *a
+
+	c.BuyPlacements = make([]*ArbMarketMakingPlacement, 0, len(a.BuyPlacements))
+	for _, p := range a.BuyPlacements {
+		c.BuyPlacements = append(c.BuyPlacements, &ArbMarketMakingPlacement{
+			Lots:       p.Lots,
+			Multiplier: p.Multiplier,
+		})
+	}
+
+	c.SellPlacements = make([]*ArbMarketMakingPlacement, 0, len(a.SellPlacements))
+	for _, p := range a.SellPlacements {
+		c.SellPlacements = append(c.SellPlacements, &ArbMarketMakingPlacement{
+			Lots:       p.Lots,
+			Multiplier: p.Multiplier,
+		})
+	}
+
+	return &c
+}
+
+// updateLotSize modifies the number of lots in each placement in the event
+// of a lot size change. It will place as many lots as possible without
+// exceeding the total quantity placed using the original lot size.
+//
+// This function is NOT thread safe.
+func (c *ArbMarketMakerConfig) updateLotSize(originalLotSize, newLotSize uint64) {
+	for _, p := range c.SellPlacements {
+		p.Lots = (p.Lots * originalLotSize) / newLotSize
+	}
+
+	for _, p := range c.BuyPlacements {
+		p.Lots = (p.Lots * originalLotSize) / newLotSize
+	}
+}
+
+func (a *ArbMarketMakerConfig) placementLots() *placementLots {
+	var baseLots, quoteLots uint64
+	for _, p := range a.BuyPlacements {
+		quoteLots += p.Lots
+	}
+	for _, p := range a.SellPlacements {
+		baseLots += p.Lots
+	}
+	return &placementLots{
+		baseLots:  baseLots,
+		quoteLots: quoteLots,
+	}
+}
+
 type placementLots struct {
 	baseLots  uint64
 	quoteLots uint64
@@ -91,8 +142,6 @@ type arbMarketMaker struct {
 	*unifiedExchangeAdaptor
 	cex              botCexAdaptor
 	core             botCoreAdaptor
-	cfgV             atomic.Value // *ArbMarketMakerConfig
-	placementLotsV   atomic.Value // *placementLots
 	book             dexOrderBook
 	rebalanceRunning atomic.Bool
 	currEpoch        atomic.Uint64
@@ -108,7 +157,7 @@ type arbMarketMaker struct {
 var _ bot = (*arbMarketMaker)(nil)
 
 func (a *arbMarketMaker) cfg() *ArbMarketMakerConfig {
-	return a.cfgV.Load().(*ArbMarketMakerConfig)
+	return a.botCfg().ArbMarketMakerConfig
 }
 
 func (a *arbMarketMaker) handleCEXTradeUpdate(update *libxc.Trade) {
@@ -201,7 +250,8 @@ func dexPlacementRate(cexRate uint64, sell bool, profitRate float64, mkt *market
 		unadjustedRate = uint64(math.Round(float64(cexRate) / (1 + profitRate)))
 	}
 
-	rateAdj := rateAdjustment(feesInQuoteUnits, mkt.lotSize)
+	lotSize, rateStep := mkt.lotSize.Load(), mkt.rateStep.Load()
+	rateAdj := rateAdjustment(feesInQuoteUnits, lotSize)
 
 	if log.Level() <= dex.LevelTrace {
 		log.Tracef("%s %s placement rate: cexRate = %s, profitRate = %.3f, unadjustedRate = %s, rateAdj = %s, fees = %s",
@@ -210,14 +260,14 @@ func dexPlacementRate(cexRate uint64, sell bool, profitRate float64, mkt *market
 	}
 
 	if sell {
-		return steppedRate(unadjustedRate+rateAdj, mkt.rateStep), nil
+		return steppedRate(unadjustedRate+rateAdj, rateStep), nil
 	}
 
 	if rateAdj > unadjustedRate {
 		return 0, fmt.Errorf("rate adjustment required for fees %d > rate %d", rateAdj, unadjustedRate)
 	}
 
-	return steppedRate(unadjustedRate-rateAdj, mkt.rateStep), nil
+	return steppedRate(unadjustedRate-rateAdj, rateStep), nil
 }
 
 func rateAdjustment(feesInQuoteUnits, lotSize uint64) uint64 {
@@ -246,7 +296,7 @@ func (a *arbMarketMaker) ordersToPlace() (buys, sells []*TradePlacement, err err
 		newPlacements := make([]*TradePlacement, 0, len(cfgPlacements))
 		var cumulativeCEXDepth uint64
 		for i, cfgPlacement := range cfgPlacements {
-			cumulativeCEXDepth += uint64(float64(cfgPlacement.Lots*a.lotSize) * cfgPlacement.Multiplier)
+			cumulativeCEXDepth += uint64(float64(cfgPlacement.Lots*a.lotSize.Load()) * cfgPlacement.Multiplier)
 			_, extrema, filled, err := a.CEX.VWAP(a.baseID, a.quoteID, sellOnDEX, cumulativeCEXDepth)
 			if err != nil {
 				return nil, fmt.Errorf("error getting CEX VWAP: %w", err)
@@ -291,11 +341,7 @@ func (a *arbMarketMaker) ordersToPlace() (buys, sells []*TradePlacement, err err
 // distribution parses the current inventory distribution and checks if better
 // distributions are possible via deposit or withdrawal.
 func (a *arbMarketMaker) distribution() (dist *distribution, err error) {
-	cfgI := a.placementLotsV.Load()
-	if cfgI == nil {
-		return nil, errors.New("no placements?")
-	}
-	placements := cfgI.(*placementLots)
+	placements := a.cfg().placementLots()
 	if placements.baseLots == 0 && placements.quoteLots == 0 {
 		return nil, errors.New("zero placement lots?")
 	}
@@ -429,7 +475,7 @@ func feeGap(core botCoreAdaptor, cex libxc.CEX, baseID, quoteID uint32, lotSize 
 }
 
 func (a *arbMarketMaker) registerFeeGap() {
-	feeGap, err := feeGap(a.core, a.CEX, a.baseID, a.quoteID, a.lotSize)
+	feeGap, err := feeGap(a.core, a.CEX, a.baseID, a.quoteID, a.lotSize.Load())
 	if err != nil {
 		a.log.Warnf("error getting fee-gap stats: %v", err)
 		return
@@ -508,31 +554,6 @@ func (a *arbMarketMaker) botLoop(ctx context.Context) (*sync.WaitGroup, error) {
 	return &wg, nil
 }
 
-func (a *arbMarketMaker) setTransferConfig(cfg *ArbMarketMakerConfig) {
-	var baseLots, quoteLots uint64
-	for _, p := range cfg.BuyPlacements {
-		quoteLots += p.Lots
-	}
-	for _, p := range cfg.SellPlacements {
-		baseLots += p.Lots
-	}
-	a.placementLotsV.Store(&placementLots{
-		baseLots:  baseLots,
-		quoteLots: quoteLots,
-	})
-}
-
-func (a *arbMarketMaker) updateConfig(cfg *BotConfig) error {
-	if cfg.ArbMarketMakerConfig == nil {
-		return errors.New("no arb market maker config provided")
-	}
-
-	a.cfgV.Store(cfg.ArbMarketMakerConfig)
-	a.setTransferConfig(cfg.ArbMarketMakerConfig)
-	a.unifiedExchangeAdaptor.updateConfig(cfg)
-	return nil
-}
-
 func newArbMarketMaker(cfg *BotConfig, adaptorCfg *exchangeAdaptorCfg, log dex.Logger) (*arbMarketMaker, error) {
 	if cfg.ArbMarketMakerConfig == nil {
 		// implies bug in caller
@@ -554,8 +575,5 @@ func newArbMarketMaker(cfg *BotConfig, adaptorCfg *exchangeAdaptorCfg, log dex.L
 	}
 
 	adaptor.setBotLoop(arbMM.botLoop)
-
-	arbMM.cfgV.Store(cfg.ArbMarketMakerConfig)
-	arbMM.setTransferConfig(cfg.ArbMarketMakerConfig)
 	return arbMM, nil
 }

--- a/client/mm/mm_basic.go
+++ b/client/mm/mm_basic.go
@@ -78,7 +78,7 @@ func needBreakEvenHalfSpread(strat GapStrategy) bool {
 	return strat == GapStrategyAbsolutePlus || strat == GapStrategyPercentPlus || strat == GapStrategyMultiplier
 }
 
-func (c *BasicMarketMakingConfig) Validate() error {
+func (c *BasicMarketMakingConfig) validate() error {
 	if c.DriftTolerance == 0 {
 		c.DriftTolerance = 0.001
 	}
@@ -142,23 +142,15 @@ func (c *BasicMarketMakingConfig) Validate() error {
 func (c *BasicMarketMakingConfig) copy() *BasicMarketMakingConfig {
 	cfg := *c
 
-	sellPlacements := make([]*OrderPlacement, 0, len(c.SellPlacements))
-	for _, p := range c.SellPlacements {
-		sellPlacements = append(sellPlacements, &OrderPlacement{
+	copyOrderPlacement := func(p *OrderPlacement) *OrderPlacement {
+		return &OrderPlacement{
 			Lots:      p.Lots,
 			GapFactor: p.GapFactor,
-		})
+		}
 	}
-	cfg.SellPlacements = sellPlacements
 
-	buyPlacements := make([]*OrderPlacement, 0, len(c.BuyPlacements))
-	for _, p := range c.BuyPlacements {
-		buyPlacements = append(buyPlacements, &OrderPlacement{
-			Lots:      p.Lots,
-			GapFactor: p.GapFactor,
-		})
-	}
-	cfg.BuyPlacements = buyPlacements
+	cfg.SellPlacements = utils.Map(c.SellPlacements, copyOrderPlacement)
+	cfg.BuyPlacements = utils.Map(c.BuyPlacements, copyOrderPlacement)
 
 	return &cfg
 }
@@ -508,7 +500,7 @@ func newBasicMarketMaker(cfg *BotConfig, adaptorCfg *exchangeAdaptorCfg, oracle 
 		return nil, fmt.Errorf("error constructing exchange adaptor: %w", err)
 	}
 
-	err = cfg.BasicMMConfig.Validate()
+	err = cfg.BasicMMConfig.validate()
 	if err != nil {
 		return nil, fmt.Errorf("invalid market making config: %v", err)
 	}

--- a/client/mm/mm_basic_test.go
+++ b/client/mm/mm_basic_test.go
@@ -176,6 +176,72 @@ func TestBreakEvenHalfSpread(t *testing.T) {
 	}
 }
 
+func TestUpdateLotSize(t *testing.T) {
+	tests := []struct {
+		name           string
+		placements     []*OrderPlacement
+		originalSize   uint64
+		newSize        uint64
+		wantPlacements []*OrderPlacement
+	}{
+		{
+			name: "simple halving",
+			placements: []*OrderPlacement{
+				{Lots: 2, GapFactor: 1.0},
+				{Lots: 4, GapFactor: 2.0},
+			},
+			originalSize: 100,
+			newSize:      200,
+			wantPlacements: []*OrderPlacement{
+				{Lots: 1, GapFactor: 1.0},
+				{Lots: 2, GapFactor: 2.0},
+			},
+		},
+		{
+			name: "rounding up",
+			placements: []*OrderPlacement{
+				{Lots: 3, GapFactor: 1.0},
+				{Lots: 1, GapFactor: 1.0},
+			},
+			originalSize: 100,
+			newSize:      160,
+			wantPlacements: []*OrderPlacement{
+				{Lots: 2, GapFactor: 1.0},
+			},
+		},
+		{
+			name: "minimum 1 lot",
+			placements: []*OrderPlacement{
+				{Lots: 1, GapFactor: 1.0},
+				{Lots: 1, GapFactor: 1.0},
+				{Lots: 1, GapFactor: 1.0},
+			},
+			originalSize: 100,
+			newSize:      250,
+			wantPlacements: []*OrderPlacement{
+				{Lots: 1, GapFactor: 1.0},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := updateLotSize(tt.placements, tt.originalSize, tt.newSize)
+			if len(got) != len(tt.wantPlacements) {
+				t.Fatalf("got %d placements, want %d", len(got), len(tt.wantPlacements))
+			}
+			for i := range got {
+				if got[i].Lots != tt.wantPlacements[i].Lots {
+					t.Errorf("placement %d: got %d lots, want %d", i, got[i].Lots, tt.wantPlacements[i].Lots)
+				}
+				if got[i].GapFactor != tt.wantPlacements[i].GapFactor {
+					t.Errorf("placement %d: got %f gap factor, want %f", i, got[i].GapFactor, tt.wantPlacements[i].GapFactor)
+				}
+			}
+		})
+	}
+}
+
 func TestBasicMMRebalance(t *testing.T) {
 	const basisPrice uint64 = 5e6
 	const halfSpread uint64 = 2e5

--- a/client/mm/mm_basic_test.go
+++ b/client/mm/mm_basic_test.go
@@ -365,11 +365,13 @@ func TestBasicMMRebalance(t *testing.T) {
 			mm.baseCexBalances[baseID] = lotSize * 50
 			mm.baseDexBalances[quoteID] = int64(calc.BaseToQuote(basisPrice, lotSize*50))
 			mm.baseCexBalances[quoteID] = int64(calc.BaseToQuote(basisPrice, lotSize*50))
-			mm.cfgV.Store(&BasicMarketMakingConfig{
-				GapStrategy:    tt.strategy,
-				BuyPlacements:  tt.cfgBuyPlacements,
-				SellPlacements: tt.cfgSellPlacements,
-			})
+			mm.unifiedExchangeAdaptor.botCfgV.Store(&BotConfig{
+				BasicMMConfig: &BasicMarketMakingConfig{
+					GapStrategy:    tt.strategy,
+					BuyPlacements:  tt.cfgBuyPlacements,
+					SellPlacements: tt.cfgSellPlacements,
+				}})
+
 			mm.rebalance(100)
 
 			if len(tcore.multiTradesPlaced) != 2 {

--- a/client/mm/mm_simple_arb.go
+++ b/client/mm/mm_simple_arb.go
@@ -43,7 +43,7 @@ func (c *SimpleArbConfig) copy() *SimpleArbConfig {
 	}
 }
 
-func (c *SimpleArbConfig) Validate() error {
+func (c *SimpleArbConfig) validate() error {
 	if c.ProfitTrigger <= 0 || c.ProfitTrigger > 1 {
 		return fmt.Errorf("profit trigger must be 0 < t <= 1, but got %v", c.ProfitTrigger)
 	}

--- a/client/mm/mm_simple_arb.go
+++ b/client/mm/mm_simple_arb.go
@@ -35,6 +35,14 @@ type SimpleArbConfig struct {
 	NumEpochsLeaveOpen uint32 `json:"numEpochsLeaveOpen"`
 }
 
+func (c *SimpleArbConfig) copy() *SimpleArbConfig {
+	return &SimpleArbConfig{
+		ProfitTrigger:      c.ProfitTrigger,
+		MaxActiveArbs:      c.MaxActiveArbs,
+		NumEpochsLeaveOpen: c.NumEpochsLeaveOpen,
+	}
+}
+
 func (c *SimpleArbConfig) Validate() error {
 	if c.ProfitTrigger <= 0 || c.ProfitTrigger > 1 {
 		return fmt.Errorf("profit trigger must be 0 < t <= 1, but got %v", c.ProfitTrigger)
@@ -67,7 +75,6 @@ type simpleArbMarketMaker struct {
 	*unifiedExchangeAdaptor
 	cex              botCexAdaptor
 	core             botCoreAdaptor
-	cfgV             atomic.Value // *SimpleArbConfig
 	book             dexOrderBook
 	rebalanceRunning atomic.Bool
 
@@ -78,7 +85,7 @@ type simpleArbMarketMaker struct {
 var _ bot = (*simpleArbMarketMaker)(nil)
 
 func (a *simpleArbMarketMaker) cfg() *SimpleArbConfig {
-	return a.cfgV.Load().(*SimpleArbConfig)
+	return a.botCfg().SimpleArbConfig
 }
 
 // arbExists checks if an arbitrage opportunity exists.
@@ -101,11 +108,11 @@ func (a *simpleArbMarketMaker) arbExists() (exists, sellOnDex bool, lotsToArb, d
 // arbExistsOnSide checks if an arbitrage opportunity exists either when
 // buying or selling on the dex.
 func (a *simpleArbMarketMaker) arbExistsOnSide(sellOnDEX bool) (exists bool, lotsToArb, dexRate, cexRate uint64, err error) {
-	lotSize := a.lotSize
+	lotSize := a.lotSize.Load()
 	var prevProfit uint64
 
 	for numLots := uint64(1); ; numLots++ {
-		dexAvg, dexExtrema, dexFilled, err := a.book.VWAP(numLots, a.lotSize, !sellOnDEX)
+		dexAvg, dexExtrema, dexFilled, err := a.book.VWAP(numLots, lotSize, !sellOnDEX)
 		if err != nil {
 			return false, 0, 0, 0, fmt.Errorf("error calculating dex VWAP: %w", err)
 		}
@@ -207,6 +214,8 @@ func (a *simpleArbMarketMaker) executeArb(sellOnDex bool, lotsToArb, dexRate, ce
 	}
 	// also check self-match on CEX?
 
+	lotSize := a.lotSize.Load()
+
 	// Hold the lock for this entire process because updates to the cex trade
 	// may come even before the Trade function has returned, and in order to
 	// be able to process them, the new arbSequence struct must already be in
@@ -215,13 +224,13 @@ func (a *simpleArbMarketMaker) executeArb(sellOnDex bool, lotsToArb, dexRate, ce
 	defer a.activeArbsMtx.Unlock()
 
 	// Place cex order first. If placing dex order fails then can freely cancel cex order.
-	cexTrade, err := a.cex.CEXTrade(a.ctx, a.baseID, a.quoteID, !sellOnDex, cexRate, lotsToArb*a.lotSize)
+	cexTrade, err := a.cex.CEXTrade(a.ctx, a.baseID, a.quoteID, !sellOnDex, cexRate, lotsToArb*lotSize)
 	if err != nil {
 		a.log.Errorf("error placing cex order: %v", err)
 		return
 	}
 
-	dexOrder, err := a.core.DEXTrade(dexRate, lotsToArb*a.lotSize, sellOnDex)
+	dexOrder, err := a.core.DEXTrade(dexRate, lotsToArb*lotSize, sellOnDex)
 	if err != nil {
 		if err != nil {
 			a.log.Errorf("error placing dex order: %v", err)
@@ -426,14 +435,15 @@ func (a *simpleArbMarketMaker) distribution() (dist *distribution, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting converted fees: %w", err)
 	}
-	adj := float64(sellFeesInBase)/float64(a.lotSize) + a.cfg().ProfitTrigger
-	sellRate := steppedRate(uint64(math.Round(float64(sellVWAP)*(1+adj))), a.rateStep)
+	lotSize, rateStep := a.lotSize.Load(), a.rateStep.Load()
+	adj := float64(sellFeesInBase)/float64(lotSize) + a.cfg().ProfitTrigger
+	sellRate := steppedRate(uint64(math.Round(float64(sellVWAP)*(1+adj))), rateStep)
 	buyFeesInBase, err := a.OrderFeesInUnits(false, true, buyVWAP)
 	if err != nil {
 		return nil, fmt.Errorf("error getting converted fees: %w", err)
 	}
-	adj = float64(buyFeesInBase)/float64(a.lotSize) + a.cfg().ProfitTrigger
-	buyRate := steppedRate(uint64(math.Round(float64(buyVWAP)/(1+adj))), a.rateStep)
+	adj = float64(buyFeesInBase)/float64(lotSize) + a.cfg().ProfitTrigger
+	buyRate := steppedRate(uint64(math.Round(float64(buyVWAP)/(1+adj))), rateStep)
 	perLot, err := a.lotCosts(sellRate, buyRate)
 	if perLot == nil {
 		return nil, fmt.Errorf("error getting lot costs: %w", err)
@@ -521,21 +531,12 @@ func (a *simpleArbMarketMaker) botLoop(ctx context.Context) (*sync.WaitGroup, er
 }
 
 func (a *simpleArbMarketMaker) registerFeeGap() {
-	feeGap, err := feeGap(a.core, a.CEX, a.baseID, a.quoteID, a.lotSize)
+	feeGap, err := feeGap(a.core, a.CEX, a.baseID, a.quoteID, a.lotSize.Load())
 	if err != nil {
 		a.log.Warnf("error getting fee-gap stats: %v", err)
 		return
 	}
 	a.unifiedExchangeAdaptor.registerFeeGap(feeGap)
-}
-
-func (a *simpleArbMarketMaker) updateConfig(cfg *BotConfig) error {
-	if cfg.SimpleArbConfig == nil {
-		// implies bug in caller
-		return fmt.Errorf("no arb config provided")
-	}
-	a.cfgV.Store(cfg.SimpleArbConfig)
-	return nil
 }
 
 func newSimpleArbMarketMaker(cfg *BotConfig, adaptorCfg *exchangeAdaptorCfg, log dex.Logger) (*simpleArbMarketMaker, error) {
@@ -555,7 +556,6 @@ func newSimpleArbMarketMaker(cfg *BotConfig, adaptorCfg *exchangeAdaptorCfg, log
 		core:                   adaptor,
 		activeArbs:             make([]*arbSequence, 0),
 	}
-	simpleArb.cfgV.Store(cfg.SimpleArbConfig)
 	adaptor.setBotLoop(simpleArb.botLoop)
 	return simpleArb, nil
 }

--- a/client/mm/mm_simple_arb_test.go
+++ b/client/mm/mm_simple_arb_test.go
@@ -544,10 +544,12 @@ func TestArbRebalance(t *testing.T) {
 				BookingFeesPerLot: sellSwapFees,
 			}
 			// arbEngine.setBotLoop(arbEngine.botLoop)
-			a.cfgV.Store(&SimpleArbConfig{
-				ProfitTrigger:      profitTrigger,
-				MaxActiveArbs:      maxActiveArbs,
-				NumEpochsLeaveOpen: numEpochsLeaveOpen,
+			a.unifiedExchangeAdaptor.botCfgV.Store(&BotConfig{
+				SimpleArbConfig: &SimpleArbConfig{
+					ProfitTrigger:      profitTrigger,
+					MaxActiveArbs:      maxActiveArbs,
+					NumEpochsLeaveOpen: numEpochsLeaveOpen,
+				},
 			})
 			a.book = orderBook
 			a.rebalance(currEpoch)
@@ -698,11 +700,14 @@ func TestArbDexTradeUpdates(t *testing.T) {
 		arbEngine.CEX = newTCEX()
 		arbEngine.ctx = ctx
 		arbEngine.setBotLoop(arbEngine.botLoop)
-		arbEngine.cfgV.Store(&SimpleArbConfig{
-			ProfitTrigger:      0.01,
-			MaxActiveArbs:      5,
-			NumEpochsLeaveOpen: 10,
+		arbEngine.unifiedExchangeAdaptor.botCfgV.Store(&BotConfig{
+			SimpleArbConfig: &SimpleArbConfig{
+				ProfitTrigger:      0.01,
+				MaxActiveArbs:      5,
+				NumEpochsLeaveOpen: 10,
+			},
 		})
+
 		err := arbEngine.runBotLoop(ctx)
 		if err != nil {
 			t.Fatalf("%s: Connect error: %v", test.name, err)
@@ -820,10 +825,12 @@ func TestCexTradeUpdates(t *testing.T) {
 		arbEngine.ctx = ctx
 		arbEngine.CEX = newTCEX()
 		arbEngine.setBotLoop(arbEngine.botLoop)
-		arbEngine.cfgV.Store(&SimpleArbConfig{
-			ProfitTrigger:      0.01,
-			MaxActiveArbs:      5,
-			NumEpochsLeaveOpen: 10,
+		arbEngine.unifiedExchangeAdaptor.botCfgV.Store(&BotConfig{
+			SimpleArbConfig: &SimpleArbConfig{
+				ProfitTrigger:      0.01,
+				MaxActiveArbs:      5,
+				NumEpochsLeaveOpen: 10,
+			},
 		})
 
 		err := arbEngine.runBotLoop(ctx)

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -884,7 +884,7 @@ func handleStartBot(s *RPCServer, params *RawParams) *msgjson.ResponsePayload {
 		return usage(startBotRoute, err)
 	}
 
-	err = s.mm.StartBot(&mm.StartConfig{MarketWithHost: *form.mkt}, &form.cfgFilePath, form.appPass)
+	err = s.mm.StartBot(&mm.StartConfig{MarketWithHost: *form.mkt}, &form.cfgFilePath, form.appPass, true)
 	if err != nil {
 		resErr := msgjson.NewError(msgjson.RPCStartMarketMakingError, "unable to start market making: %v", err)
 		return createResponse(startBotRoute, nil, resErr)

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1913,7 +1913,7 @@ func (s *WebServer) apiStartMarketMakingBot(w http.ResponseWriter, r *http.Reque
 		s.writeAPIError(w, errors.New("config missing"))
 		return
 	}
-	if err = s.mm.StartBot(form.Config, nil, appPW); err != nil {
+	if err = s.mm.StartBot(form.Config, nil, appPW, true); err != nil {
 		s.writeAPIError(w, fmt.Errorf("error starting market making: %v", err))
 		return
 	}

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -2145,7 +2145,7 @@ func (m *TMarketMaker) MarketReport(host string, baseID, quoteID uint32) (*mm.Ma
 	}, nil
 }
 
-func (m *TMarketMaker) StartBot(startCfg *mm.StartConfig, alternateConfigPath *string, appPW []byte) (err error) {
+func (m *TMarketMaker) StartBot(startCfg *mm.StartConfig, alternateConfigPath *string, appPW []byte, overrideLotSizeUpdate bool) (err error) {
 	m.runningBotsMtx.Lock()
 	defer m.runningBotsMtx.Unlock()
 

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -176,7 +176,7 @@ type clientCore interface {
 
 type MMCore interface {
 	MarketReport(host string, base, quote uint32) (*mm.MarketReport, error)
-	StartBot(mkt *mm.StartConfig, alternateConfigPath *string, pw []byte) (err error)
+	StartBot(mkt *mm.StartConfig, alternateConfigPath *string, pw []byte, overrideLotSizeChange bool) (err error)
 	StopBot(mkt *mm.MarketWithHost) error
 	UpdateCEXConfig(updatedCfg *mm.CEXConfig) error
 	CEXBalance(cexName string, assetID uint32) (*libxc.ExchangeBalance, error)

--- a/dex/utils/generics.go
+++ b/dex/utils/generics.go
@@ -35,6 +35,14 @@ func MapKeys[K comparable, V any](m map[K]V) []K {
 	return ks
 }
 
+func Map[F any, T any](s []F, f func(F) T) []T {
+	r := make([]T, len(s))
+	for i, v := range s {
+		r[i] = f(v)
+	}
+	return r
+}
+
 func SafeSub[I constraints.Unsigned](a I, b I) I {
 	if a < b {
 		return 0


### PR DESCRIPTION
This diff updates the market maker to listen for updates to the server config. If the lot size of a market that a bot is currently trading on is updated, the number of placements that the bot makes is updated so that the bot places as many lots as possible without exceeding the amount that was placed before the lot size update.

Additionally, the lot size is now saved with the `BotConfig`. An additional `overrideLotSizeChange` parameter is added to `StartBot`, which if false, will return an error if the lot size has changed since the bot was configured. This will allow the UI to prompt the user to either update their configuration, or continue with the old one even though the lot size has changed.