### PR TITLE
btc: Validate TxHash in AuditContract.

### DIFF
--- a/client/asset/btc/btc.go
+++ b/client/asset/btc/btc.go
@@ -5347,6 +5347,9 @@ func (btc *baseWallet) AuditContract(coinID, contract, txData dex.Bytes, rebroad
 		if err != nil {
 			return nil, fmt.Errorf("coin not found, and error encountered decoding tx data: %v", err)
 		}
+		if h := tx.TxHash(); h != *txHash {
+			return nil, fmt.Errorf("invalid contract tx data: expected hash %s, got %s", txHash, h)
+		}
 		if len(tx.TxOut) <= int(vout) {
 			return nil, fmt.Errorf("specified output %d not found in decoded tx %s", vout, txHash)
 		}

--- a/client/asset/btc/btc_test.go
+++ b/client/asset/btc/btc_test.go
@@ -3588,8 +3588,9 @@ func testAuditContract(t *testing.T, segwit bool, walletType string) {
 
 	txHash := tx.TxHash()
 	const vout = 0
+	contractCoinID := ToCoinID(&txHash, vout)
 
-	audit, err := wallet.AuditContract(ToCoinID(&txHash, vout), contract, txData, false)
+	audit, err := wallet.AuditContract(contractCoinID, contract, txData, false)
 	if err != nil {
 		t.Fatalf("audit error: %v", err)
 	}
@@ -3609,11 +3610,23 @@ func testAuditContract(t *testing.T, segwit bool, walletType string) {
 		t.Fatalf("no error for bad txid")
 	}
 
+	// Correct coin ID, correct contract, correct pkScript, wrong value.
+	forgedTx := makeRawTx([]dex.Bytes{pkScript}, []*wire.TxIn{dummyInput()})
+	forgedTx.TxOut[0].Value = 100 * 1e8
+	forgedTxData, err := serializeMsgTx(forgedTx)
+	if err != nil {
+		t.Fatalf("error making forged contract tx data: %v", err)
+	}
+	_, err = wallet.AuditContract(contractCoinID, contract, forgedTxData, false)
+	if err == nil {
+		t.Fatalf("no error for coin id different than tx hash")
+	}
+
 	// Wrong contract
 	pkh, _ := hex.DecodeString("c6a704f11af6cbee8738ff19fc28cdc70aba0b82")
 	wrongAddr, _ := btcutil.NewAddressPubKeyHash(pkh, &chaincfg.MainNetParams)
 	badContract, _ := txscript.PayToAddrScript(wrongAddr)
-	_, err = wallet.AuditContract(ToCoinID(&txHash, vout), badContract, nil, false)
+	_, err = wallet.AuditContract(contractCoinID, badContract, nil, false)
 	if err == nil {
 		t.Fatalf("no error for wrong contract")
 	}

--- a/client/asset/dcr/dcr_test.go
+++ b/client/asset/dcr/dcr_test.go
@@ -3111,7 +3111,23 @@ func TestAuditContract(t *testing.T) {
 		t.Fatalf("no error for bad txid")
 	}
 
-	// Wrong contract
+	// Correct coin ID, correct contract, correct pkScript, wrong value.
+	forgedTx := wire.NewMsgTx()
+	forgedTx.AddTxIn(&wire.TxIn{})
+	forgedTx.AddTxOut(&wire.TxOut{
+		Value:    500 * int64(tLotSize),
+		PkScript: pkScript,
+	})
+	forgedTxData, err := forgedTx.Bytes()
+	if err != nil {
+		t.Fatalf("error preparing forged contract txdata: %v", err)
+	}
+	_, err = wallet.AuditContract(contractCoinID, contract, forgedTxData, false)
+	if err == nil {
+		t.Fatalf("no error for coin id different than tx hash")
+	}
+
+	// Correct coin ID, wrong contract, correct pkScript, correct tx data.
 	pkh, _ := hex.DecodeString("c6a704f11af6cbee8738ff19fc28cdc70aba0b82")
 	wrongAddr, _ := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(pkh, tChainParams)
 	wrongAddrStr := wrongAddr.String()
@@ -3148,7 +3164,7 @@ func TestAuditContract(t *testing.T) {
 		t.Fatalf("no error for unknown txout")
 	}
 
-	// Wrong txdata, wrong output script
+	// Wrong coin ID, correct contract, wrong pkScript, wrong tx data.
 	wrongContractTx := wire.NewMsgTx()
 	wrongContractTx.AddTxIn(&wire.TxIn{})
 	wrongContractTx.AddTxOut(&wire.TxOut{
@@ -3159,7 +3175,9 @@ func TestAuditContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error preparing wrong contract txdata: %v", err)
 	}
-	_, err = wallet.AuditContract(contractCoinID, contract, wrongContractTxData, false)
+	wrongContractHash := wrongContractTx.TxHash()
+	wrongContractCoinID := ToCoinID(&wrongContractHash, contractVout)
+	_, err = wallet.AuditContract(wrongContractCoinID, contract, wrongContractTxData, false)
 	if err == nil {
 		t.Fatalf("no error for unknown txout")
 	}


### PR DESCRIPTION
If AuditContract checks the coinID and the contract but not the transaction hash, it is possible for a malicious server to send a taker a transaction which meets those criteria yet underpays the expected amount.

This check was already performed in the DCR asset so the fix for BTC has been modeled on that implementation.