### PR TITLE
refactor: replace context.WithCancel with t.Context

### DIFF
--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -4341,8 +4341,7 @@ func TestReconfigure(t *testing.T) {
 
 	wallet.wallet = &reconfigurer
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	cfg1 := &walletConfig{
 		UseSplitTx:       true,

--- a/client/asset/dcr/spv_test.go
+++ b/client/asset/dcr/spv_test.go
@@ -1000,8 +1000,7 @@ func TestRescan(t *testing.T) {
 
 	dcrw.makeBlocks(0, tipHeight)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ensureErr := func(errStr string, us []wallet.RescanProgress) {
 		t.Helper()

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1975,8 +1975,7 @@ func TestBalanceNoMempool(t *testing.T) {
 }
 
 func TestFeeRate(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	node := &testNode{}
 	eth := &baseWallet{
 		node:          node,
@@ -4470,8 +4469,7 @@ func TestOwnsAddress(t *testing.T) {
 }
 
 func TestSignMessage(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	node := newTestNode(BipID)
 	eth := &assetWallet{
@@ -4533,8 +4531,7 @@ func TestSwapConfirmation(t *testing.T) {
 
 	ver := uint32(0)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	checkResult := func(expErr bool, expConfs uint32, expSpent bool) {
 		t.Helper()
@@ -5801,8 +5798,7 @@ func testEstimateSendTxFee(t *testing.T, assetID uint32) {
 }
 
 func TestSwapOrRedemptionFeesPaid(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	_, bw, node, shutdown := tassetWallet(BipID)
 	defer shutdown()
 

--- a/client/comms/wsconn_test.go
+++ b/client/comms/wsconn_test.go
@@ -64,8 +64,7 @@ func TestWsConn(t *testing.T) {
 	pingCh := make(chan struct{})
 	readPumpCh := make(chan any)
 	writePumpCh := make(chan *msgjson.Message)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	type conn struct {
 		sync.WaitGroup

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -10736,8 +10736,7 @@ func (dtfc *TDynamicSwapper) DynamicRedemptionFeesPaid(ctx context.Context, coin
 var _ asset.DynamicSwapper = (*TDynamicSwapper)(nil)
 
 func TestUpdateFeesPaid(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	tests := []struct {
 		name                   string
 		paid                   uint64

--- a/client/db/bolt/db_test.go
+++ b/client/db/bolt/db_test.go
@@ -1327,8 +1327,7 @@ func TestDeleteInactiveMatches(t *testing.T) {
 	boltdb, shutdown := newTestDB(t)
 	defer shutdown()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Create an account to use.
 	acct1 := dbtest.RandomAccountInfo()
@@ -1505,8 +1504,7 @@ func TestDeleteInactiveOrders(t *testing.T) {
 	boltdb, shutdown := newTestDB(t)
 	defer shutdown()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Create an account to use.
 	acct1 := dbtest.RandomAccountInfo()

--- a/client/mm/event_log_test.go
+++ b/client/mm/event_log_test.go
@@ -4,7 +4,6 @@
 package mm
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -34,8 +33,7 @@ func tryWithTimeout(t *testing.T, f func() error) {
 func TestEventLogDB(t *testing.T) {
 	dir := t.TempDir()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var wg sync.WaitGroup
 	db, err := newBoltEventLogDB(ctx, filepath.Join(dir, "event_log.db"), &wg, tLogger)
@@ -456,8 +454,7 @@ func TestUpdateFinalBalanceDueToEventDiff(t *testing.T) {
 
 	dir := t.TempDir()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var wg sync.WaitGroup
 	db, err := newBoltEventLogDB(ctx, filepath.Join(dir, "event_log.db"), &wg, tLogger)

--- a/client/mm/event_log_upgrades_test.go
+++ b/client/mm/event_log_upgrades_test.go
@@ -2,7 +2,6 @@ package mm
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -40,8 +39,7 @@ func TestEventLogV2Upgrade(t *testing.T) {
 	db1.Close()
 
 	// Create new DB instance which should trigger upgrade
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var wg sync.WaitGroup
 	db2, err := newBoltEventLogDB(ctx, dbPath, &wg, dex.StdOutLogger("TEST", dex.LevelError))

--- a/client/mm/exchange_adaptor_test.go
+++ b/client/mm/exchange_adaptor_test.go
@@ -4973,8 +4973,7 @@ func TestDeposit(t *testing.T) {
 				}
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			botID := dexMarketID("host1", test.assetID, 0)
 			eventLogDB := newTEventLogDB()
@@ -5296,8 +5295,7 @@ func TestWithdraw(t *testing.T) {
 
 			tCEX.withdrawalID = withdrawalID
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			botID := dexMarketID("host1", test.assetID, 0)
 			eventLogDB := newTEventLogDB()

--- a/client/mm/mm_test.go
+++ b/client/mm/mm_test.go
@@ -753,8 +753,7 @@ func (t *tExchangeAdaptor) latestEpoch() *EpochReport       { return &EpochRepor
 func (t *tExchangeAdaptor) latestCEXProblems() *CEXProblems { return nil }
 
 func TestAvailableBalances(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tCore := newTCore()
 

--- a/dex/dexnet/http_test.go
+++ b/dex/dexnet/http_test.go
@@ -1,15 +1,13 @@
 package dexnet
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
 func TestErrorParsing(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"code": -150, "msg": "you messed up, bruh"}`, http.StatusBadRequest)

--- a/dex/feerates/oracle_test.go
+++ b/dex/feerates/oracle_test.go
@@ -1,7 +1,6 @@
 package feerates
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -25,8 +24,7 @@ func TestOracleRun(t *testing.T) {
 		t.Fatalf("failed to create oracle: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Start the oracle in a separate goroutine.
 	go o.Run(ctx, dex.StdOutLogger("T", dex.LevelTrace))

--- a/dex/wait/queue_test.go
+++ b/dex/wait/queue_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestTaperingQueueExpiration(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	q := NewTaperingTickerQueue(time.Millisecond, time.Millisecond*10)
 	go q.Run(ctx)

--- a/dex/ws/wslink_test.go
+++ b/dex/ws/wslink_test.go
@@ -4,7 +4,6 @@
 package ws
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -145,8 +144,7 @@ func TestWSLink_send(t *testing.T) {
 	}
 	ipk := dex.IPKey{16, 16, 120, 120 /* ipv6 1010:7878:: */}
 	wsLink := NewWSLink(ipk.String(), conn, time.Second, inMsgHandler, tLogger)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// start the in/out/pingHandlers, and the initial read deadline
 	wg, err := wsLink.Connect(ctx)

--- a/server/market/market_test.go
+++ b/server/market/market_test.go
@@ -1843,8 +1843,7 @@ func TestMarket_CancelWhileSuspended(t *testing.T) {
 	storage.archivedCancels = make([]*order.CancelOrder, 0, 1)
 	storage.canceledOrders = make([]*order.LimitOrder, 0, 1)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Insert a limit order into the book before the market has started
 	lo := makeLO(buyer3, mkRate3(1.0, 1.2), 1, order.StandingTiF)


### PR DESCRIPTION
The addition of the Context method to Go's testing.T provides significant improvements for writing concurrent tests. It allows better management of goroutines, ensuring they properly exit and preventing issues like deadlocks and unfinished processes.

By using Context, errors and cancellations can be handled more effectively, making tests more robust and easier to reason about. This change also enables tighter integration between tests and the application code, especially for systems that span multiple concurrent components. Overall, it simplifies test code and enhances test stability and maintainability.

More info: [golang/go#18368](https://github.com/golang/go/issues/18368)