### PR TITLE
mm/core: Fix multi trade funding error

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -565,7 +565,7 @@ type Wallet interface {
 	// FundMultiOrder funds multiple orders at once. The return values will
 	// be in the same order as the passed orders. If less values are returned
 	// than the number of orders, then the orders at the end of the list were
-	// not about to be funded.
+	// not able to be funded.
 	FundMultiOrder(ord *MultiOrder, maxLock uint64) (coins []Coins, redeemScripts [][]dex.Bytes, fundingFees uint64, err error)
 	// MaxFundingFees returns the max fees that could be paid for funding a swap.
 	MaxFundingFees(numTrades uint32, feeRate uint64, options map[string]string) uint64

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -3630,11 +3630,14 @@ func (u *unifiedExchangeAdaptor) tradingLimitNotReached(epochNum uint64) bool {
 		if err == nil && !tradingLimitReached {
 			return
 		}
-
+		var unknownErr string
+		if err != nil {
+			unknownErr = err.Error()
+		}
 		u.updateEpochReport(&EpochReport{
 			PreOrderProblems: &BotProblems{
 				UserLimitTooLow: tradingLimitReached,
-				UnknownError:    err,
+				UnknownError:    unknownErr,
 			},
 			EpochNum: epochNum,
 		})
@@ -3707,6 +3710,10 @@ func (u *unifiedExchangeAdaptor) checkBotHealth(epochNum uint64) (healthy bool) 
 		if healthy {
 			return
 		}
+		var unknownErr string
+		if err != nil {
+			unknownErr = err.Error()
+		}
 		problems := &BotProblems{
 			NoWalletPeers: map[uint32]bool{
 				u.baseID:  baseAssetNoPeers,
@@ -3717,7 +3724,7 @@ func (u *unifiedExchangeAdaptor) checkBotHealth(epochNum uint64) (healthy bool) 
 				u.quoteID: quoteAssetNotSynced,
 			},
 			AccountSuspended: accountSuspended,
-			UnknownError:     err,
+			UnknownError:     unknownErr,
 		}
 		u.updateEpochReport(&EpochReport{
 			PreOrderProblems: problems,

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -264,7 +264,7 @@ type BotProblems struct {
 	// CausesSelfMatch is true if the order would cause a self match.
 	CausesSelfMatch bool `json:"causesSelfMatch"`
 	// UnknownError is set if an error occurred that was not one of the above.
-	UnknownError error `json:"unknownError"`
+	UnknownError string `json:"unknownError"`
 }
 
 // EpochReport contains a report of a bot's activity during an epoch.

--- a/client/mm/utils.go
+++ b/client/mm/utils.go
@@ -68,5 +68,5 @@ func updateBotProblemsBasedOnError(problems *BotProblems, err error) {
 		return
 	}
 
-	problems.UnknownError = err
+	problems.UnknownError = err.Error()
 }

--- a/client/webserver/site/src/js/mmutil.ts
+++ b/client/webserver/site/src/js/mmutil.ts
@@ -1352,6 +1352,10 @@ function botProblemMessages (problems: BotProblems | undefined, cexName: string,
     msgs.push(intl.prep(intl.ID_CAUSES_SELF_MATCH))
   }
 
+  if (problems.unknownError) {
+    msgs.push(problems.unknownError)
+  }
+
   return msgs
 }
 


### PR DESCRIPTION
When the wallet is not able to fund all the orders requested, it resulted in a panic in the mm code, because a nil MultiTradeResult was returned. This also fixes the UI to properly display unknown errors in the epoch report.