### PR TITLE
client: Fix some politeia issues.

### DIFF
--- a/client/asset/dcr/rpcwallet.go
+++ b/client/asset/dcr/rpcwallet.go
@@ -6,6 +6,7 @@ package dcr
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -1252,11 +1253,6 @@ func (w *rpcWallet) AddressUsed(ctx context.Context, addrStr string) (bool, erro
 // CommittedTickets takes a list of tickets and returns a filtered list of
 // tickets that are controlled by this wallet.
 func (w *rpcWallet) CommittedTickets(ctx context.Context, tickets []*chainhash.Hash) ([]*chainhash.Hash, []stdaddr.Address, error) {
-	req := make(anylist, len(tickets))
-	for i, t := range tickets {
-		req[i] = t
-	}
-
 	var res struct {
 		TicketAddresses []struct {
 			Ticket  []byte `json:"ticket"`
@@ -1268,9 +1264,9 @@ func (w *rpcWallet) CommittedTickets(ctx context.Context, tickets []*chainhash.H
 		return nil, nil, fmt.Errorf("unable to fetch wallet tickets: %v", err)
 	}
 
-	nTicketAddresess := len(res.TicketAddresses)
-	respTickets := make([]*chainhash.Hash, nTicketAddresess)
-	addresses := make([]stdaddr.Address, nTicketAddresess)
+	nTicketAddresses := len(res.TicketAddresses)
+	respTickets := make([]*chainhash.Hash, nTicketAddresses)
+	addresses := make([]stdaddr.Address, nTicketAddresses)
 	for i, ad := range res.TicketAddresses {
 		respTickets[i], err = chainhash.NewHash(ad.Ticket)
 		if err != nil {
@@ -1331,7 +1327,7 @@ func (w *rpcWallet) SignMessage(ctx context.Context, message string, address str
 		return nil, err
 	}
 
-	return []byte(sig), nil
+	return base64.StdEncoding.DecodeString(sig)
 }
 
 // anylist is a list of RPC parameters to be converted to []json.RawMessage and

--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -1462,7 +1462,13 @@ func (w *spvWallet) AddressAccount(ctx context.Context, address string) (bool, u
 		return false, 0, err
 	}
 
-	known, _ := w.dcrWallet.KnownAddress(ctx, addr)
+	known, err := w.dcrWallet.KnownAddress(ctx, addr)
+	if err != nil {
+		if errors.Is(err, walleterrors.NotExist) {
+			return false, 0, nil
+		}
+		return false, 0, fmt.Errorf("KnownAddress error: %w", err)
+	}
 	if known != nil {
 		accountNumber, err := w.dcrWallet.AccountNumber(ctx, known.AccountName())
 		return true, accountNumber, err

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -1521,9 +1521,9 @@ type Core struct {
 	mesh    *mesh.Mesh
 	meshCM  *dex.ConnectionMaster
 
-	politeia       *pi.Politeia
-	politeiaURL    string
-	politiaSyncing atomic.Bool
+	politeia        *pi.Politeia
+	politeiaURL     string
+	politeiaSyncing atomic.Bool
 }
 
 // New is the constructor for a new Core.
@@ -1698,10 +1698,11 @@ func (c *Core) Run(ctx context.Context) {
 	c.politeiaURL = pi.PoliteiaMainnetHost
 	c.politeia, err = pi.New(ctx, c.politeiaURL, filepath.Join(filepath.Dir(c.cfg.DBPath), "politeia"), c.log.SubLogger("Politeia"))
 	if err != nil {
-		c.log.Errorf("failed to set up politeia: %v", err.Error())
-		return
+		c.log.Errorf("failed to set up politeia: %v", err)
 	}
-	defer c.politeia.Close()
+	if c.politeia != nil {
+		defer c.politeia.Close()
+	}
 
 	// The DB starts first and stops last.
 	ctxDB, stopDB := context.WithCancel(context.Background())
@@ -1777,31 +1778,35 @@ fetchers:
 	}()
 
 	// Start a goroutine to keep proposals synced.
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
+	if c.politeia != nil {
+		c.wg.Add(1)
+		go func() {
+			defer c.wg.Done()
 
-		// Initiate first sync.
-		c.politiaSyncing.Store(true)
-		err := c.politeia.ProposalsSync()
-		if err != nil {
-			c.log.Errorf("politeia.ProposalsSync failed: %v", err)
-		}
-		c.politiaSyncing.Store(false)
-
-		tick := time.NewTicker(time.Minute * 20)
-		defer tick.Stop()
-		for {
-			select {
-			case <-tick.C:
-				c.politiaSyncing.Store(true)
-				c.politeia.ProposalsSync()
-				c.politiaSyncing.Store(false)
-			case <-ctx.Done():
-				return
+			// Initiate first sync.
+			c.politeiaSyncing.Store(true)
+			err := c.politeia.ProposalsSync()
+			if err != nil {
+				c.log.Errorf("politeia.ProposalsSync failed: %v", err)
 			}
-		}
-	}()
+			c.politeiaSyncing.Store(false)
+
+			tick := time.NewTicker(time.Minute * 20)
+			defer tick.Stop()
+			for {
+				select {
+				case <-tick.C:
+					c.politeiaSyncing.Store(true)
+					if err := c.politeia.ProposalsSync(); err != nil {
+						c.log.Errorf("politeia.ProposalsSync failed: %v", err)
+					}
+					c.politeiaSyncing.Store(false)
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
 
 	c.wg.Wait() // block here until all goroutines except DB complete
 

--- a/client/core/politeia.go
+++ b/client/core/politeia.go
@@ -10,12 +10,18 @@ import (
 
 // PoliteiaDetails retrieves the current state for c.politeia, including the politeia URL.
 func (c *Core) PoliteiaDetails() (string, bool, int64) {
-	return c.politeiaURL, c.politiaSyncing.Load(), c.politeia.ProposalsLastSync()
+	if c.politeia == nil {
+		return c.politeiaURL, false, 0
+	}
+	return c.politeiaURL, c.politeiaSyncing.Load(), c.politeia.ProposalsLastSync()
 }
 
 // ProposalsAll fetches the proposals data from local db.
 // The argument searchPhrase and filterByVoteStatus are optional.
 func (c *Core) ProposalsAll(offset, rowsCount int, searchPhrase string, filterByVoteStatus ...int) ([]*pi.Proposal, int, error) {
+	if c.politeia == nil {
+		return nil, 0, fmt.Errorf("politeia not configured")
+	}
 	return c.politeia.ProposalsAll(offset, rowsCount, searchPhrase, filterByVoteStatus...)
 }
 
@@ -23,6 +29,9 @@ func (c *Core) ProposalsAll(offset, rowsCount int, searchPhrase string, filterBy
 // a configured TicketBuyer and the proposal is currently voting, the
 // wallet voting details will be returned as part of the proposal details.
 func (c *Core) Proposal(assetID uint32, token string) (*pi.Proposal, error) {
+	if c.politeia == nil {
+		return nil, fmt.Errorf("politeia not configured")
+	}
 	proposal, err := c.politeia.ProposalByToken(token)
 	if err != nil {
 		return nil, err
@@ -59,10 +68,13 @@ func (c *Core) Proposal(assetID uint32, token string) (*pi.Proposal, error) {
 // progress, meaning their vote status is unauthorized, authorized or started.
 // This is used to display the in progress proposals on the Bison Wallet UI.
 func (c *Core) ProposalsInProgress() ([]*pi.MiniProposal, error) {
+	if c.politeia == nil {
+		return nil, nil
+	}
 	return c.politeia.ProposalsInProgress()
 }
 
-// CastVotes casts votes for the provided eligible tickets using the provided
+// CastVote casts votes for the provided eligible tickets using the provided
 // wallet and passphrase for signing.
 // The proposal identified by token must exist in the Politeia DB.
 // The wallet must be unlocked prior to calling c.politeia.CastVotes.

--- a/client/core/politeia_test.go
+++ b/client/core/politeia_test.go
@@ -1,0 +1,67 @@
+//go:build !harness && !botlive
+
+package core
+
+import (
+	"testing"
+)
+
+// TestPoliteiaDetailsNilPoliteia verifies that PoliteiaDetails returns safe
+// defaults when c.politeia is nil (e.g., initialization failure).
+func TestPoliteiaDetailsNilPoliteia(t *testing.T) {
+	c := &Core{politeiaURL: "https://proposals.decred.org"}
+	url, syncing, lastSync := c.PoliteiaDetails()
+	if url != "https://proposals.decred.org" {
+		t.Errorf("URL: got %q, want %q", url, "https://proposals.decred.org")
+	}
+	if syncing {
+		t.Error("syncing should be false when politeia is nil")
+	}
+	if lastSync != 0 {
+		t.Error("lastSync should be 0 when politeia is nil")
+	}
+}
+
+// TestProposalsAllNilPoliteia verifies that ProposalsAll returns an error
+// when c.politeia is nil.
+func TestProposalsAllNilPoliteia(t *testing.T) {
+	c := &Core{}
+	_, _, err := c.ProposalsAll(0, 10, "")
+	if err == nil {
+		t.Fatal("expected error when politeia is nil")
+	}
+}
+
+// TestProposalNilPoliteia verifies that Proposal returns an error
+// when c.politeia is nil.
+func TestProposalNilPoliteia(t *testing.T) {
+	c := &Core{}
+	_, err := c.Proposal(42, "sometoken")
+	if err == nil {
+		t.Fatal("expected error when politeia is nil")
+	}
+}
+
+// TestProposalsInProgressNilPoliteia verifies that ProposalsInProgress returns
+// nil, nil (non-error) when c.politeia is nil, since this is used on the
+// wallet staking status page and should not block the UI.
+func TestProposalsInProgressNilPoliteia(t *testing.T) {
+	c := &Core{}
+	proposals, err := c.ProposalsInProgress()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if proposals != nil {
+		t.Fatal("expected nil proposals when politeia is nil")
+	}
+}
+
+// TestCastVoteNilPoliteia verifies that CastVote returns an error
+// when c.politeia is nil.
+func TestCastVoteNilPoliteia(t *testing.T) {
+	c := &Core{}
+	err := c.CastVote(42, []byte("pw"), "sometoken", "yes")
+	if err == nil {
+		t.Fatal("expected error when politeia is nil")
+	}
+}

--- a/client/webserver/api.go
+++ b/client/webserver/api.go
@@ -1790,8 +1790,7 @@ func (s *WebServer) apiStakeStatus(w http.ResponseWriter, r *http.Request) {
 
 	proposalsInProgress, err := s.core.ProposalsInProgress()
 	if err != nil {
-		s.writeAPIError(w, fmt.Errorf("error fetching proposals in progress for asset ID %d: %w", assetID, err))
-		return
+		log.Errorf("error fetching proposals in progress: %v", err)
 	}
 
 	writeJSON(w, &struct {

--- a/client/webserver/jsintl.go
+++ b/client/webserver/jsintl.go
@@ -344,7 +344,7 @@ const (
 	idInsuffRedeemFundsErrMsg     = "INSUFFICIENT_REDEEM_FUNDS_ERR_MSG"
 	idInsuffRedeemFundsBundErrMsg = "INSUFFICIENT_REDEEM_FUNDS_BUNDLER_ERR_MSG"
 	idVoteCastMsg                 = "VOTE_CAST_MESSAGE"
-	versionTxt                    = "VERSION"
+	idVersionTxt                  = "VERSION"
 )
 
 var enUS = map[string]*intl.Translation{
@@ -688,7 +688,7 @@ var enUS = map[string]*intl.Translation{
 	idInsuffRedeemFundsErrMsg:     {T: "Insufficient gas for redemption. Configure an ERC-4337 bundler to do a gasless redemption."},
 	idInsuffRedeemFundsBundErrMsg: {T: "Redemption lot size is too small to cover the gas fees in a gasless redemption."},
 	idVoteCastMsg:                 {T: "Your vote has been cast"},
-	versionTxt:                    {T: "Version"},
+	idVersionTxt:                  {T: "Version"},
 }
 
 var ptBR = map[string]*intl.Translation{

--- a/client/webserver/middleware.go
+++ b/client/webserver/middleware.go
@@ -217,11 +217,11 @@ func getOrderIDCtx(r *http.Request) (dex.Bytes, error) {
 	return oidB, nil
 }
 
-// proposalTokenCtx embeds the host into the request context.
+// proposalTokenCtx embeds the proposal token into the request context.
 func proposalTokenCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		host := chi.URLParam(r, "token")
-		ctx := context.WithValue(r.Context(), ctxProposalToken, host)
+		token := chi.URLParam(r, "token")
+		ctx := context.WithValue(r.Context(), ctxProposalToken, token)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/client/webserver/site/src/css/colors.scss
+++ b/client/webserver/site/src/css/colors.scss
@@ -10,7 +10,7 @@ body:not(.dark) {
   --text-color: #333;
   --text-color-secondary: #4a4949;
   --text-danger: #d22;
-  --text-sucess: green;
+  --text-success: green;
   --text-warning: #f82e;
   --text-grey: #777;
   --border-color: #ddd;

--- a/client/webserver/site/src/css/components.scss
+++ b/client/webserver/site/src/css/components.scss
@@ -302,8 +302,8 @@ input:invalid {
   border-right: 1px solid var(--border-color);
 }
 
-div[data-handler=proposal]
-div[data-handler=proposals]
+div[data-handler=proposal],
+div[data-handler=proposals],
 div[data-handler=dexsettings],
 div[data-handler=init],
 div[data-handler=login],
@@ -339,7 +339,8 @@ div[data-handler=wallets] {
   }
 }
 
-.card {
+div[data-handler=proposal] .card,
+div[data-handler=proposals] .card {
   background-color: var(--body-bg);
   padding: 3px;
 }

--- a/client/webserver/site/src/css/proposal.scss
+++ b/client/webserver/site/src/css/proposal.scss
@@ -3,8 +3,10 @@
   display: block;
 }
 
-.proposal-content h1, h2, h3 {
-  font-size: 1.3rem;
+.proposal-content {
+  h1, h2, h3 {
+    font-size: 1.3rem;
+  }
 }
 
 .vote-btn {
@@ -33,11 +35,11 @@
   text-align: center;
 }
 
-.vote-yes {
+.vote-btn.vote-yes {
   background: #6dff4f;
 }
 
-.vote-no {
+.vote-btn.vote-no {
   background: #d81e14;
 }
 

--- a/client/webserver/site/src/html/proposal.tmpl
+++ b/client/webserver/site/src/html/proposal.tmpl
@@ -3,7 +3,6 @@
 <div id="main" data-handler="proposal" class="py-5 overflow-y-auto">
     {{$politeiaURL := .PoliteiaURL}}
     {{$shortToken := .ShortToken}}
-    {{$statuses := .VoteStatuses }}
     {{$votingPower := 0}}
     {{$proposalToken := ""}}
     {{with .Proposal}}
@@ -125,7 +124,7 @@
                 </p>
                 <div>[[[voting_power]]]: {{$votingPower}}</div>
                 <div class="vote-actions">
-                    <button class="vote-btn vote-yes rounded3 active" type="button" data-value="yes">
+                    <button class="vote-btn vote-yes rounded3" type="button" data-value="yes">
                         <span class="icon">
                             <svg class="vote-icon" viewBox="0 0 24 24" width="20" height="20" fill="none"
                                 xmlns="http://www.w3.org/2000/svg">

--- a/client/webserver/site/src/html/proposals.tmpl
+++ b/client/webserver/site/src/html/proposals.tmpl
@@ -115,7 +115,7 @@
             {{if .Pagination.HasNext}}
             <div class="page-item m-1">
                 <a class="page-link"
-                    href="?page={{.Pagination.NextPage}}&status={{if $statusFilter }}&status={{$statusFilter}}{{else}}all{{end}}{{if $query }}&query={{$query}}{{end}}">›</a>
+                    href="?page={{.Pagination.NextPage}}&status={{if $statusFilter }}{{$statusFilter}}{{else}}all{{end}}{{if $query }}&query={{$query}}{{end}}">›</a>
             </div>
             {{end}}
         </div>

--- a/client/webserver/site/src/js/proposal.ts
+++ b/client/webserver/site/src/js/proposal.ts
@@ -25,10 +25,10 @@ export default class ProposalPage extends BasePage {
     Doc.applySelector(page.forms, '.form-closer').forEach(el => {
       Doc.bind(el, 'click', () => { this.closePopups() })
     })
-    Doc.bind(page.goBackToProposals, 'click', (e: Event) => {
+    Doc.bind(page.goBackToProposals, 'click', async (e: Event) => {
       e.preventDefault()
       const loaded = app().loading(body)
-      app().loadPage('proposals')
+      await app().loadPage('proposals')
       loaded()
     })
     Doc.applySelector(page.proposalInfo, '.vote-bar').forEach(bar => {
@@ -113,7 +113,7 @@ export default class ProposalPage extends BasePage {
 
   async loadProposal (token: string) {
     const assetID = 42 // dcr asset ID
-    const loaded = app().loading(this.page.proposals)
+    const loaded = app().loading(this.body)
     const data: Record<string, string> = {
       assetID: assetID.toString()
     }

--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -402,9 +402,9 @@ export default class WalletsPage extends BasePage {
     Doc.bind(page.expandPendingTxs, 'click', () => { this.toggleExpandPendingTxs() })
     Doc.bind(page.txHistoryBack, 'click', () => { this.showTxHistoryPage(this.txHistory.currentPage - 1) })
     Doc.bind(page.txHistoryFwd, 'click', () => { this.showTxHistoryPage(this.txHistory.currentPage + 1) })
-    Doc.bind(page.viewAllProposals, 'click', () => {
+    Doc.bind(page.viewAllProposals, 'click', async () => {
       const loaded = app().loading(body)
-      app().loadPage('proposals')
+      await app().loadPage('proposals')
       loaded()
     })
 
@@ -1259,7 +1259,7 @@ export default class WalletsPage extends BasePage {
     Doc.show(page.stakingSummary, page.ticketPriceBox)
     const proposalsMeta = res.proposalsMeta as ProposalsMeta
     this.proposalsMeta = proposalsMeta
-    page.proposalsInProgressCount.textContent = String(proposalsMeta.proposalsInProgress?.length)
+    page.proposalsInProgressCount.textContent = String(proposalsMeta?.proposalsInProgress?.length ?? 0)
     const stakeStatus = res.status as TicketStakingStatus
     this.stakeStatus = stakeStatus
     page.stakingAgendaCount.textContent = String(stakeStatus.stances.agendas.length)
@@ -1603,7 +1603,7 @@ export default class WalletsPage extends BasePage {
 
     Doc.empty(page.proposalsInProgress)
     Doc.hide(page.noInProgressProposal)
-    if (proposalsMeta?.proposalsInProgress.length === 0) Doc.show(page.noInProgressProposal)
+    if ((proposalsMeta?.proposalsInProgress?.length ?? 0) === 0) Doc.show(page.noInProgressProposal)
     for (const proposal of (proposalsMeta?.proposalsInProgress ?? [])) {
       const div = page.proposalTmpl.cloneNode(true) as PageElement
       page.proposalsInProgress.appendChild(div)
@@ -2814,7 +2814,7 @@ export default class WalletsPage extends BasePage {
 
   async loadProposal (token: string, displayedEl: PageElement) {
     const loaded = app().loading(displayedEl)
-    await app().loadPage(`proposal/${token}?assetID=42`)
+    await app().loadPage(`proposal/${token}`, { assetID: '42' })
     loaded()
   }
 }

--- a/client/webserver/template.go
+++ b/client/webserver/template.go
@@ -20,7 +20,6 @@ import (
 	"decred.org/dcrdex/dex/encode"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
-	"github.com/yuin/goldmark/renderer/html"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
@@ -251,13 +250,10 @@ var templateFuncs = template.FuncMap{
 				extension.GFM,
 				extension.Table,
 			),
-			goldmark.WithRendererOptions(
-				html.WithUnsafe(),
-			),
 		)
 		var buf bytes.Buffer
 		if err := md.Convert([]byte(mdTxt), &buf); err != nil {
-			return template.HTML(fmt.Sprintf(`<div class="text-danger">Failed to parse content: %v</div>`, err))
+			return template.HTML(`<div class="text-danger">Failed to parse content</div>`)
 		}
 		return template.HTML(buf.String())
 	},

--- a/dex/politeia/proposals_test.go
+++ b/dex/politeia/proposals_test.go
@@ -3,8 +3,17 @@
 package pi
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math"
 	"reflect"
 	"testing"
+
+	"github.com/decred/politeia/politeiad/plugins/usermd"
+	piv1 "github.com/decred/politeia/politeiawww/api/pi/v1"
+	rv1 "github.com/decred/politeia/politeiawww/api/records/v1"
+	tv1 "github.com/decred/politeia/politeiawww/api/ticketvote/v1"
 )
 
 func TestPaginateTokens(t *testing.T) {
@@ -134,5 +143,827 @@ func TestPaginateTokens(t *testing.T) {
 				t.Errorf("paginateTokens() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestProposalKey(t *testing.T) {
+	tests := []struct {
+		token string
+		want  string
+	}{
+		{"abc123", "proposal:abc123"},
+		{"", "proposal:"},
+		{"tokenwithspecialchars!@#", "proposal:tokenwithspecialchars!@#"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.token, func(t *testing.T) {
+			got := string(proposalKey(tt.token))
+			if got != tt.want {
+				t.Errorf("proposalKey(%q) = %q, want %q", tt.token, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProposalsStatusIndex(t *testing.T) {
+	p := &Proposal{
+		Token:      "abc123",
+		VoteStatus: tv1.VoteStatusStarted,
+		Timestamp:  1000,
+	}
+	got := string(proposalsStatusIndex(p))
+	reversed := uint64(math.MaxInt64) - 1000
+	want := fmt.Sprintf("proposal:status:%s:%020d:%s", "Started", reversed, "abc123")
+	if got != want {
+		t.Errorf("proposalsStatusIndex() = %q, want %q", got, want)
+	}
+}
+
+func TestProposalsStatusIndex_LargeTimestamp(t *testing.T) {
+	// This tests the uint64 cast fix: using int64 subtraction with a timestamp
+	// near MaxInt64 would overflow. Using uint64 prevents this.
+	p := &Proposal{
+		Token:      "token1",
+		VoteStatus: tv1.VoteStatusApproved,
+		Timestamp:  uint64(math.MaxInt64) - 1,
+	}
+	got := string(proposalsStatusIndex(p))
+	reversed := uint64(math.MaxInt64) - p.Timestamp
+	want := fmt.Sprintf("proposal:status:%s:%020d:%s", "Approved", reversed, "token1")
+	if got != want {
+		t.Errorf("proposalsStatusIndex() = %q, want %q", got, want)
+	}
+}
+
+func TestProposalsTimestampIndex(t *testing.T) {
+	p := &Proposal{
+		Token:     "xyz789",
+		Timestamp: 5000,
+	}
+	got := string(proposalsTimestampIndex(p))
+	reversed := uint64(math.MaxInt64) - 5000
+	want := fmt.Sprintf("proposal:ts:%020d:%s", reversed, "xyz789")
+	if got != want {
+		t.Errorf("proposalsTimestampIndex() = %q, want %q", got, want)
+	}
+}
+
+func TestProposalsTimestampIndex_LargeTimestamp(t *testing.T) {
+	p := &Proposal{
+		Token:     "token2",
+		Timestamp: uint64(math.MaxInt64) - 1,
+	}
+	got := string(proposalsTimestampIndex(p))
+	reversed := uint64(math.MaxInt64) - p.Timestamp
+	want := fmt.Sprintf("proposal:ts:%020d:%s", reversed, "token2")
+	if got != want {
+		t.Errorf("proposalsTimestampIndex() = %q, want %q", got, want)
+	}
+}
+
+func TestProposalMarshalUnmarshalBinary(t *testing.T) {
+	original := &Proposal{
+		ID:               1,
+		State:            rv1.RecordStateVetted,
+		Status:           rv1.RecordStatusPublic,
+		Token:            "abc123",
+		Version:          2,
+		Timestamp:        1234567890,
+		Username:         "testuser",
+		Description:      "Test proposal description",
+		Name:             "Test Proposal",
+		UserID:           "user123",
+		CommentsCount:    5,
+		VoteStatus:       tv1.VoteStatusStarted,
+		EligibleTickets:  40960,
+		StartBlockHeight: 100000,
+		EndBlockHeight:   110000,
+		QuorumPercentage: 20,
+		PassPercentage:   60,
+		TotalVotes:       1000,
+		VoteResults: []tv1.VoteResult{
+			{ID: "yes", Votes: 700},
+			{ID: "no", Votes: 300},
+		},
+		Synced:      true,
+		PublishedAt: 1234567800,
+		CensoredAt:  0,
+		AbandonedAt: 0,
+	}
+
+	data, err := original.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary error: %v", err)
+	}
+
+	decoded := new(Proposal)
+	err = decoded.UnmarshalBinary(data)
+	if err != nil {
+		t.Fatalf("UnmarshalBinary error: %v", err)
+	}
+
+	if !original.IsEqual(*decoded) {
+		t.Error("decoded proposal is not equal to original")
+	}
+	if decoded.Synced != original.Synced {
+		t.Errorf("Synced: got %v, want %v", decoded.Synced, original.Synced)
+	}
+}
+
+func TestIsEqual(t *testing.T) {
+	base := func() Proposal {
+		return Proposal{
+			Token:            "abc123",
+			Name:             "Test Proposal",
+			State:            rv1.RecordStateVetted,
+			Status:           rv1.RecordStatusPublic,
+			StatusChangeMsg:  "approved",
+			CommentsCount:    5,
+			Timestamp:        1000,
+			VoteStatus:       tv1.VoteStatusStarted,
+			TotalVotes:       100,
+			PublishedAt:      900,
+			CensoredAt:       0,
+			AbandonedAt:      0,
+			Description:      "A test proposal",
+			Version:          2,
+			Username:         "testuser",
+			EligibleTickets:  40960,
+			StartBlockHeight: 100000,
+			EndBlockHeight:   110000,
+			QuorumPercentage: 20,
+			PassPercentage:   60,
+			VoteResults: []tv1.VoteResult{
+				{ID: "yes", Votes: 70},
+				{ID: "no", Votes: 30},
+			},
+		}
+	}
+
+	t.Run("identical proposals", func(t *testing.T) {
+		a := base()
+		b := base()
+		if !a.IsEqual(b) {
+			t.Error("identical proposals should be equal")
+		}
+	})
+
+	// Test each field that should cause inequality.
+	fieldTests := []struct {
+		name   string
+		modify func(*Proposal)
+	}{
+		{"Token", func(p *Proposal) { p.Token = "different" }},
+		{"Name", func(p *Proposal) { p.Name = "Different Name" }},
+		{"State", func(p *Proposal) { p.State = rv1.RecordStateUnvetted }},
+		{"Status", func(p *Proposal) { p.Status = rv1.RecordStatusCensored }},
+		{"StatusChangeMsg", func(p *Proposal) { p.StatusChangeMsg = "censored" }},
+		{"CommentsCount", func(p *Proposal) { p.CommentsCount = 99 }},
+		{"Timestamp", func(p *Proposal) { p.Timestamp = 2000 }},
+		{"VoteStatus", func(p *Proposal) { p.VoteStatus = tv1.VoteStatusFinished }},
+		{"TotalVotes", func(p *Proposal) { p.TotalVotes = 999 }},
+		{"PublishedAt", func(p *Proposal) { p.PublishedAt = 800 }},
+		{"CensoredAt", func(p *Proposal) { p.CensoredAt = 1100 }},
+		{"AbandonedAt", func(p *Proposal) { p.AbandonedAt = 1200 }},
+		{"Description", func(p *Proposal) { p.Description = "Different description" }},
+		{"Version", func(p *Proposal) { p.Version = 3 }},
+		{"Username", func(p *Proposal) { p.Username = "otheruser" }},
+		{"EligibleTickets", func(p *Proposal) { p.EligibleTickets = 99999 }},
+		{"StartBlockHeight", func(p *Proposal) { p.StartBlockHeight = 200000 }},
+		{"EndBlockHeight", func(p *Proposal) { p.EndBlockHeight = 300000 }},
+		{"QuorumPercentage", func(p *Proposal) { p.QuorumPercentage = 30 }},
+		{"PassPercentage", func(p *Proposal) { p.PassPercentage = 70 }},
+		{"VoteResults length", func(p *Proposal) {
+			p.VoteResults = []tv1.VoteResult{{ID: "yes", Votes: 70}}
+		}},
+		{"VoteResults ID", func(p *Proposal) {
+			p.VoteResults[0].ID = "abstain"
+		}},
+		{"VoteResults Votes", func(p *Proposal) {
+			p.VoteResults[1].Votes = 999
+		}},
+	}
+
+	for _, tt := range fieldTests {
+		t.Run("different "+tt.name, func(t *testing.T) {
+			a := base()
+			b := base()
+			tt.modify(&b)
+			if a.IsEqual(b) {
+				t.Errorf("proposals with different %s should not be equal", tt.name)
+			}
+		})
+	}
+
+	t.Run("both nil VoteResults", func(t *testing.T) {
+		a := base()
+		b := base()
+		a.VoteResults = nil
+		b.VoteResults = nil
+		if !a.IsEqual(b) {
+			t.Error("proposals with nil VoteResults should be equal")
+		}
+	})
+
+	t.Run("one nil VoteResults", func(t *testing.T) {
+		a := base()
+		b := base()
+		b.VoteResults = nil
+		if a.IsEqual(b) {
+			t.Error("proposal with VoteResults should not equal one without")
+		}
+	})
+
+	t.Run("empty vs nil VoteResults", func(t *testing.T) {
+		a := base()
+		b := base()
+		a.VoteResults = nil
+		b.VoteResults = []tv1.VoteResult{}
+		// Both have length 0, so IsEqual treats them the same.
+		if !a.IsEqual(b) {
+			t.Error("nil and empty VoteResults should be equal (both length 0)")
+		}
+	})
+
+	t.Run("ignores ID field", func(t *testing.T) {
+		a := base()
+		b := base()
+		a.ID = 1
+		b.ID = 2
+		if !a.IsEqual(b) {
+			t.Error("ID field should not affect equality")
+		}
+	})
+
+	t.Run("ignores Synced field", func(t *testing.T) {
+		a := base()
+		b := base()
+		a.Synced = true
+		b.Synced = false
+		if !a.IsEqual(b) {
+			t.Error("Synced field should not affect equality")
+		}
+	})
+}
+
+func TestMetadata(t *testing.T) {
+	t.Run("started with votes", func(t *testing.T) {
+		p := &Proposal{
+			VoteStatus: tv1.VoteStatusStarted,
+			State:      rv1.RecordStateVetted,
+			Status:     rv1.RecordStatusPublic,
+			VoteResults: []tv1.VoteResult{
+				{ID: "yes", Votes: 7000},
+				{ID: "no", Votes: 3000},
+			},
+			EligibleTickets:  40960,
+			QuorumPercentage: 20,
+			PassPercentage:   60,
+		}
+		meta := p.Metadata()
+		if meta.Yes != 7000 {
+			t.Errorf("Yes: got %d, want 7000", meta.Yes)
+		}
+		if meta.No != 3000 {
+			t.Errorf("No: got %d, want 3000", meta.No)
+		}
+		if meta.VoteCount != 10000 {
+			t.Errorf("VoteCount: got %d, want 10000", meta.VoteCount)
+		}
+		// quorum = 20% of 40960 = 8192
+		if meta.QuorumCount != 8192 {
+			t.Errorf("QuorumCount: got %d, want 8192", meta.QuorumCount)
+		}
+		// 10000/40960 = 24.4%, which is >= 20%
+		if !meta.QuorumAchieved {
+			t.Error("QuorumAchieved: got false, want true")
+		}
+		if meta.PassPercent != 60 {
+			t.Errorf("PassPercent: got %f, want 60", meta.PassPercent)
+		}
+		// approval = 7000/10000 * 100 = 70%
+		if meta.Approval != 70 {
+			t.Errorf("Approval: got %f, want 70", meta.Approval)
+		}
+		// rejection = 3000/10000 * 100 = 30%
+		if meta.Rejection != 30 {
+			t.Errorf("Rejection: got %f, want 30", meta.Rejection)
+		}
+		if !meta.IsPassing {
+			t.Error("IsPassing: got false, want true (70% > 60%)")
+		}
+		if meta.VoteStatusDesc != "Started" {
+			t.Errorf("VoteStatusDesc: got %q, want %q", meta.VoteStatusDesc, "Started")
+		}
+	})
+
+	t.Run("zero eligible tickets (division by zero guard)", func(t *testing.T) {
+		p := &Proposal{
+			VoteStatus: tv1.VoteStatusStarted,
+			VoteResults: []tv1.VoteResult{
+				{ID: "yes", Votes: 0},
+				{ID: "no", Votes: 0},
+			},
+			EligibleTickets:  0,
+			QuorumPercentage: 20,
+			PassPercentage:   60,
+		}
+		meta := p.Metadata()
+		if meta.QuorumAchieved {
+			t.Error("QuorumAchieved should be false when EligibleTickets is 0")
+		}
+		if meta.QuorumCount != 0 {
+			t.Errorf("QuorumCount: got %d, want 0", meta.QuorumCount)
+		}
+	})
+
+	t.Run("not passing when approval below threshold", func(t *testing.T) {
+		p := &Proposal{
+			VoteStatus: tv1.VoteStatusStarted,
+			VoteResults: []tv1.VoteResult{
+				{ID: "yes", Votes: 4000},
+				{ID: "no", Votes: 6000},
+			},
+			EligibleTickets:  40960,
+			QuorumPercentage: 20,
+			PassPercentage:   60,
+		}
+		meta := p.Metadata()
+		if meta.IsPassing {
+			t.Error("IsPassing: got true, want false (40% < 60%)")
+		}
+		if meta.Approval != 40 {
+			t.Errorf("Approval: got %f, want 40", meta.Approval)
+		}
+	})
+
+	t.Run("quorum not achieved", func(t *testing.T) {
+		p := &Proposal{
+			VoteStatus: tv1.VoteStatusStarted,
+			VoteResults: []tv1.VoteResult{
+				{ID: "yes", Votes: 100},
+				{ID: "no", Votes: 50},
+			},
+			EligibleTickets:  40960,
+			QuorumPercentage: 20,
+			PassPercentage:   60,
+		}
+		meta := p.Metadata()
+		// 150/40960 = 0.37%, much less than 20%
+		if meta.QuorumAchieved {
+			t.Error("QuorumAchieved: got true, want false")
+		}
+		// Denominator = max(150, 8192) = 8192
+		// Approval = 100/8192 * 100 ≈ 1.22%
+		if meta.Approval > 2 {
+			t.Errorf("Approval should be low when below quorum, got %f", meta.Approval)
+		}
+	})
+
+	t.Run("approved status", func(t *testing.T) {
+		p := &Proposal{
+			VoteStatus: tv1.VoteStatusApproved,
+			VoteResults: []tv1.VoteResult{
+				{ID: "yes", Votes: 8000},
+				{ID: "no", Votes: 2000},
+			},
+			EligibleTickets:  40960,
+			QuorumPercentage: 20,
+			PassPercentage:   60,
+		}
+		meta := p.Metadata()
+		if meta.VoteStatusDesc != "Approved" {
+			t.Errorf("VoteStatusDesc: got %q, want %q", meta.VoteStatusDesc, "Approved")
+		}
+		if !meta.IsPassing {
+			t.Error("IsPassing should be true for approved proposal")
+		}
+	})
+
+	t.Run("rejected status", func(t *testing.T) {
+		p := &Proposal{
+			VoteStatus: tv1.VoteStatusRejected,
+			VoteResults: []tv1.VoteResult{
+				{ID: "yes", Votes: 2000},
+				{ID: "no", Votes: 8000},
+			},
+			EligibleTickets:  40960,
+			QuorumPercentage: 20,
+			PassPercentage:   60,
+		}
+		meta := p.Metadata()
+		if meta.VoteStatusDesc != "Rejected" {
+			t.Errorf("VoteStatusDesc: got %q, want %q", meta.VoteStatusDesc, "Rejected")
+		}
+		if meta.IsPassing {
+			t.Error("IsPassing should be false for rejected proposal")
+		}
+	})
+
+	t.Run("unauthorized status (no vote data)", func(t *testing.T) {
+		p := &Proposal{
+			VoteStatus: tv1.VoteStatusUnauthorized,
+			State:      rv1.RecordStateVetted,
+			Status:     rv1.RecordStatusPublic,
+		}
+		meta := p.Metadata()
+		if meta.Yes != 0 || meta.No != 0 || meta.VoteCount != 0 {
+			t.Error("unauthorized proposal should have zero vote counts")
+		}
+		if meta.QuorumAchieved {
+			t.Error("QuorumAchieved should be false for unauthorized proposal")
+		}
+		if meta.IsPassing {
+			t.Error("IsPassing should be false for unauthorized proposal")
+		}
+		if meta.VoteStatusDesc != "Unauthorized" {
+			t.Errorf("VoteStatusDesc: got %q, want %q", meta.VoteStatusDesc, "Unauthorized")
+		}
+	})
+
+	t.Run("zero votes on started proposal", func(t *testing.T) {
+		p := &Proposal{
+			VoteStatus:       tv1.VoteStatusStarted,
+			VoteResults:      []tv1.VoteResult{},
+			EligibleTickets:  40960,
+			QuorumPercentage: 20,
+			PassPercentage:   60,
+		}
+		meta := p.Metadata()
+		if meta.VoteCount != 0 {
+			t.Errorf("VoteCount: got %d, want 0", meta.VoteCount)
+		}
+		if meta.Approval != 0 {
+			t.Errorf("Approval should be 0 with no votes, got %f", meta.Approval)
+		}
+		if meta.IsPassing {
+			t.Error("IsPassing should be false with no votes")
+		}
+	})
+}
+
+func TestToMiniProposal(t *testing.T) {
+	p := &Proposal{
+		Token:      "abc123",
+		Name:       "Test Proposal",
+		Username:   "testuser",
+		Version:    2,
+		VoteStatus: tv1.VoteStatusStarted,
+	}
+	mini := p.ToMiniProposal()
+	if mini.Token != "abc123" {
+		t.Errorf("Token: got %q, want %q", mini.Token, "abc123")
+	}
+	if mini.Name != "Test Proposal" {
+		t.Errorf("Name: got %q, want %q", mini.Name, "Test Proposal")
+	}
+	if mini.Username != "testuser" {
+		t.Errorf("Username: got %q, want %q", mini.Username, "testuser")
+	}
+	if mini.Version != 2 {
+		t.Errorf("Version: got %d, want 2", mini.Version)
+	}
+	if mini.VoteStatus != "Started" {
+		t.Errorf("VoteStatus: got %q, want %q", mini.VoteStatus, "Started")
+	}
+}
+
+func TestUserMetadataDecode(t *testing.T) {
+	t.Run("valid user metadata", func(t *testing.T) {
+		um := usermd.UserMetadata{
+			UserID:    "user123",
+			PublicKey: "pubkey456",
+			Signature: "sig789",
+		}
+		payload, err := json.Marshal(um)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ms := []rv1.MetadataStream{
+			{
+				PluginID: usermd.PluginID,
+				StreamID: usermd.StreamIDUserMetadata,
+				Payload:  string(payload),
+			},
+		}
+		got, err := userMetadataDecode(ms)
+		if err != nil {
+			t.Fatalf("userMetadataDecode error: %v", err)
+		}
+		if got.UserID != "user123" {
+			t.Errorf("UserID: got %q, want %q", got.UserID, "user123")
+		}
+		if got.PublicKey != "pubkey456" {
+			t.Errorf("PublicKey: got %q, want %q", got.PublicKey, "pubkey456")
+		}
+	})
+
+	t.Run("no user metadata present", func(t *testing.T) {
+		ms := []rv1.MetadataStream{
+			{
+				PluginID: "otherplugin",
+				StreamID: 99,
+				Payload:  "{}",
+			},
+		}
+		_, err := userMetadataDecode(ms)
+		if err == nil {
+			t.Fatal("expected error when no user metadata present")
+		}
+	})
+
+	t.Run("empty metadata streams", func(t *testing.T) {
+		_, err := userMetadataDecode(nil)
+		if err == nil {
+			t.Fatal("expected error for nil metadata streams")
+		}
+	})
+
+	t.Run("invalid JSON payload", func(t *testing.T) {
+		ms := []rv1.MetadataStream{
+			{
+				PluginID: usermd.PluginID,
+				StreamID: usermd.StreamIDUserMetadata,
+				Payload:  "invalid json",
+			},
+		}
+		_, err := userMetadataDecode(ms)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("skips non-user metadata streams", func(t *testing.T) {
+		um := usermd.UserMetadata{UserID: "correctuser"}
+		payload, _ := json.Marshal(um)
+		ms := []rv1.MetadataStream{
+			{PluginID: "otherplugin", StreamID: 1, Payload: "{}"},
+			{PluginID: usermd.PluginID, StreamID: 99, Payload: "{}"},
+			{PluginID: usermd.PluginID, StreamID: usermd.StreamIDUserMetadata, Payload: string(payload)},
+		}
+		got, err := userMetadataDecode(ms)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.UserID != "correctuser" {
+			t.Errorf("UserID: got %q, want %q", got.UserID, "correctuser")
+		}
+	})
+}
+
+func TestProposalMetadataDecode(t *testing.T) {
+	makeFiles := func(name string, desc string) []rv1.File {
+		pm := piv1.ProposalMetadata{Name: name}
+		pmJSON, _ := json.Marshal(pm)
+		return []rv1.File{
+			{
+				Name:    piv1.FileNameIndexFile,
+				Payload: base64.StdEncoding.EncodeToString([]byte(desc)),
+			},
+			{
+				Name:    piv1.FileNameProposalMetadata,
+				Payload: base64.StdEncoding.EncodeToString(pmJSON),
+			},
+		}
+	}
+
+	t.Run("valid files", func(t *testing.T) {
+		files := makeFiles("Test Proposal", "# Description\nThis is a test.")
+		pm, desc, err := proposalMetadataDecode(files)
+		if err != nil {
+			t.Fatalf("proposalMetadataDecode error: %v", err)
+		}
+		if pm.Name != "Test Proposal" {
+			t.Errorf("Name: got %q, want %q", pm.Name, "Test Proposal")
+		}
+		if desc != "# Description\nThis is a test." {
+			t.Errorf("Description: got %q, want %q", desc, "# Description\nThis is a test.")
+		}
+	})
+
+	t.Run("missing index file", func(t *testing.T) {
+		pm := piv1.ProposalMetadata{Name: "Test"}
+		pmJSON, _ := json.Marshal(pm)
+		files := []rv1.File{
+			{
+				Name:    piv1.FileNameProposalMetadata,
+				Payload: base64.StdEncoding.EncodeToString(pmJSON),
+			},
+		}
+		_, _, err := proposalMetadataDecode(files)
+		if err == nil {
+			t.Fatal("expected error for missing index file")
+		}
+	})
+
+	t.Run("missing proposal metadata file", func(t *testing.T) {
+		files := []rv1.File{
+			{
+				Name:    piv1.FileNameIndexFile,
+				Payload: base64.StdEncoding.EncodeToString([]byte("description")),
+			},
+		}
+		_, _, err := proposalMetadataDecode(files)
+		if err == nil {
+			t.Fatal("expected error for missing proposal metadata file")
+		}
+	})
+
+	t.Run("invalid base64 in index file", func(t *testing.T) {
+		pm := piv1.ProposalMetadata{Name: "Test"}
+		pmJSON, _ := json.Marshal(pm)
+		files := []rv1.File{
+			{Name: piv1.FileNameIndexFile, Payload: "!!!invalid-base64!!!"},
+			{Name: piv1.FileNameProposalMetadata, Payload: base64.StdEncoding.EncodeToString(pmJSON)},
+		}
+		_, _, err := proposalMetadataDecode(files)
+		if err == nil {
+			t.Fatal("expected error for invalid base64")
+		}
+	})
+
+	t.Run("invalid base64 in metadata file", func(t *testing.T) {
+		files := []rv1.File{
+			{Name: piv1.FileNameIndexFile, Payload: base64.StdEncoding.EncodeToString([]byte("desc"))},
+			{Name: piv1.FileNameProposalMetadata, Payload: "!!!invalid-base64!!!"},
+		}
+		_, _, err := proposalMetadataDecode(files)
+		if err == nil {
+			t.Fatal("expected error for invalid base64")
+		}
+	})
+
+	t.Run("invalid JSON in metadata file", func(t *testing.T) {
+		files := []rv1.File{
+			{Name: piv1.FileNameIndexFile, Payload: base64.StdEncoding.EncodeToString([]byte("desc"))},
+			{Name: piv1.FileNameProposalMetadata, Payload: base64.StdEncoding.EncodeToString([]byte("not json"))},
+		}
+		_, _, err := proposalMetadataDecode(files)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON in metadata")
+		}
+	})
+
+	t.Run("empty files list", func(t *testing.T) {
+		_, _, err := proposalMetadataDecode(nil)
+		if err == nil {
+			t.Fatal("expected error for nil files")
+		}
+	})
+
+	t.Run("extra files are ignored", func(t *testing.T) {
+		files := makeFiles("Test", "desc")
+		files = append(files, rv1.File{Name: "extra.png", Payload: "data"})
+		pm, desc, err := proposalMetadataDecode(files)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if pm.Name != "Test" || desc != "desc" {
+			t.Error("extra files should not affect parsing")
+		}
+	})
+}
+
+func TestStatusChangeMetadataDecode(t *testing.T) {
+	makeStatusPayload := func(statuses ...usermd.StatusChangeMetadata) string {
+		var payload string
+		for _, s := range statuses {
+			b, _ := json.Marshal(s)
+			payload += string(b)
+		}
+		return payload
+	}
+
+	t.Run("published status", func(t *testing.T) {
+		md := []rv1.MetadataStream{
+			{
+				PluginID: usermd.PluginID,
+				StreamID: usermd.StreamIDStatusChanges,
+				Payload: makeStatusPayload(usermd.StatusChangeMetadata{
+					Status:    uint32(rv1.RecordStatusPublic),
+					Timestamp: 1000,
+					Reason:    "looks good",
+				}),
+			},
+		}
+		ts, msg, err := statusChangeMetadataDecode(md)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if ts.published != 1000 {
+			t.Errorf("published: got %d, want 1000", ts.published)
+		}
+		if ts.censored != 0 || ts.abandoned != 0 {
+			t.Error("censored and abandoned should be 0")
+		}
+		if msg != "looks good" {
+			t.Errorf("changeMsg: got %q, want %q", msg, "looks good")
+		}
+	})
+
+	t.Run("multiple status changes", func(t *testing.T) {
+		md := []rv1.MetadataStream{
+			{
+				PluginID: usermd.PluginID,
+				StreamID: usermd.StreamIDStatusChanges,
+				Payload: makeStatusPayload(
+					usermd.StatusChangeMetadata{
+						Status:    uint32(rv1.RecordStatusPublic),
+						Timestamp: 1000,
+						Reason:    "published",
+					},
+					usermd.StatusChangeMetadata{
+						Status:    uint32(rv1.RecordStatusArchived),
+						Timestamp: 2000,
+						Reason:    "abandoned after review",
+					},
+				),
+			},
+		}
+		ts, msg, err := statusChangeMetadataDecode(md)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if ts.published != 1000 {
+			t.Errorf("published: got %d, want 1000", ts.published)
+		}
+		if ts.abandoned != 2000 {
+			t.Errorf("abandoned: got %d, want 2000", ts.abandoned)
+		}
+		// Latest message should be from the most recent status change.
+		if msg != "abandoned after review" {
+			t.Errorf("changeMsg: got %q, want %q", msg, "abandoned after review")
+		}
+	})
+
+	t.Run("censored status", func(t *testing.T) {
+		md := []rv1.MetadataStream{
+			{
+				PluginID: usermd.PluginID,
+				StreamID: usermd.StreamIDStatusChanges,
+				Payload: makeStatusPayload(usermd.StatusChangeMetadata{
+					Status:    uint32(rv1.RecordStatusCensored),
+					Timestamp: 1500,
+					Reason:    "spam",
+				}),
+			},
+		}
+		ts, _, err := statusChangeMetadataDecode(md)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if ts.censored != 1500 {
+			t.Errorf("censored: got %d, want 1500", ts.censored)
+		}
+	})
+
+	t.Run("no status change metadata", func(t *testing.T) {
+		md := []rv1.MetadataStream{
+			{PluginID: "otherplugin", StreamID: 99, Payload: "{}"},
+		}
+		ts, msg, err := statusChangeMetadataDecode(md)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if ts.published != 0 || ts.censored != 0 || ts.abandoned != 0 {
+			t.Error("all timestamps should be 0 when no status change metadata")
+		}
+		if msg != "" {
+			t.Errorf("changeMsg should be empty, got %q", msg)
+		}
+	})
+
+	t.Run("empty metadata streams", func(t *testing.T) {
+		ts, msg, err := statusChangeMetadataDecode(nil)
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if ts.published != 0 || ts.censored != 0 || ts.abandoned != 0 {
+			t.Error("all timestamps should be 0 for nil metadata")
+		}
+		if msg != "" {
+			t.Errorf("changeMsg should be empty, got %q", msg)
+		}
+	})
+
+	t.Run("invalid JSON in payload", func(t *testing.T) {
+		md := []rv1.MetadataStream{
+			{
+				PluginID: usermd.PluginID,
+				StreamID: usermd.StreamIDStatusChanges,
+				Payload:  "invalid json content here",
+			},
+		}
+		_, _, err := statusChangeMetadataDecode(md)
+		if err == nil {
+			t.Fatal("expected error for invalid JSON payload")
+		}
+	})
+}
+
+func TestInProgressStatuses(t *testing.T) {
+	expected := []string{"Unauthorized", "Authorized", "Started"}
+	if !reflect.DeepEqual(inProgressStatuses, expected) {
+		t.Errorf("inProgressStatuses = %v, want %v", inProgressStatuses, expected)
 	}
 }

--- a/dex/politeia/util.go
+++ b/dex/politeia/util.go
@@ -2,6 +2,7 @@
 // See LICENSE for details.
 // This code is available on the terms of the project LICENSE.md file,
 // also available online at https://blueoakcouncil.org/license/1.0.0.
+
 package pi
 
 import (
@@ -15,7 +16,6 @@ import (
 	"github.com/decred/politeia/politeiad/plugins/usermd"
 	piv1 "github.com/decred/politeia/politeiawww/api/pi/v1"
 	rv1 "github.com/decred/politeia/politeiawww/api/records/v1"
-	tv1 "github.com/decred/politeia/politeiawww/api/ticketvote/v1"
 )
 
 // userMetadataDecode returns the parsed data for the usermd plugin metadata
@@ -139,31 +139,4 @@ func statusChangeMetadataDecode(md []rv1.MetadataStream) (*statusTimestamps, str
 	}
 
 	return &timestamps, changeMsg, nil
-}
-
-// voteBitVerify verifies that the vote bit corresponds to a valid vote option.
-// This verification matches the one used on politeia's code base to verify
-// vote bits.
-func voteBitVerify(options []tv1.VoteOption, mask, bit uint64) error {
-	if len(options) == 0 {
-		return fmt.Errorf("no vote options found")
-	}
-	if bit == 0 {
-		return fmt.Errorf("invalid bit %#x", bit)
-	}
-
-	// Verify bit is included in mask
-	if mask&bit != bit {
-		return fmt.Errorf("invalid mask 0x%x bit %#x", mask, bit)
-	}
-
-	// Verify bit is included in vote options
-	for _, v := range options {
-		if v.Bit == bit {
-			// Bit matches one of the options. We're done.
-			return nil
-		}
-	}
-
-	return fmt.Errorf("bit %#x not found in vote options", bit)
 }


### PR DESCRIPTION
- Fix XSS risk: remove html.WithUnsafe() from goldmark renderer
- Fix SignMessage to decode base64 signature from RPC wallet
- Fix iterateTable swallowing errors (return nil -> return err)
- Make politeia init non-fatal so wallet still runs without it
- Add nil guards for c.politeia in all core politeia methods
- Move table/index setup after version check to avoid DropAll issues
- Add nil Vote check before dereferencing in CastVotes
- Fix division by zero when EligibleTickets is 0
- Fix lastSync stored on error (move from defer to after success)
- Fix swallowed error in spv AddressAccount
- Fix copy-paste error in proposalTokenCtx (host -> token)
- Make ProposalsInProgress failure non-fatal in apiStakeStatus
- Add bounds check before proposals[0] access
- Fix IsEqual to compare all meaningful fields
- Fix CSS selector bugs: missing commas, incorrect nesting
- Fix typos: politiaSyncing, nTicketAddresess, --text-sucess
- Fix async/await on loadPage calls in TypeScript
- Fix null safety for proposalsInProgress in wallets.ts
- Fix duplicate &status= in proposals pagination link
- Fix loadProposal query string format in wallets.ts
- Remove dead voteBitVerify function and unused imports
- Remove pre-selected active class on Yes vote button
- Rename versionTxt -> idVersionTxt for naming consistency
- Scope .card CSS override to proposal pages only
- Remove stale storm tags and dcrdata references