### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -117,14 +118,8 @@ func (btc *ExchangeWalletElectrum) Connect(ctx context.Context) (*sync.WaitGroup
 	if err != nil {
 		return nil, err
 	}
-	var hasFreezeUTXO bool
-	for i := range commands {
-		if commands[i] == "freeze_utxo" {
-			hasFreezeUTXO = true
-			break
-		}
-	}
-	if !hasFreezeUTXO {
+
+	if !slices.Contains(commands, "freeze_utxo") {
 		return nil, errors.New("wallet does not support the freeze_utxo command")
 	}
 

--- a/client/core/wallet.go
+++ b/client/core/wallet.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -91,12 +92,7 @@ func (w *xcWallet) setEncPW(encPW []byte) {
 }
 
 func (w *xcWallet) supportsVer(ver uint32) bool {
-	for _, v := range w.supportedVersions {
-		if v == ver {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(w.supportedVersions, ver)
 }
 
 // Unlock unlocks the wallet backend and caches the decrypted wallet password so

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -1104,12 +1105,7 @@ func (db *BoltDB) Orders(orderFilter *dexdb.OrderFilter) (ords []*dexdb.MetaOrde
 	if len(orderFilter.Statuses) > 0 {
 		filters = append(filters, func(_ []byte, oBkt *bbolt.Bucket) bool {
 			status := order.OrderStatus(intCoder.Uint16(oBkt.Get(statusKey)))
-			for _, acceptable := range orderFilter.Statuses {
-				if status == acceptable {
-					return true
-				}
-			}
-			return false
+			return slices.Contains(orderFilter.Statuses, status)
 		})
 		includeArchived = false
 		for _, status := range orderFilter.Statuses {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.