### PR TITLE
eth: Treat "already known" tx responses as success.

### DIFF
--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -1518,7 +1518,7 @@ func (m *multiRPCClient) EstimateGas(ctx context.Context, call ethereum.CallMsg)
 }
 
 func (m *multiRPCClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	return m.sendSignedTransaction(ctx, tx)
+	return m.sendSignedTransaction(ctx, tx, allowAlreadyKnownFilter)
 }
 
 func (m *multiRPCClient) FilterLogs(ctx context.Context, query ethereum.FilterQuery) (logs []types.Log, err error) {


### PR DESCRIPTION
closes #3449

When sending transactions to multiple RPC providers, if a provider
returns "already known" it means the transaction is in the mempool.
Previously this was treated as an error, causing the code to try other
providers which might return "nonce too low" (if the tx was already
mined). This combined error triggered unnecessary nonce recovery,
creating new transactions with different nonces and causing failures.

Add allowAlreadyKnownFilter to transaction sending calls so "already
known" responses are treated as success.

When recovering missing nonces by sending zero-value self-transfers,
treat "already known" responses as success since it means the recovery
transaction is already in the mempool.