### PR TITLE
Don't block on channel send in oracle fee polling.

### DIFF
--- a/dex/feerates/oracle.go
+++ b/dex/feerates/oracle.go
@@ -118,7 +118,11 @@ func (o *Oracle) calculateAverage() []int {
 
 	// Notify all listeners if we have rates to broadcast.
 	if len(broadCastFeeRates) > 0 {
-		o.listener <- broadCastFeeRates
+		select {
+		case o.listener <- broadCastFeeRates:
+		default:
+			// Listener channel is busy (or shutting down). Do not block the Oracle.
+		}
 	}
 
 	return reActivatedSourceIndexes


### PR DESCRIPTION
Because this channel send occurs without a timeout or non-blocking select fallback, a delay in the consuming goroutine which synchronously transmits the fees to connected WebSocket clients will lock the Oracle's execution thread indefinitely. A remote attacker can exploit this architectural flaw by initiating slow or locked WebSocket connections (e.g. Slow Loris), effectively paralyzing the server's global fee rate calculations and resulting in a Denial of Service.

As the ticker-driven background Oracle loop should never be subject to downstream consumer availability, the channel send must be refactored to be non-blocking. This allows the Oracle to drop a broadcast instance under severe load to prioritize system health rather than failing globally.