### PR TITLE
ui: Clean up dead code in MMSettings React rewrite.

### DIFF
--- a/client/webserver/jsintl.go
+++ b/client/webserver/jsintl.go
@@ -221,17 +221,8 @@ const (
 	mmProfitThresholdID            = "MM_PROFIT_THRESHOLD"
 	mmProfitThresholdDescID        = "MM_PROFIT_THRESHOLD_DESC"
 	mmPriceLevelsPerSideID         = "MM_PRICE_LEVELS_PER_SIDE"
-	mmLotsPerLevelID               = "MM_LOTS_PER_LEVEL"
-	mmUSDPerSideID                 = "MM_USD_PER_SIDE"
 	mmPriceIncrementID             = "MM_PRICE_INCREMENT"
 	mmMatchBufferID                = "MM_MATCH_BUFFER"
-	mmQuickPlacementsID            = "MM_QUICK_PLACEMENTS"
-	mmAdvancedPlacementsID         = "MM_ADVANCED_PLACEMENTS"
-	mmQuickConfigID                = "MM_QUICK_CONFIG"
-	mmAdvancedConfigID             = "MM_ADVANCED_CONFIG"
-	mmPlacementsDescriptionID      = "MM_PLACEMENTS_DESCRIPTION"
-	mmQuickAllocationID            = "MM_QUICK_ALLOCATION"
-	mmManualAllocationID           = "MM_MANUAL_ALLOCATION"
 	mmTradedAmountID               = "MM_TRADED_AMOUNT"
 	mmSwapFeesID                   = "MM_SWAP_FEES"
 	mmRedeemFeesID                 = "MM_REDEEM_FEES"
@@ -562,17 +553,8 @@ var enUS = map[string]*intl.Translation{
 	mmProfitThresholdID:            {T: "Profit Threshold"},
 	mmProfitThresholdDescID:        {T: "Minimum profit required for arbitrage opportunities."},
 	mmPriceLevelsPerSideID:         {T: "Price levels per side"},
-	mmLotsPerLevelID:               {T: "Lots per level"},
-	mmUSDPerSideID:                 {T: "USD per side"},
 	mmPriceIncrementID:             {T: "Price increment"},
 	mmMatchBufferID:                {T: "Match buffer"},
-	mmQuickPlacementsID:            {T: "Quick Placements"},
-	mmAdvancedPlacementsID:         {T: "Advanced Placements"},
-	mmQuickConfigID:                {T: "Quick config"},
-	mmAdvancedConfigID:             {T: "Advanced config"},
-	mmPlacementsDescriptionID:      {T: "Configure the price levels of the placements on both sides of the order book."},
-	mmQuickAllocationID:            {T: "Quick Allocation"},
-	mmManualAllocationID:           {T: "Manual Allocation"},
 	mmTradedAmountID:               {T: "Traded Amount"},
 	mmSwapFeesID:                   {T: "Swap Fees"},
 	mmRedeemFeesID:                 {T: "Redeem Fees"},

--- a/client/webserver/site/src/css/mm.scss
+++ b/client/webserver/site/src/css/mm.scss
@@ -2,33 +2,13 @@ div[data-handler=mmsettings],
 div[data-handler=mmarchives],
 div[data-handler=mmlogs],
 div[data-handler=mm] {
-  #gapStrategySelect {
-    width: 300px;
-  }
-
   .gap-factor-input,
   .lots-input {
     max-width: 75px;
   }
 
-  .mw-500 {
-    max-width: 500px;
-  }
-
-  [data-tmpl=value].wide {
-    width: 3rem;
-  }
-
-  .ico-arrowup.ml2px {
-    margin-left: 2px;
-  }
-
   .pt-pt5 {
     padding-top: 0.125rem;
-  }
-
-  #profitInput {
-    width: 70px;
   }
 
   .bot-type-selector {
@@ -121,34 +101,6 @@ div[data-handler=mm] {
     }
   }
 
-  #quickConfig input[type=number] {
-    width: 100px;
-  }
-
-  #levelSpacingBox.disabled {
-    opacity: 0.5;
-  }
-
-  #placementsChart,
-  [data-tmpl=placementsChart] {
-    height: 100px;
-
-    canvas {
-      @extend .fill-abs;
-    }
-  }
-
-  #buyPlacementsBox,
-  #sellPlacementsBox {
-    .ico-cross {
-      color: var(--text-danger);
-    }
-
-    .ico-plus {
-      color: var(--btn-go-bg);
-    }
-  }
-
   #noBots {
     .ico-robot {
       font-size: 80px;
@@ -161,61 +113,6 @@ div[data-handler=mm] {
   #depositDetailsForm,
   #withdrawalDetailsForm {
       min-width: 400px;
-  }
-
-  .allocation-grid {
-    display: grid;
-    grid-template-columns: 1fr auto auto;
-
-    .second {
-      grid-column: 2;
-    }
-
-    .third {
-      grid-column: 3;
-    }
-  }
-
-  section.datum {
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    justify-content: start;
-    text-align: center;
-    font-size: 15px;
-  }
-
-  .buffer-input,
-  .transfer-input {
-    width: 30%;
-  }
-
-  .bridge-label {
-    min-width: 120px;
-  }
-
-  .bridge-select {
-    max-width: 200px;
-  }
-
-  #limitOrderBufferSection {
-    display: none;
-  }
-
-  .configure-bot-content {
-    width: 100%;
-    background-color: var(--section-bg);
-    margin: 20px 0;
-    display: flex;
-    flex-direction: column;
-    // border: 1px solid #dee2e6;
-    border-radius: 0.375rem;
-    box-shadow: 0 0.125rem 0.25rem rgb(0 0 0 / 7.5%);
-  }
-
-  .configure-bot-market-box {
-    padding: 1rem;
-    border-bottom: 1px solid #dee2e6;
   }
 
   .configure-bot-market-display {

--- a/client/webserver/site/src/html/mmsettings.tmpl
+++ b/client/webserver/site/src/html/mmsettings.tmpl
@@ -2,5 +2,5 @@
 {{template "top" .}}
 <div id="main" data-handler="mmsettings" class="flex-grow-1 flex-stretch-column stylish-overflow">
 </div>
-{{template "bottom" .}}
+{{template "bottom"}}
 {{end}}

--- a/client/webserver/site/src/js/mmsettings/components/CEXConfigForm.tsx
+++ b/client/webserver/site/src/js/mmsettings/components/CEXConfigForm.tsx
@@ -43,7 +43,7 @@ const CEXConfigForm: React.FC<CEXConfigFormProps> = ({
         onClose()
       }
     } catch (error) {
-      setError(`Failed to update CEX configuration: ${error}`)
+      setError(`Failed to update CEX configuration: ${error instanceof Error ? error.message : String(error)}`)
     }
   }
 

--- a/client/webserver/site/src/js/mmsettings/components/ManualAllocation.tsx
+++ b/client/webserver/site/src/js/mmsettings/components/ManualAllocation.tsx
@@ -51,7 +51,7 @@ const ManualBalanceEntry: React.FC<ManualBalanceEntryProps> = ({
         <NumberInput
           min={-runningBotAvailable / asset.unitInfo.conventional.conversionFactor}
           max={availableBalance / asset.unitInfo.conventional.conversionFactor}
-          precision={Math.log10(asset.unitInfo.conventional.conversionFactor)}
+          precision={Math.round(Math.log10(asset.unitInfo.conventional.conversionFactor))}
           value={currentValue / asset.unitInfo.conventional.conversionFactor}
           onChange={(amount : number) => dispatch({
             type: 'UPDATE_MANUAL_ALLOCATION',
@@ -72,7 +72,7 @@ const ManualAllocationView: React.FC = () => {
 
   // Calculate column class based on number of items
   const getColumnClass = (itemCount: number) => {
-    return `col-${Math.floor(24 / itemCount)}`
+    return `col-${Math.floor(12 / itemCount)}`
   }
 
   return (

--- a/client/webserver/site/src/js/mmsettings/components/PlacementsChartWrapper.tsx
+++ b/client/webserver/site/src/js/mmsettings/components/PlacementsChartWrapper.tsx
@@ -6,7 +6,7 @@ import { OrderPlacement } from '../../registry'
 const PlacementsChartWrapper: React.FC = () => {
   const chartRef = React.useRef<HTMLDivElement>(null)
   const chartInstanceRef = React.useRef<PlacementsChart | null>(null)
-  const { botConfig, dexMarket, quickPlacements } = useBotConfigState()
+  const { botConfig, dexMarket, quickPlacements, fiatRatesMap } = useBotConfigState()
 
   React.useEffect(() => {
     if (chartRef.current && !chartInstanceRef.current) {
@@ -49,7 +49,7 @@ const PlacementsChartWrapper: React.FC = () => {
       const chartConfig: PlacementChartConfig = {
         cexName: botConfig.cexName,
         botType: isBasicMM ? 'basicMM' : isArbMM ? 'arbMM' : 'basicArb',
-        baseFiatRate: 1, // TODO: We'll use 1 for now, could be enhanced to use actual fiat rate
+        baseFiatRate: fiatRatesMap[dexMarket.baseID] || 1,
         dict: {
           profit,
           buyPlacements,
@@ -59,7 +59,7 @@ const PlacementsChartWrapper: React.FC = () => {
 
       chartInstanceRef.current.setMarket(chartConfig)
     }
-  }, [botConfig, dexMarket, quickPlacements])
+  }, [botConfig, dexMarket, quickPlacements, fiatRatesMap])
 
   return (
       <div

--- a/client/webserver/site/src/js/mmsettings/components/QuickPlacements.tsx
+++ b/client/webserver/site/src/js/mmsettings/components/QuickPlacements.tsx
@@ -57,6 +57,7 @@ const LotsOrUsdSelector: React.FC = () => {
     const convFactor = baseAsset.unitInfo.conventional.conversionFactor
     const convLotSize = lotSize / convFactor
     const usdPerLot = USD_RATE * convLotSize
+    if (usdPerLot === 0 || quickPlacements.priceLevelsPerSide === 0) return 1
     return Math.floor(usd / usdPerLot / quickPlacements.priceLevelsPerSide)
   }
 

--- a/client/webserver/site/src/js/mmsettings/components/RebalanceSettingsTab.tsx
+++ b/client/webserver/site/src/js/mmsettings/components/RebalanceSettingsTab.tsx
@@ -52,7 +52,7 @@ const MinTransferControl: React.FC<MinTransferControlProps> = ({
   // Get asset ID and calculate precision from conversion factor
   const assetID = asset === 'base' ? dexMarket.baseID : dexMarket.quoteID
   const conversionFactor = app().unitInfo(assetID).conventional.conversionFactor
-  const precision = Math.log10(conversionFactor)
+  const precision = Math.round(Math.log10(conversionFactor))
 
   // Calculate max as total allocated amount on DEX + CEX
   const cexAssetID = asset === 'base' ? botConfig.cexBaseID : botConfig.cexQuoteID

--- a/client/webserver/site/src/js/mmsettings/components/Tooltip.tsx
+++ b/client/webserver/site/src/js/mmsettings/components/Tooltip.tsx
@@ -14,7 +14,7 @@ const Tooltip: React.FC<TooltipProps> = ({ content, children }) => {
   const handleMouseEnter = () => {
     if (triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect()
-      const tooltipWidth = 200 // Approximate tooltip width
+      const tooltipWidth = 300 // Match maxWidth of tooltip element
       let left = rect.left + rect.width / 2 - tooltipWidth / 2
 
       // Ensure tooltip doesn't go off screen

--- a/client/webserver/site/src/js/mmutil.ts
+++ b/client/webserver/site/src/js/mmutil.ts
@@ -407,7 +407,6 @@ export function liveBotStatus (host: string, baseID: number, quoteID: number): M
 }
 
 export function feeAssetID (assetID: number) {
-  console.log('assetID', assetID)
   const asset = app().assets[assetID]
   if (asset.token) return asset.token.parentID
   return assetID


### PR DESCRIPTION
Remove debug console.log from mmutil.ts feeAssetID. Remove 9 unused locale keys from jsintl.go. Remove ~100 lines of dead CSS selectors from mm.scss. Fix Bootstrap grid calculation (24 -> 12 columns) in ManualAllocation. Use nullish coalescing for falsy default values in BotConfig. Add null guards for walletMap entries. Wrap fetchCEXAssetAndBridgeInfo in try/catch for botConfigStateFromSavedConfig. Fix Math.log10 precision with Math.round. Fix tooltip positioning width to match maxWidth. Use actual fiat rates in PlacementsChartWrapper. Add division-by-zero guard in QuickPlacements usdToLots. Fix inconsistent template call in mmsettings.tmpl. Improve error stringification in CEXConfigForm.