### PR TITLE
eth: Use value of one for gas estimate.

### DIFF
--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -738,7 +738,7 @@ func (c *contractorV1) estimateInitGas(ctx context.Context, n int) (uint64, erro
 			SecretHash:      secretHash,
 			Initiator:       c.acctAddr,
 			Participant:     common.BytesToAddress(encode.RandomBytes(20)),
-			Value:           big.NewInt(dexeth.GweiFactor),
+			Value:           c.evmify(1),
 		})
 	}
 


### PR DESCRIPTION
closes #3307

bug introduced by https://github.com/decred/dcrdex/commit/98f845d4b5c60dc3568b4d6f0cb93d58b94ab704

Because a token has less decimals, accounts with less than 1e9 worth of token which may be $1000 if it has six decimals cannot get an estimate as they don't have the ability to send more. Just use 1 for estimate like the v0 contractor.