### PR TITLE
webserver/site: bind tooltip for repeat config elements

### DIFF
--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -619,6 +619,7 @@ export class WalletConfigForm {
       input.value = dateToString(date)
     } else input.value = opt.default !== null ? opt.default : ''
     input.disabled = Boolean(opt.disablewhenactive && this.assetHasActiveOrders)
+    app().bindTooltips(el)
     return el
   }
 


### PR DESCRIPTION
Issue: During testing, I discovered the tooltip for repeat wallet config elements, e.g provider input for ETH based tokens weren't working.

This PR fixes that by ensuring the tooltip for all repeat config elements work as expected by binding them right in `WalletConfigForm.addOpt`.

Works as expected in the video attached.

https://github.com/user-attachments/assets/7c8e95d3-16fd-46b0-849d-41eefa3272c9
