### PR TITLE
server: Fix market buy funding validation.

### DIFF
--- a/server/market/orderrouter.go
+++ b/server/market/orderrouter.go
@@ -584,11 +584,12 @@ func (r *OrderRouter) processTrade(oRecord *orderRecord, tunnel MarketTunnel, as
 				}
 				buyBuffer := tunnel.MarketBuyBuffer()
 				lotWithBuffer := uint64(float64(lotSize) * buyBuffer)
-				swapVal = matcher.BaseToQuote(midGap, lotWithBuffer)
-				if trade.Quantity < swapVal {
+				bufferQty := matcher.BaseToQuote(midGap, lotWithBuffer)
+				if trade.Quantity < bufferQty {
 					return false, msgjson.NewError(msgjson.FundingError, "order quantity does not satisfy market buy buffer. %d < %d. midGap = %d",
-						trade.Quantity, swapVal, midGap)
+						trade.Quantity, bufferQty, midGap)
 				}
+				swapVal = trade.Quantity
 			}
 		}
 

--- a/server/market/routers_test.go
+++ b/server/market/routers_test.go
@@ -484,6 +484,7 @@ func (b *TBackend) ValidateFeeRate(asset.Coin, uint64) bool {
 
 type tUTXOBackend struct {
 	*TBackend
+	lastSwapVal uint64
 }
 
 func (b *tUTXOBackend) FundingCoin(ctx context.Context, coinID, redeemScript []byte) (asset.FundingCoin, error) {
@@ -496,6 +497,7 @@ func (b *tUTXOBackend) VerifyUnspentCoin(_ context.Context, coinID []byte) error
 }
 
 func (b *tUTXOBackend) ValidateOrderFunding(swapVal, valSum, inputCount, inputsSize, maxSwaps uint64, nfo *dex.Asset) bool {
+	b.lastSwapVal = swapVal
 	return !b.unfunded
 }
 
@@ -1147,6 +1149,13 @@ func TestMarketStartProcessStop(t *testing.T) {
 	mkt.ServerTime = 0
 	oRig.auth.sends = nil
 	ensureSuccess("market buy")
+
+	// Verify that ValidateOrderFunding received the actual order quantity as
+	// swapVal, not the buffer minimum. This was a bug where swapVal was set
+	// to the buffer minimum, causing inflated fee estimates.
+	if oRig.btc.lastSwapVal != mktBuyQty {
+		t.Fatalf("market buy swapVal: expected trade.Quantity %d, got %d", mktBuyQty, oRig.btc.lastSwapVal)
+	}
 
 	// Create the order manually, so that we can compare the IDs as another check
 	// of equivalence.


### PR DESCRIPTION
For market buy orders, swapVal was set to the market buy buffer minimum rather than the actual order quantity. This caused ValidateOrderFunding to combine a small swapVal with the full lot count, producing an inflated fee estimate that exceeded the provided coin value.