### PR TITLE
client: update docker image for Go and Node.js

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -11,13 +11,13 @@
 
 # frontend build
 
-# The image below is node:current-alpine3.18 (linux/amd64)
+# The image below is node:current-alpine3.22 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull node:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM node@sha256:d75175d449921d06250afd87d51f39a74fc174789fa3c50eba0d3b18369cc749 AS nodebuilder
+FROM node@sha256:809972647175c30a4c7763d3e6cc064dec588972af57e540e5a6f27442bb0845 AS nodebuilder
 WORKDIR /root/dex
 COPY . .
 RUN apk add git
@@ -27,13 +27,13 @@ RUN npm run build
 
 # bisonw binary build
 
-# The image below is golang:1.24.1-alpine3.21 (linux/amd64)
+# The image below is golang:1.25.3-alpine3.22 (linux/amd64)
 # It's pulled by the digest (immutable id) to avoid supply-chain attacks.
 # Maintainer Note:
 #    To update to a new digest, you must first manually pull the new image:
 #    `docker pull golang:<new version>`
 #    Docker will print the digest of the new image after the pull has finished.
-FROM golang@sha256:43c094ad24b6ac0546c62193baeb3e6e49ce14d3250845d166c77c25f64b0386 AS gobuilder
+FROM golang@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS gobuilder
 COPY --from=nodebuilder /root/dex/ /root/dex/
 WORKDIR /root/dex/client/cmd/bisonw/
 RUN CGO_ENABLED=0 GOOS=linux go build


### PR DESCRIPTION
This updates the docker image for go to golang:1.25.3-alpine3.22 and node to current-alpine3.22.

To verify the new digest for go:

```
$ docker pull golang:1.25.3-alpine3.22
1.25.3-alpine3.22: Pulling from library/golang
...
Digest: sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34
...
```

To verify for node:

```
$ docker pull node:current-alpine3.22
current-alpine3.22: Pulling from library/node
...
Digest: sha256:809972647175c30a4c7763d3e6cc064dec588972af57e540e5a6f27442bb0845
...
```

The previous images had critical security issues, see: https://hub.docker.com/layers/library/node/current-alpine3.18/images/sha256-77bef4a73625e5df6b719f12fc98983efdda096710d9d34bdfcef2ebd3c9943a (node), https://hub.docker.com/layers/library/golang/1.24.1-alpine3.21/images/sha256-526119861996722e742a85cb0df18f89028dd04981e0852b5fcdcf09b0f51b6a (golang)

