### PR TITLE
dcr: add default Pi keys from network params to voting preferences

### DIFF
--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -19,7 +19,6 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
-	dexdcr "decred.org/dcrdex/dex/networks/dcr"
 	"decred.org/dcrwallet/v5/rpc/client/dcrwallet"
 	walletjson "decred.org/dcrwallet/v5/rpc/jsonrpc/types"
 	"decred.org/dcrwallet/v5/wallet"
@@ -1188,19 +1187,10 @@ func (w *rpcWallet) VotingPreferences(ctx context.Context) ([]*walletjson.VoteCh
 		treasuryPolicy = append(treasuryPolicy, &tp)
 	}
 
-	// Add default Pi keys from network params if not already present.
+	// Add default Pi keys from chain params if not already present.
 	// This allows users to see and set policies for treasury keys without
 	// having to manually discover and add them.
-	var net dex.Network
-	switch w.chainParams.Net {
-	case wire.MainNet:
-		net = dex.Mainnet
-	case wire.TestNet3:
-		net = dex.Testnet
-	default:
-		net = dex.Simnet
-	}
-	for _, piKey := range dexdcr.PiKeysForNet(net) {
+	for _, piKey := range w.chainParams.PiKeys {
 		keyHex := hex.EncodeToString(piKey)
 		if !existingKeys[keyHex] {
 			treasuryPolicy = append(treasuryPolicy, &walletjson.TreasuryPolicyResult{

--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -20,7 +20,6 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
-	dexdcr "decred.org/dcrdex/dex/networks/dcr"
 	"decred.org/dcrdex/dex/utils"
 	"decred.org/dcrwallet/v5/chain"
 	walleterrors "decred.org/dcrwallet/v5/errors"
@@ -1264,19 +1263,10 @@ func (w *spvWallet) VotingPreferences(ctx context.Context) ([]*walletjson.VoteCh
 		treasuryPolicy = append(treasuryPolicy, &r)
 	}
 
-	// Add default Pi keys from network params if not already present.
+	// Add default Pi keys from chain params if not already present.
 	// This allows users to see and set policies for treasury keys without
 	// having to manually discover and add them.
-	var net dex.Network
-	switch w.chainParams.Net {
-	case wire.MainNet:
-		net = dex.Mainnet
-	case wire.TestNet3:
-		net = dex.Testnet
-	default:
-		net = dex.Simnet
-	}
-	for _, piKey := range dexdcr.PiKeysForNet(net) {
+	for _, piKey := range w.chainParams.PiKeys {
 		keyHex := hex.EncodeToString(piKey)
 		if !existingKeys[keyHex] {
 			treasuryPolicy = append(treasuryPolicy, &walletjson.TreasuryPolicyResult{

--- a/dex/networks/dcr/params.go
+++ b/dex/networks/dcr/params.go
@@ -3,11 +3,7 @@
 
 package dcr
 
-import (
-	"encoding/hex"
-
-	"decred.org/dcrdex/dex"
-)
+import "decred.org/dcrdex/dex"
 
 var UnitInfo = dex.UnitInfo{
 	AtomicUnit: "atoms",
@@ -26,44 +22,4 @@ var UnitInfo = dex.UnitInfo{
 		},
 	},
 	FeeRateDenom: "B",
-}
-
-// mustDecodeHex decodes a hex string and panics on error. Used for compile-time
-// constants.
-func mustDecodeHex(s string) []byte {
-	b, err := hex.DecodeString(s)
-	if err != nil {
-		panic("invalid hex in Pi key constant: " + err.Error())
-	}
-	return b
-}
-
-// MainNetPiKeys are the Politeia public keys for mainnet treasury voting.
-// These keys are used to sign treasury spend transactions (tspends).
-// Source: https://github.com/decred/dcrd/blob/master/chaincfg/mainnetparams.go
-var MainNetPiKeys = [][]byte{
-	mustDecodeHex("03f6e7041f1cf51ee10e0a01cd2b0385ce3cd9debaabb2296f7e9dee9329da946c"),
-	mustDecodeHex("0319a37405cb4d1691971847d7719cfce70857c0f6e97d7c9174a3998cf0ab86dd"),
-}
-
-// TestNet3PiKeys are the Politeia public keys for testnet3 treasury voting.
-// Source: https://github.com/decred/dcrd/blob/master/chaincfg/testnetparams.go
-var TestNet3PiKeys = [][]byte{
-	mustDecodeHex("03f86d30788f205a548cc55a1d677e5d5f84f60af29cdc358e4e44fabc9b5aa965"),
-}
-
-// SimNetPiKeys is empty because simnet uses generated fake keys for testing.
-var SimNetPiKeys = [][]byte{}
-
-// PiKeysForNet returns the default Politeia public keys for the given network.
-// These are the treasury keys that users can set voting policies for.
-func PiKeysForNet(net dex.Network) [][]byte {
-	switch net {
-	case dex.Mainnet:
-		return MainNetPiKeys
-	case dex.Testnet:
-		return TestNet3PiKeys
-	default:
-		return SimNetPiKeys
-	}
 }


### PR DESCRIPTION
Close #3437

This PR:
- Add default Politeia (Pi) public keys from network params to Treasury Keys