### PR TITLE
refactor: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -542,9 +543,7 @@ func (ew *electrumWallet) calcMedianTime(ctx context.Context, height int64) (tim
 	// 	timestamps = append(timestamps, hdr.Timestamp.Unix())
 	// }
 
-	sort.Slice(timestamps, func(i, j int) bool {
-		return timestamps[i] < timestamps[j]
-	})
+	slices.Sort(timestamps)
 
 	medianTimestamp := timestamps[len(timestamps)/2]
 	return time.Unix(medianTimestamp, 0), nil

--- a/client/asset/btc/wallet.go
+++ b/client/asset/btc/wallet.go
@@ -3,7 +3,7 @@ package btc
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -104,9 +104,7 @@ func CalcMedianTime(stamper chainStamper, blockHash *chainhash.Hash) (time.Time,
 		h = prevHash
 	}
 
-	sort.Slice(timestamps, func(i, j int) bool {
-		return timestamps[i] < timestamps[j]
-	})
+	slices.Sort(timestamps)
 
 	medianTimestamp := timestamps[len(timestamps)/2]
 	return time.Unix(medianTimestamp, 0), nil

--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -13,7 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -815,9 +815,7 @@ func (w *spvWallet) medianTime(ctx context.Context, iBlkHeader *wire.BlockHeader
 			return 0, fmt.Errorf("info not found for previous block: %v", err)
 		}
 	}
-	sort.Slice(timestamps, func(i, j int) bool {
-		return timestamps[i] < timestamps[j]
-	})
+	slices.Sort(timestamps)
 	return timestamps[len(timestamps)/2], nil
 }
 

--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1300,9 +1300,7 @@ func sortHelpKeys() []string {
 	for k := range helpMsgs {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i] < keys[j]
-	})
+	slices.Sort(keys)
 	return keys
 }
 

--- a/client/webserver/locales/parse_test.go
+++ b/client/webserver/locales/parse_test.go
@@ -2,7 +2,7 @@ package locales
 
 import (
 	"reflect"
-	"sort"
+	"slices"
 	"testing"
 )
 
@@ -48,9 +48,7 @@ func TestTokens(t *testing.T) {
 		"[[[Import Account]]]",
 		"[[[ and Lets tRy: a_different  _HARDER_  .pattern. ::.-_-. ]]]",
 	}
-	sort.Slice(wantTokens, func(i, j int) bool {
-		return wantTokens[i] < wantTokens[j]
-	})
+	slices.Sort(wantTokens)
 	wantKeys := []string{
 		"Show pop-up notifications",
 		"fiat_exchange_rate_msg",
@@ -60,9 +58,7 @@ func TestTokens(t *testing.T) {
 		"Import Account",
 		" and Lets tRy: a_different  _HARDER_  .pattern. ::.-_-. ",
 	}
-	sort.Slice(wantKeys, func(i, j int) bool {
-		return wantKeys[i] < wantKeys[j]
-	})
+	slices.Sort(wantKeys)
 
 	got := Tokens(tmplFile)
 	var (
@@ -77,12 +73,8 @@ func TestTokens(t *testing.T) {
 		gotTokens = append(gotTokens, token)
 		gotKeys = append(gotKeys, key)
 	}
-	sort.Slice(gotTokens, func(i, j int) bool {
-		return gotTokens[i] < gotTokens[j]
-	})
-	sort.Slice(gotKeys, func(i, j int) bool {
-		return gotKeys[i] < gotKeys[j]
-	})
+	slices.Sort(gotTokens)
+	slices.Sort(gotKeys)
 
 	if !reflect.DeepEqual(wantTokens, gotTokens) {
 		t.Fatalf("expected tokens: %+v, got: %+v", wantTokens, gotTokens)


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.