### PR TITLE
firo: Electrum wallet get block height fix 

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -811,6 +811,10 @@ type baseWallet struct {
 	feeCache          *feeRateCache
 	decodeAddr        dexbtc.AddressDecoder
 	walletDir         string
+	// noListTxHistory is true for assets that cannot call the
+	// ListTransactionSinceBlock method. This is true for Firo
+	// electrum as of electrum 4.1.5.3.
+	noListTxHistory bool
 
 	deserializeTx func([]byte) (*wire.MsgTx, error)
 	serializeTx   func(*wire.MsgTx) ([]byte, error)
@@ -5899,6 +5903,10 @@ func (btc *baseWallet) idUnknownTx(tx *ListTransactionsResult) (*asset.WalletTra
 func (btc *baseWallet) addUnknownTransactionsToHistory(tip uint64) {
 	txHistoryDB := btc.txDB()
 	if txHistoryDB == nil {
+		return
+	}
+
+	if btc.noListTxHistory {
 		return
 	}
 


### PR DESCRIPTION
The Firo Electrum wallet was unable to get the block height using the hash because the code assumed that the block hash was calculated using a double sha256 hash like Bitcoin, when in fact Firo has its own hash algorithm. There is no Golang library for FiroPOW, so instead of fetching the block header that we are looking for and hashing it, we fetch the subsequent block header and check the previous block hash field.

There were two almost identical `syncTxHistory` functions in the BTC `baseWallet` and the `ExchangeWalletElectrum`. The only difference was the block height check. This logic is now passed in as a parameter, and the `syncTxHistory` function in `ExchangeWalletElectrum` is removed.








