### PR TITLE
multi: Route outgoing connections through Tor.

### DIFF
--- a/client/asset/btc/electrum.go
+++ b/client/asset/btc/electrum.go
@@ -67,6 +67,7 @@ func ElectrumWallet(cfg *BTCCloneCFG) (*ExchangeWalletElectrum, error) {
 		addrStringer: cfg.AddressStringer,
 		segwit:       cfg.Segwit,
 		rpcCfg:       rpcCfg,
+		torProxy:     cfg.WalletCFG.TorProxy,
 	})
 	btc.setNode(ew)
 

--- a/client/asset/btc/electrum_client.go
+++ b/client/asset/btc/electrum_client.go
@@ -80,6 +80,7 @@ type electrumWallet struct {
 	wallet      electrumWalletClient
 	chainV      atomic.Value // electrumNetworkClient
 	segwit      bool
+	torProxy    string
 
 	// ctx is set on connect, and used in asset.Wallet and btc.Wallet interface
 	// method implementations that have no ctx arg yet (refactoring TODO).
@@ -109,6 +110,7 @@ type electrumWalletConfig struct {
 	addrStringer dexbtc.AddressStringer
 	segwit       bool // indicates if segwit addresses are expected from requests
 	rpcCfg       *RPCConfig
+	torProxy     string
 }
 
 func newElectrumWallet(ew electrumWalletClient, cfg *electrumWalletConfig) *electrumWallet {
@@ -131,6 +133,7 @@ func newElectrumWallet(ew electrumWalletClient, cfg *electrumWalletConfig) *elec
 		stringAddr:  addrStringer,
 		wallet:      ew,
 		segwit:      cfg.segwit,
+		torProxy:    cfg.torProxy,
 		// TODO: remove this when all interface methods are given a Context. In
 		// the meantime, init with a valid sentry context until connect().
 		ctx: context.TODO(),
@@ -215,7 +218,7 @@ func (ew *electrumWallet) Connect(ctx context.Context, wg *sync.WaitGroup) error
 			return "", nil, fmt.Errorf("no suitable address for host %q: %w", host, err)
 		}
 		srvOpts = &electrum.ConnectOpts{
-			// TorProxy: TODO
+			TorProxy:    ew.torProxy,
 			TLSConfig:   tlsConfig, // may be nil if not ssl host
 			DebugLogger: ew.log.Debugf,
 		}

--- a/client/asset/btc/spv.go
+++ b/client/asset/btc/spv.go
@@ -163,6 +163,8 @@ func (w *btcSPVWallet) Start() (SPVService, error) {
 	}
 	errCloser.Add(w.neutrinoDB.Close)
 
+	// TODO: Route SPV peer connections through Tor when TorProxy is
+	// configured. Requires upstream library support.
 	w.log.Debug("Starting neutrino chain service...")
 	w.cl, err = neutrino.NewChainService(neutrino.Config{
 		DataDir:       w.dir,

--- a/client/asset/dcr/dcr.go
+++ b/client/asset/dcr/dcr.go
@@ -6743,6 +6743,8 @@ func (dcr *ExchangeWallet) startPoliteia(ctx context.Context) {
 
 	// Create the Politeia instance outside the lock to avoid blocking readers
 	// (PoliteiaDetails, ProposalsAll, etc.) during filesystem I/O.
+	// TODO: Route Politeia requests through Tor when TorProxy is configured.
+	// The upstream piclient.Opts does not accept a custom http.Client.
 	p, err := pi.New(ctx, pi.PoliteiaMainnetHost, filepath.Join(dcr.walletDir, "politeia"), dcr.log.SubLogger("Politeia"))
 	if err != nil {
 		dcr.log.Errorf("failed to set up politeia: %v", err)

--- a/client/asset/dcr/spv.go
+++ b/client/asset/dcr/spv.go
@@ -1557,6 +1557,8 @@ func (w *spvWallet) newSpvSyncer() *spv.Syncer {
 	case wire.SimNet:
 		connectPeers = []string{"localhost:19560"}
 	}
+	// TODO: Route SPV peer connections through Tor when TorProxy is
+	// configured. Requires upstream library support.
 	addr := &net.TCPAddr{IP: net.ParseIP("::1"), Port: 0}
 	amgr := addrmgr.New(w.dir)
 	lp := p2p.NewLocalPeer(dcrw.ChainParams(), addr, amgr)

--- a/client/asset/driver.go
+++ b/client/asset/driver.go
@@ -38,6 +38,7 @@ type CreateWalletParams struct {
 	DataDir  string
 	Net      dex.Network
 	Logger   dex.Logger
+	TorProxy string
 }
 
 // Driver is the interface required of all exchange wallets.

--- a/client/asset/eth/bundler.go
+++ b/client/asset/eth/bundler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"decred.org/dcrdex/dex/dexnet"
 	"decred.org/dcrdex/dex/networks/eth/contracts/entrypoint"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -101,8 +102,14 @@ var _ bundler = (*rpcBundler)(nil)
 // newBundler creates a new bundler instance with the specified endpoint. If
 // the bundler does not support the specified entrypoint, or is not one of the
 // supported bundler implementations, an error is returned.
-func newBundler(ctx context.Context, endpoint string, entryPointAddr common.Address, backend bind.ContractCaller, getBaseFee func(ctx context.Context) (*big.Int, error)) (*rpcBundler, error) {
-	rpcClient, err := rpc.DialContext(ctx, endpoint)
+func newBundler(ctx context.Context, endpoint string, entryPointAddr common.Address, backend bind.ContractCaller, getBaseFee func(ctx context.Context) (*big.Int, error), torProxy string) (*rpcBundler, error) {
+	var rpcClient *rpc.Client
+	var err error
+	if torProxy != "" {
+		rpcClient, err = rpc.DialOptions(ctx, endpoint, rpc.WithHTTPClient(dexnet.ProxyHTTPClient(torProxy)))
+	} else {
+		rpcClient, err = rpc.DialContext(ctx, endpoint)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/client/asset/eth/deploy.go
+++ b/client/asset/eth/deploy.go
@@ -371,7 +371,7 @@ func (contractDeployer) nodeAndRate(
 		return nil, nil, nil, fmt.Errorf("error creating wallet: %w", err)
 	}
 
-	cl, err := newMultiRPCClient(walletDir, providers, log, chainCfg, 3, net)
+	cl, err := newMultiRPCClient(walletDir, providers, log, chainCfg, 3, net, "")
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error creating rpc client: %w", err)
 	}

--- a/client/asset/eth/eth.go
+++ b/client/asset/eth/eth.go
@@ -447,6 +447,7 @@ type baseWallet struct {
 	log        dex.Logger
 	dir        string
 	walletType string
+	torProxy   string
 
 	bundlerMtx sync.RWMutex
 	bundler    bundler
@@ -1658,7 +1659,7 @@ func CreateEVMWallet(chainID int64, createWalletParams *asset.CreateWalletParams
 		if !skipConnect && len(providerDef) > 0 {
 			endpoints := strings.Split(providerDef, providerDelimiter)
 			if err := createAndCheckProviders(context.Background(), walletDir, endpoints,
-				big.NewInt(chainID), compat, createWalletParams.Net, createWalletParams.Logger, false); err != nil {
+				big.NewInt(chainID), compat, createWalletParams.Net, createWalletParams.Logger, false, createWalletParams.TorProxy); err != nil {
 				return fmt.Errorf("create and check providers: %v", err)
 			}
 		}
@@ -1787,6 +1788,7 @@ func NewEVMWallet(cfg *EVMWalletConfig) (w *ETHWallet, err error) {
 		log:                 cfg.Logger,
 		dir:                 cfg.AssetCfg.DataDir,
 		walletType:          cfg.AssetCfg.Type,
+		torProxy:            cfg.AssetCfg.TorProxy,
 		finalizeConfs:       cfg.FinalizeConfs,
 		settings:            cfg.AssetCfg.Settings,
 		gasFeeLimitV:        gasFeeLimit,
@@ -1890,7 +1892,7 @@ func (w *ETHWallet) Connect(ctx context.Context) (_ *sync.WaitGroup, err error) 
 		if providerDef, found := w.settings[providersKey]; found && len(providerDef) > 0 {
 			endpoints = strings.Split(providerDef, " ")
 		}
-		rpcCl, err := newMultiRPCClient(w.dir, endpoints, w.log.SubLogger("RPC"), w.chainCfg, w.finalizeConfs, w.net)
+		rpcCl, err := newMultiRPCClient(w.dir, endpoints, w.log.SubLogger("RPC"), w.chainCfg, w.finalizeConfs, w.net, w.torProxy)
 		if err != nil {
 			return nil, err
 		}
@@ -2131,7 +2133,7 @@ func (w *ETHWallet) setBundler(bundlerAddr string) error {
 		return fmt.Errorf("error getting entrypoint address: %v", err)
 	}
 
-	bundler, err := newBundler(w.ctx, bundlerAddr, entrypoint, w.node.contractBackend(), w.currentBaseFee)
+	bundler, err := newBundler(w.ctx, bundlerAddr, entrypoint, w.node.contractBackend(), w.currentBaseFee, w.torProxy)
 	if err != nil {
 		return fmt.Errorf("error connecting to bundler: %v", err)
 	}
@@ -8953,7 +8955,7 @@ func quickNode(ctx context.Context, walletDir string, contractVer uint32,
 		return nil, nil, fmt.Errorf("error creating initiator wallet: %v", err)
 	}
 
-	cl, err := newMultiRPCClient(walletDir, providers, log, wParams.ChainCfg, 3, net)
+	cl, err := newMultiRPCClient(walletDir, providers, log, wParams.ChainCfg, 3, net, "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("error opening initiator rpc client: %v", err)
 	}

--- a/client/asset/eth/multirpc.go
+++ b/client/asset/eth/multirpc.go
@@ -25,6 +25,7 @@ import (
 
 	"decred.org/dcrdex/client/asset"
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/dexnet"
 	"decred.org/dcrdex/dex/networks/erc20"
 	dexeth "decred.org/dcrdex/dex/networks/eth"
 	"github.com/ethereum/go-ethereum"
@@ -39,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/gorilla/websocket"
 )
 
 const (
@@ -380,11 +382,12 @@ type receiptRecord struct {
 
 // multiRPCClient is an ethFetcher backed by one or more public RPC providers.
 type multiRPCClient struct {
-	cfg     *params.ChainConfig
-	creds   *accountCredentials
-	log     dex.Logger
-	chainID *big.Int
-	net     dex.Network
+	cfg      *params.ChainConfig
+	creds    *accountCredentials
+	log      dex.Logger
+	chainID  *big.Int
+	net      dex.Network
+	torProxy string
 
 	finalizeConfs uint64
 
@@ -416,6 +419,7 @@ func newMultiRPCClient(
 	cfg *params.ChainConfig,
 	finalizeConfs uint64,
 	net dex.Network,
+	torProxy string,
 ) (*multiRPCClient, error) {
 	walletDir := getWalletDir(dir, net)
 	creds, err := pathCredentials(filepath.Join(walletDir, "keystore"))
@@ -431,6 +435,7 @@ func newMultiRPCClient(
 		chainID:       cfg.ChainID,
 		endpoints:     endpoints,
 		finalizeConfs: finalizeConfs,
+		torProxy:      torProxy,
 	}
 	m.receipts.cache = make(map[common.Hash]*receiptRecord)
 	m.receipts.lastClean = time.Now()
@@ -442,7 +447,7 @@ func newMultiRPCClient(
 // list of providers that were successfully connected. It is not an error for a
 // connection to fail, unless all endpoints fail. The caller can infer failed
 // connections from the length and contents of the returned provider list.
-func connectProviders(ctx context.Context, endpoints []string, log dex.Logger, chainID *big.Int, net dex.Network) ([]*provider, error) {
+func connectProviders(ctx context.Context, endpoints []string, log dex.Logger, chainID *big.Int, net dex.Network, torProxy string) ([]*provider, error) {
 	providers := make([]*provider, 0, len(endpoints))
 	var success bool
 
@@ -514,7 +519,14 @@ func connectProviders(ctx context.Context, endpoints []string, log dex.Logger, c
 			// Some providers appear to meter websocket connections.
 			var err error
 			startTime := time.Now()
-			rpcClient, err = rpc.DialWebsocket(timedCtx, wsURL.String(), "")
+			if torProxy != "" {
+				rpcClient, err = rpc.DialOptions(timedCtx, wsURL.String(), rpc.WithWebsocketDialer(websocket.Dialer{
+					NetDialContext:   dexnet.ProxyDialContext(torProxy),
+					HandshakeTimeout: 30 * time.Second,
+				}))
+			} else {
+				rpcClient, err = rpc.DialWebsocket(timedCtx, wsURL.String(), "")
+			}
 			log.Tracef("%s to connect to %s", time.Since(startTime), wsURL)
 			if err == nil {
 				ec = ethclient.NewClient(rpcClient)
@@ -544,7 +556,11 @@ func connectProviders(ctx context.Context, endpoints []string, log dex.Logger, c
 		if ec == nil {
 			var err error
 			startTime := time.Now()
-			rpcClient, err = rpc.DialContext(timedCtx, endpoint)
+			if torProxy != "" {
+				rpcClient, err = rpc.DialOptions(timedCtx, endpoint, rpc.WithHTTPClient(dexnet.ProxyHTTPClient(torProxy)))
+			} else {
+				rpcClient, err = rpc.DialContext(timedCtx, endpoint)
+			}
 			log.Tracef("%s to connect to %s", time.Since(startTime), endpoint)
 			if err != nil {
 				log.Errorf("error creating http client for %q: %v", endpoint, err)
@@ -664,7 +680,7 @@ out:
 }
 
 func (m *multiRPCClient) connect(ctx context.Context) (err error) {
-	providers, err := connectProviders(ctx, m.endpoints, m.log, m.chainID, m.net)
+	providers, err := connectProviders(ctx, m.endpoints, m.log, m.chainID, m.net, m.torProxy)
 	if err != nil {
 		return err
 	}
@@ -700,7 +716,7 @@ func (m *multiRPCClient) connect(ctx context.Context) (err error) {
 // unknown providers have a sufficient api to trade and saves good providers to
 // file. One bad provider or connect problem will cause this to error.
 func createAndCheckProviders(ctx context.Context, walletDir string, endpoints []string, chainID *big.Int,
-	compat *CompatibilityData, net dex.Network, log dex.Logger, allProvidersMustConnect bool) error {
+	compat *CompatibilityData, net dex.Network, log dex.Logger, allProvidersMustConnect bool, torProxy string) error {
 
 	var localCP map[string]bool
 	path := filepath.Join(walletDir, "compliant-providers.json")
@@ -737,7 +753,7 @@ func createAndCheckProviders(ctx context.Context, walletDir string, endpoints []
 	}
 
 	if len(unknownEndpoints) > 0 {
-		providers, err := connectProviders(ctx, unknownEndpoints, log, chainID, net)
+		providers, err := connectProviders(ctx, unknownEndpoints, log, chainID, net, torProxy)
 		if err != nil {
 			return fmt.Errorf("expected to successfully connect to at least 1 of these unfamiliar providers: %s",
 				failedProviders(providers, unknownEndpoints))
@@ -793,12 +809,12 @@ func failedProviders(succeeded []*provider, tried []string) string {
 }
 
 func (m *multiRPCClient) reconfigure(ctx context.Context, endpoints []string, compat *CompatibilityData, walletDir string, defaultProviders bool) error {
-	if err := createAndCheckProviders(ctx, walletDir, endpoints, m.chainID, compat, m.net, m.log, !defaultProviders); err != nil {
+	if err := createAndCheckProviders(ctx, walletDir, endpoints, m.chainID, compat, m.net, m.log, !defaultProviders, m.torProxy); err != nil {
 		return fmt.Errorf("create and check providers: %v", err)
 	}
 
 	// TODO: If endpoints haven't change, do nothing.
-	providers, err := connectProviders(ctx, endpoints, m.log, m.chainID, m.net)
+	providers, err := connectProviders(ctx, endpoints, m.log, m.chainID, m.net, m.torProxy)
 	if err != nil {
 		return err
 	}

--- a/client/asset/eth/multirpc_test_util.go
+++ b/client/asset/eth/multirpc_test_util.go
@@ -95,7 +95,7 @@ func (m *MRPCTest) rpcClient(dir string, seed []byte, endpoints []string, net de
 		return nil, fmt.Errorf("error creating wallet: %v", err)
 	}
 
-	return newMultiRPCClient(dir, endpoints, log, cfg, 3, net)
+	return newMultiRPCClient(dir, endpoints, log, cfg, 3, net, "")
 }
 
 func (m *MRPCTest) TestHTTP(t *testing.T, port string) {
@@ -280,7 +280,7 @@ func (m *MRPCTest) TestMainnetCompliance(t *testing.T) {
 	}
 
 	log := dex.StdOutLogger("T", dex.LevelTrace)
-	providers, err := connectProviders(ctx, providerLookup, log, cfg.ChainID, dex.Mainnet)
+	providers, err := connectProviders(ctx, providerLookup, log, cfg.ChainID, dex.Mainnet, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/asset/eth/nodeclient_harness_test.go
+++ b/client/asset/eth/nodeclient_harness_test.go
@@ -231,7 +231,7 @@ func prepareRPCClient(name, dataDir string, providers []string, net dex.Network)
 		return nil, nil, err
 	}
 
-	c, err := newMultiRPCClient(dataDir, providers, tLogger.SubLogger(name), cfg, 3, net)
+	c, err := newMultiRPCClient(dataDir, providers, tLogger.SubLogger(name), cfg, 3, net, "")
 	if err != nil {
 		return nil, nil, fmt.Errorf("(%s) prepareRPCClient error: %v", name, err)
 	}

--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -443,6 +443,9 @@ type WalletConfig struct {
 	// DataDir is a filesystem directory the wallet may use for persistent
 	// storage.
 	DataDir string
+	// TorProxy is the address (host:port) of a SOCKS5 proxy (e.g. Tor) for
+	// outgoing wallet connections such as RPC providers and Electrum servers.
+	TorProxy string
 }
 
 // ConfirmTxStatus contains the coinID which redeemed or refunded a swap, the

--- a/client/core/core.go
+++ b/client/core/core.go
@@ -37,6 +37,7 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/calc"
 	"decred.org/dcrdex/dex/config"
+	"decred.org/dcrdex/dex/dexnet"
 	"decred.org/dcrdex/dex/encode"
 	"decred.org/dcrdex/dex/encrypt"
 	"decred.org/dcrdex/dex/msgjson"
@@ -1561,6 +1562,7 @@ func New(cfg *Config) (*Core, error) {
 		if _, _, err = net.SplitHostPort(cfg.TorProxy); err != nil {
 			return nil, err
 		}
+		dexnet.SetProxy(cfg.TorProxy)
 	}
 	if cfg.Onion != "" {
 		if _, _, err = net.SplitHostPort(cfg.Onion); err != nil {
@@ -1969,6 +1971,11 @@ func (c *Core) setCredentials(creds *db.PrimaryCredentials) {
 // Network returns the current DEX network.
 func (c *Core) Network() dex.Network {
 	return c.net
+}
+
+// TorProxy returns the configured Tor proxy address, or "" if none.
+func (c *Core) TorProxy() string {
+	return c.cfg.TorProxy
 }
 
 // Exchanges creates a map of *Exchange keyed by host, including markets and
@@ -2776,6 +2783,7 @@ func (c *Core) createSeededWallet(assetID uint32, crypter encrypt.Crypter, form 
 		DataDir:  c.assetDataDirectory(assetID),
 		Net:      c.net,
 		Logger:   c.log.SubLogger(unbip(assetID)),
+		TorProxy: c.cfg.TorProxy,
 	}); err != nil {
 		return nil, fmt.Errorf("Error creating wallet: %w", err)
 	}
@@ -2913,6 +2921,7 @@ func (c *Core) loadXCWallet(dbWallet *db.Wallet) (*xcWallet, error) {
 			Emit:        asset.NewWalletEmitter(c.notes, assetID, log),
 			PeersChange: peersChange,
 			DataDir:     c.assetDataDirectory(assetID),
+			TorProxy:    c.cfg.TorProxy,
 		}
 
 		settings[asset.SpecialSettingActivelyUsed] =
@@ -3302,6 +3311,7 @@ func (c *Core) RecoverWallet(assetID uint32, appPW []byte, force bool) error {
 		DataDir:  c.assetDataDirectory(assetID),
 		Net:      c.net,
 		Logger:   c.log.SubLogger(unbip(assetID)),
+		TorProxy: c.cfg.TorProxy,
 	}); err != nil {
 		return fmt.Errorf("error creating wallet: %w", err)
 	}
@@ -3594,6 +3604,7 @@ func (c *Core) ReconfigureWallet(appPW, newWalletPW []byte, form *WalletForm) er
 			Type:     form.Type,
 			Settings: form.Config,
 			DataDir:  c.assetDataDirectory(assetID),
+			TorProxy: c.cfg.TorProxy,
 		}, oldWallet.currentDepositAddress()); err != nil {
 			return fmt.Errorf("Reconfigure: %v", err)
 		} else if !restart {

--- a/client/mm/libxc/binance.go
+++ b/client/mm/libxc/binance.go
@@ -588,6 +588,7 @@ type binance struct {
 	tradeIDNoncePrefix dex.Bytes
 	broadcast          func(any)
 	isUS               bool
+	torProxy           string
 
 	markets atomic.Value // map[string]*binanceMarket
 	// tokenIDs maps the token's symbol to the list of bip ids of the token
@@ -665,6 +666,7 @@ func newBinance(cfg *CEXConfig, binanceUS bool) *binance {
 		balances:           make(map[uint32]*ExchangeBalance),
 		books:              make(map[string]*binanceOrderBook),
 		net:                cfg.Net,
+		torProxy:           cfg.TorProxy,
 		tradeInfo:          make(map[string]*tradeInfo),
 		tradeUpdaters:      make(map[int]chan *Trade),
 		tradeIDNoncePrefix: encode.RandomBytes(10),
@@ -1875,7 +1877,7 @@ func (bnc *binance) getUserDataStream(ctx context.Context) (err error) {
 			return nil, err
 		}
 
-		conn, err := comms.NewWsConn(&comms.WsCfg{
+		wsCfg := &comms.WsCfg{
 			URL:          bnc.wsURL + "/ws/" + listenKey,
 			PingWait:     time.Minute * 4,
 			EchoPingData: true,
@@ -1885,7 +1887,11 @@ func (bnc *binance) getUserDataStream(ctx context.Context) (err error) {
 			Logger:         bnc.log.SubLogger("BNCWS"),
 			RawHandler:     bnc.handleUserDataStreamUpdate,
 			ConnectHeaders: http.Header{"X-MBX-APIKEY": []string{bnc.apiKey}},
-		})
+		}
+		if bnc.torProxy != "" {
+			wsCfg.NetDialContext = dexnet.ProxyDialContext(bnc.torProxy)
+		}
+		conn, err := comms.NewWsConn(wsCfg)
 		if err != nil {
 			return nil, fmt.Errorf("NewWsConn error: %w", err)
 		}
@@ -2244,7 +2250,7 @@ func (bnc *binance) connectToMarketDataStream(ctx context.Context, baseID, quote
 				}
 			}
 		}
-		conn, err := comms.NewWsConn(&comms.WsCfg{
+		marketWsCfg := &comms.WsCfg{
 			URL: bnc.streamURL(),
 			// Binance Docs: The websocket server will send a ping frame every 3
 			// minutes. If the websocket server does not receive a pong frame
@@ -2262,7 +2268,11 @@ func (bnc *binance) connectToMarketDataStream(ctx context.Context, baseID, quote
 			ConnectEventFunc: connectEventFunc,
 			Logger:           bnc.log.SubLogger("BNCBOOK"),
 			RawHandler:       bnc.handleMarketDataNote,
-		})
+		}
+		if bnc.torProxy != "" {
+			marketWsCfg.NetDialContext = dexnet.ProxyDialContext(bnc.torProxy)
+		}
+		conn, err := comms.NewWsConn(marketWsCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/client/mm/libxc/bitget.go
+++ b/client/mm/libxc/bitget.go
@@ -562,6 +562,7 @@ type bitget struct {
 	passphrase string // Bitget requires a passphrase for API access
 	net        dex.Network
 	broadcast  func(any)
+	torProxy   string
 	ctx        context.Context
 
 	tradeIDNonce       atomic.Uint32
@@ -789,6 +790,7 @@ func newBitget(cfg *CEXConfig) *bitget {
 		secretKey:          cfg.SecretKey,
 		passphrase:         cfg.APIPassphrase,
 		net:                cfg.Net,
+		torProxy:           cfg.TorProxy,
 		balances:           make(map[uint32]*ExchangeBalance),
 		books:              make(map[string]*bitgetOrderBook),
 		tradeInfo:          make(map[string]*bitgetTradeInfo),
@@ -1190,6 +1192,9 @@ func (bg *bitget) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		Logger:        bg.log.SubLogger("WS-PRIV"),
 		RawHandler:    bg.handlePrivateWsMessage,
 		ReconnectSync: bg.onPrivateReconnect,
+	}
+	if bg.torProxy != "" {
+		privateWSCfg.NetDialContext = dexnet.ProxyDialContext(bg.torProxy)
 	}
 	privateWS, err := comms.NewWsConn(privateWSCfg)
 	if err != nil {
@@ -1920,7 +1925,9 @@ func (bg *bitget) ensureMarketConnection(ctx context.Context) error {
 		ReconnectSync:    bg.onMarketReconnect,
 		ConnectEventFunc: connectEventFunc,
 	}
-
+	if bg.torProxy != "" {
+		marketWSCfg.NetDialContext = dexnet.ProxyDialContext(bg.torProxy)
+	}
 	marketWS, err := comms.NewWsConn(marketWSCfg)
 	if err != nil {
 		return fmt.Errorf("create market ws: %w", err)

--- a/client/mm/libxc/coinbase.go
+++ b/client/mm/libxc/coinbase.go
@@ -68,9 +68,10 @@ type cbWSConn struct {
 	setSynced  func(bool)
 	apiName    string
 	privKey    *ecdsa.PrivateKey
+	torProxy   string
 }
 
-func newCBWSConn(apiName, wsPath, productID, channel, channelID string, msgHandler func([]byte), setSynced func(bool), privKey *ecdsa.PrivateKey, log dex.Logger) *cbWSConn {
+func newCBWSConn(apiName, wsPath, productID, channel, channelID string, msgHandler func([]byte), setSynced func(bool), privKey *ecdsa.PrivateKey, log dex.Logger, torProxy string) *cbWSConn {
 	subLoggerName := fmt.Sprintf("WS-%s", channel)
 	if productID != "" {
 		subLoggerName += "-" + productID
@@ -85,6 +86,7 @@ func newCBWSConn(apiName, wsPath, productID, channel, channelID string, msgHandl
 		msgHandler: msgHandler,
 		setSynced:  setSynced,
 		privKey:    privKey,
+		torProxy:   torProxy,
 	}
 }
 
@@ -222,7 +224,7 @@ func (c *cbWSConn) handleSubscriptionMessage(b []byte) {
 
 func (c *cbWSConn) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	initialConnect := true
-	conn, err := comms.NewWsConn(&comms.WsCfg{
+	wsCfg := &comms.WsCfg{
 		URL: "wss://" + c.wsPath,
 		// Coinbase does not send pings, but there is a heartbeat every second,
 		// so if no messages come for one minute, we are disconnected.
@@ -243,7 +245,11 @@ func (c *cbWSConn) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		},
 		Logger:     c.log,
 		RawHandler: c.handleWebsocketMessage,
-	})
+	}
+	if c.torProxy != "" {
+		wsCfg.NetDialContext = dexnet.ProxyDialContext(c.torProxy)
+	}
+	conn, err := comms.NewWsConn(wsCfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating WsConn: %w", err)
 	}
@@ -289,9 +295,10 @@ type cbBook struct {
 	bui       *dex.UnitInfo
 	qui       *dex.UnitInfo
 	log       dex.Logger
+	torProxy  string
 }
 
-func newCBBook(wsPath, productID string, bui, qui *dex.UnitInfo, log dex.Logger) *cbBook {
+func newCBBook(wsPath, productID string, bui, qui *dex.UnitInfo, log dex.Logger, torProxy string) *cbBook {
 	return &cbBook{
 		wsPath:    wsPath,
 		productID: productID,
@@ -299,6 +306,7 @@ func newCBBook(wsPath, productID string, bui, qui *dex.UnitInfo, log dex.Logger)
 		bui:       bui,
 		qui:       qui,
 		log:       log,
+		torProxy:  torProxy,
 	}
 }
 func (c *cbBook) convertOBUpdates(updates []*cbtypes.OrderbookUpdate) (bids, asks []*obEntry) {
@@ -373,7 +381,7 @@ func (c *cbBook) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 
 	// apiName and signer not provided because these subscriptions do not need
 	// authentication.
-	conn := newCBWSConn("", c.wsPath, c.productID, "level2", "l2_data", c.handleLevel2Message, setSynced, nil, c.log)
+	conn := newCBWSConn("", c.wsPath, c.productID, "level2", "l2_data", c.handleLevel2Message, setSynced, nil, c.log, c.torProxy)
 	wsCM := dex.NewConnectionMaster(conn)
 	if err := wsCM.ConnectOnce(ctx); err != nil {
 		return nil, fmt.Errorf("error connecting to websocket feed: %w", err)
@@ -410,6 +418,7 @@ type coinbase struct {
 	idTicker   map[uint32]string
 	ctx        context.Context
 	net        dex.Network
+	torProxy   string
 	accounts   atomic.Value // map[string]*coinbaseAccount
 	assets     atomic.Value // map[string]*coinbaseAsset
 	markets    atomic.Value // map[string]*coinbaseMarket
@@ -501,6 +510,7 @@ func newCoinbase(cfg *CEXConfig) (*coinbase, error) {
 		apiPrivKey:         key,
 		tickerIDs:          tickerIDs,
 		idTicker:           idTicker,
+		torProxy:           cfg.TorProxy,
 		tradeIDNoncePrefix: encode.RandomBytes(10),
 		books:              make(map[string]*cbBook),
 		cexUpdaters:        make(map[chan any]struct{}),
@@ -571,7 +581,7 @@ func (c *coinbase) handleUserMessage(b []byte) {
 }
 
 func (c *coinbase) subscribeUserChannel(ctx context.Context) (*sync.WaitGroup, error) {
-	conn := newCBWSConn(c.apiName, c.wsPath, "", "user", "user", c.handleUserMessage, func(bool) {}, c.apiPrivKey, c.log)
+	conn := newCBWSConn(c.apiName, c.wsPath, "", "user", "user", c.handleUserMessage, func(bool) {}, c.apiPrivKey, c.log, c.torProxy)
 	cm := dex.NewConnectionMaster(conn)
 	if err := cm.ConnectOnce(ctx); err != nil {
 		return nil, fmt.Errorf("error connecting to websocket feed: %w", err)
@@ -824,7 +834,7 @@ func (c *coinbase) SubscribeMarket(ctx context.Context, baseID, quoteID uint32) 
 		return nil
 	}
 
-	book = newCBBook(c.wsPath, productID, &bui, &qui, c.log)
+	book = newCBBook(c.wsPath, productID, &bui, &qui, c.log, c.torProxy)
 	err = book.sync(c.ctx)
 	if err != nil {
 		return fmt.Errorf("error syncing book: %v", err)

--- a/client/mm/libxc/interface.go
+++ b/client/mm/libxc/interface.go
@@ -179,6 +179,7 @@ type CEXConfig struct {
 	APIPassphrase string // Required by some exchanges like Bitget
 	Logger        dex.Logger
 	Notify        func(any)
+	TorProxy      string
 }
 
 // NewCEX creates a new CEX.

--- a/client/mm/libxc/mexc.go
+++ b/client/mm/libxc/mexc.go
@@ -48,6 +48,7 @@ type mexc struct {
 	notify    func(any)
 	apiKey    string
 	secretKey string
+	torProxy  string
 	ctx       context.Context
 
 	mtx sync.RWMutex
@@ -108,9 +109,6 @@ type mexc struct {
 	tradeInfo          map[string]*mexcTradeInfo
 	tradeUpdaters      map[int]chan *Trade
 	tradeUpdateCounter int
-
-	httpOnce sync.Once
-	httpCli  *http.Client
 }
 
 type mexcTradeInfo struct {
@@ -411,6 +409,7 @@ func newMEXC(cfg *CEXConfig) (*mexc, error) {
 		notify:        cfg.Notify,
 		apiKey:        cfg.APIKey,
 		secretKey:     cfg.SecretKey,
+		torProxy:      cfg.TorProxy,
 		activeTopics:  make(map[string]struct{}),
 		symbols:       make(map[string]struct{}),
 		symbolMeta:    make(map[string]*mxctypes.Symbol),
@@ -639,6 +638,9 @@ func (m *mexc) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 		EchoPingData:  true,
 		ReconnectSync: m.onPrivateReconnect,
 	}
+	if m.torProxy != "" {
+		privateWSCfg.NetDialContext = dexnet.ProxyDialContext(m.torProxy)
+	}
 	privateWS, err := comms.NewWsConn(privateWSCfg)
 	if err != nil {
 		return &wg, fmt.Errorf("create private ws: %w", err)
@@ -709,15 +711,6 @@ func (m *mexc) stop() {
 	}
 }
 
-// initHTTPClient initializes the HTTP client on first use.
-func (m *mexc) initHTTPClient() {
-	m.httpOnce.Do(func() {
-		m.httpCli = &http.Client{
-			Timeout: 30 * time.Second,
-		}
-	})
-}
-
 // getAPI performs a signed GET request.
 // getOrderbookSnapshot fetches a full order book snapshot from MEXC REST API.
 // This is used for initial synchronization of order books.
@@ -756,8 +749,6 @@ func (m *mexc) deleteAPI(ctx context.Context, endpoint string, query url.Values,
 
 // request performs an HTTP request with optional HMAC signature.
 func (m *mexc) request(ctx context.Context, method, endpoint string, query, form url.Values, sign bool, thing any) error {
-	m.initHTTPClient()
-
 	fullURL := mexcHTTPURL + endpoint
 
 	if query == nil {
@@ -1239,7 +1230,9 @@ func (m *mexc) ensureMarketConnection(ctx context.Context) error {
 		ReconnectSync:    m.onMarketReconnect,
 		ConnectEventFunc: connectEventFunc,
 	}
-
+	if m.torProxy != "" {
+		wsCfg.NetDialContext = dexnet.ProxyDialContext(m.torProxy)
+	}
 	marketWS, err := comms.NewWsConn(wsCfg)
 	if err != nil {
 		return fmt.Errorf("create market ws: %w", err)

--- a/client/mm/mm.go
+++ b/client/mm/mm.go
@@ -44,6 +44,7 @@ type clientCore interface {
 	Send(pw []byte, assetID uint32, value uint64, address string, subtract bool) (asset.Coin, error)
 	NewDepositAddress(assetID uint32) (string, error)
 	Network() dex.Network
+	TorProxy() string
 	Order(oidB dex.Bytes) (*core.Order, error)
 	WalletTransaction(uint32, string) (*asset.WalletTransaction, error)
 	TradingLimits(host string) (userParcels, parcelLimit uint32, err error)
@@ -619,6 +620,7 @@ func (m *MarketMaker) loadCEX(ctx context.Context, cfg *CEXConfig) (*centralized
 		APIPassphrase: cfg.APIPassphrase,
 		Logger:        logger,
 		Net:           m.core.Network(),
+		TorProxy:      m.core.TorProxy(),
 		Notify: func(n any) {
 			m.handleCEXUpdate(cfg.Name, n)
 		},

--- a/client/mm/mm_test.go
+++ b/client/mm/mm_test.go
@@ -186,6 +186,10 @@ func (c *tCore) Network() dex.Network {
 	return dex.Simnet
 }
 
+func (c *tCore) TorProxy() string {
+	return ""
+}
+
 func (c *tCore) FiatConversionRates() map[uint32]float64 {
 	return c.fiatRates
 }

--- a/dex/dexnet/http.go
+++ b/dex/dexnet/http.go
@@ -9,8 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"sync"
 	"time"
+
+	"github.com/decred/go-socks/socks"
 )
 
 const defaultResponseSizeLimit = 1 << 20 // 1 MiB = 1,048,576 bytes
@@ -18,6 +22,50 @@ const defaultResponseSizeLimit = 1 << 20 // 1 MiB = 1,048,576 bytes
 // Client is the default HTTP client used for requests.
 var Client = &http.Client{
 	Timeout: 20 * time.Second, // 20 seconds
+}
+
+// ProxyDialContext returns a DialContext function that routes connections
+// through a SOCKS5 proxy at addr (host:port). If addr is empty, nil is
+// returned.
+func ProxyDialContext(addr string) func(ctx context.Context, network, address string) (net.Conn, error) {
+	if addr == "" {
+		return nil
+	}
+	proxy := &socks.Proxy{Addr: addr}
+	return proxy.DialContext
+}
+
+// ProxyTransport returns an *http.Transport that routes all connections through
+// a SOCKS5 proxy at addr (host:port).
+func ProxyTransport(addr string) *http.Transport {
+	return &http.Transport{
+		DialContext:           ProxyDialContext(addr),
+		ForceAttemptHTTP2:     false,
+		TLSHandshakeTimeout:   10 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+		MaxIdleConns:          100,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// ProxyHTTPClient returns an *http.Client that routes all requests through a
+// SOCKS5 proxy at addr (host:port).
+func ProxyHTTPClient(addr string) *http.Client {
+	return &http.Client{
+		Transport: ProxyTransport(addr),
+		Timeout:   20 * time.Second,
+	}
+}
+
+var setProxyOnce sync.Once
+
+// SetProxy configures the global Client to route all requests through a SOCKS5
+// proxy at the given address (host:port). Only the first call takes effect;
+// subsequent calls are no-ops.
+func SetProxy(addr string) {
+	setProxyOnce.Do(func() {
+		Client.Transport = ProxyTransport(addr)
+	})
 }
 
 // RequestOption are optional arguments to Get, Post, or Do.

--- a/dex/dexnet/http_test.go
+++ b/dex/dexnet/http_test.go
@@ -1,9 +1,16 @@
 package dexnet
 
 import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestErrorParsing(t *testing.T) {
@@ -23,5 +30,180 @@ func TestErrorParsing(t *testing.T) {
 	}
 	if errPayload.Code != -150 || errPayload.Msg != "you messed up, bruh" {
 		t.Fatal("unexpected error body")
+	}
+}
+
+func TestProxyDialContext(t *testing.T) {
+	if fn := ProxyDialContext(""); fn != nil {
+		t.Fatal("expected nil for empty address")
+	}
+	if fn := ProxyDialContext("127.0.0.1:1080"); fn == nil {
+		t.Fatal("expected non-nil for valid address")
+	}
+}
+
+func TestProxyTransport(t *testing.T) {
+	tr := ProxyTransport("127.0.0.1:1080")
+	if tr.DialContext == nil {
+		t.Fatal("expected non-nil DialContext")
+	}
+	if tr.TLSHandshakeTimeout != 10*time.Second {
+		t.Fatalf("unexpected TLSHandshakeTimeout: %v", tr.TLSHandshakeTimeout)
+	}
+	if tr.IdleConnTimeout != 90*time.Second {
+		t.Fatalf("unexpected IdleConnTimeout: %v", tr.IdleConnTimeout)
+	}
+}
+
+func TestProxyHTTPClient(t *testing.T) {
+	cl := ProxyHTTPClient("127.0.0.1:1080")
+	if cl.Timeout != 20*time.Second {
+		t.Fatalf("unexpected timeout: %v", cl.Timeout)
+	}
+	tr, ok := cl.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("expected non-nil DialContext on transport")
+	}
+}
+
+// startTestSOCKS5 starts a minimal SOCKS5 server (no-auth, CONNECT only) on a
+// random localhost port. It returns the listener address and a cleanup function.
+func startTestSOCKS5(t *testing.T) (addr string, cleanup func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer conn.Close()
+				handleSOCKS5(conn)
+			}()
+		}
+	}()
+
+	return ln.Addr().String(), func() {
+		ln.Close()
+		wg.Wait()
+	}
+}
+
+func handleSOCKS5(conn net.Conn) {
+	// Greeting: ver | nmethods | methods...
+	var hdr [2]byte
+	if _, err := io.ReadFull(conn, hdr[:]); err != nil {
+		return
+	}
+	if hdr[0] != 0x05 {
+		return
+	}
+	methods := make([]byte, hdr[1])
+	if _, err := io.ReadFull(conn, methods); err != nil {
+		return
+	}
+	// Reply: no-auth
+	conn.Write([]byte{0x05, 0x00})
+
+	// Connect request: ver | cmd | rsv | atyp | addr | port
+	var req [4]byte
+	if _, err := io.ReadFull(conn, req[:]); err != nil {
+		return
+	}
+	if req[1] != 0x01 { // CONNECT
+		return
+	}
+
+	var targetHost string
+	switch req[3] { // atyp
+	case 0x01: // IPv4
+		var ip [4]byte
+		if _, err := io.ReadFull(conn, ip[:]); err != nil {
+			return
+		}
+		targetHost = net.IP(ip[:]).String()
+	case 0x03: // Domain
+		var domLen [1]byte
+		if _, err := io.ReadFull(conn, domLen[:]); err != nil {
+			return
+		}
+		dom := make([]byte, domLen[0])
+		if _, err := io.ReadFull(conn, dom); err != nil {
+			return
+		}
+		targetHost = string(dom)
+	default:
+		return
+	}
+
+	var portBuf [2]byte
+	if _, err := io.ReadFull(conn, portBuf[:]); err != nil {
+		return
+	}
+	port := binary.BigEndian.Uint16(portBuf[:])
+	target := net.JoinHostPort(targetHost, strconv.Itoa(int(port)))
+
+	remote, err := net.DialTimeout("tcp", target, 5*time.Second)
+	if err != nil {
+		// Send failure reply.
+		conn.Write([]byte{0x05, 0x05, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+		return
+	}
+	defer remote.Close()
+
+	// Success reply.
+	conn.Write([]byte{0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0})
+
+	// Bidirectional copy. Close write halves so the other io.Copy unblocks.
+	done := make(chan struct{})
+	go func() {
+		io.Copy(remote, conn)
+		if tc, ok := remote.(*net.TCPConn); ok {
+			tc.CloseWrite()
+		}
+		close(done)
+	}()
+	io.Copy(conn, remote)
+	if tc, ok := conn.(*net.TCPConn); ok {
+		tc.CloseWrite()
+	}
+	<-done
+}
+
+func TestProxyHTTPClientRouting(t *testing.T) {
+	proxyAddr, cleanup := startTestSOCKS5(t)
+	defer cleanup()
+
+	const want = "hello through socks5"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, want)
+	}))
+	defer ts.Close()
+
+	cl := ProxyHTTPClient(proxyAddr)
+	resp, err := cl.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("GET through SOCKS5 proxy failed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if string(body) != want {
+		t.Fatalf("unexpected body: %q, want %q", body, want)
 	}
 }


### PR DESCRIPTION
When --torproxy is set, configure the global dexnet HTTP client with a SOCKS5 transport so that fee rate APIs, fiat rate fetchers, CEX APIs, bridge protocol calls, GitHub version checks, and other HTTP requests are routed through Tor. Thread the proxy address into ETH RPC provider connections (both HTTP and WebSocket via rpc.DialOptions), the ERC-4337 bundler, and Electrum server connections. Add TODO comments for BTC and DCR SPV peer connections which require upstream library support.

closes #3528