### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/dex/logging.go
+++ b/dex/logging.go
@@ -6,6 +6,7 @@ package dex
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -188,9 +189,7 @@ func NewLoggerMaker(writer io.Writer, debugLevel string, utc ...bool) (*LoggerMa
 // SetLevelsFromMap sets all logs for certain subsystems with the same name to
 // the corresponding log level in the map.
 func (lm *LoggerMaker) SetLevelsFromMap(lvls map[string]slog.Level) {
-	for name, lvl := range lvls {
-		lm.Levels[name] = lvl
-	}
+	maps.Copy(lm.Levels, lvls)
 }
 
 // SetLevels either set the DefaultLevel or resets the Levels map for future

--- a/dex/utils/generics.go
+++ b/dex/utils/generics.go
@@ -3,7 +3,11 @@
 
 package utils
 
-import "golang.org/x/exp/constraints"
+import (
+	"maps"
+
+	"golang.org/x/exp/constraints"
+)
 
 func ReverseSlice[T any](s []T) {
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
@@ -13,9 +17,7 @@ func ReverseSlice[T any](s []T) {
 
 func CopyMap[K comparable, V any](m map[K]V) map[K]V {
 	r := make(map[K]V, len(m))
-	for k, v := range m {
-		r[k] = v
-	}
+	maps.Copy(r, m)
 	return r
 }
 

--- a/server/asset/driver.go
+++ b/server/asset/driver.go
@@ -5,6 +5,7 @@ package asset
 
 import (
 	"fmt"
+	"maps"
 
 	"decred.org/dcrdex/dex"
 )
@@ -163,9 +164,7 @@ func IsToken(assetID uint32) (is bool, parentID uint32) {
 // Tokens returns the child tokens registered for a base chain asset.
 func Tokens(assetID uint32) map[uint32]*dex.Token {
 	m := make(map[uint32]*dex.Token, len(childTokens[assetID]))
-	for k, v := range childTokens[assetID] {
-		m[k] = v
-	}
+	maps.Copy(m, childTokens[assetID])
 	return m
 }
 


### PR DESCRIPTION
Optimize code using a more modern writing style.