### PR TITLE
server/mesh: Add infrastructure for two-node mesh

### DIFF
--- a/dex/msgjson/types.go
+++ b/dex/msgjson/types.go
@@ -107,6 +107,11 @@ const (
 	RPCTestContractGasError              // 87
 	RPCReconfigureWalletError            // 88
 	UnknownOrderError                    // 89
+	SubscribeRejectedError               // 90
+	UserNotConnectedError                // 91
+	ResultUnavailableError               // 92
+	MeshAlreadyConnectedError            // 93
+	MeshIncompatibleLogError             // 94
 )
 
 // Routes are destinations for a "payload" of data. The type of data being

--- a/server/account/account.go
+++ b/server/account/account.go
@@ -49,6 +49,24 @@ func (aid AccountID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(aid.String())
 }
 
+// UnmarshalJSON satisfies the json.Unmarshaler interface, and expects the
+// account ID as a quoted hexadecimal string.
+func (aid *AccountID) UnmarshalJSON(data []byte) error {
+	var enc string
+	if err := json.Unmarshal(data, &enc); err != nil {
+		return err
+	}
+	decoded, err := hex.DecodeString(enc)
+	if err != nil {
+		return err
+	}
+	if len(decoded) != HashSize {
+		return fmt.Errorf("invalid account id length %d", len(decoded))
+	}
+	copy(aid[:], decoded)
+	return nil
+}
+
 // Value implements the sql/driver.Valuer interface.
 func (aid AccountID) Value() (driver.Value, error) {
 	return aid[:], nil // []byte

--- a/server/account/account_test.go
+++ b/server/account/account_test.go
@@ -3,7 +3,10 @@ package account
 import (
 	"bytes"
 	"encoding/hex"
+	"encoding/json"
 	"testing"
+
+	"decred.org/dcrdex/dex/encode"
 )
 
 func TestNewAccountFromPubKey(t *testing.T) {
@@ -81,5 +84,24 @@ func TestNewID(t *testing.T) {
 			t.Errorf("[NewID #%d] expected id %v, got %v",
 				idx+1, hex.EncodeToString(tc.id), hex.EncodeToString(id[:]))
 		}
+	}
+}
+
+func TestAccountIDJSONRoundTrip(t *testing.T) {
+	var want AccountID
+	copy(want[:], encode.RandomBytes(len(want)))
+
+	enc, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	var got AccountID
+	if err := json.Unmarshal(enc, &got); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if got != want {
+		t.Fatalf("wrong account id after round trip. got %s, want %s", got, want)
 	}
 }

--- a/server/db/interface.go
+++ b/server/db/interface.go
@@ -5,6 +5,8 @@ package db
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"time"
 
 	"decred.org/dcrdex/dex"
@@ -363,6 +365,117 @@ type SwapDataFull struct {
 type MarketMatchID struct {
 	order.MatchID
 	Base, Quote uint32 // market
+}
+
+// EventLogEntry is a row in the event log.
+type EventLogEntry struct {
+	// Seq is the entry's sequence number. Stored entries start at 1 and
+	// increase monotonically.
+	Seq uint64
+	// Kind identifies the type of the event.
+	Kind string
+	// Event is the encoded canonical mesh event payload.
+	Event []byte
+	// TxData is the encoded transaction data.
+	TxData []byte
+	// TipHash is the hash of the log through this entry.
+	TipHash []byte
+}
+
+// SnapshotAnchorKind is the kind of the first entry in the event log that
+// was initialized using a snapshot.
+const SnapshotAnchorKind = "snapshot_anchor"
+
+// MeshGenesisKind is the kind of the first entry in the event log of a database
+// that was upgraded from a pre-mesh database. The seq of mesh genesis entries
+// is always 1.
+const MeshGenesisKind = "mesh_genesis"
+
+// IsEventLogAnchorKind reports whether kind is a non-replayable event-log
+// anchor.
+func IsEventLogAnchorKind(kind string) bool {
+	return kind == MeshGenesisKind || kind == SnapshotAnchorKind
+}
+
+// EventLogPosition identifies a position in the event log by sequence number
+// and tip hash. A zero seq represents an empty log.
+type EventLogPosition struct {
+	Seq     uint64
+	TipHash []byte
+}
+
+func (p *EventLogPosition) String() string {
+	if p == nil {
+		return "Position{nil}"
+	}
+	if p.Seq == 0 {
+		return "Position{seq=0}"
+	}
+	return fmt.Sprintf("Position{seq=%d hash=%x}", p.Seq, p.TipHash)
+}
+
+// EventCommitUnknownError means the database could not confirm whether an
+// event transaction committed.
+type EventCommitUnknownError struct {
+	Err error
+}
+
+func (e *EventCommitUnknownError) Error() string {
+	if e == nil || e.Err == nil {
+		return "event commit outcome unknown"
+	}
+	return fmt.Sprintf("event commit outcome unknown: %v", e.Err)
+}
+
+func (e *EventCommitUnknownError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// EventLogDivergenceError means the tip hash at Seq differs from the expected
+// hash.
+type EventLogDivergenceError struct {
+	Seq             uint64
+	ExpectedTipHash []byte
+	ActualTipHash   []byte
+	Err             error
+}
+
+func (e *EventLogDivergenceError) Error() string {
+	if e == nil {
+		return "event log divergence"
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("event log divergence at seq %d: %v", e.Seq, e.Err)
+	}
+	return fmt.Sprintf("event log divergence at seq %d", e.Seq)
+}
+
+func (e *EventLogDivergenceError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// SnapshotStore imports and exports a snapshot of the database state, required
+// to sync a fresh database with a mesh peer.
+type SnapshotStore interface {
+	WriteSnapshot(ctx context.Context, w io.Writer) (*EventLogPosition, error)
+	LoadSnapshot(ctx context.Context, r io.Reader) (*EventLogPosition, error)
+}
+
+// EventLogReader allows callers to read the event log.
+type EventLogReader interface {
+	// EventLogFrontier returns the latest entry's position, or a zero
+	// position if the log is empty.
+	EventLogFrontier(context.Context) (*EventLogPosition, error)
+
+	// EventLogEntriesAfter returns up to limit entries with sequence numbers
+	// greater than after, in increasing order.
+	EventLogEntriesAfter(ctx context.Context, after uint64, limit int) ([]*EventLogEntry, error)
 }
 
 // MatchID constructs a MarketMatchID from an order.Match.

--- a/server/mesh/commands.go
+++ b/server/mesh/commands.go
@@ -9,10 +9,22 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/server/account"
+)
+
+const (
+	// defaultPendingCommandTimeout is how long a slave waits for a forwarded
+	// command before giving up and answering with an unknown outcome error.
+	defaultPendingCommandTimeout = 2 * time.Minute
+
+	// forwardCommandTimeout bounds the command_forward request itself. It must
+	// stay below defaultPendingCommandTimeout so an entry held after a forward
+	// timeout still has a window in which a late completion can land.
+	forwardCommandTimeout = 90 * time.Second
 )
 
 // CommandRequest is a client state-changing request.
@@ -31,6 +43,21 @@ type CommandRequest struct {
 	// If ExecuteCommand returns an error, the caller sends that error
 	// to the client and Respond is not called.
 	Respond func(*msgjson.Message) error
+}
+
+// pendingCommand tracks a forwarded command awaiting completion.
+type pendingCommand struct {
+	reqID   uint64
+	respond func(*msgjson.Message) error
+	expire  *time.Timer
+	acked   bool
+}
+
+// resultUnavailableError answers a pending command whose outcome this node
+// does not know. It must never be used for a refusal.
+func resultUnavailableError(reason string) *msgjson.Error {
+	return msgjson.NewError(msgjson.ResultUnavailableError,
+		"mesh command outcome unknown (%s); resend the request", reason)
 }
 
 // commandCoordinator coordinates the execution of commands and the delivery of
@@ -98,6 +125,176 @@ func (c *commandCoordinator) executeLocal(ctx context.Context, originCommandID s
 		Request:    req,
 		Completion: completion,
 	})
+}
+
+// executeForwarded executes a command forwarded from the slave to the master.
+func (c *commandCoordinator) executeForwarded(ctx context.Context, commandID string, req CommandRequest) *msgjson.Error {
+	return c.executeLocal(ctx, commandID, req)
+}
+
+// forward forwards a command to the master. It registers a pending command
+// and then sends the request to the master.
+func (c *commandCoordinator) forward(ctx context.Context, req CommandRequest) *msgjson.Error {
+	commandID := c.newCommandID()
+	cmd := &commandForward{
+		CommandID: commandID,
+		Kind:      req.Kind,
+		User:      req.User,
+		Msg:       req.Msg,
+	}
+	c.registerPending(commandID, req)
+
+	rpcErr, outcomeUnknown := c.transport.forwardCommand(ctx, cmd)
+	if outcomeUnknown {
+		c.log.Debugf("Command %s forward outcome unknown; holding the pending entry.", commandID)
+		return nil
+	}
+
+	if rpcErr != nil {
+		// failAllPending may have already answered; do not reply twice.
+		if c.takePending(commandID) == nil {
+			return nil
+		}
+		return rpcErr
+	}
+
+	c.markPendingAcked(commandID)
+
+	return nil
+}
+
+// markPendingAcked marks that the master has acknowledged they have received
+// the command.
+func (c *commandCoordinator) markPendingAcked(commandID string) {
+	c.pendingMtx.Lock()
+	if pending := c.pending[commandID]; pending != nil {
+		pending.acked = true
+	}
+	c.pendingMtx.Unlock()
+}
+
+func (c *commandCoordinator) newCommandID() string {
+	return fmt.Sprintf("%s-%d", c.nodeID, nextRequestID())
+}
+
+// receiveForwardedFailure completes a forwarded command with the failure that
+// the master sent.
+func (c *commandCoordinator) receiveForwardedFailure(commandID string, msgErr *msgjson.Error) {
+	if err := c.deliverPendingError(commandID, msgErr); err != nil {
+		c.log.Debugf("failed to deliver command %s failure: %v", commandID, err)
+	}
+}
+
+// receiveForwardedResult completes a forwarded command with the result that
+// the master sent.
+func (c *commandCoordinator) receiveForwardedResult(commandID string, result json.RawMessage) {
+	if err := c.deliverPending(commandID, result); err != nil {
+		c.log.Debugf("failed to deliver command %s result: %v", commandID, err)
+	}
+}
+
+// registerPending is used by the slave to start tracking a command they
+// forwarded to the master.
+func (c *commandCoordinator) registerPending(commandID string, req CommandRequest) {
+	reqID := req.Msg.ID
+	c.pendingMtx.Lock()
+	defer c.pendingMtx.Unlock()
+	c.pending[commandID] = &pendingCommand{
+		reqID:   reqID,
+		respond: req.Respond,
+		expire: time.AfterFunc(defaultPendingCommandTimeout, func() {
+			c.expirePending(commandID)
+		}),
+	}
+}
+
+// expirePending removes a command that has timed out and replies with
+// ResultUnavailableError.
+func (c *commandCoordinator) expirePending(commandID string) {
+	pending := c.takePending(commandID)
+	if pending == nil {
+		return
+	}
+	reason := "forwarded command expired unacknowledged"
+	if pending.acked {
+		reason = "forwarded command expired without a completion"
+	}
+	c.log.Warnf("Forwarded command %s expired after %v (%s); "+
+		"answering the client with an unknown-outcome error.", commandID, defaultPendingCommandTimeout, reason)
+	msgErr := resultUnavailableError(reason)
+	if err := deliverCommandError(pending.reqID, pending.respond, msgErr); err != nil {
+		c.log.Debugf("failed to deliver expiry error for command %s: %v", commandID, err)
+	}
+}
+
+// failAllPending answers every pending forward with an unknown-outcome error.
+func (c *commandCoordinator) failAllPending(reason string) {
+	c.pendingMtx.Lock()
+	pending := c.pending
+	c.pending = make(map[string]*pendingCommand)
+	c.pendingMtx.Unlock()
+
+	if len(pending) == 0 {
+		return
+	}
+	c.log.Warnf("Failing %d pending forwarded command(s) with an unknown-outcome error: %s.",
+		len(pending), reason)
+	msgErr := resultUnavailableError(reason)
+	for commandID, p := range pending {
+		p.expire.Stop()
+		if err := deliverCommandError(p.reqID, p.respond, msgErr); err != nil {
+			c.log.Debugf("failed to deliver failure for command %s: %v", commandID, err)
+		}
+	}
+}
+
+// pendingCount returns the number of pending commands.
+func (c *commandCoordinator) pendingCount() int {
+	c.pendingMtx.Lock()
+	defer c.pendingMtx.Unlock()
+	return len(c.pending)
+}
+
+// removePending is used by the slave to remove a command from the pending list.
+func (c *commandCoordinator) removePending(commandID string) {
+	c.pendingMtx.Lock()
+	if pending := c.pending[commandID]; pending != nil {
+		pending.expire.Stop()
+		delete(c.pending, commandID)
+	}
+	c.pendingMtx.Unlock()
+}
+
+// takePending is used by the slave to remove a command from the pending list
+// and return it.
+func (c *commandCoordinator) takePending(commandID string) *pendingCommand {
+	c.pendingMtx.Lock()
+	defer c.pendingMtx.Unlock()
+	pending := c.pending[commandID]
+	if pending == nil {
+		return nil
+	}
+	pending.expire.Stop()
+	delete(c.pending, commandID)
+	return pending
+}
+
+// deliverPending is used by the slave to deliver a command result to the client.
+func (c *commandCoordinator) deliverPending(commandID string, result any) error {
+	pending := c.takePending(commandID)
+	if pending == nil {
+		return nil
+	}
+	return deliverCommandResult(pending.reqID, pending.respond, result)
+}
+
+// deliverPendingError is used by the slave to deliver a command error to the client.
+func (c *commandCoordinator) deliverPendingError(commandID string, msgErr *msgjson.Error) error {
+	pending := c.takePending(commandID)
+	if pending == nil {
+		return nil
+	}
+	return deliverCommandError(pending.reqID, pending.respond, msgErr)
 }
 
 // CommandCompletion completes a command. A command can be completed

--- a/server/mesh/commands.go
+++ b/server/mesh/commands.go
@@ -1,0 +1,219 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
+)
+
+// CommandRequest is a client state-changing request.
+type CommandRequest struct {
+	// Kind identifies the type of command.
+	Kind string
+
+	// User is the user that is requesting the command.
+	User account.AccountID
+
+	// Msg is the command payload.
+	Msg *msgjson.Message
+
+	// Mesh calls Respond to deliver the command result or failure.
+	// Command executors complete requests through CommandCompletion.
+	// If ExecuteCommand returns an error, the caller sends that error
+	// to the client and Respond is not called.
+	Respond func(*msgjson.Message) error
+}
+
+// commandCoordinator coordinates the execution of commands and the delivery of
+// results and errors to the correct destination.
+type commandCoordinator struct {
+	log        dex.Logger
+	transport  commandTransport
+	nodeID     string
+	executors  map[string]CommandExecutor
+	applyEvent func(context.Context, *Event, eventOrigin) (any, error)
+
+	pendingMtx sync.Mutex
+	pending    map[string]*pendingCommand
+}
+
+func newCommandCoordinator(
+	log dex.Logger,
+	transport commandTransport,
+	nodeID string,
+	executors map[string]CommandExecutor,
+	applyEvent func(context.Context, *Event, eventOrigin) (any, error),
+) *commandCoordinator {
+	return &commandCoordinator{
+		log:        log,
+		transport:  transport,
+		nodeID:     nodeID,
+		executors:  executors,
+		applyEvent: applyEvent,
+		pending:    make(map[string]*pendingCommand),
+	}
+}
+
+// execute executes a command. If the node is currently master, the command
+// will be executed locally, otherwise it is forwarded to the master. If the
+// node is currently not in the state where it can execute locally or forward,
+// a TryAgainLaterError is returned.
+func (c *commandCoordinator) execute(ctx context.Context, req CommandRequest) *msgjson.Error {
+	if req.Msg == nil {
+		return msgjson.NewError(msgjson.RPCInternalError, "nil command message")
+	}
+	if req.Respond == nil {
+		return msgjson.NewError(msgjson.RPCInternalError, "nil command responder")
+	}
+
+	if c.transport.canExecuteCommandLocally() {
+		return c.executeLocal(ctx, "", req)
+	}
+	if c.transport.canForwardCommand() {
+		return c.forward(ctx, req)
+	}
+	return msgjson.NewError(msgjson.TryAgainLaterError,
+		"mesh command %q waiting for established master or slave state", req.Kind)
+}
+
+// executeLocal executes a command locally.
+func (c *commandCoordinator) executeLocal(ctx context.Context, originCommandID string, req CommandRequest) *msgjson.Error {
+	exec := c.executors[req.Kind]
+	if exec == nil {
+		return msgjson.NewError(msgjson.RPCInternalError, "mesh command executor not found for kind %q", req.Kind)
+	}
+
+	completion := newCommandCompletion(originCommandID, req, c)
+	return exec(&CommandContext{
+		Context:    ctx,
+		Request:    req,
+		Completion: completion,
+	})
+}
+
+// CommandCompletion completes a command. A command can be completed
+// by emitting an event, successfully completing without an event,
+// or failing with an error before an event is emitted.
+type CommandCompletion struct {
+	originCommandID string
+	reqID           uint64
+	respond         func(*msgjson.Message) error
+	commands        *commandCoordinator
+}
+
+func newCommandCompletion(
+	originCommandID string,
+	req CommandRequest,
+	commands *commandCoordinator,
+) *CommandCompletion {
+	return &CommandCompletion{
+		originCommandID: originCommandID,
+		reqID:           req.Msg.ID,
+		respond:         req.Respond,
+		commands:        commands,
+	}
+}
+
+// Emit applies and publishes event, then attempts to send a non-nil local
+// result. Forwarded results travel with the event for delivery by the slave.
+// If resultFn is nil, it uses the result set by the event applier.
+func (c *CommandCompletion) Emit(ctx context.Context, event *Event, resultFn func() any) error {
+	_, err := c.commands.applyEvent(ctx, event, c.eventOrigin(resultFn))
+	return err
+}
+
+// eventOrigin describes this completion's command as an event origin: a
+// forwarded command when a peer command ID is attached, a local command
+// otherwise.
+func (c *CommandCompletion) eventOrigin(resultFn func() any) eventOrigin {
+	if c.originCommandID != "" {
+		return forwardedCommandEventOrigin(c.originCommandID, resultFn)
+	}
+	return localCommandEventOrigin(c, resultFn)
+}
+
+// Complete completes a command successfully without emitting an event. Local
+// commands send the result directly; forwarded commands send the result to the
+// slave.
+func (c *CommandCompletion) Complete(ctx context.Context, result any) error {
+	if c.originCommandID == "" {
+		return c.deliverResult(result)
+	}
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	return c.commands.transport.sendCommandResult(ctx, &commandResult{
+		CommandID: c.originCommandID,
+		Result:    b,
+	})
+}
+
+// Fail completes a command without an event. Local commands send the error
+// response directly; forwarded commands send a failure response to the slave.
+func (c *CommandCompletion) Fail(ctx context.Context, msgErr *msgjson.Error) error {
+	if msgErr == nil {
+		panic("nil command error")
+	}
+	if c.originCommandID != "" {
+		return c.commands.transport.sendCommandFailure(ctx, &commandFailure{
+			CommandID: c.originCommandID,
+			Error:     msgErr,
+		})
+	}
+	return c.deliverError(msgErr)
+}
+
+func (c *CommandCompletion) deliverResult(result any) error {
+	return deliverCommandResult(c.reqID, c.respond, result)
+}
+
+func (c *CommandCompletion) deliverError(msgErr *msgjson.Error) error {
+	return deliverCommandError(c.reqID, c.respond, msgErr)
+}
+
+// CommandContext contains a command request and its completion.
+type CommandContext struct {
+	context.Context
+	Request    CommandRequest
+	Completion *CommandCompletion
+}
+
+// CommandExecutor validates the command, and completes it using
+// CommandContext.Completion. If the command is invalid, an error
+// is returned, and the command is not completed.
+type CommandExecutor func(*CommandContext) *msgjson.Error
+
+// errEncodeCommandResult tags a failure to build the response message itself,
+// distinguishing a server-side encoding bug from a routine transport failure.
+var errEncodeCommandResult = errors.New("encode command result")
+
+// deliverCommandResult sends a typed command result to the locally connected
+// client.
+func deliverCommandResult(reqID uint64, respond func(*msgjson.Message) error, result any) error {
+	resp, err := msgjson.NewResponse(reqID, result, nil)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errEncodeCommandResult, err)
+	}
+	return respond(resp)
+}
+
+// deliverCommandError sends a command error to the client.
+func deliverCommandError(reqID uint64, respond func(*msgjson.Message) error, msgErr *msgjson.Error) error {
+	resp, err := msgjson.NewResponse(reqID, nil, msgErr)
+	if err != nil {
+		return err
+	}
+	_ = respond(resp)
+	return nil
+}

--- a/server/mesh/commands_test.go
+++ b/server/mesh/commands_test.go
@@ -25,6 +25,15 @@ func (s *testCommandResponder) Send(msg *msgjson.Message) error {
 	return s.err
 }
 
+func mustMarshalJSON(t testing.TB, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal %T: %v", v, err)
+	}
+	return b
+}
+
 func requireJSONResult(t testing.TB, raw json.RawMessage, want any) {
 	t.Helper()
 	if want == nil {
@@ -81,6 +90,170 @@ func newTestCommandCoordinator(transport meshTransport, applyEvent func(context.
 		ct = transport
 	}
 	return newCommandCoordinator(dex.Disabled, ct, "test-node", nil, applyEvent)
+}
+
+func requireNoPendingCommand(t testing.TB, commands *commandCoordinator, commandID string) {
+	t.Helper()
+	commands.pendingMtx.Lock()
+	defer commands.pendingMtx.Unlock()
+	if commands.pending[commandID] != nil {
+		t.Fatalf("pending command %q was not removed", commandID)
+	}
+}
+
+func TestCommandCoordinatorExecuteForwarded(t *testing.T) {
+	req := testCommandRequest(t)
+	responder := new(testCommandResponder)
+	req.Respond = responder.Send
+	result := map[string]string{"status": "ok"}
+	transport := new(testTransport)
+	var got *CommandContext
+
+	commands := newCommandCoordinator(dex.Disabled, transport, "test-node", map[string]CommandExecutor{
+		"test": func(cmd *CommandContext) *msgjson.Error {
+			got = cmd
+			if err := cmd.Completion.Complete(cmd.Context, result); err != nil {
+				return msgjson.NewError(msgjson.RPCInternalError, "complete failed: %v", err)
+			}
+			return nil
+		},
+	}, nil)
+
+	if msgErr := commands.executeForwarded(context.Background(), "cmd-forwarded", req); msgErr != nil {
+		t.Fatalf("executeForwarded error: %v", msgErr)
+	}
+	if got == nil {
+		t.Fatalf("executor was not called")
+	}
+	if got.Request.Kind != req.Kind || got.Request.User != req.User || got.Request.Msg != req.Msg {
+		t.Fatalf("executed request mismatch: %+v", got.Request)
+	}
+	if got.Completion.originCommandID != "cmd-forwarded" {
+		t.Fatalf("completion origin command id = %q, want cmd-forwarded", got.Completion.originCommandID)
+	}
+	if len(responder.sent) != 0 {
+		t.Fatalf("local responses = %d, want 0", len(responder.sent))
+	}
+	transport.requireCommandResult(t, "cmd-forwarded")
+	requireJSONResult(t, transport.commandResults[0].Result, result)
+}
+
+func TestCommandCoordinatorForwardOutcomeUnknown(t *testing.T) {
+	req := testCommandRequest(t)
+	responder := new(testCommandResponder)
+	req.Respond = responder.Send
+	transport := &testTransport{slave: true, err: errors.New("boom")}
+	commands := newTestCommandCoordinator(transport, nil)
+
+	if msgErr := commands.execute(context.Background(), req); msgErr != nil {
+		t.Fatalf("execute error: %v", msgErr)
+	}
+	responder.requireNoResponses(t)
+	commandID := transport.requireForwardedCommand(t, req).CommandID
+
+	commands.pendingMtx.Lock()
+	pending := commands.pending[commandID]
+	commands.pendingMtx.Unlock()
+	if pending == nil {
+		t.Fatal("pending entry was not held on an unknown forward outcome")
+	}
+	if pending.acked {
+		t.Fatal("unknown forward outcome marked the pending entry acked")
+	}
+
+	result := map[string]string{"status": "ok"}
+	commands.receiveForwardedResult(commandID, mustMarshalJSON(t, result))
+	responder.requireResult(t, result)
+	requireNoPendingCommand(t, commands, commandID)
+}
+
+func TestCommandCoordinatorForwardAckMarksPending(t *testing.T) {
+	req := testCommandRequest(t)
+	transport := &testTransport{slave: true}
+	commands := newTestCommandCoordinator(transport, nil)
+
+	if msgErr := commands.execute(context.Background(), req); msgErr != nil {
+		t.Fatalf("execute error: %v", msgErr)
+	}
+	commandID := transport.requireForwardedCommand(t, req).CommandID
+	defer commands.removePending(commandID)
+
+	commands.pendingMtx.Lock()
+	pending := commands.pending[commandID]
+	commands.pendingMtx.Unlock()
+	if pending == nil {
+		t.Fatal("acked forward removed the pending entry")
+	}
+	if !pending.acked {
+		t.Fatal("acked forward did not mark the pending entry")
+	}
+}
+
+func TestCommandCoordinatorExpirePending(t *testing.T) {
+	for _, acked := range []bool{false, true} {
+		req := testCommandRequest(t)
+		responder := new(testCommandResponder)
+		req.Respond = responder.Send
+		commands := newTestCommandCoordinator(nil, nil)
+		commands.registerPending("cmd-exp", req)
+		if acked {
+			commands.markPendingAcked("cmd-exp")
+		}
+
+		commands.expirePending("cmd-exp")
+		responder.requireErrorCode(t, msgjson.ResultUnavailableError)
+		requireNoPendingCommand(t, commands, "cmd-exp")
+
+		commands.expirePending("cmd-exp")
+		if len(responder.sent) != 1 {
+			t.Fatalf("acked=%v: responses = %d, want 1", acked, len(responder.sent))
+		}
+	}
+}
+
+func TestCommandCoordinatorReceiveForwardedResult(t *testing.T) {
+	req := testCommandRequest(t)
+	responder := new(testCommandResponder)
+	req.Respond = responder.Send
+	commands := newTestCommandCoordinator(nil, nil)
+	commands.registerPending("cmd-ok", req)
+	defer commands.removePending("cmd-ok")
+	result := map[string]string{"status": "ok"}
+
+	commands.receiveForwardedResult("cmd-ok", mustMarshalJSON(t, result))
+	responder.requireResult(t, result)
+	requireNoPendingCommand(t, commands, "cmd-ok")
+}
+
+func TestCommandCoordinatorReceiveForwardedFailure(t *testing.T) {
+	req := testCommandRequest(t)
+	responder := new(testCommandResponder)
+	req.Respond = responder.Send
+	commands := newTestCommandCoordinator(nil, nil)
+	commands.registerPending("cmd-fail", req)
+	defer commands.removePending("cmd-fail")
+
+	commands.receiveForwardedFailure("cmd-fail", msgjson.NewError(msgjson.FundingError, "funding failed"))
+	responder.requireErrorCode(t, msgjson.FundingError)
+	requireNoPendingCommand(t, commands, "cmd-fail")
+}
+
+func TestCommandCoordinatorFailAllPending(t *testing.T) {
+	commands := newTestCommandCoordinator(nil, nil)
+	req := testCommandRequest(t)
+	responder := new(testCommandResponder)
+	req.Respond = responder.Send
+	commands.registerPending("cmd-a", req)
+
+	commands.failAllPending("mesh slave lost its master connection")
+	responder.requireErrorCode(t, msgjson.ResultUnavailableError)
+	requireNoPendingCommand(t, commands, "cmd-a")
+
+	// Second call with nothing pending does not re-answer.
+	commands.failAllPending("node promoted to mesh master")
+	if len(responder.sent) != 1 {
+		t.Fatalf("responses = %d, want 1", len(responder.sent))
+	}
 }
 
 func TestCommandCompletionEmit(t *testing.T) {
@@ -196,6 +369,20 @@ func TestCommandCompletionFail(t *testing.T) {
 			t.Fatalf("local error response = %+v, want funding error", resp.Error)
 		}
 	})
+
+	t.Run("forwarded command sends command failure to slave", func(t *testing.T) {
+		msgErr := msgjson.NewError(msgjson.FundingError, "funding failed")
+		transport := new(testTransport)
+		forwarded := newCommandCompletion("cmd-err", CommandRequest{Msg: newMsg(t)}, newTestCommandCoordinator(transport, nil))
+
+		if err := forwarded.Fail(context.Background(), msgErr); err != nil {
+			t.Fatalf("forwarded Fail error: %v", err)
+		}
+		transport.requireCommandFailure(t, "cmd-err", msgjson.FundingError)
+		if gotErr := transport.commandFailures[0].Error; gotErr != msgErr {
+			t.Fatalf("forwarded failure error = %v, want %v", gotErr, msgErr)
+		}
+	})
 }
 
 func TestCommandCompletionComplete(t *testing.T) {
@@ -220,5 +407,32 @@ func TestCommandCompletionComplete(t *testing.T) {
 			t.Fatalf("local Complete error: %v", err)
 		}
 		responder.requireResult(t, localResult)
+	})
+
+	t.Run("forwarded command sends command result to slave", func(t *testing.T) {
+		transport := new(testTransport)
+		forwarded := newCommandCompletion("cmd-ok", CommandRequest{Msg: newMsg(t)}, newTestCommandCoordinator(transport, nil))
+
+		forwardedResult := map[string]string{"status": "already"}
+		if err := forwarded.Complete(context.Background(), forwardedResult); err != nil {
+			t.Fatalf("forwarded Complete error: %v", err)
+		}
+		transport.requireCommandResult(t, "cmd-ok")
+		requireJSONResult(t, transport.commandResults[0].Result, forwardedResult)
+	})
+
+	t.Run("forwarded nil result is valid command result JSON", func(t *testing.T) {
+		transport := new(testTransport)
+		nilForwarded := newCommandCompletion("cmd-null", CommandRequest{Msg: newMsg(t)}, newTestCommandCoordinator(transport, nil))
+
+		if err := nilForwarded.Complete(context.Background(), nil); err != nil {
+			t.Fatalf("forwarded nil Complete error: %v", err)
+		}
+		transport.requireCommandResult(t, "cmd-null")
+		nilResult := transport.commandResults[0].Result
+		requireJSONResult(t, nilResult, nil)
+		if err := validateCommandResult(&commandResult{CommandID: "cmd-null", Result: nilResult}); err != nil {
+			t.Fatalf("nil command result validation error: %v", err)
+		}
 	})
 }

--- a/server/mesh/commands_test.go
+++ b/server/mesh/commands_test.go
@@ -1,0 +1,224 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
+)
+
+type testCommandResponder struct {
+	sent []*msgjson.Message
+	err  error
+}
+
+func (s *testCommandResponder) Send(msg *msgjson.Message) error {
+	s.sent = append(s.sent, msg)
+	return s.err
+}
+
+func requireJSONResult(t testing.TB, raw json.RawMessage, want any) {
+	t.Helper()
+	if want == nil {
+		var got any
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("result decode into nil: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("result = %v, want nil", got)
+		}
+		return
+	}
+
+	wantType := reflect.TypeOf(want)
+	gotPtr := reflect.New(wantType)
+	if err := json.Unmarshal(raw, gotPtr.Interface()); err != nil {
+		t.Fatalf("result decode into %T: %v", want, err)
+	}
+	got := gotPtr.Elem().Interface()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("result = %#v, want %#v", got, want)
+	}
+}
+
+func (s *testCommandResponder) requireResult(t testing.TB, want any) {
+	t.Helper()
+	if len(s.sent) != 1 {
+		t.Fatalf("responses = %d, want 1", len(s.sent))
+	}
+	resp, err := s.sent[0].Response()
+	if err != nil {
+		t.Fatalf("response decode: %v", err)
+	}
+	requireJSONResult(t, resp.Result, want)
+}
+
+func testCommandRequest(t *testing.T) CommandRequest {
+	t.Helper()
+	msg, err := msgjson.NewRequest(42, "test_route", map[string]string{"ok": "true"})
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	return CommandRequest{
+		Kind:    "test",
+		User:    account.AccountID{0x01},
+		Msg:     msg,
+		Respond: func(*msgjson.Message) error { return nil },
+	}
+}
+
+func newTestCommandCoordinator(transport meshTransport, applyEvent func(context.Context, *Event, eventOrigin) (any, error)) *commandCoordinator {
+	var ct commandTransport = newSingleServerTransport()
+	if transport != nil {
+		ct = transport
+	}
+	return newCommandCoordinator(dex.Disabled, ct, "test-node", nil, applyEvent)
+}
+
+func TestCommandCompletionEmit(t *testing.T) {
+	t.Run("passes local command origin to apply function", func(t *testing.T) {
+		req := testCommandRequest(t)
+		event := &Event{Kind: "test"}
+		result := "ok"
+		var (
+			gotEvent  *Event
+			gotOrigin eventOrigin
+		)
+		commands := newTestCommandCoordinator(nil, func(_ context.Context, event *Event, origin eventOrigin) (any, error) {
+			gotEvent = event
+			gotOrigin = origin
+			return nil, nil
+		})
+		completion := newCommandCompletion("", req, commands)
+
+		if err := completion.Emit(context.Background(), event, func() any { return result }); err != nil {
+			t.Fatalf("Emit error: %v", err)
+		}
+		if gotEvent != event {
+			t.Fatalf("event was not passed to apply function")
+		}
+		if gotOrigin.kind != originLocalCommand {
+			t.Fatalf("origin kind = %d, want %d", gotOrigin.kind, originLocalCommand)
+		}
+		if gotOrigin.completion != completion {
+			t.Fatalf("completion was not passed to apply function")
+		}
+		if gotOrigin.commandID != "" {
+			t.Fatalf("local origin commandID = %q, want empty", gotOrigin.commandID)
+		}
+		if gotOrigin.resultFn == nil || gotOrigin.resultFn() != result {
+			t.Fatalf("result = %v, want %v", gotOrigin.resultFn(), result)
+		}
+	})
+
+	t.Run("passes forwarded command origin without completion", func(t *testing.T) {
+		req := testCommandRequest(t)
+		event := &Event{Kind: "test"}
+		result := "ok"
+		var gotOrigin eventOrigin
+		commands := newTestCommandCoordinator(nil, func(_ context.Context, _ *Event, origin eventOrigin) (any, error) {
+			gotOrigin = origin
+			return nil, nil
+		})
+		completion := newCommandCompletion("cmd-forwarded", req, commands)
+
+		if err := completion.Emit(context.Background(), event, func() any { return result }); err != nil {
+			t.Fatalf("Emit error: %v", err)
+		}
+		if gotOrigin.kind != originForwardedCommand {
+			t.Fatalf("origin kind = %d, want %d", gotOrigin.kind, originForwardedCommand)
+		}
+		if gotOrigin.commandID != "cmd-forwarded" {
+			t.Fatalf("commandID = %q, want cmd-forwarded", gotOrigin.commandID)
+		}
+		if gotOrigin.completion != nil {
+			t.Fatalf("forwarded origin unexpectedly carried completion")
+		}
+		if gotOrigin.resultFn == nil || gotOrigin.resultFn() != result {
+			t.Fatalf("result = %v, want %v", gotOrigin.resultFn(), result)
+		}
+	})
+
+	t.Run("returns apply error", func(t *testing.T) {
+		req := testCommandRequest(t)
+		event := &Event{Kind: "test"}
+		result := "ok"
+		applyErr := errors.New("apply failed")
+		commands := newTestCommandCoordinator(nil, func(context.Context, *Event, eventOrigin) (any, error) {
+			return nil, applyErr
+		})
+		completion := newCommandCompletion("", req, commands)
+
+		err := completion.Emit(context.Background(), event, func() any { return result })
+		if !errors.Is(err, applyErr) {
+			t.Fatalf("Emit apply error = %v, want %v", err, applyErr)
+		}
+	})
+}
+
+func TestCommandCompletionFail(t *testing.T) {
+	newMsg := func(t *testing.T) *msgjson.Message {
+		t.Helper()
+		msg, err := msgjson.NewRequest(42, "test_route", nil)
+		if err != nil {
+			t.Fatalf("NewRequest error: %v", err)
+		}
+		return msg
+	}
+
+	t.Run("local command delivers error response directly", func(t *testing.T) {
+		responder := new(testCommandResponder)
+		msgErr := msgjson.NewError(msgjson.FundingError, "funding failed")
+		local := newCommandCompletion("", CommandRequest{
+			Msg:     newMsg(t),
+			Respond: responder.Send,
+		}, newTestCommandCoordinator(nil, nil))
+
+		if err := local.Fail(context.Background(), msgErr); err != nil {
+			t.Fatalf("local Fail error: %v", err)
+		}
+		if len(responder.sent) != 1 {
+			t.Fatalf("local error responses = %d, want 1", len(responder.sent))
+		}
+		resp, err := responder.sent[0].Response()
+		if err != nil {
+			t.Fatalf("local error response decode: %v", err)
+		}
+		if resp.Error == nil || resp.Error.Code != msgjson.FundingError {
+			t.Fatalf("local error response = %+v, want funding error", resp.Error)
+		}
+	})
+}
+
+func TestCommandCompletionComplete(t *testing.T) {
+	newMsg := func(t *testing.T) *msgjson.Message {
+		t.Helper()
+		msg, err := msgjson.NewRequest(42, "test_route", nil)
+		if err != nil {
+			t.Fatalf("NewRequest error: %v", err)
+		}
+		return msg
+	}
+
+	t.Run("local command delivers response directly", func(t *testing.T) {
+		responder := new(testCommandResponder)
+		local := newCommandCompletion("", CommandRequest{
+			Msg:     newMsg(t),
+			Respond: responder.Send,
+		}, newTestCommandCoordinator(nil, nil))
+
+		localResult := map[string]string{"status": "ok"}
+		if err := local.Complete(context.Background(), localResult); err != nil {
+			t.Fatalf("local Complete error: %v", err)
+		}
+		responder.requireResult(t, localResult)
+	})
+}

--- a/server/mesh/compat.go
+++ b/server/mesh/compat.go
@@ -1,0 +1,131 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// CompatAsset is an asset setting that must be identical on both peers.
+type CompatAsset struct {
+	ID         uint32 `json:"id"`
+	Symbol     string `json:"symbol"`
+	MaxFeeRate uint64 `json:"maxFeeRate"`
+	SwapConf   uint32 `json:"swapConf"`
+	RegFee     uint64 `json:"regFee"`
+	RegConfs   uint32 `json:"regConfs"`
+	RegXPub    string `json:"regXPub,omitempty"`
+	BondAmt    uint64 `json:"bondAmt"`
+	BondConfs  uint32 `json:"bondConfs"`
+}
+
+// CompatMarket is a market setting that must be identical on both peers.
+type CompatMarket struct {
+	Name                   string  `json:"name"`
+	Base                   uint32  `json:"base"`
+	Quote                  uint32  `json:"quote"`
+	LotSize                uint64  `json:"lotSize"`
+	ParcelSize             uint32  `json:"parcelSize"`
+	RateStep               uint64  `json:"rateStep"`
+	EpochDuration          uint64  `json:"epochDuration"`
+	MarketBuyBuffer        float64 `json:"marketBuyBuffer"`
+	MaxUserCancelsPerEpoch uint32  `json:"maxUserCancelsPerEpoch"`
+}
+
+// meshProtocolVersion identifies the mesh wire protocol.
+const meshProtocolVersion uint32 = 0
+
+// CompatConfig is the server config that must be identical on both peers.
+type CompatConfig struct {
+	Network            string `json:"network"`
+	APIVersion         uint16 `json:"apiVersion"`
+	EventSchemaVersion uint32 `json:"eventSchemaVersion"`
+	// MeshProtocolVersion identifies the mesh wire protocol. NewCompatSnapshot
+	// pins it to this package's constant; any caller-supplied value will error
+	// in NewCompatSnapshot.
+	MeshProtocolVersion uint32         `json:"meshProtocolVersion"`
+	BroadcastTimeoutMS  uint64         `json:"broadcastTimeoutMs"`
+	TxWaitExpirationMS  uint64         `json:"txWaitExpirationMs"`
+	CancelThreshold     float64        `json:"cancelThreshold"`
+	FreeCancels         bool           `json:"freeCancels"`
+	PenaltyThreshold    uint32         `json:"penaltyThreshold"`
+	Assets              []CompatAsset  `json:"assets"`
+	Markets             []CompatMarket `json:"markets"`
+}
+
+// CompatSnapshot is the hashed CompatConfig compared during handshake.
+type CompatSnapshot struct {
+	Config *CompatConfig
+	Hash   [32]byte
+}
+
+// NewCompatSnapshot normalizes and hashes cfg for handshake.
+func NewCompatSnapshot(cfg CompatConfig) (*CompatSnapshot, error) {
+	if cfg.MeshProtocolVersion != 0 {
+		return nil, fmt.Errorf("mesh protocol version must be 0")
+	}
+	normalized := normalizeCompatConfig(cfg)
+	encoded, err := json.Marshal(normalized)
+	if err != nil {
+		return nil, fmt.Errorf("marshal compatibility config: %w", err)
+	}
+	return &CompatSnapshot{
+		Config: &normalized,
+		Hash:   sha256.Sum256(encoded),
+	}, nil
+}
+
+// HashString returns the compatibility hash as hex for logging.
+func (s *CompatSnapshot) HashString() string {
+	if s == nil {
+		return ""
+	}
+	return hex.EncodeToString(s.Hash[:])
+}
+
+func normalizeCompatConfig(cfg CompatConfig) CompatConfig {
+	normalized := CompatConfig{
+		Network:             normalizeName(cfg.Network),
+		APIVersion:          cfg.APIVersion,
+		EventSchemaVersion:  cfg.EventSchemaVersion,
+		MeshProtocolVersion: meshProtocolVersion,
+		BroadcastTimeoutMS:  cfg.BroadcastTimeoutMS,
+		TxWaitExpirationMS:  cfg.TxWaitExpirationMS,
+		CancelThreshold:     cfg.CancelThreshold,
+		FreeCancels:         cfg.FreeCancels,
+		PenaltyThreshold:    cfg.PenaltyThreshold,
+		Assets:              make([]CompatAsset, len(cfg.Assets)),
+		Markets:             make([]CompatMarket, len(cfg.Markets)),
+	}
+
+	for i, a := range cfg.Assets {
+		a.Symbol = normalizeName(a.Symbol)
+		normalized.Assets[i] = a
+	}
+	for i, m := range cfg.Markets {
+		m.Name = normalizeName(m.Name)
+		normalized.Markets[i] = m
+	}
+
+	sort.Slice(normalized.Assets, func(i, j int) bool {
+		if normalized.Assets[i].ID == normalized.Assets[j].ID {
+			return normalized.Assets[i].Symbol < normalized.Assets[j].Symbol
+		}
+		return normalized.Assets[i].ID < normalized.Assets[j].ID
+	})
+	sort.Slice(normalized.Markets, func(i, j int) bool {
+		return normalized.Markets[i].Name < normalized.Markets[j].Name
+	})
+
+	return normalized
+}
+
+func normalizeName(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}

--- a/server/mesh/compat_test.go
+++ b/server/mesh/compat_test.go
@@ -1,0 +1,112 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import "testing"
+
+func TestNewCompatSnapshotDeterministic(t *testing.T) {
+	cfgA := CompatConfig{
+		Network:            "testnet",
+		APIVersion:         4,
+		BroadcastTimeoutMS: 720000,
+		TxWaitExpirationMS: 120000,
+		CancelThreshold:    0.95,
+		FreeCancels:        false,
+		PenaltyThreshold:   20,
+		Assets: []CompatAsset{
+			{ID: 42, Symbol: "DCR", MaxFeeRate: 10, SwapConf: 2, BondAmt: 1},
+			{ID: 0, Symbol: "btc", MaxFeeRate: 20, SwapConf: 3, RegFee: 5, RegConfs: 6},
+		},
+		Markets: []CompatMarket{
+			{Name: "btc_dcr", Base: 0, Quote: 42, LotSize: 2, ParcelSize: 3, RateStep: 4, EpochDuration: 5, MarketBuyBuffer: 1.25, MaxUserCancelsPerEpoch: 7},
+			{Name: "dcr_btc", Base: 42, Quote: 0, LotSize: 20, ParcelSize: 30, RateStep: 40, EpochDuration: 50, MarketBuyBuffer: 1.15, MaxUserCancelsPerEpoch: 70},
+		},
+	}
+	cfgB := CompatConfig{
+		Network:            "TESTNET",
+		APIVersion:         4,
+		BroadcastTimeoutMS: 720000,
+		TxWaitExpirationMS: 120000,
+		CancelThreshold:    0.95,
+		FreeCancels:        false,
+		PenaltyThreshold:   20,
+		Assets: []CompatAsset{
+			{ID: 0, Symbol: "BTC", MaxFeeRate: 20, SwapConf: 3, RegFee: 5, RegConfs: 6},
+			{ID: 42, Symbol: "dcr", MaxFeeRate: 10, SwapConf: 2, BondAmt: 1},
+		},
+		Markets: []CompatMarket{
+			{Name: "DCR_BTC", Base: 42, Quote: 0, LotSize: 20, ParcelSize: 30, RateStep: 40, EpochDuration: 50, MarketBuyBuffer: 1.15, MaxUserCancelsPerEpoch: 70},
+			{Name: "BTC_DCR", Base: 0, Quote: 42, LotSize: 2, ParcelSize: 3, RateStep: 4, EpochDuration: 5, MarketBuyBuffer: 1.25, MaxUserCancelsPerEpoch: 7},
+		},
+	}
+
+	snapA, err := NewCompatSnapshot(cfgA)
+	if err != nil {
+		t.Fatalf("NewCompatSnapshot(cfgA) error: %v", err)
+	}
+	snapB, err := NewCompatSnapshot(cfgB)
+	if err != nil {
+		t.Fatalf("NewCompatSnapshot(cfgB) error: %v", err)
+	}
+
+	if snapA.Hash != snapB.Hash {
+		t.Fatalf("hash mismatch for equivalent configs: %x != %x", snapA.Hash, snapB.Hash)
+	}
+}
+
+func TestNewCompatSnapshotDetectsRelevantChange(t *testing.T) {
+	cfg := CompatConfig{
+		Network:            "testnet",
+		APIVersion:         4,
+		EventSchemaVersion: 2,
+		BroadcastTimeoutMS: 720000,
+		TxWaitExpirationMS: 120000,
+		CancelThreshold:    0.95,
+		PenaltyThreshold:   20,
+		Assets: []CompatAsset{
+			{ID: 42, Symbol: "dcr", MaxFeeRate: 10, SwapConf: 2},
+		},
+		Markets: []CompatMarket{
+			{Name: "dcr_btc", Base: 42, Quote: 0, LotSize: 2, ParcelSize: 3, RateStep: 4, EpochDuration: 5},
+		},
+	}
+
+	snapA, err := NewCompatSnapshot(cfg)
+	if err != nil {
+		t.Fatalf("NewCompatSnapshot(cfg) error: %v", err)
+	}
+
+	cfg.Markets[0].RateStep++
+	snapB, err := NewCompatSnapshot(cfg)
+	if err != nil {
+		t.Fatalf("NewCompatSnapshot(modified cfg) error: %v", err)
+	}
+
+	if snapA.Hash == snapB.Hash {
+		t.Fatalf("hash did not change after relevant config change")
+	}
+}
+
+func TestNewCompatSnapshotDetectsEventSchemaChange(t *testing.T) {
+	cfg := CompatConfig{
+		Network:            "testnet",
+		APIVersion:         4,
+		EventSchemaVersion: 2,
+	}
+
+	snapA, err := NewCompatSnapshot(cfg)
+	if err != nil {
+		t.Fatalf("NewCompatSnapshot(cfg) error: %v", err)
+	}
+
+	cfg.EventSchemaVersion++
+	snapB, err := NewCompatSnapshot(cfg)
+	if err != nil {
+		t.Fatalf("NewCompatSnapshot(modified cfg) error: %v", err)
+	}
+
+	if snapA.Hash == snapB.Hash {
+		t.Fatalf("hash did not change after event schema version change")
+	}
+}

--- a/server/mesh/conn.go
+++ b/server/mesh/conn.go
@@ -1,0 +1,331 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/dex/ws"
+	"decred.org/dcrdex/server/db"
+)
+
+const (
+	// meshPingPeriod is the period at which a mesh node will ping its peer.
+	meshPingPeriod = 20 * time.Second
+
+	// defaultRequestTimeout is the default timeout for a request to the mesh peer.
+	defaultRequestTimeout = 10 * time.Second
+)
+
+var (
+	connIDCounter    uint64
+	requestIDCounter uint64
+)
+
+func nextConnID() uint64 {
+	return atomic.AddUint64(&connIDCounter, 1)
+}
+
+func nextRequestID() uint64 {
+	return atomic.AddUint64(&requestIDCounter, 1)
+}
+
+// rpcConn wraps the websocket connection to the mesh peer. It also
+// handles request/response bookkeeping, and dispatches inbound requests
+// to the request handlers.
+type rpcConn struct {
+	*ws.WSLink
+
+	wsConn ws.Connection
+
+	id     uint64
+	routes map[string]meshRoute
+	authed atomic.Bool
+
+	ctx           context.Context
+	cancelContext context.CancelFunc
+
+	reqMtx       sync.Mutex
+	respHandlers map[uint64]chan<- *msgjson.Message
+}
+
+func newRPCConn(ctx context.Context, addr string, wsConn ws.Connection, routes map[string]meshRoute, log dex.Logger) *rpcConn {
+	connCtx, cancel := context.WithCancel(ctx)
+	conn := &rpcConn{
+		wsConn:        wsConn,
+		id:            nextConnID(),
+		routes:        routes,
+		ctx:           connCtx,
+		cancelContext: cancel,
+		respHandlers:  make(map[uint64]chan<- *msgjson.Message),
+	}
+	conn.WSLink = ws.NewWSLink(addr, wsConn, meshPingPeriod, conn.handleMessage, log)
+	conn.WSLink.SetReadLimit(meshReadLimit)
+	return conn
+}
+
+func (c *rpcConn) connect() (*sync.WaitGroup, error) {
+	wg, err := c.WSLink.Connect(c.ctx)
+	if err != nil {
+		c.cancelContext()
+		_ = c.wsConn.Close()
+		return nil, err
+	}
+	c.watchDisconnect()
+	return wg, nil
+}
+
+func (c *rpcConn) watchDisconnect() {
+	go func() {
+		select {
+		case <-c.ctx.Done():
+		case <-c.Done():
+			c.cancelContext()
+		}
+	}()
+}
+
+func (c *rpcConn) ID() uint64 {
+	return c.id
+}
+
+func (c *rpcConn) Authorize() {
+	c.authed.Store(true)
+}
+
+func (c *rpcConn) Authed() bool {
+	return c.authed.Load()
+}
+
+// peerRPCError is a peer's RPC failure, decoded from their response.
+type peerRPCError struct {
+	Code    int
+	Message string
+}
+
+// Error implements the error interface.
+func (e *peerRPCError) Error() string {
+	return fmt.Sprintf("error code %d: %s", e.Code, e.Message)
+}
+
+// MsgError returns the peer error as *msgjson.Error so callers can relay it.
+func (e *peerRPCError) MsgError() *msgjson.Error {
+	return msgjson.NewError(e.Code, "%s", e.Message)
+}
+
+// Request sends a request on route and waits for the peer's response. The
+// result is unmarshaled into response when it is non-nil; a peer-reported
+// failure is returned as a *peerRPCError. If ctx carries no deadline,
+// defaultRequestTimeout applies. The wait ends if the link drops.
+func (c *rpcConn) Request(ctx context.Context, route string, payload any, response any) error {
+	reqID := nextRequestID()
+	req, err := msgjson.NewRequest(reqID, route, payload)
+	if err != nil {
+		return err
+	}
+
+	rawReq, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	respChan := make(chan *msgjson.Message, 1)
+	c.reqMtx.Lock()
+	c.respHandlers[reqID] = respChan
+	c.reqMtx.Unlock()
+	defer c.clearRespHandler(reqID)
+
+	if err := c.SendRaw(rawReq); err != nil {
+		return err
+	}
+
+	reqCtx := ctx
+	cancel := func() {}
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		reqCtx, cancel = context.WithTimeout(ctx, defaultRequestTimeout)
+	}
+	defer cancel()
+
+	select {
+	case respMsg := <-respChan:
+		resp, err := respMsg.Response()
+		if err != nil {
+			return err
+		}
+		if resp.Error != nil {
+			return &peerRPCError{Code: resp.Error.Code, Message: resp.Error.Message}
+		}
+		if response != nil {
+			return json.Unmarshal(resp.Result, response)
+		}
+		return nil
+	case <-reqCtx.Done():
+		if errors.Is(reqCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			return fmt.Errorf("timed out waiting for route %s response", route)
+		}
+		return reqCtx.Err()
+	case <-c.Done():
+		return fmt.Errorf("mesh link disconnected during route %s", route)
+	}
+}
+
+// classifyHelloPeerError wraps a permanent hello refusal from the peer as
+// errPeerIncompatible, if required.
+// AuthenticationError means our hello did not verify
+// MeshIncompatibleLogError means our event log is below the peer's snapshot anchor,
+// so we cannot stream events from them.
+func classifyHelloPeerError(err error, localFrontier *db.EventLogPosition) error {
+	var peerErr *peerRPCError
+	if !errors.As(err, &peerErr) {
+		return err
+	}
+	switch peerErr.Code {
+	case msgjson.AuthenticationError:
+		return wrapPeerIncompatible(peerErr)
+	case msgjson.MeshIncompatibleLogError:
+		err := wrapPeerIncompatible(peerErr)
+		if token := forkResetToken(localFrontier); token != "" {
+			err = fmt.Errorf("%w. This node's event log ends at %s. Back up the database (pg_dump),"+
+				"then restart with --meshforkreset=%s to wipe it and reseed from the peer",
+				err, localFrontier, token)
+		}
+		return err
+	}
+	return err
+}
+
+func (c *rpcConn) requestHello(ctx context.Context, req *helloMessage) (*helloResponse, error) {
+	var resp helloResponse
+	if err := c.Request(ctx, helloRoute, req, &resp); err != nil {
+		return nil, classifyHelloPeerError(err, fromFrontierMessage(req.Frontier))
+	}
+	return &resp, nil
+}
+
+// classifyDecisionPeerError wraps a MeshAlreadyConnectedError from the peer
+// as errPeerAlreadyConnected. Other errors are returned unchanged.
+func classifyDecisionPeerError(err error) error {
+	var peerErr *peerRPCError
+	if errors.As(err, &peerErr) && peerErr.Code == msgjson.MeshAlreadyConnectedError {
+		return fmt.Errorf("%w: %v", errPeerAlreadyConnected, peerErr)
+	}
+	return err
+}
+
+func (c *rpcConn) requestDecision(ctx context.Context, req *decisionMessage) error {
+	return classifyDecisionPeerError(c.Request(ctx, helloDecisionRoute, req, nil))
+}
+
+// handleMessage handles an incoming message from the mesh peer.
+func (c *rpcConn) handleMessage(msg *msgjson.Message) *msgjson.Error {
+	switch msg.Type {
+	case msgjson.Response:
+		if msg.ID == 0 {
+			return msgjson.NewError(msgjson.RPCParseError, "response id cannot be 0")
+		}
+		cb := c.takeRespHandler(msg.ID)
+		if cb == nil {
+			// Response arrived after the requester gave up, so silently drop it.
+			return nil
+		}
+		select {
+		case cb <- msg:
+		default:
+		}
+		return nil
+
+	case msgjson.Request, msgjson.Notification:
+		route := c.routes[msg.Route]
+		if route.handler == nil {
+			return msgjson.NewError(msgjson.RPCUnknownRoute, "unknown route")
+		}
+		if route.requiresAuth && !c.Authed() {
+			return msgjson.NewError(msgjson.UnauthorizedConnection,
+				"cannot use route '%s' on an unauthorized mesh connection", msg.Route)
+		}
+		return route.handler(c.ctx, c, msg)
+
+	default:
+		return msgjson.NewError(msgjson.UnknownMessageType, "unknown message type")
+	}
+}
+
+// takeRespHandler removes and returns the response channel registered for id,
+// or nil if no handler is registered.
+func (c *rpcConn) takeRespHandler(id uint64) chan<- *msgjson.Message {
+	c.reqMtx.Lock()
+	defer c.reqMtx.Unlock()
+	cb, ok := c.respHandlers[id]
+	if ok {
+		delete(c.respHandlers, id)
+	}
+	return cb
+}
+
+func (c *rpcConn) clearRespHandler(id uint64) {
+	c.reqMtx.Lock()
+	delete(c.respHandlers, id)
+	c.reqMtx.Unlock()
+}
+
+// nodeConn holds a peer connection, its node IDs, and any snapshot download.
+type nodeConn struct {
+	// link is the websocket link to the peer.
+	link link
+
+	// peerNodeID is the nodeID of the peer.
+	peerNodeID string
+
+	// initiatorNodeID identifies the node that opened the connection.
+	// It breaks ties between parallel connections.
+	initiatorNodeID string
+
+	// seed is the in-progress snapshot download on this conn.
+	// It is set on the slave when the slave starts a snapshot download,
+	// and cleared after seeding is complete.
+	seed atomic.Pointer[seedAttempt]
+}
+
+func newNodeConn(conn link, peerNodeID, initiatorNodeID string) *nodeConn {
+	return &nodeConn{
+		link:            conn,
+		peerNodeID:      peerNodeID,
+		initiatorNodeID: initiatorNodeID,
+	}
+}
+
+func (c *nodeConn) ID() uint64 {
+	if c == nil || c.link == nil {
+		return 0
+	}
+	return c.link.ID()
+}
+
+func (c *nodeConn) String() string {
+	if c == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("nodeConn{id=%d peer=%s initiator=%s}",
+		c.ID(), c.peerNodeID, c.initiatorNodeID)
+}
+
+// sameConn compares two nodeConns for equality.
+func sameConn(a, b *nodeConn) bool {
+	switch {
+	case a == nil || b == nil:
+		return a == b
+	case a.link == nil || b.link == nil:
+		return a == b
+	default:
+		return a.ID() == b.ID()
+	}
+}

--- a/server/mesh/conn_test.go
+++ b/server/mesh/conn_test.go
@@ -1,0 +1,187 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"github.com/gorilla/websocket"
+)
+
+func TestMeshConnHandleMessageAuthGate(t *testing.T) {
+	conn := &rpcConn{
+		ctx: context.Background(),
+		routes: map[string]meshRoute{
+			helloRoute: {
+				handler: func(context.Context, link, *msgjson.Message) *msgjson.Error {
+					return nil
+				},
+			},
+			helloDecisionRoute: {
+				requiresAuth: true,
+				handler: func(context.Context, link, *msgjson.Message) *msgjson.Error {
+					t.Fatalf("decision handler should not be called on an unauthorized connection")
+					return nil
+				},
+			},
+		},
+		respHandlers: make(map[uint64]chan<- *msgjson.Message),
+	}
+
+	msg, err := msgjson.NewRequest(1, helloDecisionRoute, struct{}{})
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+
+	rpcErr := conn.handleMessage(msg)
+	if rpcErr == nil || rpcErr.Code != msgjson.UnauthorizedConnection {
+		t.Fatalf("wrong rpc error: %+v", rpcErr)
+	}
+}
+
+func TestMeshConnHandleMessageAllowsHelloBeforeAuth(t *testing.T) {
+	type ctxKey struct{}
+	called := false
+	ctx := context.WithValue(context.Background(), ctxKey{}, "route-context")
+	conn := &rpcConn{
+		ctx: ctx,
+		routes: map[string]meshRoute{
+			helloRoute: {
+				handler: func(got context.Context, _ link, _ *msgjson.Message) *msgjson.Error {
+					if got.Value(ctxKey{}) != "route-context" {
+						t.Fatalf("route context value = %v, want route-context", got.Value(ctxKey{}))
+					}
+					called = true
+					return nil
+				},
+			},
+		},
+		respHandlers: make(map[uint64]chan<- *msgjson.Message),
+	}
+
+	msg, err := msgjson.NewRequest(1, helloRoute, struct{}{})
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+
+	if rpcErr := conn.handleMessage(msg); rpcErr != nil {
+		t.Fatalf("handleMessage error: %+v", rpcErr)
+	}
+	if !called {
+		t.Fatalf("hello handler was not called")
+	}
+}
+
+type tWSConn struct {
+	readDeadlineErr error
+
+	closed     chan struct{}
+	closeCount int
+	mtx        sync.Mutex
+	once       sync.Once
+}
+
+func (c *tWSConn) Close() error {
+	c.mtx.Lock()
+	c.closeCount++
+	c.mtx.Unlock()
+	c.once.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+func (c *tWSConn) SetReadLimit(int64) {}
+
+func (c *tWSConn) SetReadDeadline(time.Time) error {
+	return c.readDeadlineErr
+}
+
+func (c *tWSConn) ReadMessage() (int, []byte, error) {
+	<-c.closed
+	return 0, nil, &websocket.CloseError{Code: websocket.CloseNormalClosure}
+}
+
+func (c *tWSConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func (c *tWSConn) WriteMessage(int, []byte) error {
+	return nil
+}
+
+func (c *tWSConn) WriteControl(int, []byte, time.Time) error {
+	return nil
+}
+
+func (c *tWSConn) closes() int {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.closeCount
+}
+
+func TestMeshConnConnectLifecycle(t *testing.T) {
+	t.Run("disconnect cancels route context", func(t *testing.T) {
+		wsConn := &tWSConn{closed: make(chan struct{})}
+		conn := newRPCConn(t.Context(), "test-peer", wsConn, nil, dex.Disabled)
+
+		wg, err := conn.connect()
+		if err != nil {
+			t.Fatalf("connect error: %v", err)
+		}
+
+		conn.Disconnect()
+		defer wg.Wait()
+
+		select {
+		case <-conn.ctx.Done():
+		case <-time.After(time.Second):
+			t.Fatalf("route context was not canceled after disconnect")
+		}
+	})
+
+	t.Run("connect failure cancels route context and closes websocket", func(t *testing.T) {
+		readDeadlineErr := errors.New("set read deadline")
+		wsConn := &tWSConn{
+			closed:          make(chan struct{}),
+			readDeadlineErr: readDeadlineErr,
+		}
+		conn := newRPCConn(t.Context(), "test-peer", wsConn, nil, dex.Disabled)
+
+		wg, err := conn.connect()
+		if !errors.Is(err, readDeadlineErr) {
+			t.Fatalf("connect error = %v, want %v", err, readDeadlineErr)
+		}
+		if wg != nil {
+			t.Fatalf("connect returned waitgroup on error")
+		}
+		if got := wsConn.closes(); got != 1 {
+			t.Fatalf("websocket close count = %d, want 1", got)
+		}
+		select {
+		case <-conn.ctx.Done():
+		case <-time.After(time.Second):
+			t.Fatalf("route context was not canceled after connect failure")
+		}
+	})
+}
+
+func TestPeerRPCError(t *testing.T) {
+	err := &peerRPCError{Code: msgjson.SubscribeRejectedError, Message: "bad tip"}
+	var p *peerRPCError
+	if !errors.As(fmt.Errorf("wrap: %w", err), &p) || p.Code != msgjson.SubscribeRejectedError {
+		t.Fatalf("errors.As peerRPCError = (%v, ok)", p)
+	}
+	msgErr := err.MsgError()
+	if msgErr.Code != err.Code || msgErr.Message != err.Message {
+		t.Fatalf("MsgError = %#v, want code %d message %q", msgErr, err.Code, err.Message)
+	}
+}

--- a/server/mesh/controlloop.go
+++ b/server/mesh/controlloop.go
@@ -1,0 +1,333 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+)
+
+const defaultSlavePromotionDelay = 30 * time.Second
+
+// queuedSignal is a signal queued for the reducer, with an optional reply
+// channel: send sets it to receive the result, post leaves it nil.
+type queuedSignal struct {
+	signal meshSignal
+	reply  chan signalResult
+}
+
+// signalResult is the synchronous reply returned by send.
+type signalResult struct {
+	handled bool
+	err     error
+	state   nodeState
+	outcome signalOutcome
+}
+
+// controlLoopSink provides callbacks for lifecycle related events.
+type controlLoopSink interface {
+	handleEffect(effect)
+	controlHalted(error)
+}
+
+// controlRun is a running control loop's two channels: the queue signals
+// are sent on, and a done channel that tells a blocked sender the loop
+// has exited.
+type controlRun struct {
+	queue   chan queuedSignal
+	runDone <-chan struct{}
+}
+
+// controlLoop is the layer between the node and the pure
+// reducer which updates the node's state. It is responsible
+// for applying signals to the reducer sequentially, updating
+// the node's state, and executing the effects returned by
+// the reducer.
+type controlLoop struct {
+	sink                controlLoopSink
+	log                 dex.Logger
+	nodeID              string
+	slavePromotionDelay time.Duration
+
+	stateMtx       sync.RWMutex
+	state          nodeState
+	lastTransition time.Time
+	// activeRun is non-nil when the loop is running.
+	// There will only be one active run per process.
+	activeRun *controlRun
+}
+
+func newControlLoop(log dex.Logger, nodeID string, sink controlLoopSink) *controlLoop {
+	return &controlLoop{
+		log:                 log,
+		nodeID:              nodeID,
+		slavePromotionDelay: defaultSlavePromotionDelay,
+		sink:                sink,
+		state:               nodeState{mode: modePending},
+	}
+}
+
+// prepareRun sets up the queue before the loop goroutine starts. Once it
+// returns, send and post are safe to call even if the loop hasn't been
+// scheduled yet; signals just wait in the queue. Call it before run.
+func (c *controlLoop) prepareRun(ctx context.Context) {
+	if c.slavePromotionDelay <= 0 {
+		c.slavePromotionDelay = defaultSlavePromotionDelay
+	}
+
+	c.stateMtx.Lock()
+	c.state = nodeState{
+		mode: modePending,
+	}
+	c.activeRun = &controlRun{
+		queue:   make(chan queuedSignal, 16),
+		runDone: ctx.Done(),
+	}
+	c.stateMtx.Unlock()
+}
+
+// teardown cleans up the control-loop variables after the loop exits.
+func (c *controlLoop) teardown() {
+	c.stateMtx.Lock()
+	c.activeRun = nil
+	c.stateMtx.Unlock()
+}
+
+// run starts the mesh control loop. startup resolves once startup reaches an
+// established role (effectStartupResolved).
+func (c *controlLoop) run(ctx context.Context, startup *readiness) {
+	run := c.currentRun()
+	if run == nil {
+		return
+	}
+	defer c.teardown()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case queued := <-run.queue:
+			c.handleSignal(queued, startup)
+		}
+	}
+}
+
+func replySignal(signal queuedSignal, result reduceResult, err error, state nodeState) {
+	if signal.reply == nil {
+		return
+	}
+	signal.reply <- signalResult{
+		handled: result.handled,
+		err:     err,
+		state:   state,
+		outcome: result.outcome,
+	}
+}
+
+// handleSignal reduces one queued signal, commits the resulting state, and
+// executes the reducer's effects.
+func (c *controlLoop) handleSignal(queued queuedSignal, startup *readiness) {
+	currState := c.currentState()
+	sig := queued.signal
+
+	result, err := reduceSignal(c.nodeID, c.slavePromotionDelay, currState, sig)
+	c.logSignal(currState, result.next, sig, result.handled, err)
+
+	if err != nil {
+		replySignal(queued, result, err, currState)
+		return
+	}
+
+	if !result.handled {
+		replySignal(queued, result, nil, currState)
+		return
+	}
+
+	nextState := result.next
+	c.setState(nextState)
+	c.logMeshStateUpdate(currState, nextState, sig)
+
+	halt := c.applyReducerEffects(result.effects, startup)
+
+	// Reply to the signal before calling the halt callback so a caller is never
+	// torn down while still waiting on its own event.
+	replySignal(queued, result, nil, nextState)
+
+	if halt {
+		c.sink.controlHalted(nextState.haltErr)
+	}
+}
+
+// applyReducerEffects executes the reducer's effects in order.
+// Some effects are directly handled by the control loop. Others
+// are passed upstream to the node's effect handler.
+func (c *controlLoop) applyReducerEffects(effects []effect, startup *readiness) (halt bool) {
+	for _, eff := range effects {
+		switch eff.(type) {
+		case effectStartupResolved:
+			startup.resolve(nil)
+		case effectScheduleSlavePromotionCheck:
+			c.scheduleSlavePromotionCheck()
+		case effectHalt:
+			halt = true
+		default:
+			c.sink.handleEffect(eff)
+		}
+	}
+	return halt
+}
+
+func (c *controlLoop) logSignal(prev, next nodeState, sig meshSignal, handled bool, err error) {
+	if err != nil {
+		c.log.Errorf("Mesh signal failed: signal=%s state=%s err=%v",
+			sig, prev, err)
+		return
+	}
+	if handled {
+		c.log.Tracef("Mesh signal handled: signal=%s prev=%s next=%s",
+			sig, prev, next)
+		return
+	}
+	c.log.Tracef("Mesh signal ignored: signal=%s state=%s",
+		sig, prev)
+}
+
+func (c *controlLoop) logMeshStateUpdate(prev, next nodeState, sig meshSignal) {
+	switch sig := sig.(type) {
+	case streamCaughtUpSignal:
+		c.log.Infof("Mesh event stream with peer %s caught up to target %s. Entered state %s.",
+			meshPeerLogID(sig.conn), sig.target, next.mode)
+	case streamFailedSignal:
+		c.log.Warnf("Mesh event stream with peer %s failed: %v. Entered state %s.",
+			meshPeerLogID(sig.conn), sig.err, next.mode)
+	case connectionDisconnectedSignal:
+		c.logConnectionDisconnected(prev, next, sig)
+	case slavePromotionCheckSignal:
+		c.log.Infof("Mesh peer remained disconnected for %v. Entered state %s.",
+			c.slavePromotionDelay, next.mode)
+	case plannedHandoffSignal:
+		c.log.Infof("Mesh planned handoff received at frontier %s. Entered state %s.",
+			sig.target, next.mode)
+	case dialIncompatibleSignal:
+		c.log.Warnf("Mesh peer incompatible: %v. Entered state %s.",
+			sig.err, next.mode)
+	case subscribeRejectedSignal:
+		c.log.Warnf("Mesh subscribe rejected: %v. Entered state %s.",
+			sig.err, next.mode)
+	case terminalApplyFailureSignal:
+		c.log.Criticalf("Mesh event apply failed terminally: %v. Entered state %s.",
+			sig.err, next.mode)
+	case masterReadySignal:
+		c.log.Infof("Mesh master preparation complete. Entered state %s.", next.mode)
+	case masterPreparationFailedSignal:
+		c.log.Criticalf("Mesh master preparation failed: %v. Entered state %s.",
+			sig.err, next.mode)
+	}
+}
+
+func (c *controlLoop) logConnectionDisconnected(prev, next nodeState, sig connectionDisconnectedSignal) {
+	switch {
+	case prev.mode == modeEstablishedSlave && next.mode == modeSlaveNoMaster:
+		c.log.Warnf("Mesh peer %s disconnected. Entered state %s. Will promote to master after %v if the peer remains disconnected.",
+			meshPeerLogID(sig.conn), next.mode, c.slavePromotionDelay)
+	case prev.mode != next.mode:
+		c.log.Warnf("Mesh peer %s disconnected. Entered state %s.",
+			meshPeerLogID(sig.conn), next.mode)
+	case prev.mode.isAuthoritativeMaster() && next.mode.isAuthoritativeMaster():
+		c.log.Warnf("Mesh peer %s disconnected. Remaining in state %s.",
+			meshPeerLogID(sig.conn), next.mode)
+	case prev.mode == modeEstablishedSlaveSyncing && next.mode == modePending:
+		c.log.Warnf("Mesh peer %s disconnected during event stream sync. Entered state %s.",
+			meshPeerLogID(sig.conn), next.mode)
+	}
+}
+
+func meshPeerLogID(peerConn *nodeConn) string {
+	if peerConn == nil {
+		return "<nil>"
+	}
+	if peerConn.peerNodeID != "" {
+		return peerConn.peerNodeID
+	}
+	return peerConn.String()
+}
+
+// send synchronously sends a signal to the control loop and waits for the
+// result.
+func (c *controlLoop) send(sig meshSignal) (signalResult, error) {
+	run := c.currentRun()
+	if run == nil {
+		return signalResult{}, fmt.Errorf("mesh not running")
+	}
+
+	reply := make(chan signalResult, 1)
+
+	select {
+	case run.queue <- queuedSignal{signal: sig, reply: reply}:
+	case <-run.runDone:
+		return signalResult{}, fmt.Errorf("mesh stopped")
+	}
+
+	// Wait for the result. If the loop stops, return any reply
+	// already queued.
+	select {
+	case res := <-reply:
+		return res, nil
+	case <-run.runDone:
+		select {
+		case res := <-reply:
+			return res, nil
+		default:
+		}
+		return signalResult{}, fmt.Errorf("mesh stopped")
+	}
+}
+
+// post queues a signal without waiting for it to be processed.
+func (c *controlLoop) post(sig meshSignal) error {
+	run := c.currentRun()
+	if run == nil {
+		return fmt.Errorf("mesh not running")
+	}
+
+	select {
+	case run.queue <- queuedSignal{signal: sig}:
+		return nil
+	case <-run.runDone:
+		return fmt.Errorf("mesh stopped")
+	}
+}
+
+// currentRun returns the active control run, or nil if none is active.
+func (c *controlLoop) currentRun() *controlRun {
+	c.stateMtx.RLock()
+	defer c.stateMtx.RUnlock()
+	return c.activeRun
+}
+
+// scheduleSlavePromotionCheck waits a certain period of time before posting a
+// slavePromotionCheckSignal. This gives the master a period of time to return
+// before promoting the slave to master, and possibly causing a split brain.
+func (c *controlLoop) scheduleSlavePromotionCheck() {
+	run := c.currentRun()
+	if run == nil {
+		return
+	}
+
+	go func() {
+		timer := time.NewTimer(c.slavePromotionDelay)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			_ = c.post(slavePromotionCheckSignal{
+				at: time.Now(),
+			})
+		case <-run.runDone:
+		}
+	}()
+}

--- a/server/mesh/controlloop_test.go
+++ b/server/mesh/controlloop_test.go
@@ -1,0 +1,430 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/db"
+)
+
+func unexpectedControlEffect(eff effect) {
+	panic(fmt.Sprintf("unexpected reducer effect %T", eff))
+}
+
+func unexpectedHalted(error) {
+	panic("unexpected halt callback")
+}
+
+type testControlSink struct {
+	effect func(effect)
+	halted func(error)
+}
+
+func (s *testControlSink) handleEffect(eff effect) {
+	if s.effect != nil {
+		s.effect(eff)
+	}
+}
+
+func (s *testControlSink) controlHalted(err error) {
+	if s.halted != nil {
+		s.halted(err)
+	}
+}
+
+func newControlLoopWithFuncs(log dex.Logger, nodeID string, effectFn func(effect), haltedFn func(error)) *controlLoop {
+	return newControlLoop(log, nodeID, &testControlSink{effect: effectFn, halted: haltedFn})
+}
+
+func newTestControlLoop(state nodeState) *controlLoop {
+	c := newControlLoopWithFuncs(dex.Disabled, "node-a", unexpectedControlEffect, unexpectedHalted)
+	c.setState(state)
+	return c
+}
+
+func newQueuedTestControlLoop(state nodeState, queueSize int) *controlLoop {
+	c := newTestControlLoop(state)
+	c.stateMtx.Lock()
+	c.activeRun = &controlRun{
+		queue:   make(chan queuedSignal, queueSize),
+		runDone: make(chan struct{}),
+	}
+	c.stateMtx.Unlock()
+	return c
+}
+
+// testQueue exposes the active run's signal queue to tests.
+func (c *controlLoop) testQueue() chan queuedSignal {
+	run := c.currentRun()
+	if run == nil {
+		return nil
+	}
+	return run.queue
+}
+
+type controlSendOutcome struct {
+	res signalResult
+	err error
+}
+
+func TestControlLoopBecameMasterCallback(t *testing.T) {
+	const delay = time.Second
+	at := time.Unix(1_700_000_000, 0)
+	calls := 0
+	control := newControlLoopWithFuncs(dex.Disabled, "node-a", func(eff effect) {
+		switch eff.(type) {
+		case effectBecameMaster:
+			calls++
+		case effectFailPendingCommands:
+		default:
+			unexpectedControlEffect(eff)
+		}
+	}, unexpectedHalted)
+	control.slavePromotionDelay = delay
+	control.setState(nodeState{
+		mode:             modeSlaveNoMaster,
+		peerDisconnected: at,
+	})
+
+	control.handleSignal(queuedSignal{
+		signal: slavePromotionCheckSignal{at: at.Add(delay)},
+	}, newReadiness())
+
+	if control.currentMode() != modePreparingMaster {
+		t.Fatalf("current mode = %s, want %s", control.currentMode(), modePreparingMaster)
+	}
+	if calls != 1 {
+		t.Fatalf("becameMaster calls = %d, want 1", calls)
+	}
+
+	control.handleSignal(queuedSignal{
+		signal: masterReadySignal{},
+	}, newReadiness())
+	if control.currentMode() != modeEstablishedMaster {
+		t.Fatalf("current mode after master ready = %s, want %s", control.currentMode(), modeEstablishedMaster)
+	}
+	if calls != 1 {
+		t.Fatalf("becameMaster calls after master ready = %d, want 1", calls)
+	}
+
+	control.handleSignal(queuedSignal{
+		signal: slavePromotionCheckSignal{at: at.Add(2 * delay)},
+	}, newReadiness())
+	if calls != 1 {
+		t.Fatalf("becameMaster calls after ignored event = %d, want 1", calls)
+	}
+}
+
+func TestControlLoopHandleMeshEventOrdering(t *testing.T) {
+	conn := testSession("node-b", "node-a")
+	reply := make(chan signalResult, 1)
+	var order []string
+	var control *controlLoop
+	control = newControlLoopWithFuncs(dex.Disabled, "node-a", func(eff effect) {
+		mode := control.currentState().mode
+		if mode != modePreparingMaster && mode != modeEstablishedMaster {
+			t.Fatalf("state not committed before effect %T: %s", eff, control.currentState())
+		}
+		if _, ok := eff.(effectBecameMaster); ok && mode != modePreparingMaster {
+			t.Fatalf("state not committed before becameMaster: %s", control.currentState())
+		}
+		order = append(order, reflect.TypeOf(eff).Name())
+	}, unexpectedHalted)
+
+	startup := newReadiness()
+	control.handleSignal(queuedSignal{
+		signal: testHandshakeResolvedSignal(conn, roleUnknown, progressEqual),
+		reply:  reply,
+	}, startup)
+
+	if control.currentMode() != modePreparingMaster {
+		t.Fatalf("current mode = %s, want %s", control.currentMode(), modePreparingMaster)
+	}
+	select {
+	case <-startup.resolved():
+		t.Fatal("startup resolved before master preparation completed")
+	default:
+	}
+	select {
+	case res := <-reply:
+		if res.err != nil || !res.handled || res.state.mode != modePreparingMaster {
+			t.Fatalf("reply = %+v, want handled preparing master", res)
+		}
+	default:
+		t.Fatal("missing synchronous reply")
+	}
+	control.handleSignal(queuedSignal{
+		signal: masterReadySignal{},
+	}, startup)
+	if control.currentMode() != modeEstablishedMaster {
+		t.Fatalf("current mode = %s, want %s", control.currentMode(), modeEstablishedMaster)
+	}
+	select {
+	case <-startup.resolved():
+	default:
+		t.Fatal("startup not resolved after master ready")
+	}
+	wantOrder := []string{
+		"effectBecameMaster",
+		"effectWatchConn",
+		"effectPeerClientEndpointChanged",
+		"effectFailPendingCommands",
+	}
+	if !reflect.DeepEqual(order, wantOrder) {
+		t.Fatalf("order = %v, want %v", order, wantOrder)
+	}
+}
+
+func TestControlLoopHaltCallback(t *testing.T) {
+	t.Run("startup halt preserves reducer result", func(t *testing.T) {
+		var (
+			effectMtx sync.Mutex
+			effects   []string
+		)
+		startup := newReadiness()
+		runCtx, cancel := context.WithCancel(context.Background())
+		control := newControlLoopWithFuncs(dex.Disabled, "node-a", func(eff effect) {
+			effectMtx.Lock()
+			effects = append(effects, reflect.TypeOf(eff).Name())
+			effectMtx.Unlock()
+		}, func(error) {
+			cancel()
+		})
+		var wg sync.WaitGroup
+		control.prepareRun(runCtx)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			control.run(runCtx, startup)
+		}()
+		defer func() {
+			cancel()
+			wg.Wait()
+		}()
+
+		conn := testSession("node-b", "node-a")
+		sendDone := make(chan controlSendOutcome, 1)
+		go func() {
+			res, err := control.send(testHandshakeResolvedSignal(conn, roleSlave, progressDiverged))
+			sendDone <- controlSendOutcome{res: res, err: err}
+		}()
+
+		select {
+		case <-runCtx.Done():
+		case <-time.After(time.Second):
+			t.Fatal("control loop was not canceled after halt")
+		}
+
+		err := (&node{control: control}).waitForStartup(runCtx, startup)
+		if err == nil || !strings.Contains(err.Error(), "halting after handshake") {
+			t.Fatalf("startup error = %v, want handshake halt error", err)
+		}
+		if control.currentState().mode != modeHalted {
+			t.Fatalf("state mode = %s, want halted", control.currentState().mode)
+		}
+		var outcome controlSendOutcome
+		select {
+		case outcome = <-sendDone:
+		case <-time.After(time.Second):
+			t.Fatal("send did not return after halt")
+		}
+		if outcome.err != nil {
+			t.Fatalf("send error = %v, want reducer result", outcome.err)
+		}
+		if !outcome.res.handled || outcome.res.state.mode != modeHalted {
+			t.Fatalf("send result = %+v, want handled halted state", outcome.res)
+		}
+		if outcome.res.state.haltErr == nil || !strings.Contains(outcome.res.state.haltErr.Error(), "halting after handshake") {
+			t.Fatalf("send halt error = %v, want handshake halt error", outcome.res.state.haltErr)
+		}
+
+		effectMtx.Lock()
+		gotEffects := append([]string(nil), effects...)
+		effectMtx.Unlock()
+		wantEffects := []string{"effectDisconnect"}
+		if !reflect.DeepEqual(gotEffects, wantEffects) {
+			t.Fatalf("effects = %v, want %v", gotEffects, wantEffects)
+		}
+	})
+
+	t.Run("runtime halt replies before callback", func(t *testing.T) {
+		haltErr := errors.New("apply failed")
+		reply := make(chan signalResult, 1)
+		runCtx, cancel := context.WithCancel(context.Background())
+
+		callbackCalled := false
+		control := newControlLoopWithFuncs(dex.Disabled, "node-a", unexpectedControlEffect, func(err error) {
+			callbackCalled = true
+			if !errors.Is(err, haltErr) {
+				t.Fatalf("halt callback error = %v, want %v", err, haltErr)
+			}
+			if len(reply) != 1 {
+				t.Fatalf("halt callback ran before synchronous reply was sent")
+			}
+			cancel()
+			select {
+			case <-runCtx.Done():
+			default:
+				t.Fatalf("halt callback did not cancel run context")
+			}
+		})
+		control.prepareRun(runCtx)
+		defer control.teardown()
+		control.setState(nodeState{mode: modeEstablishedMaster})
+
+		startup := newReadiness()
+		control.handleSignal(queuedSignal{
+			signal: terminalApplyFailureSignal{err: haltErr, at: time.Now()},
+			reply:  reply,
+		}, startup)
+		select {
+		case <-startup.resolved():
+			t.Fatalf("startup reported for runtime halt")
+		default:
+		}
+
+		if !callbackCalled {
+			t.Fatalf("halt callback was not called")
+		}
+		select {
+		case res := <-reply:
+			if res.err != nil || !res.handled || res.state.mode != modeHalted {
+				t.Fatalf("reply = %+v, want handled halted state", res)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("missing synchronous reply")
+		}
+	})
+}
+
+func TestControlLoopSendReturnsStoppedIfMeshStopsBeforeReply(t *testing.T) {
+	control := newQueuedTestControlLoop(nodeState{mode: modePending}, 1)
+	runDone := make(chan struct{})
+	control.stateMtx.Lock()
+	control.activeRun.runDone = runDone
+	control.stateMtx.Unlock()
+
+	sendDone := make(chan controlSendOutcome, 1)
+	go func() {
+		res, err := control.send(slavePromotionCheckSignal{})
+		sendDone <- controlSendOutcome{res: res, err: err}
+	}()
+
+	var queued queuedSignal
+	select {
+	case queued = <-control.testQueue():
+	case <-time.After(time.Second):
+		t.Fatal("send did not enqueue event")
+	}
+	if queued.reply == nil {
+		t.Fatal("send queued event without reply channel")
+	}
+
+	close(runDone)
+	select {
+	case outcome := <-sendDone:
+		if outcome.err == nil || !strings.Contains(outcome.err.Error(), "mesh stopped") {
+			t.Fatalf("send error = %v, want mesh stopped", outcome.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("send did not return after mesh stopped")
+	}
+}
+
+func TestControlLoopPromotionTimer(t *testing.T) {
+	becameMaster := make(chan struct{}, 1)
+	control := newControlLoopWithFuncs(dex.Disabled, "node-b", func(eff effect) {
+		if _, ok := eff.(effectBecameMaster); !ok {
+			return
+		}
+		select {
+		case becameMaster <- struct{}{}:
+		default:
+		}
+	}, unexpectedHalted)
+	control.slavePromotionDelay = 20 * time.Millisecond
+	startup := newReadiness()
+	runCtx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	control.prepareRun(runCtx)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		control.run(runCtx, startup)
+	}()
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	conn := testSession("node-a", "node-b")
+	if res, err := control.send(testHandshakeResolvedSignal(conn, roleUnknown, progressEqual)); err != nil || res.err != nil {
+		t.Fatalf("handshake send result = %+v err=%v", res, err)
+	}
+	if control.currentMode() != modeEstablishedSlave {
+		t.Fatalf("mode after handshake = %s, want %s", control.currentMode(), modeEstablishedSlave)
+	}
+	if res, err := control.send(connectionDisconnectedSignal{conn: conn, at: time.Now()}); err != nil || res.err != nil {
+		t.Fatalf("disconnect send result = %+v err=%v", res, err)
+	}
+	waitForCondition(t, func() bool {
+		return control.currentMode() == modePreparingMaster
+	}, "slave promotion timer")
+	select {
+	case <-becameMaster:
+	case <-time.After(time.Second):
+		t.Fatal("missing becameMaster callback")
+	}
+}
+
+func TestControlLoopSendPostLifecycle(t *testing.T) {
+	control := newControlLoopWithFuncs(dex.Disabled, "node-a", func(effect) {}, unexpectedHalted)
+	if _, err := control.send(slavePromotionCheckSignal{}); err == nil || !strings.Contains(err.Error(), "mesh not running") {
+		t.Fatalf("send before start error = %v, want mesh not running", err)
+	}
+	if err := control.post(slavePromotionCheckSignal{}); err == nil || !strings.Contains(err.Error(), "mesh not running") {
+		t.Fatalf("post before start error = %v, want mesh not running", err)
+	}
+
+	startup := newReadiness()
+	runCtx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	control.prepareRun(runCtx)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		control.run(runCtx, startup)
+	}()
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	conn := testSession("node-b", "node-a")
+	res, err := control.send(testHandshakeResolvedSignal(conn, roleUnknown, progressEqual))
+	if err != nil || res.err != nil || !res.handled {
+		t.Fatalf("send while running result = %+v err=%v", res, err)
+	}
+	if err := control.post(streamCaughtUpSignal{conn: conn, target: &db.EventLogPosition{}}); err != nil {
+		t.Fatalf("post while running error = %v", err)
+	}
+
+	cancel()
+	wg.Wait()
+	if _, err := control.send(slavePromotionCheckSignal{}); err == nil {
+		t.Fatalf("send after stop error = nil, want error")
+	}
+	if err := control.post(slavePromotionCheckSignal{}); err == nil {
+		t.Fatalf("post after stop error = nil, want error")
+	}
+}

--- a/server/mesh/dialer.go
+++ b/server/mesh/dialer.go
@@ -1,0 +1,302 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"github.com/gorilla/websocket"
+)
+
+const defaultReconnectInterval = 5 * time.Second
+
+// peerTransport is the transport pieces needed by the outbound dialer.
+type peerTransport interface {
+	link
+	handshakeTransport
+}
+
+// dialFunc dials a peer connection and returns its read-loop waitgroup.
+type dialFunc func(ctx context.Context) (peerTransport, *sync.WaitGroup, error)
+
+// handshakeFunc runs the outbound handshake on a connected peer.
+type handshakeFunc func(ctx context.Context, conn handshakeTransport) (*handshakeResult, error)
+
+// dialerNode is the node surface the outbound dialer needs.
+type dialerNode interface {
+	hasPeerConnection() bool
+	applyHandshakeResult(ctx context.Context, conn link, result *handshakeResult, initiatorNodeID string) error
+	postDialIncompatible(err error)
+	postMasterEvidence(at time.Time)
+}
+
+// outboundDialer dials the configured peer whenever this node has no peer
+// connection. A completed handshake is handed to the control loop, which
+// decides whether to adopt the connection.
+type outboundDialer struct {
+	peerURL           *url.URL
+	peerRoots         *x509.CertPool
+	reconnectInterval time.Duration
+	log               dex.Logger
+	handshakeSvc      *handshakeService
+	meshRoutes        map[string]meshRoute
+	node              dialerNode
+
+	attempts atomic.Uint64
+
+	lastDialMtx sync.Mutex
+	lastDialErr string
+	lastDialAt  time.Time
+}
+
+func newOutboundDialer(
+	peerAddr string,
+	peerCert []byte,
+	log dex.Logger,
+	handshakeSvc *handshakeService,
+	meshRoutes map[string]meshRoute,
+	node dialerNode,
+) (*outboundDialer, error) {
+	peerURL, err := parsePeerURL(peerAddr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid peer address: %w", err)
+	}
+
+	var peerRoots *x509.CertPool
+	if peerURL.Scheme == "wss" {
+		if len(peerCert) == 0 {
+			return nil, fmt.Errorf("peer certificate required for TLS mesh peer")
+		}
+		peerRoots = x509.NewCertPool()
+		if ok := peerRoots.AppendCertsFromPEM(peerCert); !ok {
+			return nil, fmt.Errorf("invalid peer cert")
+		}
+	}
+
+	return &outboundDialer{
+		peerURL:           peerURL,
+		peerRoots:         peerRoots,
+		reconnectInterval: defaultReconnectInterval,
+		log:               log,
+		handshakeSvc:      handshakeSvc,
+		meshRoutes:        meshRoutes,
+		node:              node,
+	}, nil
+}
+
+// attemptCount reports outbound dial attempts since startup.
+func (d *outboundDialer) attemptCount() uint64 {
+	return d.attempts.Load()
+}
+
+// lastDialError reports the most recent failed dial/handshake error and when it
+// occurred.
+func (d *outboundDialer) lastDialError() (string, time.Time) {
+	d.lastDialMtx.Lock()
+	defer d.lastDialMtx.Unlock()
+	return d.lastDialErr, d.lastDialAt
+}
+
+// useTLS reports whether the outbound connection uses TLS.
+func (d *outboundDialer) useTLS() bool {
+	return d.peerURL.Scheme == "wss"
+}
+
+// Run runs the reconnect loop until ctx is canceled.
+func (d *outboundDialer) Run(ctx context.Context) {
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			d.connectPeer(ctx, d.dial, d.handshakeSvc.initiateHandshake)
+			timer.Reset(d.reconnectInterval)
+		}
+	}
+}
+
+// connectPeer makes one connection attempt, unless the node already has a
+// peer connection. dial and initiateHandshake are parameters so the flow can
+// be tested without websockets.
+func (d *outboundDialer) connectPeer(ctx context.Context, dial dialFunc, initiateHandshake handshakeFunc) {
+	if d.node.hasPeerConnection() {
+		return
+	}
+
+	d.attempts.Add(1)
+
+	err := d.dialAndHandshake(ctx, dial, initiateHandshake)
+	if err == nil || ctx.Err() != nil {
+		return
+	}
+
+	d.lastDialMtx.Lock()
+	repeatErr := d.lastDialErr == err.Error()
+	d.lastDialErr = err.Error()
+	d.lastDialAt = time.Now()
+	d.lastDialMtx.Unlock()
+
+	// The signal is posted on every attempt because master evidence must stay
+	// fresh, but avoid spamming the logs.
+	var what string
+	switch {
+	case errors.Is(err, errPeerAlreadyConnected):
+		what = "still holds the active session; postponing slave promotion"
+		d.node.postMasterEvidence(time.Now())
+	case errors.Is(err, errPeerIncompatible):
+		what = "is incompatible"
+		d.node.postDialIncompatible(err)
+	default:
+		what = "connection ended"
+	}
+	if repeatErr {
+		d.log.Debugf("Mesh peer %s %s: %v", d.peerURL, what, err)
+	} else {
+		d.log.Warnf("Mesh peer %s %s: %v", d.peerURL, what, err)
+	}
+}
+
+// dialAndHandshake dials the peer, runs the outbound handshake, and hands the
+// result to the control loop via applyHandshakeResult.
+func (d *outboundDialer) dialAndHandshake(ctx context.Context, dial dialFunc, initiateHandshake handshakeFunc) error {
+	conn, wg, err := dial(ctx)
+	if err != nil {
+		return err
+	}
+
+	handshake, err := initiateHandshake(ctx, conn)
+	if err == nil {
+		conn.Authorize()
+		err = d.node.applyHandshakeResult(ctx, conn, handshake, d.handshakeSvc.nodeID)
+	}
+	if err != nil {
+		conn.Disconnect()
+		wg.Wait()
+		return err
+	}
+
+	d.log.Infof("Connected to mesh peer %s", d.peerURL)
+	return nil
+}
+
+// dial opens a websocket connection to the configured peer and wraps it in an
+// rpcConn. It is the production implementation of dialFunc used by Run.
+func (d *outboundDialer) dial(ctx context.Context) (peerTransport, *sync.WaitGroup, error) {
+	var tlsConfig *tls.Config
+	if d.useTLS() {
+		tlsConfig = &tls.Config{
+			RootCAs:    d.peerRoots,
+			MinVersion: tls.VersionTLS12,
+			ServerName: d.peerURL.Hostname(),
+		}
+	}
+
+	dialer := &websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:  tlsConfig,
+	}
+	peerAddr := d.peerURL.String()
+	wsConn, _, err := dialer.DialContext(ctx, peerAddr, nil)
+	if err != nil {
+		if isTLSConfigError(err) {
+			err = wrapPeerIncompatible(err)
+		}
+		return nil, nil, err
+	}
+
+	wsConn.SetPongHandler(func(string) error {
+		return wsConn.SetReadDeadline(time.Now().Add(meshPingPeriod * 2))
+	})
+
+	conn := newRPCConn(ctx, peerAddr, wsConn, d.meshRoutes, d.log)
+	wg, err := conn.connect()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return conn, wg, nil
+}
+
+// isTLSConfigError reports whether err is a TLS failure that indicates a
+// configuration problem rather than a transient outage.
+func isTLSConfigError(err error) bool {
+	var recErr tls.RecordHeaderError
+	var unknownAuth x509.UnknownAuthorityError
+	var hostnameErr x509.HostnameError
+	var invalidCert x509.CertificateInvalidError
+	var tlsVerify *tls.CertificateVerificationError
+	return errors.As(err, &recErr) || errors.As(err, &unknownAuth) ||
+		errors.As(err, &hostnameErr) || errors.As(err, &invalidCert) ||
+		errors.As(err, &tlsVerify)
+}
+
+// parsePeerURL validates and normalizes peerAddr into a *url.URL. A bare
+// host:port is treated as wss:// and the path is defaulted to meshWSPath if
+// it is empty or the root.
+func parsePeerURL(peerAddr string) (*url.URL, error) {
+	peerAddr = strings.TrimSpace(peerAddr)
+	if peerAddr == "" {
+		return nil, fmt.Errorf("empty peer address")
+	}
+
+	raw := peerAddr
+	if !strings.Contains(raw, "://") {
+		raw = "wss://" + raw
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "ws" && u.Scheme != "wss" {
+		return nil, fmt.Errorf("unsupported scheme %q", u.Scheme)
+	}
+	if u.Hostname() == "" {
+		return nil, fmt.Errorf("missing host")
+	}
+	port := u.Port()
+	if port == "" {
+		return nil, fmt.Errorf("missing port")
+	}
+	if portNum, err := strconv.Atoi(port); err != nil || portNum < 1 || portNum > 65535 {
+		return nil, fmt.Errorf("invalid port %q", port)
+	}
+	if u.Path == "" || u.Path == "/" {
+		u.Path = meshWSPath
+	}
+
+	return u, nil
+}
+
+// hasPeerConnection reports if the control loop has a peer connection.
+func (n *node) hasPeerConnection() bool {
+	return n.control.hasPeerConnection()
+}
+
+// postDialIncompatible sends a signal to the control loop to indicate
+// the node is incompatible with the peer.
+func (n *node) postDialIncompatible(err error) {
+	_ = n.control.post(dialIncompatibleSignal{err: err, at: time.Now()})
+}
+
+// postMasterEvidence sends a signal to the control loop to indicate
+// the serving master is alive, even though it is not the current
+// active connection.
+func (n *node) postMasterEvidence(at time.Time) {
+	_ = n.control.post(masterEvidenceSignal{at: at})
+}

--- a/server/mesh/dialer_test.go
+++ b/server/mesh/dialer_test.go
@@ -17,6 +17,7 @@ import (
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/server/db"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/gorilla/websocket"
 )
 
@@ -55,6 +56,15 @@ func (c *tPeerConn) requestHello(context.Context, *helloMessage) (*helloResponse
 	return nil, nil
 }
 func (c *tPeerConn) requestDecision(context.Context, *decisionMessage) error { return nil }
+
+func testPrivKey() *secp256k1.PrivateKey {
+	return secp256k1.PrivKeyFromBytes([]byte{
+		1, 1, 1, 1, 1, 1, 1, 1,
+		1, 1, 1, 1, 1, 1, 1, 1,
+		1, 1, 1, 1, 1, 1, 1, 1,
+		1, 1, 1, 1, 1, 1, 1, 1,
+	})
+}
 
 func TestParsePeerURL(t *testing.T) {
 	tests := []struct {

--- a/server/mesh/dialer_test.go
+++ b/server/mesh/dialer_test.go
@@ -2,9 +2,22 @@ package mesh
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
 	"sync"
+	"testing"
+	"time"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/db"
+	"github.com/gorilla/websocket"
 )
 
 type tPeerConn struct {
@@ -13,6 +26,8 @@ type tPeerConn struct {
 	done chan struct{}
 	once sync.Once
 }
+
+var _ peerTransport = (*tPeerConn)(nil)
 
 func newTPeerConn() *tPeerConn {
 	return &tPeerConn{
@@ -40,3 +55,404 @@ func (c *tPeerConn) requestHello(context.Context, *helloMessage) (*helloResponse
 	return nil, nil
 }
 func (c *tPeerConn) requestDecision(context.Context, *decisionMessage) error { return nil }
+
+func TestParsePeerURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		want    string
+		wantErr bool
+	}{
+		{name: "host port defaults to tls", addr: "127.0.0.1:17232", want: "wss://127.0.0.1:17232/meshws"},
+		{name: "ws no path", addr: "ws://127.0.0.1:17232", want: "ws://127.0.0.1:17232/meshws"},
+		{name: "wss with path", addr: "wss://127.0.0.1:17232/custom", want: "wss://127.0.0.1:17232/custom"},
+		{name: "wss trailing slash defaults path", addr: "wss://127.0.0.1:17232/", want: "wss://127.0.0.1:17232/meshws"},
+		{name: "no scheme trailing slash", addr: "127.0.0.1:17232/", want: "wss://127.0.0.1:17232/meshws"},
+		{name: "no scheme with explicit path", addr: "127.0.0.1:17232/custom", want: "wss://127.0.0.1:17232/custom"},
+		{name: "no scheme with meshws path", addr: "127.0.0.1:17232/meshws", want: "wss://127.0.0.1:17232/meshws"},
+		{name: "surrounding whitespace", addr: "  wss://127.0.0.1:17232  ", want: "wss://127.0.0.1:17232/meshws"},
+		{name: "invalid host", addr: "bad host:17232", wantErr: true},
+		{name: "missing port", addr: "mesh.example", wantErr: true},
+		{name: "invalid port", addr: "mesh.example:notaport", wantErr: true},
+		{name: "unsupported scheme", addr: "http://mesh.example:17232", wantErr: true},
+		{name: "empty", addr: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePeerURL(tt.addr)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parsePeerURL error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got.String() != tt.want {
+				t.Fatalf("parsePeerURL = %q, want %q", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+type testDialerNode struct {
+	hasPeer        func() bool
+	apply          func(context.Context, link, *handshakeResult, string) error
+	incompatible   func(error)
+	masterEvidence func(time.Time)
+}
+
+func (r *testDialerNode) hasPeerConnection() bool {
+	if r.hasPeer == nil {
+		return false
+	}
+	return r.hasPeer()
+}
+
+func (r *testDialerNode) applyHandshakeResult(ctx context.Context, conn link, result *handshakeResult, initiatorNodeID string) error {
+	if r.apply == nil {
+		return nil
+	}
+	return r.apply(ctx, conn, result, initiatorNodeID)
+}
+
+func (r *testDialerNode) postDialIncompatible(err error) {
+	if r.incompatible != nil {
+		r.incompatible(err)
+	}
+}
+
+func (r *testDialerNode) postMasterEvidence(at time.Time) {
+	if r.masterEvidence != nil {
+		r.masterEvidence(at)
+	}
+}
+
+func TestConnectPeer(t *testing.T) {
+	// completeParams captures the arguments applyHandshakeResult was invoked with
+	// during a TestConnectPeer subtest.
+	type completeParams struct {
+		peerNodeID      string
+		initiatorNodeID string
+		role            helloRole
+		progress        progressState
+		peerFrontier    *db.EventLogPosition
+	}
+
+	okHandshake := func(peerNodeID string, role helloRole, prog progressState) handshakeFunc {
+		return func(context.Context, handshakeTransport) (*handshakeResult, error) {
+			return &handshakeResult{
+				peerHello: &helloMessage{
+					NodeID:   peerNodeID,
+					Role:     role,
+					Frontier: toFrontierMessage(&db.EventLogPosition{Seq: 4, TipHash: testTipHash(4)}),
+				},
+				progress: prog,
+			}, nil
+		}
+	}
+	failHandshake := func(err error) handshakeFunc {
+		return func(context.Context, handshakeTransport) (*handshakeResult, error) {
+			return nil, err
+		}
+	}
+
+	tlsIncompatErr := wrapPeerIncompatible(x509.UnknownAuthorityError{})
+	plainDialErr := errors.New("dial tcp: connection refused")
+	handshakeErr := errors.New("handshake rejected")
+	completeErr := errors.New("apply failed")
+
+	defaultCompleteParams := &completeParams{
+		peerNodeID:      "peer-id",
+		initiatorNodeID: "local",
+		role:            roleSlave,
+		progress:        progressEqual,
+		peerFrontier:    &db.EventLogPosition{Seq: 4, TipHash: testTipHash(4)},
+	}
+
+	tests := []struct {
+		name                    string
+		hasPeerConnection       bool
+		dialPeer                *tPeerConn
+		dialErr                 error
+		handshakeFn             handshakeFunc
+		applyHandshakeResultErr error
+
+		wantDialCalled           bool
+		wantHandshakeFnCalled    bool
+		wantCompleteParams       *completeParams // nil means applyHandshakeResult not expected
+		wantPostDialIncompatible bool
+		wantPostMasterEvidence   bool
+		wantConnDisconnected     bool
+	}{
+		{
+			name:              "already connected short-circuits before dial",
+			hasPeerConnection: true,
+		},
+		{
+			name:           "plain dial error does not trigger postDialIncompatible",
+			dialErr:        plainDialErr,
+			wantDialCalled: true,
+		},
+		{
+			name:                     "TLS dial error triggers postDialIncompatible",
+			dialErr:                  tlsIncompatErr,
+			wantDialCalled:           true,
+			wantPostDialIncompatible: true,
+		},
+		{
+			name:                  "handshake failure disconnects conn",
+			dialPeer:              newTPeerConn(),
+			handshakeFn:           failHandshake(handshakeErr),
+			wantDialCalled:        true,
+			wantHandshakeFnCalled: true,
+			wantConnDisconnected:  true,
+		},
+		{
+			name:                     "handshake incompatibility triggers postDialIncompatible and disconnects",
+			dialPeer:                 newTPeerConn(),
+			handshakeFn:              failHandshake(wrapPeerIncompatible(errors.New("hello rejected"))),
+			wantDialCalled:           true,
+			wantHandshakeFnCalled:    true,
+			wantPostDialIncompatible: true,
+			wantConnDisconnected:     true,
+		},
+		{
+			name:                   "already-connected rejection posts master evidence and disconnects",
+			dialPeer:               newTPeerConn(),
+			handshakeFn:            failHandshake(fmt.Errorf("mesh hello: %w", errPeerAlreadyConnected)),
+			wantDialCalled:         true,
+			wantHandshakeFnCalled:  true,
+			wantPostMasterEvidence: true,
+			wantConnDisconnected:   true,
+		},
+		{
+			name:                  "happy path calls applyHandshakeResult",
+			dialPeer:              newTPeerConn(),
+			handshakeFn:           okHandshake("peer-id", roleSlave, progressEqual),
+			wantDialCalled:        true,
+			wantHandshakeFnCalled: true,
+			wantCompleteParams:    defaultCompleteParams,
+		},
+		{
+			name:                    "applyHandshakeResult failure disconnects conn",
+			dialPeer:                newTPeerConn(),
+			handshakeFn:             okHandshake("peer-id", roleSlave, progressEqual),
+			applyHandshakeResultErr: completeErr,
+			wantDialCalled:          true,
+			wantHandshakeFnCalled:   true,
+			wantCompleteParams:      defaultCompleteParams,
+			wantConnDisconnected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peerURL, err := parsePeerURL("wss://mesh.example:17232")
+			if err != nil {
+				t.Fatalf("parsePeerURL error: %v", err)
+			}
+
+			var (
+				dialCalled           bool
+				handshakeCalled      bool
+				incompatibleCalled   bool
+				masterEvidenceCalled bool
+				gotComplete          *completeParams
+			)
+
+			cm := &outboundDialer{
+				peerURL:           peerURL,
+				reconnectInterval: time.Second,
+				log:               dex.Disabled,
+				handshakeSvc:      &handshakeService{nodeID: "local"},
+				node: &testDialerNode{
+					hasPeer: func() bool { return tt.hasPeerConnection },
+					apply: func(_ context.Context, conn link, result *handshakeResult, initiatorNodeID string) error {
+						if conn != tt.dialPeer {
+							t.Fatalf("applyHandshakeResult conn = %v, want dial peer", conn)
+						}
+						gotComplete = &completeParams{
+							peerNodeID:      result.peerHello.NodeID,
+							initiatorNodeID: initiatorNodeID,
+							role:            result.peerHello.Role,
+							progress:        result.progress,
+							peerFrontier:    fromFrontierMessage(result.peerHello.Frontier),
+						}
+						return tt.applyHandshakeResultErr
+					},
+					incompatible:   func(error) { incompatibleCalled = true },
+					masterEvidence: func(time.Time) { masterEvidenceCalled = true },
+				},
+			}
+
+			dialFn := func(context.Context) (peerTransport, *sync.WaitGroup, error) {
+				dialCalled = true
+				if tt.dialPeer != nil {
+					return tt.dialPeer, &sync.WaitGroup{}, nil
+				}
+				return nil, nil, tt.dialErr
+			}
+			handshakeFn := func(ctx context.Context, conn handshakeTransport) (*handshakeResult, error) {
+				handshakeCalled = true
+				if tt.handshakeFn == nil {
+					t.Fatal("handshakeFn not expected to be called")
+					return nil, nil
+				}
+				return tt.handshakeFn(ctx, conn)
+			}
+
+			cm.connectPeer(t.Context(), dialFn, handshakeFn)
+
+			if dialCalled != tt.wantDialCalled {
+				t.Errorf("dialCalled = %v, want %v", dialCalled, tt.wantDialCalled)
+			}
+			if handshakeCalled != tt.wantHandshakeFnCalled {
+				t.Errorf("handshakeFnCalled = %v, want %v", handshakeCalled, tt.wantHandshakeFnCalled)
+			}
+			if !reflect.DeepEqual(gotComplete, tt.wantCompleteParams) {
+				t.Errorf("applyHandshakeResult params = %+v, want %+v", gotComplete, tt.wantCompleteParams)
+			}
+			if incompatibleCalled != tt.wantPostDialIncompatible {
+				t.Errorf("postDialIncompatible called = %v, want %v", incompatibleCalled, tt.wantPostDialIncompatible)
+			}
+			if masterEvidenceCalled != tt.wantPostMasterEvidence {
+				t.Errorf("postMasterEvidence called = %v, want %v", masterEvidenceCalled, tt.wantPostMasterEvidence)
+			}
+			if tt.dialPeer != nil {
+				disconnected := false
+				select {
+				case <-tt.dialPeer.done:
+					disconnected = true
+				default:
+				}
+				if disconnected != tt.wantConnDisconnected {
+					t.Errorf("connDisconnected = %v, want %v", disconnected, tt.wantConnDisconnected)
+				}
+			} else if tt.wantConnDisconnected {
+				t.Fatal("cannot assert connDisconnected without a dialPeer")
+			}
+		})
+	}
+}
+
+// startMeshWSServer starts a minimal httptest server that upgrades /meshws to
+// a websocket and blocks reading until the peer disconnects.
+func startMeshWSServer(t *testing.T, tls bool) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/meshws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	if tls {
+		return httptest.NewTLSServer(mux)
+	}
+	return httptest.NewServer(mux)
+}
+
+// peerAddrFrom converts an httptest server URL (http:// or https://) into a
+// ws:// or wss:// URL pointing at /meshws, letting tests drive the dialer at
+// the protocol of their choice regardless of the server's scheme.
+func peerAddrFrom(t *testing.T, srvURL, scheme string) string {
+	t.Helper()
+	u, err := url.Parse(srvURL)
+	if err != nil {
+		t.Fatalf("parse server url: %v", err)
+	}
+	return scheme + "://" + u.Host + "/meshws"
+}
+
+func TestDial(t *testing.T) {
+	wsSrv := startMeshWSServer(t, false)
+	defer wsSrv.Close()
+
+	wssSrv := startMeshWSServer(t, true)
+	defer wssSrv.Close()
+
+	wssCertPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: wssSrv.Certificate().Raw,
+	})
+
+	tests := []struct {
+		name             string
+		peerAddr         string
+		peerCert         []byte
+		wantErr          bool
+		wantIncompatible bool
+	}{
+		{
+			name:     "plaintext happy path",
+			peerAddr: peerAddrFrom(t, wsSrv.URL, "ws"),
+		},
+		{
+			name:     "tls happy path",
+			peerAddr: peerAddrFrom(t, wssSrv.URL, "wss"),
+			peerCert: wssCertPEM,
+		},
+		{
+			name:     "wss without peer cert",
+			peerAddr: peerAddrFrom(t, wssSrv.URL, "wss"),
+			wantErr:  true,
+		},
+		{
+			name:             "wss dialing plaintext peer is incompatible",
+			peerAddr:         peerAddrFrom(t, wsSrv.URL, "wss"),
+			peerCert:         wssCertPEM,
+			wantErr:          true,
+			wantIncompatible: true,
+		},
+		{
+			name:             "ws dialing tls peer is a plain dial failure",
+			peerAddr:         peerAddrFrom(t, wssSrv.URL, "ws"),
+			wantErr:          true,
+			wantIncompatible: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm, err := newOutboundDialer(tt.peerAddr, tt.peerCert, dex.Disabled, nil, nil, &testDialerNode{})
+			if err != nil {
+				if !tt.wantErr {
+					t.Fatalf("newOutboundDialer error: %v", err)
+				}
+				if errors.Is(err, errPeerIncompatible) != tt.wantIncompatible {
+					t.Fatalf("errors.Is(%v, errPeerIncompatible) = %v, want %v",
+						err, errors.Is(err, errPeerIncompatible), tt.wantIncompatible)
+				}
+				return
+			}
+
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+
+			conn, wg, err := cm.dial(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("dial err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if errors.Is(err, errPeerIncompatible) != tt.wantIncompatible {
+				t.Fatalf("errors.Is(%v, errPeerIncompatible) = %v, want %v",
+					err, errors.Is(err, errPeerIncompatible), tt.wantIncompatible)
+			}
+
+			if err == nil {
+				if conn == nil {
+					t.Fatal("nil conn on successful dial")
+				}
+				if wg == nil {
+					t.Fatal("nil wg on successful dial")
+				}
+				conn.Disconnect()
+				wg.Wait()
+			}
+		})
+	}
+}

--- a/server/mesh/dialer_test.go
+++ b/server/mesh/dialer_test.go
@@ -1,0 +1,42 @@
+package mesh
+
+import (
+	"context"
+	"sync"
+
+	"decred.org/dcrdex/dex/msgjson"
+)
+
+type tPeerConn struct {
+	id   uint64
+	addr string
+	done chan struct{}
+	once sync.Once
+}
+
+func newTPeerConn() *tPeerConn {
+	return &tPeerConn{
+		id:   nextConnID(),
+		addr: "test-peer",
+		done: make(chan struct{}),
+	}
+}
+
+func (c *tPeerConn) ID() uint64                  { return c.id }
+func (c *tPeerConn) Addr() string                { return c.addr }
+func (c *tPeerConn) Send(*msgjson.Message) error { return nil }
+func (c *tPeerConn) Request(context.Context, string, any, any) error {
+	return nil
+}
+func (c *tPeerConn) Authorize()            {}
+func (c *tPeerConn) Done() <-chan struct{} { return c.done }
+func (c *tPeerConn) Disconnect() {
+	c.once.Do(func() {
+		close(c.done)
+	})
+}
+
+func (c *tPeerConn) requestHello(context.Context, *helloMessage) (*helloResponse, error) {
+	return nil, nil
+}
+func (c *tPeerConn) requestDecision(context.Context, *decisionMessage) error { return nil }

--- a/server/mesh/doc.go
+++ b/server/mesh/doc.go
@@ -1,0 +1,55 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+// Package mesh implements a two node, master-slave network for the dex.
+// Clients can connect to either node. Only the master originates events.
+// Both nodes apply them to their local application state. Client requests
+// that change the state are executed on the master, so if the client is
+// connected to the slave, the request is forwarded to the master. State
+// updates (events) are streamed from the master to the slave.
+//
+// Two important concepts in the system are Commands and Events. Commands are
+// client-originating requests that may change the state of the system. A
+// Command may be resolved by emitting an Event, by responding to the client
+// with a result without emitting an Event (for example if this was a
+// duplicate Command that already has a result), or by responding with a
+// failure. In all three cases it is mesh that sends the response to the
+// client, through whichever node the client is connected to. A response is
+// delivered at most once. A forwarded command whose outcome is unknown may
+// receive ResultUnavailableError. A lost client connection can prevent any
+// response from being delivered.
+//
+// Events are state updates that happen either as a result of a Command, or
+// are created by the master directly (a MasterWorker calling ApplyEvent).
+// Every Event is appended to a durable event log, and the slave applies the
+// Events in log order. This way two nodes with the same event log will have
+// the same state.
+//
+// Service is the entry point to the mesh package. With both ListenAddr
+// and PeerAddr empty, it runs as a single server.
+//
+// If we are running as a two-node mesh, the node will remain in a pending
+// state until it connects to its peer and completes a handshake. A pending
+// node does not serve clients. A node with an empty log has ten minutes to
+// finish seeding, including waiting for its peer. A node with existing history
+// waits for its peer until startup is canceled or fails. The handshake compares
+// configurations and event logs to decide if the nodes are compatible and
+// which node should be master.
+// A node with an empty event log loads a snapshot when joining a master
+// with existing history, then follows its event stream.
+//
+// A pending node halts if its outbound handshake reports permanent
+// configuration incompatibility. An established master rejects the
+// incompatible peer and keeps serving.
+// A node will also halt if its event log has diverged from the serving
+// master's, in which case the master keeps serving. If both nodes are master
+// and their event logs have diverged, both will halt. A halt is terminal:
+// the node stops serving and has to be restarted.
+//
+// During graceful shutdown, the master waits for the slave to catch up
+// and requests handoff. Shutdown continues if either step fails or times out.
+// Without handoff, an established slave promotes only after the full
+// promotion delay without reconnection or fresh evidence of a live master.
+// A slave that loses its master during initial catch-up returns to pending
+// and does not promote on a timer.
+package mesh

--- a/server/mesh/errors.go
+++ b/server/mesh/errors.go
@@ -5,6 +5,7 @@ package mesh
 
 import (
 	"errors"
+	"fmt"
 
 	"decred.org/dcrdex/dex/msgjson"
 )
@@ -49,4 +50,19 @@ func LogApplyFailure(log applyFailureLogger, err error, format string, args ...a
 		return
 	}
 	log.Errorf(format, args...)
+}
+
+var (
+	// errPeerIncompatible means that the peer's configuration is incompatible
+	// with this node.
+	errPeerIncompatible = errors.New("mesh peer incompatible")
+
+	// errPeerAlreadyConnected means the peer is alive and already holds a
+	// session with this node.
+	errPeerAlreadyConnected = errors.New("peer already holds an active session")
+)
+
+// wrapPeerIncompatible marks err as an errPeerIncompatible.
+func wrapPeerIncompatible(err error) error {
+	return fmt.Errorf("%w: %v", errPeerIncompatible, err)
 }

--- a/server/mesh/errors.go
+++ b/server/mesh/errors.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/db"
 )
 
 var (
@@ -65,4 +66,15 @@ var (
 // wrapPeerIncompatible marks err as an errPeerIncompatible.
 func wrapPeerIncompatible(err error) error {
 	return fmt.Errorf("%w: %v", errPeerIncompatible, err)
+}
+
+// isTerminalEventApplyFailure reports whether an event application error
+// requires the node to halt.
+func isTerminalEventApplyFailure(err error) bool {
+	var divergence *db.EventLogDivergenceError
+	var unknown *db.EventCommitUnknownError
+	var committed *CommittedEventApplyError
+	var wedged *replicationWedgedError
+	return errors.As(err, &divergence) || errors.As(err, &unknown) ||
+		errors.As(err, &committed) || errors.As(err, &wedged)
 }

--- a/server/mesh/errors.go
+++ b/server/mesh/errors.go
@@ -1,0 +1,52 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"errors"
+
+	"decred.org/dcrdex/dex/msgjson"
+)
+
+var (
+	// ErrUnavailable means the current state of the node does not allow the
+	// requested operation. This is used to represent a temporary unavailability,
+	// that can be retried later.
+	ErrUnavailable = errors.New("mesh unavailable")
+
+	// ErrClientNotConnected means the user is not connected to the node that was
+	// asked to deliver a client message.
+	ErrClientNotConnected = errors.New("client not connected")
+
+	// ErrClientProxyUnavailable indicates that no active mesh peer can relay live
+	// client messages.
+	ErrClientProxyUnavailable = errors.New("mesh client proxy unavailable")
+)
+
+// ClientError maps a failed Emit or ApplyEvent to a client wire error:
+// TryAgainLater for ErrUnavailable, the given permanent error otherwise.
+func ClientError(err error, code int, format string, args ...any) *msgjson.Error {
+	if errors.Is(err, ErrUnavailable) {
+		return msgjson.NewError(msgjson.TryAgainLaterError,
+			"mesh temporarily unavailable; retry the request")
+	}
+	return msgjson.NewError(code, format, args...)
+}
+
+// applyFailureLogger is the subset of slog/dex loggers used by LogApplyFailure.
+type applyFailureLogger interface {
+	Debugf(format string, args ...any)
+	Errorf(format string, args ...any)
+}
+
+// LogApplyFailure logs a failed Emit or ApplyEvent at a client edge.
+// ErrUnavailable is expected temporary unavailability (Debug); other
+// failures are Error.
+func LogApplyFailure(log applyFailureLogger, err error, format string, args ...any) {
+	if errors.Is(err, ErrUnavailable) {
+		log.Debugf(format, args...)
+		return
+	}
+	log.Errorf(format, args...)
+}

--- a/server/mesh/errors_test.go
+++ b/server/mesh/errors_test.go
@@ -1,0 +1,37 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"decred.org/dcrdex/dex/msgjson"
+)
+
+func TestClientError(t *testing.T) {
+	msgErr := ClientError(fmt.Errorf("drain: %w", ErrUnavailable), msgjson.RPCInternalError, "internal server error")
+	if msgErr.Code != msgjson.TryAgainLaterError {
+		t.Fatalf("transient code = %d, want TryAgainLater", msgErr.Code)
+	}
+	// The wire message is fixed; the diagnostic chain stays out of it.
+	if msgErr.Message != "mesh temporarily unavailable; retry the request" {
+		t.Fatalf("transient message = %q", msgErr.Message)
+	}
+
+	deepWrapped := fmt.Errorf("wrap: %w",
+		fmt.Errorf("event publisher unavailable for command %s: %w", "cmd-1", ErrUnavailable))
+	if msgErr := ClientError(deepWrapped, msgjson.RPCInternalError, "x"); msgErr.Code != msgjson.TryAgainLaterError {
+		t.Fatalf("deep-wrapped transient code = %d, want TryAgainLater", msgErr.Code)
+	}
+
+	msgErr = ClientError(errors.New("db down"), msgjson.RedemptionError, "match %d revoked", 5)
+	if msgErr.Code != msgjson.RedemptionError {
+		t.Fatalf("permanent code = %d, want RedemptionError", msgErr.Code)
+	}
+	if msgErr.Message != "match 5 revoked" {
+		t.Fatalf("permanent message = %q", msgErr.Message)
+	}
+}

--- a/server/mesh/events.go
+++ b/server/mesh/events.go
@@ -76,6 +76,13 @@ func forwardedCommandEventOrigin(commandID string, resultFn func() any) eventOri
 	}
 }
 
+func receivedCommandEventOrigin(commandID string) eventOrigin {
+	return eventOrigin{
+		kind:      originReceivedCommand,
+		commandID: commandID,
+	}
+}
+
 // collectsAfterCommandResult reports whether this node owns the local client
 // response for the event and should therefore gather AfterCommandResult
 // callbacks during apply.
@@ -133,3 +140,10 @@ func (c *EventApplyContext) AfterCommandResult(f func(context.Context)) bool {
 // (at Position when set). Mesh delivers the client response; the applier
 // does not.
 type EventApplier func(*EventApplyContext, *Event) (*db.EventLogEntry, error)
+
+func eventFromEnvelope(entry *eventEnvelope) *Event {
+	return &Event{
+		Kind:    entry.Kind,
+		Payload: append([]byte(nil), entry.Payload...),
+	}
+}

--- a/server/mesh/events.go
+++ b/server/mesh/events.go
@@ -1,0 +1,135 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"fmt"
+
+	"decred.org/dcrdex/server/db"
+)
+
+// CommittedEventApplyError reports a failure after the event transaction
+// committed.
+type CommittedEventApplyError struct {
+	Applied *db.EventLogEntry
+	Err     error
+}
+
+func (err *CommittedEventApplyError) Error() string {
+	return fmt.Sprintf("committed event apply side effect failed: %v", err.Err)
+}
+
+func (err *CommittedEventApplyError) Unwrap() error {
+	return err.Err
+}
+
+// eventOriginKind states who initiated an event and therefore who is owed a
+// client response after applying the event.
+type eventOriginKind uint8
+
+const (
+	// originPlain is an authoritative event with no client command attached.
+	// This is used for events which are emitted by master workers.
+	originPlain eventOriginKind = iota
+	// originLocalCommand is a command from a client connected to this node.
+	originLocalCommand
+	// originForwardedCommand is a command forwarded by the peer slave and
+	// is currently being applied on the master.
+	originForwardedCommand
+	// originReceivedCommand is a command that was forwarded by the slave to
+	// the master, and is currently being applied on the slave after successfully
+	// being applied on the master.
+	originReceivedCommand
+)
+
+// eventOrigin records how to deliver the command result for an event.
+// Construct it with the origin helpers.
+//
+// Fields by origin kind:
+//   - originLocalCommand: completion, resultFn
+//   - originForwardedCommand: commandID, resultFn
+//   - originReceivedCommand: commandID
+type eventOrigin struct {
+	kind       eventOriginKind
+	commandID  string
+	completion *CommandCompletion
+	resultFn   func() any
+}
+
+func plainEventOrigin() eventOrigin { return eventOrigin{kind: originPlain} }
+
+func localCommandEventOrigin(completion *CommandCompletion, resultFn func() any) eventOrigin {
+	return eventOrigin{
+		kind:       originLocalCommand,
+		completion: completion,
+		resultFn:   resultFn,
+	}
+}
+
+func forwardedCommandEventOrigin(commandID string, resultFn func() any) eventOrigin {
+	return eventOrigin{
+		kind:      originForwardedCommand,
+		commandID: commandID,
+		resultFn:  resultFn,
+	}
+}
+
+// collectsAfterCommandResult reports whether this node owns the local client
+// response for the event and should therefore gather AfterCommandResult
+// callbacks during apply.
+func (o eventOrigin) collectsAfterCommandResult() bool {
+	return o.kind == originLocalCommand || o.kind == originReceivedCommand
+}
+
+// deliverLocalResult delivers a local-command result when this origin owns
+// that response. Other origins are a no-op.
+func (o eventOrigin) deliverLocalResult(result any) error {
+	if o.kind != originLocalCommand || result == nil || o.completion == nil {
+		return nil
+	}
+	return o.completion.deliverResult(result)
+}
+
+// EventApplyContext is passed to an EventApplier. It contains metadata
+// related to the event, and callbacks to run after the event is applied.
+type EventApplyContext struct {
+	context.Context
+	// Position is the master's assigned seq and tip hash for a received event.
+	// It is nil when this node is the master and is applying the event for
+	// the first time.
+	Position *db.EventLogPosition
+
+	collectAfterCommandResult bool
+	afterCommandResult        []func(context.Context)
+	result                    any
+}
+
+// SetResult sets the apply's result: ApplyEvent returns it, and for a command
+// with no result function it is also the client's command response.
+func (c *EventApplyContext) SetResult(result any) {
+	c.result = result
+}
+
+// Result returns the value recorded by SetResult, or nil.
+func (c *EventApplyContext) Result() any {
+	return c.result
+}
+
+// AfterCommandResult registers f to run after successful application,
+// following any attempt by this node to send the command result.
+// It returns false if this apply does not handle that response,
+// or if c or f is nil.
+func (c *EventApplyContext) AfterCommandResult(f func(context.Context)) bool {
+	if c == nil || !c.collectAfterCommandResult || f == nil {
+		return false
+	}
+	c.afterCommandResult = append(c.afterCommandResult, f)
+	return true
+}
+
+// EventApplier applies one event and must persist and return the log row
+// (at Position when set). Mesh delivers the client response; the applier
+// does not.
+type EventApplier func(*EventApplyContext, *Event) (*db.EventLogEntry, error)

--- a/server/mesh/forkreset.go
+++ b/server/mesh/forkreset.go
@@ -1,0 +1,54 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"decred.org/dcrdex/server/db"
+)
+
+// forkResetHashPrefixLen is the number of tip hash bytes in a fork reset
+// token.
+const forkResetHashPrefixLen = 8
+
+// forkResetToken returns the --meshforkreset token for the frontier, in the
+// form "seq:tiphash-prefix". It returns "" if the event log is empty. A node
+// that halts on a fork puts this token in its halt error.
+func forkResetToken(p *db.EventLogPosition) string {
+	if p == nil || p.Seq == 0 || len(p.TipHash) < forkResetHashPrefixLen {
+		return ""
+	}
+	return fmt.Sprintf("%d:%x", p.Seq, p.TipHash[:forkResetHashPrefixLen])
+}
+
+// ValidateForkResetToken checks the operator's --meshforkreset token against
+// the current frontier. It returns nil if the token matches, and the wipe can
+// proceed.
+func ValidateForkResetToken(token string, frontier *db.EventLogPosition) error {
+	if frontier == nil || frontier.Seq == 0 {
+		return fmt.Errorf("the event log is empty, there is nothing to reset")
+	}
+	seqStr, hashStr, found := strings.Cut(strings.TrimSpace(token), ":")
+	if !found {
+		return fmt.Errorf("malformed token %q: expected <seq>:<tiphash-prefix>", token)
+	}
+	seq, err := strconv.ParseUint(seqStr, 10, 64)
+	if err != nil || seq == 0 {
+		return fmt.Errorf("malformed token sequence %q", seqStr)
+	}
+	prefix, err := hex.DecodeString(hashStr)
+	if err != nil || len(prefix) < forkResetHashPrefixLen {
+		return fmt.Errorf("malformed token tip-hash prefix %q: expected %d hex bytes",
+			hashStr, forkResetHashPrefixLen)
+	}
+	if seq != frontier.Seq || !bytes.HasPrefix(frontier.TipHash, prefix) {
+		return fmt.Errorf("token %q does not match the current frontier %s", token, frontier)
+	}
+	return nil
+}

--- a/server/mesh/forkreset_test.go
+++ b/server/mesh/forkreset_test.go
@@ -1,0 +1,80 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"testing"
+
+	"decred.org/dcrdex/server/db"
+)
+
+func TestForkResetToken(t *testing.T) {
+	frontier := &db.EventLogPosition{
+		Seq:     41,
+		TipHash: []byte{0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+	}
+	if token := forkResetToken(frontier); token != "41:deadbeef01020304" {
+		t.Fatalf("token = %q", token)
+	}
+	for name, p := range map[string]*db.EventLogPosition{
+		"nil":        nil,
+		"empty log":  {},
+		"short hash": {Seq: 7, TipHash: []byte{0x01, 0x02}},
+	} {
+		if token := forkResetToken(p); token != "" {
+			t.Fatalf("%s: token = %q, want empty", name, token)
+		}
+	}
+}
+
+func TestValidateForkResetToken(t *testing.T) {
+	frontier := &db.EventLogPosition{
+		Seq:     41,
+		TipHash: []byte{0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+	}
+	valid := []string{
+		forkResetToken(frontier),  // the generated token round-trips
+		"41:deadbeef01020304",     // minimum hash prefix
+		"41:deadbeef010203040506", // the full hash from Position{...}
+		" 41:deadbeef01020304 ",   // surrounding whitespace tolerated
+	}
+	for _, token := range valid {
+		if err := ValidateForkResetToken(token, frontier); err != nil {
+			t.Fatalf("token %q rejected: %v", token, err)
+		}
+	}
+
+	invalid := map[string]string{
+		"no separator":      "41deadbeef",
+		"zero seq":          "0:deadbeef",
+		"non-numeric seq":   "x:deadbeef",
+		"wrong seq":         "40:deadbeef",
+		"short hash prefix": "41:deadbeef",
+		"odd hex":           "41:deadbee",
+		"non-hex":           "41:zzzzzzzz",
+		"wrong hash":        "41:deadbeee",
+		"empty":             "",
+	}
+	for name, token := range invalid {
+		if err := ValidateForkResetToken(token, frontier); err == nil {
+			t.Fatalf("%s: token %q accepted", name, token)
+		}
+	}
+
+	if err := ValidateForkResetToken("41:deadbeef", &db.EventLogPosition{}); err == nil {
+		t.Fatal("token accepted against an empty frontier")
+	}
+	if err := ValidateForkResetToken("41:deadbeef", nil); err == nil {
+		t.Fatal("token accepted against a nil frontier")
+	}
+
+	// Same seq, different tip hash → token must not match (single-shot).
+	reseeded := &db.EventLogPosition{
+		Seq:     41,
+		TipHash: []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa},
+	}
+	if err := ValidateForkResetToken(forkResetToken(frontier), reseeded); err == nil {
+		t.Fatal("pre-reset token accepted against the reseeded history")
+	}
+}

--- a/server/mesh/handshake.go
+++ b/server/mesh/handshake.go
@@ -1,0 +1,429 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/db"
+)
+
+type frontierMessage struct {
+	Tip     uint64    `json:"tip"`
+	TipHash dex.Bytes `json:"tipHash"`
+}
+
+func fromFrontierMessage(msg frontierMessage) *db.EventLogPosition {
+	return &db.EventLogPosition{
+		Seq:     msg.Tip,
+		TipHash: append([]byte(nil), msg.TipHash...),
+	}
+}
+
+func toFrontierMessage(frontier *db.EventLogPosition) frontierMessage {
+	return frontierMessage{
+		Tip:     frontier.Seq,
+		TipHash: dex.Bytes(frontier.TipHash),
+	}
+}
+
+func validateFrontierMessage(frontier frontierMessage) error {
+	if frontier.Tip == 0 {
+		if len(frontier.TipHash) != 0 {
+			return fmt.Errorf("zero event-log frontier hash length %d, want 0", len(frontier.TipHash))
+		}
+		return nil
+	}
+	if len(frontier.TipHash) != eventLogTipHashSize {
+		return fmt.Errorf("event-log frontier hash length %d, want %d", len(frontier.TipHash), eventLogTipHashSize)
+	}
+	return nil
+}
+
+type helloMessage struct {
+	NodeID       string          `json:"nodeID"`
+	Role         helloRole       `json:"role"`
+	Frontier     frontierMessage `json:"frontier"`
+	CompatHash   dex.Bytes       `json:"compatHash"`
+	ClientHost   string          `json:"clientHost,omitempty"`
+	ClientCert   dex.Bytes       `json:"clientCert,omitempty"`
+	CompatConfig *CompatConfig   `json:"compatConfig,omitempty"`
+	Sig          dex.Bytes       `json:"sig,omitempty"`
+}
+
+// helloSignable is the signed subset of helloMessage (no CompatConfig, no Sig).
+type helloSignable struct {
+	NodeID     string          `json:"nodeID"`
+	Role       helloRole       `json:"role"`
+	Frontier   frontierMessage `json:"frontier"`
+	CompatHash dex.Bytes       `json:"compatHash"`
+	ClientHost string          `json:"clientHost,omitempty"`
+	ClientCert dex.Bytes       `json:"clientCert,omitempty"`
+}
+
+func (h *helloMessage) signableBytes() ([]byte, error) {
+	if h == nil {
+		return nil, fmt.Errorf("nil hello payload")
+	}
+	return json.Marshal(helloSignable{
+		NodeID:     h.NodeID,
+		Role:       h.Role,
+		Frontier:   h.Frontier,
+		CompatHash: h.CompatHash,
+		ClientHost: h.ClientHost,
+		ClientCert: h.ClientCert,
+	})
+}
+
+func (h *helloMessage) sign(s signer) error {
+	hash, err := h.signableBytes()
+	if err != nil {
+		return err
+	}
+	sig, err := s.sign(hash)
+	if err != nil {
+		return err
+	}
+	h.Sig = sig
+	return nil
+}
+
+func (h *helloMessage) verifySig(s signer) error {
+	if h == nil {
+		return fmt.Errorf("nil hello payload")
+	}
+	signable, err := h.signableBytes()
+	if err != nil {
+		return fmt.Errorf("failed to marshal hello signable: %w", err)
+	}
+	if !s.verify(h.Sig, signable) {
+		return fmt.Errorf("invalid hello signature")
+	}
+	return nil
+}
+
+type helloResponse struct {
+	Hello *helloMessage `json:"hello"`
+	// Ancestor is meaningful only when the responder is strictly ahead.
+	// True means the initiator's frontier is in the responder's history;
+	// false means a fork.
+	Ancestor bool `json:"ancestor,omitempty"`
+	// NotAdopted means the responder kept an existing peer session instead of
+	// this connection.
+	NotAdopted bool `json:"notAdopted,omitempty"`
+}
+
+type decisionMessage struct {
+	// Ancestor is true if the responder's frontier is in the initiator's history.
+	Ancestor bool `json:"ancestor"`
+}
+
+type signer interface {
+	sign(data []byte) ([]byte, error)
+	verify(sig, data []byte) bool
+}
+
+type handshakeTransport interface {
+	requestHello(ctx context.Context, req *helloMessage) (*helloResponse, error)
+	requestDecision(ctx context.Context, req *decisionMessage) error
+}
+
+type handshakeResult struct {
+	peerHello  *helloMessage
+	progress   progressState
+	clientHost string
+	clientCert []byte
+}
+
+// handshakeService implements the mesh hello protocol. Two nodes maintain
+// replicas of one logical event log; before serving together they must establish
+// compatibility and whether their logs have diverged or not.
+//
+// Compatibility is determined by checking if the hash of the CompatConfigs are equal.
+//
+// Determining if the logs have diverged or not is done by comparing the frontiers. If
+// the initiator is behind or the two nodes are equal, one round of messages is enough.
+// If the initiator is ahead, they will need to check if the responder's frontier is
+// part of their history, so a second round of messages is needed.
+//
+//	initiator                            responder
+//	    |-- mesh_hello -------------------->|
+//	    |<-- hello_response ----------------|  Ancestor only if responder is ahead
+//	    |   only when the initiator is ahead:
+//	    |-- mesh_hello_decision ------------>|
+//	    |<-- ack ----------------------------|
+type handshakeService struct {
+	nodeID         string
+	currentRole    func() helloRole
+	signer         signer
+	compat         *CompatSnapshot
+	eventLogReader db.EventLogReader
+	clientHost     string
+	clientCert     []byte
+	log            dex.Logger
+}
+
+func newHandshakeService(
+	nodeID string,
+	roleFn func() helloRole,
+	signer signer,
+	compat *CompatSnapshot,
+	eventLogReader db.EventLogReader,
+	clientHost string,
+	clientCert []byte,
+	log dex.Logger,
+) *handshakeService {
+	return &handshakeService{
+		nodeID:         nodeID,
+		currentRole:    roleFn,
+		signer:         signer,
+		compat:         compat,
+		eventLogReader: eventLogReader,
+		clientHost:     clientHost,
+		clientCert:     append([]byte(nil), clientCert...),
+		log:            log,
+	}
+}
+
+// initiateHandshake is called to initiate a handshake with a peer.
+// It sends a hello request, and if the initiator is ahead, they follow up with
+// a decision request.
+func (s *handshakeService) initiateHandshake(ctx context.Context, peer handshakeTransport) (*handshakeResult, error) {
+	localFrontier, err := s.eventLogReader.EventLogFrontier(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	hello, err := s.signedHello(localFrontier)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := peer.requestHello(ctx, hello)
+	if err != nil {
+		return nil, err
+	}
+
+	peerHello := resp.Hello
+	if err := s.validatePeerHello(peerHello); err != nil {
+		return nil, wrapPeerIncompatible(err)
+	}
+	if resp.NotAdopted {
+		return nil, fmt.Errorf("%w: peer marked our hello not adopted", errPeerAlreadyConnected)
+	}
+
+	peerFrontier := fromFrontierMessage(peerHello.Frontier)
+	var progress progressState
+	switch {
+	case localFrontier.Seq == peerFrontier.Seq:
+		progress = equalProgress(localFrontier, peerFrontier)
+	case localFrontier.Seq < peerFrontier.Seq:
+		progress = progressFromAncestor(resp.Ancestor)
+	default: // localFrontier.Seq > peerFrontier.Seq
+		progress, err = s.sendDecision(ctx, peer, peerFrontier)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &handshakeResult{
+		peerHello:  peerHello,
+		progress:   progress,
+		clientHost: peerHello.ClientHost,
+		clientCert: append([]byte(nil), peerHello.ClientCert...),
+	}, nil
+}
+
+// sendDecision is used by the initiator to send a decision request to the responder.
+func (s *handshakeService) sendDecision(ctx context.Context, peer handshakeTransport, peerFrontier *db.EventLogPosition) (progressState, error) {
+	_, progress, err := compareEventLogFrontier(ctx, s.eventLogReader, peerFrontier)
+	if err != nil {
+		return progress, err
+	}
+
+	if err := peer.requestDecision(ctx, &decisionMessage{Ancestor: progress == progressLocalAhead}); err != nil {
+		if progress == progressDiverged && ctx.Err() == nil {
+			// We have already proven that the logs diverge. Report that result even if
+			// notifying the peer fails, so this node halts regardless of which node dialed.
+			s.log.Warnf("Mesh peer unreachable for diverged decision delivery: %v", err)
+			return progress, nil
+		}
+		return progress, err
+	}
+
+	return progress, nil
+}
+
+// processHello processes the initiator's hello. If the initiator is ahead,
+// the handshake waits for its decision message.
+func (s *handshakeService) processHello(ctx context.Context, hello *helloMessage) (*helloResponse, *handshakeResult, error) {
+	peerFrontier := fromFrontierMessage(hello.Frontier)
+	localFrontier, progress, err := compareEventLogFrontier(ctx, s.eventLogReader, peerFrontier)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ourHello, err := s.signedHello(localFrontier)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resp := &helloResponse{Hello: ourHello, Ancestor: progress == progressLocalAhead}
+	result := &handshakeResult{
+		peerHello:  hello,
+		progress:   progress,
+		clientHost: hello.ClientHost,
+		clientCert: append([]byte(nil), hello.ClientCert...),
+	}
+	return resp, result, nil
+}
+
+// signedHello builds and signs this node's hello.
+func (s *handshakeService) signedHello(frontier *db.EventLogPosition) (*helloMessage, error) {
+	hello := &helloMessage{
+		NodeID:       s.nodeID,
+		Role:         s.currentRole(),
+		Frontier:     toFrontierMessage(frontier),
+		CompatHash:   s.compat.Hash[:],
+		CompatConfig: s.compat.Config,
+		ClientHost:   s.clientHost,
+		ClientCert:   append(dex.Bytes(nil), s.clientCert...),
+	}
+	if err := hello.sign(s.signer); err != nil {
+		return nil, err
+	}
+	return hello, nil
+}
+
+func (s *handshakeService) validatePeerHello(hello *helloMessage) error {
+	if hello == nil {
+		return fmt.Errorf("nil hello payload")
+	}
+	if err := validatePeerNodeID(s.nodeID, hello.NodeID); err != nil {
+		return err
+	}
+	if err := validatePeerRole(hello.Role); err != nil {
+		return err
+	}
+	if err := validateFrontierMessage(hello.Frontier); err != nil {
+		return fmt.Errorf("invalid peer frontier: %w", err)
+	}
+	if err := hello.verifySig(s.signer); err != nil {
+		return err
+	}
+	return validatePeerCompat(s.compat, hello.CompatHash, hello.CompatConfig)
+}
+
+func validatePeerNodeID(localNodeID, peerNodeID string) error {
+	if err := validateNodeID(peerNodeID); err != nil {
+		return fmt.Errorf("invalid peer node ID: %w", err)
+	}
+	if localNodeID != "" && peerNodeID == localNodeID {
+		return fmt.Errorf("peer node ID matches local node ID")
+	}
+	return nil
+}
+
+func validatePeerRole(role helloRole) error {
+	if !role.valid() {
+		return fmt.Errorf("invalid peer role %d", role)
+	}
+	return nil
+}
+
+func validatePeerCompat(localCompat *CompatSnapshot, peerHash dex.Bytes, peerConfig *CompatConfig) error {
+	if localCompat == nil {
+		return fmt.Errorf("nil local compatibility snapshot")
+	}
+	var peerHashArr [32]byte
+	if len(peerHash) != len(peerHashArr) {
+		return fmt.Errorf("invalid peer compatibility hash length %d", len(peerHash))
+	}
+	copy(peerHashArr[:], peerHash)
+
+	if peerHashArr != localCompat.Hash {
+		return fmt.Errorf("peer compatibility hash mismatch")
+	}
+	if peerConfig != nil {
+		snap, err := NewCompatSnapshot(*peerConfig)
+		if err != nil {
+			return fmt.Errorf("invalid peer compatibility config: %w", err)
+		}
+		if snap.Hash != peerHashArr {
+			return fmt.Errorf("peer compatibility config does not match peer compatibility hash")
+		}
+	}
+	return nil
+}
+
+// errPeerBelowAnchor is returned when the peer's frontier is below the anchor
+// at which this node's log begins. This node was seeded from a snapshot taken
+// above the peer's tip. It cannot check whether the peer's log is an ancestor
+// of its own, and the peer cannot subscribe to the event stream from that
+// position. The peer must wipe its event sourced state and rejoin from a
+// snapshot.
+var errPeerBelowAnchor = errors.New("peer frontier is below this node's snapshot anchor")
+
+func compareEventLogFrontier(ctx context.Context, reader db.EventLogReader, peer *db.EventLogPosition) (*db.EventLogPosition, progressState, error) {
+	local, err := reader.EventLogFrontier(ctx)
+	if err != nil {
+		return nil, progressEqual, err
+	}
+
+	switch {
+	case local.Seq == peer.Seq:
+		return local, equalProgress(local, peer), nil
+	case local.Seq < peer.Seq:
+		return local, progressPeerAhead, nil
+	}
+
+	// local.Seq > peer.Seq
+
+	if peer.Seq == 0 { // new peer
+		return local, progressLocalAhead, nil
+	}
+
+	entries, err := reader.EventLogEntriesAfter(ctx, peer.Seq-1, 1)
+	if err != nil {
+		return local, progressEqual, err
+	}
+
+	if len(entries) == 0 || entries[0] == nil {
+		return local, progressEqual, fmt.Errorf("no event log entry at seq %d", peer.Seq)
+	}
+
+	entry := entries[0]
+	if entry.Seq != peer.Seq {
+		// The first retained row is above the peer's position. If that row
+		// is an anchor, this node's log begins there and the peer is below
+		// it. Any other gap is an error.
+		if entry.Seq > peer.Seq && db.IsEventLogAnchorKind(entry.Kind) {
+			return local, progressEqual, fmt.Errorf("%w, this node's log begins at the seq %d anchor",
+				errPeerBelowAnchor, entry.Seq)
+		}
+		return local, progressEqual, fmt.Errorf("no event log entry at seq %d", peer.Seq)
+	}
+	if bytes.Equal(entry.TipHash, peer.TipHash) {
+		return local, progressLocalAhead, nil
+	}
+	return local, progressDiverged, nil
+}
+
+func equalProgress(local, peer *db.EventLogPosition) progressState {
+	if bytes.Equal(local.TipHash, peer.TipHash) {
+		return progressEqual
+	}
+	return progressDiverged
+}
+
+func progressFromAncestor(ancestor bool) progressState {
+	if ancestor {
+		return progressPeerAhead
+	}
+	return progressDiverged
+}

--- a/server/mesh/handshake_session.go
+++ b/server/mesh/handshake_session.go
@@ -1,0 +1,211 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+)
+
+const defaultPendingHandshakeTimeout = 2 * time.Minute
+
+// handshakeSessions handles inbound handshakes and stores the hello state
+// while waiting for a decision from an initiator with a longer log.
+type handshakeSessions struct {
+	log  dex.Logger
+	svc  *handshakeService
+	node *node
+
+	pendingTimeout time.Duration
+
+	pendingMtx sync.Mutex
+	pending    map[uint64]*pendingHandshakeSession
+}
+
+type pendingHandshakeSession struct {
+	pending *handshakeResult
+	timer   *time.Timer
+}
+
+func newHandshakeSessions(log dex.Logger, svc *handshakeService, node *node) *handshakeSessions {
+	return &handshakeSessions{
+		log:            log,
+		svc:            svc,
+		node:           node,
+		pendingTimeout: defaultPendingHandshakeTimeout,
+		pending:        make(map[uint64]*pendingHandshakeSession),
+	}
+}
+
+func sendHelloResponse(conn link, reqID uint64, resp *helloResponse) *msgjson.Error {
+	return sendRouteResponse(conn, reqID, resp, "mesh hello")
+}
+
+// handleHello handles the hello message from the peer.
+func (h *handshakeSessions) handleHello(ctx context.Context, conn link, reqID uint64, hello *helloMessage) *msgjson.Error {
+	if h.hasPending(conn.ID()) {
+		return msgjson.NewError(msgjson.RPCInternal, "mesh connection already has pending decision")
+	}
+	if state := h.node.control.currentState(); state.activeConn != nil && state.activeConn.link != nil &&
+		state.activeConn.link.ID() == conn.ID() {
+		return msgjson.NewError(msgjson.RPCInternal, "mesh hello on the active connection")
+	}
+
+	if err := h.svc.validatePeerHello(hello); err != nil {
+		h.log.Warnf("Rejecting mesh hello from %s: %v", conn.Addr(), err)
+		return msgjson.NewError(msgjson.AuthenticationError, "mesh hello verification failed: %v", err)
+	}
+
+	respHello, result, err := h.svc.processHello(ctx, hello)
+	if err != nil {
+		h.log.Warnf("Rejecting mesh hello from %s: %v", conn.Addr(), err)
+		if errors.Is(err, errPeerBelowAnchor) {
+			return msgjson.NewError(msgjson.MeshIncompatibleLogError,
+				"mesh hello rejected, the initiator's event log ends below the responder's "+
+					"snapshot anchor, so the initiator cannot join from that position")
+		}
+		return msgjson.NewError(msgjson.RPCInternal, "mesh hello processing failed: %v", err)
+	}
+
+	conn.Authorize()
+
+	switch result.progress {
+	case progressPeerAhead:
+		// The initiator decides, so we store the result until the decision
+		// message arrives.
+		session := h.addPending(conn, result)
+		msgErr := sendHelloResponse(conn, reqID, respHello)
+		if msgErr != nil {
+			h.clearPending(conn.ID(), session)
+		}
+		return msgErr
+	case progressDiverged:
+		// The apply may halt this node, so we send the response first so the
+		// initiator can see the result.
+		msgErr := sendHelloResponse(conn, reqID, respHello)
+		if err := h.node.applyHandshakeResult(ctx, conn, result, hello.NodeID); err != nil {
+			conn.Disconnect()
+		}
+		return msgErr
+	}
+
+	// progress is equal or we are ahead, so the handshake can be resolved.
+
+	err = h.node.applyHandshakeResult(ctx, conn, result, hello.NodeID)
+	switch {
+	case err == nil:
+		msgErr := sendHelloResponse(conn, reqID, respHello)
+		if msgErr == nil {
+			h.log.Infof("Accepted mesh hello from peer %s", hello.NodeID)
+		}
+		return msgErr
+	case errors.Is(err, errConnNotAdopted):
+		// Answer before disconnect so the dialer can tell a live peer from
+		// silence.
+		respHello.NotAdopted = true
+		if msgErr := sendHelloResponse(conn, reqID, respHello); msgErr != nil {
+			h.log.Warnf("Failed to send mesh hello adoption rejection to %s: %v", conn.Addr(), msgErr)
+		}
+	}
+
+	conn.Disconnect()
+	return nil
+}
+
+// handleDecision handles the decision message from the peer. It completes
+// the handshake for a hello that was stored because the peer was ahead.
+func (h *handshakeSessions) handleDecision(ctx context.Context, conn link, reqID uint64, decision *decisionMessage) *msgjson.Error {
+	session := h.takePending(conn.ID())
+	if session == nil {
+		// The stored hello expired, or there never was one.
+		return msgjson.NewError(msgjson.RPCInternal, "mesh decision processing failed: unexpected mesh decision")
+	}
+	result := session.pending
+	result.progress = progressFromAncestor(decision.Ancestor)
+	peerID := result.peerHello.NodeID
+
+	if result.progress == progressDiverged {
+		// The apply may halt this node, so we send the response first so the
+		// initiator can see the result.
+		msgErr := sendRouteAck(conn, reqID, "mesh decision")
+		if err := h.node.applyHandshakeResult(ctx, conn, result, peerID); err != nil {
+			conn.Disconnect()
+		}
+		return msgErr
+	}
+
+	err := h.node.applyHandshakeResult(ctx, conn, result, peerID)
+	switch {
+	case err == nil:
+		return sendRouteAck(conn, reqID, "mesh decision")
+	case errors.Is(err, errConnNotAdopted):
+		// Answer before disconnect so the dialer can tell a live peer from silence.
+		msgErr := sendRouteErrorResponse(conn, reqID,
+			msgjson.NewError(msgjson.MeshAlreadyConnectedError, "a session with this peer is already active"),
+			"mesh decision")
+		if msgErr != nil {
+			h.log.Warnf("Failed to send mesh decision adoption rejection to %s: %v", conn.Addr(), msgErr)
+		}
+	}
+	conn.Disconnect()
+	return nil
+}
+
+func (h *handshakeSessions) hasPending(connID uint64) bool {
+	h.pendingMtx.Lock()
+	defer h.pendingMtx.Unlock()
+	_, found := h.pending[connID]
+	return found
+}
+
+func (h *handshakeSessions) addPending(conn link, pending *handshakeResult) *pendingHandshakeSession {
+	session := &pendingHandshakeSession{pending: pending}
+
+	h.pendingMtx.Lock()
+	h.pending[conn.ID()] = session
+	session.timer = time.AfterFunc(h.pendingTimeout, func() {
+		if h.clearPending(conn.ID(), session) {
+			h.log.Warnf("Mesh handshake with %s timed out waiting for decision", conn.Addr())
+			conn.Disconnect()
+		}
+	})
+	h.pendingMtx.Unlock()
+
+	go func() {
+		<-conn.Done()
+		h.clearPending(conn.ID(), session)
+	}()
+
+	return session
+}
+
+func (h *handshakeSessions) takePending(connID uint64) *pendingHandshakeSession {
+	h.pendingMtx.Lock()
+	defer h.pendingMtx.Unlock()
+
+	session := h.pending[connID]
+	if session == nil {
+		return nil
+	}
+	delete(h.pending, connID)
+	session.timer.Stop()
+	return session
+}
+
+func (h *handshakeSessions) clearPending(connID uint64, session *pendingHandshakeSession) bool {
+	h.pendingMtx.Lock()
+	defer h.pendingMtx.Unlock()
+
+	if h.pending[connID] != session {
+		return false
+	}
+	delete(h.pending, connID)
+	session.timer.Stop()
+	return true
+}

--- a/server/mesh/handshake_session_test.go
+++ b/server/mesh/handshake_session_test.go
@@ -1,0 +1,588 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/db"
+)
+
+func pendingHandshakeCount(h *handshakeSessions) int {
+	h.pendingMtx.Lock()
+	defer h.pendingMtx.Unlock()
+	return len(h.pending)
+}
+
+func getPendingHandshake(h *handshakeSessions, connID uint64) (*pendingHandshakeSession, bool) {
+	h.pendingMtx.Lock()
+	defer h.pendingMtx.Unlock()
+	session, found := h.pending[connID]
+	return session, found
+}
+
+func newSessionTestNode(t testing.TB, state handshakeServiceState) *node {
+	t.Helper()
+
+	svc, _ := newTestHandshakeService(t, state)
+	node := newRouteHandshakeNode(svc)
+	node.handshakes.pendingTimeout = time.Hour
+	return node
+}
+
+func newSessionPending(t testing.TB, spec helloSpec) *handshakeResult {
+	t.Helper()
+
+	return &handshakeResult{
+		peerHello:  buildSignedHello(t, spec),
+		progress:   progressPeerAhead,
+		clientHost: spec.clientHost,
+		clientCert: append([]byte(nil), spec.clientCert...),
+	}
+}
+
+func expirePendingHandshakeForTest(t testing.TB, h *handshakeSessions, conn *tRouteLink, session *pendingHandshakeSession) bool {
+	t.Helper()
+
+	if h.clearPending(conn.ID(), session) {
+		conn.Disconnect()
+		return true
+	}
+	return false
+}
+
+func TestHandshakeSessionsHandleHelloResolvedAdoption(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+	link := newTRouteLink(1201)
+	node := newSessionTestNode(t, fix.state(roleMaster))
+	captured, stopResolver := startHandshakeResolver(node, nil)
+	defer stopResolver()
+
+	hello := fix.hello(t, routePeerNodeID, roleSlave, fix.peerEqualFrontier)
+	rpcErr := node.handshakes.handleHello(context.Background(), link, 1, hello)
+	requireNoRPCError(t, rpcErr)
+
+	decodeHelloResponse(t, requireSent(t, link, 1)[0])
+	if got := link.authorizeCount(); got != 1 {
+		t.Fatalf("authorize calls = %d, want 1", got)
+	}
+	if !reflect.DeepEqual(link.operations(), []string{"authorize", "send"}) {
+		t.Fatalf("operations = %v, want authorize then send", link.operations())
+	}
+	requireHandshakeCapture(t, captured, link, peerHandshakeCapture(roleSlave, progressEqual, fix.peerEqualFrontier))
+	if got := pendingHandshakeCount(node.handshakes); got != 0 {
+		t.Fatalf("pending handshakes = %d, want 0", got)
+	}
+}
+
+func TestHandshakeSessionsHandleHelloApplyFailure(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+	forkFrontier := &db.EventLogPosition{Seq: 8, TipHash: testTipHash(8)}
+
+	tests := []struct {
+		name         string
+		peerRole     helloRole
+		entries      []*db.EventLogEntry
+		frontier     *db.EventLogPosition
+		wantSent     int
+		wantAncestor bool
+		wantProgress progressState
+		wantOps      []string
+	}{
+		{
+			name:         "equal: apply fails before send",
+			peerRole:     roleSlave,
+			frontier:     fix.peerEqualFrontier,
+			wantSent:     0,
+			wantProgress: progressEqual,
+			wantOps:      []string{"authorize", "disconnect"},
+		},
+		{
+			name:         "fork: send before apply",
+			peerRole:     roleMaster,
+			entries:      []*db.EventLogEntry{{Seq: 8, Kind: "test", TipHash: testTipHash(9)}},
+			frontier:     forkFrontier,
+			wantSent:     1,
+			wantProgress: progressDiverged,
+			wantOps:      []string{"authorize", "send", "disconnect"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			link := newTRouteLink(1202)
+			state := fix.state(roleMaster)
+			state.eventEntries = tt.entries
+			node := newSessionTestNode(t, state)
+			captured, stopResolver := startHandshakeResolver(node, errors.New("apply failed"))
+			defer stopResolver()
+
+			hello := fix.hello(t, routePeerNodeID, tt.peerRole, tt.frontier)
+			rpcErr := node.handshakes.handleHello(context.Background(), link, 1, hello)
+			requireNoRPCError(t, rpcErr)
+
+			sent := requireSent(t, link, tt.wantSent)
+			if tt.wantSent > 0 {
+				resp := decodeHelloResponse(t, sent[0])
+				if resp.Ancestor != tt.wantAncestor {
+					t.Fatalf("response ancestor = %v, want %v", resp.Ancestor, tt.wantAncestor)
+				}
+			}
+			if got := link.authorizeCount(); got != 1 {
+				t.Fatalf("authorize calls = %d, want 1", got)
+			}
+			if !reflect.DeepEqual(link.operations(), tt.wantOps) {
+				t.Fatalf("operations = %v, want %v", link.operations(), tt.wantOps)
+			}
+			requireHandshakeCapture(t, captured, link, peerHandshakeCapture(tt.peerRole, tt.wantProgress, tt.frontier))
+			if got := pendingHandshakeCount(node.handshakes); got != 0 {
+				t.Fatalf("pending handshakes = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func decodeErrorResponse(t testing.TB, msg *msgjson.Message) *msgjson.Error {
+	t.Helper()
+
+	resp, err := msg.Response()
+	if err != nil {
+		t.Fatalf("Response error: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatalf("expected an error response")
+	}
+	return resp.Error
+}
+
+func TestHandshakeSessionsHandleHelloNotAdoptedAnswersBeforeDisconnect(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+	link := newTRouteLink(1208)
+	node := newSessionTestNode(t, fix.state(roleMaster))
+	captured, stopResolver := startHandshakeResolver(node, fmt.Errorf("handshake: %w", errConnNotAdopted))
+	defer stopResolver()
+
+	hello := fix.hello(t, routePeerNodeID, roleSlave, fix.peerEqualFrontier)
+	rpcErr := node.handshakes.handleHello(context.Background(), link, 1, hello)
+	requireNoRPCError(t, rpcErr)
+
+	sent := requireSent(t, link, 1)
+	resp := decodeHelloResponse(t, sent[0])
+	if !resp.NotAdopted {
+		t.Fatal("hello response not marked NotAdopted")
+	}
+	if err := resp.Hello.verifySig(node.handshakes.svc.signer); err != nil {
+		t.Fatalf("NotAdopted response hello signature: %v", err)
+	}
+	if !reflect.DeepEqual(link.operations(), []string{"authorize", "send", "disconnect"}) {
+		t.Fatalf("operations = %v, want authorize, send, disconnect", link.operations())
+	}
+	requireHandshakeCapture(t, captured, link, peerHandshakeCapture(roleSlave, progressEqual, fix.peerEqualFrontier))
+	if got := pendingHandshakeCount(node.handshakes); got != 0 {
+		t.Fatalf("pending handshakes = %d, want 0", got)
+	}
+}
+
+func TestHandshakeSessionsHandleHelloUnresolvedPendingLifecycle(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+	link := newTRouteLink(1203)
+	node := newSessionTestNode(t, fix.state(roleSlave))
+
+	hello := fix.hello(t, routePeerNodeID, roleMaster, fix.peerAheadFrontier)
+	rpcErr := node.handshakes.handleHello(context.Background(), link, 1, hello)
+	requireNoRPCError(t, rpcErr)
+
+	sent := requireSent(t, link, 1)
+	if got := decodeHelloResponse(t, sent[0]).Ancestor; got {
+		// A behind responder cannot resolve the fork check, so it must not
+		// claim the initiator is a prefix; the initiator's decision completes
+		// the handshake.
+		t.Fatalf("hello response ancestor = true, want false")
+	}
+	if got := link.authorizeCount(); got != 1 {
+		t.Fatalf("authorize calls = %d, want 1", got)
+	}
+	if !reflect.DeepEqual(link.operations(), []string{"authorize", "send"}) {
+		t.Fatalf("operations = %v, want authorize then send", link.operations())
+	}
+	session, found := getPendingHandshake(node.handshakes, link.ID())
+	if !found {
+		t.Fatalf("missing pending handshake")
+	}
+	if session.pending.peerHello != hello {
+		t.Fatalf("pending hello pointer changed")
+	}
+
+	link.Disconnect()
+	waitForCondition(t, func() bool {
+		return pendingHandshakeCount(node.handshakes) == 0
+	}, "pending cleanup after disconnect")
+}
+
+func TestHandshakeSessionsHandleHelloResponseFailureCreatesNoPending(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+	tests := []struct {
+		name  string
+		reqID uint64
+		err   error
+		code  int
+		msg   string
+	}{
+		{
+			name:  "send failure",
+			reqID: 1,
+			err:   errors.New("send failed"),
+			code:  msgjson.RPCInternal,
+			msg:   "failed to send mesh hello response",
+		},
+		{
+			name:  "encode failure",
+			reqID: 0,
+			code:  msgjson.RPCInternal,
+			msg:   "failed to encode mesh hello response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			link := newTRouteLink(1204)
+			link.sendErr = tt.err
+			node := newSessionTestNode(t, fix.state(roleSlave))
+			node.handshakes.pendingTimeout = 10 * time.Millisecond
+			hello := fix.hello(t, routePeerNodeID, roleMaster, fix.peerAheadFrontier)
+
+			rpcErr := node.handshakes.handleHello(context.Background(), link, tt.reqID, hello)
+			requireRPCOutcome(t, rpcErr, tt.code, tt.msg)
+			if got := link.authorizeCount(); got != 1 {
+				t.Fatalf("authorize calls = %d, want 1", got)
+			}
+			if got := pendingHandshakeCount(node.handshakes); got != 0 {
+				t.Fatalf("pending handshakes = %d, want 0", got)
+			}
+			time.Sleep(25 * time.Millisecond)
+			if got := link.disconnectCount(); got != 0 {
+				t.Fatalf("disconnects = %d, want 0", got)
+			}
+		})
+	}
+}
+
+func TestHandshakeSessionsHandleDecision(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+	peerHost, peerCert := "peer.example:7232", []byte{9, 8, 7}
+
+	tests := []struct {
+		name         string
+		decision     *decisionMessage
+		applyErr     error
+		sendErr      error
+		wantRPC      routeRPCExpectation
+		wantSent     int
+		wantSentCode int
+		wantDisc     int
+		wantCalled   bool
+	}{
+		{
+			name:       "success sends ack",
+			decision:   &decisionMessage{Ancestor: true},
+			wantSent:   1,
+			wantCalled: true,
+		},
+		{
+			name:       "diverged decision acks before the halting apply",
+			decision:   &decisionMessage{Ancestor: false},
+			wantSent:   1,
+			wantDisc:   1,
+			wantCalled: true,
+		},
+		{
+			name:       "diverged apply failure still acks before disconnect",
+			decision:   &decisionMessage{Ancestor: false},
+			applyErr:   errors.New("apply failed"),
+			wantSent:   1,
+			wantDisc:   1,
+			wantCalled: true,
+		},
+		{
+			name:       "non-diverged apply failure disconnects and sends no ack",
+			decision:   &decisionMessage{Ancestor: true},
+			applyErr:   errors.New("apply failed"),
+			wantDisc:   1,
+			wantCalled: true,
+		},
+		{
+			name:         "not-adopted decision answers already connected before disconnect",
+			decision:     &decisionMessage{Ancestor: true},
+			applyErr:     fmt.Errorf("handshake: %w", errConnNotAdopted),
+			wantSent:     1,
+			wantSentCode: msgjson.MeshAlreadyConnectedError,
+			wantDisc:     1,
+			wantCalled:   true,
+		},
+		{
+			name:       "ack send failure returns internal error after adoption",
+			decision:   &decisionMessage{Ancestor: true},
+			sendErr:    errors.New("send failed"),
+			wantRPC:    routeRPCExpectation{code: msgjson.RPCInternal, msg: "failed to send mesh decision response"},
+			wantCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			link := newTRouteLink(1205)
+			link.sendErr = tt.sendErr
+			node := newSessionTestNode(t, fix.state(roleSlave))
+			captured, stopResolver := startHandshakeResolver(node, tt.applyErr)
+			defer stopResolver()
+			node.handshakes.addPending(link, newSessionPending(t, helloSpec{
+				nodeID:     routePeerNodeID,
+				role:       roleMaster,
+				frontier:   fix.decisionFrontier,
+				compat:     fix.compat,
+				clientHost: peerHost,
+				clientCert: peerCert,
+			}))
+
+			rpcErr := node.handshakes.handleDecision(context.Background(), link, 1, tt.decision)
+			requireRPCOutcome(t, rpcErr, tt.wantRPC.code, tt.wantRPC.msg)
+			sent := requireSent(t, link, tt.wantSent)
+			if tt.wantSentCode != 0 {
+				if got := decodeErrorResponse(t, sent[0]).Code; got != tt.wantSentCode {
+					t.Fatalf("sent response code = %d, want %d", got, tt.wantSentCode)
+				}
+			}
+			if tt.wantSent > 0 && tt.wantDisc > 0 {
+				// A verdict-bearing reply must be queued before the
+				// disconnect tears the transport down.
+				if !reflect.DeepEqual(link.operations(), []string{"send", "disconnect"}) {
+					t.Fatalf("operations = %v, want send then disconnect", link.operations())
+				}
+			}
+			if got := link.disconnectCount(); got != tt.wantDisc {
+				t.Fatalf("disconnects = %d, want %d", got, tt.wantDisc)
+			}
+			if got := pendingHandshakeCount(node.handshakes); got != 0 {
+				t.Fatalf("pending handshakes = %d, want 0", got)
+			}
+			wantCapture := peerHandshakeCapture(roleMaster, progressPeerAhead, fix.decisionFrontier)
+			if !tt.decision.Ancestor {
+				wantCapture.progress = progressDiverged
+			}
+			requireHandshakeCapture(t, captured, link, wantCapture)
+			if tt.wantCalled && (captured.clientHost != peerHost || !reflect.DeepEqual(captured.clientCert, peerCert)) {
+				t.Fatalf("captured endpoint = %q/%x, want %q/%x", captured.clientHost, captured.clientCert, peerHost, peerCert)
+			}
+		})
+	}
+}
+
+func TestHandshakeSessionsTimeoutDisconnects(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+	link := newTRouteLink(1207)
+	node := newSessionTestNode(t, fix.state(roleSlave))
+	node.handshakes.pendingTimeout = 10 * time.Millisecond
+
+	hello := fix.hello(t, routePeerNodeID, roleMaster, fix.peerAheadFrontier)
+	rpcErr := node.handshakes.handleHello(context.Background(), link, 1, hello)
+	requireNoRPCError(t, rpcErr)
+
+	waitForCondition(t, func() bool {
+		return pendingHandshakeCount(node.handshakes) == 0 && link.disconnectCount() == 1
+	}, "pending timeout disconnect")
+
+	rpcErr = node.handshakes.handleDecision(context.Background(), link, 2, &decisionMessage{Ancestor: true})
+	requireRPCOutcome(t, rpcErr, msgjson.RPCInternal, "unexpected mesh decision")
+}
+
+func TestHandshakeSessionsTimeoutDisconnectRace(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+
+	t.Run("disconnect cleanup wins", func(t *testing.T) {
+		link := newTRouteLink(1210)
+		node := newSessionTestNode(t, fix.state(roleSlave))
+		session := node.handshakes.addPending(link, newSessionPending(t, helloSpec{
+			nodeID:   routePeerNodeID,
+			role:     roleMaster,
+			frontier: fix.decisionFrontier,
+			compat:   fix.compat,
+		}))
+
+		link.Disconnect()
+		waitForCondition(t, func() bool {
+			return pendingHandshakeCount(node.handshakes) == 0
+		}, "pending cleanup after disconnect")
+
+		if expirePendingHandshakeForTest(t, node.handshakes, link, session) {
+			t.Fatalf("stale timeout removed already-cleared pending session")
+		}
+		if got := link.disconnectCount(); got != 1 {
+			t.Fatalf("disconnects = %d, want 1", got)
+		}
+	})
+
+	t.Run("timeout cleanup wins", func(t *testing.T) {
+		link := newTRouteLink(1211)
+		node := newSessionTestNode(t, fix.state(roleSlave))
+		session := node.handshakes.addPending(link, newSessionPending(t, helloSpec{
+			nodeID:   routePeerNodeID,
+			role:     roleMaster,
+			frontier: fix.decisionFrontier,
+			compat:   fix.compat,
+		}))
+
+		if !expirePendingHandshakeForTest(t, node.handshakes, link, session) {
+			t.Fatalf("timeout failed to clear pending session")
+		}
+		if got := pendingHandshakeCount(node.handshakes); got != 0 {
+			t.Fatalf("pending handshakes = %d, want 0", got)
+		}
+		if got := link.disconnectCount(); got != 1 {
+			t.Fatalf("disconnects = %d, want 1", got)
+		}
+		if node.handshakes.clearPending(link.ID(), session) {
+			t.Fatalf("disconnect cleanup removed already-expired pending session")
+		}
+	})
+}
+
+func TestHandshakeSessionsTimeoutDecisionRace(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+
+	t.Run("timeout cleanup wins", func(t *testing.T) {
+		link := newTRouteLink(1212)
+		node := newSessionTestNode(t, fix.state(roleSlave))
+		session := node.handshakes.addPending(link, newSessionPending(t, helloSpec{
+			nodeID:   routePeerNodeID,
+			role:     roleMaster,
+			frontier: fix.decisionFrontier,
+			compat:   fix.compat,
+		}))
+
+		if !expirePendingHandshakeForTest(t, node.handshakes, link, session) {
+			t.Fatalf("timeout failed to clear pending session")
+		}
+		rpcErr := node.handshakes.handleDecision(context.Background(), link, 1, &decisionMessage{Ancestor: true})
+		requireRPCOutcome(t, rpcErr, msgjson.RPCInternal, "unexpected mesh decision")
+		requireSent(t, link, 0)
+		if got := link.disconnectCount(); got != 1 {
+			t.Fatalf("disconnects = %d, want 1", got)
+		}
+	})
+
+	t.Run("decision cleanup wins", func(t *testing.T) {
+		link := newTRouteLink(1213)
+		node := newSessionTestNode(t, fix.state(roleSlave))
+		captured, stopResolver := startHandshakeResolver(node, nil)
+		defer stopResolver()
+		session := node.handshakes.addPending(link, newSessionPending(t, helloSpec{
+			nodeID:   routePeerNodeID,
+			role:     roleMaster,
+			frontier: fix.decisionFrontier,
+			compat:   fix.compat,
+		}))
+
+		rpcErr := node.handshakes.handleDecision(context.Background(), link, 1, &decisionMessage{Ancestor: true})
+		requireNoRPCError(t, rpcErr)
+		requireOneAck(t, link)
+		requireHandshakeCapture(t, captured, link, peerHandshakeCapture(roleMaster, progressPeerAhead, fix.decisionFrontier))
+		if expirePendingHandshakeForTest(t, node.handshakes, link, session) {
+			t.Fatalf("stale timeout removed already-resolved pending session")
+		}
+		if got := link.disconnectCount(); got != 0 {
+			t.Fatalf("disconnects = %d, want 0", got)
+		}
+		if got := pendingHandshakeCount(node.handshakes); got != 0 {
+			t.Fatalf("pending handshakes = %d, want 0", got)
+		}
+	})
+}
+
+func TestHandshakeSessionsDuplicateHelloPreservesOriginalPending(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+	tests := []struct {
+		name        string
+		secondHello *helloMessage
+	}{
+		{
+			name:        "duplicate unresolved hello",
+			secondHello: fix.hello(t, routePeerNodeID, roleMaster, fix.peerAheadFrontier),
+		},
+		{
+			name:        "duplicate resolving hello",
+			secondHello: fix.hello(t, routePeerNodeID, roleSlave, fix.peerEqualFrontier),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			link := newTRouteLink(1208)
+			node := newSessionTestNode(t, fix.state(roleSlave))
+			firstHello := fix.hello(t, routePeerNodeID, roleMaster, fix.peerAheadFrontier)
+			rpcErr := node.handshakes.handleHello(context.Background(), link, 1, firstHello)
+			requireNoRPCError(t, rpcErr)
+			firstSession, found := getPendingHandshake(node.handshakes, link.ID())
+			if !found {
+				t.Fatalf("missing first pending session")
+			}
+
+			rpcErr = node.handshakes.handleHello(context.Background(), link, 2, tt.secondHello)
+			requireRPCOutcome(t, rpcErr, msgjson.RPCInternal, "already has pending decision")
+			requireSent(t, link, 1)
+			if got := pendingHandshakeCount(node.handshakes); got != 1 {
+				t.Fatalf("pending handshakes = %d, want 1", got)
+			}
+			gotSession, found := getPendingHandshake(node.handshakes, link.ID())
+			if !found || gotSession != firstSession {
+				t.Fatalf("pending session replaced: got %p found %v, want %p", gotSession, found, firstSession)
+			}
+			if gotSession.pending.peerHello != firstHello {
+				t.Fatalf("pending hello replaced")
+			}
+		})
+	}
+}
+
+func TestHandshakeSessionsStaleCleanupNoop(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+	link := newTRouteLink(1209)
+	node := newSessionTestNode(t, fix.state(roleSlave))
+
+	first := node.handshakes.addPending(link, newSessionPending(t, helloSpec{
+		nodeID:   routePeerNodeID,
+		role:     roleMaster,
+		frontier: &db.EventLogPosition{Seq: 11, TipHash: testTipHash(11)},
+		compat:   fix.compat,
+	}))
+	taken := node.handshakes.takePending(link.ID())
+	if taken != first {
+		t.Fatalf("taken session = %p, want %p", taken, first)
+	}
+	second := node.handshakes.addPending(link, newSessionPending(t, helloSpec{
+		nodeID:   routePeerNodeID,
+		role:     roleMaster,
+		frontier: &db.EventLogPosition{Seq: 12, TipHash: testTipHash(12)},
+		compat:   fix.compat,
+	}))
+
+	if node.handshakes.clearPending(link.ID(), first) {
+		t.Fatalf("stale cleanup removed current pending session")
+	}
+	if got := pendingHandshakeCount(node.handshakes); got != 1 {
+		t.Fatalf("pending handshakes = %d, want 1", got)
+	}
+	got, found := getPendingHandshake(node.handshakes, link.ID())
+	if !found || got != second {
+		t.Fatalf("pending session = %p found %v, want %p", got, found, second)
+	}
+	if got := link.disconnectCount(); got != 0 {
+		t.Fatalf("disconnects = %d, want 0", got)
+	}
+}

--- a/server/mesh/handshake_test.go
+++ b/server/mesh/handshake_test.go
@@ -6,8 +6,13 @@ package mesh
 import (
 	"context"
 	"encoding/binary"
+	"errors"
+	"reflect"
+	"strings"
 	"sync"
+	"testing"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/server/db"
 )
 
@@ -55,4 +60,1227 @@ func (p *testEventLogReader) EventLogEntriesAfter(_ context.Context, after uint6
 		return nil, p.entriesErr
 	}
 	return p.entries, nil
+}
+
+type tHandshakeTransport struct {
+	resp *helloResponse
+
+	helloErr    error
+	decisionErr error
+
+	helloReq      *helloMessage
+	decisionReq   *decisionMessage
+	helloCalls    int
+	decisionCalls int
+}
+
+func (t *tHandshakeTransport) requestHello(_ context.Context, req *helloMessage) (*helloResponse, error) {
+	t.helloCalls++
+	t.helloReq = req
+	return t.resp, t.helloErr
+}
+
+func (t *tHandshakeTransport) requestDecision(_ context.Context, req *decisionMessage) error {
+	t.decisionCalls++
+	t.decisionReq = req
+	return t.decisionErr
+}
+
+type helloSpec struct {
+	nodeID string
+	role   helloRole
+
+	frontier   *db.EventLogPosition
+	compat     *CompatSnapshot
+	clientHost string
+	clientCert []byte
+
+	omitCompatConfig bool
+	mutate           func(*helloMessage)
+}
+
+type pendingDecisionState struct {
+	connID    uint64
+	peerHello helloSpec
+}
+
+type handshakeServiceState struct {
+	nodeID string
+	role   helloRole
+
+	compat *CompatSnapshot
+
+	localFrontier *db.EventLogPosition
+	eventEntries  []*db.EventLogEntry
+	frontierErr   error
+	entriesErr    error
+
+	clientHost string
+	clientCert []byte
+	pending    []pendingDecisionState
+}
+
+func testCompatSnapshot(t testing.TB) *CompatSnapshot {
+	t.Helper()
+
+	snapshot, err := NewCompatSnapshot(CompatConfig{
+		Network:    "testnet",
+		APIVersion: 4,
+	})
+	if err != nil {
+		t.Fatalf("NewCompatSnapshot error: %v", err)
+	}
+	return snapshot
+}
+
+func differentCompatSnapshot(t testing.TB) *CompatSnapshot {
+	t.Helper()
+
+	snapshot, err := NewCompatSnapshot(CompatConfig{
+		Network:    "testnet",
+		APIVersion: 4,
+		Markets: []CompatMarket{
+			{Name: "dcr_btc", Base: 42, Quote: 0, LotSize: 1, ParcelSize: 1, RateStep: 1, EpochDuration: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewCompatSnapshot error: %v", err)
+	}
+	return snapshot
+}
+
+func testHandshakeSigner(t testing.TB) *secp256k1Signer {
+	t.Helper()
+
+	signer, err := newSecp256k1Signer(testPrivKey())
+	if err != nil {
+		t.Fatalf("newSecp256k1Signer error: %v", err)
+	}
+	return signer
+}
+
+func cloneCompatHash(hash [32]byte) dex.Bytes {
+	return append(dex.Bytes(nil), hash[:]...)
+}
+
+func cloneCompatConfig(cfg *CompatConfig) *CompatConfig {
+	if cfg == nil {
+		return nil
+	}
+	cloned := *cfg
+	return &cloned
+}
+
+func buildSignedHello(t testing.TB, spec helloSpec) *helloMessage {
+	t.Helper()
+
+	compat := spec.compat
+	if compat == nil {
+		compat = testCompatSnapshot(t)
+	}
+	frontier := spec.frontier
+	if frontier == nil {
+		frontier = &db.EventLogPosition{}
+	}
+
+	hello := &helloMessage{
+		NodeID:     spec.nodeID,
+		Role:       spec.role,
+		Frontier:   toFrontierMessage(frontier),
+		CompatHash: cloneCompatHash(compat.Hash),
+		ClientHost: spec.clientHost,
+		ClientCert: append(dex.Bytes(nil), spec.clientCert...),
+	}
+	if !spec.omitCompatConfig {
+		hello.CompatConfig = cloneCompatConfig(compat.Config)
+	}
+	if spec.mutate != nil {
+		spec.mutate(hello)
+	}
+	if err := hello.sign(testHandshakeSigner(t)); err != nil {
+		t.Fatalf("hello.sign error: %v", err)
+	}
+	return hello
+}
+
+func newTestHandshakeService(t testing.TB, state handshakeServiceState) (*handshakeService, *testEventLogReader) {
+	t.Helper()
+
+	compat := state.compat
+	if compat == nil {
+		compat = testCompatSnapshot(t)
+	}
+	nodeID := state.nodeID
+	if nodeID == "" {
+		nodeID = "local-node"
+	}
+	localFrontier := state.localFrontier
+	if localFrontier == nil {
+		localFrontier = &db.EventLogPosition{}
+	}
+
+	eventLogReader := &testEventLogReader{
+		frontier:    localFrontier,
+		entries:     state.eventEntries,
+		frontierErr: state.frontierErr,
+		entriesErr:  state.entriesErr,
+	}
+
+	svc := newHandshakeService(
+		nodeID,
+		func() helloRole { return state.role },
+		testHandshakeSigner(t),
+		compat,
+		eventLogReader,
+		state.clientHost,
+		state.clientCert,
+		dex.Disabled,
+	)
+
+	return svc, eventLogReader
+}
+
+func requireClientEndpoint(t testing.TB, gotHost string, gotCert []byte, wantHost string, wantCert []byte) {
+	t.Helper()
+	if gotHost != wantHost || !reflect.DeepEqual(gotCert, wantCert) {
+		t.Fatalf("client endpoint = %q/%x, want %q/%x", gotHost, gotCert, wantHost, wantCert)
+	}
+}
+
+func TestCompareEventLogFrontier(t *testing.T) {
+	providerErr := errors.New("provider error")
+
+	tests := []struct {
+		name string
+
+		local       *db.EventLogPosition
+		peer        *db.EventLogPosition
+		entries     []*db.EventLogEntry
+		frontierErr error
+		entriesErr  error
+
+		want            progressState
+		wantErr         bool
+		wantBelowAnchor bool
+		wantAfter       uint64
+		wantLimit       int
+		wantCalls       int
+	}{
+		{
+			name:  "empty equal",
+			local: &db.EventLogPosition{},
+			peer:  &db.EventLogPosition{},
+			want:  progressEqual,
+		},
+		{
+			name:  "same tip and hash equal",
+			local: &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			peer:  &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			want:  progressEqual,
+		},
+		{
+			name:  "same tip different hash diverged",
+			local: &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			peer:  &db.EventLogPosition{Seq: 2, TipHash: testTipHash(3)},
+			want:  progressDiverged,
+		},
+		{
+			name:  "peer ahead is undecidable locally",
+			local: &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			peer:  &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			want:  progressPeerAhead,
+		},
+		{
+			// The empty-joiner bootstrap: a Seq-0 peer is an ancestor by
+			// definition and must resolve WITHOUT a history lookup — a
+			// snapshot-seeded log has no entry at seq 0 to look up.
+			name:      "empty peer against a non-empty log is local ahead without a lookup",
+			local:     &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:      &db.EventLogPosition{},
+			want:      progressLocalAhead,
+			wantCalls: 0,
+		},
+		{
+			name:  "empty local log behind a non-empty peer",
+			local: &db.EventLogPosition{},
+			peer:  &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			want:  progressPeerAhead,
+		},
+		{
+			name:      "local ahead with peer prefix",
+			local:     &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:      &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			entries:   []*db.EventLogEntry{{Seq: 2, Kind: "test", TipHash: testTipHash(2)}},
+			want:      progressLocalAhead,
+			wantAfter: 1,
+			wantLimit: 1,
+			wantCalls: 1,
+		},
+		{
+			name:      "local ahead without peer prefix diverged",
+			local:     &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:      &db.EventLogPosition{Seq: 2, TipHash: testTipHash(9)},
+			entries:   []*db.EventLogEntry{{Seq: 2, Kind: "test", TipHash: testTipHash(2)}},
+			want:      progressDiverged,
+			wantAfter: 1,
+			wantLimit: 1,
+			wantCalls: 1,
+		},
+		{
+			name:       "historical lookup error",
+			local:      &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:       &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			entriesErr: providerErr,
+			wantErr:    true,
+			wantAfter:  1,
+			wantLimit:  1,
+			wantCalls:  1,
+		},
+		{
+			name:      "historical entry missing",
+			local:     &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:      &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			entries:   nil,
+			wantErr:   true,
+			wantAfter: 1,
+			wantLimit: 1,
+			wantCalls: 1,
+		},
+		{
+			name:      "historical entry nil",
+			local:     &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:      &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			entries:   []*db.EventLogEntry{nil},
+			wantErr:   true,
+			wantAfter: 1,
+			wantLimit: 1,
+			wantCalls: 1,
+		},
+		{
+			// A row above the peer's seq that is not an anchor is a hole in
+			// the log, not a snapshot anchor.
+			name:      "historical entry wrong sequence",
+			local:     &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:      &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			entries:   []*db.EventLogEntry{{Seq: 3, Kind: "test", TipHash: testTipHash(2)}},
+			wantErr:   true,
+			wantAfter: 1,
+			wantLimit: 1,
+			wantCalls: 1,
+		},
+		{
+			name:            "peer below the snapshot anchor",
+			local:           &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:            &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			entries:         []*db.EventLogEntry{{Seq: 3, Kind: db.SnapshotAnchorKind, TipHash: testTipHash(3)}},
+			wantErr:         true,
+			wantBelowAnchor: true,
+			wantAfter:       1,
+			wantLimit:       1,
+			wantCalls:       1,
+		},
+		{
+			// The peer sits on the anchor. The hashes decide, as for any row.
+			name:      "peer on the snapshot anchor",
+			local:     &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:      &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+			entries:   []*db.EventLogEntry{{Seq: 2, Kind: db.SnapshotAnchorKind, TipHash: testTipHash(2)}},
+			want:      progressLocalAhead,
+			wantAfter: 1,
+			wantLimit: 1,
+			wantCalls: 1,
+		},
+		{
+			name:      "peer on the snapshot anchor with another hash",
+			local:     &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:      &db.EventLogPosition{Seq: 2, TipHash: testTipHash(9)},
+			entries:   []*db.EventLogEntry{{Seq: 2, Kind: db.SnapshotAnchorKind, TipHash: testTipHash(2)}},
+			want:      progressDiverged,
+			wantAfter: 1,
+			wantLimit: 1,
+			wantCalls: 1,
+		},
+		{
+			// Genesis is stamped at seq 1, and a seq 0 peer never reaches
+			// the lookup, so a genesis anchor cannot put a peer below it.
+			name:    "genesis anchor against an empty peer",
+			local:   &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:    &db.EventLogPosition{},
+			entries: []*db.EventLogEntry{{Seq: 1, Kind: db.MeshGenesisKind, TipHash: testTipHash(1)}},
+			want:    progressLocalAhead,
+		},
+		{
+			name:      "genesis anchor against a foreign genesis",
+			local:     &db.EventLogPosition{Seq: 3, TipHash: testTipHash(3)},
+			peer:      &db.EventLogPosition{Seq: 1, TipHash: testTipHash(9)},
+			entries:   []*db.EventLogEntry{{Seq: 1, Kind: db.MeshGenesisKind, TipHash: testTipHash(1)}},
+			want:      progressDiverged,
+			wantAfter: 0,
+			wantLimit: 1,
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &testEventLogReader{
+				frontier:    tt.local,
+				entries:     tt.entries,
+				frontierErr: tt.frontierErr,
+				entriesErr:  tt.entriesErr,
+			}
+
+			_, got, err := compareEventLogFrontier(context.Background(), reader, tt.peer)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if errors.Is(err, errPeerBelowAnchor) != tt.wantBelowAnchor {
+					t.Fatalf("below anchor = %v, want %v (error %v)", !tt.wantBelowAnchor, tt.wantBelowAnchor, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("compareEventLogFrontier error: %v", err)
+				}
+				if got != tt.want {
+					t.Fatalf("progress = %v, want %v", got, tt.want)
+				}
+			}
+			if reader.entriesCalls != tt.wantCalls {
+				t.Fatalf("entries calls = %d, want %d", reader.entriesCalls, tt.wantCalls)
+			}
+			if tt.wantCalls > 0 && reader.after != tt.wantAfter {
+				t.Fatalf("entries after = %d, want %d", reader.after, tt.wantAfter)
+			}
+			if tt.wantCalls > 0 && reader.limit != tt.wantLimit {
+				t.Fatalf("entries limit = %d, want %d", reader.limit, tt.wantLimit)
+			}
+		})
+	}
+}
+
+func TestHandshakeServiceInitiateHandshake(t *testing.T) {
+	snapshot := testCompatSnapshot(t)
+	localFrontier := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)}
+	peerEqualFrontier := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)}
+	peerEqualForkFrontier := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(11)}
+	peerAheadFrontier := &db.EventLogPosition{Seq: 12, TipHash: testTipHash(12)}
+	peerBehindFrontier := &db.EventLogPosition{Seq: 8, TipHash: testTipHash(8)}
+	localHost, localCert := "local.example:7232", []byte{1, 2}
+	peerHost, peerCert := "Peer.EXAMPLE:7232", []byte{3, 4}
+
+	// The behind-peer prefix entry: our log's hash at the peer's Seq 8.
+	behindPrefixEntry := []*db.EventLogEntry{{Seq: 8, Kind: "test", TipHash: testTipHash(8)}}
+	// The forked variant: our log's hash at Seq 8 differs from the peer's tip.
+	behindForkEntry := []*db.EventLogEntry{{Seq: 8, Kind: "test", TipHash: testTipHash(9)}}
+
+	tests := []struct {
+		name  string
+		state handshakeServiceState
+
+		respHello    helloSpec
+		respAncestor bool
+		decisionErr  error
+
+		wantProgress        progressState
+		wantErr             string
+		wantIncompatibility bool
+		wantDecisionCalls   int
+		// wantDecisionAncestor is asserted only when wantDecisionCalls > 0.
+		wantDecisionAncestor bool
+		wantClientHost       string
+		wantClientCert       []byte
+	}{
+		{
+			name: "equal frontiers resolve without a bit",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				clientHost:    localHost,
+				clientCert:    localCert,
+			},
+			respHello: helloSpec{
+				nodeID:     "peer-node",
+				role:       roleSlave,
+				frontier:   peerEqualFrontier,
+				compat:     snapshot,
+				clientHost: peerHost,
+				clientCert: peerCert,
+			},
+			wantProgress:      progressEqual,
+			wantDecisionCalls: 0,
+			wantClientHost:    peerHost,
+			wantClientCert:    peerCert,
+		},
+		{
+			name: "equal-length fork resolves from the advertised hashes",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleMaster,
+				frontier: peerEqualForkFrontier,
+				compat:   snapshot,
+			},
+			wantProgress:      progressDiverged,
+			wantDecisionCalls: 0,
+		},
+		{
+			name: "ahead responder's true bit means we are cleanly behind",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleSlave,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleMaster,
+				frontier: peerAheadFrontier,
+				compat:   snapshot,
+			},
+			respAncestor:      true,
+			wantProgress:      progressPeerAhead,
+			wantDecisionCalls: 0,
+		},
+		{
+			name: "ahead responder's false bit is a fork",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleMaster,
+				frontier: peerAheadFrontier,
+				compat:   snapshot,
+			},
+			wantProgress:      progressDiverged,
+			wantDecisionCalls: 0,
+		},
+		{
+			name: "missing bit from an ahead responder is a fork",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleSlave,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleMaster,
+				frontier: peerAheadFrontier,
+				compat:   snapshot,
+			},
+			wantProgress:      progressDiverged,
+			wantDecisionCalls: 0,
+		},
+		{
+			name: "bit from an equal-length responder is ignored",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerEqualFrontier,
+				compat:   snapshot,
+			},
+			respAncestor:      true,
+			wantProgress:      progressEqual,
+			wantDecisionCalls: 0,
+		},
+		{
+			name: "bit from a behind responder is ignored",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				eventEntries:  behindPrefixEntry,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerBehindFrontier,
+				compat:   snapshot,
+			},
+			respAncestor:         true,
+			wantProgress:         progressLocalAhead,
+			wantDecisionCalls:    1,
+			wantDecisionAncestor: true,
+		},
+		{
+			name: "behind responder with a clean prefix gets a true decision",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				eventEntries:  behindPrefixEntry,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerBehindFrontier,
+				compat:   snapshot,
+			},
+			wantProgress:         progressLocalAhead,
+			wantDecisionCalls:    1,
+			wantDecisionAncestor: true,
+		},
+		{
+			name: "behind responder with a forked prefix gets a false decision",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				eventEntries:  behindForkEntry,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleMaster,
+				frontier: peerBehindFrontier,
+				compat:   snapshot,
+			},
+			wantProgress:         progressDiverged,
+			wantDecisionCalls:    1,
+			wantDecisionAncestor: false,
+		},
+		{
+			name: "computed fork survives decision send failure",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				eventEntries:  behindForkEntry,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleMaster,
+				frontier: peerBehindFrontier,
+				compat:   snapshot,
+			},
+			// The responder may have disconnected on this very conclusion
+			// before acking; the locally computed fork must still come back
+			// so this node applies it to its own branch.
+			decisionErr:          errors.New("mesh link disconnected during route mesh_hello_decision"),
+			wantProgress:         progressDiverged,
+			wantDecisionCalls:    1,
+			wantDecisionAncestor: false,
+		},
+		{
+			name: "clean-prefix decision send failure returns the error",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				eventEntries:  behindPrefixEntry,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerBehindFrontier,
+				compat:   snapshot,
+			},
+			decisionErr:          errors.New("send failed"),
+			wantErr:              "send failed",
+			wantDecisionCalls:    1,
+			wantDecisionAncestor: true,
+		},
+		{
+			// This node's log begins at an anchor above the peer's tip. The
+			// error stays local. Only the responder can tell the peer to
+			// reset, and this node is the initiator.
+			name: "behind responder below the anchor is an error, not a fork",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				eventEntries:  []*db.EventLogEntry{{Seq: 10, Kind: db.SnapshotAnchorKind, TipHash: testTipHash(10)}},
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerBehindFrontier,
+				compat:   snapshot,
+			},
+			wantErr:           "below this node's snapshot anchor",
+			wantDecisionCalls: 0,
+		},
+		{
+			name: "peer compat mismatch is incompatible",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerBehindFrontier,
+				compat:   differentCompatSnapshot(t),
+			},
+			wantErr:             "compatibility hash mismatch",
+			wantIncompatibility: true,
+			wantDecisionCalls:   0,
+		},
+		{
+			name: "invalid peer metadata is incompatible",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleUnknown,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			respHello: helloSpec{
+				nodeID:   "local-node",
+				role:     roleSlave,
+				frontier: peerBehindFrontier,
+				compat:   snapshot,
+			},
+			wantErr:             "peer node ID matches local node ID",
+			wantIncompatibility: true,
+			wantDecisionCalls:   0,
+		},
+		{
+			name: "invalid peer frontier is incompatible",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			respHello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerBehindFrontier,
+				compat:   snapshot,
+				mutate: func(hello *helloMessage) {
+					hello.Frontier.TipHash = dex.Bytes{1}
+				},
+			},
+			wantErr:             "frontier",
+			wantIncompatibility: true,
+			wantDecisionCalls:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _ := newTestHandshakeService(t, tt.state)
+			transport := &tHandshakeTransport{
+				resp: &helloResponse{
+					Hello:    buildSignedHello(t, tt.respHello),
+					Ancestor: tt.respAncestor,
+				},
+				decisionErr: tt.decisionErr,
+			}
+
+			result, err := svc.initiateHandshake(context.Background(), transport)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+				}
+				if tt.wantIncompatibility && !errors.Is(err, errPeerIncompatible) {
+					t.Fatalf("expected incompatibility error, got %v", err)
+				}
+				if !tt.wantIncompatibility && errors.Is(err, errPeerIncompatible) {
+					t.Fatalf("unexpected incompatibility classification: %v", err)
+				}
+				if result != nil {
+					t.Fatalf("expected nil result, got %+v", result)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("initiateHandshake error: %v", err)
+				}
+				if result == nil {
+					t.Fatalf("nil handshake result")
+				}
+				if result.progress != tt.wantProgress {
+					t.Fatalf("progress = %v, want %v", result.progress, tt.wantProgress)
+				}
+				if result.peerHello == nil || result.peerHello.NodeID != tt.respHello.nodeID {
+					t.Fatalf("peerHello = %+v, want nodeID %q", result.peerHello, tt.respHello.nodeID)
+				}
+			}
+
+			if transport.helloCalls != 1 {
+				t.Fatalf("requestHello calls = %d, want 1", transport.helloCalls)
+			}
+			if transport.helloReq == nil {
+				t.Fatalf("nil hello request")
+			}
+			if err := transport.helloReq.verifySig(svc.signer); err != nil {
+				t.Fatalf("hello request signature error: %v", err)
+			}
+			if transport.helloReq.NodeID != tt.state.nodeID {
+				t.Fatalf("hello request nodeID = %q, want %q", transport.helloReq.NodeID, tt.state.nodeID)
+			}
+			if transport.helloReq.Role != tt.state.role {
+				t.Fatalf("hello request role = %v, want %v", transport.helloReq.Role, tt.state.role)
+			}
+			if !reflect.DeepEqual(fromFrontierMessage(transport.helloReq.Frontier), tt.state.localFrontier) {
+				t.Fatalf("hello request frontier = %+v, want %+v",
+					fromFrontierMessage(transport.helloReq.Frontier), tt.state.localFrontier)
+			}
+			requireClientEndpoint(t, transport.helloReq.ClientHost, transport.helloReq.ClientCert, tt.state.clientHost, tt.state.clientCert)
+			if !reflect.DeepEqual(transport.helloReq.CompatConfig, tt.state.compat.Config) {
+				t.Fatalf("hello request compat config = %+v, want %+v",
+					transport.helloReq.CompatConfig, tt.state.compat.Config)
+			}
+			if !reflect.DeepEqual(transport.helloReq.CompatHash, cloneCompatHash(tt.state.compat.Hash)) {
+				t.Fatalf("hello request compat hash = %x, want %x",
+					transport.helloReq.CompatHash, tt.state.compat.Hash)
+			}
+
+			if transport.decisionCalls != tt.wantDecisionCalls {
+				t.Fatalf("requestDecision calls = %d, want %d", transport.decisionCalls, tt.wantDecisionCalls)
+			}
+			if tt.wantDecisionCalls > 0 {
+				if transport.decisionReq == nil {
+					t.Fatalf("nil decision request")
+				}
+				if transport.decisionReq.Ancestor != tt.wantDecisionAncestor {
+					t.Fatalf("decision ancestor = %v, want %v", transport.decisionReq.Ancestor, tt.wantDecisionAncestor)
+				}
+			}
+
+			if result != nil {
+				requireClientEndpoint(t, result.clientHost, result.clientCert, tt.wantClientHost, tt.wantClientCert)
+			}
+		})
+	}
+}
+
+func TestHandshakeServiceValidatePeerHello(t *testing.T) {
+	snapshot := testCompatSnapshot(t)
+	localFrontier := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)}
+	peerEqualFrontier := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)}
+
+	tests := []struct {
+		name    string
+		state   handshakeServiceState
+		hello   helloSpec
+		wantErr string
+	}{
+		{
+			name: "valid hello passes",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerEqualFrontier,
+				compat:   snapshot,
+			},
+		},
+		{
+			name: "zero frontier non-empty hash returns error",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: &db.EventLogPosition{},
+				compat:   snapshot,
+				mutate: func(hello *helloMessage) {
+					hello.Frontier.TipHash = dex.Bytes{1}
+				},
+			},
+			wantErr: "invalid peer frontier",
+		},
+		{
+			name: "non-zero frontier empty hash returns error",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: &db.EventLogPosition{Seq: 8},
+				compat:   snapshot,
+			},
+			wantErr: "invalid peer frontier",
+		},
+		{
+			name: "non-zero frontier short hash returns error",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerEqualFrontier,
+				compat:   snapshot,
+				mutate: func(hello *helloMessage) {
+					hello.Frontier.TipHash = dex.Bytes{1}
+				},
+			},
+			wantErr: "invalid peer frontier",
+		},
+		{
+			name: "non-zero frontier long hash returns error",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerEqualFrontier,
+				compat:   snapshot,
+				mutate: func(hello *helloMessage) {
+					hello.Frontier.TipHash = make(dex.Bytes, eventLogTipHashSize+1)
+				},
+			},
+			wantErr: "invalid peer frontier",
+		},
+		{
+			name: "invalid peer metadata returns error",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleUnknown,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			hello: helloSpec{
+				nodeID:   "local-node",
+				role:     roleSlave,
+				frontier: peerEqualFrontier,
+				compat:   snapshot,
+			},
+			wantErr: "peer node ID matches local node ID",
+		},
+		{
+			name: "peer compat mismatch returns error",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: peerEqualFrontier,
+				compat:   differentCompatSnapshot(t),
+			},
+			wantErr: "compatibility hash mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _ := newTestHandshakeService(t, tt.state)
+			err := svc.validatePeerHello(buildSignedHello(t, tt.hello))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validatePeerHello error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestHandshakeServiceProcessHello(t *testing.T) {
+	snapshot := testCompatSnapshot(t)
+	localFrontier := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)}
+	peerEqualFrontier := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)}
+	peerAheadFrontier := &db.EventLogPosition{Seq: 11, TipHash: testTipHash(11)}
+	localHost, localCert := "local.example:7232", []byte{1, 2}
+	peerHost, peerCert := "Peer.EXAMPLE:7232", []byte{3, 4}
+
+	tests := []struct {
+		name  string
+		state handshakeServiceState
+
+		hello helloSpec
+
+		wantAncestor   bool
+		wantProgress   progressState
+		wantErr        string
+		wantClientHost string
+		wantClientCert []byte
+	}{
+		{
+			name: "resolved hello returns result",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				clientHost:    localHost,
+				clientCert:    localCert,
+			},
+			hello: helloSpec{
+				nodeID:     "peer-node",
+				role:       roleSlave,
+				frontier:   peerEqualFrontier,
+				compat:     snapshot,
+				clientHost: peerHost,
+				clientCert: peerCert,
+			},
+			wantProgress:   progressEqual,
+			wantClientHost: peerHost,
+			wantClientCert: peerCert,
+		},
+		{
+			name: "equal-length fork resolves without a bit",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleMaster,
+				frontier: &db.EventLogPosition{Seq: 10, TipHash: testTipHash(11)},
+				compat:   snapshot,
+			},
+			wantProgress: progressDiverged,
+		},
+		{
+			name: "ahead of a clean prefix sets a true bit",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				eventEntries:  []*db.EventLogEntry{{Seq: 8, Kind: "test", TipHash: testTipHash(8)}},
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: &db.EventLogPosition{Seq: 8, TipHash: testTipHash(8)},
+				compat:   snapshot,
+			},
+			wantAncestor: true,
+			wantProgress: progressLocalAhead,
+		},
+		{
+			name: "ahead of a forked prefix sets a false bit",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				eventEntries:  []*db.EventLogEntry{{Seq: 8, Kind: "test", TipHash: testTipHash(9)}},
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleMaster,
+				frontier: &db.EventLogPosition{Seq: 8, TipHash: testTipHash(8)},
+				compat:   snapshot,
+			},
+			wantProgress: progressDiverged,
+		},
+		{
+			name: "peer below the snapshot anchor returns error",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleMaster,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				eventEntries:  []*db.EventLogEntry{{Seq: 10, Kind: db.SnapshotAnchorKind, TipHash: testTipHash(10)}},
+			},
+			hello: helloSpec{
+				nodeID:   "peer-node",
+				role:     roleSlave,
+				frontier: &db.EventLogPosition{Seq: 8, TipHash: testTipHash(8)},
+				compat:   snapshot,
+			},
+			wantErr: "below this node's snapshot anchor",
+		},
+		{
+			name: "peer ahead stores pending decision",
+			state: handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleSlave,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+				clientHost:    localHost,
+				clientCert:    localCert,
+			},
+			hello: helloSpec{
+				nodeID:     "peer-node",
+				role:       roleMaster,
+				frontier:   peerAheadFrontier,
+				compat:     snapshot,
+				clientHost: peerHost,
+				clientCert: peerCert,
+			},
+			wantProgress:   progressPeerAhead,
+			wantClientHost: peerHost,
+			wantClientCert: peerCert,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			svc, reader := newTestHandshakeService(t, tt.state)
+			inboundHello := buildSignedHello(t, tt.hello)
+
+			resp, result, err := svc.processHello(ctx, inboundHello)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+				}
+				if resp != nil {
+					t.Fatalf("expected nil response, got %+v", resp)
+				}
+				if result != nil {
+					t.Fatalf("expected nil result, got %+v", result)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("processHello error: %v", err)
+				}
+				if resp == nil || resp.Hello == nil {
+					t.Fatalf("nil hello response")
+				}
+				if resp.Ancestor != tt.wantAncestor {
+					t.Fatalf("response ancestor = %v, want %v", resp.Ancestor, tt.wantAncestor)
+				}
+				if err := resp.Hello.verifySig(svc.signer); err != nil {
+					t.Fatalf("response hello signature error: %v", err)
+				}
+				if resp.Hello.NodeID != tt.state.nodeID {
+					t.Fatalf("response hello nodeID = %q, want %q", resp.Hello.NodeID, tt.state.nodeID)
+				}
+				if resp.Hello.Role != tt.state.role {
+					t.Fatalf("response hello role = %v, want %v", resp.Hello.Role, tt.state.role)
+				}
+				if !reflect.DeepEqual(fromFrontierMessage(resp.Hello.Frontier), tt.state.localFrontier) {
+					t.Fatalf("response hello frontier = %+v, want %+v",
+						fromFrontierMessage(resp.Hello.Frontier), tt.state.localFrontier)
+				}
+				requireClientEndpoint(t, resp.Hello.ClientHost, resp.Hello.ClientCert, tt.state.clientHost, tt.state.clientCert)
+				if !reflect.DeepEqual(resp.Hello.CompatConfig, tt.state.compat.Config) {
+					t.Fatalf("response hello compat config = %+v, want %+v", resp.Hello.CompatConfig, tt.state.compat.Config)
+				}
+				if !reflect.DeepEqual(resp.Hello.CompatHash, cloneCompatHash(tt.state.compat.Hash)) {
+					t.Fatalf("response hello compat hash = %x, want %x", resp.Hello.CompatHash, tt.state.compat.Hash)
+				}
+
+				if result == nil {
+					t.Fatalf("expected handshake result")
+				}
+				if result.progress != tt.wantProgress {
+					t.Fatalf("result progress = %v, want %v", result.progress, tt.wantProgress)
+				}
+				if result.peerHello != inboundHello {
+					t.Fatalf("result peerHello was not the inbound hello")
+				}
+				requireClientEndpoint(t, result.clientHost, result.clientCert, tt.wantClientHost, tt.wantClientCert)
+			}
+
+			if reader.frontierCalls > 0 && reader.frontierCtx != ctx {
+				t.Fatalf("frontier reader did not receive the processHello context")
+			}
+		})
+	}
+}
+
+func TestInitiateHandshakeNotAdoptedAfterVerifiedHello(t *testing.T) {
+	snapshot := testCompatSnapshot(t)
+	localFrontier := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)}
+	peerFrontier := &db.EventLogPosition{Seq: 8, TipHash: testTipHash(8)}
+
+	tests := []struct {
+		name         string
+		peerFrontier *db.EventLogPosition
+		respAncestor bool
+	}{{
+		name:         "verified hello permits adoption rejection",
+		peerFrontier: peerFrontier,
+	}, {
+		// The combination a real already-connected ahead responder sends:
+		// its resolved response carries Ancestor=true AND NotAdopted. The
+		// rejection must win over the bit, or the dialer would adopt a
+		// duplicate connection and skip the promotion-clock evidence.
+		name:         "rejection wins over a present ancestor bit",
+		peerFrontier: &db.EventLogPosition{Seq: 12, TipHash: testTipHash(12)},
+		respAncestor: true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _ := newTestHandshakeService(t, handshakeServiceState{
+				nodeID:        "local-node",
+				role:          roleSlave,
+				compat:        snapshot,
+				localFrontier: localFrontier,
+			})
+			transport := &tHandshakeTransport{
+				resp: &helloResponse{
+					Hello: buildSignedHello(t, helloSpec{
+						nodeID:   "peer-node",
+						role:     roleMaster,
+						frontier: tt.peerFrontier,
+						compat:   snapshot,
+					}),
+					Ancestor:   tt.respAncestor,
+					NotAdopted: true,
+				},
+			}
+
+			result, err := svc.initiateHandshake(context.Background(), transport)
+			if result != nil {
+				t.Fatalf("expected nil result, got %+v", result)
+			}
+			if !errors.Is(err, errPeerAlreadyConnected) {
+				t.Fatalf("errPeerAlreadyConnected = false, want true (err %v)", err)
+			}
+		})
+	}
 }

--- a/server/mesh/handshake_test.go
+++ b/server/mesh/handshake_test.go
@@ -1,0 +1,58 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+
+	"decred.org/dcrdex/server/db"
+)
+
+func testTipHash(seq uint64) []byte {
+	tipHash := make([]byte, eventLogTipHashSize)
+	binary.BigEndian.PutUint64(tipHash[len(tipHash)-8:], seq)
+	return tipHash
+}
+
+type testEventLogReader struct {
+	mtx sync.Mutex
+
+	frontier    *db.EventLogPosition
+	entries     []*db.EventLogEntry
+	frontierErr error
+	entriesErr  error
+
+	frontierCalls int
+	entriesCalls  int
+	frontierCtx   context.Context
+	after         uint64
+	limit         int
+}
+
+func (p *testEventLogReader) EventLogFrontier(ctx context.Context) (*db.EventLogPosition, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	p.frontierCalls++
+	p.frontierCtx = ctx
+	if p.frontierErr != nil {
+		return nil, p.frontierErr
+	}
+	return p.frontier, nil
+}
+
+func (p *testEventLogReader) EventLogEntriesAfter(_ context.Context, after uint64, limit int) ([]*db.EventLogEntry, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	p.entriesCalls++
+	p.after = after
+	p.limit = limit
+	if p.entriesErr != nil {
+		return nil, p.entriesErr
+	}
+	return p.entries, nil
+}

--- a/server/mesh/integration_test.go
+++ b/server/mesh/integration_test.go
@@ -744,6 +744,80 @@ func TestMeshNodeStartsAfterPeerAppears(t *testing.T) {
 	}
 }
 
+func TestMeshSlavePromotesAfterMasterDisconnect(t *testing.T) {
+	nodeA, nodeB := newMeshPair(t, testCompatSnapshot(t), testCompatSnapshot(t))
+	nodeA.control.slavePromotionDelay = 50 * time.Millisecond
+	nodeB.control.slavePromotionDelay = 50 * time.Millisecond
+
+	runA := startIntegrationNode(t, nodeA)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	runA.waitForStartup(t)
+	runB.waitForStartup(t)
+
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+	var masterRun *runningMeshNode
+	if master == nodeA {
+		masterRun = runA
+	} else {
+		masterRun = runB
+	}
+
+	masterRun.shutdown(t)
+
+	waitForMeshCondition(t, "slave_no_master", func() bool {
+		return slave.control.currentMode() == modeSlaveNoMaster
+	})
+	waitForMeshCondition(t, "slave promotion to master", func() bool {
+		return slave.control.currentMode() == modeEstablishedMaster
+	})
+
+	if !slave.control.currentState().peerDisconnected.IsZero() {
+		t.Fatalf("peerDisconnected = %v, want zero", slave.control.currentState().peerDisconnected)
+	}
+}
+
+func TestMeshPlannedHandoffPromotesWithoutDelay(t *testing.T) {
+	nodeA, nodeB := newMeshPair(t, testCompatSnapshot(t), testCompatSnapshot(t))
+	nodeA.control.slavePromotionDelay = time.Hour
+	nodeB.control.slavePromotionDelay = time.Hour
+
+	runA := startIntegrationNode(t, nodeA)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	runA.waitForStartup(t)
+	runB.waitForStartup(t)
+
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+	masterRun := runA
+	if master == nodeB {
+		masterRun = runB
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	drained, err := master.drainEventStream(ctx)
+	if err != nil || !drained {
+		t.Fatalf("drainEventStream = (%v, %v), want (true, nil)", drained, err)
+	}
+	if err := master.requestMasterHandoff(ctx); err != nil {
+		t.Fatalf("requestMasterHandoff error: %v", err)
+	}
+
+	masterRun.shutdown(t)
+	waitForMeshCondition(t, "planned slave promotion to master", func() bool {
+		return slave.control.currentMode() == modeEstablishedMaster
+	})
+}
+
 func TestMeshCompatMismatchHaltsStartup(t *testing.T) {
 	nodeA, nodeB := newMeshPair(t, testCompatSnapshot(t), differentCompatSnapshot(t))
 

--- a/server/mesh/integration_test.go
+++ b/server/mesh/integration_test.go
@@ -15,6 +15,7 @@ import (
 
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
 )
 
@@ -781,6 +782,199 @@ func TestMeshCompatMismatchHaltsStartup(t *testing.T) {
 	if haltErr == nil || !strings.Contains(haltErr.Error(), "compatibility hash mismatch") {
 		t.Fatalf("HaltStatus err = %v, want compatibility hash mismatch", haltErr)
 	}
+}
+
+func TestMeshRequestForwardsLimitToMaster(t *testing.T) {
+	var (
+		handlerMtx   sync.Mutex
+		calls        int
+		gotCommandID string
+		gotUser      account.AccountID
+		gotMsgID     uint64
+		gotRoute     string
+	)
+	handler := func(ctx context.Context, commandID string, req CommandRequest) *msgjson.Error {
+		handlerMtx.Lock()
+		calls++
+		gotCommandID = commandID
+		gotUser = req.User
+		gotMsgID = req.Msg.ID
+		gotRoute = req.Msg.Route
+		handlerMtx.Unlock()
+		return nil
+	}
+	nodeA, nodeB := func() (*node, *node) {
+		aListen := reserveTCPAddr(t)
+		bListen := reserveTCPAddr(t)
+		aPeer := "ws://" + bListen + meshWSPath
+		bPeer := "ws://" + aListen + meshWSPath
+		return newIntegrationNode(t, integrationNodeConfig{
+				listenAddr: aListen,
+				peerAddr:   aPeer,
+				compat:     testCompatSnapshot(t),
+				cmdHandler: handler,
+			}),
+			newIntegrationNode(t, integrationNodeConfig{
+				listenAddr: bListen,
+				peerAddr:   bPeer,
+				compat:     testCompatSnapshot(t),
+				cmdHandler: handler,
+			})
+	}()
+
+	runA := startIntegrationNode(t, nodeA)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	runA.waitForStartup(t)
+	runB.waitForStartup(t)
+
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+	masterConn, ok := master.control.currentState().activeConn.link.(*rpcConn)
+	if !ok {
+		t.Fatalf("master active conn type = %T", master.control.currentState().activeConn.link)
+	}
+	slaveConn, ok := slave.control.currentState().activeConn.link.(*rpcConn)
+	if !ok {
+		t.Fatalf("slave active conn type = %T", slave.control.currentState().activeConn.link)
+	}
+	if !masterConn.Authed() || !slaveConn.Authed() {
+		t.Fatalf("authed flags before request: master=%v slave=%v", masterConn.Authed(), slaveConn.Authed())
+	}
+
+	var user account.AccountID
+	user[0] = 0x99
+
+	req, err := msgjson.NewRequest(77, msgjson.LimitRoute, map[string]string{"market": "dcr_btc"})
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+
+	const commandID = "prepared-limit-command"
+	rpcErr, outcomeUnknown := slave.forwardCommand(context.Background(), &commandForward{
+		CommandID: commandID,
+		Kind:      "limit",
+		User:      user,
+		Msg:       req,
+	})
+	if rpcErr != nil {
+		t.Fatalf("slave forwardCommand error: %v", rpcErr)
+	}
+	if outcomeUnknown {
+		t.Fatal("acked forward reported an unknown outcome")
+	}
+
+	handlerMtx.Lock()
+	defer handlerMtx.Unlock()
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
+	}
+	if gotCommandID != commandID {
+		t.Fatalf("handler command id = %q, want %q", gotCommandID, commandID)
+	}
+	if gotUser != user {
+		t.Fatalf("handler user = %v, want %v", gotUser, user)
+	}
+	if gotMsgID != req.ID {
+		t.Fatalf("handler msg id = %d, want %d", gotMsgID, req.ID)
+	}
+	if gotRoute != msgjson.LimitRoute {
+		t.Fatalf("handler route = %q, want %q", gotRoute, msgjson.LimitRoute)
+	}
+}
+
+func TestMeshSendCommandResult(t *testing.T) {
+	type recordedResult struct {
+		commandID string
+		result    json.RawMessage
+	}
+	type resultRecorder struct {
+		mtx     sync.Mutex
+		results []recordedResult
+	}
+	record := func(rec *resultRecorder) func(string, json.RawMessage) {
+		return func(commandID string, result json.RawMessage) {
+			rec.mtx.Lock()
+			defer rec.mtx.Unlock()
+			rec.results = append(rec.results, recordedResult{
+				commandID: commandID,
+				result:    append([]byte(nil), result...),
+			})
+		}
+	}
+
+	recA := new(resultRecorder)
+	recB := new(resultRecorder)
+
+	aListen := reserveTCPAddr(t)
+	bListen := reserveTCPAddr(t)
+	aPeer := "ws://" + bListen + meshWSPath
+	bPeer := "ws://" + aListen + meshWSPath
+
+	nodeA := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:    aListen,
+		peerAddr:      aPeer,
+		compat:        testCompatSnapshot(t),
+		resultHandler: record(recA),
+	})
+	nodeB := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:    bListen,
+		peerAddr:      bPeer,
+		compat:        testCompatSnapshot(t),
+		resultHandler: record(recB),
+	})
+
+	runA := startIntegrationNode(t, nodeA)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	runA.waitForStartup(t)
+	runB.waitForStartup(t)
+
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+	masterConn, ok := master.control.currentState().activeConn.link.(*rpcConn)
+	if !ok {
+		t.Fatalf("master active conn type = %T", master.control.currentState().activeConn.link)
+	}
+	slaveConn, ok := slave.control.currentState().activeConn.link.(*rpcConn)
+	if !ok {
+		t.Fatalf("slave active conn type = %T", slave.control.currentState().activeConn.link)
+	}
+	waitForMeshCondition(t, "authorized mesh links", func() bool {
+		return masterConn.Authed() && slaveConn.Authed()
+	})
+
+	result := map[string]string{"status": "ok"}
+	if err := master.sendCommandResult(context.Background(), &commandResult{
+		CommandID: "cmd-ok",
+		Result:    mustMarshalJSON(t, result),
+	}); err != nil {
+		t.Fatalf("sendCommandResult error: %v", err)
+	}
+
+	var results []recordedResult
+	if slave == nodeA {
+		recA.mtx.Lock()
+		results = append([]recordedResult(nil), recA.results...)
+		recA.mtx.Unlock()
+	} else {
+		recB.mtx.Lock()
+		results = append([]recordedResult(nil), recB.results...)
+		recB.mtx.Unlock()
+	}
+	if len(results) != 1 {
+		t.Fatalf("received command results = %d, want 1", len(results))
+	}
+	if results[0].commandID != "cmd-ok" {
+		t.Fatalf("received command id = %q, want cmd-ok", results[0].commandID)
+	}
+	requireJSONResult(t, results[0].result, result)
 }
 
 func TestMeshPublishEvent(t *testing.T) {

--- a/server/mesh/integration_test.go
+++ b/server/mesh/integration_test.go
@@ -1,9 +1,13 @@
 package mesh
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -29,6 +33,43 @@ type runningMeshNode struct {
 
 	wg              *sync.WaitGroup
 	connectReturned bool
+}
+
+type memoryEventLogProvider struct {
+	mtx      sync.Mutex
+	frontier *db.EventLogPosition
+	entries  []*db.EventLogEntry
+}
+
+func (p *memoryEventLogProvider) EventLogFrontier(context.Context) (*db.EventLogPosition, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	return p.frontier, nil
+}
+
+func (p *memoryEventLogProvider) EventLogEntriesAfter(_ context.Context, after uint64, limit int) ([]*db.EventLogEntry, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	var entries []*db.EventLogEntry
+	for _, entry := range p.entries {
+		if entry.Seq > after {
+			entries = append(entries, entry)
+			if len(entries) == limit {
+				break
+			}
+		}
+	}
+	return entries, nil
+}
+
+func (p *memoryEventLogProvider) appendEntry(entry *db.EventLogEntry) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.entries = append(p.entries, entry)
+	p.frontier = &db.EventLogPosition{
+		Seq:     entry.Seq,
+		TipHash: entry.TipHash,
+	}
 }
 
 func reserveTCPAddr(t *testing.T) string {
@@ -147,6 +188,18 @@ func startIntegrationNode(t *testing.T, node *node) *runningMeshNode {
 	}()
 
 	return run
+}
+
+func publishEventForTest(ctx context.Context, master *node, entry *eventEnvelope) error {
+	state := master.control.currentState()
+	if state.activeConn == nil || state.activeConn.link == nil {
+		return fmt.Errorf("master has no active connection")
+	}
+	var ack eventAck
+	if err := state.activeConn.link.Request(ctx, eventEnvelopeRoute, &eventBatch{Entries: []*eventEnvelope{entry}}, &ack); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *runningMeshNode) waitForConnectResult(t *testing.T, timeout time.Duration) meshConnectResult {
@@ -304,6 +357,333 @@ func TestMeshNodesEstablishMasterSlave(t *testing.T) {
 	}
 }
 
+func TestMeshEventStreamReplaysAndStaysLive(t *testing.T) {
+	aListen := reserveTCPAddr(t)
+	bListen := reserveTCPAddr(t)
+	aPeer := "ws://" + bListen + meshWSPath
+	bPeer := "ws://" + aListen + meshWSPath
+
+	entries := []*db.EventLogEntry{
+		{Seq: 1, Kind: "stream_test", Event: []byte(`"one"`), TipHash: testTipHash(1)},
+		{Seq: 2, Kind: "stream_test", Event: []byte(`"two"`), TipHash: testTipHash(2)},
+	}
+	aFrontier := &memoryEventLogProvider{
+		frontier: &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+		entries:  entries,
+	}
+	bFrontier := &memoryEventLogProvider{
+		frontier: &db.EventLogPosition{},
+	}
+
+	entryBySeq := make(map[uint64]*db.EventLogEntry, len(entries))
+	for _, entry := range entries {
+		entryBySeq[entry.Seq] = entry
+	}
+	var applied []uint64
+	var appliedMtx sync.Mutex
+	applyStreamEvent := func(_ context.Context, entry *eventEnvelope) error {
+		logEntry := entryBySeq[entry.Seq]
+		switch {
+		case logEntry != nil:
+			bFrontier.appendEntry(logEntry)
+		case entry.Seq == 3:
+			bFrontier.appendEntry(&db.EventLogEntry{
+				Seq:     entry.Seq,
+				Kind:    entry.Kind,
+				Event:   append([]byte(nil), entry.Payload...),
+				TipHash: append([]byte(nil), entry.TipHash...),
+			})
+		default:
+			return fmt.Errorf("unexpected stream seq %d", entry.Seq)
+		}
+		appliedMtx.Lock()
+		applied = append(applied, entry.Seq)
+		appliedMtx.Unlock()
+		return nil
+	}
+
+	nodeA := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     aListen,
+		peerAddr:       aPeer,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: aFrontier,
+	})
+	nodeB := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     bListen,
+		peerAddr:       bPeer,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: bFrontier,
+		eventHandler:   applyStreamEvent,
+	})
+	nodeA.dialer.reconnectInterval = time.Hour
+	nodeB.dialer.reconnectInterval = 10 * time.Millisecond
+
+	runA := startIntegrationNode(t, nodeA)
+	time.Sleep(100 * time.Millisecond)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	runA.waitForStartup(t)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if nodeA.control.currentMode() == modeEstablishedMaster && nodeB.control.currentMode() == modeEstablishedSlave {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if nodeA.control.currentMode() != modeEstablishedMaster || nodeB.control.currentMode() != modeEstablishedSlave {
+		t.Fatalf("timed out waiting for stream establishment: a=%s b=%s", nodeA.control.currentState(), nodeB.control.currentState())
+	}
+	runB.waitForStartup(t)
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+	if master != nodeA || slave != nodeB {
+		t.Fatalf("unexpected roles after stream replay: master=%p slave=%p", master, slave)
+	}
+
+	appliedMtx.Lock()
+	gotApplied := append([]uint64(nil), applied...)
+	appliedMtx.Unlock()
+	wantApplied := []uint64{1, 2}
+	if !reflect.DeepEqual(gotApplied, wantApplied) {
+		t.Fatalf("applied stream seqs = %v, want %v", gotApplied, wantApplied)
+	}
+	frontier, err := bFrontier.EventLogFrontier(context.Background())
+	if err != nil {
+		t.Fatalf("frontier error: %v", err)
+	}
+	if frontier.Seq != 2 || !bytes.Equal(frontier.TipHash, testTipHash(2)) {
+		t.Fatalf("frontier = %+v, want seq=2 hash=02", frontier)
+	}
+
+	aFrontier.appendEntry(&db.EventLogEntry{
+		Seq:     3,
+		Kind:    "stream_test",
+		Event:   []byte(`"three"`),
+		TipHash: testTipHash(3),
+	})
+	master.notifyLocalEventCommitted(3, "", nil)
+	waitForMeshCondition(t, "slave event seq 3", func() bool {
+		frontier, err := bFrontier.EventLogFrontier(context.Background())
+		return err == nil && frontier.Seq == 3
+	})
+	appliedMtx.Lock()
+	gotApplied = append([]uint64(nil), applied...)
+	appliedMtx.Unlock()
+	wantApplied = []uint64{1, 2, 3}
+	if !reflect.DeepEqual(gotApplied, wantApplied) {
+		t.Fatalf("applied stream seqs after live tail = %v, want %v", gotApplied, wantApplied)
+	}
+	frontier, err = bFrontier.EventLogFrontier(context.Background())
+	if err != nil {
+		t.Fatalf("frontier error after live tail: %v", err)
+	}
+	if frontier.Seq != 3 || !bytes.Equal(frontier.TipHash, testTipHash(3)) {
+		t.Fatalf("frontier after live tail = %+v, want seq=3 hash=03", frontier)
+	}
+}
+
+func TestMeshEventStreamReconnectResyncsAfterApplyFailure(t *testing.T) {
+	aListen := reserveTCPAddr(t)
+	bListen := reserveTCPAddr(t)
+	aPeer := "ws://" + bListen + meshWSPath
+	bPeer := "ws://" + aListen + meshWSPath
+
+	entries := []*db.EventLogEntry{
+		{Seq: 1, Kind: "stream_test", Event: []byte(`"one"`), TipHash: testTipHash(1)},
+		{Seq: 2, Kind: "stream_test", Event: []byte(`"two"`), TipHash: testTipHash(2)},
+	}
+	aFrontier := &memoryEventLogProvider{
+		frontier: &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+		entries:  entries,
+	}
+	bFrontier := &memoryEventLogProvider{
+		frontier: &db.EventLogPosition{},
+	}
+
+	entryBySeq := make(map[uint64]*db.EventLogEntry, len(entries))
+	for _, entry := range entries {
+		entryBySeq[entry.Seq] = entry
+	}
+
+	var (
+		applyMtx sync.Mutex
+		attempts []uint64
+		failed   bool
+	)
+	firstAttempt := make(chan struct{})
+	applyStreamEvent := func(_ context.Context, entry *eventEnvelope) error {
+		applyMtx.Lock()
+		attempts = append(attempts, entry.Seq)
+		if !failed {
+			failed = true
+			close(firstAttempt)
+			applyMtx.Unlock()
+			return errors.New("one-shot stream apply failure")
+		}
+		applyMtx.Unlock()
+
+		logEntry := entryBySeq[entry.Seq]
+		if logEntry == nil {
+			return fmt.Errorf("unexpected stream seq %d", entry.Seq)
+		}
+		bFrontier.appendEntry(logEntry)
+		return nil
+	}
+
+	nodeA := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     aListen,
+		peerAddr:       aPeer,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: aFrontier,
+	})
+	nodeB := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     bListen,
+		peerAddr:       bPeer,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: bFrontier,
+		eventHandler:   applyStreamEvent,
+	})
+	nodeA.dialer.reconnectInterval = time.Hour
+	nodeB.dialer.reconnectInterval = 10 * time.Millisecond
+
+	runA := startIntegrationNode(t, nodeA)
+	time.Sleep(100 * time.Millisecond)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	runA.waitForStartup(t)
+	select {
+	case <-firstAttempt:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for first stream apply attempt")
+	}
+	frontier, err := bFrontier.EventLogFrontier(context.Background())
+	if err != nil {
+		t.Fatalf("frontier error after one-shot failure: %v", err)
+	}
+	if frontier.Seq != 0 {
+		t.Fatalf("frontier after one-shot failure = %+v, want seq 0", frontier)
+	}
+
+	runB.waitForStartup(t)
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+	if master != nodeA || slave != nodeB {
+		t.Fatalf("unexpected roles after reconnect: master=%p slave=%p", master, slave)
+	}
+
+	waitForMeshCondition(t, "slave resynced to seq 2", func() bool {
+		frontier, err := bFrontier.EventLogFrontier(context.Background())
+		return err == nil && frontier.Seq == 2
+	})
+	frontier, err = bFrontier.EventLogFrontier(context.Background())
+	if err != nil {
+		t.Fatalf("frontier error after reconnect: %v", err)
+	}
+	if frontier.Seq != 2 || !bytes.Equal(frontier.TipHash, testTipHash(2)) {
+		t.Fatalf("frontier after reconnect = %+v, want seq=2 hash=02", frontier)
+	}
+
+	applyMtx.Lock()
+	gotAttempts := append([]uint64(nil), attempts...)
+	applyMtx.Unlock()
+	if len(gotAttempts) < 3 || gotAttempts[0] != 1 || gotAttempts[1] != 1 {
+		t.Fatalf("stream attempts = %v, want first failure and replay of seq 1", gotAttempts)
+	}
+}
+
+// Mid-batch apply failure: seq 1 is durable, reconnect resumes at seq 2.
+func TestMeshEventStreamReconnectResyncsAfterMidBatchApplyFailure(t *testing.T) {
+	entries := []*db.EventLogEntry{
+		{Seq: 1, Kind: "stream_test", Event: []byte(`"one"`), TipHash: testTipHash(1)},
+		{Seq: 2, Kind: "stream_test", Event: []byte(`"two"`), TipHash: testTipHash(2)},
+	}
+	aFrontier := &memoryEventLogProvider{
+		frontier: &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)},
+		entries:  entries,
+	}
+	bFrontier := &memoryEventLogProvider{frontier: &db.EventLogPosition{}}
+
+	var (
+		applyMtx sync.Mutex
+		attempts []uint64
+		failOnce = true
+	)
+	failed := make(chan struct{})
+	apply := func(_ context.Context, env *eventEnvelope) error {
+		applyMtx.Lock()
+		attempts = append(attempts, env.Seq)
+		if env.Seq == 2 && failOnce {
+			failOnce = false
+			applyMtx.Unlock()
+			close(failed)
+			return errors.New("mid-batch apply failure")
+		}
+		applyMtx.Unlock()
+		for _, e := range entries {
+			if e.Seq == env.Seq {
+				bFrontier.appendEntry(e)
+				return nil
+			}
+		}
+		return fmt.Errorf("unexpected seq %d", env.Seq)
+	}
+
+	aListen, bListen := reserveTCPAddr(t), reserveTCPAddr(t)
+	nodeA := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     aListen,
+		peerAddr:       "ws://" + bListen + meshWSPath,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: aFrontier,
+	})
+	nodeB := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     bListen,
+		peerAddr:       "ws://" + aListen + meshWSPath,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: bFrontier,
+		eventHandler:   apply,
+	})
+	nodeA.dialer.reconnectInterval = time.Hour
+	nodeB.dialer.reconnectInterval = 10 * time.Millisecond
+
+	runA := startIntegrationNode(t, nodeA)
+	time.Sleep(100 * time.Millisecond)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() { runA.shutdown(t); runB.shutdown(t) })
+
+	runA.waitForStartup(t)
+	select {
+	case <-failed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for mid-batch failure")
+	}
+	if f, _ := bFrontier.EventLogFrontier(context.Background()); f.Seq != 1 {
+		t.Fatalf("frontier after partial apply = %+v, want seq 1", f)
+	}
+
+	runB.waitForStartup(t)
+	if master, slave := waitForComplementaryModes(t, nodeA, nodeB); master != nodeA || slave != nodeB {
+		t.Fatalf("unexpected roles: master=%p slave=%p", master, slave)
+	}
+	waitForMeshCondition(t, "slave at seq 2", func() bool {
+		f, err := bFrontier.EventLogFrontier(context.Background())
+		return err == nil && f.Seq == 2
+	})
+
+	applyMtx.Lock()
+	got := append([]uint64(nil), attempts...)
+	applyMtx.Unlock()
+	// apply 1, fail 2, reconnect from frontier 1, apply only 2.
+	if want := []uint64{1, 2, 2}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("attempts = %v, want %v", got, want)
+	}
+}
+
 func TestMeshConnectWaitsForPeerUntilCanceled(t *testing.T) {
 	listenAddr := reserveTCPAddr(t)
 	peerAddr := "ws://" + reserveTCPAddr(t) + meshWSPath
@@ -400,5 +780,239 @@ func TestMeshCompatMismatchHaltsStartup(t *testing.T) {
 	}
 	if haltErr == nil || !strings.Contains(haltErr.Error(), "compatibility hash mismatch") {
 		t.Fatalf("HaltStatus err = %v, want compatibility hash mismatch", haltErr)
+	}
+}
+
+func TestMeshPublishEvent(t *testing.T) {
+	recA := new(meshEventRecorder)
+	recB := new(meshEventRecorder)
+	frontierA := &memoryEventLogProvider{frontier: &db.EventLogPosition{}}
+	frontierB := &memoryEventLogProvider{frontier: &db.EventLogPosition{}}
+
+	aListen := reserveTCPAddr(t)
+	bListen := reserveTCPAddr(t)
+	aPeer := "ws://" + bListen + meshWSPath
+	bPeer := "ws://" + aListen + meshWSPath
+
+	nodeA := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     aListen,
+		peerAddr:       aPeer,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: frontierA,
+		eventHandler:   recA.handler(frontierA),
+	})
+	nodeB := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     bListen,
+		peerAddr:       bPeer,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: frontierB,
+		eventHandler:   recB.handler(frontierB),
+	})
+
+	runA := startIntegrationNode(t, nodeA)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+	})
+	runA.assertStartupPending(t, 200*time.Millisecond)
+
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runB.shutdown(t)
+	})
+	runB.waitForStartup(t)
+	runA.waitForStartup(t)
+
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+	masterConn, ok := master.control.currentState().activeConn.link.(*rpcConn)
+	if !ok {
+		t.Fatalf("master active conn type = %T", master.control.currentState().activeConn.link)
+	}
+	slaveConn, ok := slave.control.currentState().activeConn.link.(*rpcConn)
+	if !ok {
+		t.Fatalf("slave active conn type = %T", slave.control.currentState().activeConn.link)
+	}
+	waitForMeshCondition(t, "authorized mesh links", func() bool {
+		return masterConn.Authed() && slaveConn.Authed()
+	})
+
+	if err := publishEventForTest(context.Background(), master, &eventEnvelope{
+		Seq:             1,
+		TipHash:         testTipHash(1),
+		MasterTip:       1,
+		Kind:            "test_order_accepted",
+		OriginCommandID: "cmd-88",
+		Payload:         []byte(`{"oid":"abc123"}`),
+	}); err != nil {
+		t.Fatalf("PublishEvent #1 error: %v", err)
+	}
+	if err := publishEventForTest(context.Background(), master, &eventEnvelope{
+		Seq:       2,
+		TipHash:   testTipHash(2),
+		MasterTip: 2,
+		Kind:      "epoch_ended",
+		Payload:   []byte(`{"epoch":7}`),
+	}); err != nil {
+		t.Fatalf("PublishEvent #2 error: %v", err)
+	}
+
+	waitForMeshCondition(t, "slave event seq 2", func() bool {
+		if slave == nodeA {
+			return recA.count() == 2
+		}
+		return recB.count() == 2
+	})
+
+	var applied []eventEnvelope
+	if slave == nodeA {
+		applied = recA.events()
+	} else {
+		applied = recB.events()
+	}
+
+	if len(applied) != 2 {
+		t.Fatalf("applied events = %d, want 2", len(applied))
+	}
+	if applied[0].Seq != 1 || applied[0].Kind != "test_order_accepted" {
+		t.Fatalf("first event = %+v, want seq=1 kind=order_accepted", applied[0])
+	}
+	if applied[0].OriginCommandID != "cmd-88" {
+		t.Fatalf("first event origin command id = %q, want cmd-88", applied[0].OriginCommandID)
+	}
+	if string(applied[0].Payload) != `{"oid":"abc123"}` {
+		t.Fatalf("first event payload = %s", applied[0].Payload)
+	}
+	if applied[1].Seq != 2 || applied[1].Kind != "epoch_ended" {
+		t.Fatalf("second event = %+v, want seq=2 kind=epoch_ended", applied[1])
+	}
+	if string(applied[1].Payload) != `{"epoch":7}` {
+		t.Fatalf("second event payload = %s", applied[1].Payload)
+	}
+}
+
+type meshEventRecorder struct {
+	mtx       sync.Mutex
+	envelopes []eventEnvelope
+}
+
+func (r *meshEventRecorder) handler(frontier *memoryEventLogProvider) func(context.Context, *eventEnvelope) error {
+	return func(_ context.Context, entry *eventEnvelope) error {
+		r.mtx.Lock()
+		defer r.mtx.Unlock()
+		copied := *entry
+		copied.TipHash = append([]byte(nil), entry.TipHash...)
+		copied.Payload = append([]byte(nil), entry.Payload...)
+		copied.CommandResult = append([]byte(nil), entry.CommandResult...)
+		r.envelopes = append(r.envelopes, copied)
+		frontier.appendEntry(&db.EventLogEntry{
+			Seq:     entry.Seq,
+			Kind:    entry.Kind,
+			Event:   append([]byte(nil), entry.Payload...),
+			TipHash: append([]byte(nil), entry.TipHash...),
+		})
+		return nil
+	}
+}
+
+func (r *meshEventRecorder) count() int {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return len(r.envelopes)
+}
+
+func (r *meshEventRecorder) events() []eventEnvelope {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return append([]eventEnvelope(nil), r.envelopes...)
+}
+
+func TestMeshPreparingMasterDefersStartupEventStreamUntilReady(t *testing.T) {
+	recA := new(meshEventRecorder)
+	recB := new(meshEventRecorder)
+	frontierA := &memoryEventLogProvider{frontier: &db.EventLogPosition{}}
+	frontierB := &memoryEventLogProvider{frontier: &db.EventLogPosition{}}
+
+	aListen := reserveTCPAddr(t)
+	bListen := reserveTCPAddr(t)
+	aPeer := "ws://" + bListen + meshWSPath
+	bPeer := "ws://" + aListen + meshWSPath
+
+	nodeA := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     aListen,
+		peerAddr:       aPeer,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: frontierA,
+		eventHandler:   recA.handler(frontierA),
+		lifecycle:      &lifecycleHooks{},
+	})
+	nodeB := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:     bListen,
+		peerAddr:       bPeer,
+		compat:         testCompatSnapshot(t),
+		eventLogReader: frontierB,
+		eventHandler:   recB.handler(frontierB),
+		lifecycle:      &lifecycleHooks{},
+	})
+
+	runA := startIntegrationNode(t, nodeA)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	waitForMeshCondition(t, "preparing master and established slave", func() bool {
+		aState := nodeA.control.currentState()
+		bState := nodeB.control.currentState()
+		paired := aState.activeConn != nil && bState.activeConn != nil &&
+			aState.activeConn.initiatorNodeID == bState.activeConn.initiatorNodeID
+		return paired && ((aState.mode == modePreparingMaster && bState.mode == modeEstablishedSlave) ||
+			(aState.mode == modeEstablishedSlave && bState.mode == modePreparingMaster))
+	})
+
+	master, slaveRec, masterFrontier := nodeA, recB, frontierA
+	if nodeB.control.currentMode() == modePreparingMaster {
+		master, slaveRec, masterFrontier = nodeB, recA, frontierB
+	}
+
+	if err := master.checkEventPublishAvailable(false); err != nil {
+		t.Fatalf("direct event unavailable during master preparation: %v", err)
+	}
+	if err := master.checkEventPublishAvailable(true); err == nil {
+		t.Fatalf("forwarded-command event available during master preparation")
+	}
+
+	startupEntry := &db.EventLogEntry{
+		Seq:     1,
+		Kind:    "test_market_started",
+		Event:   []byte(`{"market":"dcr_btc"}`),
+		TipHash: testTipHash(1),
+	}
+	masterFrontier.appendEntry(startupEntry)
+	master.notifyLocalEventCommitted(startupEntry.Seq, "", nil)
+
+	time.Sleep(100 * time.Millisecond)
+	if got := slaveRec.count(); got != 0 {
+		t.Fatalf("slave received %d events before master readiness, want 0", got)
+	}
+
+	if err := master.notifyMasterReady(); err != nil {
+		t.Fatalf("notifyMasterReady error: %v", err)
+	}
+	runA.waitForStartup(t)
+	runB.waitForStartup(t)
+	waitForComplementaryModes(t, nodeA, nodeB)
+
+	waitForMeshCondition(t, "slave received market_started event", func() bool {
+		return slaveRec.count() == 1
+	})
+	got := slaveRec.events()[0]
+	if got.Seq != startupEntry.Seq || got.MasterTip != startupEntry.Seq || got.Kind != startupEntry.Kind {
+		t.Fatalf("event envelope = %+v, want seq/tip=%d kind=%q", got, startupEntry.Seq, startupEntry.Kind)
+	}
+	if got.OriginCommandID != "" || len(got.CommandResult) != 0 {
+		t.Fatalf("event command ID/result = %q/%x, want empty", got.OriginCommandID, got.CommandResult)
+	}
+	if string(got.Payload) != string(startupEntry.Event) {
+		t.Fatalf("event payload = %s, want %s", got.Payload, startupEntry.Event)
 	}
 }

--- a/server/mesh/integration_test.go
+++ b/server/mesh/integration_test.go
@@ -1,0 +1,404 @@
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/db"
+)
+
+type meshConnectResult struct {
+	wg  *sync.WaitGroup
+	err error
+}
+
+var integrationTestLogger dex.Logger = dex.Disabled
+
+type runningMeshNode struct {
+	node *node
+
+	cancel context.CancelFunc
+	result chan meshConnectResult
+
+	wg              *sync.WaitGroup
+	connectReturned bool
+}
+
+func reserveTCPAddr(t *testing.T) string {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer l.Close()
+
+	return l.Addr().String()
+}
+
+type integrationNodeConfig struct {
+	listenAddr, peerAddr string
+	compat               *CompatSnapshot
+	eventLogReader       db.EventLogReader
+	initialSeq           uint64
+	cmdHandler           func(context.Context, string, CommandRequest) *msgjson.Error
+	resultHandler        func(string, json.RawMessage)
+	proxyHandler         func(context.Context, *ClientProxyMessage) error
+	eventHandler         func(context.Context, *eventEnvelope) error
+
+	// A nil lifecycle reports master readiness automatically. Supplying hooks
+	// lets the test control readiness.
+	lifecycle *lifecycleHooks
+}
+
+func newIntegrationNode(t *testing.T, cfg integrationNodeConfig) *node {
+	t.Helper()
+	var node *node
+	eventLogReader := cfg.eventLogReader
+	lifecycle := lifecycleHooks{}
+	if cfg.lifecycle != nil {
+		lifecycle = *cfg.lifecycle
+	} else {
+		lifecycle.becameMaster = func() {
+			go func() {
+				if node != nil {
+					_ = node.notifyMasterReady()
+				}
+			}()
+		}
+	}
+
+	if lifecycle.becameMaster == nil {
+		lifecycle.becameMaster = func() {}
+	}
+	if lifecycle.peerClientEndpointChanged == nil {
+		lifecycle.peerClientEndpointChanged = func(string, []byte) {}
+	}
+	if lifecycle.failPendingCommands == nil {
+		lifecycle.failPendingCommands = func(string) {}
+	}
+	if lifecycle.halted == nil {
+		lifecycle.halted = func(error) {}
+	}
+
+	initialFrontier := &db.EventLogPosition{Seq: cfg.initialSeq}
+	if eventLogReader == nil {
+		eventLogReader = &testEventLogReader{frontier: initialFrontier}
+	} else {
+		frontier, err := eventLogReader.EventLogFrontier(context.Background())
+		if err != nil {
+			t.Fatalf("initial frontier: %v", err)
+		}
+		if frontier != nil {
+			initialFrontier = frontier
+		}
+	}
+
+	var err error
+	node, err = newNode(&nodeConfig{
+		dataDir:         t.TempDir(),
+		listenAddr:      cfg.listenAddr,
+		peerAddr:        cfg.peerAddr,
+		compat:          cfg.compat,
+		dexPrivKey:      testPrivKey(),
+		noTLS:           true,
+		logger:          integrationTestLogger,
+		eventLogReader:  eventLogReader,
+		snapshotStore:   &fakeSnapshotStore{},
+		initialFrontier: initialFrontier,
+		app: &testMeshApplication{
+			commandForward: cfg.cmdHandler,
+			commandResult:  cfg.resultHandler,
+			clientProxy:    cfg.proxyHandler,
+			event:          cfg.eventHandler,
+		},
+		lifecycle: lifecycle,
+	})
+	if err != nil {
+		t.Fatalf("newNode(%s): %v", cfg.listenAddr, err)
+	}
+	// These tests have no state loaders; open the events gate immediately,
+	// as the service does once its loaders complete.
+	node.notifyReadyForEvents()
+
+	return node
+}
+
+func startIntegrationNode(t *testing.T, node *node) *runningMeshNode {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	run := &runningMeshNode{
+		node:   node,
+		cancel: cancel,
+		result: make(chan meshConnectResult, 1),
+	}
+
+	go func() {
+		wg, err := node.connect(ctx)
+		run.result <- meshConnectResult{wg: wg, err: err}
+	}()
+
+	return run
+}
+
+func (r *runningMeshNode) waitForConnectResult(t *testing.T, timeout time.Duration) meshConnectResult {
+	t.Helper()
+
+	select {
+	case res := <-r.result:
+		r.connectReturned = true
+		r.wg = res.wg
+		return res
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for Connect to return; state=%s", r.node.control.currentState())
+		return meshConnectResult{}
+	}
+}
+
+func (r *runningMeshNode) waitForStartup(t *testing.T) {
+	t.Helper()
+
+	res := r.waitForConnectResult(t, 5*time.Second)
+	if res.err != nil {
+		t.Fatalf("Connect error: %v", res.err)
+	}
+	if res.wg == nil {
+		t.Fatal("Connect returned nil waitgroup")
+	}
+}
+
+func (r *runningMeshNode) assertStartupPending(t *testing.T, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case res := <-r.result:
+		r.connectReturned = true
+		r.wg = res.wg
+		t.Fatalf("Connect returned early: wg=%v err=%v", res.wg, res.err)
+	case <-time.After(timeout):
+	}
+}
+
+func (r *runningMeshNode) shutdown(t *testing.T) {
+	t.Helper()
+
+	r.cancel()
+
+	if !r.connectReturned {
+		res := r.waitForConnectResult(t, 5*time.Second)
+		if res.err != nil || res.wg == nil {
+			return
+		}
+	}
+	if r.wg == nil {
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for mesh node shutdown")
+	}
+}
+
+func waitForMeshCondition(t *testing.T, desc string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for %s", desc)
+}
+
+func waitForComplementaryModes(t *testing.T, a, b *node) (master, slave *node) {
+	t.Helper()
+
+	var pairedSince time.Time
+	var aConnID, bConnID uint64
+	waitForMeshCondition(t, "complementary master/slave modes with paired active link", func() bool {
+		aState := a.control.currentState()
+		bState := b.control.currentState()
+		modesReady := (aState.mode == modeEstablishedMaster && bState.mode == modeEstablishedSlave) ||
+			(aState.mode == modeEstablishedSlave && bState.mode == modeEstablishedMaster)
+		if !modesReady || aState.activeConn == nil || bState.activeConn == nil ||
+			aState.activeConn.initiatorNodeID != bState.activeConn.initiatorNodeID {
+			pairedSince = time.Time{}
+			return false
+		}
+
+		if aID, bID := aState.activeConn.ID(), bState.activeConn.ID(); pairedSince.IsZero() || aID != aConnID || bID != bConnID {
+			aConnID, bConnID = aID, bID
+			pairedSince = time.Now()
+			return false
+		}
+		return time.Since(pairedSince) >= 100*time.Millisecond
+	})
+
+	if a.control.currentMode() == modeEstablishedMaster {
+		return a, b
+	}
+	return b, a
+}
+
+func newMeshPair(t *testing.T, aCompat, bCompat *CompatSnapshot) (*node, *node) {
+	t.Helper()
+
+	aListen := reserveTCPAddr(t)
+	bListen := reserveTCPAddr(t)
+
+	aPeer := "ws://" + bListen + meshWSPath
+	bPeer := "ws://" + aListen + meshWSPath
+
+	nodeA := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr: aListen,
+		peerAddr:   aPeer,
+		compat:     aCompat,
+	})
+	nodeB := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr: bListen,
+		peerAddr:   bPeer,
+		compat:     bCompat,
+	})
+
+	return nodeA, nodeB
+}
+
+func TestMeshNodesEstablishMasterSlave(t *testing.T) {
+	nodeA, nodeB := newMeshPair(t, testCompatSnapshot(t), testCompatSnapshot(t))
+
+	runA := startIntegrationNode(t, nodeA)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	runA.waitForStartup(t)
+	runB.waitForStartup(t)
+
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+	if !master.control.hasPeerConnection() {
+		t.Fatal("master has no active peer connection")
+	}
+	if !slave.control.hasPeerConnection() {
+		t.Fatal("slave has no active peer connection")
+	}
+}
+
+func TestMeshConnectWaitsForPeerUntilCanceled(t *testing.T) {
+	listenAddr := reserveTCPAddr(t)
+	peerAddr := "ws://" + reserveTCPAddr(t) + meshWSPath
+
+	node := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr: listenAddr,
+		peerAddr:   peerAddr,
+		compat:     testCompatSnapshot(t),
+	})
+	run := startIntegrationNode(t, node)
+
+	run.assertStartupPending(t, 200*time.Millisecond)
+
+	run.cancel()
+	res := run.waitForConnectResult(t, 5*time.Second)
+	if res.err == nil || !strings.Contains(res.err.Error(), "mesh stopped during startup") {
+		t.Fatalf("Connect error = %v, want mesh stopped during startup", res.err)
+	}
+	if res.wg != nil {
+		done := make(chan struct{})
+		go func() {
+			res.wg.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for mesh node shutdown")
+		}
+	}
+}
+
+func TestMeshNodeStartsAfterPeerAppears(t *testing.T) {
+	nodeA, nodeB := newMeshPair(t, testCompatSnapshot(t), testCompatSnapshot(t))
+
+	runA := startIntegrationNode(t, nodeA)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+	})
+
+	runA.assertStartupPending(t, 200*time.Millisecond)
+
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runB.shutdown(t)
+	})
+
+	runA.waitForStartup(t)
+	runB.waitForStartup(t)
+
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+	if !master.control.hasPeerConnection() {
+		t.Fatal("master has no active peer connection")
+	}
+	if !slave.control.hasPeerConnection() {
+		t.Fatal("slave has no active peer connection")
+	}
+}
+
+func TestMeshCompatMismatchHaltsStartup(t *testing.T) {
+	nodeA, nodeB := newMeshPair(t, testCompatSnapshot(t), differentCompatSnapshot(t))
+
+	runA := startIntegrationNode(t, nodeA)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	waitForMeshCondition(t, "mesh halt due to incompatibility", func() bool {
+		haltedA, _ := nodeA.control.haltStatus()
+		haltedB, _ := nodeB.control.haltStatus()
+		return haltedA || haltedB
+	})
+
+	haltedRun := runA
+	haltedNode := nodeA
+	if halted, _ := nodeA.control.haltStatus(); !halted {
+		haltedRun = runB
+		haltedNode = nodeB
+	}
+
+	res := haltedRun.waitForConnectResult(t, 5*time.Second)
+	if res.err == nil {
+		t.Fatal("expected Connect error for halted node")
+	}
+	if !strings.Contains(res.err.Error(), "compatibility hash mismatch") {
+		t.Fatalf("Connect error = %q, want compatibility hash mismatch", res.err)
+	}
+
+	halted, haltErr := haltedNode.control.haltStatus()
+	if !halted {
+		t.Fatal("expected node to report halted state")
+	}
+	if haltErr == nil || !strings.Contains(haltErr.Error(), "compatibility hash mismatch") {
+		t.Fatalf("HaltStatus err = %v, want compatibility hash mismatch", haltErr)
+	}
+}

--- a/server/mesh/integration_test.go
+++ b/server/mesh/integration_test.go
@@ -1210,3 +1210,147 @@ func TestMeshPreparingMasterDefersStartupEventStreamUntilReady(t *testing.T) {
 		t.Fatalf("event payload = %s, want %s", got.Payload, startupEntry.Event)
 	}
 }
+
+func TestMeshProxyClientMessage(t *testing.T) {
+	type proxiedCall struct {
+		user      account.AccountID
+		msgType   msgjson.MessageType
+		route     string
+		msgID     uint64
+		timeout   time.Duration
+		broadcast bool
+	}
+
+	var (
+		callMtx sync.Mutex
+		calls   []proxiedCall
+	)
+
+	proxiedHandler := func(_ context.Context, req *ClientProxyMessage) error {
+		time.Sleep(20 * time.Millisecond)
+		callMtx.Lock()
+		calls = append(calls, proxiedCall{
+			user:      req.User,
+			msgType:   req.Msg.Type,
+			route:     req.Msg.Route,
+			msgID:     req.Msg.ID,
+			timeout:   time.Duration(req.TimeoutMS) * time.Millisecond,
+			broadcast: req.Broadcast,
+		})
+		callMtx.Unlock()
+		return nil
+	}
+
+	aListen := reserveTCPAddr(t)
+	bListen := reserveTCPAddr(t)
+	aPeer := "ws://" + bListen + meshWSPath
+	bPeer := "ws://" + aListen + meshWSPath
+
+	nodeA := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:   aListen,
+		peerAddr:     aPeer,
+		compat:       testCompatSnapshot(t),
+		proxyHandler: proxiedHandler,
+	})
+	nodeB := newIntegrationNode(t, integrationNodeConfig{
+		listenAddr:   bListen,
+		peerAddr:     bPeer,
+		compat:       testCompatSnapshot(t),
+		proxyHandler: proxiedHandler,
+	})
+
+	runA := startIntegrationNode(t, nodeA)
+	runB := startIntegrationNode(t, nodeB)
+	t.Cleanup(func() {
+		runA.shutdown(t)
+		runB.shutdown(t)
+	})
+
+	runA.waitForStartup(t)
+	runB.waitForStartup(t)
+
+	master, slave := waitForComplementaryModes(t, nodeA, nodeB)
+
+	var user account.AccountID
+	user[0] = 0x44
+
+	req, err := msgjson.NewRequest(88, msgjson.PreimageRoute, map[string]string{"mkt": "dcr_btc"})
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+
+	err = master.sendClientProxyMessage(context.Background(), &ClientProxyMessage{
+		User:      user,
+		Msg:       req,
+		TimeoutMS: 50,
+	})
+	if err != nil {
+		t.Fatalf("ProxyClientMessage error: %v", err)
+	}
+
+	resp, err := msgjson.NewResponse(89, struct{}{}, nil)
+	if err != nil {
+		t.Fatalf("NewResponse error: %v", err)
+	}
+	err = slave.sendClientProxyMessage(context.Background(), &ClientProxyMessage{
+		User: user,
+		Msg:  resp,
+	})
+	if err != nil {
+		t.Fatalf("response ProxyClientMessage error: %v", err)
+	}
+
+	note, err := msgjson.NewNotification(msgjson.NotifyRoute, "scheduled maintenance in 10 minutes")
+	if err != nil {
+		t.Fatalf("NewNotification error: %v", err)
+	}
+	err = master.sendClientProxyMessage(context.Background(), &ClientProxyMessage{
+		Msg:       note,
+		Broadcast: true,
+	})
+	if err != nil {
+		t.Fatalf("broadcast ProxyClientMessage error: %v", err)
+	}
+
+	callMtx.Lock()
+	defer callMtx.Unlock()
+	if len(calls) != 3 {
+		t.Fatalf("proxied handler calls = %d, want 3", len(calls))
+	}
+	if calls[0].user != user {
+		t.Fatalf("proxied handler user = %v, want %v", calls[0].user, user)
+	}
+	if calls[0].msgType != msgjson.Request {
+		t.Fatalf("proxied handler message type = %v, want request", calls[0].msgType)
+	}
+	if calls[0].route != msgjson.PreimageRoute {
+		t.Fatalf("proxied handler route = %q, want %q", calls[0].route, msgjson.PreimageRoute)
+	}
+	if calls[0].msgID != req.ID {
+		t.Fatalf("proxied handler msg id = %d, want %d", calls[0].msgID, req.ID)
+	}
+	if calls[0].timeout != 50*time.Millisecond {
+		t.Fatalf("proxied handler timeout = %v, want %v", calls[0].timeout, 50*time.Millisecond)
+	}
+	if calls[1].user != user {
+		t.Fatalf("response handler user = %v, want %v", calls[1].user, user)
+	}
+	if calls[1].msgType != msgjson.Response {
+		t.Fatalf("response handler message type = %v, want response", calls[1].msgType)
+	}
+	if calls[1].msgID != resp.ID {
+		t.Fatalf("response handler msg id = %d, want %d", calls[1].msgID, resp.ID)
+	}
+	if calls[0].broadcast || calls[1].broadcast {
+		t.Fatalf("per-user proxied messages arrived flagged as broadcast")
+	}
+	if !calls[2].broadcast {
+		t.Fatalf("broadcast flag not relayed")
+	}
+	if calls[2].msgType != msgjson.Notification {
+		t.Fatalf("broadcast handler message type = %v, want notification", calls[2].msgType)
+	}
+	if calls[2].route != msgjson.NotifyRoute {
+		t.Fatalf("broadcast handler route = %q, want %q", calls[2].route, msgjson.NotifyRoute)
+	}
+}

--- a/server/mesh/node.go
+++ b/server/mesh/node.go
@@ -592,6 +592,91 @@ func (n *node) activePeerForRequest(allowed func(nodeMode) bool) (*nodeConn, err
 	return state.activeConn, nil
 }
 
+// activePeerForCommandForward returns the active peer connection if the
+// current mode allows command forwarding. If there is no active connection,
+// or if command forwarding is not allowed in the current mode, it returns an
+// error.
+func (n *node) activePeerForCommandForward(kind string) (*nodeConn, *msgjson.Error) {
+	state := n.control.currentState()
+	if !state.mode.canForwardCommands() || state.activeConn == nil || state.activeConn.link == nil {
+		return nil, msgjson.NewError(msgjson.TryAgainLaterError,
+			"mesh command %q cannot be forwarded; retry the request", kind)
+	}
+	return state.activeConn, nil
+}
+
+// canExecuteCommandLocally reports if the current mode allows command
+// execution locally.
+func (n *node) canExecuteCommandLocally() bool {
+	return n.control.currentMode().canExecuteCommands()
+}
+
+// canForwardCommand reports if the current mode allows command forwarding.
+func (n *node) canForwardCommand() bool {
+	state := n.control.currentState()
+	return state.mode.canForwardCommands() && state.activeConn != nil && state.activeConn.link != nil
+}
+
+// forwardCommand forwards a prepared state-changing client command from a
+// slave to the current master.
+func (n *node) forwardCommand(ctx context.Context, cmd *commandForward) (*msgjson.Error, bool) {
+	conn, msgErr := n.activePeerForCommandForward(cmd.Kind)
+	if msgErr != nil {
+		return msgErr, false
+	}
+
+	// Use a default request timeout shorter than the pending-command
+	// timeout so a late completion can still find the pending entry.
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, forwardCommandTimeout)
+		defer cancel()
+	}
+
+	if err := conn.link.Request(ctx, commandForwardRoute, cmd, nil); err != nil {
+		n.log.Debugf("Command %q forward to master failed: %v", cmd.Kind, err)
+
+		// peerRPCError means that the request reached the master, but was
+		// rejected.
+		var peerErr *peerRPCError
+		if errors.As(err, &peerErr) {
+			// UnauthorizedConnection is returned when the request is rejected
+			// because master not in the correct mode to execute a forwarded
+			// command. This means the client should TryAgainLater.
+			if peerErr.Code != msgjson.UnauthorizedConnection {
+				return peerErr.MsgError(), false
+			}
+			return msgjson.NewError(msgjson.TryAgainLaterError,
+				"mesh command %q forward refused by a mesh gate; retry the request", cmd.Kind), false
+		}
+
+		// No response. The command may have reached the master anyway.
+		return nil, true
+	}
+
+	return nil, false
+}
+
+// sendCommandFailure sends a terminal failure for an accepted forwarded command
+// from the master to the slave holding the original client request.
+func (n *node) sendCommandFailure(ctx context.Context, fail *commandFailure) error {
+	conn, err := n.activePeerForRequest(nodeMode.canDeliverCommandCompletions)
+	if err != nil {
+		return fmt.Errorf("mesh command failure: %w", err)
+	}
+	return conn.link.Request(ctx, commandFailureRoute, fail, nil)
+}
+
+// sendCommandResult sends a success result for an accepted forwarded command
+// from the master to the slave holding the original client request.
+func (n *node) sendCommandResult(ctx context.Context, result *commandResult) error {
+	conn, err := n.activePeerForRequest(nodeMode.canDeliverCommandCompletions)
+	if err != nil {
+		return fmt.Errorf("mesh command result: %w", err)
+	}
+	return conn.link.Request(ctx, commandResultRoute, result, nil)
+}
+
 // notifyMasterReady sends a signal to the control loop to indicate
 // the master is ready to serve clients.
 func (n *node) notifyMasterReady() error {

--- a/server/mesh/node.go
+++ b/server/mesh/node.go
@@ -677,6 +677,62 @@ func (n *node) sendCommandResult(ctx context.Context, result *commandResult) err
 	return conn.link.Request(ctx, commandResultRoute, result, nil)
 }
 
+// sendClientProxyMessage relays a live client message through the active mesh
+// peer and waits only for mesh-level receipt.
+func (n *node) sendClientProxyMessage(ctx context.Context, msg *ClientProxyMessage) error {
+	if err := validateClientProxyMessage(msg); err != nil {
+		return err
+	}
+
+	conn, err := n.activePeerForRequest(nodeMode.canRelayClientMessages)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrClientProxyUnavailable, err)
+	}
+
+	if err := conn.link.Request(ctx, clientProxyMessageRoute, msg, nil); err != nil {
+		var peerErr *peerRPCError
+		if errors.As(err, &peerErr) && peerErr.Code == msgjson.UserNotConnectedError {
+			return fmt.Errorf("%w to peer", ErrClientNotConnected)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// queryClientConnected asks the active mesh peer which of the listed client
+// accounts are connected to it and returns the peer's answer.
+func (n *node) queryClientConnected(ctx context.Context, users []account.AccountID) ([]account.AccountID, error) {
+	query := &clientConnectedQuery{Users: users}
+	if err := validateClientConnectedQuery(query); err != nil {
+		return nil, err
+	}
+
+	conn, err := n.activePeerForRequest(nodeMode.canExchangeClientConnectivity)
+	if err != nil {
+		return nil, fmt.Errorf("mesh client connected query: %w", err)
+	}
+
+	var result clientConnectedResult
+	if err := conn.link.Request(ctx, clientConnectedRoute, query, &result); err != nil {
+		return nil, err
+	}
+
+	// A connectivity claim for an account this node never asked about is a
+	// malformed answer. Reject the whole response.
+	queried := make(map[account.AccountID]struct{}, len(users))
+	for _, user := range users {
+		queried[user] = struct{}{}
+	}
+	for _, user := range result.Connected {
+		if _, found := queried[user]; !found {
+			return nil, fmt.Errorf("client connected response claims un-queried account %v", user)
+		}
+	}
+
+	return result.Connected, nil
+}
+
 // notifyMasterReady sends a signal to the control loop to indicate
 // the master is ready to serve clients.
 func (n *node) notifyMasterReady() error {

--- a/server/mesh/node.go
+++ b/server/mesh/node.go
@@ -764,3 +764,25 @@ func (n *node) notifyMasterPreparationFailed(err error) error {
 	}
 	return res.err
 }
+
+// requestMasterHandoff asks the caught-up slave to begin master preparation.
+// This is done to assure the slave that the master is purposely shutting down,
+// and does not need to wait for the slavePromotionDelay before promoting to
+// master.
+func (n *node) requestMasterHandoff(ctx context.Context) error {
+	frontier, err := n.eventLogReader.EventLogFrontier(ctx)
+	if err != nil {
+		return fmt.Errorf("read handoff frontier: %w", err)
+	}
+
+	peerConn, err := n.activePeerForRequest(nodeMode.canStreamEvents)
+	if err != nil {
+		return err
+	}
+	if err := peerConn.link.Request(ctx, masterHandoffRoute, &masterHandoff{
+		Frontier: toFrontierMessage(frontier),
+	}, nil); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/mesh/node.go
+++ b/server/mesh/node.go
@@ -6,6 +6,7 @@ package mesh
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -122,6 +123,78 @@ func (n *node) handleEffect(eff effect) {
 		n.lifecycle.peerClientEndpointChanged(e.Host, append([]byte(nil), e.Cert...))
 	case effectFailPendingCommands:
 		n.lifecycle.failPendingCommands(e.Reason)
+	}
+}
+
+// errConnNotAdopted means this conn lost adoption to an existing session
+// with the same peer.
+var errConnNotAdopted = errors.New("connection not adopted")
+
+// applyHandshakeResult hands a completed wire handshake to the control loop,
+// which decides whether to adopt the connection and which mode this node
+// moves to (possibly halting it).
+//   - nil means the connection was adopted as the active connection
+//   - Any error means the connection was not adopted and the caller must disconnect it.
+//   - errConnNotAdopted specifically means the handshake itself was fine but an
+//     existing session with this peer took precedence.
+func (n *node) applyHandshakeResult(ctx context.Context, conn link, result *handshakeResult, initiatorNodeID string) error {
+	peerConn := newNodeConn(conn, result.peerHello.NodeID, initiatorNodeID)
+	peerRole := result.peerHello.Role
+	progress := result.progress
+	peerFrontier := fromFrontierMessage(result.peerHello.Frontier)
+
+	localFrontier, err := n.eventLogReader.EventLogFrontier(ctx)
+	if err != nil {
+		return fmt.Errorf("local event log frontier: %w", err)
+	}
+
+	res, err := n.control.send(handshakeResolvedSignal{
+		conn:          peerConn,
+		peerRole:      peerRole,
+		progress:      progress,
+		localFrontier: localFrontier,
+		peerFrontier:  peerFrontier,
+		clientHost:    result.clientHost,
+		clientCert:    append([]byte(nil), result.clientCert...),
+		at:            time.Now(),
+	})
+	if err != nil {
+		return err
+	}
+	if res.err != nil {
+		return res.err
+	}
+
+	state := res.state
+
+	switch outcome := res.outcome.(type) {
+	case handshakeOutcome:
+		switch outcome {
+		case handshakeAdopted:
+			n.log.Infof("Mesh handshake with peer %s resolved: peer_role=%s progress=%s local_state=%s",
+				meshPeerLogID(peerConn), peerRole, progress, state.mode)
+			return nil
+		case handshakeNotAdopted:
+			n.log.Infof("Mesh handshake with peer %s resolved: peer_role=%s progress=%s connection_not_adopted local_state=%s",
+				meshPeerLogID(peerConn), peerRole, progress, state.mode)
+			return errConnNotAdopted
+		case handshakeDivergedJoinRejected:
+			n.log.Warnf("Mesh peer %s presented a diverged event log (peer_role=%s); "+
+				"rejecting join, remaining serving master. local_state=%s",
+				meshPeerLogID(peerConn), peerRole, state.mode)
+			return fmt.Errorf("diverged peer join rejected; this node remains the serving master")
+		case handshakeHalted:
+			n.log.Warnf("Mesh handshake with peer %s resolved: peer_role=%s progress=%s local_state=%s err=%v",
+				meshPeerLogID(peerConn), peerRole, progress, state.mode, state.haltErr)
+			if state.haltErr != nil {
+				return state.haltErr
+			}
+			return fmt.Errorf("mesh halted after handshake")
+		default:
+			return fmt.Errorf("unknown handshake outcome %s", outcome)
+		}
+	default:
+		return fmt.Errorf("handshake resolution reported no outcome (local_state=%s)", state.mode)
 	}
 }
 

--- a/server/mesh/node.go
+++ b/server/mesh/node.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
 // meshApplication lets the node deliver peer commands, events, and results to
@@ -34,6 +36,72 @@ type lifecycleHooks struct {
 	peerClientEndpointChanged func(string, []byte)
 	failPendingCommands       func(reason string)
 	halted                    func(error)
+}
+
+// nodeConfig is configuration of a mesh node.
+type nodeConfig struct {
+	app       meshApplication
+	lifecycle lifecycleHooks
+
+	dataDir    string
+	listenAddr string
+	rpcKey     string
+	rpcCert    string
+	noTLS      bool
+	compat     *CompatSnapshot
+	// dexPrivKey is the server signing identity already used for client-facing
+	// messages. In the current mesh design, both nodes share that key so
+	// client-facing signatures do not change during failover, and mesh hello
+	// payloads are authenticated with the same shared identity.
+	dexPrivKey     *secp256k1.PrivateKey
+	eventLogReader db.EventLogReader
+	snapshotStore  db.SnapshotStore
+	logger         dex.Logger
+
+	peerAddr string
+	peerCert []byte
+
+	// clientHost and clientCert are advertised in the signed mesh hello.
+	clientHost string
+	clientCert []byte
+
+	// initialFrontier is the event-log frontier at service construction time.
+	// It may be nil for a brand-new node.
+	initialFrontier *db.EventLogPosition
+}
+
+func (cfg *nodeConfig) validate() error {
+	if cfg == nil {
+		return fmt.Errorf("nil config")
+	}
+	if cfg.dataDir == "" {
+		return fmt.Errorf("empty data dir")
+	}
+	if cfg.listenAddr == "" {
+		return fmt.Errorf("empty listen address")
+	}
+	if cfg.peerAddr == "" {
+		return fmt.Errorf("empty peer address")
+	}
+	if !cfg.noTLS && (cfg.rpcKey == "" || cfg.rpcCert == "") {
+		return fmt.Errorf("missing cert pair file")
+	}
+	if cfg.compat == nil {
+		return fmt.Errorf("nil compatibility snapshot")
+	}
+	if cfg.dexPrivKey == nil {
+		return fmt.Errorf("nil DEX private key")
+	}
+	if cfg.eventLogReader == nil {
+		return fmt.Errorf("nil event log reader")
+	}
+	if cfg.snapshotStore == nil {
+		return fmt.Errorf("nil snapshot store")
+	}
+	if cfg.app == nil {
+		return fmt.Errorf("nil mesh application")
+	}
+	return nil
 }
 
 // node is the peered implementation of meshTransport (as opposed to
@@ -72,6 +140,160 @@ type node struct {
 }
 
 var _ meshTransport = (*node)(nil)
+
+// newNode constructs the mesh node.
+func newNode(cfg *nodeConfig) (*node, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	var initialEventSeq uint64
+	if cfg.initialFrontier != nil {
+		initialEventSeq = cfg.initialFrontier.Seq
+	}
+
+	logger := cfg.logger
+	if logger == nil {
+		logger = dex.Disabled
+	}
+
+	nodeID, err := loadOrCreateNodeID(cfg.dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("loadOrCreateNodeID: %w", err)
+	}
+
+	peerParsed, err := parsePeerURL(cfg.peerAddr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid peer address: %w", err)
+	}
+	peerURL := peerParsed.String()
+
+	node := &node{
+		log:    logger,
+		nodeID: nodeID,
+		serverCfg: meshServerConfig{
+			ListenAddr: cfg.listenAddr,
+			RPCKey:     cfg.rpcKey,
+			RPCCert:    cfg.rpcCert,
+			NoTLS:      cfg.noTLS,
+		},
+		app:            cfg.app,
+		lifecycle:      cfg.lifecycle,
+		eventLogReader: cfg.eventLogReader,
+		snapshotStore:  cfg.snapshotStore,
+		eventsGate:     newReadiness(),
+	}
+	if initialEventSeq == 0 {
+		node.seeding.Store(true)
+	}
+	node.control = newControlLoop(logger, nodeID, node)
+	node.stream = newEventStreamManager(&eventStreamManagerConfig{
+		log:                logger,
+		eventLogReader:     cfg.eventLogReader,
+		node:               node,
+		initialFrontierSeq: initialEventSeq,
+	})
+	node.snapshots = newSnapshotServer(logger, cfg.snapshotStore, node)
+
+	signer, err := newSecp256k1Signer(cfg.dexPrivKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize signer: %w", err)
+	}
+
+	node.handshakeSvc = newHandshakeService(
+		nodeID,
+		node.control.currentRole,
+		signer,
+		cfg.compat,
+		cfg.eventLogReader,
+		cfg.clientHost,
+		cfg.clientCert,
+		logger,
+	)
+	node.handshakes = newHandshakeSessions(logger, node.handshakeSvc, node)
+
+	dialer, err := newOutboundDialer(
+		peerURL,
+		cfg.peerCert,
+		logger,
+		node.handshakeSvc,
+		node.routes(),
+		node,
+	)
+	if err != nil {
+		return nil, err
+	}
+	node.dialer = dialer
+
+	return node, nil
+}
+
+// connect starts the node. It returns once startup has resolved: the node is
+// established as master, established as slave, or has halted due to
+// incompatibility with the configured peer.
+func (n *node) connect(ctx context.Context) (*sync.WaitGroup, error) {
+	n.log.Infof("Mesh starting. Local node ID %s", n.nodeID)
+
+	server, err := newMeshServer(&n.serverCfg, n.routes(), n.log)
+	if err != nil {
+		return nil, err
+	}
+
+	wg := new(sync.WaitGroup)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	startup := n.startLoops(runCtx, cancel, wg)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := server.Run(runCtx); err != nil {
+			n.log.Errorf("mesh server error: %v", err)
+			cancel()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		n.dialer.Run(runCtx)
+	}()
+
+	if err := n.waitForStartup(runCtx, startup); err != nil {
+		cancel()
+		wg.Wait()
+		return nil, err
+	}
+
+	return wg, nil
+}
+
+// startLoops starts the control loop and the event stream manager.
+func (n *node) startLoops(ctx context.Context, cancel context.CancelFunc, wg *sync.WaitGroup) *readiness {
+	startup := newReadiness()
+	n.cancelRun = cancel
+	n.runContext = ctx
+	n.control.prepareRun(ctx)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		n.control.run(ctx, startup)
+	}()
+
+	streamReady := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := n.stream.run(ctx, streamReady); err != nil && ctx.Err() == nil {
+			n.log.Errorf("eventStreamManager.run error: %v", err)
+			cancel()
+		}
+	}()
+	<-streamReady
+
+	return startup
+}
 
 // waitForStartup blocks until startup resolves or the run context ends. A
 // context end is refined into the halt error when the control loop halted.
@@ -124,6 +346,18 @@ func (n *node) handleEffect(eff effect) {
 	case effectFailPendingCommands:
 		n.lifecycle.failPendingCommands(e.Reason)
 	}
+}
+
+// watchPeerConn starts a goroutine to monitor a peer connection and report a
+// disconnection event to the control loop when the connection is closed.
+// If this node is the master, it also starts a timer to make sure the slave
+// establishes a stream in time.
+func (n *node) watchPeerConn(peerConn *nodeConn) {
+	go func() {
+		<-peerConn.link.Done()
+		_ = n.control.post(connectionDisconnectedSignal{conn: peerConn, at: time.Now()})
+	}()
+	go n.watchSubscribeTimeout(peerConn)
 }
 
 // errConnNotAdopted means this conn lost adoption to an existing session
@@ -196,6 +430,21 @@ func (n *node) applyHandshakeResult(ctx context.Context, conn link, result *hand
 	default:
 		return fmt.Errorf("handshake resolution reported no outcome (local_state=%s)", state.mode)
 	}
+}
+
+// activePeerForRequest returns the active peer connection if allowed returns
+// true for the current mode the node is in. It is used to authorize incoming
+// requests. If there is no active connection, or the request is not allowed
+// in the current mode, it returns an error.
+func (n *node) activePeerForRequest(allowed func(nodeMode) bool) (*nodeConn, error) {
+	state := n.control.currentState()
+	if !allowed(state.mode) {
+		return nil, fmt.Errorf("mesh active peer unavailable in node mode %s", state.mode)
+	}
+	if state.activeConn == nil || state.activeConn.link == nil {
+		return nil, fmt.Errorf("mesh active peer connection unavailable")
+	}
+	return state.activeConn, nil
 }
 
 // notifyMasterReady sends a signal to the control loop to indicate

--- a/server/mesh/node.go
+++ b/server/mesh/node.go
@@ -1,0 +1,158 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
+	"decred.org/dcrdex/server/db"
+)
+
+// meshApplication lets the node deliver peer commands, events, and results to
+// Service, and relay client messages and connection queries.
+type meshApplication interface {
+	executeForwardedCommand(context.Context, string, CommandRequest) *msgjson.Error
+	receiveCommandFailure(string, *msgjson.Error)
+	receiveCommandResult(string, json.RawMessage)
+	applyReceivedEvent(context.Context, *eventEnvelope) error
+	handleClientProxyMessage(context.Context, *ClientProxyMessage) error
+	answerClientConnected([]account.AccountID) []account.AccountID
+}
+
+// lifecycleHooks are lifecycle notifications sent from the node to its creator.
+type lifecycleHooks struct {
+	becameMaster              func()
+	peerClientEndpointChanged func(string, []byte)
+	failPendingCommands       func(reason string)
+	halted                    func(error)
+}
+
+// node is the peered implementation of meshTransport (as opposed to
+// singleServerTransport). It manages the communication with the peer,
+// the lifecycle of the node, and calls back into the meshApplication as
+// needed. It implements the meshTransport interface.
+type node struct {
+	log          dex.Logger
+	nodeID       string
+	handshakeSvc *handshakeService
+	handshakes   *handshakeSessions
+	dialer       *outboundDialer
+	serverCfg    meshServerConfig
+	app          meshApplication
+
+	control       *controlLoop
+	stream        *eventStreamManager
+	snapshots     *snapshotServer
+	lifecycle     lifecycleHooks
+	applyFailures applyFailureStreak
+
+	eventLogReader db.EventLogReader
+	snapshotStore  db.SnapshotStore
+
+	// eventsGate is used to block sending events to the application until
+	// it is ready to receive them.
+	eventsGate *readiness
+
+	// seeding marks a first join in progress: set at construction for an
+	// empty-log node, cleared at seed-orchestrator teardown.
+	seeding atomic.Bool
+
+	routeTable map[string]meshRoute
+	cancelRun  context.CancelFunc
+	runContext context.Context
+}
+
+var _ meshTransport = (*node)(nil)
+
+// waitForStartup blocks until startup resolves or the run context ends. A
+// context end is refined into the halt error when the control loop halted.
+func (n *node) waitForStartup(runCtx context.Context, startup *readiness) error {
+	if err := startup.wait(runCtx); err != nil {
+		state := n.control.currentState()
+		if state.mode == modeHalted {
+			if state.haltErr != nil {
+				return state.haltErr
+			}
+			return fmt.Errorf("mesh halted during startup")
+		}
+		return fmt.Errorf("mesh stopped during startup")
+	}
+	return nil
+}
+
+// controlHalted is a callback passed to the control loop to handle
+// the situation where the node has been halted.
+func (n *node) controlHalted(err error) {
+	n.cancelRun()
+	n.lifecycle.halted(err)
+}
+
+// haltStatus reports the control loop's terminal halt state.
+func (n *node) haltStatus() (bool, error) {
+	return n.control.haltStatus()
+}
+
+// handleEffect handles an effect from the control loop.
+func (n *node) handleEffect(eff effect) {
+	switch e := eff.(type) {
+	case effectBecameMaster:
+		n.lifecycle.becameMaster()
+	case effectDisconnect:
+		n.stopStreamForConn(e.Conn)
+		e.Conn.link.Disconnect()
+	case effectStopEventStream:
+		n.stopStreamForConn(e.Conn)
+	case effectWatchConn:
+		n.watchPeerConn(e.Conn)
+	case effectStartSubscriber:
+		go n.runSubscriber(e.Conn)
+	case effectStartEventStream:
+		n.startEventStream(e.Conn, e.SlaveFrontier)
+	case effectStartSnapshotSend:
+		n.startSnapshotSend(e.Conn)
+	case effectPeerClientEndpointChanged:
+		n.lifecycle.peerClientEndpointChanged(e.Host, append([]byte(nil), e.Cert...))
+	case effectFailPendingCommands:
+		n.lifecycle.failPendingCommands(e.Reason)
+	}
+}
+
+// notifyMasterReady sends a signal to the control loop to indicate
+// the master is ready to serve clients.
+func (n *node) notifyMasterReady() error {
+	res, err := n.control.send(masterReadySignal{})
+	if err != nil {
+		return err
+	}
+	if res.err != nil {
+		return res.err
+	}
+	if res.state.mode != modeEstablishedMaster {
+		return fmt.Errorf("master readiness resolved to node mode %s", res.state.mode)
+	}
+	return nil
+}
+
+// notifyMasterPreparationFailed sends a signal to the control loop to indicate
+// the master preparation failed.
+func (n *node) notifyMasterPreparationFailed(err error) error {
+	if err == nil {
+		err = fmt.Errorf("master preparation failed")
+	}
+	res, sendErr := n.control.send(masterPreparationFailedSignal{
+		err: err,
+		at:  time.Now(),
+	})
+	if sendErr != nil {
+		return sendErr
+	}
+	return res.err
+}

--- a/server/mesh/node.go
+++ b/server/mesh/node.go
@@ -268,6 +268,97 @@ func (n *node) connect(ctx context.Context) (*sync.WaitGroup, error) {
 	return wg, nil
 }
 
+// notifyReadyForEvents notifies that the application is ready to receive
+// and apply streamed events.
+func (n *node) notifyReadyForEvents() {
+	n.eventsGate.resolve(nil)
+}
+
+// eventsGateOpen reports whether notifyReadyForEvents has been called.
+func (n *node) eventsGateOpen() bool {
+	if n.eventsGate == nil {
+		return true
+	}
+	select {
+	case <-n.eventsGate.resolved():
+		return true
+	default:
+		return false
+	}
+}
+
+// applyWedgeStreakThreshold is consecutive apply failures at one seq before
+// the node treats the failure as deterministic and halts.
+const applyWedgeStreakThreshold = 3
+
+// applyFailureStreak counts consecutive apply failures at one seq.
+type applyFailureStreak struct {
+	mtx   sync.Mutex
+	seq   uint64
+	count int
+}
+
+// observe returns the consecutive failure count for seq (0 on success). A
+// different seq restarts the count. A dead apply context reports 0 without
+// resetting the streak.
+func (e *applyFailureStreak) observe(ctx context.Context, seq uint64, err error) int {
+	e.mtx.Lock()
+	defer e.mtx.Unlock()
+	if err == nil {
+		e.seq, e.count = 0, 0
+		return 0
+	}
+	if ctx.Err() != nil {
+		return 0
+	}
+	if seq != e.seq {
+		e.seq, e.count = seq, 1
+	} else {
+		e.count++
+	}
+	return e.count
+}
+
+// replicationWedgedError is returned when the slave has tried to apply a replicated
+// event multiple times, and failed.
+type replicationWedgedError struct {
+	Seq      uint64
+	Attempts int
+	Err      error
+}
+
+func (err *replicationWedgedError) Error() string {
+	return fmt.Sprintf("replicated event at seq %d failed to apply %d consecutive times: %v.",
+		err.Seq, err.Attempts, err.Err)
+}
+
+func (err *replicationWedgedError) Unwrap() error {
+	return err.Err
+}
+
+// applyInboundEventEnvelope is used by the slave to apply an event received from the master.
+func (n *node) applyInboundEventEnvelope(peerConn *nodeConn, entry *eventEnvelope) error {
+	ctx := n.runContext
+	if err := n.app.applyReceivedEvent(ctx, entry); err != nil {
+		if isTerminalEventApplyFailure(err) {
+			n.postTerminalApplyFailureIfNeeded(err)
+			return err
+		}
+		if count := n.applyFailures.observe(ctx, entry.Seq, err); count >= applyWedgeStreakThreshold {
+			n.postTerminalApplyFailureIfNeeded(&replicationWedgedError{
+				Seq: entry.Seq, Attempts: count, Err: err,
+			})
+		}
+		return err
+	}
+
+	n.applyFailures.observe(ctx, entry.Seq, nil)
+	n.stream.eventCommitted(entry.Seq, "", nil)
+	n.postStreamCaughtUpIfAtMasterTip(peerConn, entry)
+
+	return nil
+}
+
 // startLoops starts the control loop and the event stream manager.
 func (n *node) startLoops(ctx context.Context, cancel context.CancelFunc, wg *sync.WaitGroup) *readiness {
 	startup := newReadiness()
@@ -430,6 +521,60 @@ func (n *node) applyHandshakeResult(ctx context.Context, conn link, result *hand
 	default:
 		return fmt.Errorf("handshake resolution reported no outcome (local_state=%s)", state.mode)
 	}
+}
+
+// postStreamCaughtUpIfAtMasterTip reports completion of initial catch-up
+// when the slave reaches the tip carried by the received event.
+func (n *node) postStreamCaughtUpIfAtMasterTip(peerConn *nodeConn, entry *eventEnvelope) {
+	if entry.Seq != entry.MasterTip || n.control.currentMode() != modeEstablishedSlaveSyncing {
+		return
+	}
+	target := &db.EventLogPosition{
+		Seq:     entry.MasterTip,
+		TipHash: append([]byte(nil), entry.TipHash...),
+	}
+	if err := n.control.post(streamCaughtUpSignal{conn: peerConn, target: target}); err != nil {
+		n.log.Debugf("failed to post mesh stream caught-up event: %v", err)
+	}
+}
+
+// postTerminalApplyFailureIfNeeded requests a halt if err is terminal.
+func (n *node) postTerminalApplyFailureIfNeeded(err error) {
+	if isTerminalEventApplyFailure(err) {
+		_ = n.control.post(terminalApplyFailureSignal{err: err, at: time.Now()})
+	}
+}
+
+// checkEventPublishAvailable returns nil if the node can publish an event now,
+// or an error wrapping ErrUnavailable if it cannot. Only a master can publish
+// an event, and only a master with an established stream can publish an event
+// originating from a forwarded command.
+func (n *node) checkEventPublishAvailable(forwardedCommand bool) error {
+	state := n.control.currentState()
+
+	if !(state.mode == modeEstablishedMaster || state.mode == modePreparingMaster) {
+		return fmt.Errorf("event publisher unavailable for local apply: %w", ErrUnavailable)
+	}
+
+	if !forwardedCommand {
+		return nil
+	}
+
+	// This check is a sanity check.. redundant with the below checks. Only established
+	// master should have a stream.
+	if state.mode != modeEstablishedMaster {
+		return fmt.Errorf("event publisher unavailable for forwarded command: %w", ErrUnavailable)
+	}
+
+	if state.activeConn == nil || state.activeConn.link == nil {
+		return fmt.Errorf("event publisher has no active peer for forwarded command: %w", ErrUnavailable)
+	}
+
+	if !n.stream.isStreamingTo(state.activeConn.ID()) {
+		return fmt.Errorf("no event stream for forwarded command: %w", ErrUnavailable)
+	}
+
+	return nil
 }
 
 // activePeerForRequest returns the active peer connection if allowed returns

--- a/server/mesh/node_test.go
+++ b/server/mesh/node_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
@@ -393,6 +394,94 @@ func TestNodeForwardCommandActivePeerStates(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNodeDrainEventStream(t *testing.T) {
+	conn := testSession("node-b", "node-a")
+	masterWithStream := func(tip uint64) *node {
+		n := newTestNodeWithState(nodeState{mode: modeEstablishedMaster, activeConn: conn}, nil)
+		n.stream = newTestEventStreamManager(&streamTestReader{}, nil, nil, &db.EventLogPosition{Seq: tip})
+		n.stream.ctx = context.Background()
+		return n
+	}
+
+	t.Run("established master with a caught-up stream drains", func(t *testing.T) {
+		n := masterWithStream(5)
+		n.stream.startStreamOnConn(1, &db.EventLogPosition{Seq: 5})
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		drained, err := n.drainEventStream(ctx)
+		if err != nil || !drained {
+			t.Fatalf("drainEventStream = (%v, %v), want (true, nil)", drained, err)
+		}
+	})
+
+	t.Run("stale stream tip still drains against the durable frontier", func(t *testing.T) {
+		reader := &streamTestReader{}
+		n := newTestNodeWithState(nodeState{mode: modeEstablishedMaster, activeConn: conn}, nil)
+		n.stream = newTestEventStreamManager(reader, nil, nil, &db.EventLogPosition{Seq: 5})
+		n.stream.ctx = context.Background()
+		n.stream.startStreamOnConn(1, &db.EventLogPosition{Seq: 5})
+		reader.setFrontier(&db.EventLogPosition{Seq: 7})
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		drained, err := n.drainEventStream(ctx)
+		if drained || err == nil || !strings.Contains(err.Error(), "slave acked through seq 5 of 7") {
+			t.Fatalf("drainEventStream = (%v, %v), want lag error against the durable frontier", drained, err)
+		}
+	})
+
+	t.Run("preparing master errors loudly", func(t *testing.T) {
+		n := newTestNodeWithState(nodeState{mode: modePreparingMaster}, nil)
+		drained, err := n.drainEventStream(context.Background())
+		if drained || err == nil || !strings.Contains(err.Error(), "preparing master") {
+			t.Fatalf("drainEventStream = (%v, %v), want preparing-master error", drained, err)
+		}
+	})
+
+	t.Run("non-streaming modes drain trivially", func(t *testing.T) {
+		for _, mode := range []nodeMode{modePending, modeEstablishedSlave, modeSlaveNoMaster, modeHalted} {
+			n := newTestNodeWithState(nodeState{mode: mode}, nil)
+			drained, err := n.drainEventStream(context.Background())
+			if drained || err != nil {
+				t.Fatalf("mode %s: drainEventStream = (%v, %v), want (false, nil)", mode, drained, err)
+			}
+		}
+	})
+
+	t.Run("no active stream fails the drain on deadline", func(t *testing.T) {
+		n := newTestNodeWithState(nodeState{mode: modeEstablishedMaster}, nil)
+		n.stream = newTestEventStreamManager(&streamTestReader{}, nil, nil, &db.EventLogPosition{Seq: 5})
+		n.stream.ctx = context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		start := time.Now()
+		drained, err := n.drainEventStream(ctx)
+		if drained || err == nil || !strings.Contains(err.Error(), "no active event stream") {
+			t.Fatalf("drainEventStream = (%v, %v), want no-active-stream error", drained, err)
+		}
+		if time.Since(start) > time.Second {
+			t.Fatal("no-stream drain was not bounded by the caller deadline")
+		}
+	})
+
+	t.Run("stopped stream manager fails the drain fast", func(t *testing.T) {
+		n := masterWithStream(5)
+		n.stream.startStreamOnConn(1, &db.EventLogPosition{Seq: 3})
+		n.stream.mtx.Lock()
+		n.stream.stopped = true
+		n.stream.mtx.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		start := time.Now()
+		drained, err := n.drainEventStream(ctx)
+		if drained || err == nil || !strings.Contains(err.Error(), "manager stopped") {
+			t.Fatalf("drainEventStream = (%v, %v), want manager-stopped error", drained, err)
+		}
+		if time.Since(start) > time.Second {
+			t.Fatal("stopped manager did not fail the drain fast")
+		}
+	})
 }
 
 func TestNodeForwardCommandErrorTranslation(t *testing.T) {

--- a/server/mesh/node_test.go
+++ b/server/mesh/node_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/server/db"
 )
 
@@ -320,6 +321,139 @@ func TestNodeSendEventEnvelopeTreatsClosedLinkAsCanceled(t *testing.T) {
 	}}})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("send event envelope error = %v, want context canceled", err)
+	}
+}
+
+func TestNodeForwardCommandActivePeerStates(t *testing.T) {
+	t.Run("established slave forwards", func(t *testing.T) {
+		active := newTRouteLink(901)
+		var (
+			gotRoute   string
+			gotPayload any
+		)
+		active.requestFunc = func(_ context.Context, route string, payload any, _ any) error {
+			gotRoute = route
+			gotPayload = payload
+			return nil
+		}
+		n := newTestNodeWithState(nodeState{
+			mode:       modeEstablishedSlave,
+			activeConn: newNodeConn(active, "peer-node", "peer-node"),
+		}, nil)
+		if !n.canForwardCommand() {
+			t.Fatal("established slave with an active master connection cannot forward")
+		}
+		cmd := validCommandForward(t, "cmd-ok")
+
+		rpcErr, outcomeUnknown := n.forwardCommand(context.Background(), cmd)
+		requireNoRPCError(t, rpcErr)
+		if outcomeUnknown {
+			t.Fatal("acked forward reported an unknown outcome")
+		}
+		if gotRoute != commandForwardRoute {
+			t.Fatalf("request route = %q, want %q", gotRoute, commandForwardRoute)
+		}
+		if gotPayload != cmd {
+			t.Fatalf("request payload = %p, want %p", gotPayload, cmd)
+		}
+	})
+
+	tests := []struct {
+		name     string
+		mode     nodeMode
+		active   bool
+		wantCode int
+	}{
+		{name: "pending", mode: modePending, active: true, wantCode: msgjson.TryAgainLaterError},
+		{name: "syncing slave", mode: modeEstablishedSlaveSyncing, active: true, wantCode: msgjson.TryAgainLaterError},
+		{name: "slave no master", mode: modeSlaveNoMaster, active: true, wantCode: msgjson.TryAgainLaterError},
+		{name: "preparing master", mode: modePreparingMaster, active: true, wantCode: msgjson.TryAgainLaterError},
+		{name: "preparing master without conn", mode: modePreparingMaster, wantCode: msgjson.TryAgainLaterError},
+		{name: "master", mode: modeEstablishedMaster, active: true, wantCode: msgjson.TryAgainLaterError},
+		{name: "halted", mode: modeHalted, active: true, wantCode: msgjson.TryAgainLaterError},
+		{name: "unknown mode", mode: nodeMode(255), active: true, wantCode: msgjson.TryAgainLaterError},
+		{name: "slave missing active link", mode: modeEstablishedSlave, wantCode: msgjson.TryAgainLaterError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := nodeState{mode: tt.mode}
+			if tt.active {
+				state.activeConn = newNodeConn(newTRouteLink(902), "peer-node", "peer-node")
+			}
+			n := newTestNodeWithState(state, nil)
+			if n.canForwardCommand() {
+				t.Fatal("canForwardCommand = true, want false")
+			}
+
+			rpcErr, outcomeUnknown := n.forwardCommand(context.Background(), validCommandForward(t, "cmd-state"))
+			requireRPCCode(t, rpcErr, tt.wantCode)
+			if outcomeUnknown {
+				t.Fatal("mode-gate refusal reported an unknown outcome")
+			}
+		})
+	}
+}
+
+func TestNodeForwardCommandErrorTranslation(t *testing.T) {
+	tests := []struct {
+		name        string
+		reqErr      error
+		wantCode    int
+		wantUnknown bool
+	}{
+		{
+			name:        "transport failure leaves the outcome unknown",
+			reqErr:      errors.New("ws send failed"),
+			wantUnknown: true,
+		},
+		{
+			name: "master gate rejection translates to retryable",
+			reqErr: &peerRPCError{
+				Code:    msgjson.UnauthorizedConnection,
+				Message: "mesh route requires active peer connection in an allowed local state",
+			},
+			wantCode: msgjson.TryAgainLaterError,
+		},
+		{
+			name: "internal peer error passes through",
+			reqErr: &peerRPCError{
+				Code:    msgjson.RPCInternalError,
+				Message: "command forward handling failed",
+			},
+			wantCode: msgjson.RPCInternalError,
+		},
+		{
+			name: "app-level rejection",
+			reqErr: &peerRPCError{
+				Code:    msgjson.OrderParameterError,
+				Message: "bad order",
+			},
+			wantCode: msgjson.OrderParameterError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			active := newTRouteLink(903)
+			active.requestFunc = func(context.Context, string, any, any) error {
+				return tt.reqErr
+			}
+			n := newTestNodeWithState(nodeState{
+				mode:       modeEstablishedSlave,
+				activeConn: newNodeConn(active, "peer-node", "peer-node"),
+			}, nil)
+
+			rpcErr, outcomeUnknown := n.forwardCommand(context.Background(), validCommandForward(t, "cmd-err"))
+			if outcomeUnknown != tt.wantUnknown {
+				t.Fatalf("outcomeUnknown = %v, want %v", outcomeUnknown, tt.wantUnknown)
+			}
+			if tt.wantUnknown {
+				requireNoRPCError(t, rpcErr)
+				return
+			}
+			requireRPCCode(t, rpcErr, tt.wantCode)
+		})
 	}
 }
 

--- a/server/mesh/node_test.go
+++ b/server/mesh/node_test.go
@@ -1,0 +1,142 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/db"
+)
+
+func newTestNodeWithState(state nodeState, app meshApplication) *node {
+	if app == nil {
+		app = &testMeshApplication{}
+	}
+	n := &node{
+		log:        dex.Disabled,
+		nodeID:     "node-a",
+		control:    newQueuedTestControlLoop(state, 4),
+		app:        app,
+		runContext: context.Background(),
+		stream: newEventStreamManager(&eventStreamManagerConfig{
+			log:  dex.Disabled,
+			node: &testStreamNode{},
+		}),
+		eventLogReader: &testEventLogReader{frontier: &db.EventLogPosition{}},
+		snapshotStore:  &fakeSnapshotStore{},
+	}
+	n.snapshots = newSnapshotServer(n.log, n.snapshotStore, n)
+	return n
+}
+
+func TestNodeApplyHandshakeResult(t *testing.T) {
+	haltErr := errors.New("halted after handshake")
+	peerFrontier := &db.EventLogPosition{Seq: 4, TipHash: testTipHash(4)}
+	clientHost := "peer.example:7232"
+	clientCert := []byte{1, 2, 3}
+	tests := []struct {
+		name    string
+		state   nodeState
+		outcome handshakeOutcome
+		wantErr string
+	}{
+		{
+			name: "adopted connection succeeds",
+			state: nodeState{
+				mode: modeEstablishedMaster,
+			},
+			outcome: handshakeAdopted,
+		},
+		{
+			name: "halted returns halt error",
+			state: nodeState{
+				mode:    modeHalted,
+				haltErr: haltErr,
+			},
+			outcome: handshakeHalted,
+			wantErr: haltErr.Error(),
+		},
+		{
+			name: "non adopted connection returns error",
+			state: nodeState{
+				mode:       modeEstablishedMaster,
+				activeConn: testRPCSession("node-c", "node-a"),
+			},
+			outcome: handshakeNotAdopted,
+			wantErr: "connection not adopted",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := newTRouteLink(800)
+			wantConn := newNodeConn(conn, "node-b", "node-a")
+			state := tt.state
+			if state.activeConn == nil && state.mode != modeHalted {
+				state.activeConn = wantConn
+			}
+			p := newTestNodeWithState(nodeState{mode: modePending}, nil)
+			result := &handshakeResult{
+				peerHello: &helloMessage{
+					NodeID:   "node-b",
+					Role:     roleSlave,
+					Frontier: toFrontierMessage(peerFrontier),
+				},
+				progress:   progressEqual,
+				clientHost: clientHost,
+				clientCert: clientCert,
+			}
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				queued := <-p.control.testQueue()
+				ev, ok := queued.signal.(handshakeResolvedSignal)
+				if !ok {
+					t.Errorf("queued event = %T, want handshakeResolvedSignal", queued.signal)
+					queued.reply <- signalResult{err: errors.New("unexpected event")}
+					return
+				}
+				if ev.conn == nil || ev.conn.link != conn || ev.conn.peerNodeID != "node-b" || ev.conn.initiatorNodeID != "node-a" {
+					t.Errorf("handshake event conn = %+v, want peer node-b initiator node-a", ev.conn)
+				}
+				if ev.peerRole != roleSlave || ev.progress != progressEqual {
+					t.Errorf("handshake event = %+v, want roleSlave progressEqual", ev)
+				}
+				if ev.peerFrontier == nil || ev.peerFrontier.Seq != peerFrontier.Seq || !reflect.DeepEqual(ev.peerFrontier.TipHash, peerFrontier.TipHash) {
+					t.Errorf("handshake event frontier = %+v, want %+v", ev.peerFrontier, peerFrontier)
+				}
+				if ev.clientHost != clientHost || !reflect.DeepEqual(ev.clientCert, clientCert) {
+					t.Errorf("handshake event endpoint = %q/%x, want %q/%x", ev.clientHost, ev.clientCert, clientHost, clientCert)
+				}
+				queued.reply <- signalResult{
+					handled: true,
+					state:   state,
+					outcome: tt.outcome,
+				}
+			}()
+
+			err := p.applyHandshakeResult(context.Background(), conn, result, "node-a")
+			<-done
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("applyHandshakeResult error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("applyHandshakeResult error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func testRPCSession(cpNode, localNode string) *nodeConn {
+	return newNodeConn(newTRouteLink(801), cpNode, localNode)
+}

--- a/server/mesh/node_test.go
+++ b/server/mesh/node_test.go
@@ -6,6 +6,7 @@ package mesh
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -33,6 +34,158 @@ func newTestNodeWithState(state nodeState, app meshApplication) *node {
 	}
 	n.snapshots = newSnapshotServer(n.log, n.snapshotStore, n)
 	return n
+}
+
+func TestCheckEventPublishAvailable(t *testing.T) {
+	peer := newNodeConn(newTRouteLink(1), "peer-node", "peer-node")
+
+	startStream := func(n *node, connID uint64) {
+		t.Helper()
+		n.stream = newTestEventStreamManager(&streamTestReader{}, nil, nil, &db.EventLogPosition{})
+		n.stream.ctx = context.Background()
+		n.stream.startStreamOnConn(connID, &db.EventLogPosition{})
+	}
+
+	t.Run("forwarded conn no stream", func(t *testing.T) {
+		n := newTestNodeWithState(nodeState{mode: modeEstablishedMaster, activeConn: peer}, nil)
+		err := n.checkEventPublishAvailable(true)
+		if !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+	})
+
+	t.Run("forwarded stream to other conn", func(t *testing.T) {
+		n := newTestNodeWithState(nodeState{mode: modeEstablishedMaster, activeConn: peer}, nil)
+		startStream(n, 2)
+		err := n.checkEventPublishAvailable(true)
+		if !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("err = %v, want ErrUnavailable", err)
+		}
+	})
+
+	t.Run("forwarded stream to active conn", func(t *testing.T) {
+		n := newTestNodeWithState(nodeState{mode: modeEstablishedMaster, activeConn: peer}, nil)
+		startStream(n, 1)
+		if err := n.checkEventPublishAvailable(true); err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+	})
+
+	t.Run("local no stream", func(t *testing.T) {
+		n := newTestNodeWithState(nodeState{mode: modeEstablishedMaster, activeConn: peer}, nil)
+		if err := n.checkEventPublishAvailable(false); err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+	})
+
+	t.Run("preparation local vs forwarded", func(t *testing.T) {
+		n := newTestNodeWithState(nodeState{mode: modePreparingMaster, activeConn: peer}, nil)
+		if err := n.checkEventPublishAvailable(false); err != nil {
+			t.Fatalf("local err = %v, want nil", err)
+		}
+		err := n.checkEventPublishAvailable(true)
+		if !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("forwarded err = %v, want ErrUnavailable", err)
+		}
+	})
+}
+
+func TestApplyInboundEventEnvelopeTerminalFailure(t *testing.T) {
+	const appliedSeq uint64 = 1
+	applyErr := &db.EventLogDivergenceError{
+		Seq:             appliedSeq + 1,
+		ExpectedTipHash: testTipHash(appliedSeq + 1),
+		ActualTipHash:   testTipHash(appliedSeq + 2),
+		Err:             errors.New("frontier mismatch"),
+	}
+	n := newTestNodeWithState(nodeState{mode: modeEstablishedSlave}, &testMeshApplication{
+		event: func(context.Context, *eventEnvelope) error {
+			return applyErr
+		},
+	})
+	queue := n.control.testQueue()
+
+	err := n.applyInboundEventEnvelope(nil, &eventEnvelope{
+		Seq:       appliedSeq + 1,
+		TipHash:   testTipHash(appliedSeq + 1),
+		MasterTip: appliedSeq + 1,
+		Kind:      "test",
+		Payload:   []byte("peer-payload"),
+	})
+	if !errors.Is(err, applyErr) {
+		t.Fatalf("apply error = %v, want %v", err, applyErr)
+	}
+
+	select {
+	case queued := <-queue:
+		ev, ok := queued.signal.(terminalApplyFailureSignal)
+		if !ok {
+			t.Fatalf("posted event = %T, want terminalApplyFailureSignal", queued.signal)
+		}
+		if !errors.Is(ev.err, applyErr) {
+			t.Fatalf("posted error = %v, want %v", ev.err, applyErr)
+		}
+	default:
+		t.Fatalf("missing terminalApplyFailureSignal")
+	}
+}
+
+func TestNodePostTerminalApplyFailureIfNeeded(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantPosted bool
+	}{
+		{
+			name: "ignores non-terminal error",
+			err:  errors.New("apply failed"),
+		},
+		{
+			name: "posts terminal divergence error",
+			err: &db.EventLogDivergenceError{
+				Seq: 2,
+				Err: errors.New("projection mismatch"),
+			},
+			wantPosted: true,
+		},
+		{
+			name:       "posts unknown commit outcome",
+			err:        &db.EventCommitUnknownError{Err: errors.New("commit outcome unknown")},
+			wantPosted: true,
+		},
+		{
+			name:       "posts replication wedge",
+			err:        &replicationWedgedError{Seq: 7, Attempts: 3, Err: errors.New("apply failed")},
+			wantPosted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newTestNodeWithState(nodeState{mode: modeEstablishedSlave}, nil)
+			queue := p.control.testQueue()
+
+			p.postTerminalApplyFailureIfNeeded(tt.err)
+
+			select {
+			case queued := <-queue:
+				if !tt.wantPosted {
+					t.Fatalf("posted event = %T, want none", queued.signal)
+				}
+				ev, ok := queued.signal.(terminalApplyFailureSignal)
+				if !ok {
+					t.Fatalf("posted event = %T, want terminalApplyFailureSignal", queued.signal)
+				}
+				if !errors.Is(ev.err, tt.err) {
+					t.Fatalf("posted error = %v, want %v", ev.err, tt.err)
+				}
+			default:
+				if tt.wantPosted {
+					t.Fatalf("missing terminalApplyFailureSignal")
+				}
+			}
+		})
+	}
 }
 
 func TestNodeApplyHandshakeResult(t *testing.T) {
@@ -139,4 +292,137 @@ func TestNodeApplyHandshakeResult(t *testing.T) {
 
 func testRPCSession(cpNode, localNode string) *nodeConn {
 	return newNodeConn(newTRouteLink(801), cpNode, localNode)
+}
+
+func TestNodeSendEventEnvelopeTreatsClosedLinkAsCanceled(t *testing.T) {
+	wsConn := &tWSConn{closed: make(chan struct{})}
+	reqConn := newRPCConn(t.Context(), "test-peer", wsConn, nil, dex.Disabled)
+	wg, err := reqConn.connect()
+	if err != nil {
+		t.Fatalf("connect error: %v", err)
+	}
+	reqConn.Disconnect()
+	wg.Wait()
+
+	conn := newNodeConn(reqConn, "node-b", "node-a")
+	p := &node{
+		control: newTestControlLoop(nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: conn,
+		}),
+	}
+	err = p.sendEventBatch(context.Background(), conn.ID(), &eventBatch{Entries: []*eventEnvelope{{
+		Seq:       1,
+		TipHash:   testTipHash(1),
+		MasterTip: 1,
+		Kind:      "test",
+		Payload:   []byte(`{"payload":1}`),
+	}}})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("send event envelope error = %v, want context canceled", err)
+	}
+}
+
+func TestApplyFailureStreak(t *testing.T) {
+	var e applyFailureStreak
+	err := errors.New("apply failed")
+	live := context.Background()
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	steps := []struct {
+		ctx  context.Context
+		seq  uint64
+		err  error
+		want int
+	}{
+		{live, 5, err, 1},
+		{live, 5, err, 2},
+		{live, 5, err, 3},
+		{live, 6, err, 1}, // different seq restarts
+		{live, 6, err, 2},
+		{canceled, 6, err, 0}, // dead ctx did not reset
+		{canceled, 6, context.Canceled, 0},
+		{live, 6, err, 3},
+		{live, 6, context.Canceled, 4}, // live ctx: internal cancel still counts
+		{live, 6, fmt.Errorf("apply: %w", context.DeadlineExceeded), 5},
+		{live, 6, nil, 0}, // success resets
+		{live, 6, err, 1},
+	}
+	for i, step := range steps {
+		if got := e.observe(step.ctx, step.seq, step.err); got != step.want {
+			t.Fatalf("step %d: observe(%d, %v) = %d, want %d",
+				i, step.seq, step.err, got, step.want)
+		}
+	}
+}
+
+func TestApplyInboundEventEnvelopeWedgeHalt(t *testing.T) {
+	applyErr := errors.New("event apply failed: swap contract recorded event for unknown match")
+	failing := true
+	n := newTestNodeWithState(nodeState{mode: modeEstablishedSlaveSyncing}, &testMeshApplication{
+		event: func(context.Context, *eventEnvelope) error {
+			if failing {
+				return applyErr
+			}
+			return nil
+		},
+	})
+	queue := n.control.testQueue()
+
+	requireNoSignal := func(step string) {
+		t.Helper()
+		select {
+		case queued := <-queue:
+			t.Fatalf("%s: unexpected posted signal %T", step, queued.signal)
+		default:
+		}
+	}
+
+	// MasterTip != Seq so the success path does not post a caught-up signal.
+	env := &eventEnvelope{Seq: 24, MasterTip: 30, Kind: "test", Payload: []byte("p")}
+	otherEnv := &eventEnvelope{Seq: 25, MasterTip: 30, Kind: "test", Payload: []byte("p")}
+
+	// Two failures, then a different seq, then a success: streak resets, no halt.
+	for i := 0; i < applyWedgeStreakThreshold-1; i++ {
+		if err := n.applyInboundEventEnvelope(nil, env); !errors.Is(err, applyErr) {
+			t.Fatalf("apply %d error = %v, want %v", i, err, applyErr)
+		}
+	}
+	if err := n.applyInboundEventEnvelope(nil, otherEnv); !errors.Is(err, applyErr) {
+		t.Fatalf("other-seq apply error = %v, want %v", err, applyErr)
+	}
+	requireNoSignal("below threshold")
+	failing = false
+	if err := n.applyInboundEventEnvelope(nil, otherEnv); err != nil {
+		t.Fatalf("successful apply error: %v", err)
+	}
+	if got := n.applyFailures.count; got != 0 {
+		t.Fatalf("failure streak after success = %d, want 0", got)
+	}
+
+	// Three consecutive failures at one seq post the wedge halt.
+	failing = true
+	for i := 0; i < applyWedgeStreakThreshold; i++ {
+		if err := n.applyInboundEventEnvelope(nil, env); !errors.Is(err, applyErr) {
+			t.Fatalf("apply %d error = %v, want %v", i, err, applyErr)
+		}
+	}
+	select {
+	case queued := <-queue:
+		sig, ok := queued.signal.(terminalApplyFailureSignal)
+		if !ok {
+			t.Fatalf("posted signal = %T, want terminalApplyFailureSignal", queued.signal)
+		}
+		var wedged *replicationWedgedError
+		if !errors.As(sig.err, &wedged) {
+			t.Fatalf("posted error = %v, want replicationWedgedError", sig.err)
+		}
+		if wedged.Seq != env.Seq || wedged.Attempts != applyWedgeStreakThreshold || !errors.Is(wedged, applyErr) {
+			t.Fatalf("wedged error = %+v, want seq %d, attempts %d, cause %v",
+				wedged, env.Seq, applyWedgeStreakThreshold, applyErr)
+		}
+	default:
+		t.Fatalf("missing wedge halt signal after %d failures", applyWedgeStreakThreshold)
+	}
 }

--- a/server/mesh/nodeid.go
+++ b/server/mesh/nodeid.go
@@ -1,0 +1,69 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	nodeIDDirName  = "mesh"
+	nodeIDFileName = "nodeid"
+	nodeIDSize     = 16
+)
+
+// loadOrCreateNodeID loads a persisted node ID from the DEX data directory or
+// creates and stores a new one if none exists yet.
+func loadOrCreateNodeID(dataDir string) (string, error) {
+	meshDir := filepath.Join(dataDir, nodeIDDirName)
+	if err := os.MkdirAll(meshDir, 0700); err != nil {
+		return "", fmt.Errorf("create mesh dir: %w", err)
+	}
+
+	nodeIDPath := filepath.Join(meshDir, nodeIDFileName)
+	if nodeIDB, err := os.ReadFile(nodeIDPath); err == nil {
+		nodeID := strings.TrimSpace(string(nodeIDB))
+		if err := validateNodeID(nodeID); err != nil {
+			return "", fmt.Errorf("invalid stored node ID in %s: %w", nodeIDPath, err)
+		}
+		return nodeID, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("read node ID file: %w", err)
+	}
+
+	nodeID, err := newNodeID()
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(nodeIDPath, []byte(nodeID+"\n"), 0600); err != nil {
+		return "", fmt.Errorf("write node ID file: %w", err)
+	}
+	return nodeID, nil
+}
+
+// newNodeID returns a new random node ID of nodeIDSize bytes, hex encoded.
+func newNodeID() (string, error) {
+	b := make([]byte, nodeIDSize)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate node ID: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// validateNodeID checks a node ID from the data directory or from a peer.
+func validateNodeID(nodeID string) error {
+	if nodeID == "" {
+		return fmt.Errorf("empty node ID")
+	}
+	if strings.ContainsAny(nodeID, " \t\r\n") {
+		return fmt.Errorf("node ID may not contain whitespace")
+	}
+	return nil
+}

--- a/server/mesh/nodeid_test.go
+++ b/server/mesh/nodeid_test.go
@@ -1,0 +1,45 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadOrCreateNodeID(t *testing.T) {
+	dataDir := t.TempDir()
+
+	nodeID1, err := loadOrCreateNodeID(dataDir)
+	if err != nil {
+		t.Fatalf("loadOrCreateNodeID error: %v", err)
+	}
+	if nodeID1 == "" {
+		t.Fatalf("empty node ID")
+	}
+
+	nodeID2, err := loadOrCreateNodeID(dataDir)
+	if err != nil {
+		t.Fatalf("loadOrCreateNodeID second call error: %v", err)
+	}
+	if nodeID1 != nodeID2 {
+		t.Fatalf("node ID not persisted: %q != %q", nodeID1, nodeID2)
+	}
+}
+
+func TestLoadOrCreateNodeIDRejectsInvalidStoredValue(t *testing.T) {
+	dataDir := t.TempDir()
+	meshDir := filepath.Join(dataDir, nodeIDDirName)
+	if err := os.MkdirAll(meshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(meshDir, nodeIDFileName), []byte("bad id\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadOrCreateNodeID(dataDir); err == nil {
+		t.Fatalf("expected error for invalid stored node ID")
+	}
+}

--- a/server/mesh/protocol.go
+++ b/server/mesh/protocol.go
@@ -83,6 +83,72 @@ func validateCommandResult(result *commandResult) error {
 	return nil
 }
 
+// ClientProxyMessage is a request to deliver a message to a client
+// connected to the peer.
+type ClientProxyMessage struct {
+	User account.AccountID `json:"user"`
+	Msg  *msgjson.Message  `json:"msg"`
+	// Broadcast delivers Msg to every client on the peer. User is ignored.
+	Broadcast bool `json:"broadcast,omitempty"`
+	// TimeoutMS is the timeout of a proxied request.
+	TimeoutMS uint64 `json:"timeoutMS,omitempty"`
+	// DeliverToClient marks a Response that the server sends to the client,
+	// as opposed to a Response that the client sends to the peer.
+	DeliverToClient bool `json:"deliverToClient,omitempty"`
+}
+
+func validateClientProxyMessage(msg *ClientProxyMessage) error {
+	if msg == nil {
+		return fmt.Errorf("nil client proxy message")
+	}
+	if msg.Msg == nil {
+		return fmt.Errorf("nil client proxy message payload")
+	}
+	if msg.Broadcast && msg.Msg.Type != msgjson.Notification {
+		return fmt.Errorf("broadcast requires a notification message, got type %d", msg.Msg.Type)
+	}
+	switch msg.Msg.Type {
+	case msgjson.Request:
+		if msg.Msg.ID == 0 {
+			return fmt.Errorf("request id cannot be 0")
+		}
+	case msgjson.Response:
+		if msg.Msg.ID == 0 {
+			return fmt.Errorf("response id cannot be 0")
+		}
+	case msgjson.Notification:
+	default:
+		return fmt.Errorf("unsupported message type %d", msg.Msg.Type)
+	}
+	return nil
+}
+
+// maxClientConnectedUsers is the maximum number of users in one
+// client_connected query. QueryClientConnected splits larger queries.
+const maxClientConnectedUsers = 4096
+
+// clientConnectedQuery asks the peer which of the listed client accounts are
+// currently connected to it.
+type clientConnectedQuery struct {
+	Users []account.AccountID `json:"users"`
+}
+
+// clientConnectedResult lists the subset of the queried accounts that are
+// connected to the answering node.
+type clientConnectedResult struct {
+	Connected []account.AccountID `json:"connected,omitempty"`
+}
+
+func validateClientConnectedQuery(query *clientConnectedQuery) error {
+	if query == nil || len(query.Users) == 0 {
+		return fmt.Errorf("empty client connected query")
+	}
+	if len(query.Users) > maxClientConnectedUsers {
+		return fmt.Errorf("client connected query for %d users exceeds limit %d", len(query.Users), maxClientConnectedUsers)
+	}
+	return nil
+}
+
 func validateClientRequestMsg(msg *msgjson.Message) error {
 	if msg == nil {
 		return fmt.Errorf("nil request message")

--- a/server/mesh/protocol.go
+++ b/server/mesh/protocol.go
@@ -7,6 +7,8 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+
+	"decred.org/dcrdex/dex"
 )
 
 // Event is one replicated state change.
@@ -42,6 +44,90 @@ func validateEvent(event *Event) error {
 }
 
 const eventLogTipHashSize = sha256.Size
+
+// eventEnvelope is an event and its metadata, sent by the master to the slave
+// over the event stream.
+type eventEnvelope struct {
+	Seq     uint64    `json:"seq"`
+	TipHash dex.Bytes `json:"tipHash"`
+	// MasterTip is the master's tip when the event was sent. If
+	// Seq == MasterTip, the slave will know that it is caught up.
+	MasterTip       uint64          `json:"masterTip"`
+	Kind            string          `json:"kind"`
+	OriginCommandID string          `json:"originCommandID,omitempty"`
+	CommandResult   json.RawMessage `json:"commandResult,omitempty"`
+	Payload         json.RawMessage `json:"payload,omitempty"`
+}
+
+func validateEventEnvelope(envelope *eventEnvelope) error {
+	if envelope == nil {
+		return fmt.Errorf("nil event envelope")
+	}
+	if envelope.Seq == 0 {
+		return fmt.Errorf("event seq cannot be 0")
+	}
+	if envelope.MasterTip < envelope.Seq {
+		return fmt.Errorf("event master tip %d before seq %d", envelope.MasterTip, envelope.Seq)
+	}
+	if len(envelope.TipHash) != eventLogTipHashSize {
+		return fmt.Errorf("event tip hash length %d, want %d", len(envelope.TipHash), eventLogTipHashSize)
+	}
+	return validateEvent(&Event{
+		Kind:    envelope.Kind,
+		Payload: envelope.Payload,
+	})
+}
+
+// eventBatch is an ordered run of event envelopes sent as one request over
+// the event stream.
+type eventBatch struct {
+	Entries []*eventEnvelope `json:"entries"`
+}
+
+func validateEventBatch(batch *eventBatch) error {
+	if batch == nil || len(batch.Entries) == 0 {
+		return fmt.Errorf("empty event batch")
+	}
+	if len(batch.Entries) > eventStreamBatchLimit {
+		return fmt.Errorf("event batch of %d entries exceeds limit %d",
+			len(batch.Entries), eventStreamBatchLimit)
+	}
+	for i, envelope := range batch.Entries {
+		if err := validateEventEnvelope(envelope); err != nil {
+			return fmt.Errorf("entry %d: %w", i, err)
+		}
+		if i > 0 && envelope.Seq != batch.Entries[i-1].Seq+1 {
+			return fmt.Errorf("entry %d: seq %d does not follow %d", i, envelope.Seq, batch.Entries[i-1].Seq)
+		}
+	}
+	return nil
+}
+
+// eventAck is the slave's response to an eventBatch, sent after every
+// entry in the batch was applied.
+type eventAck struct{}
+
+// streamSubscribe is the slave's subscription to the master's event stream. A
+// slave with no replayable history must first seed from a snapshot by sending
+// a snapshotRequest.
+type streamSubscribe struct {
+	Frontier frontierMessage `json:"frontier"`
+}
+
+// streamSubscribeResult is the master's response to a slave's streamSubscribe.
+type streamSubscribeResult struct {
+	MasterTip uint64 `json:"masterTip"`
+}
+
+func validateStreamSubscribe(sub *streamSubscribe) error {
+	if sub == nil {
+		return fmt.Errorf("nil stream subscribe")
+	}
+	if err := validateFrontierMessage(sub.Frontier); err != nil {
+		return fmt.Errorf("invalid subscribe frontier: %w", err)
+	}
+	return nil
+}
 
 // snapshotRequest is the slave's request for a snapshot of the master's
 // state. A slave with an empty event log sends it before it subscribes to the

--- a/server/mesh/protocol.go
+++ b/server/mesh/protocol.go
@@ -280,6 +280,19 @@ func validateStreamSubscribe(sub *streamSubscribe) error {
 	return nil
 }
 
+// masterHandoff is a request from the master to let the slave know that it
+// should take over as the master immediately.
+type masterHandoff struct {
+	Frontier frontierMessage `json:"frontier"`
+}
+
+func validateMasterHandoff(handoff *masterHandoff) error {
+	if handoff == nil {
+		return fmt.Errorf("nil master handoff")
+	}
+	return validateFrontierMessage(handoff.Frontier)
+}
+
 // snapshotRequest is the slave's request for a snapshot of the master's
 // state. A slave with an empty event log sends it before it subscribes to the
 // event stream.

--- a/server/mesh/protocol.go
+++ b/server/mesh/protocol.go
@@ -4,6 +4,7 @@
 package mesh
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 )
@@ -39,3 +40,5 @@ func validateEvent(event *Event) error {
 	}
 	return nil
 }
+
+const eventLogTipHashSize = sha256.Size

--- a/server/mesh/protocol.go
+++ b/server/mesh/protocol.go
@@ -42,3 +42,8 @@ func validateEvent(event *Event) error {
 }
 
 const eventLogTipHashSize = sha256.Size
+
+// snapshotRequest is the slave's request for a snapshot of the master's
+// state. A slave with an empty event log sends it before it subscribes to the
+// event stream.
+type snapshotRequest struct{}

--- a/server/mesh/protocol.go
+++ b/server/mesh/protocol.go
@@ -1,0 +1,41 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Event is one replicated state change.
+type Event struct {
+	Kind    string          `json:"kind"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// EventEncoder is a typed event payload that can be turned into an Event.
+// Kind names the event and Encode produces its payload.
+type EventEncoder interface {
+	Kind() string
+	Encode() ([]byte, error)
+}
+
+// NewEvent wraps e as an *Event ready to apply or publish.
+func NewEvent(e EventEncoder) (*Event, error) {
+	payload, err := e.Encode()
+	if err != nil {
+		return nil, err
+	}
+	return &Event{Kind: e.Kind(), Payload: payload}, nil
+}
+
+func validateEvent(event *Event) error {
+	if event == nil {
+		return fmt.Errorf("nil event")
+	}
+	if event.Kind == "" {
+		return fmt.Errorf("event kind not specified")
+	}
+	return nil
+}

--- a/server/mesh/protocol.go
+++ b/server/mesh/protocol.go
@@ -9,7 +9,92 @@ import (
 	"fmt"
 
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
 )
+
+// commandForward is a request from the slave to the master that wraps a
+// client's state changing request. The master answers the forward when the
+// command has run, with an error if the command was refused, or with an
+// empty ack. The result arrives separately, in the CommandResult field of
+// the eventEnvelope if an event was emitted, or in a commandResult or a
+// commandFailure if not, and it can arrive before the ack.
+type commandForward struct {
+	CommandID string            `json:"commandID"`
+	Kind      string            `json:"kind"`
+	User      account.AccountID `json:"user"`
+	Msg       *msgjson.Message  `json:"msg"`
+}
+
+func validateCommandForward(cmd *commandForward) error {
+	if cmd == nil {
+		return fmt.Errorf("nil command")
+	}
+	if cmd.CommandID == "" {
+		return fmt.Errorf("command id not specified")
+	}
+	if cmd.Kind == "" {
+		return fmt.Errorf("command kind not specified")
+	}
+	return validateClientRequestMsg(cmd.Msg)
+}
+
+// commandFailure is a message from the master to the slave that completes a
+// forwarded command with an error, when no event was emitted.
+type commandFailure struct {
+	CommandID string         `json:"commandID"`
+	Error     *msgjson.Error `json:"error"`
+}
+
+func validateCommandFailure(fail *commandFailure) error {
+	if fail == nil {
+		return fmt.Errorf("nil command failure")
+	}
+	if fail.CommandID == "" {
+		return fmt.Errorf("command id not specified")
+	}
+	if fail.Error == nil {
+		return fmt.Errorf("command error not specified")
+	}
+	return nil
+}
+
+// commandResult is a message from the master to the slave that completes a
+// forwarded command with a result, when no event was emitted (for example a
+// duplicate command that already has a result).
+type commandResult struct {
+	CommandID string          `json:"commandID"`
+	Result    json.RawMessage `json:"result"`
+}
+
+func validateCommandResult(result *commandResult) error {
+	if result == nil {
+		return fmt.Errorf("nil command result")
+	}
+	if result.CommandID == "" {
+		return fmt.Errorf("command id not specified")
+	}
+	if len(result.Result) == 0 {
+		return fmt.Errorf("command result not specified")
+	}
+	if !json.Valid(result.Result) {
+		return fmt.Errorf("invalid command result JSON")
+	}
+	return nil
+}
+
+func validateClientRequestMsg(msg *msgjson.Message) error {
+	if msg == nil {
+		return fmt.Errorf("nil request message")
+	}
+	if msg.Type != msgjson.Request {
+		return fmt.Errorf("invalid message type %d", msg.Type)
+	}
+	if msg.ID == 0 {
+		return fmt.Errorf("request id cannot be 0")
+	}
+	return nil
+}
 
 // Event is one replicated state change.
 type Event struct {

--- a/server/mesh/readiness.go
+++ b/server/mesh/readiness.go
@@ -1,0 +1,55 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"sync"
+)
+
+// readiness records a single outcome and lets callers wait for it.
+type readiness struct {
+	once sync.Once
+	err  error
+	done chan struct{}
+}
+
+// newReadiness returns an unresolved readiness.
+func newReadiness() *readiness {
+	return &readiness{done: make(chan struct{})}
+}
+
+// resolve records the outcome. Only the first call has any effect.
+func (r *readiness) resolve(err error) {
+	r.once.Do(func() {
+		r.err = err
+		close(r.done)
+	})
+}
+
+// resolved returns a channel that is closed when the outcome is recorded.
+func (r *readiness) resolved() <-chan struct{} {
+	return r.done
+}
+
+// result returns the recorded outcome and whether it is recorded yet.
+func (r *readiness) result() (error, bool) {
+	select {
+	case <-r.done:
+		return r.err, true
+	default:
+		return nil, false
+	}
+}
+
+// wait blocks until the outcome is recorded or ctx is done, and returns the
+// outcome or the context error.
+func (r *readiness) wait(ctx context.Context) error {
+	select {
+	case <-r.done:
+		return r.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/server/mesh/reducer.go
+++ b/server/mesh/reducer.go
@@ -1,0 +1,493 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"decred.org/dcrdex/server/db"
+)
+
+// reduceResult is the result of applying one signal. It holds the next
+// state, the effects to run, and whether the signal was handled.
+type reduceResult struct {
+	next    nodeState
+	effects []effect
+	handled bool          // false if the signal was ignored, so no transition effects are added
+	outcome signalOutcome // optional, returned to the sender of the signal
+}
+
+// ignoredResult leaves the state unchanged and runs no effects.
+func ignoredResult(cur nodeState) reduceResult {
+	return reduceResult{next: cur}
+}
+
+// handledResult moves the node to next and runs effects.
+func handledResult(next nodeState, effects []effect) reduceResult {
+	return reduceResult{
+		next:    next,
+		effects: effects,
+		handled: true,
+	}
+}
+
+// withOutcome sets the outcome that the sender of the signal receives.
+func (r reduceResult) withOutcome(o signalOutcome) reduceResult {
+	r.outcome = o
+	return r
+}
+
+// halt moves the node to modeHalted with err as the reason, and disconnects
+// the active connection, if any.
+func halt(cur nodeState, err error, at time.Time) reduceResult {
+	next := cur
+	next.mode = modeHalted
+	next.haltErr = err
+
+	var effects []effect
+	if cur.activeConn != nil {
+		effects = append(effects, effectDisconnect{Conn: cur.activeConn})
+		next.activeConn = nil
+		next.peerDisconnected = at
+	}
+	effects = append(effects, effectHalt{})
+	return handledResult(next, effects)
+}
+
+// promote moves the node to preparing master. Entering a master mode makes
+// withTransitionEffects add effectBecameMaster, which starts the workers.
+func promote(cur nodeState) reduceResult {
+	next := cur
+	next.mode = modePreparingMaster
+	next.peerDisconnected = time.Time{}
+	return handledResult(next, nil)
+}
+
+// sameFrontier reports whether two log positions are identical.
+func sameFrontier(a, b *db.EventLogPosition) bool {
+	return a.Seq == b.Seq && bytes.Equal(a.TipHash, b.TipHash)
+}
+
+// supersedeAfter is the age at which the active connection can be replaced by
+// a new handshake from the same peer. It equals the transport's pong read
+// deadline. A younger connection is considered a parallel dial and is decided
+// by node ID. An older one may be dead.
+const supersedeAfter = 2 * meshPingPeriod
+
+// peerAdoptionDecision reports whether to adopt the new connection. A node
+// with no active connection adopts it. A connection from a different peer
+// node ID is refused. A second connection from the same peer replaces the
+// active one if its initiator node ID is lower, or if the active one is stale.
+func peerAdoptionDecision(cur nodeState, peerNodeID, initiatorNodeID string, at time.Time) bool {
+	active := cur.activeConn
+	switch {
+	case active == nil:
+		return true // nothing to replace
+	case active.peerNodeID != peerNodeID:
+		return false // a different node, and the mesh has one peer
+	case initiatorNodeID < active.initiatorNodeID:
+		return true // parallel dial: the lower initiator wins
+	case !cur.connAdopted.IsZero() && !at.IsZero() && at.Sub(cur.connAdopted) >= supersedeAfter:
+		return true // the active connection is old enough to be dead
+	default:
+		return false
+	}
+}
+
+// rejectsDivergedJoin reports whether a diverged handshake is refused without
+// a mode change. A preparing or established master refuses a peer that does
+// not report master, and keeps its role. Master against master is not
+// refused here. It halts.
+func rejectsDivergedJoin(localMode nodeMode, peerRole helloRole) bool {
+	return localMode.isAuthoritativeMaster() && peerRole != roleMaster
+}
+
+// resolvePeerState picks this node's mode after a successful handshake. A
+// serving master rejects a fork from a peer that is not master before this
+// function. Every other fork reaches this function and halts.
+//
+//	logs                 we              they            we become
+//	prefix, we ahead     *               *               master
+//	prefix, they ahead   not master      *               slave (catch up)
+//	prefix, they ahead   master          *               halt (will not demote)
+//	equal                neither master  neither master  lower node ID becomes master, else slave
+//	equal                master          not master      stay master
+//	equal                master          master          both halt
+//	equal                not master      master          slave
+//	fork                 master          master          halt
+//	fork                 not master      *               halt
+func resolvePeerState(localNodeID string, localMode nodeMode, peerNodeID string, peerRole helloRole, progress progressState) (nodeMode, error) {
+	// Unequal frontier states determine the next mesh state directly.
+	switch progress {
+	case progressDiverged:
+		return modeHalted, nil
+	case progressLocalAhead:
+		// An established master keeps its role. Anyone else becomes the
+		// preparing master.
+		if localMode == modeEstablishedMaster {
+			return modeEstablishedMaster, nil
+		}
+		return modePreparingMaster, nil
+	case progressPeerAhead:
+		if localMode.isAuthoritativeMaster() {
+			return modeHalted, nil
+		}
+		return modeEstablishedSlaveSyncing, nil
+	case progressEqual:
+		// Handled below.
+	default:
+		return modePending, fmt.Errorf("unknown progress state %d", progress)
+	}
+
+	// With equal frontiers, an established master keeps control unless the peer
+	// also reports master, which halts. Otherwise a peer that reports master makes
+	// the local node a slave, and all remaining equal cases fall back to the
+	// node ID tie break.
+	if localMode.isAuthoritativeMaster() {
+		if peerRole == roleMaster {
+			return modeHalted, nil
+		}
+		return localMode, nil
+	}
+	if peerRole == roleMaster {
+		return modeEstablishedSlave, nil
+	}
+	if localNodeID < peerNodeID {
+		return modePreparingMaster, nil
+	}
+	return modeEstablishedSlave, nil
+}
+
+// onHandshakeResolved handles a completed handshake. It decides whether to
+// adopt the connection, then picks this node's mode from the peer's role and
+// the event log comparison, and halts the node on a fork or a role clash.
+func onHandshakeResolved(localNodeID string, cur nodeState, ev handshakeResolvedSignal) (reduceResult, error) {
+	if cur.mode == modeHalted {
+		return ignoredResult(cur).withOutcome(handshakeHalted), nil
+	}
+	if ev.conn == nil {
+		return ignoredResult(cur), fmt.Errorf("nil peer connection")
+	}
+
+	// Two connections may have been opened in parallel, one from each side.
+	// peerAdoptionDecision picks which one to keep.
+	if !peerAdoptionDecision(cur, ev.conn.peerNodeID, ev.conn.initiatorNodeID, ev.at) {
+		// No disconnect here. The handshake handler must first answer that the
+		// connection was not adopted, and effects run before it gets this result.
+		return handledResult(cur, nil).withOutcome(handshakeNotAdopted), nil
+	}
+
+	// A serving master rejects a diverged join from a peer that is not master,
+	// and stays in mode.
+	// The handshake handler answers before applying a diverged result, so
+	// disconnecting here is safe.
+	if ev.progress == progressDiverged && rejectsDivergedJoin(cur.mode, ev.peerRole) {
+		return handledResult(cur, []effect{effectDisconnect{Conn: ev.conn}}).
+			withOutcome(handshakeDivergedJoinRejected), nil
+	}
+
+	nextMode, err := resolvePeerState(localNodeID, cur.mode, ev.conn.peerNodeID, ev.peerRole, ev.progress)
+	if err != nil {
+		return ignoredResult(cur), err
+	}
+	if nextMode == modeHalted {
+		return haltAfterHandshake(cur, ev), nil
+	}
+
+	next := cur
+	next.mode = nextMode
+	next.activeConn = ev.conn
+	next.connAdopted = ev.at
+	next.peerDisconnected = time.Time{}
+
+	var effects []effect
+	if !sameConn(cur.activeConn, ev.conn) {
+		if cur.activeConn != nil {
+			effects = append(effects, effectDisconnect{Conn: cur.activeConn})
+		}
+		effects = append(effects, effectWatchConn{Conn: ev.conn})
+	}
+	if next.mode.canReceiveEventStream() {
+		effects = append(effects, effectStartSubscriber{Conn: ev.conn})
+	}
+	effects = append(effects, effectPeerClientEndpointChanged{Host: ev.clientHost, Cert: append([]byte(nil), ev.clientCert...)})
+	return handledResult(next, effects).withOutcome(handshakeAdopted), nil
+}
+
+// haltAfterHandshake halts the node after a handshake that resolved to a
+// fork or a role clash. The new connection and any old one are closed.
+func haltAfterHandshake(cur nodeState, ev handshakeResolvedSignal) reduceResult {
+	res := halt(cur, handshakeHaltError(cur, ev), ev.at)
+	if !sameConn(cur.activeConn, ev.conn) {
+		res.effects = append([]effect{effectDisconnect{Conn: ev.conn}}, res.effects...)
+	}
+	return res.withOutcome(handshakeHalted)
+}
+
+// handshakeHaltError builds the halt reason. A fork names both frontiers and,
+// for a node joining a serving master, the --meshforkreset token.
+func handshakeHaltError(cur nodeState, ev handshakeResolvedSignal) error {
+	if ev.progress != progressDiverged {
+		return fmt.Errorf("halting after handshake: local role %s, peer %s role %s, progress %s",
+			cur.mode.helloRole(), ev.conn.peerNodeID, ev.peerRole, ev.progress)
+	}
+	hint := ""
+	if !cur.mode.isAuthoritativeMaster() && ev.peerRole == roleMaster {
+		if token := forkResetToken(ev.localFrontier); token != "" {
+			hint = fmt.Sprintf("; this node holds committed events the serving master never received. "+
+				"Back up the database for audit (pg_dump), then restart with --meshforkreset=%s "+
+				"to wipe and resync from the master", token)
+		}
+	}
+	return fmt.Errorf("MESH FORK DETECTED: halting after handshake, event logs diverged "+
+		"(local role %s frontier %s, peer %s role %s frontier %s)%s",
+		cur.mode.helloRole(), ev.localFrontier, ev.conn.peerNodeID, ev.peerRole, ev.peerFrontier, hint)
+}
+
+// onStreamCaughtUp moves a syncing slave to established slave once the event
+// stream over the active connection has reached the tip the master reported.
+// Any other mode, or a stale connection, ignores it.
+func onStreamCaughtUp(cur nodeState, ev streamCaughtUpSignal) (reduceResult, error) {
+	if cur.mode != modeEstablishedSlaveSyncing || !sameConn(cur.activeConn, ev.conn) {
+		return ignoredResult(cur), nil
+	}
+	next := cur
+	next.mode = modeEstablishedSlave
+	return handledResult(next, nil), nil
+}
+
+// onSubscribeRejected halts the node after the peer refused, for good, to
+// stream events from this node's frontier. A rejection on a replaced
+// connection is ignored, and so is any rejection when this node is a master.
+func onSubscribeRejected(cur nodeState, ev subscribeRejectedSignal) (reduceResult, error) {
+	if !sameConn(cur.activeConn, ev.conn) || cur.mode.isAuthoritativeMaster() {
+		return ignoredResult(cur), nil
+	}
+	return halt(cur, ev.err, ev.at), nil
+}
+
+// onConnectionDisconnected clears the closed active connection and sets the
+// disconnect time. A slave enters modeSlaveNoMaster and starts the promotion
+// timer, a syncing slave returns to pending, a master keeps its mode.
+func onConnectionDisconnected(cur nodeState, ev connectionDisconnectedSignal) (reduceResult, error) {
+	if !sameConn(cur.activeConn, ev.conn) {
+		return ignoredResult(cur), nil
+	}
+
+	next := cur
+	next.activeConn = nil
+	next.peerDisconnected = ev.at
+
+	effects := []effect{effectStopEventStream{Conn: ev.conn}}
+	switch cur.mode {
+	case modeEstablishedSlave:
+		// The promotion delay counts from peerDisconnected, which was set
+		// above. A zero value would promote on the first timer.
+		next.mode = modeSlaveNoMaster
+		effects = append(effects, effectScheduleSlavePromotionCheck{})
+	case modeEstablishedSlaveSyncing:
+		next.mode = modePending
+	default:
+		// A master keeps its mode and waits for the slave to reconnect.
+	}
+	return handledResult(next, effects), nil
+}
+
+// onStreamFailed handles a failed event stream or snapshot send to the slave.
+// The master clears activeConn, records the disconnect time, and emits
+// effectDisconnect to close the link so the slave reconnects and handshakes
+// again.
+func onStreamFailed(cur nodeState, ev streamFailedSignal) (reduceResult, error) {
+	if cur.mode != modeEstablishedMaster || !sameConn(cur.activeConn, ev.conn) {
+		return ignoredResult(cur), nil
+	}
+	next := cur
+	next.activeConn = nil
+	next.peerDisconnected = ev.at
+	return handledResult(next, []effect{effectDisconnect{Conn: ev.conn}}), nil
+}
+
+// onMasterEvidence handles proof that the lost master is still alive. A
+// slave without a master moves peerDisconnected forward to the evidence
+// time and schedules a new promotion check, so the promotion delay restarts.
+func onMasterEvidence(cur nodeState, ev masterEvidenceSignal) (reduceResult, error) {
+	if cur.mode != modeSlaveNoMaster || !ev.at.After(cur.peerDisconnected) {
+		return ignoredResult(cur), nil
+	}
+	next := cur
+	next.peerDisconnected = ev.at
+	return handledResult(next, []effect{effectScheduleSlavePromotionCheck{}}), nil
+}
+
+// onSlavePromotionCheck promotes a slave that has had no master for the full
+// delay to preparing master. A check that fires early or belongs to an older
+// disconnect is ignored.
+func onSlavePromotionCheck(cur nodeState, ev slavePromotionCheckSignal, delay time.Duration) (reduceResult, error) {
+	if cur.mode != modeSlaveNoMaster || ev.at.Sub(cur.peerDisconnected) < delay {
+		return ignoredResult(cur), nil
+	}
+	return promote(cur), nil
+}
+
+// onPlannedHandoff moves a connected slave straight to modePreparingMaster,
+// skipping the promotion delay, when its log frontier equals the departing
+// master's. Any other frontier means the logs disagree, so the node
+// disconnects and halts.
+func onPlannedHandoff(cur nodeState, ev plannedHandoffSignal) (reduceResult, error) {
+	if !cur.mode.canAcceptMasterHandoff() || !sameConn(cur.activeConn, ev.conn) ||
+		ev.local == nil || ev.target == nil {
+		return ignoredResult(cur), nil
+	}
+	if !sameFrontier(ev.local, ev.target) {
+		return halt(cur, fmt.Errorf("planned handoff frontier mismatch (local %s, master %s)",
+			ev.local, ev.target), ev.at), nil
+	}
+	return promote(cur), nil
+}
+
+// onMasterReady moves a preparing master to established master once its
+// workers run, which also resolves startup. An established master ignores
+// the signal. Any other mode is an error, since only a preparing master
+// starts workers.
+func onMasterReady(cur nodeState) (reduceResult, error) {
+	if cur.mode == modeEstablishedMaster {
+		return ignoredResult(cur), nil
+	}
+	if cur.mode != modePreparingMaster {
+		return ignoredResult(cur), fmt.Errorf("master ready in node mode %s", cur.mode)
+	}
+	next := cur
+	next.mode = modeEstablishedMaster
+	return handledResult(next, nil), nil
+}
+
+// onMasterPreparationFailed halts a preparing or established master. Any
+// other mode ignores it, because only a master runs the workers.
+func onMasterPreparationFailed(cur nodeState, ev masterPreparationFailedSignal) (reduceResult, error) {
+	if !cur.mode.isAuthoritativeMaster() {
+		return ignoredResult(cur), nil
+	}
+	return halt(cur, ev.err, ev.at), nil
+}
+
+// servesStreamRequests reports whether the node serves a stream subscribe or
+// snapshot request that arrived on connID. Only the established master serves
+// them, and only on its active connection.
+func servesStreamRequests(cur nodeState, connID uint64) bool {
+	return cur.mode == modeEstablishedMaster &&
+		cur.activeConn != nil && cur.activeConn.ID() == connID
+}
+
+// onStreamSubscribe handles a slave's stream_subscribe. An established master
+// emits effectStartEventStream, which starts (or replaces) the stream to its
+// active connection from the slave's frontier. Any other mode or connection
+// ignores it.
+func onStreamSubscribe(cur nodeState, ev streamSubscribeSignal) (reduceResult, error) {
+	if !servesStreamRequests(cur, ev.connID) {
+		return ignoredResult(cur), nil
+	}
+	return handledResult(cur, []effect{effectStartEventStream{
+		Conn:          cur.activeConn,
+		SlaveFrontier: ev.frontier,
+	}}), nil
+}
+
+// onSnapshotRequest answers a peer's snapshot request. Only an established
+// master emits effectStartSnapshotSend, and only for its active connection.
+// The node state does not change.
+func onSnapshotRequest(cur nodeState, ev snapshotRequestSignal) (reduceResult, error) {
+	if !servesStreamRequests(cur, ev.connID) {
+		return ignoredResult(cur), nil
+	}
+	return handledResult(cur, []effect{effectStartSnapshotSend{Conn: cur.activeConn}}), nil
+}
+
+// onDialIncompatible halts a pending node. The peer refused its dial for a
+// reason no retry can fix, and a node with no role cannot serve alone. A node
+// that already has a role ignores it and keeps running.
+func onDialIncompatible(cur nodeState, ev dialIncompatibleSignal) (reduceResult, error) {
+	if cur.mode != modePending {
+		return ignoredResult(cur), nil
+	}
+	return halt(cur, ev.err, ev.at), nil
+}
+
+// onTerminalEventApplyFailure halts the node. A node that is halted already
+// ignores it, so the first halt reason is kept.
+func onTerminalEventApplyFailure(cur nodeState, ev terminalApplyFailureSignal) (reduceResult, error) {
+	if cur.mode == modeHalted {
+		return ignoredResult(cur), nil
+	}
+	return halt(cur, ev.err, ev.at), nil
+}
+
+// reduceSignal is the node's state machine. Given the current state and one
+// signal, it returns the next state and the effects to run. It is pure. The
+// effects describe work for the caller to do. The effects of the mode change
+// itself, such as starting the master workers, are added by
+// withTransitionEffects.
+func reduceSignal(localNodeID string, slavePromotionDelay time.Duration, cur nodeState, ev meshSignal) (reduceResult, error) {
+	var result reduceResult
+	var err error
+	switch ev := ev.(type) {
+	case handshakeResolvedSignal:
+		result, err = onHandshakeResolved(localNodeID, cur, ev)
+	case streamCaughtUpSignal:
+		result, err = onStreamCaughtUp(cur, ev)
+	case subscribeRejectedSignal:
+		result, err = onSubscribeRejected(cur, ev)
+	case connectionDisconnectedSignal:
+		result, err = onConnectionDisconnected(cur, ev)
+	case streamFailedSignal:
+		result, err = onStreamFailed(cur, ev)
+	case masterEvidenceSignal:
+		result, err = onMasterEvidence(cur, ev)
+	case slavePromotionCheckSignal:
+		result, err = onSlavePromotionCheck(cur, ev, slavePromotionDelay)
+	case plannedHandoffSignal:
+		result, err = onPlannedHandoff(cur, ev)
+	case masterReadySignal:
+		result, err = onMasterReady(cur)
+	case masterPreparationFailedSignal:
+		result, err = onMasterPreparationFailed(cur, ev)
+	case streamSubscribeSignal:
+		result, err = onStreamSubscribe(cur, ev)
+	case snapshotRequestSignal:
+		result, err = onSnapshotRequest(cur, ev)
+	case dialIncompatibleSignal:
+		result, err = onDialIncompatible(cur, ev)
+	case terminalApplyFailureSignal:
+		result, err = onTerminalEventApplyFailure(cur, ev)
+	default:
+		return ignoredResult(cur), fmt.Errorf("unhandled signal %T in mode %s", ev, cur.mode)
+	}
+	if err != nil || !result.handled {
+		return result, err
+	}
+	result.effects = withTransitionEffects(cur, result.next, result.effects)
+	return result, nil
+}
+
+// withTransitionEffects adds the effects of the mode change itself.
+func withTransitionEffects(cur, next nodeState, effects []effect) []effect {
+	// Start master workers and fail pending commands with unknown outcomes.
+	if !cur.mode.isAuthoritativeMaster() && next.mode.isAuthoritativeMaster() {
+		effects = append([]effect{effectBecameMaster{}}, effects...)
+		effects = append(effects, effectFailPendingCommands{Reason: "node promoted to mesh master"})
+	}
+
+	// Fail pending commands if the node just lost its master.
+	if cur.mode != modeSlaveNoMaster && next.mode == modeSlaveNoMaster {
+		effects = append(effects, effectFailPendingCommands{Reason: "mesh slave lost its master connection"})
+	}
+
+	// Resolve startup if the node just became established.
+	if cur.mode.startupPending() && next.mode.startupResolved() && next.mode != modeHalted {
+		effects = append(effects, effectStartupResolved{})
+	}
+
+	return effects
+}

--- a/server/mesh/reducer_test.go
+++ b/server/mesh/reducer_test.go
@@ -1,0 +1,915 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/server/db"
+)
+
+func testSession(cpNode, localNode string) *nodeConn {
+	return newNodeConn(newTPeerConn(), cpNode, localNode)
+}
+
+var (
+	testLocalFrontier = &db.EventLogPosition{Seq: 41, TipHash: []byte{0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}}
+	testPeerFrontier  = &db.EventLogPosition{Seq: 44, TipHash: []byte{0xfe, 0xed, 0xfa, 0xce, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f}}
+)
+
+func testHandshakeResolvedSignal(conn *nodeConn, role helloRole, progress progressState) handshakeResolvedSignal {
+	return handshakeResolvedSignal{
+		conn:          conn,
+		peerRole:      role,
+		progress:      progress,
+		localFrontier: testLocalFrontier,
+		peerFrontier:  testPeerFrontier,
+	}
+}
+
+func requireTransition(t *testing.T, localNodeID string, initial nodeState, signal meshSignal, want reduceResult) {
+	t.Helper()
+	result, err := reduceSignal(localNodeID, defaultSlavePromotionDelay, initial, signal)
+	if err != nil {
+		t.Fatalf("reduceSignal error: %v", err)
+	}
+	if !reflect.DeepEqual(result, want) {
+		t.Fatalf("result = %#v, want %#v", result, want)
+	}
+}
+
+func TestReduceConnectionAdoption(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	const nodeB = "node-b"
+	const nodeC = "node-c"
+	t.Run("adopts lower initiator connection", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		active := testSession(cpNode, cpNode)
+		adopted := testSession(cpNode, localNode)
+		initial := nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: active,
+		}
+		signal := testHandshakeResolvedSignal(adopted, roleSlave, progressEqual)
+		want := handledResult(nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: adopted,
+		}, []effect{
+			effectDisconnect{Conn: active},
+			effectWatchConn{Conn: adopted},
+			// No stream at adoption: the replacement conn's slave
+			// must subscribe before anything streams.
+			effectPeerClientEndpointChanged{},
+		}).withOutcome(handshakeAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("rejects higher initiator connection", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		active := testSession(cpNode, localNode)
+		rejected := testSession(cpNode, cpNode)
+		initial := nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: active,
+		}
+		signal := testHandshakeResolvedSignal(rejected, roleSlave, progressEqual)
+		want := handledResult(nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: active,
+		}, nil).withOutcome(handshakeNotAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("same-peer handshake supersedes a stale connection", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		active := testSession(cpNode, localNode)
+		redial := testSession(cpNode, cpNode)
+		sig := testHandshakeResolvedSignal(redial, roleSlave, progressEqual)
+		sig.at = at.Add(supersedeAfter)
+		initial := nodeState{
+			mode:        modeEstablishedMaster,
+			activeConn:  active,
+			connAdopted: at,
+		}
+		signal := sig
+		want := handledResult(nodeState{
+			mode:        modeEstablishedMaster,
+			activeConn:  redial,
+			connAdopted: at.Add(supersedeAfter),
+		}, []effect{
+			effectDisconnect{Conn: active},
+			effectWatchConn{Conn: redial},
+			effectPeerClientEndpointChanged{},
+		}).withOutcome(handshakeAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("fresh same-peer conflict still tie-breaks", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		active := testSession(cpNode, localNode)
+		redial := testSession(cpNode, cpNode)
+		sig := testHandshakeResolvedSignal(redial, roleSlave, progressEqual)
+		sig.at = at.Add(supersedeAfter - time.Second)
+		initial := nodeState{
+			mode:        modeEstablishedMaster,
+			activeConn:  active,
+			connAdopted: at,
+		}
+		signal := sig
+		want := handledResult(nodeState{
+			mode:        modeEstablishedMaster,
+			activeConn:  active,
+			connAdopted: at,
+		}, nil).withOutcome(handshakeNotAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("rejects connection from different peer", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		otherNode := nodeC
+		active := testSession(cpNode, cpNode)
+		differentPeer := testSession(otherNode, otherNode)
+		initial := nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: active,
+		}
+		signal := testHandshakeResolvedSignal(differentPeer, roleSlave, progressEqual)
+		want := handledResult(nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: active,
+		}, nil).withOutcome(handshakeNotAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+}
+
+func TestReduceRoleSelection(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	const nodeB = "node-b"
+	t.Run("equal progress local wins tie break", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePending}
+		signal := testHandshakeResolvedSignal(peerConn, roleUnknown, progressEqual)
+		want := handledResult(nodeState{
+			mode:       modePreparingMaster,
+			activeConn: peerConn,
+		}, []effect{
+			effectBecameMaster{},
+			effectWatchConn{Conn: peerConn},
+			effectPeerClientEndpointChanged{},
+			effectFailPendingCommands{Reason: "node promoted to mesh master"},
+		}).withOutcome(handshakeAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("equal progress local loses tie break", func(t *testing.T) {
+		localNode, cpNode := nodeB, nodeA
+		tieLoseConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePending}
+		signal := testHandshakeResolvedSignal(tieLoseConn, roleUnknown, progressEqual)
+		want := handledResult(nodeState{
+			mode:       modeEstablishedSlave,
+			activeConn: tieLoseConn,
+		}, []effect{
+			effectWatchConn{Conn: tieLoseConn},
+			effectStartSubscriber{Conn: tieLoseConn},
+			effectPeerClientEndpointChanged{},
+			effectStartupResolved{},
+		}).withOutcome(handshakeAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("equal progress peer master becomes slave", func(t *testing.T) {
+		localNode, cpNode := nodeB, nodeA
+		peerMasterConn := testSession(cpNode, cpNode)
+		initial := nodeState{mode: modePending}
+		signal := testHandshakeResolvedSignal(peerMasterConn, roleMaster, progressEqual)
+		want := handledResult(nodeState{
+			mode:       modeEstablishedSlave,
+			activeConn: peerMasterConn,
+		}, []effect{
+			effectWatchConn{Conn: peerMasterConn},
+			effectStartSubscriber{Conn: peerMasterConn},
+			effectPeerClientEndpointChanged{},
+			effectStartupResolved{},
+		}).withOutcome(handshakeAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("local ahead becomes master", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePending}
+		signal := testHandshakeResolvedSignal(peerConn, roleUnknown, progressLocalAhead)
+		want := handledResult(nodeState{
+			mode:       modePreparingMaster,
+			activeConn: peerConn,
+		}, []effect{
+			effectBecameMaster{},
+			effectWatchConn{Conn: peerConn},
+			effectPeerClientEndpointChanged{},
+			effectFailPendingCommands{Reason: "node promoted to mesh master"},
+		}).withOutcome(handshakeAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("peer ahead enters stream sync", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePending}
+		signal := testHandshakeResolvedSignal(peerConn, roleMaster, progressPeerAhead)
+		want := handledResult(nodeState{
+			mode:       modeEstablishedSlaveSyncing,
+			activeConn: peerConn,
+		}, []effect{
+			effectWatchConn{Conn: peerConn},
+			effectStartSubscriber{Conn: peerConn},
+			effectPeerClientEndpointChanged{},
+		}).withOutcome(handshakeAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("syncing replacement connection with equal frontier becomes established slave", func(t *testing.T) {
+		localNode, cpNode := nodeB, nodeA
+		active := testSession(cpNode, localNode)
+		replacement := testSession(cpNode, cpNode)
+		initial := nodeState{
+			mode:       modeEstablishedSlaveSyncing,
+			activeConn: active,
+		}
+		signal := testHandshakeResolvedSignal(replacement, roleMaster, progressEqual)
+		want := handledResult(nodeState{
+			mode:       modeEstablishedSlave,
+			activeConn: replacement,
+		}, []effect{
+			effectDisconnect{Conn: active},
+			effectWatchConn{Conn: replacement},
+			effectStartSubscriber{Conn: replacement},
+			effectPeerClientEndpointChanged{},
+			effectStartupResolved{},
+		}).withOutcome(handshakeAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("established master peer ahead halts", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedMaster}
+		signal := testHandshakeResolvedSignal(peerConn, roleSlave, progressPeerAhead)
+		want := handledResult(nodeState{
+			mode:    modeHalted,
+			haltErr: fmt.Errorf("halting after handshake: local role master, peer %s role slave, progress peer_ahead", cpNode),
+		}, []effect{
+			effectDisconnect{Conn: peerConn},
+			effectHalt{},
+		}).withOutcome(handshakeHalted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("diverged handshake halts", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePending}
+		signal := testHandshakeResolvedSignal(peerConn, roleSlave, progressDiverged)
+		want := handledResult(nodeState{
+			mode: modeHalted,
+			haltErr: fmt.Errorf("MESH FORK DETECTED: halting after handshake, event logs diverged "+
+				"(local role unknown frontier Position{seq=41 hash=deadbeef010203040506}, peer %s role slave frontier Position{seq=44 hash=feedface0a0b0c0d0e0f})", cpNode),
+		}, []effect{
+			effectDisconnect{Conn: peerConn},
+			effectHalt{},
+		}).withOutcome(handshakeHalted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("diverged startup join against serving master halts with reset token", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePending}
+		signal := testHandshakeResolvedSignal(peerConn, roleMaster, progressDiverged)
+		want := handledResult(nodeState{
+			mode: modeHalted,
+			haltErr: fmt.Errorf("MESH FORK DETECTED: halting after handshake, event logs diverged "+
+				"(local role unknown frontier Position{seq=41 hash=deadbeef010203040506}, peer %s role master frontier Position{seq=44 hash=feedface0a0b0c0d0e0f})"+
+				"; this node holds committed events the serving master never received. "+
+				"Back up the database for audit (pg_dump), then restart with --meshforkreset=41:deadbeef01020304 "+
+				"to wipe and resync from the master", cpNode),
+		}, []effect{
+			effectDisconnect{Conn: peerConn},
+			effectHalt{},
+		}).withOutcome(handshakeHalted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("serving master rejects diverged non-master join and keeps serving", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedMaster}
+		signal := testHandshakeResolvedSignal(peerConn, roleUnknown, progressDiverged)
+		want := handledResult(nodeState{
+			mode: modeEstablishedMaster,
+		}, []effect{
+			effectDisconnect{Conn: peerConn},
+		}).withOutcome(handshakeDivergedJoinRejected)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("preparing master rejects diverged slave join and keeps preparing", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePreparingMaster}
+		signal := testHandshakeResolvedSignal(peerConn, roleSlave, progressDiverged)
+		want := handledResult(nodeState{
+			mode: modePreparingMaster,
+		}, []effect{
+			effectDisconnect{Conn: peerConn},
+		}).withOutcome(handshakeDivergedJoinRejected)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("symmetric fork master versus master still halts", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedMaster}
+		signal := testHandshakeResolvedSignal(peerConn, roleMaster, progressDiverged)
+		want := handledResult(nodeState{
+			mode: modeHalted,
+			haltErr: fmt.Errorf("MESH FORK DETECTED: halting after handshake, event logs diverged "+
+				"(local role master frontier Position{seq=41 hash=deadbeef010203040506}, peer %s role master frontier Position{seq=44 hash=feedface0a0b0c0d0e0f})", cpNode),
+		}, []effect{
+			effectDisconnect{Conn: peerConn},
+			effectHalt{},
+		}).withOutcome(handshakeHalted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("equal master master halts", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedMaster}
+		signal := testHandshakeResolvedSignal(peerConn, roleMaster, progressEqual)
+		want := handledResult(nodeState{
+			mode:    modeHalted,
+			haltErr: fmt.Errorf("halting after handshake: local role master, peer %s role master, progress equal", cpNode),
+		}, []effect{
+			effectDisconnect{Conn: peerConn},
+			effectHalt{},
+		}).withOutcome(handshakeHalted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("slave rejoins behind an established master", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		peerConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedMaster, peerDisconnected: at}
+		signal := testHandshakeResolvedSignal(peerConn, roleSlave, progressLocalAhead)
+		want := handledResult(nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: peerConn,
+		}, []effect{
+			effectWatchConn{Conn: peerConn},
+			effectPeerClientEndpointChanged{},
+		}).withOutcome(handshakeAdopted)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+}
+
+func TestReduceStreamProgress(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	const nodeB = "node-b"
+	t.Run("stream caught up establishes slave", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		streamConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedSlaveSyncing, activeConn: streamConn}
+		signal := streamCaughtUpSignal{conn: streamConn, target: &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)}}
+		want := handledResult(nodeState{
+			mode:       modeEstablishedSlave,
+			activeConn: streamConn,
+		}, []effect{effectStartupResolved{}})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("master stream failure disconnects peer and remains master", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		streamConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedMaster, activeConn: streamConn}
+		signal := streamFailedSignal{conn: streamConn, err: errors.New("boom"), at: at}
+		want := handledResult(nodeState{
+			mode:             modeEstablishedMaster,
+			peerDisconnected: at,
+		}, []effect{effectDisconnect{Conn: streamConn}})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("stale stream caught up ignored", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		streamConn := testSession(cpNode, localNode)
+		staleConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedSlaveSyncing, activeConn: streamConn}
+		signal := streamCaughtUpSignal{conn: staleConn, target: &db.EventLogPosition{Seq: 2, TipHash: testTipHash(2)}}
+		want := ignoredResult(nodeState{
+			mode:       modeEstablishedSlaveSyncing,
+			activeConn: streamConn,
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("stale stream failure ignored", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		streamConn := testSession(cpNode, localNode)
+		staleConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedMaster, activeConn: streamConn}
+		signal := streamFailedSignal{conn: staleConn, err: errors.New("boom"), at: at}
+		want := ignoredResult(nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: streamConn,
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+}
+
+func TestReduceDisconnect(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	const nodeB = "node-b"
+	t.Run("disconnect during stream sync returns pending", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		streamConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedSlaveSyncing, activeConn: streamConn}
+		signal := connectionDisconnectedSignal{conn: streamConn, at: at}
+		want := handledResult(nodeState{
+			mode:             modePending,
+			peerDisconnected: at,
+		}, []effect{effectStopEventStream{Conn: streamConn}})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("slave disconnect enters slave without master", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		slaveConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedSlave, activeConn: slaveConn}
+		signal := connectionDisconnectedSignal{conn: slaveConn, at: at}
+		want := handledResult(nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: at,
+		}, []effect{
+			effectStopEventStream{Conn: slaveConn},
+			effectScheduleSlavePromotionCheck{},
+			effectFailPendingCommands{Reason: "mesh slave lost its master connection"},
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("established master keeps its mode on disconnect", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		activeConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedMaster, activeConn: activeConn}
+		signal := connectionDisconnectedSignal{conn: activeConn, at: at}
+		want := handledResult(nodeState{
+			mode:             modeEstablishedMaster,
+			peerDisconnected: at,
+		}, []effect{effectStopEventStream{Conn: activeConn}})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("preparing master keeps its mode on disconnect", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		activeConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePreparingMaster, activeConn: activeConn}
+		signal := connectionDisconnectedSignal{conn: activeConn, at: at}
+		want := handledResult(nodeState{
+			mode:             modePreparingMaster,
+			peerDisconnected: at,
+		}, []effect{effectStopEventStream{Conn: activeConn}})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+}
+
+func TestReduceSlavePromotion(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	t.Run("promotion delay starts master preparation", func(t *testing.T) {
+		localNode := nodeA
+		initial := nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: at,
+		}
+		signal := slavePromotionCheckSignal{at: at.Add(defaultSlavePromotionDelay)}
+		want := handledResult(nodeState{
+			mode: modePreparingMaster,
+		}, []effect{
+			effectBecameMaster{},
+			effectFailPendingCommands{Reason: "node promoted to mesh master"},
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("slave promotion check ignored before delay elapses", func(t *testing.T) {
+		localNode := nodeA
+		initial := nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: at,
+		}
+		signal := slavePromotionCheckSignal{at: at.Add(defaultSlavePromotionDelay - time.Millisecond)}
+		want := ignoredResult(nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: at,
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("stale slave promotion check ignored after newer disconnect", func(t *testing.T) {
+		localNode := nodeA
+		newerDisconnect := at.Add(time.Second)
+		initial := nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: newerDisconnect,
+		}
+		signal := slavePromotionCheckSignal{at: at.Add(defaultSlavePromotionDelay)}
+		want := ignoredResult(nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: newerDisconnect,
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("master evidence restarts the promotion window", func(t *testing.T) {
+		localNode := nodeA
+		evidenceAt := at.Add(10 * time.Second)
+		initial := nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: at,
+		}
+		signal := masterEvidenceSignal{at: evidenceAt}
+		want := handledResult(nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: evidenceAt,
+		}, []effect{
+			effectScheduleSlavePromotionCheck{},
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("stale master evidence ignored", func(t *testing.T) {
+		localNode := nodeA
+		initial := nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: at,
+		}
+		signal := masterEvidenceSignal{at: at}
+		want := ignoredResult(nodeState{
+			mode:             modeSlaveNoMaster,
+			peerDisconnected: at,
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("master evidence ignored outside slave-no-master", func(t *testing.T) {
+		localNode := nodeA
+		initial := nodeState{mode: modePending}
+		signal := masterEvidenceSignal{at: at.Add(10 * time.Second)}
+		want := ignoredResult(nodeState{mode: modePending})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+}
+
+func TestReduceMasterHandoff(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	const nodeB = "node-b"
+	t.Run("planned handoff promotes caught-up slave immediately", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		active := testSession(cpNode, localNode)
+		local := &db.EventLogPosition{Seq: 5, TipHash: testTipHash(5)}
+		target := &db.EventLogPosition{Seq: 5, TipHash: testTipHash(5)}
+		initial := nodeState{mode: modeEstablishedSlave, activeConn: active}
+		signal := plannedHandoffSignal{conn: active, local: local, target: target, at: at}
+		want := handledResult(nodeState{
+			mode:       modePreparingMaster,
+			activeConn: active,
+		}, []effect{
+			effectBecameMaster{},
+			effectFailPendingCommands{Reason: "node promoted to mesh master"},
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("planned handoff promotes durably caught-up syncing slave", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		active := testSession(cpNode, localNode)
+		local := &db.EventLogPosition{Seq: 5, TipHash: testTipHash(5)}
+		target := &db.EventLogPosition{Seq: 5, TipHash: testTipHash(5)}
+		initial := nodeState{mode: modeEstablishedSlaveSyncing, activeConn: active}
+		signal := plannedHandoffSignal{conn: active, local: local, target: target, at: at}
+		want := handledResult(nodeState{
+			mode:       modePreparingMaster,
+			activeConn: active,
+		}, []effect{
+			effectBecameMaster{},
+			effectFailPendingCommands{Reason: "node promoted to mesh master"},
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("planned handoff halts on behind frontier", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		active := testSession(cpNode, localNode)
+		local := &db.EventLogPosition{Seq: 4, TipHash: testTipHash(4)}
+		target := &db.EventLogPosition{Seq: 5, TipHash: testTipHash(5)}
+		haltErr := fmt.Errorf("planned handoff frontier mismatch (local %s, master %s)", local, target)
+		initial := nodeState{mode: modeEstablishedSlave, activeConn: active}
+		signal := plannedHandoffSignal{conn: active, local: local, target: target, at: at}
+		want := handledResult(nodeState{
+			mode:             modeHalted,
+			peerDisconnected: at,
+			haltErr:          haltErr,
+		}, []effect{
+			effectDisconnect{Conn: active},
+			effectHalt{},
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("planned handoff halts on conflicting frontier", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		active := testSession(cpNode, localNode)
+		local := &db.EventLogPosition{Seq: 5, TipHash: testTipHash(5)}
+		target := &db.EventLogPosition{Seq: 5, TipHash: testTipHash(6)}
+		haltErr := fmt.Errorf("planned handoff frontier mismatch (local %s, master %s)", local, target)
+		initial := nodeState{mode: modeEstablishedSlave, activeConn: active}
+		signal := plannedHandoffSignal{conn: active, local: local, target: target, at: at}
+		want := handledResult(nodeState{
+			mode:             modeHalted,
+			peerDisconnected: at,
+			haltErr:          haltErr,
+		}, []effect{
+			effectDisconnect{Conn: active},
+			effectHalt{},
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("planned handoff from stale connection is ignored", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		active := testSession(cpNode, localNode)
+		stale := testSession(cpNode, localNode)
+		state := nodeState{mode: modeEstablishedSlave, activeConn: active}
+		frontier := &db.EventLogPosition{Seq: 5, TipHash: testTipHash(5)}
+		initial := state
+		signal := plannedHandoffSignal{
+			conn: stale, local: frontier, target: frontier, at: at,
+		}
+		want := ignoredResult(state)
+		requireTransition(t, localNode, initial, signal, want)
+	})
+}
+
+func TestReduceMasterReadiness(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	const nodeB = "node-b"
+	t.Run("master ready establishes master and starts no stream", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		slaveConn := testSession(cpNode, localNode)
+		initial := nodeState{
+			mode:       modePreparingMaster,
+			activeConn: slaveConn,
+		}
+		signal := masterReadySignal{}
+		want := handledResult(nodeState{
+			mode:       modeEstablishedMaster,
+			activeConn: slaveConn,
+		}, []effect{
+			effectStartupResolved{},
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("master preparation failure halts authoritative master", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		slaveConn := testSession(cpNode, localNode)
+		prepErr := errors.New("market startup cleanup failed")
+		initial := nodeState{
+			mode:       modePreparingMaster,
+			activeConn: slaveConn,
+		}
+		signal := masterPreparationFailedSignal{err: prepErr, at: at}
+		want := handledResult(nodeState{
+			mode:             modeHalted,
+			peerDisconnected: at,
+			haltErr:          prepErr,
+		}, []effect{
+			effectDisconnect{Conn: slaveConn},
+			effectHalt{},
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+}
+
+func TestReduceDialIncompatibility(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	const nodeB = "node-b"
+	t.Run("startup incompatibility halts and disconnects", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		incompatConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePending, activeConn: incompatConn}
+		signal := dialIncompatibleSignal{err: errors.New("boom"), at: at}
+		want := handledResult(nodeState{
+			mode:             modeHalted,
+			peerDisconnected: at,
+			haltErr:          errors.New("boom"),
+		}, []effect{effectDisconnect{Conn: incompatConn}, effectHalt{}})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("startup incompatibility without conn halts", func(t *testing.T) {
+		localNode := nodeA
+		initial := nodeState{mode: modePending}
+		signal := dialIncompatibleSignal{err: errors.New("boom"), at: at}
+		want := handledResult(nodeState{
+			mode:    modeHalted,
+			haltErr: errors.New("boom"),
+		}, []effect{effectHalt{}})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("preparing master dial incompatibility keeps active conn", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		activeConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modePreparingMaster, activeConn: activeConn}
+		signal := dialIncompatibleSignal{err: errors.New("boom"), at: at}
+		want := ignoredResult(nodeState{
+			mode:       modePreparingMaster,
+			activeConn: activeConn,
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("slave-no-master incompatibility ignored", func(t *testing.T) {
+		localNode := nodeA
+		initial := nodeState{mode: modeSlaveNoMaster, peerDisconnected: at}
+		signal := dialIncompatibleSignal{err: errors.New("boom"), at: at}
+		want := ignoredResult(nodeState{mode: modeSlaveNoMaster, peerDisconnected: at})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+}
+
+func TestReduceSubscribeRejection(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	const nodeB = "node-b"
+	t.Run("subscribe rejected from replaced conn ignored", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		activeConn := testSession(cpNode, localNode)
+		staleConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedSlaveSyncing, activeConn: activeConn}
+		signal := subscribeRejectedSignal{conn: staleConn, err: errors.New("boom"), at: at}
+		want := ignoredResult(nodeState{
+			mode:       modeEstablishedSlaveSyncing,
+			activeConn: activeConn,
+		})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("subscribe rejected from active conn halts", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		activeConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedSlaveSyncing, activeConn: activeConn}
+		signal := subscribeRejectedSignal{conn: activeConn, err: errors.New("boom"), at: at}
+		want := handledResult(nodeState{
+			mode:             modeHalted,
+			peerDisconnected: at,
+			haltErr:          errors.New("boom"),
+		}, []effect{effectDisconnect{Conn: activeConn}, effectHalt{}})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+}
+
+func TestReduceTerminalApplyFailure(t *testing.T) {
+	at := time.Unix(1700000000, 0)
+	const nodeA = "node-a"
+	const nodeB = "node-b"
+	t.Run("terminal apply failure halts and disconnects the active conn", func(t *testing.T) {
+		localNode, cpNode := nodeA, nodeB
+		activeConn := testSession(cpNode, localNode)
+		initial := nodeState{mode: modeEstablishedMaster, activeConn: activeConn}
+		signal := terminalApplyFailureSignal{err: errors.New("boom"), at: at}
+		want := handledResult(nodeState{
+			mode:             modeHalted,
+			peerDisconnected: at,
+			haltErr:          errors.New("boom"),
+		}, []effect{effectDisconnect{Conn: activeConn}, effectHalt{}})
+		requireTransition(t, localNode, initial, signal, want)
+	})
+
+	t.Run("terminal apply failure halts without a conn", func(t *testing.T) {
+		initial := nodeState{mode: modePending}
+		signal := terminalApplyFailureSignal{err: errors.New("boom"), at: at}
+		want := handledResult(nodeState{
+			mode:    modeHalted,
+			haltErr: errors.New("boom"),
+		}, []effect{effectHalt{}})
+		requireTransition(t, nodeA, initial, signal, want)
+	})
+
+	t.Run("terminal apply failure ignored when already halted", func(t *testing.T) {
+		halted := nodeState{mode: modeHalted, haltErr: errors.New("first")}
+		initial := halted
+		signal := terminalApplyFailureSignal{err: errors.New("second"), at: at}
+		want := ignoredResult(halted)
+		requireTransition(t, nodeA, initial, signal, want)
+	})
+}
+
+func TestReduceStreamSubscribe(t *testing.T) {
+	frontier := &db.EventLogPosition{Seq: 4, TipHash: testTipHash(4)}
+	conn := testSession("node-b", "node-a")
+
+	tests := []struct {
+		name      string
+		mode      nodeMode
+		connID    uint64
+		wantStart bool
+	}{
+		{"established master starts stream", modeEstablishedMaster, conn.ID(), true},
+		{"preparing master rejects retryably", modePreparingMaster, conn.ID(), false},
+		{"slave ignores", modeEstablishedSlave, conn.ID(), false},
+		{"pending ignores", modePending, conn.ID(), false},
+		{"non-active conn ignores", modeEstablishedMaster, conn.ID() + 1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cur := nodeState{mode: tt.mode, activeConn: conn}
+			result, err := reduceSignal("node-a", defaultSlavePromotionDelay, cur,
+				streamSubscribeSignal{connID: tt.connID, frontier: frontier})
+			if err != nil {
+				t.Fatalf("reduce error: %v", err)
+			}
+			if result.handled != tt.wantStart {
+				t.Fatalf("handled = %t, want %t", result.handled, tt.wantStart)
+			}
+			var started *effectStartEventStream
+			for _, eff := range result.effects {
+				if start, ok := eff.(effectStartEventStream); ok {
+					started = &start
+				}
+			}
+			if (started != nil) != tt.wantStart {
+				t.Fatalf("stream start = %v, want %t", started, tt.wantStart)
+			}
+			if started != nil {
+				if started.SlaveFrontier.Seq != frontier.Seq {
+					t.Fatalf("start effect = %+v, want subscribe frontier %d", started, frontier.Seq)
+				}
+			}
+		})
+	}
+}
+
+func TestReduceSnapshotRequest(t *testing.T) {
+	conn := testSession("node-b", "node-a")
+
+	tests := []struct {
+		name      string
+		mode      nodeMode
+		connID    uint64
+		wantStart bool
+	}{
+		{"established master starts send", modeEstablishedMaster, conn.ID(), true},
+		{"preparing master rejects retryably", modePreparingMaster, conn.ID(), false},
+		{"non-active conn ignores", modeEstablishedMaster, conn.ID() + 1, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cur := nodeState{mode: tt.mode, activeConn: conn}
+			result, err := reduceSignal("node-a", defaultSlavePromotionDelay, cur,
+				snapshotRequestSignal{connID: tt.connID})
+			if err != nil {
+				t.Fatalf("reduce error: %v", err)
+			}
+			if result.handled != tt.wantStart {
+				t.Fatalf("handled = %t, want %t", result.handled, tt.wantStart)
+			}
+			var started bool
+			for _, eff := range result.effects {
+				if _, ok := eff.(effectStartSnapshotSend); ok {
+					started = true
+				}
+			}
+			if started != tt.wantStart {
+				t.Fatalf("snapshot send start = %t, want %t", started, tt.wantStart)
+			}
+		})
+	}
+}

--- a/server/mesh/reducer_test.go
+++ b/server/mesh/reducer_test.go
@@ -830,6 +830,26 @@ func TestReduceTerminalApplyFailure(t *testing.T) {
 	})
 }
 
+// TestHelloFrontierIsNotAStreamPosition checks that handshake adoption
+// does not start an event stream.
+func TestHelloFrontierIsNotAStreamPosition(t *testing.T) {
+	conn := testSession("node-b", "node-a")
+	cur := nodeState{mode: modeEstablishedMaster}
+	result, err := reduceSignal("node-a", defaultSlavePromotionDelay, cur,
+		testHandshakeResolvedSignal(conn, roleSlave, progressLocalAhead))
+	if err != nil {
+		t.Fatalf("reduce error: %v", err)
+	}
+	if !result.handled {
+		t.Fatal("handshake not handled")
+	}
+	for _, eff := range result.effects {
+		if _, ok := eff.(effectStartEventStream); ok {
+			t.Fatal("adoption started a stream; streaming must be slave-initiated")
+		}
+	}
+}
+
 func TestReduceStreamSubscribe(t *testing.T) {
 	frontier := &db.EventLogPosition{Seq: 4, TipHash: testTipHash(4)}
 	conn := testSession("node-b", "node-a")

--- a/server/mesh/reducer_types.go
+++ b/server/mesh/reducer_types.go
@@ -1,0 +1,359 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"fmt"
+	"time"
+
+	"decred.org/dcrdex/server/db"
+)
+
+// meshSignal is an input to the node's state machine.
+type meshSignal interface {
+	isMeshSignal()
+	String() string
+}
+
+// handshakeResolvedSignal reports a completed handshake with the peer.
+type handshakeResolvedSignal struct {
+	conn          *nodeConn
+	peerRole      helloRole
+	progress      progressState
+	localFrontier *db.EventLogPosition
+	peerFrontier  *db.EventLogPosition
+	clientHost    string
+	clientCert    []byte
+	at            time.Time
+}
+
+func (handshakeResolvedSignal) isMeshSignal() {}
+
+func (ev handshakeResolvedSignal) String() string {
+	return fmt.Sprintf("handshakeResolved(conn=%s peerRole=%s progress=%s at=%s)",
+		ev.conn, ev.peerRole, ev.progress, formatLogTime(ev.at))
+}
+
+// connectionDisconnectedSignal reports that the connection to the peer has been
+// disconnected.
+type connectionDisconnectedSignal struct {
+	conn *nodeConn
+	at   time.Time
+}
+
+func (connectionDisconnectedSignal) isMeshSignal() {}
+
+func (ev connectionDisconnectedSignal) String() string {
+	return fmt.Sprintf("connectionDisconnected(conn=%s at=%s)",
+		ev.conn, formatLogTime(ev.at))
+}
+
+// terminalApplyFailureSignal reports that this node can no longer be trusted
+// to match the event log, so it should halt.
+type terminalApplyFailureSignal struct {
+	err error
+	at  time.Time
+}
+
+func (terminalApplyFailureSignal) isMeshSignal() {}
+
+func (ev terminalApplyFailureSignal) String() string {
+	return fmt.Sprintf("terminalEventApplyFailure(at=%s err=%v)",
+		formatLogTime(ev.at), ev.err)
+}
+
+// streamCaughtUpSignal is only used on the slave, to report that the slave
+// has caught up to the master's tip. target is the position reached. It is
+// for logging only.
+type streamCaughtUpSignal struct {
+	conn   *nodeConn
+	target *db.EventLogPosition
+}
+
+func (streamCaughtUpSignal) isMeshSignal() {}
+
+func (ev streamCaughtUpSignal) String() string {
+	return fmt.Sprintf("streamCaughtUp(conn=%s target=%s)", ev.conn, ev.target)
+}
+
+// streamFailedSignal is posted on the master to report that the event stream
+// failed.
+type streamFailedSignal struct {
+	conn *nodeConn
+	err  error
+	at   time.Time
+}
+
+func (streamFailedSignal) isMeshSignal() {}
+
+func (ev streamFailedSignal) String() string {
+	return fmt.Sprintf("streamFailed(conn=%s at=%s err=%v)",
+		ev.conn, formatLogTime(ev.at), ev.err)
+}
+
+// slavePromotionCheckSignal fires slavePromotionDelay after a slave lost its
+// master. If the slave is still without a master and the full delay has
+// passed since the disconnect, it promotes itself.
+type slavePromotionCheckSignal struct {
+	at time.Time
+}
+
+func (slavePromotionCheckSignal) isMeshSignal() {}
+
+func (ev slavePromotionCheckSignal) String() string {
+	return fmt.Sprintf("slavePromotionCheck(at=%s)",
+		formatLogTime(ev.at))
+}
+
+// plannedHandoffSignal is posted by the slave after the master sends a
+// masterHandoff message. If the master's tip is equal to the local tip,
+// the slave will immediately promote itself, otherwise the node will halt.
+type plannedHandoffSignal struct {
+	conn   *nodeConn
+	local  *db.EventLogPosition
+	target *db.EventLogPosition
+	at     time.Time
+}
+
+func (plannedHandoffSignal) isMeshSignal() {}
+
+func (ev plannedHandoffSignal) String() string {
+	return fmt.Sprintf("plannedHandoff(conn=%s local=%s target=%s at=%s)",
+		ev.conn, ev.local, ev.target, formatLogTime(ev.at))
+}
+
+// masterEvidenceSignal is sent when we have proof that the master is alive.
+// The slave must not promote.
+type masterEvidenceSignal struct {
+	at time.Time
+}
+
+func (masterEvidenceSignal) isMeshSignal() {}
+
+func (ev masterEvidenceSignal) String() string {
+	return fmt.Sprintf("masterEvidence(at=%s)", formatLogTime(ev.at))
+}
+
+// dialIncompatibleSignal reports that the peer refused our dial for a reason
+// that retrying cannot fix. Only a pending node acts on it, by halting.
+// A node that already has a role keeps running, because it means that a
+// successful handshake happened in the past, and the incompatibility is due
+// to the peer restarting.
+type dialIncompatibleSignal struct {
+	err error
+	at  time.Time
+}
+
+func (dialIncompatibleSignal) isMeshSignal() {}
+
+func (ev dialIncompatibleSignal) String() string {
+	return fmt.Sprintf("dialIncompatible(at=%s err=%v)", formatLogTime(ev.at), ev.err)
+}
+
+// subscribeRejectedSignal reports that the master refused to stream events
+// from this slave's position, and retrying cannot help. The slave's event
+// log is ahead of the master's, has diverged from it, or is too old to
+// replay. The slave halts.
+type subscribeRejectedSignal struct {
+	conn *nodeConn
+	err  error
+	at   time.Time
+}
+
+func (subscribeRejectedSignal) isMeshSignal() {}
+
+func (ev subscribeRejectedSignal) String() string {
+	return fmt.Sprintf("subscribeRejected(at=%s conn=%s err=%v)",
+		formatLogTime(ev.at), ev.conn, ev.err)
+}
+
+// streamSubscribeSignal carries a validated stream_subscribe from the route
+// handler into the reducer, which does the active-conn and mode checks
+// atomically with state.
+type streamSubscribeSignal struct {
+	connID   uint64
+	frontier *db.EventLogPosition
+}
+
+func (streamSubscribeSignal) isMeshSignal() {}
+
+func (ev streamSubscribeSignal) String() string {
+	return fmt.Sprintf("streamSubscribe(connID=%d frontier=%s)", ev.connID, ev.frontier)
+}
+
+// snapshotRequestSignal reports that the peer requested a snapshot of this
+// node's state. If this node is the established master and the request
+// came over the active connection, it starts sending the snapshot.
+type snapshotRequestSignal struct {
+	connID uint64
+}
+
+func (snapshotRequestSignal) isMeshSignal() {}
+
+func (ev snapshotRequestSignal) String() string {
+	return fmt.Sprintf("snapshotRequest(connID=%d)", ev.connID)
+}
+
+// masterReadySignal reports that the master workers have started and the
+// node can serve as master. It moves the node from preparing master to
+// established master.
+type masterReadySignal struct{}
+
+func (masterReadySignal) isMeshSignal() {}
+
+func (masterReadySignal) String() string {
+	return "masterReady"
+}
+
+// masterPreparationFailedSignal reports that master preparation failed. The
+// state loaders or a master worker failed to start. The node cannot serve as
+// master without them, so it halts.
+type masterPreparationFailedSignal struct {
+	err error
+	at  time.Time
+}
+
+func (masterPreparationFailedSignal) isMeshSignal() {}
+
+func (ev masterPreparationFailedSignal) String() string {
+	return fmt.Sprintf("masterPreparationFailed(at=%s err=%v)",
+		formatLogTime(ev.at), ev.err)
+}
+
+// signalOutcome is an optional result that says how a signal was resolved.
+// Each kind of signal defines its own.
+type signalOutcome interface {
+	isSignalOutcome()
+}
+
+// handshakeOutcome is how onHandshakeResolved resolved a handshake.
+type handshakeOutcome uint8
+
+const (
+	// handshakeAdopted means the connection is now the active peer connection.
+	handshakeAdopted handshakeOutcome = iota
+	// handshakeNotAdopted means the handshake was fine, but an existing
+	// session with this peer kept precedence.
+	handshakeNotAdopted
+	// handshakeDivergedJoinRejected means a serving master rejected a diverged
+	// join from a peer that is not master, and keeps serving unchanged.
+	handshakeDivergedJoinRejected
+	// handshakeHalted means the node is halted, either from before this signal
+	// or because this handshake detected a fork. nodeState.haltErr has the
+	// cause.
+	handshakeHalted
+)
+
+func (handshakeOutcome) isSignalOutcome() {}
+
+func (o handshakeOutcome) String() string {
+	switch o {
+	case handshakeAdopted:
+		return "adopted"
+	case handshakeNotAdopted:
+		return "not_adopted"
+	case handshakeDivergedJoinRejected:
+		return "diverged_join_rejected"
+	case handshakeHalted:
+		return "halted"
+	default:
+		return fmt.Sprintf("handshakeOutcome(%d)", uint8(o))
+	}
+}
+
+// effect is an action for the caller to perform after a state change.
+type effect interface {
+	isEffect()
+}
+
+// effectDisconnect closes the connection, and stops any event stream or
+// snapshot send to it.
+type effectDisconnect struct {
+	Conn *nodeConn
+}
+
+func (effectDisconnect) isEffect() {}
+
+// effectStopEventStream stops any event stream or snapshot send to the
+// connection, without closing it.
+type effectStopEventStream struct {
+	Conn *nodeConn
+}
+
+func (effectStopEventStream) isEffect() {}
+
+// effectWatchConn starts watching an adopted connection. A
+// connectionDisconnectedSignal is posted when it closes, and the master
+// disconnects it if the slave does not subscribe within subscribeTimeout.
+type effectWatchConn struct {
+	Conn *nodeConn
+}
+
+func (effectWatchConn) isEffect() {}
+
+// effectStartSubscriber starts the slave's subscriber, which subscribes to
+// the master's event stream over the connection.
+type effectStartSubscriber struct {
+	Conn *nodeConn
+}
+
+func (effectStartSubscriber) isEffect() {}
+
+// effectStartEventStream starts streaming events to the slave, from the
+// entry after SlaveFrontier.
+type effectStartEventStream struct {
+	Conn          *nodeConn
+	SlaveFrontier *db.EventLogPosition
+}
+
+func (effectStartEventStream) isEffect() {}
+
+// effectStartSnapshotSend starts sending a snapshot of this node's state to
+// the slave.
+type effectStartSnapshotSend struct {
+	Conn *nodeConn
+}
+
+func (effectStartSnapshotSend) isEffect() {}
+
+// effectScheduleSlavePromotionCheck starts the timer that posts a
+// slavePromotionCheckSignal after slavePromotionDelay.
+type effectScheduleSlavePromotionCheck struct{}
+
+func (effectScheduleSlavePromotionCheck) isEffect() {}
+
+// effectBecameMaster reports that the node became the preparing master. It
+// starts the master workers. The node becomes the established master once
+// they are ready.
+type effectBecameMaster struct{}
+
+func (effectBecameMaster) isEffect() {}
+
+// effectStartupResolved reports that the node is established as master or
+// slave, so node startup is complete.
+type effectStartupResolved struct{}
+
+func (effectStartupResolved) isEffect() {}
+
+// effectHalt stops the node. nodeState.haltErr is the reason.
+type effectHalt struct{}
+
+func (effectHalt) isEffect() {}
+
+// effectFailPendingCommands answers pending forwarded commands with
+// ResultUnavailableError.
+type effectFailPendingCommands struct {
+	Reason string
+}
+
+func (effectFailPendingCommands) isEffect() {}
+
+// effectPeerClientEndpointChanged reports the peer's client endpoint, as
+// learned in the handshake, so it can be advertised to clients for failover.
+type effectPeerClientEndpointChanged struct {
+	Host string
+	Cert []byte
+}
+
+func (effectPeerClientEndpointChanged) isEffect() {}

--- a/server/mesh/routes.go
+++ b/server/mesh/routes.go
@@ -4,10 +4,12 @@
 package mesh
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/db"
 )
 
 // link is a connection to the peer, as the routes and the handshake use it.
@@ -167,6 +169,29 @@ func (n *node) handleDecision(ctx context.Context, conn link, msg *msgjson.Messa
 	return n.handshakes.handleDecision(ctx, conn, msg.ID, decision)
 }
 
+// handleEventEnvelope applies a batch of streamed events from the master in
+// order. It answers with an eventAck after every entry was applied, or with
+// an error at the first entry that failed to apply.
+func (n *node) handleEventEnvelope(ctx context.Context, conn link, peerConn *nodeConn, msg *msgjson.Message) *msgjson.Error {
+	batch, msgErr := decodeRoutePayload(msg, "event batch", validateEventBatch)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	if !n.eventsGateOpen() {
+		return msgjson.NewError(msgjson.RPCInternal,
+			"event envelope before this node was ready for events")
+	}
+
+	for _, entry := range batch.Entries {
+		if err := n.applyInboundEventEnvelope(peerConn, entry); err != nil {
+			return msgjson.NewError(msgjson.RPCInternal, "event apply failed: %v", err)
+		}
+	}
+
+	return sendRouteResponse(conn, msg.ID, &eventAck{}, "event")
+}
+
 // requestServe sends sig to the state machine and reports whether the
 // signal has been handled. TryAgainLater is returned if the node is not
 // in the correct mode to handle the signal.
@@ -183,6 +208,121 @@ func (n *node) requestServe(sig meshSignal, routeName string) *msgjson.Error {
 			"%s: this node is not the established master on this connection (mode %s)", routeName, res.state.mode)
 	}
 	return nil
+}
+
+// handleStreamSubscribe answers a subscription to the event stream. It first
+// checks the slave's frontier against the log. Then the state machine starts
+// the stream, and the response carries this node's current tip.
+func (n *node) handleStreamSubscribe(ctx context.Context, conn link, msg *msgjson.Message) *msgjson.Error {
+	sub, msgErr := decodeRoutePayload(msg, "stream subscribe", validateStreamSubscribe)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	frontier := fromFrontierMessage(sub.Frontier)
+
+	if msgErr := n.validateSubscribeAgainstLog(ctx, frontier); msgErr != nil {
+		if msgErr.Code == msgjson.SubscribeRejectedError {
+			n.log.Warnf("Rejecting stream subscription from %s: %v", conn.Addr(), msgErr)
+		}
+		return msgErr
+	}
+
+	sig := streamSubscribeSignal{connID: conn.ID(), frontier: frontier}
+	if msgErr := n.requestServe(sig, "stream subscribe"); msgErr != nil {
+		return msgErr
+	}
+
+	// The stream is started. Tell the slave where this node's log ends.
+	local, err := n.eventLogReader.EventLogFrontier(ctx)
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCInternal, "event log frontier: %v", err)
+	}
+
+	return sendRouteResponse(conn, msg.ID, &streamSubscribeResult{MasterTip: local.Seq}, "stream subscribe")
+}
+
+// validateSubscribeAgainstLog checks that this node's log can serve the event
+// stream from peerFrontier. A SubscribeRejectedError will cause the slave to halt.
+func (n *node) validateSubscribeAgainstLog(ctx context.Context, peerFrontier *db.EventLogPosition) *msgjson.Error {
+	localFrontier, err := n.eventLogReader.EventLogFrontier(ctx)
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCInternal, "event log frontier: %v", err)
+	}
+
+	if peerFrontier.Seq > 0 {
+		return n.validateResumePosition(ctx, peerFrontier, localFrontier)
+	}
+
+	return n.validateFullReplay(ctx, localFrontier)
+}
+
+// validateResumePosition checks that peerFrontier is a position in this
+// node's log with the same tip hash.
+func (n *node) validateResumePosition(ctx context.Context, peerFrontier, localFrontier *db.EventLogPosition) *msgjson.Error {
+	if peerFrontier.Seq > localFrontier.Seq {
+		return msgjson.NewError(msgjson.SubscribeRejectedError,
+			"subscribe frontier %d beyond this node's tip %d", peerFrontier.Seq, localFrontier.Seq)
+	}
+	tipHash := localFrontier.TipHash
+	if peerFrontier.Seq < localFrontier.Seq {
+		entry, err := entryAt(ctx, n.eventLogReader, peerFrontier.Seq)
+		if err != nil {
+			return msgjson.NewError(msgjson.RPCInternal, "event log read: %v", err)
+		}
+		if entry == nil {
+			return msgjson.NewError(msgjson.SubscribeRejectedError,
+				"subscribe frontier %d is not in this node's replayable history", peerFrontier.Seq)
+		}
+		tipHash = entry.TipHash
+	}
+	if !bytes.Equal(tipHash, peerFrontier.TipHash) {
+		return msgjson.NewError(msgjson.SubscribeRejectedError,
+			"subscribe frontier %d tip hash does not match this node's log (diverged)", peerFrontier.Seq)
+	}
+	return nil
+}
+
+// validateFullReplay checks that this node's log can be replayed from the
+// start. The log must be empty, or begin at sequence 1 with a real event. A
+// log that begins at an anchor can only be joined from a snapshot.
+func (n *node) validateFullReplay(ctx context.Context, localFrontier *db.EventLogPosition) *msgjson.Error {
+	if localFrontier.Seq == 0 {
+		return nil
+	}
+	entry, err := entryAt(ctx, n.eventLogReader, 1)
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCInternal, "event log read: %v", err)
+	}
+	if entry == nil {
+		return msgjson.NewError(msgjson.SubscribeRejectedError,
+			"this node's event log does not begin at sequence 1 and its earlier state is "+
+				"not replayable; the peer must seed from a snapshot instead")
+	}
+	if db.IsEventLogAnchorKind(entry.Kind) {
+		return msgjson.NewError(msgjson.SubscribeRejectedError,
+			"this node's event log begins at a %q anchor and its earlier state is not "+
+				"replayable; the peer must seed from a snapshot instead", entry.Kind)
+	}
+	return nil
+}
+
+// entryAt returns the log entry at seq, or nil when the log has none. The
+// entry is missing when it was never written or was pruned behind an anchor.
+// Seq 0 is the empty log and has no entry.
+func entryAt(ctx context.Context, reader db.EventLogReader, seq uint64) (*db.EventLogEntry, error) {
+	if seq == 0 {
+		return nil, nil
+	}
+	entries, err := reader.EventLogEntriesAfter(ctx, seq-1, 1)
+	if err != nil {
+		return nil, err
+	}
+	// entries[0].Seq != seq  means the entry was pruned behind an anchor.
+	if len(entries) == 0 || entries[0] == nil || entries[0].Seq != seq {
+		return nil, nil
+	}
+	return entries[0], nil
 }
 
 // handleSnapshotRequest handles a slave's request for a snapshot of the

--- a/server/mesh/routes.go
+++ b/server/mesh/routes.go
@@ -48,3 +48,71 @@ const (
 	snapshotRequestRoute    = "snapshot_request"
 	snapshotChunkRoute      = "snapshot_chunk"
 )
+
+// decodeRoutePayload unmarshals the request payload into a T and validates
+// it, if validate is given. A failure is answered with RPCParseError, and
+// payloadName identifies the payload in that error.
+func decodeRoutePayload[T any](msg *msgjson.Message, payloadName string, validate func(*T) error) (*T, *msgjson.Error) {
+	var payload T
+	if err := msg.Unmarshal(&payload); err != nil {
+		return nil, msgjson.NewError(msgjson.RPCParseError, "error parsing %s", payloadName)
+	}
+	if validate != nil {
+		if err := validate(&payload); err != nil {
+			return nil, msgjson.NewError(msgjson.RPCParseError, "invalid %s: %v", payloadName, err)
+		}
+	}
+	return &payload, nil
+}
+
+// sendRouteReply sends the response to request reqID. The response carries
+// result on success or respErr on failure. If it cannot be encoded or sent,
+// the returned error names the route as routeName.
+func sendRouteReply(conn link, reqID uint64, result any, respErr *msgjson.Error, routeName string) *msgjson.Error {
+	resp, err := msgjson.NewResponse(reqID, result, respErr)
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCInternal, "failed to encode %s response", routeName)
+	}
+	if err := conn.Send(resp); err != nil {
+		return msgjson.NewError(msgjson.RPCInternal, "failed to send %s response", routeName)
+	}
+	return nil
+}
+
+// sendRouteResponse sends result as the response to request reqID.
+func sendRouteResponse(conn link, reqID uint64, result any, routeName string) *msgjson.Error {
+	return sendRouteReply(conn, reqID, result, nil, routeName)
+}
+
+// sendRouteErrorResponse sends respErr as the response to request reqID.
+func sendRouteErrorResponse(conn link, reqID uint64, respErr *msgjson.Error, routeName string) *msgjson.Error {
+	return sendRouteReply(conn, reqID, nil, respErr, routeName)
+}
+
+// sendRouteAck sends an empty response to request reqID.
+func sendRouteAck(conn link, reqID uint64, routeName string) *msgjson.Error {
+	return sendRouteResponse(conn, reqID, struct{}{}, routeName)
+}
+
+// handleHello decodes the peer's hello and passes it to the handshake
+// sessions. A bad payload is answered with a parse error.
+func (n *node) handleHello(ctx context.Context, conn link, msg *msgjson.Message) *msgjson.Error {
+	hello, msgErr := decodeRoutePayload[helloMessage](msg, "mesh hello request", nil)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	return n.handshakes.handleHello(ctx, conn, msg.ID, hello)
+}
+
+// handleDecision completes a handshake that waited for the initiator's
+// decision. It hands the result to the state machine and answers with an
+// ack, or with MeshAlreadyConnectedError when the connection is not adopted.
+func (n *node) handleDecision(ctx context.Context, conn link, msg *msgjson.Message) *msgjson.Error {
+	decision, msgErr := decodeRoutePayload[decisionMessage](msg, "mesh decision request", nil)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	return n.handshakes.handleDecision(ctx, conn, msg.ID, decision)
+}

--- a/server/mesh/routes.go
+++ b/server/mesh/routes.go
@@ -169,6 +169,75 @@ func (n *node) handleDecision(ctx context.Context, conn link, msg *msgjson.Messa
 	return n.handshakes.handleDecision(ctx, conn, msg.ID, decision)
 }
 
+// handleCommandForward accepts a command that the slave forwarded. It checks
+// the payload and runs the command in a new goroutine, which sends the
+// response when the command is finished. A bad payload is refused at once.
+func (n *node) handleCommandForward(_ context.Context, conn link, _ *nodeConn, msg *msgjson.Message) *msgjson.Error {
+	cmd, msgErr := decodeRoutePayload(msg, "forwarded command", validateCommandForward)
+	if msgErr != nil {
+		return msgErr
+	}
+	// The executor can send requests to the slave on this same link, for
+	// example command_result, command_failure or a relayed client message.
+	// This connection's read loop reads their responses. The command must
+	// run off the read loop, or the loop would wait on itself.
+	go n.runForwardedCommand(conn, msg.ID, cmd.CommandID, CommandRequest{
+		Kind: cmd.Kind,
+		User: cmd.User,
+		Msg:  cmd.Msg,
+	})
+
+	return nil
+}
+
+// runForwardedCommand runs a forwarded command and answers the forward
+// request.
+func (n *node) runForwardedCommand(conn link, reqID uint64, commandID string, req CommandRequest) {
+	// The command runs under the node run context. The handler context is
+	// the connection context, and a peer disconnect must not abort a command
+	// in the middle of an apply.
+	//
+	// Errors in the executor are sent as an error response.
+	if msgErr := n.app.executeForwardedCommand(n.runContext, commandID, req); msgErr != nil {
+		if sendErr := sendRouteErrorResponse(conn, reqID, msgErr, "forwarded command"); sendErr != nil {
+			n.log.Debugf("failed to send forwarded command error response: %v", sendErr)
+		}
+		return
+	}
+
+	// Just ack here. The actual response is sent in an event envelope, command_result or
+	// command_failure.
+	if err := sendRouteAck(conn, reqID, "forwarded command"); err != nil {
+		n.log.Debugf("failed to send forwarded command ack: %v", err)
+	}
+}
+
+// handleCommandFailure handles a command_failure sent from the master
+// to the slave. This is an async response to a command_forward.
+func (n *node) handleCommandFailure(_ context.Context, conn link, _ *nodeConn, msg *msgjson.Message) *msgjson.Error {
+	fail, msgErr := decodeRoutePayload(msg, "command failure", validateCommandFailure)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	n.app.receiveCommandFailure(fail.CommandID, fail.Error)
+
+	return sendRouteAck(conn, msg.ID, "command failure")
+}
+
+// handleCommandResult handles a command_result sent from the master to the
+// slave. This is an async response to a command_forward.
+func (n *node) handleCommandResult(_ context.Context, conn link, _ *nodeConn, msg *msgjson.Message) *msgjson.Error {
+	result, msgErr := decodeRoutePayload(msg, "command result", validateCommandResult)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	n.app.receiveCommandResult(result.CommandID, result.Result)
+
+	return sendRouteAck(conn, msg.ID, "command result")
+}
+
 // handleEventEnvelope applies a batch of streamed events from the master in
 // order. It answers with an eventAck after every entry was applied, or with
 // an error at the first entry that failed to apply.

--- a/server/mesh/routes.go
+++ b/server/mesh/routes.go
@@ -1,0 +1,50 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+
+	"decred.org/dcrdex/dex/msgjson"
+)
+
+// link is a connection to the peer, as the routes and the handshake use it.
+// It is implemented by rpcConn, but we use an interface for easier testing.
+type link interface {
+	ID() uint64
+	Addr() string
+	Send(*msgjson.Message) error
+	Request(context.Context, string, any, any) error
+	Authorize()
+	Done() <-chan struct{}
+	Disconnect()
+}
+
+// meshHandler is the function signature for a route handler. A return value
+// that is not nil is sent to the peer as the error response. A nil return
+// means the handler answered itself, will answer later from another
+// goroutine, or closed the connection without an answer.
+type meshHandler func(context.Context, link, *msgjson.Message) *msgjson.Error
+
+// meshRoute is how an incoming message is handled and whether it
+// requires the connection to have completed a handshake.
+type meshRoute struct {
+	handler      meshHandler
+	requiresAuth bool
+}
+
+const (
+	helloRoute              = "mesh_hello"
+	helloDecisionRoute      = "mesh_hello_decision"
+	commandForwardRoute     = "command_forward"
+	commandFailureRoute     = "command_failure"
+	commandResultRoute      = "command_result"
+	clientProxyMessageRoute = "client_proxy_message"
+	clientConnectedRoute    = "client_connected"
+	eventEnvelopeRoute      = "event"
+	streamSubscribeRoute    = "stream_subscribe"
+	masterHandoffRoute      = "master_handoff"
+	snapshotRequestRoute    = "snapshot_request"
+	snapshotChunkRoute      = "snapshot_chunk"
+)

--- a/server/mesh/routes.go
+++ b/server/mesh/routes.go
@@ -6,6 +6,7 @@ package mesh
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"decred.org/dcrdex/dex/msgjson"
@@ -236,6 +237,39 @@ func (n *node) handleCommandResult(_ context.Context, conn link, _ *nodeConn, ms
 	n.app.receiveCommandResult(result.CommandID, result.Result)
 
 	return sendRouteAck(conn, msg.ID, "command result")
+}
+
+// handleClientProxyMessage delivers a client message from the peer to a
+// client on this node, or to all of them for a broadcast.
+// Returns UserNotConnectedError if the client is not connected to this node.
+func (n *node) handleClientProxyMessage(ctx context.Context, conn link, _ *nodeConn, msg *msgjson.Message) *msgjson.Error {
+	req, msgErr := decodeRoutePayload(msg, "client proxy message", validateClientProxyMessage)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	if err := n.app.handleClientProxyMessage(ctx, req); err != nil {
+		if errors.Is(err, ErrClientNotConnected) {
+			return msgjson.NewError(msgjson.UserNotConnectedError, "client proxy message: client not connected")
+		}
+		return msgjson.NewError(msgjson.RPCInternal, "client proxy message: %v", err)
+	}
+
+	return sendRouteAck(conn, msg.ID, "client proxy message")
+}
+
+// handleClientConnected answers a peer's client connected query. The answer
+// is the subset of the queried accounts that have a client connection to
+// this node.
+func (n *node) handleClientConnected(_ context.Context, conn link, _ *nodeConn, msg *msgjson.Message) *msgjson.Error {
+	query, msgErr := decodeRoutePayload(msg, "client connected query", validateClientConnectedQuery)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	result := &clientConnectedResult{Connected: n.app.answerClientConnected(query.Users)}
+
+	return sendRouteResponse(conn, msg.ID, result, "client connected")
 }
 
 // handleEventEnvelope applies a batch of streamed events from the master in

--- a/server/mesh/routes.go
+++ b/server/mesh/routes.go
@@ -49,6 +49,55 @@ const (
 	snapshotChunkRoute      = "snapshot_chunk"
 )
 
+// routes returns the node's route table for incoming messages.
+func (n *node) routes() map[string]meshRoute {
+	if n.routeTable != nil {
+		return n.routeTable
+	}
+	n.routeTable = map[string]meshRoute{
+		helloRoute:              {handler: n.handleHello},
+		helloDecisionRoute:      {handler: n.handleDecision, requiresAuth: true},
+		commandForwardRoute:     n.activePeerRoute(n.handleCommandForward, nodeMode.canExecuteCommands),
+		commandFailureRoute:     n.activePeerRoute(n.handleCommandFailure, nodeMode.canForwardCommands),
+		commandResultRoute:      n.activePeerRoute(n.handleCommandResult, nodeMode.canForwardCommands),
+		clientProxyMessageRoute: n.activePeerRoute(n.handleClientProxyMessage, nodeMode.canRelayClientMessages),
+		clientConnectedRoute:    n.activePeerRoute(n.handleClientConnected, nodeMode.canExchangeClientConnectivity),
+		eventEnvelopeRoute:      n.activePeerRoute(n.handleEventEnvelope, nodeMode.canReceiveEventStream),
+		masterHandoffRoute:      n.activePeerRoute(n.handleMasterHandoff, nodeMode.canAcceptMasterHandoff),
+		snapshotChunkRoute:      n.activePeerRoute(n.handleSnapshotChunk, nodeMode.canReceiveEventStream),
+
+		// stream_subscribe and snapshot_request are gated by the state machine,
+		// not by activePeerRoute. A request that races the master's adoption
+		// of the handshake must get a retryable rejection, not an unauthorized
+		// error.
+		streamSubscribeRoute: {requiresAuth: true, handler: n.handleStreamSubscribe},
+		snapshotRequestRoute: {requiresAuth: true, handler: n.handleSnapshotRequest},
+	}
+	return n.routeTable
+}
+
+// peerMeshHandler is the function signature for a route handler that only the
+// active peer may use.
+type peerMeshHandler func(context.Context, link, *nodeConn, *msgjson.Message) *msgjson.Error
+
+// activePeerRoute wraps a handler in a route that only the active peer may
+// use, and only while allowed reports true for the node's mode. Any other
+// request is refused with UnauthorizedConnection.
+func (n *node) activePeerRoute(handler peerMeshHandler, allowed func(nodeMode) bool) meshRoute {
+	return meshRoute{
+		requiresAuth: true,
+		handler: func(ctx context.Context, conn link, msg *msgjson.Message) *msgjson.Error {
+			state := n.control.currentState()
+			if !allowed(state.mode) || state.activeConn == nil || state.activeConn.link == nil ||
+				state.activeConn.link.ID() != conn.ID() {
+				return msgjson.NewError(msgjson.UnauthorizedConnection,
+					"mesh route requires active peer connection in an allowed local state")
+			}
+			return handler(ctx, conn, state.activeConn, msg)
+		},
+	}
+}
+
 // decodeRoutePayload unmarshals the request payload into a T and validates
 // it, if validate is given. A failure is answered with RPCParseError, and
 // payloadName identifies the payload in that error.

--- a/server/mesh/routes.go
+++ b/server/mesh/routes.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/server/db"
@@ -426,6 +427,42 @@ func entryAt(ctx context.Context, reader db.EventLogReader, seq uint64) (*db.Eve
 		return nil, nil
 	}
 	return entries[0], nil
+}
+
+// handleMasterHandoff handles the master_handoff request sent from the master.
+// The state machine immediately promotes the node if its event log frontier
+// is equal to what was sent in the request.
+func (n *node) handleMasterHandoff(ctx context.Context, conn link, peerConn *nodeConn, msg *msgjson.Message) *msgjson.Error {
+	handoff, msgErr := decodeRoutePayload(msg, "master handoff", validateMasterHandoff)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	local, err := n.eventLogReader.EventLogFrontier(ctx)
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCInternal, "event log frontier: %v", err)
+	}
+	res, err := n.control.send(plannedHandoffSignal{
+		conn:   peerConn,
+		local:  local,
+		target: fromFrontierMessage(handoff.Frontier),
+		at:     time.Now(),
+	})
+	if err == nil {
+		err = res.err
+	}
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCInternal, "master handoff transition: %v", err)
+	}
+	if !res.handled {
+		return msgjson.NewError(msgjson.UnauthorizedConnection,
+			"master handoff refused in state %s", res.state.mode)
+	}
+	if res.state.mode == modeHalted {
+		return msgjson.NewError(msgjson.RPCInternal, "%v", res.state.haltErr)
+	}
+
+	return sendRouteAck(conn, msg.ID, "master handoff")
 }
 
 // handleSnapshotRequest handles a slave's request for a snapshot of the

--- a/server/mesh/routes.go
+++ b/server/mesh/routes.go
@@ -5,6 +5,7 @@ package mesh
 
 import (
 	"context"
+	"fmt"
 
 	"decred.org/dcrdex/dex/msgjson"
 )
@@ -164,4 +165,71 @@ func (n *node) handleDecision(ctx context.Context, conn link, msg *msgjson.Messa
 	}
 
 	return n.handshakes.handleDecision(ctx, conn, msg.ID, decision)
+}
+
+// requestServe sends sig to the state machine and reports whether the
+// signal has been handled. TryAgainLater is returned if the node is not
+// in the correct mode to handle the signal.
+func (n *node) requestServe(sig meshSignal, routeName string) *msgjson.Error {
+	res, err := n.control.send(sig)
+	if err == nil {
+		err = res.err
+	}
+	if err != nil {
+		return msgjson.NewError(msgjson.RPCInternal, "%s failed: %v", routeName, err)
+	}
+	if !res.handled {
+		return msgjson.NewError(msgjson.TryAgainLaterError,
+			"%s: this node is not the established master on this connection (mode %s)", routeName, res.state.mode)
+	}
+	return nil
+}
+
+// handleSnapshotRequest handles a slave's request for a snapshot of the
+// node's state. If the node can handle the request, it is acked, and the
+// transfer is initiated.
+func (n *node) handleSnapshotRequest(_ context.Context, conn link, msg *msgjson.Message) *msgjson.Error {
+	if _, msgErr := decodeRoutePayload[snapshotRequest](msg, "snapshot request", nil); msgErr != nil {
+		return msgErr
+	}
+
+	// The state machine will kick off the snapshot transfer.
+	if msgErr := n.requestServe(snapshotRequestSignal{connID: conn.ID()}, "snapshot request"); msgErr != nil {
+		return msgErr
+	}
+
+	return sendRouteAck(conn, msg.ID, "snapshot request")
+}
+
+// handleSnapshotChunk appends one snapshot chunk to the seed in progress on
+// this connection. It answers each accepted chunk with an ack. After the final
+// chunk it loads the snapshot into the DB in a new goroutine.
+func (n *node) handleSnapshotChunk(_ context.Context, conn link, peerConn *nodeConn, msg *msgjson.Message) *msgjson.Error {
+	chunk, msgErr := decodeRoutePayload[snapshotChunk](msg, "snapshot chunk", nil)
+	if msgErr != nil {
+		return msgErr
+	}
+
+	// A chunk is only accepted while a seed attempt is running on this
+	// connection.
+	seed := peerConn.seed.Load()
+	if seed == nil {
+		return msgjson.NewError(msgjson.RPCInternal, "unsolicited snapshot chunk: no seed in progress on this connection")
+	}
+	if seed.rx.transferComplete() {
+		return msgjson.NewError(msgjson.RPCInternal, "snapshot chunk after final chunk")
+	}
+
+	last, err := seed.rx.receiveChunk(chunk)
+	if err != nil {
+		seed.fail(fmt.Errorf("snapshot receive: %w", err))
+		return msgjson.NewError(msgjson.RPCInternal, "snapshot receive failed: %v", err)
+	}
+
+	if last {
+		go seed.runLoad()
+	}
+
+	msgErr = sendRouteResponse(conn, msg.ID, &eventAck{}, "snapshot chunk")
+	return msgErr
 }

--- a/server/mesh/routes_test.go
+++ b/server/mesh/routes_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -331,6 +332,18 @@ func validCommandForward(t *testing.T, commandID string) *commandForward {
 		Kind:      req.Kind,
 		User:      req.User,
 		Msg:       req.Msg,
+	}
+}
+
+func validClientProxyMessage(t testing.TB) *ClientProxyMessage {
+	t.Helper()
+	req, err := msgjson.NewRequest(77, msgjson.PreimageRoute, map[string]string{"ok": "true"})
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	return &ClientProxyMessage{
+		User: account.AccountID{0x22},
+		Msg:  req,
 	}
 }
 
@@ -707,6 +720,100 @@ func TestNodeRoutesHandleCommandForward(t *testing.T) {
 		if called.Load() {
 			t.Fatalf("unexpected command app call")
 		}
+	})
+}
+
+func TestNodeRoutesHandleClientProxyMessage(t *testing.T) {
+	t.Run("sends ack on success", func(t *testing.T) {
+		active := newTRouteLink(501)
+		var calls int
+		handler := newRouteTestNode(modeEstablishedMaster, active, &testMeshApplication{
+			clientProxy: func(context.Context, *ClientProxyMessage) error {
+				calls++
+				return nil
+			},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, clientProxyMessageRoute, active, validClientProxyMessage(t))
+		requireNoRPCError(t, rpcErr)
+		if calls != 1 {
+			t.Fatalf("client proxy calls = %d, want 1", calls)
+		}
+		requireOneAck(t, active)
+	})
+
+	t.Run("allows a syncing slave", func(t *testing.T) {
+		active := newTRouteLink(502)
+		var calls int
+		handler := newRouteTestNode(modeEstablishedSlaveSyncing, active, &testMeshApplication{
+			clientProxy: func(context.Context, *ClientProxyMessage) error {
+				calls++
+				return nil
+			},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, clientProxyMessageRoute, active, validClientProxyMessage(t))
+		requireNoRPCError(t, rpcErr)
+		if calls != 1 {
+			t.Fatalf("client proxy calls = %d, want 1", calls)
+		}
+		requireOneAck(t, active)
+	})
+
+	t.Run("maps client-not-connected app error", func(t *testing.T) {
+		active := newTRouteLink(506)
+		handler := newRouteTestNode(modeEstablishedSlave, active, &testMeshApplication{
+			clientProxy: func(context.Context, *ClientProxyMessage) error {
+				return fmt.Errorf("%w: user gone", ErrClientNotConnected)
+			},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, clientProxyMessageRoute, active, validClientProxyMessage(t))
+		requireRPCCode(t, rpcErr, msgjson.UserNotConnectedError)
+	})
+
+	t.Run("client-not-connected verdict reaches requester as sentinel", func(t *testing.T) {
+		active := newTRouteLink(507)
+		handler := newRouteTestNode(modeEstablishedSlave, active, &testMeshApplication{
+			clientProxy: func(context.Context, *ClientProxyMessage) error {
+				return fmt.Errorf("%w: user gone", ErrClientNotConnected)
+			},
+		})
+		active.requestFunc = func(ctx context.Context, route string, payload any, response any) error {
+			msg, err := msgjson.NewRequest(99, route, payload)
+			if err != nil {
+				return err
+			}
+			rpcErr := handleRouteMessage(t, ctx, handler, active, msg)
+			if rpcErr != nil {
+				return &peerRPCError{Code: rpcErr.Code, Message: rpcErr.Message}
+			}
+			return nil
+		}
+		requester := &node{
+			log: dex.Disabled,
+			control: newTestControlLoop(nodeState{
+				mode:       modeEstablishedMaster,
+				activeConn: newNodeConn(active, "peer-node", "peer-node"),
+			}),
+		}
+
+		err := requester.sendClientProxyMessage(context.Background(), validClientProxyMessage(t))
+		if !errors.Is(err, ErrClientNotConnected) {
+			t.Fatalf("requester error = %v, want ErrClientNotConnected", err)
+		}
+	})
+
+	t.Run("wraps ordinary app error", func(t *testing.T) {
+		active := newTRouteLink(503)
+		handler := newRouteTestNode(modeEstablishedSlave, active, &testMeshApplication{
+			clientProxy: func(context.Context, *ClientProxyMessage) error {
+				return errors.New("boom")
+			},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, clientProxyMessageRoute, active, validClientProxyMessage(t))
+		requireRPCCode(t, rpcErr, msgjson.RPCInternal)
 	})
 }
 
@@ -1235,6 +1342,88 @@ func TestNodeRoutesHandshakeAuthPolicy(t *testing.T) {
 	}
 	if !routes[helloDecisionRoute].requiresAuth {
 		t.Fatalf("%s does not require auth", helloDecisionRoute)
+	}
+}
+
+func decodeClientConnectedResult(t testing.TB, msg *msgjson.Message) []account.AccountID {
+	t.Helper()
+	resp, err := msg.Response()
+	if err != nil {
+		t.Fatalf("Response error: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected response error: %v", resp.Error)
+	}
+	var result clientConnectedResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("Unmarshal client connected result error: %v", err)
+	}
+	return result.Connected
+}
+
+func TestNodeRoutesHandleClientConnected(t *testing.T) {
+	userA, userB := account.AccountID{0x01}, account.AccountID{0x02}
+	validQuery := &clientConnectedQuery{Users: []account.AccountID{userA, userB}}
+
+	t.Run("answers from app in every established mode", func(t *testing.T) {
+		for _, mode := range []nodeMode{modeEstablishedMaster, modeEstablishedSlaveSyncing, modeEstablishedSlave} {
+			active := newTRouteLink(521)
+			var gotUsers []account.AccountID
+			handler := newRouteTestNode(mode, active, &testMeshApplication{
+				clientConnected: func(users []account.AccountID) []account.AccountID {
+					gotUsers = users
+					return []account.AccountID{userB}
+				},
+			})
+
+			rpcErr := handleRoutePayload(t, handler, clientConnectedRoute, active, validQuery)
+			requireNoRPCError(t, rpcErr)
+			if len(gotUsers) != 2 || gotUsers[0] != userA || gotUsers[1] != userB {
+				t.Fatalf("mode %s: queried users = %v, want [%v %v]", mode, gotUsers, userA, userB)
+			}
+			connected := decodeClientConnectedResult(t, requireSent(t, active, 1)[0])
+			if len(connected) != 1 || connected[0] != userB {
+				t.Fatalf("mode %s: connected = %v, want just %v", mode, connected, userB)
+			}
+		}
+	})
+
+	t.Run("rejects invalid payload before app", func(t *testing.T) {
+		active := newTRouteLink(522)
+		handler := newRouteTestNode(modeEstablishedSlave, active, &testMeshApplication{
+			clientConnected: func([]account.AccountID) []account.AccountID {
+				t.Fatalf("unexpected client connected app call")
+				return nil
+			},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, clientConnectedRoute, active, &clientConnectedQuery{})
+		requireRPCCode(t, rpcErr, msgjson.RPCParseError)
+		requireNoSent(t, active)
+	})
+}
+
+func TestValidateClientConnectedQuery(t *testing.T) {
+	user := account.AccountID{0x01}
+	overLimit := make([]account.AccountID, maxClientConnectedUsers+1)
+	tests := []struct {
+		name    string
+		query   *clientConnectedQuery
+		wantErr bool
+	}{
+		{"nil", nil, true},
+		{"empty", &clientConnectedQuery{}, true},
+		{"over limit", &clientConnectedQuery{Users: overLimit}, true},
+		{"at limit ok", &clientConnectedQuery{Users: overLimit[:maxClientConnectedUsers]}, false},
+		{"one user ok", &clientConnectedQuery{Users: []account.AccountID{user}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateClientConnectedQuery(tt.query)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateClientConnectedQuery error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/server/mesh/routes_test.go
+++ b/server/mesh/routes_test.go
@@ -1,0 +1,22 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"testing"
+	"time"
+)
+
+func waitForCondition(t testing.TB, cond func() bool, desc string) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not met: %s", desc)
+}

--- a/server/mesh/routes_test.go
+++ b/server/mesh/routes_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -164,6 +165,19 @@ func decodeEmptyResponse(t testing.TB, msg *msgjson.Message) {
 	}
 }
 
+func decodeResponseError(t testing.TB, msg *msgjson.Message) *msgjson.Error {
+	t.Helper()
+
+	resp, err := msg.Response()
+	if err != nil {
+		t.Fatalf("Response error: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatalf("expected response error")
+	}
+	return resp.Error
+}
+
 func requireNoRPCError(t testing.TB, rpcErr *msgjson.Error) {
 	t.Helper()
 	if rpcErr != nil {
@@ -207,6 +221,17 @@ func requireOneAck(t testing.TB, conn *tRouteLink) {
 func requireNoSent(t testing.TB, conn *tRouteLink) {
 	t.Helper()
 	requireSent(t, conn, 0)
+}
+
+func requireResponseErrorCode(t testing.TB, conn *tRouteLink, code int) {
+	t.Helper()
+	msg := requireSent(t, conn, 1)[0]
+	if msg.ID != 1 {
+		t.Fatalf("response id = %d, want 1", msg.ID)
+	}
+	if got := decodeResponseError(t, msg); got.Code != code {
+		t.Fatalf("response error = %+v, want code %d", got, code)
+	}
 }
 
 func waitForCondition(t testing.TB, cond func() bool, desc string) {
@@ -296,6 +321,17 @@ func handleRouteMessage(t testing.TB, ctx context.Context, n *node, conn link, m
 		t.Fatalf("missing test route %q", msg.Route)
 	}
 	return route.handler(ctx, conn, msg)
+}
+
+func validCommandForward(t *testing.T, commandID string) *commandForward {
+	t.Helper()
+	req := testCommandRequest(t)
+	return &commandForward{
+		CommandID: commandID,
+		Kind:      req.Kind,
+		User:      req.User,
+		Msg:       req.Msg,
+	}
 }
 
 type capturedHandshakeResolution struct {
@@ -503,6 +539,175 @@ func peerHandshakeCapture(role helloRole, progress progressState, frontier *db.E
 		peerNodeID:   routePeerNodeID,
 		initiatorID:  routePeerNodeID,
 	}
+}
+
+func TestNodeRoutesHandleCommandResult(t *testing.T) {
+	t.Run("delivers pending result and sends ack", func(t *testing.T) {
+		active := newTRouteLink(301)
+		svc := &Service{commands: newTestCommandCoordinator(nil, nil)}
+		req := testCommandRequest(t)
+		responder := new(testCommandResponder)
+		req.Respond = responder.Send
+		svc.commands.registerPending("cmd-ok", req)
+		defer svc.commands.removePending("cmd-ok")
+		result := map[string]string{"status": "ok"}
+
+		handler := newRouteTestNode(modeEstablishedSlave, active, &testMeshApplication{
+			commandResult: svc.receiveCommandResult,
+		})
+
+		rpcErr := handleRoutePayload(t, handler, commandResultRoute, active, &commandResult{
+			CommandID: "cmd-ok",
+			Result:    mustMarshalJSON(t, result),
+		})
+		requireNoRPCError(t, rpcErr)
+
+		requireOneAck(t, active)
+		svc.commands.pendingMtx.Lock()
+		pending := svc.commands.pending["cmd-ok"]
+		svc.commands.pendingMtx.Unlock()
+		if pending != nil {
+			t.Fatalf("pending command was not removed")
+		}
+		responder.requireResult(t, result)
+	})
+
+	t.Run("rejects invalid payload", func(t *testing.T) {
+		active := newTRouteLink(305)
+		handler := newRouteTestNode(modeEstablishedSlave, active, &testMeshApplication{
+			commandResult: func(string, json.RawMessage) {
+				t.Fatalf("unexpected command result callback")
+			},
+		})
+
+		result := map[string]string{"status": "ok"}
+		rpcErr := handleRoutePayload(t, handler, commandResultRoute, active, &commandResult{
+			Result: mustMarshalJSON(t, result),
+		})
+		requireRPCCode(t, rpcErr, msgjson.RPCParseError)
+	})
+}
+
+func TestNodeRoutesHandleCommandFailure(t *testing.T) {
+	t.Run("delivers failure and sends ack", func(t *testing.T) {
+		active := newTRouteLink(351)
+		wantErr := msgjson.NewError(msgjson.FundingError, "funding failed")
+		var (
+			gotCommandID string
+			gotErr       *msgjson.Error
+		)
+		handler := newRouteTestNode(modeEstablishedSlave, active, &testMeshApplication{
+			commandFailure: func(commandID string, msgErr *msgjson.Error) {
+				gotCommandID = commandID
+				gotErr = msgErr
+			},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, commandFailureRoute, active, &commandFailure{
+			CommandID: "cmd-fail",
+			Error:     wantErr,
+		})
+		requireNoRPCError(t, rpcErr)
+		if gotErr == nil {
+			t.Fatalf("command failure callback was not called")
+		}
+		if gotCommandID != "cmd-fail" || gotErr.Code != wantErr.Code {
+			t.Fatalf("command failure = %s %+v, want command cmd-fail code %d", gotCommandID, gotErr, wantErr.Code)
+		}
+		requireOneAck(t, active)
+	})
+
+}
+
+func TestNodeRoutesHandleCommandForward(t *testing.T) {
+	t.Run("sends startup ack only after app completes", func(t *testing.T) {
+		active := newTRouteLink(401)
+		started := make(chan struct{})
+		release := make(chan struct{})
+		handler := newRouteTestNode(modeEstablishedMaster, active, &testMeshApplication{
+			commandForward: func(context.Context, string, CommandRequest) *msgjson.Error {
+				close(started)
+				<-release
+				return nil
+			},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, commandForwardRoute, active, validCommandForward(t, "cmd-async"))
+		requireNoRPCError(t, rpcErr)
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("command app handler did not start")
+		}
+		requireNoSent(t, active)
+
+		close(release)
+		waitForCondition(t, func() bool { return len(active.sentMessages()) == 1 }, "forwarded command ack")
+		requireOneAck(t, active)
+	})
+
+	t.Run("preserves msgjson app error", func(t *testing.T) {
+		active := newTRouteLink(402)
+		wantErr := msgjson.NewError(msgjson.FundingError, "funding failed")
+		handler := newRouteTestNode(modeEstablishedMaster, active, &testMeshApplication{
+			commandForward: func(context.Context, string, CommandRequest) *msgjson.Error {
+				return wantErr
+			},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, commandForwardRoute, active, validCommandForward(t, "cmd-msgjson-err"))
+		requireNoRPCError(t, rpcErr)
+		waitForCondition(t, func() bool { return len(active.sentMessages()) == 1 }, "forwarded command error response")
+		requireResponseErrorCode(t, active, wantErr.Code)
+	})
+
+	t.Run("runs under the node run context", func(t *testing.T) {
+		active := newTRouteLink(405)
+		gotCtx := make(chan context.Context, 1)
+		handler := newRouteTestNode(modeEstablishedMaster, active, &testMeshApplication{
+			commandForward: func(ctx context.Context, _ string, _ CommandRequest) *msgjson.Error {
+				gotCtx <- ctx
+				return nil
+			},
+		})
+		type runKey struct{}
+		runCtx := context.WithValue(context.Background(), runKey{}, "run")
+		handler.runContext = runCtx
+		routeCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		rpcErr := handleRouteMessage(t, routeCtx, handler, active,
+			mustRequestMessage(t, commandForwardRoute, validCommandForward(t, "cmd-ctx")))
+		requireNoRPCError(t, rpcErr)
+		select {
+		case got := <-gotCtx:
+			if got != runCtx {
+				t.Fatalf("command context = %v, want node run context", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("command was not run")
+		}
+		waitForCondition(t, func() bool { return len(active.sentMessages()) == 1 }, "forwarded command ack")
+		requireOneAck(t, active)
+	})
+
+	t.Run("rejects invalid payload before app goroutine", func(t *testing.T) {
+		active := newTRouteLink(404)
+		var called atomic.Bool
+		handler := newRouteTestNode(modeEstablishedMaster, active, &testMeshApplication{
+			commandForward: func(context.Context, string, CommandRequest) *msgjson.Error {
+				called.Store(true)
+				return nil
+			},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, commandForwardRoute, active, &commandForward{})
+		requireRPCCode(t, rpcErr, msgjson.RPCParseError)
+		requireNoSent(t, active)
+		if called.Load() {
+			t.Fatalf("unexpected command app call")
+		}
+	})
 }
 
 func TestNodeRoutesPolicyBeforeParse(t *testing.T) {

--- a/server/mesh/routes_test.go
+++ b/server/mesh/routes_test.go
@@ -4,9 +4,197 @@
 package mesh
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
+	"decred.org/dcrdex/server/db"
 )
+
+const (
+	routeLocalNodeID = "local-node"
+	routePeerNodeID  = "peer-node"
+)
+
+type tRouteLink struct {
+	id   uint64
+	addr string
+
+	sendErr     error
+	requestFunc func(context.Context, string, any, any) error
+
+	mtx            sync.Mutex
+	sent           []*msgjson.Message
+	authorizeCalls int
+	disconnects    int
+	ops            []string
+	done           chan struct{}
+	once           sync.Once
+}
+
+func newTRouteLink(id uint64) *tRouteLink {
+	return &tRouteLink{
+		id:   id,
+		addr: "route-test-peer",
+		done: make(chan struct{}),
+	}
+}
+
+func (c *tRouteLink) ID() uint64            { return c.id }
+func (c *tRouteLink) Addr() string          { return c.addr }
+func (c *tRouteLink) Done() <-chan struct{} { return c.done }
+
+func (c *tRouteLink) Send(msg *msgjson.Message) error {
+	if c.sendErr != nil {
+		return c.sendErr
+	}
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	// Model the real link: once disconnected, sends are refused, so a test
+	// cannot certify delivery of an answer queued after a disconnect.
+	if c.disconnects > 0 {
+		return errors.New("peer disconnected")
+	}
+	c.sent = append(c.sent, msg)
+	c.ops = append(c.ops, "send")
+	return nil
+}
+
+func (c *tRouteLink) Authorize() {
+	c.mtx.Lock()
+	c.authorizeCalls++
+	c.ops = append(c.ops, "authorize")
+	c.mtx.Unlock()
+}
+
+func (c *tRouteLink) Disconnect() {
+	c.mtx.Lock()
+	c.disconnects++
+	c.ops = append(c.ops, "disconnect")
+	c.mtx.Unlock()
+	c.once.Do(func() {
+		close(c.done)
+	})
+}
+
+func (c *tRouteLink) sentMessages() []*msgjson.Message {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return append([]*msgjson.Message(nil), c.sent...)
+}
+
+func (c *tRouteLink) authorizeCount() int {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.authorizeCalls
+}
+
+func (c *tRouteLink) disconnectCount() int {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return c.disconnects
+}
+
+func (c *tRouteLink) operations() []string {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+	return append([]string(nil), c.ops...)
+}
+
+func mustRequestMessage(t testing.TB, route string, payload any) *msgjson.Message {
+	t.Helper()
+
+	msg, err := msgjson.NewRequest(1, route, payload)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	return msg
+}
+
+func decodeHelloResponse(t testing.TB, msg *msgjson.Message) *helloResponse {
+	t.Helper()
+
+	resp, err := msg.Response()
+	if err != nil {
+		t.Fatalf("Response error: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected response error: %v", resp.Error)
+	}
+
+	var helloResp helloResponse
+	if err := json.Unmarshal(resp.Result, &helloResp); err != nil {
+		t.Fatalf("Unmarshal hello response error: %v", err)
+	}
+	return &helloResp
+}
+
+func decodeEmptyResponse(t testing.TB, msg *msgjson.Message) {
+	t.Helper()
+
+	resp, err := msg.Response()
+	if err != nil {
+		t.Fatalf("Response error: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected response error: %v", resp.Error)
+	}
+
+	var ack map[string]json.RawMessage
+	if err := json.Unmarshal(resp.Result, &ack); err != nil {
+		t.Fatalf("Unmarshal ack error: %v", err)
+	}
+	if len(ack) != 0 {
+		t.Fatalf("ack payload fields = %d, want 0", len(ack))
+	}
+}
+
+func requireNoRPCError(t testing.TB, rpcErr *msgjson.Error) {
+	t.Helper()
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %+v", rpcErr)
+	}
+}
+
+func requireRPCCode(t testing.TB, rpcErr *msgjson.Error, code int) {
+	t.Helper()
+	if rpcErr == nil || rpcErr.Code != code {
+		t.Fatalf("rpc error = %+v, want code %d", rpcErr, code)
+	}
+}
+
+func requireRPCOutcome(t testing.TB, rpcErr *msgjson.Error, code int, msg string) {
+	t.Helper()
+	if code == 0 {
+		requireNoRPCError(t, rpcErr)
+		return
+	}
+	requireRPCCode(t, rpcErr, code)
+	if msg != "" && !strings.Contains(rpcErr.Message, msg) {
+		t.Fatalf("rpc error message %q does not contain %q", rpcErr.Message, msg)
+	}
+}
+
+func requireSent(t testing.TB, conn *tRouteLink, want int) []*msgjson.Message {
+	t.Helper()
+	sent := conn.sentMessages()
+	if len(sent) != want {
+		t.Fatalf("sent messages = %d, want %d", len(sent), want)
+	}
+	return sent
+}
+
+func requireOneAck(t testing.TB, conn *tRouteLink) {
+	t.Helper()
+	decodeEmptyResponse(t, requireSent(t, conn, 1)[0])
+}
 
 func waitForCondition(t testing.TB, cond func() bool, desc string) {
 	t.Helper()
@@ -19,4 +207,630 @@ func waitForCondition(t testing.TB, cond func() bool, desc string) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("condition not met: %s", desc)
+}
+
+type testMeshApplication struct {
+	commandForward  func(context.Context, string, CommandRequest) *msgjson.Error
+	commandFailure  func(string, *msgjson.Error)
+	commandResult   func(string, json.RawMessage)
+	clientProxy     func(context.Context, *ClientProxyMessage) error
+	clientConnected func([]account.AccountID) []account.AccountID
+	event           func(context.Context, *eventEnvelope) error
+}
+
+func (a *testMeshApplication) answerClientConnected(users []account.AccountID) []account.AccountID {
+	if a.clientConnected == nil {
+		return nil
+	}
+	return a.clientConnected(users)
+}
+
+func (a *testMeshApplication) executeForwardedCommand(ctx context.Context, commandID string, req CommandRequest) *msgjson.Error {
+	if a.commandForward == nil {
+		return nil
+	}
+	return a.commandForward(ctx, commandID, req)
+}
+
+func (a *testMeshApplication) receiveCommandFailure(commandID string, msgErr *msgjson.Error) {
+	if a.commandFailure != nil {
+		a.commandFailure(commandID, msgErr)
+	}
+}
+
+func (a *testMeshApplication) receiveCommandResult(commandID string, result json.RawMessage) {
+	if a.commandResult != nil {
+		a.commandResult(commandID, result)
+	}
+}
+
+func (a *testMeshApplication) handleClientProxyMessage(ctx context.Context, msg *ClientProxyMessage) error {
+	if a.clientProxy == nil {
+		return nil
+	}
+	return a.clientProxy(ctx, msg)
+}
+
+func (a *testMeshApplication) applyReceivedEvent(ctx context.Context, entry *eventEnvelope) error {
+	if a.event == nil {
+		return nil
+	}
+	return a.event(ctx, entry)
+}
+
+type capturedHandshakeResolution struct {
+	calls        int
+	conn         *nodeConn
+	role         helloRole
+	progress     progressState
+	peerFrontier *db.EventLogPosition
+	clientHost   string
+	clientCert   []byte
+}
+
+type handshakeCaptureExpectation struct {
+	calls        int
+	role         helloRole
+	progress     progressState
+	peerFrontier *db.EventLogPosition
+	peerNodeID   string
+	initiatorID  string
+}
+
+func startHandshakeResolver(n *node, applyErr error) (*capturedHandshakeResolution, func()) {
+	captured := new(capturedHandshakeResolution)
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+
+	go func() {
+		defer close(stopped)
+		select {
+		case queued := <-n.control.testQueue():
+			ev, ok := queued.signal.(handshakeResolvedSignal)
+			if !ok {
+				if queued.reply != nil {
+					queued.reply <- signalResult{err: errors.New("unexpected mesh signal")}
+				}
+				return
+			}
+			captured.calls++
+			captured.conn = ev.conn
+			captured.role = ev.peerRole
+			captured.progress = ev.progress
+			captured.peerFrontier = ev.peerFrontier
+			captured.clientHost = ev.clientHost
+			captured.clientCert = append([]byte(nil), ev.clientCert...)
+			if queued.reply != nil {
+				res := signalResult{
+					handled: applyErr == nil,
+					err:     applyErr,
+					state: nodeState{
+						mode:       modeEstablishedMaster,
+						activeConn: ev.conn,
+					},
+				}
+				switch {
+				case applyErr != nil:
+				case ev.progress == progressDiverged:
+					// A fork halts this node. The state machine reports the
+					// halt as the outcome, and the apply returns the halt
+					// error.
+					res.outcome = handshakeHalted
+					res.state = nodeState{mode: modeHalted, haltErr: errors.New("diverged")}
+				default:
+					res.outcome = handshakeAdopted
+				}
+				queued.reply <- res
+			}
+		case <-done:
+		}
+	}()
+
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			close(done)
+			<-stopped
+		})
+	}
+	return captured, stop
+}
+
+func newRouteHandshakeNode(svc *handshakeService) *node {
+	n := newTestNodeWithState(nodeState{mode: modePending}, &testMeshApplication{})
+	n.handshakeSvc = svc
+	n.handshakes = newHandshakeSessions(n.log, svc, n)
+	return n
+}
+
+func installRoutePendingDecision(t testing.TB, handshakes *handshakeSessions, conn link, state handshakeServiceState) {
+	t.Helper()
+
+	for _, pending := range state.pending {
+		if pending.connID != conn.ID() {
+			t.Fatalf("test pending connID = %d, want route link ID %d", pending.connID, conn.ID())
+		}
+		handshakes.addPending(conn, &handshakeResult{
+			peerHello:  buildSignedHello(t, pending.peerHello),
+			progress:   progressPeerAhead,
+			clientHost: pending.peerHello.clientHost,
+			clientCert: append([]byte(nil), pending.peerHello.clientCert...),
+		})
+	}
+}
+
+func requireHandshakeCapture(t testing.TB, captured *capturedHandshakeResolution, conn link, want handshakeCaptureExpectation) {
+	t.Helper()
+	if captured.calls != want.calls {
+		t.Fatalf("callback calls = %d, want %d", captured.calls, want.calls)
+	}
+	if want.calls == 0 {
+		return
+	}
+	if captured.conn == nil {
+		t.Fatalf("nil callback conn")
+	}
+	if captured.role != want.role {
+		t.Fatalf("callback role = %v, want %v", captured.role, want.role)
+	}
+	if captured.progress != want.progress {
+		t.Fatalf("callback progress = %v, want %v", captured.progress, want.progress)
+	}
+	if want.peerFrontier != nil {
+		if captured.peerFrontier == nil {
+			t.Fatalf("nil callback peer frontier")
+		}
+		if captured.peerFrontier.Seq != want.peerFrontier.Seq || !bytes.Equal(captured.peerFrontier.TipHash, want.peerFrontier.TipHash) {
+			t.Fatalf("callback peer frontier = %+v, want %+v", captured.peerFrontier, want.peerFrontier)
+		}
+	}
+	if captured.conn.peerNodeID != want.peerNodeID {
+		t.Fatalf("conn peerNodeID = %q, want %q", captured.conn.peerNodeID, want.peerNodeID)
+	}
+	if captured.conn.initiatorNodeID != want.initiatorID {
+		t.Fatalf("conn initiatorNodeID = %q, want %q", captured.conn.initiatorNodeID, want.initiatorID)
+	}
+	if captured.conn.link != conn {
+		t.Fatalf("callback conn did not wrap the route link")
+	}
+}
+
+type routeRPCExpectation struct {
+	code int
+	msg  string
+}
+
+type routeHandshakeFixture struct {
+	compat            *CompatSnapshot
+	localFrontier     *db.EventLogPosition
+	peerEqualFrontier *db.EventLogPosition
+	peerAheadFrontier *db.EventLogPosition
+	decisionFrontier  *db.EventLogPosition
+}
+
+func newRouteHandshakeFixture(t testing.TB) routeHandshakeFixture {
+	t.Helper()
+	return routeHandshakeFixture{
+		compat:            testCompatSnapshot(t),
+		localFrontier:     &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)},
+		peerEqualFrontier: &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)},
+		peerAheadFrontier: &db.EventLogPosition{Seq: 11, TipHash: testTipHash(11)},
+		decisionFrontier:  &db.EventLogPosition{Seq: 15, TipHash: testTipHash(15)},
+	}
+}
+
+func (f routeHandshakeFixture) state(role helloRole) handshakeServiceState {
+	return handshakeServiceState{
+		nodeID:        routeLocalNodeID,
+		role:          role,
+		compat:        f.compat,
+		localFrontier: f.localFrontier,
+	}
+}
+
+func (f routeHandshakeFixture) hello(t testing.TB, nodeID string, role helloRole, frontier *db.EventLogPosition) *helloMessage {
+	t.Helper()
+	return buildSignedHello(t, helloSpec{
+		nodeID:   nodeID,
+		role:     role,
+		frontier: frontier,
+		compat:   f.compat,
+	})
+}
+
+func (f routeHandshakeFixture) decisionState(role helloRole) handshakeServiceState {
+	return handshakeServiceState{
+		nodeID: routeLocalNodeID,
+		compat: f.compat,
+		pending: []pendingDecisionState{{
+			connID: 202,
+			peerHello: helloSpec{
+				nodeID:   routePeerNodeID,
+				role:     role,
+				frontier: f.decisionFrontier,
+				compat:   f.compat,
+			},
+		}},
+	}
+}
+
+func peerHandshakeCapture(role helloRole, progress progressState, frontier *db.EventLogPosition) handshakeCaptureExpectation {
+	return handshakeCaptureExpectation{
+		calls:        1,
+		role:         role,
+		progress:     progress,
+		peerFrontier: frontier,
+		peerNodeID:   routePeerNodeID,
+		initiatorID:  routePeerNodeID,
+	}
+}
+
+func TestNodeRoutesHandleHello(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+
+	type expectation struct {
+		rpc            routeRPCExpectation
+		capture        handshakeCaptureExpectation
+		authorize      int
+		sent           int
+		disconnects    int
+		ancestor       bool
+		pending        int
+		cleanupPending bool
+	}
+	// activeConnCase says which connection, if any, is the node's active
+	// connection when the hello arrives.
+	type activeConnCase int
+	const (
+		noActiveConn activeConnCase = iota
+		activeConnIsHelloLink
+		activeConnIsOtherLink
+	)
+	type routeCase struct {
+		name          string
+		state         handshakeServiceState
+		msgPayload    any
+		zeroRequestID bool
+		sendErr       error
+		onCompleteErr error
+		activeConn    activeConnCase
+		want          expectation
+	}
+
+	run := func(t *testing.T, tt routeCase) {
+		t.Helper()
+		svc, _ := newTestHandshakeService(t, tt.state)
+		link := newTRouteLink(101)
+		link.sendErr = tt.sendErr
+
+		node := newRouteHandshakeNode(svc)
+		switch tt.activeConn {
+		case activeConnIsHelloLink:
+			node.control.setState(nodeState{
+				mode:       modeEstablishedMaster,
+				activeConn: newNodeConn(link, routePeerNodeID, routePeerNodeID),
+			})
+		case activeConnIsOtherLink:
+			node.control.setState(nodeState{
+				mode:       modeEstablishedMaster,
+				activeConn: newNodeConn(newTRouteLink(102), routePeerNodeID, routePeerNodeID),
+			})
+		}
+		captured, stopResolver := startHandshakeResolver(node, tt.onCompleteErr)
+		defer stopResolver()
+
+		msg := mustRequestMessage(t, helloRoute, tt.msgPayload)
+		if tt.zeroRequestID {
+			msg.ID = 0
+		}
+
+		rpcErr := node.handleHello(context.Background(), link, msg)
+		requireRPCOutcome(t, rpcErr, tt.want.rpc.code, tt.want.rpc.msg)
+		if got := link.authorizeCount(); got != tt.want.authorize {
+			t.Fatalf("authorize calls = %d, want %d", got, tt.want.authorize)
+		}
+		sent := requireSent(t, link, tt.want.sent)
+		requireHandshakeCapture(t, captured, link, tt.want.capture)
+		if got := link.disconnectCount(); got != tt.want.disconnects {
+			t.Fatalf("disconnects = %d, want %d", got, tt.want.disconnects)
+		}
+		if tt.want.sent > 0 {
+			helloResp := decodeHelloResponse(t, sent[0])
+			if helloResp.Ancestor != tt.want.ancestor {
+				t.Fatalf("hello response ancestor = %v, want %v", helloResp.Ancestor, tt.want.ancestor)
+			}
+		}
+		if got := pendingHandshakeCount(node.handshakes); got != tt.want.pending {
+			t.Fatalf("pending decisions = %d, want %d", got, tt.want.pending)
+		}
+		if tt.want.cleanupPending {
+			if _, found := getPendingHandshake(node.handshakes, link.ID()); !found {
+				t.Fatalf("missing pending decision for connection %d", link.ID())
+			}
+			link.Disconnect()
+			waitForCondition(t, func() bool {
+				_, found := getPendingHandshake(node.handshakes, link.ID())
+				return !found
+			}, "pending decision cleanup after disconnect")
+		}
+	}
+
+	tests := []routeCase{
+		{
+			name:       "parse error",
+			state:      handshakeServiceState{nodeID: routeLocalNodeID, compat: fix.compat},
+			msgPayload: "not a hello",
+			want: expectation{
+				rpc: routeRPCExpectation{code: msgjson.RPCParseError},
+			},
+		},
+		{
+			name:       "handshake validation error",
+			state:      fix.state(roleUnknown),
+			msgPayload: fix.hello(t, routeLocalNodeID, roleSlave, fix.peerEqualFrontier),
+			want: expectation{
+				rpc: routeRPCExpectation{
+					code: msgjson.AuthenticationError,
+					msg:  "mesh hello verification failed",
+				},
+			},
+		},
+		{
+			name: "frontier read error is internal",
+			state: func() handshakeServiceState {
+				state := fix.state(roleMaster)
+				state.frontierErr = errors.New("db down")
+				return state
+			}(),
+			msgPayload: fix.hello(t, routePeerNodeID, roleSlave, fix.peerEqualFrontier),
+			want: expectation{
+				rpc: routeRPCExpectation{
+					code: msgjson.RPCInternal,
+					msg:  "mesh hello processing failed",
+				},
+			},
+		},
+		{
+			// This node's log begins at an anchor above the peer's tip.
+			name: "hello below the snapshot anchor is incompatible",
+			state: func() handshakeServiceState {
+				state := fix.state(roleMaster)
+				state.eventEntries = []*db.EventLogEntry{{Seq: 10, Kind: db.SnapshotAnchorKind, TipHash: testTipHash(10)}}
+				return state
+			}(),
+			msgPayload: fix.hello(t, routePeerNodeID, roleSlave, &db.EventLogPosition{Seq: 8, TipHash: testTipHash(8)}),
+			want: expectation{
+				rpc: routeRPCExpectation{
+					code: msgjson.MeshIncompatibleLogError,
+					msg:  "mesh hello rejected",
+				},
+			},
+		},
+		{
+			name:       "hello on the active connection is refused",
+			state:      fix.state(roleMaster),
+			msgPayload: fix.hello(t, routePeerNodeID, roleSlave, fix.peerEqualFrontier),
+			activeConn: activeConnIsHelloLink,
+			want: expectation{
+				rpc: routeRPCExpectation{
+					code: msgjson.RPCInternal,
+					msg:  "mesh hello on the active connection",
+				},
+			},
+		},
+		{
+			name:       "hello on another connection proceeds",
+			state:      fix.state(roleMaster),
+			msgPayload: fix.hello(t, routePeerNodeID, roleSlave, fix.peerEqualFrontier),
+			activeConn: activeConnIsOtherLink,
+			want: expectation{
+				authorize: 1,
+				sent:      1,
+				capture:   peerHandshakeCapture(roleSlave, progressEqual, fix.peerEqualFrontier),
+			},
+		},
+		{
+			name:       "resolved handshake calls callback",
+			state:      fix.state(roleMaster),
+			msgPayload: fix.hello(t, routePeerNodeID, roleSlave, fix.peerEqualFrontier),
+			want: expectation{
+				authorize: 1,
+				sent:      1,
+				capture:   peerHandshakeCapture(roleSlave, progressEqual, fix.peerEqualFrontier),
+			},
+		},
+		{
+			name:       "unresolved handshake waits for decision",
+			state:      fix.state(roleSlave),
+			msgPayload: fix.hello(t, routePeerNodeID, roleMaster, fix.peerAheadFrontier),
+			want: expectation{
+				authorize:      1,
+				sent:           1,
+				pending:        1,
+				cleanupPending: true,
+			},
+		},
+		{
+			// The result is adopted before the response is written, so a send
+			// failure still leaves the handshake applied; the broken link is
+			// cleaned up through the disconnect watch.
+			name:       "response send failure returns internal error",
+			state:      fix.state(roleMaster),
+			msgPayload: fix.hello(t, routePeerNodeID, roleSlave, fix.peerEqualFrontier),
+			sendErr:    errors.New("send failed"),
+			want: expectation{
+				rpc: routeRPCExpectation{
+					code: msgjson.RPCInternal,
+					msg:  "failed to send mesh hello response",
+				},
+				authorize: 1,
+				capture:   peerHandshakeCapture(roleSlave, progressEqual, fix.peerEqualFrontier),
+			},
+		},
+		{
+			name:       "unresolved response send failure clears pending",
+			state:      fix.state(roleSlave),
+			msgPayload: fix.hello(t, routePeerNodeID, roleMaster, fix.peerAheadFrontier),
+			sendErr:    errors.New("send failed"),
+			want: expectation{
+				rpc: routeRPCExpectation{
+					code: msgjson.RPCInternal,
+					msg:  "failed to send mesh hello response",
+				},
+				authorize: 1,
+				pending:   0,
+			},
+		},
+		{
+			name:          "unresolved response encode failure clears pending",
+			state:         fix.state(roleSlave),
+			msgPayload:    fix.hello(t, routePeerNodeID, roleMaster, fix.peerAheadFrontier),
+			zeroRequestID: true,
+			want: expectation{
+				rpc: routeRPCExpectation{
+					code: msgjson.RPCInternal,
+					msg:  "failed to encode mesh hello response",
+				},
+				authorize: 1,
+				pending:   0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run(t, tt)
+		})
+	}
+}
+
+func TestNodeRoutesHandleDecision(t *testing.T) {
+	fix := newRouteHandshakeFixture(t)
+
+	type expectation struct {
+		rpc         routeRPCExpectation
+		capture     handshakeCaptureExpectation
+		sent        int
+		disconnects int
+		pending     int
+	}
+	type routeCase struct {
+		name          string
+		state         handshakeServiceState
+		msgPayload    any
+		sendErr       error
+		onCompleteErr error
+		want          expectation
+	}
+
+	run := func(t *testing.T, tt routeCase) {
+		t.Helper()
+		svc, _ := newTestHandshakeService(t, tt.state)
+		link := newTRouteLink(202)
+		link.sendErr = tt.sendErr
+
+		node := newRouteHandshakeNode(svc)
+		installRoutePendingDecision(t, node.handshakes, link, tt.state)
+		captured, stopResolver := startHandshakeResolver(node, tt.onCompleteErr)
+		defer stopResolver()
+
+		rpcErr := node.handleDecision(context.Background(), link, mustRequestMessage(t, helloDecisionRoute, tt.msgPayload))
+		requireRPCOutcome(t, rpcErr, tt.want.rpc.code, tt.want.rpc.msg)
+		sent := requireSent(t, link, tt.want.sent)
+		requireHandshakeCapture(t, captured, link, tt.want.capture)
+		if got := link.disconnectCount(); got != tt.want.disconnects {
+			t.Fatalf("disconnects = %d, want %d", got, tt.want.disconnects)
+		}
+		if got := pendingHandshakeCount(node.handshakes); got != tt.want.pending {
+			t.Fatalf("pending decisions = %d, want %d", got, tt.want.pending)
+		}
+		if tt.want.sent > 0 {
+			decodeEmptyResponse(t, sent[0])
+		}
+	}
+
+	tests := []routeCase{
+		{
+			name:       "parse error",
+			state:      handshakeServiceState{nodeID: routeLocalNodeID, compat: fix.compat},
+			msgPayload: "not a decision",
+			want: expectation{
+				rpc: routeRPCExpectation{code: msgjson.RPCParseError},
+			},
+		},
+		{
+			// A missing ancestor bit is false, which the behind node treats
+			// as a fork. Seq already said the initiator is ahead.
+			name:       "missing decision ancestor is a fork",
+			state:      fix.decisionState(roleMaster),
+			msgPayload: map[string]any{},
+			want: expectation{
+				sent:        1,
+				capture:     peerHandshakeCapture(roleMaster, progressDiverged, fix.decisionFrontier),
+				disconnects: 1,
+			},
+		},
+		{
+			name:       "explicit false decision ancestor decodes on the wire",
+			state:      fix.decisionState(roleSlave),
+			msgPayload: map[string]any{"ancestor": false},
+			want: expectation{
+				sent:        1,
+				capture:     peerHandshakeCapture(roleSlave, progressDiverged, fix.decisionFrontier),
+				disconnects: 1,
+			},
+		},
+		{
+			name:       "decision without pending session is internal",
+			state:      handshakeServiceState{nodeID: routeLocalNodeID, compat: fix.compat},
+			msgPayload: &decisionMessage{Ancestor: true},
+			want: expectation{
+				rpc: routeRPCExpectation{
+					code: msgjson.RPCInternal,
+					msg:  "mesh decision processing failed",
+				},
+			},
+		},
+		{
+			name:       "successful decision sends ack",
+			state:      fix.decisionState(roleMaster),
+			msgPayload: &decisionMessage{Ancestor: true},
+			want: expectation{
+				sent:    1,
+				capture: peerHandshakeCapture(roleMaster, progressPeerAhead, fix.decisionFrontier),
+			},
+		},
+		{
+			name:          "callback error disconnects and suppresses rpc error",
+			state:         fix.decisionState(roleSlave),
+			msgPayload:    &decisionMessage{Ancestor: false},
+			onCompleteErr: errors.New("apply failed"),
+			want: expectation{
+				// The diverged decision's ack goes out before the failing
+				// apply disconnects the initiator.
+				sent:        1,
+				capture:     peerHandshakeCapture(roleSlave, progressDiverged, fix.decisionFrontier),
+				disconnects: 1,
+			},
+		},
+		{
+			name:       "ack send failure returns internal error",
+			state:      fix.decisionState(roleMaster),
+			msgPayload: &decisionMessage{Ancestor: true},
+			sendErr:    errors.New("send failed"),
+			want: expectation{
+				rpc: routeRPCExpectation{
+					code: msgjson.RPCInternal,
+					msg:  "failed to send mesh decision response",
+				},
+				capture: peerHandshakeCapture(roleMaster, progressPeerAhead, fix.decisionFrontier),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run(t, tt)
+		})
+	}
 }

--- a/server/mesh/routes_test.go
+++ b/server/mesh/routes_test.go
@@ -558,6 +558,101 @@ func TestNodeRoutesPolicyBeforeParse(t *testing.T) {
 	}
 }
 
+func TestNodeRoutesHandleEventEnvelope(t *testing.T) {
+	t.Run("allows syncing and established slave states", func(t *testing.T) {
+		for _, mode := range []nodeMode{modeEstablishedSlaveSyncing, modeEstablishedSlave} {
+			t.Run(mode.String(), func(t *testing.T) {
+				active := newTRouteLink(701)
+				handler := newRouteTestNode(mode, active, &testMeshApplication{
+					event: func(context.Context, *eventEnvelope) error {
+						return nil
+					},
+				})
+
+				rpcErr := handleRoutePayload(t, handler, eventEnvelopeRoute, active, &eventBatch{Entries: []*eventEnvelope{{
+					Seq:       1,
+					TipHash:   testTipHash(1),
+					MasterTip: 2,
+					Kind:      "test",
+				}}})
+				requireNoRPCError(t, rpcErr)
+				requireSent(t, active, 1)
+			})
+		}
+	})
+
+	t.Run("uses accepted connection snapshot for caught up event", func(t *testing.T) {
+		active := newTRouteLink(702)
+		replacement := newTRouteLink(703)
+		handler := newRouteTestNode(modeEstablishedSlaveSyncing, active, nil)
+		handler.app = &testMeshApplication{
+			event: func(context.Context, *eventEnvelope) error {
+				handler.control.setState(nodeState{
+					mode:       modeEstablishedSlaveSyncing,
+					activeConn: newNodeConn(replacement, "replacement-node", "replacement-node"),
+				})
+				return nil
+			},
+		}
+
+		caughtUp := make(chan *nodeConn, 1)
+		go func() {
+			queued := <-handler.control.testQueue()
+			ev, ok := queued.signal.(streamCaughtUpSignal)
+			if ok {
+				caughtUp <- ev.conn
+			}
+		}()
+
+		rpcErr := handleRoutePayload(t, handler, eventEnvelopeRoute, active, &eventBatch{Entries: []*eventEnvelope{{
+			Seq:       1,
+			TipHash:   testTipHash(1),
+			MasterTip: 1,
+			Kind:      "test",
+		}}})
+		requireNoRPCError(t, rpcErr)
+
+		select {
+		case got := <-caughtUp:
+			if got == nil || got.link != active {
+				t.Fatalf("caught up conn = %v, want original active link", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("missing stream caught up event")
+		}
+	})
+
+	t.Run("uses run context after route cancellation", func(t *testing.T) {
+		active := newTRouteLink(704)
+		appliedCtx := make(chan context.Context, 1)
+		handler := newRouteTestNode(modeEstablishedSlave, active, &testMeshApplication{
+			event: func(ctx context.Context, _ *eventEnvelope) error {
+				appliedCtx <- ctx
+				return ctx.Err()
+			},
+		})
+		runCtx := context.Background()
+		handler.runContext = runCtx
+		routeCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		rpcErr := handleRouteMessage(t, routeCtx, handler, active,
+			mustRequestMessage(t, eventEnvelopeRoute, &eventBatch{Entries: []*eventEnvelope{{
+				Seq: 1, TipHash: testTipHash(1), MasterTip: 2, Kind: "test",
+			}}}))
+		requireNoRPCError(t, rpcErr)
+		requireSent(t, active, 1)
+		select {
+		case got := <-appliedCtx:
+			if got != runCtx {
+				t.Fatalf("apply context = %v, want node run context", got)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("event was not applied")
+		}
+	})
+}
+
 func TestNodeRoutesHandleHello(t *testing.T) {
 	fix := newRouteHandshakeFixture(t)
 
@@ -938,6 +1033,47 @@ func TestNodeRoutesHandshakeAuthPolicy(t *testing.T) {
 	}
 }
 
+func TestValidateEventBatch(t *testing.T) {
+	valid := func(seq uint64) *eventEnvelope {
+		return &eventEnvelope{
+			Seq:       seq,
+			TipHash:   testTipHash(seq),
+			MasterTip: eventStreamBatchLimit + 1,
+			Kind:      "test",
+		}
+	}
+	atLimit := make([]*eventEnvelope, eventStreamBatchLimit)
+	for i := range atLimit {
+		atLimit[i] = valid(uint64(i + 1))
+	}
+	overLimit := make([]*eventEnvelope, eventStreamBatchLimit+1)
+	for i := range overLimit {
+		overLimit[i] = valid(uint64(i + 1))
+	}
+	tests := []struct {
+		name    string
+		batch   *eventBatch
+		wantErr bool
+	}{
+		{"nil", nil, true},
+		{"empty", &eventBatch{}, true},
+		{"nil entry", &eventBatch{Entries: []*eventEnvelope{nil}}, true},
+		{"non-contiguous", &eventBatch{Entries: []*eventEnvelope{valid(1), valid(3)}}, true},
+		{"over limit", &eventBatch{Entries: overLimit}, true},
+		{"at limit ok", &eventBatch{Entries: atLimit}, false},
+		{"one entry ok", &eventBatch{Entries: []*eventEnvelope{valid(1)}}, false},
+		{"two contiguous ok", &eventBatch{Entries: []*eventEnvelope{valid(1), valid(2)}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEventBatch(tt.batch)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateEventBatch error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // controlAnswer replies to the next signal on a node's control queue and
 // records that signal.
 type controlAnswer struct {
@@ -975,6 +1111,97 @@ func (a *controlAnswer) wait(t testing.TB) meshSignal {
 		t.Fatalf("no control signal received")
 		return nil
 	}
+}
+
+// none fails the test if a signal was answered.
+func (a *controlAnswer) none(t testing.TB) {
+	t.Helper()
+	select {
+	case sig := <-a.got:
+		t.Fatalf("unexpected control signal %T", sig)
+	default:
+	}
+}
+
+func decodeResultInto(t testing.TB, msg *msgjson.Message, result any) {
+	t.Helper()
+	resp, err := msg.Response()
+	if err != nil {
+		t.Fatalf("Response error: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected response error: %v", resp.Error)
+	}
+	if err := json.Unmarshal(resp.Result, result); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+}
+
+func TestNodeRoutesHandleStreamSubscribe(t *testing.T) {
+	tip := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)}
+	subscribeAt := func(pos *db.EventLogPosition) *streamSubscribe {
+		return &streamSubscribe{Frontier: toFrontierMessage(pos)}
+	}
+
+	t.Run("starts the stream and reports the master tip", func(t *testing.T) {
+		active := newTRouteLink(801)
+		handler := newRouteTestNode(modeEstablishedMaster, active, nil)
+		handler.eventLogReader = &testEventLogReader{frontier: tip}
+		answer := answerControlSignal(t, handler, signalResult{
+			handled: true,
+			state:   nodeState{mode: modeEstablishedMaster},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, streamSubscribeRoute, active, subscribeAt(tip))
+		requireNoRPCError(t, rpcErr)
+		sig, ok := answer.wait(t).(streamSubscribeSignal)
+		if !ok || sig.connID != active.ID() || sig.frontier.Seq != tip.Seq {
+			t.Fatalf("control signal = %+v, want stream subscribe on conn %d at seq %d", sig, active.ID(), tip.Seq)
+		}
+		var result streamSubscribeResult
+		decodeResultInto(t, requireSent(t, active, 1)[0], &result)
+		if result.MasterTip != tip.Seq {
+			t.Fatalf("master tip = %d, want %d", result.MasterTip, tip.Seq)
+		}
+	})
+
+	t.Run("not the master gets try again later", func(t *testing.T) {
+		active := newTRouteLink(802)
+		handler := newRouteTestNode(modeEstablishedSlave, active, nil)
+		handler.eventLogReader = &testEventLogReader{frontier: tip}
+		answerControlSignal(t, handler, signalResult{state: nodeState{mode: modeEstablishedSlave}})
+
+		rpcErr := handleRoutePayload(t, handler, streamSubscribeRoute, active, subscribeAt(tip))
+		requireRPCOutcome(t, rpcErr, msgjson.TryAgainLaterError, "not the established master")
+		requireNoSent(t, active)
+	})
+
+	t.Run("control error is internal", func(t *testing.T) {
+		active := newTRouteLink(803)
+		handler := newRouteTestNode(modeEstablishedMaster, active, nil)
+		handler.eventLogReader = &testEventLogReader{frontier: tip}
+		answerControlSignal(t, handler, signalResult{err: errors.New("boom")})
+
+		rpcErr := handleRoutePayload(t, handler, streamSubscribeRoute, active, subscribeAt(tip))
+		requireRPCOutcome(t, rpcErr, msgjson.RPCInternal, "stream subscribe failed")
+		requireNoSent(t, active)
+	})
+
+	t.Run("rejects a frontier beyond the tip before the state machine", func(t *testing.T) {
+		active := newTRouteLink(804)
+		handler := newRouteTestNode(modeEstablishedMaster, active, nil)
+		handler.eventLogReader = &testEventLogReader{frontier: tip}
+		answer := answerControlSignal(t, handler, signalResult{
+			handled: true,
+			state:   nodeState{mode: modeEstablishedMaster},
+		})
+
+		beyond := &db.EventLogPosition{Seq: 11, TipHash: testTipHash(11)}
+		rpcErr := handleRoutePayload(t, handler, streamSubscribeRoute, active, subscribeAt(beyond))
+		requireRPCOutcome(t, rpcErr, msgjson.SubscribeRejectedError, "beyond this node's tip")
+		requireNoSent(t, active)
+		answer.none(t)
+	})
 }
 
 func TestNodeRoutesHandleSnapshotRequest(t *testing.T) {

--- a/server/mesh/routes_test.go
+++ b/server/mesh/routes_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
@@ -50,6 +51,13 @@ func newTRouteLink(id uint64) *tRouteLink {
 func (c *tRouteLink) ID() uint64            { return c.id }
 func (c *tRouteLink) Addr() string          { return c.addr }
 func (c *tRouteLink) Done() <-chan struct{} { return c.done }
+
+func (c *tRouteLink) Request(ctx context.Context, route string, payload any, response any) error {
+	if c.requestFunc != nil {
+		return c.requestFunc(ctx, route, payload, response)
+	}
+	return nil
+}
 
 func (c *tRouteLink) Send(msg *msgjson.Message) error {
 	if c.sendErr != nil {
@@ -194,6 +202,11 @@ func requireSent(t testing.TB, conn *tRouteLink, want int) []*msgjson.Message {
 func requireOneAck(t testing.TB, conn *tRouteLink) {
 	t.Helper()
 	decodeEmptyResponse(t, requireSent(t, conn, 1)[0])
+}
+
+func requireNoSent(t testing.TB, conn *tRouteLink) {
+	t.Helper()
+	requireSent(t, conn, 0)
 }
 
 func waitForCondition(t testing.TB, cond func() bool, desc string) {
@@ -923,4 +936,121 @@ func TestNodeRoutesHandshakeAuthPolicy(t *testing.T) {
 	if !routes[helloDecisionRoute].requiresAuth {
 		t.Fatalf("%s does not require auth", helloDecisionRoute)
 	}
+}
+
+// controlAnswer replies to the next signal on a node's control queue and
+// records that signal.
+type controlAnswer struct {
+	got chan meshSignal
+}
+
+// answerControlSignal starts a goroutine that answers the next signal on the
+// node's control queue with reply. The goroutine stops at test cleanup if no
+// signal arrives.
+func answerControlSignal(t testing.TB, n *node, reply signalResult) *controlAnswer {
+	t.Helper()
+	answer := &controlAnswer{got: make(chan meshSignal, 1)}
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+	go func() {
+		select {
+		case queued := <-n.control.testQueue():
+			answer.got <- queued.signal
+			if queued.reply != nil {
+				queued.reply <- reply
+			}
+		case <-done:
+		}
+	}()
+	return answer
+}
+
+// wait returns the answered signal.
+func (a *controlAnswer) wait(t testing.TB) meshSignal {
+	t.Helper()
+	select {
+	case sig := <-a.got:
+		return sig
+	case <-time.After(time.Second):
+		t.Fatalf("no control signal received")
+		return nil
+	}
+}
+
+func TestNodeRoutesHandleSnapshotRequest(t *testing.T) {
+	t.Run("starts the snapshot and acks", func(t *testing.T) {
+		active := newTRouteLink(811)
+		handler := newRouteTestNode(modeEstablishedMaster, active, nil)
+		answer := answerControlSignal(t, handler, signalResult{
+			handled: true,
+			state:   nodeState{mode: modeEstablishedMaster},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, snapshotRequestRoute, active, &snapshotRequest{})
+		requireNoRPCError(t, rpcErr)
+		sig, ok := answer.wait(t).(snapshotRequestSignal)
+		if !ok || sig.connID != active.ID() {
+			t.Fatalf("control signal = %+v, want snapshot request on conn %d", sig, active.ID())
+		}
+		requireOneAck(t, active)
+	})
+
+	t.Run("not the master gets try again later", func(t *testing.T) {
+		active := newTRouteLink(812)
+		handler := newRouteTestNode(modePreparingMaster, active, nil)
+		answerControlSignal(t, handler, signalResult{state: nodeState{mode: modePreparingMaster}})
+
+		rpcErr := handleRoutePayload(t, handler, snapshotRequestRoute, active, &snapshotRequest{})
+		requireRPCOutcome(t, rpcErr, msgjson.TryAgainLaterError, "not the established master")
+		requireNoSent(t, active)
+	})
+}
+
+func TestNodeRoutesHandleSnapshotChunk(t *testing.T) {
+	seedFinished := func(seed *seedAttempt) bool {
+		seed.mtx.Lock()
+		defer seed.mtx.Unlock()
+		return seed.finished
+	}
+
+	t.Run("no seed in progress is internal", func(t *testing.T) {
+		active := newTRouteLink(831)
+		handler := newRouteTestNode(modeEstablishedSlaveSyncing, active, nil)
+
+		rpcErr := handleRoutePayload(t, handler, snapshotChunkRoute, active, &snapshotChunk{Bytes: []byte("abc")})
+		requireRPCOutcome(t, rpcErr, msgjson.RPCInternal, "unsolicited snapshot chunk")
+		requireNoSent(t, active)
+	})
+
+	t.Run("buffers the chunk and acks", func(t *testing.T) {
+		active := newTRouteLink(832)
+		handler := newRouteTestNode(modeEstablishedSlaveSyncing, active, nil)
+		seed := newSeedAttempt(context.Background(), nil, dex.Disabled)
+		handler.control.currentState().activeConn.seed.Store(seed)
+
+		rpcErr := handleRoutePayload(t, handler, snapshotChunkRoute, active, &snapshotChunk{Bytes: []byte("abc")})
+		requireNoRPCError(t, rpcErr)
+		requireOneAck(t, active)
+		if got := seed.rx.buf.String(); got != "abc" {
+			t.Fatalf("buffered %q, want %q", got, "abc")
+		}
+		if seedFinished(seed) {
+			t.Fatalf("seed finished after a chunk that was not the last")
+		}
+	})
+
+	t.Run("stray chunk after the final chunk does not fail the seed", func(t *testing.T) {
+		active := newTRouteLink(833)
+		handler := newRouteTestNode(modeEstablishedSlaveSyncing, active, nil)
+		seed := newSeedAttempt(context.Background(), nil, dex.Disabled)
+		seed.rx.done = true
+		handler.control.currentState().activeConn.seed.Store(seed)
+
+		rpcErr := handleRoutePayload(t, handler, snapshotChunkRoute, active, &snapshotChunk{Bytes: []byte("abc")})
+		requireRPCOutcome(t, rpcErr, msgjson.RPCInternal, "after final chunk")
+		requireNoSent(t, active)
+		if seedFinished(seed) {
+			t.Fatalf("stray chunk failed the seed")
+		}
+	})
 }

--- a/server/mesh/routes_test.go
+++ b/server/mesh/routes_test.go
@@ -258,6 +258,33 @@ func (a *testMeshApplication) applyReceivedEvent(ctx context.Context, entry *eve
 	return a.event(ctx, entry)
 }
 
+func newRouteTestNode(mode nodeMode, active link, app meshApplication) *node {
+	if app == nil {
+		app = &testMeshApplication{}
+	}
+	state := nodeState{
+		mode: mode,
+	}
+	if active != nil {
+		state.activeConn = newNodeConn(active, "peer-node", "peer-node")
+	}
+	return newTestNodeWithState(state, app)
+}
+
+func handleRoutePayload(t testing.TB, n *node, routeName string, conn link, payload any) *msgjson.Error {
+	t.Helper()
+	return handleRouteMessage(t, context.Background(), n, conn, mustRequestMessage(t, routeName, payload))
+}
+
+func handleRouteMessage(t testing.TB, ctx context.Context, n *node, conn link, msg *msgjson.Message) *msgjson.Error {
+	t.Helper()
+	route := n.routes()[msg.Route]
+	if route.handler == nil {
+		t.Fatalf("missing test route %q", msg.Route)
+	}
+	return route.handler(ctx, conn, msg)
+}
+
 type capturedHandshakeResolution struct {
 	calls        int
 	conn         *nodeConn
@@ -462,6 +489,59 @@ func peerHandshakeCapture(role helloRole, progress progressState, frontier *db.E
 		peerFrontier: frontier,
 		peerNodeID:   routePeerNodeID,
 		initiatorID:  routePeerNodeID,
+	}
+}
+
+func TestNodeRoutesPolicyBeforeParse(t *testing.T) {
+	active := newTRouteLink(601)
+	inactive := newTRouteLink(602)
+
+	tests := []struct {
+		name  string
+		mode  nodeMode
+		conn  link
+		route string
+	}{
+		{"command forward wrong mode", modeEstablishedSlave, active, commandForwardRoute},
+		{"command forward preparing master", modePreparingMaster, active, commandForwardRoute},
+		{"command forward inactive", modeEstablishedMaster, inactive, commandForwardRoute},
+		{"command failure while syncing", modeEstablishedSlaveSyncing, active, commandFailureRoute},
+		{"command failure wrong mode", modeEstablishedMaster, active, commandFailureRoute},
+		{"command failure inactive", modeEstablishedSlave, inactive, commandFailureRoute},
+		{"command result while syncing", modeEstablishedSlaveSyncing, active, commandResultRoute},
+		{"command result wrong mode", modeEstablishedMaster, active, commandResultRoute},
+		{"command result inactive", modeEstablishedSlave, inactive, commandResultRoute},
+		{"client proxy wrong mode", modePending, active, clientProxyMessageRoute},
+		{"client proxy preparing master", modePreparingMaster, active, clientProxyMessageRoute},
+		{"client proxy inactive", modeEstablishedMaster, inactive, clientProxyMessageRoute},
+		{"client connected wrong mode", modePending, active, clientConnectedRoute},
+		{"client connected inactive", modeEstablishedSlave, inactive, clientConnectedRoute},
+		{"event wrong mode", modeEstablishedMaster, active, eventEnvelopeRoute},
+		{"event inactive", modeEstablishedSlave, inactive, eventEnvelopeRoute},
+		{"master handoff wrong mode", modeEstablishedMaster, active, masterHandoffRoute},
+		{"master handoff inactive", modeEstablishedSlave, inactive, masterHandoffRoute},
+		{"snapshot chunk wrong mode", modeEstablishedMaster, active, snapshotChunkRoute},
+		{"snapshot chunk inactive", modeEstablishedSlaveSyncing, inactive, snapshotChunkRoute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			handler := newRouteTestNode(tt.mode, active, &testMeshApplication{
+				commandForward:  func(context.Context, string, CommandRequest) *msgjson.Error { calls++; return nil },
+				commandFailure:  func(string, *msgjson.Error) { calls++ },
+				commandResult:   func(string, json.RawMessage) { calls++ },
+				clientProxy:     func(context.Context, *ClientProxyMessage) error { calls++; return nil },
+				clientConnected: func([]account.AccountID) []account.AccountID { calls++; return nil },
+				event:           func(context.Context, *eventEnvelope) error { calls++; return nil },
+			})
+
+			rpcErr := handleRoutePayload(t, handler, tt.route, tt.conn, "not a valid payload")
+			requireRPCCode(t, rpcErr, msgjson.UnauthorizedConnection)
+			if calls != 0 {
+				t.Fatalf("app calls = %d, want 0", calls)
+			}
+		})
 	}
 }
 
@@ -832,5 +912,15 @@ func TestNodeRoutesHandleDecision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			run(t, tt)
 		})
+	}
+}
+
+func TestNodeRoutesHandshakeAuthPolicy(t *testing.T) {
+	routes := newRouteTestNode(modePending, nil, nil).routes()
+	if routes[helloRoute].requiresAuth {
+		t.Fatalf("%s requires auth", helloRoute)
+	}
+	if !routes[helloDecisionRoute].requiresAuth {
+		t.Fatalf("%s does not require auth", helloDecisionRoute)
 	}
 }

--- a/server/mesh/routes_test.go
+++ b/server/mesh/routes_test.go
@@ -1627,6 +1627,69 @@ func TestNodeRoutesHandleSnapshotRequest(t *testing.T) {
 	})
 }
 
+func TestNodeRoutesHandleMasterHandoff(t *testing.T) {
+	target := &db.EventLogPosition{Seq: 12, TipHash: testTipHash(12)}
+	local := &db.EventLogPosition{Seq: 10, TipHash: testTipHash(10)}
+	handoff := &masterHandoff{Frontier: toFrontierMessage(target)}
+
+	t.Run("plans the handoff and acks", func(t *testing.T) {
+		active := newTRouteLink(821)
+		handler := newRouteTestNode(modeEstablishedSlave, active, nil)
+		handler.eventLogReader = &testEventLogReader{frontier: local}
+		answer := answerControlSignal(t, handler, signalResult{
+			handled: true,
+			state:   nodeState{mode: modePreparingMaster},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, masterHandoffRoute, active, handoff)
+		requireNoRPCError(t, rpcErr)
+		sig, ok := answer.wait(t).(plannedHandoffSignal)
+		if !ok || sig.conn == nil || sig.conn.link != active {
+			t.Fatalf("control signal = %+v, want planned handoff on the active connection", sig)
+		}
+		if sig.local.Seq != local.Seq || sig.target.Seq != target.Seq {
+			t.Fatalf("planned handoff local %d target %d, want %d and %d", sig.local.Seq, sig.target.Seq, local.Seq, target.Seq)
+		}
+		requireOneAck(t, active)
+	})
+
+	t.Run("refusal is unauthorized", func(t *testing.T) {
+		active := newTRouteLink(822)
+		handler := newRouteTestNode(modeEstablishedSlave, active, nil)
+		handler.eventLogReader = &testEventLogReader{frontier: local}
+		answerControlSignal(t, handler, signalResult{state: nodeState{mode: modeEstablishedSlave}})
+
+		rpcErr := handleRoutePayload(t, handler, masterHandoffRoute, active, handoff)
+		requireRPCOutcome(t, rpcErr, msgjson.UnauthorizedConnection, "master handoff refused")
+		requireNoSent(t, active)
+	})
+
+	t.Run("halt answers the halt error", func(t *testing.T) {
+		active := newTRouteLink(823)
+		handler := newRouteTestNode(modeEstablishedSlave, active, nil)
+		handler.eventLogReader = &testEventLogReader{frontier: local}
+		answerControlSignal(t, handler, signalResult{
+			handled: true,
+			state:   nodeState{mode: modeHalted, haltErr: errors.New("handoff halted")},
+		})
+
+		rpcErr := handleRoutePayload(t, handler, masterHandoffRoute, active, handoff)
+		requireRPCOutcome(t, rpcErr, msgjson.RPCInternal, "handoff halted")
+		requireNoSent(t, active)
+	})
+
+	t.Run("control error is internal", func(t *testing.T) {
+		active := newTRouteLink(824)
+		handler := newRouteTestNode(modeEstablishedSlave, active, nil)
+		handler.eventLogReader = &testEventLogReader{frontier: local}
+		answerControlSignal(t, handler, signalResult{err: errors.New("boom")})
+
+		rpcErr := handleRoutePayload(t, handler, masterHandoffRoute, active, handoff)
+		requireRPCOutcome(t, rpcErr, msgjson.RPCInternal, "master handoff transition")
+		requireNoSent(t, active)
+	})
+}
+
 func TestNodeRoutesHandleSnapshotChunk(t *testing.T) {
 	seedFinished := func(seed *seedAttempt) bool {
 		seed.mtx.Lock()

--- a/server/mesh/server.go
+++ b/server/mesh/server.go
@@ -1,0 +1,187 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/ws"
+)
+
+// meshWSPath is the HTTP path the mesh websocket endpoint is served on.
+const meshWSPath = "/meshws"
+
+// meshServerConfig is the listener configuration.
+type meshServerConfig struct {
+	ListenAddr string
+	RPCKey     string
+	RPCCert    string
+	NoTLS      bool
+}
+
+// meshServer is the HTTP server that listens for inbound mesh connections.
+type meshServer struct {
+	log      dex.Logger
+	routes   map[string]meshRoute
+	listener net.Listener
+
+	mtx    sync.Mutex
+	closed bool
+}
+
+// newMeshServer binds the listen address and prepares the server. The port is
+// bound here, so a bind failure is reported before Run.
+func newMeshServer(cfg *meshServerConfig, routes map[string]meshRoute, log dex.Logger) (*meshServer, error) {
+	if cfg == nil {
+		return nil, errors.New("nil mesh server config")
+	}
+	if cfg.ListenAddr == "" {
+		return nil, errors.New("empty mesh listen address")
+	}
+
+	tlsConfig, err := buildServerTLSConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	listener, err := net.Listen("tcp", cfg.ListenAddr)
+	if err != nil {
+		return nil, err
+	}
+	if tlsConfig != nil {
+		listener = tls.NewListener(listener, tlsConfig)
+	}
+
+	return &meshServer{
+		log:      log,
+		routes:   routes,
+		listener: listener,
+	}, nil
+}
+
+// buildServerTLSConfig returns the tls.Config for the mesh listener, or nil
+// if NoTLS is set.
+func buildServerTLSConfig(cfg *meshServerConfig) (*tls.Config, error) {
+	if cfg.NoTLS {
+		return nil, nil
+	}
+	if cfg.RPCKey == "" || cfg.RPCCert == "" {
+		return nil, errors.New("TLS enabled but RPCKey or RPCCert is empty")
+	}
+	if !dex.FileExists(cfg.RPCKey) || !dex.FileExists(cfg.RPCCert) {
+		return nil, errors.New("missing cert pair file")
+	}
+	keypair, err := tls.LoadX509KeyPair(cfg.RPCCert, cfg.RPCKey)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{keypair},
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}
+
+// acceptWS upgrades the HTTP request to a websocket and wraps it in an
+// rpcConn.
+func (s *meshServer) acceptWS(ctx context.Context, w http.ResponseWriter, r *http.Request) (*rpcConn, *sync.WaitGroup, error) {
+	wsConn, err := ws.NewConnection(w, r, meshPingPeriod*2)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	conn := newRPCConn(ctx, r.RemoteAddr, wsConn, s.routes, s.log)
+	wg, err := conn.connect()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return conn, wg, nil
+}
+
+// Run serves the listener until ctx ends or the server fails.
+func (s *meshServer) Run(ctx context.Context) error {
+	connCtx, cancelConns := context.WithCancel(ctx)
+	defer cancelConns()
+
+	var wg sync.WaitGroup
+	mux := http.NewServeMux()
+	mux.HandleFunc(meshWSPath, s.handleMeshWS(connCtx, &wg))
+
+	httpServer := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+	}
+
+	serveErr := make(chan error, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.log.Infof("Mesh server listening on %s", s.listener.Addr())
+		if err := httpServer.Serve(s.listener); !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
+		}
+	}()
+
+	var runErr error
+	select {
+	case <-ctx.Done():
+	case runErr = <-serveErr:
+	}
+
+	cancelConns()
+	s.mtx.Lock()
+	s.closed = true
+	s.mtx.Unlock()
+	s.shutdown(httpServer)
+	wg.Wait()
+
+	return runErr
+}
+
+// handleMeshWS returns the HTTP handler for the websocket path. The handler
+// accepts the connection and adds a goroutine to wg that waits for the
+// connection to end.
+func (s *meshServer) handleMeshWS(ctx context.Context, wg *sync.WaitGroup) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		conn, connWG, err := s.acceptWS(ctx, w, r)
+		if err != nil {
+			if errors.Is(err, ws.ErrHandshake) {
+				s.log.Debug(err)
+			} else {
+				s.log.Errorf("mesh websocket connection error: %v", err)
+			}
+			return
+		}
+
+		s.mtx.Lock()
+		if s.closed {
+			s.mtx.Unlock()
+			return
+		}
+
+		wg.Add(1)
+		s.mtx.Unlock()
+		go func() {
+			defer wg.Done()
+			<-conn.Done()
+			connWG.Wait()
+		}()
+	}
+}
+
+func (s *meshServer) shutdown(httpServer *http.Server) {
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := httpServer.Shutdown(ctxTimeout); err != nil {
+		s.log.Warnf("mesh http.Server.Shutdown: %v", err)
+	}
+}

--- a/server/mesh/server_test.go
+++ b/server/mesh/server_test.go
@@ -1,0 +1,78 @@
+package mesh
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"github.com/gorilla/websocket"
+)
+
+func TestNewMeshServerValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *meshServerConfig
+		wantErr bool
+	}{
+		{name: "nil cfg", cfg: nil, wantErr: true},
+		{name: "empty listen addr", cfg: &meshServerConfig{NoTLS: true}, wantErr: true},
+		{name: "tls without cert/key", cfg: &meshServerConfig{ListenAddr: "127.0.0.1:0"}, wantErr: true},
+		{name: "happy path", cfg: &meshServerConfig{ListenAddr: "127.0.0.1:0", NoTLS: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := newMeshServer(tt.cfg, nil, dex.Disabled)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if s != nil {
+				_ = s.listener.Close()
+			}
+		})
+	}
+}
+
+func TestMeshServerLifecycle(t *testing.T) {
+	s, err := newMeshServer(&meshServerConfig{
+		ListenAddr: "127.0.0.1:0",
+		NoTLS:      true,
+	}, nil, dex.Disabled)
+	if err != nil {
+		t.Fatalf("newMeshServer: %v", err)
+	}
+	addr := s.listener.Addr().String()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- s.Run(ctx) }()
+
+	u := url.URL{Scheme: "ws", Host: addr, Path: meshWSPath}
+	client, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		t.Fatalf("client dial: %v", err)
+	}
+	defer client.Close()
+
+	cancel()
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run err = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+
+	// The server closes the websocket with a normal close frame. A deadline
+	// error here would mean the socket was left open.
+	_ = client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, _, err := client.ReadMessage(); !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+		t.Fatalf("client read after server shutdown = %v, want a normal close", err)
+	}
+}

--- a/server/mesh/service.go
+++ b/server/mesh/service.go
@@ -4,6 +4,7 @@
 package mesh
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -572,6 +573,68 @@ func (s *Service) applyEvent(ctx context.Context, event *Event, origin eventOrig
 	}
 
 	return result, nil
+}
+
+// applyReceivedEvent applies an event on a slave that was streamed from the
+// master.
+func (s *Service) applyReceivedEvent(ctx context.Context, entry *eventEnvelope) error {
+	// Determine the event origin. If there is a OriginCommandID on the
+	// envelope, it means this event is the result of the local node (slave)
+	// forwarding a command to the master.
+	origin := plainEventOrigin()
+	if entry.OriginCommandID != "" {
+		if len(entry.CommandResult) == 0 {
+			return fmt.Errorf("event %q for command %s missing command result", entry.Kind, entry.OriginCommandID)
+		}
+		origin = receivedCommandEventOrigin(entry.OriginCommandID)
+	}
+
+	// Skip application if this event is already stored with the same tip
+	// hash. A different hash at this sequence is a divergence error.
+	applyCtx, err := func() (*EventApplyContext, error) {
+		s.applyMtx.Lock()
+		defer s.applyMtx.Unlock()
+
+		stored, err := entryAt(ctx, s.eventLogReader, entry.Seq)
+		var applyCtx *EventApplyContext
+		switch {
+		case err != nil:
+			err = fmt.Errorf("event log entry %d: %w", entry.Seq, err)
+		case stored == nil:
+			_, applyCtx, err = s.applyEventLocal(ctx, eventFromEnvelope(entry), &db.EventLogPosition{
+				Seq:     entry.Seq,
+				TipHash: append([]byte(nil), entry.TipHash...),
+			}, origin.collectsAfterCommandResult())
+		case !bytes.Equal(stored.TipHash, entry.TipHash):
+			err = &db.EventLogDivergenceError{
+				Seq:             entry.Seq,
+				ExpectedTipHash: append([]byte(nil), entry.TipHash...),
+				ActualTipHash:   append([]byte(nil), stored.TipHash...),
+				Err:             fmt.Errorf("event log replay tip hash mismatch"),
+			}
+		}
+		return applyCtx, err
+	}()
+	if err != nil {
+		return err
+	}
+
+	// Deliver the response to the client, if the command that created this
+	// event originated on the local (slave) node.
+	if origin.kind == originReceivedCommand {
+		if err := s.commands.deliverPending(origin.commandID, entry.CommandResult); err != nil {
+			s.log.Debugf("failed to deliver event %s result for command %s: %v", entry.Kind, origin.commandID, err)
+		}
+	}
+
+	// applyCtx is nil when this seq was already in the log.
+	if applyCtx != nil {
+		for _, callback := range applyCtx.afterCommandResult {
+			callback(ctx)
+		}
+	}
+
+	return nil
 }
 
 // applyEventLocal calls the registered applier and checks that it returned

--- a/server/mesh/service.go
+++ b/server/mesh/service.go
@@ -656,6 +656,40 @@ func (s *Service) applyEventLocal(ctx context.Context, event *Event, position *d
 	return entry, applyCtx, err
 }
 
+// ProxyClientMessage relays a live client message through the active mesh
+// peer. When no peer can relay, it fails with ErrClientProxyUnavailable,
+// except broadcasts in single-server mode, which are a silent no-op. A
+// unicast whose user is not connected on the peer fails with
+// ErrClientNotConnected.
+func (s *Service) ProxyClientMessage(ctx context.Context, msg *ClientProxyMessage) error {
+	return s.transport.sendClientProxyMessage(ctx, msg)
+}
+
+// QueryClientConnected asks the peer which of the listed accounts are
+// connected to it. Large lists are split across requests; single-server mode
+// returns an empty set.
+func (s *Service) QueryClientConnected(ctx context.Context, users []account.AccountID) ([]account.AccountID, error) {
+	var connected []account.AccountID
+	for start := 0; start < len(users); start += maxClientConnectedUsers {
+		chunk, err := s.transport.queryClientConnected(ctx, users[start:min(start+maxClientConnectedUsers, len(users))])
+		if err != nil {
+			return nil, err
+		}
+		connected = append(connected, chunk...)
+	}
+	return connected, nil
+}
+
+// answerClientConnected implements the meshApplication interface.
+func (s *Service) answerClientConnected(users []account.AccountID) []account.AccountID {
+	return s.clientConnectedHandler(users)
+}
+
+// handleClientProxyMessage implements the meshApplication interface.
+func (s *Service) handleClientProxyMessage(ctx context.Context, msg *ClientProxyMessage) error {
+	return s.clientProxyHandler(ctx, msg)
+}
+
 // executeForwardedCommand implements the meshApplication interface.
 func (s *Service) executeForwardedCommand(ctx context.Context, commandID string, req CommandRequest) *msgjson.Error {
 	return s.commands.executeForwarded(ctx, commandID, req)

--- a/server/mesh/service.go
+++ b/server/mesh/service.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
@@ -428,6 +429,39 @@ func (s *Service) serve(ctx, lifeCtx context.Context) {
 			s.drain(lifeCtx)
 		}
 	case <-lifeCtx.Done():
+	}
+}
+
+// drainTimeout caps how long a graceful stop waits for the peer to catch up
+// before returning with the drain incomplete.
+const drainTimeout = 30 * time.Second
+
+// drain is the graceful-stop path after the caller cancels: it stops producing
+// new authoritative work and waits (up to drainTimeout) for the peer to catch
+// up.
+func (s *Service) drain(lifeCtx context.Context) {
+	s.workers.stopWorkers()
+
+	s.applyMtx.Lock()
+	s.eventPublishClosed = true
+	s.applyMtx.Unlock()
+
+	ctx, cancel := context.WithTimeout(lifeCtx, drainTimeout)
+	defer cancel()
+	drained, err := s.transport.drainEventStream(ctx)
+	if err != nil {
+		s.log.Errorf("Mesh drain incomplete: %v. If the peer promotes without the missing events, "+
+			"this node will halt with MESH FORK DETECTED on restart and require the manual "+
+			"--meshforkreset procedure.", err)
+		return
+	}
+	if drained {
+		s.log.Infof("Mesh drain complete: the slave holds every committed event.")
+		if err := s.transport.requestMasterHandoff(ctx); err != nil {
+			s.log.Errorf("Mesh planned handoff failed: %v", err)
+			return
+		}
+		s.log.Infof("Mesh planned handoff accepted.")
 	}
 }
 

--- a/server/mesh/service.go
+++ b/server/mesh/service.go
@@ -205,6 +205,8 @@ type Service struct {
 	eventPublishClosed bool
 }
 
+var _ meshApplication = (*Service)(nil)
+
 // NewService creates the mesh service.
 func NewService(cfg *ServiceConfig) (*Service, error) {
 	if err := cfg.validate(); err != nil {

--- a/server/mesh/service.go
+++ b/server/mesh/service.go
@@ -655,3 +655,18 @@ func (s *Service) applyEventLocal(ctx context.Context, event *Event, position *d
 	}
 	return entry, applyCtx, err
 }
+
+// executeForwardedCommand implements the meshApplication interface.
+func (s *Service) executeForwardedCommand(ctx context.Context, commandID string, req CommandRequest) *msgjson.Error {
+	return s.commands.executeForwarded(ctx, commandID, req)
+}
+
+// receiveCommandFailure implements the meshApplication interface.
+func (s *Service) receiveCommandFailure(commandID string, msgErr *msgjson.Error) {
+	s.commands.receiveForwardedFailure(commandID, msgErr)
+}
+
+// receiveCommandResult implements the meshApplication interface.
+func (s *Service) receiveCommandResult(commandID string, result json.RawMessage) {
+	s.commands.receiveForwardedResult(commandID, result)
+}

--- a/server/mesh/service.go
+++ b/server/mesh/service.go
@@ -1,0 +1,592 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
+	"decred.org/dcrdex/server/db"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+// MasterWorker is an application worker that is run while the node is the
+// master. These emit events that are not initiated by a client, such as
+// progressing markets, revoking orders, etc.
+type MasterWorker struct {
+	Name string
+	// Run starts the worker. Call reportReady with nil once the worker is ready.
+	// A non-nil error, or returning without reporting, halts the node. Extra calls
+	// are ignored.
+	Run func(ctx context.Context, reportReady func(error))
+}
+
+// StateLoader loads state from the database into memory.
+type StateLoader struct {
+	Name string
+	Load func(context.Context) error
+}
+
+// commandTransport routes state-changing client commands between mesh peers:
+// slave-to-master forwarding and master-to-slave completion delivery.
+type commandTransport interface {
+	canExecuteCommandLocally() bool
+	canForwardCommand() bool
+	forwardCommand(context.Context, *commandForward) (msgErr *msgjson.Error, outcomeUnknown bool)
+	sendCommandFailure(context.Context, *commandFailure) error
+	sendCommandResult(context.Context, *commandResult) error
+}
+
+// meshTransport is the exposed surface of the mesh node. It is
+// implemented by both node and singleServerTransport (which contains
+// mostly no-ops).
+type meshTransport interface {
+	commandTransport
+
+	connect(context.Context) (*sync.WaitGroup, error)
+	notifyMasterReady() error
+	notifyMasterPreparationFailed(error) error
+	ensureSeeded(context.Context) error
+	notifyReadyForEvents()
+	haltStatus() (bool, error)
+	drainEventStream(context.Context) (bool, error)
+	requestMasterHandoff(context.Context) error
+	checkEventPublishAvailable(forwardedCommand bool) error
+	notifyLocalEventCommitted(seq uint64, originCommandID string, commandResult json.RawMessage)
+	postTerminalApplyFailureIfNeeded(error)
+	sendClientProxyMessage(context.Context, *ClientProxyMessage) error
+	queryClientConnected(context.Context, []account.AccountID) ([]account.AccountID, error)
+	fillStatus(*Status)
+}
+
+// ServiceConfig configures the mesh service. To run in single-server mode,
+// leave ListenAddr and PeerAddr empty.
+type ServiceConfig struct {
+	// DataDir is the directory to store persistent mesh node state.
+	DataDir string
+
+	// ListenAddr is the address to listen for incoming mesh connections.
+	// Empty in single-server mode.
+	ListenAddr string
+
+	// PeerAddr is the address of the peer to connect to.
+	// Empty in single-server mode.
+	PeerAddr string
+
+	// PeerCert is required for a TLS-enabled peer. It can be empty for non-TLS.
+	PeerCert []byte
+
+	// RPCKey is the path to the TLS private key for the local mesh listener.
+	RPCKey string
+
+	// RPCCert is the path to the TLS certificate for the local mesh listener.
+	RPCCert string
+
+	// NoTLS disables TLS on the local mesh listener.
+	NoTLS bool
+
+	// Compat contains the configuration and hash compared during handshake.
+	Compat *CompatSnapshot
+
+	// DEXPrivKey is the server's client-facing signing identity. Both mesh
+	// nodes must share this key.
+	DEXPrivKey *secp256k1.PrivateKey
+
+	// SnapshotStore is the persistence interface for snapshot storage and
+	// loading.
+	SnapshotStore db.SnapshotStore
+
+	// EventLogReader is the interface for querying the event log.
+	EventLogReader db.EventLogReader
+
+	// Logger is the logger for the mesh service.
+	Logger dex.Logger
+
+	// ClientHost is this node's client facing address, advertised to the peer.
+	ClientHost string
+
+	// ClientCert is this node's client facing TLS certificate, advertised
+	// to the peer.
+	ClientCert []byte
+
+	// Commands map command types to their executors.
+	Commands map[string]CommandExecutor
+
+	// Events map event types to their appliers.
+	Events map[string]EventApplier
+
+	// MasterWorkers run while the node is the master (in single-server mode,
+	// always). They are started one at a time in registration order, after the
+	// state loaders have completed; each must report ready before the next
+	// starts.
+	MasterWorkers []MasterWorker
+
+	// StateLoaders load state from the database into memory. They run once, in
+	// registration order, during startup, after any required snapshot seed (a
+	// brand-new node seeds from the peer first). A loader error fails startup.
+	StateLoaders []StateLoader
+
+	// ClientProxyHandler is called when the other mesh server asks us to
+	// deliver a client message. If the message is for one user and that user
+	// is not connected here, return ErrClientNotConnected.
+	ClientProxyHandler func(context.Context, *ClientProxyMessage) error
+
+	// ClientConnectedHandler answers the peer's connectivity query: return
+	// the subset of users currently connected to this node.
+	ClientConnectedHandler func(users []account.AccountID) []account.AccountID
+
+	// PeerClientEndpointChanged is called with the peer's advertised
+	// client-facing host/cert at each handshake adoption.
+	PeerClientEndpointChanged func(string, []byte)
+
+	// OnHalt is called when a live mesh (after startup has completed) halts.
+	OnHalt func(error)
+}
+
+func (cfg *ServiceConfig) validate() error {
+	if cfg == nil {
+		return fmt.Errorf("nil mesh service config")
+	}
+	if cfg.EventLogReader == nil {
+		return fmt.Errorf("event log reader is required")
+	}
+	if cfg.OnHalt == nil {
+		return fmt.Errorf("OnHalt handler is required")
+	}
+
+	transportEnabled := cfg.ListenAddr != "" || cfg.PeerAddr != ""
+	allTransportConfigDefined := cfg.ClientHost != "" && cfg.ListenAddr != "" && cfg.PeerAddr != ""
+	if transportEnabled && !allTransportConfigDefined {
+		return fmt.Errorf("client host, listen addr, and peer addr are required when mesh transport is enabled")
+	}
+
+	return nil
+}
+
+// Service is the mesh service: the application-facing surface over the mesh transport.
+type Service struct {
+	log dex.Logger
+
+	transport      meshTransport
+	eventLogReader db.EventLogReader
+
+	commands *commandCoordinator
+	events   map[string]EventApplier
+
+	clientProxyHandler     func(context.Context, *ClientProxyMessage) error
+	clientConnectedHandler func(users []account.AccountID) []account.AccountID
+
+	masterWorkers []MasterWorker
+
+	workers *workerSupervisor
+
+	stateLoaders []StateLoader
+	loadOnce     sync.Once
+	loaded       *readiness
+
+	lifeCtx    context.Context
+	lifeCancel context.CancelFunc
+	runWG      sync.WaitGroup
+
+	// ready resolves once client comms can start (or startup failed).
+	ready *readiness
+
+	onHalt   func(error)
+	haltOnce sync.Once
+
+	applyMtx           sync.Mutex
+	eventPublishClosed bool
+}
+
+// NewService creates the mesh service.
+func NewService(cfg *ServiceConfig) (*Service, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
+	log := cfg.Logger
+	if log == nil {
+		log = dex.Disabled
+	}
+
+	s := &Service{
+		log:                    log,
+		eventLogReader:         cfg.EventLogReader,
+		events:                 cfg.Events,
+		clientProxyHandler:     cfg.ClientProxyHandler,
+		clientConnectedHandler: cfg.ClientConnectedHandler,
+		masterWorkers:          append([]MasterWorker(nil), cfg.MasterWorkers...),
+		stateLoaders:           append([]StateLoader(nil), cfg.StateLoaders...),
+		loaded:                 newReadiness(),
+		onHalt:                 cfg.OnHalt,
+		ready:                  newReadiness(),
+	}
+
+	// Single server mode
+	transportEnabled := cfg.ListenAddr != "" || cfg.PeerAddr != ""
+	if !transportEnabled {
+		transport := newSingleServerTransport()
+		transport.becameMaster = func() { s.workers.startWorkers() }
+		s.transport = transport
+		s.commands = newCommandCoordinator(log, transport, "", cfg.Commands, s.applyEvent)
+		return s, nil
+	}
+
+	frontier, err := cfg.EventLogReader.EventLogFrontier(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("event log frontier: %w", err)
+	}
+
+	nodeCfg := &nodeConfig{
+		dataDir:        cfg.DataDir,
+		listenAddr:     cfg.ListenAddr,
+		peerAddr:       cfg.PeerAddr,
+		peerCert:       cfg.PeerCert,
+		rpcKey:         cfg.RPCKey,
+		rpcCert:        cfg.RPCCert,
+		noTLS:          cfg.NoTLS,
+		compat:         cfg.Compat,
+		dexPrivKey:     cfg.DEXPrivKey,
+		eventLogReader: cfg.EventLogReader,
+		snapshotStore:  cfg.SnapshotStore,
+		logger:         log,
+		app:            s,
+		lifecycle: lifecycleHooks{
+			becameMaster:              func() { s.workers.startWorkers() },
+			peerClientEndpointChanged: cfg.PeerClientEndpointChanged,
+			failPendingCommands:       func(reason string) { s.commands.failAllPending(reason) },
+			halted:                    s.notifyHalt,
+		},
+		initialFrontier: frontier,
+	}
+	nodeCfg.clientHost = cfg.ClientHost
+	nodeCfg.clientCert = append([]byte(nil), cfg.ClientCert...)
+	node, err := newNode(nodeCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	s.transport = node
+	s.commands = newCommandCoordinator(log, node, node.nodeID, cfg.Commands, s.applyEvent)
+
+	return s, nil
+}
+
+// ensureLoaded runs the state loaders once, after any required snapshot
+// has been loaded.
+func (s *Service) ensureLoaded(ctx context.Context) error {
+	s.loadOnce.Do(func() {
+		if err := s.transport.ensureSeeded(ctx); err != nil {
+			s.loaded.resolve(fmt.Errorf("snapshot seed from mesh peer failed: %w", err))
+			return
+		}
+		err := s.runLoaders(ctx)
+		s.loaded.resolve(err)
+		if err == nil {
+			s.transport.notifyReadyForEvents()
+		}
+	})
+	return s.loaded.wait(ctx)
+}
+
+// runLoaders runs the registered state loaders in order, failing fast on the
+// first error.
+func (s *Service) runLoaders(ctx context.Context) error {
+	for _, loader := range s.stateLoaders {
+		if loader.Load == nil {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		s.log.Infof("Running mesh state loader %q.", loader.Name)
+		if err := loader.Load(ctx); err != nil {
+			err = fmt.Errorf("state loader %q: %w", loader.Name, err)
+			s.log.Errorf("Mesh state loaders failed: %v", err)
+			return err
+		}
+	}
+	s.log.Infof("Mesh state loaders complete.")
+	return nil
+}
+
+// failStartup resolves comms readiness with a startup failure.
+// It replaces the error with the transport's halt reason when the
+// transport has halted.
+func (s *Service) failStartup(err error) {
+	if halted, haltErr := s.transport.haltStatus(); halted {
+		err = haltErr
+	}
+	s.ready.resolve(err)
+	s.lifeCancel()
+}
+
+// Run starts the mesh and blocks until ctx is canceled or the mesh tears
+// down internally (startup failure or halt). Must be called at most once
+// per Service. Canceling ctx is a graceful stop and may wait for the peer
+// to catch up before returning.
+func (s *Service) Run(ctx context.Context) {
+	// Deliberately not a child of ctx: the drain must outlive the stop
+	// request, with the transport still up.
+	lifeCtx, cancelLife := context.WithCancel(context.Background())
+	s.lifeCtx, s.lifeCancel = lifeCtx, cancelLife
+
+	var transportWG *sync.WaitGroup
+	defer func() {
+		cancelLife() // a no-op on failure paths: failStartup already canceled
+		if transportWG != nil {
+			transportWG.Wait()
+		}
+		s.runWG.Wait()
+	}()
+
+	var ok bool
+	if transportWG, ok = s.startup(ctx, lifeCtx); !ok {
+		return
+	}
+	s.serve(ctx, lifeCtx)
+}
+
+// startup brings the mesh up far enough to serve. On failure, lifeCtx is already
+// canceled via failStartup and the bool is false. On success the returned
+// WaitGroup is the transport's and must be waited on after lifeCtx ends.
+func (s *Service) startup(ctx, lifeCtx context.Context) (*sync.WaitGroup, bool) {
+	// Start the worker supervisor before connect so becameMaster can start workers.
+	s.workers = newWorkerSupervisor(s.masterWorkers, s.log, s.ensureLoaded, s.handleMasterWorkerReadiness)
+	s.workers.startSupervisor(lifeCtx, &s.runWG)
+
+	startupDone := make(chan struct{})
+	defer close(startupDone)
+	s.watchStartupStop(ctx, startupDone)
+
+	// Run loading alongside connection setup so it can fetch a snapshot
+	// when the peer connects.
+	s.runWG.Add(1)
+	go func() {
+		defer s.runWG.Done()
+		if err := s.ensureLoaded(lifeCtx); err != nil {
+			s.failStartup(err)
+		}
+	}()
+
+	// Start the transport
+	transportWG, err := s.transport.connect(lifeCtx)
+	if err != nil {
+		// lifeCtx already canceled means another path failed startup first.
+		if lifeCtx.Err() == nil {
+			s.log.Errorf("mesh transport startup error: %v", err)
+		}
+		s.failStartup(fmt.Errorf("mesh transport startup error: %w", err))
+		return nil, false
+	}
+
+	if err := s.loaded.wait(lifeCtx); err != nil {
+		s.failStartup(err)
+		return transportWG, false
+	}
+
+	return transportWG, true
+}
+
+// watchStartupStop fails startup if the caller cancels ctx before startup
+// finishes. Once startupDone is closed, cancel is left for serve (which may
+// drain) instead of treating it as a startup failure.
+func (s *Service) watchStartupStop(ctx context.Context, startupDone <-chan struct{}) {
+	s.runWG.Add(1)
+	go func() {
+		defer s.runWG.Done()
+		select {
+		case <-ctx.Done():
+			select {
+			case <-startupDone:
+			default:
+				s.failStartup(ctx.Err())
+			}
+		case <-startupDone:
+		}
+	}()
+}
+
+// serve resolves comms readiness, then waits for a caller stop (drain then
+// tear down) or an internal teardown (no drain).
+func (s *Service) serve(ctx, lifeCtx context.Context) {
+	s.ready.resolve(nil)
+
+	select {
+	case <-ctx.Done():
+		if lifeCtx.Err() == nil {
+			s.drain(lifeCtx)
+		}
+	case <-lifeCtx.Done():
+	}
+}
+
+// WaitUntilReadyForComms blocks until clients may connect, or returns the
+// startup or halt error (clients will never connect).
+func (s *Service) WaitUntilReadyForComms(ctx context.Context) error {
+	return s.ready.wait(ctx)
+}
+
+func (s *Service) handleMasterWorkerReadiness(ctx context.Context, err error) {
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, ctxErr) {
+			return
+		}
+		s.reportMeshMasterPreparationFailed(ctx, err)
+		return
+	}
+
+	if err := s.transport.notifyMasterReady(); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		s.reportMeshMasterPreparationFailed(ctx,
+			fmt.Errorf("mesh master readiness transition failed: %w", err))
+	}
+}
+
+func (s *Service) reportMeshMasterPreparationFailed(ctx context.Context, err error) {
+	s.log.Errorf("%v", err)
+	if postErr := s.transport.notifyMasterPreparationFailed(err); postErr != nil && ctx.Err() == nil {
+		s.log.Errorf("failed to post mesh master preparation failure: %v", postErr)
+		s.lifeCancel()
+	}
+}
+
+func (s *Service) notifyHalt(err error) {
+	if err == nil {
+		err = fmt.Errorf("mesh halted")
+	}
+
+	// If startup already resolved, this is a no-op.
+	s.ready.resolve(fmt.Errorf("mesh halted during startup: %w", err))
+
+	// If startup already resolved with a failure, do nothing.
+	if err, _ := s.ready.result(); err != nil {
+		return
+	}
+
+	// The halt did not happen during startup, so deliver a live halt.
+	s.haltOnce.Do(func() {
+		s.onHalt(err)
+	})
+}
+
+// ExecuteCommand runs a command locally or forwards it to the master.
+// A command may emit an event or complete without one. Mesh delivers its
+// response through req.Respond. If an error is returned, the caller sends
+// that error to the client and req.Respond is not called.
+func (s *Service) ExecuteCommand(ctx context.Context, req CommandRequest) *msgjson.Error {
+	return s.commands.execute(ctx, req)
+}
+
+// ApplyEvent originates an event. This is only called by the master (or
+// single server). If we are not in single server mode, and the node currently
+// cannot publish events, an error is returned.
+//
+// The return value is whatever was set by the event applier, using SetResult.
+// If nothing was set, the result is nil.
+func (s *Service) ApplyEvent(ctx context.Context, event *Event) (any, error) {
+	return s.applyEvent(ctx, event, plainEventOrigin())
+}
+
+// applyEvent applies an event. This is the path used by the master. It
+// applies the event, and after successful application notifies the event
+// stream of the new event so it can be sent to the slave.
+func (s *Service) applyEvent(ctx context.Context, event *Event, origin eventOrigin) (any, error) {
+	// Serialize event application and stream notification under
+	// the applyMtx.
+	result, applyCtx, err := func() (any, *EventApplyContext, error) {
+		s.applyMtx.Lock()
+		defer s.applyMtx.Unlock()
+
+		if s.eventPublishClosed {
+			return nil, nil, fmt.Errorf("mesh master is shutting down: %w", ErrUnavailable)
+		}
+
+		if err := s.transport.checkEventPublishAvailable(origin.commandID != ""); err != nil {
+			return nil, nil, err
+		}
+
+		appliedEvent, applyCtx, err := s.applyEventLocal(ctx, event, nil, origin.collectsAfterCommandResult())
+		if err != nil {
+			return nil, nil, err
+		}
+
+		result := applyCtx.Result()
+		if origin.resultFn != nil {
+			result = origin.resultFn()
+		}
+
+		// If the event is a result of a forwarded command from the slave, serialize
+		// the result so it can be sent to the slave.
+		var commandResultRaw json.RawMessage
+		originCommandID := origin.commandID
+		if origin.kind == originForwardedCommand {
+			commandResultRaw, err = json.Marshal(result)
+			if err != nil {
+				// The event is durable; only the result reply is lost. Stream the
+				// row as a plain event so the slave still applies it and its
+				// pending command expires to a retryable answer.
+				s.log.Errorf("Failed to encode %s result for forwarded command %s: %v",
+					event.Kind, origin.commandID, err)
+				originCommandID = ""
+				commandResultRaw = nil
+			}
+		}
+
+		// Notify that a new event is ready to be sent to the slave.
+		s.transport.notifyLocalEventCommitted(appliedEvent.Seq, originCommandID, commandResultRaw)
+
+		return result, applyCtx, nil
+	}()
+	if err != nil {
+		s.transport.postTerminalApplyFailureIfNeeded(err)
+		return nil, err
+	}
+
+	// Event is durable. Client delivery may perform network I/O, so it runs
+	// outside applyMtx; delivery errors are logged, not returned.
+	if deliverErr := origin.deliverLocalResult(result); deliverErr != nil {
+		if errors.Is(deliverErr, errEncodeCommandResult) {
+			s.log.Errorf("Failed to encode %s command result: %v", event.Kind, deliverErr)
+		} else {
+			s.log.Infof("Unable to send %s command result to client: %v", event.Kind, deliverErr)
+		}
+	}
+
+	// Run any after-command-result callbacks.
+	if applyCtx != nil {
+		for _, callback := range applyCtx.afterCommandResult {
+			callback(ctx)
+		}
+	}
+
+	return result, nil
+}
+
+// applyEventLocal calls the registered applier and checks that it returned
+// an event-log entry on success.
+func (s *Service) applyEventLocal(ctx context.Context, event *Event, position *db.EventLogPosition, collectAfter bool) (*db.EventLogEntry, *EventApplyContext, error) {
+	applyCtx := &EventApplyContext{
+		Context:                   ctx,
+		Position:                  position,
+		collectAfterCommandResult: collectAfter,
+	}
+	apply := s.events[event.Kind]
+	if apply == nil {
+		return nil, applyCtx, fmt.Errorf("unsupported mesh event kind %q", event.Kind)
+	}
+	entry, err := apply(applyCtx, event)
+	if err == nil && entry == nil {
+		return nil, applyCtx, fmt.Errorf("applier for event kind %q returned no durable event-log row", event.Kind)
+	}
+	return entry, applyCtx, err
+}

--- a/server/mesh/service_test.go
+++ b/server/mesh/service_test.go
@@ -80,6 +80,20 @@ func (f *testTransport) haltStatus() (bool, error) {
 	return false, nil
 }
 
+func (f *testTransport) drainEventStream(ctx context.Context) (bool, error) {
+	if f.drain != nil {
+		return f.drain(ctx)
+	}
+	return false, nil
+}
+
+func (f *testTransport) requestMasterHandoff(ctx context.Context) error {
+	if f.handoff != nil {
+		return f.handoff(ctx)
+	}
+	return nil
+}
+
 func (f *testTransport) notifyMasterReady() error {
 	f.master = true
 	if f.notifyMasterReadyCalled != nil {
@@ -210,6 +224,17 @@ func (f *testTransport) postTerminalApplyFailureIfNeeded(err error) {
 func (f *testTransport) postEvent(ev meshSignal) error {
 	f.postedEvents = append(f.postedEvents, ev)
 	return nil
+}
+
+func (f *testTransport) fillStatus(st *Status) {
+	switch {
+	case f.master:
+		st.Mode = modeEstablishedMaster.String()
+	case f.slave:
+		st.Mode = modeEstablishedSlave.String()
+	default:
+		st.Mode = modePending.String()
+	}
 }
 
 func (f *testTransport) canExecuteCommandLocally() bool {
@@ -1760,4 +1785,172 @@ func TestRunSeedsBeforeLoaders(t *testing.T) {
 	if !reflect.DeepEqual(order, want) {
 		t.Fatalf("startup order = %v, want %v", order, want)
 	}
+}
+
+func TestServiceDrain(t *testing.T) {
+	applied := make(chan string, 4)
+	workerStarted := make(chan struct{})
+	workerExited := make(chan struct{})
+	drainCalled := make(chan struct{}, 1)
+	handoffCalled := make(chan struct{}, 1)
+	var drainComplete atomic.Bool
+	svc := &Service{
+		loaded: newReadiness(),
+		log:    dex.Disabled,
+		ready:  newReadiness(),
+		events: map[string]EventApplier{
+			"k": func(_ *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+				applied <- string(event.Payload)
+				return &db.EventLogEntry{Seq: 1, Kind: event.Kind}, nil
+			},
+		},
+		masterWorkers: []MasterWorker{{
+			Name: "test",
+			Run: func(ctx context.Context, reportReady func(error)) {
+				reportReady(nil)
+				close(workerStarted)
+				<-ctx.Done()
+				close(workerExited)
+			},
+		}},
+	}
+	sealRejected := func(err error) bool {
+		return errors.Is(err, ErrUnavailable)
+	}
+	svc.transport = &testTransport{
+		drain: func(context.Context) (bool, error) {
+			select {
+			case <-workerExited:
+			default:
+				t.Error("drainEventStream ran before the master worker exited")
+			}
+			// The measurement runs strictly after the seal: a commit
+			// attempted from here must already be rejected.
+			if _, err := svc.ApplyEvent(context.Background(), &Event{Kind: "k", Payload: []byte("mid-drain")}); !sealRejected(err) {
+				t.Errorf("mid-drain ApplyEvent err = %v, want ErrUnavailable", err)
+			}
+			drainCalled <- struct{}{}
+			drainComplete.Store(true)
+			return true, nil
+		},
+		handoff: func(context.Context) error {
+			if !drainComplete.Load() {
+				t.Error("master handoff ran before the event stream drained")
+			}
+			handoffCalled <- struct{}{}
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := runServiceForTest(ctx, svc)
+
+	readyCtx, readyCancel := context.WithTimeout(context.Background(), time.Second)
+	defer readyCancel()
+	if err := svc.WaitUntilReadyForComms(readyCtx); err != nil {
+		t.Fatalf("WaitUntilReadyForComms: %v", err)
+	}
+
+	svc.workers.startWorkers()
+	select {
+	case <-workerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("master worker did not start")
+	}
+
+	// Publication is open while the service runs.
+	if _, err := svc.ApplyEvent(context.Background(), &Event{Kind: "k", Payload: []byte("live")}); err != nil {
+		t.Fatalf("live ApplyEvent: %v", err)
+	}
+	if got := <-applied; got != "live" {
+		t.Fatalf("applied %q, want live", got)
+	}
+
+	cancel()
+	select {
+	case <-drainCalled:
+	case <-time.After(time.Second):
+		t.Fatal("transport drain was not called")
+	}
+	select {
+	case <-handoffCalled:
+	case <-time.After(time.Second):
+		t.Fatal("master handoff was not requested after the drain")
+	}
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after the drain")
+	}
+
+	if _, err := svc.ApplyEvent(context.Background(), &Event{Kind: "k", Payload: []byte("late")}); !sealRejected(err) {
+		t.Fatalf("post-drain ApplyEvent err = %v, want ErrUnavailable", err)
+	}
+	select {
+	case extra := <-applied:
+		t.Fatalf("event %q applied through the seal", extra)
+	default:
+	}
+}
+
+// TestServiceStopWithoutDrain checks that startup cancellation and an
+// internal shutdown do not drain replication.
+func TestServiceStopWithoutDrain(t *testing.T) {
+	newSvc := func(t *testing.T, loaders []StateLoader) *Service {
+		return &Service{
+			loaded: newReadiness(),
+			log:    dex.Disabled,
+			transport: &testTransport{drain: func(context.Context) (bool, error) {
+				t.Error("drain ran on a no-drain stop path")
+				return false, nil
+			}},
+			stateLoaders: loaders,
+			ready:        newReadiness(),
+		}
+	}
+
+	t.Run("stop during blocked startup aborts", func(t *testing.T) {
+		svc := newSvc(t, []StateLoader{{
+			Name: "blocked",
+			Load: func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}})
+		ctx, cancel := context.WithCancel(context.Background())
+		runDone := runServiceForTest(ctx, svc)
+		cancel()
+
+		select {
+		case <-runDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Run did not return after a stop during blocked startup")
+		}
+		readyCtx, readyCancel := context.WithTimeout(context.Background(), time.Second)
+		defer readyCancel()
+		if err := svc.WaitUntilReadyForComms(readyCtx); err == nil {
+			t.Fatal("readiness resolved without error for an aborted startup")
+		}
+	})
+
+	t.Run("internal cancel after ready", func(t *testing.T) {
+		svc := newSvc(t, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		runDone := runServiceForTest(ctx, svc)
+
+		readyCtx, readyCancel := context.WithTimeout(context.Background(), time.Second)
+		defer readyCancel()
+		if err := svc.WaitUntilReadyForComms(readyCtx); err != nil {
+			t.Fatalf("WaitUntilReadyForComms: %v", err)
+		}
+
+		svc.lifeCancel()
+		select {
+		case <-runDone:
+		case <-time.After(time.Second):
+			t.Fatal("Run did not return after an internal cancel")
+		}
+	})
 }

--- a/server/mesh/service_test.go
+++ b/server/mesh/service_test.go
@@ -9,8 +9,10 @@ import (
 	"encoding/json"
 	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -107,6 +109,64 @@ func requireServiceReadyBlocked(t testing.TB, svc *Service, desc string) {
 	}
 }
 
+// registerPeerService links two test services synchronously. This is only test
+// plumbing for exercising service-to-service flow without websocket transport.
+func (f *testTransport) registerPeerService(peer *Service) {
+	f.peer = peer
+}
+
+func (f *testTransport) forwardCommand(ctx context.Context, cmd *commandForward) (*msgjson.Error, bool) {
+	var kind string
+	if cmd != nil {
+		kind = cmd.Kind
+	}
+	if !f.slave {
+		return msgjson.NewError(msgjson.TryAgainLaterError,
+			"mesh command %q cannot be forwarded; retry the request", kind), false
+	}
+
+	f.commandForwards = append(f.commandForwards, cmd)
+	if f.err != nil {
+		var peerErr *peerRPCError
+		if errors.As(f.err, &peerErr) {
+			return peerErr.MsgError(), false
+		}
+		return nil, true
+	}
+	if f.peer != nil {
+		if msgErr := f.peer.executeForwardedCommand(ctx, cmd.CommandID, CommandRequest{
+			Kind: cmd.Kind,
+			User: cmd.User,
+			Msg:  cmd.Msg,
+		}); msgErr != nil {
+			return msgErr, false
+		}
+	}
+	return nil, false
+}
+
+func (f *testTransport) sendCommandFailure(_ context.Context, fail *commandFailure) error {
+	f.commandFailures = append(f.commandFailures, fail)
+	if f.err != nil {
+		return f.err
+	}
+	if f.peer != nil {
+		f.peer.receiveCommandFailure(fail.CommandID, fail.Error)
+	}
+	return nil
+}
+
+func (f *testTransport) sendCommandResult(_ context.Context, result *commandResult) error {
+	f.commandResults = append(f.commandResults, result)
+	if f.err != nil {
+		return f.err
+	}
+	if f.peer != nil {
+		f.peer.receiveCommandResult(result.CommandID, result.Result)
+	}
+	return nil
+}
+
 func (f *testTransport) notifyLocalEventCommitted(seq uint64, originCommandID string, commandResult json.RawMessage) {
 	if f.owner == nil || seq == 0 || seq > uint64(len(f.owner.appliedEvents)) {
 		return
@@ -148,6 +208,59 @@ func (f *testTransport) canForwardCommand() bool {
 
 func (f *testTransport) checkEventPublishAvailable(bool) error {
 	return f.eventPublishErr
+}
+
+func (f *testTransport) requireForwardedCommand(t *testing.T, req CommandRequest) *commandForward {
+	t.Helper()
+	if len(f.commandForwards) != 1 {
+		t.Fatalf("forwarded commands = %d, want 1", len(f.commandForwards))
+	}
+	cmd := f.commandForwards[0]
+	if cmd.CommandID == "" {
+		t.Fatalf("forwarded command has empty command id")
+	}
+	if cmd.Kind != req.Kind || cmd.User != req.User || cmd.Msg != req.Msg {
+		t.Fatalf("forwarded command mismatch: %+v", cmd)
+	}
+	return cmd
+}
+
+func (f *testTransport) requireNoForwardedCommands(t *testing.T) {
+	t.Helper()
+	if len(f.commandForwards) != 0 {
+		t.Fatalf("forwarded commands = %d, want 0", len(f.commandForwards))
+	}
+}
+
+func (f *testTransport) requireCommittedEvent(t *testing.T, originCommandID string) {
+	t.Helper()
+	if len(f.committedEvents) != 1 {
+		t.Fatalf("committed events = %d, want 1", len(f.committedEvents))
+	}
+	if got := f.committedEvents[0].OriginCommandID; got != originCommandID {
+		t.Fatalf("committed origin command id = %q, want %q", got, originCommandID)
+	}
+}
+
+func (f *testTransport) requireCommandResult(t *testing.T, commandID string) {
+	t.Helper()
+	if len(f.commandResults) != 1 {
+		t.Fatalf("command results = %d, want 1", len(f.commandResults))
+	}
+	if got := f.commandResults[0].CommandID; got != commandID {
+		t.Fatalf("command result id = %q, want %s", got, commandID)
+	}
+}
+
+func (f *testTransport) requireCommandFailure(t *testing.T, commandID string, code int) {
+	t.Helper()
+	if len(f.commandFailures) != 1 {
+		t.Fatalf("command failures = %d, want 1", len(f.commandFailures))
+	}
+	fail := f.commandFailures[0]
+	if fail.CommandID != commandID || fail.Error.Code != code {
+		t.Fatalf("command failure = %+v, want command %s code %d", fail, commandID, code)
+	}
 }
 
 func newTestService(t *testing.T, exec CommandExecutor, transport *testTransport) *testService {
@@ -266,11 +379,97 @@ func (s *testService) requireAppliedPayload(t *testing.T, want string) {
 	}
 }
 
+func (s *testService) requirePending(t *testing.T, commandID string) {
+	t.Helper()
+	s.commands.pendingMtx.Lock()
+	defer s.commands.pendingMtx.Unlock()
+	if s.commands.pending[commandID] == nil {
+		t.Fatalf("pending command %q was not retained", commandID)
+	}
+}
+
+func (s *testService) requirePendingRemoved(t *testing.T, commandID string) {
+	t.Helper()
+	s.commands.pendingMtx.Lock()
+	defer s.commands.pendingMtx.Unlock()
+	if s.commands.pending[commandID] != nil {
+		t.Fatalf("pending command %q was not removed", commandID)
+	}
+}
+
+func (s *testService) requireNoPending(t *testing.T) {
+	t.Helper()
+	s.commands.pendingMtx.Lock()
+	defer s.commands.pendingMtx.Unlock()
+	if len(s.commands.pending) != 0 {
+		t.Fatalf("pending commands = %d, want 0", len(s.commands.pending))
+	}
+}
+
+type linkedTestServices struct {
+	master *testService
+	slave  *testService
+}
+
+func newLinkedTestServices(t *testing.T, masterExec CommandExecutor) *linkedTestServices {
+	t.Helper()
+	masterTransport := &testTransport{master: true}
+	slaveTransport := &testTransport{slave: true}
+	master := newTestService(t, masterExec, masterTransport)
+	slave := newTestService(t, nil, slaveTransport)
+	masterTransport.registerPeerService(slave.Service)
+	slaveTransport.registerPeerService(master.Service)
+	return &linkedTestServices{master: master, slave: slave}
+}
+
+func (s *linkedTestServices) forwardCommand(t *testing.T, req CommandRequest) string {
+	t.Helper()
+	if rpcErr := s.slave.ExecuteCommand(context.Background(), req); rpcErr != nil {
+		t.Fatalf("ExecuteCommand error: %v", rpcErr)
+	}
+	return s.slave.testTransport.requireForwardedCommand(t, req).CommandID
+}
+
+func (s *testCommandResponder) requireErrorCode(t *testing.T, want int) {
+	t.Helper()
+	if len(s.sent) != 1 {
+		t.Fatalf("responses = %d, want 1", len(s.sent))
+	}
+	resp, err := s.sent[0].Response()
+	if err != nil {
+		t.Fatalf("response decode: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != want {
+		t.Fatalf("response error = %+v, want code %d", resp.Error, want)
+	}
+}
+
 func (s *testCommandResponder) requireNoResponses(t *testing.T) {
 	t.Helper()
 	if len(s.sent) != 0 {
 		t.Fatalf("responses = %d, want 0", len(s.sent))
 	}
+}
+
+func requireGeneratedCommandID(t *testing.T, commandID string) {
+	t.Helper()
+	suffix, ok := strings.CutPrefix(commandID, "test-node-")
+	if !ok {
+		t.Fatalf("command id = %q, want test-node prefix", commandID)
+	}
+	if suffix == "" {
+		t.Fatalf("command id = %q, want numeric suffix", commandID)
+	}
+	if _, err := strconv.ParseUint(suffix, 10, 64); err != nil {
+		t.Fatalf("command id suffix %q is not numeric: %v", suffix, err)
+	}
+}
+
+func boolInt(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
 }
 
 func requireExecuteCommandError(t *testing.T, got *msgjson.Error, wantCode int, wantErr *msgjson.Error) {
@@ -318,6 +517,91 @@ func TestServiceApplyEvent(t *testing.T) {
 		if applyCalled {
 			t.Fatal("applier was called unexpectedly")
 		}
+		if got := len(transport.committedEvents); got != 0 {
+			t.Fatalf("committed events = %d, want 0", got)
+		}
+		if got := len(transport.postedEvents); got != 0 {
+			t.Fatalf("posted events = %d, want 0", got)
+		}
+	})
+
+	t.Run("rejects forwarded command in single-server mode", func(t *testing.T) {
+		result := map[string]string{"status": "ok"}
+		svc := newTestService(t, nil, nil)
+		apply := svc.events["test"]
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return apply(applyCtx, event)
+		}
+
+		responder := new(testCommandResponder)
+		req := testCommandRequest(t)
+		req.Respond = responder.Send
+		completion := newCommandCompletion("cmd-forwarded", req, svc.commands)
+		resultCalled := false
+		origin := completion.eventOrigin(func() any {
+			resultCalled = true
+			return result
+		})
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("rejects forwarded command in single-server mode"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if err == nil {
+			t.Fatal("apply succeeded, want error")
+		}
+		if applyCalled {
+			t.Fatal("applier was called unexpectedly")
+		}
+		if resultCalled {
+			t.Fatal("result callback was called unexpectedly")
+		}
+		responder.requireNoResponses(t)
+	})
+
+	t.Run("rejects forwarded command when delivery is unavailable", func(t *testing.T) {
+		result := map[string]string{"status": "ok"}
+		transport := &testTransport{eventPublishErr: errors.New("mesh event publisher unavailable for command cmd-forwarded")}
+		svc := newTestService(t, nil, transport)
+		apply := svc.events["test"]
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return apply(applyCtx, event)
+		}
+
+		responder := new(testCommandResponder)
+		req := testCommandRequest(t)
+		req.Respond = responder.Send
+		completion := newCommandCompletion("cmd-forwarded", req, svc.commands)
+		resultCalled := false
+		origin := completion.eventOrigin(func() any {
+			resultCalled = true
+			return result
+		})
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("rejects forwarded command when delivery is unavailable"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if err == nil {
+			t.Fatal("apply succeeded, want error")
+		}
+		if applyCalled {
+			t.Fatal("applier was called unexpectedly")
+		}
+		if resultCalled {
+			t.Fatal("result callback was called unexpectedly")
+		}
+		responder.requireNoResponses(t)
 		if got := len(transport.committedEvents); got != 0 {
 			t.Fatalf("committed events = %d, want 0", got)
 		}
@@ -467,6 +751,109 @@ func TestServiceApplyEvent(t *testing.T) {
 		responder.requireResult(t, result)
 	})
 
+	t.Run("forwarded command result is attached to committed event", func(t *testing.T) {
+		result := map[string]string{"status": "ok"}
+		transport := &testTransport{master: true}
+		svc := newTestService(t, nil, transport)
+		apply := svc.events["test"]
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return apply(applyCtx, event)
+		}
+
+		responder := new(testCommandResponder)
+		req := testCommandRequest(t)
+		req.Respond = responder.Send
+		completion := newCommandCompletion("cmd-forwarded", req, svc.commands)
+		resultCalled := false
+		origin := completion.eventOrigin(func() any {
+			resultCalled = true
+			return result
+		})
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("forwarded command result is attached to committed event"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+		if !applyCalled {
+			t.Fatal("applier was not called")
+		}
+		if !resultCalled {
+			t.Fatal("result callback was not called")
+		}
+		responder.requireNoResponses(t)
+		if got := len(transport.committedEvents); got != 1 {
+			t.Fatalf("committed events = %d, want 1", got)
+		}
+		entry := transport.committedEvents[0]
+		if entry.OriginCommandID != "cmd-forwarded" {
+			t.Fatalf("origin command id = %q, want %q", entry.OriginCommandID, "cmd-forwarded")
+		}
+		requireJSONResult(t, entry.CommandResult, result)
+		if got := len(transport.postedEvents); got != 0 {
+			t.Fatalf("posted events = %d, want 0", got)
+		}
+	})
+
+	t.Run("forwarded command result marshal error commits without a command result", func(t *testing.T) {
+		transport := &testTransport{master: true}
+		svc := newTestService(t, nil, transport)
+		apply := svc.events["test"]
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return apply(applyCtx, event)
+		}
+
+		responder := new(testCommandResponder)
+		req := testCommandRequest(t)
+		req.Respond = responder.Send
+		completion := newCommandCompletion("cmd-forwarded", req, svc.commands)
+		resultCalled := false
+		origin := completion.eventOrigin(func() any {
+			resultCalled = true
+			return make(chan int)
+		})
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("forwarded command result marshal error commits without a command result"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+		if !applyCalled {
+			t.Fatal("applier was not called")
+		}
+		if !resultCalled {
+			t.Fatal("result callback was not called")
+		}
+		responder.requireNoResponses(t)
+		if got := len(transport.committedEvents); got != 1 {
+			t.Fatalf("committed events = %d, want 1", got)
+		}
+		entry := transport.committedEvents[0]
+		if entry.OriginCommandID != "" {
+			t.Fatalf("origin command id = %q, want %q", entry.OriginCommandID, "")
+		}
+		if len(entry.CommandResult) != 0 {
+			t.Fatalf("command result = %q, want empty", entry.CommandResult)
+		}
+		if got := len(transport.postedEvents); got != 0 {
+			t.Fatalf("posted events = %d, want 0", got)
+		}
+	})
+
 	t.Run("apply without durable row fails", func(t *testing.T) {
 		transport := &testTransport{master: true}
 		svc := newTestService(t, nil, transport)
@@ -612,12 +999,16 @@ func TestServiceApplyEventLocal(t *testing.T) {
 }
 
 func TestServiceExecuteCommand(t *testing.T) {
+	wantForwardErr := msgjson.NewError(msgjson.AuthenticationError, "nope")
+	wantForwardPeerErr := &peerRPCError{Code: msgjson.AuthenticationError, Message: "nope"}
 	tests := []struct {
 		name                string
 		transport           *testTransport
 		mutateReq           func(*CommandRequest)
 		wantErrCode         int
+		wantErrIs           *msgjson.Error
 		wantExecutedLocally bool
+		wantForward         bool
 	}{
 		{
 			name:                "single-server executes locally",
@@ -629,9 +1020,25 @@ func TestServiceExecuteCommand(t *testing.T) {
 			wantExecutedLocally: true,
 		},
 		{
+			name:        "slave forwards",
+			transport:   &testTransport{slave: true},
+			wantForward: true,
+		},
+		{
 			name:        "unavailable mesh rejects retryably",
 			transport:   &testTransport{},
 			wantErrCode: msgjson.TryAgainLaterError,
+		},
+		{
+			name:        "forward transport error holds pending",
+			transport:   &testTransport{slave: true, err: errors.New("boom")},
+			wantForward: true,
+		},
+		{
+			name:        "forward preserves peer app-level error",
+			transport:   &testTransport{slave: true, err: wantForwardPeerErr},
+			wantErrIs:   wantForwardErr,
+			wantForward: true,
 		},
 		{
 			name:        "nil command message",
@@ -663,7 +1070,7 @@ func TestServiceExecuteCommand(t *testing.T) {
 			svc := newTestService(t, testEmitResult(result), tt.transport)
 
 			rpcErr := svc.ExecuteCommand(context.Background(), req)
-			requireExecuteCommandError(t, rpcErr, tt.wantErrCode, nil)
+			requireExecuteCommandError(t, rpcErr, tt.wantErrCode, tt.wantErrIs)
 
 			if tt.wantExecutedLocally {
 				svc.requireExecutedCommand(t, req)
@@ -674,8 +1081,238 @@ func TestServiceExecuteCommand(t *testing.T) {
 				svc.requireNoAppliedEvents(t)
 				responder.requireNoResponses(t)
 			}
+
+			if tt.transport == nil {
+				svc.requireNoPending(t)
+				return
+			}
+			if !tt.wantForward {
+				tt.transport.requireNoForwardedCommands(t)
+				svc.requireNoPending(t)
+				return
+			}
+
+			commandID := tt.transport.requireForwardedCommand(t, req).CommandID
+			requireGeneratedCommandID(t, commandID)
+			wantPending := tt.wantErrCode == 0 && tt.wantErrIs == nil
+			if wantPending {
+				svc.requirePending(t, commandID)
+			} else {
+				svc.requirePendingRemoved(t, commandID)
+			}
+			svc.commands.removePending(commandID)
 		})
 	}
+}
+
+func TestServiceReceivedEventReplay(t *testing.T) {
+	svc := newTestService(t, nil, &testTransport{slave: true})
+	applyStarted := make(chan struct{})
+	releaseApply := make(chan struct{})
+	originalApply := svc.events["test"]
+	var applyCalls atomic.Int32
+	svc.events["test"] = func(ctx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+		applyCalls.Add(1)
+		close(applyStarted)
+		<-releaseApply
+		return originalApply(ctx, event)
+	}
+	env := &eventEnvelope{Seq: 1, TipHash: testTipHash(1), Kind: "test"}
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- svc.applyReceivedEvent(context.Background(), env) }()
+	<-applyStarted
+	commandResult := map[string]string{"status": "accepted"}
+	responder := new(testCommandResponder)
+	req := testCommandRequest(t)
+	req.Respond = responder.Send
+	svc.commands.registerPending("cmd-replay", req)
+	replay := *env
+	replay.OriginCommandID = "cmd-replay"
+	replay.CommandResult = mustMarshalJSON(t, commandResult)
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- svc.applyReceivedEvent(context.Background(), &replay) }()
+	select {
+	case err := <-secondDone:
+		t.Fatalf("replay returned before the original apply completed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseApply)
+	for i, done := range []<-chan error{firstDone, secondDone} {
+		if err := <-done; err != nil {
+			t.Fatalf("apply %d: %v", i+1, err)
+		}
+	}
+	if calls := applyCalls.Load(); calls != 1 {
+		t.Fatalf("applier calls = %d, want 1", calls)
+	}
+	responder.requireResult(t, commandResult)
+	svc.requirePendingRemoved(t, replay.OriginCommandID)
+
+	diverged := *env
+	diverged.TipHash = testTipHash(2)
+	err := svc.applyReceivedEvent(context.Background(), &diverged)
+	var divergence *db.EventLogDivergenceError
+	if !errors.As(err, &divergence) {
+		t.Fatalf("divergent replay error = %T %[1]v, want EventLogDivergenceError", err)
+	}
+}
+
+func TestServiceForwardedCommandLifecycle(t *testing.T) {
+	t.Run("event backed command publishes event and slave delivers result", func(t *testing.T) {
+		req := testCommandRequest(t)
+		responder := new(testCommandResponder)
+		req.Respond = responder.Send
+		result := map[string]string{"status": "accepted"}
+		services := newLinkedTestServices(t, func(cmd *CommandContext) *msgjson.Error {
+			if err := cmd.Completion.Emit(cmd.Context, &Event{
+				Kind:    "test",
+				Payload: []byte("accepted"),
+			}, func() any {
+				return result
+			}); err != nil {
+				return msgjson.NewError(msgjson.RPCInternalError, "emit failed: %v", err)
+			}
+			return nil
+		})
+
+		commandID := services.forwardCommand(t, req)
+		services.master.requireExecutedCommand(t, req)
+		services.master.requireAppliedEvents(t, 1)
+
+		services.master.testTransport.requireCommittedEvent(t, commandID)
+		entry := services.master.testTransport.committedEvents[0]
+		if entry.OriginCommandID != commandID {
+			t.Fatalf("origin command id = %q, want %s", entry.OriginCommandID, commandID)
+		}
+		if len(entry.CommandResult) == 0 {
+			t.Fatalf("missing forwarded command result")
+		}
+		services.slave.requireAppliedPayload(t, "accepted")
+		responder.requireResult(t, result)
+		services.slave.requirePendingRemoved(t, commandID)
+	})
+
+	t.Run("no event command sends command result and slave delivers result", func(t *testing.T) {
+		req := testCommandRequest(t)
+		responder := new(testCommandResponder)
+		req.Respond = responder.Send
+		result := map[string]string{"status": "already"}
+		services := newLinkedTestServices(t, func(cmd *CommandContext) *msgjson.Error {
+			if err := cmd.Completion.Complete(cmd.Context, result); err != nil {
+				return msgjson.NewError(msgjson.RPCInternalError, "complete failed: %v", err)
+			}
+			return nil
+		})
+
+		commandID := services.forwardCommand(t, req)
+		services.master.requireExecutedCommand(t, req)
+		services.master.requireNoAppliedEvents(t)
+		services.master.testTransport.requireCommandResult(t, commandID)
+		responder.requireResult(t, result)
+		services.slave.requirePendingRemoved(t, commandID)
+	})
+
+	t.Run("event with origin command id requires command result", func(t *testing.T) {
+		slave := newTestService(t, nil, &testTransport{slave: true})
+		missingResult := &eventEnvelope{Seq: 2, TipHash: testTipHash(2), MasterTip: 2, Kind: "test", OriginCommandID: "cmd-missing-result"}
+		if err := slave.applyReceivedEvent(context.Background(), missingResult); err == nil {
+			t.Fatalf("missing command result did not error")
+		}
+		slave.requireNoAppliedEvents(t)
+	})
+
+	t.Run("received event delivers command result", func(t *testing.T) {
+		slave := newTestService(t, nil, &testTransport{slave: true})
+		commandID := "cmd-event-result"
+		req := testCommandRequest(t)
+		responder := new(testCommandResponder)
+		req.Respond = func(msg *msgjson.Message) error {
+			if !slave.applyMtx.TryLock() {
+				t.Fatal("applyMtx held during received result delivery")
+			}
+			slave.applyMtx.Unlock()
+			return responder.Send(msg)
+		}
+		slave.commands.registerPending(commandID, req)
+		defer slave.commands.removePending(commandID)
+
+		commandResult := map[string]string{"status": "accepted"}
+		err := slave.applyReceivedEvent(context.Background(), &eventEnvelope{
+			Seq:             1,
+			TipHash:         testTipHash(1),
+			MasterTip:       1,
+			Kind:            "test",
+			OriginCommandID: commandID,
+			CommandResult:   mustMarshalJSON(t, commandResult),
+			Payload:         []byte("accepted"),
+		})
+		if err != nil {
+			t.Fatalf("applyReceivedEvent error: %v", err)
+		}
+		slave.requireAppliedPayload(t, "accepted")
+		responder.requireResult(t, commandResult)
+		slave.requirePendingRemoved(t, commandID)
+	})
+
+	t.Run("received event treats missing pending command as no-op", func(t *testing.T) {
+		slave := newTestService(t, nil, &testTransport{slave: true})
+		err := slave.applyReceivedEvent(context.Background(), &eventEnvelope{
+			Seq:             1,
+			TipHash:         testTipHash(1),
+			MasterTip:       1,
+			Kind:            "test",
+			OriginCommandID: "cmd-not-pending",
+			CommandResult:   mustMarshalJSON(t, map[string]string{"status": "accepted"}),
+		})
+		if err != nil {
+			t.Fatalf("applyReceivedEvent error: %v", err)
+		}
+		slave.requireAppliedEvents(t, 1)
+		slave.requireNoPending(t)
+	})
+
+	t.Run("received event ignores command result delivery error", func(t *testing.T) {
+		slave := newTestService(t, nil, &testTransport{slave: true})
+		commandID := "cmd-bad-result"
+		req := testCommandRequest(t)
+		responder := new(testCommandResponder)
+		req.Respond = responder.Send
+		slave.commands.registerPending(commandID, req)
+		defer slave.commands.removePending(commandID)
+
+		err := slave.applyReceivedEvent(context.Background(), &eventEnvelope{
+			Seq:             1,
+			TipHash:         testTipHash(1),
+			MasterTip:       1,
+			Kind:            "test",
+			OriginCommandID: commandID,
+			CommandResult:   json.RawMessage(`{`),
+		})
+		if err != nil {
+			t.Fatalf("applyReceivedEvent error: %v", err)
+		}
+		responder.requireNoResponses(t)
+		slave.requirePendingRemoved(t, commandID)
+	})
+
+	t.Run("command failure delivers pending error", func(t *testing.T) {
+		req := testCommandRequest(t)
+		responder := new(testCommandResponder)
+		req.Respond = responder.Send
+		services := newLinkedTestServices(t, func(cmd *CommandContext) *msgjson.Error {
+			if err := cmd.Completion.Fail(cmd.Context, msgjson.NewError(msgjson.FundingError, "funding failed")); err != nil {
+				return msgjson.NewError(msgjson.RPCInternalError, "fail failed: %v", err)
+			}
+			return nil
+		})
+
+		commandID := services.forwardCommand(t, req)
+		services.master.requireExecutedCommand(t, req)
+		services.master.testTransport.requireCommandFailure(t, commandID, msgjson.FundingError)
+		responder.requireErrorCode(t, msgjson.FundingError)
+		services.slave.requirePendingRemoved(t, commandID)
+	})
 }
 
 func TestServiceWaitUntilReadyForComms(t *testing.T) {

--- a/server/mesh/service_test.go
+++ b/server/mesh/service_test.go
@@ -18,6 +18,7 @@ import (
 
 	"decred.org/dcrdex/dex"
 	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
 	"decred.org/dcrdex/server/db"
 )
 
@@ -165,6 +166,19 @@ func (f *testTransport) sendCommandResult(_ context.Context, result *commandResu
 		f.peer.receiveCommandResult(result.CommandID, result.Result)
 	}
 	return nil
+}
+
+func (f *testTransport) sendClientProxyMessage(context.Context, *ClientProxyMessage) error {
+	return nil
+}
+
+func (f *testTransport) queryClientConnected(_ context.Context, users []account.AccountID) ([]account.AccountID, error) {
+	f.connectedQueries = append(f.connectedQueries, len(users))
+	if f.queryConnectedErr != nil {
+		return nil, f.queryConnectedErr
+	}
+	// Echo the queried chunk back so callers can verify chunked merging.
+	return users, nil
 }
 
 func (f *testTransport) notifyLocalEventCommitted(seq uint64, originCommandID string, commandResult json.RawMessage) {
@@ -1541,6 +1555,80 @@ func TestServiceWaitUntilReadyForComms(t *testing.T) {
 		waitServiceWorkers(t, svc, "mesh worker failure shutdown")
 	})
 
+}
+
+func TestServiceQueryClientConnectedChunking(t *testing.T) {
+	transport := &testTransport{}
+	svc := &Service{log: dex.Disabled, transport: transport}
+
+	users := make([]account.AccountID, 2*maxClientConnectedUsers+1)
+	for i := range users {
+		users[i][0], users[i][1], users[i][2] = byte(i), byte(i>>8), byte(i>>16)
+	}
+
+	connected, err := svc.QueryClientConnected(context.Background(), users)
+	if err != nil {
+		t.Fatalf("QueryClientConnected error: %v", err)
+	}
+	wantChunks := []int{maxClientConnectedUsers, maxClientConnectedUsers, 1}
+	if len(transport.connectedQueries) != len(wantChunks) {
+		t.Fatalf("requests = %d, want %d", len(transport.connectedQueries), len(wantChunks))
+	}
+	for i, want := range wantChunks {
+		if transport.connectedQueries[i] != want {
+			t.Fatalf("request %d queried %d users, want %d", i, transport.connectedQueries[i], want)
+		}
+	}
+	// The echoing test transport claims every queried user is connected, so
+	// the merged result must be the full user list in order.
+	if len(connected) != len(users) {
+		t.Fatalf("connected = %d users, want %d", len(connected), len(users))
+	}
+	for i, user := range users {
+		if connected[i] != user {
+			t.Fatalf("connected[%d] = %v, want %v", i, connected[i], user)
+		}
+	}
+
+	// A chunk failure fails the whole query.
+	transport.queryConnectedErr = errors.New("peer gone")
+	if _, err := svc.QueryClientConnected(context.Background(), users); err == nil {
+		t.Fatalf("no error from failed chunk")
+	}
+
+	// No users, no requests.
+	transport.connectedQueries = nil
+	if connected, err := svc.QueryClientConnected(context.Background(), nil); err != nil || len(connected) != 0 {
+		t.Fatalf("empty query returned %v, %v", connected, err)
+	}
+	if len(transport.connectedQueries) != 0 {
+		t.Fatalf("empty query issued %d requests, want 0", len(transport.connectedQueries))
+	}
+}
+
+func TestServiceQueryClientConnectedSingleServer(t *testing.T) {
+	svc := &Service{log: dex.Disabled, transport: newSingleServerTransport()}
+	connected, err := svc.QueryClientConnected(context.Background(), []account.AccountID{{0x01}, {0x02}})
+	if err != nil {
+		t.Fatalf("single-server QueryClientConnected error: %v", err)
+	}
+	if len(connected) != 0 {
+		t.Fatalf("single-server connected = %v, want empty", connected)
+	}
+}
+
+func TestServiceProxyClientMessageSingleServer(t *testing.T) {
+	svc := &Service{log: dex.Disabled, transport: newSingleServerTransport()}
+	note, err := msgjson.NewNotification(msgjson.NotifyRoute, "note")
+	if err != nil {
+		t.Fatalf("NewNotification error: %v", err)
+	}
+	if err := svc.ProxyClientMessage(context.Background(), &ClientProxyMessage{Msg: note, Broadcast: true}); err != nil {
+		t.Fatalf("single-server broadcast error: %v", err)
+	}
+	if err := svc.ProxyClientMessage(context.Background(), &ClientProxyMessage{Msg: note}); !errors.Is(err, ErrClientProxyUnavailable) {
+		t.Fatalf("single-server unicast error = %v, want %v", err, ErrClientProxyUnavailable)
+	}
 }
 
 func TestEnsureLoaded(t *testing.T) {

--- a/server/mesh/service_test.go
+++ b/server/mesh/service_test.go
@@ -1,0 +1,932 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/db"
+)
+
+type testTransport struct {
+	master                              bool
+	slave                               bool
+	err                                 error
+	owner                               *testService
+	peer                                *Service
+	connectErr                          error
+	eventPublishErr                     error
+	notifyMasterReadyCalled             chan struct{}
+	notifyMasterPreparationFailedCalled chan error
+
+	connectedQueries  []int // per-request user counts
+	queryConnectedErr error
+
+	commandForwards []*commandForward
+	commandFailures []*commandFailure
+	commandResults  []*commandResult
+	committedEvents []*eventEnvelope
+	postedEvents    []meshSignal
+
+	drain   func(context.Context) (bool, error)
+	handoff func(context.Context) error
+}
+
+type testService struct {
+	*Service
+
+	testTransport    *testTransport
+	appliedEvents    []*eventEnvelope
+	executedCommands []CommandRequest
+}
+
+func runServiceForTest(ctx context.Context, svc *Service) <-chan struct{} {
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		svc.Run(ctx)
+	}()
+	return runDone
+}
+
+func (f *testTransport) connect(context.Context) (*sync.WaitGroup, error) {
+	if f.connectErr != nil {
+		return nil, f.connectErr
+	}
+	return new(sync.WaitGroup), nil
+}
+
+func (f *testTransport) ensureSeeded(context.Context) error {
+	return nil
+}
+
+func (f *testTransport) notifyReadyForEvents() {}
+
+func (f *testTransport) haltStatus() (bool, error) {
+	return false, nil
+}
+
+func (f *testTransport) notifyMasterReady() error {
+	f.master = true
+	if f.notifyMasterReadyCalled != nil {
+		select {
+		case f.notifyMasterReadyCalled <- struct{}{}:
+		default:
+		}
+	}
+	return nil
+}
+
+func (f *testTransport) notifyMasterPreparationFailed(err error) error {
+	if f.notifyMasterPreparationFailedCalled != nil {
+		select {
+		case f.notifyMasterPreparationFailedCalled <- err:
+		default:
+		}
+	}
+	return nil
+}
+
+func requireServiceReadyBlocked(t testing.TB, svc *Service, desc string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := svc.WaitUntilReadyForComms(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitUntilReadyForComms returned %v, want timeout while %s", err, desc)
+	}
+}
+
+func (f *testTransport) notifyLocalEventCommitted(seq uint64, originCommandID string, commandResult json.RawMessage) {
+	if f.owner == nil || seq == 0 || seq > uint64(len(f.owner.appliedEvents)) {
+		return
+	}
+	applied := f.owner.appliedEvents[int(seq-1)]
+	entry := &eventEnvelope{
+		Seq:             seq,
+		TipHash:         append([]byte(nil), applied.TipHash...),
+		MasterTip:       seq,
+		Kind:            applied.Kind,
+		OriginCommandID: originCommandID,
+		CommandResult:   append([]byte(nil), commandResult...),
+		Payload:         append([]byte(nil), applied.Payload...),
+	}
+	f.committedEvents = append(f.committedEvents, entry)
+	if f.peer != nil {
+		_ = f.peer.applyReceivedEvent(context.Background(), entry)
+	}
+}
+
+func (f *testTransport) canExecuteCommandLocally() bool {
+	return f.master
+}
+
+func (f *testTransport) canForwardCommand() bool {
+	return f.slave
+}
+
+func (f *testTransport) checkEventPublishAvailable(bool) error {
+	return f.eventPublishErr
+}
+
+func newTestService(t *testing.T, exec CommandExecutor, transport *testTransport) *testService {
+	t.Helper()
+	testSvc := new(testService)
+	eventLogReader := new(testEventLogReader)
+	var transportIface meshTransport = newSingleServerTransport()
+	if transport != nil {
+		testSvc.testTransport = transport
+		transport.owner = testSvc
+		transportIface = transport
+	}
+	commands := make(map[string]CommandExecutor)
+	if exec != nil {
+		commands["test"] = func(cmd *CommandContext) *msgjson.Error {
+			testSvc.executedCommands = append(testSvc.executedCommands, cmd.Request)
+			return exec(cmd)
+		}
+	}
+	eventHandlers := map[string]EventApplier{
+		"test": func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			meta := applyCtx.Position
+			var seq uint64
+			var tipHash []byte
+			if meta != nil {
+				seq = meta.Seq
+				tipHash = append([]byte(nil), meta.TipHash...)
+				if want := testTipHash(seq); !bytes.Equal(tipHash, want) {
+					t.Fatalf("apply meta tip hash = %x, want %x", tipHash, want)
+				}
+			}
+			if seq == 0 {
+				seq = uint64(len(testSvc.appliedEvents) + 1)
+			}
+			if tipHash == nil {
+				tipHash = testTipHash(seq)
+			}
+			payload := append([]byte(nil), event.Payload...)
+			appliedEvent := &db.EventLogEntry{
+				Seq:     seq,
+				Kind:    event.Kind,
+				Event:   payload,
+				TipHash: tipHash,
+			}
+			testSvc.appliedEvents = append(testSvc.appliedEvents, &eventEnvelope{
+				Seq:       appliedEvent.Seq,
+				TipHash:   append([]byte(nil), appliedEvent.TipHash...),
+				MasterTip: appliedEvent.Seq,
+				Kind:      appliedEvent.Kind,
+				Payload:   append([]byte(nil), appliedEvent.Event...),
+			})
+			eventLogReader.mtx.Lock()
+			eventLogReader.entries = append(eventLogReader.entries, appliedEvent)
+			eventLogReader.mtx.Unlock()
+			return appliedEvent, nil
+		},
+	}
+	testSvc.Service = &Service{
+		loaded:         newReadiness(),
+		transport:      transportIface,
+		eventLogReader: eventLogReader,
+		events:         eventHandlers,
+		log:            dex.Disabled,
+		ready:          newReadiness(),
+	}
+	testSvc.Service.commands = newCommandCoordinator(dex.Disabled, transportIface, "test-node", commands, testSvc.Service.applyEvent)
+	return testSvc
+}
+
+func testEmitResult(result any) CommandExecutor {
+	return func(cmd *CommandContext) *msgjson.Error {
+		if err := cmd.Completion.Emit(cmd.Context, &Event{Kind: "test"}, func() any {
+			return result
+		}); err != nil {
+			return msgjson.NewError(msgjson.RPCInternalError, "emit failed: %v", err)
+		}
+		return nil
+	}
+}
+
+func (s *testService) requireExecutedCommand(t *testing.T, req CommandRequest) {
+	t.Helper()
+	if len(s.executedCommands) != 1 {
+		t.Fatalf("executed commands = %d, want 1", len(s.executedCommands))
+	}
+	executed := s.executedCommands[0]
+	if executed.Kind != req.Kind || executed.User != req.User || executed.Msg != req.Msg {
+		t.Fatalf("executed command mismatch: %+v", executed)
+	}
+}
+
+func (s *testService) requireNoExecutedCommands(t *testing.T) {
+	t.Helper()
+	if len(s.executedCommands) != 0 {
+		t.Fatalf("executed commands = %d, want 0", len(s.executedCommands))
+	}
+}
+
+func (s *testService) requireAppliedEvents(t *testing.T, want int) {
+	t.Helper()
+	if len(s.appliedEvents) != want {
+		t.Fatalf("applied events = %d, want %d", len(s.appliedEvents), want)
+	}
+}
+
+func (s *testService) requireNoAppliedEvents(t *testing.T) {
+	t.Helper()
+	s.requireAppliedEvents(t, 0)
+}
+
+func (s *testService) requireAppliedPayload(t *testing.T, want string) {
+	t.Helper()
+	s.requireAppliedEvents(t, 1)
+	if string(s.appliedEvents[0].Payload) != want {
+		t.Fatalf("applied payload = %q, want %s", s.appliedEvents[0].Payload, want)
+	}
+}
+
+func (s *testCommandResponder) requireNoResponses(t *testing.T) {
+	t.Helper()
+	if len(s.sent) != 0 {
+		t.Fatalf("responses = %d, want 0", len(s.sent))
+	}
+}
+
+func requireExecuteCommandError(t *testing.T, got *msgjson.Error, wantCode int, wantErr *msgjson.Error) {
+	t.Helper()
+	if wantCode == 0 && wantErr == nil {
+		if got != nil {
+			t.Fatalf("ExecuteCommand error: %v", got)
+		}
+		return
+	}
+	if got == nil {
+		t.Fatalf("no error")
+	}
+	if wantErr != nil && (got.Code != wantErr.Code || got.Message != wantErr.Message) {
+		t.Fatalf("error = %v, want %v", got, wantErr)
+	}
+	if wantCode != 0 && got.Code != wantCode {
+		t.Fatalf("error code = %d, want %d", got.Code, wantCode)
+	}
+}
+
+func TestServiceApplyEvent(t *testing.T) {
+	t.Run("rejects when local apply is unavailable", func(t *testing.T) {
+		transport := &testTransport{eventPublishErr: errors.New("mesh event publisher unavailable for local apply")}
+		svc := newTestService(t, nil, transport)
+		apply := svc.events["test"]
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return apply(applyCtx, event)
+		}
+
+		origin := plainEventOrigin()
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("rejects when local apply is unavailable"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if err == nil {
+			t.Fatal("apply succeeded, want error")
+		}
+		if applyCalled {
+			t.Fatal("applier was called unexpectedly")
+		}
+		if got := len(transport.committedEvents); got != 0 {
+			t.Fatalf("committed events = %d, want 0", got)
+		}
+		if got := len(transport.postedEvents); got != 0 {
+			t.Fatalf("posted events = %d, want 0", got)
+		}
+	})
+
+	t.Run("plain event applies in single-server mode", func(t *testing.T) {
+		svc := newTestService(t, nil, nil)
+		apply := svc.events["test"]
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return apply(applyCtx, event)
+		}
+
+		origin := plainEventOrigin()
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("plain event applies in single-server mode"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+		if !applyCalled {
+			t.Fatal("applier was not called")
+		}
+	})
+
+	t.Run("plain event applies and notifies in mesh master mode", func(t *testing.T) {
+		transport := &testTransport{master: true}
+		svc := newTestService(t, nil, transport)
+		apply := svc.events["test"]
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return apply(applyCtx, event)
+		}
+
+		origin := plainEventOrigin()
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("plain event applies and notifies in mesh master mode"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+		if !applyCalled {
+			t.Fatal("applier was not called")
+		}
+		if got := len(transport.committedEvents); got != 1 {
+			t.Fatalf("committed events = %d, want 1", got)
+		}
+		entry := transport.committedEvents[0]
+		if entry.OriginCommandID != "" {
+			t.Fatalf("origin command id = %q, want %q", entry.OriginCommandID, "")
+		}
+		if len(entry.CommandResult) != 0 {
+			t.Fatalf("command result = %q, want empty", entry.CommandResult)
+		}
+		if got := len(transport.postedEvents); got != 0 {
+			t.Fatalf("posted events = %d, want 0", got)
+		}
+	})
+
+	t.Run("local command result is delivered after apply", func(t *testing.T) {
+		result := map[string]string{"status": "ok"}
+		svc := newTestService(t, nil, nil)
+		apply := svc.events["test"]
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return apply(applyCtx, event)
+		}
+
+		responder := new(testCommandResponder)
+		req := testCommandRequest(t)
+		req.Respond = responder.Send
+		completion := newCommandCompletion("", req, svc.commands)
+		resultCalled := false
+		origin := completion.eventOrigin(func() any {
+			resultCalled = true
+			return result
+		})
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("local command result is delivered after apply"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if err != nil {
+			t.Fatalf("apply error: %v", err)
+		}
+		if !applyCalled {
+			t.Fatal("applier was not called")
+		}
+		if !resultCalled {
+			t.Fatal("result callback was not called")
+		}
+		responder.requireResult(t, result)
+	})
+
+	t.Run("apply without durable row fails", func(t *testing.T) {
+		transport := &testTransport{master: true}
+		svc := newTestService(t, nil, transport)
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return nil, nil
+		}
+
+		origin := plainEventOrigin()
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("apply without durable row fails"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if err == nil {
+			t.Fatal("apply succeeded, want error")
+		}
+		if !applyCalled {
+			t.Fatal("applier was not called")
+		}
+		if got := len(transport.committedEvents); got != 0 {
+			t.Fatalf("committed events = %d, want 0", got)
+		}
+		if got := len(transport.postedEvents); got != 0 {
+			t.Fatalf("posted events = %d, want 0", got)
+		}
+	})
+}
+
+func TestServiceApplyEventDeliversApplierSetResult(t *testing.T) {
+	result := map[string]string{"status": "applied"}
+	responder := &testCommandResponder{}
+	req := testCommandRequest(t)
+	req.Respond = responder.Send
+
+	svc := newTestService(t, nil, nil)
+	completion := newCommandCompletion("", req, svc.commands)
+
+	svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+		applyCtx.SetResult(result)
+		return &db.EventLogEntry{
+			Seq:     1,
+			Kind:    event.Kind,
+			Event:   append([]byte(nil), event.Payload...),
+			TipHash: testTipHash(1),
+		}, nil
+	}
+
+	// With no result function, the result recorded by the applier through
+	// SetResult is delivered as the command result.
+	if _, err := svc.applyEvent(context.Background(), &Event{Kind: "test"}, completion.eventOrigin(nil)); err != nil {
+		t.Fatalf("applyEvent error: %v", err)
+	}
+	responder.requireResult(t, result)
+}
+
+// TestServiceApplyEventReturnsApplierResult verifies the plain-event path: the
+// value an applier records with SetResult is returned to the local emitter
+// from ApplyEvent, so emitters can consume applier-derived state without a
+// side channel.
+func TestServiceApplyEventReturnsApplierResult(t *testing.T) {
+	result := map[string]string{"status": "applied"}
+
+	svc := newTestService(t, nil, nil)
+	svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+		applyCtx.SetResult(result)
+		return &db.EventLogEntry{
+			Seq:     1,
+			Kind:    event.Kind,
+			Event:   append([]byte(nil), event.Payload...),
+			TipHash: testTipHash(1),
+		}, nil
+	}
+
+	got, err := svc.ApplyEvent(context.Background(), &Event{Kind: "test"})
+	if err != nil {
+		t.Fatalf("ApplyEvent error: %v", err)
+	}
+	gotMap, ok := got.(map[string]string)
+	if !ok || gotMap["status"] != "applied" {
+		t.Fatalf("ApplyEvent result = %v, want %v", got, result)
+	}
+}
+
+func TestServiceApplyEventIgnoresDeliveryError(t *testing.T) {
+	result := map[string]string{"status": "ok"}
+	deliverErr := errors.New("delivery failed")
+	responder := &testCommandResponder{err: deliverErr}
+	req := testCommandRequest(t)
+
+	svc := newTestService(t, nil, nil)
+	req.Respond = func(msg *msgjson.Message) error {
+		if !svc.applyMtx.TryLock() {
+			t.Fatal("applyMtx held during result delivery")
+		}
+		svc.applyMtx.Unlock()
+		return responder.Send(msg)
+	}
+	completion := newCommandCompletion("", req, svc.commands)
+
+	callbackRan := false
+	svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+		if !applyCtx.AfterCommandResult(func(context.Context) {
+			callbackRan = true
+		}) {
+			t.Fatalf("AfterCommandResult returned false")
+		}
+		return &db.EventLogEntry{
+			Seq:     1,
+			Kind:    event.Kind,
+			Event:   append([]byte(nil), event.Payload...),
+			TipHash: testTipHash(1),
+		}, nil
+	}
+
+	_, err := svc.applyEvent(context.Background(), &Event{Kind: "test"}, completion.eventOrigin(func() any {
+		return result
+	}))
+	if err != nil {
+		t.Fatalf("applyEvent error = %v, want nil for post-commit delivery failure", err)
+	}
+	if !callbackRan {
+		t.Fatalf("after-command-result callback did not run")
+	}
+	responder.requireResult(t, result)
+}
+
+func TestServiceApplyEventLocal(t *testing.T) {
+	svc := newTestService(t, nil, nil)
+
+	if _, _, err := svc.applyEventLocal(context.Background(), &Event{Kind: "test", Payload: []byte("applied")}, nil, false); err != nil {
+		t.Fatalf("applyEventLocal error: %v", err)
+	}
+	svc.requireAppliedPayload(t, "applied")
+
+	if _, _, err := svc.applyEventLocal(context.Background(), &Event{Kind: "unknown"}, nil, false); err == nil {
+		t.Fatalf("no error for unknown event kind")
+	}
+}
+
+func TestServiceExecuteCommand(t *testing.T) {
+	tests := []struct {
+		name                string
+		transport           *testTransport
+		mutateReq           func(*CommandRequest)
+		wantErrCode         int
+		wantExecutedLocally bool
+	}{
+		{
+			name:                "single-server executes locally",
+			wantExecutedLocally: true,
+		},
+		{
+			name:                "master executes locally",
+			transport:           &testTransport{master: true},
+			wantExecutedLocally: true,
+		},
+		{
+			name:        "unavailable mesh rejects retryably",
+			transport:   &testTransport{},
+			wantErrCode: msgjson.TryAgainLaterError,
+		},
+		{
+			name:        "nil command message",
+			mutateReq:   func(req *CommandRequest) { req.Msg = nil },
+			wantErrCode: msgjson.RPCInternalError,
+		},
+		{
+			name:        "nil command responder",
+			mutateReq:   func(req *CommandRequest) { req.Respond = nil },
+			wantErrCode: msgjson.RPCInternalError,
+		},
+		{
+			name:        "unknown local command",
+			mutateReq:   func(req *CommandRequest) { req.Kind = "unknown" },
+			wantErrCode: msgjson.RPCInternalError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := testCommandRequest(t)
+			responder := new(testCommandResponder)
+			req.Respond = responder.Send
+			if tt.mutateReq != nil {
+				tt.mutateReq(&req)
+			}
+
+			result := map[string]string{"status": "ok"}
+			svc := newTestService(t, testEmitResult(result), tt.transport)
+
+			rpcErr := svc.ExecuteCommand(context.Background(), req)
+			requireExecuteCommandError(t, rpcErr, tt.wantErrCode, nil)
+
+			if tt.wantExecutedLocally {
+				svc.requireExecutedCommand(t, req)
+				svc.requireAppliedEvents(t, 1)
+				responder.requireResult(t, result)
+			} else {
+				svc.requireNoExecutedCommands(t)
+				svc.requireNoAppliedEvents(t)
+				responder.requireNoResponses(t)
+			}
+		})
+	}
+}
+
+func TestServiceWaitUntilReadyForComms(t *testing.T) {
+	t.Run("single-server worker success owns readiness", func(t *testing.T) {
+		ready := make(chan struct{})
+		svc, err := NewService(&ServiceConfig{
+			EventLogReader: &testEventLogReader{},
+			OnHalt:         func(error) {},
+			MasterWorkers: []MasterWorker{{
+				Name: "test",
+				Run: func(ctx context.Context, reportReady func(error)) {
+					select {
+					case <-ready:
+						reportReady(nil)
+					case <-ctx.Done():
+						return
+					}
+					<-ctx.Done()
+				},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("NewService error: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		runDone := runServiceForTest(ctx, svc)
+
+		requireServiceReadyBlocked(t, svc, "single-server worker startup")
+		close(ready)
+		if err := svc.WaitUntilReadyForComms(context.Background()); err != nil {
+			t.Fatalf("WaitUntilReadyForComms error: %v", err)
+		}
+
+		cancel()
+		select {
+		case <-runDone:
+		case <-time.After(time.Second):
+			t.Fatalf("service did not stop")
+		}
+	})
+
+	t.Run("single-server worker failure fails readiness", func(t *testing.T) {
+		readyErr := errors.New("market startup cleanup failed")
+		halted := make(chan error, 1)
+		svc, err := NewService(&ServiceConfig{
+			EventLogReader: &testEventLogReader{},
+			OnHalt: func(err error) {
+				halted <- err
+			},
+			MasterWorkers: []MasterWorker{{
+				Name: "test",
+				Run: func(ctx context.Context, reportReady func(error)) {
+					reportReady(readyErr)
+					<-ctx.Done()
+				},
+			}},
+		})
+		if err != nil {
+			t.Fatalf("NewService error: %v", err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		runDone := runServiceForTest(ctx, svc)
+
+		err = svc.WaitUntilReadyForComms(context.Background())
+		if !errors.Is(err, readyErr) {
+			t.Fatalf("WaitUntilReadyForComms error = %v, want %v", err, readyErr)
+		}
+		if !strings.Contains(err.Error(), `mesh master worker "test" startup readiness failed`) {
+			t.Fatalf("WaitUntilReadyForComms error = %v, missing service wrapper", err)
+		}
+		select {
+		case haltErr := <-halted:
+			t.Fatalf("OnHalt called for startup readiness failure: %v", haltErr)
+		default:
+		}
+		select {
+		case <-runDone:
+		case <-time.After(time.Second):
+			t.Fatalf("service did not stop after readiness failure")
+		}
+	})
+
+	t.Run("mesh transport connect success owns readiness", func(t *testing.T) {
+		svc := &Service{
+			loaded:    newReadiness(),
+			log:       dex.Disabled,
+			transport: &testTransport{},
+			ready:     newReadiness(),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		runDone := runServiceForTest(ctx, svc)
+
+		if err := svc.WaitUntilReadyForComms(context.Background()); err != nil {
+			t.Fatalf("WaitUntilReadyForComms error: %v", err)
+		}
+
+		cancel()
+		select {
+		case <-runDone:
+		case <-time.After(time.Second):
+			t.Fatalf("service did not stop")
+		}
+	})
+
+	t.Run("mesh transport connect error fails readiness", func(t *testing.T) {
+		connectErr := errors.New("connect failed")
+		halted := make(chan error, 1)
+		svc := &Service{
+			loaded:    newReadiness(),
+			log:       dex.Disabled,
+			transport: &testTransport{connectErr: connectErr},
+			ready:     newReadiness(),
+			onHalt: func(err error) {
+				halted <- err
+			},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		runDone := runServiceForTest(ctx, svc)
+
+		err := svc.WaitUntilReadyForComms(context.Background())
+		if !errors.Is(err, connectErr) {
+			t.Fatalf("WaitUntilReadyForComms error = %v, want %v", err, connectErr)
+		}
+		if !strings.Contains(err.Error(), "mesh transport startup error") {
+			t.Fatalf("WaitUntilReadyForComms error = %v, missing startup wrapper", err)
+		}
+		select {
+		case haltErr := <-halted:
+			t.Fatalf("OnHalt called for transport startup error: %v", haltErr)
+		default:
+		}
+		select {
+		case <-runDone:
+		case <-time.After(time.Second):
+			t.Fatalf("service did not stop after transport startup error")
+		}
+	})
+
+	t.Run("mesh worker success posts master ready without service readiness", func(t *testing.T) {
+		masterReady := make(chan struct{}, 1)
+		transport := &testTransport{notifyMasterReadyCalled: masterReady}
+		svc := &Service{
+			loaded:    newReadiness(),
+			log:       dex.Disabled,
+			transport: transport,
+			masterWorkers: []MasterWorker{{
+				Name: "test",
+				Run: func(ctx context.Context, reportReady func(error)) {
+					reportReady(nil)
+					<-ctx.Done()
+				},
+			}},
+			ready: newReadiness(),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		svc.lifeCtx = ctx
+		svc.lifeCancel = cancel
+		startTestWorkerSupervisor(svc, ctx)
+		svc.workers.startWorkers()
+
+		select {
+		case <-masterReady:
+		case <-time.After(time.Second):
+			t.Fatalf("transport notifyMasterReady was not called")
+		}
+		if !transport.master {
+			t.Fatalf("transport notifyMasterReady was not called")
+		}
+		requireServiceReadyBlocked(t, svc, "mesh worker success waits for transport connect readiness")
+
+		cancel()
+		waitServiceWorkers(t, svc, "mesh worker success shutdown")
+	})
+
+	t.Run("mesh worker failure posts preparation failure without service readiness", func(t *testing.T) {
+		readyErr := errors.New("market startup cleanup failed")
+		prepFailed := make(chan error, 1)
+		halted := make(chan error, 1)
+		transport := &testTransport{notifyMasterPreparationFailedCalled: prepFailed}
+		svc := &Service{
+			loaded:    newReadiness(),
+			log:       dex.Disabled,
+			transport: transport,
+			onHalt: func(err error) {
+				halted <- err
+			},
+			masterWorkers: []MasterWorker{{
+				Name: "test",
+				Run: func(ctx context.Context, reportReady func(error)) {
+					reportReady(readyErr)
+					<-ctx.Done()
+				},
+			}},
+			ready: newReadiness(),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		svc.lifeCtx = ctx
+		svc.lifeCancel = cancel
+		startTestWorkerSupervisor(svc, ctx)
+		svc.workers.startWorkers()
+
+		select {
+		case err := <-prepFailed:
+			if !errors.Is(err, readyErr) {
+				t.Fatalf("notifyMasterPreparationFailed error = %v, want %v", err, readyErr)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("transport notifyMasterPreparationFailed was not called")
+		}
+		requireServiceReadyBlocked(t, svc, "mesh worker failure waits for transport connect readiness")
+		select {
+		case haltErr := <-halted:
+			t.Fatalf("OnHalt called directly for mesh worker failure: %v", haltErr)
+		default:
+		}
+
+		cancel()
+		waitServiceWorkers(t, svc, "mesh worker failure shutdown")
+	})
+
+}
+
+func TestEnsureLoaded(t *testing.T) {
+	t.Run("order and once", func(t *testing.T) {
+		var order []string
+		release := make(chan struct{})
+		s := &Service{
+			log:       dex.Disabled,
+			loaded:    newReadiness(),
+			transport: newSingleServerTransport(),
+			stateLoaders: []StateLoader{
+				{Name: "a", Load: func(context.Context) error {
+					<-release
+					order = append(order, "a")
+					return nil
+				}},
+				{Name: "b", Load: func(context.Context) error {
+					order = append(order, "b")
+					return nil
+				}},
+			},
+		}
+
+		first := make(chan error, 1)
+		go func() { first <- s.ensureLoaded(context.Background()) }()
+
+		// A second caller must wait for the first run, not skip it.
+		second := make(chan error, 1)
+		go func() { second <- s.ensureLoaded(context.Background()) }()
+
+		select {
+		case err := <-second:
+			t.Fatalf("second caller returned before loaders ran: %v", err)
+		case <-time.After(20 * time.Millisecond):
+		}
+
+		close(release)
+		for i, ch := range []chan error{first, second} {
+			select {
+			case err := <-ch:
+				if err != nil {
+					t.Fatalf("caller %d: %v", i, err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("caller %d never returned", i)
+			}
+		}
+		if len(order) != 2 || order[0] != "a" || order[1] != "b" {
+			t.Fatalf("loader order = %v, want [a b]", order)
+		}
+	})
+
+	t.Run("failure resolves latch with error", func(t *testing.T) {
+		boom := errors.New("boom")
+		s := &Service{
+			log:       dex.Disabled,
+			loaded:    newReadiness(),
+			transport: newSingleServerTransport(),
+			stateLoaders: []StateLoader{
+				{Name: "bad", Load: func(context.Context) error { return boom }},
+				{Name: "never", Load: func(context.Context) error {
+					t.Error("loader after a failure ran")
+					return nil
+				}},
+			},
+		}
+		if err := s.ensureLoaded(context.Background()); !errors.Is(err, boom) {
+			t.Fatalf("err = %v, want %v", err, boom)
+		}
+		if err, _ := s.loaded.result(); !errors.Is(err, boom) {
+			t.Fatalf("latch = %v, want %v", err, boom)
+		}
+	})
+}

--- a/server/mesh/service_test.go
+++ b/server/mesh/service_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -929,4 +930,62 @@ func TestEnsureLoaded(t *testing.T) {
 			t.Fatalf("latch = %v, want %v", err, boom)
 		}
 	})
+}
+
+// seedOrderTransport records the order of startup lifecycle calls, riding
+// the single-server transport for everything else.
+type seedOrderTransport struct {
+	*singleServerTransport
+	mtx   sync.Mutex
+	order []string
+}
+
+func (tr *seedOrderTransport) record(step string) {
+	tr.mtx.Lock()
+	tr.order = append(tr.order, step)
+	tr.mtx.Unlock()
+}
+
+func (tr *seedOrderTransport) ensureSeeded(context.Context) error {
+	tr.record("seed")
+	return nil
+}
+
+func (tr *seedOrderTransport) notifyReadyForEvents() {
+	tr.record("ready-for-events")
+}
+
+func TestRunSeedsBeforeLoaders(t *testing.T) {
+	tr := &seedOrderTransport{singleServerTransport: newSingleServerTransport()}
+	s := &Service{
+		log:       dex.Disabled,
+		loaded:    newReadiness(),
+		ready:     newReadiness(),
+		transport: tr,
+		stateLoaders: []StateLoader{{Name: "loader", Load: func(context.Context) error {
+			tr.record("load")
+			return nil
+		}}},
+	}
+	tr.becameMaster = func() { s.workers.startWorkers() }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := runServiceForTest(ctx, s)
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer waitCancel()
+	if err := s.WaitUntilReadyForComms(waitCtx); err != nil {
+		t.Fatalf("WaitUntilReadyForComms: %v", err)
+	}
+	cancel()
+	<-runDone
+
+	tr.mtx.Lock()
+	order := append([]string(nil), tr.order...)
+	tr.mtx.Unlock()
+	want := []string{"seed", "load", "ready-for-events"}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("startup order = %v, want %v", order, want)
+	}
 }

--- a/server/mesh/service_test.go
+++ b/server/mesh/service_test.go
@@ -127,6 +127,17 @@ func (f *testTransport) notifyLocalEventCommitted(seq uint64, originCommandID st
 	}
 }
 
+func (f *testTransport) postTerminalApplyFailureIfNeeded(err error) {
+	if isTerminalEventApplyFailure(err) {
+		_ = f.postEvent(terminalApplyFailureSignal{err: err, at: time.Now()})
+	}
+}
+
+func (f *testTransport) postEvent(ev meshSignal) error {
+	f.postedEvents = append(f.postedEvents, ev)
+	return nil
+}
+
 func (f *testTransport) canExecuteCommandLocally() bool {
 	return f.master
 }
@@ -312,6 +323,42 @@ func TestServiceApplyEvent(t *testing.T) {
 		}
 		if got := len(transport.postedEvents); got != 0 {
 			t.Fatalf("posted events = %d, want 0", got)
+		}
+	})
+
+	t.Run("terminal apply error is reported to transport", func(t *testing.T) {
+		terminalErr := &CommittedEventApplyError{
+			Applied: &db.EventLogEntry{Seq: 1, Kind: "test", TipHash: testTipHash(1)},
+			Err:     errors.New("side effect failed"),
+		}
+		transport := &testTransport{}
+		svc := newTestService(t, nil, transport)
+		applyCalled := false
+		svc.events["test"] = func(applyCtx *EventApplyContext, event *Event) (*db.EventLogEntry, error) {
+			applyCalled = true
+			if applyCtx.Position != nil {
+				t.Fatalf("apply position = %+v, want nil", applyCtx.Position)
+			}
+			return nil, terminalErr
+		}
+
+		origin := plainEventOrigin()
+		event := &Event{
+			Kind:    "test",
+			Payload: []byte("terminal apply error is reported to transport"),
+		}
+		_, err := svc.applyEvent(context.Background(), event, origin)
+		if !errors.Is(err, terminalErr) {
+			t.Fatalf("apply error = %v, want %v", err, terminalErr)
+		}
+		if !applyCalled {
+			t.Fatal("applier was not called")
+		}
+		if got := len(transport.committedEvents); got != 0 {
+			t.Fatalf("committed events = %d, want 0", got)
+		}
+		if got := len(transport.postedEvents); got != 1 {
+			t.Fatalf("posted events = %d, want 1", got)
 		}
 	})
 

--- a/server/mesh/signer.go
+++ b/server/mesh/signer.go
@@ -1,0 +1,43 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+)
+
+// secp256k1Signer implements the signer interface using a secp256k1 private key.
+type secp256k1Signer struct {
+	privKey *secp256k1.PrivateKey
+}
+
+var _ signer = (*secp256k1Signer)(nil)
+
+// newSecp256k1Signer creates a new signer using the provided private key.
+func newSecp256k1Signer(privKey *secp256k1.PrivateKey) (*secp256k1Signer, error) {
+	if privKey == nil {
+		return nil, fmt.Errorf("nil private key")
+	}
+	return &secp256k1Signer{
+		privKey: privKey,
+	}, nil
+}
+
+func (s *secp256k1Signer) sign(data []byte) ([]byte, error) {
+	hash := sha256.Sum256(data)
+	return ecdsa.Sign(s.privKey, hash[:]).Serialize(), nil
+}
+
+func (s *secp256k1Signer) verify(sigBytes, data []byte) bool {
+	sig, err := ecdsa.ParseDERSignature(sigBytes)
+	if err != nil {
+		return false
+	}
+	hash := sha256.Sum256(data)
+	return sig.Verify(hash[:], s.privKey.PubKey())
+}

--- a/server/mesh/signer_test.go
+++ b/server/mesh/signer_test.go
@@ -1,0 +1,43 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import "testing"
+
+func TestNewSecp256k1Signer(t *testing.T) {
+	t.Run("nil private key", func(t *testing.T) {
+		signer, err := newSecp256k1Signer(nil)
+		if err == nil {
+			t.Fatalf("expected error for nil private key")
+		}
+		if signer != nil {
+			t.Fatalf("expected nil signer for nil private key")
+		}
+	})
+
+	t.Run("sign and verify", func(t *testing.T) {
+		signer, err := newSecp256k1Signer(testPrivKey())
+		if err != nil {
+			t.Fatalf("newSecp256k1Signer error: %v", err)
+		}
+
+		data := []byte("mesh hello payload")
+		sig, err := signer.sign(data)
+		if err != nil {
+			t.Fatalf("sign error: %v", err)
+		}
+		if len(sig) == 0 {
+			t.Fatalf("empty signature")
+		}
+		if !signer.verify(sig, data) {
+			t.Fatalf("signature did not verify")
+		}
+		if signer.verify(sig, []byte("mesh hello payload modified")) {
+			t.Fatalf("signature verified modified data")
+		}
+		if signer.verify([]byte("not a der signature"), data) {
+			t.Fatalf("malformed signature verified")
+		}
+	})
+}

--- a/server/mesh/singleserver.go
+++ b/server/mesh/singleserver.go
@@ -1,0 +1,110 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/account"
+)
+
+// singleServerTransport is the meshTransport when no peer is configured.
+type singleServerTransport struct {
+	// becameMaster starts the master workers.
+	becameMaster func()
+	// prep resolves with the master preparation outcome.
+	prep *readiness
+}
+
+var _ meshTransport = (*singleServerTransport)(nil)
+
+func newSingleServerTransport() *singleServerTransport {
+	return &singleServerTransport{prep: newReadiness()}
+}
+
+// connect declares this node master immediately, as it can have no other
+// master.
+func (t *singleServerTransport) connect(ctx context.Context) (*sync.WaitGroup, error) {
+	if t.becameMaster != nil {
+		t.becameMaster()
+	}
+	if err := t.prep.wait(ctx); err != nil {
+		return nil, err
+	}
+	return new(sync.WaitGroup), nil
+}
+
+func (t *singleServerTransport) notifyMasterReady() error {
+	t.prep.resolve(nil)
+	return nil
+}
+
+func (t *singleServerTransport) notifyMasterPreparationFailed(err error) error {
+	if err == nil {
+		err = fmt.Errorf("master preparation failed")
+	}
+	t.prep.resolve(err)
+	return nil
+}
+
+func (t *singleServerTransport) ensureSeeded(context.Context) error {
+	return nil
+}
+
+func (t *singleServerTransport) notifyReadyForEvents() {}
+
+func (t *singleServerTransport) drainEventStream(context.Context) (bool, error) {
+	return false, nil
+}
+
+func (t *singleServerTransport) requestMasterHandoff(context.Context) error {
+	return nil
+}
+
+func (t *singleServerTransport) haltStatus() (bool, error) {
+	return false, nil
+}
+
+func (t *singleServerTransport) checkEventPublishAvailable(forwardedCommand bool) error {
+	if forwardedCommand {
+		// Who forwarded?
+		return fmt.Errorf("mesh event publisher unavailable for forwarded command")
+	}
+	return nil
+}
+
+func (t *singleServerTransport) notifyLocalEventCommitted(uint64, string, json.RawMessage) {}
+
+func (t *singleServerTransport) postTerminalApplyFailureIfNeeded(error) {}
+
+func (t *singleServerTransport) canExecuteCommandLocally() bool { return true }
+
+func (t *singleServerTransport) canForwardCommand() bool { return false }
+
+func (t *singleServerTransport) forwardCommand(context.Context, *commandForward) (*msgjson.Error, bool) {
+	return msgjson.NewError(msgjson.RPCInternalError, "mesh transport unavailable for command forward"), false
+}
+
+func (t *singleServerTransport) sendCommandFailure(context.Context, *commandFailure) error {
+	return fmt.Errorf("mesh transport unavailable for forwarded command failure")
+}
+
+func (t *singleServerTransport) sendCommandResult(context.Context, *commandResult) error {
+	return fmt.Errorf("mesh transport unavailable for forwarded command result")
+}
+
+func (t *singleServerTransport) sendClientProxyMessage(_ context.Context, msg *ClientProxyMessage) error {
+	if msg != nil && msg.Broadcast {
+		return nil
+	}
+	return fmt.Errorf("%w in single-server mode", ErrClientProxyUnavailable)
+}
+
+func (t *singleServerTransport) queryClientConnected(context.Context, []account.AccountID) ([]account.AccountID, error) {
+	return nil, nil
+}

--- a/server/mesh/snapshot.go
+++ b/server/mesh/snapshot.go
@@ -1,0 +1,252 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/db"
+)
+
+const (
+	snapshotChunkBytes = 1 << 20 // 1 MiB
+	// meshReadLimit is the websocket read limit for mesh connections. It must
+	// comfortably fit a JSON encoded snapshot chunk.
+	meshReadLimit    = 4 * snapshotChunkBytes
+	maxSnapshotBytes = 256 << 20 // 256 MiB
+)
+
+// snapshotChunk is one chunk of a snapshot.
+// The final chunk has Last set and may be empty.
+type snapshotChunk struct {
+	Bytes dex.Bytes `json:"bytes"`
+	Last  bool      `json:"last,omitempty"`
+}
+
+// snapshotChunkFunc sends one chunk and waits for the receiver to acknowledge it.
+type snapshotChunkFunc func(ctx context.Context, chunk *snapshotChunk) error
+
+// snapshotNode is the node surface required for snapshotServer.
+type snapshotNode interface {
+	// sendSnapshotChunk returns context.Canceled if connID is no longer the
+	// active slave.
+	sendSnapshotChunk(ctx context.Context, connID uint64, chunk *snapshotChunk) error
+	handleStreamError(connID uint64, err error)
+}
+
+// snapshotSend is one snapshot transfer to a seeding slave.
+type snapshotSend struct {
+	connID uint64
+	ctx    context.Context
+	kill   context.CancelFunc
+}
+
+// snapshotServer tracks the active snapshot send to a seeding slave.
+// A replaced send can still be running while it handles cancellation.
+type snapshotServer struct {
+	log   dex.Logger
+	store db.SnapshotStore
+	node  snapshotNode
+
+	mtx    sync.Mutex
+	active *snapshotSend
+}
+
+// newSnapshotServer creates a snapshot server with no active transfer.
+func newSnapshotServer(log dex.Logger, store db.SnapshotStore, node snapshotNode) *snapshotServer {
+	return &snapshotServer{log: log, store: store, node: node}
+}
+
+// startSendOnConn starts a snapshot send to connID.
+// It cancels the previous send without waiting for it to stop.
+func (s *snapshotServer) startSendOnConn(parent context.Context, connID uint64) {
+	ctx, cancel := context.WithCancel(parent)
+	send := &snapshotSend{connID: connID, ctx: ctx, kill: cancel}
+
+	s.mtx.Lock()
+	if s.active != nil {
+		s.active.kill()
+	}
+	s.active = send
+	s.mtx.Unlock()
+
+	go s.runSend(send)
+}
+
+func (s *snapshotServer) runSend(send *snapshotSend) {
+	defer send.kill()
+
+	frontier, err := streamSnapshot(send.ctx, s.store, func(ctx context.Context, chunk *snapshotChunk) error {
+		return s.node.sendSnapshotChunk(ctx, send.connID, chunk)
+	})
+
+	s.mtx.Lock()
+	if s.active == send {
+		s.active = nil
+	}
+	s.mtx.Unlock()
+
+	if err != nil {
+		if send.ctx.Err() != nil || errors.Is(err, context.Canceled) {
+			return
+		}
+		s.node.handleStreamError(send.connID, err)
+		return
+	}
+
+	s.log.Infof("Sent snapshot to conn %d at frontier %s. Events flow once the seeded slave subscribes.",
+		send.connID, frontier)
+}
+
+// stopConn cancels and clears the active send if its connection ID matches.
+// It does not wait for the send to finish.
+func (s *snapshotServer) stopConn(connID uint64) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if s.active == nil || s.active.connID != connID {
+		return
+	}
+	s.active.kill()
+	s.active = nil
+}
+
+// sendingTo reports whether the active snapshot send targets connID.
+func (s *snapshotServer) sendingTo(connID uint64) bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.active != nil && s.active.connID == connID
+}
+
+// streamSnapshot sends the producer's snapshot in chunks.
+// It returns the snapshot frontier after the final chunk is acknowledged.
+func streamSnapshot(ctx context.Context, producer db.SnapshotStore, send snapshotChunkFunc) (*db.EventLogPosition, error) {
+	cw := &chunkWriter{ctx: ctx, send: send}
+	frontier, err := producer.WriteSnapshot(ctx, cw)
+	if err != nil {
+		return nil, fmt.Errorf("write snapshot: %w", err)
+	}
+	if err := cw.flush(); err != nil {
+		return nil, fmt.Errorf("flush snapshot: %w", err)
+	}
+	return frontier, nil
+}
+
+// chunkWriter splits snapshot bytes into chunks.
+type chunkWriter struct {
+	ctx  context.Context
+	send snapshotChunkFunc
+	buf  []byte
+}
+
+// Write buffers p and sends it in chunks.
+func (cw *chunkWriter) Write(p []byte) (int, error) {
+	cw.buf = append(cw.buf, p...)
+	for len(cw.buf) >= snapshotChunkBytes {
+		chunk := append([]byte(nil), cw.buf[:snapshotChunkBytes]...)
+		if err := cw.send(cw.ctx, &snapshotChunk{Bytes: chunk}); err != nil {
+			return len(p), err
+		}
+		cw.buf = cw.buf[snapshotChunkBytes:]
+	}
+	return len(p), nil
+}
+
+// flush sends the remaining bytes with Last set to true.
+// It sends an empty final chunk when no bytes remain.
+func (cw *chunkWriter) flush() error {
+	return cw.send(cw.ctx, &snapshotChunk{Bytes: append([]byte(nil), cw.buf...), Last: true})
+}
+
+// snapshotReceiver collects the chunks of one snapshot.
+// It holds the whole snapshot in memory for the load into the DB.
+type snapshotReceiver struct {
+	mtx      sync.Mutex
+	buf      bytes.Buffer
+	done     bool
+	lastRecv time.Time
+}
+
+// receiveChunk appends a snapshot chunk and reports whether it is the final chunk.
+// It rejects chunks after completion and chunks that would exceed the size limit.
+// A rejected chunk leaves the receiver unchanged.
+func (r *snapshotReceiver) receiveChunk(chunk *snapshotChunk) (last bool, err error) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	if r.done {
+		return false, fmt.Errorf("snapshot chunk after final chunk")
+	}
+	if r.buf.Len()+len(chunk.Bytes) > maxSnapshotBytes {
+		return false, fmt.Errorf("snapshot exceeds maximum size of %d bytes", maxSnapshotBytes)
+	}
+	r.buf.Write(chunk.Bytes)
+	r.lastRecv = time.Now()
+	if chunk.Last {
+		r.done = true
+	}
+	return chunk.Last, nil
+}
+
+// load loads the snapshot into the DB.
+// It refuses to load before the final chunk arrives.
+func (r *snapshotReceiver) load(ctx context.Context, store db.SnapshotStore) (*db.EventLogPosition, error) {
+	r.mtx.Lock()
+	if !r.done {
+		r.mtx.Unlock()
+		return nil, fmt.Errorf("snapshot load before final chunk")
+	}
+	reader := bytes.NewReader(r.buf.Bytes())
+	r.mtx.Unlock()
+
+	frontier, err := store.LoadSnapshot(ctx, reader)
+	if err != nil {
+		return nil, fmt.Errorf("load snapshot: %w", err)
+	}
+	return frontier, nil
+}
+
+// transferComplete reports whether the final chunk has been received.
+func (r *snapshotReceiver) transferComplete() bool {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.done
+}
+
+// lastProgress returns the time of the last accepted chunk.
+func (r *snapshotReceiver) lastProgress() time.Time {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.lastRecv
+}
+
+// startSnapshotSend starts a snapshot send to the peer.
+func (n *node) startSnapshotSend(peerConn *nodeConn) {
+	n.log.Infof("Starting snapshot send to peer %s.", meshPeerLogID(peerConn))
+	n.snapshots.startSendOnConn(n.runContext, peerConn.ID())
+}
+
+// sendSnapshotChunk sends one snapshot chunk to the active slave identified by
+// connID and waits for its ack. It returns context.Canceled if the node cannot
+// stream to connID or a request fails after the link closes.
+func (n *node) sendSnapshotChunk(ctx context.Context, connID uint64, chunk *snapshotChunk) error {
+	conn, err := n.activePeerForRequest(nodeMode.canStreamEvents)
+	if err != nil || conn.ID() != connID {
+		return context.Canceled
+	}
+	var ack eventAck
+	err = conn.link.Request(ctx, snapshotChunkRoute, chunk, &ack)
+	if err != nil {
+		select {
+		case <-conn.link.Done():
+			return context.Canceled
+		default:
+		}
+	}
+	return err
+}

--- a/server/mesh/snapshot_test.go
+++ b/server/mesh/snapshot_test.go
@@ -1,0 +1,39 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"decred.org/dcrdex/server/db"
+)
+
+// fakeSnapshotStore writes its payload and records loaded bytes.
+type fakeSnapshotStore struct {
+	payload  []byte
+	frontier *db.EventLogPosition
+	loaded   []byte
+	loadErr  error
+}
+
+func (f *fakeSnapshotStore) WriteSnapshot(_ context.Context, w io.Writer) (*db.EventLogPosition, error) {
+	if _, err := w.Write(f.payload); err != nil {
+		return nil, err
+	}
+	return f.frontier, nil
+}
+
+func (f *fakeSnapshotStore) LoadSnapshot(_ context.Context, r io.Reader) (*db.EventLogPosition, error) {
+	if f.loadErr != nil {
+		return nil, f.loadErr
+	}
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	f.loaded = b
+	return f.frontier, nil
+}

--- a/server/mesh/snapshot_test.go
+++ b/server/mesh/snapshot_test.go
@@ -6,7 +6,10 @@ package mesh
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"math/rand"
+	"testing"
 
 	"decred.org/dcrdex/server/db"
 )
@@ -36,4 +39,180 @@ func (f *fakeSnapshotStore) LoadSnapshot(_ context.Context, r io.Reader) (*db.Ev
 	}
 	f.loaded = b
 	return f.frontier, nil
+}
+
+func TestSnapshotChunkRoundTrip(t *testing.T) {
+	// The payload varies across chunk boundaries.
+	payload := make([]byte, snapshotChunkBytes*3+500)
+	rand.New(rand.NewSource(1)).Read(payload)
+	frontier := &db.EventLogPosition{Seq: 42, TipHash: []byte("tip-hash")}
+
+	var chunks []*snapshotChunk
+	send := func(_ context.Context, c *snapshotChunk) error {
+		if len(c.Bytes) > snapshotChunkBytes {
+			t.Fatalf("chunk of %d bytes exceeds bound %d", len(c.Bytes), snapshotChunkBytes)
+		}
+		chunks = append(chunks, &snapshotChunk{Bytes: append([]byte(nil), c.Bytes...), Last: c.Last})
+		return nil
+	}
+
+	producer := &fakeSnapshotStore{payload: payload, frontier: frontier}
+	writeFrontier, err := streamSnapshot(context.Background(), producer, send)
+	if err != nil {
+		t.Fatalf("streamSnapshot: %v", err)
+	}
+	if writeFrontier.Seq != frontier.Seq {
+		t.Fatalf("write frontier seq = %d, want %d", writeFrontier.Seq, frontier.Seq)
+	}
+	if len(chunks) == 0 || !chunks[len(chunks)-1].Last {
+		t.Fatalf("final chunk not marked Last")
+	}
+	for i, c := range chunks[:len(chunks)-1] {
+		if c.Last {
+			t.Fatalf("non-final chunk %d marked Last", i)
+		}
+	}
+
+	recv := &snapshotReceiver{}
+	for i, c := range chunks {
+		if recv.transferComplete() {
+			t.Fatalf("transfer complete before chunk %d of %d", i, len(chunks))
+		}
+		last, err := recv.receiveChunk(c)
+		if err != nil {
+			t.Fatalf("receive chunk %d: %v", i, err)
+		}
+		if last != (i == len(chunks)-1) {
+			t.Fatalf("chunk %d last = %t", i, last)
+		}
+	}
+	if !recv.transferComplete() {
+		t.Fatal("transfer not complete after the final chunk")
+	}
+	if recv.lastProgress().IsZero() {
+		t.Fatal("no progress recorded")
+	}
+
+	consumer := &fakeSnapshotStore{frontier: frontier}
+	loadFrontier, err := recv.load(context.Background(), consumer)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loadFrontier.Seq != frontier.Seq {
+		t.Fatalf("load frontier seq = %d, want %d", loadFrontier.Seq, frontier.Seq)
+	}
+	if !bytes.Equal(consumer.loaded, payload) {
+		t.Fatalf("reassembled payload mismatch: got %d bytes, want %d", len(consumer.loaded), len(payload))
+	}
+}
+
+// TestSnapshotReceiverChunkAfterFinal checks that a completed receiver rejects chunks.
+func TestSnapshotReceiverChunkAfterFinal(t *testing.T) {
+	recv := &snapshotReceiver{}
+	if _, err := recv.receiveChunk(&snapshotChunk{Bytes: []byte("abc"), Last: true}); err != nil {
+		t.Fatalf("final chunk: %v", err)
+	}
+	progress := recv.lastProgress()
+	if _, err := recv.receiveChunk(&snapshotChunk{Bytes: []byte("more")}); err == nil {
+		t.Fatal("chunk after the final chunk accepted")
+	}
+	if recv.buf.String() != "abc" || !recv.transferComplete() || recv.lastProgress() != progress {
+		t.Fatal("rejected chunk changed the receiver")
+	}
+}
+
+// TestStreamSnapshotSendError checks that a send failure stops the transfer.
+func TestStreamSnapshotSendError(t *testing.T) {
+	producer := &fakeSnapshotStore{
+		payload:  make([]byte, snapshotChunkBytes*3),
+		frontier: &db.EventLogPosition{Seq: 7},
+	}
+
+	sendErr := errors.New("link down")
+	var sends int
+	send := func(_ context.Context, c *snapshotChunk) error {
+		sends++
+		if sends > 2 {
+			t.Fatal("chunk sent after a send failure")
+		}
+		if sends == 2 {
+			return sendErr
+		}
+		return nil
+	}
+
+	frontier, err := streamSnapshot(context.Background(), producer, send)
+	if !errors.Is(err, sendErr) {
+		t.Fatalf("streamSnapshot error = %v, want %v", err, sendErr)
+	}
+	if frontier != nil {
+		t.Fatalf("frontier = %v for a failed transfer, want nil", frontier)
+	}
+	if sends != 2 {
+		t.Fatalf("%d sends, want 2", sends)
+	}
+}
+
+// TestSnapshotReceiverLoadError checks that a load failure returns no frontier.
+func TestSnapshotReceiverLoadError(t *testing.T) {
+	recv := &snapshotReceiver{}
+	if _, err := recv.receiveChunk(&snapshotChunk{Bytes: []byte("junk"), Last: true}); err != nil {
+		t.Fatalf("final chunk: %v", err)
+	}
+
+	loadErr := errors.New("bad gob")
+	frontier, err := recv.load(context.Background(), &fakeSnapshotStore{loadErr: loadErr})
+	if !errors.Is(err, loadErr) {
+		t.Fatalf("load error = %v, want %v", err, loadErr)
+	}
+	if frontier != nil {
+		t.Fatalf("frontier = %v for a failed load, want nil", frontier)
+	}
+}
+
+// TestSnapshotChunkBoundaries checks the empty final chunk.
+// Empty input and exact chunk multiples both need this marker.
+func TestSnapshotChunkBoundaries(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		payloadLen int
+		wantChunks int
+	}{
+		{"exact multiple", snapshotChunkBytes * 2, 3},
+		{"empty payload", 0, 1},
+	} {
+		payload := make([]byte, tt.payloadLen)
+		rand.New(rand.NewSource(2)).Read(payload)
+		producer := &fakeSnapshotStore{payload: payload, frontier: &db.EventLogPosition{Seq: 3}}
+
+		var chunks []*snapshotChunk
+		send := func(_ context.Context, c *snapshotChunk) error {
+			chunks = append(chunks, &snapshotChunk{Bytes: append([]byte(nil), c.Bytes...), Last: c.Last})
+			return nil
+		}
+		if _, err := streamSnapshot(context.Background(), producer, send); err != nil {
+			t.Fatalf("%s: streamSnapshot: %v", tt.name, err)
+		}
+		if len(chunks) != tt.wantChunks {
+			t.Fatalf("%s: %d chunks, want %d", tt.name, len(chunks), tt.wantChunks)
+		}
+		last := chunks[len(chunks)-1]
+		if !last.Last || len(last.Bytes) != 0 {
+			t.Fatalf("%s: final chunk Last=%t with %d bytes, want an empty Last chunk", tt.name, last.Last, len(last.Bytes))
+		}
+
+		recv := &snapshotReceiver{}
+		for i, c := range chunks {
+			if _, err := recv.receiveChunk(c); err != nil {
+				t.Fatalf("%s: receive chunk %d: %v", tt.name, i, err)
+			}
+		}
+		consumer := &fakeSnapshotStore{frontier: &db.EventLogPosition{Seq: 3}}
+		if _, err := recv.load(context.Background(), consumer); err != nil {
+			t.Fatalf("%s: load: %v", tt.name, err)
+		}
+		if !bytes.Equal(consumer.loaded, payload) {
+			t.Fatalf("%s: reassembled %d bytes, want %d", tt.name, len(consumer.loaded), len(payload))
+		}
+	}
 }

--- a/server/mesh/state.go
+++ b/server/mesh/state.go
@@ -1,0 +1,238 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"fmt"
+	"time"
+)
+
+// helloRole is the role advertised during handshake.
+type helloRole uint8
+
+const (
+	roleUnknown helloRole = iota
+	roleMaster
+	roleSlave
+)
+
+func (r helloRole) String() string {
+	switch r {
+	case roleUnknown:
+		return "unknown"
+	case roleMaster:
+		return "master"
+	case roleSlave:
+		return "slave"
+	default:
+		return fmt.Sprintf("helloRole(%d)", uint8(r))
+	}
+}
+
+func (r helloRole) valid() bool {
+	switch r {
+	case roleUnknown, roleMaster, roleSlave:
+		return true
+	default:
+		return false
+	}
+}
+
+// progressState is the result of comparing the local and peer frontiers.
+type progressState uint8
+
+const (
+	progressEqual progressState = iota
+	progressLocalAhead
+	progressPeerAhead
+	progressDiverged
+)
+
+func (p progressState) String() string {
+	switch p {
+	case progressEqual:
+		return "equal"
+	case progressLocalAhead:
+		return "local_ahead"
+	case progressPeerAhead:
+		return "peer_ahead"
+	case progressDiverged:
+		return "diverged"
+	default:
+		return fmt.Sprintf("progressState(%d)", uint8(p))
+	}
+}
+
+// nodeMode is the node's current operating mode in the mesh.
+type nodeMode uint8
+
+const (
+	modePending nodeMode = iota
+	modePreparingMaster
+	modeEstablishedMaster
+	modeEstablishedSlaveSyncing
+	modeEstablishedSlave
+	modeSlaveNoMaster
+	modeHalted
+)
+
+func (m nodeMode) String() string {
+	switch m {
+	case modePending:
+		return "pending"
+	case modePreparingMaster:
+		return "preparing_master"
+	case modeEstablishedMaster:
+		return "established_master"
+	case modeEstablishedSlaveSyncing:
+		return "established_slave_syncing"
+	case modeEstablishedSlave:
+		return "established_slave"
+	case modeSlaveNoMaster:
+		return "slave_no_master"
+	case modeHalted:
+		return "halted"
+	default:
+		return fmt.Sprintf("nodeMode(%d)", uint8(m))
+	}
+}
+
+// helloRole maps the node mode to the role reported in a hello message.
+func (m nodeMode) helloRole() helloRole {
+	switch m {
+	case modePreparingMaster, modeEstablishedMaster:
+		return roleMaster
+	case modeEstablishedSlaveSyncing, modeEstablishedSlave, modeSlaveNoMaster:
+		return roleSlave
+	default:
+		return roleUnknown
+	}
+}
+
+func (m nodeMode) startupResolved() bool {
+	switch m {
+	case modeEstablishedMaster, modeEstablishedSlave, modeSlaveNoMaster, modeHalted:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m nodeMode) startupPending() bool {
+	return !m.startupResolved()
+}
+
+func (m nodeMode) isAuthoritativeMaster() bool {
+	return m == modePreparingMaster || m == modeEstablishedMaster
+}
+
+func (m nodeMode) canExecuteCommands() bool {
+	return m == modeEstablishedMaster
+}
+
+func (m nodeMode) canForwardCommands() bool {
+	return m == modeEstablishedSlave
+}
+
+func (m nodeMode) canDeliverCommandCompletions() bool {
+	return m == modeEstablishedMaster
+}
+
+func (m nodeMode) canStreamEvents() bool {
+	return m == modeEstablishedMaster
+}
+
+func (m nodeMode) canReceiveEventStream() bool {
+	return m == modeEstablishedSlaveSyncing || m == modeEstablishedSlave
+}
+
+func (m nodeMode) canAcceptMasterHandoff() bool {
+	return m == modeEstablishedSlaveSyncing || m == modeEstablishedSlave
+}
+
+func (m nodeMode) canRelayClientMessages() bool {
+	return m == modeEstablishedMaster || m == modeEstablishedSlaveSyncing || m == modeEstablishedSlave
+}
+
+func (m nodeMode) canExchangeClientConnectivity() bool {
+	switch m {
+	case modeEstablishedMaster, modeEstablishedSlaveSyncing, modeEstablishedSlave:
+		return true
+	default:
+		return false
+	}
+}
+
+// nodeState is the current mesh state published by the control loop.
+type nodeState struct {
+	mode        nodeMode
+	activeConn  *nodeConn
+	connAdopted time.Time
+	// peerDisconnected is the time when the peer disconnected.
+	// It is used to determine if the slave has waited long enough
+	// to be promoted.
+	peerDisconnected time.Time
+	haltErr          error
+}
+
+func (s nodeState) helloRole() helloRole {
+	return s.mode.helloRole()
+}
+
+func (s nodeState) hasActiveConnection() bool {
+	return s.activeConn != nil
+}
+
+func (s nodeState) String() string {
+	return fmt.Sprintf("nodeState{mode=%s activeConn=%s peerDisconnected=%s haltErr=%v}",
+		s.mode, s.activeConn, formatLogTime(s.peerDisconnected), s.haltErr)
+}
+
+func formatLogTime(t time.Time) string {
+	if t.IsZero() {
+		return "<zero>"
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func (c *controlLoop) setState(state nodeState) {
+	c.stateMtx.Lock()
+	c.state = state
+	c.lastTransition = time.Now()
+	c.stateMtx.Unlock()
+}
+
+func (c *controlLoop) currentState() nodeState {
+	c.stateMtx.RLock()
+	defer c.stateMtx.RUnlock()
+	return c.state
+}
+
+func (c *controlLoop) currentRole() helloRole {
+	return c.currentState().helloRole()
+}
+
+func (c *controlLoop) currentMode() nodeMode {
+	return c.currentState().mode
+}
+
+// haltStatus reports whether the node has halted and returns its halt error.
+func (c *controlLoop) haltStatus() (bool, error) {
+	state := c.currentState()
+	if state.mode != modeHalted {
+		return false, nil
+	}
+	return true, state.haltErr
+}
+
+func (c *controlLoop) hasPeerConnection() bool {
+	return c.currentState().hasActiveConnection()
+}
+
+// lastTransitionTime returns the time of the most recent node state update.
+func (c *controlLoop) lastTransitionTime() time.Time {
+	c.stateMtx.RLock()
+	defer c.stateMtx.RUnlock()
+	return c.lastTransition
+}

--- a/server/mesh/status.go
+++ b/server/mesh/status.go
@@ -1,0 +1,95 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"encoding/hex"
+	"time"
+)
+
+// Status reports mesh status for the admin API.
+type Status struct {
+	Mode                     string    `json:"mode"`
+	Ready                    bool      `json:"ready"`
+	NodeID                   string    `json:"nodeID,omitempty"`
+	PeerNodeID               string    `json:"peerNodeID,omitempty"`
+	PeerConnected            bool      `json:"peerConnected"`
+	HaltErr                  string    `json:"haltErr,omitempty"`
+	LastTransition           time.Time `json:"lastTransition,omitzero"`
+	FrontierSeq              uint64    `json:"frontierSeq,omitempty"`
+	FrontierHash             string    `json:"frontierHash,omitempty"`
+	PeerDisconnectedAt       time.Time `json:"peerDisconnectedAt,omitzero"`
+	PromoteAt                time.Time `json:"promoteAt,omitzero"`
+	DialAttempts             uint64    `json:"dialAttempts"`
+	LastDialError            string    `json:"lastDialError,omitempty"`
+	LastDialAt               time.Time `json:"lastDialAt,omitzero"`
+	StreamActive             bool      `json:"streamActive,omitempty"`
+	StreamTip                uint64    `json:"streamTip,omitempty"`
+	StreamCursor             uint64    `json:"streamCursor,omitempty"`
+	StreamLag                uint64    `json:"streamLag,omitempty"`
+	PendingStreamResults     int       `json:"pendingStreamResults,omitempty"`
+	PendingForwardedCommands int       `json:"pendingForwardedCommands"`
+	StateLoaded              bool      `json:"stateLoaded"`
+	Seeding                  bool      `json:"seeding,omitempty"`
+}
+
+// Status reports the mesh status for the admin API.
+func (s *Service) Status() Status {
+	st := Status{
+		PendingForwardedCommands: s.commands.pendingCount(),
+	}
+	if err, ok := s.ready.result(); ok {
+		st.Ready = err == nil
+	}
+	if err, ok := s.loaded.result(); ok {
+		st.StateLoaded = err == nil
+	}
+	s.transport.fillStatus(&st)
+	return st
+}
+
+func (t *singleServerTransport) fillStatus(st *Status) {
+	st.Mode = "single_server"
+}
+
+func (n *node) fillStatus(st *Status) {
+	state := n.control.currentState()
+	st.Mode = state.mode.String()
+	st.NodeID = n.nodeID
+	if state.activeConn != nil {
+		st.PeerConnected = true
+		st.PeerNodeID = state.activeConn.peerNodeID
+	}
+	if state.haltErr != nil {
+		st.HaltErr = state.haltErr.Error()
+	}
+	st.LastTransition = n.control.lastTransitionTime()
+	st.DialAttempts = n.dialer.attemptCount()
+	st.LastDialError, st.LastDialAt = n.dialer.lastDialError()
+	st.Seeding = n.seedInProgress()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	if frontier, err := n.eventLogReader.EventLogFrontier(ctx); err == nil && frontier != nil {
+		st.FrontierSeq = frontier.Seq
+		st.FrontierHash = hex.EncodeToString(frontier.TipHash)
+	}
+	cancel()
+
+	if state.mode == modeSlaveNoMaster && !state.peerDisconnected.IsZero() {
+		st.PeerDisconnectedAt = state.peerDisconnected
+		st.PromoteAt = state.peerDisconnected.Add(n.control.slavePromotionDelay)
+	}
+
+	if state.mode.canStreamEvents() {
+		tip, cursor, active := n.stream.progress()
+		st.StreamActive = active
+		st.StreamTip = tip
+		st.StreamCursor = cursor
+		if tip > cursor {
+			st.StreamLag = tip - cursor
+		}
+		st.PendingStreamResults = n.stream.pendingResults()
+	}
+}

--- a/server/mesh/status_test.go
+++ b/server/mesh/status_test.go
@@ -1,0 +1,103 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/db"
+)
+
+func TestServiceStatusSingleServer(t *testing.T) {
+	svc := newTestService(t, nil, nil)
+	st := svc.Status()
+	if st.Mode != "single_server" {
+		t.Fatalf("mode = %q, want single_server", st.Mode)
+	}
+	if st.Ready {
+		t.Fatalf("ready = true before startup resolved")
+	}
+
+	svc.ready.resolve(nil)
+	if st = svc.Status(); !st.Ready {
+		t.Fatalf("ready = false after successful startup")
+	}
+}
+
+func TestServiceStatusMeshTransport(t *testing.T) {
+	svc := newTestService(t, nil, &testTransport{master: true})
+	st := svc.Status()
+	if st.Mode != modeEstablishedMaster.String() {
+		t.Fatalf("mode = %q, want %s", st.Mode, modeEstablishedMaster)
+	}
+}
+
+func TestNodeFillStatus(t *testing.T) {
+	haltErr := errors.New("terminal apply failure")
+	peerConn := newNodeConn(newTRouteLink(9901), "peer-node", "node-a")
+	n := newTestNodeWithState(nodeState{
+		mode:       modeEstablishedMaster,
+		activeConn: peerConn,
+	}, nil)
+	n.stream = newEventStreamManager(&eventStreamManagerConfig{
+		log:                dex.Disabled,
+		initialFrontierSeq: 7,
+	})
+	n.eventLogReader = &testEventLogReader{
+		frontier: &db.EventLogPosition{Seq: 42, TipHash: []byte{0xab, 0xcd}},
+	}
+	dialer, err := newOutboundDialer("ws://mesh.example:17232", nil, dex.Disabled, nil, nil, &testDialerNode{})
+	if err != nil {
+		t.Fatalf("newOutboundDialer error: %v", err)
+	}
+	dialer.attempts.Add(3)
+	n.dialer = dialer
+
+	var st Status
+	n.fillStatus(&st)
+	if st.Mode != modeEstablishedMaster.String() {
+		t.Fatalf("mode = %q, want %s", st.Mode, modeEstablishedMaster)
+	}
+	if st.NodeID != "node-a" {
+		t.Fatalf("node id = %q, want node-a", st.NodeID)
+	}
+	if !st.PeerConnected || st.PeerNodeID != "peer-node" {
+		t.Fatalf("peer = connected=%t id=%q, want connected peer-node", st.PeerConnected, st.PeerNodeID)
+	}
+	if st.HaltErr != "" {
+		t.Fatalf("master halt err = %q, want none", st.HaltErr)
+	}
+	// The test constructor commits the initial state through setState.
+	if st.LastTransition.IsZero() {
+		t.Fatalf("last transition unset, want a timestamp")
+	}
+	if st.DialAttempts != 3 {
+		t.Fatalf("dial attempts = %d, want 3", st.DialAttempts)
+	}
+	if st.FrontierSeq != 42 || st.FrontierHash != "abcd" {
+		t.Fatalf("frontier = %d/%q, want 42/abcd", st.FrontierSeq, st.FrontierHash)
+	}
+	if st.StreamTip != 7 || st.StreamCursor != 0 {
+		t.Fatalf("stream tip/cursor = %d/%d, want 7/0", st.StreamTip, st.StreamCursor)
+	}
+	if st.StreamLag != 7 || st.StreamActive {
+		t.Fatalf("stream lag/active = %d/%t, want 7/false", st.StreamLag, st.StreamActive)
+	}
+
+	n.control.setState(halt(n.control.currentState(), haltErr, time.Now()).next)
+	st = Status{}
+	n.fillStatus(&st)
+	if st.Mode != modeHalted.String() || st.HaltErr != haltErr.Error() {
+		t.Fatalf("halted mode/error = %q/%q, want halted/%q", st.Mode, st.HaltErr, haltErr)
+	}
+	if st.PeerConnected || st.PeerNodeID != "" {
+		t.Fatalf("halted peer = connected %t, ID %q", st.PeerConnected, st.PeerNodeID)
+	}
+	if st.StreamActive || st.StreamTip != 0 || st.StreamCursor != 0 || st.StreamLag != 0 || st.PendingStreamResults != 0 {
+		t.Fatalf("halted status contains stream progress: %+v", st)
+	}
+}

--- a/server/mesh/stream.go
+++ b/server/mesh/stream.go
@@ -204,6 +204,43 @@ func (s *eventStreamManager) eventCommitted(seq uint64, originCommandID string, 
 	s.wakeUp()
 }
 
+// waitDrained waits for the slave to acknowledge the available log tip.
+// It returns an error if the manager stops or ctx ends first.
+func (s *eventStreamManager) waitDrained(ctx context.Context) error {
+	if err := s.refreshAvailableTip(ctx); err != nil {
+		return err
+	}
+
+	const drainPollInterval = 25 * time.Millisecond
+	ticker := time.NewTicker(drainPollInterval)
+	defer ticker.Stop()
+	for {
+		tip, cursor, active := s.progress()
+		if active && cursor >= tip {
+			// Success
+			return nil
+		}
+
+		s.mtx.Lock()
+		stopped := s.stopped
+		s.mtx.Unlock()
+		if stopped {
+			return fmt.Errorf("event stream manager stopped during the drain; " +
+				"the slave's position is unknown")
+		}
+
+		select {
+		case <-ctx.Done():
+			if !active {
+				return fmt.Errorf("no active event stream at the drain deadline (local tip %d); "+
+					"the slave's position is unknown", tip)
+			}
+			return fmt.Errorf("drain deadline: slave acked through seq %d of %d", cursor, tip)
+		case <-ticker.C:
+		}
+	}
+}
+
 // refreshAvailableTip raises the available tip to the durable log frontier.
 func (s *eventStreamManager) refreshAvailableTip(ctx context.Context) error {
 	frontier, err := s.eventLogReader.EventLogFrontier(ctx)
@@ -458,6 +495,26 @@ func (n *node) stopStreamForConn(peerConn *nodeConn) {
 // available to the stream.
 func (n *node) notifyLocalEventCommitted(seq uint64, originCommandID string, commandResult json.RawMessage) {
 	n.stream.eventCommitted(seq, originCommandID, commandResult)
+}
+
+// drainEventStream waits for an established master's slave to acknowledge the
+// committed tip.
+// It returns an error while preparing master.
+// Other modes return false without an error because no drain is required.
+func (n *node) drainEventStream(ctx context.Context) (drained bool, err error) {
+	state := n.control.currentState()
+	switch state.mode {
+	case modeEstablishedMaster:
+		if err := n.stream.waitDrained(ctx); err != nil {
+			return false, err
+		}
+		return true, nil
+	case modePreparingMaster:
+		return false, fmt.Errorf("stopping while preparing master: no stream exists yet, " +
+			"so replication cannot be confirmed")
+	default:
+		return false, nil
+	}
 }
 
 // sendEventBatch sends a batch to the active slave identified by connID and

--- a/server/mesh/stream.go
+++ b/server/mesh/stream.go
@@ -1,0 +1,506 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/db"
+)
+
+const (
+	// eventStreamBatchLimit is the maximum number of events in a batch.
+	eventStreamBatchLimit = 100
+	// eventStreamBatchBytes is the target total envelope size in a batch.
+	eventStreamBatchBytes = 1 << 20 // 1 MiB
+)
+
+// streamNode is the node surface required by eventStreamManager.
+type streamNode interface {
+	sendEventBatch(ctx context.Context, connID uint64, batch *eventBatch) error
+	handleStreamError(connID uint64, err error)
+}
+
+type eventStreamManagerConfig struct {
+	log                dex.Logger
+	eventLogReader     db.EventLogReader
+	node               streamNode
+	initialFrontierSeq uint64
+}
+
+// eventStreamManager keeps a slave up to date with the master's event log.
+//
+// The slave subscribes with its committed log position. The manager reads
+// later events from the database and sends them in order. It waits for the
+// slave to acknowledge each batch before sending the next one. Once the
+// slave catches up, the stream waits for new events (calls to eventCommitted)
+// and then sends those as well.
+//
+// Only one subscription is served at a time. A new subscription cancels the
+// previous stream and starts from the position supplied by the slave.
+// Results of forwarded commands travel with their events. These results are
+// held in memory until acknowledged and are discarded if the stream ends.
+type eventStreamManager struct {
+	log            dex.Logger
+	eventLogReader db.EventLogReader
+	node           streamNode
+	wake           chan struct{}
+	ctx            context.Context
+
+	mtx          sync.Mutex
+	stopped      bool
+	availableTip uint64
+	activeStream *eventStream
+}
+
+func newEventStreamManager(cfg *eventStreamManagerConfig) *eventStreamManager {
+	return &eventStreamManager{
+		log:            cfg.log,
+		eventLogReader: cfg.eventLogReader,
+		node:           cfg.node,
+		wake:           make(chan struct{}, 1),
+		availableTip:   cfg.initialFrontierSeq,
+	}
+}
+
+func (s *eventStreamManager) run(ctx context.Context, ready chan<- struct{}) error {
+	defer func() {
+		s.mtx.Lock()
+		s.stopped = true
+		s.mtx.Unlock()
+	}()
+
+	s.ctx = ctx
+	close(ready)
+
+	for {
+		stream, tip := s.waitForWork(ctx)
+		if ctx.Err() != nil {
+			return nil
+		}
+		if err := stream.sendThrough(tip, s.eventLogReader, s.node.sendEventBatch); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			s.failStream(stream, err)
+		}
+	}
+}
+
+// waitForWork blocks until there is an active stream whose cursor is behind
+// the available tip, or ctx ends.
+func (s *eventStreamManager) waitForWork(ctx context.Context) (*eventStream, uint64) {
+	for {
+		s.mtx.Lock()
+		stream := s.activeStream
+		tip := s.availableTip
+		s.mtx.Unlock()
+
+		if stream != nil && stream.cursorSeq() < tip {
+			return stream, tip
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, 0
+		case <-s.wake:
+		}
+	}
+}
+
+// wakeUp wakes up the waitForWork loop.
+func (s *eventStreamManager) wakeUp() {
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// startStreamOnConn is called after the slave sent a subscription request.
+// It replaces the existing stream.
+func (s *eventStreamManager) startStreamOnConn(connID uint64, slaveFrontier *db.EventLogPosition) {
+	// Refresh the frontier in case it has advanced.
+	frontier, err := s.eventLogReader.EventLogFrontier(s.ctx)
+	if err != nil {
+		// Keep the old tip. Event notifications can advance it.
+		s.log.Errorf("Could not refresh the available tip from the event log: %v", err)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if s.stopped {
+		s.log.Errorf("event stream stopped")
+		return
+	}
+
+	if frontier != nil && frontier.Seq > s.availableTip {
+		s.availableTip = frontier.Seq
+	}
+
+	if s.activeStream != nil {
+		s.activeStream.kill()
+	}
+
+	s.activeStream = newEventStream(s.ctx, connID, slaveFrontier)
+
+	s.wakeUp()
+}
+
+// stopConn cancels and removes the active stream if it belongs to connID.
+func (s *eventStreamManager) stopConn(connID uint64) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	if s.activeStream == nil || s.activeStream.connID != connID {
+		return
+	}
+
+	s.activeStream.kill()
+	s.activeStream = nil
+}
+
+// failStream removes and cancels stream if it is still active.
+// It reports errors other than context.Canceled to the node.
+func (s *eventStreamManager) failStream(stream *eventStream, err error) {
+	s.mtx.Lock()
+	if s.activeStream != stream {
+		s.mtx.Unlock()
+		return
+	}
+	s.activeStream = nil
+	s.mtx.Unlock()
+
+	stream.kill()
+
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+
+	s.node.handleStreamError(stream.connID, err)
+}
+
+// eventCommitted updates the available log tip, records any command
+// result for the active stream, and wakes the sender.
+func (s *eventStreamManager) eventCommitted(seq uint64, originCommandID string, commandResult json.RawMessage) {
+	s.mtx.Lock()
+	if seq > s.availableTip {
+		s.availableTip = seq
+	}
+	if s.activeStream != nil && originCommandID != "" {
+		s.activeStream.addMeta(seq, originCommandID, commandResult)
+	}
+	s.mtx.Unlock()
+
+	s.wakeUp()
+}
+
+// refreshAvailableTip raises the available tip to the durable log frontier.
+func (s *eventStreamManager) refreshAvailableTip(ctx context.Context) error {
+	frontier, err := s.eventLogReader.EventLogFrontier(ctx)
+	if err != nil {
+		return fmt.Errorf("could not refresh the available tip from the event log: %w", err)
+	}
+	if frontier == nil {
+		return nil
+	}
+
+	s.mtx.Lock()
+	raised := frontier.Seq > s.availableTip
+	if raised {
+		s.availableTip = frontier.Seq
+	}
+	s.mtx.Unlock()
+
+	if raised {
+		s.wakeUp()
+	}
+
+	return nil
+}
+
+// isStreamingTo reports whether the active stream belongs to connID.
+func (s *eventStreamManager) isStreamingTo(connID uint64) bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.activeStream != nil && s.activeStream.connID == connID
+}
+
+// progress reports the available tip and the active stream cursor.
+// The cursor is zero when no stream is active.
+func (s *eventStreamManager) progress() (tip, cursor uint64, active bool) {
+	s.mtx.Lock()
+	tip = s.availableTip
+	stream := s.activeStream
+	s.mtx.Unlock()
+	if stream != nil {
+		active = true
+		cursor = stream.cursorSeq()
+	}
+	return tip, cursor, active
+}
+
+// pendingResults counts unacknowledged command results on the active stream.
+// It returns zero when no stream is active.
+func (s *eventStreamManager) pendingResults() int {
+	s.mtx.Lock()
+	stream := s.activeStream
+	s.mtx.Unlock()
+	if stream == nil {
+		return 0
+	}
+	return stream.pendingMetaCount()
+}
+
+// streamCommandResult holds the results of a forwarded command.
+type streamCommandResult struct {
+	originCommandID string
+	commandResult   json.RawMessage
+}
+
+// eventStreamSendFunc sends a batch and waits for the slave to acknowledge it.
+type eventStreamSendFunc func(ctx context.Context, connID uint64, batch *eventBatch) error
+
+// eventStream is a single event stream over a single connection.
+type eventStream struct {
+	connID uint64
+	ctx    context.Context
+	kill   context.CancelFunc
+
+	mtx            sync.Mutex
+	cursor         uint64
+	pendingResults map[uint64]*streamCommandResult
+}
+
+func newEventStream(parent context.Context, connID uint64, slaveFrontier *db.EventLogPosition) *eventStream {
+	ctx, cancel := context.WithCancel(parent)
+	return &eventStream{
+		connID:         connID,
+		ctx:            ctx,
+		kill:           cancel,
+		cursor:         slaveFrontier.Seq,
+		pendingResults: make(map[uint64]*streamCommandResult),
+	}
+}
+
+// sendThrough reads and sends events after the cursor through the target
+// sequence.
+// It returns the first read or send error.
+func (r *eventStream) sendThrough(through uint64, reader db.EventLogReader, send eventStreamSendFunc) error {
+	cursor := r.cursorSeq()
+	for cursor < through {
+		entries, err := r.readEntries(reader, cursor, through)
+		if err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			return fmt.Errorf("event stream gap after seq %d before target %d", cursor, through)
+		}
+		if cursor, err = r.batchAndSend(entries, cursor, through, send); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readEntries retrieves a set of event log entries.
+func (r *eventStream) readEntries(reader db.EventLogReader, after, through uint64) ([]*db.EventLogEntry, error) {
+	if err := r.ctx.Err(); err != nil {
+		return nil, err
+	}
+	limit := eventStreamBatchLimit
+	if remaining := through - after; remaining < uint64(limit) {
+		limit = int(remaining)
+	}
+	return reader.EventLogEntriesAfter(r.ctx, after, limit)
+}
+
+// batchAndSend groups entries by encoded size and sends each batch.
+func (r *eventStream) batchAndSend(entries []*db.EventLogEntry, cursor, through uint64, send eventStreamSendFunc) (uint64, error) {
+	if err := r.ctx.Err(); err != nil {
+		return cursor, err
+	}
+	batch := &eventBatch{Entries: make([]*eventEnvelope, 0, len(entries))}
+	batchBytes := 0
+	for _, entry := range entries {
+		envelope := r.eventEnvelopeForEntry(entry, through)
+		raw, err := json.Marshal(envelope)
+		if err != nil {
+			return cursor, err
+		}
+		if len(batch.Entries) > 0 && batchBytes+len(raw) > eventStreamBatchBytes {
+			if cursor, err = r.deliverBatch(batch, send); err != nil {
+				return cursor, err
+			}
+			batch = &eventBatch{Entries: make([]*eventEnvelope, 0, len(entries))}
+			batchBytes = 0
+		}
+		batch.Entries = append(batch.Entries, envelope)
+		batchBytes += len(raw)
+	}
+	return r.deliverBatch(batch, send)
+}
+
+// eventEnvelopeForEntry copies an event row into an envelope and adds any
+// pending command result.
+func (r *eventStream) eventEnvelopeForEntry(entry *db.EventLogEntry, masterTip uint64) *eventEnvelope {
+	envelope := &eventEnvelope{
+		Seq:       entry.Seq,
+		TipHash:   append([]byte(nil), entry.TipHash...),
+		MasterTip: masterTip,
+		Kind:      entry.Kind,
+		Payload:   append([]byte(nil), entry.Event...),
+	}
+
+	r.mtx.Lock()
+	meta := r.pendingResults[entry.Seq]
+	if meta != nil {
+		envelope.OriginCommandID = meta.originCommandID
+		envelope.CommandResult = append([]byte(nil), meta.commandResult...)
+	}
+	r.mtx.Unlock()
+
+	return envelope
+}
+
+// eventBatchWireBytes returns the encoded size of a batch request.
+func eventBatchWireBytes(batch *eventBatch) (int, error) {
+	req, err := msgjson.NewRequest(math.MaxUint64, eventEnvelopeRoute, batch)
+	if err != nil {
+		return 0, err
+	}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return 0, err
+	}
+	return len(raw), nil
+}
+
+// deliverBatch sends the batch to the slave and updates the cursor.
+func (r *eventStream) deliverBatch(batch *eventBatch, send eventStreamSendFunc) (uint64, error) {
+	// Do not send if the batch is larger than the mesh read limit.
+	wireBytes, err := eventBatchWireBytes(batch)
+	if err != nil {
+		return 0, err
+	}
+	if wireBytes > meshReadLimit {
+		return 0, fmt.Errorf("event stream batch ending at seq %d encoded size %d exceeds mesh read limit %d",
+			batch.Entries[len(batch.Entries)-1].Seq, wireBytes, meshReadLimit)
+	}
+
+	if err := send(r.ctx, r.connID, batch); err != nil {
+		return 0, err
+	}
+
+	// Update the cursor and remove pending command results.
+	last := batch.Entries[len(batch.Entries)-1].Seq
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	if last > r.cursor {
+		r.cursor = last
+	}
+	for _, envelope := range batch.Entries {
+		delete(r.pendingResults, envelope.Seq)
+	}
+	return last, nil
+}
+
+// cursorSeq returns the last acknowledged sequence.
+func (r *eventStream) cursorSeq() uint64 {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.cursor
+}
+
+// addMeta copies a command result into the pending results for seq.
+func (r *eventStream) addMeta(seq uint64, originCommandID string, commandResult json.RawMessage) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.pendingResults[seq] = &streamCommandResult{
+		originCommandID: originCommandID,
+		commandResult:   append([]byte(nil), commandResult...),
+	}
+}
+
+// pendingMetaCount counts unacknowledged command results held by the stream.
+func (r *eventStream) pendingMetaCount() int {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return len(r.pendingResults)
+}
+
+// startEventStream opens an event stream from the slave's subscribed frontier.
+func (n *node) startEventStream(peerConn *nodeConn, slaveFrontier *db.EventLogPosition) {
+	n.log.Infof("Mesh event stream opening with peer %s from subscribed frontier %s.",
+		meshPeerLogID(peerConn), slaveFrontier)
+	n.stream.startStreamOnConn(peerConn.ID(), slaveFrontier)
+}
+
+// stopStreamForConn stops event and snapshot sends for peerConn.
+// It does nothing if peerConn is nil.
+func (n *node) stopStreamForConn(peerConn *nodeConn) {
+	if peerConn != nil {
+		n.stream.stopConn(peerConn.ID())
+		n.snapshots.stopConn(peerConn.ID())
+	}
+}
+
+// notifyLocalEventCommitted makes a durable local event and its command result
+// available to the stream.
+func (n *node) notifyLocalEventCommitted(seq uint64, originCommandID string, commandResult json.RawMessage) {
+	n.stream.eventCommitted(seq, originCommandID, commandResult)
+}
+
+// sendEventBatch sends a batch to the active slave identified by connID and
+// waits for acknowledgement.
+// It returns context.Canceled if the connection is unavailable or closes during
+// a failed request.
+func (n *node) sendEventBatch(ctx context.Context, connID uint64, batch *eventBatch) error {
+	conn, err := n.activePeerForRequest(nodeMode.canStreamEvents)
+	if err != nil || conn.ID() != connID {
+		return context.Canceled
+	}
+	err = requestEventBatch(ctx, conn.link.Request, batch)
+	if err != nil {
+		select {
+		case <-conn.link.Done():
+			return context.Canceled
+		default:
+		}
+	}
+	return err
+}
+
+// requestEventBatch sends a batch to the slave and waits for its
+// acknowledgement.
+// It returns without sending if ctx has ended.
+func requestEventBatch(ctx context.Context, request func(context.Context, string, any, any) error, batch *eventBatch) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	var ack eventAck
+	return request(ctx, eventEnvelopeRoute, batch, &ack)
+}
+
+// handleStreamError reports a failed event or snapshot stream for the active
+// slave connection.
+func (n *node) handleStreamError(connID uint64, err error) {
+	state := n.control.currentState()
+	if !state.mode.canStreamEvents() || state.activeConn == nil || state.activeConn.ID() != connID {
+		return
+	}
+	_ = n.control.post(streamFailedSignal{
+		conn: state.activeConn,
+		err:  err,
+		at:   time.Now(),
+	})
+}

--- a/server/mesh/stream_test.go
+++ b/server/mesh/stream_test.go
@@ -1,0 +1,34 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+)
+
+type testStreamNode struct {
+	send      func(context.Context, uint64, *eventBatch) error
+	sendChunk func(context.Context, uint64, *snapshotChunk) error
+	fail      func(uint64, error)
+}
+
+func (p *testStreamNode) sendEventBatch(ctx context.Context, connID uint64, batch *eventBatch) error {
+	if p.send == nil {
+		return nil
+	}
+	return p.send(ctx, connID, batch)
+}
+
+func (p *testStreamNode) sendSnapshotChunk(ctx context.Context, connID uint64, chunk *snapshotChunk) error {
+	if p.sendChunk == nil {
+		return nil
+	}
+	return p.sendChunk(ctx, connID, chunk)
+}
+
+func (p *testStreamNode) handleStreamError(connID uint64, err error) {
+	if p.fail != nil {
+		p.fail(connID, err)
+	}
+}

--- a/server/mesh/stream_test.go
+++ b/server/mesh/stream_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -26,6 +27,12 @@ func (r *streamTestReader) EventLogFrontier(context.Context) (*db.EventLogPositi
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 	return r.frontier, nil
+}
+
+func (r *streamTestReader) setFrontier(pos *db.EventLogPosition) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	r.frontier = pos
 }
 
 func (r *streamTestReader) EventLogEntriesAfter(ctx context.Context, after uint64, limit int) ([]*db.EventLogEntry, error) {
@@ -466,4 +473,90 @@ func TestRequestEventBatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWaitDrained(t *testing.T) {
+	newMgr := func(tip uint64) *eventStreamManager {
+		m := newTestEventStreamManager(&streamTestReader{}, nil, nil, &db.EventLogPosition{Seq: tip})
+		m.ctx = context.Background()
+		return m
+	}
+	shortCtx := func(d time.Duration) (context.Context, context.CancelFunc) {
+		return context.WithTimeout(context.Background(), d)
+	}
+
+	t.Run("caught-up active stream drains immediately", func(t *testing.T) {
+		m := newMgr(5)
+		m.startStreamOnConn(1, &db.EventLogPosition{Seq: 5})
+		ctx, cancel := shortCtx(time.Second)
+		defer cancel()
+		if err := m.waitDrained(ctx); err != nil {
+			t.Fatalf("waitDrained: %v", err)
+		}
+	})
+
+	t.Run("lagging stream reports cursor and tip at the deadline", func(t *testing.T) {
+		m := newMgr(0)
+		m.startStreamOnConn(1, &db.EventLogPosition{Seq: 3})
+		m.eventCommitted(7, "", nil)
+		ctx, cancel := shortCtx(100 * time.Millisecond)
+		defer cancel()
+		err := m.waitDrained(ctx)
+		if err == nil || !strings.Contains(err.Error(), "slave acked through seq 3 of 7") {
+			t.Fatalf("waitDrained err = %v", err)
+		}
+	})
+
+	t.Run("no active stream waits out the deadline", func(t *testing.T) {
+		m := newMgr(7)
+		ctx, cancel := shortCtx(100 * time.Millisecond)
+		defer cancel()
+		err := m.waitDrained(ctx)
+		if err == nil || !strings.Contains(err.Error(), "no active event stream") {
+			t.Fatalf("waitDrained err = %v", err)
+		}
+	})
+
+	t.Run("completed drain wins over a stopped manager", func(t *testing.T) {
+		m := newMgr(5)
+		m.startStreamOnConn(1, &db.EventLogPosition{Seq: 5})
+		m.mtx.Lock()
+		m.stopped = true
+		m.mtx.Unlock()
+		ctx, cancel := shortCtx(time.Second)
+		defer cancel()
+		if err := m.waitDrained(ctx); err != nil {
+			t.Fatalf("completed drain reported %v", err)
+		}
+	})
+
+	t.Run("stopped manager fails fast", func(t *testing.T) {
+		m := newMgr(5)
+		m.mtx.Lock()
+		m.stopped = true
+		m.mtx.Unlock()
+		ctx, cancel := shortCtx(2 * time.Second)
+		defer cancel()
+		start := time.Now()
+		err := m.waitDrained(ctx)
+		if err == nil || !strings.Contains(err.Error(), "manager stopped") {
+			t.Fatalf("waitDrained err = %v", err)
+		}
+		if time.Since(start) > time.Second {
+			t.Fatal("stopped manager did not fail fast")
+		}
+	})
+
+	t.Run("stream appearing mid-drain completes it", func(t *testing.T) {
+		m := newMgr(5)
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			m.startStreamOnConn(2, &db.EventLogPosition{Seq: 5})
+		}()
+		ctx, cancel := shortCtx(2 * time.Second)
+		defer cancel()
+		if err := m.waitDrained(ctx); err != nil {
+			t.Fatalf("waitDrained after reconnect: %v", err)
+		}
+	})
 }

--- a/server/mesh/stream_test.go
+++ b/server/mesh/stream_test.go
@@ -5,7 +5,87 @@ package mesh
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/db"
 )
+
+type streamTestReader struct {
+	mtx      sync.Mutex
+	frontier *db.EventLogPosition
+	entries  []*db.EventLogEntry
+}
+
+func (r *streamTestReader) EventLogFrontier(context.Context) (*db.EventLogPosition, error) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return r.frontier, nil
+}
+
+func (r *streamTestReader) EventLogEntriesAfter(ctx context.Context, after uint64, limit int) ([]*db.EventLogEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	var entries []*db.EventLogEntry
+	for _, entry := range r.entries {
+		if entry.Seq > after {
+			entries = append(entries, entry)
+			if len(entries) == limit {
+				break
+			}
+		}
+	}
+	return entries, nil
+}
+
+type testSequenceStreamRequester struct {
+	errs  []error
+	calls int
+}
+
+func (r *testSequenceStreamRequester) Request(_ context.Context, route string, payload any, response any) error {
+	r.calls++
+	if route != eventEnvelopeRoute {
+		return fmt.Errorf("route = %q, want %q", route, eventEnvelopeRoute)
+	}
+	if _, ok := payload.(*eventBatch); !ok {
+		return fmt.Errorf("payload = %T, want *eventBatch", payload)
+	}
+	if len(r.errs) > 0 {
+		err := r.errs[0]
+		r.errs = r.errs[1:]
+		if err != nil {
+			return err
+		}
+	}
+	ack, ok := response.(*eventAck)
+	if !ok {
+		return fmt.Errorf("response = %T, want *eventAck", response)
+	}
+	*ack = eventAck{}
+	return nil
+}
+
+type sentEventEnvelope struct {
+	connID   uint64
+	envelope *eventEnvelope
+}
+
+type eventStreamManagerHarness struct {
+	manager *eventStreamManager
+	cancel  context.CancelFunc
+	done    chan error
+	sent    chan sentEventEnvelope
+}
 
 type testStreamNode struct {
 	send      func(context.Context, uint64, *eventBatch) error
@@ -30,5 +110,360 @@ func (p *testStreamNode) sendSnapshotChunk(ctx context.Context, connID uint64, c
 func (p *testStreamNode) handleStreamError(connID uint64, err error) {
 	if p.fail != nil {
 		p.fail(connID, err)
+	}
+}
+
+func newTestEventStreamManager(eventLogReader db.EventLogReader, sendEvent func(context.Context, uint64, *eventBatch) error, onError func(uint64, error), initialFrontier *db.EventLogPosition) *eventStreamManager {
+	if initialFrontier == nil {
+		initialFrontier = &db.EventLogPosition{}
+	}
+	return newEventStreamManager(&eventStreamManagerConfig{
+		log:                dex.Disabled,
+		eventLogReader:     eventLogReader,
+		node:               &testStreamNode{send: sendEvent, fail: onError},
+		initialFrontierSeq: initialFrontier.Seq,
+	})
+}
+
+func newStreamHarness(t *testing.T, entries []*db.EventLogEntry, initialFrontier *db.EventLogPosition) *eventStreamManagerHarness {
+	t.Helper()
+	h := &eventStreamManagerHarness{
+		sent: make(chan sentEventEnvelope, 32),
+		done: make(chan error, 1),
+	}
+	reader := &streamTestReader{entries: entries}
+	// Flatten batches into per-envelope sends so assertions can observe
+	// individual envelopes.
+	sendEvent := func(ctx context.Context, connID uint64, batch *eventBatch) error {
+		for _, envelope := range batch.Entries {
+			select {
+			case h.sent <- sentEventEnvelope{connID: connID, envelope: cloneEventEnvelope(envelope)}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	}
+	h.manager = newTestEventStreamManager(reader, sendEvent, func(uint64, error) {}, initialFrontier)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	h.cancel = cancel
+	ready := make(chan struct{})
+	go func() {
+		h.done <- h.manager.run(ctx, ready)
+	}()
+	select {
+	case <-ready:
+	case err := <-h.done:
+		t.Fatalf("event stream manager stopped before ready: %v", err)
+	case <-time.After(time.Second):
+		t.Fatalf("event stream manager did not become ready")
+	}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-h.done:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Fatalf("event stream manager stopped with error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("event stream manager did not stop")
+		}
+	})
+	return h
+}
+
+func (h *eventStreamManagerHarness) start(connID uint64, slaveFrontier *db.EventLogPosition) {
+	h.manager.startStreamOnConn(connID, slaveFrontier)
+}
+
+func (h *eventStreamManagerHarness) stop(connID uint64) {
+	h.manager.stopConn(connID)
+}
+
+func (h *eventStreamManagerHarness) commit(seq uint64) {
+	h.commitWithResult(seq, "", nil)
+}
+
+func (h *eventStreamManagerHarness) commitWithResult(seq uint64, originCommandID string, commandResult []byte) {
+	h.manager.eventCommitted(seq, originCommandID, commandResult)
+}
+
+func (h *eventStreamManagerHarness) wantSent(t *testing.T, connID, seq, masterTip uint64) *eventEnvelope {
+	t.Helper()
+	var got sentEventEnvelope
+	select {
+	case got = <-h.sent:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for sent event envelope")
+	}
+	if got.connID != connID || got.envelope.Seq != seq || got.envelope.MasterTip != masterTip {
+		t.Fatalf("sent envelope = conn %d seq %d tip %d, want %d/%d/%d",
+			got.connID, got.envelope.Seq, got.envelope.MasterTip, connID, seq, masterTip)
+	}
+	return got.envelope
+}
+
+func (h *eventStreamManagerHarness) wantNoSent(t *testing.T) {
+	t.Helper()
+	select {
+	case sent := <-h.sent:
+		t.Fatalf("unexpected sent envelope: conn=%d envelope=%+v", sent.connID, sent.envelope)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func (h *eventStreamManagerHarness) wantActiveStream(t *testing.T, connID uint64) {
+	t.Helper()
+	waitActiveStreamConnID(t, h.manager, connID)
+}
+
+func (h *eventStreamManagerHarness) wantNoActiveStream(t *testing.T) {
+	t.Helper()
+	waitNoActiveStream(t, h.manager)
+}
+
+func entry(seq uint64) *db.EventLogEntry {
+	return &db.EventLogEntry{
+		Seq:     seq,
+		Kind:    "test",
+		Event:   []byte(fmt.Sprintf(`{"seq":%d}`, seq)),
+		TipHash: testTipHash(seq),
+	}
+}
+
+func entries(seqs ...uint64) []*db.EventLogEntry {
+	entries := make([]*db.EventLogEntry, 0, len(seqs))
+	for _, seq := range seqs {
+		entries = append(entries, entry(seq))
+	}
+	return entries
+}
+
+func pos(seq uint64) *db.EventLogPosition {
+	if seq == 0 {
+		return &db.EventLogPosition{}
+	}
+	return &db.EventLogPosition{Seq: seq, TipHash: testTipHash(seq)}
+}
+
+func cloneEventEnvelope(envelope *eventEnvelope) *eventEnvelope {
+	if envelope == nil {
+		return nil
+	}
+	return &eventEnvelope{
+		Seq:             envelope.Seq,
+		TipHash:         append([]byte(nil), envelope.TipHash...),
+		MasterTip:       envelope.MasterTip,
+		Kind:            envelope.Kind,
+		OriginCommandID: envelope.OriginCommandID,
+		CommandResult:   append([]byte(nil), envelope.CommandResult...),
+		Payload:         append([]byte(nil), envelope.Payload...),
+	}
+}
+
+func activeStream(stream *eventStreamManager) *eventStream {
+	stream.mtx.Lock()
+	defer stream.mtx.Unlock()
+	return stream.activeStream
+}
+
+func activeStreamConnID(manager *eventStreamManager) uint64 {
+	stream := activeStream(manager)
+	if stream == nil {
+		return 0
+	}
+	return stream.connID
+}
+
+func waitActiveStreamConnID(t *testing.T, manager *eventStreamManager, want uint64) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for activeStreamConnID(manager) != want {
+		if time.Now().After(deadline) {
+			t.Fatalf("active stream connection ID = %d, want %d", activeStreamConnID(manager), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func waitNoActiveStream(t *testing.T, manager *eventStreamManager) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for activeStream(manager) != nil {
+		if time.Now().After(deadline) {
+			t.Fatalf("active stream = %p, want nil", activeStream(manager))
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestEventStreamManager(t *testing.T) {
+	h := newStreamHarness(t, entries(1, 2, 3), pos(2))
+
+	h.wantNoSent(t)
+	h.start(10, pos(0))
+	h.wantSent(t, 10, 1, 2)
+	h.wantSent(t, 10, 2, 2)
+
+	commandResult := []byte(`{"status":"ok"}`)
+	h.commitWithResult(3, "cmd-3", commandResult)
+	live := h.wantSent(t, 10, 3, 3)
+	if live.OriginCommandID != "cmd-3" || string(live.CommandResult) != string(commandResult) {
+		t.Fatalf("live command result = %q/%s, want cmd-3/%s",
+			live.OriginCommandID, live.CommandResult, commandResult)
+	}
+
+	h.start(20, pos(1))
+	h.wantActiveStream(t, 20)
+	h.stop(10)
+	h.wantActiveStream(t, 20)
+	h.wantSent(t, 20, 2, 3)
+	h.wantSent(t, 20, 3, 3)
+
+	h.stop(20)
+	h.wantNoActiveStream(t)
+}
+
+// TestStreamReplacementDropsPendingCommandResults checks that a replacement
+// stream drops pending command results.
+func TestStreamReplacementDropsPendingCommandResults(t *testing.T) {
+	entry := &db.EventLogEntry{Seq: 1, Kind: "k", Event: []byte(`"e1"`), TipHash: testTipHash(1)}
+	reader := &streamTestReader{entries: []*db.EventLogEntry{entry}}
+
+	entered := make(chan struct{})
+	sentSeqs := make(chan *eventEnvelope, 8)
+	mgr := newEventStreamManager(&eventStreamManagerConfig{
+		log:            dex.Disabled,
+		eventLogReader: reader,
+		node: &testStreamNode{
+			send: func(ctx context.Context, connID uint64, batch *eventBatch) error {
+				if connID == 1 {
+					// Keep the result pending until
+					// replacement cancels this send.
+					close(entered)
+					<-ctx.Done()
+					return ctx.Err()
+				}
+				for _, e := range batch.Entries {
+					sentSeqs <- e
+				}
+				return nil
+			},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	var runErr error
+	go func() {
+		runErr = mgr.run(ctx, ready)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+			if runErr != nil && !errors.Is(runErr, context.Canceled) {
+				t.Errorf("stream manager stopped with error: %v", runErr)
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("stream manager did not stop")
+		}
+	})
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream manager did not become ready")
+	}
+
+	// Block the send to conn 1 so its command result stays pending.
+	mgr.startStreamOnConn(1, &db.EventLogPosition{})
+	mgr.eventCommitted(1, "cmd-1", []byte(`"result"`))
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("original stream did not enter send")
+	}
+
+	// Replacement cancels the blocked send and starts from the same
+	// position.
+	mgr.startStreamOnConn(2, &db.EventLogPosition{})
+	mgr.eventCommitted(1, "", nil)
+
+	select {
+	case envelope := <-sentSeqs:
+		if envelope.Seq != 1 {
+			t.Fatalf("streamed seq %d, want 1", envelope.Seq)
+		}
+		if envelope.OriginCommandID != "" || len(envelope.CommandResult) != 0 {
+			t.Fatalf("replacement stream carried a pending result for command %q", envelope.OriginCommandID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("entry not streamed on the replacement stream")
+	}
+}
+
+func TestRequestEventBatch(t *testing.T) {
+	envelope := &eventEnvelope{
+		Seq:       1,
+		TipHash:   testTipHash(1),
+		MasterTip: 1,
+		Kind:      "test",
+	}
+
+	tests := []struct {
+		name      string
+		errs      []error
+		cancel    bool
+		wantErr   bool
+		wantCalls int
+	}{
+		{
+			name:      "unauthorized is not retried",
+			errs:      []error{msgjson.NewError(msgjson.UnauthorizedConnection, "not active yet")},
+			wantErr:   true,
+			wantCalls: 1,
+		},
+		{
+			name:      "internal error is not retried",
+			errs:      []error{msgjson.NewError(msgjson.RPCInternal, "apply failed")},
+			wantErr:   true,
+			wantCalls: 1,
+		},
+		{
+			name:      "plain error is not retried",
+			errs:      []error{errors.New("connection failed")},
+			wantErr:   true,
+			wantCalls: 1,
+		},
+		{
+			name:    "canceled context is not sent",
+			cancel:  true,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancel {
+				cancel()
+			}
+			requester := &testSequenceStreamRequester{errs: append([]error(nil), tt.errs...)}
+			err := requestEventBatch(ctx, requester.Request, &eventBatch{Entries: []*eventEnvelope{envelope}})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("requestEventBatch error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if tt.cancel && !errors.Is(err, context.Canceled) {
+				t.Fatalf("requestEventBatch error = %v, want context.Canceled", err)
+			}
+			if requester.calls != tt.wantCalls {
+				t.Fatalf("request calls = %d, want %d", requester.calls, tt.wantCalls)
+			}
+		})
 	}
 }

--- a/server/mesh/subscribe.go
+++ b/server/mesh/subscribe.go
@@ -11,10 +11,15 @@ import (
 	"time"
 
 	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
 	"decred.org/dcrdex/server/db"
 )
 
 const (
+	// subscribeTimeout is the slave's idle timeout. If the slave does not have
+	// an active stream or snapshot for this timeout, it is disconnected.
+	subscribeTimeout = 15 * time.Minute
+
 	// seedTimeout limits the wait for seeding a new node.
 	seedTimeout = 10 * time.Minute
 
@@ -25,6 +30,97 @@ const (
 
 // errSeedConnectionClosed identifies a seed wait stopped by connection loss.
 var errSeedConnectionClosed = errors.New("connection closed")
+
+// runSubscriber starts the subscriber loop on the slave. It waits
+// for the node to be able to receive events, then requests the
+// master to start streaming events.
+func (n *node) runSubscriber(conn *nodeConn) {
+	select {
+	case <-n.eventsGate.resolved():
+	case <-conn.link.Done():
+		return
+	}
+
+	for {
+		state := n.control.currentState()
+		if !sameConn(state.activeConn, conn) || !state.mode.canReceiveEventStream() {
+			return
+		}
+		if n.trySubscribe(conn) {
+			return
+		}
+		if sleepSubscribeRetry(n.runContext, conn) != nil {
+			return
+		}
+	}
+}
+
+// trySubscribe requests the master to start streaming events.
+// It returns true if the request was accepted.
+func (n *node) trySubscribe(conn *nodeConn) (done bool) {
+	frontier, err := n.eventLogReader.EventLogFrontier(n.runContext)
+	if err != nil {
+		if n.runContext.Err() == nil {
+			n.log.Errorf("trySubscribe: EventLogFrontier: %v", err)
+		}
+		return false
+	}
+
+	var result streamSubscribeResult
+	err = conn.link.Request(n.runContext, streamSubscribeRoute, &streamSubscribe{
+		Frontier: toFrontierMessage(frontier),
+	}, &result)
+	if err == nil {
+		n.log.Infof("Mesh event subscribe accepted by peer %s from frontier %s (peer tip %d).",
+			meshPeerLogID(conn), frontier, result.MasterTip)
+
+		// Check if we are already caught up.
+		if result.MasterTip == frontier.Seq {
+			if postErr := n.control.post(streamCaughtUpSignal{conn: conn, target: frontier}); postErr != nil {
+				n.log.Debugf("failed to post subscribe caught-up: %v", postErr)
+			}
+		}
+		return true
+	}
+
+	if subscribeRejectionPermanent(err) {
+		n.log.Warnf("Mesh event subscribe permanently rejected by peer %s: %v", meshPeerLogID(conn), err)
+		n.postSubscribeRejected(conn, fmt.Errorf("stream subscribe rejected: %w", err))
+		return true
+	}
+
+	// Retryable rejection or transport failure.
+	return false
+}
+
+// subscribeRejectionPermanent reports whether err is a permanent stream
+// refusal.
+func subscribeRejectionPermanent(err error) bool {
+	var peerErr *peerRPCError
+	return errors.As(err, &peerErr) && peerErr.Code == msgjson.SubscribeRejectedError
+}
+
+// postSubscribeRejected reports a permanent stream refusal to the state
+// machine.
+func (n *node) postSubscribeRejected(conn *nodeConn, err error) {
+	_ = n.control.post(subscribeRejectedSignal{conn: conn, err: err, at: time.Now()})
+}
+
+// sleepSubscribeRetry waits for the retry delay.
+// It returns an error if ctx ends or the connection closes first.
+func sleepSubscribeRetry(ctx context.Context, conn *nodeConn) error {
+	const subscribeRetryDelay = time.Second
+	timer := time.NewTimer(subscribeRetryDelay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-conn.link.Done():
+		return errSeedConnectionClosed
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
 
 // seedInProgress reports whether initial database seeding is pending or
 // running.
@@ -229,4 +325,44 @@ func (a *seedAttempt) outcome() error {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
 	return a.err
+}
+
+// watchSubscribeTimeout periodically checks that the slave has either
+// an active stream or snapshot. If the slave is idle for too long,
+// it is disconnected.
+func (n *node) watchSubscribeTimeout(peerConn *nodeConn) {
+	ticker := time.NewTicker(subscribeTimeout / 10)
+	defer ticker.Stop()
+
+	var silentSince time.Time
+	for {
+		select {
+		case <-peerConn.link.Done():
+			return
+		case <-ticker.C:
+		}
+
+		state := n.control.currentState()
+		if !sameConn(state.activeConn, peerConn) {
+			return
+		}
+
+		silent := state.mode.isAuthoritativeMaster() &&
+			!n.stream.isStreamingTo(peerConn.ID()) &&
+			!n.snapshots.sendingTo(peerConn.ID())
+		if !silent {
+			silentSince = time.Time{}
+			continue
+		}
+		if silentSince.IsZero() {
+			silentSince = time.Now()
+		}
+		if time.Since(silentSince) < subscribeTimeout {
+			continue
+		}
+		n.log.Debugf("Mesh peer %s adopted but not streaming for %v. Disconnecting so it can connect and handshake again.",
+			meshPeerLogID(peerConn), subscribeTimeout)
+		peerConn.link.Disconnect()
+		return
+	}
 }

--- a/server/mesh/subscribe.go
+++ b/server/mesh/subscribe.go
@@ -1,0 +1,232 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/server/db"
+)
+
+const (
+	// seedTimeout limits the wait for seeding a new node.
+	seedTimeout = 10 * time.Minute
+
+	// seedChunkStallTimeout is the maximum time the slave waits between
+	// snapshot chunks before seeding is considered stalled.
+	seedChunkStallTimeout = 90 * time.Second
+)
+
+// errSeedConnectionClosed identifies a seed wait stopped by connection loss.
+var errSeedConnectionClosed = errors.New("connection closed")
+
+// seedInProgress reports whether initial database seeding is pending or
+// running.
+func (n *node) seedInProgress() bool {
+	return n.seeding.Load()
+}
+
+// ensureSeeded loads a snapshot if required for startup.
+// It returns immediately when no seeding is pending.
+func (n *node) ensureSeeded(ctx context.Context) error {
+	if !n.seeding.Load() {
+		return nil
+	}
+	defer n.seeding.Store(false)
+
+	ctx, cancel := context.WithTimeout(ctx, seedTimeout)
+	defer cancel()
+
+	const seedResolutionPollInterval = 250 * time.Millisecond
+	poll := time.NewTicker(seedResolutionPollInterval)
+	defer poll.Stop()
+
+	for {
+		// Check if we are already seeded.
+		if frontier, err := n.eventLogReader.EventLogFrontier(ctx); err == nil && frontier.Seq > 0 {
+			n.log.Infof("Mesh join: database already seeded at frontier %s.", frontier)
+			return nil
+		}
+
+		state := n.control.currentState()
+		switch {
+		case state.mode.isAuthoritativeMaster():
+			n.log.Infof("Mesh join: resolved as master; nothing to seed.")
+			return nil
+		case state.mode == modeEstablishedSlave:
+			// Equal progress, and our log is empty, so the peer's is too.
+			n.log.Infof("Mesh join: peer has no history; nothing to seed (mesh genesis).")
+			return nil
+		case state.mode == modeEstablishedSlaveSyncing && state.activeConn != nil:
+			if err := n.seedFromConn(ctx, state.activeConn); err != nil {
+				if ctx.Err() != nil {
+					return seedDeadlineError(ctx)
+				}
+				if errors.Is(err, errSeedConnectionClosed) {
+					n.log.Debugf("Mesh seed attempt ended after connection loss: %v", err)
+				} else {
+					n.log.Warnf("Mesh seed attempt failed: %v", err)
+				}
+				break
+			}
+			return nil
+		}
+
+		select {
+		case <-poll.C:
+		case <-ctx.Done():
+			return seedDeadlineError(ctx)
+		}
+	}
+}
+
+// seedFromConn requests a snapshot and waits for it to be received and
+// loaded into the database.
+func (n *node) seedFromConn(ctx context.Context, conn *nodeConn) error {
+	seed := newSeedAttempt(n.runContext, n.snapshotStore, n.log)
+	conn.seed.Store(seed)
+	defer conn.seed.Store(nil)
+
+	if err := n.requestSnapshot(ctx, conn); err != nil {
+		return err
+	}
+	n.log.Infof("Mesh snapshot request accepted; awaiting snapshot from peer %s.", meshPeerLogID(conn))
+
+	return awaitSeedOutcome(ctx, conn, seed)
+}
+
+// requestSnapshot sends a snapshot request to the master.
+// It keeps retrying until the request is accepted, the context is cancelled,
+// or the connection is lost.
+func (n *node) requestSnapshot(ctx context.Context, conn *nodeConn) error {
+	for {
+		err := conn.link.Request(ctx, snapshotRequestRoute, &snapshotRequest{}, nil)
+		if err == nil {
+			return nil
+		}
+		if err := sleepSubscribeRetry(ctx, conn); err != nil {
+			return fmt.Errorf("snapshot request not accepted: %w", err)
+		}
+	}
+}
+
+// awaitSeedOutcome waits for the snapshot transfer and database load
+// to complete. It ends early if the transfer has had no updates for
+// seedChunkStallTimeout.
+func awaitSeedOutcome(ctx context.Context, conn *nodeConn, seed *seedAttempt) error {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	// Wait for the transfer to complete.
+	for !seed.rx.transferComplete() {
+		select {
+		case <-seed.done: // a receive error can fail the seed early
+			return seed.outcome()
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-conn.link.Done():
+			if !seed.rx.transferComplete() {
+				return fmt.Errorf("%w during snapshot transfer", errSeedConnectionClosed)
+			}
+			// The final chunk landed as the conn died.
+		case <-ticker.C:
+			if seed.rx.transferComplete() {
+				continue
+			}
+			if last := seed.rx.lastProgress(); !last.IsZero() && time.Since(last) > seedChunkStallTimeout {
+				conn.link.Disconnect()
+				return fmt.Errorf("snapshot transfer stalled: no chunk for %v", seedChunkStallTimeout)
+			}
+		}
+	}
+
+	// Wait for the database load to complete.
+	select {
+	case <-seed.done:
+		return seed.outcome()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// seedDeadlineError describes an expired seed deadline or interrupted seed
+// wait.
+func seedDeadlineError(ctx context.Context) error {
+	err := context.Cause(ctx)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return errors.New("snapshot seed from mesh peer did not complete within the deadline")
+	}
+	return fmt.Errorf("snapshot seed interrupted: %w", err)
+}
+
+// seedAttempt holds one attempt to seed the database from a peer's snapshot.
+type seedAttempt struct {
+	rx    *snapshotReceiver
+	ctx   context.Context
+	store db.SnapshotStore
+	log   dex.Logger
+
+	mtx      sync.Mutex
+	finished bool
+	err      error
+	done     chan struct{}
+}
+
+func newSeedAttempt(ctx context.Context, store db.SnapshotStore, log dex.Logger) *seedAttempt {
+	return &seedAttempt{
+		rx:    &snapshotReceiver{},
+		ctx:   ctx,
+		store: store,
+		log:   log,
+		done:  make(chan struct{}),
+	}
+}
+
+// runLoad loads the received snapshot into the database and records the
+// outcome.
+func (a *seedAttempt) runLoad() {
+	frontier, err := a.rx.load(a.ctx, a.store)
+	if err != nil {
+		a.fail(err)
+		return
+	}
+	a.log.Infof("Loaded snapshot from mesh peer; database seeded at frontier %s.", frontier)
+	a.succeed()
+}
+
+// fail records the first failure unless the attempt has already finished.
+func (a *seedAttempt) fail(err error) {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+	if a.finished {
+		return
+	}
+	a.finished = true
+	a.err = err
+	close(a.done)
+}
+
+// succeed records success unless the attempt has already finished.
+func (a *seedAttempt) succeed() {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+	if a.finished {
+		return
+	}
+	a.finished = true
+	close(a.done)
+}
+
+// outcome returns the recorded error. Wait for done before reading the final
+// outcome.
+func (a *seedAttempt) outcome() error {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+	return a.err
+}

--- a/server/mesh/subscribe_test.go
+++ b/server/mesh/subscribe_test.go
@@ -1,0 +1,282 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+	"decred.org/dcrdex/dex/msgjson"
+	"decred.org/dcrdex/server/db"
+)
+
+// subLogReader is an event-log fake honoring after/limit semantics, unlike
+// the handshake tests' reader.
+type subLogReader struct {
+	frontier *db.EventLogPosition
+	entries  []*db.EventLogEntry
+}
+
+func (r *subLogReader) EventLogFrontier(context.Context) (*db.EventLogPosition, error) {
+	if r.frontier == nil {
+		return &db.EventLogPosition{}, nil
+	}
+	return r.frontier, nil
+}
+
+func (r *subLogReader) EventLogEntriesAfter(_ context.Context, after uint64, limit int) ([]*db.EventLogEntry, error) {
+	var out []*db.EventLogEntry
+	for _, entry := range r.entries {
+		if entry.Seq > after {
+			out = append(out, entry)
+			if len(out) == limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// TestValidateSubscribeAgainstLog covers the handler-side, append-only-log
+// validations: frontier bounds, hash agreement, and anchored-history
+// rejection at subscribe time.
+func TestValidateSubscribeAgainstLog(t *testing.T) {
+	entry := func(seq uint64, kind string) *db.EventLogEntry {
+		return &db.EventLogEntry{Seq: seq, Kind: kind, TipHash: testTipHash(seq)}
+	}
+	position := func(seq uint64) *db.EventLogPosition {
+		return &db.EventLogPosition{Seq: seq, TipHash: testTipHash(seq)}
+	}
+
+	tests := []struct {
+		name     string
+		frontier *db.EventLogPosition
+		reader   *subLogReader
+		wantCode int // 0 means accepted
+	}{
+		{
+			name:     "matching mid-log frontier accepted",
+			frontier: position(2),
+			reader: &subLogReader{frontier: position(3),
+				entries: []*db.EventLogEntry{entry(1, "k"), entry(2, "k"), entry(3, "k")}},
+		},
+		{
+			name:     "matching tip frontier accepted",
+			frontier: position(3),
+			reader:   &subLogReader{frontier: position(3)},
+		},
+		{
+			name:     "beyond tip rejected permanently",
+			frontier: position(9),
+			reader:   &subLogReader{frontier: position(3)},
+			wantCode: msgjson.SubscribeRejectedError,
+		},
+		{
+			name:     "hash mismatch rejected permanently",
+			frontier: &db.EventLogPosition{Seq: 2, TipHash: testTipHash(99)},
+			reader: &subLogReader{frontier: position(3),
+				entries: []*db.EventLogEntry{entry(1, "k"), entry(2, "k"), entry(3, "k")}},
+			wantCode: msgjson.SubscribeRejectedError,
+		},
+		{
+			name:     "hash mismatch at the tip rejected permanently",
+			frontier: &db.EventLogPosition{Seq: 3, TipHash: testTipHash(99)},
+			reader: &subLogReader{frontier: position(3),
+				entries: []*db.EventLogEntry{entry(1, "k"), entry(2, "k"), entry(3, "k")}},
+			wantCode: msgjson.SubscribeRejectedError,
+		},
+		{
+			name:     "full replay from empty log accepted",
+			frontier: &db.EventLogPosition{},
+			reader:   &subLogReader{frontier: &db.EventLogPosition{}},
+		},
+		{
+			name:     "full replay across genesis anchor rejected permanently",
+			frontier: &db.EventLogPosition{},
+			reader: &subLogReader{frontier: position(1),
+				entries: []*db.EventLogEntry{entry(1, db.MeshGenesisKind)}},
+			wantCode: msgjson.SubscribeRejectedError,
+		},
+		{
+			name:     "full replay across snapshot anchor rejected permanently",
+			frontier: &db.EventLogPosition{},
+			reader: &subLogReader{frontier: position(5),
+				entries: []*db.EventLogEntry{entry(5, db.SnapshotAnchorKind)}},
+			wantCode: msgjson.SubscribeRejectedError,
+		},
+		{
+			name:     "full replay against pruned log head rejected permanently",
+			frontier: &db.EventLogPosition{},
+			reader: &subLogReader{frontier: position(5),
+				entries: []*db.EventLogEntry{entry(3, "k"), entry(4, "k"), entry(5, "k")}},
+			wantCode: msgjson.SubscribeRejectedError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := &node{log: dex.Disabled, eventLogReader: tt.reader}
+			msgErr := n.validateSubscribeAgainstLog(context.Background(), tt.frontier)
+			if tt.wantCode == 0 {
+				if msgErr != nil {
+					t.Fatalf("unexpected rejection: %v", msgErr)
+				}
+				return
+			}
+			if msgErr == nil {
+				t.Fatalf("accepted, want rejection code %d", tt.wantCode)
+			}
+			if msgErr.Code != tt.wantCode {
+				t.Fatalf("rejection code = %d (%s), want %d", msgErr.Code, msgErr.Message, tt.wantCode)
+			}
+		})
+	}
+}
+
+// TestSnapshotServeThenSubscribe checks that events are sent only after
+// the peer subscribes following a snapshot transfer.
+func TestSnapshotServeThenSubscribe(t *testing.T) {
+	snapFrontier := &db.EventLogPosition{Seq: 5, TipHash: testTipHash(5)}
+	store := &fakeSnapshotStore{payload: []byte("snapshot-bytes"), frontier: snapFrontier}
+
+	reader := &streamTestReader{entries: []*db.EventLogEntry{
+		{Seq: 6, Kind: "k", Event: []byte(`"e6"`), TipHash: testTipHash(6)},
+	}}
+
+	var mtx sync.Mutex
+	var chunks int
+	var sawLast bool
+	sentSeqs := make(chan uint64, 16)
+
+	peer := &testStreamNode{
+		sendChunk: func(_ context.Context, _ uint64, chunk *snapshotChunk) error {
+			mtx.Lock()
+			chunks++
+			if chunk.Last {
+				sawLast = true
+			}
+			mtx.Unlock()
+			return nil
+		},
+		send: func(ctx context.Context, _ uint64, batch *eventBatch) error {
+			for _, e := range batch.Entries {
+				select {
+				case sentSeqs <- e.Seq:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return nil
+		},
+	}
+	srv := newSnapshotServer(dex.Disabled, store, peer)
+	mgr := newEventStreamManager(&eventStreamManagerConfig{
+		log:            dex.Disabled,
+		eventLogReader: reader,
+		node:           peer,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	var runErr error
+	go func() {
+		runErr = mgr.run(ctx, ready)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+			if runErr != nil && !errors.Is(runErr, context.Canceled) {
+				t.Errorf("stream manager stopped with error: %v", runErr)
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("stream manager did not stop")
+		}
+	})
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream manager did not become ready")
+	}
+
+	// The seed request starts a send on the snapshot server.
+	srv.startSendOnConn(ctx, 1)
+	t.Cleanup(func() { srv.stopConn(1) })
+
+	deadline := time.After(2 * time.Second)
+	for {
+		mtx.Lock()
+		finished := sawLast
+		mtx.Unlock()
+		if finished && !srv.sendingTo(1) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("snapshot never completed")
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+	mtx.Lock()
+	if chunks == 0 {
+		t.Fatal("no snapshot chunks sent")
+	}
+	mtx.Unlock()
+
+	if mgr.isStreamingTo(1) {
+		t.Fatal("stream manager should have no part in a snapshot send")
+	}
+
+	// No events flow after the snapshot: no stream exists until the seeded
+	// slave subscribes.
+	mgr.eventCommitted(6, "", nil)
+	select {
+	case seq := <-sentSeqs:
+		t.Fatalf("empty slot sent seq %d", seq)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// The post-load event subscribe fills the slot and the tail flows.
+	mgr.startStreamOnConn(1, snapFrontier)
+	mgr.eventCommitted(6, "", nil)
+	select {
+	case seq := <-sentSeqs:
+		if seq != 6 {
+			t.Fatalf("streamed seq %d, want 6 (snapshot covered <=5)", seq)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("event 6 not streamed after the event subscribe")
+	}
+}
+
+// TestSubscribeRejectionClasses pins the permanent classification the
+// subscriber's retry loop depends on: only a SubscribeRejectedError aborts
+// retries; every other failure retries on the normal cadence.
+func TestSubscribeRejectionClasses(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		err           error
+		wantPermanent bool
+	}{
+		{"unauthorized retries", &peerRPCError{Code: msgjson.UnauthorizedConnection, Message: "x"}, false},
+		{"try-again retries", &peerRPCError{Code: msgjson.TryAgainLaterError, Message: "x"}, false},
+		{"subscribe-rejected permanent", &peerRPCError{Code: msgjson.SubscribeRejectedError, Message: "x"}, true},
+		{"internal retries", &peerRPCError{Code: msgjson.RPCInternal, Message: "x"}, false},
+		{"plain error retries", errors.New("x"), false},
+		{"wrapped permanent", fmt.Errorf("wrap: %w", &peerRPCError{Code: msgjson.SubscribeRejectedError, Message: "x"}), true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if permanent := subscribeRejectionPermanent(tt.err); permanent != tt.wantPermanent {
+				t.Fatalf("permanent = %t, want %t", permanent, tt.wantPermanent)
+			}
+		})
+	}
+}

--- a/server/mesh/workers.go
+++ b/server/mesh/workers.go
@@ -1,0 +1,132 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"decred.org/dcrdex/dex"
+)
+
+// workerSupervisor starts master workers once in registration order.
+type workerSupervisor struct {
+	workers      []MasterWorker
+	log          dex.Logger
+	ensureLoaded func(context.Context) error
+	onReadiness  func(context.Context, error)
+
+	startCh chan struct{}
+	done    chan struct{}
+	cancel  context.CancelFunc
+}
+
+// newWorkerSupervisor creates a supervisor that waits for a start request.
+func newWorkerSupervisor(workers []MasterWorker, log dex.Logger,
+	ensureLoaded func(context.Context) error, onReadiness func(context.Context, error)) *workerSupervisor {
+	return &workerSupervisor{
+		workers:      workers,
+		log:          log,
+		ensureLoaded: ensureLoaded,
+		onReadiness:  onReadiness,
+		startCh:      make(chan struct{}, 1),
+		done:         make(chan struct{}),
+	}
+}
+
+// startWorkers requests worker startup without waiting.
+// Repeated requests do not restart workers.
+func (ws *workerSupervisor) startWorkers() {
+	select {
+	case ws.startCh <- struct{}{}:
+	default:
+	}
+}
+
+// stopWorkers cancels workers and waits until all have exited.
+func (ws *workerSupervisor) stopWorkers() {
+	ws.cancel()
+	<-ws.done
+}
+
+// startSupervisor starts a goroutine that waits for a worker startup request.
+// It must be called exactly once, before stopWorkers.
+func (ws *workerSupervisor) startSupervisor(lifeCtx context.Context, wg *sync.WaitGroup) {
+	ctx, cancel := context.WithCancel(lifeCtx)
+	ws.cancel = cancel
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ws.run(ctx)
+	}()
+}
+
+// run waits for a start request and loads state before starting workers.
+// It waits for each startup result before starting the next worker.
+// It reports the group result and waits for all started workers to exit.
+func (ws *workerSupervisor) run(ctx context.Context) {
+	defer close(ws.done)
+
+	select {
+	case <-ws.startCh:
+	case <-ctx.Done():
+		return
+	}
+
+	var workers sync.WaitGroup
+	defer workers.Wait()
+
+	if err := ws.ensureLoaded(ctx); err != nil {
+		ws.onReadiness(ctx, err)
+		return
+	}
+
+	for _, worker := range ws.workers {
+		if err := ctx.Err(); err != nil {
+			ws.onReadiness(ctx, err)
+			return
+		}
+		workerReady := ws.startWorker(ctx, &workers, worker)
+		if err := waitWorkerReady(ctx, worker.Name, workerReady); err != nil {
+			ws.onReadiness(ctx, err)
+			return
+		}
+	}
+
+	ws.onReadiness(ctx, nil)
+}
+
+// startWorker starts a worker and returns its startup result.
+// The first readiness report sets the result.
+// A return before that report sets a failure or the context error.
+func (ws *workerSupervisor) startWorker(ctx context.Context, workers *sync.WaitGroup, worker MasterWorker) *readiness {
+	ready := newReadiness()
+	workers.Add(1)
+	go func() {
+		defer workers.Done()
+		ws.log.Infof("Starting mesh master worker %q.", worker.Name)
+		worker.Run(ctx, ready.resolve)
+		if err := ctx.Err(); err != nil {
+			ready.resolve(err)
+		} else {
+			ready.resolve(fmt.Errorf("returned before reporting startup readiness"))
+		}
+		ws.log.Infof("Mesh master worker %q stopped.", worker.Name)
+	}()
+	return ready
+}
+
+// waitWorkerReady waits for startup readiness and adds the worker name to
+// failures.
+// If the wait fails after cancellation, it returns the context error.
+func waitWorkerReady(ctx context.Context, workerName string, workerReady *readiness) error {
+	if err := workerReady.wait(ctx); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return fmt.Errorf("mesh master worker %q startup readiness failed: %w", workerName, err)
+	}
+	return nil
+}

--- a/server/mesh/workers_test.go
+++ b/server/mesh/workers_test.go
@@ -1,0 +1,222 @@
+// This code is available on the terms of the project LICENSE.md file,
+// also available online at https://blueoakcouncil.org/license/1.0.0.
+
+package mesh
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"decred.org/dcrdex/dex"
+)
+
+func waitServiceWorkers(t testing.TB, svc *Service, desc string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		svc.runWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", desc)
+	}
+}
+
+// startTestWorkerSupervisor starts the supervisor as Service.startup does.
+func startTestWorkerSupervisor(svc *Service, ctx context.Context) {
+	svc.workers = newWorkerSupervisor(svc.masterWorkers, svc.log, svc.ensureLoaded, svc.handleMasterWorkerReadiness)
+	svc.workers.startSupervisor(ctx, &svc.runWG)
+}
+
+func TestServiceMasterWorkersSingleServer(t *testing.T) {
+	started := make(chan struct{}, 1)
+	stopped := make(chan struct{}, 1)
+	svc, err := NewService(&ServiceConfig{
+		EventLogReader: &testEventLogReader{},
+		OnHalt:         func(error) {},
+		MasterWorkers: []MasterWorker{{
+			Name: "test",
+			Run: func(ctx context.Context, reportReady func(error)) {
+				reportReady(nil)
+				started <- struct{}{}
+				<-ctx.Done()
+				stopped <- struct{}{}
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NewService error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := runServiceForTest(ctx, svc)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatalf("master worker did not start in single-server mode")
+	}
+
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatalf("master worker did not stop")
+	}
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatalf("service did not stop")
+	}
+}
+
+func TestServiceMasterWorkersStartOnce(t *testing.T) {
+	started := make(chan struct{}, 4)
+	var starts atomic.Uint32
+	svc := &Service{
+		loaded:    newReadiness(),
+		log:       dex.Disabled,
+		transport: newSingleServerTransport(),
+		masterWorkers: []MasterWorker{{
+			Name: "test",
+			Run: func(ctx context.Context, reportReady func(error)) {
+				reportReady(nil)
+				starts.Add(1)
+				started <- struct{}{}
+				<-ctx.Done()
+			},
+		}},
+		ready: newReadiness(),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	svc.lifeCtx = ctx
+	svc.lifeCancel = cancel
+	startTestWorkerSupervisor(svc, ctx)
+
+	svc.workers.startWorkers()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatalf("master worker did not start")
+	}
+
+	svc.workers.startWorkers()
+	select {
+	case <-started:
+		t.Fatalf("master worker started twice")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if starts.Load() != 1 {
+		t.Fatalf("worker starts = %d, want 1", starts.Load())
+	}
+
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		svc.runWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("master worker did not stop after service shutdown")
+	}
+}
+
+func TestServiceMasterWorkersStartSequentiallyInConfigOrder(t *testing.T) {
+	firstReady := make(chan struct{})
+	secondReady := make(chan struct{})
+	started := make(chan string, 3)
+	svc, err := NewService(&ServiceConfig{
+		EventLogReader: &testEventLogReader{},
+		OnHalt:         func(error) {},
+		MasterWorkers: []MasterWorker{
+			{
+				Name: "z-first",
+				Run: func(ctx context.Context, reportReady func(error)) {
+					started <- "first"
+					select {
+					case <-firstReady:
+						reportReady(nil)
+					case <-ctx.Done():
+						return
+					}
+					<-ctx.Done()
+				},
+			},
+			{
+				Name: "a-second",
+				Run: func(ctx context.Context, reportReady func(error)) {
+					started <- "second"
+					select {
+					case <-secondReady:
+						reportReady(nil)
+					case <-ctx.Done():
+						return
+					}
+					<-ctx.Done()
+				},
+			},
+			{
+				Name: "m-third",
+				Run: func(ctx context.Context, reportReady func(error)) {
+					started <- "third"
+					reportReady(nil)
+					<-ctx.Done()
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewService error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := runServiceForTest(ctx, svc)
+
+	requireStarted := func(want string) {
+		t.Helper()
+		select {
+		case got := <-started:
+			if got != want {
+				t.Fatalf("started worker = %q, want %q", got, want)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("worker %q did not start", want)
+		}
+	}
+	requireNoStart := func(msg string) {
+		t.Helper()
+		select {
+		case got := <-started:
+			t.Fatalf("%s: worker %q started", msg, got)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	requireStarted("first")
+	requireNoStart("second worker started before first worker was ready")
+	close(firstReady)
+	requireStarted("second")
+	requireNoStart("third worker started before second worker was ready")
+	close(secondReady)
+	requireStarted("third")
+	if err := svc.WaitUntilReadyForComms(context.Background()); err != nil {
+		t.Fatalf("WaitUntilReadyForComms error: %v", err)
+	}
+
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatalf("service did not stop")
+	}
+}


### PR DESCRIPTION
This PR introduces `server/mesh`, which provides the infrastructure for running DCRDEX as a two-node master/slave mesh.

This package lays the foundation for converting the server into a two-node replicated state machine. It handles all the communication between the two nodes and exposes an API for the rest of the server to integrate with. The application and database changes will follow separately. Those changes mainly involve refactoring the existing logic into command handlers, event appliers, master workers, and state loaders.

I've already completed the meshification of the rest of the server. Those changes still need some polish before review, but they can be viewed here:

https://github.com/martonp/dcrdex/tree/mesh

I also have a mainnet mesh running on these two nodes:

- 2.28.52.0:7232
- 204.168.178.234:7232

Let me know if you want to test it out, I can send prepaid bonds.

The goal was to preserve the existing client/server protocol. The only changes to the client are that the client can learn the second server's address and reconnect there if its current server becomes unavailable. Legacy clients can still connect to one server using the existing API.

### Application API

`Service` is the entry point to the mesh package. The application registers four things:
- **Events** describe changes to the application state that both nodes apply in the same order. The application state may only be updated by a well defined event. The application registers an `EventApplier` for each event kind. It must commit the database changes in one transaction, then update the in-memory state after that transaction succeeds.
- **Commands** correspond to client or admin API requests that may change shared state. API handlers submit them to the mesh service, which executes them on the master. The application’s command handlers validate the requests and produce events when changes are needed.
- **MasterWorkers** run background tasks while the node is master, such as advancing markets and monitoring swaps. These produce server originated events, as opposed to events which are emitted due to a Command.
- **StateLoaders** load the in-memory representation of the active durable state (the state in the DB that is required for active orders and active swaps). These are run once at startup.

The full conversion currently has 10 command types and 16 event types. For example, the `limit` command validates an order and can produce an `order_accepted` event. A market worker produces events such as `advance_epoch` or `epoch_processed`. The application registers these types and implements their behavior. The mesh package is not aware of what they do.

### Event application and replication

The master produces events containing the inputs needed for both nodes to apply the same state transition. Event application can only include deterministic computation based on the event itself and the previous state.

Each event’s database transaction records an event-log entry containing its sequence number and tip hash. Mesh applies events one at a time and streams committed entries from the master to the slave.

After successfully connecting, the slave subscribes to the master's event stream using its last committed event log position. The master reads later entries from its database and sends them in batches. The slave applies the events in order and checks their expected positions and hashes. The master waits for each batch to be acknowledged before sending the next.

Replication is asynchronous. The master can commit new events without waiting for the slave. Waiting for acknowledgement limits the event stream, not local event application.

The tip hash identifies event history by chaining each event to the previous tip. Starting from the same state, both nodes must produce the same state changes when applying the same events. A tip-hash mismatch while applying a replicated event halts the slave.

### Commands

The mesh service executes commands on the master and delivers responses through the node that received the request. A command can produce an event or complete without changing shared state.

Response timing depends on where the request arrives:

- **On the master:** the response can be returned after local event application, before replication.
- **On the slave:** the slave forwards the command to the master. The master applies the event and sends it together with the command result. The slave applies the event before returning the result.

Commands that fail or complete without an event send their replies separately from the event stream.

A command may commit on the master even if the slave never receives its result. If the slave cannot determine the outcome, it returns `ResultUnavailableError` to the client. The application must make command handlers idempotent so the client can retry the same request without having a second event be emitted.

### Startup, handshake, and readiness

A node configured with a peer must complete a handshake before serving clients. On each connection, the nodes perform a handshake and compare configurations, roles, and event-log positions to determine compatibility and select the master. Both nodes must share the same signing key and compatible market and asset configurations.

After the handshake is complete, the state loaders must run before event application / master workers can begin.

Then, before clients can connect:

- **The master** starts its master workers and waits for all of them to become ready.
- **The slave** subscribes to the master's event stream, and applies all events up to the master's tip.

### Role selection and divergent histories

The handshake compares the nodes’ event histories:

- **Equal:** the same sequence number and tip hash.
- **One extends the other:** the longer log contains the shorter log’s last entry with the same tip hash.
- **Divergent:** the logs have different tip hashes at the same sequence number.

Histories are compatible if they are equal or one extends the other.

For compatible histories, an existing master keeps its role if its log is at least as long as the peer’s. If neither node is master, the longer log wins, with the lower node ID breaking a tie. The other node becomes slave and catches up if needed.

With divergent histories, an existing master rejects the joining peer and keeps serving. The joining peer halts. If neither or both nodes are master, both halt.

Two masters with equal histories also halt.

The exact role-selection rules are defined in `reducer.go`.

A node that has not established a role halts if the peer’s configuration is incompatible. An established master rejects the incompatible peer and keeps serving, so a misconfigured joining node cannot take it offline.

### Snapshots

A fresh node can load a snapshot from a master instead of replaying the entire history. Replaying the full history is not possible if the node was created pre-mesh.

A snapshot includes all account data, active trade/swap data, and historical trade/swap data for the past 30 days. This logic is not part of this PR. The mesh package just handles the transfer.

A snapshot includes the event-log position corresponding to its database state. After loading it, the slave subscribes to events after that position.

### Failover and shutdown

An established slave that loses its master waits 30 seconds before promoting itself, giving the master time to reconnect. A slave still performing its initial sync returns to pending if it loses the connection and does not promote from that state.

During graceful shutdown, the master stops its workers and closes event publication and waits for the slave to catch up. If the slave catches up, the master requests handoff. On receiving the request, the slave promotes immediately, avoiding the usual promotion delay.

Two failure scenarios are important:

- **The master may have committed events that the slave never received.** If the master crashes and the slave takes over, those events are absent from the promoted node. If the new master commits a conflicting event at the same sequence number, the histories fork. When the old process restarts and joins the new master, the returning node halts while the new master keeps serving.
- **A lost connection does not prove the master stopped.** During a network partition, the master can continue running while the slave eventually promotes. When they reconnect, equal or divergent histories cause both nodes to halt.

Mesh does not reconcile divergent histories or automatically discard committed events. The operator has to decide which history to keep. In the first failure scenario, which can happen quite easily if the master crashes, this is very simple. This is why we do not halt the serving master. In the split-brain scenario, which is rare, this would be a larger challenge. 

### Client message relaying / presence

The mesh package also provides the functionality to relay client messages between nodes and query which users are connected to the peer.

Messages can target an individual user or be broadcast to the peer's clients. This lets the master send swap requests and notifications to users connected to the slave.

The application combines the peer's response to a presence query with its local connection state to determine whether a user is still connected to the mesh. The master uses this when deciding whether to revoke booked orders after a prolonged disconnection.
