### PR TITLE
client: Add broadcast recovery.

### DIFF
--- a/client/asset/broadcast/broadcast.go
+++ b/client/asset/broadcast/broadcast.go
@@ -1,0 +1,160 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package broadcast
+
+import (
+	"encoding/hex"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/dex"
+)
+
+// CacheExpiry is the duration after which a broadcast cache entry is
+// considered stale and will be removed.
+const CacheExpiry = 10 * time.Minute
+
+// CoinIDsCacheKey builds a cache key from sorted coin IDs.
+func CoinIDsCacheKey(coins []asset.Coin) string {
+	ids := make([]string, len(coins))
+	for i, c := range coins {
+		if c != nil {
+			ids[i] = hex.EncodeToString(c.ID())
+		} else {
+			ids[i] = "<nil>"
+		}
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
+}
+
+// RedeemCacheKey builds a cache key from sorted redemption input coin IDs.
+func RedeemCacheKey(redemptions []*asset.Redemption) string {
+	ids := make([]string, len(redemptions))
+	for i, r := range redemptions {
+		if r.Spends != nil && r.Spends.Coin != nil {
+			ids[i] = hex.EncodeToString(r.Spends.Coin.ID())
+		} else {
+			ids[i] = "<nil>"
+		}
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ",")
+}
+
+// RefundCacheKey builds a cache key from a coin ID.
+func RefundCacheKey(coinID []byte) string {
+	return hex.EncodeToString(coinID)
+}
+
+// IsAlreadyBroadcastErr checks if the error indicates the transaction is
+// already in the mempool or blockchain.
+func IsAlreadyBroadcastErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	for _, m := range []string{
+		"txn-already-in-mempool",     // Bitcoin Core, btcd (mempool)
+		"txn-already-known",          // Bitcoin Core (confirmed tx resubmission)
+		"already in block chain",     // btcd
+		"transaction already exists", // dcrd
+		"already have transaction",   // zcashd
+		"tx already exists",          // Bitcoin Core
+		"already in the mempool",     // Electrum
+	} {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// CacheEntry is the interface that broadcast cache entry types must implement.
+type CacheEntry interface {
+	Stamp() time.Time
+}
+
+// Cache is a thread-safe cache for broadcast entries with automatic expiry.
+type Cache[T CacheEntry] struct {
+	mtx   sync.Mutex
+	cache map[string]T
+}
+
+// NewCache creates a new broadcast cache.
+func NewCache[T CacheEntry]() *Cache[T] {
+	return &Cache[T]{
+		cache: make(map[string]T),
+	}
+}
+
+// Get returns the entry for the given key. If the entry is expired, it is
+// deleted and the zero value is returned with false.
+func (c *Cache[T]) Get(key string) (T, bool) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	entry, ok := c.cache[key]
+	if ok && time.Since(entry.Stamp()) > CacheExpiry {
+		delete(c.cache, key)
+		var zero T
+		return zero, false
+	}
+	return entry, ok
+}
+
+// Put stores an entry in the cache and removes any expired entries.
+func (c *Cache[T]) Put(key string, entry T) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	c.cache[key] = entry
+	for k, e := range c.cache {
+		if k != key && time.Since(e.Stamp()) > CacheExpiry {
+			delete(c.cache, k)
+		}
+	}
+}
+
+// Delete removes an entry from the cache.
+func (c *Cache[T]) Delete(key string) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	delete(c.cache, key)
+}
+
+// RecoverFromCache attempts to recover a previously built transaction from the
+// cache. It first tries to rebroadcast the cached transaction. If that fails,
+// it checks whether the transaction is already confirmed in the wallet. If
+// either succeeds, the cached entry is returned and left in the cache to
+// expire naturally. On any failure the cache entry is cleared and the caller
+// should rebuild the transaction.
+func RecoverFromCache[T CacheEntry](
+	cache *Cache[T],
+	key string,
+	rebroadcast func(T) error,
+	isConfirmed func(T) bool,
+	log dex.Logger,
+	opName string,
+) (T, bool) {
+	cached, ok := cache.Get(key)
+	if !ok {
+		var zero T
+		return zero, false
+	}
+	err := rebroadcast(cached)
+	if err == nil {
+		log.Infof("%s broadcast recovered from cache", opName)
+		return cached, true
+	}
+	if isConfirmed(cached) {
+		log.Infof("%s transaction found in wallet, recovering", opName)
+		return cached, true
+	}
+	cache.Delete(key)
+	log.Warnf("Cached %s tx rebroadcast failed (%v), rebuilding", opName, err)
+	var zero T
+	return zero, false
+}

--- a/client/asset/broadcast/broadcast_test.go
+++ b/client/asset/broadcast/broadcast_test.go
@@ -1,0 +1,235 @@
+package broadcast
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/dex"
+)
+
+func TestIsAlreadyBroadcastErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"mempool", errors.New("txn-already-in-mempool"), true},
+		{"known", errors.New("txn-already-known"), true},
+		{"blockchain", errors.New("already in block chain"), true},
+		{"exists", errors.New("transaction already exists"), true},
+		{"have", errors.New("already have transaction"), true},
+		{"tx exists", errors.New("tx already exists"), true},
+		{"in mempool", errors.New("Already in the mempool"), true},
+		{"unrelated", errors.New("insufficient funds"), false},
+		{"wrapped", errors.New("rpc error: txn-already-in-mempool"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAlreadyBroadcastErr(tt.err); got != tt.want {
+				t.Errorf("IsAlreadyBroadcastErr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type testCoin struct {
+	id []byte
+}
+
+func (c *testCoin) ID() dex.Bytes  { return c.id }
+func (c *testCoin) String() string { return dex.Bytes(c.id).String() }
+func (c *testCoin) TxID() string   { return "" }
+func (c *testCoin) Value() uint64  { return 0 }
+
+func TestCoinIDsCacheKey(t *testing.T) {
+	coins := []asset.Coin{
+		&testCoin{id: []byte{0xbb}},
+		&testCoin{id: []byte{0xaa}},
+	}
+	key := CoinIDsCacheKey(coins)
+	// Should be sorted.
+	if key != "aa,bb" {
+		t.Fatalf("unexpected key: %s", key)
+	}
+}
+
+func TestRedeemCacheKey(t *testing.T) {
+	redemptions := []*asset.Redemption{
+		{Spends: &asset.AuditInfo{Coin: &testCoin{id: []byte{0xdd}}}},
+		{Spends: &asset.AuditInfo{Coin: &testCoin{id: []byte{0xcc}}}},
+	}
+	key := RedeemCacheKey(redemptions)
+	if key != "cc,dd" {
+		t.Fatalf("unexpected key: %s", key)
+	}
+}
+
+func TestRedeemCacheKeyNilSpends(t *testing.T) {
+	redemptions := []*asset.Redemption{
+		{Spends: nil},
+		{Spends: &asset.AuditInfo{Coin: &testCoin{id: []byte{0xaa}}}},
+	}
+	key := RedeemCacheKey(redemptions)
+	if key != "<nil>,aa" {
+		t.Fatalf("unexpected key: %s", key)
+	}
+}
+
+func TestRefundCacheKey(t *testing.T) {
+	key := RefundCacheKey([]byte{0xde, 0xad})
+	if key != "dead" {
+		t.Fatalf("unexpected key: %s", key)
+	}
+}
+
+type testEntry struct {
+	stamp time.Time
+	val   int
+}
+
+func (e *testEntry) Stamp() time.Time { return e.stamp }
+
+func TestCacheGetPutDelete(t *testing.T) {
+	c := NewCache[*testEntry]()
+
+	// Get from empty cache.
+	_, ok := c.Get("key")
+	if ok {
+		t.Fatal("expected no entry")
+	}
+
+	// Put and Get.
+	entry := &testEntry{stamp: time.Now(), val: 42}
+	c.Put("key", entry)
+	got, ok := c.Get("key")
+	if !ok {
+		t.Fatal("expected entry")
+	}
+	if got.val != 42 {
+		t.Fatalf("expected val 42, got %d", got.val)
+	}
+
+	// Delete and verify gone.
+	c.Delete("key")
+	_, ok = c.Get("key")
+	if ok {
+		t.Fatal("expected no entry after delete")
+	}
+}
+
+func TestCacheExpiry(t *testing.T) {
+	c := NewCache[*testEntry]()
+
+	// Insert an entry that is already expired.
+	entry := &testEntry{stamp: time.Now().Add(-CacheExpiry - time.Second), val: 99}
+	c.Put("expired", entry)
+
+	// Get should return false and clean up.
+	_, ok := c.Get("expired")
+	if ok {
+		t.Fatal("expected expired entry to be removed")
+	}
+
+	// Verify it's actually gone.
+	c.mtx.Lock()
+	_, exists := c.cache["expired"]
+	c.mtx.Unlock()
+	if exists {
+		t.Fatal("expired entry should have been deleted from map")
+	}
+}
+
+func TestRecoverFromCache(t *testing.T) {
+	log := dex.StdOutLogger("TEST", dex.LevelWarn)
+
+	t.Run("cache miss", func(t *testing.T) {
+		c := NewCache[*testEntry]()
+		_, ok := RecoverFromCache(c, "missing",
+			func(e *testEntry) error { return nil },
+			func(e *testEntry) bool { return false },
+			log, "Test",
+		)
+		if ok {
+			t.Fatal("expected no recovery on cache miss")
+		}
+	})
+
+	t.Run("rebroadcast success", func(t *testing.T) {
+		c := NewCache[*testEntry]()
+		entry := &testEntry{stamp: time.Now(), val: 7}
+		c.Put("key", entry)
+
+		got, ok := RecoverFromCache(c, "key",
+			func(e *testEntry) error { return nil },
+			func(e *testEntry) bool { t.Fatal("should not check wallet"); return false },
+			log, "Test",
+		)
+		if !ok {
+			t.Fatal("expected recovery")
+		}
+		if got.val != 7 {
+			t.Fatalf("expected val 7, got %d", got.val)
+		}
+		// Cache entry should still exist (expires naturally).
+		if _, exists := c.Get("key"); !exists {
+			t.Fatal("cache entry should still exist after successful recovery")
+		}
+	})
+
+	t.Run("rebroadcast fail wallet success", func(t *testing.T) {
+		c := NewCache[*testEntry]()
+		entry := &testEntry{stamp: time.Now(), val: 8}
+		c.Put("key", entry)
+
+		got, ok := RecoverFromCache(c, "key",
+			func(e *testEntry) error { return errors.New("broadcast failed") },
+			func(e *testEntry) bool { return true },
+			log, "Test",
+		)
+		if !ok {
+			t.Fatal("expected recovery via wallet")
+		}
+		if got.val != 8 {
+			t.Fatalf("expected val 8, got %d", got.val)
+		}
+		// Cache entry should still exist (expires naturally).
+		if _, exists := c.Get("key"); !exists {
+			t.Fatal("cache entry should still exist after successful recovery")
+		}
+	})
+
+	t.Run("both fail", func(t *testing.T) {
+		c := NewCache[*testEntry]()
+		entry := &testEntry{stamp: time.Now(), val: 9}
+		c.Put("key", entry)
+
+		_, ok := RecoverFromCache(c, "key",
+			func(e *testEntry) error { return errors.New("broadcast failed") },
+			func(e *testEntry) bool { return false },
+			log, "Test",
+		)
+		if ok {
+			t.Fatal("expected no recovery when both fail")
+		}
+		if _, exists := c.Get("key"); exists {
+			t.Fatal("cache entry should have been deleted")
+		}
+	})
+
+	t.Run("expired entry", func(t *testing.T) {
+		c := NewCache[*testEntry]()
+		entry := &testEntry{stamp: time.Now().Add(-CacheExpiry - time.Second), val: 10}
+		c.Put("key", entry)
+
+		_, ok := RecoverFromCache(c, "key",
+			func(e *testEntry) error { t.Fatal("should not attempt broadcast"); return nil },
+			func(e *testEntry) bool { t.Fatal("should not check wallet"); return false },
+			log, "Test",
+		)
+		if ok {
+			t.Fatal("expected no recovery for expired entry")
+		}
+	})
+}

--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/asset/broadcast"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
 	"decred.org/dcrdex/dex/config"
@@ -860,6 +861,10 @@ type baseWallet struct {
 	txHistoryDB atomic.Value // *BadgerTxDB
 
 	ar *AddressRecycler
+
+	swapCache   *broadcast.Cache[*swapCacheEntry]
+	redeemCache *broadcast.Cache[*redeemCacheEntry]
+	refundCache *broadcast.Cache[*refundCacheEntry]
 }
 
 func (w *baseWallet) fallbackFeeRate() uint64 {
@@ -1374,6 +1379,9 @@ func newUnconnectedWallet(cfg *BTCCloneCFG, walletCfg *WalletConfig) (*baseWalle
 		pendingTxs:        make(map[chainhash.Hash]ExtendedWalletTx),
 		walletDir:         walletDir,
 		ar:                addressRecyler,
+		swapCache:         broadcast.NewCache[*swapCacheEntry](),
+		redeemCache:       broadcast.NewCache[*redeemCacheEntry](),
+		refundCache:       broadcast.NewCache[*refundCacheEntry](),
 	}
 	w.cfgV.Store(baseCfg)
 
@@ -3793,6 +3801,44 @@ func (btc *baseWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Re
 		return nil, nil, 0, fmt.Errorf("cannot send swap with with zero fee rate")
 	}
 
+	// Check broadcast cache for retry of a previously built transaction.
+	cacheKey := broadcast.CoinIDsCacheKey(swaps.Inputs)
+	if cached, ok := broadcast.RecoverFromCache(btc.swapCache, cacheKey,
+		func(e *swapCacheEntry) error { _, err := btc.broadcastTx(ctx, e.signedTx); return err },
+		func(e *swapCacheEntry) bool {
+			_, err := btc.node.GetWalletTransaction(btc.hashTx(e.signedTx))
+			return err == nil
+		},
+		btc.log, "Swap",
+	); ok {
+		txHash := btc.hashTx(cached.signedTx)
+		btc.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.Swap,
+			ID:     txHash.String(),
+			Amount: cached.totalOut,
+			Fees:   cached.fees,
+		}, txHash, true)
+		var changeCoin asset.Coin
+		if cached.change != nil {
+			changeCoin = cached.change
+		}
+		// Replicate post-broadcast coin manager bookkeeping.
+		if cached.changeLock != nil {
+			btc.log.Debugf("locking change coin %s (from cache recovery)", cached.change)
+			err := btc.node.LockUnspent(false, []*Output{cached.change})
+			if err != nil {
+				btc.log.Errorf("failed to lock change output: %v", err)
+			}
+		}
+		var locks []*UTxO
+		if cached.changeLock != nil {
+			locks = append(locks, cached.changeLock)
+		}
+		btc.cm.LockUTXOs(locks)
+		btc.cm.UnlockOutPoints(cached.pts)
+		return cached.receipts, changeCoin, cached.fees, nil
+	}
+
 	contracts := make([][]byte, 0, len(swaps.Contracts))
 	var totalOut uint64
 	// Start with an empty MsgTx.
@@ -3906,6 +3952,35 @@ func (btc *baseWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Re
 		})
 	}
 
+	// Pre-build the change lock UTxO for caching if LockChange is set.
+	var changeLock *UTxO
+	if change != nil && swaps.LockChange {
+		addrStr, err := btc.stringAddr(changeAddr, btc.chainParams)
+		if err != nil {
+			btc.log.Errorf("Failed to stringify address %v (default encoding): %v", changeAddr, err)
+			addrStr = changeAddr.String()
+		}
+		changeLock = &UTxO{
+			TxHash:  change.txHash(),
+			Vout:    change.vout(),
+			Address: addrStr,
+			Amount:  change.Val,
+		}
+	}
+
+	// Save to cache before broadcast for recovery on timeout/retry.
+	btc.swapCache.Put(cacheKey, &swapCacheEntry{
+		signedTx:   msgTx,
+		receipts:   receipts,
+		change:     change,
+		fees:       fees,
+		totalOut:   totalOut,
+		lockChange: swaps.LockChange,
+		changeLock: changeLock,
+		pts:        pts,
+		timestamp:  time.Now(),
+	})
+
 	// Refund txs prepared and signed. Can now broadcast the swap(s).
 	_, err = btc.broadcastTx(ctx, msgTx)
 	if err != nil {
@@ -3925,8 +4000,7 @@ func (btc *baseWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Re
 		changeCoin = change
 	}
 
-	var locks []*UTxO
-	if change != nil && swaps.LockChange {
+	if changeLock != nil {
 		// Lock the change output
 		btc.log.Debugf("locking change coin %s", change)
 		err = btc.node.LockUnspent(false, []*Output{change})
@@ -3934,23 +4008,12 @@ func (btc *baseWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Re
 			// The swap transaction is already broadcasted, so don't fail now.
 			btc.log.Errorf("failed to lock change output: %v", err)
 		}
-
-		addrStr, err := btc.stringAddr(changeAddr, btc.chainParams)
-		if err != nil {
-			btc.log.Errorf("Failed to stringify address %v (default encoding): %v", changeAddr, err)
-			addrStr = changeAddr.String() // may or may not be able to retrieve the private keys for the next swap!
-		}
-
-		// Log it as a fundingCoin, since it is expected that this will be
-		// chained into further matches.
-		locks = append(locks, &UTxO{
-			TxHash:  change.txHash(),
-			Vout:    change.vout(),
-			Address: addrStr,
-			Amount:  change.Val,
-		})
 	}
 
+	var locks []*UTxO
+	if changeLock != nil {
+		locks = append(locks, changeLock)
+	}
 	btc.cm.LockUTXOs(locks)
 	btc.cm.UnlockOutPoints(pts)
 
@@ -5022,6 +5085,26 @@ func (btc *baseWallet) MarkPrivateSwapComplete(contract *asset.PrivateContract, 
 
 // Redeem sends the redemption transaction, completing the atomic swap.
 func (btc *baseWallet) Redeem(ctx context.Context, form *asset.RedeemForm) ([]dex.Bytes, asset.Coin, uint64, error) {
+	// Check broadcast cache for retry of a previously built transaction.
+	cacheKey := broadcast.RedeemCacheKey(form.Redemptions)
+	if cached, ok := broadcast.RecoverFromCache(btc.redeemCache, cacheKey,
+		func(e *redeemCacheEntry) error { _, err := btc.broadcastTx(ctx, e.signedTx); return err },
+		func(e *redeemCacheEntry) bool {
+			_, err := btc.node.GetWalletTransaction(btc.hashTx(e.signedTx))
+			return err == nil
+		},
+		btc.log, "Redeem",
+	); ok {
+		txHash := btc.hashTx(cached.signedTx)
+		btc.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.Redeem,
+			ID:     txHash.String(),
+			Amount: cached.totalIn,
+			Fees:   cached.fees,
+		}, txHash, true)
+		return cached.coinIDs, cached.outCoin, cached.fees, nil
+	}
+
 	// Create a transaction that spends the referenced contract.
 	msgTx := wire.NewMsgTx(btc.txVersion())
 	var totalIn uint64
@@ -5138,8 +5221,26 @@ func (btc *baseWallet) Redeem(ctx context.Context, form *asset.RedeemForm) ([]de
 		}
 	}
 
+	// Prepare return values for caching.
+	txHash := btc.hashTx(msgTx)
+	coinIDs := make([]dex.Bytes, 0, len(form.Redemptions))
+	for i := range form.Redemptions {
+		coinIDs = append(coinIDs, ToCoinID(txHash, uint32(i)))
+	}
+	outCoin := NewOutput(txHash, 0, uint64(txOut.Value))
+
+	// Save to cache before broadcast for recovery on timeout/retry.
+	btc.redeemCache.Put(cacheKey, &redeemCacheEntry{
+		signedTx:  msgTx,
+		coinIDs:   coinIDs,
+		outCoin:   outCoin,
+		fees:      fee,
+		totalIn:   totalIn,
+		timestamp: time.Now(),
+	})
+
 	// Send the transaction.
-	txHash, err := btc.broadcastTx(ctx, msgTx)
+	_, err = btc.broadcastTx(ctx, msgTx)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -5151,12 +5252,7 @@ func (btc *baseWallet) Redeem(ctx context.Context, form *asset.RedeemForm) ([]de
 		Fees:   fee,
 	}, txHash, true)
 
-	// Log the change output.
-	coinIDs := make([]dex.Bytes, 0, len(form.Redemptions))
-	for i := range form.Redemptions {
-		coinIDs = append(coinIDs, ToCoinID(txHash, uint32(i)))
-	}
-	return coinIDs, NewOutput(txHash, 0, uint64(txOut.Value)), fee, nil
+	return coinIDs, outCoin, fee, nil
 }
 
 // ConvertAuditInfo converts from the common *asset.AuditInfo type to our
@@ -5363,6 +5459,26 @@ func (btc *intermediaryWallet) FindRedemption(ctx context.Context, coinID, _ dex
 // was created. The client should store this information for persistence across
 // sessions.
 func (btc *baseWallet) Refund(ctx context.Context, coinID, contract dex.Bytes, feeRate uint64) (dex.Bytes, error) {
+	// Check broadcast cache for retry of a previously built transaction.
+	cacheKey := broadcast.RefundCacheKey(coinID)
+	if cached, ok := broadcast.RecoverFromCache(btc.refundCache, cacheKey,
+		func(e *refundCacheEntry) error { _, err := btc.broadcastTx(ctx, e.signedTx); return err },
+		func(e *refundCacheEntry) bool {
+			_, err := btc.node.GetWalletTransaction(btc.hashTx(e.signedTx))
+			return err == nil
+		},
+		btc.log, "Refund",
+	); ok {
+		refundHash := btc.hashTx(cached.signedTx)
+		btc.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.Refund,
+			ID:     refundHash.String(),
+			Amount: cached.refundVal,
+			Fees:   cached.fees,
+		}, refundHash, true)
+		return cached.refundCoinID, nil
+	}
+
 	txHash, vout, err := decodeCoinID(coinID)
 	if err != nil {
 		return nil, err
@@ -5398,15 +5514,27 @@ func (btc *baseWallet) Refund(ctx context.Context, coinID, contract dex.Bytes, f
 		return nil, fmt.Errorf("error creating refund tx: %w", err)
 	}
 
-	refundHash, err := btc.broadcastTx(ctx, msgTx)
-	if err != nil {
-		return nil, fmt.Errorf("broadcastTx: %w", err)
-	}
-
 	var fee uint64
 	if len(msgTx.TxOut) > 0 { // something went very wrong if not true
 		fee = uint64(utxo.Value - msgTx.TxOut[0].Value)
 	}
+	refundHash := btc.hashTx(msgTx)
+	refundCoinID := ToCoinID(refundHash, 0)
+
+	// Save to cache before broadcast for recovery on timeout/retry.
+	btc.refundCache.Put(cacheKey, &refundCacheEntry{
+		signedTx:     msgTx,
+		refundCoinID: refundCoinID,
+		refundVal:    uint64(utxo.Value),
+		fees:         fee,
+		timestamp:    time.Now(),
+	})
+
+	_, err = btc.broadcastTx(ctx, msgTx)
+	if err != nil {
+		return nil, fmt.Errorf("broadcastTx: %w", err)
+	}
+
 	btc.addTxToHistory(&asset.WalletTransaction{
 		Type:   asset.Refund,
 		ID:     refundHash.String(),
@@ -5414,7 +5542,7 @@ func (btc *baseWallet) Refund(ctx context.Context, coinID, contract dex.Bytes, f
 		Fees:   fee,
 	}, refundHash, true)
 
-	return ToCoinID(refundHash, 0), nil
+	return refundCoinID, nil
 }
 
 // refundTx creates and signs a contract`s refund transaction. If refundAddr is
@@ -6023,9 +6151,49 @@ func (btc *baseWallet) signTxAndAddChange(ctx context.Context, baseTx *wire.MsgT
 	return msgTx, change, fee, nil
 }
 
+type swapCacheEntry struct {
+	signedTx   *wire.MsgTx
+	receipts   []asset.Receipt
+	change     *Output
+	fees       uint64
+	totalOut   uint64
+	lockChange bool
+	changeLock *UTxO // pre-built UTxO for LockUTXOs when LockChange is set
+	pts        []OutPoint
+	timestamp  time.Time
+}
+
+func (e *swapCacheEntry) Stamp() time.Time { return e.timestamp }
+
+type redeemCacheEntry struct {
+	signedTx  *wire.MsgTx
+	coinIDs   []dex.Bytes
+	outCoin   *Output
+	fees      uint64
+	totalIn   uint64
+	timestamp time.Time
+}
+
+func (e *redeemCacheEntry) Stamp() time.Time { return e.timestamp }
+
+type refundCacheEntry struct {
+	signedTx     *wire.MsgTx
+	refundCoinID dex.Bytes
+	refundVal    uint64
+	fees         uint64
+	timestamp    time.Time
+}
+
+func (e *refundCacheEntry) Stamp() time.Time { return e.timestamp }
+
 func (btc *baseWallet) broadcastTx(ctx context.Context, signedTx *wire.MsgTx) (*chainhash.Hash, error) {
 	txHash, err := btc.node.SendRawTransaction(ctx, signedTx)
 	if err != nil {
+		if broadcast.IsAlreadyBroadcastErr(err) {
+			h := btc.hashTx(signedTx)
+			btc.log.Warnf("Transaction %s appears to already be broadcast: %v", h, err)
+			return h, nil
+		}
 		return nil, fmt.Errorf("sendrawtx error: %v, raw tx: %x", err, btc.wireBytes(signedTx))
 	}
 	checkHash := btc.hashTx(signedTx)

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/asset/broadcast"
 	"decred.org/dcrdex/client/asset/btc"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
@@ -704,6 +705,10 @@ type ExchangeWallet struct {
 		sync.RWMutex
 		progress *rescanProgress // nil = no rescan in progress
 	}
+
+	swapCache   *broadcast.Cache[*dcrSwapCacheEntry]
+	redeemCache *broadcast.Cache[*dcrRedeemCacheEntry]
+	refundCache *broadcast.Cache[*dcrRefundCacheEntry]
 }
 
 func (dcr *ExchangeWallet) config() *exchangeWalletConfig {
@@ -867,6 +872,9 @@ func unconnectedWallet(cfg *asset.WalletConfig, dcrCfg *walletConfig, chainParam
 		subsidyCache:        blockchain.NewSubsidyCache(chainParams),
 		pendingTxs:          make(map[chainhash.Hash]*btc.ExtendedWalletTx),
 		walletDir:           dir,
+		swapCache:           broadcast.NewCache[*dcrSwapCacheEntry](),
+		redeemCache:         broadcast.NewCache[*dcrRedeemCacheEntry](),
+		refundCache:         broadcast.NewCache[*dcrRefundCacheEntry](),
 	}
 
 	if b, err := os.ReadFile(vspFilepath); err == nil {
@@ -3789,6 +3797,47 @@ func (dcr *ExchangeWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asse
 		return nil, nil, 0, fmt.Errorf("cannot send swap with with zero fee rate")
 	}
 
+	// Check broadcast cache for retry of a previously built transaction.
+	cacheKey := broadcast.CoinIDsCacheKey(swaps.Inputs)
+	if cached, ok := broadcast.RecoverFromCache(dcr.swapCache, cacheKey,
+		func(e *dcrSwapCacheEntry) error { _, err := dcr.broadcastTx(ctx, e.signedTx, e.feeRate); return err },
+		func(e *dcrSwapCacheEntry) bool {
+			_, err := dcr.wallet.GetTransaction(ctx, e.signedTx.CachedTxHash())
+			return err == nil
+		},
+		dcr.log, "Swap",
+	); ok {
+		txHash := cached.signedTx.CachedTxHash()
+		dcr.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.Swap,
+			ID:     txHash.String(),
+			Amount: cached.totalOut,
+			Fees:   cached.fees,
+		}, txHash, true)
+		// Replicate post-broadcast bookkeeping: unlock inputs, lock change.
+		dcr.fundingMtx.Lock()
+		_, err := dcr.returnCoins(swaps.Inputs)
+		if err != nil {
+			dcr.log.Errorf("cache recovery: error unlocking swapped coins: %v", err)
+		}
+		if cached.lockChange && cached.change != nil {
+			dcr.log.Debugf("locking change coin %s (from cache recovery)", cached.change)
+			err = dcr.lockFundingCoins([]*fundingCoin{{
+				op:   cached.change,
+				addr: cached.changeAddr,
+			}})
+			if err != nil {
+				dcr.log.Warnf("Failed to lock dcr change coin %s", cached.change)
+			}
+		}
+		dcr.fundingMtx.Unlock()
+		var changeCoin asset.Coin
+		if cached.change != nil {
+			changeCoin = cached.change
+		}
+		return cached.receipts, changeCoin, cached.fees, nil
+	}
+
 	var totalOut uint64
 	// Start with an empty MsgTx.
 	baseTx := wire.NewMsgTx()
@@ -3884,6 +3933,19 @@ func (dcr *ExchangeWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asse
 		})
 	}
 
+	// Save to cache before broadcast for recovery on timeout/retry.
+	dcr.swapCache.Put(cacheKey, &dcrSwapCacheEntry{
+		signedTx:   msgTx,
+		receipts:   receipts,
+		change:     change,
+		changeAddr: changeAddr,
+		fees:       fees,
+		totalOut:   totalOut,
+		feeRate:    feeRate,
+		lockChange: swaps.LockChange,
+		timestamp:  time.Now(),
+	})
+
 	// Refund txs prepared and signed. Can now broadcast the swap(s).
 	_, err = dcr.broadcastTx(ctx, msgTx, feeRate)
 	if err != nil {
@@ -3927,6 +3989,34 @@ func (dcr *ExchangeWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asse
 // redemption. FeeSuggestion is just a fallback if an internal estimate using
 // the wallet's redeem confirm block target setting is not available.
 func (dcr *ExchangeWallet) Redeem(ctx context.Context, form *asset.RedeemForm) ([]dex.Bytes, asset.Coin, uint64, error) {
+	// Check broadcast cache for retry of a previously built transaction.
+	cacheKey := broadcast.RedeemCacheKey(form.Redemptions)
+	if cached, ok := broadcast.RecoverFromCache(dcr.redeemCache, cacheKey,
+		func(e *dcrRedeemCacheEntry) error { _, err := dcr.broadcastTx(ctx, e.signedTx, e.feeRate); return err },
+		func(e *dcrRedeemCacheEntry) bool {
+			_, err := dcr.wallet.GetTransaction(ctx, e.signedTx.CachedTxHash())
+			return err == nil
+		},
+		dcr.log, "Redeem",
+	); ok {
+		txHash := cached.signedTx.CachedTxHash()
+		dcr.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.Redeem,
+			ID:     txHash.String(),
+			Amount: cached.totalIn,
+			Fees:   cached.fees,
+		}, txHash, true)
+		// Register with mempoolTxs so ConfirmTransaction can track.
+		dcr.mempoolTxsMtx.Lock()
+		for i := range form.Redemptions {
+			var secretHash [32]byte
+			copy(secretHash[:], form.Redemptions[i].Spends.SecretHash)
+			dcr.mempoolTxs[secretHash] = &mempoolTx{txHash: *txHash, firstSeen: time.Now(), txType: asset.CTRedeem}
+		}
+		dcr.mempoolTxsMtx.Unlock()
+		return cached.coinIDs, cached.outCoin, cached.fees, nil
+	}
+
 	// Create a transaction that spends the referenced contract.
 	msgTx := wire.NewMsgTx()
 	var totalIn uint64
@@ -4009,8 +4099,27 @@ func (dcr *ExchangeWallet) Redeem(ctx context.Context, form *asset.RedeemForm) (
 		}
 		msgTx.TxIn[i].SignatureScript = redeemSigScript
 	}
+	// Prepare return values for caching.
+	txHash := msgTx.CachedTxHash()
+	coinIDs := make([]dex.Bytes, 0, len(form.Redemptions))
+	for i := range form.Redemptions {
+		coinIDs = append(coinIDs, ToCoinID(txHash, uint32(i)))
+	}
+	outCoin := newOutput(txHash, 0, uint64(txOut.Value), wire.TxTreeRegular)
+
+	// Save to cache before broadcast for recovery on timeout/retry.
+	dcr.redeemCache.Put(cacheKey, &dcrRedeemCacheEntry{
+		signedTx:  msgTx,
+		coinIDs:   coinIDs,
+		outCoin:   outCoin,
+		fees:      fee,
+		totalIn:   totalIn,
+		feeRate:   feeRate,
+		timestamp: time.Now(),
+	})
+
 	// Send the transaction.
-	txHash, err := dcr.broadcastTx(ctx, msgTx, feeRate)
+	_, err = dcr.broadcastTx(ctx, msgTx, feeRate)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -4022,16 +4131,14 @@ func (dcr *ExchangeWallet) Redeem(ctx context.Context, form *asset.RedeemForm) (
 		Fees:   fee,
 	}, txHash, true)
 
-	coinIDs := make([]dex.Bytes, 0, len(form.Redemptions))
 	dcr.mempoolTxsMtx.Lock()
 	for i := range form.Redemptions {
-		coinIDs = append(coinIDs, ToCoinID(txHash, uint32(i)))
 		var secretHash [32]byte
 		copy(secretHash[:], form.Redemptions[i].Spends.SecretHash)
 		dcr.mempoolTxs[secretHash] = &mempoolTx{txHash: *txHash, firstSeen: time.Now(), txType: asset.CTRedeem}
 	}
 	dcr.mempoolTxsMtx.Unlock()
-	return coinIDs, newOutput(txHash, 0, uint64(txOut.Value), wire.TxTreeRegular), fee, nil
+	return coinIDs, outCoin, fee, nil
 }
 
 // SignCoinMessage signs the message with the private key associated with the
@@ -4679,6 +4786,26 @@ func (dcr *ExchangeWallet) fatalFindRedemptionsError(err error, contractOutpoint
 // was created. The client should store this information for persistence across
 // sessions.
 func (dcr *ExchangeWallet) Refund(ctx context.Context, coinID, contract dex.Bytes, feeRate uint64) (dex.Bytes, error) {
+	// Check broadcast cache for retry of a previously built transaction.
+	cacheKey := broadcast.RefundCacheKey(coinID)
+	if cached, ok := broadcast.RecoverFromCache(dcr.refundCache, cacheKey,
+		func(e *dcrRefundCacheEntry) error { _, err := dcr.broadcastTx(ctx, e.signedTx, e.feeRate); return err },
+		func(e *dcrRefundCacheEntry) bool {
+			_, err := dcr.wallet.GetTransaction(ctx, e.signedTx.CachedTxHash())
+			return err == nil
+		},
+		dcr.log, "Refund",
+	); ok {
+		refundHash := cached.signedTx.CachedTxHash()
+		dcr.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.Refund,
+			ID:     refundHash.String(),
+			Amount: cached.refundVal,
+			Fees:   cached.fees,
+		}, refundHash, true)
+		return cached.refundCoinID, nil
+	}
+
 	// Caller should provide a non-zero fee rate, so we could just do
 	// dcr.feeRateWithFallback(feeRate), but be permissive for now.
 	if feeRate == 0 {
@@ -4689,10 +4816,24 @@ func (dcr *ExchangeWallet) Refund(ctx context.Context, coinID, contract dex.Byte
 		return nil, fmt.Errorf("error creating refund tx: %w", err)
 	}
 
-	refundHash, err := dcr.broadcastTx(ctx, msgTx, feeRate)
+	refundHash := msgTx.CachedTxHash()
+	refundCoinID := ToCoinID(refundHash, 0)
+
+	// Save to cache before broadcast for recovery on timeout/retry.
+	dcr.refundCache.Put(cacheKey, &dcrRefundCacheEntry{
+		signedTx:     msgTx,
+		refundCoinID: refundCoinID,
+		refundVal:    refundVal,
+		fees:         fee,
+		feeRate:      feeRate,
+		timestamp:    time.Now(),
+	})
+
+	_, err = dcr.broadcastTx(ctx, msgTx, feeRate)
 	if err != nil {
 		return nil, err
 	}
+
 	dcr.addTxToHistory(&asset.WalletTransaction{
 		Type:   asset.Refund,
 		ID:     refundHash.String(),
@@ -4700,7 +4841,7 @@ func (dcr *ExchangeWallet) Refund(ctx context.Context, coinID, contract dex.Byte
 		Fees:   fee,
 	}, refundHash, true)
 
-	return ToCoinID(refundHash, 0), nil
+	return refundCoinID, nil
 }
 
 // refundTx crates and signs a contract's refund transaction. If refundAddr is
@@ -6554,6 +6695,43 @@ func (dcr *ExchangeWallet) CommittedTickets(tickets []*chainhash.Hash) ([]*chain
 	return dcr.wallet.CommittedTickets(dcr.ctx, tickets)
 }
 
+type dcrSwapCacheEntry struct {
+	signedTx   *wire.MsgTx
+	receipts   []asset.Receipt
+	change     *output
+	changeAddr string
+	fees       uint64
+	totalOut   uint64
+	feeRate    uint64
+	lockChange bool
+	timestamp  time.Time
+}
+
+func (e *dcrSwapCacheEntry) Stamp() time.Time { return e.timestamp }
+
+type dcrRedeemCacheEntry struct {
+	signedTx  *wire.MsgTx
+	coinIDs   []dex.Bytes
+	outCoin   *output
+	fees      uint64
+	totalIn   uint64
+	feeRate   uint64
+	timestamp time.Time
+}
+
+func (e *dcrRedeemCacheEntry) Stamp() time.Time { return e.timestamp }
+
+type dcrRefundCacheEntry struct {
+	signedTx     *wire.MsgTx
+	refundCoinID dex.Bytes
+	refundVal    uint64
+	fees         uint64
+	feeRate      uint64
+	timestamp    time.Time
+}
+
+func (e *dcrRefundCacheEntry) Stamp() time.Time { return e.timestamp }
+
 func (dcr *ExchangeWallet) broadcastTx(ctx context.Context, signedTx *wire.MsgTx, feeRate uint64) (*chainhash.Hash, error) {
 	// Hard limit: Validate transaction size before broadcasting to prevent
 	// transactions from getting stuck in mempool.
@@ -6601,6 +6779,11 @@ func (dcr *ExchangeWallet) broadcastTx(ctx context.Context, signedTx *wire.MsgTx
 
 	txHash, err := dcr.wallet.SendRawTransaction(ctx, signedTx, false)
 	if err != nil {
+		if broadcast.IsAlreadyBroadcastErr(err) {
+			h := signedTx.CachedTxHash()
+			dcr.log.Warnf("Transaction %s appears to already be broadcast: %v", h, err)
+			return h, nil
+		}
 		return nil, fmt.Errorf("sendrawtx error: %w, raw tx: %x", err, dcr.wireBytes(signedTx))
 	}
 	checkHash := signedTx.TxHash()

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/asset/broadcast"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/config"
 	"decred.org/dcrdex/dex/encode"
@@ -518,7 +519,24 @@ type assetWallet struct {
 	// status of pending txs if the tip has changed OR if the balance has
 	// changed.
 	pendingTxCheckBal *big.Int
+
+	// swapSeen tracks input keys that have been seen by Swap. A cache hit
+	// means this is a retry, and the AlreadyInitialized on-chain check
+	// should be performed. On the first call (cache miss), we skip the
+	// check to avoid unnecessary RPC calls.
+	swapSeen *broadcast.Cache[*ethSwapSeen]
+
+	// redeemSeen tracks redemption keys that have been seen by Redeem. A
+	// cache hit means this is a retry, and the on-chain SSRedeemed check
+	// should be performed.
+	redeemSeen *broadcast.Cache[*ethSwapSeen]
 }
+
+type ethSwapSeen struct {
+	timestamp time.Time
+}
+
+func (e *ethSwapSeen) Stamp() time.Time { return e.timestamp }
 
 // ETHWallet implements some Ethereum-specific methods.
 type ETHWallet struct {
@@ -1683,6 +1701,8 @@ func NewEVMWallet(cfg *EVMWalletConfig) (w *ETHWallet, err error) {
 		ui:                 dexeth.UnitInfo,
 		pendingTxCheckBal:  new(big.Int),
 		wi:                 cfg.WalletInfo,
+		swapSeen:           broadcast.NewCache[*ethSwapSeen](),
+		redeemSeen:         broadcast.NewCache[*ethSwapSeen](),
 	}
 
 	aw.wallets = map[uint32]*assetWallet{
@@ -2528,6 +2548,8 @@ func (w *ETHWallet) OpenTokenWallet(tokenCfg *asset.TokenConfig) (asset.Wallet, 
 		},
 		tokenAddr:         netToken.Address,
 		pendingTxCheckBal: new(big.Int),
+		swapSeen:          broadcast.NewCache[*ethSwapSeen](),
+		redeemSeen:        broadcast.NewCache[*ethSwapSeen](),
 	}
 
 	w.baseWallet.walletsMtx.Lock()
@@ -3456,10 +3478,58 @@ func (w *ETHWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Recei
 		return fail("Swap: failed to get network tip cap: %w", err)
 	}
 
+	// Only check on-chain state on retry (cache hit) to avoid unnecessary
+	// RPC calls on the first attempt.
+	cacheKey := broadcast.CoinIDsCacheKey(swaps.Inputs)
+	if _, seen := w.swapSeen.Get(cacheKey); seen {
+		allInitiated := true
+		for _, contract := range swaps.Contracts {
+			initiated, _, _, err := w.AlreadyInitialized(swaps.AssetVersion, contract)
+			if err != nil {
+				w.log.Warnf("AlreadyInitialized check error: %v", err)
+				allInitiated = false
+				break
+			}
+			if !initiated {
+				allInitiated = false
+				break
+			}
+		}
+		if allInitiated {
+			w.log.Infof("All %d swaps already initiated on-chain, returning cached results", n)
+			// The zero txHash is safe here because downstream swap
+			// confirmation uses contract state via the locator, not txHash.
+			zeroHash := common.Hash{}
+			receipts := make([]asset.Receipt, 0, n)
+			for _, swap := range swaps.Contracts {
+				receipts = append(receipts, &swapReceipt{
+					expiration:   time.Unix(int64(swap.LockTime), 0),
+					value:        swap.Value,
+					txHash:       zeroHash,
+					locator:      acToLocator(contractVer, swap, dexeth.GweiToWei(swap.Value), w.addr),
+					contractVer:  contractVer,
+					contractAddr: w.versionedContracts[contractVer].String(),
+				})
+			}
+			var change asset.Coin
+			if swaps.LockChange {
+				w.unlockFunds(swapVal+fees, initiationReserve)
+				change = w.createFundingCoin(reservedVal - swapVal - fees)
+			} else {
+				w.unlockFunds(reservedVal, initiationReserve)
+			}
+			// fees is an estimate (gasLimit * feeRate), not actual tx fees.
+			return receipts, change, fees, nil
+		}
+	}
 	tx, err := w.initiate(ctx, w.assetID, swaps.Contracts, gasLimit, maxFeeRate, tipRate, contractVer)
 	if err != nil {
 		return fail("Swap: initiate error: %w", err)
 	}
+
+	// Mark as seen only after successful initiation to avoid unnecessary
+	// on-chain checks on retry after permanent failures.
+	w.swapSeen.Put(cacheKey, &ethSwapSeen{timestamp: time.Now()})
 
 	txHash := tx.Hash()
 	receipts := make([]asset.Receipt, 0, n)
@@ -3568,12 +3638,62 @@ func (w *TokenWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Rec
 		return fail("unable to find contract address for asset %d contract version %d", w.assetID, swaps.AssetVersion)
 	}
 
+	contractAddr := w.netToken.SwapContracts[contractVer].Address.String()
+
+	// Only check on-chain state on retry (cache hit) to avoid unnecessary
+	// RPC calls on the first attempt.
+	cacheKey := broadcast.CoinIDsCacheKey(swaps.Inputs)
+	if _, seen := w.swapSeen.Get(cacheKey); seen {
+		allInitiated := true
+		for _, contract := range swaps.Contracts {
+			initiated, _, _, err := w.AlreadyInitialized(swaps.AssetVersion, contract)
+			if err != nil {
+				w.log.Warnf("AlreadyInitialized check error: %v", err)
+				allInitiated = false
+				break
+			}
+			if !initiated {
+				allInitiated = false
+				break
+			}
+		}
+		if allInitiated {
+			w.log.Infof("All %d token swaps already initiated on-chain, returning cached results", n)
+			// The zero txHash is safe here because downstream swap
+			// confirmation uses contract state via the locator, not txHash.
+			zeroHash := common.Hash{}
+			receipts := make([]asset.Receipt, 0, n)
+			for _, swap := range swaps.Contracts {
+				receipts = append(receipts, &swapReceipt{
+					expiration:   time.Unix(int64(swap.LockTime), 0),
+					value:        swap.Value,
+					txHash:       zeroHash,
+					locator:      acToLocator(contractVer, swap, w.evmify(swap.Value), w.addr),
+					contractVer:  contractVer,
+					contractAddr: contractAddr,
+				})
+			}
+			var change asset.Coin
+			if swaps.LockChange {
+				w.unlockFunds(swapVal, initiationReserve)
+				w.parent.unlockFunds(fees, initiationReserve)
+				change = w.createTokenFundingCoin(reservedVal-swapVal, reservedParent-fees)
+			} else {
+				w.unlockFunds(reservedVal, initiationReserve)
+				w.parent.unlockFunds(reservedParent, initiationReserve)
+			}
+			// fees is an estimate (gasLimit * feeRate), not actual tx fees.
+			return receipts, change, fees, nil
+		}
+	}
 	tx, err := w.initiate(ctx, w.assetID, swaps.Contracts, gasLimit, maxFeeRate, tipRate, contractVer)
 	if err != nil {
 		return fail("Swap: initiate error: %w", err)
 	}
 
-	contractAddr := w.netToken.SwapContracts[contractVer].Address.String()
+	// Mark as seen only after successful initiation to avoid unnecessary
+	// on-chain checks on retry after permanent failures.
+	w.swapSeen.Put(cacheKey, &ethSwapSeen{timestamp: time.Now()})
 
 	txHash := tx.Hash()
 	receipts := make([]asset.Receipt, 0, n)
@@ -3930,6 +4050,54 @@ func (w *assetWallet) Redeem(ctx context.Context, form *asset.RedeemForm, feeWal
 		return fail(errors.New("Redeem: must be called with at least 1 redemption"))
 	}
 
+	// Only check on-chain state on retry (cache hit) to avoid unnecessary
+	// RPC calls on the first attempt.
+	redeemCacheKey := broadcast.RedeemCacheKey(form.Redemptions)
+	if _, seen := w.redeemSeen.Get(redeemCacheKey); seen {
+		allRedeemed := true
+		var contractVer uint32
+		var redeemedValue uint64
+		for i, redemption := range form.Redemptions {
+			ver, locator, err := dexeth.DecodeContractData(redemption.Spends.Contract)
+			if err != nil {
+				w.log.Warnf("Redeem recovery: invalid contract data: %v", err)
+				allRedeemed = false
+				break
+			}
+			if i == 0 {
+				contractVer = ver
+			}
+			status, vector, err := w.statusAndVector(ctx, locator, ver)
+			if err != nil {
+				w.log.Warnf("Redeem recovery: status check error: %v", err)
+				allRedeemed = false
+				break
+			}
+			if status.Step != dexeth.SSRedeemed {
+				allRedeemed = false
+				break
+			}
+			redeemedValue += w.atomize(vector.Value)
+		}
+		if allRedeemed {
+			w.log.Infof("All %d redemptions already redeemed on-chain, returning cached results", n)
+			zeroHash := common.Hash{}
+			txs := make([]dex.Bytes, n)
+			for i := range txs {
+				txs[i] = zeroHash[:]
+			}
+			g := w.gases(contractVer)
+			var fees uint64
+			if g != nil {
+				fees = g.RedeemN(int(n)) * form.FeeSuggestion
+			}
+			outputCoin := &coin{
+				txHash: zeroHash,
+				value:  redeemedValue,
+			}
+			return txs, outputCoin, fees, nil
+		}
+	}
 	contractVer, redeemedValue, err := w.validateRedemptions(ctx, form.Redemptions)
 	if err != nil {
 		return fail(fmt.Errorf("Redeem: failed to validate redemptions: %w", err))
@@ -3999,6 +4167,10 @@ func (w *assetWallet) Redeem(ctx context.Context, form *asset.RedeemForm, feeWal
 	if err != nil {
 		return fail(fmt.Errorf("Redeem: redeem error: %w", err))
 	}
+
+	// Mark as seen only after successful redemption to avoid unnecessary
+	// on-chain checks on retry after permanent failures.
+	w.redeemSeen.Put(redeemCacheKey, &ethSwapSeen{timestamp: time.Now()})
 
 	txHash := tx.Hash()
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/asset/broadcast"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/config"
 	"decred.org/dcrdex/dex/encode"
@@ -1680,6 +1681,8 @@ func tassetWallet(assetID uint32) (asset.Wallet, *assetWallet, *tMempoolNode, co
 		pendingTxCheckBal:  new(big.Int),
 		pendingApprovals:   make(map[common.Address]*pendingApproval),
 		approvalCache:      make(map[common.Address]bool),
+		swapSeen:           broadcast.NewCache[*ethSwapSeen](),
+		redeemSeen:         broadcast.NewCache[*ethSwapSeen](),
 		// move up after review
 		wi:   WalletInfo,
 		emit: asset.NewWalletEmitter(emitChan, BipID, tLogger),

--- a/client/asset/zec/zec.go
+++ b/client/asset/zec/zec.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/asset/broadcast"
 	"decred.org/dcrdex/client/asset/btc"
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/config"
@@ -270,10 +271,13 @@ func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (ass
 		decodeAddr: func(addr string, net *chaincfg.Params) (btcutil.Address, error) {
 			return dexzec.DecodeAddress(addr, addrParams, btcParams)
 		},
-		ar:         ar,
-		node:       cl,
-		walletDir:  cfg.DataDir,
-		pendingTxs: make(map[chainhash.Hash]*btc.ExtendedWalletTx),
+		ar:          ar,
+		node:        cl,
+		walletDir:   cfg.DataDir,
+		pendingTxs:  make(map[chainhash.Hash]*btc.ExtendedWalletTx),
+		swapCache:   broadcast.NewCache[*zecSwapCacheEntry](),
+		redeemCache: broadcast.NewCache[*zecRedeemCacheEntry](),
+		refundCache: broadcast.NewCache[*zecRefundCacheEntry](),
 	}
 	zw.walletCfg.Store(&walletCfg)
 	zw.prepareCoinManager()
@@ -333,6 +337,10 @@ type zecWallet struct {
 
 	txHistoryDB      atomic.Value // *btc.BadgerTxDB
 	syncingTxHistory atomic.Bool
+
+	swapCache   *broadcast.Cache[*zecSwapCacheEntry]
+	redeemCache *broadcast.Cache[*zecRedeemCacheEntry]
+	refundCache *broadcast.Cache[*zecRefundCacheEntry]
 }
 
 var _ asset.FeeRater = (*zecWallet)(nil)
@@ -864,6 +872,27 @@ func (w *zecWallet) FundOrder(ord *asset.Order) (asset.Coins, []dex.Bytes, uint6
 
 // Redeem sends the redemption transaction, completing the atomic swap.
 func (w *zecWallet) Redeem(ctx context.Context, form *asset.RedeemForm) ([]dex.Bytes, asset.Coin, uint64, error) {
+	// Check broadcast cache for retry of a previously built transaction.
+	cacheKey := broadcast.RedeemCacheKey(form.Redemptions)
+	if cached, ok := broadcast.RecoverFromCache(w.redeemCache, cacheKey,
+		func(e *zecRedeemCacheEntry) error { _, err := w.broadcastTx(ctx, e.signedTx); return err },
+		func(e *zecRedeemCacheEntry) bool {
+			txHash := e.signedTx.TxHash()
+			_, err := getWalletTransaction(w, &txHash)
+			return err == nil
+		},
+		w.log, "Redeem",
+	); ok {
+		txHash := cached.signedTx.TxHash()
+		w.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.Redeem,
+			ID:     txHash.String(),
+			Amount: cached.totalIn,
+			Fees:   cached.fees,
+		}, &txHash, true)
+		return cached.coinIDs, cached.outCoin, cached.fees, nil
+	}
+
 	// Create a transaction that spends the referenced contract.
 	tx := dexzec.NewTxFromMsgTx(wire.NewMsgTx(dexzec.VersionNU5), dexzec.MaxExpiryHeight)
 	var totalIn uint64
@@ -955,8 +984,26 @@ func (w *zecWallet) Redeem(ctx context.Context, form *asset.RedeemForm) ([]dex.B
 		}
 	}
 
+	// Prepare return values for caching.
+	txHash := tx.TxHash()
+	coinIDs := make([]dex.Bytes, 0, len(form.Redemptions))
+	for i := range form.Redemptions {
+		coinIDs = append(coinIDs, btc.ToCoinID(&txHash, uint32(i)))
+	}
+	outCoin := btc.NewOutput(&txHash, 0, uint64(txOut.Value))
+
+	// Save to cache before broadcast for recovery on timeout/retry.
+	w.redeemCache.Put(cacheKey, &zecRedeemCacheEntry{
+		signedTx:  tx,
+		coinIDs:   coinIDs,
+		outCoin:   outCoin,
+		fees:      fee,
+		totalIn:   totalIn,
+		timestamp: time.Now(),
+	})
+
 	// Send the transaction.
-	txHash, err := w.broadcastTx(ctx, tx)
+	_, err = w.broadcastTx(ctx, tx)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("error sending tx: %w", err)
 	}
@@ -966,14 +1013,9 @@ func (w *zecWallet) Redeem(ctx context.Context, form *asset.RedeemForm) ([]dex.B
 		ID:     txHash.String(),
 		Amount: totalIn,
 		Fees:   fee,
-	}, txHash, true)
+	}, &txHash, true)
 
-	// Log the change output.
-	coinIDs := make([]dex.Bytes, 0, len(form.Redemptions))
-	for i := range form.Redemptions {
-		coinIDs = append(coinIDs, btc.ToCoinID(txHash, uint32(i)))
-	}
-	return coinIDs, btc.NewOutput(txHash, 0, uint64(txOut.Value)), fee, nil
+	return coinIDs, outCoin, fee, nil
 }
 
 // scriptHashAddress returns a new p2sh address.
@@ -1945,6 +1987,27 @@ func (w *zecWallet) recyclableAddress() (string, error) {
 }
 
 func (w *zecWallet) Refund(ctx context.Context, coinID, contract dex.Bytes, feeRate uint64) (dex.Bytes, error) {
+	// Check broadcast cache for retry of a previously built transaction.
+	cacheKey := broadcast.RefundCacheKey(coinID)
+	if cached, ok := broadcast.RecoverFromCache(w.refundCache, cacheKey,
+		func(e *zecRefundCacheEntry) error { _, err := w.broadcastTx(ctx, e.signedTx); return err },
+		func(e *zecRefundCacheEntry) bool {
+			refundHash := e.signedTx.TxHash()
+			_, err := getWalletTransaction(w, &refundHash)
+			return err == nil
+		},
+		w.log, "Refund",
+	); ok {
+		refundHash := cached.signedTx.TxHash()
+		w.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.Refund,
+			ID:     refundHash.String(),
+			Amount: cached.refundVal,
+			Fees:   cached.fees,
+		}, &refundHash, true)
+		return cached.refundCoinID, nil
+	}
+
 	txHash, vout, err := decodeCoinID(coinID)
 	if err != nil {
 		return nil, err
@@ -1970,21 +2033,69 @@ func (w *zecWallet) Refund(ctx context.Context, coinID, contract dex.Bytes, feeR
 		return nil, fmt.Errorf("error creating refund tx: %w", err)
 	}
 
-	refundHash, err := w.broadcastTx(ctx, dexzec.NewTxFromMsgTx(msgTx, dexzec.MaxExpiryHeight))
+	zecRefundTx := zecTx(msgTx)
+	refundTxFees := zecRefundTx.RequiredTxFeesZIP317()
+	refundHash := zecRefundTx.TxHash()
+	refundCoinID := btc.ToCoinID(&refundHash, 0)
+
+	// Save to cache before broadcast for recovery on timeout/retry.
+	w.refundCache.Put(cacheKey, &zecRefundCacheEntry{
+		signedTx:     zecRefundTx,
+		refundCoinID: refundCoinID,
+		refundVal:    uint64(utxo.Value),
+		fees:         refundTxFees,
+		timestamp:    time.Now(),
+	})
+
+	_, err = w.broadcastTx(ctx, zecRefundTx)
 	if err != nil {
 		return nil, fmt.Errorf("broadcastTx: %w", err)
 	}
 
-	tx := zecTx(msgTx)
 	w.addTxToHistory(&asset.WalletTransaction{
 		Type:   asset.Refund,
 		ID:     refundHash.String(),
 		Amount: uint64(utxo.Value),
-		Fees:   tx.RequiredTxFeesZIP317(),
-	}, refundHash, true)
+		Fees:   refundTxFees,
+	}, &refundHash, true)
 
-	return btc.ToCoinID(refundHash, 0), nil
+	return refundCoinID, nil
 }
+
+type zecSwapCacheEntry struct {
+	signedTx   *dexzec.Tx
+	receipts   []asset.Receipt
+	change     *btc.Output
+	fees       uint64
+	totalOut   uint64
+	lockChange bool
+	changeLock *btc.UTxO // pre-built UTxO for LockUTXOs when LockChange is set
+	pts        []btc.OutPoint
+	timestamp  time.Time
+}
+
+func (e *zecSwapCacheEntry) Stamp() time.Time { return e.timestamp }
+
+type zecRedeemCacheEntry struct {
+	signedTx  *dexzec.Tx
+	coinIDs   []dex.Bytes
+	outCoin   *btc.Output
+	fees      uint64
+	totalIn   uint64
+	timestamp time.Time
+}
+
+func (e *zecRedeemCacheEntry) Stamp() time.Time { return e.timestamp }
+
+type zecRefundCacheEntry struct {
+	signedTx     *dexzec.Tx
+	refundCoinID dex.Bytes
+	refundVal    uint64
+	fees         uint64
+	timestamp    time.Time
+}
+
+func (e *zecRefundCacheEntry) Stamp() time.Time { return e.timestamp }
 
 // TODO: The ctx parameter is accepted but not threaded through to the
 // underlying RPC calls (sendRawTransaction, signTxByRPC, dumpPrivKey, etc.)
@@ -2001,6 +2112,11 @@ func (w *zecWallet) broadcastTx(ctx context.Context, tx *dexzec.Tx) (*chainhash.
 	}
 	txHash, err := sendRawTransaction(w, tx)
 	if err != nil {
+		if broadcast.IsAlreadyBroadcastErr(err) {
+			h := tx.TxHash()
+			w.log.Warnf("Transaction %s appears to already be broadcast: %v", h, err)
+			return &h, nil
+		}
 		return nil, fmt.Errorf("sendrawtx error: %v: %s", err, rawTx())
 	}
 	checkHash := tx.TxHash()
@@ -2372,6 +2488,41 @@ func (w *zecWallet) SignCoinMessage(coin asset.Coin, msg dex.Bytes) (pubkeys, si
 }
 
 func (w *zecWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Receipt, asset.Coin, uint64, error) {
+	// Check broadcast cache for retry of a previously built transaction.
+	cacheKey := broadcast.CoinIDsCacheKey(swaps.Inputs)
+	if cached, ok := broadcast.RecoverFromCache(w.swapCache, cacheKey,
+		func(e *zecSwapCacheEntry) error { _, err := w.broadcastTx(ctx, e.signedTx); return err },
+		func(e *zecSwapCacheEntry) bool {
+			txHash := e.signedTx.TxHash()
+			_, err := getWalletTransaction(w, &txHash)
+			return err == nil
+		},
+		w.log, "Swap",
+	); ok {
+		txHash := cached.signedTx.TxHash()
+		w.addTxToHistory(&asset.WalletTransaction{
+			Type:   asset.Swap,
+			ID:     txHash.String(),
+			Amount: cached.totalOut,
+			Fees:   cached.fees,
+		}, &txHash, true)
+		var changeCoin asset.Coin
+		if cached.change != nil {
+			changeCoin = cached.change
+		}
+		// Replicate post-broadcast coin manager bookkeeping.
+		if cached.changeLock != nil {
+			w.log.Debugf("locking change coin %s (from cache recovery)", cached.change)
+			err := lockUnspent(w, false, []*btc.Output{cached.change})
+			if err != nil {
+				w.log.Errorf("failed to lock change output: %v", err)
+			}
+			w.cm.LockUTXOs([]*btc.UTxO{cached.changeLock})
+		}
+		w.cm.UnlockOutPoints(cached.pts)
+		return cached.receipts, changeCoin, cached.fees, nil
+	}
+
 	contracts := make([][]byte, 0, len(swaps.Contracts))
 	var totalOut uint64
 	// Start with an empty MsgTx.
@@ -2493,6 +2644,35 @@ func (w *zecWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Recei
 		})
 	}
 
+	// Pre-build the change lock UTxO for caching if LockChange is set.
+	var changeLock *btc.UTxO
+	if change != nil && swaps.LockChange {
+		addrStr, err := dexzec.EncodeAddress(changeAddr, w.addrParams)
+		if err != nil {
+			w.log.Errorf("Failed to stringify address %v (default encoding): %v", changeAddr, err)
+			addrStr = changeAddr.String()
+		}
+		changeLock = &btc.UTxO{
+			TxHash:  &change.Pt.TxHash,
+			Vout:    change.Pt.Vout,
+			Address: addrStr,
+			Amount:  change.Val,
+		}
+	}
+
+	// Save to cache before broadcast for recovery on timeout/retry.
+	w.swapCache.Put(cacheKey, &zecSwapCacheEntry{
+		signedTx:   msgTx,
+		receipts:   receipts,
+		change:     change,
+		fees:       fees,
+		totalOut:   totalOut,
+		lockChange: swaps.LockChange,
+		changeLock: changeLock,
+		pts:        pts,
+		timestamp:  time.Now(),
+	})
+
 	// Refund txs prepared and signed. Can now broadcast the swap(s).
 	_, err = w.broadcastTx(ctx, msgTx)
 	if err != nil {
@@ -2512,7 +2692,7 @@ func (w *zecWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Recei
 		changeCoin = change
 	}
 
-	if swaps.LockChange && change != nil {
+	if changeLock != nil {
 		// Lock the change output
 		w.log.Debugf("locking change coin %s", change)
 		err = lockUnspent(w, false, []*btc.Output{change})
@@ -2520,18 +2700,7 @@ func (w *zecWallet) Swap(ctx context.Context, swaps *asset.Swaps) ([]asset.Recei
 			// The swap transaction is already broadcasted, so don't fail now.
 			w.log.Errorf("failed to lock change output: %v", err)
 		}
-
-		addrStr, err := dexzec.EncodeAddress(changeAddr, w.addrParams)
-		if err != nil {
-			w.log.Errorf("Failed to stringify address %v (default encoding): %v", changeAddr, err)
-			addrStr = changeAddr.String() // may or may not be able to retrieve the private keys for the next swap!
-		}
-		w.cm.LockUTXOs([]*btc.UTxO{{
-			TxHash:  &change.Pt.TxHash,
-			Vout:    change.Pt.Vout,
-			Address: addrStr,
-			Amount:  change.Val,
-		}})
+		w.cm.LockUTXOs([]*btc.UTxO{changeLock})
 	}
 
 	w.cm.UnlockOutPoints(pts)

--- a/client/asset/zec/zec_test.go
+++ b/client/asset/zec/zec_test.go
@@ -1044,8 +1044,13 @@ func TestSwap(t *testing.T) {
 	}
 	swaps.Inputs = coins
 
-	// Make sure we can succeed again.
-	queueSuccess()
+	// Make sure we can succeed again. The first successful swap cached
+	// the result, so RecoverFromCache will rebroadcast and return early.
+	cl.queueResponse("sendrawtransaction", func(args []json.RawMessage) (json.RawMessage, error) {
+		rawSent = true
+		tx, _ := signRawJSONTx(args[0])
+		return json.Marshal(tx.TxHash().String())
+	})
 	_, _, _, err = w.Swap(t.Context(), swaps)
 	if err != nil {
 		t.Fatalf("re-swap error: %v", err)

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -267,15 +267,12 @@ const (
 	// existing retry logic (suspectSwap / suspectRedeem) will re-attempt
 	// the operation on the next tick.
 	//
-	// NOTE: For UTXO wallets, a retry after a successful-but-timed-out
-	// broadcast will build a different transaction (new change address)
-	// with the same inputs, which the node will reject as a double-spend.
-	// The original transaction will still confirm, but the match state
-	// won't be updated with the receipts. The match will be marked with
-	// swapErr after exhausting retries. The BTC SPV wallet mitigates this
-	// by checking for a completed publish before returning a context error.
-	// ETH Redeem and Refund are safe (idempotent state checks), but ETH
-	// Swap lacks an AlreadyInitialized pre-check.
+	// UTXO wallets (BTC, DCR, ZEC) cache the signed transaction before
+	// broadcast. On retry, the cached transaction is rebroadcast instead
+	// of building a new one, and "already in mempool" errors are treated
+	// as success. ETH wallets check on-chain contract state on retry
+	// (AlreadyInitialized for Swap, SSRedeemed for Redeem) and return
+	// early if the operation already completed.
 	walletCallTimeout = 45 * time.Second
 )
 


### PR DESCRIPTION
depends on #3514

The 45-second walletCallTimeout can fire after a wallet has already
broadcast a transaction. On retry, UTXO wallets build a different tx
(new change address) with the same inputs, which gets rejected as a
double-spend. ETH Swap doesn't check on-chain state before calling
initiate(), wasting gas on a duplicate the contract rejects.

BTC, ZEC, DCR: Add isAlreadyBroadcastErr() to treat "already in
mempool/blockchain" responses as success in broadcastTx, computing
the tx hash locally and returning it with a warning log.

BTC, ZEC, DCR: Add broadcast result cache for Swap/Redeem/Refund.
Before broadcasting, cache the signed tx and all return values keyed
by sorted input outpoints (or coinID for Refund). On retry with the
same inputs, rebroadcast the cached tx instead of building a new one.
Combined with the error filtering, a cached tx that's already in the
mempool returns success. Falls back to GetWalletTransaction to recover
confirmed transactions. Entries expire after 10 minutes.

ETH: Add AlreadyInitialized pre-check in both ETHWallet.Swap and
TokenWallet.Swap. Before calling initiate(), check each contract
on-chain. If all are already initiated, return receipts with zero
txHash matching the existing idempotent pattern used in Refund.