### PR TITLE
Increase file size limit for Binance market info requests

### DIFF
--- a/client/mm/libxc/binance.go
+++ b/client/mm/libxc/binance.go
@@ -1917,5 +1917,5 @@ func binanceMarketToDexMarkets(binanceBaseSymbol, binanceQuoteSymbol string, tok
 
 func requestInto(req *http.Request, thing interface{}) error {
 	// bnc.log.Tracef("Sending request: %+v", req)
-	return dexnet.Do(req, thing, dexnet.WithSizeLimit(1<<22))
+	return dexnet.Do(req, thing, dexnet.WithSizeLimit(1<<24))
 }

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -446,12 +446,12 @@ func (m *MarketMaker) loadCEX(ctx context.Context, cfg *CEXConfig) (*centralized
 	}
 	c.mkts, err = cex.Markets(ctx)
 	if err != nil {
-		m.log.Errorf("Failed to get markets for %s: %w", cfg.Name, err)
+		m.log.Errorf("Failed to get markets for %s: %v", cfg.Name, err)
 		c.mkts = make(map[string]*libxc.Market)
 		c.connectErr = err.Error()
 	}
 	if c.balances, err = c.Balances(ctx); err != nil {
-		m.log.Errorf("Failed to get balances for %s: %w", cfg.Name, err)
+		m.log.Errorf("Failed to get balances for %s: %v", cfg.Name, err)
 		c.balances = make(map[uint32]*libxc.ExchangeBalance)
 		c.connectErr = err.Error()
 	}


### PR DESCRIPTION
`https://api.binance.com/api/v3/exchangeInfo` currently weighs ~6 MB, preventing the MM bot from being configured:

```
[ERR] WEB: error loading Binance with updated config: error connecting to CEX: failed to connect to CEX: connect failure: error getting markets: error getting markets from Binance: error decoding request: unexpected EOF
```

This PR increases the size limit to 16 MiB and fixes a couple of incorrectly wrapped errors.