### PR TITLE
dex/testing: Add more info about required harness execs

### DIFF
--- a/dex/testing/btc/README.md
+++ b/dex/testing/btc/README.md
@@ -23,6 +23,8 @@ outputs, but has a number of UTXOs of varying size and confirmation count.
 You must have [bitcoind and bitcoin-cli](https://github.com/bitcoin/bitcoin/releases)
 in `PATH` to use the harness. Bitcoin Core v26.0.0+ is recommended. v30+ is fully supported.
 
+To get `bitcoind` and `bitcoin-cli`, you must download only a `.tar.gz` for the operating system you choose. Then extract the `.tar.gz` file to find the `bin` folder and add the `bin` folder to `PATH`.
+
 It also requires tmux.
 
 ## Harness control scripts

--- a/dex/testing/dcr/README.md
+++ b/dex/testing/dcr/README.md
@@ -11,6 +11,12 @@ The harness depends on [dcrd](https://github.com/decred/dcrd), [dcrwallet](https
 
 You must have `dcrd` `dcrwallet` and `dcrctl` in `PATH` to use the harness.
 
+All of the above can be downloaded at once from [Decred Binaries Release Page](https://github.com/decred/decred-binaries/releases).
+
+Download the `Decred-{os}-{architecture}-{version}` file with a `.tar.gz` extension and extract it to find all the executables you need. 
+
+Then add the path to those executables in `PATH`.
+
 The harness script will create two connected simnet nodes and wallets, and
 then mine some blocks and send some regular transactions. The result is a set of
 wallets named **alpha** and **beta**, each with slightly different properties.


### PR DESCRIPTION
Going through the DCR and BTC harness again and it becomes easy to get confuse about where to get the required execs for the harness, esp for btc.

This PR adds more info about which file actually contains the required btc harness exec and also for dcr. 