### PR TITLE
electrum: Fix GetBlockHash for Firo compatibility

### DIFF
--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -473,12 +473,12 @@ func (btc *ExchangeWalletElectrum) syncTxHistory(tip uint64) {
 					btc.log.Errorf("Cannot find mined tx block number for %s", gtr.BlockHash)
 					return
 				}
-				bh, err := btc.ew.getBlockHeaderByHeight(btc.ctx, int64(blockHeight))
+				bh, err := btc.ew.GetBlockHash(int64(blockHeight))
 				if err != nil {
 					btc.log.Errorf("Error getting mined tx block number %s: %v", gtr.BlockHash, err)
 					return
 				}
-				if bh.BlockHash().String() == gtr.BlockHash {
+				if bh.String() == gtr.BlockHash {
 					break
 				}
 				i++

--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -555,11 +555,18 @@ func (ew *electrumWallet) calcMedianTime(ctx context.Context, height int64) (tim
 
 // part of btc.Wallet interface
 func (ew *electrumWallet) GetBlockHash(height int64) (*chainhash.Hash, error) {
-	hdr, err := ew.getBlockHeaderByHeight(ew.ctx, height)
+	hdrStr, err := ew.chain().BlockHeader(ew.ctx, uint32(height))
 	if err != nil {
 		return nil, err
 	}
-	hash := hdr.BlockHash()
+
+	fullHeader, err := hex.DecodeString(hdrStr)
+	if err != nil {
+		return nil, err
+	}
+
+	hash := chainhash.DoubleHashH(fullHeader)
+
 	return &hash, nil
 }
 


### PR DESCRIPTION
Fixed GetBlockHash to handle Firo's 120-byte block header. Previously, it deserialized a hex string and re-serialized it in Bitcoin's 80-byte format before double SHA-256 hashing, causing issues with Firo. Now, the hex string is converted to bytes and hashed.
