### PR TITLE
mm: Cancel existing orders when starting bot

### DIFF
--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -661,6 +661,20 @@ func (m *MarketMaker) StartBot(startCfg *StartConfig, alternateConfigPath *strin
 		return fmt.Errorf("bot for %s already running", mkt)
 	}
 
+	coreMkt, err := m.core.ExchangeMarket(startCfg.Host, startCfg.BaseID, startCfg.QuoteID)
+	if err != nil {
+		return fmt.Errorf("error getting market: %v", err)
+	}
+
+	for _, ord := range coreMkt.Orders {
+		if ord.Status <= order.OrderStatusBooked {
+			err = m.core.Cancel(ord.ID)
+			if err != nil {
+				return fmt.Errorf("error canceling order %s: %v", ord.ID, err)
+			}
+		}
+	}
+
 	botCfg, cexCfg, err := m.configsForMarket(&startCfg.MarketWithHost, alternateConfigPath)
 	if err != nil {
 		return err

--- a/client/webserver/site/src/html/mm.tmpl
+++ b/client/webserver/site/src/html/mm.tmpl
@@ -434,6 +434,12 @@
                         configuration. If you'd like, we can still start in this starved
                         condition, but the bot will probably not perform as intended.
                       </div>
+
+                      <div data-tmpl="existingOrdersBox" class="d-hide fs17 text-justify mt-3">
+                        <span class="ico-info text-sellcolor fs20"></span>
+                        You have existing orders on this market. These will be cancelled
+                        when you start the bot.
+                      </div>
                     </div>
 
                     <div class="p-3 ps-4 d-flex flex-column justify-content-between align-items-end">

--- a/client/webserver/site/src/js/mm.ts
+++ b/client/webserver/site/src/js/mm.ts
@@ -29,6 +29,7 @@ import BasePage from './basepage'
 import * as OrderUtil from './orderutil'
 import { Forms, CEXConfigurationForm } from './forms'
 import * as intl from './locales'
+import { StatusBooked } from './orderutil'
 
 const mediumBreakpoint = 768
 
@@ -603,7 +604,7 @@ class Bot extends BotMarket {
     const {
       page, marketReport: { baseFiatRate, quoteFiatRate }, baseID, quoteID,
       baseFeeID, quoteFeeID, baseFeeFiatRate, quoteFeeFiatRate, cexName,
-      baseFactor, quoteFactor, baseFeeFactor, quoteFeeFactor
+      baseFactor, quoteFactor, baseFeeFactor, quoteFeeFactor, host, mktID
     } = this
 
     const [proposedDexBase, proposedCexBase, baseSlider] = parseFundingOptions(f.base)
@@ -700,6 +701,18 @@ class Bot extends BotMarket {
       page.proposedDexQuoteFeeAllocUSD.textContent = Doc.formatFourSigFigs(proposedFees * quoteFeeFiatRate)
       page.proposedDexQuoteFeeAlloc.classList.toggle('text-warning', !f.quote.fees.funded)
     }
+
+    const mkt = app().exchanges[host]?.markets[mktID]
+    let existingOrders = false
+    if (mkt && mkt.orders) {
+      for (let i = 0; i < mkt.orders.length; i++) {
+        if (mkt.orders[i].status <= StatusBooked) {
+          existingOrders = true
+          break
+        }
+      }
+    }
+    Doc.setVis(existingOrders, page.existingOrdersBox)
 
     Doc.show(page.allocationDialog)
     const closeDialog = (e: MouseEvent) => {


### PR DESCRIPTION
When starting a bot, existing orders on the books will be cancelled. A message regarding this is displayed on the allocation screen.
