### PR TITLE
mm: Internal transfers

### DIFF
--- a/client/mm/config.go
+++ b/client/mm/config.go
@@ -50,6 +50,10 @@ type CEXConfig struct {
 type AutoRebalanceConfig struct {
 	MinBaseTransfer  uint64 `json:"minBaseTransfer"`
 	MinQuoteTransfer uint64 `json:"minQuoteTransfer"`
+	// InternalOnly means that the bot will only simulate transfers by
+	// allocating unallocated funds to the bot's balance and never actually
+	// perform deposits and withdrawals with the CEX.
+	InternalOnly bool `json:"internalOnly"`
 }
 
 func (a *AutoRebalanceConfig) copy() *AutoRebalanceConfig {

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -3016,14 +3016,6 @@ func (u *unifiedExchangeAdaptor) optimizeTransfers(dist *distribution, dexSellLo
 		onlyQuoteInternal
 	)
 
-	isETHToken := func(assetID uint32) bool {
-		token := asset.TokenInfo(assetID)
-		if token == nil {
-			return false
-		}
-		return token.ParentID == 60
-	}
-
 	splits := make([]*scoredSplit, 0)
 	// scoreSplitSource gets a score for the proposed asset distribution using
 	// the specified sources for the transfer, and, if the score is higher than
@@ -3035,10 +3027,13 @@ func (u *unifiedExchangeAdaptor) optimizeTransfers(dist *distribution, dexSellLo
 		incrementFees := func(base bool) {
 			// TODO: use actual fees
 			fees++
-			if base && (u.baseID == 0 || u.baseID == 60 || isETHToken(u.baseID)) {
+
+			baseToken := asset.TokenInfo(u.baseID)
+			if base && (u.baseID == 0 || u.baseID == 60 || (baseToken != nil && baseToken.ParentID == 60)) {
 				fees++
 			}
-			if !base && (u.quoteID == 0 || u.quoteID == 60 || isETHToken(u.quoteID)) {
+			quoteToken := asset.TokenInfo(u.quoteID)
+			if !base && (u.quoteID == 0 || u.quoteID == 60 || (quoteToken != nil && quoteToken.ParentID == 60)) {
 				fees++
 			}
 		}

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -3016,6 +3016,10 @@ func (u *unifiedExchangeAdaptor) optimizeTransfers(dist *distribution, dexSellLo
 		onlyQuoteInternal
 	)
 
+	baseToken, quoteToken := asset.TokenInfo(u.baseID), asset.TokenInfo(u.quoteID)
+	highBaseFees := u.baseID == 0 || u.baseID == 60 || (baseToken != nil && baseToken.ParentID == 60)
+	highQuoteFees := u.quoteID == 0 || u.quoteID == 60 || (quoteToken != nil && quoteToken.ParentID == 60)
+
 	splits := make([]*scoredSplit, 0)
 	// scoreSplitSource gets a score for the proposed asset distribution using
 	// the specified sources for the transfer, and, if the score is higher than
@@ -3028,12 +3032,10 @@ func (u *unifiedExchangeAdaptor) optimizeTransfers(dist *distribution, dexSellLo
 			// TODO: use actual fees
 			fees++
 
-			baseToken := asset.TokenInfo(u.baseID)
-			if base && (u.baseID == 0 || u.baseID == 60 || (baseToken != nil && baseToken.ParentID == 60)) {
+			if base && highBaseFees {
 				fees++
 			}
-			quoteToken := asset.TokenInfo(u.quoteID)
-			if !base && (u.quoteID == 0 || u.quoteID == 60 || (quoteToken != nil && quoteToken.ParentID == 60)) {
+			if !base && highQuoteFees {
 				fees++
 			}
 		}

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -899,6 +899,7 @@ func (m *MarketMaker) startBot(startCfg *StartConfig, botCfg *BotConfig, cexCfg 
 		log:                 m.botSubLogger(botCfg),
 		botCfg:              botCfg,
 		eventLogDB:          m.eventLogDB,
+		internalTransfer:    m.internalTransfer,
 	}
 
 	bot, err := m.newBot(botCfg, adaptorCfg)
@@ -1097,6 +1098,29 @@ func validRunningBotCfgUpdate(oldCfg, newCfg *BotConfig) error {
 	}
 
 	return nil
+}
+
+// internalTransfer is called from the exchange adaptor when attempting an
+// internal transfer.
+//
+// ** IMPORTANT ** No mutexes in exchangeAdaptor should be locked when calling this
+// function.
+func (m *MarketMaker) internalTransfer(mkt *MarketWithHost, doTransfer doInternalTransferFunc) error {
+	m.startUpdateMtx.Lock()
+	defer m.startUpdateMtx.Unlock()
+
+	runningBots := m.runningBotsLookup()
+	rb, found := runningBots[*mkt]
+	if !found {
+		return fmt.Errorf("internalTransfer called for non-running bot %s", mkt)
+	}
+
+	dex, cex, err := m.availableBalances(mkt, rb.cexCfg)
+	if err != nil {
+		return fmt.Errorf("error getting available balances: %v", err)
+	}
+
+	return doTransfer(dex, cex)
 }
 
 // UpdateRunningBotInventory updates the inventory of a running bot.

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -1744,7 +1744,6 @@ func (m *MarketMaker) availableBalances(mkt *MarketWithHost, cexCfg *CEXConfig) 
 		if balancesEqual(updatedDEXBalances, totalDEXBalances) && balancesEqual(updatedCEXBalances, totalCEXBalances) {
 			for assetID, bal := range reservedDEXBalances {
 				if bal > totalDEXBalances[assetID] {
-					m.log.Warnf("reserved DEX balance for %s exceeds available balance: %d > %d", dex.BipIDSymbol(assetID), bal, totalDEXBalances[assetID])
 					totalDEXBalances[assetID] = 0
 				} else {
 					totalDEXBalances[assetID] -= bal
@@ -1752,7 +1751,6 @@ func (m *MarketMaker) availableBalances(mkt *MarketWithHost, cexCfg *CEXConfig) 
 			}
 			for assetID, bal := range reservedCEXBalances {
 				if bal > totalCEXBalances[assetID] {
-					m.log.Warnf("reserved CEX balance for %s exceeds available balance: %d > %d", dex.BipIDSymbol(assetID), bal, totalCEXBalances[assetID])
 					totalCEXBalances[assetID] = 0
 				} else {
 					totalCEXBalances[assetID] -= bal

--- a/client/mm/mm_arb_market_maker_test.go
+++ b/client/mm/mm_arb_market_maker_test.go
@@ -452,6 +452,9 @@ func mustParseAdaptorFromMarket(m *core.Market) *unifiedExchangeAdaptor {
 		pendingWithdrawals: make(map[string]*pendingWithdrawal),
 		clientCore:         tCore,
 		cexProblems:        newCEXProblems(),
+		internalTransfer: func(mwh *MarketWithHost, fn doInternalTransferFunc) error {
+			return fn(map[uint32]uint64{}, map[uint32]uint64{})
+		},
 	}
 
 	u.botCfgV.Store(&BotConfig{
@@ -461,6 +464,12 @@ func mustParseAdaptorFromMarket(m *core.Market) *unifiedExchangeAdaptor {
 	})
 
 	return u
+}
+
+func updateInternalTransferBalances(u *unifiedExchangeAdaptor, baseBal, quoteBal map[uint32]uint64) {
+	u.internalTransfer = func(mwh *MarketWithHost, fn doInternalTransferFunc) error {
+		return fn(baseBal, quoteBal)
+	}
 }
 
 func mustParseAdaptor(cfg *exchangeAdaptorCfg) *unifiedExchangeAdaptor {

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -689,4 +689,8 @@ var EnUS = map[string]*intl.Translation{
 	"delete_bot":                  {T: "Delete Bot"},
 	"export_logs":                 {T: "Export Logs"},
 	"address has been used":       {T: "address has been used"},
+	"Allow external transfers":    {T: "Allow external transfers"},
+	"external_transfers_tooltip":  {T: "When enabled, the bot will be able to transfer funds between the DEX and the CEX."},
+	"Internal transfers only":     {T: "Internal transfers only"},
+	"internal_only_tooltip":       {T: "When enabled, the bot will be able to use any available funds in the wallet to simulate a transfer between the DEX and the CEX, (i.e. increase the bot's DEX balance and decrease the bot's CEX balance when a withdrawal needs to be made) but no actual transfers will be made."},
 }

--- a/client/webserver/site/src/html/mmsettings.tmpl
+++ b/client/webserver/site/src/html/mmsettings.tmpl
@@ -659,6 +659,7 @@
             <span class="ico-lever fs20 pe-2"></span>
             <span class="fs22">Knobs</span>
           </div>
+
           {{- /* CEX REBALANCE CHECKBOX */ -}}
           <label id="cexRebalanceSettings" for="cexRebalanceCheckbox" class="fs16 d-flex align-items-center justify-content-between mt-2 pt-2 border-top">
             <div class="flex-center">
@@ -666,6 +667,24 @@
               <span>[[[Arbitrage Rebalance]]]</span>
             </div>
             <span class="ico-info fs12" data-tooltip="[[[enable_rebalance_tooltip]]]"></span>
+          </label>
+
+          {{- /* ALLOW EXTERNAL TRANSFERS */ -}}
+          <label id="externalTransfersSettings" for="externalTransfersRadio" class="fs16 d-flex align-items-center justify-content-between mt-1 pt-1 ms-2">
+            <div class="flex-center">
+              <input type="radio" id="externalTransfersRadio" class="form-check-input me-2 mt-0">
+              <span>[[[Allow external transfers]]]</span>
+            </div>
+            <span class="ico-info fs12" data-tooltip="[[[external_transfers_tooltip]]]"></span>
+          </label>
+
+          {{- /* INTERNAL TRANSFERS ONLY */ -}}
+          <label id="internalOnlySettings" for="internalOnlyRadio" class="fs16 d-flex align-items-center justify-content-between mt-1 pt-1 ms-2">
+            <div class="flex-center">
+              <input type="radio" id="internalOnlyRadio" class="form-check-input me-2 mt-0" checked>
+              <span>[[[Internal transfers only]]]</span>
+            </div>
+            <span class="ico-info fs12" data-tooltip="[[[internal_only_tooltip]]]"></span>
           </label>
 
           {{- /* DRIFT TOLERANCE */ -}}

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -760,6 +760,7 @@ export interface OrderPlacement {
 export interface AutoRebalanceConfig {
   minBaseTransfer: number
   minQuoteTransfer: number
+  internalOnly: boolean
 }
 
 export interface BasicMarketMakingConfig {
@@ -810,6 +811,7 @@ export interface UIConfig {
   quoteConfig: BotAssetConfig
   simpleArbLots?: number
   cexRebalance: boolean
+  internalTransfers: boolean
 }
 
 export interface StartConfig extends MarketWithHost {


### PR DESCRIPTION
```
This diff updates the market maker to attempt to reallocate available funds
to bots before doing a deposit or a withdrawal. For example, if a deposit
is required, and the user has additional available funds on the CEX that are
not allocated to any bots, funds will be allocated to the bot on the CEX
and unallocated from the bot on the wallet to simulate a deposit. Bots may
be configured to only attempt these "internal transfers", to attempt both
internal and external transfers, or to do no rebalancing at all.
```

<img width="951" alt="Screenshot 2024-11-01 at 11 22 03 AM" src="https://github.com/user-attachments/assets/eefdb937-8b30-46e6-85b6-90485a8fb392">

