### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/client/asset/btc/txdb.go
+++ b/client/asset/btc/txdb.go
@@ -93,17 +93,17 @@ type badgerLoggerWrapper struct {
 var _ badger.Logger = (*badgerLoggerWrapper)(nil)
 
 // Debugf -> dex.Logger.Tracef
-func (log *badgerLoggerWrapper) Debugf(s string, a ...interface{}) {
+func (log *badgerLoggerWrapper) Debugf(s string, a ...any) {
 	log.Tracef(s, a...)
 }
 
 // Infof -> dex.Logger.Debugf
-func (log *badgerLoggerWrapper) Infof(s string, a ...interface{}) {
+func (log *badgerLoggerWrapper) Infof(s string, a ...any) {
 	log.Debugf(s, a...)
 }
 
 // Warningf -> dex.Logger.Warnf
-func (log *badgerLoggerWrapper) Warningf(s string, a ...interface{}) {
+func (log *badgerLoggerWrapper) Warningf(s string, a ...any) {
 	log.Warnf(s, a...)
 }
 

--- a/client/asset/eth/base_test_util.go
+++ b/client/asset/eth/base_test_util.go
@@ -145,7 +145,7 @@ func (cc *combinedRPCClient) BaseBlockByNumber(ctx context.Context, number *big.
 		for i := range reqs {
 			reqs[i] = rpc.BatchElem{
 				Method: "eth_getUncleByBlockHashAndIndex",
-				Args:   []interface{}{body.Hash, basehexutil.EncodeUint64(uint64(i))},
+				Args:   []any{body.Hash, basehexutil.EncodeUint64(uint64(i))},
 				Result: &uncles[i],
 			}
 		}

--- a/client/asset/eth/bundler.go
+++ b/client/asset/eth/bundler.go
@@ -54,7 +54,7 @@ const (
 
 // bundler is an interface to interact with an ERC-4337 bundler.
 type bundler interface {
-	supportedEntryPoints(ctx context.Context) (map[common.Address]interface{}, error)
+	supportedEntryPoints(ctx context.Context) (map[common.Address]any, error)
 	sendUserOp(ctx context.Context, userOp *userOp) (common.Hash, error)
 	getUserOpReceipt(ctx context.Context, userOpHash common.Hash) (*getUserOpReceiptResult, error)
 	withNonce(opts *bind.CallOpts, ethSwapAddr, participantAddr common.Address, f func(*big.Int) error) error
@@ -118,14 +118,14 @@ func newBundler(ctx context.Context, endpoint string, entryPointAddr common.Addr
 }
 
 // supportedEntryPoints returns the entry points supported by the bundler.
-func (b *rpcBundler) supportedEntryPoints(ctx context.Context) (map[common.Address]interface{}, error) {
+func (b *rpcBundler) supportedEntryPoints(ctx context.Context) (map[common.Address]any, error) {
 	var res []string
 	err := b.rpcClient.CallContext(ctx, &res, "eth_supportedEntryPoints")
 	if err != nil {
 		return nil, err
 	}
 
-	entryPoints := make(map[common.Address]interface{}, len(res))
+	entryPoints := make(map[common.Address]any, len(res))
 	for _, v := range res {
 		entryPoints[common.HexToAddress(v)] = true
 	}

--- a/client/asset/eth/contractor.go
+++ b/client/asset/eth/contractor.go
@@ -783,7 +783,7 @@ func (c *contractorV1) estimateInitGas(ctx context.Context, n int) (uint64, erro
 	return c.estimateGas(ctx, value, "initiate", c.tokenAddr, initiations)
 }
 
-func (c *contractorV1) estimateGas(ctx context.Context, value *big.Int, method string, args ...interface{}) (uint64, error) {
+func (c *contractorV1) estimateGas(ctx context.Context, value *big.Int, method string, args ...any) (uint64, error) {
 	return estimateGas(ctx, c.acctAddr, c.swapContractAddr, c.abi, c.cb, value, method, args...)
 }
 
@@ -957,7 +957,7 @@ func (c *tokenContractorV1) tokenAddress() common.Address {
 var _ contractor = (*tokenContractorV1)(nil)
 var _ tokenContractor = (*tokenContractorV1)(nil)
 
-func estimateGas(ctx context.Context, from, to common.Address, abi *abi.ABI, cb bind.ContractBackend, value *big.Int, method string, args ...interface{}) (uint64, error) {
+func estimateGas(ctx context.Context, from, to common.Address, abi *abi.ABI, cb bind.ContractBackend, value *big.Int, method string, args ...any) (uint64, error) {
 	data, err := abi.Pack(method, args...)
 	if err != nil {
 		return 0, fmt.Errorf("Pack error: %v", err)

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -835,7 +835,7 @@ func (db *tTxDB) getBridgeCompletions(initiationTxID string) ([]*extendedWalletT
 // }
 
 type tBundler struct {
-	supportedEntrypointsResult map[common.Address]interface{}
+	supportedEntrypointsResult map[common.Address]any
 	supportedEntrypointsErr    error
 	// if both are set, on the first call the error will be returned, and on the
 	// second call, the result will be returned.
@@ -855,7 +855,7 @@ type tBundler struct {
 
 var _ bundler = (*tBundler)(nil)
 
-func (b *tBundler) supportedEntryPoints(ctx context.Context) (map[common.Address]interface{}, error) {
+func (b *tBundler) supportedEntryPoints(ctx context.Context) (map[common.Address]any, error) {
 	return b.supportedEntrypointsResult, b.supportedEntrypointsErr
 }
 
@@ -896,7 +896,7 @@ func (b *tBundler) getGasPrice(ctx context.Context) (string, string, error) {
 
 func newTBundler() *tBundler {
 	return &tBundler{
-		supportedEntrypointsResult: make(map[common.Address]interface{}),
+		supportedEntrypointsResult: make(map[common.Address]any),
 		getUserOpReceiptResults:    make(map[common.Hash]*getUserOpReceiptResult),
 		getUserOpReceiptErrs:       make(map[common.Hash]error),
 		submittedUserOps:           make([]*userOp, 0),

--- a/client/asset/eth/txdb_legacy.go
+++ b/client/asset/eth/txdb_legacy.go
@@ -321,28 +321,28 @@ type badgerLoggerWrapper struct {
 var _ badger.Logger = (*badgerLoggerWrapper)(nil)
 
 // Debugf -> dex.Logger.Tracef
-func (log *badgerLoggerWrapper) Debugf(s string, a ...interface{}) {
+func (log *badgerLoggerWrapper) Debugf(s string, a ...any) {
 	log.Tracef(s, a...)
 }
 
-func (log *badgerLoggerWrapper) Debug(a ...interface{}) {
+func (log *badgerLoggerWrapper) Debug(a ...any) {
 	log.Trace(a...)
 }
 
 // Infof -> dex.Logger.Debugf
-func (log *badgerLoggerWrapper) Infof(s string, a ...interface{}) {
+func (log *badgerLoggerWrapper) Infof(s string, a ...any) {
 	log.Debugf(s, a...)
 }
 
-func (log *badgerLoggerWrapper) Info(a ...interface{}) {
+func (log *badgerLoggerWrapper) Info(a ...any) {
 	log.Debug(a...)
 }
 
 // Warningf -> dex.Logger.Warnf
-func (log *badgerLoggerWrapper) Warningf(s string, a ...interface{}) {
+func (log *badgerLoggerWrapper) Warningf(s string, a ...any) {
 	log.Warnf(s, a...)
 }
 
-func (log *badgerLoggerWrapper) Warning(a ...interface{}) {
+func (log *badgerLoggerWrapper) Warning(a ...any) {
 	log.Warn(a...)
 }

--- a/client/asset/zcl/zcl.go
+++ b/client/asset/zcl/zcl.go
@@ -187,7 +187,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (ass
 		BalanceFunc: func(ctx context.Context, locked uint64) (*asset.Balance, error) {
 			var bal float64
 			// args: "(dummy)" minconf includeWatchonly
-			if err := w.CallRPC("getbalance", []interface{}{"", 0, false}, &bal); err != nil {
+			if err := w.CallRPC("getbalance", []any{"", 0, false}, &bal); err != nil {
 				return nil, err
 			}
 			return &asset.Balance{
@@ -208,7 +208,7 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (ass
 		UnlockSpends:             true,
 		FeeEstimator: func(_ context.Context, _ btc.RawRequester, nBlocks uint64) (uint64, error) {
 			var r float64
-			if err := w.CallRPC("estimatefee", []interface{}{nBlocks}, &r); err != nil {
+			if err := w.CallRPC("estimatefee", []any{nBlocks}, &r); err != nil {
 				return 0, fmt.Errorf("error calling 'estimatefee': %v", err)
 			}
 			if r < 0 {

--- a/client/cmd/testbinance/harness_test.go
+++ b/client/cmd/testbinance/harness_test.go
@@ -70,7 +70,7 @@ func testWallet(t *testing.T, ctx context.Context, w Wallet) {
 	t.Fatal("Failed to get confirmations")
 }
 
-func getInto(method, endpoint string, thing interface{}) error {
+func getInto(method, endpoint string, thing any) error {
 	req, err := http.NewRequest(method, "http://localhost:37346"+endpoint, nil)
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func getInto(method, endpoint string, thing interface{}) error {
 	return requestInto(req, thing)
 }
 
-func requestInto(req *http.Request, thing interface{}) error {
+func requestInto(req *http.Request, thing any) error {
 	req.Header.Add("X-MBX-APIKEY", testAPIKey)
 
 	resp, err := http.DefaultClient.Do(req)
@@ -90,7 +90,7 @@ func requestInto(req *http.Request, thing interface{}) error {
 	return json.Unmarshal(b, thing)
 }
 
-func printThing(name string, thing interface{}) {
+func printThing(name string, thing any) {
 	b, _ := json.MarshalIndent(thing, "", "    ")
 	fmt.Println("#####", name, ":", string(b))
 }

--- a/client/cmd/testbinance/main.go
+++ b/client/cmd/testbinance/main.go
@@ -1445,7 +1445,7 @@ func (m *market) shuffle() (buys, sells [][2]json.Number) {
 
 // writeJSONWithStatus marshals the provided interface and writes the bytes to the
 // ResponseWriter with the specified response code.
-func writeJSONWithStatus(w http.ResponseWriter, thing interface{}, code int) {
+func writeJSONWithStatus(w http.ResponseWriter, thing any, code int) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	b, err := json.Marshal(thing)
 	if err != nil {

--- a/client/mm/exchange_adaptor.go
+++ b/client/mm/exchange_adaptor.go
@@ -575,7 +575,7 @@ func (u *unifiedExchangeAdaptor) logBalanceAdjustments(dexDiffs, cexDiffs map[ui
 	}
 
 	var msg strings.Builder
-	writeLine := func(s string, a ...interface{}) {
+	writeLine := func(s string, a ...any) {
 		msg.WriteString("\n" + fmt.Sprintf(s, a...))
 	}
 	writeLine("")
@@ -1693,7 +1693,7 @@ func (u *unifiedExchangeAdaptor) CEXBalance(assetID uint32) *BotBalance {
 
 // allAssets returns a list of all the assets this bot uses.
 func (u *unifiedExchangeAdaptor) allAssets() []uint32 {
-	assets := make(map[uint32]interface{}, 6)
+	assets := make(map[uint32]any, 6)
 	assets[u.dexBaseID] = struct{}{}
 	assets[u.dexQuoteID] = struct{}{}
 	assets[feeAssetID(u.dexBaseID)] = struct{}{}

--- a/client/mm/libxc/binance.go
+++ b/client/mm/libxc/binance.go
@@ -586,7 +586,7 @@ type binance struct {
 	net                dex.Network
 	tradeIDNonce       atomic.Uint32
 	tradeIDNoncePrefix dex.Bytes
-	broadcast          func(interface{})
+	broadcast          func(any)
 	isUS               bool
 
 	markets atomic.Value // map[string]*binanceMarket
@@ -1635,15 +1635,15 @@ func (bnc *binance) MatchedMarkets(ctx context.Context) (_ []*MarketMatch, err e
 	return markets, nil
 }
 
-func (bnc *binance) getAPI(ctx context.Context, endpoint string, query url.Values, key, sign bool, thing interface{}) error {
+func (bnc *binance) getAPI(ctx context.Context, endpoint string, query url.Values, key, sign bool, thing any) error {
 	return bnc.request(ctx, http.MethodGet, endpoint, query, nil, key, sign, thing)
 }
 
-func (bnc *binance) postAPI(ctx context.Context, endpoint string, query, form url.Values, key, sign bool, thing interface{}) error {
+func (bnc *binance) postAPI(ctx context.Context, endpoint string, query, form url.Values, key, sign bool, thing any) error {
 	return bnc.request(ctx, http.MethodPost, endpoint, query, form, key, sign, thing)
 }
 
-func (bnc *binance) request(ctx context.Context, method, endpoint string, query, form url.Values, key, sign bool, thing interface{}) error {
+func (bnc *binance) request(ctx context.Context, method, endpoint string, query, form url.Values, key, sign bool, thing any) error {
 	var fullURL string
 	if strings.Contains(endpoint, "sapi") {
 		fullURL = bnc.accountsURL + endpoint

--- a/client/mm/libxc/binance_live_test.go
+++ b/client/mm/libxc/binance_live_test.go
@@ -80,7 +80,7 @@ func tNewBinance() *binance {
 		APIKey:    apiKey,
 		SecretKey: apiSecret,
 		Logger:    log,
-		Notify: func(n interface{}) {
+		Notify: func(n any) {
 			log.Infof("Notification sent: %+v", n)
 		},
 	}

--- a/client/mm/libxc/coinbase_live_test.go
+++ b/client/mm/libxc/coinbase_live_test.go
@@ -74,7 +74,7 @@ func tNewCoinbase(t *testing.T) (*coinbase, func()) {
 		APIKey:    creds.Name,
 		SecretKey: creds.PrivateKey,
 		Logger:    dex.StdOutLogger("T", dex.LevelInfo),
-		Notify:    func(interface{}) {},
+		Notify:    func(any) {},
 	})
 	if err != nil {
 		t.Fatalf("error creating coinbase: %v", err)

--- a/client/mm/libxc/interface.go
+++ b/client/mm/libxc/interface.go
@@ -176,7 +176,7 @@ type CEXConfig struct {
 	APIKey    string
 	SecretKey string
 	Logger    dex.Logger
-	Notify    func(interface{})
+	Notify    func(any)
 }
 
 // NewCEX creates a new CEX.

--- a/client/mm/libxc/mexc.go
+++ b/client/mm/libxc/mexc.go
@@ -45,7 +45,7 @@ import (
 // MEXC Spot v3 CEX adaptor.
 type mexc struct {
 	log       dex.Logger
-	notify    func(interface{})
+	notify    func(any)
 	apiKey    string
 	secretKey string
 	ctx       context.Context
@@ -735,27 +735,27 @@ func (m *mexc) getOrderbookSnapshot(ctx context.Context, symbol string) (*mxctyp
 	return &resp, nil
 }
 
-func (m *mexc) getAPI(ctx context.Context, endpoint string, query url.Values, sign bool, thing interface{}) error {
+func (m *mexc) getAPI(ctx context.Context, endpoint string, query url.Values, sign bool, thing any) error {
 	return m.request(ctx, http.MethodGet, endpoint, query, nil, sign, thing)
 }
 
 // postAPI performs a signed POST request.
-func (m *mexc) postAPI(ctx context.Context, endpoint string, query url.Values, sign bool, thing interface{}) error {
+func (m *mexc) postAPI(ctx context.Context, endpoint string, query url.Values, sign bool, thing any) error {
 	return m.request(ctx, http.MethodPost, endpoint, query, nil, sign, thing)
 }
 
 // putAPI performs a signed PUT request.
-func (m *mexc) putAPI(ctx context.Context, endpoint string, query url.Values, sign bool, thing interface{}) error {
+func (m *mexc) putAPI(ctx context.Context, endpoint string, query url.Values, sign bool, thing any) error {
 	return m.request(ctx, http.MethodPut, endpoint, query, nil, sign, thing)
 }
 
 // deleteAPI performs a signed DELETE request.
-func (m *mexc) deleteAPI(ctx context.Context, endpoint string, query url.Values, sign bool, thing interface{}) error {
+func (m *mexc) deleteAPI(ctx context.Context, endpoint string, query url.Values, sign bool, thing any) error {
 	return m.request(ctx, http.MethodDelete, endpoint, query, nil, sign, thing)
 }
 
 // request performs an HTTP request with optional HMAC signature.
-func (m *mexc) request(ctx context.Context, method, endpoint string, query, form url.Values, sign bool, thing interface{}) error {
+func (m *mexc) request(ctx context.Context, method, endpoint string, query, form url.Values, sign bool, thing any) error {
 	m.initHTTPClient()
 
 	fullURL := mexcHTTPURL + endpoint
@@ -1380,7 +1380,7 @@ func (m *mexc) handleMarketRaw(b []byte) {
 	if err := json.Unmarshal(b, &msg); err == nil {
 		// Handle server PING - respond with PONG
 		if msg.Method == "PING" {
-			pong := map[string]interface{}{
+			pong := map[string]any{
 				"id":   0,
 				"code": 0,
 				"msg":  "PONG",
@@ -1586,7 +1586,7 @@ func (m *mexc) handlePrivateRaw(b []byte) {
 		m.log.Tracef("Parsed as JSON control message: method=%s, code=%d, msg=%s", msg.Method, msg.Code, msg.Msg)
 		// Handle server PING - respond with PONG
 		if msg.Method == "PING" {
-			pong := map[string]interface{}{
+			pong := map[string]any{
 				"id":   0,
 				"code": 0,
 				"msg":  "PONG",

--- a/client/mm/libxc/orderbook.go
+++ b/client/mm/libxc/orderbook.go
@@ -26,7 +26,7 @@ const asksComparable = obEntryComparable(1)
 
 var _ skiplist.Comparable = (*obEntryComparable)(nil)
 
-func (o obEntryComparable) Compare(lhs, rhs interface{}) int {
+func (o obEntryComparable) Compare(lhs, rhs any) int {
 	lhsEntry := lhs.(*obEntry)
 	rhsEntry := rhs.(*obEntry)
 
@@ -45,7 +45,7 @@ func (o obEntryComparable) Compare(lhs, rhs interface{}) int {
 	return toReturn
 }
 
-func (o obEntryComparable) CalcScore(key interface{}) float64 {
+func (o obEntryComparable) CalcScore(key any) float64 {
 	if o == bidsComparable {
 		return math.MaxFloat64 - float64(key.(*obEntry).rate)
 	} else {

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -123,8 +123,8 @@ type runningBot struct {
 	cexCfg *CEXConfig
 }
 
-func (rb *runningBot) assets() map[uint32]interface{} {
-	assets := make(map[uint32]interface{})
+func (rb *runningBot) assets() map[uint32]any {
+	assets := make(map[uint32]any)
 	cfg := rb.botCfg()
 	assets[cfg.BaseID] = struct{}{}
 	assets[cfg.QuoteID] = struct{}{}
@@ -607,7 +607,7 @@ func (m *MarketMaker) loadCEX(ctx context.Context, cfg *CEXConfig) (*centralized
 		SecretKey: cfg.APISecret,
 		Logger:    logger,
 		Net:       m.core.Network(),
-		Notify: func(n interface{}) {
+		Notify: func(n any) {
 			m.handleCEXUpdate(cfg.Name, n)
 		},
 	})
@@ -634,7 +634,7 @@ func (m *MarketMaker) loadCEX(ctx context.Context, cfg *CEXConfig) (*centralized
 	return c, nil
 }
 
-func (m *MarketMaker) handleCEXUpdate(cexName string, ni interface{}) {
+func (m *MarketMaker) handleCEXUpdate(cexName string, ni any) {
 	switch n := ni.(type) {
 	case *libxc.BalanceUpdate:
 		m.cexMtx.RLock()
@@ -1777,8 +1777,8 @@ func marketFees(c clientCore, host string, baseID, quoteID uint32, useMaxFeeRate
 }
 
 func (m *MarketMaker) availableBalances(mkt *MarketWithHost, cexBaseID, cexQuoteID uint32, cexCfg *CEXConfig) (dexBalances, cexBalances map[uint32]uint64, _ error) {
-	dexAssets := make(map[uint32]interface{})
-	cexAssets := make(map[uint32]interface{})
+	dexAssets := make(map[uint32]any)
+	cexAssets := make(map[uint32]any)
 
 	dexAssets[mkt.BaseID] = struct{}{}
 	dexAssets[mkt.QuoteID] = struct{}{}

--- a/client/mm/notification.go
+++ b/client/mm/notification.go
@@ -58,15 +58,15 @@ func newRunEventNote(host string, baseID, quoteID uint32, startTime int64, event
 
 type cexNotification struct {
 	db.Notification
-	CEXName string      `json:"cexName"`
-	Note    interface{} `json:"note"`
+	CEXName string `json:"cexName"`
+	Note    any    `json:"note"`
 }
 
 const (
 	TopicBalanceUpdate = "BalanceUpdate"
 )
 
-func newCexUpdateNote(cexName string, topic db.Topic, note interface{}) *cexNotification {
+func newCexUpdateNote(cexName string, topic db.Topic, note any) *cexNotification {
 	return &cexNotification{
 		Notification: db.NewNotification(NoteTypeCEXNotification, topic, "", "", db.Data),
 		CEXName:      cexName,

--- a/dex/lexi/json.go
+++ b/dex/lexi/json.go
@@ -25,7 +25,7 @@ func JSON(thing any) BinaryMarshal {
 
 // UnJSON can be used in index entry generator functions for some syntactic
 // sugar.
-func UnJSON(thing any) interface{} {
+func UnJSON(thing any) any {
 	if lj, is := thing.(*lexiJSON); is {
 		return lj.thing
 	}

--- a/dex/lexi/lexi.go
+++ b/dex/lexi/lexi.go
@@ -291,7 +291,7 @@ func (db *DB) deleteDBID(txn *badger.Txn, dbID DBID) error {
 
 // KV is any one of a number of common types whose binary encoding is
 // straight-forward.
-type KV interface{}
+type KV any
 
 func parseKV(i KV) (b []byte, err error) {
 	switch it := i.(type) {

--- a/dex/lexi/log.go
+++ b/dex/lexi/log.go
@@ -15,28 +15,28 @@ type badgerLoggerWrapper struct {
 var _ badger.Logger = (*badgerLoggerWrapper)(nil)
 
 // Debugf -> dex.Logger.Tracef
-func (log *badgerLoggerWrapper) Debugf(s string, a ...interface{}) {
+func (log *badgerLoggerWrapper) Debugf(s string, a ...any) {
 	log.Tracef(s, a...)
 }
 
-func (log *badgerLoggerWrapper) Debug(a ...interface{}) {
+func (log *badgerLoggerWrapper) Debug(a ...any) {
 	log.Trace(a...)
 }
 
 // Infof -> dex.Logger.Debugf
-func (log *badgerLoggerWrapper) Infof(s string, a ...interface{}) {
+func (log *badgerLoggerWrapper) Infof(s string, a ...any) {
 	log.Debugf(s, a...)
 }
 
-func (log *badgerLoggerWrapper) Info(a ...interface{}) {
+func (log *badgerLoggerWrapper) Info(a ...any) {
 	log.Debug(a...)
 }
 
 // Warningf -> dex.Logger.Warnf
-func (log *badgerLoggerWrapper) Warningf(s string, a ...interface{}) {
+func (log *badgerLoggerWrapper) Warningf(s string, a ...any) {
 	log.Warnf(s, a...)
 }
 
-func (log *badgerLoggerWrapper) Warning(a ...interface{}) {
+func (log *badgerLoggerWrapper) Warning(a ...any) {
 	log.Warn(a...)
 }

--- a/dex/networks/erc20/erc20_abi.go
+++ b/dex/networks/erc20/erc20_abi.go
@@ -157,7 +157,7 @@ func bindIERC20(address common.Address, caller bind.ContractCaller, transactor b
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_IERC20 *IERC20Raw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_IERC20 *IERC20Raw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _IERC20.Contract.IERC20Caller.contract.Call(opts, result, method, params...)
 }
 
@@ -168,7 +168,7 @@ func (_IERC20 *IERC20Raw) Transfer(opts *bind.TransactOpts) (*types.Transaction,
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_IERC20 *IERC20Raw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+func (_IERC20 *IERC20Raw) Transact(opts *bind.TransactOpts, method string, params ...any) (*types.Transaction, error) {
 	return _IERC20.Contract.IERC20Transactor.contract.Transact(opts, method, params...)
 }
 
@@ -176,7 +176,7 @@ func (_IERC20 *IERC20Raw) Transact(opts *bind.TransactOpts, method string, param
 // sets the output to result. The result type might be a single field for simple
 // returns, a slice of interfaces for anonymous returns and a struct for named
 // returns.
-func (_IERC20 *IERC20CallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+func (_IERC20 *IERC20CallerRaw) Call(opts *bind.CallOpts, result *[]any, method string, params ...any) error {
 	return _IERC20.Contract.contract.Call(opts, result, method, params...)
 }
 
@@ -187,7 +187,7 @@ func (_IERC20 *IERC20TransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Tr
 }
 
 // Transact invokes the (paid) contract method with params as input values.
-func (_IERC20 *IERC20TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+func (_IERC20 *IERC20TransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...any) (*types.Transaction, error) {
 	return _IERC20.Contract.contract.Transact(opts, method, params...)
 }
 
@@ -195,7 +195,7 @@ func (_IERC20 *IERC20TransactorRaw) Transact(opts *bind.TransactOpts, method str
 //
 // Solidity: function allowance(address owner, address spender) view returns(uint256)
 func (_IERC20 *IERC20Caller) Allowance(opts *bind.CallOpts, owner common.Address, spender common.Address) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _IERC20.contract.Call(opts, &out, "allowance", owner, spender)
 
 	if err != nil {
@@ -226,7 +226,7 @@ func (_IERC20 *IERC20CallerSession) Allowance(owner common.Address, spender comm
 //
 // Solidity: function balanceOf(address account) view returns(uint256)
 func (_IERC20 *IERC20Caller) BalanceOf(opts *bind.CallOpts, account common.Address) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _IERC20.contract.Call(opts, &out, "balanceOf", account)
 
 	if err != nil {
@@ -257,7 +257,7 @@ func (_IERC20 *IERC20CallerSession) BalanceOf(account common.Address) (*big.Int,
 //
 // Solidity: function totalSupply() view returns(uint256)
 func (_IERC20 *IERC20Caller) TotalSupply(opts *bind.CallOpts) (*big.Int, error) {
-	var out []interface{}
+	var out []any
 	err := _IERC20.contract.Call(opts, &out, "totalSupply")
 
 	if err != nil {
@@ -427,11 +427,11 @@ type IERC20Approval struct {
 // Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
 func (_IERC20 *IERC20Filterer) FilterApproval(opts *bind.FilterOpts, owner []common.Address, spender []common.Address) (*IERC20ApprovalIterator, error) {
 
-	var ownerRule []interface{}
+	var ownerRule []any
 	for _, ownerItem := range owner {
 		ownerRule = append(ownerRule, ownerItem)
 	}
-	var spenderRule []interface{}
+	var spenderRule []any
 	for _, spenderItem := range spender {
 		spenderRule = append(spenderRule, spenderItem)
 	}
@@ -448,11 +448,11 @@ func (_IERC20 *IERC20Filterer) FilterApproval(opts *bind.FilterOpts, owner []com
 // Solidity: event Approval(address indexed owner, address indexed spender, uint256 value)
 func (_IERC20 *IERC20Filterer) WatchApproval(opts *bind.WatchOpts, sink chan<- *IERC20Approval, owner []common.Address, spender []common.Address) (event.Subscription, error) {
 
-	var ownerRule []interface{}
+	var ownerRule []any
 	for _, ownerItem := range owner {
 		ownerRule = append(ownerRule, ownerItem)
 	}
-	var spenderRule []interface{}
+	var spenderRule []any
 	for _, spenderItem := range spender {
 		spenderRule = append(spenderRule, spenderItem)
 	}
@@ -581,11 +581,11 @@ type IERC20Transfer struct {
 // Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
 func (_IERC20 *IERC20Filterer) FilterTransfer(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*IERC20TransferIterator, error) {
 
-	var fromRule []interface{}
+	var fromRule []any
 	for _, fromItem := range from {
 		fromRule = append(fromRule, fromItem)
 	}
-	var toRule []interface{}
+	var toRule []any
 	for _, toItem := range to {
 		toRule = append(toRule, toItem)
 	}
@@ -602,11 +602,11 @@ func (_IERC20 *IERC20Filterer) FilterTransfer(opts *bind.FilterOpts, from []comm
 // Solidity: event Transfer(address indexed from, address indexed to, uint256 value)
 func (_IERC20 *IERC20Filterer) WatchTransfer(opts *bind.WatchOpts, sink chan<- *IERC20Transfer, from []common.Address, to []common.Address) (event.Subscription, error) {
 
-	var fromRule []interface{}
+	var fromRule []any
 	for _, fromItem := range from {
 		fromRule = append(fromRule, fromItem)
 	}
-	var toRule []interface{}
+	var toRule []any
 	for _, toItem := range to {
 		toRule = append(toRule, toItem)
 	}

--- a/dex/testing/eth/bundler/main.go
+++ b/dex/testing/eth/bundler/main.go
@@ -52,9 +52,9 @@ type rpcRequest struct {
 
 // rpcResponse represents a JSON-RPC response.
 type rpcResponse struct {
-	JSONRPC string      `json:"jsonrpc"`
-	ID      int         `json:"id"`
-	Result  interface{} `json:"result"`
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Result  any    `json:"result"`
 }
 
 // storedUserOp stores user operation data with its transaction hash.

--- a/server/dex/dex.go
+++ b/server/dex/dex.go
@@ -308,7 +308,7 @@ func ValidateConfigFile(cfgPath string, net dex.Network, log dex.Logger) error {
 	}
 	parsedAssets := make(map[uint32]*parsedAsset, len(assets))
 
-	printSuccess := func(s string, a ...interface{}) {
+	printSuccess := func(s string, a ...any) {
 		fmt.Printf(s+"\n", a...)
 	}
 

--- a/tatanka/client/conn/conn.go
+++ b/tatanka/client/conn/conn.go
@@ -1011,7 +1011,7 @@ func (c *MeshConn) ConnectPeer(peerID tanka.PeerID) error {
 }
 
 // RequestPeer sends a request to an already-connected peer.
-func (c *MeshConn) RequestPeer(peerID tanka.PeerID, msg *msgjson.Message, thing interface{}) error {
+func (c *MeshConn) RequestPeer(peerID tanka.PeerID, msg *msgjson.Message, thing any) error {
 	c.peersMtx.RLock()
 	p, known := c.peers[peerID]
 	c.peersMtx.RUnlock()

--- a/tatanka/client/conn/conn_live_test.go
+++ b/tatanka/client/conn/conn_live_test.go
@@ -77,7 +77,7 @@ func genKeyPair() (*secp256k1.PrivateKey, tanka.PeerID) {
 	return priv, peerID
 }
 
-func mustEncode(thing interface{}) json.RawMessage {
+func mustEncode(thing any) json.RawMessage {
 	b, err := json.Marshal(thing)
 	if err != nil {
 		panic("mustEncode: " + err.Error())

--- a/tatanka/client/mesh/mesh.go
+++ b/tatanka/client/mesh/mesh.go
@@ -40,7 +40,7 @@ type Mesh struct {
 	log       dex.Logger
 	entryNode *TatankaCredentials
 	conn      *meshConn
-	payloads  chan interface{}
+	payloads  chan any
 
 	dataDir   string
 	db        *lexi.DB
@@ -72,7 +72,7 @@ func New(cfg *Config) (*Mesh, error) {
 		log:       cfg.Logger,
 		dataDir:   cfg.DataDir,
 		entryNode: cfg.EntryNode,
-		payloads:  make(chan interface{}, 128),
+		payloads:  make(chan any, 128),
 		markets:   make(map[string]*market),
 		fiatRates: make(map[string]*fiatrates.FiatRateInfo),
 	}
@@ -184,7 +184,7 @@ func (m *Mesh) handlePeerRequest(peerID tanka.PeerID, route string, payload json
 	}
 }
 
-func (m *Mesh) Broadcast(topic tanka.Topic, subject tanka.Subject, msgType mj.BroadcastMessageType, thing interface{}) error {
+func (m *Mesh) Broadcast(topic tanka.Topic, subject tanka.Subject, msgType mj.BroadcastMessageType, thing any) error {
 	payload, err := json.Marshal(thing)
 	if err != nil {
 		return fmt.Errorf("error marshaling broadcast payload: %v", err)
@@ -326,7 +326,7 @@ func (m *Mesh) ConnectPeer(peerID tanka.PeerID) error {
 	return m.conn.ConnectPeer(peerID)
 }
 
-func (m *Mesh) RequestPeer(peerID tanka.PeerID, msg *msgjson.Message, thing interface{}) error {
+func (m *Mesh) RequestPeer(peerID tanka.PeerID, msg *msgjson.Message, thing any) error {
 	return m.conn.RequestPeer(peerID, msg, thing)
 }
 

--- a/tatanka/client_messages.go
+++ b/tatanka/client_messages.go
@@ -19,8 +19,8 @@ import (
 
 // clientJob is a job for the remote clients loop.
 type clientJob struct {
-	task interface{}
-	res  chan interface{}
+	task any
+	res  chan any
 }
 
 // clientJobNewRemote is a clientJob task that adds a remote client to the
@@ -87,7 +87,7 @@ func (t *Tatanka) registerRemoteClient(tankaID, clientID tanka.PeerID) {
 			clientID: clientID,
 			tankaID:  tankaID,
 		},
-		res: make(chan interface{}, 1),
+		res: make(chan any, 1),
 	}
 	t.clientJobs <- job
 	select {
@@ -687,7 +687,7 @@ func (t *Tatanka) findPath(peerID tanka.PeerID) []*remoteTatanka {
 		task: &clientJobFindRemotes{
 			clientID: peerID,
 		},
-		res: make(chan interface{}),
+		res: make(chan any),
 	}
 	t.clientJobs <- job
 	ttIDs := (<-job.res).(map[tanka.PeerID]struct{})
@@ -819,7 +819,7 @@ func (t *Tatanka) handleSetScore(c *client, msg *msgjson.Message) {
 const ErrNoPath = dex.ErrorKind("no path")
 
 // requestAnyOne tries to request from the senders in order until one succeeds.
-func (t *Tatanka) requestAnyOne(senders []tanka.Sender, msg *msgjson.Message, resp interface{}) (sent bool, clientErr, err error) {
+func (t *Tatanka) requestAnyOne(senders []tanka.Sender, msg *msgjson.Message, resp any) (sent bool, clientErr, err error) {
 	mj.SignMessage(t.priv, msg)
 	rawMsg, err := json.Marshal(msg)
 	if err != nil {
@@ -828,7 +828,7 @@ func (t *Tatanka) requestAnyOne(senders []tanka.Sender, msg *msgjson.Message, re
 	return t.requestAnyOneRaw(senders, msg.ID, rawMsg, resp)
 }
 
-func (t *Tatanka) requestAnyOneRaw(senders []tanka.Sender, msgID uint64, rawMsg []byte, resp interface{}) (sent bool, clientErr, err error) {
+func (t *Tatanka) requestAnyOneRaw(senders []tanka.Sender, msgID uint64, rawMsg []byte, resp any) (sent bool, clientErr, err error) {
 	for _, sender := range senders {
 		var errChan = make(chan error)
 		if err := sender.RequestRaw(msgID, rawMsg, func(msg *msgjson.Message) {

--- a/tatanka/cmd/tatanka/main.go
+++ b/tatanka/cmd/tatanka/main.go
@@ -130,7 +130,7 @@ type Config struct {
 }
 
 func config() (*dex.LoggerMaker, *Config) {
-	emitConfigError := func(s string, a ...interface{}) {
+	emitConfigError := func(s string, a ...any) {
 		fmt.Fprintln(os.Stderr, fmt.Errorf(s, a...))
 		os.Exit(0)
 	}

--- a/tatanka/tatanka_messages.go
+++ b/tatanka/tatanka_messages.go
@@ -237,7 +237,7 @@ func (t *Tatanka) handleRemoteClientDisconnect(tt *remoteTatanka, msg *msgjson.M
 			clientID: dconn.ID,
 			tankaID:  tt.ID,
 		},
-		res: make(chan interface{}, 1),
+		res: make(chan any, 1),
 	}
 	t.clientJobs <- job
 	<-job.res

--- a/tatanka/tatanka_test.go
+++ b/tatanka/tatanka_test.go
@@ -97,8 +97,8 @@ func tNewTatanka() *Tatanka {
 		topics:          make(map[tanka.Topic]*Topic),
 		recentRelays:    make(map[[32]byte]time.Time),
 		clientJobs:      make(chan *clientJob, 128),
-		clientHandlers:  make(map[string]interface{}),
-		tatankaHandlers: make(map[string]interface{}),
+		clientHandlers:  make(map[string]any),
+		tatankaHandlers: make(map[string]any),
 		httpReqHandlers: make(map[string]comms.HTTPHandler),
 	}
 }


### PR DESCRIPTION
Inspired by https://github.com/decred/dcrdex/pull/3413 and replace all of the case.


This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.