### PR TITLE
server/dex: assign live swap fee rates to dynamic-tx-fee assets

### DIFF
--- a/server/dex/feemgr.go
+++ b/server/dex/feemgr.go
@@ -52,6 +52,13 @@ type feeFetcher struct {
 		rate  uint64
 		stamp time.Time
 	}
+
+	// erosionWarning rate-limits the operator warning that is logged when
+	// the live fee estimate approaches the configured maxFeeRate.
+	erosionWarning struct {
+		sync.Mutex
+		stamp time.Time
+	}
 }
 
 var _ market.FeeFetcher = (*feeFetcher)(nil)
@@ -76,6 +83,27 @@ func newFeeFetcher(asset *asset.BackedAsset) *feeFetcher {
 // Use the lower rate for a minute after a rate increase to avoid races.
 const stashedRateExpiry = time.Minute
 
+// erosionWarningInterval limits how often the maxFeeRate erosion warning is
+// logged per asset.
+const erosionWarningInterval = 10 * time.Minute
+
+// warnErosion logs an operator warning, at most once per
+// erosionWarningInterval, that the live fee estimate is approaching the
+// configured maxFeeRate. Once the estimate exceeds maxFeeRate, assigned swap
+// fee rates are capped there, and swap transactions may not mine promptly.
+func (f *feeFetcher) warnErosion(rate uint64) {
+	f.erosionWarning.Lock()
+	defer f.erosionWarning.Unlock()
+	if time.Since(f.erosionWarning.stamp) < erosionWarningInterval {
+		return
+	}
+	f.erosionWarning.stamp = time.Now()
+	log.Warnf("Live %s fee rate estimate (%d) is above half of the configured maxFeeRate (%d). "+
+		"If the estimate exceeds maxFeeRate, assigned swap fee rates will be capped there and swap "+
+		"transactions may not mine promptly. Consider raising the %s maxFeeRate.",
+		f.Symbol, rate, f.Asset.MaxFeeRate, f.Symbol)
+}
+
 // FeeRate fetches a new fee rate and updates the cache.
 func (f *feeFetcher) FeeRate(ctx context.Context) uint64 {
 	r, err := f.Backend.FeeRate(ctx)
@@ -85,6 +113,9 @@ func (f *feeFetcher) FeeRate(ctx context.Context) uint64 {
 	}
 	if r <= 0 {
 		return 0
+	}
+	if r > f.Asset.MaxFeeRate/2 {
+		f.warnErosion(r)
 	}
 	if r > f.Asset.MaxFeeRate {
 		r = f.Asset.MaxFeeRate
@@ -124,12 +155,22 @@ func (f *feeFetcher) MaxFeeRate() uint64 {
 	return f.Asset.MaxFeeRate
 }
 
-// SwapFeeRate returns the tx fee that needs to be used to initiate a swap.
-// This fee will be the max fee rate if the asset supports dynamic tx fees,
-// and otherwise it will be the current market fee rate.
+// SwapFeeRate returns the tx fee rate assigned to a match's swap transactions:
+// the current market fee rate, capped at the configured maxFeeRate. The
+// configured maxFeeRate is a reserve bound, not the assigned value.
+//
+// Historically, assets that support dynamic tx fees (EIP-1559) were assigned
+// maxFeeRate itself, since an overshooting fee cap is refunded on-chain and a
+// maximal cap made the assigned rate immune to fee movement between match
+// time and broadcast time. But the maximal cap has off-chain costs that grow
+// with the configured value: clients reserve funds per lot at this rate, gate
+// order placement on it, and lock it into resting orders, so operators are
+// pressured to configure it low, and a network fee spike above the configured
+// value renders every swap transaction unminable. Assigning a live rate frees
+// maxFeeRate to be set high as pure insurance. Fee movement after match time
+// is instead handled client-side: the wallet may raise its fee cap above the
+// assigned rate, up to its order reserves, when the base fee demands
+// (ValidateFeeRate only enforces the assigned rate as a floor).
 func (f *feeFetcher) SwapFeeRate(ctx context.Context) uint64 {
-	if f.Backend.Info().SupportsDynamicTxFee {
-		return f.MaxFeeRate()
-	}
 	return f.FeeRate(ctx)
 }

--- a/server/dex/feemgr_test.go
+++ b/server/dex/feemgr_test.go
@@ -1,0 +1,77 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package dex
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/asset"
+)
+
+// tFeeBackend implements only the asset.Backend methods that feeFetcher
+// uses. Calls to anything else panic via the embedded nil interface.
+type tFeeBackend struct {
+	asset.Backend
+	feeRate uint64
+	feeErr  error
+}
+
+func (b *tFeeBackend) FeeRate(context.Context) (uint64, error) {
+	return b.feeRate, b.feeErr
+}
+
+func tFeeFetcher(maxFeeRate, liveRate uint64) (*feeFetcher, *tFeeBackend) {
+	be := &tFeeBackend{feeRate: liveRate}
+	f := newFeeFetcher(&asset.BackedAsset{
+		Asset: dex.Asset{
+			Symbol:     "polygon",
+			MaxFeeRate: maxFeeRate,
+		},
+		Backend: be,
+	})
+	return f, be
+}
+
+func TestSwapFeeRateLive(t *testing.T) {
+	ctx := context.Background()
+
+	// The assigned rate tracks the live estimate when it is below the
+	// configured max, for all assets, including dynamic-tx-fee assets.
+	f, be := tFeeFetcher(1000, 300)
+	if r := f.SwapFeeRate(ctx); r != 300 {
+		t.Fatalf("expected live rate 300, got %d", r)
+	}
+
+	// The configured max caps the assigned rate.
+	be.feeRate = 5000
+	// A rate increase is stashed: the pre-increase rate is returned once to
+	// avoid racing clients that funded orders against the old rate.
+	if r := f.SwapFeeRate(ctx); r != 300 {
+		t.Fatalf("expected stashed rate 300 after increase, got %d", r)
+	}
+	// Age out the stash to observe the capped rate.
+	f.stashedRate.Lock()
+	f.stashedRate.stamp = time.Now().Add(-2 * stashedRateExpiry)
+	f.stashedRate.Unlock()
+	if r := f.SwapFeeRate(ctx); r != 1000 {
+		t.Fatalf("expected capped rate 1000, got %d", r)
+	}
+
+	// A backend error yields zero, which the market's getFeeRate translates
+	// to maxFeeRate.
+	be.feeErr = errors.New("test error")
+	if r := f.SwapFeeRate(ctx); r != 0 {
+		t.Fatalf("expected 0 on backend error, got %d", r)
+	}
+	be.feeErr = nil
+
+	// LastRate survives the error path from the last good fetch.
+	if r := f.LastRate(); r != 1000 {
+		t.Fatalf("expected last rate 1000, got %d", r)
+	}
+}


### PR DESCRIPTION
Server half of the fee-pipeline fix #3615: EVM matches are now assigned a live fee-rate estimate capped at maxFeeRate, instead of the static `maxFeeRate` config value verbatim.

This restores maxFeeRate to its documented role as a reserve bound (spec/fundamentals.mediawiki), so operators can set it high as pure insurance without inflating client reserves, order gating, or orphaning resting orders on config changes. Adds a rate-limited operator warning when the live estimate exceeds half of `maxFeeRate`.

Related issue: #3608