### PR TITLE
mm,client,firo: Fix Electrum Firo mm issues.

### DIFF
--- a/client/asset/firo/firo.go
+++ b/client/asset/firo/firo.go
@@ -76,12 +76,14 @@ var (
 				Description:       "Connect to firod",
 				DefaultConfigPath: dexbtc.SystemConfigPath("firo"),
 				ConfigOpts:        configOpts,
+				MultiFundingOpts:  btc.MultiFundingOpts,
 			},
 			{
-				Type:        walletTypeElectrum,
-				Tab:         "Electrum-Firo (external)",
-				Description: "Use an external Electrum-Firo Wallet",
-				ConfigOpts:  append(btc.ElectrumConfigOpts, btc.CommonConfigOpts("FIRO", true)...),
+				Type:             walletTypeElectrum,
+				Tab:              "Electrum-Firo (external)",
+				Description:      "Use an external Electrum-Firo Wallet",
+				ConfigOpts:       append(btc.ElectrumConfigOpts, btc.CommonConfigOpts("FIRO", true)...),
+				MultiFundingOpts: btc.MultiFundingOpts,
 			},
 		},
 	}


### PR DESCRIPTION
Firo Electrum is a dex "external" wallet. While testing dex `basic-MM` for a set of Simnet harnesses and electrum firo wallets on DCR-FIRO it was noticed that Firo placements were not able to be funded. This was the tested on `bison.exchange` **mainnet** and the same was observed.

![image](https://github.com/user-attachments/assets/fa3aa2ef-4d6d-4846-a3bd-911a0e447d21)

```sh
2025-02-26 09:06:15.137 [DBG] CORE[firo]: Attempting to fund a multi-order for firo, maxFeeRate = 20
2025-02-26 09:06:15.152 [INF] CORE: FundMultiOrder only funded 0 orders out of 3 (options = map[])
```