### PR TITLE
mmui: Fix allocation display bug

### DIFF
--- a/client/webserver/site/src/js/mmsettings.ts
+++ b/client/webserver/site/src/js/mmsettings.ts
@@ -2169,7 +2169,7 @@ class AssetPane {
       const totalInventory = Math.max(cexCommit, dexCommit) / ui.conventional.conversionFactor
       page.orderReservesBasis.textContent = Doc.formatFourSigFigs(totalInventory)
       const orderReserves = totalInventory * cfg.orderReservesFactor
-      inv.orderReserves = totalInventory
+      inv.orderReserves = orderReserves
       page.orderReserves.textContent = Doc.formatFourSigFigs(orderReserves)
     }
     if (isToken) {


### PR DESCRIPTION
The total allocation displayed did not properly reflect the order reserves.