### PR TITLE
multi: Check book feed isn't closed.

### DIFF
--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -352,9 +352,7 @@ func (b *bookie) send(u *BookUpdate) {
 		select {
 		case feed.c <- u:
 		default:
-			b.log.Warnf("bookie %p: Closing book update feed %d with no receiver. "+
-				"The receiver should have closed the feed before going away.", b, fid)
-			go b.closeFeed(feed.id) // delete it and maybe start a delayed bookie close
+			b.log.Errorf("bookie %p: feed %d is blocking and book update was thrown away.", b, fid)
 		}
 	}
 }

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -3386,7 +3386,9 @@ func (u *unifiedExchangeAdaptor) updateFeeRates() (buyFees, sellFees *OrderFees,
 }
 
 func (u *unifiedExchangeAdaptor) Connect(ctx context.Context) (*sync.WaitGroup, error) {
-	u.ctx, u.kill = context.WithCancel(ctx)
+	ctx, u.kill = context.WithCancel(ctx)
+	u.ctx = ctx
+
 	fiatRates := u.clientCore.FiatConversionRates()
 	u.fiatRates.Store(fiatRates)
 

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -2460,7 +2460,12 @@ func (u *unifiedExchangeAdaptor) cancelAllOrders(ctx context.Context) {
 	i := 0
 	for {
 		select {
-		case ni := <-bookFeed.Next():
+		case ni, ok := <-bookFeed.Next():
+			if !ok {
+				u.log.Error("Stopping bot due to nil book feed.")
+				u.kill()
+				return
+			}
 			switch epoch := ni.Payload.(type) {
 			case *core.ResolvedEpoch:
 				if u.tryCancelOrders(ctx, &epoch.Current, true) {

--- a/client/mm/mm_arb_market_maker.go
+++ b/client/mm/mm_arb_market_maker.go
@@ -529,7 +529,12 @@ func (a *arbMarketMaker) botLoop(ctx context.Context) (*sync.WaitGroup, error) {
 		defer bookFeed.Close()
 		for {
 			select {
-			case ni := <-bookFeed.Next():
+			case ni, ok := <-bookFeed.Next():
+				if !ok {
+					a.log.Error("Stopping bot due to nil book feed.")
+					a.kill()
+					return
+				}
 				switch epoch := ni.Payload.(type) {
 				case *core.ResolvedEpoch:
 					a.rebalance(epoch.Current, book)

--- a/client/mm/mm_basic.go
+++ b/client/mm/mm_basic.go
@@ -474,7 +474,12 @@ func (m *basicMarketMaker) botLoop(ctx context.Context) (*sync.WaitGroup, error)
 		defer bookFeed.Close()
 		for {
 			select {
-			case ni := <-bookFeed.Next():
+			case ni, ok := <-bookFeed.Next():
+				if !ok {
+					m.log.Error("Stopping bot due to nil book feed.")
+					m.kill()
+					return
+				}
 				switch epoch := ni.Payload.(type) {
 				case *core.ResolvedEpoch:
 					m.rebalance(epoch.Current)

--- a/client/mm/mm_simple_arb.go
+++ b/client/mm/mm_simple_arb.go
@@ -487,7 +487,12 @@ func (a *simpleArbMarketMaker) botLoop(ctx context.Context) (*sync.WaitGroup, er
 		defer bookFeed.Close()
 		for {
 			select {
-			case ni := <-bookFeed.Next():
+			case ni, ok := <-bookFeed.Next():
+				if !ok {
+					a.log.Error("Stopping bot due to nil book feed.")
+					a.kill()
+					return
+				}
 				switch epoch := ni.Payload.(type) {
 				case *core.ResolvedEpoch:
 					a.rebalance(epoch.Current)


### PR DESCRIPTION
closes #3097 

For core were were handling this correctly:

 https://github.com/decred/dcrdex/blob/8ecd2ea3bfad93a97a4602ec064c978bda9d1878/client/websocket/websocket.go#L260-L264

However in mm we were not checking if the feed is closed. It can be closed when the market is shut down or when the cert is updated? Unsure if that is handled correctly, but it could possibly panic.

It could also potentiality close on send if the channel is blocking, but I think this is a mistake. The close is there in case the caller did not call Close but the docs say that the caller MUST call close, so I don't think we need to check. The problem will be that the channel is blocking with a 256 buffer, so we need to see that error log and do something about it if it happens.