### PR TITLE
ui: remove token contract address from ui to avoid confusion

### DIFF
--- a/client/webserver/site/src/css/wallets.scss
+++ b/client/webserver/site/src/css/wallets.scss
@@ -160,10 +160,6 @@
       width: 18px;
       height: 18px;
     }
-
-    #contractAddress {
-      opacity: 0.4;
-    }
   }
 
   .peers-table-icon {

--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -57,7 +57,6 @@
                 <img id="tokenParentLogo" class="ms-1">
                 <span id="tokenParentName"></span>
               </div>
-              <div id="contractAddress" class="fs14 mt-2"></div>
             </div>
 
             <div class="flex-stretch-column flex-md-row" id="walletDetails">

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1003,7 +1003,6 @@ export default class WalletsPage extends BasePage {
       const parentAsset = app().assets[token.parentID]
       page.tokenParentLogo.src = Doc.logoPath(parentAsset.symbol)
       page.tokenParentName.textContent = parentAsset.name
-      page.contractAddress.textContent = token.contractAddress
       Doc.show(page.tokenInfoBox)
     }
     if (wallet) {


### PR DESCRIPTION
I could have sworn there was an issue opened for this, but I can't find it now. For tokens, the token address was shown in the wallet dialog. A user could potentially think the displayed address was their own address, and cause mass destruction. This removes the token contract address from the UI.