### PR TITLE
multi: Disable electrum wallets.

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -217,7 +217,7 @@ var (
 		AvailableWallets: []*asset.WalletDefinition{
 			spvWalletDefinition,
 			rpcWalletDefinition,
-			electrumWalletDefinition,
+			// electrumWalletDefinition, // TODO: Broken. Investigate and re-enable.
 		},
 		LegacyWalletIndex: 1,
 		BlockchainClass:   asset.BlockchainClassUTXO,

--- a/client/asset/firo/firo.go
+++ b/client/asset/firo/firo.go
@@ -80,13 +80,13 @@ var (
 				ConfigOpts:        configOpts,
 				MultiFundingOpts:  btc.MultiFundingOpts,
 			},
-			{
-				Type:             walletTypeElectrum,
-				Tab:              "Electrum-Firo (external)",
-				Description:      "Use an external Electrum-Firo Wallet",
-				ConfigOpts:       append(btc.ElectrumConfigOpts, btc.CommonConfigOpts("FIRO", true)...),
-				MultiFundingOpts: btc.MultiFundingOpts,
-			},
+			// {
+			// 	Type:             walletTypeElectrum,
+			// 	Tab:              "Electrum-Firo (external)",
+			// 	Description:      "Use an external Electrum-Firo Wallet",
+			// 	ConfigOpts:       append(btc.ElectrumConfigOpts, btc.CommonConfigOpts("FIRO", true)...),
+			// 	MultiFundingOpts: btc.MultiFundingOpts,
+			// }, // TODO: Broken. Investigate and re-enable.
 		},
 		BlockchainClass: asset.BlockchainClassUTXO,
 	}

--- a/client/asset/ltc/ltc.go
+++ b/client/asset/ltc/ltc.go
@@ -77,7 +77,7 @@ var (
 		AvailableWallets: []*asset.WalletDefinition{
 			spvWalletDefinition,
 			rpcWalletDefinition,
-			electrumWalletDefinition,
+			// electrumWalletDefinition, // TODO: Broken. Investigate and re-enable.
 		},
 		BlockchainClass: asset.BlockchainClassUTXO,
 	}

--- a/client/cmd/simnet-trade-tests/README.md
+++ b/client/cmd/simnet-trade-tests/README.md
@@ -59,12 +59,14 @@ Run `./run help` to see all pre-configured pairs and available flags.
 | `ltcdcr`           | LTC-DCR         | RPC wallets                   |
 | `ltcspvdcr`        | LTC-DCR         | LTC SPV, DCR RPC              |
 | `ltcelectrumdcr`   | LTC-DCR         | LTC Electrum, DCR RPC         |
+| `ltcelectrumeth`   | LTC-ETH         | LTC Electrum, ETH native      |
 | `dcrdash`          | DCR-DASH        | RPC wallets                   |
 | `dcrdoge`          | DCR-DOGE        | RPC wallets                   |
 | `dcrdgb`           | DCR-DGB         | RPC wallets                   |
 | `dcreth`           | DCR-ETH         | DCR RPC, ETH native           |
 | `dcrfiro`          | DCR-FIRO        | RPC wallets                   |
 | `dcrfiroelectrum`  | DCR-FIRO        | DCR RPC, FIRO Electrum        |
+| `firoelectrumdoge` | FIRO-DOGE       | FIRO Electrum, DOGE RPC       |
 | `zecbtc`           | ZEC-BTC         | RPC wallets                   |
 | `dcrusdc`          | DCR-USDC.ETH    | ERC-20 token on Ethereum      |
 | `polygondcr`       | POLYGON-DCR     | Polygon RPC, DCR RPC          |

--- a/client/cmd/simnet-trade-tests/run
+++ b/client/cmd/simnet-trade-tests/run
@@ -116,6 +116,10 @@ case $1 in
     ./simnet-trade-tests --base bch --quote eth --regasset bch ${@:2}
     ;;
 
+  ltcelectrumeth)
+    ./simnet-trade-tests --base ltc --quote eth --regasset ltc --base1type electrum ${@:2}
+    ;;
+
   ltcspveth)
     ./simnet-trade-tests --base ltc --quote eth --regasset ltc --base1type spv ${@:2}
     ;;
@@ -126,6 +130,10 @@ case $1 in
 
   firobtcspv)
     ./simnet-trade-tests --base firo --quote btc --regasset btc --quote1type spv ${@:2}
+    ;;
+
+  firoelectrumdoge)
+    ./simnet-trade-tests --base firo --quote doge --regasset doge --base1type electrum ${@:2}
     ;;
 
   firodoge)
@@ -189,9 +197,11 @@ bchpolygon - Bitcoin Cash RPC wallet and Polygon wallet on BCH-POLYGON market
 ltcdash - Litecoin RPC wallet and Dash RPC wallet on LTC-DASH market
 dogepolygon - Dogecoin RPC wallet and Polygon wallet on DOGE-POLYGON market
 bcheth - Bitcoin Cash RPC wallet and Ethereum wallet on BCH-ETH market
+ltcelectrumeth - Litecoin Electrum wallet and Ethereum wallet on LTC-ETH market
 ltcspveth - Litecoin SPV wallet and Ethereum wallet on LTC-ETH market
 firobtc - Firo RPC wallet and Bitcoin RPC wallet on FIRO-BTC market
 firobtcspv - Firo RPC wallet and Bitcoin SPV wallet on FIRO-BTC market
+firoelectrumdoge - Firo Electrum wallet and Dogecoin RPC wallet on FIRO-DOGE market
 firodoge - Firo RPC wallet and Dogecoin RPC wallet on FIRO-DOGE market
 btcusdceth - Bitcoin RPC wallet and USDC.ETH token on BTC-USDC.ETH market
 btcusdteth - Bitcoin RPC wallet and USDT.ETH token on BTC-USDT.ETH market

--- a/client/core/simnet_trade.go
+++ b/client/core/simnet_trade.go
@@ -396,7 +396,7 @@ func (s *simulationTest) startClients() error {
 					return fmt.Errorf("fund error: %w", err)
 				}
 			mined:
-				for {
+				for fundTimeout := time.After(20 * time.Second); ; {
 					hctrl.mineBlocks(s.ctx, 2)
 					bal, err := c.core.AssetBalance(form.AssetID)
 					if err != nil {
@@ -407,6 +407,8 @@ func (s *simulationTest) startClients() error {
 					}
 					s.log.Infof("Waiting for %s funding tx to be mined", unbip(form.AssetID))
 					select {
+					case <-fundTimeout:
+						return fmt.Errorf("timed out waiting for %s funding tx to be mined", unbip(form.AssetID))
 					case <-time.After(time.Second * 2):
 					case <-s.ctx.Done():
 						return s.ctx.Err()


### PR DESCRIPTION
Disable electrum wallet definitions for BTC, LTC, and FIRO. Simnet trade testing revealed that electrum wallets fail to track swap outputs and confirm redemptions reliably across all three assets.

Add ltcelectrumeth and firoelectrumdoge test pairs to the run script so electrum tests can run in parallel on non-overlapping markets once the issues are fixed. Add a 20s timeout to the funding tx mining loop to prevent tests from hanging indefinitely.