### PR TITLE
docs: Document unique address requirement for UTXO.

### DIFF
--- a/client/asset/interface.go
+++ b/client/asset/interface.go
@@ -591,6 +591,14 @@ type Wallet interface {
 	// presently called when each trade order is *submitted*. If these are
 	// unique addresses and the orders are canceled, the gap limit may become a
 	// hurdle when restoring the wallet.
+	//
+	// For UTXO-based assets, implementations MUST return a unique address on
+	// each call. The address becomes part of the HTLC script, so a unique
+	// address per trade ensures each swap contract has a unique script hash
+	// and therefore a unique CoinID. This is a critical security property: it
+	// prevents a malicious counterparty from presenting a single on-chain
+	// contract as fulfilling multiple matches. (EVM-based assets use a
+	// different contract structure and are not subject to this requirement.)
 	RedemptionAddress() (string, error)
 	// LockTimeExpired returns true if the specified locktime has expired,
 	// making it possible to redeem the locked coins.

--- a/client/core/trade.go
+++ b/client/core/trade.go
@@ -3925,7 +3925,12 @@ func (t *trackedTrade) auditContract(match *matchTracker, coinID, contract, txDa
 	contractID := coinIDString(assetID, coinID)
 
 	// Audit the contract.
-	// 1. Recipient Address
+	// 1. Recipient Address — must be our own address. For UTXO-based assets,
+	//    this check is also a critical defense against CoinID reuse: since our
+	//    address is unique per trade (see RedemptionAddress), each legitimate
+	//    contract must have a unique script hash and CoinID. A counterparty
+	//    cannot present a single on-chain output as the contract for multiple
+	//    different matches, because each match expects a different recipient.
 	// 2. Contract value
 	// 3. Secret hash: maker compares, taker records
 	if auditInfo.Recipient != t.Trade().Address {


### PR DESCRIPTION
For UTXO-based assets, RedemptionAddress must return a unique address per trade so that each HTLC contract has a unique script hash and CoinID, preventing a malicious counterparty from presenting a single on-chain contract as fulfilling multiple matches.