### PR TITLE
client/eth: Tx history recipient bug

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -5123,6 +5123,13 @@ func (w *baseWallet) extendAndStoreTx(tx *types.Transaction, txType asset.Transa
 		w.log.Errorf("Error marshaling tx %q: %v", tx.Hash(), err)
 	}
 
+	if recipient == nil {
+		if to := tx.To(); to != nil {
+			s := to.String()
+			recipient = &s
+		}
+	}
+
 	now := time.Now()
 
 	wt := &extendedWalletTx{

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -688,7 +688,7 @@ func TestCheckPendingTxs(t *testing.T) {
 
 	val := dexeth.GweiToWei(1)
 	extendedTx := func(nonce, blockNum, blockStamp, submissionStamp uint64) *extendedWalletTx {
-		pendingTx := eth.extendedTx(node.newTransaction(nonce, val), asset.Send, 1)
+		pendingTx := eth.extendedTx(node.newTransaction(nonce, val), asset.Send, 1, nil)
 		pendingTx.BlockNumber = blockNum
 		pendingTx.Confirmed = blockNum > 0 && blockNum <= finalized
 		pendingTx.Timestamp = blockStamp
@@ -844,7 +844,7 @@ func TestTakeAction(t *testing.T) {
 
 	aGwei := dexeth.GweiToWei(1)
 
-	pendingTx := eth.extendedTx(node.newTransaction(0, aGwei), asset.Send, 1)
+	pendingTx := eth.extendedTx(node.newTransaction(0, aGwei), asset.Send, 1, nil)
 	eth.pendingTxs = []*extendedWalletTx{pendingTx}
 
 	feeCap := new(big.Int).Mul(aGwei, big.NewInt(5))
@@ -878,7 +878,7 @@ func TestTakeAction(t *testing.T) {
 		t.Fatal("didn't save to DB")
 	}
 
-	pendingTx = eth.extendedTx(node.newTransaction(1, aGwei), asset.Send, 1)
+	pendingTx = eth.extendedTx(node.newTransaction(1, aGwei), asset.Send, 1, nil)
 	eth.pendingTxs = []*extendedWalletTx{pendingTx}
 	pendingTx.SubmissionTime = 0
 	// Neglecting to bump should reset submission time.
@@ -917,7 +917,7 @@ func TestTakeAction(t *testing.T) {
 		t.Fatalf("replacement tx wasn't accepted")
 	}
 	// wrong nonce is an error though
-	pendingTx = eth.extendedTx(node.newTransaction(5050, aGwei), asset.Send, 1)
+	pendingTx = eth.extendedTx(node.newTransaction(5050, aGwei), asset.Send, 1, nil)
 	eth.pendingTxs = []*extendedWalletTx{pendingTx}
 	lostNonceAction = []byte(fmt.Sprintf(`{"txID":"%s","abandon":false,"replacementID":"%s"}`, pendingTx.ID, replacementTx.Hash()))
 	if err := eth.TakeAction(actionTypeLostNonce, lostNonceAction); err == nil {
@@ -925,7 +925,7 @@ func TestTakeAction(t *testing.T) {
 	}
 
 	// Missing nonces
-	tx5 := eth.extendedTx(node.newTransaction(5, aGwei), asset.Send, 1)
+	tx5 := eth.extendedTx(node.newTransaction(5, aGwei), asset.Send, 1, nil)
 	eth.pendingTxs = []*extendedWalletTx{tx5}
 	eth.confirmedNonceAt = big.NewInt(2)
 	eth.pendingNonceAt = big.NewInt(6)
@@ -5099,7 +5099,7 @@ func TestSwapOrRedemptionFeesPaid(t *testing.T) {
 	for _, test := range tests {
 		var txHash common.Hash
 		if test.pendingTx != nil {
-			wt := bw.extendedTx(test.pendingTx, asset.Unknown, 1)
+			wt := bw.extendedTx(test.pendingTx, asset.Unknown, 1, nil)
 			wt.BlockNumber = test.pendingTxBlock
 			wt.Fees = fees
 			bw.pendingTxs = []*extendedWalletTx{wt}

--- a/client/asset/eth/txdb_test.go
+++ b/client/asset/eth/txdb_test.go
@@ -33,7 +33,7 @@ func TestTxDB(t *testing.T) {
 	}
 
 	newTx := func(nonce uint64) *extendedWalletTx {
-		return eth.extendedTx(node.newTransaction(nonce, big.NewInt(1)), asset.Send, 1)
+		return eth.extendedTx(node.newTransaction(nonce, big.NewInt(1)), asset.Send, 1, nil)
 	}
 
 	wt1 := newTx(1)


### PR DESCRIPTION
The recipient field was being populated with the "to" field of the eth transaction (which may be a contract address) instead of the recipient of a send transaction as in other assets.