### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/client/asset/btc/rpcclient.go
+++ b/client/asset/btc/rpcclient.go
@@ -624,12 +624,12 @@ func (wc *rpcClient) SignTx(inTx *wire.MsgTx) (*wire.MsgTx, error) {
 	}
 	if !res.Complete {
 		sep := ""
-		errMsg := ""
+		var errMsg strings.Builder
 		for _, e := range res.Errors {
-			errMsg += e.Error + sep
+			errMsg.WriteString(e.Error + sep)
 			sep = ";"
 		}
-		return nil, fmt.Errorf("signing incomplete. %d signing errors encountered: %s", len(res.Errors), errMsg)
+		return nil, fmt.Errorf("signing incomplete. %d signing errors encountered: %s", len(res.Errors), errMsg.String())
 	}
 	outTx, err := wc.deserializeTx(res.Hex)
 	if err != nil {

--- a/client/asset/zec/transparent_rpc.go
+++ b/client/asset/zec/transparent_rpc.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/client/asset/btc"
@@ -92,12 +93,12 @@ func signTxByRPC(c rpcCaller, inTx *dexzec.Tx) (*dexzec.Tx, error) {
 	}
 	if !res.Complete {
 		sep := ""
-		errMsg := ""
+		var errMsg strings.Builder
 		for _, e := range res.Errors {
-			errMsg += e.Error + sep
+			errMsg.WriteString(e.Error + sep)
 			sep = ";"
 		}
-		return nil, fmt.Errorf("signing incomplete. %d signing errors encountered: %s", len(res.Errors), errMsg)
+		return nil, fmt.Errorf("signing incomplete. %d signing errors encountered: %s", len(res.Errors), errMsg.String())
 	}
 	outTx, err := dexzec.DeserializeTx(res.Hex)
 	if err != nil {

--- a/client/cmd/mmbaltracker/main.go
+++ b/client/cmd/mmbaltracker/main.go
@@ -147,26 +147,26 @@ func main() {
 			currBalances[*mkt].CEXBalances[assetID] = newBal
 		}
 
-		logStr := ""
+		var logStr strings.Builder
 
 		if len(dexDiffs) > 0 || len(cexDiffs) > 0 {
-			logStr += "================================================\n"
-			logStr += fmt.Sprintf("\nDiffs on Market: %s-%d-%d", mkt.Host, mkt.BaseID, mkt.QuoteID)
+			logStr.WriteString("================================================\n")
+			logStr.WriteString(fmt.Sprintf("\nDiffs on Market: %s-%d-%d", mkt.Host, mkt.BaseID, mkt.QuoteID))
 			if len(dexDiffs) > 0 {
-				logStr += "\n  DEX diffs:"
+				logStr.WriteString("\n  DEX diffs:")
 				for _, d := range dexDiffs {
-					logStr += fmt.Sprintf("\n    %s: %d -> %d (%d)", dex.BipIDSymbol(d.assetID), d.oldBal, d.newBal, int64(d.newBal)-int64(d.oldBal))
+					logStr.WriteString(fmt.Sprintf("\n    %s: %d -> %d (%d)", dex.BipIDSymbol(d.assetID), d.oldBal, d.newBal, int64(d.newBal)-int64(d.oldBal)))
 				}
 			}
 
 			if len(cexDiffs) > 0 {
-				logStr += "\n  CEX diffs:"
+				logStr.WriteString("\n  CEX diffs:")
 				for _, d := range cexDiffs {
-					logStr += fmt.Sprintf("\n    %s: %d -> %d (%d)", dex.BipIDSymbol(d.assetID), d.oldBal, d.newBal, int64(d.newBal)-int64(d.oldBal))
+					logStr.WriteString(fmt.Sprintf("\n    %s: %d -> %d (%d)", dex.BipIDSymbol(d.assetID), d.oldBal, d.newBal, int64(d.newBal)-int64(d.oldBal)))
 				}
 			}
-			logStr += "\n\n"
-			log.Infof(logStr)
+			logStr.WriteString("\n\n")
+			log.Infof(logStr.String())
 		}
 	}
 

--- a/dex/fiatrates/sources.go
+++ b/dex/fiatrates/sources.go
@@ -252,11 +252,11 @@ func fiatSources(cfg Config) []*source {
 }
 
 func parseTickers(tickerSymbols ...string) string {
-	var tickers string
+	var tickers strings.Builder
 	for _, ticker := range tickerSymbols {
-		tickers += parseTicker(ticker) + ","
+		tickers.WriteString(parseTicker(ticker) + ",")
 	}
-	return strings.Trim(tickers, ",")
+	return strings.Trim(tickers.String(), ",")
 }
 
 func parseTicker(ticker string) string {
@@ -269,13 +269,13 @@ func parseTicker(ticker string) string {
 }
 
 func parseBinanceTickers(tickerSymbols []string) string {
-	var tickers string
+	var tickers strings.Builder
 	for _, ticker := range tickerSymbols {
 		ticker = parseTicker(ticker)
 		if strings.EqualFold(ticker, "zcl") { // not supported on binance as of writing
 			continue
 		}
-		tickers += fmt.Sprintf("%q,", ticker+"USDT")
+		tickers.WriteString(fmt.Sprintf("%q,", ticker+"USDT"))
 	}
-	return strings.Trim(tickers, ",")
+	return strings.Trim(tickers.String(), ",")
 }

--- a/server/db/driver/pg/system.go
+++ b/server/db/driver/pg/system.go
@@ -322,14 +322,15 @@ func (pgs PGSettings) String() string {
 		"s | %10.10s | %" + strconv.Itoa(fileWidth) + "s | %5s | %-48.48s\n"
 
 	// Write the headers and a horizontal bar.
-	out := fmt.Sprintf(format, "Name", "Setting", "Source", "File", "Line", "Description")
+	var out strings.Builder
+	out.WriteString(fmt.Sprintf(format, "Name", "Setting", "Source", "File", "Line", "Description"))
 	hBar := strings.Repeat(string([]rune{0x2550}), nameWidth+1) + string([]rune{0x256A}) +
 		strings.Repeat(string([]rune{0x2550}), settingWidth+2) + string([]rune{0x256A}) +
 		strings.Repeat(string([]rune{0x2550}), 12) + string([]rune{0x256A}) +
 		strings.Repeat(string([]rune{0x2550}), fileWidth+2) + string([]rune{0x256A}) +
 		strings.Repeat(string([]rune{0x2550}), 7) + string([]rune{0x256A}) +
 		strings.Repeat(string([]rune{0x2550}), 50)
-	out += hBar + "\n"
+	out.WriteString(hBar + "\n")
 
 	// Write each row.
 	for i := range names {
@@ -338,10 +339,10 @@ func (pgs PGSettings) String() string {
 			log.Warnf("(PGSettings).String is not thread-safe!")
 			continue
 		}
-		out += fmt.Sprintf(format, s.Name, fullSettings[i], s.Source,
-			s.SourceFile, s.SourceLine, s.ShortDesc)
+		out.WriteString(fmt.Sprintf(format, s.Name, fullSettings[i], s.Source,
+			s.SourceFile, s.SourceLine, s.ShortDesc))
 	}
-	return out
+	return out.String()
 }
 
 // retrievePGVersion retrieves the version of the connected PostgreSQL server.


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)