### PR TITLE
refactor: use slices.Sort where appropriate

### DIFF
--- a/dex/lexi/db_test.go
+++ b/dex/lexi/db_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -452,9 +453,7 @@ func TestNotIndexed(t *testing.T) {
 	if count != 5 {
 		t.Fatalf("Expected 5 indexed values, got %d", count)
 	}
-	sort.Slice(foundValues, func(i, j int) bool {
-		return foundValues[i] < foundValues[j]
-	})
+	slices.Sort(foundValues)
 	if !reflect.DeepEqual(foundValues, expectedValues) {
 		t.Fatalf("Expected values %v, got %v", expectedValues, foundValues)
 	}
@@ -504,9 +503,7 @@ func TestNotIndexed(t *testing.T) {
 	if count != 4 {
 		t.Fatalf("Expected 4 indexed values after deletion, got %d", count)
 	}
-	sort.Slice(foundValues, func(i, j int) bool {
-		return foundValues[i] < foundValues[j]
-	})
+	slices.Sort(foundValues)
 	if !reflect.DeepEqual(foundValues, expectedValues) {
 		t.Fatalf("Expected values %v after deletion, got %v", expectedValues, foundValues)
 	}

--- a/server/asset/btc/rpcclient.go
+++ b/server/asset/btc/rpcclient.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand/v2"
-	"sort"
+	"slices"
 
 	"decred.org/dcrdex/dex"
 	"github.com/btcsuite/btcd/btcjson"
@@ -542,7 +542,7 @@ out:
 		rates[i] = r
 	}
 
-	sort.Slice(rates, func(i, j int) bool { return rates[i] < rates[j] })
+	slices.Sort(rates)
 	return rates[len(rates)/2], nil
 }
 


### PR DESCRIPTION
Replace older sort functions with slices.Sort to simplify code