### PR TITLE
ui: Fix rate display on fee bump notification

### DIFF
--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -677,7 +677,7 @@ export default class Application {
     switch (req.actionID) {
       case 'tooCheap': {
         Doc.show(tmpl.newFeesRow)
-        tmpl.newFees.textContent = Doc.formatCoinValue(n.tx.fees, parentUI)
+        tmpl.newFees.textContent = Doc.formatCoinValue(n.newFees, parentUI)
         tmpl.newFeesUnit.textContent = parentUI.conventional.unit
         break
       }


### PR DESCRIPTION
The fee bump notification was showing the original transaction's fee in the place where it should have been showing the updated fee.