### PR TITLE
mm: add volume minimums and sanity checks for oracle rates

### DIFF
--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -706,7 +706,7 @@ func (c *Core) rotateBonds(ctx context.Context) {
 
 		bondCfg := c.dexBondConfig(dc, now)
 		if len(bondCfg.bondAssets) == 0 {
-			if !dc.IsDown() {
+			if !dc.IsDown() && dc.config() != nil {
 				dc.log.Meter("no-bond-assets", time.Minute*10).Warnf("Zero bond assets reported for apparently connected DCRDEX server")
 			}
 			continue

--- a/client/mm/mm_basic_test.go
+++ b/client/mm/mm_basic_test.go
@@ -45,8 +45,14 @@ func TestBasisPrice(t *testing.T) {
 		{
 			name:        "oracle price",
 			oraclePrice: 2000,
-			fiatRate:    1000,
+			fiatRate:    1900,
 			exp:         2000,
+		},
+		{
+			name:        "failed sanity check",
+			oraclePrice: 2000,
+			fiatRate:    1850, // mismatch > 5%
+			exp:         0,
 		},
 		{
 			name:        "no oracle price",

--- a/client/mm/mm_test.go
+++ b/client/mm/mm_test.go
@@ -556,7 +556,7 @@ func newTBotCEXAdaptor() *tBotCexAdaptor {
 
 var _ botCexAdaptor = (*tBotCexAdaptor)(nil)
 
-var tLogger = dex.StdOutLogger("mm_TEST", dex.LevelTrace)
+var tLogger = dex.StdOutLogger("mm_TEST", dex.LevelInfo)
 
 func (c *tBotCexAdaptor) CEXBalance(assetID uint32) (*BotBalance, error) {
 	return c.balances[assetID], c.balanceErr

--- a/client/mm/price_oracle.go
+++ b/client/mm/price_oracle.go
@@ -276,7 +276,7 @@ func fetchMarketPrice(ctx context.Context, baseID, quoteID uint32, log dex.Logge
 	}
 	if usdVolume < minimumUSDVolumeForOraclesAvg {
 		log.Meter("oracle_low_volume_"+b.Symbol+"_"+q.Symbol, 12*time.Hour).Infof(
-			"rejecting oracle average price for %s. not enough volume (%.2f USD < %.2f)",
+			"Rejecting oracle average price for %s. not enough volume (%.2f USD < %.2f)",
 			b.Symbol+"_"+q.Symbol, usdVolume, float32(minimumUSDVolumeForOraclesAvg),
 		)
 		return 0, oracles, nil


### PR DESCRIPTION
I noticed while making dcr-btc with the basic market maker that we only had one oracle, the volume was super low, and the rate had drifted an uncomfortable amount without any indication that something was wrong. But since volume was not zero, we used the oracle average anyway. This PR adds a number of improvements and failsafes that prevent oracle-derived rates from being used unless certain reasonable conditions are met.

1. Sum of oracles' 24-hr. volume must be > $100,000 USD, or else we use the fiat-derived basis price.
2. If we have a valid oracle price (enough volume), and a valid fiat-derived price, we'll do a sanity check for mismatch and error if the mismatch between the rates is > 5%.
3. Stop trying to look up binance.com markets on binance.us when binance.com is 451.