### PR TITLE
lexi: Simplify upgrade API

### DIFF
--- a/dex/lexi/db_test.go
+++ b/dex/lexi/db_test.go
@@ -11,6 +11,7 @@ import (
 
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/encode"
+	"github.com/dgraph-io/badger"
 )
 
 func newTestDB(t *testing.T) (*DB, func()) {
@@ -555,7 +556,9 @@ func TestDeleteIndex(t *testing.T) {
 		t.Fatalf("Expected 10 values, got %d", count)
 	}
 
-	err = db.DeleteIndex("DeleteIndexTest", "I")
+	err = db.Update(func(tx *badger.Txn) error {
+		return db.DeleteIndex(tx, "DeleteIndexTest", "I")
+	})
 	if err != nil {
 		t.Fatalf("Error deleting index: %v", err)
 	}
@@ -613,12 +616,20 @@ func TestReIndex(t *testing.T) {
 	}
 
 	// Reindex the indexes.
-	db.ReIndex("DeleteIndexTest", "K", func(k, v []byte) ([]byte, error) {
-		return k, nil
+	err = db.Update(func(tx *badger.Txn) error {
+		err = db.ReIndex(tx, "DeleteIndexTest", "K", func(k, v []byte) ([]byte, error) {
+			return k, nil
+		})
+		if err != nil {
+			return err
+		}
+		return db.ReIndex(tx, "DeleteIndexTest", "V", func(k, v []byte) ([]byte, error) {
+			return v, nil
+		})
 	})
-	db.ReIndex("DeleteIndexTest", "V", func(k, v []byte) ([]byte, error) {
-		return v, nil
-	})
+	if err != nil {
+		t.Fatalf("Error reindexing index: %v", err)
+	}
 
 	// Check the key index.
 	var count int
@@ -661,172 +672,47 @@ func TestReIndex(t *testing.T) {
 	}
 }
 
-func TestUpgrade(t *testing.T) {
+func TestDBVersion(t *testing.T) {
 	db, shutdown := newTestDB(t)
 	defer shutdown()
 
-	var expectedError string
-
-	// Test that a fresh database starts with version 0
-	version, err := db.getDBVersion()
+	// Initially, the version should be 0
+	got, err := db.GetDBVersion()
 	if err != nil {
-		t.Fatalf("Error getting initial DB version: %v", err)
+		t.Fatalf("unexpected error when getting unset DB version: %v", err)
 	}
-	if version != 0 {
-		t.Fatalf("Expected initial DB version to be 0, got %d", version)
-	}
-
-	// Create some test upgrade functions that track their execution
-	var upgrade1Called, upgrade2Called, upgrade3Called bool
-
-	upgrade1 := func() error {
-		upgrade1Called = true
-		return nil
+	if got != 0 {
+		t.Fatalf("expected initial version 0, got %d", got)
 	}
 
-	upgrade2 := func() error {
-		upgrade2Called = true
-		return nil
+	// Set a version
+	var version uint32 = 2
+	if err := db.Update(func(tx *badger.Txn) error {
+		return db.SetDBVersion(version, tx)
+	}); err != nil {
+		t.Fatalf("SetDBVersion error: %v", err)
 	}
 
-	upgrade3 := func() error {
-		upgrade3Called = true
-		return nil
-	}
-
-	upgrades := []func() error{upgrade1, upgrade2, upgrade3}
-
-	// Test successful upgrade of all upgrades
-	err = db.Upgrade(upgrades)
+	got, err = db.GetDBVersion()
 	if err != nil {
-		t.Fatalf("Error during upgrade: %v", err)
+		t.Fatalf("GetDBVersion error: %v", err)
+	}
+	if got != version {
+		t.Fatalf("expected version %d, got %d", version, got)
 	}
 
-	// Verify all upgrades were called
-	if !upgrade1Called {
-		t.Fatal("Upgrade 1 was not called")
+	// Set a new version
+	version = 3
+	if err := db.Update(func(tx *badger.Txn) error {
+		return db.SetDBVersion(version, tx)
+	}); err != nil {
+		t.Fatalf("SetDBVersion error: %v", err)
 	}
-	if !upgrade2Called {
-		t.Fatal("Upgrade 2 was not called")
-	}
-	if !upgrade3Called {
-		t.Fatal("Upgrade 3 was not called")
-	}
-
-	// Verify database version was updated to 3
-	version, err = db.getDBVersion()
+	got, err = db.GetDBVersion()
 	if err != nil {
-		t.Fatalf("Error getting DB version after upgrade: %v", err)
+		t.Fatalf("GetDBVersion error: %v", err)
 	}
-	if version != 3 {
-		t.Fatalf("Expected DB version to be 3 after upgrade, got %d", version)
-	}
-
-	// Test that calling Upgrade again with the same upgrades (version == len(upgrades)) succeeds and skips all
-	upgrade1Called, upgrade2Called, upgrade3Called = false, false, false
-	err = db.Upgrade(upgrades)
-	if err != nil {
-		t.Fatalf("Error during second upgrade call: %v", err)
-	}
-	// Verify no upgrades were called this time
-	if upgrade1Called {
-		t.Fatal("Upgrade 1 was called again when it should have been skipped")
-	}
-	if upgrade2Called {
-		t.Fatal("Upgrade 2 was called again when it should have been skipped")
-	}
-	if upgrade3Called {
-		t.Fatal("Upgrade 3 was called again when it should have been skipped")
-	}
-	// Verify database version is still 3
-	version, err = db.getDBVersion()
-	if err != nil {
-		t.Fatalf("Error getting DB version after second upgrade call: %v", err)
-	}
-	if version != 3 {
-		t.Fatalf("Expected DB version to remain 3 after second upgrade call, got %d", version)
-	}
-
-	// Test that calling Upgrade with fewer upgrades than the current version returns an error
-	upgrade1Called, upgrade2Called = false, false
-	err = db.Upgrade([]func() error{upgrade1, upgrade2})
-	if err == nil {
-		t.Fatal("Expected error when upgrade list is too short, but got none")
-	}
-	expectedError = "upgrade list is too short. expected at least 3 upgrades, got 2"
-	if err.Error() != expectedError {
-		t.Fatalf("Expected error '%s', got '%v'", expectedError, err)
-	}
-	// Verify no upgrades were called
-	if upgrade1Called {
-		t.Fatal("Upgrade 1 was called when it should have been skipped")
-	}
-	if upgrade2Called {
-		t.Fatal("Upgrade 2 was called when it should have been skipped")
-	}
-	// Verify database version is still 3
-	version, err = db.getDBVersion()
-	if err != nil {
-		t.Fatalf("Error getting DB version after upgrade with fewer functions: %v", err)
-	}
-	if version != 3 {
-		t.Fatalf("Expected DB version to remain 3 after upgrade with fewer functions, got %d", version)
-	}
-
-	// Test that calling Upgrade with more upgrades applies only the new ones
-	upgrade4Called := false
-	upgrade4 := func() error {
-		upgrade4Called = true
-		return nil
-	}
-
-	err = db.Upgrade([]func() error{upgrade1, upgrade2, upgrade3, upgrade4})
-	if err != nil {
-		t.Fatalf("Error during upgrade with additional function: %v", err)
-	}
-	// Verify only upgrade4 was called
-	if upgrade1Called {
-		t.Fatal("Upgrade 1 was called when it should have been skipped")
-	}
-	if upgrade2Called {
-		t.Fatal("Upgrade 2 was called when it should have been skipped")
-	}
-	if upgrade3Called {
-		t.Fatal("Upgrade 3 was called when it should have been skipped")
-	}
-	if !upgrade4Called {
-		t.Fatal("Upgrade 4 was not called")
-	}
-	// Verify database version was updated to 4
-	version, err = db.getDBVersion()
-	if err != nil {
-		t.Fatalf("Error getting DB version after upgrade with additional function: %v", err)
-	}
-	if version != 4 {
-		t.Fatalf("Expected DB version to be 4 after upgrade with additional function, got %d", version)
-	}
-
-	// Test that an upgrade function that errors doesn't update the version
-	upgrade5Called := false
-	upgrade5 := func() error {
-		upgrade5Called = true
-		return fmt.Errorf("upgrade 5 failed")
-	}
-
-	err = db.Upgrade([]func() error{upgrade1, upgrade2, upgrade3, upgrade4, upgrade5})
-	if err == nil {
-		t.Fatal("Expected error when upgrade 5 fails, but got none")
-	}
-	// Verify upgrade5 was called
-	if !upgrade5Called {
-		t.Fatal("Upgrade 5 was not called")
-	}
-	// Verify database version is still 4 (not updated due to error)
-	version, err = db.getDBVersion()
-	if err != nil {
-		t.Fatalf("Error getting DB version after failed upgrade: %v", err)
-	}
-	if version != 4 {
-		t.Fatalf("Expected DB version to remain 4 after failed upgrade, got %d", version)
+	if got != version {
+		t.Fatalf("expected version %d, got %d", version, got)
 	}
 }

--- a/dex/lexi/index.go
+++ b/dex/lexi/index.go
@@ -71,7 +71,7 @@ func (t *Table) AddUniqueIndex(name string, f func(k, v KV) ([]byte, error)) (*I
 
 // DeleteIndex deletes all index entries for any index of this table with the
 // given name.
-func (db *DB) DeleteIndex(tableName, indexName string) error {
+func (db *DB) DeleteIndex(txn *badger.Txn, tableName, indexName string) error {
 	tablePrefix, err := db.existingPrefixForName(tableName)
 	if errors.Is(err, badger.ErrKeyNotFound) {
 		return nil
@@ -88,40 +88,38 @@ func (db *DB) DeleteIndex(tableName, indexName string) error {
 		return err
 	}
 
-	return db.Update(func(txn *badger.Txn) error {
-		// Delete all the index entries
-		if err := iteratePrefix(txn, indexPrefix[:], nil, func(i *badger.Iterator) error {
-			return txn.Delete(i.Item().Key())
-		}); err != nil {
-			return fmt.Errorf("error deleting index entries: %w", err)
-		}
+	// Delete all the index entries
+	if err := iteratePrefix(txn, indexPrefix[:], nil, func(i *badger.Iterator) error {
+		return txn.Delete(i.Item().Key())
+	}); err != nil {
+		return fmt.Errorf("error deleting index entries: %w", err)
+	}
 
-		// Update all the datums to no longer reference the deleted index
-		return iteratePrefix(txn, tablePrefix[:], nil, func(iter *badger.Iterator) error {
-			return iter.Item().Value(func(dB []byte) error {
-				d, err := decodeDatum(dB)
-				if err != nil {
-					return fmt.Errorf("error decoding datum during index deletion: %w", err)
-				}
+	// Update all the datums to no longer reference the deleted index
+	return iteratePrefix(txn, tablePrefix[:], nil, func(iter *badger.Iterator) error {
+		return iter.Item().Value(func(dB []byte) error {
+			d, err := decodeDatum(dB)
+			if err != nil {
+				return fmt.Errorf("error decoding datum during index deletion: %w", err)
+			}
 
-				// Filter out indexes that match the deleted index prefix
-				newIndexes := make([][]byte, 0, len(d.indexes)-1)
-				for _, idxB := range d.indexes {
-					if !bytes.Equal(idxB[:prefixSize], indexPrefix[:]) {
-						newIndexes = append(newIndexes, idxB)
-					}
+			// Filter out indexes that match the deleted index prefix
+			newIndexes := make([][]byte, 0, len(d.indexes)-1)
+			for _, idxB := range d.indexes {
+				if !bytes.Equal(idxB[:prefixSize], indexPrefix[:]) {
+					newIndexes = append(newIndexes, idxB)
 				}
-				d.indexes = newIndexes
+			}
+			d.indexes = newIndexes
 
-				b, err := d.bytes()
-				if err != nil {
-					return fmt.Errorf("error encoding datum after index deletion: %w", err)
-				}
-				if err := txn.Set(iter.Item().Key(), b); err != nil {
-					return fmt.Errorf("error storing new datum after index deletion: %w", err)
-				}
-				return nil
-			})
+			b, err := d.bytes()
+			if err != nil {
+				return fmt.Errorf("error encoding datum after index deletion: %w", err)
+			}
+			if err := txn.Set(iter.Item().Key(), b); err != nil {
+				return fmt.Errorf("error storing new datum after index deletion: %w", err)
+			}
+			return nil
 		})
 	})
 }
@@ -129,7 +127,7 @@ func (db *DB) DeleteIndex(tableName, indexName string) error {
 // ReIndex updates the index entries on this index for all items in the table.
 // decoder should generate the value that would be passed to the index
 // generation function supplied to (*Table).AddIndex for this index.
-func (db *DB) ReIndex(tableName, indexName string, f func(k, v []byte) ([]byte, error)) error {
+func (db *DB) ReIndex(txn *badger.Txn, tableName, indexName string, f func(k, v []byte) ([]byte, error)) error {
 	tablePrefix, err := db.existingPrefixForName(tableName)
 	if errors.Is(err, badger.ErrKeyNotFound) {
 		return nil
@@ -146,66 +144,64 @@ func (db *DB) ReIndex(tableName, indexName string, f func(k, v []byte) ([]byte, 
 		return err
 	}
 
-	return db.Update(func(txn *badger.Txn) error {
-		return iteratePrefix(txn, tablePrefix[:], nil, func(iter *badger.Iterator) error {
-			return iter.Item().Value(func(dB []byte) error {
-				d, err := decodeDatum(dB)
-				if err != nil {
-					return fmt.Errorf("error decoding datum: %w", err)
-				}
+	return iteratePrefix(txn, tablePrefix[:], nil, func(iter *badger.Iterator) error {
+		return iter.Item().Value(func(dB []byte) error {
+			d, err := decodeDatum(dB)
+			if err != nil {
+				return fmt.Errorf("error decoding datum: %w", err)
+			}
 
-				tableKey := iter.Item().Key()
-				dbIDB := tableKey[prefixSize:]
+			tableKey := iter.Item().Key()
+			dbIDB := tableKey[prefixSize:]
 
-				// Get the original key for this datum
-				keyItem, err := txn.Get(prefixedKey(idToKeyPrefix, dbIDB))
-				if err != nil {
-					return fmt.Errorf("error finding key for entry: %w", err)
-				}
-				k, err := keyItem.ValueCopy(nil)
-				if err != nil {
-					return err
-				}
+			// Get the original key for this datum
+			keyItem, err := txn.Get(prefixedKey(idToKeyPrefix, dbIDB))
+			if err != nil {
+				return fmt.Errorf("error finding key for entry: %w", err)
+			}
+			k, err := keyItem.ValueCopy(nil)
+			if err != nil {
+				return err
+			}
 
-				// Generate the new index entry
-				idxB, err := f(k, d.v)
-				if err != nil {
-					return fmt.Errorf("indexer function error: %w", err)
-				}
-				indexEntry := prefixedKey(indexPrefix, append(idxB, dbIDB...))
+			// Generate the new index entry
+			idxB, err := f(k, d.v)
+			if err != nil {
+				return fmt.Errorf("indexer function error: %w", err)
+			}
+			indexEntry := prefixedKey(indexPrefix, append(idxB, dbIDB...))
 
-				// Remove old index entries for this index and add the new one
-				var replaced bool
-				for j, idxBi := range d.indexes {
-					if bytes.Equal(idxBi[:prefixSize], indexPrefix[:]) {
-						// Delete the old index entry from the database
-						if err := txn.Delete(idxBi); err != nil {
-							return fmt.Errorf("error deleting old index entry during reindex: %w", err)
-						}
-						d.indexes[j] = indexEntry
-						replaced = true
-						break
+			// Remove old index entries for this index and add the new one
+			var replaced bool
+			for j, idxBi := range d.indexes {
+				if bytes.Equal(idxBi[:prefixSize], indexPrefix[:]) {
+					// Delete the old index entry from the database
+					if err := txn.Delete(idxBi); err != nil {
+						return fmt.Errorf("error deleting old index entry during reindex: %w", err)
 					}
+					d.indexes[j] = indexEntry
+					replaced = true
+					break
 				}
-				if !replaced {
-					d.indexes = append(d.indexes, indexEntry)
-				}
+			}
+			if !replaced {
+				d.indexes = append(d.indexes, indexEntry)
+			}
 
-				// Update the datum with the new index references
-				b, err := d.bytes()
-				if err != nil {
-					return fmt.Errorf("error encoding datum after index reindex: %w", err)
-				}
-				if err := txn.Set(tableKey, b); err != nil {
-					return fmt.Errorf("error storing new datum after reindex: %w", err)
-				}
+			// Update the datum with the new index references
+			b, err := d.bytes()
+			if err != nil {
+				return fmt.Errorf("error encoding datum after index reindex: %w", err)
+			}
+			if err := txn.Set(tableKey, b); err != nil {
+				return fmt.Errorf("error storing new datum after reindex: %w", err)
+			}
 
-				// Store the new index entry
-				if err := txn.Set(indexEntry, nil); err != nil {
-					return fmt.Errorf("error storing index entry for reindex: %w", err)
-				}
-				return nil
-			})
+			// Store the new index entry
+			if err := txn.Set(indexEntry, nil); err != nil {
+				return fmt.Errorf("error storing index entry for reindex: %w", err)
+			}
+			return nil
 		})
 	})
 }

--- a/dex/lexi/index.go
+++ b/dex/lexi/index.go
@@ -71,7 +71,7 @@ func (t *Table) AddUniqueIndex(name string, f func(k, v KV) ([]byte, error)) (*I
 
 // DeleteIndex deletes all index entries for any index of this table with the
 // given name.
-func (db *DB) DeleteIndex(txn *badger.Txn, tableName, indexName string) error {
+func (db *DB) DeleteIndex(tableName, indexName string) error {
 	tablePrefix, err := db.existingPrefixForName(tableName)
 	if errors.Is(err, badger.ErrKeyNotFound) {
 		return nil
@@ -88,38 +88,40 @@ func (db *DB) DeleteIndex(txn *badger.Txn, tableName, indexName string) error {
 		return err
 	}
 
-	// Delete all the index entries
-	if err := iteratePrefix(txn, indexPrefix[:], nil, func(i *badger.Iterator) error {
-		return txn.Delete(i.Item().Key())
-	}); err != nil {
-		return fmt.Errorf("error deleting index entries: %w", err)
-	}
+	return db.Update(func(txn *badger.Txn) error {
+		// Delete all the index entries
+		if err := iteratePrefix(txn, indexPrefix[:], nil, func(i *badger.Iterator) error {
+			return txn.Delete(i.Item().Key())
+		}); err != nil {
+			return fmt.Errorf("error deleting index entries: %w", err)
+		}
 
-	// Update all the datums to no longer reference the deleted index
-	return iteratePrefix(txn, tablePrefix[:], nil, func(iter *badger.Iterator) error {
-		return iter.Item().Value(func(dB []byte) error {
-			d, err := decodeDatum(dB)
-			if err != nil {
-				return fmt.Errorf("error decoding datum during index deletion: %w", err)
-			}
-
-			// Filter out indexes that match the deleted index prefix
-			newIndexes := make([][]byte, 0, len(d.indexes)-1)
-			for _, idxB := range d.indexes {
-				if !bytes.Equal(idxB[:prefixSize], indexPrefix[:]) {
-					newIndexes = append(newIndexes, idxB)
+		// Update all the datums to no longer reference the deleted index
+		return iteratePrefix(txn, tablePrefix[:], nil, func(iter *badger.Iterator) error {
+			return iter.Item().Value(func(dB []byte) error {
+				d, err := decodeDatum(dB)
+				if err != nil {
+					return fmt.Errorf("error decoding datum during index deletion: %w", err)
 				}
-			}
-			d.indexes = newIndexes
 
-			b, err := d.bytes()
-			if err != nil {
-				return fmt.Errorf("error encoding datum after index deletion: %w", err)
-			}
-			if err := txn.Set(iter.Item().Key(), b); err != nil {
-				return fmt.Errorf("error storing new datum after index deletion: %w", err)
-			}
-			return nil
+				// Filter out indexes that match the deleted index prefix
+				newIndexes := make([][]byte, 0, len(d.indexes)-1)
+				for _, idxB := range d.indexes {
+					if !bytes.Equal(idxB[:prefixSize], indexPrefix[:]) {
+						newIndexes = append(newIndexes, idxB)
+					}
+				}
+				d.indexes = newIndexes
+
+				b, err := d.bytes()
+				if err != nil {
+					return fmt.Errorf("error encoding datum after index deletion: %w", err)
+				}
+				if err := txn.Set(iter.Item().Key(), b); err != nil {
+					return fmt.Errorf("error storing new datum after index deletion: %w", err)
+				}
+				return nil
+			})
 		})
 	})
 }
@@ -127,7 +129,7 @@ func (db *DB) DeleteIndex(txn *badger.Txn, tableName, indexName string) error {
 // ReIndex updates the index entries on this index for all items in the table.
 // decoder should generate the value that would be passed to the index
 // generation function supplied to (*Table).AddIndex for this index.
-func (db *DB) ReIndex(txn *badger.Txn, tableName, indexName string, f func(k, v []byte) ([]byte, error)) error {
+func (db *DB) ReIndex(tableName, indexName string, f func(k, v []byte) ([]byte, error)) error {
 	tablePrefix, err := db.existingPrefixForName(tableName)
 	if errors.Is(err, badger.ErrKeyNotFound) {
 		return nil
@@ -144,64 +146,66 @@ func (db *DB) ReIndex(txn *badger.Txn, tableName, indexName string, f func(k, v 
 		return err
 	}
 
-	return iteratePrefix(txn, tablePrefix[:], nil, func(iter *badger.Iterator) error {
-		return iter.Item().Value(func(dB []byte) error {
-			d, err := decodeDatum(dB)
-			if err != nil {
-				return fmt.Errorf("error decoding datum: %w", err)
-			}
-
-			tableKey := iter.Item().Key()
-			dbIDB := tableKey[prefixSize:]
-
-			// Get the original key for this datum
-			keyItem, err := txn.Get(prefixedKey(idToKeyPrefix, dbIDB))
-			if err != nil {
-				return fmt.Errorf("error finding key for entry: %w", err)
-			}
-			k, err := keyItem.ValueCopy(nil)
-			if err != nil {
-				return err
-			}
-
-			// Generate the new index entry
-			idxB, err := f(k, d.v)
-			if err != nil {
-				return fmt.Errorf("indexer function error: %w", err)
-			}
-			indexEntry := prefixedKey(indexPrefix, append(idxB, dbIDB...))
-
-			// Remove old index entries for this index and add the new one
-			var replaced bool
-			for j, idxBi := range d.indexes {
-				if bytes.Equal(idxBi[:prefixSize], indexPrefix[:]) {
-					// Delete the old index entry from the database
-					if err := txn.Delete(idxBi); err != nil {
-						return fmt.Errorf("error deleting old index entry during reindex: %w", err)
-					}
-					d.indexes[j] = indexEntry
-					replaced = true
-					break
+	return db.Update(func(txn *badger.Txn) error {
+		return iteratePrefix(txn, tablePrefix[:], nil, func(iter *badger.Iterator) error {
+			return iter.Item().Value(func(dB []byte) error {
+				d, err := decodeDatum(dB)
+				if err != nil {
+					return fmt.Errorf("error decoding datum: %w", err)
 				}
-			}
-			if !replaced {
-				d.indexes = append(d.indexes, indexEntry)
-			}
 
-			// Update the datum with the new index references
-			b, err := d.bytes()
-			if err != nil {
-				return fmt.Errorf("error encoding datum after index reindex: %w", err)
-			}
-			if err := txn.Set(tableKey, b); err != nil {
-				return fmt.Errorf("error storing new datum after reindex: %w", err)
-			}
+				tableKey := iter.Item().Key()
+				dbIDB := tableKey[prefixSize:]
 
-			// Store the new index entry
-			if err := txn.Set(indexEntry, nil); err != nil {
-				return fmt.Errorf("error storing index entry for reindex: %w", err)
-			}
-			return nil
+				// Get the original key for this datum
+				keyItem, err := txn.Get(prefixedKey(idToKeyPrefix, dbIDB))
+				if err != nil {
+					return fmt.Errorf("error finding key for entry: %w", err)
+				}
+				k, err := keyItem.ValueCopy(nil)
+				if err != nil {
+					return err
+				}
+
+				// Generate the new index entry
+				idxB, err := f(k, d.v)
+				if err != nil {
+					return fmt.Errorf("indexer function error: %w", err)
+				}
+				indexEntry := prefixedKey(indexPrefix, append(idxB, dbIDB...))
+
+				// Remove old index entries for this index and add the new one
+				var replaced bool
+				for j, idxBi := range d.indexes {
+					if bytes.Equal(idxBi[:prefixSize], indexPrefix[:]) {
+						// Delete the old index entry from the database
+						if err := txn.Delete(idxBi); err != nil {
+							return fmt.Errorf("error deleting old index entry during reindex: %w", err)
+						}
+						d.indexes[j] = indexEntry
+						replaced = true
+						break
+					}
+				}
+				if !replaced {
+					d.indexes = append(d.indexes, indexEntry)
+				}
+
+				// Update the datum with the new index references
+				b, err := d.bytes()
+				if err != nil {
+					return fmt.Errorf("error encoding datum after index reindex: %w", err)
+				}
+				if err := txn.Set(tableKey, b); err != nil {
+					return fmt.Errorf("error storing new datum after reindex: %w", err)
+				}
+
+				// Store the new index entry
+				if err := txn.Set(indexEntry, nil); err != nil {
+					return fmt.Errorf("error storing index entry for reindex: %w", err)
+				}
+				return nil
+			})
 		})
 	})
 }

--- a/dex/lexi/keyprefix.go
+++ b/dex/lexi/keyprefix.go
@@ -30,6 +30,7 @@ var (
 	primarySequencePrefix = keyPrefix{0x00, 0x02}
 	keyToIDPrefix         = keyPrefix{0x00, 0x03}
 	idToKeyPrefix         = keyPrefix{0x00, 0x04}
+	versionPrefix         = keyPrefix{0x00, 0x05}
 
 	firstAvailablePrefix = keyPrefix{0x01, 0x00}
 )


### PR DESCRIPTION
- Gets rid of the upgrade function and exposes GetDBVersion and SetDBVersion instead.
- Adds a badger.Txn argument to DeleteIndex and ReIndex to be able to do an upgrade and change the DB version in the same transaction.
- Moves db version to the reserved prefixes.