### PR TITLE
btc: estimatesmartfee in economical mode.

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -1879,7 +1879,7 @@ func (btc *baseWallet) feeRate(confTarget uint64) (uint64, error) {
 }
 
 func rpcFeeRate(ctx context.Context, rr RawRequester, confTarget uint64) (uint64, error) {
-	feeResult, err := estimateSmartFee(ctx, rr, confTarget, &btcjson.EstimateModeConservative)
+	feeResult, err := estimateSmartFee(ctx, rr, confTarget, &btcjson.EstimateModeEconomical)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Conservative mode is known to massively overestimate transaction fees, and while economical mode still has issues and still overestimates, its not nearly as extreme.

I'm new on this repo so not totally aware of the ramifications of this, but opening this PR for awareness/discussion. My understanding is that the server mandates fee rates for swap txns, so this change should only affect clients when calculating their redeem transactions (which are not as sensitive to timely mining)

References:
https://github.com/bitcoin/bitcoin/pull/30275
https://delvingbitcoin.org/t/bitcoind-policy-estimator-modes-analysis/964