### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -6141,7 +6141,7 @@ func TestAddressRecycling(t *testing.T) {
 	w.ar.WriteRecycledAddrsToFile()
 	b, _ := os.ReadFile(w.ar.recyclePath)
 	var fileAddrs []string
-	for _, addr := range strings.Split(string(b), "\n") {
+	for addr := range strings.SplitSeq(string(b), "\n") {
 		if addr == "" {
 			continue
 		}

--- a/dex/fiatrates/oracle.go
+++ b/dex/fiatrates/oracle.go
@@ -41,8 +41,7 @@ func NewFiatOracle(cfg Config, tickerSymbols string, log dex.Logger) (*Oracle, e
 		listeners: make(map[string]chan<- map[string]*FiatRateInfo),
 	}
 
-	tickers := strings.Split(tickerSymbols, ",")
-	for _, ticker := range tickers {
+	for ticker := range strings.SplitSeq(tickerSymbols, ",") {
 		_, ok := dex.BipSymbolID(strings.ToLower(ticker))
 		if !ok {
 			return nil, fmt.Errorf("unknown asset %s", ticker)

--- a/dex/lexi/cmd/lexidbexplorer/views.go
+++ b/dex/lexi/cmd/lexidbexplorer/views.go
@@ -55,7 +55,7 @@ func buildEntryDetailLines(entry entryData) []string {
 
 	// Key section
 	lines = append(lines, headerStyle.Render("Key:"))
-	for _, line := range strings.Split(formatKey(entry.key), "\n") {
+	for line := range strings.SplitSeq(formatKey(entry.key), "\n") {
 		lines = append(lines, keyStyle.Render(line))
 	}
 	lines = append(lines, "")
@@ -63,7 +63,7 @@ func buildEntryDetailLines(entry entryData) []string {
 	// Index key section (if present)
 	if len(entry.indexKey) > 0 {
 		lines = append(lines, headerStyle.Render("Index Key:"))
-		for _, line := range strings.Split(formatKey(entry.indexKey), "\n") {
+		for line := range strings.SplitSeq(formatKey(entry.indexKey), "\n") {
 			lines = append(lines, indexKeyStyle.Render(line))
 		}
 		lines = append(lines, "")
@@ -71,7 +71,7 @@ func buildEntryDetailLines(entry entryData) []string {
 
 	// Value section
 	lines = append(lines, headerStyle.Render("Value:"))
-	for _, line := range strings.Split(formatValue(entry.value), "\n") {
+	for line := range strings.SplitSeq(formatValue(entry.value), "\n") {
 		lines = append(lines, valueStyle.Render(line))
 	}
 

--- a/dex/networks/eth/abi.go
+++ b/dex/networks/eth/abi.go
@@ -115,7 +115,7 @@ func parseSelector(unescapedSelector string) ([]byte, error) {
 	// Reassemble the fake ABI and constuct the JSON
 	arguments := make([]fakeArg, 0)
 	if len(args) > 0 {
-		for _, arg := range strings.Split(args, ",") {
+		for arg := range strings.SplitSeq(args, ",") {
 			arguments = append(arguments, fakeArg{arg})
 		}
 	}


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23) returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901