### PR TITLE
refactor: use maps.Copy to simplify the code

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
@@ -7080,9 +7081,7 @@ func (btc *intermediaryWallet) syncTxHistory(tip uint64) {
 
 	pendingTxsCopy := make(map[chainhash.Hash]ExtendedWalletTx, len(btc.pendingTxs))
 	btc.pendingTxsMtx.RLock()
-	for hash, tx := range btc.pendingTxs {
-		pendingTxsCopy[hash] = tx
-	}
+	maps.Copy(pendingTxsCopy, btc.pendingTxs)
 	btc.pendingTxsMtx.RUnlock()
 
 	handlePendingTx := func(txHash chainhash.Hash, tx *ExtendedWalletTx) {

--- a/client/asset/btc/coinmanager.go
+++ b/client/asset/btc/coinmanager.go
@@ -3,6 +3,7 @@ package btc
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"sort"
 	"sync"
@@ -140,9 +141,7 @@ func (c *CoinManager) fundWithUTXOs(
 		if err != nil {
 			return nil, nil, nil, nil, 0, 0, fmt.Errorf("LockUnspent error: %w", err)
 		}
-		for pt, utxo := range fundingCoins {
-			c.lockedOutputs[pt] = utxo
-		}
+		maps.Copy(c.lockedOutputs, fundingCoins)
 	}
 
 	return coins, fundingCoins, spents, redeemScripts, size, sum, err
@@ -541,9 +540,7 @@ func (c *CoinManager) LockUTXOs(utxos []*UTxO) {
 // LockOutputsMap locks the utxos in the provided mapping.
 func (c *CoinManager) LockOutputsMap(utxos map[OutPoint]*UTxO) {
 	c.mtx.Lock()
-	for pt, utxo := range utxos {
-		c.lockedOutputs[pt] = utxo
-	}
+	maps.Copy(c.lockedOutputs, utxos)
 	c.mtx.Unlock()
 }
 

--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -424,9 +425,7 @@ func (btc *ExchangeWalletElectrum) syncTxHistory(tip uint64) {
 
 	pendingTxsCopy := make(map[chainhash.Hash]ExtendedWalletTx, len(btc.pendingTxs))
 	btc.pendingTxsMtx.RLock()
-	for hash, tx := range btc.pendingTxs {
-		pendingTxsCopy[hash] = tx
-	}
+	maps.Copy(pendingTxsCopy, btc.pendingTxs)
 	btc.pendingTxsMtx.RUnlock()
 
 	handlePendingTx := func(txHash chainhash.Hash, tx *ExtendedWalletTx) {

--- a/client/asset/btc/redemption_finder.go
+++ b/client/asset/btc/redemption_finder.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"sync"
 	"time"
@@ -331,9 +332,7 @@ func (r *RedemptionFinder) tryRedemptionRequests(ctx context.Context, startBlock
 	}
 
 	// Check mempool for any remaining undiscovered requests.
-	for outPt, req := range undiscovered {
-		mempoolReqs[outPt] = req
-	}
+	maps.Copy(mempoolReqs, undiscovered)
 
 	if len(mempoolReqs) == 0 {
 		return

--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1144,10 +1145,7 @@ func FindRedemptionsInMempool(
 			return
 		}
 		newlyDiscovered := FindRedemptionsInTxWithHasher(ctx, segwit, reqs, tx, chainParams, hashTx)
-		for outPt, res := range newlyDiscovered {
-			discovered[outPt] = res
-		}
-
+		maps.Copy(discovered, newlyDiscovered)
 	}
 	return
 }
@@ -1176,9 +1174,7 @@ func SearchBlockForRedemptions(
 
 	for _, msgTx := range msgBlock.Transactions {
 		newlyDiscovered := FindRedemptionsInTxWithHasher(ctx, segwit, reqs, msgTx, chainParams, hashTx)
-		for outPt, res := range newlyDiscovered {
-			discovered[outPt] = res
-		}
+		maps.Copy(discovered, newlyDiscovered)
 	}
 	return
 }

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"math"
 	"os"
 	"path/filepath"
@@ -1200,9 +1201,7 @@ func (w *spvWallet) SearchBlockForRedemptions(ctx context.Context, reqs map[OutP
 
 	for _, msgTx := range block.MsgBlock().Transactions {
 		newlyDiscovered := FindRedemptionsInTxWithHasher(ctx, true, reqs, msgTx, w.chainParams, hashTx)
-		for outPt, res := range newlyDiscovered {
-			discovered[outPt] = res
-		}
+		maps.Copy(discovered, newlyDiscovered)
 	}
 	return
 }

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"os"
 	"os/exec"
@@ -4374,9 +4375,7 @@ func (w *assetWallet) findRedemptionRequests() map[string]*findRedemptionRequest
 	w.findRedemptionMtx.RLock()
 	defer w.findRedemptionMtx.RUnlock()
 	reqs := make(map[string]*findRedemptionRequest, len(w.findRedemptionReqs))
-	for loc, req := range w.findRedemptionReqs {
-		reqs[loc] = req
-	}
+	maps.Copy(reqs, w.findRedemptionReqs)
 	return reqs
 }
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"math/rand"
 	"reflect"
@@ -1613,9 +1614,7 @@ func tassetWallet(assetID uint32) (asset.Wallet, *assetWallet, *tMempoolNode, co
 
 	versionedGases := make(map[uint32]*dexeth.Gases)
 	if assetID == BipID { // just make a copy
-		for ver, g := range dexeth.VersionedGases {
-			versionedGases[ver] = g
-		}
+		maps.Copy(versionedGases, dexeth.VersionedGases)
 	} else {
 		netToken := dexeth.Tokens[assetID].NetTokens[dex.Simnet]
 		for ver, c := range netToken.SwapContracts {

--- a/client/core/bookie.go
+++ b/client/core/bookie.go
@@ -6,6 +6,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -906,9 +907,7 @@ func (dc *dexConnection) subPriceFeed() {
 
 	// We expect there to be a map in handlePriceUpdateNote.
 	spotsCopy := make(map[string]*msgjson.Spot, len(spots))
-	for mkt, spot := range spots {
-		spotsCopy[mkt] = spot
-	}
+	maps.Copy(spotsCopy, spots)
 	dc.notify(newSpotPriceNote(dc.acct.host, spotsCopy)) // consumers read spotsCopy async with this call
 
 	dc.spotsMtx.Lock()

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"net"
 	"net/url"
@@ -504,9 +505,7 @@ func (c *Core) exchangeInfo(dc *dexConnection) *Exchange {
 
 	dc.assetsMtx.RLock()
 	assets := make(map[uint32]*dex.Asset, len(dc.assets))
-	for assetID, dexAsset := range dc.assets {
-		assets[assetID] = dexAsset
-	}
+	maps.Copy(assets, dc.assets)
 	dc.assetsMtx.RUnlock()
 
 	bondCfg := c.dexBondConfig(dc, time.Now().Unix())
@@ -3353,9 +3352,7 @@ func (c *Core) RecoverWallet(assetID uint32, appPW []byte, force bool) error {
 			c.log.Errorf("RecoverWallet: unable to get recovery config: %v", err)
 		} else {
 			// merge recoveryCfg with dbWallet.Settings
-			for key, val := range recoveryCfg {
-				dbWallet.Settings[key] = val
-			}
+			maps.Copy(dbWallet.Settings, recoveryCfg)
 		}
 		oldWallet.Disconnect() // wallet now shut down and w.hookedUp == false -> connected() returns false
 	}


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.