### PR TITLE
get rid of dead asset zcl

### DIFF
--- a/client/asset/importall/importall.go
+++ b/client/asset/importall/importall.go
@@ -9,6 +9,7 @@ import (
 	_ "decred.org/dcrdex/client/asset/doge" // register doge asset
 	_ "decred.org/dcrdex/client/asset/firo" // register firo asset
 	_ "decred.org/dcrdex/client/asset/ltc"  // register ltc asset
-	_ "decred.org/dcrdex/client/asset/zcl"  // register zcl asset
 	_ "decred.org/dcrdex/client/asset/zec"  // register zec asset
+	// nixed
+	// _ "decred.org/dcrdex/client/asset/zcl"  // register zcl asset
 )

--- a/client/cmd/bisonw-desktop/main.go
+++ b/client/cmd/bisonw-desktop/main.go
@@ -54,18 +54,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	_ "decred.org/dcrdex/client/asset/bch"  // register bch asset
-	_ "decred.org/dcrdex/client/asset/btc"  // register btc asset
-	_ "decred.org/dcrdex/client/asset/dash" // register dash asset
-	_ "decred.org/dcrdex/client/asset/dcr"  // register dcr asset
-	_ "decred.org/dcrdex/client/asset/dgb"  // register dgb asset
-	_ "decred.org/dcrdex/client/asset/doge" // register doge asset
-	_ "decred.org/dcrdex/client/asset/firo" // register firo asset
-	_ "decred.org/dcrdex/client/asset/ltc"  // register ltc asset
-	_ "decred.org/dcrdex/client/asset/zec"  // register zec asset
-
-	// Ethereum loaded in client/app/importlgpl.go
-
+	_ "decred.org/dcrdex/client/asset/importall"
 	"decred.org/dcrdex/dex"
 )
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -7139,6 +7139,10 @@ func (c *Core) initialize() error {
 	c.log.Infof("Connected to %d of %d DEX servers", liveConns, len(accts))
 
 	for _, dbWallet := range dbWallets {
+		if asset.Asset(dbWallet.AssetID) == nil && asset.TokenInfo(dbWallet.AssetID) == nil {
+			c.log.Infof("Wallet for asset %s no longer supported", dex.BipIDSymbol(dbWallet.AssetID))
+			continue
+		}
 		assetID := dbWallet.AssetID
 		wallet, err := c.loadWallet(dbWallet)
 		if err != nil {

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -794,12 +794,19 @@ export default class Application {
    * updateMarketElements sets the textContent for any ticker or asset name
    * elements or any asset logo src attributes for descendents of ancestor.
    */
-  updateMarketElements (ancestor: PageElement, baseID: number, quoteID: number) {
-    const { unitInfo: bui, name: baseName, symbol: baseSymbol } = this.assets[baseID]
+  updateMarketElements (ancestor: PageElement, baseID: number, quoteID: number, xc?: Exchange) {
+    const getAsset = (assetID: number) => {
+      const a = this.assets[assetID]
+      if (a) return a
+      if (!xc) throw Error(`no asset found for asset ID ${assetID}`)
+      const xcAsset = xc.assets[assetID]
+      return { unitInfo: xcAsset.unitInfo, name: xcAsset.symbol, symbol: xcAsset.symbol }
+    }
+    const { unitInfo: bui, name: baseName, symbol: baseSymbol } = getAsset(baseID)
     for (const el of Doc.applySelector(ancestor, '[data-base-name')) el.textContent = baseName
     for (const img of Doc.applySelector(ancestor, '[data-base-logo]')) img.src = Doc.logoPath(baseSymbol)
     for (const el of Doc.applySelector(ancestor, '[data-base-ticker]')) el.textContent = bui.conventional.unit
-    const { unitInfo: qui, name: quoteName, symbol: quoteSymbol } = this.assets[quoteID]
+    const { unitInfo: qui, name: quoteName, symbol: quoteSymbol } = getAsset(quoteID)
     for (const el of Doc.applySelector(ancestor, '[data-quote-name')) el.textContent = quoteName
     for (const img of Doc.applySelector(ancestor, '[data-quote-logo]')) img.src = Doc.logoPath(quoteSymbol)
     for (const el of Doc.applySelector(ancestor, '[data-quote-ticker]')) el.textContent = qui.conventional.unit

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -785,7 +785,7 @@ export default class MarketsPage extends BasePage {
     }
 
     const mmStatus = app().mmStatus
-    if (mmStatus && this.mmRunning === undefined) {
+    if (mmStatus && this.mmRunning === undefined && this.market.base && this.market.quote) {
       const { base: { id: baseID }, quote: { id: quoteID }, dex: { host } } = this.market
       const botStatus = mmStatus.bots.find(({ config: cfg }) => cfg.baseID === baseID && cfg.quoteID === quoteID && cfg.host === host)
       this.mmRunning = Boolean(botStatus?.running)
@@ -1113,6 +1113,7 @@ export default class MarketsPage extends BasePage {
     const mktId = marketID(baseCfg.symbol, quoteCfg.symbol)
     const baseAsset = app().assets[baseID]
     const quoteAsset = app().assets[quoteID]
+
     const mkt = {
       dex: dex,
       sid: mktId, // A string market identifier used by the DEX.
@@ -1139,7 +1140,6 @@ export default class MarketsPage extends BasePage {
     this.mmRunning = undefined
     page.lotSize.textContent = Doc.formatCoinValue(mkt.cfg.lotsize, mkt.baseUnitInfo)
     page.rateStep.textContent = Doc.formatCoinValue(mkt.cfg.ratestep / rateConversionFactor)
-    app().updateMarketElements(this.main, baseID, quoteID)
 
     this.displayMessageIfMissingWallet()
     this.balanceWgt.setWallets(host, baseID, quoteID)
@@ -1156,7 +1156,7 @@ export default class MarketsPage extends BasePage {
       base: baseID,
       quote: quoteID
     })
-    app().updateMarketElements(this.main, baseID, quoteID)
+    app().updateMarketElements(this.main, baseID, quoteID, dex)
     this.marketList.select(host, baseID, quoteID)
     this.setLoaderMsgVisibility()
     this.setTokenApprovalVisibility()

--- a/client/webserver/site/src/js/orders.ts
+++ b/client/webserver/site/src/js/orders.ts
@@ -169,6 +169,7 @@ export default class OrdersPage extends BasePage {
       let fromSymbol, toSymbol, fromUnit, toUnit, fromQty
       let toQty = ''
       const xc = app().exchanges[ord.host] || undefined
+      if ((!app().assets[ord.baseID] && !xc.assets[ord.baseID]) || (!app().assets[ord.quoteID] && !xc.assets[ord.quoteID])) continue
       const [baseUnitInfo, quoteUnitInfo] = [app().unitInfo(ord.baseID, xc), app().unitInfo(ord.quoteID, xc)]
       if (ord.sell) {
         [fromSymbol, toSymbol] = [ord.baseSymbol, ord.quoteSymbol];

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -1211,7 +1211,7 @@ export interface Application {
   bindTooltips (ancestor: HTMLElement): void
   bindUrlHandlers (ancestor: HTMLElement): void
   attachHeader (): void
-  updateMarketElements (ancestor: PageElement, baseID: number, quoteID: number): void
+  updateMarketElements (ancestor: PageElement, baseID: number, quoteID: number, xc?: Exchange): void
   showDropdown (icon: HTMLElement, dialog: HTMLElement): void
   ackNotes (): void
   setNoteTimes (noteList: HTMLElement): void

--- a/server/asset/importall/importall.go
+++ b/server/asset/importall/importall.go
@@ -9,6 +9,7 @@ import (
 	_ "decred.org/dcrdex/server/asset/doge" // register doge asset
 	_ "decred.org/dcrdex/server/asset/firo" // register firo asset
 	_ "decred.org/dcrdex/server/asset/ltc"  // register ltc asset
-	_ "decred.org/dcrdex/server/asset/zcl"  // register zcl asset
 	_ "decred.org/dcrdex/server/asset/zec"  // register zec asset
+	// nixed
+	// _ "decred.org/dcrdex/server/asset/zcl"  // register zcl asset
 )


### PR DESCRIPTION
Also switches to using **importall** package in **bisonw-desktop**.

Does not delete the **client/asset/zcl** or **server/asset/zcl** or testing packages yet. We can do that any time, but it might be worth discussing a way to handle low-cap assets that enables them to be switched on by the user somehow, so I'll leave the code for now.

I highly doubt anybody is using bw as a Zclassic wallet, but it doesn't matter if they are, since the only option for wallet type is the external RPC wallet.