### PR TITLE
app: Tx history token tx row fix

### DIFF
--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1657,7 +1657,8 @@ export default class WalletsPage extends BasePage {
     if (tx.timestamp > 0) tmpl.age.dataset.stamp = String(tx.timestamp)
     let txType = txTypeString(tx.type)
     if (tx.tokenID && tx.tokenID !== assetID) {
-      const tokenSymbol = ui.conventional.unit
+      const tokenAsset = app().assets[tx.tokenID]
+      const tokenSymbol = tokenAsset.unitInfo.conventional.unit
       txType = `${tokenSymbol} ${txType}`
     }
     tmpl.type.textContent = txType


### PR DESCRIPTION
In the tx history for a parent asset, the rows involving a token were displaying the parent's asset symbol instead of the token's.