### PR TITLE
ui: Fix reconfigure from UI

### DIFF
--- a/client/webserver/site/src/js/wallets.ts
+++ b/client/webserver/site/src/js/wallets.ts
@@ -2573,7 +2573,8 @@ export default class WalletsPage extends BasePage {
   /* update wallet configuration */
   async reconfig (): Promise<void> {
     const page = this.page
-    const assetID = this.selectedWalletID
+    const assetID = this.reconfigForm.assetID
+
     Doc.hide(page.reconfigErr)
     let walletType = app().currentWalletDefinition(assetID).type
     if (!Doc.isHidden(page.changeWalletType)) {


### PR DESCRIPTION
The incorrect asset ID was being sent to the backend when reconfiguring base. This changes fixes this.