### PR TITLE
tatanka: Improve client connection maintenance

### DIFF
--- a/dex/ws/wslink.go
+++ b/dex/ws/wslink.go
@@ -263,6 +263,9 @@ out:
 				websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
 				break out // clean Close from client
 			}
+
+			// TODO: this error check is not working. The error is not an OpError,
+			// but the text is still the same.
 			var opErr *net.OpError
 			if errors.As(err, &opErr) && opErr.Op == "read" &&
 				(strings.Contains(opErr.Err.Error(), "use of closed network connection") || // we hung up

--- a/tatanka/client/conn/conn.go
+++ b/tatanka/client/conn/conn.go
@@ -590,7 +590,7 @@ func (c *MeshConn) failoverToSecondary() bool {
 // there's no primary, and attempts to find new nodes if there is no primary
 // or secondary node.
 //
-// c.nodesMtx MUST locked when calling this function.
+// c.nodesMtx MUST be locked when calling this function.
 func (c *MeshConn) maintainMeshConnections() {
 	if !c.maintainingMeshConnections.CompareAndSwap(false, true) {
 		return

--- a/tatanka/client/conn/conn_live_test.go
+++ b/tatanka/client/conn/conn_live_test.go
@@ -3,10 +3,12 @@
 package conn
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -15,7 +17,6 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex"
-	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
 	dexbtc "decred.org/dcrdex/dex/networks/btc"
 	"decred.org/dcrdex/server/comms"
@@ -98,18 +99,14 @@ type tTatanka struct {
 	nodeInfo *tTatankaNodeInfo
 }
 
-type tMesh struct {
-	tatankas []*tTatanka
-}
-
 type tConn struct {
 	conn                         *MeshConn
 	cm                           *dex.ConnectionMaster
 	priv                         *secp256k1.PrivateKey
 	peerID                       tanka.PeerID
-	incomingTatankaRequests      chan *msgjson.Message
-	incomingTatankaNotifications chan *msgjson.Message
-	incomingPeerMsgs             chan *IncomingTankagram
+	incomingTatankaRequests      chan *tatankaRequestHandler
+	incomingTatankaNotifications chan *tatankaNoteHandler
+	incomingPeerMsgs             chan *tankagramHandler
 }
 
 // ### Network Setup Functions
@@ -173,6 +170,7 @@ func runServer(t *testing.T, ctx context.Context, thisNode *tTatankaNodeInfo, ot
 		},
 		ConfigPath: cfgPath,
 		WhiteList:  whiteList,
+		MaxClients: 100,
 	}
 
 	if disableMessariFiatRateSource {
@@ -200,9 +198,61 @@ func runServer(t *testing.T, ctx context.Context, thisNode *tTatankaNodeInfo, ot
 	}, nil
 }
 
+type tMesh struct {
+	nodeInfos []*tTatankaNodeInfo
+	ctx       context.Context
+	t         *testing.T
+
+	mtx      sync.RWMutex
+	tatankas []*tTatanka
+}
+
+func (m *tMesh) tatanka(i int) *tTatanka {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return m.tatankas[i]
+}
+
+func (m *tMesh) stop(i int) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	m.tatankas[i].cm.Disconnect()
+}
+
+// TODO: simply connecting a node after disconnecting does not work.
+// There will be the following error:
+// unexpected (http.Server).Serve error: accept tcp4 127.0.0.1:57146: use of closed network connection
+func (m *tMesh) start(i int) {
+	m.t.Helper()
+
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	if m.tatankas[i].cm.On() {
+		m.t.Fatalf("tatanka %d already running", i)
+	}
+
+	thisNode := m.nodeInfos[i]
+	var otherNodes []*tTatankaNodeInfo
+	for j := range m.nodeInfos {
+		if j == i {
+			continue
+		}
+		otherNodes = append(otherNodes, m.nodeInfos[j])
+	}
+
+	tt, err := runServer(m.t, m.ctx, thisNode, otherNodes, true)
+	if err != nil {
+		panic(err)
+	}
+
+	m.tatankas[i] = tt
+}
+
 // setupMesh creates a mesh of numNode tatankas, with each node having all
 // other nodes in the mesh as its whitelist.
-func setupMesh(t *testing.T, ctx context.Context, numNodes int) ([]*tTatanka, error) {
+func setupMesh(t *testing.T, ctx context.Context, numNodes int) (*tMesh, error) {
 	nodes, err := meshNodeInfos(numNodes)
 	if err != nil {
 		return nil, fmt.Errorf("meshNodeInfos error: %w", err)
@@ -223,7 +273,30 @@ func setupMesh(t *testing.T, ctx context.Context, numNodes int) ([]*tTatanka, er
 		tatankas = append(tatankas, tt)
 	}
 
-	return tatankas, nil
+	return &tMesh{
+		nodeInfos: nodes,
+		ctx:       ctx,
+		t:         t,
+		tatankas:  tatankas,
+	}, nil
+}
+
+type tatankaRequestHandler struct {
+	route   string
+	payload json.RawMessage
+	respond func(any, *msgjson.Error)
+}
+
+type tatankaNoteHandler struct {
+	route   string
+	payload json.RawMessage
+}
+
+type tankagramHandler struct {
+	peerID  tanka.PeerID
+	route   string
+	payload json.RawMessage
+	respond func(any, mj.TankagramError)
 }
 
 // newTestConn creates a new client connection to a tatanka node.
@@ -231,9 +304,9 @@ func newTestConn(t *testing.T, i int, ctx context.Context, tatankaNodeInfo *tTat
 	priv, peerID := genKeyPair()
 
 	// Setup channels for incoming messages
-	incomingTatankaRequests := make(chan *msgjson.Message, 10)
-	incomingTatankaNotifications := make(chan *msgjson.Message, 10)
-	incomingPeerMsgs := make(chan *IncomingTankagram, 10)
+	incomingTatankaRequests := make(chan *tatankaRequestHandler, 10)
+	incomingTatankaNotifications := make(chan *tatankaNoteHandler, 10)
+	incomingPeerMsgs := make(chan *tankagramHandler, 10)
 
 	// Configure connection
 	cfg := &Config{
@@ -243,16 +316,14 @@ func newTestConn(t *testing.T, i int, ctx context.Context, tatankaNodeInfo *tTat
 			NoTLS:  true,
 		},
 		Handlers: &MessageHandlers{
-			HandleTatankaRequest: func(_ tanka.PeerID, msg *msgjson.Message) *msgjson.Error {
-				incomingTatankaRequests <- msg
-				return nil
+			HandleTatankaRequest: func(route string, payload json.RawMessage, respond func(any, *msgjson.Error)) {
+				incomingTatankaRequests <- &tatankaRequestHandler{route: route, payload: payload, respond: respond}
 			},
-			HandleTatankaNotification: func(_ tanka.PeerID, msg *msgjson.Message) {
-				incomingTatankaNotifications <- msg
+			HandleTatankaNotification: func(route string, payload json.RawMessage) {
+				incomingTatankaNotifications <- &tatankaNoteHandler{route: route, payload: payload}
 			},
-			HandlePeerMessage: func(_ tanka.PeerID, msg *IncomingTankagram) *msgjson.Error {
-				incomingPeerMsgs <- msg
-				return nil
+			HandlePeerMessage: func(peerID tanka.PeerID, route string, payload json.RawMessage, respond func(any, mj.TankagramError)) {
+				incomingPeerMsgs <- &tankagramHandler{peerID: peerID, route: route, payload: payload, respond: respond}
 			},
 		},
 		Logger:     logMaker.NewLogger(fmt.Sprintf("CONN%d", i), dex.LevelTrace),
@@ -264,25 +335,6 @@ func newTestConn(t *testing.T, i int, ctx context.Context, tatankaNodeInfo *tTat
 	cm := dex.NewConnectionMaster(conn)
 	if err := cm.ConnectOnce(ctx); err != nil {
 		return nil, fmt.Errorf("ConnectOnce error: %w", err)
-	}
-
-	// Post a DCR bond with 1 year expiration
-	const bondExpirationDuration = time.Hour * 24 * 365
-	postBondReq := mj.MustRequest(mj.RoutePostBond, []*tanka.Bond{&tanka.Bond{
-		PeerID:     peerID,
-		AssetID:    42,
-		CoinID:     encode.RandomBytes(32),
-		Strength:   1,
-		Expiration: time.Now().Add(bondExpirationDuration),
-	}})
-	err := conn.RequestMesh(postBondReq, nil)
-	if err != nil {
-		return nil, fmt.Errorf("PostBond error: %w", err)
-	}
-
-	err = conn.Auth(tatankaNodeInfo.peerID)
-	if err != nil {
-		return nil, fmt.Errorf("Auth error: %w", err)
 	}
 
 	return &tConn{
@@ -306,9 +358,12 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// TestConnectPeer tests that a client can connect to another client
+// and send a tankagram request to it.
 func TestConnectPeer(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, cc := context.WithCancel(context.Background())
+	fmt.Println(cc)
+	// defer cancel()
 
 	// Create a two node mesh
 	mesh, err := setupMesh(t, ctx, 2)
@@ -317,11 +372,12 @@ func TestConnectPeer(t *testing.T) {
 	}
 
 	// Create two clients, one connected to each node
-	conn1, err := newTestConn(t, 1, ctx, mesh[0].nodeInfo)
+	conn1, err := newTestConn(t, 1, ctx, mesh.nodeInfos[0])
 	if err != nil {
 		t.Fatalf("newTestConn error: %v", err)
 	}
-	conn2, err := newTestConn(t, 2, ctx, mesh[1].nodeInfo)
+
+	conn2, err := newTestConn(t, 2, ctx, mesh.nodeInfos[1])
 	if err != nil {
 		t.Fatalf("newTestConn error: %v", err)
 	}
@@ -345,31 +401,35 @@ func TestConnectPeer(t *testing.T) {
 	// Send the request and check the response
 	wg := sync.WaitGroup{}
 	wg.Add(1)
+	errChan := make(chan error, 1)
 	go func() {
 		defer wg.Done()
 
 		var res testRequest
 		err = conn1.conn.RequestPeer(conn2.peerID, testReq, &res)
 		if err != nil {
-			t.Fatalf("RequestPeer error: %v", err)
+			errChan <- fmt.Errorf("RequestPeer error: %w", err)
 		}
 		if res != expResponse {
-			t.Fatalf("expected %+v, got %+v", expResponse, res)
+			errChan <- fmt.Errorf("expected %+v, got %+v", expResponse, res)
 		}
 	}()
 
 	// Use client 2 to respond to the request
 	select {
 	case msg := <-conn2.incomingPeerMsgs:
-		err = msg.Respond(expResponse)
-		if err != nil {
-			t.Fatalf("Respond error: %v", err)
-		}
+		msg.respond(expResponse, mj.TEErrNone)
 	case <-time.After(time.Second):
 		t.Fatalf("timeout waiting for incoming tatanka request peer 2")
 	}
 
 	wg.Wait()
+
+	select {
+	case err := <-errChan:
+		t.Fatal(err)
+	default:
+	}
 
 	// Simulate client 2 restarting and no longer knowing about the
 	// original ephemeral key. Ensure that ErrPeerNeedsReconnect is returned
@@ -380,4 +440,168 @@ func TestConnectPeer(t *testing.T) {
 	if err != ErrPeerNeedsReconnect {
 		t.Fatalf("expected ErrPeerNeedsReconnect, got %v", err)
 	}
+}
+
+// TestFailover tests that if nodes go down, the connection to the mesh
+// will switch to other nodes and the subscriptions are restored.
+func TestFailover(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mesh, err := setupMesh(t, ctx, 4)
+	if err != nil {
+		t.Fatalf("setupMesh error: %v", err)
+	}
+
+	mesh.stop(2)
+	mesh.stop(3)
+
+	conn1, err := newTestConn(t, 1, ctx, mesh.nodeInfos[0])
+	if err != nil {
+		t.Fatalf("newTestConn error: %v", err)
+	}
+	defer conn1.cm.Disconnect()
+
+	conn2, err := newTestConn(t, 2, ctx, mesh.nodeInfos[1])
+	if err != nil {
+		t.Fatalf("newTestConn error: %v", err)
+	}
+	defer conn2.cm.Disconnect()
+
+	marketsTopic := tanka.Topic("market")
+	dcrBtcSubject := tanka.Subject("dcr/btc")
+	conn1.conn.Subscribe(marketsTopic, dcrBtcSubject)
+	conn2.conn.Subscribe(marketsTopic, dcrBtcSubject)
+
+	// testBroadcast sends a broadcast on the source client and makes sure that
+	// the destination client recieves it.
+	testBroadcast := func(bcast *mj.Broadcast, source, dest *tConn) {
+		t.Helper()
+
+		var ok bool
+		err = source.conn.RequestMesh(mj.MustRequest(mj.RouteBroadcast, bcast), &ok)
+		if err != nil {
+			t.Fatalf("RequestMesh error: %v", err)
+		}
+
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		errChan := make(chan error, 1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case msg := <-dest.incomingTatankaNotifications:
+					if msg.route == mj.RouteBroadcast {
+						var broadcast mj.Broadcast
+						err := json.Unmarshal(msg.payload, &broadcast)
+						if err != nil {
+							errChan <- fmt.Errorf("Unmarshal error: %w", err)
+							return
+						}
+						if bytes.Equal(broadcast.Payload, bcast.Payload) {
+							return
+						}
+					}
+				case <-time.After(time.Second * 10):
+					errChan <- fmt.Errorf("timed out waiting for broadcast")
+				}
+			}
+		}()
+
+		wg.Wait()
+
+		select {
+		case err := <-errChan:
+			t.Fatal(err)
+		default:
+		}
+	}
+
+	connectedNodes := make(map[tanka.PeerID]map[string]bool)
+	updateConnectedNodes := func(conn *tConn) {
+		connectedNodes[conn.conn.peerID] = make(map[string]bool)
+		hostOnly := func(uri string) string {
+			parsedURL, _ := url.Parse(uri)
+			return parsedURL.Host
+		}
+		if conn.conn.primaryNode != nil {
+			connectedNodes[conn.conn.peerID][hostOnly(conn.conn.primaryNode.url)] = true
+		}
+		if conn.conn.secondaryNode != nil {
+			connectedNodes[conn.conn.peerID][hostOnly(conn.conn.secondaryNode.url)] = true
+		}
+	}
+
+	// checkConnected that the connections are connected to the expected nodes
+	// on both conn1 and conn2.
+	checkConnected := func(expected []string) {
+		t.Helper()
+		updateConnectedNodes(conn1)
+		updateConnectedNodes(conn2)
+		for _, node := range expected {
+			if !connectedNodes[conn1.conn.peerID][node] {
+				t.Fatalf("node %s not connected to conn1", node)
+			}
+			if !connectedNodes[conn2.conn.peerID][node] {
+				t.Fatalf("node %s not connected to conn2", node)
+			}
+		}
+	}
+
+	checkConnected([]string{
+		mesh.nodeInfos[0].addr.String(),
+		mesh.nodeInfos[1].addr.String(),
+	})
+
+	testBroadcast(&mj.Broadcast{
+		PeerID:      conn1.peerID,
+		Topic:       marketsTopic,
+		Subject:     dcrBtcSubject,
+		MessageType: mj.MessageTypeTrollBox,
+		Payload:     []byte("hello"),
+		Stamp:       time.Now(),
+	}, conn1, conn2)
+
+	testBroadcast(&mj.Broadcast{
+		PeerID:      conn2.peerID,
+		Topic:       marketsTopic,
+		Subject:     dcrBtcSubject,
+		MessageType: mj.MessageTypeTrollBox,
+		Payload:     []byte("hello2"),
+		Stamp:       time.Now(),
+	}, conn2, conn1)
+
+	// Stop the two nodes that the connections were using, and start the two
+	// that were previously shut down.
+	mesh.stop(0)
+	mesh.stop(1)
+	mesh.start(2)
+	mesh.start(3)
+
+	conn1.conn.maintainMeshConnections()
+	conn2.conn.maintainMeshConnections()
+
+	checkConnected([]string{
+		mesh.nodeInfos[2].addr.String(),
+		mesh.nodeInfos[3].addr.String(),
+	})
+
+	testBroadcast(&mj.Broadcast{
+		PeerID:      conn1.peerID,
+		Topic:       marketsTopic,
+		Subject:     dcrBtcSubject,
+		MessageType: mj.MessageTypeTrollBox,
+		Payload:     []byte("hello3"),
+		Stamp:       time.Now(),
+	}, conn1, conn2)
+
+	testBroadcast(&mj.Broadcast{
+		PeerID:      conn2.peerID,
+		Topic:       marketsTopic,
+		Subject:     dcrBtcSubject,
+		MessageType: mj.MessageTypeTrollBox,
+		Payload:     []byte("hello4"),
+		Stamp:       time.Now(),
+	}, conn2, conn1)
 }

--- a/tatanka/cmd/tatanka/main.go
+++ b/tatanka/cmd/tatanka/main.go
@@ -32,6 +32,7 @@ const (
 	defaultHSHost         = defaultHost // should be a loopback address
 	defaultHSPort         = "7252"
 	defaultLogLevel       = "debug"
+	defaultMaxClients     = 1000
 )
 
 var (
@@ -71,11 +72,17 @@ func mainErr() (err error) {
 		net = dex.Testnet
 	}
 
+	maxClients := defaultMaxClients
+	if cfg.MaxClients > 0 {
+		maxClients = cfg.MaxClients
+	}
+
 	t, err := tatanka.New(&tatanka.Config{
 		Net:        net,
 		DataDir:    cfg.AppDataDir,
 		Logger:     logMaker.Logger("🦬"),
 		ConfigPath: cfg.ConfigFile,
+		MaxClients: maxClients,
 		RPC: comms.RPCConfig{
 			HiddenServiceAddr: cfg.HiddenService,
 			ListenAddrs:       cfg.Listeners,
@@ -116,7 +123,8 @@ type Config struct {
 	HiddenService    string   `long:"hiddenservice" description:"A host:port on which the RPC server should listen for incoming hidden service connections. No TLS is used for these connections."`
 	feerateOracleCfg feerates.Config
 
-	WebAddr string `long:"webaddr" description:"The public facing address by which peers should connect."`
+	WebAddr    string `long:"webaddr" description:"The public facing address by which peers should connect."`
+	MaxClients int    `long:"maxclients" description:"The maximum number of clients that can connect to this node."`
 
 	FiatOracleConfig fiatrates.Config `group:"Fiat Oracle Config"`
 }

--- a/tatanka/mj/types.go
+++ b/tatanka/mj/types.go
@@ -26,6 +26,7 @@ const (
 	ErrBanned
 	ErrFailedRelay
 	ErrUnknownSender
+	ErrCapacity
 )
 
 const (
@@ -40,20 +41,23 @@ const (
 	RouteShareScore       = "share_score"
 
 	// tatanka <=> client
-	RouteConnect         = "connect"
-	RouteConfig          = "config"
-	RoutePostBond        = "post_bond"
-	RouteSubscribe       = "subscribe"
-	RouteUnsubscribe     = "unsubscribe"
-	RouteRates           = "rates"
-	RouteSetScore        = "set_score"
-	RouteFeeRateEstimate = "fee_rate_estimate"
+	RouteConnect             = "connect"
+	RoutePostBond            = "post_bond"
+	RouteSubscribe           = "subscribe"
+	RouteUnsubscribe         = "unsubscribe"
+	RouteUpdateSubscriptions = "update_subscriptions"
+	RouteRates               = "rates"
+	RouteSetScore            = "set_score"
+	RouteFeeRateEstimate     = "fee_rate_estimate"
 
 	// client1 <=> tatankanode <=> client2
 	RouteTankagram     = "tankagram"
 	RouteEncryptionKey = "encryption_key"
 	RouteBroadcast     = "broadcast"
 	RouteNewSubscriber = "new_subscriber"
+
+	// HTTP Requests, used before client established WS connection
+	RouteNodeInfo = "node_info"
 )
 
 const (
@@ -89,7 +93,12 @@ type TatankaConfig struct {
 }
 
 type Connect struct {
-	ID tanka.PeerID `json:"id"`
+	ID          tanka.PeerID                    `json:"id"`
+	InitialSubs map[tanka.Topic][]tanka.Subject `json:"initialSubs"`
+}
+
+type UpdateSubscriptions struct {
+	Subscriptions map[tanka.Topic][]tanka.Subject `json:"subscriptions"`
 }
 
 type Disconnect = Connect
@@ -145,6 +154,8 @@ type TankagramResult struct {
 }
 
 type Broadcast struct {
+	// TOOD: Why is PeerID part of the broadcast message when it can be
+	// determined by the request?
 	PeerID      tanka.PeerID         `json:"peerID"`
 	Topic       tanka.Topic          `json:"topic"`
 	Subject     tanka.Subject        `json:"subject"`

--- a/tatanka/tatanka_test.go
+++ b/tatanka/tatanka_test.go
@@ -11,6 +11,7 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/comms"
 	"decred.org/dcrdex/tatanka/mj"
 	"decred.org/dcrdex/tatanka/tanka"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -98,6 +99,7 @@ func tNewTatanka() *Tatanka {
 		clientJobs:      make(chan *clientJob, 128),
 		clientHandlers:  make(map[string]interface{}),
 		tatankaHandlers: make(map[string]interface{}),
+		httpReqHandlers: make(map[string]comms.HTTPHandler),
 	}
 }
 


### PR DESCRIPTION
Starts some groundwork on making the client connection to the mesh more robust.

- Adds an http request to the tatanka node that allows clients to fetch its whitelist.
- Client connection maintains two connections to the mesh, one primary and one secondary.
- The primary connection is used for sending messages and subscribing to topics. The secondary connection is maintained for quick failover.
- Updates the client connect request to include a set of initial subscriptions.
- Adds a UpdateSubscriptions request to update all the subscriptions of a client in a single request. This is useful when upgrading the secondary connection to the primary connection.
- The `conn.MessageHandlers` tatanka request and peer request handlers are updated to include a respond function to avoid having to look up the node by ID to respond to a request.