### PR TITLE
tatanka: Update orderbook for push data.

### DIFF
--- a/tatanka/client/mesh/mesh.go
+++ b/tatanka/client/mesh/mesh.go
@@ -259,7 +259,7 @@ func (m *Mesh) SubscribeMarket(baseID, quoteID uint32) error {
 
 	m.markets[mktName] = &market{
 		log:  m.log.SubLogger(mktName),
-		ords: make(map[tanka.ID32]*order),
+		ords: make(map[tanka.ID40]*order),
 	}
 	return nil
 }

--- a/tatanka/client/mesh/trade.go
+++ b/tatanka/client/mesh/trade.go
@@ -14,7 +14,7 @@ import (
 
 type order struct {
 	*tanka.Order
-	oid      tanka.ID32
+	oid      tanka.ID40
 	proposed map[tanka.ID32]*tanka.Match
 	accepted map[tanka.ID32]*tanka.Match
 }
@@ -23,7 +23,7 @@ type market struct {
 	log dex.Logger
 
 	ordsMtx sync.RWMutex
-	ords    map[tanka.ID32]*order
+	ords    map[tanka.ID40]*order
 }
 
 func (m *market) addOrder(ord *tanka.Order) {

--- a/tatanka/client/orderbook/orderbook_test.go
+++ b/tatanka/client/orderbook/orderbook_test.go
@@ -8,111 +8,75 @@ import (
 	"decred.org/dcrdex/tatanka/tanka"
 )
 
-func testOrders() []*tanka.OrderUpdate {
-	mustParse := func(s string) time.Time {
-		t, err := time.Parse(time.RFC1123, s)
-		if err != nil {
-			panic(err)
-		}
-		return t
+func mustParseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC1123, s)
+	if err != nil {
+		panic(err)
 	}
+	return t
+}
 
+func testOrders() []*tanka.Order {
 	var peer tanka.PeerID
 	copy(peer[:], encode.RandomBytes(32))
 	baseID, quoteID := uint32(0), uint32(42)
-	lowbuy := &tanka.OrderUpdate{
-		Sig: encode.RandomBytes(32),
-		Order: &tanka.Order{
-			From:    peer,
-			BaseID:  baseID,
-			QuoteID: quoteID,
-			Sell:    false,
-			Qty:     1000,
-			Rate:    123,
-			LotSize: 3,
-			Nonce:   0,
-			Stamp:   mustParse("Sun, 12 Dec 2024 12:23:00 UTC"),
-		},
-		Expiration: mustParse("Sun, 12 Jan 2025 12:23:00 UTC"),
-		Settled:    500,
+	lowbuy := &tanka.Order{
+		From:    peer,
+		BaseID:  baseID,
+		QuoteID: quoteID,
+		Sell:    false,
+		Qty:     1000,
+		Rate:    123,
+		LotSize: 3,
+		Nonce:   0,
+		Stamp:   mustParseTime("Sun, 12 Dec 2024 12:23:00 UTC"),
 	}
-	highbuy := &tanka.OrderUpdate{
-		Sig: encode.RandomBytes(32),
-		Order: &tanka.Order{
-			From:    peer,
-			BaseID:  baseID,
-			QuoteID: quoteID,
-			Sell:    false,
-			Qty:     1000,
-			Rate:    1234,
-			LotSize: 2,
-			Nonce:   1,
-			Stamp:   mustParse("Sun, 12 Dec 2024 12:23:00 UTC"),
-		},
-		Expiration: mustParse("Sun, 12 Jan 2025 12:23:00 UTC"),
-		Settled:    500,
+	highbuy := &tanka.Order{
+		From:    peer,
+		BaseID:  baseID,
+		QuoteID: quoteID,
+		Sell:    false,
+		Qty:     1000,
+		Rate:    1234,
+		LotSize: 2,
+		Nonce:   1,
+		Stamp:   mustParseTime("Sun, 12 Dec 2024 12:23:00 UTC"),
 	}
-	lowsell := &tanka.OrderUpdate{
-		Sig: encode.RandomBytes(32),
-		Order: &tanka.Order{
-			From:    peer,
-			BaseID:  baseID,
-			QuoteID: quoteID,
-			Sell:    true,
-			Qty:     1000,
-			Rate:    12345,
-			LotSize: 2,
-			Nonce:   2,
-			Stamp:   mustParse("Sun, 12 Dec 2024 12:23:00 UTC"),
-		},
-		Expiration: mustParse("Sun, 12 Jan 2025 12:23:00 UTC"),
-		Settled:    500,
+	lowsell := &tanka.Order{
+		From:    peer,
+		BaseID:  baseID,
+		QuoteID: quoteID,
+		Sell:    true,
+		Qty:     1000,
+		Rate:    12345,
+		LotSize: 2,
+		Nonce:   2,
+		Stamp:   mustParseTime("Sun, 12 Dec 2024 12:23:00 UTC"),
 	}
-	highsell := &tanka.OrderUpdate{
-		Sig: encode.RandomBytes(32),
-		Order: &tanka.Order{
-			From:    peer,
-			BaseID:  baseID,
-			QuoteID: quoteID,
-			Sell:    true,
-			Qty:     1000,
-			Rate:    123456,
-			LotSize: 4,
-			Nonce:   3,
-			Stamp:   mustParse("Sun, 12 Dec 2024 12:23:00 UTC"),
-		},
-		Expiration: mustParse("Sun, 12 Jan 2025 12:23:00 UTC"),
-		Settled:    500,
+	highsell := &tanka.Order{
+		From:    peer,
+		BaseID:  baseID,
+		QuoteID: quoteID,
+		Sell:    true,
+		Qty:     1000,
+		Rate:    123456,
+		LotSize: 4,
+		Nonce:   3,
+		Stamp:   mustParseTime("Sun, 12 Dec 2024 12:23:00 UTC"),
 	}
-	return []*tanka.OrderUpdate{lowbuy, highbuy, lowsell, highsell}
-}
-
-func TestOrderIDs(t *testing.T) {
-	ob := NewOrderBook()
-	for _, o := range testOrders() {
-		if err := ob.AddUpdate(o); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	ous := ob.OrderIDs()
-	if len(ous) != 4 {
-		t.Fatalf("wanted 4 but got %d orders", len(ous))
-	}
+	return []*tanka.Order{lowbuy, highbuy, lowsell, highsell}
 }
 
 func TestOrders(t *testing.T) {
 	ob := NewOrderBook()
-	var oids [][32]byte
+	var oids []tanka.ID40
 	for _, o := range testOrders() {
-		if err := ob.AddUpdate(o); err != nil {
-			t.Fatal(err)
-		}
+		ob.Add(o)
 		oids = append(oids, o.ID())
 	}
-	ous := ob.Orders(oids)
-	if len(ous) != 4 {
-		t.Fatalf("wanted 4 but got %d orders", len(oids))
+	ords := ob.Orders(oids)
+	if len(ords) != 4 {
+		t.Fatalf("wanted 4 but got %d orders", len(ords))
 	}
 }
 
@@ -120,9 +84,7 @@ func TestFindOrders(t *testing.T) {
 	ob := NewOrderBook()
 	tOrds := testOrders()
 	for _, o := range tOrds {
-		if err := ob.AddUpdate(o); err != nil {
-			t.Fatal(err)
-		}
+		ob.Add(o)
 	}
 	yes, no := true, false
 
@@ -153,8 +115,8 @@ func TestFindOrders(t *testing.T) {
 	}, {
 		name: "lot size over 2",
 		filter: &OrderFilter{
-			Check: func(ou *tanka.OrderUpdate) (ok, done bool) {
-				return ou.LotSize > 2, false
+			Check: func(o *tanka.Order) (ok, done bool) {
+				return o.LotSize > 2, false
 			},
 		},
 		wantOrderLen: 2,
@@ -163,8 +125,8 @@ func TestFindOrders(t *testing.T) {
 		name: "lot size over 2 and sell",
 		filter: &OrderFilter{
 			IsSell: &yes,
-			Check: func(ou *tanka.OrderUpdate) (ok, done bool) {
-				return ou.LotSize > 2, false
+			Check: func(o *tanka.Order) (ok, done bool) {
+				return o.LotSize > 2, false
 			},
 		},
 		wantOrderLen: 1,
@@ -173,9 +135,9 @@ func TestFindOrders(t *testing.T) {
 		name: "buy done after one",
 		filter: &OrderFilter{
 			IsSell: &no,
-			Check: func() func(*tanka.OrderUpdate) (ok, done bool) {
+			Check: func() func(*tanka.Order) (ok, done bool) {
 				var i int
-				return func(ou *tanka.OrderUpdate) (ok, done bool) {
+				return func(*tanka.Order) (ok, done bool) {
 					defer func() { i++ }()
 					return true, i == 1
 				}
@@ -188,12 +150,12 @@ func TestFindOrders(t *testing.T) {
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ous := ob.FindOrders(test.filter)
-			if len(ous) != test.wantOrderLen {
-				t.Fatalf("wanted %d but got %d orders", test.wantOrderLen, len(ous))
+			ords := ob.FindOrders(test.filter)
+			if len(ords) != test.wantOrderLen {
+				t.Fatalf("wanted %d but got %d orders", test.wantOrderLen, len(ords))
 			}
 			for i, idx := range test.wantOrderIdx {
-				if tOrds[idx].ID() != ous[i].ID() {
+				if tOrds[idx].ID() != ords[i].ID() {
 					t.Fatalf("returned order at idx %d not equal to test order at %d", idx, i)
 				}
 			}
@@ -201,13 +163,64 @@ func TestFindOrders(t *testing.T) {
 	}
 }
 
+func TestUpdate(t *testing.T) {
+	ob := NewOrderBook()
+	ords := testOrders()
+	for _, o := range ords {
+		ob.Add(o)
+	}
+	o := ords[0]
+	updateTime := mustParseTime("Sun, 28 Dec 2025 12:00:00 UTC")
+	tests := []struct {
+		name    string
+		update  *tanka.OrderUpdate
+		wantErr bool
+	}{{
+		name: "ok",
+		update: &tanka.OrderUpdate{
+			From:  o.From,
+			Nonce: o.Nonce,
+			Qty:   7,
+			Stamp: updateTime,
+		},
+	}, {
+		name: "order does not exist",
+		update: &tanka.OrderUpdate{
+			From:  o.From,
+			Nonce: 100,
+			Qty:   7,
+			Stamp: updateTime,
+		},
+		wantErr: true,
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ob.Update(test.update)
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			ord := ob.Order(test.update.ID())
+			if ord.Qty != test.update.Qty {
+				t.Fatalf("expected qty %d but got %d", test.update.Qty, ord.Qty)
+			}
+			if ord.Stamp != test.update.Stamp {
+				t.Fatalf("expected stamp %s but got %s", test.update.Stamp, ord.Stamp)
+			}
+		})
+	}
+}
+
 func TestDeleteOrder(t *testing.T) {
 	ob := NewOrderBook()
-	var oids [][32]byte
+	var oids []tanka.ID40
 	for _, o := range testOrders() {
-		if err := ob.AddUpdate(o); err != nil {
-			t.Fatal(err)
-		}
+		ob.Add(o)
 		oids = append(oids, o.ID())
 	}
 	ob.Delete(oids[0])

--- a/tatanka/tanka/swaps.go
+++ b/tatanka/tanka/swaps.go
@@ -13,6 +13,8 @@ import (
 	"github.com/decred/dcrd/crypto/blake256"
 )
 
+const orderIDLen = 40
+
 type Order struct {
 	From    PeerID `json:"from"`
 	BaseID  uint32 `json:"baseID"`
@@ -21,32 +23,20 @@ type Order struct {
 	Qty     uint64 `json:"qty"`
 	Rate    uint64 `json:"rate"`
 	// LotSize: Tatankanet does not prescribe a lot size. Instead, users must
-	// select their own minimum minimum lot size. The user's UI should ignore
+	// select their own minimum lot size. The user's UI should ignore
 	// orderbook orders that don't have the requisite lot size. The UI should
 	// show lot size selection in terms of a sliding scale of fee exposure.
 	// Lot sizes can only be powers of 2.
 	LotSize uint64    `json:"lotSize"`
+	Nonce   uint64    `json:"nonce"`
 	Stamp   time.Time `json:"stamp"`
-	// Nonce can be used to force unique ids while other values are the same.
-	Nonce uint32 `json:"nonce"`
 }
 
-func (ord *Order) ID() [32]byte {
-	const msgLen = 32 + 4 + 4 + 1 + 8 + 8 + 8 + 8 + 4
-	b := make([]byte, msgLen)
+func (ord *Order) ID() ID40 {
+	var b ID40
 	copy(b[:32], ord.From[:])
-	binary.BigEndian.PutUint32(b[32:36], ord.BaseID)
-	binary.BigEndian.PutUint32(b[36:40], ord.QuoteID)
-	if ord.Sell {
-		b[41] = 1
-	}
-	binary.BigEndian.PutUint64(b[41:49], ord.Qty)
-	binary.BigEndian.PutUint64(b[49:57], ord.Rate)
-	binary.BigEndian.PutUint64(b[57:65], ord.LotSize)
-	binary.BigEndian.PutUint64(b[65:73], uint64(ord.Stamp.UnixMilli()))
-	binary.BigEndian.PutUint32(b[73:77], ord.Nonce)
-	return blake256.Sum256(b)
-
+	binary.BigEndian.PutUint64(b[32:], ord.Nonce)
+	return b
 }
 
 func (ord *Order) Valid() error {
@@ -75,9 +65,15 @@ func (i ID32) String() string {
 	return hex.EncodeToString(i[:])
 }
 
+type ID40 [40]byte
+
+func (i ID40) String() string {
+	return hex.EncodeToString(i[:])
+}
+
 type Match struct {
 	From    PeerID    `json:"from"`
-	OrderID ID32      `json:"orderID"`
+	OrderID ID40      `json:"orderID"`
 	Qty     uint64    `json:"qty"`
 	Stamp   time.Time `json:"stamp"`
 }
@@ -93,7 +89,7 @@ func (m *Match) ID() ID32 {
 }
 
 type MatchAcceptance struct {
-	OrderID ID32 `json:"orderID"`
+	OrderID ID40 `json:"orderID"`
 	MatchID ID32 `json:"matchID"`
 }
 
@@ -102,48 +98,16 @@ type MarketParameters struct {
 	QuoteID uint32 `json:"quoteID"`
 }
 
-const (
-	OrderExpiration    = time.Hour * 12
-	OrderUpdateVersion = 0
-)
-
 type OrderUpdate struct {
-	*Order
-	Version    uint8     `json:"version"`
-	Expiration time.Time `json:"expiration"`
-	Settled    uint64    `json:"settled"`
-	// The signature of all other serialized fields with private key
-	// belonging to PeerID.
-	Sig []byte `json:"sig"`
+	From  PeerID    `json:"from"`
+	Nonce uint64    `json:"nonce"`
+	Qty   uint64    `json:"qty"`
+	Stamp time.Time `json:"stamp"`
 }
 
-func NewOrderUpdate(o *Order, settled uint64) *OrderUpdate {
-	return &OrderUpdate{
-		Version:    OrderUpdateVersion,
-		Expiration: o.Stamp.Add(OrderExpiration),
-		Settled:    settled,
-		Order:      o,
-	}
-}
-
-// Serialize returns the bytes needed to sign the update.
-func (ou *OrderUpdate) Serialize() ([]byte, error) {
-	msgLen := 1 + 32 + 4 + 4 + 1 + 8 + 8 + 8 + 8 + 4 + 8 + 8
-	b := make([]byte, msgLen)
-	b[0] = ou.Version
-	copy(b[1:33], ou.From[:])
-	binary.BigEndian.PutUint32(b[33:37], ou.BaseID)
-	binary.BigEndian.PutUint32(b[37:41], ou.QuoteID)
-	if ou.Sell {
-		b[42] = 1
-	}
-	binary.BigEndian.PutUint64(b[42:50], ou.Qty)
-	binary.BigEndian.PutUint64(b[50:58], ou.Rate)
-	binary.BigEndian.PutUint64(b[58:66], ou.LotSize)
-	binary.BigEndian.PutUint64(b[66:74], uint64(ou.Stamp.UnixMilli()))
-	binary.BigEndian.PutUint32(b[74:78], ou.Nonce)
-	binary.BigEndian.PutUint64(b[78:84], uint64(ou.Expiration.UnixMilli()))
-	binary.BigEndian.PutUint64(b[84:92], ou.Settled)
-
-	return b, nil
+func (ou *OrderUpdate) ID() ID40 {
+	var b ID40
+	copy(b[:32], ou.From[:])
+	binary.BigEndian.PutUint64(b[32:], ou.Nonce)
+	return b
 }


### PR DESCRIPTION
This applies review from #3194

It was suggested the orders would be "push" oriented. So, a user will be listening for new users and send them their orders periodically along with separate order updates that are very small. The signature is no longer stored as we expect listeners to catch messages directly from other peers. The order id is now just the peerID and a nonce. This is simple and allows an order to be found by update easily. Update is now a separate method.