### PR TITLE
refactor: use maps.Copy to simplify the code

### DIFF
--- a/client/cmd/bwctl/payload.go
+++ b/client/cmd/bwctl/payload.go
@@ -6,6 +6,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"reflect"
 	"strconv"
 	"strings"
@@ -323,9 +324,7 @@ func parseConfigFromRemainingArgs(args []string) (reflect.Value, int, error) {
 			if err := json.Unmarshal([]byte(a), &jm); err != nil {
 				return reflect.Value{}, 0, fmt.Errorf("bad JSON config arg: %w", err)
 			}
-			for k, v := range jm {
-				cfg[k] = v
-			}
+			maps.Copy(cfg, jm)
 		} else if k, v, ok := strings.Cut(a, "="); ok {
 			cfg[k] = v
 		} else {

--- a/client/mm/libxc/bitget.go
+++ b/client/mm/libxc/bitget.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
+	"maps"
 	"math"
 	"math/big"
 	"net/http"
@@ -642,9 +643,7 @@ var bitgetToDexSymbol = make(map[string]string)
 
 func init() {
 	// Build the bitgetToDexSymbol map
-	for key, value := range bitgetToDexCoinSymbol {
-		bitgetToDexSymbol[key] = value
-	}
+	maps.Copy(bitgetToDexSymbol, bitgetToDexCoinSymbol)
 
 	for key, value := range dexToBitgetCoinSymbol {
 		if _, exists := bitgetToDexSymbol[value]; !exists {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.