### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/client/mm/libxc/coinbase.go
+++ b/client/mm/libxc/coinbase.go
@@ -17,6 +17,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -205,11 +206,9 @@ func (c *cbWSConn) handleSubscriptionMessage(b []byte) {
 	var subbed bool
 	for channel, productIDs := range msg.Events[0].Subscriptions {
 		if channel == c.channel {
-			for _, productID := range productIDs {
-				if subscribed(productID) {
-					subbed = true
-					break
-				}
+			if slices.ContainsFunc(productIDs, subscribed) {
+				subbed = true
+				break
 			}
 		}
 	}


### PR DESCRIPTION

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.