### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/client/asset/eth/eth_test.go
+++ b/client/asset/eth/eth_test.go
@@ -1369,7 +1369,7 @@ func TestTakeAction(t *testing.T) {
 	}), signer, node.privKey)
 	node.sendTxTx = replacementTx
 
-	tooCheapAction := []byte(fmt.Sprintf(`{"txID":"%s","bump":true}`, pendingTx.ID))
+	tooCheapAction := fmt.Appendf(nil, `{"txID":"%s","bump":true}`, pendingTx.ID)
 	if err := eth.TakeAction(actionTypeTooCheap, tooCheapAction); err != nil {
 		t.Fatalf("TakeAction error: %v", err)
 	}
@@ -1397,7 +1397,7 @@ func TestTakeAction(t *testing.T) {
 	eth.pendingTxs = []*extendedWalletTx{pendingTx}
 	pendingTx.SubmissionTime = 0
 	// Neglecting to bump should reset submission time.
-	tooCheapAction = []byte(fmt.Sprintf(`{"txID":"%s","bump":false}`, pendingTx.ID))
+	tooCheapAction = fmt.Appendf(nil, `{"txID":"%s","bump":false}`, pendingTx.ID)
 	if err := eth.TakeAction(actionTypeTooCheap, tooCheapAction); err != nil {
 		t.Fatalf("TakeAction bump=false error: %v", err)
 	}
@@ -1414,7 +1414,7 @@ func TestTakeAction(t *testing.T) {
 
 	// Nonce-replaced tx
 	eth.pendingTxs = []*extendedWalletTx{pendingTx}
-	lostNonceAction := []byte(fmt.Sprintf(`{"txID":"%s","abandon":true}`, pendingTx.ID))
+	lostNonceAction := fmt.Appendf(nil, `{"txID":"%s","abandon":true}`, pendingTx.ID)
 	if err := eth.TakeAction(actionTypeLostNonce, lostNonceAction); err != nil {
 		t.Fatalf("TakeAction replacment=false, abandon=true error: %v", err)
 	}
@@ -1423,7 +1423,7 @@ func TestTakeAction(t *testing.T) {
 	}
 	eth.pendingTxs = []*extendedWalletTx{pendingTx}
 	node.getTxRes = replacementTx
-	lostNonceAction = []byte(fmt.Sprintf(`{"txID":"%s","abandon":false,"replacementID":"%s"}`, pendingTx.ID, replacementTx.Hash()))
+	lostNonceAction = fmt.Appendf(nil, `{"txID":"%s","abandon":false,"replacementID":"%s"}`, pendingTx.ID, replacementTx.Hash())
 	if err := eth.TakeAction(actionTypeLostNonce, lostNonceAction); err != nil {
 		t.Fatalf("TakeAction replacment=true, error: %v", err)
 	}
@@ -1438,7 +1438,7 @@ func TestTakeAction(t *testing.T) {
 		amt:    1,
 	})
 	eth.pendingTxs = []*extendedWalletTx{pendingTx}
-	lostNonceAction = []byte(fmt.Sprintf(`{"txID":"%s","abandon":false,"replacementID":"%s"}`, pendingTx.ID, replacementTx.Hash()))
+	lostNonceAction = fmt.Appendf(nil, `{"txID":"%s","abandon":false,"replacementID":"%s"}`, pendingTx.ID, replacementTx.Hash())
 	if err := eth.TakeAction(actionTypeLostNonce, lostNonceAction); err == nil {
 		t.Fatalf("no error for wrong nonce")
 	}

--- a/client/core/core_test.go
+++ b/client/core/core_test.go
@@ -11969,7 +11969,7 @@ func TestTakeAction(t *testing.T) {
 
 	rig.dc.trades[oid] = tracker
 
-	requestData := []byte(fmt.Sprintf(`{"orderID":"abcd","coinID":"%s","retry":true}`, dex.Bytes(coinID)))
+	requestData := fmt.Appendf(nil, `{"orderID":"abcd","coinID":"%s","retry":true}`, dex.Bytes(coinID))
 
 	err := rig.core.TakeAction(0, ActionIDRedeemRejected, requestData)
 	if err == nil {
@@ -11977,7 +11977,7 @@ func TestTakeAction(t *testing.T) {
 	}
 
 	rig.core.requestedActions[uniqueID] = nil
-	requestData = []byte(fmt.Sprintf(`{"orderID":"%s","coinID":"%s","retry":false}`, oid, dex.Bytes(coinID)))
+	requestData = fmt.Appendf(nil, `{"orderID":"%s","coinID":"%s","retry":false}`, oid, dex.Bytes(coinID))
 
 	err = rig.core.TakeAction(0, ActionIDRedeemRejected, requestData)
 	if err != nil {
@@ -11987,7 +11987,7 @@ func TestTakeAction(t *testing.T) {
 		t.Fatal("requested action not removed")
 	}
 
-	requestData = []byte(fmt.Sprintf(`{"orderID":"%s","coinID":"%s","retry":true}`, oid, dex.Bytes(coinID)))
+	requestData = fmt.Appendf(nil, `{"orderID":"%s","coinID":"%s","retry":true}`, oid, dex.Bytes(coinID))
 	err = rig.core.TakeAction(0, ActionIDRedeemRejected, requestData)
 	if err != nil {
 		t.Fatalf("error for taker retry=true: %v", err)

--- a/client/tor/tor.go
+++ b/client/tor/tor.go
@@ -79,7 +79,7 @@ func (s *HiddenService) Connect(ctx context.Context) (*sync.WaitGroup, error) {
 	socksPort, serverPort := ports[0], ports[1]
 	s.serverAddr = "127.0.0.1:" + serverPort
 
-	torrcData := []byte(fmt.Sprintf(torrcTemplate, socksPort, s.dataDir, hiddenServiceDir, s.serverAddr))
+	torrcData := fmt.Appendf(nil, torrcTemplate, socksPort, s.dataDir, hiddenServiceDir, s.serverAddr)
 	if err := os.WriteFile(torrcPath, torrcData, 0600); err != nil {
 		return nil, fmt.Errorf("error writing torrc file: %w", err)
 	}

--- a/dex/politeia/proposals.go
+++ b/dex/politeia/proposals.go
@@ -577,7 +577,7 @@ func (p *Politeia) fetchAllProposals() ([]*Proposal, error) {
 // The key is the proposal token prefixed with proposalPrefix to avoid key
 // collisions with other data saved in the db.
 func proposalKey(proposalToken string) []byte {
-	return []byte(fmt.Sprintf("%s:%s", proposalPrefix, proposalToken))
+	return fmt.Appendf(nil, "%s:%s", proposalPrefix, proposalToken)
 }
 
 // proposalsStatusIndex creates the key for the proposal status index. The key is
@@ -585,13 +585,13 @@ func proposalKey(proposalToken string) []byte {
 // vote status to allow querying proposals by their vote status.
 func proposalsStatusIndex(p *Proposal) []byte {
 	reversed := uint64(math.MaxInt64) - p.Timestamp
-	return []byte(fmt.Sprintf(
+	return fmt.Appendf(nil,
 		"%s:%s:%020d:%s",
 		proposalStatusIndexPrefix,
 		VotesStatuses[p.VoteStatus],
 		reversed,
 		p.Token,
-	))
+	)
 }
 
 // proposalsTimestampIndex creates the key for the proposal timestamp index. The key is
@@ -599,12 +599,12 @@ func proposalsStatusIndex(p *Proposal) []byte {
 // timestamp to allow querying proposals by their timestamp.
 func proposalsTimestampIndex(p *Proposal) []byte {
 	reversed := uint64(math.MaxInt64) - p.Timestamp
-	return []byte(fmt.Sprintf(
+	return fmt.Appendf(nil,
 		"%s:%020d:%s",
 		proposalTimestampIndexPrefix,
 		reversed,
 		p.Token,
-	))
+	)
 }
 
 // iterateTable iterates all entries in a table and returns the entries.
@@ -670,7 +670,7 @@ func iterateIndex(db *lexi.DB, limit int, voteStatus string, f func(k, val []byt
 
 		var voteSearchKey []byte
 		if voteStatus != "" {
-			voteSearchKey = lexi.PrefixedKey(indexPrefix, []byte(fmt.Sprintf("%s:%s", proposalStatusIndexPrefix, voteStatus)))
+			voteSearchKey = lexi.PrefixedKey(indexPrefix, fmt.Appendf(nil, "%s:%s", proposalStatusIndexPrefix, voteStatus))
 			it.Seek(voteSearchKey)
 		} else {
 			it.Rewind()


### PR DESCRIPTION
I modified the return statement to utilize fmt.Appendf instead of fmt.Sprintf for creating the formatted byte slice. 
 
 This change enhances performance by directly appending the formatted string to the byte slice, avoiding the need for intermediate memory allocation created by fmt.Sprintf. 
 
 The resulting code is cleaner and more efficient, maintaining the same functionality while improving resource usage.
 
 More info can see https://github.com/golang/go/issues/47579