### PR TITLE
core: Fix connecting via Tor

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -228,7 +228,7 @@ func (conn *wsConn) setConnectionStatus(status ConnectionStatus) {
 // connect attempts to establish a websocket connection.
 func (conn *wsConn) connect(ctx context.Context) error {
 	dialer := &websocket.Dialer{
-		HandshakeTimeout: 10 * time.Second,
+		HandshakeTimeout: DefaultResponseTimeout,
 		TLSClientConfig:  conn.tlsCfg,
 	}
 	if conn.cfg.NetDialContext != nil {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -8111,14 +8111,15 @@ func (c *Core) newDEXConnection(acctInfo *db.AccountInfo, flag connectDEXFlag) (
 				return nil, errors.New("tor must be configured for .onion addresses")
 			}
 			proxyAddr = c.cfg.Onion
+
+			wsURL.Scheme = "ws"
+			wsCfg.URL = wsURL.String()
 		}
 		proxy := &socks.Proxy{
 			Addr:         proxyAddr,
 			TorIsolation: c.cfg.TorIsolation, // need socks.NewPool with isolation???
 		}
 		wsCfg.NetDialContext = proxy.DialContext
-		wsURL.Scheme = "ws"
-		wsCfg.URL = wsURL.String()
 	}
 
 	wsCfg.ConnectEventFunc = func(status comms.ConnectionStatus) {


### PR DESCRIPTION
Only servers behind an .onion address will be using cleartext.