### PR TITLE
btc: Log SingleLotRedeemFees estimates.

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -2444,6 +2444,9 @@ func (btc *baseWallet) SingleLotRedeemFees(_ uint32, feeSuggestion uint64) (uint
 	if err != nil {
 		return 0, err
 	}
+
+	btc.log.Tracef("SingleLotRedeemFees: worst case = %d, feeSuggestion = %d", preRedeem.Estimate.RealisticWorstCase, feeSuggestion)
+
 	return preRedeem.Estimate.RealisticWorstCase, nil
 }
 


### PR DESCRIPTION
This logging already existed in the dcr package but it was absent in btc where it is arguably much more important (btc fees are a lot more variable and have much higher real world value).