### PR TITLE
mm: Update run end time after each event

### DIFF
--- a/client/mm/event_log_test.go
+++ b/client/mm/event_log_test.go
@@ -314,7 +314,7 @@ func TestEventLogDB(t *testing.T) {
 		t.Fatalf("expected event:\n%v\n\ngot:\n%v", event2, runEvents[0])
 	}
 
-	err = db.endRun(startTime, mkt, startTime+1000)
+	err = db.endRun(startTime, mkt)
 	if err != nil {
 		t.Fatalf("error ending run: %v", err)
 	}
@@ -323,8 +323,8 @@ func TestEventLogDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error getting run overview: %v", err)
 	}
-	if *overview.EndTime != startTime+1000 {
-		t.Fatalf("expected end time %d, got %d", startTime+1000, overview.EndTime)
+	if *overview.EndTime < startTime || *overview.EndTime > time.Now().Unix() {
+		t.Fatalf("expected end time %d, got %d", startTime, overview.EndTime)
 	}
 	if !reflect.DeepEqual(overview.InitialBalances, initialBals) {
 		t.Fatalf("expected initial balances %v, got %v", initialBals, overview.InitialBalances)

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -3582,7 +3582,7 @@ func (u *unifiedExchangeAdaptor) Connect(ctx context.Context) (*sync.WaitGroup, 
 	go func() {
 		defer u.wg.Done()
 		<-ctx.Done()
-		u.eventLogDB.endRun(startTime, u.mwh, time.Now().Unix())
+		u.eventLogDB.endRun(startTime, u.mwh)
 	}()
 
 	u.wg.Add(1)

--- a/client/mm/exchange_adaptor_test.go
+++ b/client/mm/exchange_adaptor_test.go
@@ -39,7 +39,7 @@ func newTEventLogDB() *tEventLogDB {
 func (db *tEventLogDB) storeNewRun(startTime int64, mkt *MarketWithHost, cfg *BotConfig, initialState *BalanceState) error {
 	return nil
 }
-func (db *tEventLogDB) endRun(startTime int64, mkt *MarketWithHost, endTime int64) error { return nil }
+func (db *tEventLogDB) endRun(startTime int64, mkt *MarketWithHost) error { return nil }
 func (db *tEventLogDB) storeEvent(startTime int64, mkt *MarketWithHost, e *MarketMakingEvent, fs *BalanceState) {
 	db.storedEventsMtx.Lock()
 	defer db.storedEventsMtx.Unlock()


### PR DESCRIPTION
Updates the run end time along with each event update in order to avoid having a nil end time if the process is killed during a market making run.

Closes #3227