### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2521,12 +2521,9 @@ func (btc *baseWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, ui
 			// TODO
 			// 1.0: Error when no suggestion.
 			// return nil, nil, fmt.Errorf("cannot do a split transaction without a fee rate suggestion from the server")
-			splitFeeRate = btc.targetFeeRateWithFallback(btc.redeemConfTarget(), 0)
 			// We PreOrder checked this as <= MaxFeeRate, so use that as an
 			// upper limit.
-			if splitFeeRate > ord.MaxFeeRate {
-				splitFeeRate = ord.MaxFeeRate
-			}
+			splitFeeRate = min(btc.targetFeeRateWithFallback(btc.redeemConfTarget(), 0), ord.MaxFeeRate)
 		}
 		splitFeeRate, err = calcBumpedRate(splitFeeRate, customCfg.FeeBump)
 		if err != nil {

--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -498,10 +498,7 @@ func (ew *electrumWallet) MedianTime() (time.Time, error) {
 }
 
 func (ew *electrumWallet) calcMedianTime(ctx context.Context, height int64) (time.Time, error) {
-	startHeight := height - medianTimeBlocks + 1
-	if startHeight < 0 {
-		startHeight = 0
-	}
+	startHeight := max(height-medianTimeBlocks+1, 0)
 
 	// TODO: check a block hash => median time cache
 

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -1929,12 +1929,9 @@ func (dcr *ExchangeWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes
 			// TODO
 			// 1.0: Error when no suggestion.
 			// return nil, false, fmt.Errorf("cannot do a split transaction without a fee rate suggestion from the server")
-			rawFeeRate = dcr.targetFeeRateWithFallback(cfg.redeemConfTarget, 0)
 			// We PreOrder checked this as <= MaxFeeRate, so use that as an
 			// upper limit.
-			if rawFeeRate > ord.MaxFeeRate {
-				rawFeeRate = ord.MaxFeeRate
-			}
+			rawFeeRate = min(dcr.targetFeeRateWithFallback(cfg.redeemConfTarget, 0), ord.MaxFeeRate)
 		}
 		splitFeeRate, err := calcBumpedRate(rawFeeRate, customCfg.FeeBump)
 		if err != nil {
@@ -4853,10 +4850,7 @@ func (dcr *ExchangeWallet) SyncStatus() (ss *asset.SyncStatus, err error) {
 	dcr.rescan.RUnlock()
 
 	if rescanProgress != nil {
-		height := dcr.cachedBestBlock().height
-		if height < rescanProgress.scannedThrough {
-			height = rescanProgress.scannedThrough
-		}
+		height := max(dcr.cachedBestBlock().height, rescanProgress.scannedThrough)
 		txHeight := uint64(rescanProgress.scannedThrough)
 		return &asset.SyncStatus{
 			Synced:         false,

--- a/client/core/bond.go
+++ b/client/core/bond.go
@@ -285,11 +285,8 @@ func (c *Core) minBondReserves(dc *dexConnection, bondAsset *BondAsset) uint64 {
 			continue
 		}
 
-		tiers := bond.Amount / ba.Amt
 		// We won't count any active bond strength > our tier target.
-		if tiers > targetTier-tierSum {
-			tiers = targetTier - tierSum
-		}
+		tiers := min(bond.Amount/ba.Amt, targetTier-tierSum)
 		tierSum += tiers
 		activeTiers = append(activeTiers, [2]uint64{weakTime, tiers})
 		if tierSum == targetTier {
@@ -443,10 +440,7 @@ func (c *Core) bondStateOfDEX(dc *dexConnection, bondCfg *dexBondCfg) *dexAcctBo
 	reportedServerTier := state.Rep.EffectiveTier()
 	if reportedServerTier < expectedServerTier {
 		state.toComp = expectedServerTier - reportedServerTier
-		penaltyCompRemainder := int64(dc.acct.penaltyComps) - state.Compensation
-		if penaltyCompRemainder <= 0 {
-			penaltyCompRemainder = 0
-		}
+		penaltyCompRemainder := max(int64(dc.acct.penaltyComps)-state.Compensation, 0)
 		if state.toComp > penaltyCompRemainder {
 			state.toComp = penaltyCompRemainder
 		}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -9337,10 +9337,8 @@ func (c *Core) schedTradeTick(tracker *trackedTrade) {
 	}
 
 	// Schedule a tick for this trade.
-	delay := 2*time.Second + time.Duration(numMatches)*time.Second/10 // 1 sec extra delay for every 10 active matches
-	if delay > 5*time.Second {
-		delay = 5 * time.Second
-	}
+	// 1 sec extra delay for every 10 active matches
+	delay := min(2*time.Second+time.Duration(numMatches)*time.Second/10, 5*time.Second)
 	c.log.Debugf("Waiting %v to tick trade %v with %d active matches", delay, oid, numMatches)
 	c.tickSched[oid] = time.AfterFunc(delay, func() {
 		c.tickSchedMtx.Lock()

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -2603,12 +2603,10 @@ func (c *Core) sendInitAsync(t *trackedTrade, match *matchTracker, coinID, contr
 		}
 		// The DEX may wait up to its configured broadcast timeout, but we will
 		// retry on timeout or other error.
-		timeout := t.broadcastTimeout() / 4
-		if timeout < time.Minute { // sane minimum, or if we lack server config for any reason
-			// Send would fail right away anyway if the server is really down,
-			// but at least attempt it with a non-zero timeout.
-			timeout = time.Minute
-		}
+		// sane minimum, or if we lack server config for any reason
+		// Send would fail right away anyway if the server is really down,
+		// but at least attempt it with a non-zero timeout.
+		timeout := max(t.broadcastTimeout()/4, time.Minute)
 		err = t.dc.signAndRequest(init, msgjson.InitRoute, ack, timeout)
 		if err != nil {
 			var msgErr *msgjson.Error
@@ -2896,12 +2894,10 @@ func (c *Core) sendRedeemAsync(t *trackedTrade, match *matchTracker, coinID, sec
 		ack := new(msgjson.Acknowledgement)
 		// The DEX may wait up to its configured broadcast timeout, but we will
 		// retry on timeout or other error.
-		timeout := t.broadcastTimeout() / 4
-		if timeout < time.Minute { // sane minimum, or if we lack server config for any reason
-			// Send would fail right away anyway if the server is really down,
-			// but at least attempt it with a non-zero timeout.
-			timeout = time.Minute
-		}
+		// sane minimum, or if we lack server config for any reason
+		// Send would fail right away anyway if the server is really down,
+		// but at least attempt it with a non-zero timeout.
+		timeout := max(t.broadcastTimeout()/4, time.Minute)
 		err = t.dc.signAndRequest(msgRedeem, msgjson.RedeemRoute, ack, timeout)
 		if err != nil {
 			var msgErr *msgjson.Error

--- a/client/db/bolt/db.go
+++ b/client/db/bolt/db.go
@@ -2175,10 +2175,7 @@ func (db *BoltDB) DeleteInactiveOrders(ctx context.Context, olderThan *time.Time
 		}
 
 		// Check if this is the last batch.
-		end := i + batchSize
-		if end > len(keys) {
-			end = len(keys)
-		}
+		end := min(i+batchSize, len(keys))
 
 		nDeletedBatch := 0
 		err := db.Update(func(tx *bbolt.Tx) error {
@@ -2335,10 +2332,7 @@ func (db *BoltDB) DeleteInactiveMatches(ctx context.Context, olderThan *time.Tim
 		}
 
 		// Check if this is the last batch.
-		end := i + batchSize
-		if end > len(keys) {
-			end = len(keys)
-		}
+		end := min(i+batchSize, len(keys))
 
 		nDeletedBatch := 0
 		if err := db.Update(func(tx *bbolt.Tx) error {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.