### PR TITLE
app: prevent auto form submission for forms with a single input

### DIFF
--- a/client/webserver/site/src/js/app.ts
+++ b/client/webserver/site/src/js/app.ts
@@ -388,8 +388,9 @@ export default class Application {
       return
     }
     this.attachCommon(this.main)
-    // Nix annoying auto-typing of form buttons.
+    // Nix form auto-submit behavior.
     for (const bttn of Doc.applySelector(this.main, 'form button')) bttn.setAttribute('type', 'button')
+    for (const form of Doc.applySelector(this.main, 'form')) Doc.bind(form, 'submit', (e) => e.preventDefault())
     if (this.loadedPage) this.loadedPage.unload()
     const constructor = constructors[handlerID]
     if (constructor) this.loadedPage = new constructor(this.main, data)


### PR DESCRIPTION
Closes #3451

In #3201, I had removed the `forms.bind`/`bindForm` function in favor of [a single line of code in app.ts](https://github.com/decred/dcrdex/blob/c6851d258c5cfa734fd5305a0a493d620d35a6b7/client/webserver/site/src/js/app.ts#L392) that I thought accomplished the same goal, which is to prevent form auto-submission which causes a page reload and precludes our own button bindings. This is because of an HTML quirk where a form with a single button will implicitly assign `type="submit"` to the button.

But I forgot about another HTML quirk where a form with a single text or password input will automatically submit the form if the `Enter` key is pressed while the cursor is in the input. 

This change disables auto-form submission completely,  which we will never want because Bison Wallet is a single-page app.