### PR TITLE
refactor: use a more straightforward return value

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -624,7 +624,7 @@ func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
 	if err != nil {
 		return "<invalid>", err
 	}
-	return fmt.Sprintf("%v:%d", txid, vout), err
+	return fmt.Sprintf("%v:%d", txid, vout), nil
 }
 
 // Info returns basic information about the wallet and asset.

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -361,7 +361,7 @@ func (w *spvWallet) getChainHeight() (int32, error) {
 	if err != nil {
 		return -1, err
 	}
-	return blk.Height, err
+	return blk.Height, nil
 }
 
 func (w *spvWallet) peerCount() (uint32, error) {


### PR DESCRIPTION
 use a more straightforward return value