### PR TITLE
umbrel: Set to v1.0.5.

### DIFF
--- a/dcrdex-umbrel/README.md
+++ b/dcrdex-umbrel/README.md
@@ -21,7 +21,7 @@ docker buildx build -f client/Dockerfile \
   --output "type=registry"  .
 ```
 
-This is a multi-platform (targeting `amd64` and `arm64`) build which takes longer, this is normal.  
+This is a multi-platform (targeting `amd64` and `arm64`) build which takes longer, this is normal.
 If there are no error messages, at the end of the build the image will be published to Docker.
 
 1. Verify that the image has been published on <https://hub.docker.com/r/decred/dcrdex/tags>.  There should be 2 digest lines; these indicate that both target platforms have been built and are included in the published image.

--- a/dcrdex-umbrel/docker-compose.yml
+++ b/dcrdex-umbrel/docker-compose.yml
@@ -4,12 +4,12 @@ services:
   app_proxy:
     environment:
 # DCRDEX uses its own auth
-      PROXY_AUTH_ADD: "false"  
+      PROXY_AUTH_ADD: "false"
       APP_HOST: decred-dcrdex_web_1
       APP_PORT: 5758
-  
+
   web:
-    image: decred/dcrdex:v1.0.3@sha256:6c504ae6570ce7753d345cae3c592b411c903430405e1ab9379271124fc44088
+    image: decred/dcrdex:v1.0.5@sha256:5d010b92fbb452c9df6e0205d9bb0c8f8c446e011d69501c1e0a9b1fc4abd792
     restart: on-failure
     volumes:
       - ${APP_DATA_DIR}/data:/dex/.dexc

--- a/dcrdex-umbrel/umbrel-app.yml
+++ b/dcrdex-umbrel/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1
 id: dcrdex-umbrel
 category: Finance
 name: Bison Wallet
-version: "1.0.3"
+version: "1.0.5"
 tagline: Multi-asset cryptocurrency wallet with integrated DEX
 description: >-
   Trade Bitcoin, USDC, Ethereum, Decred, Dogecoin, Zcash and more peer-to-peer using atomic swaps.

--- a/umbrel-app-store.yml
+++ b/umbrel-app-store.yml
@@ -1,2 +1,2 @@
 id: "decred"
-name: "Decred" 
+name: "Decred"


### PR DESCRIPTION
~Update the docker file to get a certain version of dcrdex from github rather than using the local repo so that we can update the docker file itself without updating the tag.~