### PR TITLE
btc: remove unused field from fundrawtransaction result struct

### DIFF
--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -907,9 +907,8 @@ func (wc *rpcClient) estimateSendTxFee(tx *wire.MsgTx, feeRate uint64, subtract 
 	args = append(args, options)
 
 	var res struct {
-		TxBytes        dex.Bytes `json:"hex"`
-		Fees           float64   `json:"fee"`
-		ChangePosition uint32    `json:"changepos"`
+		TxBytes dex.Bytes `json:"hex"`
+		Fees    float64   `json:"fee"`
 	}
 	err = wc.call(methodFundRawTransaction, args, &res)
 	if err != nil {


### PR DESCRIPTION
The `ChangePosition` field is unused and sometimes negative apparently, causing an error when estimating send fees.