### PR TITLE
multi: refactor sync status

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -4700,9 +4700,11 @@ func (btc *intermediaryWallet) watchBlocks(ctx context.Context) {
 				queuedBlock = &polledBlock{
 					BlockVector: newTip,
 					queue: time.AfterFunc(blockAllowance, func() {
-						btc.log.Warnf("Reporting a block found in polling that the wallet apparently "+
-							"never reported: %d %s. If you see this message repeatedly, it may indicate "+
-							"an issue with the wallet.", newTip.Height, newTip.Hash)
+						if ss, _ := btc.SyncStatus(); ss != nil && ss.Synced {
+							btc.log.Warnf("Reporting a block found in polling that the wallet apparently "+
+								"never reported: %d %s. If you see this message repeatedly, it may indicate "+
+								"an issue with the wallet.", newTip.Height, newTip.Hash)
+						}
 						btc.reportNewTip(ctx, newTip)
 					}),
 				}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -4277,14 +4277,14 @@ func testSyncStatus(t *testing.T, segwit bool, walletType string) {
 	node.birthdayTime = msgBlock.Header.Timestamp.Add(-time.Minute) // SPV, wallet birthday is passed
 	node.mainchain[100] = blkHash                                   // SPV, actually has to reach target
 
-	synced, progress, err := wallet.SyncStatus()
+	ss, err := wallet.SyncStatus()
 	if err != nil {
 		t.Fatalf("SyncStatus error (synced expected): %v", err)
 	}
-	if !synced {
+	if !ss.Synced {
 		t.Fatalf("synced = false")
 	}
-	if progress < 1 {
+	if ss.BlockProgress() < 1 {
 		t.Fatalf("progress not complete when loading last block")
 	}
 
@@ -4293,7 +4293,7 @@ func testSyncStatus(t *testing.T, segwit bool, walletType string) {
 	node.getBestBlockHashErr = tErr // spv BestBlock()
 	node.blockchainMtx.Unlock()
 	delete(node.mainchain, 100) // force spv to BestBlock() with no wallet block
-	_, _, err = wallet.SyncStatus()
+	_, err = wallet.SyncStatus()
 	if err == nil {
 		t.Fatalf("SyncStatus error not propagated")
 	}
@@ -4308,15 +4308,15 @@ func testSyncStatus(t *testing.T, segwit bool, walletType string) {
 		Blocks:  150,
 	}
 	node.addRawTx(150, makeRawTx([]dex.Bytes{randBytes(1)}, []*wire.TxIn{dummyInput()})) // spv needs this for BestBlock
-	synced, progress, err = wallet.SyncStatus()
+	ss, err = wallet.SyncStatus()
 	if err != nil {
 		t.Fatalf("SyncStatus error (half-synced): %v", err)
 	}
-	if synced {
+	if ss.Synced {
 		t.Fatalf("synced = true for 50 blocks to go")
 	}
-	if progress > 0.500001 || progress < 0.4999999 {
-		t.Fatalf("progress out of range. Expected 0.5, got %.2f", progress)
+	if ss.BlockProgress() > 0.500001 || ss.BlockProgress() < 0.4999999 {
+		t.Fatalf("progress out of range. Expected 0.5, got %.2f", ss.BlockProgress())
 	}
 }
 

--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -367,13 +367,13 @@ func (btc *ExchangeWalletElectrum) watchBlocks(ctx context.Context) {
 			// only comparing heights instead of hashes, which means we might
 			// not notice a reorg to a block at the same height, which is
 			// unimportant because of how electrum searches for transactions.
-			stat, err := btc.node.syncStatus()
+			ss, err := btc.node.syncStatus()
 			if err != nil {
 				btc.log.Errorf("failed to get sync status: %w", err)
 				continue
 			}
 
-			sameTip := currentTip.Height == int64(stat.Height)
+			sameTip := currentTip.Height == int64(ss.Blocks)
 			if sameTip {
 				// Could have actually been a reorg to different block at same
 				// height. We'll report a new tip block on the next block.
@@ -419,12 +419,12 @@ func (btc *ExchangeWalletElectrum) syncTxHistory(tip uint64) {
 		return
 	}
 
-	synced, _, err := btc.SyncStatus()
+	ss, err := btc.SyncStatus()
 	if err != nil {
 		btc.log.Errorf("Error getting sync status: %v", err)
 		return
 	}
-	if !synced {
+	if !ss.Synced {
 		return
 	}
 

--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -964,15 +964,15 @@ func (ew *electrumWallet) ownsAddress(addr btcutil.Address) (bool, error) {
 }
 
 // part of the btc.Wallet interface
-func (ew *electrumWallet) syncStatus() (*SyncStatus, error) {
+func (ew *electrumWallet) syncStatus() (*asset.SyncStatus, error) {
 	info, err := ew.wallet.GetInfo(ew.ctx)
 	if err != nil {
 		return nil, err
 	}
-	return &SyncStatus{
-		Target:  int32(info.ServerHeight),
-		Height:  int32(info.SyncHeight),
-		Syncing: !info.Connected || info.SyncHeight < info.ServerHeight,
+	return &asset.SyncStatus{
+		Synced:       info.Connected && info.SyncHeight >= info.ServerHeight,
+		TargetHeight: uint64(info.ServerHeight),
+		Blocks:       uint64(info.SyncHeight),
 	}, nil
 }
 

--- a/client/asset/btc/livetest/regnet_test.go
+++ b/client/asset/btc/livetest/regnet_test.go
@@ -106,14 +106,14 @@ func TestWallet(t *testing.T) {
 		time.Sleep(time.Second * 3)
 
 		for {
-			synced, progress, err := w.SyncStatus()
+			ss, err := w.SyncStatus()
 			if err != nil {
 				return fmt.Errorf("SyncStatus error: %w", err)
 			}
-			if synced {
+			if ss.Synced {
 				break
 			}
-			fmt.Printf("%s sync progress %.1f \n", name, progress*100)
+			fmt.Printf("%s sync progress %.1f \n", name, ss.BlockProgress()*100)
 			time.Sleep(time.Second)
 		}
 

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -982,15 +982,16 @@ func (wc *rpcClient) ownsAddress(addr btcutil.Address) (bool, error) {
 }
 
 // syncStatus is information about the blockchain sync status.
-func (wc *rpcClient) syncStatus() (*SyncStatus, error) {
+func (wc *rpcClient) syncStatus() (*asset.SyncStatus, error) {
 	chainInfo, err := wc.getBlockchainInfo()
 	if err != nil {
 		return nil, fmt.Errorf("getblockchaininfo error: %w", err)
 	}
-	return &SyncStatus{
-		Target:  int32(chainInfo.Headers),
-		Height:  int32(chainInfo.Blocks),
-		Syncing: chainInfo.Syncing(),
+	synced := !chainInfo.Syncing()
+	return &asset.SyncStatus{
+		Synced:       synced,
+		TargetHeight: uint64(chainInfo.Headers),
+		Blocks:       uint64(chainInfo.Blocks),
 	}, nil
 }
 

--- a/client/asset/btc/types.go
+++ b/client/asset/btc/types.go
@@ -192,10 +192,3 @@ func (r *SwapReceipt) String() string {
 func (r *SwapReceipt) SignedRefund() dex.Bytes {
 	return r.SignedRefundBytes
 }
-
-// SyncStatus is the current synchronization state of the node.
-type SyncStatus struct {
-	Target  int32 `json:"target"`
-	Height  int32 `json:"height"`
-	Syncing bool  `json:"syncing"`
-}

--- a/client/asset/btc/wallet.go
+++ b/client/asset/btc/wallet.go
@@ -36,7 +36,7 @@ type Wallet interface {
 	walletUnlock(pw []byte) error
 	walletLock() error
 	locked() bool
-	syncStatus() (*SyncStatus, error)
+	syncStatus() (*asset.SyncStatus, error)
 	peerCount() (uint32, error)
 	swapConfirmations(txHash *chainhash.Hash, vout uint32, contract []byte, startTime time.Time) (confs uint32, spent bool, err error)
 	getBestBlockHeader() (*BlockHeader, error)

--- a/client/asset/dcr/config.go
+++ b/client/asset/dcr/config.go
@@ -37,6 +37,7 @@ type walletConfig struct {
 	RedeemConfTarget uint64  `ini:"redeemconftarget"`
 	ActivelyUsed     bool    `ini:"special_activelyUsed"` //injected by core
 	ApiFeeFallback   bool    `ini:"apifeefallback"`
+	GapLimit         uint32  `ini:"gaplimit"`
 }
 
 type rpcConfig struct {

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -150,6 +150,12 @@ var (
 			DefaultValue: defaultRedeemConfTarget,
 		},
 		{
+			Key:          "gaplimit",
+			DisplayName:  "Address Gap Limit",
+			Description:  "The gap limit for used address discovery",
+			DefaultValue: wallet.DefaultGapLimit,
+		},
+		{
 			Key:         "txsplit",
 			DisplayName: "Pre-size funding inputs",
 			Description: "When placing an order, create a \"split\" transaction to " +
@@ -529,7 +535,7 @@ func (d *Driver) Create(params *asset.CreateWalletParams) error {
 	}
 
 	return createSPVWallet(params.Pass, params.Seed, params.DataDir, recoveryCfg.NumExternalAddresses,
-		recoveryCfg.NumInternalAddresses, chainParams)
+		recoveryCfg.NumInternalAddresses, recoveryCfg.GapLimit, chainParams)
 }
 
 // MinLotSize calculates the minimum bond size for a given fee rate that avoids
@@ -548,6 +554,7 @@ func init() {
 type RecoveryCfg struct {
 	NumExternalAddresses uint32 `ini:"numexternaladdr"`
 	NumInternalAddresses uint32 `ini:"numinternaladdr"`
+	GapLimit             uint32 `ini:"gaplimit"`
 }
 
 // swapOptions captures the available Swap options. Tagged to be used with
@@ -616,18 +623,19 @@ type ExchangeWallet struct {
 	bondReserves atomic.Uint64
 	cfgV         atomic.Value // *exchangeWalletConfig
 
-	ctx           context.Context // the asset subsystem starts with Connect(ctx)
-	wg            sync.WaitGroup
-	wallet        Wallet
-	chainParams   *chaincfg.Params
-	log           dex.Logger
-	network       dex.Network
-	emit          *asset.WalletEmitter
-	lastPeerCount uint32
-	peersChange   func(uint32, error)
-	vspFilepath   string
-	walletType    string
-	walletDir     string
+	ctx            context.Context // the asset subsystem starts with Connect(ctx)
+	wg             sync.WaitGroup
+	wallet         Wallet
+	chainParams    *chaincfg.Params
+	log            dex.Logger
+	network        dex.Network
+	emit           *asset.WalletEmitter
+	lastPeerCount  uint32
+	peersChange    func(uint32, error)
+	vspFilepath    string
+	walletType     string
+	walletDir      string
+	startingBlocks atomic.Uint64
 
 	oracleFeesMtx sync.Mutex
 	oracleFees    map[uint64]feeStamped // conf target => fee rate
@@ -747,7 +755,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 			return nil, err
 		}
 	case walletTypeSPV:
-		dcr.wallet, err = openSPVWallet(cfg.DataDir, chainParams, logger)
+		dcr.wallet, err = openSPVWallet(cfg.DataDir, walletCfg.GapLimit, chainParams, logger)
 		if err != nil {
 			return nil, err
 		}
@@ -857,7 +865,7 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *walletConfig, chainParam
 }
 
 // openSPVWallet opens the previously created native SPV wallet.
-func openSPVWallet(dataDir string, chainParams *chaincfg.Params, log dex.Logger) (*spvWallet, error) {
+func openSPVWallet(dataDir string, gapLimit uint32, chainParams *chaincfg.Params, log dex.Logger) (*spvWallet, error) {
 	dir := filepath.Join(dataDir, chainParams.Name, "spv")
 	if exists, err := walletExists(dir); err != nil {
 		return nil, err
@@ -872,7 +880,8 @@ func openSPVWallet(dataDir string, chainParams *chaincfg.Params, log dex.Logger)
 		blockCache: blockCache{
 			blocks: make(map[chainhash.Hash]*cachedBlock),
 		},
-		tipChan: make(chan *block, 16),
+		tipChan:  make(chan *block, 16),
+		gapLimit: gapLimit,
 	}, nil
 }
 
@@ -1053,6 +1062,7 @@ func (dcr *ExchangeWallet) Connect(ctx context.Context) (*sync.WaitGroup, error)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing best block for DCR: %w", err)
 	}
+	dcr.startingBlocks.Store(uint64(tip.height))
 
 	dbCM, err := dcr.startTxHistoryDB(ctx)
 	if err != nil {
@@ -4818,7 +4828,7 @@ func (dcr *ExchangeWallet) shutdown() {
 }
 
 // SyncStatus is information about the blockchain sync status.
-func (dcr *ExchangeWallet) SyncStatus() (bool, float32, error) {
+func (dcr *ExchangeWallet) SyncStatus() (*asset.SyncStatus, error) {
 	// If we have a rescan running, do different math.
 	dcr.rescan.RLock()
 	rescanProgress := dcr.rescan.progress
@@ -4828,10 +4838,22 @@ func (dcr *ExchangeWallet) SyncStatus() (bool, float32, error) {
 		if height < rescanProgress.scannedThrough {
 			height = rescanProgress.scannedThrough
 		}
-		return false, float32(rescanProgress.scannedThrough) / float32(height), nil
+		txHeight := uint64(rescanProgress.scannedThrough)
+		return &asset.SyncStatus{
+			Synced:         false,
+			TargetHeight:   uint64(height),
+			StartingBlocks: dcr.startingBlocks.Load(),
+			Blocks:         uint64(height),
+			Transactions:   &txHeight,
+		}, nil
 	}
 	// No rescan in progress. Ask wallet.
-	return dcr.wallet.SyncStatus(dcr.ctx)
+	ss, err := dcr.wallet.SyncStatus(dcr.ctx)
+	if err != nil {
+		return nil, err
+	}
+	ss.StartingBlocks = dcr.startingBlocks.Load()
+	return ss, nil
 }
 
 // Combines the RPC type with the spending input information.
@@ -6233,12 +6255,12 @@ func (dcr *ExchangeWallet) syncTxHistory(ctx context.Context, tip uint64) {
 		return
 	}
 
-	synced, _, err := dcr.SyncStatus()
+	ss, err := dcr.SyncStatus()
 	if err != nil {
 		dcr.log.Errorf("Error getting sync status: %v", err)
 		return
 	}
-	if !synced {
+	if !ss.Synced {
 		return
 	}
 
@@ -6523,10 +6545,10 @@ func (dcr *ExchangeWallet) monitorBlocks(ctx context.Context) {
 		blockAllowance := walletBlockAllowance
 		ctxInternal, cancel1 := context.WithTimeout(ctx, 4*time.Second)
 		defer cancel1()
-		synced, _, err := dcr.wallet.SyncStatus(ctxInternal)
+		ss, err := dcr.wallet.SyncStatus(ctxInternal)
 		if err != nil {
 			dcr.log.Errorf("Error retrieving sync status before queuing polled block: %v", err)
-		} else if !synced {
+		} else if !ss.Synced {
 			blockAllowance *= 10
 		}
 		queuedBlock = &polledBlock{

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -6554,9 +6554,11 @@ func (dcr *ExchangeWallet) monitorBlocks(ctx context.Context) {
 		queuedBlock = &polledBlock{
 			block: newTip,
 			queue: time.AfterFunc(blockAllowance, func() {
-				dcr.log.Warnf("Reporting a block found in polling that the wallet apparently "+
-					"never reported: %s (%d). If you see this message repeatedly, it may indicate "+
-					"an issue with the wallet.", newTip.hash, newTip.height)
+				if ss, _ := dcr.SyncStatus(); ss != nil && ss.Synced {
+					dcr.log.Warnf("Reporting a block found in polling that the wallet apparently "+
+						"never reported: %s (%d). If you see this message repeatedly, it may indicate "+
+						"an issue with the wallet.", newTip.hash, newTip.height)
+				}
 				dcr.handleTipChange(ctx, newTip.hash, newTip.height, nil)
 			}),
 		}

--- a/client/asset/dcr/native_wallet.go
+++ b/client/asset/dcr/native_wallet.go
@@ -203,8 +203,8 @@ func (w *NativeWallet) Lock() (err error) {
 // mixFunds checks the status of mixing operations and starts a mix cycle.
 // mixFunds must be called with the mixer.mtx >= RLock'd.
 func (w *NativeWallet) mixFunds() {
-	synced, _, _ := w.SyncStatus()
-	if !synced {
+	ss, _ := w.SyncStatus()
+	if !ss.Synced {
 		return
 	}
 	on := w.mixer.ctx != nil

--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -33,6 +33,7 @@ import (
 	"decred.org/dcrdex/dex/config"
 	"decred.org/dcrdex/dex/encode"
 	dexdcr "decred.org/dcrdex/dex/networks/dcr"
+	"decred.org/dcrwallet/v4/wallet"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -95,7 +96,7 @@ func tBackend(t *testing.T, name string, isInternal bool, blkFunc func(string)) 
 			t.Fatal(err)
 		}
 		dataDir := t.TempDir()
-		createSPVWallet(walletPassword, seed, dataDir, 0, 0, chaincfg.SimNetParams())
+		createSPVWallet(walletPassword, seed, dataDir, 0, 0, wallet.DefaultGapLimit, chaincfg.SimNetParams())
 		walletCfg.Type = walletTypeSPV
 		walletCfg.DataDir = dataDir
 	}
@@ -127,11 +128,11 @@ func tBackend(t *testing.T, name string, isInternal bool, blkFunc func(string)) 
 	if isInternal {
 		i := 0
 		for {
-			synced, _, err := backend.SyncStatus()
+			ss, err := backend.SyncStatus()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if synced {
+			if ss.Synced {
 				break
 			}
 			if i == 5 {

--- a/client/asset/dcr/spv_test.go
+++ b/client/asset/dcr/spv_test.go
@@ -426,6 +426,10 @@ func (w *tDcrWallet) RescanProgressFromHeight(ctx context.Context, n wallet.Netw
 	}()
 }
 
+func (w *tDcrWallet) RescanPoint(ctx context.Context) (*chainhash.Hash, error) {
+	return nil, nil
+}
+
 func tNewSpvWallet() (*spvWallet, *tDcrWallet) {
 	dcrw := &tDcrWallet{
 		blockInfo:      make(map[int32]*wallet.BlockInfo),

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -158,7 +158,7 @@ type Wallet interface {
 	// UnlockAccount unlocks the account.
 	UnlockAccount(ctx context.Context, passphrase []byte, acctName string) error
 	// SyncStatus returns the wallet's sync status.
-	SyncStatus(ctx context.Context) (bool, float32, error)
+	SyncStatus(ctx context.Context) (*asset.SyncStatus, error)
 	// PeerCount returns the number of network peers to which the wallet or its
 	// backing node are connected.
 	PeerCount(ctx context.Context) (uint32, error)

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1029,19 +1029,14 @@ func TestSyncStatus(t *testing.T) {
 		wantRatio:  1,
 		wantSynced: true,
 	}, {
-		name: "ok syncing",
-		syncProg: ethereum.SyncProgress{
-			CurrentBlock: 25,
-			HighestBlock: 100,
-		},
-		wantRatio: 0.25,
-	}, {
 		name: "ok header too old",
 		syncProg: ethereum.SyncProgress{
 			CurrentBlock: 25,
-			HighestBlock: 0,
+			HighestBlock: 25,
 		},
-		subSecs: dexeth.MaxBlockInterval + 1,
+		subSecs:    dexeth.MaxBlockInterval + 1,
+		wantRatio:  0.999,
+		wantSynced: false,
 	}, {
 		name: "sync progress error",
 		syncProg: ethereum.SyncProgress{
@@ -1067,7 +1062,7 @@ func TestSyncStatus(t *testing.T) {
 			log:           tLogger,
 			finalizeConfs: txConfsNeededToConfirm,
 		}
-		synced, ratio, err := eth.SyncStatus()
+		ss, err := eth.SyncStatus()
 		cancel()
 		if test.wantErr {
 			if err == nil {
@@ -1078,11 +1073,11 @@ func TestSyncStatus(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error for test %q: %v", test.name, err)
 		}
-		if synced != test.wantSynced {
-			t.Fatalf("want synced %v got %v for test %q", test.wantSynced, synced, test.name)
+		if ss.Synced != test.wantSynced {
+			t.Fatalf("want synced %v got %v for test %q", test.wantSynced, ss.Synced, test.name)
 		}
-		if ratio != test.wantRatio {
-			t.Fatalf("want ratio %v got %v for test %q", test.wantRatio, ratio, test.name)
+		if ss.BlockProgress() != test.wantRatio {
+			t.Fatalf("want ratio %v got %v for test %q", test.wantRatio, ss.BlockProgress(), test.name)
 		}
 	}
 }

--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -1339,7 +1339,7 @@ func (m *multiRPCClient) signData(data []byte) (sig, pubKey []byte, err error) {
 // but the best header's time in seconds can be used to determine if the
 // provider is out of sync.
 func (m *multiRPCClient) syncProgress(ctx context.Context) (prog *ethereum.SyncProgress, tipTime uint64, err error) {
-	return prog, tipTime, m.withAny(ctx, func(ctx context.Context, p *provider) error {
+	return prog, tipTime, m.withFreshest(ctx, func(ctx context.Context, p *provider) error {
 		tip, err := p.bestHeader(ctx, m.log)
 		if err != nil {
 			return err

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -616,7 +616,7 @@ func (ss *SyncStatus) BlockProgress() float32 {
 	if ss.Transactions == nil { // If the asset doesn't support tx sync status, max unsynced is 0.999
 		return utils.Min(prog, 0.999)
 	}
-	return float32(ss.Blocks-ss.StartingBlocks) / float32(ss.TargetHeight-ss.StartingBlocks)
+	return prog
 }
 
 // BondDetails is the return from Bonder.FindBond.

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/utils"
 	dcrwalletjson "decred.org/dcrwallet/v4/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
@@ -536,7 +537,7 @@ type Wallet interface {
 	// SyncStatus is information about the blockchain sync status. It should
 	// only indicate synced when there are network peers and all blocks on the
 	// network have been processed by the wallet.
-	SyncStatus() (synced bool, progress float32, err error)
+	SyncStatus() (*SyncStatus, error)
 	// RegFeeConfirmations gets the confirmations for a registration fee
 	// payment. This method need not be supported by all assets. Those assets
 	// which do no support DEX registration fees will return an ErrUnsupported.
@@ -593,6 +594,29 @@ type TxFeeEstimator interface {
 type Broadcaster interface {
 	// SendTransaction broadcasts a raw transaction, returning its coin ID.
 	SendTransaction(rawTx []byte) ([]byte, error)
+}
+
+// SyncStatus is the status of wallet syncing.
+type SyncStatus struct {
+	Synced         bool    `json:"synced"`
+	TargetHeight   uint64  `json:"targetHeight"`
+	StartingBlocks uint64  `json:"startingBlocks"`
+	Blocks         uint64  `json:"blocks"`
+	Transactions   *uint64 `json:"txs,omitempty"`
+}
+
+func (ss *SyncStatus) BlockProgress() float32 {
+	switch {
+	case ss.Synced:
+		return 1
+	case ss.TargetHeight == 0:
+		return 0
+	}
+	prog := float32(ss.Blocks-ss.StartingBlocks) / float32(ss.TargetHeight-ss.StartingBlocks)
+	if ss.Transactions == nil { // If the asset doesn't support tx sync status, max unsynced is 0.999
+		return utils.Min(prog, 0.999)
+	}
+	return float32(ss.Blocks-ss.StartingBlocks) / float32(ss.TargetHeight-ss.StartingBlocks)
 }
 
 // BondDetails is the return from Bonder.FindBond.

--- a/client/asset/zec/transparent_rpc.go
+++ b/client/asset/zec/transparent_rpc.go
@@ -353,15 +353,15 @@ func getTxOutput(c rpcCaller, txHash *chainhash.Hash, index uint32) (*btcjson.Ge
 	return res, c.CallRPC("gettxout", []any{txHash.String(), index, true}, &res)
 }
 
-func syncStatus(c rpcCaller) (*btc.SyncStatus, error) {
+func syncStatus(c rpcCaller) (*asset.SyncStatus, error) {
 	chainInfo, err := getBlockchainInfo(c)
 	if err != nil {
 		return nil, newError(errGetChainInfo, "getblockchaininfo error: %w", err)
 	}
-	return &btc.SyncStatus{
-		Target:  int32(chainInfo.Headers),
-		Height:  int32(chainInfo.Blocks),
-		Syncing: chainInfo.Syncing(),
+	return &asset.SyncStatus{
+		Synced:       chainInfo.Blocks > 0 && !chainInfo.Syncing(),
+		TargetHeight: uint64(chainInfo.Headers),
+		Blocks:       uint64(chainInfo.Blocks),
 	}, nil
 }
 

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -31,6 +31,7 @@ const (
 	NoteTypeSpots          = "spots"
 	NoteTypeWalletConfig   = "walletconfig"
 	NoteTypeWalletState    = "walletstate"
+	NoteTypeWalletSync     = "walletsync"
 	NoteTypeServerNotify   = "notify"
 	NoteTypeSecurity       = "security"
 	NoteTypeUpgrade        = "upgrade"
@@ -627,6 +628,25 @@ func newWalletStateNote(walletState *WalletState) *WalletStateNote {
 	return &WalletStateNote{
 		Notification: db.NewNotification(NoteTypeWalletState, TopicWalletState, "", "", db.Data),
 		Wallet:       walletState,
+	}
+}
+
+// WalletSyncNote is a notification of the wallet sync status.
+type WalletSyncNote struct {
+	db.Notification
+	AssetID      uint32            `json:"assetID"`
+	SyncStatus   *asset.SyncStatus `json:"syncStatus"`
+	SyncProgress float32           `json:"syncProgress"`
+}
+
+const TopicWalletSync = "WalletSync"
+
+func newWalletSyncNote(assetID uint32, ss *asset.SyncStatus) *WalletSyncNote {
+	return &WalletSyncNote{
+		Notification: db.NewNotification(NoteTypeWalletSync, TopicWalletState, "", "", db.Data),
+		AssetID:      assetID,
+		SyncStatus:   ss,
+		SyncProgress: ss.BlockProgress(),
 	}
 }
 

--- a/client/core/types.go
+++ b/client/core/types.go
@@ -134,6 +134,7 @@ type WalletState struct {
 	PeerCount    uint32                          `json:"peerCount"`
 	Synced       bool                            `json:"synced"`
 	SyncProgress float32                         `json:"syncProgress"`
+	SyncStatus   *asset.SyncStatus               `json:"syncStatus"`
 	Disabled     bool                            `json:"disabled"`
 	Approved     map[uint32]asset.ApprovalStatus `json:"approved"`
 	FeeState     *FeeState                       `json:"feeState"`

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -1376,6 +1376,7 @@ func (c *TCore) walletState(assetID uint32) *core.WalletState {
 		PeerCount:    10,
 		Synced:       syncPct == 100,
 		SyncProgress: float32(syncPct) / 100,
+		SyncStatus:   &asset.SyncStatus{Synced: syncPct == 100, TargetHeight: 100, Blocks: uint64(syncPct)},
 		Traits:       traits,
 	}
 }

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -641,4 +641,7 @@ var EnUS = map[string]*intl.Translation{
 	"withdrawal":                  {T: "Withdrawal"},
 	"filters":                     {T: "Filters"},
 	"Apply":                       {T: "Apply"},
+	"Block Sync":                  {T: "Block Sync"},
+	"Balance Discovery":           {T: "Balance Discovery"},
+	"Finding Addresses":           {T: "Finding Addresses"},
 }

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -132,8 +132,18 @@
                       <td id="peerCount" class="demi"></td>
                     </tr>
                     <tr id="syncProgressBox">
-                      <td class="grey text-nowrap">[[[Sync Progress]]]</td>
+                      <td class="grey text-nowrap">Block Sync</td>
                       <td id="syncProgress" class="demi"></td>
+                    </tr>
+                    <tr id="txSyncBox">
+                      <td class="grey text-nowrap">Tx Sync</td>
+                      <td id="txProgress" class="demi text-end"></td>
+                      <td id="txFindingAddrs" class="demi">
+                        <div class="d-flex align-items-center justify-content-end">
+                          <div class="fs10 ico-spinner spinner me-1"></div>
+                          <span>Finding Addresses</span>
+                        </div>
+                      </td>
                     </tr>
                   </tbody>
                 </table>

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -132,16 +132,16 @@
                       <td id="peerCount" class="demi"></td>
                     </tr>
                     <tr id="syncProgressBox">
-                      <td class="grey text-nowrap">Block Sync</td>
+                      <td class="grey text-nowrap">[[[Block Sync]]]</td>
                       <td id="syncProgress" class="demi"></td>
                     </tr>
                     <tr id="txSyncBox">
-                      <td class="grey text-nowrap">Tx Sync</td>
+                      <td class="grey text-nowrap">[[[Balance Discovery]]]</td>
                       <td id="txProgress" class="demi text-end"></td>
                       <td id="txFindingAddrs" class="demi">
                         <div class="d-flex align-items-center justify-content-end">
                           <div class="fs10 ico-spinner spinner me-1"></div>
-                          <span>Finding Addresses</span>
+                          <span>[[[Finding Addresses]]]</span>
                         </div>
                       </td>
                     </tr>

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -33,6 +33,7 @@ import {
   Match,
   BalanceNote,
   WalletConfigNote,
+  WalletSyncNote,
   MatchNote,
   ConnEventNote,
   SpotPriceNote,
@@ -1091,6 +1092,16 @@ export default class Application {
         const asset = assets[wallet.assetID]
         asset.wallet = wallet
         walletMap[wallet.assetID] = wallet
+        break
+      }
+      case 'walletsync': {
+        const n = note as WalletSyncNote
+        const w = this.walletMap[n.assetID]
+        if (w) {
+          w.syncStatus = n.syncStatus
+          w.synced = w.syncStatus.synced
+          w.syncProgress = n.syncProgress
+        }
         break
       }
       case 'match': {

--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -23,6 +23,7 @@ import {
   Order,
   XYRange,
   WalletStateNote,
+  WalletSyncNote,
   WalletInfo,
   Token,
   WalletCreationNote,
@@ -151,6 +152,7 @@ export class NewWalletForm {
 
     app().registerNoteFeeder({
       walletstate: (note: WalletStateNote) => { this.reportWalletState(note.wallet) },
+      walletsync: (note: WalletSyncNote) => { if (this.parentSyncer) this.parentSyncer(app().walletMap[note.assetID]) },
       createwallet: (note: WalletCreationNote) => { this.reportCreationUpdate(note) }
     })
   }
@@ -1254,6 +1256,11 @@ export class WalletWaitForm {
 
     app().registerNoteFeeder({
       walletstate: (note: WalletStateNote) => this.reportWalletState(note.wallet),
+      walletsync: (note: WalletSyncNote) => {
+        if (note.assetID !== this.assetID) return
+        const w = app().walletMap[note.assetID]
+        this.reportProgress(w.synced, w.syncProgress)
+      },
       balance: (note: BalanceNote) => this.reportBalance(note.assetID)
     })
   }

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -47,6 +47,7 @@ import {
   PreSwap,
   PreRedeem,
   WalletStateNote,
+  WalletSyncNote,
   WalletCreationNote,
   SpotPriceNote,
   BondNote,
@@ -3245,6 +3246,7 @@ class BalanceWidget {
     app().registerNoteFeeder({
       balance: (note: BalanceNote) => { this.updateAsset(note.assetID) },
       walletstate: (note: WalletStateNote) => { this.updateAsset(note.wallet.assetID) },
+      walletsync: (note: WalletSyncNote) => { this.updateAsset(note.assetID) },
       createwallet: (note: WalletCreationNote) => { this.updateAsset(note.assetID) }
     })
   }

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -230,6 +230,14 @@ export interface FeeState {
   stampMS: number
 }
 
+export interface SyncStatus {
+  synced: boolean
+  targetHeight: number
+  startingBlocks: number
+  blocks: number
+  txs: number | undefined
+}
+
 export interface WalletState {
   symbol: string
   assetID: number
@@ -246,6 +254,7 @@ export interface WalletState {
   peerCount: number
   synced: boolean
   syncProgress: number
+  syncStatus: SyncStatus
   approved: Record<number, ApprovalStatus>
   feeState?: FeeState
 }
@@ -394,6 +403,12 @@ export interface RateNote extends CoreNote {
 
 export interface WalletConfigNote extends CoreNote {
   wallet: WalletState
+}
+
+export interface WalletSyncNote extends CoreNote {
+  assetID: number
+  syncStatus: SyncStatus
+  syncProgress: number
 }
 
 export type WalletStateNote = WalletConfigNote

--- a/dex/utils/generics.go
+++ b/dex/utils/generics.go
@@ -54,3 +54,12 @@ func Max[I constraints.Ordered](m I, ns ...I) I {
 	}
 	return max
 }
+
+func Clamp[I constraints.Ordered](v I, min I, max I) I {
+	if v < min {
+		v = min
+	} else if v > max {
+		v = max
+	}
+	return v
+}


### PR DESCRIPTION
```
Use a more detailed structure for sync status. Add a sync 
notification to replace wallet state notifications where only 
the sync status has changed. Lower default account and 
address gap limits for Decred and make address gap limit 
configurable. Add information about address and tx syncing, 
for after headers and filters have synced.
```
Our synchronization display has always been a little funky, and it still will be after this PR, but less so. For full-node RPC wallets, we show block synchronization, which is fine. For SPV wallets, we show header synchronization, but SPV wallets also have to synchronize filters and then scan for addresses and then scan again for transactions. We've always handled this by just showing 99.9% if we have our headers synced but haven't finished all the other stuff. The other stuff took substantial amounts of time though, so users were just staring at the 99.9% and probably thinking something is wrong. I've heard lots of feedback about the ux around this.

For Decred, part of the reason that post-header synchronization was taking so long is because we always start with a seed so we always get a full scan. We set our account gap limit to 10, same as dcrwallet default, but our address gap limit is 100 where dcrwallet's default is 20. I think we set this high because of concerns about the way we generate redemption addresses, but we have a wrapping gap-policy, so as long as we can set the address gap limit for initialization and rescan, we can restore wallets properly. We also only use 3 accounts max in our SPV wallets, so an account gap limit of 10 is not needed. I've lowered the account gap limit to 3 and the address gap limit to 20, and added a configuration option for the address gap limit. This reduces the time spent scanning for addresses by at least 80%. 

I don't think there's currently a way to track the actual filter synchronization, but luckily it is done in parallel with headers so there is really very little lag there. I also can't track the address scan. But I can track the transaction scan portion using the `RescanPoint` method provided by dcrwallet. So I've updated the UI to show the header download progress separately from the transaction scan progress, and for the address scan that preceeds the transaction scan, I just show a spinner and a message. On my system, that message is only displayed for about 1 minute now. 

**Initial header sync**
![image](https://github.com/user-attachments/assets/5e7f1200-daa8-4854-9e8c-db9f09659d44)

**Address discovery**
![image](https://github.com/user-attachments/assets/e54374cc-cd5a-41f5-8912-c4b069f0ba56)

**Transaction sync**
![image](https://github.com/user-attachments/assets/49619fa9-087b-43ba-aca8-15a4db1b00a7)

