### PR TITLE
zec: fix zcash multisplit

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2626,7 +2626,7 @@ func (btc *baseWallet) submitMultiSplitTx(fundingCoins asset.Coins, spents []*Ou
 			Address: outputAddresses[i].String(),
 		}
 	}
-	btc.cm.LockOutputs(locks)
+	btc.cm.LockUTXOs(locks)
 	btc.node.lockUnspent(false, ops)
 
 	var totalOut uint64
@@ -2760,8 +2760,7 @@ func (btc *baseWallet) fundMultiWithSplit(keep, maxLock uint64, values []*asset.
 		}
 	}
 
-	btc.cm.LockOutputs(locks)
-
+	btc.cm.LockUTXOs(locks)
 	btc.node.lockUnspent(false, spents)
 
 	return coins, redeemScripts, splitFees, nil
@@ -3360,7 +3359,7 @@ func accelerateOrder(btc *baseWallet, swapCoins, accelerationCoins []dex.Bytes, 
 
 		// Log it as a fundingCoin, since it is expected that this will be
 		// chained into further matches.
-		btc.cm.LockOutputs([]*UTxO{{
+		btc.cm.LockUTXOs([]*UTxO{{
 			TxHash:  newChange.txHash(),
 			Vout:    newChange.vout(),
 			Address: newChange.String(),
@@ -3880,7 +3879,7 @@ func (btc *baseWallet) Swap(swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, ui
 		})
 	}
 
-	btc.cm.LockOutputs(locks)
+	btc.cm.LockUTXOs(locks)
 	btc.cm.UnlockOutPoints(pts)
 
 	return receipts, changeCoin, fees, nil

--- a/client/asset/btc/coinmanager.go
+++ b/client/asset/btc/coinmanager.go
@@ -527,8 +527,10 @@ func (c *CoinManager) FundingCoins(ids []dex.Bytes) (asset.Coins, error) {
 	return coins, nil
 }
 
-// LockOutputs locks the specified utxos.
-func (c *CoinManager) LockOutputs(utxos []*UTxO) {
+// LockUTXOs locks the specified utxos.
+// TODO: Move lockUnspent calls into this method instead of the caller doing it
+// at every callsite, and because that's what we do with unlocking.
+func (c *CoinManager) LockUTXOs(utxos []*UTxO) {
 	c.mtx.Lock()
 	for _, utxo := range utxos {
 		c.lockedOutputs[NewOutPoint(utxo.TxHash, utxo.Vout)] = utxo

--- a/client/asset/zec/regnet_test.go
+++ b/client/asset/zec/regnet_test.go
@@ -8,14 +8,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/asset/btc"
 	"decred.org/dcrdex/client/asset/btc/livetest"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/config"
+	dexbtc "decred.org/dcrdex/dex/networks/btc"
 	dexzec "decred.org/dcrdex/dex/networks/zec"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/decred/dcrd/rpcclient/v8"
 )
 
@@ -151,4 +159,242 @@ func testDeserializeBlocks(t *testing.T, port string, upgradeHeights ...int64) {
 		nBlocksFromHash(lastVerBlock.String(), 1000)
 		ver--
 	}
+}
+
+func TestMultiSplit(t *testing.T) {
+	log := dex.StdOutLogger("T", dex.LevelTrace)
+	c := make(chan asset.WalletNotification, 16)
+	tmpDir, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(tmpDir)
+	walletCfg := &asset.WalletConfig{
+		Type: walletTypeRPC,
+		Settings: map[string]string{
+			"txsplit":     "true",
+			"rpcuser":     "user",
+			"rpcpassword": "pass",
+			"regtest":     "1",
+			"rpcport":     "33770",
+		},
+		Emit: asset.NewWalletEmitter(c, BipID, log),
+		PeersChange: func(u uint32, err error) {
+			log.Info("peers changed", u, err)
+		},
+		DataDir: tmpDir,
+	}
+	wi, err := NewWallet(walletCfg, log, dex.Simnet)
+	if err != nil {
+		t.Fatalf("Error making new wallet: %v", err)
+	}
+	w := wi.(*zecWallet)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		for {
+			select {
+			case n := <-c:
+				log.Infof("wallet note emitted: %+v", n)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	cm := dex.NewConnectionMaster(w)
+	if err := cm.ConnectOnce(ctx); err != nil {
+		t.Fatalf("Error connecting wallet: %v", err)
+	}
+
+	// Unlock all transparent outputs.
+	if ops, err := listLockUnspent(w, log); err != nil {
+		t.Fatalf("Error listing unspent outputs: %v", err)
+	} else if len(ops) > 0 {
+		coins := make([]*btc.Output, len(ops))
+		for i, op := range ops {
+			txHash, _ := chainhash.NewHashFromStr(op.TxID)
+			coins[i] = btc.NewOutput(txHash, op.Vout, 0)
+		}
+		if err := lockUnspent(w, true, coins); err != nil {
+			t.Fatalf("Error unlocking coins")
+		}
+		log.Info("Unlocked %d transparent outputs", len(ops))
+	}
+
+	bals, err := w.balances()
+	if err != nil {
+		t.Fatalf("Error getting wallet balance: %v", err)
+	}
+
+	var v0, v1 uint64 = 1e8, 2e8
+	orderReq0, orderReq1 := dexzec.RequiredOrderFunds(v0, 1, dexbtc.RedeemP2PKHInputSize, 1), dexzec.RequiredOrderFunds(v1, 1, dexbtc.RedeemP2PKHInputSize, 2)
+
+	tAddr := func() string {
+		addr, err := transparentAddressString(w)
+		if err != nil {
+			t.Fatalf("Error getting transparent address: %v", err)
+		}
+		return addr
+	}
+
+	// Send everything to a transparent address.
+	unspents, err := listUnspent(w)
+	if err != nil {
+		t.Fatalf("listUnspent error: %v", err)
+	}
+	fees := dexzec.TxFeesZIP317(1+(dexbtc.RedeemP2PKHInputSize*uint64(len(unspents))), 1+(3*dexbtc.P2PKHOutputSize), 0, 0, 0, uint64(bals.orchard.noteCount))
+	netBal := bals.available() - fees
+	changeVal := netBal - orderReq0 - orderReq1
+
+	recips := []*zSendManyRecipient{
+		{Address: tAddr(), Amount: btcutil.Amount(orderReq0).ToBTC()},
+		{Address: tAddr(), Amount: btcutil.Amount(orderReq1).ToBTC()},
+		{Address: tAddr(), Amount: btcutil.Amount(changeVal).ToBTC()},
+	}
+
+	txHash, err := w.sendManyShielded(recips)
+	if err != nil {
+		t.Fatalf("sendManyShielded error: %v", err)
+	}
+
+	log.Infof("z_sendmany successful. txid = %s", txHash)
+
+	// Could be orchard notes. Mature them.
+	if err := mineAlpha(ctx); err != nil {
+		t.Fatalf("Error mining a block: %v", err)
+	}
+
+	// All funds should be transparent now.
+	multiFund := &asset.MultiOrder{
+		Version: version,
+		Values: []*asset.MultiOrderValue{
+			{Value: v0, MaxSwapCount: 1},
+			{Value: v1, MaxSwapCount: 2},
+		},
+		Options: map[string]string{"multisplit": "true"},
+	}
+
+	checkFundMulti := func(expSplit bool) {
+		t.Helper()
+		coinSets, _, fundingFees, err := w.FundMultiOrder(multiFund, 0)
+		if err != nil {
+			t.Fatalf("FundMultiOrder error: %v", err)
+		}
+
+		if len(coinSets) != 2 || len(coinSets[0]) != 1 || len(coinSets[1]) != 1 {
+			t.Fatalf("Expected 2 coin sets of len 1 each, got %+v", coinSets)
+		}
+
+		coin0, coin1 := coinSets[0][0], coinSets[1][0]
+
+		if err := w.cm.ReturnCoins(asset.Coins{coin0, coin1}); err != nil {
+			t.Fatalf("ReturnCoins error: %v", err)
+		}
+
+		if coin0.Value() != orderReq0 {
+			t.Fatalf("coin 0 had insufficient value: %d < %d", coin0.Value(), orderReq0)
+		}
+
+		if coin1.Value() < orderReq1 {
+			t.Fatalf("coin 1 had insufficient value: %d < %d", coin1.Value(), orderReq1)
+		}
+
+		// Should be no split tx.
+		split := fundingFees > 0
+		if split != expSplit {
+			t.Fatalf("Expected split %t, got %t", expSplit, split)
+		}
+
+		log.Infof("Coin 0: %s", coin0)
+		log.Infof("Coin 1: %s", coin1)
+		log.Infof("Funding fees: %d", fundingFees)
+	}
+
+	checkFundMulti(false) // no split
+
+	// Could be orchard notes. Mature them.
+	if err := mineAlpha(ctx); err != nil {
+		t.Fatalf("Error mining a block: %v", err)
+	}
+
+	// Send everything to a single transparent address to test for a
+	// fully-transparent split tx.
+	splitFees := dexzec.TxFeesZIP317(1+(3*dexbtc.RedeemP2PKHInputSize), 1+dexbtc.P2PKHOutputSize, 0, 0, 0, 0)
+	netBal -= splitFees
+	txHash, err = w.sendOneShielded(ctx, tAddr(), netBal, NoPrivacy)
+	if err != nil {
+		t.Fatalf("sendOneShielded(transparent) error: %v", err)
+	}
+	log.Infof("Sent all to transparent with tx %s", txHash)
+
+	// Could be orchard notes. Mature them.
+	if err := mineAlpha(ctx); err != nil {
+		t.Fatalf("Error mining a block: %v", err)
+	}
+
+	checkFundMulti(true) // fully-transparent split
+
+	// Could be orchard notes. Mature them.
+	if err := mineAlpha(ctx); err != nil {
+		t.Fatalf("Error mining a block: %v", err)
+	}
+
+	// Send everything to a shielded address.
+	addrRes, err := zGetAddressForAccount(w, shieldedAcctNumber, []string{transparentAddressType, orchardAddressType})
+	if err != nil {
+		t.Fatalf("zGetAddressForAccount error: %v", err)
+	}
+	receivers, err := zGetUnifiedReceivers(w, addrRes.Address)
+	if err != nil {
+		t.Fatalf("zGetUnifiedReceivers error: %v", err)
+	}
+	orchardAddr := receivers.Orchard
+
+	bals, err = w.balances()
+	if err != nil {
+		t.Fatalf("Error getting wallet balance: %v", err)
+	}
+	unspents, err = listUnspent(w)
+	if err != nil {
+		t.Fatalf("listUnspent error: %v", err)
+	}
+
+	splitFees = dexzec.TxFeesZIP317(1+(dexbtc.RedeemP2PKHInputSize*uint64(len(unspents))), 1, 0, 0, 0, uint64(bals.orchard.noteCount))
+	netBal = bals.available() - splitFees
+
+	txHash, err = w.sendOneShielded(ctx, orchardAddr, netBal, NoPrivacy)
+	if err != nil {
+		t.Fatalf("sendManyShielded error: %v", err)
+	}
+	log.Infof("sendOneShielded(shielded) successful. txid = %s", txHash)
+
+	// Could be orchard notes. Mature them.
+	if err := mineAlpha(ctx); err != nil {
+		t.Fatalf("Error mining a block: %v", err)
+	}
+
+	checkFundMulti(true) // shielded split
+
+	cancel()
+	cm.Wait()
+}
+
+func mineAlpha(ctx context.Context) error {
+	// Wait for txs to propagate
+	select {
+	case <-time.After(time.Second * 5):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	// Mine
+	if err := exec.Command("tmux", "send-keys", "-t", "zec-harness:4", "./mine-alpha 1", "C-m").Run(); err != nil {
+		return err
+	}
+	// Wait for blocks to propagate
+	select {
+	case <-time.After(time.Second * 5):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
 }

--- a/client/asset/zec/shielded_rpc.go
+++ b/client/asset/zec/shielded_rpc.go
@@ -153,8 +153,8 @@ const (
 
 // z_sendmany "fromaddress" [{"address":... ,"amount":...},...] ( minconf ) ( fee ) ( privacyPolicy )
 func zSendMany(c rpcCaller, fromAddress string, recips []*zSendManyRecipient, priv privacyPolicy) (operationID string, err error) {
-	const minConf, fee = 1, 0.00001
-	return operationID, c.CallRPC(methodZSendMany, []any{fromAddress, recips, minConf, fee, priv}, &operationID)
+	const minConf = 1
+	return operationID, c.CallRPC(methodZSendMany, []any{fromAddress, recips, minConf, nil, priv}, &operationID)
 }
 
 type opResult struct {

--- a/client/asset/zec/transparent_rpc.go
+++ b/client/asset/zec/transparent_rpc.go
@@ -256,8 +256,8 @@ func getRPCBlockHeader(c rpcCaller, blockHash *chainhash.Hash) (*btc.BlockHeader
 	return blkHeader, nil
 }
 
-func getWalletTransaction(c rpcCaller, txHash *chainhash.Hash) (*btc.GetTransactionResult, error) {
-	var tx btc.GetTransactionResult
+func getWalletTransaction(c rpcCaller, txHash *chainhash.Hash) (*GetTransactionResult, error) {
+	var tx GetTransactionResult
 	err := c.CallRPC("gettransaction", []any{txHash.String()}, &tx)
 	if err != nil {
 		if btc.IsTxNotFoundErr(err) {

--- a/client/asset/zec/transparent_rpc.go
+++ b/client/asset/zec/transparent_rpc.go
@@ -43,8 +43,19 @@ type zTx struct {
 	blockHash *chainhash.Hash
 }
 
+type GetTransactionResult struct {
+	Confirmations int64  `json:"confirmations"`
+	BlockHash     string `json:"blockhash"`
+	// BlockIndex    int64  `json:"blockindex"` // unused, consider commenting
+	BlockTime    uint64    `json:"blocktime"`
+	TxID         string    `json:"txid"`
+	Time         uint64    `json:"time"`
+	TimeReceived uint64    `json:"timereceived"`
+	Bytes        dex.Bytes `json:"hex"`
+}
+
 func getTransaction(c rpcCaller, txHash *chainhash.Hash) (*zTx, error) {
-	var tx btc.GetTransactionResult
+	var tx GetTransactionResult
 	if err := c.CallRPC("gettransaction", []any{txHash.String()}, &tx); err != nil {
 		return nil, err
 	}

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -46,7 +46,7 @@ const (
 	// structure.
 	defaultFee          = 10
 	defaultFeeRateLimit = 1000
-	minNetworkVersion   = 5040250 // v5.4.2
+	minNetworkVersion   = 5090150 // v5.9.1
 	walletTypeRPC       = "zcashdRPC"
 
 	// defaultConfTarget is the amount of confirmations required to consider

--- a/client/cmd/testbinance/main.go
+++ b/client/cmd/testbinance/main.go
@@ -60,6 +60,7 @@ var (
 			makeMarket("dcr", "btc"),
 			makeMarket("eth", "btc"),
 			makeMarket("dcr", "usdc"),
+			makeMarket("zec", "btc"),
 		},
 	}
 
@@ -68,6 +69,7 @@ var (
 		makeCoinInfo("ETH", "ETH", true, true, 0.00035, 0.008),
 		makeCoinInfo("DCR", "DCR", true, true, 0.00001000, 0.05),
 		makeCoinInfo("USDC", "MATIC", true, true, 0.01000, 10),
+		makeCoinInfo("ZEC", "ZEC", true, true, 0.00500000, 0.01000000),
 	}
 
 	coinpapAssets = []*fiatrates.CoinpaprikaAsset{
@@ -75,6 +77,7 @@ var (
 		makeCoinpapAsset(42, "dcr", "Decred"),
 		makeCoinpapAsset(60, "eth", "Ethereum"),
 		makeCoinpapAsset(966001, "usdc.polygon", "USDC"),
+		makeCoinpapAsset(133, "zec", "Zcash"),
 	}
 
 	initialBalances = []*bntypes.Balance{
@@ -82,6 +85,7 @@ var (
 		makeBalance("dcr", 10000),
 		makeBalance("eth", 5),
 		makeBalance("usdc", 1152),
+		makeBalance("zec", 10000),
 	}
 )
 

--- a/client/mm/libxc/binance_live_test.go
+++ b/client/mm/libxc/binance_live_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -357,15 +358,15 @@ func TestGetCoinInfo(t *testing.T) {
 		if !coinLookup[c.Coin] {
 			continue
 		}
-		networks := make([]string, 0)
+		networkMins := make([]string, 0)
 		for _, n := range c.NetworkList {
 			if !n.DepositEnable || !n.WithdrawEnable {
 				fmt.Printf("%s on network %s not withdrawing and/or depositing. withdraw = %t, deposit = %t\n",
 					c.Coin, n.Network, n.WithdrawEnable, n.DepositEnable)
 			}
-			networks = append(networks, n.Network)
+			networkMins = append(networkMins, fmt.Sprintf("{net: %s, min_withdraw: %.8f, withdraw_fee: %.8f}", n.Network, n.WithdrawMin, n.WithdrawFee))
 		}
-		fmt.Printf("%q networks: %+v \n", c.Coin, networks)
+		fmt.Printf("%q network mins: %+v \n", c.Coin, strings.Join(networkMins, ", "))
 	}
 }
 

--- a/dex/testing/dcrdex/genmarkets.sh
+++ b/dex/testing/dcrdex/genmarkets.sh
@@ -239,8 +239,8 @@ if [ $ZEC_ON -eq 0 ]; then
         {
             "base": "ZEC_simnet",
             "quote": "BTC_simnet",
-            "lotSize": 1000000,
-            "rateStep": 100000,
+            "lotSize": 100000000,
+            "rateStep": 10,
             "epochDuration": ${EPOCH_DURATION},
             "marketBuyBuffer": 1.2,
             "parcelSize": 5


### PR DESCRIPTION
- Refactor zcash multi-split. It wasn't working well or considering shielded funds
- Fix Zcash withdraw address sent to cex. The unified address wasn't being parsed to a transparent.
- Add ZEC-BTC market on the testbinance server
- 0-conf transparent outputs are now immature for the purposes of split-order funding and e.g. simple sends. This is because orchard outputs require 1 conf, and we use z_sendmany which is ambigious as to where it will get funds from. Calling z_sendmany with 0 sometimes seems to throw errors, even if there is enough transparent funding.

I'll have a ZEC-USDT market up on the mainnet testing server in the morning. There's is a matching market on binance.us that bots can arb against. We can't arb zec on binance global until we implement the new exchange addresses.