### PR TITLE
ui: add per-network lock/unlock/configure controls to wallet page

### DIFF
--- a/client/webserver/site/src/html/wallets.tmpl
+++ b/client/webserver/site/src/html/wallets.tmpl
@@ -102,9 +102,18 @@
                       <td data-tmpl="avail">—</td>
                       <td data-tmpl="locked">—</td>
                       <td data-tmpl="immature">—</td>
-                      <td>
+                      <td class="text-nowrap">
                         <button data-tmpl="txsBttn" class="micro">Txs</button>
                         <button data-tmpl="createWalletBttn" class="micro">Create Wallet</button>
+                        <button data-tmpl="unlockNetBttn" class="micro d-hide" title="Unlock">
+                          <span class="ico-unlocked"></span>
+                        </button>
+                        <button data-tmpl="lockNetBttn" class="micro d-hide" title="Lock">
+                          <span class="ico-locked"></span>
+                        </button>
+                        <button data-tmpl="configNetBttn" class="micro d-hide" title="Configure">
+                          <span class="ico-settings"></span>
+                        </button>
                       </td>
                     </tr>
                   </tbody>

--- a/client/webserver/site/src/js/assets.ts
+++ b/client/webserver/site/src/js/assets.ts
@@ -91,6 +91,11 @@ export class TickerAsset {
     this.isMultiNet = this.networkAssets.length > 1
   }
 
+  isRelatedAsset (assetID: number): boolean {
+    if (this.networkAssetLookup[assetID]) return true
+    return this.networkAssets.some(na => na.token?.parentID === assetID)
+  }
+
   walletInfo (): WalletInfo | undefined {
     for (const { assetID } of this.networkAssets) {
       const { info } = app().assets[assetID]

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -1096,6 +1096,28 @@ export default class WalletsPage extends BasePage {
 
       Doc.setVis(usable, tmpl.txsBttn)
       Doc.setVis(!usable, tmpl.createWalletBttn)
+
+      // Per-network wallet controls
+      const configAssetID = token ? token.parentID : assetID
+      Doc.bind(tmpl.configNetBttn, 'click', () => this.showReconfig(configAssetID))
+
+      const walletForLock = token ? app().walletMap[token.parentID] : w
+      if (walletForLock) {
+        const { encrypted, open: unlocked, running, disabled } = walletForLock
+        const walletAssetID = token ? token.parentID : assetID
+        Doc.bind(tmpl.unlockNetBttn, 'click', () => this.openWallet(walletAssetID))
+        Doc.bind(tmpl.lockNetBttn, 'click', () => this.lock(walletAssetID))
+
+        const hasActiveOrders = app().haveActiveOrders(walletAssetID)
+        const canUnlock = encrypted && !unlocked && running && !disabled
+        const canLock = encrypted && unlocked && running && !disabled && !hasActiveOrders
+
+        Doc.setVis(canUnlock, tmpl.unlockNetBttn)
+        Doc.setVis(canLock, tmpl.lockNetBttn)
+        Doc.setVis(running && !disabled, tmpl.configNetBttn)
+      } else if (usable) {
+        Doc.setVis(true, tmpl.configNetBttn)
+      }
     }
 
     // TODO: handle reserves deficit with a notification.
@@ -2481,6 +2503,7 @@ export default class WalletsPage extends BasePage {
     const res = await postJSON('/api/closewallet', { assetID: assetID })
     loaded()
     if (!app().checkResponse(res)) return
+    if (this.selectedTicker.isRelatedAsset(assetID)) this.updateDisplayedTicker()
     this.updateSyncAndPeers()
     this.updatePrivacy()
   }
@@ -2611,7 +2634,7 @@ export default class WalletsPage extends BasePage {
    */
   handleWalletStateNote (note: WalletStateNote): void {
     const { assetID } = note.wallet
-    if (this.selectedTicker.networkAssetLookup[assetID]) this.updateDisplayedTicker()
+    if (this.selectedTicker.isRelatedAsset(assetID)) this.updateDisplayedTicker()
     if (assetID === this.selectedWalletID) this.updateFeeState()
     if (note.topic === 'WalletPeersUpdate' &&
       assetID === this.selectedWalletID &&


### PR DESCRIPTION
Close #3476 

This PR:
- Add per-network Lock, Unlock, and Configure buttons to each row in the Balance Breakdown table on the Wallets page.

After changed:
<img width="841" height="351" alt="image" src="https://github.com/user-attachments/assets/88ebba4d-ed6e-481a-8ff3-e796dfd276a4" />

