### PR TITLE
webserver/site: handle `Enter` `KeyEvent` on login and pass reset form

### DIFF
--- a/client/webserver/site/src/js/login.ts
+++ b/client/webserver/site/src/js/login.ts
@@ -36,6 +36,10 @@ export default class LoginPage extends BasePage {
     Doc.bind(page.forms, 'keydown', (e: KeyboardEvent) => {
       if (e.key !== 'Enter') return
       e.preventDefault()
+    })
+    Doc.bind(page.forms, 'keyup', (e: KeyboardEvent) => {
+      if (e.key !== 'Enter') return
+      e.preventDefault()
       if (Doc.isDisplayed(page.resetAppPWForm)) { this.appPassResetForm.resetAppPW() }
       if (Doc.isDisplayed(page.loginForm)) { this.loginForm.submit() }
     })


### PR DESCRIPTION
Fixes a bug where the `Enter` key was not captured correctly on the login and password reset form. Causing the page to refresh when the enter key is clicked instead of submitting the form displayed.
