### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/client/mm/event_log_test.go
+++ b/client/mm/event_log_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -99,9 +100,7 @@ func TestEventLogDB(t *testing.T) {
 			}
 		}
 		rates := make(map[uint32]float64, len(fiatRates))
-		for k, v := range fiatRates {
-			rates[k] = v
-		}
+		maps.Copy(rates, fiatRates)
 		return &BalanceState{
 			Balances:      balances,
 			FiatRates:     rates,

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"sort"
 	"strconv"
@@ -128,9 +129,7 @@ func newBalanceEffectsDiff() *balanceEffectsDiff {
 func (b *BalanceEffects) sub(other *BalanceEffects) *balanceEffectsDiff {
 	res := newBalanceEffectsDiff()
 
-	for assetID, v := range b.Settled {
-		res.settled[assetID] = v
-	}
+	maps.Copy(res.settled, b.Settled)
 	for assetID, v := range b.Locked {
 		res.locked[assetID] = int64(v)
 	}
@@ -1517,21 +1516,13 @@ func (u *unifiedExchangeAdaptor) refreshAllPendingEvents(ctx context.Context) {
 	// Make copies of all maps to avoid locking balancesMtx for the entire process
 	u.balancesMtx.Lock()
 	pendingDEXOrders := make(map[order.OrderID]*pendingDEXOrder, len(u.pendingDEXOrders))
-	for oid, pendingOrder := range u.pendingDEXOrders {
-		pendingDEXOrders[oid] = pendingOrder
-	}
+	maps.Copy(pendingDEXOrders, u.pendingDEXOrders)
 	pendingCEXOrders := make(map[string]*pendingCEXOrder, len(u.pendingCEXOrders))
-	for tradeID, pendingOrder := range u.pendingCEXOrders {
-		pendingCEXOrders[tradeID] = pendingOrder
-	}
+	maps.Copy(pendingCEXOrders, u.pendingCEXOrders)
 	pendingWithdrawals := make(map[string]*pendingWithdrawal, len(u.pendingWithdrawals))
-	for withdrawalID, pendingWithdrawal := range u.pendingWithdrawals {
-		pendingWithdrawals[withdrawalID] = pendingWithdrawal
-	}
+	maps.Copy(pendingWithdrawals, u.pendingWithdrawals)
 	pendingDeposits := make(map[string]*pendingDeposit, len(u.pendingDeposits))
-	for txID, pendingDeposit := range u.pendingDeposits {
-		pendingDeposits[txID] = pendingDeposit
-	}
+	maps.Copy(pendingDeposits, u.pendingDeposits)
 	u.balancesMtx.Unlock()
 
 	for _, pendingOrder := range pendingDEXOrders {
@@ -1697,9 +1688,7 @@ func (u *unifiedExchangeAdaptor) balanceState() *BalanceState {
 	}
 
 	mods := make(map[uint32]int64, len(u.inventoryMods))
-	for assetID, mod := range u.inventoryMods {
-		mods[assetID] = mod
-	}
+	maps.Copy(mods, u.inventoryMods)
 
 	return &BalanceState{
 		FiatRates:     u.fiatRates.Load().(map[uint32]float64),
@@ -4047,9 +4036,7 @@ type exchangeAdaptorCfg struct {
 // newUnifiedExchangeAdaptor is the constructor for a unifiedExchangeAdaptor.
 func newUnifiedExchangeAdaptor(cfg *exchangeAdaptorCfg) (*unifiedExchangeAdaptor, error) {
 	initialBalances := make(map[uint32]uint64, len(cfg.baseDexBalances))
-	for assetID, balance := range cfg.baseDexBalances {
-		initialBalances[assetID] = balance
-	}
+	maps.Copy(initialBalances, cfg.baseDexBalances)
 	for assetID, balance := range cfg.baseCexBalances {
 		initialBalances[assetID] += balance
 	}

--- a/client/mm/exchange_adaptor_test.go
+++ b/client/mm/exchange_adaptor_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"math"
 	"reflect"
 	"sort"
@@ -3287,9 +3288,7 @@ func TestMultiTrade(t *testing.T) {
 					}
 
 					pendingOrdersCopy := make(map[order.OrderID]*pendingDEXOrder)
-					for id, order := range pendingOrders {
-						pendingOrdersCopy[id] = order
-					}
+					maps.Copy(pendingOrdersCopy, pendingOrders)
 					adaptor.pendingDEXOrders = pendingOrdersCopy
 
 					adaptor.buyFees = buyFees

--- a/client/mm/libxc/binance.go
+++ b/client/mm/libxc/binance.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net/http"
 	"net/url"
@@ -470,9 +471,7 @@ func init() {
 	// MATIC is still returned with a balance of 0 in the balances response.
 
 	// Direct Binance -> DEX coin symbol mappings (highest priority)
-	for key, value := range binanceToDexCoinSymbol {
-		binanceToDexSymbol[key] = value
-	}
+	maps.Copy(binanceToDexSymbol, binanceToDexCoinSymbol)
 
 	// From coin symbol mappings (DEX -> Binance, reverse to Binance -> DEX)
 	for key, value := range dexToBinanceCoinSymbol {

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"sync"
 	"time"
@@ -89,9 +90,7 @@ type centralizedExchange struct {
 // mtx must be locked
 func (c *centralizedExchange) balancesCopy() map[uint32]*libxc.ExchangeBalance {
 	bs := make(map[uint32]*libxc.ExchangeBalance, len(c.balances))
-	for assetID, bal := range c.balances {
-		bs[assetID] = bal
-	}
+	maps.Copy(bs, c.balances)
 	return bs
 }
 
@@ -191,9 +190,7 @@ func (m *MarketMaker) runningBotsLookup() map[MarketWithHost]*runningBot {
 	defer m.runningBotsMtx.RUnlock()
 
 	mkts := make(map[MarketWithHost]*runningBot, len(m.runningBots))
-	for mkt, rb := range m.runningBots {
-		mkts[mkt] = rb
-	}
+	maps.Copy(mkts, m.runningBots)
 
 	return mkts
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.