### PR TITLE
testing: Add random commitment to client db test.

### DIFF
--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -813,6 +813,7 @@ func TestIncludePartialFilter(t *testing.T) {
 					BaseAsset:  base,
 					QuoteAsset: quote,
 					ServerTime: time.Now(),
+					Commit:     ordertest.RandomCommitment(),
 				},
 			},
 		}


### PR DESCRIPTION
When testing if the timestamp is the same the order ids will end up being the same as well. For slower systems this is ok but on a faster one tests will fail. Add a random commitment to ensure different order ids.