### PR TITLE
core: enable limiting connections to one server

### DIFF
--- a/client/app/config.go
+++ b/client/app/config.go
@@ -101,6 +101,8 @@ type CoreConfig struct {
 	// Net is a derivative field set by ResolveConfig.
 	Net dex.Network
 
+	TheOneHost string `long:"onehost" description:"Only connect with this server."`
+
 	NoAutoWalletLock   bool `long:"no-wallet-lock" description:"Disable locking of wallets on shutdown or logout. Use this if you want your external wallets to stay unlocked after closing the DEX app."`
 	NoAutoDBBackup     bool `long:"no-db-backup" description:"Disable creation of a database backup on shutdown."`
 	UnlockCoinsOnLogin bool `long:"release-wallet-coins" description:"On login or wallet creation, instruct the wallet to release any coins that it may have locked."`
@@ -213,6 +215,7 @@ func (cfg *Config) Core(log dex.Logger) *core.Config {
 		NoAutoWalletLock:   cfg.NoAutoWalletLock,
 		NoAutoDBBackup:     cfg.NoAutoDBBackup,
 		ExtensionModeFile:  cfg.ExtensionModeFile,
+		TheOneHost:         cfg.TheOneHost,
 	}
 }
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1433,6 +1433,8 @@ type Config struct {
 	// for running core in extension mode, which gives the caller options for
 	// e.g. limiting the ability to configure wallets.
 	ExtensionModeFile string
+
+	TheOneHost string
 }
 
 // locale is data associated with the currently selected language.
@@ -7172,6 +7174,11 @@ func (c *Core) connectAccount(acct *db.AccountInfo) (connected bool) {
 	if err != nil {
 		c.log.Errorf("skipping loading of %s due to address parse error: %v", host, err)
 		return
+	}
+
+	if c.cfg.TheOneHost != "" && c.cfg.TheOneHost != host {
+		c.log.Infof("Running with --onehost = %q.", c.cfg.TheOneHost)
+		return false
 	}
 
 	var connectFlag connectDEXFlag


### PR DESCRIPTION
This is useful enough for testing and working around bugs to add permanently, I think.