### PR TITLE
[1.0]client/db: enable archive pruning

### DIFF
--- a/client/app/config.go
+++ b/client/app/config.go
@@ -110,7 +110,7 @@ type CoreConfig struct {
 
 	ExtensionModeFile string `long:"extension-mode-file" description:"path to a file that specifies options for running core as an extension."`
 
-	ArchiveSizeLimit uint64 `long:"archivesize" description:"the maximum number of orders to be archived before deleting the oldest"`
+	PruneArchive uint64 `long:"prunearchive" description:"prune that order archive to the specified number of most recent orders"`
 }
 
 // WebConfig encapsulates the configuration needed for the web server.
@@ -219,7 +219,7 @@ func (cfg *Config) Core(log dex.Logger) *core.Config {
 		NoAutoDBBackup:     cfg.NoAutoDBBackup,
 		ExtensionModeFile:  cfg.ExtensionModeFile,
 		TheOneHost:         cfg.TheOneHost,
-		ArchiveSizeLimit:   cfg.ArchiveSizeLimit,
+		PruneArchive:       cfg.PruneArchive,
 	}
 }
 
@@ -229,9 +229,6 @@ var DefaultConfig = Config{
 	LogConfig:  LogConfig{DebugLevel: defaultLogLevel},
 	RPCConfig: RPCConfig{
 		CertHosts: []string{defaultTestnetHost, defaultSimnetHost, defaultMainnetHost},
-	},
-	CoreConfig: CoreConfig{
-		ArchiveSizeLimit: defaultArchiveSizeLimit,
 	},
 }
 

--- a/client/app/config.go
+++ b/client/app/config.go
@@ -110,7 +110,7 @@ type CoreConfig struct {
 
 	ExtensionModeFile string `long:"extension-mode-file" description:"path to a file that specifies options for running core as an extension."`
 
-	PruneArchive uint64 `long:"prunearchive" description:"prune that order archive to the specified number of most recent orders"`
+	PruneArchive uint64 `long:"prunearchive" description:"prune that order archive to the specified number of most recent orders. zero means no pruning."`
 }
 
 // WebConfig encapsulates the configuration needed for the web server.

--- a/client/app/config.go
+++ b/client/app/config.go
@@ -22,17 +22,18 @@ import (
 )
 
 const (
-	defaultRPCCertFile = "rpc.cert"
-	defaultRPCKeyFile  = "rpc.key"
-	defaultMainnetHost = "127.0.0.1"
-	defaultTestnetHost = "127.0.0.2"
-	defaultSimnetHost  = "127.0.0.3"
-	walletPairOneHost  = "127.0.0.6"
-	walletPairTwoHost  = "127.0.0.7"
-	defaultRPCPort     = "5757"
-	defaultWebPort     = "5758"
-	defaultLogLevel    = "debug"
-	configFilename     = "dexc.conf"
+	defaultRPCCertFile      = "rpc.cert"
+	defaultRPCKeyFile       = "rpc.key"
+	defaultMainnetHost      = "127.0.0.1"
+	defaultTestnetHost      = "127.0.0.2"
+	defaultSimnetHost       = "127.0.0.3"
+	walletPairOneHost       = "127.0.0.6"
+	walletPairTwoHost       = "127.0.0.7"
+	defaultRPCPort          = "5757"
+	defaultWebPort          = "5758"
+	defaultLogLevel         = "debug"
+	configFilename          = "dexc.conf"
+	defaultArchiveSizeLimit = 1000
 )
 
 var (
@@ -108,6 +109,8 @@ type CoreConfig struct {
 	UnlockCoinsOnLogin bool `long:"release-wallet-coins" description:"On login or wallet creation, instruct the wallet to release any coins that it may have locked."`
 
 	ExtensionModeFile string `long:"extension-mode-file" description:"path to a file that specifies options for running core as an extension."`
+
+	ArchiveSizeLimit uint64 `long:"archivesize" description:"the maximum number of orders to be archived before deleting the oldest"`
 }
 
 // WebConfig encapsulates the configuration needed for the web server.
@@ -216,6 +219,7 @@ func (cfg *Config) Core(log dex.Logger) *core.Config {
 		NoAutoDBBackup:     cfg.NoAutoDBBackup,
 		ExtensionModeFile:  cfg.ExtensionModeFile,
 		TheOneHost:         cfg.TheOneHost,
+		ArchiveSizeLimit:   cfg.ArchiveSizeLimit,
 	}
 }
 
@@ -225,6 +229,9 @@ var DefaultConfig = Config{
 	LogConfig:  LogConfig{DebugLevel: defaultLogLevel},
 	RPCConfig: RPCConfig{
 		CertHosts: []string{defaultTestnetHost, defaultSimnetHost, defaultMainnetHost},
+	},
+	CoreConfig: CoreConfig{
+		ArchiveSizeLimit: defaultArchiveSizeLimit,
 	},
 }
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1462,9 +1462,9 @@ type Config struct {
 	ExtensionModeFile string
 	// TheOneHost will run core with only the specified server.
 	TheOneHost string
-	// ArchiveSizeLimit is the maximum number of orders that will be archived
-	// before we start deleting the oldest.
-	ArchiveSizeLimit uint64
+	// PruneArchive will prune the order archive to the specified number of
+	// orders.
+	PruneArchive uint64
 }
 
 // locale is data associated with the currently selected language.
@@ -1547,7 +1547,7 @@ func New(cfg *Config) (*Core, error) {
 	}
 	dbOpts := bolt.Opts{
 		BackupOnShutdown: !cfg.NoAutoDBBackup,
-		ArchiveSizeLimit: cfg.ArchiveSizeLimit,
+		PruneArchive:     cfg.PruneArchive,
 	}
 	boltDB, err := bolt.NewDB(cfg.DBPath, cfg.Logger.SubLogger("DB"), dbOpts)
 	if err != nil {

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1460,8 +1460,11 @@ type Config struct {
 	// for running core in extension mode, which gives the caller options for
 	// e.g. limiting the ability to configure wallets.
 	ExtensionModeFile string
-
+	// TheOneHost will run core with only the specified server.
 	TheOneHost string
+	// ArchiveSizeLimit is the maximum number of orders that will be archived
+	// before we start deleting the oldest.
+	ArchiveSizeLimit uint64
 }
 
 // locale is data associated with the currently selected language.
@@ -1544,6 +1547,7 @@ func New(cfg *Config) (*Core, error) {
 	}
 	dbOpts := bolt.Opts{
 		BackupOnShutdown: !cfg.NoAutoDBBackup,
+		ArchiveSizeLimit: cfg.ArchiveSizeLimit,
 	}
 	boltDB, err := bolt.NewDB(cfg.DBPath, cfg.Logger.SubLogger("DB"), dbOpts)
 	if err != nil {

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"decred.org/dcrdex/client/db"
@@ -137,6 +138,7 @@ var (
 // Opts is a set of options for the DB.
 type Opts struct {
 	BackupOnShutdown bool // default is true
+	ArchiveSizeLimit uint64
 }
 
 var defaultOpts = Opts{
@@ -233,7 +235,28 @@ func (db *BoltDB) fileSize(path string) int64 {
 
 // Run waits for context cancellation and closes the database.
 func (db *BoltDB) Run(ctx context.Context) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tick := time.After(time.Minute)
+		for {
+			select {
+			case <-tick:
+			case <-ctx.Done():
+				return
+			}
+			if err := db.pruneArchivedOrders(); err != nil {
+				db.log.Errorf("Error cleaning archive: %v", err)
+			}
+			tick = time.After(time.Minute * 30)
+		}
+	}()
+
 	<-ctx.Done() // wait for shutdown to backup and compact
+
+	// Wait for archive cleaner to exit.
+	wg.Wait()
 
 	// Create a backup in the backups folder.
 	if db.opts.BackupOnShutdown {
@@ -404,6 +427,124 @@ func (db *BoltDB) SetPrimaryCredentials(creds *dexdb.PrimaryCredentials) error {
 
 	return db.Update(func(tx *bbolt.Tx) error {
 		return db.setCreds(tx, creds)
+	})
+}
+
+func (db *BoltDB) pruneArchivedOrders() error {
+	var archiveSizeLimit uint64 = 1000
+	if db.opts.ArchiveSizeLimit != 0 {
+		archiveSizeLimit = db.opts.ArchiveSizeLimit
+	}
+
+	return db.Update(func(tx *bbolt.Tx) error {
+		archivedOB := tx.Bucket(archivedOrdersBucket)
+		if archivedOB == nil {
+			return fmt.Errorf("failed to open %s bucket", string(archivedOrdersBucket))
+		}
+
+		// We won't delete any orders with active matches.
+		activeMatches := tx.Bucket(activeMatchesBucket)
+		if activeMatches == nil {
+			return fmt.Errorf("failed to open %s bucket", string(activeMatchesBucket))
+		}
+		oidsWithActiveMatches := make(map[order.OrderID]struct{}, 0)
+		if err := activeMatches.ForEach(func(k, _ []byte) error {
+			mBkt := activeMatches.Bucket(k)
+			if mBkt == nil {
+				return fmt.Errorf("error getting match bucket %x", k)
+			}
+			var oid order.OrderID
+			copy(oid[:], mBkt.Get(orderIDKey))
+			oidsWithActiveMatches[oid] = struct{}{}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("error building active match order ID index: %w", err)
+		}
+
+		nOrds := uint64(archivedOB.Stats().BucketN - 1 /* BucketN includes top bucket */)
+		if nOrds <= archiveSizeLimit {
+			return nil
+		}
+
+		toClear := int(nOrds - archiveSizeLimit)
+
+		type orderStamp struct {
+			oid   []byte
+			stamp int64
+		}
+		deletes := make([]*orderStamp, 0, toClear)
+		sortDeletes := func() {
+			sort.Slice(deletes, func(i, j int) bool {
+				return deletes[i].stamp < deletes[j].stamp
+			})
+		}
+		if err := archivedOB.ForEach(func(oidB, v []byte) error {
+			var oid order.OrderID
+			copy(oid[:], oidB)
+			if _, found := oidsWithActiveMatches[oid]; found {
+				return nil
+			}
+			ord, err := decodeOrderBucket(oidB, archivedOB.Bucket(oidB))
+			if err != nil {
+				return fmt.Errorf("error decoding order %x: %v", oid, err)
+			}
+			stamp := ord.Order.Prefix().ClientTime.Unix()
+			if len(deletes) < toClear {
+				deletes = append(deletes, &orderStamp{
+					stamp: stamp,
+					oid:   oidB,
+				})
+				sortDeletes()
+				return nil
+			}
+			if stamp > deletes[len(deletes)-1].stamp {
+				return nil
+			}
+			deletes[len(deletes)-1] = &orderStamp{
+				stamp: stamp,
+				oid:   oidB,
+			}
+			sortDeletes()
+			return nil
+		}); err != nil {
+			return fmt.Errorf("archive iteration error: %v", err)
+		}
+
+		deletedOrders := make(map[order.OrderID]struct{})
+		for _, del := range deletes {
+			var oid order.OrderID
+			copy(oid[:], del.oid)
+			deletedOrders[oid] = struct{}{}
+			if err := archivedOB.DeleteBucket(del.oid); err != nil {
+				return fmt.Errorf("error deleting archived order %q: %v", del.oid, err)
+			}
+		}
+
+		matchesToDelete := make([][]byte, 0, archiveSizeLimit /* just avoid some allocs if we can */)
+		archivedMatches := tx.Bucket(archivedMatchesBucket)
+		if archivedMatches == nil {
+			return errors.New("no archived match bucket")
+		}
+		if err := archivedMatches.ForEach(func(k, _ []byte) error {
+			matchBkt := archivedMatches.Bucket(k)
+			if matchBkt == nil {
+				return fmt.Errorf("no bucket found for %x during iteration", k)
+			}
+			var oid order.OrderID
+			copy(oid[:], matchBkt.Get(orderIDKey))
+			if _, found := deletedOrders[oid]; found {
+				matchesToDelete = append(matchesToDelete, k)
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("error finding matches to prune: %w", err)
+		}
+		for i := range matchesToDelete {
+			if err := archivedMatches.DeleteBucket(matchesToDelete[i]); err != nil {
+				return fmt.Errorf("error deleting pruned match %x: %w", matchesToDelete[i], err)
+			}
+		}
+		return nil
 	})
 }
 

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -470,7 +470,7 @@ func (db *BoltDB) pruneArchivedOrders() error {
 
 		type orderStamp struct {
 			oid   []byte
-			stamp int64
+			stamp uint64
 		}
 		deletes := make([]*orderStamp, 0, toClear)
 		sortDeletes := func() {
@@ -484,11 +484,16 @@ func (db *BoltDB) pruneArchivedOrders() error {
 			if _, found := oidsWithActiveMatches[oid]; found {
 				return nil
 			}
-			ord, err := decodeOrderBucket(oidB, archivedOB.Bucket(oidB))
-			if err != nil {
-				return fmt.Errorf("error decoding order %x: %v", oid, err)
+			oBkt := archivedOB.Bucket(oidB)
+			if oBkt == nil {
+				return fmt.Errorf("no order bucket iterated order %x", oidB)
 			}
-			stamp := ord.Order.Prefix().ClientTime.Unix()
+			stampB := oBkt.Get(updateTimeKey)
+			if stampB == nil {
+				// Highly improbable.
+				stampB = make([]byte, 8)
+			}
+			stamp := intCoder.Uint64(stampB)
 			if len(deletes) < toClear {
 				deletes = append(deletes, &orderStamp{
 					stamp: stamp,

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -1641,13 +1641,11 @@ func TestPruneArchivedOrders(t *testing.T) {
 		return n
 	}
 
-	var ordStampI int64
-	addOrder := func(optStamp int64) order.OrderID {
+	var ordStampI uint64
+	addOrder := func(stamp uint64) order.OrderID {
 		ord, _ := ordertest.RandomLimitOrder()
-		if optStamp != 0 {
-			ord.P.ClientTime = time.Unix(optStamp, 0)
-		} else {
-			ord.P.ClientTime = time.Unix(ordStampI, 0)
+		if stamp == 0 {
+			stamp = ordStampI
 			ordStampI++
 		}
 		boltdb.UpdateOrder(&db.MetaOrder{
@@ -1658,7 +1656,12 @@ func TestPruneArchivedOrders(t *testing.T) {
 			},
 			Order: ord,
 		})
-		return ord.ID()
+		oid := ord.ID()
+		boltdb.ordersUpdate(func(ob, archivedOB *bbolt.Bucket) error {
+			archivedOB.Bucket(oid[:]).Put(updateTimeKey, uint64Bytes(stamp))
+			return nil
+		})
+		return oid
 	}
 	for i := 0; i < archiveSizeLimit*2; i++ {
 		addOrder(0)
@@ -1680,11 +1683,7 @@ func TestPruneArchivedOrders(t *testing.T) {
 	if err := boltdb.View(func(tx *bbolt.Tx) error {
 		bkt := tx.Bucket(archivedOrdersBucket)
 		return bkt.ForEach(func(oidB, _ []byte) error {
-			ord, err := decodeOrderBucket(oidB, bkt.Bucket(oidB))
-			if err != nil {
-				return fmt.Errorf("error decoding order %x: %v", oidB, err)
-			}
-			if stamp := ord.Order.Prefix().ClientTime.Unix(); stamp < int64(archiveSizeLimit) {
+			if stamp := intCoder.Uint64(bkt.Bucket(oidB).Get(updateTimeKey)); stamp < archiveSizeLimit {
 				return fmt.Errorf("order stamp %d should have been pruned", stamp)
 			}
 			return nil


### PR DESCRIPTION
This is a refactor of #2975 meant as a stop-gap for the release branch. I will close #2975 in favor of a more comprehensive archiving solution to be worked out later.