### PR TITLE
wsconn: Ignore some connect errors.

### DIFF
--- a/client/comms/wsconn.go
+++ b/client/comms/wsconn.go
@@ -564,7 +564,7 @@ func (conn *wsConn) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		close(conn.readCh) // signal to MessageSource receivers that the wsConn is dead
 	}()
 
-	return &conn.wg, err
+	return &conn.wg, nil
 }
 
 // Stop can be used to close the connection and all of the goroutines started by


### PR DESCRIPTION
All of the surrounding code suggests that we want to continue on error with initial connect unless reconnect is off. We are also already logging the error. So, do not return error for some connect failures.

closes #3180