### PR TITLE
multi: fix error checks in core and dcr wallet

### DIFF
--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -6611,7 +6611,7 @@ func (dcr *ExchangeWallet) monitorBlocks(ctx context.Context) {
 		}
 
 		if walletBlock == nil {
-			dcr.handleTipChange(ctx, newTip.hash, newTip.height, nil)
+			dcr.handleTipChange(ctx, newTip.hash, newTip.height)
 			return
 		}
 
@@ -6639,7 +6639,7 @@ func (dcr *ExchangeWallet) monitorBlocks(ctx context.Context) {
 						"never reported: %s (%d). If you see this message repeatedly, it may indicate "+
 						"an issue with the wallet.", newTip.hash, newTip.height)
 				}
-				dcr.handleTipChange(ctx, newTip.hash, newTip.height, nil)
+				dcr.handleTipChange(ctx, newTip.hash, newTip.height)
 			}),
 		}
 	}
@@ -6666,7 +6666,7 @@ func (dcr *ExchangeWallet) monitorBlocks(ctx context.Context) {
 				}
 				queuedBlock = nil
 			}
-			dcr.handleTipChange(ctx, walletTip.hash, walletTip.height, nil)
+			dcr.handleTipChange(ctx, walletTip.hash, walletTip.height)
 		case <-ctx.Done():
 			return
 		}
@@ -6678,9 +6678,8 @@ func (dcr *ExchangeWallet) monitorBlocks(ctx context.Context) {
 	}
 }
 
-func (dcr *ExchangeWallet) handleTipChange(ctx context.Context, newTipHash *chainhash.Hash, newTipHeight int64, err error) {
-	if err != nil {
-		dcr.log.Error(err)
+func (dcr *ExchangeWallet) handleTipChange(ctx context.Context, newTipHash *chainhash.Hash, newTipHeight int64) {
+	if dcr.ctx.Err() != nil {
 		return
 	}
 


### PR DESCRIPTION
My linter picked up the incorrect error check in core, and I also found that `dcr.handleTipChange` always accepts an err arg that was checked, but all of the current sites provide a nil error, hence the need for this PR to fix these error checks.