### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/client/asset/eth/txdb.go
+++ b/client/asset/eth/txdb.go
@@ -457,7 +457,7 @@ func (db *TxDB) getTxs(assetIDPtr *uint32, req *asset.TxHistoryRequest) (*asset.
 		}
 		refID = &h
 	}
-	var assetID interface{}
+	var assetID any
 	idx := db.allAssetIndex
 	if assetIDPtr != nil {
 		assetID = *assetIDPtr

--- a/client/mm/libxc/bgtypes/ws.go
+++ b/client/mm/libxc/bgtypes/ws.go
@@ -51,7 +51,7 @@ type WsDataMessage struct {
 }
 
 // WsData is a generic container for WebSocket data
-type WsData interface{}
+type WsData any
 
 // WsBookData represents orderbook data from WebSocket
 type WsBookData struct {

--- a/client/mm/libxc/bitget.go
+++ b/client/mm/libxc/bitget.go
@@ -649,7 +649,7 @@ type bitget struct {
 	secretKey  string
 	passphrase string // Bitget requires a passphrase for API access
 	net        dex.Network
-	broadcast  func(interface{})
+	broadcast  func(any)
 	ctx        context.Context
 
 	tradeIDNonce       atomic.Uint32
@@ -908,7 +908,7 @@ func (bg *bitget) sign(timestamp, method, requestPath, body string) string {
 }
 
 // request makes an HTTP request to the Bitget API
-func (bg *bitget) request(ctx context.Context, method, endpoint string, params map[string]string, body interface{}, needsAuth bool, result interface{}) error {
+func (bg *bitget) request(ctx context.Context, method, endpoint string, params map[string]string, body any, needsAuth bool, result any) error {
 	fullURL := bg.apiURL + endpoint
 
 	var bodyBytes []byte
@@ -969,12 +969,12 @@ func (bg *bitget) request(ctx context.Context, method, endpoint string, params m
 }
 
 // getAPI makes a GET request to the Bitget API
-func (bg *bitget) getAPI(ctx context.Context, endpoint string, params map[string]string, needsAuth bool, result interface{}) error {
+func (bg *bitget) getAPI(ctx context.Context, endpoint string, params map[string]string, needsAuth bool, result any) error {
 	return bg.request(ctx, http.MethodGet, endpoint, params, nil, needsAuth, result)
 }
 
 // postAPI makes a POST request to the Bitget API
-func (bg *bitget) postAPI(ctx context.Context, endpoint string, body interface{}, needsAuth bool, result interface{}) error {
+func (bg *bitget) postAPI(ctx context.Context, endpoint string, body any, needsAuth bool, result any) error {
 	return bg.request(ctx, http.MethodPost, endpoint, nil, body, needsAuth, result)
 }
 

--- a/client/mm/libxc/interface.go
+++ b/client/mm/libxc/interface.go
@@ -178,7 +178,7 @@ type CEXConfig struct {
 	SecretKey     string
 	APIPassphrase string // Required by some exchanges like Bitget
 	Logger        dex.Logger
-	Notify        func(interface{})
+	Notify        func(any)
 }
 
 // NewCEX creates a new CEX.

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -618,7 +618,7 @@ func (m *MarketMaker) loadCEX(ctx context.Context, cfg *CEXConfig) (*centralized
 		APIPassphrase: cfg.APIPassphrase,
 		Logger:        logger,
 		Net:           m.core.Network(),
-		Notify: func(n interface{}) {
+		Notify: func(n any) {
 			m.handleCEXUpdate(cfg.Name, n)
 		},
 	})


### PR DESCRIPTION
Inspired by https://github.com/decred/dcrdex/pull/3413 and replace all of the case.

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.