### PR TITLE
eth: Add L1 fee support for OP Stack L2s.

### DIFF
--- a/client/asset/base/base.go
+++ b/client/asset/base/base.go
@@ -4,7 +4,6 @@
 package base
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -97,9 +96,6 @@ type Driver struct{}
 
 // Open opens the Base exchange wallet. Start the wallet with its Run method.
 func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, net dex.Network) (asset.Wallet, error) {
-	if net == dex.Mainnet {
-		return nil, errors.New("base is disable until we get L1 security fees worked out")
-	}
 	chainCfg, err := ChainConfig(net)
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate Base genesis configuration for network %s", net)
@@ -154,6 +150,7 @@ func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, net dex.Networ
 		Net:                net,
 		DefaultProviders:   defaultProviders,
 		MaxTxFeeGwei:       dexeth.GweiFactor, // 1 ETH
+		IsOpStack:          true,
 	})
 }
 

--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -338,6 +338,14 @@ func (n *testNode) nonce(ctx context.Context) (*big.Int, *big.Int, error) {
 	return big.NewInt(0), big.NewInt(1), nil
 }
 
+func (n *testNode) l1FeeForCalldata(ctx context.Context, calldata []byte) (*big.Int, error) {
+	return new(big.Int), nil
+}
+
+func (n *testNode) l1FeeFromReceipt(ctx context.Context, txHash common.Hash) (*big.Int, error) {
+	return new(big.Int), nil
+}
+
 func (n *testNode) setBalanceError(w *assetWallet, err error) {
 	n.balErr = err
 	n.tokenContractor.balErr = err
@@ -499,6 +507,18 @@ func (c *tContractor) estimateRedeemGas(ctx context.Context, secrets [][32]byte,
 
 func (c *tContractor) estimateRefundGas(ctx context.Context, locator []byte) (uint64, error) {
 	return c.gasEstimates.Refund, c.refundGasErr
+}
+
+func (c *tContractor) packInitiateData(n int) ([]byte, error) {
+	return make([]byte, 100*n), nil // representative-sized calldata
+}
+
+func (c *tContractor) packRedeemData(n int) ([]byte, error) {
+	return make([]byte, 100*n), nil
+}
+
+func (c *tContractor) packRefundData() ([]byte, error) {
+	return make([]byte, 100), nil
 }
 
 func (c *tContractor) isRedeemable(locator []byte, secret [32]byte) (bool, error) {

--- a/client/asset/eth/l1fees.go
+++ b/client/asset/eth/l1fees.go
@@ -1,0 +1,94 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package eth
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// gasPriceOracleAddr is the OP Stack GasPriceOracle precompile address.
+// See https://docs.optimism.io/chain/addresses
+var gasPriceOracleAddr = common.HexToAddress("0x420000000000000000000000000000000000000F")
+
+// gasPriceOracleABI is the minimal ABI for the OP Stack GasPriceOracle's
+// getL1Fee method: getL1Fee(bytes) returns (uint256).
+var gasPriceOracleABI *abi.ABI
+
+func init() {
+	const abiJSON = `[{"inputs":[{"internalType":"bytes","name":"_data","type":"bytes"}],"name":"getL1Fee","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]`
+	parsed, err := abi.JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse GasPriceOracle ABI: %v", err))
+	}
+	gasPriceOracleABI = &parsed
+}
+
+// wrapCalldata wraps the given calldata in a dummy DynamicFeeTx and returns
+// the RLP-encoded transaction. The OP Stack GasPriceOracle.getL1Fee expects
+// the full RLP-encoded transaction, not just the calldata, because the L1 fee
+// is based on the total serialized size including the transaction envelope.
+// A zero ChainID is used because getL1Fee only cares about the serialized
+// size, not the chain — the size difference from ChainID encoding is negligible.
+func wrapCalldata(calldata []byte) ([]byte, error) {
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   big.NewInt(0),
+		Nonce:     0,
+		GasTipCap: big.NewInt(0),
+		GasFeeCap: big.NewInt(0),
+		Gas:       0,
+		To:        &common.Address{},
+		Value:     big.NewInt(0),
+		Data:      calldata,
+	})
+	return tx.MarshalBinary()
+}
+
+// l1FeeForCalldata calls the OP Stack GasPriceOracle precompile to estimate
+// the L1 fee for a transaction with the given calldata. The calldata is wrapped
+// in a dummy RLP-encoded transaction before being passed to getL1Fee, which
+// expects the full serialized transaction.
+// NOTE: getL1Fee is deprecated since the Ecotone upgrade (March 2024) in
+// favor of getL1FeeUpperBound, but is still populated for backwards
+// compatibility. If it is removed in a future upgrade, this function will
+// return an error.
+func l1FeeForCalldata(ctx context.Context, cb bind.ContractBackend, calldata []byte) (*big.Int, error) {
+	rawTx, err := wrapCalldata(calldata)
+	if err != nil {
+		return nil, fmt.Errorf("error wrapping calldata in dummy tx: %w", err)
+	}
+	data, err := gasPriceOracleABI.Pack("getL1Fee", rawTx)
+	if err != nil {
+		return nil, fmt.Errorf("error packing getL1Fee: %w", err)
+	}
+
+	result, err := cb.CallContract(ctx, ethereum.CallMsg{
+		To:   &gasPriceOracleAddr,
+		Data: data,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error calling GasPriceOracle.getL1Fee: %w", err)
+	}
+
+	out, err := gasPriceOracleABI.Unpack("getL1Fee", result)
+	if err != nil {
+		return nil, fmt.Errorf("error unpacking getL1Fee result: %w", err)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("empty result from getL1Fee")
+	}
+	fee, ok := out[0].(*big.Int)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type %T for getL1Fee result", out[0])
+	}
+	return fee, nil
+}


### PR DESCRIPTION
closes #3434

Base chain is an OP Stack L2 where every transaction pays both an L2 execution fee and an L1 security fee for posting calldata to Ethereum. This adds L1 fee estimation via the GasPriceOracle precompile at 0x420...0F, integrates it into all fee calculation paths (maxOrder, FundOrder, estimateSwap, PreRedeem, SingleLotSwapRefundFees, SingleLotRedeemFees, canSend, StandardSendFee, Redeem), and reports actual L1 fees from receipts in updatePendingTx and swapOrRedemptionFeesPaidOnChainTx.

- Add IsOpStack flag to EVMWalletConfig and baseWallet
- New l1fees.go with GasPriceOracle ABI and l1FeeForCalldata helper
- Add l1FeeForCalldata/l1FeeFromReceipt to ethFetcher and multiRPCClient
- Add packInitiateData/packRedeemData/packRefundData to contractor interface for calldata size estimation
- Add per-block cached l1FeesForOps and sendL1Fee methods on baseWallet
- Extend gasEstimate with swapL1Fee, redeemL1Fee, refundL1Fee fields
- Remove mainnet disable guard from Base and set IsOpStack: true