### PR TITLE
mm: Account for mult split buffer when making MultiTrade

### DIFF
--- a/client/mm/config.go
+++ b/client/mm/config.go
@@ -3,6 +3,7 @@ package mm
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 // MarketMakingConfig is the overall configuration of the market maker.
@@ -125,6 +126,23 @@ func (c *BotConfig) requiresPriceOracle() bool {
 
 func (c *BotConfig) requiresCEX() bool {
 	return c.SimpleArbConfig != nil || c.ArbMarketMakerConfig != nil
+}
+
+// multiSplitBuffer returns the additional buffer to add to the order size
+// when doing a multi-split. This only applies to the quote asset.
+func (c *BotConfig) multiSplitBuffer() float64 {
+	if c.QuoteWalletOptions == nil {
+		return 0
+	}
+	multiSplitBuffer, ok := c.QuoteWalletOptions["multisplitbuffer"]
+	if !ok {
+		return 0
+	}
+	multiSplitBufferFloat, err := strconv.ParseFloat(multiSplitBuffer, 64)
+	if err != nil {
+		return 0
+	}
+	return multiSplitBufferFloat
 }
 
 // maxPlacements returns the max amount of placements this bot will place on

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -1229,14 +1229,19 @@ func (u *unifiedExchangeAdaptor) multiTrade(
 
 	rateCausesSelfMatch := u.rateCausesSelfMatchFunc(sell)
 
+	multiSplitBuffer := u.botCfg().multiSplitBuffer()
+
 	fundingReq := func(rate, lots, counterTradeRate uint64) (dexReq map[uint32]uint64, cexReq uint64) {
 		qty := u.lotSize * lots
+		swapFees := fees.Swap * lots
 		if !sell {
 			qty = calc.BaseToQuote(rate, qty)
+			qty = uint64(math.Round(float64(qty) * (100 + multiSplitBuffer) / 100))
+			swapFees = uint64(math.Round(float64(swapFees) * (100 + multiSplitBuffer) / 100))
 		}
 		dexReq = make(map[uint32]uint64)
 		dexReq[fromID] += qty
-		dexReq[fromFeeID] += fees.Swap * lots
+		dexReq[fromFeeID] += swapFees
 		if u.isAccountLocker(fromID) {
 			dexReq[fromFeeID] += fees.Refund * lots
 		}


### PR DESCRIPTION
The market making code did not account for the multi split buffer when determining the orders to place. This caused the btc and dcr wallets to error when the bot had insufficient funds.

Closes #3130