### PR TITLE
testing: use ubuntu 22 for github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ permissions:
 jobs:
   build-go:
     name: Go CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         go: ['1.22', '1.23']


### PR DESCRIPTION
`ubuntu-latest` was [bumped](https://github.com/actions/runner-images/pull/10687) from v22 to v24.