### PR TITLE
multi: assorted fixes

### DIFF
--- a/client/cmd/bisonw-desktop/go.mod
+++ b/client/cmd/bisonw-desktop/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240223125850-b1e8a79f509c // indirect
 	github.com/crate-crypto/go-kzg-4844 v1.0.0 // indirect
-	github.com/dcrlabs/ltcwallet v0.0.0-20240817190502-ee5cf83672a6 // indirect
+	github.com/dcrlabs/ltcwallet v0.0.0-20240823165752-3e026e8da010 // indirect
 	github.com/decred/dcrd/mixing v0.3.0 // indirect
 	github.com/decred/vspd/client/v3 v3.0.0 // indirect
 	github.com/ethereum/c-kzg-4844 v1.0.0 // indirect

--- a/client/cmd/bisonw-desktop/go.sum
+++ b/client/cmd/bisonw-desktop/go.sum
@@ -257,8 +257,8 @@ github.com/dchest/siphash v1.2.3/go.mod h1:0NvQU092bT0ipiFN++/rXm69QG9tVxLAlQHIX
 github.com/dcrlabs/bchwallet v0.0.0-20240114115928-2a995d024eed/go.mod h1:dX7SZgs+dmGL56e6KHn+MktfriF/aM2qI4yYK56ySEQ=
 github.com/dcrlabs/bchwallet v0.0.0-20240114124852-0e95005810be h1:F61HTz77YatFuMgleG4Hp4QpXWJgjSG+S72YlXD4jPA=
 github.com/dcrlabs/bchwallet v0.0.0-20240114124852-0e95005810be/go.mod h1:Km7vMslEkg88jIFE2TA/XX7kAvXvnsoGTXN9ktYSi98=
-github.com/dcrlabs/ltcwallet v0.0.0-20240817190502-ee5cf83672a6 h1:8xo4LEr6/zI+0NuAQk67GBoDiAiaTN6dvr94DmvFXiI=
-github.com/dcrlabs/ltcwallet v0.0.0-20240817190502-ee5cf83672a6/go.mod h1:UwMkslDKQGQx7UCGjolqPKulzX3YQxMhDvVZ0KukIQk=
+github.com/dcrlabs/ltcwallet v0.0.0-20240823165752-3e026e8da010 h1:PtsVisotEbfWvFEvp2QbwT6rYrNP7b7v2ZXDkwYrCMY=
+github.com/dcrlabs/ltcwallet v0.0.0-20240823165752-3e026e8da010/go.mod h1:UwMkslDKQGQx7UCGjolqPKulzX3YQxMhDvVZ0KukIQk=
 github.com/dcrlabs/neutrino-bch v0.0.0-20240114121828-d656bce11095 h1:oGXgq+wZ2FvBzBTqXnOJ+ZP6f79zhfJNd46nDkJaUdU=
 github.com/dcrlabs/neutrino-bch v0.0.0-20240114121828-d656bce11095/go.mod h1:aymH7e5PUsdsLagAIIMbpyJIff0Kv8/BJg7nolIVJbU=
 github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -9353,6 +9353,8 @@ func (c *Core) peerChange(w *xcWallet, numPeers uint32, err error) {
 		c.notify(newWalletConfigNote(TopicWalletPeersRestored, subject, details,
 			db.Success, w.state()))
 		c.startWalletSyncMonitor(w)
+	} else if !ss.Synced {
+		c.startWalletSyncMonitor(w)
 	}
 
 	// Send a WalletStateNote in case Synced or anything else has changed.

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -112,6 +112,11 @@ img.dex-logo {
 
 img.logo-square {
   content: url("/img/bison-square_50.png");
+
+  &.small {
+    height: 25px;
+    width: 25px;
+  }
 }
 
 img.logo-full {

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -225,7 +225,6 @@ type cachedPassword struct {
 type Config struct {
 	Core          clientCore // *core.Core
 	MarketMaker   MMCore     // *mm.MarketMaker
-	MMCfgPath     string
 	Addr          string
 	CustomSiteDir string
 	Language      string
@@ -251,19 +250,18 @@ type valStamp struct {
 // WebServer is a single-client http and websocket server enabling a browser
 // interface to Bison Wallet.
 type WebServer struct {
-	ctx       context.Context
-	wsServer  *websocket.Server
-	mux       *chi.Mux
-	siteDir   string
-	lang      atomic.Value // string
-	langs     []string
-	core      clientCore
-	mm        MMCore
-	mmCfgPath string
-	addr      string
-	csp       string
-	srv       *http.Server
-	html      atomic.Value // *templates
+	ctx      context.Context
+	wsServer *websocket.Server
+	mux      *chi.Mux
+	siteDir  string
+	lang     atomic.Value // string
+	langs    []string
+	core     clientCore
+	mm       MMCore
+	addr     string
+	csp      string
+	srv      *http.Server
+	html     atomic.Value // *templates
 
 	authMtx         sync.RWMutex
 	authTokens      map[string]bool
@@ -385,7 +383,6 @@ func New(cfg *Config) (*WebServer, error) {
 		langs:           langs,
 		core:            cfg.Core,
 		mm:              cfg.MarketMaker,
-		mmCfgPath:       cfg.MMCfgPath,
 		siteDir:         siteDir,
 		mux:             mux,
 		srv:             httpServer,

--- a/dex/testing/loadbot/go.mod
+++ b/dex/testing/loadbot/go.mod
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/dcrlabs/ltcwallet v0.0.0-20240817190502-ee5cf83672a6 // indirect
+	github.com/dcrlabs/ltcwallet v0.0.0-20240823165752-3e026e8da010 // indirect
 	github.com/ltcsuite/lnd/tlv v0.0.0-20240222214433-454d35886119 // indirect
 	github.com/ltcsuite/ltcd/chaincfg/chainhash v1.0.2 // indirect
 )

--- a/dex/testing/loadbot/go.sum
+++ b/dex/testing/loadbot/go.sum
@@ -253,8 +253,8 @@ github.com/dchest/siphash v1.2.3/go.mod h1:0NvQU092bT0ipiFN++/rXm69QG9tVxLAlQHIX
 github.com/dcrlabs/bchwallet v0.0.0-20240114115928-2a995d024eed/go.mod h1:dX7SZgs+dmGL56e6KHn+MktfriF/aM2qI4yYK56ySEQ=
 github.com/dcrlabs/bchwallet v0.0.0-20240114124852-0e95005810be h1:F61HTz77YatFuMgleG4Hp4QpXWJgjSG+S72YlXD4jPA=
 github.com/dcrlabs/bchwallet v0.0.0-20240114124852-0e95005810be/go.mod h1:Km7vMslEkg88jIFE2TA/XX7kAvXvnsoGTXN9ktYSi98=
-github.com/dcrlabs/ltcwallet v0.0.0-20240817190502-ee5cf83672a6 h1:8xo4LEr6/zI+0NuAQk67GBoDiAiaTN6dvr94DmvFXiI=
-github.com/dcrlabs/ltcwallet v0.0.0-20240817190502-ee5cf83672a6/go.mod h1:UwMkslDKQGQx7UCGjolqPKulzX3YQxMhDvVZ0KukIQk=
+github.com/dcrlabs/ltcwallet v0.0.0-20240823165752-3e026e8da010 h1:PtsVisotEbfWvFEvp2QbwT6rYrNP7b7v2ZXDkwYrCMY=
+github.com/dcrlabs/ltcwallet v0.0.0-20240823165752-3e026e8da010/go.mod h1:UwMkslDKQGQx7UCGjolqPKulzX3YQxMhDvVZ0KukIQk=
 github.com/dcrlabs/neutrino-bch v0.0.0-20240114121828-d656bce11095 h1:oGXgq+wZ2FvBzBTqXnOJ+ZP6f79zhfJNd46nDkJaUdU=
 github.com/dcrlabs/neutrino-bch v0.0.0-20240114121828-d656bce11095/go.mod h1:aymH7e5PUsdsLagAIIMbpyJIff0Kv8/BJg7nolIVJbU=
 github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dchest/blake2b v1.0.0
 	github.com/dcrlabs/bchwallet v0.0.0-20240114124852-0e95005810be
-	github.com/dcrlabs/ltcwallet v0.0.0-20240817190502-ee5cf83672a6
+	github.com/dcrlabs/ltcwallet v0.0.0-20240823165752-3e026e8da010
 	github.com/dcrlabs/neutrino-bch v0.0.0-20240114121828-d656bce11095
 	github.com/decred/base58 v1.0.5
 	github.com/decred/dcrd/addrmgr/v2 v2.0.4

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/dchest/siphash v1.2.3/go.mod h1:0NvQU092bT0ipiFN++/rXm69QG9tVxLAlQHIX
 github.com/dcrlabs/bchwallet v0.0.0-20240114115928-2a995d024eed/go.mod h1:dX7SZgs+dmGL56e6KHn+MktfriF/aM2qI4yYK56ySEQ=
 github.com/dcrlabs/bchwallet v0.0.0-20240114124852-0e95005810be h1:F61HTz77YatFuMgleG4Hp4QpXWJgjSG+S72YlXD4jPA=
 github.com/dcrlabs/bchwallet v0.0.0-20240114124852-0e95005810be/go.mod h1:Km7vMslEkg88jIFE2TA/XX7kAvXvnsoGTXN9ktYSi98=
-github.com/dcrlabs/ltcwallet v0.0.0-20240817190502-ee5cf83672a6 h1:8xo4LEr6/zI+0NuAQk67GBoDiAiaTN6dvr94DmvFXiI=
-github.com/dcrlabs/ltcwallet v0.0.0-20240817190502-ee5cf83672a6/go.mod h1:UwMkslDKQGQx7UCGjolqPKulzX3YQxMhDvVZ0KukIQk=
+github.com/dcrlabs/ltcwallet v0.0.0-20240823165752-3e026e8da010 h1:PtsVisotEbfWvFEvp2QbwT6rYrNP7b7v2ZXDkwYrCMY=
+github.com/dcrlabs/ltcwallet v0.0.0-20240823165752-3e026e8da010/go.mod h1:UwMkslDKQGQx7UCGjolqPKulzX3YQxMhDvVZ0KukIQk=
 github.com/dcrlabs/neutrino-bch v0.0.0-20240114121828-d656bce11095 h1:oGXgq+wZ2FvBzBTqXnOJ+ZP6f79zhfJNd46nDkJaUdU=
 github.com/dcrlabs/neutrino-bch v0.0.0-20240114121828-d656bce11095/go.mod h1:aymH7e5PUsdsLagAIIMbpyJIff0Kv8/BJg7nolIVJbU=
 github.com/deckarep/golang-set/v2 v2.6.0 h1:XfcQbWM1LlMB8BsJ8N9vW5ehnnPVIw0je80NsVHagjM=


### PR DESCRIPTION
- werbserver: remove unused fields for mm config path
- ltc: update ltcwallet to tame the warnings when a peer was rejected for not supporting compact filters
- ui: CSS fix to follow up #2927 where small logo size wasn't always being set correctly
- core: fix some fallout from #2895 where a transient unsynced state at peer change wasn't properly followed up on, resulting incorrect sync status % displayed at the UI