### PR TITLE
asset/dcr: Skip starting mixer during initial sync

### DIFF
--- a/client/asset/dcr/native_wallet.go
+++ b/client/asset/dcr/native_wallet.go
@@ -197,10 +197,12 @@ func (w *NativeWallet) Lock() (err error) {
 // mixFunds checks the status of mixing operations and starts a mix cycle.
 // mixFunds must be called with the mixer.mtx >= RLock'd.
 func (w *NativeWallet) mixFunds() {
-	if on := w.mixer.ctx != nil; !on {
+	synced, _, _ := w.SyncStatus()
+	if !synced {
 		return
 	}
-	if !w.mixing.Load() {
+	on := w.mixer.ctx != nil
+	if !on || !w.mixing.Load() {
 		return
 	}
 	ctx := w.mixer.ctx

--- a/client/asset/dcr/spv_mixing.go
+++ b/client/asset/dcr/spv_mixing.go
@@ -23,7 +23,7 @@ func (w *spvWallet) mix(ctx context.Context) {
 	// unmixed account is the default account
 	unmixedAccount := uint32(defaultAcct)
 
-	w.log.Debug("Starting cspp peer-to-peer funds mixer")
+	w.log.Debug("Starting new cspp peer-to-peer funds mixing cycle")
 
 	// Don't perform any actions while transactions are not synced
 	// through the tip block.


### PR DESCRIPTION
Closes https://github.com/decred/dcrdex/issues/2845.

Also resolves @JoeGruffins concerns here https://github.com/decred/dcrdex/issues/2856#issuecomment-2208171213