### PR TITLE
Add Support for DigiByte v8.22+ Descriptor Wallets, Connect to Latest DGB v8.26

### DIFF
--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -107,6 +107,8 @@ type rpcCore struct {
 	stringAddr        dexbtc.AddressStringer
 	legacyRawSends    bool
 	minNetworkVersion uint64
+	minDescriptorVersion uint64
+	
 	log               dex.Logger
 	chainParams       *chaincfg.Params
 	omitAddressType   bool
@@ -188,9 +190,9 @@ func (wc *rpcClient) Connect(ctx context.Context, _ *sync.WaitGroup) error {
 	}
 	wc.descriptors = wiRes.Descriptors
 	if wc.descriptors {
-		if netVer < minDescriptorVersion {
+		if netVer < wc.minDescriptorVersion {
 			return fmt.Errorf("reported node version %d is less than minimum %d"+
-				" for descriptor wallets", netVer, minDescriptorVersion)
+				" for descriptor wallets", netVer, wc.minDescriptorVersion)
 		}
 		wc.log.Debug("Using a descriptor wallet.")
 	}

--- a/client/asset/dgb/dgb.go
+++ b/client/asset/dgb/dgb.go
@@ -27,6 +27,7 @@ const (
 	// 7.17, so I guess we'll support both and let the chain decide when to
 	// kill 7.17 wallets.
 	minNetworkVersion       = 82200
+	minDescriptorVersion    = 82200 // DGB v8.22+ supports descriptors
 	walletTypeRPC           = "digibytedRPC"
 	defaultRedeemConfTarget = 2
 )
@@ -142,6 +143,8 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) 
 	cloneCFG := &btc.BTCCloneCFG{
 		WalletCFG:           cfg,
 		MinNetworkVersion:   minNetworkVersion,
+		MinDescriptorVersion: minDescriptorVersion,
+		
 		WalletInfo:          WalletInfo,
 		Symbol:              "dgb",
 		Logger:              logger,


### PR DESCRIPTION
DigiByte uses a different version numbering scheme than Bitcoin Core. DigiByte v8.22+ (version 82200) is based on Bitcoin Core v0.22+ and supports descriptor wallets, but the hardcoded minDescriptorVersion check was comparing against Bitcoin's version scheme (220000), causing descriptor wallet connections to fail.

This commit adds a configurable MinDescriptorVersion field to BTCCloneCFG, allowing Bitcoin forks and related codebases with different versioning schemes to specify their own minimum descriptor wallet version. The field defaults to Bitcoin's minDescriptorVersion (220000) if not set, maintaining backward compatibility for all existing implementations.

For DigiByte, minDescriptorVersion is set to 82200, corresponding to DigiByte v8.22.0, which is the first version to support descriptor wallets based on Bitcoin Core v0.22.

Changes:
- Add MinDescriptorVersion field to BTCCloneCFG struct (btc.go)
- Add minDescriptorVersion field to rpcCore struct (rpcclient.go)
- Use configurable descriptor version in wallet connection check
- Set DGB minDescriptorVersion to 82200 (dgb.go)

Fixes error: "reported node version 82600 is less than minimum 220000 for descriptor wallets" when connecting DigiByte v8.26 with descriptor wallets enabled.

The DigiByte community would love to get $DGB actively traded along with the other great assets listed on Bison Wallet and DCRDex. Thank you for adding support for DGB originally!

<img width="1264" height="720" alt="Screenshot 2025-10-13 at 3 06 28 PM" src="https://github.com/user-attachments/assets/8e90841c-893d-44fb-8824-b54f9319f067" />
<img width="1227" height="838" alt="Screenshot 2025-10-13 at 3 04 03 PM" src="https://github.com/user-attachments/assets/d572a214-d04d-4dd8-80e4-86787b707831" />
