### PR TITLE
client/asset/btc: Add SPV rescan stall detection and recovery.

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -170,6 +170,7 @@ type testData struct {
 	ownedAddresses    map[string]bool
 	ownsAddress       bool
 	locked            bool
+	noPeers           bool
 }
 
 func newTestData() *testData {
@@ -666,7 +667,7 @@ func tNewWallet(segwit bool, walletType string) (*intermediaryWallet, *testData,
 			spvw := &spvWallet{
 				chainParams: &chaincfg.MainNetParams,
 				cfg:         &WalletConfig{},
-				wallet:      &tBtcWallet{data},
+				wallet:      &tBtcWallet{testData: data},
 				cl:          neutrinoClient,
 				tipChan:     make(chan *BlockVector, 1),
 				acctNum:     0,

--- a/client/asset/btc/spv_test.go
+++ b/client/asset/btc/spv_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -37,6 +38,9 @@ import (
 
 type tBtcWallet struct {
 	*testData
+	walletSyncHeight atomic.Pointer[int32] // override SyncedTo height when non-nil
+	rescanCalled     atomic.Bool
+	rescanErr        error
 }
 
 func (c *tBtcWallet) ListSinceBlock(start, end, syncHeight int32) ([]btcjson.ListTransactionsResult, error) {
@@ -293,6 +297,24 @@ func (c *tBtcWallet) WalletTransaction(txHash *chainhash.Hash) (*wtxmgr.TxDetail
 }
 
 func (c *tBtcWallet) SyncedTo() waddrmgr.BlockStamp {
+	if hp := c.walletSyncHeight.Load(); hp != nil {
+		h := *hp
+		// Return a stamp at the overridden height. Find the block at that
+		// height if it exists, otherwise use a zero hash/timestamp.
+		c.blockchainMtx.RLock()
+		defer c.blockchainMtx.RUnlock()
+		for height, hash := range c.mainchain {
+			if int32(height) == h {
+				blk := c.verboseBlocks[*hash]
+				return waddrmgr.BlockStamp{
+					Height:    h,
+					Hash:      *hash,
+					Timestamp: blk.msgBlock.Header.Timestamp,
+				}
+			}
+		}
+		return waddrmgr.BlockStamp{Height: h}
+	}
 	bestHash, bestHeight := c.bestBlock() // NOTE: in reality this may be lower than the chain service's best block
 	blk := c.getBlock(*bestHash)
 	return waddrmgr.BlockStamp{
@@ -323,10 +345,13 @@ func (c *tBtcWallet) BlockNotifications(ctx context.Context) <-chan *BlockNotifi
 
 func (c *tBtcWallet) ForceRescan() {}
 
-func (c *tBtcWallet) RescanAsync() error { return nil }
+func (c *tBtcWallet) RescanAsync() error {
+	c.rescanCalled.Store(true)
+	return c.rescanErr
+}
 
 func (c *tBtcWallet) Birthday() time.Time {
-	return time.Time{}
+	return c.birthdayTime
 }
 
 func (c *tBtcWallet) Reconfigure(*asset.WalletConfig, string) (bool, error) {
@@ -383,6 +408,9 @@ func (c *tNeutrinoClient) BestBlock() (*headerfs.BlockStamp, error) {
 func (c *tNeutrinoClient) Peers() []SPVPeer {
 	c.blockchainMtx.RLock()
 	defer c.blockchainMtx.RUnlock()
+	if c.noPeers {
+		return nil
+	}
 	peer := &neutrino.ServerPeer{Peer: &peer.Peer{}}
 	if c.getBlockchainInfo != nil {
 		peer.UpdateLastBlockHeight(int32(c.getBlockchainInfo.Headers))
@@ -913,4 +941,211 @@ func TestGetBlockHeader(t *testing.T) {
 		t.Fatalf("confirmations not zero for lower mainchain tip height, got: %d", hdr.Confirmations)
 	}
 	node.mainchain = prevMainchain // clean up
+}
+
+func TestCheckRescanStall(t *testing.T) {
+	data := newTestData()
+	btcWallet := &tBtcWallet{testData: data}
+	neutrinoClient := &tNeutrinoClient{data}
+	spvw := &spvWallet{
+		chainParams: &chaincfg.MainNetParams,
+		cfg:         &WalletConfig{},
+		wallet:      btcWallet,
+		cl:          neutrinoClient,
+		tipChan:     make(chan *BlockVector, 1),
+		log:         dex.StdOutLogger("T", dex.LevelTrace),
+	}
+
+	// Build a chain of 20 blocks. Both chain service and wallet see the
+	// same chain by default (bestBlock returns the highest mainchain entry).
+	const tipHeight = 20
+	for i := int64(0); i <= tipHeight; i++ {
+		data.addRawTx(i, dummyTx())
+	}
+	// Need getBlockchainInfo for Peers() to work.
+	data.blockchainMtx.Lock()
+	data.getBlockchainInfo = &GetBlockchainInfoResult{
+		Headers: tipHeight,
+		Blocks:  tipHeight,
+	}
+	data.blockchainMtx.Unlock()
+
+	// Helper to set the wallet's SyncedTo override.
+	setWalletHeight := func(h int32) {
+		btcWallet.walletSyncHeight.Store(&h)
+	}
+	clearWalletHeight := func() {
+		btcWallet.walletSyncHeight.Store(nil)
+	}
+
+	// --- No stall when divergence < threshold ---
+	setWalletHeight(tipHeight - stallThreshold + 1) // divergence = stallThreshold-1
+	if spvw.checkRescanStall() {
+		t.Fatal("should not detect stall when divergence < threshold")
+	}
+
+	// --- No stall when wallet height is 0 (rescan in progress) ---
+	setWalletHeight(0)
+	if spvw.checkRescanStall() {
+		t.Fatal("should not detect stall when wallet height is 0")
+	}
+
+	// --- No stall before wallet birthday ---
+	// Set birthday to a time in the future relative to chain tip timestamp.
+	data.birthdayTime = time.Now().Add(time.Hour)
+	setWalletHeight(5)
+	if spvw.checkRescanStall() {
+		t.Fatal("should not detect stall before wallet birthday")
+	}
+	data.birthdayTime = time.Time{} // reset
+
+	// --- No stall with 0 peers ---
+	setWalletHeight(5) // divergence = 15, well above threshold
+	data.noPeers = true
+	if spvw.checkRescanStall() {
+		t.Fatal("should not detect stall with 0 peers")
+	}
+	data.noPeers = false
+
+	// --- No stall when wallet is making progress ---
+	setWalletHeight(5)
+	spvw.lastWalletHeight.Store(4) // previous was 4, now 5 => progressing
+	if spvw.checkRescanStall() {
+		t.Fatal("should not detect stall when wallet is making progress")
+	}
+	if spvw.stallDetectedAt.Load() != 0 {
+		t.Fatal("stall timer should be cleared when wallet is progressing")
+	}
+
+	// --- Stall detected but not confirmed until stallConfirmationTime ---
+	// Reset state.
+	spvw.lastWalletHeight.Store(0)
+	spvw.stallDetectedAt.Store(0)
+	setWalletHeight(5) // divergence = 15
+
+	// First call: should notice the divergence and record timestamp.
+	if spvw.checkRescanStall() {
+		t.Fatal("should not trigger rescan on first detection")
+	}
+	firstSeen := spvw.stallDetectedAt.Load()
+	if firstSeen == 0 {
+		t.Fatal("stallDetectedAt should be set after first detection")
+	}
+
+	// Second call shortly after: should not trigger yet.
+	if spvw.checkRescanStall() {
+		t.Fatal("should not trigger rescan before confirmation time elapses")
+	}
+	if btcWallet.rescanCalled.Load() {
+		t.Fatal("RescanAsync should not have been called yet")
+	}
+
+	// --- Stall confirmed after stallConfirmationTime → RescanAsync called ---
+	// Simulate the confirmation time having elapsed by backdating firstSeen.
+	spvw.stallDetectedAt.Store(time.Now().Add(-stallConfirmationTime - time.Second).Unix())
+	btcWallet.rescanCalled.Store(false)
+
+	if !spvw.checkRescanStall() {
+		t.Fatal("should trigger rescan after confirmation time")
+	}
+	if !btcWallet.rescanCalled.Load() {
+		t.Fatal("RescanAsync should have been called")
+	}
+	// State should be reset after triggering rescan.
+	if spvw.stallDetectedAt.Load() != 0 {
+		t.Fatal("stallDetectedAt should be reset after rescan")
+	}
+	if spvw.lastWalletHeight.Load() != 0 {
+		t.Fatal("lastWalletHeight should be reset after rescan")
+	}
+
+	// --- lastWalletHeight reset when divergence drops below threshold ---
+	// Simulate: wallet was stalled at height 5, then catches up to tip.
+	// lastWalletHeight should be cleared so that a future stall is not
+	// confused by the old value.
+	spvw.lastWalletHeight.Store(5)
+	spvw.stallDetectedAt.Store(time.Now().Unix())
+	clearWalletHeight() // wallet == chain tip, divergence = 0
+	if spvw.checkRescanStall() {
+		t.Fatal("should not detect stall when wallet caught up")
+	}
+	if spvw.lastWalletHeight.Load() != 0 {
+		t.Fatal("lastWalletHeight should be reset when divergence drops below threshold")
+	}
+	if spvw.stallDetectedAt.Load() != 0 {
+		t.Fatal("stallDetectedAt should be reset when divergence drops below threshold")
+	}
+
+	// --- Cooldown prevents rapid re-triggering ---
+	// Set up a confirmed stall, but with a recent lastRescanAt.
+	spvw.lastWalletHeight.Store(0)
+	spvw.stallDetectedAt.Store(0)
+	spvw.lastRescanAt.Store(time.Now().Unix()) // just rescanned
+	setWalletHeight(5)                         // divergence = 15
+
+	// First call records the stall.
+	if spvw.checkRescanStall() {
+		t.Fatal("should not trigger during first detection even with cooldown")
+	}
+	// Backdate stallDetectedAt to exceed confirmation time.
+	spvw.stallDetectedAt.Store(time.Now().Add(-stallConfirmationTime - time.Second).Unix())
+	btcWallet.rescanCalled.Store(false)
+
+	if spvw.checkRescanStall() {
+		t.Fatal("should not trigger rescan during cooldown period")
+	}
+	if btcWallet.rescanCalled.Load() {
+		t.Fatal("RescanAsync should not have been called during cooldown")
+	}
+
+	// Backdate lastRescanAt to exceed cooldown.
+	spvw.lastRescanAt.Store(time.Now().Add(-stallRescanCooldown - time.Second).Unix())
+	// Re-backdate stallDetectedAt since the previous call didn't reset it.
+	spvw.stallDetectedAt.Store(time.Now().Add(-stallConfirmationTime - time.Second).Unix())
+
+	if !spvw.checkRescanStall() {
+		t.Fatal("should trigger rescan after cooldown expires")
+	}
+	if !btcWallet.rescanCalled.Load() {
+		t.Fatal("RescanAsync should have been called after cooldown")
+	}
+
+	// --- RescanAsync error: still returns true and resets state ---
+	spvw.lastWalletHeight.Store(0)
+	spvw.stallDetectedAt.Store(0)
+	spvw.lastRescanAt.Store(0)
+	setWalletHeight(5)
+	btcWallet.rescanCalled.Store(false)
+	btcWallet.rescanErr = fmt.Errorf("test rescan error")
+
+	// First call records the stall.
+	spvw.checkRescanStall()
+	// Backdate to exceed confirmation time.
+	spvw.stallDetectedAt.Store(time.Now().Add(-stallConfirmationTime - time.Second).Unix())
+
+	if !spvw.checkRescanStall() {
+		t.Fatal("should trigger rescan even when RescanAsync returns error")
+	}
+	if !btcWallet.rescanCalled.Load() {
+		t.Fatal("RescanAsync should have been called")
+	}
+	if spvw.stallDetectedAt.Load() != 0 {
+		t.Fatal("stallDetectedAt should be reset even on RescanAsync error")
+	}
+	if spvw.lastWalletHeight.Load() != 0 {
+		t.Fatal("lastWalletHeight should be reset even on RescanAsync error")
+	}
+	if spvw.lastRescanAt.Load() == 0 {
+		t.Fatal("lastRescanAt should be set even on RescanAsync error")
+	}
+	btcWallet.rescanErr = nil // reset
+
+	// --- No stall when wallet and chain are in sync ---
+	clearWalletHeight()
+	spvw.stallDetectedAt.Store(0)
+	spvw.lastWalletHeight.Store(0)
+	spvw.lastRescanAt.Store(0)
+	if spvw.checkRescanStall() {
+		t.Fatal("should not detect stall when wallet is synced")
+	}
 }

--- a/client/asset/btc/spv_wrapper.go
+++ b/client/asset/btc/spv_wrapper.go
@@ -202,6 +202,20 @@ func extendAddresses(extIdx, intIdx uint32, btcw *wallet.Wallet) error {
 	})
 }
 
+const (
+	// stallThreshold is the chain-vs-wallet block divergence that must be
+	// exceeded before suspecting a rescan stall (~1 hr at BTC's block rate).
+	stallThreshold = 6
+	// stallConfirmationTime is how long the divergence must persist before
+	// triggering a rescan.
+	stallConfirmationTime = 10 * time.Minute
+	// stallCheckInterval is how often the nanny goroutine checks for stalls.
+	stallCheckInterval = time.Minute
+	// stallRescanCooldown is the minimum time between rescan triggers to
+	// prevent rapid re-triggering if RescanAsync doesn't fix the stall.
+	stallRescanCooldown = 30 * time.Minute
+)
+
 // spvWallet is an in-process btcwallet.Wallet + neutrino light-filter-based
 // Bitcoin wallet. spvWallet controls an instance of btcwallet.Wallet directly
 // and does not run or connect to the RPC server.
@@ -220,6 +234,15 @@ type spvWallet struct {
 	tipChan            chan *BlockVector
 	syncTarget         int32
 	lastPrenatalHeight int32
+
+	// Stall detection: lastWalletHeight is the wallet's SyncedTo height
+	// observed on the previous check. stallDetectedAt is the unix timestamp
+	// when divergence was first noticed (0 means not stalled).
+	// lastRescanAt is the unix timestamp of the last rescan trigger, used
+	// to enforce a cooldown between rescans.
+	lastWalletHeight atomic.Int32
+	stallDetectedAt  atomic.Int64
+	lastRescanAt     atomic.Int64
 
 	*BlockFiltersScanner
 }
@@ -922,6 +945,98 @@ func (w *spvWallet) logFilePath() string {
 	return filepath.Join(w.dir, logDirName, logFileName)
 }
 
+// checkRescanStall detects and recovers from a neutrino bug where the rescan
+// goroutine silently dies on a peer timeout during block fetching (specifically
+// in catchup mode). When this happens, both notification and polling paths go
+// permanently dead: BlockNotifications() stops producing events because the
+// rescan is dead, and watchBlocks() polling via GetBestBlockHash() calls
+// wallet.SyncedTo() which never advances. Meanwhile, the chain service
+// (w.cl.BestBlock()) continues syncing headers normally, so the data to detect
+// the stall already exists — it's just never compared.
+//
+// A proper upstream fix requires changes in both neutrino and btcwallet.
+// This method is defense-in-depth: it compares chain service height
+// against wallet SyncedTo height, and if the divergence exceeds stallThreshold
+// and persists for stallConfirmationTime with no wallet progress, triggers a
+// rescan to recover.
+func (w *spvWallet) checkRescanStall() bool {
+	chainStamp, err := w.cl.BestBlock()
+	if err != nil || chainStamp.Height == 0 {
+		return false
+	}
+
+	// Don't flag a stall if the chain tip is before the wallet's birthday.
+	// The wallet is expected to not process those blocks.
+	if bday := w.wallet.Birthday(); !bday.IsZero() && chainStamp.Timestamp.Before(bday) {
+		return false
+	}
+
+	walletStamp := w.wallet.SyncedTo()
+	walletHeight := walletStamp.Height
+	if walletHeight == 0 {
+		// Wallet hasn't started processing blocks yet (possibly a rescan
+		// is already in progress). Don't interfere.
+		return false
+	}
+
+	if len(w.cl.Peers()) == 0 {
+		return false
+	}
+
+	if walletHeight >= chainStamp.Height {
+		w.stallDetectedAt.Store(0)
+		w.lastWalletHeight.Store(0)
+		return false
+	}
+
+	divergence := chainStamp.Height - walletHeight
+	if divergence <= stallThreshold {
+		// Wallet is keeping up (or close enough). Clear any stall state.
+		w.stallDetectedAt.Store(0)
+		w.lastWalletHeight.Store(0)
+		return false
+	}
+
+	prevHeight := w.lastWalletHeight.Swap(walletHeight)
+	if walletHeight > prevHeight && prevHeight != 0 {
+		// Wallet is making progress, just behind. Reset the timer.
+		w.stallDetectedAt.Store(0)
+		return false
+	}
+
+	now := time.Now().Unix()
+	firstSeen := w.stallDetectedAt.Load()
+	if firstSeen == 0 {
+		// First time noticing the divergence.
+		w.log.Warnf("Possible rescan stall detected: chain height %d, wallet height %d (divergence %d blocks)",
+			chainStamp.Height, walletHeight, divergence)
+		w.stallDetectedAt.Store(now)
+		return false
+	}
+
+	stalledFor := time.Since(time.Unix(firstSeen, 0))
+	if stalledFor < stallConfirmationTime {
+		return false
+	}
+
+	// Stall confirmed. Enforce cooldown to prevent rapid re-triggering.
+	if lastRescan := w.lastRescanAt.Load(); lastRescan != 0 {
+		if time.Since(time.Unix(lastRescan, 0)) < stallRescanCooldown {
+			return false
+		}
+	}
+
+	w.log.Errorf("Rescan stall confirmed (chain height %d, wallet height %d, stalled for %s). Triggering rescan.",
+		chainStamp.Height, walletHeight, stalledFor)
+	if err := w.wallet.RescanAsync(); err != nil {
+		w.log.Errorf("RescanAsync error: %v", err)
+	}
+	w.stallDetectedAt.Store(0)
+	w.lastWalletHeight.Store(0)
+	w.lastRescanAt.Store(now)
+	return true
+}
+
 // Connect will start the wallet and begin syncing.
 func (w *spvWallet) Connect(ctx context.Context, wg *sync.WaitGroup) (err error) {
 	w.cl, err = w.wallet.Start()
@@ -939,13 +1054,24 @@ func (w *spvWallet) Connect(ctx context.Context, wg *sync.WaitGroup) (err error)
 
 		ticker := time.NewTicker(time.Minute * 20)
 		defer ticker.Stop()
+
+		stallTicker := time.NewTicker(stallCheckInterval)
+		defer stallTicker.Stop()
+
 		expiration := time.Hour * 2
 		for {
 			select {
 			case <-ticker.C:
 				w.BlockFiltersScanner.CleanCaches(expiration)
 
+			case <-stallTicker.C:
+				w.checkRescanStall()
+
 			case blk := <-blockNotes:
+				// Block received from the wallet's rescan — it's alive.
+				w.stallDetectedAt.Store(0)
+				w.lastWalletHeight.Store(0)
+
 				syncTarget := atomic.LoadInt32(&w.syncTarget)
 				if syncTarget == 0 || (blk.Height < syncTarget && blk.Height%10_000 != 0) {
 					continue


### PR DESCRIPTION
When neutrino's rescan goroutine dies (e.g., peer timeout during block fetch), the BTC SPV wallet permanently stops processing blocks. Add defense-in-depth stall detection to the Connect() nanny goroutine that compares the chain service height against the wallet's SyncedTo height. If the divergence exceeds 6 blocks and persists for 10 minutes with no wallet progress, a rescan is triggered to recover. A proper upstream fix requires changes in both neutrino and btcwallet. Since LTC and BCH SPV wallets share spvWallet, they get this protection automatically.

closes #2899