### PR TITLE
libxc/binance: Fix polygon symbol conversion

### DIFF
--- a/client/mm/libxc/binance.go
+++ b/client/mm/libxc/binance.go
@@ -345,12 +345,12 @@ var dexToBinanceSymbol = map[string]string{
 var binanceToDexSymbol = make(map[string]string)
 
 // convertBnCoin converts a binance coin symbol to a dex symbol.
-func convertBnCoin(coin string, weth bool) string {
+func convertBnCoin(coin string) string {
 	symbol := strings.ToLower(coin)
 	if convertedSymbol, found := binanceToDexSymbol[strings.ToUpper(coin)]; found {
 		symbol = convertedSymbol
 	}
-	if !weth && symbol == "weth" {
+	if symbol == "weth" {
 		return "eth"
 	}
 	return symbol
@@ -359,12 +359,12 @@ func convertBnCoin(coin string, weth bool) string {
 // binanceCoinNetworkToDexSymbol takes the coin name and its network name as
 // returned by the binance API and returns the DEX symbol.
 func binanceCoinNetworkToDexSymbol(coin, network string) string {
-	symbol, netSymbol := convertBnCoin(coin, true), convertBnCoin(network, false)
-	if symbol == "weth" && netSymbol == "eth" {
-		return "eth"
-	}
+	symbol, netSymbol := convertBnCoin(coin), convertBnCoin(network)
 	if symbol == netSymbol {
 		return symbol
+	}
+	if symbol == "eth" {
+		symbol = "weth"
 	}
 	return symbol + "." + netSymbol
 }
@@ -2130,7 +2130,7 @@ func (bnc *binance) TradeStatus(ctx context.Context, tradeID string, baseID, quo
 }
 
 func getDEXAssetIDs(coin string, tokenIDs map[string][]uint32) []uint32 {
-	dexSymbol := convertBnCoin(coin, false)
+	dexSymbol := convertBnCoin(coin)
 
 	isRegistered := func(assetID uint32) bool {
 		_, err := asset.UnitInfo(assetID)

--- a/client/mm/libxc/binance_test.go
+++ b/client/mm/libxc/binance_test.go
@@ -5,6 +5,8 @@ package libxc
 
 import (
 	"testing"
+
+	_ "decred.org/dcrdex/client/asset/importall"
 )
 
 func TestSubscribeTradeUpdates(t *testing.T) {
@@ -44,6 +46,77 @@ func TestBinanceToDexSymbol(t *testing.T) {
 		dexSymbol := binanceCoinNetworkToDexSymbol(test[0], test[1])
 		if expected != dexSymbol {
 			t.Fatalf("expected %s but got %v", expected, dexSymbol)
+		}
+	}
+}
+
+func TestBncAssetCfg(t *testing.T) {
+	tests := map[uint32]*bncAssetConfig{
+		0: {
+			assetID:          0,
+			symbol:           "btc",
+			coin:             "BTC",
+			chain:            "BTC",
+			conversionFactor: 1e8,
+		},
+		2: {
+			assetID:          2,
+			symbol:           "ltc",
+			coin:             "LTC",
+			chain:            "LTC",
+			conversionFactor: 1e8,
+		},
+		3: {
+			assetID:          3,
+			symbol:           "doge",
+			coin:             "DOGE",
+			chain:            "DOGE",
+			conversionFactor: 1e8,
+		},
+		5: {
+			assetID:          5,
+			symbol:           "dash",
+			coin:             "DASH",
+			chain:            "DASH",
+			conversionFactor: 1e8,
+		},
+		60: {
+			assetID:          60,
+			symbol:           "eth",
+			coin:             "ETH",
+			chain:            "ETH",
+			conversionFactor: 1e9,
+		},
+		42: {
+			assetID:          42,
+			symbol:           "dcr",
+			coin:             "DCR",
+			chain:            "DCR",
+			conversionFactor: 1e8,
+		},
+		966001: {
+			assetID:          966001,
+			symbol:           "usdc.polygon",
+			coin:             "USDC",
+			chain:            "MATIC",
+			conversionFactor: 1e6,
+		},
+		966002: {
+			assetID:          966002,
+			symbol:           "weth.polygon",
+			coin:             "ETH",
+			chain:            "MATIC",
+			conversionFactor: 1e9,
+		},
+	}
+
+	for test, expected := range tests {
+		cfg, err := bncAssetCfg(test)
+		if err != nil {
+			t.Fatalf("error getting asset config: %v", err)
+		}
+		if *expected != *cfg {
+			t.Fatalf("expected %v but got %v", expected, cfg)
 		}
 	}
 }


### PR DESCRIPTION
Since the conversion from MATIC -> POL (#2957), the symbol conversion for polygon and polygon tokens was not working properly. This is fixed.