### PR TITLE
refactor: omit unnecessary reassignment

### DIFF
--- a/client/db/bolt/upgrades_test.go
+++ b/client/db/bolt/upgrades_test.go
@@ -41,7 +41,6 @@ func TestUpgrades(t *testing.T) {
 	upgradeLog = tLogger
 	t.Run("group", func(t *testing.T) {
 		for _, tc := range dbUpgradeTests {
-			tc := tc // capture range variable
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				dbPath := unpack(t, tc.filename)

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -426,7 +426,6 @@ func (auth *AuthManager) unbookUserOrders(user account.AccountID) {
 func (auth *AuthManager) ExpectUsers(users map[account.AccountID]struct{}, within time.Duration) {
 	log.Debugf("Expecting %d users with booked orders to connect within %v", len(users), within)
 	for user := range users {
-		user := user // bad go
 		auth.unbookers[user] = time.AfterFunc(within, func() { auth.unbookUserOrders(user) })
 	}
 }


### PR DESCRIPTION
The new version of Go has been optimized, and variables do not need to be reassigned.

For more info: https://tip.golang.org/wiki/LoopvarExperiment#does-this-mean-i-dont-have-to-write-x--x-in-my-loops-anymore