### PR TITLE
mm: allocate for redemptions when fee asset mismatch

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -5865,6 +5865,9 @@ func (btc *baseWallet) addUnknownTransactionsToHistory(tip uint64) {
 	}
 
 	for _, tx := range txs {
+		if btc.ctx.Err() != nil {
+			return
+		}
 		txHash, err := chainhash.NewHashFromStr(tx.TxID)
 		if err != nil {
 			btc.log.Errorf("Error decoding tx hash %s: %v", tx.TxID, err)
@@ -6014,6 +6017,9 @@ func (btc *intermediaryWallet) syncTxHistory(tip uint64) {
 	}
 
 	for hash, tx := range pendingTxsCopy {
+		if btc.ctx.Err() != nil {
+			return
+		}
 		handlePendingTx(hash, &tx)
 	}
 }

--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -499,6 +499,9 @@ func (btc *ExchangeWalletElectrum) syncTxHistory(tip uint64) {
 	}
 
 	for hash, tx := range pendingTxsCopy {
+		if btc.ctx.Err() != nil {
+			return
+		}
 		handlePendingTx(hash, &tx)
 	}
 }

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -6174,6 +6174,9 @@ func (dcr *ExchangeWallet) addUnknownTransactionsToHistory(tip uint64) {
 	}
 
 	for _, tx := range txs {
+		if dcr.ctx.Err() != nil {
+			return
+		}
 		txHash, err := chainhash.NewHashFromStr(tx.TxID)
 		if err != nil {
 			dcr.log.Errorf("Error decoding tx hash %s: %v", tx.TxID, err)
@@ -6325,6 +6328,9 @@ func (dcr *ExchangeWallet) syncTxHistory(ctx context.Context, tip uint64) {
 	}
 
 	for hash, tx := range pendingTxsCopy {
+		if dcr.ctx.Err() != nil {
+			return
+		}
 		handlePendingTx(hash, &tx)
 	}
 }

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -815,7 +815,7 @@ func NewEVMWallet(cfg *EVMWalletConfig) (w *ETHWallet, err error) {
 
 	maxSwaps, maxRedeems := aw.maxSwapsAndRedeems()
 
-	cfg.Logger.Infof("ETH wallet will support a maximum of %d swaps and %d redeems per transaction.",
+	cfg.Logger.Debugf("ETH wallet will support a maximum of %d swaps and %d redeems per transaction.",
 		maxSwaps, maxRedeems)
 
 	aw.wallets = map[uint32]*assetWallet{

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -1716,7 +1716,6 @@ func (w *TokenWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, uin
 	}
 
 	ethToLock := ord.MaxFeeRate * g.Swap * ord.MaxSwapCount
-
 	var success bool
 	if err = w.lockFunds(ord.Value, initiationReserve); err != nil {
 		return nil, nil, 0, fmt.Errorf("error locking token funds: %v", err)

--- a/client/asset/eth/txdb.go
+++ b/client/asset/eth/txdb.go
@@ -476,12 +476,24 @@ func (log *badgerLoggerWrapper) Debugf(s string, a ...interface{}) {
 	log.Tracef(s, a...)
 }
 
+func (log *badgerLoggerWrapper) Debug(a ...interface{}) {
+	log.Trace(a...)
+}
+
 // Infof -> dex.Logger.Debugf
 func (log *badgerLoggerWrapper) Infof(s string, a ...interface{}) {
 	log.Debugf(s, a...)
 }
 
+func (log *badgerLoggerWrapper) Info(a ...interface{}) {
+	log.Debug(a...)
+}
+
 // Warningf -> dex.Logger.Warnf
 func (log *badgerLoggerWrapper) Warningf(s string, a ...interface{}) {
 	log.Warnf(s, a...)
+}
+
+func (log *badgerLoggerWrapper) Warning(a ...interface{}) {
+	log.Warn(a...)
 }

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -3560,6 +3560,9 @@ func (w *zecWallet) addUnknownTransactionsToHistory(tip uint64) {
 	}
 
 	for _, tx := range txs {
+		if w.ctx.Err() != nil {
+			return
+		}
 		txHash, err := chainhash.NewHashFromStr(tx.TxID)
 		if err != nil {
 			w.log.Errorf("Error decoding tx hash %s: %v", tx.TxID, err)
@@ -3654,6 +3657,9 @@ func (w *zecWallet) syncTxHistory(tip uint64) {
 			return
 		}
 		if err != nil {
+			if w.ctx.Err() != nil {
+				return
+			}
 			w.log.Errorf("Error getting transaction %s: %v", txHash, err)
 			return
 		}

--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -1724,7 +1724,6 @@ func (c *Core) bondConfirmed(dc *dexConnection, assetID uint32, coinID []byte, p
 		if err != nil {
 			return fmt.Errorf("db.ConfirmBond failure: %w", err)
 		}
-		c.log.Infof("Bond %s (%s) confirmed.", bondIDStr, unbip(assetID))
 		subject, details := c.formatDetails(TopicBondConfirmed, effectiveTier, targetTier)
 		c.notify(newBondPostNoteWithTier(TopicBondConfirmed, subject, details, db.Success, dc.acct.host, bondedTier, c.exchangeAuth(dc)))
 	} else if !foundConfirmed {

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -443,13 +443,13 @@ func (dc *dexConnection) syncBook(base, quote uint32) (*orderbook.OrderBook, Boo
 // request. The response, which includes book's snapshot, is returned. Proper
 // synchronization is required by the caller to ensure that order feed messages
 // aren't processed before they are prepared to handle this subscription.
-func (dc *dexConnection) subscribe(base, quote uint32) (*msgjson.OrderBook, error) {
-	mkt := marketName(base, quote)
+func (dc *dexConnection) subscribe(baseID, quoteID uint32) (*msgjson.OrderBook, error) {
+	mkt := marketName(baseID, quoteID)
 	// Subscribe via the 'orderbook' request.
 	dc.log.Debugf("Subscribing to the %v order book for %v", mkt, dc.acct.host)
 	req, err := msgjson.NewRequest(dc.NextID(), msgjson.OrderBookRoute, &msgjson.OrderBookSubscription{
-		Base:  base,
-		Quote: quote,
+		Base:  baseID,
+		Quote: quoteID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error encoding 'orderbook' request: %w", err)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -8765,15 +8765,6 @@ func (c *Core) listen(dc *dexConnection) {
 	}()
 
 	checkTrades := func() {
-		// checkTrades should be snappy. If it takes too long we are creating
-		// lock contention.
-		tStart := time.Now()
-		defer func() {
-			if eTime := time.Since(tStart); eTime > 250*time.Millisecond {
-				c.log.Warnf("checkTrades completed in %v (slow)", eTime)
-			}
-		}()
-
 		var doneTrades, activeTrades []*trackedTrade
 		// NOTE: Don't lock tradeMtx while also locking a trackedTrade's mtx
 		// since we risk blocking access to the trades map if there is lock
@@ -8813,7 +8804,7 @@ func (c *Core) listen(dc *dexConnection) {
 		updatedAssets := make(assetMap)
 		for _, trade := range doneTrades {
 			trade.mtx.Lock()
-			c.log.Infof("Retiring inactive order %v in status %v", trade.ID(), trade.metaData.Status)
+			c.log.Debugf("Retiring inactive order %v in status %v", trade.ID(), trade.metaData.Status)
 			trade.returnCoins()
 			trade.mtx.Unlock()
 			updatedAssets.count(trade.wallets.fromWallet.AssetID)

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -6287,7 +6287,7 @@ func (c *Core) prepareMultiTradeRequests(pw []byte, form *MultiTradeForm) ([]*tr
 	}
 
 	if len(allCoins) != len(form.Placements) {
-		c.log.Infof("FundMultiOrder only funded %d orders out of %d", len(allCoins), len(form.Placements))
+		c.log.Infof("FundMultiOrder only funded %d orders out of %d (options = %+v)", len(allCoins), len(form.Placements), form.Options)
 	}
 	defer func() {
 		if _, err := c.updateWalletBalance(fromWallet); err != nil {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2047,7 +2047,7 @@ func (c *Core) connectAndUpdateWalletResumeTrades(w *xcWallet, resumeTrades bool
 		}
 	}
 
-	c.log.Infof("Connecting wallet for %s", unbip(assetID))
+	c.log.Debugf("Connecting wallet for %s", unbip(assetID))
 	addr := w.currentDepositAddress()
 	newAddr, err := c.connectWalletResumeTrades(w, resumeTrades)
 	if err != nil {
@@ -3133,7 +3133,7 @@ func (c *Core) walletCheckAndNotify(w *xcWallet) bool {
 	}
 	if synced && !wasSynced {
 		c.updateWalletBalance(w)
-		c.log.Infof("Wallet synced for asset %s", unbip(w.AssetID))
+		c.log.Debugf("Wallet synced for asset %s", unbip(w.AssetID))
 		c.updateBondReserves(w.AssetID)
 	}
 	return synced
@@ -7161,7 +7161,7 @@ func (c *Core) initialize() error {
 			continue
 		}
 		// Wallet is loaded from the DB, but not yet connected.
-		c.log.Infof("Loaded %s wallet configuration.", unbip(assetID))
+		c.log.Tracef("Loaded %s wallet configuration.", unbip(assetID))
 		c.updateWallet(assetID, wallet)
 	}
 

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -852,7 +852,7 @@ func (t *trackedTrade) negotiate(msgMatches []*msgjson.Match) error {
 	// Record any cancel order Match and update order status.
 	var metaCancelMatch *db.MetaMatch
 	if cancelMatch != nil {
-		t.dc.log.Infof("Maker notification for cancel order received for order %s. match id = %s",
+		t.dc.log.Infof("Order %s canceled. match id = %s",
 			t.ID(), cancelMatch.MatchID)
 
 		// Set this order status to Canceled and unlock any locked coins
@@ -1092,7 +1092,8 @@ func (t *trackedTrade) processCancelMatch(msgMatch *msgjson.Match) error {
 	if oid != t.cancel.ID() {
 		return fmt.Errorf("negotiate called for wrong order. %s != %s", oid, t.cancel.ID())
 	}
-	t.dc.log.Infof("Taker notification for cancel order %v received. Match id = %s", oid, mid)
+	// Maker notification is logged at info.
+	t.dc.log.Debugf("Taker notification for cancel order %v received. Match id = %s", oid, mid)
 	t.cancel.matches.taker = msgMatch
 	// Store the completed taker cancel match.
 	takerCancelMeta := t.makeMetaMatch(t.cancel.matches.taker)
@@ -2541,7 +2542,7 @@ func (c *Core) sendInitAsync(t *trackedTrade, match *matchTracker, coinID, contr
 		return
 	}
 
-	c.log.Infof("Notifying DEX %s of our %s swap contract %v for match %s",
+	c.log.Debugf("Notifying DEX %s of our %s swap contract %v for match %s",
 		t.dc.acct.host, t.wallets.fromWallet.Symbol, coinIDString(t.wallets.fromWallet.AssetID, coinID), match)
 
 	// Send the init request asynchronously.
@@ -2811,7 +2812,7 @@ func (c *Core) sendRedeemAsync(t *trackedTrade, match *matchTracker, coinID, sec
 		return
 	}
 
-	c.log.Infof("Notifying DEX %s of our %s swap redemption %v for match %s",
+	c.log.Debugf("Notifying DEX %s of our %s swap redemption %v for match %s",
 		t.dc.acct.host, t.wallets.toWallet.Symbol, coinIDString(t.wallets.toWallet.AssetID, coinID), match)
 
 	// Send the redeem request asynchronously.

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -1801,7 +1801,6 @@ func (u *unifiedExchangeAdaptor) withdraw(ctx context.Context, assetID uint32, a
 		return err
 	}
 
-	u.balancesMtx.Lock()
 	withdrawalID, err := u.CEX.Withdraw(ctx, assetID, amount, addr)
 	if err != nil {
 		return err
@@ -1812,6 +1811,7 @@ func (u *unifiedExchangeAdaptor) withdraw(ctx context.Context, assetID uint32, a
 	} else {
 		u.pendingQuoteRebalance.Store(true)
 	}
+	u.balancesMtx.Lock()
 	u.pendingWithdrawals[withdrawalID] = &pendingWithdrawal{
 		eventLogID:   u.eventLogID.Add(1),
 		timestamp:    time.Now().Unix(),

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -1801,8 +1801,10 @@ func (u *unifiedExchangeAdaptor) withdraw(ctx context.Context, assetID uint32, a
 		return err
 	}
 
+	u.balancesMtx.Lock()
 	withdrawalID, err := u.CEX.Withdraw(ctx, assetID, amount, addr)
 	if err != nil {
+		u.balancesMtx.Unlock()
 		return err
 	}
 	u.log.Infof("Withdrew %s", u.fmtQty(assetID, amount))
@@ -1811,7 +1813,6 @@ func (u *unifiedExchangeAdaptor) withdraw(ctx context.Context, assetID uint32, a
 	} else {
 		u.pendingQuoteRebalance.Store(true)
 	}
-	u.balancesMtx.Lock()
 	u.pendingWithdrawals[withdrawalID] = &pendingWithdrawal{
 		eventLogID:   u.eventLogID.Add(1),
 		timestamp:    time.Now().Unix(),

--- a/client/mm/libxc/binance.go
+++ b/client/mm/libxc/binance.go
@@ -564,7 +564,7 @@ func (bnc *binance) readCoins(coins []*bntypes.CoinInfo) {
 	for _, nfo := range coins {
 		for _, netInfo := range nfo.NetworkList {
 			if !netInfo.WithdrawEnable || !netInfo.DepositEnable {
-				bnc.log.Infof("Skipping %s network %s because deposits and/or withdraws are not enabled.", netInfo.Coin, netInfo.Network)
+				// bnc.log.Tracef("Skipping %s network %s because deposits and/or withdraws are not enabled.", netInfo.Coin, netInfo.Network)
 				continue
 			}
 			symbol := binanceCoinNetworkToDexSymbol(nfo.Coin, netInfo.Network)
@@ -1267,10 +1267,9 @@ func (bnc *binance) handleOutboundAccountPosition(update *bntypes.StreamUpdate) 
 
 	bnc.balanceMtx.Lock()
 	for _, bal := range update.Balances {
-		symbol := strings.ToLower(bal.Asset)
-		processSymbol(symbol, bal)
-		if symbol == "eth" {
-			processSymbol("weth", bal)
+		processSymbol(bal.Asset, bal)
+		if bal.Asset == "ETH" {
+			processSymbol("WETH", bal)
 		}
 	}
 	bnc.balanceMtx.Unlock()
@@ -1847,10 +1846,7 @@ func (bnc *binance) TradeStatus(ctx context.Context, tradeID string, baseID, quo
 }
 
 func getDEXAssetIDs(coin string, tokenIDs map[string][]uint32) []uint32 {
-	dexSymbol := strings.ToLower(coin)
-	if convertedDEXSymbol, found := binanceToDexSymbol[coin]; found {
-		dexSymbol = strings.ToLower(convertedDEXSymbol)
-	}
+	dexSymbol := convertBnCoin(coin)
 
 	// Binance does not differentiate between eth and weth like we do.
 	dexNonTokenSymbol := dexSymbol

--- a/client/mm/libxc/binance.go
+++ b/client/mm/libxc/binance.go
@@ -579,7 +579,7 @@ func (bnc *binance) readCoins(coins []*bntypes.CoinInfo) {
 			}
 			ui, err := asset.UnitInfo(assetID)
 			if err != nil {
-				bnc.log.Error("known asset but no unit info")
+				// not a registered asset
 				continue
 			}
 			withdrawMin := uint64(math.Round(float64(ui.Conventional.ConversionFactor) * netInfo.WithdrawMin))

--- a/client/mm/libxc/binance_live_test.go
+++ b/client/mm/libxc/binance_live_test.go
@@ -179,7 +179,7 @@ func TestMatchedMarkets(t *testing.T) {
 	}
 
 	for _, market := range markets {
-		fmt.Printf("%s_%s \n", dex.BipIDSymbol(market.BaseID), dex.BipIDSymbol(market.QuoteID))
+		fmt.Printf("%s_%s %d %d\n", dex.BipIDSymbol(market.BaseID), dex.BipIDSymbol(market.QuoteID), market.BaseMinWithdraw, market.QuoteMinWithdraw)
 	}
 }
 

--- a/client/mm/libxc/bntypes/types.go
+++ b/client/mm/libxc/bntypes/types.go
@@ -38,7 +38,7 @@ type NetworkInfo struct {
 	WithdrawFee    float64 `json:"withdrawFee,string"`
 	// WithdrawIntegerMultiple float64 `json:"withdrawIntegerMultiple,string"`
 	// WithdrawMax             float64 `json:"withdrawMax,string"`
-	// WithdrawMin             float64 `json:"withdrawMin,string"`
+	WithdrawMin float64 `json:"withdrawMin,string"`
 	// SameAddress             bool    `json:"sameAddress"`
 	// EstimatedArrivalTime    int     `json:"estimatedArrivalTime"`
 	// Busy                    bool    `json:"busy"`

--- a/client/mm/libxc/interface.go
+++ b/client/mm/libxc/interface.go
@@ -89,7 +89,7 @@ type CEX interface {
 	// Balance returns the balance of an asset at the CEX.
 	Balance(assetID uint32) (*ExchangeBalance, error)
 	// Balances returns the balances of known assets on the CEX.
-	Balances() (map[uint32]*ExchangeBalance, error)
+	Balances(ctx context.Context) (map[uint32]*ExchangeBalance, error)
 	// CancelTrade cancels a trade on the CEX.
 	CancelTrade(ctx context.Context, baseID, quoteID uint32, tradeID string) error
 	// MatchedMarkets returns the list of markets at the CEX.

--- a/client/mm/libxc/interface.go
+++ b/client/mm/libxc/interface.go
@@ -43,9 +43,11 @@ type MarketDay struct {
 
 // Market is the base and quote assets of a market on a CEX.
 type Market struct {
-	BaseID  uint32     `json:"baseID"`
-	QuoteID uint32     `json:"quoteID"`
-	Day     *MarketDay `json:"day"`
+	BaseID           uint32     `json:"baseID"`
+	QuoteID          uint32     `json:"quoteID"`
+	Day              *MarketDay `json:"day"`
+	BaseMinWithdraw  uint64     `json:"baseMinWithdraw"`
+	QuoteMinWithdraw uint64     `json:"quoteMinWithdraw"`
 }
 
 type Status struct {

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -379,7 +379,7 @@ func (m *MarketMaker) connectCEX(ctx context.Context, c *centralizedExchange) er
 			return fmt.Errorf("error refreshing markets: %v", err)
 		}
 		c.mkts = mkts
-		bals, err := c.Balances()
+		bals, err := c.Balances(ctx)
 		if err != nil {
 			c.connectErr = err.Error()
 			return fmt.Errorf("error getting balances: %v", err)
@@ -450,7 +450,7 @@ func (m *MarketMaker) loadCEX(ctx context.Context, cfg *CEXConfig) (*centralized
 		c.mkts = make(map[string]*libxc.Market)
 		c.connectErr = err.Error()
 	}
-	if c.balances, err = c.Balances(); err != nil {
+	if c.balances, err = c.Balances(ctx); err != nil {
 		m.log.Errorf("Failed to get balances for %s: %w", cfg.Name, err)
 		c.balances = make(map[uint32]*libxc.ExchangeBalance)
 		c.connectErr = err.Error()
@@ -473,7 +473,7 @@ func (m *MarketMaker) handleCEXUpdate(cexName string, ni interface{}) {
 		cex.mtx.Lock()
 		cex.balances[n.AssetID] = n.Balance
 		cex.mtx.Unlock()
-		m.core.Broadcast(newCexUpdateNote(cexName, NoteTypeCEXBalanceUpdate, ni))
+		m.core.Broadcast(newCexUpdateNote(cexName, TopicBalanceUpdate, ni))
 	}
 }
 

--- a/client/mm/mm_test.go
+++ b/client/mm/mm_test.go
@@ -418,7 +418,7 @@ var _ libxc.CEX = (*tCEX)(nil)
 func (c *tCEX) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	return &sync.WaitGroup{}, nil
 }
-func (c *tCEX) Balances() (map[uint32]*libxc.ExchangeBalance, error) {
+func (c *tCEX) Balances(ctx context.Context) (map[uint32]*libxc.ExchangeBalance, error) {
 	return nil, nil
 }
 func (c *tCEX) MatchedMarkets(ctx context.Context) ([]*libxc.MarketMatch, error) {

--- a/client/mm/notification.go
+++ b/client/mm/notification.go
@@ -49,18 +49,18 @@ type runEventNote struct {
 	db.Notification
 
 	Host      string             `json:"host"`
-	Base      uint32             `json:"base"`
-	Quote     uint32             `json:"quote"`
+	BaseID    uint32             `json:"baseID"`
+	QuoteID   uint32             `json:"quoteID"`
 	StartTime int64              `json:"startTime"`
 	Event     *MarketMakingEvent `json:"event"`
 }
 
-func newRunEventNote(host string, base, quote uint32, startTime int64, event *MarketMakingEvent) *runEventNote {
+func newRunEventNote(host string, baseID, quoteID uint32, startTime int64, event *MarketMakingEvent) *runEventNote {
 	return &runEventNote{
 		Notification: db.NewNotification(NoteTypeRunEvent, "", "", "", db.Data),
 		Host:         host,
-		Base:         base,
-		Quote:        quote,
+		BaseID:       baseID,
+		QuoteID:      quoteID,
 		StartTime:    startTime,
 		Event:        event,
 	}

--- a/client/mm/notification.go
+++ b/client/mm/notification.go
@@ -4,26 +4,14 @@
 package mm
 
 import (
-	"fmt"
-
 	"decred.org/dcrdex/client/db"
-	"decred.org/dcrdex/dex"
 )
 
 const (
-	NoteTypeValidation       = "validation"
-	NoteTypeRunStats         = "runstats"
-	NoteTypeRunEvent         = "runevent"
-	NoteTypeCEXBalanceUpdate = "cexbal"
+	NoteTypeRunStats        = "runstats"
+	NoteTypeRunEvent        = "runevent"
+	NoteTypeCEXNotification = "cexnote"
 )
-
-func newValidationErrorNote(host string, baseID, quoteID uint32, errorMsg string) *db.Notification {
-	baseSymbol := dex.BipIDSymbol(baseID)
-	quoteSymbol := dex.BipIDSymbol(quoteID)
-	msg := fmt.Sprintf("%s-%s @ %s: %s", baseSymbol, quoteSymbol, host, errorMsg)
-	note := db.NewNotification(NoteTypeValidation, "", "Bot Config Validation Error", msg, db.ErrorLevel)
-	return &note
-}
 
 type runStatsNote struct {
 	db.Notification
@@ -72,9 +60,13 @@ type cexNotification struct {
 	Note    interface{} `json:"note"`
 }
 
-func newCexUpdateNote(cexName string, noteType string, note interface{}) *cexNotification {
+const (
+	TopicBalanceUpdate = "BalanceUpdate"
+)
+
+func newCexUpdateNote(cexName string, topic db.Topic, note interface{}) *cexNotification {
 	return &cexNotification{
-		Notification: db.NewNotification(noteType, "", "", "", db.Data),
+		Notification: db.NewNotification(NoteTypeCEXNotification, topic, "", "", db.Data),
 		CEXName:      cexName,
 		Note:         note,
 	}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -185,7 +185,7 @@
           <button data-tmpl="doNothingBttn" class="flex-grow-1 me-2 danger">Do Nothing</button>
           <button data-tmpl="recoverBttn" class="flex-grow-1 ms-2">Attempt Recovery</button>
         </div>
-        <div data-tmpl="errMsg" class="p-2 errcolor d-hide"></div>
+        <div data-tmpl="errMsg" class="p-2 text-warning d-hide"></div>
       </div>
 
       <div id="tooCheapTmpl" class="flex-stretch-column mt-2">
@@ -199,7 +199,7 @@
           <button data-tmpl="keepWaitingBttn" class="flex-grow-1 me-2">Keep Waiting</button>
           <button data-tmpl="addFeesBttn" class="flex-grow-1 ms-2">Add Fees</button>
         </div>
-        <div data-tmpl="errMsg" class="p-2 errcolor d-hide"></div>
+        <div data-tmpl="errMsg" class="p-2 text-warning d-hide"></div>
       </div>
 
       <div id="lostNonceTmpl" class="flex-stretch-column mt-2">
@@ -221,7 +221,7 @@
           <input type="text" data-tmpl="idInput" class="flex-grow-1">
           <button data-tmpl="replaceBttn" class="ms-2">Submit</button>
         </div>
-        <div data-tmpl="errMsg" class="p-2 errcolor d-hide"></div>
+        <div data-tmpl="errMsg" class="p-2 text-warning d-hide"></div>
       </div>
 
       <div id="rejectedRedemptionTmpl" class="flex-stretch-column mt-2">
@@ -241,7 +241,7 @@
             Find technical support
           </a>
         </div>
-        <div data-tmpl="errMsg" class="p-2 errcolor mt-2 d-hide"></div>
+        <div data-tmpl="errMsg" class="p-2 text-warning mt-2 d-hide"></div>
       </div>
 
     </div>

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -872,8 +872,26 @@
           <td class="ps-3">
             <img class="mini-icon" data-cex-logo>
           </td>
-          <td data-tmpl="cexBaseInventory" class="text-end"></td>
-          <td data-tmpl="cexQuoteInventory" class="no-stretch text-end pe-3"></td>
+          <td class="text-end">
+            <div class="d-inline-flex flex-column align-items-end text-nowrap">
+              <span data-tmpl="cexBaseInventory"></span>
+              <span class="fs14 grey">
+                <span>~</span>
+                <span data-tmpl="cexBaseInventoryFiat"></span>
+                <span>USD</span>
+              </span>
+            </div>
+          </td>
+          <td class="no-stretch text-end pe-3">
+            <div class="d-inline-flex flex-column text-nowrap">
+              <span data-tmpl="cexQuoteInventory"></span>
+              <span class="fs14 grey">
+                <span>~</span>
+                <span data-tmpl="cexQuoteInventoryFiat"></span>
+                <span>USD</span>
+              </span>
+            </div>
+          </td>
         </tr>
       </tbody>
     </table>

--- a/client/webserver/site/src/html/mm.tmpl
+++ b/client/webserver/site/src/html/mm.tmpl
@@ -73,11 +73,12 @@
                           <span data-tmpl="usdBalance"></span>
                           <span class="grey fs15 ms-1">USD</span>
                         </div>
+                        <button data-tmpl="reconfigBttn" class="ico-settings ms-2"></button>
                       </div>
                     </td>
                     <td data-tmpl="connectErrBox" class="d-hide pe-3">
-                      <span data-tmpl="connectErr" class="errcolor"></span>
-                      <button data-tmpl="reconfigureBttn" class="ico-settings ms-2 d-hide"></button>
+                      <span data-tmpl="connectErr" class="text-warning"></span>
+                      <button data-tmpl="errConfigureBttn" class="ico-settings ms-2"></button>
                     </td>
                   </tr>
                 </tbody>

--- a/client/webserver/site/src/html/mmsettings.tmpl
+++ b/client/webserver/site/src/html/mmsettings.tmpl
@@ -484,6 +484,20 @@
                       <span data-fee-ticker></span> per lot
                     </span>
                   </div>
+                  <div data-tmpl="redemptionFeesBox" class="flex-stretch-column">
+                    <div class="d-flex align-items-end justify-content-end">
+                      <span class="fs14 grey me-1">+</span>
+                      <span data-tmpl="redemptionFeesLots" class="fs16"></span>
+                      <span class="fs14 grey ms-1">redeems</span>
+                    </div>
+                    <div class="d-flex align-items-end justify-content-end">
+                      <span class="fs14 grey me-1">x</span>
+                      <span data-tmpl="redemptionFeesPerLot" class="fs16"></span>
+                      <span class="fs14 grey ms-1">
+                        <span data-fee-ticker></span> per redeem
+                      </span>
+                    </div>
+                  </div>
                   <div class="d-flex align-items-end justify-content-end">
                     <span class="fs14 grey me-1">=</span>
                     <span data-tmpl="bookingFees" class="fs16"></span>

--- a/client/webserver/site/src/html/mmsettings.tmpl
+++ b/client/webserver/site/src/html/mmsettings.tmpl
@@ -484,6 +484,11 @@
                       <span data-fee-ticker></span> per lot
                     </span>
                   </div>
+                  <div class="d-flex align-items-end justify-content-end">
+                    <span class="fs14 grey me-1">x</span>
+                    <span data-tmpl="swapReservesFactor" class="fs16"></span>
+                    <span class="fs14 grey ms-1">reserves</span>
+                  </div>
                   <div data-tmpl="redemptionFeesBox" class="flex-stretch-column">
                     <div class="d-flex align-items-end justify-content-end">
                       <span class="fs14 grey me-1">+</span>
@@ -496,6 +501,11 @@
                       <span class="fs14 grey ms-1">
                         <span data-fee-ticker></span> per redeem
                       </span>
+                    </div>
+                    <div class="d-flex align-items-end justify-content-end">
+                      <span class="fs14 grey me-1">x</span>
+                      <span data-tmpl="redeemReservesFactor" class="fs16"></span>
+                      <span class="fs14 grey ms-1">reserves</span>
                     </div>
                   </div>
                   <div class="d-flex align-items-end justify-content-end">

--- a/client/webserver/site/src/html/mmsettings.tmpl
+++ b/client/webserver/site/src/html/mmsettings.tmpl
@@ -338,7 +338,7 @@
             <div>
               <button id="deleteBttn" class="danger">Delete This Program</button>
             </div>
-            <div id="deleteErr" class="errcolor pt-2 d-hide"></div>
+            <div id="deleteErr" class="text-warning pt-2 d-hide"></div>
           </div>
         </div>
       </section>

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -57,7 +57,9 @@ import {
   RejectedRedemptionData,
   MarketMakingStatus,
   RunStatsNote,
-  MMBotStatus
+  MMBotStatus,
+  CEXNotification,
+  CEXBalanceUpdate
 } from './registry'
 import { setCoinHref } from './coinexplorers'
 
@@ -1157,6 +1159,17 @@ export default class Application {
           bot.runStats = n.stats
           bot.running = Boolean(n.stats)
         }
+        break
+      }
+      case 'cexnote': {
+        const n = note as CEXNotification
+        switch (n.topic) {
+          case 'BalanceUpdate': {
+            const u = n.note as CEXBalanceUpdate
+            this.mmStatus.cexes[n.cexName].balances[u.assetID] = u.balance
+          }
+        }
+        break
       }
     }
   }

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -1496,10 +1496,9 @@ export default class Application {
    * a subsequent call.
   */
   async txHistory (assetID: number, n: number, after?: string): Promise<TxHistoryResult> {
-    const url = '/api/txhistory'
     const cachedTxHistory = this.txHistoryMap[assetID]
     if (!cachedTxHistory) {
-      const res = await postJSON(url, {
+      const res = await postJSON('/api/txhistory', {
         n: n,
         assetID: assetID
       })

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -1496,9 +1496,10 @@ export default class Application {
    * a subsequent call.
   */
   async txHistory (assetID: number, n: number, after?: string): Promise<TxHistoryResult> {
+    const url = '/api/txhistory'
     const cachedTxHistory = this.txHistoryMap[assetID]
     if (!cachedTxHistory) {
-      const res = await postJSON('/api/txhistory', {
+      const res = await postJSON(url, {
         n: n,
         assetID: assetID
       })

--- a/client/webserver/site/src/js/doc.ts
+++ b/client/webserver/site/src/js/doc.ts
@@ -30,11 +30,11 @@ const BipIDs: Record<number, string> = {
   3: 'doge',
   145: 'bch',
   60: 'eth',
+  60001: 'usdc.eth',
+  60002: 'usdt.eth',
   136: 'firo',
   133: 'zec',
   966: 'polygon',
-  60001: 'usdc.eth',
-  60002: 'usdt.eth',
   966001: 'usdc.polygon',
   966002: 'weth.polygon',
   966003: 'wbtc.polygon',
@@ -451,6 +451,14 @@ export default class Doc {
 
   static bipIDFromSymbol (symbol: string): number {
     return BipSymbolIDs[symbol]
+  }
+
+  static bipCEXSymbol (assetID: number): string {
+    const bipSymbol = BipIDs[assetID]
+    if (!bipSymbol || bipSymbol === '') return ''
+    const parts = bipSymbol.split('.')
+    if (parts[0] === 'weth') return 'eth'
+    return parts[0]
   }
 
   static logoPathFromID (assetID: number): string {

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -520,7 +520,8 @@ export default class MarketsPage extends BasePage {
           this.mmRunning = Boolean(note.stats)
           this.resolveOrderFormVisibility()
         }
-      }
+      },
+      runevent: (/* note: RunEventNote */) => { this.mm.update() }
     })
 
     this.loadingAnimations = {}

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -642,6 +642,7 @@ class Bot extends BotMarket {
       const feeReq = f.base.fees.req + (baseFeeID === quoteFeeID ? f.quote.fees.req : 0)
       page.proposedDexBaseFeeAlloc.textContent = Doc.formatFourSigFigs(feeReq)
       page.proposedDexBaseFeeAllocUSD.textContent = Doc.formatFourSigFigs(feeReq * baseFeeFiatRate)
+      page.proposedDexBaseFeeAlloc.classList.toggle('text-warning', !f.base.fees.funded)
     }
 
     const needQuoteTokenFees = quoteFeeID !== quoteID && quoteFeeID !== baseFeeID
@@ -650,6 +651,7 @@ class Bot extends BotMarket {
       const feeReq = f.quote.fees.req
       page.proposedDexQuoteFeeAlloc.textContent = Doc.formatFourSigFigs(feeReq)
       page.proposedDexQuoteFeeAllocUSD.textContent = Doc.formatFourSigFigs(feeReq * quoteFeeFiatRate)
+      page.proposedDexQuoteFeeAlloc.classList.toggle('text-warning', !f.quote.fees.funded)
     }
 
     Doc.show(page.allocationDialog)

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -684,9 +684,10 @@ class Bot extends BotMarket {
 
     try {
       app().log('mm', 'starting mm bot', startConfig)
-      await MM.startBot(startConfig)
+      const res = await MM.startBot(startConfig)
+      if (!app().checkResponse(res)) throw res
     } catch (e) {
-      page.errMsg.textContent = intl.prep(intl.ID_API_ERROR, e.msg)
+      page.errMsg.textContent = intl.prep(intl.ID_API_ERROR, e)
       Doc.show(page.errMsg)
       return
     }

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -3,6 +3,7 @@ import {
   PageElement,
   MMBotStatus,
   RunStatsNote,
+  RunEventNote,
   ExchangeBalance,
   StartConfig,
   OrderPlacement,
@@ -220,7 +221,11 @@ export default class MarketMakerPage extends BasePage {
 
     const botConfigs = mmStatus.bots.map((s: MMBotStatus) => s.config)
     app().registerNoteFeeder({
-      runstats: (note: RunStatsNote) => { this.handleRunStatsNote(note) }
+      runstats: (note: RunStatsNote) => { this.handleRunStatsNote(note) },
+      runevent: (note: RunEventNote) => {
+        const bot = this.bots[hostedMarketID(note.host, note.baseID, note.quoteID)]
+        if (bot) return bot.handleRunStats()
+      }
       // TODO bot start-stop notification
     })
 

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -95,7 +95,7 @@ function parseFundingOptions (f: FundingOutlook): [number, number, FundingSlider
         // We did something really bad with math to get here.
         throw Error('bad math has us with dex surplus + cex underfund invalid remains')
       }
-      proposedDex += cexShort
+      proposedDex += cexShort + transferable
     } else {
       // We don't have enough on dex, but we have enough on cex to cover the
       // short.
@@ -104,7 +104,7 @@ function parseFundingOptions (f: FundingOutlook): [number, number, FundingSlider
       if (cexRemain < dexShort) {
         throw Error('bad math got us with cex surplus + dex underfund invalid remains')
       }
-      proposedCex += dexShort
+      proposedCex += dexShort + transferable
     }
   } else if (f.fundedAndBalanced && transferable > 0) {
     // This asset is fully funded, but the user may choose to fund order

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -579,8 +579,9 @@ class Bot extends BotMarket {
         [quoteID]: proposedCexQuote * quoteFactor
       }
     }
-    alloc.dex[baseFeeID] = Math.min((alloc.dex[baseFeeID] ?? 0) + f.base.fees.req, f.base.fees.avail) * baseFeeFactor
-    alloc.dex[quoteFeeID] = Math.min((alloc.dex[quoteFeeID] ?? 0) + f.quote.fees.req, f.quote.fees.avail) * quoteFeeFactor
+
+    alloc.dex[baseFeeID] = Math.min((alloc.dex[baseFeeID] ?? 0) + (f.base.fees.req * baseFeeFactor), f.base.fees.avail * baseFeeFactor)
+    alloc.dex[quoteFeeID] = Math.min((alloc.dex[quoteFeeID] ?? 0) + (f.quote.fees.req * quoteFeeFactor), f.quote.fees.avail * quoteFeeFactor)
 
     let totalUSD = (alloc.dex[baseID] / baseFactor * baseFiatRate) + (alloc.dex[quoteID] / quoteFactor * quoteFiatRate)
     totalUSD += (alloc.cex[baseID] / baseFactor * baseFiatRate) + (alloc.cex[quoteID] / quoteFactor * quoteFiatRate)

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -329,8 +329,12 @@ export default class MarketMakerPage extends BasePage {
     tmpl.logo.classList.toggle('greyscale', !status)
     if (!status) return
     let usdBal = 0
+    const cexSymbolAdded : Record<string, boolean> = {} // avoid double counting tokens or counting both eth and weth
     for (const [assetIDStr, bal] of Object.entries(status.balances)) {
       const assetID = parseInt(assetIDStr)
+      const cexSymbol = Doc.bipCEXSymbol(assetID)
+      if (cexSymbolAdded[cexSymbol]) continue
+      cexSymbolAdded[cexSymbol] = true
       const { unitInfo } = app().assets[assetID]
       const fiatRate = app().fiatRatesMap[assetID]
       if (fiatRate) usdBal += fiatRate * (bal.available + bal.locked) / unitInfo.conventional.conversionFactor

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -206,10 +206,13 @@ export default class MarketMakerPage extends BasePage {
       const tr = page.exchangeRowTmpl.cloneNode(true) as PageElement
       page.cexRows.appendChild(tr)
       const tmpl = Doc.parseTemplate(tr)
-      Doc.bind(tmpl.configureBttn, 'click', () => {
+      const configure = () => {
         this.cexConfigForm.setCEX(cexName)
         this.forms.show(page.cexConfigForm)
-      })
+      }
+      Doc.bind(tmpl.configureBttn, 'click', configure)
+      Doc.bind(tmpl.reconfigBttn, 'click', configure)
+      Doc.bind(tmpl.errConfigureBttn, 'click', configure)
       const row = this.cexes[cexName] = { tr, tmpl, dinfo, cexName }
       this.updateCexRow(row)
     }

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -574,8 +574,8 @@ class Bot extends BotMarket {
         [quoteID]: proposedCexQuote * quoteFactor
       }
     }
-    alloc.dex[baseFeeID] = (alloc.dex[baseFeeID] ?? 0) + f.base.fees.req * baseFeeFactor
-    alloc.dex[quoteFeeID] = (alloc.dex[quoteFeeID] ?? 0) + f.quote.fees.req * quoteFeeFactor
+    alloc.dex[baseFeeID] = Math.min((alloc.dex[baseFeeID] ?? 0) + f.base.fees.req, f.base.fees.avail) * baseFeeFactor
+    alloc.dex[quoteFeeID] = Math.min((alloc.dex[quoteFeeID] ?? 0) + f.quote.fees.req, f.quote.fees.avail) * quoteFeeFactor
 
     let totalUSD = (alloc.dex[baseID] / baseFactor * baseFiatRate) + (alloc.dex[quoteID] / quoteFactor * quoteFiatRate)
     totalUSD += (alloc.cex[baseID] / baseFactor * baseFiatRate) + (alloc.cex[quoteID] / quoteFactor * quoteFiatRate)
@@ -639,18 +639,19 @@ class Bot extends BotMarket {
 
     Doc.setVis(baseFeeID !== baseID, ...Doc.applySelector(page.allocationDialog, '[data-base-token-fees]'))
     if (baseFeeID !== baseID) {
-      const feeReq = f.base.fees.req + (baseFeeID === quoteFeeID ? f.quote.fees.req : 0)
-      page.proposedDexBaseFeeAlloc.textContent = Doc.formatFourSigFigs(feeReq)
-      page.proposedDexBaseFeeAllocUSD.textContent = Doc.formatFourSigFigs(feeReq * baseFeeFiatRate)
+      const reqFees = f.base.fees.req + (baseFeeID === quoteFeeID ? f.quote.fees.req : 0)
+      const proposedFees = Math.min(reqFees, f.base.fees.avail)
+      page.proposedDexBaseFeeAlloc.textContent = Doc.formatFourSigFigs(proposedFees)
+      page.proposedDexBaseFeeAllocUSD.textContent = Doc.formatFourSigFigs(proposedFees * baseFeeFiatRate)
       page.proposedDexBaseFeeAlloc.classList.toggle('text-warning', !f.base.fees.funded)
     }
 
     const needQuoteTokenFees = quoteFeeID !== quoteID && quoteFeeID !== baseFeeID
     Doc.setVis(needQuoteTokenFees, ...Doc.applySelector(page.allocationDialog, '[data-quote-token-fees]'))
     if (needQuoteTokenFees) {
-      const feeReq = f.quote.fees.req
-      page.proposedDexQuoteFeeAlloc.textContent = Doc.formatFourSigFigs(feeReq)
-      page.proposedDexQuoteFeeAllocUSD.textContent = Doc.formatFourSigFigs(feeReq * quoteFeeFiatRate)
+      const proposedFees = Math.min(f.quote.fees.req, f.quote.fees.avail)
+      page.proposedDexQuoteFeeAlloc.textContent = Doc.formatFourSigFigs(proposedFees)
+      page.proposedDexQuoteFeeAllocUSD.textContent = Doc.formatFourSigFigs(proposedFees * quoteFeeFiatRate)
       page.proposedDexQuoteFeeAlloc.classList.toggle('text-warning', !f.quote.fees.funded)
     }
 

--- a/client/webserver/site/src/js/mmlogs.ts
+++ b/client/webserver/site/src/js/mmlogs.ts
@@ -217,7 +217,7 @@ export default class MarketMakerLogsPage extends BasePage {
 
   handleRunEventNote (note: RunEventNote) {
     const { baseID, quoteID, host } = this.mkt
-    if (note.host !== host || note.base !== baseID || note.quote !== quoteID) return
+    if (note.host !== host || note.baseID !== baseID || note.quoteID !== quoteID) return
     if (!eventPassesFilter(note.event, this.filters)) return
     const event = note.event
     const cachedEvent = this.events[event.id]

--- a/client/webserver/site/src/js/mmsettings.ts
+++ b/client/webserver/site/src/js/mmsettings.ts
@@ -879,7 +879,8 @@ export default class MarketMakerSettingsPage extends BasePage {
 
     const { commit, fees } = feesAndCommit(
       baseID, quoteID, baseFees, quoteFees, lotSize, dexBaseLots, dexQuoteLots,
-      baseFeeAssetID, quoteFeeAssetID, baseIsAccountLocker, quoteIsAccountLocker
+      baseFeeAssetID, quoteFeeAssetID, baseIsAccountLocker, quoteIsAccountLocker,
+      cfg.baseConfig.orderReservesFactor, cfg.quoteConfig.orderReservesFactor
     )
 
     return {
@@ -2221,7 +2222,7 @@ class AssetPane {
     this.minTransferSlider = new MiniSlider(page.minTransferSlider, (r: number) => {
       const { cfg } = this
       const totalInventory = this.commit()
-      const [minV, maxV] = [0, totalInventory]
+      const [minV, maxV] = [this.minTransfer.min, Math.min(this.minTransfer.min, totalInventory)]
       cfg.transferFactor = r
       this.minTransfer.setValue(minV + r * (maxV - minV))
     })
@@ -2296,6 +2297,7 @@ class AssetPane {
     page.bookCommitment.textContent = Doc.formatFourSigFigs(inv.book)
     const feesPerLotConv = fees.bookingFeesPerLot / feeUI.conventional.conversionFactor
     page.bookingFeesPerLot.textContent = Doc.formatFourSigFigs(feesPerLotConv)
+    page.swapReservesFactor.textContent = fees.swapReservesFactor.toFixed(2)
     page.bookingFeesLots.textContent = String(lots)
     inv.bookingFees = fees.bookingFees / feeUI.conventional.conversionFactor
     page.bookingFees.textContent = Doc.formatFourSigFigs(inv.bookingFees)
@@ -2327,6 +2329,7 @@ class AssetPane {
       const feesPerLotConv = fees.bookingFeesPerCounterLot / feeUI.conventional.conversionFactor
       page.redemptionFeesPerLot.textContent = Doc.formatFourSigFigs(feesPerLotConv)
       page.redemptionFeesLots.textContent = String(counterLots)
+      page.redeemReservesFactor.textContent = fees.redeemReservesFactor.toFixed(2)
     }
     this.updateCommitTotal()
     this.updateTokenFees()
@@ -2354,7 +2357,7 @@ class AssetPane {
     Doc.setVis(showRebalance, page.rebalanceOpts)
     if (!showRebalance) return
     const totalInventory = this.commit()
-    const [minV, maxV] = [this.minTransfer.min, totalInventory]
+    const [minV, maxV] = [this.minTransfer.min, Math.min(this.minTransfer.min * 2, totalInventory)]
     const rangeV = maxV - minV
     this.minTransfer.setValue(minV + cfg.transferFactor * rangeV)
     this.minTransferSlider.setValue((cfg.transferFactor - defaultTransfer.minR) / defaultTransfer.range)

--- a/client/webserver/site/src/js/mmsettings.ts
+++ b/client/webserver/site/src/js/mmsettings.ts
@@ -2297,7 +2297,7 @@ class AssetPane {
     const feesPerLotConv = fees.bookingFeesPerLot / feeUI.conventional.conversionFactor
     page.bookingFeesPerLot.textContent = Doc.formatFourSigFigs(feesPerLotConv)
     page.bookingFeesLots.textContent = String(lots)
-    inv.bookingFees = lots * feesPerLotConv
+    inv.bookingFees = fees.bookingFees / feeUI.conventional.conversionFactor
     page.bookingFees.textContent = Doc.formatFourSigFigs(inv.bookingFees)
     if (cexName) {
       inv.cex = cexCommit / ui.conventional.conversionFactor

--- a/client/webserver/site/src/js/mmutil.ts
+++ b/client/webserver/site/src/js/mmutil.ts
@@ -1002,8 +1002,8 @@ export function feesAndCommit (
     base: {
       ...baseFees,
       bookingFeesPerLot: baseBookingFeesPerLot,
-      bookingFeesPerCounterLot: baseRedeemReservesPerLot + baseRedeemReservesPerLot * quoteLots,
-      bookingFees: baseBookingFeesPerLot * baseLots,
+      bookingFeesPerCounterLot: baseRedeemReservesPerLot,
+      bookingFees: baseBookingFeesPerLot * baseLots + baseRedeemReservesPerLot * quoteLots,
       tokenFeesPerSwap: baseTokenFeesPerSwap
     },
     quote: {

--- a/client/webserver/site/src/js/mmutil.ts
+++ b/client/webserver/site/src/js/mmutil.ts
@@ -722,7 +722,7 @@ export class BotMarket {
           funded: baseFeesFunded
         },
         fundedAndBalanced: baseFundedAndBalanced,
-        fundedAndNotBalanced: !baseFundedAndBalanced && baseAvail >= totalBaseReq
+        fundedAndNotBalanced: !baseFundedAndBalanced && baseAvail >= totalBaseReq && canRebalance
       },
       quote: {
         dex: {
@@ -742,7 +742,7 @@ export class BotMarket {
           funded: quoteFeesFunded
         },
         fundedAndBalanced: quoteFundedAndBalanced,
-        fundedAndNotBalanced: !quoteFundedAndBalanced && quoteAvail >= totalQuoteReq
+        fundedAndNotBalanced: !quoteFundedAndBalanced && quoteAvail >= totalQuoteReq && canRebalance
       },
       fundedAndBalanced,
       fundedAndNotBalanced,

--- a/client/webserver/site/src/js/mmutil.ts
+++ b/client/webserver/site/src/js/mmutil.ts
@@ -878,10 +878,10 @@ export class RunningMarketMakerDisplay {
 
     const dexBaseInv = summedBalance(runStats.dexBalances[baseID]) / baseFactor
     page.walletBaseInventory.textContent = Doc.formatFourSigFigs(dexBaseInv)
-    page.walletBaseInvFiat.textContent = Doc.formatFourSigFigs(dexBaseInv * baseFiatRate)
+    page.walletBaseInvFiat.textContent = Doc.formatFourSigFigs(dexBaseInv * baseFiatRate, 2)
     const dexQuoteInv = summedBalance(runStats.dexBalances[quoteID]) / quoteFactor
     page.walletQuoteInventory.textContent = Doc.formatFourSigFigs(dexQuoteInv)
-    page.walletQuoteInvFiat.textContent = Doc.formatFourSigFigs(dexQuoteInv * quoteFiatRate)
+    page.walletQuoteInvFiat.textContent = Doc.formatFourSigFigs(dexQuoteInv * quoteFiatRate, 2)
 
     Doc.setVis(cexName, page.cexRow)
     if (cexName) {
@@ -889,8 +889,10 @@ export class RunningMarketMakerDisplay {
       setCexElements(div, cexName)
       const cexBaseInv = summedBalance(runStats.cexBalances[baseID]) / baseFactor
       page.cexBaseInventory.textContent = Doc.formatFourSigFigs(cexBaseInv)
+      page.cexBaseInventoryFiat.textContent = Doc.formatFourSigFigs(cexBaseInv * baseFiatRate, 2)
       const cexQuoteInv = summedBalance(runStats.cexBalances[quoteID]) / quoteFactor
       page.cexQuoteInventory.textContent = Doc.formatFourSigFigs(cexQuoteInv)
+      page.cexQuoteInventoryFiat.textContent = Doc.formatFourSigFigs(cexQuoteInv * quoteFiatRate, 2)
     }
 
     if (baseFeeID !== baseID) {

--- a/client/webserver/site/src/js/mmutil.ts
+++ b/client/webserver/site/src/js/mmutil.ts
@@ -688,8 +688,9 @@ export class BotMarket {
     const totalQuoteReq = dexMinQuoteAlloc + cexMinQuoteAlloc + transferableQuoteAlloc
     const baseFundedAndBalanced = dexBaseFunded && cexBaseFunded && baseAvail >= totalBaseReq
     const quoteFundedAndBalanced = dexQuoteFunded && cexQuoteFunded && quoteAvail >= totalQuoteReq
-    const baseFeesFunded = (baseID === baseFeeID) || dexBaseFeeAvail >= dexBaseFeeReq
-    const quoteFeesFunded = (quoteID === quoteFeeID && dexQuoteFunded) || dexQuoteFeeAvail >= dexQuoteFeeReq
+    const baseFeesFunded = dexBaseFeeAvail >= dexBaseFeeReq
+    const quoteFeesFunded = dexQuoteFeeAvail >= dexQuoteFeeReq
+
     const fundedAndBalanced = baseFundedAndBalanced && quoteFundedAndBalanced && baseFeesFunded && quoteFeesFunded
 
     // Are we funded but not balanced, but able to rebalance with a cex?
@@ -1003,6 +1004,8 @@ export function feesAndCommit (
       ...baseFees,
       bookingFeesPerLot: baseBookingFeesPerLot,
       bookingFeesPerCounterLot: baseRedeemReservesPerLot,
+      // TODO: We may want to consider the order reserves factor too, since
+      // booking fees for the taker are not freed immediately after matching.
       bookingFees: baseBookingFeesPerLot * baseLots + baseRedeemReservesPerLot * quoteLots,
       tokenFeesPerSwap: baseTokenFeesPerSwap
     },

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -508,6 +508,18 @@ export interface LotFeeRange {
   estimated: LotFees
 }
 
+export interface AssetBookingFees extends LotFeeRange {
+  bookingFeesPerLot: number
+  bookingFeesPerCounterLot: number
+  bookingFees: number
+  tokenFeesPerSwap: number
+}
+
+export interface BookingFees {
+  base: AssetBookingFees
+  quote:AssetBookingFees
+}
+
 export interface MarketReport {
   price: number
   oracles: OracleReport[]

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -512,6 +512,8 @@ export interface AssetBookingFees extends LotFeeRange {
   bookingFeesPerLot: number
   bookingFeesPerCounterLot: number
   bookingFees: number
+  swapReservesFactor: number // (1 + orderReservesFactor)
+  redeemReservesFactor: number
   tokenFeesPerSwap: number
 }
 

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -466,8 +466,8 @@ export interface RunStatsNote extends CoreNote {
 
 export interface RunEventNote extends CoreNote {
   host: string
-  base: number
-  quote: number
+  baseID: number
+  quoteID: number
   startTime: number
   event: MarketMakingEvent
 }

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -989,6 +989,8 @@ interface MarketDay {
 export interface CEXMarket {
   baseID: number
   quoteID: number
+  baseMinWithdraw: number
+  quoteMinWithdraw: number
   day: MarketDay
 }
 

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -860,6 +860,16 @@ export interface RunningBotInventory {
   cex: BotInventory
 }
 
+export interface CEXNotification extends CoreNote {
+  cexName: string
+  note: any
+}
+
+export interface CEXBalanceUpdate {
+  assetID: number
+  balance: ExchangeBalance
+}
+
 export interface FeeEstimates extends LotFeeRange {
   bookingFeesPerLot: number
   bookingFees: number

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1850,7 +1850,7 @@ export default class WalletsPage extends BasePage {
     Doc.hide(page.txHistoryTable, page.txHistoryBox, page.noTxHistory, page.earlierTxs, page.txHistoryNotAvailable)
     Doc.empty(page.txHistoryTableBody)
     const w = app().assets[assetID].wallet
-    if (!w || (w.traits & traitHistorian) === 0) {
+    if (!w || w.disabled || (w.traits & traitHistorian) === 0) {
       Doc.show(page.txHistoryNotAvailable)
       return
     }

--- a/dex/logging.go
+++ b/dex/logging.go
@@ -33,7 +33,7 @@ const (
 	LevelCritical = slog.LevelCritical
 	LevelOff      = slog.LevelOff
 
-	DefaultLogLevel = LevelDebug // TODO: back to LevelInfo at some point
+	DefaultLogLevel = LevelInfo
 )
 
 // Logger is a logger. Many dcrdex types will take a logger as an argument.

--- a/dex/networks/polygon/params.go
+++ b/dex/networks/polygon/params.go
@@ -218,8 +218,8 @@ var (
 						Gas: dexeth.Gases{
 							Swap:      235_661,
 							SwapAdd:   146_368,
-							Redeem:    92_032,
-							RedeemAdd: 41_117,
+							Redeem:    122_032,
+							RedeemAdd: 61_117,
 							Refund:    82_059,
 							Approve:   67_693,
 							Transfer:  74_451,

--- a/dex/utils/generics.go
+++ b/dex/utils/generics.go
@@ -27,6 +27,14 @@ func MapItems[K comparable, V any](m map[K]V) []V {
 	return vs
 }
 
+func MapKeys[K comparable, V any](m map[K]V) []K {
+	ks := make([]K, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}
+
 func Min[I constraints.Ordered](m I, ns ...I) I {
 	min := m
 	for _, n := range ns {

--- a/docs/wiki/Simnet-Testing.md
+++ b/docs/wiki/Simnet-Testing.md
@@ -285,7 +285,7 @@ During this process, `bisonw` should log messages similar to the following:
 ...
 [TRC] CORE: processing tip change for dcr
 [DBG] CORE: Registration fee txn 326661613264653632393833386337653864616464643433326663333434633939636661323836633436373766393832666532626139656161306166393234393030303030303030 now has 1 confirmations.
-[INF] CORE: Notifying dex http://127.0.0.1:17273 of fee payment.
+[DBG] CORE: Notifying dex http://127.0.0.1:17273 of fee payment.
 [DBG] CORE: authenticated connection to http://127.0.0.1:17273
 [INF] CORE: notify: |SUCCESS| (fee payment) Account registered - You may now trade at http://127.0.0.1:17273
 ```


### PR DESCRIPTION
We weren't properly reserving redemption fees for evm assets when the counter-asset didn't share a fee asset.