### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/server/admin/api.go
+++ b/server/admin/api.go
@@ -83,11 +83,8 @@ func (s *Server) apiAsset(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errs = append(errs, fmt.Sprintf("unable to get current fee rate: %v", err))
 	} else {
-		scaledFeeRate = s.core.ScaleFeeRate(assetID, currentFeeRate)
 		// Limit the scaled fee rate just as in (*Market).processReadyEpoch.
-		if scaledFeeRate > asset.MaxFeeRate {
-			scaledFeeRate = asset.MaxFeeRate
-		}
+		scaledFeeRate = min(s.core.ScaleFeeRate(assetID, currentFeeRate), asset.MaxFeeRate)
 	}
 
 	synced, err := backend.Synced()

--- a/server/asset/btc/testing.go
+++ b/server/asset/btc/testing.go
@@ -185,10 +185,7 @@ out:
 	t.Logf("%d unexpected empty scriptSig", stats.empty)
 	numUnknown := len(unknowns)
 	if numUnknown > 0 {
-		numToShow := 5
-		if numUnknown < numToShow {
-			numToShow = numUnknown
-		}
+		numToShow := min(numUnknown, 5)
 		t.Logf("showing %d of %d unknown scripts", numToShow, numUnknown)
 		for i, unknown := range unknowns {
 			if i == numToShow {
@@ -310,10 +307,7 @@ out:
 	t.Logf("%d P2PK(H) UTXO retrieval errors", stats.utxoErr)
 	numUnknown := len(unknowns)
 	if numUnknown > 0 {
-		numToShow := 5
-		if numUnknown < numToShow {
-			numToShow = numUnknown
-		}
+		numToShow := min(numUnknown, 5)
 		t.Logf("showing %d of %d unknown scripts", numToShow, numUnknown)
 		for i, unknown := range unknowns {
 			if i == numToShow {

--- a/server/db/driver/pg/upgrades.go
+++ b/server/db/driver/pg/upgrades.go
@@ -212,10 +212,7 @@ func v2Upgrade(tx *sql.Tx) error {
 			endIdx := ends[i]
 			for idx := starts[i]; idx <= endIdx; idx++ {
 				if idx%50000 == 0 {
-					to := idx + 50000
-					if to > endIdx+1 {
-						to = endIdx + 1
-					}
+					to := min(idx+50000, endIdx+1)
 					log.Infof(" - Processing epochs [%d, %d)...", idx, to)
 				}
 				var rates, quantities []uint64 // don't shadow err from outer scope

--- a/server/market/integ/booker_matcher_test.go
+++ b/server/market/integ/booker_matcher_test.go
@@ -1081,10 +1081,7 @@ func marketBuyQuoteAmt(lots uint64) uint64 {
 	nSell := len(bookSellOrders)
 	for lots > 0 && i < nSell {
 		sellOrder := bookSellOrders[nSell-1-i]
-		orderLots := sellOrder.Quantity / LotSize
-		if orderLots > lots {
-			orderLots = lots
-		}
+		orderLots := min(sellOrder.Quantity/LotSize, lots)
 		lots -= orderLots
 
 		amt += matcher.BaseToQuote(sellOrder.Rate, orderLots*LotSize)

--- a/server/market/market.go
+++ b/server/market/market.go
@@ -581,11 +581,7 @@ func (m *Market) ResumeEpoch(asSoonAs time.Time) (startEpochIdx int64) {
 	nextEpochIdx := 1 + now/dur
 
 	ms := asSoonAs.UnixMilli()
-	startEpochIdx = 1 + ms/dur
-
-	if startEpochIdx < nextEpochIdx {
-		startEpochIdx = nextEpochIdx
-	}
+	startEpochIdx = max(1+ms/dur, nextEpochIdx)
 	return
 }
 


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.