### PR TITLE
Remove Deprecated CPP Funds Mixer Configuration

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -665,8 +665,8 @@ type ExchangeWallet struct {
 
 	// Embedding wallets can set cycleMixer, which will be triggered after
 	// new block are seen.
-	cycleMixer      func()
-	isMixingEnabled func() bool
+	cycleMixer func()
+	mixing     atomic.Bool
 
 	pendingTxsMtx sync.RWMutex
 	pendingTxs    map[chainhash.Hash]*btc.ExtendedWalletTx
@@ -5673,7 +5673,7 @@ func (dcr *ExchangeWallet) runTicketBuyer() {
 			err = errors.New("no vsp set")
 		} else {
 			vInfo := v.(*vsp)
-			tickets, err = dcr.wallet.PurchaseTickets(dcr.ctx, int(remain), vInfo.URL, vInfo.PubKey, dcr.isMixingEnabled())
+			tickets, err = dcr.wallet.PurchaseTickets(dcr.ctx, int(remain), vInfo.URL, vInfo.PubKey, dcr.mixing.Load())
 		}
 	}
 	if err != nil {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -665,8 +665,8 @@ type ExchangeWallet struct {
 
 	// Embedding wallets can set cycleMixer, which will be triggered after
 	// new block are seen.
-	cycleMixer   func()
-	mixingConfig func() *mixingConfig
+	cycleMixer      func()
+	isMixingEnabled func() bool
 
 	pendingTxsMtx sync.RWMutex
 	pendingTxs    map[chainhash.Hash]*btc.ExtendedWalletTx
@@ -5666,14 +5666,14 @@ func (dcr *ExchangeWallet) runTicketBuyer() {
 
 	var tickets []*asset.Ticket
 	if !dcr.isNative() {
-		tickets, err = dcr.wallet.PurchaseTickets(dcr.ctx, int(remain), "", "", nil)
+		tickets, err = dcr.wallet.PurchaseTickets(dcr.ctx, int(remain), "", "", false)
 	} else {
 		v := dcr.vspV.Load()
 		if v == nil {
 			err = errors.New("no vsp set")
 		} else {
 			vInfo := v.(*vsp)
-			tickets, err = dcr.wallet.PurchaseTickets(dcr.ctx, int(remain), vInfo.URL, vInfo.PubKey, dcr.mixingConfig())
+			tickets, err = dcr.wallet.PurchaseTickets(dcr.ctx, int(remain), vInfo.URL, vInfo.PubKey, dcr.isMixingEnabled())
 		}
 	}
 	if err != nil {

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -172,8 +172,8 @@ func tNewWalletMonitorBlocks(monitorBlocks bool) (*ExchangeWallet, *tRPCClient, 
 		go wallet.monitorBlocks(walletCtx)
 	}
 
-	wallet.mixingConfig = func() *mixingConfig {
-		return &mixingConfig{enabled: false}
+	wallet.isMixingEnabled = func() bool {
+		return false
 	}
 
 	return wallet, client, shutdown

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -172,10 +172,6 @@ func tNewWalletMonitorBlocks(monitorBlocks bool) (*ExchangeWallet, *tRPCClient, 
 		go wallet.monitorBlocks(walletCtx)
 	}
 
-	wallet.isMixingEnabled = func() bool {
-		return false
-	}
-
 	return wallet, client, shutdown
 
 }

--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -1008,7 +1008,7 @@ func (w *rpcWallet) StakeInfo(ctx context.Context) (*wallet.StakeInfoData, error
 
 // PurchaseTickets purchases n amount of tickets. Returns the purchased ticket
 // hashes if successful.
-func (w *rpcWallet) PurchaseTickets(ctx context.Context, n int, _, _ string, _ *mixingConfig) ([]*asset.Ticket, error) {
+func (w *rpcWallet) PurchaseTickets(ctx context.Context, n int, _, _ string, _ bool) ([]*asset.Ticket, error) {
 	hashes, err := w.rpcClient.PurchaseTicket(
 		ctx,
 		"default",

--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -1047,7 +1047,7 @@ func (w *spvWallet) rescan(ctx context.Context, fromHeight int32, c chan wallet.
 
 // PurchaseTickets purchases n tickets, tells the provided vspd to monitor the
 // ticket, and pays the vsp fee.
-func (w *spvWallet) PurchaseTickets(ctx context.Context, n int, vspHost, vspPubKey string, isMixingEnabled bool) ([]*asset.Ticket, error) {
+func (w *spvWallet) PurchaseTickets(ctx context.Context, n int, vspHost, vspPubKey string, mixing bool) ([]*asset.Ticket, error) {
 	vspClient, err := w.newVSPClient(vspHost, vspPubKey, w.log.SubLogger("VSP"))
 	if err != nil {
 		return nil, err
@@ -1057,9 +1057,10 @@ func (w *spvWallet) PurchaseTickets(ctx context.Context, n int, vspHost, vspPubK
 		Count:                n,
 		VSPFeePaymentProcess: vspClient.Process,
 		VSPFeePercent:        vspClient.FeePercentage,
+		Mixing:               mixing,
 	}
 
-	if isMixingEnabled {
+	if mixing {
 		accts := w.Accounts()
 		mixedAccountNum, err := w.AccountNumber(ctx, accts.PrimaryAccount)
 		if err != nil {

--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -1047,7 +1047,7 @@ func (w *spvWallet) rescan(ctx context.Context, fromHeight int32, c chan wallet.
 
 // PurchaseTickets purchases n tickets, tells the provided vspd to monitor the
 // ticket, and pays the vsp fee.
-func (w *spvWallet) PurchaseTickets(ctx context.Context, n int, vspHost, vspPubKey string, mixCfg *mixingConfig) ([]*asset.Ticket, error) {
+func (w *spvWallet) PurchaseTickets(ctx context.Context, n int, vspHost, vspPubKey string, isMixingEnabled bool) ([]*asset.Ticket, error) {
 	vspClient, err := w.newVSPClient(vspHost, vspPubKey, w.log.SubLogger("VSP"))
 	if err != nil {
 		return nil, err
@@ -1059,7 +1059,7 @@ func (w *spvWallet) PurchaseTickets(ctx context.Context, n int, vspHost, vspPubK
 		VSPFeePercent:        vspClient.FeePercentage,
 	}
 
-	if mixCfg.enabled {
+	if isMixingEnabled {
 		accts := w.Accounts()
 		mixedAccountNum, err := w.AccountNumber(ctx, accts.PrimaryAccount)
 		if err != nil {

--- a/client/asset/dcr/spv_mixing.go
+++ b/client/asset/dcr/spv_mixing.go
@@ -13,7 +13,7 @@ const (
 	tradingAccountName    = "dextrading"
 )
 
-func (w *spvWallet) mix(ctx context.Context, cfg *mixingConfig) {
+func (w *spvWallet) mix(ctx context.Context) {
 	mixedAccount, err := w.AccountNumber(ctx, mixedAccountName)
 	if err != nil {
 		w.log.Errorf("unable to look up mixed account: %v", err)
@@ -23,7 +23,7 @@ func (w *spvWallet) mix(ctx context.Context, cfg *mixingConfig) {
 	// unmixed account is the default account
 	unmixedAccount := uint32(defaultAcct)
 
-	w.log.Debugf("Starting cspp funds mixer with %s", cfg.server)
+	w.log.Debug("Starting cspp peer-to-peer funds mixer")
 
 	// Don't perform any actions while transactions are not synced
 	// through the tip block.

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -166,7 +166,7 @@ type Wallet interface {
 	AddressPrivKey(ctx context.Context, address stdaddr.Address) (*secp256k1.PrivateKey, error)
 	// PurchaseTickets purchases n tickets. vspHost and vspPubKey only
 	// needed for internal wallets. Peer-to-peer mixing can be enabled if required.
-	PurchaseTickets(ctx context.Context, n int, vspHost, vspPubKey string, isMixingEnabled bool) ([]*asset.Ticket, error)
+	PurchaseTickets(ctx context.Context, n int, vspHost, vspPubKey string, isMixing bool) ([]*asset.Ticket, error)
 	// Tickets returns current active ticket hashes up until they are voted
 	// or revoked. Includes unconfirmed tickets.
 	Tickets(ctx context.Context) ([]*asset.Ticket, error)

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -165,8 +165,8 @@ type Wallet interface {
 	// AddressPrivKey fetches the privkey for the specified address.
 	AddressPrivKey(ctx context.Context, address stdaddr.Address) (*secp256k1.PrivateKey, error)
 	// PurchaseTickets purchases n tickets. vspHost and vspPubKey only
-	// needed for internal wallets.
-	PurchaseTickets(ctx context.Context, n int, vspHost, vspPubKey string, mixCfg *mixingConfig) ([]*asset.Ticket, error)
+	// needed for internal wallets. Peer-to-peer mixing can be enabled if required.
+	PurchaseTickets(ctx context.Context, n int, vspHost, vspPubKey string, isMixingEnabled bool) ([]*asset.Ticket, error)
 	// Tickets returns current active ticket hashes up until they are voted
 	// or revoked. Includes unconfirmed tickets.
 	Tickets(ctx context.Context) ([]*asset.Ticket, error)

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -738,8 +738,6 @@ type FundsMixingStats struct {
 	// Enabled is true if the wallet is configured for funds mixing. The wallet
 	// must be configured before mixing can be started.
 	Enabled bool `json:"enabled"`
-	// IsMixing is true if the wallet is currently mixing funds.
-	IsMixing bool `json:"isMixing"`
 	// UnmixedBalanceThreshold is the minimum amount of unmixed funds that must
 	// be in the wallet for mixing to happen.
 	UnmixedBalanceThreshold uint64 `json:"unmixedBalanceThreshold"`
@@ -750,19 +748,7 @@ type FundsMixer interface {
 	// FundsMixingStats returns the current state of the wallet's funds mixer.
 	FundsMixingStats() (*FundsMixingStats, error)
 	// ConfigureFundsMixer configures the wallet for funds mixing.
-	ConfigureFundsMixer(isMixing bool) error
-	// StartFundsMixer starts the funds mixer. This will error if the wallet
-	// does not allow starting or stopping the mixer or if the mixer was already
-	// started.
-	StartFundsMixer(ctx context.Context) error
-	// StopFundsMixer stops the funds mixer. This will error if the wallet does
-	// not allow starting or stopping the mixer or if the mixer was not already
-	// running.
-	StopFundsMixer()
-	// DisableFundsMixer disables the funds mixer and moves all funds to the
-	// default account. The wallet will need to be re-configured to re-enable
-	// mixing.
-	DisableFundsMixer() error
+	ConfigureFundsMixer(enabled bool) error
 }
 
 // WalletRestoration contains all the information needed for a user to restore

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -738,8 +738,6 @@ type FundsMixingStats struct {
 	// Enabled is true if the wallet is configured for funds mixing. The wallet
 	// must be configured before mixing can be started.
 	Enabled bool `json:"enabled"`
-	// Server is the currently configured server.
-	Server string `json:"server"`
 	// IsMixing is true if the wallet is currently mixing funds.
 	IsMixing bool `json:"isMixing"`
 	// UnmixedBalanceThreshold is the minimum amount of unmixed funds that must
@@ -752,7 +750,7 @@ type FundsMixer interface {
 	// FundsMixingStats returns the current state of the wallet's funds mixer.
 	FundsMixingStats() (*FundsMixingStats, error)
 	// ConfigureFundsMixer configures the wallet for funds mixing.
-	ConfigureFundsMixer(serverAddress string, cert []byte) error
+	ConfigureFundsMixer(isMixing bool) error
 	// StartFundsMixer starts the funds mixer. This will error if the wallet
 	// does not allow starting or stopping the mixer or if the mixer was already
 	// started.

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -11360,12 +11360,12 @@ func (c *Core) FundsMixingStats(assetID uint32) (*asset.FundsMixingStats, error)
 }
 
 // ConfigureFundsMixer configures the wallet for funds mixing.
-func (c *Core) ConfigureFundsMixer(assetID uint32, serverAddress string, cert []byte) error {
+func (c *Core) ConfigureFundsMixer(assetID uint32, isMixerEnabled bool) error {
 	_, mw, err := c.mixingWallet(assetID)
 	if err != nil {
 		return err
 	}
-	return mw.ConfigureFundsMixer(serverAddress, cert)
+	return mw.ConfigureFundsMixer(isMixerEnabled)
 }
 
 // StartFundsMixer starts the funds mixer. This will error if the wallet

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1953,75 +1953,14 @@ func (s *WebServer) apiMixingStats(w http.ResponseWriter, r *http.Request) {
 
 func (s *WebServer) apiConfigureMixer(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AssetID         uint32 `json:"assetID"`
-		IsMixingEnabled bool   `json:"isMixingEnabled"`
+		AssetID uint32 `json:"assetID"`
+		Enabled bool   `json:"enabled"`
 	}
 	if !readPost(w, r, &req) {
 		return
 	}
-	if err := s.core.ConfigureFundsMixer(req.AssetID, req.IsMixingEnabled); err != nil {
+	if err := s.core.ConfigureFundsMixer(req.AssetID, req.Enabled); err != nil {
 		s.writeAPIError(w, fmt.Errorf("error configuring mixing for %d: %w", req.AssetID, err))
-		return
-	}
-	writeJSON(w, simpleAck())
-}
-
-func (s *WebServer) apiStartMixer(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		AssetID uint32           `json:"assetID"`
-		AppPW   encode.PassBytes `json:"appPW"`
-	}
-	if !readPost(w, r, &req) {
-		return
-	}
-	defer req.AppPW.Clear()
-	// We only need a password if the wallet is locked.
-	walletState := s.core.WalletState(req.AssetID)
-	if walletState == nil {
-		s.writeAPIError(w, errors.New("no wallet state retrieved"))
-		return
-	}
-
-	var appPW []byte
-	defer encode.ClearBytes(appPW)
-	if !walletState.Open {
-		var err error
-		appPW, err = s.resolvePass(req.AppPW, r)
-		if err != nil {
-			s.writeAPIError(w, fmt.Errorf("password error: %w", err))
-			return
-		}
-	}
-	if err := s.core.StartFundsMixer(appPW, req.AssetID); err != nil {
-		s.writeAPIError(w, fmt.Errorf("error starting mixing for %d: %w", req.AssetID, err))
-		return
-	}
-	writeJSON(w, simpleAck())
-}
-
-func (s *WebServer) apiStopMixer(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		AssetID uint32 `json:"assetID"`
-	}
-	if !readPost(w, r, &req) {
-		return
-	}
-	if err := s.core.StopFundsMixer(req.AssetID); err != nil {
-		s.writeAPIError(w, fmt.Errorf("error stopping mixing for %d: %w", req.AssetID, err))
-		return
-	}
-	writeJSON(w, simpleAck())
-}
-
-func (s *WebServer) apiDisableMixer(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		AssetID uint32 `json:"assetID"`
-	}
-	if !readPost(w, r, &req) {
-		return
-	}
-	if err := s.core.DisableFundsMixer(req.AssetID); err != nil {
-		s.writeAPIError(w, fmt.Errorf("error disabling mixing for %d: %w", req.AssetID, err))
 		return
 	}
 	writeJSON(w, simpleAck())

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1953,14 +1953,13 @@ func (s *WebServer) apiMixingStats(w http.ResponseWriter, r *http.Request) {
 
 func (s *WebServer) apiConfigureMixer(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AssetID    uint32 `json:"assetID"`
-		ServerAddr string `json:"serverAddr"`
-		Cert       string `json:"cert"`
+		AssetID         uint32 `json:"assetID"`
+		IsMixingEnabled bool   `json:"isMixingEnabled"`
 	}
 	if !readPost(w, r, &req) {
 		return
 	}
-	if err := s.core.ConfigureFundsMixer(req.AssetID, req.ServerAddr, []byte(req.Cert)); err != nil {
+	if err := s.core.ConfigureFundsMixer(req.AssetID, req.IsMixingEnabled); err != nil {
 		s.writeAPIError(w, fmt.Errorf("error configuring mixing for %d: %w", req.AssetID, err))
 		return
 	}

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -2101,19 +2101,7 @@ func (c *TCore) FundsMixingStats(assetID uint32) (*asset.FundsMixingStats, error
 	return nil, nil
 }
 
-func (c *TCore) ConfigureFundsMixer(assetID uint32, isMixerEnabled bool) error {
-	return nil
-}
-
-func (c *TCore) StartFundsMixer(appPW []byte, assetID uint32) error {
-	return nil
-}
-
-func (c *TCore) StopFundsMixer(assetID uint32) error {
-	return nil
-}
-
-func (c *TCore) DisableFundsMixer(assetID uint32) error {
+func (c *TCore) ConfigureFundsMixer(assetID uint32, enabled bool) error {
 	return nil
 }
 

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -2101,7 +2101,7 @@ func (c *TCore) FundsMixingStats(assetID uint32) (*asset.FundsMixingStats, error
 	return nil, nil
 }
 
-func (c *TCore) ConfigureFundsMixer(assetID uint32, serverAddress string, cert []byte) error {
+func (c *TCore) ConfigureFundsMixer(assetID uint32, isMixerEnabled bool) error {
 	return nil
 }
 

--- a/client/webserver/site/src/css/wallets.scss
+++ b/client/webserver/site/src/css/wallets.scss
@@ -214,10 +214,6 @@
     #walletDetailsBox {
       border-bottom: none !important;
     }
-
-    #mixerConfigForm {
-      min-width: 325px;
-    }
   }
 
   .flex-wrap-lg {

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -321,18 +321,7 @@
 
             {{- /* MIXING */ -}}
             <section id="mixingBox" class="position-relative d-flex align-items-stretch flex-column border">
-              <div id="enableMixing" class="w-100 d-flex align-items-stretch">
-                <div class="flex-grow-1 d-flex justify-content-between align-items-stretch">
-                  <div class="flex-center p-2">
-                    <span class="fs35 ico-secretagent me-2"></span>
-                    <span class="fs24">[[[Privacy]]]</span>
-                  </div>
-                  <button id="enablePrivacyButton" class="feature m-2">[[[Enable]]]</button>
-                </div>
-                <div id="privacyInfoBttn" class="flex-center p-3 fs24 ico-info border-start hoverbg pointer"></div>
-                <div id="configureMixer" class="flex-center p-3 fs24 ico-settings border-start hoverbg pointer"></div>
-              </div>
-              <div id="mixerSettings" class="w-100 d-flex align-items-stretch d-hide">
+              <div class="w-100 d-flex align-items-stretch">
                 <div class="p-2 flex-center fs35 ico-secretagent border-end"></div>
                 <div class="flex-center flex-grow-1">
                   <div id="mixerOn" class="flex-center fs20 d-hide">
@@ -344,10 +333,10 @@
                     <span class="">[[[Privacy off]]]</span>
                   </div>
                 </div>
+                <div id="privacyInfoBttn" class="flex-center p-3 fs24 ico-info border-start hoverbg pointer"></div>
                 <div class="p-2 border-start flex-center">
                   <div id="toggleMixer" class="anitoggle big"></div>
                 </div>
-                <div id="reconfigureMixer" class="ico-settings fs28 p-2 flex-center border-start hoverbg pointer"></div>
               </div>
               <div id="mixerLoading" class="fill-abs flex-center bodybg">
                 <span>
@@ -1125,55 +1114,6 @@
       </table>
     </form>
 
-    {{- /* START MIXER PASSWORD FORM */ -}}
-    <form id="mixerPWForm" class="d-flex align-items-stretch flex-column p-0 m-4 mw-425">
-      <div class="form-closer hoverbg p-2 mt-2"><span class="ico-cross"></span></div>
-      <div class="flex-center px-3">
-        [[[mixing_pw_prompt]]]
-      </div>
-      <div class="d-flex flex-column align-items-stretch mt-2">
-        <div class="flex-center w-100">
-          <div class="flex-column flex-center">
-            <label for="mixerPWInput">[[[App Password]]]</label>
-            <input type="password" id="mixerPWInput" class="p-2 text-center mt-1" autocomplete="off">
-          </div>
-        </div>
-        <div id="mixerPWErr" class="p-2 flex-center text-danger d-hide"></div>
-        <div id="mixerPWSubmit" class="feature flex-center m-2 p-3 rounded3">
-          <span class="ico-arrowright me-1"></span>
-          Start
-        </div>
-      </div>
-    </form>
-
-    {{- /* CSPP ADDRESS CONFIG */ -}}
-    <form id="mixerConfigForm" class="d-flex align-items-stretch flex-column mw-425">
-      <div class="form-closer"><span class="ico-cross"></span></div>
-      <h3>
-        <span class="ico-secretagent fs35 me-1"></span>
-        <span id="mixerEnableLabel">[[[Enable Privacy]]]</span>
-        <span id="mixerConfigureLabel">[[[Configure Privacy]]]</span>
-      </h3>
-      <div id="mixAddrDisplayBox" class="flex-center fs18 mb-3 px-3">
-        <span id="mixAddrDisplay"></span>
-        <div id="mixAddrEdit" class="d-inline-block ico-edit fs14 p-2 hoverbg pointer"></div>
-      </div>
-      <div id="mixAddrInputBox" class="flex-column mb-3">
-        <div class="mb-3">
-          <label for="mixAddrInput">[[[cspp_addr]]]</label>
-          <input type="text" id="mixAddrInput">
-        </div>
-        <div class="mb-3">
-          {{template "certPicker"}}
-        </div>
-      </div>
-      <div class="d-flex justify-content-between w-100">
-        <button id="mixerDisable" type="button" class="danger me-4">[[[Disable Privacy]]]</button>
-        <button id="mixConfigSubmit" type="button" class="go ms-auto">[[[Submit]]]</button>
-      </div>
-      <div id="mixConfigErr" class="pt-3 flex-center text-danger d-hide"></div>
-    </form>
-
     {{- /* CSPP INFO */ -}}
     <form id="mixingInfo" class="mw-425">
       <div class="form-closer"><span class="ico-cross"></span></div>
@@ -1191,22 +1131,6 @@
           [[[privacy_optional]]]
         </li>
       </ul>
-    </form>
-
-    {{- /* CSPP INFO */ -}}
-    <form id="mixingOffConfirmationForm" class="mw-425">
-      <div class="form-closer"><span class="ico-cross"></span></div>
-      <h3 class="w-100 px-3 mb-4">
-        Are you sure that you want to turn off the privacy engine?
-      </h3>
-      <div class="flex-center w-100 mb-3">
-        Newly received funds will not become available for
-        use until privacy is turned back on.
-      </div>
-      <div class="d-flex justify-content-between mt-4">
-        <button id="mixingOffNo" type="button">Nevermind</button>
-        <button id="mixingOffGo" type="button" class="danger">Turn it off</button>
-      </div>
     </form>
   </div>
 </div>

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -1097,12 +1097,6 @@ export interface TicketStats {
   queued: number
 }
 
-export interface FundsMixingStats {
-  enabled: boolean
-  server: string
-  isMixing: boolean
-}
-
 export interface TicketStakingStatus {
   ticketPrice: number
   votingSubsidy: number

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1485,7 +1485,7 @@ export default class WalletsPage extends BasePage {
     const { page, selectedAssetID: assetID, mixerStatus } = this
     if (!mixerStatus) return
     const loaded = app().loading(page.mixingBox)
-    const cfg = { assetID: assetID, IsMixingEnabled: page.enableMixing } as any
+    const cfg = { assetID: assetID, isMixingEnabled: page.enableMixing } as any
     const res = await postJSON('/api/configuremixer', cfg)
     loaded()
     if (!app().checkResponse(res)) {
@@ -1522,17 +1522,8 @@ export default class WalletsPage extends BasePage {
     const { page, selectedAssetID: assetID, mixerStatus } = this
     if (!mixerStatus) return
     Doc.hide(page.mixConfigErr)
-    const cfg = { assetID: assetID, IsMixingEnabled: page.enableMixing } as any
+    const cfg = { assetID: assetID, isMixingEnabled: page.enableMixing } as any
     const loaded = app().loading(page.mixerConfigForm)
-    if (Doc.isDisplayed(page.mixAddrInputBox)) {
-      cfg.serverAddr = page.mixAddrInput.value
-      if (!cfg.serverAddr) {
-        Doc.show(page.mixConfigErr)
-        page.mixConfigErr.textContent = intl.prep(intl.ID_INVALID_ADDRESS_MSG)
-        return
-      }
-      cfg.cert = await this.mixCertPicker.file()
-    }
     const res = await postJSON('/api/configuremixer', cfg)
     loaded()
     if (!app().checkResponse(res)) {

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1485,7 +1485,8 @@ export default class WalletsPage extends BasePage {
     const { page, selectedAssetID: assetID, mixerStatus } = this
     if (!mixerStatus) return
     const loaded = app().loading(page.mixingBox)
-    const res = await postJSON('/api/configuremixer', { assetID })
+    const cfg = { assetID: assetID, IsMixingEnabled: page.enableMixing } as any
+    const res = await postJSON('/api/configuremixer', cfg)
     loaded()
     if (!app().checkResponse(res)) {
       Doc.show(page.mixingErr)
@@ -1521,7 +1522,7 @@ export default class WalletsPage extends BasePage {
     const { page, selectedAssetID: assetID, mixerStatus } = this
     if (!mixerStatus) return
     Doc.hide(page.mixConfigErr)
-    const cfg = { assetID: assetID } as any
+    const cfg = { assetID: assetID, IsMixingEnabled: page.enableMixing } as any
     const loaded = app().loading(page.mixerConfigForm)
     if (Doc.isDisplayed(page.mixAddrInputBox)) {
       cfg.serverAddr = page.mixAddrInput.value

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -167,7 +167,7 @@ type clientCore interface {
 	TicketPage(assetID uint32, scanStart int32, n, skipN int) ([]*asset.Ticket, error)
 	TxHistory(assetID uint32, n int, refID *string, past bool) ([]*asset.WalletTransaction, error)
 	FundsMixingStats(assetID uint32) (*asset.FundsMixingStats, error)
-	ConfigureFundsMixer(assetID uint32, serverAddress string, cert []byte) error
+	ConfigureFundsMixer(assetID uint32, isMixerEnabled bool) error
 	StartFundsMixer(appPW []byte, assetID uint32) error
 	StopFundsMixer(assetID uint32) error
 	DisableFundsMixer(assetID uint32) error

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -167,10 +167,7 @@ type clientCore interface {
 	TicketPage(assetID uint32, scanStart int32, n, skipN int) ([]*asset.Ticket, error)
 	TxHistory(assetID uint32, n int, refID *string, past bool) ([]*asset.WalletTransaction, error)
 	FundsMixingStats(assetID uint32) (*asset.FundsMixingStats, error)
-	ConfigureFundsMixer(assetID uint32, isMixerEnabled bool) error
-	StartFundsMixer(appPW []byte, assetID uint32) error
-	StopFundsMixer(assetID uint32) error
-	DisableFundsMixer(assetID uint32) error
+	ConfigureFundsMixer(assetID uint32, enabled bool) error
 	SetLanguage(string) error
 	Language() string
 	TakeAction(assetID uint32, actionID string, actionB json.RawMessage) error
@@ -569,9 +566,6 @@ func New(cfg *Config) (*WebServer, error) {
 
 			apiAuth.Post("/mixingstats", s.apiMixingStats)
 			apiAuth.Post("/configuremixer", s.apiConfigureMixer)
-			apiAuth.Post("/startmixer", s.apiStartMixer)
-			apiAuth.Post("/stopmixer", s.apiStopMixer)
-			apiAuth.Post("/disablemixer", s.apiDisableMixer)
 
 			if cfg.Experimental {
 				apiAuth.Post("/startmarketmakingbot", s.apiStartMarketMakingBot)

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -336,7 +336,7 @@ func (c *TCore) FundsMixingStats(assetID uint32) (*asset.FundsMixingStats, error
 	return nil, nil
 }
 
-func (c *TCore) ConfigureFundsMixer(assetID uint32, serverAddress string, cert []byte) error {
+func (c *TCore) ConfigureFundsMixer(assetID uint32, isMixerEnabled bool) error {
 	return nil
 }
 

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -336,19 +336,7 @@ func (c *TCore) FundsMixingStats(assetID uint32) (*asset.FundsMixingStats, error
 	return nil, nil
 }
 
-func (c *TCore) ConfigureFundsMixer(assetID uint32, isMixerEnabled bool) error {
-	return nil
-}
-
-func (c *TCore) StartFundsMixer(appPW []byte, assetID uint32) error {
-	return nil
-}
-
-func (c *TCore) StopFundsMixer(assetID uint32) error {
-	return nil
-}
-
-func (c *TCore) DisableFundsMixer(assetID uint32) error {
+func (c *TCore) ConfigureFundsMixer(assetID uint32, enabled bool) error {
 	return nil
 }
 


### PR DESCRIPTION
The `CSPPServer` and `Cert` configurations are no longer necessary when setting the mixing configuration.
To activate a the Peer-to-peer of a boolean true that is required. 