### PR TITLE
server/btc: use external fee rates

### DIFF
--- a/dex/dexnet/http.go
+++ b/dex/dexnet/http.go
@@ -18,6 +18,7 @@ const defaultResponseSizeLimit = 1 << 20 // 1 MiB = 1,048,576 bytes
 type RequestOption struct {
 	responseSizeLimit int64
 	statusFunc        func(int)
+	header            *[2]string
 }
 
 // WithSizeLimit sets a size limit for a response. See defaultResponseSizeLimit
@@ -30,6 +31,12 @@ func WithSizeLimit(limit int64) *RequestOption {
 // performed.
 func WithStatusFunc(f func(int)) *RequestOption {
 	return &RequestOption{statusFunc: f}
+}
+
+// WithRequestHeader adds a header entry to the request.
+func WithRequestHeader(k, v string) *RequestOption {
+	h := [2]string{k, v}
+	return &RequestOption{header: &h}
 }
 
 // Post peforms an HTTP POST request. If thing is non-nil, the response will
@@ -66,6 +73,10 @@ func Do(req *http.Request, thing interface{}, opts ...*RequestOption) error {
 			sizeLimit = opt.responseSizeLimit
 		case opt.statusFunc != nil:
 			statusFunc = opt.statusFunc
+		case opt.header != nil:
+			h := *opt.header
+			k, v := h[0], h[1]
+			req.Header.Add(k, v)
 		}
 	}
 	resp, err := http.DefaultClient.Do(req)

--- a/dex/logging.go
+++ b/dex/logging.go
@@ -68,14 +68,13 @@ type logger struct {
 // exists in the levels map, use that level, otherwise the parent's log level is
 // used.
 func (lggr *logger) SubLogger(name string) Logger {
-	combinedName := fmt.Sprintf("%s[%s]", lggr.name, name)
-	return lggr.newLoggerWithBackend(lggr.backend, combinedName)
+	return lggr.newLoggerWithBackend(lggr.backend, name)
 }
 
 // FileLogger creates a logger that logs to a file rotator. Subloggers will also
 // log to the file only.
 func (lggr *logger) FileLogger(r *rotator.Rotator) Logger {
-	return lggr.newLoggerWithBackend(slog.NewBackend(r), lggr.name)
+	return lggr.newLoggerWithBackend(slog.NewBackend(r), "F")
 }
 
 func (lggr *logger) newLoggerWithBackend(backend *slog.Backend, name string) *logger {
@@ -85,11 +84,12 @@ func (lggr *logger) newLoggerWithBackend(backend *slog.Backend, name string) *lo
 		level = lvl
 	}
 
-	newLggr := backend.Logger(name)
+	combinedName := fmt.Sprintf("%s[%s]", lggr.name, name)
+	newLggr := backend.Logger(combinedName)
 	newLggr.SetLevel(level)
 	return &logger{
 		Logger:  newLggr,
-		name:    name,
+		name:    combinedName,
 		level:   level,
 		levels:  lggr.levels,
 		backend: backend,

--- a/dex/txfee/feefetcher.go
+++ b/dex/txfee/feefetcher.go
@@ -14,8 +14,9 @@ import (
 	"decred.org/dcrdex/dex/utils"
 )
 
-// FeeFetchFunc is a function that fetches a fee rate. If an error encountered
-// the FeeFetchFunc will indicate how long to wait until trying again.
+// FeeFetchFunc is a function that fetches a fee rate. If an error is
+// encountered the FeeFetchFunc will indicate how long to wait until trying
+// again.
 type FeeFetchFunc func(ctx context.Context) (rate uint64, errDelay time.Duration, err error)
 
 // SourceConfig defines a fee rate source.
@@ -159,7 +160,7 @@ func (f *FeeFetcher) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		defer cancel()
 		r, errDelay, err := src.F(ctx)
 		if err != nil {
-			src.log.Meter("fetch-error", time.Minute*30).Error("Fetch error: %v", err)
+			src.log.Meter("fetch-error", time.Minute*30).Errorf("Fetch error: %v", err)
 			src.failUntil = time.Now().Add(utils.Max(minFeeFetchErrorDelay, errDelay))
 			return false
 		}

--- a/dex/txfee/feefetcher.go
+++ b/dex/txfee/feefetcher.go
@@ -1,0 +1,223 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package txfee
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/utils"
+)
+
+// FeeFetchFunc is a function that fetches a fee rate. If an error encountered
+// the FeeFetchFunc will indicate how long to wait until trying again.
+type FeeFetchFunc func(ctx context.Context) (rate uint64, errDelay time.Duration, err error)
+
+// SourceConfig defines a fee rate source.
+type SourceConfig struct {
+	F      FeeFetchFunc
+	Name   string
+	Period time.Duration
+	// Rank controls which priority group the source is in. Lower Rank is higher
+	// priority. Fee rates from similarly-ranked sources are grouped together
+	// for a composite rate. Lower-ranked groups are not considered at all
+	// until all sources from higher ranked groups are error or expired.
+	Rank uint
+}
+
+type feeFetchSource struct {
+	*SourceConfig
+
+	log       dex.Logger
+	rate      uint64
+	stamp     time.Time
+	failUntil time.Time
+}
+
+type FeeFetcher struct {
+	log     dex.Logger
+	c       chan uint64
+	sources [][]*feeFetchSource
+}
+
+func groupedSources(sources []*SourceConfig, log dex.Logger) [][]*feeFetchSource {
+	srcs := make([]*feeFetchSource, len(sources))
+	for i, cfg := range sources {
+		srcs[i] = &feeFetchSource{SourceConfig: cfg, log: log.SubLogger(cfg.Name)}
+	}
+	return groupSources(srcs)
+}
+
+func groupSources(sources []*feeFetchSource) [][]*feeFetchSource {
+	groupedSources := make([][]*feeFetchSource, 0)
+next:
+	for _, src := range sources {
+		for i, group := range groupedSources {
+			if group[0].Rank == src.Rank {
+				groupedSources[i] = append(group, src)
+				continue next
+			}
+		}
+		groupedSources = append(groupedSources, []*feeFetchSource{src})
+	}
+	sort.Slice(groupedSources, func(i, j int) bool {
+		return groupedSources[i][0].Rank < groupedSources[j][0].Rank
+	})
+	return groupedSources
+}
+
+// NewFeeFetcher creates and returns a new FeeFetcher.
+func NewFeeFetcher(sources []*SourceConfig, log dex.Logger) *FeeFetcher {
+	return &FeeFetcher{
+		log:     log,
+		sources: groupedSources(sources, log),
+		c:       make(chan uint64, 1),
+	}
+}
+
+const (
+	feeFetchTimeout       = time.Second * 10
+	feeFetchDefaultTick   = time.Minute
+	minFeeFetchErrorDelay = time.Minute
+	// Fees are fully weighted for 5 minutes, then the weight decays to zero
+	// over the next 10 minutes. Fee rates older than 15 minutes are not
+	// considered valid.
+	feeFetchFullValidityPeriod  = time.Minute * 5
+	feeFetchValidityDecayPeriod = time.Minute * 10
+	feeExpiration               = feeFetchFullValidityPeriod + feeFetchValidityDecayPeriod
+)
+
+func prioritizedFeeRate(sources [][]*feeFetchSource) uint64 {
+	for _, group := range sources {
+		var weightedRate float64
+		var weight float64
+		for _, src := range group {
+			age := time.Since(src.stamp)
+			if !src.failUntil.IsZero() || age >= feeExpiration {
+				continue
+			}
+			if age < feeFetchFullValidityPeriod {
+				weight += 1
+				weightedRate += float64(src.rate)
+				continue
+			}
+			decayAge := age - feeFetchFullValidityPeriod
+			w := 1 - (float64(decayAge) / float64(feeFetchValidityDecayPeriod))
+			weight += w
+			weightedRate += w * float64(src.rate)
+		}
+		if weightedRate != 0 {
+			return utils.Max(1, uint64(math.Round(weightedRate/weight)))
+		}
+	}
+	return 0
+}
+
+func nextSource(sources [][]*feeFetchSource) (src *feeFetchSource, delay time.Duration) {
+	delay = time.Duration(math.MaxInt64)
+	for _, group := range sources {
+		for _, s := range group {
+			if !s.failUntil.IsZero() {
+				if until := time.Until(s.failUntil); until < delay {
+					delay = until
+					src = s
+				}
+			} else if until := s.Period - time.Since(s.stamp); until < delay {
+				delay = until
+				src = s
+			}
+		}
+		if src != nil {
+			return src, delay
+		}
+	}
+	return
+}
+
+func (f *FeeFetcher) Connect(ctx context.Context) (*sync.WaitGroup, error) {
+	reportCompositeRate := func() {
+		r := prioritizedFeeRate(f.sources)
+		if r == 0 {
+			// Probably not possible if we have things right below.
+			f.log.Critical("Goose egg for prioritized fee rate")
+			return
+		}
+		select {
+		case f.c <- r:
+		default:
+			f.log.Meter("blocking-channel", time.Minute*5).Errorf("Blocking report channel")
+		}
+	}
+
+	updateSource := func(src *feeFetchSource) bool {
+		ctx, cancel := context.WithTimeout(ctx, feeFetchTimeout)
+		defer cancel()
+		r, errDelay, err := src.F(ctx)
+		if err != nil {
+			src.log.Meter("fetch-error", time.Minute*30).Error("Fetch error: %v", err)
+			src.failUntil = time.Now().Add(utils.Max(minFeeFetchErrorDelay, errDelay))
+			return false
+		}
+		if r == 0 {
+			src.log.Meter("zero-rate", time.Minute*30).Error("Fee rate of zero")
+			src.failUntil = time.Now().Add(minFeeFetchErrorDelay)
+			return false
+		}
+		src.failUntil = time.Time{}
+		src.stamp = time.Now()
+		src.rate = r
+		src.log.Tracef("New rate %d", r)
+		return true
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		// Prime the sources.
+		var any bool
+		for _, group := range f.sources {
+			for _, src := range group {
+				any = updateSource(src) || any
+			}
+		}
+		if any {
+			reportCompositeRate()
+		}
+
+		// Start the fetch loop.
+		defer wg.Done()
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			src, delay := nextSource(f.sources)
+			var timeout *time.Timer
+			if src == nil {
+				f.log.Meter("all-failed", time.Minute*10).Error("All sources failed")
+				timeout = time.NewTimer(feeFetchDefaultTick)
+			} else {
+				timeout = time.NewTimer(utils.Max(0, delay))
+			}
+			select {
+			case <-timeout.C:
+				if src == nil || !updateSource(src) {
+					continue
+				}
+				reportCompositeRate()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return &wg, nil
+}
+
+func (f *FeeFetcher) Next() <-chan uint64 {
+	return f.c
+}

--- a/dex/txfee/feefetcher_test.go
+++ b/dex/txfee/feefetcher_test.go
@@ -1,0 +1,113 @@
+package txfee
+
+import (
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+)
+
+func TestGroupedSources(t *testing.T) {
+	log := dex.StdOutLogger("T", dex.LevelTrace)
+	checkSort := func(sources []*SourceConfig, groupSizes ...int) {
+		t.Helper()
+		groups := groupedSources(sources, log)
+		if len(groups) != len(groupSizes) {
+			t.Fatalf("expected %d groups, got %d", len(groupSizes), len(groups))
+		}
+		for i, group := range groups {
+			if len(group) != groupSizes[i] {
+				t.Fatalf("%d'th group has %d members. expected %d", i, len(group), groupSizes[i])
+			}
+		}
+	}
+	sources := func(ranks ...uint) (srcs []*SourceConfig) {
+		for _, rank := range ranks {
+			srcs = append(srcs, &SourceConfig{Rank: rank})
+		}
+		return
+	}
+	checkSort(sources(1, 1), 2)
+	checkSort(sources(1, 2), 1, 1)
+	checkSort(sources(1, 1, 2), 2, 1)
+	checkSort(sources(4, 4, 4, 2, 1, 1), 2, 1, 3)
+}
+
+func TestPrioritizedFeeRate(t *testing.T) {
+	feeFetchers := func(priorityRates [][2]uint) [][]*feeFetchSource {
+		sources := make([]*feeFetchSource, len(priorityRates))
+		for i, rr := range priorityRates {
+			rank, rate := rr[0], rr[1]
+			sources[i] = &feeFetchSource{
+				SourceConfig: &SourceConfig{Rank: rank},
+				rate:         uint64(rate),
+				stamp:        time.Now(),
+			}
+		}
+		return groupSources(sources)
+	}
+
+	var fetchers [][]*feeFetchSource
+	checkRate := func(expRate uint64) {
+		t.Helper()
+		if r := prioritizedFeeRate(fetchers); r != expRate {
+			t.Fatalf("expected rate %d, got %d", expRate, r)
+		}
+	}
+
+	// just one
+	fetchers = feeFetchers([][2]uint{
+		{1, 10},
+	})
+	checkRate(10)
+
+	// good until expired
+	f0 := fetchers[0][0]
+	f0.stamp = time.Now().Add(-feeExpiration + time.Second*10)
+	checkRate(10)
+	// expired
+	f0.stamp = time.Now().Add(-feeExpiration)
+	checkRate(0)
+
+	// two at different priorities
+	fetchers = feeFetchers([][2]uint{
+		{1, 10},
+		{2, 20},
+	})
+	// Only first is considered if not expired or failed.
+	checkRate(10)
+	// expire first
+	f0, f1 := fetchers[0][0], fetchers[1][0]
+	f0.stamp = time.Now().Add(-feeExpiration)
+	checkRate(20)
+	// first failed
+	f0.stamp = time.Now()
+	f0.failUntil = time.Now()
+	checkRate(20)
+	// both failed
+	f1.failUntil = time.Now()
+	checkRate(0)
+
+	// first group has multiple
+	fetchers = feeFetchers([][2]uint{
+		{1, 10}, {1, 30},
+		{2, 250},
+	})
+	checkRate(20)
+	// expire second from group 1
+	f0, f1 = fetchers[0][0], fetchers[0][1]
+	f1.failUntil = time.Now()
+	checkRate(10)
+	// second from group 1 half-decayed
+	f1.failUntil = time.Time{}
+	f1.stamp = time.Now().Add(-1 * (feeFetchFullValidityPeriod + (feeFetchValidityDecayPeriod / 2)))
+	checkRate(17) // (10 + (0.5 * 30)) / 1.5 = 16.6666
+	// first from group 1  decayed by 75%
+	f1.stamp = time.Now()
+	f0.stamp = time.Now().Add(-1 * (feeFetchFullValidityPeriod + (feeFetchValidityDecayPeriod * 3 / 4)))
+	checkRate(26) // (30 + (0.25 * 10)) / 1.25 = 26
+	// group 1 unusable
+	f0.failUntil = time.Now()
+	f1.failUntil = time.Now()
+	checkRate(250)
+}

--- a/server/asset/btc/btc.go
+++ b/server/asset/btc/btc.go
@@ -9,9 +9,12 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -19,7 +22,9 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
 	"decred.org/dcrdex/dex/config"
+	"decred.org/dcrdex/dex/dexnet"
 	dexbtc "decred.org/dcrdex/dex/networks/btc"
+	"decred.org/dcrdex/dex/txfee"
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/asset"
 	srvdex "decred.org/dcrdex/server/dex"
@@ -34,6 +39,12 @@ import (
 )
 
 const defaultNoCompetitionRate = 10
+
+type v1Config struct {
+	ConfigPath     string `json:"configPath"`
+	TatumKey       string `json:"tatumKey"`
+	BlockdaemonKey string `json:"blockdaemonKey"`
+}
 
 // Driver implements asset.Driver.
 type Driver struct{}
@@ -187,6 +198,12 @@ type Backend struct {
 		fee  uint64
 		hash chainhash.Hash
 	}
+
+	feeRateCache struct {
+		sync.RWMutex
+		feeRate uint64
+		stamp   time.Time
+	}
 }
 
 // Check that Backend satisfies the Backend interface.
@@ -207,6 +224,25 @@ func NewBackend(cfg *asset.BackendConfig) (asset.Backend, error) {
 		configPath = dexbtc.SystemConfigPath("bitcoin")
 	}
 
+	feeSources := make([]*txfee.SourceConfig, len(freeFeeSources), len(freeFeeSources)+1)
+	copy(feeSources, freeFeeSources)
+	b, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config file: %w", err)
+	}
+	var cfgV1 v1Config
+	if err = json.Unmarshal(b, &cfgV1); err == nil {
+		if cfgV1.ConfigPath == "" {
+			return nil, errors.New("no config path defined in v1 config file")
+		}
+		configPath = cfgV1.ConfigPath
+		if cfgV1.TatumKey != "" {
+			feeSources = append(feeSources, tatumFeeFetcher(cfgV1.TatumKey))
+		}
+		if cfgV1.BlockdaemonKey != "" {
+			feeSources = append(feeSources, blockDaemonFeeFetcher(cfgV1.BlockdaemonKey))
+		}
+	}
 	return NewBTCClone(&BackendCloneConfig{
 		Name:        assetName,
 		Segwit:      true,
@@ -216,6 +252,7 @@ func NewBackend(cfg *asset.BackendConfig) (asset.Backend, error) {
 		ChainParams: params,
 		Ports:       dexbtc.RPCPorts,
 		RelayAddr:   cfg.RelayAddr,
+		FeeFetcher:  txfee.NewFeeFetcher(feeSources, cfg.Logger),
 	})
 }
 
@@ -341,7 +378,8 @@ type BackendCloneConfig struct {
 	InitTxSize     uint32
 	InitTxSizeBase uint32
 	// RelayAddr is an address for a NodeRelay.
-	RelayAddr string
+	RelayAddr  string
+	FeeFetcher *txfee.FeeFetcher
 }
 
 // NewBTCClone creates a BTC backend for a set of network parameters and default
@@ -438,11 +476,37 @@ func (btc *Backend) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		return nil, fmt.Errorf("%s transaction index is not enabled. Please enable txindex in the node config and you might need to re-index when you enable txindex", btc.name)
 	}
 
+	var wg sync.WaitGroup
+
+	if fetcher := btc.cfg.FeeFetcher; fetcher != nil {
+		cm := dex.NewConnectionMaster(btc.cfg.FeeFetcher)
+		if err := cm.ConnectOnce(ctx); err != nil {
+			btc.shutdown()
+			return nil, fmt.Errorf("error starting fee fetcher: %w", err)
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer cm.Disconnect()
+			for {
+				select {
+				case r := <-fetcher.Next():
+					btc.log.Tracef("New fee reported: %d", r)
+					btc.feeRateCache.Lock()
+					btc.feeRateCache.stamp = time.Now()
+					btc.feeRateCache.feeRate = r
+					btc.feeRateCache.Unlock()
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+
 	if _, err = btc.estimateFee(ctx); err != nil {
 		btc.log.Warnf("Backend started without fee estimation available: %v", err)
 	}
 
-	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -1490,6 +1554,18 @@ out:
 // case, an estimate is calculated from the median fees of the previous
 // block(s).
 func (btc *Backend) estimateFee(ctx context.Context) (satsPerB uint64, err error) {
+	if btc.cfg.FeeFetcher != nil {
+		const feeRateExpiry = time.Minute * 10
+		btc.feeRateCache.RLock()
+		stamp, feeRate := btc.feeRateCache.stamp, btc.feeRateCache.feeRate
+		btc.feeRateCache.RUnlock()
+		if time.Since(stamp) < feeRateExpiry {
+			return feeRate, nil
+		} else {
+			btc.log.Warnf("external btc fee rate is expired. falling back to estimatesmartfee")
+		}
+	}
+
 	if btc.cfg.DumbFeeEstimates {
 		satsPerB, err = btc.node.EstimateFee(btc.feeConfs)
 	} else {
@@ -1601,4 +1677,235 @@ func msgTxFromBytes(txB []byte) (*wire.MsgTx, error) {
 func hashTx(tx *wire.MsgTx) *chainhash.Hash {
 	h := tx.TxHash()
 	return &h
+}
+
+var freeFeeSources = []*txfee.SourceConfig{
+	{ // https://mempool.space/docs/api/rest#get-recommended-fees
+		Name:   "mempool.space",
+		Rank:   1,
+		Period: time.Minute * 2, // Rate limit might be 1 per 10 seconds.
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://mempool.space/api/v1/fees/recommended"
+			var res struct {
+				FastestFee uint64 `json:"fastestFee"`
+			}
+			var code int
+			if err := dexnet.Get(ctx, uri, &res, dexnet.WithStatusFunc(func(respCode int) {
+				code = respCode
+			})); err != nil {
+				if code == http.StatusTooManyRequests { // 429 per docs
+					return 0, time.Minute * 30, errors.New("exceeded request limit")
+				}
+				return 0, time.Minute * 2, err
+			}
+			return res.FastestFee, 0, nil
+		},
+	},
+	{ // https://bitcoiner.live/doc/api
+		Name:   "bitcoiner.live",
+		Rank:   1,
+		Period: time.Minute * 5, // Data is refreshed every 5 minutes
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://bitcoiner.live/api/fees/estimates/latest"
+			var res struct {
+				Estimates map[string]struct {
+					SatsPerVB float64 `json:"sat_per_vbyte"`
+				} `json:"estimates"`
+			}
+			if err := dexnet.Get(ctx, uri, &res); err != nil {
+				return 0, time.Minute * 10, err
+			}
+			if res.Estimates == nil {
+				return 0, time.Minute * 10, errors.New("no estimates returned")
+			}
+			// Using 30 minutes estimate. There is also a 60, 120, and higher
+			r, found := res.Estimates["30"]
+			if !found {
+				return 0, time.Minute * 10, errors.New("no 30-minute estimate returned")
+			}
+			return uint64(math.Round(r.SatsPerVB)), 0, nil
+		},
+	},
+	{
+		// https://api.blockcypher.com/v1/btc/main
+		// Also have ltc, dash, doge
+		Name:   "blockcypher.com",
+		Rank:   1,
+		Period: time.Minute * 3, // 100 requests/hr => 0.6 minutes
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://api.blockcypher.com/v1/btc/main"
+			var res struct {
+				MediumPerKB uint64 `json:"medium_fee_per_kb"`
+			}
+			var code int
+			if err := dexnet.Get(ctx, uri, &res, dexnet.WithStatusFunc(func(respCode int) {
+				code = respCode
+			})); err != nil {
+				if code == http.StatusTooManyRequests { // 429 per docs
+					// There's a X-Ratelimit-Remaining response header that
+					// could potentially be used to caculate a proper delay here.
+					return 0, time.Minute * 30, errors.New("exceeded request limit")
+				}
+				return 0, time.Minute * 10, err
+			}
+			return uint64(math.Round(float64(res.MediumPerKB) / 1e3)), 0, nil
+		},
+	},
+	{ // undocumented
+		Name:   "btc.com",
+		Rank:   2,
+		Period: time.Minute * 5,
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://btc.com/service/fees/distribution"
+			var res struct {
+				RecommendedFees struct {
+					OneBlockFee uint64 `json:"one_block_fee"`
+				} `json:"fees_recommended"`
+			}
+			if err := dexnet.Get(ctx, uri, &res); err != nil {
+				return 0, time.Minute * 10, err
+			}
+			return res.RecommendedFees.OneBlockFee, 0, nil
+		},
+	},
+	{ // undocumented. source is somehow related to blockchain.com
+		Name:   "blockchain.info",
+		Rank:   2,
+		Period: time.Minute * 3, // Rate limit might be 1 per 10 seconds.
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://api.blockchain.info/mempool/fees"
+			var res struct {
+				Regular  uint64 `json:"regular"` // Might be a little low
+				Priority uint64 `json:"priority"`
+			}
+			if err := dexnet.Get(ctx, uri, &res); err != nil {
+				return 0, time.Minute * 10, err
+			}
+			return res.Priority, 0, nil
+		},
+	},
+	{
+		// undocumented. Probably just estimatesmartfee underneath
+		Name:   "bitcoinfees.net",
+		Rank:   2,
+		Period: time.Minute * 3,
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://bitcoinfees.net/api.json"
+			var res struct {
+				FeePerKBByBlockTarget map[string]uint64 `json:"fee_by_block_target"`
+			}
+			if err := dexnet.Get(ctx, uri, &res); err != nil {
+				return 0, time.Minute * 10, err
+			}
+			if res.FeePerKBByBlockTarget == nil {
+				return 0, time.Minute * 10, errors.New("no estimates returned")
+			}
+			// Using 30 minutes estimate. There is also a 60, 120, and higher
+			r, found := res.FeePerKBByBlockTarget["1"]
+			if !found {
+				return 0, time.Minute * 10, errors.New("no 1-block estimate returned")
+			}
+			return uint64(math.Round(float64(r) / 1e3)), 0, nil
+		},
+	},
+	{
+		// undocumented
+		Name:   "billfodl.com",
+		Rank:   2,
+		Period: time.Minute * 3,
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://bitcoinfees.billfodl.com/api/fees/"
+			var res struct {
+				Fastest uint64 `json:"fastestFee,string"`
+			}
+			if err := dexnet.Get(ctx, uri, &res); err != nil {
+				return 0, time.Minute * 10, err
+			}
+			return res.Fastest, 0, nil
+		},
+	},
+	{
+		// https://blockchair.com/api/docs#link_M0
+		Name:   "blockchair.com",
+		Rank:   3,               // blockchair sometimes returns zero. Use only as a last resort.
+		Period: time.Minute * 3, // 1440 per day => 1 request / minute
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://api.blockchair.com/bitcoin/stats"
+			var res struct {
+				Data struct {
+					SatsPerByte uint64 `json:"suggested_transaction_fee_per_byte_sat"`
+				} `json:"data"`
+			}
+			var code int
+			if err := dexnet.Get(ctx, uri, &res, dexnet.WithStatusFunc(func(respCode int) {
+				code = respCode
+			})); err != nil {
+				switch code {
+				case http.StatusTooManyRequests, http.StatusPaymentRequired:
+					return 0, time.Minute * 30, errors.New("exceeded request limit")
+				case http.StatusServiceUnavailable, 430, 434:
+					return 0, time.Hour * 24, errors.New("banned from api")
+				}
+				return 0, time.Minute * 10, err
+			}
+			return res.Data.SatsPerByte, 0, nil
+		},
+	},
+}
+
+func tatumFeeFetcher(apiKey string) *txfee.SourceConfig {
+	return &txfee.SourceConfig{
+		Name:   "tatum",
+		Rank:   1,
+		Period: time.Minute * 1, // 1M credit / mo => 3 req / sec
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://api.tatum.io/v3/blockchain/fee/BTC"
+			var res struct {
+				Fast   float64 `json:"fast"` // Might be a little high
+				Medium float64 `json:"medium"`
+			}
+			var code int
+			withCode := dexnet.WithStatusFunc(func(respCode int) {
+				code = respCode
+			})
+			withApiKey := dexnet.WithRequestHeader("x-api-key", apiKey)
+			if err := dexnet.Get(ctx, uri, &res, withCode, withApiKey); err != nil {
+				if code == http.StatusForbidden {
+					return 0, time.Minute * 30, errors.New("exceeded request limit")
+				}
+				return 0, time.Minute * 10, err
+			}
+			return uint64(math.Round(res.Medium)), 0, nil
+		},
+	}
+}
+
+func blockDaemonFeeFetcher(apiKey string) *txfee.SourceConfig {
+	// https://docs.blockdaemon.com/reference/getfeeestimate
+	return &txfee.SourceConfig{
+		Name:   "blockdaemon",
+		Rank:   1,
+		Period: time.Minute * 2, // 25 reqs/second, 3M compute units, request is 50 compute units => 1 req / 43 secs
+		F: func(ctx context.Context) (rate uint64, errDelay time.Duration, err error) {
+			const uri = "https://svc.blockdaemon.com/universal/v1/bitcoin/mainnet/tx/estimate_fee"
+			var res struct {
+				Fees struct {
+					Fast   uint64 `json:"fast"` // a little high
+					Medium uint64 `json:"medium"`
+				} `json:"estimated_fees"`
+			}
+			var code int
+			withCode := dexnet.WithStatusFunc(func(respCode int) {
+				code = respCode
+			})
+			withApiKey := dexnet.WithRequestHeader("X-API-Key", apiKey)
+			if err := dexnet.Get(ctx, uri, &res, withCode, withApiKey); err != nil {
+				if code == http.StatusTooManyRequests {
+					return 0, time.Minute * 30, errors.New("exceeded request limit")
+				}
+				return 0, time.Minute * 10, err
+			}
+			return res.Fees.Medium, 0, nil
+		},
+	}
 }

--- a/server/asset/btc/btc_test.go
+++ b/server/asset/btc/btc_test.go
@@ -1,4 +1,4 @@
-//go:build !btclive
+//go:build !btclive && !btcfees && !feefetcher
 
 // These tests will not be run if the btclive build tag is set. In that case,
 // the live_test.go tests will run.

--- a/server/asset/btc/feefetchers_test.go
+++ b/server/asset/btc/feefetchers_test.go
@@ -1,0 +1,38 @@
+//go:build feefetcher
+
+package btc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex/txfee"
+)
+
+func testSource(src *txfee.SourceConfig) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	feeRate, _, err := src.F(ctx)
+	if err != nil {
+		fmt.Printf("XXXXX Error fetching fee for %s: %v \n", src.Name, err)
+		return
+	}
+	fmt.Printf("##### Fee fetched for %s: %d \n", src.Name, feeRate)
+}
+
+func TestFreeFeeFetchers(t *testing.T) {
+	for _, src := range freeFeeSources {
+		testSource(src)
+	}
+}
+
+func TestTatumFeeFetcher(t *testing.T) {
+	testSource(tatumFeeFetcher(os.Getenv("KEY")))
+}
+
+func TestBlockDaemonFeeFetcher(t *testing.T) {
+	testSource(blockDaemonFeeFetcher(os.Getenv("KEY")))
+}


### PR DESCRIPTION
Replaces #2638, which was never merged to the release branch
Steps on #2769. Does not replace that work, but offers some patterns that I think are useful and should be adapted to Tatanka.

Enables external fee rate estimation for Bitcoin. `estimatesmartfee` is not always the best estimate and requires priming. We retain `estimatesmartfee` as a backup. 

- Sources have rank / priority
- Sources have customizable refresh times
- Registered APIs for Tatum and Blockdaemon are available via a new configuration file format option
- A composite score is calculated based on the the valid scores from the best available priority group, with the weight of the individual score in the composite falling off over time after a period of full validity