### PR TITLE
mm: Allow reconfig to 0 placements

### DIFF
--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -1178,9 +1178,6 @@ func (u *unifiedExchangeAdaptor) multiTrade(
 	currEpoch uint64,
 ) (_ map[order.OrderID]*dexOrderInfo, or *OrderReport) {
 	or = newOrderReport(placements)
-	if len(placements) == 0 {
-		return nil, or
-	}
 
 	buyFees, sellFees, err := u.orderFees()
 	if err != nil {
@@ -1207,7 +1204,10 @@ func (u *unifiedExchangeAdaptor) multiTrade(
 
 	// If the placements include a counterTradeRate, the CEX balance must also
 	// be taken into account to determine how many trades can be placed.
-	accountForCEXBal := placements[0].CounterTradeRate > 0
+	var accountForCEXBal bool
+	if len(placements) > 0 {
+		accountForCEXBal = placements[0].CounterTradeRate > 0
+	}
 	if accountForCEXBal {
 		or.AvailableCEXBal = u.CEXBalance(toID).copy()
 		or.RemainingCEXBal = or.AvailableCEXBal.Available

--- a/client/mm/exchange_adaptor_test.go
+++ b/client/mm/exchange_adaptor_test.go
@@ -3193,6 +3193,47 @@ func TestMultiTrade(t *testing.T) {
 				orderIDs[3], orderIDs[4],
 			},
 		},
+		{
+			name:    "no placements, pending orders should be cancelled",
+			baseID:  42,
+			quoteID: 0,
+			// ---- Sell ----
+			sellDexBalances: map[uint32]uint64{
+				42: 100 * lotSize,
+				0:  0,
+			},
+			sellCexBalances: map[uint32]uint64{
+				42: 0,
+				0:  100 * lotSize,
+			},
+			sellPlacements: []*TradePlacement{},
+			sellPendingOrders: func() map[order.OrderID]*pendingDEXOrder {
+				return pendingOrders(true, 42, 0)
+			}(),
+			expectedSellPlacements:              []*core.QtyRate{},
+			expectedSellPlacementsWithDecrement: []*core.QtyRate{},
+			expectedCancels: []order.OrderID{
+				orderIDs[1], orderIDs[2], orderIDs[3],
+			},
+			expectedCancelsWithDecrement: []order.OrderID{
+				orderIDs[1], orderIDs[2], orderIDs[3],
+			},
+			// ---- Buy ----
+			buyDexBalances: map[uint32]uint64{
+				42: 0,
+				0:  100 * lotSize,
+			},
+			buyCexBalances: map[uint32]uint64{
+				42: 100 * lotSize,
+				0:  0,
+			},
+			buyPlacements: []*TradePlacement{},
+			buyPendingOrders: func() map[order.OrderID]*pendingDEXOrder {
+				return pendingOrders(false, 42, 0)
+			}(),
+			expectedBuyPlacements:              []*core.QtyRate{},
+			expectedBuyPlacementsWithDecrement: []*core.QtyRate{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Reconfiguring bots to 0 placements did not cancel existing orders because `MultiTrade` would return early when 0 placements are passed in.