### PR TITLE
mm: Multi-hop arb improvements 

### DIFF
--- a/client/mm/exchange_adaptor_test.go
+++ b/client/mm/exchange_adaptor_test.go
@@ -304,7 +304,7 @@ func TestSufficientBalanceForCEXTrade(t *testing.T) {
 						QuoteID: quoteID,
 					},
 				})
-				sufficient := adaptor.SufficientBalanceForCEXTrade(baseID, quoteID, test.sell, test.rate, test.qty, test.orderType)
+				sufficient := adaptor.SufficientBalanceForCEXTrade(baseID, quoteID, test.sell, test.rate, test.qty, 0 /* quoteQty */, test.orderType)
 				if sufficient != expSufficient {
 					t.Fatalf("expected sufficient=%v, got %v", expSufficient, sufficient)
 				}
@@ -5322,6 +5322,7 @@ func TestCEXTrade(t *testing.T) {
 		sell      bool
 		rate      uint64
 		qty       uint64
+		quoteQty  uint64
 		orderType libxc.OrderType
 		balances  map[uint32]uint64
 
@@ -5877,7 +5878,7 @@ func TestCEXTrade(t *testing.T) {
 			quoteID:   60002,
 			sell:      false,
 			orderType: libxc.OrderTypeMarket,
-			qty:       100e6,
+			quoteQty:  100e6,
 			balances: map[uint32]uint64{
 				42:    1e7,
 				0:     1e7,
@@ -6004,7 +6005,7 @@ func TestCEXTrade(t *testing.T) {
 
 		adaptor.SubscribeTradeUpdates()
 
-		_, err = adaptor.CEXTrade(ctx, test.baseID, test.quoteID, test.sell, test.rate, test.qty, test.orderType)
+		_, err = adaptor.CEXTrade(ctx, test.baseID, test.quoteID, test.sell, test.rate, test.qty, test.quoteQty, test.orderType)
 		if test.wantErr {
 			if err == nil {
 				t.Fatalf("%s: expected error but did not get", test.name)

--- a/client/mm/libxc/cbtypes/types.go
+++ b/client/mm/libxc/cbtypes/types.go
@@ -74,6 +74,15 @@ type LimitOrderConfig struct {
 	Limit LimitOrderConfigData `json:"limit_limit_gtc"`
 }
 
+type LimitIocConfigData struct {
+	BaseSize   string `json:"base_size"`
+	LimitPrice string `json:"limit_price"`
+}
+
+type LimitIocConfig struct {
+	SorLimitIoc LimitIocConfigData `json:"sor_limit_ioc"`
+}
+
 type MarketOrderConfigData struct {
 	BaseSize  *string `json:"base_size"`
 	QuoteSize *string `json:"quote_size"`

--- a/client/mm/libxc/coinbase_live_test.go
+++ b/client/mm/libxc/coinbase_live_test.go
@@ -527,18 +527,18 @@ func TestPlaceTrade(t *testing.T) {
 	}
 
 	marketStr := os.Getenv("MARKET")
-	orderType := OrderTypeLimit
+	orderType := OrderTypeLimitIOC
 	if marketStr == "true" {
 		orderType = OrderTypeMarket
 	}
 
 	rateStr := os.Getenv("RATE")
-	if orderType == OrderTypeLimit && rateStr == "" {
+	if orderType != OrderTypeMarket && rateStr == "" {
 		t.Fatalf("RATE env var not set")
 	}
 
 	var rate float64
-	if orderType == OrderTypeLimit {
+	if orderType != OrderTypeMarket {
 		rate, err = strconv.ParseFloat(rateStr, 64)
 		if err != nil {
 			t.Fatalf("Invalid RATE: %v", err)

--- a/client/mm/libxc/coinbase_test.go
+++ b/client/mm/libxc/coinbase_test.go
@@ -52,8 +52,10 @@ func TestBuildCoinbaseOrderRequest(t *testing.T) {
 		orderType  OrderType
 		rate       uint64
 		qty        uint64
+		quoteQty   uint64
 		tradeID    string
 		expRequest *cbtypes.OrderRequest
+		wantQtyRet uint64
 		wantErr    bool
 	}{
 		{
@@ -76,6 +78,7 @@ func TestBuildCoinbaseOrderRequest(t *testing.T) {
 					},
 				},
 			},
+			wantQtyRet: btcAmt(0.1),
 		},
 		{
 			name:      "limit buy order 2",
@@ -97,6 +100,7 @@ func TestBuildCoinbaseOrderRequest(t *testing.T) {
 					},
 				},
 			},
+			wantQtyRet: btcAmt(0.1),
 		},
 		{
 			name:      "limit buy qty too low",
@@ -121,6 +125,50 @@ func TestBuildCoinbaseOrderRequest(t *testing.T) {
 			wantErr:   true,
 		},
 		{
+			name:      "limit buy with quote qty",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimit,
+			rate:      msgRate(100_000),
+			quoteQty:  usdcAmt(10000),
+			tradeID:   "test-trade-1",
+			expRequest: &cbtypes.OrderRequest{
+				ProductID:     "BTC-USDC",
+				Side:          "BUY",
+				ClientOrderID: "test-trade-1",
+				OrderConfig: &cbtypes.LimitOrderConfig{
+					Limit: cbtypes.LimitOrderConfigData{
+						BaseSize:   "0.10000000",
+						LimitPrice: "100000.00",
+					},
+				},
+			},
+			wantQtyRet: calc.QuoteToBase(msgRate(100_000), usdcAmt(10000)),
+		},
+		{
+			name:      "limit buy, quote qty leads to quantity too low",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimit,
+			rate:      msgRate(1e8),
+			quoteQty:  usdcAmt(0.01),
+			tradeID:   "test-trade-2",
+			wantErr:   true,
+		},
+		{
+			name:      "limit buy, quote qty leads to quantity too high",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimit,
+			rate:      msgRate(1),      // Very low rate means large base quantity
+			quoteQty:  mkt.MaxQuoteQty, // Use maximum quote quantity
+			tradeID:   "test-trade-2",
+			wantErr:   true,
+		},
+		{
 			name:      "limit sell order",
 			baseID:    btcID,
 			quoteID:   usdcID,
@@ -140,15 +188,127 @@ func TestBuildCoinbaseOrderRequest(t *testing.T) {
 					},
 				},
 			},
+			wantQtyRet: btcAmt(0.1),
+		},
+
+		{
+			name:      "limit ioc buy order 1",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimitIOC,
+			rate:      msgRate(100_000),
+			qty:       btcAmt(0.1),
+			tradeID:   "test-trade-1",
+			expRequest: &cbtypes.OrderRequest{
+				ProductID:     "BTC-USDC",
+				Side:          "BUY",
+				ClientOrderID: "test-trade-1",
+				OrderConfig: &cbtypes.LimitIocConfig{
+					SorLimitIoc: cbtypes.LimitIocConfigData{
+						BaseSize:   "0.10000000",
+						LimitPrice: "100000.00",
+					},
+				},
+			},
+			wantQtyRet: btcAmt(0.1),
 		},
 		{
-			name:      "market buy order",
+			name:      "limit ioc buy order 2",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimitIOC,
+			rate:      msgRate(100.12345),
+			qty:       btcAmt(0.1),
+			tradeID:   "test-trade-1",
+			expRequest: &cbtypes.OrderRequest{
+				ProductID:     "BTC-USDC",
+				Side:          "BUY",
+				ClientOrderID: "test-trade-1",
+				OrderConfig: &cbtypes.LimitIocConfig{
+					SorLimitIoc: cbtypes.LimitIocConfigData{
+						BaseSize:   "0.10000000",
+						LimitPrice: "100.12",
+					},
+				},
+			},
+			wantQtyRet: btcAmt(0.1),
+		},
+		{
+			name:      "limit ioc buy qty too low",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimitIOC,
+			rate:      msgRate(100.12345),
+			qty:       btcAmt(0),
+			tradeID:   "test-trade-2",
+			wantErr:   true,
+		},
+		{
+			name:      "limit ioc buy qty too high",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimitIOC,
+			rate:      msgRate(100.12345),
+			qty:       btcAmt(3400) + 1,
+			tradeID:   "test-trade-2",
+			wantErr:   true,
+		},
+		{
+			name:      "limit ioc buy with quote qty",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimitIOC,
+			rate:      msgRate(100_000),
+			quoteQty:  usdcAmt(10000),
+			tradeID:   "test-trade-1",
+			expRequest: &cbtypes.OrderRequest{
+				ProductID:     "BTC-USDC",
+				Side:          "BUY",
+				ClientOrderID: "test-trade-1",
+				OrderConfig: &cbtypes.LimitIocConfig{
+					SorLimitIoc: cbtypes.LimitIocConfigData{
+						BaseSize:   "0.10000000",
+						LimitPrice: "100000.00",
+					},
+				},
+			},
+			wantQtyRet: calc.QuoteToBase(msgRate(100_000), usdcAmt(10000)),
+		},
+		{
+			name:      "limit ioc sell order",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      true,
+			orderType: OrderTypeLimitIOC,
+			rate:      msgRate(100.12345),
+			qty:       btcAmt(0.1),
+			tradeID:   "test-trade-2",
+			expRequest: &cbtypes.OrderRequest{
+				ProductID:     "BTC-USDC",
+				Side:          "SELL",
+				ClientOrderID: "test-trade-2",
+				OrderConfig: &cbtypes.LimitIocConfig{
+					SorLimitIoc: cbtypes.LimitIocConfigData{
+						BaseSize:   "0.10000000",
+						LimitPrice: "100.12",
+					},
+				},
+			},
+			wantQtyRet: btcAmt(0.1),
+		},
+
+		{
+			name:      "market buy with quote qty",
 			baseID:    btcID,
 			quoteID:   usdcID,
 			sell:      false,
 			orderType: OrderTypeMarket,
-			rate:      0,
-			qty:       usdcAmt(5000),
+			quoteQty:  usdcAmt(5000),
 			tradeID:   "test-trade-3",
 			expRequest: &cbtypes.OrderRequest{
 				ProductID:     "BTC-USDC",
@@ -160,36 +320,35 @@ func TestBuildCoinbaseOrderRequest(t *testing.T) {
 					},
 				},
 			},
+			wantQtyRet: usdcAmt(5000), // For market orders with quoteQty, qtyToReturn is the quoteQty
 		},
 		{
-			name:      "market buy qty too low",
+			name:      "market buy with quote qty too low",
 			baseID:    btcID,
 			quoteID:   usdcID,
 			sell:      false,
 			orderType: OrderTypeMarket,
-			rate:      0,
-			qty:       usdcAmt(0.01) - 1,
+			quoteQty:  usdcAmt(0.01) - 1,
 			tradeID:   "test-trade-3",
 			wantErr:   true,
 		},
 		{
-			name:      "market buy qty too high",
+			name:      "market buy with quote qty too high",
 			baseID:    btcID,
 			quoteID:   usdcID,
 			sell:      false,
 			orderType: OrderTypeMarket,
-			rate:      0,
-			qty:       usdcAmt(150_000_000) + 1,
+			quoteQty:  usdcAmt(150_000_000) + 1,
 			tradeID:   "test-trade-3",
 			wantErr:   true,
 		},
+
 		{
-			name:      "market sell order",
+			name:      "market sell with base qty",
 			baseID:    btcID,
 			quoteID:   usdcID,
 			sell:      true,
 			orderType: OrderTypeMarket,
-			rate:      0,
 			qty:       btcAmt(2),
 			tradeID:   "test-trade-4",
 			expRequest: &cbtypes.OrderRequest{
@@ -202,26 +361,68 @@ func TestBuildCoinbaseOrderRequest(t *testing.T) {
 					},
 				},
 			},
+			wantQtyRet: btcAmt(2),
 		},
 		{
-			name:      "market sell qty too low",
+			name:      "market sell with base qty too low",
 			baseID:    btcID,
 			quoteID:   usdcID,
 			sell:      true,
 			orderType: OrderTypeMarket,
-			rate:      0,
 			qty:       btcAmt(0.00000001) - 1,
 			tradeID:   "test-trade-3",
 			wantErr:   true,
 		},
 		{
-			name:      "market sell qty too high",
+			name:      "market sell with base qty too high",
 			baseID:    btcID,
 			quoteID:   usdcID,
 			sell:      true,
 			orderType: OrderTypeMarket,
-			rate:      0,
 			qty:       btcAmt(3400) + 1,
+			tradeID:   "test-trade-3",
+			wantErr:   true,
+		},
+
+		{
+			name:      "cannot specify both qty and quote qty",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimit,
+			rate:      msgRate(100_000),
+			qty:       btcAmt(0.1),
+			quoteQty:  usdcAmt(10000),
+			tradeID:   "test-trade-1",
+			wantErr:   true,
+		},
+		{
+			name:      "must specify quantity or quote quantity",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeLimit,
+			rate:      msgRate(100_000),
+			tradeID:   "test-trade-1",
+			wantErr:   true,
+		},
+		{
+			name:      "quote quantity cannot be used for sell orders",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      true,
+			orderType: OrderTypeMarket,
+			quoteQty:  usdcAmt(5000),
+			tradeID:   "test-trade-3",
+			wantErr:   true,
+		},
+		{
+			name:      "quoteQty MUST be used for market buys",
+			baseID:    btcID,
+			quoteID:   usdcID,
+			sell:      false,
+			orderType: OrderTypeMarket,
+			qty:       btcAmt(0.1),
 			tradeID:   "test-trade-3",
 			wantErr:   true,
 		},
@@ -229,7 +430,7 @@ func TestBuildCoinbaseOrderRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := buildOrderRequest(mkt, tt.baseID, tt.quoteID, tt.sell, tt.orderType, tt.rate, tt.qty, tt.tradeID)
+			req, qtyRet, err := buildOrderRequest(mkt, tt.baseID, tt.quoteID, tt.sell, tt.orderType, tt.rate, tt.qty, tt.quoteQty, tt.tradeID)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("expected error, got nil")
@@ -242,6 +443,9 @@ func TestBuildCoinbaseOrderRequest(t *testing.T) {
 			}
 			if !reflect.DeepEqual(req, tt.expRequest) {
 				t.Errorf("expected request %s, got %s", spew.Sdump(tt.expRequest), spew.Sdump(req))
+			}
+			if qtyRet != tt.wantQtyRet {
+				t.Errorf("buildOrderRequest() qtyRet = %v, want %v", qtyRet, tt.wantQtyRet)
 			}
 		})
 	}

--- a/client/mm/libxc/interface.go
+++ b/client/mm/libxc/interface.go
@@ -89,6 +89,7 @@ type OrderType uint8
 const (
 	OrderTypeLimit OrderType = iota
 	OrderTypeMarket
+	OrderTypeLimitIOC
 )
 
 // CEX implements a set of functions that can be used to interact with a
@@ -117,13 +118,15 @@ type CEX interface {
 	// Trade executes a trade on the CEX.
 	//   - subscriptionID takes an ID returned from SubscribeTradeUpdates.
 	//   - Rate is ignored for market orders.
-	//   - Qty is in units of base asset, except for market buys where it is in
-	//     units of quote asset.
-	Trade(ctx context.Context, baseID, quoteID uint32, sell bool, rate, qty uint64, orderType OrderType, subscriptionID int) (*Trade, error)
+	//   - Qty is in units of base asset, quoteQty is in units of quote asset.
+	//     Only one of qty or quoteQty should be non-zero.
+	//   - QuoteQty is only allowed for BUY orders, and it is required for market
+	//     buy orders.
+	Trade(ctx context.Context, baseID, quoteID uint32, sell bool, rate, qty, quoteQty uint64, orderType OrderType, subscriptionID int) (*Trade, error)
 	// ValidateTrade validates a trade before it is executed. This is used to
 	// ensure that the trade will be able to be executed on the CEX before trades
 	// are placed on the DEX orderbook expecting to be able to be arbitraged.
-	ValidateTrade(baseID, quoteID uint32, sell bool, rate, qty uint64, orderType OrderType) error
+	ValidateTrade(baseID, quoteID uint32, sell bool, rate, qty, quoteQty uint64, orderType OrderType) error
 	// UnsubscribeMarket unsubscribes from order book updates on a market.
 	UnsubscribeMarket(baseID, quoteID uint32) error
 	// VWAP returns the volume weighted average price for a certain quantity

--- a/client/mm/mm_arb_market_maker.go
+++ b/client/mm/mm_arb_market_maker.go
@@ -28,16 +28,38 @@ type ArbMarketMakingPlacement struct {
 	Multiplier float64 `json:"multiplier"`
 }
 
-// MultiHopCfg is the configuration for a multi-hop market maker. It
-// specifies the two markets on the CEX that the bot will use to make
-// an arbitrage trade. The BaseAssetMarket is the market on which the
-// base asset of the DEX market is traded. The QuoteAssetMarket is the
-// market on which the quote asset of the DEX market is traded. The
-// other asset (other than the DEX base or quote asset) on each market
-// must be the same.
+// MultiHopCfg is the configuration for a multi-hop market maker.
+// A multi-hop arb market maker is a market maker that uses two
+// markets on the CEX to make an arbitrage trade. For example, if
+// there is a DCR/BTC market on the DEX, but does not have a DCR/BTC
+// market, this bot can use the DCR/USDT and BTC/USDT markets on the CEX
+// to make an arbitrage trade. The first leg of the multi-hop arb will
+// be a Limit IOC order, then depending on the configuration, the second
+// leg will be either a Market trade or a Limit order (which is open for
+// NumEpochsLeaveOpen epochs) to limit the amount of funds stuck in the
+// intermediate asset.
 type MultiHopCfg struct {
-	BaseAssetMarket  [2]uint32 `json:"baseAssetMarket"`
+	// BaseAssetMarket is the market on the CEX that the base asset of the
+	// DEX market is traded on. The "other" asset on the market must be the
+	// same as the "other" asset on the QuoteAssetMarket.
+	BaseAssetMarket [2]uint32 `json:"baseAssetMarket"`
+	// QuoteAssetMarket is the market on the CEX that the quote asset of the
+	// DEX market is traded on. The other asset on the market must be the
+	// same as the "other" asset on the BaseAssetMarket.
 	QuoteAssetMarket [2]uint32 `json:"quoteAssetMarket"`
+	// MarketOrders set to true means that the second leg of the multi-hop
+	// arb will be a market order. This allows the bot to never have any
+	// funds stuck in the intermediate asset, but may result in the bot
+	// incurring losses if there is a sudden price change.
+	MarketOrders bool `json:"marketOrders"`
+	// LimitOrdersBuffer is only relevant if MarketOrders is false. It
+	// specifies a percentage to adjust the limit order rate for the
+	// second leg of the multi-hop arb. It will adjust the rate in
+	// the less profitable direction, i.e. lower for sell orders and
+	// higher for buy orders. The purpose of the buffer is to increase
+	// the probability of the trade being filled in order to avoid having
+	// funds stuck in the intermediate asset.
+	LimitOrdersBuffer float64 `json:"limitOrdersBuffer"`
 }
 
 // ArbMarketMakerConfig is the configuration for a market maker that places
@@ -203,6 +225,11 @@ type placementLots struct {
 	quoteLots uint64
 }
 
+type cexTradeInfo struct {
+	epochPlaced       uint64
+	followUpTradeRate uint64
+}
+
 type arbMarketMaker struct {
 	*unifiedExchangeAdaptor
 	cex              botCexAdaptor
@@ -211,12 +238,19 @@ type arbMarketMaker struct {
 	rebalanceRunning atomic.Bool
 	currEpoch        atomic.Uint64
 
-	matchesMtx    sync.Mutex
-	matchesSeen   map[order.MatchID]bool
-	pendingOrders map[order.OrderID]uint64 // orderID -> rate for counter trade on cex
+	matchesMtx  sync.Mutex
+	matchesSeen map[order.MatchID]bool
+	// orderArbRates maps from orderID to the counter trade rate(s) on the CEX.
+	// If the bot is configured for multi-hop, there will be two rates, one for
+	// the first leg and one for the second leg. Otherwise, only the first rate
+	// will be populated.
+	orderArbRates map[order.OrderID][2]uint64
+	// orderIndex maps sell -> orderID -> placement index. This is used to
+	// update the arb rates for existing orders.
+	orderIndex map[bool]map[order.OrderID]int
 
 	cexTradesMtx sync.RWMutex
-	cexTrades    map[string]uint64
+	cexTrades    map[string]*cexTradeInfo
 }
 
 var _ bot = (*arbMarketMaker)(nil)
@@ -225,49 +259,83 @@ func (a *arbMarketMaker) cfg() *ArbMarketMakerConfig {
 	return a.botCfg().ArbMarketMakerConfig
 }
 
+// worsenRate adjusts the rate in the less profitable direction, i.e. lower
+// for sell orders and higher for buy orders.
+func worsenRate(rate uint64, buffer float64, sell bool) uint64 {
+	if buffer <= 0 {
+		return rate
+	}
+	multiplier := 1.0
+	if sell {
+		multiplier -= buffer
+	} else {
+		multiplier += buffer
+	}
+	adjusted := float64(rate) * multiplier
+	if sell {
+		return uint64(math.Floor(adjusted))
+	}
+	return uint64(math.Ceil(adjusted))
+}
+
 // multiHopArbCompletionParams is called when a trade is completed on the
-// CEX. It checks if the completion of this trade should trigger another
-// trade on the CEX that will complete the multi-hop arbitrage and returns
-// the parameters of that trade.
-func (a *arbMarketMaker) multiHopArbCompletionParams(update *libxc.Trade) (makeTrade bool, baseID, quoteID uint32, sell bool, qty uint64) {
-	if !update.Market {
-		// multi-hop arbs always use market trades on the CEX.
-		return
+// CEX. It checks if the completion of this trade should trigger the second
+// leg of the multi-hop arb, and if so, returns the parameters of that trade.
+func (a *arbMarketMaker) multiHopArbCompletionParams(update *libxc.Trade, followUpRate uint64) (makeTrade bool, orderType libxc.OrderType, baseID, quoteID uint32, sell bool, qty, quoteQty, rate uint64) {
+	fail := func(err error) (bool, libxc.OrderType, uint32, uint32, bool, uint64, uint64, uint64) {
+		if err != nil {
+			a.log.Error(err)
+		}
+		return false, libxc.OrderTypeLimit, 0, 0, false, 0, 0, 0
 	}
 
 	multiHopCfg := a.cfg().MultiHop
-	baseAssetMarket := a.baseID == update.BaseID || a.baseID == update.QuoteID
-	quoteAssetMarket := a.quoteID == update.BaseID || a.quoteID == update.QuoteID
+	updateOnBaseAssetMarket := a.baseID == update.BaseID || a.baseID == update.QuoteID
+	updateOnQuoteAssetMarket := a.quoteID == update.BaseID || a.quoteID == update.QuoteID
 
-	if baseAssetMarket {
-		baseID = multiHopCfg.QuoteAssetMarket[0]
-		quoteID = multiHopCfg.QuoteAssetMarket[1]
-		sell = multiHopCfg.QuoteAssetMarket[1] == a.quoteID
-		if a.baseID == update.BaseID {
-			qty = update.QuoteFilled
-			makeTrade = update.Sell
-		} else {
-			qty = update.BaseFilled
-			makeTrade = !update.Sell
-		}
-	} else if quoteAssetMarket {
-		baseID = multiHopCfg.BaseAssetMarket[0]
-		quoteID = multiHopCfg.BaseAssetMarket[1]
-		sell = multiHopCfg.BaseAssetMarket[1] == a.baseID
-		if a.quoteID == update.QuoteID {
-			qty = update.BaseFilled
-			makeTrade = !update.Sell
-		} else {
-			qty = update.QuoteFilled
-			makeTrade = update.Sell
-		}
+	var market [2]uint32
+	var fromAssetID, toAssetID uint32
+	switch {
+	case updateOnBaseAssetMarket:
+		market = multiHopCfg.QuoteAssetMarket
+		fromAssetID = a.baseID
+		toAssetID = a.quoteID
+	case updateOnQuoteAssetMarket:
+		market = multiHopCfg.BaseAssetMarket
+		fromAssetID = a.quoteID
+		toAssetID = a.baseID
+	default:
+		return fail(fmt.Errorf("trade is not on the base or quote asset market: %+v", update))
+	}
+	baseID = market[0]
+	quoteID = market[1]
+
+	// Set sell, qty, quoteQty, and makeTrade
+	sell = market[1] == toAssetID
+	if fromAssetID == update.BaseID {
+		qty = update.QuoteFilled
+		makeTrade = update.Sell
 	} else {
-		a.log.Errorf("multiHopArbCompletionParams: trade is on unknown market: %+v", update)
-		return false, 0, 0, false, 0
+		qty = update.BaseFilled
+		makeTrade = !update.Sell
+	}
+	if !makeTrade {
+		return fail(nil)
+	}
+	if !sell {
+		quoteQty = qty
+		qty = 0
 	}
 
-	if !makeTrade {
-		return false, 0, 0, false, 0
+	// Set the order type and rate.
+	orderType = libxc.OrderTypeMarket
+	rate = 0
+	if !multiHopCfg.MarketOrders {
+		orderType = libxc.OrderTypeLimit
+		rate = worsenRate(followUpRate, multiHopCfg.LimitOrdersBuffer, sell)
+		if rate == 0 {
+			return fail(fmt.Errorf("worsenRate returned 0 rate"))
+		}
 	}
 
 	return
@@ -279,7 +347,8 @@ func (a *arbMarketMaker) handleCEXTradeUpdate(update *libxc.Trade) {
 	}
 
 	a.cexTradesMtx.Lock()
-	if _, ok := a.cexTrades[update.ID]; !ok {
+	cexTradeInfo, ok := a.cexTrades[update.ID]
+	if !ok {
 		a.cexTradesMtx.Unlock()
 		return
 	}
@@ -291,22 +360,17 @@ func (a *arbMarketMaker) handleCEXTradeUpdate(update *libxc.Trade) {
 		return
 	}
 
-	if !update.Market {
-		a.log.Errorf("multi hop bot cex trade is not a market trade: %+v", update)
-		return
-	}
-
-	makeTrade, baseID, quoteID, sell, qty := a.multiHopArbCompletionParams(update)
+	makeTrade, orderType, baseID, quoteID, sell, qty, quoteQty, rate := a.multiHopArbCompletionParams(update, cexTradeInfo.followUpTradeRate)
 	if makeTrade {
-		a.tradeOnCEX(baseID, quoteID, 0, qty, sell, libxc.OrderTypeMarket)
+		a.tradeOnCEX(baseID, quoteID, rate, qty, quoteQty, sell, orderType, 0)
 	}
 }
 
 // tradeOnCEX executes a trade on the CEX.
-func (a *arbMarketMaker) tradeOnCEX(baseID, quoteID uint32, rate, qty uint64, sell bool, orderType libxc.OrderType) {
+func (a *arbMarketMaker) tradeOnCEX(baseID, quoteID uint32, rate, qty, quoteQty uint64, sell bool, orderType libxc.OrderType, followUpRate uint64) {
 	a.cexTradesMtx.Lock()
 
-	cexTrade, err := a.cex.CEXTrade(a.ctx, baseID, quoteID, sell, rate, qty, orderType)
+	cexTrade, err := a.cex.CEXTrade(a.ctx, baseID, quoteID, sell, rate, qty, quoteQty, orderType)
 	if err != nil {
 		a.cexTradesMtx.Unlock()
 		a.log.Errorf("Error sending trade to CEX: %v", err)
@@ -316,7 +380,10 @@ func (a *arbMarketMaker) tradeOnCEX(baseID, quoteID uint32, rate, qty uint64, se
 	// Keep track of the epoch in which the trade was sent to the CEX. This way
 	// the bot can cancel the trade if it is not filled after a certain number
 	// of epochs.
-	a.cexTrades[cexTrade.ID] = a.currEpoch.Load()
+	a.cexTrades[cexTrade.ID] = &cexTradeInfo{
+		epochPlaced:       a.currEpoch.Load(),
+		followUpTradeRate: followUpRate,
+	}
 	a.cexTradesMtx.Unlock()
 
 	a.handleCEXTradeUpdate(cexTrade)
@@ -325,61 +392,79 @@ func (a *arbMarketMaker) tradeOnCEX(baseID, quoteID uint32, rate, qty uint64, se
 // initiateMultiHopArb is called when a DEX order is matched and a multi-hop
 // arb should be started. The second trade of the multi-hop arb is executed
 // when this trade is complete.
-func (a *arbMarketMaker) initiateMultiHopArb(dexSell bool, match *core.Match) {
-	cfg := a.cfg()
-	var baseID, quoteID uint32
-	var sell bool
-	var qty uint64
+func (a *arbMarketMaker) initiateMultiHopArb(dexSell bool, matchRate, matchQty uint64, arbRates [2]uint64) {
+	cfg := a.cfg().MultiHop
 
+	// Determine the CEX market and trade direction.
+	var cexMarket [2]uint32
+	var sell bool
 	if dexSell {
-		baseID = cfg.MultiHop.QuoteAssetMarket[0]
-		quoteID = cfg.MultiHop.QuoteAssetMarket[1]
-		sell = a.quoteID == baseID
-		qty = calc.BaseToQuote(match.Rate, match.Qty)
+		cexMarket = cfg.QuoteAssetMarket
+		sell = cexMarket[0] == a.quoteID
 	} else {
-		baseID = cfg.MultiHop.BaseAssetMarket[0]
-		quoteID = cfg.MultiHop.BaseAssetMarket[1]
-		sell = a.baseID == baseID
-		qty = match.Qty
+		cexMarket = cfg.BaseAssetMarket
+		sell = cexMarket[0] == a.baseID
 	}
 
-	a.tradeOnCEX(baseID, quoteID, 0, qty, sell, libxc.OrderTypeMarket)
+	// Calculate the quantity for the first CEX leg.
+	// The qty is in the base asset of the CEX market.
+	var cexQty uint64
+	if dexSell {
+		cexQty = calc.BaseToQuote(matchRate, matchQty)
+	} else {
+		cexQty = matchQty
+	}
+	if !sell {
+		cexQty = calc.QuoteToBase(arbRates[0], cexQty)
+	}
+
+	// Execute the first leg as a Limit IOC order.
+	a.tradeOnCEX(cexMarket[0], cexMarket[1], arbRates[0], cexQty, 0 /* quoteQty */, sell, libxc.OrderTypeLimitIOC, arbRates[1])
 }
 
 func (a *arbMarketMaker) processDEXOrderUpdate(o *core.Order) {
 	var orderID order.OrderID
 	copy(orderID[:], o.ID)
 
+	// Determine the arb rates and the new matches.
 	a.matchesMtx.Lock()
-	defer a.matchesMtx.Unlock()
-
-	cexRate, found := a.pendingOrders[orderID]
+	cexRates, found := a.orderArbRates[orderID]
 	if !found {
+		a.matchesMtx.Unlock()
 		return
 	}
-
+	newMatches := make([]*core.Match, 0, len(o.Matches))
 	for _, match := range o.Matches {
 		var matchID order.MatchID
 		copy(matchID[:], match.MatchID)
+		if a.matchesSeen[matchID] {
+			continue
+		}
+		a.matchesSeen[matchID] = true
+		newMatches = append(newMatches, match)
+	}
+	a.matchesMtx.Unlock()
 
-		if !a.matchesSeen[matchID] {
-			a.matchesSeen[matchID] = true
-
-			if a.cfg().isMultiHop() {
-				a.initiateMultiHopArb(o.Sell, match)
-			} else {
-				a.tradeOnCEX(a.baseID, a.quoteID, cexRate, match.Qty, !o.Sell, libxc.OrderTypeLimit)
-			}
+	// Execute the cex trades.
+	for _, match := range newMatches {
+		if a.cfg().isMultiHop() {
+			a.initiateMultiHopArb(o.Sell, match.Rate, match.Qty, cexRates)
+		} else {
+			a.tradeOnCEX(a.baseID, a.quoteID, cexRates[0], match.Qty, 0 /* quoteQty */, !o.Sell, libxc.OrderTypeLimit, 0)
 		}
 	}
 
+	// If the order will have no more matches, remove it from memory.
 	if !o.Status.IsActive() {
-		delete(a.pendingOrders, orderID)
+		a.matchesMtx.Lock()
+		delete(a.orderArbRates, orderID)
+		delete(a.orderIndex[o.Sell], orderID)
 		for _, match := range o.Matches {
 			var matchID order.MatchID
 			copy(matchID[:], match.MatchID)
 			delete(a.matchesSeen, matchID)
 		}
+		a.matchesMtx.Unlock()
 	}
 }
 
@@ -391,8 +476,8 @@ func (a *arbMarketMaker) cancelExpiredCEXTrades() {
 	a.cexTradesMtx.RLock()
 	defer a.cexTradesMtx.RUnlock()
 
-	for tradeID, epoch := range a.cexTrades {
-		if currEpoch-epoch >= a.cfg().NumEpochsLeaveOpen {
+	for tradeID, cexTradeInfo := range a.cexTrades {
+		if currEpoch-cexTradeInfo.epochPlaced >= a.cfg().NumEpochsLeaveOpen {
 			err := a.cex.CancelTrade(a.ctx, a.baseID, a.quoteID, tradeID)
 			if err != nil {
 				a.log.Errorf("Error canceling CEX trade %s: %v", tradeID, err)
@@ -463,39 +548,34 @@ func convRate(rate uint64, baseID, quoteID uint32) float64 {
 	return calc.ConventionalRate(rate, baseUI, quoteUI)
 }
 
-// aggregateRates returns the rate on a DEX market based on the rates on two
-// CEX markets. One of the CEX markets contains the DEX market's base asset,
-// and the other contains the DEX market's quote asset. The two CEX markets
-// must both contain the same third asset.
+// aggregateRates computes the effective rate on a DEX market by combining rates
+// from two CEX markets. One CEX market involves the DEX base asset, the other
+// the DEX quote asset, sharing a common intermediate asset. Inversions are
+// applied if the asset order on CEX markets differs from DEX expectations.
 func aggregateRates(baseMarketRate, quoteMarketRate uint64, mkt *market, baseMarket, quoteMarket [2]uint32) uint64 {
 	convBaseRate := convRate(baseMarketRate, baseMarket[0], baseMarket[1])
-	convQuoteRate := convRate(quoteMarketRate, quoteMarket[0], quoteMarket[1])
 	if mkt.baseID != baseMarket[0] {
 		convBaseRate = 1 / convBaseRate
 	}
+
+	convQuoteRate := convRate(quoteMarketRate, quoteMarket[0], quoteMarket[1])
 	if mkt.quoteID != quoteMarket[1] {
 		convQuoteRate = 1 / convQuoteRate
 	}
+
 	convAggRate := convBaseRate * convQuoteRate
 	return msgRate(convAggRate, mkt.baseID, mkt.quoteID)
 }
 
 type vwapFunc func(baseID, quoteID uint32, sell bool, qty uint64) (vwap uint64, extrema uint64, filled bool, err error)
 
-// multiHopPriceExtrema calculates the extrema price for buying or selling a
-// certain asset on one of the multi hop markets.
-//
-//   - assetID is the asset to which assetQty and receiveAsset refer.
-//   - receiveAsset specifies whether you want to receive the asset or use it
-//     to acquire the counter asset.
-//     We use "receiveAsset" rather than "sell" to avoid confusion, because the
-//     asset may be the base or quote asset of the market.
-//   - counterQty is the amount of the counter asset that will be received as a
-//     result of the multi-hop trade.
-//
-// For example, on a DCR/USDT market, if assetID is USDT, and receiveAsset is false,
-// this means that we will be buying DCR on the CEX using qty USDT.
-func multiHopPriceExtrema(market [2]uint32, assetID uint32, depth uint64, receiveAsset bool,
+// tradeAssetPriceExtrema calculates the current extrema price for acquiring
+// or spending a specified asset on a multi-hop market.
+// - assetID identifies the target asset.
+// - receiveAsset is true if acquiring the asset (buy), false if spending it (sell).
+// - Returns the extrema rate, counter-asset quantity, fill status, and any error.
+// If the fill status is false, the extrema rate is 0.
+func tradeAssetPriceExtrema(market [2]uint32, assetID uint32, depth uint64, receiveAsset bool,
 	vwapF, invVwapF vwapFunc) (extrema, counterQty uint64, filled bool, err error) {
 
 	var f vwapFunc
@@ -510,10 +590,10 @@ func multiHopPriceExtrema(market [2]uint32, assetID uint32, depth uint64, receiv
 
 	_, extrema, filled, err = f(market[0], market[1], sell, depth)
 	if err != nil {
-		return 0, 0, false, fmt.Errorf("error getting VWAP: %w", err)
+		return 0, 0, false, fmt.Errorf("VWAP error: %w", err)
 	}
 	if !filled {
-		return
+		return 0, 0, false, nil
 	}
 
 	if assetID == market[0] {
@@ -531,81 +611,133 @@ type arbTradeArgs struct {
 	orderType libxc.OrderType
 	rate      uint64
 	qty       uint64
+	quoteQty  uint64
 	sell      bool
 }
 
-func multiHopArbTrades(mkt [2]uint32, sell bool, assetID uint32, minQty, maxQty, rate uint64) []*arbTradeArgs {
-	qtys := [2]uint64{}
-	if sell && (mkt[0] == assetID) {
-		qtys[0] = minQty
-		qtys[1] = maxQty
-	} else if sell && (mkt[1] == assetID) {
-		qtys[0] = calc.QuoteToBase(rate, minQty)
-		qtys[1] = calc.QuoteToBase(rate, maxQty)
-	} else if !sell && (mkt[0] == assetID) {
-		qtys[0] = calc.BaseToQuote(rate, minQty)
-		qtys[1] = calc.BaseToQuote(rate, maxQty)
-	} else {
-		qtys[0] = minQty
-		qtys[1] = maxQty
+// multiHopArbTrades determines the parameters for the trades that will
+// be executed on the DEX to make a multi-hop arb trade. It will return
+// two trades, one for the min quantity and one for the max quantity.
+func multiHopArbTrades(mkt [2]uint32, sell bool, qtyAssetID uint32, minQty, maxQty uint64, rate uint64, cfg *MultiHopCfg, isFirstLeg bool) []*arbTradeArgs {
+	orderType := libxc.OrderTypeLimitIOC
+	buffer := 0.0
+	if !isFirstLeg {
+		if cfg.MarketOrders {
+			orderType = libxc.OrderTypeMarket
+		} else {
+			orderType = libxc.OrderTypeLimit
+			buffer = cfg.LimitOrdersBuffer
+		}
 	}
-	return []*arbTradeArgs{
-		{baseID: mkt[0], quoteID: mkt[1], sell: sell, qty: qtys[0], orderType: libxc.OrderTypeMarket},
-		{baseID: mkt[0], quoteID: mkt[1], sell: sell, qty: qtys[1], orderType: libxc.OrderTypeMarket},
+
+	if orderType != libxc.OrderTypeMarket {
+		rate = worsenRate(rate, buffer, sell)
 	}
+
+	// Only buy orders on the second leg of a multi-hop trade will be in the
+	// quote asset, in order to be able to specify the total quantity that
+	// should be traded.
+	qtyIsQuote := !isFirstLeg && !sell
+
+	qtys := []uint64{minQty, maxQty}
+	if !qtyIsQuote && qtyAssetID != mkt[0] {
+		for i := range qtys {
+			qtys[i] = calc.QuoteToBase(rate, qtys[i])
+		}
+	} else if qtyIsQuote && qtyAssetID != mkt[1] {
+		for i := range qtys {
+			qtys[i] = calc.BaseToQuote(rate, qtys[i])
+		}
+	}
+
+	if orderType == libxc.OrderTypeMarket {
+		rate = 0
+	}
+
+	trades := make([]*arbTradeArgs, len(qtys))
+	for i, q := range qtys {
+		trades[i] = &arbTradeArgs{
+			baseID:    mkt[0],
+			quoteID:   mkt[1],
+			orderType: orderType,
+			rate:      rate,
+			sell:      sell,
+		}
+		if qtyIsQuote {
+			trades[i].quoteQty = q
+		} else {
+			trades[i].qty = q
+		}
+	}
+
+	return trades
 }
 
-// multiHopRateAndTrades returns the aggregate rate that can be achieved by
-// completing a multi-hop trade, and the minimum and maximum quantities for
-// the trades on both the base and quote asset markets.
-func multiHopRateAndTrades(sellOnDEX bool, depth, numLots uint64, multiHopCfg *MultiHopCfg, mkt *market, vwap, invVwap vwapFunc) (uint64, bool, []*arbTradeArgs, error) {
+// multiHopRateAndTrades determines whether the trade can be filled, the
+// aggregate rate of a multi-hop trade, the rates for the two legs of the
+// multi-hop trade, and the arguments for the trades with the expected min
+// and max quantities (which can be used for trade validation).
+func multiHopRateAndTrades(sellOnDEX bool, depth, numLots uint64, multiHopCfg *MultiHopCfg, mkt *market, vwap, invVwap vwapFunc) (filled bool, aggregateRate uint64, multiHopRates [2]uint64, trades []*arbTradeArgs, err error) {
+	fail := func(err error) (bool, uint64, [2]uint64, []*arbTradeArgs, error) {
+		return false, 0, [2]uint64{}, nil, err
+	}
+
 	intermediateAsset := multiHopCfg.BaseAssetMarket[0]
 	if mkt.baseID == intermediateAsset {
 		intermediateAsset = multiHopCfg.BaseAssetMarket[1]
 	}
 
-	// First, we find the extrema price for buying or selling the base asset on
-	// the base asset market.
-	// intAssetQty is either the quantity of the intermediate asset that will
-	// be received by selling "depth" units of the base asset, or the amount
-	// required to buy "depth" units of the base asset.
-	receiveBase := !sellOnDEX
-	baseRate, intAssetQty, filled, err := multiHopPriceExtrema(multiHopCfg.BaseAssetMarket, mkt.baseID, depth, receiveBase, vwap, invVwap)
+	// Compute price extrema for base asset leg.
+	receiveBaseOnDEX := !sellOnDEX
+	baseRate, intAssetQty, filled, err := tradeAssetPriceExtrema(multiHopCfg.BaseAssetMarket, mkt.baseID, depth, receiveBaseOnDEX, vwap, invVwap)
 	if err != nil {
-		return 0, false, nil, fmt.Errorf("error getting intermediate market VWAP: %w", err)
+		return fail(fmt.Errorf("error getting intermediate market VWAP: %w", err))
 	}
 	if !filled {
-		return 0, false, nil, nil
+		return fail(nil)
 	}
 
-	baseMktSell := receiveBase != (multiHopCfg.BaseAssetMarket[0] == mkt.baseID)
-	lotSize := mkt.lotSize.Load()
-	baseArbTrades := multiHopArbTrades(multiHopCfg.BaseAssetMarket, !baseMktSell, mkt.baseID, lotSize, lotSize*numLots, baseRate)
-
-	// Next we find the rate on the quote asset market to buy or sell the
-	// required amount of the intermediate asset.
+	// Compute price extrema for quote asset leg.
 	receiveIntermediate := !sellOnDEX
-	quoteRate, _, filled, err := multiHopPriceExtrema(multiHopCfg.QuoteAssetMarket, intermediateAsset, intAssetQty, receiveIntermediate, vwap, invVwap)
+	quoteRate, _, filled, err := tradeAssetPriceExtrema(multiHopCfg.QuoteAssetMarket, intermediateAsset, intAssetQty, receiveIntermediate, vwap, invVwap)
 	if err != nil {
-		return 0, false, nil, fmt.Errorf("error getting target market VWAP: %w", err)
+		return fail(fmt.Errorf("error getting target market VWAP: %w", err))
 	}
 	if !filled {
-		return 0, false, nil, nil
+		return fail(nil)
 	}
 
-	quoteMktSell := receiveIntermediate != (multiHopCfg.QuoteAssetMarket[1] == mkt.quoteID)
-	var intAssetMinQty uint64
+	// Aggregate the rates.
+	aggregatedRate := aggregateRates(baseRate, quoteRate, mkt, multiHopCfg.BaseAssetMarket, multiHopCfg.QuoteAssetMarket)
+
+	if sellOnDEX {
+		multiHopRates = [2]uint64{quoteRate, baseRate}
+	} else {
+		multiHopRates = [2]uint64{baseRate, quoteRate}
+	}
+
+	// Determine the potential parameters for the trade on the base asset market
+	receiveBaseOnCEX := !receiveBaseOnDEX
+	baseMktSell := receiveBaseOnCEX != (multiHopCfg.BaseAssetMarket[0] == mkt.baseID)
+	lotSize := mkt.lotSize.Load()
+	firstLegIsBase := !sellOnDEX
+	baseArbTrades := multiHopArbTrades(multiHopCfg.BaseAssetMarket, baseMktSell, mkt.baseID, lotSize, lotSize*numLots, baseRate, multiHopCfg, firstLegIsBase)
+
+	// Determine the potential parameters for the trade on the quote asset market
+	receiveIntermediateOnCEX := !receiveIntermediate
+	quoteMktSell := receiveIntermediateOnCEX != (multiHopCfg.QuoteAssetMarket[1] == mkt.quoteID)
+	var intAssetMinQty, intAssetMaxQty uint64
 	if multiHopCfg.BaseAssetMarket[0] == mkt.baseID {
 		intAssetMinQty = calc.BaseToQuote(baseRate, lotSize)
+		intAssetMaxQty = calc.BaseToQuote(baseRate, lotSize*numLots)
 	} else {
 		intAssetMinQty = calc.QuoteToBase(baseRate, lotSize)
+		intAssetMaxQty = calc.QuoteToBase(baseRate, lotSize*numLots)
 	}
-	quoteArbTrades := multiHopArbTrades(multiHopCfg.QuoteAssetMarket, !quoteMktSell, intermediateAsset, intAssetMinQty, intAssetMinQty*numLots, quoteRate)
+	quoteArbTrades := multiHopArbTrades(multiHopCfg.QuoteAssetMarket, quoteMktSell, intermediateAsset, intAssetMinQty, intAssetMaxQty, quoteRate, multiHopCfg, !firstLegIsBase)
 	allArbTrades := append(baseArbTrades, quoteArbTrades...)
 
-	// Finally, we aggregate the rates.
-	aggregatedRate := aggregateRates(baseRate, quoteRate, mkt, multiHopCfg.BaseAssetMarket, multiHopCfg.QuoteAssetMarket)
-	return aggregatedRate, true, allArbTrades, nil
+	return true, aggregatedRate, multiHopRates, allArbTrades, nil
 }
 
 // singleHopRateAndTrades returns the extrema rate for buying or selling
@@ -642,12 +774,13 @@ func singleHopRateAndTrades(sell bool, depth, numLots uint64, mkt *market, vwap,
 // certain quantity on the CEX, either directly on a matching market, or via
 // a multi-hop trade. It also returns the potential arb trades that may
 // be executed, with the minimum and maximum quantities for those arb trades.
-func arbMMExtremaAndTrades(sell bool, depth, numLots uint64, multiHopCfg *MultiHopCfg, mkt *market, vwap, invVwap vwapFunc) (uint64, bool, []*arbTradeArgs, error) {
+func arbMMExtremaAndTrades(sell bool, depth, numLots uint64, multiHopCfg *MultiHopCfg, mkt *market, vwap, invVwap vwapFunc) (filled bool, cexRate uint64, multiHopRates [2]uint64, trades []*arbTradeArgs, err error) {
 	if multiHopCfg != nil {
 		return multiHopRateAndTrades(sell, depth, numLots, multiHopCfg, mkt, vwap, invVwap)
 	}
 
-	return singleHopRateAndTrades(sell, depth, numLots, mkt, vwap, invVwap)
+	cexRate, filled, trades, err = singleHopRateAndTrades(sell, depth, numLots, mkt, vwap, invVwap)
+	return
 }
 
 // validateArbTrades validates the potential arb trades that may be executed in
@@ -655,7 +788,7 @@ func arbMMExtremaAndTrades(sell bool, depth, numLots uint64, multiHopCfg *MultiH
 // would be invalid.
 func (a *arbMarketMaker) validateArbTrades(arbTrades []*arbTradeArgs) error {
 	for _, arbTrade := range arbTrades {
-		err := a.cex.ValidateTrade(arbTrade.baseID, arbTrade.quoteID, arbTrade.sell, arbTrade.rate, arbTrade.qty, arbTrade.orderType)
+		err := a.cex.ValidateTrade(arbTrade.baseID, arbTrade.quoteID, arbTrade.sell, arbTrade.rate, arbTrade.qty, arbTrade.quoteQty, arbTrade.orderType)
 		if err != nil {
 			return err
 		}
@@ -671,7 +804,7 @@ func (a *arbMarketMaker) ordersToPlace() (buys, sells []*TradePlacement, err err
 		for i, cfgPlacement := range cfgPlacements {
 			cumulativeCEXDepth += uint64(float64(cfgPlacement.Lots*lotSize) * cfgPlacement.Multiplier)
 
-			cexRate, filled, arbTrades, err := arbMMExtremaAndTrades(sellOnDEX,
+			filled, cexRate, multiHopRates, arbTrades, err := arbMMExtremaAndTrades(sellOnDEX,
 				cumulativeCEXDepth, cfgPlacement.Lots, a.cfg().MultiHop,
 				a.market, a.CEX.VWAP, a.CEX.InvVWAP)
 			if err != nil {
@@ -711,6 +844,7 @@ func (a *arbMarketMaker) ordersToPlace() (buys, sells []*TradePlacement, err err
 				Rate:             placementRate,
 				Lots:             cfgPlacement.Lots,
 				CounterTradeRate: cexRate,
+				MultiHopRates:    multiHopRates,
 			})
 		}
 
@@ -756,6 +890,30 @@ func (a *arbMarketMaker) distribution(additionalDEX, additionalCEX map[uint32]ui
 	return dist, nil
 }
 
+func (a *arbMarketMaker) updatePendingOrders(placements []*TradePlacement, placedOrders map[order.OrderID]*dexOrderInfo, sells bool) {
+	a.matchesMtx.Lock()
+	defer a.matchesMtx.Unlock()
+
+	for id, ord := range placedOrders {
+		a.orderIndex[sells][id] = int(ord.placementIndex)
+	}
+
+	cfg := a.cfg()
+
+	for oid, index := range a.orderIndex[sells] {
+		if len(placements) <= index {
+			// Could be hit if there is a reconfig.
+			continue
+		}
+
+		if cfg.isMultiHop() {
+			a.orderArbRates[oid] = placements[index].MultiHopRates
+		} else {
+			a.orderArbRates[oid] = [2]uint64{placements[index].CounterTradeRate, 0}
+		}
+	}
+}
+
 // rebalance is called on each new epoch. It will calculate the rates orders
 // need to be placed on the DEX orderbook based on the CEX orderbook, and
 // potentially update the orders on the DEX orderbook. It will also process
@@ -793,20 +951,12 @@ func (a *arbMarketMaker) rebalance(epoch uint64, book *orderbook.OrderBook) {
 		a.tryCancelOrders(a.ctx, &epoch, false)
 	} else {
 		var buys, sells map[order.OrderID]*dexOrderInfo
-
 		buys, buysReport = a.multiTrade(buyOrders, false, a.cfg().DriftTolerance, currEpoch)
-		for id, ord := range buys {
-			a.matchesMtx.Lock()
-			a.pendingOrders[id] = ord.counterTradeRate
-			a.matchesMtx.Unlock()
-		}
-
+		// TODO: delete canceled orders from pending orders to avoid arbing something outside
+		// drift tolerance??
+		a.updatePendingOrders(buyOrders, buys, false)
 		sells, sellsReport = a.multiTrade(sellOrders, true, a.cfg().DriftTolerance, currEpoch)
-		for id, ord := range sells {
-			a.matchesMtx.Lock()
-			a.pendingOrders[id] = ord.counterTradeRate
-			a.matchesMtx.Unlock()
-		}
+		a.updatePendingOrders(sellOrders, sells, true)
 	}
 
 	epochReport := &EpochReport{
@@ -825,14 +975,14 @@ func (a *arbMarketMaker) rebalance(epoch uint64, book *orderbook.OrderBook) {
 func feeGap(core botCoreAdaptor, multiHopCfg *MultiHopCfg, cex libxc.CEX, mkt *market) (*FeeGapStats, error) {
 	lotSize := mkt.lotSize.Load()
 	s := &FeeGapStats{}
-	buy, filled, _, err := arbMMExtremaAndTrades(false, lotSize, 1, multiHopCfg, mkt, cex.VWAP, cex.InvVWAP)
+	filled, buy, _, _, err := arbMMExtremaAndTrades(false, lotSize, 1, multiHopCfg, mkt, cex.VWAP, cex.InvVWAP)
 	if err != nil {
 		return nil, fmt.Errorf("VWAP buy error: %w", err)
 	}
 	if !filled {
 		return s, nil
 	}
-	sell, filled, _, err := arbMMExtremaAndTrades(true, lotSize, 1, multiHopCfg, mkt, cex.VWAP, cex.InvVWAP)
+	filled, sell, _, _, err := arbMMExtremaAndTrades(true, lotSize, 1, multiHopCfg, mkt, cex.VWAP, cex.InvVWAP)
 	if err != nil {
 		return nil, fmt.Errorf("VWAP sell error: %w", err)
 	}
@@ -946,6 +1096,7 @@ func (a *arbMarketMaker) botLoop(ctx context.Context) (*sync.WaitGroup, error) {
 	go func() {
 		defer wg.Done()
 		<-ctx.Done()
+
 		for _, mkt := range cexMkts {
 			a.cex.UnsubscribeMarket(mkt[0], mkt[1])
 		}
@@ -972,9 +1123,12 @@ func newArbMarketMaker(cfg *BotConfig, adaptorCfg *exchangeAdaptorCfg, log dex.L
 		cex:                    adaptor,
 		core:                   adaptor,
 		matchesSeen:            make(map[order.MatchID]bool),
-		pendingOrders:          make(map[order.OrderID]uint64),
-		cexTrades:              make(map[string]uint64),
+		orderArbRates:          make(map[order.OrderID][2]uint64),
+		orderIndex:             make(map[bool]map[order.OrderID]int),
+		cexTrades:              make(map[string]*cexTradeInfo),
 	}
+	arbMM.orderIndex[false] = make(map[order.OrderID]int)
+	arbMM.orderIndex[true] = make(map[order.OrderID]int)
 
 	adaptor.setBotLoop(arbMM.botLoop)
 	return arbMM, nil

--- a/client/mm/mm_simple_arb.go
+++ b/client/mm/mm_simple_arb.go
@@ -148,7 +148,7 @@ func (a *simpleArbMarketMaker) arbExistsOnSide(sellOnDEX bool) (exists bool, lot
 			return false, 0, 0, 0, fmt.Errorf("error checking dex balance: %w", err)
 		}
 
-		cexSufficient := a.cex.SufficientBalanceForCEXTrade(a.baseID, a.quoteID, !sellOnDEX, cexExtrema, numLots*lotSize, libxc.OrderTypeLimit)
+		cexSufficient := a.cex.SufficientBalanceForCEXTrade(a.baseID, a.quoteID, !sellOnDEX, cexExtrema, numLots*lotSize, 0 /* quoteQty */, libxc.OrderTypeLimit)
 		if !dexSufficient || !cexSufficient {
 			if numLots == 1 {
 				return false, 0, 0, 0, nil
@@ -224,7 +224,7 @@ func (a *simpleArbMarketMaker) executeArb(sellOnDex bool, lotsToArb, dexRate, ce
 	defer a.activeArbsMtx.Unlock()
 
 	// Place cex order first. If placing dex order fails then can freely cancel cex order.
-	cexTrade, err := a.cex.CEXTrade(a.ctx, a.baseID, a.quoteID, !sellOnDex, cexRate, lotsToArb*lotSize, libxc.OrderTypeLimit)
+	cexTrade, err := a.cex.CEXTrade(a.ctx, a.baseID, a.quoteID, !sellOnDex, cexRate, lotsToArb*lotSize, 0 /* quoteQty */, libxc.OrderTypeLimit)
 	if err != nil {
 		a.log.Errorf("error placing cex order: %v", err)
 		return

--- a/client/webserver/locales/en-us.go
+++ b/client/webserver/locales/en-us.go
@@ -702,4 +702,8 @@ var EnUS = map[string]*intl.Translation{
 	"Number of Runs":              {T: "Number of Runs"},
 	"New Release Message":         {T: "<strong> 🚀 New release available!</strong> Get the latest version now."},
 	"View Website":                {T: "View Website"},
+	"multi_hop_completion_order":  {T: "Multi-Hop Completion Order"},
+	"mh_completion_tooltip":       {T: "This specifies the type of order to execute on the second leg of a multi-hop arb. Market orders will always be filled, ensuring that the bot never has any funds stuck in the intermediate asset, but may result in losses if the price suddenly moves against the bot."},
+	"limit_order_buffer":          {T: "Limit Order Buffer"},
+	"limit_order_buffer_tooltip":  {T: "This specifies the buffer to apply to the limit order rate for the second leg of a multi-hop arb. The buffer will make the rate 'worse' (lower for sell orders, higher for buy orders) resulting in a higher probability of the trade being filled in order to avoid having funds stuck in the intermediate asset."},
 }

--- a/client/webserver/site/src/html/forms.tmpl
+++ b/client/webserver/site/src/html/forms.tmpl
@@ -1140,6 +1140,7 @@
           <th class="border text-center">[[[Ordered Lots]]]</th>
           <th class="border text-center">[[[Rate]]]</th>
           <th class="border text-center" id="counterTradeRateHeader">[[[Arb Rate]]]</th>
+          <th class="border text-center" id="multiHopRatesHeader">Multi-hop Rates</th>
           <th class="border text-center">[[[Required DEX]]]</th>
           <th class="border text-center">[[[Used DEX]]]</th>
           <th class="border text-center" id="requiredCEXHeader">[[[Required CEX]]]</th>
@@ -1155,6 +1156,17 @@
           <td data-tmpl="orderedLots" class="text-center border"></td>
           <td data-tmpl="rate" class="text-center border"></td>
           <td data-tmpl="counterTradeRate" class="text-center border"></td>
+          <td data-tmpl="multiHopRates" class="text-center border">
+            <div>
+              <span class="me-1"><small>Aggregate:</small></span><span data-tmpl="aggRate"></span>
+            </div>
+            <div>
+              <span class="me-1"><small>Leg 1:</small></span><span data-tmpl="leg1Rate"></span>
+            </div>
+            <div>
+              <span class="me-1"><small>Leg 2:</small></span><span data-tmpl="leg2Rate"></span>
+            </div>
+          </td>
           <td data-tmpl="requiredDEX" class="text-center border">
             <span id="placementAmtRowTmpl" class="d-flex justify-content-end">
               <span data-tmpl="amt"></span>

--- a/client/webserver/site/src/html/mmsettings.tmpl
+++ b/client/webserver/site/src/html/mmsettings.tmpl
@@ -680,6 +680,30 @@
             <span class="fs14 grey ms-1">epochs</span>
           </div>
         </div>
+
+        {{- /* MULTI-HOP COMPLETION */ -}}
+        <div id="multiHopCompletionBox" class="flex-stretch-column mt-2 pt-2 border-top">
+          <div class="fs16 mb-2 d-flex align-items-center justify-content-between">
+            <span>[[[multi_hop_completion_order]]]</span>
+            <span class="ico-info fs12" data-tooltip="[[[mh_completion_tooltip]]]"></span>
+          </div>
+          <div class="d-flex flex-column">
+            <div class="d-flex align-items-center mb-1">
+              <input type="radio" id="multiHopLimitOrder" name="multiHopOrderType" class="form-check-input me-2 mt-0">
+              <label for="multiHopLimitOrder" class="fs15 mb-0 me-3">[[[Limit Order]]]</label>
+              <input type="radio" id="multiHopMarketOrder" name="multiHopOrderType" class="form-check-input me-2 mt-0">
+              <label for="multiHopMarketOrder" class="fs15 mb-0">[[[Market Order]]]</label>
+            </div>
+            <div id="limitOrderBufferSection" class="d-flex align-items-center mt-2" style="display: none;">
+              <span class="fs15 me-2">[[[limit_order_buffer]]]</span>
+              <div id="limitOrderBufferSlider" class="mini-slider flex-grow-1 me-2"></div>
+              <input type="number" id="limitOrderBufferInput" class="micro thin text-end">
+              <span class="fs14 grey ms-1">%</span>
+              <span class="ico-info fs12 ms-2" data-tooltip="[[[limit_order_buffer_tooltip]]]"></span>
+            </div>
+          </div>
+        </div>
+
       </section>
 
       {{- /* AUTO REBALANCE */ -}}

--- a/client/webserver/site/src/js/registry.ts
+++ b/client/webserver/site/src/js/registry.ts
@@ -779,6 +779,8 @@ export interface ArbMarketMakingPlacement {
 export interface MultiHopCfg {
   baseAssetMarket: [number, number]
   quoteAssetMarket: [number, number]
+  marketOrders: boolean
+  limitOrdersBuffer: number
 }
 
 export interface ArbMarketMakingConfig {
@@ -960,6 +962,7 @@ export interface TradePlacement {
   standingLots: number
   orderedLots: number
   counterTradeRate: number
+  multiHopRates: [number, number]
   requiredDex: Record<number, number>
   requiredCex: number
   usedDex: Record<number, number>


### PR DESCRIPTION
This PR updates multi-hop arbitrage strategy. It replaces the previous strategy of using market orders for both legs with a combination of limit IOC in the first leg, and either a market or limit GTC for the second leg.

#### client/mm/libxc
- Adds a `quoteQty` parameter to `Trade` that is required for market buys and optional for limit buys.
- The `quoteQty` parameter is required for limit buys in order to be able to use as much of the first leg as possible
  This calculation cannot be done from the calling code, as it is not aware of the lot size.
- Add Limit IOC order type for quick executions of the first leg.

#### client/mm
- First leg now always a Limit IOC order for quick executions, avoiding market movements before the second leg can be executed.
- Second leg: Limit GTC or Market, based on config.
- Adds a `LimitOrderBuffer` config in case the bot is using limit orders for the second leg. This optionally worsens the rate of the limit order in order to get a better chance at 100% fill, avoiding funds stuck in the intermediate asset.
- Update arb rates in memory after each epoch so multi-hop uses fresh data. This is required because the two rates of the multi-hop orders can move without the aggregate rate changing.

#### ui
- Add new `MultiHopConfig` options to `mmsettings` page.