### PR TITLE
multi: Keep trying init with the same secret.

### DIFF
--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -118,7 +118,6 @@ type testNode struct {
 	signDataErr     error
 	privKey         *ecdsa.PrivateKey
 	swapVers        map[uint32]struct{} // For SwapConfirmations -> swap. TODO for other contractor methods
-	swapMap         map[[32]byte]*dexeth.SwapState
 	refundable      bool
 	baseFee         *big.Int
 	tip             *big.Int
@@ -4392,9 +4391,6 @@ func testRefundReserves(t *testing.T, assetID uint32) {
 	node.bal = dexeth.GweiToWei(1e9)
 	node.refundable = true
 	node.swapVers = map[uint32]struct{}{0: {}}
-
-	var secretHash [32]byte
-	node.swapMap = map[[32]byte]*dexeth.SwapState{secretHash: {}}
 
 	feeWallet := eth
 	gasesV0 := eth.versionedGases[0]

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -1765,3 +1765,10 @@ func (e *WalletEmitter) ActionResolved(uniqueID string) {
 		UniqueID: uniqueID,
 	})
 }
+
+// InitChecker is an account wallet that checks the status of a swap init.
+type InitChecker interface {
+	// AlreadyInitialized returns if the swap was already initialized and
+	// some data needed to interact with the contract later.
+	AlreadyInitialized(assetVersion uint32, contract *Contract) (initialized bool, zeroHash, contractData []byte, err error)
+}

--- a/dex/testing/eth/harness.sh
+++ b/dex/testing/eth/harness.sh
@@ -251,11 +251,6 @@ cat > "${NODES_ROOT}/test_block1_hash.txt" <<EOF
 ${TEST_BLOCK1_HASH}
 EOF
 
-# Miner
-tmux new-window -t $SESSION:5 -n "miner" $SHELL
-tmux send-keys -t $SESSION:5 "cd ${NODES_ROOT}/harness-ctl" C-m
-tmux send-keys -t $SESSION:5 "watch -n 15 ./mine-alpha 1" C-m
-
 # Reenable history and attach to the control session.
 tmux select-window -t $SESSION:0
 tmux send-keys -t $SESSION:0 "set -o history" C-m


### PR DESCRIPTION
There was a problem reported with an init was sent twice. This was due to a nonce issue. This pr ignores that and attempts to prevent a second init being sent regardless. ~It currently doesn't work because I'm unsure how to get the txid of the swap and server wants that. I think @martonp said something about this being possible before, by examining the data from tx history, but unsure. Or we could just fail, which seems like a waste. Or change the server logic.~