### PR TITLE
client/mm: Fix unclickable rebalance settings for saved CEX bots.

### DIFF
--- a/client/webserver/site/src/js/mmsettings/utils/BotConfig.ts
+++ b/client/webserver/site/src/js/mmsettings/utils/BotConfig.ts
@@ -409,19 +409,23 @@ export async function botConfigStateFromSavedConfig (
     quoteBridgeFeesAndLimits
   )
 
+  const autoRebalance = savedBotConfig.autoRebalance
+    ? {
+        ...savedBotConfig.autoRebalance,
+        minBaseTransfer: Math.max(savedBotConfig.autoRebalance.minBaseTransfer, baseMinWithdraw),
+        minQuoteTransfer: Math.max(savedBotConfig.autoRebalance.minQuoteTransfer, quoteMinWithdraw)
+      }
+    : savedBotConfig.cexName
+      ? { minBaseTransfer: baseMinWithdraw, minQuoteTransfer: quoteMinWithdraw, internalOnly: true }
+      : undefined
+
   const config: BotConfig = {
     ...savedBotConfig,
     cexBaseID,
     cexQuoteID,
     baseBridgeName,
     quoteBridgeName,
-    autoRebalance: savedBotConfig.autoRebalance
-      ? {
-          ...savedBotConfig.autoRebalance,
-          minBaseTransfer: Math.max(savedBotConfig.autoRebalance.minBaseTransfer, baseMinWithdraw),
-          minQuoteTransfer: Math.max(savedBotConfig.autoRebalance.minQuoteTransfer, quoteMinWithdraw)
-        }
-      : undefined
+    autoRebalance
   }
 
   let intermediateAsset: number | null = null


### PR DESCRIPTION
When loading a saved bot config that lacked an autoRebalance field, the rebalance settings tab was shown but the radio buttons were inoperable. Initialize autoRebalance with defaults when cexName is set but autoRebalance is missing from the saved config.