### PR TITLE
multi: show upgrade banner if newer version is available on GitHub

### DIFF
--- a/client/webserver/http.go
+++ b/client/webserver/http.go
@@ -59,6 +59,7 @@ type CommonArguments struct {
 	Title          string
 	UseDEXBranding bool
 	Version        string
+	LatestVersion  string
 }
 
 // Create the CommonArguments for the request.
@@ -68,6 +69,7 @@ func (s *WebServer) commonArgs(r *http.Request, title string) *CommonArguments {
 		Title:          title,
 		UseDEXBranding: s.useDEXBranding,
 		Version:        s.appVersion,
+		LatestVersion:  s.latestVersion,
 	}
 }
 

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -696,4 +696,6 @@ var EnUS = map[string]*intl.Translation{
 	"Internal transfers only":     {T: "Internal transfers only"},
 	"internal_only_tooltip":       {T: "When enabled, the bot will be able to use any available funds in the wallet to simulate a transfer between the DEX and the CEX, (i.e. increase the bot's DEX balance and decrease the bot's CEX balance when a withdrawal needs to be made) but no actual transfers will be made."},
 	"running_bot_allocation_note": {T: "This bot is already running. The numbers below are the allocation adjustments that will be made, not the total balance that will be allocated."},
+	"New Release Message":         {T: "<strong> 🚀 New release available!</strong> Get the latest version on GitHub."},
+	"View Release":                {T: "View Release"},
 }

--- a/client/webserver/site/src/css/main.scss
+++ b/client/webserver/site/src/css/main.scss
@@ -309,3 +309,7 @@ z-index: 1000;
     width: auto;
   }
 }
+
+.green {
+  color: var(--indicator-good);
+}

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -12,6 +12,15 @@
   <link href="/css/style.css?v={{commitHash}}" rel="stylesheet">
 </head>
 <body class="dark{{if .UseDEXBranding}} dex-branding{{end}}">
+  {{if and (ne .Version .LatestVersion) .LatestVersion}}
+    <div class="p-2 d-flex justify-content-center">
+        <span class="fs15 green">[[[New Release Message]]]</span>
+        <a href="https://github.com/decred/dcrdex/releases/latest" target="_blank" rel="noopener noreferrer"
+          class="fs15 ps-2">
+          [[[View Release]]]
+        </a>
+    </div>
+  {{end}}
   <div class="popup-notes d-hide" id="popupNotes">
     <span data-tmpl="note" class="fs15">
       <div class="note-indicator d-inline-block" data-tmpl="indicator"></div>

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -37,6 +37,7 @@ import (
 	"decred.org/dcrdex/client/webserver/locales"
 	"decred.org/dcrdex/client/websocket"
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/dexnet"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/encrypt"
 	"github.com/decred/dcrd/certgen"
@@ -282,7 +283,8 @@ type WebServer struct {
 	bondBufMtx sync.Mutex
 	bondBuf    map[uint32]valStamp
 
-	appVersion string
+	appVersion    string
+	latestVersion string // latest version from github
 
 	useDEXBranding  bool
 	mainLogFilePath string
@@ -625,6 +627,37 @@ func New(cfg *Config) (*WebServer, error) {
 	return s, nil
 }
 
+// fetchLatestVersion is a helper function to retrieve the latest version of the app
+// from github.
+func (w *WebServer) fetchLatestVersion(ctx context.Context) {
+	if w.latestVersion != "" {
+		return // already set
+	}
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			var response struct {
+				TagName string `json:"tag_name"`
+			}
+
+			err := dexnet.Get(ctx, "https://api.github.com/repos/decred/dcrdex/releases/latest", &response, dexnet.WithSizeLimit(1<<22))
+			if err != nil {
+				log.Errorf("Error getting latest version: %v", err)
+				continue
+			}
+
+			w.latestVersion = strings.Trim(response.TagName, "v")
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 // buildTemplates prepares the HTML templates, which are executed and served in
 // sendTemplate. An empty siteDir indicates that the embedded templates in the
 // htmlTmplSub FS should be used. If siteDir is set, the templates will be
@@ -790,6 +823,12 @@ func (s *WebServer) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	go func() {
 		defer wg.Done()
 		s.readNotifications(ctx)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.fetchLatestVersion(ctx)
 	}()
 
 	log.Infof("Web server listening on %s (https = %v)", s.addr, https)


### PR DESCRIPTION
<img width="871" alt="Screenshot 2025-05-23 at 12 21 29 AM" src="https://github.com/user-attachments/assets/a798180a-59a7-49c2-b6be-7ac611a2f242" />
<img width="873" alt="Screenshot 2025-05-23 at 12 21 43 AM" src="https://github.com/user-attachments/assets/ecdaa6fc-99e0-436f-91ad-a11756af3eb7" />

Closes #3191

The banner stays until the user upgrades.