### PR TITLE
firo: Fix electrum wallet tx db panic

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -811,6 +811,10 @@ type baseWallet struct {
 	feeCache          *feeRateCache
 	decodeAddr        dexbtc.AddressDecoder
 	walletDir         string
+	// noListTxHistory is true for assets that cannot call the
+	// ListTransactionSinceBlock method. This is true for Firo
+	// electrum as of electrum 4.1.5.3.
+	noListTxHistory bool
 
 	deserializeTx func([]byte) (*wire.MsgTx, error)
 	serializeTx   func(*wire.MsgTx) ([]byte, error)
@@ -5899,6 +5903,10 @@ func (btc *baseWallet) idUnknownTx(tx *ListTransactionsResult) (*asset.WalletTra
 func (btc *baseWallet) addUnknownTransactionsToHistory(tip uint64) {
 	txHistoryDB := btc.txDB()
 	if txHistoryDB == nil {
+		return
+	}
+
+	if btc.noListTxHistory {
 		return
 	}
 


### PR DESCRIPTION
The transaction db for firo electrum wallets was not being created because the firo electrum wallet does not supporting listing onchain history. This was a bug. The db should have been created, but only the syncing of historical transactions should have been disabled.

Closes #3247 