### PR TITLE
client/rpcserver: fix startmmbot and stopmmbot help messages

### DIFF
--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -1910,19 +1910,22 @@ supported for DCR wallets.`,
 		num (int): The number of notifications to load.`,
 	},
 	startBotRoute: {
-		cmdSummary: `Start market making.`,
-		argsShort:  `(cfgPath) (host) (baseID) (quoteID) (dexBals) (dexBals)`,
+		pwArgsShort: `"appPass"`,
+		cmdSummary:  `Start market making.`,
+		argsShort:   `cfgPath host baseID quoteID dexBals cexBals`,
+		pwArgsLong: `Password Args:
+    appPass (string): The Bison Wallet password.`,
 		argsLong: `Args:
-		cfgPath (string): The path to the market maker config file.
-		host (string): The DEX address.
-		baseID (int): The base asset's BIP-44 registered coin index.
-		quoteID (int): The quote asset's BIP-44 registered coin index.
-		dexBalances (array): The DEX balances i.e. [[60,1000000],[42,10000000]].
-		cexBalances (array): The CEX balances i.e. [[60,1000000],[42,10000000]].`,
+    cfgPath (string): The path to the market maker config file.
+    host (string): The DEX address.
+    baseID (int): The base asset's BIP-44 registered coin index.
+    quoteID (int): The quote asset's BIP-44 registered coin index.
+    dexBalances (array): The DEX balances i.e. [[60,1000000],[42,10000000]].
+    cexBalances (array): The CEX balances i.e. [[60,1000000],[42,10000000]].`,
 	},
 	stopBotRoute: {
 		cmdSummary: `Stop market making.`,
-		argsShort:  `(host) (baseID) (quoteID)`,
+		argsShort:  `host baseID quoteID`,
 		argsLong: `Args:
 		host (string): The DEX address.
 		baseID (int): The base asset's BIP-44 registered coin index.


### PR DESCRIPTION
The parameters were marked as optional when they were actually required.

Closes #3477