### PR TITLE
chore: fix inconsistent function name in comment

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -4330,7 +4330,7 @@ func (btc *baseWallet) SwapPrivate(swaps *asset.PrivateSwaps) (receipts []asset.
 	return receipts, change, txData, fees, nil
 }
 
-// taprootSigHash returns the sig hash to sign to spend a taproot output.
+// tapRootSigHash returns the sig hash to sign to spend a taproot output.
 func tapRootSigHash(prevOutPKScript []byte, prevOutVal uint64, tx *wire.MsgTx) ([32]byte, error) {
 	a := txscript.NewCannedPrevOutputFetcher(prevOutPKScript, int64(prevOutVal))
 	sigHashes := txscript.NewTxSigHashes(tx, a)

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -345,7 +345,7 @@ func (wc *rpcClient) GetTxOut(txHash *chainhash.Hash, index uint32, _ []byte, _ 
 	return wire.NewTxOut(int64(toSatoshi(txOut.Value)), outputScript), uint32(txOut.Confirmations), nil
 }
 
-// getTxOut returns the transaction output info if it's unspent and
+// getTxOutput returns the transaction output info if it's unspent and
 // nil, otherwise.
 func (wc *rpcClient) getTxOutput(txHash *chainhash.Hash, index uint32) (*btcjson.GetTxOutResult, error) {
 	// Note that we pass to call pointer to a pointer (&res) so that

--- a/client/asset/btc/spv_peer_manager.go
+++ b/client/asset/btc/spv_peer_manager.go
@@ -159,7 +159,7 @@ func (s *SPVPeerManager) resolveAddress(addr string) (string, error) {
 	return net.JoinHostPort(ip, strPort), nil
 }
 
-// peerWithResolvedAddress checks to see if there is a peer with a resolved
+// peerWithResolvedAddr checks to see if there is a peer with a resolved
 // address in s.peers, and if so, returns the address that was user to add
 // the peer.
 func (s *SPVPeerManager) peerWithResolvedAddr(resolvedAddr string) (string, bool) {


### PR DESCRIPTION
fix inconsistent function name in comment