### PR TITLE
lexi: add KV argument type

### DIFF
--- a/dex/lexi/db_test.go
+++ b/dex/lexi/db_test.go
@@ -2,7 +2,6 @@ package lexi
 
 import (
 	"bytes"
-	"encoding"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,11 +65,11 @@ func (v *tValue) MarshalBinary() ([]byte, error) {
 	return v.v, nil
 }
 
-func valueIndex(k, v encoding.BinaryMarshaler) ([]byte, error) {
+func valueIndex(k, v KV) ([]byte, error) {
 	return v.(*tValue).idx, nil
 }
 
-func valueKey(k, v encoding.BinaryMarshaler) ([]byte, error) {
+func valueKey(k, v KV) ([]byte, error) {
 	return v.(*tValue).k, nil
 }
 
@@ -109,7 +108,7 @@ func TestIndex(t *testing.T) {
 		indexKey = append(prefix, indexKey...)
 		v := &tValue{k: indexKey, v: encode.RandomBytes(10), idx: []byte{byte(i)}}
 		vs[i] = v
-		if err := tbl.Set(B(k), v); err != nil {
+		if err := tbl.Set(k, v); err != nil {
 			t.Fatalf("Error setting table entry: %v", err)
 		}
 	}

--- a/dex/lexi/table.go
+++ b/dex/lexi/table.go
@@ -37,8 +37,8 @@ func (db *DB) Table(name string) (*Table, error) {
 }
 
 // GetRaw retrieves a value from the Table as raw bytes.
-func (t *Table) GetRaw(k encoding.BinaryMarshaler) (b []byte, err error) {
-	kB, err := k.MarshalBinary()
+func (t *Table) GetRaw(k KV) (b []byte, err error) {
+	kB, err := parseKV(k)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling key: %w", err)
 	}
@@ -58,7 +58,7 @@ func (t *Table) GetRaw(k encoding.BinaryMarshaler) (b []byte, err error) {
 }
 
 // Get retrieves a value from the Table.
-func (t *Table) Get(k encoding.BinaryMarshaler, thing encoding.BinaryUnmarshaler) error {
+func (t *Table) Get(k KV, thing encoding.BinaryUnmarshaler) error {
 	b, err := t.GetRaw(k)
 	if err != nil {
 		return err
@@ -114,8 +114,8 @@ func (t *Table) UseDefaultSetOptions(setOpts ...SetOption) {
 }
 
 // Set inserts a new value for the key, and creates index entries.
-func (t *Table) Set(k, v encoding.BinaryMarshaler, setOpts ...SetOption) error {
-	kB, err := k.MarshalBinary()
+func (t *Table) Set(k, v KV, setOpts ...SetOption) error {
+	kB, err := parseKV(k)
 	if err != nil {
 		return fmt.Errorf("error marshaling key: %w", err)
 	}
@@ -124,7 +124,7 @@ func (t *Table) Set(k, v encoding.BinaryMarshaler, setOpts ...SetOption) error {
 	if len(kB) == 0 {
 		return errors.New("no zero-length keys allowed")
 	}
-	vB, err := v.MarshalBinary()
+	vB, err := parseKV(v)
 	if err != nil {
 		return fmt.Errorf("error marshaling value: %w", err)
 	}
@@ -210,6 +210,6 @@ func (t *Table) UseDefaultIterationOptions(optss ...IterationOption) {
 }
 
 // Iterate iterates the table.
-func (t *Table) Iterate(prefixI IndexBucket, f func(*Iter) error, iterOpts ...IterationOption) error {
+func (t *Table) Iterate(prefixI KV, f func(*Iter) error, iterOpts ...IterationOption) error {
 	return t.iterate(t.prefix, t, t.defaultIterationOptions, false, prefixI, f, iterOpts...)
 }

--- a/tatanka/client/mesh/mesh.go
+++ b/tatanka/client/mesh/mesh.go
@@ -214,7 +214,7 @@ func (m *Mesh) SubscribeToFiatRates() error {
 // PostBond stores the bond in the database and sends it to the mesh.
 func (m *Mesh) PostBond(bond *tanka.Bond) error {
 	k := bond.ID()
-	if err := m.bondTable.Set(lexi.B(k[:]), lexi.JSON(bond)); err != nil {
+	if err := m.bondTable.Set(k[:], lexi.JSON(bond)); err != nil {
 		return fmt.Errorf("error storing bond in DB: %w", err)
 	}
 	req := mj.MustRequest(mj.RoutePostBond, []*tanka.Bond{bond})

--- a/tatanka/db/bonds.go
+++ b/tatanka/db/bonds.go
@@ -50,7 +50,7 @@ func (bond *dbBond) UnmarshalBinary(b []byte) error {
 }
 
 func (d *DB) StoreBond(newBond *tanka.Bond) error {
-	return d.bonds.Set(lexi.B(newBond.CoinID), &dbBond{newBond}, lexi.WithReplace())
+	return d.bonds.Set(newBond.CoinID[:], &dbBond{newBond}, lexi.WithReplace())
 }
 
 func (d *DB) GetBonds(peerID tanka.PeerID) ([]*tanka.Bond, error) {

--- a/tatanka/db/reputation.go
+++ b/tatanka/db/reputation.go
@@ -30,7 +30,7 @@ func (d *DB) SetScore(scored, scorer tanka.PeerID, score int8, stamp time.Time) 
 		score:  score,
 		stamp:  stamp,
 	}
-	return d.scores.Set(lexi.B(k), s, lexi.WithReplace())
+	return d.scores.Set(k, s, lexi.WithReplace())
 }
 
 func (d *DB) Reputation(scored tanka.PeerID) (*tanka.Reputation, error) {


### PR DESCRIPTION
This adds a new type `lexi.KV` to be used for key and value arguments to lexi. `KV` is just defined as an `interface{}`, but must be one of a handful of types parseable by `parseKV`. This extends and replaces the `IndexBucket` that was used for iteration prefixes. 

This approach is sloppier, and relies on the caller to ensure their arguments are of an appropriate type, but negates the necessity of `lexi.B` for conversion of `[]byte` everywhere, and really just makes using lexi easier to use, which I'm all for. A argument-type mistake reaching production would be a panic-worthy event anyway, imho.