### PR TITLE
ui: Fix slippage estimation overflow.

### DIFF
--- a/client/webserver/site/src/js/markets.ts
+++ b/client/webserver/site/src/js/markets.ts
@@ -2112,7 +2112,7 @@ export default class MarketsPage extends BasePage {
         Doc.hide(page.vMarketEstimate)
       }
       // Show slippage estimate for market orders.
-      this.showSlippageEstimate(order, toAsset)
+      this.showSlippageEstimate(order)
     }
     // Visually differentiate between buy/sell orders.
     if (isSell) {
@@ -2139,7 +2139,7 @@ export default class MarketsPage extends BasePage {
    * showSlippageEstimate calculates and displays slippage/price impact
    * information for market orders on the verification dialog.
    */
-  showSlippageEstimate (order: TradeForm, toAsset: SupportedAsset) {
+  showSlippageEstimate (order: TradeForm) {
     const page = this.page
     if (!this.book || order.isLimit) {
       Doc.hide(page.vSlippageSection)
@@ -2174,11 +2174,6 @@ export default class MarketsPage extends BasePage {
       page.vmSlippagePct.classList.add('text-success')
     }
 
-    // Update "Receiving Approximately" with more accurate VWAP-based estimate.
-    if (estimate.receivedEstimate > 0) {
-      page.vmToTotal.textContent = Doc.formatCoinValue(estimate.receivedEstimate, toAsset.unitInfo)
-    }
-
     // Partial fill warning: order is larger than available book depth.
     if (!estimate.filled) {
       Doc.show(page.vPartialFillWarning)
@@ -2193,13 +2188,7 @@ export default class MarketsPage extends BasePage {
       const pctStr = percentFormatter.format(slippage)
       const isHigh = slippage >= slippageAckPct
       const msgId = isHigh ? intl.ID_HIGH_SLIPPAGE_WARNING_MSG : intl.ID_SLIPPAGE_WARNING_MSG
-      let msg = intl.prep(msgId, { slippagePct: pctStr })
-      if (!msg) {
-        msg = isHigh
-          ? `This order has very high price impact (${pctStr}% slippage). You may receive significantly less than expected.`
-          : `This order has significant price impact. The estimated fill rate is ${pctStr}% away from the mid-market rate.`
-      }
-      page.vmSlippageWarnMsg.textContent = msg
+      page.vmSlippageWarnMsg.textContent = intl.prep(msgId, { slippagePct: pctStr })
       page.vSlippageWarning.classList.remove('border-warning', 'text-warning', 'border-danger', 'text-danger')
       if (isHigh) {
         page.vSlippageWarning.classList.add('border-danger', 'text-danger')
@@ -2811,7 +2800,7 @@ export default class MarketsPage extends BasePage {
     if (!Doc.isHidden(page.vHighSlippageAck)) {
       const ackCheck = page.slippageAckCheck as HTMLInputElement
       if (!ackCheck.checked) {
-        page.vErr.textContent = intl.prep(intl.ID_SLIPPAGE_ACK_REQUIRED) || 'Please acknowledge the high slippage warning before submitting.'
+        page.vErr.textContent = intl.prep(intl.ID_SLIPPAGE_ACK_REQUIRED)
         Doc.show(page.vErr)
         return
       }

--- a/client/webserver/site/src/js/orderbook.ts
+++ b/client/webserver/site/src/js/orderbook.ts
@@ -14,7 +14,6 @@ export interface MarketOrderEstimate {
   orderFillPct: number // % of the order that can be filled
   bookDepthPct: number // % of book side consumed (by base qty)
   levelsConsumed: number // Number of price levels consumed
-  receivedEstimate: number // Estimated received amount (base atoms for buy, quote atoms for sell)
 }
 
 export default class OrderBook {
@@ -187,18 +186,20 @@ export default class OrderBook {
       worstRate = ord.msgRate
 
       if (isMarketBuy) {
-        // qty is in quote atoms. Each order costs qtyAtomic * msgRate / RateEncodingFactor quote atoms.
-        const quoteCost = ord.qtyAtomic * ord.msgRate / RateEncodingFactor
+        // qty is in quote atoms. Each order costs qtyAtomic * (msgRate / RateEncodingFactor) quote atoms.
+        // Divide first to avoid intermediate overflow past Number.MAX_SAFE_INTEGER.
+        const rate = ord.msgRate / RateEncodingFactor
+        const quoteCost = ord.qtyAtomic * rate
         if (quoteCost >= remainingQty) {
           // Partial fill
-          const baseUsed = remainingQty * RateEncodingFactor / ord.msgRate
-          weightedSum += baseUsed * ord.msgRate
+          const baseUsed = remainingQty / rate
+          weightedSum += baseUsed * rate
           baseQtySum += baseUsed
           filledBaseQty += baseUsed
           remainingQty = 0
           filled = true
         } else {
-          weightedSum += ord.qtyAtomic * ord.msgRate
+          weightedSum += ord.qtyAtomic * rate
           baseQtySum += ord.qtyAtomic
           filledBaseQty += ord.qtyAtomic
           remainingQty -= quoteCost
@@ -206,14 +207,15 @@ export default class OrderBook {
       } else {
         // qty is in base atoms.
         const orderQty = ord.qtyAtomic
+        const rate = ord.msgRate / RateEncodingFactor
         if (orderQty >= remainingQty) {
-          weightedSum += remainingQty * ord.msgRate
+          weightedSum += remainingQty * rate
           baseQtySum += remainingQty
           filledBaseQty += remainingQty
           remainingQty = 0
           filled = true
         } else {
-          weightedSum += orderQty * ord.msgRate
+          weightedSum += orderQty * rate
           baseQtySum += orderQty
           filledBaseQty += orderQty
           remainingQty -= orderQty
@@ -223,7 +225,11 @@ export default class OrderBook {
 
     if (baseQtySum === 0) return null
 
-    const avgRate = weightedSum / baseQtySum
+    // weightedSum uses conventional rate (msgRate / RateEncodingFactor) to
+    // avoid overflow, so avgConvRate is also conventional.
+    const avgConvRate = weightedSum / baseQtySum
+    // Convert back to msgRate-encoded for the interface contract.
+    const avgRate = avgConvRate * RateEncodingFactor
     const bookDepthPct = totalBookBaseQty > 0 ? (filledBaseQty / totalBookBaseQty) * 100 : 0
     const slippagePct = Math.abs(avgRate - midGapRate) / midGapRate * 100
     // For sell: qty is base atoms, filledBaseQty is base atoms matched.
@@ -231,11 +237,6 @@ export default class OrderBook {
     const orderFillPct = sell
       ? (filledBaseQty / qty) * 100
       : ((qty - remainingQty) / qty) * 100
-
-    // For buy, it's base atoms received; for sell, it's quote atoms received.
-    const receivedEstimate = sell
-      ? baseQtySum * avgRate / RateEncodingFactor
-      : baseQtySum
 
     return {
       avgRate,
@@ -245,8 +246,7 @@ export default class OrderBook {
       filled,
       orderFillPct,
       bookDepthPct,
-      levelsConsumed,
-      receivedEstimate
+      levelsConsumed
     }
   }
 }


### PR DESCRIPTION
Restructure arithmetic in estimateMarketOrder to divide msgRate by RateEncodingFactor before multiplying by qtyAtomic, preventing intermediate products from exceeding Number.MAX_SAFE_INTEGER. Remove unused receivedEstimate field and the receivedEstimate-based override of the "Receiving Approximately" display which could conflict with the server-side calculation. Remove dead-code intl.prep fallback strings that duplicate registered translations.