### PR TITLE
webserver/site: refetch user info after updating a DEX server

### DIFF
--- a/client/webserver/site/src/js/dexsettings.ts
+++ b/client/webserver/site/src/js/dexsettings.ts
@@ -355,6 +355,10 @@ export default class DexSettingsPage extends BasePage {
     } else this.page.toggleAccountStatusBtn.textContent = intl.prep(intl.ID_DISABLE_ACCOUNT)
 
     this.accountDisabled = disable
+
+    // Refresh exchange information since we've just enabled/disabled the
+    // exchange.
+    await app().fetchUser()
     app().loadPage(`dexsettings/${host}`)
   }
 


### PR DESCRIPTION
This PR fixes an issue where a dex server's new status is unknown until the user refreshes the page to trigger fetching user info, usually after a server has been disabled or enabled.

Closes #3030 

I believe the message is sufficient, suggestions are welcomed.

<img width="1662" alt="Screenshot 2024-10-22 at 4 42 35 AM" src="https://github.com/user-attachments/assets/048cae82-da46-4557-8a76-19f883e71ebb">
