### PR TITLE
client: Deserialize Firo blocks from wire bytes

### DIFF
--- a/client/asset/firo/block_deserialize.go
+++ b/client/asset/firo/block_deserialize.go
@@ -1,0 +1,96 @@
+package firo
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+)
+
+const (
+	// Only blocks mined with progpow are considered.
+	// Previous mining algorithms: MTP and Lyra2z ignored as being too early for
+	// Firo wallet on Dex ~ late 2023
+	ProgpowStartTime        = 1635228000 // Tue Oct 26 2021 06:00:00 UTC+0
+	HeaderLength            = 80
+	ProgpowExtraLength      = 40
+	ProgpowFullHeaderLength = HeaderLength + ProgpowExtraLength
+)
+
+// deserializeBlock deserializes the wire bytes passed in as blk and returns the
+// header for the network plus any Transparent transactions found parsed into a
+// wire.MsgBlock.
+//
+// Other transaction types are discarded; including coinbase.
+func deserializeBlock(net *chaincfg.Params, blk []byte) (*wire.MsgBlock, error) {
+	var hdrHash chainhash.Hash
+	var hdr *wire.BlockHeader
+
+	// hash header
+	var header []byte
+	switch net.Name {
+	case "mainnet", "testnet3, testnet":
+		header = make([]byte, ProgpowFullHeaderLength)
+		copy(header, blk[:ProgpowFullHeaderLength])
+	case "regtest":
+		header = make([]byte, HeaderLength)
+		copy(header, blk[:HeaderLength])
+	default:
+		return nil, fmt.Errorf("unknown net: %s", net.Name)
+	}
+	hdrHash = chainhash.DoubleHashH(header)
+
+	fmt.Printf("firo block hash: %s\n", hdrHash.String()) // TODO: delete this
+
+	// make a reader over the full block
+	r := bytes.NewReader(blk)
+
+	// deserialize the first 80 bytes of the header
+	hdr = &wire.BlockHeader{}
+	err := hdr.Deserialize(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deserialize block header: %w", err)
+	}
+
+	if int(hdr.Timestamp.Unix()) < ProgpowStartTime {
+		return nil, fmt.Errorf("dex not considering blocks mined before progpow")
+	}
+
+	if net.Name != "regtest" {
+		// Blocks mined later than progpow start time have 40 extra bytes holding
+		// mining info. Skip over!
+		var extraBytes = make([]byte, ProgpowExtraLength)
+		r.Read(extraBytes)
+	}
+
+	// This block's transactions
+	txnCount, err := wire.ReadVarInt(r, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse transaction count: %w", err)
+	}
+
+	if txnCount == 0 {
+		return nil, fmt.Errorf("invalid transaction count 0 -- must at least have a coinbase")
+	}
+
+	txns := make([]*wire.MsgTx, 0, int(txnCount))
+	for i := 0; i < cap(txns); i++ {
+		tx, err := deserializeTransaction(r)
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to deserialize transaction %d of %d (type=%d) in block %s: %w",
+				i+1, txnCount, tx.txType, hdrHash.String(), err)
+		}
+
+		if tx.txType == TransactionNormal {
+			txns = append(txns, tx.msgTx)
+		}
+	}
+
+	return &wire.MsgBlock{
+		Header:       *hdr,
+		Transactions: txns,
+	}, nil
+}

--- a/client/asset/firo/block_deserialize.go
+++ b/client/asset/firo/block_deserialize.go
@@ -31,7 +31,7 @@ func deserializeBlock(net *chaincfg.Params, blk []byte) (*wire.MsgBlock, error) 
 	// hash header
 	var header []byte
 	switch net.Name {
-	case "mainnet", "testnet3, testnet":
+	case "mainnet", "testnet3", "testnet":
 		header = make([]byte, ProgpowFullHeaderLength)
 		copy(header, blk[:ProgpowFullHeaderLength])
 	case "regtest":

--- a/client/asset/firo/firo.go
+++ b/client/asset/firo/firo.go
@@ -22,6 +22,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
 )
 
 const (
@@ -137,13 +138,6 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		return nil, fmt.Errorf("unknown network ID %v", network)
 	}
 
-	// Designate the clone ports.
-	ports := dexbtc.NetPorts{
-		Mainnet: "8888",
-		Testnet: "18888",
-		Simnet:  "28888",
-	}
-
 	cloneCFG := &btc.BTCCloneCFG{
 		WalletCFG:                cfg,
 		MinNetworkVersion:        minNetworkVersion,
@@ -152,7 +146,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		Logger:                   logger,
 		Network:                  network,
 		ChainParams:              params,
-		Ports:                    ports,
+		Ports:                    dexfiro.NetPorts,
 		DefaultFallbackFee:       dexfiro.DefaultFee,
 		DefaultFeeRateLimit:      dexfiro.DefaultFeeRateLimit,
 		Segwit:                   false,
@@ -172,14 +166,17 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 		ExternalFeeEstimator:     externalFeeRate,
 		AddressDecoder:           decodeAddress,
 		PrivKeyFunc:              nil, // set only for walletTypeRPC below
+		BlockDeserializer:        nil, // set only for walletTypeRPC below
 	}
 
 	switch cfg.Type {
 	case walletTypeRPC:
 		var exw *btc.ExchangeWalletFullNode
-		// override PrivKeyFunc - we need our own Firo dumpprivkey fn
 		cloneCFG.PrivKeyFunc = func(addr string) (*btcec.PrivateKey, error) {
 			return privKeyForAddress(exw, addr)
+		}
+		cloneCFG.BlockDeserializer = func(blk []byte) (*wire.MsgBlock, error) {
+			return deserializeBlock(params, blk)
 		}
 		var err error
 		exw, err = btc.BTCCloneWallet(cloneCFG)

--- a/client/asset/firo/firo.go
+++ b/client/asset/firo/firo.go
@@ -29,8 +29,8 @@ const (
 	version = 0
 	// Zcoin XZC
 	BipID = 136
-	// Consensus changes v0.14.14.0
-	minNetworkVersion   = 141400
+	//  https://github.com/firoorg/firo/releases/tag/v0.14.14.1
+	minNetworkVersion   = 141401
 	walletTypeRPC       = "firodRPC"
 	walletTypeElectrum  = "electrumRPC"
 	estimateFeeConfs    = 2 // 2 blocks should be enough

--- a/client/asset/firo/regnet_test.go
+++ b/client/asset/firo/regnet_test.go
@@ -1,4 +1,4 @@
-//go:build harness
+///////go:build harness
 
 package firo
 

--- a/client/asset/firo/regnet_test.go
+++ b/client/asset/firo/regnet_test.go
@@ -1,4 +1,4 @@
-///////go:build harness
+//go:build harness
 
 package firo
 

--- a/client/asset/firo/tx_deserialize.go
+++ b/client/asset/firo/tx_deserialize.go
@@ -215,7 +215,8 @@ func deserializeTransaction(r io.Reader) (*txn, error) {
 		TransactionProviderUpdateRevoke,
 		TransactionCoinbase,
 		TransactionLelantus,
-		TransactionSpark:
+		TransactionSpark,
+		TransactionAlias:
 		{
 			deserializeTx(dec, &tx, tx.txType)
 		}
@@ -223,11 +224,13 @@ func deserializeTransaction(r io.Reader) (*txn, error) {
 		err = deserializeNonSpendingTx(dec, &tx, tx.txType)
 	case TransactionSpork:
 		err = deserializeNonSpendingTx(dec, &tx, tx.txType)
-	case TransactionAlias:
-		err = fmt.Errorf("TRANSACTION_ALIAS transaction type - wtf")
 	default:
 		err = fmt.Errorf("unknown transaction type %d", tx.txType)
 	}
+
+	// TRANSACTION_ALIAS is a regular spark spend transaction, but contains
+	// additional info, it is spark name transaction, so in that tx besides
+	// spark spend outputs you also have data about created/modified spark name.
 
 	return &tx, err
 }

--- a/client/asset/firo/tx_deserialize.go
+++ b/client/asset/firo/tx_deserialize.go
@@ -219,9 +219,8 @@ func deserializeTransaction(r io.Reader) (*txn, error) {
 		{
 			deserializeTx(dec, &tx, tx.txType)
 		}
-	case TransactionQuorumCommitment:
-		err = deserializeNonSpendingTx(dec, &tx, tx.txType)
-	case TransactionSpork:
+	case TransactionQuorumCommitment,
+		TransactionSpork:
 		err = deserializeNonSpendingTx(dec, &tx, tx.txType)
 	default:
 		err = fmt.Errorf("unknown transaction type %d", tx.txType)
@@ -286,11 +285,7 @@ func deserializeTx(dec *decoder, tx *txn, txType TxType) error {
 
 	// read vExtraPayload
 	_, err = dec.readVarBytes()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // deserializeNonSpendingTx deserializes spork, quorum txs which have no inputs and
@@ -320,9 +315,5 @@ func deserializeNonSpendingTx(dec *decoder, tx *txn, txType TxType) error {
 	}
 
 	_, err = dec.readVarBytes()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/client/asset/firo/tx_deserialize.go
+++ b/client/asset/firo/tx_deserialize.go
@@ -34,9 +34,8 @@ const (
 	TransactionSpork                   = 7
 	TransactionLelantus                = 8
 	TransactionSpark                   = 9
-	// src/primitives/transaction.h
-	// Git says it is recent (3 weeks ago) and associated with the upcoming
-	// Spark names. Introduced in https://github.com/firoorg/firo/pull/1532
+	// TRANSACTION_ALIAS is a regular spark spend transaction, but contains
+	// additional info about a created/modified spark name.
 	TransactionAlias = 10
 )
 
@@ -227,10 +226,6 @@ func deserializeTransaction(r io.Reader) (*txn, error) {
 	default:
 		err = fmt.Errorf("unknown transaction type %d", tx.txType)
 	}
-
-	// TRANSACTION_ALIAS is a regular spark spend transaction, but contains
-	// additional info, it is spark name transaction, so in that tx besides
-	// spark spend outputs you also have data about created/modified spark name.
 
 	return &tx, err
 }

--- a/client/asset/firo/tx_deserialize.go
+++ b/client/asset/firo/tx_deserialize.go
@@ -1,0 +1,330 @@
+package firo
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+var byteOrder = binary.LittleEndian
+
+const (
+	// protocol version 0
+	pver uint32 = 0
+	// wire.maxTxInPerMessage
+	maxTxInPerMessage = wire.MaxMessagePayload/41 + 1
+	// wire.maxTxOutPerMessage
+	maxTxOutPerMessage = wire.MaxMessagePayload/wire.MinTxOutPayload + 1
+)
+
+var errNotYetImplemented = errors.New("not yet implemented")
+
+type TxType int
+
+const (
+	// Transaction types
+	TransactionNormal                  = 0
+	TransactionProviderRegister        = 1
+	TransactionProviderUpdateService   = 2
+	TransactionProviderUpdateRegistrar = 3
+	TransactionProviderUpdateRevoke    = 4
+	TransactionCoinbase                = 5
+	TransactionQuorumCommitment        = 6
+	TransactionSpork                   = 7
+	TransactionLelantus                = 8
+	TransactionSpark                   = 9
+	TransactionAlias                   = 10
+)
+
+type decoder struct {
+	buf [8]byte
+	rd  io.Reader
+	tee *bytes.Buffer // anything read from rd is Written to tee
+}
+
+func newDecoder(r io.Reader) *decoder {
+	return &decoder{rd: r}
+}
+
+func (d *decoder) Read(b []byte) (n int, err error) {
+	n, err = d.rd.Read(b)
+	if err != nil {
+		return 0, err
+	}
+	if d.tee != nil {
+		d.tee.Write(b)
+	}
+	return n, nil
+}
+
+func (d *decoder) readByte() (byte, error) {
+	b := d.buf[:1]
+	if _, err := io.ReadFull(d, b); err != nil {
+		return 0, err
+	}
+	return b[0], nil
+}
+
+func (d *decoder) readUint16() (uint16, error) {
+	b := d.buf[:2]
+	if _, err := io.ReadFull(d, b); err != nil {
+		return 0, err
+	}
+	return byteOrder.Uint16(b), nil
+}
+
+func (d *decoder) readUint32() (uint32, error) {
+	b := d.buf[:4]
+	if _, err := io.ReadFull(d, b); err != nil {
+		return 0, err
+	}
+	return byteOrder.Uint32(b), nil
+}
+
+func (d *decoder) readUint64() (uint64, error) {
+	b := d.buf[:]
+	if _, err := io.ReadFull(d, b); err != nil {
+		return 0, err
+	}
+	return byteOrder.Uint64(b), nil
+}
+
+// readOutPoint reads the next sequence of bytes from r as an OutPoint.
+func (d *decoder) readOutPoint(op *wire.OutPoint) error {
+	_, err := io.ReadFull(d, op.Hash[:])
+	if err != nil {
+		return err
+	}
+
+	op.Index, err = d.readUint32()
+	return err
+}
+
+// wire.ReadVarInt a.k.a. CompactSize, not VARINT
+// https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer
+func (d *decoder) readCompactSize() (uint64, error) {
+	// Compact Size
+	// size <  253        -- 1 byte
+	// size <= USHRT_MAX  -- 3 bytes  (253 + 2 bytes)
+	// size <= UINT_MAX   -- 5 bytes  (254 + 4 bytes)
+	// size >  UINT_MAX   -- 9 bytes  (255 + 8 bytes)
+	chSize, err := d.readByte()
+	if err != nil {
+		return 0, err
+	}
+	switch chSize {
+	case 253:
+		sz, err := d.readUint16()
+		if err != nil {
+			return 0, err
+		}
+		return uint64(sz), nil
+	case 254:
+		sz, err := d.readUint32()
+		if err != nil {
+			return 0, err
+		}
+		return uint64(sz), nil
+	case 255:
+		sz, err := d.readUint64()
+		if err != nil {
+			return 0, err
+		}
+		return sz, nil
+	default: // < 253
+		return uint64(chSize), nil
+	}
+}
+
+// readTxIn reads the next sequence of bytes from r as a transaction input.
+func (d *decoder) readTxIn(ti *wire.TxIn) error {
+	err := d.readOutPoint(&ti.PreviousOutPoint)
+	if err != nil {
+		return err
+	}
+
+	ti.SignatureScript, err = wire.ReadVarBytes(d, pver, wire.MaxMessagePayload, "sigScript")
+	if err != nil {
+		return err
+	}
+
+	ti.Sequence, err = d.readUint32()
+	return err
+}
+
+// readTxOut reads the next sequence of bytes from r as a transaction output.
+func (d *decoder) readTxOut(to *wire.TxOut) error {
+	v, err := d.readUint64()
+	if err != nil {
+		return err
+	}
+
+	pkScript, err := wire.ReadVarBytes(d, pver, wire.MaxMessagePayload, "pkScript")
+	if err != nil {
+		return err
+	}
+
+	to.Value = int64(v)
+	to.PkScript = pkScript
+
+	return nil
+}
+
+// readVarBytes reads the next sequence of bytes from r and returns them.
+func (d *decoder) readVarBytes() ([]byte, error) {
+	byteArray, err := wire.ReadVarBytes(d, pver, wire.MaxMessagePayload, "extra")
+	if err != nil {
+		return nil, err
+	}
+	return byteArray, nil
+}
+
+type txn struct {
+	msgTx  *wire.MsgTx
+	txType TxType
+}
+
+// deserializeTransaction deserializes a transaction
+func deserializeTransaction(r io.Reader) (*txn, error) {
+	tx := txn{
+		msgTx:  &wire.MsgTx{},
+		txType: 0,
+	}
+
+	dec := newDecoder(r)
+
+	fullVersion, err := dec.readUint32()
+	if err != nil {
+		return nil, err
+	}
+	ver := fullVersion & 0x0000ffff
+	typ := (fullVersion >> 16) & 0x0000ffff
+
+	tx.msgTx.Version = int32(ver)
+	tx.txType = TxType(typ)
+
+	switch tx.txType {
+	case TransactionNormal,
+		TransactionProviderRegister,
+		TransactionProviderUpdateService,
+		TransactionProviderUpdateRegistrar,
+		TransactionProviderUpdateRevoke,
+		TransactionCoinbase,
+		// TransactionSpork,
+		TransactionLelantus,
+		TransactionSpark:
+		{
+			deserializeTx(dec, &tx, tx.txType)
+		}
+	case TransactionQuorumCommitment:
+		err = deserializeQuorumTx(dec, &tx)
+	case TransactionSpork:
+		err = errNotYetImplemented // checking with levon
+	case TransactionAlias:
+		err = fmt.Errorf("TRANSACTION_ALIAS transaction type - wtf")
+	default:
+		err = fmt.Errorf("unknown transaction type %d", tx.txType)
+	}
+
+	return &tx, err
+}
+
+// deserializeTx deserializes a transaction
+func deserializeTx(dec *decoder, tx *txn, txType TxType) error {
+	count, err := dec.readCompactSize()
+	if err != nil {
+		return err
+	}
+
+	if count == 0 {
+		return fmt.Errorf("input count is 0 -- but no segwit transactions for Firo")
+	}
+
+	if count > maxTxInPerMessage {
+		return fmt.Errorf("too many transaction inputs to fit into "+
+			"max message size [count %d, max %d]", count, maxTxInPerMessage)
+	}
+
+	tx.msgTx.TxIn = make([]*wire.TxIn, count)
+	for i := range tx.msgTx.TxIn {
+		txIn := &wire.TxIn{}
+		err = dec.readTxIn(txIn)
+		if err != nil {
+			return err
+		}
+		tx.msgTx.TxIn[i] = txIn
+	}
+
+	count, err = dec.readCompactSize()
+	if err != nil {
+		return err
+	}
+	if count > maxTxOutPerMessage {
+		return fmt.Errorf("too many transactions outputs to fit into "+
+			"max message size [count %d, max %d]", count, maxTxOutPerMessage)
+	}
+
+	tx.msgTx.TxOut = make([]*wire.TxOut, count)
+	for i := range tx.msgTx.TxOut {
+		txOut := &wire.TxOut{}
+		err = dec.readTxOut(txOut)
+		if err != nil {
+			return err
+		}
+		tx.msgTx.TxOut[i] = txOut
+	}
+
+	tx.msgTx.LockTime, err = dec.readUint32()
+	if err != nil {
+		return err
+	}
+
+	if txType == TransactionNormal {
+		return nil
+	}
+
+	// read vExtraPayload
+	_, err = dec.readVarBytes()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deserializeQuorumTx deserializes a quorum tx with no inputs and no outputs
+func deserializeQuorumTx(dec *decoder, tx *txn) error {
+	count, err := dec.readCompactSize()
+	if err != nil {
+		return err
+	}
+
+	if count != 0 {
+		return fmt.Errorf("quorum tx expected 0 txins - got %d", count)
+	}
+
+	count, err = dec.readCompactSize()
+	if err != nil {
+		return err
+	}
+
+	if count != 0 {
+		return fmt.Errorf("quorum tx expected 0 txouts - got %d", count)
+	}
+
+	tx.msgTx.LockTime, err = dec.readUint32()
+	if err != nil {
+		return err
+	}
+
+	_, err = dec.readVarBytes()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/client/asset/firo/tx_deserialize.go
+++ b/client/asset/firo/tx_deserialize.go
@@ -1,7 +1,6 @@
 package firo
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -42,7 +41,6 @@ const (
 type decoder struct {
 	buf [8]byte
 	rd  io.Reader
-	tee *bytes.Buffer // anything read from rd is Written to tee
 }
 
 func newDecoder(r io.Reader) *decoder {
@@ -53,9 +51,6 @@ func (d *decoder) Read(b []byte) (n int, err error) {
 	n, err = d.rd.Read(b)
 	if err != nil {
 		return 0, err
-	}
-	if d.tee != nil {
-		d.tee.Write(b)
 	}
 	return n, nil
 }

--- a/dex/networks/firo/params.go
+++ b/dex/networks/firo/params.go
@@ -30,6 +30,13 @@ func mustHash(hash string) *chainhash.Hash {
 	return h
 }
 
+// Clone ports.
+var NetPorts = btc.NetPorts{
+	Mainnet: "8888",
+	Testnet: "18888",
+	Simnet:  "28888",
+}
+
 var (
 	UnitInfo = dex.UnitInfo{
 		AtomicUnit: "Sats",

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -100,7 +100,7 @@ checkmark in the "native" column, no external software is required.
 | Dogecoin     | x      | [v1.14.7.0](https://dogecoin.com/)                          | x                                                             |                                                                                                   |
 | Zcash        | x      | [v5.4.2](https://z.cash/download/)                          | x                                                             |                                                                                                   |
 | Dash         | x      | [v20.1.1](https://github.com/dashpay/dash/releases)         | x                                                             |                                                                                                   |
-| Firo         | x      | [v0.14.14.0](https://github.com/firoorg/firo/releases)      | [v4.1.5.5](https://github.com/firoorg/electrum-firo/releases) |                                                                                                   |
+| Firo         | x      | [v0.14.14.1](https://github.com/firoorg/firo/releases)      | [v4.1.5.5](https://github.com/firoorg/electrum-firo/releases) |                                                                                                   |
 
 
 # Project History


### PR DESCRIPTION
	Fix: #3252

    De-serialize:
	- header: for either regtest, mainnet or testnet
	- minimally: all Firo transaction types to reach the start of the next transaction in a block stream.
	- fully: Normal transparent transactions

	Return de-serialized header and any Normal transparent
	transactions as wire.MsgTx's