### PR TITLE
binance: parse error responses

### DIFF
--- a/client/mm/libxc/binance.go
+++ b/client/mm/libxc/binance.go
@@ -1253,7 +1253,7 @@ func (bnc *binance) request(ctx context.Context, method, endpoint string, query,
 		Code int    `json:"code"`
 		Msg  string `json:"msg"`
 	}
-	if err := dexnet.Do(req, thing, dexnet.WithSizeLimit(1<<24), dexnet.WithErrorParsing(errPayload)); err != nil {
+	if err := dexnet.Do(req, thing, dexnet.WithSizeLimit(1<<24), dexnet.WithErrorParsing(&errPayload)); err != nil {
 		bnc.log.Errorf("request error from endpoint %q with query = %q, body = %q", endpoint, queryString, bodyString)
 		return fmt.Errorf("%w, bn code = %d, msg = %q", err, errPayload.Code, errPayload.Msg)
 	}

--- a/dex/dexnet/http_live_test.go
+++ b/dex/dexnet/http_live_test.go
@@ -1,0 +1,32 @@
+//go:build live
+
+package dexnet
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	uri := "https://dcrdata.decred.org/api/block/best"
+	var resp struct {
+		Height int64 `json:"height"`
+	}
+	var code int
+	if err := Get(ctx, uri, &resp, WithStatusFunc(func(c int) { code = c })); err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if resp.Height == 0 {
+		t.Fatal("Height not parsed")
+	}
+	if code != http.StatusOK {
+		t.Fatalf("expected code 200, got %d", code)
+	}
+	// Check size limit
+	if err := Get(ctx, uri, &resp, WithSizeLimit(1)); err == nil {
+		t.Fatal("Didn't get parse error for low size limit")
+	}
+}


### PR DESCRIPTION
Parse binance error response bodies for error code and message. Log query strings and request bodies when an error is encountered.

Replaces #2912