### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -519,10 +519,7 @@ type TokenWallet struct {
 func (w *assetWallet) perTxGasLimit(feeRateGwei uint64) uint64 {
 	blockGasLimit := w.tip().GasLimit
 	maxFeeBasedGasLimit := w.maxTxFeeGwei / feeRateGwei
-	if maxFeeBasedGasLimit < blockGasLimit {
-		return maxFeeBasedGasLimit
-	}
-	return blockGasLimit
+	return min(maxFeeBasedGasLimit, blockGasLimit)
 }
 
 // maxSwapsOrRedeems calculates the maximum number of swaps or redemptions that

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex"
-	"decred.org/dcrdex/dex/utils"
 	dcrwalletjson "decred.org/dcrwallet/v4/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
@@ -611,7 +610,7 @@ func (ss *SyncStatus) BlockProgress() float32 {
 	}
 	prog := float32(ss.Blocks-ss.StartingBlocks) / float32(ss.TargetHeight-ss.StartingBlocks)
 	if ss.Transactions == nil { // If the asset doesn't support tx sync status, max unsynced is 0.999
-		return utils.Min(prog, 0.999)
+		return min(prog, 0.999)
 	}
 	return prog
 }

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -2928,8 +2928,8 @@ func (u *unifiedExchangeAdaptor) optimizeTransfers(dist *distribution, dexSellLo
 	// matchability is the number of lots that can be matched with a specified
 	// asset distribution.
 	matchability := func(dexBaseLots, dexQuoteLots, cexBaseLots, cexQuoteLots uint64) uint64 {
-		sells := utils.Min(dexBaseLots, cexQuoteLots, maxSellLots)
-		buys := utils.Min(dexQuoteLots, cexBaseLots, maxBuyLots)
+		sells := min(dexBaseLots, cexQuoteLots, maxSellLots)
+		buys := min(dexQuoteLots, cexBaseLots, maxBuyLots)
 		return buys + sells
 	}
 
@@ -2955,10 +2955,10 @@ func (u *unifiedExchangeAdaptor) optimizeTransfers(dist *distribution, dexSellLo
 	}
 
 	baseSplit := func(dexTarget, cexTarget uint64) (dexLots, cexLots, extra uint64) {
-		return targetedSplit(baseAvail, utils.Min(dexTarget, maxSellLots), utils.Min(cexTarget, maxBuyLots), perLot.dexBase, perLot.cexBase)
+		return targetedSplit(baseAvail, min(dexTarget, maxSellLots), min(cexTarget, maxBuyLots), perLot.dexBase, perLot.cexBase)
 	}
 	quoteSplit := func(dexTarget, cexTarget uint64) (dexLots, cexLots, extra uint64) {
-		return targetedSplit(quoteAvail, utils.Min(dexTarget, maxBuyLots), utils.Min(cexTarget, maxSellLots), perLot.dexQuote, perLot.cexQuote)
+		return targetedSplit(quoteAvail, min(dexTarget, maxBuyLots), min(cexTarget, maxSellLots), perLot.dexQuote, perLot.cexQuote)
 	}
 
 	// We'll keep track of any distributions that have a matchability score
@@ -3048,7 +3048,7 @@ func (u *unifiedExchangeAdaptor) optimizeTransfers(dist *distribution, dexSellLo
 			baseWithdraw:  baseWithdraw,
 			quoteDeposit:  quoteDeposit,
 			quoteWithdraw: quoteWithdraw,
-			spread:        utils.Min(dexBaseLots, dexQuoteLots, cexBaseLots, cexQuoteLots),
+			spread:        min(dexBaseLots, dexQuoteLots, cexBaseLots, cexQuoteLots),
 		})
 	}
 

--- a/client/mm/exchange_adaptor_test.go
+++ b/client/mm/exchange_adaptor_test.go
@@ -20,7 +20,6 @@ import (
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/dex/order"
-	"decred.org/dcrdex/dex/utils"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -622,7 +621,7 @@ func testDistribution(t *testing.T, baseID, quoteID uint32) {
 			t.Fatalf("Error getting lot costs: %v", err)
 		}
 		a.autoRebalanceCfg.MinBaseTransfer = lotSize
-		a.autoRebalanceCfg.MinQuoteTransfer = utils.Min(perLot.cexQuote, perLot.dexQuote)
+		a.autoRebalanceCfg.MinQuoteTransfer = min(perLot.cexQuote, perLot.dexQuote)
 	}
 
 	checkDistribution := func(baseDeposit, baseWithdraw, quoteDeposit, quoteWithdraw uint64) {

--- a/client/mm/mm_basic.go
+++ b/client/mm/mm_basic.go
@@ -163,9 +163,9 @@ func updateLotSize(placements []*OrderPlacement, originalLotSize, newLotSize uin
 	newPlacements := make([]*OrderPlacement, 0, len(placements))
 	for _, p := range placements {
 		lots := uint64(math.Round((float64(p.Lots) * float64(originalLotSize)) / float64(newLotSize)))
-		lots = utils.Max(lots, 1)
+		lots = max(lots, 1)
 		maxLots := qtyCounter / newLotSize
-		lots = utils.Min(lots, maxLots)
+		lots = min(lots, maxLots)
 		if lots == 0 {
 			continue
 		}

--- a/dex/testing/loadbot/mantle.go
+++ b/dex/testing/loadbot/mantle.go
@@ -705,17 +705,6 @@ func truncate(v, mod int64) uint64 {
 	return t
 }
 
-// clamp returns the closest value to v within the bounds of [min, max].
-func clamp(v, min, max int) int {
-	if v > max {
-		return max
-	}
-	if v < min {
-		return min
-	}
-	return v
-}
-
 const walletNameLength = 4
 
 var chars = []byte("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")

--- a/dex/testing/loadbot/sidestacker.go
+++ b/dex/testing/loadbot/sidestacker.go
@@ -17,6 +17,7 @@ import (
 	"decred.org/dcrdex/dex/calc"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/dex/order"
+	"decred.org/dcrdex/dex/utils"
 )
 
 const stackerSpread = 50.0
@@ -208,7 +209,7 @@ func (s *sideStacker) stack(m *Mantle, currentEpoch uint64) {
 		numNewStanding = s.numStanding - activeSells
 		neg = 1
 	}
-	numNewStanding = clamp(numNewStanding, 0, s.ordsPerEpoch)
+	numNewStanding = utils.Clamp(numNewStanding, 0, s.ordsPerEpoch)
 	numMatchers := s.ordsPerEpoch - numNewStanding
 	s.log.Infof("Seller = %t placing %d standers and %d matchers. Currently %d active orders",
 		s.seller, numNewStanding, numMatchers, activeOrders)

--- a/dex/testing/loadbot/sniper.go
+++ b/dex/testing/loadbot/sniper.go
@@ -95,9 +95,9 @@ func (s *sniper) snipe(m *Mantle) {
 	}
 
 	maxOrders := 1 + rand.Intn(s.maxOrdsPerEpoch)
-	targets := book.Sells[:clamp(maxOrders, 0, len(book.Sells))]
+	targets := book.Sells[:min(maxOrders, len(book.Sells))]
 	if sell {
-		targets = book.Buys[:clamp(maxOrders, 0, len(book.Buys))]
+		targets = book.Buys[:min(maxOrders, len(book.Buys))]
 	}
 	rem := maxQty
 

--- a/dex/txfee/feefetcher.go
+++ b/dex/txfee/feefetcher.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex"
-	"decred.org/dcrdex/dex/utils"
 )
 
 // FeeFetchFunc is a function that fetches a fee rate. If an error is
@@ -113,7 +112,7 @@ func prioritizedFeeRate(sources [][]*feeFetchSource) uint64 {
 			weightedRate += w * float64(src.rate)
 		}
 		if weightedRate != 0 {
-			return utils.Max(1, uint64(math.Round(weightedRate/weight)))
+			return max(1, uint64(math.Round(weightedRate/weight)))
 		}
 	}
 	return 0
@@ -161,7 +160,7 @@ func (f *FeeFetcher) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		r, errDelay, err := src.F(ctx)
 		if err != nil {
 			src.log.Meter("fetch-error", time.Minute*30).Errorf("Fetch error: %v", err)
-			src.failUntil = time.Now().Add(utils.Max(minFeeFetchErrorDelay, errDelay))
+			src.failUntil = time.Now().Add(max(minFeeFetchErrorDelay, errDelay))
 			return false
 		}
 		if r == 0 {
@@ -202,7 +201,7 @@ func (f *FeeFetcher) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 				f.log.Meter("all-failed", time.Minute*10).Error("All sources failed")
 				timeout = time.NewTimer(feeFetchDefaultTick)
 			} else {
-				timeout = time.NewTimer(utils.Max(0, delay))
+				timeout = time.NewTimer(max(0, delay))
 			}
 			select {
 			case <-timeout.C:

--- a/dex/utils/generics.go
+++ b/dex/utils/generics.go
@@ -50,31 +50,6 @@ func SafeSub[I constraints.Unsigned](a I, b I) I {
 	return a - b
 }
 
-func Min[I constraints.Ordered](m I, ns ...I) I {
-	min := m
-	for _, n := range ns {
-		if n < min {
-			min = n
-		}
-	}
-	return min
-}
-
-func Max[I constraints.Ordered](m I, ns ...I) I {
-	max := m
-	for _, n := range ns {
-		if n > max {
-			max = n
-		}
-	}
-	return max
-}
-
-func Clamp[I constraints.Ordered](v I, min I, max I) I {
-	if v < min {
-		v = min
-	} else if v > max {
-		v = max
-	}
-	return v
+func Clamp[I constraints.Ordered](v I, minVal I, maxVal I) I {
+	return max(min(v, maxVal), minVal)
 }


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.