### PR TITLE
build: Update golangci-lint to v2.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: restore timestamps
         run: git restore-mtime
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2"
       - name: Use test and module cache
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,12 @@
+version: "2"
 run:
-  deadline: 10m
-
-output:
-  formats: colored-line-number
-
+  timeout: 10m
 linters:
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bidichk
     - durationcheck
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - grouper
     - ineffassign
@@ -21,6 +15,20 @@ linters:
     - reassign
     - rowserrcheck
     - sqlclosecheck
+    - staticcheck
     - tparallel
-    - typecheck
     - unconvert
+  settings:
+    staticcheck:
+      checks:
+          - S1*
+  exclusions:
+    paths:
+      - docs/examples
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    paths:
+      - docs/examples


### PR DESCRIPTION
Various changes in this new major version, including a new config file format:

- gofmt and goimports are now categorized as formatters (instead of linters) and are moved to their own section.
- The functionality of gosimple has been bundled into staticcheck. Only the gosimple behaviour is enabled (prefix "S1") and all other staticcheck behaviour is disabled.
- typecheck is now always on and cannot be independently enabled/disabled.