### PR TITLE
webserver,html: Fix USD Exchange Rate showing 'USD/<coin ticker>'

### DIFF
--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -181,7 +181,11 @@
                   <span class="grey demi">Exchange Rate</span>
                   <span>
                     <span id="feeStateXcRate" class="fs20"></span>
-                    <span class="fs17 grey">USD/<span data-ticker></span></span>
+                      <span class="fs17 grey">
+                        <span data-ticker></span>
+                        / USD
+                      </span>
+                    </span>
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
Fixes #3126

	Now showing '<coin ticker> / USD'