### PR TITLE
ui: hide "~USD" when no fiat rate is available

### DIFF
--- a/client/webserver/site/src/js/forms.ts
+++ b/client/webserver/site/src/js/forms.ts
@@ -990,7 +990,7 @@ export class FeeAssetSelectionForm {
           tmpl.fiatTradeLimitLow.textContent = Doc.formatFourSigFigs(startingLimit * baseFiatRate)
           tmpl.fiatTradeLimitHigh.textContent = Doc.formatFourSigFigs(privilegedLimit * baseFiatRate)
         }
-        Doc.setVis(baseFiatRate, page.fiatTradeLowBox, page.fiatTradeHighBox)
+        Doc.setVis(baseFiatRate, tmpl.fiatTradeLowBox, tmpl.fiatTradeHighBox)
       }
 
       setTier(strongTier(xc.auth) || 1)


### PR DESCRIPTION
close #3113 

I have checked the issue #3113 and the issues regarding the BTC fee rate being too high and the Balance check being incorrect have been resolved previously, so this PR:

- Fix misleading "~ USD" display in bond-view when no fiat rate is available
- The fiat box is now hidden when fiatRate is undefined/null