### PR TITLE
core: protect epoch checksum with its own mutex

### DIFF
--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -271,6 +271,7 @@ func testDexConnection(ctx context.Context, crypter *tCrypter) (*dexConnection, 
 		},
 		notify:            func(Notification) {},
 		trades:            make(map[order.OrderID]*trackedTrade),
+		cancels:           make(map[order.OrderID]order.OrderID),
 		inFlightOrders:    make(map[uint64]*InFlightOrder),
 		epoch:             map[string]uint64{tDcrBtcMktName: 0},
 		resolvedEpoch:     map[string]uint64{tDcrBtcMktName: 0},
@@ -3792,9 +3793,9 @@ func TestHandlePreimageRequest(t *testing.T) {
 		// resetCsum resets csum for further preimage request since multiple
 		// testing scenarios use the same tracker object.
 		resetCsum := func(tracker *trackedTrade) {
-			tracker.mtx.Lock()
+			tracker.csumMtx.Lock()
 			tracker.csum = nil
-			tracker.mtx.Unlock()
+			tracker.csumMtx.Unlock()
 		}
 
 		rig.dc.trades[oid] = tracker
@@ -3923,15 +3924,17 @@ func TestHandlePreimageRequest(t *testing.T) {
 			t.Fatal("no order note from preimage request handling")
 		}
 
-		tracker.mtx.RLock()
-		if !bytes.Equal(commitCSum, tracker.csum) {
+		tracker.csumMtx.RLock()
+		csum := tracker.csum
+		tracker.csumMtx.RUnlock()
+		if !bytes.Equal(commitCSum, csum) {
 			t.Fatalf(
 				"handlePreimageRequest must initialize tracker csum, exp: %s, got: %s",
 				commitCSum,
-				tracker.csum,
+				csum,
 			)
 		}
-		tracker.mtx.RUnlock()
+
 	})
 	t.Run("more than one preimage request for order (different csums)", func(t *testing.T) {
 		rig := newTestRig()
@@ -3997,14 +4000,16 @@ func TestHandlePreimageRequest(t *testing.T) {
 		}
 
 		tracker.mtx.RLock()
-		if !bytes.Equal(firstCSum, tracker.csum) {
+		csum := tracker.csum
+		tracker.mtx.RUnlock()
+		if !bytes.Equal(firstCSum, csum) {
 			t.Fatalf(
 				"[handlePreimageRequest] csum was changed, exp: %s, got: %s",
 				firstCSum,
-				tracker.csum,
+				csum,
 			)
 		}
-		tracker.mtx.RUnlock()
+
 	})
 	t.Run("more than one preimage request for order (same csum)", func(t *testing.T) {
 		rig := newTestRig()
@@ -4066,14 +4071,15 @@ func TestHandlePreimageRequest(t *testing.T) {
 		}
 
 		tracker.mtx.RLock()
-		if !bytes.Equal(csum, tracker.csum) {
+		checkSum := tracker.csum
+		tracker.mtx.RUnlock()
+		if !bytes.Equal(csum, checkSum) {
 			t.Fatalf(
 				"[handlePreimageRequest] csum was changed, exp: %s, got: %s",
 				csum,
-				tracker.csum,
+				checkSum,
 			)
 		}
-		tracker.mtx.RUnlock()
 	})
 	t.Run("csum for cancel order", func(t *testing.T) {
 		rig := newTestRig()
@@ -4104,7 +4110,8 @@ func TestHandlePreimageRequest(t *testing.T) {
 				epochLen: mkt.EpochLen,
 			},
 		}
-		oid := tracker.cancel.ID()
+		oid := tracker.ID()
+		cid := tracker.cancel.ID()
 
 		// Test the new path with rig.core.sentCommits.
 		readyCommitment := func(commit order.Commitment) chan struct{} {
@@ -4119,7 +4126,7 @@ func TestHandlePreimageRequest(t *testing.T) {
 		commitCSum := dex.Bytes{2, 3, 5, 7, 11, 13}
 		commitSig := readyCommitment(commit)
 		payload := &msgjson.PreimageRequest{
-			OrderID:        oid[:],
+			OrderID:        cid[:],
 			Commitment:     commit[:],
 			CommitChecksum: commitCSum,
 		}
@@ -4127,7 +4134,8 @@ func TestHandlePreimageRequest(t *testing.T) {
 
 		notes := rig.core.NotificationFeed()
 
-		rig.dc.trades[order.OrderID{}] = tracker
+		rig.dc.trades[oid] = tracker
+		rig.dc.registerCancelLink(cid, oid)
 		err := handlePreimageRequest(rig.core, rig.dc, reqCommit)
 		if err != nil {
 			t.Fatalf("handlePreimageRequest error: %v", err)
@@ -4147,14 +4155,16 @@ func TestHandlePreimageRequest(t *testing.T) {
 		}
 
 		tracker.mtx.RLock()
-		if !bytes.Equal(commitCSum, tracker.cancel.csum) {
+		cancelCsum := tracker.cancelCsum
+		tracker.mtx.RUnlock()
+		if !bytes.Equal(commitCSum, cancelCsum) {
 			t.Fatalf(
 				"handlePreimageRequest must initialize tracker cancel csum, exp: %s, got: %s",
 				commitCSum,
-				tracker.cancel.csum,
+				cancelCsum,
 			)
 		}
-		tracker.mtx.RUnlock()
+
 	})
 	t.Run("more than one preimage request for cancel order (different csums)", func(t *testing.T) {
 		rig := newTestRig()
@@ -4171,9 +4181,9 @@ func TestHandlePreimageRequest(t *testing.T) {
 			db:       rig.db,
 			dc:       rig.dc,
 			metaData: &db.OrderMetaData{},
+			// Simulate first preimage request by initializing csum here.
+			cancelCsum: firstCSum,
 			cancel: &trackedCancel{
-				// Simulate first preimage request by initializing csum here.
-				csum: firstCSum,
 				CancelOrder: order.CancelOrder{
 					P: order.Prefix{
 						AccountID:  rig.dc.acct.ID(),
@@ -4188,7 +4198,8 @@ func TestHandlePreimageRequest(t *testing.T) {
 				epochLen: mkt.EpochLen,
 			},
 		}
-		oid := tracker.cancel.ID()
+		oid := tracker.ID()
+		cid := tracker.cancel.ID()
 
 		// Test the new path with rig.core.sentCommits.
 		readyCommitment := func(commit order.Commitment) chan struct{} {
@@ -4203,7 +4214,7 @@ func TestHandlePreimageRequest(t *testing.T) {
 		secondCSum := dex.Bytes{2, 3, 5, 7, 11, 14}
 		commitSig := readyCommitment(commit)
 		payload := &msgjson.PreimageRequest{
-			OrderID:        oid[:],
+			OrderID:        cid[:],
 			Commitment:     commit[:],
 			CommitChecksum: secondCSum,
 		}
@@ -4214,7 +4225,8 @@ func TestHandlePreimageRequest(t *testing.T) {
 		rig.ws.sendMsgErrChan = make(chan *msgjson.Error, 1)
 		defer func() { rig.ws.sendMsgErrChan = nil }()
 
-		rig.dc.trades[order.OrderID{}] = tracker
+		rig.dc.trades[oid] = tracker
+		rig.dc.registerCancelLink(cid, oid)
 		err := handlePreimageRequest(rig.core, rig.dc, reqCommit)
 		if err != nil {
 			t.Fatalf("handlePreimageRequest error: %v", err)
@@ -4233,14 +4245,15 @@ func TestHandlePreimageRequest(t *testing.T) {
 			t.Fatal("no msgjson.Error sent from preimage request handling")
 		}
 		tracker.mtx.RLock()
-		if !bytes.Equal(firstCSum, tracker.cancel.csum) {
+		cancelCsum := tracker.cancelCsum
+		tracker.mtx.RUnlock()
+		if !bytes.Equal(firstCSum, cancelCsum) {
 			t.Fatalf(
 				"[handlePreimageRequest] cancel csum was changed, exp: %s, got: %s",
 				firstCSum,
-				tracker.cancel.csum,
+				cancelCsum,
 			)
 		}
-		tracker.mtx.RUnlock()
 	})
 	t.Run("more than one preimage request for cancel order (same csum)", func(t *testing.T) {
 		rig := newTestRig()
@@ -4257,9 +4270,9 @@ func TestHandlePreimageRequest(t *testing.T) {
 			db:       rig.db,
 			dc:       rig.dc,
 			metaData: &db.OrderMetaData{},
+			// Simulate first preimage request by initializing csum here.
+			cancelCsum: csum,
 			cancel: &trackedCancel{
-				// Simulate first preimage request by initializing csum here.
-				csum: csum,
 				CancelOrder: order.CancelOrder{
 					P: order.Prefix{
 						AccountID:  rig.dc.acct.ID(),
@@ -4274,7 +4287,8 @@ func TestHandlePreimageRequest(t *testing.T) {
 				epochLen: mkt.EpochLen,
 			},
 		}
-		oid := tracker.cancel.ID()
+		oid := tracker.ID()
+		cid := tracker.cancel.ID()
 
 		// Test the new path with rig.core.sentCommits.
 		readyCommitment := func(commit order.Commitment) chan struct{} {
@@ -4288,7 +4302,7 @@ func TestHandlePreimageRequest(t *testing.T) {
 		commit := preImg.Commit()
 		commitSig := readyCommitment(commit)
 		payload := &msgjson.PreimageRequest{
-			OrderID:        oid[:],
+			OrderID:        cid[:],
 			Commitment:     commit[:],
 			CommitChecksum: csum,
 		}
@@ -4296,7 +4310,8 @@ func TestHandlePreimageRequest(t *testing.T) {
 
 		notes := rig.core.NotificationFeed()
 
-		rig.dc.trades[order.OrderID{}] = tracker
+		rig.dc.trades[oid] = tracker
+		rig.dc.registerCancelLink(cid, oid)
 		err := handlePreimageRequest(rig.core, rig.dc, reqCommit)
 		if err != nil {
 			t.Fatalf("handlePreimageRequest error: %v", err)
@@ -4316,14 +4331,15 @@ func TestHandlePreimageRequest(t *testing.T) {
 		}
 
 		tracker.mtx.RLock()
-		if !bytes.Equal(csum, tracker.cancel.csum) {
+		cancelCsum := tracker.cancelCsum
+		tracker.mtx.RUnlock()
+		if !bytes.Equal(csum, cancelCsum) {
 			t.Fatalf(
 				"[handlePreimageRequest] cancel csum was changed, exp: %s, got: %s",
 				csum,
-				tracker.cancel.csum,
+				cancelCsum,
 			)
 		}
-		tracker.mtx.RUnlock()
 	})
 }
 
@@ -4391,6 +4407,7 @@ func TestHandleRevokeOrderMsg(t *testing.T) {
 	tracker.cancel = &trackedCancel{CancelOrder: *co}
 	coid := co.ID()
 	rig.dc.trades[oid] = tracker
+	rig.dc.registerCancelLink(coid, oid)
 
 	orderNotes, feedDone := orderNoteFeed(tCore)
 	defer feedDone()
@@ -5016,6 +5033,7 @@ func TestTradeTracking(t *testing.T) {
 	}
 	tracker.cancel = &trackedCancel{CancelOrder: *co, epochLen: mkt.EpochLen}
 	coid := co.ID()
+	rig.dc.registerCancelLink(coid, tracker.ID())
 	m1 := &msgjson.Match{
 		OrderID:  loid[:],
 		MatchID:  mid[:],
@@ -7057,6 +7075,7 @@ func TestHandleNomatch(t *testing.T) {
 	standingTracker.cancel = &trackedCancel{
 		CancelOrder: *cancelOrder,
 	}
+	dc.registerCancelLink(cancelOID, standingOID)
 
 	// 4. Market order.
 	loWillBeMarket, dbOrder, preImgL, _ := makeLimitOrder(dc, true, dcrBtcLotSize*100, dcrBtcRateStep)


### PR DESCRIPTION
The `trackedTrade.csum` field was protected under the very broad `trackedTrade.mtx`. This created lock contention when preimage requests came in while we had long running ticks, since `acceptCsum` had to lock that mutex. With this work, we now protect the checksum fields for trades and cancels under a different mutex.

Additionally, there were two places where the `trackedTrade.cancel` field was being read unsafely. A solution for that is implemented.