### PR TITLE
client/asset/btc: Fix data race on mainchain map in TestSyncStatus.

### DIFF
--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -4428,7 +4428,9 @@ func testSyncStatus(t *testing.T, segwit bool, walletType string) {
 	// spv
 	blkHash, msgBlock := node.addRawTx(100, dummyTx())
 	node.birthdayTime = msgBlock.Header.Timestamp.Add(-time.Minute) // SPV, wallet birthday is passed
-	node.mainchain[100] = blkHash                                   // SPV, actually has to reach target
+	node.blockchainMtx.Lock()
+	node.mainchain[100] = blkHash // SPV, actually has to reach target
+	node.blockchainMtx.Unlock()
 
 	ss, err := wallet.SyncStatus()
 	if err != nil {
@@ -4444,8 +4446,8 @@ func testSyncStatus(t *testing.T, segwit bool, walletType string) {
 	node.getBlockchainInfoErr = tErr // rpc
 	node.blockchainMtx.Lock()
 	node.getBestBlockHashErr = tErr // spv BestBlock()
+	delete(node.mainchain, 100)     // force spv to BestBlock() with no wallet block
 	node.blockchainMtx.Unlock()
-	delete(node.mainchain, 100) // force spv to BestBlock() with no wallet block
 	_, err = wallet.SyncStatus()
 	if err == nil {
 		t.Fatalf("SyncStatus error not propagated")


### PR DESCRIPTION
Protect mainchain map writes/deletes with blockchainMtx in testSyncStatus to prevent racing with the background watchBlocks goroutine that iterates the map under RLock.

fixes test error seen in #3538

https://github.com/decred/dcrdex/actions/runs/22472915727/job/65093767077?pr=3538