### PR TITLE
client/rpcserver: fix cert handling in handlePostBond

### DIFF
--- a/client/rpcserver/handlers.go
+++ b/client/rpcserver/handlers.go
@@ -1115,6 +1115,20 @@ func handlePostBond(s *RPCServer, msg *msgjson.Message) *msgjson.ResponsePayload
 	exchCfg := exchInf[form.Addr]
 	if exchCfg == nil {
 		// Not already registered.
+		//
+		// form.Cert arrives as a JSON string - bwctl's optionalTextFiles
+		// pre-reads a cert filepath argument into the certificate's raw
+		// content before sending it, same as handleGetDEXConfig does
+		// above (which explicitly converts to []byte for this reason).
+		// core.PostBondForm.Cert is typed any, so it unmarshals as a Go
+		// string rather than []byte here, and core.parseCert then
+		// treats that string as a filepath and tries to re-read the PEM
+		// content as if it were a filename, which always fails. Convert
+		// to []byte here, matching handleGetDEXConfig, so parseCert
+		// takes its []byte branch instead.
+		if certStr, ok := form.Cert.(string); ok && certStr != "" {
+			form.Cert = []byte(certStr)
+		}
 		var err error
 		exchCfg, err = s.core.GetDEXConfig(form.Addr, form.Cert)
 		if err != nil {


### PR DESCRIPTION
## Summary

`handlePostBond` doesn't convert `form.Cert` from a JSON string to `[]byte` before use, unlike `handleGetDEXConfig` two functions above it (which does exactly this conversion, for exactly this reason).

`bwctl`'s `optionalTextFiles` pre-reads a cert filepath argument into the certificate's raw content before sending it over RPC. `handleGetDEXConfig`'s params struct types `Cert` as `string` and explicitly converts it to `[]byte` before passing to core, so `parseCert` takes its `[]byte` branch and uses the content directly.

`core.PostBondForm.Cert` is typed `any`, so it unmarshals as a plain Go `string` instead, and `core.parseCert`'s `string` branch tries to re-read that PEM content as if it were a filename - always fails with a misleading `failed to read certificate file from -----BEGIN CERTIFICATE-----...` error.

Adds the same string-to-`[]byte` conversion `handleGetDEXConfig` already does, so `bwctl postbond <host> <bond> ... <certpath>` actually works for registering a new DEX.

## Test plan

- [x] `go build ./client/rpcserver/...` clean
- [x] `gofmt -l` clean
- [x] Reproduced the original bug and confirmed the fix live: `bwctl postbond` with a cert filepath failed with the misleading file-read error before this change, succeeded (real bond posted, confirmed on-chain) after