### PR TITLE
ui: filter out injected non-existent language

### DIFF
--- a/client/webserver/site/package-lock.json
+++ b/client/webserver/site/package-lock.json
@@ -6162,12 +6162,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -13695,12 +13695,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },

--- a/client/webserver/site/src/js/doc.ts
+++ b/client/webserver/site/src/js/doc.ts
@@ -6,7 +6,6 @@ import {
   PageElement
 } from './registry'
 import State from './state'
-import { RateEncodingFactor } from './orderutil'
 
 // Symbolizer is satisfied by both dex.Asset and core.SupportedAsset. Used by
 // Doc.symbolize.
@@ -51,11 +50,15 @@ const BipSymbolIDs: Record<string, number> = {};
 
 const BipSymbols = Object.values(BipIDs)
 
+const RateEncodingFactor = 1e8 // same as value defined in ./orderutil
+
 const log10RateEncodingFactor = Math.round(Math.log10(RateEncodingFactor))
 
-const intFormatter = new Intl.NumberFormat(navigator.languages as string[], { maximumFractionDigits: 0 })
+const languages = navigator.languages.filter((locale: string) => locale !== 'c')
 
-const fourSigFigs = new Intl.NumberFormat((navigator.languages as string[]), {
+const intFormatter = new Intl.NumberFormat(languages, { maximumFractionDigits: 0 })
+
+const fourSigFigs = new Intl.NumberFormat(languages, {
   minimumSignificantDigits: 4,
   maximumSignificantDigits: 4
 })
@@ -90,7 +93,7 @@ function formatter (formatters: Record<string, Intl.NumberFormat>, min: number, 
   const k = `${min}-${max}`
   let fmt = formatters[k]
   if (!fmt) {
-    fmt = new Intl.NumberFormat(locales || navigator.languages as string[], {
+    fmt = new Intl.NumberFormat(locales ?? languages, {
       minimumFractionDigits: min,
       maximumFractionDigits: max
     })
@@ -363,6 +366,10 @@ export default class Doc {
     const [v] = convertToConventional(vAtomic, unitInfo)
     const value = v * rate
     return fullPrecisionFormatter(prec).format(value)
+  }
+
+  static languages (): string[] {
+    return languages
   }
 
   static formatFiatValue (value: number): string {

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -91,7 +91,7 @@ const sellBtnClass = 'sellred-bg'
 const fiveMinBinKey = '5m'
 const oneHrBinKey = '1h'
 
-const percentFormatter = new Intl.NumberFormat(document.documentElement.lang, {
+const percentFormatter = new Intl.NumberFormat(Doc.languages(), {
   minimumFractionDigits: 1,
   maximumFractionDigits: 2
 })

--- a/client/webserver/site/src/js/opts.ts
+++ b/client/webserver/site/src/js/opts.ts
@@ -19,7 +19,7 @@ export function setOptionTemplates (page: Record<string, PageElement>): void {
   [booleanOptTmpl, rangeOptTmpl, orderOptTmpl] = [page.booleanOptTmpl, page.rangeOptTmpl, page.orderOptTmpl]
 }
 
-const threeSigFigs = new Intl.NumberFormat((navigator.languages as string[]), {
+const threeSigFigs = new Intl.NumberFormat(Doc.languages(), {
   minimumSignificantDigits: 3,
   maximumSignificantDigits: 3
 })

--- a/client/webserver/site/src/js/order.ts
+++ b/client/webserver/site/src/js/order.ts
@@ -152,7 +152,7 @@ export default class OrderPage extends BasePage {
     tmpl.matchID.textContent = match.matchID
 
     const time = new Date(match.stamp)
-    tmpl.matchTime.textContent = time.toLocaleTimeString(navigator.languages as string[], {
+    tmpl.matchTime.textContent = time.toLocaleTimeString(Doc.languages(), {
       year: 'numeric',
       month: 'short',
       day: 'numeric'
@@ -287,7 +287,7 @@ export default class OrderPage extends BasePage {
       const refundAfter = new Date(m.stamp + lockTime)
       if (Date.now() > refundAfter.getTime()) tmpl.refundPending.textContent = intl.prep(intl.ID_REFUND_IMMINENT)
       else {
-        const refundAfterStr = refundAfter.toLocaleTimeString(navigator.languages as string[], {
+        const refundAfterStr = refundAfter.toLocaleTimeString(Doc.languages(), {
           year: 'numeric',
           month: 'short',
           day: 'numeric'

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1225,7 +1225,7 @@ export default class WalletsPage extends BasePage {
       Doc.show(page.purchaserErr)
       return
     }
-    this.showSuccess(intl.prep(intl.ID_TICKETS_PURCHASED, { n: n.toLocaleString(navigator.languages) }))
+    this.showSuccess(intl.prep(intl.ID_TICKETS_PURCHASED, { n: n.toLocaleString(Doc.languages()) }))
   }
 
   processTicketPurchaseUpdate (walletNote: CustomWalletNote) {


### PR DESCRIPTION
This was a patch we did on the `release-v0.6` branch (#2596) that somehow never made it into master. This is to address a bug in Electron that adds a non-existent language code into `navigator.languages`.

