### PR TITLE
internal/adaptorsigs: Correct endianness conversion for DLEQ verification

### DIFF
--- a/internal/adaptorsigs/dleq_test.go
+++ b/internal/adaptorsigs/dleq_test.go
@@ -25,36 +25,38 @@ func TestDleqProof(t *testing.T) {
 		return epk.PubKey(), spk.PubKey()
 	}
 
-	var secret [32]byte
-	copy(secret[1:], encode.RandomBytes(31))
+	for i := 0; i < 10; i++ {
+		var secret [32]byte
+		copy(secret[1:], encode.RandomBytes(31))
 
-	epk, spk := pubKeysFromSecret(secret)
-	proof, err := ProveDLEQ(secret[:])
-	if err != nil {
-		t.Fatalf("ProveDLEQ error: %v", err)
-	}
-	err = VerifyDLEQ(spk, epk, proof)
-	if err != nil {
-		t.Fatalf("VerifyDLEQ error: %v", err)
-	}
+		epk, spk := pubKeysFromSecret(secret)
+		proof, err := ProveDLEQ(secret[:])
+		if err != nil {
+			t.Fatalf("ProveDLEQ error: %v", err)
+		}
+		err = VerifyDLEQ(spk, epk, proof)
+		if err != nil {
+			t.Fatalf("%d: VerifyDLEQ error: %v", i, err)
+		}
 
-	secret[31] += 1
-	badEpk, badSpk := pubKeysFromSecret(secret)
-	err = VerifyDLEQ(badSpk, epk, proof)
-	if err == nil {
-		t.Fatalf("badSpk should not verify")
-	}
-	err = VerifyDLEQ(spk, badEpk, proof)
-	if err == nil {
-		t.Fatalf("badEpk should not verify")
-	}
+		secret[31] += 1
+		badEpk, badSpk := pubKeysFromSecret(secret)
+		err = VerifyDLEQ(badSpk, epk, proof)
+		if err == nil {
+			t.Fatalf("badSpk should not verify")
+		}
+		err = VerifyDLEQ(spk, badEpk, proof)
+		if err == nil {
+			t.Fatalf("badEpk should not verify")
+		}
 
-	extractedSecp, err := ExtractSecp256k1PubKeyFromProof(proof)
-	if err != nil {
-		t.Fatalf("ExtractSecp256k1PubKeyFromProof error: %v", err)
-	}
+		extractedSecp, err := ExtractSecp256k1PubKeyFromProof(proof)
+		if err != nil {
+			t.Fatalf("ExtractSecp256k1PubKeyFromProof error: %v", err)
+		}
 
-	if !extractedSecp.IsEqual(spk) {
-		t.Fatalf("extractedSecp != spk")
+		if !extractedSecp.IsEqual(spk) {
+			t.Fatalf("extractedSecp != spk")
+		}
 	}
 }


### PR DESCRIPTION
Resolves intermittent failures in the `VerifyDLEQ` function where it would incorrectly report that ed25519 points do not match.

The root cause of the bug was an improper conversion of point coordinates from `*big.Int` (used by `dcr/dcrec`) to the fixed-size little-endian byte arrays required by the `filippo.io/edwards25519` library.

The `(*big.Int).Bytes()` method returns a variable-length big-endian slice that omits leading zeros. The previous code reversed this variable-length slice directly. This process is only correct by chance if the coordinate's value is large enough to occupy all 32 bytes. For smaller values, the resulting byte slice was not a valid 32-byte little-endian representation, causing the point comparison to fail.

This commit introduces a `bigIntToLittleEndian32` helper function that performs a robust conversion. It pads the big-endian bytes to a full 32-byte array *before* reversing it, guaranteeing a correct little-endian representation regardless of the number's size. The `edwardsPointsEqual` function has been updated to use this new helper, making the DLEQ verification reliable.

Closes: #3282 