### PR TITLE
Remove GO111MODULE=on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,6 @@ jobs:
           restore-keys: go-test-${{ matrix.go }}
 
       - name: Test
-        env:
-          GO111MODULE: "on"
         run: |
           mkdir -p client/webserver/site/dist
           touch -t 2306151245 client/webserver/site/dist/placeholder

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -36,9 +36,9 @@ RUN npm run build
 FROM golang@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS gobuilder
 COPY --from=nodebuilder /root/dex/ /root/dex/
 WORKDIR /root/dex/client/cmd/bisonw/
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
+RUN CGO_ENABLED=0 GOOS=linux go build
 WORKDIR /root/dex/client/cmd/bwctl/
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
+RUN CGO_ENABLED=0 GOOS=linux go build
 
 # Final image
 FROM debian:buster-slim

--- a/client/Dockerfile.release
+++ b/client/Dockerfile.release
@@ -24,9 +24,9 @@ FROM golang@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0
 WORKDIR /root/dex
 COPY . . 
 WORKDIR /root/dex/client/cmd/bisonw/
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
+RUN CGO_ENABLED=0 GOOS=linux go build
 WORKDIR /root/dex/client/cmd/bwctl/
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
+RUN CGO_ENABLED=0 GOOS=linux go build
 
 # Final image
 FROM debian:buster-slim


### PR DESCRIPTION
The default value has been "on" since go 1.16 so this declaration only serves as noise in modern projects.