### PR TITLE
dcr: Enable mixing for v5 wallet.

### DIFF
--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -1528,6 +1528,9 @@ func newWalletConfig(db wallet.DB, chainParams *chaincfg.Params, gapLimit uint32
 		RelayFee:        defaultRelayFeePerKb,
 		Params:          chainParams,
 		MixSplitLimit:   defaultMixSplitLimit,
+		// TODO: Wallet should be closed and reopened when turning on
+		// and off mixing, and this should be a variable.
+		MixingEnabled: true,
 	}
 }
 


### PR DESCRIPTION
closes #3240

The wallet config was changed from Disabled to Enabled, so we pass true now instead of the default of false.