### PR TITLE
client: eth, fix user action resolution handling

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -4683,7 +4683,7 @@ func (w *baseWallet) checkPendingTxs() {
 			// on it, cancel that request.
 			if pendingTx.actionRequested {
 				pendingTx.actionRequested = false
-				w.requestAction(asset.ActionResolved, pendingTx.ID, nil, pendingTx.TokenID)
+				w.resolveAction(pendingTx.ID, pendingTx.TokenID)
 			}
 		}
 	}
@@ -5044,8 +5044,8 @@ func (w *assetWallet) userActionRecoverNonces(actionB []byte) error {
 	return nil
 }
 
-// requestAction sends a ActionRequired or ActionResolved notification up the
-// chain of command. nonceMtx must be locked.
+// requestAction sends a ActionRequired notification up the chain of command.
+// nonceMtx must be locked.
 func (w *baseWallet) requestAction(actionID, uniqueID string, req *TransactionActionNote, tokenID *uint32) {
 	assetID := w.baseChainID
 	if tokenID != nil {
@@ -5056,6 +5056,20 @@ func (w *baseWallet) requestAction(actionID, uniqueID string, req *TransactionAc
 		return
 	}
 	aw.emit.ActionRequired(uniqueID, actionID, req)
+}
+
+// resolveAction sends a ActionResolved notification up the chain of command.
+// nonceMtx must be locked.
+func (w *baseWallet) resolveAction(uniqueID string, tokenID *uint32) {
+	assetID := w.baseChainID
+	if tokenID != nil {
+		assetID = *tokenID
+	}
+	aw := w.wallet(assetID)
+	if aw == nil { // sanity
+		return
+	}
+	aw.emit.ActionResolved(uniqueID)
 }
 
 // TakeAction satisfies asset.ActionTaker. This handles responses from the

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -1537,10 +1537,6 @@ type ActionRequiredNote struct {
 	ActionID string `json:"actionID"`
 }
 
-// ActionResolved is sent by wallets when action is no longer required for a
-// unique ID.
-const ActionResolved = "actionResolved"
-
 type ActionResolvedNote struct {
 	baseWalletNotification
 	UniqueID string `json:"uniqueID"`


### PR DESCRIPTION
I've noticed UI breaks in the following scenario:
- Ethereum/Polygon transaction gets stuck 
- user action is requested in UI suggesting to bump transaction fee
- I didn't do anything about this user action (eventually clicked "keep waiting") but transaction got mined on its own
- and then UI broke with the following error in console:

<img width="550" alt="image" src="https://github.com/user-attachments/assets/418ccd46-bef1-4741-aab9-e24a283d7b9c" />

looking through the relevant code it seems we are **requesting** action while we should **resolve** action instead, which is what I've done in this PR