### PR TITLE
Fix webtls in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 client/webserver/site/node_modules/
+spec/
+docs/

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -44,10 +44,11 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
 FROM debian:buster-slim
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates
 WORKDIR /dex
-ENV HOME /dex
+ENV HOME=/dex
 RUN mkdir -p /dex/.dexc && chown 1000 /dex/.dexc
 USER 1000
 COPY --from=gobuilder /root/dex/client/cmd/bisonw/bisonw ./
 COPY --from=gobuilder /root/dex/client/cmd/bwctl/bwctl ./
+COPY ./client/entrypoint.sh ./
 EXPOSE 5758
-CMD [ "./bisonw", "--webaddr=0.0.0.0:5758" ]
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/client/Dockerfile.release
+++ b/client/Dockerfile.release
@@ -32,10 +32,11 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
 FROM debian:buster-slim
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates
 WORKDIR /dex
-ENV HOME /dex
+ENV HOME=/dex
 RUN mkdir -p /dex/.dexc && chown 1000 /dex/.dexc
 USER 1000
 COPY --from=gobuilder /root/dex/client/cmd/bisonw/bisonw ./
 COPY --from=gobuilder /root/dex/client/cmd/bwctl/bwctl ./
+COPY ./client/entrypoint.sh ./
 EXPOSE 5758
-CMD [ "./bisonw", "--webaddr=0.0.0.0:5758" ]
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/client/entrypoint.sh
+++ b/client/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Get the IP address of the primary network interface
+IP_ADDRESS=$(hostname -I | awk '{print $1}')
+
+CMD="./bisonw"
+if [ "$IP_ADDRESS" != "" ]; then
+    CMD="$CMD --webaddr $IP_ADDRESS:5758"
+fi
+
+exec $CMD


### PR DESCRIPTION
Obtain container IP address and set `--webaddr`, in order to allow `http` access to port `5758`.