### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/client/asset/eth/multirpc_test_util.go
+++ b/client/asset/eth/multirpc_test_util.go
@@ -178,8 +178,7 @@ func (m *MRPCTest) TestSimnetMultiRPCClient(t *testing.T, wsPort, httpPort strin
 
 func (m *MRPCTest) TestMonitorNet(t *testing.T, net dex.Network) {
 	seed, providers := m.readProviderFile(t, net)
-	dir, _ := os.MkdirTemp("", "")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cl, err := m.rpcClient(dir, seed, providers, net, true)
 	if err != nil {
@@ -202,8 +201,7 @@ func (m *MRPCTest) TestRPC(t *testing.T, net dex.Network) {
 	if endpoint == "" {
 		t.Fatalf("specify a provider in the PROVIDER environmental variable")
 	}
-	dir, _ := os.MkdirTemp("", "")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	cl, err := m.rpcClient(dir, encode.RandomBytes(32), []string{endpoint}, net, true)
 	if err != nil {
 		t.Fatal(err)
@@ -233,8 +231,7 @@ func (m *MRPCTest) TestFreeServers(t *testing.T, freeServers []string, net dex.N
 		t.Fatalf("compatDataLookup error: %v", err)
 	}
 	runTest := func(endpoint string) error {
-		dir, _ := os.MkdirTemp("", "")
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 		cl, err := m.rpcClient(dir, encode.RandomBytes(32), []string{endpoint}, net, true)
 		if err != nil {
 			return fmt.Errorf("tRPCClient error: %v", err)
@@ -333,8 +330,7 @@ func (m *MRPCTest) TestReceiptsHaveEffectiveGasPrice(t *testing.T) {
 
 func (m *MRPCTest) withClient(t *testing.T, net dex.Network, f func(context.Context, *multiRPCClient)) {
 	seed, providers := m.readProviderFile(t, net)
-	dir, _ := os.MkdirTemp("", "")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cl, err := m.rpcClient(dir, seed, providers, net, false)
 	if err != nil {

--- a/client/asset/zec/regnet_test.go
+++ b/client/asset/zec/regnet_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
@@ -164,8 +163,7 @@ func testDeserializeBlocks(t *testing.T, port string, upgradeHeights ...int64) {
 func TestMultiSplit(t *testing.T) {
 	log := dex.StdOutLogger("T", dex.LevelTrace)
 	c := make(chan asset.WalletNotification, 16)
-	tmpDir, _ := os.MkdirTemp("", "")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	walletCfg := &asset.WalletConfig{
 		Type: walletTypeRPC,
 		Settings: map[string]string{

--- a/client/tor/tor_live_test.go
+++ b/client/tor/tor_live_test.go
@@ -5,15 +5,13 @@ package tor
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"decred.org/dcrdex/dex"
 )
 
 func TestConnect(t *testing.T) {
-	dataDir, _ := os.MkdirTemp("", "")
-	defer os.RemoveAll(dataDir)
+	dataDir := t.TempDir()
 
 	log := dex.StdOutLogger("T", dex.LevelDebug)
 	relay, err := New(dataDir, log)

--- a/dex/lexi/db_test.go
+++ b/dex/lexi/db_test.go
@@ -2,7 +2,6 @@ package lexi
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,10 +11,7 @@ import (
 )
 
 func newTestDB(t *testing.T) (*DB, func()) {
-	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("error making temp dir: %v", err)
-	}
+	tmpDir := t.TempDir()
 	db, err := New(&Config{
 		Path: filepath.Join(tmpDir, "test.db"),
 		Log:  dex.StdOutLogger("T", dex.LevelInfo),
@@ -23,7 +19,7 @@ func newTestDB(t *testing.T) (*DB, func()) {
 	if err != nil {
 		t.Fatalf("error constructing db: %v", err)
 	}
-	return db, func() { os.RemoveAll(tmpDir) }
+	return db, func() {}
 }
 
 func TestPrefixes(t *testing.T) {

--- a/server/noderelay/noderelay_test.go
+++ b/server/noderelay/noderelay_test.go
@@ -29,11 +29,7 @@ func TestNexus(t *testing.T) {
 		t.Fatalf("error splitting host and port from address %q", addr)
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("Error making temp dir: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	relayID := "0xabcanything_you-want"
 


### PR DESCRIPTION
`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.  More detail about TempDir  https://pkg.go.dev/testing#B.TempDir