### PR TITLE
mm: Close event log on context done.

### DIFF
--- a/client/mm/event_log_test.go
+++ b/client/mm/event_log_test.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"path/filepath"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,7 +37,8 @@ func TestEventLogDB(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db, err := newBoltEventLogDB(ctx, filepath.Join(dir, "event_log.db"), tLogger)
+	var wg sync.WaitGroup
+	db, err := newBoltEventLogDB(ctx, filepath.Join(dir, "event_log.db"), &wg, tLogger)
 	if err != nil {
 		t.Fatalf("error creating event log db: %v", err)
 	}
@@ -457,7 +459,8 @@ func TestUpdateFinalBalanceDueToEventDiff(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db, err := newBoltEventLogDB(ctx, filepath.Join(dir, "event_log.db"), tLogger)
+	var wg sync.WaitGroup
+	db, err := newBoltEventLogDB(ctx, filepath.Join(dir, "event_log.db"), &wg, tLogger)
 	if err != nil {
 		t.Fatalf("error creating event log db: %v", err)
 	}

--- a/client/mm/event_log_upgrades_test.go
+++ b/client/mm/event_log_upgrades_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,7 +43,8 @@ func TestEventLogV2Upgrade(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db2, err := newBoltEventLogDB(ctx, dbPath, dex.StdOutLogger("TEST", dex.LevelError))
+	var wg sync.WaitGroup
+	db2, err := newBoltEventLogDB(ctx, dbPath, &wg, dex.StdOutLogger("TEST", dex.LevelError))
 	if err != nil {
 		t.Fatalf("Failed to create DB for upgrade: %v", err)
 	}
@@ -56,8 +58,6 @@ func TestEventLogV2Upgrade(t *testing.T) {
 		t.Fatalf("Expected version 2 after upgrade, got %d", version)
 	}
 	verifyV2EventLogUpgrade(t, db2.DB)
-
-	db2.Close()
 }
 
 func setupV1EventLogData(tx *bbolt.Tx) error {

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -685,15 +685,14 @@ func (m *MarketMaker) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		}
 	}
 
-	eventLogDB, err := newBoltEventLogDB(ctx, m.eventLogDBPath, m.log.SubLogger("eventlogdb"))
+	var wg sync.WaitGroup
+	eventLogDB, err := newBoltEventLogDB(ctx, m.eventLogDBPath, &wg, m.log.SubLogger("eventlogdb"))
 	if err != nil {
 		return nil, fmt.Errorf("error creating event log DB: %v", err)
 	}
 	m.eventLogDB = eventLogDB
 
 	m.oracle = newPriceOracle(m.ctx, m.log.SubLogger("oracle"))
-
-	var wg sync.WaitGroup
 
 	wg.Add(1)
 	go func() {


### PR DESCRIPTION
closes #3384

When closing a channel that a select is listening on a nil will be sent. Close was only being using in tests so this change does not fix anything serious. This changes the behavior to wait for the channel to finish after ctx is done rather than closing at all.

https://go.dev/play/p/p4ONBM86_75