### PR TITLE
client: Always set default config values.

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -147,7 +147,7 @@ var (
 				Description: "Allow split funding transactions that pre-size outputs to " +
 					"prevent excessive overlock.",
 				IsBoolean:    true,
-				DefaultValue: true,
+				DefaultValue: "true",
 			},
 		},
 		{
@@ -156,7 +156,7 @@ var (
 				DisplayName: "Multi split buffer",
 				Description: "Add an integer percent buffer to split output amounts to " +
 					"facilitate output reuse. This is only required for quote assets.",
-				DefaultValue: 5,
+				DefaultValue: "5",
 				DependsOn:    multiSplitKey,
 			},
 			QuoteAssetOnly: true,
@@ -227,7 +227,7 @@ func apiFallbackOpt(defaultV bool) *asset.ConfigOption {
 			"This is useful as a fallback for SPV wallets and RPC wallets " +
 			"that have recently been started.",
 		IsBoolean:    true,
-		DefaultValue: defaultV,
+		DefaultValue: strconv.FormatBool(defaultV),
 	}
 }
 
@@ -239,7 +239,7 @@ func CommonConfigOpts(symbol string /* upper-case */, withApiFallback bool) []*a
 			DisplayName: "Fallback fee rate",
 			Description: fmt.Sprintf("The fee rate to use for sending or withdrawing funds and fee payment when"+
 				" estimatesmartfee is not available. Units: %s/kB", symbol),
-			DefaultValue: defaultFee * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(defaultFee*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "feeratelimit",
@@ -248,7 +248,7 @@ func CommonConfigOpts(symbol string /* upper-case */, withApiFallback bool) []*a
 				"pay on swap transactions. If feeratelimit is lower than a market's "+
 				"maxfeerate, you will not be able to trade on that market with this "+
 				"wallet.  Units: %s/kB", symbol),
-			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(defaultFeeRateLimit*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "redeemconftarget",
@@ -256,7 +256,7 @@ func CommonConfigOpts(symbol string /* upper-case */, withApiFallback bool) []*a
 			Description: "The target number of blocks for the redeem transaction " +
 				"to be mined. Used to set the transaction's fee rate. " +
 				"(default: 2 blocks)",
-			DefaultValue: defaultRedeemConfTarget,
+			DefaultValue: strconv.FormatUint(defaultRedeemConfTarget, 10),
 		},
 		{
 			Key:         "txsplit",
@@ -268,7 +268,7 @@ func CommonConfigOpts(symbol string /* upper-case */, withApiFallback bool) []*a
 				"or the order is canceled. This an extra transaction for which network " +
 				"mining fees are paid.",
 			IsBoolean:    true,
-			DefaultValue: false,
+			DefaultValue: "false",
 		},
 	}
 
@@ -2158,7 +2158,7 @@ func (btc *baseWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, error) {
 				Key:          swapFeeBumpKey,
 				DisplayName:  "Faster Swaps",
 				Description:  desc,
-				DefaultValue: 1.0,
+				DefaultValue: "1.0",
 			},
 			XYRange: &asset.XYRange{
 				Start: asset.XYRangePoint{
@@ -2224,7 +2224,7 @@ func (btc *baseWallet) splitOption(req *asset.PreSwapForm, utxos []*CompositeUTX
 			Key:           splitKey,
 			DisplayName:   "Pre-size Funds",
 			IsBoolean:     true,
-			DefaultValue:  btc.useSplitTx(), // not nil interface
+			DefaultValue:  strconv.FormatBool(btc.useSplitTx()), // not nil interface
 			ShowByDefault: true,
 		},
 		Boolean: &asset.BooleanConfig{},
@@ -2250,7 +2250,7 @@ func (btc *baseWallet) splitOption(req *asset.PreSwapForm, utxos []*CompositeUTX
 		opt.Boolean.Reason = fmt.Sprintf("avoids no %s overlock for this order (ignored)", symbol)
 		opt.Description = fmt.Sprintf("A split transaction for this order avoids no %s overlock, "+
 			"but adds additional fees.", symbol)
-		opt.DefaultValue = false
+		opt.DefaultValue = "false"
 		return opt // not enabled by default, but explain why
 	}
 
@@ -2405,7 +2405,7 @@ func (btc *baseWallet) preRedeem(numLots, feeSuggestion uint64, options map[stri
 			Key:          redeemFeeBumpFee,
 			DisplayName:  "Change Redemption Fees",
 			Description:  "Bump the redemption transaction fees up to 2x for faster confirmation of your redemption transaction.",
-			DefaultValue: 1.0,
+			DefaultValue: "1.0",
 		},
 		XYRange: &asset.XYRange{
 			Start: asset.XYRangePoint{

--- a/client/asset/dash/dash.go
+++ b/client/asset/dash/dash.go
@@ -5,6 +5,7 @@ package dash
 
 import (
 	"fmt"
+	"strconv"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/asset/btc"
@@ -29,7 +30,7 @@ var (
 			Key:          "fallbackfee",
 			DisplayName:  "Fallback fee rate",
 			Description:  "Dash's 'fallbackfee' rate. Units: DASH/kB",
-			DefaultValue: dexdash.DefaultFee * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(dexdash.DefaultFee*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "feeratelimit",
@@ -38,7 +39,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: DASH/kB",
-			DefaultValue: dexdash.DefaultFeeRateLimit * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(dexdash.DefaultFeeRateLimit*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "redeemconftarget",
@@ -46,7 +47,7 @@ var (
 			Description: "The target number of blocks for the redeem transaction " +
 				"to be mined. Used to set the transaction's fee rate. " +
 				"(default: 2 blocks)",
-			DefaultValue: defaultRedeemConfTarget,
+			DefaultValue: strconv.FormatUint(defaultRedeemConfTarget, 10),
 		},
 		{
 			Key:         "txsplit",
@@ -56,7 +57,7 @@ var (
 				"during match settlement, or the order is canceled. This an extra transaction for which network mining fees are paid. " +
 				"Used only for standing-type orders, e.g. limit orders without immediate time-in-force.",
 			IsBoolean:    true,
-			DefaultValue: true,
+			DefaultValue: "true",
 		},
 	}...)
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -132,7 +132,7 @@ var (
 			DisplayName: "Fallback fee rate",
 			Description: "The fee rate to use for fee payment and withdrawals when " +
 				"estimatesmartfee is not available. Units: DCR/kB",
-			DefaultValue: defaultFee * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(defaultFee*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "feeratelimit",
@@ -141,7 +141,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: DCR/kB",
-			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(defaultFeeRateLimit*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "redeemconftarget",
@@ -149,13 +149,13 @@ var (
 			Description: "The target number of blocks for the redeem transaction " +
 				"to get a confirmation. Used to set the transaction's fee rate." +
 				" (default: 1 block)",
-			DefaultValue: defaultRedeemConfTarget,
+			DefaultValue: strconv.FormatUint(defaultRedeemConfTarget, 10),
 		},
 		{
 			Key:          "gaplimit",
 			DisplayName:  "Address Gap Limit",
 			Description:  "The gap limit for used address discovery",
-			DefaultValue: wallet.DefaultGapLimit,
+			DefaultValue: strconv.FormatUint(uint64(wallet.DefaultGapLimit), 10),
 		},
 		{
 			Key:         "txsplit",
@@ -167,7 +167,7 @@ var (
 				"the order is canceled. This an extra transaction for which network " +
 				"mining fees are paid.",
 			IsBoolean:    true,
-			DefaultValue: true, // cheap fees, helpful for bond reserves, and adjustable at order-time
+			DefaultValue: "true", // cheap fees, helpful for bond reserves, and adjustable at order-time
 		},
 		{
 			Key:         "apifeefallback",
@@ -176,7 +176,7 @@ var (
 				"This is useful as a fallback for SPV wallets and RPC wallets " +
 				"that have recently been started.",
 			IsBoolean:    true,
-			DefaultValue: true,
+			DefaultValue: "true",
 		},
 	}
 
@@ -234,7 +234,7 @@ var (
 				Description: "Allow split funding transactions that pre-size outputs to " +
 					"prevent excessive overlock.",
 				IsBoolean:    true,
-				DefaultValue: true,
+				DefaultValue: "true",
 			},
 		},
 		{
@@ -243,7 +243,7 @@ var (
 				DisplayName: "Multi split buffer",
 				Description: "Add an integer percent buffer to split output amounts to " +
 					"facilitate output reuse. This is only required for quote assets.",
-				DefaultValue: 5,
+				DefaultValue: "5",
 				DependsOn:    multiSplitKey,
 			},
 			QuoteAssetOnly: true,
@@ -1269,8 +1269,8 @@ func (dcr *ExchangeWallet) SetBondReserves(reserves uint64) {
 func (dcr *ExchangeWallet) FeeRate() uint64 {
 	const confTarget = 2 // 1 historically gives crazy rates
 	rate, err := dcr.feeRate(confTarget)
-	if err != nil && dcr.network != dex.Simnet { // log and return 0
-		dcr.log.Errorf("feeRate error: %v", err)
+	if err != nil && dcr.network != dex.Simnet {
+		dcr.log.Debugf("feeRate error: %v", err)
 	}
 	return rate
 }
@@ -1653,7 +1653,7 @@ func (dcr *ExchangeWallet) PreSwap(req *asset.PreSwapForm) (*asset.PreSwap, erro
 				Key:          swapFeeBumpKey,
 				DisplayName:  "Faster Swaps",
 				Description:  desc,
-				DefaultValue: 1.0,
+				DefaultValue: "1.0",
 			},
 			XYRange: &asset.XYRange{
 				Start: asset.XYRangePoint{
@@ -1716,7 +1716,7 @@ func (dcr *ExchangeWallet) splitOption(req *asset.PreSwapForm, utxos []*composit
 			Key:           splitKey,
 			DisplayName:   "Pre-size Funds",
 			IsBoolean:     true,
-			DefaultValue:  dcr.config().useSplitTx, // not nil interface
+			DefaultValue:  strconv.FormatBool(dcr.config().useSplitTx), // not nil interface
 			ShowByDefault: true,
 		},
 		Boolean: &asset.BooleanConfig{},
@@ -1740,7 +1740,7 @@ func (dcr *ExchangeWallet) splitOption(req *asset.PreSwapForm, utxos []*composit
 	if !splitUsed || splitLocked >= noSplitLocked { // locked check should be redundant
 		opt.Boolean.Reason = "avoids no DCR overlock for this order (ignored)"
 		opt.Description = "A split transaction for this order avoids no DCR overlock, but adds additional fees."
-		opt.DefaultValue = false
+		opt.DefaultValue = "false"
 		return opt // not enabled by default, but explain why
 	}
 
@@ -1797,7 +1797,7 @@ func (dcr *ExchangeWallet) preRedeem(numLots, feeSuggestion uint64, options map[
 			Key:          redeemFeeBumpFee,
 			DisplayName:  "Faster Redemption",
 			Description:  "Bump the redemption transaction fees up to 2x for faster confirmations on your redemption transaction.",
-			DefaultValue: 1.0,
+			DefaultValue: "1.0",
 		},
 		XYRange: &asset.XYRange{
 			Start: asset.XYRangePoint{

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -151,6 +151,7 @@ func tNewWalletMonitorBlocks(monitorBlocks bool) (*ExchangeWallet, *tRPCClient, 
 		shutdown()
 		panic(err.Error())
 	}
+	wallet.connected.Store(true)
 	rpcw := &rpcWallet{
 		rpcClient: client,
 		log:       log,

--- a/client/asset/dgb/dgb.go
+++ b/client/asset/dgb/dgb.go
@@ -5,6 +5,7 @@ package dgb
 
 import (
 	"fmt"
+	"strconv"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/asset/btc"
@@ -36,7 +37,7 @@ var (
 			Key:          "fallbackfee",
 			DisplayName:  "Fallback fee rate",
 			Description:  "DigiByte's 'fallbackfee' rate. Units: DGB/kB",
-			DefaultValue: dexdgb.DefaultFee * 1000 / 1e8, // higher than BTC default
+			DefaultValue: strconv.FormatFloat(dexdgb.DefaultFee*1000/1e8, 'f', -1, 64), // higher than BTC default
 		},
 		{
 			Key:         "feeratelimit",
@@ -45,7 +46,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: BTC/kB",
-			DefaultValue: dexdgb.DefaultFeeRateLimit * 1000 / 1e8, // higher than BTC default
+			DefaultValue: strconv.FormatFloat(dexdgb.DefaultFeeRateLimit*1000/1e8, 'f', -1, 64), // higher than BTC default
 		},
 		{
 			Key:         "redeemconftarget",
@@ -53,7 +54,7 @@ var (
 			Description: "The target number of blocks for the redeem transaction " +
 				"to be mined. Used to set the transaction's fee rate. " +
 				"(default: 2 blocks)",
-			DefaultValue: defaultRedeemConfTarget,
+			DefaultValue: strconv.FormatUint(defaultRedeemConfTarget, 10),
 		},
 		{
 			Key:         "txsplit",
@@ -63,7 +64,7 @@ var (
 				"during match settlement, or the order is canceled. This an extra transaction for which network mining fees are paid. " +
 				"Used only for standing-type orders, e.g. limit orders without immediate time-in-force.",
 			IsBoolean:    true,
-			DefaultValue: true, // low fee, fast chain
+			DefaultValue: "true", // low fee, fast chain
 		}, // no ExternalFeeEstimator, so no apifeefallback option
 	}...)
 	// WalletInfo defines some general information about a DigiByte wallet.

--- a/client/asset/doge/doge.go
+++ b/client/asset/doge/doge.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strconv"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/asset/btc"
@@ -56,7 +57,7 @@ var (
 			Key:          fallbackFeeKey,
 			DisplayName:  "Fallback fee rate",
 			Description:  "Dogecoin's 'fallbackfee' rate. Units: DOGE/kB",
-			DefaultValue: dexdoge.DefaultFee * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(dexdoge.DefaultFee*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "feeratelimit",
@@ -65,7 +66,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: BTC/kB",
-			DefaultValue: dexdoge.DefaultFeeRateLimit * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(dexdoge.DefaultFeeRateLimit*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "txsplit",
@@ -83,7 +84,7 @@ var (
 				"This is useful as a fallback for SPV wallets and RPC wallets " +
 				"that have recently been started.",
 			IsBoolean:    true,
-			DefaultValue: true,
+			DefaultValue: "true",
 		},
 	}
 	// WalletInfo defines some general information about a Dogecoin wallet.

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -127,7 +127,7 @@ var (
 				"pay on swap transactions. If gasfeelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: gwei / gas",
-			DefaultValue: defaultGasFeeLimit,
+			DefaultValue: strconv.FormatUint(defaultGasFeeLimit, 10),
 		},
 	}
 	RPCOpts = []*asset.ConfigOption{

--- a/client/asset/firo/firo.go
+++ b/client/asset/firo/firo.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -43,7 +44,7 @@ var (
 			Key:          "fallbackfee",
 			DisplayName:  "Fallback fee rate",
 			Description:  "Firo's 'fallbackfee' rate. Units: FIRO/kB",
-			DefaultValue: dexfiro.DefaultFee * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(dexfiro.DefaultFee*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "feeratelimit",
@@ -52,7 +53,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: FIRO/kB",
-			DefaultValue: dexfiro.DefaultFeeRateLimit * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(dexfiro.DefaultFeeRateLimit*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "txsplit",

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -336,7 +336,7 @@ type ConfigOption struct {
 	Key          string `json:"key"`
 	DisplayName  string `json:"displayname"`
 	Description  string `json:"description"`
-	DefaultValue any    `json:"default"`
+	DefaultValue string `json:"default"`
 	// If MaxValue/MinValue are set to the string "now" for a date config, the
 	// UI will display the current date.
 	MaxValue          any `json:"max"`

--- a/client/asset/polygon/polygon.go
+++ b/client/asset/polygon/polygon.go
@@ -74,7 +74,7 @@ var (
 				"pay on swap transactions. If gasfeelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: gwei / gas",
-			DefaultValue: defaultGasFeeLimit,
+			DefaultValue: strconv.FormatUint(defaultGasFeeLimit, 10),
 		},
 	}
 	WalletInfo = asset.WalletInfo{

--- a/client/asset/zcl/zcl.go
+++ b/client/asset/zcl/zcl.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/asset/btc"
@@ -65,7 +66,7 @@ var (
 			Key:          "fallbackfee",
 			DisplayName:  "Fallback fee rate",
 			Description:  "Zclassic's 'fallbackfee' rate. Units: ZEC/kB",
-			DefaultValue: defaultFee * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(defaultFee*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "feeratelimit",
@@ -74,7 +75,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: BTC/kB",
-			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(defaultFeeRateLimit*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "txsplit",

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -105,7 +106,7 @@ var (
 			Key:          "fallbackfee",
 			DisplayName:  "Fallback fee rate",
 			Description:  "Zcash's 'fallbackfee' rate. Units: ZEC/kB",
-			DefaultValue: defaultFee * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(defaultFee*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "feeratelimit",
@@ -114,7 +115,7 @@ var (
 				"pay on swap transactions. If feeratelimit is lower than a market's " +
 				"maxfeerate, you will not be able to trade on that market with this " +
 				"wallet.  Units: BTC/kB",
-			DefaultValue: defaultFeeRateLimit * 1000 / 1e8,
+			DefaultValue: strconv.FormatFloat(defaultFeeRateLimit*1000/1e8, 'f', -1, 64),
 		},
 		{
 			Key:         "txsplit",
@@ -1167,7 +1168,7 @@ func (w *zecWallet) splitOption(req *asset.PreSwapForm, utxos []*btc.CompositeUT
 			Key:           "swapsplit",
 			DisplayName:   "Pre-size Funds",
 			IsBoolean:     true,
-			DefaultValue:  w.useSplitTx(), // not nil interface
+			DefaultValue:  strconv.FormatBool(w.useSplitTx()), // not nil interface
 			ShowByDefault: true,
 		},
 		Boolean: &asset.BooleanConfig{},
@@ -1192,7 +1193,7 @@ func (w *zecWallet) splitOption(req *asset.PreSwapForm, utxos []*btc.CompositeUT
 		opt.Boolean.Reason = "avoids no ZEC overlock for this order (ignored)"
 		opt.Description = "A split transaction for this order avoids no ZEC overlock, " +
 			"but adds additional fees."
-		opt.DefaultValue = false
+		opt.DefaultValue = "false"
 		return opt // not enabled by default, but explain why
 	}
 

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -2965,22 +2965,37 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 		}()
 	}
 
+	// Ensure default settings are always supplied to the wallet as they
+	// may not be saved yet.
+	walletDef, err := asset.WalletDef(assetID, dbWallet.Type)
+	if err != nil {
+		return nil, newError(assetSupportErr, "asset.WalletDef error: %w", err)
+	}
+	defaultValues := make(map[string]string, len(walletDef.ConfigOpts))
+	for _, option := range walletDef.ConfigOpts {
+		defaultValues[strings.ToLower(option.Key)] = option.DefaultValue
+	}
+	settings := dbWallet.Settings
+	for k, v := range defaultValues {
+		if _, has := settings[k]; !has {
+			settings[k] = v
+		}
+	}
+
 	log := c.log.SubLogger(unbip(assetID))
 	var w asset.Wallet
-	var err error
 	if token == nil {
-
 		walletCfg := &asset.WalletConfig{
 			Type:        dbWallet.Type,
-			Settings:    dbWallet.Settings,
+			Settings:    settings,
 			Emit:        asset.NewWalletEmitter(c.notes, assetID, log),
 			PeersChange: peersChange,
 			DataDir:     c.assetDataDirectory(assetID),
 		}
 
-		walletCfg.Settings[asset.SpecialSettingActivelyUsed] =
+		settings[asset.SpecialSettingActivelyUsed] =
 			strconv.FormatBool(c.assetHasActiveOrders(dbWallet.AssetID))
-		defer delete(walletCfg.Settings, asset.SpecialSettingActivelyUsed)
+		defer delete(settings, asset.SpecialSettingActivelyUsed)
 
 		w, err = asset.OpenWallet(assetID, walletCfg, log, c.net)
 	} else {
@@ -2997,7 +3012,7 @@ func (c *Core) loadWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 
 		w, err = tokenMaster.OpenTokenWallet(&asset.TokenConfig{
 			AssetID:     assetID,
-			Settings:    dbWallet.Settings,
+			Settings:    settings,
 			Emit:        asset.NewWalletEmitter(c.notes, assetID, log),
 			PeersChange: peersChange,
 		})

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -237,8 +237,8 @@ func handleNewWallet(s *RPCServer, params *RawParams) *msgjson.ResponsePayload {
 
 	// Apply default config options if they exist.
 	for _, opt := range walletDef.ConfigOpts {
-		if _, has := form.config[opt.Key]; !has && opt.DefaultValue != nil {
-			form.config[opt.Key] = fmt.Sprintf("%v", opt.DefaultValue)
+		if _, has := form.config[opt.Key]; !has {
+			form.config[opt.Key] = opt.DefaultValue
 		}
 	}
 

--- a/client/webserver/live_test.go
+++ b/client/webserver/live_test.go
@@ -714,7 +714,7 @@ func (c *TCore) PreOrder(*core.TradeForm) (*core.OrderEstimate, error) {
 						Key:          "moredough",
 						DisplayName:  "Get More Dough",
 						Description:  "Cast a magical incantation to double the amount of XYZ received.",
-						DefaultValue: true,
+						DefaultValue: "true",
 					},
 					Boolean: &asset.BooleanConfig{
 						Reason: "Cuz why not?",
@@ -725,7 +725,7 @@ func (c *TCore) PreOrder(*core.TradeForm) (*core.OrderEstimate, error) {
 						Key:          "awesomeness",
 						DisplayName:  "More Awesomeness",
 						Description:  "Crank up the awesomeness for next-level trading.",
-						DefaultValue: 1.0,
+						DefaultValue: "1.0",
 					},
 					XYRange: &asset.XYRange{
 						Start: asset.XYRangePoint{
@@ -755,7 +755,7 @@ func (c *TCore) PreOrder(*core.TradeForm) (*core.OrderEstimate, error) {
 						Key:          "lesshassle",
 						DisplayName:  "Smoother Experience",
 						Description:  "Select this option for a super-elite VIP DEX experience.",
-						DefaultValue: false,
+						DefaultValue: "false",
 					},
 					Boolean: &asset.BooleanConfig{
 						Reason: "Half the time, twice the service",


### PR DESCRIPTION
Existing wallets aren't having default settings set when loading. The settings are only saved when creating or re configuring. This checks every load that the wallet has all defaults.