### PR TITLE
client/site: Hide copy button on unsecure connection.

### DIFF
--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -1870,7 +1870,12 @@ export class DepositAddress {
     const page = this.page = Doc.idDescendants(form)
     Doc.cleanTemplates(page.unifiedReceiverTmpl)
     Doc.bind(page.newDepAddrBttn, 'click', async () => { this.newDepositAddress() })
-    Doc.bind(page.copyAddressBtn, 'click', () => { this.copyAddress() })
+    // navigator.clipboard can only be accessed on localhost or over https.
+    if (window.isSecureContext) {
+      Doc.bind(page.copyAddressBtn, 'click', () => { this.copyAddress() })
+    } else {
+      Doc.hide(page.copyAddressBtn)
+    }
   }
 
   /* Display a deposit address. */


### PR DESCRIPTION
closes #2724

Another solution is to use this hack https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript/33928558#33928558

It's probably best for the user to run on localhost or with the --webtls flag if they want to use the clipboard from a remote location.