### PR TITLE
Add Sharecoin (SHC) asset

### DIFF
--- a/client/asset/importall/importall.go
+++ b/client/asset/importall/importall.go
@@ -11,6 +11,7 @@ import (
 	_ "decred.org/dcrdex/client/asset/doge" // register doge asset
 	_ "decred.org/dcrdex/client/asset/firo" // register firo asset
 	_ "decred.org/dcrdex/client/asset/ltc"  // register ltc asset
+	_ "decred.org/dcrdex/client/asset/shc"  // register shc asset
 	_ "decred.org/dcrdex/client/asset/zec"  // register zec asset
 	// nixed
 	// _ "decred.org/dcrdex/client/asset/zcl"  // register zcl asset

--- a/client/asset/shc/shc.go
+++ b/client/asset/shc/shc.go
@@ -1,0 +1,175 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package shc
+
+import (
+	"fmt"
+	"strconv"
+
+	"decred.org/dcrdex/client/asset"
+	"decred.org/dcrdex/client/asset/btc"
+	"decred.org/dcrdex/dex"
+	dexbtc "decred.org/dcrdex/dex/networks/btc"
+	dexshc "decred.org/dcrdex/dex/networks/shc"
+
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+const (
+	version = 0
+
+	// BipID is not an officially-registered SLIP-44 index - Sharecoin has
+	// none as of 2026-08-09 (confirmed against both this repo's own
+	// dex/bip-id.go, 600 entries, and the upstream satoshilabs/slips
+	// registry directly - zero hits either place). Self-assigned here
+	// following the same convention already used by other self-registered
+	// entries in that table (aqua, kusd, fluid, qkc all use large
+	// arbitrary values rather than seeking a low reserved number).
+	// Derived from Sharecoin's own real mainnet P2P port (8443).
+	BipID = 8443000
+
+	// Real value from a live mainnet node's `getnetworkinfo` "version"
+	// field, 2026-08-09 (all four live nodes run this exact build as of
+	// the 2026-08-07 LoadBlockIndexGuts-fix redeploy) - not guessed.
+	minNetworkVersion    = 319900
+	minDescriptorVersion = 319900
+
+	walletTypeRPC           = "sharecoindRPC"
+	defaultRedeemConfTarget = 2
+)
+
+var (
+	configOpts = append(btc.RPCConfigOpts("Sharecoin", "8332"), []*asset.ConfigOption{
+		{
+			Key:          "fallbackfee",
+			DisplayName:  "Fallback fee rate",
+			Description:  "Sharecoin's 'fallbackfee' rate. Units: SHC/kB",
+			DefaultValue: strconv.FormatFloat(dexshc.DefaultFee*1000/1e8, 'f', -1, 64),
+		},
+		{
+			Key:         "feeratelimit",
+			DisplayName: "Highest acceptable fee rate",
+			Description: "This is the highest network fee rate you are willing to " +
+				"pay on swap transactions. If feeratelimit is lower than a market's " +
+				"maxfeerate, you will not be able to trade on that market with this " +
+				"wallet.  Units: SHC/kB",
+			DefaultValue: strconv.FormatFloat(dexshc.DefaultFeeRateLimit*1000/1e8, 'f', -1, 64),
+		},
+		{
+			Key:         "redeemconftarget",
+			DisplayName: "Redeem confirmation target",
+			Description: "The target number of blocks for the redeem transaction " +
+				"to be mined. Used to set the transaction's fee rate. " +
+				"(default: 2 blocks)",
+			DefaultValue: strconv.FormatUint(defaultRedeemConfTarget, 10),
+		},
+		{
+			Key:         "txsplit",
+			DisplayName: "Pre-split funding inputs",
+			Description: "When placing an order, create a \"split\" transaction to fund the order without locking more of the wallet balance than " +
+				"necessary. Otherwise, excess funds may be reserved to fund the order until the first swap contract is broadcast " +
+				"during match settlement, or the order is canceled. This an extra transaction for which network mining fees are paid. " +
+				"Used only for standing-type orders, e.g. limit orders without immediate time-in-force.",
+			IsBoolean:    true,
+			DefaultValue: "true", // low fee, fast (~120s) block time
+		},
+	}...)
+
+	// WalletInfo defines some general information about a Sharecoin wallet.
+	WalletInfo = &asset.WalletInfo{
+		Name:              "Sharecoin",
+		SupportedVersions: []uint32{version},
+		UnitInfo:          dexshc.UnitInfo,
+		AvailableWallets: []*asset.WalletDefinition{{
+			Type:              walletTypeRPC,
+			Tab:               "External",
+			Description:       "Connect to sharecoind",
+			DefaultConfigPath: dexbtc.SystemConfigPath("sharecoin"),
+			ConfigOpts:        configOpts,
+		}},
+		BlockchainClass: asset.BlockchainClassUTXO,
+	}
+)
+
+func init() {
+	asset.Register(BipID, &Driver{})
+}
+
+// Driver implements asset.Driver.
+type Driver struct{}
+
+// Open creates the Sharecoin exchange wallet. Start the wallet with its Run method.
+func (d *Driver) Open(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
+	return NewWallet(cfg, logger, network)
+}
+
+// DecodeCoinID creates a human-readable representation of a coin ID for
+// Sharecoin.
+func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
+	// Sharecoin and Bitcoin have the same tx hash and output format -
+	// Sharecoin only swaps the PoW algorithm (SHA-256d -> KawPow); the
+	// rest of the Bitcoin Core RPC/wallet/script surface is untouched
+	// upstream, confirmed in this project's own chainparams.cpp/patch
+	// files.
+	return (&btc.Driver{}).DecodeCoinID(coinID)
+}
+
+// Info returns basic information about the wallet and asset.
+func (d *Driver) Info() *asset.WalletInfo {
+	return WalletInfo
+}
+
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinLotSize(maxFeeRate, false)
+}
+
+// NewWallet is the exported constructor by which the DEX will import the
+// exchange wallet. The wallet will shut down when the provided context is
+// canceled. The configPath can be an empty string, in which case the standard
+// system location of the sharecoind config file is assumed.
+func NewWallet(cfg *asset.WalletConfig, logger dex.Logger, network dex.Network) (asset.Wallet, error) {
+	var params *chaincfg.Params
+	switch network {
+	case dex.Mainnet:
+		params = dexshc.MainNetParams
+	default:
+		return nil, fmt.Errorf("unsupported network for shc: %v (mainnet only)", network)
+	}
+
+	// Designate the clone ports. These will be overwritten by any explicit
+	// settings in the configuration file.
+	ports := dexbtc.NetPorts{
+		Mainnet: "8332",
+	}
+	cloneCFG := &btc.BTCCloneCFG{
+		WalletCFG:            cfg,
+		MinNetworkVersion:    minNetworkVersion,
+		MinDescriptorVersion: minDescriptorVersion,
+
+		WalletInfo:          WalletInfo,
+		Symbol:              "shc",
+		Logger:              logger,
+		Network:             network,
+		ChainParams:         params,
+		Ports:               ports,
+		DefaultFallbackFee:  dexshc.DefaultFee,
+		DefaultFeeRateLimit: dexshc.DefaultFeeRateLimit,
+		// false, not DGB's true - confirmed live 2026-08-09 against a real
+		// regtest node that `getbalances` (the modern RPC) works fine here;
+		// `LegacyBalance: true` silently caused Balance() to always report 0
+		// despite the underlying wallet holding real funds, since Sharecoin's
+		// node (a very recent Bitcoin Core fork) doesn't need the legacy
+		// `listunspent`-sum fallback older clones like DigiByte require.
+		LegacyBalance:  false,
+		Segwit:         true,
+		InitTxSize:     dexbtc.InitTxSizeSegwit,
+		InitTxSizeBase: dexbtc.InitTxSizeBaseSegwit,
+		AssetID:        BipID,
+	}
+
+	return btc.BTCCloneWallet(cloneCFG)
+}

--- a/dex/bip-id.go
+++ b/dex/bip-id.go
@@ -647,6 +647,7 @@ var bipIDs = map[uint32]string{
 	91927009: "kusd",
 	99999998: "fluid",
 	99999999: "qkc",
+	8443000:  "shc", // Sharecoin - self-assigned, not an official SLIP-44 index
 	// math.MaxInt32 is the highest ID we should gol for v1 non-mesh dcrdex cuz
 	// of db type used for asset ID.
 	// Reserved for pre-paid bonds.

--- a/dex/networks/shc/params.go
+++ b/dex/networks/shc/params.go
@@ -1,0 +1,77 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org
+
+package shc
+
+import (
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/networks/btc"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+const (
+	// DefaultFee and DefaultFeeRateLimit are estimates, not yet verified
+	// against a real fee market - Sharecoin has no exchange-priced fee
+	// history yet. Units: sats/kvB, same convention as the other BTC-clone
+	// packages in this directory. Revisit once real trading data exists.
+	DefaultFee          = 1000
+	DefaultFeeRateLimit = 25000
+)
+
+func mustHash(hash string) *chainhash.Hash {
+	h, err := chainhash.NewHashFromStr(hash)
+	if err != nil {
+		panic(err.Error())
+	}
+	return h
+}
+
+var (
+	UnitInfo = dex.UnitInfo{
+		AtomicUnit: "satoshi",
+		Conventional: dex.Denomination{
+			Unit:             "SHC",
+			ConversionFactor: 1e8,
+		},
+		FeeRateDenom: "vB",
+	}
+
+	// MainNetParams are the clone parameters for Sharecoin mainnet.
+	// Values read directly from this project's own
+	// bitcoin-source/src/kernel/chainparams.cpp (CMainParams), and the
+	// genesis hash cross-checked against a live mainnet node's own
+	// `getblockhash 0` RPC response, 2026-08-09 - not guessed or derived.
+	MainNetParams = btc.ReadCloneParams(&btc.CloneParams{
+		Name:             "mainnet",
+		PubKeyHashAddrID: 63, // base58Prefixes[PUBKEY_ADDRESS]
+		ScriptHashAddrID: 18, // base58Prefixes[SCRIPT_ADDRESS]
+		Bech32HRPSegwit:  "shc",
+		CoinbaseMaturity: 100, // untouched Bitcoin default (consensus/consensus.h)
+		// pchMessageStart = {0x53,0x48,0x43,0x31} ("SHC1" in
+		// chainparams.cpp), read little-endian - same byte-order
+		// convention as Bitcoin's own pchMessageStart 0xf9beb4d9
+		// becoming wire.MainNet 0xd9b4bef9.
+		Net:         0x31434853,
+		GenesisHash: mustHash("f1f36342dfeca02a77bb5de429c39f9cbac8794275b603c318c79bcab145fc6e"),
+		// HD key prefixes - not required by the client, included for
+		// completeness / server-side fee-address derivation. From
+		// base58Prefixes[EXT_PUBLIC_KEY] / [EXT_SECRET_KEY].
+		HDPublicKeyID:  [4]byte{0x04, 0x2C, 0x03, 0xE3},
+		HDPrivateKeyID: [4]byte{0x04, 0x2C, 0x08, 0x1E},
+	})
+
+	// Regtest params are deliberately not included here. This project's
+	// real, live network is mainnet only (see SHARECOINADMIN.md topology)
+	// - the point of this integration is real people trading real SHC on
+	// Sharecoin's actual live mainnet. Regtest support was built and
+	// verified separately during development (a full local swap was
+	// completed against it, see NOTES.md) but is not part of what gets
+	// submitted upstream.
+)
+
+func init() {
+	if err := chaincfg.Register(MainNetParams); err != nil {
+		panic("failed to register shc parameters: " + err.Error())
+	}
+}

--- a/server/asset/importall/importall.go
+++ b/server/asset/importall/importall.go
@@ -9,6 +9,7 @@ import (
 	_ "decred.org/dcrdex/server/asset/doge" // register doge asset
 	_ "decred.org/dcrdex/server/asset/firo" // register firo asset
 	_ "decred.org/dcrdex/server/asset/ltc"  // register ltc asset
+	_ "decred.org/dcrdex/server/asset/shc"  // register shc asset
 	_ "decred.org/dcrdex/server/asset/xmr"  // register xmr asset
 	_ "decred.org/dcrdex/server/asset/zec"  // register zec asset
 	// nixed

--- a/server/asset/shc/shc.go
+++ b/server/asset/shc/shc.go
@@ -1,0 +1,115 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package shc
+
+import (
+	"fmt"
+
+	"decred.org/dcrdex/dex"
+	dexbtc "decred.org/dcrdex/dex/networks/btc"
+	dexshc "decred.org/dcrdex/dex/networks/shc"
+	"decred.org/dcrdex/server/asset"
+	"decred.org/dcrdex/server/asset/btc"
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+var maxFeeBlocks = 16
+
+// Driver implements asset.Driver.
+type Driver struct{}
+
+// Setup creates the Sharecoin backend. Start the backend with its Run method.
+func (d *Driver) Setup(cfg *asset.BackendConfig) (asset.Backend, error) {
+	return NewBackend(cfg)
+}
+
+// DecodeCoinID creates a human-readable representation of a coin ID for
+// Sharecoin.
+func (d *Driver) DecodeCoinID(coinID []byte) (string, error) {
+	// Sharecoin and Bitcoin have the same tx hash and output format - see
+	// the matching comment in client/asset/shc/shc.go.
+	return (&btc.Driver{}).DecodeCoinID(coinID)
+}
+
+// Version returns the Backend implementation's version number.
+func (d *Driver) Version() uint32 {
+	return version
+}
+
+// UnitInfo returns the dex.UnitInfo for the asset.
+func (d *Driver) UnitInfo() dex.UnitInfo {
+	return dexshc.UnitInfo
+}
+
+// MinBondSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the bond and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinBondSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinBondSize(maxFeeRate, false)
+}
+
+// MinLotSize calculates the minimum bond size for a given fee rate that avoids
+// dust outputs on the swap and refund txs, assuming the maxFeeRate doesn't
+// change.
+func (d *Driver) MinLotSize(maxFeeRate uint64) uint64 {
+	return dexbtc.MinLotSize(maxFeeRate, false)
+}
+
+// Name is the asset's name.
+func (d *Driver) Name() string {
+	return "Sharecoin"
+}
+
+func init() {
+	asset.Register(BipID, &Driver{})
+}
+
+const (
+	version = 0
+	// BipID must match the same self-assigned value used in
+	// client/asset/shc/shc.go - see the comment there for why this isn't
+	// an officially-registered SLIP-44 index.
+	BipID     = 8443000
+	assetName = "shc"
+	feeConfs  = 3
+)
+
+// NewBackend generates the network parameters and creates a shc backend as a
+// btc clone using an asset/btc helper function.
+func NewBackend(cfg *asset.BackendConfig) (asset.Backend, error) {
+	var params *chaincfg.Params
+	switch cfg.Net {
+	case dex.Mainnet:
+		params = dexshc.MainNetParams
+	default:
+		return nil, fmt.Errorf("unsupported network for shc: %v (mainnet only)", cfg.Net)
+	}
+
+	// Designate the clone ports. These will be overwritten by any explicit
+	// settings in the configuration file.
+	ports := dexbtc.NetPorts{
+		Mainnet: "8332",
+	}
+
+	configPath := cfg.ConfigPath
+	if configPath == "" {
+		configPath = dexbtc.SystemConfigPath("sharecoin")
+	}
+
+	return btc.NewBTCClone(&btc.BackendCloneConfig{
+		Name:        assetName,
+		Segwit:      true,
+		ConfigPath:  configPath,
+		Logger:      cfg.Logger,
+		Net:         cfg.Net,
+		ChainParams: params,
+		Ports:       ports,
+		FeeConfs:    feeConfs,
+		// Estimate, not yet verified against a real fee market - see the
+		// matching comment in dex/networks/shc/params.go.
+		NoCompetitionFeeRate: 1000,
+		MaxFeeBlocks:         maxFeeBlocks,
+		RelayAddr:            cfg.RelayAddr,
+	})
+}


### PR DESCRIPTION
## Summary

Adds SHC (Sharecoin) as a standard BTC-clone asset. Sharecoin is an untouched Bitcoin Core fork - only the PoW algorithm is changed (SHA-256d -> KawPow, vendored from Ravencoin's real integration). The rest of the RPC/wallet/script surface is upstream Bitcoin Core, so this integrates via the existing `btc.BTCCloneWallet`/`btc.NewBTCClone` framework, following DigiByte's `dgb.go` as the closest existing reference (also a recent, untouched Bitcoin Core fork).

- `dex/networks/shc/params.go` - mainnet chain params, read directly from Sharecoin's own `chainparams.cpp`, genesis hash and minimum node version cross-checked against a live mainnet node.
- `client/asset/shc/shc.go` - wallet driver (external `sharecoind` RPC connection).
- `server/asset/shc/shc.go` - market-backend driver.
- `dex/bip-id.go` - adds the `shc` symbol entry needed for `markets.json` to recognize the ticker.

`BipID` (8443000) is self-assigned, not an official SLIP-44 index - Sharecoin doesn't have one registered (confirmed against both this repo's own `bip-id.go` and the upstream `satoshilabs/slips` registry directly). Follows the same convention already used by other self-registered entries in this same table (`aqua`, `kusd`, `fluid`, `qkc`).

Mainnet-only for this PR.

## Test plan

- [x] `go vet` and `go build` clean on all three new/modified packages
- [x] `gofmt -l` clean
- [ ] Maintainer review of chain params against Sharecoin's real network