### PR TITLE
multi: Bump version to 1.1.0.

### DIFF
--- a/client/app/version.go
+++ b/client/app/version.go
@@ -36,7 +36,7 @@ var (
 	// and build metadata portions MUST only contain characters from
 	// semanticAlphabet.
 	// NOTE: The Version string is overridden on init.
-	Version = "1.1.0-rc2+release.local"
+	Version = "1.1.0+release.local"
 )
 
 func init() {

--- a/client/cmd/bisonw-desktop/electron/pkg.sh
+++ b/client/cmd/bisonw-desktop/electron/pkg.sh
@@ -5,8 +5,8 @@ set -e
 cd "$(dirname "$0")"
 
 # For release, remove pre-release info, and set metadata to "release".
-VER="1.1.0-rc2" # pre, beta, rc1, etc.
-META="release.local" # "release"
+VER="1.1.0" # pre, beta, rc1, etc.
+META="release"
 BISONW_EXE="bisonw"
 
 # Parse flags.

--- a/client/cmd/bisonw-desktop/electron/prepare.sh
+++ b/client/cmd/bisonw-desktop/electron/prepare.sh
@@ -5,8 +5,8 @@ set -e
 cd "$(dirname "$0")"
 
 # For release, remove pre-release info, and set metadata to "release".
-VER="1.1.0-rc2" # pre, beta, rc1, etc.
-META="release.local" # "release"
+VER="1.1.0" # pre, beta, rc1, etc.
+META="release"
 BISONW_EXE="bisonw"
 
 # Parse flags.

--- a/client/cmd/bisonw-desktop/linux/pkg-debian.sh
+++ b/client/cmd/bisonw-desktop/linux/pkg-debian.sh
@@ -7,7 +7,7 @@
 # set -ex
 
 source linux/common.sh
-VER="1.1.0-rc2" # pre, beta, rc1, etc.
+VER="1.1.0" # pre, beta, rc1, etc.
 
 # Parse flags.
 TAGS=""

--- a/client/cmd/bisonw-desktop/winres.json
+++ b/client/cmd/bisonw-desktop/winres.json
@@ -17,22 +17,22 @@
     "#1": {
       "0000": {
         "fixed": {
-          "file_version": "1.1.0.0-rc2",
-          "product_version": "1.1.0.0-rc2"
+          "file_version": "1.1.0.0",
+          "product_version": "1.1.0.0"
         },
         "info": {
           "0409": {
             "Comments": "",
             "CompanyName": "Decred",
             "FileDescription": "Bison Wallet (WebView version)",
-            "FileVersion": "1.1.0.0-rc2",
+            "FileVersion": "1.1.0.0",
             "InternalName": "bisonw",
             "LegalCopyright": "© The Decred Developers. Blue Oak Model License 1.0.0",
             "LegalTrademarks": "",
             "OriginalFilename": "bisonw-desktop.exe",
             "PrivateBuild": "",
             "ProductName": "Bison Wallet",
-            "ProductVersion": "1.1.0.0-rc2",
+            "ProductVersion": "1.1.0.0",
             "SpecialBuild": ""
           }
         }

--- a/client/cmd/bisonw/winres.json
+++ b/client/cmd/bisonw/winres.json
@@ -14,22 +14,22 @@
     "#1": {
       "0000": {
         "fixed": {
-          "file_version": "1.1.0.0-rc2",
-          "product_version": "1.1.0.0-rc2"
+          "file_version": "1.1.0.0",
+          "product_version": "1.1.0.0"
         },
         "info": {
           "0409": {
             "Comments": "",
             "CompanyName": "Decred",
             "FileDescription": "Bison Wallet",
-            "FileVersion": "1.1.0.0-rc2",
+            "FileVersion": "1.1.0.0",
             "InternalName": "bisonw",
             "LegalCopyright": "© The Decred Developers. Blue Oak Model License 1.0.0",
             "LegalTrademarks": "",
             "OriginalFilename": "bisonw.exe",
             "PrivateBuild": "",
             "ProductName": "Bison Wallet",
-            "ProductVersion": "1.1.0.0-rc2",
+            "ProductVersion": "1.1.0.0",
             "SpecialBuild": ""
           }
         }

--- a/client/cmd/bwctl/version.go
+++ b/client/cmd/bwctl/version.go
@@ -41,7 +41,7 @@ var (
 	// and build metadata portions MUST only contain characters from
 	// semanticAlphabet.
 	// NOTE: The Version string is overridden on init.
-	Version = "1.1.0-rc2+release.local"
+	Version = "1.1.0+release.local"
 )
 
 func init() {

--- a/pkg.sh
+++ b/pkg.sh
@@ -3,8 +3,8 @@
 set -e
 
 # For release, remove pre-release info, and set metadata to "release".
-VER="1.1.0-rc2" # pre, beta, rc1, etc.
-META="release.local" # "release"
+VER="1.1.0" # pre, beta, rc1, etc.
+META="release"
 
 export CGO_ENABLED=0
 export GOWORK=off

--- a/server/cmd/dcrdex/version.go
+++ b/server/cmd/dcrdex/version.go
@@ -39,7 +39,7 @@ var (
 	// and build metadata portions MUST only contain characters from
 	// semanticAlphabet.
 	// NOTE: The Version string is overridden on init.
-	Version = "1.1.0-rc2+release.local"
+	Version = "1.1.0+release.local"
 )
 
 func init() {


### PR DESCRIPTION
Rolls the 1.1.0 final release: drops the `-rc2` pre-release suffix and sets build metadata to `release` in the packaging scripts, following the same pattern as the v1.0.0 final bump (#2932) and the rc1->rc2 bump on this branch (#3584).

- `client/app/version.go`, `client/cmd/bwctl/version.go`, `server/cmd/dcrdex/version.go`: `1.1.0-rc2+release.local` -> `1.1.0+release.local`
- `pkg.sh`, `client/cmd/bisonw-desktop/electron/pkg.sh`, `client/cmd/bisonw-desktop/electron/prepare.sh`: `VER="1.1.0-rc2"` -> `VER="1.1.0"`, `META="release.local"` -> `META="release"`
- `client/cmd/bisonw-desktop/linux/pkg-debian.sh`: `VER="1.1.0-rc2"` -> `VER="1.1.0"`
- `client/cmd/bisonw/winres.json`, `client/cmd/bisonw-desktop/winres.json`: `1.1.0.0-rc2` -> `1.1.0.0`

Builds cleanly (`go build ./client/app/... ./client/cmd/bwctl/... ./server/cmd/dcrdex/...`).

Depends on / should land alongside #3612 (commit web assets for 1.1.0), which has not been merged yet.