### PR TITLE
multi: bump app version(s)

### DIFF
--- a/client/app/config.go
+++ b/client/app/config.go
@@ -197,7 +197,7 @@ func (cfg *Config) Web(c *core.Core, mm *mm.MarketMaker, log dex.Logger, utc boo
 		KeyFile:         keyFile,
 		NoEmbed:         cfg.NoEmbedSite,
 		HttpProf:        cfg.HTTPProfile,
-		AppVersion:      userAppVersion(Version),
+		AppVersion:      Version,
 		Language:        cfg.Language,
 		Tor:             cfg.Tor,
 		MainLogFilePath: cfg.LogPath,
@@ -355,12 +355,6 @@ func ResolveConfig(appData string, cfg *Config) error {
 	}
 
 	return nil
-}
-
-// userAppVersion returns a simple user-facing version: maj.min.patch.
-func userAppVersion(fullVersion string) string {
-	parts := strings.Split(fullVersion, "-")
-	return parts[0]
 }
 
 // setNet sets the filepath for the network directory and some network specific

--- a/client/app/version.go
+++ b/client/app/version.go
@@ -36,7 +36,7 @@ var (
 	// and build metadata portions MUST only contain characters from
 	// semanticAlphabet.
 	// NOTE: The Version string is overridden on init.
-	Version = "1.0.1-pre"
+	Version = "1.0.4-pre"
 )
 
 func init() {

--- a/client/cmd/bisonw-desktop/pkg/pkg-darwin.sh
+++ b/client/cmd/bisonw-desktop/pkg/pkg-darwin.sh
@@ -9,9 +9,9 @@ set -o pipefail;
 export GOWORK=off
 
 # For release set metadata to "release".
-VER="0.7.0-pre"
+VER="1.0.4-pre"
 META= # "release"
-BUILD_VER="1.0.0" # increment for every build.
+BUILD_VER="1.0.4" # increment for every build.
 OS_FULL_VERSION="$(sw_vers | sed -n 2p | cut -d : -f 2 | tr -d '[:space:]' | cut -c1-)"
 OS_MAJOR_VERSION="$(echo $OS_FULL_VERSION | cut -d . -f 1)"
 OS_MINOR_VERSION="$(echo $OS_FULL_VERSION | cut -d . -f 2)"

--- a/client/cmd/bisonw-desktop/pkg/pkg-debian.sh
+++ b/client/cmd/bisonw-desktop/pkg/pkg-debian.sh
@@ -6,7 +6,10 @@
 # turn this on for debugging, keep noise low for prod builds
 # set -ex
 
-source $(dirname "$0")/common.sh
+APP="bisonw"
+VER="1.0.4-pre" # pre, beta, rc1, etc.
+META= #"release"
+ARCH="amd64"
 
 # A directory containing metadata files
 SRC_DIR="./src"

--- a/client/cmd/bisonw-desktop/pkg/windows-msi/BisonWallet.wxs
+++ b/client/cmd/bisonw-desktop/pkg/windows-msi/BisonWallet.wxs
@@ -1,5 +1,5 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
-  <Package UpgradeCode="2c62692a-c72e-4182-a8eb-7d1d7e55adc0" Version="1.0.0.0" Language="1033"
+  <Package UpgradeCode="2c62692a-c72e-4182-a8eb-7d1d7e55adc0" Version="1.0.4.0" Language="1033"
     Name="BisonWallet" Manufacturer="Decred Developers" InstallerVersion="300">
     <Media Id="1" Cabinet="bisonwdesktop.cab" EmbedCab="yes" />
     <Property Id="PIDTEMPLATE" Value="Decred Developers" />

--- a/client/cmd/bisonw-desktop/winres.json
+++ b/client/cmd/bisonw-desktop/winres.json
@@ -25,7 +25,7 @@
             "Comments": "",
             "CompanyName": "Decred",
             "FileDescription": "Bison Wallet (WebView version)",
-            "FileVersion": "1.0.0",
+            "FileVersion": "1.0.4",
             "InternalName": "bisonw",
             "LegalCopyright": "© The Decred Developers. Blue Oak Model License 1.0.0",
             "LegalTrademarks": "",

--- a/client/cmd/bisonw-desktop/winres.json
+++ b/client/cmd/bisonw-desktop/winres.json
@@ -17,22 +17,22 @@
     "#1": {
       "0000": {
         "fixed": {
-          "file_version": "0.7.0.0",
-          "product_version": "0.7.0.0"
+          "file_version": "1.0.0.0",
+          "product_version": "1.0.4.0"
         },
         "info": {
           "0409": {
             "Comments": "",
             "CompanyName": "Decred",
             "FileDescription": "Bison Wallet (WebView version)",
-            "FileVersion": "0.7.0",
+            "FileVersion": "1.0.0",
             "InternalName": "bisonw",
             "LegalCopyright": "© The Decred Developers. Blue Oak Model License 1.0.0",
             "LegalTrademarks": "",
             "OriginalFilename": "bisonw-desktop.exe",
             "PrivateBuild": "",
             "ProductName": "Bison Wallet",
-            "ProductVersion": "0.7.0",
+            "ProductVersion": "1.0.4.0",
             "SpecialBuild": ""
           }
         }

--- a/client/cmd/bisonw-desktop/winres.json
+++ b/client/cmd/bisonw-desktop/winres.json
@@ -17,8 +17,8 @@
     "#1": {
       "0000": {
         "fixed": {
-          "file_version": "1.0.0.0",
-          "product_version": "1.0.4.0"
+          "file_version": "1.0.4.0",
+          "product_version": "1.0.4.0 pre"
         },
         "info": {
           "0409": {
@@ -32,7 +32,7 @@
             "OriginalFilename": "bisonw-desktop.exe",
             "PrivateBuild": "",
             "ProductName": "Bison Wallet",
-            "ProductVersion": "1.0.4.0",
+            "ProductVersion": "1.0.4.0 pre",
             "SpecialBuild": ""
           }
         }

--- a/client/cmd/bisonw/winres.json
+++ b/client/cmd/bisonw/winres.json
@@ -14,22 +14,22 @@
     "#1": {
       "0000": {
         "fixed": {
-          "file_version": "0.7.0.0",
-          "product_version": "0.7.0.0"
+          "file_version": "1.0.0.0",
+          "product_version": "1.0.4.0"
         },
         "info": {
           "0409": {
             "Comments": "",
             "CompanyName": "Decred",
             "FileDescription": "Bison Wallet",
-            "FileVersion": "0.7.0",
+            "FileVersion": "1.0.0",
             "InternalName": "bisonw",
             "LegalCopyright": "© The Decred Developers. Blue Oak Model License 1.0.0",
             "LegalTrademarks": "",
             "OriginalFilename": "bisonw.exe",
             "PrivateBuild": "",
             "ProductName": "Bison Wallet",
-            "ProductVersion": "0.7.0",
+            "ProductVersion": "1.0.4.0",
             "SpecialBuild": ""
           }
         }

--- a/client/cmd/bisonw/winres.json
+++ b/client/cmd/bisonw/winres.json
@@ -14,22 +14,22 @@
     "#1": {
       "0000": {
         "fixed": {
-          "file_version": "1.0.0.0",
-          "product_version": "1.0.4.0"
+          "file_version": "1.0.4.0",
+          "product_version": "1.0.4.0 pre"
         },
         "info": {
           "0409": {
             "Comments": "",
             "CompanyName": "Decred",
             "FileDescription": "Bison Wallet",
-            "FileVersion": "1.0.0",
+            "FileVersion": "1.0.4",
             "InternalName": "bisonw",
             "LegalCopyright": "© The Decred Developers. Blue Oak Model License 1.0.0",
             "LegalTrademarks": "",
             "OriginalFilename": "bisonw.exe",
             "PrivateBuild": "",
             "ProductName": "Bison Wallet",
-            "ProductVersion": "1.0.4.0",
+            "ProductVersion": "1.0.4.0 pre",
             "SpecialBuild": ""
           }
         }

--- a/client/cmd/bwctl/version.go
+++ b/client/cmd/bwctl/version.go
@@ -41,7 +41,7 @@ var (
 	// and build metadata portions MUST only contain characters from
 	// semanticAlphabet.
 	// NOTE: The Version string is overridden on init.
-	Version = "0.7.0-pre"
+	Version = "1.0.4-pre"
 )
 
 func init() {

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -236,7 +236,7 @@ type Config struct {
 	Language      string
 	Logger        dex.Logger
 	UTC           bool   // for stdout http request logging
-	AppVersion    string // user app version for UI
+	AppVersion    string // e.g. "1.0.4-pre", "1.0.4"
 	CertFile      string
 	KeyFile       string
 	// NoEmbed indicates to serve files from the system disk rather than the
@@ -411,7 +411,7 @@ func New(cfg *Config) (*WebServer, error) {
 		cachedPasswords: make(map[string]*cachedPassword),
 		tor:             cfg.Tor,
 		bondBuf:         map[uint32]valStamp{},
-		appVersion:      cfg.AppVersion,
+		appVersion:      userAppVersion(cfg.AppVersion, false),
 		useDEXBranding:  useDEXBranding,
 		mainLogFilePath: cfg.MainLogFilePath,
 	}
@@ -1167,6 +1167,20 @@ func writeJSONWithStatus(w http.ResponseWriter, thing any, code int) {
 func folderExists(fp string) bool {
 	stat, err := os.Stat(fp)
 	return err == nil && stat.IsDir()
+}
+
+// userAppVersion is a template function that returns the user-facing
+// application version, which is the full version without the build metadata. If
+// semVerOnly is true, it returns the version without the pre-release tag. The
+// full version is expected to be in the format
+// "MAJOR.MINOR.PATCH[-PRE-RELEASE][+BUILD-METADATA]". For example,
+// "1.0.4-pre+4ba3fd93b" would return "1.0.4-pre" if semVerOnly is false, and
+// "1.0.4" if semVerOnly is true.
+func userAppVersion(fullVersion string, semVerOnly bool) string {
+	if semVerOnly {
+		return strings.Split(fullVersion, "-")[0]
+	}
+	return strings.Split(fullVersion, "+")[0]
 }
 
 // chiLogger is an adaptor around dex.Logger that satisfies

--- a/client/webserver/webserver.go
+++ b/client/webserver/webserver.go
@@ -39,6 +39,7 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/encrypt"
+	"decred.org/dcrdex/dex/version"
 	"github.com/decred/dcrd/certgen"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -1177,10 +1178,17 @@ func folderExists(fp string) bool {
 // "1.0.4-pre+4ba3fd93b" would return "1.0.4-pre" if semVerOnly is false, and
 // "1.0.4" if semVerOnly is true.
 func userAppVersion(fullVersion string, semVerOnly bool) string {
-	if semVerOnly {
-		return strings.Split(fullVersion, "-")[0]
+	major, minor, patch, pre, _, err := version.ParseSemVer(fullVersion) // validate the version format
+	if err != nil {
+		log.Errorf("Invalid version %q: %v", fullVersion, err)
+		return fullVersion // return the full version as is
 	}
-	return strings.Split(fullVersion, "+")[0]
+
+	if semVerOnly {
+		return fmt.Sprintf("%d.%d.%d", major, minor, patch)
+	}
+
+	return fmt.Sprintf("%d.%d.%d-%s", major, minor, patch, pre)
 }
 
 // chiLogger is an adaptor around dex.Logger that satisfies

--- a/client/webserver/webserver_test.go
+++ b/client/webserver/webserver_test.go
@@ -33,7 +33,7 @@ var (
 	tErr           = fmt.Errorf("expected dummy error")
 	tLogger        dex.Logger
 	tCtx           context.Context
-	testAppVersion = "1.0.3"
+	testAppVersion = "1.0.4-pre"
 )
 
 type tCoin struct {

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -8,24 +8,24 @@ This checklist is designed to ensure a smooth and successful release process for
     - Remove the pre-release portion (if any)
     - Set the build metadata to 'release.local'
     - Example: 'Version = "1.0.4+release.local"'
-      - See [Version Update](#version-update) section below for details
+    - See `Version Update` section below for details
         on updating version variables.
-  - [ ] Update the version varible(s) on the master branch to the next
-        expected version while retaining a pre-release of 'pre'
-    - [ ] Tag the release in Git of the form 'vMAJOR.MINOR.PATCH'
-    - [ ] Push the changes to the remote repository
+  - [ ] Update the version variable(s) on the `master` branch to the next
+        expected version while retaining a pre-release of `pre`
+  - [ ] Tag the release in Git of the form 'vMAJOR.MINOR.PATCH'
+  - [ ] Push the changes to the remote repository
 - Version Update:
   - [ ] Ensure the version number follows semantic versioning (MAJOR.MINOR.PATCH)
-  - [ ] Update the version number in [client/app/version.go](/client/app/version.go)
-  - [ ] Update the version number in [server/cmd/dcrdex/version.go](/server/cmd/dcrdex/version.go)
-  - [ ] Update the version number in [client/cmd/bwctl/version.go](/client/cmd/bwctl/version.go)
-  - [ ] Update the version number in [client/webserver/webserver_test.go](/client/webserver/webserver_test.go)
-  - [ ] Update the version number in [client/cmd/bisonw-desktop/pkg/pkg-darwin.sh](/client/cmd/bisonw-desktop/pkg/pkg-darwin.sh)
-  - [ ] Update the version number in [client/cmd/bisonw-desktop/pkg/pkg-debian.sh](/client/cmd/bisonw-desktop/pkg/pkg-debian.sh)
-  - [ ] Update the version number in [client/cmd/bisonw-desktop/winres.json](/client/cmd/bisonw-desktop/winres.json)
-  - [ ] Update the version number in [lient/cmd/bisonw-desktop/pkg/windows-msi/BisonWallet.wxs](/client/cmd/bisonw-desktop/pkg/windows-msi/BisonWallet.wxs)
-  - [ ] Update the version number in [client/cmd/bisonw/winres.json](/client/cmd/bisonw/winres.json)
-  - [ ] Update the version number in [pkg.sh](/pkg.sh)
+  - [ ] Update the version number in [client/app/version.go](../client/app/version.go)
+  - [ ] Update the version number in [server/cmd/dcrdex/version.go](../server/cmd/dcrdex/version.go)
+  - [ ] Update the version number in [client/cmd/bwctl/version.go](../client/cmd/bwctl/version.go)
+  - [ ] Update the version number in [client/webserver/webserver_test.go](../client/webserver/webserver_test.go)
+  - [ ] Update the version number in [client/cmd/bisonw-desktop/pkg/pkg-darwin.sh](../client/cmd/bisonw-desktop/pkg/pkg-darwin.sh)
+  - [ ] Update the version number in [client/cmd/bisonw-desktop/pkg/pkg-debian.sh](../client/cmd/bisonw-desktop/pkg/pkg-debian.sh)
+  - [ ] Update the version number in [client/cmd/bisonw-desktop/winres.json](../client/cmd/bisonw-desktop/winres.json)
+  - [ ] Update the version number in [lient/cmd/bisonw-desktop/pkg/windows-msi/BisonWallet.wxs](../client/cmd/bisonw-desktop/pkg/windows-msi/BisonWallet.wxs)
+  - [ ] Update the version number in [client/cmd/bisonw/winres.json](../client/cmd/bisonw/winres.json)
+  - [ ] Update the version number in [pkg.sh](../pkg.sh)
 - Documentation:
   - [ ] Update the documentation to reflect any new features or changes
   - [ ] Ensure all examples in the documentation are up-to-date
@@ -65,4 +65,4 @@ This checklist is designed to ensure a smooth and successful release process for
 - Community:
   - [ ] Engage with the community for feedback and suggestions
   - [ ] Encourage contributions and participation in the project
-  - [ ] Consider hosting a Q&A session or webinar to discuss the new release
+  - [ ] Consider hosting a Q&A session, a webinar, or preparing a blog article to discuss the new release

--- a/docs/RELEASE-CHECKLIST.md
+++ b/docs/RELEASE-CHECKLIST.md
@@ -1,0 +1,68 @@
+# Release Checklist
+
+This checklist is designed to ensure a smooth and successful release process for the project. Each item should be completed before the release is finalized.
+
+- Release:
+  - [ ] Create a release branch of the form 'release-vMAJOR.MINOR'
+  - [ ] Modify the version variables on that branch to:
+    - Remove the pre-release portion (if any)
+    - Set the build metadata to 'release.local'
+    - Example: 'Version = "1.0.4+release.local"'
+      - See [Version Update](#version-update) section below for details
+        on updating version variables.
+  - [ ] Update the version varible(s) on the master branch to the next
+        expected version while retaining a pre-release of 'pre'
+    - [ ] Tag the release in Git of the form 'vMAJOR.MINOR.PATCH'
+    - [ ] Push the changes to the remote repository
+- Version Update:
+  - [ ] Ensure the version number follows semantic versioning (MAJOR.MINOR.PATCH)
+  - [ ] Update the version number in [client/app/version.go](/client/app/version.go)
+  - [ ] Update the version number in [server/cmd/dcrdex/version.go](/server/cmd/dcrdex/version.go)
+  - [ ] Update the version number in [client/cmd/bwctl/version.go](/client/cmd/bwctl/version.go)
+  - [ ] Update the version number in [client/webserver/webserver_test.go](/client/webserver/webserver_test.go)
+  - [ ] Update the version number in [client/cmd/bisonw-desktop/pkg/pkg-darwin.sh](/client/cmd/bisonw-desktop/pkg/pkg-darwin.sh)
+  - [ ] Update the version number in [client/cmd/bisonw-desktop/pkg/pkg-debian.sh](/client/cmd/bisonw-desktop/pkg/pkg-debian.sh)
+  - [ ] Update the version number in [client/cmd/bisonw-desktop/winres.json](/client/cmd/bisonw-desktop/winres.json)
+  - [ ] Update the version number in [lient/cmd/bisonw-desktop/pkg/windows-msi/BisonWallet.wxs](/client/cmd/bisonw-desktop/pkg/windows-msi/BisonWallet.wxs)
+  - [ ] Update the version number in [client/cmd/bisonw/winres.json](/client/cmd/bisonw/winres.json)
+  - [ ] Update the version number in [pkg.sh](/pkg.sh)
+- Documentation:
+  - [ ] Update the documentation to reflect any new features or changes
+  - [ ] Ensure all examples in the documentation are up-to-date
+  - [ ] Check for broken links in the documentation
+- Tests:
+  - [ ] Run all tests to ensure they pass
+  - [ ] Add new tests for any new features or changes
+  - [ ] Ensure test coverage is adequate
+- Build:
+  - [ ] Build the project for all supported platforms
+  - [ ] Ensure the build artifacts are correctly versioned
+  - [ ] Verify that the build artifacts are functional
+- Packaging:
+  - [ ] Create packages for all supported platforms (e.g., .deb, .rpm, .tar.gz)
+  - [ ] Ensure the packages include all necessary files and dependencies
+  - [ ] Verify that the packages can be installed and run successfully
+- Release Notes:
+  - [ ] Write release notes summarizing the changes in this release
+  - [ ] Include any breaking changes, new features, and bug fixes
+  - [ ] Highlight any important information for users upgrading from previous versions
+  - [ ] Ensure the release notes are clear and easy to understand
+  - [ ] Include links to relevant documentation or resources
+  - [ ] Acknowledge contributors in the release notes or documentation
+- Announcements:
+  - [ ] Announce the release on relevant channels (e.g., GitHub, Twitter, mailing list)
+  - [ ] Update the changelog with the release notes
+- Post-release:
+  - [ ] Update brew cask for the new version
+  - [ ] Update the project's website with the new release information
+  - [ ] Monitor for any issues or bugs reported after the release
+  - [ ] Address any critical issues promptly
+  - [ ] Gather feedback from users about the new release
+- Maintenance:
+  - [ ] Plan for the next release cycle
+  - [ ] Review and prioritize issues and feature requests
+  - [ ] Ensure the project remains active and maintained
+- Community:
+  - [ ] Engage with the community for feedback and suggestions
+  - [ ] Encourage contributions and participation in the project
+  - [ ] Consider hosting a Q&A session or webinar to discuss the new release

--- a/pkg.sh
+++ b/pkg.sh
@@ -3,7 +3,7 @@
 set -e
 
 # For release, remove pre-release info, and set metadata to "release".
-VER="1.0.1-pre" # pre, beta, rc1, etc.
+VER="1.0.4-pre" # pre, beta, rc1, etc.
 META= # "release"
 
 export CGO_ENABLED=0

--- a/server/cmd/dcrdex/version.go
+++ b/server/cmd/dcrdex/version.go
@@ -39,7 +39,7 @@ var (
 	// and build metadata portions MUST only contain characters from
 	// semanticAlphabet.
 	// NOTE: The Version string is overridden on init.
-	Version = "0.7.0-pre"
+	Version = "1.0.4-pre"
 )
 
 func init() {


### PR DESCRIPTION
According to the note for maintainers in client/app/version.go and similar files:

> // - Update the Version variable below on the master branch to the next
	//   expected version while retaining a pre-release of 'pre'

This PR updates app versions to the next expected version of `1.0.4` with a `-pre` suffix.

Closes https://github.com/decred/dcrdex/issues/3288