### PR TITLE
multi: send notifications for change in DEX account status

### DIFF
--- a/client/core/account.go
+++ b/client/core/account.go
@@ -69,7 +69,7 @@ func (c *Core) ToggleAccountStatus(pw []byte, host string, disable bool) error {
 	if disable {
 		// Check active orders or bonds.
 		if dc.hasActiveOrders() {
-			return fmt.Errorf("cannot disable account with active orders")
+			return errors.New("cannot disable account with active orders")
 		}
 
 		if dc.hasUnspentBond() {
@@ -96,7 +96,7 @@ func (c *Core) ToggleAccountStatus(pw []byte, host string, disable bool) error {
 		}
 		dc, connected := c.connectAccount(acctInfo)
 		if !connected {
-			return fmt.Errorf("failed to connected re-enabled account: %w", err)
+			return errors.New("failed to connected re-enabled account")
 		}
 		c.initializeDEXConnection(dc, crypter)
 	}

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -4639,7 +4639,6 @@ func (c *Core) Login(pw []byte) error {
 		c.resolveActiveTrades(crypter)
 		c.notify(newLoginNote("Connecting to DEX servers..."))
 		c.initializeDEXConnections(crypter)
-
 	}
 
 	return nil

--- a/client/core/locale_ntfn.go
+++ b/client/core/locale_ntfn.go
@@ -361,7 +361,7 @@ var originLocale = map[Topic]*translation{
 	},
 	TopicDEXEnabled: {
 		subject:  intl.Translation{T: "DEX server status"},
-		template: intl.Translation{T: "DEX server %s has been enable.", Notes: "args: [host]"},
+		template: intl.Translation{T: "DEX server %s has been enabled.", Notes: "args: [host]"},
 	},
 }
 

--- a/client/core/locale_ntfn.go
+++ b/client/core/locale_ntfn.go
@@ -355,6 +355,14 @@ var originLocale = map[Topic]*translation{
 			Notes: "args: [bond asset, dex host]",
 		},
 	},
+	TopicDEXDisabled: {
+		subject:  intl.Translation{T: "DEX server status"},
+		template: intl.Translation{T: "DEX server %s has been disabled.", Notes: "args: [host]"},
+	},
+	TopicDEXEnabled: {
+		subject:  intl.Translation{T: "DEX server status"},
+		template: intl.Translation{T: "DEX server %s has been enable.", Notes: "args: [host]"},
+	},
 }
 
 var ptBR = map[Topic]*translation{

--- a/client/core/notification.go
+++ b/client/core/notification.go
@@ -502,6 +502,8 @@ const (
 	TopicDEXConnected    Topic = "DEXConnected"
 	TopicDEXDisconnected Topic = "DEXDisconnected"
 	TopicDexConnectivity Topic = "DEXConnectivity"
+	TopicDEXDisabled     Topic = "DEXDisabled"
+	TopicDEXEnabled      Topic = "DEXEnabled"
 )
 
 func newConnEventNote(topic Topic, subject, host string, status comms.ConnectionStatus, details string, severity db.Severity) *ConnEventNote {

--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -3005,10 +3005,10 @@ export default class MarketsPage extends BasePage {
    */
   async handleConnNote (note: ConnEventNote) {
     this.marketList.setConnectionStatus(note)
-    if (note.connectionStatus === ConnectionStatus.Connected) {
-      // Having been disconnected from a DEX server, anything may have changed,
-      // or this may be the first opportunity to get the server's config, so
-      // fetch it all before reloading the markets page.
+    if (note.topic === 'DEXDisabled' || note.topic === 'DEXEnabled' || note.connectionStatus === ConnectionStatus.Connected) {
+      // Having been disconnected or connected from a DEX server, anything may
+      // have changed, or this may be the first opportunity to get the server's
+      // config, so fetch it all before reloading the markets page.
       await app().fetchUser()
       await app().loadPage('markets')
     }


### PR DESCRIPTION
When a DEX account is disabled or enabled, it could cause stale data/state to be displayed on the market page/other pages since there's no feedback on the action carried out.

This PR adds a notification for account status toggles. Once the FE receives this notification, user data is retrieved, and the market page is refreshed to reflect the current state.

This is an extension of the fix introduced in https://github.com/decred/dcrdex/pull/3037.