### PR TITLE
client/dcr: Remove GetRawTransaction.

### DIFF
--- a/client/asset/dcr/simnet_test.go
+++ b/client/asset/dcr/simnet_test.go
@@ -460,11 +460,7 @@ func runTest(t *testing.T, splitTx bool) {
 		if err != nil || tx == nil {
 			t.Fatalf("GetTransaction: %v", err)
 		}
-		msgTx, err := msgTxFromHex(tx.Hex)
-		if err != nil {
-			t.Fatalf("msgTxFromHex: %v", err)
-		}
-		txData, err := msgTx.Bytes()
+		txData, err := tx.MsgTx.Bytes()
 		if err != nil {
 			t.Fatalf("msgTx.Bytes: %v", err)
 		}

--- a/client/asset/dcr/spv_test.go
+++ b/client/asset/dcr/spv_test.go
@@ -949,30 +949,6 @@ func TestMatchAnyScript(t *testing.T) {
 	}
 }
 
-func TestGetRawTransaction(t *testing.T) {
-	w, dcrw := tNewSpvWallet()
-
-	dcrw.txsByHash = []*wire.MsgTx{{}}
-
-	if _, err := w.GetRawTransaction(tCtx, nil); err != nil {
-		t.Fatalf("intitial GetRawTransaction error: %v", err)
-	}
-
-	// TxDetails NotExist error
-	dcrw.txsByHash = []*wire.MsgTx{}
-	if _, err := w.GetRawTransaction(tCtx, nil); !errors.Is(err, asset.CoinNotFoundError) {
-		t.Fatalf("expected asset.CoinNotFoundError, got %v", err)
-	}
-	dcrw.txsByHash = []*wire.MsgTx{{}}
-
-	// TxDetails generic error
-	dcrw.txsByHashErr = tErr
-	if _, err := w.GetRawTransaction(tCtx, nil); err == nil {
-		t.Fatalf("expected TxDetail generic error to propagate")
-	}
-	dcrw.txsByHashErr = nil
-}
-
 func TestBirthdayBlockHeight(t *testing.T) {
 	spvw, dcrw := tNewSpvWallet()
 

--- a/client/asset/dcr/wallet.go
+++ b/client/asset/dcr/wallet.go
@@ -139,9 +139,6 @@ type Wallet interface {
 	// tx with the provided hash. Returns asset.CoinNotFoundError if the tx is not
 	// found in the wallet.
 	GetTransaction(ctx context.Context, txHash *chainhash.Hash) (*WalletTransaction, error)
-	// GetRawTransaction returns details of the tx with the provided hash.
-	// Returns asset.CoinNotFoundError if the tx is not found.
-	GetRawTransaction(ctx context.Context, txHash *chainhash.Hash) (*wire.MsgTx, error)
 	// GetBestBlock returns the hash and height of the wallet's best block.
 	GetBestBlock(ctx context.Context) (*chainhash.Hash, int64, error)
 	// GetBlockHash returns the hash of the mainchain block at the specified height.
@@ -186,7 +183,7 @@ type WalletTransaction struct {
 	Confirmations int64
 	BlockHash     string
 	Details       []walletjson.GetTransactionDetailsResult
-	Hex           string
+	MsgTx         *wire.MsgTx
 }
 
 // tipNotifier can be implemented if the Wallet is able to provide a stream of


### PR DESCRIPTION
GetRawTransaction will error if txindex is not specified on the node, and until now GetTransaction has been good enough for client.

Until 12a90a7fbd we were only using `GetRawTransaction` for mempool redemptions, which it will not error for https://github.com/decred/dcrd/blob/7735cbb4e11b61636e88ad07e9ad8c1a30dd4047/internal/rpcserver/rpcserver.go#L2899


closes #2947