### PR TITLE
app: Incorrect allocated amount displayed for base swap fees

### DIFF
--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -518,7 +518,7 @@ class Bot extends BotMarket {
       page.baseTokenBookingFees.textContent = Doc.formatFullPrecision(bookingFees * baseFeeFactor, baseFeeUI)
       page.baseTokenSwapFeeN.textContent = String(baseConfig.swapFeeN + (withQuote ? quoteConfig.swapFeeN : 0))
       const swapReserves = bProj.swapFeeReserves + (withQuote ? qProj.swapFeeReserves : 0)
-      page.baseTokenSwapFees.textContent = Doc.formatFullPrecision(swapReserves * baseFactor, baseFeeUI)
+      page.baseTokenSwapFees.textContent = Doc.formatFullPrecision(swapReserves * baseFeeFactor, baseFeeUI)
     }
 
     page.quoteAlloc.textContent = Doc.formatFullPrecision(alloc[quoteID], qui)


### PR DESCRIPTION
The conversion factor for the base asset was being used in stead of the conversion factor for the base fee asset.