### PR TITLE
multi: add `/buildinfo` endpoint and refactor

### DIFF
--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1023,6 +1023,16 @@ func (s *WebServer) apiSetLocale(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, simpleAck())
 }
 
+// apiBuildInfo is the handler for the '/buildinfo' API request.
+func (s *WebServer) apiBuildInfo(w http.ResponseWriter, r *http.Request) {
+	resp := buildInfoResponse{
+		OK:       true,
+		Version:  s.appVersion,
+		Revision: commitHash,
+	}
+	writeJSON(w, resp)
+}
+
 // apiLogin handles the 'login' API request.
 func (s *WebServer) apiLogin(w http.ResponseWriter, r *http.Request) {
 	login := new(loginForm)

--- a/client/webserver/site/src/html/bodybuilder.tmpl
+++ b/client/webserver/site/src/html/bodybuilder.tmpl
@@ -9,7 +9,7 @@
   <link rel="icon" href="/img/favicon.png?v=AZ4AZX">
   <meta name="description" content="Bison Wallet">
   <title>{{.Title}}</title>
-  <link href="/css/style.css?v={{commitHash}}" rel="stylesheet">
+  <link href="/css/style.css?v={{commitHash true}}" rel="stylesheet">
 </head>
 <body class="dark{{if .UseDEXBranding}} dex-branding{{end}}">
   <div class="popup-notes d-hide" id="popupNotes">
@@ -264,7 +264,7 @@
   </div>
 </div>
 
-<script src="/js/entry.js?v={{commitHash}}"></script>
+<script src="/js/entry.js?v={{commitHash true}}"></script>
 </body>
 </html>
 {{end}}

--- a/client/webserver/site/src/html/settings.tmpl
+++ b/client/webserver/site/src/html/settings.tmpl
@@ -85,7 +85,7 @@
       <div class="mb-3 pb-3 border-bottom {{if not $authed}}d-hide{{end}}">
         <button id="companionAppBtn" class="fs15">[[[Pair companion app]]]</button>
       </div>
-      <p class="grey">[[[Build ID]]]: <span id="commitHash" class="mono"></span></p>
+      <p class="grey">[[[Build ID]]]: <span class="mono">{{commitHash false}}</span></p>
     </div>
   </section>
 

--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -187,14 +187,12 @@ export default class Application {
     this.notes = []
     this.pokes = []
     this.seedGenTime = 0
-    this.commitHash = process.env.COMMITHASH || ''
+    this.commitHash = ''
     this.noteReceivers = []
     this.fiatRatesMap = {}
     this.showPopups = State.fetchLocal(State.popupsLK) === '1'
     this.txHistoryMap = {}
     this.requiredActions = {}
-
-    console.log('Bison Wallet, Build', this.commitHash.substring(0, 7))
 
     // Set dark theme.
     document.body.classList.toggle('dark', State.isDark())
@@ -247,6 +245,9 @@ export default class Application {
    * point. Read the id = main element and attach handlers.
    */
   async start () {
+    await this.fetchBuildInfo()
+    console.log('Bison Wallet, Build', this.commitHash.substring(0, 8))
+
     // Handle back navigation from the browser.
     bind(window, 'popstate', (e: PopStateEvent) => {
       const page = e.state?.page
@@ -328,6 +329,12 @@ export default class Application {
 
     this.updateMenuItemsDisplay()
     return user
+  }
+
+  async fetchBuildInfo () {
+    const resp = await getJSON('/api/buildinfo')
+    if (!this.checkResponse(resp)) return
+    this.commitHash = resp.revision
   }
 
   async fetchMMStatus () {

--- a/client/webserver/site/src/js/settings.ts
+++ b/client/webserver/site/src/js/settings.ts
@@ -61,7 +61,6 @@ export default class SettingsPage extends BasePage {
       app().showPopups = show
     })
 
-    page.commitHash.textContent = app().commitHash.substring(0, 7)
     Doc.bind(page.addADex, 'click', () => {
       this.dexAddrForm.refresh()
       this.showForm(page.dexAddrForm)

--- a/client/webserver/site/webpack/common.js
+++ b/client/webserver/site/webpack/common.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const webpack = require('webpack')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const StyleLintPlugin = require('stylelint-webpack-plugin')
@@ -38,9 +37,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.EnvironmentPlugin({
-      COMMITHASH: git('rev-parse HEAD'),
-    }),
     new CleanWebpackPlugin(),
     new MiniCssExtractPlugin({
       filename: '../dist/style.css'

--- a/client/webserver/types.go
+++ b/client/webserver/types.go
@@ -144,3 +144,9 @@ type deleteRecordsForm struct {
 	SaveOrdersToFile  bool  `json:"saveOrdersToFile"`
 	SaveMatchesToFile bool  `json:"saveMatchesToFile"`
 }
+
+type buildInfoResponse struct {
+	OK       bool   `json:"ok"`
+	Version  string `json:"version"`
+	Revision string `json:"revision"`
+}

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -519,6 +519,7 @@ func New(cfg *Config) (*WebServer, error) {
 		r.Get("/user", s.apiUser)
 		r.Post("/locale", s.apiLocale)
 		r.Post("/setlocale", s.apiSetLocale)
+		r.Get("/buildinfo", s.apiBuildInfo)
 
 		r.Group(func(apiInit chi.Router) {
 			apiInit.Use(s.rejectUninited)


### PR DESCRIPTION
This PR introduces a new API endpoint to ensure a consistent reporting of the Bison Wallet build ID.

Closes https://github.com/decred/dcrdex/issues/3088

