### PR TITLE
mm: Oracle token errors

### DIFF
--- a/client/mm/price_oracle.go
+++ b/client/mm/price_oracle.go
@@ -230,10 +230,12 @@ func (o *priceOracle) syncMarket(baseID, quoteID uint32) (float64, []*OracleRepo
 
 func coinpapAsset(assetID uint32) (*fiatrates.CoinpaprikaAsset, error) {
 	if tkn := asset.TokenInfo(assetID); tkn != nil {
+		symbol := dex.BipIDSymbol(assetID)
+		symbol = strings.Split(symbol, ".")[0]
 		return &fiatrates.CoinpaprikaAsset{
 			AssetID: assetID,
 			Name:    tkn.Name,
-			Symbol:  dex.BipIDSymbol(assetID),
+			Symbol:  symbol,
 		}, nil
 	}
 	a := asset.Asset(assetID)

--- a/client/mm/price_oracle_test.go
+++ b/client/mm/price_oracle_test.go
@@ -27,6 +27,8 @@ func TestPriceOracle(t *testing.T) {
 	markets := []*marketPair{
 		{baseID: 42, quoteID: 0},
 		{baseID: 60, quoteID: 0},
+		{baseID: 42, quoteID: 60002},
+		{baseID: 60001, quoteID: 60002},
 	}
 	for _, mkt := range markets {
 		price, oracleReport, err := oracle.getOracleInfo(mkt.baseID, mkt.quoteID)
@@ -89,7 +91,7 @@ func TestAutoSyncPriceOracle(t *testing.T) {
 func testSpreader(t *testing.T, spreader Spreader, baseSymbol, quoteSymbol string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	sell, buy, err := spreader(ctx, baseSymbol, quoteSymbol)
+	sell, buy, err := spreader(ctx, baseSymbol, quoteSymbol, tLogger)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The symbols used to look up token rates included the network, causing errors. This diff updates this so that only the token symbol is used.

Closes #2831