### PR TITLE
lexi: Remove txn parameter from SetDBVersion

### DIFF
--- a/dex/lexi/db_test.go
+++ b/dex/lexi/db_test.go
@@ -756,9 +756,7 @@ func TestDBVersion(t *testing.T) {
 
 	// Set a version
 	var version uint32 = 2
-	if err := db.Update(func(tx *badger.Txn) error {
-		return db.SetDBVersion(version, tx)
-	}); err != nil {
+	if err := db.SetDBVersion(version); err != nil {
 		t.Fatalf("SetDBVersion error: %v", err)
 	}
 
@@ -772,9 +770,7 @@ func TestDBVersion(t *testing.T) {
 
 	// Set a new version
 	version = 3
-	if err := db.Update(func(tx *badger.Txn) error {
-		return db.SetDBVersion(version, tx)
-	}); err != nil {
+	if err := db.SetDBVersion(version); err != nil {
 		t.Fatalf("SetDBVersion error: %v", err)
 	}
 	got, err = db.GetDBVersion()

--- a/dex/lexi/lexi.go
+++ b/dex/lexi/lexi.go
@@ -130,10 +130,12 @@ func (db *DB) GetDBVersion() (version uint32, err error) {
 }
 
 // SetDBVersion sets the current database version in the DB.
-func (db *DB) SetDBVersion(version uint32, txn *badger.Txn) error {
-	b := make([]byte, 4)
-	binary.BigEndian.PutUint32(b[:], version)
-	return txn.Set(versionPrefix[:], b)
+func (db *DB) SetDBVersion(version uint32) error {
+	return db.Update(func(txn *badger.Txn) error {
+		b := make([]byte, 4)
+		binary.BigEndian.PutUint32(b[:], version)
+		return txn.Set(versionPrefix[:], b)
+	})
 }
 
 // Update: badger can return an ErrConflict if a read and write happen


### PR DESCRIPTION
Since `DB.Upgrade` was added, `DB.SetDBVersion` does not require a txn parameter.