### PR TITLE
core: lock trade mutex for preimage resp.

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -7071,7 +7071,9 @@ func TestHandleNomatch(t *testing.T) {
 	dc.trades[marketOID] = marketTracker
 
 	runNomatch := func(tag string, oid order.OrderID) {
+		dc.tradeMtx.RLock()
 		tracker, _, _ := dc.findOrder(oid)
+		dc.tradeMtx.RUnlock()
 		if tracker == nil {
 			t.Fatalf("%s: order ID not found", tag)
 		}
@@ -7084,7 +7086,9 @@ func TestHandleNomatch(t *testing.T) {
 	}
 
 	checkTradeStatus := func(tag string, oid order.OrderID, expStatus order.OrderStatus) {
+		dc.tradeMtx.RLock()
 		tracker, _, _ := dc.findOrder(oid)
+		dc.tradeMtx.RUnlock()
 		if tracker.metaData.Status != expStatus {
 			t.Fatalf("%s: wrong status. expected %s, got %s", tag, expStatus, tracker.metaData.Status)
 		}

--- a/client/core/simnet_trade.go
+++ b/client/core/simnet_trade.go
@@ -2216,7 +2216,10 @@ func (client *simulationClient) findOrder(orderID string) (*trackedTrade, error)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing order id %s -> %v", orderID, err)
 	}
-	tracker, _, _ := client.dc().findOrder(oid)
+	dc := client.dc()
+	dc.tradeMtx.RLock()
+	tracker, _, _ := dc.findOrder(oid)
+	dc.tradeMtx.RUnlock()
 	return tracker, nil
 }
 


### PR DESCRIPTION
closes #2964

I think the only way the cancel can become nil is if we received a notification that we already missed the preimage request and so the cancel is revoked, so it would probably be fine to just error, but I'm unsure this is the only reason cancel would be nil here, so locking the trade mutex until we check the csum seems the safest and most straight forward way to deal with this.