### PR TITLE
client/webserver: Pass cert as []byte to RedeemPrepaidBond

### DIFF
--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -430,7 +430,7 @@ func (s *WebServer) apiRedeemPrepaidBond(w http.ResponseWriter, r *http.Request)
 		s.writeAPIError(w, fmt.Errorf("password error: %w", err))
 		return
 	}
-	tier, err := s.core.RedeemPrepaidBond(appPW, req.Code, req.Host, req.Cert)
+	tier, err := s.core.RedeemPrepaidBond(appPW, req.Code, req.Host, []byte(req.Cert))
 	if err != nil {
 		s.writeAPIError(w, err)
 		return


### PR DESCRIPTION
Previously the entire certificate was being passed as a string, causing core to think it was the file path of the certificate.

Closes #3309